### PR TITLE
feat: Add deployment locking to prevent concurrent deployments

### DIFF
--- a/api/deployment/deployment_v1alpha/rpc.gen.go
+++ b/api/deployment/deployment_v1alpha/rpc.gen.go
@@ -412,6 +412,135 @@ func (v *GitInfo) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type deploymentLockInfoData struct {
+	AppName              *string             `cbor:"0,keyasint,omitempty" json:"app_name,omitempty"`
+	ClusterId            *string             `cbor:"1,keyasint,omitempty" json:"cluster_id,omitempty"`
+	BlockingDeploymentId *string             `cbor:"2,keyasint,omitempty" json:"blocking_deployment_id,omitempty"`
+	StartedBy            *string             `cbor:"3,keyasint,omitempty" json:"started_by,omitempty"`
+	StartedAt            *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"started_at,omitempty"`
+	CurrentPhase         *string             `cbor:"5,keyasint,omitempty" json:"current_phase,omitempty"`
+	LockExpiresAt        *standard.Timestamp `cbor:"6,keyasint,omitempty" json:"lock_expires_at,omitempty"`
+}
+
+type DeploymentLockInfo struct {
+	data deploymentLockInfoData
+}
+
+func (v *DeploymentLockInfo) HasAppName() bool {
+	return v.data.AppName != nil
+}
+
+func (v *DeploymentLockInfo) AppName() string {
+	if v.data.AppName == nil {
+		return ""
+	}
+	return *v.data.AppName
+}
+
+func (v *DeploymentLockInfo) SetAppName(app_name string) {
+	v.data.AppName = &app_name
+}
+
+func (v *DeploymentLockInfo) HasClusterId() bool {
+	return v.data.ClusterId != nil
+}
+
+func (v *DeploymentLockInfo) ClusterId() string {
+	if v.data.ClusterId == nil {
+		return ""
+	}
+	return *v.data.ClusterId
+}
+
+func (v *DeploymentLockInfo) SetClusterId(cluster_id string) {
+	v.data.ClusterId = &cluster_id
+}
+
+func (v *DeploymentLockInfo) HasBlockingDeploymentId() bool {
+	return v.data.BlockingDeploymentId != nil
+}
+
+func (v *DeploymentLockInfo) BlockingDeploymentId() string {
+	if v.data.BlockingDeploymentId == nil {
+		return ""
+	}
+	return *v.data.BlockingDeploymentId
+}
+
+func (v *DeploymentLockInfo) SetBlockingDeploymentId(blocking_deployment_id string) {
+	v.data.BlockingDeploymentId = &blocking_deployment_id
+}
+
+func (v *DeploymentLockInfo) HasStartedBy() bool {
+	return v.data.StartedBy != nil
+}
+
+func (v *DeploymentLockInfo) StartedBy() string {
+	if v.data.StartedBy == nil {
+		return ""
+	}
+	return *v.data.StartedBy
+}
+
+func (v *DeploymentLockInfo) SetStartedBy(started_by string) {
+	v.data.StartedBy = &started_by
+}
+
+func (v *DeploymentLockInfo) HasStartedAt() bool {
+	return v.data.StartedAt != nil
+}
+
+func (v *DeploymentLockInfo) StartedAt() *standard.Timestamp {
+	return v.data.StartedAt
+}
+
+func (v *DeploymentLockInfo) SetStartedAt(started_at *standard.Timestamp) {
+	v.data.StartedAt = started_at
+}
+
+func (v *DeploymentLockInfo) HasCurrentPhase() bool {
+	return v.data.CurrentPhase != nil
+}
+
+func (v *DeploymentLockInfo) CurrentPhase() string {
+	if v.data.CurrentPhase == nil {
+		return ""
+	}
+	return *v.data.CurrentPhase
+}
+
+func (v *DeploymentLockInfo) SetCurrentPhase(current_phase string) {
+	v.data.CurrentPhase = &current_phase
+}
+
+func (v *DeploymentLockInfo) HasLockExpiresAt() bool {
+	return v.data.LockExpiresAt != nil
+}
+
+func (v *DeploymentLockInfo) LockExpiresAt() *standard.Timestamp {
+	return v.data.LockExpiresAt
+}
+
+func (v *DeploymentLockInfo) SetLockExpiresAt(lock_expires_at *standard.Timestamp) {
+	v.data.LockExpiresAt = lock_expires_at
+}
+
+func (v *DeploymentLockInfo) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *DeploymentLockInfo) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *DeploymentLockInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *DeploymentLockInfo) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type deploymentCreateDeploymentArgsData struct {
 	AppName      *string  `cbor:"0,keyasint,omitempty" json:"app_name,omitempty"`
 	ClusterId    *string  `cbor:"1,keyasint,omitempty" json:"cluster_id,omitempty"`
@@ -482,8 +611,9 @@ func (v *DeploymentCreateDeploymentArgs) UnmarshalJSON(data []byte) error {
 }
 
 type deploymentCreateDeploymentResultsData struct {
-	Deployment *DeploymentInfo `cbor:"0,keyasint,omitempty" json:"deployment,omitempty"`
-	Error      *string         `cbor:"1,keyasint,omitempty" json:"error,omitempty"`
+	Deployment *DeploymentInfo     `cbor:"0,keyasint,omitempty" json:"deployment,omitempty"`
+	Error      *string             `cbor:"1,keyasint,omitempty" json:"error,omitempty"`
+	LockInfo   *DeploymentLockInfo `cbor:"2,keyasint,omitempty" json:"lock_info,omitempty"`
 }
 
 type DeploymentCreateDeploymentResults struct {
@@ -497,6 +627,10 @@ func (v *DeploymentCreateDeploymentResults) SetDeployment(deployment *Deployment
 
 func (v *DeploymentCreateDeploymentResults) SetError(error string) {
 	v.data.Error = &error
+}
+
+func (v *DeploymentCreateDeploymentResults) SetLockInfo(lock_info *DeploymentLockInfo) {
+	v.data.LockInfo = lock_info
 }
 
 func (v *DeploymentCreateDeploymentResults) MarshalCBOR() ([]byte, error) {
@@ -1455,6 +1589,14 @@ func (v *DeploymentClientCreateDeploymentResults) Error() string {
 		return ""
 	}
 	return *v.data.Error
+}
+
+func (v *DeploymentClientCreateDeploymentResults) HasLockInfo() bool {
+	return v.data.LockInfo != nil
+}
+
+func (v *DeploymentClientCreateDeploymentResults) LockInfo() *DeploymentLockInfo {
+	return v.data.LockInfo
 }
 
 func (v DeploymentClient) CreateDeployment(ctx context.Context, app_name string, cluster_id string, app_version_id string, git_info *GitInfo) (*DeploymentClientCreateDeploymentResults, error) {

--- a/api/deployment/rpc.yml
+++ b/api/deployment/rpc.yml
@@ -34,6 +34,9 @@ interfaces:
           - name: error
             type: string
             doc: Error message if deployment creation failed
+          - name: lock_info
+            type: DeploymentLockInfo
+            doc: Structured information about the deployment lock (if blocked)
 
       - name: UpdateDeploymentStatus
         index: 1
@@ -250,3 +253,35 @@ types:
         type: standard.Timestamp
         index: 9
         doc: When the commit was made
+
+  - type: DeploymentLockInfo
+    doc: Information about a deployment lock blocking a new deployment
+    fields:
+      - name: app_name
+        type: string
+        index: 0
+        doc: The application name
+      - name: cluster_id
+        type: string
+        index: 1
+        doc: The cluster ID
+      - name: blocking_deployment_id
+        type: string
+        index: 2
+        doc: The ID of the deployment holding the lock
+      - name: started_by
+        type: string
+        index: 3
+        doc: Email or username of who started the blocking deployment
+      - name: started_at
+        type: standard.Timestamp
+        index: 4
+        doc: When the blocking deployment was started
+      - name: current_phase
+        type: string
+        index: 5
+        doc: Current phase of the blocking deployment
+      - name: lock_expires_at
+        type: standard.Timestamp
+        index: 6
+        doc: When the lock will expire

--- a/cli/commands/app_history.go
+++ b/cli/commands/app_history.go
@@ -87,13 +87,13 @@ func AppHistory(ctx *Context, opts struct {
 
 	// Table header
 	if opts.Detailed {
-		ctx.Printf("%-12s %-8s %-25s %-20s %-15s %-17s %-15s %-33s\n",
-			"STATUS", "CLUSTER", "VERSION", "DEPLOYED BY", "WHEN", "GIT SHA", "BRANCH", "COMMIT MESSAGE")
-		ctx.Printf("%s\n", strings.Repeat("-", 160))
+		ctx.Printf("%-12s %-25s %-8s %-25s %-20s %-15s %-17s %-15s %-33s\n",
+			"STATUS", "ID", "CLUSTER", "VERSION", "DEPLOYED BY", "WHEN", "GIT SHA", "BRANCH", "COMMIT MESSAGE")
+		ctx.Printf("%s\n", strings.Repeat("-", 185))
 	} else {
-		ctx.Printf("%-12s %-25s %-25s %-15s\n",
-			"STATUS", "VERSION", "DEPLOYED BY", "WHEN")
-		ctx.Printf("%s\n", strings.Repeat("-", 80))
+		ctx.Printf("%-12s %-25s %-25s %-25s %-15s\n",
+			"STATUS", "ID", "VERSION", "DEPLOYED BY", "WHEN")
+		ctx.Printf("%s\n", strings.Repeat("-", 105))
 	}
 
 	// Status colors
@@ -144,11 +144,17 @@ func AppHistory(ctx *Context, opts struct {
 
 		// Format user
 		user := dep.DeployedByUserEmail()
-		if user == "" {
-			user = dep.DeployedByUserId()
-		}
-		if len(user) > 20 {
+		// Replace placeholder emails with dash
+		if user == "" || user == "unknown@example.com" || user == "user@example.com" {
+			user = "-"
+		} else if len(user) > 20 {
 			user = user[:17] + "..."
+		}
+
+		// Format deployment ID
+		deploymentId := dep.Id()
+		if len(deploymentId) > 25 {
+			deploymentId = deploymentId[:22] + "..."
 		}
 
 		// Format git info
@@ -186,8 +192,9 @@ func AppHistory(ctx *Context, opts struct {
 		}
 
 		if opts.Detailed {
-			ctx.Printf("%-12s %-8s %-25s %-20s %-15s %-17s %-15s %-33s\n",
+			ctx.Printf("%-12s %-25s %-8s %-25s %-20s %-15s %-17s %-15s %-33s\n",
 				styledStatus,
+				deploymentId,
 				cluster,
 				version,
 				user,
@@ -196,8 +203,9 @@ func AppHistory(ctx *Context, opts struct {
 				gitBranch,
 				gitMessage)
 		} else {
-			ctx.Printf("%-12s %-25s %-25s %-15s\n",
+			ctx.Printf("%-12s %-25s %-25s %-25s %-15s\n",
 				styledStatus,
+				deploymentId,
 				version,
 				user,
 				timeStr)

--- a/cli/commands/app_status.go
+++ b/cli/commands/app_status.go
@@ -125,8 +125,13 @@ func AppStatus(ctx *Context, opts struct {
 		}
 
 		// Deployed info
-		if deployment.HasDeployedByUserEmail() && deployment.DeployedByUserEmail() != "" {
-			ctx.Printf("  Deployed By: %s\n", deployment.DeployedByUserEmail())
+		if deployment.HasDeployedByUserEmail() {
+			email := deployment.DeployedByUserEmail()
+			// Replace placeholder emails with dash
+			if email == "" || email == "unknown@example.com" || email == "user@example.com" {
+				email = "-"
+			}
+			ctx.Printf("  Deployed By: %s\n", email)
 		}
 
 		if deployment.HasDeployedAt() && deployment.DeployedAt() != nil {

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -99,7 +99,9 @@ func Deploy(ctx *Context, opts struct {
 	}
 
 	if createResult.HasError() && createResult.Error() != "" {
-		return fmt.Errorf("deployment creation failed: %s", createResult.Error())
+		// Deployment lock error - provide clear user feedback
+		ctx.Printf("\n❌ Deployment blocked:\n\n%s\n", createResult.Error())
+		return fmt.Errorf("deployment blocked by lock")
 	}
 
 	if !createResult.HasDeployment() || createResult.Deployment() == nil {

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -99,8 +99,44 @@ func Deploy(ctx *Context, opts struct {
 	}
 
 	if createResult.HasError() && createResult.Error() != "" {
-		// Deployment lock error - provide clear user feedback
-		ctx.Printf("\n❌ Deployment blocked:\n\n%s\n", createResult.Error())
+		// Check if we have structured lock info
+		if createResult.HasLockInfo() && createResult.LockInfo() != nil {
+			lockInfo := createResult.LockInfo()
+
+			// Format the deployment lock message
+			ctx.Printf("\n❌ Deployment blocked:\n\n")
+			ctx.Printf("Another deployment is already in progress for app '%s' on cluster '%s'.\n\n",
+				lockInfo.AppName(), lockInfo.ClusterId())
+
+			ctx.Printf("Existing deployment details:\n")
+			ctx.Printf("  • Deployment ID: %s\n", lockInfo.BlockingDeploymentId())
+			ctx.Printf("  • Started by: %s\n", lockInfo.StartedBy())
+
+			if lockInfo.HasStartedAt() && lockInfo.StartedAt() != nil {
+				startedAt := time.Unix(lockInfo.StartedAt().Seconds(), 0)
+				ctx.Printf("  • Started at: %s (%s ago)\n",
+					startedAt.Format("2006-01-02 15:04:05 MST"),
+					time.Since(startedAt).Round(time.Second))
+			}
+
+			ctx.Printf("  • Current phase: %s\n", lockInfo.CurrentPhase())
+
+			if lockInfo.HasLockExpiresAt() && lockInfo.LockExpiresAt() != nil {
+				expiresAt := time.Unix(lockInfo.LockExpiresAt().Seconds(), 0)
+				timeRemaining := time.Until(expiresAt).Round(time.Second)
+				ctx.Printf("  • Lock expires in: %s\n\n", timeRemaining)
+			}
+
+			// Build contact message
+			if lockInfo.StartedBy() != "-" {
+				ctx.Printf("Please wait for it to complete or contact %s to coordinate.\n", lockInfo.StartedBy())
+			} else {
+				ctx.Printf("Please wait for it to complete.\n")
+			}
+		} else {
+			// Fall back to plain error message
+			ctx.Printf("\n❌ Deployment blocked:\n\n%s\n", createResult.Error())
+		}
 		return fmt.Errorf("deployment blocked by lock")
 	}
 

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -59,7 +59,7 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 	if len(existingDeployments) > 0 {
 		// Found an existing in_progress deployment
 		existing := existingDeployments[0]
-		
+
 		// Parse the deployment timestamp
 		deploymentTime, err := time.Parse(time.RFC3339, existing.DeployedBy.Timestamp)
 		if err != nil {
@@ -113,13 +113,13 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 		existing.Status = "failed"
 		existing.ErrorMessage = "Deployment timed out after 30 minutes"
 		existing.CompletedAt = time.Now().Format(time.RFC3339)
-		
+
 		// Update entity
 		updateAttrs := existing.Encode()
 		updateEntity := &entityserver_v1alpha.Entity{}
 		updateEntity.SetId(string(existing.ID))
 		updateEntity.SetAttrs(updateAttrs)
-		
+
 		// We don't have the revision here, so we need to get it
 		if existingEntity, err := d.EAC.Get(ctx, string(existing.ID)); err == nil {
 			updateEntity.SetRevision(existingEntity.Entity().Revision())

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -74,10 +75,11 @@ func TestCreateDeploymentWithGitInfo(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create deployment
-			results, err := client.CreateDeployment(ctx, "test-app", "test-cluster", "v1.0.0", tt.gitInfo)
+			// Create deployment with unique app name to avoid deployment lock conflicts
+			appName := fmt.Sprintf("test-app-%d", i)
+			results, err := client.CreateDeployment(ctx, appName, "test-cluster", "v1.0.0", tt.gitInfo)
 			if err != nil {
 				t.Fatalf("CreateDeployment failed: %v", err)
 			}


### PR DESCRIPTION
## Summary

Implements a deployment lock mechanism to prevent multiple concurrent deployments of the same app on the same cluster. This prevents race conditions and conflicts when multiple users or automation systems attempt to deploy simultaneously.

## Key Features

- **Mutual Exclusion**: Only one deployment can be in progress for an app+cluster combination
- **Automatic Expiration**: Lock expires after 30 minutes to prevent indefinite locks from crashed processes
- **Automatic Cleanup**: Expired in-progress deployments are automatically marked as failed
- **Clear Error Messages**: Users see detailed information about the blocking deployment including:
  - Who started it
  - When it started
  - Current phase
  - Time remaining until lock expires

## Changes

### Backend (`servers/deployment/server.go`)
- Check for existing in_progress deployments before creating new ones
- 30-minute timeout with automatic expiration handling
- Detailed lock error messages with deployment info and time remaining
- Changed default email from "user@example.com" to empty string for cleaner display

### CLI Improvements

**`cli/commands/app_history.go`:**
- Added deployment ID column for easier troubleshooting
- Show "-" instead of placeholder emails (unknown@example.com, user@example.com)

**`cli/commands/app_status.go`:**
- Show "-" instead of placeholder emails for consistent display

**`cli/commands/deploy.go`:**
- Improved deployment blocked error formatting

## Example Error Message

```
❌ Deployment blocked:

Another deployment is already in progress for app 'my-app' on cluster 'production'.

Existing deployment details:
  • Deployment ID: e-ABC123...
  • Started by: user@example.com
  • Started at: 2025-01-10 14:30:00 EST (5m ago)
  • Current phase: building
  • Lock expires in: 25m

Please wait for it to complete or contact user@example.com to coordinate.
```

## Testing

Tested by manually setting a deployment to in_progress status and verifying:
- ✅ Lock prevents new deployments
- ✅ Lock expires after 30 minutes
- ✅ Expired deployments are marked as failed
- ✅ Error messages display correctly
- ✅ Deployment ID appears in app history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment ID now shown in app history (detailed and summary views)
  * Deployment creation now surfaces structured lock details when blocked (blocking deployment, who started it, phase, expiry)

* **Bug Fixes**
  * Stale in‑progress deployments are auto‑failed to release locks (prevents persistent blocks)
  * Clearer "deployment blocked" messaging with user guidance
  * Creator email sanitized for display (placeholders shown as “–”); long IDs/emails truncated for layout consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->