### PR TITLE
Add multi-platform build and release workflow of raw binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
     needs: package
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,69 @@ jobs:
         name: runtime-linux-${{ matrix.arch }}
         path: release-linux-${{ matrix.arch }}.tar.gz
         retention-days: 7
+
+  release:
+    needs: package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      
+      - name: Check if tip release exists
+        id: check_release
+        run: |
+          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/tip -q .id || echo "")
+          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
+          if [ -n "$RELEASE_ID" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Delete existing tip release if it exists
+        if: steps.check_release.outputs.exists == 'true'
+        run: gh api -X DELETE repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Create new tip release
+        id: create_release
+        run: |
+          RELEASE_ID=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            repos/${{ github.repository }}/releases \
+            -f tag_name='tip' \
+            -f name='Tip Build' \
+            -f body='Latest build from main branch' \
+            -f prerelease=true \
+            -q .id)
+          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Upload AMD64 build to release
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/octet-stream" \
+            "repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets?name=runtime-linux-amd64.tar.gz" \
+            --input artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Upload ARM64 build to release
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/octet-stream" \
+            "repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets?name=runtime-linux-arm64.tar.gz" \
+            --input artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Dagger
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build and package for ${{ matrix.arch }}
+      uses: dagger/dagger-for-github@v7
+      with:
+        verb: call
+        args: package --dir=. export --path=release-linux-${{ matrix.arch }}.tar.gz
+        cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: runtime-linux-${{ matrix.arch }}
+        path: release-linux-${{ matrix.arch }}.tar.gz
+        retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,59 +34,62 @@ jobs:
         with:
           path: artifacts
       
-      - name: Check if tip release exists
-        id: check_release
+      - name: Get or create tip release
+        id: get_or_create_release
         run: |
-          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/tip -q .id || echo "")
-          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
-          if [ -n "$RELEASE_ID" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
+          # Try to get existing release ID
+          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/tip -q .id 2>/dev/null || echo "")
+          
+          # If no release exists, create one
+          if [ -z "$RELEASE_ID" ]; then
+            echo "Creating new tip release..."
+            RELEASE_ID=$(gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              repos/${{ github.repository }}/releases \
+              -f tag_name='tip' \
+              -f name='Tip Build' \
+              -f body='Latest build from main branch' \
+              -f prerelease=true \
+              -q .id)
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Using existing tip release with ID: $RELEASE_ID"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Delete existing tip release if it exists
-        if: steps.check_release.outputs.exists == 'true'
-        run: gh api -X DELETE repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Create new tip release
-        id: create_release
-        run: |
-          RELEASE_ID=$(gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            repos/${{ github.repository }}/releases \
-            -f tag_name='tip' \
-            -f name='Tip Build' \
-            -f body='Latest build from main branch' \
-            -f prerelease=true \
-            -q .id)
+          
           echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Upload AMD64 build to release
+      - name: Upload release assets
         run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Content-Type: application/octet-stream" \
-            "repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets?name=runtime-linux-amd64.tar.gz" \
-            --input artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Upload ARM64 build to release
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Content-Type: application/octet-stream" \
-            "repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets?name=runtime-linux-arm64.tar.gz" \
-            --input artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz
+          function upload_asset() {
+            local arch=$1
+            local asset_name="runtime-linux-$arch.tar.gz"
+            local artifact_path="artifacts/runtime-linux-$arch/release-linux-$arch.tar.gz"
+            
+            echo "Processing $asset_name..."
+            
+            # Check if asset already exists
+            ASSET_ID=$(gh api repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets -q '.[] | select(.name=="'$asset_name'") | .id' 2>/dev/null || echo "")
+            
+            # If asset exists, delete it first
+            if [ -n "$ASSET_ID" ]; then
+              echo "Deleting existing asset $asset_name with ID: $ASSET_ID"
+              gh api -X DELETE repos/${{ github.repository }}/releases/assets/$ASSET_ID
+            fi
+            
+            # Upload the new asset
+            echo "Uploading $asset_name..."
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Content-Type: application/octet-stream" \
+              "repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets?name=$asset_name" \
+              --input "$artifact_path"
+          }
+          
+          # Upload both assets
+          upload_asset "amd64"
+          upload_asset "arm64"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         args: package --dir=. export --path=release-linux-${{ matrix.arch }}.tar.gz
         cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: runtime-linux-${{ matrix.arch }}
         path: release-linux-${{ matrix.arch }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,62 +34,42 @@ jobs:
         with:
           path: artifacts
       
-      - name: Get or create tip release
-        id: get_or_create_release
+      - name: Check if tip release exists
+        id: check_release
         run: |
-          # Try to get existing release ID
-          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/tip -q .id 2>/dev/null || echo "")
-          
-          # If no release exists, create one
-          if [ -z "$RELEASE_ID" ]; then
-            echo "Creating new tip release..."
-            RELEASE_ID=$(gh api \
-              --method POST \
-              -H "Accept: application/vnd.github+json" \
-              repos/${{ github.repository }}/releases \
-              -f tag_name='tip' \
-              -f name='Tip Build' \
-              -f body='Latest build from main branch' \
-              -f prerelease=true \
-              -q .id)
+          if gh release view tip &>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
           else
