### PR TITLE
Fix race condition in app version update during deployment

### DIFF
--- a/api/app/client.go
+++ b/api/app/client.go
@@ -9,6 +9,7 @@ import (
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/rpc"
 )
 
@@ -60,6 +61,23 @@ func (c *Client) SetHost(ctx context.Context, appName, host string) error {
 	_, err = c.entityClient.CreateOrUpdate(ctx, host, route)
 	if err != nil {
 		return fmt.Errorf("failed to create/update route: %w", err)
+	}
+
+	return nil
+}
+
+// SetActiveVersion updates the active version of an app
+func (c *Client) SetActiveVersion(ctx context.Context, appName, versionID string) error {
+	app, err := c.GetByName(ctx, appName)
+	if err != nil {
+		return fmt.Errorf("failed to get app %s: %w", appName, err)
+	}
+
+	app.ActiveVersion = entity.Id(versionID)
+
+	err = c.entityClient.Update(ctx, app)
+	if err != nil {
+		return fmt.Errorf("failed to update app %s: %w", appName, err)
 	}
 
 	return nil

--- a/hack/lint-changed.sh
+++ b/hack/lint-changed.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eu
 
 echo "Running go fmt on changed files..."
 git diff --name-only HEAD | grep '\.go$' | xargs -r -n1 go fmt
 git diff --cached --name-only | grep '\.go$' | xargs -r -n1 go fmt
 
-echo "Running go vet on changed files..."
-git diff --name-only HEAD | grep '\.go$' | xargs -r -n1 go vet
-git diff --cached --name-only | grep '\.go$' | xargs -r -n1 go vet
+echo "Running go vet on changed packages..."
+# Get unique package directories from changed files
+PACKAGES=$(
+    {
+        git diff --name-only HEAD | grep '\.go$' | xargs -r dirname
+        git diff --cached --name-only | grep '\.go$' | xargs -r dirname
+    } | sort -u | sed 's|^|./|'
+)
+
+if [ -n "$PACKAGES" ]; then
+    echo "Vetting packages: $PACKAGES"
+    echo $PACKAGES | xargs go vet
+fi
 
 echo "Running go mod tidy..."
 go mod tidy


### PR DESCRIPTION
## Summary
- Fixed a race condition where the builder was holding a stale reference to the app record while updating it
- Added `SetActiveVersion` method to the app client that fetches a fresh copy before updating
- Also includes a small fix to the lint script to run go vet at package level

## Details
The builder was updating the app's active version using a stale reference that was fetched at the beginning of the build process. This was causing the deploy to clear out the app default flag which was being set in the background during the build process.

The fix ensures we always work with the latest version of the app entity by:
1. Adding a `SetActiveVersion` method to the app client that fetches a fresh copy of the app
2. Modifying `NewBuilder` to accept the app client as a parameter
3. Using the app client instead of directly updating the stale app record

## Test plan
- [ ] Deploy the first app and verify it's properly set as default

Fixes MIR-218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved app version management by introducing a dedicated method for updating the active version of an app.
- **Bug Fixes**
  - Corrected a typo in the Dockerfile name used during build operations.
- **Chores**
  - Enhanced the linting script to streamline error handling and improve static analysis of changed Go packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->