### PR TITLE
Fix authentication bypass in local/non-cloud mode

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -69,6 +69,9 @@ type CoordinatorConfig struct {
 	// Cloud authentication configuration
 	CloudAuth CloudAuthConfig `json:"cloud_auth" yaml:"cloud_auth"`
 
+	// NoAuth disables authentication entirely (for testing only)
+	NoAuth bool `json:"no_auth" yaml:"no_auth"`
+
 	Mem       *metrics.MemoryUsage
 	Cpu       *metrics.CPUUsage
 	HTTP      *metrics.HTTPMetrics
@@ -417,6 +420,10 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(authenticator))
 		c.Log.Info("cloud authentication enabled",
 			"cloud_url", authCloudURL)
+	} else if c.NoAuth {
+		// Use NoOpAuthenticator when explicitly disabled (for testing)
+		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(&rpc.NoOpAuthenticator{}))
+		c.Log.Warn("authentication disabled (NoOpAuthenticator)")
 	} else {
 		// Use LocalOnlyAuthenticator when cloud auth is not enabled
 		// This requires valid client certificates for all requests

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -417,6 +417,11 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(authenticator))
 		c.Log.Info("cloud authentication enabled",
 			"cloud_url", authCloudURL)
+	} else {
+		// Use LocalOnlyAuthenticator when cloud auth is not enabled
+		// This requires valid client certificates for all requests
+		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(&rpc.LocalOnlyAuthenticator{}))
+		c.Log.Info("local-only authentication enabled (client certificates required)")
 	}
 
 	rs, err := rpc.NewState(ctx, rpcOpts...)

--- a/components/coordinate/coordinator_test.go
+++ b/components/coordinate/coordinator_test.go
@@ -41,6 +41,7 @@ func TestCoordinatorParse(t *testing.T) {
 		EtcdEndpoints: []string{"etcd:2379"},     // Default etcd port
 		Prefix:        "/test/miren/" + t.Name(), // Unique prefix for this test
 		DataPath:      tempDir,                   // Use temp directory to prevent file leaks
+		NoAuth:        true,
 	}
 
 	// Create contexts

--- a/pkg/cloudauth/rpc_authenticator.go
+++ b/pkg/cloudauth/rpc_authenticator.go
@@ -114,7 +114,8 @@ func (a *RPCAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Requ
 	// Extract token from Authorization header
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
-		// No auth header - could be certificate-based auth
+		// No auth header - shouldn't happen because rpc server only calls
+		// this method if an auth header is present
 		return false, "", nil
 	}
 

