### PR TITLE
Reattach logs to sandboxes during controller restart

### DIFF
--- a/controllers/sandbox/testdata/heavy-logger/Procfile
+++ b/controllers/sandbox/testdata/heavy-logger/Procfile
@@ -1,0 +1,1 @@
+web: /bin/app

--- a/controllers/sandbox/testdata/heavy-logger/README.md
+++ b/controllers/sandbox/testdata/heavy-logger/README.md
@@ -1,0 +1,126 @@
+# Heavy Logger Test App
+
+A Go HTTP server designed to generate large volumes of logs for testing the log reattachment fix after miren restart. Mimics the cloud server's logging behavior using `slog`.
+
+## Purpose
+
+This app helps test the fix for the restart bug where stdout buffers fill up and block processes when logs aren't properly reattached. It generates configurable amounts of logs per request, making it easy to reproduce the buffer-filling scenario.
+
+## Features
+
+- **Mimics cloud server** - Uses `slog` with JSON output, same logging patterns
+- **Logs heavily on each request** - Configurable number of log lines per request
+- **Request lifecycle logging** - "Request began" + "Request ended" (like cloud server)
+- **Background heartbeat logging** - Keeps stdout active even without requests
+- **Request tracking** - Each request gets a unique ID and detailed logging
+- **Configurable log volume** - Adjust via environment variables
+
+## Configuration
+
+Environment variables:
+- `PORT` - Server port (default: 3000)
+- `LINES_PER_REQUEST` - Number of log lines per request (default: 20)
+- `LOG_LINE_SIZE` - Approximate size of each log line in bytes (default: 200)
+
+## Usage
+
+### Manual Testing of Log Reattachment
+
+1. **Deploy with miren:**
+   ```bash
+   cd controllers/sandbox/testdata/heavy-logger
+   miren deploy heavy-logger
+   ```
+
+   Or for heavy logging mode:
+   ```bash
+   LINES_PER_REQUEST=100 LOG_LINE_SIZE=500 miren deploy heavy-logger
+   ```
+
+2. **Expose via http route:**
+   ```bash
+   miren route add heavy-logger.test heavy-logger
+   ```
+
+3. **Generate traffic to fill stdout buffer:**
+   ```bash
+   # Make many requests quickly
+   for i in {1..100}; do
+     curl http://heavy-logger.test/ &
+   done
+   wait
+
+   # Or use a simple loop
+   while true; do curl http://heavy-logger.test/; sleep 0.1; done
+   ```
+
+4. **Restart miren and verify app still works:**
+   ```bash
+   systemctl restart miren
+   # Wait a few seconds for recovery
+   curl http://heavy-logger.test/  # Should still respond
+
+   # Check that logs were reattached
+   miren logs -a heavy-logger | grep "reattached logs"
+   ```
+
+### Testing Different Log Volumes
+
+**Light logging (baseline):**
+- `LINES_PER_REQUEST=5`, `LOG_LINE_SIZE=100`
+- ~500 bytes per request
+- Should work even without log reattachment
+
+**Medium logging (typical app):**
+- `LINES_PER_REQUEST=20`, `LOG_LINE_SIZE=200`
+- ~4KB per request
+- Will fill 64KB buffer after ~16 requests
+
+**Heavy logging (reproduces bug):**
+- `LINES_PER_REQUEST=100`, `LOG_LINE_SIZE=500`
+- ~50KB per request
+- Will fill buffer after just 1-2 requests
+
+## What to Look For
+
+### Bug Present (without fix):
+1. Deploy heavy-logger with high log volume
+2. Make a few requests - app works initially
+3. Restart miren
+4. Make requests after restart
+5. **App wedges** - requests hang, TCP connections in CLOSE_WAIT
+6. `ss -s` inside container shows many sockets stuck
+
+### Bug Fixed (with log reattachment):
+1. Same steps as above
+2. After restart, check logs: `INFO reattached logs to container`
+3. **App continues working** - requests succeed
+4. Logs continue being collected in ClickHouse
+
+## Response Format
+
+```json
+{
+  "requestId": 42,
+  "message": "Heavy Logger Test App",
+  "linesLogged": 50,
+  "duration": "23ms",
+  "totalRequests": 42,
+  "config": {
+    "linesPerRequest": 50,
+    "logLineSize": 300
+  }
+}
+```
+
+## Logs Generated
+
+Each request generates:
+- 1 REQUEST START line
+- N lines of heavy log data (configurable)
+- 1 REQUEST END line
+- 1 STATS line
+
+Plus background heartbeat every 5 seconds.
+
+With default settings (20 lines * 200 bytes = 4KB per request), the 64KB stdout buffer fills after ~16 requests, making it easy to reproduce the blocking issue.

--- a/controllers/sandbox/testdata/heavy-logger/go.mod
+++ b/controllers/sandbox/testdata/heavy-logger/go.mod
@@ -1,0 +1,3 @@
+module heavy-logger
+
+go 1.21

