### PR TITLE
Fix QUIC stream exhaustion and optimize large file transfers

### DIFF
--- a/pkg/rpc/inline.go
+++ b/pkg/rpc/inline.go
@@ -150,6 +150,10 @@ func (c *inlineClient) Call(ctx context.Context, method string, args any, ret an
 	var rr refResponse
 
 	// Read response without timeout loop - let QUIC handle flow control
+	if err := ctx.Err(); err != nil {
+		shouldReturn = false
+		return err
+	}
 	err = conn.dec.Decode(&rr)
 	if err != nil {
 		shouldReturn = false

--- a/pkg/rpc/inline.go
+++ b/pkg/rpc/inline.go
@@ -4,61 +4,155 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"time"
+	"sync"
 
 	"github.com/fxamacker/cbor/v2"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/webtransport"
 )
 
+const inlineStreamPoolSize = 10
+
+type streamConn struct {
+	stream webtransport.Stream
+	enc    *cbor.Encoder
+	dec    *cbor.Decoder
+}
+
 type inlineClient struct {
 	log     *slog.Logger
 	oid     OID
 	ctrl    *controlStream
 	session *webtransport.Session
+
+	// Stream pool
+	poolMu      sync.Mutex
+	pool        chan *streamConn
+	activeCount int // tracks total active streams (in use + in pool)
+	closed      bool
+}
+
+// initPool initializes the stream pool
+func (c *inlineClient) initPool() {
+	c.poolMu.Lock()
+	defer c.poolMu.Unlock()
+
+	if c.pool != nil {
+		return
+	}
+
+	c.pool = make(chan *streamConn, inlineStreamPoolSize)
+}
+
+// getStream gets a stream from the pool or creates a new one if pool is not full
+func (c *inlineClient) getStream(ctx context.Context) (*streamConn, error) {
+	// Ensure pool is initialized
+	c.initPool()
+
+	// Try to get an existing stream from the pool
+	select {
+	case conn := <-c.pool:
+		return conn, nil
+	default:
+		// Pool is empty, check if we can create a new stream
+		c.poolMu.Lock()
+		canCreate := c.activeCount < inlineStreamPoolSize
+		if canCreate {
+			c.activeCount++
+		}
+		c.poolMu.Unlock()
+
+		if canCreate {
+			// We can create a new stream
+			str, err := c.session.OpenStreamSync(ctx)
+			if err != nil {
+				// Decrement counter on error
+				c.poolMu.Lock()
+				c.activeCount--
+				c.poolMu.Unlock()
+				return nil, err
+			}
+
+			return &streamConn{
+				stream: str,
+				enc:    cbor.NewEncoder(str),
+				dec:    cbor.NewDecoder(str),
+			}, nil
+		}
+
+		// Pool is at capacity, wait for a stream to become available
+		select {
+		case conn := <-c.pool:
+			return conn, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// returnStream returns a stream to the pool for reuse
+func (c *inlineClient) returnStream(conn *streamConn) {
+	c.poolMu.Lock()
+	defer c.poolMu.Unlock()
+
+	if c.closed {
+		_ = conn.stream.Close()
+		c.activeCount--
+		return
+	}
+
+	// Try to return to pool
+	select {
+	case c.pool <- conn:
+		// Successfully returned to pool (activeCount stays the same)
+	default:
+		// Pool is full, close the stream
+		_ = conn.stream.Close()
+		c.activeCount--
+	}
 }
 
 func (c *inlineClient) Call(ctx context.Context, method string, args any, ret any) error {
-	str, err := c.session.OpenStreamSync(ctx)
+	conn, err := c.getStream(ctx)
 	if err != nil {
 		return err
 	}
 
-	defer str.Close()
+	// Return stream to pool when done (unless there's an error)
+	shouldReturn := true
+	defer func() {
+		if shouldReturn {
+			c.returnStream(conn)
+		} else {
+			_ = conn.stream.Close()
+			c.poolMu.Lock()
+			c.activeCount--
+			c.poolMu.Unlock()
+		}
+	}()
 
-	enc := cbor.NewEncoder(str)
-
-	enc.Encode(streamRequest{
+	err = conn.enc.Encode(streamRequest{
 		Kind:   "call",
 		OID:    c.oid,
 		Method: method,
 	})
+	if err != nil {
+		shouldReturn = false
+		return err
+	}
 
-	enc.Encode(args)
-
-	dec := cbor.NewDecoder(str)
+	err = conn.enc.Encode(args)
+	if err != nil {
+		shouldReturn = false
+		return err
+	}
 
 	var rr refResponse
 
-	for {
-		ts := time.Now().Add(1 * time.Second)
-		str.SetReadDeadline(ts)
-
-		err = dec.Decode(&rr)
-		if err == nil {
-			break
-		}
-
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		if to, ok := err.(interface {
-			Timeout() bool
-		}); ok && to.Timeout() {
-			continue
-		}
-
+	// Read response without timeout loop - let QUIC handle flow control
+	err = conn.dec.Decode(&rr)
+	if err != nil {
+		shouldReturn = false
 		return err
 	}
 
@@ -66,13 +160,13 @@ func (c *inlineClient) Call(ctx context.Context, method string, args any, ret an
 	case "error":
 		return cond.RemoteError(rr.Category, rr.Code, rr.Error)
 	case "ok":
-		return dec.Decode(ret)
+		return conn.dec.Decode(ret)
 	default:
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
-		return fmt.Errorf("unknown response status to %s/%s: %s: %w", c.oid, method, rr.Status, err)
+		return fmt.Errorf("unknown response status to %s/%s: %s", c.oid, method, rr.Status)
 	}
 }
 
@@ -83,4 +177,25 @@ func (c *inlineClient) derefOID(ctx context.Context, oid OID) error {
 	}, nil)
 
 	return err
+}
+
+// Close closes all streams in the pool
+func (c *inlineClient) Close() error {
+	c.poolMu.Lock()
+	defer c.poolMu.Unlock()
+
+	c.closed = true
+
+	if c.pool == nil {
+		return nil
+	}
+
+	// Close all streams in the pool
+	close(c.pool)
+	for conn := range c.pool {
+		_ = conn.stream.Close()
+		c.activeCount--
+	}
+
+	return nil
 }

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/qlog"
 	"miren.dev/runtime/pkg/packet"
 	"miren.dev/runtime/pkg/slogfmt"
 	"miren.dev/runtime/pkg/webtransport"
@@ -45,6 +46,7 @@ func init() {
 		Allow0RTT:             true,
 		KeepAlivePeriod:       10 * time.Second,
 		MaxIdleTimeout:        30 * time.Second,
+		Tracer:                qlog.DefaultConnectionTracer,
 	}
 
 	DefaultTransport.QUICConfig = &DefaultQUICConfig
@@ -290,6 +292,7 @@ func NewState(ctx context.Context, opts ...StateOption) (*State, error) {
 		MaxIncomingUniStreams: 1000,
 		Allow0RTT:             true,
 		KeepAlivePeriod:       10 * time.Second,
+		Tracer:                qlog.DefaultConnectionTracer,
 	}
 
 	s.qc = qc


### PR DESCRIPTION
  ## Summary

  This PR fixes critical performance issues with large file uploads in the RPC system, specifically addressing QUIC stream exhaustion and slow transfer speeds when deploying
  applications with large assets.

  Fixes MIR-247

  ## Problem

  When deploying applications with large files (10MB+), the system would:
  1. Hit QUIC's 1000 bidirectional stream limit with error: "blocked at 1000 bidirectional streams"
  2. Transfer files extremely slowly (~110-185 KB/s instead of expected 5-10 MB/s)
  3. Keep RPC streams open unnecessarily during long build processes

  ## Root Causes

  1. **Stream Exhaustion**: Each inline RPC call created a new QUIC stream, quickly exhausting the 1000 stream limit
  2. **Small Chunk Size**: Using 4KB chunks meant a 10MB file required ~2,500 RPC round-trips
  3. **Stream Lifecycle**: Streams weren't closed promptly after data transfer completed

  ## Solution

  ### 1. QLOG Debugging Support (a3ac7be)
  - Added QLOG tracing to diagnose QUIC performance issues
  - Enabled by setting QLOGDIR environment variable
  - Helped identify the root causes below

  ### 2. Stream Pooling (f18e9e3)
  - Implemented stream pool (size 10) for inline clients
  - Streams are reused instead of being closed after each call
  - Includes proper concurrency control with activeCount tracking to prevent races
  - Testing shows: reduced from 280 unique streams to only 6 streams with massive reuse

  ### 3. Chunk Size Optimization (0c32d5b)
  - Increased chunk size from 4KB to 1MB with buffering
  - Reduces 10MB transfer from ~2,500 to ~10 RPC calls
  - Expected 100-250x throughput improvement

  ### 4. Context Cancellation Check (f5eabe9)
  - Added context check before decode operations
  - Handles client-side cancellations more responsively

  ## Testing

  - Manual testing with large file deployments
  - QLOG analysis confirmed stream reuse working correctly:
    - Before: 280 unique streams created → exhaustion
    - After: Only 6 unique streams, main stream reused 7,444 times
  - Observed transfer rates improved from 110-185 KB/s to expected speeds

  ## Review Notes

  The history has been rebased to simplify the implementation details. The final solution uses stream pooling rather than semaphore-based limiting, as it provides better performance
   and resource management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced connection tracing for QUIC connections to enhance observability.
  * Added chunked reading and writing for streaming, optimizing performance and memory usage.

* **Improvements**
  * Implemented a concurrency-limited stream pooling mechanism to reduce overhead and improve efficiency for stream-based operations.
  * Enhanced handling of multiple requests per stream for improved responsiveness and throughput.

* **Bug Fixes**
  * Improved resource cleanup and error handling when closing network clients and streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->