### PR TITLE
Make List RPC resilient to missing entities

### DIFF
--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -549,7 +549,10 @@ func (e *EntityServer) List(ctx context.Context, req *entityserver_v1alpha.Entit
 	var ret []*entityserver_v1alpha.Entity
 	for i, entity := range entities {
 		if entity == nil {
-			return fmt.Errorf("entity not found: %s", ids[i])
+			e.Log.Error("entity in index but not in store, skipping",
+				"id", ids[i],
+				"index", index)
+			continue
 		}
 
 		var rpcEntity entityserver_v1alpha.Entity

--- a/servers/entityserver/entityserver_test.go
+++ b/servers/entityserver/entityserver_test.go
@@ -394,10 +394,11 @@ func TestEntityServer_List_WithMissingEntity(t *testing.T) {
 		return []*entity.Entity{nil}, nil
 	}
 
-	// List should fail when GetEntities returns nil entry
-	_, err = sc.List(ctx, entity.Keyword(entity.EntityKind, "test"))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "entity not found")
+	// List should succeed and skip the missing entity
+	resp, err := sc.List(ctx, entity.Keyword(entity.EntityKind, "test"))
+	require.NoError(t, err)
+	results := resp.Values()
+	assert.Len(t, results, 0, "should return empty list when all entities are missing")
 }
 
 // TestEntityServer_List_NestedIndexCleanup tests that DeleteEntity properly cleans up


### PR DESCRIPTION
## Summary

- Changed List RPC to skip missing entities instead of failing the entire operation
- Logs errors when entities are in the index but missing from the store
- Updated test to verify the new resilient behavior

## Context

During the Nov 6 incident, stale index entries caused List operations to fail with "entity not found" errors. This blocked pool controllers from reconciling, preventing recovery even after reindex cleaned up the stale entries.

With this change, controllers can make forward progress with partial data while ops teams are alerted to index corruption via error logs.

## Changes

- `servers/entityserver/entityserver.go:551-556`: Skip nil entities with error log instead of returning error
- `servers/entityserver/entityserver_test.go:397-401`: Update `TestEntityServer_List_WithMissingEntity` to expect success

## Test plan

- [x] Unit tests pass: `./hack/it servers/entityserver`
- [x] Linter passes: `make lint`
- [x] Test verifies missing entities are skipped gracefully
- [ ] Monitor error logs in staging for any index corruption alerts

## Related

Addresses the P1 action item from the Nov 6 reindex incident: https://gist.github.com/phinze/292a5c1ff5f5d005fc520cce6de960d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data retrieval robustness: when unavailable entries are encountered, the system now logs the issue and continues processing remaining entries instead of terminating the operation. This improves reliability when dealing with incomplete or temporarily unavailable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->