### PR TITLE
feat: implement per-service concurrency controls (MIR-227)

### DIFF
--- a/api/core/schema.yml
+++ b/api/core/schema.yml
@@ -75,7 +75,7 @@ kinds:
           doc: The TCP port to access, default to 3000
         concurrency:
           type: component
-          doc: How to control the concurrency for the application
+          doc: How to control the concurrency for the application (deprecated, use services)
           attrs:
             fixed:
               type: int
@@ -83,6 +83,30 @@ kinds:
             auto:
               type: int
               doc: How to scale the application based on the node
+        services:
+          type: component
+          doc: Per-service configuration including concurrency controls
+          many: true
+          attrs:
+            name:
+              type: string
+              doc: The service name (e.g. web, worker)
+            service_concurrency:
+              type: component
+              doc: Concurrency configuration for this service
+              attrs:
+                mode:
+                  type: string
+                  doc: The concurrency mode (auto or fixed)
+                requests_per_instance:
+                  type: int
+                  doc: For auto mode, number of concurrent requests per instance
+                scale_down_delay:
+                  type: string
+                  doc: For auto mode, delay before scaling down idle instances (e.g. 2m, 15m)
+                num_instances:
+                  type: int
+                  doc: For fixed mode, number of instances to maintain
         entrypoint:
           type: string
           doc: The container entrypoint command

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -153,8 +153,8 @@ func (ac *AppConfig) Validate() error {
 
 		// Validate fixed mode settings
 		if concurrency.Mode == "fixed" {
-			if concurrency.NumInstances < 0 {
-				return fmt.Errorf("service %s: num_instances must be non-negative", serviceName)
+			if concurrency.NumInstances <= 0 {
+				return fmt.Errorf("service %s: num_instances must be at least 1 for fixed mode", serviceName)
 			}
 			if concurrency.RequestsPerInstance > 0 {
 				return fmt.Errorf("service %s: requests_per_instance cannot be set in fixed mode", serviceName)

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -1,0 +1,201 @@
+package appconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "valid auto mode config",
+			config: `
+name = "test-app"
+
+[services.web.concurrency]
+mode = "auto"
+requests_per_instance = 50
+scale_down_delay = "5m"
+`,
+			wantErr: "",
+		},
+		{
+			name: "valid fixed mode config",
+			config: `
+name = "test-app"
+
+[services.worker.concurrency]
+mode = "fixed"
+num_instances = 3
+`,
+			wantErr: "",
+		},
+		{
+			name: "invalid mode",
+			config: `
+name = "test-app"
+
+[services.web.concurrency]
+mode = "invalid"
+`,
+			wantErr: `service web: invalid concurrency mode "invalid", must be "auto" or "fixed"`,
+		},
+		{
+			name: "negative requests_per_instance",
+			config: `
+name = "test-app"
+
+[services.web.concurrency]
+mode = "auto"
+requests_per_instance = -5
+`,
+			wantErr: "service web: requests_per_instance must be non-negative",
+		},
+		{
+			name: "invalid scale_down_delay",
+			config: `
+name = "test-app"
+
+[services.web.concurrency]
+mode = "auto"
+scale_down_delay = "invalid"
+`,
+			wantErr: "service web: invalid scale_down_delay",
+		},
+		{
+			name: "num_instances in auto mode",
+			config: `
+name = "test-app"
+
+[services.web.concurrency]
+mode = "auto"
+num_instances = 2
+`,
+			wantErr: "service web: num_instances cannot be set in auto mode",
+		},
+		{
+			name: "requests_per_instance in fixed mode",
+			config: `
+name = "test-app"
+
+[services.worker.concurrency]
+mode = "fixed"
+requests_per_instance = 10
+`,
+			wantErr: "service worker: requests_per_instance cannot be set in fixed mode",
+		},
+		{
+			name: "scale_down_delay in fixed mode",
+			config: `
+name = "test-app"
+
+[services.worker.concurrency]
+mode = "fixed"
+scale_down_delay = "2m"
+`,
+			wantErr: "service worker: scale_down_delay cannot be set in fixed mode",
+		},
+		{
+			name: "negative num_instances",
+			config: `
+name = "test-app"
+
+[services.worker.concurrency]
+mode = "fixed"
+num_instances = -1
+`,
+			wantErr: "service worker: num_instances must be non-negative",
+		},
+		{
+			name: "empty mode defaults to auto",
+			config: `
+name = "test-app"
+
+[services.web.concurrency]
+requests_per_instance = 100
+scale_down_delay = "10m"
+`,
+			wantErr: "",
+		},
+		{
+			name: "multiple services with mixed modes",
+			config: `
+name = "test-app"
+
+[services.web.concurrency]
+mode = "auto"
+requests_per_instance = 80
+scale_down_delay = "2m"
+
+[services.worker.concurrency]
+mode = "fixed"
+num_instances = 2
+
+[services.cron.concurrency]
+mode = "fixed"
+num_instances = 1
+`,
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac, err := Parse([]byte(tt.config))
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, ac)
+			}
+		})
+	}
+}
+
+func TestAppConfigParsing(t *testing.T) {
+	config := `
+name = "my-app"
+
+[services.web.concurrency]
+mode = "auto"
+requests_per_instance = 80
+scale_down_delay = "15m"
+
+[services.worker.concurrency]
+mode = "fixed"
+num_instances = 1
+`
+
+	ac, err := Parse([]byte(config))
+	require.NoError(t, err)
+	require.NotNil(t, ac)
+
+	assert.Equal(t, "my-app", ac.Name)
+	require.NotNil(t, ac.Services)
+	require.Len(t, ac.Services, 2)
+
+	// Check web service
+	webSvc, ok := ac.Services["web"]
+	require.True(t, ok)
+	require.NotNil(t, webSvc.Concurrency)
+	assert.Equal(t, "auto", webSvc.Concurrency.Mode)
+	assert.Equal(t, 80, webSvc.Concurrency.RequestsPerInstance)
+	assert.Equal(t, "15m", webSvc.Concurrency.ScaleDownDelay)
+	assert.Equal(t, 0, webSvc.Concurrency.NumInstances)
+
+	// Check worker service
+	workerSvc, ok := ac.Services["worker"]
+	require.True(t, ok)
+	require.NotNil(t, workerSvc.Concurrency)
+	assert.Equal(t, "fixed", workerSvc.Concurrency.Mode)
+	assert.Equal(t, 0, workerSvc.Concurrency.RequestsPerInstance)
+	assert.Equal(t, "", workerSvc.Concurrency.ScaleDownDelay)
+	assert.Equal(t, 1, workerSvc.Concurrency.NumInstances)
+}

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -86,6 +86,7 @@ name = "test-app"
 
 [services.worker.concurrency]
 mode = "fixed"
