### PR TITLE
Show access URLs after deploy with route suggestions

### DIFF
--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -122,6 +122,74 @@ func (v *Status) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type accessInfoData struct {
+	Hostnames       *[]string `cbor:"0,keyasint,omitempty" json:"hostnames,omitempty"`
+	DefaultRoute    *bool     `cbor:"1,keyasint,omitempty" json:"default_route,omitempty"`
+	ClusterHostname *string   `cbor:"2,keyasint,omitempty" json:"cluster_hostname,omitempty"`
+}
+
+type AccessInfo struct {
+	data accessInfoData
+}
+
+func (v *AccessInfo) HasHostnames() bool {
+	return v.data.Hostnames != nil
+}
+
+func (v *AccessInfo) Hostnames() *[]string {
+	return v.data.Hostnames
+}
+
+func (v *AccessInfo) SetHostnames(hostnames *[]string) {
+	v.data.Hostnames = hostnames
+}
+
+func (v *AccessInfo) HasDefaultRoute() bool {
+	return v.data.DefaultRoute != nil
+}
+
+func (v *AccessInfo) DefaultRoute() bool {
+	if v.data.DefaultRoute == nil {
+		return false
+	}
+	return *v.data.DefaultRoute
+}
+
+func (v *AccessInfo) SetDefaultRoute(default_route bool) {
+	v.data.DefaultRoute = &default_route
+}
+
+func (v *AccessInfo) HasClusterHostname() bool {
+	return v.data.ClusterHostname != nil
+}
+
+func (v *AccessInfo) ClusterHostname() string {
+	if v.data.ClusterHostname == nil {
+		return ""
+	}
+	return *v.data.ClusterHostname
+}
+
+func (v *AccessInfo) SetClusterHostname(cluster_hostname string) {
+	v.data.ClusterHostname = &cluster_hostname
+}
+
+func (v *AccessInfo) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *AccessInfo) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *AccessInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *AccessInfo) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type streamRecvArgsData struct {
 	Count *int32 `cbor:"0,keyasint,omitempty" json:"count,omitempty"`
 }
