### PR TITLE
sandbox: Only track initial port binding

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -112,7 +112,9 @@ func (c *SandboxController) SetPortStatus(id string, port observability.BoundPor
 
 	switch status {
 	case observability.PortStatusBound:
-		ports.Ports = append(ports.Ports, port)
+		if !slices.Contains(ports.Ports, port) {
+			ports.Ports = append(ports.Ports, port)
+		}
 	case observability.PortStatusUnbound:
 		ports.Ports = slices.DeleteFunc(ports.Ports, func(p observability.BoundPort) bool {
 			return p == port

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -1209,16 +1209,7 @@ func TestSandbox(t *testing.T) {
 		err = co.Delete(ctx, id)
 		r.NoError(err)
 
-		// Verify port is marked as unbound after deletion
-		time.Sleep(1 * time.Second)
-		co.portMu.Lock()
-		ports, ok := co.portMap[containerID]
-		if ok {
-			for _, p := range ports.Ports {
-				r.NotEqual(8080, p.Port, "Port 8080 should not be in bound ports after deletion")
-			}
-		}
-		co.portMu.Unlock()
+		// NOTE we only track port binding now, not unbounding.
 	})
 
 	t.Run("multiple ports detection", func(t *testing.T) {


### PR DESCRIPTION
This code used to use the gvisor syscall monitor to wattch for port unbinding, so it was effectively free. The version here was FAR from free, effectively flooding the containers twice a second with new TCP sessions just to check for continual port binding.

We don't do anything with port unbinding anyway, so this now just waits for port binding, then stops monitoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Port monitoring now completes when all ports are bound instead of running indefinitely.
  * Prevented duplicate port entries from being tracked.
  * Simplified port unbinding to only occur during task cancellation.
  * Added finalization logging for port monitoring completion.

* **Tests**
  * Updated test assertions to match the simplified port tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->