### PR TITLE
Split e2e tests into separate suite, and run them on depot.dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: depot-ubuntu-latest,dagger=0.18.9
     steps:
     - uses: actions/checkout@v4
+    - name: Enable netlink
+      run: modprobe nbd
     - name: Test
       run: dagger --progress=plain call test --dir=.
 
@@ -18,6 +20,8 @@ jobs:
     runs-on: depot-ubuntu-latest,dagger=0.18.9
     steps:
     - uses: actions/checkout@v4
+    - name: Enable netlink
+      run: modprobe nbd
     - name: Test
       run: dagger --progress=plain call test --dir=. --tests="./e2e" --tags="e2e"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Enable netlink
-      run: modprobe nbd
+      run: sudo modprobe nbd
     - name: Test
       run: dagger --progress=plain call test --dir=.
 
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Enable netlink
-      run: modprobe nbd
+      run: sudo modprobe nbd
     - name: Test
       run: dagger --progress=plain call test --dir=. --tests="./e2e" --tags="e2e"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: depot-ubuntu-latest,dagger=0.18.9
     steps:
     - uses: actions/checkout@v4
-    - name: Enable netlink
-      run: sudo modprobe nbd
     - name: Test
       run: dagger --progress=plain call test --dir=.
 
@@ -20,8 +18,6 @@ jobs:
     runs-on: depot-ubuntu-latest,dagger=0.18.9
     steps:
     - uses: actions/checkout@v4
-    - name: Enable netlink
-      run: sudo modprobe nbd
     - name: Test
       run: dagger --progress=plain call test --dir=. --tests="./e2e" --tags="e2e"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Test
-      run: dagger call test --dir=.
+      run: dagger --progress=plain call test --dir=.
 
   test-e2e:
     runs-on: depot-ubuntu-latest,dagger=0.18.9
     steps:
     - uses: actions/checkout@v4
     - name: Test
-      run: dagger call test --dir=. --tests="./e2e" --tags="e2e"
+      run: dagger --progress=plain call test --dir=. --tests="./e2e" --tags="e2e"
 
   build:
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.23'
+        go-version-file: 'go.mod'
 
     - name: Build
       run: make bin/runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,17 @@ jobs:
         args: test --dir=.
         cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test
+      uses: dagger/dagger-for-github@v7
+      with:
+        verb: call
+        args: test --dir=. --tests="./e2e" --tags="e2e"
+        cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,26 +8,18 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest,dagger=0.18.9
     steps:
     - uses: actions/checkout@v4
     - name: Test
-      uses: dagger/dagger-for-github@v7
-      with:
-        verb: call
-        args: test --dir=.
-        cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+      run: dagger call test --dir=.
 
   test-e2e:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest,dagger=0.18.9
     steps:
     - uses: actions/checkout@v4
     - name: Test
-      uses: dagger/dagger-for-github@v7
-      with:
-        verb: call
-        args: test --dir=. --tests="./e2e" --tags="e2e"
-        cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+      run: dagger call test --dir=. --tests="./e2e" --tags="e2e"
 
   build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ test-i:
 test-shell:
 	dagger call -q test --dir=. --shell
 
+test-e2e:
+	dagger call -q test --dir=. --tests="./e2e" --tags=e2e
+
 dev-tmux:
 	dagger call -q dev --dir=. --tmux
 

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -831,6 +831,10 @@ func TestSandbox(t *testing.T) {
 	})
 
 	t.Run("sets up miren volumes", func(t *testing.T) {
+		if !testutils.IsModuleLoaded("nbd") {
+			t.Skip("miren volumes require nbd kernel module and it doesn't look loaded")
+		}
+
 		r := require.New(t)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "runtime",
-  "engineVersion": "v0.14.0",
+  "engineVersion": "v0.18.9",
   "sdk": "go",
   "source": "dagger",
   "views": [

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"dagger/runtime/internal/dagger"
+	"fmt"
 	"runtime"
 	"strconv"
 	"strings"
@@ -190,6 +191,8 @@ func (m *Runtime) Test(
 	run string,
 	// +optional
 	fast bool,
+	// +optional
+	tags string,
 ) (string, error) {
 	w := m.WithServices(dir).
 		WithDirectory("/src", dir).
@@ -229,6 +232,10 @@ func (m *Runtime) Test(
 
 		if fast {
 			args = append(args, "-failfast")
+		}
+
+		if tags != "" {
+			args = append(args, fmt.Sprintf("--tags=%s", tags))
 		}
 
 		w = w.WithExec(args, dagger.ContainerWithExecOpts{

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -80,8 +80,9 @@ func (m *Runtime) WithServices(dir *dagger.Directory) *dagger.Container {
 		WithEnvVariable("MINIO_ROOT_PASSWORD", "password").
 		WithEnvVariable("MINIO_UPDATE", "off").
 		WithExposedPort(9000).
-		WithExec([]string{"minio", "server", "/data"}).
-		AsService()
+		AsService(dagger.ContainerAsServiceOpts{
+			Args: []string{"minio", "server", "/data"},
+		})
 
 	return m.BuildEnv(dir).
 		WithServiceBinding("clickhouse", ch).

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -1,0 +1,5 @@
+// This package contains end-to-end tests, all of which are meant to be tagged
+// with the e2e build tag. The `test-e2e` Makefile target and GitHub jobs
+// specify this tag and this package to separate out e2e tests from the rest of
+// the suite.
+package e2e

--- a/e2e/sandbox_lifecycle_test.go
+++ b/e2e/sandbox_lifecycle_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e
 
 import (

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,9 @@
             pkgs.go_1_24
             dagger.packages.${system}.dagger
           ];
+
+          # Allow gopls to work in e2e tests
+          GOFLAGS = "-tags=e2e";
         };
       }
     );

--- a/pkg/testutils/linuxmodule.go
+++ b/pkg/testutils/linuxmodule.go
@@ -11,5 +11,12 @@ func IsModuleLoaded(moduleName string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(content), moduleName)
+	lines := strings.SplitSeq(string(content), "\n")
+	for line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == moduleName {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/testutils/linuxmodule.go
+++ b/pkg/testutils/linuxmodule.go
@@ -1,0 +1,15 @@
+package testutils
+
+import (
+	"os"
+	"strings"
+)
+
+// IsModuleLoaded does a naive check to see if the given linux kernel module is available
+func IsModuleLoaded(moduleName string) bool {
+	content, err := os.ReadFile("/proc/modules")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(content), moduleName)
+}


### PR DESCRIPTION
Should help keep e2e tests isolated and CI a bit faster as the job can run
in parallel with the others.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated support for running end-to-end (e2e) tests, including a new Makefile target and GitHub Actions workflow for automated e2e test execution.
  - Added a new package for organizing e2e tests, isolated by build tags.

- **Chores**
  - Updated development environment configuration to improve compatibility with e2e test workflows.
  - Upgraded engine version to enhance overall system performance and stability.
  - Improved test and build workflows with updated runners and dynamic Go version setup.
  - Added checks to skip certain tests when required kernel modules are not loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->