### PR TITLE
Add sandbox list command with status filtering

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -38,6 +38,9 @@ func AllCommands() map[string]cli.CommandFactory {
 		"sandbox exec": func() (cli.Command, error) {
 			return Infer("sandbox exec", "Execute a command in a sandbox", SandboxExec), nil
 		},
+		"sandbox list": func() (cli.Command, error) {
+			return Infer("sandbox list", "List all sandboxes", SandboxList), nil
+		},
 		"sandbox metrics": func() (cli.Command, error) {
 			return Infer("sandbox metrics", "Get metrics from a sandbox", SandboxMetrics), nil
 		},

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+)
+
+func SandboxList(ctx *Context, opts struct {
+	Status string `short:"s" long:"status" description:"Filter by status (pending, not_ready, running, stopped, dead)"`
+	ConfigCentric
+}) error {
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+
+	// Get the sandbox kind attribute
+	kindRes, err := eac.LookupKind(ctx, "sandbox")
+	if err != nil {
+		return err
+	}
+
+	// List all sandboxes
+	res, err := eac.List(ctx, kindRes.Attr())
+	if err != nil {
+		return err
+	}
+
+	if len(res.Values()) == 0 {
+		ctx.Printf("No sandboxes found\n")
+		return nil
+	}
+
+	// Create a tabwriter for formatted output
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "ID\tSTATUS\tVERSION\tCONTAINERS\n")
+
+	for _, e := range res.Values() {
+		// Decode the sandbox entity
+		var sandbox compute_v1alpha.Sandbox
+		sandbox.Decode(e.Entity())
+
+		// Get status string
+		status := string(sandbox.Status)
+		if status == "" {
+			status = "unknown"
+		}
+
+		// Filter by status if specified
+		if opts.Status != "" && status != "status."+opts.Status {
+			continue
+		}
+
+		// Get version string
+		version := sandbox.Version.String()
+		if version == "" {
+			version = "-"
+		}
+
+		// Count containers
+		containerCount := len(sandbox.Container)
+
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\n",
+			sandbox.ID.String(),
+			status,
+			version,
+			containerCount,
+		)
+	}
+
+	return w.Flush()
+}


### PR DESCRIPTION
## Summary
- Add new `runtime sandbox list` command to display all sandboxes and their current status
- Support filtering by sandbox status using `--status` flag

## Test plan
- [x] Build the runtime binary with `make bin/runtime`
- [x] Test listing all sandboxes: `runtime sandbox list`
- [x] Test filtering by status: `runtime sandbox list --status dead`
- [x] Test with no results: `runtime sandbox list --status running`
- [x] Verify output shows ID, status, version, and container count in columnar format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new CLI command, "sandbox list", which displays all sandboxes in a tabular format.
  * Added support for filtering sandboxes by status when listing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->