### PR TITLE
Improve CLI error messages with actionable guidance

### DIFF
--- a/cli/commands/cluster.go
+++ b/cli/commands/cluster.go
@@ -28,7 +28,7 @@ func ClusterList(ctx *Context, opts struct {
 				}
 				return PrintJSON([]ClusterInfo{})
 			}
-			ctx.Printf("No clusters configured\n")
+			ctx.Printf("No clusters configured. Is your miren server running? Check server status with `miren server status`\n")
 			ctx.Printf("\nUse 'miren cluster add' to add a cluster\n")
 			return nil
 		}

--- a/cli/commands/login.go
+++ b/cli/commands/login.go
@@ -620,6 +620,7 @@ func autoConfigureCluster(ctx *Context, identityName, cloudURL string, keyPair *
 
 	if len(validClusters) == 0 {
 		ctx.Info("No clusters available for your account")
+		ctx.Printf("No clusters configured. Is your miren server running? Check server status with `miren server status`\n")
 		return ErrNoAutoConfigNeeded
 	}
 

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -520,7 +520,9 @@ func ServerStatus(ctx *Context, opts struct {
 	// Check if service file exists
 	if _, err := os.Stat(servicePath); os.IsNotExist(err) {
 		ctx.Warn("Service file not found at %s", servicePath)
-		ctx.Info("The miren service is not installed. Run 'sudo miren server install' to set it up.")
+		ctx.Info("The miren service is not installed. Run 'sudo miren server install' to set up a local server")
+		ctx.Info("or use Miren's hosted demo server: https://miren.dev/docs/getting-started#using-our-demo-cluster")
+
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- Provides specific, user-friendly error messages when RPC calls fail
- Guides users to the most likely fix for each error type
- Replaces confusing network timeout errors with clear instructions

## Error outputs

**Network Error (Server Not Responding)**
```
W Server not responding at 127.0.0.1:8443
    → Check if miren is running: sudo systemctl status miren
    → Start it: sudo systemctl start miren
```

**TLS/Certificate Error**
```
W TLS/certificate error connecting to 127.0.0.1:8443
    → The server's certificate may have changed
    → Re-add the cluster: miren cluster add
```

**401 Unauthorized**
```
W Access denied to cluster 'my-cluster'
    → Check your auth: miren whoami
    → Try logging out and back in: miren logout && miren login
```

**403 Forbidden**
```
W Permission denied
    → You're authenticated but don't have permission for this action
    → Contact your cluster administrator
```

**5xx Server Error**
```
W Server error (502)
    → The server is having issues
    → Check server logs: sudo journalctl -u miren -n 50
```

## Test plan

- [ ] Test with server stopped - should show network error guidance
- [ ] Test with invalid credentials - should show 401 guidance
- [ ] Test with server returning 5xx - should show server error guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error messages and guidance for server connectivity issues.
  * Added prompts to check server status when no clusters are configured.
  * Improved HTTP error handling with actionable feedback for authentication, permission, and server errors.
  * Added reference to hosted demo server as an alternative setup option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->