### PR TITLE
ci: remove GitHub App token now that iso is public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,25 +114,7 @@ jobs:
         go-version-file: 'go.mod'
         cache: true
 
-    - name: Generate GitHub App token
-      id: generate-token
-      uses: actions/create-github-app-token@v2
-      with:
-        app-id: ${{ vars.MIREN_RFD_DEPLOY_GH_APP_ID }}
-        private-key: ${{ secrets.MIREN_RFD_DEPLOY_GH_APP_KEY }}
-        owner: mirendev
-
-    - name: Configure git for private modules
-      run: |
-        # Set GOPRIVATE to include miren.dev modules
-        echo "GOPRIVATE=miren.dev,github.com/mirendev" >> $GITHUB_ENV
-        # Configure git to use the token for GitHub access
-        git config --global url."https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-
     - name: Install iso
-      env:
-        GOPRIVATE: miren.dev
-        CGO_ENABLED: 0
       run: |
         go install miren.dev/iso/cmd/iso@latest
         echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,25 +86,7 @@ jobs:
         go-version-file: 'go.mod'
         cache: true
 
-    - name: Generate GitHub App token
-      id: generate-token
-      uses: actions/create-github-app-token@v2
-      with:
-        app-id: ${{ vars.MIREN_RFD_DEPLOY_GH_APP_ID }}
-        private-key: ${{ secrets.MIREN_RFD_DEPLOY_GH_APP_KEY }}
-        owner: mirendev
-
-    - name: Configure Git for private Go modules
-      run: |
-        # Set GOPRIVATE to include miren.dev modules
-        echo "GOPRIVATE=miren.dev,github.com/mirendev" >> $GITHUB_ENV
-        # Configure git to use the token for GitHub access
-        git config --global url."https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-
     - name: Install iso
-      env:
-        GOPRIVATE: miren.dev
-        CGO_ENABLED: 0
       run: |
         go install miren.dev/iso/cmd/iso@latest
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
@@ -218,25 +200,7 @@ jobs:
         go-version-file: 'go.mod'
         cache: true
 
-    - name: Generate GitHub App token
-      id: generate-token
-      uses: actions/create-github-app-token@v2
-      with:
-        app-id: ${{ vars.MIREN_RFD_DEPLOY_GH_APP_ID }}
-        private-key: ${{ secrets.MIREN_RFD_DEPLOY_GH_APP_KEY }}
-        owner: mirendev
-
-    - name: Configure Git for private Go modules
-      run: |
-        # Set GOPRIVATE to include miren.dev modules
-        echo "GOPRIVATE=miren.dev,github.com/mirendev" >> $GITHUB_ENV
-        # Configure git to use the token for GitHub access
-        git config --global url."https://x-access-token:${{ steps.generate-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-
     - name: Install iso
-      env:
-        GOPRIVATE: miren.dev
-        CGO_ENABLED: 0
       run: |
         go install miren.dev/iso/cmd/iso@latest
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Summary
- Remove GitHub App token generation from test and release workflows
- `miren.dev/iso` is now public, so no authentication needed to `go install` it

## Context
Fork PRs were failing CI because GitHub Actions doesn't expose secrets to `pull_request` events from forks (for good security reasons). The only secret we needed was for accessing the private `iso` module.

Now that iso is public, fork PRs will get full CI coverage (tests, e2e, lint, build).

## Cleanup
After merging, these can be removed from repo settings:
- `vars.MIREN_RFD_DEPLOY_GH_APP_ID`
- `secrets.MIREN_RFD_DEPLOY_GH_APP_KEY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD workflows by removing token-based authentication configuration for private module handling in release and test pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->