### PR TITLE
Add cross-architecture builds to PR checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
       run: dagger --progress=plain call test --dir=. --tests="./e2e" --tags="e2e"
 
   build-binaries:
+    needs: lint
     strategy:
       matrix:
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,39 @@ jobs:
     - name: Test
       run: dagger --progress=plain call test --dir=. --tests="./e2e" --tags="e2e"
 
+  build-binaries:
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+            runner: depot-ubuntu-latest,dagger=0.18.9
+          - os: linux
+            arch: arm64
+            runner: depot-ubuntu-latest-arm,dagger=0.18.9
+          - os: darwin
+            arch: amd64
+            runner: macos-latest
+          - os: darwin
+            arch: arm64
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: Build binary for ${{ matrix.os }}-${{ matrix.arch }}
+        run: |
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make bin/runtime
+          # Create a zip file with the binary
+          zip -j runtime-${{ matrix.os }}-${{ matrix.arch }}.zip bin/runtime
+
   build:
     needs: lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Added `build-binaries` job to test.yml to validate cross-platform builds during PR checks
- Tests compilation across linux/darwin and amd64/arm64 architectures
- Helps catch platform-specific build issues before they reach main

## Test plan
- [x] Verify the workflow syntax is correct
- [ ] PR checks should now include build-binaries job for all 4 platforms
- [ ] Builds should complete successfully without uploading artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to build and package binaries for multiple operating systems and architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->