### PR TITLE
Fix Slack notifications for CI failures on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
+              "channel": "${{ vars.SLACK_CHANNEL_ID }}",
               "text": "❌ Tests failed on main branch - Release blocked",
               "blocks": [
                 {
@@ -200,6 +201,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
+              "channel": "${{ vars.SLACK_CHANNEL_ID }}",
               "text": "❌ Miren Docker build/push failed on main branch",
               "blocks": [
                 {
@@ -384,6 +386,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {
+              "channel": "${{ vars.SLACK_CHANNEL_ID }}",
               "text": "❌ Miren release upload failed on main branch",
               "blocks": [
                 {


### PR DESCRIPTION
## Summary

Fixes silent Slack notification failures when CI fails on main branch.

## Problem

While investigating why we weren't getting notified about test failures on main, I discovered:

1. **Tests ARE failing properly** - The Test workflow correctly fails when tests don't pass
2. **The Release workflow IS running** - The `tests-failed` job correctly detects failures and runs
3. **But Slack notifications fail silently** - The Slack API returns: `missing required field: channel`

Evidence from workflow run 19079100780:
```
tests-failed  UNKNOWN STEP  2025-11-04T18:33:44.7572662Z ##[error]missing required field: channel
```

## Root Cause

The Slack `chat.postMessage` API method requires a `channel` field in the payload to specify where to send the message. Our workflow was missing this field in all three Slack notification steps.

## Solution

Added `"channel": "${{ vars.SLACK_CHANNEL_ID }}"` to all three Slack notification payloads:
- Test failure notifications (line 46)
- Docker build failure notifications (line 204)  
- Release upload failure notifications (line 389)

The `SLACK_CHANNEL_ID` variable is already configured at the org level (value: `C091NDY7GFM`), and this pattern matches the working implementation in the rfd repo.

## Test Plan

- [x] Verified the working Slack notification pattern in rfd repo
- [x] Confirmed SLACK_CHANNEL_ID and SLACK_BOT_TOKEN are configured at org level
- [ ] Merge this and wait for next test failure on main to verify notification works

## Related

This follows the same pattern as the rfd-garden-deploy workflow which successfully sends Slack notifications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal notification routing in the CI/CD release workflow to direct failure alerts to a dedicated Slack channel for test failures, Docker build/push failures, and release upload failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->