### PR TITLE
Fix Darwin build: Add server_darwin.go stub

### DIFF
--- a/cli/commands/dev_darwin.go
+++ b/cli/commands/dev_darwin.go
@@ -1,7 +1,0 @@
-//go:build darwin
-
-package commands
-
-func Dev(ctx *Context, opts struct{}) error {
-	return nil
-}

--- a/cli/commands/server_darwin.go
+++ b/cli/commands/server_darwin.go
@@ -1,0 +1,10 @@
+//go:build darwin
+// +build darwin
+
+package commands
+
+import "fmt"
+
+func Server(ctx *Context, opts struct{}) error {
+	return fmt.Errorf("server command is not supported on macOS/Darwin")
+}


### PR DESCRIPTION
## Summary
- Added a Darwin (macOS) stub for the server command that returns an error message
- This fixes the CI/CD build error that occurred after renaming the 'dev' command to 'server'

## Background
The server command is Linux-only (with `//go:build linux` constraint). After the rename from 'dev' to 'server', Darwin builds were failing because there was no implementation for the server command on macOS.

## Test plan
- [ ] Verify that the CI/CD pipeline passes on all platforms
- [ ] Confirm that running `runtime server` on macOS shows the appropriate error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear message indicating that the server command is not supported on macOS.

* **Bug Fixes**
  * Prevented the server command from running on macOS by displaying an appropriate error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->