### PR TITLE
logs: Implement a chunking log stream API

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -3408,7 +3408,8 @@ type logsStreamLogChunksArgsData struct {
 	Target *LogTarget          `cbor:"0,keyasint,omitempty" json:"target,omitempty"`
 	From   *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"from,omitempty"`
 	Follow *bool               `cbor:"2,keyasint,omitempty" json:"follow,omitempty"`
-	Chunks *rpc.Capability     `cbor:"3,keyasint,omitempty" json:"chunks,omitempty"`
+	Filter *string             `cbor:"3,keyasint,omitempty" json:"filter,omitempty"`
+	Chunks *rpc.Capability     `cbor:"4,keyasint,omitempty" json:"chunks,omitempty"`
 }
 
 type LogsStreamLogChunksArgs struct {
@@ -3441,6 +3442,17 @@ func (v *LogsStreamLogChunksArgs) Follow() bool {
 		return false
 	}
 	return *v.data.Follow
+}
+
+func (v *LogsStreamLogChunksArgs) HasFilter() bool {
+	return v.data.Filter != nil
+}
+
+func (v *LogsStreamLogChunksArgs) Filter() string {
+	if v.data.Filter == nil {
+		return ""
+	}
+	return *v.data.Filter
 }
 
 func (v *LogsStreamLogChunksArgs) HasChunks() bool {
@@ -3775,12 +3787,13 @@ type LogsClientStreamLogChunksResults struct {
 	data   logsStreamLogChunksResultsData
 }
 
-func (v LogsClient) StreamLogChunks(ctx context.Context, target *LogTarget, from *standard.Timestamp, follow bool, chunks stream.SendStream[*LogChunk]) (*LogsClientStreamLogChunksResults, error) {
+func (v LogsClient) StreamLogChunks(ctx context.Context, target *LogTarget, from *standard.Timestamp, follow bool, filter string, chunks stream.SendStream[*LogChunk]) (*LogsClientStreamLogChunksResults, error) {
 	args := LogsStreamLogChunksArgs{}
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	args.data.Target = target
 	args.data.From = from
 	args.data.Follow = &follow
+	args.data.Filter = &filter
 	{
 		ic, oid, c := v.NewInlineCapability(stream.AdaptSendStream[*LogChunk](chunks), chunks)
 		args.data.Chunks = c

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -458,6 +458,9 @@ interfaces:
             type: standard.Timestamp
           - name: follow
             type: bool
+          - name: filter
+            type: string
+            doc: "Optional regex pattern to filter log lines"
           - name: chunks
             type: stream.SendStream[*LogChunk]
 

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -283,6 +283,13 @@ types:
         type: string
         index: 3
 
+  - type: LogChunk
+    fields:
+      - name: entries
+        type: list
+        element: "*LogEntry"
+        index: 0
+
   - type: UserInfo
     fields:
       - name: subject
@@ -443,6 +450,16 @@ interfaces:
             type: bool
           - name: logs
             type: stream.SendStream[*LogEntry]
+      - name: streamLogChunks
+        parameters:
+          - name: target
+            type: LogTarget
+          - name: from
+            type: standard.Timestamp
+          - name: follow
+            type: bool
+          - name: chunks
+            type: stream.SendStream[*LogChunk]
 
   - name: Disks
     methods:

--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -22,7 +22,7 @@ The Miren CLI (`miren`) provides commands for managing applications and deployme
 
 ### Application Management
 
-- `miren app` - Get information about an application
+- `miren app` - Get information and metrics about an application ([details](/cli/app))
 - `miren app list` (or `miren apps`) - List all applications
 - `miren app delete` - Delete an application and all its resources
 - `miren app history` - Show deployment history for an application
@@ -30,7 +30,7 @@ The Miren CLI (`miren`) provides commands for managing applications and deployme
 
 ### Logs & Monitoring
 
-- `miren logs` - Get logs for an application
+- `miren logs` - Get logs for an application ([details](/cli/logs))
 - `miren route` - List all HTTP routes
 
 ### Environment & Configuration
@@ -135,5 +135,6 @@ miren app list --format json
 
 - [Getting Started](/getting-started) - Learn by deploying
 - [App Commands](/cli/app) - Manage your applications
+- [Logs Command](/cli/logs) - View application logs
 - [Disk Commands](/cli/disk) - Manage persistent storage
 - [Disks Overview](/disks) - Learn about persistent storage

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'cli/app',
+        'cli/logs',
         'cli/sandbox',
         'cli/entity',
       ],

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -267,25 +267,36 @@ func (l *LogReader) ReadBySandbox(ctx context.Context, sandboxID string, opts ..
 type LogTarget struct {
 	EntityID  string
 	SandboxID string
+	Filter    string // Optional LogsQL filter expression (e.g., "error" or ~"regex")
 }
 
-func (t LogTarget) query() string {
+// Query returns the LogsQL query string for this target.
+func (t LogTarget) Query() string {
+	var base string
 	if t.SandboxID != "" {
-		return `sandbox:` + logsQLQuote(t.SandboxID)
+		base = `sandbox:` + logsQLQuote(t.SandboxID)
+	} else {
+		base = `entity:` + logsQLQuote(t.EntityID)
 	}
-	return `entity:` + logsQLQuote(t.EntityID)
+
+	if t.Filter != "" {
+		// Append filter to query - VictoriaLogs LogsQL syntax
+		// User can specify word filters, phrase filters ("phrase"), or regex (~"pattern")
+		return base + " " + t.Filter
+	}
+	return base
 }
 
 // ReadStream queries historical logs and sends them to a channel as they're parsed.
 // Unlike Read(), this has no limit and streams results incrementally.
 func (l *LogReader) ReadStream(ctx context.Context, target LogTarget, logCh chan<- LogEntry, opts ...LogReaderOption) error {
-	return l.executeStreamQuery(ctx, target.query(), logCh, opts...)
+	return l.executeStreamQuery(ctx, target.Query(), logCh, opts...)
 }
 
 // TailStream connects to VictoriaLogs tail endpoint for live tailing.
 // Blocks until context is cancelled.
 func (l *LogReader) TailStream(ctx context.Context, target LogTarget, logCh chan<- LogEntry, opts ...LogReaderOption) error {
-	return l.executeTailQuery(ctx, target.query(), logCh, opts...)
+	return l.executeTailQuery(ctx, target.Query(), logCh, opts...)
 }
 
 func (l *LogReader) executeStreamQuery(ctx context.Context, query string, logCh chan<- LogEntry, opts ...LogReaderOption) error {

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -297,8 +297,11 @@ func (l *LogReader) executeStreamQuery(ctx context.Context, query string, logCh 
 	baseURL := normalizeBaseURL(l.Address)
 	queryURL := baseURL + "/select/logsql/query"
 
+	// Sort by time ascending so older logs appear first
+	sortedQuery := query + " | sort by (_time) asc"
+
 	params := url.Values{}
-	params.Set("query", query)
+	params.Set("query", sortedQuery)
 	// No limit - stream all results
 
 	startTime := o.From
@@ -443,8 +446,11 @@ func (l *LogReader) executeQuery(ctx context.Context, query string, limit int, s
 	baseURL := normalizeBaseURL(l.Address)
 	queryURL := baseURL + "/select/logsql/query"
 
+	// Sort by time ascending so older logs appear first
+	sortedQuery := query + " | sort by (_time) asc"
+
 	params := url.Values{}
-	params.Set("query", query)
+	params.Set("query", sortedQuery)
 	params.Set("limit", fmt.Sprintf("%d", limit))
 	// Add time range - VictoriaLogs uses RFC3339 timestamps
 	params.Set("start", start.Format(time.RFC3339Nano))

--- a/pkg/logfilter/filter.go
+++ b/pkg/logfilter/filter.go
@@ -1,0 +1,267 @@
+// Package logfilter provides a simple query syntax for filtering logs.
+// The syntax supports:
+//   - Word matching: `error` matches logs containing "error" (case-insensitive)
+//   - Quoted phrases: `"error message"` or `'error message'` matches exact phrase (case-insensitive)
+//   - Regex matching: `/pattern/` matches logs matching the regex pattern
+//   - Negation: `-word` excludes logs containing "word"
+//   - Multiple terms: `error timeout` requires both terms to match (AND)
+//
+// Examples:
+//   - `error` - logs containing "error"
+//   - `"connection failed"` - logs containing exact phrase "connection failed"
+//   - `error timeout` - logs containing both "error" AND "timeout"
+//   - `-debug` - logs NOT containing "debug"
+//   - `error -debug` - logs containing "error" but NOT "debug"
+//   - `/err(or)?/` - logs matching the regex
+//   - `error /warn(ing)?/` - logs containing "error" AND matching the regex
+package logfilter
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Filter represents a compiled log filter that can match log lines
+// and be converted to LogsQL for server-side filtering.
+type Filter struct {
+	terms []term
+}
+
+type termType int
+
+const (
+	termWord   termType = iota // Simple word/substring match
+	termPhrase                 // Quoted phrase (exact match with spaces)
+	termRegex                  // Regex match
+)
+
+type term struct {
+	typ     termType
+	value   string         // Original value (for word) or pattern (for regex)
+	regex   *regexp.Regexp // Compiled regex (for regex terms, or word converted to case-insensitive)
+	negated bool           // If true, this term must NOT match
+}
+
+// Parse parses a filter string into a Filter.
+// Returns nil if the input is empty.
+func Parse(input string) (*Filter, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, nil
+	}
+
+	// Convert to runes for proper UTF-8 handling
+	runes := []rune(input)
+	var terms []term
+
+	i := 0
+	for i < len(runes) {
+		// Skip whitespace
+		for i < len(runes) && (runes[i] == ' ' || runes[i] == '\t') {
+			i++
+		}
+		if i >= len(runes) {
+			break
+		}
+
+		// Check for negation prefix
+		negated := false
+		if runes[i] == '-' {
+			negated = true
+			i++
+			if i >= len(runes) {
+				break
+			}
+		}
+
+		// Check for quoted string (starts with " or ')
+		if runes[i] == '"' || runes[i] == '\'' {
+			quote := runes[i]
+			i++ // Skip opening quote
+			var phrase strings.Builder
+			for i < len(runes) && runes[i] != quote {
+				if runes[i] == '\\' && i+1 < len(runes) {
+					i++ // Skip backslash
+					phrase.WriteRune(runes[i])
+				} else {
+					phrase.WriteRune(runes[i])
+				}
+				i++
+			}
+			if i < len(runes) {
+				i++ // Skip closing quote
+			}
+			phraseStr := phrase.String()
+			if phraseStr != "" {
+				re, err := regexp.Compile("(?i)" + regexp.QuoteMeta(phraseStr))
+				if err != nil {
+					return nil, err
+				}
+				terms = append(terms, term{
+					typ:     termPhrase,
+					value:   phraseStr,
+					regex:   re,
+					negated: negated,
+				})
+			}
+		} else if runes[i] == '/' {
+			// Regex (starts with /)
+			start := i
+			i++ // Skip opening /
+			var pattern strings.Builder
+			for i < len(runes) && runes[i] != '/' {
+				if runes[i] == '\\' && i+1 < len(runes) {
+					pattern.WriteRune(runes[i])
+					i++
+					pattern.WriteRune(runes[i])
+				} else {
+					pattern.WriteRune(runes[i])
+				}
+				i++
+			}
+			if i >= len(runes) {
+				// No closing /, treat as literal word
+				literal := string(runes[start:])
+				re, err := regexp.Compile("(?i)" + regexp.QuoteMeta(literal))
+				if err != nil {
+					return nil, err
+				}
+				terms = append(terms, term{
+					typ:     termWord,
+					value:   literal,
+					regex:   re,
+					negated: negated,
+				})
+				break
+			}
+			i++ // Skip closing /
+
+			patternStr := pattern.String()
+			re, err := regexp.Compile(patternStr)
+			if err != nil {
+				return nil, err
+			}
+			terms = append(terms, term{
+				typ:     termRegex,
+				value:   patternStr,
+				regex:   re,
+				negated: negated,
+			})
+		} else {
+			// Regular word - read until whitespace
+			var word strings.Builder
+			for i < len(runes) && runes[i] != ' ' && runes[i] != '\t' {
+				word.WriteRune(runes[i])
+				i++
+			}
+			wordStr := word.String()
+			if wordStr != "" {
+				re, err := regexp.Compile("(?i)" + regexp.QuoteMeta(wordStr))
+				if err != nil {
+					return nil, err
+				}
+				terms = append(terms, term{
+					typ:     termWord,
+					value:   wordStr,
+					regex:   re,
+					negated: negated,
+				})
+			}
+		}
+	}
+
+	if len(terms) == 0 {
+		return nil, nil
+	}
+
+	return &Filter{terms: terms}, nil
+}
+
+// Match returns true if the line matches the filter.
+// All terms must match (AND logic), with negated terms inverted.
+func (f *Filter) Match(line string) bool {
+	if f == nil {
+		return true
+	}
+
+	for _, t := range f.terms {
+		matches := t.regex.MatchString(line)
+		if t.negated {
+			matches = !matches
+		}
+		if !matches {
+			return false
+		}
+	}
+	return true
+}
+
+// ToLogsQL converts the filter to a LogsQL filter expression.
+// This can be appended to a LogsQL query for server-side filtering.
+func (f *Filter) ToLogsQL() string {
+	if f == nil || len(f.terms) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, t := range f.terms {
+		var part string
+		switch t.typ {
+		case termWord:
+			// LogsQL word filter - case insensitive by default
+			if t.negated {
+				part = "-" + t.value
+			} else {
+				part = t.value
+			}
+		case termPhrase:
+			// LogsQL phrase filter - quoted for exact match
+			if t.negated {
+				part = "-\"" + escapeLogsQLString(t.value) + "\""
+			} else {
+				part = "\"" + escapeLogsQLString(t.value) + "\""
+			}
+		case termRegex:
+			// LogsQL regex filter
+			if t.negated {
+				part = "-~\"" + escapeLogsQLString(t.value) + "\""
+			} else {
+				part = "~\"" + escapeLogsQLString(t.value) + "\""
+			}
+		}
+		parts = append(parts, part)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// String returns the original filter string representation.
+func (f *Filter) String() string {
+	if f == nil || len(f.terms) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, t := range f.terms {
+		var part string
+		if t.negated {
+			part = "-"
+		}
+		switch t.typ {
+		case termWord:
+			part += t.value
+		case termPhrase:
+			part += "\"" + strings.ReplaceAll(t.value, "\"", "\\\"") + "\""
+		case termRegex:
+			part += "/" + t.value + "/"
+		}
+		parts = append(parts, part)
+	}
+	return strings.Join(parts, " ")
+}
+
+func escapeLogsQLString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}

--- a/pkg/logfilter/filter_test.go
+++ b/pkg/logfilter/filter_test.go
@@ -1,0 +1,410 @@
+package logfilter
+
+import (
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool
+		wantErr bool
+	}{
+		{"empty", "", true, false},
+		{"whitespace only", "   ", true, false},
+		{"single word", "error", false, false},
+		{"multiple words", "error timeout", false, false},
+		{"negated word", "-debug", false, false},
+		{"word with negation", "error -debug", false, false},
+		{"simple regex", "/err.*/", false, false},
+		{"negated regex", "-/debug/", false, false},
+		{"mixed", "error /warn.*/ -debug", false, false},
+		{"unclosed regex treated as word", "/unclosed", false, false},
+		{"invalid regex", "/[invalid/", true, true},
+		// Quoted strings
+		{"double quoted phrase", `"error message"`, false, false},
+		{"single quoted phrase", `'error message'`, false, false},
+		{"negated quoted phrase", `-"debug info"`, false, false},
+		{"mixed with quotes", `error "connection failed" -debug`, false, false},
+		{"empty quotes", `""`, true, false},
+		{"unclosed double quote", `"unclosed`, false, false},
+		{"unclosed single quote", `'unclosed`, false, false},
+		{"escaped quote in phrase", `"say \"hello\""`, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := Parse(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if (f == nil) != tt.wantNil {
+				t.Errorf("Parse(%q) = %v, wantNil %v", tt.input, f, tt.wantNil)
+			}
+		})
+	}
+}
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		line   string
+		want   bool
+	}{
+		// Word matching (case-insensitive)
+		{"word matches", "error", "This is an error message", true},
+		{"word matches case insensitive", "ERROR", "this is an error message", true},
+		{"word no match", "error", "This is a warning message", false},
+		{"partial word match", "err", "This is an error message", true},
+
+		// Multiple words (AND logic)
+		{"multiple words all match", "error timeout", "Connection error due to timeout", true},
+		{"multiple words partial match", "error timeout", "Connection error occurred", false},
+		{"multiple words order independent", "timeout error", "error happened then timeout", true},
+
+		// Negation
+		{"negated word excludes", "-debug", "Debug: some message", false},
+		{"negated word includes", "-debug", "Error: some message", true},
+		{"word and negation", "error -debug", "Error: something failed", true},
+		{"word and negation excludes", "error -debug", "Debug: Error occurred", false},
+
+		// Regex
+		{"regex matches", "/err(or)?/", "This is an error", true},
+		{"regex matches partial", "/err(or)?/", "This is err", true},
+		{"regex no match", "/^error$/", "This is an error", false},
+		{"regex case sensitive", "/Error/", "this is an error", false},
+		{"regex case insensitive flag", "/(?i)Error/", "this is an error", true},
+
+		// Negated regex (regex is case-sensitive)
+		{"negated regex excludes", "-/debug/", "debug message", false},
+		{"negated regex includes", "-/debug/", "Error message", true},
+		{"negated regex case mismatch", "-/debug/", "Debug message", true}, // regex doesn't match, so negation passes
+
+		// Mixed
+		{"mixed word and regex", "error /warn(ing)?/", "error and warning here", true},
+		{"mixed word and regex partial", "error /warn(ing)?/", "error only", false},
+		{"mixed with negation", "error -/debug/", "error occurred", true},
+		{"mixed with negation excludes", "error -/debug/", "debug error", false},
+
+		// Nil filter matches everything
+		{"nil filter", "", "anything", true},
+
+		// Quoted phrases
+		{"quoted phrase matches", `"connection failed"`, "Error: connection failed at startup", true},
+		{"quoted phrase case insensitive", `"Connection Failed"`, "error: connection failed", true},
+		{"quoted phrase no match", `"connection failed"`, "connection was successful", false},
+		{"quoted phrase with spaces", `"hello world"`, "message: hello world!", true},
+		{"quoted phrase partial no match", `"hello world"`, "hello there world", false},
+		{"single quoted phrase", `'error occurred'`, "Error occurred in module", true},
+		{"negated quoted phrase excludes", `-"debug info"`, "debug info: checking", false},
+		{"negated quoted phrase includes", `-"debug info"`, "error occurred", true},
+		{"mixed word and phrase", `error "connection timeout"`, "error: connection timeout happened", true},
+		{"mixed word and phrase partial", `error "connection timeout"`, "error: connection refused", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := Parse(tt.filter)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.filter, err)
+			}
+			if got := f.Match(tt.line); got != tt.want {
+				t.Errorf("Filter(%q).Match(%q) = %v, want %v", tt.filter, tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToLogsQL(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"single word", "error", "error"},
+		{"multiple words", "error timeout", "error timeout"},
+		{"negated word", "-debug", "-debug"},
+		{"word with negation", "error -debug", "error -debug"},
+		{"simple regex", "/err.*/", `~"err.*"`},
+		{"negated regex", "-/debug/", `-~"debug"`},
+		{"mixed", "error /warn.*/ -debug", `error ~"warn.*" -debug`},
+		{"regex with quotes", `/say "hello"/`, `~"say \"hello\""`},
+		{"regex with backslash", `/path\\file/`, `~"path\\\\file"`},
+		// Quoted phrases
+		{"quoted phrase", `"connection failed"`, `"connection failed"`},
+		{"negated phrase", `-"debug info"`, `-"debug info"`},
+		{"phrase with special chars", `"error: failed"`, `"error: failed"`},
+		{"mixed with phrase", `error "timeout occurred"`, `error "timeout occurred"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := Parse(tt.filter)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.filter, err)
+			}
+			if got := f.ToLogsQL(); got != tt.want {
+				t.Errorf("Filter(%q).ToLogsQL() = %q, want %q", tt.filter, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"single word", "error", "error"},
+		{"multiple words", "error timeout", "error timeout"},
+		{"negated word", "-debug", "-debug"},
+		{"regex", "/pattern/", "/pattern/"},
+		{"negated regex", "-/pattern/", "-/pattern/"},
+		{"mixed", "error /warn/ -debug", "error /warn/ -debug"},
+		// Quoted phrases (always output with double quotes)
+		{"double quoted phrase", `"error message"`, `"error message"`},
+		{"single quoted phrase", `'error message'`, `"error message"`},
+		{"negated phrase", `-"debug info"`, `-"debug info"`},
+		{"phrase with escaped quote", `"say \"hi\""`, `"say \"hi\""`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := Parse(tt.filter)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.filter, err)
+			}
+			if got := f.String(); got != tt.want {
+				t.Errorf("Filter(%q).String() = %q, want %q", tt.filter, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseEdgeCases(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		terms  int
+		wantOK bool
+	}{
+		{"trailing dash", "error -", 1, true},
+		{"only dash", "-", 0, true},
+		{"escaped in regex", `/test\//`, 1, true},
+		{"tabs as whitespace", "error\ttimeout", 2, true},
+		{"multiple spaces", "error    timeout", 2, true},
+		{"trailing whitespace", "error   ", 1, true},
+		{"leading and trailing whitespace", "  error  ", 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := Parse(tt.input)
+			if err != nil {
+				if tt.wantOK {
+					t.Errorf("Parse(%q) unexpected error = %v", tt.input, err)
+				}
+				return
+			}
+			if !tt.wantOK {
+				t.Errorf("Parse(%q) expected error", tt.input)
+				return
+			}
+			if f == nil && tt.terms > 0 {
+				t.Errorf("Parse(%q) = nil, want %d terms", tt.input, tt.terms)
+				return
+			}
+			if f != nil && len(f.terms) != tt.terms {
+				t.Errorf("Parse(%q) has %d terms, want %d", tt.input, len(f.terms), tt.terms)
+			}
+		})
+	}
+}
+
+func TestUTF8Support(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		line   string
+		want   bool
+	}{
+		// UTF-8 word matching
+		{"japanese word", "エラー", "システムエラーが発生しました", true},
+		{"chinese word", "错误", "发生了一个错误", true},
+		{"emoji filter", "🔥", "Server is on 🔥", true},
+		{"cyrillic word", "ошибка", "Произошла ошибка", true},
+		{"mixed utf8 and ascii", "error エラー", "error エラー occurred", true},
+
+		// UTF-8 in quoted phrases
+		{"quoted japanese phrase", `"接続エラー"`, "Error: 接続エラーが発生", true},
+		{"quoted emoji phrase", `"🎉 success"`, "Result: 🎉 success!", true},
+
+		// UTF-8 in regex
+		{"regex with unicode", `/エラー.+/`, "エラーが発生しました", true},
+
+		// Negation with UTF-8
+		{"negated utf8", "-デバッグ", "エラーが発生しました", true},
+		{"negated utf8 excludes", "-デバッグ", "デバッグ: チェック中", false},
+
+		// Case insensitivity for latin extended
+		{"german umlaut case", "MÜLLER", "Herr müller ist hier", true},
+		{"french accent case", "café", "Welcome to CAFÉ Paris", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := Parse(tt.filter)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.filter, err)
+			}
+			if got := f.Match(tt.line); got != tt.want {
+				t.Errorf("Filter(%q).Match(%q) = %v, want %v", tt.filter, tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchRealWorldLogs(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		line   string
+		want   bool
+	}{
+		// Typical log formats
+		{"json log error field", "error", `{"level":"error","msg":"connection failed","time":"2024-01-01T00:00:00Z"}`, true},
+		{"json log info field", "error", `{"level":"info","msg":"server started","time":"2024-01-01T00:00:00Z"}`, false},
+		{"syslog format", "error", "Jan  1 00:00:00 host app[1234]: ERROR: connection failed", true},
+		{"klog format", "error", "E0101 00:00:00.000000       1 main.go:42] error occurred", true},
+
+		// HTTP status codes
+		{"http 500 error", "500", "192.168.1.1 - - [01/Jan/2024:00:00:00] \"GET /api HTTP/1.1\" 500 1234", true},
+		{"http 200 ok", "500", "192.168.1.1 - - [01/Jan/2024:00:00:00] \"GET /api HTTP/1.1\" 200 1234", false},
+
+		// Stack traces
+		{"panic line", "panic", "panic: runtime error: invalid memory address", true},
+		{"goroutine", "/goroutine/", "goroutine 1 [running]:", true},
+
+		// Empty and whitespace lines
+		{"empty line no filter", "", "", true},
+		{"empty line with filter", "error", "", false},
+		{"whitespace line", "error", "   ", false},
+
+		// Special characters in logs
+		{"brackets in log", "error", "[ERROR] something went wrong", true},
+		{"parens in log", "failed", "Connection failed (timeout)", true},
+		{"equals in log", "status=500", "request completed status=500 duration=1.5s", true},
+
+		// UUID/ID matching
+		{"uuid partial", "abc123", "Request ID: abc123-def456-ghi789", true},
+		{"trace id", "/[a-f0-9]{8}/", "trace_id=deadbeef span_id=12345678", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := Parse(tt.filter)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.filter, err)
+			}
+			if got := f.Match(tt.line); got != tt.want {
+				t.Errorf("Filter(%q).Match(%q) = %v, want %v", tt.filter, tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchOnlyNegation(t *testing.T) {
+	// Filter with only negation should match lines that don't contain the term
+	f, err := Parse("-debug -trace")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{"error occurred", true},
+		{"debug message", false},
+		{"trace started", false},
+		{"debug and trace", false},
+		{"info log", true},
+	}
+
+	for _, tt := range tests {
+		if got := f.Match(tt.line); got != tt.want {
+			t.Errorf("Filter(-debug -trace).Match(%q) = %v, want %v", tt.line, got, tt.want)
+		}
+	}
+}
+
+func TestFilterReuse(t *testing.T) {
+	// Verify filter can be reused multiple times
+	f, err := Parse("error -debug")
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	lines := []string{
+		"error occurred",
+		"debug message",
+		"error in debug mode",
+		"warning message",
+		"another error",
+	}
+	expected := []bool{true, false, false, false, true}
+
+	for i, line := range lines {
+		if got := f.Match(line); got != expected[i] {
+			t.Errorf("Filter.Match(%q) = %v, want %v", line, got, expected[i])
+		}
+	}
+
+	// Run again to ensure filter state isn't modified
+	for i, line := range lines {
+		if got := f.Match(line); got != expected[i] {
+			t.Errorf("Second run: Filter.Match(%q) = %v, want %v", line, got, expected[i])
+		}
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	inputs := []string{
+		"error",
+		"error timeout -debug",
+		"/err(or)?/ warning -/debug/",
+	}
+
+	for _, input := range inputs {
+		b.Run(input, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, _ = Parse(input)
+			}
+		})
+	}
+}
+
+func BenchmarkMatch(b *testing.B) {
+	filters := []string{
+		"error",
+		"error timeout",
+		"error -debug",
+		"/err(or)?/",
+	}
+	line := "2024-01-01T00:00:00Z ERROR: connection timeout occurred in debug mode"
+
+	for _, filterStr := range filters {
+		f, _ := Parse(filterStr)
+		b.Run(filterStr, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				f.Match(line)
+			}
+		})
+	}
+}

