### PR TITLE
feat: implement hot restart upgrade mechanism for miren

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -140,6 +140,18 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("download release", "Download and extract miren release", DownloadRelease), nil
 		},
 
+		"upgrade": func() (cli.Command, error) {
+			return Infer("upgrade", "Perform hot restart upgrade of miren server", UpgradeLocal), nil
+		},
+
+		"upgrade-status": func() (cli.Command, error) {
+			return Infer("upgrade-status", "Check status of ongoing upgrade", UpgradeStatus), nil
+		},
+
+		"upgrade-rollback": func() (cli.Command, error) {
+			return Infer("upgrade-rollback", "Rollback failed upgrade", UpgradeRollback), nil
+		},
+
 		"auth generate": func() (cli.Command, error) {
 			return Infer("auth generate", "Generate authentication config file", AuthGenerate), nil
 		},

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -197,7 +197,11 @@ func Server(ctx *Context, opts struct {
 
 		// Wait for ports to be free before starting services
 		ctx.Log.Info("waiting for ports to become available")
-		if err := waitForPortsFree(ctx, []string{opts.Address, opts.RunnerAddress, ":8989"}, 30*time.Second); err != nil {
+		ports := []string{opts.Address, opts.RunnerAddress, ":8989", ":5000"}
+		if opts.StandardTLS {
+			ports = append(ports, ":80", ":443")
+		}
+		if err := waitForPortsFree(ctx, ports, 30*time.Second); err != nil {
 			return fmt.Errorf("failed waiting for ports to be free: %w", err)
 		}
 	}
@@ -773,7 +777,7 @@ func Server(ctx *Context, opts struct {
 		resolvedClickHouseAddr = opts.ClickHouseAddress
 	}
 
-	upgradeServer := upgradeserver.NewServer(ctx.Log, opts.DataPath)
+	upgradeServer := upgradeserver.NewServerWithCoordinator(ctx.Log, upgradeCoordinator)
 	upgradeServer.SetServerState(
 		resolvedContainerdSocket,
 		opts.EtcdEndpoints,

--- a/cli/commands/upgrade.go
+++ b/cli/commands/upgrade.go
@@ -1,0 +1,183 @@
+//go:build ignore
+// +build ignore
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"miren.dev/runtime/components/upgrade"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+// Upgrade performs a hot restart upgrade of the miren server
+func Upgrade(ctx *Context, opts struct {
+	BinaryPath string `short:"b" long:"binary" description:"Path to new miren binary (defaults to latest downloaded release)"`
+	Force      bool   `short:"f" long:"force" description:"Force upgrade even if versions match"`
+	Timeout    int    `short:"t" long:"timeout" description:"Timeout in seconds for upgrade" default:"60"`
+}) error {
+	// Determine the binary path
+	if opts.BinaryPath == "" {
+		// Check for downloaded release in standard locations
+		locations := []string{
+			"/var/lib/miren/release.new/miren",
+			"/var/lib/miren/release/miren",
+			filepath.Join(os.Getenv("HOME"), ".miren/release/miren"),
+		}
+
+		for _, loc := range locations {
+			if info, err := os.Stat(loc); err == nil && !info.IsDir() {
+				opts.BinaryPath = loc
+				break
+			}
+		}
+
+		if opts.BinaryPath == "" {
+			return fmt.Errorf("no miren binary specified and no release found in standard locations")
+		}
+	}
+
+	// Verify the binary exists and is executable
+	info, err := os.Stat(opts.BinaryPath)
+	if err != nil {
+		return fmt.Errorf("binary not found at %s: %w", opts.BinaryPath, err)
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("specified path %s is a directory, not a binary", opts.BinaryPath)
+	}
+
+	if info.Mode()&0111 == 0 {
+		return fmt.Errorf("binary at %s is not executable", opts.BinaryPath)
+	}
+
+	ctx.Log.Info("using binary for upgrade", "path", opts.BinaryPath)
+
+	// Connect to the running miren server
+	var client rpc.ServerUpgradeClient
+	if err := ctx.Client.Resolve(&client); err != nil {
+		return fmt.Errorf("failed to connect to miren server: %w", err)
+	}
+
+	// Get current server version
+	currentVersion, err := client.GetVersion(ctx)
+	if err != nil {
+		ctx.Log.Warn("failed to get current server version", "error", err)
+		currentVersion = "unknown"
+	}
+
+	// Get new binary version
+	newVersion, err := getVersionFromBinary(opts.BinaryPath)
+	if err != nil {
+		ctx.Log.Warn("failed to get version from new binary", "error", err)
+		newVersion = "unknown"
+	}
+
+	ctx.UILog.Info("preparing upgrade",
+		"current_version", currentVersion,
+		"new_version", newVersion,
+		"binary", opts.BinaryPath)
+
+	// Check if versions match (unless forced)
+	if !opts.Force && currentVersion == newVersion && currentVersion != "unknown" {
+		return fmt.Errorf("current and new versions are the same (%s), use --force to upgrade anyway", currentVersion)
+	}
+
+	// Initiate the upgrade
+	upgradeCtx, cancel := context.WithTimeout(ctx, time.Duration(opts.Timeout)*time.Second)
+	defer cancel()
+
+	ctx.UILog.Info("initiating hot restart upgrade...")
+
+	request := &rpc.UpgradeRequest{
+		NewBinaryPath: opts.BinaryPath,
+		Force:         opts.Force,
+	}
+
+	result, err := client.InitiateUpgrade(upgradeCtx, request)
+	if err != nil {
+		return fmt.Errorf("upgrade failed: %w", err)
+	}
+
+	if !result.Success {
+		return fmt.Errorf("upgrade failed: %s", result.Message)
+	}
+
+	ctx.UILog.Info("upgrade completed successfully", "message", result.Message)
+	return nil
+}
+
+// UpgradeStatus checks the status of an ongoing upgrade
+func UpgradeStatus(ctx *Context, opts struct{}) error {
+	// Check for upgrade state file
+	dataPath := "/var/lib/miren"
+	if envPath := os.Getenv("MIREN_DATA_PATH"); envPath != "" {
+		dataPath = envPath
+	}
+
+	coordinator := upgrade.NewCoordinator(ctx.Log, dataPath)
+	state, err := coordinator.LoadHandoffState()
+	if err != nil {
+		return fmt.Errorf("failed to load upgrade state: %w", err)
+	}
+
+	if state == nil {
+		ctx.UILog.Info("no upgrade in progress")
+		return nil
+	}
+
+	ctx.UILog.Info("upgrade in progress",
+		"started", state.Timestamp.Format(time.RFC3339),
+		"old_pid", state.OldPID,
+		"mode", state.Mode)
+
+	// Check if old process is still running
+	if processExists(state.OldPID) {
+		ctx.UILog.Info("old process still running", "pid", state.OldPID)
+	} else {
+		ctx.UILog.Info("old process has exited", "pid", state.OldPID)
+	}
+
+	return nil
+}
+
+// UpgradeRollback rolls back a failed upgrade
+func UpgradeRollback(ctx *Context, opts struct{}) error {
+	dataPath := "/var/lib/miren"
+	if envPath := os.Getenv("MIREN_DATA_PATH"); envPath != "" {
+		dataPath = envPath
+	}
+
+	coordinator := upgrade.NewCoordinator(ctx.Log, dataPath)
+	if err := coordinator.ClearHandoffState(); err != nil {
+		return fmt.Errorf("failed to clear upgrade state: %w", err)
+	}
+
+	ctx.UILog.Info("upgrade state cleared")
+	return nil
+}
+
+// getVersionFromBinary executes the binary with --version flag to get its version
+func getVersionFromBinary(binaryPath string) (string, error) {
+	cmd := exec.Command(binaryPath, "version")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+// processExists checks if a process with the given PID exists
+func processExists(pid int) bool {
+	// Send signal 0 to check if process exists
+	err := syscall.Kill(pid, 0)
+	return err == nil
+}

--- a/cli/commands/upgrade_darwin.go
+++ b/cli/commands/upgrade_darwin.go
@@ -1,0 +1,68 @@
+//go:build darwin
+// +build darwin
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+
+	"miren.dev/runtime/components/upgrade"
+)
+
+// UpgradeLocal performs a local hot restart upgrade without RPC
+func UpgradeLocal(ctx *Context, opts struct {
+	BinaryPath string `short:"b" long:"binary" description:"Path to new miren binary"`
+	DataPath   string `short:"d" long:"data-path" description:"Data path" default:"/var/lib/miren"`
+	PID        int    `short:"p" long:"pid" description:"PID of running miren server (auto-detected if not specified)"`
+	Force      bool   `short:"f" long:"force" description:"Force upgrade even if versions match"`
+	Timeout    int    `short:"t" long:"timeout" description:"Timeout in seconds" default:"60"`
+}) error {
+	return fmt.Errorf("hot restart upgrade is not yet supported on %s", runtime.GOOS)
+}
+
+// UpgradeStatus checks the status of an ongoing upgrade
+func UpgradeStatus(ctx *Context, opts struct{}) error {
+	// Check for upgrade state file
+	dataPath := "/var/lib/miren"
+	if envPath := os.Getenv("MIREN_DATA_PATH"); envPath != "" {
+		dataPath = envPath
+	}
+
+	coordinator := upgrade.NewCoordinator(ctx.Log, dataPath)
+	state, err := coordinator.LoadHandoffState()
+	if err != nil {
+		return fmt.Errorf("failed to load upgrade state: %w", err)
+	}
+
+	if state == nil {
+		ctx.UILog.Info("no upgrade in progress")
+		return nil
+	}
+
+	// On Darwin, we shouldn't have any upgrade state, but if we do, show it
+	ctx.UILog.Warn("unexpected upgrade state found on Darwin",
+		"started", state.Timestamp.Format(time.RFC3339),
+		"old_pid", state.OldPID,
+		"mode", state.Mode)
+
+	return nil
+}
+
+// UpgradeRollback rolls back a failed upgrade
+func UpgradeRollback(ctx *Context, opts struct{}) error {
+	dataPath := "/var/lib/miren"
+	if envPath := os.Getenv("MIREN_DATA_PATH"); envPath != "" {
+		dataPath = envPath
+	}
+
+	coordinator := upgrade.NewCoordinator(ctx.Log, dataPath)
+	if err := coordinator.ClearHandoffState(); err != nil {
+		return fmt.Errorf("failed to clear upgrade state: %w", err)
+	}
+
+	ctx.UILog.Info("upgrade state cleared")
+	return nil
+}

--- a/cli/commands/upgrade_linux.go
+++ b/cli/commands/upgrade_linux.go
@@ -1,0 +1,334 @@
+//go:build linux
+// +build linux
+
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"miren.dev/runtime/components/upgrade"
+)
+
+// UpgradeLocal performs a local hot restart upgrade without RPC
+func UpgradeLocal(ctx *Context, opts struct {
+	BinaryPath string `short:"b" long:"binary" description:"Path to new miren binary"`
+	DataPath   string `short:"d" long:"data-path" description:"Data path" default:"/var/lib/miren"`
+	PID        int    `short:"p" long:"pid" description:"PID of running miren server (auto-detected if not specified)"`
+	Force      bool   `short:"f" long:"force" description:"Force upgrade even if versions match"`
+	Timeout    int    `short:"t" long:"timeout" description:"Timeout in seconds" default:"60"`
+}) error {
+	// Auto-detect the new binary path if not specified
+	if opts.BinaryPath == "" {
+		// First check for .new binary
+		newBinary := filepath.Join(opts.DataPath, "release.new", "miren")
+		if info, err := os.Stat(newBinary); err == nil && !info.IsDir() {
+			opts.BinaryPath = newBinary
+			ctx.Log.Info("found new release binary", "path", newBinary)
+		} else {
+			// Check standard release locations
+			locations := []string{
+				filepath.Join(opts.DataPath, "release", "miren"),
+				filepath.Join(os.Getenv("HOME"), ".miren/release/miren"),
+			}
+
+			for _, loc := range locations {
+				if info, err := os.Stat(loc); err == nil && !info.IsDir() {
+					opts.BinaryPath = loc
+					break
+				}
+			}
+		}
+
+		if opts.BinaryPath == "" {
+			return fmt.Errorf("no new miren binary found, please download a release first or specify --binary")
+		}
+	}
+
+	// Verify the binary exists and is executable
+	info, err := os.Stat(opts.BinaryPath)
+	if err != nil {
+		return fmt.Errorf("binary not found at %s: %w", opts.BinaryPath, err)
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("specified path %s is a directory, not a binary", opts.BinaryPath)
+	}
+
+	if info.Mode()&0111 == 0 {
+		return fmt.Errorf("binary at %s is not executable", opts.BinaryPath)
+	}
+
+	// Auto-detect the running miren server PID if not specified
+	if opts.PID == 0 {
+		pid, err := findMirenServerPID()
+		if err != nil {
+			return fmt.Errorf("failed to find running miren server: %w", err)
+		}
+		opts.PID = pid
+		ctx.Log.Info("found miren server", "pid", pid)
+	}
+
+	// Verify the process exists
+	if err := syscall.Kill(opts.PID, 0); err != nil {
+		return fmt.Errorf("process with PID %d does not exist or is not accessible: %w", opts.PID, err)
+	}
+
+	// Get current version
+	currentVersion := "unknown"
+	if currentBinary, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", opts.PID)); err == nil {
+		if ver, err := getVersionFromBinary(currentBinary); err == nil {
+			currentVersion = ver
+		}
+	}
+
+	// Get new version
+	newVersion, err := getVersionFromBinary(opts.BinaryPath)
+	if err != nil {
+		ctx.Log.Warn("failed to get version from new binary", "error", err)
+		newVersion = "unknown"
+	}
+
+	ctx.UILog.Info("preparing local upgrade",
+		"current_version", currentVersion,
+		"new_version", newVersion,
+		"current_pid", opts.PID,
+		"new_binary", opts.BinaryPath)
+
+	// Check if versions match (unless forced)
+	if !opts.Force && currentVersion == newVersion && currentVersion != "unknown" {
+		return fmt.Errorf("current and new versions are the same (%s), use --force to upgrade anyway", currentVersion)
+	}
+
+	if upgrade.IsRunningUnderSystemd() {
+		ctx.Log.Info("detected systemd supervision, will notify systemd during upgrade")
+	}
+
+	// Load the current server's handoff state if it exists
+	coordinator := upgrade.NewCoordinator(ctx.Log, opts.DataPath)
+	existingState, err := coordinator.LoadHandoffState()
+	if err != nil {
+		ctx.Log.Warn("failed to load existing handoff state", "error", err)
+	}
+
+	if existingState != nil {
+		ctx.Log.Info("found existing handoff state, using it",
+			"timestamp", existingState.Timestamp,
+			"old_pid", existingState.OldPID)
+	} else {
+		// No handoff state found - fail fast
+		return fmt.Errorf("no handoff state found - the running server must initiate the upgrade first")
+	}
+
+	ctx.UILog.Info("initiating hot restart upgrade...")
+
+	// Launch the new process with takeover flag
+	args := []string{
+		"server",
+		"--takeover",
+		"--mode", existingState.Mode,
+		"--data-path", existingState.DataPath,
+		"--address", existingState.ServerAddress,
+		"--runner-address", existingState.RunnerAddress,
+		"--runner-id", existingState.RunnerID,
+	}
+
+	// Add etcd endpoints if present
+	for _, endpoint := range existingState.EtcdEndpoints {
+		args = append(args, "--etcd", endpoint)
+	}
+
+	// Add containerd socket if present
+	if existingState.ContainerdSocket != "" {
+		args = append(args, "--containerd-socket", existingState.ContainerdSocket)
+	}
+
+	// Add ClickHouse address if present
+	if existingState.ClickHouseAddress != "" {
+		args = append(args, "--clickhouse-addr", existingState.ClickHouseAddress)
+	}
+
+	cmd := exec.Command(opts.BinaryPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	// Set process attributes to create new process group
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+		Pgid:    0,
+	}
+
+	ctx.Log.Info("starting new miren process", "command", opts.BinaryPath, "args", args)
+
+	// Start the new process
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start new process: %w", err)
+	}
+
+	ctx.UILog.Info("new process started", "pid", cmd.Process.Pid)
+
+	// Wait for the new process to be ready (monitor its output or wait for signal)
+	timeout := time.After(time.Duration(opts.Timeout) * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			// NOTE: We intentionally kill only the child process, not the process group.
+			// This preserves child processes like containerd that should continue running
+			// even if the upgrade times out. The child processes will be orphaned and
+			// reparented to init, but this is preferable to killing critical services.
+			if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+				ctx.Log.Warn("failed to kill new process on timeout", "error", err)
+			}
+			return fmt.Errorf("timeout waiting for new process to be ready")
+
+		case <-ticker.C:
+			// First check if the new process is still running
+			if err := syscall.Kill(cmd.Process.Pid, 0); err != nil {
+				// New process died, upgrade failed
+				// Clear the upgrade state to avoid leaving the system in an "upgrading" state
+				if cleanupErr := coordinator.ClearHandoffState(); cleanupErr != nil {
+					ctx.Log.Warn("failed to clear upgrade state after process failure", "error", cleanupErr)
+				}
+				return fmt.Errorf("new process exited unexpectedly")
+			}
+
+			// Check if the old process has exited (which means handoff completed)
+			err := syscall.Kill(opts.PID, 0)
+			if err == nil {
+				// Process still exists, continue waiting
+				continue
+			} else if errors.Is(err, syscall.ESRCH) {
+				// Old process has exited (No such process), upgrade successful
+				ctx.UILog.Info("upgrade completed successfully",
+					"old_pid", opts.PID,
+					"new_pid", cmd.Process.Pid)
+
+				// Clear the handoff state
+				if err := coordinator.ClearHandoffState(); err != nil {
+					ctx.Log.Warn("failed to clear handoff state", "error", err)
+				}
+
+				// If there's a release.new directory, move it to release
+				newReleaseDir := filepath.Join(opts.DataPath, "release.new")
+				releaseDir := filepath.Join(opts.DataPath, "release")
+				if _, err := os.Stat(newReleaseDir); err == nil {
+					// Backup old release
+					if _, err := os.Stat(releaseDir); err == nil {
+						backupDir := filepath.Join(opts.DataPath, fmt.Sprintf("release.backup.%d", time.Now().Unix()))
+						os.Rename(releaseDir, backupDir)
+						ctx.Log.Info("backed up old release", "backup", backupDir)
+					}
+					// Move new release to active
+					if err := os.Rename(newReleaseDir, releaseDir); err != nil {
+						ctx.Log.Warn("failed to move release.new to release", "error", err)
+					} else {
+						ctx.Log.Info("activated new release", "path", releaseDir)
+					}
+				}
+
+				return nil
+			} else if errors.Is(err, syscall.EPERM) {
+				// Permission denied - old process exists but we can't signal it
+				ctx.Log.Error("permission denied checking old process status", "pid", opts.PID)
+				return fmt.Errorf("permission denied checking old process (PID %d) - upgrade cannot proceed", opts.PID)
+			} else {
+				// Other error checking old process
+				ctx.Log.Error("unexpected error checking old process status", "pid", opts.PID, "error", err)
+				return fmt.Errorf("failed to check old process status: %w", err)
+			}
+		}
+	}
+}
+
+// findMirenServerPID finds the PID of a running miren server process
+func findMirenServerPID() (int, error) {
+	// Look for miren server process
+	output, err := exec.Command("pgrep", "-f", "miren server").Output()
+	if err != nil {
+		return 0, fmt.Errorf("no miren server process found")
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(lines) == 0 {
+		return 0, fmt.Errorf("no miren server process found")
+	}
+
+	// Parse the first PID
+	var pid int
+	if _, err := fmt.Sscanf(lines[0], "%d", &pid); err != nil {
+		return 0, fmt.Errorf("failed to parse PID: %w", err)
+	}
+
+	return pid, nil
+}
+
+// getVersionFromBinary executes the binary with version flag to get its version
+func getVersionFromBinary(binaryPath string) (string, error) {
+	cmd := exec.Command(binaryPath, "version")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+// UpgradeStatus checks the status of an ongoing upgrade
+func UpgradeStatus(ctx *Context, opts struct{}) error {
+	// Check for upgrade state file
+	dataPath := "/var/lib/miren"
+	if envPath := os.Getenv("MIREN_DATA_PATH"); envPath != "" {
+		dataPath = envPath
+	}
+
+	coordinator := upgrade.NewCoordinator(ctx.Log, dataPath)
+	state, err := coordinator.LoadHandoffState()
+	if err != nil {
+		return fmt.Errorf("failed to load upgrade state: %w", err)
+	}
+
+	if state == nil {
+		ctx.UILog.Info("no upgrade in progress")
+		return nil
+	}
+
+	ctx.UILog.Info("upgrade in progress",
+		"started", state.Timestamp.Format(time.RFC3339),
+		"old_pid", state.OldPID,
+		"mode", state.Mode)
+
+	// Check if old process is still running
+	if err := syscall.Kill(state.OldPID, 0); err == nil {
+		ctx.UILog.Info("old process still running", "pid", state.OldPID)
+	} else {
+		ctx.UILog.Info("old process has exited", "pid", state.OldPID)
+	}
+
+	return nil
+}
+
+// UpgradeRollback rolls back a failed upgrade
+func UpgradeRollback(ctx *Context, opts struct{}) error {
+	dataPath := "/var/lib/miren"
+	if envPath := os.Getenv("MIREN_DATA_PATH"); envPath != "" {
+		dataPath = envPath
+	}
+
+	coordinator := upgrade.NewCoordinator(ctx.Log, dataPath)
+	if err := coordinator.ClearHandoffState(); err != nil {
+		return fmt.Errorf("failed to clear upgrade state: %w", err)
+	}
+
+	ctx.UILog.Info("upgrade state cleared")
+	return nil
+}

--- a/components/upgrade/cgroup_manager_darwin.go
+++ b/components/upgrade/cgroup_manager_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+// +build darwin
+
+package upgrade
+
+// CgroupManager handles cgroup operations (stub for Darwin)
+type CgroupManager struct{}
+
+// NewCgroupManager creates a new cgroup manager (returns nil on Darwin)
+func NewCgroupManager() (*CgroupManager, error) {
+	// No cgroups on Darwin
+	return nil, nil
+}
+
+// AdoptProcess is a no-op on Darwin
+func (m *CgroupManager) AdoptProcess(pid int) error {
+	return nil
+}
+
+// AdoptChildProcesses is a no-op on Darwin
+func (m *CgroupManager) AdoptChildProcesses(parentPID int) error {
+	return nil
+}
+
+// FindContainerdPID is a no-op on Darwin
+func FindContainerdPID(socketPath string) (int, error) {
+	return 0, nil
+}

--- a/components/upgrade/cgroup_manager_darwin.go
+++ b/components/upgrade/cgroup_manager_darwin.go
@@ -6,10 +6,10 @@ package upgrade
 // CgroupManager handles cgroup operations (stub for Darwin)
 type CgroupManager struct{}
 
-// NewCgroupManager creates a new cgroup manager (returns nil on Darwin)
+// NewCgroupManager creates a new cgroup manager (returns no-op stub on Darwin)
 func NewCgroupManager() (*CgroupManager, error) {
-	// No cgroups on Darwin
-	return nil, nil
+	// No cgroups on Darwin; return a no-op stub
+	return &CgroupManager{}, nil
 }
 
 // AdoptProcess is a no-op on Darwin

--- a/components/upgrade/cgroup_manager_darwin.go
+++ b/components/upgrade/cgroup_manager_darwin.go
@@ -3,6 +3,8 @@
 
 package upgrade
 
+import "fmt"
+
 // CgroupManager handles cgroup operations (stub for Darwin)
 type CgroupManager struct{}
 
@@ -22,7 +24,7 @@ func (m *CgroupManager) AdoptChildProcesses(parentPID int) error {
 	return nil
 }
 
-// FindContainerdPID is a no-op on Darwin
+// FindContainerdPID returns an error on Darwin (cgroups not supported)
 func FindContainerdPID(socketPath string) (int, error) {
-	return 0, nil
+	return 0, fmt.Errorf("cgroup operations not supported on Darwin")
 }

--- a/components/upgrade/cgroup_manager_linux.go
+++ b/components/upgrade/cgroup_manager_linux.go
@@ -1,0 +1,263 @@
+//go:build linux
+// +build linux
+
+package upgrade
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// CgroupManager handles cgroup operations for process adoption
+type CgroupManager struct {
+	serviceCgroup string
+}
+
+// NewCgroupManager creates a new cgroup manager
+func NewCgroupManager() (*CgroupManager, error) {
+	// Detect our current cgroup
+	cgroup, err := getCurrentServiceCgroup()
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect service cgroup: %w", err)
+	}
+
+	if cgroup == "" {
+		return nil, fmt.Errorf("not running in a systemd service cgroup")
+	}
+
+	return &CgroupManager{
+		serviceCgroup: cgroup,
+	}, nil
+}
+
+// AdoptProcess moves a process (and its children) into our service cgroup
+func (m *CgroupManager) AdoptProcess(pid int) error {
+	// For cgroup v2 (unified hierarchy)
+	cgroupV2Path := filepath.Join("/sys/fs/cgroup", m.serviceCgroup, "cgroup.procs")
+	if err := m.writeToFile(cgroupV2Path, strconv.Itoa(pid)); err == nil {
+		return nil // Success with cgroup v2
+	}
+
+	// Fallback to cgroup v1 (legacy hierarchy)
+	// Try common controller paths
+	controllers := []string{"systemd", "cpu", "memory", "pids"}
+	var lastErr error
+	successCount := 0
+
+	for _, controller := range controllers {
+		cgroupV1Path := filepath.Join("/sys/fs/cgroup", controller, m.serviceCgroup, "cgroup.procs")
+		if err := m.writeToFile(cgroupV1Path, strconv.Itoa(pid)); err == nil {
+			successCount++
+		} else {
+			lastErr = err
+		}
+	}
+
+	if successCount > 0 {
+		return nil // At least some controllers succeeded
+	}
+
+	return fmt.Errorf("failed to adopt process %d: %w", pid, lastErr)
+}
+
+// AdoptChildProcesses finds and adopts all child processes of the given PID
+func (m *CgroupManager) AdoptChildProcesses(parentPID int) error {
+	children, err := findChildProcesses(parentPID)
+	if err != nil {
+		return fmt.Errorf("failed to find child processes: %w", err)
+	}
+
+	for _, childPID := range children {
+		if err := m.AdoptProcess(childPID); err != nil {
+			// Log but don't fail - some processes might have exited
+			fmt.Fprintf(os.Stderr, "warning: failed to adopt child process %d: %v\n", childPID, err)
+		}
+	}
+
+	// Also adopt the parent itself
+	return m.AdoptProcess(parentPID)
+}
+
+// writeToFile writes content to a file (helper for cgroup operations)
+func (m *CgroupManager) writeToFile(path, content string) error {
+	file, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(content)
+	return err
+}
+
+// getCurrentServiceCgroup detects the current process's systemd service cgroup
+func getCurrentServiceCgroup() (string, error) {
+	// Read /proc/self/cgroup
+	file, err := os.Open("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Format: ID:controllers:path
+		// Example: 0::/system.slice/miren.service
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+
+		cgroupPath := parts[2]
+
+		// Look for systemd service pattern
+		if strings.Contains(cgroupPath, ".service") {
+			// For cgroup v2, the path is the full path
+			if parts[0] == "0" && parts[1] == "" {
+				return cgroupPath, nil
+			}
+			// For cgroup v1 with systemd controller
+			if strings.Contains(parts[1], "systemd") {
+				return cgroupPath, nil
+			}
+		}
+	}
+
+	// If we didn't find it in the expected format, try another approach
+	// Check if we're in a service by looking for INVOCATION_ID
+	if os.Getenv("INVOCATION_ID") != "" {
+		// We're in a systemd service, try to construct the path
+		// This is a fallback and might not always work
+		serviceName := getServiceNameFromEnvironment()
+		if serviceName != "" {
+			return fmt.Sprintf("/system.slice/%s.service", serviceName), nil
+		}
+	}
+
+	return "", fmt.Errorf("not running in a systemd service")
+}
+
+// findChildProcesses finds all child processes of a given PID
+func findChildProcesses(parentPID int) ([]int, error) {
+	var children []int
+
+	// Read /proc to find children
+	procDir, err := os.Open("/proc")
+	if err != nil {
+		return nil, err
+	}
+	defer procDir.Close()
+
+	entries, err := procDir.Readdir(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	parentPIDStr := strconv.Itoa(parentPID)
+
+	for _, entry := range entries {
+		// Skip non-numeric directories
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+
+		// Read the stat file to get PPID
+		statPath := fmt.Sprintf("/proc/%d/stat", pid)
+		statData, err := os.ReadFile(statPath)
+		if err != nil {
+			continue // Process might have exited
+		}
+
+		// Parse PPID from stat file
+		// Format: pid (comm) state ppid ...
+		statStr := string(statData)
+		// Find the last ) to skip the command name which might contain spaces/parens
+		lastParen := strings.LastIndex(statStr, ")")
+		if lastParen == -1 {
+			continue
+		}
+
+		fields := strings.Fields(statStr[lastParen+1:])
+		if len(fields) < 2 {
+			continue
+		}
+
+		// fields[1] is PPID (fields[0] is state)
+		if fields[1] == parentPIDStr {
+			children = append(children, pid)
+			// Recursively find children of children
+			grandchildren, _ := findChildProcesses(pid)
+			children = append(children, grandchildren...)
+		}
+	}
+
+	return children, nil
+}
+
+// getServiceNameFromEnvironment tries to extract service name from environment
+func getServiceNameFromEnvironment() string {
+	// Try to get from systemd environment variables
+	// This is a heuristic and might not always work
+
+	// Check if we can read our own cmdline to find service name
+	cmdline, err := os.ReadFile("/proc/self/cmdline")
+	if err != nil {
+		return ""
+	}
+
+	// Look for common patterns in cmdline
+	cmdlineStr := string(cmdline)
+	if strings.Contains(cmdlineStr, "miren") {
+		return "miren"
+	}
+
+	return ""
+}
+
+// FindContainerdPID finds the PID of containerd by socket path
+func FindContainerdPID(socketPath string) (int, error) {
+	// Method 1: Check all processes for the socket path in their cmdline
+	procDir, err := os.Open("/proc")
+	if err != nil {
+		return 0, err
+	}
+	defer procDir.Close()
+
+	entries, err := procDir.Readdir(-1)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+
+		// Read cmdline
+		cmdlinePath := fmt.Sprintf("/proc/%d/cmdline", pid)
+		cmdline, err := os.ReadFile(cmdlinePath)
+		if err != nil {
+			continue
+		}
+
+		cmdlineStr := string(cmdline)
+		// Check if this is containerd with our socket
+		if strings.Contains(cmdlineStr, "containerd") &&
+			strings.Contains(cmdlineStr, socketPath) {
+			return pid, nil
+		}
+	}
+
+	// Method 2: Use lsof or ss to find process holding the socket
+	// (would require exec.Command which we're trying to avoid)
+
+	return 0, fmt.Errorf("containerd process not found for socket %s", socketPath)
+}

--- a/components/upgrade/cgroup_manager_linux.go
+++ b/components/upgrade/cgroup_manager_linux.go
@@ -90,6 +90,10 @@ func (m *CgroupManager) writeToFile(path, content string) error {
 	}
 	defer file.Close()
 
+	// Add newline for broader kernel compatibility
+	if !strings.HasSuffix(content, "\n") {
+		content = content + "\n"
+	}
 	_, err = file.WriteString(content)
 	return err
 }

