### PR TITLE
A Few Dagger QoL Improvements

### DIFF
--- a/dagger/main.go
+++ b/dagger/main.go
@@ -99,15 +99,11 @@ func (m *Runtime) Etcd() *dagger.Container {
 func (m *Runtime) BuildEnv(dir *dagger.Directory) *dagger.Container {
 	return dag.Container().
 		From("golang:1.24").
-		WithMountedCache("/go/pkg/mod", dag.CacheVolume("go-mod-124")).
-		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
-		WithMountedCache("/go/build-cache", dag.CacheVolume("go-build-124")).
-		WithEnvVariable("GOCACHE", "/go/build-cache").
 		WithExec([]string{"apt-get", "update"}).
-		WithExec([]string{"go", "install", "gotest.tools/gotestsum@latest"}).
-		WithExec([]string{"sh", "-c", "cd /usr/bin && curl https://clickhouse.com/ | sh"}, dagger.ContainerWithExecOpts{}).
 		WithExec([]string{"apt-get", "install", "-y",
 			"bash",
+			"clickhouse-client",
+			"gotestsum",
 			"inetutils-ping",
 			"iproute2",
 			"iptables",
@@ -136,7 +132,11 @@ func (m *Runtime) BuildEnv(dir *dagger.Directory) *dagger.Container {
 		WithExec([]string{"mv", "/upstream/runc", "/usr/local/bin/runc"}).
 		WithExec([]string{"mv", "/upstream/runsc", "/usr/local/bin/runsc"}).
 		WithExec([]string{"mv", "/upstream/containerd-shim-runsc-v1", "/usr/local/bin/containerd-shim-runsc-v1"}).
-		WithExec([]string{"/usr/local/bin/runsc", "install"})
+		WithExec([]string{"/usr/local/bin/runsc", "install"}).
+		WithMountedCache("/go/pkg/mod", dag.CacheVolume("go-mod-124")).
+		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
+		WithMountedCache("/go/build-cache", dag.CacheVolume("go-build-124")).
+		WithEnvVariable("GOCACHE", "/go/build-cache")
 }
 
 func (m *Runtime) Package(

--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -40,10 +40,10 @@ binary_name = "/src/hack/runsc-ignore"
 EOF
 
 mkdir -p /run/containerd
-containerd --root /data --state /data/state --address /run/containerd/containerd.sock -l trace >/dev/null 2>&1 &
+containerd --root /data --state /data/state --address /run/containerd/containerd.sock -l trace >/tmp/containerd.log 2>&1 &
 
 # Handy to build stuff with.
-buildkitd --root /data/buildkit >/dev/null 2>&1 &
+buildkitd --root /data/buildkit >/tmp/buildkit.log 2>&1 &
 
 mount -t debugfs nodev /sys/kernel/debug
 mount -t tracefs nodev /sys/kernel/debug/tracing
@@ -88,7 +88,7 @@ if [[ -n "$USE_TMUX" ]]; then
   tmux attach-session -t dev
 else
   # Start the server in the background
-  ./bin/runtime dev -vv > /tmp/server.log 2>&1 &
+  ./bin/runtime dev -vv >/tmp/server.log 2>&1 &
   echo "Server started, logs are in /tmp/server.log"
 
   # Start a shell


### PR DESCRIPTION
- Move cache volume mounts down on the hunch this will result in fewer
  cache invalidations (I was seeing a lot of apt-get reinstalls)
- Move clickhouse and gotestsum install to apt, so they get cached more
  reliably
- Store containerd and buildkit logs in dev for inspection when things
  get weird


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved logging by redirecting background process logs to dedicated files for easier troubleshooting.
  - Simplified and consolidated package installation steps during environment setup. 

- **Refactor**
  - Rearranged the order of environment setup tasks for better organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->