### PR TITLE
Fix duplicate sandboxes on pool recovery

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -766,6 +766,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	}
 
 	ctx.Log.Info("miren server shutting down, cleaning up resources")
+	co.Stop()
 	return err
 }
 

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -660,9 +660,8 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		return sch.Watch(sub, eac)
 	})
 
-	eg.Go(func() error {
-		return spm.Run(sub)
-	})
+	// SandboxPool manager is now managed by the controller framework in coordinator.Start()
+	// No need to run it separately here
 
 	go func() {
 		err := http.ListenAndServe(":8989", hs)

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -796,12 +796,107 @@ func (a *localActivator) recoverPools(ctx context.Context) error {
 		}
 		a.mu.Unlock()
 
+		// Migrate existing sandboxes without pool labels to this pool
+		migratedCount, err := a.migrateOrphanedSandboxes(ctx, &pool)
+		if err != nil {
+			a.log.Error("failed to migrate orphaned sandboxes to pool", "pool", pool.ID, "error", err)
+		}
+
+		// If we migrated sandboxes, trigger pool reconciliation by updating the pool entity
+		// This ensures the pool manager immediately sees and reconciles the new sandbox count
+		if migratedCount > 0 {
+			// Touch the pool entity to trigger a watch event and immediate reconciliation
+			var rpcE entityserver_v1alpha.Entity
+			rpcE.SetId(pool.ID.String())
+			rpcE.SetAttrs(entity.New(
+				(&core_v1alpha.Metadata{
+					Labels: types.LabelSet("migration-trigger", time.Now().Format(time.RFC3339)),
+				}).Encode,
+			).Attrs())
+			if _, err := a.eac.Put(ctx, &rpcE); err != nil {
+				a.log.Error("failed to trigger pool reconciliation", "pool", pool.ID, "error", err)
+			}
+		}
+
 		a.log.Info("recovered pool", "pool", pool.ID, "service", pool.Service, "version", versionID, "desired_instances", pool.DesiredInstances)
 	}
 
 	return nil
 }
 
