### PR TITLE
Switch to golangci-lint for code linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  # Used by golangci-lint to emit annotations that are picked up by github
+  contents: read
+  # Used by golangci-lint for only-new-issues
+  pull-requests: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -17,18 +23,11 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
-    - name: Check Go formatting
-      run: |
-        # Run go fmt and capture any files that need formatting
-        unformatted=$(go fmt ./...)
-        if [ -n "$unformatted" ]; then
-          echo "Error: The following files need to be formatted with 'go fmt':"
-          echo "$unformatted"
-          echo ""
-          echo "Please run 'go fmt ./...' to fix formatting issues."
-          exit 1
-        fi
-        echo "All Go files are properly formatted."
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: v2.2
+        only-new-issues: true
 
     - name: Check go.mod tidiness
       run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,26 @@
+version: "2"
+linters:
+  default: standard
+  exclusions:
+    warn-unused: true
+    rules:
+      - path: pkg/perf
+        linters:
+          - govet
+        text: unreachable code
+      - path: dataset/
+        linters:
+          - govet
+        text: unreachable code
+      - path: pkg/runsc/monitor
+        linters:
+          - govet
+        text: unreachable code
+      - path: pkg/entity/mock
+        linters:
+          - govet
+        text: unreachable code
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,16 @@ bin/runtime-debug:
 
 .PHONY: bin/runtime-debug
 
+lint:
+	golangci-lint run ./...
+
+.PHONY: lint
+
+lint-fix:
+	golangci-lint run --fix ./...
+
+.PHONY: lint-fix
+
 lint-changed:
 	@bash ./hack/lint-changed.sh
 

