### PR TITLE
Mark distributed mode as experimental in CLI help

### DIFF
--- a/cli/commands/server_config_cmds.go
+++ b/cli/commands/server_config_cmds.go
@@ -11,7 +11,7 @@ import (
 // ServerConfigGenerate generates a server configuration file
 func ServerConfigGenerate(ctx *Context, opts struct {
 	Output   string `short:"o" long:"output" description:"Output file path (defaults to stdout)"`
-	Mode     string `short:"m" long:"mode" description:"Server mode (standalone or distributed)" default:"standalone"`
+	Mode     string `short:"m" long:"mode" description:"Server mode: standalone (default), distributed (experimental)" default:"standalone"`
 	Defaults bool   `short:"d" long:"defaults" description:"Generate config with default values"`
 }) error {
 	var cfg *serverconfig.Config

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -6,7 +6,7 @@ package serverconfig
 // All fields are pointers to distinguish between set and unset values
 type CLIFlags struct {
 	ConfigFile                           *string  `long:"config" description:"Path to configuration file"`
-	Mode                                 *string  `long:"mode" short:"m" description:"Server mode (standalone, distributed)"`
+	Mode                                 *string  `long:"mode" short:"m" description:"Server mode: standalone (default), distributed (experimental)"`
 	ContainerdConfigBinaryPath           *string  `long:"containerd-binary" description:"Path to containerd binary"`
 	ContainerdConfigSocketPath           *string  `long:"containerd-socket" description:"Path to containerd socket"`
 	ContainerdConfigStartEmbedded        *bool    `long:"start-containerd" description:"Start embedded containerd daemon"`

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -17,7 +17,7 @@ configs:
         cli:
           long: mode
           short: m
-          description: Server mode (standalone, distributed)
+          description: "Server mode: standalone (default), distributed (experimental)"
         env: MIREN_MODE
         toml: mode
         validation:


### PR DESCRIPTION
## Summary

Updates the `--mode` flag description in the CLI to clearly indicate that distributed mode is experimental, while standalone is the default for the first release.

## Changes

- Updated `pkg/serverconfig/schema.yml` to change the mode description
- Regenerated `pkg/serverconfig/cli.gen.go` with the new description  
- Updated `cli/commands/server_config_cmds.go` to match

## Result

Help text now shows:
```
-m, --mode=    Server mode: standalone (default), distributed (experimental)
```

This makes it clear that standalone is the default and recommended mode for the first release, while distributed mode remains available but marked as experimental.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated server mode flag help text to clarify that standalone is the default mode and distributed mode is experimental.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->