### PR TITLE
deploy: Cleanup the workflow when running deploy with no config

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -55,7 +55,7 @@ func Deploy(ctx *Context, opts struct {
 			ui.WithIndent("  "),
 		)
 		if err != nil || !confirmed {
-			return fmt.Errorf("no clusters configured; run 'miren login' to authenticate and configure a cluster, or install a server locally")
+			return fmt.Errorf("no clusters configured; run 'miren login' to authenticate and 'miren cluster add' to configure a cluster, or install a server locally")
 		}
 
 		if err := AddClusterInteractive(ctx); err != nil {

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -18,6 +18,7 @@ import (
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/deployment/deployment_v1alpha"
 	"miren.dev/runtime/appconfig"
+	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/deploygating"
 	"miren.dev/runtime/pkg/git"
 	"miren.dev/runtime/pkg/progress/upload"
@@ -37,8 +38,58 @@ func Deploy(ctx *Context, opts struct {
 	name := opts.App
 	dir := opts.Dir
 
-	// Confirm deployment unless --force is used, stdin is not a TTY, or only one cluster is configured
+	if ctx.ClientConfig == nil {
+		return fmt.Errorf("no client configuration available; run `miren login` to authenticate or install a server locally")
+	}
+
 	isInteractive := term.IsTerminal(int(os.Stdin.Fd()))
+
+	// Check that we have at least one cluster configured
+	// Check if we have an identity - if so, offer to add a cluster
+	if isInteractive &&
+		ctx.ClientConfig.GetClusterCount() == 0 &&
+		ctx.ClientConfig.HasIdentities() {
+		confirmed, err := ui.Confirm(
+			ui.WithMessage("No clusters configured. Would you like to add one now?"),
+			ui.WithDefault(true),
+			ui.WithIndent("  "),
+		)
+		if err != nil || !confirmed {
+			return fmt.Errorf("no clusters configured; run 'miren login' to authenticate and configure a cluster, or install a server locally")
+		}
+
+		if err := AddClusterInteractive(ctx); err != nil {
+			return fmt.Errorf("failed to add cluster: %w", err)
+		}
+
+		// Reload the client config
+		cfg, err := clientconfig.LoadConfig()
+		if err != nil {
+			return fmt.Errorf("failed to reload config after adding cluster: %w", err)
+		}
+		ctx.ClientConfig = cfg
+
+		// Get the active cluster (the one we just added)
+		clusterName := cfg.ActiveCluster()
+		if clusterName == "" {
+			return fmt.Errorf("no active cluster set after adding cluster")
+		}
+
+		clusterCfg, err := cfg.GetCluster(clusterName)
+		if err == nil && clusterCfg != nil {
+			ctx.ClusterConfig = clusterCfg
+			ctx.ClusterName = clusterName
+		}
+
+		ctx.Info("")
+	}
+
+	// Re-check after potential cluster add
+	if ctx.ClientConfig.GetClusterCount() == 0 {
+		return fmt.Errorf("no clusters configured; run 'miren login' to authenticate and configure a cluster, or install a server locally")
+	}
+
+	// Confirm deployment unless --force is used, stdin is not a TTY, or only one cluster is configured
 	hasSingleCluster := ctx.ClientConfig != nil && ctx.ClientConfig.GetClusterCount() == 1
 	if !opts.Force && isInteractive && !hasSingleCluster {
 		message := fmt.Sprintf("Deploy app '%s' to cluster '%s'?", name, ctx.ClusterName)


### PR DESCRIPTION
1. If no clusters and no identities, tell them they need to login or add a cluster.
2. If an identity but no clusters, inline let them add a cluster from miren.cloud.

Closes MIR-566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive cluster addition flow to simplify adding clusters during CLI use.
  * Deploy command prompts to add a cluster when none exist but identities are configured.
  * Newly added clusters are auto-activated when they are the first configured cluster.

* **Improvements**
  * More consistent and clearer messaging during cluster/identity selection and errors.
  * Centralized cluster-add flow for more reliable configuration handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->