### PR TITLE
Fix race condition in LSVD write cache causing "file already closed" error

### DIFF
--- a/lsvd/disk.go
+++ b/lsvd/disk.go
@@ -465,12 +465,15 @@ func (d *Disk) fillFromWriteCache(ctx *Context, log *slog.Logger, data RangeData
 }
 
 func (d *Disk) fillingFromPrevWriteCache(ctx *Context, log *slog.Logger, data RangeData, holes []Extent) ([]Extent, error) {
-	oc := d.prevCache.Load()
+	oc := d.prevCache.Acquire()
 
 	// If there is no previous cache, bail.
 	if oc == nil {
 		return holes, nil
 	}
+
+	// Ensure we release the reference when done, regardless of success or failure
+	defer d.prevCache.Release()
 
 	var remaining []Extent
 

--- a/lsvd/prev_cache.go
+++ b/lsvd/prev_cache.go
@@ -3,11 +3,13 @@ package lsvd
 import "sync"
 
 // PreviousCache manages holding onto a single segment creator as
-// the previous cache.
+// the previous cache. It uses reference counting to ensure the
+// SegmentCreator is not closed while reads are still in progress.
 type PreviousCache struct {
 	prevCacheMu   sync.Mutex
 	prevCacheCond *sync.Cond
 	prevCache     *SegmentCreator
+	activeReaders int
 }
 
 func NewPreviousCache() *PreviousCache {
@@ -17,6 +19,9 @@ func NewPreviousCache() *PreviousCache {
 	return p
 }
 
+// Load returns the current SegmentCreator without incrementing the reference count.
+// This should only be used when the caller does not need to perform I/O operations
+// on the returned SegmentCreator, as it may be closed at any time.
 func (p *PreviousCache) Load() *SegmentCreator {
 	p.prevCacheMu.Lock()
 	defer p.prevCacheMu.Unlock()
@@ -24,13 +29,47 @@ func (p *PreviousCache) Load() *SegmentCreator {
 	return p.prevCache
 }
 
+// Acquire returns the current SegmentCreator and increments the reference count.
+// The caller MUST call Release() when done using the SegmentCreator.
+// Returns nil if there is no previous cache.
+func (p *PreviousCache) Acquire() *SegmentCreator {
+	p.prevCacheMu.Lock()
+	defer p.prevCacheMu.Unlock()
+
+	if p.prevCache != nil {
+		p.activeReaders++
+	}
+
+	return p.prevCache
+}
+
+// Release decrements the reference count after the caller is done using the
+// SegmentCreator obtained from Acquire(). Must be called exactly once for
+// each successful Acquire() call that returned a non-nil value.
+func (p *PreviousCache) Release() {
+	p.prevCacheMu.Lock()
+	defer p.prevCacheMu.Unlock()
+
+	p.activeReaders--
+	if p.activeReaders == 0 {
+		p.prevCacheCond.Broadcast()
+	}
+}
+
+// Clear waits for all active readers to finish and then clears the cache.
+// After this returns, no readers will be able to access the old SegmentCreator.
 func (p *PreviousCache) Clear() {
 	p.prevCacheMu.Lock()
 	defer p.prevCacheMu.Unlock()
 
+	// Wait for all active readers to finish
+	for p.activeReaders > 0 {
+		p.prevCacheCond.Wait()
+	}
+
 	p.prevCache = nil
 
-	p.prevCacheCond.Signal()
+	p.prevCacheCond.Broadcast()
 }
 
 func (p *PreviousCache) SetWhenClear(sc *SegmentCreator) {

--- a/lsvd/prev_cache_test.go
+++ b/lsvd/prev_cache_test.go
@@ -1,0 +1,179 @@
+package lsvd
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreviousCacheAcquireRelease(t *testing.T) {
+	t.Run("acquire returns nil when cache is empty", func(t *testing.T) {
+		pc := NewPreviousCache()
+		sc := pc.Acquire()
+		require.Nil(t, sc)
+	})
+
+	t.Run("acquire returns SegmentCreator when cache is set", func(t *testing.T) {
+		pc := NewPreviousCache()
+		sc := &SegmentCreator{}
+		pc.SetWhenClear(sc)
+
+		acquired := pc.Acquire()
+		require.Same(t, sc, acquired)
+
+		// Must release
+		pc.Release()
+	})
+
+	t.Run("clear blocks until all readers release", func(t *testing.T) {
+		pc := NewPreviousCache()
+		sc := &SegmentCreator{}
+		pc.SetWhenClear(sc)
+
+		// Acquire a reference
+		acquired := pc.Acquire()
+		require.Same(t, sc, acquired)
+
+		var clearDone atomic.Bool
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		// Start clearing in background - should block
+		go func() {
+			defer wg.Done()
+			pc.Clear()
+			clearDone.Store(true)
+		}()
+
+		// Give the goroutine time to start and block
+		time.Sleep(50 * time.Millisecond)
+
+		// Clear should still be blocked
+		require.False(t, clearDone.Load(), "Clear should block while reader is active")
+
+		// Release the reference
+		pc.Release()
+
+		// Wait for clear to complete
+		wg.Wait()
+
+		// Clear should have completed
+		require.True(t, clearDone.Load(), "Clear should complete after release")
+
+		// Cache should be empty now
+		require.Nil(t, pc.Load())
+	})
+
+	t.Run("multiple readers all block clear", func(t *testing.T) {
+		pc := NewPreviousCache()
+		sc := &SegmentCreator{}
+		pc.SetWhenClear(sc)
+
+		// Acquire multiple references
+		const numReaders = 5
+		for i := 0; i < numReaders; i++ {
+			acquired := pc.Acquire()
+			require.Same(t, sc, acquired)
+		}
+
+		var clearDone atomic.Bool
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		// Start clearing in background
+		go func() {
+			defer wg.Done()
+			pc.Clear()
+			clearDone.Store(true)
+		}()
+
+		// Give the goroutine time to start
+		time.Sleep(50 * time.Millisecond)
+
+		// Release all but one reader
+		for i := 0; i < numReaders-1; i++ {
+			pc.Release()
+			time.Sleep(10 * time.Millisecond)
+			require.False(t, clearDone.Load(), "Clear should still block with active readers")
+		}
+
+		// Release the last reader
+		pc.Release()
+
+		// Wait for clear to complete
+		wg.Wait()
+		require.True(t, clearDone.Load())
+	})
+
+	t.Run("new acquire after clear returns nil", func(t *testing.T) {
+		pc := NewPreviousCache()
+		sc := &SegmentCreator{}
+		pc.SetWhenClear(sc)
+
+		// Acquire and release
+		acquired := pc.Acquire()
+		require.Same(t, sc, acquired)
+		pc.Release()
+
+		// Clear the cache
+		pc.Clear()
+
+		// New acquire should return nil
+		acquired = pc.Acquire()
+		require.Nil(t, acquired)
+	})
+
+	t.Run("concurrent acquires and clear", func(t *testing.T) {
+		pc := NewPreviousCache()
+		sc := &SegmentCreator{}
+		pc.SetWhenClear(sc)
+
+		const numReaders = 100
+		var wg sync.WaitGroup
+		var successfulAcquires atomic.Int32
+
+		// Start many readers concurrently
+		for i := 0; i < numReaders; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				acquired := pc.Acquire()
+				if acquired != nil {
+					successfulAcquires.Add(1)
+					// Simulate some work
+					time.Sleep(time.Millisecond)
+					pc.Release()
+				}
+			}()
+		}
+
+		// Also clear concurrently
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Wait a tiny bit to let some readers start
+			time.Sleep(5 * time.Millisecond)
+			pc.Clear()
+		}()
+
+		// Wait for everything to complete without deadlock
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Success - no deadlock
+		case <-time.After(5 * time.Second):
+			t.Fatal("test timed out - possible deadlock")
+		}
+
+		// After clear, cache should be empty
+		require.Nil(t, pc.Load())
+	})
+}


