### PR TITLE
dev-tmux: Use vi mode-keys

### DIFF
--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -78,6 +78,9 @@ if [[ -n "$USE_TMUX" ]]; then
   tmux set-option -g prefix C-s
   tmux bind-key C-s send-prefix
 
+  # Some quality of life settings
+  tmux set-option -g mode-keys vi
+
   # Start with two panes with the server running on top and a shell running on the bottom
   tmux split-window -v
   tmux send-keys -t dev:0.0 "./bin/runtime dev -vv" Enter


### PR DESCRIPTION
It's way nicer for copying


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development environment script to enable vi-style keybindings in tmux copy mode for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->