### PR TITLE
Validate env var keys in app.toml to catch errors early

### DIFF
--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -10,9 +10,8 @@ import (
 )
 
 type AppEnvVar struct {
-	Name      string `json:"name" toml:"key"`
-	Value     string `json:"value" toml:"value"`
-	Generator string `json:"generator" toml:"generator"`
+	Key   string `json:"key" toml:"key"`
+	Value string `json:"value" toml:"value"`
 }
 
 type BuildConfig struct {
@@ -139,6 +138,13 @@ func Parse(data []byte) (*AppConfig, error) {
 
 // Validate checks that the AppConfig has valid values
 func (ac *AppConfig) Validate() error {
+	// Validate global environment variables
+	for i, ev := range ac.EnvVars {
+		if ev.Key == "" {
+			return fmt.Errorf("env[%d]: key is required", i)
+		}
+	}
+
 	// Validate service configurations
 	for serviceName, svcConfig := range ac.Services {
 		if svcConfig == nil {
@@ -180,6 +186,13 @@ func (ac *AppConfig) Validate() error {
 				if concurrency.ScaleDownDelay != "" {
 					return fmt.Errorf("service %s: scale_down_delay cannot be set in fixed mode", serviceName)
 				}
+			}
+		}
+
+		// Validate service environment variables
+		for i, ev := range svcConfig.EnvVars {
+			if ev.Key == "" {
+				return fmt.Errorf("service %s: env[%d] key is required", serviceName, i)
 			}
 		}
 

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -214,7 +214,7 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 				svc.Env = make([]core_v1alpha.Env, 0, len(serviceConfig.EnvVars))
 				for _, envVar := range serviceConfig.EnvVars {
 					svc.Env = append(svc.Env, core_v1alpha.Env{
-						Key:    envVar.Name,
+						Key:    envVar.Key,
 						Value:  envVar.Value,
 						Source: "config",
 					})
@@ -236,7 +236,7 @@ func buildVariablesFromAppConfig(appConfig *appconfig.AppConfig) []core_v1alpha.
 	variables := make([]core_v1alpha.Variable, 0, len(appConfig.EnvVars))
 	for _, envVar := range appConfig.EnvVars {
 		variables = append(variables, core_v1alpha.Variable{
-			Key:    envVar.Name,
+			Key:    envVar.Key,
 			Value:  envVar.Value,
 			Source: "config",
 		})

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -32,7 +32,7 @@ func TestBuildVariablesFromAppConfig(t *testing.T) {
 			name: "single env var",
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "DATABASE_URL", Value: "postgres://localhost/db"},
+					{Key: "DATABASE_URL", Value: "postgres://localhost/db"},
 				},
 			},
 			wantVariables: []core_v1alpha.Variable{
@@ -43,26 +43,15 @@ func TestBuildVariablesFromAppConfig(t *testing.T) {
 			name: "multiple env vars",
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "DATABASE_URL", Value: "postgres://localhost/db"},
-					{Name: "API_KEY", Value: "secret123"},
-					{Name: "PORT", Value: "8080"},
+					{Key: "DATABASE_URL", Value: "postgres://localhost/db"},
+					{Key: "API_KEY", Value: "secret123"},
+					{Key: "PORT", Value: "8080"},
 				},
 			},
 			wantVariables: []core_v1alpha.Variable{
 				{Key: "DATABASE_URL", Value: "postgres://localhost/db"},
 				{Key: "API_KEY", Value: "secret123"},
 				{Key: "PORT", Value: "8080"},
-			},
-		},
-		{
-			name: "env var with generator field (ignored)",
-			appConfig: &appconfig.AppConfig{
-				EnvVars: []appconfig.AppEnvVar{
-					{Name: "SECRET_KEY", Value: "default", Generator: "random"},
-				},
-			},
-			wantVariables: []core_v1alpha.Variable{
-				{Key: "SECRET_KEY", Value: "default"},
 			},
 		},
 	}
@@ -456,8 +445,8 @@ func TestBuildServicesConfig(t *testing.T) {
 							RequestsPerInstance: 10,
 						},
 						EnvVars: []appconfig.AppEnvVar{
-							{Name: "NODE_ENV", Value: "production"},
-							{Name: "PORT", Value: "3000"},
+							{Key: "NODE_ENV", Value: "production"},
+							{Key: "PORT", Value: "3000"},
 						},
 					},
 				},
