### PR TITLE
Remove apt cache from CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,32 +26,13 @@ jobs:
         go-version-file: 'go.mod'
         cache: true
 
-    - name: Cache apt packages
-      uses: actions/cache@v4
-      id: cache-apt
-      with:
-        path: |
-          /var/cache/apt/archives
-          /var/lib/apt/lists
-        key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/test.yml') }}-clang-llvm
-        restore-keys: |
-          ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/test.yml') }}-
-          ${{ runner.os }}-apt-
-
     - name: Install system dependencies
-      if: steps.cache-apt.outputs.cache-hit != 'true'
       run: |
         # Disable expensive operations on throwaway CI runners
         sudo sed -i 's/^DPkg::Post-Invoke.*//' /etc/apt/apt.conf.d/90_man-db || true
-        # Install packages
+        # Install packages (depot runners have persistent images, so this is usually cached)
         sudo DEBIAN_FRONTEND=noninteractive apt-get update
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clang llvm
-
-    - name: Clean up apt lock files
-      run: |
-        # Remove lock files and partial directories to prevent cache save errors
-        sudo rm -f /var/cache/apt/archives/lock /var/lib/apt/lists/lock
-        sudo rm -rf /var/cache/apt/archives/partial /var/lib/apt/lists/partial
 
     - name: Cache Go tools
       id: cache-go-tools


### PR DESCRIPTION
## Summary
- Remove apt package caching from the lint job that was causing tar restore warnings
- The cache was trying to restore system directories that already exist on depot runners, causing permission and file conflict errors

## Context
The tar warning appeared because `/var/lib/apt/lists` and `/var/cache/apt/archives` are root-owned system directories that already exist on every runner. When the cache action tried to restore them, tar failed with "File exists" and "Permission denied" errors.

Depot runners use persistent images, so apt packages are typically already available anyway.

## Test plan
- [ ] CI passes without tar warnings in the lint job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow configuration by streamlining the build process steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->