### PR TITLE
MIR-397: Cluster Command Makeover

### DIFF
--- a/cli/commands/cluster.go
+++ b/cli/commands/cluster.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"net"
+
+	"github.com/charmbracelet/lipgloss"
+	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// ClusterList lists all configured clusters (replaces config info)
+func ClusterList(ctx *Context, opts struct {
+	FormatOptions
+	ConfigCentric
+}) error {
+	cfg, err := opts.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	// Prepare structured data
+	type ClusterInfo struct {
+		Name     string `json:"name"`
+		Address  string `json:"address"`
+		Identity string `json:"identity"`
+		Active   bool   `json:"active"`
+	}
+
+	var clusters []ClusterInfo
+	var rows []ui.Row
+	headers := []string{"", "CLUSTER", "ADDRESS", "IDENTITY"}
+
+	err = cfg.IterateClusters(func(name string, ccfg *clientconfig.ClusterConfig) error {
+		// Determine if this is the active cluster
+		isActive := false
+		if opts.Cluster != "" {
+			isActive = (name == opts.Cluster)
+		} else {
+			isActive = (name == cfg.ActiveCluster())
+		}
+
+		// Use a star for active cluster
+		prefix := " "
+		if isActive {
+			prefix = "*"
+		}
+
+		// Get identity info if present
+		identity := ccfg.Identity
+		if identity == "" {
+			identity = "-"
+		}
+
+		// Build structured data for JSON
+		clusterInfo := ClusterInfo{
+			Name:     name,
+			Address:  ccfg.Hostname,
+			Identity: ccfg.Identity,
+			Active:   isActive,
+		}
+		clusters = append(clusters, clusterInfo)
+
+		// Build table row with formatting
+		if !opts.IsJSON() {
+			// Format address - color port portion gray for table display
+			address := ccfg.Hostname
+			if host, port, err := net.SplitHostPort(address); err == nil {
+				grayPort := lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render(":" + port)
+				address = host + grayPort
+			}
+
+			rows = append(rows, ui.Row{
+				prefix,
+				name,
+				address,
+				identity,
+			})
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Output based on format
+	if opts.IsJSON() {
+		return PrintJSON(clusters)
+	}
+
+	if len(clusters) == 0 {
+		ctx.Printf("No clusters configured\n")
+		ctx.Printf("\nUse 'miren cluster add' to add a cluster\n")
+		return nil
+	}
+
+	// Create and render the table
+	columns := ui.AutoSizeColumns(headers, rows)
+	table := ui.NewTable(
+		ui.WithColumns(columns),
+		ui.WithRows(rows),
+	)
+
+	ctx.Printf("%s\n", table.Render())
+	return nil
+}
+
+// Cluster is the default command for the cluster group - shows the list
+func Cluster(ctx *Context, opts struct {
+	FormatOptions
+	ConfigCentric
+}) error {
+	return ClusterList(ctx, opts)
+}

--- a/cli/commands/cluster.go
+++ b/cli/commands/cluster.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"net"
 
 	"github.com/charmbracelet/lipgloss"
@@ -15,6 +16,22 @@ func ClusterList(ctx *Context, opts struct {
 }) error {
 	cfg, err := opts.LoadConfig()
 	if err != nil {
+		// Handle missing config gracefully
+		if errors.Is(err, clientconfig.ErrNoConfig) {
+			if opts.IsJSON() {
+				// Return empty array for JSON
+				type ClusterInfo struct {
+					Name     string `json:"name"`
+					Address  string `json:"address"`
+					Identity string `json:"identity"`
+					Active   bool   `json:"active"`
+				}
+				return PrintJSON([]ClusterInfo{})
+			}
+			ctx.Printf("No clusters configured\n")
+			ctx.Printf("\nUse 'miren cluster add' to add a cluster\n")
+			return nil
+		}
 		return err
 	}
 

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -1,0 +1,254 @@
+package commands
+
+import (
+	"context"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"miren.dev/runtime/clientconfig"
+)
+
+func ClusterAdd(ctx *Context, opts struct {
+	Identity string `short:"i" long:"identity" description:"Name of the identity to use (optional - will use the only one if single)"`
+	Cluster  string `short:"c" long:"cluster" description:"Name of the cluster to create (optional - will list available)"`
+	Address  string `short:"a" long:"address" description:"Address/hostname of the cluster (optional - will use from selected cluster)"`
+	Force    bool   `short:"f" long:"force" description:"Overwrite existing cluster configuration"`
+}) error {
+	// Load the main config to check if the identity exists
+	mainConfig, err := clientconfig.LoadConfig()
+	if err != nil && err != clientconfig.ErrNoConfig {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	// Check if the identity exists
+	if mainConfig == nil || !mainConfig.HasIdentities() {
+		return fmt.Errorf("no identities configured. Please run 'miren login' first")
+	}
+
+	// If no identity specified, check if we can auto-select
+	if opts.Identity == "" {
+		availableIdentities := mainConfig.GetIdentityNames()
+		if len(availableIdentities) == 1 {
+			// Auto-select the only identity
+			opts.Identity = availableIdentities[0]
+			ctx.Info("Using identity '%s' (only one available)", opts.Identity)
+		} else if len(availableIdentities) > 1 {
+			// Multiple identities available, user must specify
+			return fmt.Errorf("multiple identities available, please specify one with --identity: %s", strings.Join(availableIdentities, ", "))
+		} else {
+			return fmt.Errorf("no identities configured. Please run 'miren login' first")
+		}
+	}
+
+	identity, err := mainConfig.GetIdentity(opts.Identity)
+	if err != nil {
+		// List available identities to help the user
+		availableIdentities := mainConfig.GetIdentityNames()
+		if len(availableIdentities) > 0 {
+			return fmt.Errorf("identity %q not found. Available identities: %v", opts.Identity, availableIdentities)
+		}
+		return fmt.Errorf("identity %q not found in configuration", opts.Identity)
+	}
+
+	// If no cluster name or address provided, query the identity server for available clusters
+	var caCert string
+	var allAddresses []string
+
+	if opts.Cluster == "" && opts.Address == "" {
+		ctx.Info("Fetching available clusters from identity server...")
+
+		clusters, err := fetchAvailableClusters(ctx, identity)
+		if err != nil {
+			return fmt.Errorf("failed to fetch available clusters: %w", err)
+		}
+
+		if len(clusters) == 0 {
+			return fmt.Errorf("no clusters available for your account")
+		}
+
+		// Present cluster selection to user and get local name
+		selectedCluster, localName, err := selectClusterFromList(ctx, clusters)
+		if err != nil {
+			return err
+		}
+
+		opts.Cluster = localName
+
+		// Store all available addresses
+		allAddresses = selectedCluster.APIAddresses
+
+		// Try to connect to the cluster
+		workingAddress, cert, err := tryConnectToCluster(ctx, selectedCluster, true)
+		if err != nil {
+			return err
+		}
+
+		caCert = cert
+		opts.Address = workingAddress
+
+		if localName != selectedCluster.Name {
+			ctx.Info("Adding cluster '%s' as '%s' (connected to %s)", selectedCluster.Name, localName, workingAddress)
+		} else {
+			ctx.Info("Adding cluster '%s' (connected to %s)", selectedCluster.Name, workingAddress)
+		}
+	} else if opts.Cluster == "" || opts.Address == "" {
+		return fmt.Errorf("both --cluster and --address must be specified, or neither (to list available clusters)")
+	} else {
+		// Manual mode - address was specified directly
+		ctx.Info("Connecting to %s to extract TLS certificate...", opts.Address)
+
+		// Extract the TLS certificate from the server
+		cert, fingerprint, err := extractTLSCertificateFromAddress(ctx, opts.Address)
+		if err != nil {
+			return fmt.Errorf("failed to extract TLS certificate: %w", err)
+		}
+		caCert = cert
+		ctx.Completed("Successfully extracted TLS certificate (fingerprint: %s)", fingerprint)
+	}
+
+	// Create the cluster configuration
+	clusterConfig := &clientconfig.ClusterConfig{
+		Hostname:     opts.Address,
+		AllAddresses: allAddresses,
+		Identity:     opts.Identity,
+		CACert:       caCert,
+	}
+
+	// Load or create the main client config
+	mainConfig, err = clientconfig.LoadConfig()
+	if err != nil {
+		// If no config exists, create a new one
+		if err == clientconfig.ErrNoConfig {
+			mainConfig = clientconfig.NewConfig()
+		} else {
+			return fmt.Errorf("failed to load client config: %w", err)
+		}
+	}
+
+	// Check if the leaf config already exists (by trying to get the cluster)
+	if mainConfig.HasCluster(opts.Cluster) && !opts.Force {
+		return fmt.Errorf("cluster configuration %q already exists. Use --force to overwrite", opts.Cluster)
+	}
+
+	// Create the cluster config data
+	leafConfigData := &clientconfig.ConfigData{
+		Clusters: map[string]*clientconfig.ClusterConfig{
+			opts.Cluster: clusterConfig,
+		},
+	}
+
+	// Add as a leaf config (this will be saved to clientconfig.d/{cluster}.yaml)
+	mainConfig.SetLeafConfig(opts.Cluster, leafConfigData)
+
+	// Save the main config (which will also save the leaf config)
+	if err := mainConfig.Save(); err != nil {
+		return fmt.Errorf("failed to save cluster configuration: %w", err)
+	}
+
+	ctx.Completed("Successfully added cluster %q with identity %q at %s", opts.Cluster, opts.Identity, opts.Address)
+	ctx.Info("Configuration saved to clientconfig.d/%s.yaml", opts.Cluster)
+
+	// If there's no active cluster set, suggest setting this one
+	if mainConfig != nil && mainConfig.ActiveCluster() == "" {
+		ctx.Info("")
+		ctx.Info("Tip: Set this as your active cluster with:")
+		ctx.Info("  miren cluster switch %s", opts.Cluster)
+	}
+
+	return nil
+}
+
+// extractTLSCertificateFromAddress connects to the server via QUIC and extracts the TLS certificate
+// This is a renamed version to avoid conflicts, the original is in config_bind.go
+func extractTLSCertificateFromAddress(ctx *Context, address string) (string, string, error) {
+	// Normalize the address with robust parsing
+	normalizedAddr, sniHost, err := normalizeAddress(address)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to normalize address: %w", err)
+	}
+
+	// Create a context with timeout
+	connCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	// Create TLS config that accepts any certificate for now (we're extracting it)
+	tlsConfig := &tls.Config{
+		ServerName:         sniHost,                                   // Use properly stripped SNI host
+		InsecureSkipVerify: true,                                      // We're extracting the cert, not verifying it yet
+		NextProtos:         []string{"h3", "h3-29", "h3-28", "h3-27"}, // HTTP/3 ALPN with common variants
+	}
+
+	// Create QUIC config
+	quicConfig := &quic.Config{
+		HandshakeIdleTimeout: 5 * time.Second,
+		MaxIdleTimeout:       10 * time.Second,
+	}
+
+	// Try to establish a QUIC connection
+	udpAddr, err := net.ResolveUDPAddr("udp", normalizedAddr)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve address: %w", err)
+	}
+
+	// Try IPv6/dual-stack binding first, fallback to IPv4
+	var udpConn *net.UDPConn
+	udpConn, err = net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv6zero, Port: 0})
+	if err != nil {
+		// Fallback to IPv4 if IPv6 fails
+		udpConn, err = net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+		if err != nil {
+			return "", "", fmt.Errorf("failed to create UDP socket: %w", err)
+		}
+	}
+	defer udpConn.Close()
+
+	transport := &quic.Transport{
+		Conn: udpConn,
+	}
+	defer transport.Close()
+
+	conn, err := transport.Dial(connCtx, udpAddr, tlsConfig, quicConfig)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to establish QUIC connection: %w", err)
+	}
+	defer conn.CloseWithError(0, "done")
+
+	// Get the TLS connection state
+	connState := conn.ConnectionState().TLS
+
+	// Extract the certificate chain
+	if len(connState.PeerCertificates) == 0 {
+		return "", "", fmt.Errorf("no certificates found in TLS handshake")
+	}
+
+	// Get the root CA certificate (usually the last in the chain)
+	// But for self-signed certs, there might be only one
+	var rootCert *x509.Certificate
+	if len(connState.PeerCertificates) == 1 {
+		// Self-signed certificate
+		rootCert = connState.PeerCertificates[0]
+	} else {
+		// Take the last certificate in the chain as the root CA
+		rootCert = connState.PeerCertificates[len(connState.PeerCertificates)-1]
+	}
+
+	// Calculate SHA1 fingerprint of the raw DER bytes
+	sum := sha1.Sum(rootCert.Raw)
+	fingerprint := hex.EncodeToString(sum[:])
+
+	// Encode the certificate to PEM
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: rootCert.Raw,
+	})
+
+	return string(certPEM), fingerprint, nil
+}

