### PR TITLE
Improve README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Miren Runtime
 
-[![Test](https://github.com/mirendev/runtime/workflows/Test/badge.svg)](https://github.com/mirendev/runtime/actions/workflows/test.yml)
+[![Test](https://github.com/mirendev/runtime/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/mirendev/runtime/actions/workflows/test.yml?query=branch%3Amain)
+[![Release](https://img.shields.io/github/v/tag/mirendev/runtime?sort=semver)](https://github.com/mirendev/runtime/releases/latest)
+[![License](https://img.shields.io/github/license/mirendev/runtime)](LICENSE)
 
 A container orchestration system built on containerd for running secure, isolated applications with etcd-backed state management.
 


### PR DESCRIPTION
## Summary
- Fix test badge to show main branch status only (was showing all workflow runs)
- Add release badge with semver sorting
- Add license badge

## Notes
The Release and License badges use shields.io which requires public repo access. They'll show "not found" until we flip the repo public.

Here's what they'll look like (using ghostty-org/ghostty as an example):

[![Release](https://img.shields.io/github/v/tag/ghostty-org/ghostty?sort=semver)](https://github.com/ghostty-org/ghostty/releases/latest) [![License](https://img.shields.io/github/license/ghostty-org/ghostty)](https://github.com/ghostty-org/ghostty/blob/main/LICENSE)

## Test plan
- [ ] Verify test badge shows main branch status after merge
- [ ] Confirm shields.io badges work once repo is public

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test badge URL with main branch parameter.
  * Added Release and License badges to documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->