### PR TITLE
Address test flakes when buildkit/containerd are not ready

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -38,6 +38,10 @@ EOF
 
 mkdir -p /run/containerd
 containerd --root /data --state /data/state --address /run/containerd/containerd.sock -l trace >/dev/null 2>&1 &
+
+# Since our buildkit dir is cached across runs, there might be a stale lockfile
+# sitting around that should be safe to kill
+rm -f /data/buildkit/buildkit.lock
 buildkitd --root /data/buildkit 2>&1 &
 
 mount -t debugfs nodev /sys/kernel/debug

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -41,7 +41,7 @@ containerd --root /data --state /data/state --address /run/containerd/containerd
 
 # Since our buildkit dir is cached across runs, there might be a stale lockfile
 # sitting around that should be safe to kill
-rm -f /data/buildkit/buildkit.lock
+rm -f /data/buildkit/buildkitd.lock
 buildkitd --root /data/buildkit 2>&1 &
 
 mount -t debugfs nodev /sys/kernel/debug

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -45,7 +45,7 @@ mount -t tracefs nodev /sys/kernel/debug/tracing
 mount -t tracefs nodev /sys/kernel/tracing
 
 # Wait for containerd and buildkitd to start
-sleep 1
+sleep 10
 
 cd /src
 

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -38,7 +38,7 @@ EOF
 
 mkdir -p /run/containerd
 containerd --root /data --state /data/state --address /run/containerd/containerd.sock -l trace >/dev/null 2>&1 &
-buildkitd --root /data/buildkit >/dev/null 2>&1 &
+buildkitd --root /data/buildkit 2>&1 &
 
 mount -t debugfs nodev /sys/kernel/debug
 mount -t tracefs nodev /sys/kernel/debug/tracing

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -45,7 +45,32 @@ mount -t tracefs nodev /sys/kernel/debug/tracing
 mount -t tracefs nodev /sys/kernel/tracing
 
 # Wait for containerd and buildkitd to start
-sleep 10
+echo "Waiting for containerd..."
+timeout=30
+count=0
+while ! ctr --address /run/containerd/containerd.sock version >/dev/null 2>&1; do
+  sleep 1
+  count=$((count + 1))
+  if [ "$count" -ge "$timeout" ]; then
+    echo "Timeout waiting for containerd"
+    exit 1
+  fi
+done
+echo "containerd is ready"
+
+# Wait for buildkitd with timeout
+echo "Waiting for buildkitd..."
+timeout=30
+count=0
+while ! buildctl debug info >/dev/null 2>&1; do
+  sleep 1
+  count=$((count + 1))
+  if [ "$count" -ge "$timeout" ]; then
+    echo "Timeout waiting for buildkitd"
+    exit 1
+  fi
+done
+echo "buildkitd is ready"
 
 cd /src
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved reliability of service startup by actively checking readiness of background services and providing clearer error handling and log visibility during test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->