### PR TITLE
cli: Fix calculation of container / cluster name

### DIFF
--- a/cli/commands/server_install_docker.go
+++ b/cli/commands/server_install_docker.go
@@ -21,7 +21,7 @@ import (
 // ServerInstallDocker sets up a Docker container to run the miren server
 func ServerInstallDocker(ctx *Context, opts struct {
 	Image        string            `short:"i" long:"image" description:"Docker image to use" default:"oci.miren.cloud/miren:latest"`
-	Name         string            `short:"n" long:"name" description:"Container name" default:"miren"`
+	Name         string            `short:"n" long:"name" description:"Container name"`
 	Force        bool              `short:"f" long:"force" description:"Remove existing container if present"`
 	HTTPPort     int               `long:"http-port" description:"HTTP port mapping" default:"80"`
 	HostNetwork  bool              `long:"host-network" description:"Use host networking (ignores port mappings)"`
@@ -30,6 +30,16 @@ func ServerInstallDocker(ctx *Context, opts struct {
 	CloudURL     string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
 	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
 }) error {
+	if opts.ClusterName == "" {
+		opts.ClusterName = opts.Name
+	} else if opts.Name == "" {
+		opts.Name = opts.ClusterName
+	}
+
+	if opts.Name == "" {
+		opts.Name = "miren"
+	}
+
 	// Derive volume name from container name
 	volumeName := opts.Name + "-data"
 	// Check if Docker is installed and running
@@ -60,10 +70,6 @@ func ServerInstallDocker(ctx *Context, opts struct {
 	// Create volume if it doesn't exist
 	if err := dockerEnsureVolume(volumeName); err != nil {
 		return fmt.Errorf("failed to ensure volume exists: %w", err)
-	}
-
-	if opts.ClusterName != "" {
-		opts.ClusterName = opts.Name
 	}
 
 	// Register with cloud unless --without-cloud is specified


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved name handling in Docker server installation. Container names and cluster names now properly reconcile with each other, with both defaulting to "miren" when not provided. This ensures consistent naming across volume creation and cloud registration processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->