### PR TITLE
Add runtime config management commands

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -110,6 +110,10 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("config load", "Load config and merge it with your current config", ConfigLoad), nil
 		},
 
+		"config set-active": func() (cli.Command, error) {
+			return Infer("config set-active", "Set the active cluster", ConfigSetActive), nil
+		},
+
 		// TODO: Errors with "unknown object: user"
 		// "user": func() (cli.Command, error) {
 		// 	return Section("user", "Commands related to cluster users"), nil

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -114,6 +114,10 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("config set-active", "Set the active cluster", ConfigSetActive), nil
 		},
 
+		"config remove": func() (cli.Command, error) {
+			return Infer("config remove", "Remove a cluster from the configuration", ConfigRemove), nil
+		},
+
 		// TODO: Errors with "unknown object: user"
 		// "user": func() (cli.Command, error) {
 		// 	return Section("user", "Commands related to cluster users"), nil

--- a/cli/commands/config_remove.go
+++ b/cli/commands/config_remove.go
@@ -1,0 +1,180 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func ConfigRemove(ctx *Context, opts struct {
+	ConfigCentric
+	Force bool `short:"f" long:"force" description:"Force removal without confirmation"`
+	Args  struct {
+		Cluster string `positional-arg-name:"cluster" description:"Name of the cluster to remove"`
+	} `positional-args:"yes"`
+}) error {
+	cfg, err := opts.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	// Check if there's only one cluster
+	if len(cfg.Clusters) <= 1 {
+		return fmt.Errorf("cannot remove the last cluster")
+	}
+
+	clusterName := opts.Args.Cluster
+
+	// If no cluster name provided, show interactive menu
+	if clusterName == "" {
+		// Get sorted list of cluster names
+		clusterNames := make([]string, 0, len(cfg.Clusters))
+		for name := range cfg.Clusters {
+			clusterNames = append(clusterNames, name)
+		}
+		sort.Strings(clusterNames)
+
+		// Create and run the selection model
+		m := &clusterRemoveModel{
+			clusters: clusterNames,
+			cursor:   0,
+			active:   cfg.ActiveCluster,
+		}
+
+		p := tea.NewProgram(m)
+		result, err := p.Run()
+		if err != nil {
+			// If we can't run interactive mode (no TTY), show available clusters
+			ctx.Printf("Cannot run interactive mode. Available clusters:\n")
+			for _, name := range clusterNames {
+				prefix := "  "
+				if name == cfg.ActiveCluster {
+					prefix = "* "
+				}
+				ctx.Printf("%s%s\n", prefix, name)
+			}
+			ctx.Printf("\nUsage: runtime config remove <cluster-name>\n")
+			return nil
+		}
+
+		// Check if user cancelled
+		model := result.(*clusterRemoveModel)
+		if model.cancelled {
+			return nil
+		}
+
+		clusterName = model.selected
+	}
+
+	// Check if the cluster exists
+	if _, exists := cfg.Clusters[clusterName]; !exists {
+		availableClusters := make([]string, 0, len(cfg.Clusters))
+		for name := range cfg.Clusters {
+			availableClusters = append(availableClusters, name)
+		}
+		return fmt.Errorf("cluster %q not found. Available clusters: %v", clusterName, availableClusters)
+	}
+
+	// Check if trying to remove the active cluster
+	if clusterName == cfg.ActiveCluster {
+		return fmt.Errorf("cannot remove the active cluster %q. Please switch to another cluster first", clusterName)
+	}
+
+	// Ask for confirmation unless --force is used
+	if !opts.Force {
+		ctx.Printf("This will remove cluster '%s' from your configuration.\n", clusterName)
+		ctx.Printf("To confirm, run the command with --force flag\n")
+		return nil
+	}
+
+	// Remove the cluster
+	delete(cfg.Clusters, clusterName)
+
+	// Save the configuration
+	err = cfg.Save()
+	if err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	ctx.Printf("Removed cluster: %s\n", clusterName)
+	return nil
+}
+
+// clusterRemoveModel is the model for the cluster removal selection menu
+type clusterRemoveModel struct {
+	clusters  []string
+	cursor    int
+	selected  string
+	cancelled bool
+	active    string
+}
+
+func (m *clusterRemoveModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m *clusterRemoveModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			m.cancelled = true
+			return m, tea.Quit
+
+		case "enter", " ":
+			m.selected = m.clusters[m.cursor]
+			return m, tea.Quit
+
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+
+		case "down", "j":
+			if m.cursor < len(m.clusters)-1 {
+				m.cursor++
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m *clusterRemoveModel) View() string {
+	var b strings.Builder
+
+	b.WriteString("Select a cluster to remove:\n\n")
+
+	for i, cluster := range m.clusters {
+		cursor := " "
+		if m.cursor == i {
+			cursor = ">"
+		}
+
+		activeMarker := "  "
+		if cluster == m.active {
+			activeMarker = " * (active)"
+		}
+
+		style := lipgloss.NewStyle()
+		if m.cursor == i {
+			style = style.Foreground(lipgloss.Color("170"))
+		}
+
+		// Dim the active cluster to indicate it can't be removed
+		if cluster == m.active {
+			style = style.Foreground(lipgloss.Color("240"))
+		}
+
+		line := fmt.Sprintf("%s %s%s", cursor, cluster, activeMarker)
+		b.WriteString(style.Render(line) + "\n")
+	}
+
+	b.WriteString("\n(Use arrow keys to navigate, enter to select, esc to cancel)\n")
+	b.WriteString("Note: You cannot remove the active cluster\n")
+
+	return b.String()
+}

--- a/cli/commands/config_set_active.go
+++ b/cli/commands/config_set_active.go
@@ -1,0 +1,158 @@
+package commands
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func ConfigSetActive(ctx *Context, opts struct {
+	ConfigCentric
+	Args struct {
+		Cluster string `positional-arg-name:"cluster" description:"Name of the cluster to set as active"`
+	} `positional-args:"yes"`
+}) error {
+	cfg, err := opts.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	clusterName := opts.Args.Cluster
+
+	// If no cluster name provided, show interactive menu
+	if clusterName == "" {
+		// Get sorted list of cluster names
+		clusterNames := make([]string, 0, len(cfg.Clusters))
+		for name := range cfg.Clusters {
+			clusterNames = append(clusterNames, name)
+		}
+		sort.Strings(clusterNames)
+
+		// Find current active cluster index
+		currentIndex := 0
+		for i, name := range clusterNames {
+			if name == cfg.ActiveCluster {
+				currentIndex = i
+				break
+			}
+		}
+
+		// Create and run the selection model
+		m := &clusterSelectModel{
+			clusters: clusterNames,
+			cursor:   currentIndex,
+			active:   cfg.ActiveCluster,
+		}
+
+		p := tea.NewProgram(m)
+		result, err := p.Run()
+		if err != nil {
+			return fmt.Errorf("failed to run selection menu: %w", err)
+		}
+
+		// Check if user cancelled
+		model := result.(*clusterSelectModel)
+		if model.cancelled {
+			return nil
+		}
+
+		clusterName = model.selected
+	}
+
+	// Check if the cluster exists
+	if _, exists := cfg.Clusters[clusterName]; !exists {
+		availableClusters := make([]string, 0, len(cfg.Clusters))
+		for name := range cfg.Clusters {
+			availableClusters = append(availableClusters, name)
+		}
+		return fmt.Errorf("cluster %q not found. Available clusters: %v", clusterName, availableClusters)
+	}
+
+	// Set the active cluster
+	err = cfg.SetActiveCluster(clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to set active cluster: %w", err)
+	}
+
+	// Save the configuration
+	err = cfg.Save()
+	if err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	ctx.Printf("Active cluster set to: %s\n", clusterName)
+	return nil
+}
+
+// clusterSelectModel is the model for the cluster selection menu
+type clusterSelectModel struct {
+	clusters  []string
+	cursor    int
+	selected  string
+	cancelled bool
+	active    string
+}
+
+func (m *clusterSelectModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m *clusterSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			m.cancelled = true
+			return m, tea.Quit
+
+		case "enter", " ":
+			m.selected = m.clusters[m.cursor]
+			return m, tea.Quit
+
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+
+		case "down", "j":
+			if m.cursor < len(m.clusters)-1 {
+				m.cursor++
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m *clusterSelectModel) View() string {
+	var b strings.Builder
+
+	b.WriteString("Select a cluster to set as active:\n\n")
+
+	for i, cluster := range m.clusters {
+		cursor := " "
+		if m.cursor == i {
+			cursor = ">"
+		}
+
+		activeMarker := "  "
+		if cluster == m.active {
+			activeMarker = " *"
+		}
+
+		style := lipgloss.NewStyle()
+		if m.cursor == i {
+			style = style.Foreground(lipgloss.Color("170"))
+		}
+
+		line := fmt.Sprintf("%s %s%s", cursor, cluster, activeMarker)
+		b.WriteString(style.Render(line) + "\n")
+	}
+
+	b.WriteString("\n(Use arrow keys to navigate, enter to select, esc to cancel)\n")
+
+	return b.String()
+}

--- a/cli/commands/tea_utils.go
+++ b/cli/commands/tea_utils.go
@@ -1,0 +1,154 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// SelectionModel is a generic model for selecting from a list of items
+type SelectionModel struct {
+	Title     string
+	Items     []string
+	cursor    int
+	Selected  string
+	Cancelled bool
+	Footer    string // Optional footer text
+
+	// Optional styling/marking functions
+	ItemMarker func(item string) string         // Returns marker like " *" for special items
+	ItemStyle  func(item string) lipgloss.Style // Returns style for special items
+}
+
+func (m *SelectionModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m *SelectionModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			m.Cancelled = true
+			return m, tea.Quit
+
+		case "enter", " ":
+			m.Selected = m.Items[m.cursor]
+			return m, tea.Quit
+
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+
+		case "down", "j":
+			if m.cursor < len(m.Items)-1 {
+				m.cursor++
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m *SelectionModel) View() string {
+	var b strings.Builder
+
+	b.WriteString(m.Title + "\n\n")
+
+	for i, item := range m.Items {
+		cursor := " "
+		if m.cursor == i {
+			cursor = ">"
+		}
+
+		marker := "  "
+		if m.ItemMarker != nil {
+			marker = m.ItemMarker(item)
+		}
+
+		// Start with base style
+		style := lipgloss.NewStyle()
+
+		// Apply custom item style if provided
+		if m.ItemStyle != nil {
+			style = m.ItemStyle(item)
+		}
+
+		// Apply selection highlighting
+		if m.cursor == i {
+			// Override with selection color unless item already has custom styling
+			if m.ItemStyle == nil {
+				style = style.Foreground(lipgloss.Color("170"))
+			} else {
+				// If there's custom styling, just make it bold
+				style = style.Bold(true).Foreground(lipgloss.Color("170"))
+			}
+		}
+
+		line := fmt.Sprintf("%s %s%s", cursor, item, marker)
+		b.WriteString(style.Render(line) + "\n")
+	}
+
+	b.WriteString("\n(Use arrow keys to navigate, enter to select, esc to cancel)\n")
+
+	if m.Footer != "" {
+		b.WriteString(m.Footer + "\n")
+	}
+
+	return b.String()
+}
+
+// SetCursor sets the cursor to the specified index
+func (m *SelectionModel) SetCursor(index int) {
+	if index >= 0 && index < len(m.Items) {
+		m.cursor = index
+	}
+}
+
+// Helper function to run cluster selection
+func SelectCluster(ctx *Context, title string, clusters []string, activeCluster string, dimActive bool) (string, error) {
+	model := &SelectionModel{
+		Title: title,
+		Items: clusters,
+		ItemMarker: func(item string) string {
+			if item == activeCluster {
+				return " *"
+			}
+			return "  "
+		},
+	}
+
+	if dimActive {
+		model.ItemStyle = func(item string) lipgloss.Style {
+			if item == activeCluster {
+				return lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+			}
+			return lipgloss.NewStyle()
+		}
+		model.Footer = "Note: You cannot remove the active cluster"
+	}
+
+	// Find current active cluster index
+	for i, name := range clusters {
+		if name == activeCluster {
+			model.SetCursor(i)
+			break
+		}
+	}
+
+	p := tea.NewProgram(model)
+	result, err := p.Run()
+	if err != nil {
+		return "", err
+	}
+
+	m := result.(*SelectionModel)
+	if m.Cancelled {
+		return "", nil
+	}
+
+	return m.Selected, nil
+}


### PR DESCRIPTION
## Summary
- Adds `runtime config set-active` command to switch between configured clusters
- Adds `runtime config remove` command to remove clusters from configuration
- Both commands support interactive selection menus when no cluster name is provided

## New Commands

### runtime config set-active
Allows users to switch the active cluster either by specifying a cluster name or using an interactive menu.

```bash
# Direct selection
runtime config set-active <cluster-name>

# Interactive menu
runtime config set-active
```

### runtime config remove
Allows users to remove clusters from their configuration with safety checks.

```bash
# Remove with confirmation
runtime config remove <cluster-name>
runtime config remove --force <cluster-name>

# Interactive selection
runtime config remove
```

## Safety Features
- Cannot remove the active cluster (must switch first)
- Cannot remove the last cluster
- Requires `--force` flag for confirmation (follows existing CLI patterns)
- Interactive menus show current active cluster

## Test plan
- [x] Test `config set-active` with direct cluster name
- [x] Test `config set-active` with interactive menu
- [x] Test `config remove` without force flag
- [x] Test `config remove` with force flag
- [x] Test removing active cluster (should fail)
- [x] Test removing last cluster (should fail)
- [x] Test interactive selection in both commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to set the active cluster, with interactive selection if no cluster is specified.
  * Added a command to remove a cluster, featuring an interactive UI for selection and safeguards against removing the last or active cluster.
* **User Experience**
  * Interactive terminal menus provide guided selection and clear feedback during cluster management tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->