### PR TITLE
Implement streaming logs and RPC method discovery (RFD-42)

### DIFF
--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -2,8 +2,23 @@ imports:
   standard:
     path: ../../pkg/rpc/standard/standard.yml
     import: miren.dev/runtime/pkg/rpc/standard
+  stream:
+    path: ../../pkg/rpc/stream/stream.yml
+    import: miren.dev/runtime/pkg/rpc/stream
 
 types:
+  - type: LogTarget
+    fields:
+      - name: app
+        type: string
+        index: 0
+        optional: true
+      - name: sandbox
+        type: string
+        index: 1
+        optional: true
+
+
   - type: AutoConcurrency
     fields:
       - name: factor
@@ -418,6 +433,16 @@ interfaces:
           - name: logs
             type: list
             element: LogEntry
+      - name: streamLogs
+        parameters:
+          - name: target
+            type: LogTarget
+          - name: from
+            type: standard.Timestamp
+          - name: follow
+            type: bool
+          - name: logs
+            type: stream.SendStream[*LogEntry]
 
   - name: Disks
     methods:

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -80,15 +80,15 @@ func Logs(ctx *Context, opts struct {
 	return legacyLogs(ctx, cl, opts.App, opts.Sandbox, opts.Last)
 }
 
+var streamTypePrefixes = map[string]string{
+	"stdout":   "S",
+	"stderr":   "E",
+	"error":    "ERR",
+	"user-oob": "U",
+}
+
 func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *time.Duration, follow bool) error {
 	ac := app_v1alpha.LogsClient{Client: cl}
-
-	typ := map[string]string{
-		"stdout":   "S",
-		"stderr":   "E",
-		"error":    "ERR",
-		"user-oob": "U",
-	}
 
 	// Build target
 	target := &app_v1alpha.LogTarget{}
@@ -121,7 +121,7 @@ func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *
 			prefix = "[" + source + "] "
 		}
 		ctx.Printf("%s %s: %s%s\n",
-			typ[l.Stream()],
+			streamTypePrefixes[l.Stream()],
 			standard.FromTimestamp(l.Timestamp()).Format("2006-01-02 15:04:05"),
 			prefix,
 			l.Line())
@@ -134,13 +134,6 @@ func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *
 
 func legacyLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *time.Duration) error {
 	ac := app_v1alpha.LogsClient{Client: cl}
-
-	typ := map[string]string{
-		"stdout":   "S",
-		"stderr":   "E",
-		"error":    "ERR",
-		"user-oob": "U",
-	}
 
 	var ts *standard.Timestamp
 
@@ -182,7 +175,7 @@ func legacyLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *
 				prefix = "[" + source + "] "
 			}
 			ctx.Printf("%s %s: %s%s\n",
-				typ[l.Stream()],
+				streamTypePrefixes[l.Stream()],
 				standard.FromTimestamp(l.Timestamp()).Format("2006-01-02 15:04:05"),
 				prefix,
 				l.Line())

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -1,6 +1,7 @@
 package observability
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -260,6 +261,181 @@ func (l *LogReader) ReadBySandbox(ctx context.Context, sandboxID string, opts ..
 	}
 
 	return l.executeQuery(ctx, query, limit, startTime, time.Now())
