### PR TITLE
Add `set host` to configure a host name route for an application

### DIFF
--- a/app/routes.go
+++ b/app/routes.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
+)
+
+func (a *AppAccess) LoadApplicationForHost(ctx context.Context, host string) (*AppConfig, error) {
+	var app AppConfig
+
+	err := a.DB.QueryRow(ctx,
+		`SELECT app.id, app.xid, app.name, app.created_at, app.updated_at 
+		   FROM http_routes r, applications app
+		  WHERE (host = $1 OR host = '*')
+		    AND r.application_id = app.id
+		  ORDER BY CASE WHEN host = $1 THEN 0 ELSE 1 END
+		  LIMIT 1`, host).Scan(
+		&app.Id, &app.Xid, &app.Name, &app.CreatedAt, &app.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return &app, nil
+}
+
+func (a *AppAccess) SetApplicationHost(ctx context.Context, ac *AppConfig, host string) error {
+	cur, err := a.LoadApplicationForHost(ctx, host)
+	if err != nil {
+		return err
+	}
+
+	if cur != nil {
+		if cur.Id == ac.Id {
+			return nil
+		}
+
+		return errors.New("host already in use")
+	}
+
+	_, err = a.DB.Exec(ctx,
+		`INSERT INTO http_routes (application_id, host)
+		 VALUES ($1, $2)`,
+		ac.Id, host,
+	)
+	return err
+}

--- a/app/rpc.gen.go
+++ b/app/rpc.gen.go
@@ -345,6 +345,77 @@ func (v *CrudGetConfigurationResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type crudSetHostArgsData struct {
+	App  *string `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
+	Host *string `cbor:"1,keyasint,omitempty" json:"host,omitempty"`
+}
+
+type CrudSetHostArgs struct {
+	call *rpc.Call
+	data crudSetHostArgsData
+}
+
+func (v *CrudSetHostArgs) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *CrudSetHostArgs) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *CrudSetHostArgs) HasHost() bool {
+	return v.data.Host != nil
+}
+
+func (v *CrudSetHostArgs) Host() string {
+	if v.data.Host == nil {
+		return ""
+	}
+	return *v.data.Host
+}
+
+func (v *CrudSetHostArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CrudSetHostArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CrudSetHostArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CrudSetHostArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type crudSetHostResultsData struct{}
+
+type CrudSetHostResults struct {
+	call *rpc.Call
+	data crudSetHostResultsData
+}
+
+func (v *CrudSetHostResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CrudSetHostResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CrudSetHostResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CrudSetHostResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type CrudNew struct {
 	*rpc.Call
 	args    CrudNewArgs
@@ -423,10 +494,37 @@ func (t *CrudGetConfiguration) Results() *CrudGetConfigurationResults {
 	return results
 }
 
+type CrudSetHost struct {
+	*rpc.Call
+	args    CrudSetHostArgs
+	results CrudSetHostResults
+}
+
+func (t *CrudSetHost) Args() *CrudSetHostArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *CrudSetHost) Results() *CrudSetHostResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type Crud interface {
 	New(ctx context.Context, state *CrudNew) error
 	SetConfiguration(ctx context.Context, state *CrudSetConfiguration) error
 	GetConfiguration(ctx context.Context, state *CrudGetConfiguration) error
+	SetHost(ctx context.Context, state *CrudSetHost) error
 }
 
 type reexportCrud struct {
@@ -442,6 +540,10 @@ func (_ reexportCrud) SetConfiguration(ctx context.Context, state *CrudSetConfig
 }
 
 func (_ reexportCrud) GetConfiguration(ctx context.Context, state *CrudGetConfiguration) error {
+	panic("not implemented")
+}
+
+func (_ reexportCrud) SetHost(ctx context.Context, state *CrudSetHost) error {
 	panic("not implemented")
 }
 
@@ -473,6 +575,14 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Index:         0,
 			Handler: func(ctx context.Context, call *rpc.Call) error {
 				return t.GetConfiguration(ctx, &CrudGetConfiguration{Call: call})
+			},
+		},
+		{
+			Name:          "setHost",
+			InterfaceName: "Crud",
+			Index:         0,
+			Handler: func(ctx context.Context, call *rpc.Call) error {
+				return t.SetHost(ctx, &CrudSetHost{Call: call})
 			},
 		},
 	}
@@ -585,4 +695,24 @@ func (v CrudClient) GetConfiguration(ctx context.Context, app string) (*CrudClie
 	}
 
 	return &CrudClientGetConfigurationResults{client: v.Client, data: ret}, nil
+}
+
+type CrudClientSetHostResults struct {
+	client *rpc.Client
+	data   crudSetHostResultsData
+}
+
+func (v CrudClient) SetHost(ctx context.Context, app string, host string) (*CrudClientSetHostResults, error) {
+	args := CrudSetHostArgs{}
+	args.data.App = &app
+	args.data.Host = &host
+
+	var ret crudSetHostResultsData
+
+	err := v.Client.Call(ctx, "setHost", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CrudClientSetHostResults{client: v.Client, data: ret}, nil
 }

--- a/app/rpc.go
+++ b/app/rpc.go
@@ -107,3 +107,13 @@ func (r *RPCCrud) GetConfiguration(ctx context.Context, state *CrudGetConfigurat
 
 	return nil
 }
+
+func (r *RPCCrud) SetHost(ctx context.Context, state *CrudSetHost) error {
+	name := state.Args().App()
+	ac, err := r.Access.LoadApp(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	return r.Access.SetApplicationHost(ctx, ac, state.Args().Host())
+}

--- a/app/rpc.yml
+++ b/app/rpc.yml
@@ -49,3 +49,9 @@ interfaces:
             type: Configuration
           - name: versionId
             type: string
+      - name: setHost
+        parameters:
+          - name: app
+            type: string
+          - name: host
+            type: string

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -26,6 +26,9 @@ func AllCommands() map[string]cli.CommandFactory {
 		"set": func() (cli.Command, error) {
 			return Infer("set", "Set environment variables for an application", Set), nil
 		},
+		"set host": func() (cli.Command, error) {
+			return Infer("set host", "Set the hostname of an application", SetHost), nil
+		},
 
 		"logs": func() (cli.Command, error) {
 			return Infer("logs", "Get logs for an application", Logs), nil

--- a/cli/commands/set_host.go
+++ b/cli/commands/set_host.go
@@ -1,0 +1,20 @@
+package commands
+
+import (
+	"miren.dev/runtime/app"
+)
+
+func SetHost(ctx *Context, opts struct {
+	AppCentric
+	Host string `long:"host" description:"Set host"`
+}) error {
+	cl, err := ctx.RPCClient("app")
+	if err != nil {
+		return err
+	}
+
+	ac := app.CrudClient{Client: cl}
+
+	_, err = ac.SetHost(ctx, opts.App, opts.Host)
+	return err
+}

--- a/db/001_initial.sql
+++ b/db/001_initial.sql
@@ -39,6 +39,16 @@ CREATE TABLE application_versions (
     UNIQUE(application_id, version)
 );
 
+CREATE TABLE http_routes (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    application_id BIGINT NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
+    host TEXT NOT NULL,
+
+    UNIQUE(host)
+);
+
 INSERT INTO organizations (name, external_id) VALUES ('local', 'local');
 
 ---- create above / drop below ----


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added ability to set and manage application hosts through a new RPC method.
  - Introduced new CLI command to configure application hostnames.

- **Database Changes**
  - Created new `http_routes` table to support host-based application routing.

- **Improvements**
  - Enhanced application lookup and routing mechanisms, improving error reporting.
  - Improved RPC interface for host configuration management.

- **Technical Enhancements**
  - Updated RPC generation and handling for more robust host configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->