### PR TITLE
Fix broken commit links in Slack notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "<${{ github.event.workflow_run.head_commit.url }}|View commit> • <${{ github.event.workflow_run.html_url }}|View test run>"
+                      "text": "<${{ github.event.workflow_run.repository.html_url }}/commit/${{ github.event.workflow_run.head_sha }}|View commit> • <${{ github.event.workflow_run.html_url }}|View test run>"
                     }
                   ]
                 }
@@ -251,7 +251,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Commit:*\n<${{ github.event.workflow_run.head_commit.url }}|${{ github.event.workflow_run.head_commit.message }}>"
+                      "text": "*Commit:*\n<${{ github.event.workflow_run.repository.html_url }}/commit/${{ github.event.workflow_run.head_sha }}|${{ github.event.workflow_run.head_commit.message }}>"
                     }
                   ]
                 },
@@ -436,7 +436,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Commit:*\n<${{ github.event.workflow_run.head_commit.url }}|${{ github.event.workflow_run.head_commit.message }}>"
+                      "text": "*Commit:*\n<${{ github.event.workflow_run.repository.html_url }}/commit/${{ github.event.workflow_run.head_sha }}|${{ github.event.workflow_run.head_commit.message }}>"
                     }
                   ]
                 },


### PR DESCRIPTION
## Summary

- Fixed broken commit links in Slack notifications that were showing as `<|View commit>`
- Changed from using non-existent `github.event.workflow_run.head_commit.url` to constructing the URL from `repository.html_url` and `head_sha`
- Applied fix to all three Slack notifications: test failures, Docker build failures, and upload failures

## Test plan

- Verified the correct properties using `gh api` to inspect actual workflow_run payloads
- Confirmed `head_commit.url` doesn't exist in the GitHub Actions context
- Confirmed `head_sha` and `repository.html_url` are available and can be combined to form the correct commit URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD notification workflow to improve commit link generation.

---

**Note:** This release contains no user-facing changes. Updates are internal infrastructure-related.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->