### PR TITLE
Set PORT env var for services with configured ports

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -313,6 +313,9 @@ func (l *Launcher) buildSandboxSpec(
 				Type: portType,
 			},
 		}
+
+		// Set PORT env var so apps can listen on $PORT
+		appCont.Env = append(appCont.Env, fmt.Sprintf("PORT=%d", port))
 	}
 
 	// Add global config env vars
@@ -507,7 +510,7 @@ func envVarsEqual(env1, env2 []string) bool {
 func filterSystemEnvVars(envVars []string) []string {
 	filtered := []string{}
 	for _, e := range envVars {
-		// Skip MIREN_VERSION, MIREN_APP, and MIREN_INSTANCE_NUM - these are set automatically
+		// Skip MIREN_VERSION, MIREN_APP, MIREN_INSTANCE_NUM, and PORT - these are set automatically
 		if strings.HasPrefix(e, "MIREN_VERSION=") {
 			continue
 		}
@@ -515,6 +518,9 @@ func filterSystemEnvVars(envVars []string) []string {
 			continue
 		}
 		if strings.HasPrefix(e, "MIREN_INSTANCE_NUM=") {
+			continue
+		}
+		if strings.HasPrefix(e, "PORT=") {
 			continue
 		}
 		filtered = append(filtered, e)


### PR DESCRIPTION
## Summary
- Apps can now listen on `$PORT` and trust they'll be wired correctly
- PORT env var is set to match the configured port for any service that has a port
- Web services default to PORT=3000, other services need explicit port config
- Services without ports (workers, etc.) don't get PORT set

## Test plan
- [x] `TestPerServicePortConfiguration` verifies PORT is set for web (8080) and api (3001), not set for admin/worker
- [x] `TestWebServiceDefaultPort` verifies PORT=3000 for default web service
- [x] All existing tests pass
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Services with configured ports now automatically receive a PORT environment variable, enabling applications to discover their assigned listening port.
  - Environment variable management has been optimized for improved resource pool reuse and consistency across deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->