### PR TITLE
Fix Slack notification formatting for multiline commit messages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,23 +55,26 @@ jobs:
                 },
                 {
                   "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Commit:*\n<${{ github.event.workflow_run.head_commit.url }}|${{ github.event.workflow_run.head_commit.message }}>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Author:*\n${{ github.event.workflow_run.head_commit.author.name }}"
-                    }
-                  ]
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Commit:*\n${{ github.event.workflow_run.head_commit.message }}"
+                  }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<${{ github.event.workflow_run.html_url }}|View failed test run>"
+                    "text": "*Author:* ${{ github.event.workflow_run.head_commit.author.name }}"
                   }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.event.workflow_run.head_commit.url }}|View commit> • <${{ github.event.workflow_run.html_url }}|View test run>"
+                    }
+                  ]
                 }
               ],
               "unfurl_links": false,


### PR DESCRIPTION
## Summary

Fixes the Slack notification formatting when tests fail on main. The previous format tried to embed the full commit message inside a Slack link, which breaks when commit messages have newlines (like merge commits). This resulted in the commit message and author appearing as plain text without links.

## Changes

- Display commit message as plain text (handles multiline properly)
- Move author to separate section for better clarity
- Consolidate both links into a `context` block for compact, metadata-style display
- Links now appear smaller and grayed out at the bottom

## Result

The notification is now more readable, properly formatted, and not too tall.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal Slack notification formatting for release workflow alerts with enhanced readability and direct links to commit details and test results.

---

*Note: This update affects internal development tooling only and has no impact on end-user functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->