### PR TITLE
Don't alert on cancelled test runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
 
   tests-failed:
     runs-on: ubuntu-latest
-    # Only notify for main branch or version tags, not for every PR
-    if: ${{ github.event.workflow_run.conclusion != 'success' && (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')) }}
+    # Only notify for actual failures on main branch or version tags, not for cancellations or PRs
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')) }}
     steps:
       - name: Tests failed - blocking release
         run: |


### PR DESCRIPTION
## Summary
- Change the tests-failed job condition from `!= 'success'` to `== 'failure'` so cancelled runs don't trigger Slack alerts

## Context
When a test run is cancelled (e.g., superseded by a higher priority queued run), the release workflow was firing a "tests failed" alert to Slack. This is noisy and misleading since nothing actually failed.

## Test plan
- [ ] Verify PR passes CI
- [ ] Merge and observe that cancelled runs no longer alert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-facing changes. Internal CI/CD workflow improvements have been made to enhance notification accuracy during the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->