### PR TITLE
disk: Support operations when nbd isn't available

### DIFF
--- a/controllers/disk/disk_controller_directory_test.go
+++ b/controllers/disk/disk_controller_directory_test.go
@@ -1,0 +1,581 @@
+package disk
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log/slog"
+	"miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+func TestDiskController_DirectoryMode_Init(t *testing.T) {
+	t.Run("enables directory mode when NBD unavailable", func(t *testing.T) {
+		log := slog.Default()
+		controller := NewDiskController(log, nil, nil)
+
+		// Set environment to disable NBD
+		t.Setenv("MIREN_DISABLE_NBD", "1")
+
+		err := controller.Init(context.Background())
+		require.NoError(t, err)
+
+		assert.True(t, controller.directoryMode, "Directory mode should be enabled when NBD is unavailable")
+	})
+
+	t.Run("disables directory mode when NBD available", func(t *testing.T) {
+		log := slog.Default()
+		controller := NewDiskController(log, nil, nil)
+
+		// Don't set MIREN_DISABLE_NBD - NBD availability depends on system
+		// This test may pass or fail depending on whether NBD is actually available
+
+		err := controller.Init(context.Background())
+		require.NoError(t, err)
+
+		// We can't assert a specific value here since it depends on the system
+		// Just verify Init doesn't error
+	})
+}
+
+func TestDiskController_DirectoryMode_ProvisionVolume(t *testing.T) {
+	t.Run("creates directory instead of LSVD volume", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		disk := &storage_v1alpha.Disk{
+			ID:         entity.Id("disk/test-dir-1"),
+			Name:       "test-dir-1",
+			SizeGb:     10,
+			Filesystem: storage_v1alpha.EXT4,
+			Status:     storage_v1alpha.PROVISIONING,
+		}
+
+		volumeId, err := controller.provisionVolume(ctx, disk)
+		require.NoError(t, err)
+		assert.NotEmpty(t, volumeId)
+
+		// Verify directory was created
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		stat, err := os.Stat(diskDataPath)
+		require.NoError(t, err, "Directory should exist")
+		assert.True(t, stat.IsDir(), "Should be a directory")
+	})
+
+	t.Run("handles invalid disk size", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		disk := &storage_v1alpha.Disk{
+			ID:         entity.Id("disk/test-invalid"),
+			Name:       "test-invalid",
+			SizeGb:     0, // Invalid size
+			Filesystem: storage_v1alpha.EXT4,
+			Status:     storage_v1alpha.PROVISIONING,
+		}
+
+		_, err := controller.provisionVolume(ctx, disk)
+		assert.Error(t, err, "Should reject invalid disk size")
+		assert.Contains(t, err.Error(), "invalid disk size")
+	})
+
+	t.Run("handles directory creation failure", func(t *testing.T) {
+		ctx := context.Background()
+		log := slog.Default()
+
+		// Use an invalid path to cause directory creation to fail
+		controller := NewDiskControllerWithMountPath(log, nil, nil, "/dev/null/invalid")
+		controller.directoryMode = true
+
+		disk := &storage_v1alpha.Disk{
+			ID:         entity.Id("disk/test-fail"),
+			Name:       "test-fail",
+			SizeGb:     10,
+			Filesystem: storage_v1alpha.EXT4,
+			Status:     storage_v1alpha.PROVISIONING,
+		}
+
+		_, err := controller.provisionVolume(ctx, disk)
+		assert.Error(t, err, "Should fail when directory cannot be created")
+		assert.Contains(t, err.Error(), "failed to create directory")
+	})
+}
+
+func TestDiskController_DirectoryMode_AttachToExistingVolume(t *testing.T) {
+	t.Run("attaches to existing directory", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		// Pre-create the directory
+		volumeId := "existing-vol-123"
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		err := os.MkdirAll(diskDataPath, 0755)
+		require.NoError(t, err)
+
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/test-attach"),
+			Name:         "test-attach",
+			SizeGb:       10,
+			Filesystem:   storage_v1alpha.EXT4,
+			Status:       storage_v1alpha.PROVISIONING,
+			LsvdVolumeId: volumeId,
+		}
+
+		err = controller.attachToExistingVolume(ctx, disk)
+		require.NoError(t, err)
+		assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status)
+	})
+
+	t.Run("fails when directory does not exist", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		volumeId := "nonexistent-vol-456"
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/test-notfound"),
+			Name:         "test-notfound",
+			SizeGb:       10,
+			Filesystem:   storage_v1alpha.EXT4,
+			Status:       storage_v1alpha.PROVISIONING,
+			LsvdVolumeId: volumeId,
+		}
+
+		err := controller.attachToExistingVolume(ctx, disk)
+		assert.Error(t, err, "Should fail when directory doesn't exist")
+		assert.Contains(t, err.Error(), "does not exist")
+	})
+
+	t.Run("handles permission error gracefully", func(t *testing.T) {
+		if os.Getuid() == 0 {
+			t.Skip("Skipping permission test when running as root")
+		}
+
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		// Create directory with no permissions
+		volumeId := "no-perms-vol"
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		err := os.MkdirAll(diskDataPath, 0000)
+		require.NoError(t, err)
+		defer os.Chmod(diskDataPath, 0755) // Restore for cleanup
+
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/test-perms"),
+			Name:         "test-perms",
+			SizeGb:       10,
+			Filesystem:   storage_v1alpha.EXT4,
+			Status:       storage_v1alpha.PROVISIONING,
+			LsvdVolumeId: volumeId,
+		}
+
+		err = controller.attachToExistingVolume(ctx, disk)
+		// Stat should still succeed even with 0000 perms for the owner
+		// So this test might not fail as expected - adjust expectations
+		if err != nil {
+			assert.Contains(t, err.Error(), "permission denied")
+		}
+	})
+}
+
+func TestDiskController_DirectoryMode_HandleProvisioned(t *testing.T) {
+	t.Run("verifies directory exists for provisioned disk", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		// Pre-create the directory
+		volumeId := "provisioned-vol-789"
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		err := os.MkdirAll(diskDataPath, 0755)
+		require.NoError(t, err)
+
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/test-provisioned"),
+			Name:         "test-provisioned",
+			SizeGb:       10,
+			Filesystem:   storage_v1alpha.EXT4,
+			Status:       storage_v1alpha.PROVISIONED,
+			LsvdVolumeId: volumeId,
+		}
+
+		err = controller.handleProvisioned(ctx, disk)
+		require.NoError(t, err)
+		assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status, "Status should remain PROVISIONED")
+	})
+
+	t.Run("re-provisions when directory is missing", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		volumeId := "missing-vol-101"
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/test-missing"),
+			Name:         "test-missing",
+			SizeGb:       10,
+			Filesystem:   storage_v1alpha.EXT4,
+			Status:       storage_v1alpha.PROVISIONED,
+			LsvdVolumeId: volumeId,
+		}
+
+		err := controller.handleProvisioned(ctx, disk)
+		require.NoError(t, err)
+
+		// After re-provisioning, a new volume ID should be assigned
+		assert.NotEqual(t, volumeId, disk.LsvdVolumeId, "Should have new volume ID after re-provisioning")
+		assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status)
+
+		// Verify the new directory was created
+		newDiskDataPath := filepath.Join(tempDir, "disk-data", disk.LsvdVolumeId)
+		stat, err := os.Stat(newDiskDataPath)
+		require.NoError(t, err, "New directory should exist")
+		assert.True(t, stat.IsDir())
+	})
+
+	t.Run("re-provisions when volume ID is empty", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		disk := &storage_v1alpha.Disk{
+			ID:         entity.Id("disk/test-empty-vol"),
+			Name:       "test-empty-vol",
+			SizeGb:     10,
+			Filesystem: storage_v1alpha.EXT4,
+			Status:     storage_v1alpha.PROVISIONED,
+			// No LsvdVolumeId
+		}
+
+		err := controller.handleProvisioned(ctx, disk)
+		require.NoError(t, err)
+
+		// Should have provisioned a new volume
+		assert.NotEmpty(t, disk.LsvdVolumeId, "Should have provisioned new volume")
+		assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status)
+
+		// Verify directory was created
+		diskDataPath := filepath.Join(tempDir, "disk-data", disk.LsvdVolumeId)
+		stat, err := os.Stat(diskDataPath)
+		require.NoError(t, err, "Directory should exist")
+		assert.True(t, stat.IsDir())
+	})
+}
+
+func TestDiskController_DirectoryMode_HandleProvisioning(t *testing.T) {
+	t.Run("full provisioning workflow in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		disk := &storage_v1alpha.Disk{
+			ID:         entity.Id("disk/test-workflow"),
+			Name:       "test-workflow",
+			SizeGb:     50,
+			Filesystem: storage_v1alpha.XFS,
+			Status:     storage_v1alpha.PROVISIONING,
+		}
+
+		err := controller.handleProvisioning(ctx, disk)
+		require.NoError(t, err)
+
+		// Verify disk state after provisioning
+		assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status)
+		assert.NotEmpty(t, disk.LsvdVolumeId)
+
+		// Verify directory was created
+		diskDataPath := filepath.Join(tempDir, "disk-data", disk.LsvdVolumeId)
+		stat, err := os.Stat(diskDataPath)
+		require.NoError(t, err, "Directory should exist")
+		assert.True(t, stat.IsDir())
+
+		// Verify permissions
+		assert.Equal(t, os.FileMode(0755), stat.Mode().Perm())
+	})
+
+	t.Run("attach mode in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		// Pre-create existing directory
+		existingVolumeId := "attach-vol-202"
+		diskDataPath := filepath.Join(tempDir, "disk-data", existingVolumeId)
+		err := os.MkdirAll(diskDataPath, 0755)
+		require.NoError(t, err)
+
+		// Write some test data to verify directory is reused
+		testFile := filepath.Join(diskDataPath, "test.txt")
+		err = os.WriteFile(testFile, []byte("existing data"), 0644)
+		require.NoError(t, err)
+
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/test-attach-mode"),
+			Name:         "test-attach-mode",
+			SizeGb:       25,
+			Filesystem:   storage_v1alpha.EXT4,
+			Status:       storage_v1alpha.PROVISIONING,
+			LsvdVolumeId: existingVolumeId, // Attach to existing
+		}
+
+		err = controller.handleProvisioning(ctx, disk)
+		require.NoError(t, err)
+
+		assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status)
+		assert.Equal(t, existingVolumeId, disk.LsvdVolumeId, "Should keep original volume ID")
+
+		// Verify existing data is still there
+		data, err := os.ReadFile(testFile)
+		require.NoError(t, err)
+		assert.Equal(t, "existing data", string(data), "Should preserve existing directory contents")
+	})
+}
+
+func TestDiskController_DirectoryMode_ReconcileDisk(t *testing.T) {
+	t.Run("reconciles disk in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		disk := &storage_v1alpha.Disk{
+			ID:         entity.Id("disk/test-reconcile"),
+			Name:       "test-reconcile",
+			SizeGb:     15,
+			Filesystem: storage_v1alpha.EXT4,
+			Status:     storage_v1alpha.PROVISIONING,
+		}
+
+		meta := &entity.Meta{
+			Entity: entity.New(disk.Encode()),
+		}
+
+		err := controller.reconcileDisk(ctx, disk, meta)
+		require.NoError(t, err)
+
+		// Should transition to PROVISIONED
+		assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status)
+		assert.NotEmpty(t, disk.LsvdVolumeId)
+	})
+
+	t.Run("handles ATTACHED status in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		volumeId := "attached-vol-303"
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/test-attached"),
+			Name:         "test-attached",
+			SizeGb:       20,
+			Filesystem:   storage_v1alpha.EXT4,
+			Status:       storage_v1alpha.ATTACHED,
+			LsvdVolumeId: volumeId,
+		}
+
+		err := controller.reconcileDisk(ctx, disk, nil)
+		require.NoError(t, err)
+
+		// ATTACHED status should be left as-is (handled by lease controller)
+		assert.Equal(t, storage_v1alpha.ATTACHED, disk.Status)
+	})
+
+	t.Run("handles ERROR status in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		disk := &storage_v1alpha.Disk{
+			ID:         entity.Id("disk/test-error"),
+			Name:       "test-error",
+			SizeGb:     10,
+			Filesystem: storage_v1alpha.EXT4,
+			Status:     storage_v1alpha.ERROR,
+		}
+
+		err := controller.reconcileDisk(ctx, disk, nil)
+		require.NoError(t, err)
+
+		// ERROR status should remain terminal
+		assert.Equal(t, storage_v1alpha.ERROR, disk.Status)
+	})
+}
+
+func TestDiskController_DirectoryMode_Integration(t *testing.T) {
+	t.Run("full lifecycle in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		// Step 1: Create disk
+		disk := &storage_v1alpha.Disk{
+			ID:         entity.Id("disk/lifecycle-test"),
+			Name:       "lifecycle-test",
+			SizeGb:     30,
+			Filesystem: storage_v1alpha.EXT4,
+			Status:     storage_v1alpha.PROVISIONING,
+		}
+
+		meta := &entity.Meta{
+			Entity: entity.New(disk.Encode()),
+		}
+
+		err := controller.Create(ctx, disk, meta)
+		require.NoError(t, err)
+		assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status)
+		assert.NotEmpty(t, disk.LsvdVolumeId)
+
+		volumeId := disk.LsvdVolumeId
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+
+		// Verify directory exists
+		stat, err := os.Stat(diskDataPath)
+		require.NoError(t, err)
+		assert.True(t, stat.IsDir())
+
+		// Step 2: Update disk (verify it stays provisioned)
+		disk.Status = storage_v1alpha.PROVISIONED
+		err = controller.Update(ctx, disk, meta)
+		require.NoError(t, err)
+		assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status)
+		assert.Equal(t, volumeId, disk.LsvdVolumeId)
+
+		// Step 3: Delete disk
+		disk.Status = storage_v1alpha.DELETING
+		err = controller.reconcileDisk(ctx, disk, meta)
+		require.NoError(t, err)
+
+		// Directory should still exist (deleteVolumeData is a stub)
+		_, err = os.Stat(diskDataPath)
+		assert.NoError(t, err, "Directory still exists (deletion is stubbed)")
+	})
+
+	t.Run("multiple disks in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		controller := NewDiskControllerWithMountPath(log, nil, nil, tempDir)
+		controller.directoryMode = true
+
+		// Create multiple disks
+		numDisks := 5
+		disks := make([]*storage_v1alpha.Disk, numDisks)
+
+		for i := 0; i < numDisks; i++ {
+			disk := &storage_v1alpha.Disk{
+				ID:         entity.Id("disk/multi-" + string(rune('a'+i))),
+				Name:       "multi-test-" + string(rune('a'+i)),
+				SizeGb:     int64(10 * (i + 1)),
+				Filesystem: storage_v1alpha.EXT4,
+				Status:     storage_v1alpha.PROVISIONING,
+			}
+
+			err := controller.handleProvisioning(ctx, disk)
+			require.NoError(t, err)
+
+			disks[i] = disk
+			assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status)
+			assert.NotEmpty(t, disk.LsvdVolumeId)
+		}
+
+		// Verify all directories exist
+		for i, disk := range disks {
+			diskDataPath := filepath.Join(tempDir, "disk-data", disk.LsvdVolumeId)
+			stat, err := os.Stat(diskDataPath)
+			require.NoError(t, err, "Directory for disk %d should exist", i)
+			assert.True(t, stat.IsDir())
+		}
+
+		// Verify all volume IDs are unique
+		volumeIds := make(map[string]bool)
+		for _, disk := range disks {
+			assert.False(t, volumeIds[disk.LsvdVolumeId], "Volume IDs should be unique")
+			volumeIds[disk.LsvdVolumeId] = true
+		}
+	})
+}
+
+func TestDiskController_DirectoryMode_WithNormalMode(t *testing.T) {
+	t.Run("directory mode does not affect LSVD client when disabled", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := &mockLsvdClient{
+			createInSegmentAccessFunc: func(ctx context.Context, volumeId string, sizeGb int64, filesystem string) error {
+				return nil
+			},
+		}
+
+		controller := NewDiskControllerWithMountPath(log, nil, mockClient, tempDir)
+		controller.directoryMode = false // Normal mode
+
+		disk := &storage_v1alpha.Disk{
+			ID:         entity.Id("disk/normal-mode"),
+			Name:       "normal-mode",
+			SizeGb:     10,
+			Filesystem: storage_v1alpha.EXT4,
+			Status:     storage_v1alpha.PROVISIONING,
+		}
+
+		volumeId, err := controller.provisionVolume(ctx, disk)
+		require.NoError(t, err)
+		assert.NotEmpty(t, volumeId)
+
+		// In normal mode, should NOT create a directory
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		_, err = os.Stat(diskDataPath)
+		assert.True(t, os.IsNotExist(err), "Directory should not exist in normal mode")
+	})
+}

