### PR TITLE
CLI error output now redirects the user to check server status and links demo server instructions

### DIFF
--- a/cli/commands/cluster.go
+++ b/cli/commands/cluster.go
@@ -28,7 +28,7 @@ func ClusterList(ctx *Context, opts struct {
 				}
 				return PrintJSON([]ClusterInfo{})
 			}
-			ctx.Printf("No clusters configured\n")
+			ctx.Printf("No clusters configured. Is your miren server running? Check server status with `miren server status`\n")
 			ctx.Printf("\nUse 'miren cluster add' to add a cluster\n")
 			return nil
 		}

--- a/cli/commands/login.go
+++ b/cli/commands/login.go
@@ -620,6 +620,7 @@ func autoConfigureCluster(ctx *Context, identityName, cloudURL string, keyPair *
 
 	if len(validClusters) == 0 {
 		ctx.Info("No clusters available for your account")
+		ctx.Printf("No clusters configured. Is your miren server running? Check server status with `miren server status`\n")
 		return ErrNoAutoConfigNeeded
 	}
 

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -520,7 +520,9 @@ func ServerStatus(ctx *Context, opts struct {
 	// Check if service file exists
 	if _, err := os.Stat(servicePath); os.IsNotExist(err) {
 		ctx.Warn("Service file not found at %s", servicePath)
-		ctx.Info("The miren service is not installed. Run 'sudo miren server install' to set it up.")
+		ctx.Info("The miren service is not installed. Run 'sudo miren server install' to set up a local server")
+		ctx.Info("or use Miren's hosted demo server: https://miren.dev/docs/getting-started#using-our-demo-cluster")
+
 		return nil
 	}
 


### PR DESCRIPTION
Giving the user some clearer guidance in CLI output when the Miren client cannot find the cluster / has no server installed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when no clusters are configured with guidance on checking server status
  * Enhanced setup instructions to include information about Miren's hosted demo server as an alternative option

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->