### PR TITLE
Improve CLI output with consistent table formatting and JSON support

### DIFF
--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -188,6 +188,6 @@ func ConfigInfo(ctx *Context, opts struct {
 		ui.WithRows(rows),
 	)
 
-	fmt.Println(table.Render())
+	ctx.Printf("%s\n", table.Render())
 	return nil
 }

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -251,7 +251,7 @@ func EnvList(ctx *Context, opts struct {
 
 	if !cfg.HasEnvVars() {
 		if opts.IsJSON() {
-			return PrintJSON([]interface{}{})
+			return PrintJSON([]any{})
 		}
 		ctx.Printf("No environment variables set\n")
 		return nil

--- a/cli/commands/format.go
+++ b/cli/commands/format.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // FormatOptions provides common output formatting options
@@ -10,9 +11,9 @@ type FormatOptions struct {
 	Format string `long:"format" description:"Output format (table, json)" default:"table"`
 }
 
-// IsJSON returns true if JSON format is selected
+// IsJSON returns true if JSON format is selected (case-insensitive)
 func (f *FormatOptions) IsJSON() bool {
-	return f.Format == "json"
+	return strings.EqualFold(f.Format, "json")
 }
 
 // PrintJSONStdout prints data as formatted JSON to stdout

--- a/cli/commands/format.go
+++ b/cli/commands/format.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// FormatOptions provides common output formatting options
+type FormatOptions struct {
+	Format string `long:"format" description:"Output format (table, json)" default:"table"`
+}
+
+// IsJSON returns true if JSON format is selected
+func (f *FormatOptions) IsJSON() bool {
+	return f.Format == "json"
+}
+
+// PrintJSONStdout prints data as formatted JSON to stdout
+func PrintJSON(data interface{}) error {
+	output, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(output))
+	return nil
+}

--- a/cli/commands/format.go
+++ b/cli/commands/format.go
@@ -2,7 +2,8 @@ package commands
 
 import (
 	"encoding/json"
-	"fmt"
+	"io"
+	"os"
 	"strings"
 )
 
@@ -16,12 +17,15 @@ func (f *FormatOptions) IsJSON() bool {
 	return strings.EqualFold(f.Format, "json")
 }
 
-// PrintJSONStdout prints data as formatted JSON to stdout
-func PrintJSON(data interface{}) error {
-	output, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return err
-	}
-	fmt.Println(string(output))
-	return nil
+// PrintJSON prints data as formatted JSON to stdout
+func PrintJSON(data any) error {
+	return PrintJSONTo(os.Stdout, data)
+}
+
+// PrintJSONTo prints JSON to the given writer with pretty formatting.
+func PrintJSONTo(w io.Writer, data any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	return enc.Encode(data)
 }

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -33,14 +33,6 @@ func SandboxList(ctx *Context, opts struct {
 		return err
 	}
 
-	if len(res.Values()) == 0 {
-		if opts.IsJSON() {
-			return PrintJSON([]interface{}{})
-		}
-		ctx.Printf("No sandboxes found\n")
-		return nil
-	}
-
 	// For JSON output, just filter and return the raw sandbox structs
 	if opts.IsJSON() {
 		var sandboxes []compute_v1alpha.Sandbox
@@ -67,7 +59,6 @@ func SandboxList(ctx *Context, opts struct {
 	// Table output - all the UI formatting logic
 	var rows []ui.Row
 	headers := []string{"ID", "STATUS", "VERSION", "CONTAINERS", "CREATED", "UPDATED"}
-	hasResults := false
 
 	for _, e := range res.Values() {
 		// Decode the sandbox entity
@@ -88,8 +79,6 @@ func SandboxList(ctx *Context, opts struct {
 			continue
 		}
 
-		hasResults = true
-
 		// Apply all UI formatting for table display
 		rows = append(rows, ui.Row{
 			ui.CleanEntityID(sandbox.ID.String()),
@@ -101,9 +90,8 @@ func SandboxList(ctx *Context, opts struct {
 		})
 	}
 
-	// If no results after filtering
-	if !hasResults {
-		ctx.Printf("No sandboxes found matching criteria\n")
+	if len(rows) == 0 {
+		ctx.Printf("No sandboxes found\n")
 		return nil
 	}
 

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -114,7 +114,7 @@ func SandboxList(ctx *Context, opts struct {
 		ui.WithRows(rows),
 	)
 
-	fmt.Println(table.Render())
+	ctx.Printf("%s\n", table.Render())
 	return nil
 }
 

--- a/pkg/ui/entity.go
+++ b/pkg/ui/entity.go
@@ -1,0 +1,52 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// CleanEntityID removes common entity type prefixes from entity IDs for cleaner display.
+// For example: "sandbox/sb-ABC123" -> "sb-ABC123", "app_version/meet-vXYZ" -> "meet-vXYZ"
+func CleanEntityID(id string) string {
+	// Common entity prefixes to remove
+	prefixes := []string{
+		"sandbox/",
+		"app_version/",
+		"app/",
+	}
+
+	cleaned := id
+	for _, prefix := range prefixes {
+		if after, ok := strings.CutPrefix(cleaned, prefix); ok {
+			cleaned = after
+			break // Only remove the first matching prefix
+		}
+	}
+
+	return cleaned
+}
+
+// DisplayAppVersion formats an app version string by removing prefixes and bolding the app name.
+// For example: "app_version/meet-vXYZ123" -> "**meet**-vXYZ123" (where **meet** is bold)
+func DisplayAppVersion(version string) string {
+	if version == "" || version == "-" {
+		return "-"
+	}
+
+	// First clean the entity ID prefix
+	cleaned := CleanEntityID(version)
+
+	// Find the hyphen that separates app name from version ID
+	parts := strings.SplitN(cleaned, "-", 2)
+	if len(parts) != 2 {
+		// No hyphen found, return as-is
+		return cleaned
+	}
+
+	// Bold the app name part
+	appName := lipgloss.NewStyle().Bold(true).Render(parts[0])
+
+	// Reconstruct with bold app name
+	return appName + "-" + parts[1]
+}

--- a/pkg/ui/status.go
+++ b/pkg/ui/status.go
@@ -1,0 +1,35 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// DisplayStatus returns a colored version of the status string based on common status values.
+// It also removes the "status." prefix if present.
+func DisplayStatus(status string) string {
+	// Remove "status." prefix if present
+	status = strings.TrimPrefix(status, "status.")
+
+	// Apply color based on status value
+	switch status {
+	case "dead", "failed", "error":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render(status) // gray
+	case "running", "active", "healthy", "ready":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Render(status) // green
+	case "stopped", "inactive", "unhealthy", "not_ready":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(status) // red
+	case "pending", "starting", "waiting", "creating":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Render(status) // blue
+	case "paused", "suspended":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render(status) // yellow
+	default:
+		return status // no color for unknown/other statuses
+	}
+}
+
+// CleanStatus removes the "status." prefix from a status string without applying color.
+func CleanStatus(status string) string {
+	return strings.TrimPrefix(status, "status.")
+}


### PR DESCRIPTION
## Summary
- Uses our new table UI control for consistent, styled output across CLI commands
- Adds JSON output format support via `--format` flag for programmatic use
- Improves visual presentation with colors, bold text, and cleaner formatting

## Changes

### Display Utilities (`pkg/ui/`)
- `DisplayStatus()`: Colors status values (green=running, red=stopped, gray=dead, blue=pending)
- `DisplayAppVersion()`: Bolds app names and removes entity prefixes
- `CleanEntityID()`: Removes redundant entity type prefixes (sandbox/, app_version/, etc.)

### Commands Updated

#### `sandbox list`
- Migrated from tabwriter to new table UI
- Status values colored and "status." prefix removed
- App versions show bold app names
- Entity ID prefixes cleaned for readability
- JSON format returns raw `compute_v1alpha.Sandbox` structs

#### `config info` 
- Now uses table UI with ADDRESS column (renamed from HOSTNAME)
- Port portion of addresses colored gray for visual hierarchy
- Added IDENTITY column to show authentication info
- JSON format returns structured cluster data with active flag

#### `env list`
- Already used table UI, now supports JSON output
- JSON excludes sensitive values for security
- Maintains gray dots for sensitive values in table view

### Format Flag
- All list commands now support `--format` flag (defaults to "table")
- `--format json` returns structured data for programmatic use
- Clean separation between UI formatting and data output

## Test Plan
- [x] Test `miren sandbox list` displays styled table
- [x] Test `miren sandbox list --format json` returns valid JSON
- [x] Test `miren config info` shows clusters with gray ports
- [x] Test `miren config info --format json` returns structured data
- [x] Test `miren env list --format json` excludes sensitive values
- [ ] Verify terminal width handling with narrow terminals
- [ ] Test status filtering still works: `miren sandbox list -s running`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global --format option (table|json); JSON output for clusters, env vars, and sandboxes with structured fields and empty arrays when none.
  * Env JSON omits values for sensitive variables.

* **Enhancements**
  * Sandbox list supports normalized status filtering and shows “No sandboxes found matching criteria” for no results.
  * Improved table auto-sizing, colorized statuses and address ports, active cluster marked with a leading star.
  * Empty identities render as “-”; app names in versions are emphasized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->