### PR TITLE
MIR-252: Fix buildkit hang when deploying unsupported stacks

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -237,7 +237,11 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 	b.Log.Info("buildkit launch completed successfully")
 
-	defer rbk.Close(ctx)
+	defer func() {
+		if err := rbk.Close(ctx); err != nil {
+			b.Log.Error("failed to close buildkit", "error", err)
+		}
+	}()
 
 	b.Log.Debug("attempting to get buildkit client")
 	bkc, err := rbk.Client(ctx)

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -26,6 +26,7 @@ import (
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/procfile"
 	"miren.dev/runtime/pkg/rpc/stream"
+	"miren.dev/runtime/pkg/stackbuild"
 	"miren.dev/runtime/pkg/tarx"
 )
 
@@ -192,7 +193,18 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		}
 	}
 
-	b.Log.Debug("launching buildkitd")
+	// Check if stack is supported before launching buildkit
+	if buildStack.Stack == "auto" {
+		_, err := stackbuild.DetectStack(buildStack.CodeDir)
+		if err != nil {
+			b.Log.Error("stack detection failed", "error", err, "app", name, "codeDir", buildStack.CodeDir)
+			return fmt.Errorf("no supported stack detected for app %s: %w", name, err)
+		}
+		b.Log.Debug("stack detection successful, proceeding with build")
+	}
+
+	// Now we know the stack is valid, proceed with buildkit setup
+	b.Log.Debug("setting up buildkit")
 
 	cacheDir := filepath.Join(b.TempDir, "buildkit-cache")
 	b.Log.Debug("creating buildkit cache directory", "path", cacheDir)
@@ -225,7 +237,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 	b.Log.Info("buildkit launch completed successfully")
 
-	defer rbk.Close(context.Background())
+	defer rbk.Close(ctx)
 
 	b.Log.Debug("attempting to get buildkit client")
 	bkc, err := rbk.Client(ctx)


### PR DESCRIPTION
## Summary
- Add early stack detection before launching buildkit sandbox to prevent hangs
- Fix context usage in defer rbk.Close() to respect cancellation
- System now fails fast with clear error message for unsupported stacks

## Problem
When deploying apps with unsupported stacks (like HTML-only apps), buildkit would hang indefinitely, leaving orphaned sandbox entities that continuously failed to reconcile.

## Solution
Check if the stack is supported BEFORE launching the buildkit sandbox. This prevents:
1. Unnecessary buildkit sandbox creation
2. Hanging buildkit processes
3. Orphaned sandbox entities in etcd

## Test plan
- [x] Deploy an HTML app (unsupported stack) and verify it fails quickly with error message
- [x] Verify no buildkit sandboxes are created for unsupported stacks
- [x] Deploy a supported app (Go/Node/Python) and verify it still works correctly
- [x] Check that no orphaned sandbox entities remain after failed deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and validation of the build stack when the stack type is set to "auto". Builds will now abort with an error if stack detection fails.

* **Improvements**
  * Enhanced logging during the build process to provide clearer status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->