### PR TITLE
MIR-318: Tune ClickHouse memory settings for low-memory operation

### DIFF
--- a/components/clickhouse/config.xml
+++ b/components/clickhouse/config.xml
@@ -3,6 +3,15 @@
   If you have accidentally specified user-level settings here, server won't start.
   You can either move the settings to the right place inside "users.xml" file
    or add <skip_check_for_incorrect_settings>1</skip_check_for_incorrect_settings> here.
+
+  MEMORY TUNING: This configuration has been tuned for low-memory standalone operation
+  to prevent excessive memory usage and OOM issues. Key changes from defaults:
+  - max_server_memory_usage_to_ram_ratio: 0.5 (from 0.9)
+  - mark_cache_size: 1GB (from 5GB)
+  - uncompressed_cache_size: 512MB (from 8GB)
+  - background_pool_size: 4 (from 16)
+  - max_concurrent_queries: 100 (from 1000)
+  See users.xml for per-query memory limits.
 -->
 <clickhouse>
     <logger>
@@ -31,7 +40,7 @@
         <count>10</count>
 
         <console>1</console> <!-- Default behavior is autodetection (log to console if not daemon mode and is tty) -->
-         <console_log_level>notice</console_log_level> 
+         <console_log_level>notice</console_log_level>
 
         <!-- <use_syslog>0</use_syslog> -->
         <!-- <syslog_level>trace</syslog_level> -->
@@ -353,8 +362,8 @@
     <concurrent_threads_soft_limit_num>0</concurrent_threads_soft_limit_num>
     <concurrent_threads_soft_limit_ratio_to_cores>2</concurrent_threads_soft_limit_ratio_to_cores>
 
-    <!-- Maximum number of concurrent queries. -->
-    <max_concurrent_queries>1000</max_concurrent_queries>
+    <!-- Maximum number of concurrent queries. Reduced for low-memory operation -->
+    <max_concurrent_queries>100</max_concurrent_queries>
 
     <!-- Maximum memory usage (resident set size) for server process.
          Zero value or unset means default. Default is "max_server_memory_usage_to_ram_ratio" of available physical RAM.
@@ -378,21 +387,17 @@
 
     <max_thread_pool_size>10000</max_thread_pool_size>
 
-    <!-- Configure other thread pools: -->
-    <!--
-    <background_buffer_flush_schedule_pool_size>16</background_buffer_flush_schedule_pool_size>
-    <background_pool_size>16</background_pool_size>
-    <background_merges_mutations_concurrency_ratio>2</background_merges_mutations_concurrency_ratio>
+    <!-- Configure other thread pools: reduced for low-memory operation -->
+    <background_buffer_flush_schedule_pool_size>4</background_buffer_flush_schedule_pool_size>
+    <background_pool_size>4</background_pool_size>
+    <background_merges_mutations_concurrency_ratio>1</background_merges_mutations_concurrency_ratio>
     <background_merges_mutations_scheduling_policy>round_robin</background_merges_mutations_scheduling_policy>
-    <background_move_pool_size>8</background_move_pool_size>
-    <background_fetches_pool_size>8</background_fetches_pool_size>
-    <background_common_pool_size>8</background_common_pool_size>
-    <background_schedule_pool_size>128</background_schedule_pool_size>
-    <background_message_broker_schedule_pool_size>16</background_message_broker_schedule_pool_size>
-    <background_distributed_schedule_pool_size>16</background_distributed_schedule_pool_size>
-    <tables_loader_foreground_pool_size>0</tables_loader_foreground_pool_size>
-    <tables_loader_background_pool_size>0</tables_loader_background_pool_size>
-    -->
+    <background_move_pool_size>2</background_move_pool_size>
+    <background_fetches_pool_size>2</background_fetches_pool_size>
+    <background_common_pool_size>2</background_common_pool_size>
+    <background_schedule_pool_size>16</background_schedule_pool_size>
+    <background_message_broker_schedule_pool_size>4</background_message_broker_schedule_pool_size>
+    <background_distributed_schedule_pool_size>4</background_distributed_schedule_pool_size>
 
     <!-- Enables asynchronous loading of databases and tables to speedup server startup.
          Queries to not yet loaded entity will be blocked until load is finished.
@@ -400,8 +405,9 @@
     <async_load_databases>true</async_load_databases>
 
     <!-- On memory constrained environments you may have to set this to value larger than 1.
+         Reduced from default 0.9 to 0.5 for low-memory standalone operation to prevent OOM issues
       -->
-    <max_server_memory_usage_to_ram_ratio>0.9</max_server_memory_usage_to_ram_ratio>
+    <max_server_memory_usage_to_ram_ratio>0.5</max_server_memory_usage_to_ram_ratio>
 
     <!-- Simple server-wide memory profiler. Collect a stack trace at every peak allocation step (in bytes).
          Data will be stored in system.trace_log table with query_id = empty string.
@@ -430,12 +436,13 @@
          is slower than multi-core decompression on some server configurations.
          Enabling it can sometimes paradoxically make queries slower.
       -->
-    <uncompressed_cache_size>8589934592</uncompressed_cache_size>
+    <!-- Reduced from 8GB to 512MB for low-memory operation -->
+    <uncompressed_cache_size>536870912</uncompressed_cache_size>
 
     <!-- Approximate size of mark cache, used in tables of MergeTree family.
          In bytes. Cache is single for server. Memory is allocated only on demand.
-         You should not lower this value. -->
-    <!-- <mark_cache_size>5368709120</mark_cache_size> -->
+         Reduced from 5GB default to 1GB for low-memory operation -->
+    <mark_cache_size>1073741824</mark_cache_size>
 
     <!-- For marks of secondary indices. -->
     <!-- <index_mark_cache_size>5368709120</index_mark_cache_size> -->
