### PR TITLE
Use tmux to run server in make dev

### DIFF
--- a/dagger/main.go
+++ b/dagger/main.go
@@ -112,7 +112,13 @@ func (m *Runtime) BuildEnv(dir *dagger.Directory) *dagger.Container {
 		WithExec([]string{"apt-get", "update"}).
 		WithExec([]string{"go", "install", "gotest.tools/gotestsum@latest"}).
 		WithExec([]string{"sh", "-c", "cd /usr/bin && curl https://clickhouse.com/ | sh"}, dagger.ContainerWithExecOpts{}).
-		WithExec([]string{"apt-get", "install", "-y", "iptables", "bash", "iproute2", "inetutils-ping"}).
+		WithExec([]string{"apt-get", "install", "-y",
+			"bash",
+			"inetutils-ping",
+			"iproute2",
+			"iptables",
+			"tmux",
+		}).
 		WithFile("/upstream/containerd.tar.gz", dag.HTTP(containerd)).
 		WithFile("/upstream/buildkit.tar.gz", dag.HTTP(buildkit)).
 		WithFile("/upstream/nerdctl.tar.gz", dag.HTTP(nerdctl)).

--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -78,6 +78,11 @@ export CONTAINERD_NAMESPACE=runtime
 # Make a tmux session for us to run multiple shells in
 tmux new-session -d -s dev
 
+# Set the prefix to one that is unlikely to overlap: ctrl-s
+tmux unbind-key C-b
+tmux set-option -g prefix C-s
+tmux bind-key C-s send-prefix
+
 # Start with two panes with the server running on top and a shell running on the bottom
 tmux split-window -v
 tmux send-keys -t dev:0.0 "./bin/runtime dev -vv" Enter

--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -71,10 +71,15 @@ EOF
 echo "Cleaning runtime namespace to begin..."
 r debug ctr nuke -n runtime
 
-./bin/runtime dev -vv >>/var/log/runtime.log 2>&1 &
-
 export HISTFILE=/data/.bash_history
 export HISTIGNORE=exit
 export CONTAINERD_NAMESPACE=runtime
 
-bash
+# Make a tmux session for us to run multiple shells in
+tmux new-session -d -s dev
+
+# Start with two panes with the server running on top and a shell running on the bottom
+tmux split-window -v
+tmux send-keys -t dev:0.0 "./bin/runtime dev -vv" Enter
+tmux select-pane -t dev:0.1
+tmux attach-session -t dev


### PR DESCRIPTION
Fixes the mixing of server logs with shell output and gives us a
platform to run multiple shells inside the dev container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tmux support to the development script, enabling simultaneous viewing of the runtime server output and an interactive shell in split panes.

- **Chores**
  - Updated the development environment to include tmux by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->