### PR TITLE
Move Dir flag to AppCentric

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -22,12 +22,21 @@ type AppCentric struct {
 	ConfigCentric
 
 	App string `short:"a" long:"app" env:"RUNTIME_APP" description:"Application get info about"`
+	Dir string `short:"d" long:"dir" description:"Directory to run from" default:"."`
 
 	config *appconfig.AppConfig
 }
 
 func (a *AppCentric) Validate(glbl *GlobalFlags) error {
-	ac, err := appconfig.LoadAppConfig()
+	var ac *appconfig.AppConfig
+	var err error
+
+	if a.Dir != "." {
+		ac, err = appconfig.LoadAppConfigUnder(a.Dir)
+	} else {
+		ac, err = appconfig.LoadAppConfig()
+	}
+
 	if err == nil {
 		a.config = ac
 	}

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -27,7 +27,6 @@ import (
 func Deploy(ctx *Context, opts struct {
 	AppCentric
 
-	Dir           string `short:"d" long:"dir" description:"Directory to run from" default:"."`
 	Explain       bool   `short:"x" long:"explain" description:"Explain the build process"`
 	ExplainFormat string `long:"explain-format" description:"Explain format" choice:"auto" choice:"plain" choice:"tty" choice:"rawjson" default:"auto"`
 }) error {


### PR DESCRIPTION
Anything that's loading an app should be able to infer that app from a
directory of code containing config.

This makes things like `runtime deploy -d testdata/bun` work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the option to specify the directory when running the deploy command for a more streamlined experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->