### PR TITLE
Fix sandbox controller failing to remove containers when pause task not found

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1587,10 +1587,12 @@ func (c *SandboxController) stopSandbox(ctx context.Context, sb *compute.Sandbox
 
 		task, err := container.Task(ctx, nil)
 		if err != nil {
-			return err
-		}
-
-		if task != nil {
+			if !errdefs.IsNotFound(err) {
+				c.Log.Error("failed to get pause task", "id", sb.ID, "err", err)
+				return err
+			}
+			c.Log.Debug("pause task not found, continuing with container deletion", "id", sb.ID)
+		} else if task != nil {
 			_, err = task.Delete(ctx, containerd.WithProcessKill)
 			if err != nil {
 				c.Log.Error("failed to delete pause task", "id", sb.ID, "err", err)


### PR DESCRIPTION
## Summary
- Fixes MIR-269 where the sandbox controller fails to finish removing a container when it cannot find the running pause task
- Handles the `NotFound` error gracefully when attempting to get the pause task during container deletion

## Problem
The sandbox controller's `stopSandbox` function would fail completely if `container.Task()` returned an error, preventing container cleanup from completing. This could occur when the pause task was already gone or in an inconsistent state.

## Solution
Check if the error from `container.Task()` is a `NotFound` error using `errdefs.IsNotFound()`:
- If it's a `NotFound` error: Log a debug message and continue with container deletion
- If it's any other error: Log an error and return (existing behavior)
- If no error and task exists: Attempt to delete the task (existing behavior)

This ensures the sandbox can be properly cleaned up even when the pause task is missing.

## Test plan
- [x] Run `make lint-changed` - passed
- [x] Deploy to staging and verify sandbox cleanup works correctly
- [x] Monitor for any errors related to pause task deletion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during sandbox stop to allow container deletion to proceed gracefully if the pause task is missing, preventing unnecessary failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->