### PR TITLE
Properly use the deleted slice

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -113,7 +113,7 @@ func (c *SandboxController) SetPortStatus(id string, port observability.BoundPor
 	case observability.PortStatusBound:
 		ports.Ports = append(ports.Ports, port)
 	case observability.PortStatusUnbound:
-		slices.DeleteFunc(ports.Ports, func(p observability.BoundPort) bool {
+		ports.Ports = slices.DeleteFunc(ports.Ports, func(p observability.BoundPort) bool {
 			return p == port
 		})
 	}


### PR DESCRIPTION
Yay for linters finding this!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where unbinding a sandbox port didn’t actually remove it, leading to stale port entries and incorrect status reporting.
  * Unbound ports are now removed promptly, improving reliability of operations that wait for port availability and reducing unexpected timeouts.
  * Users may notice more accurate port lists and smoother teardown/restart workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->