### PR TITLE
Makefile: fix make dev flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test-shell:
 	dagger call -q test --dir=. --shell
 
 dev:
-	dagger call -q dev --dir=. --shell
+	dagger call -q dev --dir=.
 
 image:
 	dagger call -q container --dir=. export --path=tmp/latest.tar


### PR DESCRIPTION
The `--shell` flag was removed in the dagger layer in https://github.com/mirendev/runtime/pull/48, but I neglected to catch the Makefile usage of the flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development command in the Makefile to simplify how it runs the development environment. No impact on application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->