### PR TITLE
Fix KeyRef resolution in cluster switch and whoami

### DIFF
--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -610,9 +610,6 @@ func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName,
 		if appName != "" && dep.AppName != appName {
 			continue
 		}
-		if clusterId != "" && dep.ClusterId != clusterId {
-			continue
-		}
 		if status != "" && dep.Status != status {
 			continue
 		}


### PR DESCRIPTION
## Summary
- Fix `cluster switch` and `whoami` commands to properly resolve `KeyRef` when loading private keys
- Both were directly accessing `identity.PrivateKey` which is empty when using `KeyRef`
- Remove clusterId filter from listDeploymentsInternal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cross-cluster deployment visibility: Deployments now display across clusters when filtering by application name.

* **Improvements**
  * Enhanced authentication: Improved private key retrieval now supports both direct keys and key references.
  * Refined error messaging: Clearer authentication and key-related error messages for improved troubleshooting.
  * Optimized cluster access validation: Streamlined configuration handling in cluster access checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->