### PR TITLE
Fix activator sandbox recovery with CIDR notation in network addresses

### DIFF
--- a/components/activator/activator_test.go
+++ b/components/activator/activator_test.go
@@ -431,3 +431,69 @@ func TestActivatorRecoveryIntegration(t *testing.T) {
 	// If cleanup is needed in the future, consider adding a Close() method to the interface.
 	_ = activator1
 }
+
+// TestActivatorRecoverSandboxesWithCIDR tests recovery of sandboxes with CIDR notation in addresses
+func TestActivatorRecoverSandboxesWithCIDR(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create and store app version
+	appVer := &core_v1alpha.AppVersion{
+		App:      entity.Id("app-cidr-test"),
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Concurrency: core_v1alpha.Concurrency{
+				Fixed: 5,
+			},
+		},
+	}
+
+	verID, err := server.Client.Create(ctx, "ver-cidr-test", appVer)
+	require.NoError(t, err)
+	appVer.ID = verID
+
+	// Create sandbox with CIDR notation in address
+	sb := &compute_v1alpha.Sandbox{
+		Version: appVer.ID,
+		Status:  compute_v1alpha.RUNNING,
+		Network: []compute_v1alpha.Network{
+			{
+				Address: "10.8.24.21/24", // CIDR notation that caused the bug
+			},
+		},
+	}
+
+	// Create sandbox using entityserver.Client with labels
+	sbID, err := server.Client.Create(ctx, "sb-cidr-test", sb,
+		apiserver.WithLabels(types.LabelSet("app", "app-cidr-test", "pool", "default")))
+	require.NoError(t, err)
+	sb.ID = sbID
+
+	// Create activator with the real entity access client
+	activator := &localActivator{
+		eac:      server.EAC,
+		log:      log,
+		versions: make(map[verKey]*verSandboxes),
+	}
+
+	// Test recovery
+	err = activator.recoverSandboxes(ctx)
+	require.NoError(t, err)
+
+	// Verify sandbox was recovered with correct URL (without CIDR notation)
+	key := verKey{appVer.ID.String(), "default"}
+	vs, ok := activator.versions[key]
+	require.True(t, ok, "version should be in map")
+	require.Len(t, vs.sandboxes, 1, "should have recovered 1 running sandbox")
+
+	// Verify the URL was built correctly without CIDR notation
+	recoveredSb := vs.sandboxes[0]
+	assert.Equal(t, "http://10.8.24.21:3000", recoveredSb.url, "URL should not contain CIDR notation")
+	assert.Equal(t, sb.ID, recoveredSb.sandbox.ID)
+	assert.Equal(t, compute_v1alpha.RUNNING, recoveredSb.sandbox.Status)
+}


### PR DESCRIPTION
## Summary
- Fixes MIR-313: Sandbox network recovery fails after runtime restart
- Strips CIDR notation from network addresses when building URLs during sandbox recovery
- Prevents invalid URLs like `http://10.8.24.21/24:3000` that cause DNS lookup failures

## Problem
After runtime restart, the activator's sandbox recovery was building invalid URLs by including CIDR notation from stored network addresses. This caused proxy errors:
```
http: proxy error: dial tcp: lookup 10.8.24.21/24: no such host
```

## Solution
Updated the `recoverSandboxes` function to parse network addresses and extract just the IP, stripping any CIDR notation. Uses the same `netip.ParsePrefix` approach as the existing `activateApp` function for consistency.

## Test plan
- [x] Added new test `TestActivatorRecoverSandboxesWithCIDR` that verifies CIDR notation is correctly stripped
- [x] All existing activator tests pass
- [x] Manually tested with script demonstrating CIDR stripping logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of network addresses with CIDR notation during sandbox recovery, ensuring correct parsing and URL construction for sandbox endpoints.

* **Tests**
  * Added a new test to verify proper recovery of sandboxes with CIDR-formatted network addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->