### PR TITLE
Add --raw-id flag to sandbox-pool set-desired

### DIFF
--- a/cli/commands/sandbox_pool_set_desired.go
+++ b/cli/commands/sandbox_pool_set_desired.go
@@ -12,7 +12,8 @@ import (
 
 func SandboxPoolSetDesired(ctx *Context, opts struct {
 	ConfigCentric
-	Args struct {
+	RawID bool `long:"raw-id" description:"Use the provided ID as-is without adding the pool/ prefix"`
+	Args  struct {
 		PoolID  string `positional-arg-name:"pool-id" description:"Pool ID (e.g., pool-CUSkT8J58BmgkDeGyPP2e or pool/pool-CUSkT8J58BmgkDeGyPP2e)" required:"true"`
 		Desired string `positional-arg-name:"desired" description:"Desired instance count (absolute number, +N to increase, or -N to decrease)" required:"true"`
 	} `positional-args:"yes"`
@@ -25,9 +26,9 @@ func SandboxPoolSetDesired(ctx *Context, opts struct {
 	eac := entityserver_v1alpha.NewEntityAccessClient(client)
 
 	// Normalize the pool ID - accept both "pool-ABC" and "pool/pool-ABC" formats
-	// Add the "pool/" prefix if it's not already present
+	// Add the "pool/" prefix if it's not already present (unless --raw-id is used)
 	poolID := opts.Args.PoolID
-	if !strings.HasPrefix(poolID, "pool/") {
+	if !opts.RawID && !strings.HasPrefix(poolID, "pool/") {
 		poolID = "pool/" + poolID
 	}
 


### PR DESCRIPTION
## Summary

Adds a `--raw-id` flag to the `sandbox-pool set-desired` command to handle legacy pool IDs that don't follow the current `pool/pool-<id>` format.

## Motivation

During system evolution, pools were created with different ID formats:
- **Current**: `pool/pool-<id>` (set via explicit `entity.Ident`)
- **Legacy**: `sandbox_pool-<id>` (auto-generated from kind name)
- **Edge cases**: `e-<id>` (fallback when kind couldn't be determined)

The command currently auto-prepends `pool/` to IDs, which breaks when working with these legacy formats.

## Changes

- Added `--raw-id` boolean flag to skip automatic prefix normalization
- Updated ID normalization logic to respect the flag
- Updated comment to reflect conditional behavior

## Usage

```bash
# Standard usage (current pools)
m sandbox-pool set-desired pool-ABC 5

# Legacy pools with --raw-id
m sandbox-pool set-desired --raw-id sandbox_pool-ABC 5
m sandbox-pool set-desired --raw-id e-ABC 5
```

## Test plan

- [x] Code compiles successfully (`make bin/miren`)
- [x] Command works with standard pool IDs (pool-ABC)
- [ ] Manual test with legacy sandbox_pool-<id> format
- [ ] Manual test with e-<id> format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--raw-id` flag to the sandbox pool command, allowing users to provide pool IDs without automatic prefix normalization. When not used, the existing auto-prefix behavior is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->