### PR TITLE
Fix server upgrade health check failures on Oracle Linux

### DIFF
--- a/pkg/release/manager.go
+++ b/pkg/release/manager.go
@@ -52,10 +52,8 @@ func NewManager(opts ManagerOptions) *Manager {
 		BackupSuffix: ".old",
 	}
 
-	healthOpts := HealthCheckOptions{
-		ServiceName: opts.ServiceName,
-		// Health endpoint can be configured later
-	}
+	healthOpts := DefaultHealthCheckOptions()
+	healthOpts.ServiceName = opts.ServiceName
 
 	return &Manager{
 		downloader: NewDownloader(),


### PR DESCRIPTION
## Summary

- Fix misleading "service not found" error during `server upgrade` health checks
- Add retry logic to systemd status checks to handle service startup timing
- Use `DefaultHealthCheckOptions()` to ensure retries are properly configured

## Problem

`miren server upgrade` was failing on Oracle Linux with the error:
```
health check failed, successfully rolled back: systemd service check failed: service miren not found
```

This was misleading because the service definitely existed and was running.

## Root Causes

1. **Incorrect service existence check**: The code used `systemctl status miren` to check if a service exists, but `systemctl status` returns non-zero when the service is stopped/starting—not just when it doesn't exist. After `systemctl restart`, the service is briefly in a non-active state, causing the false "not found" error.

2. **Missing retry configuration**: `NewManager()` created a `HealthCheckOptions` struct but only set `ServiceName`, leaving `MaxRetries` and `RetryDelay` at zero. This meant the retry loop never executed, causing immediate failure when the service wasn't instantly active after restart.

## Fixes

- Use `systemctl list-unit-files` to check service existence (returns success regardless of service state)
- Check existence once upfront, then retry `is-active` in a loop
- Use `DefaultHealthCheckOptions()` which provides sensible defaults (30 retries, 2s delay)

## Test plan

- [x] Tested on Oracle Linux instance where the bug originally occurred—upgrade now succeeds
- [x] Tested on Ubuntu instance—upgrade still works (was working before, still works after)
- [x] Unit tests pass
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved system service health checking with retry logic and deadline enforcement for enhanced reliability.
  * Enhanced error messages with contextual details about service status and failures.

* **Refactor**
  * Streamlined health check configuration defaults for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->