### PR TITLE
Add GitHub Actions workflow for auto-deployment to miren-dev-server

### DIFF
--- a/.github/workflows/deploy-dev-server.yml
+++ b/.github/workflows/deploy-dev-server.yml
@@ -1,0 +1,49 @@
+name: Deploy to miren-dev-server
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_SA_KEY }}
+    
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+    
+    - name: Deploy to miren-dev-server
+      run: |
+        echo "🚀 Starting deployment to miren-dev-server"
+        
+        # Reset the VM to trigger startup script and rebuild
+        echo "Resetting VM to trigger fresh build..."
+        gcloud compute instances reset miren-dev-server --zone=us-central1-a
+        
+        # Wait for VM to start booting
+        echo "Waiting for VM to restart..."
+        sleep 30
+        
+        # Wait for startup script to complete (with timeout)
+        echo "Waiting for startup script to complete..."
+        for i in {1..20}; do
+          if gcloud compute ssh miren-dev-server --zone=us-central1-a --command="sudo systemctl is-active miren-runtime" 2>/dev/null; then
+            echo "✅ Runtime service is active!"
+            break
+          fi
+          echo "Still waiting... ($i/20)"
+          sleep 30
+        done
+        
+        # Get final status
+        echo "Deployment status:"
+        gcloud compute ssh miren-dev-server --zone=us-central1-a --command="sudo systemctl status miren-runtime --no-pager" || true
+        
+        # Show the binary version
+        echo "Runtime version:"
+        gcloud compute ssh miren-dev-server --zone=us-central1-a --command="/usr/local/bin/runtime version" || true

--- a/.github/workflows/deploy-dev-server.yml
+++ b/.github/workflows/deploy-dev-server.yml
@@ -39,6 +39,10 @@ jobs:
           echo "Still waiting... ($i/20)"
           sleep 30
         done
+        if [[ $i -eq 20 ]]; then
+          echo "❌ Service did not start in time"
+          exit 1
+        fi
         
         # Get final status
         echo "Deployment status:"


### PR DESCRIPTION
## Summary
Teresa is testing whether i can get this github action to work. FOR TESTING PURPOSES ONLY.

This PR adds a GitHub Actions workflow that automatically deploys to miren-dev-server whenever code is pushed to the main branch.

## How it works
1. Triggered on every push to main
2. Authenticates to Google Cloud using a service account
3. Resets the miren-dev-server VM, which triggers the startup script
4. The startup script pulls the latest code, builds the runtime, and restarts the service
5. Waits for the deployment to complete and reports status

## Setup required
Before merging, ensure the `GCP_SA_KEY` secret is added to the repository with the service account JSON credentials.

## Testing
Once merged, any push to main will automatically trigger a deployment to the dev server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced an automated deployment workflow for the development server, enabling seamless updates and status checks after each push to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->