### PR TITLE
fix: compare commit hashes before build dates in version detection

### DIFF
--- a/pkg/release/version.go
+++ b/pkg/release/version.go
@@ -83,6 +83,16 @@ func parseVersionText(output string) VersionInfo {
 
 // IsNewer returns true if this version is newer than the other
 func (v VersionInfo) IsNewer(other VersionInfo) bool {
+	// If both have commits, compare commits first
+	// Same commit means identical code regardless of build time
+	if v.Commit != "" && v.Commit != "unknown" &&
+		other.Commit != "" && other.Commit != "unknown" {
+		if v.Commit == other.Commit {
+			return false
+		}
+		// Different commits - fall through to build date comparison
+	}
+
 	// If both have build dates, use those for comparison
 	if !v.BuildDate.IsZero() && !other.BuildDate.IsZero() {
 		return v.BuildDate.After(other.BuildDate)

--- a/pkg/release/version_test.go
+++ b/pkg/release/version_test.go
@@ -1,0 +1,141 @@
+package release
+
+import (
+	"testing"
+	"time"
+)
+
+func TestVersionInfo_IsNewer(t *testing.T) {
+	now := time.Now()
+	later := now.Add(5 * time.Minute)
+
+	tests := []struct {
+		name     string
+		v        VersionInfo
+		other    VersionInfo
+		expected bool
+	}{
+		{
+			name: "same commit different build times - not newer",
+			v: VersionInfo{
+				Version:   "main:abc123",
+				Commit:    "abc123def456",
+				BuildDate: later,
+			},
+			other: VersionInfo{
+				Version:   "main:abc123",
+				Commit:    "abc123def456",
+				BuildDate: now,
+			},
+			expected: false,
+		},
+		{
+			name: "different commits newer build time - newer",
+			v: VersionInfo{
+				Version:   "main:def456",
+				Commit:    "def456abc123",
+				BuildDate: later,
+			},
+			other: VersionInfo{
+				Version:   "main:abc123",
+				Commit:    "abc123def456",
+				BuildDate: now,
+			},
+			expected: true,
+		},
+		{
+			name: "different commits older build time - not newer",
+			v: VersionInfo{
+				Version:   "main:def456",
+				Commit:    "def456abc123",
+				BuildDate: now,
+			},
+			other: VersionInfo{
+				Version:   "main:abc123",
+				Commit:    "abc123def456",
+				BuildDate: later,
+			},
+			expected: false,
+		},
+		{
+			name: "no commits different build times - newer by build time",
+			v: VersionInfo{
+				Version:   "main:abc123",
+				BuildDate: later,
+			},
+			other: VersionInfo{
+				Version:   "main:abc123",
+				BuildDate: now,
+			},
+			expected: true,
+		},
+		{
+			name: "no commits same build time same version - not newer",
+			v: VersionInfo{
+				Version:   "main:abc123",
+				BuildDate: now,
+			},
+			other: VersionInfo{
+				Version:   "main:abc123",
+				BuildDate: now,
+			},
+			expected: false,
+		},
+		{
+			name: "unknown commits different build times - newer by build time",
+			v: VersionInfo{
+				Version:   "main:abc123",
+				Commit:    "unknown",
+				BuildDate: later,
+			},
+			other: VersionInfo{
+				Version:   "main:abc123",
+				Commit:    "unknown",
+				BuildDate: now,
+			},
+			expected: true,
+		},
+		{
+			name: "one has build date other doesn't - newer",
+			v: VersionInfo{
+				Version:   "main:abc123",
+				Commit:    "abc123def456",
+				BuildDate: now,
+			},
+			other: VersionInfo{
+				Version: "main:abc123",
+				Commit:  "def456abc123",
+			},
+			expected: true,
+		},
+		{
+			name: "same version no commits no build dates - not newer",
+			v: VersionInfo{
+				Version: "main:abc123",
+			},
+			other: VersionInfo{
+				Version: "main:abc123",
+			},
+			expected: false,
+		},
+		{
+			name: "different versions no other info - newer",
+			v: VersionInfo{
+				Version: "main:def456",
+			},
+			other: VersionInfo{
+				Version: "main:abc123",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.v.IsNewer(tt.other)
+			if got != tt.expected {
+				t.Errorf("IsNewer() = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The server upgrade command was incorrectly detecting upgrades when the same commit was rebuilt with slightly different timestamps. This caused unnecessary downloads and restarts.

Example from miren-garden:
```
$ sudo miren server upgrade --verbose
Upgrading server to base version main...
Downloading base version main...
Downloading: 100% (88.5/88.5 MB)
Installing new binary...
Upgraded from main:62b7d2e to main:62b7d2e  # Same version!
```

## Root Cause

The upgrade check was comparing build timestamps before commit hashes. Multi-artifact builds take ~2.5 minutes, causing each binary to get a slightly different timestamp even though they're built from the same commit:

- Current binary: `62b7d2e` built at `2025-10-02 23:03:21 UTC`
- Remote metadata: `62b7d2e` built at `2025-10-02 23:05:55 UTC`

The `IsNewer()` function compared build dates first, saw `23:05:55 > 23:03:21`, and incorrectly returned `true`.

## Solution

Modified `pkg/release/version.go:IsNewer()` to check commit hashes first:

1. If both versions have the same commit → return `false` (not newer)
2. Only fall through to build date comparison if commits differ or are unavailable

This is semantically correct because identical commits mean identical code, regardless of when they were built.

## Testing

- Added comprehensive unit tests in `pkg/release/version_test.go`
- All tests pass ✓
- Verified with exact production scenario (same commit, different build times) ✓

## Result

After this fix, `miren server upgrade` correctly detects when already on the latest commit and skips unnecessary downloads/restarts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version comparison to avoid falsely treating builds with identical commit IDs as newer. When commits differ, comparison falls back to build date, preserving existing behavior. Prevents incorrect update prompts and ordering.

* **Tests**
  * Added comprehensive tests covering scenarios with identical/different commits, newer/older build dates, missing or unknown fields, and differing versions to ensure accurate version comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->