### PR TITLE
Add groups version tracking for JWT token invalidation

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -14,6 +14,10 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("login", "Authenticate with miren.cloud", Login), nil
 		},
 
+		"whoami": func() (cli.Command, error) {
+			return Infer("whoami", "Display information about the current authenticated user", Whoami), nil
+		},
+
 		"debug": func() (cli.Command, error) {
 			return Section("debug", "Debug and troubleshooting commands"), nil
 		},

--- a/cli/commands/whoami.go
+++ b/cli/commands/whoami.go
@@ -1,0 +1,137 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/auth"
+	"miren.dev/runtime/pkg/cloudauth"
+)
+
+// Whoami displays information about the current authenticated user
+func Whoami(ctx *Context, opts struct {
+	ConfigCentric
+	JSON bool `long:"json" description:"Output as JSON"`
+}) error {
+	// Check if we have a configured cluster
+	if ctx.ClusterConfig == nil {
+		return fmt.Errorf("no cluster configured - use 'miren cluster add' to add a cluster")
+	}
+
+	// Get server hostname
+	hostname := ctx.ClusterConfig.Hostname
+	if hostname == "" {
+		return fmt.Errorf("no hostname configured for cluster %s", ctx.ClusterName)
+	}
+
+	// Get JWT token if using keypair auth
+	token := ""
+	authMethod := "none"
+	var identity *clientconfig.IdentityConfig
+	
+	if ctx.ClusterConfig.Identity != "" && ctx.ClientConfig != nil {
+		var err error
+		identity, err = ctx.ClientConfig.GetIdentity(ctx.ClusterConfig.Identity)
+		if err == nil && identity != nil && identity.Type == "keypair" && identity.PrivateKey != "" {
+			keyPair, err := cloudauth.LoadKeyPairFromPEM(identity.PrivateKey)
+			if err != nil {
+				ctx.Warn("Failed to load keypair: %v", err)
+			} else {
+				// Get the auth server URL
+				authServer := identity.Issuer
+				if authServer == "" {
+					authServer = hostname
+				}
+				
+				// For local development, use HTTP
+				if !strings.HasPrefix(authServer, "http://") && !strings.HasPrefix(authServer, "https://") {
+					if strings.Contains(authServer, "localhost") || strings.Contains(authServer, "127.0.0.1") {
+						authServer = "http://" + authServer
+					} else {
+						authServer = "https://" + authServer
+					}
+				}
+				
+				// Get JWT token
+				token, err = clientconfig.AuthenticateWithKey(ctx, authServer, keyPair)
+				if err != nil {
+					return fmt.Errorf("failed to authenticate with keypair: %w", err)
+				}
+				authMethod = "keypair"
+			}
+		} else if identity != nil && identity.Type == "certificate" {
+			authMethod = "certificate"
+		}
+	}
+
+	// Try to parse JWT claims if we have a token
+	var claims *auth.ExtendedClaims
+	if token != "" {
+		claims, _ = auth.ParseUnverifiedClaims(token)
+	}
+
+	// Prepare output
+	type WhoamiOutput struct {
+		Cluster    string   `json:"cluster"`
+		ServerURL  string   `json:"server_url"`
+		AuthMethod string   `json:"auth_method"`
+		Identity   string   `json:"identity,omitempty"`
+		UserID     string   `json:"user_id,omitempty"`
+		UserEmail  string   `json:"user_email,omitempty"`
+		Groups     []string `json:"groups,omitempty"`
+		GroupIDs   []string `json:"group_ids,omitempty"`
+	}
+
+	output := WhoamiOutput{
+		Cluster:    ctx.ClusterName,
+		ServerURL:  hostname,
+		AuthMethod: authMethod,
+	}
+	
+	if identity != nil {
+		output.Identity = ctx.ClusterConfig.Identity
+	}
+
+	// Add claims data if available
+	if claims != nil {
+		output.UserEmail = claims.Subject
+		output.UserID = claims.UserID
+		output.Groups = claims.Groups
+		output.GroupIDs = claims.GroupIDs
+	}
+
+	// Output results
+	if opts.JSON {
+		encoder := json.NewEncoder(ctx.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(output)
+	}
+
+	// Human-readable output
+	ctx.Info("Cluster:       %s", ctx.ClusterName)
+	ctx.Info("Server:        %s", hostname)
+	ctx.Info("Auth Method:   %s", authMethod)
+	
+	if identity != nil {
+		ctx.Info("Identity:      %s", ctx.ClusterConfig.Identity)
+	}
+	
+	if claims != nil {
+		ctx.Info("")
+		ctx.Info("User:          %s", claims.Subject)
+		ctx.Info("User ID:       %s", claims.UserID)
+		if len(claims.Groups) > 0 {
+			ctx.Info("Groups:        %v", claims.Groups)
+		}
+		if len(claims.GroupIDs) > 0 {
+			ctx.Info("Group IDs:     %v", claims.GroupIDs)
+		}
+	} else if authMethod == "none" {
+		ctx.Info("")
+		ctx.Info("No authentication configured for this cluster")
+	}
+
+	return nil
+}

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"context"
+)
+
+type contextKey struct{}
+
+var claimsContextKey = contextKey{}
+
+// WithClaims adds JWT claims to the context
+func WithClaims(ctx context.Context, claims *Claims) context.Context {
+	return context.WithValue(ctx, claimsContextKey, claims)
+}
+
+// GetClaims retrieves JWT claims from the context
+func GetClaims(ctx context.Context) (*Claims, bool) {
+	claims, ok := ctx.Value(claimsContextKey).(*Claims)
+	return claims, ok
+}
+
+// GetUserEmail retrieves the user email from context claims
+func GetUserEmail(ctx context.Context) string {
+	claims, ok := GetClaims(ctx)
+	if !ok || claims == nil {
+		return ""
+	}
+	// JWT uses "sub" for subject, which is typically the email in Miren
+	return claims.Subject
+}
+
+// GetUserGroups retrieves the user's groups from context claims  
+func GetUserGroups(ctx context.Context) []string {
+	claims, ok := GetClaims(ctx)
+	if !ok || claims == nil {
+		return nil
+	}
+	return claims.GroupIDs
+}
+
+// GetOrganizationID retrieves the organization ID from context claims
+func GetOrganizationID(ctx context.Context) string {
+	claims, ok := GetClaims(ctx)
+	if !ok || claims == nil {
+		return ""
+	}
+	return claims.OrganizationID
+}

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -44,6 +44,7 @@ type Claims struct {
 	jwt.RegisteredClaims
 	OrganizationID string   `json:"organization_id,omitempty"`
 	GroupIDs       []string `json:"group_ids,omitempty"`
+	GroupsVersion  string   `json:"groups_version,omitempty"` // Version/timestamp of group membership
 }
 
 // ValidateToken validates a JWT token and returns the claims
