### PR TITLE
Overwrite meta-attributes when applying schema

### DIFF
--- a/pkg/entity/schema/schema.go
+++ b/pkg/entity/schema/schema.go
@@ -62,14 +62,14 @@ func (b *SchemaBuilder) Apply(ctx context.Context, store entity.Store) error {
 	for _, eid := range b.singletons {
 		_, err := store.CreateEntity(ctx, entity.Attrs(
 			entity.Ident, types.Keyword(eid),
-		))
+		), entity.WithOverwrite)
 		if err != nil && !errors.Is(err, entity.ErrEntityAlreadyExists) {
 			return err
 		}
 	}
 
 	for _, e := range b.attrs {
-		_, err := store.CreateEntity(ctx, e.Attrs)
+		_, err := store.CreateEntity(ctx, e.Attrs, entity.WithOverwrite)
 		if err != nil && !errors.Is(err, entity.ErrEntityAlreadyExists) {
 			return err
 		}


### PR DESCRIPTION
We don't have a way to reconcile things yet and we're still a bit
unstable in terms of schema, so we're going to just jam them in for now.

Using WithOverwrite now only applies the overwrite if the entity is
different than the one stored also, reducing the write load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved entity creation to allow overwriting existing entities, preventing errors when applying schema changes that involve already existing singletons or attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->