### PR TITLE
Update linter configuration to run on entire codebase

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.2
-        only-new-issues: true
+        version: v2.5.0
 
     - name: Check go.mod tidiness
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,8 @@ The system uses Dagger for containerized development with all dependencies (cont
 
 ### Code Style & Formatting
 
-- **ALWAYS run `make lint-changed` before committing** - This runs go fmt, go vet on changed files and go mod tidy
+- **ALWAYS run `make lint` before committing** - This runs golangci-lint on the entire codebase
+- Run `make lint-fix` to automatically fix issues where possible
 - The codebase follows standard Go formatting conventions
 - **Comment style**: Only add comments when they provide valuable context or explain "why" something is done
   - Avoid redundant comments that restate what the code does (e.g., `// Start server` above `server.Start()`)

--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,6 @@ lint-fix:
 
 .PHONY: lint-fix
 
-lint-changed:
-	@bash ./hack/lint-changed.sh
-
-.PHONY: lint-changed
-
 lint-pr:
 	golangci-lint run --new-from-rev main ./...
 

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748352427,
-        "narHash": "sha256-k4Kfgj8i9l4w/FyX3f5HYjvGz+/bzyh0ALnVUJkOvqM=",
+        "lastModified": 1759943815,
+        "narHash": "sha256-FRQ39EJyAXjwhD6jo21cBwPu84MuMEkTIWKHm4Sp6D0=",
         "owner": "dagger",
         "repo": "nix",
-        "rev": "70530d252c0b3172161dbbb81dc3f63a33a4f17b",
+        "rev": "474769abf51cdb9dc460030632ef28ff8a43c2f5",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744868846,
-        "narHash": "sha256-5RJTdUHDmj12Qsv7XOhuospjAjATNiTMElplWnJE9Hs=",
+        "lastModified": 1759977445,
+        "narHash": "sha256-LYr4IDfuihCkFAkSYz5//gT2r1ewcWBYgd5AxPzPLIo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ebe4301cbd8f81c4f8d3244b3632338bbeb6d49c",
+        "rev": "2dad7af78a183b6c486702c18af8a9544f298377",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Remove `lint-changed` make target and update documentation to use `make lint`
- Update GitHub Actions to run golangci-lint on entire codebase (remove `only-new-issues: true`)
- Upgrade golangci-lint from v2.2 to v2.5.0
- Update nix flake.lock with latest dependencies

Now that all lint issues are fixed, we can run the linter on the entire codebase to ensure consistent code quality.

## Test plan
- [x] CI lint job will run golangci-lint v2.5.0 on entire codebase
- [x] All existing tests should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Chores
  - Updated CI linting action to the latest version for improved reliability.
  - Simplified lint workflow by removing the “lint-changed” make target.

- Documentation
  - Updated linting instructions: use “make lint” before committing; added “make lint-fix” for auto-fixes.
  - Expanded code style guidance with clearer expectations for meaningful comments and documenting side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->