### PR TITLE
Fix entity delete config loading

### DIFF
--- a/cli/commands/dev_darwin.go
+++ b/cli/commands/dev_darwin.go
@@ -1,7 +1,0 @@
-//go:build darwin
-
-package commands
-
-func Dev(ctx *Context, opts struct{}) error {
-	return nil
-}

--- a/cli/commands/entity_delete.go
+++ b/cli/commands/entity_delete.go
@@ -9,6 +9,7 @@ import (
 )
 
 func EntityDelete(ctx *Context, opts struct {
+	ConfigCentric
 	Id      string `short:"i" long:"id" description:"Entity ID" required:"true"`
 	Address string `short:"a" long:"address" description:"Address to listen on" default:"localhost:8443"`
 }) error {

--- a/cli/commands/entity_get.go
+++ b/cli/commands/entity_get.go
@@ -7,10 +7,9 @@ import (
 )
 
 func EntityGet(ctx *Context, opts struct {
+	ConfigCentric
 	Id      string `short:"i" long:"id" description:"Entity ID" required:"true"`
 	Address string `short:"a" long:"address" description:"Address to listen on" default:"localhost:8443"`
-
-	ConfigCentric
 }) error {
 	client, err := ctx.RPCClient("entities")
 	if err != nil {

--- a/cli/commands/entity_list.go
+++ b/cli/commands/entity_list.go
@@ -8,12 +8,11 @@ import (
 )
 
 func EntityList(ctx *Context, opts struct {
+	ConfigCentric
 	Attribute string `short:"a" long:"attribute" description:"Attribute to filter by"`
 	Value     string `short:"v" long:"value" description:"Value to filter by"`
 	Kind      string `short:"k" long:"kind" description:"Kind of entity to filter by"`
 	Address   string `long:"address" description:"Address to listen on" default:"localhost:8443"`
-
-	ConfigCentric
 }) error {
 	client, err := ctx.RPCClient("entities")
 	if err != nil {

--- a/cli/commands/entity_put.go
+++ b/cli/commands/entity_put.go
@@ -10,13 +10,12 @@ import (
 )
 
 func EntityPut(ctx *Context, opts struct {
+	ConfigCentric
 	Address string   `short:"a" long:"address" description:"Address to listen on" default:"localhost:8443"`
 	Path    []string `short:"p" long:"path" description:"Path to the entity"`
 	Id      string   `short:"i" long:"id" description:"ID of the entity"`
 	DryRun  bool     `short:"d" long:"dry-run" description:"Dry run, do not actually put the entity"`
 	Update  bool     `short:"u" long:"update" description:"Update the entity if it exists"`
-
-	ConfigCentric
 }) error {
 	var (
 		data []byte
@@ -36,12 +35,12 @@ func EntityPut(ctx *Context, opts struct {
 			return fmt.Errorf("failed to read file %s: %v", opts.Path, err)
 		}
 
-		pres, err := eac.Parse(ctx, data)
+		press, err := eac.Parse(ctx, data)
 		if err != nil {
 			return fmt.Errorf("failed to parse entity: %v", err)
 		}
 
-		pf := pres.File()
+		pf := press.File()
 
 		for _, rpcEnt := range pf.Entities() {
 			ent := rpcEnt.Entity()

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -566,10 +566,10 @@ func Server(ctx *Context, opts struct {
 		return err
 	}
 
-	cert, err := co.IssueCertificate("runtime")
+	cert, err := co.IssueCertificate("runtime-server")
 	if err != nil {
-		ctx.Log.Error("failed to issue dev certificate", "error", err)
-		return fmt.Errorf("failed to issue dev certificate: %w", err)
+		ctx.Log.Error("failed to issue server certificate", "error", err)
+		return fmt.Errorf("failed to issue server certificate: %w", err)
 	}
 
 	if opts.ConfigClusterName == "" {

--- a/cli/commands/server_darwin.go
+++ b/cli/commands/server_darwin.go
@@ -1,0 +1,10 @@
+//go:build darwin
+// +build darwin
+
+package commands
+
+import "fmt"
+
+func Server(ctx *Context, opts struct{}) error {
+	return fmt.Errorf("server command is not supported on macOS/Darwin")
+}

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -122,6 +122,7 @@ func (a *localActivator) AcquireLease(ctx context.Context, ver *core_v1alpha.App
 					ver:     ver,
 					sandbox: s.sandbox,
 					ent:     s.ent,
+					pool:    pool,
 					Size:    vs.leaseSlots,
 					URL:     s.url,
 				}, nil
@@ -272,6 +273,7 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 		ver:     ver,
 		sandbox: lsb.sandbox,
 		ent:     lsb.ent,
+		pool:    pool,
 		Size:    leaseSlots,
 		URL:     lsb.url,
 	}


### PR DESCRIPTION
Also move ConficCentric to the top of siblings so it's easier to spot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Go version detection for builds by automatically extracting the version from the go.mod file if not specified.
  * Added a clear error message when attempting to use the server command on macOS, indicating it is not supported.

* **Bug Fixes**
  * Ensured that lease objects consistently include pool information during activation and acquisition.

* **Tests**
  * Added tests to verify correct detection of the Go version from go.mod files.

* **Refactor**
  * Updated internal struct field orderings for consistency in command option handling.
  * Updated log and error messages to reflect changes in certificate naming.

* **Chores**
  * Removed an unused development command for Darwin platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->