### PR TITLE
fix: detect and recover unhealthy sandboxes after containerd restart

### DIFF
--- a/api/entityserver/entityserver_v1alpha/constants.go
+++ b/api/entityserver/entityserver_v1alpha/constants.go
@@ -1,0 +1,33 @@
+package entityserver_v1alpha
+
+// EntityOperation represents the type of operation on an entity
+type EntityOperation int64
+
+const (
+	// EntityOperationCreate indicates an entity was created
+	EntityOperationCreate EntityOperation = 1
+	// EntityOperationUpdate indicates an entity was updated
+	EntityOperationUpdate EntityOperation = 2
+	// EntityOperationDelete indicates an entity was deleted
+	EntityOperationDelete EntityOperation = 3
+)
+
+// OperationType returns the typed operation for this EntityOp
+func (v *EntityOp) OperationType() EntityOperation {
+	return EntityOperation(v.Operation())
+}
+
+// IsCreate returns true if this is a create operation
+func (v *EntityOp) IsCreate() bool {
+	return v.Operation() == int64(EntityOperationCreate)
+}
+
+// IsUpdate returns true if this is an update operation
+func (v *EntityOp) IsUpdate() bool {
+	return v.Operation() == int64(EntityOperationUpdate)
+}
+
+// IsDelete returns true if this is a delete operation
+func (v *EntityOp) IsDelete() bool {
+	return v.Operation() == int64(EntityOperationDelete)
+}

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -589,9 +589,10 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 					var sb compute_v1alpha.Sandbox
 					sb.Decode(op.Entity().Entity())
 