--- a/servers/logs/logs.go
+++ b/servers/logs/logs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -163,6 +164,134 @@ func (s *Server) StreamLogs(ctx context.Context, state *app_v1alpha.LogsStreamLo
 			return err
 		}
 	}
+
+	// Check for reader errors
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return nil
+	}
+}
+
+const defaultChunkSize = 100
+
+func (s *Server) StreamLogChunks(ctx context.Context, state *app_v1alpha.LogsStreamLogChunks) error {
+	args := state.Args()
+	send := args.Chunks()
+	target := args.Target()
+
+	var opts []observability.LogReaderOption
+	if args.HasFrom() {
+		fromTime := standard.FromTimestamp(args.From())
+		opts = append(opts, observability.WithFromTime(fromTime))
+	}
+
+	// Build log target from RPC target
+	var logTarget observability.LogTarget
+
+	if target.HasSandbox() && target.Sandbox() != "" {
+		logTarget.SandboxID = target.Sandbox()
+		s.Log.Debug("streaming log chunks by sandbox", "sandbox", logTarget.SandboxID, "follow", args.Follow())
+	} else if target.HasApp() && target.App() != "" {
+		// Resolve app to entity ID
+		var appRec core_v1alpha.App
+		err := s.EC.Get(ctx, target.App(), &appRec)
+		if err != nil {
+			s.Log.Error("failed to get app", "app", target.App(), "err", err)
+			return err
+		}
+		logTarget.EntityID = appRec.EntityId().String()
+		s.Log.Debug("streaming log chunks by app", "app", target.App(), "entityID", logTarget.EntityID, "follow", args.Follow())
+	} else {
+		return fmt.Errorf("target must specify either app or sandbox")
+	}
+
+	// Create channel for log entries
+	logCh := make(chan observability.LogEntry, 100)
+	errCh := make(chan error, 1)
+
+	// Start reader goroutine
+	go func() {
+		defer close(logCh)
+		var err error
+		if args.Follow() {
+			err = s.LogReader.TailStream(ctx, logTarget, logCh, opts...)
+		} else {
+			err = s.LogReader.ReadStream(ctx, logTarget, logCh, opts...)
+		}
+		if err != nil && err != context.Canceled {
+			errCh <- err
+		}
+	}()
+
+	// Buffer entries into chunks
+	chunk := &app_v1alpha.LogChunk{}
+	entries := make([]*app_v1alpha.LogEntry, 0, defaultChunkSize)
+
+	sendChunk := func() error {
+		if len(entries) == 0 {
+			return nil
+		}
+		chunk.SetEntries(entries)
+		if _, err := send.Send(ctx, chunk); err != nil {
+			s.Log.Debug("client disconnected", "err", err)
+			return err
+		}
+		// Reset for next chunk
+		chunk = &app_v1alpha.LogChunk{}
+		entries = make([]*app_v1alpha.LogEntry, 0, defaultChunkSize)
+		return nil
+	}
+
+	// In follow mode, use a ticker to flush chunks periodically
+	if args.Follow() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case entry, ok := <-logCh:
+				if !ok {
+					// Channel closed, send remaining entries
+					if err := sendChunk(); err != nil {
+						return err
+					}
+					goto done
+				}
+				entries = append(entries, toLogEntry(entry))
+				if len(entries) >= defaultChunkSize {
+					if err := sendChunk(); err != nil {
+						return err
+					}
+				}
+			case <-ticker.C:
+				// Periodic flush for timely delivery in tail mode
+				if err := sendChunk(); err != nil {
+					return err
+				}
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	} else {
+		// Non-follow mode: batch efficiently without time constraints
+		for entry := range logCh {
+			entries = append(entries, toLogEntry(entry))
+			if len(entries) >= defaultChunkSize {
+				if err := sendChunk(); err != nil {
+					return err
+				}
+			}
+		}
+
+		// Send remaining entries
+		if err := sendChunk(); err != nil {
+			return err
+		}
+	}
+
+done:
 
 	// Check for reader errors
 	select {

--- a/servers/logs/logs_test.go
+++ b/servers/logs/logs_test.go
@@ -1,0 +1,472 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/observability"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/standard"
+	"miren.dev/runtime/pkg/rpc/stream"
+)
+
+type mockLogEntry struct {
+	Time   string `json:"_time"`
+	Msg    string `json:"_msg"`
+	Stream string `json:"stream"`
+	Source string `json:"source,omitempty"`
+}
+
+func createMockVictoriaLogs(t *testing.T, entries []mockLogEntry, delay time.Duration) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+
+		for _, entry := range entries {
+			if delay > 0 {
+				time.Sleep(delay)
+			}
+			data, err := json.Marshal(entry)
+			if err != nil {
+				t.Errorf("failed to marshal entry: %v", err)
+				return
+			}
+			w.Write(data)
+			w.Write([]byte("\n"))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	}))
+}
+
+func setupTestServer(t *testing.T, mockServer *httptest.Server) (*Server, *entityserver.Client, func()) {
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+
+	lr := &observability.LogReader{
+		Address: mockServer.URL,
+		Timeout: 30 * time.Second,
+	}
+
+	server := NewServer(slog.Default(), ec, lr)
+
+	return server, ec, func() {
+		cleanup()
+		mockServer.Close()
+	}
+}
+
+func TestStreamLogChunks_Basic(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	r := require.New(t)
+
+	now := time.Now()
+	entries := []mockLogEntry{
+		{Time: now.Add(-2 * time.Second).Format(time.RFC3339Nano), Msg: "log line 1", Stream: "stdout"},
+		{Time: now.Add(-1 * time.Second).Format(time.RFC3339Nano), Msg: "log line 2", Stream: "stderr"},
+		{Time: now.Format(time.RFC3339Nano), Msg: "log line 3", Stream: "stdout", Source: "worker-1"},
+	}
+
+	mockServer := createMockVictoriaLogs(t, entries, 0)
+	server, ec, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	// Create a test app
+	app := &core_v1alpha.App{}
+	_, err := ec.Create(ctx, "test-app", app)
+	r.NoError(err)
+
+	// Create RPC client
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	// Collect received chunks
+	var receivedChunks []*app_v1alpha.LogChunk
+	var mu sync.Mutex
+
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedChunks = append(receivedChunks, chunk)
+		return nil
+	})
+
+	target := &app_v1alpha.LogTarget{}
+	target.SetApp("test-app")
+
+	_, err = client.StreamLogChunks(ctx, target, nil, false, callback)
+	r.NoError(err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Should have received at least one chunk
+	r.NotEmpty(receivedChunks)
+
+	// Count total entries across all chunks
+	var totalEntries int
+	for _, chunk := range receivedChunks {
+		totalEntries += len(chunk.Entries())
+	}
+	r.Equal(3, totalEntries)
+
+	// Verify first chunk has expected content
+	firstChunk := receivedChunks[0]
+	r.NotEmpty(firstChunk.Entries())
+	r.Equal("log line 1", firstChunk.Entries()[0].Line())
+}
+
+func TestStreamLogChunks_Chunking(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	r := require.New(t)
+
+	// Create more entries than chunk size (100)
+	now := time.Now()
+	entries := make([]mockLogEntry, 250)
+	for i := range entries {
+		entries[i] = mockLogEntry{
+			Time:   now.Add(time.Duration(i) * time.Millisecond).Format(time.RFC3339Nano),
+			Msg:    "log line",
+			Stream: "stdout",
+		}
+	}
+
+	mockServer := createMockVictoriaLogs(t, entries, 0)
+	server, ec, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	// Create a test app
+	app := &core_v1alpha.App{}
+	_, err := ec.Create(ctx, "test-app", app)
+	r.NoError(err)
+
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	var receivedChunks []*app_v1alpha.LogChunk
+	var mu sync.Mutex
+
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedChunks = append(receivedChunks, chunk)
+		return nil
+	})
+
+	target := &app_v1alpha.LogTarget{}
+	target.SetApp("test-app")
+
+	_, err = client.StreamLogChunks(ctx, target, nil, false, callback)
+	r.NoError(err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Should have multiple chunks (250 entries / 100 per chunk = 3 chunks)
+	r.GreaterOrEqual(len(receivedChunks), 2)
+
+	// First chunks should be full (100 entries)
+	r.Equal(100, len(receivedChunks[0].Entries()))
+	r.Equal(100, len(receivedChunks[1].Entries()))
+
+	// Last chunk should have remaining entries
+	r.Equal(50, len(receivedChunks[2].Entries()))
+
+	// Total should be 250
+	var total int
+	for _, chunk := range receivedChunks {
+		total += len(chunk.Entries())
+	}
+	r.Equal(250, total)
+}
+
+func TestStreamLogChunks_BySandbox(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	r := require.New(t)
+
+	now := time.Now()
+	entries := []mockLogEntry{
+		{Time: now.Format(time.RFC3339Nano), Msg: "sandbox log", Stream: "stdout"},
+	}
+
+	mockServer := createMockVictoriaLogs(t, entries, 0)
+	server, _, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	var receivedChunks []*app_v1alpha.LogChunk
+	var mu sync.Mutex
+
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedChunks = append(receivedChunks, chunk)
+		return nil
+	})
+
+	target := &app_v1alpha.LogTarget{}
+	target.SetSandbox("sandbox/test-sandbox-123")
+
+	_, err := client.StreamLogChunks(ctx, target, nil, false, callback)
+	r.NoError(err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	r.NotEmpty(receivedChunks)
+	r.Equal("sandbox log", receivedChunks[0].Entries()[0].Line())
+}
+
+func TestStreamLogChunks_WithFromTime(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	r := require.New(t)
+
+	now := time.Now()
+	entries := []mockLogEntry{
+		{Time: now.Format(time.RFC3339Nano), Msg: "recent log", Stream: "stdout"},
+	}
+
+	mockServer := createMockVictoriaLogs(t, entries, 0)
+	server, ec, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	app := &core_v1alpha.App{}
+	_, err := ec.Create(ctx, "test-app", app)
+	r.NoError(err)
+
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	var receivedChunks []*app_v1alpha.LogChunk
+	var mu sync.Mutex
+
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedChunks = append(receivedChunks, chunk)
+		return nil
+	})
+
+	target := &app_v1alpha.LogTarget{}
+	target.SetApp("test-app")
+
+	fromTime := standard.ToTimestamp(now.Add(-1 * time.Hour))
+
+	_, err = client.StreamLogChunks(ctx, target, fromTime, false, callback)
+	r.NoError(err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	r.NotEmpty(receivedChunks)
+}
+
+func TestStreamLogChunks_FollowModePeriodicFlush(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	r := require.New(t)
+
+	// Create a mock server that sends entries slowly (one every 300ms)
+	now := time.Now()
+	entries := []mockLogEntry{
+		{Time: now.Format(time.RFC3339Nano), Msg: "log 1", Stream: "stdout"},
+		{Time: now.Add(100 * time.Millisecond).Format(time.RFC3339Nano), Msg: "log 2", Stream: "stdout"},
+		{Time: now.Add(200 * time.Millisecond).Format(time.RFC3339Nano), Msg: "log 3", Stream: "stdout"},
+	}
+
+	// Use /select/logsql/tail endpoint for follow mode
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+
+		for i, entry := range entries {
+			if i > 0 {
+				time.Sleep(300 * time.Millisecond)
+			}
+			data, _ := json.Marshal(entry)
+			w.Write(data)
+			w.Write([]byte("\n"))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	}))
+	defer mockServer.Close()
+
+	server, ec, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	app := &core_v1alpha.App{}
+	_, err := ec.Create(ctx, "test-app", app)
+	r.NoError(err)
+
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	var receivedChunks []*app_v1alpha.LogChunk
+	var chunkTimes []time.Time
+	var mu sync.Mutex
+
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedChunks = append(receivedChunks, chunk)
+		chunkTimes = append(chunkTimes, time.Now())
+		return nil
+	})
+
+	target := &app_v1alpha.LogTarget{}
+	target.SetApp("test-app")
+
+	_, err = client.StreamLogChunks(ctx, target, nil, true, callback)
+	r.NoError(err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Should have received chunks
+	r.NotEmpty(receivedChunks)
+
+	// Total entries should be 3
+	var total int
+	for _, chunk := range receivedChunks {
+		total += len(chunk.Entries())
+	}
+	r.Equal(3, total)
+}
+
+func TestStreamLogChunks_ErrorNoTarget(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	r := require.New(t)
+
+	mockServer := createMockVictoriaLogs(t, nil, 0)
+	server, _, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
+		return nil
+	})
+
+	// Empty target - should error
+	target := &app_v1alpha.LogTarget{}
+
+	_, err := client.StreamLogChunks(ctx, target, nil, false, callback)
+	r.Error(err)
+	r.Contains(err.Error(), "target must specify either app or sandbox")
+}
+
+func TestStreamLogChunks_AppNotFound(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	r := require.New(t)
+
+	mockServer := createMockVictoriaLogs(t, nil, 0)
+	server, _, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
+		return nil
+	})
+
+	target := &app_v1alpha.LogTarget{}
+	target.SetApp("nonexistent-app")
+
+	_, err := client.StreamLogChunks(ctx, target, nil, false, callback)
+	r.Error(err)
+}
+
+func TestStreamLogChunks_LogEntryFields(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	r := require.New(t)
+
+	now := time.Now()
+	entries := []mockLogEntry{
+		{
+			Time:   now.Format(time.RFC3339Nano),
+			Msg:    "test message",
+			Stream: "stderr",
+			Source: "my-source",
+		},
+	}
+
+	mockServer := createMockVictoriaLogs(t, entries, 0)
+	server, ec, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	app := &core_v1alpha.App{}
+	_, err := ec.Create(ctx, "test-app", app)
+	r.NoError(err)
+
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	var receivedEntry *app_v1alpha.LogEntry
+	var mu sync.Mutex
+
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(chunk.Entries()) > 0 {
+			receivedEntry = chunk.Entries()[0]
+		}
+		return nil
+	})
+
+	target := &app_v1alpha.LogTarget{}
+	target.SetApp("test-app")
+
+	_, err = client.StreamLogChunks(ctx, target, nil, false, callback)
+	r.NoError(err)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	r.NotNil(receivedEntry)
+	r.Equal("test message", receivedEntry.Line())
+	r.Equal("stderr", receivedEntry.Stream())
+	r.Equal("my-source", receivedEntry.Source())
+	r.True(receivedEntry.HasTimestamp())
+}


### PR DESCRIPTION
This is quite a bit faster as it doesn't require a round trip from server to client on every log entry.

Fixes MIR-575

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chunked log streaming: stream LogChunk items with target, time-range, follow-mode and filter support; CLI prefers chunked streaming when available and validates filter input.
  * Server and client support for streaming LogChunk payloads.

* **New Package**
  * Added logfilter utility to parse/evaluate filter expressions and translate them to server-side queries.

* **Tests**
  * Extensive unit and end-to-end tests for streaming, chunking, filtering, follow-mode, and filter parser.

* **Documentation**
  * CLI docs updated with logs command details and sidebar entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->