### PR TITLE
Add debug reindex command to rebuild entity indexes

### DIFF
--- a/api/entityserver/rpc.yml
+++ b/api/entityserver/rpc.yml
@@ -11,6 +11,15 @@ imports:
       - Attr
 
 types:
+  - type: ReindexStat
+    fields:
+      - name: name
+        type: string
+        index: 0
+      - name: value
+        type: int64
+        index: 1
+
   - type: Entity
     fields:
       - name: id
@@ -234,3 +243,12 @@ interfaces:
         parameters:
           - name: id
             type: string
+
+      - name: reindex
+        parameters:
+          - name: dry_run
+            type: bool
+        results:
+          - name: stats
+            type: list
+            element: ReindexStat

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -22,6 +22,10 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("debug connection", "Test connectivity and authentication with a server", DebugConnection), nil
 		},
 
+		"debug reindex": func() (cli.Command, error) {
+			return Infer("debug reindex", "Rebuild all entity indexes from scratch", DebugReindex), nil
+		},
+
 		"init": func() (cli.Command, error) {
 			return Infer("init", "Initialize a new application", Init), nil
 		},

--- a/cli/commands/debug_reindex.go
+++ b/cli/commands/debug_reindex.go
@@ -1,0 +1,84 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// DebugReindex rebuilds all entity indexes from scratch
+func DebugReindex(ctx *Context, opts struct {
+	ConfigCentric
+	DryRun  bool `short:"d" long:"dry-run" description:"Show what would be done without making changes"`
+	Confirm bool `short:"y" long:"yes" description:"Skip confirmation prompt"`
+}) error {
+
+	if !opts.DryRun && !opts.Confirm {
+		ctx.Warn("⚠️  This will rebuild ALL entity indexes by:")
+		ctx.Warn("   1. Rebuilding indexes for all existing entities")
+		ctx.Warn("   2. Cleaning up stale index entries")
+		ctx.Warn("")
+		ctx.Warn("This operation is safe and can run during normal operation.")
+		ctx.Warn("It may take several minutes depending on the number of entities.")
+		ctx.Warn("")
+
+		confirmed, err := ui.Confirm(
+			ui.WithMessage("Continue with reindex?"),
+			ui.WithDefault(false),
+		)
+		if err != nil {
+			return fmt.Errorf("confirmation failed: %w", err)
+		}
+		if !confirmed {
+			return fmt.Errorf("cancelled")
+		}
+	}
+
+	// Connect to entity server
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
+	}
+
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+
+	if opts.DryRun {
+		ctx.Info("🔍 Running in dry-run mode (no changes will be made)")
+	} else {
+		ctx.Info("🔄 Starting reindex operation...")
+	}
+
+	// Call reindex RPC
+	resp, err := eac.Reindex(ctx, opts.DryRun)
+	if err != nil {
+		return fmt.Errorf("reindex failed: %w", err)
+	}
+
+	// Convert stats list to map for easy access
+	statsMap := make(map[string]int64)
+	if resp.HasStats() {
+		for _, stat := range resp.Stats() {
+			if stat.HasName() && stat.HasValue() {
+				statsMap[stat.Name()] = stat.Value()
+			}
+		}
+	}
+
+	// Display results
+	ctx.Info("")
+	ctx.Info("✅ Reindex complete!")
+	ctx.Info("")
+	ctx.Info("Work completed:")
+	ctx.Info("  • Entities processed: %d", statsMap["entities_processed"])
+	ctx.Info("  • Indexes rebuilt: %d", statsMap["indexes_rebuilt"])
+	ctx.Info("")
+	ctx.Info("Health check:")
+	ctx.Info("  • Collection entries scanned: %d", statsMap["collection_entries_scanned"])
+	ctx.Info("  • Stale entries found: %d", statsMap["stale_entries_found"])
+	if !opts.DryRun {
+		ctx.Info("  • Stale entries removed: %d", statsMap["stale_entries_removed"])
+	}
+
+	return nil
+}

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -869,3 +869,204 @@ func (e *EntityServer) PingSession(ctx context.Context, req *entityserver_v1alph
 
 	return nil
 }
