### PR TITLE
Fix task shutdown in clickhouse component

### DIFF
--- a/components/clickhouse/clickhouse.go
+++ b/components/clickhouse/clickhouse.go
@@ -291,7 +291,7 @@ func (c *ClickHouseComponent) stopTask(ctx context.Context, task containerd.Task
 	}
 
 	// Delete the task
-	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	deleteCtx, deleteCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer deleteCancel()
 
 	if _, err := task.Delete(deleteCtx); err != nil {


### PR DESCRIPTION
The context w/ the containerd namespace was not being used so the task
operation was failing.

This addresses the following error logs in clickhouse tests:

```
time=2025-06-26T14:29:55.708Z level=INFO msg="clickhouse task exited" code=0
time=2025-06-26T14:29:55.709Z level=ERROR msg="failed to delete clickhouse task" error="namespace is required: failed precondition"
time=2025-06-26T14:29:55.709Z level=ERROR msg="failed to delete clickhouse container" error="cannot delete running task runtime-clickhouse: failed precondition" attempt=1 max_retries=3
time=2025-06-26T14:29:57.712Z level=ERROR msg="failed to delete clickhouse container" error="cannot delete running task runtime-clickhouse: failed precondition" attempt=2 max_retries=3
time=2025-06-26T14:29:59.714Z level=ERROR msg="failed to delete clickhouse container" error="cannot delete running task runtime-clickhouse: failed precondition" attempt=3 max_retries=3
time=2025-06-26T14:29:59.714Z level=ERROR msg="failed to delete clickhouse container after all retries, potential snapshot leak"
time=2025-06-26T14:29:59.714Z level=INFO msg="clickhouse server stopped"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task stopping behavior to better respect cancellation or timeouts from the original operation context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->