### PR TITLE
Implement automatic cleanup of dead sandboxes

### DIFF
--- a/api/entityserver/entityserver_v1alpha/extra.go
+++ b/api/entityserver/entityserver_v1alpha/extra.go
@@ -7,7 +7,9 @@ import (
 
 func (e *Entity) Entity() *entity.Entity {
 	return &entity.Entity{
-		ID:    types.Id(e.Id()),
-		Attrs: e.Attrs(),
+		ID:        types.Id(e.Id()),
+		UpdatedAt: e.UpdatedAt(),
+		CreatedAt: e.CreatedAt(),
+		Attrs:     e.Attrs(),
 	}
 }

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -245,17 +245,19 @@ func (r *Runner) SetupControllers(
 		workers = DefaulWorkers
 	}
 
-	cm.AddController(
-		controller.NewReconcileController(
-			"sandbox",
-			log,
-			compute_v1alpha.Index(compute_v1alpha.KindSandbox, entity.Id("node/"+r.Id)),
-			eas,
-			controller.AdaptController(&sbc),
-			time.Minute,
-			workers,
-		),
+	sbController := controller.NewReconcileController(
+		"sandbox",
+		log,
+		compute_v1alpha.Index(compute_v1alpha.KindSandbox, entity.Id("node/"+r.Id)),
+		eas,
+		controller.AdaptController(&sbc),
+		time.Minute,
+		workers,
 	)
+
+	sbController.SetPeriodic(sbc.Periodic)
+
+	cm.AddController(sbController)
 
 	cm.AddController(
 		controller.NewReconcileController(

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -255,7 +255,7 @@ func (r *Runner) SetupControllers(
 		workers,
 	)
 
-	sbController.SetPeriodic(sbc.Periodic)
+	sbController.SetPeriodic(5*time.Minute, sbc.Periodic)
 
 	cm.AddController(sbController)
 

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -117,7 +117,7 @@ func TestSandbox(t *testing.T) {
 		ca, err := netip.ParseAddr(tco.Network[0].Address)
 		r.NoError(err)
 
-		c, err := cc.LoadContainer(ctx, co.containerId(id))
+		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
 		r.NoError(err)
 
 		r.NotNil(c)
@@ -279,7 +279,7 @@ func TestSandbox(t *testing.T) {
 			err := co.Create(ctx, &sb, meta)
 			r.NoError(err)
 
-			c, err := cc.LoadContainer(ctx, co.containerId(id))
+			c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
 			r.NoError(err)
 
 			labels, err := c.Labels(ctx)
@@ -419,7 +419,7 @@ func TestSandbox(t *testing.T) {
 		err = co.Create(ctx, &tco, meta)
 		r.NoError(err)
 
-		c, err := cc.LoadContainer(ctx, co.containerId(id))
+		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
 		r.NoError(err)
 
 		r.NotNil(c)
@@ -538,7 +538,7 @@ func TestSandbox(t *testing.T) {
 		ca, err := netip.ParseAddr(tco.Network[0].Address)
 		r.NoError(err)
 
-		c, err := cc.LoadContainer(ctx, co.containerId(id))
+		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
 		r.NoError(err)
 
 		r.NotNil(c)
@@ -673,7 +673,7 @@ func TestSandbox(t *testing.T) {
 		ca, err := netip.ParseAddr(tco.Network[0].Address)
 		r.NoError(err)
 
-		c, err := cc.LoadContainer(ctx, co.containerId(id))
+		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
 		r.NoError(err)
 
 		r.NotNil(c)
@@ -800,7 +800,7 @@ func TestSandbox(t *testing.T) {
 		ca, err := netip.ParseAddr(tco.Network[0].Address)
 		r.NoError(err)
 
-		c, err := cc.LoadContainer(ctx, co.containerId(id))
+		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
 		r.NoError(err)
 
 		r.NotNil(c)
@@ -936,7 +936,7 @@ func TestSandbox(t *testing.T) {
 		ca, err := netip.ParseAddr(tco.Network[0].Address)
 		r.NoError(err)
 
-		c, err := cc.LoadContainer(ctx, co.containerId(id))
+		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
 		r.NoError(err)
 
 		r.NotNil(c)

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/image"
 	"miren.dev/runtime/observability"
 	build "miren.dev/runtime/pkg/buildkit"
@@ -325,7 +326,7 @@ func TestSandbox(t *testing.T) {
 			err = co.Create(ctx, &sb, meta)
 			r.NoError(err)
 
-			c, err := cc.LoadContainer(ctx, co.containerId(id)+"-nginx")
+			c, err := cc.LoadContainer(ctx, co.containerPrefix(id)+"-nginx")
 			r.NoError(err)
 
 			task, err := c.Task(ctx, nil)
@@ -970,5 +971,125 @@ func TestSandbox(t *testing.T) {
 		r.Contains(string(data), "this is from testdata/static-site")
 
 		r.Equal(http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("cleans up dead sandboxes older than 1 hour", func(t *testing.T) {
+		r := require.New(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		reg, cleanup := testutils.Registry(observability.TestInject, build.TestInject)
+		defer cleanup()
+
+		var sbc SandboxController
+
+		err := reg.Populate(&sbc)
+		r.NoError(err)
+
+		defer sbc.Close()
+
+		err = sbc.Init(ctx)
+		r.NoError(err)
+
+		// Create a few sandboxes
+		sbID1 := entity.Id(sbName())
+		sb1 := &compute.Sandbox{
+			ID:     sbID1,
+			Status: compute.RUNNING,
+		}
+
+		// Store sandbox in entity store with ident
+		var rpcE1 entityserver_v1alpha.Entity
+		rpcE1.SetId(sbID1.String())
+		rpcE1.SetAttrs(entity.Attrs(
+			entity.Keyword(entity.Ident, sbID1.String()),
+			sb1.Encode))
+		_, err = sbc.EAC.Put(ctx, &rpcE1)
+		r.NoError(err)
+
+		// Now retrieve it to get the entity with proper metadata
+		result1, err := sbc.EAC.Get(ctx, sbID1.String())
+		r.NoError(err)
+
+		meta1 := &entity.Meta{
+			Entity:   result1.Entity().Entity(),
+			Revision: result1.Entity().Revision(),
+		}
+
+		err = sbc.Create(ctx, sb1, meta1)
+		r.NoError(err)
+
+		// Create a second sandbox
+		sbID2 := entity.Id(sbName())
+		sb2 := &compute.Sandbox{
+			ID:     sbID2,
+			Status: compute.RUNNING,
+		}
+
+		// Store sandbox in entity store with ident
+		var rpcE2 entityserver_v1alpha.Entity
+		rpcE2.SetId(sbID2.String())
+		rpcE2.SetAttrs(entity.Attrs(
+			entity.Keyword(entity.Ident, sbID2.String()),
+			sb2.Encode))
+		_, err = sbc.EAC.Put(ctx, &rpcE2)
+		r.NoError(err)
+
+		// Now retrieve it to get the entity with proper metadata
+		result2, err := sbc.EAC.Get(ctx, sbID2.String())
+		r.NoError(err)
+
+		meta2 := &entity.Meta{
+			Entity:   result2.Entity().Entity(),
+			Revision: result2.Entity().Revision(),
+		}
+
+		err = sbc.Create(ctx, sb2, meta2)
+		r.NoError(err)
+
+		// Wait a bit for containers to be created
+		time.Sleep(2 * time.Second)
+
+		// Stop the first sandbox (this should set status to DEAD)
+		err = sbc.Delete(ctx, sbID1)
+		r.NoError(err)
+
+		// Manually update the UpdatedAt timestamp to be more than 1 hour ago
+		// We need to get the entity and update it
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(sbID1.String())
+
+		// Set UpdatedAt to 2 hours ago by updating the entity
+		twoHoursAgo := time.Now().Add(-2 * time.Hour).UnixMilli()
+		rpcE.SetAttrs(entity.Attrs(
+			entity.Keyword(entity.Ident, sbID1.String()),
+			(&compute.Sandbox{
+				Status: compute.DEAD,
+			}).Encode,
+			entity.Int64(entity.UpdatedAt, twoHoursAgo)))
+
+		_, err = sbc.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Run the periodic cleanup
+		err = sbc.Periodic(ctx)
+		r.NoError(err)
+
+		// Check that the old dead sandbox was deleted
+		resp, err := sbc.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+		r.NoError(err)
+
+		// Should only have one sandbox left (sbID2)
+		r.Equal(1, len(resp.Values()))
+
+		var remainingSb compute.Sandbox
+		remainingSb.Decode(resp.Values()[0].Entity())
+		r.Equal(sbID2, remainingSb.ID)
+		r.Equal(compute.RUNNING, remainingSb.Status)
+
+		// Clean up the remaining sandbox
+		err = sbc.Delete(ctx, sbID2)
+		r.NoError(err)
 	})
 }

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -973,6 +973,14 @@ func TestSandbox(t *testing.T) {
 		r.Equal(http.StatusOK, resp.StatusCode)
 	})
 
+	checkClosed := func(t *testing.T, c io.Closer) {
+		t.Helper()
+		err := c.Close()
+		if err != nil {
+			t.Errorf("failed to close: %v", err)
+		}
+	}
+
 	t.Run("cleans up dead sandboxes older than 1 hour", func(t *testing.T) {
 		r := require.New(t)
 
@@ -987,7 +995,7 @@ func TestSandbox(t *testing.T) {
 		err := reg.Populate(&sbc)
 		r.NoError(err)
 
-		defer sbc.Close()
+		defer checkClosed(t, &sbc)
 
 		err = sbc.Init(ctx)
 		r.NoError(err)

--- a/controllers/service/service_test.go
+++ b/controllers/service/service_test.go
@@ -1,0 +1,815 @@
+package service
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	core_v1alpha "miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/network/network_v1alpha"
+	"miren.dev/runtime/components/ipalloc"
+	"miren.dev/runtime/controllers/sandbox"
+	"miren.dev/runtime/observability"
+	build "miren.dev/runtime/pkg/buildkit"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/testutils"
+)
+
+func TestServiceController(t *testing.T) {
+	sbName := func() string {
+		return idgen.GenNS("sb")
+	}
+
+	svcName := func() string {
+		return idgen.GenNS("svc")
+	}
+
+	t.Run("creates service without errors", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		reg, cleanup := testutils.Registry(observability.TestInject)
+		defer cleanup()
+
+		var sc ServiceController
+		err := reg.Populate(&sc)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		// Create a service
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "test"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name: "http",
+					Port: 80,
+				},
+			},
+		}
+
+		meta := &entity.Meta{
+			Entity: &entity.Entity{
+				ID:    svcID,
+				Attrs: svc.Encode(),
+			},
+			Revision: 1,
+		}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+	})
+
+	t.Run("creates endpoints when sandbox matches service", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		reg, cleanup := testutils.Registry(observability.TestInject, build.TestInject)
+		defer cleanup()
+
+		var (
+			sc  ServiceController
+			sbC sandbox.SandboxController
+			eac *entityserver_v1alpha.EntityAccessClient
+		)
+
+		err := reg.Init(&eac)
+		r.NoError(err)
+
+		err = reg.Populate(&sc)
+		r.NoError(err)
+
+		err = reg.Populate(&sbC)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		defer sbC.Close()
+
+		err = sbC.Init(ctx)
+		r.NoError(err)
+
+		// Create a service
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "nginx"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name: "http",
+					Port: 80,
+				},
+			},
+		}
+
+		svcEntity := &entity.Entity{
+			ID:    svcID,
+			Attrs: svc.Encode(),
+		}
+
+		// Store the service in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetAttrs(entity.Attrs(
+			entity.Keyword(entity.Ident, svcID.String()),
+			svc.Encode))
+		_, err = eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		meta := &entity.Meta{
+			Entity:   svcEntity,
+			Revision: 1,
+		}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		// Create a sandbox with matching labels and containers with ports
+		sbID := entity.Id(sbName())
+		sb := &compute.Sandbox{
+			ID: sbID,
+			Container: []compute.Container{
+				{
+					Name:  "nginx",
+					Image: "docker.io/library/nginx:latest",
+					Port: []compute.Port{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+		}
+
+		// Add metadata labels to entity attributes
+		attrs := sb.Encode()
+		attrs = append(attrs, entity.Label(core_v1alpha.MetadataLabelsId, "app", "nginx"))
+
+		sbEntity := &entity.Entity{
+			ID:    sbID,
+			Attrs: attrs,
+		}
+
+		sbMeta := &entity.Meta{
+			Entity:   sbEntity,
+			Revision: 1,
+		}
+
+		err = sbC.Create(ctx, sb, sbMeta)
+		r.NoError(err)
+
+		// Give it a moment for endpoints to be created
+		time.Sleep(200 * time.Millisecond)
+
+		// Check that endpoints were created
+		endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+		r.NoError(err)
+
+		r.Greater(len(endpoints.Values()), 0, "Expected to find endpoints for service")
+
+		found := false
+		for _, epEntity := range endpoints.Values() {
+			var ep network_v1alpha.Endpoints
+			ep.Decode(epEntity.Entity())
+			spew.Dump(ep)
+			if ep.Service == svcID {
+				found = true
+				r.Len(ep.Endpoint, 1)
+				r.NotEmpty(ep.Endpoint[0].Ip)
+				r.Equal(int64(80), ep.Endpoint[0].Port)
+				break
+			}
+		}
+		r.True(found, "Expected to find endpoints for service")
+
+		// Clean up
+		err = sbC.Delete(ctx, sbID)
+		r.NoError(err)
+	})
+
+	t.Run("deletes endpoints when sandbox is deleted", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		reg, cleanup := testutils.Registry(observability.TestInject, build.TestInject)
+		defer cleanup()
+
+		var (
+			sc  ServiceController
+			sbC sandbox.SandboxController
+			eac *entityserver_v1alpha.EntityAccessClient
+		)
+
+		err := reg.Init(&eac)
+		r.NoError(err)
+
+		err = reg.Populate(&sc)
+		r.NoError(err)
+
+		err = reg.Populate(&sbC)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		defer sbC.Close()
+
+		err = sbC.Init(ctx)
+		r.NoError(err)
+
+		// Create a service
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "nginx"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name: "http",
+					Port: 80,
+				},
+			},
+		}
+
+		// Store the service in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetAttrs(entity.Attrs(
+			entity.Keyword(entity.Ident, svcID.String()),
+			svc.Encode))
+		_, err = eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		meta := &entity.Meta{
+			Entity: &entity.Entity{
+				ID:    svcID,
+				Attrs: svc.Encode(),
+			},
+			Revision: 1,
+		}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		// Create a sandbox with matching labels and containers with ports
+		sbID := entity.Id(sbName())
+		sb := &compute.Sandbox{
+			ID: sbID,
+			Container: []compute.Container{
+				{
+					Name:  "nginx",
+					Image: "docker.io/library/nginx:latest",
+					Port: []compute.Port{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+		}
+
+		// Add metadata labels to entity attributes
+		attrs := sb.Encode()
+		attrs = append(attrs, entity.Label(core_v1alpha.MetadataLabelsId, "app", "nginx"))
+
+		sbEntity := &entity.Entity{
+			ID:    sbID,
+			Attrs: attrs,
+		}
+
+		sbMeta := &entity.Meta{
+			Entity:   sbEntity,
+			Revision: 1,
+		}
+
+		err = sbC.Create(ctx, sb, sbMeta)
+		r.NoError(err)
+
+		// Give it a moment for endpoints to be created
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify endpoints exist
+		endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+		r.NoError(err)
+
+		var endpointID entity.Id
+		var sandboxIP string
+		found := false
+		for _, epEntity := range endpoints.Values() {
+			var ep network_v1alpha.Endpoints
+			ep.Decode(epEntity.Entity())
+			if ep.Service == svcID {
+				found = true
+				endpointID = ep.ID
+				r.Len(ep.Endpoint, 1)
+				sandboxIP = ep.Endpoint[0].Ip
+				break
+			}
+		}
+		r.True(found, "Expected to find endpoints for service")
+		r.NotEmpty(sandboxIP)
+
+		// Delete the sandbox
+		err = sbC.Delete(ctx, sbID)
+		r.NoError(err)
+
+		// Give it a moment for endpoints to be deleted
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify endpoints are deleted
+		endpoints, err = eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+		r.NoError(err)
+
+		found = false
+		for _, epEntity := range endpoints.Values() {
+			var ep network_v1alpha.Endpoints
+			ep.Decode(epEntity.Entity())
+			if ep.ID == endpointID {
+				found = true
+				break
+			}
+		}
+		r.False(found, "Expected endpoints to be deleted when sandbox was deleted")
+	})
+
+	t.Run("handles service updates", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		reg, cleanup := testutils.Registry(observability.TestInject)
+		defer cleanup()
+
+		var (
+			sc  ServiceController
+			eac *entityserver_v1alpha.EntityAccessClient
+		)
+
+		err := reg.Init(&eac)
+		r.NoError(err)
+
+		err = reg.Populate(&sc)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		// Create initial service
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "nginx"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name: "http",
+					Port: 80,
+				},
+			},
+		}
+
+		meta := &entity.Meta{
+			Entity: &entity.Entity{
+				ID:    svcID,
+				Attrs: svc.Encode(),
+			},
+			Revision: 1,
+		}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		// Update service with additional port
+		svc.Port = append(svc.Port, network_v1alpha.Port{
+			Name: "https",
+			Port: 443,
+		})
+
+		meta.Entity.Attrs = svc.Encode()
+		meta.Revision = 2
+
+		// Re-create the service with updated configuration
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+	})
+
+	t.Run("handles multiple sandboxes matching one service", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		reg, cleanup := testutils.Registry(observability.TestInject, build.TestInject)
+		defer cleanup()
+
+		var (
+			sc  ServiceController
+			sbC sandbox.SandboxController
+			eac *entityserver_v1alpha.EntityAccessClient
+		)
+
+		err := reg.Init(&eac)
+		r.NoError(err)
+
+		err = reg.Populate(&sc)
+		r.NoError(err)
+
+		err = reg.Populate(&sbC)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		defer sbC.Close()
+
+		err = sbC.Init(ctx)
+		r.NoError(err)
+
+		// Create a service
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "nginx"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name: "http",
+					Port: 80,
+				},
+			},
+		}
+
+		// Store the service in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetAttrs(entity.Attrs(
+			entity.Keyword(entity.Ident, svcID.String()),
+			svc.Encode))
+		_, err = eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		meta := &entity.Meta{
+			Entity: &entity.Entity{
+				ID:    svcID,
+				Attrs: svc.Encode(),
+			},
+			Revision: 1,
+		}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		// Create first sandbox with containers and ports
+		sbID1 := entity.Id(sbName())
+		sb1 := &compute.Sandbox{
+			ID: sbID1,
+			Container: []compute.Container{
+				{
+					Name:  "nginx",
+					Image: "docker.io/library/nginx:latest",
+					Port: []compute.Port{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+		}
+
+		// Add metadata labels to entity attributes
+		attrs1 := sb1.Encode()
+		attrs1 = append(attrs1, entity.Label(core_v1alpha.MetadataLabelsId, "app", "nginx"))
+
+		sbEntity1 := &entity.Entity{
+			ID:    sbID1,
+			Attrs: attrs1,
+		}
+
+		sbMeta1 := &entity.Meta{
+			Entity:   sbEntity1,
+			Revision: 1,
+		}
+
+		err = sbC.Create(ctx, sb1, sbMeta1)
+		r.NoError(err)
+
+		// Create second sandbox with containers and ports
+		sbID2 := entity.Id(sbName())
+		sb2 := &compute.Sandbox{
+			ID: sbID2,
+			Container: []compute.Container{
+				{
+					Name:  "nginx",
+					Image: "docker.io/library/nginx:latest",
+					Port: []compute.Port{
+						{
+							Port: 80,
+						},
+					},
+				},
+			},
+		}
+
+		// Add metadata labels to entity attributes
+		attrs2 := sb2.Encode()
+		attrs2 = append(attrs2, entity.Label(core_v1alpha.MetadataLabelsId, "app", "nginx"))
+
+		sbEntity2 := &entity.Entity{
+			ID:    sbID2,
+			Attrs: attrs2,
+		}
+
+		sbMeta2 := &entity.Meta{
+			Entity:   sbEntity2,
+			Revision: 1,
+		}
+
+		err = sbC.Create(ctx, sb2, sbMeta2)
+		r.NoError(err)
+
+		// Give it a moment for endpoints to be created
+		time.Sleep(100 * time.Millisecond)
+
+		// Check that endpoints contain both sandboxes - each sandbox creates its own endpoint entity
+		endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+		r.NoError(err)
+
+		serviceEndpoints := 0
+		for _, epEntity := range endpoints.Values() {
+			var ep network_v1alpha.Endpoints
+			ep.Decode(epEntity.Entity())
+			if ep.Service == svcID {
+				serviceEndpoints++
+				// Each endpoint entity should have 1 endpoint (for one sandbox)
+				r.Len(ep.Endpoint, 1)
+			}
+		}
+		// Should have 2 separate endpoint entities, one for each sandbox
+		r.Equal(2, serviceEndpoints, "Expected to find 2 endpoint entities for service")
+
+		// Delete first sandbox
+		err = sbC.Delete(ctx, sbID1)
+		r.NoError(err)
+
+		// Give it a moment for endpoints to be updated
+		time.Sleep(100 * time.Millisecond)
+
+		// Check that only one endpoint entity remains after deleting first sandbox
+		endpoints, err = eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+		r.NoError(err)
+
+		serviceEndpoints = 0
+		for _, epEntity := range endpoints.Values() {
+			var ep network_v1alpha.Endpoints
+			ep.Decode(epEntity.Entity())
+			if ep.Service == svcID {
+				serviceEndpoints++
+				// Each endpoint entity should have 1 endpoint (for one sandbox)
+				r.Len(ep.Endpoint, 1)
+			}
+		}
+		// Should have 1 endpoint entity remaining after deleting first sandbox
+		r.Equal(1, serviceEndpoints, "Expected to find 1 endpoint entity for service after deleting first sandbox")
+
+		// Clean up
+		err = sbC.Delete(ctx, sbID2)
+		r.NoError(err)
+	})
+
+	t.Run("handles endpoint updates", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		reg, cleanup := testutils.Registry(observability.TestInject)
+		defer cleanup()
+
+		var (
+			sc  ServiceController
+			eac *entityserver_v1alpha.EntityAccessClient
+		)
+
+		err := reg.Init(&eac)
+		r.NoError(err)
+
+		err = reg.Populate(&sc)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		// Create a service
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "nginx"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name: "http",
+					Port: 80,
+				},
+			},
+		}
+
+		// Store the service in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetAttrs(entity.Attrs(
+			entity.Keyword(entity.Ident, svcID.String()),
+			svc.Encode))
+		_, err = eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		meta := &entity.Meta{
+			Entity: &entity.Entity{
+				ID:    svcID,
+				Attrs: svc.Encode(),
+			},
+			Revision: 1,
+		}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		// Create endpoints
+		epID := entity.Id("endpoints-" + svcID.String())
+		eps := &network_v1alpha.Endpoints{
+			ID:      epID,
+			Service: svcID,
+			Endpoint: []network_v1alpha.Endpoint{
+				{
+					Ip:   "10.0.0.1",
+					Port: 80,
+				},
+			},
+		}
+
+		event := controller.Event{
+			Entity: &entity.Entity{
+				ID:    epID,
+				Attrs: eps.Encode(),
+			},
+		}
+
+		// Update endpoints through the controller
+		_, err = sc.UpdateEndpoints(ctx, event)
+		r.NoError(err)
+	})
+
+	t.Run("handles service with nodeport", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		reg, cleanup := testutils.Registry(observability.TestInject)
+		defer cleanup()
+
+		var sc ServiceController
+		err := reg.Populate(&sc)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		// Create a service with nodeport
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "nginx"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name:     "http",
+					Port:     80,
+					NodePort: 30080,
+				},
+			},
+		}
+
+		meta := &entity.Meta{
+			Entity: &entity.Entity{
+				ID:    svcID,
+				Attrs: svc.Encode(),
+			},
+			Revision: 1,
+		}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+	})
+
+	t.Run("handles service IP allocation", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		reg, cleanup := testutils.Registry(observability.TestInject)
+		defer cleanup()
+
+		var (
+			sc  ServiceController
+			eac *entityserver_v1alpha.EntityAccessClient
+		)
+
+		err := reg.Init(&eac)
+		r.NoError(err)
+
+		err = reg.Populate(&sc)
+		r.NoError(err)
+
+		// Set service prefixes for IP allocation
+		servicePrefixes := []netip.Prefix{
+			netip.MustParsePrefix("10.96.0.0/16"),
+		}
+		sc.ServicePrefixes = servicePrefixes
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		// Create and start the IP allocator
+		ipalloc := ipalloc.NewAllocator(sc.Log, servicePrefixes)
+		
+		// Start watching for services in background
+		go func() {
+			err := ipalloc.Watch(ctx, eac)
+			if err != nil && ctx.Err() == nil {
+				r.NoError(err)
+			}
+		}()
+		
+		// Give the watcher a moment to start
+		time.Sleep(50 * time.Millisecond)
+
+		// Create a service
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "nginx"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name: "http",
+					Port: 80,
+				},
+			},
+		}
+
+		// Store the service in entity store first
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetAttrs(entity.Attrs(
+			entity.Keyword(entity.Ident, svcID.String()),
+			svc.Encode))
+		_, err = eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		meta := &entity.Meta{
+			Entity: &entity.Entity{
+				ID:    svcID,
+				Attrs: svc.Encode(),
+			},
+			Revision: 1,
+		}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		// Give ipalloc time to assign an IP
+		time.Sleep(100 * time.Millisecond)
+
+		// Re-read the service from entity storage to get the allocated IP
+		result, err := eac.Get(ctx, svcID.String())
+		r.NoError(err)
+		
+		var updatedSvc network_v1alpha.Service
+		updatedSvc.Decode(result.Entity().Entity())
+
+		// Verify service was allocated an IP
+		r.NotEmpty(updatedSvc.Ip)
+		r.Greater(len(updatedSvc.Ip), 0)
+		ip, err := netip.ParseAddr(updatedSvc.Ip[0])
+		r.NoError(err)
+		r.True(sc.ServicePrefixes[0].Contains(ip))
+	})
+}

