### PR TITLE
Fix generate diff from recent schemagen change

### DIFF
--- a/api/compute/compute_v1alpha/schema.gen.go
+++ b/api/compute/compute_v1alpha/schema.gen.go
@@ -452,9 +452,7 @@ func (o *SandboxSpecContainerPort) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.NodePort) {
 		attrs = append(attrs, entity.Int64(SandboxSpecContainerPortNodePortId, o.NodePort))
 	}
-	if !entity.Empty(o.Port) {
-		attrs = append(attrs, entity.Int64(SandboxSpecContainerPortPortId, o.Port))
-	}
+	attrs = append(attrs, entity.Int64(SandboxSpecContainerPortPortId, o.Port))
 	if a, ok := SandboxSpecContainerPortprotocolToId[o.Protocol]; ok {
 		attrs = append(attrs, entity.Ref(SandboxSpecContainerPortProtocolId, a))
 	}
@@ -1364,9 +1362,7 @@ func (o *Port) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.NodePort) {
 		attrs = append(attrs, entity.Int64(PortNodePortId, o.NodePort))
 	}
-	if !entity.Empty(o.Port) {
-		attrs = append(attrs, entity.Int64(PortPortId, o.Port))
-	}
+	attrs = append(attrs, entity.Int64(PortPortId, o.Port))
 	if a, ok := PortprotocolToId[o.Protocol]; ok {
 		attrs = append(attrs, entity.Ref(PortProtocolId, a))
 	}

--- a/api/network/network_v1alpha/schema.gen.go
+++ b/api/network/network_v1alpha/schema.gen.go
@@ -260,9 +260,7 @@ func (o *Port) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.NodePort) {
 		attrs = append(attrs, entity.Int64(PortNodePortId, o.NodePort))
 	}
-	if !entity.Empty(o.Port) {
-		attrs = append(attrs, entity.Int64(PortPortId, o.Port))
-	}
+	attrs = append(attrs, entity.Int64(PortPortId, o.Port))
 	if a, ok := PortprotocolToId[o.Protocol]; ok {
 		attrs = append(attrs, entity.Ref(PortProtocolId, a))
 	}

--- a/api/storage/storage_v1alpha/schema.go
+++ b/api/storage/storage_v1alpha/schema.go
@@ -117,9 +117,7 @@ func (o *Disk) Encode() (attrs []entity.Attr) {
 		attrs = append(attrs, entity.String(DiskNameId, o.Name))
 	}
 	attrs = append(attrs, entity.Bool(DiskRemoteOnlyId, o.RemoteOnly))
-	if !entity.Empty(o.SizeGb) {
-		attrs = append(attrs, entity.Int64(DiskSizeGbId, o.SizeGb))
-	}
+	attrs = append(attrs, entity.Int64(DiskSizeGbId, o.SizeGb))
 	if a, ok := diskstatusToId[o.Status]; ok {
 		attrs = append(attrs, entity.Ref(DiskStatusId, a))
 	}


### PR DESCRIPTION
Landed before the CI check made it in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved data consistency in API responses** – Port fields in compute and network services now consistently appear in API responses with their values, including zero values, ensuring complete data representation.
* **Storage size representation** – Disk size attributes are now consistently included in storage API responses, eliminating previously incomplete representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->