### PR TITLE
Fix release workflow to only run for main and tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,8 @@ jobs:
             }
   package:
     needs: check-test-success
+    # Only build releases for main branch or version tags
+    if: ${{ github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v') }}
     strategy:
       matrix:
         include:
@@ -129,8 +131,8 @@ jobs:
 
     - name: Build and package for ${{ matrix.arch }}
       env:
-        GIT_BRANCH: ${{ github.ref_name }}
-        GIT_COMMIT: ${{ github.sha }}
+        GIT_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        GIT_COMMIT: ${{ github.event.workflow_run.head_sha }}
       run: |
         # Pass git info from GitHub Actions context to avoid git commands in iso
         export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -166,7 +168,7 @@ jobs:
                 "fields": [
                   {
                     "type": "mrkdwn",
-                    "text": "*Branch:*\n`${{ github.ref_name }}`"
+                    "text": "*Branch:*\n`${{ github.event.workflow_run.head_branch }}`"
                   },
                   {
                     "type": "mrkdwn",
@@ -285,11 +287,12 @@ jobs:
       - name: Determine Docker tags
         id: docker-tags
         run: |
-          TAGS="us-central1-docker.pkg.dev/miren-cloud/miren-oci/miren:${{ github.ref_name }}"
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          TAGS="us-central1-docker.pkg.dev/miren-cloud/miren-oci/miren:$HEAD_BRANCH"
 
           # Add latest tag for stable releases only (exclude all prereleases)
           # Prereleases have a hyphen: v0.0.0-test.1, v0.1.0-rc.1, v1.0.0-beta.1, etc.
-          if [[ "${{ github.ref }}" == refs/tags/v* ]] && [[ ! "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+          if [[ "$HEAD_BRANCH" == v* ]] && [[ ! "$HEAD_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
             TAGS="$TAGS
           us-central1-docker.pkg.dev/miren-cloud/miren-oci/miren:latest"
           fi
@@ -332,7 +335,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Branch:*\n`${{ github.ref_name }}`"
+                      "text": "*Branch:*\n`${{ github.event.workflow_run.head_branch }}`"
                     }
                   ]
                 },
@@ -361,7 +364,7 @@ jobs:
     needs: [package, build-binaries]
     runs-on: depot-ubuntu-latest
     concurrency:
-      group: upload-to-miren-${{ github.ref_name }}
+      group: upload-to-miren-${{ github.event.workflow_run.head_branch }}
       cancel-in-progress: false
     permissions:
       id-token: write
@@ -387,12 +390,14 @@ jobs:
         run: |
           set -eo pipefail
 
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+
           # Determine if this is a tag build
           IS_TAG_BUILD=false
           IS_PRERELEASE=false
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$HEAD_BRANCH" == v* ]]; then
             IS_TAG_BUILD=true
-            TAG_NAME="${{ github.ref_name }}"
+            TAG_NAME="$HEAD_BRANCH"
             echo "Building for tag: $TAG_NAME"
 
             # Check if this is a prerelease (has hyphen: v0.0.0-test.1, v0.1.0-rc.1, etc.)
@@ -414,7 +419,7 @@ jobs:
             fi
           else
             # For branches, upload to branch path only
-            paths+=("${{ github.ref_name }}")
+            paths+=("$HEAD_BRANCH")
           fi
 
           echo "Upload paths: ${paths[*]}"
@@ -501,11 +506,11 @@ jobs:
           # Get git information
           COMMIT=$(git rev-parse HEAD)
           COMMIT_SHORT=$(git rev-parse --short HEAD)
-          BRANCH="${{ github.ref_name }}"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           # Determine version string
-          # Note: Uses github.ref_name pattern matching (workflow context) rather than
+          # Note: Uses workflow_run head_branch pattern matching rather than
           # git describe (used in build scripts). Produces equivalent results for tagged releases.
           if [[ $BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             VERSION="$BRANCH"
@@ -565,7 +570,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Branch:*\n`${{ github.ref_name }}`"
+                      "text": "*Branch:*\n`${{ github.event.workflow_run.head_branch }}`"
                     }
                   ]
                 },
@@ -594,24 +599,24 @@ jobs:
         if: success()
         run: |
           # Determine what was uploaded
-          REF_NAME="${{ github.ref_name }}"
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
           IS_TAG=false
           IS_PRERELEASE=false
           RELEASE_TYPE="Branch build"
 
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$HEAD_BRANCH" == v* ]]; then
             IS_TAG=true
             # Check if it's a prerelease (has hyphen)
-            if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+            if [[ "$HEAD_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
               IS_PRERELEASE=true
               RELEASE_TYPE="Prerelease"
-              PATHS_MSG="Uploaded to: \`$REF_NAME\` only (prereleases don't update \`latest\`)"
+              PATHS_MSG="Uploaded to: \`$HEAD_BRANCH\` only (prereleases don't update \`latest\`)"
             else
               RELEASE_TYPE="Stable release"
-              PATHS_MSG="Uploaded to: \`$REF_NAME\` and \`latest\`"
+              PATHS_MSG="Uploaded to: \`$HEAD_BRANCH\` and \`latest\`"
             fi
           else
-            PATHS_MSG="Uploaded to: \`$REF_NAME\`"
+            PATHS_MSG="Uploaded to: \`$HEAD_BRANCH\`"
           fi
 
           # Get version from version.json

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release script for creating version tags following RFD-40 conventions
+# Usage: hack/release.sh <version>
+# Examples:
+#   hack/release.sh v0.0.0-test.1    # Test release
+#   hack/release.sh v0.1.0           # Preview release
+#   hack/release.sh v1.0.0           # GA release
+
+VERSION="${1:-}"
+
+if [ -z "$VERSION" ]; then
+  echo "Error: Version required"
+  echo "Usage: $0 <version>"
+  echo ""
+  echo "Examples:"
+  echo "  $0 v0.0.0-test.1    # Test release"
+  echo "  $0 v0.1.0           # Preview release"
+  echo "  $0 v1.0.0           # GA release"
+  exit 1
+fi
+
+# Validate version format
+if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+  echo "Error: Invalid semver format: $VERSION"
+  echo "Must match: v<major>.<minor>.<patch>[-<prerelease>]"
+  exit 1
+fi
+
+# Check we're on main branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo "Error: Must be on main branch (currently on: $CURRENT_BRANCH)"
+  echo "Run: git checkout main"
+  exit 1
+fi
+
+# Check working directory is clean
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: Working directory has uncommitted changes"
+  git status --short
+  exit 1
+fi
+
+# Check we're up to date with origin
+echo "Fetching from origin..."
+git fetch origin main
+
+LOCAL=$(git rev-parse main)
+REMOTE=$(git rev-parse origin/main)
+
+if [ "$LOCAL" != "$REMOTE" ]; then
+  echo "Error: Local main is not up to date with origin/main"
+  echo "Run: git pull origin main"
+  exit 1
+fi
+
+# Check if tag already exists
+if git rev-parse "$VERSION" >/dev/null 2>&1; then
+  echo "Error: Tag $VERSION already exists"
+  exit 1
+fi
+
+# Determine release type
+RELEASE_TYPE=""
+if [[ "$VERSION" =~ ^v0\.0\.0-test\. ]]; then
+  RELEASE_TYPE="Test release"
+elif [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+  RELEASE_TYPE="Prerelease"
+elif [[ "$VERSION" =~ ^v0\. ]]; then
+  RELEASE_TYPE="Preview release"
+else
+  RELEASE_TYPE="GA release"
+fi
+
+# Show what we're about to do
+echo ""
+echo "======================================"
+echo "Creating $RELEASE_TYPE: $VERSION"
+echo "======================================"
+echo "Branch: $CURRENT_BRANCH"
+echo "Commit: $(git rev-parse --short HEAD)"
+echo ""
+
+# Ask for confirmation
+read -p "Continue? (y/N) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Aborted"
+  exit 1
+fi
+
+# Create annotated tag
+TAG_MESSAGE="Release $VERSION
+
+$RELEASE_TYPE created from main branch"
+
+git tag -a "$VERSION" -m "$TAG_MESSAGE"
+
+echo ""
+echo "✓ Created annotated tag: $VERSION"
+echo ""
+
+# Push the tag
+echo "Pushing tag to origin..."
+git push origin "$VERSION"
+
+echo ""
+echo "======================================"
+echo "✓ Release tag pushed successfully"
+echo "======================================"
+echo ""
+echo "What happens next:"
+echo "1. Test workflow runs: https://github.com/mirendev/runtime/actions"
+echo "2. Once tests pass, release workflow builds and uploads"
+if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+  echo "3. Artifacts uploaded to: $VERSION (prereleases don't update 'latest')"
+else
+  echo "3. Artifacts uploaded to: $VERSION and latest"
+fi
+echo "4. Slack notification sent with deployment details"
+echo ""
+echo "Monitor progress:"
+echo "  https://github.com/mirendev/runtime/actions"
+echo ""


### PR DESCRIPTION
## Summary

- Add `hack/release.sh` script for standardized tag creation
- Fix release workflow triggering for every PR (critical bug)

## Problem

The release workflow was triggering for **every PR** after we removed the `branches` filter to support tag-based releases. This caused extraneous release builds and uploads.

Root cause: In `workflow_run` events, `github.ref_name` refers to where the workflow file lives (always "main"), not the ref that triggered the original Test workflow. All conditionals were checking the wrong ref.

## Changes

**1. Add release script (`hack/release.sh`)**
- Validates semver format
- Ensures on main branch with clean working directory
- Creates annotated tags with standardized messages
- Shows next steps after pushing

**2. Fix workflow_run context issues**
- Add job-level filter: only run for `main` or `v*` branches
- Replace all `github.ref_name` → `github.event.workflow_run.head_branch`
- Replace `github.sha` → `github.event.workflow_run.head_sha`
- Updated Docker tagging, upload paths, Slack notifications, concurrency groups

## Result

✅ Main commits trigger releases (uploaded to `main` path)
✅ Version tags trigger releases (uploaded to tag path + `latest` for stable)
❌ PR branches no longer trigger releases

## Test plan

- [ ] Merge this PR
- [ ] Verify no release triggered for this PR's tests
- [ ] Create v0.0.0-test.1 tag using `hack/release.sh v0.0.0-test.1`
- [ ] Verify release uploads to `v0.0.0-test.1` path only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow with improved git context handling for more reliable build and deployment operations
  * Added new automated release script featuring version format validation, automatic release type detection, repository state verification, duplicate tag prevention, and user confirmation prompts for release operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->