### PR TITLE
Allow entities without schemas to be text formatted

### DIFF
--- a/pkg/model/text_test.go
+++ b/pkg/model/text_test.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/schema"
+	"miren.dev/runtime/pkg/entity/types"
+)
+
+func testTextFormatter(t *testing.T) (*TextFormatter, *entity.MockStore) {
+	r := require.New(t)
+	store := entity.NewMockStore()
+	sc, err := entity.NewSchemaCache(store)
+	r.NoError(err)
+
+	tf, err := NewTextFormatter(sc)
+	r.NoError(err)
+	return tf, store
+}
+
+func TestTextFormatter_Format(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("works with simple entity", func(t *testing.T) {
+		r := require.New(t)
+		tf, store := testTextFormatter(t)
+		testEntity, err := store.CreateEntity(context.Background(), []entity.Attr{
+			{ID: entity.Ident, Value: entity.KeywordValue("test/entity")},
+			{ID: entity.Doc, Value: entity.StringValue("Test entity")},
+		})
+		r.NoError(err)
+
+		out, err := tf.Format(ctx, testEntity)
+		r.NoError(err)
+
+		expected := `attrs:
+  - id: db/ident
+    value: test/entity
+  - id: db/doc
+    value: Test entity
+`
+		r.Equal(expected, out)
+	})
+
+	t.Run("works for simple entity with schema", func(t *testing.T) {
+		r := require.New(t)
+		tf, store := testTextFormatter(t)
+
+		// TODO: we're depending on a real schema/kind here, it would be better if we could create isolated schemas and kinds in the context of tests
+		err := schema.Apply(ctx, store)
+		r.NoError(err)
+
+		testEntity, err := store.CreateEntity(context.Background(), entity.Attrs(
+			entity.Ident, types.Keyword("test/myproject"),
+			entity.EntityKind, entity.RefValue("dev.miren.core/kind.project"),
+		))
+		r.NoError(err)
+
+		out, err := tf.Format(ctx, testEntity)
+		r.NoError(err)
+
+		expected := `id: test/myproject
+kind: dev.miren.core/project
+version: v1alpha
+spec: {}
+attrs:
+  - id: db/ident
+    value: test/myproject
+  - id: entity/kind
+    value: dev.miren.core/kind.project
+`
+
+		r.Equal(expected, out)
+	})
+}


### PR DESCRIPTION
Previously, if an entity didn't have any `entity/kind` that could be looked up, the `TextFormatter` would error out. There are plenty of entities in the system without an entity/kind attribute, and we'd like to be able to display them in the output of commands like `entity get` and `entity list`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved comments for the entity formatting feature, clarifying how entity kinds and metadata are handled in the output.

- **Bug Fixes**
  - Adjusted formatting behavior to avoid errors when no kinds are present, ensuring smoother output generation.

- **Tests**
  - Added unit tests to verify entity formatting, covering both basic and schema-based scenarios for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->