-					// Remove sandbox if it's not in RUNNING state
-					if sb.Status != compute_v1alpha.RUNNING {
-						a.log.Debug("sandbox status changed to non-RUNNING",
+					// Only remove sandboxes that are in terminal states
+					// Don't remove PENDING or blank status (still starting up)
+					if sb.Status == compute_v1alpha.STOPPED || sb.Status == compute_v1alpha.DEAD {
+						a.log.Debug("sandbox reached terminal state, removing from tracking",
 							"sandbox_id", sb.ID,
 							"status", sb.Status)
 						a.removeSandbox(sb.ID.String())

--- a/components/ipalloc/ipalloc.go
+++ b/components/ipalloc/ipalloc.go
@@ -166,8 +166,8 @@ func (a *Allocator) Watch(ctx context.Context, eac *entityserver_v1alpha.EntityA
 			return nil
 		}
 
-		switch op.Operation() {
-		case 1, 2:
+		switch op.OperationType() {
+		case entityserver_v1alpha.EntityOperationCreate, entityserver_v1alpha.EntityOperationUpdate:
 			// fine
 		default:
 			return nil

--- a/components/scheduler/scheduler.go
+++ b/components/scheduler/scheduler.go
@@ -103,8 +103,8 @@ func (s *Scheduler) Watch(ctx context.Context, eac *eas.EntityAccessClient) erro
 			return nil
 		}
 
-		switch op.Operation() {
-		case 1, 2:
+		switch op.OperationType() {
+		case eas.EntityOperationCreate, eas.EntityOperationUpdate:
 			// fine
 		default:
 			return nil

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -170,6 +170,161 @@ func (c *SandboxController) waitForPort(ctx context.Context, id string, port int
 	}
 }
 
+// reconcileSandboxesOnBoot checks all Running sandboxes and marks unhealthy ones as DEAD
+// This is called during controller initialization to clean up after containerd restarts
+func (c *SandboxController) reconcileSandboxesOnBoot(ctx context.Context) error {
+	c.Log.Info("reconciling sandboxes on boot")
+
+	// List all sandboxes marked as RUNNING
+	resp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+	if err != nil {
+		return fmt.Errorf("failed to list sandboxes: %w", err)
+	}
+
+	var unhealthySandboxes []entity.Id
+
+	for _, e := range resp.Values() {
+		var sb compute.Sandbox
+		sb.Decode(e.Entity())
+
+		// Only check sandboxes that think they're running
+		if sb.Status != compute.RUNNING {
+			continue
+		}
+
+		// Check pause container health
+		pauseID := c.pauseContainerId(sb.ID)
+		if !c.isContainerHealthy(ctx, pauseID) {
+			c.Log.Warn("found unhealthy sandbox during boot reconciliation",
+				"sandbox_id", sb.ID,
+				"pause_container_id", pauseID)
+			unhealthySandboxes = append(unhealthySandboxes, sb.ID)
+			continue
+		}
+
+		// Check subcontainers health
+		allHealthy := true
+		for _, container := range sb.Container {
+			containerID := fmt.Sprintf("%s-%s", c.containerPrefix(sb.ID), container.Name)
+			if !c.isContainerHealthy(ctx, containerID) {
+				c.Log.Warn("found unhealthy subcontainer during boot reconciliation",
+					"sandbox_id", sb.ID,
+					"container_name", container.Name,
+					"container_id", containerID)
+				allHealthy = false
+				break
+			}
+		}
+
+		if !allHealthy {
+			unhealthySandboxes = append(unhealthySandboxes, sb.ID)
+		}
+	}
+
+	// Mark unhealthy sandboxes as DEAD and clean them up
+	for _, id := range unhealthySandboxes {
+		c.Log.Info("marking unhealthy sandbox as DEAD and cleaning up", "id", id)
+
+		// Try to clean up the sandbox
+		err := c.Delete(ctx, id)
+		if err != nil {
+			c.Log.Error("failed to cleanup unhealthy sandbox", "id", id, "err", err)
+			// Continue with other sandboxes even if one fails
+		}
+	}
+
+	c.Log.Info("boot reconciliation complete",
+		"total_running_sandboxes", len(resp.Values()),
+		"unhealthy_sandboxes", len(unhealthySandboxes))
+
+	return nil
+}
+
+// cleanupOrphanedContainers removes containers not associated with Running sandboxes
+func (c *SandboxController) cleanupOrphanedContainers(ctx context.Context) error {
+	c.Log.Info("cleaning up orphaned containers")
+
+	ctx = namespaces.WithNamespace(ctx, c.Namespace)
+
+	// List all containers in the namespace
+	containers, err := c.CC.Containers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	// Build a set of valid container IDs from Running sandboxes
+	validContainers := make(map[string]bool)
+
+	resp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+	if err != nil {
+		return fmt.Errorf("failed to list sandboxes for orphan check: %w", err)
+	}
+
+	for _, e := range resp.Values() {
+		var sb compute.Sandbox
+		sb.Decode(e.Entity())
+
+		// Only track containers for Running sandboxes
+		if sb.Status == compute.RUNNING {
+			// Add pause container
+			validContainers[c.pauseContainerId(sb.ID)] = true
+
+			// Add subcontainers
+			for _, container := range sb.Container {
+				validContainers[fmt.Sprintf("%s-%s", c.containerPrefix(sb.ID), container.Name)] = true
+			}
+		}
+	}
+
+	// Clean up orphaned containers
+	orphanCount := 0
+	for _, container := range containers {
+		containerID := container.ID()
+
+		// Skip if this is a valid container
+		if validContainers[containerID] {
+			continue
+		}
+
+		// Check labels to see if this might be a special container we shouldn't touch
+		labels, err := container.Labels(ctx)
+		if err != nil {
+			c.Log.Error("failed to get container labels", "id", containerID, "err", err)
+			continue
+		}
+
+		// Skip if not a sandbox container (check for our labels)
+		if _, ok := labels[sandboxEntityLabel]; !ok {
+			c.Log.Debug("skipping non-sandbox container", "id", containerID)
+			continue
+		}
+
+		c.Log.Info("found orphaned container, cleaning up", "id", containerID)
+		orphanCount++
+
+		// Try to delete any task first
+		task, err := container.Task(ctx, nil)
+		if err == nil && task != nil {
+			_, err = task.Delete(ctx, containerd.WithProcessKill)
+			if err != nil {
+				c.Log.Error("failed to delete orphaned task", "id", containerID, "err", err)
+			}
+		}
+
+		// Delete the container
+		err = container.Delete(ctx, containerd.WithSnapshotCleanup)
+		if err != nil {
+			c.Log.Error("failed to delete orphaned container", "id", containerID, "err", err)
+		}
+	}
+
+	c.Log.Info("orphaned container cleanup complete",
+		"total_containers", len(containers),
+		"orphaned_containers", orphanCount)
+
+	return nil
+}
+
 func (c *SandboxController) Init(ctx context.Context) error {
 	c.portCond = sync.NewCond(&c.portMu)
 	c.portMap = make(map[string]*containerPorts)
@@ -192,6 +347,22 @@ func (c *SandboxController) Init(ctx context.Context) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	// Reconcile sandboxes after containerd restart
+	// This must happen after bridge setup but before starting normal operations
+	err = c.reconcileSandboxesOnBoot(ctx)
+	if err != nil {
+		// Log error but don't fail Init - we want the controller to start
+		// and handle new requests even if some cleanup failed
+		c.Log.Error("failed to reconcile sandboxes on boot", "err", err)
+	}
+
+	// Clean up any orphaned containers
+	err = c.cleanupOrphanedContainers(ctx)
+	if err != nil {
+		// Log error but don't fail Init
+		c.Log.Error("failed to cleanup orphaned containers on boot", "err", err)
 	}
 
 	go c.Metrics.Monitor(c.topCtx)
@@ -244,6 +415,7 @@ const (
 	notFound = iota
 	same
 	differentVersion
+	unhealthy // container exists but task is missing or dead
 )
 
 // canUpdateInPlace checks if the sandbox can be updated in place without destroying it.
@@ -340,7 +512,71 @@ func (c *SandboxController) checkSandbox(ctx context.Context, co *compute.Sandbo
 		return differentVersion, nil
 	}
 
+	// Check if the pause container has a healthy task
+	pauseID := c.pauseContainerId(co.ID)
+	if !c.isContainerHealthy(ctx, pauseID) {
+		c.Log.Warn("sandbox container exists but task is unhealthy", "id", co.ID, "pause_id", pauseID)
+		return unhealthy, nil
+	}
+
+	// Check subcontainers health
+	for _, container := range co.Container {
+		containerID := fmt.Sprintf("%s-%s", c.containerPrefix(co.ID), container.Name)
+		if !c.isContainerHealthy(ctx, containerID) {
+			c.Log.Warn("sandbox subcontainer exists but task is unhealthy",
+				"sandbox_id", co.ID,
+				"container_name", container.Name,
+				"container_id", containerID)
+			return unhealthy, nil
+		}
+	}
+
 	return same, nil
+}
+
+// isContainerHealthy checks if a container has a running task
+// Returns true if the container and its task are healthy, false otherwise
+func (c *SandboxController) isContainerHealthy(ctx context.Context, containerID string) bool {
+	ctx = namespaces.WithNamespace(ctx, c.Namespace)
+
+	container, err := c.CC.LoadContainer(ctx, containerID)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			c.Log.Debug("container not found when checking health", "id", containerID)
+		} else {
+			c.Log.Error("failed to load container when checking health", "id", containerID, "err", err)
+		}
+		return false
+	}
+
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			c.Log.Debug("task not found for container", "id", containerID)
+		} else {
+			c.Log.Error("failed to get task for container", "id", containerID, "err", err)
+		}
+		return false
+	}
+
+	if task == nil {
+		c.Log.Debug("task is nil for container", "id", containerID)
+		return false
+	}
+
+	status, err := task.Status(ctx)
+	if err != nil {
+		c.Log.Error("failed to get task status", "id", containerID, "err", err)
+		return false
+	}
+
+	// Check if task is in a running state
+	if status.Status != containerd.Running {
+		c.Log.Debug("task not in running state", "id", containerID, "status", status.Status)
+		return false
+	}
+
+	return true
 }
 
 func (c *SandboxController) saveEntity(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) error {
@@ -460,6 +696,15 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 				return nil
 			case differentVersion:
 				return c.updateSandbox(ctx, co, meta)
+			case unhealthy:
+				c.Log.Info("sandbox container exists but is unhealthy, cleaning up and recreating", "id", co.ID)
+				// Clean up the unhealthy sandbox
+				err := c.Delete(ctx, co.ID)
+				if err != nil {
+					c.Log.Error("failed to cleanup unhealthy sandbox", "id", co.ID, "err", err)
+					return fmt.Errorf("failed to cleanup unhealthy sandbox: %w", err)
+				}
+				// Fall through to create a new sandbox
 			}
 		}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -142,12 +142,12 @@ func (c *ReconcileController) Start(top context.Context) error {
 				}
 				var eventType EventType
 
