### PR TITLE
Fix race in rpc tests

### DIFF
--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -217,10 +217,11 @@ func TestRPC(t *testing.T) {
 		r.Equal("test", up.reading.Meter())
 		r.Equal(float32(42), up.reading.Temperature())
 
+		time.Sleep(100 * time.Millisecond) // wait for goroutine running close
+
 		up.mu.Lock()
 		defer up.mu.Unlock()
 
-		time.Sleep(100 * time.Millisecond) // wait for goroutine running close
 		r.True(up.closed)
 	})
 

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -737,7 +737,6 @@ func (cs *controlStream) NoReply(rs streamRequest, arg any) error {
 }
 
 func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
-	s.state.log.Warn("starting call stream")
 	oid := OID(r.PathValue("oid"))
 
 	method := r.PathValue("method")


### PR DESCRIPTION
Also:
* Remove unnecessary warn logging
* Disable Actor tests as functionality is unused


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved thread safety in test code to prevent race conditions.
  - Disabled a previously existing test case.
- **Chores**
  - Removed a warning log message from server startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->