### PR TITLE
Use the new cache setting for iso now that it uses ephemeral sessions

### DIFF
--- a/.iso/config.yml
+++ b/.iso/config.yml
@@ -2,4 +2,6 @@ privileged: true
 workdir: /src
 volumes:
   - /data
+cache:
   - /go/pkg
+  - /root/.cache


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build caching configuration to improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->