### PR TITLE
Improve upload speeds for high-latency connections

### DIFF
--- a/hack/test-upload-speed.sh
+++ b/hack/test-upload-speed.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upload speed test for measuring baseline network performance
+# Usage: ./test-upload-speed.sh <host> [size_mb]
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <host> [size_mb]"
+    echo "Example: $0 my-remote-server.example.com 100"
+    exit 1
+fi
+
+HOST="$1"
+SIZE_MB="${2:-100}"
+REMOTE_USER="${REMOTE_USER:-phinze}"
+
+echo "Testing upload speed to $HOST (user: $REMOTE_USER)"
+echo "File size: ${SIZE_MB}MB"
+echo "---"
+
+# Create test file
+TEST_FILE="/tmp/upload-test-$(date +%s).bin"
+echo "Creating ${SIZE_MB}MB test file..."
+dd if=/dev/urandom of="$TEST_FILE" bs=1M count="$SIZE_MB" 2>&1 | grep -v records
+
+FILE_SIZE=$(stat -c%s "$TEST_FILE" 2>/dev/null || stat -f%z "$TEST_FILE" 2>/dev/null)
+echo "Test file size: $(numfmt --to=iec-i --suffix=B $FILE_SIZE 2>/dev/null || echo "$FILE_SIZE bytes")"
+echo ""
+
+# Test 1: Direct SCP upload (baseline)
+echo "Test 1: Direct SCP upload (no compression)"
+START=$(date +%s.%N)
+scp -o Compression=no "$TEST_FILE" "${REMOTE_USER}@${HOST}:/tmp/test-upload.bin" 2>&1 | tail -1 || true
+END=$(date +%s.%N)
+DURATION=$(awk "BEGIN {printf \"%.2f\", $END - $START}")
+SPEED=$(awk "BEGIN {printf \"%.2f\", $FILE_SIZE / $DURATION / 1024 / 1024}")
+echo "Duration: ${DURATION}s"
+echo "Speed: ${SPEED} MB/s"
+echo ""
+
+# Test 2: Tar stream through SSH pipe (similar to BuildFromTar)
+echo "Test 2: Tar stream through SSH pipe"
+START=$(date +%s.%N)
+tar -cf - -C "$(dirname $TEST_FILE)" "$(basename $TEST_FILE)" | \
+  ssh "${REMOTE_USER}@${HOST}" "cat > /tmp/test-stream.tar"
+END=$(date +%s.%N)
+DURATION=$(awk "BEGIN {printf \"%.2f\", $END - $START}")
+TAR_SIZE=$(ssh "${REMOTE_USER}@${HOST}" "stat -c%s /tmp/test-stream.tar")
+SPEED=$(awk "BEGIN {printf \"%.2f\", $TAR_SIZE / $DURATION / 1024 / 1024}")
+echo "Duration: ${DURATION}s"
+echo "Tar size: $(numfmt --to=iec-i --suffix=B $TAR_SIZE 2>/dev/null || echo "$TAR_SIZE bytes")"
+echo "Speed: ${SPEED} MB/s"
+echo "Overhead: $(awk "BEGIN {printf \"%.1f%%\", ($TAR_SIZE - $FILE_SIZE) * 100.0 / $FILE_SIZE}")"
+echo ""
+
+# Test 3: Piped gzip through SSH (compressed streaming)
+echo "Test 3: Gzipped stream through SSH pipe"
+START=$(date +%s.%N)
+gzip -c "$TEST_FILE" | \
+  ssh "${REMOTE_USER}@${HOST}" "cat > /tmp/test-gzip.gz"
+END=$(date +%s.%N)
+DURATION=$(awk "BEGIN {printf \"%.2f\", $END - $START}")
+GZ_SIZE=$(ssh "${REMOTE_USER}@${HOST}" "stat -c%s /tmp/test-gzip.gz")
+SPEED=$(awk "BEGIN {printf \"%.2f\", $GZ_SIZE / $DURATION / 1024 / 1024}")
+RATIO=$(awk "BEGIN {printf \"%.1f%%\", $GZ_SIZE * 100.0 / $FILE_SIZE}")
+echo "Duration: ${DURATION}s"
+echo "Compressed size: $(numfmt --to=iec-i --suffix=B $GZ_SIZE 2>/dev/null || echo "$GZ_SIZE bytes") (${RATIO} of original)"
+echo "Speed: ${SPEED} MB/s (of compressed data)"
+echo "Effective speed: $(awk "BEGIN {printf \"%.2f\", $FILE_SIZE / $DURATION / 1024 / 1024}") MB/s (of original data)"
+echo ""
+
+# Cleanup
+echo "Cleaning up..."
+rm -f "$TEST_FILE"
+ssh "${REMOTE_USER}@${HOST}" "rm -f /tmp/test-upload.bin /tmp/test-stream.tar /tmp/test-gzip.gz"
+
+echo "---"
+echo "Summary:"
+echo "  Direct SCP: ${SPEED} MB/s baseline"
+echo "  Tar streaming: Most similar to BuildFromTar's approach"
+echo "  Gzipped: Shows potential if compression is added"
+echo ""
+echo "Compare these speeds with your BuildFromTar performance to identify overhead"

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -40,13 +40,17 @@ func init() {
 	}
 
 	DefaultQUICConfig = quic.Config{
-		EnableDatagrams:       true,
-		MaxIncomingStreams:    1000,
-		MaxIncomingUniStreams: 1000,
-		Allow0RTT:             true,
-		KeepAlivePeriod:       10 * time.Second,
-		MaxIdleTimeout:        30 * time.Second,
-		Tracer:                qlog.DefaultConnectionTracer,
+		EnableDatagrams:                true,
+		MaxIncomingStreams:             1000,
+		MaxIncomingUniStreams:          1000,
+		Allow0RTT:                      true,
+		KeepAlivePeriod:                10 * time.Second,
+		MaxIdleTimeout:                 30 * time.Second,
+		Tracer:                         qlog.DefaultConnectionTracer,
+		InitialStreamReceiveWindow:     5 * 1024 * 1024,  // 5MB per stream
+		MaxStreamReceiveWindow:         20 * 1024 * 1024, // 20MB max per stream
+		InitialConnectionReceiveWindow: 10 * 1024 * 1024, // 10MB total
+		MaxConnectionReceiveWindow:     20 * 1024 * 1024, // 20MB total max
 	}
 
 	DefaultTransport.QUICConfig = &DefaultQUICConfig

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -309,16 +309,7 @@ func NewState(ctx context.Context, opts ...StateOption) (*State, error) {
 		transport:       &quic.Transport{Conn: udpConn},
 	}
 