@@ -281,6 +282,13 @@ func (tc *TokenCache) Set(token string, claims *Claims) {
 		claims:  claims,
 		expires: expiry,
 	}
+}
+
+// Delete removes a token from the cache
+func (tc *TokenCache) Delete(token string) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	delete(tc.cache, token)
 }
 
 // cleanup periodically removes expired entries

--- a/pkg/auth/parse_unverified.go
+++ b/pkg/auth/parse_unverified.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ExtendedClaims represents the full JWT claims from miren.cloud including custom fields
+type ExtendedClaims struct {
+	Claims
+	UserID   string   `json:"user_id,omitempty"`
+	UserName string   `json:"name,omitempty"`
+	Groups   []string `json:"groups,omitempty"`
+}
+
+// ParseUnverifiedClaims parses JWT claims without verification
+// This is only for client-side display purposes and should NOT be used for authentication
+func ParseUnverifiedClaims(token string) (*ExtendedClaims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid token format")
+	}
+
+	// Decode the claims part (second segment)
+	claimsData, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode claims: %w", err)
+	}
+
+	// First unmarshal into a map to see all fields
+	var rawClaims map[string]interface{}
+	if err := json.Unmarshal(claimsData, &rawClaims); err != nil {
+		return nil, fmt.Errorf("failed to parse raw claims: %w", err)
+	}
+
+	// Then unmarshal into our extended claims structure
+	var claims ExtendedClaims
+	if err := json.Unmarshal(claimsData, &claims); err != nil {
+		return nil, fmt.Errorf("failed to parse claims: %w", err)
+	}
+	
+	// Map additional fields that might have different names
+	if orgID, ok := rawClaims["organization_id"].(string); ok {
+		claims.OrganizationID = orgID
+	}
+	
+	// The subject field is the user ID in miren JWTs
+	if claims.Subject != "" && claims.UserID == "" {
+		claims.UserID = claims.Subject
+	}
+
+	return &claims, nil
+}

