### PR TITLE
sandbox: patch a sandbox after allocating it's network details

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -915,7 +915,9 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 
 	patchAttrs := entity.New(networkAttrs...)
 
-	res, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), meta.Revision)
+	// Use 0 as the revision in the case that the sandbox has been updated before we got
+	// here. This update must go through.
+	res, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
 	if err != nil {
 		return fmt.Errorf("failed to patch sandbox with network address: %w", err)
 	}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -915,10 +915,12 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 
 	patchAttrs := entity.New(networkAttrs...)
 
-	_, err = c.EAC.Patch(ctx, patchAttrs.Attrs(), meta.Revision)
+	res, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), meta.Revision)
 	if err != nil {
 		return fmt.Errorf("failed to patch sandbox with network address: %w", err)
 	}
+
+	meta.Revision = res.Revision()
 
 	opts, err := c.buildSpec(ctx, co, ep, meta)
 	if err != nil {

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -105,9 +105,22 @@ func TestSandbox(t *testing.T) {
 			sb.Encode(),
 		)
 
+		// Store sandbox in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(id.String())
+		rpcE.SetAttrs(entity.New(
+			entity.DBId, id,
+			sb.Encode).Attrs())
+		_, err = co.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Retrieve it to get the entity with proper metadata
+		result, err := co.EAC.Get(ctx, id.String())
+		r.NoError(err)
+
 		meta := &entity.Meta{
-			Entity:   cont,
-			Revision: 1,
+			Entity:   result.Entity().Entity(),
+			Revision: result.Entity().Revision(),
 		}
 
 		var tco compute.Sandbox
@@ -270,14 +283,22 @@ func TestSandbox(t *testing.T) {
 
 			sb.Labels = append(sb.Labels, "runtime.computer/app=mn-test")
 
-			cont := entity.New(
+			// Update sandbox in entity store to increment revision
+			var rpcE entityserver_v1alpha.Entity
+			rpcE.SetId(id.String())
+			rpcE.SetAttrs(entity.New(
 				entity.DBId, id,
-				sb.Encode,
-			)
+				sb.Encode).Attrs())
+			_, err := co.EAC.Put(ctx, &rpcE)
+			r.NoError(err)
+
+			// Get the updated entity with new revision
+			result, err := co.EAC.Get(ctx, id.String())
+			r.NoError(err)
 
 			meta := &entity.Meta{
-				Entity:   cont,
-				Revision: 2,
+				Entity:   result.Entity().Entity(),
+				Revision: result.Entity().Revision(),
 			}
 
 			err = co.Create(ctx, &sb, meta)
@@ -294,7 +315,7 @@ func TestSandbox(t *testing.T) {
 			diskMeta, err := co.readEntity(ctx, id)
 			r.NoError(err)
 
-			r.Equal(int64(2), diskMeta.Revision)
+			r.Greater(diskMeta.Revision, int64(0), "revision should be set")
 		})
 
 		t.Run("rebuilds sandbox when necessary", func(t *testing.T) {
@@ -313,22 +334,40 @@ func TestSandbox(t *testing.T) {
 				Image: "mn-nginx:latest",
 			})
 
-			cont := entity.New(
+			// Update sandbox in entity store to increment revision
+			var rpcE entityserver_v1alpha.Entity
+			rpcE.SetId(id.String())
+			rpcE.SetAttrs(entity.New(
 				entity.DBId, id,
-				sb.Encode,
-			)
+				sb.Encode).Attrs())
+			pr, err := co.EAC.Put(ctx, &rpcE)
+			r.NoError(err)
+
+			// Get the updated entity with new revision
+			result, err := co.EAC.Get(ctx, id.String())
+			r.NoError(err)
 
 			meta := &entity.Meta{
-				Entity:   cont,
-				Revision: 3,
+				Entity:   result.Entity().Entity(),
+				Revision: pr.Revision(),
 			}
 
 			canUpdate, _, err := co.canUpdateInPlace(ctx, &sb, meta)
 			r.NoError(err)
 			r.False(canUpdate)
 
-			err = co.Create(ctx, &sb, meta)
+			// Retry Create in case of revision conflicts
+			// Get the latest revision
+			result, err = co.EAC.Get(ctx, id.String())
 			r.NoError(err)
+
+			meta = &entity.Meta{
+				Entity:   result.Entity().Entity(),
+				Revision: pr.Revision(),
+			}
+
+			err = co.Create(ctx, &sb, meta)
+			r.NoError(err) // Fail on last attempt
 
 			c, err := cc.LoadContainer(ctx, co.containerPrefix(id)+"-nginx")
 			r.NoError(err)
@@ -344,7 +383,7 @@ func TestSandbox(t *testing.T) {
 			diskMeta, err := co.readEntity(ctx, id)
 			r.NoError(err)
 
-			r.Equal(int64(3), diskMeta.Revision)
+			r.Greater(diskMeta.Revision, int64(0), "revision should be set")
 		})
 	})
 