--- a/components/upgrade/coordinator.go
+++ b/components/upgrade/coordinator.go
@@ -1,0 +1,356 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// HandoffState contains the state to be preserved during upgrade
+type HandoffState struct {
+	// Version of the handoff protocol
+	Version int `json:"version"`
+
+	// PID of the old process
+	OldPID int `json:"old_pid"`
+
+	// Timestamp of handoff initiation
+	Timestamp time.Time `json:"timestamp"`
+
+	// ContainerdSocket path for reconnection
+	ContainerdSocket string `json:"containerd_socket"`
+
+	// EtcdEndpoints for reconnection
+	EtcdEndpoints []string `json:"etcd_endpoints"`
+
+	// ClickHouseAddress if using external or embedded
+	ClickHouseAddress string `json:"clickhouse_address,omitempty"`
+
+	// ServerAddress that the server is listening on
+	ServerAddress string `json:"server_address"`
+
+	// RunnerAddress for the runner service
+	RunnerAddress string `json:"runner_address"`
+
+	// DataPath for persistent data
+	DataPath string `json:"data_path"`
+
+	// RunnerID for the runner
+	RunnerID string `json:"runner_id"`
+
+	// Mode of operation (standalone, distributed)
+	Mode string `json:"mode"`
+
+	// Additional custom state that components can add
+	CustomState map[string]interface{} `json:"custom_state,omitempty"`
+}
+
+// Coordinator manages the hot restart upgrade process
+type Coordinator struct {
+	log          *slog.Logger
+	dataPath     string
+	statePath    string
+	mu           sync.RWMutex
+	state        *HandoffState
+	upgrading    bool
+	readyChannel chan error
+	systemd      *SystemdNotifier
+}
+
+// NewCoordinator creates a new upgrade coordinator
+func NewCoordinator(log *slog.Logger, dataPath string) *Coordinator {
+	c := &Coordinator{
+		log:       log.With("component", "upgrade-coordinator"),
+		dataPath:  dataPath,
+		statePath: filepath.Join(dataPath, "upgrade-state.json"),
+		systemd:   NewSystemdNotifier(),
+	}
+
+	// Log systemd detection status
+	if c.systemd != nil {
+		c.log.Info("systemd supervision detected, will send status notifications")
+		// Check if we have notify socket (Type=notify)
+		if os.Getenv("NOTIFY_SOCKET") != "" {
+			c.log.Info("systemd Type=notify detected, PID changes will be notified")
+		} else {
+			c.log.Info("systemd detected but not Type=notify, some notifications will be skipped")
+		}
+	} else {
+		c.log.Debug("not running under systemd supervision")
+	}
+
+	return c
+}
+
+// IsUpgrading returns true if an upgrade is in progress
+func (c *Coordinator) IsUpgrading() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.upgrading
+}
+
+// LoadHandoffState loads a previously saved handoff state
+func (c *Coordinator) LoadHandoffState() (*HandoffState, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	data, err := os.ReadFile(c.statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // No state file, not an upgrade
+		}
+		return nil, fmt.Errorf("failed to read handoff state: %w", err)
+	}
+
+	var state HandoffState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal handoff state: %w", err)
+	}
+
+	// Check if state is stale (older than 5 minutes)
+	if time.Since(state.Timestamp) > 5*time.Minute {
+		c.log.Warn("handoff state is stale, ignoring", "age", time.Since(state.Timestamp))
+		if err := os.Remove(c.statePath); err != nil && !os.IsNotExist(err) {
+			c.log.Warn("failed to remove stale handoff state", "error", err)
+		}
+		return nil, nil
+	}
+
+	c.state = &state
+	return &state, nil
+}
+
+// SaveHandoffState saves the current state for handoff
+func (c *Coordinator) SaveHandoffState(state *HandoffState) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	const handoffVersion = 1
+	state.Version = handoffVersion
+	state.Timestamp = time.Now()
+	// Only set OldPID if not already set (preserve prefilled value)
+	if state.OldPID == 0 {
+		state.OldPID = os.Getpid()
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal handoff state: %w", err)
+	}
+
+	// Write atomically by writing to temp file and renaming
+	tempPath := c.statePath + ".tmp"
+	if err := os.WriteFile(tempPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write handoff state: %w", err)
+	}
+
+	if err := os.Rename(tempPath, c.statePath); err != nil {
+		return fmt.Errorf("failed to rename handoff state: %w", err)
+	}
+
+	c.state = state
+	c.log.Info("saved handoff state", "path", c.statePath)
+	return nil
+}
+
+// ClearHandoffState removes the handoff state file
+func (c *Coordinator) ClearHandoffState() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := os.Remove(c.statePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to clear handoff state: %w", err)
+	}
+
+	c.state = nil
+	return nil
+}
+
+// InitiateUpgrade starts the upgrade process by launching the new binary
+func (c *Coordinator) InitiateUpgrade(ctx context.Context, newBinaryPath string, state *HandoffState) error {
+	c.mu.Lock()
+	if c.upgrading {
+		c.mu.Unlock()
+		return fmt.Errorf("upgrade already in progress")
+	}
+	c.upgrading = true
+	c.readyChannel = make(chan error, 1)
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		c.upgrading = false
+		c.mu.Unlock()
+	}()
+
+	// Save the handoff state
+	if err := c.SaveHandoffState(state); err != nil {
+		return fmt.Errorf("failed to save handoff state: %w", err)
+	}
+
+	// Verify the new binary exists and is executable
+	info, err := os.Stat(newBinaryPath)
+	if err != nil {
+		return fmt.Errorf("new binary not found at %s: %w", newBinaryPath, err)
+	}
+
+	if info.Mode()&0111 == 0 {
+		return fmt.Errorf("new binary at %s is not executable", newBinaryPath)
+	}
+
+	c.log.Info("launching new miren process", "binary", newBinaryPath)
+
+	// Build the command for the new process
+	args := []string{
+		"server",
+		"--takeover",
+		"--mode", state.Mode,
+		"--data-path", state.DataPath,
+		"--address", state.ServerAddress,
+		"--runner-address", state.RunnerAddress,
+		"--runner-id", state.RunnerID,
+	}
+
+	// Add etcd endpoints if present
+	for _, endpoint := range state.EtcdEndpoints {
+		args = append(args, "--etcd", endpoint)
+	}
+
+	// Add containerd socket if present
+	if state.ContainerdSocket != "" {
+		args = append(args, "--containerd-socket", state.ContainerdSocket)
+	}
+
+	// Add ClickHouse address if present
+	if state.ClickHouseAddress != "" {
+		args = append(args, "--clickhouse-addr", state.ClickHouseAddress)
+	}
+
+	cmd := exec.Command(newBinaryPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	// Set process attributes to create new process group
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+		Pgid:    0,
+	}
+
+	// Start the new process
+	if err := cmd.Start(); err != nil {
+		c.ClearHandoffState()
+		return fmt.Errorf("failed to start new process: %w", err)
+	}
+
+	c.log.Info("new process started", "pid", cmd.Process.Pid)
+
+	// Wait for the new process to signal readiness or timeout
+	select {
+	case <-ctx.Done():
+		// Kill the process group to avoid stray children
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		c.ClearHandoffState()
+		return fmt.Errorf("upgrade cancelled: %w", ctx.Err())
+
+	case err := <-c.readyChannel:
+		if err != nil {
+			// Kill the process group to avoid stray children
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			c.ClearHandoffState()
+			return fmt.Errorf("new process failed to start: %w", err)
+		}
+
+		c.log.Info("new process signaled ready, initiating graceful shutdown")
+		// The new process is ready, we can now gracefully shutdown
+		return nil
+
+	case <-time.After(60 * time.Second):
+		// Kill the process group to avoid stray children
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		c.ClearHandoffState()
+		return fmt.Errorf("timeout waiting for new process to be ready")
+	}
+}
+
+// SignalReady signals that the new process is ready to take over
+func (c *Coordinator) SignalReady() error {
+	// Capture needed values while holding the lock
+	c.mu.Lock()
+	if c.state == nil {
+		c.mu.Unlock()
+		return fmt.Errorf("no handoff state found")
+	}
+
+	oldPID := c.state.OldPID
+	systemdNotifier := c.systemd
+	c.mu.Unlock()
+
+	// Signal the old process that we're ready (outside lock)
+	if oldPID > 0 && oldPID != os.Getpid() {
+		c.log.Info("signaling old process to shutdown", "old_pid", oldPID)
+
+		// Send SIGUSR1 to indicate readiness
+		if err := syscall.Kill(oldPID, syscall.SIGUSR1); err != nil {
+			c.log.Warn("failed to signal old process", "error", err)
+		}
+	}
+
+	// Notify systemd of the PID change if running under systemd
+	if systemdNotifier != nil {
+		newPID := os.Getpid()
+		c.log.Info("notifying systemd of PID change", "new_pid", newPID)
+		if err := systemdNotifier.NotifyPIDChange(newPID); err != nil {
+			c.log.Warn("failed to notify systemd of PID change", "error", err)
+		}
+	}
+
+	// Clear the handoff state as we've successfully taken over
+	return c.ClearHandoffState()
+}
+
+// WaitForReadiness waits for the new process to signal readiness
+func (c *Coordinator) WaitForReadiness(ctx context.Context) error {
+	c.mu.RLock()
+	readyChan := c.readyChannel
+	c.mu.RUnlock()
+
+	if readyChan == nil {
+		return fmt.Errorf("no upgrade in progress")
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-readyChan:
+		return err
+	}
+}
+
+// HandleReadinessSignal handles SIGUSR1 from the new process indicating it's ready
+func (c *Coordinator) HandleReadinessSignal() {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Notify systemd that we're stopping for upgrade
+	if c.systemd != nil {
+		c.log.Info("notifying systemd of graceful shutdown for upgrade")
+		if err := c.systemd.NotifyStopping(); err != nil {
+			c.log.Warn("failed to notify systemd of stopping", "error", err)
+		}
+	}
+
+	if c.readyChannel != nil {
+		select {
+		case c.readyChannel <- nil:
+		default:
+		}
+	}
+}

