### PR TITLE
clientconfig: Fix updating config when server starts

### DIFF
--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -107,12 +107,21 @@ func (c *Config) MarshalYAML() (interface{}, error) {
 }
 
 func NewConfig() *Config {
-	return &Config{
+	cfg := &Config{
 		clusters:           make(map[string]*ClusterConfig),
 		identities:         make(map[string]*IdentityConfig),
 		keys:               make(map[string]*KeyConfig),
 		unsavedLeafConfigs: make(map[string]*ConfigData),
 	}
+
+	// When creating a new config, assume it's going to be saved to the default path
+	configPath, loadConfigD, err := getConfigPath()
+	if err == nil {
+		cfg.sourcePath = configPath
+		cfg.loadConfigD = loadConfigD
+	}
+
+	return cfg
 }
 
 // IsEmpty checks if the configuration has no clusters defined
@@ -392,8 +401,6 @@ func LoadConfig() (*Config, error) {
 	if err != nil {
 		// If main config doesn't exist, try loading from config.d directory
 		config := NewConfig()
-		config.sourcePath = configPath
-		config.loadConfigD = loadConfigD
 
 		if loadConfigD {
 			if err := loadConfigDir(config); err != nil {

--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -471,6 +471,8 @@ func LoadConfigFrom(configPath string) (*Config, error) {
 
 	var config Config
 	config.sourcePath = configPath
+	config.loadConfigD = true
+
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}


### PR DESCRIPTION
The old method failed basic validation and cause the config to constantly lose it's active cluster indicator, which is what the old code was designed exactly to not do.

So instead, I've refactored this to just use the normal method, which is more likely to be what's expected anyway.

Fixes MIR-494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposes the resolved active config path and lets the app list per-cluster (leaf) configs; prefers the original user’s home when run via sudo.

* **Bug Fixes**
  * Automatically creates missing config instead of failing and improves error handling and logging.
  * Safer file-permission and ownership handling when creating or updating config files.

* **Chores**
  * Refactored config loading to better support loading a config directory and more robust initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->