### PR TITLE
docker: Let container boot a bit before making UDP requests

### DIFF
--- a/cli/commands/server_install_docker.go
+++ b/cli/commands/server_install_docker.go
@@ -104,6 +104,14 @@ func ServerInstallDocker(ctx *Context, opts struct {
 
 	// Wait for server to be ready
 	ctx.Info("Waiting for miren server to initialize...")
+
+	// NOTE: We've found that, on docker desktop, if we make a http3 UDP request
+	// to the port BEFORE the container has booted enough, docker desktop seems to
+	// stop listening on that port entirely until the container is restarted.
+	// Only a 1 second delay was required to fix the issue in testing, but
+	// I'm making it 3 seconds here to be safe.
+	time.Sleep(3 * time.Second)
+
 	if err := waitForServerReady(ctx); err != nil {
 		ctx.Warn("Failed to confirm server is ready: %v", err)
 		ctx.Info("The server may still be starting. Check logs with: docker logs %s", opts.Name)


### PR DESCRIPTION
The behavior is so bizarre. If we make an http3 request to the forwarded port before the container has had enough time to startup (note: doesn't have to actually wait for the server to listen on the port inside the container, just for the container to actually boot), then docker desktop removes it's listener for the port!

I have to presume it's some pathalogical condition in docker desktop itself, but since it's closed source, we can't pin point it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker server installation reliability by introducing an initialization delay during server startup. This addresses intermittent health check failures experienced in Docker Desktop environments, ensuring more stable and successful server deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->