### PR TITLE
Add WriteTracker pattern for manual entity writes in controllers

### DIFF
--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -397,6 +397,9 @@ func (r *Runner) SetupControllers(
 		workers,
 	)
 
+	// Wire up write tracker so manual Patch calls can skip self-generated watch events
+	sbc.SetWriteTracker(sbController.WriteTracker())
+
 	sbController.SetPeriodic(5*time.Minute, func(ctx context.Context) error {
 		return sbc.Periodic(ctx, time.Hour)
 	})

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -33,6 +33,7 @@ import (
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/containerdx"
+	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/netdb"
@@ -95,11 +96,19 @@ type SandboxController struct {
 	portMonitor *PortMonitor
 
 	watchdog *ContainerWatchdog
+
+	// writeTracker tracks entity write revisions to skip self-generated watch events
+	writeTracker controller.WriteTracker
 }
 
 func (c *SandboxController) Populated() error {
 	c.Log = c.Log.With("module", "sandbox")
 	return nil
+}
+
+// SetWriteTracker sets the write tracker for recording manual entity writes
+func (c *SandboxController) SetWriteTracker(wt controller.WriteTracker) {
+	c.writeTracker = wt
 }
 
 func (c *SandboxController) SetPortStatus(id string, port observability.BoundPort, status observability.PortStatus) {
@@ -703,10 +712,13 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 							Status: compute.DEAD,
 						}).Encode,
 					)
-					_, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
+					result, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
 					if err != nil {
 						c.Log.Error("failed to mark sandbox as DEAD", "id", co.ID, "error", err)
 						return fmt.Errorf("failed to mark sandbox as DEAD: %w", err)
+					}
+					if c.writeTracker != nil && result.HasRevision() {
+						c.writeTracker.RecordWrite(result.Revision())
 					}
 				}
 
@@ -757,6 +769,9 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 	}
 
 	meta.Revision = res.Revision()
