### PR TITLE
Fix dev environment buildkit container failures on fresh boot

### DIFF
--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -40,6 +40,15 @@ cp /usr/local/bin/ctr /var/lib/miren/release/
 # Setup environment variables
 setup_bash_environment
 
+# Clear stale containerd state to avoid race condition on fresh boot
+# Keep root directory (images/snapshots) for performance, but clear state (runtime metadata)
+# This prevents the sandbox reconciler from cleaning up newly created containers
+# that it mistakes for stale containers from previous dev sessions
+if [ -d /var/lib/miren/containerd/state ]; then
+    echo "Cleaning stale containerd state..."
+    rm -rf /var/lib/miren/containerd/state/*
+fi
+
 echo ""
 echo "✓ Development environment ready!"
 echo ""


### PR DESCRIPTION
## Summary

Fixes buildkit sandbox failures on fresh dev environment boot by clearing stale containerd state.

## Problem

The dev environment uses a persistent cache volume for containerd (`/var/lib/miren/containerd/`) that persists between `make dev-stop` and `make dev-start` cycles. This causes a race condition on fresh boot:

1. Containerd boots and loads **stale container metadata** from the state directory (containers from previous dev session)
2. A new buildkit sandbox is created with a pause container
3. The sandbox reconciler detects the stale metadata and triggers cleanup
4. The cleanup **deletes the newly created pause container** thinking it's unhealthy
5. Buildkit container creation fails with errors like: `failed to create shim task: unable to create new parent process: lstat /proc/901/ns/ipc: no such file or directory`

## Solution

Clear the containerd state directory (`/var/lib/miren/containerd/state/*`) at dev environment startup while preserving the root directory (`/var/lib/miren/containerd/root/`) for image caching performance.

The fix:
- Only clears state if the directory exists (safe for first-time runs)
- Keeps image cache intact for build performance
- Prevents the race condition from ever occurring

## Testing

- ✅ Verified clean boot with no stale container issues
- ✅ Confirmed image cache is preserved (etcd, clickhouse images persist)
- ✅ Multiple dev-stop/dev-start cycles work correctly
- ✅ Deployments succeed on first attempt after fresh boot

## Files Changed

- `hack/dev.sh` - Added conditional cleanup of stale containerd state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized initialization handling for fresh deployments to enhance stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->