### PR TITLE
Add prerequisite checks to server install with helpful guidance

### DIFF
--- a/cli/commands/commands_other.go
+++ b/cli/commands/commands_other.go
@@ -9,6 +9,19 @@ import (
 	"miren.dev/runtime/pkg/asm"
 )
 
-func addCommands(cmds map[string]cli.CommandFactory) {}
+func addCommands(cmds map[string]cli.CommandFactory) {
+	// Server management commands - provide helpful errors directing to Docker
+	cmds["server install"] = func() (cli.Command, error) {
+		return Infer("server install", "Install miren server (Linux only)", ServerInstall), nil
+	}
+
+	cmds["server uninstall"] = func() (cli.Command, error) {
+		return Infer("server uninstall", "Uninstall miren server (Linux only)", ServerUninstall), nil
+	}
+
+	cmds["server status"] = func() (cli.Command, error) {
+		return Infer("server status", "Show miren service status (Linux only)", ServerStatus), nil
+	}
+}
 
 func (c *Context) setupServerComponents(_ context.Context, _ *asm.Registry) {}

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -16,6 +16,74 @@ import (
 	"miren.dev/runtime/pkg/registration"
 )
 
+// installPrerequisites holds information about the system's readiness for installation
+type installPrerequisites struct {
+	hasRoot    bool
+	hasSystemd bool
+	hasDocker  bool
+}
+
+// checkInstallPrerequisites checks all prerequisites and returns their status
+func checkInstallPrerequisites() installPrerequisites {
+	return installPrerequisites{
+		hasRoot:    os.Geteuid() == 0,
+		hasSystemd: checkSystemdAvailable(),
+		hasDocker:  checkDockerAvailable() == nil,
+	}
+}
+
+// checkSystemdAvailable checks if systemd is available on the system
+func checkSystemdAvailable() bool {
+	// Check if systemctl exists and is functional
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return false
+	}
+
+	// Verify systemd is actually running by checking if we can communicate with it
+	cmd := exec.Command("systemctl", "--version")
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// printInstallPrerequisiteGuidance prints helpful guidance based on what's available
+func printInstallPrerequisiteGuidance(ctx *Context, prereqs installPrerequisites) {
+	fmt.Println()
+	ctx.Warn("Cannot proceed with systemd installation.")
+	fmt.Println()
+
+	if !prereqs.hasRoot {
+		ctx.Info("Root privileges are required for systemd installation.")
+		fmt.Println("  Run with sudo: sudo miren server install")
+		fmt.Println()
+	}
+
+	if !prereqs.hasSystemd {
+		ctx.Info("systemd is not available on this system.")
+		fmt.Println()
+
+		if prereqs.hasDocker {
+			ctx.Info("Docker is available! You can install using Docker instead:")
+			fmt.Println("  miren server docker install")
+			fmt.Println()
+			ctx.Info("This will run the miren server in a Docker container with automatic restarts.")
+		} else {
+			ctx.Info("Alternative installation options:")
+			fmt.Println()
+			fmt.Println("  1. Install using Docker (recommended for non-systemd systems):")
+			fmt.Println("     First install Docker: https://docs.docker.com/get-docker/")
+			fmt.Println("     Then run: miren server docker install")
+			fmt.Println()
+			fmt.Println("  2. Run the server directly (for testing or development):")
+			fmt.Println("     miren server")
+			fmt.Println()
+			fmt.Println("  3. Use your system's init system to manage the miren server process")
+		}
+	}
+}
+
 // fixSELinuxContext sets the proper SELinux context on the miren binary
 // so systemd can execute it. This is needed on systems like RHEL/Oracle Linux
 // where SELinux is enforcing and /var/lib files get var_lib_t context by default.
