### PR TITLE
Add pre-approval token support for server registration

### DIFF
--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -19,15 +19,16 @@ import (
 
 // ServerInstall sets up systemd units to run the miren server
 func ServerInstall(ctx *Context, opts struct {
-	Address      string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
-	Verbosity    string            `short:"v" long:"verbosity" description:"Verbosity level" default:"-vv"`
-	Branch       string            `short:"b" long:"branch" description:"Branch to download if release not found" default:"main"`
-	Force        bool              `short:"f" long:"force" description:"Overwrite existing service file"`
-	NoStart      bool              `long:"no-start" description:"Do not start the service after installation"`
-	WithoutCloud bool              `long:"without-cloud" description:"Skip cloud registration setup"`
-	ClusterName  string            `short:"n" long:"name" description:"Cluster name for cloud registration"`
-	CloudURL     string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
-	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
+	Address          string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
+	Verbosity        string            `short:"v" long:"verbosity" description:"Verbosity level" default:"-vv"`
+	Branch           string            `short:"b" long:"branch" description:"Branch to download if release not found" default:"main"`
+	Force            bool              `short:"f" long:"force" description:"Overwrite existing service file"`
+	NoStart          bool              `long:"no-start" description:"Do not start the service after installation"`
+	WithoutCloud     bool              `long:"without-cloud" description:"Skip cloud registration setup"`
+	ClusterName      string            `short:"n" long:"name" description:"Cluster name for cloud registration"`
+	CloudURL         string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
+	Tags             map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
+	PreApprovalToken string            `long:"token" description:"Pre-approval token for automated registration"`
 }) error {
 	// Check if running with sufficient privileges
 	if os.Geteuid() != 0 {
@@ -68,10 +69,11 @@ func ServerInstall(ctx *Context, opts struct {
 			}
 
 			registerOpts := RegisterOptions{
-				ClusterName: clusterName,
-				CloudURL:    opts.CloudURL,
-				Tags:        opts.Tags,
-				OutputDir:   "/var/lib/miren/server",
+				ClusterName:      clusterName,
+				CloudURL:         opts.CloudURL,
+				Tags:             opts.Tags,
+				OutputDir:        "/var/lib/miren/server",
+				PreApprovalToken: opts.PreApprovalToken,
 			}
 
 			if err := Register(ctx, registerOpts); err != nil {
@@ -95,10 +97,11 @@ func ServerInstall(ctx *Context, opts struct {
 			}
 
 			registerOpts := RegisterOptions{
-				ClusterName: clusterName,
-				CloudURL:    opts.CloudURL,
-				Tags:        opts.Tags,
-				OutputDir:   "/var/lib/miren/server",
+				ClusterName:      clusterName,
+				CloudURL:         opts.CloudURL,
+				Tags:             opts.Tags,
+				OutputDir:        "/var/lib/miren/server",
+				PreApprovalToken: opts.PreApprovalToken,
 			}
 
 			if err := Register(ctx, registerOpts); err != nil {


### PR DESCRIPTION
## Summary

This PR adds support for pre-approval tokens in the server registration process, enabling automated cluster registration without manual approval via the web UI.

## Changes

### Registration Package (`pkg/registration/registration.go`)
- Added `PreApprovalToken` field to `Config` struct
- Extended `Result` struct with pre-approval response fields (`Status`, `ClusterID`, `OrganizationID`, `ServiceAccountID`)
- Added `IsPreApproved()` method to detect immediate approval
- Updated `StartRegistration()` to accept both HTTP 200 (manual) and 201 (pre-approved) status codes

### CLI Commands
- **`register` command** (`cli/commands/register.go`):
  - Added `--token` flag for pre-approval token
  - Implemented automatic approval detection
  - Skips auth URL display and polling when using pre-approval token
  - Saves registration immediately on pre-approval

- **`server install` command** (`cli/commands/server_install.go`):
  - Added `--token` flag
  - Passes token through to registration process

## Usage

**Automated registration with pre-approval token:**
```bash
miren register --name my-cluster --token <pre-approval-token>
sudo miren server install --name my-cluster --token <pre-approval-token>
```

**Manual approval (unchanged):**
```bash
miren register --name my-cluster
sudo miren server install --name my-cluster
```

## Testing

- ✅ All files pass `make lint` with no issues
- ✅ Backward compatibility maintained for manual approval flow
- ✅ Pre-approval token field is optional and only used when provided

## Related

Integrates with the pre-approval API implemented in miren.cloud (~/mn-git/cloud).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--token` flag to `register` and `server-install` commands to support pre-approval tokens for accelerated registration workflows
  * When a valid pre-approval token is provided, the registration process now completes automatically without requiring manual polling or confirmation steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->