### PR TITLE
Get things building on Darwin with lots of noop impls

### DIFF
--- a/cli/commands/coordinator_darwin.go
+++ b/cli/commands/coordinator_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package commands
+
+func CoordinatorRun(ctx *Context, opts struct {
+}) error {
+	return nil
+}

--- a/cli/commands/dev_darwin.go
+++ b/cli/commands/dev_darwin.go
@@ -1,0 +1,7 @@
+//go:build darwin
+
+package commands
+
+func Dev(ctx *Context, opts struct{}) error {
+	return nil
+}

--- a/controllers/sandbox/firewall.go
+++ b/controllers/sandbox/firewall.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package sandbox
 
 import (

--- a/controllers/sandbox/firewall_darwin.go
+++ b/controllers/sandbox/firewall_darwin.go
@@ -1,0 +1,12 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/network"
+)
+
+func (c *SandboxController) configureFirewall(sb *compute.Sandbox, ep *network.EndpointConfig) error {
+	return nil
+}

--- a/controllers/sandbox/metrics.go
+++ b/controllers/sandbox/metrics.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package sandbox
 
 import (

--- a/controllers/sandbox/metrics_darwin.go
+++ b/controllers/sandbox/metrics_darwin.go
@@ -1,0 +1,48 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"miren.dev/runtime/api/metric/metric_v1alpha"
+	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/pkg/asm/autoreg"
+)
+
+type Cgroups struct {
+}
+
+type Metrics struct {
+	Log      *slog.Logger
+	CPUUsage *metrics.CPUUsage
+	MemUsage *metrics.MemoryUsage
+
+	mu           sync.Mutex
+	namedEntries map[string]*Cgroups
+}
+
+var _ = autoreg.Register[Metrics]()
+
+func (m *Metrics) Add(name string, pathes map[string]string, attributes map[string]string) error {
+	return nil
+}
+
+func (m *Metrics) Remove(name string) error {
+	return nil
+}
+
+func (m *Metrics) Gather(name string) ([]*metric_v1alpha.ContainerSnapshot, error) {
+	return nil, nil
+}
+
+var _ metric_v1alpha.SandboxMetrics = (*Metrics)(nil)
+
+func (m *Metrics) Snapshot(ctx context.Context, req *metric_v1alpha.SandboxMetricsSnapshot) error {
+	return nil
+}
+
+func (m *Metrics) Monitor(ctx context.Context) {
+}

--- a/disk/run.go
+++ b/disk/run.go
@@ -192,7 +192,7 @@ func (r *Runner) Start(ctx context.Context, name, fsPath, bindAddr string) error
 
 	log.Info("ext4 filesystem ready", "size", fsSize, "mount-point", fsPath)
 
