### PR TITLE
command: Cleanup commands

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -225,7 +225,7 @@ Warning: These commands are intended for advanced users and developers. They may
 		},
 
 		"debug test load": func() (cli.Command, error) {
-			return Infer("test load", "Loadtest a URL", TestLoad), nil
+			return Infer("debug test load", "Loadtest a URL", TestLoad), nil
 		},
 
 		"debug ctr nuke": func() (cli.Command, error) {
@@ -245,19 +245,19 @@ Warning: These commands are intended for advanced users and developers. They may
 		},
 
 		"debug entity get": func() (cli.Command, error) {
-			return Infer("entity get", "Get an entity", EntityGet), nil
+			return Infer("debug entity get", "Get an entity", EntityGet), nil
 		},
 
 		"debug entity put": func() (cli.Command, error) {
-			return Infer("entity put", "Put an entity", EntityPut), nil
+			return Infer("debug entity put", "Put an entity", EntityPut), nil
 		},
 
 		"debug entity delete": func() (cli.Command, error) {
-			return Infer("entity delete", "Delete an entity", EntityDelete), nil
+			return Infer("debug entity delete", "Delete an entity", EntityDelete), nil
 		},
 
 		"debug entity list": func() (cli.Command, error) {
-			return Infer("entity list", "List entities", EntityList), nil
+			return Infer("debug entity list", "List entities", EntityList), nil
 		},
 
 		"debug entity create": func() (cli.Command, error) {

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -18,18 +18,6 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("whoami", "Display information about the current authenticated user", Whoami), nil
 		},
 
-		"debug": func() (cli.Command, error) {
-			return Section("debug", "Debug and troubleshooting commands"), nil
-		},
-
-		"debug connection": func() (cli.Command, error) {
-			return Infer("debug connection", "Test connectivity and authentication with a server", DebugConnection), nil
-		},
-
-		"debug reindex": func() (cli.Command, error) {
-			return Infer("debug reindex", "Rebuild all entity indexes from scratch", DebugReindex), nil
-		},
-
 		"init": func() (cli.Command, error) {
 			return Infer("init", "Initialize a new application", Init), nil
 		},
@@ -38,15 +26,6 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("Deploy", "Deploy an application", Deploy), nil
 		},
 
-		// TODO: This hangs when pointed at a deployed hw-bun but works w/ combo.yaml
-		"console": func() (cli.Command, error) {
-			return Infer("console", "Start a console", Console), nil
-		},
-
-		// TODO: This hangs when pointed at a deployed hw-bun but works w/ combo.yaml
-		"sandbox exec": func() (cli.Command, error) {
-			return Infer("sandbox exec", "Execute a command in a sandbox", SandboxExec), nil
-		},
 		"sandbox list": func() (cli.Command, error) {
 			return Infer("sandbox list", "List all sandboxes", SandboxList), nil
 		},
