### PR TITLE
Fix Slack notification syntax for Docker and upload failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,10 +316,6 @@ jobs:
                     {
                       "type": "mrkdwn",
                       "text": "*Branch:*\n`${{ github.ref_name }}`"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Commit:*\n<${{ github.event.workflow_run.repository.html_url }}/commit/${{ github.event.workflow_run.head_sha }}|${{ github.event.workflow_run.head_commit.message }}>"
                     }
                   ]
                 },
@@ -327,8 +323,17 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                    "text": "*Commit:*\n${{ github.event.workflow_run.head_commit.message }}"
                   }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.event.workflow_run.repository.html_url }}/commit/${{ github.event.workflow_run.head_sha }}|View commit> • <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                    }
+                  ]
                 }
               ],
               "unfurl_links": false,
@@ -501,10 +506,6 @@ jobs:
                     {
                       "type": "mrkdwn",
                       "text": "*Branch:*\n`${{ github.ref_name }}`"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Commit:*\n<${{ github.event.workflow_run.repository.html_url }}/commit/${{ github.event.workflow_run.head_sha }}|${{ github.event.workflow_run.head_commit.message }}>"
                     }
                   ]
                 },
@@ -512,8 +513,17 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                    "text": "*Commit:*\n${{ github.event.workflow_run.head_commit.message }}"
                   }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "<${{ github.event.workflow_run.repository.html_url }}/commit/${{ github.event.workflow_run.head_sha }}|View commit> • <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+                    }
+                  ]
                 }
               ],
               "unfurl_links": false,


### PR DESCRIPTION
## Summary
- Fixes Slack notification rendering for Docker build and upload failure messages
- Separates commit message from link syntax to prevent nested mrkdwn links
- Ensures all 4 release workflow notifications use consistent formatting

## Problem
When commit messages contain links (like merge commits with PR links), embedding them as Slack link text creates invalid nested syntax: `<url|<url|text>>`. This causes Slack to display the raw mrkdwn instead of rendering links properly.

## Solution
- Display commit message in its own section (preserving any mrkdwn it contains)
- Show "View commit" and "View workflow run" as separate links in a context block
- Makes Docker build and upload failure notifications consistent with test failure format

## Changes
- `.github/workflows/release.yml`: Updated Docker build failure notification (lines 313-337)
- `.github/workflows/release.yml`: Updated upload failure notification (lines 503-527)

All 4 notifications in the release workflow now follow the same pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release notification structure for improved clarity and easier access to commit and workflow details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->