+num_instances = 1
 requests_per_instance = 10
 `,
 			wantErr: "service worker: requests_per_instance cannot be set in fixed mode",
@@ -97,6 +98,7 @@ name = "test-app"
 
 [services.worker.concurrency]
 mode = "fixed"
+num_instances = 1
 scale_down_delay = "2m"
 `,
 			wantErr: "service worker: scale_down_delay cannot be set in fixed mode",
@@ -110,7 +112,18 @@ name = "test-app"
 mode = "fixed"
 num_instances = -1
 `,
-			wantErr: "service worker: num_instances must be non-negative",
+			wantErr: "service worker: num_instances must be at least 1 for fixed mode",
+		},
+		{
+			name: "zero num_instances in fixed mode",
+			config: `
+name = "test-app"
+
+[services.worker.concurrency]
+mode = "fixed"
+num_instances = 0
+`,
+			wantErr: "service worker: num_instances must be at least 1 for fixed mode",
 		},
 		{
 			name: "empty mode defaults to auto",

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -24,6 +24,7 @@ type Lease struct {
 	sandbox *compute_v1alpha.Sandbox
 	ent     *entity.Entity
 	pool    string
+	service string
 
 	Size int
 	URL  string
@@ -68,7 +69,7 @@ type verSandboxes struct {
 }
 
 type verKey struct {
-	ver, pool string
+	ver, pool, service string
 }
 
 type localActivator struct {
@@ -98,47 +99,116 @@ func NewLocalActivator(ctx context.Context, log *slog.Logger, eac *entityserver_
 	return la
 }
 
+// ensureFixedInstances ensures that fixed mode services have the required number of instances running
+func (a *localActivator) ensureFixedInstances(ctx context.Context) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Track which versions/services we've seen
+	seenServices := make(map[verKey]bool)
+
+	// Check existing sandboxes
+	for key, vs := range a.versions {
+		svcConcurrency := a.getServiceConcurrency(vs.ver, key.service)
+		if svcConcurrency.Mode != "fixed" {
+			continue
+		}
+
+		seenServices[key] = true
+
+		// Count running sandboxes
+		runningCount := 0
+		for _, sb := range vs.sandboxes {
+			if sb.sandbox.Status == compute_v1alpha.RUNNING {
+				runningCount++
+			}
+		}
+
+		targetInstances := int(svcConcurrency.NumInstances)
+		if targetInstances <= 0 {
+			targetInstances = 1
+		}
+
+		// Start additional instances if needed
+		for i := runningCount; i < targetInstances; i++ {
+			a.log.Info("starting fixed instance", "app", vs.ver.App, "service", key.service, "current", runningCount, "target", targetInstances)
+
+			// Release the lock temporarily while creating sandbox
+			a.mu.Unlock()
+			_, err := a.activateApp(ctx, vs.ver, key.pool, key.service)
+			a.mu.Lock()
+
+			if err != nil {
+				a.log.Error("failed to start fixed instance", "app", vs.ver.App, "service", key.service, "error", err)
+			}
+		}
+	}
+}
+
 func (a *localActivator) AcquireLease(ctx context.Context, ver *core_v1alpha.AppVersion, pool, service string) (*Lease, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	key := verKey{ver.ID.String(), pool}
+	key := verKey{ver.ID.String(), pool, service}
 	vs, ok := a.versions[key]
 
+	// Get service concurrency config
+	svcConcurrency := a.getServiceConcurrency(ver, service)
+
 	if !ok {
-		a.log.Info("creating new sandbox for app", "app", ver.App, "version", ver.Version, "pool", pool, "key", key)
+		a.log.Info("creating new sandbox for app", "app", ver.App, "version", ver.Version, "pool", pool, "service", service, "key", key)
 		return a.activateApp(ctx, ver, pool, service)
 	}
 
 	if len(vs.sandboxes) == 0 {
 		a.log.Info("no sandboxes available, creating new sandbox for app", "app", ver.App, "version", ver.Version)
 	} else {
-
 		a.log.Debug("reusing existing sandboxes", "app", ver.App, "version", ver.Version, "sandboxes", len(vs.sandboxes))
 
-		start := rand.Int() % len(vs.sandboxes)
-
-		for i := 0; i < len(vs.sandboxes); i++ {
-			s := vs.sandboxes[(start+i)%len(vs.sandboxes)]
-			if s.inuseSlots+vs.leaseSlots < s.maxSlots {
-				s.inuseSlots += vs.leaseSlots
-				s.lastRenewal = time.Now()
-
-				a.log.Debug("reusing sandbox", "app", ver.App, "version", ver.Version, "sandbox", s.sandbox.ID, "in-use", s.inuseSlots)
-				return &Lease{
-					ver:     ver,
-					sandbox: s.sandbox,
-					ent:     s.ent,
-					pool:    pool,
-					Size:    vs.leaseSlots,
-					URL:     s.url,
-				}, nil
+		// For fixed mode, just round-robin across available sandboxes
+		if svcConcurrency.Mode == "fixed" {
+			// Find a running sandbox
+			start := rand.Int() % len(vs.sandboxes)
+			for i := 0; i < len(vs.sandboxes); i++ {
+				s := vs.sandboxes[(start+i)%len(vs.sandboxes)]
+				if s.sandbox.Status == compute_v1alpha.RUNNING {
+					s.lastRenewal = time.Now()
+					a.log.Debug("reusing fixed mode sandbox", "app", ver.App, "version", ver.Version, "sandbox", s.sandbox.ID, "service", service)
+					return &Lease{
+						ver:     ver,
+						sandbox: s.sandbox,
+						ent:     s.ent,
+						pool:    pool,
+						service: service,
+						Size:    1, // Fixed mode doesn't use slots
+						URL:     s.url,
+					}, nil
+				}
 			}
+			// No running sandboxes found, will create new one below
+			a.log.Info("no running sandboxes for fixed mode service, creating new sandbox", "app", ver.App, "version", ver.Version, "service", service)
+		} else {
+			// Auto mode: use slot-based allocation
+			start := rand.Int() % len(vs.sandboxes)
+			for i := 0; i < len(vs.sandboxes); i++ {
+				s := vs.sandboxes[(start+i)%len(vs.sandboxes)]
+				if s.inuseSlots+vs.leaseSlots < s.maxSlots {
+					s.inuseSlots += vs.leaseSlots
+					s.lastRenewal = time.Now()
+
+					a.log.Debug("reusing sandbox", "app", ver.App, "version", ver.Version, "sandbox", s.sandbox.ID, "in-use", s.inuseSlots)
+					return &Lease{
+						ver:     ver,
+						sandbox: s.sandbox,
+						ent:     s.ent,
+						pool:    pool,
+						service: service,
+						Size:    vs.leaseSlots,
+						URL:     s.url,
+					}, nil
+				}
+			}
+			a.log.Info("no space in existing sandboxes, creating new sandbox for app", "app", ver.App, "version", ver.Version)
 		}
-
-		// NOTE: We could attempt to fulfill a lease of 1 slot, but if we're getting to the bottom
-		// of what the sandboxes can fulfill, it's best to just boot a new sandbox anyway.
-
-		a.log.Info("no space in existing sandboxes, creating new sandbox for app", "app", ver.App, "version", ver.Version)
 	}
 
 	return a.activateApp(ctx, ver, pool, service)
@@ -210,7 +280,7 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 	rpcE.SetAttrs(entity.Attrs(
 		(&core_v1alpha.Metadata{
 			Name:   name,
-			Labels: types.LabelSet("app", appMD.Name, "pool", pool),
+			Labels: types.LabelSet("app", appMD.Name, "pool", pool, "service", service),
 		}).Encode,
 		entity.Ident, "sandbox/"+name,
 		sb.Encode,
@@ -264,13 +334,26 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 	// If it's already a plain IP (old format), use as-is
 	addr := fmt.Sprintf("http://%s:%d", ip, port)
 
+	// Get service-specific concurrency configuration
+	svcConcurrency := a.getServiceConcurrency(ver, service)
+
 	var leaseSlots int
+	var maxSlots int
 
-	if ver.Config.Concurrency.Fixed <= 0 {
+	if svcConcurrency.Mode == "fixed" {
+		// For fixed mode, we don't use slots - the sandbox handles one instance
 		leaseSlots = 1
+		maxSlots = 1
 	} else {
-		leaseSlots = int(float32(ver.Config.Concurrency.Fixed) * 0.20)
+		// For auto mode, use requests_per_instance as max slots
+		if svcConcurrency.RequestsPerInstance <= 0 {
+			maxSlots = 10 // default
+		} else {
+			maxSlots = int(svcConcurrency.RequestsPerInstance)
+		}
 
+		// Lease slots is 20% of max slots
+		leaseSlots = int(float32(maxSlots) * 0.20)
 		if leaseSlots < 1 {
 			leaseSlots = 1
 		}
@@ -281,7 +364,7 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 		ent:         sbEnt,
 		lastRenewal: time.Now(),
 		url:         addr,
-		maxSlots:    int(ver.Config.Concurrency.Fixed),
+		maxSlots:    maxSlots,
 		inuseSlots:  leaseSlots,
 	}
 
@@ -290,11 +373,12 @@ func (a *localActivator) activateApp(ctx context.Context, ver *core_v1alpha.AppV
 		sandbox: lsb.sandbox,
 		ent:     lsb.ent,
 		pool:    pool,
+		service: service,
 		Size:    leaseSlots,
 		URL:     lsb.url,
 	}
 
-	key := verKey{ver.ID.String(), pool}
+	key := verKey{ver.ID.String(), pool, service}
 
 	vs, ok := a.versions[key]
 	if !ok {
@@ -315,15 +399,21 @@ func (a *localActivator) ReleaseLease(ctx context.Context, lease *Lease) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	vs, ok := a.versions[verKey{lease.ver.ID.String(), lease.pool}]
+	vs, ok := a.versions[verKey{lease.ver.ID.String(), lease.pool, lease.service}]
 	if !ok {
 		return nil
 	}
 
-	for _, s := range vs.sandboxes {
-		if s.sandbox == lease.sandbox {
-			s.inuseSlots -= lease.Size
-			break
+	// Get service concurrency config
+	svcConcurrency := a.getServiceConcurrency(lease.ver, lease.service)
+
+	// Only adjust slots for auto mode
+	if svcConcurrency.Mode != "fixed" {
+		for _, s := range vs.sandboxes {
+			if s.sandbox == lease.sandbox {
+				s.inuseSlots -= lease.Size
+				break
+			}
 		}
 	}
 
@@ -334,7 +424,7 @@ func (a *localActivator) RenewLease(ctx context.Context, lease *Lease) (*Lease, 
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	vs, ok := a.versions[verKey{lease.ver.ID.String(), lease.pool}]
+	vs, ok := a.versions[verKey{lease.ver.ID.String(), lease.pool, lease.service}]
 	if !ok {
 		return nil, fmt.Errorf("lease not found")
 	}
@@ -350,13 +440,18 @@ func (a *localActivator) RenewLease(ctx context.Context, lease *Lease) (*Lease, 
 }
 
 func (a *localActivator) InBackground(ctx context.Context) {
-	ticker := time.NewTicker(20 * time.Second)
-	defer ticker.Stop()
+	retireTicker := time.NewTicker(20 * time.Second)
+	defer retireTicker.Stop()
+
+	fixedTicker := time.NewTicker(30 * time.Second)
+	defer fixedTicker.Stop()
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-retireTicker.C:
 			a.retireUnusedSandboxes()
+		case <-fixedTicker.C:
+			a.ensureFixedInstances(ctx)
 		case <-ctx.Done():
 			return
 		}
@@ -371,6 +466,45 @@ func getLabel(metadata *core_v1alpha.Metadata, key string, defaultValue string) 
 		}
 	}
 	return defaultValue
+}
+
+// getServiceConcurrency returns the concurrency configuration for a specific service
+// If no service-specific config is found, it falls back to defaults based on service name
+func (a *localActivator) getServiceConcurrency(ver *core_v1alpha.AppVersion, service string) *core_v1alpha.ServiceConcurrency {
+	// Look for service-specific configuration
+	for _, svc := range ver.Config.Services {
+		if svc.Name == service {
+			return &svc.ServiceConcurrency
+		}
+	}
+
+	// Check for legacy global concurrency configuration
+	if ver.Config.Concurrency.Fixed > 0 || ver.Config.Concurrency.Auto > 0 {
+		// Use global config for backward compatibility
+		if ver.Config.Concurrency.Fixed > 0 {
+			return &core_v1alpha.ServiceConcurrency{
+				Mode:                "auto",
+				RequestsPerInstance: ver.Config.Concurrency.Fixed,
+				ScaleDownDelay:      "2m", // Legacy default
+			}
+		}
+		// Handle auto mode from legacy config if needed
+	}
+
+	// Apply defaults based on service name
+	if service == "web" {
+		return &core_v1alpha.ServiceConcurrency{
+			Mode:                "auto",
+			RequestsPerInstance: 10,
+			ScaleDownDelay:      "15m",
+		}
+	}
+
+	// Default for all other services is fixed with 1 instance
+	return &core_v1alpha.ServiceConcurrency{
+		Mode:         "fixed",
+		NumInstances: 1,
+	}
 }
 
 func (a *localActivator) recoverSandboxes(ctx context.Context) error {
@@ -408,10 +542,11 @@ func (a *localActivator) recoverSandboxes(ctx context.Context) error {
 		var appVer core_v1alpha.AppVersion
 		appVer.Decode(verResp.Entity().Entity())
 
-		// Extract pool from sandbox labels - default to "default" if not found
+		// Extract pool and service from sandbox labels - default to "default" if not found
 		var metadata core_v1alpha.Metadata
 		metadata.Decode(ent.Entity())
 		pool := getLabel(&metadata, "pool", "default")
+		service := getLabel(&metadata, "service", "web") // Default to web if not found
 
 		// Calculate the URL
 		port := int64(3000)
@@ -438,12 +573,24 @@ func (a *localActivator) recoverSandboxes(ctx context.Context) error {
 		// If it's already a plain IP (old format), use as-is
 		addr := fmt.Sprintf("http://%s:%d", ipAddr, port)
 
+		// Get service-specific concurrency configuration
+		svcConcurrency := a.getServiceConcurrency(&appVer, service)
+
 		// Calculate lease slots
 		var leaseSlots int
-		if appVer.Config.Concurrency.Fixed <= 0 {
+		var maxSlots int
+
+		if svcConcurrency.Mode == "fixed" {
 			leaseSlots = 1
+			maxSlots = 1
 		} else {
-			leaseSlots = int(float32(appVer.Config.Concurrency.Fixed) * 0.20)
+			if svcConcurrency.RequestsPerInstance <= 0 {
+				maxSlots = 10 // default
+			} else {
+				maxSlots = int(svcConcurrency.RequestsPerInstance)
+			}
+
+			leaseSlots = int(float32(maxSlots) * 0.20)
 			if leaseSlots < 1 {
 				leaseSlots = 1
 			}
@@ -455,12 +602,12 @@ func (a *localActivator) recoverSandboxes(ctx context.Context) error {
 			ent:         ent.Entity(),
 			lastRenewal: recoveryTime, // Set to now to give grace period
 			url:         addr,
-			maxSlots:    int(appVer.Config.Concurrency.Fixed),
+			maxSlots:    maxSlots,
 			inuseSlots:  0, // Start with no slots in use
 		}
 
 		// Add to versions map
-		key := verKey{appVer.ID.String(), pool}
+		key := verKey{appVer.ID.String(), pool, service}
 		vs, ok := a.versions[key]
 		if !ok {
 			vs = &verSandboxes{
@@ -472,7 +619,7 @@ func (a *localActivator) recoverSandboxes(ctx context.Context) error {
 		}
 		vs.sandboxes = append(vs.sandboxes, lsb)
 
-		a.log.Info("recovered sandbox", "app", appVer.App, "version", appVer.Version, "sandbox", sb.ID, "pool", pool)
+		a.log.Info("recovered sandbox", "app", appVer.App, "version", appVer.Version, "sandbox", sb.ID, "pool", pool, "service", service)
 	}
 
 	return nil
@@ -482,12 +629,28 @@ func (a *localActivator) retireUnusedSandboxes() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	for _, vs := range a.versions {
+	for key, vs := range a.versions {
+		// Get service-specific concurrency config
+		svcConcurrency := a.getServiceConcurrency(vs.ver, key.service)
+
+		// Never retire fixed mode sandboxes
+		if svcConcurrency.Mode == "fixed" {
+			continue
+		}
+
+		// Calculate scale down delay for auto mode
+		scaleDownDelay := 2 * time.Minute // default
+		if svcConcurrency.ScaleDownDelay != "" {
+			if duration, err := time.ParseDuration(svcConcurrency.ScaleDownDelay); err == nil {
+				scaleDownDelay = duration
+			}
+		}
+
 		var newSandboxes []*sandbox
 
 		for _, sb := range vs.sandboxes {
-			if time.Since(sb.lastRenewal) > 2*time.Minute {
-				a.log.Debug("retiring unused sandbox", "app", vs.ver.App, "sandbox", sb.sandbox.ID)
+			if time.Since(sb.lastRenewal) > scaleDownDelay {
+				a.log.Debug("retiring unused sandbox", "app", vs.ver.App, "sandbox", sb.sandbox.ID, "service", key.service, "idle_time", time.Since(sb.lastRenewal))
 
 				if sb.sandbox.Status != compute_v1alpha.RUNNING {
 					continue

--- a/components/activator/activator_fixed_mode_test.go
+++ b/components/activator/activator_fixed_mode_test.go
@@ -129,12 +129,16 @@ func TestActivatorFixedModeRoundRobin(t *testing.T) {
 	// Both sandboxes should have been used
 	assert.Equal(t, 2, len(sandboxURLs), "should use both sandboxes")
 
-	// With only 10 iterations, distribution might not be perfectly even due to randomness
-	// Just verify both were used
+	// Verify distribution
+	// The implementation uses a random starting point for each request,
+	// so the distribution is random rather than strict round-robin
+	totalRequests := 0
 	for url, count := range sandboxURLs {
 		t.Logf("Sandbox %s used %d times", url, count)
 		assert.Greater(t, count, 0, "each sandbox should be used at least once")
+		totalRequests += count
 	}
+	assert.Equal(t, 10, totalRequests, "all requests should be handled")
 
 	// Verify no slots were tracked for fixed mode
 	vs := activator.versions[verKey{appVer.ID.String(), "default", "web"}]

--- a/components/activator/activator_fixed_mode_test.go
+++ b/components/activator/activator_fixed_mode_test.go
@@ -1,0 +1,226 @@
+package activator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+// TestActivatorFixedModeRoundRobin tests that fixed mode services
+// round-robin across existing sandboxes without creating new ones
+func TestActivatorFixedModeRoundRobin(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	// Create in-memory entity server
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app entity
+	app := &core_v1alpha.App{}
+	appID, err := server.Client.Create(ctx, "test-fixed-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// Create app version with fixed mode concurrency
+	appVer := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+
+	verID, err := server.Client.Create(ctx, "test-fixed-v1", appVer)
+	require.NoError(t, err)
+	appVer.ID = verID
+
+	// Update app with active version
+	app.ActiveVersion = appVer.ID
+	var updateEntity entityserver_v1alpha.Entity
+	updateEntity.SetId(app.ID.String())
+	updateEntity.SetAttrs(entity.Attrs(
+		app.Encode,
+	))
+	_, err = server.EAC.Put(ctx, &updateEntity)
+	require.NoError(t, err)
+
+	// Create two running sandboxes
+	sb1 := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+		Network: []compute_v1alpha.Network{
+			{Address: "10.0.0.1"},
+		},
+	}
+	sb2 := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+		Network: []compute_v1alpha.Network{
+			{Address: "10.0.0.2"},
+		},
+	}
+
+	// Create activator with pre-existing sandboxes
+	activator := &localActivator{
+		log: log.With("module", "activator"),
+		eac: server.EAC,
+		versions: map[verKey]*verSandboxes{
+			{appVer.ID.String(), "default", "web"}: {
+				ver: appVer,
+				sandboxes: []*sandbox{
+					{
+						sandbox:     sb1,
+						ent:         &entity.Entity{ID: entity.Id("sb-1")},
+						lastRenewal: time.Now(),
+						url:         "http://10.0.0.1:3000",
+						maxSlots:    1,
+						inuseSlots:  0,
+					},
+					{
+						sandbox:     sb2,
+						ent:         &entity.Entity{ID: entity.Id("sb-2")},
+						lastRenewal: time.Now(),
+						url:         "http://10.0.0.2:3000",
+						maxSlots:    1,
+						inuseSlots:  0,
+					},
+				},
+				leaseSlots: 1,
+			},
+		},
+	}
+
+	// Track which sandboxes we get leases for
+	sandboxURLs := make(map[string]int)
+
+	// Acquire multiple leases - should round-robin
+	for i := 0; i < 10; i++ {
+		lease, err := activator.AcquireLease(ctx, appVer, "default", "web")
+		require.NoError(t, err)
+		require.NotNil(t, lease)
+
+		sandboxURLs[lease.URL]++
+
+		// For fixed mode, slot tracking shouldn't affect anything
+		assert.Equal(t, 1, lease.Size)
+
+		// Release the lease
+		err = activator.ReleaseLease(ctx, lease)
+		require.NoError(t, err)
+	}
+
+	// Both sandboxes should have been used
+	assert.Equal(t, 2, len(sandboxURLs), "should use both sandboxes")
+
+	// With only 10 iterations, distribution might not be perfectly even due to randomness
+	// Just verify both were used
+	for url, count := range sandboxURLs {
+		t.Logf("Sandbox %s used %d times", url, count)
+		assert.Greater(t, count, 0, "each sandbox should be used at least once")
+	}
+
+	// Verify no slots were tracked for fixed mode
+	vs := activator.versions[verKey{appVer.ID.String(), "default", "web"}]
+	for _, s := range vs.sandboxes {
+		assert.Equal(t, 0, s.inuseSlots, "fixed mode should not track slots")
+	}
+}
+
+// TestActivatorFixedModeNoSlotExhaustion tests that fixed mode never
+// reports "no space" and creates new sandboxes unnecessarily
+func TestActivatorFixedModeNoSlotExhaustion(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	// Create in-memory entity server
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app entity
+	app := &core_v1alpha.App{}
+	appID, err := server.Client.Create(ctx, "test-fixed-exhaust", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// Create app version with fixed mode
+	appVer := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+
+	// Create activator with one sandbox
+	activator := &localActivator{
+		log: log.With("module", "activator"),
+		eac: server.EAC,
+		versions: map[verKey]*verSandboxes{
+			{appVer.ID.String(), "default", "web"}: {
+				ver: appVer,
+				sandboxes: []*sandbox{
+					{
+						sandbox: &compute_v1alpha.Sandbox{
+							ID:     entity.Id("sb-1"),
+							Status: compute_v1alpha.RUNNING,
+						},
+						ent:         &entity.Entity{ID: entity.Id("sb-1")},
+						lastRenewal: time.Now(),
+						url:         "http://10.0.0.1:3000",
+						maxSlots:    1,
+						inuseSlots:  0,
+					},
+				},
+				leaseSlots: 1,
+			},
+		},
+	}
+
+	// Acquire many leases simultaneously (without releasing)
+	// For auto mode this would exhaust slots, but fixed mode should handle it fine
+	leases := make([]*Lease, 0)
+	for i := 0; i < 20; i++ {
+		lease, err := activator.AcquireLease(ctx, appVer, "default", "web")
+		require.NoError(t, err)
+		require.NotNil(t, lease)
+		assert.Equal(t, "http://10.0.0.1:3000", lease.URL, "should always use the same sandbox")
+		leases = append(leases, lease)
+	}
+
+	// Verify still only one sandbox exists
+	vs := activator.versions[verKey{appVer.ID.String(), "default", "web"}]
+	assert.Equal(t, 1, len(vs.sandboxes), "should not create new sandboxes for fixed mode")
+
+	// Release all leases
+	for _, lease := range leases {
+		err := activator.ReleaseLease(ctx, lease)
+		require.NoError(t, err)
+	}
+}

--- a/components/activator/activator_test.go
+++ b/components/activator/activator_test.go
@@ -31,6 +31,18 @@ func TestActivatorRetireUnusedSandboxes(t *testing.T) {
 	ver := &core_v1alpha.AppVersion{
 		ID:  entity.Id("ver-1"),
 		App: entity.Id("app-1"),
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+						ScaleDownDelay:      "2m", // 2 minute scale down for testing
+					},
+				},
+			},
+		},
 	}
 
 	// Create sandbox entities using the entityserver.Client
@@ -60,7 +72,7 @@ func TestActivatorRetireUnusedSandboxes(t *testing.T) {
 		log: log,
 		eac: server.EAC,
 		versions: map[verKey]*verSandboxes{
-			{"ver-1", "default"}: {
+			{"ver-1", "default", "web"}: {
 				ver: ver,
 				sandboxes: []*sandbox{
 					// Old sandbox - should be retired
@@ -97,14 +109,14 @@ func TestActivatorRetireUnusedSandboxes(t *testing.T) {
 	}
 
 	// Count initial sandboxes
-	initialCount := len(activator.versions[verKey{"ver-1", "default"}].sandboxes)
+	initialCount := len(activator.versions[verKey{"ver-1", "default", "web"}].sandboxes)
 	assert.Equal(t, 3, initialCount)
 
 	// Run retirement
 	activator.retireUnusedSandboxes()
 
 	// Check that non-RUNNING sandbox was removed and old sandbox was marked for retirement
-	vs := activator.versions[verKey{"ver-1", "default"}]
+	vs := activator.versions[verKey{"ver-1", "default", "web"}]
 	assert.Equal(t, 1, len(vs.sandboxes), "should only have recent sandbox left")
 	assert.Equal(t, sb2.ID, vs.sandboxes[0].sandbox.ID, "should be the recent sandbox")
 
@@ -149,7 +161,7 @@ func TestActivatorLeaseOperations(t *testing.T) {
 	activator := &localActivator{
 		log: log,
 		versions: map[verKey]*verSandboxes{
-			{"ver-1", "default"}: {
+			{"ver-1", "default", "web"}: {
 				ver:        testVer,
 				sandboxes:  []*sandbox{testSandbox},
 				leaseSlots: 2,
@@ -162,6 +174,7 @@ func TestActivatorLeaseOperations(t *testing.T) {
 		ver:     testVer,
 		sandbox: testSandbox.sandbox,
 		pool:    "default",
+		service: "web",
 		Size:    2,
 	}
 
@@ -192,7 +205,7 @@ func TestActivatorConcurrentSafety(t *testing.T) {
 	go func() {
 		for range 100 {
 			activator.mu.Lock()
-			activator.versions[verKey{"ver-1", "default"}] = &verSandboxes{
+			activator.versions[verKey{"ver-1", "default", "web"}] = &verSandboxes{
 				sandboxes: []*sandbox{},
 			}
 			activator.mu.Unlock()
@@ -204,7 +217,7 @@ func TestActivatorConcurrentSafety(t *testing.T) {
 	go func() {
 		for range 100 {
 			activator.mu.Lock()
-			_ = activator.versions[verKey{"ver-1", "default"}]
+			_ = activator.versions[verKey{"ver-1", "default", "web"}]
 			activator.mu.Unlock()
 		}
 		done <- true
@@ -214,7 +227,7 @@ func TestActivatorConcurrentSafety(t *testing.T) {
 	go func() {
 		for range 100 {
 			activator.mu.Lock()
-			delete(activator.versions, verKey{"ver-1", "default"})
+			delete(activator.versions, verKey{"ver-1", "default", "web"})
 			activator.mu.Unlock()
 		}
 		done <- true
@@ -298,7 +311,7 @@ func TestActivatorRecoverSandboxesWithEntityServer(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify sandbox was recovered
-	key := verKey{appVer.ID.String(), "production"}
+	key := verKey{appVer.ID.String(), "production", "web"}
 	vs, ok := activator.versions[key]
 	require.True(t, ok, "version should be in map")
 	require.Len(t, vs.sandboxes, 1, "should have recovered 1 running sandbox")
@@ -486,7 +499,7 @@ func TestActivatorRecoverSandboxesWithCIDR(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify sandbox was recovered with correct URL (without CIDR notation)
-	key := verKey{appVer.ID.String(), "default"}
+	key := verKey{appVer.ID.String(), "default", "web"}
 	vs, ok := activator.versions[key]
 	require.True(t, ok, "version should be in map")
 	require.Len(t, vs.sandboxes, 1, "should have recovered 1 running sandbox")


### PR DESCRIPTION
## Summary

This PR implements RFD 0022 for improved concurrency controls in the Miren runtime, enabling per-service configuration with both auto-scaling and fixed instance modes.

### Key Changes

- **Schema Updates**: Added `services` configuration to `app_version` with per-service concurrency settings
- **Dual Modes**: Support for both `auto` (request-based scaling) and `fixed` (steady-state instances) modes  
- **Service-Aware Activator**: Refactored to maintain separate sandbox pools per service
- **Configuration Validation**: Added comprehensive validation with clear error messages
- **Fixed Instance Management**: Background process ensures target instance counts are maintained
- **Backward Compatibility**: Existing global concurrency settings continue to work

### Default Behaviors

- Web services: Auto mode with 10 requests/instance, 15m scale down delay
- Other services: Fixed mode with 1 instance

### Configuration Example

```toml
# app.toml
name = "my-app"

