### PR TITLE
docs: Add link to How Miren Compares page

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -30,6 +30,11 @@ const sidebars: SidebarsConfig = {
       ],
     },
     'firewall',
+    {
+      type: 'link',
+      label: 'How Miren Compares',
+      href: 'https://miren.dev/compare',
+    },
   ],
 };
 


### PR DESCRIPTION
Adds an external link to https://miren.dev/compare in the docs sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new navigation link titled "How Miren Compares" to the documentation sidebar, providing access to comparison information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->