### PR TITLE
Fix miren to properly exit with non-zero status on errors

### DIFF
--- a/cmd/miren/main.go
+++ b/cmd/miren/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	cli.Run(os.Args)
+	os.Exit(cli.Run(os.Args))
 }


### PR DESCRIPTION
## Summary
- Fixed a critical bug where miren always exited with status 0, even on errors
- The issue affected ALL miren commands that encountered errors
- main() was ignoring the exit code returned by cli.Run()

Fixes MIR-340

## Impact
This bug prevented proper error handling in:
- Shell scripts using miren commands
- CI/CD pipelines 
- Any automation relying on miren exit codes
- Error detection in general command usage

## Test Case
Before this fix:
```bash
$ bin/miren config load -i /bin/notafile
An error occurred:
no config file found
$ echo $?
0  # Wrong\! Should be non-zero
```

After this fix:
```bash
$ bin/miren config load -i /bin/notafile  
An error occurred:
no config file found
$ echo $?
1  # Correct\! Properly indicates failure
```

## Solution
Changed `main()` from:
```go
func main() {
    cli.Run(os.Args)
}
```

To:
```go
func main() {
    os.Exit(cli.Run(os.Args))
}
```

This ensures the exit code from cli.Run() is properly propagated to the OS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now exits with the correct status code from command execution rather than always indicating success. This allows shell scripts, automation, and CI pipelines to reliably detect and react to failures. No changes to command options or output; only termination behavior is corrected. Improves reliability for users chaining commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->