### PR TITLE
Add sandbox-pool set-desired command for debugging pool scaling

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -55,6 +55,9 @@ func AllCommands() map[string]cli.CommandFactory {
 		"sandbox-pool list": func() (cli.Command, error) {
 			return Infer("sandbox-pool list", "List all sandbox pools", SandboxPoolList), nil
 		},
+		"sandbox-pool set-desired": func() (cli.Command, error) {
+			return Infer("sandbox-pool set-desired", "Set desired instance count for a sandbox pool", SandboxPoolSetDesired), nil
+		},
 
 		"app": func() (cli.Command, error) {
 			return Infer("app", "Get information about an application", App), nil

--- a/cli/commands/sandbox_pool_set_desired.go
+++ b/cli/commands/sandbox_pool_set_desired.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+func SandboxPoolSetDesired(ctx *Context, opts struct {
+	ConfigCentric
+	Args struct {
+		PoolID  string `positional-arg-name:"pool-id" description:"Pool ID (e.g., pool-CUSkT8J58BmgkDeGyPP2e or pool/pool-CUSkT8J58BmgkDeGyPP2e)" required:"true"`
+		Desired string `positional-arg-name:"desired" description:"Desired instance count (absolute number, +N to increase, or -N to decrease)" required:"true"`
+	} `positional-args:"yes"`
+}) error {
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+
+	// Normalize the pool ID - accept both "pool-ABC" and "pool/pool-ABC" formats
+	// TrimPrefix only removes the prefix if it exists, so this handles both forms
+	poolID := strings.TrimPrefix(opts.Args.PoolID, "pool/")
+
+	// Look up the pool by ID
+	var pool compute_v1alpha.SandboxPool
+	getRes, err := eac.Get(ctx, poolID)
+	if err != nil {
+		return fmt.Errorf("sandbox pool not found: %s (error: %v)", opts.Args.PoolID, err)
+	}
+
+	pool.Decode(getRes.Entity().Entity())
+
+	// Parse the desired count (absolute or relative)
+	var newDesired int64
+	desiredStr := strings.TrimSpace(opts.Args.Desired)
+
+	if strings.HasPrefix(desiredStr, "+") || strings.HasPrefix(desiredStr, "-") {
+		// Relative adjustment
+		delta, err := strconv.ParseInt(desiredStr, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid relative count %q: %v", opts.Args.Desired, err)
+		}
+		newDesired = pool.DesiredInstances + delta
+		if newDesired < 0 {
+			return fmt.Errorf("relative adjustment would result in negative count: %d + %d = %d", pool.DesiredInstances, delta, newDesired)
+		}
+	} else {
+		// Absolute count
+		count, err := strconv.ParseInt(desiredStr, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid count %q: %v", opts.Args.Desired, err)
+		}
+		if count < 0 {
+			return fmt.Errorf("count cannot be negative: %d", count)
+		}
+		newDesired = count
+	}
+
+	// Check if there's actually a change
+	if newDesired == pool.DesiredInstances {
+		ctx.Printf("Pool %s (service=%s) already has desired_instances=%d\n",
+			pool.ID.String(), pool.Service, pool.DesiredInstances)
+		return nil
+	}
+
+	// Prepare the patch
+	attrs := []entity.Attr{
+		{
+			ID:    entity.DBId,
+			Value: entity.AnyValue(pool.ID),
+		},
+		{
+			ID:    compute_v1alpha.SandboxPoolDesiredInstancesId,
+			Value: entity.AnyValue(newDesired),
+		},
+	}
+
+	// Apply the patch
+	patchRes, err := eac.Patch(ctx, attrs, 0)
+	if err != nil {
+		return fmt.Errorf("failed to patch sandbox pool: %v", err)
+	}
+
+	ctx.Printf("Successfully updated sandbox pool:\n")
+	ctx.Printf("  Pool ID: %s\n", pool.ID.String())
+	ctx.Printf("  Service: %s\n", pool.Service)
+	ctx.Printf("  Previous desired_instances: %d\n", pool.DesiredInstances)
+	ctx.Printf("  New desired_instances: %d\n", newDesired)
+	ctx.Printf("  Current instances: %d\n", pool.CurrentInstances)
+	ctx.Printf("  Ready instances: %d\n", pool.ReadyInstances)
+	ctx.Printf("  Revision: %d\n", patchRes.Revision())
+
+	return nil
+}

--- a/cli/commands/sandbox_pool_set_desired.go
+++ b/cli/commands/sandbox_pool_set_desired.go
@@ -82,8 +82,8 @@ func SandboxPoolSetDesired(ctx *Context, opts struct {
 		},
 	}
 
-	// Apply the patch
-	patchRes, err := eac.Patch(ctx, attrs, 0)
+	// Apply the patch with optimistic concurrency control
+	patchRes, err := eac.Patch(ctx, attrs, getRes.Entity().Revision())
 	if err != nil {
 		return fmt.Errorf("failed to patch sandbox pool: %v", err)
 	}


### PR DESCRIPTION
## Summary

Adds a `sandbox-pool set-desired` command to allow operators to manually override the desired instance count for sandbox pools. This is particularly useful for debugging runaway scaling issues or forcing pools to a specific size during troubleshooting.

## Changes

- Added new CLI command: `sandbox-pool set-desired <pool-id> <desired>`
- Supports both short (`pool-ABC`) and full (`pool/pool-ABC`) pool ID formats
- Supports absolute counts (e.g., `10`) and relative adjustments (`+5`, `-3`)
- Includes validation to prevent negative instance counts
- Shows comprehensive before/after state for verification

## Usage Examples

```bash
# Set pool to exactly 5 instances
m sandbox-pool set-desired pool-CUSkT8J58BmgkDeGyPP2e 5

# Increase current desired count by 10
m sandbox-pool set-desired pool-ABC123 +10

# Decrease current desired count by 3
m sandbox-pool set-desired pool-ABC123 -3

# Force pool to zero (stop all scaling)
m sandbox-pool set-desired pool-ABC123 0
```

## Test Plan

- Builds successfully with `make bin/miren`
- Passes all linting checks with `make lint`
- Command help displays correctly with `--help`
- Follows existing CLI command patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "sandbox-pool set-desired" CLI command to update a sandbox pool's desired instance count. Accepts absolute values or relative adjustments (+N / -N), validates inputs and prevents negative totals, skips no-op updates, applies changes when needed, and prints a success summary with pool ID, service, previous/new desired, current instances, ready instances, and patch revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->