### PR TITLE
Log empty lines as just having a space

### DIFF
--- a/observability/logs.go
+++ b/observability/logs.go
@@ -69,9 +69,17 @@ func (l *PersistentLogWriter) Client() *http.Client {
 }
 
 func (l *PersistentLogWriter) WriteEntry(entity string, le LogEntry) error {
+	// VictoriaLogs requires a non-empty _msg field but we want to preserve
+	// empty log messages because they'll show up as blank lines in the output.
+	// So use a single space if empty
+	msg := le.Body
+	if msg == "" {
+		msg = " "
+	}
+
 	// Convert LogEntry to VictoriaLogs JSON format
-	logData := map[string]interface{}{
-		"_msg":     le.Body,
+	logData := map[string]any{
+		"_msg":     msg,
 		"_time":    le.Timestamp.UTC().Format(time.RFC3339Nano),
 		"entity":   entity,
 		"stream":   string(le.Stream),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty log messages to ensure proper processing by the logging system, where empty message bodies are now represented as a single space to maintain system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->