### PR TITLE
Post dev env tweak fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,22 +15,38 @@ export DO_NOT_TRACK=1
 # Generate a unique session name based on the project directory
 ISO_SESSION ?= dev-$(shell basename "$$(pwd)")
 
+.PHONY: help
+help: ## Show this help message
+	@echo "Miren Runtime"
+	@echo ""
+	@echo "Available targets:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_/-]+:.*?## / {printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
 #
-# ISO targets (for local development)
+# Development (iso - recommended)
 #
 
-# Isolated test runs (clean environment every time)
-test:
-	iso run bash hack/test.sh ./...
+dev: dev-start dev-server-start dev-shell ## Start dev environment, server, and open shell
 
-test-shell:
-	iso run USESHELL=1 bash hack/test.sh
+dev-shell: ## Open interactive shell in dev environment
+	@./hack/dev-exec bash
 
-test-e2e:
-	iso run bash hack/test.sh ./e2e --tags=e2e
+dev-server-start: ## Start the miren server
+	./hack/dev-exec bash hack/dev-server start
 
-# Persistent dev environment (standalone mode)
-dev-start:
+dev-server-stop: ## Stop the miren server
+	./hack/dev-exec bash hack/dev-server stop
+
+dev-server-restart: ## Restart the miren server
+	./hack/dev-exec bash hack/dev-server restart
+
+dev-server-status: ## Check miren server status
+	./hack/dev-exec bash hack/dev-server status
+
+dev-server-logs: ## View miren server logs
+	./hack/dev-exec bash hack/dev-server logs
+
+dev-start: ## Start dev environment (internal - use 'dev' instead)
 	@if ! ISO_SESSION=$(ISO_SESSION) iso status 2>&1 | grep -q "Container is running"; then \
 		ISO_SESSION=$(ISO_SESSION) iso start && \
 		ISO_SESSION=$(ISO_SESSION) iso run bash hack/dev.sh; \
@@ -38,139 +54,68 @@ dev-start:
 		echo "✓ Container already running"; \
 	fi
 
-# Start environment, server, and open shell (default for teammates - idempotent)
-dev: dev-start dev-server-start dev-shell
-
-# Interactive shell as host user (preserves file ownership)
-dev-shell:
-	@./hack/dev-exec bash
-
-# Server lifecycle
-dev-server-start:
-	./hack/dev-exec bash hack/dev-server start
-
-dev-server-stop:
-	./hack/dev-exec bash hack/dev-server stop
-
-dev-server-restart:
-	./hack/dev-exec bash hack/dev-server restart
-
-dev-server-status:
-	./hack/dev-exec bash hack/dev-server status
-
-dev-server-logs:
-	./hack/dev-exec bash hack/dev-server logs
-
-# Environment management
-dev-stop:
+dev-stop: ## Stop the dev environment
 	ISO_SESSION=$(ISO_SESSION) iso stop
 
-dev-restart: dev-stop dev-start
+dev-restart: dev-stop dev-start ## Restart the dev environment
 
-dev-status:
+dev-status: ## Check dev environment status
 	ISO_SESSION=$(ISO_SESSION) iso status
 
-dev-rebuild:
+dev-rebuild: ## Rebuild dev environment image
 	ISO_SESSION=$(ISO_SESSION) iso build --rebuild
 
 .PHONY: dev dev-start dev-shell dev-server-start dev-server-stop \
         dev-server-restart dev-server-status dev-server-logs \
         dev-stop dev-restart dev-status dev-rebuild
 
-services:
-	iso run bash hack/run-services.sh
-
-.PHONY: services
-
-image:
-	iso run sh -c "docker save runtime-shell | gzip > /workspace/tmp/miren-image.tar.gz"
-	@echo "Image saved to tmp/miren-image.tar.gz"
-
-release-data:
-	iso run bash -c "make bin/miren && mkdir -p /tmp/package && \
-		cp bin/miren /tmp/package && \
-		cp /usr/local/bin/runc /tmp/package && \
-		cp /usr/local/bin/containerd-shim-runsc-v1 /tmp/package && \
-		cp /usr/local/bin/containerd-shim-runc-v2 /tmp/package && \
-		cp /usr/local/bin/containerd /tmp/package && \
-		cp /usr/local/bin/nerdctl /tmp/package && \
-		cp /usr/local/bin/ctr /tmp/package && \
-		tar -C /tmp/package -czf /workspace/release.tar.gz ."
-
-.PHONY: release-data
-
 #
-# Dagger targets (for CI/CD)
+# Testing (iso)
 #
 
-test-dagger:
-	dagger call -q test --dir=.
+test: ## Run all tests
+	iso run bash hack/test.sh ./...
 
-test-dagger-interactive:
-	dagger call -i -q test --dir=.
+test-shell: ## Run tests with interactive shell
+	iso run USESHELL=1 bash hack/test.sh
 
-test-shell-dagger:
-	dagger call -q test --dir=. --shell
+test-e2e: ## Run end-to-end tests
+	iso run bash hack/test.sh ./e2e --tags=e2e
 