--- a/controllers/service/service_test.go
+++ b/controllers/service/service_test.go
@@ -185,8 +185,11 @@ func TestServiceController(t *testing.T) {
 		err = sbC.Create(ctx, sb, sbMeta)
 		r.NoError(err)
 
-		// Give it a moment for endpoints to be created
-		time.Sleep(200 * time.Millisecond)
+		// Poll for endpoints to be created
+		require.Eventually(t, func() bool {
+			endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+			return err == nil && len(endpoints.Values()) > 0
+		}, 5*time.Second, 50*time.Millisecond, "Expected endpoints to be created")
 
 		// Check that endpoints were created
 		endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
@@ -313,8 +316,11 @@ func TestServiceController(t *testing.T) {
 		err = sbC.Create(ctx, sb, sbMeta)
 		r.NoError(err)
 
-		// Give it a moment for endpoints to be created
-		time.Sleep(100 * time.Millisecond)
+		// Poll for endpoints to be created
+		require.Eventually(t, func() bool {
+			endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+			return err == nil && len(endpoints.Values()) > 0
+		}, 5*time.Second, 50*time.Millisecond, "Expected endpoints to be created")
 
 		// Verify endpoints exist
 		endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
@@ -341,8 +347,11 @@ func TestServiceController(t *testing.T) {
 		err = sbC.Delete(ctx, sbID)
 		r.NoError(err)
 
-		// Give it a moment for endpoints to be deleted
-		time.Sleep(100 * time.Millisecond)
+		// Poll for endpoints to be created
+		require.Eventually(t, func() bool {
+			endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+			return err == nil && len(endpoints.Values()) != 2
+		}, 5*time.Second, 50*time.Millisecond, "Expected endpoints to be created")
 
 		// Verify endpoints are deleted
 		endpoints, err = eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
@@ -555,8 +564,11 @@ func TestServiceController(t *testing.T) {
 		err = sbC.Create(ctx, sb2, sbMeta2)
 		r.NoError(err)
 
-		// Give it a moment for endpoints to be created
-		time.Sleep(100 * time.Millisecond)
+		// Poll for endpoints to be created
+		require.Eventually(t, func() bool {
+			endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+			return err == nil && len(endpoints.Values()) != 0
+		}, 5*time.Second, 50*time.Millisecond, "Expected endpoints to be created")
 
 		// Check that endpoints contain both sandboxes - each sandbox creates its own endpoint entity
 		endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
@@ -579,8 +591,11 @@ func TestServiceController(t *testing.T) {
 		err = sbC.Delete(ctx, sbID1)
 		r.NoError(err)
 
-		// Give it a moment for endpoints to be updated
-		time.Sleep(100 * time.Millisecond)
+		// Poll for endpoints to be created
+		require.Eventually(t, func() bool {
+			endpoints, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+			return err == nil && len(endpoints.Values()) != 2
+		}, 5*time.Second, 50*time.Millisecond, "Expected endpoints to be created")
 
 		// Check that only one endpoint entity remains after deleting first sandbox
 		endpoints, err = eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/containerd/containerd v1.7.23
 	github.com/containerd/containerd/api v1.8.0
 	github.com/containerd/containerd/v2 v2.0.2
+	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/containerd/typeurl/v2 v2.2.3
@@ -157,7 +158,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.4.5 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/nydus-snapshotter v0.15.0 // indirect

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -652,6 +652,16 @@ func (s *EtcdStore) UpdateEntity(
 
 	entity.Attrs = primary
 
+	// Set UpdatedAt based on whether it was explicitly provided or already exists
+	// Check if UpdatedAt attribute exists in the entity after update
+	if updatedAtAttr, ok := entity.Get(UpdatedAt); ok && updatedAtAttr.Value.Kind() == KindInt64 {
+		entity.UpdatedAt = updatedAtAttr.Value.Int64()
+		// Remove it from attributes since we're promoting it to the field
+		entity.Remove(UpdatedAt)
+	} else {
+		entity.UpdatedAt = now()
+	}
+
 	data, err := encoder.Marshal(entity)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize entity: %w", err)

--- a/pkg/entity/system.go
+++ b/pkg/entity/system.go
@@ -61,6 +61,8 @@ const (
 	Schema Id = "db/schema"
 
 	TTL Id = "db/entity.ttl"
+
+	UpdatedAt Id = "db/entity.updated-at"
 )
 
 func InitSystemEntities(save func(*Entity) error) error {
@@ -172,6 +174,15 @@ func InitSystemEntities(save func(*Entity) error) error {
 			Doc, "Time to live for this entity",
 			Cardinality, CardinalityOne,
 			Type, TypeDuration,
+		),
+	}
+
+	updatedAt := &Entity{
+		Attrs: Attrs(
+			Ident, types.Keyword(UpdatedAt),
+			Doc, "Last update timestamp for this entity",
+			Cardinality, CardinalityOne,
+			Type, TypeInt,
 		),
 	}
 
@@ -300,7 +311,7 @@ func InitSystemEntities(save func(*Entity) error) error {
 		ident, doc, uniq, card, typ, enumValues, enumType,
 		uniqueIdentity, uniqueValue, cardOne, cardMany,
 		typeAny, typeRef, typeStr, typeKW, typeInt, typeFloat, typeBool, typeTime, typeEnum,
-		typeArray, typeDuration, typeComponent, typeLabel, typeBytes, index, session, ttl,
+		typeArray, typeDuration, typeComponent, typeLabel, typeBytes, index, session, ttl, updatedAt,
 		attrSession,
 		attrPred, predIP, predCidr, entityAttrs, entityPreds, entityEnsure,
 		entityKind, entitySchema, entityESchema, schemaKind,

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -187,7 +187,6 @@ func (e *EntityServer) Put(ctx context.Context, req *entityserver_v1alpha.Entity
 	var opts []entity.EntityOption
 
 	if rpcE.HasId() {
-		// TODO: handle updated_at
 		e.Log.Debug("updating entity", "id", rpcE.Id(), "revision", rpcE.Revision())
 
 		// If the entity has a revision, then make sure that we're updating that specific entity.
@@ -209,7 +208,6 @@ func (e *EntityServer) Put(ctx context.Context, req *entityserver_v1alpha.Entity
 		}
 	}
 
-	// TODO: handle created_at and updated_at fields
 	re, err := e.Store.CreateEntity(ctx, attrs, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create entity in put: %w", err)
@@ -252,7 +250,6 @@ func (e *EntityServer) PutSession(ctx context.Context, req *entityserver_v1alpha
 	opts = append(opts, entity.WithSession(data))
 
 	if rpcE.HasId() {
-		// TODO: handle updated_at
 		re, err := e.Store.UpdateEntity(ctx, entity.Id(rpcE.Id()), attrs, opts...)
 		if err != nil {
 			if !errors.Is(err, entity.ErrNotFound) {
@@ -263,7 +260,6 @@ func (e *EntityServer) PutSession(ctx context.Context, req *entityserver_v1alpha
 			results.SetId(re.ID.String())
 		}
 	} else {
-		// TODO: handle created_at and updated_at fields
 		re, err := e.Store.CreateEntity(ctx, attrs, opts...)
 		if err != nil {
 			return fmt.Errorf("failed to create entity: %w", err)


### PR DESCRIPTION
## Summary

This PR implements automatic cleanup functionality that removes dead sandboxes older than 1 hour from the entity store, preventing accumulation of stale records.

## Key Changes

### UpdatedAt System Attribute
- Added `UpdatedAt` as a proper system attribute that gets automatically set on entity updates
- Enhanced `EtcdStore.UpdateEntity` to detect and promote `UpdatedAt` values to the entity struct field
- Allows explicit setting of `UpdatedAt` for testing while auto-updating for normal operations

### Periodic Controller Framework
- Extended `ReconcileController` with optional periodic callback support (runs every 10 minutes)
- Added `PeriodicController` interface for controllers that need maintenance tasks
- Modified runner to detect and wire up periodic callbacks automatically

### Dead Sandbox Cleanup
- Implemented `Periodic` method in `SandboxController` that:
  - Lists all sandboxes and checks their status and last update time
  - Deletes sandboxes that have been `DEAD` for more than 1 hour
  - Logs cleanup actions for monitoring
- Runs automatically every 10 minutes via the periodic callback framework

### Supporting Changes
- Fixed entity conversion in `entityserver` to properly populate `CreatedAt`/`UpdatedAt` fields
- Added comprehensive test with proper `Ident` attributes to verify cleanup behavior
- Updated runner to integrate periodic callbacks with sandbox controller

## Test Plan

- [x] Added test that creates sandboxes, marks one as dead with old timestamp, and verifies cleanup
- [x] Test uses proper `Ident` attributes to ensure predictable entity names
- [x] Verified periodic cleanup removes only old dead sandboxes while preserving active ones
- [x] Confirmed `UpdatedAt` attribute promotion and field population works correctly

## Impact

This prevents the entity store from accumulating dead sandbox records indefinitely, improving system cleanliness and potentially reducing storage/query overhead over time. The 1-hour grace period ensures sandboxes aren't cleaned up too aggressively while still maintaining reasonable cleanup intervals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic cleanup to automatically remove dead sandboxes older than one hour.
  * Enhanced sandbox lifecycle management with improved cleanup, retry logic, and robust endpoint deletion.
  * Service controller now has comprehensive tests covering service and endpoint lifecycle, updates, and IP allocation.
  * Introduced periodic task support for controllers, enabling scheduled background operations.
  * Extended entity data to include creation and update timestamps for better tracking.

* **Bug Fixes**
  * Improved handling of entity update timestamps to ensure accurate tracking of changes.

* **Documentation**
  * Expanded test coverage for sandbox and service controllers, improving reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->