### PR TITLE
command: don't warn on a fresh install

### DIFF
--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -66,7 +66,7 @@ func (c *ConfigCentric) LoadCluster() (*clientconfig.ClusterConfig, string, erro
 	if c.Cluster == "" {
 		name = cfg.ActiveCluster()
 		if name == "" {
-			return nil, "", fmt.Errorf("no cluster specified and no active cluster set")
+			return nil, "", nil
 		}
 	} else {
 		name = c.Cluster

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -112,9 +112,9 @@ func setup(ctx context.Context, flags *GlobalFlags, opts any) *Context {
 		LoadConfig() (*clientconfig.Config, error)
 	}); ok {
 		cfg, err := lc.LoadConfig()
-		if err == nil {
+		if cfg != nil {
 			s.ClientConfig = cfg
-		} else {
+		} else if err != nil && !errors.Is(err, clientconfig.ErrNoConfig) {
 			s.Log.Warn("Failed to load client config", "error", err)
 		}
 	}
@@ -123,10 +123,10 @@ func setup(ctx context.Context, flags *GlobalFlags, opts any) *Context {
 		LoadCluster() (*clientconfig.ClusterConfig, string, error)
 	}); ok {
 		cfg, name, err := lc.LoadCluster()
-		if err == nil {
+		if cfg != nil {
 			s.ClusterConfig = cfg
 			s.ClusterName = name
-		} else {
+		} else if err != nil && !errors.Is(err, clientconfig.ErrNoConfig) {
 			s.Log.Warn("Failed to load cluster config", "error", err)
 		}
 	}


### PR DESCRIPTION
When the user hasn't yet setup a config, we warn them unnecessarily about there not being a clientconfig. Yeah, no duh, they haven't created one yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing cluster configurations—the system now gracefully proceeds with an empty cluster name instead of returning an error when no cluster is specified and no active cluster is set.
  * Enhanced error handling for configuration loading to better distinguish between missing configurations and other error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->