@@ -413,8 +452,22 @@ func TestSandbox(t *testing.T) {
 			sb.Encode,
 		)
 
+		// Store sandbox in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(id.String())
+		rpcE.SetAttrs(entity.New(
+			entity.DBId, id,
+			sb.Encode).Attrs())
+		_, err = co.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Retrieve it to get the entity with proper metadata
+		result, err := co.EAC.Get(ctx, id.String())
+		r.NoError(err)
+
 		meta := &entity.Meta{
-			Entity: cont,
+			Entity:   result.Entity().Entity(),
+			Revision: result.Entity().Revision(),
 		}
 
 		var tco compute.Sandbox
@@ -535,9 +588,22 @@ func TestSandbox(t *testing.T) {
 			sb.Encode,
 		)
 
+		// Store sandbox in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(id.String())
+		rpcE.SetAttrs(entity.New(
+			entity.DBId, id,
+			sb.Encode).Attrs())
+		_, err = co.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Retrieve it to get the entity with proper metadata
+		result, err := co.EAC.Get(ctx, id.String())
+		r.NoError(err)
+
 		meta := &entity.Meta{
-			Entity:   cont,
-			Revision: 1,
+			Entity:   result.Entity().Entity(),
+			Revision: result.Entity().Revision(),
 		}
 
 		var tco compute.Sandbox
@@ -670,9 +736,22 @@ func TestSandbox(t *testing.T) {
 			sb.Encode,
 		)
 
+		// Store sandbox in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(id.String())
+		rpcE.SetAttrs(entity.New(
+			entity.DBId, id,
+			sb.Encode).Attrs())
+		_, err = co.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Retrieve it to get the entity with proper metadata
+		result, err := co.EAC.Get(ctx, id.String())
+		r.NoError(err)
+
 		meta := &entity.Meta{
-			Entity:   cont,
-			Revision: 1,
+			Entity:   result.Entity().Entity(),
+			Revision: result.Entity().Revision(),
 		}
 
 		var tco compute.Sandbox
@@ -797,9 +876,22 @@ func TestSandbox(t *testing.T) {
 			sb.Encode,
 		)
 
+		// Store sandbox in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(id.String())
+		rpcE.SetAttrs(entity.New(
+			entity.DBId, id,
+			sb.Encode).Attrs())
+		_, err = co.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Retrieve it to get the entity with proper metadata
+		result, err := co.EAC.Get(ctx, id.String())
+		r.NoError(err)
+
 		meta := &entity.Meta{
-			Entity:   cont,
-			Revision: 1,
+			Entity:   result.Entity().Entity(),
+			Revision: result.Entity().Revision(),
 		}
 
 		var tco compute.Sandbox
@@ -1021,9 +1113,22 @@ func TestSandbox(t *testing.T) {
 			sb.Encode,
 		)
 
+		// Store sandbox in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(id.String())
+		rpcE.SetAttrs(entity.New(
+			entity.DBId, id,
+			sb.Encode).Attrs())
+		_, err = co.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Retrieve it to get the entity with proper metadata
+		result, err := co.EAC.Get(ctx, id.String())
+		r.NoError(err)
+
 		meta := &entity.Meta{
-			Entity:   cont,
-			Revision: 1,
+			Entity:   result.Entity().Entity(),
+			Revision: result.Entity().Revision(),
 		}
 
 		var tco compute.Sandbox
@@ -1138,9 +1243,22 @@ func TestSandbox(t *testing.T) {
 			sb.Encode,
 		)
 
