### PR TITLE
Fix race condition in TestRunnerCoordinatorIntegration

### DIFF
--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -107,13 +107,21 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 			res, err = eac.Get(ctx, nodeId)
 			require.NoError(t, err, "failed to get node entity after runner started")
 			require.True(t, res.HasEntity(), "node entity not found after runner started")
+			// Verify status field is present
+			node := entity.New(res.Entity().Attrs())
+			_, ok := node.Get(compute.NodeStatusId)
+			require.True(t, ok, "node entity status not set after runner started")
 			goto nodeReady
 		case <-pollTimeout:
-			t.Fatal("timeout waiting for node entity to be created")
+			t.Fatal("timeout waiting for node entity to be created with status")
 		case <-pollTicker.C:
 			res, err = eac.Get(ctx, nodeId)
 			if err == nil && res.HasEntity() {
-				goto nodeReady
+				// Check that status field is present before proceeding
+				node := entity.New(res.Entity().Attrs())
+				if _, ok := node.Get(compute.NodeStatusId); ok {
+					goto nodeReady
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes a flaky test that occasionally failed in CI with the error:
```
integration_test.go:128: 
    Error Trace:    /src/components/runner/integration_test.go:128
    Error:          Should be true
    Test:           TestRunnerCoordinatorIntegration
```

## Root Cause
The test had a race condition where it polled until the node entity existed, but didn't verify that the `NodeStatusId` field was populated. 

The runner creates the node entity in two separate operations in `runner.go:setupEntity()`:
1. `CreateOrUpdate()` creates the entity (line 264)
2. `UpdateAttrs()` sets the status field (lines 269-274)

The test could exit the polling loop after step 1 but before step 2, causing the assertion at line 128 to fail.

## Solution
Updated the polling logic in `integration_test.go` to wait for both:
- The entity to exist (`res.HasEntity()`)
- The `NodeStatusId` field to be present

This ensures the test doesn't proceed until the node entity is fully initialized.

## Test Results
Verified the fix by running the test 5 consecutive times - all passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test to verify node status field presence after startup, with improved timeout error messaging for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->