### PR TITLE
Add cluster and org specific tags

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -383,6 +383,14 @@ func Server(ctx *Context, opts struct {
 			"org-id", reg.OrganizationID,
 			"cloud-url", reg.CloudURL)
 
+		if reg.Tags == nil {
+			reg.Tags = make(map[string]string)
+		}
+
+		reg.Tags["cluster_id"] = reg.ClusterID
+		reg.Tags["cluster_name"] = reg.ClusterName
+		reg.Tags["organization_id"] = reg.OrganizationID
+
 		// Configure cloud authentication from registration
 		cloudAuthConfig.Enabled = true
 		cloudAuthConfig.CloudURL = reg.CloudURL


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud authentication configurations now include cluster metadata as tags: cluster ID, cluster name, and organization ID. These tags are automatically attached during server registration and carried through to cloud auth, making this metadata available in dashboards, APIs, and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->