### PR TITLE
A couple fixes found while dogfooding

### DIFF
--- a/cli/commands/register.go
+++ b/cli/commands/register.go
@@ -12,7 +12,7 @@ import (
 // Register handles cluster registration with miren.cloud
 func Register(ctx *Context, opts struct {
 	ClusterName string            `short:"n" long:"name" description:"Cluster name" required:"true"`
-	CloudURL    string            `short:"u" long:"url" description:"Cloud URL" default:"https://api.miren.cloud"`
+	CloudURL    string            `short:"u" long:"url" description:"Cloud URL" default:"https://miren.cloud"`
 	Tags        map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
 	OutputDir   string            `short:"o" long:"output" description:"Output directory for registration" default:"/var/lib/miren/server"`
 }) error {

--- a/pkg/cloudauth/keypair.go
+++ b/pkg/cloudauth/keypair.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"strings"
 )
 
 // KeyPair represents an ED25519 key pair for cluster authentication
@@ -64,7 +65,7 @@ func (kp *KeyPair) PrivateKeyPEM() (string, error) {
 // in the format "SHA256:base64encoded" to match the server
 func (kp *KeyPair) Fingerprint() string {
 	hash := sha256.Sum256(kp.PublicKey)
-	return base64.StdEncoding.EncodeToString(hash[:])
+	return "SHA256:" + strings.TrimSuffix(base64.StdEncoding.EncodeToString(hash[:]), "=")
 }
 
 // Sign signs a message with the private key


### PR DESCRIPTION
1. Use https://miren.cloud as the URL to register with (cookies, etc)
2. Fix the fingerprint format to make it the same as elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fingerprint output now includes a “SHA256:” prefix and trims trailing padding for clearer, standards-aligned display in tools and logs. Existing keys are unaffected; only the shown format changes.
  * The register command now defaults to https://miren.cloud when no endpoint is specified, improving out-of-the-box connectivity. Custom endpoints provided via flags continue to work unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->