### PR TITLE
Fix dev-exec flag parsing conflict with iso run

### DIFF
--- a/hack/dev-exec
+++ b/hack/dev-exec
@@ -42,18 +42,18 @@ fi
 
 # Guard: if no arguments, drop into an interactive shell
 if [ "$#" -eq 0 ]; then
-  ISO_SESSION="$SESSION" iso run bash -c "cd /src && exec su dev"
+  ISO_SESSION="$SESSION" iso run -- bash -c "cd /src && exec su dev"
   exit
 fi
 
 # Special case: dev-server needs to run as root for process management
 if [[ "$1" == "bash" && "$2" == "hack/dev-server" ]]; then
   # Run dev-server as root (needs to manage root-owned server process)
-  ISO_SESSION="$SESSION" iso run "$@"
+  ISO_SESSION="$SESSION" iso run -- "$@"
 # Special case: interactive bash shell needs proper TTY (no -c flag)
 elif [[ "$1" == "bash" && $# -eq 1 ]]; then
   # Use exec su dev for proper interactive shell with job control
-  ISO_SESSION="$SESSION" iso run bash -c "cd /src && exec su dev"
+  ISO_SESSION="$SESSION" iso run -- bash -c "cd /src && exec su dev"
 else
   # Build a properly quoted command string to preserve arguments with spaces/special chars
   # Use -s /bin/bash to ensure ANSI-C quoting ($'...' from printf %q) is supported
@@ -61,5 +61,5 @@ else
   for arg in "$@"; do
     CMD+="$(printf '%q ' "$arg")"
   done
-  ISO_SESSION="$SESSION" iso run su -s /bin/bash dev -c "$CMD"
+  ISO_SESSION="$SESSION" iso run -- su -s /bin/bash dev -c "$CMD"
 fi


### PR DESCRIPTION
## Summary

Fixes a bug in `hack/dev-exec` where the `-s` flag was being intercepted by `iso run`'s flag parser instead of being passed through to the `su` command.

## Problem

When running `./hack/dev-exec whoami`, the script would fail with:
```
Error: failed to create fresh service container clickhouse: Error response from daemon: 
Invalid container name (runtime-/bin/bash_clickhouse-fresh-...), 
only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed
```

**Root cause:** The command `iso run su -s /bin/bash dev -c "$CMD"` was being parsed incorrectly:
- `iso run` has a `--session/-s` flag
- The flag parser captured `-s /bin/bash` as the session name
- This overrode the `ISO_SESSION` environment variable
- Service containers were looked up with session name `/bin/bash` instead of `dev-runtime`
- Container names like `runtime-/bin/bash_etcd` are invalid (contain `/`)
- Script tried to create fresh services instead of using the running persistent ones

## Solution

Add `--` separator before commands in all `iso run` invocations to stop flag parsing:
```bash
ISO_SESSION="$SESSION" iso run -- su -s /bin/bash dev -c "$CMD"
```

This ensures all arguments after `--` are treated as the command, not as flags to `iso run`.

## Test plan

- [x] `./hack/dev-exec whoami` - returns "dev"
- [x] `./hack/dev-exec pwd` - returns "/src"
- [x] `./hack/dev-exec echo "test with spaces"` - works correctly
- [x] `./hack/dev-exec ls -la` - flags are preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument handling in development command execution to correctly process flags and parameters that begin with dashes, ensuring consistent and reliable parameter passing across all command invocation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->