@@ -55,9 +34,6 @@ func AllCommands() map[string]cli.CommandFactory {
 		},
 		"sandbox delete": func() (cli.Command, error) {
 			return Infer("sandbox delete", "Delete a dead sandbox", SandboxDelete), nil
-		},
-		"sandbox metrics": func() (cli.Command, error) {
-			return Infer("sandbox metrics", "Get metrics from a sandbox", SandboxMetrics), nil
 		},
 
 		"sandbox-pool list": func() (cli.Command, error) {
@@ -92,7 +68,7 @@ func AllCommands() map[string]cli.CommandFactory {
 		},
 
 		"env": func() (cli.Command, error) {
-			return Section("env", "Environment variable management commands"), nil
+			return Section("env", "Environment variable management commands", ""), nil
 		},
 
 		"env set": func() (cli.Command, error) {
@@ -109,10 +85,6 @@ func AllCommands() map[string]cli.CommandFactory {
 
 		"env delete": func() (cli.Command, error) {
 			return Infer("env delete", "Delete environment variables", EnvDelete), nil
-		},
-
-		"set": func() (cli.Command, error) {
-			return Infer("set", "Set concurrency for an application", Set), nil
 		},
 
 		"route": func() (cli.Command, error) {
@@ -149,7 +121,7 @@ func AllCommands() map[string]cli.CommandFactory {
 
 		// Config commands - for config file management
 		"config": func() (cli.Command, error) {
-			return Section("config", "Configuration file management"), nil
+			return Section("config", "Configuration file management", ""), nil
 		},
 
 		"config info": func() (cli.Command, error) {
@@ -186,7 +158,7 @@ func AllCommands() map[string]cli.CommandFactory {
 		},
 
 		"server config": func() (cli.Command, error) {
-			return Section("server config", "Server configuration management commands"), nil
+			return Section("server config", "Server configuration management commands", ""), nil
 		},
 
 		"server config generate": func() (cli.Command, error) {
@@ -214,7 +186,7 @@ func AllCommands() map[string]cli.CommandFactory {
 		},
 
 		"server docker": func() (cli.Command, error) {
-			return Section("server docker", "Docker-based server management commands"), nil
+			return Section("server docker", "Docker-based server management commands", ""), nil
 		},
 
 		"server docker install": func() (cli.Command, error) {
@@ -233,28 +205,26 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("auth generate", "Generate authentication config file", AuthGenerate), nil
 		},
 
-		"entity get": func() (cli.Command, error) {
-			return Infer("entity get", "Get an entity", EntityGet), nil
+		// Debug Commands. These have no guarantees of stability and may change or be removed without notice.
+
+		"debug": func() (cli.Command, error) {
+			return Section("debug", "Debug and troubleshooting commands", `
+Use these commands to help diagnose issues with the miren runtime.
+
+Warning: These commands are intended for advanced users and developers. They may change or be removed without notice.
+
+`), nil
 		},
 
-		"entity put": func() (cli.Command, error) {
-			return Infer("entity put", "Put an entity", EntityPut), nil
+		"debug connection": func() (cli.Command, error) {
+			return Infer("debug connection", "Test connectivity and authentication with a server", DebugConnection), nil
 		},
 
-		"entity delete": func() (cli.Command, error) {
-			return Infer("entity delete", "Delete an entity", EntityDelete), nil
+		"debug reindex": func() (cli.Command, error) {
+			return Infer("debug reindex", "Rebuild all entity indexes from scratch", DebugReindex), nil
 		},
 
-		"entity list": func() (cli.Command, error) {
-			return Infer("entity list", "List entities", EntityList), nil
-		},
-
-		// TODO: Unclear if this is still useful; leaving it in for now
-		"internal dial-stdio": func() (cli.Command, error) {
-			return Infer("internal dial-stdio", "Dial a stdio connection", DialStdio), nil
-		},
-
-		"test load": func() (cli.Command, error) {
+		"debug test load": func() (cli.Command, error) {
 			return Infer("test load", "Loadtest a URL", TestLoad), nil
 		},
 
@@ -274,6 +244,22 @@ func AllCommands() map[string]cli.CommandFactory {
 			return Infer("debug rbac test", "Test RBAC evaluation with fetched rules", DebugRBACTest), nil
 		},
 
+		"debug entity get": func() (cli.Command, error) {
+			return Infer("entity get", "Get an entity", EntityGet), nil
+		},
+
+		"debug entity put": func() (cli.Command, error) {
+			return Infer("entity put", "Put an entity", EntityPut), nil
+		},
+
+		"debug entity delete": func() (cli.Command, error) {
+			return Infer("entity delete", "Delete an entity", EntityDelete), nil
+		},
+
+		"debug entity list": func() (cli.Command, error) {
+			return Infer("entity list", "List entities", EntityList), nil
+		},
+
 		"debug entity create": func() (cli.Command, error) {
 			return Infer("debug entity create", "Create a new entity", EntityCreate), nil
 		},
@@ -291,7 +277,7 @@ func AllCommands() map[string]cli.CommandFactory {
 		},
 
 		"debug disk": func() (cli.Command, error) {
-			return Section("debug disk", "Disk entity debug commands"), nil
+			return Section("debug disk", "Disk entity debug commands", ""), nil
 		},
 
 		"debug disk create": func() (cli.Command, error) {

--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -1,20 +1,35 @@
 package commands
 
-import "github.com/mitchellh/cli"
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+)
 
 type section struct {
 	name string
+	help string
 	desc string
 }
 
 var _ cli.Command = &section{}
 
-func Section(name, desc string) cli.Command {
+func Section(name, desc, help string) cli.Command {
+	help = strings.TrimSpace(help)
+
+	if help == "" {
+		help = desc
+	}
+
+	if desc == "" {
+		desc = help
+	}
+
 	return &section{name: name, desc: desc}
 }
 
 func (s *section) Help() string {
-	return s.desc
+	return s.help
 }
 
 func (s *section) Synopsis() string {

--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -49,10 +49,10 @@ The Miren CLI (`miren`) provides commands for managing applications and deployme
 - `miren sandbox stop` - Stop a sandbox
 - `miren sandbox delete` - Delete a dead sandbox
 - `miren sandbox metrics` - Get metrics from a sandbox
-- `miren entity list` - List entities
-- `miren entity get` - Get an entity
-- `miren entity delete` - Delete an entity
-- `miren entity put` - Put an entity
+- `miren debug entity list` - List entities
+- `miren debug entity get` - Get an entity
+- `miren debug entity delete` - Delete an entity
+- `miren debug entity put` - Put an entity
 
 ### Utility Commands
 

--- a/docs/docs/cli/entity.md
+++ b/docs/docs/cli/entity.md
@@ -20,71 +20,71 @@ Entities are flexible metadata objects stored in Miren's etcd-backed entity stor
 - **Clusters** - Cluster registrations
 - **Users** - User accounts
 
-## miren entity list
+## miren debug entity list
 
 List entities of a specific type.
 
 ### Usage
 
 ```bash
-miren entity list <type> [flags]
+miren debug entity list <type> [flags]
 ```
 
 ### Examples
 
 ```bash
 # List all apps
-miren entity list app
+miren debug entity list app
 
 # List all sandboxes
-miren entity list sandbox
+miren debug entity list sandbox
 ```
 
-## miren entity get
+## miren debug entity get
 
 Get a specific entity by type and name.
 
 ### Usage
 
 ```bash
-miren entity get <type> <name> [flags]
+miren debug entity get <type> <name> [flags]
 ```
 
 ### Examples
 
 ```bash
 # Get an app entity
-miren entity get app myapp
+miren debug entity get app myapp
 
 # Get a sandbox entity
-miren entity get sandbox sb-abc123
+miren debug entity get sandbox sb-abc123
 ```
 
-## miren entity delete
+## miren debug entity delete
 
 Delete an entity.
 
 ### Usage
 
 ```bash
-miren entity delete <type> <name> [flags]
+miren debug entity delete <type> <name> [flags]
 ```
 
 ### Examples
 
 ```bash
 # Delete an entity
-miren entity delete app myapp
+miren debug entity delete app myapp
 ```
 
-## miren entity put
+## miren debug entity put
 
 Put (create or update) an entity.
 
 ### Usage
 
 ```bash
-miren entity put <type> <name> [flags]
+miren debug entity put <type> <name> [flags]
 ```
 
 :::warning

--- a/e2e/sandbox_lifecycle_test.go
+++ b/e2e/sandbox_lifecycle_test.go
@@ -36,7 +36,7 @@ func TestSandboxLifecycleEndToEnd(t *testing.T) {
 
 	t.Log("putting entities")
 	// Spin up combo
-	putCode := cli.Run([]string{"miren", "entity", "put", "-v", "--config", cfgPath, "-p", filePath})
+	putCode := cli.Run([]string{"miren", "debug", "entity", "put", "-v", "--config", cfgPath, "-p", filePath})
 	r.Equal(0, putCode)
 
 	// Ensure we can route to nginx container


### PR DESCRIPTION
Remove broken commands, move the rest of entity under debug.

Fixes MIR-526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Entity management commands moved from miren entity to miren debug entity (list, get, delete, put).

* **Improvements**
  * Debug, server and config commands reorganized into clearer sections with expanded help/warning text for unstable/advanced debug commands.
  * New consolidated debug group exposes additional debug operations (connection, reindex, test-load, disk, entity).

* **Documentation**
  * CLI reference and examples updated to use miren debug entity paths and explicit advanced-operation warnings.

* **Tests**
  * End-to-end tests updated to invoke debug entity command paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->