### PR TITLE
Fix apt cache tar warning in lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,12 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive apt-get update
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang llvm
 
+    - name: Clean up apt lock files
+      run: |
+        # Remove lock files and partial directories to prevent cache save errors
+        sudo rm -f /var/cache/apt/archives/lock /var/lib/apt/lists/lock
+        sudo rm -rf /var/cache/apt/archives/partial /var/lib/apt/lists/partial
+
     - name: Cache Go tools
       id: cache-go-tools
       uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Fixes the tar warning that appears in the lint job post-cleanup
- Removes apt lock files and partial directories before cache save
- Preserves the apt cache functionality for faster CI runs

## Problem
The lint job was showing this warning during post-job cleanup:
```
Failed to save: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2
```

Analysis of the workflow logs showed tar was failing on:
- `/var/cache/apt/archives/lock` - Permission denied
- `/var/cache/apt/archives/partial` - Permission denied  
- `/var/lib/apt/lists/lock` - Permission denied
- `/var/lib/apt/lists/partial` - Permission denied

## Solution
Added a cleanup step that removes these lock files and partial directories after package installation. These are just operational metadata created by apt and don't need to be cached. The actual `.deb` packages and package lists remain intact for caching.

## Test plan
- [x] Wait for CI to run and verify the warning no longer appears in the lint job
- [x] Verify the apt cache still works (check for cache hits on subsequent runs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline reliability by cleaning up system cache during dependency installation to prevent cache-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->