### PR TITLE
Implement the ability to do RPC over a stream

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -38,6 +38,10 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("app new", "Create a new application", AppNew), nil
 		},
 
+		"internal dial-stdio": func() (cli.Command, error) {
+			return Infer("internal dial-stdio", "Dial a stdio connection", DialStdio), nil
+		},
+
 		"debug ctr nuke": func() (cli.Command, error) {
 			return Infer("debug ctr nuke", "Nuke a containerd namespace", CtrNuke), nil
 		},

--- a/cli/commands/dial_stdio.go
+++ b/cli/commands/dial_stdio.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+)
+
+func DialStdio(ctx *Context, opts struct {
+	Addr string `long:"addr" description:"address to dial" required:"true"`
+}) error {
+	c, err := net.Dial("unix", opts.Addr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to dial: %v\n", err)
+		os.Exit(1)
+	}
+
+	defer c.Close()
+
+	fmt.Fprintf(os.Stderr, "connected to %s\n", opts.Addr)
+
+	var wg sync.WaitGroup
+
+	sctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		<-sctx.Done()
+		c.Close()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+
+		io.Copy(c, os.Stdin)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+
+		io.Copy(os.Stdout, c)
+	}()
+
+	wg.Wait()
+
+	return nil
+}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -11,6 +11,7 @@ func Server(ctx *Context, opts struct {
 	TempDir           string `long:"temp-dir" description:"Directory to store temporary files" asm:"tempdir" type:"path"`
 	RunscBinary       string `long:"runsc-binary" description:"Path to the runsc binary" asm:"runsc_binary" type:"path"`
 	Id                string `long:"id" description:"Unique identifier for the server" asm:"server-id"`
+	Local             string `long:"local" description:"Run the server locally" asm:"local-path"`
 }) error {
 	var server server.Server
 

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -49,6 +49,8 @@ func init() {
 func (m *Runtime) WithServices(dir *dagger.Directory) *dagger.Container {
 	ch := dag.Container().
 		From("clickhouse/clickhouse-server:latest").
+		WithEnvVariable("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1").
+		WithEnvVariable("CLICKHOUSE_PASSWORD", "default").
 		WithExposedPort(9000).
 		AsService()
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.3
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.30.0
+	github.com/NimbleMarkets/ntcharts v0.3.1
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.2.4
 	github.com/charmbracelet/lipgloss v1.0.0
@@ -22,9 +23,9 @@ require (
 	github.com/dave/jennifer v1.7.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8
-	github.com/evertras/bubble-table v0.17.1
 	github.com/fxamacker/cbor/v2 v2.7.0
 	github.com/google/pprof v0.0.0-20241203143554-1e3fdc7de467
+	github.com/hashicorp/yamux v0.1.2
 	github.com/ironpark/skiplist v0.0.0-20230103051251-d63941a7d606
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jackc/tern/v2 v2.2.3
@@ -39,7 +40,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/pkg/errors v0.9.1
-	github.com/quic-go/quic-go v0.48.2
+	github.com/quic-go/quic-go v0.49.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
@@ -55,6 +56,8 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.33.0
 	go.opentelemetry.io/otel/trace v1.33.0
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba
+	golang.org/x/net v0.32.0
+	golang.org/x/sync v0.10.0
 	golang.org/x/sys v0.29.0
 	golang.org/x/tools v0.28.0
 	google.golang.org/protobuf v1.35.2
@@ -71,10 +74,8 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.9 // indirect
-	github.com/NimbleMarkets/ntcharts v0.3.1 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
@@ -133,7 +134,6 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/onsi/ginkgo/v2 v2.19.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -168,12 +168,10 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.31.0 // indirect
 	go.opentelemetry.io/otel/metric v1.33.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
-	go.uber.org/mock v0.4.0 // indirect
+	go.uber.org/mock v0.5.0 // indirect
 	golang.org/x/crypto v0.30.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
-	golang.org/x/net v0.32.0 // indirect
-	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.6.0 // indirect
 	google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7X
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
-github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
@@ -121,8 +119,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/evertras/bubble-table v0.17.1 h1:HJwq3iQrZulXDE93ZcqJNiUVQCBbN4IJ2CkB/IxO3kk=
-github.com/evertras/bubble-table v0.17.1/go.mod h1:ifHujS1YxwnYSOgcR2+m3GnJ84f7CVU/4kUOxUCjEbQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
@@ -197,6 +193,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
+github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
@@ -243,7 +241,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
-github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
@@ -287,8 +284,6 @@ github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
-github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
-github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=
@@ -330,9 +325,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
 github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
-github.com/quic-go/quic-go v0.48.2 h1:wsKXZPeGWpMpCGSWqOcqpW2wZYic/8T3aqiOID0/KWE=
-github.com/quic-go/quic-go v0.48.2/go.mod h1:yBgs3rWBOADpga7F+jJsb6Ybg1LSYiQvwWlLX+/6HMs=
-github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/quic-go/quic-go v0.49.0 h1:w5iJHXwHxs1QxyBv1EHKuC50GX5to8mJAxvtnttJp94=
+github.com/quic-go/quic-go v0.49.0/go.mod h1:s2wDnmCdooUQBmQfpUSTCYBl1/D4FcqbULMMkASvR6s=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -442,8 +436,8 @@ go.opentelemetry.io/otel/trace v1.33.0 h1:cCJuF7LRjUFso9LPnEAHJDB2pqzp+hbO8eu1qq
 go.opentelemetry.io/otel/trace v1.33.0/go.mod h1:uIcdVUZMpTAmz0tI1z04GoVSezK37CbGV4fr1f2nBck=
 go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
-go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
-go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
+go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
 go4.org/netipx v0.0.0-20231129151722-fdeea329fbba h1:0b9z3AuHCjxk0x/opv64kcgZLBseWJUpBw5I82+2U4M=
 go4.org/netipx v0.0.0-20231129151722-fdeea329fbba/go.mod h1:PLyyIXexvUFg3Owu6p/WfdlivPbZJsZdgWZlrGope/Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/health/container.go
+++ b/health/container.go
@@ -150,8 +150,6 @@ func (c *ContainerMonitor) Populated() error {
 }
 
 func (c *ContainerMonitor) refreshStatus(ctx context.Context) {
-	c.Log.Debug("refreshing container status")
-
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
 	containers, err := c.CC.Containers(ctx)

--- a/pkg/packet/multi.go
+++ b/pkg/packet/multi.go
@@ -1,0 +1,324 @@
+package packet
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"miren.dev/runtime/pkg/idgen"
+)
+
+type multiplexAddr struct {
+	id string
+}
+
+func (a multiplexAddr) Network() string {
+	return "multiplex"
+}
+
+func (a multiplexAddr) String() string {
+	return a.id
+}
+
+// connection wraps an individual io.ReadWriteCloser with its metadata
+type connection struct {
+	rw     io.ReadWriteCloser
+	raddr  net.Addr
+	closed atomic.Int32
+
+	wmu sync.Mutex
+}
+
+// PacketConnMultiplex implements net.PacketConn by managing multiple io.ReadWriteClosers
+// and routing packets based on remote addresses.
+type PacketConnMultiplex struct {
+	ctx      context.Context
+	mu       sync.RWMutex
+	conns    map[string]*connection
+	readChan chan packet
+	closed   atomic.Int32
+
+	bufpool sync.Pool
+}
+
+type bufPE struct {
+	buf []byte
+}
+
+// packet represents a received packet and its metadata
+type packet struct {
+	data []byte
+	addr net.Addr
+
+	// currently unused because we emulate the behavior of a UDP based PacketConn
+	err error
+}
+
+// NewPacketConnMultiplex creates a new PacketConnMultiplex.
+func NewPacketConnMultiplex(ctx context.Context) *PacketConnMultiplex {
+	p := &PacketConnMultiplex{
+		ctx:      ctx,
+		conns:    make(map[string]*connection),
+		readChan: make(chan packet, 32), // Buffered channel for received packets
+	}
+	return p
+}
+
+// AddConn adds a new connection to the adapter.
+// Returns an error if a connection with the same remote address already exists.
+func (p *PacketConnMultiplex) AddConn(rw io.ReadWriteCloser) (net.Addr, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed.Load() == 1 {
+		return nil, net.ErrClosed
+	}
+
+	addr := &multiplexAddr{id: idgen.Gen("c") + ":0"}
+
+	key := addr.String()
+
+	if _, exists := p.conns[key]; exists {
+		return nil, fmt.Errorf("connection already exists for address: %s", key)
+	}
+
+	conn := &connection{
+		rw:    rw,
+		raddr: addr,
+	}
+	p.conns[key] = conn
+
+	// Start a goroutine to read packets from this connection
+	go p.readLoop(conn)
+
+	return addr, nil
+}
+
+// RemoveConn removes and closes a connection.
+func (p *PacketConnMultiplex) RemoveConn(remoteAddr net.Addr) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	key := remoteAddr.String()
+	conn, exists := p.conns[key]
+	if !exists {
+		return fmt.Errorf("no connection exists for address: %s", key)
+	}
+
+	conn.closed.Store(1)
+	delete(p.conns, key)
+	return conn.rw.Close()
+}
+
+const MaxPacketSize = 64 * 1024
+
+// readLoop continuously reads packets from a connection and sends them to readChan
+func (p *PacketConnMultiplex) readLoop(conn *connection) {
+	rb := make([]byte, 4)
+
+	for {
+		var next packet
+
+		_, err := io.ReadFull(conn.rw, rb)
+		if err != nil {
+			if conn.closed.Load() == 1 {
+				return
+			}
+
+			// We emulate the behavior of a UDP based PacketConn here, where
+			// there are no read errors, just silence.
+			p.RemoveConn(conn.raddr)
+
+			return
+		}
+
+		length := binary.BigEndian.Uint32(rb)
+
+		if length > MaxPacketSize {
+			// Even with jumbo frames, etc, there is no reason we'd see
+			// a packed this big, considering we're emulating UDP style
+			// diagrams here. So we assume it's someone attempting to
+			// DoS us.
+			p.RemoveConn(conn.raddr)
+			return
+		}
+
+		var data []byte
+		v := p.bufpool.Get()
+
+		if v == nil {
+			data = make([]byte, max(length, 2048))
+		} else {
+			data = v.(*bufPE).buf
+			if len(data) < int(length) {
+				data = make([]byte, max(length, 2048))
+			}
+		}
+
+		buf := data[:length]
+
+		_, err = io.ReadFull(conn.rw, buf)
+		if err != nil {
+			if conn.closed.Load() == 1 {
+				return
+			}
+
+			// We emulate the behavior of a UDP based PacketConn here, where
+			// there are no read errors, just silence.
+
+			p.RemoveConn(conn.raddr)
+
+			return
+		}
+
+		next = packet{buf, conn.raddr, nil}
+
+		select {
+		case p.readChan <- next:
+		// ok
+		case <-p.ctx.Done():
+			return
+		}
+	}
+}
+
+// ReadFrom implements net.PacketConn.ReadFrom.
+func (p *PacketConnMultiplex) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
+	if p.closed.Load() == 1 {
+		return 0, nil, net.ErrClosed
+	}
+
+	// Wait for a packet from any connection
+	select {
+	case <-p.ctx.Done():
+		return 0, nil, p.ctx.Err()
+	case pkt := <-p.readChan:
+		if pkt.err != nil {
+			return 0, pkt.addr, pkt.err
+		}
+
+		if len(pkt.data) > len(b) {
+			return 0, pkt.addr, io.ErrShortBuffer
+		}
+
+		n = copy(b, pkt.data)
+
+		p.bufpool.Put(&bufPE{
+			buf: pkt.data[:cap(pkt.data)],
+		})
+
+		return n, pkt.addr, nil
+	}
+}
+
+// WriteTo implements net.PacketConn.WriteTo.
+func (p *PacketConnMultiplex) WriteTo(b []byte, addr net.Addr) (n int, err error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.closed.Load() == 1 {
+		return 0, net.ErrClosed
+	}
+
+	conn, exists := p.conns[addr.String()]
+	if !exists {
+		// We emulate the behavior of a UDP based PacketConn here, which has no idea
+		// if the remote side is alive or not.
+		return len(b), nil // fmt.Errorf("no connection exists for address: %s", addr.String())
+	}
+
+	var wb [4]byte
+
+	binary.BigEndian.PutUint32(wb[:], uint32(len(b)))
+
+	conn.wmu.Lock()
+	defer conn.wmu.Unlock()
+
+	if _, err := conn.rw.Write(wb[:]); err != nil {
+		return 0, err
+	}
+
+	return conn.rw.Write(b)
+}
+
+// Close implements net.PacketConn.Close.
+func (p *PacketConnMultiplex) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed.Load() == 1 {
+		return net.ErrClosed
+	}
+
+	p.closed.Store(1)
+	close(p.readChan)
+
+	var lastErr error
+	for _, conn := range p.conns {
+		if err := conn.rw.Close(); err != nil {
+			lastErr = err
+		}
+		conn.closed.Store(1)
+	}
+	p.conns = nil
+
+	return lastErr
+}
+
+// LocalAddr implements net.PacketConn.LocalAddr.
+func (p *PacketConnMultiplex) LocalAddr() net.Addr {
+	return &multiplexAddr{id: "multiplex:0"}
+}
+
+// SetDeadline implements net.PacketConn.SetDeadline.
+func (p *PacketConnMultiplex) SetDeadline(t time.Time) error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	var lastErr error
+	for _, conn := range p.conns {
+		if setter, ok := conn.rw.(interface{ SetDeadline(time.Time) error }); ok {
+			if err := setter.SetDeadline(t); err != nil {
+				lastErr = err
+			}
+		}
+	}
+	return lastErr
+}
+
+// SetReadDeadline implements net.PacketConn.SetReadDeadline.
+func (p *PacketConnMultiplex) SetReadDeadline(t time.Time) error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	var lastErr error
+	for _, conn := range p.conns {
+		if setter, ok := conn.rw.(interface{ SetReadDeadline(time.Time) error }); ok {
+			if err := setter.SetReadDeadline(t); err != nil {
+				lastErr = err
+			}
+		}
+	}
+	return lastErr
+}
+
+// SetWriteDeadline implements net.PacketConn.SetWriteDeadline.
+func (p *PacketConnMultiplex) SetWriteDeadline(t time.Time) error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	var lastErr error
+	for _, conn := range p.conns {
+		if setter, ok := conn.rw.(interface{ SetWriteDeadline(time.Time) error }); ok {
+			if err := setter.SetWriteDeadline(t); err != nil {
+				lastErr = err
+			}
+		}
+	}
+	return lastErr
+}