-				switch op.Operation() {
-				case 1:
+				switch op.OperationType() {
+				case entityserver_v1alpha.EntityOperationCreate:
 					eventType = EventAdded
-				case 2:
+				case entityserver_v1alpha.EntityOperationUpdate:
 					eventType = EventUpdated
-				case 3:
+				case entityserver_v1alpha.EntityOperationDelete:
 					eventType = EventDeleted
 				default:
 					return nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -98,13 +98,13 @@ func TestReconcileController_EventProcessing(t *testing.T) {
 		1, // single worker
 	)
 
-	store.Entities[entity.Id("test/entity1")] = &entity.Entity{
+	store.AddEntity(entity.Id("test/entity1"), &entity.Entity{
 		ID: entity.Id("test/entity1"),
 		Attrs: entity.Attrs(
 			entity.Ident, "test/entity1",
 			entity.Type, "test/type",
 		),
-	}
+	})
 
 	// Setup mock watch handler
 	store.OnWatchIndex = func(ctx context.Context, attr entity.Attr) (clientv3.WatchChan, error) {
@@ -217,13 +217,13 @@ func TestReconcileController_Resync(t *testing.T) {
 	testIndex := entity.Any(entity.Type, "test/type")
 
 	// Setup test entities
-	store.Entities[entity.Id("test/entity1")] = &entity.Entity{
+	store.AddEntity(entity.Id("test/entity1"), &entity.Entity{
 		ID: entity.Id("test/entity1"),
 		Attrs: entity.Attrs(
 			entity.Ident, "test/entity1",
 			entity.Type, "test/type",
 		),
-	}
+	})
 
 	resyncCalls := 0
 	eventsChan := make(chan Event, 10)
@@ -498,20 +498,20 @@ func TestReconcileController_WatchReconnect(t *testing.T) {
 	}
 
 	// Add test entity to store
-	store.Entities[entity.Id("test/entity1")] = &entity.Entity{
+	store.AddEntity(entity.Id("test/entity1"), &entity.Entity{
 		ID: entity.Id("test/entity1"),
 		Attrs: entity.Attrs(
 			entity.Ident, "test/entity1",
 			entity.Type, "test/type",
 		),
-	}
-	store.Entities[entity.Id("test/entity2")] = &entity.Entity{
+	})
+	store.AddEntity(entity.Id("test/entity2"), &entity.Entity{
 		ID: entity.Id("test/entity2"),
 		Attrs: entity.Attrs(
 			entity.Ident, "test/entity2",
 			entity.Type, "test/type",
 		),
-	}
+	})
 
 	// Start controller
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -578,13 +578,13 @@ func TestReconcileController_QueueOverflow(t *testing.T) {
 	for i := range numEntities {
 		id := fmt.Sprintf("test/entity%d", i)
 		entityIds = append(entityIds, entity.Id(id))
-		store.Entities[entity.Id(id)] = &entity.Entity{
+		store.AddEntity(entity.Id(id), &entity.Entity{
 			ID: entity.Id(id),
 			Attrs: entity.Attrs(
 				entity.Ident, id,
 				entity.Type, "test/type",
 			),
-		}
+		})
 	}
 
 	// Track resync completion attempts

--- a/pkg/entity/testutils/inmem_server.go
+++ b/pkg/entity/testutils/inmem_server.go
@@ -63,12 +63,16 @@ func NewInMemEntityServer(t *testing.T) (*InMemEntityServer, func()) {
 
 // AddEntity adds an entity to the mock store
 func (s *InMemEntityServer) AddEntity(ent *entity.Entity) {
-	s.Store.Entities[ent.ID] = ent
+	s.Store.AddEntity(ent.ID, ent)
 }
 
 // GetEntity retrieves an entity from the mock store
 func (s *InMemEntityServer) GetEntity(id entity.Id) *entity.Entity {
-	return s.Store.Entities[id]
+	ent, err := s.Store.GetEntity(context.Background(), id)
+	if err != nil {
+		return nil
+	}
+	return ent
 }
 
 // TestLogger creates a test logger that discards all output

--- a/servers/entityserver/entityserver_test.go
+++ b/servers/entityserver/entityserver_test.go
@@ -202,7 +202,7 @@ func TestEntityServer_WatchIndex(t *testing.T) {
 	_, err := sc.WatchIndex(ctx, index, stream.Callback(func(op *v1alpha.EntityOp) error {
 		r.NotNil(op)
 
-		r.Equal(int64(1), op.Operation())
+		r.Equal(int64(v1alpha.EntityOperationCreate), op.Operation())
 
 		r.True(op.HasEntity())
 


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where sandboxes become unreachable after containerd restarts. The problem occurs because containers persist in containerd's state but their tasks (actual running processes) are lost, leaving sandboxes marked as RUNNING but without network connectivity.

## Problem

After containerd restart:
- Containers persist in containerd's state
- Tasks (actual running processes) are lost  
- SandboxController doesn't detect this inconsistent state
- Sandboxes remain marked as RUNNING but are actually dead (no network)

## Solution

Implements a "let it crash" philosophy - detect dead things and mark them as DEAD so higher-level controllers can recreate them.

### Key Changes

1. **Boot-time reconciliation**: On SandboxController startup, sweep all Running sandboxes and verify they have healthy tasks
2. **Enhanced health checks**: Check not just container existence but also task health
3. **Orphaned container cleanup**: Remove containers not associated with Running sandboxes
4. **Improved reconciliation**: Regular reconciliation now detects and handles missing tasks

### Implementation Details

- Added `unhealthy` status to identify containers without tasks
- New `isContainerHealthy()` helper method checks container + task health
- `reconcileSandboxesOnBoot()` runs on controller init to detect unhealthy sandboxes
- `cleanupOrphanedContainers()` removes orphaned containers
- Enhanced `checkSandbox()` to verify task health
- Updated `Create()` to handle unhealthy status

## Testing

Ready for automated code review and manual smoke testing.

### Manual Test Plan
1. Start miren with sandboxes running
2. Stop miren server (keep containerd running)
3. Kill sandbox tasks: `pkill -f runsc`
4. Restart miren server
5. Verify sandboxes are detected as unhealthy and recreated

## Related Issues

Fixes: MIR-421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup reconciliation verifies RUNNING sandboxes, removes unhealthy ones, and recreates as needed.
  * Startup cleanup removes orphaned containers and related resources.
  * Background watcher evicts deleted or non-RUNNING sandboxes from activator tracking.

* **Bug Fixes**
  * Expanded health checks detect and clean up sandboxes whose containers/tasks are missing or dead.
  * Init proceeds even if cleanup reports errors, improving startup resilience.

* **Chores**
  * Added concurrency protections in mocks and test helpers; reduced lock contention in activator.
  * Introduced explicit operation enums for clearer event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->