### PR TITLE
Implement key reuse in login to prevent server-side key proliferation

### DIFF
--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -65,7 +65,7 @@ func ClusterAdd(ctx *Context, opts struct {
 	if opts.Cluster == "" && opts.Address == "" {
 		ctx.Info("Fetching available clusters from identity server...")
 
-		clusters, err := fetchAvailableClusters(ctx, identity)
+		clusters, err := fetchAvailableClusters(ctx, mainConfig, identity)
 		if err != nil {
 			return fmt.Errorf("failed to fetch available clusters: %w", err)
 		}

--- a/cli/commands/config_bind.go
+++ b/cli/commands/config_bind.go
@@ -74,7 +74,7 @@ func ConfigBind(ctx *Context, opts struct {
 	if opts.Cluster == "" && opts.Address == "" {
 		ctx.Info("Fetching available clusters from identity server...")
 
-		clusters, err := fetchAvailableClusters(ctx, identity)
+		clusters, err := fetchAvailableClusters(ctx, mainConfig, identity)
 		if err != nil {
 			return fmt.Errorf("failed to fetch available clusters: %w", err)
 		}

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -161,7 +161,7 @@ func isPrivateAddress(host string) bool {
 }
 
 // fetchAvailableClusters queries the identity server for available clusters
-func fetchAvailableClusters(ctx *Context, identity *clientconfig.IdentityConfig) ([]ClusterResponse, error) {
+func fetchAvailableClusters(ctx *Context, config *clientconfig.Config, identity *clientconfig.IdentityConfig) ([]ClusterResponse, error) {
 	if identity.Type != "keypair" {
 		return nil, fmt.Errorf("cluster listing is only supported for keypair identities")
 	}
@@ -172,8 +172,14 @@ func fetchAvailableClusters(ctx *Context, identity *clientconfig.IdentityConfig)
 		return nil, fmt.Errorf("identity has no issuer configured")
 	}
 
+	// Get the private key (handles both direct PrivateKey and KeyRef)
+	privateKeyPEM, err := config.GetPrivateKeyPEM(identity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get private key: %w", err)
+	}
+
 	// Load the private key
-	keyPair, err := cloudauth.LoadKeyPairFromPEM(identity.PrivateKey)
+	keyPair, err := cloudauth.LoadKeyPairFromPEM(privateKeyPEM)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load private key: %w", err)
 	}

--- a/cli/commands/login.go
+++ b/cli/commands/login.go
@@ -73,10 +73,48 @@ type KeyRegistrationResponse struct {
 	CreatedAt   string `json:"created_at"`
 }
 
+// getOrCreateKey checks if a key with the given name already exists in the config,
+// and reuses it if found. Otherwise, it generates a new key.
+// Returns the keypair, whether it was already registered, and any error.
+func getOrCreateKey(ctx *Context, keyName string) (*cloudauth.KeyPair, bool, error) {
+	// Try to load existing config
+	config, err := clientconfig.LoadConfig()
+	if err != nil && err != clientconfig.ErrNoConfig {
+		return nil, false, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Check if key already exists
+	if config != nil && config.HasKey(keyName) {
+		keyConfig, err := config.GetKey(keyName)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to get key: %w", err)
+		}
+
+		// Load the keypair from the stored private key
+		keyPair, err := cloudauth.LoadKeyPairFromPEM(keyConfig.PrivateKey)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to load keypair from config: %w", err)
+		}
+
+		ctx.Info("Found existing key: %s", keyName)
+		return keyPair, true, nil
+	}
+
+	// No existing key found, generate a new one
+	ctx.Info("Generating new keypair for future authentication...")
+	keyPair, err := cloudauth.GenerateKeyPair()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to generate keypair: %w", err)
+	}
+
+	return keyPair, false, nil
+}
+
 // Login authenticates with miren.cloud using device flow
 func Login(ctx *Context, opts struct {
 	CloudURL     string `short:"u" long:"url" description:"Cloud URL" default:"https://miren.cloud"`
 	IdentityName string `short:"i" long:"identity" description:"Name for this identity in config" default:"cloud"`
+	KeyName      string `short:"k" long:"key-name" description:"Name for the authentication key" default:"miren-cli"`
 	NoSave       bool   `long:"no-save" description:"Don't save credentials to config file"`
 	NoQR         bool   `long:"no-qr" description:"Don't display QR code"`
 }) error {
@@ -151,34 +189,31 @@ func Login(ctx *Context, opts struct {
 
 	ctx.Completed("Authentication successful!")
 
-	// Generate and register a keypair for future authentication
-	ctx.Info("Generating keypair for future authentication...")
-	keyPair, err := cloudauth.GenerateKeyPair()
+	// Get or create a keypair for future authentication
+	keyPair, keyAlreadyRegistered, err := getOrCreateKey(ctx, opts.KeyName)
 	if err != nil {
-		ctx.Warn("Failed to generate keypair: %v", err)
+		ctx.Warn("Failed to get or create keypair: %v", err)
 		ctx.Info("You can still use token authentication")
-	} else {
-		// Register the public key with the server
-		hostname, err := os.Hostname()
-		if err != nil {
-			hostname = "miren-cli"
-		}
-		keyName := fmt.Sprintf("miren-cli@%s", hostname)
-
-		if err := registerPublicKey(opts.CloudURL, token, keyPair, keyName); err != nil {
+		keyPair = nil
+	} else if !keyAlreadyRegistered {
+		// Register the public key with the server (only if it's a new key)
+		ctx.Info("Registering public key with server...")
+		if err := registerPublicKey(opts.CloudURL, token, keyPair, opts.KeyName); err != nil {
 			ctx.Warn("Failed to register public key: %v", err)
 			ctx.Info("You can still use token authentication")
 			keyPair = nil // Don't save the key if registration failed
 		} else {
 			ctx.Info("Public key registered successfully")
 		}
+	} else {
+		ctx.Info("Reusing existing keypair for authentication")
 	}
 
 	// Save to config unless --no-save is specified
 	if !opts.NoSave {
 		if keyPair != nil {
 			// Save identity with keypair for future authentication
-			if err := saveKeyPairToConfig(opts.IdentityName, opts.CloudURL, keyPair); err != nil {
+			if err := saveKeyPairToConfig(opts.IdentityName, opts.CloudURL, keyPair, opts.KeyName); err != nil {
 				ctx.Warn("Failed to save identity to config: %v", err)
 			} else {
 				ctx.Info("Identity '%s' saved to config", opts.IdentityName)
@@ -472,8 +507,9 @@ func registerPublicKey(cloudURL, token string, keyPair *cloudauth.KeyPair, keyNa
 	return nil
 }
 
-// saveKeyPairToConfig saves a keypair as an identity in clientconfig.d
-func saveKeyPairToConfig(identityName, cloudURL string, keyPair *cloudauth.KeyPair) error {
+// saveKeyPairToConfig saves a keypair as a key in clientconfig.d and creates
+// an identity that references it
+func saveKeyPairToConfig(identityName, cloudURL string, keyPair *cloudauth.KeyPair, keyName string) error {
 	// Get private key in PEM format
 	privateKeyPEM, err := keyPair.PrivateKeyPEM()
 	if err != nil {
@@ -497,13 +533,30 @@ func saveKeyPairToConfig(identityName, cloudURL string, keyPair *cloudauth.KeyPa
 		}
 	}
 
-	// Create the identity config data
+	// Save the key separately (if it doesn't already exist)
+	if !mainConfig.HasKey(keyName) {
+		keyConfigData := &clientconfig.ConfigData{
+			Keys: map[string]*clientconfig.KeyConfig{
+				keyName: {
+					Name:        keyName,
+					Type:        "ed25519",
+					PrivateKey:  privateKeyPEM,
+					Fingerprint: keyPair.Fingerprint(),
+				},
+			},
+		}
+
+		// Add as a leaf config (this will be saved to clientconfig.d/key-{name}.yaml)
+		mainConfig.SetLeafConfig("key-"+keyName, keyConfigData)
+	}
+
+	// Create the identity config data that references the key
 	leafConfigData := &clientconfig.ConfigData{
 		Identities: map[string]*clientconfig.IdentityConfig{
 			identityName: {
-				Type:       "keypair",
-				Issuer:     issuer,
-				PrivateKey: privateKeyPEM,
+				Type:   "keypair",
+				Issuer: issuer,
+				KeyRef: keyName,
 			},
 		},
 	}
@@ -511,7 +564,7 @@ func saveKeyPairToConfig(identityName, cloudURL string, keyPair *cloudauth.KeyPa
 	// Add as a leaf config (this will be saved to clientconfig.d/identity-{name}.yaml)
 	mainConfig.SetLeafConfig("identity-"+identityName, leafConfigData)
 
-	// Save the main config (which will also save the leaf config)
+	// Save the main config (which will also save the leaf configs)
 	return mainConfig.Save()
 }
 
@@ -551,7 +604,12 @@ func autoConfigureCluster(ctx *Context, identityName, cloudURL string, keyPair *
 	}
 
 	// Fetch available clusters from the server
-	clusters, err := fetchAvailableClusters(ctx, identity)
+	// Pass mainConfig even though this identity has a direct PrivateKey (not KeyRef)
+	// The helper will handle both cases
+	if mainConfig == nil {
+		mainConfig = clientconfig.NewConfig()
+	}
+	clusters, err := fetchAvailableClusters(ctx, mainConfig, identity)
 	if err != nil {
 		return fmt.Errorf("failed to fetch available clusters: %w", err)
 	}

--- a/cli/commands/login_keys_test.go
+++ b/cli/commands/login_keys_test.go
@@ -1,0 +1,377 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/cloudauth"
+)
+
+// newTestContext creates a Context suitable for testing
+func newTestContext() *Context {
+	return &Context{
+		Context: context.Background(),
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+}
+
+func TestGetOrCreateKey(t *testing.T) {
+	t.Run("creates new key when none exists", func(t *testing.T) {
+		// Setup temp config directory
+		tmpDir := t.TempDir()
+		os.Setenv("MIREN_CONFIG", tmpDir)
+		defer os.Unsetenv("MIREN_CONFIG")
+
+		ctx := newTestContext()
+		keyName := "test-key"
+
+		// Get or create key (should create)
+		keyPair, alreadyRegistered, err := getOrCreateKey(ctx, keyName)
+		require.NoError(t, err)
+		require.NotNil(t, keyPair)
+		assert.False(t, alreadyRegistered, "Should indicate key was newly created")
+
+		// Verify keypair is valid
+		privateKeyPEM, err := keyPair.PrivateKeyPEM()
+		require.NoError(t, err)
+		assert.NotEmpty(t, privateKeyPEM)
+
+		publicKeyPEM, err := keyPair.PublicKeyPEM()
+		require.NoError(t, err)
+		assert.NotEmpty(t, publicKeyPEM)
+	})
+
+	t.Run("reuses existing key", func(t *testing.T) {
+		// Setup temp config directory
+		tmpDir := t.TempDir()
+		os.Setenv("MIREN_CONFIG", tmpDir)
+		defer os.Unsetenv("MIREN_CONFIG")
+
+		ctx := newTestContext()
+		keyName := "test-key"
+
+		// First call - create the key
+		keyPair1, alreadyRegistered1, err := getOrCreateKey(ctx, keyName)
+		require.NoError(t, err)
+		require.NotNil(t, keyPair1)
+		assert.False(t, alreadyRegistered1)
+
+		// Save the key to config
+		config := clientconfig.NewConfig()
+		privateKeyPEM, err := keyPair1.PrivateKeyPEM()
+		require.NoError(t, err)
+
+		config.SetKey(keyName, &clientconfig.KeyConfig{
+			Name:        keyName,
+			Type:        "ed25519",
+			PrivateKey:  privateKeyPEM,
+			Fingerprint: keyPair1.Fingerprint(),
+		})
+
+		configPath := filepath.Join(tmpDir, "clientconfig.yaml")
+		err = config.SaveTo(configPath)
+		require.NoError(t, err)
+
+		// Second call - should reuse the key
+		keyPair2, alreadyRegistered2, err := getOrCreateKey(ctx, keyName)
+		require.NoError(t, err)
+		require.NotNil(t, keyPair2)
+		assert.True(t, alreadyRegistered2, "Should indicate key was reused")
+
+		// Verify the keys are the same
+		assert.Equal(t, keyPair1.Fingerprint(), keyPair2.Fingerprint())
+	})
+
+	t.Run("creates different keys for different names", func(t *testing.T) {
+		// Setup temp config directory
+		tmpDir := t.TempDir()
+		os.Setenv("MIREN_CONFIG", tmpDir)
+		defer os.Unsetenv("MIREN_CONFIG")
+
+		ctx := newTestContext()
+
+		// Create first key
+		keyPair1, _, err := getOrCreateKey(ctx, "key1")
+		require.NoError(t, err)
+
+		// Create second key
+		keyPair2, _, err := getOrCreateKey(ctx, "key2")
+		require.NoError(t, err)
+
+		// Verify they're different
+		assert.NotEqual(t, keyPair1.Fingerprint(), keyPair2.Fingerprint())
+	})
+}
+
+func TestSaveKeyPairToConfig(t *testing.T) {
+	t.Run("saves key separately and creates identity with KeyRef", func(t *testing.T) {
+		// Setup temp config directory
+		tmpDir := t.TempDir()
+		os.Setenv("MIREN_CONFIG", tmpDir)
+		defer os.Unsetenv("MIREN_CONFIG")
+
+		// Generate a test keypair
+		keyPair, err := cloudauth.GenerateKeyPair()
+		require.NoError(t, err)
+
+		identityName := "test-identity"
+		cloudURL := "https://test.miren.cloud"
+		keyName := "test-key"
+
+		// Save to config
+		err = saveKeyPairToConfig(identityName, cloudURL, keyPair, keyName)
+		require.NoError(t, err)
+
+		// Load config and verify
+		config, err := clientconfig.LoadConfig()
+		require.NoError(t, err)
+
+		// Check that the key was saved
+		assert.True(t, config.HasKey(keyName), "Key should be saved")
+		key, err := config.GetKey(keyName)
+		require.NoError(t, err)
+		assert.Equal(t, keyName, key.Name)
+		assert.Equal(t, "ed25519", key.Type)
+		assert.NotEmpty(t, key.PrivateKey)
+		assert.Equal(t, keyPair.Fingerprint(), key.Fingerprint)
+
+		// Check that the identity was created with KeyRef
+		assert.True(t, config.HasIdentity(identityName), "Identity should be saved")
+		identity, err := config.GetIdentity(identityName)
+		require.NoError(t, err)
+		assert.Equal(t, "keypair", identity.Type)
+		assert.Equal(t, "https://test.miren.cloud", identity.Issuer)
+		assert.Equal(t, keyName, identity.KeyRef, "Identity should reference the key")
+		assert.Empty(t, identity.PrivateKey, "Identity should not have direct PrivateKey")
+	})
+
+	t.Run("does not create duplicate keys", func(t *testing.T) {
+		// Setup temp config directory
+		tmpDir := t.TempDir()
+		os.Setenv("MIREN_CONFIG", tmpDir)
+		defer os.Unsetenv("MIREN_CONFIG")
+
+		// Generate a test keypair
+		keyPair, err := cloudauth.GenerateKeyPair()
+		require.NoError(t, err)
+
+		keyName := "test-key"
+
+		// Save first identity with the key
+		err = saveKeyPairToConfig("identity1", "https://test.miren.cloud", keyPair, keyName)
+		require.NoError(t, err)
+
+		// Save second identity with the same key name
+		err = saveKeyPairToConfig("identity2", "https://test.miren.cloud", keyPair, keyName)
+		require.NoError(t, err)
+
+		// Verify only one key exists
+		config, err := clientconfig.LoadConfig()
+		require.NoError(t, err)
+
+		keyNames := config.GetKeyNames()
+		assert.Contains(t, keyNames, keyName)
+
+		// Both identities should reference the same key
+		identity1, err := config.GetIdentity("identity1")
+		require.NoError(t, err)
+		assert.Equal(t, keyName, identity1.KeyRef)
+
+		identity2, err := config.GetIdentity("identity2")
+		require.NoError(t, err)
+		assert.Equal(t, keyName, identity2.KeyRef)
+	})
+}
+
+func TestGetPrivateKeyPEM(t *testing.T) {
+	t.Run("resolves private key from KeyRef", func(t *testing.T) {
+		// Generate a test keypair
+		keyPair, err := cloudauth.GenerateKeyPair()
+		require.NoError(t, err)
+
+		privateKeyPEM, err := keyPair.PrivateKeyPEM()
+		require.NoError(t, err)
+
+		// Create config with key and identity
+		config := clientconfig.NewConfig()
+		keyName := "test-key"
+
+		config.SetKey(keyName, &clientconfig.KeyConfig{
+			Name:        keyName,
+			Type:        "ed25519",
+			PrivateKey:  privateKeyPEM,
+			Fingerprint: keyPair.Fingerprint(),
+		})
+
+		identity := &clientconfig.IdentityConfig{
+			Type:   "keypair",
+			Issuer: "https://test.miren.cloud",
+			KeyRef: keyName,
+		}
+
+		// Resolve the private key
+		resolvedPEM, err := config.GetPrivateKeyPEM(identity)
+		require.NoError(t, err)
+		assert.Equal(t, privateKeyPEM, resolvedPEM)
+
+		// Verify we can load the keypair from the resolved PEM
+		loadedKeyPair, err := cloudauth.LoadKeyPairFromPEM(resolvedPEM)
+		require.NoError(t, err)
+		assert.Equal(t, keyPair.Fingerprint(), loadedKeyPair.Fingerprint())
+	})
+
+	t.Run("falls back to direct PrivateKey for backward compatibility", func(t *testing.T) {
+		// Generate a test keypair
+		keyPair, err := cloudauth.GenerateKeyPair()
+		require.NoError(t, err)
+
+		privateKeyPEM, err := keyPair.PrivateKeyPEM()
+		require.NoError(t, err)
+
+		// Create config with identity that has direct PrivateKey (legacy)
+		config := clientconfig.NewConfig()
+		identity := &clientconfig.IdentityConfig{
+			Type:       "keypair",
+			Issuer:     "https://test.miren.cloud",
+			PrivateKey: privateKeyPEM,
+		}
+
+		// Resolve the private key
+		resolvedPEM, err := config.GetPrivateKeyPEM(identity)
+		require.NoError(t, err)
+		assert.Equal(t, privateKeyPEM, resolvedPEM)
+	})
+
+	t.Run("returns error when KeyRef does not exist", func(t *testing.T) {
+		config := clientconfig.NewConfig()
+		identity := &clientconfig.IdentityConfig{
+			Type:   "keypair",
+			Issuer: "https://test.miren.cloud",
+			KeyRef: "nonexistent-key",
+		}
+
+		_, err := config.GetPrivateKeyPEM(identity)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nonexistent-key")
+	})
+
+	t.Run("returns error when no private key available", func(t *testing.T) {
+		config := clientconfig.NewConfig()
+		identity := &clientconfig.IdentityConfig{
+			Type:   "keypair",
+			Issuer: "https://test.miren.cloud",
+		}
+
+		_, err := config.GetPrivateKeyPEM(identity)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no private key")
+	})
+}
+
+func TestKeyManagementIntegration(t *testing.T) {
+	t.Run("full workflow: create, save, load, and use key", func(t *testing.T) {
+		// Setup temp config directory
+		tmpDir := t.TempDir()
+		os.Setenv("MIREN_CONFIG", tmpDir)
+		defer os.Unsetenv("MIREN_CONFIG")
+
+		ctx := newTestContext()
+		keyName := "miren-cli"
+		identityName := "cloud"
+		cloudURL := "https://miren.cloud"
+
+		// Step 1: Create a new key
+		keyPair1, alreadyRegistered1, err := getOrCreateKey(ctx, keyName)
+		require.NoError(t, err)
+		assert.False(t, alreadyRegistered1)
+		fingerprint1 := keyPair1.Fingerprint()
+
+		// Step 2: Save the key to config
+		err = saveKeyPairToConfig(identityName, cloudURL, keyPair1, keyName)
+		require.NoError(t, err)
+
+		// Step 3: Simulate a new login attempt - should reuse the key
+		keyPair2, alreadyRegistered2, err := getOrCreateKey(ctx, keyName)
+		require.NoError(t, err)
+		assert.True(t, alreadyRegistered2, "Should reuse existing key")
+		assert.Equal(t, fingerprint1, keyPair2.Fingerprint(), "Should have same fingerprint")
+
+		// Step 4: Load config and verify we can resolve the private key
+		config, err := clientconfig.LoadConfig()
+		require.NoError(t, err)
+
+		identity, err := config.GetIdentity(identityName)
+		require.NoError(t, err)
+
+		privateKeyPEM, err := config.GetPrivateKeyPEM(identity)
+		require.NoError(t, err)
+
+		// Step 5: Verify we can use the resolved key
+		loadedKeyPair, err := cloudauth.LoadKeyPairFromPEM(privateKeyPEM)
+		require.NoError(t, err)
+		assert.Equal(t, fingerprint1, loadedKeyPair.Fingerprint())
+
+		// Sign something with both keypairs to verify they're functionally identical
+		message := []byte("test message")
+		sig1, err := keyPair1.Sign(message)
+		require.NoError(t, err)
+		sig2, err := loadedKeyPair.Sign(message)
+		require.NoError(t, err)
+
+		// Verify signatures with public keys
+		assert.True(t, cloudauth.VerifySignature(keyPair1.PublicKey, message, sig1))
+		assert.True(t, cloudauth.VerifySignature(loadedKeyPair.PublicKey, message, sig2))
+	})
+
+	t.Run("multiple identities can share the same key", func(t *testing.T) {
+		// Setup temp config directory
+		tmpDir := t.TempDir()
+		os.Setenv("MIREN_CONFIG", tmpDir)
+		defer os.Unsetenv("MIREN_CONFIG")
+
+		// Generate a single keypair
+		keyPair, err := cloudauth.GenerateKeyPair()
+		require.NoError(t, err)
+		keyName := "shared-key"
+
+		// Create multiple identities with the same key
+		err = saveKeyPairToConfig("identity1", "https://cloud1.miren.cloud", keyPair, keyName)
+		require.NoError(t, err)
+
+		err = saveKeyPairToConfig("identity2", "https://cloud2.miren.cloud", keyPair, keyName)
+		require.NoError(t, err)
+
+		err = saveKeyPairToConfig("identity3", "https://cloud3.miren.cloud", keyPair, keyName)
+		require.NoError(t, err)
+
+		// Verify all identities reference the same key
+		config, err := clientconfig.LoadConfig()
+		require.NoError(t, err)
+
+		for _, identityName := range []string{"identity1", "identity2", "identity3"} {
+			identity, err := config.GetIdentity(identityName)
+			require.NoError(t, err)
+			assert.Equal(t, keyName, identity.KeyRef)
+
+			// Verify we can resolve the same key for all identities
+			privateKeyPEM, err := config.GetPrivateKeyPEM(identity)
+			require.NoError(t, err)
+
+			loadedKeyPair, err := cloudauth.LoadKeyPairFromPEM(privateKeyPEM)
+			require.NoError(t, err)
+			assert.Equal(t, keyPair.Fingerprint(), loadedKeyPair.Fingerprint())
+		}
+
+		// Verify only one key exists in config
+		keyNames := config.GetKeyNames()
+		assert.Len(t, keyNames, 1)
+		assert.Contains(t, keyNames, keyName)
+	})
+}

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -110,8 +110,14 @@ foundAddress:
 		// Handle different identity types
 		switch identity.Type {
 		case "keypair":
-			// Load the private key from identity
-			keyPair, err := cloudauth.LoadKeyPairFromPEM(identity.PrivateKey)
+			// Get the private key (handles both direct PrivateKey and KeyRef)
+			privateKeyPEM, err := config.GetPrivateKeyPEM(identity)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get private key: %w", err)
+			}
+
+			// Load the private key
+			keyPair, err := cloudauth.LoadKeyPairFromPEM(privateKeyPEM)
 			if err != nil {
 				return nil, fmt.Errorf("failed to load private key: %w", err)
 			}


### PR DESCRIPTION
Add key management system to store and reuse authentication keys across login attempts. Previously, each login created a new keypair and registered it with the server, leading to key pollution when users repeatedly logged in.

Changes:
- Add KeyConfig to clientconfig for storing reusable keys separately
- Add KeyRef to IdentityConfig to reference keys instead of embedding them
- Store keys in clientconfig.d/key-{name}.yaml for reuse across identities
- Add --key-name CLI option (default: "miren-cli") for custom key names
- Implement getOrCreateKey() to check for existing keys before generating
- Update key consumers to resolve keys via GetPrivateKeyPEM() helper
- Maintain backward compatibility with legacy direct PrivateKey fields
- Add comprehensive test suite with 11 tests covering all key operations

Keys are now identified by name (default "miren-cli") and reused on subsequent logins, reducing server-side storage and preventing duplicate registrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced named cryptographic key management allowing keys to be created, reused, and referenced across multiple identities. Keys now include fingerprint tracking and metadata for improved organization and lifecycle management within configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->