### PR TITLE
Improve build container UX with better naming and log access

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -495,7 +495,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	b.Log.Debug("resolved cluster.local", "ip", ip.String())
 
 	b.Log.Info("starting buildkit launch", "clusterIP", ip.String(), "logEntity", name)
-	rbk, err := lbk.Launch(ctx, ip.String(), WithLogEntity(name), WithLogAttrs(map[string]string{
+	rbk, err := lbk.Launch(ctx, ip.String(), WithLogEntity(name), WithAppName(name), WithLogAttrs(map[string]string{
 		"version": "build",
 	}))
 	if err != nil {

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -10,6 +10,37 @@ import (
 	"miren.dev/runtime/appconfig"
 )
 
+func TestSanitizeNameForID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple lowercase", "myapp", "myapp"},
+		{"uppercase converted", "MyApp", "myapp"},
+		{"spaces to hyphens", "my app", "my-app"},
+		{"underscores to hyphens", "my_app", "my-app"},
+		{"slashes to hyphens", "my/app", "my-app"},
+		{"colons to hyphens", "my:app", "my-app"},
+		{"multiple separators collapsed", "my--app", "my-app"},
+		{"mixed separators", "My App_Name/Test:123", "my-app-name-test-123"},
+		{"leading separator stripped", "/myapp", "myapp"},
+		{"trailing separator stripped", "myapp/", "myapp"},
+		{"numbers preserved", "app123", "app123"},
+		{"special chars removed", "my@app#name!", "myappname"},
+		{"empty string", "", ""},
+		{"only spaces", "   ", ""},
+		{"only special chars", "@#$%", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeNameForID(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestBuildVariablesFromAppConfig(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

- Use `build-{app}-{id}` naming scheme for buildkit sandboxes instead of generic `sb-{id}`, making it easier to identify which app a build belongs to
- Stop buildkit sandbox on close instead of deleting it, preserving build logs for debugging until natural cleanup
- Simplify logs command to normalize sandbox IDs without requiring entity lookup, allowing log queries for deleted sandboxes

## Test plan

- [ ] Deploy an app and verify buildkit sandbox is named `build-{appname}-{id}`
- [ ] After deploy completes, verify sandbox is stopped (not deleted)
- [ ] Query logs for the build sandbox by name: `m logs -s build-{appname}-{id}`
- [ ] Verify logs still work after sandbox is naturally cleaned up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandboxes are now stopped (marked stopped) during cleanup instead of being immediately deleted.

* **Improvements**
  * Sandbox identifiers now incorporate sanitized application names for better traceability.
  * Sandbox ID handling is standardized with consistent normalization to accept IDs with or without a sandbox prefix.
  * Logging messages and sandbox naming reflect the sanitized app-based names.

* **New Features**
  * Launch operations now accept an application name to include in sandbox creation.

* **Tests**
  * Added unit tests verifying name sanitization and ID normalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->