### PR TITLE
Work around bug in yaml parser

### DIFF
--- a/servers/build/launch.go
+++ b/servers/build/launch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"maps"
+	"strings"
 	"time"
 
 	"github.com/containerd/containerd/v2/client"
@@ -141,7 +142,7 @@ func (l *LaunchBuildkit) Launch(ctx context.Context, addr string, lo ...LaunchOp
 			{
 				Path: "/etc/buildkit/buildkitd.toml",
 				Mode: "0644",
-				Data: config,
+				Data: strings.TrimSpace(config),
 			},
 		},
 	})


### PR DESCRIPTION
Seems that the yaml parser (that is invoked when calling Encode) really dislikes having a leading newline character! We've openned a bug about it: https://github.com/yaml/go-yaml/issues/65

This is a fix work around for now, but we're considering moving the config file body to something opaque rather than a string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trim extraneous leading/trailing whitespace from generated build configuration, preventing parsing issues and intermittent build failures.
  * No impact on public APIs; only whitespace handling behavior is adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->