### PR TITLE
Fix: Fail build on compilation errors in deploy command

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -179,7 +179,7 @@ func Deploy(ctx *Context, opts struct {
 
 	if results.Version() == "" {
 		ctx.Printf("\n\nError detected in building %s. No version returned.\n", name)
-		return nil
+		return fmt.Errorf("build failed: no version returned")
 	}
 
 	ctx.Printf("\n\nUpdated version %s deployed. All traffic moved to new version.\n", results.Version())


### PR DESCRIPTION
## Summary
- Fixed the deploy command to properly exit with an error when the build fails
- Previously, the command would continue even if compilation failed

## Test plan
- [ ] Deploy an app with compilation errors
- [ ] Verify the deploy command exits with non-zero status
- [ ] Verify error message is displayed to the user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during the build process by explicitly reporting failures when no version is returned. This ensures build issues are clearly communicated to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->