-	qc := quic.Config{
-		EnableDatagrams:       true,
-		MaxIncomingStreams:    1000,
-		MaxIncomingUniStreams: 1000,
-		Allow0RTT:             true,
-		KeepAlivePeriod:       10 * time.Second,
-		Tracer:                qlog.DefaultConnectionTracer,
-	}
-
-	s.qc = qc
+	s.qc = DefaultQUICConfig
 
 	err = s.startListener(ctx, &so)
 	if err != nil {

--- a/pkg/rpc/stream/stream.go
+++ b/pkg/rpc/stream/stream.go
@@ -45,7 +45,7 @@ func StreamRecv[T any](fn func(T) error) SendStream[T] {
 	return &Receiver[T]{fn: fn}
 }
 
-const streamChunkSize = 1024 * 1024 // 1MB chunks for efficient streaming
+const streamChunkSize = 10 * 1024 * 1024 // 10MB chunks for efficient streaming over high-latency links
 
 type rscReader struct {
 	ctx    context.Context


### PR DESCRIPTION
## Summary

Addresses slow upload speeds when deploying to remote clusters by optimizing QUIC flow control and RPC streaming parameters.

**Problem:** Deploy uploads were running at ~361 KB/s vs 10+ MB/s baseline network performance - about 30× slower than expected.

**Root Cause:** RPC streaming uses a request/response pattern where the server pulls each chunk from the client. Each chunk requires a full network round-trip. With high latency (100ms+ RTT), this creates significant overhead.

## Changes

1. **Increase QUIC flow control windows** to support larger in-flight data:
   - `InitialStreamReceiveWindow: 5MB` (from default ~512KB)
   - `MaxStreamReceiveWindow: 20MB`
   - `InitialConnectionReceiveWindow: 10MB`
   - `MaxConnectionReceiveWindow: 20MB`
   
   These values are conservative for budget VMs (~20MB per connection) while still providing 4-10× improvement.

2. **Increase streaming chunk size** from 1MB to 10MB
   - Reduces round-trips for large transfers (84 chunks → 8 chunks for an 84MB artifact)
   - Saves multiple seconds of pure latency overhead

3. **Add test script** (`hack/test-upload-speed.sh`)
   - Measures baseline upload speeds (SCP, tar streaming, gzip)
   - Helps compare BuildFromTar performance against network baseline

## Testing Plan

- [x] Passes linting
- [ ] Test deploy to remote cluster and measure upload speed improvement
- [ ] Verify memory usage stays reasonable on budget VMs

## Performance Impact

**Expected improvements** (based on analysis):
- High-latency connections (100ms+ RTT): Significant improvement (5-10× faster)
- Low-latency connections (<10ms RTT): Minimal change, already near optimal
- Memory usage: ~20MB per active connection (acceptable for cloud VMs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a command-line upload speed test utility that runs three transfer methods, reports transfer rates, sizes, overheads, and cleans up artifacts.

* **Refactor**
  * Tuned QUIC receive window defaults to allow larger in-flight data for improved throughput.
  * Increased streaming chunk size to use larger transfer blocks, improving efficiency on high-latency links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->