### PR TITLE
Consolidate containerd socket paths into constants

### DIFF
--- a/cli/commands/commands_linux.go
+++ b/cli/commands/commands_linux.go
@@ -18,6 +18,7 @@ import (
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/asm"
 	"miren.dev/runtime/pkg/asm/autoreg"
+	"miren.dev/runtime/pkg/containerdx"
 )
 
 func addCommands(cmds map[string]cli.CommandFactory) {
@@ -29,7 +30,7 @@ func addCommands(cmds map[string]cli.CommandFactory) {
 func (c *Context) setupServerComponents(ctx context.Context, reg *asm.Registry) {
 	reg.Register("namespace", "runtime")
 	reg.Register("top_context", ctx)
-	reg.Register("containerd-socket", "/run/containerd/containerd.sock")
+	reg.Register("containerd-socket", containerdx.DefaultSocket)
 
 	reg.Provide(func(opts struct {
 		Namespace string `asm:"namespace"`

--- a/cli/commands/ctr_nuke.go
+++ b/cli/commands/ctr_nuke.go
@@ -5,18 +5,25 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/testutils"
 )
 
 func CtrNuke(c *Context, opts struct {
-	Namespace  string `short:"n" long:"namespace" description:"namespace to nuke"`
-	Containers bool   `short:"c" long:"containers" description:"nuke containers only"`
+	Namespace        string `short:"n" long:"namespace" description:"namespace to nuke"`
+	Containers       bool   `short:"c" long:"containers" description:"nuke containers only"`
+	ContainerdSocket string `long:"containerd-socket" description:"path to containerd socket"`
 }) error {
 	if opts.Namespace == "" {
 		return errors.New("namespace is required")
 	}
 
-	cl, err := containerd.New("/run/containerd/containerd.sock")
+	socket := opts.ContainerdSocket
+	if socket == "" {
+		socket = containerdx.DefaultSocket
+	}
+
+	cl, err := containerd.New(socket)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/dev.go
+++ b/cli/commands/dev.go
@@ -35,6 +35,7 @@ import (
 	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/caauth"
+	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/grunge"
 	"miren.dev/runtime/pkg/ipdiscovery"
 	"miren.dev/runtime/pkg/netdb"
@@ -186,7 +187,7 @@ func Dev(ctx *Context, opts struct {
 		ctx.Server.Override("containerd-socket", containerdComponent.SocketPath())
 	} else {
 		// Use existing containerd with provided or default socket path
-		defaultSocket := "/run/containerd/containerd.sock"
+		defaultSocket := containerdx.DefaultSocket
 		if containerdSocketPath != "" {
 			defaultSocket = containerdSocketPath
 		}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"miren.dev/runtime/pkg/containerdx"
 )
 
 func Server(ctx *Context, opts struct {
@@ -45,7 +46,7 @@ func Server(ctx *Context, opts struct {
 		// Wait for containerd to start
 
 		for {
-			cl, err := containerd.New("/run/containerd/containerd.sock")
+			cl, err := containerd.New(containerdx.DefaultSocket)
 			if err == nil {
 				_, err = cl.Server(ctx)
 				if err == nil {

--- a/components/clickhouse/integration_test.go
+++ b/components/clickhouse/integration_test.go
@@ -17,19 +17,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 	mc "miren.dev/runtime/components/clickhouse"
+	"miren.dev/runtime/pkg/testutils"
 )
 
 const testNamespace = "runtime-clickhouse-test"
 
 func TestClickHouseComponentIntegration(t *testing.T) {
 	ctx := context.Background()
+	reg, cleanup := testutils.Registry()
+	defer cleanup()
 
-	// Skip if containerd is not available
-	cc, err := containerd.New("/run/containerd/containerd.sock")
-	if err != nil {
-		t.Skipf("containerd not available: %v", err)
-	}
-	defer cc.Close()
+	var cc *containerd.Client
+	err := reg.Resolve(&cc)
+	require.NoError(t, err, "failed to resolve containerd client")
 
 	// Create temporary directory for test data
 	tmpDir, err := os.MkdirTemp("", "clickhouse-test")

--- a/components/etcd/integration_test.go
+++ b/components/etcd/integration_test.go
@@ -16,19 +16,19 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"golang.org/x/sys/unix"
 	"miren.dev/runtime/components/etcd"
+	"miren.dev/runtime/pkg/testutils"
 )
 
 const testNamespace = "runtime-etcd-test"
 
 func TestEtcdComponentIntegration(t *testing.T) {
 	ctx := t.Context()
+	reg, cleanup := testutils.Registry()
+	defer cleanup()
 
-	// Skip if containerd is not available
-	cc, err := containerd.New("/run/containerd/containerd.sock")
-	if err != nil {
-		t.Skipf("containerd not available: %v", err)
-	}
-	defer cc.Close()
+	var cc *containerd.Client
+	err := reg.Resolve(&cc)
+	require.NoError(t, err, "failed to resolve containerd client")
 
 	// Create temporary directory for test data
 	tmpDir, err := os.MkdirTemp("", "etcd-test")

--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -15,6 +15,8 @@ mkdir -p /data /run
 
 export OTEL_SDK_DISABLED=true
 
+CONTAINERD_SOCKET="/var/lib/miren/containerd/containerd.sock"
+
 cat <<EOF >/etc/containerd/config.toml
 version = 2
 [plugins."io.containerd.runtime.v1.linux"]
@@ -40,7 +42,7 @@ binary_name = "/src/hack/runsc-ignore"
 EOF
 
 mkdir -p /var/lib/miren/containerd
-containerd --root /data --state /data/state --address /var/lib/miren/containerd/containerd.sock -l trace >/tmp/containerd.log 2>&1 &
+containerd --root /data --state /data/state --address "$CONTAINERD_SOCKET" -l trace >/tmp/containerd.log 2>&1 &
 
 # Handy to build stuff with.
 buildkitd --root /data/buildkit >/tmp/buildkit.log 2>&1 &
@@ -63,7 +65,7 @@ mkdir -p ~/.config/runtime
 r auth generate -c ~/.config/runtime/clientconfig.yaml
 
 echo "Cleaning runtime namespace to begin..."
-r debug ctr nuke -n runtime
+r debug ctr nuke -n runtime --containerd-socket "$CONTAINERD_SOCKET"
 
 export HISTFILE=/data/.bash_history
 export HISTIGNORE=exit

--- a/pkg/containerdx/constants.go
+++ b/pkg/containerdx/constants.go
@@ -1,0 +1,6 @@
+package containerdx
+
+const (
+	// DefaultSocket is the default path to the containerd socket on Linux systems
+	DefaultSocket = "/run/containerd/containerd.sock"
+)

--- a/pkg/testutils/reg.go
+++ b/pkg/testutils/reg.go
@@ -19,6 +19,7 @@ import (
 	"miren.dev/runtime/network"
 	"miren.dev/runtime/pkg/asm"
 	"miren.dev/runtime/pkg/asm/autoreg"
+	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc"
@@ -87,7 +88,7 @@ func Registry(extra ...func(*asm.Registry)) (*asm.Registry, func()) {
 	})
 
 	r.Provide(func() (*containerd.Client, error) {
-		cl, err := containerd.New("/run/containerd/containerd.sock")
+		cl, err := containerd.New(containerdx.DefaultSocket)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- Consolidates all hardcoded containerd socket paths into a single constant `containerdx.DefaultSocket`
- Updates `ctr nuke` command to accept a `--containerd-socket` argument, making it consistent with other commands
- Adds `CONTAINERD_SOCKET` variables to shell scripts for easy configuration

## Changes
- Added `pkg/containerdx/constants.go` with `DefaultSocket` constant
- Updated all Go files to use the constant instead of hardcoded paths
- Modified `hack/dev.sh` and `hack/test.sh` to use socket path variables
- Updated integration tests to use testutils registry for containerd client resolution

## Test plan
- [x] Run `make test` to ensure all tests pass
- [x] Run `make dev` and verify the dev environment starts correctly
- [x] Test `r debug ctr nuke` command with custom socket path

Fixes MIR-221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the containerd socket path via a new option in the `CtrNuke` command.
  * Introduced a standard default containerd socket constant used across the application.

* **Chores**
  * Replaced hardcoded containerd socket paths with a configurable constant throughout the CLI, scripts, and tests.
  * Updated development and testing scripts to use environment variables for containerd socket configuration.
  * Improved test setup to use dependency injection for containerd client management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->