### PR TITLE
Revert "Initialize buildkit cache to avoid warning"

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -208,9 +208,9 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 
 	cacheDir := filepath.Join(b.TempDir, "buildkit-cache")
 	b.Log.Debug("creating buildkit cache directory", "path", cacheDir)
-	if err := initializeBuildKitCache(cacheDir); err != nil {
-		b.Log.Error("failed to initialize buildkit cache directory", "error", err, "path", cacheDir)
-		return fmt.Errorf("failed to initialize buildkit cache directory: %w", err)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		b.Log.Error("failed to create buildkit cache directory", "error", err, "path", cacheDir)
+		return fmt.Errorf("failed to create buildkit cache directory: %w", err)
 	}
 
 	lbk := &LaunchBuildkit{

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -455,7 +454,7 @@ func (b *Buildkit) BuildImage(
 				}
 				if data, err := json.Marshal(ss); err == nil {
 					if opts.phaseUpdates != nil {
-						for _, s := range ss.Vertexes { // codespell:ignore
+						for _, s := range ss.Vertexes {
 							if s.Started == nil || s.Completed != nil {
 								continue
 							}
@@ -509,23 +508,4 @@ func (b *Buildkit) BuildImage(
 	}, ssProgress)
 
 	return &res, err
-}
-
-func initializeBuildKitCache(cacheDir string) error {
-	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		return err
-	}
-
-	// Create a minimal index.json, which prevents a warning log on buildkit's first boot
-	indexPath := filepath.Join(cacheDir, "index.json")
-	indexContent := []byte(`{"manifests":[]}`)
-
-	// Only create if it doesn't already exist
-	if _, err := os.Stat(indexPath); os.IsNotExist(err) {
-		if err := os.WriteFile(indexPath, indexContent, 0644); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
This reverts commit 6da90e05348e7e0f3b47c4d31673c59bbf4e8c88.

Turns out, buildkit hates there being an empty index.json way more than it hates there not being one there!

Deploys were failing with the following error:

```
22:04:27.697 [ERROR] coordinator.builder error building image │ error:
  │ local cache importer requires either explicit digest, "latest" tag or custom tag on index.json
  │ github.com/moby/buildkit/client.parseCacheOptions
  │     /go/pkg/mod/github.com/moby/buildkit@v0.19.0/client/solve.go:502
  │ github.com/moby/buildkit/client.(*Client).solve
  │     /go/pkg/mod/github.com/moby/buildkit@v0.19.0/client/solve.go:128
  │ github.com/moby/buildkit/client.(*Client).Solve
  │     /go/pkg/mod/github.com/moby/buildkit@v0.19.0/client/solve.go:84
  │ miren.dev/runtime/servers/build.(*Buildkit).BuildImage
  │     /build/servers/build/buildkit.go:482
  │ miren.dev/runtime/servers/build.(*Builder).BuildFromTar
  │     /build/servers/build/build.go:318
  │ miren.dev/runtime/api/build/build_v1alpha.AdaptBuilder.func1
  │     /build/api/build/build_v1alpha/rpc.gen.go:407
  │ miren.dev/runtime/pkg/rpc.(*Server).startCallStream
  │     /build/pkg/rpc/server.go:839
  │ net/http.HandlerFunc.ServeHTTP
  │     /usr/local/go/src/net/http/server.go:2294
  │ net/http.(*ServeMux).ServeHTTP
  │     /usr/local/go/src/net/http/server.go:2822
  │ miren.dev/runtime/pkg/rpc.(*Server).ServeHTTP
  │     /build/pkg/rpc/server.go:309
  │ github.com/quic-go/quic-go/http3.(*Server).handleRequest.func2
  │     /go/pkg/mod/github.com/quic-go/quic-go@v0.49.0/http3/server.go:690
  │ github.com/quic-go/quic-go/http3.(*Server).handleRequest
  │     /go/pkg/mod/github.com/quic-go/quic-go@v0.49.0/http3/server.go:691
  │ github.com/quic-go/quic-go/http3.(*Server).handleConn.func1
  │     /go/pkg/mod/github.com/quic-go/quic-go@v0.49.0/http3/server.go:578
  │ runtime.goexit
  │     /usr/local/go/src/runtime/asm_amd64.s:1700
```

Turns out if the index.json is there, it assumes some relevant stuff is gonna be in it:

https://github.com/moby/buildkit/blob/0396f3eda2c756696cfc773dc2cc15845891176b/client/solve.go#L490-L511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the process for creating the build cache directory, removing a custom initialization step.
  * Improved error messages related to directory creation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->