### PR TITLE
Fix Docker build to fail on download errors

### DIFF
--- a/.iso/Dockerfile
+++ b/.iso/Dockerfile
@@ -36,12 +36,12 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
         echo "https://github.com/containerd/nerdctl/releases/download/v2.0.5/nerdctl-2.0.5-linux-amd64.tar.gz" > /tmp/nerdctl_url; \
     fi && \
     mkdir -p /upstream && \
-    curl -L -o /upstream/containerd.tar.gz "$(cat /tmp/containerd_url)" && \
-    curl -L -o /upstream/buildkit.tar.gz "$(cat /tmp/buildkit_url)" && \
-    curl -L -o /upstream/nerdctl.tar.gz "$(cat /tmp/nerdctl_url)" && \
-    curl -L -o /upstream/runc "$(cat /tmp/runc_url)" && \
-    curl -L -o /upstream/runsc "$(cat /tmp/runsc_url)" && \
-    curl -L -o /upstream/containerd-shim-runsc-v1 "$(cat /tmp/runscshim_url)" && \
+    curl -fL -o /upstream/containerd.tar.gz "$(cat /tmp/containerd_url)" && \
+    curl -fL -o /upstream/buildkit.tar.gz "$(cat /tmp/buildkit_url)" && \
+    curl -fL -o /upstream/nerdctl.tar.gz "$(cat /tmp/nerdctl_url)" && \
+    curl -fL -o /upstream/runc "$(cat /tmp/runc_url)" && \
+    curl -fL -o /upstream/runsc "$(cat /tmp/runsc_url)" && \
+    curl -fL -o /upstream/containerd-shim-runsc-v1 "$(cat /tmp/runscshim_url)" && \
     chmod +x /upstream/runc /upstream/runsc /upstream/containerd-shim-runsc-v1 && \
     tar -C /usr/local -xvf /upstream/containerd.tar.gz && \
     tar -C /usr/local -xvf /upstream/buildkit.tar.gz && \


### PR DESCRIPTION
## Summary
Adds `-f` flag to curl commands in `.iso/Dockerfile` to prevent silent failures when downloads return HTTP errors.

## Problem
When curl downloads fail (404, 500, etc.), curl silently saves the HTML error page instead of failing the build. This causes cryptic runtime errors later:
```
fork/exec /var/lib/miren/release/runc: exec format error
```

## Solution
Add the `-f` (fail) flag to all curl commands. Now when downloads fail, the Docker build fails immediately with a clear error instead of continuing with corrupted files.

## Test Plan
- All existing tests pass
- Linter clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system resilience and error detection. Download operations within the build pipeline now properly identify and report HTTP errors rather than silently continuing, ensuring builds only proceed when all required components are successfully obtained.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->