### PR TITLE
Fix TLS file leaks in test suite

### DIFF
--- a/components/coordinate/coordinator_test.go
+++ b/components/coordinate/coordinator_test.go
@@ -32,11 +32,15 @@ func TestCoordinatorParse(t *testing.T) {
 	err := reg.Init(&log)
 	r.NoError(err)
 
+	// Create temp directory for test data
+	tempDir := t.TempDir()
+
 	// Setup coordinator config
 	coordCfg := coordinate.CoordinatorConfig{
 		Address:       "localhost:9991",          // Use test port
 		EtcdEndpoints: []string{"etcd:2379"},     // Default etcd port
 		Prefix:        "/test/miren/" + t.Name(), // Unique prefix for this test
+		DataPath:      tempDir,                   // Use temp directory to prevent file leaks
 	}
 
 	// Create contexts

--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -31,11 +31,15 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 	err := reg.Init(&log)
 	r.NoError(err)
 
+	// Create temp directory for test data
+	tempDir := t.TempDir()
+
 	// Setup coordinator config
 	coordCfg := coordinate.CoordinatorConfig{
 		Address:       "localhost:9991",          // Use test port
 		EtcdEndpoints: []string{"etcd:2379"},     // Default etcd port
 		Prefix:        "/test/miren/" + t.Name(), // Unique prefix for this test
+		DataPath:      tempDir,                   // Use temp directory to prevent file leaks
 	}
 
 	// Setup runner config

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -95,12 +95,15 @@ func TestServer(t *testing.T) error {
 		return err
 	}
 
+	tempDir := t.TempDir()
+
 	co := coordinate.NewCoordinator(log, coordinate.CoordinatorConfig{
 		Address:       optsAddress,
 		EtcdEndpoints: optsEtcdEndpoints,
 		Prefix:        optsEtcdPrefix,
 		Resolver:      res,
-		TempDir:       os.TempDir(),
+		TempDir:       tempDir,
+		DataPath:      filepath.Join(tempDir, "coordinator"),
 		Mem:           &mem,
 		Cpu:           &cpu,
 		Logs:          &logs,


### PR DESCRIPTION
## Summary

Fixes TLS certificate file leaks in the test suite that were creating `server/` directories with certificate files in the source tree under various `components/` subdirectories.

## Root Cause

Tests that created `Coordinator` instances without specifying a `DataPath` were causing TLS files (ca.crt, ca.key, api.crt, api.key) to be written relative to the current working directory instead of to temporary directories.

## Changes

- **components/coordinate/coordinator_test.go**: Added `DataPath` using `t.TempDir()` to ensure TLS files are written to a temporary directory
- **components/runner/integration_test.go**: Added `DataPath` using `t.TempDir()` for the same reason  
- **pkg/testserver/server.go**: Created `tempDir` using `t.TempDir()` and configured both `TempDir` and `DataPath: filepath.Join(tempDir, "coordinator")` following the pattern established in `pkg/testutils/reg.go`

## Testing

- All modified packages compile successfully
- Changes follow the established pattern from `pkg/testutils/reg.go:36,179-180`
- TLS files are now written to temporary directories that are automatically cleaned up by Go's testing framework

## Notes

The fix in `pkg/testserver/server.go` required special attention because `TestServer` creates its own coordinator (separate from the registry's coordinator) in order to bind to a specific address. The solution follows the same pattern as the registry: create a dedicated tempDir and use it for both `TempDir` and `DataPath`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test data isolation by implementing per-test temporary directories to prevent file leaks and ensure clean test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->