### PR TITLE
Upgrade golangci-lint to v2.6.1 and Go to 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.5.0
+        version: v2.6.1
 
     - name: Check go.mod tidiness
       run: |

--- a/.iso/Dockerfile
+++ b/.iso/Dockerfile
@@ -1,6 +1,6 @@
 # Miren Runtime Build Environment
 
-FROM golang:1.24
+FROM golang:1.25
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ m app list
 
 ### ISO Environment
 The project uses **iso** for containerized development with all dependencies provided:
-- `.iso/Dockerfile` - Defines the build environment (Go 1.24, containerd, buildkit, gvisor, etc.)
+- `.iso/Dockerfile` - Defines the build environment (Go 1.25, containerd, buildkit, gvisor, etc.)
 - `.iso/services.yml` - Defines external service containers (MinIO for object storage)
 - All default `make` targets and `hack/` scripts run inside the isolated container
 - Services are automatically started and ready before commands run

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ghcr.io/mirendev/runsc:latest AS binaries
 
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache clang
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Miren runtime provides a platform for deploying and managing containerized a
 
 ### Prerequisites
 
-- Go 1.24+ (required for building)
+- Go 1.25+ (required for building)
 - iso (optional, for containerized development environment)
 
 ### Development Setup

--- a/cli/commands/commands_other.go
+++ b/cli/commands/commands_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package commands
 

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package commands
 

--- a/cli/commands/server_darwin.go
+++ b/cli/commands/server_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package commands
 

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package commands
 

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -393,7 +394,7 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 }
 
 func (e *EtcdComponent) waitForReady(ctx context.Context, host string, port int) {
-	endpoint := fmt.Sprintf("%s:%d", host, port)
+	endpoint := net.JoinHostPort(host, strconv.Itoa(port))
 
 	for i := 0; i < 30; i++ {
 		conn, err := net.DialTimeout("tcp", endpoint, 1*time.Second)

--- a/components/victorialogs/victorialogs_test.go
+++ b/components/victorialogs/victorialogs_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package victorialogs_test
 

--- a/controllers/disk/lsvd_mount_test.go
+++ b/controllers/disk/lsvd_mount_test.go
@@ -1,5 +1,4 @@
 //go:build linux && integration
-// +build linux,integration
 
 package disk
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       in {
         devShells.default = pkgs.mkShell {
           packages = [
-            pkgs.go_1_24
+            pkgs.go_1_25
             pkgs.golangci-lint
             pkgs.gotools
           ];

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module miren.dev/runtime
 
-go 1.24
+go 1.25
 
 require (
 	github.com/NimbleMarkets/ntcharts v0.3.1

--- a/hack/build-dist.sh
+++ b/hack/build-dist.sh
@@ -33,7 +33,7 @@ echo "Building portable Linux amd64 binary (version $version)..."
 
 # Create the Dockerfile content
 cat >"$DOCKERFILE" <<EOF
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Accept version as a build argument
 ARG VERSION

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package network
 

--- a/network/netns.go
+++ b/network/netns.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package network
 

--- a/network/noop_darwin.go
+++ b/network/noop_darwin.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package network
 

--- a/observability/integration_test.go
+++ b/observability/integration_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package observability_test
 

--- a/pkg/color/live_unix.go
+++ b/pkg/color/live_unix.go
@@ -1,7 +1,4 @@
 //go:build (darwin || dragonfly || freebsd || netbsd || openbsd) && !solaris && !illumos
-// +build darwin dragonfly freebsd netbsd openbsd
-// +build !solaris
-// +build !illumos
 
 package color
 

--- a/pkg/hey/requester/now_other.go
+++ b/pkg/hey/requester/now_other.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package requester
 

--- a/pkg/perf/count.go
+++ b/pkg/perf/count.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package perf
 

--- a/pkg/perf/group.go
+++ b/pkg/perf/group.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package perf
 

--- a/pkg/perf/perf.go
+++ b/pkg/perf/perf.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package perf
 

--- a/pkg/perf/perf_example_test.go
+++ b/pkg/perf/perf_example_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package perf_test
 

--- a/pkg/perf/perf_test.go
+++ b/pkg/perf/perf_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package perf_test
 

--- a/pkg/perf/record.go
+++ b/pkg/perf/record.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package perf
 

--- a/pkg/perf/record_amd64_test.go
+++ b/pkg/perf/record_amd64_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package perf_test
 

--- a/pkg/perf/record_test.go
+++ b/pkg/perf/record_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package perf_test
 

--- a/testdata/db-app/go.mod
+++ b/testdata/db-app/go.mod
@@ -1,5 +1,5 @@
 module db-app
 
-go 1.24
+go 1.25
 
 require github.com/lib/pq v1.10.9


### PR DESCRIPTION
## Summary

This PR upgrades golangci-lint from v2.5.0 to v2.6.1 and Go from 1.24 to 1.25, fixing all linter issues detected by the newer version.

## Changes

### Tooling Updates
- Updated `.github/workflows/test.yml` to use golangci-lint v2.6.1
- Upgraded Go from 1.24 to 1.25 across all build configurations
  - Updated `go.mod` files
  - Updated Dockerfiles (`.iso/Dockerfile`, `Dockerfile`, `hack/build-dist.sh`)
  - Updated `flake.nix` for Nix development environment
  - Updated documentation (README.md, CLAUDE.md)

### Code Fixes

1. **Deprecated build tags** (21 files)
   - Removed old `// +build` directives that are no longer needed
   - Modern `//go:build` directives already exist and are sufficient
   - Affected files across: `cli/`, `components/`, `controllers/`, `network/`, `observability/`, `pkg/`

2. **IPv6 incompatible address formatting** (`components/etcd/etcd.go:396`)
   - Fixed `fmt.Sprintf("%s:%d", host, port)` which doesn't work with IPv6 addresses
   - Now using `net.JoinHostPort(host, strconv.Itoa(port))` which properly handles both IPv4 and IPv6

## Root Cause Analysis

**Version mismatch between CI and local:**
- CI was running golangci-lint v2.5.0
- Local development (the nix flake at least) uses v2.6.1
- Lint issues existed in the codebase but were not caught by v2.5.0
- PRs passed CI, but failed locally with `make lint`

## Testing

- ✅ `make lint` passes with v2.6.1 (0 issues)
- ✅ `make bin/miren` builds successfully with Go 1.25
- ✅ All files properly formatted
- ✅ CI will verify full test suite with new versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to 1.25 across project files, Docker images, and dev environment.
  * Bumped linter version used in CI.
  * Modernized Go build-tag syntax throughout the codebase and applied minor internal refinements (e.g., host/port handling).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->