### PR TITLE
Print the name of the cluster being deployed to

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/progress/progresswriter"
 
@@ -27,6 +28,9 @@ func Deploy(ctx *Context, opts struct {
 	Explain       bool   `short:"x" long:"explain" description:"Explain the build process"`
 	ExplainFormat string `long:"explain-format" description:"Explain format" choice:"auto" choice:"plain" choice:"tty" choice:"rawjson" default:"auto"`
 }) error {
+	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+	ctx.Printf("  ✓ %s: %s\n", greenStyle.Render("Deploying to cluster"), ctx.ClusterName)
+
 	cl, err := ctx.RPCClient("dev.miren.runtime/build")
 	if err != nil {
 		return err

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -46,6 +46,7 @@ type Context struct {
 
 	ClientConfig  *clientconfig.Config
 	ClusterConfig *clientconfig.ClusterConfig
+	ClusterName   string
 
 	Config struct {
 		ServerAddress string `asm:"server-addr"`
@@ -118,11 +119,12 @@ func setup(ctx context.Context, flags *GlobalFlags, opts any) *Context {
 	}
 
 	if lc, ok := opts.(interface {
-		LoadCluster() (*clientconfig.ClusterConfig, error)
+		LoadCluster() (*clientconfig.ClusterConfig, string, error)
 	}); ok {
-		cfg, err := lc.LoadCluster()
+		cfg, name, err := lc.LoadCluster()
 		if err == nil {
 			s.ClusterConfig = cfg
+			s.ClusterName = name
 		} else {
 			s.Log.Warn("Failed to load cluster config", "error", err)
 		}


### PR DESCRIPTION
Deploy is a big operation, and so we should be clear where the deploying is coming to.

A user mistakenly had the local cluster as the active one and was deploying to it and confused why the deploy wasn't going to the correct cluster. This gives them some feedback to be able to solve that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deploy now displays the target cluster (colorized, with a checkmark) before starting, so you see the deployment destination up front.
  * CLI captures and exposes the resolved cluster name in the command context for clearer status and flows.

* **User-facing Behavior**
  * If no cluster is specified and no active cluster is set, the command now reports an error instead of proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->