### PR TITLE
Add make dist target for building portable binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,8 @@ lint-changed:
 	@bash ./hack/lint-changed.sh
 
 .PHONY: lint-changed
+
+dist:
+	@bash ./hack/build-dist.sh
+
+.PHONY: dist

--- a/hack/build-dist.sh
+++ b/hack/build-dist.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -euo pipefail
+
+# Create a temporary file for the Dockerfile
+DOCKERFILE=$(mktemp -t dockerfile.dist.XXXXXX)
+
+# Cleanup function
+cleanup() {
+    echo "Cleaning up..."
+    # Remove temporary Dockerfile
+    rm -f "$DOCKERFILE"
+}
+
+# Set up trap to ensure cleanup on exit, interrupt, or error
+trap cleanup EXIT INT TERM
+
+# Get version info
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+short_sha=$(git rev-parse --short HEAD)
+
+# Handle detached HEAD state
+if [[ "$current_branch" == "HEAD" ]]; then
+    # In detached HEAD state, use short SHA as version
+    version="$short_sha"
+else
+    # Sanitize branch name: replace unsafe characters with underscores
+    # Only allow alphanumeric, dots, underscores, and dashes
+    sanitized_branch=$(echo "$current_branch" | sed 's/[^a-zA-Z0-9._-]/_/g')
+    version="$sanitized_branch:$short_sha"
+fi
+
+echo "Building portable Linux amd64 binary (version $version)..."
+
+# Create the Dockerfile content
+cat >"$DOCKERFILE" <<EOF
+FROM golang:1.24-alpine AS builder
+
+# Accept version as a build argument
+ARG VERSION
+
+# Install build dependencies including C compiler for CGO
+RUN apk add --no-cache git ca-certificates gcc musl-dev linux-headers
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+
+# Copy source code
+COPY . .
+
+# Download dependencies if vendor directory doesn't exist
+RUN if [ ! -d vendor ]; then go mod download; fi
+
+# Build a binary
+# We need CGO enabled for flannel dependencies
+# But we'll link statically against musl libc for portability
+# Version is safely passed via build arg
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+    -ldflags "-X miren.dev/runtime/version.Version=\${VERSION} -linkmode external -extldflags '-static'" \
+    -o runtime \
+    ./cmd/runtime
+
+# Use scratch for minimal final stage with just the binary
+FROM scratch
+COPY --from=builder /build/runtime /runtime
+EOF
+
+# Ensure bin directory exists
+mkdir -p ./bin
+
+# Build using Docker with version passed as build argument and export binary directly
+# Specify platform to ensure consistent builds across different architectures
+docker build --platform=linux/amd64 -f "$DOCKERFILE" --build-arg "VERSION=$version" --output type=local,dest=./bin .
+
+# Rename the binary to runtime-dist
+mv ./bin/runtime ./bin/runtime-dist
+
+# Make it executable
+chmod +x ./bin/runtime-dist
+
+echo "Portable binary created at ./bin/runtime-dist"
+
+# Verify it's statically linked
+echo ""
+echo "Binary info:"
+file ./bin/runtime-dist
+
+# Show ldd info if available (will show "not a dynamic executable" for static binaries)
+if command -v ldd >/dev/null 2>&1; then
+    echo ""
+    echo "Dynamic dependencies:"
+    ldd ./bin/runtime-dist 2>&1 || echo "No dynamic dependencies (static binary)"
+fi
+


### PR DESCRIPTION
## Summary
Adds a `make dist` target for building portable, statically-linked Linux amd64 binaries.

## Why?
I've been working on issues that are reproducing on the sandbox server and I wanted a way to iterate that was quicker than the `package` dagger process but still made a portable binary (which my local NixOS dev env does not like to do).

## Details
The new target creates a distribution-ready binary that can run on various Linux systems without dependency issues. 

Key features:
- Uses Docker with Alpine Linux for consistent builds
- Produces statically-linked binaries via musl libc
- Embeds version information from git
- Handles detached HEAD states gracefully
- Sanitizes branch names for security
- Output: `bin/runtime-dist`

## Test plan
- [x] Run `make dist` and verify it creates `bin/runtime-dist`
- [x] Verify the binary is statically linked using `file` and `ldd`
- [x] Test the binary runs on different Linux distributions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new command to build a portable Linux amd64 binary for the application.
  * Introduced an automated script to streamline the build and packaging process for distribution.

* **Chores**
  * Updated build configuration to always execute the new distribution build process when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->