--- a/controllers/disk/disk_lease_controller_directory_test.go
+++ b/controllers/disk/disk_lease_controller_directory_test.go
@@ -1,0 +1,706 @@
+package disk
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+func TestDiskLeaseController_DirectoryMode_Init(t *testing.T) {
+	t.Run("enables directory mode when NBD unavailable", func(t *testing.T) {
+		log := slog.Default()
+		controller := NewDiskLeaseController(log, nil, nil)
+
+		// Set environment to disable NBD
+		t.Setenv("MIREN_DISABLE_NBD", "1")
+
+		err := controller.Init(context.Background())
+		require.NoError(t, err)
+
+		assert.True(t, controller.directoryMode, "Directory mode should be enabled when NBD is unavailable")
+	})
+
+	t.Run("disables directory mode when NBD available", func(t *testing.T) {
+		log := slog.Default()
+		controller := NewDiskLeaseController(log, nil, nil)
+
+		// Don't set MIREN_DISABLE_NBD - NBD availability depends on system
+		err := controller.Init(context.Background())
+		require.NoError(t, err)
+
+		// We can't assert a specific value here since it depends on the system
+		// Just verify Init doesn't error
+	})
+}
+
+func TestDiskLeaseController_DirectoryMode_HandlePendingLease(t *testing.T) {
+	t.Run("binds lease to directory without mounting", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		// Create directory for the volume
+		volumeId := "dir-vol-123"
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		err := os.MkdirAll(diskDataPath, 0755)
+		require.NoError(t, err)
+
+		// Create a test disk
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/dir-test-disk"),
+			Status:       storage_v1alpha.PROVISIONED,
+			LsvdVolumeId: volumeId,
+			Filesystem:   storage_v1alpha.EXT4,
+		}
+		dlc.SetTestDisk(disk)
+
+		// Create a pending lease
+		lease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/dir-test-lease"),
+			DiskId:    entity.Id("disk/dir-test-disk"),
+			SandboxId: entity.Id("sandbox/dir-test-sandbox"),
+			Status:    storage_v1alpha.PENDING,
+			Mount: storage_v1alpha.Mount{
+				Path:     "/data",
+				ReadOnly: false,
+			},
+		}
+
+		// Process the lease
+		meta := &entity.Meta{}
+		err = dlc.Create(ctx, lease, meta)
+		require.NoError(t, err)
+
+		// Should update status to BOUND
+		assert.Equal(t, storage_v1alpha.BOUND, lease.Status)
+		assert.Empty(t, lease.ErrorMessage)
+
+		// Verify no volume was mounted in the mock client (directory mode)
+		for _, vol := range mockClient.volumes {
+			assert.NotEqual(t, VolumeStatusMounted, vol.Status, "No volumes should be mounted in directory mode")
+		}
+
+		// Verify lease is tracked
+		currentLease, exists := dlc.activeLeases["disk/dir-test-disk"]
+		assert.True(t, exists)
+		assert.Equal(t, "disk-lease/dir-test-lease", currentLease)
+	})
+
+	t.Run("fails when directory does not exist", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		volumeId := "missing-dir-vol"
+		// Don't create the directory
+
+		// Create a test disk
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/missing-dir-disk"),
+			Status:       storage_v1alpha.PROVISIONED,
+			LsvdVolumeId: volumeId,
+			Filesystem:   storage_v1alpha.EXT4,
+		}
+		dlc.SetTestDisk(disk)
+
+		// Create a pending lease
+		lease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/missing-dir-lease"),
+			DiskId:    entity.Id("disk/missing-dir-disk"),
+			SandboxId: entity.Id("sandbox/missing-dir-sandbox"),
+			Status:    storage_v1alpha.PENDING,
+			Mount: storage_v1alpha.Mount{
+				Path: "/data",
+			},
+		}
+
+		// Process the lease
+		meta := &entity.Meta{}
+		err := dlc.Create(ctx, lease, meta)
+		require.NoError(t, err)
+
+		// Should update status to FAILED
+		assert.Equal(t, storage_v1alpha.FAILED, lease.Status)
+		assert.Contains(t, lease.ErrorMessage, "Directory not found")
+
+		// Verify lease is not tracked
+		_, exists := dlc.activeLeases["disk/missing-dir-disk"]
+		assert.False(t, exists, "Failed lease should not be tracked")
+	})
+
+	t.Run("handles disk provisioning in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		// Create a disk that is still provisioning
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/provisioning-dir-disk"),
+			Status:       storage_v1alpha.PROVISIONING,
+			LsvdVolumeId: "",
+			SizeGb:       10,
+			Filesystem:   storage_v1alpha.EXT4,
+		}
+		dlc.SetTestDisk(disk)
+
+		// Create a pending lease
+		lease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/provisioning-dir-lease"),
+			DiskId:    entity.Id("disk/provisioning-dir-disk"),
+			SandboxId: entity.Id("sandbox/provisioning-dir-sandbox"),
+			Status:    storage_v1alpha.PENDING,
+			Mount: storage_v1alpha.Mount{
+				Path: "/data",
+			},
+		}
+
+		// First reconciliation - disk is still provisioning
+		meta := &entity.Meta{}
+		err := dlc.Create(ctx, lease, meta)
+		require.NoError(t, err)
+
+		// Lease should remain in PENDING state
+		assert.Equal(t, storage_v1alpha.PENDING, lease.Status)
+
+		// Now simulate disk becoming provisioned
+		volumeId := "provisioned-dir-vol"
+		disk.Status = storage_v1alpha.PROVISIONED
+		disk.LsvdVolumeId = volumeId
+
+		// Create the directory
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		err = os.MkdirAll(diskDataPath, 0755)
+		require.NoError(t, err)
+
+		// Second reconciliation - disk is now provisioned
+		meta2 := &entity.Meta{}
+		err = dlc.Create(ctx, lease, meta2)
+		require.NoError(t, err)
+
+		// Lease should now be BOUND
+		assert.Equal(t, storage_v1alpha.BOUND, lease.Status)
+		assert.Empty(t, lease.ErrorMessage)
+	})
+}
+
+func TestDiskLeaseController_DirectoryMode_HandleBoundLease(t *testing.T) {
+	t.Run("tracks bound lease without mounting in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		// Create directory for the volume
+		volumeId := "bound-dir-vol"
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		err := os.MkdirAll(diskDataPath, 0755)
+		require.NoError(t, err)
+
+		// Create a test disk
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/bound-dir-disk"),
+			Status:       storage_v1alpha.PROVISIONED,
+			LsvdVolumeId: volumeId,
+			Filesystem:   storage_v1alpha.EXT4,
+		}
+		dlc.SetTestDisk(disk)
+
+		// Initially, no lease is tracked
+		assert.Empty(t, dlc.activeLeases)
+
+		// Create a bound lease (simulating what we get from EAS)
+		boundLease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/bound-dir-lease"),
+			DiskId:    entity.Id("disk/bound-dir-disk"),
+			SandboxId: entity.Id("sandbox/bound-dir-sandbox"),
+			Status:    storage_v1alpha.BOUND,
+			Mount: storage_v1alpha.Mount{
+				Path:     "/data",
+				ReadOnly: false,
+			},
+		}
+
+		// Process the bound lease
+		meta := &entity.Meta{}
+		err = dlc.Update(ctx, boundLease, meta)
+		require.NoError(t, err)
+
+		// Verify the lease is now tracked as active
+		currentLease, hasLease := dlc.activeLeases["disk/bound-dir-disk"]
+		assert.True(t, hasLease, "Bound lease should be tracked")
+		assert.Equal(t, "disk-lease/bound-dir-lease", currentLease)
+
+		// Verify no volumes were mounted
+		for _, vol := range mockClient.volumes {
+			assert.NotEqual(t, VolumeStatusMounted, vol.Status, "No volumes should be mounted in directory mode")
+		}
+	})
+
+	t.Run("handles bound lease with missing directory gracefully", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		volumeId := "missing-bound-dir-vol"
+		// Don't create the directory
+
+		// Create a test disk
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/missing-bound-dir-disk"),
+			Status:       storage_v1alpha.PROVISIONED,
+			LsvdVolumeId: volumeId,
+			Filesystem:   storage_v1alpha.EXT4,
+		}
+		dlc.SetTestDisk(disk)
+
+		// Pre-track the lease (simulating it was bound earlier)
+		dlc.activeLeases["disk/missing-bound-dir-disk"] = "disk-lease/missing-bound-dir-lease"
+		dlc.leaseDetails["disk-lease/missing-bound-dir-lease"] = &leaseInfo{
+			leaseId:   "disk-lease/missing-bound-dir-lease",
+			diskId:    "disk/missing-bound-dir-disk",
+			sandboxId: "sandbox/missing-bound-dir-sandbox",
+			volumeId:  volumeId,
+		}
+
+		// Create a bound lease
+		boundLease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/missing-bound-dir-lease"),
+			DiskId:    entity.Id("disk/missing-bound-dir-disk"),
+			SandboxId: entity.Id("sandbox/missing-bound-dir-sandbox"),
+			Status:    storage_v1alpha.BOUND,
+			Mount: storage_v1alpha.Mount{
+				Path: "/data",
+			},
+		}
+
+		// Process the bound lease - should not fail even if directory is missing
+		meta := &entity.Meta{}
+		err := dlc.Update(ctx, boundLease, meta)
+		require.NoError(t, err)
+
+		// In directory mode, handleBoundLease doesn't verify directory exists for already-tracked leases
+		// It just returns early
+		assert.Equal(t, storage_v1alpha.BOUND, boundLease.Status)
+	})
+
+	t.Run("bound lease is idempotent in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		// Create directory
+		volumeId := "idempotent-dir-vol"
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		err := os.MkdirAll(diskDataPath, 0755)
+		require.NoError(t, err)
+
+		// Create a test disk
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/idempotent-dir-disk"),
+			Status:       storage_v1alpha.PROVISIONED,
+			LsvdVolumeId: volumeId,
+			Filesystem:   storage_v1alpha.EXT4,
+		}
+		dlc.SetTestDisk(disk)
+
+		// Pre-track the lease
+		dlc.activeLeases["disk/idempotent-dir-disk"] = "disk-lease/idempotent-dir-lease"
+		dlc.leaseDetails["disk-lease/idempotent-dir-lease"] = &leaseInfo{
+			leaseId:   "disk-lease/idempotent-dir-lease",
+			diskId:    "disk/idempotent-dir-disk",
+			sandboxId: "sandbox/idempotent-dir-sandbox",
+			volumeId:  volumeId,
+		}
+
+		// Create a bound lease
+		boundLease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/idempotent-dir-lease"),
+			DiskId:    entity.Id("disk/idempotent-dir-disk"),
+			SandboxId: entity.Id("sandbox/idempotent-dir-sandbox"),
+			Status:    storage_v1alpha.BOUND,
+			Mount: storage_v1alpha.Mount{
+				Path: "/data",
+			},
+		}
+
+		// Process the bound lease multiple times
+		for i := 0; i < 3; i++ {
+			meta := &entity.Meta{}
+			err := dlc.Update(ctx, boundLease, meta)
+			require.NoError(t, err, "Iteration %d should succeed", i)
+			assert.Equal(t, storage_v1alpha.BOUND, boundLease.Status)
+		}
+
+		// Verify lease is still tracked
+		currentLease, exists := dlc.activeLeases["disk/idempotent-dir-disk"]
+		assert.True(t, exists)
+		assert.Equal(t, "disk-lease/idempotent-dir-lease", currentLease)
+
+		// Verify no volumes were mounted
+		assert.Empty(t, mockClient.volumes, "No volumes should be created in directory mode")
+	})
+}
+
+func TestDiskLeaseController_DirectoryMode_HandleReleasedLease(t *testing.T) {
+	t.Run("releases lease without unmounting in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		volumeId := "released-dir-vol"
+
+		// Setup active lease
+		dlc.activeLeases["disk/released-dir-disk"] = "disk-lease/released-dir-lease"
+		dlc.leaseDetails["disk-lease/released-dir-lease"] = &leaseInfo{
+			leaseId:   "disk-lease/released-dir-lease",
+			diskId:    "disk/released-dir-disk",
+			sandboxId: "sandbox/released-dir-sandbox",
+			volumeId:  volumeId,
+		}
+
+		// Create a released lease
+		releasedLease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/released-dir-lease"),
+			DiskId:    entity.Id("disk/released-dir-disk"),
+			SandboxId: entity.Id("sandbox/released-dir-sandbox"),
+			Status:    storage_v1alpha.RELEASED,
+		}
+
+		// Process the release
+		meta := &entity.Meta{}
+		err := dlc.Update(ctx, releasedLease, meta)
+		require.NoError(t, err)
+
+		// Should remove from active leases
+		_, exists := dlc.activeLeases["disk/released-dir-disk"]
+		assert.False(t, exists, "Should remove released lease from active leases")
+
+		// Should remove from lease details
+		_, detailsExist := dlc.leaseDetails["disk-lease/released-dir-lease"]
+		assert.False(t, detailsExist, "Should remove from lease details")
+
+		// Verify no unmount was attempted (no volumes in mock client)
+		assert.Empty(t, mockClient.volumes, "No volumes should exist in directory mode")
+	})
+
+	t.Run("release is idempotent in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		// Setup: No active lease (already released)
+		releasedLease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/already-released-dir"),
+			DiskId:    entity.Id("disk/already-released-dir"),
+			SandboxId: entity.Id("sandbox/released-dir-sandbox"),
+			Status:    storage_v1alpha.RELEASED,
+		}
+
+		// Process the release multiple times - should be idempotent
+		for i := 0; i < 3; i++ {
+			meta := &entity.Meta{}
+			err := dlc.Update(ctx, releasedLease, meta)
+			require.NoError(t, err, "Iteration %d should succeed", i)
+		}
+
+		// Verify no lease is tracked
+		_, exists := dlc.activeLeases["disk/already-released-dir"]
+		assert.False(t, exists, "No lease should be tracked")
+	})
+}
+
+func TestDiskLeaseController_DirectoryMode_Delete(t *testing.T) {
+	t.Run("deletes lease without unmounting in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		volumeId := "delete-dir-vol"
+
+		// Setup active lease and lease details
+		dlc.activeLeases["disk/delete-dir-disk"] = "disk-lease/delete-dir-lease"
+		dlc.leaseDetails["disk-lease/delete-dir-lease"] = &leaseInfo{
+			leaseId:   "disk-lease/delete-dir-lease",
+			diskId:    "disk/delete-dir-disk",
+			sandboxId: "sandbox/delete-dir-sandbox",
+			volumeId:  volumeId,
+		}
+
+		// Process the deletion
+		err := dlc.Delete(ctx, entity.Id("disk-lease/delete-dir-lease"))
+		require.NoError(t, err)
+
+		// Should remove from active leases
+		_, exists := dlc.activeLeases["disk/delete-dir-disk"]
+		assert.False(t, exists, "Should remove lease from active leases")
+
+		// Should remove from lease details
+		_, detailsExist := dlc.leaseDetails["disk-lease/delete-dir-lease"]
+		assert.False(t, detailsExist, "Should remove lease from lease details")
+
+		// Verify no unmount was attempted
+		assert.Empty(t, mockClient.volumes, "No volumes should exist in directory mode")
+	})
+
+	t.Run("delete is idempotent in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		leaseId := entity.Id("disk-lease/idempotent-delete-dir")
+
+		// First deletion - lease doesn't exist
+		err := dlc.Delete(ctx, leaseId)
+		require.NoError(t, err)
+
+		// Second deletion - should still work
+		err = dlc.Delete(ctx, leaseId)
+		require.NoError(t, err)
+	})
+}
+
+func TestDiskLeaseController_DirectoryMode_Integration(t *testing.T) {
+	t.Run("full lifecycle in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		// Create directory for the volume
+		volumeId := "lifecycle-dir-vol"
+		diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+		err := os.MkdirAll(diskDataPath, 0755)
+		require.NoError(t, err)
+
+		// Create a test disk
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/lifecycle-dir-disk"),
+			Status:       storage_v1alpha.PROVISIONED,
+			LsvdVolumeId: volumeId,
+			Filesystem:   storage_v1alpha.EXT4,
+		}
+		dlc.SetTestDisk(disk)
+
+		// Step 1: Create and bind a pending lease
+		lease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/lifecycle-dir-lease"),
+			DiskId:    entity.Id("disk/lifecycle-dir-disk"),
+			SandboxId: entity.Id("sandbox/lifecycle-dir-sandbox"),
+			Status:    storage_v1alpha.PENDING,
+			Mount: storage_v1alpha.Mount{
+				Path: "/data",
+			},
+		}
+
+		meta := &entity.Meta{}
+		err = dlc.Create(ctx, lease, meta)
+		require.NoError(t, err)
+
+		// Verify lease is bound
+		assert.Equal(t, storage_v1alpha.BOUND, lease.Status)
+		currentLease, exists := dlc.activeLeases["disk/lifecycle-dir-disk"]
+		assert.True(t, exists)
+		assert.Equal(t, "disk-lease/lifecycle-dir-lease", currentLease)
+
+		// Step 2: Update bound lease (should be idempotent)
+		lease.Status = storage_v1alpha.BOUND
+		meta2 := &entity.Meta{}
+		err = dlc.Update(ctx, lease, meta2)
+		require.NoError(t, err)
+		assert.Equal(t, storage_v1alpha.BOUND, lease.Status)
+
+		// Step 3: Release the lease
+		lease.Status = storage_v1alpha.RELEASED
+		meta3 := &entity.Meta{}
+		err = dlc.Update(ctx, lease, meta3)
+		require.NoError(t, err)
+
+		// Verify lease is released
+		_, exists = dlc.activeLeases["disk/lifecycle-dir-disk"]
+		assert.False(t, exists)
+
+		// Step 4: Delete the lease
+		err = dlc.Delete(ctx, lease.ID)
+		require.NoError(t, err)
+
+		// Verify complete cleanup
+		assert.Empty(t, dlc.activeLeases)
+		assert.Empty(t, dlc.leaseDetails)
+		assert.Empty(t, mockClient.volumes, "No volumes should have been created in directory mode")
+	})
+
+	t.Run("multiple concurrent leases in directory mode", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = true
+
+		// Create multiple disks and directories
+		numDisks := 3
+		for i := 0; i < numDisks; i++ {
+			volumeId := "multi-dir-vol-" + string(rune('a'+i))
+			diskDataPath := filepath.Join(tempDir, "disk-data", volumeId)
+			err := os.MkdirAll(diskDataPath, 0755)
+			require.NoError(t, err)
+
+			diskId := "disk/multi-dir-disk-" + string(rune('a'+i))
+			disk := &storage_v1alpha.Disk{
+				ID:           entity.Id(diskId),
+				Status:       storage_v1alpha.PROVISIONED,
+				LsvdVolumeId: volumeId,
+				Filesystem:   storage_v1alpha.EXT4,
+			}
+			dlc.SetTestDisk(disk)
+
+			// Create and bind lease
+			leaseId := "disk-lease/multi-dir-lease-" + string(rune('a'+i))
+			lease := &storage_v1alpha.DiskLease{
+				ID:        entity.Id(leaseId),
+				DiskId:    entity.Id(diskId),
+				SandboxId: entity.Id("sandbox/multi-dir-sandbox"),
+				Status:    storage_v1alpha.PENDING,
+				Mount: storage_v1alpha.Mount{
+					Path: "/data" + string(rune('a'+i)),
+				},
+			}
+
+			meta := &entity.Meta{}
+			err = dlc.Create(ctx, lease, meta)
+			require.NoError(t, err)
+			assert.Equal(t, storage_v1alpha.BOUND, lease.Status)
+		}
+
+		// Verify all leases are tracked
+		assert.Equal(t, numDisks, len(dlc.activeLeases))
+		assert.Equal(t, numDisks, len(dlc.leaseDetails))
+
+		// Release all leases
+		for i := 0; i < numDisks; i++ {
+			leaseId := "disk-lease/multi-dir-lease-" + string(rune('a'+i))
+			diskId := "disk/multi-dir-disk-" + string(rune('a'+i))
+
+			lease := &storage_v1alpha.DiskLease{
+				ID:        entity.Id(leaseId),
+				DiskId:    entity.Id(diskId),
+				SandboxId: entity.Id("sandbox/multi-dir-sandbox"),
+				Status:    storage_v1alpha.RELEASED,
+			}
+
+			meta := &entity.Meta{}
+			err := dlc.Update(ctx, lease, meta)
+			require.NoError(t, err)
+		}
+
+		// Verify all leases are released
+		assert.Empty(t, dlc.activeLeases)
+		assert.Empty(t, dlc.leaseDetails)
+	})
+}
+
+func TestDiskLeaseController_DirectoryMode_WithNormalMode(t *testing.T) {
+	t.Run("directory mode does not affect LSVD mounting when disabled", func(t *testing.T) {
+		ctx := context.Background()
+		tempDir := t.TempDir()
+		log := slog.Default()
+
+		mockClient := NewMockLsvdClient()
+		dlc := NewDiskLeaseControllerWithMountPath(log, nil, mockClient, tempDir)
+		dlc.directoryMode = false // Normal mode
+
+		volumeId := "normal-mode-vol"
+
+		// Add volume to mock client
+		mockClient.volumes[volumeId] = VolumeInfo{
+			ID:         volumeId,
+			Name:       volumeId,
+			SizeBytes:  10 * 1024 * 1024 * 1024,
+			Status:     VolumeStatusOnDisk,
+			Filesystem: "ext4",
+		}
+
+		// Create a test disk
+		disk := &storage_v1alpha.Disk{
+			ID:           entity.Id("disk/normal-mode-disk"),
+			Status:       storage_v1alpha.PROVISIONED,
+			LsvdVolumeId: volumeId,
+			Filesystem:   storage_v1alpha.EXT4,
+		}
+		dlc.SetTestDisk(disk)
+
+		// Create a pending lease
+		lease := &storage_v1alpha.DiskLease{
+			ID:        entity.Id("disk-lease/normal-mode-lease"),
+			DiskId:    entity.Id("disk/normal-mode-disk"),
+			SandboxId: entity.Id("sandbox/normal-mode-sandbox"),
+			Status:    storage_v1alpha.PENDING,
+			Mount: storage_v1alpha.Mount{
+				Path: "/data",
+			},
+		}
+
+		// Process the lease
+		meta := &entity.Meta{}
+		err := dlc.Create(ctx, lease, meta)
+		require.NoError(t, err)
+
+		// In normal mode, should mount the volume
+		assert.Equal(t, storage_v1alpha.BOUND, lease.Status)
+
+		// Verify volume was mounted
+		vol := mockClient.volumes[volumeId]
+		assert.Equal(t, VolumeStatusMounted, vol.Status, "Volume should be mounted in normal mode")
+		assert.NotEmpty(t, vol.MountPath, "Mount path should be set in normal mode")
+	})
+}


### PR DESCRIPTION
The disks won't be persistented by miren.cloud, but they'll at least work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now automatically detects NBD availability and switches to directory-based disk operations when unavailable, improving compatibility across different environments.

* **Tests**
  * Comprehensive test coverage added for directory-based disk and lease management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->