### PR TITLE
Fix Ruby stack detection to work with any Gemfile

### DIFF
--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -149,7 +149,7 @@ func (s *RubyStack) Name() string {
 }
 
 func (s *RubyStack) Detect() bool {
-	return s.hasFile("Gemfile") && s.detectGem("rails")
+	return s.hasFile("Gemfile")
 }
 
 type highlevelBuilder struct {


### PR DESCRIPTION
## Summary
Fixed Ruby stack detection to only require a Gemfile, not Rails

## Problem
The Ruby stack detection was overly restrictive, requiring both a Gemfile and the Rails gem. This prevented non-Rails Ruby applications (Sinatra, Rack, etc.) from being detected properly.

## Solution
Changed the detection logic from:
```go
return s.hasFile("Gemfile") && s.detectGem("rails")
```
to:
```go
return s.hasFile("Gemfile")
```

## Testing
Tested with various Ruby applications including Rails, Sinatra, and plain Ruby apps with just a Gemfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Ruby stack detection logic to identify projects based solely on the presence of a Gemfile, without checking for the "rails" gem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->