### PR TITLE
Optimize Docker build in release workflow (20+ min → 2-5 min)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Download amd64 package
+        uses: actions/download-artifact@v4
+        with:
+          name: miren-base-linux-amd64
+          path: artifacts/amd64
+
+      - name: Download arm64 package
+        uses: actions/download-artifact@v4
+        with:
+          name: miren-base-linux-arm64
+          path: artifacts/arm64
+
+      - name: Extract pre-built binaries
+        run: |
+          mkdir -p docker/artifacts/amd64 docker/artifacts/arm64
+          tar -xzf artifacts/amd64/release-base-linux-amd64.tar.gz -C docker/artifacts/amd64
+          tar -xzf artifacts/arm64/release-base-linux-arm64.tar.gz -C docker/artifacts/arm64
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:

--- a/docker/Dockerfile.miren
+++ b/docker/Dockerfile.miren
@@ -1,17 +1,6 @@
 # Multi-stage Dockerfile for Miren Runtime OCI image
 # This image contains all executables needed to run the miren server
 
-# Build stage
-FROM golang:1.24 AS builder
-
-WORKDIR /build
-
-# Copy source code
-COPY . .
-
-# Build miren binary
-RUN make bin/miren
-
 # Final stage
 FROM ubuntu:22.04
 
@@ -30,38 +19,12 @@ RUN apt-get update && apt-get install -y \
 ARG TARGETARCH
 RUN echo "Building for architecture: $TARGETARCH"
 
-# Download and install containerd
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        CONTAINERD_URL="https://github.com/containerd/containerd/releases/download/v2.0.4/containerd-2.0.4-linux-arm64.tar.gz"; \
-    else \
-        CONTAINERD_URL="https://github.com/containerd/containerd/releases/download/v2.0.4/containerd-2.0.4-linux-amd64.tar.gz"; \
-    fi && \
-    curl -L "$CONTAINERD_URL" | tar -C /usr/local -xz
-
-
-# Download and install runc
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        RUNC_URL="https://github.com/opencontainers/runc/releases/download/v1.2.2/runc.arm64"; \
-    else \
-        RUNC_URL="https://github.com/opencontainers/runc/releases/download/v1.2.2/runc.amd64"; \
-    fi && \
-    curl -L "$RUNC_URL" -o /usr/local/bin/runc && \
-    chmod +x /usr/local/bin/runc
-
-
-# Download and install nerdctl (for debugging)
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        NERDCTL_URL="https://github.com/containerd/nerdctl/releases/download/v2.0.5/nerdctl-2.0.5-linux-arm64.tar.gz"; \
-    else \
-        NERDCTL_URL="https://github.com/containerd/nerdctl/releases/download/v2.0.5/nerdctl-2.0.5-linux-amd64.tar.gz"; \
-    fi && \
-    curl -L "$NERDCTL_URL" | tar -C /usr/local/bin -xz
+# Copy pre-built artifacts from extracted tarballs
+# These are extracted in the GitHub Actions workflow before the Docker build
+COPY docker/artifacts/${TARGETARCH}/ /usr/local/bin/
 
 # Copy configuration files
 COPY hack/containerd-config.toml /etc/containerd/config.toml
-
-# Copy miren binary from builder
-COPY --from=builder /build/bin/miren /usr/local/bin/miren
 
 # Create necessary directories
 RUN mkdir -p /var/lib/miren/containerd /var/lib/miren/containerd/state /var/log /root/.config/miren


### PR DESCRIPTION
## Summary
Significantly speeds up the `build-and-push-docker` job in the release workflow by eliminating redundant builds and downloads.

## Changes

### 1. Use pre-built artifacts instead of rebuilding
- The `package` job already builds miren binaries with all runtime dependencies (containerd, runc, nerdctl, etc.)
- Download these pre-built artifacts and extract them before the Docker build
- Copy the extracted binaries directly into the Docker image instead of building from source

### 2. Eliminate redundant downloads
- Removed slow `curl` downloads for containerd, runc, and nerdctl from Dockerfile
- Removed the entire Go build stage from the multi-stage Dockerfile
- All binaries now come from the pre-built packages

## Performance Impact
- **Before:** 20+ minutes for Docker build
- **After:** ~2-5 minutes (just copying binaries + installing apt packages)
- **Savings:** ~15-18 minutes per release

## Testing
- [ ] Verify Docker image builds successfully for both amd64 and arm64
- [ ] Confirm all expected binaries are present in the final image
- [ ] Test that the miren server starts correctly from the built image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to download prebuilt amd64/arm64 binaries and stage them for Docker builds, streamlining the build-and-push process.

* **Refactor**
  * Simplified Docker image build to use prebuilt binaries instead of building in-container.
  * Removed runtime downloads and builder stages, improving build speed and reliability across architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->