### PR TITLE
MIR-224: Fix nil pointer error in app command

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -295,11 +295,13 @@ func (m Model) View() string {
 
 	envvars := []string{}
 
-	for _, v := range m.cfg.EnvVars() {
-		if v.Sensitive() {
-			envvars = append(envvars, fmt.Sprintf("%s=****", v.Key()))
-		} else {
-			envvars = append(envvars, fmt.Sprintf("%s=%s", v.Key(), v.Value()))
+	if m.cfg != nil {
+		for _, v := range m.cfg.EnvVars() {
+			if v.Sensitive() {
+				envvars = append(envvars, fmt.Sprintf("%s=****", v.Key()))
+			} else {
+				envvars = append(envvars, fmt.Sprintf("%s=%s", v.Key(), v.Value()))
+			}
 		}
 	}
 
@@ -307,18 +309,22 @@ func (m Model) View() string {
 
 	var concurrency string
 
-	if m.cfg.HasAutoConcurrency() {
-		if m.cfg.AutoConcurrency().HasFactor() {
-			concurrency = fmt.Sprintf("auto (factor of %d)",
-				m.cfg.AutoConcurrency().Factor(),
-			)
+	if m.cfg != nil {
+		if m.cfg.HasAutoConcurrency() {
+			if m.cfg.AutoConcurrency().HasFactor() {
+				concurrency = fmt.Sprintf("auto (factor of %d)",
+					m.cfg.AutoConcurrency().Factor(),
+				)
+			} else {
+				concurrency = "auto"
+			}
+		} else if m.cfg.HasConcurrency() {
+			concurrency = fmt.Sprintf("%d", m.cfg.Concurrency())
 		} else {
-			concurrency = "auto"
+			// Really shouldn't happen
+			concurrency = "unknown"
 		}
-	} else if m.cfg.HasConcurrency() {
-		concurrency = fmt.Sprintf("%d", m.cfg.Concurrency())
 	} else {
-		// Really shouldn't happen
 		concurrency = "unknown"
 	}
 


### PR DESCRIPTION
## Summary
Fix panic in `runtime app` command when viewing apps that have no active version.

## Problem
The command would panic with a nil pointer dereference when running `runtime app` on an app that exists but has no active version (no deployments):

```
runtime error: invalid memory address or nil pointer dereference
```

### When this happens
The panic occurs "sometimes" because the app name can come from different sources:
1. **Explicitly via `-a/--app` flag**: `runtime app -a myapp`
2. **From `.runtime/app.toml` in current directory**: `runtime app` (when in an app directory)
3. **From `RUNTIME_APP` environment variable**

If no app name is found from any source, the command exits early with "app is required" error, avoiding the panic.

The panic only occurs when:
- An app name IS provided (through any of the above methods)
- AND the app exists in the entity store
- BUT has no active version (hasn't been deployed yet)

This happens because `GetConfiguration` returns success but with a nil configuration when the app has no active version.

## Solution
Added nil checks for `m.cfg` before accessing its methods in the View function:
- Check before iterating over environment variables  
- Check before accessing concurrency settings
- Set concurrency to "unknown" when configuration is nil

## Test plan
- [ ] In a directory with `.runtime/app.toml`, run `runtime app` before deploying - should no longer panic
- [ ] Run `runtime app -a test-app` on an undeployed app - should no longer panic
- [ ] Deploy an app and run `runtime app` - should show configuration normally
- [ ] Run `runtime app` in a directory without `.runtime/app.toml` - should show "app is required" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by preventing potential errors when configuration data is unavailable. The app now safely handles missing configuration and avoids crashes related to nil references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->