+}
+
+// LogTarget specifies what logs to query - either by entity ID or sandbox ID.
+type LogTarget struct {
+	EntityID  string
+	SandboxID string
+}
+
+func (t LogTarget) query() string {
+	if t.SandboxID != "" {
+		return `sandbox:` + logsQLQuote(t.SandboxID)
+	}
+	return `entity:` + logsQLQuote(t.EntityID)
+}
+
+// ReadStream queries historical logs and sends them to a channel as they're parsed.
+// Unlike Read(), this has no limit and streams results incrementally.
+func (l *LogReader) ReadStream(ctx context.Context, target LogTarget, logCh chan<- LogEntry, opts ...LogReaderOption) error {
+	return l.executeStreamQuery(ctx, target.query(), logCh, opts...)
+}
+
+// TailStream connects to VictoriaLogs tail endpoint for live tailing.
+// Blocks until context is cancelled.
+func (l *LogReader) TailStream(ctx context.Context, target LogTarget, logCh chan<- LogEntry, opts ...LogReaderOption) error {
+	return l.executeTailQuery(ctx, target.query(), logCh, opts...)
+}
+
+func (l *LogReader) executeStreamQuery(ctx context.Context, query string, logCh chan<- LogEntry, opts ...LogReaderOption) error {
+	var o logReadOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	baseURL := normalizeBaseURL(l.Address)
+	queryURL := baseURL + "/select/logsql/query"
+
+	params := url.Values{}
+	params.Set("query", query)
+	// No limit - stream all results
+
+	startTime := o.From
+	if startTime.IsZero() {
+		startTime = time.Now().Add(-24 * time.Hour)
+	}
+	params.Set("start", startTime.Format(time.RFC3339Nano))
+	params.Set("end", time.Now().Format(time.RFC3339Nano))
+
+	fullURL := fmt.Sprintf("%s?%s", queryURL, params.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Use a client without timeout for streaming
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to query victorialogs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("victorialogs returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return l.parseLogStream(ctx, resp.Body, logCh)
+}
+
+func (l *LogReader) executeTailQuery(ctx context.Context, query string, logCh chan<- LogEntry, opts ...LogReaderOption) error {
+	var o logReadOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	baseURL := normalizeBaseURL(l.Address)
+	tailURL := baseURL + "/select/logsql/tail"
+
+	params := url.Values{}
+	params.Set("query", query)
+
+	// Include historical logs if From time specified
+	if !o.From.IsZero() {
+		offset := time.Since(o.From)
+		params.Set("start_offset", offset.String())
+	}
+
+	fullURL := fmt.Sprintf("%s?%s", tailURL, params.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Use a client without timeout for streaming
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to victorialogs tail: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("victorialogs returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return l.parseLogStream(ctx, resp.Body, logCh)
+}
+
+func (l *LogReader) parseLogStream(ctx context.Context, body io.Reader, logCh chan<- LogEntry) error {
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		entry, err := l.parseLogLine(line)
+		if err != nil {
+			// Skip malformed lines
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case logCh <- entry:
+		}
+	}
+
+	return scanner.Err()
+}
+
+func (l *LogReader) parseLogLine(line []byte) (LogEntry, error) {
+	var logData map[string]interface{}
+	if err := json.Unmarshal(line, &logData); err != nil {
+		return LogEntry{}, err
+	}
+
+	entry := LogEntry{
+		Attributes: make(map[string]string),
+	}
+
+	// Parse standard fields
+	if msg, ok := logData["_msg"].(string); ok {
+		entry.Body = msg
+	}
+
+	if timeStr, ok := logData["_time"].(string); ok {
+		if t, err := time.Parse(time.RFC3339Nano, timeStr); err == nil {
+			entry.Timestamp = t
+		}
+	}
+
+	if stream, ok := logData["stream"].(string); ok {
+		entry.Stream = LogStream(stream)
+	}
+
+	if traceID, ok := logData["trace_id"].(string); ok {
+		entry.TraceID = traceID
+	}
+
+	// Add all other fields as attributes
+	for k, v := range logData {
+		if k == "_msg" || k == "_time" || k == "stream" || k == "trace_id" || k == "entity" {
+			continue
+		}
+		if strVal, ok := v.(string); ok {
+			entry.Attributes[k] = strVal
+		}
+	}
+
+	return entry, nil
 }
 
 func (l *LogReader) executeQuery(ctx context.Context, query string, limit int, start, end time.Time) ([]LogEntry, error) {

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -427,7 +427,7 @@ func (l *LogReader) parseLogLine(line []byte) (LogEntry, error) {
 
 	// Add all other fields as attributes
 	for k, v := range logData {
-		if k == "_msg" || k == "_time" || k == "stream" || k == "trace_id" || k == "entity" || k == "sandbox" {
+		if k == "_msg" || k == "_time" || k == "stream" || k == "trace_id" || k == "entity" {
 			continue
 		}
 		if strVal, ok := v.(string); ok {


### PR DESCRIPTION
## Summary

Implements [RFD-42: Streaming Logs and RPC Method Discovery](https://github.com/mirendev/rfd/pull/XX).

This PR adds:
- **RPC Method Discovery**: New `/_rpc/methods/{oid}` endpoint and client-side `HasMethod()` for capability detection
- **Streaming Logs**: New `streamLogs` RPC method with `--follow` support for live tailing
- **Backward Compatibility**: CLI detects server capabilities and falls back to legacy pagination

## Changes

### RPC Layer (`pkg/rpc/`)
- `server.go`: Add `GET /_rpc/methods/{oid}` endpoint returning available method names
- `client.go`: Add `ListMethods()` and `HasMethod()` for runtime capability detection

### API (`api/app/`)
- `rpc.yml`: Add `stream` import, `LogTarget` type, and `streamLogs` method
- Regenerated `rpc.gen.go`

### Observability (`observability/`)
- `logs.go`: Add `LogTarget` type, `ReadStream()`, and `TailStream()` methods
- Streaming uses `bufio.Scanner` to parse NDJSON incrementally

### Server (`servers/logs/`)
- `logs.go`: Add `StreamLogs()` handler that streams entries via RPC

### CLI (`cli/commands/`)
- `logs.go`: Add `--follow` flag, capability detection, streaming path with legacy fallback

## Test plan

- [ ] Unit tests for RPC method introspection
- [ ] Integration test: streaming returns >1000 logs
- [ ] Integration test: `--follow` receives live logs  
- [ ] Manual test: new CLI against old server (graceful fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live log streaming support for real-time tailing; client auto-detects server streaming capability.
  * Added --follow flag to the logs command for continuous/live output.

* **Improvements**
  * Faster, low-latency log delivery when streaming is available; automatic fallback to polling with a non-fatal warning if not supported.
  * Unified timestamp/prefix formatting and optional source truncation for clearer, consistent log lines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->