### PR TITLE
Fix runsc monitor socket cleanup on startup

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -226,7 +226,14 @@ func (c *SandboxController) Init(ctx context.Context) error {
 
 	c.RunscMon.Ports = c
 
-	c.RunscMon.SetEndpoint(filepath.Join(c.Tempdir, "runsc-mon.sock"))
+	monPath := filepath.Join(c.Tempdir, "runsc-mon.sock")
+
+	if _, err := os.Stat(monPath); err == nil {
+		c.Log.Warn("runsc monitor socket already exists, removing it", "path", monPath)
+		os.Remove(monPath)
+	}
+
+	c.RunscMon.SetEndpoint(monPath)
 
 	err := c.RunscMon.WritePodInit(podInit)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Remove existing runsc monitor socket if it exists before creating a new one
- Prevents errors when the runtime restarts and the socket file was not properly cleaned up

## Test plan
- [ ] Test runtime restart scenarios
- [ ] Verify no errors occur when socket file exists from previous run
- [ ] Confirm runsc monitor functions correctly after cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability by automatically removing any existing monitor socket file before initialization, preventing potential startup issues caused by leftover files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->