### PR TITLE
Fix app default config loading

### DIFF
--- a/cli/commands/app_default.go
+++ b/cli/commands/app_default.go
@@ -58,7 +58,9 @@ func AppDefaultSet(ctx *Context, opts struct {
 }
 
 // AppDefaultUnset removes the default flag from all apps
-func AppDefaultUnset(ctx *Context, opts struct{}) error {
+func AppDefaultUnset(ctx *Context, _opts struct {
+	ConfigCentric
+}) error {
 	cl, err := ctx.RPCClient("entities")
 	if err != nil {
 		return err
@@ -102,7 +104,9 @@ func AppDefaultUnset(ctx *Context, opts struct{}) error {
 }
 
 // AppDefaultShow shows which app is currently the default
-func AppDefaultShow(ctx *Context, opts struct{}) error {
+func AppDefaultShow(ctx *Context, _opts struct {
+	ConfigCentric
+}) error {
 	cl, err := ctx.RPCClient("entities")
 	if err != nil {
 		return err


### PR DESCRIPTION
All commands that talk to the server should be ConfigCentric or else
they fall back to always talking to localhost

Fixes MIR-217


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated internal options handling for certain commands to improve consistency with configuration management. No changes to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->