+	if c.writeTracker != nil && res.HasRevision() {
+		c.writeTracker.RecordWrite(res.Revision())
+	}
 
 	opts, err := c.buildSpec(ctx, co, ep, meta)
 	if err != nil {
@@ -1577,7 +1592,7 @@ func (c *SandboxController) monitorTaskExit(
 		)
 
 		ctx := context.Background()
-		_, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
+		result, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
 		if err != nil {
 			if !errors.Is(err, cond.ErrNotFound{}) {
 				c.Log.Error("failed to update sandbox status to STOPPED",
@@ -1586,6 +1601,9 @@ func (c *SandboxController) monitorTaskExit(
 				)
 			}
 			return
+		}
+		if c.writeTracker != nil && result.HasRevision() {
+			c.writeTracker.RecordWrite(result.Revision())
 		}
 
 		c.Log.Info("marked sandbox as STOPPED due to process exit, cleanup will be triggered by reconciliation", "sandbox", sb.ID)
@@ -2087,7 +2105,7 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 	_ = os.RemoveAll(tmpDir)
 
 	// Mark sandbox as DEAD in entity store
-	_, err = c.EAC.Patch(ctx, entity.New(
+	result, err := c.EAC.Patch(ctx, entity.New(
 		entity.Ref(entity.DBId, id),
 		(&compute.Sandbox{
 			Status: compute.DEAD,
@@ -2099,6 +2117,9 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 		if !errors.Is(err, cond.ErrNotFound{}) {
 			c.Log.Error("failed to mark sandbox as DEAD", "id", id, "error", err)
 		}
+	}
+	if c.writeTracker != nil && result.HasRevision() {
+		c.writeTracker.RecordWrite(result.Revision())
 	}
 
 	c.Log.Info("sandbox retired", "id", id, "status", compute.DEAD)

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -2117,8 +2117,7 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 		if !errors.Is(err, cond.ErrNotFound{}) {
 			c.Log.Error("failed to mark sandbox as DEAD", "id", id, "error", err)
 		}
-	}
-	if c.writeTracker != nil && result.HasRevision() {
+	} else if c.writeTracker != nil && result.HasRevision() {
 		c.writeTracker.RecordWrite(result.Revision())
 	}
 

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -95,10 +95,7 @@ func (m *Manager) Reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPo
 			"consecutive_crashes", pool.ConsecutiveCrashCount,
 			"cooldown_until", pool.CooldownUntil)
 
-		// Update pool entity with new crash state
-		if err := m.updatePoolCrashState(ctx, pool); err != nil {
-			m.log.Error("failed to update pool crash state", "pool", pool.ID, "error", err)
-		}
+		// Pool crash state fields are already updated, framework will apply via entity.Diff
 	}
 
 	// Check if pool is in cooldown
@@ -122,9 +119,7 @@ func (m *Manager) Reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPo
 				"unreferenced", isUnreferenced,
 				"cooldown_until", pool.CooldownUntil)
 			pool.DesiredInstances = targetDesired
-			if err := m.updatePoolDesiredInstances(ctx, pool); err != nil {
-				m.log.Error("failed to update pool DesiredInstances", "pool", pool.ID, "error", err)
-			}
+			// DesiredInstances updated, framework will apply via entity.Diff
 		}
 
 		// Update current/ready counts even during cooldown, then skip scaling logic
@@ -139,9 +134,7 @@ func (m *Manager) Reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPo
 		pool.ConsecutiveCrashCount = 0
 		pool.LastCrashTime = time.Time{}
 		pool.CooldownUntil = time.Time{}
-		if err := m.updatePoolCrashState(ctx, pool); err != nil {
-			m.log.Error("failed to reset pool crash state", "pool", pool.ID, "error", err)
-		}
+		// Pool crash state fields reset, framework will apply via entity.Diff
 	}
 
 	// actual and ready were already counted at the top of Reconcile
@@ -501,7 +494,8 @@ func (m *Manager) scaleDown(ctx context.Context, pool *compute_v1alpha.SandboxPo
 	return nil
 }
 
-// updatePoolStatus updates the pool's CurrentInstances and ReadyInstances fields
+// updatePoolStatus updates the pool's CurrentInstances and ReadyInstances fields.
+// The framework will automatically apply these changes via entity.Diff.
 func (m *Manager) updatePoolStatus(ctx context.Context, pool *compute_v1alpha.SandboxPool, current, ready int64) error {
 	// Only update if values changed
 	if pool.CurrentInstances == current && pool.ReadyInstances == ready {
@@ -510,18 +504,6 @@ func (m *Manager) updatePoolStatus(ctx context.Context, pool *compute_v1alpha.Sa
 
 	pool.CurrentInstances = current
 	pool.ReadyInstances = ready
-
-	// Use Patch to update just the status counter fields
-	// This explicitly sets the values, even when they are 0 (empty pool)
-	attrs := []entity.Attr{
-		entity.Ref(entity.DBId, pool.ID),
-		entity.Int64(compute_v1alpha.SandboxPoolCurrentInstancesId, current),
-		entity.Int64(compute_v1alpha.SandboxPoolReadyInstancesId, ready),
-	}
-
-	if _, err := m.eac.Patch(ctx, attrs, 0); err != nil {
-		return fmt.Errorf("failed to update pool status: %w", err)
-	}
 
 	m.log.Debug("updated pool status",
 		"pool", pool.ID,
@@ -808,28 +790,4 @@ func (m *Manager) hasHealthySandbox(sandboxes []*sandboxWithMeta, crashCount int
 	}
 
 	return false
-}
-
-// updatePoolCrashState updates the crash-related fields in the pool entity
-func (m *Manager) updatePoolCrashState(ctx context.Context, pool *compute_v1alpha.SandboxPool) error {
-	attrs := []entity.Attr{
-		entity.Ref(entity.DBId, pool.ID),
-		entity.Int64(compute_v1alpha.SandboxPoolConsecutiveCrashCountId, pool.ConsecutiveCrashCount),
-		entity.Time(compute_v1alpha.SandboxPoolLastCrashTimeId, pool.LastCrashTime),
-		entity.Time(compute_v1alpha.SandboxPoolCooldownUntilId, pool.CooldownUntil),
-	}
-
-	_, err := m.eac.Patch(ctx, attrs, 0)
-	return err
-}
-
-// updatePoolDesiredInstances updates only the DesiredInstances field in the pool entity
-func (m *Manager) updatePoolDesiredInstances(ctx context.Context, pool *compute_v1alpha.SandboxPool) error {
-	attrs := []entity.Attr{
-		entity.Ref(entity.DBId, pool.ID),
-		entity.Int64(compute_v1alpha.SandboxPoolDesiredInstancesId, pool.DesiredInstances),
-	}
-
-	_, err := m.eac.Patch(ctx, attrs, 0)
-	return err
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -40,6 +40,13 @@ type Controller interface {
 	Stop()
 }
 
+// WriteTracker provides a way to track entity write revisions to skip self-generated watch events.
+// Controllers that make manual entity writes outside the reconciliation framework can use this
+// to record their writes and avoid unnecessary re-reconciliation.
+type WriteTracker interface {
+	RecordWrite(revision int64)
+}
+
 type workerIdKey struct{}
 
 func withWorkerId(ctx context.Context, id string) context.Context {
@@ -273,6 +280,12 @@ func (c *ReconcileController) RecordWrite(revision int64) {
 	if revision > 0 {
 		c.recentWrites.Add(revision)
 	}
+}
+
+// WriteTracker returns a WriteTracker interface that can be used by controllers
+// to record manual entity writes outside the reconciliation framework.
+func (c *ReconcileController) WriteTracker() WriteTracker {
+	return c
 }
 
 // Enqueue adds an event to the work queue for processing

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -396,6 +396,14 @@ func (c *ReconcileController) processItem(ctx context.Context, event Event) ([]e
 	}
 }
 
+// ProcessEventForTest processes a single event and applies any updates.
+// This is exposed for testing controllers without starting the full controller loop.
+func (c *ReconcileController) ProcessEventForTest(ctx context.Context, event Event) error {
+	updates, err := c.processItem(ctx, event)
+	c.applyUpdates(ctx, event, updates)
+	return err
+}
+
 // applyUpdates applies the given updates to an entity using Patch
 func (c *ReconcileController) applyUpdates(ctx context.Context, event Event, updates []entity.Attr) {
 	if len(updates) == 0 {


### PR DESCRIPTION
## Summary

This PR improves controller entity write patterns through two changes:

1. **Add WriteTracker pattern** - Enables controllers making manual entity writes outside the reconciliation framework to record their write revisions, allowing them to skip self-generated watch events
2. **Remove redundant writes** - Cleans up SandboxPoolManager where manual Patch calls duplicated the framework's automatic entity.Diff behavior

Additionally includes a complete audit of all entity writes across controllers, confirming correct patterns throughout the codebase.

---

## Part 1: WriteTracker Pattern for SandboxController

### Framework Level (`pkg/controller/controller.go`)

**WriteTracker Interface:**
```go
type WriteTracker interface {
    RecordWrite(revision int64)
}
```

**ReconcileController.WriteTracker():**
Returns the controller itself as a `WriteTracker` interface. This keeps coupling minimal - controllers don't need a full `ReconcileController` reference.

### SandboxController Integration

**Fields and Methods:**
- Added `writeTracker controller.WriteTracker` field
- Added `SetWriteTracker(wt controller.WriteTracker)` method for dependency injection

**Updated 4 Manual Patch Calls:**
1. **Line 680**: `RUNNING→DEAD` (unhealthy sandbox detection)
2. **Line 734**: Network address update after sandbox creation
3. **Line 1561**: `→STOPPED` (background goroutine monitoring process exit)
4. **Line 2074**: `→DEAD` (cleanup in stopSandbox)

Each now:
- Captures the result (changed `_` to `result`)
- Calls `c.writeTracker.RecordWrite(result.Revision())` if tracker is available

**Analysis of why these must be manual:**
- **#1**: Intentionally returns early to trigger new reconciliation cycle - can't defer to framework
- **#2**: Network address must persist BEFORE creating container, updated meta.Revision used by subsequent operations
- **#3**: Runs in background goroutine outside reconciliation flow - must manually write to trigger reconciliation
- **#4**: Complex with multiple call sites having different needs - would require significant refactoring with marginal benefit

### Wiring (`components/runner/runner.go`)

After creating both controllers:
```go
sbc.SetWriteTracker(sbController.WriteTracker())
```

---

## Part 2: SandboxPoolManager Cleanup

The SandboxPoolManager uses `AdaptReconcileController` which automatically applies changes to the pool object via `entity.Diff(meta.Entity, orig)`.

**Removed redundant helper functions (47 lines deleted):**
1. **`updatePoolStatus()`** - Was manually patching `CurrentInstances`/`ReadyInstances` after modifying pool object
2. **`updatePoolCrashState()`** - Was manually patching crash state fields after modifying pool object  
3. **`updatePoolDesiredInstances()`** - Was manually patching `DesiredInstances` after modifying pool object

Since the pool object is modified in-place and the framework diffs changes automatically, these manual Patch calls were redundant double-writes. Call sites now have inline comments explaining the framework handles updates automatically.

**Manual Patch calls that correctly remain:**
- **Line 474** (`scaleDown`): Writes to **Sandbox** entities (different type) - generates watch events for SandboxController
- **Line 664** (`checkPoolForScaleDown`): Runs in background goroutine - writes to SandboxPool to trigger reconciliation

Both are outside the normal reconciliation flow and correctly need manual writes. Notably, we do NOT use WriteTracker for these because:
- Line 474 writes different entity types - we WANT SandboxController to see those events
- Line 664 explicitly wants to trigger a reconciliation with its write

---

## Part 3: Controller Write Audit

Audited all entity writes across controllers to ensure correct patterns:

### ✅ SandboxController (`controllers/sandbox/`)
- **4 Manual Patch calls**: Now use WriteTracker (this PR)
- **2 Create calls** (volume.go): Creates Disk/DiskLease entities (different types) - correct, WANT those watch events

### ✅ SandboxPoolManager (`controllers/sandboxpool/manager.go`)
- **3 Redundant Patch calls**: Removed (this PR)
- **2 Remaining Patch calls**: Correct (different entity types OR background goroutine)

### ✅ DeploymentLauncher (`controllers/deployment/launcher.go`)
- **Create/Replace calls**: Creates/updates SandboxPool entities while watching App entities - correct, different types

### ✅ ServiceController (`controllers/service/service.go`)
- **No direct entity writes**: Only uses controller callbacks - correct

**Conclusion:** All entity writes follow correct patterns:
- Cross-entity writes (different types than watched) correctly generate watch events
- Same-entity writes (SandboxController) use WriteTracker to skip self-generated events
- Redundant framework duplications have been removed

---

## Benefits

- ✅ Manual Patch calls in SandboxController now skip self-generated watch events
- ✅ Reduces unnecessary reconciliation for sandbox state transitions
- ✅ Eliminates 47 lines of redundant code in SandboxPoolManager
- ✅ Pattern is reusable for any controller making manual entity writes
- ✅ Clean dependency injection without architectural changes
- ✅ Minimal interface keeps coupling low
- ✅ Complete audit confirms correct write patterns across all controllers

## Testing

- All controller tests pass (`./hack/it ./pkg/controller`)
- Sandbox controller compiles successfully
- SandboxPool controller compiles successfully  
- Runner component compiles successfully

## Stack

- Stacked on: #396 (controller-use-patch)
- Follows: #395 (skip-self-generated-watch-events)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced state change tracking to better distinguish between manual updates and external changes, improving system accuracy.
  * Refactored state persistence to use framework-based updates instead of direct calls.

* **Tests**
  * Added new test infrastructure for improved test coverage and more production-like test execution paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->