### PR TITLE
Make logs command work with entity system

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -57,10 +57,9 @@ func AllCommands() map[string]cli.CommandFactory {
 		// 	return Infer("set host", "Set the hostname of an application", SetHost), nil
 		// },
 
-		// TODO: Errors with "unknown object: logs"
-		// "logs": func() (cli.Command, error) {
-		// 	return Infer("logs", "Get logs for an application", Logs), nil
-		// },
+		"logs": func() (cli.Command, error) {
+			return Infer("logs", "Get logs for an application", Logs), nil
+		},
 
 		// TODO: Errors with "unknown object: app"
 		// "app new": func() (cli.Command, error) {

--- a/cli/commands/dev.go
+++ b/cli/commands/dev.go
@@ -27,6 +27,7 @@ import (
 	"miren.dev/runtime/components/runner"
 	"miren.dev/runtime/components/scheduler"
 	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/grunge"
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc"
@@ -52,8 +53,9 @@ func Dev(ctx *Context, opts struct {
 	res, hm := netresolve.NewLocalResolver()
 
 	var (
-		cpu metrics.CPUUsage
-		mem metrics.MemoryUsage
+		cpu  metrics.CPUUsage
+		mem  metrics.MemoryUsage
+		logs observability.LogReader
 	)
 
 	err := ctx.Server.Populate(&mem)
@@ -65,6 +67,12 @@ func Dev(ctx *Context, opts struct {
 	err = ctx.Server.Populate(&cpu)
 	if err != nil {
 		ctx.Log.Error("failed to populate CPU usage", "error", err)
+		return err
+	}
+
+	err = ctx.Server.Populate(&logs)
+	if err != nil {
+		ctx.Log.Error("failed to populate log reader", "error", err)
 		return err
 	}
 
@@ -126,6 +134,7 @@ func Dev(ctx *Context, opts struct {
 		TempDir:         os.TempDir(),
 		Mem:             &mem,
 		Cpu:             &cpu,
+		Logs:            &logs,
 	})
 
 	err = co.Start(sub)

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -12,7 +12,7 @@ func Logs(ctx *Context, opts struct {
 
 	Last *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
 }) error {
-	cl, err := ctx.RPCClient("logs")
+	cl, err := ctx.RPCClient("dev.miren.runtime/logs")
 	if err != nil {
 		return err
 	}

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -151,7 +151,7 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 	var sb compute_v1alpha.Sandbox
 	sb.Version = app.ActiveVersion
 
-	sb.LogEntity = appMD.Name
+	sb.LogEntity = app.EntityId().String()
 	sb.LogAttribute = types.LabelSet("stage", "app-run", "pool", pool, "service", service)
 
 	// Determine port from config or default to 3000

--- a/e2e/sandbox_lifecycle_test.go
+++ b/e2e/sandbox_lifecycle_test.go
@@ -51,8 +51,6 @@ func TestSandboxLifecycleEndToEnd(t *testing.T) {
 		logsCode = cli.Run([]string{"runtime", "logs", "-a", "nginx"})
 	})
 	r.NoError(err)
-	// TODO: remove this print once things are working properly
-	t.Logf("OUTPUT %s", output)
 	r.Equal(0, logsCode)
 	r.Contains(output, `"GET / HTTP/1.1"`)
 }

--- a/e2e/sandbox_lifecycle_test.go
+++ b/e2e/sandbox_lifecycle_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/cli"
 	"miren.dev/runtime/pkg/testserver"
+	"miren.dev/runtime/pkg/testutils"
 )
 
-func TestCustomPortEndToEnd(t *testing.T) {
+func TestSandboxLifecycleEndToEnd(t *testing.T) {
 	r := require.New(t)
 
 	// Start a test server that we expect to be shut down properly by t.Cleanup functions at the end of the test
@@ -43,6 +44,17 @@ func TestCustomPortEndToEnd(t *testing.T) {
 
 	r.Equal(200, resp.StatusCode)
 	r.Contains(string(body), "Welcome to nginx!")
+
+	// Fetch logs from app
+	var logsCode int
+	output, err := testutils.CaptureStdout(func() {
+		logsCode = cli.Run([]string{"runtime", "logs", "-a", "nginx"})
+	})
+	r.NoError(err)
+	// TODO: remove this print once things are working properly
+	t.Logf("OUTPUT %s", output)
+	r.Equal(0, logsCode)
+	r.Contains(output, `"GET / HTTP/1.1"`)
 }
 
 func writeTempContents(t *testing.T, filename, contents string) string {

--- a/observability/logs_test.go
+++ b/observability/logs_test.go
@@ -1,4 +1,4 @@
-package observability
+package observability_test
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/moby/buildkit/identity"
 	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/testutils"
 )
 
@@ -18,13 +19,13 @@ func TestLogs(t *testing.T) {
 
 		r := require.New(t)
 
-		reg, cleanup := testutils.Registry(TestInject)
+		reg, cleanup := testutils.Registry(observability.TestInject)
 		defer cleanup()
 
 		var (
-			lm LogsMaintainer
-			pw PersistentLogWriter
-			pr PersistentLogReader
+			lm observability.LogsMaintainer
+			pw observability.PersistentLogWriter
+			pr observability.PersistentLogReader
 		)
 
 		err := reg.Populate(&lm)
@@ -41,9 +42,9 @@ func TestLogs(t *testing.T) {
 
 		id := identity.NewID()
 
-		err = pw.WriteEntry(id, LogEntry{
+		err = pw.WriteEntry(id, observability.LogEntry{
 			Timestamp: time.Now(),
-			Stream:    Stdout,
+			Stream:    observability.Stdout,
 			Body:      "this is a log line",
 		})
 		r.NoError(err)

--- a/observability/runsc_test.go
+++ b/observability/runsc_test.go
@@ -1,4 +1,4 @@
-package observability
+package observability_test
 
 import (
 	"encoding/json"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/runsc"
 	"miren.dev/runtime/pkg/testutils"
 )
@@ -18,9 +19,9 @@ func TestRunSCMonitor(t *testing.T) {
 		reg, cleanup := testutils.Registry()
 		defer cleanup()
 
-		reg.Register("status-monitor", &StatusMonitor{})
+		reg.Register("status-monitor", &observability.StatusMonitor{})
 
-		var m RunSCMonitor
+		var m observability.RunSCMonitor
 
 		err := reg.Populate(&m)
 		r.NoError(err)

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -51,8 +51,9 @@ func TestServer(t *testing.T) error {
 	res, hm := netresolve.NewLocalResolver()
 
 	var (
-		cpu metrics.CPUUsage
-		mem metrics.MemoryUsage
+		cpu  metrics.CPUUsage
+		mem  metrics.MemoryUsage
+		logs observability.LogReader
 	)
 
 	err := reg.Populate(&mem)
@@ -69,6 +70,12 @@ func TestServer(t *testing.T) error {
 		return err
 	}
 
+	err = reg.Populate(&logs)
+	if err != nil {
+		log.Error("failed to populate log reader", "error", err)
+		return err
+	}
+
 	co := coordinate.NewCoordinator(log, coordinate.CoordinatorConfig{
 		Address:       optsAddress,
 		EtcdEndpoints: optsEtcdEndpoints,
@@ -77,6 +84,7 @@ func TestServer(t *testing.T) error {
 		TempDir:       os.TempDir(),
 		Mem:           &mem,
 		Cpu:           &cpu,
+		Logs:          &logs,
 	})
 
 	t.Log("Starting coordinator")

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -73,6 +73,7 @@ func TestServer(t *testing.T) error {
 	err = reg.Populate(&logs)
 	if err != nil {
 		log.Error("failed to populate log reader", "error", err)
+		ctxCancel()
 		return err
 	}
 
@@ -127,6 +128,7 @@ func TestServer(t *testing.T) error {
 	// Create RPC client to interact with coordinator
 	scfg, err := co.ServiceConfig()
 	if err != nil {
+		ctxCancel()
 		return err
 	}
 
@@ -168,6 +170,7 @@ func TestServer(t *testing.T) error {
 
 	rcfg, err := co.NamedConfig("runner")
 	if err != nil {
+		ctxCancel()
 		return err
 	}
 

--- a/pkg/testutils/stdout.go
+++ b/pkg/testutils/stdout.go
@@ -1,0 +1,33 @@
+package testutils
+
+import (
+	"io"
+	"os"
+)
+
+func CaptureStdout(fn func()) (string, error) {
+	originalStdout := os.Stdout
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = w
+
+	// Use defer to ensure cleanup happens
+	defer func() {
+		w.Close()
+		os.Stdout = originalStdout
+	}()
+
+	// Execute function
+	fn()
+
+	// Close writer before reading
+	w.Close()
+	os.Stdout = originalStdout
+
+	captured, err := io.ReadAll(r)
+	return string(captured), err
+}

--- a/servers/logs/logs.go
+++ b/servers/logs/logs.go
@@ -1,0 +1,73 @@
+package logs
+
+import (
+	"context"
+	"log/slog"
+
+	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/observability"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+type Server struct {
+	Log       *slog.Logger
+	EC        *entityserver.Client
+	LogReader *observability.LogReader
+}
+
+var _ app_v1alpha.Logs = &Server{}
+
+func NewServer(log *slog.Logger, ec *entityserver.Client, lr *observability.LogReader) *Server {
+	return &Server{
+		Log:       log.With("module", "logserver"),
+		EC:        ec,
+		LogReader: lr,
+	}
+}
+
+func (s *Server) AppLogs(ctx context.Context, state *app_v1alpha.LogsAppLogs) error {
+	args := state.Args()
+
+	var appRec core_v1alpha.App
+
+	err := s.EC.Get(ctx, args.Application(), &appRec)
+	if err != nil {
+		s.Log.Error("failed to get app", "app", args.Application(), "err", err)
+		return err
+	}
+
+	var opts []observability.LogReaderOption
+
+	if args.HasFrom() {
+		opts = append(opts, observability.WithFromTime(
+			standard.FromTimestamp(args.From())))
+	}
+
+	s.Log.Debug("reading logs", "app", appRec.EntityId().String(), "from", args.From())
+
+	entries, err := s.LogReader.Read(ctx, appRec.EntityId().String(), opts...)
+	if err != nil {
+		s.Log.Error("failed to read logs", "app", appRec.EntityId().String(), "err", err)
+		return err
+	}
+
+	var ret []*app_v1alpha.LogEntry
+
+	for _, entry := range entries {
+		var le app_v1alpha.LogEntry
+
+		le.SetTimestamp(standard.ToTimestamp(entry.Timestamp))
+		le.SetLine(entry.Body)
+		le.SetStream(string(entry.Stream))
+
+		ret = append(ret, &le)
+	}
+
+	s.Log.Debug("returning logs", "lineCount", len(entries))
+
+	state.Results().SetLogs(ret)
+
+	return nil
+}


### PR DESCRIPTION
- Rescue a logs server implementation from an old commit and expose it on the coordinator's RPC server
- Change log writing to use full entity id ("app/nginx") instead of just app name ("nginx")
- Rename e2e test as general purpose and add a check for logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled a new CLI command to retrieve application logs.
  - Added log retrieval functionality within the development workflow.
  - Introduced a backend service to serve application logs via RPC.

- **Bug Fixes**
  - Improved accuracy in associating logs with application entities.

- **Tests**
  - Enhanced end-to-end tests to verify log retrieval for applications.
  - Added a utility for capturing standard output during tests.
  - Updated test package structure for better isolation and clarity.

- **Documentation**
  - Updated test names for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->