### PR TITLE
docs: Add missing pages to sidebar navigation

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -18,6 +18,19 @@ const sidebars: SidebarsConfig = {
     'getting-started',
     {
       type: 'category',
+      label: 'Core Concepts',
+      items: [
+        'terminology',
+        'languages',
+        'services',
+        'scaling',
+        'disks',
+        'firewall',
+      ],
+    },
+    'working-with-miren-cloud',
+    {
+      type: 'category',
       label: 'CLI Reference',
       link: {
         type: 'doc',
@@ -26,14 +39,22 @@ const sidebars: SidebarsConfig = {
       items: [
         'cli/app',
         'cli/sandbox',
+        'cli/disk',
         'cli/entity',
       ],
     },
-    'firewall',
     {
-      type: 'link',
-      label: 'How Miren Compares',
-      href: 'https://miren.dev/compare',
+      type: 'category',
+      label: 'Resources',
+      items: [
+        'support',
+        'conduct',
+        {
+          type: 'link',
+          label: 'How Miren Compares',
+          href: 'https://miren.dev/compare',
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
## Summary
- Add 9 documentation pages that existed but weren't visible in the sidebar
- Organize content into logical categories: Core Concepts, CLI Reference, and Resources
- Add missing `cli/disk` commands to CLI Reference section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Core Concepts documentation section featuring terminology, languages, services, scaling, disk management, and firewall topics to guide users through fundamental platform concepts and capabilities.
  * Restructured Resources section for improved organization and accessibility of support, conduct, and product comparison information.
  * Expanded CLI documentation with new disk command reference materials and guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->