### PR TITLE
Add config merging functionality and improve config management

### DIFF
--- a/cli/commands/auth_generate.go
+++ b/cli/commands/auth_generate.go
@@ -1,13 +1,18 @@
 package commands
 
 import (
+	"net"
+
+	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/components/coordinate"
 )
 
 func AuthGenerate(ctx *Context, opts struct {
-	DataPath   string `short:"d" long:"data-path" description:"Data path" default:"/var/lib/miren"`
-	ConfigPath string `short:"c" long:"config-path" description:"Path to the config file" default:"clientconfig.yaml"`
-	Name       string `short:"n" long:"name" description:"Name of the client certificate" require:"true"`
+	DataPath    string `short:"d" long:"data-path" description:"Data path" default:"/var/lib/miren"`
+	ConfigPath  string `short:"c" long:"config-path" description:"Path to the config file, - for stdout" default:"clientconfig.yaml"`
+	Name        string `short:"n" long:"name" description:"Name of the client certificate" require:"true"`
+	Target      string `short:"t" long:"target" description:"Hostname to embed in the config" default:"localhost"`
+	ClusterName string `short:"C" long:"cluster-name" description:"Name of the cluster" default:"local"`
 }) error {
 	co := coordinate.NewCoordinator(ctx.Log, coordinate.CoordinatorConfig{
 		DataPath: opts.DataPath,
@@ -23,9 +28,22 @@ func AuthGenerate(ctx *Context, opts struct {
 		return err
 	}
 
-	lcfg, err := co.NamedConfig(opts.Name)
+	cc, err := co.IssueCertificate(opts.Name)
 	if err != nil {
 		return err
+	}
+
+	lcfg := &clientconfig.Config{
+		ActiveCluster: opts.ClusterName,
+
+		Clusters: map[string]*clientconfig.ClusterConfig{
+			opts.ClusterName: {
+				Hostname:   net.JoinHostPort(opts.Target, "8443"),
+				CACert:     string(cc.CACert),
+				ClientCert: string(cc.CertPEM),
+				ClientKey:  string(cc.KeyPEM),
+			},
+		},
 	}
 
 	return lcfg.SaveTo(opts.ConfigPath)

--- a/cli/commands/auth_generate.go
+++ b/cli/commands/auth_generate.go
@@ -11,7 +11,7 @@ import (
 func AuthGenerate(ctx *Context, opts struct {
 	DataPath    string `short:"d" long:"data-path" description:"Data path" default:"/var/lib/miren"`
 	ConfigPath  string `short:"c" long:"config-path" description:"Path to the config file, - for stdout" default:"clientconfig.yaml"`
-  Name        string `short:"n" long:"name" description:"Name of the client certificate" default:"runtime-user"`
+	Name        string `short:"n" long:"name" description:"Name of the client certificate" default:"runtime-user"`
 	Target      string `short:"t" long:"target" description:"Hostname to embed in the config" default:"localhost"`
 	ClusterName string `short:"C" long:"cluster-name" description:"Name of the cluster" default:"local"`
 }) error {

--- a/cli/commands/auth_generate.go
+++ b/cli/commands/auth_generate.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"net"
+	"strings"
 
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/components/coordinate"
@@ -33,12 +34,17 @@ func AuthGenerate(ctx *Context, opts struct {
 		return err
 	}
 
+	tgt := opts.Target
+	if !strings.Contains(tgt, ":") {
+		tgt = net.JoinHostPort(tgt, "8443")
+	}
+
 	lcfg := &clientconfig.Config{
 		ActiveCluster: opts.ClusterName,
 
 		Clusters: map[string]*clientconfig.ClusterConfig{
 			opts.ClusterName: {
-				Hostname:   net.JoinHostPort(opts.Target, "8443"),
+				Hostname:   tgt,
 				CACert:     string(cc.CACert),
 				ClientCert: string(cc.CertPEM),
 				ClientKey:  string(cc.KeyPEM),

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -95,6 +95,10 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("config info", "Get information about the client configuration", ConfigInfo), nil
 		},
 
+		"config load": func() (cli.Command, error) {
+			return Infer("config load", "Load config and merge it with your current config", ConfigLoad), nil
+		},
+
 		// TODO: Errors with "unknown object: user"
 		// "user": func() (cli.Command, error) {
 		// 	return Section("user", "Commands related to cluster users"), nil

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -50,7 +50,7 @@ func (c *ConfigCentric) SaveConfig() error {
 		return nil
 	}
 
-	return clientconfig.SaveConfig(c.cfg)
+	return c.cfg.Save()
 }
 
 func (c *ConfigCentric) LoadCluster() (*clientconfig.ClusterConfig, error) {

--- a/cli/commands/config_load.go
+++ b/cli/commands/config_load.go
@@ -8,7 +8,7 @@ import (
 
 func ConfigLoad(ctx *Context, opts struct {
 	Config    string `long:"config" description:"Path to the config file to update"`
-	Input     string `short:"i" long:"input" description:"Path to the input config file to add"`
+	Input     string `short:"i" long:"input" description:"Path to the input config file to add" required:"true"`
 	Force     bool   `short:"f" long:"force" description:"Force the update"`
 	SetActive bool   `short:"a" long:"set-active" description:"Set the active cluster"`
 }) error {

--- a/cli/commands/config_load.go
+++ b/cli/commands/config_load.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"errors"
+
+	"miren.dev/runtime/clientconfig"
+)
+
+func ConfigLoad(ctx *Context, opts struct {
+	Config    string `long:"config" description:"Path to the config file to update"`
+	Input     string `short:"i" long:"input" description:"Path to the input config file to add"`
+	Force     bool   `short:"f" long:"force" description:"Force the update"`
+	SetActive bool   `short:"a" long:"set-active" description:"Set the active cluster"`
+}) error {
+	var (
+		cfg *clientconfig.Config
+		err error
+	)
+
+	if opts.Config != "" {
+		cfg, err = clientconfig.LoadConfigFrom(opts.Config)
+	} else {
+		cfg, err = clientconfig.LoadConfig()
+	}
+
+	if err != nil {
+		if errors.Is(err, clientconfig.ErrNoConfig) {
+			cfg = clientconfig.NewConfig()
+		} else {
+			return err
+		}
+	}
+
+	input, err := clientconfig.LoadConfigFrom(opts.Input)
+	if err != nil {
+		return err
+	}
+
+	err = cfg.Merge(input, opts.SetActive, opts.Force)
+	if err != nil {
+		return err
+	}
+
+	err = cfg.Save()
+	if err != nil {
+		return err
+	}
+
+	for name, cluster := range input.Clusters {
+		ctx.Printf("Added cluster %s: %s\n", name, cluster.Hostname)
+	}
+
+	return nil
+}

--- a/cli/commands/dev.go
+++ b/cli/commands/dev.go
@@ -223,7 +223,7 @@ func Dev(ctx *Context, opts struct {
 		return err
 	}
 
-	client, err := rs.Connect(opts.Address, "entities")
+	client, err := rs.Client("entities")
 	if err != nil {
 		ctx.Log.Error("failed to connect to RPC server", "error", err)
 		return err
@@ -253,7 +253,6 @@ func Dev(ctx *Context, opts struct {
 
 	r := runner.NewRunner(ctx.Log, ctx.Server, runner.RunnerConfig{
 		Id:            opts.RunnerId,
-		ServerAddress: opts.Address,
 		ListenAddress: opts.RunnerAddress,
 		Workers:       runner.DefaulWorkers,
 		Config:        rcfg,

--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -207,7 +207,7 @@ func (c *Config) Merge(other *Config, updateActiveCluster, force bool) error {
 	// Merge clusters from other config
 	for name, cluster := range other.Clusters {
 		if _, exists := c.Clusters[name]; exists && !force {
-			return fmt.Errorf("cluster %q already exists in current config, use force to overwrite", name)
+			return fmt.Errorf("cluster %q already exists in current config, use --force to overwrite", name)
 		}
 
 		c.Clusters[name] = cluster

--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -113,6 +113,7 @@ func LoadConfigFrom(configPath string) (*Config, error) {
 	}
 
 	var config Config
+	config.sourcePath = configPath
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}

--- a/clientconfig/clientconfig_test.go
+++ b/clientconfig/clientconfig_test.go
@@ -36,7 +36,7 @@ func TestConfigLoadSave(t *testing.T) {
 	}
 
 	// Save configuration
-	err = SaveConfig(originalConfig)
+	err = originalConfig.Save()
 	r.NoError(err)
 
 	// Load configuration

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -23,13 +23,22 @@ func Local(cc *caauth.ClientCertificate) *Config {
 }
 
 func (c *Config) RPCOptions() []rpc.StateOption {
+	if c.ActiveCluster == "" {
+		return nil
+	}
+
+	active, exists := c.Clusters[c.ActiveCluster]
+	if !exists {
+		return nil
+	}
+
 	return []rpc.StateOption{
 		rpc.WithCertPEMs(
-			[]byte(c.Clusters[c.ActiveCluster].ClientCert),
-			[]byte(c.Clusters[c.ActiveCluster].ClientKey),
+			[]byte(active.ClientCert),
+			[]byte(active.ClientKey),
 		),
-		rpc.WithCertificateVerification([]byte(c.Clusters[c.ActiveCluster].CACert)),
-		rpc.WithEndpoint(c.Clusters[c.ActiveCluster].Hostname),
+		rpc.WithCertificateVerification([]byte(active.CACert)),
+		rpc.WithEndpoint(active.Hostname),
 		rpc.WithBindAddr("[::]:0"),
 	}
 }

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -2,18 +2,29 @@ package clientconfig
 
 import (
 	"context"
+	"net"
 
 	"miren.dev/runtime/pkg/caauth"
 	"miren.dev/runtime/pkg/rpc"
 )
 
-func Local(cc *caauth.ClientCertificate) *Config {
+func Local(cc *caauth.ClientCertificate, listenAddr string) *Config {
+	addr := listenAddr
+	if addr == "" {
+		addr = "localhost:8443"
+	} else {
+		_, port, err := net.SplitHostPort(addr)
+		if err == nil {
+			addr = net.JoinHostPort("127.0.0.1", port)
+		}
+	}
+
 	return &Config{
 		ActiveCluster: "local",
 
 		Clusters: map[string]*ClusterConfig{
 			"local": {
-				Hostname:   "127.0.0.1:8443",
+				Hostname:   addr,
 				CACert:     string(cc.CACert),
 				ClientCert: string(cc.CertPEM),
 				ClientKey:  string(cc.KeyPEM),

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -7,14 +7,14 @@ import (
 	"miren.dev/runtime/pkg/rpc"
 )
 
-func Local(cc *caauth.ClientCertificate, cert []byte) *Config {
+func Local(cc *caauth.ClientCertificate) *Config {
 	return &Config{
 		ActiveCluster: "local",
 
 		Clusters: map[string]*ClusterConfig{
 			"local": {
 				Hostname:   "127.0.0.1:8443",
-				CACert:     string(cert),
+				CACert:     string(cc.CACert),
 				ClientCert: string(cc.CertPEM),
 				ClientKey:  string(cc.KeyPEM),
 			},

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -29,6 +29,8 @@ func (c *Config) RPCOptions() []rpc.StateOption {
 			[]byte(c.Clusters[c.ActiveCluster].ClientKey),
 		),
 		rpc.WithCertificateVerification([]byte(c.Clusters[c.ActiveCluster].CACert)),
+		rpc.WithEndpoint(c.Clusters[c.ActiveCluster].Hostname),
+		rpc.WithBindAddr("[::]:0"),
 	}
 }
 

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -323,7 +323,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	server.ExposeValue("entities", esv1.AdaptEntityAccess(ess))
 
-	loopback, err := rs.Connect(rs.ListenAddr(), "entities")
+	loopback, err := rs.Connect(rs.LoopbackAddr(), "entities")
 	if err != nil {
 		c.Log.Error("failed to connect to RPC server", "error", err)
 		return err

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -250,6 +250,10 @@ func (c *Coordinator) NamedConfig(name string) (*clientconfig.Config, error) {
 }
 
 func (c *Coordinator) IssueCertificate(name string) (*caauth.ClientCertificate, error) {
+	if c.authority == nil {
+		return nil, fmt.Errorf("CA authority not initialized")
+	}
+
 	return c.authority.IssueCertificate(caauth.Options{
 		CommonName:   name,
 		Organization: "miren",

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -246,7 +246,7 @@ func (c *Coordinator) NamedConfig(name string) (*clientconfig.Config, error) {
 		return nil, err
 	}
 
-	return clientconfig.Local(cc), nil
+	return clientconfig.Local(cc, c.Address), nil
 }
 
 func (c *Coordinator) IssueCertificate(name string) (*caauth.ClientCertificate, error) {

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -246,7 +246,15 @@ func (c *Coordinator) NamedConfig(name string) (*clientconfig.Config, error) {
 		return nil, err
 	}
 
-	return clientconfig.Local(cc, c.authority.GetCACertificate()), nil
+	return clientconfig.Local(cc), nil
+}
+
+func (c *Coordinator) IssueCertificate(name string) (*caauth.ClientCertificate, error) {
+	return c.authority.IssueCertificate(caauth.Options{
+		CommonName:   name,
+		Organization: "miren",
+		ValidFor:     1 * year,
+	})
 }
 
 func (c *Coordinator) ListenAddress() string {

--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -40,9 +40,8 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 
 	// Setup runner config
 	runnerCfg := RunnerConfig{
-		Id:            "test-runner",
-		ServerAddress: coordCfg.Address,
-		Workers:       2,
+		Id:      "test-runner",
+		Workers: 2,
 	}
 
 	// Create contexts

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -102,22 +102,31 @@ func (r *Runner) Start(ctx context.Context) error {
 	r.Log.Info("Starting runner", "id", r.Id)
 
 	var (
-		rs  *rpc.State
-		err error
+		rs     *rpc.State
+		err    error
+		client *rpc.NetworkClient
 	)
 
 	if r.Config == nil {
 		rs, err = rpc.NewState(ctx, rpc.WithLogger(r.Log), rpc.WithBindAddr(r.ListenAddress), rpc.WithSkipVerify)
+		if err != nil {
+			return err
+		}
+
+		client, err = rs.Connect(r.ServerAddress, "entities")
+		if err != nil {
+			return err
+		}
 	} else {
 		rs, err = r.Config.State(ctx, rpc.WithLogger(r.Log), rpc.WithBindAddr(r.ListenAddress))
-	}
-	if err != nil {
-		return err
-	}
+		if err != nil {
+			return err
+		}
 
-	client, err := rs.Connect(r.ServerAddress, "entities")
-	if err != nil {
-		return err
+		client, err = rs.Client("entities")
+		if err != nil {
+			return err
+		}
 	}
 
 	eas := es.NewEntityAccessClient(client)

--- a/pkg/caauth/caauth.go
+++ b/pkg/caauth/caauth.go
@@ -152,6 +152,7 @@ func (ca *Authority) ExportPEM() (certPEM, keyPEM []byte, err error) {
 type ClientCertificate struct {
 	CertPEM []byte
 	KeyPEM  []byte
+	CACert  []byte
 }
 
 var (
@@ -251,6 +252,7 @@ func (ca *Authority) IssueCertificate(opts Options) (*ClientCertificate, error) 
 	return &ClientCertificate{
 		CertPEM: certPEM,
 		KeyPEM:  keyPEM,
+		CACert:  ca.GetCACertificate(),
 	}, nil
 }
 

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -87,6 +87,15 @@ func (s *State) ListenAddr() string {
 	return s.transport.Conn.LocalAddr().String()
 }
 
+func (s *State) LoopbackAddr() string {
+	addr := s.transport.Conn.LocalAddr().String()
+	if _, port, err := net.SplitHostPort(addr); err == nil {
+		return "127.0.0.1:" + port
+	}
+
+	return addr
+}
+
 type cachedConn struct {
 	ec quic.EarlyConnection
 	hc *http3.ClientConn


### PR DESCRIPTION
## Summary
- Add `Merge` method to `Config` struct with `updateActiveCluster` and `force` flags for safe configuration merging
- Implement new `config load` CLI command for merging configurations from files or stdin
- Enhance `auth_generate` command with configurable cluster names and target hostnames

## Test plan
- [x] Test `config load` command with existing and new configurations
- [x] Verify force flag properly handles duplicate cluster names
- [x] Test `updateActiveCluster` flag behavior
- [x] Validate `auth_generate` generates correct cluster configurations
- [x] Test stdin input support with `-` path

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new CLI command to load and merge configuration files, with options for force overwrite and setting the active cluster.
  - Enhanced configuration management: supports reading configs from standard input, writing to standard output, and merging multiple configs.
  - Added options to specify target hostname and cluster name when generating authentication configs.
- **Improvements**
  - Client certificates now include the CA certificate for easier configuration.
  - Config files now track their source path for improved management.
  - Saving and loading of config files is more flexible and robust.
  - RPC client connections support specifying default endpoints and obtaining clients via config.
  - Authentication config generation now issues fresh client certificates and embeds cluster info explicitly.
  - Improved RPC client initialization in various commands and runner to support config-centric connections with error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->