### PR TITLE
Move to a proper one-cell wide spinner

### DIFF
--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -37,12 +37,6 @@ func init() {
 var (
 	mirenBlue = "#3E53FB"
 	lightBlue = colortheory.ChangeLightness(mirenBlue, -10)
-	square    = "▰"
-
-	spinBlankStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
-		Light: "#111111",
-		Dark:  colortheory.ChangeLightness(mirenBlue, 25),
-	})
 
 	spinStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
 		Light: "#3E53FB",

--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -53,13 +53,7 @@ var (
 func line(str string) string {
 	var sb strings.Builder
 
-	for _, b := range str {
-		if b == ' ' {
-			sb.WriteString(spinBlankStyle.Render(square))
-		} else {
-			sb.WriteString(spinStyle.Render(square))
-		}
-	}
+	sb.WriteString(spinStyle.Render(str))
 
 	return sb.String()
 }
@@ -67,14 +61,18 @@ func line(str string) string {
 // Meter is the custom spinner animation
 var Meter = spinner.Spinner{
 	Frames: []string{
-		line("    "),
-		line("▰   "),
-		line("▰▰  "),
-		line("▰▰▰ "),
-		line(" ▰▰ "),
-		line("  ▰ "),
+		line("⠋"),
+		line("⠙"),
+		line("⠹"),
+		line("⠸"),
+		line("⠼"),
+		line("⠴"),
+		line("⠦"),
+		line("⠧"),
+		line("⠇"),
+		line("⠏"),
 	},
-	FPS: time.Second / 7, //nolint:mnd
+	FPS: time.Second / 10, //nolint:mnd
 }
 
 // Data types for UI


### PR DESCRIPTION
Turns out the paralellograms are in some really weird fonts and can't really be rendered right! So switch to dots which can be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated deploy UI spinner to a smoother Unicode-based animation for improved readability.
  * Made spinner rendering consistent across the whole status text (no per-character styling).
  * Increased animation frame rate for a quicker, more responsive spinner during deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->