### PR TITLE
Fix activator to skip DEAD sandboxes when acquiring leases

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -168,7 +168,7 @@ func (a *localActivator) AcquireLease(ctx context.Context, ver *core_v1alpha.App
 		start := rand.Int() % len(vs.sandboxes)
 		for i := 0; i < len(vs.sandboxes); i++ {
 			s := vs.sandboxes[(start+i)%len(vs.sandboxes)]
-			if s.tracker.HasCapacity() {
+			if s.sandbox.Status == compute_v1alpha.RUNNING && s.tracker.HasCapacity() {
 				candidateSandbox = s
 				break
 			}
@@ -273,7 +273,7 @@ func (a *localActivator) ensurePoolAndWaitForSandbox(ctx context.Context, ver *c
 			start := rand.Int() % len(vs.sandboxes)
 			for i := 0; i < len(vs.sandboxes); i++ {
 				s := vs.sandboxes[(start+i)%len(vs.sandboxes)]
-				if s.tracker.HasCapacity() {
+				if s.sandbox.Status == compute_v1alpha.RUNNING && s.tracker.HasCapacity() {
 					candidateSandbox = s
 					break
 				}

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -501,10 +501,12 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 			// First, check if we're already tracking this sandbox (read lock for scan)
 			a.mu.RLock()
 			var trackedSandbox *sandbox
-			for _, vs := range a.versions {
+			var trackedKey verKey
+			for key, vs := range a.versions {
 				for _, s := range vs.sandboxes {
 					if s.sandbox.ID == sb.ID {
 						trackedSandbox = s
+						trackedKey = key
 						break
 					}
 				}
@@ -519,10 +521,34 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 				a.mu.Lock()
 				oldStatus := trackedSandbox.sandbox.Status
 				trackedSandbox.sandbox.Status = sb.Status
+
+				// If sandbox transitioned to DEAD, remove it from tracking
+				if sb.Status == compute_v1alpha.DEAD {
+					if vs, ok := a.versions[trackedKey]; ok {
+						// Find and remove the sandbox from the slice
+						for i, s := range vs.sandboxes {
+							if s.sandbox.ID == sb.ID {
+								// Remove by replacing with last element and truncating
+								vs.sandboxes[i] = vs.sandboxes[len(vs.sandboxes)-1]
+								vs.sandboxes = vs.sandboxes[:len(vs.sandboxes)-1]
+								break
+							}
+						}
+
+						// If no sandboxes remain for this version+service, remove the entry
+						if len(vs.sandboxes) == 0 {
+							delete(a.versions, trackedKey)
+						}
+					}
+				}
+
 				a.mu.Unlock()
 
 				if oldStatus != sb.Status {
 					a.log.Info("sandbox status changed", "sandbox", sb.ID, "old_status", oldStatus, "new_status", sb.Status)
+					if sb.Status == compute_v1alpha.DEAD {
+						a.log.Info("removed DEAD sandbox from tracking", "sandbox", sb.ID)
+					}
 				}
 				return nil
 			}


### PR DESCRIPTION
## Summary

- Fixed bug where DEAD sandboxes were being considered for lease acquisition
- Added status check to ensure only RUNNING sandboxes are selected for leases
- **NEW**: Added automatic removal of DEAD sandboxes from tracking to prevent memory leak
- Added test cases to verify the fix and removal behavior

## Problem

The activator's `AcquireLease` method was scanning sandboxes for available capacity without checking their health status. This meant that sandboxes marked as DEAD (by the `watchSandboxes` goroutine) could still receive new lease assignments, causing requests to be routed to non-functional sandboxes.

Additionally, DEAD sandboxes were never removed from the tracking structures (`versions` map), causing:
- **Memory leak**: Accumulation of dead sandbox references over time
- **Performance degradation**: Each lease acquisition iterates through more dead sandboxes
- **Stale data**: The `versions` map never shrinks

The bug existed in two locations:
1. Main `AcquireLease` initial scan (line 171)
2. `checkForSandbox` helper in `ensurePoolAndWaitForSandbox` (line 276)

## Solution

### Commit 1: Skip DEAD sandboxes during lease acquisition
Added `s.sandbox.Status == compute_v1alpha.RUNNING` check before `s.tracker.HasCapacity()` in both locations to ensure only healthy sandboxes are considered for lease acquisition.

### Commit 2: Remove DEAD sandboxes from tracking
Modified `watchSandboxes` to actively remove sandboxes from tracking when they transition to DEAD status:
- Tracks the `verKey` during sandbox lookup
- Removes sandbox from `vs.sandboxes` slice when status changes to DEAD
- Cleans up empty version entries to prevent map growth
- Logs removal for observability

## Test Plan

- [x] Added `TestActivatorAcquireLeaseFromDeadSandbox` - verifies DEAD sandboxes are skipped
- [x] Added `TestActivatorRemovesDeadSandbox` - verifies DEAD sandboxes are removed from tracking
- [x] All existing activator tests still pass (8 tests total)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox selection now requires sandboxes to be RUNNING; DEAD sandboxes are ignored for lease acquisition.
  * Improved tracking and cleanup: DEAD sandboxes are removed from in-memory tracking and version entries are pruned; removals are logged.

* **Tests**
  * Added tests validating that DEAD sandboxes are not used for leasing and are removed from tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->