### PR TITLE
Fix sandbox reconcile error due to CIDR/IP mismatch

### DIFF
--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -114,7 +114,7 @@ func TestSandbox(t *testing.T) {
 
 		r.Len(tco.Network, 1)
 
-		ca, err := netip.ParseAddr(tco.Network[0].Address)
+		ca, err := netip.ParsePrefix(tco.Network[0].Address)
 		r.NoError(err)
 
 		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
@@ -208,7 +208,7 @@ func TestSandbox(t *testing.T) {
 
 		addr := strings.Fields(strings.TrimSpace(lines[0]))[1]
 
-		r.Equal(addr, ca.String()+"/24", "address doesn't match")
+		r.Equal(addr, ca.Addr().String()+"/24", "address doesn't match")
 
 		t.Run("create on existing sandbox is no-op", func(t *testing.T) {
 			searchRes, err := co.checkSandbox(ctx, &sb, meta)
@@ -535,7 +535,7 @@ func TestSandbox(t *testing.T) {
 
 		r.Len(tco.Network, 1)
 
-		ca, err := netip.ParseAddr(tco.Network[0].Address)
+		ca, err := netip.ParsePrefix(tco.Network[0].Address)
 		r.NoError(err)
 
 		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
@@ -556,7 +556,7 @@ func TestSandbox(t *testing.T) {
 			Timeout: 1 * time.Second,
 		}
 
-		resp, err := hc.Get(fmt.Sprintf("http://%s:80", ca.String()))
+		resp, err := hc.Get(fmt.Sprintf("http://%s:80", ca.Addr().String()))
 		r.NoError(err)
 
 		defer resp.Body.Close()
@@ -670,7 +670,7 @@ func TestSandbox(t *testing.T) {
 
 		r.Len(tco.Network, 1)
 
-		ca, err := netip.ParseAddr(tco.Network[0].Address)
+		ca, err := netip.ParsePrefix(tco.Network[0].Address)
 		r.NoError(err)
 
 		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
@@ -686,7 +686,7 @@ func TestSandbox(t *testing.T) {
 			Timeout: 1 * time.Second,
 		}
 
-		resp, err := hc.Get(fmt.Sprintf("http://%s:80", ca.String()))
+		resp, err := hc.Get(fmt.Sprintf("http://%s:80", ca.Addr().String()))
 		r.NoError(err)
 
 		defer resp.Body.Close()
@@ -797,7 +797,7 @@ func TestSandbox(t *testing.T) {
 
 		r.Len(tco.Network, 1)
 
-		ca, err := netip.ParseAddr(tco.Network[0].Address)
+		ca, err := netip.ParsePrefix(tco.Network[0].Address)
 		r.NoError(err)
 
 		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
@@ -818,7 +818,7 @@ func TestSandbox(t *testing.T) {
 			Timeout: 1 * time.Second,
 		}
 
-		resp, err := hc.Get(fmt.Sprintf("http://%s:80", ca.String()))
+		resp, err := hc.Get(fmt.Sprintf("http://%s:80", ca.Addr().String()))
 		r.NoError(err)
 
 		defer resp.Body.Close()
@@ -933,7 +933,7 @@ func TestSandbox(t *testing.T) {
 
 		r.Len(tco.Network, 1)
 
-		ca, err := netip.ParseAddr(tco.Network[0].Address)
+		ca, err := netip.ParsePrefix(tco.Network[0].Address)
 		r.NoError(err)
 
 		c, err := cc.LoadContainer(ctx, co.pauseContainerId(id))
@@ -960,7 +960,7 @@ func TestSandbox(t *testing.T) {
 			Timeout: 1 * time.Second,
 		}
 
-		resp, err := hc.Get(fmt.Sprintf("http://%s:80", ca.String()))
+		resp, err := hc.Get(fmt.Sprintf("http://%s:80", ca.Addr().String()))
 		r.NoError(err)
 
 		defer resp.Body.Close()


### PR DESCRIPTION
## Summary
- Fixed MIR-268: Sandbox reconciliation failing with "invalid address" error
- Changed address storage format from plain IP to CIDR notation during sandbox creation
- Updated tests to handle CIDR format correctly

## Problem
When a sandbox is created with automatic network allocation, the address was stored as a plain IP address (e.g., "10.8.0.5") but the reconciliation process expected a CIDR format (e.g., "10.8.0.5/32"). This caused the `netip.ParsePrefix()` call to fail during reconciliation.

## Solution
Modified `controllers/sandbox/sandbox.go` to store the full CIDR format by using `prefix.String()` instead of `prefix.Addr().String()` when saving the network address.

## Test plan
- [x] Code compiles successfully with `make bin/runtime`
- [x] Linting passes with `make lint-changed`
- [x] Manual testing: Create a sandbox and verify reconciliation works
- [x] Unit tests pass in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and assignment of network addresses in sandbox network configuration to ensure accurate representation and backward compatibility.
  * Updated tests to correctly parse and compare network address values, enhancing test reliability.
  * Ensured sandbox network addresses are consistently validated and formatted as plain IP addresses across URLs and returned values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->