### PR TITLE
Add SandboxPoolManager Controller

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -592,6 +592,9 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 
 	aa := co.Activator()
 
+	// Create SandboxPoolManager to reconcile pool entities
+	spm := co.SandboxPoolManager()
+
 	// HttpRequestTimeout is already validated by cfg.Validate() to be >= 1
 	// No need for additional checks here
 
@@ -601,6 +604,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	hs := httpingress.NewServer(ctx, ctx.Log, ingressConfig, client, aa, &httpMetrics)
 
 	reg.Register("app-activator", aa)
+	reg.Register("sandbox-pool-manager", spm)
 	reg.Register("resolver", res)
 
 	rcfg, err := co.NamedConfig("runner")

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -26,6 +26,7 @@ import (
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/components/activator"
 	"miren.dev/runtime/components/netresolve"
+	"miren.dev/runtime/controllers/sandboxpool"
 	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/caauth"
@@ -87,7 +88,8 @@ type Coordinator struct {
 
 	state *rpc.State
 
-	aa activator.AppActivator
+	aa  activator.AppActivator
+	spm *sandboxpool.Manager
 
 	authority *caauth.Authority
 
@@ -99,6 +101,10 @@ type Coordinator struct {
 
 func (c *Coordinator) Activator() activator.AppActivator {
 	return c.aa
+}
+
+func (c *Coordinator) SandboxPoolManager() *sandboxpool.Manager {
+	return c.spm
 }
 
 const (
@@ -446,6 +452,9 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	aa := activator.NewLocalActivator(ctx, c.Log, eac)
 	c.aa = aa
+
+	spm := sandboxpool.NewManager(c.Log, eac)
+	c.spm = spm
 
 	eps := execproxy.NewServer(c.Log, eac, rs, aa)
 	server.ExposeValue("dev.miren.runtime/exec", exec_v1alpha.AdaptSandboxExec(eps))

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -455,6 +455,11 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	spm := sandboxpool.NewManager(c.Log, eac)
 	c.spm = spm
+	go func() {
+		if err := spm.Run(ctx); err != nil && ctx.Err() == nil {
+			c.Log.Error("sandbox pool manager stopped", "error", err)
+		}
+	}()
 
 	eps := execproxy.NewServer(c.Log, eac, rs, aa)
 	server.ExposeValue("dev.miren.runtime/exec", exec_v1alpha.AdaptSandboxExec(eps))

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -200,6 +200,7 @@ func (m *Manager) createSandbox(ctx context.Context, pool *compute_v1alpha.Sandb
 				"pool", pool.ID.String(),
 			),
 		}).Encode,
+		entity.Ident, entity.MustKeyword("sandbox/"+sbName),
 		sb.Encode,
 	))
 

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -118,6 +118,12 @@ func (m *Manager) reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPo
 				// Continue - partial scaling is acceptable
 			}
 		}
