### PR TITLE
controller: fix concurrency entity processing races

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -294,13 +294,13 @@ func (c *ReconcileController) runWorker(ctx context.Context) {
 			if entry, inFlight := c.inFlight[event.Id]; inFlight {
 				// Entity is already in-flight, queue event to the in-flight entry
 				entry.pendingEvents = append(entry.pendingEvents, event)
-				c.inFlightMu.Unlock()
 				c.Log.Debug("Entity already in-flight, queuing to pending events",
 					"entity", event.Id,
 					"worker", WorkerId(ctx),
 					"inFlightRev", entry.revision,
 					"eventRev", event.Rev,
 					"pendingCount", len(entry.pendingEvents))
+				c.inFlightMu.Unlock()
 				continue
 			}
 


### PR DESCRIPTION
The system needs multilpe workers per controller to function currently (workers occasionally block to wait for a condition). We have always had a situation where 2 workers could concurrently be processing the same entity, which is super bad.

This solves the problem by doing a sort of inverted work stealing. If a worker detects that an event is for an entity that is currently being processed by another worker, it enqueues that event FOR THAT OTHER WORKER. Then when a worker finishes it's work, it checks if anyone dropped additional events for processing and it handles them there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures events for the same entity are processed sequentially (queued when already in-flight), preventing duplicate/concurrent handling and improving reliability.
* **Tests**
  * Adds tests validating per-entity sequencing and concurrency limits across multiple workers and entities, ensuring no cross-entity interference and correct event ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->