### PR TITLE
Add support for connecting to local Miren Cloud

### DIFF
--- a/.iso/config.yml
+++ b/.iso/config.yml
@@ -7,3 +7,5 @@ cache:
   - /go/pkg
   - /go/build-cache
   - /root/.cache
+extra_hosts:
+  - "miren.host:host-gateway"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,50 @@ make dev-shell                # Open another shell (from host)
 make dev-stop                 # Tear down environment
 ```
 
+**Connecting to a local Miren Cloud instance:**
+
+The dev environment can connect to a local copy of Miren Cloud for testing the full authentication and registration flow.
+
+Prerequisites:
+- Miren Cloud running locally (typically on `http://localhost:3001`)
+- The `.iso/config.yml` includes `extra_hosts` configuration for host access:
+  ```yaml
+  extra_hosts:
+    - "miren.host:host-gateway"
+  ```
+  This allows containers to reach the host machine via `miren.host` instead of `localhost`.
+
+Workflow:
+```bash
+# 1. Start the dev environment
+make dev
+
+# 2. Login to your local cloud (inside dev shell or via dev-exec)
+m login --url http://miren.host:3001
+# Follow the URL to authenticate in your browser
+
+# 3. Register the cluster with cloud
+m register -u http://miren.host:3001 -n my-dev-cluster
+# Approve the registration in the browser when prompted
+
+# 4. Restart server to activate registration
+make dev-server-restart
+
+# 5. Verify the setup
+m cluster list
+m app list
+```
+
+**Important notes:**
+- Use `miren.host:3001` (not `localhost:3001`) from inside the dev container
+- The server must be restarted after registration to load the new cluster configuration
+- Registration creates `/var/lib/miren/server/registration.json` with cluster credentials
+- Login creates `~/.config/miren/clientconfig.yaml` with user credentials
+
+**With Dagger (for CI compatibility):**
+- `make dev-dagger` - Start development environment with Dagger
+- `make services-dagger` - Run services container for debugging
+
 ### Other Commands
 - `make image` - Export Docker image
 - `make release-data` - Create release package tar.gz


### PR DESCRIPTION
## Summary

Enables the dev environment to connect to a local copy of Miren Cloud for testing authentication and registration workflows.

This makes it easy to test the full runtime + cloud integration locally without needing a deployed cloud instance.

## Changes

- **Add `extra_hosts` to `.iso/config.yml`** - Configures `miren.host:host-gateway` to allow containers to reach the host machine
- **Document local cloud workflow in `CLAUDE.md`** - Complete step-by-step guide including:
  - Prerequisites (local cloud setup + iso config)
  - Login and registration workflow
  - Server restart requirement
  - Important gotchas and file locations

## Usage

```bash
# 1. Start dev environment
make dev

# 2. Login to local cloud
m login --url http://miren.host:3001

# 3. Register cluster
m register -u http://miren.host:3001 -n my-dev-cluster

# 4. Restart server to load registration
make dev-server-restart

# 5. Verify
m app list
```

## Dependencies

- Requires https://github.com/mirendev/cloud/pull/61 for proper `http://` scheme detection in `poll_url` generation
- Requires `iso` with `extra_hosts` support (implemented separately in iso repo)

## Test Plan

- [x] Verified `miren.host` resolves to host gateway IP (`172.17.0.1`)
- [x] Successfully ran `m login --url http://miren.host:3001`
- [x] Successfully ran `m register -u http://miren.host:3001 -n superdevcool`
- [x] Confirmed server restart loads registration properly
- [x] Documentation tested and verified accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for connecting and testing authentication against a local Miren Cloud instance from the development environment, including configuration prerequisites and workflow steps.

* **Chores**
  * Updated container configuration to enable host network mapping for local Miren Cloud connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->