### PR TITLE
feat: implement local shared storage for apps (RFD 26)

### DIFF
--- a/testdata/bun/index.js
+++ b/testdata/bun/index.js
@@ -1,8 +1,22 @@
+import { appendFile } from "fs/promises";
+
 const server = Bun.serve({
   port: 3000,
-  fetch(request) {
+  async fetch(request) {
+    // Create timestamped log entry
+    const timestamp = new Date().toISOString();
+    const logEntry = `${timestamp} - ${request.method} ${request.url} - ${request.headers.get("user-agent") || "Unknown"}\n`;
+
+    try {
+      // Append to log file in the specified directory
+      await appendFile("/miren/data/local/server.log", logEntry);
+    } catch (error) {
+      console.error("Failed to write to log file:", error);
+    }
+
     return new Response("Welcome to Bun!");
   },
 });
 
 console.log(`Listening on ${server.url}`);
+console.log("Logging requests to /miren/data/local/server.log");


### PR DESCRIPTION
## Summary
Implements [RFD 26: Local Shared Storage](https://github.com/mirendev/rfd/pull/36) to add persistent, host-local storage to Miren applications.

This PR adds a bind mount at `/miren/data/local` inside containers that persists across container restarts and is shared between all containers within an app.

## Changes
- Modified `controllers/sandbox/sandbox.go` to add local storage mount in `buildSubContainerSpec`
- When creating application containers, the controller:
  1. Fetches the AppVersion entity to get the App ID
  2. Creates a directory at `/var/lib/miren/data/local/{app_id}/` on the host
  3. Bind mounts this directory to `/miren/data/local` inside the container

## Storage Properties
- **Persistent**: Data survives container restarts and redeployments
- **Shared**: All containers within an app (across all versions) share the same storage
- **Isolated**: Each app has its own isolated storage directory
- **Well-organized**: Apps store data at `/var/lib/miren/data/local/app/{app-name}` on the host

## Use Cases
This enables applications to use:
- SQLite databases that persist across deployments
- File-based session storage
- User upload directories
- Any file-based data that needs to survive container lifecycle

## Testing
- [x] Code compiles successfully
- [x] Passes lint checks (`make lint-changed`)
- [x] Manual testing with a sample app using SQLite
- [x] Verify storage persists across container restarts

## Notes
- Only application containers get the mount (not the pause container) to keep it simple
- The implementation handles app IDs with prefixes (e.g., `app/myapp`) correctly
- Errors in fetching AppVersion are logged at ERROR level since this impacts storage availability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds per-app local storage inside sandboxed containers, providing a writable, persistent data area for each app when an app version and data path are present.
  * Request logging: sandboxed apps now append request logs to a local server.log in the app data area.

* **Bug Fixes**
  * More resilient startup: if app metadata or storage setup fails, the container proceeds without the local storage mount and logs the issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->