### PR TITLE
feat: auto-configure cluster on login and improve config bind UX

### DIFF
--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -49,6 +49,9 @@ type Config struct {
 	// The path to the config file that was loaded, if any.
 	sourcePath string
 
+	// Whether clientconfig.d should be loaded for this config
+	loadConfigD bool
+
 	// Leaf configs loaded from config.d directory
 	// These are kept separate and checked when accessing clusters/identities
 	leafConfigs []*Config
@@ -278,7 +281,7 @@ func (c *Config) SetActiveCluster(name string) error {
 
 // LoadConfig loads the configuration from disk
 func LoadConfig() (*Config, error) {
-	configPath, err := getConfigPath()
+	configPath, loadConfigD, err := getConfigPath()
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine config path: %w", err)
 	}
@@ -289,9 +292,12 @@ func LoadConfig() (*Config, error) {
 		// If main config doesn't exist, try loading from config.d directory
 		config := NewConfig()
 		config.sourcePath = configPath
+		config.loadConfigD = loadConfigD
 
-		if err := loadConfigDir(config); err != nil {
-			return nil, ErrNoConfig
+		if loadConfigD {
+			if err := loadConfigDir(config); err != nil {
+				return nil, ErrNoConfig
+			}
 		}
 
 		// Check if config is still empty after loading config.d
@@ -312,6 +318,7 @@ func LoadConfig() (*Config, error) {
 	)
 
 	config.sourcePath = configPath
+	config.loadConfigD = loadConfigD
 
 	if err := yaml.Unmarshal(data, &cdata); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
@@ -321,9 +328,11 @@ func LoadConfig() (*Config, error) {
 	config.clusters = cdata.Clusters
 	config.identities = cdata.Identities
 
-	// Load additional configs from config.d directory
-	if err := loadConfigDir(&config); err != nil {
-		return nil, fmt.Errorf("failed to load config.d: %w", err)
+	// Load additional configs from config.d directory if enabled
+	if loadConfigD {
+		if err := loadConfigDir(&config); err != nil {
+			return nil, fmt.Errorf("failed to load config.d: %w", err)
+		}
 	}
 
 	if err := config.Validate(); err != nil {
@@ -384,7 +393,7 @@ func (c *Config) Save() error {
 
 	var err error
 	if configPath == "" {
-		configPath, err = getConfigPath()
+		configPath, _, err = getConfigPath()
 		if err != nil {
 			return fmt.Errorf("failed to determine config path: %w", err)
 		}
@@ -502,7 +511,7 @@ func (c *Config) saveLeafConfigs(mainConfigPath string) error {
 }
 
 func (c *Config) SaveToHome() error {
-	configPath, err := getConfigPath()
+	configPath, _, err := getConfigPath()
 	if err != nil {
 		return fmt.Errorf("failed to determine config path: %w", err)
 	}
@@ -641,20 +650,17 @@ func (c *Config) IterateClusters(fn func(name string, cluster *ClusterConfig) er
 
 // loadConfigDir loads additional config files from the config.d directory
 func loadConfigDir(config *Config) error {
+	// If clientconfig.d loading is disabled, return early
+	if !config.loadConfigD {
+		return nil
+	}
+
 	var (
 		configDirPath string
 		err           error
 	)
 
 	if config.sourcePath != "" {
-		// Check if MIREN_CONFIG was set to a file (not a directory)
-		if envPath := os.Getenv(EnvConfigPath); envPath != "" {
-			// If sourcePath matches envPath, it means MIREN_CONFIG points directly to a file
-			if config.sourcePath == envPath {
-				// Don't load clientconfig.d when MIREN_CONFIG points to a file
-				return nil
-			}
-		}
 		configDirPath = filepath.Join(filepath.Dir(config.sourcePath), "clientconfig.d")
 	} else {
 		// Determine the config.d directory path
@@ -662,11 +668,10 @@ func loadConfigDir(config *Config) error {
 		if err != nil {
 			return fmt.Errorf("failed to determine config.d path: %w", err)
 		}
-	}
-
-	// If configDirPath is empty, it means clientconfig.d is disabled
-	if configDirPath == "" {
-		return nil
+		// If configDirPath is empty, it means clientconfig.d is disabled
+		if configDirPath == "" {
+			return nil
+		}
 	}
 
 	// Check if the directory exists
@@ -759,34 +764,35 @@ func getConfigDirPath() (string, error) {
 	return filepath.Join(homeDir, ".config/miren/clientconfig.d"), nil
 }
 
-// getConfigPath determines the configuration file path
-func getConfigPath() (string, error) {
+// getConfigPath determines the configuration file path and whether clientconfig.d should be loaded
+// Returns: (configPath, loadConfigD, error)
+func getConfigPath() (string, bool, error) {
 	// Check environment variable first
 	if envPath := os.Getenv(EnvConfigPath); envPath != "" {
 		// Check if it's a file or directory
 		info, err := os.Stat(envPath)
 		if err == nil {
 			if !info.IsDir() {
-				// It's a file, use it directly
-				return envPath, nil
+				// It's a file, use it directly, don't load clientconfig.d
+				return envPath, false, nil
 			}
-			// It's a directory, append clientconfig.yaml
-			return filepath.Join(envPath, "clientconfig.yaml"), nil
+			// It's a directory, append clientconfig.yaml and load clientconfig.d
+			return filepath.Join(envPath, "clientconfig.yaml"), true, nil
 		}
 		// Path doesn't exist yet, check if it has a .yaml or .yml extension
 		if strings.HasSuffix(envPath, ".yaml") || strings.HasSuffix(envPath, ".yml") {
-			// Looks like a file path, use it directly
-			return envPath, nil
+			// Looks like a file path, use it directly, don't load clientconfig.d
+			return envPath, false, nil
 		}
-		// Assume it's a directory
-		return filepath.Join(envPath, "clientconfig.yaml"), nil
+		// Assume it's a directory, load clientconfig.d
+		return filepath.Join(envPath, "clientconfig.yaml"), true, nil
 	}
 
-	// Fall back to default path in user's home directory
+	// Fall back to default path in user's home directory, load clientconfig.d
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to get user home directory: %w", err)
+		return "", false, fmt.Errorf("failed to get user home directory: %w", err)
 	}
 
-	return filepath.Join(homeDir, DefaultConfigPath), nil
+	return filepath.Join(homeDir, DefaultConfigPath), true, nil
 }

--- a/clientconfig/clientconfig_dir_test.go
+++ b/clientconfig/clientconfig_dir_test.go
@@ -62,7 +62,7 @@ clusters:
 
 	// Set environment variable to use our test directory
 	oldEnv := os.Getenv(EnvConfigPath)
-	os.Setenv(EnvConfigPath, mainConfigPath)
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Setenv(EnvConfigPath, oldEnv)
 
 	// Load the config
@@ -118,7 +118,7 @@ clusters:
 
 	// Set environment variable to use our test directory
 	oldEnv := os.Getenv(EnvConfigPath)
-	os.Setenv(EnvConfigPath, filepath.Join(tmpDir, "clientconfig.yaml"))
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Setenv(EnvConfigPath, oldEnv)
 
 	// Load the config
@@ -166,7 +166,7 @@ clusters:
 
 	// Set environment variable to use our test directory
 	oldEnv := os.Getenv(EnvConfigPath)
-	os.Setenv(EnvConfigPath, mainConfigPath)
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Setenv(EnvConfigPath, oldEnv)
 
 	// Load the config - should fail due to invalid YAML

--- a/clientconfig/clientconfig_file_test.go
+++ b/clientconfig/clientconfig_file_test.go
@@ -212,7 +212,7 @@ func TestMirenConfigPathResolution(t *testing.T) {
 			defer os.Setenv(EnvConfigPath, oldEnv)
 
 			// Get the config path
-			configPath, err := getConfigPath()
+			configPath, loadConfigD, err := getConfigPath()
 			require.NoError(t, err)
 
 			// Get the config dir path
@@ -222,10 +222,12 @@ func TestMirenConfigPathResolution(t *testing.T) {
 			if tt.expectedIsFile {
 				// Should treat as file
 				assert.Equal(t, testPath, configPath, "Config path should be the file itself")
+				assert.False(t, loadConfigD, "Should not load clientconfig.d when MIREN_CONFIG is a file")
 				assert.Empty(t, configDirPath, "Config dir should be empty when MIREN_CONFIG is a file")
 			} else {
 				// Should treat as directory
 				assert.Equal(t, filepath.Join(testPath, "clientconfig.yaml"), configPath, "Config path should be within the directory")
+				assert.True(t, loadConfigD, "Should load clientconfig.d when MIREN_CONFIG is a directory")
 				assert.Equal(t, filepath.Join(testPath, "clientconfig.d"), configDirPath, "Config dir should be within the directory")
 			}
 		})

--- a/clientconfig/clientconfig_file_test.go
+++ b/clientconfig/clientconfig_file_test.go
@@ -1,0 +1,233 @@
+package clientconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMirenConfigAsFileDisablesConfigD(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+
+	// Create main config file
+	mainConfigPath := filepath.Join(tmpDir, "myconfig.yaml")
+	mainConfig := `
+active_cluster: main
+clusters:
+  main:
+    hostname: main.example.com
+    ca_cert: main-ca
+identities:
+  main-identity:
+    type: keypair
+    issuer: main-issuer
+    private_key: main-key
+`
+	err := os.WriteFile(mainConfigPath, []byte(mainConfig), 0644)
+	require.NoError(t, err)
+
+	// Create config.d directory with additional configs that should be ignored
+	configDirPath := filepath.Join(tmpDir, "clientconfig.d")
+	err = os.MkdirAll(configDirPath, 0755)
+	require.NoError(t, err)
+
+	additionalConfig := `
+clusters:
+  should-not-load:
+    hostname: should-not-load.example.com
+    ca_cert: should-not-load-ca
+identities:
+  should-not-load-identity:
+    type: keypair
+    issuer: should-not-load-issuer
+    private_key: should-not-load-key
+`
+	err = os.WriteFile(filepath.Join(configDirPath, "extra.yaml"), []byte(additionalConfig), 0644)
+	require.NoError(t, err)
+
+	// Set environment variable to point directly to the config file
+	oldEnv := os.Getenv(EnvConfigPath)
+	os.Setenv(EnvConfigPath, mainConfigPath)
+	defer os.Setenv(EnvConfigPath, oldEnv)
+
+	// Load the config
+	config, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// Verify only the main config was loaded (config.d should be ignored)
+	assert.Equal(t, 1, config.GetClusterCount(), "Should only have clusters from main config")
+	assert.Equal(t, 1, config.GetIdentityCount(), "Should only have identities from main config")
+
+	// Verify the main cluster exists
+	mainCluster, err := config.GetCluster("main")
+	assert.NoError(t, err)
+	assert.Equal(t, "main.example.com", mainCluster.Hostname)
+
+	// Verify the config.d cluster was NOT loaded
+	_, err = config.GetCluster("should-not-load")
+	assert.Error(t, err, "Cluster from config.d should not be loaded")
+
+	// Verify the config.d identity was NOT loaded
+	_, err = config.GetIdentity("should-not-load-identity")
+	assert.Error(t, err, "Identity from config.d should not be loaded")
+}
+
+func TestMirenConfigAsDirectoryLoadsConfigD(t *testing.T) {
+	// Create a temporary directory structure
+	tmpDir := t.TempDir()
+
+	// Create main config file
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
+	mainConfig := `
+active_cluster: main
+clusters:
+  main:
+    hostname: main.example.com
+    ca_cert: main-ca
+identities:
+  main-identity:
+    type: keypair
+    issuer: main-issuer
+    private_key: main-key
+`
+	err := os.WriteFile(mainConfigPath, []byte(mainConfig), 0644)
+	require.NoError(t, err)
+
+	// Create config.d directory with additional configs
+	configDirPath := filepath.Join(tmpDir, "clientconfig.d")
+	err = os.MkdirAll(configDirPath, 0755)
+	require.NoError(t, err)
+
+	additionalConfig := `
+clusters:
+  from-config-d:
+    hostname: from-config-d.example.com
+    ca_cert: from-config-d-ca
+identities:
+  from-config-d-identity:
+    type: keypair
+    issuer: from-config-d-issuer
+    private_key: from-config-d-key
+`
+	err = os.WriteFile(filepath.Join(configDirPath, "extra.yaml"), []byte(additionalConfig), 0644)
+	require.NoError(t, err)
+
+	// Set environment variable to point to the directory
+	oldEnv := os.Getenv(EnvConfigPath)
+	os.Setenv(EnvConfigPath, tmpDir)
+	defer os.Setenv(EnvConfigPath, oldEnv)
+
+	// Load the config
+	config, err := LoadConfig()
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// Verify both main config and config.d were loaded
+	assert.Equal(t, 2, config.GetClusterCount(), "Should have clusters from both main and config.d")
+	assert.Equal(t, 2, config.GetIdentityCount(), "Should have identities from both main and config.d")
+
+	// Verify the main cluster exists
+	mainCluster, err := config.GetCluster("main")
+	assert.NoError(t, err)
+	assert.Equal(t, "main.example.com", mainCluster.Hostname)
+
+	// Verify the config.d cluster was loaded
+	configDCluster, err := config.GetCluster("from-config-d")
+	assert.NoError(t, err)
+	assert.Equal(t, "from-config-d.example.com", configDCluster.Hostname)
+
+	// Verify the config.d identity was loaded
+	configDIdentity, err := config.GetIdentity("from-config-d-identity")
+	assert.NoError(t, err)
+	assert.Equal(t, "from-config-d-issuer", configDIdentity.Issuer)
+}
+
+func TestMirenConfigPathResolution(t *testing.T) {
+	tests := []struct {
+		name           string
+		envPath        string
+		createAsFile   bool
+		createAsDir    bool
+		expectedIsFile bool
+	}{
+		{
+			name:           "yaml extension treated as file",
+			envPath:        "/tmp/test/config.yaml",
+			createAsFile:   false,
+			createAsDir:    false,
+			expectedIsFile: true,
+		},
+		{
+			name:           "yml extension treated as file",
+			envPath:        "/tmp/test/config.yml",
+			createAsFile:   false,
+			createAsDir:    false,
+			expectedIsFile: true,
+		},
+		{
+			name:           "existing file treated as file",
+			envPath:        "testconfig",
+			createAsFile:   true,
+			createAsDir:    false,
+			expectedIsFile: true,
+		},
+		{
+			name:           "existing directory treated as directory",
+			envPath:        "testdir",
+			createAsFile:   false,
+			createAsDir:    true,
+			expectedIsFile: false,
+		},
+		{
+			name:           "non-existent path without extension treated as directory",
+			envPath:        "/tmp/test/config",
+			createAsFile:   false,
+			createAsDir:    false,
+			expectedIsFile: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			testPath := filepath.Join(tmpDir, tt.envPath)
+
+			// Create file or directory if needed
+			if tt.createAsFile {
+				err := os.WriteFile(testPath, []byte("test"), 0644)
+				require.NoError(t, err)
+			} else if tt.createAsDir {
+				err := os.MkdirAll(testPath, 0755)
+				require.NoError(t, err)
+			}
+
+			// Set environment variable
+			oldEnv := os.Getenv(EnvConfigPath)
+			os.Setenv(EnvConfigPath, testPath)
+			defer os.Setenv(EnvConfigPath, oldEnv)
+
+			// Get the config path
+			configPath, err := getConfigPath()
+			require.NoError(t, err)
+
+			// Get the config dir path
+			configDirPath, err := getConfigDirPath()
+			require.NoError(t, err)
+
+			if tt.expectedIsFile {
+				// Should treat as file
+				assert.Equal(t, testPath, configPath, "Config path should be the file itself")
+				assert.Empty(t, configDirPath, "Config dir should be empty when MIREN_CONFIG is a file")
+			} else {
+				// Should treat as directory
+				assert.Equal(t, filepath.Join(testPath, "clientconfig.yaml"), configPath, "Config path should be within the directory")
+				assert.Equal(t, filepath.Join(testPath, "clientconfig.d"), configDirPath, "Config dir should be within the directory")
+			}
+		})
+	}
+}

--- a/clientconfig/clientconfig_modification_test.go
+++ b/clientconfig/clientconfig_modification_test.go
@@ -52,7 +52,7 @@ clusters:
 
 	// Set environment variable
 	oldEnv := os.Getenv(EnvConfigPath)
-	os.Setenv(EnvConfigPath, mainConfigPath)
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Setenv(EnvConfigPath, oldEnv)
 
 	// Load the config
@@ -132,7 +132,7 @@ clusters:
 
 	// Set environment variable
 	oldEnv := os.Getenv(EnvConfigPath)
-	os.Setenv(EnvConfigPath, mainConfigPath)
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Setenv(EnvConfigPath, oldEnv)
 
 	// Load the config
@@ -216,7 +216,7 @@ clusters:
 
 	// Set environment variable
 	oldEnv := os.Getenv(EnvConfigPath)
-	os.Setenv(EnvConfigPath, mainConfigPath)
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Setenv(EnvConfigPath, oldEnv)
 
 	// Load the config

--- a/clientconfig/clientconfig_save_test.go
+++ b/clientconfig/clientconfig_save_test.go
@@ -68,7 +68,7 @@ clusters:
 
 	// Set environment variable to use our test directory
 	oldEnv := os.Getenv(EnvConfigPath)
-	os.Setenv(EnvConfigPath, mainConfigPath)
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Setenv(EnvConfigPath, oldEnv)
 
 	// Load the config (this will merge clientconfig.d entries)
@@ -152,7 +152,7 @@ clusters:
 
 	// Set environment variable
 	oldEnv := os.Getenv(EnvConfigPath)
-	os.Setenv(EnvConfigPath, mainConfigPath)
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Setenv(EnvConfigPath, oldEnv)
 
 	// Load the config
@@ -220,9 +220,8 @@ clusters:
 	require.NoError(t, err)
 
 	// Set environment variable
-	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
 	oldEnv := os.Getenv(EnvConfigPath)
-	os.Setenv(EnvConfigPath, mainConfigPath)
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Setenv(EnvConfigPath, oldEnv)
 
 	// Load the config (should load from config.d only)
@@ -235,6 +234,7 @@ clusters:
 	require.NoError(t, err)
 
 	// Read back the saved config
+	mainConfigPath := filepath.Join(tmpDir, "clientconfig.yaml")
 	savedData, err := os.ReadFile(mainConfigPath)
 	require.NoError(t, err)
 

--- a/clientconfig/clientconfig_test.go
+++ b/clientconfig/clientconfig_test.go
@@ -80,15 +80,17 @@ func TestConfigPathResolution(t *testing.T) {
 	// Test environment variable path
 	testDir := "/tmp/test-config"
 	os.Setenv(EnvConfigPath, testDir)
-	path, err := getConfigPath()
+	path, loadConfigD, err := getConfigPath()
 	r.NoError(err)
 	r.Equal(filepath.Join(testDir, "clientconfig.yaml"), path)
+	r.True(loadConfigD, "Should load clientconfig.d when pointing to directory")
 	os.Unsetenv(EnvConfigPath)
 
 	// Test default path
 	homeDir, err := os.UserHomeDir()
 	r.NoError(err)
-	path, err = getConfigPath()
+	path, loadConfigD, err = getConfigPath()
 	r.NoError(err)
 	r.Equal(filepath.Join(homeDir, DefaultConfigPath), path)
+	r.True(loadConfigD, "Should load clientconfig.d by default")
 }

--- a/clientconfig/clientconfig_test.go
+++ b/clientconfig/clientconfig_test.go
@@ -17,8 +17,7 @@ func TestConfigLoadSave(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Set environment variable to use temporary directory
-	configPath := filepath.Join(tmpDir, "config.yaml")
-	os.Setenv(EnvConfigPath, configPath)
+	os.Setenv(EnvConfigPath, tmpDir)
 	defer os.Unsetenv(EnvConfigPath)
 
 	// Create test configuration
@@ -79,11 +78,11 @@ func TestConfigPathResolution(t *testing.T) {
 	r := require.New(t)
 
 	// Test environment variable path
-	testPath := "/tmp/test-config.yaml"
-	os.Setenv(EnvConfigPath, testPath)
+	testDir := "/tmp/test-config"
+	os.Setenv(EnvConfigPath, testDir)
 	path, err := getConfigPath()
 	r.NoError(err)
-	r.Equal(testPath, path)
+	r.Equal(filepath.Join(testDir, "clientconfig.yaml"), path)
 	os.Unsetenv(EnvConfigPath)
 
 	// Test default path


### PR DESCRIPTION
## Summary
- Automatically configures cluster connection during `miren login` when only one cluster is available
- Auto-selects identity in `miren config bind` when only one identity exists  
- Improves overall UX by reducing manual configuration steps

## Changes
- **Auto-configuration on login**: When a user logs in and has access to only one cluster, automatically set up the cluster connection without requiring manual `config bind`
- **Smart identity selection**: `config bind` now works without `--identity` flag when there's only one identity configured
- **Parallel connection attempts**: Cluster addresses are now tried in parallel for faster discovery
- **Code refactoring**: Extracted shared cluster connection logic into `tryConnectToCluster` helper to eliminate duplication between login and config bind
- **Better error handling**: Using proper sentinel errors (`ErrNoAutoConfigNeeded`, `ErrAutoConfigFailed`) instead of string comparison
- **New helper method**: Added `HasAnyClusters()` to clientconfig package

## Test Plan
- [x] Test `miren login` with single cluster - should auto-configure
- [x] Test `miren login` with multiple clusters - should list them
- [x] Test `miren login` with no clusters - should complete without error
- [x] Test `miren config bind` with single identity - should auto-select
- [x] Test `miren config bind` with multiple identities - should list them
- [x] Test parallel connection attempts work correctly
- [x] Verify error messages are clear and helpful

## Related
- Improves initial setup experience
- Reduces friction for new users
- Part of ongoing UX improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login can auto-configure a cluster when none are set, saving a working API address and its CA certificate.
  * Identity flag is now optional: auto-selects when only one identity exists; prompts appropriately for none or multiple.

* **Improvements**
  * More reliable cluster connection selection with concurrent probing, TLS/fingerprint validation, and localhost fallback.
  * Config loading supports per-directory overrides (clientconfig.d); MIREN_CONFIG now distinguishes file vs directory.

* **Tests**
  * Tests updated to cover directory-based config loading and path-resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->