### PR TITLE
lsvd: use Go File.Write instead of raw unix.Write for NBD responses

### DIFF
--- a/lsvd/nbd.go
+++ b/lsvd/nbd.go
@@ -153,8 +153,6 @@ func (n *nbdWrapper) ReadIntoConn(b []byte, off int64, output *os.File) (bool, e
 		return false, err
 	}
 
-	wfd := output.Fd()
-
 	var written int
 
 	left := len(b)
@@ -164,9 +162,9 @@ func (n *nbdWrapper) ReadIntoConn(b []byte, off int64, output *os.File) (bool, e
 
 		off := 0
 		for left > 0 {
-			written, err = unix.Write(int(wfd), b[off:])
+			written, err = output.Write(b[off:])
 			if err != nil {
-				n.log.Error("error sending data via write(2)", "error", err)
+				n.log.Error("error sending data via Write", "error", err)
 				return true, nil
 			}
 
@@ -184,6 +182,7 @@ func (n *nbdWrapper) ReadIntoConn(b []byte, off int64, output *os.File) (bool, e
 		return true, nil
 	}
 
+	wfd := output.Fd()
 	rfd := cps.fd.Fd()
 	sendfileResponses.Inc()
 


### PR DESCRIPTION
## Summary

- Replace `unix.Write` syscall with Go's `*os.File.Write()` for NBD read responses
- Go's Write handles transient errors (EAGAIN) with internal retry logic, which the raw syscall does not

## Context

NBD transport errors like "resource temporarily unavailable" could cause the disk-lease controller to hang when socket buffer pressure led to EAGAIN errors that weren't being retried.

The sendfile path is unchanged since `unix.Sendfile` is significantly faster and we haven't observed the same issue there yet.

## Test plan

- [x] Deployed to miren-garden and verified disk provisioning/mounting works
- [x] Monitored logs for NBD errors during disk operations - none observed
- [ ] Long-term monitoring to verify fix under load conditions that previously triggered the issue

Part of: MIR-578