### PR TITLE
Switch to pushing assets to our asset server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,16 +48,16 @@ jobs:
 
       - name: Upload to Miren API
         run: |
+          set -e
+
           # Upload amd64 artifact
-          curl -X POST \
+          curl -X PUT \
             -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
-            -H "Content-Type: application/octet-stream" \
             -F "file=@artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz" \
             https://api.miren.cloud/assets/release/main/release-linux-amd64.tar.gz
 
           # Upload arm64 artifact
-          curl -X POST \
+          curl -X PUT \
             -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
-            -H "Content-Type: application/octet-stream" \
             -F "file=@artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz" \
             https://api.miren.cloud/assets/release/main/release-linux-arm64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,33 @@ jobs:
         run: |
           set -e
 
+          # Generate SHA256 checksums
+          echo "release-linux-amd64.tar.gz SHA256"
+          sha256sum artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz | cut -d' ' -f1 | tee release-linux-amd64.tar.gz.sha256
+
+          echo "release-linux-arm64.tar.gz SHA256"
+          sha256sum artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz | cut -d' ' -f1 | tee release-linux-arm64.tar.gz.sha256
+
           # Upload amd64 artifact
           curl -X PUT \
             -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
             -F "file=@artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz" \
-            https://api.miren.cloud/assets/release/main/release-linux-amd64.tar.gz
+            https://api.miren.cloud/assets/release/runtime/main/release-linux-amd64.tar.gz
+
+          # Upload amd64 SHA256
+          curl -X PUT \
+            -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
+            -F "file=@release-linux-amd64.tar.gz.sha256" \
+            https://api.miren.cloud/assets/release/runtime/main/release-linux-amd64.tar.gz.sha256
 
           # Upload arm64 artifact
           curl -X PUT \
             -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
             -F "file=@artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz" \
-            https://api.miren.cloud/assets/release/main/release-linux-arm64.tar.gz
+            https://api.miren.cloud/assets/release/runtime/main/release-linux-arm64.tar.gz
+
+          # Upload arm64 SHA256
+          curl -X PUT \
+            -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
+            -F "file=@release-linux-arm64.tar.gz.sha256" \
+            https://api.miren.cloud/assets/release/runtime/main/release-linux-arm64.tar.gz.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,12 @@ name: Dagger
 
 on:
   push:
-    branches: [ "main", "evan/mir-146" ]
+    branches: [ "main", "evan/mir-204" ]
 
 # Set permissions for the entire workflow
 permissions:
   contents: write    # Required for creating releases and uploading assets
+  id-token: write   # Required for OIDC token
 
 jobs:
   package:
@@ -25,52 +26,38 @@ jobs:
         path: release-linux-${{ matrix.arch }}.tar.gz
         retention-days: 7
 
-  release:
+  upload-to-miren:
     needs: package
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
-      - name: Check if tip release exists
-        id: check_release
-        run: |
-          if gh release view tip &>/dev/null; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get OIDC token
+        uses: actions/github-script@v7
+        id: get-oidc-token
+        with:
+          script: |
+            const token = await core.getIDToken()
+            core.setOutput('token', token)
 
-      - name: Create tip release if it doesn't exist
-        if: steps.check_release.outputs.exists == 'false'
+      - name: Upload to Miren API
         run: |
-          gh release create tip \
-            --title "Tip Build" \
-            --notes "Latest build from main branch" \
-            --prerelease
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Upload amd64 artifact
+          curl -X POST \
+            -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            -F "file=@artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz" \
+            https://api.miren.cloud/assets/release/main/release-linux-amd64.tar.gz
 
-      - name: Delete existing assets if they exist
-        run: |
-          # Delete existing assets if they exist (ignoring errors if they don't)
-          gh release delete-asset tip runtime-linux-amd64.tar.gz --yes 2>/dev/null || true
-          gh release delete-asset tip runtime-linux-arm64.tar.gz --yes 2>/dev/null || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload release assets
-        run: |
-          # Rename the artifacts to the expected names
-          cp artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz runtime-linux-amd64.tar.gz
-          cp artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz runtime-linux-arm64.tar.gz
-
-          # Upload both assets to the release
-          gh release upload tip runtime-linux-amd64.tar.gz runtime-linux-arm64.tar.gz --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Upload arm64 artifact
+          curl -X POST \
+            -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
+            -H "Content-Type: application/octet-stream" \
+            -F "file=@artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz" \
+            https://api.miren.cloud/assets/release/main/release-linux-arm64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,33 +50,20 @@ jobs:
         run: |
           set -e
 
