### PR TITLE
Automatically pivot traffic to new versions

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/mitchellh/cli"
@@ -15,8 +17,10 @@ func Run(args []string) int {
 
 	exitStatus, err := c.Run()
 	if err != nil {
-		fmt.Printf("ERROR: %s\n", err)
-		return 1
+		if !errors.Is(err, context.Canceled) {
+			fmt.Printf("ERROR: %s\n", err)
+			return 1
+		}
 	}
 
 	return exitStatus

--- a/cli/commands/components.go
+++ b/cli/commands/components.go
@@ -31,6 +31,7 @@ import (
 
 func (c *Context) setupServerComponents(ctx context.Context, reg *asm.Registry) {
 	reg.Register("namespace", "miren-test")
+	reg.Register("top_context", ctx)
 
 	reg.Provide(func(opts struct {
 		Namespace string `asm:"namespace"`

--- a/cli/commands/run.go
+++ b/cli/commands/run.go
@@ -26,12 +26,12 @@ func Run(ctx *Context, opts struct {
 }) error {
 	c := &cliRun{}
 
-	_, err := c.buildCode(ctx, opts.App, opts.Dir, opts.Explain)
+	id, err := c.buildCode(ctx, opts.App, opts.Dir, opts.Explain)
 	if err != nil {
 		return err
 	}
 
-	ctx.Printf("\nUpdated version deployed!\n")
+	ctx.Printf("\nUpdated version %s deployed. All traffic moved to new version.\n", id)
 
 	return nil
 }

--- a/lease/container_test.go
+++ b/lease/container_test.go
@@ -404,8 +404,6 @@ func TestLeaseContainer(t *testing.T) {
 			case err := <-errors:
 				r.NoError(err)
 			case cur := <-leases:
-				r.NotNil(cur)
-
 				if lease == nil {
 					cur = lease
 				} else {
@@ -690,7 +688,12 @@ func TestLeaseContainer(t *testing.T) {
 
 		r.Equal(on.applications["test"].pools["default"].idle.Len(), 1)
 
-		err = on.ClearVersion(ctx, mrv)
+		fake := &app.AppVersion{
+			App:     mrv.App,
+			Version: "not-real",
+		}
+
+		err = on.ClearOldVersions(ctx, fake)
 		r.NoError(err)
 
 		r.Equal(on.applications["test"].pools["default"].idle.Len(), 0)
@@ -704,7 +707,7 @@ func TestLeaseContainer(t *testing.T) {
 			_, err = lc.Obj(ctx)
 			r.NoError(err)
 
-			err = on.ClearVersion(ctx, mrv)
+			err = on.ClearOldVersions(ctx, fake)
 			r.NoError(err)
 
 			r.Equal(on.applications["test"].pools["default"].idle.Len(), 0)
@@ -726,7 +729,7 @@ func TestLeaseContainer(t *testing.T) {
 			lc, err = on.Lease(ctx, "test", Pool("default"))
 			r.NoError(err)
 
-			err = on.ClearVersion(ctx, mrv)
+			err = on.ClearOldVersions(ctx, fake)
 			r.NoError(err)
 
 			lc2, err := on.Lease(ctx, "test", Pool("default"))

--- a/lease/operation_lease.go
+++ b/lease/operation_lease.go
@@ -1,0 +1,333 @@
+package lease
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"miren.dev/runtime/app"
+	"miren.dev/runtime/network"
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/set"
+	"miren.dev/runtime/run"
+)
+
+type leaseOperation struct {
+	*LaunchContainer
+	name string
+	opts leaseOptions
+	pool *pool
+
+	ac  *app.AppConfig
+	mrv *app.AppVersion
+
+	pc *pendingContainer
+}
+
+func (l *leaseOperation) tryAvailableWindow() (*LeasedContainer, error) {
+	l.pool.mu.Lock()
+	defer l.pool.mu.Unlock()
+
+	win := l.pool.availableWindow()
+	if win != nil {
+		start, err := win.container.cpuUsage()
+		if err != nil {
+			return nil, err
+		}
+
+		l.Log.Info("adding lease to existing window", "window", win.Id)
+
+		lc := &LeasedContainer{
+			lc:        l.LaunchContainer,
+			Pool:      l.pool,
+			StartTime: time.Now(),
+			Window:    win,
+			Start:     start,
+		}
+
+		win.TotalLeases++
+		win.Leases.Add(lc)
+
+		l.rif.Add(1)
+
+		return lc, nil
+	}
+
+	return nil, nil
+}
+
+func (l *leaseOperation) tryAvailableIdleContainer() (*LeasedContainer, error) {
+	l.pool.mu.Lock()
+	defer l.pool.mu.Unlock()
+
+	// No windows, but we might still have a container kicking around
+	// we can reuse.
+	rc := l.pool.availableIdleContainer()
+	if rc != nil {
+		start, err := rc.cpuUsage()
+		if err != nil {
+			return nil, err
+		}
+
+		l.pool.idle.Remove(rc)
+
+		l.Log.Debug("beginning new usage window", "app", l.pool.app.name, "pool", l.pool.name, "start", start)
+
+		win := &UsageWindow{
+			App:         l.pool.app.name,
+			Id:          idgen.Gen("w"),
+			Start:       start,
+			Leases:      set.New[*LeasedContainer](),
+			TotalLeases: 1,
+
+			container: rc,
+		}
+
+		l.pool.windows.Add(win)
+
+		lc := &LeasedContainer{
+			lc:            l.LaunchContainer,
+			Pool:          l.pool,
+			StartTime:     time.Now(),
+			Window:        win,
+			Start:         start,
+			StartedWindow: true,
+		}
+
+		win.Leases.Add(lc)
+
+		l.rif.Add(1)
+
+		return lc, nil
+	}
+
+	return nil, nil
+}
+
+func (l *leaseOperation) setupPending() (*pendingContainer, chan *UsageWindow) {
+	l.pool.mu.Lock()
+	defer l.pool.mu.Unlock()
+
+	pool := l.pool
+
+	if !pool.pending.Empty() {
+		for pc := range pool.pending {
+			if pc.waiters.Len() < l.MaxLeasesPerContainer {
+				// So that the sender doesn't block.
+				pendingCh := make(chan *UsageWindow, 1)
+				pc.waiters.Add(pendingCh)
+
+				return pc, pendingCh
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func (l *leaseOperation) tryPendingContainer(ctx context.Context) (*LeasedContainer, bool, error) {
+	// If there are any pending containers, find one with room and attach ourselves
+	// to it.
+
+	pc, pendingCh := l.setupPending()
+
+	if pc == nil {
+		return nil, false, nil
+	}
+
+	defer func() {
+		l.pool.mu.Lock()
+		defer l.pool.mu.Unlock()
+		pc.waiters.Remove(pendingCh)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, false, ctx.Err()
+	case win, ok := <-pendingCh:
+
+		if !ok {
+			l.Log.Warn("pending container wait failed, retrying lease")
+			// I don't love recursing here, but it's rare (famous last words)
+			//pool.mu.Unlock()
+			//lc, err := l.Lease(ctx, name, opts...)
+			//pool.mu.Lock()
+
+			return nil, true, nil
+		}
+
+		l.pool.mu.Lock()
+		defer l.pool.mu.Unlock()
+
+		lc := &LeasedContainer{
+			lc:        l.LaunchContainer,
+			Pool:      l.pool,
+			StartTime: time.Now(),
+			Window:    win,
+			Start:     win.Start,
+		}
+
+		win.Leases.Add(lc)
+		l.rif.Add(1)
+
+		return lc, false, nil
+	}
+}
+
+func (l *leaseOperation) setupLaunch(ctx context.Context) error {
+	l.pool.mu.Lock()
+	defer l.pool.mu.Unlock()
+
+	// ok, we need to launch a container.
+
+	pool := l.pool
+
+	ac, err := l.AppAccess.LoadApp(ctx, pool.app.name)
+	if err != nil {
+		return err
+	}
+
+	l.ac = ac
+
+	mrv, err := l.AppAccess.MostRecentVersion(ctx, ac)
+	if err != nil {
+		return err
+	}
+
+	l.mrv = mrv
+
+	pc := &pendingContainer{
+		waiters: set.New[chan *UsageWindow](),
+	}
+
+	pool.pending.Add(pc)
+
+	l.pc = pc
+
+	return nil
+}
+
+func (l *leaseOperation) cleanupLaunch() {
+	l.pool.mu.Lock()
+	defer l.pool.mu.Unlock()
+
+	if l.pc != nil {
+		l.pc.Close()
+		l.pool.pending.Remove(l.pc)
+	}
+}
+
+func (l *leaseOperation) launchContainer(ctx context.Context) (*LeasedContainer, error) {
+	err := l.setupLaunch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer l.cleanupLaunch()
+
+	winId := idgen.Gen("w")
+	l.Log.Info("launching container", "app", l.ac.Name, "pool", l.opts.poolName, "version", l.mrv.Version, "window", winId)
+
+	rc, err := l.launch(ctx)
+
+	if err != nil {
+		l.Log.Error("failed to launch container", "app", l.ac.Name, "version", l.mrv.Version, "error", err)
+		return nil, err
+	} else {
+		l.Log.Info("launched container", "app", l.ac.Name, "version", l.mrv.Version, "window", winId)
+	}
+
+	l.pool.mu.Lock()
+	defer l.pool.mu.Unlock()
+
+	win := &UsageWindow{
+		App:         l.pool.app.name,
+		Id:          winId,
+		Start:       0,
+		Leases:      set.New[*LeasedContainer](),
+		TotalLeases: 1,
+		Version:     l.mrv,
+
+		container: rc,
+	}
+
+	l.pool.windows.Add(win)
+
+	lc := &LeasedContainer{
+		lc:            l.LaunchContainer,
+		Pool:          l.pool,
+		StartTime:     time.Now(),
+		Window:        win,
+		Start:         win.Start,
+		StartedWindow: true,
+	}
+
+	win.Leases.Add(lc)
+	l.rif.Add(1)
+
+loop:
+	for ch := range l.pc.waiters {
+		select {
+		case <-ctx.Done():
+			l.Log.Warn("context cancelled while sending window to pending waiters")
+			// we've got everything setup already, let's return the lease.
+			// defers will cleanup the pending waiters and then can make other arrangements.
+			break loop
+		case ch <- win:
+			// ok
+		}
+	}
+
+	return lc, nil
+}
+
+func (l *leaseOperation) launch(
+	ctx context.Context,
+) (*runningContainer, error) {
+	ec, err := network.AllocateOnBridge(l.Bridge, l.Subnet)
+	if err != nil {
+		return nil, err
+	}
+
+	l.Log.Debug("allocated network endpoint", "bridge", l.Bridge, "addresses", ec.Addresses)
+
+	config := &run.ContainerConfig{
+		App:      l.ac.Name,
+		Image:    l.mrv.ImageName(),
+		Endpoint: ec,
+		Env: map[string]string{
+			"MIREN_APP":     l.ac.Name,
+			"MIREN_POOL":    l.opts.poolName,
+			"MIREN_VERSION": l.mrv.Version,
+		},
+		Labels: map[string]string{
+			"miren.dev/pool":    l.pool.name,
+			"miren.dev/version": l.mrv.Version,
+		},
+	}
+
+	_, err = l.CR.RunContainer(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	if l.opts.dontWaitNetwork {
+		l.Log.Info("not waiting for network", "container", config.Id)
+		err = l.Health.WaitReady(ctx, config.Id)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err = l.Health.WaitForReady(ctx, config.Id)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	rc := &runningContainer{
+		id:          config.Id,
+		image:       config.Image,
+		cpuStatPath: filepath.Join("/sys/fs/cgroup", config.CGroupPath, "cpu.stat"),
+	}
+
+	return rc, nil
+}

--- a/pkg/multierror/multierror.go
+++ b/pkg/multierror/multierror.go
@@ -1,0 +1,65 @@
+package multierror
+
+import (
+	"errors"
+	"slices"
+)
+
+type MultiError struct {
+	errors []error
+}
+
+func (m *MultiError) Error() string {
+	var s string
+	for _, err := range m.errors {
+		s += err.Error() + "\n"
+	}
+	return s
+}
+
+func (m *MultiError) Unwrap() []error {
+	return m.errors
+}
+
+func (m *MultiError) Errors() []error {
+	return m.errors
+}
+
+func (m *MultiError) Is(err error) bool {
+	for _, e := range m.errors {
+		if e == err {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MultiError) As(target any) bool {
+	for _, e := range m.errors {
+		if errors.As(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func Append(err error, errs ...error) error {
+	if err == nil {
+		return nil
+	}
+
+	if len(errs) == 0 {
+		return err
+	}
+
+	me, ok := err.(*MultiError)
+	if ok {
+		return &MultiError{
+			errors: append(slices.Clone(me.errors), errs...),
+		}
+	}
+
+	return &MultiError{
+		errors: errs,
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -103,5 +103,5 @@ func (s *Server) Run(ctx context.Context) error {
 
 	<-ctx.Done()
 
-	return ctx.Err()
+	return nil
 }


### PR DESCRIPTION
When releasing a new version, we clear the access to the old versions from the leaser. This prevents them from continuing to have leases issued on them, and then once they go idle the container is removed.

One side note, the lease abstraction is really paying off here.