+// migrateOrphanedSandboxes finds RUNNING sandboxes that match a pool's version+service
+// but don't have a pool label, and labels them with this pool's ID.
+// This handles migration of pre-pool sandboxes into the pool system.
+// Returns the count of migrated sandboxes and any error.
+func (a *localActivator) migrateOrphanedSandboxes(ctx context.Context, pool *compute_v1alpha.SandboxPool) (int, error) {
+	// Query sandboxes by version
+	resp, err := a.eac.List(ctx, entity.Ref(compute_v1alpha.SandboxVersionId, pool.SandboxSpec.Version))
+	if err != nil {
+		return 0, fmt.Errorf("failed to list sandboxes by version: %w", err)
+	}
+
+	migratedCount := 0
+
+	for _, ent := range resp.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(ent.Entity())
+
+		// Only consider RUNNING sandboxes
+		if sb.Status != compute_v1alpha.RUNNING {
+			continue
+		}
+
+		// Check labels
+		var md core_v1alpha.Metadata
+		md.Decode(ent.Entity())
+
+		// Must match service
+		serviceLabel, _ := md.Labels.Get("service")
+		if serviceLabel != pool.Service {
+			continue
+		}
+
+		// Check if already has a pool label
+		poolLabel, _ := md.Labels.Get("pool")
+		if poolLabel != "" {
+			continue // Already belongs to a pool
+		}
+
+		// This is an orphaned sandbox - label it with this pool
+		a.log.Info("migrating orphaned sandbox to pool",
+			"sandbox", sb.ID,
+			"pool", pool.ID,
+			"service", pool.Service)
+
+		// Update the sandbox entity with pool label (add to existing labels)
+		newLabels := types.LabelSet("pool", pool.ID.String())
+		md.Labels = append(md.Labels, newLabels...)
+
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(sb.ID.String())
+		rpcE.SetAttrs(entity.New(
+			md.Encode,
+		).Attrs())
+
+		if _, err := a.eac.Put(ctx, &rpcE); err != nil {
+			a.log.Error("failed to label orphaned sandbox",
+				"sandbox", sb.ID,
+				"pool", pool.ID,
+				"error", err)
+			continue
+		}
+
+		migratedCount++
+	}
+
+	if migratedCount > 0 {
+		a.log.Info("migration complete",
+			"pool", pool.ID,
+			"migrated_sandboxes", migratedCount)
+	}
+
+	return migratedCount, nil
+}
 
 func (a *localActivator) createSandboxPool(ctx context.Context, ver *core_v1alpha.AppVersion, service string, spec *compute_v1alpha.SandboxSpec) (*compute_v1alpha.SandboxPool, error) {
 	// Get service concurrency config to determine initial instance count

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -19,6 +19,7 @@ import (
 	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/api/build/build_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	deployment_v1alpha "miren.dev/runtime/api/deployment/deployment_v1alpha"
 	aes "miren.dev/runtime/api/entityserver"
@@ -29,6 +30,7 @@ import (
 	"miren.dev/runtime/components/netresolve"
 	"miren.dev/runtime/controllers/sandboxpool"
 	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/caauth"
 	"miren.dev/runtime/pkg/cloudauth"
@@ -476,11 +478,31 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	spm := sandboxpool.NewManager(c.Log, eac)
 	c.spm = spm
-	go func() {
-		if err := spm.Run(ctx); err != nil && ctx.Err() == nil {
-			c.Log.Error("sandbox pool manager stopped", "error", err)
-		}
-	}()
+
+	// Initialize the pool manager
+	if err := spm.Init(ctx); err != nil {
+		c.Log.Error("failed to initialize pool manager", "error", err)
+		return err
+	}
+
+	// Create controller manager and add pool controller
+	cm := controller.NewControllerManager()
+	poolController := controller.NewReconcileController(
+		"sandboxpool",
+		c.Log,
+		entity.Ref(entity.EntityKind, "SandboxPool"),
+		eac,
+		controller.AdaptReconcileController[compute_v1alpha.SandboxPool](spm),
+		time.Minute, // Resync every minute to ensure pools are reconciled
+		3,           // 3 workers
+	)
+	cm.AddController(poolController)
+
+	// Start the controller manager
+	if err := cm.Start(ctx); err != nil {
+		c.Log.Error("failed to start controller manager", "error", err)
+		return err
+	}
 
 	eps := execproxy.NewServer(c.Log, eac, rs, aa)
 	server.ExposeValue("dev.miren.runtime/exec", exec_v1alpha.AdaptSandboxExec(eps))

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -490,7 +490,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	poolController := controller.NewReconcileController(
 		"sandboxpool",
 		c.Log,
-		entity.Ref(entity.EntityKind, "SandboxPool"),
+		entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool),
 		eac,
 		controller.AdaptReconcileController[compute_v1alpha.SandboxPool](spm),
 		time.Minute, // Resync every minute to ensure pools are reconciled

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -59,11 +59,13 @@ func (m *Manager) Reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPo
 		return fmt.Errorf("failed to list sandboxes: %w", err)
 	}
 
-	// Count only non-STOPPED sandboxes as "actual" - STOPPED sandboxes are being retired
+	// Count RUNNING and PENDING as "actual" (prevents duplicates while sandboxes boot)
+	// Count only RUNNING as "ready" (sandboxes serving traffic)
+	// We exclude STOPPED (being retired), DEAD (failed), and "" (uninitialized)
 	actual := int64(0)
 	ready := int64(0)
 	for _, sb := range sandboxes {
-		if sb.Status != compute_v1alpha.STOPPED {
+		if sb.Status == compute_v1alpha.RUNNING || sb.Status == compute_v1alpha.PENDING {
 			actual++
 		}
 		if sb.Status == compute_v1alpha.RUNNING {
@@ -106,7 +108,7 @@ func (m *Manager) Reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPo
 		actual = 0
 		ready = 0
 		for _, sb := range sandboxes {
-			if sb.Status != compute_v1alpha.STOPPED {
+			if sb.Status == compute_v1alpha.RUNNING || sb.Status == compute_v1alpha.PENDING {
 				actual++
 			}
 			if sb.Status == compute_v1alpha.RUNNING {
@@ -140,7 +142,7 @@ func (m *Manager) Reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPo
 		actual = 0
 		ready = 0
 		for _, sb := range sandboxes {
-			if sb.Status != compute_v1alpha.STOPPED {
+			if sb.Status == compute_v1alpha.RUNNING || sb.Status == compute_v1alpha.PENDING {
 				actual++
 			}
 			if sb.Status == compute_v1alpha.RUNNING {

--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -48,7 +48,7 @@ func TestManagerScaleUpFromZero(t *testing.T) {
 
 	// Create manager and run reconciliation
 	manager := NewManager(log, server.EAC)
-	err = manager.reconcile(ctx, pool)
+	err = manager.Reconcile(ctx, pool, nil)
 	require.NoError(t, err)
 
 	// Verify 3 sandboxes were created
@@ -115,7 +115,7 @@ func TestManagerScaleUpPartial(t *testing.T) {
 
 	// Run reconciliation
 	manager := NewManager(log, server.EAC)
-	err = manager.reconcile(ctx, pool)
+	err = manager.Reconcile(ctx, pool, nil)
 	require.NoError(t, err)
 
 	// Verify total is now 5 (2 existing + 3 new)
@@ -183,9 +183,9 @@ func TestManagerServiceIsolation(t *testing.T) {
 
 	// Run reconciliation for both
 	manager := NewManager(log, server.EAC)
-	err = manager.reconcile(ctx, pool1)
+	err = manager.Reconcile(ctx, pool1, nil)
 	require.NoError(t, err)
-	err = manager.reconcile(ctx, pool2)
+	err = manager.Reconcile(ctx, pool2, nil)
 	require.NoError(t, err)
 
 	// Verify each pool has correct count
@@ -250,7 +250,7 @@ func TestManagerVersionFiltering(t *testing.T) {
 
 	// Run reconciliation
 	manager := NewManager(log, server.EAC)
-	err = manager.reconcile(ctx, pool)
+	err = manager.Reconcile(ctx, pool, nil)
 	require.NoError(t, err)
 
 	// Should create 3 new sandboxes (old version doesn't count)
@@ -316,7 +316,7 @@ func TestManagerStatusOnlyUpdate(t *testing.T) {
 
 	// Run reconciliation
 	manager := NewManager(log, server.EAC)
-	err = manager.reconcile(ctx, pool)
+	err = manager.Reconcile(ctx, pool, nil)
 	require.NoError(t, err)
 
 	// Should not create new sandboxes
@@ -367,7 +367,7 @@ func TestManagerNoUpdateWhenStatusUnchanged(t *testing.T) {
 
 	// Run reconciliation
 	manager := NewManager(log, server.EAC)
-	err = manager.reconcile(ctx, pool)
+	err = manager.Reconcile(ctx, pool, nil)
 	require.NoError(t, err)
 
 	// Get pool again and verify status is correct
@@ -473,7 +473,7 @@ func TestManagerScaleDownIdle(t *testing.T) {
 
 	// Create manager and run reconciliation
 	manager := NewManager(log, server.EAC)
-	err = manager.reconcile(ctx, pool)
+	err = manager.Reconcile(ctx, pool, nil)
 	require.NoError(t, err)
 
 	// Verify pool status was updated
@@ -551,7 +551,7 @@ func TestManagerScaleDownFixedMode(t *testing.T) {
 
 	// Run reconciliation
 	manager := NewManager(log, server.EAC)
-	err = manager.reconcile(ctx, pool)
+	err = manager.Reconcile(ctx, pool, nil)
 	require.NoError(t, err)
 
 	// Verify NO sandboxes were stopped (fixed mode never scales down)

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -228,10 +228,7 @@ func TestServer(t *testing.T) error {
 		return sch.Watch(ctx, eac)
 	})
 
-	eg.Go(func() error {
-		defer t.Log("sandboxpool-manager complete")
-		return spm.Run(sub)
-	})
+	// Note: sandboxpool-manager is now managed by the controller framework in coordinate
 
 	httpServer := &http.Server{
 		Addr:    ":8989",

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -309,6 +309,9 @@ func TestServer(t *testing.T) error {
 		// 	client.Close()
 		// }
 
+		log.Info("Stopping coordinator and controllers")
+		co.Stop()
+
 		log.Info("Canceling context to stop all components")
 		ctxCancel()
 


### PR DESCRIPTION
## Summary
Fixes duplicate sandboxes and implements reliable pool reconciliation using the controller framework.

## Problems Solved

### 1. Duplicate Sandboxes on Recovery
When the activator recovered on restart, it was recovering pre-pool sandboxes (without pool labels) but the pool manager couldn't see them because it filters by pool label. This
caused:
- Pool manager thinks there are 0 instances when there are actually 2
- System creates additional sandboxes on new requests
- Multiple sandboxes running for apps configured with fixed instances

**Example from logs:**
20:55:10 recovered sandbox │ sandbox: sb-CUSKf42mT9Vuhv1Kvxrkx
20:55:10 recovered sandbox │ sandbox: sb-CUSKfJygVPyVrPJ7Ay67m
20:55:10 recovered pool │ desired: 1 current: 0
21:05:48 no available sandboxes, requesting capacity from pool

### 2. No Reliable Reconciliation
The SandboxPoolManager was using a custom watch loop without the benefits of the controller framework:
- No work queues for handling bursts
- No parallel processing of pool updates
- No automatic periodic resync
- Manual retry logic for watch failures
- No guarantee pools would reconcile after migration

## Solutions

### Orphan Sandbox Migration (Commit 1)
- Add `migrateOrphanedSandboxes()` to label pre-existing sandboxes during pool recovery
- Runs during `recoverPools()` - labels sandboxes without pool labels
- Safe filters ensure only app sandboxes are migrated:
  - Must have version ID (buildkit doesn't)
  - Must have service label (ephemeral containers don't)
  - Must be RUNNING (short-lived containers won't be)

### Controller Framework Integration (Commit 2 - MIR-456)
Implemented the ReconcileController pattern for reliable pool reconciliation:

**New controller interfaces in `pkg/controller`:**
- `ReconcileControllerI[P]` - For controllers that maintain 1:N relationships (one entity → N resources)
- `DeletingReconcileController` - Optional interface to handle entity deletion
- `AdaptReconcileController` - Adapts reconcile controllers to framework HandlerFunc

**SandboxPoolManager refactoring:**
- Implements `ReconcileControllerI[*SandboxPool]` interface
  - `Init()` - Starts scale-down monitor
  - `Reconcile()` - Called for both Add and Update events
- Implements `DeletingReconcileController` interface
  - `Delete()` - Stops all sandboxes when pool is deleted
- Removed custom `Run()` and watch loop

**Integration in `coordinate.go`:**
- Uses `ControllerManager` to manage pool controller
- Configured with:
  - 1-minute periodic resync for reliability
  - 3 parallel workers for throughput
  - Automatic retry on watch failures

## Benefits
- ✅ Migrates pre-pool sandboxes automatically on first restart
- ✅ **Automatic periodic reconciliation every minute** ensures pools match desired state
- ✅ Duplicate sandboxes will be detected and scaled down within 1 minute
- ✅ Parallel processing with work queues handles concurrent pool updates
- ✅ Built-in retry and reconnection logic for watch failures
  - ✅ Orphaned sandboxes are cleaned up when pools are deleted
  - ✅ Framework consistency across all controllers (matches runner.go pattern)

  ## What Happens on Next Restart
  1. Activator recovers the 2 existing meet sandboxes
  2. Activator recovers the meet pool with `desired=1`
  3. `migrateOrphanedSandboxes()` labels both sandboxes with the pool ID
  4. Controller framework starts with 1-minute periodic resync
  5. Pool manager reconciles and sees 2 instances when only 1 is desired
  6. Pool manager scales down, stopping one of the idle sandboxes
  7. Future requests use the single remaining sandbox

  ## Migration Notes
  The orphaned sandbox migration code:
  - Runs on each restart but becomes a no-op once all sandboxes are labeled
  - Is safe to remove once all environments are rolled over to the pool system
  - Can be identified by searching for `migrateOrphanedSandboxes`

  ## Testing
  - ✅ Code compiles
  - ✅ Passes linter
  - ✅ Unit tests updated for new `Reconcile()` signature
  - Ready to test on miren-garden server restart

  Addresses: MIR-456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox pool lifecycle now runs under a controller-based reconciliation framework with structured init/start and explicit delete handling.
  * Added an adapter to integrate reconcile-style controllers with the manager.

* **Bug Fixes**
  * Pool recovery now detects and relabels orphaned RUNNING sandboxes so they’re reassociated with pools; migration errors are logged without aborting recovery.

* **Tests**
  * Updated tests to exercise the new reconcile entrypoints and lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->