### PR TITLE
build: propogate service specific env vars into the config

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -138,6 +138,17 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 					})
 				}
 			}
+
+			// Convert service-specific environment variables
+			if len(serviceConfig.EnvVars) > 0 {
+				svc.Env = make([]core_v1alpha.Env, 0, len(serviceConfig.EnvVars))
+				for _, envVar := range serviceConfig.EnvVars {
+					svc.Env = append(svc.Env, core_v1alpha.Env{
+						Key:   envVar.Name,
+						Value: envVar.Value,
+					})
+				}
+			}
 		}
 
 		services = append(services, svc)


### PR DESCRIPTION
We already had the space for them in the core Service Config, we should weren't pulling them in from the appconfig.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-service environment variables in service configuration, enabling runtime environment setup for each service.

* **Tests**
  * Added test cases to verify correct environment variable handling for single and multiple services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->