### PR TITLE
Refresh RBAC rules after rejection with 30-second cooldown

### DIFF
--- a/pkg/cloudauth/policy_fetcher.go
+++ b/pkg/cloudauth/policy_fetcher.go
@@ -56,11 +56,13 @@ type PolicyFetcher struct {
 	httpClient      *http.Client
 	logger          *slog.Logger
 	refreshInterval time.Duration
+	evaluator       *rbac.Evaluator
 
 	mu          sync.RWMutex
 	policy      *rbac.Policy
 	lastFetched time.Time
 	lastError   error
+	lastRefresh time.Time
 
 	stop func()
 	wg   sync.WaitGroup
@@ -196,6 +198,14 @@ func (pf *PolicyFetcher) fetchPolicy(ctx context.Context) error {
 	pf.setPolicy(&policy)
 	pf.logger.Info("policy fetched successfully", "rules", len(policy.Rules))
 
+	// Update refresh timestamp and clear evaluator cache
+	pf.mu.Lock()
+	pf.lastRefresh = time.Now()
+	if pf.evaluator != nil {
+		pf.evaluator.ClearCache()
+	}
+	pf.mu.Unlock()
+
 	return nil
 }
 
@@ -228,4 +238,43 @@ func (pf *PolicyFetcher) setError(err error) {
 	pf.mu.Lock()
 	defer pf.mu.Unlock()
 	pf.lastError = err
+}
+
+// RefreshIfNeeded performs an immediate refresh if more than 30 seconds have passed since last refresh
+func (pf *PolicyFetcher) RefreshIfNeeded(ctx context.Context) {
+	pf.mu.Lock()
+	now := time.Now()
+	shouldRefresh := now.Sub(pf.lastRefresh) > 30*time.Second
+	if shouldRefresh {
+		pf.lastRefresh = now
+	}
+	pf.mu.Unlock()
+
+	if !shouldRefresh {
+		pf.logger.Debug("skipping refresh, too soon since last refresh",
+			"last_refresh", pf.lastRefresh,
+			"time_since", now.Sub(pf.lastRefresh))
+		return
+	}
+
+	pf.logger.Info("refreshing RBAC rules after rejection")
+
+	go func() {
+		if err := pf.fetchPolicy(ctx); err != nil {
+			pf.logger.Warn("failed to refresh policy after rejection", "error", err)
+		} else {
+			pf.logger.Info("successfully refreshed policy after rejection")
+			// Clear the evaluator's cache if we have one
+			if pf.evaluator != nil {
+				pf.evaluator.ClearCache()
+			}
+		}
+	}()
+}
+
+// SetEvaluator sets the RBAC evaluator (for cache clearing on refresh)
+func (pf *PolicyFetcher) SetEvaluator(evaluator *rbac.Evaluator) {
+	pf.mu.Lock()
+	defer pf.mu.Unlock()
+	pf.evaluator = evaluator
 }

--- a/pkg/cloudauth/policy_fetcher.go
+++ b/pkg/cloudauth/policy_fetcher.go
@@ -257,12 +257,17 @@ func (pf *PolicyFetcher) RefreshIfNeeded(ctx context.Context) {
 
 	pf.logger.Info("refreshing RBAC rules after rejection")
 
+	// Clear the cache immediately to remove the cached denial
+	if pf.evaluator != nil {
+		pf.evaluator.ClearCache()
+	}
+
 	go func() {
 		if err := pf.fetchPolicy(ctx); err != nil {
 			pf.logger.Warn("failed to refresh policy after rejection", "error", err)
 		} else {
 			pf.logger.Info("successfully refreshed policy after rejection")
-			// Clear the evaluator's cache if we have one
+			// Clear again after successful fetch to ensure fresh evaluation
 			if pf.evaluator != nil {
 				pf.evaluator.ClearCache()
 			}

--- a/pkg/cloudauth/policy_fetcher.go
+++ b/pkg/cloudauth/policy_fetcher.go
@@ -251,9 +251,7 @@ func (pf *PolicyFetcher) RefreshIfNeeded(ctx context.Context) {
 	pf.mu.Unlock()
 
 	if !shouldRefresh {
-		pf.logger.Debug("skipping refresh, too soon since last refresh",
-			"last_refresh", pf.lastRefresh,
-			"time_since", now.Sub(pf.lastRefresh))
+		// Don't log here, it's too noisy.
 		return
 	}
 

--- a/pkg/rbac/evaluator.go
+++ b/pkg/rbac/evaluator.go
@@ -152,8 +152,7 @@ func (e *Evaluator) Evaluate(req *Request, opts ...EvaluateOption) Decision {
 	if options.Explainer != nil {
 		options.Explainer.NoRulesMatched()
 	}
-	decision := DecisionDeny
-	e.cache.set(req, decision)
+	// Don't cache denials - they should be re-evaluated each time
 	e.logger.Debug("authorization denied",
 		"subject", req.Subject,
 		"groups", req.Groups,
@@ -161,7 +160,7 @@ func (e *Evaluator) Evaluate(req *Request, opts ...EvaluateOption) Decision {
 		"action", req.Action,
 		"tags", req.Tags,
 	)
-	return decision
+	return DecisionDeny
 }
 
 // ClearCache clears the decision cache


### PR DESCRIPTION
## Summary
- Automatically refresh RBAC rules from miren.cloud when access is denied
- Implement 30-second cooldown to prevent excessive API calls
- Clear decision cache after successful refresh to ensure fresh evaluation

## Details
When RBAC denies a request, the system now automatically triggers a refresh of the RBAC rules. This helps ensure the runtime has the latest permissions without waiting for the next periodic refresh cycle (default 60 seconds).

### Implementation
- Added `RefreshIfNeeded()` method to `PolicyFetcher` that:
  - Checks if 30 seconds have passed since last refresh attempt
  - Runs the refresh asynchronously to avoid blocking the rejection response
  - Clears the RBAC evaluator's decision cache on successful refresh
  
- Integrated with `RPCAuthenticator` to call `RefreshIfNeeded()` when RBAC denies access

### Benefits
- Faster permission updates when rules change in miren.cloud
- Reduced latency between permission grant and access
- No excessive API calls due to 30-second cooldown
- Non-blocking implementation maintains response times

## Test Plan
- [x] Unit tests pass
- [x] Code builds successfully
- [x] Linting passes
- [ ] Manual testing with RBAC rejections
- [ ] Verify cooldown prevents excessive refreshes
- [ ] Confirm cache is cleared after refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically refreshes access policies in the background when needed.
  - Triggers a quick policy refresh after an access denial (with cooldown) to keep decisions current.
  - Improved coordination between policy updates and authorization checks.

- **Bug Fixes**
  - Clears cached evaluations after successful refreshes to reduce stale authorization results.
  - Avoids caching denial decisions so access denials are re-evaluated, improving consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->