### PR TITLE
Handle crashy apps - sandbox monitoring and activator fail-fast

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -931,15 +931,16 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 					}
 				}
 
-				// Keep DEAD sandboxes in tracking so fail-fast logic can see them
+				// Keep STOPPED and DEAD sandboxes in tracking so fail-fast logic can see them
 				// They will be cleaned up later by periodic reconciliation or when
 				// new RUNNING sandboxes are discovered
 
-				// Notify waiters when sandbox status changes to RUNNING or DEAD
+				// Notify waiters when sandbox status changes to RUNNING, STOPPED, or DEAD
 				// RUNNING: sandbox is ready to serve traffic
-				// DEAD: sandbox failed, waiters should check if they need to fail fast
+				// STOPPED: sandbox process exited, will be cleaned up by reconciliation
+				// DEAD: sandbox cleaned up, only entity remains
 				// Notify ALL versions that reference this pool
-				if oldStatus != sb.Status && (sb.Status == compute_v1alpha.RUNNING || sb.Status == compute_v1alpha.DEAD) {
+				if oldStatus != sb.Status && (sb.Status == compute_v1alpha.RUNNING || sb.Status == compute_v1alpha.STOPPED || sb.Status == compute_v1alpha.DEAD) {
 					// Notify all versions that reference this pool
 					// Find all version->service mappings that use this pool
 					for key, versionRef := range a.versions {

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -894,7 +894,7 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 				if co.Status == compute.RUNNING {
 					c.Log.Info("marking unhealthy sandbox as DEAD", "id", co.ID)
 					patchAttrs := entity.New(
-						entity.Keyword(entity.Ident, co.ID.String()),
+						entity.Keyword(entity.DBId, co.ID.String()),
 						(&compute.Sandbox{
 							Status: compute.DEAD,
 						}).Encode,
@@ -1730,7 +1730,7 @@ func (c *SandboxController) monitorTaskExit(
 		// - Cleans up containers
 		// - Marks as DEAD afterward
 		patchAttrs := entity.New(
-			entity.Keyword(entity.Ident, sb.ID.String()),
+			entity.Keyword(entity.DBId, sb.ID.String()),
 			(&compute.Sandbox{
 				Status: compute.STOPPED,
 			}).Encode,

--- a/testdata/bad-command/.miren/app.toml
+++ b/testdata/bad-command/.miren/app.toml
@@ -1,0 +1,1 @@
+name = "bad-command"

--- a/testdata/bad-command/Procfile
+++ b/testdata/bad-command/Procfile
@@ -1,0 +1,1 @@
+web: nonexistent-command-that-will-fail

--- a/testdata/bad-command/go.mod
+++ b/testdata/bad-command/go.mod
@@ -1,0 +1,3 @@
+module bad-command
+
+go 1.21

--- a/testdata/bad-command/main.go
+++ b/testdata/bad-command/main.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	// This file exists only to make the build succeed
+	// The Procfile will try to run a non-existent command instead
+}

--- a/testdata/crash-loop/.miren/app.toml
+++ b/testdata/crash-loop/.miren/app.toml
@@ -1,0 +1,1 @@
+name = "crash-loop"

--- a/testdata/crash-loop/Procfile
+++ b/testdata/crash-loop/Procfile
@@ -1,0 +1,1 @@
+web: go run main.go

--- a/testdata/crash-loop/Procfile
+++ b/testdata/crash-loop/Procfile
@@ -1,1 +1,1 @@
-web: go run main.go
+web: /bin/app

--- a/testdata/crash-loop/go.mod
+++ b/testdata/crash-loop/go.mod
@@ -1,0 +1,3 @@
+module crash-loop
+
+go 1.21

--- a/testdata/crash-loop/main.go
+++ b/testdata/crash-loop/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	fmt.Println("Crash loop app starting...")
+	fmt.Println("Running for 2 seconds before crashing...")
+	time.Sleep(2 * time.Second)
+	fmt.Println("Time's up! Crashing now!")
+	os.Exit(1)
+}

--- a/testdata/crash-on-startup/.miren/app.toml
+++ b/testdata/crash-on-startup/.miren/app.toml
@@ -1,0 +1,1 @@
+name = "crash-on-startup"

--- a/testdata/crash-on-startup/Procfile
+++ b/testdata/crash-on-startup/Procfile
@@ -1,0 +1,1 @@
+web: go run main.go

--- a/testdata/crash-on-startup/Procfile
+++ b/testdata/crash-on-startup/Procfile
@@ -1,1 +1,1 @@
-web: go run main.go
+web: /bin/app

--- a/testdata/crash-on-startup/go.mod
+++ b/testdata/crash-on-startup/go.mod
@@ -1,0 +1,3 @@
+module crash-on-startup
+
+go 1.21

--- a/testdata/crash-on-startup/main.go
+++ b/testdata/crash-on-startup/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("App starting...")
+	fmt.Println("Oh no! Something went wrong!")
+	os.Exit(1)
+}

--- a/testdata/go-server/.miren/app.toml
+++ b/testdata/go-server/.miren/app.toml
@@ -1,0 +1,1 @@
+name = "go-server"


### PR DESCRIPTION
**Stacked on #341** - Review and merge #341 first

Fixes MIR-514, Fixes MIR-195

## Summary

Improves handling of apps that crash during boot by immediately detecting process exits and failing fast when all sandboxes are DEAD, reducing timeout from 50 seconds to ~65ms.

## Changes

### Sandbox Controller (`controllers/sandbox/sandbox.go`)
- Added `monitorTaskExit()` to detect process exits via `task.Wait()`
- Launch monitoring goroutine in `bootContainers()` after `task.Start()`
- Re-establish monitoring in `reattachLogs()` after server restart
- Enhanced `checkSandbox()` to mark unhealthy sandboxes as DEAD
- Modified `createSandbox()` to avoid race condition overwriting DEAD status

### Activator (`components/activator/activator.go`)
- Modified `watchSandboxes()` to keep DEAD sandboxes in tracking (previously removed immediately)
- Modified notification logic to notify on DEAD status (not just RUNNING)
- Updated to work with pool-based sandbox tracking from PR #341
- Added fail-fast check in `waitForSandbox()` with detailed debug logging
- Track PENDING sandboxes even without network addresses

### Test Coverage
- Updated `TestActivatorKeepsDeadSandbox` to verify DEAD sandboxes remain in tracking
- Added `TestActivatorFailsFastWhenAllSandboxesDead` to verify sub-second failure response
- Created test apps: `bad-command`, `crash-on-startup`, `crash-loop`

## Results

**Before**: 50,000ms timeout when all sandboxes crash  
**After**: 65-500ms fast failure with clear error message

```
HTTP/1.1 408 Request Timeout
The application app/crash-loop failed to boot. Please check the applications logs.
```

All 26 activator tests pass.

## Test Plan

- [x] Unit tests for DEAD sandbox tracking
- [x] Unit tests for fail-fast logic
- [x] Manual testing with crashy test apps
- [x] Verified response time < 1 second for crashy apps
- [x] Verified normal apps still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container exit monitoring to mark sandboxes STOPPED/DEAD and improved log reattachment.
  * Pool-centric sandbox tracking with per-pool mappings and version-to-pool awareness; pending sandboxes may carry placeholder URLs.

* **Bug Fixes**
  * Fail-fast when no viable sandboxes remain; avoid overwriting externally-DEAD sandboxes.
  * Retain DEAD sandboxes for visibility and notify waiters on state transitions.

* **Tests**
  * Added fixtures for bad-command, crash-loop, crash-on-startup and a simple go-server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->