### PR TITLE
Add metadata support to key configuration

### DIFF
--- a/cli/commands/login.go
+++ b/cli/commands/login.go
@@ -535,6 +535,18 @@ func saveKeyPairToConfig(identityName, cloudURL string, keyPair *cloudauth.KeyPa
 
 	// Save the key separately (if it doesn't already exist)
 	if !mainConfig.HasKey(keyName) {
+		// Get hostname for metadata
+		hostname, err := os.Hostname()
+		if err != nil {
+			hostname = "unknown"
+		}
+
+		// Create metadata with hostname and creation timestamp
+		metadata := map[string]string{
+			"hostname":   hostname,
+			"created_at": time.Now().UTC().Format(time.RFC3339),
+		}
+
 		keyConfigData := &clientconfig.ConfigData{
 			Keys: map[string]*clientconfig.KeyConfig{
 				keyName: {
@@ -542,6 +554,7 @@ func saveKeyPairToConfig(identityName, cloudURL string, keyPair *cloudauth.KeyPa
 					Type:        "ed25519",
 					PrivateKey:  privateKeyPEM,
 					Fingerprint: keyPair.Fingerprint(),
+					Metadata:    metadata,
 				},
 			},
 		}

--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -31,10 +31,11 @@ type IdentityConfig struct {
 
 // KeyConfig holds a reusable cryptographic key
 type KeyConfig struct {
-	Name        string `yaml:"name"`                  // Name of the key (e.g., "miren-cli@hostname")
-	Type        string `yaml:"type"`                  // Type of key: "ed25519", etc.
-	PrivateKey  string `yaml:"private_key"`           // PEM encoded private key
-	Fingerprint string `yaml:"fingerprint,omitempty"` // Fingerprint of the public key
+	Name        string            `yaml:"name"`                  // Name of the key (e.g., "miren-cli@hostname")
+	Type        string            `yaml:"type"`                  // Type of key: "ed25519", etc.
+	PrivateKey  string            `yaml:"private_key"`           // PEM encoded private key
+	Fingerprint string            `yaml:"fingerprint,omitempty"` // Fingerprint of the public key
+	Metadata    map[string]string `yaml:"metadata,omitempty"`    // Arbitrary metadata about the key
 }
 
 // ClusterConfig holds the configuration for a single cluster


### PR DESCRIPTION
## Summary

Adds generic metadata support to keys in the clientconfig, enabling better key lifecycle management and tracking.

## Changes

- Added `Metadata map[string]string` field to `KeyConfig` struct
- When generating new keys during login, automatically populate metadata with:
  - `hostname`: The hostname where the key was created
  - `created_at`: ISO 8601 timestamp in UTC

## Benefits

- **Generic design**: The metadata map can be extended with additional fields without schema changes
- **Backward compatible**: Existing keys without metadata continue to work (`omitempty`)
- **Trackable**: Users can now see when and where each key was created
- **Extensible**: Future features can add more metadata (e.g., `last_used`, `description`)

## Test Plan

- [x] All existing tests pass
- [x] Verified metadata is correctly populated on new key generation
- [x] Confirmed backward compatibility with existing keys

## Example

Generated keys are saved to `~/.config/miren/clientconfig.d/key-<name>.yaml`:

```yaml
keys:
  miren-cli:
    name: miren-cli
    type: ed25519
    fingerprint: SHA256:abc123...
    metadata:
      hostname: mycomputer.local
      created_at: "2025-11-04T18:30:00Z"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication keys now automatically capture and store metadata, including hostname and creation timestamp, for improved credential tracking and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->