-	err = unix.Mount(devPath, fsPath, "ext4", 0, "")
+	err = mountDisk(devPath, fsPath)
 	if err != nil {
 		spew.Dump(err)
 		log.Info("error mounting", "error", err, "dev", devPath, "fs", fsPath)
@@ -409,7 +409,7 @@ func (r *Runner) Run(ctx context.Context, name, fsPath, bindAddr string) error {
 
 	log.Info("ext4 filesystem ready", "size", fsSize)
 
-	err = unix.Mount(devPath, fsPath, "ext4", 0, "")
+	err = mountDisk(devPath, fsPath)
 	if err != nil {
 		spew.Dump(err)
 		log.Info("error mounting", "error", err, "dev", devPath, "fs", fsPath)

--- a/disk/run_darwin.go
+++ b/disk/run_darwin.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package disk
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// NOTE: This is very unlikely to work whatsoever... possibly should just noop
+// instead, but there's a unix.Mount impl so I figured why not at least attempt
+// to wire it!
+func mountDisk(devPath string, fsPath string) error {
+	// Create a C string of the device path
+	cDevPath, err := syscall.BytePtrFromString(devPath)
+	if err != nil {
+		return err
+	}
+
+	return unix.Mount("ext4", fsPath, 0, unsafe.Pointer(cDevPath))
+}

--- a/disk/run_linux.go
+++ b/disk/run_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package disk
+
+import "golang.org/x/sys/unix"
+
+func mountDisk(devPath string, fsPath string) error {
+	return unix.Mount(devPath, fsPath, "ext4", 0, "")
+}

--- a/lsvd/pkg/nbdnl/nbdnl.go
+++ b/lsvd/pkg/nbdnl/nbdnl.go
@@ -25,7 +25,7 @@
 //
 // This package provides the low-level netlink protocol, which in particular
 // requires connections to be in the transmission phase (i.e. having done the
-// NBD handshake phase or knowning the necessary information by other means).
+// NBD handshake phase or knowing the necessary information by other means).
 // Most users will probably want to use the nbd package, which is more
 // convenientand also implements handshaking.
 package nbdnl
@@ -81,7 +81,7 @@ var conn struct {
 	family uint16
 }
 
-// dial initalizes conn, if needed.
+// dial initializes conn, if needed.
 func dial() error {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()

--- a/lsvd/pkg/nbdnl/noop_darwin.go
+++ b/lsvd/pkg/nbdnl/noop_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+// Meet the package interface so Darwin can at least build
+package nbdnl
+
+import (
+	"context"
+	"net"
+)
+
+func Loopback(ctx context.Context, size uint64) (uint32, net.Conn, func() error, error) {
+	return 0, nil, nil, nil
+}
+
+func Disconnect(idx uint32) error {
+	return nil
+}

--- a/pkg/containerdx/opts.go
+++ b/pkg/containerdx/opts.go
@@ -9,14 +9,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 // WithAdditionalGIDs adds any additional groups listed for a particular user in the
@@ -463,18 +461,6 @@ func cgroupv2HasHugetlb() (bool, error) {
 		_cgroupv2HasHugetlb = strings.Contains(string(controllers), "hugetlb")
 	})
 	return _cgroupv2HasHugetlb, _cgroupv2HasHugetlbErr
-}
-
-// IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
-func IsCgroup2UnifiedMode() bool {
-	isUnifiedOnce.Do(func() {
-		var st syscall.Statfs_t
-		if err := syscall.Statfs("/sys/fs/cgroup", &st); err != nil {
-			panic("cannot statfs cgroup root")
-		}
-		isUnified = st.Type == unix.CGROUP2_SUPER_MAGIC
-	})
-	return isUnified
 }
 
 // WithOOMScoreAdj sets the oom score

--- a/pkg/containerdx/opts_darwin.go
+++ b/pkg/containerdx/opts_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package containerdx
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
+func IsCgroup2UnifiedMode() bool {
+	return false
+}

--- a/pkg/containerdx/opts_linux.go
+++ b/pkg/containerdx/opts_linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package containerdx
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
+func IsCgroup2UnifiedMode() bool {
+	isUnifiedOnce.Do(func() {
+		var st syscall.Statfs_t
+		if err := syscall.Statfs("/sys/fs/cgroup", &st); err != nil {
+			panic("cannot statfs cgroup root")
+		}
+		isUnified = st.Type == unix.CGROUP2_SUPER_MAGIC
+	})
+	return isUnified
+}


### PR DESCRIPTION
Expect a bunch of things to break, naturally, but at least build
completes and isolated Go tests can run!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Darwin (macOS) systems, including stub implementations for coordinator, development, disk mounting, sandbox firewall, and metrics functionalities.
  - Introduced platform-specific handling for cgroup v2 unified mode detection on both Linux and Darwin systems.
- **Bug Fixes**
  - Corrected typographical errors in documentation comments.
- **Refactor**
  - Improved platform separation for disk mounting and sandbox management by introducing OS-specific implementations.
- **Documentation**
  - Updated comments for clarity and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->