--- a/pkg/cloudauth/deployment_auth.go
+++ b/pkg/cloudauth/deployment_auth.go
@@ -1,0 +1,70 @@
+package cloudauth
+
+import (
+	"context"
+	"fmt"
+
+	"miren.dev/runtime/pkg/auth"
+	"miren.dev/runtime/pkg/rbac"
+)
+
+// DeploymentAuthorizer checks deployment permissions
+type DeploymentAuthorizer struct {
+	evaluator     *rbac.Evaluator
+	policyFetcher *PolicyFetcher
+	tags          map[string]any
+}
+
+// NewDeploymentAuthorizer creates a new deployment authorizer
+func NewDeploymentAuthorizer(evaluator *rbac.Evaluator, policyFetcher *PolicyFetcher, tags map[string]any) *DeploymentAuthorizer {
+	return &DeploymentAuthorizer{
+		evaluator:     evaluator,
+		policyFetcher: policyFetcher,
+		tags:          tags,
+	}
+}
+
+// AuthorizeDeployment checks if the user can deploy the specified app
+func (a *DeploymentAuthorizer) AuthorizeDeployment(ctx context.Context, appName string) error {
+	// Get claims from context
+	claims, ok := auth.GetClaims(ctx)
+	if !ok || claims == nil {
+		return fmt.Errorf("no authentication claims found")
+	}
+
+	// Create RBAC request
+	req := &rbac.Request{
+		Subject:  claims.Subject,
+		Groups:   claims.GroupIDs,
+		Resource: fmt.Sprintf("app:%s", appName),
+		Action:   "deploy",
+		Tags:     a.tags,
+		Context: map[string]any{
+			"organization_id": claims.OrganizationID,
+		},
+	}
+
+	// Check permission
+	decision := a.evaluator.Evaluate(req)
+	if decision == rbac.DecisionDeny {
+		// Trigger a refresh of RBAC rules
+		if a.policyFetcher != nil {
+			a.policyFetcher.RefreshIfNeeded(ctx)
+		}
+		return fmt.Errorf("permission denied: you don't have permission to deploy %s on this cluster", appName)
+	}
+
+	return nil
+}
+
+// GetDeploymentUserInfo extracts user info from context for deployment records
+func GetDeploymentUserInfo(ctx context.Context) (userID, userEmail string) {
+	claims, ok := auth.GetClaims(ctx)
+	if !ok || claims == nil {
+		// Return placeholder values if no claims
+		return "unknown", "unknown@example.com"
+	}
+	
+	// Subject is the user ID, and in Miren it's typically the email
+	return claims.Subject, claims.Subject
+}

