### PR TITLE
Add space to making spinner look nicer

### DIFF
--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -67,12 +67,12 @@ func line(str string) string {
 // Meter is the custom spinner animation
 var Meter = spinner.Spinner{
 	Frames: []string{
-		line("   "),
-		line("▰  "),
-		line("▰▰ "),
-		line("▰▰▰"),
-		line(" ▰▰"),
-		line("  ▰"),
+		line("    "),
+		line("▰   "),
+		line("▰▰  "),
+		line("▰▰▰ "),
+		line(" ▰▰ "),
+		line("  ▰ "),
 	},
 	FPS: time.Second / 7, //nolint:mnd
 }


### PR DESCRIPTION
The ending box appears to get rendered witth a negative width in same cases, so adding an extra space in there makes it render correctly in more cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the spinner animation displayed during deployments with improved spacing and visual alignment for enhanced user interface presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->