-test-e2e-dagger:
-	dagger call -q test --dir=. --tests="./e2e" --tags=e2e
-
-dev-dagger:
-	dagger call -q dev --dir=.
-
-services-dagger:
-	dagger call debug --dir=.
-
-.PHONY: services-dagger
-
-image-dagger:
-	dagger call -q container --dir=. export --path=tmp/latest.tar
-	docker import tmp/latest.tar miren:latest
-	rm tmp/latest.tar
-
-release-data-dagger:
-	dagger call package --dir=. export --path=release.tar.gz
-
-.PHONY: release-data-dagger
+.PHONY: test test-shell test-e2e
 
 #
-# Common targets (work without containerization)
+# Building
 #
 
-clean:
-	rm -f bin/miren bin/miren-debug
-
-bin/miren:
+bin/miren: ## Build the miren binary
 	@bash ./hack/build.sh
 
-.PHONY: bin/miren
-
-release:
+release: ## Build release version
 	@bash ./hack/build-release.sh
 
-.PHONY: release
-
-bin/miren-debug:
+bin/miren-debug: ## Build with debug symbols
 	go build -gcflags="all=-N -l" -o bin/miren-debug ./cmd/miren
 
-.PHONY: bin/miren-debug
+clean: ## Remove built binaries
+	rm -f bin/miren bin/miren-debug
 
-lint:
+.PHONY: bin/miren release bin/miren-debug clean
+
+#
+# Code Quality
+#
+
+lint: ## Run golangci-lint
 	golangci-lint run ./...
 
-.PHONY: lint
-
-lint-fix:
+lint-fix: ## Run golangci-lint with auto-fix
 	golangci-lint run --fix ./...
 
-.PHONY: lint-fix
-
-lint-pr:
+lint-pr: ## Run golangci-lint on changes from main
 	golangci-lint run --new-from-rev main ./...
 
-.PHONY: lint-pr
-
-generate-check:
+generate-check: ## Verify go generate is up to date
 	@echo "Checking if go generate produces any changes..."
 	@if [ -n "$$(git status --porcelain)" ]; then \
 		echo "Error: Working directory is not clean. Please commit or stash changes before running generate-check."; \
@@ -188,9 +133,70 @@ generate-check:
 	fi
 	@echo "✓ go generate is up to date"
 
-.PHONY: generate-check
+.PHONY: lint lint-fix lint-pr generate-check
 
-dist:
+#
+# Release Packaging
+#
+
+release-data: ## Create release package tar.gz (iso)
+	iso run bash -c "make bin/miren && mkdir -p /tmp/package && \
+		cp bin/miren /tmp/package && \
+		cp /usr/local/bin/runc /tmp/package && \
+		cp /usr/local/bin/containerd-shim-runsc-v1 /tmp/package && \
+		cp /usr/local/bin/containerd-shim-runc-v2 /tmp/package && \
+		cp /usr/local/bin/containerd /tmp/package && \
+		cp /usr/local/bin/nerdctl /tmp/package && \
+		cp /usr/local/bin/ctr /tmp/package && \
+		tar -C /tmp/package -czf /workspace/release.tar.gz ."
+
+image: ## Export Docker image (iso)
+	iso run sh -c "docker save runtime-shell | gzip > /workspace/tmp/miren-image.tar.gz"
+	@echo "Image saved to tmp/miren-image.tar.gz"
+
+dist: ## Build distribution packages
 	@bash ./hack/build-dist.sh
 
-.PHONY: dist
+.PHONY: release-data image dist
+
+#
+# Other (iso)
+#
+
+services: ## Run services container for debugging
+	iso run bash hack/run-services.sh
+
+.PHONY: services
+
+#
+# Dagger targets (for CI/CD)
+#
+
+test-dagger: ## Run all tests (Dagger)
+	dagger call -q test --dir=.
+
+test-dagger-interactive: ## Run tests interactively (Dagger)
+	dagger call -i -q test --dir=.
+
+test-shell-dagger: ## Run tests with shell (Dagger)
+	dagger call -q test --dir=. --shell
+
+test-e2e-dagger: ## Run end-to-end tests (Dagger)
+	dagger call -q test --dir=. --tests="./e2e" --tags=e2e
+
+dev-dagger: ## Start dev environment (Dagger)
+	dagger call -q dev --dir=.
+
+services-dagger: ## Run services container (Dagger)
+	dagger call debug --dir=.
+
+image-dagger: ## Build and import Docker image (Dagger)
+	dagger call -q container --dir=. export --path=tmp/latest.tar
+	docker import tmp/latest.tar miren:latest
+	rm tmp/latest.tar
+
+release-data-dagger: ## Create release package (Dagger)
+	dagger call package --dir=. export --path=release.tar.gz
+
+.PHONY: test-dagger test-dagger-interactive test-shell-dagger test-e2e-dagger \
+        dev-dagger services-dagger image-dagger release-data-dagger

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ dev: dev-start dev-server-start dev-shell
 
 # Interactive shell as host user (preserves file ownership)
 dev-shell:
-	@./hack/dev-exec bash hack/dev-shell
+	@./hack/dev-exec bash
 
 # Server lifecycle
 dev-server-start:

--- a/hack/dev-exec
+++ b/hack/dev-exec
@@ -38,5 +38,20 @@ if echo "$STATUS_OUTPUT" | grep -q "Container does not exist"; then
   exit 1
 fi
 
-# Execute command in the persistent dev container
-ISO_SESSION="$SESSION" iso run "$@"
+# Execute command in the persistent dev container as the host user
+# Special case: dev-server needs to run as root for process management
+if [[ "$1" == "bash" && "$2" == "hack/dev-server" ]]; then
+  # Run dev-server as root (needs to manage root-owned server process)
+  ISO_SESSION="$SESSION" iso run "$@"
+# Special case: interactive bash shell needs proper TTY (no -c flag)
+elif [[ "$1" == "bash" && $# -eq 1 ]]; then
+  # Use exec su dev for proper interactive shell with job control
+  ISO_SESSION="$SESSION" iso run bash -c "cd /src && exec su dev"
+else
+  # Build a properly quoted command string to preserve arguments with spaces/special chars
+  CMD="cd /src && "
+  for arg in "$@"; do
+    CMD+="$(printf '%q ' "$arg")"
+  done
+  ISO_SESSION="$SESSION" iso run su dev -c "$CMD"
+fi

--- a/hack/dev-exec
+++ b/hack/dev-exec
@@ -39,6 +39,13 @@ if echo "$STATUS_OUTPUT" | grep -q "Container does not exist"; then
 fi
 
 # Execute command in the persistent dev container as the host user
+
+# Guard: if no arguments, drop into an interactive shell
+if [ "$#" -eq 0 ]; then
+  ISO_SESSION="$SESSION" iso run bash -c "cd /src && exec su dev"
+  exit
+fi
+
 # Special case: dev-server needs to run as root for process management
 if [[ "$1" == "bash" && "$2" == "hack/dev-server" ]]; then
   # Run dev-server as root (needs to manage root-owned server process)
@@ -49,9 +56,10 @@ elif [[ "$1" == "bash" && $# -eq 1 ]]; then
   ISO_SESSION="$SESSION" iso run bash -c "cd /src && exec su dev"
 else
   # Build a properly quoted command string to preserve arguments with spaces/special chars
+  # Use -s /bin/bash to ensure ANSI-C quoting ($'...' from printf %q) is supported
   CMD="cd /src && "
   for arg in "$@"; do
     CMD+="$(printf '%q ' "$arg")"
   done
-  ISO_SESSION="$SESSION" iso run su dev -c "$CMD"
+  ISO_SESSION="$SESSION" iso run su -s /bin/bash dev -c "$CMD"
 fi

--- a/hack/dev-server
+++ b/hack/dev-server
@@ -15,6 +15,7 @@ case "${1:-}" in
 
     echo "Starting miren server in standalone mode..."
     # Use nohup and disown to fully detach from the shell
+    # (Script runs as root for process management privileges)
     nohup ./bin/miren server -vv --mode standalone >"$LOGFILE" 2>&1 </dev/null &
     pid=$!
     disown

--- a/hack/dev-shell
+++ b/hack/dev-shell
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Helper script to launch an interactive shell as the host user
-cd /src
-exec su dev

--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -10,6 +10,11 @@ setup_kernel_mounts
 
 cd /src
 
+# Ensure Go cache directories are owned by the host user
+# These may be owned by root from previous runs before we switched to building as host user
+chown -R "$HOST_UID:$HOST_GID" /go/build-cache /go/pkg 2>/dev/null || true
+chmod -R 770 /go/build-cache /go/pkg 2>/dev/null || true
+
 echo "Building miren as host user (UID ${ISO_UID})..."
 su -s /bin/bash "$HOST_USER" -c "make bin/miren"
 


### PR DESCRIPTION
## Summary

Fixes for issues discovered after PR #310 (dev bash history improvements) merged.

## Changes

1. **Fix Go cache permissions** - Added `chmod -R 777` for Go cache directories in `hack/dev.sh` to fix "permission denied" errors when building as host user after #310 switched from root builds.

2. **Fix hack/dev-exec user context** - Updated `hack/dev-exec` to run commands as the host user (`dev`) instead of root, making it consistent with `hack/dev-shell` and avoiding permission issues.

## Problems Solved

### Go Cache Permissions
After PR #310 switched to building as the host user (UID 1000) instead of root, the Go cache directories (`/go/build-cache` and `/go/pkg`) remained owned by root from previous runs, causing build failures.

### dev-exec Running as Root
The `hack/dev-exec` script was running commands as root, which is inconsistent with `hack/dev-shell` (which uses `su dev`) and causes permission issues when creating files or using the Go cache.

## Test plan

- [x] Ran `make dev-stop` to clean up old environment
- [x] Ran `make dev` - successfully built and started server
- [x] Verified server is running with `make dev-server-status`
- [x] Tested `hack/dev-exec` runs commands as host user with correct permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made the build flow more tolerant by ensuring local build caches are owned and writable to reduce friction.
  * Updated dev-environment command execution to run commands as the host user inside the project workspace with robust argument quoting.
  * Changed interactive shell behavior to start a plain interactive session under the container's development user; server process management still runs with elevated privileges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->