### PR TITLE
Improve sandbox cleanup to prevent resource leaks

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -513,6 +513,11 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 			// Clean up the pause container using the common cleanup function
 			pauseID := c.pauseContainerId(co.ID)
 			c.cleanupContainer(ctx, container, pauseID)
+
+			// Update sandbox status to DEAD in entity store
+			co.Status = compute.DEAD
+			meta.Attrs = co.Encode()
+			c.Log.Info("marked sandbox as DEAD due to boot failure", "id", co.ID)
 		}
 	}()
 

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -515,8 +515,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 			c.destroySubContainers(ctx, co)
 
 			// Clean up the pause container using the common cleanup function
-			pauseID := c.pauseContainerId(co.ID)
-			c.cleanupContainer(ctx, container, pauseID)
+			c.cleanupContainer(ctx, container)
 
 			// Update sandbox status to DEAD in entity store
 			co.Status = compute.DEAD
@@ -1081,14 +1080,12 @@ type waitPort struct {
 }
 
 // cleanupContainer removes a container and its snapshot during failure scenarios
-func (c *SandboxController) cleanupContainer(ctx context.Context, cont containerd.Container, containerID string) {
+func (c *SandboxController) cleanupContainer(ctx context.Context, cont containerd.Container) {
 	if cont == nil {
 		return
 	}
 
-	if containerID == "" {
-		containerID = cont.ID()
-	}
+	containerID := cont.ID()
 
 	c.Log.Debug("cleaning up container", "id", containerID)
 
@@ -1140,7 +1137,7 @@ func (c *SandboxController) cleanupContainer(ctx context.Context, cont container
 func (c *SandboxController) cleanupContainers(ctx context.Context, containers []containerd.Container) {
 	for _, cont := range containers {
 		if cont != nil {
-			c.cleanupContainer(ctx, cont, cont.ID())
+			c.cleanupContainer(ctx, cont)
 		}
 	}
 }

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -482,11 +482,13 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 
 	opts, err := c.buildSpec(ctx, co, ep, meta)
 	if err != nil {
+		c.deallocateNetwork(ctx, ep)
 		return fmt.Errorf("failed to build container spec: %w", err)
 	}
 
 	err = c.configureVolumes(ctx, co)
 	if err != nil {
+		c.deallocateNetwork(ctx, ep)
 		return fmt.Errorf("failed to configure volumes: %w", err)
 	}
 
@@ -494,6 +496,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 
 	container, err := c.CC.NewContainer(ctx, cid, opts...)
 	if err != nil {
+		c.deallocateNetwork(ctx, ep)
 		return errors.Wrapf(err, "failed to create container %s", co.ID)
 	}
 
@@ -501,15 +504,15 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 		if err != nil {
 			c.Log.Error("failed to create sandbox, cleaning up", "id", co.ID, "err", err)
 
-			task, _ := container.Task(ctx, nil)
-			if task != nil {
-				task.Delete(ctx, containerd.WithProcessKill)
-			}
+			// Clean up network resources if they were allocated
+			c.deallocateNetwork(ctx, ep)
 
-			derr := container.Delete(ctx, containerd.WithSnapshotCleanup)
-			if derr != nil {
-				c.Log.Error("failed to cleanup container", "id", co.ID, "err", derr)
-			}
+			// Clean up any subcontainers that might have been created
+			c.destroySubContainers(ctx, co)
+
+			// Clean up the pause container using the common cleanup function
+			pauseID := c.pauseContainerId(co.ID)
+			c.cleanupContainer(ctx, container, pauseID)
 		}
 	}()
 
@@ -700,6 +703,21 @@ func (c *SandboxController) deleteEndpoints(ctx context.Context, sb *compute.San
 	}
 
 	return nil
+}
+
+// deallocateNetwork releases the network resources allocated for a sandbox
+func (c *SandboxController) deallocateNetwork(ctx context.Context, ep *network.EndpointConfig) {
+	if ep == nil {
+		return
+	}
+
+	for _, addr := range ep.Addresses {
+		if err := c.Subnet.ReleaseAddr(addr.Addr()); err != nil {
+			c.Log.Error("failed to release IP address during cleanup", "addr", addr.Addr(), "err", err)
+		} else {
+			c.Log.Debug("released IP address during cleanup", "addr", addr.Addr())
+		}
+	}
 }
 
 func (c *SandboxController) allocateNetwork(
@@ -1053,6 +1071,71 @@ type waitPort struct {
 	port int
 }
 
+// cleanupContainer removes a container and its snapshot during failure scenarios
+func (c *SandboxController) cleanupContainer(ctx context.Context, cont containerd.Container, containerID string) {
+	if cont == nil {
+		return
+	}
+
+	if containerID == "" {
+		containerID = cont.ID()
+	}
+
+	c.Log.Debug("cleaning up container", "id", containerID)
+
+	// Stop port monitoring for this container
+	if c.portMonitor != nil {
+		c.portMonitor.StopMonitoring(containerID)
+	}
+
+	// Try to kill and delete any task first
+	task, err := cont.Task(ctx, nil)
+	if err == nil && task != nil {
+		task.Kill(ctx, unix.SIGKILL)
+		_, err = task.Delete(ctx, containerd.WithProcessKill)
+		if err != nil {
+			c.Log.Debug("failed to delete task during cleanup", "id", containerID, "err", err)
+		}
+	}
+
+	// Get the snapshotter info from the container before deleting it
+	var snapshotKey string
+	var snapshotterName string
+	if info, ierr := cont.Info(ctx); ierr == nil {
+		snapshotKey = info.SnapshotKey
+		snapshotterName = info.Snapshotter
+	}
+
+	// Delete the container with snapshot cleanup
+	err = cont.Delete(ctx, containerd.WithSnapshotCleanup)
+	if err != nil {
+		c.Log.Error("failed to cleanup container", "id", containerID, "err", err)
+	} else {
+		c.Log.Debug("cleaned up container", "id", containerID)
+	}
+
+	// Always try to explicitly delete the snapshot to be absolutely sure
+	if snapshotterName != "" && snapshotKey != "" {
+		snapshotter := c.CC.SnapshotService(snapshotterName)
+		if snapshotter != nil {
+			if err := snapshotter.Remove(ctx, snapshotKey); err != nil && !errdefs.IsNotFound(err) {
+				c.Log.Debug("failed to explicitly delete snapshot", "id", containerID, "snapshot_key", snapshotKey, "err", err)
+			} else if err == nil {
+				c.Log.Debug("explicitly deleted snapshot", "id", containerID, "snapshot_key", snapshotKey)
+			}
+		}
+	}
+}
+
+// cleanupContainers removes containers and their snapshots during failure scenarios
+func (c *SandboxController) cleanupContainers(ctx context.Context, containers []containerd.Container) {
+	for _, cont := range containers {
+		if cont != nil {
+			c.cleanupContainer(ctx, cont, cont.ID())
+		}
+	}
+}
+
 func (c *SandboxController) bootContainers(
 	ctx context.Context,
 	sb *compute.Sandbox,
@@ -1065,10 +1148,21 @@ func (c *SandboxController) bootContainers(
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
 	var ret []waitPort
+	var createdContainers []containerd.Container
+
+	// Clean up any created containers on failure
+	defer func() {
+		if err := recover(); err != nil {
+			c.Log.Error("panic during container boot, cleaning up", "error", err)
+			c.cleanupContainers(ctx, createdContainers)
+			panic(err)
+		}
+	}()
 
 	for _, container := range sb.Container {
 		opts, err := c.buildSubContainerSpec(ctx, sb, &container, ep, sbPid)
 		if err != nil {
+			c.cleanupContainers(ctx, createdContainers)
 			return nil, fmt.Errorf("failed to build container spec: %w", err)
 		}
 
@@ -1087,11 +1181,14 @@ func (c *SandboxController) bootContainers(
 
 		cc, err := c.CC.NewContainer(ctx, id, opts...)
 		if err != nil {
+			c.cleanupContainers(ctx, createdContainers)
 			return nil, errors.Wrapf(err, "failed to create container %s", sb.ID)
 		}
+		createdContainers = append(createdContainers, cc)
 
 		spec, err := cc.Spec(ctx)
 		if err != nil {
+			c.cleanupContainers(ctx, createdContainers)
 			return nil, fmt.Errorf("failed to get container spec: %w", err)
 		}
 
@@ -1102,11 +1199,15 @@ func (c *SandboxController) bootContainers(
 		task, err := cc.NewTask(ctx, cio.NewCreator(
 			cio.WithStreams(nil, sl, sl.Stderr())))
 		if err != nil {
+			c.cleanupContainers(ctx, createdContainers)
 			return nil, err
 		}
 
 		err = task.Start(ctx)
 		if err != nil {
+			// Try to delete the task first if it was created but not started
+			task.Delete(ctx, containerd.WithProcessKill)
+			c.cleanupContainers(ctx, createdContainers)
 			return nil, err
 		}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -264,7 +264,7 @@ func (c *ReconcileController) runWorker(ctx context.Context) {
 			updates, err := c.processItem(ctx, event)
 			if err != nil {
 				c.Log.Error("error processing item", "event", event, "error", err)
-				continue
+				// we still try to process updates even if there is an error.
 			}
 
 			if len(updates) > 0 {
@@ -450,10 +450,10 @@ func AdaptController[
 			}
 
 			if err != nil {
-				return nil, fmt.Errorf("failed to process entity: %w", err)
+				err = fmt.Errorf("failed to process entity: %w", err)
 			}
 
-			return entity.Diff(meta.Entity, orig), nil
+			return entity.Diff(meta.Entity, orig), err
 
 		case EventDeleted:
 			if err := cont.Delete(ctx, event.Id); err != nil {


### PR DESCRIPTION
## Summary
- Ensures containerd snapshots are always deleted when container boot fails
- Prevents IP address and port monitoring leaks during error scenarios
- Centralizes cleanup logic for consistency and maintainability

## Changes
- **Explicit snapshot deletion**: Added fallback using `snapshotter.Remove()` that runs even if `container.Delete()` fails
- **Network cleanup**: Added `deallocateNetwork()` function that releases IP addresses back to the subnet on all error paths
- **Port monitoring cleanup**: Integrated `StopMonitoring()` calls into the container cleanup flow
- **Refactored cleanup logic**: Created `cleanupContainer()` function to centralize all cleanup operations

## Test plan
- [x] Code compiles successfully (`make bin/miren`)
- [x] Code formatted with `go fmt`
- [x] Test sandbox creation failures verify resources are cleaned up
- [x] Verify no containerd snapshot leaks after failures
- [x] Verify IP addresses are released back to subnet pool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents IP and network resource leaks when sandbox setup or boot fails.
  * Ensures pause and subcontainers, tasks and snapshots are consistently stopped and removed on errors or panics.
  * Marks failed sandboxes as DEAD and cleans up partial boot progress.

* **Behavior Change**
  * Worker processing now logs item errors but continues to allow subsequent update handling.

* **Refactor**
  * Consolidated cleanup into unified helpers for consistent error handling across sandbox creation paths.

* **Notes**
  * No changes to public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->