### PR TITLE
Fix ClientConfig Save() to exclude clientconfig.d entries

### DIFF
--- a/cli/commands/auth_generate.go
+++ b/cli/commands/auth_generate.go
@@ -61,17 +61,15 @@ func AuthGenerate(ctx *Context, opts struct {
 		return fmt.Errorf("target hostname is empty, use --target to specify a hostname")
 	}
 
-	lcfg := &clientconfig.Config{
-		ActiveCluster: opts.ClusterName,
-
-		Clusters: map[string]*clientconfig.ClusterConfig{
-			opts.ClusterName: {
-				Hostname:   tgt,
-				CACert:     string(cc.CACert),
-				ClientCert: string(cc.CertPEM),
-				ClientKey:  string(cc.KeyPEM),
-			},
-		},
+	lcfg := clientconfig.NewConfig()
+	lcfg.SetCluster(opts.ClusterName, &clientconfig.ClusterConfig{
+		Hostname:   tgt,
+		CACert:     string(cc.CACert),
+		ClientCert: string(cc.CertPEM),
+		ClientKey:  string(cc.KeyPEM),
+	})
+	if err := lcfg.SetActiveCluster(opts.ClusterName); err != nil {
+		return fmt.Errorf("failed to set active cluster: %w", err)
 	}
 
 	return lcfg.SaveTo(opts.ConfigPath)

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"miren.dev/runtime/clientconfig"
-	"miren.dev/runtime/pkg/mapx"
 )
 
 type ConfigCentric struct {
@@ -74,17 +73,16 @@ func ConfigInfo(ctx *Context, opts struct {
 		return err
 	}
 
-	for name, ccfg := range mapx.StableOrder(cfg.Clusters) {
+	return cfg.IterateClusters(func(name string, ccfg *clientconfig.ClusterConfig) error {
 		prefix := " "
 		if opts.Cluster != "" {
 			if name == opts.Cluster {
 				prefix = "*"
 			}
-		} else if name == cfg.ActiveCluster {
+		} else if name == cfg.ActiveCluster() {
 			prefix = "*"
 		}
 		ctx.Printf("%s %s at %s\n", prefix, name, ccfg.Hostname)
-	}
-
-	return nil
+		return nil
+	})
 }

--- a/cli/commands/config_set_active.go
+++ b/cli/commands/config_set_active.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"sort"
 )
 
 func ConfigSetActive(ctx *Context, opts struct {
@@ -21,20 +20,16 @@ func ConfigSetActive(ctx *Context, opts struct {
 	// If no cluster name provided, show interactive menu
 	if clusterName == "" {
 		// Get sorted list of cluster names
-		clusterNames := make([]string, 0, len(cfg.Clusters))
-		for name := range cfg.Clusters {
-			clusterNames = append(clusterNames, name)
-		}
-		sort.Strings(clusterNames)
+		clusterNames := cfg.GetClusterNames()
 
 		// Use the shared cluster selection
-		selected, err := SelectCluster(ctx, "Select a cluster to set as active:", clusterNames, cfg.ActiveCluster, false)
+		selected, err := SelectCluster(ctx, "Select a cluster to set as active:", clusterNames, cfg.ActiveCluster(), false)
 		if err != nil {
 			// If we can't run interactive mode (no TTY), show available clusters
 			ctx.Printf("Cannot run interactive mode. Available clusters:\n")
 			for _, name := range clusterNames {
 				prefix := "  "
-				if name == cfg.ActiveCluster {
+				if name == cfg.ActiveCluster() {
 					prefix = "* "
 				}
 				ctx.Printf("%s%s\n", prefix, name)
@@ -52,11 +47,8 @@ func ConfigSetActive(ctx *Context, opts struct {
 	}
 
 	// Check if the cluster exists
-	if _, exists := cfg.Clusters[clusterName]; !exists {
-		availableClusters := make([]string, 0, len(cfg.Clusters))
-		for name := range cfg.Clusters {
-			availableClusters = append(availableClusters, name)
-		}
+	if !cfg.HasCluster(clusterName) {
+		availableClusters := cfg.GetClusterNames()
 		return fmt.Errorf("cluster %q not found. Available clusters: %v", clusterName, availableClusters)
 	}
 

--- a/cli/commands/debug_connection.go
+++ b/cli/commands/debug_connection.go
@@ -48,8 +48,8 @@ func DebugConnection(ctx *Context, opts struct {
 		testServer = opts.Server
 	} else if opts.Cluster != "" && config != nil {
 		// Use cluster's hostname
-		cluster, exists := config.Clusters[opts.Cluster]
-		if !exists {
+		cluster, err := config.GetCluster(opts.Cluster)
+		if err != nil {
 			ctx.Warn("Cluster '%s' not found in config", opts.Cluster)
 			return fmt.Errorf("cluster not found")
 		}
@@ -97,8 +97,8 @@ func DebugConnection(ctx *Context, opts struct {
 	} else if opts.Cluster != "" {
 		// Use identity from cluster
 		if config != nil {
-			cluster, exists := config.Clusters[opts.Cluster]
-			if !exists {
+			cluster, err := config.GetCluster(opts.Cluster)
+			if err != nil {
 				ctx.Warn("Cluster '%s' not found in config", opts.Cluster)
 				return fmt.Errorf("cluster not found")
 			}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -685,10 +685,19 @@ func writeLocalClusterConfig(ctx *Context, cc *caauth.ClientCertificate, address
 		}
 	}
 
-	// Create the local cluster config
-	localConfigPath := filepath.Join(configDirPath, "50-local.yaml")
+	// Load or create the main client config
+	mainConfig, err := clientconfig.LoadConfig()
+	if err != nil {
+		// If no config exists, create a new one
+		if err == clientconfig.ErrNoConfig {
+			mainConfig = clientconfig.NewConfig()
+		} else {
+			return fmt.Errorf("failed to load client config: %w", err)
+		}
+	}
 
-	lcfg := &clientconfig.Config{
+	// Create the local cluster config data
+	leafConfigData := &clientconfig.ConfigData{
 		Clusters: map[string]*clientconfig.ClusterConfig{
 			clusterName: {
 				Hostname:   address,
@@ -699,11 +708,16 @@ func writeLocalClusterConfig(ctx *Context, cc *caauth.ClientCertificate, address
 		},
 	}
 
-	if err := lcfg.SaveTo(localConfigPath); err != nil {
+	// Add as a leaf config (this will be saved to clientconfig.d/50-local.yaml)
+	mainConfig.SetLeafConfig("50-local", leafConfigData)
+
+	// Save the main config (which will also save the leaf config)
+	if err := mainConfig.Save(); err != nil {
 		return fmt.Errorf("failed to save local cluster config: %w", err)
 	}
 
-	// Fix file ownership if running under sudo
+	// Fix file ownership for the created files if running under sudo
+	localConfigPath := filepath.Join(configDirPath, "50-local.yaml")
 	if err := fixOwnershipIfSudo(ctx, localConfigPath); err != nil {
 		ctx.Log.Warn("failed to fix config file ownership", "error", err)
 	}

--- a/clientconfig/clientconfig_dir_test.go
+++ b/clientconfig/clientconfig_dir_test.go
@@ -71,8 +71,8 @@ clusters:
 	require.NotNil(t, config)
 
 	// Verify the main config was loaded
-	assert.Equal(t, "main", config.ActiveCluster)
-	assert.Len(t, config.Clusters, 3)
+	assert.Equal(t, "main", config.ActiveCluster())
+	assert.Equal(t, 3, config.GetClusterCount())
 
 	// Verify main cluster
 	mainCluster, err := config.GetCluster("main")
@@ -128,8 +128,8 @@ clusters:
 
 	// Verify only config.d was loaded
 	// When main config has no active cluster, it gets set from config.d files
-	assert.Equal(t, "dev", config.ActiveCluster)
-	assert.Len(t, config.Clusters, 1)
+	assert.Equal(t, "dev", config.ActiveCluster())
+	assert.Equal(t, 1, config.GetClusterCount())
 
 	// Verify dev cluster
 	devCluster, err := config.GetCluster("dev")

--- a/clientconfig/clientconfig_loadflag_test.go
+++ b/clientconfig/clientconfig_loadflag_test.go
@@ -1,0 +1,134 @@
+package clientconfig
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProgrammaticConfigSavesEverything(t *testing.T) {
+	// Test that a programmatically created config saves all clusters and identities
+
+	// Create a config programmatically (not loaded from disk)
+	config := NewConfig()
+
+	// Add clusters first
+	config.SetCluster("test-cluster", &ClusterConfig{
+		Hostname: "test.example.com",
+		CACert:   "test-ca",
+	})
+	config.SetCluster("another-cluster", &ClusterConfig{
+		Hostname: "another.example.com",
+		CACert:   "another-ca",
+	})
+
+	// Now set active cluster
+	err := config.SetActiveCluster("test-cluster")
+	require.NoError(t, err)
+
+	// Add identities
+	config.SetIdentity("test-identity", &IdentityConfig{
+		Type:       "keypair",
+		Issuer:     "test-issuer",
+		PrivateKey: "test-key",
+	})
+
+	// Save the config
+	tmpDir := t.TempDir()
+	savedPath := filepath.Join(tmpDir, "saved.yaml")
+	err = config.SaveTo(savedPath)
+	require.NoError(t, err)
+
+	// Read back the saved config
+	savedData, err := os.ReadFile(savedPath)
+	require.NoError(t, err)
+
+	var savedConfig Config
+	err = yaml.Unmarshal(savedData, &savedConfig)
+	require.NoError(t, err)
+
+	// Verify everything was saved
+	assert.Equal(t, "test-cluster", savedConfig.ActiveCluster())
+	assert.Equal(t, 2, savedConfig.GetClusterCount(), "Should save all clusters from programmatic config")
+	_, err = savedConfig.GetCluster("test-cluster")
+	assert.NoError(t, err)
+	_, err = savedConfig.GetCluster("another-cluster")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, savedConfig.GetIdentityCount(), "Should save all identities from programmatic config")
+	_, err = savedConfig.GetIdentity("test-identity")
+	assert.NoError(t, err)
+}
+
+func TestSaveToStdoutError(t *testing.T) {
+	// Test that stdout write errors are properly returned
+
+	config := NewConfig()
+	config.SetCluster("test", &ClusterConfig{
+		Hostname: "test.example.com",
+	})
+
+	// Save original stdout
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+
+	// Create a pipe and close the write end to force an error
+	r, w, _ := os.Pipe()
+	w.Close()
+	os.Stdout = w
+
+	// Try to save to stdout (should fail)
+	err := config.SaveTo("-")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write config to stdout")
+
+	r.Close()
+}
+
+func TestSaveToBufferForStdout(t *testing.T) {
+	// Test successful stdout write using a buffer
+
+	config := NewConfig()
+	config.SetCluster("test", &ClusterConfig{
+		Hostname: "test.example.com",
+		CACert:   "test-ca",
+	})
+	err := config.SetActiveCluster("test")
+	require.NoError(t, err)
+
+	// Save original stdout
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+
+	// Create a buffer to capture output
+	var buf bytes.Buffer
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Start a goroutine to copy from pipe to buffer
+	done := make(chan bool)
+	go func() {
+		buf.ReadFrom(r)
+		done <- true
+	}()
+
+	// Save to stdout
+	err = config.SaveTo("-")
+	require.NoError(t, err)
+
+	// Close write end and wait for read to complete
+	w.Close()
+	<-done
+
+	// Verify the output
+	var savedConfig Config
+	err = yaml.Unmarshal(buf.Bytes(), &savedConfig)
+	require.NoError(t, err)
+	assert.Equal(t, "test", savedConfig.ActiveCluster())
+	_, err = savedConfig.GetCluster("test")
+	assert.NoError(t, err)
+}

--- a/clientconfig/clientconfig_modification_test.go
+++ b/clientconfig/clientconfig_modification_test.go
@@ -1,0 +1,262 @@
+package clientconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSavePreservesModificationsToMainConfigEntries(t *testing.T) {
+	// This test verifies that programmatic modifications to main config entries
+	// are preserved when saving, not reverted to original values
+
+	tmpDir := t.TempDir()
+
+	// Create main config file with a cluster
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
+	mainConfig := `
+active_cluster: prod
+clusters:
+  prod:
+    hostname: old-prod.example.com
+    ca_cert: old-ca
+    client_cert: old-cert
+    client_key: old-key
+    insecure: false
+identities:
+  prod-identity:
+    type: keypair
+    issuer: old-issuer
+    private_key: old-key
+`
+	err := os.WriteFile(mainConfigPath, []byte(mainConfig), 0644)
+	require.NoError(t, err)
+
+	// Create config.d directory with additional cluster
+	configDirPath := filepath.Join(tmpDir, "clientconfig.d")
+	err = os.MkdirAll(configDirPath, 0755)
+	require.NoError(t, err)
+
+	additionalConfig := `
+clusters:
+  dev:
+    hostname: dev.example.com
+    ca_cert: dev-ca
+`
+	err = os.WriteFile(filepath.Join(configDirPath, "dev.yaml"), []byte(additionalConfig), 0644)
+	require.NoError(t, err)
+
+	// Set environment variable
+	oldEnv := os.Getenv(EnvConfigPath)
+	os.Setenv(EnvConfigPath, mainConfigPath)
+	defer os.Setenv(EnvConfigPath, oldEnv)
+
+	// Load the config
+	config, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// MODIFY the main config cluster programmatically
+	prodCluster, err := config.GetCluster("prod")
+	require.NoError(t, err)
+	prodCluster.Hostname = "new-prod.example.com"
+	prodCluster.CACert = "new-ca"
+	prodCluster.Insecure = true
+	prodCluster.CloudAuth = true // Add new field
+
+	// MODIFY the main config identity
+	prodIdentity, err := config.GetIdentity("prod-identity")
+	require.NoError(t, err)
+	prodIdentity.Issuer = "new-issuer"
+	prodIdentity.PrivateKey = "new-key"
+
+	// Also modify the dev cluster (from config.d) - this should NOT be saved
+	devCluster, err := config.GetCluster("dev")
+	require.NoError(t, err)
+	devCluster.Hostname = "modified-dev.example.com"
+
+	// Save the config
+	savedConfigPath := filepath.Join(tmpDir, "saved-config.yaml")
+	err = config.SaveTo(savedConfigPath)
+	require.NoError(t, err)
+
+	// Read back the saved config
+	savedData, err := os.ReadFile(savedConfigPath)
+	require.NoError(t, err)
+
+	var savedConfig Config
+	err = yaml.Unmarshal(savedData, &savedConfig)
+	require.NoError(t, err)
+
+	// Verify the MODIFIED values were saved for main config entries
+	prodClusterSaved, err := savedConfig.GetCluster("prod")
+	require.NoError(t, err)
+	assert.Equal(t, "new-prod.example.com", prodClusterSaved.Hostname, "Should save modified hostname")
+	assert.Equal(t, "new-ca", prodClusterSaved.CACert, "Should save modified CA cert")
+	assert.Equal(t, "old-cert", prodClusterSaved.ClientCert, "Should preserve unmodified fields")
+	assert.Equal(t, "old-key", prodClusterSaved.ClientKey, "Should preserve unmodified fields")
+	assert.True(t, prodClusterSaved.Insecure, "Should save modified insecure value")
+	assert.True(t, prodClusterSaved.CloudAuth, "Should save newly added field")
+
+	// Verify identity modifications were saved
+	prodIdentitySaved, err := savedConfig.GetIdentity("prod-identity")
+	require.NoError(t, err)
+	assert.Equal(t, "new-issuer", prodIdentitySaved.Issuer, "Should save modified issuer")
+	assert.Equal(t, "new-key", prodIdentitySaved.PrivateKey, "Should save modified key")
+	assert.Equal(t, "keypair", prodIdentitySaved.Type, "Should preserve unmodified type")
+
+	// Verify dev cluster (from config.d) was NOT saved
+	_, err = savedConfig.GetCluster("dev")
+	assert.Error(t, err, "Should not save config.d entries")
+}
+
+func TestSaveWithNewlyAddedAndModifiedClusters(t *testing.T) {
+	// Test adding new clusters and modifying existing ones
+
+	tmpDir := t.TempDir()
+
+	// Create main config
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
+	mainConfig := `
+clusters:
+  existing:
+    hostname: existing.example.com
+    ca_cert: existing-ca
+`
+	err := os.WriteFile(mainConfigPath, []byte(mainConfig), 0644)
+	require.NoError(t, err)
+
+	// Set environment variable
+	oldEnv := os.Getenv(EnvConfigPath)
+	os.Setenv(EnvConfigPath, mainConfigPath)
+	defer os.Setenv(EnvConfigPath, oldEnv)
+
+	// Load the config
+	config, err := LoadConfig()
+	require.NoError(t, err)
+
+	// Modify the existing cluster
+	existingCluster, err := config.GetCluster("existing")
+	require.NoError(t, err)
+	existingCluster.Hostname = "modified-existing.example.com"
+	existingCluster.Insecure = true
+
+	// Add a completely new cluster programmatically
+	config.SetCluster("new-cluster", &ClusterConfig{
+		Hostname: "new.example.com",
+		CACert:   "new-ca",
+	})
+
+	// Save the config
+	savedConfigPath := filepath.Join(tmpDir, "saved-config.yaml")
+	err = config.SaveTo(savedConfigPath)
+	require.NoError(t, err)
+
+	// Read back the saved config
+	savedData, err := os.ReadFile(savedConfigPath)
+	require.NoError(t, err)
+
+	var savedConfig Config
+	err = yaml.Unmarshal(savedData, &savedConfig)
+	require.NoError(t, err)
+
+	// Verify both clusters were saved with correct values
+	assert.Equal(t, 2, savedConfig.GetClusterCount())
+
+	// Existing cluster should have modified values
+	existingClusterSaved, err := savedConfig.GetCluster("existing")
+	require.NoError(t, err)
+	assert.Equal(t, "modified-existing.example.com", existingClusterSaved.Hostname)
+	assert.Equal(t, "existing-ca", existingClusterSaved.CACert)
+	assert.True(t, existingClusterSaved.Insecure)
+
+	// New cluster should be saved
+	newClusterSaved, err := savedConfig.GetCluster("new-cluster")
+	require.NoError(t, err)
+	assert.Equal(t, "new.example.com", newClusterSaved.Hostname)
+	assert.Equal(t, "new-ca", newClusterSaved.CACert)
+}
+
+func TestConfigDOverridesDoNotAffectSavedMainConfig(t *testing.T) {
+	// Test that config.d overrides don't affect the saved main config values
+
+	tmpDir := t.TempDir()
+
+	// Create main config
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
+	mainConfig := `
+clusters:
+  shared:
+    hostname: main.example.com
+    ca_cert: main-ca
+    insecure: false
+`
+	err := os.WriteFile(mainConfigPath, []byte(mainConfig), 0644)
+	require.NoError(t, err)
+
+	// Create config.d that overrides the same cluster
+	configDirPath := filepath.Join(tmpDir, "clientconfig.d")
+	err = os.MkdirAll(configDirPath, 0755)
+	require.NoError(t, err)
+
+	overrideConfig := `
+clusters:
+  shared:
+    hostname: override.example.com
+    ca_cert: override-ca
+    insecure: true
+    cloud_auth: true
+`
+	err = os.WriteFile(filepath.Join(configDirPath, "override.yaml"), []byte(overrideConfig), 0644)
+	require.NoError(t, err)
+
+	// Set environment variable
+	oldEnv := os.Getenv(EnvConfigPath)
+	os.Setenv(EnvConfigPath, mainConfigPath)
+	defer os.Setenv(EnvConfigPath, oldEnv)
+
+	// Load the config
+	config, err := LoadConfig()
+	require.NoError(t, err)
+
+	// The in-memory config should have the override values
+	sharedCluster, err := config.GetCluster("shared")
+	require.NoError(t, err)
+	assert.Equal(t, "override.example.com", sharedCluster.Hostname)
+	assert.Equal(t, "override-ca", sharedCluster.CACert)
+	assert.True(t, sharedCluster.Insecure)
+	assert.True(t, sharedCluster.CloudAuth)
+
+	// Now modify one field programmatically
+	// With the new architecture, to save changes to a cluster from config.d,
+	// you must explicitly call SetCluster to promote it to main config
+	sharedCluster.Hostname = "user-modified.example.com"
+	config.SetCluster("shared", sharedCluster)
+
+	// Save the config
+	savedConfigPath := filepath.Join(tmpDir, "saved-config.yaml")
+	err = config.SaveTo(savedConfigPath)
+	require.NoError(t, err)
+
+	// Read back the saved config
+	savedData, err := os.ReadFile(savedConfigPath)
+	require.NoError(t, err)
+
+	var savedConfig Config
+	err = yaml.Unmarshal(savedData, &savedConfig)
+	require.NoError(t, err)
+
+	// The saved config should have:
+	// - The user's modification (hostname)
+	// - Other fields from the override (since they're in memory)
+	sharedClusterSaved, err := savedConfig.GetCluster("shared")
+	require.NoError(t, err)
+	assert.Equal(t, "user-modified.example.com", sharedClusterSaved.Hostname, "Should save user modification")
+	assert.Equal(t, "override-ca", sharedClusterSaved.CACert, "Should save current in-memory value")
+	assert.True(t, sharedClusterSaved.Insecure, "Should save current in-memory value")
+	assert.True(t, sharedClusterSaved.CloudAuth, "Should save current in-memory value")
+}

--- a/clientconfig/clientconfig_save_test.go
+++ b/clientconfig/clientconfig_save_test.go
@@ -1,0 +1,491 @@
+package clientconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSaveDoesNotIncludeConfigDirEntries(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+
+	// Create main config file with one cluster
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
+	mainConfig := `
+active_cluster: main
+clusters:
+  main:
+    hostname: main.example.com
+    ca_cert: main-ca
+    client_cert: main-cert
+    client_key: main-key
+identities:
+  main-identity:
+    type: keypair
+    issuer: main-issuer
+    private_key: main-key
+`
+	err := os.WriteFile(mainConfigPath, []byte(mainConfig), 0644)
+	require.NoError(t, err)
+
+	// Create config.d directory
+	configDirPath := filepath.Join(tmpDir, "clientconfig.d")
+	err = os.MkdirAll(configDirPath, 0755)
+	require.NoError(t, err)
+
+	// Create additional config files that should NOT be saved
+	additionalConfig1 := `
+clusters:
+  dev:
+    hostname: dev.example.com
+    ca_cert: dev-ca
+    client_cert: dev-cert
+    client_key: dev-key
+identities:
+  dev-identity:
+    type: certificate
+    issuer: dev-issuer
+    client_cert: dev-cert
+    client_key: dev-key
+`
+	err = os.WriteFile(filepath.Join(configDirPath, "01-dev.yaml"), []byte(additionalConfig1), 0644)
+	require.NoError(t, err)
+
+	additionalConfig2 := `
+clusters:
+  staging:
+    hostname: staging.example.com
+    ca_cert: staging-ca
+    insecure: true
+`
+	err = os.WriteFile(filepath.Join(configDirPath, "02-staging.yml"), []byte(additionalConfig2), 0644)
+	require.NoError(t, err)
+
+	// Set environment variable to use our test directory
+	oldEnv := os.Getenv(EnvConfigPath)
+	os.Setenv(EnvConfigPath, mainConfigPath)
+	defer os.Setenv(EnvConfigPath, oldEnv)
+
+	// Load the config (this will merge clientconfig.d entries)
+	config, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// Verify all clusters were loaded (main + dev + staging)
+	assert.Equal(t, 3, config.GetClusterCount())
+	assert.Equal(t, 2, config.GetIdentityCount())
+
+	// Modify the main cluster slightly (in-memory modification)
+	mainCluster, err := config.GetCluster("main")
+	require.NoError(t, err)
+	mainCluster.Hostname = "modified.example.com"
+
+	// Save the config to a new location
+	savedConfigPath := filepath.Join(tmpDir, "saved-config.yaml")
+	err = config.SaveTo(savedConfigPath)
+	require.NoError(t, err)
+
+	// Read back the saved config directly (not using LoadConfig to avoid merging)
+	savedData, err := os.ReadFile(savedConfigPath)
+	require.NoError(t, err)
+
+	var savedConfig Config
+	err = yaml.Unmarshal(savedData, &savedConfig)
+	require.NoError(t, err)
+
+	// Verify only the main cluster was saved, not the ones from config.d
+	assert.Equal(t, 1, savedConfig.GetClusterCount(), "Should only save clusters from main config")
+	_, err = savedConfig.GetCluster("main")
+	assert.NoError(t, err, "Should contain main cluster")
+	_, err = savedConfig.GetCluster("dev")
+	assert.Error(t, err, "Should not contain dev cluster from config.d")
+	_, err = savedConfig.GetCluster("staging")
+	assert.Error(t, err, "Should not contain staging cluster from config.d")
+
+	// Verify only the main identity was saved
+	assert.Equal(t, 1, savedConfig.GetIdentityCount(), "Should only save identities from main config")
+	_, err = savedConfig.GetIdentity("main-identity")
+	assert.NoError(t, err, "Should contain main identity")
+	_, err = savedConfig.GetIdentity("dev-identity")
+	assert.Error(t, err, "Should not contain dev identity from config.d")
+
+	// Verify the modified value was saved (current in-memory values are saved)
+	savedMainCluster, err := savedConfig.GetCluster("main")
+	require.NoError(t, err)
+	assert.Equal(t, "modified.example.com", savedMainCluster.Hostname, "Should save modified value")
+}
+
+func TestSavePreservesNewlyAddedClusters(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+
+	// Create main config file
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
+	mainConfig := `
+active_cluster: main
+clusters:
+  main:
+    hostname: main.example.com
+    ca_cert: main-ca
+`
+	err := os.WriteFile(mainConfigPath, []byte(mainConfig), 0644)
+	require.NoError(t, err)
+
+	// Create config.d directory with additional cluster
+	configDirPath := filepath.Join(tmpDir, "clientconfig.d")
+	err = os.MkdirAll(configDirPath, 0755)
+	require.NoError(t, err)
+
+	additionalConfig := `
+clusters:
+  from-config-d:
+    hostname: config-d.example.com
+    ca_cert: config-d-ca
+`
+	err = os.WriteFile(filepath.Join(configDirPath, "extra.yaml"), []byte(additionalConfig), 0644)
+	require.NoError(t, err)
+
+	// Set environment variable
+	oldEnv := os.Getenv(EnvConfigPath)
+	os.Setenv(EnvConfigPath, mainConfigPath)
+	defer os.Setenv(EnvConfigPath, oldEnv)
+
+	// Load the config
+	config, err := LoadConfig()
+	require.NoError(t, err)
+
+	// Programmatically add a new cluster (simulating user adding via CLI)
+	config.SetCluster("new-cluster", &ClusterConfig{
+		Hostname: "new.example.com",
+		CACert:   "new-ca",
+	})
+
+	// Add a new identity programmatically
+	config.SetIdentity("new-identity", &IdentityConfig{
+		Type:       "keypair",
+		Issuer:     "new-issuer",
+		PrivateKey: "new-key",
+	})
+
+	// Save the config
+	savedConfigPath := filepath.Join(tmpDir, "saved-config.yaml")
+	err = config.SaveTo(savedConfigPath)
+	require.NoError(t, err)
+
+	// Read back the saved config
+	savedData, err := os.ReadFile(savedConfigPath)
+	require.NoError(t, err)
+
+	var savedConfig Config
+	err = yaml.Unmarshal(savedData, &savedConfig)
+	require.NoError(t, err)
+
+	// Verify the correct clusters were saved
+	assert.Equal(t, 2, savedConfig.GetClusterCount(), "Should save main cluster and newly added cluster")
+	_, err = savedConfig.GetCluster("main")
+	assert.NoError(t, err, "Should contain original main cluster")
+	_, err = savedConfig.GetCluster("new-cluster")
+	assert.NoError(t, err, "Should contain newly added cluster")
+	_, err = savedConfig.GetCluster("from-config-d")
+	assert.Error(t, err, "Should not contain cluster from config.d")
+
+	// Verify the new identity was saved
+	_, err = savedConfig.GetIdentity("new-identity")
+	assert.NoError(t, err, "Should contain newly added identity")
+}
+
+func TestSaveEmptyMainConfigWithConfigD(t *testing.T) {
+	// Test case where main config doesn't exist but config.d has entries
+	tmpDir := t.TempDir()
+
+	// Don't create main config file
+
+	// Create config.d directory with clusters
+	configDirPath := filepath.Join(tmpDir, "clientconfig.d")
+	err := os.MkdirAll(configDirPath, 0755)
+	require.NoError(t, err)
+
+	additionalConfig := `
+clusters:
+  config-d-cluster:
+    hostname: config-d.example.com
+    ca_cert: config-d-ca
+`
+	err = os.WriteFile(filepath.Join(configDirPath, "cluster.yaml"), []byte(additionalConfig), 0644)
+	require.NoError(t, err)
+
+	// Set environment variable
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
+	oldEnv := os.Getenv(EnvConfigPath)
+	os.Setenv(EnvConfigPath, mainConfigPath)
+	defer os.Setenv(EnvConfigPath, oldEnv)
+
+	// Load the config (should load from config.d only)
+	config, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, 1, config.GetClusterCount())
+
+	// Save should create an empty main config (not include config.d entries)
+	err = config.Save()
+	require.NoError(t, err)
+
+	// Read back the saved config
+	savedData, err := os.ReadFile(mainConfigPath)
+	require.NoError(t, err)
+
+	var savedConfig Config
+	err = yaml.Unmarshal(savedData, &savedConfig)
+	require.NoError(t, err)
+
+	// Should be empty since nothing was in the main config
+	assert.Equal(t, 0, savedConfig.GetClusterCount(), "Should not save clusters from config.d")
+}
+
+func TestSetLeafConfigAndSaving(t *testing.T) {
+	// Test that SetLeafConfig creates leaf configs that can be accessed immediately
+	// and are saved to clientconfig.d/ when the main config is saved
+
+	tmpDir := t.TempDir()
+
+	// Create a config programmatically
+	config := NewConfig()
+
+	// Add a main config cluster
+	config.SetCluster("main-cluster", &ClusterConfig{
+		Hostname: "main.example.com",
+		CACert:   "main-ca",
+	})
+	err := config.SetActiveCluster("main-cluster")
+	require.NoError(t, err)
+
+	// Add a leaf config using SetLeafConfig
+	leafConfigData := &ConfigData{
+		Clusters: map[string]*ClusterConfig{
+			"dev-cluster": {
+				Hostname: "dev.example.com",
+				CACert:   "dev-ca",
+			},
+		},
+		Identities: map[string]*IdentityConfig{
+			"dev-identity": {
+				Type:   "keypair",
+				Issuer: "dev-issuer",
+			},
+		},
+	}
+	config.SetLeafConfig("dev", leafConfigData)
+
+	// Verify the leaf config is immediately available
+	devCluster, err := config.GetCluster("dev-cluster")
+	require.NoError(t, err)
+	assert.Equal(t, "dev.example.com", devCluster.Hostname)
+
+	devIdentity, err := config.GetIdentity("dev-identity")
+	require.NoError(t, err)
+	assert.Equal(t, "keypair", devIdentity.Type)
+
+	// Verify counts include both main and leaf configs
+	assert.Equal(t, 2, config.GetClusterCount())  // main-cluster + dev-cluster
+	assert.Equal(t, 1, config.GetIdentityCount()) // dev-identity
+
+	// Save the config
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
+	err = config.SaveTo(mainConfigPath)
+	require.NoError(t, err)
+
+	// Verify main config file was created
+	assert.FileExists(t, mainConfigPath)
+
+	// Verify leaf config file was created
+	leafConfigPath := filepath.Join(tmpDir, "clientconfig.d", "dev.yaml")
+	assert.FileExists(t, leafConfigPath)
+
+	// Read and verify main config content
+	mainData, err := os.ReadFile(mainConfigPath)
+	require.NoError(t, err)
+
+	var mainConfig Config
+	err = yaml.Unmarshal(mainData, &mainConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, "main-cluster", mainConfig.ActiveCluster())
+	assert.Equal(t, 1, mainConfig.GetClusterCount()) // Only main-cluster
+	_, err = mainConfig.GetCluster("main-cluster")
+	assert.NoError(t, err)
+	_, err = mainConfig.GetCluster("dev-cluster")
+	assert.Error(t, err) // dev-cluster should not be in main config
+
+	// Read and verify leaf config content
+	leafData, err := os.ReadFile(leafConfigPath)
+	require.NoError(t, err)
+
+	var leafConfigFromFile ConfigData
+	err = yaml.Unmarshal(leafData, &leafConfigFromFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(leafConfigFromFile.Clusters))
+	devClusterFromFile, exists := leafConfigFromFile.Clusters["dev-cluster"]
+	require.True(t, exists)
+	assert.Equal(t, "dev.example.com", devClusterFromFile.Hostname)
+
+	assert.Equal(t, 1, len(leafConfigFromFile.Identities))
+	devIdentityFromFile, exists := leafConfigFromFile.Identities["dev-identity"]
+	require.True(t, exists)
+	assert.Equal(t, "keypair", devIdentityFromFile.Type)
+}
+
+func TestSetLeafConfigUpdatesExisting(t *testing.T) {
+	// Test that calling SetLeafConfig with the same name updates the existing leaf config
+
+	tmpDir := t.TempDir()
+	config := NewConfig()
+
+	// Add initial leaf config
+	leafConfigData1 := &ConfigData{
+		Clusters: map[string]*ClusterConfig{
+			"test-cluster": {
+				Hostname: "test1.example.com",
+				CACert:   "test1-ca",
+			},
+		},
+	}
+	config.SetLeafConfig("test", leafConfigData1)
+
+	// Verify initial config
+	cluster, err := config.GetCluster("test-cluster")
+	require.NoError(t, err)
+	assert.Equal(t, "test1.example.com", cluster.Hostname)
+
+	// Update with new leaf config data
+	leafConfigData2 := &ConfigData{
+		Clusters: map[string]*ClusterConfig{
+			"test-cluster": {
+				Hostname: "test2.example.com",
+				CACert:   "test2-ca",
+			},
+		},
+	}
+	config.SetLeafConfig("test", leafConfigData2)
+
+	// Verify updated config
+	cluster, err = config.GetCluster("test-cluster")
+	require.NoError(t, err)
+	assert.Equal(t, "test2.example.com", cluster.Hostname)
+
+	// Save and verify only one leaf config file exists
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
+	err = config.SaveTo(mainConfigPath)
+	require.NoError(t, err)
+
+	leafConfigPath := filepath.Join(tmpDir, "clientconfig.d", "test.yaml")
+	assert.FileExists(t, leafConfigPath)
+
+	// Verify the saved file has the updated content
+	leafData, err := os.ReadFile(leafConfigPath)
+	require.NoError(t, err)
+
+	var leafConfigFromFile ConfigData
+	err = yaml.Unmarshal(leafData, &leafConfigFromFile)
+	require.NoError(t, err)
+
+	testClusterFromFile, exists := leafConfigFromFile.Clusters["test-cluster"]
+	require.True(t, exists)
+	assert.Equal(t, "test2.example.com", testClusterFromFile.Hostname)
+}
+
+func TestSetLeafConfigSetsActiveClusterWhenMainIsEmpty(t *testing.T) {
+	// Test that when main config has no clusters and no active cluster,
+	// adding a leaf config with clusters sets the first cluster as active
+
+	config := NewConfig()
+
+	// Verify config starts empty with no active cluster
+	assert.Equal(t, "", config.ActiveCluster())
+	assert.Equal(t, 0, config.GetClusterCount())
+
+	// Add a leaf config with multiple clusters
+	leafConfigData := &ConfigData{
+		Clusters: map[string]*ClusterConfig{
+			"prod": {
+				Hostname: "prod.example.com",
+				CACert:   "prod-ca",
+			},
+			"dev": {
+				Hostname: "dev.example.com",
+				CACert:   "dev-ca",
+			},
+		},
+	}
+	config.SetLeafConfig("environments", leafConfigData)
+
+	// Verify that one of the clusters was set as active
+	activeCluster := config.ActiveCluster()
+	assert.NotEmpty(t, activeCluster, "Active cluster should be set automatically")
+	assert.True(t, activeCluster == "prod" || activeCluster == "dev", "Active cluster should be one of the leaf config clusters")
+
+	// Verify the cluster is accessible
+	cluster, err := config.GetCluster(activeCluster)
+	require.NoError(t, err)
+	assert.NotNil(t, cluster)
+
+	// Verify both clusters are still available
+	assert.Equal(t, 2, config.GetClusterCount())
+}
+
+func TestSetLeafConfigDoesNotOverrideExistingActiveCluster(t *testing.T) {
+	// Test that adding leaf config doesn't override existing active cluster
+
+	config := NewConfig()
+
+	// Add a main cluster and set it as active
+	config.SetCluster("main-cluster", &ClusterConfig{
+		Hostname: "main.example.com",
+		CACert:   "main-ca",
+	})
+	err := config.SetActiveCluster("main-cluster")
+	require.NoError(t, err)
+
+	// Add a leaf config with clusters
+	leafConfigData := &ConfigData{
+		Clusters: map[string]*ClusterConfig{
+			"leaf-cluster": {
+				Hostname: "leaf.example.com",
+				CACert:   "leaf-ca",
+			},
+		},
+	}
+	config.SetLeafConfig("leaf", leafConfigData)
+
+	// Verify active cluster remains unchanged
+	assert.Equal(t, "main-cluster", config.ActiveCluster())
+}
+
+func TestSetLeafConfigDoesNotSetActiveWhenNoMainClustersButHasActiveCluster(t *testing.T) {
+	// Test that if main config has no clusters but already has an active cluster set,
+	// we don't override it
+
+	config := NewConfig()
+
+	// Set an active cluster even though no clusters exist yet
+	// (This could happen in some edge cases)
+	config.active = "existing-active"
+
+	// Add a leaf config with clusters
+	leafConfigData := &ConfigData{
+		Clusters: map[string]*ClusterConfig{
+			"leaf-cluster": {
+				Hostname: "leaf.example.com",
+				CACert:   "leaf-ca",
+			},
+		},
+	}
+	config.SetLeafConfig("leaf", leafConfigData)
+
+	// Verify active cluster remains unchanged
+	assert.Equal(t, "existing-active", config.ActiveCluster())
+}

--- a/clientconfig/clientconfig_test.go
+++ b/clientconfig/clientconfig_test.go
@@ -22,18 +22,15 @@ func TestConfigLoadSave(t *testing.T) {
 	defer os.Unsetenv(EnvConfigPath)
 
 	// Create test configuration
-	originalConfig := &Config{
-		Clusters: map[string]*ClusterConfig{
-			"prod": {
-				Hostname: "prod.example.com",
-				CACert:   "-----BEGIN CERTIFICATE-----\nMIIE...\n-----END CERTIFICATE-----",
-			},
-			"staging": {
-				Hostname: "staging.example.com",
-				CACert:   "-----BEGIN CERTIFICATE-----\nMIIE...\n-----END CERTIFICATE-----",
-			},
-		},
-	}
+	originalConfig := NewConfig()
+	originalConfig.SetCluster("prod", &ClusterConfig{
+		Hostname: "prod.example.com",
+		CACert:   "-----BEGIN CERTIFICATE-----\nMIIE...\n-----END CERTIFICATE-----",
+	})
+	originalConfig.SetCluster("staging", &ClusterConfig{
+		Hostname: "staging.example.com",
+		CACert:   "-----BEGIN CERTIFICATE-----\nMIIE...\n-----END CERTIFICATE-----",
+	})
 
 	// Save configuration
 	err = originalConfig.Save()
@@ -44,23 +41,29 @@ func TestConfigLoadSave(t *testing.T) {
 	r.NoError(err)
 
 	// Verify loaded configuration matches original
-	r.Equal(originalConfig.Clusters["prod"].Hostname, loadedConfig.Clusters["prod"].Hostname)
-	r.Equal(originalConfig.Clusters["prod"].CACert, loadedConfig.Clusters["prod"].CACert)
-	r.Equal(originalConfig.Clusters["staging"].Hostname, loadedConfig.Clusters["staging"].Hostname)
-	r.Equal(originalConfig.Clusters["staging"].CACert, loadedConfig.Clusters["staging"].CACert)
+	origProd, err := originalConfig.GetCluster("prod")
+	r.NoError(err)
+	loadedProd, err := loadedConfig.GetCluster("prod")
+	r.NoError(err)
+	r.Equal(origProd.Hostname, loadedProd.Hostname)
+	r.Equal(origProd.CACert, loadedProd.CACert)
+
+	origStaging, err := originalConfig.GetCluster("staging")
+	r.NoError(err)
+	loadedStaging, err := loadedConfig.GetCluster("staging")
+	r.NoError(err)
+	r.Equal(origStaging.Hostname, loadedStaging.Hostname)
+	r.Equal(origStaging.CACert, loadedStaging.CACert)
 }
 
 func TestGetCluster(t *testing.T) {
 	r := require.New(t)
 
-	config := &Config{
-		Clusters: map[string]*ClusterConfig{
-			"prod": {
-				Hostname: "prod.example.com",
-				CACert:   "-----BEGIN CERTIFICATE-----\nMIIE...\n-----END CERTIFICATE-----",
-			},
-		},
-	}
+	config := NewConfig()
+	config.SetCluster("prod", &ClusterConfig{
+		Hostname: "prod.example.com",
+		CACert:   "-----BEGIN CERTIFICATE-----\nMIIE...\n-----END CERTIFICATE-----",
+	})
 
 	// Test getting existing cluster
 	cluster, err := config.GetCluster("prod")

--- a/clientconfig/local_test.go
+++ b/clientconfig/local_test.go
@@ -133,21 +133,19 @@ func TestRPCOptionsWithAddressProbing(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("HOME", tempDir)
 
-	config := &Config{
-		Clusters: map[string]*ClusterConfig{
-			"test": {
-				Hostname: "primary.example.com:8443",
-				AllAddresses: []string{
-					"primary.example.com:8443",
-					"secondary.example.com:8443",
-					"tertiary.example.com:8443",
-				},
-				Insecure: true,
-			},
+	config := NewConfig()
+	config.SetCluster("test", &ClusterConfig{
+		Hostname: "primary.example.com:8443",
+		AllAddresses: []string{
+			"primary.example.com:8443",
+			"secondary.example.com:8443",
+			"tertiary.example.com:8443",
 		},
-	}
+		Insecure: true,
+	})
 
-	cluster := config.Clusters["test"]
+	cluster, err := config.GetCluster("test")
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	t.Run("uses cached address if available", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixed a bug where `Save()` was incorrectly writing out data merged from `clientconfig.d` files
- `clientconfig.d` entries should remain in their separate files and not be saved to the main config

## Changes
- Added tracking fields to the `Config` struct to distinguish main config entries from merged ones
- Modified loading logic to mark clusters/identities from the main config file
- Updated `SaveTo()` to only write clusters/identities from the main config file
- Added comprehensive test coverage for various scenarios

## Test Plan
- [x] Added new test `TestSaveDoesNotIncludeConfigDirEntries` to verify merged entries are excluded
- [x] Added test `TestSavePreservesNewlyAddedClusters` for programmatically added clusters
- [x] Added test `TestSaveEmptyMainConfigWithConfigD` for edge cases
- [x] All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-file "leaf" configs supported under clientconfig.d; new leaves can be staged and persisted separately; saving writes main config and new leaves independently.
  - Unified config API: accessors for clusters and identities that honor main + leaf overrides and provide counts, names, iteration, and safer setters/getters.

- CLI Changes
  - Config-related commands now use the unified API and respect leaf overrides; safer add/remove/set-active flows and clearer leaf storage messages.

- Bug Fixes
  - Improved save/load semantics, stdout save error handling, and hostname/active-cluster validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->