### PR TITLE
Fix version baked into binaries for tag builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,8 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ github.event.workflow_run.head_branch }}
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -228,6 +230,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{ github.event.workflow_run.head_branch }}
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
@@ -253,6 +257,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Download amd64 package
         uses: actions/download-artifact@v4
@@ -372,6 +378,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Problem

When upgrading to `v0.0.0-test.1`, the binary had the wrong version baked in:

```bash
$ m upgrade --version v0.0.0-test.1 --force
Upgraded from : to main:c068409  # ❌ Wrong!

$ m version
Version: main:c068409  # ❌ Should be v0.0.0-test.1
```

**Expected:** Binary should show `v0.0.0-test.1`  
**Actual:** Binary shows `main:c068409`

## Root Cause

In `workflow_run` contexts, `actions/checkout@v5` without a `ref` parameter checks out the SHA in **detached HEAD state**. The build scripts run:

```bash
git describe --exact-match --tags HEAD
```

This fails in detached HEAD, so the build falls back to `branch:commit` format, which pulls from the workflow file location (main), not the actual tag.

## Fix

Explicitly checkout the correct ref in all checkout steps:

```yaml
- uses: actions/checkout@v5
  with:
    ref: ${{ github.event.workflow_run.head_branch }}
```

This ensures:
- Tag builds: checks out the tag (e.g., `v0.0.0-test.1`)
- Main builds: checks out main branch  
- `git describe` works correctly and finds the tag

## Test Plan

- [ ] Merge this PR
- [ ] Delete and recreate `v0.0.0-test.1` tag
- [ ] Download and verify binary shows correct version:
  ```bash
  m upgrade --version v0.0.0-test.1 --force
  m version  # Should show: Version: v0.0.0-test.1
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to ensure checkout operations reference the correct branch during automated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->