### PR TITLE
Remove miren.dev email address when getting a cert

### DIFF
--- a/components/autotls/autotls.go
+++ b/components/autotls/autotls.go
@@ -14,7 +14,6 @@ func ServeTLS(ctx context.Context, log *slog.Logger, dataPath string, h http.Han
 	mgr := &autocert.Manager{
 		Prompt: autocert.AcceptTOS,
 		Cache:  autocert.DirCache(filepath.Join(dataPath, "certs")),
-		Email:  "info@miren.dev",
 		// TODO set HostPolicy to only allow certain domains
 	}
 


### PR DESCRIPTION
Let's Encrypt doesn't even do anything with the email addresses anymore anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified how contact information is handled during automatic TLS certificate provisioning. Email will no longer be automatically supplied during ACME certificate initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->