-            echo "Using existing tip release with ID: $RELEASE_ID"
+            echo "exists=false" >> $GITHUB_OUTPUT
           fi
-          
-          echo "RELEASE_ID=$RELEASE_ID" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Create tip release if it doesn't exist
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          gh release create tip \
+            --title "Tip Build" \
+            --notes "Latest build from main branch" \
+            --prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Delete existing assets if they exist
+        run: |
+          # Delete existing assets if they exist (ignoring errors if they don't)
+          gh release delete-asset tip runtime-linux-amd64.tar.gz --yes 2>/dev/null || true
+          gh release delete-asset tip runtime-linux-arm64.tar.gz --yes 2>/dev/null || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Upload release assets
         run: |
-          function upload_asset() {
-            local arch=$1
-            local asset_name="runtime-linux-$arch.tar.gz"
-            local artifact_path="artifacts/runtime-linux-$arch/release-linux-$arch.tar.gz"
-            
-            echo "Processing $asset_name..."
-            
-            # Check if asset already exists
-            ASSET_ID=$(gh api repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets -q '.[] | select(.name=="'$asset_name'") | .id' 2>/dev/null || echo "")
-            
-            # If asset exists, delete it first
-            if [ -n "$ASSET_ID" ]; then
-              echo "Deleting existing asset $asset_name with ID: $ASSET_ID"
-              gh api -X DELETE repos/${{ github.repository }}/releases/assets/$ASSET_ID
-            fi
-            
-            # Upload the new asset
-            echo "Uploading $asset_name..."
-            gh api \
-              --method POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Content-Type: application/octet-stream" \
-              "repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets?name=$asset_name" \
-              --input "$artifact_path"
-          }
+          # Rename the artifacts to the expected names
+          cp artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz runtime-linux-amd64.tar.gz
+          cp artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz runtime-linux-arm64.tar.gz
           
-          # Upload both assets
-          upload_asset "amd64"
-          upload_asset "arm64"
+          # Upload both assets to the release
+          gh release upload tip runtime-linux-amd64.tar.gz runtime-linux-arm64.tar.gz --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ "main", "evan/mir-146" ]
 
+# Set permissions for the entire workflow
+permissions:
+  contents: write    # Required for creating releases and uploading assets
+
 jobs:
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Dagger
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "evan/mir-146" ]
 
 jobs:
   package:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ image:
 	docker import tmp/latest.tar miren:latest
 	rm tmp/latest.tar
 
+release-data:
+	dagger call package --dir=. export --path=release.tar.gz
+
+.PHONY: release-data
+
 clean:
 	rm bin/runtime
 


### PR DESCRIPTION
## Summary
- Adds GitHub workflow to build and package runtime for linux/amd64 and linux/arm64
- Implements artifact upload to make builds downloadable from workflow UI
- Adds Makefile target and Dagger implementation for packaging

## Test plan
- Merge to main branch to trigger workflow
- Verify artifacts are built for both architectures and available for download

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automated packaging and release workflow supporting multiple CPU architectures.
  - Added a new Makefile command to easily generate release tarballs.
- **Chores**
  - Implemented a new release process to streamline artifact creation and distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->