### PR TITLE
fix: use proper sandbox ID format for build sandboxes

### DIFF
--- a/servers/build/launch.go
+++ b/servers/build/launch.go
@@ -147,7 +147,7 @@ func (l *LaunchBuildkit) Launch(ctx context.Context, addr string, lo ...LaunchOp
 		},
 	})
 
-	ver := idgen.Gen("buildkit")
+	ver := idgen.GenNS("sb")
 	l.log.Info("creating buildkit sandbox entity", "name", ver)
 
 	var rpcE entityserver_v1alpha.Entity
@@ -155,6 +155,7 @@ func (l *LaunchBuildkit) Launch(ctx context.Context, addr string, lo ...LaunchOp
 		(&core_v1alpha.Metadata{
 			Name: ver,
 		}).Encode,
+		entity.Ident, "sandbox/"+ver,
 		sb.Encode,
 	))
 


### PR DESCRIPTION
## Summary

Build sandboxes now use `idgen.GenNS("sb")` and set `entity.Ident` to `"sandbox/"+ver`, matching the pattern used by the activator.

This ensures build sandbox IDs follow the `sandbox/sb-*` format, allowing commands like `sandbox stop` to work correctly with build sandboxes.

## Problem

Build sandboxes were created with `idgen.Gen("buildkit")` which produces IDs like `buildkitABC123`, and didn't set the `entity.Ident` attribute. This meant they didn't follow the `sandbox/sb-*` format that commands like `sandbox stop` expect.

## Solution

Updated `servers/build/launch.go` to:
1. Use `idgen.GenNS("sb")` instead of `idgen.Gen("buildkit")`
2. Add `entity.Ident, "sandbox/"+ver` to match the pattern in `components/activator/activator.go`

## Testing

CodeRabbit review passed with no issues.

Fixes MIR-433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated internal naming for sandbox build environments to use a dedicated namespace, ensuring consistent, conflict-free identification across systems and multi-tenant setups.
- Chores
  - Added a stable identifier to sandbox build metadata, improving traceability in logs, observability tools, and external integrations, and making debugging and auditing more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->