### PR TITLE
Improve BuildKit lifecycle logging and retry client connection

### DIFF
--- a/pkg/testutils/reg.go
+++ b/pkg/testutils/reg.go
@@ -98,8 +98,17 @@ func Registry(extra ...func(*asm.Registry)) (*asm.Registry, func()) {
 		return cl, nil
 	})
 
-	r.Provide(func() (*buildkit.Client, error) {
-		return buildkit.New(context.TODO(), "")
+	r.Provide(func(opts struct {
+		Log *slog.Logger
+	}) (*buildkit.Client, error) {
+		opts.Log.Debug("creating buildkit client for tests with default address")
+		client, err := buildkit.New(context.TODO(), "")
+		if err != nil {
+			opts.Log.Error("failed to create buildkit client for tests", "error", err)
+		} else {
+			opts.Log.Info("buildkit client created for tests")
+		}
+		return client, err
 	})
 
 	ts := time.Now()

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -195,34 +195,49 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	b.Log.Debug("launching buildkitd")
 
 	cacheDir := filepath.Join(b.TempDir, "buildkit-cache")
-	os.MkdirAll(cacheDir, 0755)
+	b.Log.Debug("creating buildkit cache directory", "path", cacheDir)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		b.Log.Error("failed to create buildkit cache directory", "error", err, "path", cacheDir)
+		return fmt.Errorf("failed to create buildkit cache directory: %w", err)
+	}
 
 	lbk := &LaunchBuildkit{
 		log: b.Log.With("module", "launchbuildkit"),
 		eac: b.EAS,
 	}
+	b.Log.Debug("created LaunchBuildkit instance")
 
+	b.Log.Debug("resolving cluster.local for buildkit")
 	ip, err := b.Resolver.LookupHost("cluster.local")
 	if err != nil {
+		b.Log.Error("failed to resolve cluster.local", "error", err)
 		return fmt.Errorf("error resolving cluster.local: %w", err)
 	}
+	b.Log.Debug("resolved cluster.local", "ip", ip.String())
 
+	b.Log.Info("starting buildkit launch", "clusterIP", ip.String(), "logEntity", name)
 	rbk, err := lbk.Launch(ctx, ip.String(), WithLogEntity(name), WithLogAttrs(map[string]string{
 		"version": "build",
 	}))
 	if err != nil {
+		b.Log.Error("failed to launch buildkit", "error", err)
 		return err
 	}
+	b.Log.Info("buildkit launch completed successfully")
 
 	defer rbk.Close(context.Background())
 
+	b.Log.Debug("attempting to get buildkit client")
 	bkc, err := rbk.Client(ctx)
 	if err != nil {
+		b.Log.Error("failed to get buildkit client", "error", err)
 		return err
 	}
+	b.Log.Debug("successfully obtained buildkit client")
 
 	defer bkc.Close()
 
+	b.Log.Debug("getting buildkit daemon info")
 	ci, err := bkc.Info(ctx)
 	if err != nil {
 		b.Log.Error("error getting buildkid info", "error", err)

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -196,9 +196,9 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 
 	cacheDir := filepath.Join(b.TempDir, "buildkit-cache")
 	b.Log.Debug("creating buildkit cache directory", "path", cacheDir)
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		b.Log.Error("failed to create buildkit cache directory", "error", err, "path", cacheDir)
-		return fmt.Errorf("failed to create buildkit cache directory: %w", err)
+	if err := initializeBuildKitCache(cacheDir); err != nil {
+		b.Log.Error("failed to initialize buildkit cache directory", "error", err, "path", cacheDir)
+		return fmt.Errorf("failed to initialize buildkit cache directory: %w", err)
 	}
 
 	lbk := &LaunchBuildkit{

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -454,7 +455,7 @@ func (b *Buildkit) BuildImage(
 				}
 				if data, err := json.Marshal(ss); err == nil {
 					if opts.phaseUpdates != nil {
-						for _, s := range ss.Vertexes {
+						for _, s := range ss.Vertexes { // codespell:ignore
 							if s.Started == nil || s.Completed != nil {
 								continue
 							}
@@ -508,4 +509,23 @@ func (b *Buildkit) BuildImage(
 	}, ssProgress)
 
 	return &res, err
+}
+
+func initializeBuildKitCache(cacheDir string) error {
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return err
+	}
+
+	// Create a minimal index.json, which prevents a warning log on buildkit's first boot
+	indexPath := filepath.Join(cacheDir, "index.json")
+	indexContent := []byte(`{"manifests":[]}`)
+
+	// Only create if it doesn't already exist
+	if _, err := os.Stat(indexPath); os.IsNotExist(err) {
+		if err := os.WriteFile(indexPath, indexContent, 0644); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
- **Add comprehensive logging to buildkit connection process**
- **Initialize buildkit cache to avoid warning**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced logging throughout the build process, including detailed debug and informational messages during server setup, buildkit client creation, and build phases.
  * Improved error reporting for buildkit cache initialization and client connection issues.

* **Bug Fixes**
  * Increased reliability when establishing connections to the buildkit server by introducing retry logic with exponential backoff.

* **Chores**
  * Added automatic creation of a minimal cache file to prevent first-time warning logs from BuildKit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->