### PR TITLE
Fix: Include services with only concurrency config in app_version

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -111,7 +111,7 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 
 		// Map from appconfig to entity schema
 		// After ResolveDefaults(), every service is guaranteed to have config
-		if serviceConfig, ok := ac.Services[serviceName]; ok && serviceConfig.Concurrency != nil {
+		if serviceConfig, ok := ac.Services[serviceName]; ok && serviceConfig != nil && serviceConfig.Concurrency != nil {
 			svc.ServiceConcurrency = core_v1alpha.ServiceConcurrency{
 				Mode:                serviceConfig.Concurrency.Mode,
 				NumInstances:        int64(serviceConfig.Concurrency.NumInstances),
@@ -453,7 +453,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		// Check if this service has a command from app config or procfile
 		var cmd string
 		if ac != nil {
-			if svcConfig, ok := ac.Services[svc.Name]; ok && svcConfig.Command != "" {
+			if svcConfig, ok := ac.Services[svc.Name]; ok && svcConfig != nil && svcConfig.Command != "" {
 				cmd = svcConfig.Command
 			}
 		}

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -1,0 +1,197 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/appconfig"
+)
+
+func TestBuildServicesConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		appConfig        *appconfig.AppConfig
+		procfileServices map[string]string
+		validateServices func(t *testing.T, services []core_v1alpha.Services)
+	}{
+		{
+			name: "service with only concurrency config (no command) - uptime-kuma case",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"web": {
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:         "fixed",
+							NumInstances: 1,
+						},
+						// No Command field - relies on container default
+					},
+				},
+			},
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+				require.Len(t, services, 1, "should have one service")
+				assert.Equal(t, "web", services[0].Name)
+				assert.Equal(t, "fixed", services[0].ServiceConcurrency.Mode)
+				assert.Equal(t, int64(1), services[0].ServiceConcurrency.NumInstances)
+			},
+		},
+		{
+			name: "service with both command and concurrency",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"web": {
+						Command: "node server.js",
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:                "auto",
+							RequestsPerInstance: 10,
+							ScaleDownDelay:      "15m",
+						},
+					},
+				},
+			},
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+				require.Len(t, services, 1)
+				assert.Equal(t, "web", services[0].Name)
+				assert.Equal(t, "auto", services[0].ServiceConcurrency.Mode)
+				assert.Equal(t, int64(10), services[0].ServiceConcurrency.RequestsPerInstance)
+				assert.Equal(t, "15m", services[0].ServiceConcurrency.ScaleDownDelay)
+			},
+		},
+		{
+			name:      "procfile only - gets default concurrency",
+			appConfig: nil,
+			procfileServices: map[string]string{
+				"web": "npm start",
+			},
+			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+				require.Len(t, services, 1)
+				assert.Equal(t, "web", services[0].Name)
+				// Web service should get auto mode defaults
+				assert.Equal(t, "auto", services[0].ServiceConcurrency.Mode)
+				assert.Equal(t, int64(10), services[0].ServiceConcurrency.RequestsPerInstance)
+				assert.Equal(t, "15m", services[0].ServiceConcurrency.ScaleDownDelay)
+			},
+		},
+		{
+			name: "multiple services with mixed configs",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"web": {
+						// Only concurrency, no command
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:         "fixed",
+							NumInstances: 1,
+						},
+					},
+					"worker": {
+						Command: "node worker.js",
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:         "fixed",
+							NumInstances: 2,
+						},
+					},
+				},
+			},
+			procfileServices: map[string]string{
+				"cron": "node cron.js",
+			},
+			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+				require.Len(t, services, 3, "should have three services")
+
+				// Find each service and validate
+				serviceMap := make(map[string]core_v1alpha.Services)
+				for _, svc := range services {
+					serviceMap[svc.Name] = svc
+				}
+
+				// Web service
+				require.Contains(t, serviceMap, "web")
+				assert.Equal(t, "fixed", serviceMap["web"].ServiceConcurrency.Mode)
+				assert.Equal(t, int64(1), serviceMap["web"].ServiceConcurrency.NumInstances)
+
+				// Worker service
+				require.Contains(t, serviceMap, "worker")
+				assert.Equal(t, "fixed", serviceMap["worker"].ServiceConcurrency.Mode)
+				assert.Equal(t, int64(2), serviceMap["worker"].ServiceConcurrency.NumInstances)
+
+				// Cron service (from procfile, gets default fixed mode)
+				require.Contains(t, serviceMap, "cron")
+				assert.Equal(t, "fixed", serviceMap["cron"].ServiceConcurrency.Mode)
+				assert.Equal(t, int64(1), serviceMap["cron"].ServiceConcurrency.NumInstances)
+			},
+		},
+		{
+			name: "app config command overrides procfile",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"web": {
+						Command: "npm run prod",
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:                "auto",
+							RequestsPerInstance: 20,
+							ScaleDownDelay:      "5m",
+						},
+					},
+				},
+			},
+			procfileServices: map[string]string{
+				"web": "npm start",
+			},
+			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+				require.Len(t, services, 1)
+				assert.Equal(t, "web", services[0].Name)
+				// Should get app config concurrency, not defaults
+				assert.Equal(t, "auto", services[0].ServiceConcurrency.Mode)
+				assert.Equal(t, int64(20), services[0].ServiceConcurrency.RequestsPerInstance)
+				assert.Equal(t, "5m", services[0].ServiceConcurrency.ScaleDownDelay)
+			},
+		},
+		{
+			name: "service with command but no concurrency - empty concurrency",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"worker": {
+						Command: "node worker.js",
+						// No concurrency specified - ResolveDefaults skips existing services
+					},
+				},
+			},
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+				require.Len(t, services, 1)
+				assert.Equal(t, "worker", services[0].Name)
+				// No concurrency will be empty since ResolveDefaults skips existing services
+				assert.Equal(t, "", services[0].ServiceConcurrency.Mode)
+				assert.Equal(t, int64(0), services[0].ServiceConcurrency.NumInstances)
+			},
+		},
+		{
+			name:             "no config no procfile",
+			appConfig:        nil,
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+				assert.Len(t, services, 0, "should have no services")
+			},
+		},
+		{
+			name: "empty app config",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{},
+			},
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+				assert.Len(t, services, 0, "should have no services")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			services := buildServicesConfig(tt.appConfig, tt.procfileServices)
+			tt.validateServices(t, services)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes deployment failures for apps that define only concurrency settings without explicit commands (like uptime-kuma).

