### PR TITLE
Fix make dist to output to dist/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.test
 tmp/
 bin/
+dist/
 .aider*
 .idea/
 .claude

--- a/hack/build-dist.sh
+++ b/hack/build-dist.sh
@@ -67,30 +67,30 @@ FROM scratch
 COPY --from=builder /build/runtime /runtime
 EOF
 
-# Ensure bin directory exists
-mkdir -p ./bin
+# Ensure dist directory exists
+mkdir -p ./dist
 
 # Build using Docker with version passed as build argument and export binary directly
 # Specify platform to ensure consistent builds across different architectures
-docker build --platform=linux/amd64 -f "$DOCKERFILE" --build-arg "VERSION=$version" --output type=local,dest=./bin .
+docker build --platform=linux/amd64 -f "$DOCKERFILE" --build-arg "VERSION=$version" --output type=local,dest=./dist .
 
 # Rename the binary to runtime-dist
-mv ./bin/runtime ./bin/runtime-dist
+mv ./dist/runtime ./dist/runtime-dist
 
 # Make it executable
-chmod +x ./bin/runtime-dist
+chmod +x ./dist/runtime-dist
 
-echo "Portable binary created at ./bin/runtime-dist"
+echo "Portable binary created at ./dist/runtime-dist"
 
 # Verify it's statically linked
 echo ""
 echo "Binary info:"
-file ./bin/runtime-dist
+file ./dist/runtime-dist
 
 # Show ldd info if available (will show "not a dynamic executable" for static binaries)
 if command -v ldd >/dev/null 2>&1; then
     echo ""
     echo "Dynamic dependencies:"
-    ldd ./bin/runtime-dist 2>&1 || echo "No dynamic dependencies (static binary)"
+    ldd ./dist/runtime-dist 2>&1 || echo "No dynamic dependencies (static binary)"
 fi
 


### PR DESCRIPTION
## Summary
- Changed `make dist` output from `bin/` to `dist/` directory to prevent clobbering existing binaries
- Added `dist/` to `.gitignore`

## Problem
The `docker build --output type=local,dest=./bin` command in `build-dist.sh` was exporting the entire Alpine Linux filesystem to the `bin/` directory, overwriting any existing files there.

## Solution
Updated the script to output to a separate `dist/` directory instead, keeping build artifacts isolated from development binaries.

## Test plan
- [ ] Run `make dist` and verify it creates `dist/runtime-dist`
- [ ] Verify existing files in `bin/` are not affected
- [ ] Confirm the binary is still statically linked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script and project settings to use the dist/ directory for build outputs.
  * Ensured the dist/ directory is excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->