--- a/components/upgrade/systemd_notifier.go
+++ b/components/upgrade/systemd_notifier.go
@@ -1,0 +1,130 @@
+//go:build linux
+// +build linux
+
+package upgrade
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+// SystemdNotifier handles systemd notification protocol
+type SystemdNotifier struct {
+	socketPath string
+}
+
+// NewSystemdNotifier creates a new systemd notifier if running under systemd
+func NewSystemdNotifier() *SystemdNotifier {
+	// Auto-detect if we're running under systemd
+	if !IsRunningUnderSystemd() {
+		return nil
+	}
+
+	socketPath := os.Getenv("NOTIFY_SOCKET")
+	if socketPath == "" {
+		// We're under systemd but not Type=notify, still return a notifier
+		// (it will be a no-op but allows consistent code flow)
+		return &SystemdNotifier{}
+	}
+
+	// Handle abstract socket (starts with @)
+	if socketPath[0] == '@' {
+		socketPath = "\x00" + socketPath[1:]
+	}
+
+	return &SystemdNotifier{
+		socketPath: socketPath,
+	}
+}
+
+// IsRunningUnderSystemd detects if the process is running under systemd supervision
+func IsRunningUnderSystemd() bool {
+	// Method 1: Check for NOTIFY_SOCKET (Type=notify services)
+	if os.Getenv("NOTIFY_SOCKET") != "" {
+		return true
+	}
+
+	// Method 2: Check for INVOCATION_ID (all systemd services)
+	if os.Getenv("INVOCATION_ID") != "" {
+		return true
+	}
+
+	// Method 3: Check for JOURNAL_STREAM (systemd logging)
+	if os.Getenv("JOURNAL_STREAM") != "" {
+		return true
+	}
+
+	// Method 4: Check if parent is systemd (PID 1)
+	if os.Getppid() == 1 {
+		// Check if init system is systemd
+		if data, err := os.ReadFile("/proc/1/comm"); err == nil {
+			if string(data) == "systemd\n" {
+				return true
+			}
+		}
+	}
+
+	// Method 5: Check cgroup for systemd service pattern
+	if data, err := os.ReadFile("/proc/self/cgroup"); err == nil {
+		// Look for systemd service cgroup patterns
+		cgroupStr := string(data)
+		if strings.Contains(cgroupStr, "/system.slice/") ||
+			strings.Contains(cgroupStr, ".service") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Notify sends a notification to systemd
+func (n *SystemdNotifier) Notify(state string) error {
+	if n == nil || n.socketPath == "" {
+		return nil // Not running under systemd
+	}
+
+	conn, err := net.Dial("unixgram", n.socketPath)
+	if err != nil {
+		return fmt.Errorf("failed to connect to systemd: %w", err)
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(state))
+	if err != nil {
+		return fmt.Errorf("failed to write to systemd: %w", err)
+	}
+
+	return nil
+}
+
+// NotifyReady notifies systemd that the service is ready
+func (n *SystemdNotifier) NotifyReady() error {
+	return n.Notify("READY=1\nSTATUS=Running")
+}
+
+// NotifyReloading notifies systemd that the service is reloading (upgrading)
+func (n *SystemdNotifier) NotifyReloading() error {
+	return n.Notify("RELOADING=1\nSTATUS=Upgrade in progress")
+}
+
+// NotifyStopping notifies systemd that the service is stopping
+func (n *SystemdNotifier) NotifyStopping() error {
+	return n.Notify("STOPPING=1\nSTATUS=Shutting down for upgrade")
+}
+
+// NotifyPIDChange notifies systemd of a PID change during upgrade
+func (n *SystemdNotifier) NotifyPIDChange(newPID int) error {
+	return n.Notify(fmt.Sprintf("READY=1\nMAINPID=%d\nSTATUS=Upgrade complete", newPID))
+}
+
+// NotifyWatchdog sends a watchdog keepalive to systemd
+func (n *SystemdNotifier) NotifyWatchdog() error {
+	return n.Notify("WATCHDOG=1")
+}
+
+// NotifyStatus sends a status message to systemd
+func (n *SystemdNotifier) NotifyStatus(status string) error {
+	return n.Notify(fmt.Sprintf("STATUS=%s", status))
+}

--- a/components/upgrade/systemd_notifier_darwin.go
+++ b/components/upgrade/systemd_notifier_darwin.go
@@ -6,9 +6,9 @@ package upgrade
 // SystemdNotifier handles systemd notification protocol (stub for Darwin)
 type SystemdNotifier struct{}
 
-// NewSystemdNotifier creates a new systemd notifier (returns nil on Darwin)
+// NewSystemdNotifier creates a new systemd notifier (returns no-op stub on Darwin)
 func NewSystemdNotifier() *SystemdNotifier {
-	return nil
+	return &SystemdNotifier{}
 }
 
 // IsRunningUnderSystemd always returns false on Darwin

--- a/components/upgrade/systemd_notifier_darwin.go
+++ b/components/upgrade/systemd_notifier_darwin.go
@@ -1,0 +1,52 @@
+//go:build darwin
+// +build darwin
+
+package upgrade
+
+// SystemdNotifier handles systemd notification protocol (stub for Darwin)
+type SystemdNotifier struct{}
+
+// NewSystemdNotifier creates a new systemd notifier (returns nil on Darwin)
+func NewSystemdNotifier() *SystemdNotifier {
+	return nil
+}
+
+// IsRunningUnderSystemd always returns false on Darwin
+func IsRunningUnderSystemd() bool {
+	return false
+}
+
+// Notify sends a notification to systemd (no-op on Darwin)
+func (n *SystemdNotifier) Notify(state string) error {
+	return nil
+}
+
+// NotifyReady notifies systemd that the service is ready (no-op on Darwin)
+func (n *SystemdNotifier) NotifyReady() error {
+	return nil
+}
+
+// NotifyReloading notifies systemd that the service is reloading (no-op on Darwin)
+func (n *SystemdNotifier) NotifyReloading() error {
+	return nil
+}
+
+// NotifyStopping notifies systemd that the service is stopping (no-op on Darwin)
+func (n *SystemdNotifier) NotifyStopping() error {
+	return nil
+}
+
+// NotifyPIDChange notifies systemd of a PID change during upgrade (no-op on Darwin)
+func (n *SystemdNotifier) NotifyPIDChange(newPID int) error {
+	return nil
+}
+
+// NotifyWatchdog sends a watchdog keepalive to systemd (no-op on Darwin)
+func (n *SystemdNotifier) NotifyWatchdog() error {
+	return nil
+}
+
+// NotifyStatus sends a status message to systemd (no-op on Darwin)
+func (n *SystemdNotifier) NotifyStatus(status string) error {
+	return nil
+}

--- a/components/upgrade/systemd_notifier_linux.go
+++ b/components/upgrade/systemd_notifier_linux.go
@@ -29,10 +29,8 @@ func NewSystemdNotifier() *SystemdNotifier {
 		return &SystemdNotifier{}
 	}
 
-	// Handle abstract socket (starts with @)
-	if socketPath[0] == '@' {
-		socketPath = "\x00" + socketPath[1:]
-	}
+	// Go's net package handles @ for abstract sockets automatically
+	// No need to convert @ to NUL byte
 
 	return &SystemdNotifier{
 		socketPath: socketPath,

--- a/components/upgrade/systemd_notifier_linux.go
+++ b/components/upgrade/systemd_notifier_linux.go
@@ -60,7 +60,7 @@ func IsRunningUnderSystemd() bool {
 	if os.Getppid() == 1 {
 		// Check if init system is systemd
 		if data, err := os.ReadFile("/proc/1/comm"); err == nil {
-			if string(data) == "systemd\n" {
+			if strings.TrimSpace(string(data)) == "systemd" {
 				return true
 			}
 		}

--- a/scripts/miren.service
+++ b/scripts/miren.service
@@ -36,7 +36,7 @@ ExecReload=/bin/bash -c '\
 Restart=on-failure
 RestartSec=10
 StartLimitBurst=3
-StartLimitInterval=60s
+StartLimitIntervalSec=60s
 
 # Logging
 StandardOutput=journal

--- a/scripts/miren.service
+++ b/scripts/miren.service
@@ -1,0 +1,75 @@
+[Unit]
+Description=Miren Runtime Service
+Documentation=https://miren.dev/docs
+After=network-online.target
+Wants=network-online.target
+# Ensure proper ordering with dependencies
+After=systemd-resolved.service
+
+[Service]
+# Use notify type for proper PID tracking during upgrades
+Type=notify
+NotifyAccess=all
+
+# Pre-start setup
+ExecStartPre=/usr/local/bin/miren-env-setup
+EnvironmentFile=-/etc/default/miren
+
+# Environment configuration
+Environment="NO_COLOR=1"
+Environment="MIREN_DATA_PATH=/var/lib/miren"
+
+# Main service command
+ExecStart=/var/lib/miren/release/miren server -vv --address=0.0.0.0:8443 --serve-tls
+
+# Upgrade trigger - performs hot restart (auto-detects systemd)
+# Note: This assumes release.new directory contains the new version
+ExecReload=/bin/bash -c '\
+  if [ -f /var/lib/miren/release.new/miren ]; then \
+    /var/lib/miren/release.new/miren upgrade --timeout=90 || exit 1; \
+  else \
+    echo "No new release found at /var/lib/miren/release.new"; \
+    exit 1; \
+  fi'
+
+# Restart policy - only on failure to prevent restart during upgrade
+Restart=on-failure
+RestartSec=10
+StartLimitBurst=3
+StartLimitInterval=60s
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=miren
+
+# Security settings
+User=root  # Required for container management
+WorkingDirectory=/var/lib/miren/release
+PrivateTmp=false  # Need access to shared resources
+
+# Process management
+# mixed mode allows graceful shutdown of main process while preserving children
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=90s
+TimeoutStartSec=120s  # Allow time for takeover during upgrade
+
+# Resource limits (adjust based on your needs)
+LimitNOFILE=1048576
+LimitNPROC=32768
+LimitCORE=infinity
+TasksMax=infinity
+
+# Cgroup configuration for container runtime
+Delegate=yes
+
+# Ensure service stops cleanly on shutdown
+# Higher number means stops later (containers can finish)
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Install]
+WantedBy=multi-user.target
+Alias=miren.service

--- a/servers/upgrade/server.go
+++ b/servers/upgrade/server.go
@@ -35,6 +35,15 @@ func NewServer(log *slog.Logger, dataPath string) *Server {
 	}
 }
 
+// NewServerWithCoordinator creates a new upgrade server with a provided coordinator
+func NewServerWithCoordinator(log *slog.Logger, coordinator *upgcoord.Coordinator) *Server {
+	return &Server{
+		log:         log.With("component", "upgrade-server"),
+		coordinator: coordinator,
+		dataPath:    coordinator.DataPath(),
+	}
+}
+
 // SetServerState sets the current server state for preservation during upgrade
 func (s *Server) SetServerState(
 	containerdSocket string,

--- a/servers/upgrade/server.go
+++ b/servers/upgrade/server.go
@@ -1,0 +1,114 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	upgcoord "miren.dev/runtime/components/upgrade"
+	"miren.dev/runtime/version"
+)
+
+// Server handles upgrade-related operations for the miren server
+type Server struct {
+	log         *slog.Logger
+	coordinator *upgcoord.Coordinator
+	dataPath    string
+
+	// Server state that needs to be preserved
+	containerdSocket  string
+	etcdEndpoints     []string
+	clickhouseAddress string
+	serverAddress     string
+	runnerAddress     string
+	runnerID          string
+	mode              string
+}
+
+// NewServer creates a new upgrade server
+func NewServer(log *slog.Logger, dataPath string) *Server {
+	return &Server{
+		log:         log.With("component", "upgrade-server"),
+		coordinator: upgcoord.NewCoordinator(log, dataPath),
+		dataPath:    dataPath,
+	}
+}
+
+// SetServerState sets the current server state for preservation during upgrade
+func (s *Server) SetServerState(
+	containerdSocket string,
+	etcdEndpoints []string,
+	clickhouseAddress string,
+	serverAddress string,
+	runnerAddress string,
+	runnerID string,
+	mode string,
+) {
+	s.containerdSocket = containerdSocket
+	s.etcdEndpoints = etcdEndpoints
+	s.clickhouseAddress = clickhouseAddress
+	s.serverAddress = serverAddress
+	s.runnerAddress = runnerAddress
+	s.runnerID = runnerID
+	s.mode = mode
+}
+
+// GetVersion returns the current server version
+func (s *Server) GetVersion(ctx context.Context) (string, error) {
+	return version.Version, nil
+}
+
+// InitiateUpgrade starts the upgrade process
+func (s *Server) InitiateUpgrade(ctx context.Context, newBinaryPath string, force bool) error {
+	s.log.Info("initiating upgrade", "new_binary", newBinaryPath, "force", force)
+
+	// Verify the new binary exists
+	if _, err := os.Stat(newBinaryPath); err != nil {
+		return fmt.Errorf("new binary not found: %w", err)
+	}
+
+	// Create handoff state
+	handoffState := &upgcoord.HandoffState{
+		ContainerdSocket:  s.containerdSocket,
+		EtcdEndpoints:     s.etcdEndpoints,
+		ClickHouseAddress: s.clickhouseAddress,
+		ServerAddress:     s.serverAddress,
+		RunnerAddress:     s.runnerAddress,
+		RunnerID:          s.runnerID,
+		DataPath:          s.dataPath,
+		Mode:              s.mode,
+	}
+
+	// Note: Signal handling for SIGUSR1 is done in cli/commands/server.go
+	// to avoid duplicate handlers. The server.go handler will call
+	// HandleReadinessSignal() on the coordinator directly.
+
+	// Initiate the upgrade
+	if err := s.coordinator.InitiateUpgrade(ctx, newBinaryPath, handoffState); err != nil {
+		return fmt.Errorf("upgrade failed: %w", err)
+	}
+
+	s.log.Info("upgrade initiated successfully, shutting down gracefully")
+
+	// The coordinator has confirmed the new process is ready
+	// Now we need to gracefully shutdown this process
+	// This should be handled by the caller (e.g., by canceling the context)
+
+	return nil
+}
+
+// CheckUpgradeStatus checks if an upgrade is in progress
+func (s *Server) CheckUpgradeStatus(ctx context.Context) (bool, *upgcoord.HandoffState, error) {
+	state, err := s.coordinator.LoadHandoffState()
+	if err != nil {
+		return false, nil, err
+	}
+
+	return state != nil, state, nil
+}
+
+// CancelUpgrade cancels an in-progress upgrade
+func (s *Server) CancelUpgrade(ctx context.Context) error {
+	return s.coordinator.ClearHandoffState()
+}


### PR DESCRIPTION
## Summary

Implements zero-downtime upgrade capability that preserves running containers and services during miren binary updates. The upgrade process coordinates handoff between old and new processes while maintaining systemd supervision and cgroup integrity.

## Key Features

- **Hot restart upgrade**: Update miren binary without stopping containers or services
- **Systemd integration**: Automatic detection and sd_notify protocol support
- **Process continuity**: Cgroup adoption ensures child processes (containerd, etcd, ClickHouse) remain supervised
- **Port collision prevention**: New process waits for ports to be free before binding
- **State preservation**: HandoffState maintains critical configuration during upgrade

## Implementation Components

### Upgrade Coordinator (`components/upgrade/coordinator.go`)
- Manages handoff state between old and new processes
- Handles SIGUSR1 signaling for readiness coordination
- Atomic state file operations with version tracking

### CLI Upgrade Command (`cli/commands/upgrade_linux.go`)
- External process triggers upgrade via RPC
- Monitors upgrade progress with proper error handling
- Platform-specific implementations (Linux full, Darwin stubs)

### Server Takeover Mode (`cli/commands/server.go --takeover`)
- New process inherits state from handoff file
- Early signaling prevents port binding conflicts
- Registry-resolved values for accurate state

### Systemd Support (`components/upgrade/systemd_notifier.go`)
- Auto-detects systemd supervision (5 detection methods)
- Sends MAINPID notifications for PID changes
- Notifies stopping status during upgrade

### Cgroup Management (`components/upgrade/cgroup_manager_linux.go`)
- Adopts orphaned processes into service cgroup
- Supports both cgroup v1 and v2
- Finds and adopts containerd by socket path

## Safety Features

- Fail-fast when no handoff state exists
- Cleanup of upgrade state on failures
- Proper errno handling for process checks (ESRCH, EPERM)
- Timeout protection with configurable duration
- Preserves prefilled PIDs in handoff state

## Testing Considerations

- Tested upgrade flow preserves running containers
- Systemd service remains active during upgrade
- Child processes correctly adopted into cgroup
- Port availability properly checked before binding

## Files Changed

- CLI commands for upgrade triggering
- Upgrade coordinator for state management
- Server modifications for takeover mode
- Platform-specific implementations
- Systemd service unit file example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Zero-downtime hot-restart upgrades (Linux) with coordinated handoff and systemd integration.
  - New CLI commands: upgrade, upgrade-status, upgrade-rollback (with macOS status/rollback support; local upgrade unsupported on macOS).
  - Runtime exposes an upgrade API/server for initiating and checking upgrades.
  - Process adoption into systemd cgroups on Linux and improved readiness signaling.

- **Chores**
  - Adds a systemd unit with ExecReload-based upgrade, resource limits, and restart policies.
  - Enhanced informational logging around upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->