### PR TITLE
Upgrade go version (so easy now)

### DIFF
--- a/dagger/main.go
+++ b/dagger/main.go
@@ -69,10 +69,10 @@ func (m *Runtime) WithServices(dir *dagger.Directory) *dagger.Container {
 
 func (m *Runtime) BuildEnv(dir *dagger.Directory) *dagger.Container {
 	return dag.Container().
-		From("golang:1.23").
-		WithMountedCache("/go/pkg/mod", dag.CacheVolume("go-mod-123")).
+		From("golang:1.24").
+		WithMountedCache("/go/pkg/mod", dag.CacheVolume("go-mod-124")).
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
-		WithMountedCache("/go/build-cache", dag.CacheVolume("go-build-123")).
+		WithMountedCache("/go/build-cache", dag.CacheVolume("go-build-124")).
 		WithEnvVariable("GOCACHE", "/go/build-cache").
 		WithExec([]string{"apt-get", "update"}).
 		WithExec([]string{"apt-get", "install", "-y", "iptables", "bash"}).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module miren.dev/runtime
 
-go 1.23.3
+go 1.24
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.30.0

--- a/pkg/hey/hey.go
+++ b/pkg/hey/hey.go
@@ -264,18 +264,18 @@ func main() {
 }
 
 func errAndExit(msg string) {
-	fmt.Fprintf(os.Stderr, msg)
-	fmt.Fprintf(os.Stderr, "\n")
+	fmt.Fprint(os.Stderr, msg)
+	fmt.Fprint(os.Stderr, "\n")
 	os.Exit(1)
 }
 
 func usageAndExit(msg string) {
 	if msg != "" {
-		fmt.Fprintf(os.Stderr, msg)
-		fmt.Fprintf(os.Stderr, "\n\n")
+		fmt.Fprint(os.Stderr, msg)
+		fmt.Fprint(os.Stderr, "\n\n")
 	}
 	flag.Usage()
-	fmt.Fprintf(os.Stderr, "\n")
+	fmt.Fprint(os.Stderr, "\n")
 	os.Exit(1)
 }
 

--- a/pkg/hey/requester/report.go
+++ b/pkg/hey/requester/report.go
@@ -131,7 +131,7 @@ func (r *report) print() {
 		log.Println("error:", err.Error())
 		return
 	}
-	r.printf(buf.String())
+	r.printf("%s", buf.String())
 
 	r.printf("\n")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded to Go version 1.24 for improved performance and compatibility.
	- Updated Docker image versions and cache volume names to align with the new Go version.
	- Modified error handling functions for clearer output formatting. 
	- Adjusted string formatting in the report printing method for enhanced clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->