### PR TITLE
Solve runtime shutdown hang issue

### DIFF
--- a/cli/commands/dev.go
+++ b/cli/commands/dev.go
@@ -102,7 +102,7 @@ func Dev(ctx *Context, opts struct {
 		return err
 	}
 
-	err = gn.Start(sub)
+	err = gn.Start(sub, eg)
 	if err != nil {
 		ctx.Log.Error("failed to start grunge network", "error", err)
 		return err

--- a/pkg/cond/errors.go
+++ b/pkg/cond/errors.go
@@ -231,6 +231,10 @@ func (e ErrClosed) Is(target error) bool {
 	return false
 }
 
+func Closed(message string) error {
+	return ErrClosed{Message: message}
+}
+
 func Wrap(err error) error {
 	if err == nil {
 		return nil

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -242,7 +242,6 @@ func (s *EtcdStore) CreateEntity(
 	}
 
 	if !txnResp.Succeeded {
-
 		if len(txnResp.Responses) == 1 {
 			// If the current value of the entity has the same attributes as
 			// we were going to store, then we're all done!

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -244,7 +244,7 @@ func (s *EtcdStore) CreateEntity(
 	if !txnResp.Succeeded {
 
 		if len(txnResp.Responses) == 1 {
-			// If the curent value of the entity has the same atttributes as
+			// If the current value of the entity has the same attributes as
 			// we were going to store, then we're all done!
 			rng := txnResp.Responses[0].GetResponseRange()
 


### PR DESCRIPTION
## Summary
- Track grunge network operations in the errgroup for proper resource cleanup
- Improve RPC client to stop waiting immediately when context closes
- Fix entity storage to handle idempotent operations for identical entities
- Add error helpers for condition checking

## Test plan
- Manually tested all changes in the development environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated error for closed operations, providing clearer error messages.

- **Bug Fixes**
  - Improved entity creation to avoid conflict errors when an identical entity already exists.
  - Enhanced RPC client behavior to promptly handle cancellation and provide more informative errors.

- **Refactor**
  - Updated network startup to use improved error handling and synchronization for background processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->