### PR TITLE
Add ctr to release bundle

### DIFF
--- a/dagger/main.go
+++ b/dagger/main.go
@@ -147,6 +147,7 @@ func (m *Runtime) Package(
 		cp /usr/local/bin/containerd-shim-runc-v2 /tmp/package
 		cp /usr/local/bin/containerd /tmp/package
 		cp /usr/local/bin/nerdctl /tmp/package
+		cp /usr/local/bin/ctr /tmp/package
 		tar -C /tmp/package -czf /tmp/package.tar.gz .
 `})
 	return c.File("/tmp/package.tar.gz")


### PR DESCRIPTION
It'd be nice to have it hanging around in addition to nerdctl, since ctr
makes fewer docker-flavored assumptions about the containerd environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Package artifact now includes the ctr binary, ensuring the distributed bundle is complete and preventing failures related to the previously missing dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->