### PR TITLE
Fix sandbox recycling for slow request patterns

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -115,6 +115,7 @@ func (a *localActivator) AcquireLease(ctx context.Context, ver *core_v1alpha.App
 			s := vs.sandboxes[(start+i)%len(vs.sandboxes)]
 			if s.inuseSlots+vs.leaseSlots < s.maxSlots {
 				s.inuseSlots += vs.leaseSlots
+				s.lastRenewal = time.Now()
 
 				a.log.Debug("reusing sandbox", "app", ver.App, "version", ver.Version, "sandbox", s.sandbox.ID, "in-use", s.inuseSlots)
 				return &Lease{


### PR DESCRIPTION
When httpingress handles slow traffic (e.g., 1 req/5s), it regularly
expires and reacquires leases from the activator. Previously, when
reusing an existing sandbox for a new lease in AcquireLease, the
lastRenewal timestamp was not updated.

This caused the background retireUnusedSandboxes process to incorrectly
identify these actively-used sandboxes as stale (>2 minutes without
renewal) and retire them, leading to unnecessary sandbox recycling.

Update lastRenewal when reusing a sandbox to properly track its
activity and prevent premature retirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox management by updating the renewal timestamp when a sandbox is reused, ensuring more accurate tracking of activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->