### PR DESCRIPTION
## Summary

- Fix race condition between read operations and segment close in LSVD write cache
- Add reference counting to `PreviousCache` to prevent file from being closed while reads are in progress
- Add unit tests for the new reference counting behavior

## Root Cause

A race condition existed between:
1. **Read operations** accessing `prevCache` to read data from the previous segment
2. **Controller operations** closing the segment and releasing the file handle

The race sequence:
1. When a segment fills up, the current `SegmentCreator` is stored in `prevCache` and a `CloseSegment` event is sent to the controller
2. The controller calls `d.prevCache.Clear()` then `oc.Close()` (via defer) which closes the file
3. A concurrent read could acquire the `SegmentCreator` from `prevCache.Load()`, but before calling `FillExtent()`, the file gets closed
4. The read then fails with "file already closed"

## The Fix

Added reference counting to `PreviousCache`:

- `Acquire()` - increments counter when getting a reference
- `Release()` - decrements counter when done  
- `Clear()` - now waits for all active readers to finish before returning

Updated `fillingFromPrevWriteCache()` to use `Acquire()`/`Release()` instead of `Load()`, ensuring the file cannot be closed while any read operation is still using it.

## Test plan

- [x] Added unit tests for `PreviousCache` reference counting behavior
- [ ] Run LSVD torture tests to verify fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized cache resource management with enhanced lifecycle tracking to ensure efficient cleanup and prevent resource leaks
  * Strengthened thread-safety mechanisms and synchronization for concurrent cache operations, improving overall reliability
  * Expanded test coverage to validate cache behavior under concurrent access scenarios and high-load conditions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->