--- a/cli/commands/cluster_remove.go
+++ b/cli/commands/cluster_remove.go
@@ -1,0 +1,97 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/pkg/ui"
+)
+
+func ClusterRemove(ctx *Context, opts struct {
+	ConfigCentric
+	Args struct {
+		Cluster string `positional-arg-name:"cluster" description:"Name of the cluster to remove"`
+	} `positional-args:"yes"`
+}) error {
+	cfg, err := opts.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	clusterName := opts.Args.Cluster
+
+	// If no cluster name provided, show interactive menu
+	if clusterName == "" {
+		// Get sorted list of cluster names
+		clusterNames := cfg.GetClusterNames()
+
+		if len(clusterNames) == 0 {
+			ctx.Printf("No clusters configured\n")
+			return nil
+		}
+
+		// Create picker items
+		items := make([]ui.PickerItem, len(clusterNames))
+		activeCluster := cfg.ActiveCluster()
+		for i, name := range clusterNames {
+			items[i] = ui.SimplePickerItem{
+				Text:   name,
+				Active: name == activeCluster,
+			}
+		}
+
+		// Run the picker with dimmed active style
+		selected, err := ui.RunPicker(items,
+			ui.WithTitle("Select a cluster to remove:"),
+			ui.WithActiveMarker(),
+			ui.WithDimmedActiveStyle(),
+			ui.WithFooter("Note: You cannot remove the active cluster"),
+		)
+
+		if err != nil {
+			// If we can't run interactive mode (no TTY), show available clusters
+			ctx.Printf("Cannot run interactive mode. Available clusters:\n")
+			for _, name := range clusterNames {
+				prefix := "  "
+				if name == activeCluster {
+					prefix = "* "
+				}
+				ctx.Printf("%s%s\n", prefix, name)
+			}
+			ctx.Printf("\nUsage: miren cluster remove <cluster-name>\n")
+			return nil
+		}
+
+		if selected == nil {
+			// User cancelled
+			return nil
+		}
+
+		clusterName = selected.String()
+	}
+
+	// Check if the cluster exists
+	if !cfg.HasCluster(clusterName) {
+		availableClusters := cfg.GetClusterNames()
+		return fmt.Errorf("cluster %q not found. Available clusters: %v", clusterName, availableClusters)
+	}
+
+	// Check if this is the active cluster
+	if cfg.ActiveCluster() == clusterName {
+		return fmt.Errorf("cannot remove active cluster %q. Please switch to another cluster first using 'miren cluster switch'", clusterName)
+	}
+
+	// Remove the cluster
+	err = cfg.RemoveCluster(clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to remove cluster: %w", err)
+	}
+
+	// Save the configuration
+	err = cfg.Save()
+	if err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	ctx.Printf("Removed cluster: %s\n", clusterName)
+	return nil
+}