+
+func (e *EntityServer) Reindex(ctx context.Context, req *entityserver_v1alpha.EntityAccessReindex) error {
+	args := req.Args()
+	dryRun := args.HasDryRun() && args.DryRun()
+
+	e.Log.Info("starting entity reindex", "dry_run", dryRun)
+
+	var stats struct {
+		entitiesProcessed        int64
+		indexesRebuilt           int64
+		collectionEntriesScanned int64
+		staleEntriesFound        int64
+		staleEntriesRemoved      int64
+	}
+
+	store, ok := e.Store.(*entity.EtcdStore)
+	if !ok {
+		return fmt.Errorf("reindex requires EtcdStore")
+	}
+
+	// Step 1: List all entities
+	allEntityIDs, err := store.ListAllEntityIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list entities: %w", err)
+	}
+
+	e.Log.Info("found entities", "count", len(allEntityIDs))
+
+	// Create a set of valid entity IDs for fast lookup
+	validEntityIDs := make(map[entity.Id]bool, len(allEntityIDs))
+	for _, id := range allEntityIDs {
+		validEntityIDs[id] = true
+	}
+
+	// Step 2: Rebuild indexes for all existing entities
+	// This overwrites correct entries and ensures all current entities are indexed
+	e.Log.Info("rebuilding indexes for current entities")
+	for i, id := range allEntityIDs {
+		ent, err := e.Store.GetEntity(ctx, id)
+		if err != nil {
+			e.Log.Warn("failed to get entity", "id", id, "error", err)
+			continue
+		}
+
+		if !dryRun {
+			// Collect indexed attributes (including nested ones)
+			indexedAttrs, err := collectIndexedAttributes(ctx, e.Store, ent.Attrs())
+			if err != nil {
+				e.Log.Warn("failed to collect indexed attrs", "id", id, "error", err)
+				continue
+			}
+
+			// Rebuild index entries for all indexed attributes
+			for _, attrs := range indexedAttrs {
+				for _, attr := range attrs {
+					err := addToCollection(ctx, store, ent, attr.CAS())
+					if err != nil {
+						e.Log.Warn("failed to add to collection", "id", id, "attr", attr.ID, "error", err)
+					} else {
+						stats.indexesRebuilt++
+					}
+				}
+			}
+		}
+
+		stats.entitiesProcessed++
+
+		// Log progress every 100 entities
+		if (i+1)%100 == 0 {
+			e.Log.Info("reindex progress",
+				"processed", stats.entitiesProcessed,
+				"total", len(allEntityIDs),
+				"percent", (i+1)*100/len(allEntityIDs))
+		}
+	}
+
+	// Step 3: Clean up stale index entries
+	// Iterate through all collection entries and remove those pointing to non-existent entities
+	e.Log.Info("cleaning up stale index entries")
+	collectionPrefix := store.Prefix() + "/collections/"
+	client := store.Client()
+
+	// Get all collection entries with their values
+	resp, err := client.Get(ctx, collectionPrefix, clientv3.WithPrefix())
+	if err != nil {
+		e.Log.Warn("failed to list collection entries", "error", err)
+	} else {
+		stats.collectionEntriesScanned = int64(len(resp.Kvs))
+
+		var staleKeys []string
+		for _, kv := range resp.Kvs {
+			// Collection entry value contains the entity ID
+			entityID := entity.Id(kv.Value)
+			if !validEntityIDs[entityID] {
+				staleKeys = append(staleKeys, string(kv.Key))
+			}
+		}
+
+		stats.staleEntriesFound = int64(len(staleKeys))
+
+		// Delete stale entries in batches (only if not dry run)
+		if !dryRun && len(staleKeys) > 0 {
+			e.Log.Info("removing stale entries", "count", len(staleKeys))
+			for i := 0; i < len(staleKeys); i += 100 {
+				end := i + 100
+				if end > len(staleKeys) {
+					end = len(staleKeys)
+				}
+				batch := staleKeys[i:end]
+
+				var ops []clientv3.Op
+				for _, key := range batch {
+					ops = append(ops, clientv3.OpDelete(key))
+				}
+
+				if len(ops) > 0 {
+					_, err := client.Txn(ctx).Then(ops...).Commit()
+					if err != nil {
+						e.Log.Warn("failed to delete stale entries", "error", err)
+					} else {
+						stats.staleEntriesRemoved += int64(len(ops))
+					}
+				}
+			}
+		}
+	}
+
+	e.Log.Info("reindex complete",
+		"entities_processed", stats.entitiesProcessed,
+		"indexes_rebuilt", stats.indexesRebuilt,
+		"collection_entries_scanned", stats.collectionEntriesScanned,
+		"stale_entries_found", stats.staleEntriesFound,
+		"stale_entries_removed", stats.staleEntriesRemoved)
+
+	// Build response stats list
+	results := req.Results()
+
+	statsData := []struct {
+		name  string
+		value int64
+	}{
+		{"entities_processed", stats.entitiesProcessed},
+		{"indexes_rebuilt", stats.indexesRebuilt},
+		{"collection_entries_scanned", stats.collectionEntriesScanned},
+		{"stale_entries_found", stats.staleEntriesFound},
+		{"stale_entries_removed", stats.staleEntriesRemoved},
+	}
+
+	var rpcStats []*entityserver_v1alpha.ReindexStat
+	for _, data := range statsData {
+		stat := &entityserver_v1alpha.ReindexStat{}
+		stat.SetName(data.name)
+		stat.SetValue(data.value)
+		rpcStats = append(rpcStats, stat)
+	}
+	results.SetStats(rpcStats)
+
+	return nil
+}
+
+func collectIndexedAttributes(ctx context.Context, store entity.Store, attrs []entity.Attr) (map[entity.Id][]entity.Attr, error) {
+	indexedAttrs := make(map[entity.Id][]entity.Attr)
+	allAttrs := enumerateAllAttrs(attrs)
+	for _, attr := range allAttrs {
+		schema, err := store.GetAttributeSchema(ctx, attr.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get attribute schema: %w", err)
+		}
+		if schema.Index {
+			indexedAttrs[attr.ID] = append(indexedAttrs[attr.ID], attr)
+		}
+	}
+	return indexedAttrs, nil
+}
+
+func enumerateAllAttrs(attrs []entity.Attr) []entity.Attr {
+	var result []entity.Attr
+	for _, attr := range attrs {
+		result = append(result, attr)
+
+		if attr.Value.Kind() == entity.KindComponent {
+			comp := attr.Value.Component()
+			if comp != nil {
+				nestedAttrs := comp.Attrs()
+				result = append(result, enumerateAllAttrs(nestedAttrs)...)
+			}
+		}
+	}
+	return result
+}
+
+func addToCollection(ctx context.Context, store *entity.EtcdStore, ent *entity.Entity, collection string) error {
+	key := base58.Encode([]byte(ent.Id()))
+	colKey := strings.NewReplacer("/", "_", ":", "_").Replace(collection)
+
+	key = fmt.Sprintf("%s/collections/%s/%s", store.Prefix(), colKey, key)
+
+	client := store.Client()
+	_, err := client.Put(ctx, key, ent.Id().String())
+	return err
+}

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -909,6 +909,10 @@ func (e *EntityServer) Reindex(ctx context.Context, req *entityserver_v1alpha.En
 	for i, id := range allEntityIDs {
 		ent, err := e.Store.GetEntity(ctx, id)
 		if err != nil {
+			if errors.Is(err, cond.ErrNotFound{}) {
+				delete(validEntityIDs, id)
+				continue
+			}
 			e.Log.Warn("failed to get entity", "id", id, "error", err)
 			continue
 		}


### PR DESCRIPTION
## Summary

Adds `m debug reindex` command to rebuild entity indexes and clean up stale entries from deleted entities. This fixes the garden environment errors caused by stale index entries that accumulated before PR #305 fixed the root cause.

## Problem

The garden environment has been experiencing errors like:
```
failed to list sandboxes by version: remote error: generic unknown:
entity not found: sandbox/sb-CUfBkuEiq3MuTRg9R3E96
```

This happens because:
1. Before PR #305, DeleteEntity didn't properly clean up nested index entries
2. Stale index entries accumulated pointing to deleted entities
3. ListIndex returns these stale IDs, causing GetEntities to fail

## Solution

Implements a safe, zero-downtime reindex operation:

### Phase 1: Rebuild indexes
- Iterates through all entities and rebuilds their indexes
- Overwrites any existing entries (both correct and stale)
- Ensures no lookup failures during operation

### Phase 2: Clean up stale entries
- Scans all collection entries
- Identifies entries pointing to deleted entities
- Removes stale entries in batches

### Safety Design
Unlike the original spec which deleted all collections first, this implementation:
- ✅ Never deletes all indexes at once
- ✅ Can run during normal server operation
- ✅ No window where lookups fail
- ✅ Dry-run mode for safety

## Usage

```bash
# With confirmation prompt
m debug reindex

# Skip confirmation
m debug reindex --yes

# Preview without changes
m debug reindex --dry-run
```

## Stats Reported

Uses flexible list-based stats format for backwards/forwards compatibility:

**Work completed:**
- `entities_processed` - Total entities reindexed
- `indexes_rebuilt` - Index entries written

**Health check:**
- `collection_entries_scanned` - Total index entries checked
- `stale_entries_found` - Bad entries detected
- `stale_entries_removed` - Bad entries cleaned up

## Example Output

```
✅ Reindex complete!

Work completed:
  • Entities processed: 288
  • Indexes rebuilt: 44

Health check:
  • Collection entries scanned: 52
  • Stale entries found: 0
  • Stale entries removed: 0
```

## Test Plan

- [x] Dry-run mode works correctly
- [x] Actual reindex rebuilds indexes and removes stale entries
- [x] Progress logging every 100 entities
- [x] UI confirmation prompt using pkg/ui
- [x] All lint checks pass
- [x] Tested in dev environment with 287 entities

### Testing in Garden

After deploying to garden:
```bash
gcloud compute ssh miren-garden --project=miren-development
sudo -u miren m debug reindex --yes
```

Expected: Should remove stale entries and eliminate "entity not found" errors.

## Implementation Details

### RPC Changes
- Added `ReindexStat` type with name/value pairs
- Added `Reindex` method returning `list<ReindexStat>`
- Flexible format allows adding new stats without RPC changes

### Store Methods
- `ListAllEntityIDs()` - Returns all entity IDs
- `DeletePrefixCount()` - Bulk delete with count
- `Prefix()` / `Client()` - Expose internals for reindex

### CLI
- Uses `ui.Confirm` for consistent prompts
- Converts stats list to map for easy access
- Clear output showing both work and problems found

## Related

- Fixes stale index issues in garden environment
- Complements PR #305 which fixed the root cause
- Safe to run multiple times (idempotent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full "reindex" operation to rebuild entity indexes and return per-operation stats (ReindexStat).
  * RPC/client support to invoke reindex remotely.
  * CLI command "debug reindex" with progress output, confirmation prompt, and --dry-run/--yes flags.
  * Dry-run mode shows what would change; real run removes stale collection entries.
  * Detailed results: entities processed, indexes rebuilt, collection entries scanned, stale entries found/removed.
  * Store helpers to list entity IDs and delete key prefixes for batch operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->