### PR TITLE
Fix release build VCS stamping in iso containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,15 +137,7 @@ generate-check: ## Verify go generate is up to date
 #
 
 release-data: ## Create release package tar.gz (iso)
-	iso run bash -c "make bin/miren && mkdir -p /tmp/package && \
-		cp bin/miren /tmp/package && \
-		cp /usr/local/bin/runc /tmp/package && \
-		cp /usr/local/bin/containerd-shim-runsc-v1 /tmp/package && \
-		cp /usr/local/bin/containerd-shim-runc-v2 /tmp/package && \
-		cp /usr/local/bin/containerd /tmp/package && \
-		cp /usr/local/bin/nerdctl /tmp/package && \
-		cp /usr/local/bin/ctr /tmp/package && \
-		tar -C /tmp/package -czf /workspace/release.tar.gz ."
+	bash hack/release-data.sh
 
 image: ## Export Docker image (iso)
 	iso run sh -c "docker save runtime-shell | gzip > /workspace/tmp/miren-image.tar.gz"

--- a/hack/build-ci.sh
+++ b/hack/build-ci.sh
@@ -46,5 +46,4 @@ go build -ldflags "\
   -X miren.dev/runtime/version.Version=$version \
   -X miren.dev/runtime/version.Commit=$commit \
   -X miren.dev/runtime/version.BuildDate=$build_date" \
-  -buildvcs=false \
   -o bin/miren ./cmd/miren

--- a/hack/package-release.sh
+++ b/hack/package-release.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+# Configure git to trust the mounted source directory for VCS stamping
+git config --global --add safe.directory /src
+
 echo "Building miren binary..."
 bash hack/build-ci.sh
 


### PR DESCRIPTION
## Summary
Fixes the release workflow failure: `error obtaining VCS status: exit status 128`

The issue was that git refused to access the repository when the source directory is mounted into the iso container due to ownership mismatch. This prevented Go's automatic VCS stamping (`-buildvcs`) from working.

## Solution
Configure git to trust the `/src` directory at the start of `hack/package-release.sh`. This allows Go to embed VCS information (`vcs.revision`, `vcs.time`, `vcs.modified`) into the binary without modifying host filesystem permissions.

## Changes
- `hack/package-release.sh`: Add `git config --global safe.directory /src`
- `hack/build-ci.sh`: Remove `-buildvcs=false` flag to enable VCS stamping
- `Makefile`: Simplify `release-data` target to use existing `hack/release-data.sh`

## Test Plan
- [x] Verified `make release-data` builds successfully
- [x] Confirmed binary includes VCS info (`go version -m bin/miren` shows `vcs.revision`, `vcs.time`, `vcs.modified`)
- [x] Verified host filesystem ownership unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved packaging steps into an external script and added a confirmation message after image export for clearer feedback.
  * Ensured VCS information is embedded during compilation to improve version metadata.
  * Added trusted-directory configuration to improve reliability of builds in containerized environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->