-          # Generate SHA256 checksums
-          echo "release-linux-amd64.tar.gz SHA256"
-          sha256sum artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz | cut -d' ' -f1 | tee release-linux-amd64.tar.gz.sha256
+          for arch in amd64 arm64; do
+            # Generate SHA256 checksums
+            echo "release-linux-${arch}.tar.gz SHA256"
+            sha256sum "artifacts/runtime-linux-${arch}/release-linux-${arch}.tar.gz" | cut -d' ' -f1 | tee "release-linux-${arch}.tar.gz.sha256"
 
-          echo "release-linux-arm64.tar.gz SHA256"
-          sha256sum artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz | cut -d' ' -f1 | tee release-linux-arm64.tar.gz.sha256
+            # Upload artifact
+            curl --fail-with-body --retry 3 -X PUT \
+              -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
+              -F "file=@artifacts/runtime-linux-${arch}/release-linux-${arch}.tar.gz" \
+              https://api.miren.cloud/assets/release/runtime/${{ github.ref_name }}/runtime-base-linux-${arch}.tar.gz
 
-          # Upload amd64 artifact
-          curl -X PUT \
-            -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
-            -F "file=@artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz" \
-            https://api.miren.cloud/assets/release/runtime/main/runtime-base-linux-amd64.tar.gz
-
-          # Upload amd64 SHA256
-          curl -X PUT \
-            -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
-            -F "file=@release-linux-amd64.tar.gz.sha256" \
-            https://api.miren.cloud/assets/release/runtime/main/runtime-base-linux-amd64.tar.gz.sha256
-
-          # Upload arm64 artifact
-          curl -X PUT \
-            -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
-            -F "file=@artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz" \
-            https://api.miren.cloud/assets/release/runtime/main/runtime-base-linux-arm64.tar.gz
-
-          # Upload arm64 SHA256
-          curl -X PUT \
-            -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
-            -F "file=@release-linux-arm64.tar.gz.sha256" \
-            https://api.miren.cloud/assets/release/runtime/main/runtime-base-linux-arm64.tar.gz.sha256
+            # Upload sha256
+            curl --fail-with-body --retry 3 -X PUT \
+              -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
+              -F "file=@release-linux-${arch}.tar.gz.sha256" \
+              https://api.miren.cloud/assets/release/runtime/${{ github.ref_name }}/runtime-base-linux-${arch}.tar.gz.sha256
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,10 @@ jobs:
 
   upload-to-miren:
     needs: package
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest,dagger=0.18.9
+    concurrency:
+      group: upload-to-miren-${{ github.ref_name }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,30 +4,66 @@ on:
   push:
     branches: [ "main", "evan/mir-204" ]
 
-# Set permissions for the entire workflow
-permissions:
-  contents: write    # Required for creating releases and uploading assets
-  id-token: write   # Required for OIDC token
-
 jobs:
   package:
     runs-on: depot-ubuntu-latest,dagger=0.18.9
     strategy:
       matrix:
         arch: [amd64, arm64]
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - name: Build and package for ${{ matrix.arch }}
-      run: dagger call package --dir=. export --path=release-linux-${{ matrix.arch }}.tar.gz
+      run: dagger call package --dir=. export --path=release-base-linux-${{ matrix.arch }}.tar.gz
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:
-        name: runtime-linux-${{ matrix.arch }}
-        path: release-linux-${{ matrix.arch }}.tar.gz
+        name: runtime-base-linux-${{ matrix.arch }}
+        path: release-base-linux-${{ matrix.arch }}.tar.gz
+        retention-days: 7
+
+  build-binaries:
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+            runner: depot-ubuntu-latest,dagger=0.18.9
+          - os: linux
+            arch: arm64
+            runner: depot-ubuntu-latest,dagger=0.18.9
+          - os: darwin
+            arch: amd64
+            runner: macos-latest
+          - os: darwin
+            arch: arm64
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
+    - name: Build binary for ${{ matrix.os }}-${{ matrix.arch }}
+      run: |
+        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make bin/runtime
+        # Create a zip file with the binary
+        zip runtime-${{ matrix.os }}-${{ matrix.arch }}.zip bin/runtime
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: runtime-${{ matrix.os }}-${{ matrix.arch }}
+        path: runtime-${{ matrix.os }}-${{ matrix.arch }}.zip
         retention-days: 7
 
   upload-to-miren:
-    needs: package
+    needs: [package, build-binaries]
     runs-on: depot-ubuntu-latest,dagger=0.18.9
     concurrency:
       group: upload-to-miren-${{ github.ref_name }}
@@ -55,18 +91,39 @@ jobs:
 
           for arch in amd64 arm64; do
             # Generate SHA256 checksums
-            echo "release-linux-${arch}.tar.gz SHA256"
-            sha256sum "artifacts/runtime-linux-${arch}/release-linux-${arch}.tar.gz" | cut -d' ' -f1 | tee "release-linux-${arch}.tar.gz.sha256"
+            echo "release-base-linux-${arch}.tar.gz SHA256"
+            sha256sum "artifacts/runtime-base-linux-${arch}/release-base-linux-${arch}.tar.gz" | cut -d' ' -f1 | tee "release-base-linux-${arch}.tar.gz.sha256"
 
             # Upload artifact
             curl --fail-with-body --retry 3 -X PUT \
               -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
-              -F "file=@artifacts/runtime-linux-${arch}/release-linux-${arch}.tar.gz" \
+              -F "file=@artifacts/runtime-base-linux-${arch}/release-base-linux-${arch}.tar.gz" \
               https://api.miren.cloud/assets/release/runtime/${{ github.ref_name }}/runtime-base-linux-${arch}.tar.gz
 
             # Upload sha256
             curl --fail-with-body --retry 3 -X PUT \
               -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
-              -F "file=@release-linux-${arch}.tar.gz.sha256" \
+              -F "file=@release-base-linux-${arch}.tar.gz.sha256" \
               https://api.miren.cloud/assets/release/runtime/${{ github.ref_name }}/runtime-base-linux-${arch}.tar.gz.sha256
+          done
+
+          # Upload binary artifacts
+          for os in linux darwin; do
+            for arch in amd64 arm64; do
+              # Generate SHA256 checksum for binary
+              echo "runtime-${os}-${arch}.zip SHA256"
+              sha256sum "artifacts/runtime-${os}-${arch}/runtime-${os}-${arch}.zip" | cut -d' ' -f1 | tee "runtime-${os}-${arch}.zip.sha256"
+
+              # Upload binary zip
+              curl --fail-with-body --retry 3 -X PUT \
+                -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
+                -F "file=@artifacts/runtime-${os}-${arch}/runtime-${os}-${arch}.zip" \
+                https://api.miren.cloud/assets/release/runtime/${{ github.ref_name }}/runtime-${os}-${arch}.zip
+
+              # Upload binary sha256
+              curl --fail-with-body --retry 3 -X PUT \
+                -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
+                -F "file=@runtime-${os}-${arch}.zip.sha256" \
+                https://api.miren.cloud/assets/release/runtime/${{ github.ref_name }}/runtime-${os}-${arch}.zip.sha256
+            done
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,22 +61,22 @@ jobs:
           curl -X PUT \
             -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
             -F "file=@artifacts/runtime-linux-amd64/release-linux-amd64.tar.gz" \
-            https://api.miren.cloud/assets/release/runtime/main/release-linux-amd64.tar.gz
+            https://api.miren.cloud/assets/release/runtime/main/runtime-base-linux-amd64.tar.gz
 
           # Upload amd64 SHA256
           curl -X PUT \
             -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
             -F "file=@release-linux-amd64.tar.gz.sha256" \
-            https://api.miren.cloud/assets/release/runtime/main/release-linux-amd64.tar.gz.sha256
+            https://api.miren.cloud/assets/release/runtime/main/runtime-base-linux-amd64.tar.gz.sha256
 
           # Upload arm64 artifact
           curl -X PUT \
             -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
             -F "file=@artifacts/runtime-linux-arm64/release-linux-arm64.tar.gz" \
-            https://api.miren.cloud/assets/release/runtime/main/release-linux-arm64.tar.gz
+            https://api.miren.cloud/assets/release/runtime/main/runtime-base-linux-arm64.tar.gz
 
           # Upload arm64 SHA256
           curl -X PUT \
             -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.token }}" \
             -F "file=@release-linux-arm64.tar.gz.sha256" \
-            https://api.miren.cloud/assets/release/runtime/main/release-linux-arm64.tar.gz.sha256
+            https://api.miren.cloud/assets/release/runtime/main/runtime-base-linux-arm64.tar.gz.sha256


### PR DESCRIPTION
Rather than smuggling them in a release, push them to our new asset
server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the release workflow to trigger on a different branch and improved artifact upload security and process.
  - Artifacts are now uploaded directly to the Miren API, streamlining the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->