### PR TITLE
Don't send test failure notifications for PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,8 @@ jobs:
 
   tests-failed:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion != 'success' }}
+    # Only notify for main branch or version tags, not for every PR
+    if: ${{ github.event.workflow_run.conclusion != 'success' && (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')) }}
     steps:
       - name: Tests failed - blocking release
         run: |


### PR DESCRIPTION
## Problem

After merging PR #379, the `tests-failed` job in the release workflow started running for every PR test failure or cancellation, sending Slack notifications about "Tests failed - Release blocked" even for PRs that shouldn't trigger releases.

## Fix

Added the same branch filter to the `tests-failed` job that we have on the `package` job:
- Only run for `main` branch or version tags (starting with `v`)
- Skip all PR branches

## Result

- ✅ Slack notifications only sent when tests fail for main or tags
- ❌ No more noise from PR test failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to refine test failure notifications, restricting alerts to main branch and version-tagged releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->