@@ -348,7 +416,8 @@ func (v *BuilderBuildFromTarArgs) UnmarshalJSON(data []byte) error {
 }
 
 type builderBuildFromTarResultsData struct {
-	Version *string `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
+	Version    *string      `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
+	AccessInfo **AccessInfo `cbor:"1,keyasint,omitempty" json:"access_info,omitempty"`
 }
 
 type BuilderBuildFromTarResults struct {
@@ -358,6 +427,10 @@ type BuilderBuildFromTarResults struct {
 
 func (v *BuilderBuildFromTarResults) SetVersion(version string) {
 	v.data.Version = &version
+}
+
+func (v *BuilderBuildFromTarResults) SetAccessInfo(access_info **AccessInfo) {
+	v.data.AccessInfo = access_info
 }
 
 func (v *BuilderBuildFromTarResults) MarshalCBOR() ([]byte, error) {
@@ -459,6 +532,14 @@ func (v *BuilderClientBuildFromTarResults) Version() string {
 		return ""
 	}
 	return *v.data.Version
+}
+
+func (v *BuilderClientBuildFromTarResults) HasAccessInfo() bool {
+	return v.data.AccessInfo != nil
+}
+
+func (v *BuilderClientBuildFromTarResults) AccessInfo() *AccessInfo {
+	return *v.data.AccessInfo
 }
 
 func (v BuilderClient) BuildFromTar(ctx context.Context, application string, tardata stream.RecvStream[[]byte], status stream.SendStream[*Status]) (*BuilderClientBuildFromTarResults, error) {

--- a/api/build/rpc.yml
+++ b/api/build/rpc.yml
@@ -25,6 +25,22 @@ types:
             type: string
             index: 3
 
+  - type: AccessInfo
+    doc: Information about how to access the deployed application
+    fields:
+      - name: hostnames
+        type: '[]string'
+        index: 0
+        doc: Hostnames where the app is accessible (from configured routes)
+      - name: default_route
+        type: bool
+        index: 1
+        doc: Whether this app is the default route
+      - name: cluster_hostname
+        type: string
+        index: 2
+        doc: Cloud-provisioned DNS hostname for the cluster (if registered with Miren Cloud)
+
 interfaces:
   - name: Stream
     methods:
@@ -49,4 +65,7 @@ interfaces:
         results:
           - name: version
             type: string
+          - name: access_info
+            type: '*AccessInfo'
+            doc: Information about how to access the deployed app
 

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -508,6 +508,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		cloudAuthConfig.PrivateKey = reg.PrivateKey // Use the actual private key content from registration
 		cloudAuthConfig.Tags = reg.Tags
 		cloudAuthConfig.ClusterID = reg.ClusterID
+		cloudAuthConfig.DNSHostname = reg.DNSHostname
 	} else if reg != nil && reg.Status == "pending" {
 		ctx.Log.Info("found pending cluster registration",
 			"cluster-name", reg.ClusterName,

--- a/cli/commands/server_register.go
+++ b/cli/commands/server_register.go
@@ -77,6 +77,7 @@ func Register(ctx *Context, opts RegisterOptions) error {
 			existing.ClusterID = status.ClusterID
 			existing.OrganizationID = status.OrganizationID
 			existing.ServiceAccountID = status.ServiceAccountID
+			existing.DNSHostname = status.DNSHostname
 			existing.RegisteredAt = time.Now()
 
 			if err := registration.SaveRegistration(opts.OutputDir, existing); err != nil {
@@ -87,6 +88,9 @@ func Register(ctx *Context, opts RegisterOptions) error {
 			ctx.Info("Cluster ID: %s", status.ClusterID)
 			ctx.Info("Organization ID: %s", status.OrganizationID)
 			ctx.Info("Service Account ID: %s", status.ServiceAccountID)
+			if status.DNSHostname != "" {
+				ctx.Info("DNS Hostname: %s", status.DNSHostname)
+			}
 			ctx.Info("Configuration saved to: %s", opts.OutputDir)
 
 			return nil
@@ -176,6 +180,7 @@ func Register(ctx *Context, opts RegisterOptions) error {
 		ClusterName:      opts.ClusterName,
 		OrganizationID:   status.OrganizationID,
 		ServiceAccountID: status.ServiceAccountID,
+		DNSHostname:      status.DNSHostname,
 		PrivateKey:       privateKey,
 		CloudURL:         opts.CloudURL,
 		RegisteredAt:     time.Now(),
@@ -191,6 +196,9 @@ func Register(ctx *Context, opts RegisterOptions) error {
 	ctx.Info("Cluster ID: %s", status.ClusterID)
 	ctx.Info("Organization ID: %s", status.OrganizationID)
 	ctx.Info("Service Account ID: %s", status.ServiceAccountID)
+	if status.DNSHostname != "" {
+		ctx.Info("DNS Hostname: %s", status.DNSHostname)
+	}
 	ctx.Info("Configuration saved to: %s", opts.OutputDir)
 
 	ctx.Warn("If you're already running the miren server, you must now restart it to apply the new registration.")

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -78,11 +78,12 @@ type CoordinatorConfig struct {
 
 // CloudAuthConfig contains cloud authentication settings
 type CloudAuthConfig struct {
-	Enabled    bool              `json:"enabled" yaml:"enabled"`
-	CloudURL   string            `json:"cloud_url" yaml:"cloud_url"`     // URL of miren.cloud (default: https://api.miren.cloud)
-	PrivateKey string            `json:"private_key" yaml:"private_key"` // Required: Path to service account private key when enabled
-	Tags       map[string]string `json:"tags" yaml:"tags"`               // Tags from registration for RBAC evaluation
-	ClusterID  string            `json:"cluster_id" yaml:"cluster_id"`   // Cluster ID for status reporting
+	Enabled     bool              `json:"enabled" yaml:"enabled"`
+	CloudURL    string            `json:"cloud_url" yaml:"cloud_url"`       // URL of miren.cloud (default: https://api.miren.cloud)
+	PrivateKey  string            `json:"private_key" yaml:"private_key"`   // Required: Path to service account private key when enabled
+	Tags        map[string]string `json:"tags" yaml:"tags"`                 // Tags from registration for RBAC evaluation
+	ClusterID   string            `json:"cluster_id" yaml:"cluster_id"`     // Cluster ID for status reporting
+	DNSHostname string            `json:"dns_hostname" yaml:"dns_hostname"` // Cloud-provisioned DNS hostname for the cluster
 }
 
 const (
@@ -594,7 +595,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	// Create app client for the builder
 	appClient := appclient.NewClient(c.Log, loopback)
 
-	bs := build.NewBuilder(c.Log, eac, appClient, c.Resolver, c.TempDir, c.LogWriter)
+	bs := build.NewBuilder(c.Log, eac, appClient, c.Resolver, c.TempDir, c.LogWriter, c.CloudAuth.DNSHostname)
 	server.ExposeValue("dev.miren.runtime/build", build_v1alpha.AdaptBuilder(bs))
 
 	ai := app.NewAppInfo(c.Log, ec, c.Cpu, c.Mem, c.HTTP)

--- a/pkg/registration/registration.go
+++ b/pkg/registration/registration.go
@@ -73,6 +73,7 @@ type Status struct {
 	ClusterID        string `json:"cluster_id,omitempty"`
 	OrganizationID   string `json:"organization_id,omitempty"`
 	ServiceAccountID string `json:"service_account_id,omitempty"`
+	DNSHostname      string `json:"dns_hostname,omitempty"`
 }
 
 // StoredRegistration contains the registration data stored on disk
@@ -81,7 +82,8 @@ type StoredRegistration struct {
 	ClusterName      string            `json:"cluster_name"`
 	OrganizationID   string            `json:"organization_id"`
 	ServiceAccountID string            `json:"service_account_id"`
-	PrivateKey       string            `json:"private_key"` // PEM encoded private key
+	DNSHostname      string            `json:"dns_hostname,omitempty"` // Auto-provisioned DNS hostname from cloud
+	PrivateKey       string            `json:"private_key"`            // PEM encoded private key
 	CloudURL         string            `json:"cloud_url"`
 	RegisteredAt     time.Time         `json:"registered_at"`
 	Tags             map[string]string `json:"tags,omitempty"`


### PR DESCRIPTION
## Summary

After deploying an app, show users how to access it based on configured routes. This makes the deploy experience much more helpful by:

- Showing the URL(s) where the app is accessible
- For default routes, showing the cluster's hostname
- When no routes exist, suggesting a specific route command (using cloud DNS wildcard when available)
 
Fixes MIR-225

## Example Output

**App with configured hostname route:**
```
Updated version v3 deployed. All traffic moved to new version.

Your app is available at:
  https://api.example.com
  (also the default route)
```

**App as default route on cloud-connected cluster:**
```
Updated version v1 deployed. All traffic moved to new version.

Your app is the default route, available at:
  https://cluster-abc.org-123.miren.systems
To set a hostname, try: miren route set my-api.cluster-abc.org-123.miren.systems my-api
```

**App with no routes on cloud-connected cluster:**
```
Updated version v1 deployed. All traffic moved to new version.

No routes configured for this app.
To set a hostname, try: miren route set my-api.cluster-abc.org-123.miren.systems my-api
To make it the default route: miren route set-default my-api
```

**App with no routes (no cloud DNS):**
```
Updated version v1 deployed. All traffic moved to new version.

No routes configured for this app.
To set a hostname, try: miren route set <hostname> my-api
To make it the default route: miren route set-default my-api
```

## Implementation

- Extended build RPC to return `AccessInfo` (hostnames, default_route status, cluster_hostname)
- Server queries routes after deploy and returns access info to client
- Registration now captures and stores the cloud-provisioned DNS hostname
- Client displays access URLs, preferring cloud DNS hostname for default routes
- Suggests specific subdomain routes using the wildcard DNS (e.g., `my-app.cluster-abc.org-123.miren.systems`)

## Test plan

- [ ] Deploy app with existing hostname route - shows URL
- [ ] Deploy first app (becomes default route) - shows cluster URL
- [ ] Deploy app with no routes - shows suggested route command
- [ ] On cloud-connected cluster - suggested route uses wildcard subdomain
- [ ] App name sanitization works (underscores → hyphens, lowercase, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment now displays access information, including hostnames where the app is accessible and default route status.
  * Cloud-provisioned DNS hostnames from cluster registration are now properly tracked and integrated.
  * Deploy command automatically suggests route configuration when applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->