### PR TITLE
Fix flaky controller tests

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -171,7 +171,6 @@ func (c *ReconcileController) runWorker(ctx context.Context) {
 	id := idgen.Gen("worker")
 
 	c.Log.Info("Starting worker", "id", id)
-	defer c.Log.Info("Stopping worker", "id", id)
 
 	defer c.wg.Done()
 
@@ -180,9 +179,11 @@ func (c *ReconcileController) runWorker(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			c.Log.Info("Stopping worker", "id", id)
 			return
 		case event, ok := <-c.workQueue:
 			if !ok {
+				c.Log.Info("Stopping worker", "id", id)
 				return
 			}
 


### PR DESCRIPTION
The WorkerCount test wasn't providing much value, so I removed it and enhanced the Lifecycle test to ensure that work is making it through

Running the tests w/ -count 100 caught a panic in the Resync test where a late Log line was coming through after shutdown. Moving the "shutting down" logs out of defer seemed to help.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved concurrency safety and reliability in controller lifecycle tests by using atomic counters and test-specific log handlers.
  - Simplified test setup and context management for clearer and more robust testing.
  - Removed a test related to worker count tracking to streamline the test suite.

- **Style**
  - Updated logging in tests to use handlers that integrate with the testing framework for better output and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->