+
+		// Recount after creating sandboxes
+		actual, ready, err = m.countSandboxes(ctx, pool)
+		if err != nil {
+			return fmt.Errorf("failed to count sandboxes after scale up: %w", err)
+		}
 	}
 
 	// Scale down if needed (TODO: implement with delay + safety checks)

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -1,0 +1,248 @@
+package sandboxpool
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/rpc/stream"
+)
+
+// Manager reconciles SandboxPool entities by ensuring the actual number of
+// sandbox instances matches the desired number specified in the pool.
+type Manager struct {
+	log *slog.Logger
+	eac *entityserver_v1alpha.EntityAccessClient
+}
+
+// NewManager creates a new SandboxPoolManager
+func NewManager(
+	log *slog.Logger,
+	eac *entityserver_v1alpha.EntityAccessClient,
+) *Manager {
+	return &Manager{
+		log: log.With("component", "sandboxpool-manager"),
+		eac: eac,
+	}
+}
+
+// Run starts the reconciliation loop that watches SandboxPool entities
+// and reconciles them to match desired state.
+func (m *Manager) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		m.log.Info("starting sandbox pool watch")
+
+		_, err := m.eac.WatchIndex(
+			ctx,
+			entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool),
+			stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
+				if !op.HasEntity() {
+					return nil
+				}
+
+				var pool compute_v1alpha.SandboxPool
+				pool.Decode(op.Entity().Entity())
+
+				// Trigger reconciliation for this pool
+				if err := m.reconcile(ctx, &pool); err != nil {
+					m.log.Error("reconcile failed",
+						"pool", pool.ID,
+						"service", pool.Service,
+						"error", err)
+				}
+
+				return nil
+			}),
+		)
+
+		if err != nil && ctx.Err() == nil {
+			m.log.Error("watch failed, restarting in 5s", "error", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		return err
+	}
+}
+
+// reconcile brings the actual sandbox state in line with the desired state
+// specified in the pool entity.
+func (m *Manager) reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPool) error {
+	m.log.Debug("reconciling pool",
+		"pool", pool.ID,
+		"service", pool.Service,
+		"desired", pool.DesiredInstances)
+
+	// Count actual sandboxes for this pool
+	actual, ready, err := m.countSandboxes(ctx, pool)
+	if err != nil {
+		return fmt.Errorf("failed to count sandboxes: %w", err)
+	}
+
+	desired := pool.DesiredInstances
+
+	m.log.Debug("sandbox counts",
+		"pool", pool.ID,
+		"actual", actual,
+		"ready", ready,
+		"desired", desired)
+
+	// Scale up if needed
+	if actual < desired {
+		toCreate := desired - actual
+		m.log.Info("scaling up pool",
+			"pool", pool.ID,
+			"service", pool.Service,
+			"current", actual,
+			"desired", desired,
+			"creating", toCreate)
+
+		for i := int64(0); i < toCreate; i++ {
+			if err := m.createSandbox(ctx, pool); err != nil {
+				m.log.Error("failed to create sandbox",
+					"pool", pool.ID,
+					"error", err)
+				// Continue - partial scaling is acceptable
+			}
+		}
+	}
+
+	// Scale down if needed (TODO: implement with delay + safety checks)
+	if actual > desired {
+		m.log.Info("scale down needed but not yet implemented",
+			"pool", pool.ID,
+			"current", actual,
+			"desired", desired)
+	}
+
+	// Update pool status
+	return m.updatePoolStatus(ctx, pool, actual, ready)
+}
+
+// countSandboxes returns the total and ready sandbox count for a pool
+func (m *Manager) countSandboxes(ctx context.Context, pool *compute_v1alpha.SandboxPool) (total, ready int64, err error) {
+	// List all sandboxes (no filtering by label in List API)
+	resp, err := m.eac.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to list sandboxes: %w", err)
+	}
+
+	total = 0
+	ready = 0
+
+	for _, ent := range resp.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(ent.Entity())
+
+		// Filter: only count sandboxes for this pool's version and service
+		if sb.Version.String() != pool.SandboxSpec.Version.String() {
+			continue
+		}
+
+		// Check service label
+		var md core_v1alpha.Metadata
+		md.Decode(ent.Entity())
+
+		serviceLabel := ""
+		for _, label := range md.Labels {
+			if label.Key == "service" {
+				serviceLabel = label.Value
+				break
+			}
+		}
+
+		if serviceLabel != pool.Service {
+			continue
+		}
+
+		total++
+
+		if sb.Status == compute_v1alpha.RUNNING {
+			ready++
+		}
+	}
+
+	return total, ready, nil
+}
+
+// createSandbox creates a new sandbox from the pool's SandboxSpec template
+func (m *Manager) createSandbox(ctx context.Context, pool *compute_v1alpha.SandboxPool) error {
+	// Generate sandbox name
+	sbName := idgen.GenNS("sb")
+
+	// Clone the SandboxSpec into a Sandbox entity
+	sb := compute_v1alpha.Sandbox{
+		Status:  compute_v1alpha.PENDING,
+		Version: pool.SandboxSpec.Version,
+		Spec:    pool.SandboxSpec,
+	}
+
+	// Create entity with metadata (Put without ID creates new entity)
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetAttrs(entity.Attrs(
+		(&core_v1alpha.Metadata{
+			Name: sbName,
+			Labels: types.LabelSet(
+				"service", pool.Service,
+				"pool", pool.ID.String(),
+			),
+		}).Encode,
+		sb.Encode,
+	))
+
+	resp, err := m.eac.Put(ctx, &rpcE)
+	if err != nil {
+		return fmt.Errorf("failed to create sandbox entity: %w", err)
+	}
+
+	m.log.Info("created sandbox",
+		"sandbox", resp.Id(),
+		"pool", pool.ID,
+		"service", pool.Service)
+
+	return nil
+}
+
+// updatePoolStatus updates the pool's CurrentInstances and ReadyInstances fields
+func (m *Manager) updatePoolStatus(ctx context.Context, pool *compute_v1alpha.SandboxPool, current, ready int64) error {
+	// Only update if values changed
+	if pool.CurrentInstances == current && pool.ReadyInstances == ready {
+		return nil
+	}
+
+	pool.CurrentInstances = current
+	pool.ReadyInstances = ready
+
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetId(pool.ID.String())
+	rpcE.SetAttrs(entity.Attrs(
+		(&compute_v1alpha.SandboxPool{
+			CurrentInstances: current,
+			ReadyInstances:   ready,
+		}).Encode,
+	))
+
+	if _, err := m.eac.Put(ctx, &rpcE); err != nil {
+		return fmt.Errorf("failed to update pool status: %w", err)
+	}
+
+	m.log.Debug("updated pool status",
+		"pool", pool.ID,
+		"current", current,
+		"ready", ready)
+
+	return nil
+}

