### PR TITLE
Fix profiler test flake caused by zero sample collection

### DIFF
--- a/observability/profile/profile.go
+++ b/observability/profile/profile.go
@@ -18,7 +18,7 @@ import (
 // The generated files (perf_bpfeb.go, perf_bpfel.go, etc.) are checked into git for now
 // //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -type stack_key -type arguments perf ebpf/perf_event.c -- -I ../../../ebpf/include
 
-const samplesPerSecond = 20
+const samplesPerSecond = 99
 
 const (
 	ipOffset       = 0


### PR DESCRIPTION
## Summary

Fixes the flaky `TestProfile/can_profile_a_process` test that flaked on main with error `"0" is not greater than "1"`.

This is a **different flake** than the previous data race fix in #318. The new flake manifests as:
- Error: `"0" is not greater than "1"` (zero stacks collected)
- Log: `error reading: epoll wait: file already closed`

### Root causes identified

1. **Context lifetime bug**: The test timeout context was used to control the profiler's ringbuf reader lifetime. When the context canceled at test timeout, it closed the ringbuf mid-flight, causing "file already closed" errors and preventing sample collection.

2. **Insufficient warmup**: The profiler could start before the target process was actually executing user code, resulting in missed samples during the critical startup period.

3. **Low sample rate**: 20Hz sampling was too infrequent for short-running CI tests to reliably collect multiple samples within the test window.

### Changes made

- **Context separation**: Use `context.Background()` for profiler lifetime instead of test timeout context. The profiler now runs independently while the test polls with its own timeout.
- **Warmup period**: Add 500ms sleep after process start to ensure it's actually executing before profiling begins.
- **Increased sample rate**: Bump from 20Hz to 99Hz (a common profiler frequency) to increase likelihood of collecting samples in CI environments.

## Test plan

- [x] Verified changes compile and pass lint
- [x] Tested profiler test locally 5/5 times - all passed
- [ ] CI will validate the test passes consistently
- [ ] Monitor for flakes in subsequent runs

## References

- Previous flake fix: #318 (data race, "1 is not greater than 1")
- Failing CI run: https://github.com/mirendev/runtime/actions/runs/19316222458/job/55248178714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced performance sampling configuration to increase the frequency of profiling data collection.

* **Tests**
  * Improved profiling tests with better process initialization and refined timeout management for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->