### PR TITLE
Add workflow to update homebrew when we release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -746,9 +746,18 @@ jobs:
     # Only update homebrew tap for stable version tags (not prereleases, not branch builds)
     if: ${{ startsWith(github.event.workflow_run.head_branch, 'v') && !contains(github.event.workflow_run.head_branch, '-') }}
     steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_KEY }}
+          owner: mirendev
+          repositories: homebrew-tap
+
       - name: Trigger homebrew-tap update
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           VERSION="${{ github.event.workflow_run.head_branch }}"
           echo "Triggering homebrew-tap update for $VERSION..."
@@ -791,7 +800,7 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "You can manually update the tap by running: `gh workflow run update-formula.yml -R mirendev/homebrew-tap -f version=${{ github.event.workflow_run.head_branch }}`"
+                      "text": "You can manually update the tap by running: `gh workflow run update-cask.yml -R mirendev/homebrew-tap -f version=${{ github.event.workflow_run.head_branch }}`"
                     }
                   ]
                 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -740,3 +740,63 @@ jobs:
           }
           EOF
 
+  update-homebrew-tap:
+    needs: [upload-to-miren]
+    runs-on: ubuntu-latest
+    # Only update homebrew tap for stable version tags (not prereleases, not branch builds)
+    if: ${{ startsWith(github.event.workflow_run.head_branch, 'v') && !contains(github.event.workflow_run.head_branch, '-') }}
+    steps:
+      - name: Trigger homebrew-tap update
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ github.event.workflow_run.head_branch }}"
+          echo "Triggering homebrew-tap update for $VERSION..."
+
+          gh workflow run update-cask.yml \
+            --repo mirendev/homebrew-tap \
+            -f version="$VERSION"
+
+          echo "Homebrew tap update triggered for $VERSION"
+
+      - name: Send Slack notification on homebrew update failure
+        if: failure()
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ vars.SLACK_CHANNEL_ID }}",
+              "text": "⚠️ Homebrew tap update failed for ${{ github.event.workflow_run.head_branch }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "⚠️ *Homebrew tap update failed*\nRelease artifacts were uploaded successfully, but the homebrew tap update failed."
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Version:*\n`${{ github.event.workflow_run.head_branch }}`"
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "You can manually update the tap by running: `gh workflow run update-formula.yml -R mirendev/homebrew-tap -f version=${{ github.event.workflow_run.head_branch }}`"
+                    }
+                  ]
+                }
+              ],
+              "unfurl_links": false,
+              "unfurl_media": false
+            }
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now automatically updates the Homebrew tap for stable releases (v* tags without prereleases).
  * Failing tap updates send a Slack alert with details and manual remediation steps.
  * Deployment flow unchanged otherwise; improves automation and notification for stable version rollouts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->