### PR TITLE
Add systemd service management with graceful drain and cloud registration

### DIFF
--- a/cli/commands/commands_linux.go
+++ b/cli/commands/commands_linux.go
@@ -31,6 +31,19 @@ func addCommands(cmds map[string]cli.CommandFactory) {
 	cmds["register status"] = func() (cli.Command, error) {
 		return Infer("register status", "Show cluster registration status", RegisterStatus), nil
 	}
+
+	// Server management commands
+	cmds["server install"] = func() (cli.Command, error) {
+		return Infer("server install", "Install systemd service for miren server", ServerInstall), nil
+	}
+
+	cmds["server uninstall"] = func() (cli.Command, error) {
+		return Infer("server uninstall", "Remove systemd service for miren server", ServerUninstall), nil
+	}
+
+	cmds["server status"] = func() (cli.Command, error) {
+		return Infer("server status", "Show miren service status", ServerStatus), nil
+	}
 }
 
 func (c *Context) setupServerComponents(ctx context.Context, reg *asm.Registry) {

--- a/cli/commands/register.go
+++ b/cli/commands/register.go
@@ -9,13 +9,16 @@ import (
 	"miren.dev/runtime/pkg/registration"
 )
 
-// Register handles cluster registration with miren.cloud
-func Register(ctx *Context, opts struct {
+// RegisterOptions contains options for cluster registration
+type RegisterOptions struct {
 	ClusterName string            `short:"n" long:"name" description:"Cluster name" required:"true"`
 	CloudURL    string            `short:"u" long:"url" description:"Cloud URL" default:"https://miren.cloud"`
 	Tags        map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
 	OutputDir   string            `short:"o" long:"output" description:"Output directory for registration" default:"/var/lib/miren/server"`
-}) error {
+}
+
+// Register handles cluster registration with miren.cloud
+func Register(ctx *Context, opts RegisterOptions) error {
 	clean := map[string]string{}
 
 	// Validate tags

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -11,10 +11,12 @@ import (
 	"net/netip"
 	"os"
 	"os/exec"
+	"os/signal"
 	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -697,6 +699,31 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 
 	ctx.Info("Miren server started successfully! You can now connect to the cluster using `-C %s`\n", cfg.Server.GetConfigClusterName())
 	ctx.Info("For example: cd my-app && miren deploy -C %s", cfg.Server.GetConfigClusterName())
+
+	// Set up signal handling for graceful drain on SIGUSR2
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGUSR2)
+
+	eg.Go(func() error {
+		select {
+		case <-sub.Done():
+			return nil
+		case sig := <-sigChan:
+			ctx.Log.Info("received signal, draining runner", "signal", sig)
+
+			// Drain the runner
+			drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			if err := r.Drain(drainCtx); err != nil {
+				ctx.Log.Error("failed to drain runner", "error", err)
+				return err
+			}
+
+			ctx.Log.Info("runner drained successfully, shutting down")
+			return fmt.Errorf("runner drained, shutting down")
+		}
+	})
 
 	// Wait for all goroutines to complete or context to be cancelled
 	err = eg.Wait()

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -226,10 +226,10 @@ WantedBy=multi-user.target
 
 // ServerUninstall removes the systemd service and optionally removes /var/lib/miren
 func ServerUninstall(ctx *Context, opts struct {
-	Stop         bool   `long:"stop" description:"Stop the service before uninstalling"`
-	RemoveData   bool   `long:"remove-data" description:"Remove /var/lib/miren directory after backing it up"`
-	BackupDir    string `long:"backup-dir" description:"Directory to save backup tarball" default:"/tmp"`
-	SkipBackup   bool   `long:"skip-backup" description:"Skip backup when removing data (dangerous)"`
+	Stop       bool   `long:"stop" description:"Stop the service before uninstalling"`
+	RemoveData bool   `long:"remove-data" description:"Remove /var/lib/miren directory after backing it up"`
+	BackupDir  string `long:"backup-dir" description:"Directory to save backup tarball" default:"."`
+	SkipBackup bool   `long:"skip-backup" description:"Skip backup when removing data (dangerous)"`
 }) error {
 	// Check if running with sufficient privileges
 	if os.Geteuid() != 0 {

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -226,7 +226,6 @@ WantedBy=multi-user.target
 
 // ServerUninstall removes the systemd service and optionally removes /var/lib/miren
 func ServerUninstall(ctx *Context, opts struct {
-	Stop       bool   `long:"stop" description:"Stop the service before uninstalling"`
 	RemoveData bool   `long:"remove-data" description:"Remove /var/lib/miren directory after backing it up"`
 	BackupDir  string `long:"backup-dir" description:"Directory to save backup tarball" default:"."`
 	SkipBackup bool   `long:"skip-backup" description:"Skip backup when removing data (dangerous)"`
@@ -263,20 +262,18 @@ func ServerUninstall(ctx *Context, opts struct {
 		}
 	}
 
-	// Stop the service if requested or if it's running
-	if opts.Stop || isRunning {
-		ctx.Info("Stopping miren service...")
-		cmd := exec.Command("systemctl", "stop", "miren.service")
-		if output, err := cmd.CombinedOutput(); err != nil {
-			ctx.Warn("Failed to stop service: %v\nOutput: %s", err, output)
-		} else {
-			ctx.Completed("Service stopped")
-		}
+	// Stop the service
+	ctx.Info("Stopping miren service...")
+	cmd := exec.Command("systemctl", "stop", "miren.service")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		ctx.Warn("Failed to stop service: %v\nOutput: %s", err, output)
+	} else {
+		ctx.Completed("Service stopped")
 	}
 
 	// Disable the service
 	ctx.Info("Disabling miren service...")
-	cmd := exec.Command("systemctl", "disable", "miren.service")
+	cmd = exec.Command("systemctl", "disable", "miren.service")
 	if output, err := cmd.CombinedOutput(); err != nil {
 		ctx.Warn("Failed to disable service: %v\nOutput: %s", err, output)
 	} else {

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"time"
@@ -64,6 +65,8 @@ type Runner struct {
 	closers []io.Closer
 
 	namespace string
+
+	sbController *sandbox.SandboxController
 }
 
 func (r *Runner) Close() error {
@@ -77,6 +80,63 @@ func (r *Runner) Close() error {
 	}
 
 	return err
+}
+
+// Drain sets the runner's node status to disabled and stops all running sandboxes
+func (r *Runner) Drain(ctx context.Context) error {
+	if r.ec == nil || r.Id == "" {
+		return fmt.Errorf("runner not initialized with entity client")
+	}
+
+	r.Log.Info("draining runner", "id", r.Id)
+
+	// Set node status to disabled
+	r.Log.Info("setting node status to disabled", "id", r.Id)
+	err := r.ec.UpdateAttrs(ctx, entity.Id(r.Id), (&compute_v1alpha.Node{
+		Status: compute_v1alpha.DISABLED,
+	}).Encode)
+	if err != nil {
+		return fmt.Errorf("failed to set node status to disabled: %w", err)
+	}
+
+	r.Log.Info("node status set to disabled", "id", r.Id)
+
+	// List all sandboxes scheduled to this node
+	idx := compute_v1alpha.Index(compute_v1alpha.KindSandbox, entity.Id("node/"+r.Id))
+	results, err := r.ec.List(ctx, idx)
+	if err != nil {
+		return fmt.Errorf("failed to query sandboxes on node: %w", err)
+	}
+
+	sandboxCount := results.Length()
+	r.Log.Info("found sandboxes to drain", "count", sandboxCount, "node", r.Id)
+
+	// Stop each sandbox
+	var drainErr error
+	stoppedCount := 0
+	for results.Next() {
+		md := results.Metadata()
+		if md == nil {
+			continue
+		}
+
+		r.Log.Info("stopping sandbox", "id", md.ID)
+		err := r.sbController.Delete(ctx, md.ID)
+		if err != nil {
+			r.Log.Error("failed to stop sandbox", "id", md.ID, "error", err)
+			drainErr = multierror.Append(drainErr, fmt.Errorf("failed to stop sandbox %s: %w", md.ID, err))
+		} else {
+			r.Log.Info("stopped sandbox", "id", md.ID)
+			stoppedCount++
+		}
+	}
+
+	if drainErr != nil {
+		return fmt.Errorf("errors during drain: %w", drainErr)
+	}
+
+	r.Log.Info("runner drained successfully", "id", r.Id, "sandboxes_stopped", stoppedCount)
+	return nil
 }
 
 func (r *Runner) ContainerdNamespace() string {
@@ -245,6 +305,7 @@ func (r *Runner) SetupControllers(
 
 	r.cc = sbc.CC
 	r.namespace = sbc.Namespace
+	r.sbController = &sbc
 
 	workers := r.Workers
 	if workers <= 0 {

--- a/pkg/caauth/caauth.go
+++ b/pkg/caauth/caauth.go
@@ -76,9 +76,16 @@ func New(opts Options) (*Authority, error) {
 		return nil, fmt.Errorf("parsing CA certificate: %w", err)
 	}
 
+	// Export certificate
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	})
+
 	return &Authority{
-		cert: cert,
-		key:  priv,
+		cert:    cert,
+		certPEM: certPEM,
+		key:     priv,
 	}, nil
 }
 

--- a/pkg/caauth/caauth_test.go
+++ b/pkg/caauth/caauth_test.go
@@ -163,49 +163,6 @@ func TestGetCACertificate(t *testing.T) {
 	r.Equal("Test CA", cert.Subject.CommonName)
 }
 
-func TestClientCertificateMarshalUnmarshal(t *testing.T) {
-	r := require.New(t)
-
-	// Create a CA and issue a certificate
-	ca, err := New(Options{
-		CommonName:   "Test CA",
-		Organization: "Test Org",
-		Country:      "US",
-		ValidFor:     24 * time.Hour,
-	})
-	r.NoError(err)
-
-	originalCert, err := ca.IssueCertificate(Options{
-		CommonName:   "test.example.com",
-		Organization: "Test Org",
-		Country:      "US",
-		ValidFor:     time.Hour,
-	})
-	r.NoError(err)
-
-	// Marshal the certificate
-	marshaledData, err := originalCert.MarshalText()
-	r.NoError(err)
-	r.NotEmpty(marshaledData)
-
-	// Unmarshal into a new certificate
-	var unmarshaledCert ClientCertificate
-	err = unmarshaledCert.UnmarshalText(marshaledData)
-	r.NoError(err)
-
-	// Verify the certificates match
-	r.Equal(originalCert.CertPEM, unmarshaledCert.CertPEM)
-	r.Equal(originalCert.KeyPEM, unmarshaledCert.KeyPEM)
-
-	// Verify the unmarshaled certificate is still valid
-	err = ca.VerifyCertificate(unmarshaledCert.CertPEM)
-	r.NoError(err)
-
-	// Test unmarshaling invalid data
-	err = unmarshaledCert.UnmarshalText([]byte("invalid json"))
-	r.Error(err)
-}
-
 func TestClientCertificateValidation(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/rpc/error.go
+++ b/pkg/rpc/error.go
@@ -48,10 +48,7 @@ func (e *ResolveError) Unwrap() error {
 
 func (e *ResolveError) Is(target error) bool {
 	_, ok := target.(*ResolveError)
-	if !ok {
-		return false
-	}
-	return true
+	return ok
 }
 
 // Exported sentinel errors for common resolve error kinds

--- a/pkg/rpc/error.go
+++ b/pkg/rpc/error.go
@@ -1,5 +1,7 @@
 package rpc
 
+import "fmt"
+
 type ErrorCategory interface {
 	ErrorCategory() string
 }
@@ -10,4 +12,96 @@ type ErrorCode interface {
 
 type ErrorMessage interface {
 	ErrorMessage() string
+}
+
+// ResolveErrorKind represents different kinds of capability resolution errors
+type ResolveErrorKind int
+
+const (
+	ResolveHTTPError ResolveErrorKind = iota
+	ResolveStatusError
+	ResolveDecodeError
+	ResolveLookupError
+)
+
+// ResolveError represents an error that occurred during capability resolution
+type ResolveError struct {
+	Kind       ResolveErrorKind
+	Err        error
+	Msg        string
+	StatusCode int // HTTP status code for ResolveStatusError
+}
+
+func (e *ResolveError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "resolve error"
+}
+
+func (e *ResolveError) Unwrap() error {
+	return e.Err
+}
+
+func (e *ResolveError) Is(target error) bool {
+	_, ok := target.(*ResolveError)
+	if !ok {
+		return false
+	}
+	return true
+}
+
+// Exported sentinel errors for common resolve error kinds
+var (
+	ErrResolveHTTP   = &ResolveError{Kind: ResolveHTTPError, Msg: "http request error"}
+	ErrResolveStatus = &ResolveError{Kind: ResolveStatusError, Msg: "unexpected status code"}
+	ErrResolveDecode = &ResolveError{Kind: ResolveDecodeError, Msg: "decode error"}
+	ErrResolveLookup = &ResolveError{Kind: ResolveLookupError, Msg: "lookup error"}
+)
+
+// NewResolveError creates a new ResolveError with the specified kind and underlying error
+func NewResolveError(kind ResolveErrorKind, err error, msg string) error {
+	return &ResolveError{
+		Kind: kind,
+		Err:  err,
+		Msg:  msg,
+	}
+}
+
+// NewResolveHTTPError creates an HTTP request error
+func NewResolveHTTPError(err error, format string, args ...interface{}) error {
+	return &ResolveError{
+		Kind: ResolveHTTPError,
+		Err:  err,
+		Msg:  fmt.Sprintf(format, args...),
+	}
+}
+
+// NewResolveStatusError creates a status code error
+func NewResolveStatusError(statusCode int) error {
+	return &ResolveError{
+		Kind:       ResolveStatusError,
+		StatusCode: statusCode,
+		Msg:        fmt.Sprintf("unexpected status code: %d", statusCode),
+	}
+}
+
+// NewResolveDecodeError creates a decode error
+func NewResolveDecodeError(err error) error {
+	return &ResolveError{
+		Kind: ResolveDecodeError,
+		Err:  err,
+		Msg:  fmt.Sprintf("unable to decode response body: %v", err),
+	}
+}
+
+// NewResolveLookupError creates a lookup error
+func NewResolveLookupError(msg string) error {
+	return &ResolveError{
+		Kind: ResolveLookupError,
+		Msg:  msg,
+	}
 }


### PR DESCRIPTION
This PR adds comprehensive systemd service management commands for the miren server, including graceful node draining, idempotent installation, and cloud registration integration.

Closes MIR-442

## Summary

- New CLI commands: `miren server install`, `miren server uninstall`, `miren server status`
- Graceful node drain on SIGUSR2 signal before shutdown
- Automatic cloud registration during installation
- Improved RPC error handling with user-friendly messages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux CLI: add server install/uninstall/status commands to manage the server as a system service (install/enable/start, stop/disable, status, log follow, optional data backup/remove).
  * Graceful server drain on signal to safely stop active workloads and drain running sandboxes.

* **Bug Fixes**
  * Clearer "access denied" reporting with a user-facing warning for remote operations.
  * More descriptive, categorized errors when resolving remote capabilities for improved diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->