### PR TITLE
Fix runtime init command timeout with remote clusters

### DIFF
--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -14,6 +14,7 @@ import (
 func Init(ctx *Context, opts struct {
 	Name string `short:"n" long:"name" description:"Application name (defaults to directory name)"`
 	Dir  string `short:"d" long:"dir" description:"Application directory (defaults to current directory)"`
+	ConfigCentric
 }) error {
 	// Determine working directory
 	workDir := opts.Dir


### PR DESCRIPTION
The init command was missing ConfigCentric which is required for connecting to remote clusters. This caused timeout errors when trying to use `runtime init` with configured clusters.

## What changed
- Added `ConfigCentric` to the Init command's options struct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The initialization command now supports additional configuration options, providing more flexibility when setting up your application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->