--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -2,6 +2,7 @@ package sandboxpool
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -109,7 +110,7 @@ func TestManagerScaleUpPartial(t *testing.T) {
 			Version: pool.SandboxSpec.Version,
 			Spec:    pool.SandboxSpec,
 		}
-		_, err := server.Client.Create(ctx, "existing-sb", sb,
+		_, err := server.Client.Create(ctx, fmt.Sprintf("existing-sb-%d", i), sb,
 			entityserver.WithLabels(types.LabelSet("service", "api", "pool", poolID.String())))
 		require.NoError(t, err)
 	}

--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -368,9 +367,6 @@ func TestManagerNoUpdateWhenStatusUnchanged(t *testing.T) {
 	_, err = server.Client.Create(ctx, "sb", sb,
 		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
 	require.NoError(t, err)
-
-	// Wait a bit to ensure any processing completes
-	time.Sleep(10 * time.Millisecond)
 
 	// Run reconciliation
 	manager := NewManager(log, server.EAC)

--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -128,9 +128,10 @@ func TestManagerScaleUpPartial(t *testing.T) {
 	running := 0
 	pending := 0
 	for _, sb := range sandboxes {
-		if sb.Status == compute_v1alpha.RUNNING {
+		switch sb.Status {
+		case compute_v1alpha.RUNNING:
 			running++
-		} else if sb.Status == compute_v1alpha.PENDING {
+		case compute_v1alpha.PENDING:
 			pending++
 		}
 	}

--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -1,0 +1,442 @@
+package sandboxpool
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
+)
+
+// TestManagerScaleUpFromZero tests that the manager creates sandboxes
+// when the pool has DesiredInstances > 0 and no existing sandboxes
+func TestManagerScaleUpFromZero(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create a sandbox pool with desired instances
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 3,
+		CurrentInstances: 0,
+		ReadyInstances:   0,
+		Mode:             compute_v1alpha.AUTO,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{
+					Image: "test:latest",
+					Env:   []string{"TEST=value"},
+				},
+			},
+		},
+	}
+
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Create manager and run reconciliation
+	manager := NewManager(log, server.EAC)
+	err = manager.reconcile(ctx, pool)
+	require.NoError(t, err)
+
+	// Verify 3 sandboxes were created
+	sandboxes := listSandboxesForPool(t, ctx, server, pool)
+	assert.Equal(t, 3, len(sandboxes), "should create 3 sandboxes")
+
+	// Verify all sandboxes have correct labels and specs
+	for _, sb := range sandboxes {
+		assert.Equal(t, compute_v1alpha.PENDING, sb.Status, "new sandboxes should be PENDING")
+		assert.Equal(t, pool.SandboxSpec.Version, sb.Version, "sandbox should use pool version")
+		require.NotEmpty(t, sb.Spec.Container, "sandbox should have containers")
+		assert.Equal(t, "test:latest", sb.Spec.Container[0].Image, "sandbox should use pool image")
+
+		// Check labels
+		var md core_v1alpha.Metadata
+		md.Decode(sb.Entity)
+		serviceLabel := getLabel(md.Labels, "service")
+		assert.Equal(t, "web", serviceLabel, "sandbox should have service label")
+		poolLabel := getLabel(md.Labels, "pool")
+		assert.Equal(t, poolID.String(), poolLabel, "sandbox should have pool label")
+	}
+
+	// Verify pool status was updated
+	updatedPool := getPool(t, ctx, server, poolID)
+	assert.Equal(t, int64(3), updatedPool.CurrentInstances, "pool should reflect current count")
+	assert.Equal(t, int64(0), updatedPool.ReadyInstances, "no sandboxes are running yet")
+}
+
+// TestManagerScaleUpPartial tests that the manager only creates
+// the difference when some sandboxes already exist
+func TestManagerScaleUpPartial(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create pool
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "api",
+		DesiredInstances: 5,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Create 2 existing sandboxes for this pool
+	for i := 0; i < 2; i++ {
+		sb := &compute_v1alpha.Sandbox{
+			Status:  compute_v1alpha.RUNNING,
+			Version: pool.SandboxSpec.Version,
+			Spec:    pool.SandboxSpec,
+		}
+		_, err := server.Client.Create(ctx, "existing-sb", sb,
+			entityserver.WithLabels(types.LabelSet("service", "api", "pool", poolID.String())))
+		require.NoError(t, err)
+	}
+
+	// Run reconciliation
+	manager := NewManager(log, server.EAC)
+	err = manager.reconcile(ctx, pool)
+	require.NoError(t, err)
+
+	// Verify total is now 5 (2 existing + 3 new)
+	sandboxes := listSandboxesForPool(t, ctx, server, pool)
+	assert.Equal(t, 5, len(sandboxes), "should have 5 total sandboxes")
+
+	// Count RUNNING vs PENDING
+	running := 0
+	pending := 0
+	for _, sb := range sandboxes {
+		if sb.Status == compute_v1alpha.RUNNING {
+			running++
+		} else if sb.Status == compute_v1alpha.PENDING {
+			pending++
+		}
+	}
+
+	assert.Equal(t, 2, running, "should have 2 running (existing)")
+	assert.Equal(t, 3, pending, "should have 3 pending (newly created)")
+
+	// Verify pool status
+	updatedPool := getPool(t, ctx, server, poolID)
+	assert.Equal(t, int64(5), updatedPool.CurrentInstances)
+	assert.Equal(t, int64(2), updatedPool.ReadyInstances, "only RUNNING sandboxes are ready")
+}
+
+// TestManagerServiceIsolation tests that pools for different services
+// don't interfere with each other
+func TestManagerServiceIsolation(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create two pools for different services
+	pool1 := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 2,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+	pool1ID, err := server.Client.Create(ctx, "pool-web", pool1)
+	require.NoError(t, err)
+	pool1.ID = pool1ID
+
+	pool2 := &compute_v1alpha.SandboxPool{
+		Service:          "worker",
+		DesiredInstances: 3,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+	pool2ID, err := server.Client.Create(ctx, "pool-worker", pool2)
+	require.NoError(t, err)
+	pool2.ID = pool2ID
+
+	// Run reconciliation for both
+	manager := NewManager(log, server.EAC)
+	err = manager.reconcile(ctx, pool1)
+	require.NoError(t, err)
+	err = manager.reconcile(ctx, pool2)
+	require.NoError(t, err)
+
+	// Verify each pool has correct count
+	webSandboxes := listSandboxesForPool(t, ctx, server, pool1)
+	workerSandboxes := listSandboxesForPool(t, ctx, server, pool2)
+
+	assert.Equal(t, 2, len(webSandboxes), "web pool should have 2 sandboxes")
+	assert.Equal(t, 3, len(workerSandboxes), "worker pool should have 3 sandboxes")
+
+	// Verify sandboxes have correct service labels
+	for _, sb := range webSandboxes {
+		var md core_v1alpha.Metadata
+		md.Decode(sb.Entity)
+		assert.Equal(t, "web", getLabel(md.Labels, "service"))
+	}
+
+	for _, sb := range workerSandboxes {
+		var md core_v1alpha.Metadata
+		md.Decode(sb.Entity)
+		assert.Equal(t, "worker", getLabel(md.Labels, "service"))
+	}
+}
+
+// TestManagerVersionFiltering tests that only sandboxes with matching
+// version are counted
+func TestManagerVersionFiltering(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 3,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-2"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:v2"},
+			},
+		},
+	}
+
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Create 2 sandboxes with old version (should be ignored)
+	for i := 0; i < 2; i++ {
+		sb := &compute_v1alpha.Sandbox{
+			Status:  compute_v1alpha.RUNNING,
+			Version: entity.Id("ver-1"), // Old version
+			Spec: compute_v1alpha.SandboxSpec{
+				Version: entity.Id("ver-1"),
+				Container: []compute_v1alpha.SandboxSpecContainer{
+					{Image: "test:v1"},
+				},
+			},
+		}
+		_, err := server.Client.Create(ctx, "old-sb", sb,
+			entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
+		require.NoError(t, err)
+	}
+
+	// Run reconciliation
+	manager := NewManager(log, server.EAC)
+	err = manager.reconcile(ctx, pool)
+	require.NoError(t, err)
+
+	// Should create 3 new sandboxes (old version doesn't count)
+	sandboxes := listSandboxesForPool(t, ctx, server, pool)
+	ver2Count := 0
+	for _, sb := range sandboxes {
+		if sb.Version.String() == "ver-2" {
+			ver2Count++
+		}
+	}
+
+	assert.Equal(t, 3, ver2Count, "should create 3 sandboxes with new version")
+
+	// Verify pool status counts only ver-2 sandboxes
+	updatedPool := getPool(t, ctx, server, poolID)
+	assert.Equal(t, int64(3), updatedPool.CurrentInstances, "should count only matching version")
+}
+
+// TestManagerStatusOnlyUpdate tests that reconciliation doesn't create
+// sandboxes when actual == desired, but still updates status
+func TestManagerStatusOnlyUpdate(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 2,
+		CurrentInstances: 0, // Stale status
+		ReadyInstances:   0,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Create 2 existing sandboxes (1 running, 1 pending)
+	sb1 := &compute_v1alpha.Sandbox{
+		Status:  compute_v1alpha.RUNNING,
+		Version: pool.SandboxSpec.Version,
+		Spec:    pool.SandboxSpec,
+	}
+	_, err = server.Client.Create(ctx, "sb1", sb1,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
+	require.NoError(t, err)
+
+	sb2 := &compute_v1alpha.Sandbox{
+		Status:  compute_v1alpha.PENDING,
+		Version: pool.SandboxSpec.Version,
+		Spec:    pool.SandboxSpec,
+	}
+	_, err = server.Client.Create(ctx, "sb2", sb2,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
+	require.NoError(t, err)
+
+	// Run reconciliation
+	manager := NewManager(log, server.EAC)
+	err = manager.reconcile(ctx, pool)
+	require.NoError(t, err)
+
+	// Should not create new sandboxes
+	sandboxes := listSandboxesForPool(t, ctx, server, pool)
+	assert.Equal(t, 2, len(sandboxes), "should not create new sandboxes")
+
+	// Verify pool status was updated correctly
+	updatedPool := getPool(t, ctx, server, poolID)
+	assert.Equal(t, int64(2), updatedPool.CurrentInstances, "should update current count")
+	assert.Equal(t, int64(1), updatedPool.ReadyInstances, "should count only RUNNING")
+}
+
+// TestManagerNoUpdateWhenStatusUnchanged tests that Put is not called
+// when status values haven't changed
+func TestManagerNoUpdateWhenStatusUnchanged(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 1,
+		CurrentInstances: 1,
+		ReadyInstances:   1,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Create 1 running sandbox
+	sb := &compute_v1alpha.Sandbox{
+		Status:  compute_v1alpha.RUNNING,
+		Version: pool.SandboxSpec.Version,
+		Spec:    pool.SandboxSpec,
+	}
+	_, err = server.Client.Create(ctx, "sb", sb,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
+	require.NoError(t, err)
+
+	// Wait a bit to ensure any processing completes
+	time.Sleep(10 * time.Millisecond)
+
+	// Run reconciliation
+	manager := NewManager(log, server.EAC)
+	err = manager.reconcile(ctx, pool)
+	require.NoError(t, err)
+
+	// Get pool again and verify status is correct
+	finalPool := getPool(t, ctx, server, poolID)
+
+	// Status should still be correct
+	assert.Equal(t, int64(1), finalPool.CurrentInstances)
+	assert.Equal(t, int64(1), finalPool.ReadyInstances)
+
+	// The implementation should skip Put when values unchanged,
+	// but we can't easily verify this without instrumentation.
+	// At minimum, verify values are still correct.
+}
+
+// Helper functions
+
+type sandboxWithEntity struct {
+	compute_v1alpha.Sandbox
+	*entity.Entity
+}
+
+func listSandboxesForPool(t *testing.T, ctx context.Context, server *testutils.InMemEntityServer, pool *compute_v1alpha.SandboxPool) []*sandboxWithEntity {
+	results, err := server.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	require.NoError(t, err)
+
+	var sandboxes []*sandboxWithEntity
+
+	for _, ent := range results.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(ent.Entity())
+
+		// Filter by version and service
+		if sb.Version.String() != pool.SandboxSpec.Version.String() {
+			continue
+		}
+
+		var md core_v1alpha.Metadata
+		md.Decode(ent.Entity())
+
+		serviceLabel := getLabel(md.Labels, "service")
+		if serviceLabel != pool.Service {
+			continue
+		}
+
+		sandboxes = append(sandboxes, &sandboxWithEntity{
+			Sandbox: sb,
+			Entity:  ent.Entity(),
+		})
+	}
+
+	return sandboxes
+}
+
+func getPool(t *testing.T, ctx context.Context, server *testutils.InMemEntityServer, poolID entity.Id) *compute_v1alpha.SandboxPool {
+	resp, err := server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+
+	var pool compute_v1alpha.SandboxPool
+	pool.Decode(resp.Entity().Entity())
+
+	return &pool
+}
+
+func getLabel(labels types.Labels, key string) string {
+	val, _ := labels.Get(key)
+	return val
+}


### PR DESCRIPTION
**Stacked on:** #244 (MIR-435)

### Summary

Adds the SandboxPoolManager controller that reconciles SandboxPool entities by ensuring actual sandbox counts match desired instance counts.

### What This Does

- Watches all SandboxPool entities cluster-wide
- For each pool:
  - Counts actual sandboxes (filtered by service + version)
  - Scales up when `actual < desired` by creating Sandbox entities
  - Updates pool status (`current_instances` and `ready_instances`)
- Runs on Coordinator (global, not per-node)
- Created sandboxes are picked up by existing Scheduler → distributed to nodes

### What This Doesn't Do Yet

- Scale down (logged but not implemented)
- Consume pool sandboxes in activator (still creates directly)
- Provide any user-facing functionality

**User Impact:** Zero. Pools are created but manage nothing yet - all activator behavior unchanged.

### Tests

6 comprehensive tests covering:
- Scale up from zero and partial scaling
- Service isolation between pools
- Version filtering
- Status updates and optimizations

All tests passing using in-memory entity server.

### Next Steps

Phase 4 will make the activator consume sandboxes from pools instead of creating them directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Sandbox Pool Manager that continuously reconciles sandbox pools: creates sandboxes to meet desired counts, handles partial successes, respects service/version isolation, updates pool status (current/ready), and is exposed at server startup for discovery by other components.

* **Tests**
  * Added comprehensive tests covering scale-up, partial creation, service/version isolation, status updates, and no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->