### PR TITLE
Fix certificate name conflict: Change from 'runtime' to 'runtime-server'

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -566,10 +566,10 @@ func Server(ctx *Context, opts struct {
 		return err
 	}
 
-	cert, err := co.IssueCertificate("runtime")
+	cert, err := co.IssueCertificate("runtime-server")
 	if err != nil {
-		ctx.Log.Error("failed to issue dev certificate", "error", err)
-		return fmt.Errorf("failed to issue dev certificate: %w", err)
+		ctx.Log.Error("failed to issue server certificate", "error", err)
+		return fmt.Errorf("failed to issue server certificate: %w", err)
 	}
 
 	if opts.ConfigClusterName == "" {


### PR DESCRIPTION
## Summary
- Changed certificate name from 'runtime' to 'runtime-server' to avoid reserved name conflict
- Updated error message to refer to 'server certificate' instead of 'dev certificate'

## Problem
When running the server command, it fails with:
```
[ERROR] failed to issue dev certificate │ error: "name \"runtime\" is reserved and cannot be used"
```

This was accidentally introduced during the dev→server rename where the certificate name was changed from 'dev' to 'runtime', but 'runtime' is in the reserved names list.

## Solution
Changed the certificate name to 'runtime-server' which is not reserved.

## Test plan
- [ ] Verify that `runtime server` command starts successfully without certificate errors
- [ ] Confirm that the server can issue certificates with the new name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error messages to correctly reference "server certificate" instead of "dev certificate" when issuing certificates from the server command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->