### PR TITLE
Fix sandbox-pool set-desired pool ID normalization

### DIFF
--- a/cli/commands/sandbox_pool_set_desired.go
+++ b/cli/commands/sandbox_pool_set_desired.go
@@ -25,8 +25,11 @@ func SandboxPoolSetDesired(ctx *Context, opts struct {
 	eac := entityserver_v1alpha.NewEntityAccessClient(client)
 
 	// Normalize the pool ID - accept both "pool-ABC" and "pool/pool-ABC" formats
-	// TrimPrefix only removes the prefix if it exists, so this handles both forms
-	poolID := strings.TrimPrefix(opts.Args.PoolID, "pool/")
+	// Add the "pool/" prefix if it's not already present
+	poolID := opts.Args.PoolID
+	if !strings.HasPrefix(poolID, "pool/") {
+		poolID = "pool/" + poolID
+	}
 
 	// Look up the pool by ID
 	var pool compute_v1alpha.SandboxPool


### PR DESCRIPTION
## Summary
- Fix incorrect pool ID normalization logic in `sandbox-pool set-desired` command
- The code was trimming the `pool/` prefix instead of adding it when missing
- Entity system expects full entity ID format: `pool/pool-ABC`

## Changes
Changed from using `TrimPrefix` (which removes the prefix) to conditionally adding the prefix when not present.

Now correctly handles both input formats:
- `pool-ABC` → `pool/pool-ABC` ✅
- `pool/pool-ABC` → `pool/pool-ABC` ✅

## Test plan
- [x] Verify `m sandbox-pool set-desired pool-ABC 5` works
- [x] Verify `m sandbox-pool set-desired pool/pool-ABC 5` works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool identifier handling in sandbox commands to ensure consistent formatting and processing of pool IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->