### PR TITLE
Improve profiler test

### DIFF
--- a/observability/profile/profile_test.go
+++ b/observability/profile/profile_test.go
@@ -2,13 +2,13 @@ package profile
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,8 +39,8 @@ func TestProfile(t *testing.T) {
 		r.NoError(err)
 
 		cmd := exec.Command(path)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
 
 		err = cmd.Start()
 		r.NoError(err)
@@ -55,22 +55,22 @@ func TestProfile(t *testing.T) {
 
 		defer profiler.Stop()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
 		err = profiler.Start(ctx)
 		r.NoError(err)
 
-		time.Sleep(30 * time.Second)
+		time.Sleep(5 * time.Second)
 
 		stacks, err := profiler.Stacks()
 		r.NoError(err)
 
 		r.Greater(len(stacks), 1)
 
-		spew.Dump(stacks[0].User())
+		r.NotEmpty(stacks[0].User())
 
-		spew.Dump(profiler.CallTree())
+		r.NotNil(profiler.CallTree())
 
 		err = profiler.Stop()
 		r.NoError(err)


### PR DESCRIPTION
- Reduce sleep and timeout - save 25s of build time!
- Remove stdout prints and add a few more assertions

This doesn't directly fix the flake we observed but should make it
easier to track down if/when it occurs.

Refs MIR-213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Reduced test output noise by silencing command execution logs.
  - Shortened test duration for faster execution.
  - Improved test assertions for clearer results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->