### PR TITLE
Switch controller automatic writes from Put to Patch

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/rpc/stream"
@@ -339,28 +340,7 @@ func (c *ReconcileController) runWorker(ctx context.Context) {
 				// we still try to process updates even if there is an error.
 			}
 
-			if len(updates) > 0 {
-				if event.Id == "" {
-					c.Log.Error("entity id is empty update there are updates", "event", event)
-				} else {
-					c.Log.Info("updating entity with updates produced by controller", "event", event, "updates", len(updates))
-
-					var rpcE entityserver_v1alpha.Entity
-					rpcE.SetId(string(event.Id))
-					rpcE.SetAttrs(updates)
-
-					result, err := c.esc.Put(ctx, &rpcE)
-					if err != nil {
-						c.Log.Error("error updating entity", "entity", event.Id, "error", err)
-					} else {
-						c.Log.Info("updated entity", "entity", event.Id)
-						// Record the revision we just wrote so we can skip the watch event
-						if result.HasRevision() {
-							c.RecordWrite(result.Revision())
-						}
-					}
-				}
-			}
+			c.applyUpdates(ctx, event, updates)
 
 			// Process any pending events before removing from in-flight
 			for {
@@ -387,28 +367,7 @@ func (c *ReconcileController) runWorker(ctx context.Context) {
 					c.Log.Error("error processing pending item", "event", event, "error", err)
 				}
 
-				if len(updates) > 0 {
-					if event.Id == "" {
-						c.Log.Error("entity id is empty update there are updates", "event", event)
-					} else {
-						c.Log.Info("updating entity with updates produced by controller", "event", event, "updates", len(updates))
-
-						var rpcE entityserver_v1alpha.Entity
-						rpcE.SetId(string(event.Id))
-						rpcE.SetAttrs(updates)
-
-						result, err := c.esc.Put(ctx, &rpcE)
-						if err != nil {
-							c.Log.Error("error updating entity", "entity", event.Id, "error", err)
-						} else {
-							c.Log.Info("updated entity", "entity", event.Id)
-							// Record the revision we just wrote so we can skip the watch event
-							if result.HasRevision() {
-								c.RecordWrite(result.Revision())
-							}
-						}
-					}
-				}
+				c.applyUpdates(ctx, event, updates)
 			}
 		}
 	}
@@ -422,6 +381,40 @@ func (c *ReconcileController) processItem(ctx context.Context, event Event) ([]e
 		return c.handler(ctx, event)
 	default:
 		return nil, fmt.Errorf("unknown event type: %s", event.Type)
+	}
+}
+
+// applyUpdates applies the given updates to an entity using Patch
+func (c *ReconcileController) applyUpdates(ctx context.Context, event Event, updates []entity.Attr) {
+	if len(updates) == 0 {
+		return
+	}
+
+	if event.Id == "" {
+		c.Log.Error("entity id is empty but there are updates", "event", event)
+		return
+	}
+
+	c.Log.Info("updating entity with updates produced by controller", "event", event, "updates", len(updates))
+
+	// Add entity ID to attrs for Patch
+	attrs := append([]entity.Attr{entity.Ref(entity.DBId, event.Id)}, updates...)
+
+	// Use Patch without OCC (revision 0) to avoid breaking unforeseen code that may depend
+	// on this working without conflict detection. Can revisit with more holistic pass.
+	result, err := c.esc.Patch(ctx, attrs, 0)
+	if err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			c.Log.Warn("entity not found during update", "entity", event.Id)
+			return
+		}
+		c.Log.Error("error updating entity", "entity", event.Id, "error", err)
+	} else {
+		c.Log.Info("updated entity", "entity", event.Id)
+		// Record the revision we just wrote so we can skip the watch event
+		if result.HasRevision() {
+			c.RecordWrite(result.Revision())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Switch the automatic entity write at the end of controller actions from Put to Patch, which is more semantically correct (Patch didn't exist when this was originally written).

Also extracts duplicate update logic into a reusable helper method.

## Changes

### 1. Switch from Put to Patch

**Before:**
```go
var rpcE entityserver_v1alpha.Entity
rpcE.SetId(string(event.Id))
rpcE.SetAttrs(updates)
result, err := c.esc.Put(ctx, &rpcE)
```

**After:**
```go
attrs := append([]entity.Attr{entity.Ref(entity.DBId, event.Id)}, updates...)
result, err := c.esc.Patch(ctx, attrs, 0)
```

**OCC Decision:** Uses revision 0 (no optimistic concurrency control) to avoid breaking unforeseen code that may depend on this working without conflict detection. This is the conservative approach - we can revisit OCC protection in a more holistic pass.

### 2. Extract Duplicate Code

Lines 342-363 and 390-411 had identical code for applying updates (main event processing vs pending event processing). Extracted into new `applyUpdates` helper method.

**Benefits:**
- Eliminates code duplication
- Centralizes update logic (validation, logging, Patch call, revision recording)
- Makes future changes easier

## Manual Patch Calls in SandboxController

There are 4 manual Patch calls in SandboxController (lines 671, 719, 1545, 2055) that were identified but not changed in this PR. These could benefit from manual RecordWrite calls to skip self-generated watch events, but that would require adding a ReconcileController field to SandboxController. Since eventual consistency is acceptable, this is documented as future work.

This is addressed in the follow-up PR #397 using the WriteTracker pattern.

## Testing

- All controller tests pass (`./hack/it ./pkg/controller`)
- End-to-end tests pass (`make test-e2e`)

## Stack

- Follows: #395 (skip-self-generated-watch-events)
- Followed by: #397 (add WriteTracker pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of update operations with stronger validation, error handling, and concurrency robustness to reduce failed or duplicated updates.
  * Reduced self-generated event noise so the system skips redundant internal events and maintains accurate revision tracking.
  * Enhanced operational logging for clearer success/error visibility during update processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->