### PR TITLE
Add merge_group trigger for GitHub merge queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+  merge_group:
 
 permissions:
   # Used by golangci-lint to emit annotations that are picked up by github


### PR DESCRIPTION
## Summary
- Add `merge_group` event trigger to test workflow

## Why
This is required before enabling the GitHub merge queue feature. When PRs are added to the merge queue, GitHub triggers a `merge_group` event to run CI on the merged state. Without this trigger, the required status checks won't run and PRs will be stuck in the queue.

## Next Steps
After this merges:
1. Update "Basic Branch Protections" ruleset to add missing status checks (`lint`, `test-e2e`, `build`, `build-binaries`)
2. Add "Require merge queue" rule to the ruleset

## References
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal testing infrastructure configuration to improve CI/CD pipeline reliability and test execution.

---

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->