### PR TITLE
Fix DeleteEntity to clean up nested component field indexes

### DIFF
--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"miren.dev/runtime/pkg/cond"
 )
 
 func setupTestEtcd(t *testing.T) *clientv3.Client {
@@ -1725,6 +1726,10 @@ func TestEtcdStore_NestedComponentFieldIndexing(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, results, 0, "Should not find entity indexed under v1 after patch")
 	})
+
+	// Note: DeleteEntity nested index cleanup is tested at the entityserver level
+	// in servers/entityserver/entityserver_test.go::TestEntityServer_List_NestedIndexCleanup
+	// That test properly catches the bug by testing the full RPC path that production uses.
 }
 
 func TestEntity_Fixup_DbId(t *testing.T) {

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"miren.dev/runtime/pkg/cond"
 )
 
 func setupTestEtcd(t *testing.T) *clientv3.Client {
@@ -1730,6 +1729,97 @@ func TestEtcdStore_NestedComponentFieldIndexing(t *testing.T) {
 	// Note: DeleteEntity nested index cleanup is tested at the entityserver level
 	// in servers/entityserver/entityserver_test.go::TestEntityServer_List_NestedIndexCleanup
 	// That test properly catches the bug by testing the full RPC path that production uses.
+}
+
+// TestEtcdStore_DeleteEntity_IndexCleanup_DirectQuery tests that DeleteEntity properly
+// cleans up indexes by directly querying etcd to inspect the index collections.
+//
+// Why direct etcd queries are necessary:
+// - ListIndex internally deduplicates results, so calling ListIndex after deletion
+//   may return the correct count even if stale index entries remain in etcd
+// - This test queries etcd directly to verify that the actual index collection keys
+//   are removed, not just that ListIndex returns the right IDs
+// - When the bug exists, this test shows 2 keys remain in etcd after deletion
+// - When fixed, only 1 key remains (the non-deleted entity)
+func TestEtcdStore_DeleteEntity_IndexCleanup_DirectQuery(t *testing.T) {
+	client := setupTestEtcd(t)
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities-debug")
+	require.NoError(t, err)
+
+	// Create schema for a component with a nested indexed field
+	_, err = store.CreateEntity(t.Context(), New(
+		Ident, "debug/spec",
+		Doc, "A component type",
+		Cardinality, CardinalityOne,
+		Type, TypeComponent,
+	))
+	require.NoError(t, err)
+
+	_, err = store.CreateEntity(t.Context(), New(
+		Ident, "debug/spec.version",
+		Doc, "Version field within spec component",
+		Cardinality, CardinalityOne,
+		Type, TypeRef,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	// Create a version entity
+	v1 := Id("version/debug-v1")
+	_, err = store.CreateEntity(t.Context(), New(Ref(DBId, v1)))
+	require.NoError(t, err)
+
+	// Create two entities with nested indexed fields
+	entity1, err := store.CreateEntity(t.Context(), New([]Attr{
+		Keyword(Ident, "debug-resource1"),
+		Component(Id("debug/spec"), []Attr{
+			Ref(Id("debug/spec.version"), v1),
+		}),
+	}))
+	require.NoError(t, err)
+
+	entity2, err := store.CreateEntity(t.Context(), New([]Attr{
+		Keyword(Ident, "debug-resource2"),
+		Component(Id("debug/spec"), []Attr{
+			Ref(Id("debug/spec.version"), v1),
+		}),
+	}))
+	require.NoError(t, err)
+
+	// Query etcd directly to see the collection keys BEFORE deletion
+	attr := Ref(Id("debug/spec.version"), v1)
+	collectionKey := attr.CAS()
+	prefix, err := store.CollectionPrefix(t.Context(), collectionKey)
+	require.NoError(t, err)
+
+	t.Logf("Collection prefix: %s", prefix)
+
+	resp, err := client.Get(t.Context(), prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+	t.Logf("BEFORE DELETE: Found %d keys in etcd collection", len(resp.Kvs))
+	for _, kv := range resp.Kvs {
+		t.Logf("  Key: %s, Value: %s", string(kv.Key), string(kv.Value))
+	}
+	require.Len(t, resp.Kvs, 2, "Should have 2 index entries before deletion")
+
+	// Delete entity1
+	err = store.DeleteEntity(t.Context(), entity1.Id())
+	require.NoError(t, err)
+
+	// Query etcd directly AFTER deletion
+	resp, err = client.Get(t.Context(), prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+	t.Logf("AFTER DELETE: Found %d keys in etcd collection", len(resp.Kvs))
+	for _, kv := range resp.Kvs {
+		t.Logf("  Key: %s, Value: %s", string(kv.Key), string(kv.Value))
+	}
+
+	// CRITICAL: If the bug exists, this should show 2 keys (stale index)
+	// If the fix works, this should show 1 key
+	require.Len(t, resp.Kvs, 1, "Should have only 1 index entry after deletion - entity1's entry should be removed")
+
+	// Verify the remaining entry is for entity2
+	assert.Equal(t, entity2.Id().String(), string(resp.Kvs[0].Value))
 }
 
 func TestEntity_Fixup_DbId(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the bug where `DeleteEntity` was not cleaning up index entries for nested indexed fields within components, leaving stale index entries in etcd.

## Root Cause

When nested component field indexing was added in commit 448d597, `UpdateEntity`, `ReplaceEntity`, and `PatchEntity` were updated to use `collectIndexedAttributes()` which recursively finds nested indexed fields. However, `DeleteEntity` was not updated and continued to only iterate over top-level attributes when cleaning up indexes.

This caused stale index entries for nested fields like `sandbox_spec.version` to remain in etcd after entity deletion. When the entityserver List RPC queried by these nested indexes, it would find the stale IDs, attempt to batch-fetch them with `GetEntities`, receive `nil` for deleted entities, and error with "entity not found".

## Production Impact

The bug manifested in the garden environment on Nov 3rd with errors like:
```
failed to list sandboxes by version: remote error: generic unknown: 
entity not found: sandbox/sb-CUfBkuEiq3MuTRg9R3E96
```

These errors occurred during pool recovery which was introduced in PR #294, causing the sandboxpool manager to fail reconciliation loops.

## The Fix

Update `DeleteEntity` in `pkg/entity/store.go` to use `collectIndexedAttributes()` like the other update operations, ensuring both top-level and nested indexed fields are properly cleaned up.

## Test Coverage

Added two regression tests:

1. **`TestEntityServer_List_NestedIndexCleanup`** (`servers/entityserver/entityserver_test.go`)
   - Tests the full List RPC path with a real etcd-backed store
   - Replicates the exact production failure scenario
   - Fails with "entity not found" when the bug exists

2. **`TestEtcdStore_DeleteEntity_IndexCleanup_DirectQuery`** (`pkg/entity/store_test.go`)
   - Queries etcd directly to verify index collection keys are removed
   - Necessary because `ListIndex` deduplicates results
   - Shows 2 keys remain with buggy code, 1 key with fix

## Verification

Both tests fail with the buggy code and pass with the fix applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed index cleanup when deleting entities with indexed fields, including nested components. Index entries are now properly removed instead of leaving stale references.

* **Tests**
  * Added integration tests to verify index cleanup behavior during entity deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->