### PR TITLE
Configure gateway before DNS setup in sandbox controller

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -397,6 +397,11 @@ func (c *SandboxController) Init(ctx context.Context) error {
 		return err
 	}
 
+	err = network.MasqueradeEndpoint(ep)
+	if err != nil {
+		return err
+	}
+
 	err = c.NetServ.SetupDNS(bc)
 	if err != nil {
 		return err

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -382,7 +382,17 @@ func (c *SandboxController) Init(ctx context.Context) error {
 		Name:      c.Bridge,
 		Addresses: []netip.Prefix{c.Subnet.Router()},
 	}
-	_, err = network.SetupBridge(bc)
+
+	link, err := network.SetupBridge(bc)
+	if err != nil {
+		return err
+	}
+
+	ep := &network.EndpointConfig{
+		Bridge: bc,
+	}
+
+	err = network.ConfigureGW(link, ep)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Add `network.ConfigureGW` call during sandbox initialization
- Ensures gateway is properly configured before DNS service attempts to bind to gateway address
- Fixes issue where DNS service would fail to bind without gateway configuration

## Changes
- Capture link from `SetupBridge` call
- Create `EndpointConfig` with bridge config and link
- Call `network.ConfigureGW` before `SetupDNS`

## Test plan
- [x] Verify sandbox initialization succeeds
- [x] Verify DNS service binds correctly to gateway address
- [x] Run existing tests to ensure no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization error handling to reduce failures during startup.
  * Ensured gateway and NAT setup now report and handle errors reliably.

* **Refactor**
  * Adjusted network bridge setup and state transitions for more reliable interface bring-up.
  * Modified IP/address handling to continue processing when identical addresses are encountered, improving resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->