--- a/pkg/rpc/state_local.go
+++ b/pkg/rpc/state_local.go
@@ -1,0 +1,156 @@
+package rpc
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"miren.dev/runtime/pkg/packet"
+	"miren.dev/runtime/pkg/stdio"
+)
+
+func (s *State) setupLocal(ctx context.Context) error {
+	pm := packet.NewPacketConnMultiplex(ctx)
+	s.localMP = pm
+	s.localTransport = &quic.Transport{Conn: pm}
+
+	return nil
+}
+
+func (s *State) connectLocal(addr string) (*Client, error) {
+	c, err := net.Dial("unix", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	remote, err := s.localMP.AddConn(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		State:      s,
+		transport:  s.localTransport,
+		remote:     "local",
+		remoteAddr: remote,
+	}, nil
+}
+
+func (s *State) connectProcess(cmd *exec.Cmd) (*Client, error) {
+	se, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	bse := bufio.NewReader(se)
+	go func() {
+		defer se.Close()
+
+		for {
+			line, _, err := bse.ReadLine()
+			if err != nil {
+				return
+			}
+
+			s.log.Debug("process stderr", "line", string(line))
+		}
+	}()
+
+	nc, err := stdio.Dial(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	remote, err := s.localMP.AddConn(nc)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		err := cmd.Wait()
+
+		s.localMP.RemoveConn(remote)
+
+		time.Sleep(1 * time.Second)
+
+		if err != nil {
+			s.log.Error("process exited with error", "error", err)
+		} else {
+			s.log.Debug("process exited")
+		}
+	}()
+
+	return &Client{
+		State:      s,
+		transport:  s.localTransport,
+		remote:     "local",
+		remoteAddr: remote,
+	}, nil
+
+}
+
+func (s *State) startLocalListener(ctx context.Context, addr string) error {
+	pm := s.localMP
+
+	os.Remove(addr)
+
+	li, err := net.Listen("unix", addr)
+	if err != nil {
+		return err
+	}
+	os.Chmod(addr, 0777)
+
+	go func() {
+		for {
+			c, err := li.Accept()
+			if err != nil {
+				s.log.Error("failed to accept connection", "error", err)
+				return
+			}
+
+			go func() {
+				ir, err := pm.AddConn(c)
+				if err != nil {
+					s.log.Error("failed to add connection to multiplexer", "error", err)
+				}
+
+				s.log.Debug("accepted local connection", "remote", c.RemoteAddr(), "ir", ir)
+			}()
+		}
+	}()
+
+	ec, err := s.localTransport.ListenEarly(s.serverTlsCfg, &s.qc)
+	if err != nil {
+		return err
+	}
+
+	subS := &State{
+		StateCommon: s.StateCommon,
+		transport:   s.localTransport,
+	}
+
+	subS.server = s.server.Clone(subS)
+
+	serv := &http3.Server{
+		Handler: subS.server,
+		Logger:  subS.log.With("module", "http3-local"),
+	}
+
+	subS.hs = serv
+
+	go func() {
+		<-ctx.Done()
+		os.Remove(addr)
+		serv.Shutdown(context.Background())
+	}()
+
+	s.log.Debug("starting local listener", "addr", addr)
+	go subS.hs.ServeListener(ec)
+
+	return nil
+}

--- a/pkg/stdio/dial.go
+++ b/pkg/stdio/dial.go
@@ -1,0 +1,79 @@
+package stdio
+
+import (
+	"io"
+	"net"
+	"os/exec"
+	"time"
+)
+
+type stdioConn struct {
+	r io.ReadCloser
+	w io.WriteCloser
+}
+
+func (c *stdioConn) Read(b []byte) (int, error) {
+	return c.r.Read(b)
+}
+
+func (c *stdioConn) Write(b []byte) (int, error) {
+	return c.w.Write(b)
+}
+
+func (c *stdioConn) Close() error {
+	c.r.Close()
+	return c.w.Close()
+}
+
+type stdioAddr struct {
+	name string
+}
+
+func (a *stdioAddr) Network() string {
+	return "stdio"
+}
+
+func (a *stdioAddr) String() string {
+	return a.name
+}
+
+func (c *stdioConn) LocalAddr() net.Addr {
+	return &stdioAddr{"stdio"}
+}
+
+func (c *stdioConn) RemoteAddr() net.Addr {
+	return &stdioAddr{"stdio"}
+}
+
+func (c *stdioConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *stdioConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *stdioConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+func Dial(cmd *exec.Cmd) (net.Conn, error) {
+	r, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	w, err := cmd.StdinPipe()
+	if err != nil {
+		r.Close()
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		r.Close()
+		w.Close()
+		return nil, err
+	}
+
+	return &stdioConn{r: r, w: w}, nil
+}

--- a/pkg/testutils/reg.go
+++ b/pkg/testutils/reg.go
@@ -95,19 +95,24 @@ func Registry(extra ...func(*asm.Registry)) (*asm.Registry, func()) {
 
 	r.Register("log", log)
 
-	r.ProvideName("clickhouse", func() *sql.DB {
+	r.ProvideName("clickhouse", func(opts struct {
+		Log *slog.Logger
+	}) *sql.DB {
 		return clickhouse.OpenDB(&clickhouse.Options{
 			Addr: []string{"clickhouse:9000"},
 			Auth: clickhouse.Auth{
 				Database: "default",
 				Username: "default",
-				Password: "",
+				Password: "default",
 			},
 			DialTimeout: time.Second * 30,
 			Compression: &clickhouse.Compression{
 				Method: clickhouse.CompressionLZ4,
 			},
 			Debug: true,
+			Debugf: func(format string, v ...interface{}) {
+				opts.Log.Debug(fmt.Sprintf(format, v...))
+			},
 		})
 	})
 

--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,8 @@ type Server struct {
 	Log  *slog.Logger
 	Port int `asm:"server_port"`
 
+	LocalPath string `asm:"local-path,optional"`
+
 	Build   *build.RPCBuilder
 	Shell   *shell.RPCShell
 	AppCrud *app.RPCCrud
@@ -73,10 +75,17 @@ func (s *Server) Shutdown() {
 func (s *Server) Run(ctx context.Context) error {
 	defer s.Shutdown()
 
-	ss, err := rpc.NewState(ctx, rpc.WithSkipVerify,
+	opts := []rpc.StateOption{
+		rpc.WithSkipVerify,
 		rpc.WithBindAddr(fmt.Sprintf("127.0.0.1:%d", s.Port)),
 		rpc.WithLogger(s.Log),
-	)
+	}
+
+	if s.LocalPath != "" {
+		opts = append(opts, rpc.WithLocalServer(s.LocalPath))
+	}
+
+	ss, err := rpc.NewState(ctx, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Converts a set of streams to a single PacketConn
* Simple process-based dial (more to come)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a command for establishing standard I/O connections to enable direct interaction with external processes.
  - Enabled configurable local server options, allowing users to specify a custom local connection path.
  - Enhanced connectivity with support for QUIC transport and improved network routing for more robust communication.
  - Added environment variables for ClickHouse configuration to enhance service setup.
  - Implemented a multiplexing mechanism for packet connections to facilitate better data handling.
  - Improved logging capabilities during ClickHouse connection setup.

- **Refactor**
  - Revamped state handling and server synchronization to boost performance and reliability.

- **Chores**
  - Updated and streamlined dependency libraries for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->