### PR TITLE
Fix nil pointer panic in http3 server logger

### DIFF
--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -430,8 +430,11 @@ func (s *State) startListener(ctx context.Context, so *stateOptions) error {
 	s.ws = &webtransport.Server{
 		H3: http3.Server{
 			Handler: s.server,
-			// This is pretty noisy, as we run on DEBUG a lot, so disable for now.
-			// Logger:  s.log.With("module", "http3"),
+			// Use a logger with LevelWarn to suppress noisy debug messages from quic-go
+			// while preventing nil pointer panics
+			Logger: slog.New(slogfmt.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+				Level: slog.LevelWarn,
+			})).With("module", "http3"),
 		},
 		CheckOrigin: func(r *http.Request) bool {
 			return true


### PR DESCRIPTION
## Summary
Fix nil pointer panic in http3 server logger that crashes miren in production.

## Problem
The http3.Server Logger field was commented out to reduce noise, causing nil pointer dereferences when quic-go tried to log debug messages during response trailer flushing.

**Stack trace from production (Nov 23 03:58:03)**:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x960778]

goroutine 149039 [running]:
log/slog.(*Logger).Handler(...)
        /usr/local/go/src/log/slog/logger.go:121
log/slog.(*Logger).Enabled(0xc003241850?, {0x3f6c890?, 0x5cab700?}, 0xc003241838?)
        /usr/local/go/src/log/slog/logger.go:168 +0x18
log/slog.(*Logger).log(0x0, {0x3f6c890?, 0x5cab700?}, 0xfffffffffffffffc, {0x39efc1c, 0x18}, {0xc003241c28, 0x2, 0x2})
        /usr/local/go/src/log/slog/logger.go:244 +0x99
log/slog.(*Logger).Debug(...)
        /usr/local/go/src/log/slog/logger.go:199
github.com/quic-go/quic-go/http3.(*responseWriter).flushTrailers(0xc00114b580)
        /go/pkg/mod/github.com/quic-go/quic-go@v0.49.0/http3/response_writer.go:253 +0xa5
```

## Solution
Set Logger with `slog.LevelWarn` to suppress noisy debug output while preventing nil pointer crashes.

**Changes in `pkg/rpc/state.go:435-437`**:
```go
Logger: slog.New(slogfmt.NewTextHandler(os.Stderr, &slog.HandlerOptions{
    Level: slog.LevelWarn,
})).With("module", "http3"),
```

This approach:
- ✅ Prevents the nil pointer panic
- ✅ Suppresses noisy debug messages (only logs warnings and errors)
- ✅ Maintains consistency with the local listener logger pattern (see `state_local.go:150`)

## Test plan
- [x] Build completes successfully
- [x] Linter passes with no issues
- [ ] Deploy to test environment and verify no panic occurs under load
- [ ] Verify http3 warnings/errors are still logged appropriately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Re-enabled HTTP/3 server logging to use the app's structured logger at warning level—restores warnings/errors while reducing noisy low-level debug output, producing clearer and more actionable server logs for operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->