### PR TITLE
Remove QR code from login flow

### DIFF
--- a/cli/commands/login.go
+++ b/cli/commands/login.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mdp/qrterminal/v3"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/cloudauth"
 )
@@ -116,7 +115,6 @@ func Login(ctx *Context, opts struct {
 	IdentityName string `short:"i" long:"identity" description:"Name for this identity in config" default:"cloud"`
 	KeyName      string `short:"k" long:"key-name" description:"Name for the authentication key" default:"miren-cli"`
 	NoSave       bool   `long:"no-save" description:"Don't save credentials to config file"`
-	NoQR         bool   `long:"no-qr" description:"Don't display QR code"`
 }) error {
 	// Initialize device flow
 	ctx.Info("Initiating device flow authentication...")
@@ -127,23 +125,7 @@ func Login(ctx *Context, opts struct {
 
 	// Display instructions to user
 	if initResp.VerificationURLComplete != "" {
-		// Display QR code if we have a complete URL and QR is not disabled
-		if !opts.NoQR {
-			ctx.Completed("Scan this QR code with your phone to authenticate:")
-			ctx.Info("")
-			// Generate ASCII QR code to stdout
-			qrterminal.GenerateWithConfig(initResp.VerificationURLComplete, qrterminal.Config{
-				Level:     qrterminal.L,
-				Writer:    os.Stdout,
-				BlackChar: qrterminal.BLACK,
-				WhiteChar: qrterminal.WHITE,
-				QuietZone: 1,
-			})
-			ctx.Info("")
-			ctx.Info("Or use one of these methods:")
-		} else {
-			ctx.Completed("Please authenticate using one of these methods:")
-		}
+		ctx.Completed("Please authenticate using one of these methods:")
 		ctx.Info("")
 		ctx.Info("Option 1: Visit this URL (code included):")
 		ctx.Info("  %s", initResp.VerificationURLComplete)
@@ -153,7 +135,6 @@ func Login(ctx *Context, opts struct {
 		ctx.Info("  Code: %s", initResp.UserCode)
 		ctx.Info("")
 	} else {
-		// Show the traditional flow with separate URL and code
 		ctx.Completed("Please visit the following URL to authenticate:")
 		ctx.Info("  %s", initResp.VerificationURL)
 		ctx.Info("")

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,6 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/mdlayher/genetlink v1.3.2
 	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42
-	github.com/mdp/qrterminal/v3 v3.2.1
 	github.com/miekg/dns v1.1.63
 	github.com/mitchellh/cli v1.1.5
 	github.com/mitchellh/go-testing-interface v1.14.1
@@ -249,7 +248,6 @@ require (
 	gotest.tools/v3 v3.5.1 // indirect
 	k8s.io/apimachinery v0.31.2 // indirect
 	k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3 // indirect
-	rsc.io/qr v0.2.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/knftables v0.0.18 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,6 @@ github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 h1:A1Cq6Ysb0GM0
 github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42/go.mod h1:BB4YCPDOzfy7FniQ/lxuYQ3dgmM2cZumHbK8RpTjN2o=
 github.com/mdlayher/socket v0.5.1 h1:VZaqt6RkGkt2OE9l3GcC6nZkqD3xKeQLyfleW/uBcos=
 github.com/mdlayher/socket v0.5.1/go.mod h1:TjPLHI1UgwEv5J1B5q0zTZq12A/6H7nKmtTanQE37IQ=
-github.com/mdp/qrterminal/v3 v3.2.1 h1:6+yQjiiOsSuXT5n9/m60E54vdgFsw0zhADHhHLrFet4=
-github.com/mdp/qrterminal/v3 v3.2.1/go.mod h1:jOTmXvnBsMy5xqLniO0R++Jmjs2sTm9dFSuQ5kpz/SU=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.1.63 h1:8M5aAw6OMZfFXTT7K5V0Eu5YiiL8l7nUAkyN6C9YwaY=
 github.com/miekg/dns v1.1.63/go.mod h1:6NGHfjhpmr5lt3XPLuyfDJi5AXbNIPM9PY6H6sF1Nfs=
@@ -869,8 +867,6 @@ k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3 h1:b2FmK8YH+QEwq/Sy2uAEhmqL5nPfGYbJOcaqjeYYZoA=
 k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
-rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/knftables v0.0.18 h1:6Duvmu0s/HwGifKrtl6G3AyAPYlWiZqTgS8bkVMiyaE=


### PR DESCRIPTION
## Summary
- Removed QR code display from `miren login` command
- Removed `--no-qr` flag (no longer needed)
- Removed qrterminal dependency and related imports
- Simplified authentication flow to show URL options only

## Changes
- Updated `cli/commands/login.go`:
  - Removed QR code generation code
  - Removed `--no-qr` command-line flag
  - Removed `github.com/mdp/qrterminal/v3` import
- Ran `go mod tidy` to clean up unused dependencies

## Test plan
- [ ] Verify `miren login` still works and displays authentication URLs
- [ ] Confirm QR code is no longer displayed
- [ ] Ensure `--no-qr` flag is removed from help text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified device authentication: login now displays URL and verification code via text instructions instead of QR code display.

* **Chores**
  * Removed unused QR code-related dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->