### PR TITLE
Move packaging job to Depot Dagger VMs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,14 @@ permissions:
 
 jobs:
   package:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest,dagger=0.18.9
     strategy:
       matrix:
         arch: [amd64, arm64]
     steps:
     - uses: actions/checkout@v4
     - name: Build and package for ${{ matrix.arch }}
-      uses: dagger/dagger-for-github@v7
-      with:
-        verb: call
-        args: package --dir=. export --path=release-linux-${{ matrix.arch }}.tar.gz
-        cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+      run: dagger call package --dir=. export --path=release-linux-${{ matrix.arch }}.tar.gz
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:
@@ -38,7 +34,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-      
+
       - name: Check if tip release exists
         id: check_release
         run: |
@@ -49,7 +45,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Create tip release if it doesn't exist
         if: steps.check_release.outputs.exists == 'false'
         run: |
@@ -59,7 +55,7 @@ jobs:
             --prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Delete existing assets if they exist
         run: |
           # Delete existing assets if they exist (ignoring errors if they don't)
@@ -67,13 +63,13 @@ jobs:
           gh release delete-asset tip runtime-linux-arm64.tar.gz --yes 2>/dev/null || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Upload release assets
         run: |
           # Rename the artifacts to the expected names
           cp artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz runtime-linux-amd64.tar.gz
           cp artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz runtime-linux-arm64.tar.gz
-          
+
           # Upload both assets to the release
           gh release upload tip runtime-linux-amd64.tar.gz runtime-linux-arm64.tar.gz --clobber
         env:


### PR DESCRIPTION
We're getting version mismatches now that the config calls for 0.18.9

Fixes MIR-187


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow environment and build steps for packaging releases.
  - Cleaned up minor whitespace in workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->