### PR TITLE
Shorten relative timestamps in CLI tables

### DIFF
--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -193,42 +193,18 @@ func humanFriendlyTimestamp(t time.Time) string {
 	}
 
 	if since < time.Minute {
-		return fmt.Sprintf("%d seconds ago", int(since.Seconds()))
+		return fmt.Sprintf("%ds ago", int(since.Seconds()))
 	} else if since < time.Hour {
-		mins := int(since.Minutes())
-		if mins == 1 {
-			return "1 minute ago"
-		}
-		return fmt.Sprintf("%d minutes ago", mins)
+		return fmt.Sprintf("%dm ago", int(since.Minutes()))
 	} else if since < 24*time.Hour {
-		hours := int(since.Hours())
-		if hours == 1 {
-			return "1 hour ago"
-		}
-		return fmt.Sprintf("%d hours ago", hours)
+		return fmt.Sprintf("%dh ago", int(since.Hours()))
 	} else if since < 7*24*time.Hour {
-		days := int(since.Hours() / 24)
-		if days == 1 {
-			return "1 day ago"
-		}
-		return fmt.Sprintf("%d days ago", days)
+		return fmt.Sprintf("%dd ago", int(since.Hours()/24))
 	} else if since < 30*24*time.Hour {
-		weeks := int(since.Hours() / (24 * 7))
-		if weeks == 1 {
-			return "1 week ago"
-		}
-		return fmt.Sprintf("%d weeks ago", weeks)
+		return fmt.Sprintf("%dw ago", int(since.Hours()/(24*7)))
 	} else if since < 365*24*time.Hour {
-		months := int(since.Hours() / (24 * 30))
-		if months == 1 {
-			return "1 month ago"
-		}
-		return fmt.Sprintf("%d months ago", months)
+		return fmt.Sprintf("%dmo ago", int(since.Hours()/(24*30)))
 	} else {
-		years := int(since.Hours() / (24 * 365))
-		if years == 1 {
-			return "1 year ago"
-		}
-		return fmt.Sprintf("%d years ago", years)
+		return fmt.Sprintf("%dy ago", int(since.Hours()/(24*365)))
 	}
 }


### PR DESCRIPTION
## Summary

- Shortened relative timestamp formats in CLI table outputs to save horizontal space
- Changed from verbose formats ("30 seconds ago", "5 minutes ago") to compact formats ("30s ago", "5m ago")
- Affects commands: `m sandbox list`, `m sandbox-pool list`, `m app list`, `m route list`

## Changes

Updated `humanFriendlyTimestamp()` in `cli/commands/sandbox_list.go` to use compact time unit abbreviations:
- `s` for seconds
- `m` for minutes
- `h` for hours
- `d` for days
- `w` for weeks
- `mo` for months
- `y` for years

This brings the format in line with the existing `formatRelativeTime()` used in `m app history`.

## Test plan

- [ ] Run `m sandbox list` and verify timestamps display in compact format
- [ ] Run `m app list` and verify timestamps display in compact format
- [ ] Run `m route list` and verify timestamps display in compact format
- [ ] Verify table columns are more readable with less horizontal space usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated timestamp display format in sandbox list output to use compact notation (e.g., "ds", "dm", "dh") instead of verbose text for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->