### PR TITLE
Fix 'set host' CLI command

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -61,10 +61,9 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("app default show", "Show which app is currently default", AppDefaultShow), nil
 		},
 
-		// TODO: Errors with "unknown object: app"
-		// "set host": func() (cli.Command, error) {
-		// 	return Infer("set host", "Set the hostname of an application", SetHost), nil
-		// },
+		"set host": func() (cli.Command, error) {
+			return Infer("set host", "Set the hostname of an application", SetHost), nil
+		},
 
 		"logs": func() (cli.Command, error) {
 			return Infer("logs", "Get logs for an application", Logs), nil

--- a/cli/commands/set_host.go
+++ b/cli/commands/set_host.go
@@ -1,10 +1,7 @@
 package commands
 
 import (
-	"fmt"
-
-	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
-	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/api/app"
 	"miren.dev/runtime/pkg/rpc"
 )
 
@@ -43,31 +40,14 @@ func SetHost(ctx *Context, opts struct {
 		}
 	}
 
-	ea := entityserver_v1alpha.NewEntityAccessClient(client)
-
-	// Construct the app ID from the name
-	appId := fmt.Sprintf("dev.miren.app/v1alpha/app/%s", opts.App)
-
-	// Verify the app exists
-	_, err = ea.Get(ctx, appId)
+	// Create app client
+	appClient, err := app.NewClient(ctx, ctx.Log, client)
 	if err != nil {
 		return err
 	}
 
-	// Construct the route ID from the host
-	routeId := fmt.Sprintf("dev.miren.ingress/v1alpha/http_route/%s", opts.Host)
-
-	// Create the entity
-	var e entityserver_v1alpha.Entity
-	e.SetId(routeId)
-	e.SetAttrs(entity.Attrs(
-		entity.Ident, routeId,
-		"app", appId,
-		"host", opts.Host,
-	))
-
-	// Put the entity
-	_, err = ea.Put(ctx, &e)
+	// Set the host for the app
+	err = appClient.SetHost(ctx, opts.App, opts.Host)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Re-enables the `set host` CLI command that was previously commented out
- Adds a proper app entity client wrapper to handle app-specific operations
- Fixes the implementation to properly create/update http_route entities

## Implementation Details
- Created `api/app/client.go` with an App-specific client that wraps entityserver.Client
- Updated `cli/commands/set_host.go` to use the new app client instead of raw entity access
- The command now properly verifies the app exists before setting the host

Fixes MIR-201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new client for managing applications, enabling retrieval of apps by name and setting the hostname for an application.

- **Refactor**
  - Simplified the process for setting an application's hostname in the CLI by using the new app client, making the command more streamlined and user-friendly.

- **Chores**
  - Re-enabled the "set host" command in the CLI, making it available for use again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->