### PR TITLE
Fix activator to use configurable port instead of hard-coded 3000

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -154,6 +154,12 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 	sb.LogEntity = appMD.Name
 	sb.LogAttribute = types.LabelSet("stage", "app-run", "pool", pool, "service", service)
 
+	// Determine port from config or default to 3000
+	port := int64(3000)
+	if ver.Config.Port > 0 {
+		port = ver.Config.Port
+	}
+
 	appCont := compute_v1alpha.Container{
 		Name:  "app",
 		Image: ver.ImageUrl,
@@ -164,7 +170,7 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 		Directory: "/app",
 		Port: []compute_v1alpha.Port{
 			{
-				Port: 3000,
+				Port: port,
 				Name: "http",
 				Type: "http",
 			},
@@ -238,7 +244,7 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 		return nil, err
 	}
 
-	addr := "http://" + runningSB.Network[0].Address + ":3000"
+	addr := fmt.Sprintf("http://%s:%d", runningSB.Network[0].Address, port)
 
 	var leaseSlots int
 

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -242,7 +242,8 @@ func (s *ServiceController) initNFT(table string, nc *nftCommands) error {
 	maps := set.New[string]()
 
 	if slices.Contains(tables, table) {
-		cmd := exec.Command("nft", "-j", "list", "table", table)
+		// TODO: assuming inet family here; read from `list tables` output instead?
+		cmd := exec.Command("nft", "-j", "list", "table", "inet", table)
 
 		out, err := cmd.Output()
 		if err != nil {

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -218,16 +218,6 @@ func (m *Runtime) Test(
 func (m *Runtime) Dev(
 	ctx context.Context,
 	dir *dagger.Directory,
-	// +optional
-	shell bool,
-	// +optional
-	tests string,
-	// +optional
-	count int,
-	// +optional
-	verbose bool,
-	// +optional
-	run string,
 ) (string, error) {
 	w := m.WithServices(dir).
 		WithDirectory("/src", dir).

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -160,8 +160,9 @@ func (m *Runtime) Test(
 	tests string,
 	// +optional
 	count int,
+	// NOTE: This flag cannot be called "verbose" - see https://github.com/dagger/dagger/issues/10428
 	// +optional
-	verbose bool,
+	verboose bool,
 	// +optional
 	run string,
 	// +optional
@@ -198,7 +199,7 @@ func (m *Runtime) Test(
 			args = append(args, "-run", run)
 		}
 
-		if verbose {
+		if verboose {
 			w = w.WithEnvVariable("VERBOSE", "1")
 		}
 

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -179,9 +179,10 @@ func (m *Runtime) Test(
 	}
 
 	if shell {
+		w = w.WithEnvVariable("USESHELL", "1")
 		w = w.Terminal(dagger.ContainerTerminalOpts{
 			InsecureRootCapabilities: true,
-			Cmd:                      []string{"/bin/bash"},
+			Cmd:                      []string{"/bin/bash", "/src/hack/test.sh"},
 		})
 	} else {
 		args := []string{"sh", "/src/hack/test.sh"}

--- a/e2e/custom_port_test.go
+++ b/e2e/custom_port_test.go
@@ -1,0 +1,125 @@
+package e2e
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/cli"
+)
+
+func TestCustomPortEndToEnd(t *testing.T) {
+	r := require.New(t)
+
+	// Start dev server
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	t.Log("starting test")
+
+	exitCode := make(chan int, 1)
+	go func() {
+		t.Log("starting dev")
+		exitCode <- cli.Run([]string{"runtime", "dev"})
+	}()
+
+	// Give the dev server time to spin up
+	time.Sleep(5 * time.Second)
+
+	// Write a combo.yaml
+	filePath := writeTempContents(t, "combo.yaml", comboYaml)
+
+	// Spin up combo
+	putCode := cli.Run([]string{"runtime", "entity", "put", "-p", filePath})
+	r.Equal(0, putCode)
+
+	select {
+	case code := <-exitCode:
+		t.Logf("got code: %d", code)
+	case <-ctx.Done():
+		t.Logf("got done")
+	}
+
+	// Ensure we can route to nginx container
+	resp, err := http.Get("http://localhost:8989")
+	r.NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	r.NoError(err)
+
+	r.Equal(200, resp.StatusCode)
+	r.Contains(string(body), "Welcome to nginx!")
+}
+
+func writeTempContents(t *testing.T, filename, contents string) string {
+	r := require.New(t)
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, filename)
+	file, err := os.Create(filePath)
+	r.NoError(err)
+	_, err = file.Write([]byte(contents))
+	r.NoError(err)
+	defer file.Close()
+	return filePath
+}
+
+var comboYaml = `kind: dev.miren.core/project
+version: v1alpha
+metadata:
+  name: default
+spec:
+  owner: mbot@miren.dev
+---
+kind: dev.miren.core/app
+version: v1alpha
+metadata:
+  name: nginx
+spec:
+  project: project/default
+---
+kind: dev.miren.core/app_version
+version: v1alpha
+metadata:
+  name: abcdef
+spec:
+  app: app/nginx
+  version: abcdef
+  image_url: docker.io/library/nginx:latest
+  concurrency: 10
+  config:
+    port: 80
+---
+kind: dev.miren.ingress/http_route
+version: v1alpha
+metadata:
+  name: localhost
+spec:
+  host: localhost
+  app: app/nginx
+---
+kind: dev.miren.core/app
+version: v1alpha
+metadata:
+  name: nginx
+spec:
+  project: project/default
+  active_version: app_version/abcdef
+---
+kind: dev.miren.network/service
+version: v1alpha
+metadata:
+  name: nginx
+spec:
+  match:
+    - app=nginx
+  port:
+    - port: 80
+      target_port: 80
+      name: http
+      node_port: 8080
+`

--- a/e2e/custom_port_test.go
+++ b/e2e/custom_port_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/cli"
-	"miren.dev/runtime/pkg/testutils"
+	"miren.dev/runtime/pkg/testserver"
 )
 
 func TestCustomPortEndToEnd(t *testing.T) {
@@ -25,7 +25,7 @@ func TestCustomPortEndToEnd(t *testing.T) {
 	serverErr := make(chan error, 1)
 	go func() {
 		t.Log("starting dev")
-		serverErr <- testutils.TestServer(t)
+		serverErr <- testserver.TestServer(t)
 	}()
 
 	// Give the dev server time to spin up

--- a/hack/it
+++ b/hack/it
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-dagger call -q test --dir=. --tests="$@" --fast
+dagger call test --dir=. --tests="$@" --fast --verboose

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -5,17 +5,17 @@ set -e
 
 mkdir /sys/fs/cgroup/inner
 
-for pid in $(cat /sys/fs/cgroup/cgroup.procs); do
-  echo $pid > /sys/fs/cgroup/inner/cgroup.procs 2>/dev/null || true
+for pid in "$(cat /sys/fs/cgroup/cgroup.procs)"; do
+  echo "$pid" >/sys/fs/cgroup/inner/cgroup.procs 2>/dev/null || true
 done
 
-sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers > /sys/fs/cgroup/cgroup.subtree_control
+sed -e 's/ / +/g' -e 's/^/+/' </sys/fs/cgroup/cgroup.controllers >/sys/fs/cgroup/cgroup.subtree_control
 
 mkdir -p /data /run
 
 export OTEL_SDK_DISABLED=true
 
-cat <<EOF > /etc/containerd/config.toml
+cat <<EOF >/etc/containerd/config.toml
 version = 2
 [plugins."io.containerd.runtime.v1.linux"]
   shim_debug = true
@@ -27,7 +27,7 @@ version = 2
   runtime_type = "io.containerd.runsc.v1"
 EOF
 
-cat <<EOF > /etc/containerd/runsc.toml
+cat <<EOF >/etc/containerd/runsc.toml
 log_path = "/var/log/runsc/%ID%/shim.log"
 log_level = "debug"
 binary_name = "/src/hack/runsc-ignore"
@@ -37,8 +37,8 @@ binary_name = "/src/hack/runsc-ignore"
 EOF
 
 mkdir -p /run/containerd
-containerd --root /data --state /data/state --address /run/containerd/containerd.sock -l trace > /dev/null 2>&1 &
-buildkitd --root /data/buildkit > /dev/null 2>&1 &
+containerd --root /data --state /data/state --address /run/containerd/containerd.sock -l trace >/dev/null 2>&1 &
+buildkitd --root /data/buildkit >/dev/null 2>&1 &
 
 mount -t debugfs nodev /sys/kernel/debug
 mount -t tracefs nodev /sys/kernel/debug/tracing
@@ -49,11 +49,14 @@ sleep 1
 
 cd /src
 
+if test "$USESHELL" != ""; then
+  export HISTFILE=/data/.bash_history
+  export HISTIGNORE=exit
+  bash
 # Because all the tests use the same containerd, buildkit, and cgroups, we need to
 # make sure that they don't interfere with each other. For now, we do that by passing
 # -p 1, but in the future we should run each test in a separate namespace.
-
-if test -n "$VERBOSE"; then
+elif test "$VERBOSE" != ""; then
   go test -p 1 -v "$@"
 else
   gotestsum --format testname -- -p 1 "$@"

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -5,7 +5,7 @@ set -e
 
 mkdir /sys/fs/cgroup/inner
 
-for pid in "$(cat /sys/fs/cgroup/cgroup.procs)"; do
+cat /sys/fs/cgroup/cgroup.procs | while read -r pid; do
   echo "$pid" >/sys/fs/cgroup/inner/cgroup.procs 2>/dev/null || true
 done
 

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -1,4 +1,4 @@
-package testutils
+package testserver
 
 import (
 	"context"
@@ -26,6 +26,7 @@ import (
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/slogfmt"
+	"miren.dev/runtime/pkg/testutils"
 	"miren.dev/runtime/servers/httpingress"
 )
 
@@ -35,7 +36,7 @@ func TestServer(t *testing.T) error {
 	// Create a cancellable context
 	ctx, ctxCancel := context.WithCancel(ctx)
 	eg, sub := errgroup.WithContext(ctx)
-	reg, cleanup := Registry(observability.TestInject)
+	reg, cleanup := testutils.Registry(observability.TestInject)
 	t.Cleanup(cleanup)
 
 	// Mirroring defaults from cli/commands/dev.go

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -292,10 +292,10 @@ func TestServer(t *testing.T) error {
 		log.Info("Canceling context to stop all components")
 		ctxCancel()
 
-		// Log if errgroup has any errors when cleaned up
-		if err := eg.Wait(); err != nil {
-			log.Error("error waiting for components to stop", "error", err)
-		}
+		// TODO: eg.Wait still hangs, something's amiss in the context canecel handling. A problem for another day!
+		// if err := eg.Wait(); err != nil {
+		// 	log.Error("error waiting for components to stop", "error", err)
+		// }
 	})
 
 	// Wait in a separate goroutine for any errors from the errgroup

--- a/pkg/testutils/server.go
+++ b/pkg/testutils/server.go
@@ -1,0 +1,216 @@
+package testutils
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/components/coordinate"
+	"miren.dev/runtime/components/ipalloc"
+	"miren.dev/runtime/components/netresolve"
+	"miren.dev/runtime/components/ocireg"
+	"miren.dev/runtime/components/runner"
+	"miren.dev/runtime/components/scheduler"
+	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/observability"
+	"miren.dev/runtime/pkg/netdb"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/slogfmt"
+	"miren.dev/runtime/servers/httpingress"
+)
+
+// TestServer spins up an equivalent of the dev server for testing purposes.
+func TestServer(t *testing.T) error {
+	ctx := t.Context()
+	eg, sub := errgroup.WithContext(ctx)
+	reg, cleanup := Registry(observability.TestInject)
+	t.Cleanup(cleanup)
+
+	// Mirroring defaults from cli/commands/dev.go
+	optsAddress := "localhost:8443"
+	optsRunnerAddress := "localhost:8444"
+	optsEtcdEndpoints := []string{"http://etcd:2379"}
+	optsEtcdPrefix := "/miren"
+	optsRunnerId := "dev"
+
+	log := slog.New(slogfmt.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	res, hm := netresolve.NewLocalResolver()
+
+	var (
+		cpu metrics.CPUUsage
+		mem metrics.MemoryUsage
+	)
+
+	err := reg.Populate(&mem)
+	if err != nil {
+		log.Error("failed to populate memory usage", "error", err)
+		return err
+	}
+
+	err = reg.Populate(&cpu)
+	if err != nil {
+		log.Error("failed to populate CPU usage", "error", err)
+		return err
+	}
+
+	co := coordinate.NewCoordinator(log, coordinate.CoordinatorConfig{
+		Address:       optsAddress,
+		EtcdEndpoints: optsEtcdEndpoints,
+		Prefix:        optsEtcdPrefix,
+		Resolver:      res,
+		TempDir:       os.TempDir(),
+		Mem:           &mem,
+		Cpu:           &cpu,
+	})
+
+	t.Log("Starting coordinator")
+	err = co.Start(sub)
+	if err != nil {
+		log.Error("failed to start coordinator", "error", err)
+		return err
+	}
+
+	time.Sleep(time.Second)
+
+	reg.ProvideName("subnet", func(opts struct {
+		Dir    string       `asm:"data-path"`
+		Id     string       `asm:"server-id"`
+		Prefix netip.Prefix `asm:"ip4-routable"`
+	}) (*netdb.Subnet, error) {
+		os.MkdirAll(opts.Dir, 0755)
+		ndb, err := netdb.New(filepath.Join(opts.Dir, "net.db"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to open netdb: %w", err)
+		}
+
+		sub, err := ndb.Subnet(opts.Prefix.String())
+		if err != nil {
+			return nil, err
+		}
+
+		return sub, nil
+	})
+
+	reg.ProvideName("router-address", func(opts struct {
+		Sub *netdb.Subnet `asm:"subnet"`
+	}) (netip.Addr, error) {
+		return opts.Sub.Router().Addr(), nil
+	})
+
+	// Setup the core services on the coordinator address for dev
+
+	/*
+		{
+			serv := co.Server()
+
+			var builder build.RPCBuilder
+
+			err = reg.Populate(&builder)
+			if err != nil {
+				return fmt.Errorf("populating build: %w", err)
+			}
+
+			serv.ExposeValue("dev.miren.runtime/build", build.AdaptBuilder(&builder))
+		}
+	*/
+
+	// Run the runner!
+
+	// Create RPC client to interact with coordinator
+	rs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	if err != nil {
+		log.Error("failed to create RPC client", "error", err)
+		return err
+	}
+
+	client, err := rs.Connect(optsAddress, "entities")
+	if err != nil {
+		log.Error("failed to connect to RPC server", "error", err)
+		return err
+	}
+
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+	ec := entityserver.NewClient(log, eac)
+
+	reg.Register("hl-entity-client", ec)
+
+	var subnets []netip.Prefix
+	reg.Resolve(&subnets)
+
+	ipa := ipalloc.NewAllocator(log, subnets)
+	eg.Go(func() error {
+		return ipa.Watch(sub, eac)
+	})
+
+	aa := co.Activator()
+
+	hs := httpingress.NewServer(ctx, log, eac, aa)
+
+	reg.Register("app-activator", aa)
+	reg.Register("resolver", res)
+
+	r := runner.NewRunner(log, reg, runner.RunnerConfig{
+		Id:            optsRunnerId,
+		ServerAddress: optsAddress,
+		ListenAddress: optsRunnerAddress,
+		Workers:       runner.DefaulWorkers,
+	})
+
+	err = r.Start(sub)
+	if err != nil {
+		return err
+	}
+
+	sch, err := scheduler.NewScheduler(sub, log, eac)
+	if err != nil {
+		log.Error("failed to create scheduler", "error", err)
+		return err
+	}
+
+	eg.Go(func() error {
+		return sch.Watch(sub, eac)
+	})
+
+	go func() {
+		err := http.ListenAndServe(":8989", hs)
+		if err != nil {
+			log.Error("failed to start HTTP server", "error", err)
+		}
+	}()
+
+	var registry ocireg.Registry
+	err = reg.Populate(&registry)
+	if err != nil {
+		log.Error("failed to populate OCI registry", "error", err)
+		return err
+	}
+
+	registry.Start(ctx, ":5000")
+
+	var regAddr netip.Addr
+
+	err = reg.ResolveNamed(&regAddr, "router-address")
+	if err != nil {
+		log.Error("failed to resolve router address", "error", err)
+		return err
+	}
+
+	log.Info("OCI registry URL", "url", regAddr)
+
+	hm.SetHost("cluster.local", regAddr)
+
+	log.Info("Starting dev mode", "address", optsAddress, "etcd_endpoints", optsEtcdEndpoints, "etcd_prefix", optsEtcdPrefix, "runner_id", optsRunnerId)
+
+	return eg.Wait()
+}

--- a/servers/httpingress/testdata/combo.yaml
+++ b/servers/httpingress/testdata/combo.yaml
@@ -21,6 +21,8 @@ spec:
   version: abcdef
   image_url: docker.io/library/nginx:latest
   concurrency: 10
+  config:
+    port: 80
 ---
 kind: dev.miren.ingress/http_route
 version: v1alpha
@@ -28,7 +30,7 @@ metadata:
   name: localhost
 spec:
   host: localhost
-  app: app/hw-bun
+  app: app/nginx
 ---
 kind: dev.miren.core/app
 version: v1alpha

--- a/servers/httpingress/testdata/version.yaml
+++ b/servers/httpingress/testdata/version.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   app: app/nginx
   image_url: docker.io/library/nginx:latest
+  config:
+    port: 80


### PR DESCRIPTION
The activator was hard-coding port 3000 when creating containers, but some container images like nginx listen on different ports (80). This change makes use of the existing Config.Port field to properly configure the container port, falling back to 3000 only if no port is specified.

This fix allows the nginx app example to work properly, as it can now listen on port 80 as expected.

## Future work considerations

1. For now this changes combo.yml to use nginx instead of hw-bun for now. We might want to split out two different test files for nginx and hw-bun paths soon.
2. I wonder if the entity system should learn how to express attribute defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom application port configuration, allowing apps to specify ports other than the default.
  - Introduced a new end-to-end test to validate custom port scenarios and ensure correct routing and accessibility.
  - Added a utility for launching a comprehensive test server environment to facilitate development and testing.

- **Bug Fixes**
  - Updated activator logic to dynamically determine the container and sandbox ports, improving flexibility for different app configurations.

- **Chores**
  - Improved test and configuration files to align with new port settings and enhance test coverage.
  - Adjusted command-line scripts and parameter naming for clarity and consistency.
  - Enhanced temporary file management by isolating runtime data in dedicated temporary directories with proper cleanup.
  - Updated network service commands to explicitly specify protocol families for improved compatibility.
  - Refined test scripts to support interactive shell sessions and standardized output redirection.
  - Introduced explicit lifecycle management for the local registry server, enabling controlled startup and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->