### PR TITLE
entity: Minor revision cleanup

### DIFF
--- a/.iso/config.yml
+++ b/.iso/config.yml
@@ -2,4 +2,6 @@ privileged: true
 workdir: /src
 volumes:
   - /data
+cache:
   - /go/pkg
+  - /root/.cache

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -549,12 +549,10 @@ func (c *SandboxController) checkSandbox(ctx context.Context, co *compute.Sandbo
 	}
 
 	if _, ok := labels[sandboxVersionLabel]; !ok {
-		c.Log.Debug("sandbox version label not found, assuming new sandbox")
 		return differentVersion, nil
 	}
 
 	if labels[sandboxVersionLabel] != fmt.Sprint(meta.Revision) {
-		c.Log.Debug("sandbox version mismatch", "expected", meta.Revision, "found", labels[sandboxVersionLabel])
 		return differentVersion, nil
 	}
 
@@ -752,6 +750,8 @@ func (c *SandboxController) updateSandbox(ctx context.Context, sb *compute.Sandb
 					labels[strings.TrimSpace(k)] = strings.TrimSpace(v)
 				}
 			}
+
+			labels[sandboxVersionLabel] = strconv.FormatInt(meta.Revision, 10)
 
 			_, err = cont.SetLabels(ctx, labels)
 			if err != nil {

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -243,9 +243,7 @@ func (e *Entity) GetRevision() int64 {
 }
 
 func (e *Entity) SetRevision(rev int64) {
-	e.Remove(Revision)
-	e.attrs = append(e.attrs, Int64(Revision, rev))
-	e.attrs = SortedAttrs(e.attrs)
+	e.Set(Int64(Revision, rev))
 }
 
 func (e *Entity) GetCreatedAt() time.Time {


### PR DESCRIPTION
Don't log when the revisions are different in the detection case, the code is working the way it should. But also, be sure to update the sandbox version when you do an update!

Lastly, because we use the etcd revision as the entity revision, be more careful about not storing the Revision attr into etcd to reduce confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Revision field is now exclusively managed by the system and will not accept user-provided values during create, update, replace, and patch operations.
  * Sandbox version label is now applied consistently to avoid mismatches.

* **Chores**
  * Removed debug logging related to sandbox version detection.
  * Optimized internal revision update logic.

* **Configuration**
  * Added an extra cache path to the ISO config to include /root/.cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->