@@ -89,10 +157,18 @@ func ServerInstall(ctx *Context, opts struct {
 	CloudURL     string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
 	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
 }) error {
-	// Check if running with sufficient privileges
-	if os.Geteuid() != 0 {
-		return fmt.Errorf("server install requires root privileges (use sudo)")
+	// Check all prerequisites upfront
+	prereqs := checkInstallPrerequisites()
+
+	if !prereqs.hasRoot || !prereqs.hasSystemd {
+		printInstallPrerequisiteGuidance(ctx, prereqs)
+		if !prereqs.hasRoot {
+			return fmt.Errorf("root privileges required")
+		}
+		return fmt.Errorf("systemd not available")
 	}
+
+	ctx.Completed("Prerequisites verified (root, systemd)")
 
 	// Check if miren binary exists, download if not
 	mirenPath := "/var/lib/miren/release/miren"

--- a/cli/commands/server_install_other.go
+++ b/cli/commands/server_install_other.go
@@ -1,0 +1,54 @@
+//go:build !linux
+
+package commands
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// ServerInstall is not supported on non-Linux platforms
+func ServerInstall(ctx *Context, opts struct {
+	Address      string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
+	Verbosity    string            `short:"v" long:"verbosity" description:"Verbosity level" default:"-vv"`
+	Branch       string            `short:"b" long:"branch" description:"Branch to download if release not found" default:"main"`
+	Force        bool              `short:"f" long:"force" description:"Overwrite existing service file"`
+	NoStart      bool              `long:"no-start" description:"Do not start the service after installation"`
+	WithoutCloud bool              `long:"without-cloud" description:"Skip cloud registration setup"`
+	ClusterName  string            `short:"n" long:"name" description:"Cluster name for cloud registration"`
+	CloudURL     string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
+	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
+}) error {
+	fmt.Println()
+	ctx.Warn("The 'server install' command is only available on Linux.")
+	fmt.Println()
+
+	if runtime.GOOS == "darwin" {
+		ctx.Info("On macOS, use Docker to run the miren server:")
+		fmt.Println("  miren server docker install")
+		fmt.Println()
+		ctx.Info("This will run the miren server in a Docker container with automatic restarts.")
+	} else {
+		ctx.Info("Use Docker to run the miren server on this platform:")
+		fmt.Println("  miren server docker install")
+	}
+
+	fmt.Println()
+	return fmt.Errorf("server install requires Linux")
+}
+
+// ServerUninstall is not supported on non-Linux platforms
+func ServerUninstall(ctx *Context, opts struct {
+	RemoveData bool   `long:"remove-data" description:"Remove /var/lib/miren directory after backing it up"`
+	BackupDir  string `long:"backup-dir" description:"Directory to save backup tarball" default:"."`
+	SkipBackup bool   `long:"skip-backup" description:"Skip backup when removing data (dangerous)"`
+}) error {
+	return fmt.Errorf("server uninstall is only available on Linux; use 'miren server docker uninstall' instead")
+}
+
+// ServerStatus is not supported on non-Linux platforms
+func ServerStatus(ctx *Context, opts struct {
+	Follow bool `short:"f" long:"follow" description:"Follow logs in real-time"`
+}) error {
+	return fmt.Errorf("server status is only available on Linux; use 'miren server docker status' instead")
+}


### PR DESCRIPTION
## Summary

- Add upfront prerequisite checks to `miren server install` for root privileges and systemd availability
- When prerequisites aren't met, provide contextual guidance pointing users to alternatives
- Add non-Linux stubs that direct macOS users to `miren server docker install`

### On Linux without systemd (but with Docker):
```
⚠ Cannot proceed with systemd installation.

ℹ systemd is not available on this system.

ℹ Docker is available! You can install using Docker instead:
  miren server docker install

ℹ This will run the miren server in a Docker container with automatic restarts.
```

### On macOS:
```
⚠ The 'server install' command is only available on Linux.

ℹ On macOS, use Docker to run the miren server:
  miren server docker install

ℹ This will run the miren server in a Docker container with automatic restarts.
```

## Test plan

- [ ] Test `miren server install` on Linux with systemd (should work as before)
- [ ] Test `miren server install` on Linux without systemd but with Docker (should show Docker guidance)
- [ ] Test `miren server install` on Linux without root (should show sudo guidance)
- [ ] Test `miren server install` on macOS (should show Docker guidance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `server install`, `server uninstall`, and `server status` commands for managing server lifecycle.
  * Implemented prerequisite validation on Linux systems to verify root access, systemd availability, and Docker presence before installation.
  * Added platform-specific messaging for non-Linux systems indicating server management features are Linux-only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->