--- a/pkg/cloudauth/rpc_authenticator.go
+++ b/pkg/cloudauth/rpc_authenticator.go
@@ -116,7 +116,7 @@ func (a *RPCAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Requ
 	if authHeader == "" {
 		// No auth header - shouldn't happen because rpc server only calls
 		// this method if an auth header is present
-		return false, "", nil
+		return false, "", fmt.Errorf("missing authorization header")
 	}
 
 	if !strings.HasPrefix(authHeader, "Bearer ") {

--- a/pkg/rpc/authenticator_test.go
+++ b/pkg/rpc/authenticator_test.go
@@ -84,18 +84,21 @@ func TestLocalOnlyAuthenticator(t *testing.T) {
 		hasCert        bool
 		expectAllowed  bool
 		expectIdentity string
+		expectError    bool
 	}{
 		{
 			name:          "rejects request without certificate",
 			authHeader:    "",
 			hasCert:       false,
 			expectAllowed: false,
+			expectError:   true,
 		},
 		{
 			name:          "rejects request with auth header but no certificate",
 			authHeader:    "Bearer token123",
 			hasCert:       false,
 			expectAllowed: false,
+			expectError:   true,
 		},
 		{
 			name:           "allows request with certificate",
@@ -142,7 +145,9 @@ func TestLocalOnlyAuthenticator(t *testing.T) {
 			}
 
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
+				if !tt.expectError {
+					t.Errorf("unexpected error: %v", err)
+				}
 			}
 			if allowed != tt.expectAllowed {
 				t.Errorf("expected allowed=%v, got %v", tt.expectAllowed, allowed)

--- a/pkg/rpc/authenticator_test.go
+++ b/pkg/rpc/authenticator_test.go
@@ -2,6 +2,9 @@ package rpc
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"net/http"
 	"testing"
 )
@@ -61,6 +64,91 @@ func TestAuthenticator(t *testing.T) {
 				if allowed && identity == "" {
 					t.Error("expected non-empty identity for allowed request")
 				}
+			}
+		})
+	}
+}
+
+// TestLocalOnlyAuthenticator verifies the LocalOnlyAuthenticator behavior
+func TestLocalOnlyAuthenticator(t *testing.T) {
+	// Create a mock certificate for testing
+	mockCert := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "test-client",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		authHeader     string
+		hasCert        bool
+		expectAllowed  bool
+		expectIdentity string
+	}{
+		{
+			name:          "rejects request without certificate",
+			authHeader:    "",
+			hasCert:       false,
+			expectAllowed: false,
+		},
+		{
+			name:          "rejects request with auth header but no certificate",
+			authHeader:    "Bearer token123",
+			hasCert:       false,
+			expectAllowed: false,
+		},
+		{
+			name:           "allows request with certificate",
+			authHeader:     "",
+			hasCert:        true,
+			expectAllowed:  true,
+			expectIdentity: "test-client",
+		},
+		{
+			name:           "allows request with certificate and auth header",
+			authHeader:     "Bearer token123",
+			hasCert:        true,
+			expectAllowed:  true,
+			expectIdentity: "test-client",
+		},
+	}
+
+	auth := &LocalOnlyAuthenticator{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+
+			if tt.hasCert {
+				req.TLS = &tls.ConnectionState{
+					PeerCertificates: []*x509.Certificate{mockCert},
+				}
+			}
+
+			var allowed bool
+			var identity string
+
+			if tt.authHeader != "" {
+				allowed, identity, err = auth.AuthenticateRequest(context.Background(), req)
+			} else {
+				allowed, identity, err = auth.NoAuthorization(context.Background(), req)
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if allowed != tt.expectAllowed {
+				t.Errorf("expected allowed=%v, got %v", tt.expectAllowed, allowed)
+			}
+			if tt.expectAllowed && identity != tt.expectIdentity {
+				t.Errorf("expected identity=%q, got %q", tt.expectIdentity, identity)
 			}
 		})
 	}

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -124,6 +124,7 @@ func TestServer(t *testing.T) error {
 		Mem:           &mem,
 		Cpu:           &cpu,
 		Logs:          &logs,
+		NoAuth:        true,
 	})
 
 	t.Log("Starting coordinator")

--- a/pkg/testutils/reg.go
+++ b/pkg/testutils/reg.go
@@ -160,6 +160,7 @@ func Registry(extra ...func(*asm.Registry)) (*asm.Registry, func()) {
 			DataPath:      filepath.Join(tempDir, "coordinator"),
 			Mem:           opts.Mem,
 			Cpu:           opts.CPU,
+			NoAuth:        true, // Disable authentication for tests
 		})
 
 		err = co.Start(ctx)


### PR DESCRIPTION
## Summary

- Add `LocalOnlyAuthenticator` that requires valid client certificates for all requests
- Use `LocalOnlyAuthenticator` when cloud auth is disabled instead of `NoOpAuthenticator`
- Previously, unauthenticated requests could access the API when cloud auth was not enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-certificate (local-only) authentication when cloud auth is not enabled.
  * Added a runtime option to fully disable authentication (intended for testing); startup logs emit clear warnings when auth is disabled.

* **Tests**
  * Added TLS/X.509 tests covering certificate acceptance and rejection across authentication scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->