### PR TITLE
Fix race condition in clientconfig save causing invalid config state

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -828,12 +828,10 @@ func writeLocalClusterConfig(ctx *Context, cc *caauth.ClientCertificate, address
 	// Load or create the main client config
 	mainConfig, err := clientconfig.LoadConfig()
 	if err != nil {
-		// If no config exists, create a new one
-		if err == clientconfig.ErrNoConfig {
-			mainConfig = clientconfig.NewConfig()
-		} else {
-			return fmt.Errorf("failed to load client config: %w", err)
-		}
+		// If config is missing or invalid, create a new one
+		// This handles cases where the config references a missing cluster
+		ctx.Log.Warn("creating new client config", "reason", err.Error())
+		mainConfig = clientconfig.NewConfig()
 	}
 
 	// Create the local cluster config data


### PR DESCRIPTION
## Problem

Server boot could fail with "active cluster 'local' not found" error due to a race condition when saving client config. If the save process was interrupted (crash, kill signal, disk full) between writing the main config and leaf configs, the system would end up in a broken state:

- `clientconfig.yaml`: `active_cluster: local` (but no cluster definition)
- `clientconfig.d/50-local.yaml`: empty or missing

This prevented both server startup (which auto-generates client config) and client commands from working.

## Root Cause

Three separate issues contributed to this bug:

1. `SetLeafConfig()` automatically set `active_cluster` in main config based on leaf config contents (clientconfig.go:210-218)
2. `SaveTo()` saved main config BEFORE leaf configs, creating a window where the config could reference non-existent clusters
3. Server's `writeLocalClusterConfig()` was too strict about validation errors, preventing recovery from broken configs

## Solution

### 1. Removed auto-active-cluster logic from SetLeafConfig()
- Active cluster should be set explicitly to avoid invalid states
- Updated test to verify new behavior

### 2. Made SaveTo() atomic by saving leaf configs BEFORE main config
- If interrupted, worst case is unused leaf config (harmless)
- Before: main config referenced non-existent cluster (broken)

### 3. Made server's writeLocalClusterConfig() handle invalid configs gracefully
- Creates fresh config instead of failing on validation errors
- Allows server to recover from broken state on next boot

## Testing

- ✅ Added regression test for save ordering
- ✅ Added test documenting behavior with broken configs  
- ✅ All existing tests pass
- ✅ Verified with golangci-lint

## Impact

Fixes the issue where `sudo miren apps` failed after server restart due to corrupted client config state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for configuration loading with clearer warning messages when configs cannot be loaded.
  * Fixed configuration persistence order to ensure leaf cluster configurations are saved reliably.
  * Enhanced error reporting when referencing non-existent clusters in active configuration.

* **Behavior Changes**
  * Cluster configurations no longer auto-activate clusters when loading leaf configurations; explicit activation is now required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->