### PR TITLE
Switch container runtime from gvisor to runc

### DIFF
--- a/cli/commands/commands_linux.go
+++ b/cli/commands/commands_linux.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/netip"
 	"os"
-	"os/exec"
 	"time"
 
 	"github.com/mitchellh/cli"
@@ -64,11 +63,6 @@ func (c *Context) setupServerComponents(ctx context.Context, reg *asm.Registry) 
 
 	reg.Register("tempdir", os.TempDir())
 
-	if path, err := exec.LookPath("runsc-miren"); err == nil && path != "" {
-		reg.Register("runsc_binary", path)
-	} else {
-		reg.Register("runsc_binary", "runsc")
-	}
 
 	reg.Register("server-id", "miren-server")
 

--- a/controllers/sandbox/portmonitor.go
+++ b/controllers/sandbox/portmonitor.go
@@ -170,6 +170,6 @@ func (pm *PortMonitor) checkPort(ip string, port int) bool {
 	if err != nil {
 		return false
 	}
-	conn.Close()
+	_ = conn.Close()
 	return true
 }

--- a/controllers/sandbox/portmonitor.go
+++ b/controllers/sandbox/portmonitor.go
@@ -1,0 +1,175 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"time"
+
+	"go4.org/netipx"
+	"miren.dev/runtime/observability"
+)
+
+// PortMonitor monitors ports for containers using polling
+type PortMonitor struct {
+	log    *slog.Logger
+	ports  observability.PortTracker
+	mu     sync.Mutex
+	tasks  map[string]*monitorTask
+	wg     sync.WaitGroup
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+type monitorTask struct {
+	containerID string
+	ip          string
+	ports       []int
+	cancel      context.CancelFunc
+}
+
+// NewPortMonitor creates a new port monitor
+func NewPortMonitor(log *slog.Logger, ports observability.PortTracker) *PortMonitor {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &PortMonitor{
+		log:    log.With("module", "port-monitor"),
+		ports:  ports,
+		tasks:  make(map[string]*monitorTask),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// MonitorContainer starts monitoring ports for a container
+func (pm *PortMonitor) MonitorContainer(containerID string, ip string, ports []int) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	// Cancel any existing monitoring for this container
+	if task, exists := pm.tasks[containerID]; exists {
+		task.cancel()
+	}
+
+	// Create new monitoring task
+	taskCtx, taskCancel := context.WithCancel(pm.ctx)
+	task := &monitorTask{
+		containerID: containerID,
+		ip:          ip,
+		ports:       ports,
+		cancel:      taskCancel,
+	}
+	pm.tasks[containerID] = task
+
+	// Start monitoring in background
+	pm.wg.Add(1)
+	go pm.monitorPorts(taskCtx, task)
+}
+
+// StopMonitoring stops monitoring for a container
+func (pm *PortMonitor) StopMonitoring(containerID string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if task, exists := pm.tasks[containerID]; exists {
+		task.cancel()
+		delete(pm.tasks, containerID)
+	}
+}
+
+// Close stops all monitoring
+func (pm *PortMonitor) Close() error {
+	pm.cancel()
+	pm.wg.Wait()
+	return nil
+}
+
+func (pm *PortMonitor) monitorPorts(ctx context.Context, task *monitorTask) {
+	defer pm.wg.Done()
+
+	// Track which ports are currently bound
+	boundPorts := make(map[int]bool)
+
+	// Initial delay to let container start
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Mark all ports as unbound when stopping
+			for port := range boundPorts {
+				bp := observability.BoundPort{
+					Port: port,
+				}
+				if task.ip != "" {
+					addr, _ := net.ResolveIPAddr("ip", task.ip)
+					if addr != nil {
+						if ipAddr, ok := netipx.FromStdIP(addr.IP); ok {
+							bp.Addr = ipAddr
+						}
+					}
+				}
+				pm.ports.SetPortStatus(task.containerID, bp, observability.PortStatusUnbound)
+			}
+			return
+		case <-ticker.C:
+			// Check each port
+			for _, port := range task.ports {
+				isBound := pm.checkPort(task.ip, port)
+				wasBound := boundPorts[port]
+
+				if isBound && !wasBound {
+					// Port became bound
+					bp := observability.BoundPort{
+						Port: port,
+					}
+					if task.ip != "" {
+						addr, _ := net.ResolveIPAddr("ip", task.ip)
+						if addr != nil {
+							if ipAddr, ok := netipx.FromStdIP(addr.IP); ok {
+								bp.Addr = ipAddr
+							}
+						}
+					}
+					pm.ports.SetPortStatus(task.containerID, bp, observability.PortStatusBound)
+					boundPorts[port] = true
+					pm.log.Debug("port became bound", "container", task.containerID, "port", port)
+				} else if !isBound && wasBound {
+					// Port became unbound
+					bp := observability.BoundPort{
+						Port: port,
+					}
+					if task.ip != "" {
+						addr, _ := net.ResolveIPAddr("ip", task.ip)
+						if addr != nil {
+							if ipAddr, ok := netipx.FromStdIP(addr.IP); ok {
+								bp.Addr = ipAddr
+							}
+						}
+					}
+					pm.ports.SetPortStatus(task.containerID, bp, observability.PortStatusUnbound)
+					delete(boundPorts, port)
+					pm.log.Debug("port became unbound", "container", task.containerID, "port", port)
+				}
+			}
+		}
+	}
+}
+
+func (pm *PortMonitor) checkPort(ip string, port int) bool {
+	address := net.JoinHostPort(ip, fmt.Sprintf("%d", port))
+	conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -194,13 +194,15 @@ func (c *SandboxController) Close() error {
 	}
 	c.mu.Unlock()
 
+	var err error
+
 	if c.portMonitor != nil {
-		c.portMonitor.Close()
+		err = c.portMonitor.Close()
 	}
 
 	c.running.Wait()
 
-	return nil
+	return err
 }
 
 const (

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -1118,7 +1118,7 @@ func TestSandbox(t *testing.T) {
 		err = reg.Populate(&co)
 		r.NoError(err)
 
-		defer co.Close()
+		defer checkClosed(t, &co)
 
 		r.NoError(co.Init(ctx))
 
@@ -1199,7 +1199,7 @@ func TestSandbox(t *testing.T) {
 		// Try to connect to the port to verify it's actually listening
 		resp, err := http.Get(fmt.Sprintf("http://%s:8080", ipAddr))
 		if err == nil {
-			defer resp.Body.Close()
+			defer checkClosed(t, resp.Body)
 			r.Equal(200, resp.StatusCode, "HTTP server should respond with 200 OK")
 		}
 
@@ -1236,7 +1236,7 @@ func TestSandbox(t *testing.T) {
 		err = reg.Populate(&co)
 		r.NoError(err)
 
-		defer co.Close()
+		defer checkClosed(t, &co)
 
 		r.NoError(co.Init(ctx))
 

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -92,7 +92,6 @@ func (m *Runtime) BuildEnv(dir *dagger.Directory) *dagger.Container {
 		WithExec([]string{"apt-get", "update"}).
 		WithExec([]string{"apt-get", "install", "-y",
 			"bash",
-			"clickhouse-client",
 			"gotestsum",
 			"inetutils-ping",
 			"iproute2",

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -143,7 +143,6 @@ func (m *Runtime) Package(
 		mkdir -p /tmp/package
 		cp bin/miren /tmp/package
 		cp /usr/local/bin/runc /tmp/package
-		cp /usr/local/bin/runsc /tmp/package
 		cp /usr/local/bin/containerd-shim-runsc-v1 /tmp/package
 		cp /usr/local/bin/containerd-shim-runc-v2 /tmp/package
 		cp /usr/local/bin/containerd /tmp/package

--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,6 @@ require (
 	google.golang.org/grpc v1.68.1
 	google.golang.org/protobuf v1.35.2
 	gopkg.in/yaml.v3 v3.0.1
-	gvisor.dev/gvisor v0.0.0-20250317184159-a24f13b091dc
 	k8s.io/klog/v2 v2.130.1
 )
 
@@ -184,6 +183,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,7 +108,6 @@ github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBT
 github.com/bronze1man/goStrongswanVici v0.0.0-20231128135937-211cef3b0b20 h1:JMoL5xJSYxo1QVJ3c+4FutWQnks3gZX9DYkgAnvg+5g=
 github.com/bronze1man/goStrongswanVici v0.0.0-20231128135937-211cef3b0b20/go.mod h1:fWUtBEPt2yjrr3WFhOqvajM8JSEU8bEeBcoeSCsKRpc=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -899,8 +898,6 @@ gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
-gvisor.dev/gvisor v0.0.0-20250317184159-a24f13b091dc h1:J6cNomELwde1luDrL6hH2NeVEBIaAofaaC2Glwl0MsQ=
-gvisor.dev/gvisor v0.0.0-20250317184159-a24f13b091dc/go.mod h1:5DMfjtclAbTIjbXqO1qCe2K5GKKxWz2JHvCChuTcJEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/observability/status.go
+++ b/observability/status.go
@@ -106,4 +106,3 @@ func (s *StatusMonitor) EntityBoundPorts(entity string) ([]BoundPort, error) {
 
 	return res, nil
 }
-

--- a/observability/status.go
+++ b/observability/status.go
@@ -106,3 +106,4 @@ func (s *StatusMonitor) EntityBoundPorts(entity string) ([]BoundPort, error) {
 
 	return res, nil
 }
+


### PR DESCRIPTION
## Summary
- Replaced gvisor (runsc) runtime with standard runc runtime
- Implemented TCP-based port monitoring to replace runsc's syscall monitoring
- Added comprehensive tests for port detection functionality

## Changes

### Runtime Migration
- Updated containerd runtime from `io.containerd.runsc.v1` to `io.containerd.runc.v2`
- Removed all gvisor/runsc specific configuration and dependencies
- Removed `RunscMon` monitoring infrastructure

### Port Monitoring Implementation
- Created new `PortMonitor` that uses TCP polling (500ms intervals)
- Monitors container ports by attempting TCP connections
- Provides runtime-agnostic port detection that works with any OCI-compliant runtime

### Cgroup Management
- Fixed cgroup sharing between pause container and subcontainers
- Ensures all containers in a sandbox share the same cgroup for proper resource accounting

### Testing
- Added test for single port detection with HTTP server
- Added test for multiple simultaneous port detection
- Tests verify both port binding and unbinding on container lifecycle

## Breaking Changes
- **Security**: Removes gvisor's enhanced security isolation features (kernel-level sandboxing)
- **Performance**: Port detection now uses polling (500ms intervals) instead of real-time syscall events

## Test Plan
- [x] Run existing sandbox tests
- [x] Verify port detection with single port container
- [x] Verify port detection with multi-port container
- [x] Test container lifecycle (create, run, delete)
- [x] Verify cgroup sharing between containers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Container port monitoring: automatically detects and reports when ports become bound or unbound.
  - Adds container endpoint IP labels for easier discovery.

- Refactor
  - Migrated container runtime to runc v2; removed gVisor-specific configuration and tooling.
  - Replaced RunSC-related runtime wiring with port-monitoring lifecycle.

- Tests
  - Added tests validating port binding detection and lifecycle for single and multiple ports.

- Chores
  - Updated dependencies (removed gVisor module; added an indirect library).
  - Cleaned up CLI runtime-detection and build environment package list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->