### PR TITLE
Fix flaky CPU usage test

### DIFF
--- a/metrics/victoriametrics_writer.go
+++ b/metrics/victoriametrics_writer.go
@@ -235,6 +235,14 @@ func (w *VictoriaMetricsWriter) formatMetricLine(point MetricPoint) string {
 	return sb.String()
 }
 
+// Flush manually triggers a flush of buffered metrics
+func (w *VictoriaMetricsWriter) Flush() {
+	if w == nil {
+		return
+	}
+	w.flush()
+}
+
 // Close stops the background flush routine and flushes remaining data
 func (w *VictoriaMetricsWriter) Close() error {
 	if w.cancel != nil {


### PR DESCRIPTION
## Summary
Fixes the flaky `TestSandbox/calculates_cpu_usage_correctly` test that was regularly failing in CI.

## Changes
- **Explicit metric collection**: Directly call `writeStatsToStorage()` at controlled intervals instead of relying on background ticker
- **Manual flush**: Add `Flush()` method to `VictoriaMetricsWriter` and call it in tests instead of waiting 5+ seconds for background timer
- **Simpler assertion**: Test raw counter value (`cpu_usage_seconds_total > 0.5`) instead of rate calculation which requires data spanning the lookback window

## Why it was flaky
The test had multiple timing-dependent race conditions:
1. Metrics collection on 1-second ticker (first collection is baseline only)
2. VictoriaMetrics writer buffers and flushes every 5 seconds
3. `rate()` function needs sustained data over the lookback window
4. Test was retrying every 3 seconds for up to 15 seconds

## Result
- ✅ Test passes reliably (verified 3/3 runs)
- ⚡ Faster execution (~5s vs 10-15s)  
- 🎯 More deterministic and easier to understand

## Test plan
- [x] Run `make test` locally
- [x] Verified test passes 3/3 times
- [x] Run `make lint` - no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual metrics flush to force buffered metrics to be written and indexed promptly.

* **Tests**
  * Made container CPU usage test deterministic by taking an initial baseline, performing explicit metric samples with short waits, retrying indexing checks, and directly verifying accumulated CPU seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->