### PR TITLE
Propagate data-path from server CLI to components

### DIFF
--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -101,8 +101,8 @@ func setup(ctx context.Context, flags *GlobalFlags, opts any) *Context {
 
 	s.setupServerComponents(ctx, s.Server)
 
-	s.Server.InferFrom(opts)
-	s.Client.InferFrom(flags)
+	s.Server.InferFrom(opts, true)
+	s.Client.InferFrom(flags, true)
 
 	s.Client.Populate(&s.Config)
 

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -52,7 +52,7 @@ func Server(ctx *Context, opts struct {
 	EtcdEndpoints             []string `short:"e" long:"etcd" description:"Etcd endpoints" default:"http://etcd:2379"`
 	EtcdPrefix                string   `short:"p" long:"etcd-prefix" description:"Etcd prefix" default:"/miren"`
 	RunnerId                  string   `short:"r" long:"runner-id" description:"Runner ID" default:"miren"`
-	DataPath                  string   `short:"d" long:"data-path" description:"Data path" default:"/var/lib/miren"`
+	DataPath                  string   `short:"d" long:"data-path" description:"Data path" default:"/var/lib/miren" asm:"data-path"`
 	ReleasePath               string   `long:"release-path" description:"Path to release directory containing binaries"`
 	AdditionalNames           []string `long:"dns-names" description:"Additional DNS names assigned to the server cert"`
 	AdditionalIPs             []string `long:"ips" description:"Additional IPs assigned to the server cert"`
@@ -477,6 +477,7 @@ func Server(ctx *Context, opts struct {
 		if err := os.MkdirAll(opts.Dir, 0755); err != nil {
 			return nil, fmt.Errorf("failed to create directory %s: %w", opts.Dir, err)
 		}
+
 		ndb, err := netdb.New(filepath.Join(opts.Dir, "net.db"))
 		if err != nil {
 			return nil, fmt.Errorf("failed to open netdb: %w", err)

--- a/pkg/asm/registry.go
+++ b/pkg/asm/registry.go
@@ -291,7 +291,7 @@ func parseTag(tag string) (string, bool) {
 	return name, optional
 }
 
-func (r *Registry) InferFrom(s any) error {
+func (r *Registry) InferFrom(s any, override bool) error {
 	rv := reflect.ValueOf(s)
 
 	rv = reflect.Indirect(rv)
@@ -318,7 +318,11 @@ func (r *Registry) InferFrom(s any) error {
 			continue
 		}
 
-		r.Register(tag, field.Interface())
+		if override {
+			r.Override(tag, field.Interface())
+		} else {
+			r.Register(tag, field.Interface())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This uses a little used feature of injecting the CLI flags into the registry. It also makes a small change, allowing the flags from the CLI to override any existing values, so there can be defaults.

This was found because net.db was always being written to /var/lib/miren regardless of the value of -d on the command line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Introduced override-aware component inference to improve registration handling.
- Chores
  - Added internal annotation to the server data path option; no change to defaults or CLI behavior.
  - General internal updates to align with new inference flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->