### PR TITLE
Fix activator lease release pool mismatch

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -122,6 +122,7 @@ func (a *localActivator) AcquireLease(ctx context.Context, ver *core_v1alpha.App
 					ver:     ver,
 					sandbox: s.sandbox,
 					ent:     s.ent,
+					pool:    pool,
 					Size:    vs.leaseSlots,
 					URL:     s.url,
 				}, nil
@@ -272,6 +273,7 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 		ver:     ver,
 		sandbox: lsb.sandbox,
 		ent:     lsb.ent,
+		pool:    pool,
 		Size:    leaseSlots,
 		URL:     lsb.url,
 	}


### PR DESCRIPTION
## Summary
- Fixed activator failing to release leases due to missing pool field in Lease objects
- Prevents slot accumulation and unnecessary sandbox retirement

## Problem
The activator was experiencing a pool mismatch between AcquireLease and ReleaseLease calls:
- AcquireLease: called with `pool: "http"` (from httpingress) or `pool: "exec"` (from exec_proxy)
- ReleaseLease: received leases with `pool: ""`

This caused ReleaseLease to fail with "version not found" warnings because it was constructing the wrong version key. As a result:
- Slots weren't being released properly
- Sandboxes accumulated active slots until forcibly retired
- Unnecessary sandbox churn occurred

## Solution
Set the `pool` field when creating Lease objects in both:
1. The reuse path (when assigning existing sandbox to new lease)
2. The new sandbox creation path

Now ReleaseLease can correctly identify the pool and decrement slots.

## Test plan
- [x] Code changes are minimal and focused
- [x] Verified the pool field is now set in both lease creation paths
- [ ] Deploy to staging and monitor activator logs for:
  - No more "ReleaseLease: version not found" warnings
  - No more "retiring sandbox with active slots\!" warnings
  - Proper slot accounting (slots should go up and down, not just accumulate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lease objects now consistently include pool information, ensuring accurate tracking of app version and sandbox associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->