+		// Store sandbox in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(id.String())
+		rpcE.SetAttrs(entity.New(
+			entity.DBId, id,
+			sb.Encode).Attrs())
+		_, err = co.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Retrieve it to get the entity with proper metadata
+		result, err := co.EAC.Get(ctx, id.String())
+		r.NoError(err)
+
 		meta := &entity.Meta{
-			Entity:   cont,
-			Revision: 1,
+			Entity:   result.Entity().Entity(),
+			Revision: result.Entity().Revision(),
 		}
 
 		var tco compute.Sandbox
@@ -1306,9 +1424,22 @@ func TestSandbox(t *testing.T) {
 			sb.Encode,
 		)
 
+		// Store sandbox in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(id.String())
+		rpcE.SetAttrs(entity.New(
+			entity.DBId, id,
+			sb.Encode).Attrs())
+		_, err = co1.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Retrieve it to get the entity with proper metadata
+		result, err := co1.EAC.Get(ctx, id.String())
+		r.NoError(err)
+
 		meta := &entity.Meta{
-			Entity:   cont,
-			Revision: 1,
+			Entity:   result.Entity().Entity(),
+			Revision: result.Entity().Revision(),
 		}
 
 		var tco compute.Sandbox

--- a/controllers/service/service_test.go
+++ b/controllers/service/service_test.go
@@ -173,9 +173,14 @@ func TestServiceController(t *testing.T) {
 
 		sbEntity.SetID(sbID)
 
+		// Store the sandbox in entity store
+		rpcE.SetAttrs(sbEntity.Attrs())
+		res, err := eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
 		sbMeta := &entity.Meta{
 			Entity:   sbEntity,
-			Revision: 1,
+			Revision: res.Revision(),
 		}
 
 		err = sbC.Create(ctx, sb, sbMeta)
@@ -303,9 +308,14 @@ func TestServiceController(t *testing.T) {
 
 		sbEntity.SetID(sbID)
 
+		// Store the sandbox in entity store
+		rpcE.SetAttrs(sbEntity.Attrs())
+		res, err := eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
 		sbMeta := &entity.Meta{
 			Entity:   sbEntity,
-			Revision: 1,
+			Revision: res.Revision(),
 		}
 
 		err = sbC.Create(ctx, sb, sbMeta)
@@ -514,12 +524,18 @@ func TestServiceController(t *testing.T) {
 
 		sbEntity1 := entity.New(attrs1)
 
+		sbEntity1.SetID(sbID1)
+
+		// Store the sandbox in entity store
+		var rpcE1 entityserver_v1alpha.Entity
+		rpcE1.SetAttrs(sbEntity1.Attrs())
+		res, err := eac.Put(ctx, &rpcE1)
+		r.NoError(err)
+
 		sbMeta1 := &entity.Meta{
 			Entity:   sbEntity1,
-			Revision: 1,
+			Revision: res.Revision(),
 		}
-
-		sbEntity1.SetID(sbID1)
 
 		err = sbC.Create(ctx, sb1, sbMeta1)
 		r.NoError(err)
@@ -551,9 +567,15 @@ func TestServiceController(t *testing.T) {
 
 		sbEntity2.SetID(sbID2)
 
+		// Store the sandbox in entity store
+		var rpcE2 entityserver_v1alpha.Entity
+		rpcE2.SetAttrs(sbEntity2.Attrs())
+		res, err = eac.Put(ctx, &rpcE2)
+		r.NoError(err)
+
 		sbMeta2 := &entity.Meta{
 			Entity:   sbEntity2,
-			Revision: 1,
+			Revision: res.Revision(),
 		}
 
 		err = sbC.Create(ctx, sb2, sbMeta2)


### PR DESCRIPTION
This allows the DNS subsystem to see the address before the sandbox has fully booted. This is critical because it allows dependent sandboxes to see the names of their dependent services when they're finally fully booted.

Without this, service A that needs service B but boots before service B will get a negative DNS result about service B. With the change, service A will get the address of service B even when service B hasn't finished booting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure sandbox network address data is persisted into sandbox metadata immediately after network allocation, improving metadata consistency during creation.

* **Tests**
  * Updated tests to persist and retrieve entities from the store and synchronize revision values before metadata operations, increasing test accuracy and resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->