### PR TITLE
Add duration type support to schemagen

### DIFF
--- a/pkg/entity/cmd/schemagen/generator.go
+++ b/pkg/entity/cmd/schemagen/generator.go
@@ -399,6 +399,16 @@ func (g *gen) attr(name string, attr *schemaAttr) {
 		simpleEncoder("Time")
 		simpleDecl("Time")
 		simpleField("time")
+	case "duration":
+		if attr.Many {
+			g.fields = append(g.fields, j.Id(fname).Index().Qual("time", "Duration").Tag(tag))
+		} else {
+			g.fields = append(g.fields, j.Id(fname).Qual("time", "Duration").Tag(tag))
+		}
+		simpleDecoder("KindDuration", "Duration")
+		simpleEncoder("Duration")
+		simpleDecl("Duration")
+		simpleField("duration")
 	case "ref":
 		g.fields = append(g.fields, j.Id(fname).Qual(top, "Id").Tag(tag))
 		simpleDecoder("KindId", "Id")

--- a/pkg/entity/schema/schema.go
+++ b/pkg/entity/schema/schema.go
@@ -250,6 +250,10 @@ func (s *SchemaBuilder) Time(name, id string, opts ...AttrOption) entity.Id {
 	return s.Attr(name, id, entity.TypeTime, opts...)
 }
 
+func (s *SchemaBuilder) Duration(name, id string, opts ...AttrOption) entity.Id {
+	return s.Attr(name, id, entity.TypeDuration, opts...)
+}
+
 func (s *SchemaBuilder) Enum(name, id string, values any, opts ...AttrOption) entity.Id {
 	opts = append(opts, AdditionalAttrs(
 		entity.Attr{ID: entity.EnumValues, Value: entity.ArrayValue(values)},


### PR DESCRIPTION
This allows schema.yml files to use 'type: duration' for fields,
which generates time.Duration fields in Go structs with proper
encoding/decoding support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for "duration" attribute fields, enabling schema generation and encoding/decoding for time durations.
  * Introduced a new method for defining duration fields in schema builders.

* **Tests**
  * Added comprehensive tests covering struct generation, encoding, decoding, JSON tagging, and integration of duration fields with other types.
  * Verified handling of multi-valued duration fields and their encoding/decoding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->