### PR TITLE
Use mirrored images from oci.miren.cloud

### DIFF
--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -375,7 +375,7 @@ key = "DATABASE_URL"
 value = "postgres://localhost/db"
 
 [services.postgres]
-image = "postgres:15"
+image = "oci.miren.cloud/postgres:15"
 
 [services.postgres.concurrency]
 mode = "fixed"

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -157,7 +157,7 @@ func TestPoolReuseOnConfigChange(t *testing.T) {
 	v1 := &core_v1alpha.AppVersion{
 		App:      app.ID,
 		Version:  "v1",
-		ImageUrl: "postgres:16",
+		ImageUrl: "oci.miren.cloud/postgres:16",
 		Config: core_v1alpha.Config{
 			Port: 5432,
 			Variable: []core_v1alpha.Variable{
@@ -197,7 +197,7 @@ func TestPoolReuseOnConfigChange(t *testing.T) {
 	v2 := &core_v1alpha.AppVersion{
 		App:      app.ID,
 		Version:  "v2",
-		ImageUrl: "postgres:16", // Same image
+		ImageUrl: "oci.miren.cloud/postgres:16", // Same image
 		Config: core_v1alpha.Config{
 			Port: 5432,
 			Variable: []core_v1alpha.Variable{
@@ -261,7 +261,7 @@ func TestNewPoolOnImageChange(t *testing.T) {
 	v1 := &core_v1alpha.AppVersion{
 		App:      app.ID,
 		Version:  "v1",
-		ImageUrl: "postgres:16",
+		ImageUrl: "oci.miren.cloud/postgres:16",
 		Config: core_v1alpha.Config{
 			Port: 5432,
 			Services: []core_v1alpha.Services{
@@ -297,7 +297,7 @@ func TestNewPoolOnImageChange(t *testing.T) {
 	v2 := &core_v1alpha.AppVersion{
 		App:      app.ID,
 		Version:  "v2",
-		ImageUrl: "postgres:17", // Image changed
+		ImageUrl: "oci.miren.cloud/postgres:17", // Image changed
 		Config: core_v1alpha.Config{
 			Port: 5432,
 			Services: []core_v1alpha.Services{

--- a/pkg/imagerefs/imagerefs.go
+++ b/pkg/imagerefs/imagerefs.go
@@ -29,30 +29,33 @@ const (
 // Base images for language stacks
 const (
 	// Default Alpine Linux base image
-	AlpineDefault = "alpine:3.21"
+	AlpineDefault = "oci.miren.cloud/alpine:3.21"
+
+	// Default Busybox image
+	BusyboxDefault = "oci.miren.cloud/busybox:1.37-musl"
 )
 
 // GetPythonImage returns a Python image reference with the specified version
 func GetPythonImage(version string) string {
-	return "python:" + version + "-slim"
+	return "oci.miren.cloud/python:" + version + "-slim"
 }
 
 // GetRubyImage returns a Ruby image reference with the specified version
 func GetRubyImage(version string) string {
-	return "ruby:" + version + "-slim"
+	return "oci.miren.cloud/ruby:" + version + "-slim"
 }
 
 // GetGolangImage returns a Golang image reference with the specified version
 func GetGolangImage(version string) string {
-	return "golang:" + version + "-alpine"
+	return "oci.miren.cloud/golang:" + version + "-alpine"
 }
 
 // GetBunImage returns a Bun runtime image reference with the specified version
 func GetBunImage(version string) string {
-	return "oven/bun:" + version
+	return "oci.miren.cloud/bun:" + version
 }
 
 // GetNodeImage returns a Node.js image reference with the specified version
 func GetNodeImage(version string) string {
-	return "node:" + version + "-alpine"
+	return "oci.miren.cloud/node:" + version + "-slim"
 }

--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -237,7 +237,7 @@ func (h *highlevelBuilder) copyApp(cur, mnt llb.State) llb.State {
 func (m *MetaStack) addAppUser(cur llb.State) llb.State {
 	m.result.Config.User = "2010"
 
-	bb := llb.Image("busybox:1.37-musl")
+	bb := llb.Image(imagerefs.BusyboxDefault)
 
 	return cur.Run(
 		llb.Args([]string{"/bin/sh", "-c",
@@ -525,7 +525,7 @@ func (s *NodeStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 	if opts.Version != "" {
 		version = opts.Version
 	}
-	base := llb.Image(fmt.Sprintf("node:%s-slim", version))
+	base := llb.Image(imagerefs.GetNodeImage(version))
 
 	base = s.addAppUser(base)
 

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -247,7 +247,7 @@ func TestBuildServicesConfig(t *testing.T) {
 			appConfig: &appconfig.AppConfig{
 				Services: map[string]*appconfig.ServiceConfig{
 					"postgres": {
-						Image: "postgres:15",
+						Image: "oci.miren.cloud/postgres:15",
 						Concurrency: &appconfig.ServiceConcurrencyConfig{
 							Mode:         "fixed",
 							NumInstances: 1,
@@ -259,7 +259,7 @@ func TestBuildServicesConfig(t *testing.T) {
 			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
 				require.Len(t, services, 1)
 				assert.Equal(t, "postgres", services[0].Name)
-				assert.Equal(t, "postgres:15", services[0].Image)
+				assert.Equal(t, "oci.miren.cloud/postgres:15", services[0].Image)
 			},
 		},
 		{
@@ -286,14 +286,14 @@ func TestBuildServicesConfig(t *testing.T) {
 			appConfig: &appconfig.AppConfig{
 				Services: map[string]*appconfig.ServiceConfig{
 					"postgres": {
-						Image: "postgres:15",
+						Image: "oci.miren.cloud/postgres:15",
 						Concurrency: &appconfig.ServiceConcurrencyConfig{
 							Mode:         "fixed",
 							NumInstances: 1,
 						},
 					},
 					"redis": {
-						Image: "redis:7-alpine",
+						Image: "oci.miren.cloud/redis:7",
 						Concurrency: &appconfig.ServiceConcurrencyConfig{
 							Mode:         "fixed",
 							NumInstances: 1,
@@ -317,10 +317,10 @@ func TestBuildServicesConfig(t *testing.T) {
 				}
 
 				require.Contains(t, serviceMap, "postgres")
-				assert.Equal(t, "postgres:15", serviceMap["postgres"].Image)
+				assert.Equal(t, "oci.miren.cloud/postgres:15", serviceMap["postgres"].Image)
 
 				require.Contains(t, serviceMap, "redis")
-				assert.Equal(t, "redis:7-alpine", serviceMap["redis"].Image)
+				assert.Equal(t, "oci.miren.cloud/redis:7", serviceMap["redis"].Image)
 
 				require.Contains(t, serviceMap, "web")
 				assert.Equal(t, "", serviceMap["web"].Image, "web service should not have custom image")
@@ -331,7 +331,7 @@ func TestBuildServicesConfig(t *testing.T) {
 			appConfig: &appconfig.AppConfig{
 				Services: map[string]*appconfig.ServiceConfig{
 					"postgres": {
-						Image: "postgres:15",
+						Image: "oci.miren.cloud/postgres:15",
 						Concurrency: &appconfig.ServiceConcurrencyConfig{
 							Mode:         "fixed",
 							NumInstances: 1,
@@ -353,7 +353,7 @@ func TestBuildServicesConfig(t *testing.T) {
 				require.Len(t, services, 1)
 				svc := services[0]
 				assert.Equal(t, "postgres", svc.Name)
-				assert.Equal(t, "postgres:15", svc.Image)
+				assert.Equal(t, "oci.miren.cloud/postgres:15", svc.Image)
 
 				require.Len(t, svc.Disks, 1, "should have one disk")
 				disk := svc.Disks[0]

--- a/testdata/db-app/.miren/app.toml
+++ b/testdata/db-app/.miren/app.toml
@@ -13,7 +13,7 @@ key = "POSTGRES_PASSWORD"
 value = "hunter2"
 
 [services.db]
-image = "postgres:15"
+image = "oci.miren.cloud/postgres:15"
 
 [services.db.concurrency]
 mode = "fixed"


### PR DESCRIPTION
## Summary

Updates all language runtime and database image references to use `oci.miren.cloud` mirrors instead of pulling directly from Docker Hub. This avoids rate limiting issues (429 errors) during builds and tests.

## Changes

**Language runtimes:**
- Python: 3.11-slim, 3.12-slim, 3.13-slim
- Ruby: 3.2-slim, 3.3-slim  
- Go: 1.23-alpine, 1.24-alpine
- Node: 20-slim, 22-slim
- Bun: 1
- Alpine: 3.21
- Busybox: 1.37-musl

**Database images:**
- PostgreSQL: 15, 16, 17
- Redis: 7

All images use identical upstream tags (e.g., `postgres:15` → `oci.miren.cloud/postgres:15`) for simple read-through caching.

## Related

- Infra PR with mirror config: https://github.com/mirendev/infra/pull/34
- Closes MIR-517

## Test plan

- [x] Commit passes lint checks
- [ ] Existing tests pass with mirrored images
- [ ] Stackbuild works with mirrored language images
- [ ] Service images (postgres, redis) work in test apps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated container base images (Alpine, Python, Ruby, Golang, Bun, Node, Busybox, Postgres, and Redis) to use the oci.miren.cloud registry instead of default public registries.

* **Tests**
  * Updated test configurations to reflect the new registry paths for base images across multiple test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->