### PR TITLE
Fix duplicate release notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     # Note: No branches filter - triggers for both main branch and tags
     # This ensures all releases (main builds and tagged releases) wait for tests to pass
 
+concurrency:
+  group: release-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   check-test-success:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes duplicate Slack notifications when multiple PRs are merged to main in rapid succession.

## Problem

When multiple Test workflows complete successfully in quick succession (e.g., 4 PRs merged within 1 minute), each triggers a separate Release workflow via `workflow_run`. Without concurrency control, all Release workflows:
- Check out the same commit (HEAD of main)
- Build identical artifacts
- Send duplicate Slack notifications

## Solution

Add workflow-level concurrency control to the Release workflow:
- Group by branch name
- Cancel in-progress builds when newer ones start
- Ensures only the newest build completes and uploads artifacts

This prevents duplicate notifications and wasted CI resources while ensuring the final artifacts always reflect the latest commit.

## Test plan

- [x] Verified the issue occurred with 4 rapid PRs (commits f34e216, 44f3cd6, c76fc0b, 23552be)
- [ ] Deploy and test with next batch of merged PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved release workflow concurrency handling to prevent redundant jobs and streamline release execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->