### PR TITLE
Add pool visibility to sandbox CLI commands

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -52,6 +52,10 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("sandbox metrics", "Get metrics from a sandbox", SandboxMetrics), nil
 		},
 
+		"sandbox-pool list": func() (cli.Command, error) {
+			return Infer("sandbox-pool list", "List all sandbox pools", SandboxPoolList), nil
+		},
+
 		"app": func() (cli.Command, error) {
 			return Infer("app", "Get information about an application", App), nil
 		},

--- a/cli/commands/sandbox_pool_list.go
+++ b/cli/commands/sandbox_pool_list.go
@@ -1,0 +1,77 @@
+package commands
+
+import (
+	"fmt"
+	"time"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/ui"
+)
+
+func SandboxPoolList(ctx *Context, opts struct {
+	FormatOptions
+	ConfigCentric
+}) error {
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+
+	kindRes, err := eac.LookupKind(ctx, "sandbox_pool")
+	if err != nil {
+		return err
+	}
+
+	res, err := eac.List(ctx, kindRes.Attr())
+	if err != nil {
+		return err
+	}
+
+	if opts.IsJSON() {
+		var pools []compute_v1alpha.SandboxPool
+
+		for _, e := range res.Values() {
+			var pool compute_v1alpha.SandboxPool
+			pool.Decode(e.Entity())
+			pools = append(pools, pool)
+		}
+
+		return PrintJSON(pools)
+	}
+
+	var rows []ui.Row
+	headers := []string{"ID", "SERVICE", "DESIRED", "CURRENT", "READY", "VERSION", "CREATED", "UPDATED"}
+
+	for _, e := range res.Values() {
+		var pool compute_v1alpha.SandboxPool
+		pool.Decode(e.Entity())
+
+		rows = append(rows, ui.Row{
+			ui.CleanEntityID(pool.ID.String()),
+			pool.Service,
+			fmt.Sprintf("%d", pool.DesiredInstances),
+			fmt.Sprintf("%d", pool.CurrentInstances),
+			fmt.Sprintf("%d", pool.ReadyInstances),
+			ui.DisplayAppVersion(pool.SandboxSpec.Version.String()),
+			humanFriendlyTimestamp(time.UnixMilli(e.CreatedAt())),
+			humanFriendlyTimestamp(time.UnixMilli(e.UpdatedAt())),
+		})
+	}
+
+	if len(rows) == 0 {
+		ctx.Printf("No sandbox pools found\n")
+		return nil
+	}
+
+	columns := ui.AutoSizeColumns(headers, rows)
+	table := ui.NewTable(
+		ui.WithColumns(columns),
+		ui.WithRows(rows),
+	)
+
+	ctx.Printf("%s\n", table.Render())
+	return nil
+}

--- a/pkg/ui/entity.go
+++ b/pkg/ui/entity.go
@@ -14,6 +14,7 @@ func CleanEntityID(id string) string {
 		"sandbox/",
 		"app_version/",
 		"app/",
+		"pool/",
 	}
 
 	cleaned := id


### PR DESCRIPTION
Add pool column to 'sandbox list' showing which pool each sandbox belongs to. Create new 'sandbox-pool list' command to inspect pools and their instance counts (desired, current, ready).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "sandbox-pool list" command to view all sandbox pools.
  * Sandbox listings now include a POOL column and the JSON output includes pool info.

* **Bug Fixes / UX**
  * Entity IDs are now cleaned to remove technical prefixes and empty pools render as "-" for clearer display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->