### PR TITLE
Make HTTP host lookups case-insensitive

### DIFF
--- a/api/app/client.go
+++ b/api/app/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
@@ -97,7 +98,7 @@ func (c *Client) SetHost(ctx context.Context, appName, host string) error {
 
 	// Create the http_route entity
 	route := &ingress_v1alpha.HttpRoute{
-		Host: host,
+		Host: strings.ToLower(host),
 		App:  app.ID,
 	}
 

--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -35,7 +36,7 @@ func NewClient(log *slog.Logger, client rpc.Client) *Client {
 
 // Lookup finds an http_route by hostname, returns nil if not found
 func (c *Client) Lookup(ctx context.Context, host string) (*ingress_v1alpha.HttpRoute, error) {
-	ia := entity.String(ingress_v1alpha.HttpRouteHostId, host)
+	ia := entity.String(ingress_v1alpha.HttpRouteHostId, strings.ToLower(host))
 
 	var route ingress_v1alpha.HttpRoute
 	err := c.ec.OneAtIndex(ctx, ia, &route)
@@ -163,7 +164,7 @@ func (c *Client) List(ctx context.Context) ([]*RouteWithMeta, error) {
 // SetRoute creates or updates an http_route for the given host and app
 func (c *Client) SetRoute(ctx context.Context, host string, appId entity.Id) (*ingress_v1alpha.HttpRoute, error) {
 	route := &ingress_v1alpha.HttpRoute{
-		Host: host,
+		Host: strings.ToLower(host),
 		App:  appId,
 	}
 

--- a/api/ingress/client_test.go
+++ b/api/ingress/client_test.go
@@ -1,0 +1,153 @@
+package ingress
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+func TestClientLookupCaseInsensitive(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup in-memory entity server
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+
+	// Create ingress client
+	client := &Client{
+		log: slog.Default(),
+		ec:  ec,
+		eac: inmem.EAC,
+	}
+
+	// Create a test app ID
+	testAppID := entity.Id("test-app-123")
+
+	// Test case 1: Store route with mixed case host
+	t.Run("LookupWithVariousCases", func(t *testing.T) {
+		originalHost := "Example.Com"
+
+		// Set route with mixed case
+		route, err := client.SetRoute(ctx, originalHost, testAppID)
+		if err != nil {
+			t.Fatalf("failed to set route: %v", err)
+		}
+		if route == nil {
+			t.Fatal("expected route to be created, got nil")
+		}
+
+		// Verify the route was stored with lowercase host
+		if route.Host != "example.com" {
+			t.Errorf("expected host to be stored as 'example.com', got %q", route.Host)
+		}
+
+		// Test lookup with exact case as stored (lowercase)
+		result, err := client.Lookup(ctx, "example.com")
+		if err != nil {
+			t.Fatalf("lookup with lowercase failed: %v", err)
+		}
+		if result == nil {
+			t.Error("expected to find route with lowercase host")
+		} else if result.App != testAppID {
+			t.Errorf("expected app ID %q, got %q", testAppID, result.App)
+		}
+
+		// Test lookup with all uppercase
+		result, err = client.Lookup(ctx, "EXAMPLE.COM")
+		if err != nil {
+			t.Fatalf("lookup with uppercase failed: %v", err)
+		}
+		if result == nil {
+			t.Error("expected to find route with uppercase host")
+		} else if result.App != testAppID {
+			t.Errorf("expected app ID %q, got %q", testAppID, result.App)
+		}
+
+		// Test lookup with mixed case (different from original)
+		result, err = client.Lookup(ctx, "ExAmPlE.CoM")
+		if err != nil {
+			t.Fatalf("lookup with mixed case failed: %v", err)
+		}
+		if result == nil {
+			t.Error("expected to find route with mixed case host")
+		} else if result.App != testAppID {
+			t.Errorf("expected app ID %q, got %q", testAppID, result.App)
+		}
+
+		// Test lookup with original case used when setting
+		result, err = client.Lookup(ctx, originalHost)
+		if err != nil {
+			t.Fatalf("lookup with original case failed: %v", err)
+		}
+		if result == nil {
+			t.Error("expected to find route with original case host")
+		} else if result.App != testAppID {
+			t.Errorf("expected app ID %q, got %q", testAppID, result.App)
+		}
+	})
+
+	// Test case 2: Multiple routes with different hosts
+	t.Run("MultipleRoutesCaseInsensitive", func(t *testing.T) {
+		testAppID2 := entity.Id("test-app-456")
+		testAppID3 := entity.Id("test-app-789")
+
+		// Create routes with different hosts
+		_, err := client.SetRoute(ctx, "api.example.com", testAppID2)
+		if err != nil {
+			t.Fatalf("failed to set route for api.example.com: %v", err)
+		}
+
+		_, err = client.SetRoute(ctx, "WEB.EXAMPLE.COM", testAppID3)
+		if err != nil {
+			t.Fatalf("failed to set route for WEB.EXAMPLE.COM: %v", err)
+		}
+
+		// Lookup api.example.com with different cases
+		result, err := client.Lookup(ctx, "API.EXAMPLE.COM")
+		if err != nil {
+			t.Fatalf("lookup failed: %v", err)
+		}
+		if result == nil {
+			t.Error("expected to find route")
+		} else if result.App != testAppID2 {
+			t.Errorf("expected app ID %q, got %q", testAppID2, result.App)
+		}
+
+		// Lookup web.example.com with different cases
+		result, err = client.Lookup(ctx, "web.example.com")
+		if err != nil {
+			t.Fatalf("lookup failed: %v", err)
+		}
+		if result == nil {
+			t.Error("expected to find route")
+		} else if result.App != testAppID3 {
+			t.Errorf("expected app ID %q, got %q", testAppID3, result.App)
+		}
+	})
+
+	// Test case 3: Non-existent host returns nil
+	t.Run("NonExistentHostReturnsNil", func(t *testing.T) {
+		result, err := client.Lookup(ctx, "does-not-exist.com")
+		if err != nil {
+			t.Fatalf("lookup should not error on non-existent host: %v", err)
+		}
+		if result != nil {
+			t.Error("expected nil for non-existent host")
+		}
+
+		// Try with different case
+		result, err = client.Lookup(ctx, "DOES-NOT-EXIST.COM")
+		if err != nil {
+			t.Fatalf("lookup should not error on non-existent host: %v", err)
+		}
+		if result != nil {
+			t.Error("expected nil for non-existent host")
+		}
+	})
+}

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -382,7 +382,7 @@ func (r *AppInfo) SetHost(ctx context.Context, state *app_v1alpha.CrudSetHost) e
 
 	var routeRec ingress_v1alpha.HttpRoute
 
-	routeRec.Host = state.Args().Host()
+	routeRec.Host = strings.ToLower(state.Args().Host())
 	routeRec.App = appRec.ID
 
 	_, err = r.EC.CreateOrUpdate(ctx, routeRec.Host, &routeRec)


### PR DESCRIPTION
## Summary

Makes HTTP host lookups case-insensitive throughout the ingress system, since DNS hostnames are inherently case-insensitive.

## Changes

- **ingress.Client.SetRoute**: Store hosts in lowercase
- **ingress.Client.Lookup**: Convert lookup hosts to lowercase before querying
- **app.Client.SetHost**: Normalize hosts to lowercase
- **servers/app/app.go**: Normalize hosts in SetHost handler
- **Tests**: Add comprehensive test coverage for case-insensitive lookups

## Test Coverage

Added `TestClientLookupCaseInsensitive` which verifies:
- Routes can be looked up using any case combination (UPPERCASE, lowercase, MiXeD)
- Multiple routes with different hosts work correctly
- Non-existent hosts return nil regardless of case
- All lookups return the correct route regardless of case

## Test Plan

- [x] Unit tests pass (`go test ./api/ingress`)
- [x] Verified case-insensitive lookup works with all case variations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host names are now normalized to lowercase for consistent handling and lookups across the system, regardless of input casing.

* **Tests**
  * Added test coverage for case-insensitive host lookups with various host name formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->