### PR TITLE
Pass through readonly cgroup info to clickhouse component

### DIFF
--- a/components/clickhouse/clickhouse.go
+++ b/components/clickhouse/clickhouse.go
@@ -486,6 +486,14 @@ func (c *ClickHouseComponent) createContainer(ctx context.Context, image contain
 				Source:      configPath,
 				Options:     []string{"rbind", "ro"},
 			},
+
+			// Binding cgroup filesystem so clickhouse can monitor resource limits
+			{
+				Destination: "/sys/fs/cgroup",
+				Type:        "bind",
+				Source:      "/sys/fs/cgroup",
+				Options:     []string{"rbind", "ro"},
+			},
 		}),
 	}
 


### PR DESCRIPTION
Clickhouse monitors its own memory usage, which requires reading the
cgroup memory info. This addresses warning messages in clickhouse
component startup like this:

time=2025-06-26T14:30:00.238Z level=INFO msg="[ 1 ] {} <Warning> Application: Logging to console but received signal to close log file (ignoring)." module=clickhouse
time=2025-06-26T14:30:00.298Z level=INFO msg="[ 9 ] {} <Error> MemoryWorker: Cannot use cgroups reader: Code: 107. DB::Exception: Cannot find cgroups v1 or v2 current memory file. (FILE_DOESNT_EXIST), Stack trace (when copying this message, always inc
lude the lines below):" module=clickhouse


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to include additional system directory mounting for improved resource monitoring within ClickHouse containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->