### PR TITLE
fix: add retry logic and prevent queue blockage in controller watch (MIR-346)

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -175,6 +175,9 @@ func (c *ReconcileController) Start(top context.Context) error {
 					return nil
 				case c.workQueue <- ev:
 					//ok
+				default:
+					// Queue is full, log and continue
+					c.Log.Warn("Work queue full, dropping watch event", "entity", ev.Id, "eventType", ev.Type, "queueSize", len(c.workQueue))
 				}
 
 				return nil
@@ -340,6 +343,9 @@ func (c *ReconcileController) periodicResync(ctx context.Context) {
 				return
 			case c.workQueue <- ev:
 				// Event added to queue
+			default:
+				// Queue is full, log and skip this event
+				c.Log.Warn("Work queue full during resync, dropping event", "entity", ev.Id, "queueSize", len(c.workQueue))
 			}
 		}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -115,46 +115,98 @@ func (c *ReconcileController) Start(top context.Context) error {
 		c.Log.Info("Starting index watch")
 		defer c.Log.Info("Index watch stopped")
 
-		c.esc.WatchIndex(ctx, c.index, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
-			var eventType EventType
+		// Retry logic with exponential backoff
+		retryDelay := time.Second
+		maxRetryDelay := time.Minute * 5
+		retryCount := 0
 
-			switch op.Operation() {
-			case 1:
-				eventType = EventAdded
-			case 2:
-				eventType = EventUpdated
-			case 3:
-				eventType = EventDeleted
-			default:
-				return nil
-			}
-
-			ev := Event{
-				Type:    eventType,
-				Id:      entity.Id(op.EntityId()),
-				PrevRev: op.Previous(),
-			}
-
-			if op.HasEntity() {
-				aen := op.Entity()
-
-				ev.Entity = &entity.Entity{
-					ID:        entity.Id(aen.Id()),
-					CreatedAt: aen.CreatedAt(),
-					UpdatedAt: aen.UpdatedAt(),
-					Attrs:     aen.Attrs(),
-				}
-			}
-
+		for {
 			select {
 			case <-ctx.Done():
-				return nil
-			case c.workQueue <- ev:
-				//ok
+				return
+			default:
 			}
 
-			return nil
-		}))
+			if retryCount > 0 {
+				c.Log.Info("Attempting to reconnect watch", "index", c.index.ID, "value", c.index.Value, "attempt", retryCount)
+			} else {
+				c.Log.Debug("Attempting to establish watch connection", "index", c.index.ID, "value", c.index.Value)
+			}
+
+			_, err := c.esc.WatchIndex(ctx, c.index, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
+				// Log successful reconnection after retry
+				if retryCount > 0 {
+					c.Log.Info("Watch successfully reconnected", "index", c.index.ID, "value", c.index.Value, "afterAttempts", retryCount)
+					retryCount = 0
+					retryDelay = time.Second // Reset delay for future disconnects
+				}
+				var eventType EventType
+
+				switch op.Operation() {
+				case 1:
+					eventType = EventAdded
+				case 2:
+					eventType = EventUpdated
+				case 3:
+					eventType = EventDeleted
+				default:
+					return nil
+				}
+
+				ev := Event{
+					Type:    eventType,
+					Id:      entity.Id(op.EntityId()),
+					PrevRev: op.Previous(),
+				}
+
+				if op.HasEntity() {
+					aen := op.Entity()
+
+					ev.Entity = &entity.Entity{
+						ID:        entity.Id(aen.Id()),
+						CreatedAt: aen.CreatedAt(),
+						UpdatedAt: aen.UpdatedAt(),
+						Attrs:     aen.Attrs(),
+					}
+				}
+
+				select {
+				case <-ctx.Done():
+					return nil
+				case c.workQueue <- ev:
+					//ok
+				}
+
+				return nil
+			}))
+
+			if err != nil {
+				// Check if context was cancelled
+				if ctx.Err() != nil {
+					c.Log.Debug("Watch context cancelled, stopping watch")
+					return
+				}
+
+				retryCount++
+				c.Log.Error("Watch disconnected, will retry", "error", err, "retryDelay", retryDelay, "attempt", retryCount)
+
+				// Wait before retrying with exponential backoff
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(retryDelay):
+					// Exponential backoff with max delay
+					retryDelay = retryDelay * 2
+					if retryDelay > maxRetryDelay {
+						retryDelay = maxRetryDelay
+					}
+				}
+			} else {
+				// Watch completed normally (shouldn't happen unless context cancelled)
+				c.Log.Debug("Watch completed normally")
+				return
+			}
+		}
 	}()
 
 	// Start periodic resync