--- a/pkg/cloudauth/groups_version_tracker.go
+++ b/pkg/cloudauth/groups_version_tracker.go
@@ -1,0 +1,71 @@
+package cloudauth
+
+import (
+	"sync"
+	"time"
+)
+
+// GroupsVersionTracker tracks the groups version for authenticated users
+// to detect when permissions have changed and force token refresh
+type GroupsVersionTracker struct {
+	mu       sync.RWMutex
+	versions map[string]*groupVersionEntry // userID -> version info
+}
+
+type groupVersionEntry struct {
+	groupsVersion string
+	lastChecked   time.Time
+}
+
+// NewGroupsVersionTracker creates a new groups version tracker
+func NewGroupsVersionTracker() *GroupsVersionTracker {
+	return &GroupsVersionTracker{
+		versions: make(map[string]*groupVersionEntry),
+	}
+}
+
+// CheckAndUpdate checks if the groups version has changed for a user
+// Returns true if the version is different (or new), false if unchanged
+func (t *GroupsVersionTracker) CheckAndUpdate(userID, groupsVersion string) bool {
+	if userID == "" || groupsVersion == "" {
+		return false // Can't track without IDs
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	entry, exists := t.versions[userID]
+	if !exists {
+		// First time seeing this user, store the version
+		t.versions[userID] = &groupVersionEntry{
+			groupsVersion: groupsVersion,
+			lastChecked:   time.Now(),
+		}
+		return false // Don't force refresh on first auth
+	}
+
+	// Check if version changed
+	if entry.groupsVersion != groupsVersion {
+		// Version changed, update and return true to force refresh
+		entry.groupsVersion = groupsVersion
+		entry.lastChecked = time.Now()
+		return true
+	}
+
+	// Version unchanged
+	entry.lastChecked = time.Now()
+	return false
+}
+
+// Clean removes entries older than the specified duration
+func (t *GroupsVersionTracker) Clean(maxAge time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := time.Now()
+	for userID, entry := range t.versions {
+		if now.Sub(entry.lastChecked) > maxAge {
+			delete(t.versions, userID)
+		}
+	}
+}

--- a/pkg/cloudauth/rpc_authenticator.go
+++ b/pkg/cloudauth/rpc_authenticator.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"miren.dev/runtime/pkg/auth"
 	"miren.dev/runtime/pkg/rbac"
@@ -16,14 +18,19 @@ const DefaultCloudURL = "https://api.miren.cloud"
 
 // RPCAuthenticator adapts cloud authentication for RPC usage
 type RPCAuthenticator struct {
-	jwtValidator  *auth.JWTValidator
-	tokenCache    *auth.TokenCache
-	rbacEval      *rbac.Evaluator
-	policyFetcher *PolicyFetcher
-	logger        *slog.Logger
+	jwtValidator    *auth.JWTValidator
+	tokenCache      *auth.TokenCache
+	rbacEval        *rbac.Evaluator
+	policyFetcher   *PolicyFetcher
+	logger          *slog.Logger
+	groupsTracker   *GroupsVersionTracker
 
 	// Tags to use for RBAC evaluation
 	tags map[string]any
+	
+	// Last authenticated claims (temporary storage for passing to RPC layer)
+	lastClaims *auth.Claims
+	mu         sync.RWMutex
 }
 
 // Config for RPCAuthenticator
@@ -75,8 +82,9 @@ func NewRPCAuthenticator(ctx context.Context, config Config) (*RPCAuthenticator,
 	}
 
 	a := &RPCAuthenticator{
-		logger: config.Logger.With("module", "cloud-auth"),
-		tags:   config.Tags,
+		logger:        config.Logger.With("module", "cloud-auth"),
+		tags:          config.Tags,
+		groupsTracker: NewGroupsVersionTracker(),
 	}
 
 	// Set default tags if not provided
@@ -102,6 +110,9 @@ func NewRPCAuthenticator(ctx context.Context, config Config) (*RPCAuthenticator,
 
 	// Set the evaluator in the policy fetcher so it can clear the cache on refresh
 	a.policyFetcher.SetEvaluator(a.rbacEval)
+	
+	// Start groups version tracker cleanup
+	go a.startGroupsTrackerCleanup(ctx)
 
 	return a, nil
 }
@@ -140,6 +151,18 @@ func (a *RPCAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Requ
 		a.tokenCache.Set(token, claims)
 	}
 
+	// Check if groups version has changed (indicates permissions were modified)
+	if claims.GroupsVersion != "" && claims.Subject != "" {
+		if a.groupsTracker.CheckAndUpdate(claims.Subject, claims.GroupsVersion) {
+			// Groups version changed, invalidate cached token and reject
+			a.tokenCache.Delete(token)
+			a.logger.Warn("groups version changed, rejecting cached token",
+				"subject", claims.Subject,
+				"groups_version", claims.GroupsVersion)
+			return false, "", fmt.Errorf("permissions have changed, please authenticate again")
+		}
+	}
+
 	// TODO For now we're going to hardcode the resource and action
 	// as being related to cluster access. In the future, we'll make changes
 	// to this where we request authorization for specific high level actions,
@@ -174,6 +197,11 @@ func (a *RPCAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Requ
 		return false, "", fmt.Errorf("access denied by RBAC policy")
 	}
 
+	// Store claims for retrieval by RPC layer
+	a.mu.Lock()
+	a.lastClaims = claims
+	a.mu.Unlock()
+
 	a.logger.Debug("JWT authentication successful",
 		"subject", claims.Subject,
 		"organization_id", claims.OrganizationID,
@@ -204,4 +232,43 @@ func (a *RPCAuthenticator) NoAuthorization(ctx context.Context, r *http.Request)
 func (a *RPCAuthenticator) Stop() {
 	a.policyFetcher.Stop()
 	a.rbacEval.Stop()
+}
+
+// GetLastClaims returns the claims from the last successful authentication
+// This is a temporary mechanism until we can properly pass claims through the RPC layer
+func (a *RPCAuthenticator) GetLastClaims() *auth.Claims {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.lastClaims
+}
+
+// startGroupsTrackerCleanup periodically cleans up old entries from the groups version tracker
+func (a *RPCAuthenticator) startGroupsTrackerCleanup(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Clean entries older than 2 hours
+			a.groupsTracker.Clean(2 * time.Hour)
+		}
+	}
+}
+
+// GetEvaluator returns the RBAC evaluator
+func (a *RPCAuthenticator) GetEvaluator() *rbac.Evaluator {
+	return a.rbacEval
+}
+
+// GetPolicyFetcher returns the policy fetcher
+func (a *RPCAuthenticator) GetPolicyFetcher() *PolicyFetcher {
+	return a.policyFetcher
+}
+
+// GetTags returns the configured tags
+func (a *RPCAuthenticator) GetTags() map[string]any {
+	return a.tags
 }


