### PR TITLE
Improve CLI output for app history and whoami

### DIFF
--- a/cli/commands/app_history.go
+++ b/cli/commands/app_history.go
@@ -145,17 +145,16 @@ func AppHistory(ctx *Context, opts struct {
 			version = version[:22] + "..."
 		}
 
-		// Format user (prefer email, fallback to username, then user ID)
-		user := dep.DeployedByUserEmail()
-		// Replace placeholder emails with username or user ID as fallback
-		if user == "" || user == "unknown@example.com" || user == "user@example.com" {
-			if dep.HasDeployedByUserName() && dep.DeployedByUserName() != "" {
-				user = dep.DeployedByUserName()
-			} else if dep.DeployedByUserId() != "" {
-				user = dep.DeployedByUserId()
-			} else {
-				user = "-"
-			}
+		// Format user (prefer name, fallback to email, then user ID)
+		user := ""
+		if dep.HasDeployedByUserName() && dep.DeployedByUserName() != "" {
+			user = dep.DeployedByUserName()
+		} else if dep.DeployedByUserEmail() != "" && dep.DeployedByUserEmail() != "unknown@example.com" && dep.DeployedByUserEmail() != "user@example.com" {
+			user = dep.DeployedByUserEmail()
+		} else if dep.DeployedByUserId() != "" {
+			user = dep.DeployedByUserId()
+		} else {
+			user = "-"
 		}
 		if len(user) > 20 {
 			user = user[:17] + "..."

--- a/cli/commands/whoami.go
+++ b/cli/commands/whoami.go
@@ -81,14 +81,15 @@ func Whoami(ctx *Context, opts struct {
 
 	// Prepare output
 	type WhoamiOutput struct {
-		Cluster    string   `json:"cluster"`
-		ServerURL  string   `json:"server_url"`
-		AuthMethod string   `json:"auth_method"`
-		Identity   string   `json:"identity,omitempty"`
-		UserID     string   `json:"user_id,omitempty"`
-		UserEmail  string   `json:"user_email,omitempty"`
-		Groups     []string `json:"groups,omitempty"`
-		GroupIDs   []string `json:"group_ids,omitempty"`
+		Cluster        string   `json:"cluster"`
+		ServerURL      string   `json:"server_url"`
+		AuthMethod     string   `json:"auth_method"`
+		Identity       string   `json:"identity,omitempty"`
+		UserID         string   `json:"user_id,omitempty"`
+		UserEmail      string   `json:"user_email,omitempty"`
+		OrganizationID string   `json:"organization_id,omitempty"`
+		Groups         []string `json:"groups,omitempty"`
+		GroupIDs       []string `json:"group_ids,omitempty"`
 	}
 
 	output := WhoamiOutput{
@@ -105,6 +106,7 @@ func Whoami(ctx *Context, opts struct {
 	if claims != nil {
 		output.UserEmail = claims.Subject
 		output.UserID = claims.UserID
+		output.OrganizationID = claims.OrganizationID
 		output.Groups = claims.Groups
 		output.GroupIDs = claims.GroupIDs
 	}
@@ -129,6 +131,9 @@ func Whoami(ctx *Context, opts struct {
 		ctx.Info("")
 		ctx.Info("User:          %s", claims.Subject)
 		ctx.Info("User ID:       %s", claims.UserID)
+		if claims.OrganizationID != "" {
+			ctx.Info("Organization:  %s", claims.OrganizationID)
+		}
 		if len(claims.Groups) > 0 {
 			ctx.Info("Groups:        %v", claims.Groups)
 		}

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/google/uuid"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	deployment_v1alpha "miren.dev/runtime/api/deployment/deployment_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -138,9 +137,9 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 	}
 
 	// Get user info from context (will be implemented with auth integration)
-	// For now, use placeholder values
-	userId := "user-" + uuid.New().String()
-	userName := "testuser"
+	// For now, leave empty - the CLI display will show "-" for unknown users
+	userId := ""
+	userName := ""
 	userEmail := ""
 
 	// Create deployment entity


### PR DESCRIPTION
- Display "-" instead of placeholder values for unknown deployed-by users
- Prefer user name over email in app history display
- Add organization ID to whoami output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization ID is now included in the whoami command output when available.

* **Bug Fixes**
  * Improved user information display in application history with enhanced fallback logic for missing deployer details.
  * Updated deployment tracking to properly display unknown users as "-" in the CLI when creator information is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->