### PR TITLE
Cache Go build artifacts to speed up test runs

### DIFF
--- a/.iso/config.yml
+++ b/.iso/config.yml
@@ -4,4 +4,5 @@ volumes:
   - /data
 cache:
   - /go/pkg
+  - /go/build-cache
   - /root/.cache


### PR DESCRIPTION
## Summary

Add `/go/build-cache` to iso cache volumes to persist compiled Go packages between test runs.

## Problem

The `.iso/Dockerfile` sets `GOCACHE=/go/build-cache`, but the cache configuration only persisted `/go/pkg` (module downloads). This meant every test run recompiled all dependencies from scratch, adding ~2.5 minutes of overhead.

## Solution

Added `/go/build-cache` to the cache volumes in `.iso/config.yml`. The ~738MB of compiled Go artifacts now persist between runs.

## Results

**Before:**
- Total time: 5m 30s
- Compilation: ~2.5m
- Tests: ~3m

**After:**
- Total time: 3m (tests only)
- Compilation: cached ✅
- **Speedup: 45% faster, saving 2.5min per test run**

## Test plan

Ran `./hack/it ./controllers/sandbox -count=1 -failfast` multiple times to verify:
- First run populates cache (~5m 30s)
- Subsequent runs skip compilation (~3m)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build cache configuration to improve build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->