### PR TITLE
Fix: Fail build on compilation errors in deploy command

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -188,6 +188,11 @@ func Deploy(ctx *Context, opts struct {
 					}
 				}
 
+				// Fail the build if we detected any errors
+				if len(buildErrors) > 0 {
+					return fmt.Errorf("build failed with %d error(s)", len(buildErrors))
+				}
+
 				return nil
 			case "message":
 				msg := update.Message()
@@ -244,7 +249,7 @@ func Deploy(ctx *Context, opts struct {
 				ctx.Printf("%s\n", log)
 			}
 		}
-		return nil
+		return fmt.Errorf("build failed: no version returned")
 	}
 
 	ctx.Printf("\n\nUpdated version %s deployed. All traffic moved to new version.\n", results.Version())


### PR DESCRIPTION
## Summary
- Fixed the deploy command to properly exit with an error when build errors are detected
- Added check for buildErrors collection to fail the build when compilation errors occur
- Previously, the command would continue even if compilation failed

## Changes
1. Check if `buildErrors` array has any errors after collecting them from vertex.Error
2. Return an error with count of build errors when detected
3. Also return error (instead of nil) when no version is returned

## Test plan
- [ ] Deploy an app with compilation errors
- [ ] Verify the deploy command exits with non-zero status
- [ ] Verify error message shows "build failed with N error(s)"
- [ ] Verify build error details are displayed to the user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build failures are now reported immediately instead of continuing silently after build errors are detected.
  * Deployments that produce no version now return an explicit error so failed builds are clearly surfaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->