### PR TITLE
Add response time percentiles to HTTP metrics

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -503,6 +503,8 @@ type requestStatData struct {
 	Count         *int64              `cbor:"1,keyasint,omitempty" json:"count,omitempty"`
 	AvgDurationMs *float64            `cbor:"2,keyasint,omitempty" json:"avg_duration_ms,omitempty"`
 	ErrorRate     *float64            `cbor:"3,keyasint,omitempty" json:"error_rate,omitempty"`
+	P95DurationMs *float64            `cbor:"4,keyasint,omitempty" json:"p95_duration_ms,omitempty"`
+	P99DurationMs *float64            `cbor:"5,keyasint,omitempty" json:"p99_duration_ms,omitempty"`
 }
 
 type RequestStat struct {
@@ -564,6 +566,36 @@ func (v *RequestStat) ErrorRate() float64 {
 
 func (v *RequestStat) SetErrorRate(errorRate float64) {
 	v.data.ErrorRate = &errorRate
+}
+
+func (v *RequestStat) HasP95DurationMs() bool {
+	return v.data.P95DurationMs != nil
+}
+
+func (v *RequestStat) P95DurationMs() float64 {
+	if v.data.P95DurationMs == nil {
+		return 0
+	}
+	return *v.data.P95DurationMs
+}
+
+func (v *RequestStat) SetP95DurationMs(p95DurationMs float64) {
+	v.data.P95DurationMs = &p95DurationMs
+}
+
+func (v *RequestStat) HasP99DurationMs() bool {
+	return v.data.P99DurationMs != nil
+}
+
+func (v *RequestStat) P99DurationMs() float64 {
+	if v.data.P99DurationMs == nil {
+		return 0
+	}
+	return *v.data.P99DurationMs
+}
+
+func (v *RequestStat) SetP99DurationMs(p99DurationMs float64) {
+	v.data.P99DurationMs = &p99DurationMs
 }
 
 func (v *RequestStat) MarshalCBOR() ([]byte, error) {
@@ -666,6 +698,77 @@ func (v *PathStat) MarshalJSON() ([]byte, error) {
 }
 
 func (v *PathStat) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type errorBreakdownData struct {
+	StatusCode *int32   `cbor:"0,keyasint,omitempty" json:"status_code,omitempty"`
+	Count      *int64   `cbor:"1,keyasint,omitempty" json:"count,omitempty"`
+	Percentage *float64 `cbor:"2,keyasint,omitempty" json:"percentage,omitempty"`
+}
+
+type ErrorBreakdown struct {
+	data errorBreakdownData
+}
+
+func (v *ErrorBreakdown) HasStatusCode() bool {
+	return v.data.StatusCode != nil
+}
+
+func (v *ErrorBreakdown) StatusCode() int32 {
+	if v.data.StatusCode == nil {
+		return 0
+	}
+	return *v.data.StatusCode
+}
+
+func (v *ErrorBreakdown) SetStatusCode(statusCode int32) {
+	v.data.StatusCode = &statusCode
+}
+
+func (v *ErrorBreakdown) HasCount() bool {
+	return v.data.Count != nil
+}
+
+func (v *ErrorBreakdown) Count() int64 {
+	if v.data.Count == nil {
+		return 0
+	}
+	return *v.data.Count
+}
+
+func (v *ErrorBreakdown) SetCount(count int64) {
+	v.data.Count = &count
+}
+
+func (v *ErrorBreakdown) HasPercentage() bool {
+	return v.data.Percentage != nil
+}
+
+func (v *ErrorBreakdown) Percentage() float64 {
+	if v.data.Percentage == nil {
+		return 0
+	}
+	return *v.data.Percentage
+}
+
+func (v *ErrorBreakdown) SetPercentage(percentage float64) {
+	v.data.Percentage = &percentage
+}
+
+func (v *ErrorBreakdown) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *ErrorBreakdown) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *ErrorBreakdown) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *ErrorBreakdown) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
@@ -842,6 +945,7 @@ type applicationStatusData struct {
 	RequestsPerSecond *float64            `cbor:"10,keyasint,omitempty" json:"requests_per_second,omitempty"`
 	RequestStats      *[]*RequestStat     `cbor:"11,keyasint,omitempty" json:"request_stats,omitempty"`
 	TopPaths          *[]*PathStat        `cbor:"12,keyasint,omitempty" json:"top_paths,omitempty"`
+	ErrorBreakdown    *[]*ErrorBreakdown  `cbor:"13,keyasint,omitempty" json:"error_breakdown,omitempty"`
 }
 
 type ApplicationStatus struct {
@@ -1044,6 +1148,22 @@ func (v *ApplicationStatus) TopPaths() []*PathStat {
 func (v *ApplicationStatus) SetTopPaths(topPaths []*PathStat) {
 	x := slices.Clone(topPaths)
 	v.data.TopPaths = &x
+}
+
+func (v *ApplicationStatus) HasErrorBreakdown() bool {
+	return v.data.ErrorBreakdown != nil
+}
+
+func (v *ApplicationStatus) ErrorBreakdown() []*ErrorBreakdown {
+	if v.data.ErrorBreakdown == nil {
+		return nil
+	}
+	return *v.data.ErrorBreakdown
+}
+
+func (v *ApplicationStatus) SetErrorBreakdown(errorBreakdown []*ErrorBreakdown) {
+	x := slices.Clone(errorBreakdown)
+	v.data.ErrorBreakdown = &x
 }
 
 func (v *ApplicationStatus) MarshalCBOR() ([]byte, error) {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -108,6 +108,14 @@ types:
         type: float64
         index: 3
         doc: "Percentage of requests that resulted in errors (4xx/5xx)"
+      - name: p95DurationMs
+        type: float64
+        index: 4
+        doc: "95th percentile request duration in milliseconds"
+      - name: p99DurationMs
+        type: float64
+        index: 5
+        doc: "99th percentile request duration in milliseconds"
 
   - type: PathStat
     fields:
@@ -127,6 +135,21 @@ types:
         type: float64
         index: 3
         doc: "Error rate for this path"
+
+  - type: ErrorBreakdown
+    fields:
+      - name: statusCode
+        type: int32
+        index: 0
+        doc: "HTTP status code (4xx or 5xx)"
+      - name: count
+        type: int64
+        index: 1
+        doc: "Number of requests with this status code"
+      - name: percentage
+        type: float64
+        index: 2
+        doc: "Percentage of total errors"
 
   - type: PoolStatus
     fields:
@@ -206,6 +229,11 @@ types:
         element: '*PathStat'
         index: 12
         doc: "Most frequently accessed paths"
+      - name: errorBreakdown
+        type: list
+        element: '*ErrorBreakdown'
+        index: 13
+        doc: "Breakdown of errors by HTTP status code"
 
   - type: LogEntry
     fields:

--- a/servers/app/runtime.go
+++ b/servers/app/runtime.go
@@ -133,6 +133,8 @@ func (a *AppInfo) AppInfo(ctx context.Context, state *app_v1alpha.AppStatusAppIn
 				rs.SetCount(s.Count)
 				rs.SetAvgDurationMs(s.AvgDurationMs)
 				rs.SetErrorRate(s.ErrorRate)
+				rs.SetP95DurationMs(s.P95DurationMs)
+				rs.SetP99DurationMs(s.P99DurationMs)
 				requestStats = append(requestStats, &rs)
 			}
 			rai.SetRequestStats(requestStats)
@@ -153,6 +155,22 @@ func (a *AppInfo) AppInfo(ctx context.Context, state *app_v1alpha.AppStatusAppIn
 				pathStats = append(pathStats, &ps)
 			}
 			rai.SetTopPaths(pathStats)
+		}
+
+		// Get error breakdown
+		errorBreakdown, err := a.HTTP.ErrorsLastHour(name)
+		if err != nil {
+			a.Log.Warn("failed to get error breakdown", "error", err)
+		} else {
+			var errorStats []*app_v1alpha.ErrorBreakdown
+			for _, e := range errorBreakdown {
+				var es app_v1alpha.ErrorBreakdown
+				es.SetStatusCode(int32(e.StatusCode))
+				es.SetCount(e.Count)
+				es.SetPercentage(e.Percentage)
+				errorStats = append(errorStats, &es)
+			}
+			rai.SetErrorBreakdown(errorStats)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add P95/P99 response time percentiles to HTTP request metrics
- Improve error tracking with detailed breakdown by status code

## Changes

### Latency improvements
- Add P95 and P99 percentiles to HTTP request statistics
- Track percentiles in ClickHouse queries alongside averages
- Update RPC schema with p95DurationMs and p99DurationMs fields
- Display percentiles in current latency summary

### Error tracking improvements
- Add detailed error breakdown by HTTP status code
- Display error percentages only when errors exist
- Maintain existing error rate tracking and display

## Test plan
- [x] Tested in make dev environment with error-app
- [x] Verified percentiles display correctly
- [x] Confirmed error breakdown shows proper status codes
- [x] Checked formatting improvements in CLI output

<img width="656" alt="image" src="https://github.com/user-attachments/assets/b479e6df-1837-4af5-adba-126d33a5fa36" />


<img width="1081" alt="image" src="https://github.com/user-attachments/assets/e2c51b10-1caa-4c48-8dc3-1097dc2d8680" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added display of 95th and 99th percentile request durations (P95, P99) in application status outputs.
  * Introduced a new error rate timeseries chart in the CLI app status view.
  * Added detailed error breakdown by HTTP status code, including counts and percentages, both in CLI and API responses.

* **Enhancements**
  * Improved formatting of request statistics and error information in CLI outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->