@@ -485,7 +474,7 @@ func TestBuildServicesConfig(t *testing.T) {
 							RequestsPerInstance: 10,
 						},
 						EnvVars: []appconfig.AppEnvVar{
-							{Name: "NODE_ENV", Value: "production"},
+							{Key: "NODE_ENV", Value: "production"},
 						},
 					},
 					"worker": {
@@ -494,8 +483,8 @@ func TestBuildServicesConfig(t *testing.T) {
 							NumInstances: 2,
 						},
 						EnvVars: []appconfig.AppEnvVar{
-							{Name: "WORKER_THREADS", Value: "4"},
-							{Name: "QUEUE_NAME", Value: "default"},
+							{Key: "WORKER_THREADS", Value: "4"},
+							{Key: "QUEUE_NAME", Value: "default"},
 						},
 					},
 					"scheduler": {
@@ -601,7 +590,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			},
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "NEW_VAR", Value: "new_value"},
+					{Key: "NEW_VAR", Value: "new_value"},
 				},
 			},
 			wantVars: []core_v1alpha.Variable{
@@ -617,7 +606,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			},
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "CONFIG_VAR_1", Value: "value1"},
+					{Key: "CONFIG_VAR_1", Value: "value1"},
 				},
 			},
 			wantVars: []core_v1alpha.Variable{
@@ -632,7 +621,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			},
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "VAR1", Value: "new_value"},
+					{Key: "VAR1", Value: "new_value"},
 				},
 			},
 			wantVars: []core_v1alpha.Variable{
@@ -647,7 +636,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			},
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "NEW_VAR", Value: "new_value"},
+					{Key: "NEW_VAR", Value: "new_value"},
 				},
 			},
 			wantVars: []core_v1alpha.Variable{
@@ -661,7 +650,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			},
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "DATABASE_URL", Value: "from_config"},
+					{Key: "DATABASE_URL", Value: "from_config"},
 				},
 			},
 			wantVars: []core_v1alpha.Variable{
@@ -677,8 +666,8 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			},
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "SECRET", Value: "default_secret"}, // Should NOT override manual
-					{Name: "LOG_LEVEL", Value: "info"},        // Should override config
+					{Key: "SECRET", Value: "default_secret"}, // Should NOT override manual
+					{Key: "LOG_LEVEL", Value: "info"},        // Should override config
 				},
 			},
 			wantVars: []core_v1alpha.Variable{
@@ -696,8 +685,8 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			},
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "CONFIG_1", Value: "c1_updated"},
-					{Name: "CONFIG_3", Value: "c3"},
+					{Key: "CONFIG_1", Value: "c1_updated"},
+					{Key: "CONFIG_3", Value: "c3"},
 				},
 			},
 			wantVars: []core_v1alpha.Variable{
@@ -724,7 +713,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			existingVars: nil,
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Name: "NEW_VAR", Value: "new_value"},
+					{Key: "NEW_VAR", Value: "new_value"},
 				},
 			},
 			wantVars: []core_v1alpha.Variable{


### PR DESCRIPTION
## Summary
- Add validation for empty env var keys at config parse time
- Rename `AppEnvVar.Name` → `Key` for consistency with TOML/JSON field names
- Remove unused `Generator` field from `AppEnvVar`

## Test plan
- [x] `make lint` passes
- [x] `go test ./appconfig/...` passes
- [x] `go test ./servers/build/...` passes
- [ ] Deploy and verify error message when env var key is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Breaking Changes**
* Environment variable configuration field renamed from `Name` to `Key`
* Removed `Generator` field from environment variable configuration

**Improvements**
* Enhanced validation to ensure all environment variables have valid, non-empty keys at both global and service configuration levels
* Improved error messages for missing or invalid environment variable keys

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->