### PR TITLE
feat: rework env var handling with new env CLI command (MIR-359)

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -60,9 +60,30 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("apps", "List all applications", Apps), nil
 		},
 
-		"set": func() (cli.Command, error) {
-			return Infer("set", "Set environment variables for an application", Set), nil
+		"env": func() (cli.Command, error) {
+			return Section("env", "Environment variable management commands"), nil
 		},
+
+		"env set": func() (cli.Command, error) {
+			return Infer("env set", "Set environment variables for an application", EnvSet), nil
+		},
+
+		"env get": func() (cli.Command, error) {
+			return Infer("env get", "Get an environment variable value", EnvGet), nil
+		},
+
+		"env list": func() (cli.Command, error) {
+			return Infer("env list", "List all environment variables", EnvList), nil
+		},
+
+		"env delete": func() (cli.Command, error) {
+			return Infer("env delete", "Delete environment variables", EnvDelete), nil
+		},
+
+		"set": func() (cli.Command, error) {
+			return Infer("set", "Set concurrency for an application", Set), nil
+		},
+
 		"default-route set": func() (cli.Command, error) {
 			return Infer("default-route set", "Set an app as the default route", DefaultRouteSet), nil
 		},

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -1,0 +1,397 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/pkg/ui"
+)
+
+func EnvSet(ctx *Context, opts struct {
+	AppCentric
+	Env       []string `short:"e" long:"env" description:"Set environment variables (use KEY to prompt, KEY=VALUE to set directly, KEY=@file to read from file)"`
+	Sensitive []string `short:"s" long:"sensitive" description:"Set sensitive environment variables (use KEY to prompt with masking, KEY=VALUE to set directly, KEY=@file to read from file)"`
+}) error {
+	cl, err := ctx.RPCClient("dev.miren.runtime/app")
+	if err != nil {
+		return err
+	}
+
+	ac := app_v1alpha.NewCrudClient(cl)
+
+	res, err := ac.GetConfiguration(ctx, opts.App)
+	if err != nil {
+		return err
+	}
+
+	cfg := res.Configuration()
+
+	var changes bool
+
+	// Create a map to track existing env vars for efficient lookup
+	envMap := make(map[string]*app_v1alpha.NamedValue)
+	var envvars []*app_v1alpha.NamedValue
+
+	if cfg.HasEnvVars() {
+		// Build map from existing env vars
+		for _, ev := range cfg.EnvVars() {
+			envMap[ev.Key()] = ev
+			envvars = append(envvars, ev)
+		}
+	}
+
+	// Process all environment variables
+	// Note: go-flags doesn't preserve the exact order of mixed flags,
+	// so we process regular env vars first, then sensitive ones.
+	// Within each group, the order is preserved.
+	type envVar struct {
+		spec      string
+		sensitive bool
+	}
+
+	var allVars []envVar
+
+	// Process regular env vars first
+	for _, v := range opts.Env {
+		allVars = append(allVars, envVar{spec: v, sensitive: false})
+	}
+	// Then process sensitive env vars
+	for _, v := range opts.Sensitive {
+		allVars = append(allVars, envVar{spec: v, sensitive: true})
+	}
+
+	// Process all variables
+	for _, ev := range allVars {
+		var key, value string
+		var wasFile, wasPrompt bool
+
+		// Check if it's just a key (for prompting) or key=value
+		parts := strings.SplitN(ev.spec, "=", 2)
+		key = parts[0]
+
+		// Validate that the key is not empty
+		if key == "" {
+			return fmt.Errorf("invalid environment variable: key cannot be empty")
+		}
+
+		if len(parts) == 1 {
+			// No value provided, prompt for it
+			var label string
+			if ev.sensitive {
+				label = fmt.Sprintf("Enter value for sensitive variable '%s'", key)
+			} else {
+				label = fmt.Sprintf("Enter value for variable '%s'", key)
+			}
+
+			promptedValue, err := ui.PromptForInput(
+				ui.WithLabel(label),
+				ui.WithSensitive(ev.sensitive),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to read value for %s: %w", key, err)
+			}
+			value = promptedValue
+			wasPrompt = true
+		} else {
+			// Value was provided
+			value = parts[1]
+
+			if strings.HasPrefix(value, "@") {
+				filename := value[1:]
+				data, err := os.ReadFile(filename)
+				if err != nil {
+					if os.IsNotExist(err) {
+						return fmt.Errorf("env var references file %s which does not exist", filename)
+					}
+					return fmt.Errorf("failed to read env var from file %s: %w", filename, err)
+				}
+				wasFile = true
+				value = string(data)
+			}
+		}
+
+		// Check if this key already exists
+		existingVar, exists := envMap[key]
+		isUpdate := exists
+
+		// Only mark as changed if value or sensitivity actually changed
+		if !exists || existingVar.Value() != value || existingVar.Sensitive() != ev.sensitive {
+			changes = true
+
+			// Log the action
+			action := "setting"
+			if isUpdate {
+				action = "updating"
+			}
+
+			if wasFile {
+				ctx.Printf("%s %s from file %s...\n", action, key, parts[1][1:])
+			} else if wasPrompt {
+				if ev.sensitive {
+					ctx.Printf("%s %s (sensitive, from prompt)...\n", action, key)
+				} else {
+					ctx.Printf("%s %s (from prompt)...\n", action, key)
+				}
+			} else {
+				if ev.sensitive {
+					ctx.Printf("%s %s (sensitive)...\n", action, key)
+				} else {
+					ctx.Printf("%s %s...\n", action, key)
+				}
+			}
+
+			// Create or update the variable
+			var nv app_v1alpha.NamedValue
+			nv.SetKey(key)
+			nv.SetValue(value)
+			nv.SetSensitive(ev.sensitive)
+
+			if exists {
+				// Update existing entry in place
+				for i, v := range envvars {
+					if v.Key() == key {
+						envvars[i] = &nv
+						break
+					}
+				}
+			} else {
+				// Add new entry
+				envvars = append(envvars, &nv)
+			}
+
+			// Update the map for future lookups
+			envMap[key] = &nv
+		}
+	}
+
+	if !changes {
+		ctx.Printf("no changes to configuration\n")
+		return nil
+	}
+
+	cfg.SetEnvVars(envvars)
+
+	setres, err := ac.SetConfiguration(ctx, opts.App, cfg)
+	if err != nil {
+		return err
+	}
+
+	ctx.Printf("new version id: %s\n", setres.VersionId())
+
+	return nil
+}
+
+func EnvGet(ctx *Context, opts struct {
+	AppCentric
+	Unmask bool `short:"u" long:"unmask" description:"Show actual value of sensitive variables instead of masking them"`
+	Args   struct {
+		Key string `positional-arg-name:"KEY" description:"Environment variable key to get" required:"1"`
+	} `positional-args:"yes" required:"true"`
+}) error {
+	cl, err := ctx.RPCClient("dev.miren.runtime/app")
+	if err != nil {
+		return err
+	}
+
+	ac := app_v1alpha.NewCrudClient(cl)
+
+	res, err := ac.GetConfiguration(ctx, opts.App)
+	if err != nil {
+		return err
+	}
+
+	cfg := res.Configuration()
+
+	if !cfg.HasEnvVars() {
+		return fmt.Errorf("environment variable %s not found", opts.Args.Key)
+	}
+
+	// Find the variable with the specified key
+	envvars := cfg.EnvVars()
+	for _, nv := range envvars {
+		if nv.Key() == opts.Args.Key {
+			if nv.Sensitive() {
+				if opts.Unmask {
+					ctx.Printf("%s\n", nv.Value())
+				} else {
+					ctx.Printf("••••••••••\n")
+				}
+			} else {
+				ctx.Printf("%s\n", nv.Value())
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("environment variable %s not found", opts.Args.Key)
+}
+
+func EnvList(ctx *Context, opts struct {
+	AppCentric
+}) error {
+	cl, err := ctx.RPCClient("dev.miren.runtime/app")
+	if err != nil {
+		return err
+	}
+
+	ac := app_v1alpha.NewCrudClient(cl)
+
+	res, err := ac.GetConfiguration(ctx, opts.App)
+	if err != nil {
+		return err
+	}
+
+	cfg := res.Configuration()
+
+	if !cfg.HasEnvVars() {
+		ctx.Printf("No environment variables set\n")
+		return nil
+	}
+
+	// Get all environment variables
+	envvars := cfg.EnvVars()
+
+	// Sort by key for consistent output
+	sort.Slice(envvars, func(i, j int) bool {
+		return envvars[i].Key() < envvars[j].Key()
+	})
+
+	// Create and print the table
+	printEnvTable(ctx, envvars)
+
+	return nil
+}
+
+func EnvDelete(ctx *Context, opts struct {
+	AppCentric
+	Force bool `short:"f" long:"force" description:"Skip confirmation prompt"`
+	Args  struct {
+		Keys []string `positional-arg-name:"KEY" description:"Environment variable key to delete" required:"1"`
+	} `positional-args:"yes"`
+}) error {
+	cl, err := ctx.RPCClient("dev.miren.runtime/app")
+	if err != nil {
+		return err
+	}
+
+	ac := app_v1alpha.NewCrudClient(cl)
+
+	res, err := ac.GetConfiguration(ctx, opts.App)
+	if err != nil {
+		return err
+	}
+
+	cfg := res.Configuration()
+
+	if !cfg.HasEnvVars() {
+		ctx.Printf("No environment variables to delete\n")
+		return nil
+	}
+
+	envvars := cfg.EnvVars()
+
+	// First, verify ALL variables exist before we delete anything
+	var toDelete []string
+
+	for _, key := range opts.Args.Keys {
+		found := false
+		// Check if the key exists
+		for _, nv := range envvars {
+			if nv.Key() == key {
+				found = true
+				toDelete = append(toDelete, key)
+				break
+			}
+		}
+		if !found {
+			// Bail immediately if any variable is not found
+			return fmt.Errorf("environment variable '%s' not found", key)
+		}
+	}
+
+	// Ask for confirmation unless --force is used
+	if !opts.Force {
+		var message string
+		if len(toDelete) == 1 {
+			message = fmt.Sprintf("Delete environment variable '%s'?", toDelete[0])
+		} else {
+			message = fmt.Sprintf("Delete %d environment variables: %s?",
+				len(toDelete), strings.Join(toDelete, ", "))
+		}
+
+		confirmed, err := ui.Confirm(
+			ui.WithMessage(message),
+			ui.WithDefault(false),
+		)
+		if err != nil {
+			return fmt.Errorf("confirmation cancelled: %w", err)
+		}
+		if !confirmed {
+			ctx.Printf("deletion cancelled\n")
+			return nil
+		}
+	}
+
+	// Now perform the actual deletion
+	for _, key := range toDelete {
+		envvars = slices.DeleteFunc(envvars, func(nv *app_v1alpha.NamedValue) bool {
+			if nv.Key() == key {
+				ctx.Printf("deleting %s...\n", key)
+				return true
+			}
+			return false
+		})
+	}
+
+	cfg.SetEnvVars(envvars)
+
+	setres, err := ac.SetConfiguration(ctx, opts.App, cfg)
+	if err != nil {
+		return err
+	}
+
+	ctx.Printf("new version id: %s\n", setres.VersionId())
+
+	return nil
+}
+
+// printEnvTable prints a formatted table of environment variables
+func printEnvTable(ctx *Context, envvars []*app_v1alpha.NamedValue) {
+	// Create a gray style for sensitive values
+	grayStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+
+	// Build rows
+	var rows []ui.Row
+	for _, nv := range envvars {
+		var value string
+
+		if nv.Sensitive() {
+			value = grayStyle.Render("••••••••••")
+		} else {
+			value = nv.Value()
+		}
+
+		rows = append(rows, ui.Row{nv.Key(), value})
+	}
+
+	// Auto-size columns with reasonable maximums
+	columns := ui.AutoSizeColumns(
+		[]string{"NAME", "VALUE"},
+		rows,
+		40, // max width for NAME column
+		60, // max width for VALUE column
+	)
+
+	// Create and render the table
+	table := ui.NewTable(
+		ui.WithColumns(columns),
+		ui.WithRows(rows),
+	)
+
+	ctx.Printf("%s\n", table.Render())
+}

--- a/cli/commands/set.go
+++ b/cli/commands/set.go
@@ -1,23 +1,12 @@
 package commands
 
 import (
-	"fmt"
-	"os"
-	"slices"
-	"strings"
-
-	"github.com/charmbracelet/bubbles/textinput"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/api/app/app_v1alpha"
 )
 
 func Set(ctx *Context, opts struct {
 	AppCentric
-	Env         []string `short:"e" long:"env" description:"Set environment variables (use KEY to prompt, KEY=VALUE to set directly, KEY=@file to read from file)"`
-	Sensitive   []string `short:"s" long:"sensitive" description:"Set sensitive environment variables (use KEY to prompt with masking, KEY=VALUE to set directly, KEY=@file to read from file)"`
-	Delete      []string `short:"D" long:"delete" description:"Delete environment variables"`
-	Concurrency *int     `short:"c" long:"concurrency" description:"Set maximum concurrency of application instances"`
+	Concurrency int `short:"c" long:"concurrency" description:"Set maximum concurrency of application instances" required:"true"`
 }) error {
 	cl, err := ctx.RPCClient("dev.miren.runtime/app")
 	if err != nil {
@@ -33,129 +22,13 @@ func Set(ctx *Context, opts struct {
 
 	cfg := res.Configuration()
 
-	var changes bool
-
-	var envvars []*app_v1alpha.NamedValue
-
-	if cfg.HasEnvVars() {
-		envvars = cfg.EnvVars()
-	}
-
-	// Process all environment variables
-	// Note: go-flags doesn't preserve the exact order of mixed flags,
-	// so we process regular env vars first, then sensitive ones.
-	// Within each group, the order is preserved.
-	type envVar struct {
-		spec      string
-		sensitive bool
-	}
-
-	var allVars []envVar
-
-	// Process regular env vars first
-	for _, v := range opts.Env {
-		allVars = append(allVars, envVar{spec: v, sensitive: false})
-	}
-	// Then process sensitive env vars
-	for _, v := range opts.Sensitive {
-		allVars = append(allVars, envVar{spec: v, sensitive: true})
-	}
-
-	// Process all variables
-	for _, ev := range allVars {
-		var key, value string
-		var wasFile, wasPrompt bool
-
-		// Check if it's just a key (for prompting) or key=value
-		parts := strings.SplitN(ev.spec, "=", 2)
-		key = parts[0]
-
-		if len(parts) == 1 {
-			// No value provided, prompt for it
-			if ev.sensitive {
-				promptedValue, err := promptForSensitiveValue(ctx, key)
-				if err != nil {
-					return fmt.Errorf("failed to read sensitive value for %s: %w", key, err)
-				}
-				value = promptedValue
-			} else {
-				promptedValue, err := promptForValue(ctx, key)
-				if err != nil {
-					return fmt.Errorf("failed to read value for %s: %w", key, err)
-				}
-				value = promptedValue
-			}
-			wasPrompt = true
-		} else {
-			// Value was provided
-			value = parts[1]
-
-			if strings.HasPrefix(value, "@") {
-				if _, err := os.Stat(value[1:]); err == nil {
-					data, err := os.ReadFile(value[1:])
-					if err != nil {
-						return fmt.Errorf("failed to read env var from file %s: %w", parts[1][1:], err)
-					}
-
-					wasFile = true
-					value = string(data)
-				} else if ev.sensitive {
-					ctx.Log.Warn("sensitive env var starts with @ but file does not exist", "file", value[1:])
-				}
-			}
-		}
-
-		// Simply append the new variable - server will handle deduplication with last-value-wins
-		changes = true
-
-		if wasFile {
-			ctx.Printf("setting %s from file %s...\n", key, parts[1][1:])
-		} else if wasPrompt {
-			if ev.sensitive {
-				ctx.Printf("setting %s (sensitive, from prompt)...\n", key)
-			} else {
-				ctx.Printf("setting %s (from prompt)...\n", key)
-			}
-		} else {
-			if ev.sensitive {
-				ctx.Printf("setting %s (sensitive)...\n", key)
-			} else {
-				ctx.Printf("setting %s...\n", key)
-			}
-		}
-
-		var nv app_v1alpha.NamedValue
-		nv.SetKey(key)
-		nv.SetValue(value)
-		nv.SetSensitive(ev.sensitive)
-
-		envvars = append(envvars, &nv)
-	}
-
-	for _, v := range opts.Delete {
-		envvars = slices.DeleteFunc(envvars, func(nv *app_v1alpha.NamedValue) bool {
-			if nv.Key() == v {
-				changes = true
-				ctx.Printf("deleting %s...\n", v)
-				return true
-			}
-
-			return false
-		})
-	}
-
-	if opts.Concurrency != nil && cfg.Concurrency() != int32(*opts.Concurrency) {
-		changes = true
-		ctx.Printf("setting concurrency to %d...\n", *opts.Concurrency)
-		cfg.SetConcurrency(int32(*opts.Concurrency))
-	}
-
-	if !changes {
-		ctx.Printf("no changes to configuration\n")
+	if cfg.Concurrency() == int32(opts.Concurrency) {
+		ctx.Printf("concurrency is already set to %d\n", opts.Concurrency)
 		return nil
 	}
 
-	cfg.SetEnvVars(envvars)
+	ctx.Printf("setting concurrency to %d...\n", opts.Concurrency)
+	cfg.SetConcurrency(int32(opts.Concurrency))
 
 	setres, err := ac.SetConfiguration(ctx, opts.App, cfg)
 	if err != nil {
@@ -165,98 +38,4 @@ func Set(ctx *Context, opts struct {
 	ctx.Printf("new version id: %s\n", setres.VersionId())
 
 	return nil
-}
-
-func promptForValue(ctx *Context, key string) (string, error) {
-	return runTextInputPrompt(key, false)
-}
-
-func promptForSensitiveValue(ctx *Context, key string) (string, error) {
-	return runTextInputPrompt(key, true)
-}
-
-// textInputModel is a simple model for text input prompts
-type textInputModel struct {
-	textInput textinput.Model
-	key       string
-	sensitive bool
-	submitted bool
-	value     string
-	err       error
-}
-
-func (m textInputModel) Init() tea.Cmd {
-	return textinput.Blink
-}
-
-func (m textInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
-
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.Type {
-		case tea.KeyEnter:
-			m.value = m.textInput.Value()
-			m.submitted = true
-			return m, tea.Quit
-		case tea.KeyCtrlC, tea.KeyEsc:
-			m.err = fmt.Errorf("cancelled")
-			return m, tea.Quit
-		}
-	}
-
-	m.textInput, cmd = m.textInput.Update(msg)
-	return m, cmd
-}
-
-func (m textInputModel) View() string {
-	if m.submitted || m.err != nil {
-		return ""
-	}
-
-	var promptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	var label string
-	if m.sensitive {
-		label = fmt.Sprintf("Enter value for sensitive variable '%s'", m.key)
-	} else {
-		label = fmt.Sprintf("Enter value for variable '%s'", m.key)
-	}
-
-	return fmt.Sprintf(
-		"%s\n\n%s\n\n%s",
-		promptStyle.Render(label),
-		m.textInput.View(),
-		promptStyle.Render("(press enter to submit, esc to cancel)"),
-	)
-}
-
-func runTextInputPrompt(key string, sensitive bool) (string, error) {
-	ti := textinput.New()
-	ti.Focus()
-	ti.CharLimit = 0
-	ti.Width = 60
-
-	if sensitive {
-		ti.EchoMode = textinput.EchoPassword
-		ti.EchoCharacter = '•'
-	}
-
-	model := textInputModel{
-		textInput: ti,
-		key:       key,
-		sensitive: sensitive,
-	}
-
-	p := tea.NewProgram(model)
-	finalModel, err := p.Run()
-	if err != nil {
-		return "", err
-	}
-
-	m := finalModel.(textInputModel)
-	if m.err != nil {
-		return "", m.err
-	}
-
-	return strings.TrimSpace(m.value), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/mdlayher/genetlink v1.3.2
 	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42
@@ -198,7 +199,6 @@ require (
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/lrstanley/bubblezone v0.0.0-20240914071701-b48c55a5e78e // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect

--- a/pkg/ui/prompt.go
+++ b/pkg/ui/prompt.go
@@ -1,0 +1,286 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// PromptOption configures a text input prompt
+type PromptOption func(*promptConfig)
+
+type promptConfig struct {
+	label       string
+	sensitive   bool
+	placeholder string
+	charLimit   int
+	width       int
+}
+
+// WithLabel sets the prompt label
+func WithLabel(label string) PromptOption {
+	return func(c *promptConfig) {
+		c.label = label
+	}
+}
+
+// WithSensitive makes the input masked (for passwords/secrets)
+func WithSensitive(sensitive bool) PromptOption {
+	return func(c *promptConfig) {
+		c.sensitive = sensitive
+	}
+}
+
+// WithPlaceholder sets the placeholder text
+func WithPlaceholder(placeholder string) PromptOption {
+	return func(c *promptConfig) {
+		c.placeholder = placeholder
+	}
+}
+
+// WithCharLimit sets the character limit (0 for unlimited)
+func WithCharLimit(limit int) PromptOption {
+	return func(c *promptConfig) {
+		c.charLimit = limit
+	}
+}
+
+// WithWidth sets the input field width
+func WithWidth(width int) PromptOption {
+	return func(c *promptConfig) {
+		c.width = width
+	}
+}
+
+// PromptForInput displays an interactive text input prompt and returns the user's input
+func PromptForInput(opts ...PromptOption) (string, error) {
+	// Apply default configuration
+	config := &promptConfig{
+		label:     "Enter value",
+		sensitive: false,
+		charLimit: 0,
+		width:     60,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	// Create the text input
+	ti := textinput.New()
+	ti.Focus()
+	ti.CharLimit = config.charLimit
+	ti.Width = config.width
+
+	if config.placeholder != "" {
+		ti.Placeholder = config.placeholder
+	}
+
+	if config.sensitive {
+		ti.EchoMode = textinput.EchoPassword
+		ti.EchoCharacter = '•'
+	}
+
+	// Create and run the model
+	model := textInputModel{
+		textInput: ti,
+		label:     config.label,
+		sensitive: config.sensitive,
+	}
+
+	p := tea.NewProgram(model)
+	finalModel, err := p.Run()
+	if err != nil {
+		return "", err
+	}
+
+	m := finalModel.(textInputModel)
+	if m.err != nil {
+		return "", m.err
+	}
+
+	return strings.TrimSpace(m.value), nil
+}
+
+// textInputModel is the internal model for text input prompts
+type textInputModel struct {
+	textInput textinput.Model
+	label     string
+	sensitive bool
+	submitted bool
+	value     string
+	err       error
+}
+
+func (m textInputModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m textInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyEnter:
+			m.value = m.textInput.Value()
+			m.submitted = true
+			return m, tea.Quit
+		case tea.KeyCtrlC, tea.KeyEsc:
+			m.err = fmt.Errorf("cancelled")
+			return m, tea.Quit
+		}
+	}
+
+	m.textInput, cmd = m.textInput.Update(msg)
+	return m, cmd
+}
+
+func (m textInputModel) View() string {
+	if m.submitted || m.err != nil {
+		return ""
+	}
+
+	promptStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+
+	return fmt.Sprintf(
+		"%s\n\n%s\n\n%s",
+		promptStyle.Render(m.label),
+		m.textInput.View(),
+		promptStyle.Render("(press enter to submit, esc to cancel)"),
+	)
+}
+
+// ConfirmOption configures a confirmation prompt
+type ConfirmOption func(*confirmConfig)
+
+type confirmConfig struct {
+	message     string
+	affirmative string
+	negative    string
+	defaultYes  bool
+}
+
+// WithMessage sets the confirmation message
+func WithMessage(message string) ConfirmOption {
+	return func(c *confirmConfig) {
+		c.message = message
+	}
+}
+
+// WithAffirmative sets the affirmative response text (default: "yes")
+func WithAffirmative(text string) ConfirmOption {
+	return func(c *confirmConfig) {
+		c.affirmative = text
+	}
+}
+
+// WithNegative sets the negative response text (default: "no")
+func WithNegative(text string) ConfirmOption {
+	return func(c *confirmConfig) {
+		c.negative = text
+	}
+}
+
+// WithDefault sets the default response when user just presses enter
+func WithDefault(defaultYes bool) ConfirmOption {
+	return func(c *confirmConfig) {
+		c.defaultYes = defaultYes
+	}
+}
+
+// Confirm displays a yes/no confirmation prompt
+func Confirm(opts ...ConfirmOption) (bool, error) {
+	// Apply default configuration
+	config := &confirmConfig{
+		message:     "Are you sure?",
+		affirmative: "yes",
+		negative:    "no",
+		defaultYes:  false,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	// Create and run the model
+	model := confirmModel{
+		message:     config.message,
+		affirmative: config.affirmative,
+		negative:    config.negative,
+		defaultYes:  config.defaultYes,
+	}
+
+	p := tea.NewProgram(model)
+	finalModel, err := p.Run()
+	if err != nil {
+		return false, err
+	}
+
+	m := finalModel.(confirmModel)
+	if m.err != nil {
+		return false, m.err
+	}
+
+	return m.confirmed, nil
+}
+
+// confirmModel is the internal model for confirmation prompts
+type confirmModel struct {
+	message     string
+	affirmative string
+	negative    string
+	defaultYes  bool
+	confirmed   bool
+	err         error
+}
+
+func (m confirmModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m confirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		input := strings.ToLower(msg.String())
+		switch input {
+		case "y", "yes", strings.ToLower(m.affirmative):
+			m.confirmed = true
+			return m, tea.Quit
+		case "n", "no", strings.ToLower(m.negative):
+			m.confirmed = false
+			return m, tea.Quit
+		case "enter":
+			m.confirmed = m.defaultYes
+			return m, tea.Quit
+		case "ctrl+c", "esc":
+			m.err = fmt.Errorf("cancelled")
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m confirmModel) View() string {
+	promptStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	highlightStyle := lipgloss.NewStyle().Bold(true)
+
+	var prompt string
+	if m.defaultYes {
+		prompt = fmt.Sprintf("(%s/%s)", highlightStyle.Render("Y"), "n")
+	} else {
+		prompt = fmt.Sprintf("(y/%s)", highlightStyle.Render("N"))
+	}
+
+	return fmt.Sprintf(
+		"%s %s\n\n%s",
+		m.message,
+		prompt,
+		promptStyle.Render("Press y/n or enter for default, esc to cancel"),
+	)
+}

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -1,0 +1,262 @@
+// Package ui provides common UI components for the miren CLI
+package ui
+
+import (
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+	"golang.org/x/term"
+)
+
+// Column defines a table column with title and width
+type Column struct {
+	Title string
+	Width int
+}
+
+// Row represents a single row of data in the table
+type Row []string
+
+// Table represents a simple, non-interactive table for CLI output
+type Table struct {
+	columns []Column
+	rows    []Row
+	styles  TableStyles
+}
+
+// TableStyles contains the styling configuration for the table
+type TableStyles struct {
+	Header lipgloss.Style
+	Cell   lipgloss.Style
+}
+
+// DefaultTableStyles returns the default styling for tables
+func DefaultTableStyles() TableStyles {
+	return TableStyles{
+		Header: lipgloss.NewStyle().
+			Bold(true).
+			Underline(true).
+			UnderlineSpaces(true).
+			Foreground(lipgloss.Color("220")),
+		Cell: lipgloss.NewStyle(),
+	}
+}
+
+// TableOption is a function that configures a table
+type TableOption func(*Table)
+
+// WithColumns sets the columns for the table
+func WithColumns(cols []Column) TableOption {
+	return func(t *Table) {
+		t.columns = cols
+	}
+}
+
+// WithRows sets the rows for the table
+func WithRows(rows []Row) TableOption {
+	return func(t *Table) {
+		t.rows = rows
+	}
+}
+
+// WithStyles sets custom styles for the table
+func WithStyles(styles TableStyles) TableOption {
+	return func(t *Table) {
+		t.styles = styles
+	}
+}
+
+// NewTable creates a new table with the given options
+func NewTable(opts ...TableOption) *Table {
+	t := &Table{
+		styles: DefaultTableStyles(),
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	return t
+}
+
+// AutoSizeColumns calculates optimal column widths based on content
+// with optional maximum widths per column, respecting terminal width
+func AutoSizeColumns(headers []string, rows []Row, maxWidths ...int) []Column {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	// Get terminal width
+	termWidth := 80 // default fallback
+	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && width > 0 {
+		termWidth = width
+	}
+
+	// Initialize widths with header lengths
+	widths := make([]int, len(headers))
+	for i, header := range headers {
+		widths[i] = lipgloss.Width(header)
+	}
+
+	// Check all row values
+	for _, row := range rows {
+		for i, value := range row {
+			if i < len(widths) {
+				// For styled content, we need to measure the actual display width
+				displayWidth := measureDisplayWidth(value)
+				if displayWidth > widths[i] {
+					widths[i] = displayWidth
+				}
+			}
+		}
+	}
+
+	// Apply max widths if provided
+	for i := range widths {
+		if i < len(maxWidths) && maxWidths[i] > 0 {
+			widths[i] = min(widths[i], maxWidths[i])
+		}
+	}
+
+	// Calculate total width needed (including spaces between columns)
+	totalWidth := 0
+	for _, w := range widths {
+		totalWidth += w
+	}
+	totalWidth += (len(headers) - 1) * 2 // 2 spaces between each column
+
+	// If total width exceeds terminal width, scale down proportionally
+	if totalWidth > termWidth {
+		availableWidth := termWidth - (len(headers)-1)*2 // subtract space for margins
+
+		// Calculate scaling factor
+		scaleFactor := float64(availableWidth) / float64(totalWidth-(len(headers)-1)*2)
+
+		// Scale each column width
+		for i := range widths {
+			newWidth := int(float64(widths[i]) * scaleFactor)
+			if newWidth < 10 { // Minimum column width
+				newWidth = 10
+			}
+			widths[i] = newWidth
+		}
+	}
+
+	// Create columns
+	columns := make([]Column, len(headers))
+	for i, header := range headers {
+		columns[i] = Column{
+			Title: header,
+			Width: widths[i],
+		}
+	}
+
+	return columns
+}
+
+// measureDisplayWidth measures the display width of a string,
+// accounting for ANSI escape sequences
+func measureDisplayWidth(s string) int {
+	// Strip ANSI escape sequences to get the actual display width
+	// lipgloss.Width handles this correctly
+	return lipgloss.Width(s)
+}
+
+// Render generates the string representation of the table
+func (t *Table) Render() string {
+	if len(t.columns) == 0 || len(t.rows) == 0 {
+		return ""
+	}
+
+	var lines []string
+
+	// Render header
+	lines = append(lines, t.renderHeader())
+
+	// Render rows
+	for _, row := range t.rows {
+		lines = append(lines, t.renderRow(row))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderHeader renders the table header
+func (t *Table) renderHeader() string {
+	cells := make([]string, 0, len(t.columns)*2-1) // Account for spacers
+
+	for i, col := range t.columns {
+		if col.Width <= 0 {
+			continue
+		}
+
+		// Add spacing between columns (but not before the first)
+		if i > 0 {
+			cells = append(cells, "  ") // Two spaces between columns
+		}
+
+		// Create a style for the cell content with fixed width
+		cellStyle := lipgloss.NewStyle().
+			Width(col.Width).
+			MaxWidth(col.Width).
+			Inline(true)
+
+		// Truncate with ellipsis and render
+		truncated := runewidth.Truncate(col.Title, col.Width, "…")
+		renderedCell := cellStyle.Render(truncated)
+
+		// Apply header styling
+		cells = append(cells, t.styles.Header.Render(renderedCell))
+	}
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, cells...)
+}
+
+// renderRow renders a single data row
+func (t *Table) renderRow(row Row) string {
+	cells := make([]string, 0, len(t.columns)*2-1) // Account for spacers
+
+	for i, col := range t.columns {
+		if col.Width <= 0 {
+			continue
+		}
+
+		// Add spacing between columns (but not before the first)
+		if i > 0 {
+			cells = append(cells, "  ") // Two spaces between columns
+		}
+
+		// Get the value for this column
+		value := ""
+		if i < len(row) {
+			value = row[i]
+		}
+
+		// Create a style for the cell content with fixed width
+		cellStyle := lipgloss.NewStyle().
+			Width(col.Width).
+			MaxWidth(col.Width).
+			Inline(true)
+
+		// For already-styled content (like gray sensitive values), we can't easily truncate
+		// because runewidth.Truncate doesn't handle ANSI codes well.
+		// So we only truncate plain text values.
+		// We can detect styled content by checking if it contains ANSI escape sequences.
+		var renderedCell string
+		if strings.Contains(value, "\x1b[") {
+			// Already styled - let lipgloss handle width constraints
+			renderedCell = cellStyle.Render(value)
+		} else {
+			// Plain text - truncate with ellipsis
+			truncated := runewidth.Truncate(value, col.Width, "…")
+			renderedCell = cellStyle.Render(truncated)
+		}
+
+		// Apply cell styling
+		cells = append(cells, t.styles.Cell.Render(renderedCell))
+	}
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, cells...)
+}

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -187,33 +187,18 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 		}
 	}
 
-	// Simply append all new env vars - we'll deduplicate at the end
-	for _, ev := range cfg.EnvVars() {
-		nv := core_v1alpha.Variable{
-			Key:       ev.Key(),
-			Value:     ev.Value(),
-			Sensitive: ev.Sensitive(),
-		}
-		appVer.Config.Variable = append(appVer.Config.Variable, nv)
-	}
-
-	// Deduplicate environment variables - last value wins for each key
-	if len(appVer.Config.Variable) > 0 {
-		seen := make(map[string]int) // maps key to index in deduplicated slice
-		deduplicated := make([]core_v1alpha.Variable, 0, len(appVer.Config.Variable))
-
-		for _, v := range appVer.Config.Variable {
-			if idx, exists := seen[v.Key]; exists {
-				// Replace the existing entry with this one (last value wins)
-				deduplicated[idx] = v
-			} else {
-				// New key, add it
-				seen[v.Key] = len(deduplicated)
-				deduplicated = append(deduplicated, v)
+	// Replace the entire env var list with the new one from the client
+	// The client is responsible for sending the complete desired state
+	if cfg.HasEnvVars() {
+		appVer.Config.Variable = nil
+		for _, ev := range cfg.EnvVars() {
+			nv := core_v1alpha.Variable{
+				Key:       ev.Key(),
+				Value:     ev.Value(),
+				Sensitive: ev.Sensitive(),
 			}
+			appVer.Config.Variable = append(appVer.Config.Variable, nv)
 		}
-
-		appVer.Config.Variable = deduplicated
 	}
 
 	appVer.Config.Entrypoint = cfg.Entrypoint()

--- a/testdata/bun/index.js
+++ b/testdata/bun/index.js
@@ -14,6 +14,17 @@ const server = Bun.serve({
       console.error("Failed to write to log file:", error);
     }
 
+    // Parse the URL to get the pathname
+    const url = new URL(request.url);
+    
+    // Handle /env endpoint
+    if (url.pathname === "/env") {
+      // Return environment variables as JSON
+      return new Response(JSON.stringify(process.env, null, 2), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     return new Response("Welcome to Bun!");
   },
 });


### PR DESCRIPTION
## Summary
Fixes [MIR-359](https://linear.app/miren/issue/MIR-359): Reworks environment variable handling by moving it from the `set` command to a dedicated `env` command with full CRUD operations.

## Breaking Changes
⚠️ The `set` command no longer handles environment variables. Users must migrate to using the new `env` command.

## Changes

### New CLI Commands
- **`env set`**: Set environment variables with support for:
  - Direct values: `env set -e KEY=VALUE`
  - File input: `env set -e KEY=@file.txt`
  - Interactive prompting: `env set -e KEY` (prompts for value)
  - Sensitive variables: `env set -s SECRET_KEY=value` (masked in display)
- **`env get <KEY>`**: Retrieve a specific environment variable value
- **`env list`**: Display all environment variables in a formatted table
- **`env delete <KEY>...`**: Delete one or more environment variables with confirmation prompt (use `-f` to skip)

### UI Improvements
- Created reusable UI components in `pkg/ui/`:
  - `table.go`: Custom table component with auto-sizing columns and terminal width detection
  - `prompt.go`: Interactive prompts for text input and confirmation
- Sensitive values are displayed as gray dots in listings
- Tables automatically adjust to terminal width

### Server-Side Fixes
- Fixed env var deletion by replacing append+deduplicate logic with complete replacement
- Client now sends the complete desired state of environment variables
- Removed stale deduplication logic

### Testing
- Added comprehensive test `TestSetConfiguration_EnvVarDeletion` to verify deletion works correctly
- Enhanced testdata/bun app to expose environment variables via `/env` endpoint

## Test Plan
- [x] Unit tests pass for env var deletion
- [x] Manual testing of all env subcommands
- [x] Integration tests with real apps

## Screenshots

Table:

<img width="1600" height="756" alt="2025-09-02 at 18 04 52@2x" src="https://github.com/user-attachments/assets/6f5f144e-adb9-4627-8cc5-37c46d15e366" />

Prompt:

<img width="1016" height="164" alt="2025-09-02 at 18 05 39@2x" src="https://github.com/user-attachments/assets/c882464a-f0cd-4909-bd89-b2b12594d2ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI env namespace: set/get/list/delete with prompting, masked sensitive input, file-sourced values (@), confirmation prompts, and formatted table output.
  * Interactive prompt and table utilities for terminal input, confirmation, and styled tables.
  * Added an /env HTTP endpoint returning process environment as JSON.

* **Changes**
  * The set command now only adjusts application concurrency.
  * Env updates now replace the entire variable set (enables explicit deletions).

* **Tests**
  * Tests updated to validate env variable deletion flows.

* **Chores**
  * Promoted a terminal-width dependency to a direct requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->