### PR TITLE
Populate basic cluster status reporting fields

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -51,6 +51,7 @@ import (
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/serverconfig"
 	"miren.dev/runtime/servers/httpingress"
+	"miren.dev/runtime/version"
 )
 
 func Server(ctx *Context, opts serverconfig.CLIFlags) error {
@@ -66,6 +67,10 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
+
+	versionInfo := version.GetInfo()
+	ctx.UILog.Info("starting miren server", "version", versionInfo.Version, "commit", versionInfo.Commit)
+
 	switch cfg.GetMode() {
 	case "standalone":
 		// Mode defaults are already applied by serverconfig.Load

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -652,7 +652,7 @@ func (c *Coordinator) ReportStatus(ctx context.Context) error {
 	}
 
 	// Collect resource usage metrics
-	resourceUsage := c.collectResourceUsage(ctx)
+	resourceUsage := c.collectResourceUsage()
 
 	// Build status report
 	status := &cloudauth.StatusReport{
@@ -668,7 +668,7 @@ func (c *Coordinator) ReportStatus(ctx context.Context) error {
 }
 
 // collectResourceUsage gathers basic host system resource usage metrics
-func (c *Coordinator) collectResourceUsage(ctx context.Context) cloudauth.ResourceUsage {
+func (c *Coordinator) collectResourceUsage() cloudauth.ResourceUsage {
 	stats := sysstats.CollectSystemStats(c.DataPath)
 
 	return cloudauth.ResourceUsage{

--- a/pkg/sysstats/sysstats.go
+++ b/pkg/sysstats/sysstats.go
@@ -1,0 +1,99 @@
+//go:build linux
+
+package sysstats
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// CollectSystemStats gathers basic host system resource usage metrics
+// similar to uptime, free -m, and df -h
+func CollectSystemStats(dataPath string) ResourceUsage {
+	usage := ResourceUsage{}
+
+	// Get CPU load average (1 minute average) from /proc/loadavg
+	loadavgBytes, err := os.ReadFile("/proc/loadavg")
+	if err == nil {
+		fields := strings.Fields(string(loadavgBytes))
+		if len(fields) > 0 {
+			if load1, err := strconv.ParseFloat(fields[0], 64); err == nil {
+				usage.CPUCores = load1
+
+				// Calculate percentage based on number of CPUs
+				// Try to get CPU count from /proc/cpuinfo
+				numCPU := getCPUCount()
+				if numCPU > 0 {
+					usage.CPUPercent = (load1 / float64(numCPU)) * 100
+				}
+			}
+		}
+	}
+
+	// Get memory stats from /proc/meminfo
+	meminfoBytes, err := os.ReadFile("/proc/meminfo")
+	if err == nil {
+		var memTotal, memAvailable int64
+		lines := strings.Split(string(meminfoBytes), "\n")
+		for _, line := range lines {
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			value, err := strconv.ParseInt(fields[1], 10, 64)
+			if err != nil {
+				continue
+			}
+			// /proc/meminfo reports in kB, convert to bytes
+			valueBytes := value * 1024
+
+			if strings.HasPrefix(line, "MemTotal:") {
+				memTotal = valueBytes
+			} else if strings.HasPrefix(line, "MemAvailable:") {
+				memAvailable = valueBytes
+			}
+		}
+
+		if memTotal > 0 {
+			memUsed := memTotal - memAvailable
+			usage.MemoryBytes = memUsed
+			usage.MemoryPercent = float64(memUsed) / float64(memTotal) * 100
+		}
+	}
+
+	// Get disk usage for the specified path using syscall.Statfs
+	if dataPath != "" {
+		var stat syscall.Statfs_t
+		if err := syscall.Statfs(dataPath, &stat); err == nil {
+			totalBytes := stat.Blocks * uint64(stat.Bsize)
+			availBytes := stat.Bavail * uint64(stat.Bsize)
+			usedBytes := totalBytes - availBytes
+
+			usage.StorageBytes = int64(usedBytes)
+			if totalBytes > 0 {
+				usage.StoragePercent = float64(usedBytes) / float64(totalBytes) * 100
+			}
+		}
+	}
+
+	return usage
+}
+
+// getCPUCount returns the number of CPUs from /proc/cpuinfo
+func getCPUCount() int {
+	cpuinfoBytes, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		return 0
+	}
+
+	count := 0
+	lines := strings.Split(string(cpuinfoBytes), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "processor") {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/sysstats/sysstats_darwin.go
+++ b/pkg/sysstats/sysstats_darwin.go
@@ -1,0 +1,8 @@
+//go:build darwin
+
+package sysstats
+
+// CollectSystemStats returns empty stats on Darwin (stub implementation)
+func CollectSystemStats(dataPath string) ResourceUsage {
+	return ResourceUsage{}
+}

--- a/pkg/sysstats/types.go
+++ b/pkg/sysstats/types.go
@@ -1,0 +1,11 @@
+package sysstats
+
+// ResourceUsage contains basic host system resource utilization
+type ResourceUsage struct {
+	CPUCores       float64
+	CPUPercent     float64
+	MemoryBytes    int64
+	MemoryPercent  float64
+	StorageBytes   int64
+	StoragePercent float64
+}


### PR DESCRIPTION
This PR implements basic status reporting to populate the empty fields currently showing as "-" in the Miren Cloud cluster list UI.

<img width="2388" height="1888" alt="2025-11-14 at 17 02 48@2x" src="https://github.com/user-attachments/assets/9e2d22c0-b36e-472b-aeb8-c72ed20010f1" />

## What's Changed

**Server startup logging:**
- Added version and commit logging when miren server starts (visible in journalctl)

**Status reporting now includes:**
- **Version**: Reports the build version (e.g., "tell-it-to-the-clouds:165a03e")
- **Node count**: Static value of 1 for now
- **Workload count**: Actual count of apps from the entity store
- **Resource usage**: Basic host system metrics:
  - CPU load average (cores and percentage)
  - Memory usage (bytes and percentage) 
  - Disk usage for data path (bytes and percentage)

**New package `pkg/sysstats`:**
- Collects rudimentary global system stats similar to `uptime`, `free -m`, and `df -h`
- Linux implementation uses `/proc/loadavg`, `/proc/meminfo`, and `syscall.Statfs`
- Darwin stub implementation (returns empty stats)

## What Gets Reported

The periodic status report (every 5 minutes) now sends:
- `state`: "active"
- `version`: Build version from version info
- `node_count`: 1
- `workload_count`: Number of apps in entity store
- `resource_usage`: CPU/memory/storage metrics from host system

## Future Improvements

This is an incremental improvement to get the basic fields populated. There's plenty of room for enhancements:

- Dynamic node count when multi-node support is added
- Health check collection and smart state determination (active/degraded/inactive)
- More sophisticated resource metrics
- RBAC rules version tracking
- Per-workload resource rollups

## Testing

- ✅ Code builds successfully
- ✅ Linter passes
- Ready for testing in dev environment with local cloud instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server startup now logs version information.
  * Status reports now include workload counts and system resource metrics (CPU, memory, storage).
  * Added resource monitoring for Linux hosts; macOS currently returns placeholder metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->