### PR TITLE
Fix sandbox controller to update PENDING->RUNNING on reconciliation

### DIFF
--- a/controllers/sandbox/portmonitor.go
+++ b/controllers/sandbox/portmonitor.go
@@ -119,7 +119,7 @@ func (pm *PortMonitor) monitorPorts(ctx context.Context, task *monitorTask) {
 	// was running, but it's way too much traffic for that. So we modified this to only
 	// run until all ports are bound.
 
-	ticker := time.NewTicker(500 * time.Millisecond)
+	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 
 	// Run this until we observe all the ports bound.


### PR DESCRIPTION
## Summary

Fixes a defensive backstop issue where sandboxes could get stuck in PENDING state forever when the initial status update to RUNNING failed due to optimistic concurrency conflicts.

## The Bug

During the mirendev production deployment on 2025-11-20, two sandboxes got stuck in PENDING state even though:
- Containers were running and healthy
- Ports were bound successfully  
- The sandbox was fully operational

This happened because:
1. Sandbox controller created sandbox and waited for ports (successful)
2. While starting, activator made multiple rapid updates to the entity
3. Controller tried to update status PENDING → RUNNING but got conflict error (entity revision changed)
4. Status update was silently lost (separate issue to address)
5. Subsequent reconciliations saw "sandbox exists and is healthy" and returned early without fixing the status

## The Fix

Added a check in the `same` case (line 655-672): if the sandbox exists, is healthy, but status is PENDING, we now explicitly update it to RUNNING using `Patch` with OCC (`meta.Revision`).

This provides a backstop to recover from status update failures regardless of why they occurred.

## Test

Added comprehensive test `PENDING sandbox with running containers should transition to RUNNING` that:
1. Creates a sandbox (which starts successfully)
2. Manually resets status to PENDING (simulating failed update)
3. Calls Create again to trigger reconciliation
4. Verifies status is corrected to RUNNING

## Part of MIR-531

This is the first of several PRs to fully address the root cause:
- ✅ This PR: Defensive fix in sandbox controller
- ⏭️ Next: Retry logic in controller framework for conflict errors
- ⏭️ Future: Consider reducing activator update frequency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a case where a sandbox stuck in PENDING while containers were already healthy now correctly transitions to RUNNING.
  * Increased startup port wait timeout and polling frequency to improve readiness handling.

* **Tests**
  * Added a test ensuring a PENDING sandbox with active containers transitions to RUNNING after reconciliation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->