### PR TITLE
cli: Allow sandbox commands to accept non-prefixed IDs

### DIFF
--- a/api/compute/client.go
+++ b/api/compute/client.go
@@ -39,7 +39,7 @@ func (c *Client) GetSandbox(ctx context.Context, sandboxID string) (*compute_v1a
 		// If Get fails, try GetById in case the user provided an unprefixed ID
 		err2 := c.ec.GetById(ctx, entity.Id(sandboxID), &sandbox)
 		if err2 != nil {
-			return nil, fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
+			return nil, fmt.Errorf("sandbox %q not found (tried as name and as ID): %w", sandboxID, err2)
 		}
 	}
 

--- a/api/compute/client.go
+++ b/api/compute/client.go
@@ -8,6 +8,7 @@ import (
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/rpc"
 )
 
@@ -28,14 +29,28 @@ func NewClient(log *slog.Logger, client rpc.Client) *Client {
 	}
 }
 
-// StopSandbox updates a sandbox status to stopped
-func (c *Client) StopSandbox(ctx context.Context, sandboxID string) error {
+// GetSandbox retrieves a sandbox by name or ID
+func (c *Client) GetSandbox(ctx context.Context, sandboxID string) (*compute_v1alpha.Sandbox, error) {
 	var sandbox compute_v1alpha.Sandbox
 
-	// Get the current sandbox
+	// Try as name first, then as ID
 	err := c.ec.Get(ctx, sandboxID, &sandbox)
 	if err != nil {
-		return fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
+		// If Get fails, try GetById in case the user provided an unprefixed ID
+		err2 := c.ec.GetById(ctx, entity.Id(sandboxID), &sandbox)
+		if err2 != nil {
+			return nil, fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
+		}
+	}
+
+	return &sandbox, nil
+}
+
+// StopSandbox updates a sandbox status to stopped
+func (c *Client) StopSandbox(ctx context.Context, sandboxID string) error {
+	sandbox, err := c.GetSandbox(ctx, sandboxID)
+	if err != nil {
+		return err
 	}
 
 	// Check if already stopped or dead
@@ -48,7 +63,7 @@ func (c *Client) StopSandbox(ctx context.Context, sandboxID string) error {
 	sandbox.Status = compute_v1alpha.STOPPED
 
 	// Update the entity
-	err = c.ec.Update(ctx, &sandbox)
+	err = c.ec.Update(ctx, sandbox)
 	if err != nil {
 		return fmt.Errorf("failed to update sandbox %s: %w", sandboxID, err)
 	}
@@ -59,12 +74,9 @@ func (c *Client) StopSandbox(ctx context.Context, sandboxID string) error {
 
 // DeleteSandbox deletes a sandbox, but only if it's dead
 func (c *Client) DeleteSandbox(ctx context.Context, sandboxID string) error {
-	var sandbox compute_v1alpha.Sandbox
-
-	// Get the current sandbox
-	err := c.ec.Get(ctx, sandboxID, &sandbox)
+	sandbox, err := c.GetSandbox(ctx, sandboxID)
 	if err != nil {
-		return fmt.Errorf("failed to get sandbox %s: %w", sandboxID, err)
+		return err
 	}
 
 	// Check if sandbox is dead


### PR DESCRIPTION
## Summary

Enhances sandbox CLI commands to accept both prefixed names (e.g., `sandbox/name`) and unprefixed entity IDs (e.g., `01JBEXAMPLE123`).

## Problem

The `sandbox list` command displays IDs using `CleanEntityID()` which strips the `sandbox/` prefix for cleaner output. However, users couldn't copy these IDs and use them directly with other commands like `sandbox stop` or `logs --sandbox`, leading to confusion.

Additionally, logs are stored in ClickHouse with the full entity ID (not the prefixed name), so the `logs --sandbox` command had a workaround that didn't handle all cases correctly.

## Changes

### `api/compute/client.go`
- Added `GetSandbox()` method that tries both name-based (`Get`) and ID-based (`GetById`) lookups
- Refactored `StopSandbox()` and `DeleteSandbox()` to use `GetSandbox()` - eliminates code duplication and improves maintainability

### `cli/commands/logs.go`
- Updated to resolve sandbox identifier to full entity ID before querying logs
- Removed old prefix-adding workaround that didn't work with full entity IDs

## Benefits

- **Better UX**: Users can now copy IDs from `sandbox list` and use them directly with other commands
- **DRY**: Lookup logic is centralized in `GetSandbox()` and reused
- **Consistency**: All three commands (`sandbox stop`, `sandbox delete`, `logs --sandbox`) now accept the same input formats:
  - Full entity IDs: `01JBEXAMPLE123`
  - Prefixed names: `sandbox/mysandbox`
  - Short names: `mysandbox`

## Test Plan

- [x] Build succeeds
- [x] Lint passes with 0 issues
- [x] Backward compatibility maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sandbox identification now resolves both names and IDs automatically (no manual "sandbox/" prefix required).
  * Log retrieval consistently uses resolved full sandbox IDs for accurate results.
  * Sandbox management operations (stop/delete) use the same resolution flow for more reliable behavior.
  * Error messages for failed sandbox lookups are clearer and propagated to callers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->