--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -2125,7 +2125,7 @@ func (v CrudClient) New(ctx context.Context, name string) (*CrudClientNewResults
 
 	var ret crudNewResultsData
 
-	err := v.Client.Call(ctx, "new", &args, &ret)
+	err := v.Call(ctx, "new", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2156,7 +2156,7 @@ func (v CrudClient) SetConfiguration(ctx context.Context, app string, configurat
 
 	var ret crudSetConfigurationResultsData
 
-	err := v.Client.Call(ctx, "setConfiguration", &args, &ret)
+	err := v.Call(ctx, "setConfiguration", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2194,7 +2194,7 @@ func (v CrudClient) GetConfiguration(ctx context.Context, app string) (*CrudClie
 
 	var ret crudGetConfigurationResultsData
 
-	err := v.Client.Call(ctx, "getConfiguration", &args, &ret)
+	err := v.Call(ctx, "getConfiguration", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2214,7 +2214,7 @@ func (v CrudClient) SetHost(ctx context.Context, app string, host string) (*Crud
 
 	var ret crudSetHostResultsData
 
-	err := v.Client.Call(ctx, "setHost", &args, &ret)
+	err := v.Call(ctx, "setHost", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2243,7 +2243,7 @@ func (v CrudClient) List(ctx context.Context) (*CrudClientListResults, error) {
 
 	var ret crudListResultsData
 
-	err := v.Client.Call(ctx, "list", &args, &ret)
+	err := v.Call(ctx, "list", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2262,7 +2262,7 @@ func (v CrudClient) Destroy(ctx context.Context, name string) (*CrudClientDestro
 
 	var ret crudDestroyResultsData
 
-	err := v.Client.Call(ctx, "destroy", &args, &ret)
+	err := v.Call(ctx, "destroy", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2409,7 +2409,7 @@ func (v UserQueryClient) WhoAmI(ctx context.Context) (*UserQueryClientWhoAmIResu
 
 	var ret userQueryWhoAmIResultsData
 
-	err := v.Client.Call(ctx, "whoAmI", &args, &ret)
+	err := v.Call(ctx, "whoAmI", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2570,7 +2570,7 @@ func (v AppStatusClient) AppInfo(ctx context.Context, application string) (*AppS
 
 	var ret appStatusAppInfoResultsData
 
-	err := v.Client.Call(ctx, "appInfo", &args, &ret)
+	err := v.Call(ctx, "appInfo", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2758,7 +2758,7 @@ func (v LogsClient) AppLogs(ctx context.Context, application string, from *stand
 
 	var ret logsAppLogsResultsData
 
-	err := v.Client.Call(ctx, "appLogs", &args, &ret)
+	err := v.Call(ctx, "appLogs", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -3333,7 +3333,7 @@ func (v DisksClient) New(ctx context.Context, name string, capacity int64) (*Dis
 
 	var ret disksNewResultsData
 
-	err := v.Client.Call(ctx, "new", &args, &ret)
+	err := v.Call(ctx, "new", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -3360,7 +3360,7 @@ func (v DisksClient) GetById(ctx context.Context, id string) (*DisksClientGetByI
 
 	var ret disksGetByIdResultsData
 
-	err := v.Client.Call(ctx, "getById", &args, &ret)
+	err := v.Call(ctx, "getById", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -3387,7 +3387,7 @@ func (v DisksClient) GetByName(ctx context.Context, name string) (*DisksClientGe
 
 	var ret disksGetByNameResultsData
 
-	err := v.Client.Call(ctx, "getByName", &args, &ret)
+	err := v.Call(ctx, "getByName", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -3416,7 +3416,7 @@ func (v DisksClient) List(ctx context.Context) (*DisksClientListResults, error) 
 
 	var ret disksListResultsData
 
-	err := v.Client.Call(ctx, "list", &args, &ret)
+	err := v.Call(ctx, "list", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -3435,7 +3435,7 @@ func (v DisksClient) Delete(ctx context.Context, id string) (*DisksClientDeleteR
 
 	var ret disksDeleteResultsData
 
-	err := v.Client.Call(ctx, "delete", &args, &ret)
+	err := v.Call(ctx, "delete", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -3853,7 +3853,7 @@ func (v AddonsClient) CreateInstance(ctx context.Context, name string, addon str
 
 	var ret addonsCreateInstanceResultsData
 
-	err := v.Client.Call(ctx, "createInstance", &args, &ret)
+	err := v.Call(ctx, "createInstance", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -3883,7 +3883,7 @@ func (v AddonsClient) ListInstances(ctx context.Context, app string) (*AddonsCli
 
 	var ret addonsListInstancesResultsData
 
-	err := v.Client.Call(ctx, "listInstances", &args, &ret)
+	err := v.Call(ctx, "listInstances", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -3903,7 +3903,7 @@ func (v AddonsClient) DeleteInstance(ctx context.Context, app string, name strin
 
 	var ret addonsDeleteInstanceResultsData
 
-	err := v.Client.Call(ctx, "deleteInstance", &args, &ret)
+	err := v.Call(ctx, "deleteInstance", &args, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -258,7 +258,7 @@ func (v StreamClient) Recv(ctx context.Context, count int32) (*StreamClientRecvR
 
 	var ret streamRecvResultsData
 
-	err := v.Client.Call(ctx, "recv", &args, &ret)
+	err := v.Call(ctx, "recv", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -445,19 +445,19 @@ func (v BuilderClient) BuildFromTar(ctx context.Context, application string, tar
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	args.data.Application = &application
 	{
-		ic, oid, c := v.Client.NewInlineCapability(stream.AdaptRecvStream[[]byte](tardata), tardata)
+		ic, oid, c := v.NewInlineCapability(stream.AdaptRecvStream[[]byte](tardata), tardata)
 		args.data.Tardata = c
 		caps[oid] = ic
 	}
 	{
-		ic, oid, c := v.Client.NewInlineCapability(stream.AdaptSendStream[*Status](status), status)
+		ic, oid, c := v.NewInlineCapability(stream.AdaptSendStream[*Status](status), status)
 		args.data.Status = c
 		caps[oid] = ic
 	}
 
 	var ret builderBuildFromTarResultsData
 
-	err := v.Client.CallWithCaps(ctx, "buildFromTar", &args, &ret, caps)
+	err := v.CallWithCaps(ctx, "buildFromTar", &args, &ret, caps)
 	if err != nil {
 		return nil, err
 	}

--- a/api/entityserver/entityserver_v1alpha/rpc.gen.go
+++ b/api/entityserver/entityserver_v1alpha/rpc.gen.go
@@ -412,7 +412,7 @@ func (v StreamClient) Recv(ctx context.Context, count int32) (*StreamClientRecvR
 
 	var ret streamRecvResultsData
 
-	err := v.Client.Call(ctx, "recv", &args, &ret)
+	err := v.Call(ctx, "recv", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1958,7 +1958,7 @@ func (v EntityAccessClient) Get(ctx context.Context, id string) (*EntityAccessCl
 
 	var ret entityAccessGetResultsData
 
-	err := v.Client.Call(ctx, "get", &args, &ret)
+	err := v.Call(ctx, "get", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1999,7 +1999,7 @@ func (v EntityAccessClient) Put(ctx context.Context, entity *Entity) (*EntityAcc
 
 	var ret entityAccessPutResultsData
 
-	err := v.Client.Call(ctx, "put", &args, &ret)
+	err := v.Call(ctx, "put", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2041,7 +2041,7 @@ func (v EntityAccessClient) PutSession(ctx context.Context, entity *Entity, sess
 
 	var ret entityAccessPutSessionResultsData
 
-	err := v.Client.Call(ctx, "put_session", &args, &ret)
+	err := v.Call(ctx, "put_session", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2071,7 +2071,7 @@ func (v EntityAccessClient) Delete(ctx context.Context, id string) (*EntityAcces
 
 	var ret entityAccessDeleteResultsData
 
-	err := v.Client.Call(ctx, "delete", &args, &ret)
+	err := v.Call(ctx, "delete", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2089,14 +2089,14 @@ func (v EntityAccessClient) WatchIndex(ctx context.Context, index entity.Attr, v
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	args.data.Index = &index
 	{
-		ic, oid, c := v.Client.NewInlineCapability(stream.AdaptSendStream[*EntityOp](values), values)
+		ic, oid, c := v.NewInlineCapability(stream.AdaptSendStream[*EntityOp](values), values)
 		args.data.Values = c
 		caps[oid] = ic
 	}
 
 	var ret entityAccessWatchIndexResultsData
 
-	err := v.Client.CallWithCaps(ctx, "watch_index", &args, &ret, caps)
+	err := v.CallWithCaps(ctx, "watch_index", &args, &ret, caps)
 	if err != nil {
 		return nil, err
 	}
@@ -2114,14 +2114,14 @@ func (v EntityAccessClient) WatchEntity(ctx context.Context, id string, updates 
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	args.data.Id = &id
 	{
-		ic, oid, c := v.Client.NewInlineCapability(stream.AdaptSendStream[*EntityOp](updates), updates)
+		ic, oid, c := v.NewInlineCapability(stream.AdaptSendStream[*EntityOp](updates), updates)
 		args.data.Updates = c
 		caps[oid] = ic
 	}
 
 	var ret entityAccessWatchEntityResultsData
 
-	err := v.Client.CallWithCaps(ctx, "watch_entity", &args, &ret, caps)
+	err := v.CallWithCaps(ctx, "watch_entity", &args, &ret, caps)
 	if err != nil {
 		return nil, err
 	}
@@ -2151,7 +2151,7 @@ func (v EntityAccessClient) List(ctx context.Context, index entity.Attr) (*Entit
 
 	var ret entityAccessListResultsData
 
-	err := v.Client.Call(ctx, "list", &args, &ret)
+	err := v.Call(ctx, "list", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2179,7 +2179,7 @@ func (v EntityAccessClient) MakeAttr(ctx context.Context, id string, value strin
 
 	var ret entityAccessMakeAttrResultsData
 
-	err := v.Client.Call(ctx, "makeAttr", &args, &ret)
+	err := v.Call(ctx, "makeAttr", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2206,7 +2206,7 @@ func (v EntityAccessClient) LookupKind(ctx context.Context, kind string) (*Entit
 
 	var ret entityAccessLookupKindResultsData
 
-	err := v.Client.Call(ctx, "lookupKind", &args, &ret)
+	err := v.Call(ctx, "lookupKind", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2233,7 +2233,7 @@ func (v EntityAccessClient) Parse(ctx context.Context, data []byte) (*EntityAcce
 
 	var ret entityAccessParseResultsData
 
-	err := v.Client.Call(ctx, "parse", &args, &ret)
+	err := v.Call(ctx, "parse", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2263,7 +2263,7 @@ func (v EntityAccessClient) Format(ctx context.Context, entity *Entity) (*Entity
 
 	var ret entityAccessFormatResultsData
 
-	err := v.Client.Call(ctx, "format", &args, &ret)
+	err := v.Call(ctx, "format", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2294,7 +2294,7 @@ func (v EntityAccessClient) CreateSession(ctx context.Context, ttl int64, usage 
 
 	var ret entityAccessCreateSessionResultsData
 
-	err := v.Client.Call(ctx, "create_session", &args, &ret)
+	err := v.Call(ctx, "create_session", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2313,7 +2313,7 @@ func (v EntityAccessClient) RevokeSession(ctx context.Context, id string) (*Enti
 
 	var ret entityAccessRevokeSessionResultsData
 
-	err := v.Client.Call(ctx, "revoke_session", &args, &ret)
+	err := v.Call(ctx, "revoke_session", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2332,7 +2332,7 @@ func (v EntityAccessClient) PingSession(ctx context.Context, id string) (*Entity
 
 	var ret entityAccessPingSessionResultsData
 
-	err := v.Client.Call(ctx, "ping_session", &args, &ret)
+	err := v.Call(ctx, "ping_session", &args, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/api/exec/exec_v1alpha/rpc.gen.go
+++ b/api/exec/exec_v1alpha/rpc.gen.go
@@ -394,24 +394,24 @@ func (v SandboxExecClient) Exec(ctx context.Context, category string, value stri
 	args.data.Command = &command
 	args.data.Options = options
 	{
-		ic, oid, c := v.Client.NewInlineCapability(stream.AdaptRecvStream[[]byte](input), input)
+		ic, oid, c := v.NewInlineCapability(stream.AdaptRecvStream[[]byte](input), input)
 		args.data.Input = c
 		caps[oid] = ic
 	}
 	{
-		ic, oid, c := v.Client.NewInlineCapability(stream.AdaptSendStream[[]byte](output), output)
+		ic, oid, c := v.NewInlineCapability(stream.AdaptSendStream[[]byte](output), output)
 		args.data.Output = c
 		caps[oid] = ic
 	}
 	{
-		ic, oid, c := v.Client.NewInlineCapability(stream.AdaptRecvStream[*WindowSize](window_updates), window_updates)
+		ic, oid, c := v.NewInlineCapability(stream.AdaptRecvStream[*WindowSize](window_updates), window_updates)
 		args.data.WindowUpdates = c
 		caps[oid] = ic
 	}
 
 	var ret sandboxExecExecResultsData
 
-	err := v.Client.CallWithCaps(ctx, "exec", &args, &ret, caps)
+	err := v.CallWithCaps(ctx, "exec", &args, &ret, caps)
 	if err != nil {
 		return nil, err
 	}

--- a/api/metric/metric_v1alpha/rpc.gen.go
+++ b/api/metric/metric_v1alpha/rpc.gen.go
@@ -364,7 +364,7 @@ func (v SandboxMetricsClient) Snapshot(ctx context.Context, sandbox string) (*Sa
 
 	var ret sandboxMetricsSnapshotResultsData
 
-	err := v.Client.Call(ctx, "snapshot", &args, &ret)
+	err := v.Call(ctx, "snapshot", &args, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/api/rpc.gen.go
+++ b/api/rpc.gen.go
@@ -861,7 +861,7 @@ func (v UserQueryClient) WhoAmI(ctx context.Context) (*UserQueryClientWhoAmIResu
 
 	var ret userQueryWhoAmIResultsData
 
-	err := v.Client.Call(ctx, "whoAmI", &args, &ret)
+	err := v.Call(ctx, "whoAmI", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1022,7 +1022,7 @@ func (v AppInfoClient) AppInfo(ctx context.Context, application string) (*AppInf
 
 	var ret appInfoAppInfoResultsData
 
-	err := v.Client.Call(ctx, "appInfo", &args, &ret)
+	err := v.Call(ctx, "appInfo", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1210,7 +1210,7 @@ func (v LogsClient) AppLogs(ctx context.Context, application string, from *stand
 
 	var ret logsAppLogsResultsData
 
-	err := v.Client.Call(ctx, "appLogs", &args, &ret)
+	err := v.Call(ctx, "appLogs", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1785,7 +1785,7 @@ func (v DisksClient) New(ctx context.Context, name string, capacity int64) (*Dis
 
 	var ret disksNewResultsData
 
-	err := v.Client.Call(ctx, "new", &args, &ret)
+	err := v.Call(ctx, "new", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1812,7 +1812,7 @@ func (v DisksClient) GetById(ctx context.Context, id string) (*DisksClientGetByI
 
 	var ret disksGetByIdResultsData
 
-	err := v.Client.Call(ctx, "getById", &args, &ret)
+	err := v.Call(ctx, "getById", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1839,7 +1839,7 @@ func (v DisksClient) GetByName(ctx context.Context, name string) (*DisksClientGe
 
 	var ret disksGetByNameResultsData
 
-	err := v.Client.Call(ctx, "getByName", &args, &ret)
+	err := v.Call(ctx, "getByName", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1868,7 +1868,7 @@ func (v DisksClient) List(ctx context.Context) (*DisksClientListResults, error) 
 
 	var ret disksListResultsData
 
-	err := v.Client.Call(ctx, "list", &args, &ret)
+	err := v.Call(ctx, "list", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1887,7 +1887,7 @@ func (v DisksClient) Delete(ctx context.Context, id string) (*DisksClientDeleteR
 
 	var ret disksDeleteResultsData
 
-	err := v.Client.Call(ctx, "delete", &args, &ret)
+	err := v.Call(ctx, "delete", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2305,7 +2305,7 @@ func (v AddonsClient) CreateInstance(ctx context.Context, name string, addon str
 
 	var ret addonsCreateInstanceResultsData
 
-	err := v.Client.Call(ctx, "createInstance", &args, &ret)
+	err := v.Call(ctx, "createInstance", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2335,7 +2335,7 @@ func (v AddonsClient) ListInstances(ctx context.Context, app string) (*AddonsCli
 
 	var ret addonsListInstancesResultsData
 
-	err := v.Client.Call(ctx, "listInstances", &args, &ret)
+	err := v.Call(ctx, "listInstances", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2355,7 +2355,7 @@ func (v AddonsClient) DeleteInstance(ctx context.Context, app string, name strin
 
 	var ret addonsDeleteInstanceResultsData
 
-	err := v.Client.Call(ctx, "deleteInstance", &args, &ret)
+	err := v.Call(ctx, "deleteInstance", &args, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -243,7 +243,7 @@ var Meter = spinner.Spinner{
 		line(" ▰▰"),
 		line("  ▰"),
 	},
-	FPS: time.Second / 7, //nolint:gomnd
+	FPS: time.Second / 7, //nolint:mnd
 }
 
 func initialModel(update chan string, transfers chan transferUpdate) *deployInfo {

--- a/components/ocireg/registry.go
+++ b/components/ocireg/registry.go
@@ -119,13 +119,14 @@ func (h *RegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		name := strings.Join(parts[:len(parts)-2], "/")
 		reference := parts[len(parts)-1]
 
-		if r.Method == http.MethodGet {
+		switch r.Method {
+		case http.MethodGet:
 			h.getManifest(w, r, name, reference)
-		} else if r.Method == http.MethodPut {
+		case http.MethodPut:
 			h.putManifest(w, r, name, reference)
-		} else if r.Method == http.MethodHead {
+		case http.MethodHead:
 			h.headManifest(w, r, name, reference)
-		} else {
+		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
 
@@ -134,11 +135,12 @@ func (h *RegistryHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		name := strings.Join(parts[:len(parts)-2], "/")
 		digest := parts[len(parts)-1]
 
-		if r.Method == http.MethodGet {
+		switch r.Method {
+		case http.MethodGet:
 			h.getBlob(w, r, name, digest)
-		} else if r.Method == http.MethodHead {
+		case http.MethodHead:
 			h.headBlob(w, r, name, digest)
-		} else {
+		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
 

--- a/components/scheduler/scheduler.go
+++ b/components/scheduler/scheduler.go
@@ -187,7 +187,7 @@ func (s *Scheduler) assignSandbox(ctx context.Context, ent *entity.Entity, eac *
 		},
 	}
 
-	err := sandbox.Entity.Update(se.Encode())
+	err := sandbox.Update(se.Encode())
 	if err != nil {
 		s.log.Error("failed to update sandbox entity", "error", err)
 		return err

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -634,7 +634,9 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 	co.Status = compute.RUNNING
 
 	// The controller will detect the updates and sync them back
-	meta.Update(co.Encode())
+	if err := meta.Update(co.Encode()); err != nil {
+		return fmt.Errorf("failed to update entity metadata: %w", err)
+	}
 
 	err = c.updateServices(ctx, co, meta, ep)
 	if err != nil {

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -634,7 +634,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 	co.Status = compute.RUNNING
 
 	// The controller will detect the updates and sync them back
-	meta.Entity.Update(co.Encode())
+	meta.Update(co.Encode())
 
 	err = c.updateServices(ctx, co, meta, ep)
 	if err != nil {

--- a/dataset/rpc.gen.go
+++ b/dataset/rpc.gen.go
@@ -714,7 +714,7 @@ func (v SegmentReaderClient) ReadAt(ctx context.Context, offset int64, size int6
 
 	var ret segmentReaderReadAtResultsData
 
-	err := v.Client.Call(ctx, "readAt", &args, &ret)
+	err := v.Call(ctx, "readAt", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -732,7 +732,7 @@ func (v SegmentReaderClient) Close(ctx context.Context) (*SegmentReaderClientClo
 
 	var ret segmentReaderCloseResultsData
 
-	err := v.Client.Call(ctx, "close", &args, &ret)
+	err := v.Call(ctx, "close", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -758,7 +758,7 @@ func (v SegmentReaderClient) Layout(ctx context.Context) (*SegmentReaderClientLa
 
 	var ret segmentReaderLayoutResultsData
 
-	err := v.Client.Call(ctx, "layout", &args, &ret)
+	err := v.Call(ctx, "layout", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +784,7 @@ func (v SegmentReaderClient) DataPath(ctx context.Context) (*SegmentReaderClient
 
 	var ret segmentReaderDataPathResultsData
 
-	err := v.Client.Call(ctx, "dataPath", &args, &ret)
+	err := v.Call(ctx, "dataPath", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1046,7 +1046,7 @@ func (v SegmentWriterClient) WriteAt(ctx context.Context, offset int64, data []b
 
 	var ret segmentWriterWriteAtResultsData
 
-	err := v.Client.Call(ctx, "writeAt", &args, &ret)
+	err := v.Call(ctx, "writeAt", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1064,7 +1064,7 @@ func (v SegmentWriterClient) Close(ctx context.Context) (*SegmentWriterClientClo
 
 	var ret segmentWriterCloseResultsData
 
-	err := v.Client.Call(ctx, "close", &args, &ret)
+	err := v.Call(ctx, "close", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1637,7 +1637,7 @@ func (v DataSetClient) GetInfo(ctx context.Context) (*DataSetClientGetInfoResult
 
 	var ret dataSetGetInfoResultsData
 
-	err := v.Client.Call(ctx, "getInfo", &args, &ret)
+	err := v.Call(ctx, "getInfo", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1666,7 +1666,7 @@ func (v DataSetClient) ListSegments(ctx context.Context) (*DataSetClientListSegm
 
 	var ret dataSetListSegmentsResultsData
 
-	err := v.Client.Call(ctx, "listSegments", &args, &ret)
+	err := v.Call(ctx, "listSegments", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1691,7 +1691,7 @@ func (v DataSetClient) ReadSegment(ctx context.Context, id string) (*DataSetClie
 
 	var ret dataSetReadSegmentResultsData
 
-	err := v.Client.Call(ctx, "readSegment", &args, &ret)
+	err := v.Call(ctx, "readSegment", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1717,7 +1717,7 @@ func (v DataSetClient) NewSegment(ctx context.Context, id string, layout *Segmen
 
 	var ret dataSetNewSegmentResultsData
 
-	err := v.Client.Call(ctx, "newSegment", &args, &ret)
+	err := v.Call(ctx, "newSegment", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1748,7 +1748,7 @@ func (v DataSetClient) ReadBytes(ctx context.Context, offset int64, count int64)
 
 	var ret dataSetReadBytesResultsData
 
-	err := v.Client.Call(ctx, "readBytes", &args, &ret)
+	err := v.Call(ctx, "readBytes", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2202,7 +2202,7 @@ func (v DataSetsClient) List(ctx context.Context) (*DataSetsClientListResults, e
 
 	var ret dataSetsListResultsData
 
-	err := v.Client.Call(ctx, "list", &args, &ret)
+	err := v.Call(ctx, "list", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2227,7 +2227,7 @@ func (v DataSetsClient) Create(ctx context.Context, info *DataSetInfo) (*DataSet
 
 	var ret dataSetsCreateResultsData
 
-	err := v.Client.Call(ctx, "create", &args, &ret)
+	err := v.Call(ctx, "create", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2252,7 +2252,7 @@ func (v DataSetsClient) Get(ctx context.Context, id string) (*DataSetsClientGetR
 
 	var ret dataSetsGetResultsData
 
-	err := v.Client.Call(ctx, "get", &args, &ret)
+	err := v.Call(ctx, "get", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -2271,7 +2271,7 @@ func (v DataSetsClient) Delete(ctx context.Context, id string) (*DataSetsClientD
 
 	var ret dataSetsDeleteResultsData
 
-	err := v.Client.Call(ctx, "delete", &args, &ret)
+	err := v.Call(ctx, "delete", &args, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/disk/rpc.gen.go
+++ b/disk/rpc.gen.go
@@ -338,7 +338,7 @@ func (v DiskManagementClient) Unmount(ctx context.Context, id string) (*DiskMana
 
 	var ret diskManagementUnmountResultsData
 
-	err := v.Client.Call(ctx, "unmount", &args, &ret)
+	err := v.Call(ctx, "unmount", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ func (v DiskManagementClient) Status(ctx context.Context, id string) (*DiskManag
 
 	var ret diskManagementStatusResultsData
 
-	err := v.Client.Call(ctx, "status", &args, &ret)
+	err := v.Call(ctx, "status", &args, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/disk/run.go
+++ b/disk/run.go
@@ -159,7 +159,7 @@ func (r *Runner) Start(ctx context.Context, name, fsPath, bindAddr string) error
 		err := cmd.Run()
 		if err != nil {
 			if ee, ok := err.(*exec.ExitError); ok {
-				if ee.ProcessState.ExitCode() > 2 {
+				if ee.ExitCode() > 2 {
 					return errors.Wrapf(err, "fscking")
 				}
 			}
@@ -376,7 +376,7 @@ func (r *Runner) Run(ctx context.Context, name, fsPath, bindAddr string) error {
 		err := cmd.Run()
 		if err != nil {
 			if ee, ok := err.(*exec.ExitError); ok {
-				if ee.ProcessState.ExitCode() > 2 {
+				if ee.ExitCode() > 2 {
 					return errors.Wrapf(err, "fscking")
 				}
 			}

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
         devShells.default = pkgs.mkShell {
           packages = [
             pkgs.go_1_24
+            pkgs.golangci-lint
             dagger.packages.${system}.dagger
           ];
 

--- a/hack/lint-changed.sh
+++ b/hack/lint-changed.sh
@@ -1,23 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 
-echo "Running go fmt on changed files..."
-git diff --name-only HEAD | grep '\.go$' | xargs -r -n1 go fmt
-git diff --cached --name-only | grep '\.go$' | xargs -r -n1 go fmt
-
-echo "Running go vet on changed packages..."
-# Get unique package directories from changed files
-PACKAGES=$(
-    {
-        git diff --name-only HEAD | grep '\.go$' | xargs -r dirname
-        git diff --cached --name-only | grep '\.go$' | xargs -r dirname
-    } | sort -u | sed 's|^|./|'
-)
-
-if [ -n "$PACKAGES" ]; then
-    echo "Vetting packages: $PACKAGES"
-    echo $PACKAGES | xargs go vet
-fi
+echo "Running linters on changed files..."
+golangci-lint run --new-from-rev=HEAD --fix
 
 echo "Running go mod tidy..."
 go mod tidy

--- a/lsvd/extent_map.go
+++ b/lsvd/extent_map.go
@@ -181,7 +181,7 @@ func (e *Iterator) CompactValue() compactPE {
 }
 
 func (e *Iterator) CompactValuePtr() *compactPE {
-	return e.ForwardIterator.ValuePtr()
+	return e.ValuePtr()
 }
 
 func (e *ExtentMap) Populate(log *slog.Logger, o *ExtentMap, diskId uint16) error {

--- a/pkg/cel/cidr.go
+++ b/pkg/cel/cidr.go
@@ -42,7 +42,7 @@ func (d CIDR) ConvertToNative(typeDesc reflect.Type) (any, error) {
 		return d.Prefix, nil
 	}
 	if reflect.TypeOf("").AssignableTo(typeDesc) {
-		return d.Prefix.String(), nil
+		return d.String(), nil
 	}
 	return nil, fmt.Errorf("type conversion error from 'CIDR' to '%v'", typeDesc)
 }
@@ -55,7 +55,7 @@ func (d CIDR) ConvertToType(typeVal ref.Type) ref.Val {
 	case types.TypeType:
 		return CIDRType
 	case types.StringType:
-		return types.String(d.Prefix.String())
+		return types.String(d.String())
 	}
 	return types.NewErr("type conversion error from '%s' to '%s'", CIDRType, typeVal)
 }
@@ -83,5 +83,5 @@ func (d CIDR) Value() any {
 // Size returns the size of the CIDR prefix address in bytes.
 // Used in the size estimation of the runtime cost.
 func (d CIDR) Size() ref.Val {
-	return types.Int(int(math.Ceil(float64(d.Prefix.Bits()) / 8)))
+	return types.Int(int(math.Ceil(float64(d.Bits()) / 8)))
 }

--- a/pkg/cel/ip.go
+++ b/pkg/cel/ip.go
@@ -42,7 +42,7 @@ func (d IP) ConvertToNative(typeDesc reflect.Type) (any, error) {
 		return d.Addr, nil
 	}
 	if reflect.TypeOf("").AssignableTo(typeDesc) {
-		return d.Addr.String(), nil
+		return d.String(), nil
 	}
 	return nil, fmt.Errorf("type conversion error from 'IP' to '%v'", typeDesc)
 }
@@ -55,7 +55,7 @@ func (d IP) ConvertToType(typeVal ref.Type) ref.Val {
 	case types.TypeType:
 		return IPType
 	case types.StringType:
-		return types.String(d.Addr.String())
+		return types.String(d.String())
 	}
 	return types.NewErr("type conversion error from '%s' to '%s'", IPType, typeVal)
 }
@@ -82,5 +82,5 @@ func (d IP) Value() any {
 // Size returns the size of the IP address in bytes.
 // Used in the size estimation of the runtime cost.
 func (d IP) Size() ref.Val {
-	return types.Int(int(math.Ceil(float64(d.Addr.BitLen()) / 8)))
+	return types.Int(int(math.Ceil(float64(d.BitLen()) / 8)))
 }

--- a/pkg/cel/library/cidr.go
+++ b/pkg/cel/library/cidr.go
@@ -187,7 +187,7 @@ func cidrToString(arg ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(arg)
 	}
 
-	return types.String(cidr.Prefix.String())
+	return types.String(cidr.String())
 }
 
 func cidrContainsIPString(arg ref.Val, other ref.Val) ref.Val {
@@ -223,8 +223,8 @@ func cidrContainsCIDR(arg ref.Val, other ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(other)
 	}
 
-	equalMasked := cidr.Prefix.Masked() == netip.PrefixFrom(containsCIDR.Prefix.Addr(), cidr.Prefix.Bits())
-	return types.Bool(equalMasked && cidr.Prefix.Bits() <= containsCIDR.Prefix.Bits())
+	equalMasked := cidr.Masked() == netip.PrefixFrom(containsCIDR.Addr(), cidr.Bits())
+	return types.Bool(equalMasked && cidr.Bits() <= containsCIDR.Bits())
 }
 
 func prefixLength(arg ref.Val) ref.Val {
@@ -233,7 +233,7 @@ func prefixLength(arg ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(arg)
 	}
 
-	return types.Int(cidr.Prefix.Bits())
+	return types.Int(cidr.Bits())
 }
 
 func isCIDR(arg ref.Val) ref.Val {
@@ -253,7 +253,7 @@ func cidrToIP(arg ref.Val) ref.Val {
 	}
 
 	return mcel.IP{
-		Addr: cidr.Prefix.Addr(),
+		Addr: cidr.Addr(),
 	}
 }
 
@@ -263,7 +263,7 @@ func masked(arg ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(arg)
 	}
 
-	maskedCIDR := cidr.Prefix.Masked()
+	maskedCIDR := cidr.Masked()
 	return mcel.CIDR{
 		Prefix: maskedCIDR,
 	}

--- a/pkg/cel/library/ip.go
+++ b/pkg/cel/library/ip.go
@@ -215,7 +215,7 @@ func ipToString(arg ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(arg)
 	}
 
-	return types.String(ip.Addr.String())
+	return types.String(ip.String())
 }
 
 func family(arg ref.Val) ref.Val {
@@ -225,12 +225,12 @@ func family(arg ref.Val) ref.Val {
 	}
 
 	switch {
-	case ip.Addr.Is4():
+	case ip.Is4():
 		return types.Int(4)
-	case ip.Addr.Is6():
+	case ip.Is6():
 		return types.Int(6)
 	default:
-		return types.NewErr("IP address %q is not an IPv4 or IPv6 address", ip.Addr.String())
+		return types.NewErr("IP address %q is not an IPv4 or IPv6 address", ip.String())
 	}
 }
 
@@ -268,7 +268,7 @@ func isUnspecified(arg ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(arg)
 	}
 
-	return types.Bool(ip.Addr.IsUnspecified())
+	return types.Bool(ip.IsUnspecified())
 }
 
 func isLoopback(arg ref.Val) ref.Val {
@@ -277,7 +277,7 @@ func isLoopback(arg ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(arg)
 	}
 
-	return types.Bool(ip.Addr.IsLoopback())
+	return types.Bool(ip.IsLoopback())
 }
 
 func isLinkLocalMulticast(arg ref.Val) ref.Val {
@@ -286,7 +286,7 @@ func isLinkLocalMulticast(arg ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(arg)
 	}
 
-	return types.Bool(ip.Addr.IsLinkLocalMulticast())
+	return types.Bool(ip.IsLinkLocalMulticast())
 }
 
 func isLinkLocalUnicast(arg ref.Val) ref.Val {
@@ -295,7 +295,7 @@ func isLinkLocalUnicast(arg ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(arg)
 	}
 
-	return types.Bool(ip.Addr.IsLinkLocalUnicast())
+	return types.Bool(ip.IsLinkLocalUnicast())
 }
 
 func isGlobalUnicast(arg ref.Val) ref.Val {
@@ -304,7 +304,7 @@ func isGlobalUnicast(arg ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(arg)
 	}
 
-	return types.Bool(ip.Addr.IsGlobalUnicast())
+	return types.Bool(ip.IsGlobalUnicast())
 }
 
 // parseIPAddr parses a string into an IP address.

--- a/pkg/cel/url.go
+++ b/pkg/cel/url.go
@@ -44,7 +44,7 @@ func (d URL) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
 		return d.URL, nil
 	}
 	if reflect.TypeOf("").AssignableTo(typeDesc) {
-		return d.URL.String(), nil
+		return d.String(), nil
 	}
 	return nil, fmt.Errorf("type conversion error from 'URL' to '%v'", typeDesc)
 }
@@ -66,7 +66,7 @@ func (d URL) Equal(other ref.Val) ref.Val {
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(other)
 	}
-	return types.Bool(d.URL.String() == otherDur.URL.String())
+	return types.Bool(d.String() == otherDur.String())
 }
 
 // Type implements ref.Val.Type.

--- a/pkg/cel/value_test.go
+++ b/pkg/cel/value_test.go
@@ -85,7 +85,7 @@ func TestListValueAdd(t *testing.T) {
 	llv.Append(testValue(t, 4, lv))
 	lov := NewListValue()
 	lov.Append(testValue(t, 5, ov))
-	var v traits.Lister = llv.Add(lov).(traits.Lister)
+	var v = llv.Add(lov).(traits.Lister)
 	if v.Size() != types.Int(2) {
 		t.Errorf("got list size %d, wanted 2", v.Size())
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -372,7 +372,7 @@ func TestAdaptController_WithUpdateMethod(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify calls
-	assert.Equal(t, []string{"test1"}, updatingController.BasicController.CreateCalls)
+	assert.Equal(t, []string{"test1"}, updatingController.CreateCalls)
 	assert.Equal(t, []string{"test1"}, updatingController.UpdateCalls)
-	assert.Empty(t, updatingController.BasicController.DeleteCalls)
+	assert.Empty(t, updatingController.DeleteCalls)
 }

--- a/pkg/entity/attr.go
+++ b/pkg/entity/attr.go
@@ -941,6 +941,8 @@ func (v Value) append(dst []byte) []byte {
 
 // append appends a text representation of v to dst.
 // v is formatted as with fmt.Sprint.
+//
+//nolint:errcheck
 func (v Value) sum(w io.Writer) {
 	switch v.Kind() {
 	case KindString:

--- a/pkg/entity/attr.go
+++ b/pkg/entity/attr.go
@@ -960,7 +960,7 @@ func (v Value) sum(w io.Writer) {
 		binary.BigEndian.PutUint64(b[:], uint64(v.time().UnixNano()))
 		w.Write(b[:])
 	case KindId, KindKeyword, KindAny:
-		w.Write([]byte(fmt.Sprint(v.any)))
+		fmt.Fprint(w, v.any)
 	case KindComponent:
 		for _, a := range v.Component().Attrs {
 			a.Sum(w)

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -326,7 +326,7 @@ func (s *EtcdStore) GetEntity(ctx context.Context, id Id) (*Entity, error) {
 	}
 
 	if resp.Kvs[0].Lease != 0 {
-		ttlr, err := s.client.Lease.TimeToLive(ctx, clientv3.LeaseID(resp.Kvs[0].Lease))
+		ttlr, err := s.client.TimeToLive(ctx, clientv3.LeaseID(resp.Kvs[0].Lease))
 		if err == nil {
 			entity.Attrs = append(entity.Attrs, Duration(TTL, time.Duration(ttlr.TTL)*time.Second))
 		}
@@ -843,7 +843,7 @@ func (s *EtcdStore) ListIndex(ctx context.Context, attr Attr) ([]Id, error) {
 
 		id := attr.Value.Id()
 
-		gr, err := s.client.KV.Get(ctx, s.buildKey(id), clientv3.WithCountOnly())
+		gr, err := s.client.Get(ctx, s.buildKey(id), clientv3.WithCountOnly())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/grunge/grunge.go
+++ b/pkg/grunge/grunge.go
@@ -100,7 +100,7 @@ func (n *Network) SetupConfig(ctx context.Context, v4, v6 netip.Prefix) error {
 
 	n.log.Info("Setting up config", "key", key, "value", string(cfg))
 
-	_, err = n.ec.KV.Put(ctx, key, string(cfg))
+	_, err = n.ec.Put(ctx, key, string(cfg))
 	return err
 }
 

--- a/pkg/hey/requester/print.go
+++ b/pkg/hey/requester/print.go
@@ -87,7 +87,7 @@ func histogram(buckets []Bucket) string {
 		if max > 0 {
 			barLen = (buckets[i].Count*40 + max/2) / max
 		}
-		res.WriteString(fmt.Sprintf("  %4.3f [%v]\t|%v\n", buckets[i].Mark, buckets[i].Count, strings.Repeat(barChar, barLen)))
+		fmt.Fprintf(res, "  %4.3f [%v]\t|%v\n", buckets[i].Mark, buckets[i].Count, strings.Repeat(barChar, barLen))
 	}
 	return res.String()
 }

--- a/pkg/perf/perf_test.go
+++ b/pkg/perf/perf_test.go
@@ -173,7 +173,7 @@ type perfTestEnv struct {
 }
 
 func (env *perfTestEnv) capSysAdmin() bool {
-	env.cap.Once.Do(env.initCap)
+	env.cap.Do(env.initCap)
 	return env.cap.sysadmin
 }
 
@@ -210,7 +210,7 @@ func (env *perfTestEnv) initCap() {
 }
 
 func (env *perfTestEnv) paranoidLevel() int {
-	env.paranoid.Once.Do(env.initParanoid)
+	env.paranoid.Do(env.initParanoid)
 	return env.paranoid.value
 }
 
@@ -244,12 +244,12 @@ func (env *perfTestEnv) initTracefs() {
 }
 
 func (env *perfTestEnv) tracefsMounted() bool {
-	env.tracefs.Once.Do(env.initTracefs)
+	env.tracefs.Do(env.initTracefs)
 	return env.tracefs.mounted
 }
 
 func (env *perfTestEnv) tracefsReadable() (bool, error) {
-	env.tracefs.Once.Do(env.initTracefs)
+	env.tracefs.Do(env.initTracefs)
 	return env.tracefs.readable, env.tracefs.readErr
 }
 

--- a/pkg/perf/record.go
+++ b/pkg/perf/record.go
@@ -572,7 +572,7 @@ func (mr *MmapRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 // Executable returns a boolean indicating whether the mapping is executable.
 func (mr *MmapRecord) Executable() bool {
 	// The data bit is set when the mapping is _not_ executable.
-	return mr.RecordHeader.Misc&mmapDataBit == 0
+	return mr.Misc&mmapDataBit == 0
 }
 
 // LostRecord (PERF_RECORD_LOST) indicates when events are lost.
@@ -618,7 +618,7 @@ const commExecBit = 1 << 13
 // WasExec returns a boolean indicating whether a process name change
 // was caused by an exec(2) system call.
 func (cr *CommRecord) WasExec() bool {
-	return cr.RecordHeader.Misc&(commExecBit) != 0
+	return cr.Misc&(commExecBit) != 0
 }
 
 // ExitRecord (PERF_RECORD_EXIT) indicates a process exit event.
@@ -880,7 +880,7 @@ const exactIPBit = 1 << 14
 // ExactIP indicates that sr.IP points to the actual instruction that
 // triggered the event. See also Options.PreciseIP.
 func (sr *SampleRecord) ExactIP() bool {
-	return sr.RecordHeader.Misc&exactIPBit != 0
+	return sr.Misc&exactIPBit != 0
 }
 
 // SampleGroupRecord indicates a sample from an event group.
@@ -1012,7 +1012,7 @@ func (sr *SampleGroupRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 // ExactIP indicates that sr.IP points to the actual instruction that
 // triggered the event. See also Options.PreciseIP.
 func (sr *SampleGroupRecord) ExactIP() bool {
-	return sr.RecordHeader.Misc&exactIPBit != 0
+	return sr.Misc&exactIPBit != 0
 }
 
 // BranchEntry is a sampled branch.
@@ -1098,7 +1098,7 @@ func (mr *Mmap2Record) DecodeFrom(raw *RawRecord, ev *Event) error {
 // Executable returns a boolean indicating whether the mapping is executable.
 func (mr *Mmap2Record) Executable() bool {
 	// The data bit is set when the mapping is _not_ executable.
-	return mr.RecordHeader.Misc&mmapDataBit == 0
+	return mr.Misc&mmapDataBit == 0
 }
 
 // AuxRecord (PERF_RECORD_AUX) reports that new data is available in the
@@ -1196,12 +1196,12 @@ const switchOutPreemptBit = 1 << 14
 // Out returns a boolean indicating whether the context switch was
 // out of the current process, or into the current process.
 func (sr *SwitchRecord) Out() bool {
-	return sr.RecordHeader.Misc&switchOutBit != 0
+	return sr.Misc&switchOutBit != 0
 }
 
 // Preempted indicates whether the thread was preempted in TASK_RUNNING state.
 func (sr *SwitchRecord) Preempted() bool {
-	return sr.RecordHeader.Misc&switchOutPreemptBit != 0
+	return sr.Misc&switchOutPreemptBit != 0
 }
 
 // SwitchCPUWideRecord (PERF_RECORD_SWITCH_CPU_WIDE) indicates a context
@@ -1226,12 +1226,12 @@ func (sr *SwitchCPUWideRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 // Out returns a boolean indicating whether the context switch was
 // out of the current process, or into the current process.
 func (sr *SwitchCPUWideRecord) Out() bool {
-	return sr.RecordHeader.Misc&switchOutBit != 0
+	return sr.Misc&switchOutBit != 0
 }
 
 // Preempted indicates whether the thread was preempted in TASK_RUNNING state.
 func (sr *SwitchCPUWideRecord) Preempted() bool {
-	return sr.RecordHeader.Misc&switchOutPreemptBit != 0
+	return sr.Misc&switchOutPreemptBit != 0
 }
 
 // NamespacesRecord (PERF_RECORD_NAMESPACES) describes the namespaces of a

--- a/pkg/progress/progressui/display.go
+++ b/pkg/progress/progressui/display.go
@@ -639,10 +639,8 @@ func (t *trace) triggerVertexEvent(v *client.Vertex) {
 		old = *v
 	}
 
-	changed := false
-	if v.Digest != old.Digest {
-		changed = true
-	}
+	changed := v.Digest != old.Digest
+
 	if v.Name != old.Name {
 		changed = true
 	}
@@ -725,7 +723,7 @@ func (t *trace) update(s *client.SolveStatus, termWidth int) {
 			t.vertexes = append(t.vertexes, t.byDigest[v.Digest])
 		}
 		// allow a duplicate initial vertex that shouldn't reset state
-		if !(prev != nil && prev.isStarted() && v.Started == nil) {
+		if prev == nil || !prev.isStarted() || v.Started != nil {
 			t.byDigest[v.Digest].Vertex = v
 		}
 		if v.Started != nil {

--- a/pkg/rpc/etcdreg/etcdreg.go
+++ b/pkg/rpc/etcdreg/etcdreg.go
@@ -148,6 +148,7 @@ func (r *ActorRegistry) Register(ctx context.Context, name string, iface *rpc.In
 	owned := r.acquirePath(ctx, name, lr.ID)
 
 	go func() {
+		//nolint:errcheck
 		defer r.ec.Revoke(ctx, lr.ID)
 
 		ctx, cancel := context.WithCancel(ctx)

--- a/pkg/rpc/example/rpc.go
+++ b/pkg/rpc/example/rpc.go
@@ -412,7 +412,7 @@ func (v MeterClient) ReadTemperature(ctx context.Context, name string) (*MeterCl
 
 	var ret meterReadTemperatureResultsData
 
-	err := v.Client.Call(ctx, "readTemperature", &args, &ret)
+	err := v.Call(ctx, "readTemperature", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -437,7 +437,7 @@ func (v MeterClient) GetSetter(ctx context.Context, name string) (*MeterClientGe
 
 	var ret meterGetSetterResultsData
 
-	err := v.Client.Call(ctx, "getSetter", &args, &ret)
+	err := v.Call(ctx, "getSetter", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +601,7 @@ func (v SetTempClient) SetTemp(ctx context.Context, temp int32) (*SetTempClientS
 
 	var ret setTempSetTempResultsData
 
-	err := v.Client.Call(ctx, "setTemp", &args, &ret)
+	err := v.Call(ctx, "setTemp", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -745,7 +745,7 @@ func (v UpdateReceiverClient) Update(ctx context.Context, reading *Reading) (*Up
 
 	var ret updateReceiverUpdateResultsData
 
-	err := v.Client.Call(ctx, "update", &args, &ret)
+	err := v.Call(ctx, "update", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -890,14 +890,14 @@ func (v MeterUpdatesClient) RegisterUpdates(ctx context.Context, recv UpdateRece
 	args := MeterUpdatesRegisterUpdatesArgs{}
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	{
-		ic, oid, c := v.Client.NewInlineCapability(AdaptUpdateReceiver(recv), recv)
+		ic, oid, c := v.NewInlineCapability(AdaptUpdateReceiver(recv), recv)
 		args.data.Recv = c
 		caps[oid] = ic
 	}
 
 	var ret meterUpdatesRegisterUpdatesResultsData
 
-	err := v.Client.CallWithCaps(ctx, "registerUpdates", &args, &ret, caps)
+	err := v.CallWithCaps(ctx, "registerUpdates", &args, &ret, caps)
 	if err != nil {
 		return nil, err
 	}
@@ -1042,14 +1042,14 @@ func (v AdjustTempClient) Adjust(ctx context.Context, setter SetTemp) (*AdjustTe
 	args := AdjustTempAdjustArgs{}
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	{
-		ic, oid, c := v.Client.NewInlineCapability(AdaptSetTemp(setter), setter)
+		ic, oid, c := v.NewInlineCapability(AdaptSetTemp(setter), setter)
 		args.data.Setter = c
 		caps[oid] = ic
 	}
 
 	var ret adjustTempAdjustResultsData
 
-	err := v.Client.CallWithCaps(ctx, "adjust", &args, &ret, caps)
+	err := v.CallWithCaps(ctx, "adjust", &args, &ret, caps)
 	if err != nil {
 		return nil, err
 	}
@@ -1196,7 +1196,7 @@ func (v SetTempGClient[T]) SetTemp(ctx context.Context, temp T) (*SetTempGClient
 
 	var ret setTempGSetTempResultsData[T]
 
-	err := v.Client.Call(ctx, "setTemp", &args, &ret)
+	err := v.Call(ctx, "setTemp", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1341,14 +1341,14 @@ func (v EmitTempsClient) Emit(ctx context.Context, emitter stream.SendStream[flo
 	args := EmitTempsEmitArgs{}
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	{
-		ic, oid, c := v.Client.NewInlineCapability(stream.AdaptSendStream[float32](emitter), emitter)
+		ic, oid, c := v.NewInlineCapability(stream.AdaptSendStream[float32](emitter), emitter)
 		args.data.Emitter = c
 		caps[oid] = ic
 	}
 
 	var ret emitTempsEmitResultsData
 
-	err := v.Client.CallWithCaps(ctx, "emit", &args, &ret, caps)
+	err := v.CallWithCaps(ctx, "emit", &args, &ret, caps)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpc/generator.go
+++ b/pkg/rpc/generator.go
@@ -886,7 +886,8 @@ func (g *Generator) generateCompactStruct(f *j.File, t *DescType) error {
 		})
 
 		for _, field := range t.Fields {
-			if field.Type == "list" {
+			switch field.Type {
+			case "list":
 				if g.ti(field.Element).isMessage {
 					gr.Id(toCamal(field.Name)).Index().Id(field.Element).Tag(map[string]string{
 						"cbor": fmt.Sprintf("%d,keyasint,omitempty", field.Index),
@@ -899,9 +900,9 @@ func (g *Generator) generateCompactStruct(f *j.File, t *DescType) error {
 					})
 				}
 
-			} else if field.Type == "union" {
+			case "union":
 				gr.Id(private(t.Type) + toCamal(field.Name))
-			} else {
+			default:
 				typ := g.properType(field.Type)
 
 				if field.isInterface {
@@ -1220,7 +1221,8 @@ func (g *Generator) generateStruct(f *j.File) error {
 			}
 
 			for _, field := range t.Fields {
-				if field.Type == "list" {
+				switch field.Type {
+				case "list":
 					if g.ti(field.Element).isMessage {
 						gr.Id(toCamal(field.Name)).Op("*").Index().Op("*").Id(field.Element).Tag(map[string]string{
 							"cbor": fmt.Sprintf("%d,keyasint,omitempty", field.Index),
@@ -1233,9 +1235,9 @@ func (g *Generator) generateStruct(f *j.File) error {
 						})
 					}
 
-				} else if field.Type == "union" {
+				case "union":
 					gr.Id(private(t.Type) + toCamal(field.Name))
-				} else {
+				default:
 					typ := j.Op("*").Add(g.properType(field.Type))
 
 					if field.isInterface {

--- a/pkg/rpc/io/io.gen.go
+++ b/pkg/rpc/io/io.gen.go
@@ -166,7 +166,7 @@ func (v ReaderClient) Read(ctx context.Context, count int32) (*ReaderClientReadR
 
 	var ret readerReadResultsData
 
-	err := v.Client.Call(ctx, "Read", &args, &ret)
+	err := v.Call(ctx, "Read", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (v ReaderAtClient) ReadAt(ctx context.Context, count int32, offset int64) (
 
 	var ret readerAtReadAtResultsData
 
-	err := v.Client.Call(ctx, "ReadAt", &args, &ret)
+	err := v.Call(ctx, "ReadAt", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -508,7 +508,7 @@ func (v WriterClient) Write(ctx context.Context, data []byte) (*WriterClientWrit
 
 	var ret writerWriteResultsData
 
-	err := v.Client.Call(ctx, "Write", &args, &ret)
+	err := v.Call(ctx, "Write", &args, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -490,6 +490,7 @@ func (s *Server) lookup(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+//nolint:errcheck
 func (s *Server) reresolve(w http.ResponseWriter, r *http.Request) {
 	var rs InterfaceState
 

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -538,7 +538,7 @@ func (s *Server) reresolve(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if iface == nil {
-				cbor.NewEncoder(w).Encode(lookupResponse{Error: fmt.Sprintf("unable to restore capability")})
+				cbor.NewEncoder(w).Encode(lookupResponse{Error: "unable to restore capability"})
 				return
 			}
 		}

--- a/pkg/rpc/stream/stream.gen.go
+++ b/pkg/rpc/stream/stream.gen.go
@@ -164,7 +164,7 @@ func (v SendStreamClient[T]) Send(ctx context.Context, value T) (*SendStreamClie
 
 	var ret sendStreamSendResultsData[T]
 
-	err := v.Client.Call(ctx, "send", &args, &ret)
+	err := v.Call(ctx, "send", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +328,7 @@ func (v RecvStreamClient[T]) Recv(ctx context.Context, count int32) (*RecvStream
 
 	var ret recvStreamRecvResultsData[T]
 
-	err := v.Client.Call(ctx, "recv", &args, &ret)
+	err := v.Call(ctx, "recv", &args, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webtransport/stream.go
+++ b/pkg/webtransport/stream.go
@@ -178,8 +178,8 @@ func (s *stream) closeWithSession() {
 }
 
 func (s *stream) SetDeadline(t time.Time) error {
-	err1 := s.sendStream.SetWriteDeadline(t)
-	err2 := s.receiveStream.SetReadDeadline(t)
+	err1 := s.SetWriteDeadline(t)
+	err2 := s.SetReadDeadline(t)
 	if err1 != nil {
 		return err1
 	}


### PR DESCRIPTION
Replace bespoke linting with industry-standard golangci-lint, which:
- Provides easy opt-in for additional linters and formatters over time
- Has built-in smarts for analyzing only new code (--new-from-rev)
- Offers better performance and caching than shell scripts
- Integrates well with CI/CD pipelines via GitHub Actions

Starting with mostly the default configuration which includes the
standard set of linters (see https://golangci-lint.run/usage/linters/#enabled-by-default)
plus gofmt and goimports formatters.

Updated:
- Add .golangci.yml with v2 configuration
- Replace custom lint-changed.sh logic with golangci-lint commands
- Add `make lint` and `make lint-fix` targets
- Update GitHub Actions to use golangci-lint-action
- Add golangci-lint to nix flake development environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced manual Go formatting and vetting steps with automated linting using GolangCI-Lint in workflows and scripts.
  * Introduced a configuration file for GolangCI-Lint to control linting and formatting rules.
  * Added Makefile commands to run and auto-fix linting issues.
  * Updated the development environment to include GolangCI-Lint.
  * Improved linter directive comments for clarity.
  * Refined various internal method calls and client RPC invocations for consistency and maintainability.
  * Enhanced code clarity by restructuring conditional logic and simplifying boolean expressions.
  * Streamlined method call targets across multiple components for improved code consistency.
  * Refactored HTTP method handling in registry component for better maintainability.
  * Added explicit error handling during sandbox metadata updates.
  * Updated environment and client method usage to align with latest API changes.
  * Fixed method call targets in web transport stream with a note on potential recursion issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->