### PR TITLE
entity: add read-time migration for sandbox entity.cbor files

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -693,14 +693,13 @@ func (c *SandboxController) readEntity(ctx context.Context, id entity.Id) (*enti
 		return nil, fmt.Errorf("failed to open entity file: %w", err)
 	}
 
-	var meta entity.Meta
-
-	err = entity.Decode(data, &meta)
+	// Use MigrateMetaFromBytes for automatic migration from old format
+	meta, err := entity.MigrateMetaFromBytes(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode entity file: %w", err)
 	}
 
-	return &meta, nil
+	return meta, nil
 }
 
 func (c *SandboxController) updateSandbox(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) error {

--- a/pkg/entity/migrate_test.go
+++ b/pkg/entity/migrate_test.go
@@ -296,17 +296,17 @@ func TestMigrateMetaFromBytes(t *testing.T) {
 		r.Equal(int64(4), migratedMeta.Previous)
 
 		// Verify Entity was migrated correctly
-		r.Equal("sandbox/test-sandbox", string(migratedMeta.Entity.Id()))
+		r.Equal("sandbox/test-sandbox", string(migratedMeta.Id()))
 		r.Equal(int64(42), migratedMeta.Entity.GetRevision())
-		r.True(migratedMeta.Entity.GetCreatedAt().Equal(time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)))
-		r.True(migratedMeta.Entity.GetUpdatedAt().Equal(time.Date(2024, 6, 15, 12, 45, 0, 0, time.UTC)))
+		r.True(migratedMeta.GetCreatedAt().Equal(time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)))
+		r.True(migratedMeta.GetUpdatedAt().Equal(time.Date(2024, 6, 15, 12, 45, 0, 0, time.UTC)))
 
 		// Verify original attributes are preserved
-		statusAttr, ok := migratedMeta.Entity.Get("sandbox/status")
+		statusAttr, ok := migratedMeta.Get("sandbox/status")
 		r.True(ok)
 		r.Equal("running", statusAttr.Value.String())
 
-		imageAttr, ok := migratedMeta.Entity.Get("sandbox/image")
+		imageAttr, ok := migratedMeta.Get("sandbox/image")
 		r.True(ok)
 		r.Equal("test-image:latest", imageAttr.Value.String())
 	})
@@ -339,10 +339,10 @@ func TestMigrateMetaFromBytes(t *testing.T) {
 		// Verify it's identical to original
 		r.Equal(int64(15), decodedMeta.Revision)
 		r.Equal(int64(14), decodedMeta.Previous)
-		r.Equal("sandbox/new-sandbox", string(decodedMeta.Entity.Id()))
+		r.Equal("sandbox/new-sandbox", string(decodedMeta.Id()))
 		r.Equal(int64(10), decodedMeta.Entity.GetRevision())
 
-		statusAttr, ok := decodedMeta.Entity.Get("sandbox/status")
+		statusAttr, ok := decodedMeta.Get("sandbox/status")
 		r.True(ok)
 		r.Equal("stopped", statusAttr.Value.String())
 	})
@@ -368,13 +368,13 @@ func TestMigrateMetaFromBytes(t *testing.T) {
 		migratedMeta, err := MigrateMetaFromBytes(data)
 		r.NoError(err)
 
-		r.Equal("sandbox/minimal", string(migratedMeta.Entity.Id()))
-		r.Equal(int64(1), migratedMeta.Entity.GetRevision())
+		r.Equal("sandbox/minimal", string(migratedMeta.Id()))
+		r.Equal(int64(1), migratedMeta.GetRevision())
 		// Timestamps should be zero since they weren't set
-		r.True(migratedMeta.Entity.GetCreatedAt().IsZero())
-		r.True(migratedMeta.Entity.GetUpdatedAt().IsZero())
+		r.True(migratedMeta.GetCreatedAt().IsZero())
+		r.True(migratedMeta.GetUpdatedAt().IsZero())
 
-		nameAttr, ok := migratedMeta.Entity.Get("sandbox/name")
+		nameAttr, ok := migratedMeta.Get("sandbox/name")
 		r.True(ok)
 		r.Equal("minimal-sandbox", nameAttr.Value.String())
 	})

--- a/pkg/testutils/reg.go
+++ b/pkg/testutils/reg.go
@@ -177,6 +177,7 @@ func Registry(extra ...func(*asm.Registry)) (*asm.Registry, func()) {
 			Prefix:        opts.Prefix,
 			Resolver:      res,
 			TempDir:       tempDir,
+			DataPath:      filepath.Join(tempDir, "coordinator"),
 			Mem:           opts.Mem,
 			Cpu:           opts.CPU,
 		})


### PR DESCRIPTION
## Summary
- Add automatic read-time migration for entity.cbor files in sandbox controller
- Migrate old entity format (struct fields) to new format (attributes)
- Add defensive migration in Entity.UnmarshalCBOR as safety net

## Background
The recent entity system overhaul migrated metadata (ID, Revision, CreatedAt, UpdatedAt) from struct fields to attributes in the CBOR encoding. However, the sandbox controller stores entity.Meta structs in entity.cbor files that may still be in the old format.

## Changes
1. **Added `MigrateMetaFromBytes` in `pkg/entity/migrate.go`**:
   - Tries to decode as old format first
   - Detects migration need by checking if `entity.ID` is set
   - Migrates all metadata fields to attributes
   - Preserves absence of timestamps if they weren't set
   - Falls back to new format if no migration needed

2. **Updated `readEntity` in `controllers/sandbox/sandbox.go`**:
   - Uses `MigrateMetaFromBytes` instead of direct `Decode`
   - Automatically migrates old files on read
   - Files are re-saved in new format when `saveEntity` is called

3. **Added defensive migration in `Entity.UnmarshalCBOR`**:
   - Safety net for any other code paths that deserialize entities directly
   - Logs warnings when migration is triggered
   - Can be removed once all data is confirmed migrated

## Test plan
- [x] Added comprehensive tests in `TestMigrateMetaFromBytes`:
  - Migrates old Meta format with all metadata fields
  - Handles new Meta format without migration
  - Preserves missing timestamps correctly
- [x] All tests pass
- [x] Build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic read-time migration of legacy entity/meta formats so older persisted data is transparently upgraded.
  * Controller read paths now use the centralized migration routine to handle older formats and missing legacy fields, emitting warnings when fallback occurs.

* **Tests**
  * Added tests validating migration for old/new formats and cases with missing timestamps.

* **Chores**
  * Test harness uses an isolated data path for coordinator artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->