### PR TITLE
Fix panic in app when there aren't cpu or memory samples

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -393,7 +393,10 @@ func (m Model) View() string {
 	)
 
 	if !m.graph {
-		cpuSamples := m.status.CpuOverHour()[len(m.status.CpuOverHour())-5:]
+		cpuSamples := m.status.CpuOverHour()
+		if len(cpuSamples) > 5 {
+			cpuSamples = cpuSamples[len(m.status.CpuOverHour())-5:]
+		}
 
 		var lines []string
 
@@ -403,7 +406,10 @@ func (m Model) View() string {
 			lines = append(lines, fmt.Sprintf("%s: %.3f", t.Format(of), s.Cores()))
 		}
 
-		memSamples := m.status.MemoryOverHour()[len(m.status.MemoryOverHour())-5:]
+		memSamples := m.status.MemoryOverHour()
+		if len(memSamples) > 5 {
+			memSamples = memSamples[len(m.status.MemoryOverHour())-5:]
+		}
 
 		var memlines []string
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors when fewer than five CPU or memory data points are available in non-graph output.
  * Ensures up to five most recent CPU and memory samples are displayed reliably.
  * No changes to graph views or RPS/HTTP sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->