### PR TITLE
Remove lingering clickhouse references

### DIFF
--- a/.iso/services.yml
+++ b/.iso/services.yml
@@ -1,11 +1,4 @@
 services:
-  clickhouse:
-    image: oci.miren.cloud/clickhouse:v2
-    port: 9000
-    environment:
-      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
-      CLICKHOUSE_PASSWORD: default
-
   etcd:
     image: oci.miren.cloud/etcd:v1
     port: 2379

--- a/disk/provision.go
+++ b/disk/provision.go
@@ -30,8 +30,7 @@ type Provisioner struct {
 	//Image   string `asm:"lsvd-image"`
 	Tempdir string `asm:"tempdir"`
 
-	Clickhouse string `asm:"clickhouse-address,optional"`
-	Namespace  string `asm:"namespace"`
+	Namespace string `asm:"namespace"`
 	Bridge     string `asm:"bridge-iface"`
 	Subnet     *netdb.Subnet
 	Port       int `asm:"server_port"`
@@ -253,7 +252,6 @@ func (c *Provisioner) bootInitialTask(
 		}
 
 		io = cio.BinaryIO(exe, map[string]string{
-			"-d": c.Clickhouse,
 			"-e": id,
 			"-l": pc.AccessDir,
 		})


### PR DESCRIPTION
## Summary
- Remove clickhouse service from `.iso/services.yml`
- Remove `Clickhouse` field from `disk.Provisioner`
- Remove clickhouse address flag from `containerd-log-ingress` setup

## Context
Completes the clickhouse removal started in b25596f. These lingering references were causing:
- Dev environments to spawn clickhouse containers via iso services
- Disk provisioner to pass clickhouse addresses to log ingress
- Rogue clickhouse processes to run on VMs

## Test plan
- [ ] Verify `make dev` doesn't start clickhouse containers
- [ ] Check that no clickhouse processes remain after cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the Clickhouse service from deployment configuration, including its endpoints and environment settings.
  * Removed Clickhouse address configuration from system provisioning, which updates logging behavior to no longer include that destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->