### PR TITLE
Debug: Activator JSON state dumping for MIR-349 diagnostics

### DIFF
--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -307,7 +307,7 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 	}
 
 	if curLease != nil {
-		h.Log.Info("using existing lease", "app", targetAppId, "url", curLease.Lease.URL)
+		h.Log.Info("using existing lease", "app", targetAppId, "url", curLease.Lease.URL, "sandbox", curLease.Lease.Sandbox().ID)
 		h.forwardToLease(ctx, w, req, curLease)
 		return
 	}


### PR DESCRIPTION
## Summary
- Temporary debug code to diagnose activator issues on sandbox server (MIR-349)
- Adds JSON dumping of internal activator state to `/tmp/activator_debug.json`
- **NOT INTENDED FOR MERGE** - This is debug code deployed to sandbox server only

## Changes
- Added `dumpDebugState()` method that writes activator's internal state to JSON
- Calls debug dump after every state modification for real-time debugging
- Captures: versions map, sandboxes, pending creations, timestamps, slot usage

## Deployment
- Branch deployed to sandbox server for diagnosing MIR-349
- Monitor `/tmp/activator_debug.json` on the server to see activator state changes

## Note
This PR is created for visibility only. We will close it once debugging is complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-demand runtime diagnostic dumps for the activator, writing a JSON snapshot of current state to /tmp/activator_debug.json to aid troubleshooting.
* **Chores**
  * Enhanced logging when acquiring leases, including version tracking details when no sandboxes are available and clearer retire-scan before/after summaries.
  * Added sandbox ID to HTTP ingress logs when reusing an existing lease for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->