--- a/cli/commands/cluster_remove.go
+++ b/cli/commands/cluster_remove.go
@@ -39,11 +39,13 @@ func ClusterRemove(ctx *Context, opts struct {
 			}
 		}
 
-		// Run the picker with dimmed active style
+		// Run the picker with disabled check for active cluster
 		selected, err := ui.RunPicker(items,
 			ui.WithTitle("Select a cluster to remove:"),
-			ui.WithActiveMarker(),
-			ui.WithDimmedActiveStyle(),
+			ui.WithHeaders([]string{"CLUSTER"}),
+			ui.WithDisabledCheck(func(item ui.PickerItem) bool {
+				return item.ID() == activeCluster
+			}, "Cannot remove the active cluster"),
 			ui.WithFooter("Note: You cannot remove the active cluster"),
 		)
 
@@ -66,7 +68,7 @@ func ClusterRemove(ctx *Context, opts struct {
 			return nil
 		}
 
-		clusterName = selected.String()
+		clusterName = selected.ID()
 	}
 
 	// Check if the cluster exists

--- a/cli/commands/cluster_switch.go
+++ b/cli/commands/cluster_switch.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/pkg/ui"
+)
+
+func ClusterSwitch(ctx *Context, opts struct {
+	ConfigCentric
+	Args struct {
+		Cluster string `positional-arg-name:"cluster" description:"Name of the cluster to switch to"`
+	} `positional-args:"yes"`
+}) error {
+	cfg, err := opts.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	clusterName := opts.Args.Cluster
+
+	// If no cluster name provided, show interactive menu
+	if clusterName == "" {
+		// Get sorted list of cluster names
+		clusterNames := cfg.GetClusterNames()
+
+		if len(clusterNames) == 0 {
+			ctx.Printf("No clusters configured\n")
+			ctx.Printf("\nUse 'miren cluster add' to add a cluster\n")
+			return nil
+		}
+
+		// Create picker items
+		items := make([]ui.PickerItem, len(clusterNames))
+		activeCluster := cfg.ActiveCluster()
+		for i, name := range clusterNames {
+			items[i] = ui.SimplePickerItem{
+				Text:   name,
+				Active: name == activeCluster,
+			}
+		}
+
+		// Run the picker
+		selected, err := ui.RunPicker(items,
+			ui.WithTitle("Select a cluster to switch to:"),
+			ui.WithActiveMarker(),
+		)
+
+		if err != nil {
+			// If we can't run interactive mode (no TTY), show available clusters
+			ctx.Printf("Cannot run interactive mode. Available clusters:\n")
+			for _, name := range clusterNames {
+				prefix := "  "
+				if name == activeCluster {
+					prefix = "* "
+				}
+				ctx.Printf("%s%s\n", prefix, name)
+			}
+			ctx.Printf("\nUsage: miren cluster switch <cluster-name>\n")
+			return nil
+		}
+
+		if selected == nil {
+			// User cancelled
+			return nil
+		}
+
+		clusterName = selected.String()
+	}
+
+	// Check if the cluster exists
+	if !cfg.HasCluster(clusterName) {
+		availableClusters := cfg.GetClusterNames()
+		return fmt.Errorf("cluster %q not found. Available clusters: %v", clusterName, availableClusters)
+	}
+
+	// Set the active cluster
+	err = cfg.SetActiveCluster(clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to set active cluster: %w", err)
+	}
+
+	// Save the configuration
+	err = cfg.Save()
+	if err != nil {
+		return fmt.Errorf("failed to save configuration: %w", err)
+	}
+
+	ctx.Printf("Switched to cluster: %s\n", clusterName)
+	return nil
+}

--- a/cli/commands/cluster_switch.go
+++ b/cli/commands/cluster_switch.go
@@ -40,10 +40,10 @@ func ClusterSwitch(ctx *Context, opts struct {
 			}
 		}
 
-		// Run the picker
+		// Run the picker with single column
 		selected, err := ui.RunPicker(items,
 			ui.WithTitle("Select a cluster to switch to:"),
-			ui.WithActiveMarker(),
+			ui.WithHeaders([]string{"CLUSTER"}),
 		)
 
 		if err != nil {
@@ -65,7 +65,7 @@ func ClusterSwitch(ctx *Context, opts struct {
 			return nil
 		}
 
-		clusterName = selected.String()
+		clusterName = selected.ID()
 	}
 
 	// Check if the cluster exists

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -104,28 +104,38 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("logs", "Get logs for an application", Logs), nil
 		},
 
