### PR TITLE
Dev env QoL Extravaganza! Persistent bash history, file ownership, idemponency

### DIFF
--- a/.iso/.bashrc
+++ b/.iso/.bashrc
@@ -1,0 +1,20 @@
+# Persistent bash history
+export HISTFILE=/root/.cache/.bash_history
+export HISTSIZE=50000
+export HISTFILESIZE=100000
+export HISTIGNORE=exit
+export HISTCONTROL=ignoredups
+export HISTTIMEFORMAT='%F %T '
+
+# Interactive shell settings
+if [[ $- == *i* ]]; then
+    shopt -s histappend
+    PROMPT_COMMAND="history -a; ${PROMPT_COMMAND}"
+fi
+
+export CONTAINERD_ADDRESS="/var/lib/miren/containerd/containerd.sock"
+export OTEL_SDK_DISABLED=true
+
+# Less configuration
+export LESSCHARSET=utf-8
+export LESS='-R'

--- a/.iso/.bashrc
+++ b/.iso/.bashrc
@@ -13,6 +13,7 @@ if [[ $- == *i* ]]; then
 fi
 
 export CONTAINERD_ADDRESS="/var/lib/miren/containerd/containerd.sock"
+export CONTAINERD_NAMESPACE="miren"
 export OTEL_SDK_DISABLED=true
 
 # Less configuration

--- a/.iso/Dockerfile
+++ b/.iso/Dockerfile
@@ -64,7 +64,12 @@ COPY ./hack/containerd-config.toml /etc/containerd/config.toml
 
 # Install bashrc for persistent shell configuration
 COPY ./.iso/.bashrc /root/.bashrc
-RUN chmod 755 /root && chmod 644 /root/.bashrc && mkdir -p /root/.cache
+RUN chmod 755 /root && \
+    chmod 644 /root/.bashrc && \
+    mkdir -p /root/.cache && \
+    chmod 777 /root/.cache && \
+    touch /root/.cache/.bash_history && \
+    chmod 666 /root/.cache/.bash_history
 
 # Install runsc
 RUN /usr/local/bin/runsc install

--- a/.iso/Dockerfile
+++ b/.iso/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y \
     less \
     file \
     htop \
+    sudo \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then \

--- a/.iso/Dockerfile
+++ b/.iso/Dockerfile
@@ -61,6 +61,10 @@ RUN chmod +x /usr/local/bin/runsc-ignore
 RUN mkdir -p /etc/containerd
 COPY ./hack/containerd-config.toml /etc/containerd/config.toml
 
+# Install bashrc for persistent shell configuration
+COPY ./.iso/.bashrc /root/.bashrc
+RUN chmod 755 /root && chmod 644 /root/.bashrc && mkdir -p /root/.cache
+
 # Install runsc
 RUN /usr/local/bin/runsc install
 

--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,19 @@ test-e2e:
 
 # Persistent dev environment (standalone mode)
 dev-start:
-	ISO_SESSION=$(ISO_SESSION) iso start && \
-	ISO_SESSION=$(ISO_SESSION) iso run bash hack/dev.sh
+	@if ! ISO_SESSION=$(ISO_SESSION) iso status 2>&1 | grep -q "Container is running"; then \
+		ISO_SESSION=$(ISO_SESSION) iso start && \
+		ISO_SESSION=$(ISO_SESSION) iso run bash hack/dev.sh; \
+	else \
+		echo "✓ Container already running"; \
+	fi
 
-# Start environment, server, and open shell (default for teammates)
+# Start environment, server, and open shell (default for teammates - idempotent)
 dev: dev-start dev-server-start dev-shell
 
-# Interactive shell
+# Interactive shell as host user (preserves file ownership)
 dev-shell:
-	./hack/dev-exec bash
+	@./hack/dev-exec bash hack/dev-shell
 
 # Server lifecycle
 dev-server-start:
@@ -66,9 +70,12 @@ dev-restart: dev-stop dev-start
 dev-status:
 	ISO_SESSION=$(ISO_SESSION) iso status
 
+dev-rebuild:
+	ISO_SESSION=$(ISO_SESSION) iso build --rebuild
+
 .PHONY: dev dev-start dev-shell dev-server-start dev-server-stop \
         dev-server-restart dev-server-status dev-server-logs \
-        dev-stop dev-restart dev-status
+        dev-stop dev-restart dev-status dev-rebuild
 
 services:
 	iso run bash hack/run-services.sh

--- a/hack/common-setup.sh
+++ b/hack/common-setup.sh
@@ -159,6 +159,12 @@ EOF
         chown "$uid:$gid" "$homedir/.bashrc"
     fi
 
+    # Configure sudo for passwordless access
+    if command -v sudo >/dev/null 2>&1; then
+        echo "$username ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/$username"
+        chmod 440 "/etc/sudoers.d/$username"
+    fi
+
     # Export for use by callers
     export HOST_UID="$uid"
     export HOST_GID="$gid"

--- a/hack/dev-shell
+++ b/hack/dev-shell
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Helper script to launch an interactive shell as the host user
+cd /src
+exec su dev


### PR DESCRIPTION
## Summary

This PR enhances the dev environment with two major improvements:

1. **Persistent bash history** across container recreations
2. **Correct file ownership** for all built files (no more root-owned files!)

## Key Features

### Persistent Bash History
- History stored in `/root/.cache/.bash_history` (persists via cache mount)
- 50,000 commands in memory, 100,000 in file
- Includes timestamps for each command
- Configured `LESS=-R` and `LESSCHARSET=utf-8` for better output viewing

### Host User File Ownership
- Created `dev` user with host UID/GID
- All builds run as `dev` user via `su`
- Generated files (`bin/miren`, etc.) now owned by host user
- No more permission errors when editing built files!

### Improved Developer Experience
- `make dev` is now **idempotent** - safe to run multiple times
- Clean shell startup without TTY warnings
- New `make dev-rebuild` target for forcing image rebuilds
- Updated help text with correct commands

## Testing

Tested workflow:
```bash
make dev-rebuild  # Rebuild image with changes
make dev-stop
make dev          # Start everything
# ... work in shell, exit ...
make dev          # Reconnects instantly (idempotent)
```

Verified:
- ✅ History persists across `make dev-stop && make dev`
- ✅ Built files owned by host user (not root)
- ✅ No TTY warnings on shell startup
- ✅ `make dev` works multiple times without errors

## Files Changed

- `.iso/.bashrc` - Shared bash configuration with history and environment
- `.iso/Dockerfile` - Install bashrc, set permissions
- `Makefile` - Idempotent dev target, new dev-rebuild helper
- `hack/common-setup.sh` - New `setup_host_user()` function
- `hack/dev.sh` - Build as host user, cleanup
- `hack/dev-shell` - Helper script for clean shell startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dev-rebuild make target and a host-user interactive shell entrypoint.

* **Improvements**
  * dev-start is idempotent and won’t restart an already-running container.
  * Development builds and workflows run as the host user, preserving ownership for generated files and release artifacts; staging now includes runtime binaries.
  * Interactive shells persist command history and improve prompt behavior; pager and container-tool environment tweaks applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->