### PR TITLE
Add `miren debug ctr` command

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -232,6 +232,10 @@ Warning: These commands are intended for advanced users and developers. They may
 			return Infer("debug test load", "Loadtest a URL", TestLoad), nil
 		},
 
+		"debug ctr": func() (cli.Command, error) {
+			return Infer("debug ctr", "Run ctr with miren defaults", DebugCtr), nil
+		},
+
 		"debug ctr nuke": func() (cli.Command, error) {
 			return Infer("debug ctr nuke", "Nuke a containerd namespace", CtrNuke), nil
 		},

--- a/cli/commands/debug_ctr.go
+++ b/cli/commands/debug_ctr.go
@@ -36,20 +36,13 @@ func DebugCtr(ctx *Context, opts struct {
 	return syscall.Exec(ctrPath, args, env)
 }
 
-// findCtr looks for ctr in the miren release directories and falls back to PATH.
-// TODO: consolidate release path discovery with server.go into a shared helper
+// findCtr looks for ctr in the miren release directory and falls back to PATH.
 func findCtr() (string, error) {
-	// Check system release path first
-	systemPath := "/var/lib/miren/release/ctr"
-	if _, err := os.Stat(systemPath); err == nil {
-		return systemPath, nil
-	}
-
-	// Check user release path
-	if homeDir, err := os.UserHomeDir(); err == nil {
-		userPath := filepath.Join(homeDir, ".miren", "release", "ctr")
-		if _, err := os.Stat(userPath); err == nil {
-			return userPath, nil
+	// Check release directory first
+	if releasePath := FindReleasePath(); releasePath != "" {
+		ctrPath := filepath.Join(releasePath, "ctr")
+		if _, err := os.Stat(ctrPath); err == nil {
+			return ctrPath, nil
 		}
 	}
 
@@ -58,5 +51,5 @@ func findCtr() (string, error) {
 		return path, nil
 	}
 
-	return "", fmt.Errorf("ctr not found in release directories or PATH")
+	return "", fmt.Errorf("ctr not found in release directory or PATH")
 }

--- a/cli/commands/debug_ctr.go
+++ b/cli/commands/debug_ctr.go
@@ -6,8 +6,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
-
-	"miren.dev/runtime/pkg/containerdx"
 )
 
 func DebugCtr(ctx *Context, opts struct {
@@ -20,7 +18,7 @@ func DebugCtr(ctx *Context, opts struct {
 }) error {
 	socket := opts.Socket
 	if socket == "" {
-		socket = containerdx.DefaultSocket
+		socket = defaultContainerdSocket()
 	}
 
 	ctrPath, err := findCtr()
@@ -52,4 +50,18 @@ func findCtr() (string, error) {
 	}
 
 	return "", fmt.Errorf("ctr not found in release directory or PATH")
+}
+
+// defaultContainerdSocket returns the path to the miren containerd socket.
+// It checks for the socket in the default data path, falling back to the
+// standard system containerd socket if not found.
+func defaultContainerdSocket() string {
+	// Check miren's containerd socket (in default data path)
+	mirenSocket := "/var/lib/miren/containerd/containerd.sock"
+	if _, err := os.Stat(mirenSocket); err == nil {
+		return mirenSocket
+	}
+
+	// Fall back to system containerd socket
+	return "/run/containerd/containerd.sock"
 }

--- a/cli/commands/debug_ctr.go
+++ b/cli/commands/debug_ctr.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"miren.dev/runtime/pkg/containerdx"
+)
+
+func DebugCtr(ctx *Context, opts struct {
+	Namespace string `short:"n" long:"namespace" description:"containerd namespace" default:"miren"`
+	Socket    string `long:"socket" description:"path to containerd socket"`
+
+	Rest struct {
+		Args []string
+	} `positional-args:"yes"`
+}) error {
+	socket := opts.Socket
+	if socket == "" {
+		socket = containerdx.DefaultSocket
+	}
+
+	ctrPath, err := findCtr()
+	if err != nil {
+		return err
+	}
+
+	args := []string{"ctr", "-a", socket, "-n", opts.Namespace}
+	args = append(args, opts.Rest.Args...)
+
+	env := os.Environ()
+
+	return syscall.Exec(ctrPath, args, env)
+}
+
+// findCtr looks for ctr in the miren release directories and falls back to PATH.
+// TODO: consolidate release path discovery with server.go into a shared helper
+func findCtr() (string, error) {
+	// Check system release path first
+	systemPath := "/var/lib/miren/release/ctr"
+	if _, err := os.Stat(systemPath); err == nil {
+		return systemPath, nil
+	}
+
+	// Check user release path
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		userPath := filepath.Join(homeDir, ".miren", "release", "ctr")
+		if _, err := os.Stat(userPath); err == nil {
+			return userPath, nil
+		}
+	}
+
+	// Fall back to PATH (for dev environments where ctr might be in /usr/local/bin)
+	if path, err := exec.LookPath("ctr"); err == nil {
+		return path, nil
+	}
+
+	return "", fmt.Errorf("ctr not found in release directories or PATH")
+}

--- a/cli/commands/release_path.go
+++ b/cli/commands/release_path.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+const (
+	systemReleasePath = "/var/lib/miren/release"
+)
+
+// FindReleasePath looks for an existing miren release directory.
+// It checks the user's home directory first (~/.miren/release), then
+// falls back to the system path (/var/lib/miren/release).
+// Returns empty string if no release directory is found.
+func FindReleasePath() string {
+	// Check user release path first (respects user preference)
+	if homeDir, err := getUserHomeDir(); err == nil {
+		userPath := filepath.Join(homeDir, ".miren", "release")
+		if _, err := os.Stat(userPath); err == nil {
+			return userPath
+		}
+	}
+
+	// Check system release path
+	if _, err := os.Stat(systemReleasePath); err == nil {
+		return systemReleasePath
+	}
+
+	return ""
+}
+
+// getUserHomeDir returns the user's home directory, handling the case
+// where the command is run under sudo by checking SUDO_USER.
+func getUserHomeDir() (string, error) {
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		// Running under sudo, get the original user's home
+		u, err := user.Lookup(sudoUser)
+		if err == nil {
+			return u.HomeDir, nil
+		}
+		// Fallback to HOME env var
+		if homeDir := os.Getenv("HOME"); homeDir != "" {
+			return homeDir, nil
+		}
+	} else {
+		// Not running under sudo
+		if homeDir := os.Getenv("HOME"); homeDir != "" {
+			return homeDir, nil
+		}
+		u, err := user.Current()
+		if err != nil {
+			return "", err
+		}
+		return u.HomeDir, nil
+	}
+	return "", nil
+}


### PR DESCRIPTION
## Summary

- Add `miren debug ctr` command as a convenience wrapper for the containerd `ctr` CLI
- Automatically sets the miren namespace (`-n miren`) and containerd socket path
- Finds `ctr` binary in release directories before falling back to PATH
- Refactors release path discovery into a shared helper (`FindReleasePath()`) used by both `debug ctr` and `server` commands

## Usage

```bash
# List containers in miren namespace
miren debug ctr containers list

# List images
miren debug ctr images list

# Use a different namespace
miren debug ctr -n other-ns containers list
```

## Test plan

- [ ] Verify `miren debug ctr --help` shows usage
- [ ] Verify `miren debug ctr containers list` works in dev environment
- [ ] Verify server still starts correctly in standalone mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "debug ctr" command to run the containerd CLI with miren defaults, including namespace and socket options and passthrough arguments.

* **Improvements**
  * Centralized release-path discovery to check user and system locations.
  * Improved download workflow with writable-path detection and fallbacks when default locations are unavailable, plus clearer logging around release handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->