### PR TITLE
fix: remove unnecessary build-and-push-docker dependency from upload-to-miren

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   upload-to-miren:
-    needs: [package, build-binaries, build-and-push-docker]
+    needs: [package, build-binaries]
     runs-on: depot-ubuntu-latest,dagger=0.18.9
     concurrency:
       group: upload-to-miren-${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Removed `build-and-push-docker` from the `upload-to-miren` job dependencies
- This prevents Docker build failures from blocking artifact uploads to Miren API

## Details
The `upload-to-miren` job uploads:
- Package artifacts from the `package` job
- Binary artifacts from the `build-binaries` job  
- The docker-compose.yml file from the repository

It doesn't use any outputs from `build-and-push-docker`, which only pushes Docker images to Google Artifact Registry. The dependency was unnecessary and was causing upload blockages when Docker builds failed.

## Test plan
- [x] Verified that upload-to-miren doesn't reference any artifacts from build-and-push-docker
- [x] CI will validate the workflow syntax
- [x] Next push to main will test that uploads work without waiting for Docker builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined the release pipeline by simplifying job dependencies, allowing artifact uploads to proceed without waiting on container image builds.
  - Improves release execution speed and reduces bottlenecks in CI without altering application behavior.
  - No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->