### PR TITLE
Allow server => client callbacks to bypass typical x509 rules

### DIFF
--- a/pkg/rpc/call.go
+++ b/pkg/rpc/call.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"crypto/ed25519"
+	"crypto/x509"
 	"net/http"
 
 	"github.com/fxamacker/cbor/v2"
@@ -16,6 +17,8 @@ type Call struct {
 	method string
 
 	caller ed25519.PublicKey
+
+	peer *x509.Certificate
 
 	results any
 }
@@ -37,5 +40,5 @@ func (c *Call) NewCapability(i *Interface) *Capability {
 }
 
 func (c *Call) NewClient(capa *Capability) *Client {
-	return c.s.NewClient(capa)
+	return c.s.state.newClientFrom(capa, c.peer)
 }

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,6 +31,8 @@ type Client struct {
 	remote     string
 	remoteAddr net.Addr
 	oid        OID
+
+	tlsCfg *tls.Config
 
 	// This is the remote address that the server
 	// observes this client as coming from. We use this address
@@ -293,7 +296,7 @@ func (c *Client) conn(ctx context.Context) (*http3.ClientConn, error) {
 		addr = udpAddr
 	}
 
-	ec, err := c.transport.DialEarly(ctx, addr, c.clientTlsCfg, &DefaultQUICConfig)
+	ec, err := c.transport.DialEarly(ctx, addr, c.tlsCfg, &DefaultQUICConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -238,6 +238,7 @@ func TestRPC(t *testing.T) {
 		ac := &example.AdjustTempClient{Client: c2}
 
 		_, err = ac.Adjust(context.Background(), res2.Setter().Export())
+		r.NoError(err)
 
 		r.Equal(float32(72), em.temp)
 	})


### PR DESCRIPTION
Because the server is calling the client back, the normal x509 rules around ip/hostname validation don't apply. For now, we clamp the server connection to only connect back to the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced RPC security with integrated peer certificate support and updated TLS configurations.
  - Introduced improved connection methods that dynamically handle both local and remote transports with robust certificate verification.

- **Bug Fixes**
  - Improved error handling in RPC tests to ensure robustness.

- **Refactor**
  - Streamlined client connection processes by removing outdated creation paths and reinforcing error checking for greater reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->