+		// Config commands - for config file management
 		"config": func() (cli.Command, error) {
-			return Section("config", "Commands related to client configuration"), nil
+			return Section("config", "Configuration file management"), nil
 		},
 
 		"config info": func() (cli.Command, error) {
-			return Infer("config info", "Get information about the client configuration", ConfigInfo), nil
+			return Infer("config info", "Show configuration file locations and format", ConfigInfo), nil
 		},
 
 		"config load": func() (cli.Command, error) {
 			return Infer("config load", "Load config and merge it with your current config", ConfigLoad), nil
 		},
 
-		"config set-active": func() (cli.Command, error) {
-			return Infer("config set-active", "Set the active cluster", ConfigSetActive), nil
+		// Cluster commands - for cluster management
+		"cluster": func() (cli.Command, error) {
+			return Infer("cluster", "List configured clusters", Cluster), nil
 		},
 
-		"config bind": func() (cli.Command, error) {
-			return Infer("config bind", "Bind an identity to a cluster address", ConfigBind), nil
+		"cluster list": func() (cli.Command, error) {
+			return Infer("cluster list", "List all configured clusters", ClusterList), nil
 		},
 
-		"config remove": func() (cli.Command, error) {
-			return Infer("config remove", "Remove a cluster from the configuration", ConfigRemove), nil
+		"cluster switch": func() (cli.Command, error) {
+			return Infer("cluster switch", "Switch to a different cluster", ClusterSwitch), nil
+		},
+
+		"cluster add": func() (cli.Command, error) {
+			return Infer("cluster add", "Add a new cluster configuration", ClusterAdd), nil
+		},
+
+		"cluster remove": func() (cli.Command, error) {
+			return Infer("cluster remove", "Remove a cluster from the configuration", ClusterRemove), nil
 		},
 
 		"disk create": func() (cli.Command, error) {

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -130,12 +130,13 @@ func ConfigInfo(ctx *Context, opts struct {
 		info.IdentityCount = len(cfg.GetIdentityNames())
 
 		// List leaf config files
-		leafConfigs := cfg.GetLeafConfigNames()
-		if len(leafConfigs) > 0 {
+		if leafConfigs := cfg.GetLeafConfigNames(); len(leafConfigs) > 0 {
+			// Create a new slice to avoid mutating the original
+			formatted := make([]string, len(leafConfigs))
 			for i, name := range leafConfigs {
-				leafConfigs[i] = fmt.Sprintf("clientconfig.d/%s.yaml", name)
+				formatted[i] = fmt.Sprintf("clientconfig.d/%s.yaml", name)
 			}
-			info.LeafConfigs = leafConfigs
+			info.LeafConfigs = formatted
 		}
 	}
 

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -6,17 +6,16 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/cloudauth"
+	"miren.dev/runtime/pkg/ui"
 )
 
 // ClusterResponse represents a cluster returned from the API
@@ -97,7 +96,7 @@ func fetchAvailableClusters(ctx *Context, identity *clientconfig.IdentityConfig)
 // Returns the selected cluster and the local name to use
 func selectClusterFromList(ctx *Context, clusters []ClusterResponse) (*ClusterResponse, string, error) {
 	// Check if we can run interactive mode
-	if !isInteractive() {
+	if !ui.IsInteractive() {
 		// Non-interactive mode - list clusters and exit
 		ctx.Printf("Available clusters:\n\n")
 		clusterNum := 1
@@ -125,118 +124,189 @@ func selectClusterFromList(ctx *Context, clusters []ClusterResponse) (*ClusterRe
 		return nil, "", fmt.Errorf("interactive mode not available")
 	}
 
-	// Create list items
-	items := make([]list.Item, 0, len(clusters))
+	// Create table picker items
+	items := make([]ui.PickerItem, 0, len(clusters))
+	clusterMap := make(map[string]*ClusterResponse)
+
 	for i, cluster := range clusters {
 		if len(cluster.APIAddresses) == 0 {
 			continue // Skip clusters without API addresses
 		}
 
-		// Build multi-line description with all details
-		var descLines []string
-
-		// Organization
-		descLines = append(descLines, fmt.Sprintf("Organization: %s", cluster.OrganizationName))
-
-		// Description if available
-		if cluster.Description != "" {
-			descLines = append(descLines, fmt.Sprintf("Description: %s", cluster.Description))
+		// Primary address
+		address := cluster.APIAddresses[0]
+		if len(cluster.APIAddresses) > 1 {
+			address = fmt.Sprintf("%s (+%d)", address, len(cluster.APIAddresses)-1)
 		}
 
-		// API Addresses - show all of them
-		if len(cluster.APIAddresses) > 0 {
-			if len(cluster.APIAddresses) == 1 {
-				descLines = append(descLines, fmt.Sprintf("Address: %s", cluster.APIAddresses[0]))
-			} else {
-				descLines = append(descLines, fmt.Sprintf("Addresses (%d):", len(cluster.APIAddresses)))
-				for j, addr := range cluster.APIAddresses {
-					if j < 3 { // Show first 3 addresses
-						descLines = append(descLines, fmt.Sprintf("  • %s", addr))
-					}
-				}
-				if len(cluster.APIAddresses) > 3 {
-					descLines = append(descLines, fmt.Sprintf("  • ... and %d more", len(cluster.APIAddresses)-3))
-				}
-			}
-		}
-
-		// Certificate fingerprint if available
+		// Certificate status
+		status := "No cert"
 		if cluster.CACertFingerprint != "" {
-			// Show first and last 8 chars of fingerprint for readability
+			// Show abbreviated fingerprint
 			fp := cluster.CACertFingerprint
-			if len(fp) > 20 {
-				fp = fmt.Sprintf("%s...%s", fp[:8], fp[len(fp)-8:])
+			if len(fp) >= 16 {
+				status = fmt.Sprintf("Cert: %s...%s", fp[:8], fp[len(fp)-8:])
+			} else {
+				status = "Has cert"
 			}
-			descLines = append(descLines, fmt.Sprintf("Certificate: %s", fp))
 		}
 
-		// Tags if available
-		if len(cluster.Tags) > 0 {
-			var tagStrs []string
-			for k, v := range cluster.Tags {
-				tagStrs = append(tagStrs, fmt.Sprintf("%s=%v", k, v))
-				if len(tagStrs) >= 3 {
-					break // Only show first 3 tags
-				}
-			}
-			descLines = append(descLines, fmt.Sprintf("Tags: %s", strings.Join(tagStrs, ", ")))
-		}
-
-		items = append(items, listItem{
-			title: cluster.Name,
-			desc:  strings.Join(descLines, "\n"),
-			index: i, // Store the cluster index for direct lookup
+		// Create table item
+		itemID := fmt.Sprintf("cluster_%d", i)
+		items = append(items, ui.TablePickerItem{
+			Columns: []string{
+				cluster.Name,
+				cluster.OrganizationName,
+				address,
+				status,
+			},
+			ItemID: itemID,
 		})
+		clusterMap[itemID] = &clusters[i]
 	}
 
-	// Create the list model
-	const defaultWidth = 100 // Increased width for more detail
-	const listHeight = 20    // Increased height since items are taller
+	// Run the table picker
+	selected, err := ui.RunPicker(items,
+		ui.WithTitle("Select a cluster to bind:"),
+		ui.WithHeaders([]string{"NAME", "ORGANIZATION", "ADDRESS", "CERTIFICATE"}),
+	)
 
-	delegate := &customDelegate{}
-	l := list.New(items, delegate, defaultWidth, listHeight)
-	l.Title = "Select a cluster to bind"
-	l.SetShowStatusBar(false)
-	l.SetFilteringEnabled(true)
-	l.SetShowHelp(true)
-	l.Styles.Title = listTitleStyle
-	l.Styles.HelpStyle = modalHelpStyle
-
-	m := clusterListModel{
-		list:     l,
-		clusters: clusters,
-		selected: -1,
-		state:    "selecting",
-	}
-
-	// Run the interactive selection
-	p := tea.NewProgram(m, tea.WithAltScreen())
-	result, err := p.Run()
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to run cluster selection: %w", err)
 	}
 
-	model := result.(clusterListModel)
-	if model.cancelled {
+	if selected == nil {
 		return nil, "", fmt.Errorf("cluster selection cancelled")
 	}
 
-	if model.selected < 0 || model.selected >= len(clusters) {
+	// Get the selected cluster
+	selectedCluster := clusterMap[selected.ID()]
+	if selectedCluster == nil {
 		return nil, "", fmt.Errorf("invalid selection")
 	}
 
+	// Now prompt for local name using a text input modal
+	localName, err := promptForLocalName(ctx, selectedCluster)
+	if err != nil {
+		return nil, "", err
+	}
+
 	// Return both the selected cluster and the local name
-	return &clusters[model.selected], model.localName, nil
+	return selectedCluster, localName, nil
 }
 
-type listItem struct {
-	title, desc string
-	index       int // Store the original cluster index for direct lookup
+// promptForLocalName prompts the user to enter a local name for the cluster
+func promptForLocalName(ctx *Context, cluster *ClusterResponse) (string, error) {
+	if !ui.IsInteractive() {
+		// Non-interactive mode - use cluster name
+		return cluster.Name, nil
+	}
+
+	// Create a text input model
+	textInput := textinput.New()
+	textInput.Placeholder = cluster.Name
+	textInput.SetValue(cluster.Name)
+	textInput.Focus()
+	textInput.CharLimit = 100
+	textInput.Width = 50
+	textInput.Prompt = "Local name: "
+
+	m := localNameModel{
+		textInput: textInput,
+		cluster:   cluster,
+	}
+
+	// Run the text input
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	result, err := p.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to run name input: %w", err)
+	}
+
+	model := result.(localNameModel)
+	if model.cancelled {
+		return "", fmt.Errorf("name input cancelled")
+	}
+
+	return model.localName, nil
 }
 
-func (i listItem) Title() string       { return i.title }
-func (i listItem) Description() string { return i.desc }
-func (i listItem) FilterValue() string { return i.title }
+type localNameModel struct {
+	textInput textinput.Model
+	cluster   *ClusterResponse
+	localName string
+	cancelled bool
+}
+
+func (m localNameModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m localNameModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			m.cancelled = true
+			return m, tea.Quit
+		case "esc":
+			m.cancelled = true
+			return m, tea.Quit
+		case "enter":
+			value := m.textInput.Value()
+			if value == "" {
+				// Use placeholder if empty
+				value = m.textInput.Placeholder
+			}
+			// Validate the name
+			if strings.ContainsAny(value, "/\\:*?\"<>|") {
+				// Invalid characters - don't accept
+				return m, nil
+			}
+			m.localName = value
+			return m, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+	m.textInput, cmd = m.textInput.Update(msg)
+	return m, cmd
+}
+
+func (m localNameModel) View() string {
+	// Create the modal content
+	var modalContent strings.Builder
+
+	// Title
+	title := "Choose Local Name"
+	modalContent.WriteString(modalTitleStyle.Render(title))
+	modalContent.WriteString("\n\n")
+
+	// Show selected cluster info
+	info := fmt.Sprintf("Cluster: %s\nOrganization: %s", m.cluster.Name, m.cluster.OrganizationName)
+	if m.cluster.Description != "" {
+		info += fmt.Sprintf("\nDescription: %s", m.cluster.Description)
+	}
+	modalContent.WriteString(modalSubtitleStyle.Render(info))
+	modalContent.WriteString("\n\n")
+
+	// Text input
+	modalContent.WriteString(m.textInput.View())
+
+	// Show validation error if needed
+	value := m.textInput.Value()
+	if value != "" && strings.ContainsAny(value, "/\\:*?\"<>|") {
+		modalContent.WriteString("\n\n")
+		modalContent.WriteString(modalErrorStyle.Render("⚠ Name contains illegal characters (/\\:*?\"<>|)"))
+	}
+
+	// Help text
+	modalContent.WriteString("\n\n")
+	modalContent.WriteString(modalHelpStyle.Render("Enter: confirm • Esc: cancel • Ctrl+C: cancel"))
+
+	// Apply modal styling
+	return modalStyle.Render(modalContent.String())
+}
 
 // Define consistent styles for both list and modal
 var (
@@ -270,252 +340,7 @@ var (
 	modalHelpStyle = lipgloss.NewStyle().
 			Foreground(helpColor).
 			MarginTop(1)
-
-	// List styles
-	listTitleStyle = lipgloss.NewStyle().
-			Foreground(primaryColor).
-			Bold(true).
-			Padding(0, 0, 1, 0)
-
-	listItemStyle = lipgloss.NewStyle().
-			PaddingLeft(2)
-
-	selectedItemStyle = lipgloss.NewStyle().
-				PaddingLeft(1).
-				Foreground(primaryColor).
-				Background(lipgloss.Color("236")).
-				Bold(true)
-
-	listItemTitleStyle = lipgloss.NewStyle().
-				Foreground(primaryColor)
-
-	listItemDescStyle = lipgloss.NewStyle().
-				Foreground(secondaryColor)
 )
-
-// customDelegate implements list.ItemDelegate with our consistent styling
-type customDelegate struct{}
-
-func (d customDelegate) Height() int {
-	// Calculate height based on typical content (title + multi-line desc)
-	return 7 // Increased to accommodate more detail
-}
-func (d customDelegate) Spacing() int                            { return 1 }
-func (d customDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
-
-func (d customDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
-	i, ok := item.(listItem)
-	if !ok {
-		return
-	}
-
-	// Render title with bold styling
-	title := listItemTitleStyle.Bold(true).Render(i.title)
-
-	// Render description lines with proper indentation
-	descLines := strings.Split(i.desc, "\n")
-	var styledDesc []string
-	for _, line := range descLines {
-		styledDesc = append(styledDesc, listItemDescStyle.Render(line))
-	}
-	desc := strings.Join(styledDesc, "\n")
-
-	// Combine title and description
-	content := lipgloss.JoinVertical(lipgloss.Left, title, desc)
-
-	// Apply selection styling
-	if index == m.Index() {
-		// Add selection indicator and background
-		lines := strings.Split(content, "\n")
-		var selected []string
-		for idx, line := range lines {
-			if idx == 0 {
-				// Add arrow to title line
-				selected = append(selected, selectedItemStyle.Render("▸ "+line))
-			} else {
-				// Indent other lines under selection
-				selected = append(selected, selectedItemStyle.Render("  "+line))
-			}
-		}
-		content = strings.Join(selected, "\n")
-	} else {
-		// Regular item with padding
-		lines := strings.Split(content, "\n")
-		var padded []string
-		for _, line := range lines {
-			padded = append(padded, listItemStyle.Render(line))
-		}
-		content = strings.Join(padded, "\n")
-	}
-
-	fmt.Fprint(w, content)
-}
-
-type clusterListModel struct {
-	list         list.Model
-	textInput    textinput.Model
-	clusters     []ClusterResponse
-	selected     int
-	cancelled    bool
-	state        string // "selecting" or "naming"
-	localName    string // The final chosen local name
-	windowWidth  int
-	windowHeight int
-}
-
-func (m clusterListModel) Init() tea.Cmd {
-	return nil
-}
-
-func (m clusterListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Handle window size updates in any state
-	if msg, ok := msg.(tea.WindowSizeMsg); ok {
-		m.windowWidth = msg.Width
-		m.windowHeight = msg.Height
-		m.list.SetWidth(msg.Width)
-		m.list.SetHeight(msg.Height - 2)
-	}
-
-	// Handle different states
-	if m.state == "naming" {
-		// In naming state, handle text input
-		switch msg := msg.(type) {
-		case tea.KeyMsg:
-			switch msg.String() {
-			case "ctrl+c":
-				m.cancelled = true
-				return m, tea.Quit
-			case "esc":
-				// Go back to selection
-				m.state = "selecting"
-				return m, nil
-			case "enter":
-				value := m.textInput.Value()
-				if value == "" {
-					// Use placeholder if empty
-					value = m.textInput.Placeholder
-				}
-				// Validate the name
-				if strings.ContainsAny(value, "/\\:*?\"<>|") {
-					// Show error but stay in naming mode
-					// We'll handle this in the view
-					return m, nil
-				}
-				m.localName = value
-				return m, tea.Quit
-			}
-		}
-
-		var cmd tea.Cmd
-		m.textInput, cmd = m.textInput.Update(msg)
-		return m, cmd
-	}
-
-	// In selecting state, handle list selection
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "q", "esc":
-			m.cancelled = true
-			return m, tea.Quit
-		case "enter":
-			if i, ok := m.list.SelectedItem().(listItem); ok {
-				// Use the stored index for direct cluster lookup
-				m.selected = i.index
-				cluster := m.clusters[i.index]
-				// Switch to naming mode
-				m.state = "naming"
-				// Initialize text input with cluster name
-				m.textInput = textinput.New()
-				m.textInput.Placeholder = cluster.Name
-				m.textInput.SetValue(cluster.Name)
-				m.textInput.Focus()
-				m.textInput.CharLimit = 100
-				m.textInput.Width = 50
-				m.textInput.Prompt = "Local name: "
-				return m, textinput.Blink
-			}
-			return m, nil
-		}
-	}
-
-	var cmd tea.Cmd
-	m.list, cmd = m.list.Update(msg)
-	return m, cmd
-}
-
-func (m clusterListModel) View() string {
-	if m.state == "naming" {
-		// Create the modal content
-		var modalContent strings.Builder
-
-		// Title
-		title := "Choose Local Name"
-		modalContent.WriteString(modalTitleStyle.Render(title))
-		modalContent.WriteString("\n\n")
-
-		// Show selected cluster info
-		if m.selected >= 0 && m.selected < len(m.clusters) {
-			cluster := m.clusters[m.selected]
-			info := fmt.Sprintf("Cluster: %s\nOrganization: %s", cluster.Name, cluster.OrganizationName)
-			if cluster.Description != "" {
-				info += fmt.Sprintf("\nDescription: %s", cluster.Description)
-			}
-			modalContent.WriteString(modalSubtitleStyle.Render(info))
-			modalContent.WriteString("\n\n")
-		}
-
-		// Text input
-		modalContent.WriteString(m.textInput.View())
-
-		// Show validation error if needed
-		value := m.textInput.Value()
-		if value != "" && strings.ContainsAny(value, "/\\:*?\"<>|") {
-			modalContent.WriteString("\n\n")
-			modalContent.WriteString(modalErrorStyle.Render("⚠ Name contains illegal characters (/\\:*?\"<>|)"))
-		}
-
-		// Help text
-		modalContent.WriteString("\n\n")
-		modalContent.WriteString(modalHelpStyle.Render("Enter: confirm • Esc: back • Ctrl+C: cancel"))
-
-		// Apply modal styling
-		modal := modalStyle.Render(modalContent.String())
-
-		// If window size is not set yet, just return the modal
-		if m.windowWidth == 0 || m.windowHeight == 0 {
-			return modal
-		}
-
-		// Create the overlay effect
-		// Place the modal centered on the screen with a subtle background
-		return lipgloss.Place(
-			m.windowWidth,
-			m.windowHeight,
-			lipgloss.Center,
-			lipgloss.Center,
-			modal,
-			lipgloss.WithWhitespaceBackground(lipgloss.Color("236")),
-		)
-	}
-
-	// In selecting state, show the list
-	return m.list.View()
-}
-
-// isInteractive checks if we're in an interactive terminal
-func isInteractive() bool {
-	if os.Getenv("CI") != "" {
-		return false
-	}
-
-	fileInfo, err := os.Stdout.Stat()
-	if err != nil {
-		return false
-	}
-
-	return (fileInfo.Mode() & os.ModeCharDevice) != 0
-}
 
 // tryConnectToCluster attempts to connect to a cluster using its available addresses
 // and returns the working address and CA certificate. It tries all provided addresses

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -144,10 +145,12 @@ func isPrivateAddress(host string) bool {
 		parts := strings.Split(host, ".")
 		if len(parts) >= 2 {
 			// Second octet should be 16-31 for private range
-			if second := parts[1]; len(second) > 0 {
-				if second >= "16" && second <= "31" {
-					return true
-				}
+			secondOctet, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return false
+			}
+			if secondOctet >= 16 && secondOctet <= 31 {
+				return true
 			}
 		}
 	}

--- a/cli/commands/login.go
+++ b/cli/commands/login.go
@@ -588,7 +588,7 @@ func autoConfigureCluster(ctx *Context, identityName, cloudURL string, keyPair *
 
 	if len(validClusters) > 1 {
 		// Multiple clusters available, don't auto-configure
-		ctx.Info("Multiple clusters available. Run 'miren config bind' to select one:")
+		ctx.Info("Multiple clusters available. Run 'miren cluster add' to select one:")
 		for _, cluster := range validClusters {
 			ctx.Info("  - %s (%s)", cluster.Name, cluster.OrganizationName)
 		}
@@ -605,7 +605,7 @@ func autoConfigureCluster(ctx *Context, identityName, cloudURL string, keyPair *
 	workingAddress, caCert, err := tryConnectToCluster(ctx, &cluster, false)
 	if err != nil {
 		ctx.Warn("Could not automatically connect to cluster: %v", err)
-		ctx.Info("Run 'miren config bind' manually to configure the cluster connection")
+		ctx.Info("Run 'miren cluster add' manually to configure the cluster connection")
 		return ErrAutoConfigFailed
 	}
 

--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -796,3 +796,50 @@ func getConfigPath() (string, bool, error) {
 
 	return filepath.Join(homeDir, DefaultConfigPath), true, nil
 }
+
+// GetActiveConfigPath returns the path to the active configuration file
+func GetActiveConfigPath() string {
+	path, _, _ := getConfigPath()
+	return path
+}
+
+// GetConfigDirPath returns the path to the configuration directory
+func GetConfigDirPath() string {
+	path, _ := getConfigDirPath()
+	if path == "" {
+		// Fallback to default
+		homeDir, _ := os.UserHomeDir()
+		if homeDir != "" {
+			return filepath.Join(homeDir, ".config/miren/clientconfig.d")
+		}
+	}
+	return path
+}
+
+// GetLeafConfigNames returns the names of all leaf configs
+func (c *Config) GetLeafConfigNames() []string {
+	if c == nil {
+		return nil
+	}
+
+	var names []string
+	seen := make(map[string]bool)
+
+	// Get names from leafConfigs
+	for _, leaf := range c.leafConfigs {
+		if leaf.sourcePath != "" && !seen[leaf.sourcePath] {
+			names = append(names, leaf.sourcePath)
+			seen[leaf.sourcePath] = true
+		}
+	}
+
+	// Get names from unsaved leaf configs
+	for name := range c.unsavedLeafConfigs {
+		if !seen[name] {
+			names = append(names, name)
+			seen[name] = true
+		}
+	}
+
+	return names
+}

--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -718,6 +718,8 @@ func loadConfigDir(config *Config) error {
 		leafConfig.active = cdata.Active
 		leafConfig.clusters = cdata.Clusters
 		leafConfig.identities = cdata.Identities
+		// Store the source filename (without directory path and extension) for identification
+		leafConfig.sourcePath = strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
 
 		// Store the leaf config separately
 		config.leafConfigs = append(config.leafConfigs, &leafConfig)

--- a/go.mod
+++ b/go.mod
@@ -227,7 +227,6 @@ require (
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/safchain/ethtool v0.5.9 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,6 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/safchain/ethtool v0.5.9 h1://6RvaOKFf3nQ0rl5+8zBbE4/72455VC9Jq61pfq67E=
 github.com/safchain/ethtool v0.5.9/go.mod h1:w8oSsZeowyRaM7xJJBAbubzzrOkwO8TBgPSEqPP/5mg=
-github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
-github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICsxWQW1msNf49F0Pf2Op5Htayx335Qbs=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=

--- a/pkg/ui/picker.go
+++ b/pkg/ui/picker.go
@@ -186,18 +186,24 @@ func (m *PickerModel) View() string {
 				Width(col.Width).
 				MaxWidth(col.Width).
 				Inline(true)
-			
+
 			// Render the cell with width constraints
 			renderedCell := cellStyle.Render(col.Title)
-			
-			// Then apply header styling (underline, bold, color)
-			headerStyle := lipgloss.NewStyle().
-				Bold(true).
-				Underline(true).
-				UnderlineSpaces(true).
-				Foreground(lipgloss.Color("220"))
-			
-			headerCells = append(headerCells, headerStyle.Render(renderedCell))
+
+			// Apply header styling - skip underline for selection column (first column)
+			if i == 0 && col.Title == "" {
+				// Selection indicator column - no underline
+				headerCells = append(headerCells, renderedCell)
+			} else {
+				// Regular header with underline
+				headerStyle := lipgloss.NewStyle().
+					Bold(true).
+					Underline(true).
+					UnderlineSpaces(true).
+					Foreground(lipgloss.Color("220"))
+
+				headerCells = append(headerCells, headerStyle.Render(renderedCell))
+			}
 		}
 		tableLines = append(tableLines, lipgloss.JoinHorizontal(lipgloss.Top, headerCells...))
 	}

--- a/pkg/ui/picker.go
+++ b/pkg/ui/picker.go
@@ -1,0 +1,239 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// PickerItem represents an item that can be selected in the picker
+type PickerItem interface {
+	// String returns the display text for the item
+	String() string
+	// IsActive returns true if this is the currently active/selected item
+	IsActive() bool
+}
+
+// SimplePickerItem is a basic implementation of PickerItem
+type SimplePickerItem struct {
+	Text   string
+	Active bool
+}
+
+func (s SimplePickerItem) String() string {
+	return s.Text
+}
+
+func (s SimplePickerItem) IsActive() bool {
+	return s.Active
+}
+
+// PickerModel is a generic model for selecting from a list of items
+type PickerModel struct {
+	Title     string
+	Items     []PickerItem
+	cursor    int
+	Selected  PickerItem
+	Cancelled bool
+	Footer    string // Optional footer text
+
+	// Optional styling/marking functions
+	ItemMarker func(item PickerItem) string         // Returns marker like " *" for special items
+	ItemStyle  func(item PickerItem) lipgloss.Style // Returns style for special items
+}
+
+func (m *PickerModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m *PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			m.Cancelled = true
+			return m, tea.Quit
+
+		case "enter", " ":
+			if m.cursor >= 0 && m.cursor < len(m.Items) {
+				m.Selected = m.Items[m.cursor]
+			}
+			return m, tea.Quit
+
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+
+		case "down", "j":
+			if m.cursor < len(m.Items)-1 {
+				m.cursor++
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m *PickerModel) View() string {
+	var b strings.Builder
+
+	b.WriteString(m.Title + "\n\n")
+
+	for i, item := range m.Items {
+		cursor := " "
+		if m.cursor == i {
+			cursor = ">"
+		}
+
+		marker := "  "
+		if m.ItemMarker != nil {
+			marker = m.ItemMarker(item)
+		}
+
+		// Start with base style
+		style := lipgloss.NewStyle()
+
+		// Apply custom item style if provided
+		if m.ItemStyle != nil {
+			style = m.ItemStyle(item)
+		}
+
+		// Apply selection highlighting
+		if m.cursor == i {
+			// Override with selection color unless item already has custom styling
+			if m.ItemStyle == nil {
+				style = style.Foreground(lipgloss.Color("170"))
+			} else {
+				// If there's custom styling, just make it bold
+				style = style.Bold(true).Foreground(lipgloss.Color("170"))
+			}
+		}
+
+		line := fmt.Sprintf("%s %s%s", cursor, item.String(), marker)
+		b.WriteString(style.Render(line) + "\n")
+	}
+
+	b.WriteString("\n(Use arrow keys to navigate, enter to select, esc to cancel)\n")
+
+	if m.Footer != "" {
+		b.WriteString(m.Footer + "\n")
+	}
+
+	return b.String()
+}
+
+// SetCursor sets the cursor to the specified index
+func (m *PickerModel) SetCursor(index int) {
+	if index >= 0 && index < len(m.Items) {
+		m.cursor = index
+	}
+}
+
+// SetCursorToActive sets the cursor to the first active item
+func (m *PickerModel) SetCursorToActive() {
+	for i, item := range m.Items {
+		if item.IsActive() {
+			m.cursor = i
+			return
+		}
+	}
+}
+
+// Picker configuration options
+type PickerOption func(*PickerModel)
+
+// WithTitle sets the picker title
+func WithTitle(title string) PickerOption {
+	return func(m *PickerModel) {
+		m.Title = title
+	}
+}
+
+// WithFooter sets the picker footer text
+func WithFooter(footer string) PickerOption {
+	return func(m *PickerModel) {
+		m.Footer = footer
+	}
+}
+
+// WithActiveMarker sets a function to mark active items (e.g., with " *")
+func WithActiveMarker() PickerOption {
+	return func(m *PickerModel) {
+		m.ItemMarker = func(item PickerItem) string {
+			if item.IsActive() {
+				return " *"
+			}
+			return "  "
+		}
+	}
+}
+
+// WithDimmedActiveStyle dims the active item (useful when it cannot be selected)
+func WithDimmedActiveStyle() PickerOption {
+	return func(m *PickerModel) {
+		m.ItemStyle = func(item PickerItem) lipgloss.Style {
+			if item.IsActive() {
+				return lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+			}
+			return lipgloss.NewStyle()
+		}
+	}
+}
+
+// NewPicker creates a new picker model with the given options
+func NewPicker(items []PickerItem, opts ...PickerOption) *PickerModel {
+	m := &PickerModel{
+		Items: items,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	// Set cursor to active item by default
+	m.SetCursorToActive()
+
+	return m
+}
+
+// RunPicker runs an interactive picker and returns the selected item
+func RunPicker(items []PickerItem, opts ...PickerOption) (PickerItem, error) {
+	// Check if we can run interactive mode
+	if !IsInteractive() {
+		return nil, fmt.Errorf("interactive mode not available")
+	}
+
+	model := NewPicker(items, opts...)
+
+	p := tea.NewProgram(model)
+	result, err := p.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	m := result.(*PickerModel)
+	if m.Cancelled {
+		return nil, nil
+	}
+
+	return m.Selected, nil
+}
+
+// IsInteractive checks if we're in an interactive terminal
+func IsInteractive() bool {
+	if os.Getenv("CI") != "" {
+		return false
+	}
+
+	fileInfo, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+
+	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}

--- a/pkg/ui/picker.go
+++ b/pkg/ui/picker.go
@@ -153,7 +153,7 @@ func (m *PickerModel) View() string {
 
 	// Style for selected row
 	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("170")).
+		Foreground(lipgloss.Color("39")).
 		Bold(true)
 
 	// Style for disabled rows

--- a/pkg/ui/picker.go
+++ b/pkg/ui/picker.go
@@ -181,15 +181,23 @@ func (m *PickerModel) View() string {
 			if i > 0 {
 				headerCells = append(headerCells, "  ")
 			}
+			// First apply width constraints
 			cellStyle := lipgloss.NewStyle().
 				Width(col.Width).
 				MaxWidth(col.Width).
-				Inline(true).
+				Inline(true)
+			
+			// Render the cell with width constraints
+			renderedCell := cellStyle.Render(col.Title)
+			
+			// Then apply header styling (underline, bold, color)
+			headerStyle := lipgloss.NewStyle().
 				Bold(true).
 				Underline(true).
 				UnderlineSpaces(true).
 				Foreground(lipgloss.Color("220"))
-			headerCells = append(headerCells, cellStyle.Render(col.Title))
+			
+			headerCells = append(headerCells, headerStyle.Render(renderedCell))
 		}
 		tableLines = append(tableLines, lipgloss.JoinHorizontal(lipgloss.Top, headerCells...))
 	}


### PR DESCRIPTION
## 💅 MIR-397: Cluster Command Makeover

### The Glow-Up ✨

The cluster management experience just got a fresh new look! We've reorganized commands for clarity and given the UI some love.

### What's New 🎉

**Command Reorganization:**
- `miren config set-active` → `miren cluster switch` (now with interactive picker!)
- `miren config info` → `miren cluster list` (or just `miren cluster`)
- `miren config bind` → `miren cluster add`
- `miren config remove` → `miren cluster remove`
- `miren config info` now shows configuration file details 📁

**UI Polish:**
- **Unified table-based picker** - Consistent, clean table rendering everywhere
- **Smart address sorting** - Public IPs get the spotlight, followed by private networks
- **Miren blue highlights** - Rocking our signature brand blue 💙
- **Subtle styling touches** - Gray port numbers and thoughtful column widths

This makeover brings intuitive command names and a cohesive visual experience to cluster management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster management: list, add, remove, switch. Listing supports table or JSON output and highlights the active cluster.
  * Interactive terminal picker for selections with non-interactive fallbacks and input modal for naming.

* **Improvements**
  * Cluster add: interactive discovery or manual entry with certificate extraction/validation and guided messages.
  * Config info: shows active config path, config directory, active cluster, counts, and leaf config listing.
  
* **Chores**
  * Removed an unused dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->