### PR TITLE
Fix rpcgen to use promoted Client methods directly

### DIFF
--- a/pkg/rpc/generator.go
+++ b/pkg/rpc/generator.go
@@ -1703,7 +1703,7 @@ func (g *Generator) generateClient(f *j.File, i *DescInterface) error {
 			for _, p := range m.Parameters {
 				if g.ti(p.Type).isInterface {
 					gr.BlockFunc(func(gr *j.Group) {
-						gr.List(j.Id("ic"), j.Id("oid"), j.Id("c")).Op(":=").Id("v").Dot("Client").Dot("NewInlineCapability").
+						gr.List(j.Id("ic"), j.Id("oid"), j.Id("c")).Op(":=").Id("v").Dot("NewInlineCapability").
 							CallFunc(func(gr *j.Group) {
 								if g.isImported(p.Type) {
 									iname, tname := g.splitType(p.Type)
@@ -1733,7 +1733,7 @@ func (g *Generator) generateClient(f *j.File, i *DescInterface) error {
 			gr.Line()
 
 			if hasCaps {
-				gr.Id("err").Op(":=").Id("v").Dot("Client").Dot("CallWithCaps").Call(
+				gr.Id("err").Op(":=").Id("v").Dot("CallWithCaps").Call(
 					j.Id("ctx"),
 					j.Lit(m.Name),
 					j.Op("&").Id("args"),
@@ -1742,7 +1742,7 @@ func (g *Generator) generateClient(f *j.File, i *DescInterface) error {
 				)
 
 			} else {
-				gr.Id("err").Op(":=").Id("v").Dot("Client").Dot("Call").Call(
+				gr.Id("err").Op(":=").Id("v").Dot("Call").Call(
 					j.Id("ctx"),
 					j.Lit(m.Name),
 					j.Op("&").Id("args"),

--- a/pkg/rpc/testdata/generic.go
+++ b/pkg/rpc/testdata/generic.go
@@ -196,7 +196,7 @@ func (v ReaderClient[T]) Read(ctx context.Context, value *Container[T]) (*Reader
 
 	var ret readerReadResultsData[T]
 
-	err := v.Client.Call(ctx, "read", &args, &ret)
+	err := v.Call(ctx, "read", &args, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpc/testdata/rpc.go
+++ b/pkg/rpc/testdata/rpc.go
@@ -331,7 +331,7 @@ func (v TownClient) GetHero(ctx context.Context, name string) (*TownClientGetHer
 
 	var ret townGetHeroResultsData
 
-	err := v.Client.Call(ctx, "getHero", &args, &ret)
+	err := v.Call(ctx, "getHero", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +361,7 @@ func (v TownClient) HireHero(ctx context.Context, name string) (*TownClientHireH
 
 	var ret townHireHeroResultsData
 
-	err := v.Client.Call(ctx, "hireHero", &args, &ret)
+	err := v.Call(ctx, "hireHero", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +525,7 @@ func (v EmpowerClient) IncreasePower(ctx context.Context, power int32) (*Empower
 
 	var ret empowerIncreasePowerResultsData
 
-	err := v.Client.Call(ctx, "increasePower", &args, &ret)
+	err := v.Call(ctx, "increasePower", &args, &ret)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The linter was flagging explicit Client struct references in generated
code. Since rpc.Client is embedded in the generated client structs,
its methods are promoted and can be called directly without the
explicit field reference.

Changed generator to emit:
- v.NewInlineCapability() instead of v.Client.NewInlineCapability()
- v.CallWithCaps() instead of v.Client.CallWithCaps()
- v.Call() instead of v.Client.Call()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal method calls without affecting any user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->