### PR TITLE
Add OCI artifact entity type and improve entity operations

### DIFF
--- a/api/core/schema.yml
+++ b/api/core/schema.yml
@@ -26,6 +26,20 @@ kinds:
       type: ref
       doc: The version of the project that should be used
 
+  artifact:
+    app:
+      type: ref
+      doc: The application the artifact is for
+
+    manifest:
+      type: string
+      doc: The OCI image manifest for the version
+
+    manifest_digest:
+      type: string
+      doc: The digest of the manifest
+      indexed: true
+
   app_version:
     app:
       type: ref
@@ -33,9 +47,14 @@ kinds:
     version:
       type: string
       doc: The version of this app
+
     image_url:
       type: string
       doc: The OCI url for the versions code
+
+    artifact:
+      type: ref
+      doc: The artifact to deploy for the version
 
     manifest:
       type: string


### PR DESCRIPTION
## Summary
- Introduce new Artifact entity type to separate OCI manifest storage from AppVersion
- Improve CLI entity operations to properly use client configuration
- Deduplicate configuration values and update active version references

## Test plan
- [ ] Test that new artifacts are created when pushing to registry
- [ ] Verify entity get/put commands work with client config
- [ ] Test set command for managing environment variables
- [ ] Verify app active version is updated after configuration changes
- [ ] Check that commands and variables are properly deduplicated

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new artifact entity for applications, enabling more detailed tracking and management of application artifacts.
  - Application versions now reference associated artifacts, providing clearer linkage between versions and their deployable artifacts.

- **Refactor**
  - Updated internal logic to handle manifest storage and retrieval using artifact entities instead of application versions.
  - Adjusted build process to explicitly associate artifacts with application versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->