### PR TITLE
feat: add standalone development mode to Dagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ dev-tmux:
 dev:
 	dagger call -q dev --dir=.
 
+dev-standalone:
+	dagger call -q dev-standalone --dir=.
+
+dev-tmux-standalone:
+	dagger call -q dev-tmux-standalone --dir=.
+
 services:
 	dagger call debug --dir=.
 

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -271,3 +271,44 @@ func (m *Runtime) Debug(
 
 	return w.Stdout(ctx)
 }
+
+// DevStandalone runs the miren server in standalone mode with development environment
+func (m *Runtime) DevStandalone(
+	ctx context.Context,
+	dir *dagger.Directory,
+) (string, error) {
+	w := m.BuildEnv(dir).
+		WithDirectory("/src", dir).
+		WithWorkdir("/src").
+		WithMountedCache("/data", dag.CacheVolume("containerd")).
+		// Mount a persistent cache volume for the default data directory
+		WithMountedCache("/var/lib/miren", dag.CacheVolume("miren-data"))
+
+	w = w.Terminal(dagger.ContainerTerminalOpts{
+		InsecureRootCapabilities: true,
+		Cmd:                      []string{"/bin/bash", "/src/hack/dev-standalone.sh"},
+	})
+
+	return w.Stdout(ctx)
+}
+
+// DevTmuxStandalone runs the miren server in standalone mode with tmux splits
+func (m *Runtime) DevTmuxStandalone(
+	ctx context.Context,
+	dir *dagger.Directory,
+) (string, error) {
+	w := m.BuildEnv(dir).
+		WithDirectory("/src", dir).
+		WithWorkdir("/src").
+		WithMountedCache("/data", dag.CacheVolume("containerd")).
+		// Mount a persistent cache volume for the default data directory
+		WithMountedCache("/var/lib/miren", dag.CacheVolume("miren-data")).
+		WithEnvVariable("USE_TMUX", "1")
+
+	w = w.Terminal(dagger.ContainerTerminalOpts{
+		InsecureRootCapabilities: true,
+		Cmd:                      []string{"/bin/bash", "/src/hack/dev-standalone.sh"},
+	})
+
+	return w.Stdout(ctx)
+}

--- a/hack/dev-standalone.sh
+++ b/hack/dev-standalone.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -e
+
+# Source common setup functions
+source "$(dirname "$0")/common-setup.sh"
+
+# Setup environment
+setup_cgroups
+setup_environment
+
+# In standalone mode, miren server manages its own containerd
+# so we don't need to start external containerd or buildkitd
+# Export the address for convenience when using tools like ctr
+export CONTAINERD_ADDRESS="/var/lib/miren/containerd/containerd.sock"
+
+# Setup kernel mounts
+setup_kernel_mounts
+
+cd /src
+
+# Build miren
+make bin/miren
+
+# Create symlink
+ln -sf "$PWD"/bin/miren /bin/m
+
+# Setup miren config
+mkdir -p ~/.config/miren
+m auth generate -c ~/.config/miren/clientconfig.yaml
+
+# Copy binaries to release directory for standalone mode
+echo "Setting up release directory for standalone mode..."
+mkdir -p /var/lib/miren/release
+cp bin/miren /var/lib/miren/release/
+cp /usr/local/bin/runc /var/lib/miren/release/
+cp /usr/local/bin/containerd-shim-runsc-v1 /var/lib/miren/release/
+cp /usr/local/bin/containerd-shim-runc-v2 /var/lib/miren/release/
+cp /usr/local/bin/containerd /var/lib/miren/release/
+cp /usr/local/bin/nerdctl /var/lib/miren/release/
+cp /usr/local/bin/ctr /var/lib/miren/release/
+echo "Release directory setup complete"
+
+# Setup environment variables
+setup_bash_environment
+
+if [[ -n "$USE_TMUX" ]]; then
+  # Make a tmux session for us to run multiple shells in
+  tmux new-session -d -s dev
+
+  # Set the prefix to one that is unlikely to overlap: ctrl-s
+  tmux unbind-key C-b
+  tmux set-option -g prefix C-s
+  tmux bind-key C-s send-prefix
+
+  # Some quality of life settings
+  tmux set-option -g mode-keys vi
+
+  # Start with two panes with the server running on top and a shell running on the bottom
+  tmux split-window -v
+  tmux send-keys -t dev:0.0 "./bin/miren server -vv --mode standalone" Enter
+  tmux select-pane -t dev:0.1
+  tmux attach-session -t dev
+else
+  # Start the server in the background
+  ./bin/miren server -vv --mode standalone >/tmp/server.log 2>&1 &
+  echo "Server started in standalone mode, logs are in /tmp/server.log"
+
+  # Start a shell
+  bash
+fi


### PR DESCRIPTION
## Summary
- Adds `make dev-standalone` and `make dev-tmux-standalone` commands for running the server in standalone mode
- Enables easier development and testing of standalone features without external service dependencies

## Changes
- Added `DevStandalone` and `DevTmuxStandalone` Dagger functions that use BuildEnv without external services
- Created `hack/dev-standalone.sh` script that sets up the release directory by copying binaries instead of downloading
- Added Makefile targets for easy access to the new commands
- Mounts `/var/lib/miren` as a persistent Dagger cache volume for data persistence across runs

## Context
This PR provides the infrastructure needed to test MIR-421 (recover on restart) by giving us a proper standalone development environment with persistent data storage.

## Test plan
- [ ] Run `make dev-standalone` and verify server starts in standalone mode
- [ ] Run `make dev-tmux-standalone` and verify tmux splits work correctly
- [ ] Verify binaries are properly copied to `/var/lib/miren/release`
- [ ] Verify data persists across container restarts (using the cached volume)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Standalone development environment that prepares a workspace, builds artifacts, configures runtime, and starts the server automatically.
  - Optional tmux mode launches a preconfigured split-pane session for easier multi-window workflows, or falls back to background server + interactive shell with logs.

- **Chores**
  - Added make targets to launch the standalone environment and the tmux-enabled variant for quicker local setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->