### PR TITLE
Fix flaky CPU usage test

### DIFF
--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -502,7 +502,7 @@ func TestSandbox(t *testing.T) {
 			cpu, err = co.Metrics.CPUUsage.CurrentCPUUsage(id.String())
 			r.NoError(err)
 
-			if cpu > 0 {
+			if cpu > 0.5 {
 				break
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes the flaky `calculates cpu usage correctly` test that would intermittently fail when run in the full test suite.

## The Bug

The test was breaking out of its wait loop as soon as `cpu > 0`, but then immediately asserting `cpu > 0.5`. This caused flakes when the first non-zero CPU sample was less than 0.5 (e.g., 0.001 or 0.1).

```go
for range 5 {
    time.Sleep(3 * time.Second)
    cpu, err = co.Metrics.CPUUsage.CurrentCPUUsage(id.String())
    r.NoError(err)
    if cpu > 0 {  // ← Bug: breaks too early!
        break
    }
}
r.Greater(float64(cpu), float64(0.5))  // ← Then fails here
```

## The Fix

Changed the loop condition from `cpu > 0` to `cpu > 0.5` to match the assertion:

```go
if cpu > 0.5 {  // ← Now waits for actual threshold
    break
}
```

## Test Plan

- ✅ Ran test in isolation: passes
- ✅ Ran test 10 consecutive times: all passed
- ✅ Linting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated performance testing parameters.

*Note: This release contains internal test improvements with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->