### PR TITLE
Set the local cluster as the active one if there are no actives

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -909,6 +909,11 @@ func writeLocalClusterConfig(ctx *Context, cc *caauth.ClientCertificate, address
 	// Add as a leaf config (this will be saved to clientconfig.d/50-local.yaml)
 	config.SetLeafConfig("50-local", leafConfigData)
 
+	if config.ActiveCluster() == "" {
+		// Set the active cluster to the local one if none is set
+		config.SetActiveCluster(clusterName)
+	}
+
 	if err := config.Save(); err != nil {
 		return fmt.Errorf("failed to save local cluster leaf config: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the active cluster configuration was not automatically initialized when writing a new local cluster. The system now properly sets the active cluster in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->