### PR TITLE
Switch etcd component to use bitnami image

### DIFF
--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	etcdImage         = "gcr.io/etcd-development/etcd:v3.5.15"
+	etcdImage         = "docker.io/bitnami/etcd:3.5.19"
+	etcdBinLocation   = "/opt/bitnami/etcd/bin/etcd"
 	etcdContainerName = "runtime-etcd"
-	etcdDataDir       = "/etcd-data"
+	etcdDataDir       = "/bitnami/etcd/data"
 	defaultEtcdPort   = 12379 // Non-default port to avoid conflicts
 	defaultPeerPort   = 12380 // Non-default port to avoid conflicts
 )
@@ -335,9 +336,10 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 	// Create container spec with etcd configuration using host networking
 	opts := []oci.SpecOpts{
 		oci.WithImageConfig(image),
+		oci.WithUser("root"),
 		oci.WithHostNamespace(specs.NetworkNamespace), // Use host network namespace
 		oci.WithProcessArgs(
-			"/usr/local/bin/etcd",
+			etcdBinLocation,
 			"--name", config.Name,
 			"--data-dir", config.DataDir,
 			"--listen-client-urls", fmt.Sprintf("http://0.0.0.0:%d", config.ClientPort),


### PR DESCRIPTION
We'll want to host our own image for this eventually, but this gets the
build passing in the meantime


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the etcd component to use a new container image version.
  - Changed the default data directory and binary execution path for etcd.
  - The etcd process now runs as the root user inside the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->