### PR TITLE
Fix db/id type mismatch when updating sandbox status

### DIFF
--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -15,6 +15,7 @@ import (
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity/types"
 )
 
 // EtcdStore implements Store using etcd
@@ -653,6 +654,8 @@ func extractEntityId(attributes []Attr) (Id, error) {
 			case Id:
 				return v, nil
 			case string:
+				return Id(v), nil
+			case types.Keyword:
 				return Id(v), nil
 			default:
 				return "", fmt.Errorf("invalid db/id attribute type: %T", attr.Value.Any())


### PR DESCRIPTION
## Summary

Fixes production errors during miren server restarts where sandboxes failed to update their status to STOPPED:

```
"remote error: generic unknown: invalid db/id attribute type: types.Keyword"
```

## Root Cause

The `extractEntityId` function only accepted `types.Id` or `string` for the `db/id` attribute value. However, during RPC serialization/deserialization, some `db/id` values were being unmarshaled as `types.Keyword` instead of `types.Id`.

Since both `types.Id` and `types.Keyword` are string aliases, they're semantically equivalent for entity IDs.

## Changes

- Add `types.Keyword` case to `extractEntityId` switch statement in `pkg/entity/store.go`
- Import `pkg/entity/types` package
- Add comprehensive test coverage for `extractEntityId` with all valid types

## Test Plan

- [x] All entity package tests pass (167 tests)
- [x] All entityserver tests pass (19 tests)  
- [x] Build succeeds
- [x] Linter passes with 0 issues
- [x] New test validates the fix for the types.Keyword case

## Production Impact

This resolves the errors seen in production logs during miren restarts where sandboxes were unable to transition to STOPPED status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for entity ID extraction functionality, with new test cases thoroughly validating correct behavior across different value type inputs and various error handling scenarios.

* **Refactor**
  * Extended entity ID extraction to support additional data value types, improving overall system flexibility and robustness for consistently handling all diverse input formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->