## Problem
The build process was skipping services that had concurrency config but no command. This caused errors like:
```
service "web" not found in version config (services should be hydrated with defaults)
```

For apps like uptime-kuma that rely on container default CMD/ENTRYPOINT:
```toml
[services.web.concurrency]
mode = "fixed"
num_instances = 1
```

## Root Cause
Two-part bug in `servers/build/build.go`:
1. Collected service names from both commands AND app config into `allServiceNames` (correct)
2. BUT only iterated over `srvMap` (commands only) when building final `Config.Services` (bug)

## Solution
- Extract service collection logic into testable `buildServicesConfig()` function
- Fix iteration to use `allServiceNames` instead of `srvMap`
- Add comprehensive test coverage (8 test cases) including the uptime-kuma scenario
- Simplify code with `slices.Contains()` for duplicate checking

## Test Plan
- [x] All new unit tests pass (8/8)
- [x] Build succeeds
- [x] Linter passes with 0 issues
- [ ] Deploy uptime-kuma and verify it works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified service configuration to merge app config and Procfile inputs, ensure services from both sources appear, prefer app config commands over Procfile, apply sensible defaults, and derive per-service concurrency and commands only when present.

* **Tests**
  * Added comprehensive tests covering multiple service scenarios, precedence rules, defaulting behavior, and varied command/concurrency combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->