### PR TITLE
Fix panic in sandbox stop/delete commands

### DIFF
--- a/cli/commands/sandbox_delete.go
+++ b/cli/commands/sandbox_delete.go
@@ -9,12 +9,11 @@ import (
 func SandboxDelete(ctx *Context, opts struct {
 	Force bool `short:"f" long:"force" description:"Force delete without confirmation"`
 	ConfigCentric
-}, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("usage: sandbox delete <sandbox-id>")
-	}
-
-	sandboxID := args[0]
+	Args struct {
+		SandboxID string `positional-arg-name:"sandbox-id" description:"ID of the sandbox to delete"`
+	} `positional-args:"yes" required:"yes"`
+}) error {
+	sandboxID := opts.Args.SandboxID
 
 	client, err := ctx.RPCClient("entities")
 	if err != nil {

--- a/cli/commands/sandbox_stop.go
+++ b/cli/commands/sandbox_stop.go
@@ -1,19 +1,16 @@
 package commands
 
 import (
-	"fmt"
-
 	"miren.dev/runtime/api/compute"
 )
 
 func SandboxStop(ctx *Context, opts struct {
 	ConfigCentric
-}, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("usage: sandbox stop <sandbox-id>")
-	}
-
-	sandboxID := args[0]
+	Args struct {
+		SandboxID string `positional-arg-name:"sandbox-id" description:"ID of the sandbox to stop"`
+	} `positional-args:"yes" required:"yes"`
+}) error {
+	sandboxID := opts.Args.SandboxID
 
 	client, err := ctx.RPCClient("entities")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixed panic in `miren sandbox stop` and `miren sandbox delete` commands
- Updated command signatures to match the expected 2-parameter pattern

## Problem
The sandbox stop and delete commands were causing a panic:
```
panic: must provide two arguments only
```

This was because these functions had 3 parameters `(ctx *Context, opts struct{}, args []string)` but the `Infer` function expects exactly 2 parameters.

## Solution
Updated both commands to use the `Args` struct pattern with `positional-args` tags, matching the pattern used by other commands like `config_remove` and `config_set_active`.

Changes:
- Moved positional arguments into the opts struct using `Args` field
- Added proper struct tags for help text and validation
- Removed unused fmt import from sandbox_stop.go

## Test Plan
- [x] Built the binary with `make bin/miren`
- [x] Tested `bin/miren sandbox stop --help` - no panic, shows proper help
- [x] Tested `bin/miren sandbox delete --help` - no panic, shows proper help
- [x] Ran `make lint-changed` - all checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive confirmation when deleting a sandbox. Use --force to skip confirmation.
* **Refactor**
  * Streamlined CLI argument handling for sandbox delete and stop commands with structured positional arguments, improving consistency and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->