[services.web.concurrency]
mode = "auto"
requests_per_instance = 80
scale_down_delay = "2m"

[services.worker.concurrency]
mode = "fixed"
num_instances = 3
```

## Test Plan

- [x] Unit tests for configuration parsing and validation
- [x] Activator tests updated and passing
- [ ] Integration tests for new concurrency modes
- [x] Manual testing of auto-scaling behavior
- [x] Manual testing of fixed instance management

## Related

- Implements RFD 0022
- Fixes MIR-227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced per-service concurrency configuration, allowing each service to define its own scaling mode, instance count, and request handling.
  * Added support for both "auto" and "fixed" concurrency modes on a per-service basis, improving flexibility and scalability.

* **Improvements**
  * Enhanced activator to manage concurrency and scaling independently for each service, including sandbox lifecycle and retention policies.
  * Updated configuration validation to ensure correct concurrency settings for each service.
  * Deprecated global concurrency settings in favor of new per-service configuration.
  * App config now supports detailed service commands and concurrency settings, which take precedence over Procfile commands.

* **Bug Fixes**
  * Improved handling and validation of invalid concurrency configuration values.

* **Tests**
  * Added comprehensive tests for service concurrency configuration, validation, and activator behavior in both fixed and auto modes.
  * Updated activator tests to incorporate service-specific concurrency and leasing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->