### PR TITLE
Fix runtime apps command

### DIFF
--- a/cli/commands/apps.go
+++ b/cli/commands/apps.go
@@ -1,16 +1,16 @@
 package commands
 
-import "miren.dev/runtime/app"
+import "miren.dev/runtime/api/app/app_v1alpha"
 
 func Apps(ctx *Context, opts struct {
 	ConfigCentric
 }) error {
-	crudcl, err := ctx.RPCClient("app")
+	crudcl, err := ctx.RPCClient("dev.miren.runtime/app")
 	if err != nil {
 		return err
 	}
 
-	crud := app.CrudClient{Client: crudcl}
+	crud := app_v1alpha.NewCrudClient(crudcl)
 
 	apps, err := crud.List(ctx)
 	if err != nil {

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -42,10 +42,9 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("app", "Get information about an application", App), nil
 		},
 
-		// TODO: Errors with "unknown object: app"
-		// "apps": func() (cli.Command, error) {
-		// 	return Infer("apps", "List all applications", Apps), nil
-		// },
+		"apps": func() (cli.Command, error) {
+			return Infer("apps", "List all applications", Apps), nil
+		},
 
 		// TODO: Errors with "unknown object: app"
 		// "set": func() (cli.Command, error) {


### PR DESCRIPTION
It just needed a smidge of new wiring to the new place for the RPC client

Test Plan:
 - Run: `r entity put -p servers/httpingress/testdata/combo.yaml`
 - Run: `r apps`

Expect:
 - Output: `nginx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Re-enabled the "apps" command, allowing users to list all applications from the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->