### PR TITLE
Feature: add NoTruncate option for table columns

### DIFF
--- a/cli/commands/app_list.go
+++ b/cli/commands/app_list.go
@@ -196,7 +196,7 @@ func AppList(ctx *Context, opts struct {
 		return nil
 	}
 
-	columns := ui.AutoSizeColumns(headers, rows)
+	columns := ui.AutoSizeColumns(headers, rows, nil)
 	table := ui.NewTable(
 		ui.WithColumns(columns),
 		ui.WithRows(rows),

--- a/cli/commands/cluster.go
+++ b/cli/commands/cluster.go
@@ -112,7 +112,7 @@ func ClusterList(ctx *Context, opts struct {
 	}
 
 	// Create and render the table
-	columns := ui.AutoSizeColumns(headers, rows)
+	columns := ui.AutoSizeColumns(headers, rows, nil)
 	table := ui.NewTable(
 		ui.WithColumns(columns),
 		ui.WithRows(rows),

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -400,10 +400,11 @@ func printEnvTable(ctx *Context, entries []envVarEntry) {
 	columns := ui.AutoSizeColumns(
 		[]string{"NAME", "VALUE", "SERVICE", "SOURCE"},
 		rows,
-		30, // max width for NAME column
-		40, // max width for VALUE column
-		15, // max width for SERVICE column
-		12, // max width for SOURCE column
+		ui.Columns().
+			MaxWidth(0, 30). // NAME
+			MaxWidth(1, 40). // VALUE
+			MaxWidth(2, 15). // SERVICE
+			MaxWidth(3, 12), // SOURCE
 	)
 
 	// Create and render the table

--- a/cli/commands/route_list.go
+++ b/cli/commands/route_list.go
@@ -88,7 +88,7 @@ func RouteList(ctx *Context, opts struct {
 		return nil
 	}
 
-	columns := ui.AutoSizeColumns(headers, rows)
+	columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0))
 	table := ui.NewTable(
 		ui.WithColumns(columns),
 		ui.WithRows(rows),

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -169,7 +169,7 @@ func SandboxList(ctx *Context, opts struct {
 	}
 
 	// Create and render the table
-	columns := ui.AutoSizeColumns(headers, rows)
+	columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0))
 	table := ui.NewTable(
 		ui.WithColumns(columns),
 		ui.WithRows(rows),

--- a/cli/commands/sandbox_pool_list.go
+++ b/cli/commands/sandbox_pool_list.go
@@ -66,7 +66,7 @@ func SandboxPoolList(ctx *Context, opts struct {
 		return nil
 	}
 
-	columns := ui.AutoSizeColumns(headers, rows)
+	columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0))
 	table := ui.NewTable(
 		ui.WithColumns(columns),
 		ui.WithRows(rows),

--- a/pkg/ui/picker.go
+++ b/pkg/ui/picker.go
@@ -149,7 +149,7 @@ func (m *PickerModel) View() string {
 	}
 
 	// Auto-size columns
-	columns := AutoSizeColumns(headers, rows)
+	columns := AutoSizeColumns(headers, rows, nil)
 
 	// Style for selected row
 	selectedStyle := lipgloss.NewStyle().

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -173,18 +173,21 @@ func AutoSizeColumns(headers []string, rows []Row, builder *ColumnBuilder) []Col
 		}
 	}
 
-	// Apply max widths from hints
-	for i := range widths {
-		hint := builder.getHint(i)
-		if hint.MaxWidth > 0 {
-			widths[i] = min(widths[i], hint.MaxWidth)
-		}
-	}
-
 	// Track which columns are protected from truncation
 	noTruncate := make([]bool, len(headers))
 	for i := range headers {
 		noTruncate[i] = builder.getHint(i).NoTruncate
+	}
+
+	// Apply max widths from hints (skip NoTruncate columns)
+	for i := range widths {
+		if noTruncate[i] {
+			continue // NoTruncate columns ignore MaxWidth
+		}
+		hint := builder.getHint(i)
+		if hint.MaxWidth > 0 {
+			widths[i] = min(widths[i], hint.MaxWidth)
+		}
 	}
 
 	// Only apply terminal width constraints if stdout is a TTY

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -12,8 +12,60 @@ import (
 
 // Column defines a table column with title and width
 type Column struct {
-	Title string
-	Width int
+	Title      string
+	Width      int
+	NoTruncate bool // If true, this column won't be truncated when scaling
+}
+
+// ColumnHint provides configuration hints for a specific column
+type ColumnHint struct {
+	MaxWidth   int  // Maximum width (0 = no limit)
+	NoTruncate bool // If true, this column won't be scaled down
+	MinWidth   int  // Minimum width when scaling (0 = use default)
+}
+
+// ColumnBuilder helps configure column options using a fluent API
+type ColumnBuilder struct {
+	hints map[int]ColumnHint
+}
+
+// Columns creates a new ColumnBuilder for configuring column options
+func Columns() *ColumnBuilder {
+	return &ColumnBuilder{hints: make(map[int]ColumnHint)}
+}
+
+// NoTruncate marks the specified column indices as non-truncatable
+func (b *ColumnBuilder) NoTruncate(indices ...int) *ColumnBuilder {
+	for _, i := range indices {
+		h := b.hints[i]
+		h.NoTruncate = true
+		b.hints[i] = h
+	}
+	return b
+}
+
+// MaxWidth sets the maximum width for a specific column
+func (b *ColumnBuilder) MaxWidth(index, width int) *ColumnBuilder {
+	h := b.hints[index]
+	h.MaxWidth = width
+	b.hints[index] = h
+	return b
+}
+
+// MinWidth sets the minimum width for a specific column when scaling
+func (b *ColumnBuilder) MinWidth(index, width int) *ColumnBuilder {
+	h := b.hints[index]
+	h.MinWidth = width
+	b.hints[index] = h
+	return b
+}
+
+// getHint returns the hint for a column index, or an empty hint if none exists
+func (b *ColumnBuilder) getHint(index int) ColumnHint {
+	if b == nil {
+		return ColumnHint{}
+	}
+	return b.hints[index]
 }
 
 // Row represents a single row of data in the table
@@ -81,9 +133,10 @@ func NewTable(opts ...TableOption) *Table {
 	return t
 }
 
-// AutoSizeColumns calculates optimal column widths based on content
-// with optional maximum widths per column, respecting terminal width
-func AutoSizeColumns(headers []string, rows []Row, maxWidths ...int) []Column {
+// AutoSizeColumns calculates optimal column widths based on content,
+// respecting terminal width and column configuration hints.
+// Pass nil for builder to use default behavior.
+func AutoSizeColumns(headers []string, rows []Row, builder *ColumnBuilder) []Column {
 	if len(headers) == 0 {
 		return nil
 	}
@@ -120,11 +173,18 @@ func AutoSizeColumns(headers []string, rows []Row, maxWidths ...int) []Column {
 		}
 	}
 
-	// Apply max widths if provided
+	// Apply max widths from hints
 	for i := range widths {
-		if i < len(maxWidths) && maxWidths[i] > 0 {
-			widths[i] = min(widths[i], maxWidths[i])
+		hint := builder.getHint(i)
+		if hint.MaxWidth > 0 {
+			widths[i] = min(widths[i], hint.MaxWidth)
 		}
+	}
+
+	// Track which columns are protected from truncation
+	noTruncate := make([]bool, len(headers))
+	for i := range headers {
+		noTruncate[i] = builder.getHint(i).NoTruncate
 	}
 
 	// Only apply terminal width constraints if stdout is a TTY
@@ -134,22 +194,46 @@ func AutoSizeColumns(headers []string, rows []Row, maxWidths ...int) []Column {
 		for _, w := range widths {
 			totalWidth += w
 		}
-		totalWidth += (len(headers) - 1) * 2 // 2 spaces between each column
+		spacing := (len(headers) - 1) * 2 // 2 spaces between each column
+		totalWidth += spacing
 
-		// If total width exceeds terminal width, scale down proportionally
+		// If total width exceeds terminal width, scale down non-protected columns
 		if totalWidth > termWidth {
-			availableWidth := termWidth - (len(headers)-1)*2 // subtract space for margins
-
-			// Calculate scaling factor
-			scaleFactor := float64(availableWidth) / float64(totalWidth-(len(headers)-1)*2)
-
-			// Scale each column width
-			for i := range widths {
-				newWidth := int(float64(widths[i]) * scaleFactor)
-				if newWidth < 10 { // Minimum column width
-					newWidth = 10
+			// Calculate protected width (columns that can't be truncated)
+			protectedWidth := 0
+			scalableWidth := 0
+			for i, w := range widths {
+				if noTruncate[i] {
+					protectedWidth += w
+				} else {
+					scalableWidth += w
 				}
-				widths[i] = newWidth
+			}
+
+			// Available width for scalable columns
+			availableForScalable := termWidth - spacing - protectedWidth
+
+			// Only scale if there's something to scale and room to do it
+			if scalableWidth > 0 && availableForScalable > 0 {
+				scaleFactor := float64(availableForScalable) / float64(scalableWidth)
+
+				for i := range widths {
+					if noTruncate[i] {
+						continue // Don't scale protected columns
+					}
+
+					hint := builder.getHint(i)
+					minWidth := hint.MinWidth
+					if minWidth <= 0 {
+						minWidth = 10 // Default minimum
+					}
+
+					newWidth := int(float64(widths[i]) * scaleFactor)
+					if newWidth < minWidth {
+						newWidth = minWidth
+					}
+					widths[i] = newWidth
+				}
 			}
 		}
 	}
@@ -158,8 +242,9 @@ func AutoSizeColumns(headers []string, rows []Row, maxWidths ...int) []Column {
 	columns := make([]Column, len(headers))
 	for i, header := range headers {
 		columns[i] = Column{
-			Title: header,
-			Width: widths[i],
+			Title:      header,
+			Width:      widths[i],
+			NoTruncate: noTruncate[i],
 		}
 	}
 
@@ -213,9 +298,15 @@ func (t *Table) renderHeader() string {
 			MaxWidth(col.Width).
 			Inline(true)
 
-		// Truncate with ellipsis and render
-		truncated := runewidth.Truncate(col.Title, col.Width, "…")
-		renderedCell := cellStyle.Render(truncated)
+		var renderedCell string
+		if col.NoTruncate {
+			// Don't truncate protected columns
+			renderedCell = cellStyle.Render(col.Title)
+		} else {
+			// Truncate with ellipsis and render
+			truncated := runewidth.Truncate(col.Title, col.Width, "…")
+			renderedCell = cellStyle.Render(truncated)
+		}
 
 		// Apply header styling
 		cells = append(cells, t.styles.Header.Render(renderedCell))
@@ -250,13 +341,14 @@ func (t *Table) renderRow(row Row) string {
 			MaxWidth(col.Width).
 			Inline(true)
 
-		// For already-styled content (like gray sensitive values), we can't easily truncate
-		// because runewidth.Truncate doesn't handle ANSI codes well.
-		// So we only truncate plain text values.
-		// We can detect styled content by checking if it contains ANSI escape sequences.
+		// Determine whether to truncate this cell
 		var renderedCell string
-		if strings.Contains(value, "\x1b[") {
+		if col.NoTruncate {
+			// Don't truncate protected columns
+			renderedCell = cellStyle.Render(value)
+		} else if strings.Contains(value, "\x1b[") {
 			// Already styled - let lipgloss handle width constraints
+			// (runewidth.Truncate doesn't handle ANSI codes well)
 			renderedCell = cellStyle.Render(value)
 		} else {
 			// Plain text - truncate with ellipsis

--- a/pkg/ui/table_test.go
+++ b/pkg/ui/table_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -115,6 +116,16 @@ func TestAutoSizeColumns(t *testing.T) {
 		}
 	})
 
+	t.Run("NoTruncate columns ignore MaxWidth", func(t *testing.T) {
+		// If both NoTruncate and MaxWidth are set, NoTruncate takes precedence
+		cols := AutoSizeColumns(headers, rows, Columns().NoTruncate(1).MaxWidth(1, 5))
+
+		// "another-app" is 11 chars; NoTruncate should preserve full width
+		if cols[1].Width < 11 {
+			t.Errorf("expected NoTruncate column to ignore MaxWidth, got width %d", cols[1].Width)
+		}
+	})
+
 	t.Run("empty headers returns nil", func(t *testing.T) {
 		cols := AutoSizeColumns([]string{}, rows, nil)
 		if cols != nil {
@@ -177,18 +188,6 @@ func TestTableRender(t *testing.T) {
 	})
 }
 
-// containsText checks if a string contains text, ignoring ANSI escape codes
 func containsText(s, text string) bool {
-	// Simple check - in real output the text might be wrapped in ANSI codes
-	// but the raw text should still be present
-	return len(s) > 0 && len(text) > 0 && findInString(s, text)
-}
-
-func findInString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
+	return text != "" && strings.Contains(s, text)
 }

--- a/pkg/ui/table_test.go
+++ b/pkg/ui/table_test.go
@@ -1,0 +1,194 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestColumnBuilder(t *testing.T) {
+	t.Run("nil builder returns empty hints", func(t *testing.T) {
+		var b *ColumnBuilder
+		hint := b.getHint(0)
+		if hint.NoTruncate {
+			t.Error("expected NoTruncate to be false for nil builder")
+		}
+		if hint.MaxWidth != 0 {
+			t.Error("expected MaxWidth to be 0 for nil builder")
+		}
+	})
+
+	t.Run("NoTruncate sets flag for specified indices", func(t *testing.T) {
+		b := Columns().NoTruncate(0, 2)
+
+		if !b.getHint(0).NoTruncate {
+			t.Error("expected column 0 to have NoTruncate=true")
+		}
+		if b.getHint(1).NoTruncate {
+			t.Error("expected column 1 to have NoTruncate=false")
+		}
+		if !b.getHint(2).NoTruncate {
+			t.Error("expected column 2 to have NoTruncate=true")
+		}
+	})
+
+	t.Run("MaxWidth sets width for specified index", func(t *testing.T) {
+		b := Columns().MaxWidth(1, 30)
+
+		if b.getHint(0).MaxWidth != 0 {
+			t.Error("expected column 0 to have no MaxWidth")
+		}
+		if b.getHint(1).MaxWidth != 30 {
+			t.Errorf("expected column 1 MaxWidth=30, got %d", b.getHint(1).MaxWidth)
+		}
+	})
+
+	t.Run("MinWidth sets width for specified index", func(t *testing.T) {
+		b := Columns().MinWidth(0, 20)
+
+		if b.getHint(0).MinWidth != 20 {
+			t.Errorf("expected column 0 MinWidth=20, got %d", b.getHint(0).MinWidth)
+		}
+	})
+
+	t.Run("chained calls accumulate hints", func(t *testing.T) {
+		b := Columns().
+			NoTruncate(0).
+			MaxWidth(0, 50).
+			MinWidth(1, 15)
+
+		hint0 := b.getHint(0)
+		if !hint0.NoTruncate {
+			t.Error("expected column 0 NoTruncate=true")
+		}
+		if hint0.MaxWidth != 50 {
+			t.Errorf("expected column 0 MaxWidth=50, got %d", hint0.MaxWidth)
+		}
+
+		hint1 := b.getHint(1)
+		if hint1.MinWidth != 15 {
+			t.Errorf("expected column 1 MinWidth=15, got %d", hint1.MinWidth)
+		}
+	})
+}
+
+func TestAutoSizeColumns(t *testing.T) {
+	headers := []string{"ID", "NAME", "STATUS"}
+	rows := []Row{
+		{"abc123", "my-app", "running"},
+		{"def456", "another-app", "stopped"},
+	}
+
+	t.Run("nil builder uses default behavior", func(t *testing.T) {
+		cols := AutoSizeColumns(headers, rows, nil)
+
+		if len(cols) != 3 {
+			t.Fatalf("expected 3 columns, got %d", len(cols))
+		}
+
+		// All columns should allow truncation
+		for i, col := range cols {
+			if col.NoTruncate {
+				t.Errorf("expected column %d to allow truncation", i)
+			}
+		}
+	})
+
+	t.Run("NoTruncate flag is propagated to columns", func(t *testing.T) {
+		cols := AutoSizeColumns(headers, rows, Columns().NoTruncate(0))
+
+		if !cols[0].NoTruncate {
+			t.Error("expected column 0 to have NoTruncate=true")
+		}
+		if cols[1].NoTruncate {
+			t.Error("expected column 1 to have NoTruncate=false")
+		}
+		if cols[2].NoTruncate {
+			t.Error("expected column 2 to have NoTruncate=false")
+		}
+	})
+
+	t.Run("MaxWidth limits column width", func(t *testing.T) {
+		cols := AutoSizeColumns(headers, rows, Columns().MaxWidth(1, 5))
+
+		// "another-app" is 11 chars, but should be limited to 5
+		if cols[1].Width > 5 {
+			t.Errorf("expected column 1 width <= 5, got %d", cols[1].Width)
+		}
+	})
+
+	t.Run("empty headers returns nil", func(t *testing.T) {
+		cols := AutoSizeColumns([]string{}, rows, nil)
+		if cols != nil {
+			t.Error("expected nil for empty headers")
+		}
+	})
+
+	t.Run("width calculated from content", func(t *testing.T) {
+		cols := AutoSizeColumns(headers, rows, nil)
+
+		// "another-app" is the widest value in column 1 (11 chars)
+		if cols[1].Width < 11 {
+			t.Errorf("expected column 1 width >= 11 (for 'another-app'), got %d", cols[1].Width)
+		}
+	})
+}
+
+func TestTableRender(t *testing.T) {
+	t.Run("empty table returns empty string", func(t *testing.T) {
+		table := NewTable()
+		if table.Render() != "" {
+			t.Error("expected empty string for empty table")
+		}
+	})
+
+	t.Run("table with columns but no rows returns empty string", func(t *testing.T) {
+		table := NewTable(
+			WithColumns([]Column{{Title: "ID", Width: 10}}),
+		)
+		if table.Render() != "" {
+			t.Error("expected empty string for table with no rows")
+		}
+	})
+
+	t.Run("basic table renders", func(t *testing.T) {
+		headers := []string{"ID", "NAME"}
+		rows := []Row{{"1", "foo"}}
+		cols := AutoSizeColumns(headers, rows, nil)
+
+		table := NewTable(
+			WithColumns(cols),
+			WithRows(rows),
+		)
+
+		output := table.Render()
+		if output == "" {
+			t.Error("expected non-empty output")
+		}
+
+		// Should contain header and data
+		if !containsText(output, "ID") {
+			t.Error("expected output to contain 'ID'")
+		}
+		if !containsText(output, "NAME") {
+			t.Error("expected output to contain 'NAME'")
+		}
+		if !containsText(output, "foo") {
+			t.Error("expected output to contain 'foo'")
+		}
+	})
+}
+
+// containsText checks if a string contains text, ignoring ANSI escape codes
+func containsText(s, text string) bool {
+	// Simple check - in real output the text might be wrapped in ANSI codes
+	// but the raw text should still be present
+	return len(s) > 0 && len(text) > 0 && findInString(s, text)
+}
+
+func findInString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds a `ColumnBuilder` API to configure table columns with a fluent interface
- New `NoTruncate()` option prevents specific columns from being truncated when table width exceeds terminal width
- Protected columns maintain full width while other columns absorb size reductions proportionally
- Applied to ID column in `sandbox list`, `sandbox pool list`, and HOST column in `route list`

Fixes MIR-523

## Usage
```go
// Don't truncate the first column (ID)
columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0))

// Multiple options
columns := ui.AutoSizeColumns(headers, rows, 
    ui.Columns().
        NoTruncate(0).
        MaxWidth(1, 40))

// Default behavior
columns := ui.AutoSizeColumns(headers, rows, nil)
```

## Test plan
- [x] Added unit tests for `ColumnBuilder` and `AutoSizeColumns`
- [x] `make lint` passes
- [x] `go test ./pkg/ui/...` passes
- [x] `go test ./cli/commands/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flexible per-column configuration for tables (max/min widths, no-truncate flags)
  * Terminal-aware column sizing that preserves protected columns and fits available width

* **Improvements**
  * Better handling of truncation and ANSI-styled content for clearer table output
  * More robust width calculation and rendering for headers and rows

* **Tests**
  * Comprehensive table rendering and sizing test suite added

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->