### PR TITLE
Silence Minio and Dagger Extraneous Output and Checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# Silence Dagger message about using its cloud
+export DAGGER_NO_NAG=1
+# Disable telemetry in Dagger and anything else that honors DNT
+export DO_NOT_TRACK=1
+
 test:
 	dagger call -q test --dir=.
 

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -77,6 +77,7 @@ func (m *Runtime) WithServices(dir *dagger.Directory) *dagger.Container {
 		From("quay.io/minio/minio:RELEASE.2025-04-03T14-56-28Z").
 		WithEnvVariable("MINIO_ROOT_USER", "admin").
 		WithEnvVariable("MINIO_ROOT_PASSWORD", "password").
+		WithEnvVariable("MINIO_UPDATE", "off").
 		WithExposedPort(9000).
 		WithExec([]string{"minio", "server", "/data"}).
 		AsService()

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745342730,
-        "narHash": "sha256-NOZ4wgPbwqHS8gIZl9C8O54cIPKt5I0RJlYJ0DL7liM=",
+        "lastModified": 1748352427,
+        "narHash": "sha256-k4Kfgj8i9l4w/FyX3f5HYjvGz+/bzyh0ALnVUJkOvqM=",
         "owner": "dagger",
         "repo": "nix",
-        "rev": "38c8a8ee05ba91494aa255af8c37c90ddeeaaf53",
+        "rev": "70530d252c0b3172161dbbb81dc3f63a33a4f17b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- **Disable Minio container update checks**
- **Quiet down Dagger's nags and telemetry traffic**
- **Update dagger in Nix setup to silence its version nag**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment settings to suppress certain notifications and disable telemetry during builds.
  - Adjusted service configuration to prevent automatic updates for a storage service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->