### PR DESCRIPTION
## Summary

This PR implements the runtime side of groups version tracking to ensure that JWT tokens are invalidated when a user's group membership changes in miren.cloud. This solves the security issue where users could continue using cached JWT tokens even after their permissions were revoked.

## Problem

Previously, when a user's group membership was changed in miren.cloud (e.g., removed from a group that grants deployment permissions), they could continue performing actions using their cached JWT token until it expired. This created a security gap where permission changes didn't take effect immediately.

## Solution

This PR adds support for tracking `groups_version` from JWT claims and detecting when permissions have changed:

### 1. **JWT Claims Enhancement**:
   - Added `GroupsVersion` field to the Claims struct to match what miren.cloud sends
   - Added `Delete()` method to TokenCache for invalidating cached tokens

### 2. **Groups Version Tracking**:
   - Created `GroupsVersionTracker` that tracks the groups version for each authenticated user
   - Detects when the version has changed (indicating permissions were modified)
   - Includes automatic cleanup of old entries

### 3. **RPC Authentication Updates**:
   - Modified `RPCAuthenticator` to check groups version on each request
   - When a version mismatch is detected:
     - Invalidates the cached token
     - Returns error forcing re-authentication
     - Logs the rejection for debugging

### 4. **Context and Authorization Fixes**:
   - Fixed context passing in RPC server to ensure user JWT claims reach authorization checks
   - Deployment authorization now uses actual user permissions, not service account
   - Added `DeploymentAuthorizer` for checking deployment permissions

### 5. **Debugging Support**:
   - Added `miren whoami` command to help debug authentication state
   - Shows current user, groups, and authentication method
   - Supports both JSON and human-readable output

## How it works

1. User authenticates and receives JWT with `groups_version`
2. Runtime tracks the groups version for each user
3. When miren.cloud updates group membership, it changes the user's `groups_version`
4. On next request, runtime detects version mismatch
5. Forces user to re-authenticate with fresh permissions

## Testing

1. Deploy an app with proper permissions - should work
2. Remove user from deploy group in miren.cloud
3. Try to deploy again - runtime detects version change and denies access
4. User must re-authenticate to get updated permissions

## Related

This PR works in conjunction with cloud PR mirendev/cloud#53 which implements the server-side groups version tracking.

## Draft Status

This is a draft PR for testing the complete flow with the cloud changes. Once testing is complete, this will be marked ready for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `whoami` CLI command to display information about the currently authenticated user, including identity, authentication method, and cluster details.
  * Added deployment authorization using role-based access control policies to enforce permission requirements before deployments.
  * Enhanced authentication context handling to propagate user claims across services for consistent authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->