### PR TITLE
nbd: cleanup large request size handling

### DIFF
--- a/controllers/disk/lsvd_client.go
+++ b/controllers/disk/lsvd_client.go
@@ -997,7 +997,6 @@ func (c *lsvdClientImpl) runNBDHandlerWithReconnect(
 		nbdOpts := &nbd.Options{
 			MinimumBlockSize:   4096,
 			PreferredBlockSize: 4096,
-			MaximumBlockSize:   4096,
 			RawFile:            client,
 		}
 

--- a/disk/run.go
+++ b/disk/run.go
@@ -115,7 +115,6 @@ func (r *Runner) Start(ctx context.Context, name, fsPath, bindAddr string) error
 	nbdOpts := &nbd.Options{
 		MinimumBlockSize:   4096,
 		PreferredBlockSize: 4096,
-		MaximumBlockSize:   4096,
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -332,7 +331,6 @@ func (r *Runner) Run(ctx context.Context, name, fsPath, bindAddr string) error {
 	nbdOpts := &nbd.Options{
 		MinimumBlockSize:   4096,
 		PreferredBlockSize: 4096,
-		MaximumBlockSize:   4096,
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/lsvd/cli/bind.go
+++ b/lsvd/cli/bind.go
@@ -232,7 +232,6 @@ func (c *CLI) bind(ctx context.Context, opts struct {
 	nbdOpts := &nbd.Options{
 		MinimumBlockSize:   4096,
 		PreferredBlockSize: 4096,
-		MaximumBlockSize:   4096,
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/lsvd/cli/cli.go
+++ b/lsvd/cli/cli.go
@@ -523,7 +523,6 @@ func (c *CLI) nbdServe(ctx context.Context, opts struct {
 	nbdOpts := &nbd.Options{
 		MinimumBlockSize:   4096,
 		PreferredBlockSize: 4096,
-		MaximumBlockSize:   4096,
 	}
 
 	http.Handle("/metrics", promhttp.Handler())

--- a/lsvd/pkg/nbd/negotiation.go
+++ b/lsvd/pkg/nbd/negotiation.go
@@ -76,5 +76,5 @@ type NegotiationReplyBlockSize struct {
 	Type               uint16
 	MinimumBlockSize   uint32
 	PreferredBlockSize uint32
-	MaximumBlockSize   uint32
+	MaximumRequestSize uint32
 }


### PR DESCRIPTION
So, turns out that nbd servers don't have a way to tell the client to clamp the maximum payload size. And the linux nbd ioctl/netlink interfaces don't expose the ability to do that either.

So instead we need to honor the clients size request up to some insane maximum.

Oh, but also, the code was _wrong_ in that the 3rd field of the block size info is supposed to be the maximum payload size. I don't think any nbd clients actually even look at it, but I've corrected it just for completeness.

We don't actually use nbd.Handle in our implementation because we're using the loopback connection to the kernel, so we go straight to nbd.HandleTransport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Read-only mode now accepts incoming write/trim requests without failing, responding successfully while avoiding backend writes — improves client compatibility.
  * Added a sanity check to reject/guard against excessively large requests, preventing resource exhaustion.

* **Improvements**
  * Simplified block-size negotiation and request sizing behavior to reduce mismatches and improve performance and reliability during storage operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->