### PR TITLE
Improve deploy confirmation UX

### DIFF
--- a/pkg/ui/prompt.go
+++ b/pkg/ui/prompt.go
@@ -163,6 +163,7 @@ type confirmConfig struct {
 	affirmative string
 	negative    string
 	defaultYes  bool
+	indent      string
 }
 
 // WithMessage sets the confirmation message
@@ -193,6 +194,13 @@ func WithDefault(defaultYes bool) ConfirmOption {
 	}
 }
 
+// WithIndent sets the indentation prefix for the prompt
+func WithIndent(indent string) ConfirmOption {
+	return func(c *confirmConfig) {
+		c.indent = indent
+	}
+}
+
 // Confirm displays a yes/no confirmation prompt
 func Confirm(opts ...ConfirmOption) (bool, error) {
 	// Apply default configuration
@@ -201,6 +209,7 @@ func Confirm(opts ...ConfirmOption) (bool, error) {
 		affirmative: "yes",
 		negative:    "no",
 		defaultYes:  false,
+		indent:      "",
 	}
 
 	// Apply options
@@ -214,6 +223,7 @@ func Confirm(opts ...ConfirmOption) (bool, error) {
 		affirmative: config.affirmative,
 		negative:    config.negative,
 		defaultYes:  config.defaultYes,
+		indent:      config.indent,
 	}
 
 	p := tea.NewProgram(model)
@@ -236,6 +246,7 @@ type confirmModel struct {
 	affirmative string
 	negative    string
 	defaultYes  bool
+	indent      string
 	confirmed   bool
 	err         error
 }
@@ -267,7 +278,6 @@ func (m confirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m confirmModel) View() string {
-	promptStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	highlightStyle := lipgloss.NewStyle().Bold(true)
 
 	var prompt string
@@ -277,10 +287,5 @@ func (m confirmModel) View() string {
 		prompt = fmt.Sprintf("(y/%s)", highlightStyle.Render("N"))
 	}
 
-	return fmt.Sprintf(
-		"%s %s\n\n%s",
-		m.message,
-		prompt,
-		promptStyle.Render("Press y/n or enter for default, esc to cancel"),
-	)
+	return fmt.Sprintf("%s%s %s", m.indent, m.message, prompt)
 }


### PR DESCRIPTION
## Summary

- Skip confirmation prompt when only one cluster is configured (no ambiguity)
- Style the confirmation prompt to align with deploy output (2-space indent, single line)
- Update deploy status line to show both app and cluster: `✓ Deploying: hw-bun → local`

## Test plan

- [ ] Deploy with single cluster configured - no confirmation prompt shown
- [ ] Deploy with multiple clusters configured - confirmation prompt shown with proper indentation
- [ ] Verify deploy status line shows app and cluster with arrow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deployment confirmation prompt automatically skips when exactly one cluster is configured, streamlining the deployment process.
  * Deployment progress messages now display with improved clarity, including the app name and target cluster with visual indicators.

* **Improvements**
  * Enhanced confirmation prompt formatting with consistent indentation for better visual presentation and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->