### PR TITLE
Add health check endpoint for monitoring

### DIFF
--- a/pkg/release/health.go
+++ b/pkg/release/health.go
@@ -31,8 +31,8 @@ type HealthCheckOptions struct {
 func DefaultHealthCheckOptions() HealthCheckOptions {
 	return HealthCheckOptions{
 		ServiceName: "miren",
-		// TODO: Implement proper health check endpoint in miren server
-		// Once implemented, this should be set to the actual health endpoint URL
+		// Health endpoint available at :8989/.well-known/miren/health (returns JSON with component checks)
+		// Set this to check server health during upgrades
 		HealthEndpoint: "",
 		MaxRetries:     30,
 		RetryDelay:     2 * time.Second,

--- a/servers/httpingress/httpingress_test.go
+++ b/servers/httpingress/httpingress_test.go
@@ -1,6 +1,7 @@
 package httpingress
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -112,5 +113,43 @@ func TestHTTPTimeoutHandler(t *testing.T) {
 				t.Errorf("Expected body to contain '%s', got '%s'", tt.expectedBody, body)
 			}
 		})
+	}
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	// Create a simple server instance
+	server := &Server{}
+
+	// Create test request
+	req := httptest.NewRequest("GET", "/.well-known/miren/health", nil)
+	rec := httptest.NewRecorder()
+
+	// Call handler directly
+	server.handleHealth(rec, req)
+
+	// Check status code
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	// Check content type
+	contentType := rec.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("Expected Content-Type 'application/json', got '%s'", contentType)
+	}
+
+	// Parse JSON response
+	var response HealthResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode JSON response: %v", err)
+	}
+
+	// Verify response structure
+	if response.Status == "" {
+		t.Error("Expected status field in response")
+	}
+
+	if response.Checks == nil {
+		t.Error("Expected checks field in response")
 	}
 }


### PR DESCRIPTION
## Summary

Adds a dedicated health check endpoint at `/.well-known/miren/health` that can be used by monitoring tools like Uptime Kuma to verify the Miren server is healthy.

## Motivation

We need a reliable way to monitor Miren server health for production deployments. Currently, there's no dedicated endpoint for health checks, making it difficult to configure monitoring tools or verify server health during upgrades.

## Implementation

**Endpoint**: `/.well-known/miren/health`
- Returns JSON with overall status and component checks
- HTTP 200 when healthy, 503 when unhealthy
- Currently checks etcd connectivity (can be extended for additional components)

**Example Response** (healthy):
```json
{
  "status": "healthy",
  "checks": {
    "etcd": {
      "status": "healthy"
    }
  }
}
```

## Design Decisions

**Why `.well-known/miren/health` instead of `/health`?**

We researched common health check endpoint patterns:

1. **Kubernetes uses `/healthz`, `/livez`, `/readyz`** - However, these are marked as "alpha" and not a stable standard. Since Miren differentiates from k8s, we avoided adopting k8s-specific conventions.

2. **IETF draft standard** - There was a proposed standard ([draft-inadarei-api-health-check](https://datatracker.ietf.org/doc/html/draft-inadarei-api-health-check)) but it has expired and never became official.

3. **No global standard exists** - After research, we found no widely-adopted standard for health check endpoints.

4. **RFC 8615 `.well-known` URIs** - We chose to use the `.well-known` URI namespace (IETF RFC 8615) to:
   - Avoid collision with application routes (apps may serve their own `/health`)
   - Follow an actual IETF standard
   - Establish `miren` as a well-known namespace (can be registered with IANA later)
   - Clearly signal this is infrastructure metadata, not application-level

## Testing

- Added unit tests for the endpoint
- Verified JSON structure and content type
- All existing tests pass

## Usage

For Uptime Kuma or similar monitoring tools:
```
URL: http://miren-server:8989/.well-known/miren/health
Expected Status: 200
Type: HTTP (JSON)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a pre-routing health check endpoint at /.well-known/miren/health returning JSON with overall status and per-check details (including etcd). Responds 200 when healthy, 503 otherwise.

- Tests
  - Added tests validating health endpoint status codes, Content-Type, and JSON payload structure.

- Documentation
  - Clarified default health check options and described the health endpoint’s role during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->