### PR TITLE
Improve CLI command routing and entity operations

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -46,10 +46,9 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("apps", "List all applications", Apps), nil
 		},
 
-		// TODO: Errors with "unknown object: app"
-		// "set": func() (cli.Command, error) {
-		// 	return Infer("set", "Set environment variables for an application", Set), nil
-		// },
+		"set": func() (cli.Command, error) {
+			return Infer("set", "Set environment variables for an application", Set), nil
+		},
 
 		// TODO: Errors with "unknown object: app"
 		// "set host": func() (cli.Command, error) {

--- a/cli/commands/entity_get.go
+++ b/cli/commands/entity_get.go
@@ -10,18 +10,47 @@ import (
 func EntityGet(ctx *Context, opts struct {
 	Id      string `short:"i" long:"id" description:"Entity ID" required:"true"`
 	Address string `short:"a" long:"address" description:"Address to listen on" default:"localhost:8443"`
-}) error {
-	// Create RPC client to interact with coordinator
-	rs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
-	if err != nil {
-		ctx.Log.Error("failed to create RPC client", "error", err)
-		return err
-	}
 
-	client, err := rs.Connect(opts.Address, "entities")
+	ConfigCentric
+}) error {
+	var (
+		rs     *rpc.State
+		client *rpc.NetworkClient
+	)
+
+	cc, err := opts.LoadConfig()
 	if err != nil {
-		ctx.Log.Error("failed to connect to RPC server", "error", err)
-		return err
+		addr := opts.Address
+		if addr == "" {
+			addr = "localhost:8443"
+		}
+
+		rs, err = rpc.NewState(ctx, rpc.WithSkipVerify)
+		if err != nil {
+			ctx.Log.Error("failed to create RPC client", "error", err)
+			return err
+		}
+
+		// Create RPC client to interact with coordinator
+		client, err = rs.Connect(addr, "entities")
+		if err != nil {
+			ctx.Log.Error("failed to connect to RPC server", "error", err)
+			return err
+		}
+
+	} else {
+		rs, err = cc.State(ctx, rpc.WithLogger(ctx.Log))
+		if err != nil {
+			ctx.Log.Error("failed to create RPC client", "error", err)
+			return err
+		}
+
+		// Create RPC client to interact with coordinator
+		client, err = rs.Client("entities")
+		if err != nil {
+			ctx.Log.Error("failed to connect to RPC server", "error", err)
+			return err
+		}
 	}
 
 	eac := entityserver_v1alpha.NewEntityAccessClient(client)

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"miren.dev/runtime/api/app/app_v1alpha"
@@ -174,18 +175,26 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 	}
 
 	for _, s := range cfg.Commands() {
-		appVer.Config.Commands = append(appVer.Config.Commands, core_v1alpha.Commands{
+		cmd := core_v1alpha.Commands{
 			Service: s.Service(),
 			Command: s.Command(),
-		})
+		}
+
+		if !slices.Contains(appVer.Config.Commands, cmd) {
+			appVer.Config.Commands = append(appVer.Config.Commands, cmd)
+		}
 	}
 
 	for _, ev := range cfg.EnvVars() {
-		appVer.Config.Variable = append(appVer.Config.Variable, core_v1alpha.Variable{
+		nv := core_v1alpha.Variable{
 			Key:       ev.Key(),
 			Value:     ev.Value(),
 			Sensitive: ev.Sensitive(),
-		})
+		}
+
+		if !slices.Contains(appVer.Config.Variable, nv) {
+			appVer.Config.Variable = append(appVer.Config.Variable, nv)
+		}
 	}
 
 	appVer.Config.Entrypoint = cfg.Entrypoint()
@@ -194,7 +203,7 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 
 	appVer.Version = name + "-" + idgen.Gen("v")
 
-	_, err = r.EC.Create(ctx, appVer.Version, &appVer)
+	avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
 	if err != nil {
 		return err
 	}
@@ -209,6 +218,9 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 			return err
 		}
 	*/
+
+	appRec.ActiveVersion = avid
+	r.EC.Update(ctx, &appRec)
 
 	state.Results().SetVersionId(appVer.Version)
 

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -220,7 +220,10 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 	*/
 
 	appRec.ActiveVersion = avid
-	r.EC.Update(ctx, &appRec)
+	err = r.EC.Update(ctx, &appRec)
+	if err != nil {
+		return fmt.Errorf("error updating app entity: %w", err)
+	}
 
 	state.Results().SetVersionId(appVer.Version)
 


### PR DESCRIPTION
## Summary
- Re-enable the 'set' command for environment variable management with enhanced functionality
- Add ConfigCentric support to entity get/put operations for improved configuration handling
- Update entity commands to use proper RPC client configuration patterns
- Enhance set command with file-based sensitive variable support using @ prefix syntax

## Test plan
- [ ] Test the re-enabled 'set' command functionality
- [ ] Verify entity get/put operations work with both direct addressing and config-based routing
- [ ] Test file-based sensitive variable loading with @ prefix
- [ ] Confirm proper RPC client initialization in all scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled the "set" command in the CLI.
	- The "set" command now supports reading sensitive environment variable values from a file if specified.

- **Improvements**
	- Enhanced "entity get" and "entity put" commands to support both configuration-based and address-based RPC client creation, improving flexibility when connecting to the coordinator.
	- Updated the "set" command to use an improved API client and updated environment variable handling.
	- Improved internal logic for establishing RPC connections, providing better error handling and fallback mechanisms.
	- Prevented duplicate entries in app configuration commands and variables.
	- Automatically sets the active app version when creating a new app version.

- **User Experience**
	- Changed the short flag for the "Delete" option in the "set" command from -d to -D.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->