@@ -1493,11 +1500,13 @@
     -->
 
     <!-- Settings to fine-tune MergeTree tables. See documentation in source code, in MergeTreeSettings.h -->
-    <!--
     <merge_tree>
+        <!-- Reduced to work with lower background_pool_size (4) × background_merges_mutations_concurrency_ratio (1) = 4 -->
+        <number_of_free_entries_in_pool_to_execute_mutation>2</number_of_free_entries_in_pool_to_execute_mutation>
+        <number_of_free_entries_in_pool_to_lower_max_size_of_merge>2</number_of_free_entries_in_pool_to_lower_max_size_of_merge>
+        <number_of_free_entries_in_pool_to_execute_optimize_entire_partition>2</number_of_free_entries_in_pool_to_execute_optimize_entire_partition>
         <max_suspicious_broken_parts>5</max_suspicious_broken_parts>
     </merge_tree>
-    -->
 
     <!-- Settings to fine-tune ReplicatedMergeTree tables. See documentation in source code, in MergeTreeSettings.h -->
     <!--

--- a/components/clickhouse/users.xml
+++ b/components/clickhouse/users.xml
@@ -3,8 +3,23 @@
 
     <!-- Profiles of settings. -->
     <profiles>
-        <!-- Default settings. -->
+        <!-- Default settings with memory limits for low-memory operation -->
         <default>
+            <!-- Max memory usage for a single query (2GB) -->
+            <max_memory_usage>2147483648</max_memory_usage>
+            <!-- Max memory for GROUP BY before spilling to disk (512MB) -->
+            <max_bytes_before_external_group_by>536870912</max_bytes_before_external_group_by>
+            <!-- Max memory for sorting before spilling to disk (512MB) -->
+            <max_bytes_before_external_sort>536870912</max_bytes_before_external_sort>
+            <!-- Reduce block size for lower memory usage -->
+            <max_block_size>8192</max_block_size>
+            <!-- Reduce threads for lower memory usage -->
+            <max_threads>4</max_threads>
+            <!-- Disable parallel parsing to save memory -->
+            <input_format_parallel_parsing>0</input_format_parallel_parsing>
+            <output_format_parallel_formatting>0</output_format_parallel_formatting>
+            <!-- Limit insert threads -->
+            <max_insert_threads>2</max_insert_threads>
         </default>
 
         <!-- Profile that allows only read queries. -->
@@ -106,11 +121,11 @@
             {{else}}
             <password></password>
             {{end}}
-            
+
             <networks>
                 <ip>::/0</ip>
             </networks>
-            
+
             <profile>default</profile>
             <quota>default</quota>
             <access_management>1</access_management>


### PR DESCRIPTION
## Summary
- Tuned ClickHouse memory configuration to prevent OOM issues during standalone operation
- Reduced memory allocation from 80% to 50% of system RAM
- Applied settings recommended by ClickHouse docs for systems with <16GB RAM
- Fixed MergeTree pool settings to be compatible with reduced background pool size

## Context
ClickHouse was allocating 80% of system memory by default (14GB on a 16GB machine) and running into memory issues during merge operations. This PR implements the tuning recommended in [ClickHouse documentation](https://clickhouse.com/docs/operations/tips#using-less-than-16gb-of-ram) to allow stable operation with lower memory usage.

## Changes

### Server-level memory settings (config.xml)
- `max_server_memory_usage_to_ram_ratio`: 0.9 → 0.5 (use 50% of RAM instead of 90%)
- `mark_cache_size`: 5GB → 1GB
- `uncompressed_cache_size`: 8GB → 512MB  
- `background_pool_size`: 16 → 4 threads (reduces memory during merges)
- `background_merges_mutations_concurrency_ratio`: 2 → 1
- Other background pool sizes also reduced proportionally
- `max_concurrent_queries`: 1000 → 100

### MergeTree pool settings (config.xml)
These settings must be less than `background_pool_size` × `background_merges_mutations_concurrency_ratio` = 4:
- `number_of_free_entries_in_pool_to_execute_mutation`: 20 → 2
- `number_of_free_entries_in_pool_to_lower_max_size_of_merge`: 8 → 2  
- `number_of_free_entries_in_pool_to_execute_optimize_entire_partition`: 25 → 2

### Query-level memory limits (users.xml)
- `max_memory_usage`: Limited to 2GB per query
- `max_bytes_before_external_group_by`: 512MB (spills to disk after this)
- `max_bytes_before_external_sort`: 512MB (spills to disk after this)
- `max_threads`: Limited to 4 per query
- Disabled parallel parsing to reduce memory overhead
- `max_block_size`: Reduced to 8192
- `max_insert_threads`: Limited to 2

## Test plan
- [x] Configuration templates parse correctly
- [x] Binary builds successfully
- [x] Lint checks pass
- [x] Fixed startup errors related to pool settings
- [ ] Deploy to staging environment and monitor memory usage
- [ ] Verify merge operations complete without OOM
- [ ] Test with typical query workload

## Notes
These settings allow ClickHouse to operate with as low as 2GB RAM according to the documentation, though performance will be reduced compared to a properly-sized system. This is acceptable for our low-utilization standalone deployment scenario.

The MergeTree pool settings were adjusted after initial testing revealed configuration conflicts where the default values exceeded our reduced background pool capacity.

Fixes: MIR-318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ClickHouse default profile to use memory-conservative settings (e.g., lower memory limits and reduced parallelism).
  * Aims to improve stability on resource-constrained environments and prevent out-of-memory issues during heavy operations.
  * May slightly reduce throughput for large sorts, group-bys, and inserts due to lower thread counts and externalization thresholds.
  * Read-only profile and user/quota definitions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->