### PR TITLE
Run CI on all pull requests, not just those targeting main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   # Used by golangci-lint to emit annotations that are picked up by github


### PR DESCRIPTION
## Summary
Allow CI to run on stacked PRs by removing the branch restriction from the `pull_request` trigger.

Previously, CI would only run on PRs targeting `main`. Now it will run on all PRs, including those targeting feature branches.

## Test plan
- CI will continue to run on PRs targeting main
- CI will now also run on stacked PRs (e.g., PR targeting another feature branch)
- CI will re-run when new commits are pushed (via the default `synchronize` event)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated continuous integration to run on all pull requests, ensuring automated checks are applied consistently across contributions.
  - Broadens test coverage for incoming changes, enabling earlier feedback and reducing the risk of regressions.
  - Improves reliability of review workflows by standardizing when CI is triggered, helping maintain overall product quality before merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->