@@ -295,7 +347,7 @@ func (c *ReconcileController) periodicResync(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			break
+			// Continue to the next tick
 		}
 	}
 }

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -315,6 +315,14 @@ func (e *EntityServer) WatchIndex(ctx context.Context, req *entityserver_v1alpha
 				return nil
 			}
 
+			// Check if the watch was canceled or had an error
+			if watchevent.Canceled {
+				if err := watchevent.Err(); err != nil {
+					return fmt.Errorf("watch canceled with error: %w", err)
+				}
+				return fmt.Errorf("watch canceled")
+			}
+
 			for _, event := range watchevent.Events {
 				var (
 					eventType int


### PR DESCRIPTION
## Summary
- Adds automatic reconnection logic when entity watch connections are lost
- Prevents controller queue blockage during resync operations
- Prevents indefinite blocking when waiting for ports to be bound
- Ensures controllers remain operational even after entity server restarts

## Problem (MIR-346)
The sandbox controller's entity watch mechanism would permanently disconnect after losing connection to the entity server, causing the controller to stop processing new events. While periodic tasks continued running, the main reconciliation loop became permanently disconnected, requiring a service restart to restore functionality.

Additionally, the controller could block indefinitely waiting for ports to be bound during sandbox startup, causing the entire reconciliation to stall.

### Impact
- New sandboxes were not created/updated/deleted
- Existing sandboxes were not reconciled with desired state
- Only periodic cleanup continued to function
- Controller could become completely blocked waiting for port binding

## Solution

### Commit 1: Add retry logic to controller watch mechanism
- Implemented exponential backoff retry logic in `WatchIndex` to automatically reconnect
- Fixed entityserver to properly check and propagate watch errors
- Added comprehensive test to verify watch reconnection behavior
- Controllers now automatically reconnect when the entity server restarts or network issues occur

### Commit 2: Prevent controller queue blockage during resync
- Made queue sends non-blocking with default case to prevent deadlocks
- Added warnings when events are dropped due to full queue
- Ensured periodicResync continues running even under queue pressure
- Added test to verify resync behavior (currently skipped due to timing sensitivity)

### Commit 3: Add timeout to waitForPort to prevent indefinite blocking
- Added context and timeout parameters to waitForPort function (30 second default)
- Controller continues with sandbox startup even if port binding times out
- Prevents entire controller from stalling when individual sandboxes have port binding issues
- Added comprehensive test coverage for timeout behavior

### Commit 4: Additional activator logging
- The sandbox server got into a state where it was leaking rfd app sandboxes (running sandboxes grew to ~40 in 24h), but it disappeared after I deployed this branch to it.
- This additional logging was meant to diagnose the issue; leaving it in so we have it if the issue recurs.

## Testing
- Added unit tests for watch reconnection logic
- Added test for queue overflow handling during resync
- Added tests for port wait timeout and context cancellation
- Manually tested controller behavior during entity server restarts

## Files Changed
- `pkg/controller/controller.go` - Core retry logic and queue handling
- `pkg/controller/controller_test.go` - Comprehensive test coverage
- `servers/entityserver/entityserver.go` - Error propagation fixes
- `pkg/entity/mock.go` - Test infrastructure improvements
- `controllers/sandbox/sandbox.go` - Port wait timeout implementation
- `controllers/sandbox/sandbox_test.go` - Port timeout test coverage

Fixes MIR-346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox startup no longer blocks on port binding; per-port timeouts and cancellation allow startup to continue.
  * Mock store gains a hook to customize index listing for tests.

* **Bug Fixes**
  * Index watch is now resilient: automatic reconnect with exponential backoff, non-blocking event queuing (drops logged when full), explicit cancellation/error handling, and improved logging.
  * Resyncs now warn and drop events when the resync queue is full.

* **Tests**
  * Added tests for watch reconnection, queue overflow, and port-wait success/timeout/cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->