### PR TITLE
deploy: auto-detect TTY and fallback to non-interactive mode

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/progress/progresswriter"
+	"golang.org/x/term"
 
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/deployment/deployment_v1alpha"
@@ -179,7 +180,11 @@ func Deploy(ctx *Context, opts struct {
 		results *build_v1alpha.BuilderClientBuildFromTarResults
 	)
 
-	if opts.Explain {
+	// Detect if we have a TTY - if not, force explain mode
+	isTTY := term.IsTerminal(int(os.Stdout.Fd()))
+	useExplainMode := opts.Explain || !isTTY
+
+	if useExplainMode {
 		// In explain mode, write to stderr
 		pw, err := progresswriter.NewPrinter(ctx, os.Stderr, opts.ExplainFormat)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Adds automatic TTY detection to the `deploy` command
- Falls back to non-interactive mode when stdout is not a TTY
- Fixes deploy failures in CI/CD pipelines and when output is piped

## Details

The deploy command would fail when stdout is not a TTY (e.g., in CI/CD pipelines or when output is piped) because it tried to use the BubbleTea interactive UI which requires a terminal.

This PR adds automatic TTY detection using `golang.org/x/term.IsTerminal()` to fallback to non-interactive "explain mode" when no TTY is available, while preserving the interactive UI when running in a terminal.

## Testing

Tested with:
```bash
# Without TTY (non-interactive mode)
docker exec -i <container> m deploy -d testdata/bun < /dev/null

# With TTY (interactive mode)
./hack/dev-exec m deploy -d testdata/bun
```

Both modes work correctly - non-TTY uses buildkit progress format, TTY uses BubbleTea UI.

## Test plan

- [x] Verified deploy works without a TTY
- [x] Verified deploy still uses interactive UI with a TTY
- [x] Ran `make lint` with no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output handling for non-interactive environments (CI/CD, piped commands), ensuring progress information and deployment status are properly displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->