### PR TITLE
fix: correct file ownership for 50-local.yaml when server runs with sudo

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -640,6 +641,20 @@ func writeLocalClusterConfig(ctx *Context, cc *caauth.ClientCertificate, address
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
+	// Fix directory ownership if running under sudo
+	// Fix ownership for all parent directories that we may have created
+	dirsToFix := []string{
+		filepath.Join(homeDir, ".config"),
+		filepath.Join(homeDir, ".config/miren"),
+		configDirPath,
+	}
+
+	for _, dir := range dirsToFix {
+		if err := fixOwnershipIfSudo(ctx, dir); err != nil {
+			ctx.Log.Warn("failed to fix directory ownership", "dir", dir, "error", err)
+		}
+	}
+
 	// Create the local cluster config
 	localConfigPath := filepath.Join(configDirPath, "50-local.yaml")
 
@@ -658,6 +673,43 @@ func writeLocalClusterConfig(ctx *Context, cc *caauth.ClientCertificate, address
 		return fmt.Errorf("failed to save local cluster config: %w", err)
 	}
 
+	// Fix file ownership if running under sudo
+	if err := fixOwnershipIfSudo(ctx, localConfigPath); err != nil {
+		ctx.Log.Warn("failed to fix config file ownership", "error", err)
+	}
+
 	ctx.Log.Info("wrote local cluster config", "path", localConfigPath, "name", clusterName, "address", address)
+	return nil
+}
+
+// fixOwnershipIfSudo fixes file/directory ownership when running under sudo
+func fixOwnershipIfSudo(ctx *Context, path string) error {
+	// Check if running under sudo
+	sudoUID := os.Getenv("SUDO_UID")
+	sudoGID := os.Getenv("SUDO_GID")
+
+	if sudoUID == "" || sudoGID == "" {
+		// Not running under sudo, nothing to do
+		return nil
+	}
+
+	// Parse UID and GID
+	uid, err := strconv.Atoi(sudoUID)
+	if err != nil {
+		return fmt.Errorf("failed to parse SUDO_UID: %w", err)
+	}
+
+	gid, err := strconv.Atoi(sudoGID)
+	if err != nil {
+		return fmt.Errorf("failed to parse SUDO_GID: %w", err)
+	}
+
+	// Change ownership
+	if err := os.Chown(path, uid, gid); err != nil {
+		return fmt.Errorf("failed to chown %s to %d:%d: %w", path, uid, gid, err)
+	}
+
+	ctx.Log.Debug("fixed ownership for", "path", path, "uid", uid, "gid", gid)
+
 	return nil
 }

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -684,6 +684,11 @@ func writeLocalClusterConfig(ctx *Context, cc *caauth.ClientCertificate, address
 
 // fixOwnershipIfSudo fixes file/directory ownership when running under sudo
 func fixOwnershipIfSudo(ctx *Context, path string) error {
+	if os.Geteuid() != 0 {
+		// Not running as root, nothing to do
+		return nil
+	}
+
 	// Check if running under sudo
 	sudoUID := os.Getenv("SUDO_UID")
 	sudoGID := os.Getenv("SUDO_GID")


### PR DESCRIPTION
## Summary
- Fixed file ownership issue when miren server is run with sudo
- Uses SUDO_UID and SUDO_GID to set correct ownership for config files
- Ensures all parent directories also have correct ownership

## Problem
When the miren server is run with `sudo`, the `50-local.yaml` config file was being created with root ownership. This prevented normal users from accessing the config file later when running miren commands without sudo.

## Solution
Added a `fixOwnershipIfSudo` function that:
1. Checks for SUDO_UID and SUDO_GID environment variables
2. Uses `os.Chown` to set the correct ownership when running under sudo
3. Applies ownership fix to all created directories and the config file

## Test Plan
- [x] Run `sudo miren server` and verify 50-local.yaml has correct user ownership
- [x] Verify miren commands work without sudo after server creates config
- [x] Test when not using sudo to ensure no errors occur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Config directories and files created while running with elevated privileges are now re-owned by the invoking user to avoid permission errors.
  * Ownership adjustments are attempted for config directories and the saved config file; failures log warnings but do not interrupt execution.
  * Behavior for non-elevated runs remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->