### PR TITLE
feat: add sandbox log fetching capability to miren logs command

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 version: "2"
+
 linters:
   default: standard
   exclusions:
@@ -20,6 +21,10 @@ linters:
         linters:
           - govet
         text: unreachable code
+    # Exclude generated files from reporting issues
+    paths:
+      - ".*\\.gen\\.go$"
+
 formatters:
   enable:
     - gofmt

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -354,6 +354,18 @@ interfaces:
           - name: logs
             type: list
             element: LogEntry
+      - name: sandboxLogs
+        parameters:
+          - name: sandbox
+            type: string
+          - name: from
+            type: standard.Timestamp
+          - name: follow
+            type: bool
+        results:
+          - name: logs
+            type: list
+            element: LogEntry
 
   - name: Disks
     methods:


### PR DESCRIPTION
## Summary
- Added ability to fetch logs by sandbox ID using `--sandbox` flag
- Maintains backward compatibility with existing app-based log fetching
- Automatically reads app from directory context when no flags provided
- Fixed several issues with timestamp handling and pagination

## Changes
- Added new `sandboxLogs` RPC method to the Logs interface
- Implemented `ReadBySandbox` method in observability layer to query by sandbox attribute
- Added `--sandbox` flag to CLI with proper validation and normalization
- Updated golangci-lint config to exclude generated files
- Fixed ClickHouse DateTime64 timestamp comparison using `fromUnixTimestamp64Micro()`
- Fixed pagination to prevent duplicate logs by incrementing timestamp by 1 microsecond

## Bug Fixes During Implementation
- Fixed SQL placeholder quoting issue (removed quotes around placeholders)
- Fixed loop variable pointer issue in LogEntry creation
- Fixed "Convert overflow" error with DateTime64 comparisons
- Fixed duplicate logs appearing during pagination

## Test Plan
- [x] Deploy to sandbox server for testing
- [x] Test fetching logs by sandbox ID
- [x] Verify backward compatibility with app-based logs
- [x] Confirm directory context loading still works
- [x] Verify pagination works without duplicates
- [x] E2E tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sandbox-scoped log retrieval and RPC (sandboxLogs) with end-to-end client/server support; use --sandbox to fetch/stream sandbox logs.
  - Logs CLI is now config-centric with --app, --dir, --last, --sandbox, app auto-inference, and sandbox ID normalization.
- **Bug Fixes**
  - Improved log-reading error handling: ensured rows are closed, errors propagated, and iteration errors surfaced.
- **Chores**
  - Lint config updated to exclude generated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->