### PR TITLE
MIR-338: Schedule ready nodes

### DIFF
--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -177,12 +177,18 @@ func (r *Runner) setupEntity(ctx context.Context, ec *entityserver.Client) error
 	r.se = sess
 
 	node := compute_v1alpha.Node{
-		Status:      compute_v1alpha.READY,
 		Constraints: types.LabelSet("compute", "generic"),
 		ApiAddress:  r.ListenAddress,
 	}
 
-	res, err := ec.Create(ctx, r.Id, &node)
+	res, err := ec.CreateOrUpdate(ctx, r.Id, &node)
+	if err != nil {
+		return err
+	}
+
+	err = ec.UpdateAttrs(ctx, res, (&compute_v1alpha.Node{
+		Status: compute_v1alpha.READY,
+	}).Encode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change does two things:

1. It calls Update on the node entry on runner boot so that we're sure the session attribute is updated to Ready (this won't be an issue when we fix the Put() ambiguity issue)
2. Rather than blindly picking the first node we see in a `range` over a map, we pick a random node that has it's status set to ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Randomly distributes sandbox assignments across READY nodes for better load balancing.

* Bug Fixes
  * Uses only READY nodes for scheduling to avoid assigning work to unavailable nodes.
  * Improves node registration reliability and status handling to reduce transient failures.
  * Clarifies error messages when no nodes are available for mass scheduling.

* Refactor
  * Streamlines node creation/update and sandbox update flows for more consistent state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->