### PR TITLE
Add embedded etcd component for development mode

### DIFF
--- a/cli/commands/auth_generate.go
+++ b/cli/commands/auth_generate.go
@@ -7,7 +7,7 @@ import (
 func AuthGenerate(ctx *Context, opts struct {
 	DataPath   string `short:"d" long:"data-path" description:"Data path" default:"/var/lib/miren"`
 	ConfigPath string `short:"c" long:"config-path" description:"Path to the config file" default:"clientconfig.yaml"`
-	Name       string `short:"n" long:"name" description:"Name of the client certificate" require:"true"`
+	Name       string `short:"n" long:"name" description:"Name of the client certificate" default:"runtime-user"`
 }) error {
 	co := coordinate.NewCoordinator(ctx.Log, coordinate.CoordinatorConfig{
 		DataPath: opts.DataPath,

--- a/cli/commands/dev.go
+++ b/cli/commands/dev.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -111,9 +112,7 @@ func Dev(ctx *Context, opts struct {
 		ctx.Log.Info("using embedded etcd", "endpoint", etcdComponent.ClientEndpoint())
 
 		// Ensure cleanup on exit
-		defer func() {
-			etcdComponent.Stop(ctx.Context)
-		}()
+		defer etcdComponent.Stop(context.Background())
 	}
 
 	co := coordinate.NewCoordinator(ctx.Log, coordinate.CoordinatorConfig{

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -1,0 +1,332 @@
+// Package etcd provides a component for managing an etcd server using containerd.
+// The component uses host networking with non-default ports (12379 for client,
+// 12380 for peer) to avoid conflicts with existing etcd installations.
+package etcd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/containerd/containerd/namespaces"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	etcdImage         = "gcr.io/etcd-development/etcd:v3.5.15"
+	etcdContainerName = "runtime-etcd"
+	etcdDataDir       = "/etcd-data"
+	defaultEtcdPort   = 12379 // Non-default port to avoid conflicts
+	defaultPeerPort   = 12380 // Non-default port to avoid conflicts
+)
+
+type EtcdConfig struct {
+	Name         string
+	DataDir      string
+	ClientPort   int
+	PeerPort     int
+	InitialToken string
+	ClusterState string
+}
+
+type EtcdComponent struct {
+	Log *slog.Logger
+	CC  *containerd.Client
+
+	Namespace string
+	DataPath  string
+
+	mu         sync.Mutex
+	container  containerd.Container
+	running    bool
+	clientPort int
+	peerPort   int
+}
+
+func NewEtcdComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *EtcdComponent {
+	return &EtcdComponent{
+		Log:       log,
+		CC:        cc,
+		Namespace: namespace,
+		DataPath:  dataPath,
+	}
+}
+
+func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.running {
+		return fmt.Errorf("etcd component already running")
+	}
+
+	ctx = namespaces.WithNamespace(ctx, e.Namespace)
+
+	// Pull etcd image
+	e.Log.Info("pulling etcd image", "image", etcdImage)
+	image, err := e.CC.Pull(ctx, etcdImage, containerd.WithPullUnpack)
+	if err != nil {
+		return fmt.Errorf("failed to pull etcd image: %w", err)
+	}
+
+	dataPath := filepath.Join(e.DataPath, "etcd")
+	os.MkdirAll(dataPath, 0755)
+
+	// Check if container already exists
+	existingContainer, err := e.CC.LoadContainer(ctx, etcdContainerName)
+	if err == nil {
+		e.Log.Info("found existing etcd container, restarting it", "container_id", existingContainer.ID())
+		return e.restartExistingContainer(ctx, existingContainer, config)
+	}
+
+	// Set defaults
+	if config.Name == "" {
+		config.Name = "etcd1"
+	}
+	if config.DataDir == "" {
+		config.DataDir = etcdDataDir
+	}
+	if config.ClientPort == 0 {
+		config.ClientPort = defaultEtcdPort
+	}
+	if config.PeerPort == 0 {
+		config.PeerPort = defaultPeerPort
+	}
+	if config.InitialToken == "" {
+		config.InitialToken = "etcd-cluster-1"
+	}
+	if config.ClusterState == "" {
+		config.ClusterState = "new"
+	}
+
+	// Store ports for later use
+	e.clientPort = config.ClientPort
+	e.peerPort = config.PeerPort
+
+	e.Log.Info("starting etcd with host networking", "client_port", config.ClientPort, "peer_port", config.PeerPort)
+
+	// Create container
+	container, err := e.createContainer(ctx, image, config)
+	if err != nil {
+		return fmt.Errorf("failed to create etcd container: %w", err)
+	}
+
+	e.container = container
+
+	// Start container
+	task, err := container.NewTask(ctx, cio.NewCreator(cio.WithStdio))
+	if err != nil {
+		container.Delete(ctx, containerd.WithSnapshotCleanup)
+		return fmt.Errorf("failed to create etcd task: %w", err)
+	}
+
+	err = task.Start(ctx)
+	if err != nil {
+		task.Delete(ctx)
+		container.Delete(ctx, containerd.WithSnapshotCleanup)
+		return fmt.Errorf("failed to start etcd task: %w", err)
+	}
+
+	e.running = true
+	e.Log.Info("etcd server started", "container_id", container.ID(), "client_port", config.ClientPort)
+
+	// Wait for etcd to be ready
+	go e.waitForReady(ctx, "localhost", config.ClientPort)
+
+	return nil
+}
+
+func (e *EtcdComponent) Stop(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if !e.running {
+		return nil
+	}
+
+	ctx = namespaces.WithNamespace(ctx, e.Namespace)
+
+	if e.container != nil {
+		// Stop and delete the task
+		task, err := e.container.Task(ctx, nil)
+		if err == nil {
+			task.Kill(ctx, unix.SIGTERM)
+			task.Wait(ctx)
+			task.Delete(ctx)
+		}
+
+		// Delete the container
+		err = e.container.Delete(ctx, containerd.WithSnapshotCleanup)
+		if err != nil {
+			e.Log.Error("failed to delete etcd container", "error", err)
+		}
+
+		e.container = nil
+	}
+
+	e.running = false
+	e.Log.Info("etcd server stopped")
+
+	return nil
+}
+
+func (e *EtcdComponent) ClientEndpoint() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.running {
+		return ""
+	}
+	return fmt.Sprintf("http://localhost:%d", e.clientPort)
+}
+
+func (e *EtcdComponent) PeerEndpoint() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.running {
+		return ""
+	}
+	return fmt.Sprintf("http://localhost:%d", e.peerPort)
+}
+
+func (e *EtcdComponent) IsRunning() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.running
+}
+
+func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container containerd.Container, config EtcdConfig) error {
+	e.container = container
+
+	// Store ports for later use
+	e.clientPort = config.ClientPort
+	e.peerPort = config.PeerPort
+
+	// Check if there's already a running task
+	task, err := container.Task(ctx, nil)
+	if err == nil {
+		// Task exists, check its status
+		status, err := task.Status(ctx)
+		if err != nil {
+			e.Log.Warn("failed to get task status", "error", err)
+		} else if status.Status == containerd.Running {
+			e.Log.Info("etcd container is already running")
+			e.running = true
+			go e.waitForReady(ctx, "localhost", config.ClientPort)
+			return nil
+		}
+
+		// Task exists but not running, try to start it
+		e.Log.Info("starting existing etcd task")
+		err = task.Start(ctx)
+		if err == nil {
+			e.running = true
+			e.Log.Info("etcd server restarted", "container_id", container.ID(), "client_port", config.ClientPort)
+			go e.waitForReady(ctx, "localhost", config.ClientPort)
+			return nil
+		}
+
+		// Failed to start existing task, delete it and create new one
+		e.Log.Warn("failed to start existing task, deleting it", "error", err)
+		task.Delete(ctx)
+	}
+
+	// Create and start new task
+	e.Log.Info("creating new task for existing container")
+	task, err = container.NewTask(ctx, cio.NewCreator(cio.WithStdio))
+	if err != nil {
+		return fmt.Errorf("failed to create new task for existing container: %w", err)
+	}
+
+	err = task.Start(ctx)
+	if err != nil {
+		task.Delete(ctx)
+		return fmt.Errorf("failed to start new task for existing container: %w", err)
+	}
+
+	e.running = true
+	e.Log.Info("etcd server restarted with new task", "container_id", container.ID(), "client_port", config.ClientPort)
+
+	// Wait for etcd to be ready
+	go e.waitForReady(ctx, "localhost", config.ClientPort)
+
+	return nil
+}
+
+func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Image, config EtcdConfig) (containerd.Container, error) {
+	dataPath := filepath.Join(e.DataPath, "etcd")
+
+	// Create container spec with etcd configuration using host networking
+	opts := []oci.SpecOpts{
+		oci.WithImageConfig(image),
+		oci.WithHostNamespace(specs.NetworkNamespace), // Use host network namespace
+		oci.WithProcessArgs(
+			"/usr/local/bin/etcd",
+			"--name", config.Name,
+			"--data-dir", config.DataDir,
+			"--listen-client-urls", fmt.Sprintf("http://0.0.0.0:%d", config.ClientPort),
+			"--advertise-client-urls", fmt.Sprintf("http://localhost:%d", config.ClientPort),
+			"--listen-peer-urls", fmt.Sprintf("http://0.0.0.0:%d", config.PeerPort),
+			"--initial-advertise-peer-urls", fmt.Sprintf("http://localhost:%d", config.PeerPort),
+			"--initial-cluster", fmt.Sprintf("%s=http://localhost:%d", config.Name, config.PeerPort),
+			"--initial-cluster-token", config.InitialToken,
+			"--initial-cluster-state", config.ClusterState,
+		),
+		oci.WithEnv([]string{
+			"ETCD_AUTO_COMPACTION_MODE=periodic",
+			"ETCD_AUTO_COMPACTION_RETENTION=1h",
+		}),
+		oci.WithMounts([]specs.Mount{
+			{
+				Destination: config.DataDir,
+				Type:        "bind",
+				Source:      dataPath,
+				Options:     []string{"rbind", "rw"},
+			},
+		}),
+	}
+
+	// Create container
+	container, err := e.CC.NewContainer(
+		ctx,
+		etcdContainerName,
+		containerd.WithImage(image),
+		containerd.WithNewSnapshot(etcdContainerName+"-snapshot", image),
+		containerd.WithNewSpec(opts...),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return container, nil
+}
+
+func (e *EtcdComponent) waitForReady(ctx context.Context, host string, port int) {
+	endpoint := fmt.Sprintf("%s:%d", host, port)
+
+	for i := 0; i < 30; i++ {
+		conn, err := net.DialTimeout("tcp", endpoint, 1*time.Second)
+		if err == nil {
+			conn.Close()
+			e.Log.Info("etcd server is ready", "endpoint", endpoint)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(1 * time.Second):
+			continue
+		}
+	}
+
+	e.Log.Warn("etcd server readiness check timed out", "endpoint", endpoint)
+}

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd/namespaces"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"

--- a/components/etcd/integration_test.go
+++ b/components/etcd/integration_test.go
@@ -1,0 +1,243 @@
+package etcd_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"golang.org/x/sys/unix"
+	"miren.dev/runtime/components/etcd"
+)
+
+const testNamespace = "runtime-etcd-test"
+
+func TestEtcdComponentIntegration(t *testing.T) {
+	ctx := t.Context()
+
+	// Skip if containerd is not available
+	cc, err := containerd.New("/run/containerd/containerd.sock")
+	if err != nil {
+		t.Skipf("containerd not available: %v", err)
+	}
+	defer cc.Close()
+
+	// Create temporary directory for test data
+	tmpDir, err := os.MkdirTemp("", "etcd-test")
+	require.NoError(t, err, "failed to create temp dir")
+	defer os.RemoveAll(tmpDir)
+
+	// Create logger
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Create etcd component
+	component := etcd.NewEtcdComponent(log, cc, testNamespace, tmpDir)
+
+	// Use test-specific ports to avoid conflicts
+	clientPort := 23790
+	peerPort := 23791
+
+	config := etcd.EtcdConfig{
+		Name:         "test-etcd",
+		ClientPort:   clientPort,
+		PeerPort:     peerPort,
+		InitialToken: "test-cluster",
+		ClusterState: "new",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// Ensure cleanup
+	defer func() {
+		if component.IsRunning() {
+			err := component.Stop(ctx)
+			if err != nil {
+				t.Logf("failed to stop component: %v", err)
+			}
+		}
+
+		// Clean up any remaining containers
+		cleanupContainer(t, cc, testNamespace)
+	}()
+
+	// Start the etcd component
+	t.Log("Starting etcd component...")
+	err = component.Start(ctx, config)
+	if err != nil {
+		if strings.Contains(err.Error(), "permission denied") {
+			t.Skip("permission denied error, skipping test")
+		}
+		require.NoError(t, err, "failed to start etcd component")
+	}
+
+	// Verify component reports as running
+	assert.True(t, component.IsRunning(), "component should report as running")
+
+	// Get client endpoint
+	endpoint := component.ClientEndpoint()
+	assert.NotEmpty(t, endpoint, "client endpoint should not be empty")
+
+	expectedEndpoint := fmt.Sprintf("http://localhost:%d", clientPort)
+	assert.Equal(t, expectedEndpoint, endpoint, "client endpoint should match expected")
+
+	// Wait for etcd to be fully ready
+	t.Log("Waiting for etcd to be ready...")
+	time.Sleep(10 * time.Second)
+
+	// Test etcd functionality using etcd Go SDK
+	t.Log("Testing etcd functionality...")
+	etcdClient, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{endpoint},
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err, "failed to create etcd client")
+	defer etcdClient.Close()
+
+	// Test cluster health
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+
+	_, err = etcdClient.Get(ctx2, "health-check")
+	require.NoError(t, err, "failed to check etcd health")
+
+	// Test basic key-value operations
+	testKey := "test-key"
+	testValue := "test-value"
+
+	// Put operation
+	t.Log("Testing Put operation...")
+	ctx3, cancel3 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel3()
+
+	_, err = etcdClient.Put(ctx3, testKey, testValue)
+	require.NoError(t, err, "failed to put key-value")
+
+	// Get operation
+	t.Log("Testing Get operation...")
+	ctx4, cancel4 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel4()
+
+	resp, err := etcdClient.Get(ctx4, testKey)
+	require.NoError(t, err, "failed to get key")
+	require.Len(t, resp.Kvs, 1, "expected 1 key-value pair")
+	assert.Equal(t, testValue, string(resp.Kvs[0].Value), "value should match")
+
+	// Delete operation
+	t.Log("Testing Delete operation...")
+	ctx5, cancel5 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel5()
+
+	_, err = etcdClient.Delete(ctx5, testKey)
+	require.NoError(t, err, "failed to delete key")
+
+	// Verify deletion
+	ctx6, cancel6 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel6()
+
+	resp, err = etcdClient.Get(ctx6, testKey)
+	require.NoError(t, err, "failed to get key after deletion")
+	assert.Len(t, resp.Kvs, 0, "expected 0 key-value pairs after deletion")
+
+	// Test watch functionality
+	t.Log("Testing Watch operation...")
+	watchKey := "watch-test"
+	watchValue := "watch-value"
+
+	ctx7, cancel7 := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel7()
+
+	watchCh := etcdClient.Watch(ctx7, watchKey)
+
+	// Put a value in a goroutine to trigger the watch
+	go func() {
+		time.Sleep(1 * time.Second)
+		ctx8, cancel8 := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel8()
+		etcdClient.Put(ctx8, watchKey, watchValue)
+	}()
+
+	// Wait for watch event
+	select {
+	case watchResp := <-watchCh:
+		require.NoError(t, watchResp.Err(), "watch should not error")
+		require.Len(t, watchResp.Events, 1, "expected 1 watch event")
+		assert.Equal(t, watchValue, string(watchResp.Events[0].Kv.Value), "watch value should match")
+	case <-ctx7.Done():
+		t.Fatal("watch operation timed out")
+	}
+
+	t.Log("All etcd operations completed successfully!")
+
+	// Test restart functionality
+	t.Log("Testing restart functionality...")
+	err = component.Stop(ctx)
+	require.NoError(t, err, "failed to stop component")
+
+	assert.False(t, component.IsRunning(), "component should not report as running after stop")
+
+	// Start again - this should use the restart logic
+	err = component.Start(ctx, config)
+	require.NoError(t, err, "failed to restart etcd component")
+
+	assert.True(t, component.IsRunning(), "component should report as running after restart")
+
+	// Wait for restart to complete
+	time.Sleep(5 * time.Second)
+
+	// Test that data persisted (though we cleaned it, just test connectivity)
+	etcdClient2, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{component.ClientEndpoint()},
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err, "failed to create etcd client after restart")
+	defer etcdClient2.Close()
+
+	ctx9, cancel9 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel9()
+
+	_, err = etcdClient2.Get(ctx9, "restart-test")
+	require.NoError(t, err, "failed to connect to etcd after restart")
+
+	t.Log("Restart test completed successfully!")
+}
+
+func cleanupContainer(t *testing.T, cc *containerd.Client, namespace string) {
+	ctx := context.Background()
+	ctx = namespaces.WithNamespace(ctx, namespace)
+
+	// Try to find and delete any test containers
+	containers, err := cc.Containers(ctx)
+	if err != nil {
+		t.Logf("failed to list containers for cleanup: %v", err)
+		return
+	}
+
+	for _, container := range containers {
+		// Stop and delete task if it exists
+		task, err := container.Task(ctx, nil)
+		if err == nil {
+			task.Kill(ctx, unix.SIGTERM)
+			task.Wait(ctx)
+			task.Delete(ctx)
+		}
+
+		// Delete container
+		err = container.Delete(ctx, containerd.WithSnapshotCleanup)
+		if err != nil {
+			t.Logf("failed to delete container %s: %v", container.ID(), err)
+		} else {
+			t.Logf("cleaned up container %s", container.ID())
+		}
+	}
+}


### PR DESCRIPTION
## Summary
• Add self-contained EtcdComponent with containerd integration for development mode
• Enable embedded etcd server with `--start-etcd` flag to eliminate external dependencies
• Implement host networking with non-default ports (12379/12380) to avoid conflicts

## Key Features
• **Full lifecycle management**: Start, stop, and restart functionality with proper cleanup
• **Container restart handling**: Automatically detects and restarts existing etcd containers
• **Host networking**: Uses non-default ports to avoid conflicts with system etcd
• **Development integration**: CLI flags for easy embedded etcd startup in dev mode
• **Comprehensive testing**: Integration tests using etcd Go SDK with testify assertions

## Test plan
- [x] Unit tests for EtcdComponent API
- [x] Integration tests with actual etcd operations (put/get/delete/watch)
- [x] Container restart scenario testing
- [x] CLI integration with dev command
- [x] Proper cleanup and resource management

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running an embedded etcd server with configurable client and peer ports via new command-line options.
  - Made the client certificate name optional with a default value for easier authentication setup.
- **Tests**
  - Introduced integration tests to verify the lifecycle and functionality of the embedded etcd server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->