### PR TITLE
fix: replace 0.0.0.0 with localhost in local auth config

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -682,6 +682,9 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		srvaddr := cfg.Server.GetAddress()
 		if strings.HasPrefix(srvaddr, ":") {
 			srvaddr = "127.0.0.1" + srvaddr
+		} else if strings.HasPrefix(srvaddr, "0.0.0.0:") {
+			// Replace 0.0.0.0 with 127.0.0.1 for local connections
+			srvaddr = strings.Replace(srvaddr, "0.0.0.0:", "127.0.0.1:", 1)
 		}
 		ctx.Log.Info("writing local cluster config", "cluster-name", cfg.Server.GetConfigClusterName(), "server-address", srvaddr)
 		if err := writeLocalClusterConfig(ctx, cert, srvaddr, cfg.Server.GetConfigClusterName()); err != nil {


### PR DESCRIPTION
## Summary
- Fixed TLS certificate validation error when server binds to 0.0.0.0:8443
- Local client config now uses 127.0.0.1 instead of 0.0.0.0 for proper TLS validation

## Problem
When the server is configured to listen on `0.0.0.0:8443`, the automatically generated local client configuration was using that same address. This caused TLS certificate validation errors because certificates don't include `0.0.0.0` as a valid address - they include `127.0.0.1` and `::1` for localhost connections.

## Solution
Added a check in `cli/commands/server.go` to replace `0.0.0.0:` with `127.0.0.1:` when generating the local client config. This ensures the client connects to localhost, which matches the certificate's valid addresses.

## Test Plan
- [x] Built the binary with `make bin/miren`
- [x] Ran lint with `make lint-changed`
- [ ] Test server startup with `0.0.0.0:8443` address
- [ ] Verify local client config uses `127.0.0.1:8443`
- [ ] Confirm `miren apps` command works without TLS errors

Fixes MIR-429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local connections now correctly resolve when the server binds to 0.0.0.0 by using 127.0.0.1, improving reliability of CLI server start/connect flows. Existing handling for addresses starting with a colon remains supported.

* **Chores**
  * Updated public declarations to align with current usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->