### PR TITLE
Make a few QOL hack script tweaks

### DIFF
--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -5,17 +5,17 @@ set -e
 
 mkdir /sys/fs/cgroup/inner
 
-for pid in $(cat /sys/fs/cgroup/cgroup.procs); do
-  echo $pid > /sys/fs/cgroup/inner/cgroup.procs 2>/dev/null || true
+for pid in "$(cat /sys/fs/cgroup/cgroup.procs)"; do
+  echo "$pid" >/sys/fs/cgroup/inner/cgroup.procs 2>/dev/null || true
 done
 
-sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers > /sys/fs/cgroup/cgroup.subtree_control
+sed -e 's/ / +/g' -e 's/^/+/' </sys/fs/cgroup/cgroup.controllers >/sys/fs/cgroup/cgroup.subtree_control
 
 mkdir -p /data /run
 
 export OTEL_SDK_DISABLED=true
 
-cat <<EOF > /etc/containerd/config.toml
+cat <<EOF >/etc/containerd/config.toml
 version = 2
 [plugins."io.containerd.runtime.v1.linux"]
   shim_debug = true
@@ -30,7 +30,7 @@ version = 2
   address = "127.0.0.1:1338"
 EOF
 
-cat <<EOF > /etc/containerd/runsc.toml
+cat <<EOF >/etc/containerd/runsc.toml
 log_path = "/var/log/runsc/%ID%/shim.log"
 log_level = "debug"
 binary_name = "/src/hack/runsc-ignore"
@@ -40,10 +40,10 @@ binary_name = "/src/hack/runsc-ignore"
 EOF
 
 mkdir -p /run/containerd
-containerd --root /data --state /data/state --address /run/containerd/containerd.sock -l trace > /dev/null 2>&1 &
+containerd --root /data --state /data/state --address /run/containerd/containerd.sock -l trace >/dev/null 2>&1 &
 
 # Handy to build stuff with.
-buildkitd --root /data/buildkit > /dev/null 2>&1 &
+buildkitd --root /data/buildkit >/dev/null 2>&1 &
 
 mount -t debugfs nodev /sys/kernel/debug
 mount -t tracefs nodev /sys/kernel/debug/tracing
@@ -56,11 +56,11 @@ cd /src
 
 make bin/runtime
 
-ln -s `pwd`/bin/runtime /bin/r
+ln -s "$PWD"/bin/runtime /bin/r
 
 mkdir -p ~/.config/runtime
 
-cat > ~/.config/runtime/clientconfig.yaml <<EOF
+cat >~/.config/runtime/clientconfig.yaml <<EOF
 clusters:
   local:
     hostname: localhost
@@ -71,7 +71,7 @@ EOF
 echo "Cleaning runtime namespace to begin..."
 r debug ctr nuke -n runtime
 
-./bin/runtime dev -vv &
+./bin/runtime dev -vv >>/var/log/runtime.log 2>&1 &
 
 export HISTFILE=/data/.bash_history
 export HISTIGNORE=exit

--- a/hack/it
+++ b/hack/it
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 dagger call -q test --dir=. --tests="$@" --fast

--- a/hack/run
+++ b/hack/run
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-dagger call -q test --dir=. --tests="$1" --run="$2" 
+dagger call -q test --dir=. --tests="$1" --run="$2"


### PR DESCRIPTION
- hack/dev: redirect server logs into a file instead of having them interleave with thehack script  shell output
   - I have shellcheck set to lint bash scripts so a bunch of the small updates are from that
- hack/it, hack/run: update shebang to work in nixos envs where /bin/bash is not available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved script portability by updating shebang lines to use the environment's Bash interpreter.
  - Enhanced script robustness by quoting variables and standardizing output redirection formatting.
  - Cleaned up minor formatting issues in command invocations.

- **Chores**
  - Redirected runtime logs to a file for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->