### PR TITLE
Fix: set SELinux context on miren binary for RHEL/Oracle Linux

### DIFF
--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -69,6 +69,8 @@ func fixSELinuxContext(ctx *Context, binaryPath string) {
 		if output, err := chconCmd.CombinedOutput(); err != nil {
 			ctx.Warn("Failed to set SELinux context: %v\nOutput: %s", err, output)
 			ctx.Warn("The service may fail to start. Try running: sudo chcon -t bin_t %s", binaryPath)
+		} else {
+			ctx.Completed("SELinux context set (temporary)")
 		}
 	} else {
 		ctx.Completed("SELinux context configured (persistent)")

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -16,6 +16,65 @@ import (
 	"miren.dev/runtime/pkg/registration"
 )
 
+// fixSELinuxContext sets the proper SELinux context on the miren binary
+// so systemd can execute it. This is needed on systems like RHEL/Oracle Linux
+// where SELinux is enforcing and /var/lib files get var_lib_t context by default.
+func fixSELinuxContext(ctx *Context, binaryPath string) {
+	// Check if SELinux is enforcing by running getenforce
+	cmd := exec.Command("getenforce")
+	output, err := cmd.Output()
+	if err != nil {
+		// getenforce not found or failed - SELinux probably not installed
+		ctx.Log.Debug("getenforce failed, assuming SELinux not active", "error", err)
+		return
+	}
+
+	status := strings.TrimSpace(string(output))
+	if status != "Enforcing" {
+		ctx.Log.Debug("SELinux not enforcing", "status", status)
+		return
+	}
+
+	ctx.Info("SELinux is enforcing, configuring executable context for binary...")
+
+	// Try to add a permanent file context rule using semanage
+	// This requires policycoreutils-python-utils on RHEL/Oracle Linux
+	semanageCmd := exec.Command("semanage", "fcontext", "-a", "-t", "bin_t", binaryPath)
+	if output, err := semanageCmd.CombinedOutput(); err != nil {
+		// semanage might not be installed, or rule might already exist
+		outputStr := string(output)
+		if strings.Contains(outputStr, "already defined") || strings.Contains(outputStr, "already exists") {
+			ctx.Log.Debug("SELinux file context rule already exists")
+		} else {
+			ctx.Log.Debug("semanage fcontext failed", "error", err, "output", outputStr)
+			// Fall back to chcon if semanage isn't available
+			ctx.Info("semanage not available, using chcon (context may not persist across relabels)")
+			chconCmd := exec.Command("chcon", "-t", "bin_t", binaryPath)
+			if output, err := chconCmd.CombinedOutput(); err != nil {
+				ctx.Warn("Failed to set SELinux context: %v\nOutput: %s", err, output)
+				ctx.Warn("The service may fail to start. Try running: sudo chcon -t bin_t %s", binaryPath)
+				return
+			}
+			ctx.Completed("SELinux context set (temporary)")
+			return
+		}
+	}
+
+	// Apply the context with restorecon
+	restoreconCmd := exec.Command("restorecon", "-v", binaryPath)
+	if output, err := restoreconCmd.CombinedOutput(); err != nil {
+		ctx.Warn("Failed to apply SELinux context with restorecon: %v\nOutput: %s", err, output)
+		// Try chcon as fallback
+		chconCmd := exec.Command("chcon", "-t", "bin_t", binaryPath)
+		if output, err := chconCmd.CombinedOutput(); err != nil {
+			ctx.Warn("Failed to set SELinux context: %v\nOutput: %s", err, output)
+			ctx.Warn("The service may fail to start. Try running: sudo chcon -t bin_t %s", binaryPath)
+		}
+	} else {
+		ctx.Completed("SELinux context configured (persistent)")
+	}
+}
+
 // ServerInstall sets up systemd units to run the miren server
 func ServerInstall(ctx *Context, opts struct {
 	Address      string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
@@ -49,6 +108,9 @@ func ServerInstall(ctx *Context, opts struct {
 		}
 
 		ctx.Completed("Release downloaded successfully")
+
+		// Fix SELinux context if needed (RHEL/Oracle Linux with SELinux enforcing)
+		fixSELinuxContext(ctx, mirenPath)
 	}
 
 	// Register with cloud unless --without-cloud is specified


### PR DESCRIPTION
## Summary

On RHEL/Oracle Linux with SELinux enforcing, the miren systemd service fails to start because files in `/var/lib` get `var_lib_t` context, which systemd cannot execute.

This PR adds SELinux context handling to:
- **server install**: uses `semanage fcontext` for a persistent rule, falls back to `chcon` if semanage unavailable
- **installer** (used by upgrades): applies `restorecon` after upgrades to maintain context, falls back to `chcon` if needed

Only the miren binary needs this fix - once running as `unconfined_service_t`, it can execute the other binaries (containerd, runc, shims) regardless of their file context.

Fixes MIR-557

## Test plan

- [ ] Test fresh install on Oracle Linux with SELinux enforcing
- [ ] Test upgrade path on Oracle Linux
- [ ] Verify no impact on Ubuntu/Debian (SELinux not present)
- [ ] Verify service starts and containerd/shims launch correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability on systems with enforcing SELinux (RHEL/Oracle Linux) by automatically configuring the correct file context for the installed binary. The installer now attempts to set and verify a usable context, emits warnings if adjustment tools are unavailable or adjustments fail, and continues installation without hard failure by falling back to safer temporary context handling when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->