### PR TITLE
Fix created_at being updated on entity patch/update operations

### DIFF
--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -82,20 +82,11 @@ func New(vals ...any) *Entity {
 		}
 	}
 
-	ts := time.Now()
 	e := &Entity{
 		attrs: SortedAttrs(attrs),
 	}
 
 	e.removeIdent()
-
-	// Only set timestamps if they don't already exist
-	if e.GetCreatedAt().IsZero() {
-		e.SetCreatedAt(ts)
-	}
-	if e.GetUpdatedAt().IsZero() {
-		e.SetUpdatedAt(ts)
-	}
 
 	return e
 }

--- a/pkg/entity/entity_test.go
+++ b/pkg/entity/entity_test.go
@@ -395,9 +395,9 @@ func TestRemove(t *testing.T) {
 
 	r := require.New(t)
 
-	// New adds db/id, created_at, and updated_at automatically
-	// After removing Doc, we should have 3 attrs (db/id, created_at, updated_at)
-	r.Len(ent.Attrs(), 3)
+	// New adds db/id automatically (timestamps are added by the store)
+	// After removing Doc, we should have 1 attr (db/id)
+	r.Len(ent.Attrs(), 1)
 
 	// Verify Doc was actually removed
 	_, ok := ent.Get(Doc)
@@ -416,9 +416,9 @@ func TestEntity(t *testing.T) {
 
 		ent.Fixup()
 
-		// New adds db/id, created_at, updated_at and dedupes the duplicate Doc
-		// So we should have 4 attrs: db/id, Doc, created_at, updated_at
-		r.Len(ent.Attrs(), 4)
+		// New adds db/id and dedupes the duplicate Doc (timestamps are added by the store)
+		// So we should have 2 attrs: db/id, Doc
+		r.Len(ent.Attrs(), 2)
 
 		// Verify Doc appears only once
 		docAttrs := ent.GetAll(Doc)

--- a/pkg/entity/file_store.go
+++ b/pkg/entity/file_store.go
@@ -53,6 +53,11 @@ func NewFileStore(basePath string) (*FileStore, error) {
 
 // CreateEntity creates a new entity with the given type and attributes
 func (s *FileStore) CreateEntity(ctx context.Context, entity *Entity, opts ...EntityOption) (*Entity, error) {
+	// Set CreatedAt if not already set (store manages this timestamp)
+	if entity.GetCreatedAt().IsZero() {
+		entity.SetCreatedAt(time.Now())
+	}
+
 	// Validate attributes against schemas
 	err := s.validator.ValidateEntity(ctx, entity)
 	if err != nil {
@@ -213,6 +218,9 @@ func (s *FileStore) GetAttributeSchema(ctx context.Context, id Id) (*AttributeSc
 // saveEntity saves an entity to disk
 func (s *FileStore) saveEntity(entity *Entity) error {
 	entity.Fixup()
+
+	// Store manages UpdatedAt - set it on every save
+	entity.SetUpdatedAt(time.Now())
 
 	data, err := encoder.Marshal(entity)
 	if err != nil {

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -77,7 +77,10 @@ func (m *MockStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error
 }
 
 func (m *MockStore) CreateEntity(ctx context.Context, entity *Entity, opts ...EntityOption) (*Entity, error) {
-	entity.SetCreatedAt(m.Now())
+	// Set CreatedAt if not already set (store manages this timestamp)
+	if entity.GetCreatedAt().IsZero() {
+		entity.SetCreatedAt(m.Now())
+	}
 	entity.SetUpdatedAt(m.Now())
 	entity.SetRevision(1)
 
@@ -118,6 +121,10 @@ func (m *MockStore) UpdateEntity(ctx context.Context, id Id, entity *Entity, opt
 
 	updated.SetRevision(e.GetRevision() + 1)
 	updated.SetUpdatedAt(m.Now())
+	// Preserve CreatedAt from existing entity
+	if !e.GetCreatedAt().IsZero() {
+		updated.SetCreatedAt(e.GetCreatedAt())
+	}
 
 	// Update the entity in the store
 	m.Entities[id] = updated
@@ -141,6 +148,10 @@ func (m *MockStore) ReplaceEntity(ctx context.Context, entity *Entity, opts ...E
 	// Update revision and timestamp
 	entity.SetRevision(existing.GetRevision() + 1)
 	entity.SetUpdatedAt(m.Now())
+	// Preserve CreatedAt from existing entity
+	if !existing.GetCreatedAt().IsZero() {
+		entity.SetCreatedAt(existing.GetCreatedAt())
+	}
 
 	m.Entities[id] = entity
 	return entity, nil

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -161,6 +161,11 @@ func (s *EtcdStore) CreateEntity(
 	// when retrieving an entity, before stamping it with the current etcd revision.
 	entity.Remove(Revision)
 
+	// Set CreatedAt if not already set (store manages this timestamp)
+	if entity.GetCreatedAt().IsZero() {
+		entity.SetCreatedAt(time.Now())
+	}
+
 	// Validate attributes
 	if err := s.validator.ValidateEntity(ctx, entity); err != nil {
 		return nil, err
@@ -740,6 +745,7 @@ func (s *EtcdStore) buildEntitySaveOps(entity *Entity, key string, primary, sess
 	var ops []clientv3.Op
 
 	entity.attrs = primary
+	// Store manages UpdatedAt - set it on every save
 	entity.SetUpdatedAt(time.Now())
 
 	data, err := encoder.Marshal(entity)

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -1743,6 +1743,12 @@ func TestEtcdStore_NestedComponentFieldIndexing(t *testing.T) {
 //   - When fixed, only 1 key remains (the non-deleted entity)
 func TestEtcdStore_DeleteEntity_IndexCleanup_DirectQuery(t *testing.T) {
 	client := setupTestEtcd(t)
+
+	// Clean up test data from previous runs
+	ctx := context.Background()
+	_, err := client.Delete(ctx, "/test-entities-debug/", clientv3.WithPrefix())
+	require.NoError(t, err)
+
 	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities-debug")
 	require.NoError(t, err)
 

--- a/servers/entityserver/entityserver_test.go
+++ b/servers/entityserver/entityserver_test.go
@@ -239,9 +239,11 @@ func TestEntityServer_WatchIndex(t *testing.T) {
 
 		ae := op.Entity()
 
-		r.Len(ae.Attrs(), 4)
+		// Entity has 2 attributes: db/id and db/ident (timestamps managed by store, not present here)
+		r.Len(ae.Attrs(), 2)
 
-		r.Equal(entity.Ref(entity.DBId, "mock/entity"), ae.Attrs()[2])
+		// Verify the entity has the expected db/id attribute
+		r.Contains(ae.Attrs(), entity.Ref(entity.DBId, "mock/entity"))
 
 		return nil
 	}))


### PR DESCRIPTION
## Summary
Fixes a bug where `created_at` timestamps were being incorrectly updated during entity patch/update operations, particularly visible during sandbox recovery on server restart.

## Root Cause
The issue was in `entity.New()` automatically adding fresh `CreatedAt` and `UpdatedAt` timestamps if they weren't present in the attrs. When entityserver handlers (Patch, Replace, Update) received partial entity data (e.g., just a status update), they called `entity.New(attrs)` which would see the timestamps missing and add fresh ones, causing `created_at` to be overwritten.

## Solution
Moved timestamp management from the application layer to the storage layer, following the same pattern as the `Revision` field:

- `entity.New()` no longer auto-adds timestamps
- `Store.CreateEntity()` sets `CreatedAt` if not already present  
- Store save/update operations always set `UpdatedAt` and preserve `CreatedAt`
- **All store implementations updated consistently:** `EtcdStore`, `FileStore`, and `MockStore`

This provides clearer separation of concerns where the store manages all metadata (revision, created_at, updated_at) and prevents this entire class of bugs where partial entity updates could corrupt timestamps.

## Changes
- `pkg/entity/entity.go`: Removed automatic timestamp addition from `New()` constructor
- `pkg/entity/store.go`: Added `CreatedAt` initialization in `CreateEntity`, clarified `UpdatedAt` management
- `pkg/entity/file_store.go`: Added timestamp management to match `EtcdStore`
- `pkg/entity/mock.go`: Updated `CreateEntity`, `UpdateEntity`, and `ReplaceEntity` to properly manage timestamps
- `pkg/entity/entity_test.go`: Updated tests to reflect new behavior (entities created without going through store have no timestamps)
- `pkg/entity/store_test.go`: Fixed pre-existing test cleanup bug
- `servers/entityserver/entityserver_test.go`: Updated `TestEntityServer_WatchIndex` to expect correct attribute count

## Testing
- ✅ All entity package tests passing (including MockStore tests)
- ✅ All entityserver tests passing
- ✅ Code linting clean
- ✅ Reproduced and verified fix: deployed test app, recorded sandbox timestamps, restarted server, confirmed `created_at` remains unchanged across restarts

## Example
**Before fix:** `created_at` would change from `2025-11-14T17:22:45.274Z` to `2025-11-14T17:23:48.2Z` on restart  
**After fix:** `created_at` remains stable at `2025-11-14T17:24:16.734Z` across restarts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Timestamp handling moved out of entity constructors: CreatedAt is set when entities are stored, and UpdatedAt is refreshed on every save.

* **Tests**
  * Updated expectations and added cleanup to reflect timestamps being managed by the store; assertions adjusted accordingly.

* **Chores**
  * Mock and store behaviors adjusted to preserve pre-set CreatedAt values and ensure consistent timestamp/revision updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->