### PR TITLE
Add sandbox stop and delete CLI commands

### DIFF
--- a/api/compute/client.go
+++ b/api/compute/client.go
@@ -1,0 +1,83 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+// Client provides a domain-specific client for Sandbox entities
+type Client struct {
+	log *slog.Logger
+	ec  *entityserver.Client
+}
+
+// NewClient creates a new Compute client from an RPC client
+func NewClient(log *slog.Logger, client rpc.Client) *Client {
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+	entityClient := entityserver.NewClient(log, eac)
+
+	return &Client{
+		log: log.With("module", "compute-client"),
+		ec:  entityClient,
+	}
+}
+
+// StopSandbox updates a sandbox status to stopped
+func (c *Client) StopSandbox(ctx context.Context, sandboxID string) error {
+	var sandbox compute_v1alpha.Sandbox
+
+	// Get the current sandbox
+	err := c.ec.Get(ctx, sandboxID, &sandbox)
+	if err != nil {
+		return fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
+	}
+
+	// Check if already stopped or dead
+	if sandbox.Status == compute_v1alpha.STOPPED || sandbox.Status == compute_v1alpha.DEAD {
+		c.log.Info("Sandbox already stopped or dead", "sandbox", sandboxID, "status", sandbox.Status)
+		return nil
+	}
+
+	// Update status to stopped
+	sandbox.Status = compute_v1alpha.STOPPED
+
+	// Update the entity
+	err = c.ec.Update(ctx, &sandbox)
+	if err != nil {
+		return fmt.Errorf("failed to update sandbox %s: %w", sandboxID, err)
+	}
+
+	c.log.Info("Stopped sandbox", "sandbox", sandboxID)
+	return nil
+}
+
+// DeleteSandbox deletes a sandbox, but only if it's dead
+func (c *Client) DeleteSandbox(ctx context.Context, sandboxID string) error {
+	var sandbox compute_v1alpha.Sandbox
+
+	// Get the current sandbox
+	err := c.ec.Get(ctx, sandboxID, &sandbox)
+	if err != nil {
+		return fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
+	}
+
+	// Check if sandbox is dead
+	if sandbox.Status != compute_v1alpha.DEAD {
+		return fmt.Errorf("cannot delete sandbox %s: status is %s (must be dead)", sandboxID, sandbox.Status)
+	}
+
+	// Delete the sandbox
+	err = c.ec.Delete(ctx, sandbox.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete sandbox %s: %w", sandboxID, err)
+	}
+
+	c.log.Info("Deleted sandbox", "sandbox", sandboxID)
+	return nil
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -30,6 +30,12 @@ func AllCommands() map[string]cli.CommandFactory {
 		"sandbox list": func() (cli.Command, error) {
 			return Infer("sandbox list", "List all sandboxes", SandboxList), nil
 		},
+		"sandbox stop": func() (cli.Command, error) {
+			return Infer("sandbox stop", "Stop a sandbox", SandboxStop), nil
+		},
+		"sandbox delete": func() (cli.Command, error) {
+			return Infer("sandbox delete", "Delete a dead sandbox", SandboxDelete), nil
+		},
 		"sandbox metrics": func() (cli.Command, error) {
 			return Infer("sandbox metrics", "Get metrics from a sandbox", SandboxMetrics), nil
 		},

--- a/cli/commands/sandbox_delete.go
+++ b/cli/commands/sandbox_delete.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/api/compute"
+)
+
+func SandboxDelete(ctx *Context, opts struct {
+	Force bool `short:"f" long:"force" description:"Force delete without confirmation"`
+	ConfigCentric
+}, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: sandbox delete <sandbox-id>")
+	}
+
+	sandboxID := args[0]
+
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	computeClient := compute.NewClient(ctx.Log, client)
+
+	// Confirm deletion unless forced
+	if !opts.Force {
+		ctx.Printf("Are you sure you want to delete sandbox %s? (y/N): ", sandboxID)
+		var response string
+		_, _ = fmt.Scanln(&response)
+		if response != "y" && response != "Y" {
+			ctx.Printf("Deletion cancelled\n")
+			return nil
+		}
+	}
+
+	err = computeClient.DeleteSandbox(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+
+	ctx.Printf("Deleted sandbox %s\n", sandboxID)
+	return nil
+}

--- a/cli/commands/sandbox_stop.go
+++ b/cli/commands/sandbox_stop.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/api/compute"
+)
+
+func SandboxStop(ctx *Context, opts struct {
+	ConfigCentric
+}, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: sandbox stop <sandbox-id>")
+	}
+
+	sandboxID := args[0]
+
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	computeClient := compute.NewClient(ctx.Log, client)
+
+	err = computeClient.StopSandbox(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+
+	ctx.Printf("Stopped sandbox %s\n", sandboxID)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds `sandbox stop` command to update sandbox status to stopped
- Adds `sandbox delete` command to remove dead sandboxes with confirmation prompt
- Introduces domain-specific client for compute API following the pattern from ingress

## Details
This PR adds CLI commands for managing sandbox lifecycle:

### `runtime sandbox stop <sandbox-id>`
Updates the sandbox status to "stopped" and lets the sandbox controller handle cleanup.

### `runtime sandbox delete <sandbox-id>`
Deletes a sandbox entity, but only if it's in "dead" status. Includes a confirmation prompt unless `-f/--force` is used.

### Implementation
- Created `api/compute/client.go` following the pattern from `api/ingress/client.go`
- Encapsulates all entity manipulation logic in the compute client
- Simplified CLI commands by using the domain-specific client

## Test plan
- [ ] Test `sandbox stop` on a running sandbox
- [ ] Test `sandbox stop` on an already stopped sandbox
- [ ] Test `sandbox delete` on a dead sandbox with confirmation
- [ ] Test `sandbox delete` with `-f` flag
- [ ] Test `sandbox delete` on non-dead sandbox (should fail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to stop a sandbox from the CLI.
  * Added a command to delete a sandbox from the CLI, with an option to force deletion without confirmation.

* **Improvements**
  * Enhanced sandbox management capabilities via new CLI commands for stopping and deleting sandboxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->