### PR TITLE
Add vim as a default install on dagger dev environment.

### DIFF
--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -163,7 +163,7 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 
 	// Wait a bit for processing
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	c, err = runner.ContainerdContainerForSandbox(ctx, entity.Id(id))
 	r.NoError(err)

--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -163,7 +163,7 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 
 	// Wait a bit for processing
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	c, err = runner.ContainerdContainerForSandbox(ctx, entity.Id(id))
 	r.NoError(err)

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -180,18 +180,18 @@ func (m *Runtime) Container(
 func (m *Runtime) Test(
 	ctx context.Context,
 	dir *dagger.Directory,
-// +optional
+	// +optional
 	shell bool,
-// +optional
+	// +optional
 	tests string,
-// +optional
+	// +optional
 	count int,
-// NOTE: This flag cannot be called "verbose" - see https://github.com/dagger/dagger/issues/10428
-// +optional
+	// NOTE: This flag cannot be called "verbose" - see https://github.com/dagger/dagger/issues/10428
+	// +optional
 	verboose bool,
-// +optional
+	// +optional
 	run string,
-// +optional
+	// +optional
 	fast bool,
 	// +optional
 	tags string,
@@ -251,7 +251,7 @@ func (m *Runtime) Test(
 func (m *Runtime) Dev(
 	ctx context.Context,
 	dir *dagger.Directory,
-// +optional
+	// +optional
 	tmux bool,
 ) (string, error) {
 	w := m.WithServices(dir).

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -121,6 +121,7 @@ func (m *Runtime) BuildEnv(dir *dagger.Directory) *dagger.Container {
 			"iproute2",
 			"iptables",
 			"tmux",
+			"vim",
 		}).
 		WithFile("/upstream/containerd.tar.gz", dag.HTTP(containerd)).
 		WithFile("/upstream/buildkit.tar.gz", dag.HTTP(buildkit)).
@@ -179,18 +180,18 @@ func (m *Runtime) Container(
 func (m *Runtime) Test(
 	ctx context.Context,
 	dir *dagger.Directory,
-	// +optional
+// +optional
 	shell bool,
-	// +optional
+// +optional
 	tests string,
-	// +optional
+// +optional
 	count int,
-	// NOTE: This flag cannot be called "verbose" - see https://github.com/dagger/dagger/issues/10428
-	// +optional
+// NOTE: This flag cannot be called "verbose" - see https://github.com/dagger/dagger/issues/10428
+// +optional
 	verboose bool,
-	// +optional
+// +optional
 	run string,
-	// +optional
+// +optional
 	fast bool,
 	// +optional
 	tags string,
@@ -250,7 +251,7 @@ func (m *Runtime) Test(
 func (m *Runtime) Dev(
 	ctx context.Context,
 	dir *dagger.Directory,
-	// +optional
+// +optional
 	tmux bool,
 ) (string, error) {
 	w := m.WithServices(dir).


### PR DESCRIPTION
Add vim to the default dev environment.

(my editor doesnt like the tabs for some reason. i think it runs gofmt on save. i'll figure it out)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added installation of the "vim" editor to the environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->