--- a/controllers/sandbox/testdata/heavy-logger/main.go
+++ b/controllers/sandbox/testdata/heavy-logger/main.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// Configuration from environment variables
+var (
+	port            = getEnv("PORT", "3000")
+	linesPerRequest = getEnvInt("LINES_PER_REQUEST", 20)
+	logLineSize     = getEnvInt("LOG_LINE_SIZE", 200)
+)
+
+var requestCounter atomic.Uint64
+
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func getEnvInt(key string, defaultValue int) int {
+	if value := os.Getenv(key); value != "" {
+		if intValue, err := strconv.Atoi(value); err == nil {
+			return intValue
+		}
+	}
+	return defaultValue
+}
+
+// generateLogLine creates a log line of approximately the specified size
+func generateLogLine(requestID uint64, lineNum int) string {
+	timestamp := time.Now().Format(time.RFC3339)
+	padding := strings.Repeat("x", max(0, logLineSize-100))
+	return fmt.Sprintf("[%s] Request %d Line %d: This is a heavy log message %s",
+		timestamp, requestID, lineNum, padding)
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+type Response struct {
+	RequestID      uint64 `json:"requestId"`
+	Message        string `json:"message"`
+	LinesLogged    int    `json:"linesLogged"`
+	Duration       string `json:"duration"`
+	TotalRequests  uint64 `json:"totalRequests"`
+	Config         Config `json:"config"`
+}
+
+type Config struct {
+	LinesPerRequest int `json:"linesPerRequest"`
+	LogLineSize     int `json:"logLineSize"`
+}
+
+func main() {
+	// Create logger (similar to cloud server's slog usage)
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
+	slog.Info("===========================================")
+	slog.Info("Heavy Logger Test App Started")
+	slog.Info("===========================================",
+		"port", port,
+		"lines_per_request", linesPerRequest,
+		"log_line_size", logLineSize,
+		"estimated_bytes_per_request", linesPerRequest*logLineSize)
+	slog.Info("Ready to receive requests!")
+	slog.Info("===========================================")
+
+	// Background heartbeat (like cloud server's periodic logging)
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			slog.Info("HEARTBEAT",
+				"timestamp", time.Now().Format(time.RFC3339),
+				"requests_served", requestCounter.Load())
+		}
+	}()
+
+	// Main request handler
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		requestID := requestCounter.Add(1)
+		start := time.Now()
+
+		// Log request start (mimics cloud server's "Request began")
+		slog.Info("Request began",
+			"request_id", requestID,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"remote_addr", r.RemoteAddr)
+
+		// Generate heavy logs for this request
+		for i := 1; i <= linesPerRequest; i++ {
+			logLine := generateLogLine(requestID, i)
+			slog.Info(logLine)
+		}
+
+		// Simulate some work (like cloud server processing)
+		time.Sleep(time.Duration(10+requestID%40) * time.Millisecond)
+
+		duration := time.Since(start)
+
+		// Log request end (mimics cloud server's "Request ended")
+		slog.Info("Request ended",
+			"request_id", requestID,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", 200,
+			"duration", duration.String())
+
+		// Log stats (mimics cloud server's detailed logging)
+		slog.Info("STATS",
+			"total_requests", requestCounter.Load(),
+			"lines_per_request", linesPerRequest)
+
+		// Send response
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-ID", fmt.Sprintf("%d", requestID))
+		w.WriteHeader(http.StatusOK)
+
+		response := Response{
+			RequestID:     requestID,
+			Message:       "Heavy Logger Test App",
+			LinesLogged:   linesPerRequest,
+			Duration:      duration.String(),
+			TotalRequests: requestCounter.Load(),
+			Config: Config{
+				LinesPerRequest: linesPerRequest,
+				LogLineSize:     logLineSize,
+			},
+		}
+
+		json.NewEncoder(w).Encode(response)
+	})
+
+	// Health endpoint (no logging to avoid noise)
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK\n")
+	})
+
+	// Start server
+	addr := ":" + port
+	slog.Info("Server starting", "addr", addr)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		slog.Error("Server failed", "error", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes MIR-448: Reattach logs to sandboxes during controller restart to prevent stdout buffer fills and process wedges.

## Problem

After a miren restart, sandboxes were left in a state where their stdout/stderr streams were no longer being consumed. This caused the stdout buffer (typically 64KB on Linux) to fill up, blocking any process attempting to write logs. Applications would wedge, with symptoms including:

- Requests hanging indefinitely
- TCP connections stuck in CLOSE_WAIT
- No response from the application
- High socket counts inside containers

The issue primarily affected apps with heavy per-request logging (like our cloud server). Apps with minimal logging could run indefinitely without triggering the bug.

## Root Cause

During sandbox creation, we attach log consumers using `cio.NewAttach()` which drains stdout/stderr to ClickHouse. However, during boot reconciliation (`reconcileSandboxesOnBoot()`), we were calling `container.Task(ctx, nil)` to check health. The `nil` parameter means **no IO attachment** - we weren't reattaching the log consumers.

Without log consumers, stdout writes would fill the 64KB kernel buffer, causing subsequent writes to block. For a server logging heavily on each request, this happens quickly after restart.

## Solution

Added `reattachLogs()` function that is called during boot reconciliation for all running sandboxes. It reattaches log consumers to both pause containers and subcontainers using `cio.NewAttach(cio.WithStreams(nil, sl, sl.Stderr()))`, ensuring stdout/stderr are properly drained.

The fix is called early in `reconcileSandboxesOnBoot()` before health checks, ensuring logs are flowing before we verify container health.

## Testing

### Automated
- Added integration test that creates a sandbox with continuous logging, calls `reattachLogs()`, and verifies the process continues running without blocking

### Manual Verification
- Created `heavy-logger` test app that mimics cloud server's logging behavior
- Deployed heavy-logger, generated traffic to fill buffer, restarted miren
- Confirmed logs show "reattached logs to container"
- Verified application continues responding after restart (no wedge)

The heavy-logger app is now available in `controllers/sandbox/testdata/heavy-logger/` for future testing and reproduction.

## Metrics

Boot reconciliation now logs `reattached_sandboxes` count alongside existing metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container logs are now automatically reattached during boot reconciliation, ensuring logs are preserved during restarts.
  * New reattached_sandboxes metric provides visibility into log reattachment events.

* **Tests**
  * Added test suite validating log reattachment scenarios after controller restarts.

* **Documentation**
  * Added test utilities and documentation for log reattachment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->