### PR TITLE
Add debug ipalloc commands for IP lease inspection and cleanup

### DIFF
--- a/api/debug/debug_v1alpha/rpc.gen.go
+++ b/api/debug/debug_v1alpha/rpc.gen.go
@@ -15,6 +15,7 @@ type iPLeaseData struct {
 	Subnet     *string             `cbor:"1,keyasint,omitempty" json:"subnet,omitempty"`
 	Reserved   *bool               `cbor:"2,keyasint,omitempty" json:"reserved,omitempty"`
 	ReleasedAt *standard.Timestamp `cbor:"3,keyasint,omitempty" json:"released_at,omitempty"`
+	SandboxId  *string             `cbor:"4,keyasint,omitempty" json:"sandbox_id,omitempty"`
 }
 
 type IPLease struct {
@@ -76,6 +77,21 @@ func (v *IPLease) ReleasedAt() *standard.Timestamp {
 
 func (v *IPLease) SetReleasedAt(released_at *standard.Timestamp) {
 	v.data.ReleasedAt = released_at
+}
+
+func (v *IPLease) HasSandboxId() bool {
+	return v.data.SandboxId != nil
+}
+
+func (v *IPLease) SandboxId() string {
+	if v.data.SandboxId == nil {
+		return ""
+	}
+	return *v.data.SandboxId
+}
+
+func (v *IPLease) SetSandboxId(sandbox_id string) {
+	v.data.SandboxId = &sandbox_id
 }
 
 func (v *IPLease) MarshalCBOR() ([]byte, error) {

--- a/api/debug/debug_v1alpha/rpc.gen.go
+++ b/api/debug/debug_v1alpha/rpc.gen.go
@@ -1,0 +1,1091 @@
+package debug_v1alpha
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+
+	"github.com/fxamacker/cbor/v2"
+	rpc "miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+type iPLeaseData struct {
+	Ip         *string             `cbor:"0,keyasint,omitempty" json:"ip,omitempty"`
+	Subnet     *string             `cbor:"1,keyasint,omitempty" json:"subnet,omitempty"`
+	Reserved   *bool               `cbor:"2,keyasint,omitempty" json:"reserved,omitempty"`
+	ReleasedAt *standard.Timestamp `cbor:"3,keyasint,omitempty" json:"released_at,omitempty"`
+}
+
+type IPLease struct {
+	data iPLeaseData
+}
+
+func (v *IPLease) HasIp() bool {
+	return v.data.Ip != nil
+}
+
+func (v *IPLease) Ip() string {
+	if v.data.Ip == nil {
+		return ""
+	}
+	return *v.data.Ip
+}
+
+func (v *IPLease) SetIp(ip string) {
+	v.data.Ip = &ip
+}
+
+func (v *IPLease) HasSubnet() bool {
+	return v.data.Subnet != nil
+}
+
+func (v *IPLease) Subnet() string {
+	if v.data.Subnet == nil {
+		return ""
+	}
+	return *v.data.Subnet
+}
+
+func (v *IPLease) SetSubnet(subnet string) {
+	v.data.Subnet = &subnet
+}
+
+func (v *IPLease) HasReserved() bool {
+	return v.data.Reserved != nil
+}
+
+func (v *IPLease) Reserved() bool {
+	if v.data.Reserved == nil {
+		return false
+	}
+	return *v.data.Reserved
+}
+
+func (v *IPLease) SetReserved(reserved bool) {
+	v.data.Reserved = &reserved
+}
+
+func (v *IPLease) HasReleasedAt() bool {
+	return v.data.ReleasedAt != nil
+}
+
+func (v *IPLease) ReleasedAt() *standard.Timestamp {
+	return v.data.ReleasedAt
+}
+
+func (v *IPLease) SetReleasedAt(released_at *standard.Timestamp) {
+	v.data.ReleasedAt = released_at
+}
+
+func (v *IPLease) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPLease) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPLease) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPLease) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type subnetStatusData struct {
+	Subnet   *string `cbor:"0,keyasint,omitempty" json:"subnet,omitempty"`
+	Total    *int32  `cbor:"1,keyasint,omitempty" json:"total,omitempty"`
+	Reserved *int32  `cbor:"2,keyasint,omitempty" json:"reserved,omitempty"`
+	Released *int32  `cbor:"3,keyasint,omitempty" json:"released,omitempty"`
+	Stuck    *int32  `cbor:"4,keyasint,omitempty" json:"stuck,omitempty"`
+	Capacity *int32  `cbor:"5,keyasint,omitempty" json:"capacity,omitempty"`
+}
+
+type SubnetStatus struct {
+	data subnetStatusData
+}
+
+func (v *SubnetStatus) HasSubnet() bool {
+	return v.data.Subnet != nil
+}
+
+func (v *SubnetStatus) Subnet() string {
+	if v.data.Subnet == nil {
+		return ""
+	}
+	return *v.data.Subnet
+}
+
+func (v *SubnetStatus) SetSubnet(subnet string) {
+	v.data.Subnet = &subnet
+}
+
+func (v *SubnetStatus) HasTotal() bool {
+	return v.data.Total != nil
+}
+
+func (v *SubnetStatus) Total() int32 {
+	if v.data.Total == nil {
+		return 0
+	}
+	return *v.data.Total
+}
+
+func (v *SubnetStatus) SetTotal(total int32) {
+	v.data.Total = &total
+}
+
+func (v *SubnetStatus) HasReserved() bool {
+	return v.data.Reserved != nil
+}
+
+func (v *SubnetStatus) Reserved() int32 {
+	if v.data.Reserved == nil {
+		return 0
+	}
+	return *v.data.Reserved
+}
+
+func (v *SubnetStatus) SetReserved(reserved int32) {
+	v.data.Reserved = &reserved
+}
+
+func (v *SubnetStatus) HasReleased() bool {
+	return v.data.Released != nil
+}
+
+func (v *SubnetStatus) Released() int32 {
+	if v.data.Released == nil {
+		return 0
+	}
+	return *v.data.Released
+}
+
+func (v *SubnetStatus) SetReleased(released int32) {
+	v.data.Released = &released
+}
+
+func (v *SubnetStatus) HasStuck() bool {
+	return v.data.Stuck != nil
+}
+
+func (v *SubnetStatus) Stuck() int32 {
+	if v.data.Stuck == nil {
+		return 0
+	}
+	return *v.data.Stuck
+}
+
+func (v *SubnetStatus) SetStuck(stuck int32) {
+	v.data.Stuck = &stuck
+}
+
+func (v *SubnetStatus) HasCapacity() bool {
+	return v.data.Capacity != nil
+}
+
+func (v *SubnetStatus) Capacity() int32 {
+	if v.data.Capacity == nil {
+		return 0
+	}
+	return *v.data.Capacity
+}
+
+func (v *SubnetStatus) SetCapacity(capacity int32) {
+	v.data.Capacity = &capacity
+}
+
+func (v *SubnetStatus) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *SubnetStatus) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *SubnetStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *SubnetStatus) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocListLeasesArgsData struct {
+	Subnet       *string `cbor:"0,keyasint,omitempty" json:"subnet,omitempty"`
+	ReservedOnly *bool   `cbor:"1,keyasint,omitempty" json:"reserved_only,omitempty"`
+	ReleasedOnly *bool   `cbor:"2,keyasint,omitempty" json:"released_only,omitempty"`
+	StuckOnly    *bool   `cbor:"3,keyasint,omitempty" json:"stuck_only,omitempty"`
+}
+
+type IPAllocListLeasesArgs struct {
+	call rpc.Call
+	data iPAllocListLeasesArgsData
+}
+
+func (v *IPAllocListLeasesArgs) HasSubnet() bool {
+	return v.data.Subnet != nil
+}
+
+func (v *IPAllocListLeasesArgs) Subnet() string {
+	if v.data.Subnet == nil {
+		return ""
+	}
+	return *v.data.Subnet
+}
+
+func (v *IPAllocListLeasesArgs) HasReservedOnly() bool {
+	return v.data.ReservedOnly != nil
+}
+
+func (v *IPAllocListLeasesArgs) ReservedOnly() bool {
+	if v.data.ReservedOnly == nil {
+		return false
+	}
+	return *v.data.ReservedOnly
+}
+
+func (v *IPAllocListLeasesArgs) HasReleasedOnly() bool {
+	return v.data.ReleasedOnly != nil
+}
+
+func (v *IPAllocListLeasesArgs) ReleasedOnly() bool {
+	if v.data.ReleasedOnly == nil {
+		return false
+	}
+	return *v.data.ReleasedOnly
+}
+
+func (v *IPAllocListLeasesArgs) HasStuckOnly() bool {
+	return v.data.StuckOnly != nil
+}
+
+func (v *IPAllocListLeasesArgs) StuckOnly() bool {
+	if v.data.StuckOnly == nil {
+		return false
+	}
+	return *v.data.StuckOnly
+}
+
+func (v *IPAllocListLeasesArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocListLeasesArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocListLeasesArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocListLeasesArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocListLeasesResultsData struct {
+	Leases *[]*IPLease `cbor:"0,keyasint,omitempty" json:"leases,omitempty"`
+}
+
+type IPAllocListLeasesResults struct {
+	call rpc.Call
+	data iPAllocListLeasesResultsData
+}
+
+func (v *IPAllocListLeasesResults) SetLeases(leases []*IPLease) {
+	x := slices.Clone(leases)
+	v.data.Leases = &x
+}
+
+func (v *IPAllocListLeasesResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocListLeasesResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocListLeasesResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocListLeasesResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocStatusArgsData struct{}
+
+type IPAllocStatusArgs struct {
+	call rpc.Call
+	data iPAllocStatusArgsData
+}
+
+func (v *IPAllocStatusArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocStatusArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocStatusArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocStatusArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocStatusResultsData struct {
+	Subnets *[]*SubnetStatus `cbor:"0,keyasint,omitempty" json:"subnets,omitempty"`
+}
+
+type IPAllocStatusResults struct {
+	call rpc.Call
+	data iPAllocStatusResultsData
+}
+
+func (v *IPAllocStatusResults) SetSubnets(subnets []*SubnetStatus) {
+	x := slices.Clone(subnets)
+	v.data.Subnets = &x
+}
+
+func (v *IPAllocStatusResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocStatusResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocStatusResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocStatusResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocReleaseIPArgsData struct {
+	Ip *string `cbor:"0,keyasint,omitempty" json:"ip,omitempty"`
+}
+
+type IPAllocReleaseIPArgs struct {
+	call rpc.Call
+	data iPAllocReleaseIPArgsData
+}
+
+func (v *IPAllocReleaseIPArgs) HasIp() bool {
+	return v.data.Ip != nil
+}
+
+func (v *IPAllocReleaseIPArgs) Ip() string {
+	if v.data.Ip == nil {
+		return ""
+	}
+	return *v.data.Ip
+}
+
+func (v *IPAllocReleaseIPArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseIPArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocReleaseIPArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseIPArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocReleaseIPResultsData struct {
+	Released *bool `cbor:"0,keyasint,omitempty" json:"released,omitempty"`
+}
+
+type IPAllocReleaseIPResults struct {
+	call rpc.Call
+	data iPAllocReleaseIPResultsData
+}
+
+func (v *IPAllocReleaseIPResults) SetReleased(released bool) {
+	v.data.Released = &released
+}
+
+func (v *IPAllocReleaseIPResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseIPResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocReleaseIPResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseIPResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocReleaseSubnetArgsData struct {
+	Subnet *string `cbor:"0,keyasint,omitempty" json:"subnet,omitempty"`
+}
+
+type IPAllocReleaseSubnetArgs struct {
+	call rpc.Call
+	data iPAllocReleaseSubnetArgsData
+}
+
+func (v *IPAllocReleaseSubnetArgs) HasSubnet() bool {
+	return v.data.Subnet != nil
+}
+
+func (v *IPAllocReleaseSubnetArgs) Subnet() string {
+	if v.data.Subnet == nil {
+		return ""
+	}
+	return *v.data.Subnet
+}
+
+func (v *IPAllocReleaseSubnetArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseSubnetArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocReleaseSubnetArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseSubnetArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocReleaseSubnetResultsData struct {
+	Count *int32 `cbor:"0,keyasint,omitempty" json:"count,omitempty"`
+}
+
+type IPAllocReleaseSubnetResults struct {
+	call rpc.Call
+	data iPAllocReleaseSubnetResultsData
+}
+
+func (v *IPAllocReleaseSubnetResults) SetCount(count int32) {
+	v.data.Count = &count
+}
+
+func (v *IPAllocReleaseSubnetResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseSubnetResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocReleaseSubnetResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseSubnetResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocReleaseAllArgsData struct{}
+
+type IPAllocReleaseAllArgs struct {
+	call rpc.Call
+	data iPAllocReleaseAllArgsData
+}
+
+func (v *IPAllocReleaseAllArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseAllArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocReleaseAllArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseAllArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocReleaseAllResultsData struct {
+	Count *int32 `cbor:"0,keyasint,omitempty" json:"count,omitempty"`
+}
+
+type IPAllocReleaseAllResults struct {
+	call rpc.Call
+	data iPAllocReleaseAllResultsData
+}
+
+func (v *IPAllocReleaseAllResults) SetCount(count int32) {
+	v.data.Count = &count
+}
+
+func (v *IPAllocReleaseAllResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseAllResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocReleaseAllResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocReleaseAllResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocGcArgsData struct {
+	Subnet *string `cbor:"0,keyasint,omitempty" json:"subnet,omitempty"`
+	DryRun *bool   `cbor:"1,keyasint,omitempty" json:"dry_run,omitempty"`
+}
+
+type IPAllocGcArgs struct {
+	call rpc.Call
+	data iPAllocGcArgsData
+}
+
+func (v *IPAllocGcArgs) HasSubnet() bool {
+	return v.data.Subnet != nil
+}
+
+func (v *IPAllocGcArgs) Subnet() string {
+	if v.data.Subnet == nil {
+		return ""
+	}
+	return *v.data.Subnet
+}
+
+func (v *IPAllocGcArgs) HasDryRun() bool {
+	return v.data.DryRun != nil
+}
+
+func (v *IPAllocGcArgs) DryRun() bool {
+	if v.data.DryRun == nil {
+		return false
+	}
+	return *v.data.DryRun
+}
+
+func (v *IPAllocGcArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocGcArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocGcArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocGcArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type iPAllocGcResultsData struct {
+	OrphanedIps   *[]string `cbor:"0,keyasint,omitempty" json:"orphaned_ips,omitempty"`
+	ReleasedCount *int32    `cbor:"1,keyasint,omitempty" json:"released_count,omitempty"`
+}
+
+type IPAllocGcResults struct {
+	call rpc.Call
+	data iPAllocGcResultsData
+}
+
+func (v *IPAllocGcResults) SetOrphanedIps(orphaned_ips []string) {
+	x := slices.Clone(orphaned_ips)
+	v.data.OrphanedIps = &x
+}
+
+func (v *IPAllocGcResults) SetReleasedCount(released_count int32) {
+	v.data.ReleasedCount = &released_count
+}
+
+func (v *IPAllocGcResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *IPAllocGcResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *IPAllocGcResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *IPAllocGcResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type IPAllocListLeases struct {
+	rpc.Call
+	args    IPAllocListLeasesArgs
+	results IPAllocListLeasesResults
+}
+
+func (t *IPAllocListLeases) Args() *IPAllocListLeasesArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *IPAllocListLeases) Results() *IPAllocListLeasesResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type IPAllocStatus struct {
+	rpc.Call
+	args    IPAllocStatusArgs
+	results IPAllocStatusResults
+}
+
+func (t *IPAllocStatus) Args() *IPAllocStatusArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *IPAllocStatus) Results() *IPAllocStatusResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type IPAllocReleaseIP struct {
+	rpc.Call
+	args    IPAllocReleaseIPArgs
+	results IPAllocReleaseIPResults
+}
+
+func (t *IPAllocReleaseIP) Args() *IPAllocReleaseIPArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *IPAllocReleaseIP) Results() *IPAllocReleaseIPResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type IPAllocReleaseSubnet struct {
+	rpc.Call
+	args    IPAllocReleaseSubnetArgs
+	results IPAllocReleaseSubnetResults
+}
+
+func (t *IPAllocReleaseSubnet) Args() *IPAllocReleaseSubnetArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *IPAllocReleaseSubnet) Results() *IPAllocReleaseSubnetResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type IPAllocReleaseAll struct {
+	rpc.Call
+	args    IPAllocReleaseAllArgs
+	results IPAllocReleaseAllResults
+}
+
+func (t *IPAllocReleaseAll) Args() *IPAllocReleaseAllArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *IPAllocReleaseAll) Results() *IPAllocReleaseAllResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type IPAllocGc struct {
+	rpc.Call
+	args    IPAllocGcArgs
+	results IPAllocGcResults
+}
+
+func (t *IPAllocGc) Args() *IPAllocGcArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *IPAllocGc) Results() *IPAllocGcResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type IPAlloc interface {
+	ListLeases(ctx context.Context, state *IPAllocListLeases) error
+	Status(ctx context.Context, state *IPAllocStatus) error
+	ReleaseIP(ctx context.Context, state *IPAllocReleaseIP) error
+	ReleaseSubnet(ctx context.Context, state *IPAllocReleaseSubnet) error
+	ReleaseAll(ctx context.Context, state *IPAllocReleaseAll) error
+	Gc(ctx context.Context, state *IPAllocGc) error
+}
+
+type reexportIPAlloc struct {
+	client rpc.Client
+}
+
+func (reexportIPAlloc) ListLeases(ctx context.Context, state *IPAllocListLeases) error {
+	panic("not implemented")
+}
+
+func (reexportIPAlloc) Status(ctx context.Context, state *IPAllocStatus) error {
+	panic("not implemented")
+}
+
+func (reexportIPAlloc) ReleaseIP(ctx context.Context, state *IPAllocReleaseIP) error {
+	panic("not implemented")
+}
+
+func (reexportIPAlloc) ReleaseSubnet(ctx context.Context, state *IPAllocReleaseSubnet) error {
+	panic("not implemented")
+}
+
+func (reexportIPAlloc) ReleaseAll(ctx context.Context, state *IPAllocReleaseAll) error {
+	panic("not implemented")
+}
+
+func (reexportIPAlloc) Gc(ctx context.Context, state *IPAllocGc) error {
+	panic("not implemented")
+}
+
+func (t reexportIPAlloc) CapabilityClient() rpc.Client {
+	return t.client
+}
+
+func AdaptIPAlloc(t IPAlloc) *rpc.Interface {
+	methods := []rpc.Method{
+		{
+			Name:          "listLeases",
+			InterfaceName: "IPAlloc",
+			Index:         0,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ListLeases(ctx, &IPAllocListLeases{Call: call})
+			},
+		},
+		{
+			Name:          "status",
+			InterfaceName: "IPAlloc",
+			Index:         0,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.Status(ctx, &IPAllocStatus{Call: call})
+			},
+		},
+		{
+			Name:          "releaseIP",
+			InterfaceName: "IPAlloc",
+			Index:         0,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ReleaseIP(ctx, &IPAllocReleaseIP{Call: call})
+			},
+		},
+		{
+			Name:          "releaseSubnet",
+			InterfaceName: "IPAlloc",
+			Index:         0,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ReleaseSubnet(ctx, &IPAllocReleaseSubnet{Call: call})
+			},
+		},
+		{
+			Name:          "releaseAll",
+			InterfaceName: "IPAlloc",
+			Index:         0,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ReleaseAll(ctx, &IPAllocReleaseAll{Call: call})
+			},
+		},
+		{
+			Name:          "gc",
+			InterfaceName: "IPAlloc",
+			Index:         0,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.Gc(ctx, &IPAllocGc{Call: call})
+			},
+		},
+	}
+
+	return rpc.NewInterface(methods, t)
+}
+
+type IPAllocClient struct {
+	rpc.Client
+}
+
+func NewIPAllocClient(client rpc.Client) *IPAllocClient {
+	return &IPAllocClient{Client: client}
+}
+
+func (c IPAllocClient) Export() IPAlloc {
+	return reexportIPAlloc{client: c.Client}
+}
+
+type IPAllocClientListLeasesResults struct {
+	client rpc.Client
+	data   iPAllocListLeasesResultsData
+}
+
+func (v *IPAllocClientListLeasesResults) HasLeases() bool {
+	return v.data.Leases != nil
+}
+
+func (v *IPAllocClientListLeasesResults) Leases() []*IPLease {
+	if v.data.Leases == nil {
+		return nil
+	}
+	return *v.data.Leases
+}
+
+func (v IPAllocClient) ListLeases(ctx context.Context, subnet string, reserved_only bool, released_only bool, stuck_only bool) (*IPAllocClientListLeasesResults, error) {
+	args := IPAllocListLeasesArgs{}
+	args.data.Subnet = &subnet
+	args.data.ReservedOnly = &reserved_only
+	args.data.ReleasedOnly = &released_only
+	args.data.StuckOnly = &stuck_only
+
+	var ret iPAllocListLeasesResultsData
+
+	err := v.Call(ctx, "listLeases", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IPAllocClientListLeasesResults{client: v.Client, data: ret}, nil
+}
+
+type IPAllocClientStatusResults struct {
+	client rpc.Client
+	data   iPAllocStatusResultsData
+}
+
+func (v *IPAllocClientStatusResults) HasSubnets() bool {
+	return v.data.Subnets != nil
+}
+
+func (v *IPAllocClientStatusResults) Subnets() []*SubnetStatus {
+	if v.data.Subnets == nil {
+		return nil
+	}
+	return *v.data.Subnets
+}
+
+func (v IPAllocClient) Status(ctx context.Context) (*IPAllocClientStatusResults, error) {
+	args := IPAllocStatusArgs{}
+
+	var ret iPAllocStatusResultsData
+
+	err := v.Call(ctx, "status", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IPAllocClientStatusResults{client: v.Client, data: ret}, nil
+}
+
+type IPAllocClientReleaseIPResults struct {
+	client rpc.Client
+	data   iPAllocReleaseIPResultsData
+}
+
+func (v *IPAllocClientReleaseIPResults) HasReleased() bool {
+	return v.data.Released != nil
+}
+
+func (v *IPAllocClientReleaseIPResults) Released() bool {
+	if v.data.Released == nil {
+		return false
+	}
+	return *v.data.Released
+}
+
+func (v IPAllocClient) ReleaseIP(ctx context.Context, ip string) (*IPAllocClientReleaseIPResults, error) {
+	args := IPAllocReleaseIPArgs{}
+	args.data.Ip = &ip
+
+	var ret iPAllocReleaseIPResultsData
+
+	err := v.Call(ctx, "releaseIP", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IPAllocClientReleaseIPResults{client: v.Client, data: ret}, nil
+}
+
+type IPAllocClientReleaseSubnetResults struct {
+	client rpc.Client
+	data   iPAllocReleaseSubnetResultsData
+}
+
+func (v *IPAllocClientReleaseSubnetResults) HasCount() bool {
+	return v.data.Count != nil
+}
+
+func (v *IPAllocClientReleaseSubnetResults) Count() int32 {
+	if v.data.Count == nil {
+		return 0
+	}
+	return *v.data.Count
+}
+
+func (v IPAllocClient) ReleaseSubnet(ctx context.Context, subnet string) (*IPAllocClientReleaseSubnetResults, error) {
+	args := IPAllocReleaseSubnetArgs{}
+	args.data.Subnet = &subnet
+
+	var ret iPAllocReleaseSubnetResultsData
+
+	err := v.Call(ctx, "releaseSubnet", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IPAllocClientReleaseSubnetResults{client: v.Client, data: ret}, nil
+}
+
+type IPAllocClientReleaseAllResults struct {
+	client rpc.Client
+	data   iPAllocReleaseAllResultsData
+}
+
+func (v *IPAllocClientReleaseAllResults) HasCount() bool {
+	return v.data.Count != nil
+}
+
+func (v *IPAllocClientReleaseAllResults) Count() int32 {
+	if v.data.Count == nil {
+		return 0
+	}
+	return *v.data.Count
+}
+
+func (v IPAllocClient) ReleaseAll(ctx context.Context) (*IPAllocClientReleaseAllResults, error) {
+	args := IPAllocReleaseAllArgs{}
+
+	var ret iPAllocReleaseAllResultsData
+
+	err := v.Call(ctx, "releaseAll", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IPAllocClientReleaseAllResults{client: v.Client, data: ret}, nil
+}
+
+type IPAllocClientGcResults struct {
+	client rpc.Client
+	data   iPAllocGcResultsData
+}
+
+func (v *IPAllocClientGcResults) HasOrphanedIps() bool {
+	return v.data.OrphanedIps != nil
+}
+
+func (v *IPAllocClientGcResults) OrphanedIps() []string {
+	if v.data.OrphanedIps == nil {
+		return nil
+	}
+	return *v.data.OrphanedIps
+}
+
+func (v *IPAllocClientGcResults) HasReleasedCount() bool {
+	return v.data.ReleasedCount != nil
+}
+
+func (v *IPAllocClientGcResults) ReleasedCount() int32 {
+	if v.data.ReleasedCount == nil {
+		return 0
+	}
+	return *v.data.ReleasedCount
+}
+
+func (v IPAllocClient) Gc(ctx context.Context, subnet string, dry_run bool) (*IPAllocClientGcResults, error) {
+	args := IPAllocGcArgs{}
+	args.data.Subnet = &subnet
+	args.data.DryRun = &dry_run
+
+	var ret iPAllocGcResultsData
+
+	err := v.Call(ctx, "gc", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &IPAllocClientGcResults{client: v.Client, data: ret}, nil
+}

--- a/api/debug/debug_v1alpha/rpc.gen.go
+++ b/api/debug/debug_v1alpha/rpc.gen.go
@@ -197,421 +197,421 @@ func (v *SubnetStatus) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocListLeasesArgsData struct {
+type netDBListLeasesArgsData struct {
 	Subnet       *string `cbor:"0,keyasint,omitempty" json:"subnet,omitempty"`
 	ReservedOnly *bool   `cbor:"1,keyasint,omitempty" json:"reserved_only,omitempty"`
 	ReleasedOnly *bool   `cbor:"2,keyasint,omitempty" json:"released_only,omitempty"`
 }
 
-type IPAllocListLeasesArgs struct {
+type NetDBListLeasesArgs struct {
 	call rpc.Call
-	data iPAllocListLeasesArgsData
+	data netDBListLeasesArgsData
 }
 
-func (v *IPAllocListLeasesArgs) HasSubnet() bool {
+func (v *NetDBListLeasesArgs) HasSubnet() bool {
 	return v.data.Subnet != nil
 }
 
-func (v *IPAllocListLeasesArgs) Subnet() string {
+func (v *NetDBListLeasesArgs) Subnet() string {
 	if v.data.Subnet == nil {
 		return ""
 	}
 	return *v.data.Subnet
 }
 
-func (v *IPAllocListLeasesArgs) HasReservedOnly() bool {
+func (v *NetDBListLeasesArgs) HasReservedOnly() bool {
 	return v.data.ReservedOnly != nil
 }
 
-func (v *IPAllocListLeasesArgs) ReservedOnly() bool {
+func (v *NetDBListLeasesArgs) ReservedOnly() bool {
 	if v.data.ReservedOnly == nil {
 		return false
 	}
 	return *v.data.ReservedOnly
 }
 
-func (v *IPAllocListLeasesArgs) HasReleasedOnly() bool {
+func (v *NetDBListLeasesArgs) HasReleasedOnly() bool {
 	return v.data.ReleasedOnly != nil
 }
 
-func (v *IPAllocListLeasesArgs) ReleasedOnly() bool {
+func (v *NetDBListLeasesArgs) ReleasedOnly() bool {
 	if v.data.ReleasedOnly == nil {
 		return false
 	}
 	return *v.data.ReleasedOnly
 }
 
-func (v *IPAllocListLeasesArgs) MarshalCBOR() ([]byte, error) {
+func (v *NetDBListLeasesArgs) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocListLeasesArgs) UnmarshalCBOR(data []byte) error {
+func (v *NetDBListLeasesArgs) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocListLeasesArgs) MarshalJSON() ([]byte, error) {
+func (v *NetDBListLeasesArgs) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocListLeasesArgs) UnmarshalJSON(data []byte) error {
+func (v *NetDBListLeasesArgs) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocListLeasesResultsData struct {
+type netDBListLeasesResultsData struct {
 	Leases *[]*IPLease `cbor:"0,keyasint,omitempty" json:"leases,omitempty"`
 }
 
-type IPAllocListLeasesResults struct {
+type NetDBListLeasesResults struct {
 	call rpc.Call
-	data iPAllocListLeasesResultsData
+	data netDBListLeasesResultsData
 }
 
-func (v *IPAllocListLeasesResults) SetLeases(leases []*IPLease) {
+func (v *NetDBListLeasesResults) SetLeases(leases []*IPLease) {
 	x := slices.Clone(leases)
 	v.data.Leases = &x
 }
 
-func (v *IPAllocListLeasesResults) MarshalCBOR() ([]byte, error) {
+func (v *NetDBListLeasesResults) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocListLeasesResults) UnmarshalCBOR(data []byte) error {
+func (v *NetDBListLeasesResults) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocListLeasesResults) MarshalJSON() ([]byte, error) {
+func (v *NetDBListLeasesResults) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocListLeasesResults) UnmarshalJSON(data []byte) error {
+func (v *NetDBListLeasesResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocStatusArgsData struct{}
+type netDBStatusArgsData struct{}
 
-type IPAllocStatusArgs struct {
+type NetDBStatusArgs struct {
 	call rpc.Call
-	data iPAllocStatusArgsData
+	data netDBStatusArgsData
 }
 
-func (v *IPAllocStatusArgs) MarshalCBOR() ([]byte, error) {
+func (v *NetDBStatusArgs) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocStatusArgs) UnmarshalCBOR(data []byte) error {
+func (v *NetDBStatusArgs) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocStatusArgs) MarshalJSON() ([]byte, error) {
+func (v *NetDBStatusArgs) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocStatusArgs) UnmarshalJSON(data []byte) error {
+func (v *NetDBStatusArgs) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocStatusResultsData struct {
+type netDBStatusResultsData struct {
 	Subnets *[]*SubnetStatus `cbor:"0,keyasint,omitempty" json:"subnets,omitempty"`
 }
 
-type IPAllocStatusResults struct {
+type NetDBStatusResults struct {
 	call rpc.Call
-	data iPAllocStatusResultsData
+	data netDBStatusResultsData
 }
 
-func (v *IPAllocStatusResults) SetSubnets(subnets []*SubnetStatus) {
+func (v *NetDBStatusResults) SetSubnets(subnets []*SubnetStatus) {
 	x := slices.Clone(subnets)
 	v.data.Subnets = &x
 }
 
-func (v *IPAllocStatusResults) MarshalCBOR() ([]byte, error) {
+func (v *NetDBStatusResults) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocStatusResults) UnmarshalCBOR(data []byte) error {
+func (v *NetDBStatusResults) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocStatusResults) MarshalJSON() ([]byte, error) {
+func (v *NetDBStatusResults) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocStatusResults) UnmarshalJSON(data []byte) error {
+func (v *NetDBStatusResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocReleaseIPArgsData struct {
+type netDBReleaseIPArgsData struct {
 	Ip *string `cbor:"0,keyasint,omitempty" json:"ip,omitempty"`
 }
 
-type IPAllocReleaseIPArgs struct {
+type NetDBReleaseIPArgs struct {
 	call rpc.Call
-	data iPAllocReleaseIPArgsData
+	data netDBReleaseIPArgsData
 }
 
-func (v *IPAllocReleaseIPArgs) HasIp() bool {
+func (v *NetDBReleaseIPArgs) HasIp() bool {
 	return v.data.Ip != nil
 }
 
-func (v *IPAllocReleaseIPArgs) Ip() string {
+func (v *NetDBReleaseIPArgs) Ip() string {
 	if v.data.Ip == nil {
 		return ""
 	}
 	return *v.data.Ip
 }
 
-func (v *IPAllocReleaseIPArgs) MarshalCBOR() ([]byte, error) {
+func (v *NetDBReleaseIPArgs) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseIPArgs) UnmarshalCBOR(data []byte) error {
+func (v *NetDBReleaseIPArgs) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocReleaseIPArgs) MarshalJSON() ([]byte, error) {
+func (v *NetDBReleaseIPArgs) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseIPArgs) UnmarshalJSON(data []byte) error {
+func (v *NetDBReleaseIPArgs) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocReleaseIPResultsData struct {
+type netDBReleaseIPResultsData struct {
 	Released *bool `cbor:"0,keyasint,omitempty" json:"released,omitempty"`
 }
 
-type IPAllocReleaseIPResults struct {
+type NetDBReleaseIPResults struct {
 	call rpc.Call
-	data iPAllocReleaseIPResultsData
+	data netDBReleaseIPResultsData
 }
 
-func (v *IPAllocReleaseIPResults) SetReleased(released bool) {
+func (v *NetDBReleaseIPResults) SetReleased(released bool) {
 	v.data.Released = &released
 }
 
-func (v *IPAllocReleaseIPResults) MarshalCBOR() ([]byte, error) {
+func (v *NetDBReleaseIPResults) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseIPResults) UnmarshalCBOR(data []byte) error {
+func (v *NetDBReleaseIPResults) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocReleaseIPResults) MarshalJSON() ([]byte, error) {
+func (v *NetDBReleaseIPResults) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseIPResults) UnmarshalJSON(data []byte) error {
+func (v *NetDBReleaseIPResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocReleaseSubnetArgsData struct {
+type netDBReleaseSubnetArgsData struct {
 	Subnet *string `cbor:"0,keyasint,omitempty" json:"subnet,omitempty"`
 }
 
-type IPAllocReleaseSubnetArgs struct {
+type NetDBReleaseSubnetArgs struct {
 	call rpc.Call
-	data iPAllocReleaseSubnetArgsData
+	data netDBReleaseSubnetArgsData
 }
 
-func (v *IPAllocReleaseSubnetArgs) HasSubnet() bool {
+func (v *NetDBReleaseSubnetArgs) HasSubnet() bool {
 	return v.data.Subnet != nil
 }
 
-func (v *IPAllocReleaseSubnetArgs) Subnet() string {
+func (v *NetDBReleaseSubnetArgs) Subnet() string {
 	if v.data.Subnet == nil {
 		return ""
 	}
 	return *v.data.Subnet
 }
 
-func (v *IPAllocReleaseSubnetArgs) MarshalCBOR() ([]byte, error) {
+func (v *NetDBReleaseSubnetArgs) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseSubnetArgs) UnmarshalCBOR(data []byte) error {
+func (v *NetDBReleaseSubnetArgs) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocReleaseSubnetArgs) MarshalJSON() ([]byte, error) {
+func (v *NetDBReleaseSubnetArgs) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseSubnetArgs) UnmarshalJSON(data []byte) error {
+func (v *NetDBReleaseSubnetArgs) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocReleaseSubnetResultsData struct {
+type netDBReleaseSubnetResultsData struct {
 	Count *int32 `cbor:"0,keyasint,omitempty" json:"count,omitempty"`
 }
 
-type IPAllocReleaseSubnetResults struct {
+type NetDBReleaseSubnetResults struct {
 	call rpc.Call
-	data iPAllocReleaseSubnetResultsData
+	data netDBReleaseSubnetResultsData
 }
 
-func (v *IPAllocReleaseSubnetResults) SetCount(count int32) {
+func (v *NetDBReleaseSubnetResults) SetCount(count int32) {
 	v.data.Count = &count
 }
 
-func (v *IPAllocReleaseSubnetResults) MarshalCBOR() ([]byte, error) {
+func (v *NetDBReleaseSubnetResults) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseSubnetResults) UnmarshalCBOR(data []byte) error {
+func (v *NetDBReleaseSubnetResults) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocReleaseSubnetResults) MarshalJSON() ([]byte, error) {
+func (v *NetDBReleaseSubnetResults) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseSubnetResults) UnmarshalJSON(data []byte) error {
+func (v *NetDBReleaseSubnetResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocReleaseAllArgsData struct{}
+type netDBReleaseAllArgsData struct{}
 
-type IPAllocReleaseAllArgs struct {
+type NetDBReleaseAllArgs struct {
 	call rpc.Call
-	data iPAllocReleaseAllArgsData
+	data netDBReleaseAllArgsData
 }
 
-func (v *IPAllocReleaseAllArgs) MarshalCBOR() ([]byte, error) {
+func (v *NetDBReleaseAllArgs) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseAllArgs) UnmarshalCBOR(data []byte) error {
+func (v *NetDBReleaseAllArgs) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocReleaseAllArgs) MarshalJSON() ([]byte, error) {
+func (v *NetDBReleaseAllArgs) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseAllArgs) UnmarshalJSON(data []byte) error {
+func (v *NetDBReleaseAllArgs) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocReleaseAllResultsData struct {
+type netDBReleaseAllResultsData struct {
 	Count *int32 `cbor:"0,keyasint,omitempty" json:"count,omitempty"`
 }
 
-type IPAllocReleaseAllResults struct {
+type NetDBReleaseAllResults struct {
 	call rpc.Call
-	data iPAllocReleaseAllResultsData
+	data netDBReleaseAllResultsData
 }
 
-func (v *IPAllocReleaseAllResults) SetCount(count int32) {
+func (v *NetDBReleaseAllResults) SetCount(count int32) {
 	v.data.Count = &count
 }
 
-func (v *IPAllocReleaseAllResults) MarshalCBOR() ([]byte, error) {
+func (v *NetDBReleaseAllResults) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseAllResults) UnmarshalCBOR(data []byte) error {
+func (v *NetDBReleaseAllResults) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocReleaseAllResults) MarshalJSON() ([]byte, error) {
+func (v *NetDBReleaseAllResults) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocReleaseAllResults) UnmarshalJSON(data []byte) error {
+func (v *NetDBReleaseAllResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocGcArgsData struct {
+type netDBGcArgsData struct {
 	Subnet *string `cbor:"0,keyasint,omitempty" json:"subnet,omitempty"`
 	DryRun *bool   `cbor:"1,keyasint,omitempty" json:"dry_run,omitempty"`
 }
 
-type IPAllocGcArgs struct {
+type NetDBGcArgs struct {
 	call rpc.Call
-	data iPAllocGcArgsData
+	data netDBGcArgsData
 }
 
-func (v *IPAllocGcArgs) HasSubnet() bool {
+func (v *NetDBGcArgs) HasSubnet() bool {
 	return v.data.Subnet != nil
 }
 
-func (v *IPAllocGcArgs) Subnet() string {
+func (v *NetDBGcArgs) Subnet() string {
 	if v.data.Subnet == nil {
 		return ""
 	}
 	return *v.data.Subnet
 }
 
-func (v *IPAllocGcArgs) HasDryRun() bool {
+func (v *NetDBGcArgs) HasDryRun() bool {
 	return v.data.DryRun != nil
 }
 
-func (v *IPAllocGcArgs) DryRun() bool {
+func (v *NetDBGcArgs) DryRun() bool {
 	if v.data.DryRun == nil {
 		return false
 	}
 	return *v.data.DryRun
 }
 
-func (v *IPAllocGcArgs) MarshalCBOR() ([]byte, error) {
+func (v *NetDBGcArgs) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocGcArgs) UnmarshalCBOR(data []byte) error {
+func (v *NetDBGcArgs) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocGcArgs) MarshalJSON() ([]byte, error) {
+func (v *NetDBGcArgs) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocGcArgs) UnmarshalJSON(data []byte) error {
+func (v *NetDBGcArgs) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type iPAllocGcResultsData struct {
+type netDBGcResultsData struct {
 	OrphanedIps   *[]string `cbor:"0,keyasint,omitempty" json:"orphaned_ips,omitempty"`
 	ReleasedCount *int32    `cbor:"1,keyasint,omitempty" json:"released_count,omitempty"`
 }
 
-type IPAllocGcResults struct {
+type NetDBGcResults struct {
 	call rpc.Call
-	data iPAllocGcResultsData
+	data netDBGcResultsData
 }
 
-func (v *IPAllocGcResults) SetOrphanedIps(orphaned_ips []string) {
+func (v *NetDBGcResults) SetOrphanedIps(orphaned_ips []string) {
 	x := slices.Clone(orphaned_ips)
 	v.data.OrphanedIps = &x
 }
 
-func (v *IPAllocGcResults) SetReleasedCount(released_count int32) {
+func (v *NetDBGcResults) SetReleasedCount(released_count int32) {
 	v.data.ReleasedCount = &released_count
 }
 
-func (v *IPAllocGcResults) MarshalCBOR() ([]byte, error) {
+func (v *NetDBGcResults) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
 
-func (v *IPAllocGcResults) UnmarshalCBOR(data []byte) error {
+func (v *NetDBGcResults) UnmarshalCBOR(data []byte) error {
 	return cbor.Unmarshal(data, &v.data)
 }
 
-func (v *IPAllocGcResults) MarshalJSON() ([]byte, error) {
+func (v *NetDBGcResults) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.data)
 }
 
-func (v *IPAllocGcResults) UnmarshalJSON(data []byte) error {
+func (v *NetDBGcResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
-type IPAllocListLeases struct {
+type NetDBListLeases struct {
 	rpc.Call
-	args    IPAllocListLeasesArgs
-	results IPAllocListLeasesResults
+	args    NetDBListLeasesArgs
+	results NetDBListLeasesResults
 }
 
-func (t *IPAllocListLeases) Args() *IPAllocListLeasesArgs {
+func (t *NetDBListLeases) Args() *NetDBListLeasesArgs {
 	args := &t.args
 	if args.call != nil {
 		return args
@@ -621,7 +621,7 @@ func (t *IPAllocListLeases) Args() *IPAllocListLeasesArgs {
 	return args
 }
 
-func (t *IPAllocListLeases) Results() *IPAllocListLeasesResults {
+func (t *NetDBListLeases) Results() *NetDBListLeasesResults {
 	results := &t.results
 	if results.call != nil {
 		return results
@@ -631,13 +631,13 @@ func (t *IPAllocListLeases) Results() *IPAllocListLeasesResults {
 	return results
 }
 
-type IPAllocStatus struct {
+type NetDBStatus struct {
 	rpc.Call
-	args    IPAllocStatusArgs
-	results IPAllocStatusResults
+	args    NetDBStatusArgs
+	results NetDBStatusResults
 }
 
-func (t *IPAllocStatus) Args() *IPAllocStatusArgs {
+func (t *NetDBStatus) Args() *NetDBStatusArgs {
 	args := &t.args
 	if args.call != nil {
 		return args
@@ -647,7 +647,7 @@ func (t *IPAllocStatus) Args() *IPAllocStatusArgs {
 	return args
 }
 
-func (t *IPAllocStatus) Results() *IPAllocStatusResults {
+func (t *NetDBStatus) Results() *NetDBStatusResults {
 	results := &t.results
 	if results.call != nil {
 		return results
@@ -657,13 +657,13 @@ func (t *IPAllocStatus) Results() *IPAllocStatusResults {
 	return results
 }
 
-type IPAllocReleaseIP struct {
+type NetDBReleaseIP struct {
 	rpc.Call
-	args    IPAllocReleaseIPArgs
-	results IPAllocReleaseIPResults
+	args    NetDBReleaseIPArgs
+	results NetDBReleaseIPResults
 }
 
-func (t *IPAllocReleaseIP) Args() *IPAllocReleaseIPArgs {
+func (t *NetDBReleaseIP) Args() *NetDBReleaseIPArgs {
 	args := &t.args
 	if args.call != nil {
 		return args
@@ -673,7 +673,7 @@ func (t *IPAllocReleaseIP) Args() *IPAllocReleaseIPArgs {
 	return args
 }
 
-func (t *IPAllocReleaseIP) Results() *IPAllocReleaseIPResults {
+func (t *NetDBReleaseIP) Results() *NetDBReleaseIPResults {
 	results := &t.results
 	if results.call != nil {
 		return results
@@ -683,13 +683,13 @@ func (t *IPAllocReleaseIP) Results() *IPAllocReleaseIPResults {
 	return results
 }
 
-type IPAllocReleaseSubnet struct {
+type NetDBReleaseSubnet struct {
 	rpc.Call
-	args    IPAllocReleaseSubnetArgs
-	results IPAllocReleaseSubnetResults
+	args    NetDBReleaseSubnetArgs
+	results NetDBReleaseSubnetResults
 }
 
-func (t *IPAllocReleaseSubnet) Args() *IPAllocReleaseSubnetArgs {
+func (t *NetDBReleaseSubnet) Args() *NetDBReleaseSubnetArgs {
 	args := &t.args
 	if args.call != nil {
 		return args
@@ -699,7 +699,7 @@ func (t *IPAllocReleaseSubnet) Args() *IPAllocReleaseSubnetArgs {
 	return args
 }
 
-func (t *IPAllocReleaseSubnet) Results() *IPAllocReleaseSubnetResults {
+func (t *NetDBReleaseSubnet) Results() *NetDBReleaseSubnetResults {
 	results := &t.results
 	if results.call != nil {
 		return results
@@ -709,13 +709,13 @@ func (t *IPAllocReleaseSubnet) Results() *IPAllocReleaseSubnetResults {
 	return results
 }
 
-type IPAllocReleaseAll struct {
+type NetDBReleaseAll struct {
 	rpc.Call
-	args    IPAllocReleaseAllArgs
-	results IPAllocReleaseAllResults
+	args    NetDBReleaseAllArgs
+	results NetDBReleaseAllResults
 }
 
-func (t *IPAllocReleaseAll) Args() *IPAllocReleaseAllArgs {
+func (t *NetDBReleaseAll) Args() *NetDBReleaseAllArgs {
 	args := &t.args
 	if args.call != nil {
 		return args
@@ -725,7 +725,7 @@ func (t *IPAllocReleaseAll) Args() *IPAllocReleaseAllArgs {
 	return args
 }
 
-func (t *IPAllocReleaseAll) Results() *IPAllocReleaseAllResults {
+func (t *NetDBReleaseAll) Results() *NetDBReleaseAllResults {
 	results := &t.results
 	if results.call != nil {
 		return results
@@ -735,13 +735,13 @@ func (t *IPAllocReleaseAll) Results() *IPAllocReleaseAllResults {
 	return results
 }
 
-type IPAllocGc struct {
+type NetDBGc struct {
 	rpc.Call
-	args    IPAllocGcArgs
-	results IPAllocGcResults
+	args    NetDBGcArgs
+	results NetDBGcResults
 }
 
-func (t *IPAllocGc) Args() *IPAllocGcArgs {
+func (t *NetDBGc) Args() *NetDBGcArgs {
 	args := &t.args
 	if args.call != nil {
 		return args
@@ -751,7 +751,7 @@ func (t *IPAllocGc) Args() *IPAllocGcArgs {
 	return args
 }
 
-func (t *IPAllocGc) Results() *IPAllocGcResults {
+func (t *NetDBGc) Results() *NetDBGcResults {
 	results := &t.results
 	if results.call != nil {
 		return results
@@ -761,95 +761,95 @@ func (t *IPAllocGc) Results() *IPAllocGcResults {
 	return results
 }
 
-type IPAlloc interface {
-	ListLeases(ctx context.Context, state *IPAllocListLeases) error
-	Status(ctx context.Context, state *IPAllocStatus) error
-	ReleaseIP(ctx context.Context, state *IPAllocReleaseIP) error
-	ReleaseSubnet(ctx context.Context, state *IPAllocReleaseSubnet) error
-	ReleaseAll(ctx context.Context, state *IPAllocReleaseAll) error
-	Gc(ctx context.Context, state *IPAllocGc) error
+type NetDB interface {
+	ListLeases(ctx context.Context, state *NetDBListLeases) error
+	Status(ctx context.Context, state *NetDBStatus) error
+	ReleaseIP(ctx context.Context, state *NetDBReleaseIP) error
+	ReleaseSubnet(ctx context.Context, state *NetDBReleaseSubnet) error
+	ReleaseAll(ctx context.Context, state *NetDBReleaseAll) error
+	Gc(ctx context.Context, state *NetDBGc) error
 }
 
-type reexportIPAlloc struct {
+type reexportNetDB struct {
 	client rpc.Client
 }
 
-func (reexportIPAlloc) ListLeases(ctx context.Context, state *IPAllocListLeases) error {
+func (reexportNetDB) ListLeases(ctx context.Context, state *NetDBListLeases) error {
 	panic("not implemented")
 }
 
-func (reexportIPAlloc) Status(ctx context.Context, state *IPAllocStatus) error {
+func (reexportNetDB) Status(ctx context.Context, state *NetDBStatus) error {
 	panic("not implemented")
 }
 
-func (reexportIPAlloc) ReleaseIP(ctx context.Context, state *IPAllocReleaseIP) error {
+func (reexportNetDB) ReleaseIP(ctx context.Context, state *NetDBReleaseIP) error {
 	panic("not implemented")
 }
 
-func (reexportIPAlloc) ReleaseSubnet(ctx context.Context, state *IPAllocReleaseSubnet) error {
+func (reexportNetDB) ReleaseSubnet(ctx context.Context, state *NetDBReleaseSubnet) error {
 	panic("not implemented")
 }
 
-func (reexportIPAlloc) ReleaseAll(ctx context.Context, state *IPAllocReleaseAll) error {
+func (reexportNetDB) ReleaseAll(ctx context.Context, state *NetDBReleaseAll) error {
 	panic("not implemented")
 }
 
-func (reexportIPAlloc) Gc(ctx context.Context, state *IPAllocGc) error {
+func (reexportNetDB) Gc(ctx context.Context, state *NetDBGc) error {
 	panic("not implemented")
 }
 
-func (t reexportIPAlloc) CapabilityClient() rpc.Client {
+func (t reexportNetDB) CapabilityClient() rpc.Client {
 	return t.client
 }
 
-func AdaptIPAlloc(t IPAlloc) *rpc.Interface {
+func AdaptNetDB(t NetDB) *rpc.Interface {
 	methods := []rpc.Method{
 		{
 			Name:          "listLeases",
-			InterfaceName: "IPAlloc",
+			InterfaceName: "NetDB",
 			Index:         0,
 			Handler: func(ctx context.Context, call rpc.Call) error {
-				return t.ListLeases(ctx, &IPAllocListLeases{Call: call})
+				return t.ListLeases(ctx, &NetDBListLeases{Call: call})
 			},
 		},
 		{
 			Name:          "status",
-			InterfaceName: "IPAlloc",
+			InterfaceName: "NetDB",
 			Index:         0,
 			Handler: func(ctx context.Context, call rpc.Call) error {
-				return t.Status(ctx, &IPAllocStatus{Call: call})
+				return t.Status(ctx, &NetDBStatus{Call: call})
 			},
 		},
 		{
 			Name:          "releaseIP",
-			InterfaceName: "IPAlloc",
+			InterfaceName: "NetDB",
 			Index:         0,
 			Handler: func(ctx context.Context, call rpc.Call) error {
-				return t.ReleaseIP(ctx, &IPAllocReleaseIP{Call: call})
+				return t.ReleaseIP(ctx, &NetDBReleaseIP{Call: call})
 			},
 		},
 		{
 			Name:          "releaseSubnet",
-			InterfaceName: "IPAlloc",
+			InterfaceName: "NetDB",
 			Index:         0,
 			Handler: func(ctx context.Context, call rpc.Call) error {
-				return t.ReleaseSubnet(ctx, &IPAllocReleaseSubnet{Call: call})
+				return t.ReleaseSubnet(ctx, &NetDBReleaseSubnet{Call: call})
 			},
 		},
 		{
 			Name:          "releaseAll",
-			InterfaceName: "IPAlloc",
+			InterfaceName: "NetDB",
 			Index:         0,
 			Handler: func(ctx context.Context, call rpc.Call) error {
-				return t.ReleaseAll(ctx, &IPAllocReleaseAll{Call: call})
+				return t.ReleaseAll(ctx, &NetDBReleaseAll{Call: call})
 			},
 		},
 		{
 			Name:          "gc",
-			InterfaceName: "IPAlloc",
+			InterfaceName: "NetDB",
 			Index:         0,
 			Handler: func(ctx context.Context, call rpc.Call) error {
-				return t.Gc(ctx, &IPAllocGc{Call: call})
+				return t.Gc(ctx, &NetDBGc{Call: call})
 			},
 		},
 	}
@@ -857,206 +857,206 @@ func AdaptIPAlloc(t IPAlloc) *rpc.Interface {
 	return rpc.NewInterface(methods, t)
 }
 
-type IPAllocClient struct {
+type NetDBClient struct {
 	rpc.Client
 }
 
-func NewIPAllocClient(client rpc.Client) *IPAllocClient {
-	return &IPAllocClient{Client: client}
+func NewNetDBClient(client rpc.Client) *NetDBClient {
+	return &NetDBClient{Client: client}
 }
 
-func (c IPAllocClient) Export() IPAlloc {
-	return reexportIPAlloc{client: c.Client}
+func (c NetDBClient) Export() NetDB {
+	return reexportNetDB{client: c.Client}
 }
 
-type IPAllocClientListLeasesResults struct {
+type NetDBClientListLeasesResults struct {
 	client rpc.Client
-	data   iPAllocListLeasesResultsData
+	data   netDBListLeasesResultsData
 }
 
-func (v *IPAllocClientListLeasesResults) HasLeases() bool {
+func (v *NetDBClientListLeasesResults) HasLeases() bool {
 	return v.data.Leases != nil
 }
 
-func (v *IPAllocClientListLeasesResults) Leases() []*IPLease {
+func (v *NetDBClientListLeasesResults) Leases() []*IPLease {
 	if v.data.Leases == nil {
 		return nil
 	}
 	return *v.data.Leases
 }
 
-func (v IPAllocClient) ListLeases(ctx context.Context, subnet string, reserved_only bool, released_only bool) (*IPAllocClientListLeasesResults, error) {
-	args := IPAllocListLeasesArgs{}
+func (v NetDBClient) ListLeases(ctx context.Context, subnet string, reserved_only bool, released_only bool) (*NetDBClientListLeasesResults, error) {
+	args := NetDBListLeasesArgs{}
 	args.data.Subnet = &subnet
 	args.data.ReservedOnly = &reserved_only
 	args.data.ReleasedOnly = &released_only
 
-	var ret iPAllocListLeasesResultsData
+	var ret netDBListLeasesResultsData
 
 	err := v.Call(ctx, "listLeases", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
 
-	return &IPAllocClientListLeasesResults{client: v.Client, data: ret}, nil
+	return &NetDBClientListLeasesResults{client: v.Client, data: ret}, nil
 }
 
-type IPAllocClientStatusResults struct {
+type NetDBClientStatusResults struct {
 	client rpc.Client
-	data   iPAllocStatusResultsData
+	data   netDBStatusResultsData
 }
 
-func (v *IPAllocClientStatusResults) HasSubnets() bool {
+func (v *NetDBClientStatusResults) HasSubnets() bool {
 	return v.data.Subnets != nil
 }
 
-func (v *IPAllocClientStatusResults) Subnets() []*SubnetStatus {
+func (v *NetDBClientStatusResults) Subnets() []*SubnetStatus {
 	if v.data.Subnets == nil {
 		return nil
 	}
 	return *v.data.Subnets
 }
 
-func (v IPAllocClient) Status(ctx context.Context) (*IPAllocClientStatusResults, error) {
-	args := IPAllocStatusArgs{}
+func (v NetDBClient) Status(ctx context.Context) (*NetDBClientStatusResults, error) {
+	args := NetDBStatusArgs{}
 
-	var ret iPAllocStatusResultsData
+	var ret netDBStatusResultsData
 
 	err := v.Call(ctx, "status", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
 
-	return &IPAllocClientStatusResults{client: v.Client, data: ret}, nil
+	return &NetDBClientStatusResults{client: v.Client, data: ret}, nil
 }
 
-type IPAllocClientReleaseIPResults struct {
+type NetDBClientReleaseIPResults struct {
 	client rpc.Client
-	data   iPAllocReleaseIPResultsData
+	data   netDBReleaseIPResultsData
 }
 
-func (v *IPAllocClientReleaseIPResults) HasReleased() bool {
+func (v *NetDBClientReleaseIPResults) HasReleased() bool {
 	return v.data.Released != nil
 }
 
-func (v *IPAllocClientReleaseIPResults) Released() bool {
+func (v *NetDBClientReleaseIPResults) Released() bool {
 	if v.data.Released == nil {
 		return false
 	}
 	return *v.data.Released
 }
 
-func (v IPAllocClient) ReleaseIP(ctx context.Context, ip string) (*IPAllocClientReleaseIPResults, error) {
-	args := IPAllocReleaseIPArgs{}
+func (v NetDBClient) ReleaseIP(ctx context.Context, ip string) (*NetDBClientReleaseIPResults, error) {
+	args := NetDBReleaseIPArgs{}
 	args.data.Ip = &ip
 
-	var ret iPAllocReleaseIPResultsData
+	var ret netDBReleaseIPResultsData
 
 	err := v.Call(ctx, "releaseIP", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
 
-	return &IPAllocClientReleaseIPResults{client: v.Client, data: ret}, nil
+	return &NetDBClientReleaseIPResults{client: v.Client, data: ret}, nil
 }
 
-type IPAllocClientReleaseSubnetResults struct {
+type NetDBClientReleaseSubnetResults struct {
 	client rpc.Client
-	data   iPAllocReleaseSubnetResultsData
+	data   netDBReleaseSubnetResultsData
 }
 
-func (v *IPAllocClientReleaseSubnetResults) HasCount() bool {
+func (v *NetDBClientReleaseSubnetResults) HasCount() bool {
 	return v.data.Count != nil
 }
 
-func (v *IPAllocClientReleaseSubnetResults) Count() int32 {
+func (v *NetDBClientReleaseSubnetResults) Count() int32 {
 	if v.data.Count == nil {
 		return 0
 	}
 	return *v.data.Count
 }
 
-func (v IPAllocClient) ReleaseSubnet(ctx context.Context, subnet string) (*IPAllocClientReleaseSubnetResults, error) {
-	args := IPAllocReleaseSubnetArgs{}
+func (v NetDBClient) ReleaseSubnet(ctx context.Context, subnet string) (*NetDBClientReleaseSubnetResults, error) {
+	args := NetDBReleaseSubnetArgs{}
 	args.data.Subnet = &subnet
 
-	var ret iPAllocReleaseSubnetResultsData
+	var ret netDBReleaseSubnetResultsData
 
 	err := v.Call(ctx, "releaseSubnet", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
 
-	return &IPAllocClientReleaseSubnetResults{client: v.Client, data: ret}, nil
+	return &NetDBClientReleaseSubnetResults{client: v.Client, data: ret}, nil
 }
 
-type IPAllocClientReleaseAllResults struct {
+type NetDBClientReleaseAllResults struct {
 	client rpc.Client
-	data   iPAllocReleaseAllResultsData
+	data   netDBReleaseAllResultsData
 }
 
-func (v *IPAllocClientReleaseAllResults) HasCount() bool {
+func (v *NetDBClientReleaseAllResults) HasCount() bool {
 	return v.data.Count != nil
 }
 
-func (v *IPAllocClientReleaseAllResults) Count() int32 {
+func (v *NetDBClientReleaseAllResults) Count() int32 {
 	if v.data.Count == nil {
 		return 0
 	}
 	return *v.data.Count
 }
 
-func (v IPAllocClient) ReleaseAll(ctx context.Context) (*IPAllocClientReleaseAllResults, error) {
-	args := IPAllocReleaseAllArgs{}
+func (v NetDBClient) ReleaseAll(ctx context.Context) (*NetDBClientReleaseAllResults, error) {
+	args := NetDBReleaseAllArgs{}
 
-	var ret iPAllocReleaseAllResultsData
+	var ret netDBReleaseAllResultsData
 
 	err := v.Call(ctx, "releaseAll", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
 
-	return &IPAllocClientReleaseAllResults{client: v.Client, data: ret}, nil
+	return &NetDBClientReleaseAllResults{client: v.Client, data: ret}, nil
 }
 
-type IPAllocClientGcResults struct {
+type NetDBClientGcResults struct {
 	client rpc.Client
-	data   iPAllocGcResultsData
+	data   netDBGcResultsData
 }
 
-func (v *IPAllocClientGcResults) HasOrphanedIps() bool {
+func (v *NetDBClientGcResults) HasOrphanedIps() bool {
 	return v.data.OrphanedIps != nil
 }
 
-func (v *IPAllocClientGcResults) OrphanedIps() []string {
+func (v *NetDBClientGcResults) OrphanedIps() []string {
 	if v.data.OrphanedIps == nil {
 		return nil
 	}
 	return *v.data.OrphanedIps
 }
 
-func (v *IPAllocClientGcResults) HasReleasedCount() bool {
+func (v *NetDBClientGcResults) HasReleasedCount() bool {
 	return v.data.ReleasedCount != nil
 }
 
-func (v *IPAllocClientGcResults) ReleasedCount() int32 {
+func (v *NetDBClientGcResults) ReleasedCount() int32 {
 	if v.data.ReleasedCount == nil {
 		return 0
 	}
 	return *v.data.ReleasedCount
 }
 
-func (v IPAllocClient) Gc(ctx context.Context, subnet string, dry_run bool) (*IPAllocClientGcResults, error) {
-	args := IPAllocGcArgs{}
+func (v NetDBClient) Gc(ctx context.Context, subnet string, dry_run bool) (*NetDBClientGcResults, error) {
+	args := NetDBGcArgs{}
 	args.data.Subnet = &subnet
 	args.data.DryRun = &dry_run
 
-	var ret iPAllocGcResultsData
+	var ret netDBGcResultsData
 
 	err := v.Call(ctx, "gc", &args, &ret)
 	if err != nil {
 		return nil, err
 	}
 
-	return &IPAllocClientGcResults{client: v.Client, data: ret}, nil
+	return &NetDBClientGcResults{client: v.Client, data: ret}, nil
 }

--- a/api/debug/debug_v1alpha/rpc.gen.go
+++ b/api/debug/debug_v1alpha/rpc.gen.go
@@ -99,8 +99,7 @@ type subnetStatusData struct {
 	Total    *int32  `cbor:"1,keyasint,omitempty" json:"total,omitempty"`
 	Reserved *int32  `cbor:"2,keyasint,omitempty" json:"reserved,omitempty"`
 	Released *int32  `cbor:"3,keyasint,omitempty" json:"released,omitempty"`
-	Stuck    *int32  `cbor:"4,keyasint,omitempty" json:"stuck,omitempty"`
-	Capacity *int32  `cbor:"5,keyasint,omitempty" json:"capacity,omitempty"`
+	Capacity *int32  `cbor:"4,keyasint,omitempty" json:"capacity,omitempty"`
 }
 
 type SubnetStatus struct {
@@ -167,21 +166,6 @@ func (v *SubnetStatus) SetReleased(released int32) {
 	v.data.Released = &released
 }
 
-func (v *SubnetStatus) HasStuck() bool {
-	return v.data.Stuck != nil
-}
-
-func (v *SubnetStatus) Stuck() int32 {
-	if v.data.Stuck == nil {
-		return 0
-	}
-	return *v.data.Stuck
-}
-
-func (v *SubnetStatus) SetStuck(stuck int32) {
-	v.data.Stuck = &stuck
-}
-
 func (v *SubnetStatus) HasCapacity() bool {
 	return v.data.Capacity != nil
 }
@@ -217,7 +201,6 @@ type iPAllocListLeasesArgsData struct {
 	Subnet       *string `cbor:"0,keyasint,omitempty" json:"subnet,omitempty"`
 	ReservedOnly *bool   `cbor:"1,keyasint,omitempty" json:"reserved_only,omitempty"`
 	ReleasedOnly *bool   `cbor:"2,keyasint,omitempty" json:"released_only,omitempty"`
-	StuckOnly    *bool   `cbor:"3,keyasint,omitempty" json:"stuck_only,omitempty"`
 }
 
 type IPAllocListLeasesArgs struct {
@@ -256,17 +239,6 @@ func (v *IPAllocListLeasesArgs) ReleasedOnly() bool {
 		return false
 	}
 	return *v.data.ReleasedOnly
-}
-
-func (v *IPAllocListLeasesArgs) HasStuckOnly() bool {
-	return v.data.StuckOnly != nil
-}
-
-func (v *IPAllocListLeasesArgs) StuckOnly() bool {
-	if v.data.StuckOnly == nil {
-		return false
-	}
-	return *v.data.StuckOnly
 }
 
 func (v *IPAllocListLeasesArgs) MarshalCBOR() ([]byte, error) {
@@ -913,12 +885,11 @@ func (v *IPAllocClientListLeasesResults) Leases() []*IPLease {
 	return *v.data.Leases
 }
 
-func (v IPAllocClient) ListLeases(ctx context.Context, subnet string, reserved_only bool, released_only bool, stuck_only bool) (*IPAllocClientListLeasesResults, error) {
+func (v IPAllocClient) ListLeases(ctx context.Context, subnet string, reserved_only bool, released_only bool) (*IPAllocClientListLeasesResults, error) {
 	args := IPAllocListLeasesArgs{}
 	args.data.Subnet = &subnet
 	args.data.ReservedOnly = &reserved_only
 	args.data.ReleasedOnly = &released_only
-	args.data.StuckOnly = &stuck_only
 
 	var ret iPAllocListLeasesResultsData
 

--- a/api/debug/rpc.go
+++ b/api/debug/rpc.go
@@ -1,0 +1,3 @@
+package debug
+
+//go:generate go run ../../pkg/rpc/cmd/rpcgen -pkg debug_v1alpha -input rpc.yml -output debug_v1alpha/rpc.gen.go

--- a/api/debug/rpc.yml
+++ b/api/debug/rpc.yml
@@ -49,8 +49,8 @@ types:
         doc: Total capacity of subnet
 
 interfaces:
-  - name: IPAlloc
-    doc: Debug interface for IP allocation management
+  - name: NetDB
+    doc: Debug interface for network database inspection and management
     methods:
       - name: listLeases
         doc: List IP leases with optional filters

--- a/api/debug/rpc.yml
+++ b/api/debug/rpc.yml
@@ -43,13 +43,9 @@ types:
         type: int32
         index: 3
         doc: Number of released IPs
-      - name: stuck
-        type: int32
-        index: 4
-        doc: Number of stuck IPs (reserved but no released_at)
       - name: capacity
         type: int32
-        index: 5
+        index: 4
         doc: Total capacity of subnet
 
 interfaces:
@@ -68,9 +64,6 @@ interfaces:
           - name: released_only
             type: bool
             doc: Show only released IPs
-          - name: stuck_only
-            type: bool
-            doc: Show only stuck IPs (reserved=1, no released_at)
         results:
           - name: leases
             type: list
@@ -97,7 +90,7 @@ interfaces:
             doc: Whether the IP was released
 
       - name: releaseSubnet
-        doc: Release all stuck IPs in a subnet
+        doc: Release all reserved IPs in a subnet
         parameters:
           - name: subnet
             type: string
@@ -108,7 +101,7 @@ interfaces:
             doc: Number of IPs released
 
       - name: releaseAll
-        doc: Release all stuck IPs across all subnets
+        doc: Release all reserved IPs across all subnets
         results:
           - name: count
             type: int32

--- a/api/debug/rpc.yml
+++ b/api/debug/rpc.yml
@@ -1,0 +1,133 @@
+imports:
+  standard:
+    path: ../../pkg/rpc/standard/standard.yml
+    import: miren.dev/runtime/pkg/rpc/standard
+
+types:
+  - type: IPLease
+    doc: An IP lease from the network database
+    fields:
+      - name: ip
+        type: string
+        index: 0
+        doc: The IP address
+      - name: subnet
+        type: string
+        index: 1
+        doc: The subnet CIDR
+      - name: reserved
+        type: bool
+        index: 2
+        doc: Whether the IP is currently reserved
+      - name: released_at
+        type: standard.Timestamp
+        index: 3
+        doc: When the IP was released (if released)
+
+  - type: SubnetStatus
+    doc: Utilization stats for a subnet
+    fields:
+      - name: subnet
+        type: string
+        index: 0
+        doc: The subnet CIDR
+      - name: total
+        type: int32
+        index: 1
+        doc: Total IPs in database for this subnet
+      - name: reserved
+        type: int32
+        index: 2
+        doc: Number of reserved IPs
+      - name: released
+        type: int32
+        index: 3
+        doc: Number of released IPs
+      - name: stuck
+        type: int32
+        index: 4
+        doc: Number of stuck IPs (reserved but no released_at)
+      - name: capacity
+        type: int32
+        index: 5
+        doc: Total capacity of subnet
+
+interfaces:
+  - name: IPAlloc
+    doc: Debug interface for IP allocation management
+    methods:
+      - name: listLeases
+        doc: List IP leases with optional filters
+        parameters:
+          - name: subnet
+            type: string
+            doc: Filter by subnet CIDR (optional)
+          - name: reserved_only
+            type: bool
+            doc: Show only reserved IPs
+          - name: released_only
+            type: bool
+            doc: Show only released IPs
+          - name: stuck_only
+            type: bool
+            doc: Show only stuck IPs (reserved=1, no released_at)
+        results:
+          - name: leases
+            type: list
+            element: IPLease
+            doc: List of IP leases
+
+      - name: status
+        doc: Get subnet utilization statistics
+        results:
+          - name: subnets
+            type: list
+            element: SubnetStatus
+            doc: Status for each subnet
+
+      - name: releaseIP
+        doc: Manually release a specific IP
+        parameters:
+          - name: ip
+            type: string
+            doc: The IP address to release
+        results:
+          - name: released
+            type: bool
+            doc: Whether the IP was released
+
+      - name: releaseSubnet
+        doc: Release all stuck IPs in a subnet
+        parameters:
+          - name: subnet
+            type: string
+            doc: The subnet CIDR
+        results:
+          - name: count
+            type: int32
+            doc: Number of IPs released
+
+      - name: releaseAll
+        doc: Release all stuck IPs across all subnets
+        results:
+          - name: count
+            type: int32
+            doc: Number of IPs released
+
+      - name: gc
+        doc: Garbage collect orphaned IPs (reserved but no matching sandbox)
+        parameters:
+          - name: subnet
+            type: string
+            doc: Filter by subnet (optional)
+          - name: dry_run
+            type: bool
+            doc: If true, only report what would be released
+        results:
+          - name: orphaned_ips
+            type: list
+            element: string
+            doc: List of orphaned IP addresses
+          - name: released_count
+            type: int32
+            doc: Number of IPs released (0 if dry_run)

--- a/api/debug/rpc.yml
+++ b/api/debug/rpc.yml
@@ -23,6 +23,10 @@ types:
         type: standard.Timestamp
         index: 3
         doc: When the IP was released (if released)
+      - name: sandbox_id
+        type: string
+        index: 4
+        doc: ID of the sandbox using this IP (if any)
 
   - type: SubnetStatus
     doc: Utilization stats for a subnet

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -327,6 +327,22 @@ Warning: These commands are intended for advanced users and developers. They may
 		"debug disk mounts": func() (cli.Command, error) {
 			return Infer("debug disk mounts", "List all mounted disks from /proc/mounts", DebugDiskMounts), nil
 		},
+
+		"debug ipalloc list": func() (cli.Command, error) {
+			return Infer("debug ipalloc list", "List all IP leases from netdb", DebugIPAllocList), nil
+		},
+
+		"debug ipalloc status": func() (cli.Command, error) {
+			return Infer("debug ipalloc status", "Show IP allocation status by subnet", DebugIPAllocStatus), nil
+		},
+
+		"debug ipalloc release": func() (cli.Command, error) {
+			return Infer("debug ipalloc release", "Manually release IP leases", DebugIPAllocRelease), nil
+		},
+
+		"debug ipalloc gc": func() (cli.Command, error) {
+			return Infer("debug ipalloc gc", "Find and release orphaned IP leases", DebugIPAllocGC), nil
+		},
 	}
 
 	addCommands(base)

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -328,20 +328,20 @@ Warning: These commands are intended for advanced users and developers. They may
 			return Infer("debug disk mounts", "List all mounted disks from /proc/mounts", DebugDiskMounts), nil
 		},
 
-		"debug ipalloc list": func() (cli.Command, error) {
-			return Infer("debug ipalloc list", "List all IP leases from netdb", DebugIPAllocList), nil
+		"debug netdb list": func() (cli.Command, error) {
+			return Infer("debug netdb list", "List all IP leases from netdb", DebugNetDBList), nil
 		},
 
-		"debug ipalloc status": func() (cli.Command, error) {
-			return Infer("debug ipalloc status", "Show IP allocation status by subnet", DebugIPAllocStatus), nil
+		"debug netdb status": func() (cli.Command, error) {
+			return Infer("debug netdb status", "Show IP allocation status by subnet", DebugNetDBStatus), nil
 		},
 
-		"debug ipalloc release": func() (cli.Command, error) {
-			return Infer("debug ipalloc release", "Manually release IP leases", DebugIPAllocRelease), nil
+		"debug netdb release": func() (cli.Command, error) {
+			return Infer("debug netdb release", "Manually release IP leases", DebugNetDBRelease), nil
 		},
 
-		"debug ipalloc gc": func() (cli.Command, error) {
-			return Infer("debug ipalloc gc", "Find and release orphaned IP leases", DebugIPAllocGC), nil
+		"debug netdb gc": func() (cli.Command, error) {
+			return Infer("debug netdb gc", "Find and release orphaned IP leases", DebugNetDBGC), nil
 		},
 	}
 

--- a/cli/commands/debug_ipalloc.go
+++ b/cli/commands/debug_ipalloc.go
@@ -1,0 +1,218 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/debug/debug_v1alpha"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+// DebugIPAllocList lists all IP leases from the netdb
+func DebugIPAllocList(ctx *Context, opts struct {
+	ConfigCentric
+	Subnet   string `short:"s" long:"subnet" description:"Filter by subnet CIDR"`
+	Reserved bool   `short:"r" long:"reserved" description:"Show only reserved (in-use) IPs"`
+	Released bool   `short:"R" long:"released" description:"Show only released IPs"`
+	Stuck    bool   `short:"S" long:"stuck" description:"Show only stuck IPs (reserved=1, no released_at)"`
+}) error {
+	client, err := ctx.RPCClient("dev.miren.runtime/debug-ipalloc")
+	if err != nil {
+		return err
+	}
+
+	ipalloc := debug_v1alpha.NewIPAllocClient(client)
+
+	results, err := ipalloc.ListLeases(ctx, opts.Subnet, opts.Reserved, opts.Released, opts.Stuck)
+	if err != nil {
+		return fmt.Errorf("failed to list leases: %w", err)
+	}
+
+	ctx.Info("IP Leases:")
+	ctx.Info("")
+	ctx.Info("%-18s %-18s %-10s %s", "IP", "SUBNET", "STATUS", "RELEASED_AT")
+	ctx.Info("%-18s %-18s %-10s %s", strings.Repeat("-", 18), strings.Repeat("-", 18), strings.Repeat("-", 10), strings.Repeat("-", 20))
+
+	leases := results.Leases()
+	for _, lease := range leases {
+		status := "released"
+		if lease.Reserved() {
+			status = "reserved"
+		}
+
+		releasedStr := "-"
+		if lease.HasReleasedAt() {
+			releasedStr = standard.FromTimestamp(lease.ReleasedAt()).Format(time.RFC3339)
+		}
+
+		ctx.Info("%-18s %-18s %-10s %s", lease.Ip(), lease.Subnet(), status, releasedStr)
+	}
+
+	ctx.Info("")
+	ctx.Info("Total: %d leases", len(leases))
+
+	return nil
+}
+
+// DebugIPAllocStatus shows subnet utilization stats
+func DebugIPAllocStatus(ctx *Context, opts struct {
+	ConfigCentric
+}) error {
+	client, err := ctx.RPCClient("dev.miren.runtime/debug-ipalloc")
+	if err != nil {
+		return err
+	}
+
+	ipalloc := debug_v1alpha.NewIPAllocClient(client)
+
+	results, err := ipalloc.Status(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get status: %w", err)
+	}
+
+	ctx.Info("IP Allocation Status:")
+	ctx.Info("")
+	ctx.Info("%-20s %8s %10s %10s %8s %8s", "SUBNET", "CAPACITY", "RESERVED", "RELEASED", "STUCK", "USAGE")
+	ctx.Info("%-20s %8s %10s %10s %8s %8s", strings.Repeat("-", 20), strings.Repeat("-", 8), strings.Repeat("-", 10), strings.Repeat("-", 10), strings.Repeat("-", 8), strings.Repeat("-", 8))
+
+	for _, subnet := range results.Subnets() {
+		capacity := subnet.Capacity()
+		reserved := subnet.Reserved()
+
+		usage := float64(0)
+		if capacity > 0 {
+			usage = float64(reserved) / float64(capacity) * 100
+		}
+		usageStr := fmt.Sprintf("%.1f%%", usage)
+		if usage > 90 {
+			usageStr += " ⚠️"
+		}
+
+		ctx.Info("%-20s %8d %10d %10d %8d %8s", subnet.Subnet(), capacity, reserved, subnet.Released(), subnet.Stuck(), usageStr)
+	}
+
+	return nil
+}
+
+// DebugIPAllocRelease manually releases IP leases
+func DebugIPAllocRelease(ctx *Context, opts struct {
+	ConfigCentric
+	IP     string `short:"i" long:"ip" description:"Specific IP to release"`
+	Subnet string `short:"s" long:"subnet" description:"Release all stuck IPs in subnet"`
+	All    bool   `short:"a" long:"all" description:"Release all stuck IPs (use with caution)"`
+	Force  bool   `short:"f" long:"force" description:"Skip confirmation prompt"`
+}) error {
+	if opts.IP == "" && opts.Subnet == "" && !opts.All {
+		return fmt.Errorf("must specify --ip, --subnet, or --all")
+	}
+
+	client, err := ctx.RPCClient("dev.miren.runtime/debug-ipalloc")
+	if err != nil {
+		return err
+	}
+
+	ipalloc := debug_v1alpha.NewIPAllocClient(client)
+
+	if opts.IP != "" {
+		if !opts.Force {
+			ctx.Warn("About to release IP %s", opts.IP)
+			ctx.Warn("This will make this IP available for reallocation.")
+			ctx.Warn("Use --force to skip this confirmation.")
+			return nil
+		}
+
+		result, err := ipalloc.ReleaseIP(ctx, opts.IP)
+		if err != nil {
+			return fmt.Errorf("failed to release IP: %w", err)
+		}
+
+		if result.Released() {
+			ctx.Completed("Released IP %s", opts.IP)
+		} else {
+			ctx.Info("IP %s was not reserved or does not exist", opts.IP)
+		}
+		return nil
+	}
+
+	if opts.Subnet != "" {
+		if !opts.Force {
+			ctx.Warn("About to release all stuck IPs in subnet %s", opts.Subnet)
+			ctx.Warn("This will make these IPs available for reallocation.")
+			ctx.Warn("Use --force to skip this confirmation.")
+			return nil
+		}
+
+		result, err := ipalloc.ReleaseSubnet(ctx, opts.Subnet)
+		if err != nil {
+			return fmt.Errorf("failed to release subnet IPs: %w", err)
+		}
+
+		ctx.Completed("Released %d IP lease(s) in subnet %s", result.Count(), opts.Subnet)
+		return nil
+	}
+
+	if opts.All {
+		if !opts.Force {
+			ctx.Warn("About to release ALL stuck IPs across all subnets")
+			ctx.Warn("This will make these IPs available for reallocation.")
+			ctx.Warn("Use --force to skip this confirmation.")
+			return nil
+		}
+
+		result, err := ipalloc.ReleaseAll(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to release all IPs: %w", err)
+		}
+
+		ctx.Completed("Released %d IP lease(s)", result.Count())
+		return nil
+	}
+
+	return nil
+}
+
+// DebugIPAllocGC garbage collects IPs not associated with live sandboxes
+func DebugIPAllocGC(ctx *Context, opts struct {
+	ConfigCentric
+	Subnet string `short:"s" long:"subnet" description:"Only GC IPs in this subnet"`
+	DryRun bool   `short:"n" long:"dry-run" description:"Show what would be released without making changes"`
+	Force  bool   `short:"f" long:"force" description:"Actually perform the GC (required unless --dry-run)"`
+}) error {
+	if !opts.DryRun && !opts.Force {
+		ctx.Warn("Dry run mode (use --force to actually release IPs)")
+		opts.DryRun = true
+	}
+
+	client, err := ctx.RPCClient("dev.miren.runtime/debug-ipalloc")
+	if err != nil {
+		return err
+	}
+
+	ipalloc := debug_v1alpha.NewIPAllocClient(client)
+
+	results, err := ipalloc.Gc(ctx, opts.Subnet, opts.DryRun)
+	if err != nil {
+		return fmt.Errorf("failed to run GC: %w", err)
+	}
+
+	orphanedIPs := results.OrphanedIps()
+	if len(orphanedIPs) == 0 {
+		ctx.Info("No orphaned IPs found - all reserved IPs have associated sandboxes")
+		return nil
+	}
+
+	ctx.Info("Found %d orphaned IPs (reserved but no sandbox):", len(orphanedIPs))
+	for _, ip := range orphanedIPs {
+		ctx.Info("  %s", ip)
+	}
+
+	if opts.DryRun {
+		ctx.Info("")
+		ctx.Info("Dry run - no changes made. Use --force to release these IPs.")
+	} else {
+		ctx.Completed("Released %d orphaned IP leases", results.ReleasedCount())
+	}
+
+	return nil
+}

--- a/cli/commands/debug_netdb.go
+++ b/cli/commands/debug_netdb.go
@@ -9,21 +9,21 @@ import (
 	"miren.dev/runtime/pkg/ui"
 )
 
-// DebugIPAllocList lists all IP leases from the netdb
-func DebugIPAllocList(ctx *Context, opts struct {
+// DebugNetDBList lists all IP leases from the netdb
+func DebugNetDBList(ctx *Context, opts struct {
 	ConfigCentric
 	Subnet   string `short:"s" long:"subnet" description:"Filter by subnet CIDR"`
 	Reserved bool   `short:"r" long:"reserved" description:"Show only reserved (in-use) IPs"`
 	Released bool   `short:"R" long:"released" description:"Show only released IPs"`
 }) error {
-	client, err := ctx.RPCClient("dev.miren.runtime/debug-ipalloc")
+	client, err := ctx.RPCClient("dev.miren.runtime/debug-netdb")
 	if err != nil {
 		return err
 	}
 
-	ipalloc := debug_v1alpha.NewIPAllocClient(client)
+	netdb := debug_v1alpha.NewNetDBClient(client)
 
-	results, err := ipalloc.ListLeases(ctx, opts.Subnet, opts.Reserved, opts.Released)
+	results, err := netdb.ListLeases(ctx, opts.Subnet, opts.Reserved, opts.Released)
 	if err != nil {
 		return fmt.Errorf("failed to list leases: %w", err)
 	}
@@ -63,18 +63,18 @@ func DebugIPAllocList(ctx *Context, opts struct {
 	return nil
 }
 
-// DebugIPAllocStatus shows subnet utilization stats
-func DebugIPAllocStatus(ctx *Context, opts struct {
+// DebugNetDBStatus shows subnet utilization stats
+func DebugNetDBStatus(ctx *Context, opts struct {
 	ConfigCentric
 }) error {
-	client, err := ctx.RPCClient("dev.miren.runtime/debug-ipalloc")
+	client, err := ctx.RPCClient("dev.miren.runtime/debug-netdb")
 	if err != nil {
 		return err
 	}
 
-	ipalloc := debug_v1alpha.NewIPAllocClient(client)
+	netdb := debug_v1alpha.NewNetDBClient(client)
 
-	results, err := ipalloc.Status(ctx)
+	results, err := netdb.Status(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get status: %w", err)
 	}
@@ -120,8 +120,8 @@ func DebugIPAllocStatus(ctx *Context, opts struct {
 	return nil
 }
 
-// DebugIPAllocRelease manually releases IP leases
-func DebugIPAllocRelease(ctx *Context, opts struct {
+// DebugNetDBRelease manually releases IP leases
+func DebugNetDBRelease(ctx *Context, opts struct {
 	ConfigCentric
 	IP     string `short:"i" long:"ip" description:"Specific IP to release"`
 	Subnet string `short:"s" long:"subnet" description:"Release all reserved IPs in subnet"`
@@ -132,12 +132,12 @@ func DebugIPAllocRelease(ctx *Context, opts struct {
 		return fmt.Errorf("must specify --ip, --subnet, or --all")
 	}
 
-	client, err := ctx.RPCClient("dev.miren.runtime/debug-ipalloc")
+	client, err := ctx.RPCClient("dev.miren.runtime/debug-netdb")
 	if err != nil {
 		return err
 	}
 
-	ipalloc := debug_v1alpha.NewIPAllocClient(client)
+	netdb := debug_v1alpha.NewNetDBClient(client)
 
 	if opts.IP != "" {
 		if !opts.Force {
@@ -154,7 +154,7 @@ func DebugIPAllocRelease(ctx *Context, opts struct {
 			}
 		}
 
-		result, err := ipalloc.ReleaseIP(ctx, opts.IP)
+		result, err := netdb.ReleaseIP(ctx, opts.IP)
 		if err != nil {
 			return fmt.Errorf("failed to release IP: %w", err)
 		}
@@ -182,7 +182,7 @@ func DebugIPAllocRelease(ctx *Context, opts struct {
 			}
 		}
 
-		result, err := ipalloc.ReleaseSubnet(ctx, opts.Subnet)
+		result, err := netdb.ReleaseSubnet(ctx, opts.Subnet)
 		if err != nil {
 			return fmt.Errorf("failed to release subnet IPs: %w", err)
 		}
@@ -206,7 +206,7 @@ func DebugIPAllocRelease(ctx *Context, opts struct {
 			}
 		}
 
-		result, err := ipalloc.ReleaseAll(ctx)
+		result, err := netdb.ReleaseAll(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to release all IPs: %w", err)
 		}
@@ -218,8 +218,8 @@ func DebugIPAllocRelease(ctx *Context, opts struct {
 	return nil
 }
 
-// DebugIPAllocGC garbage collects IPs not associated with live sandboxes
-func DebugIPAllocGC(ctx *Context, opts struct {
+// DebugNetDBGC garbage collects IPs not associated with live sandboxes
+func DebugNetDBGC(ctx *Context, opts struct {
 	ConfigCentric
 	Subnet string `short:"s" long:"subnet" description:"Only GC IPs in this subnet"`
 	DryRun bool   `short:"n" long:"dry-run" description:"Show what would be released without making changes"`
@@ -230,14 +230,14 @@ func DebugIPAllocGC(ctx *Context, opts struct {
 		opts.DryRun = true
 	}
 
-	client, err := ctx.RPCClient("dev.miren.runtime/debug-ipalloc")
+	client, err := ctx.RPCClient("dev.miren.runtime/debug-netdb")
 	if err != nil {
 		return err
 	}
 
-	ipalloc := debug_v1alpha.NewIPAllocClient(client)
+	netdb := debug_v1alpha.NewNetDBClient(client)
 
-	results, err := ipalloc.Gc(ctx, opts.Subnet, opts.DryRun)
+	results, err := netdb.Gc(ctx, opts.Subnet, opts.DryRun)
 	if err != nil {
 		return fmt.Errorf("failed to run GC: %w", err)
 	}

--- a/cli/commands/debug_netdb.go
+++ b/cli/commands/debug_netdb.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"time"
 
 	"miren.dev/runtime/api/debug/debug_v1alpha"
 	"miren.dev/runtime/pkg/rpc/standard"
@@ -34,7 +33,7 @@ func DebugNetDBList(ctx *Context, opts struct {
 		return nil
 	}
 
-	headers := []string{"IP", "SUBNET", "STATUS", "RELEASED_AT"}
+	headers := []string{"IP", "SUBNET", "STATUS", "SANDBOX", "RELEASED"}
 	rows := make([]ui.Row, len(leases))
 
 	for i, lease := range leases {
@@ -43,15 +42,20 @@ func DebugNetDBList(ctx *Context, opts struct {
 			status = "reserved"
 		}
 
-		releasedStr := "-"
-		if lease.HasReleasedAt() {
-			releasedStr = standard.FromTimestamp(lease.ReleasedAt()).Format(time.RFC3339)
+		sandboxID := "-"
+		if lease.HasSandboxId() {
+			sandboxID = lease.SandboxId()
 		}
 
-		rows[i] = ui.Row{lease.Ip(), lease.Subnet(), status, releasedStr}
+		releasedStr := "-"
+		if lease.HasReleasedAt() {
+			releasedStr = humanFriendlyTimestamp(standard.FromTimestamp(lease.ReleasedAt()))
+		}
+
+		rows[i] = ui.Row{lease.Ip(), lease.Subnet(), status, sandboxID, releasedStr}
 	}
 
-	columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0, 1))
+	columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0, 1, 3))
 	table := ui.NewTable(
 		ui.WithColumns(columns),
 		ui.WithRows(rows),

--- a/cli/commands/debug_netdb.go
+++ b/cli/commands/debug_netdb.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"net/netip"
+	"slices"
 
 	"miren.dev/runtime/api/debug/debug_v1alpha"
 	"miren.dev/runtime/pkg/rpc/standard"
@@ -32,6 +34,13 @@ func DebugNetDBList(ctx *Context, opts struct {
 		ctx.Info("No IP leases found")
 		return nil
 	}
+
+	// Sort by IP address numerically
+	slices.SortFunc(leases, func(a, b *debug_v1alpha.IPLease) int {
+		addrA, _ := netip.ParseAddr(a.Ip())
+		addrB, _ := netip.ParseAddr(b.Ip())
+		return addrA.Compare(addrB)
+	})
 
 	headers := []string{"IP", "SUBNET", "STATUS", "SANDBOX", "RELEASED"}
 	rows := make([]ui.Row, len(leases))

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -21,6 +21,7 @@ import (
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/debug/debug_v1alpha"
 	deployment_v1alpha "miren.dev/runtime/api/deployment/deployment_v1alpha"
 	aes "miren.dev/runtime/api/entityserver"
 	esv1 "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -45,6 +46,7 @@ import (
 	"miren.dev/runtime/pkg/sysstats"
 	"miren.dev/runtime/servers/app"
 	"miren.dev/runtime/servers/build"
+	debugsrv "miren.dev/runtime/servers/debug"
 	"miren.dev/runtime/servers/deployment"
 	"miren.dev/runtime/servers/entityserver"
 	execproxy "miren.dev/runtime/servers/exec_proxy"
@@ -623,6 +625,9 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		return err
 	}
 	server.ExposeValue("dev.miren.runtime/deployment", deployment_v1alpha.AdaptDeployment(ds))
+
+	debugServer := debugsrv.NewServer(c.Log, c.DataPath, eac)
+	server.ExposeValue("dev.miren.runtime/debug-ipalloc", debug_v1alpha.AdaptIPAlloc(debugServer))
 
 	c.Log.Info("started RPC server")
 

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -633,7 +633,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		return err
 	}
 	debugServer := debugsrv.NewServer(c.Log, ndb, eac)
-	server.ExposeValue("dev.miren.runtime/debug-ipalloc", debug_v1alpha.AdaptIPAlloc(debugServer))
+	server.ExposeValue("dev.miren.runtime/debug-netdb", debug_v1alpha.AdaptNetDB(debugServer))
 
 	c.Log.Info("started RPC server")
 

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -42,6 +42,7 @@ import (
 	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/schema"
+	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/sysstats"
 	"miren.dev/runtime/servers/app"
@@ -626,7 +627,12 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	}
 	server.ExposeValue("dev.miren.runtime/deployment", deployment_v1alpha.AdaptDeployment(ds))
 
-	debugServer := debugsrv.NewServer(c.Log, c.DataPath, eac)
+	ndb, err := netdb.New(filepath.Join(c.DataPath, "net.db"))
+	if err != nil {
+		c.Log.Error("failed to open netdb for debug server", "error", err)
+		return err
+	}
+	debugServer := debugsrv.NewServer(c.Log, ndb, eac)
 	server.ExposeValue("dev.miren.runtime/debug-ipalloc", debug_v1alpha.AdaptIPAlloc(debugServer))
 
 	c.Log.Info("started RPC server")

--- a/pkg/netdb/netdb.go
+++ b/pkg/netdb/netdb.go
@@ -491,6 +491,10 @@ func (n *NetDB) ListLeases(filter LeaseFilter) ([]IPLease, error) {
 		leases = append(leases, lease)
 	}
 
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate leases: %w", err)
+	}
+
 	return leases, nil
 }
 
@@ -525,6 +529,10 @@ func (n *NetDB) GetSubnetStatus() ([]SubnetStatus, error) {
 		statuses = append(statuses, status)
 	}
 
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate subnet statuses: %w", err)
+	}
+
 	return statuses, nil
 }
 
@@ -550,6 +558,10 @@ func (n *NetDB) GetReservedIPs(subnet string) ([]string, error) {
 			return nil, fmt.Errorf("failed to scan IP: %w", err)
 		}
 		ips = append(ips, ip)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate reserved IPs: %w", err)
 	}
 
 	return ips, nil

--- a/pkg/netdb/netdb.go
+++ b/pkg/netdb/netdb.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,6 +19,30 @@ type NetDB struct {
 	mu   sync.Mutex
 
 	cooldownDur time.Duration
+}
+
+// IPLease represents an IP lease record from the database.
+type IPLease struct {
+	IP         string
+	Subnet     string
+	Reserved   bool
+	ReleasedAt *time.Time
+}
+
+// SubnetStatus contains utilization statistics for a subnet.
+type SubnetStatus struct {
+	Subnet   string
+	Total    int
+	Reserved int
+	Released int
+	Capacity int
+}
+
+// LeaseFilter specifies filters for listing IP leases.
+type LeaseFilter struct {
+	Subnet       string
+	ReservedOnly bool
+	ReleasedOnly bool
 }
 
 type Subnet struct {
@@ -414,4 +439,206 @@ func (n *NetDB) ReleaseInterface(name string) error {
 
 	_, err := n.db.Exec("DELETE FROM interfaces WHERE name = ?", name)
 	return err
+}
+
+// ListLeases returns IP leases matching the given filter.
+func (n *NetDB) ListLeases(filter LeaseFilter) ([]IPLease, error) {
+	query := "SELECT ip, subnet, reserved, released_at FROM ips"
+	var conditions []string
+	var args []any
+
+	if filter.Subnet != "" {
+		conditions = append(conditions, "subnet = ?")
+		args = append(args, filter.Subnet)
+	}
+	if filter.ReservedOnly {
+		conditions = append(conditions, "reserved = 1")
+	}
+	if filter.ReleasedOnly {
+		conditions = append(conditions, "reserved = 0")
+	}
+
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	query += " ORDER BY subnet, ip"
+
+	rows, err := n.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query leases: %w", err)
+	}
+	defer rows.Close()
+
+	var leases []IPLease
+	for rows.Next() {
+		var ip, subnet string
+		var reserved int
+		var releasedAt sql.NullInt64
+
+		if err := rows.Scan(&ip, &subnet, &reserved, &releasedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan lease: %w", err)
+		}
+
+		lease := IPLease{
+			IP:       ip,
+			Subnet:   subnet,
+			Reserved: reserved == 1,
+		}
+		if releasedAt.Valid {
+			t := time.Unix(releasedAt.Int64, 0)
+			lease.ReleasedAt = &t
+		}
+		leases = append(leases, lease)
+	}
+
+	return leases, nil
+}
+
+// GetSubnetStatus returns utilization statistics for all subnets.
+func (n *NetDB) GetSubnetStatus() ([]SubnetStatus, error) {
+	rows, err := n.db.Query(`
+		SELECT
+			subnet,
+			COUNT(*) as total,
+			SUM(CASE WHEN reserved = 1 THEN 1 ELSE 0 END) as reserved,
+			SUM(CASE WHEN reserved = 0 THEN 1 ELSE 0 END) as released
+		FROM ips
+		GROUP BY subnet
+		ORDER BY subnet
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query subnet status: %w", err)
+	}
+	defer rows.Close()
+
+	var statuses []SubnetStatus
+	for rows.Next() {
+		var status SubnetStatus
+		if err := rows.Scan(&status.Subnet, &status.Total, &status.Reserved, &status.Released); err != nil {
+			return nil, fmt.Errorf("failed to scan subnet status: %w", err)
+		}
+
+		if prefix, err := netip.ParsePrefix(status.Subnet); err == nil {
+			status.Capacity = calculateCapacity(prefix)
+		}
+
+		statuses = append(statuses, status)
+	}
+
+	return statuses, nil
+}
+
+// GetReservedIPs returns all reserved IP addresses, optionally filtered by subnet.
+func (n *NetDB) GetReservedIPs(subnet string) ([]string, error) {
+	query := "SELECT ip FROM ips WHERE reserved = 1"
+	var args []any
+	if subnet != "" {
+		query += " AND subnet = ?"
+		args = append(args, subnet)
+	}
+
+	rows, err := n.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query reserved IPs: %w", err)
+	}
+	defer rows.Close()
+
+	var ips []string
+	for rows.Next() {
+		var ip string
+		if err := rows.Scan(&ip); err != nil {
+			return nil, fmt.Errorf("failed to scan IP: %w", err)
+		}
+		ips = append(ips, ip)
+	}
+
+	return ips, nil
+}
+
+// ForceReleaseIP releases a specific IP address regardless of its current state.
+func (n *NetDB) ForceReleaseIP(ip string) (bool, error) {
+	result, err := n.db.Exec(
+		"UPDATE ips SET reserved = 0, released_at = ? WHERE ip = ? AND reserved = 1",
+		time.Now().Unix(), ip)
+	if err != nil {
+		return false, fmt.Errorf("failed to release IP: %w", err)
+	}
+
+	affected, _ := result.RowsAffected()
+	return affected > 0, nil
+}
+
+// ForceReleaseSubnet releases all reserved IPs in a subnet.
+func (n *NetDB) ForceReleaseSubnet(subnet string) (int, error) {
+	result, err := n.db.Exec(
+		"UPDATE ips SET reserved = 0, released_at = ? WHERE subnet = ? AND reserved = 1",
+		time.Now().Unix(), subnet)
+	if err != nil {
+		return 0, fmt.Errorf("failed to release subnet IPs: %w", err)
+	}
+
+	affected, _ := result.RowsAffected()
+	return int(affected), nil
+}
+
+// ForceReleaseAll releases all reserved IPs.
+func (n *NetDB) ForceReleaseAll() (int, error) {
+	result, err := n.db.Exec(
+		"UPDATE ips SET reserved = 0, released_at = ? WHERE reserved = 1",
+		time.Now().Unix())
+	if err != nil {
+		return 0, fmt.Errorf("failed to release all IPs: %w", err)
+	}
+
+	affected, _ := result.RowsAffected()
+	return int(affected), nil
+}
+
+// ForceReleaseIPs releases a specific set of IPs in a single transaction.
+func (n *NetDB) ForceReleaseIPs(ips []string) error {
+	if len(ips) == 0 {
+		return nil
+	}
+
+	tx, err := n.db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare("UPDATE ips SET reserved = 0, released_at = ? WHERE ip = ?")
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	now := time.Now().Unix()
+	for _, ip := range ips {
+		if _, err := stmt.Exec(now, ip); err != nil {
+			return fmt.Errorf("failed to release IP %s: %w", ip, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+func calculateCapacity(prefix netip.Prefix) int {
+	bits := prefix.Bits()
+	if prefix.Addr().Is4() {
+		hostBits := 32 - bits
+		if hostBits <= 0 {
+			return 0
+		}
+		total := 1 << hostBits
+		return total - 3 // subtract network, broadcast, gateway
+	}
+	hostBits := 128 - bits
+	if hostBits > 16 {
+		hostBits = 16
+	}
+	return (1 << hostBits) - 1
 }

--- a/servers/debug/server.go
+++ b/servers/debug/server.go
@@ -21,7 +21,7 @@ type Server struct {
 	EAC   *entityserver_v1alpha.EntityAccessClient
 }
 
-var _ debug_v1alpha.IPAlloc = &Server{}
+var _ debug_v1alpha.NetDB = &Server{}
 
 func NewServer(log *slog.Logger, ndb *netdb.NetDB, eac *entityserver_v1alpha.EntityAccessClient) *Server {
 	return &Server{
@@ -31,7 +31,7 @@ func NewServer(log *slog.Logger, ndb *netdb.NetDB, eac *entityserver_v1alpha.Ent
 	}
 }
 
-func (s *Server) ListLeases(ctx context.Context, state *debug_v1alpha.IPAllocListLeases) error {
+func (s *Server) ListLeases(ctx context.Context, state *debug_v1alpha.NetDBListLeases) error {
 	args := state.Args()
 	results := state.Results()
 
@@ -64,7 +64,7 @@ func (s *Server) ListLeases(ctx context.Context, state *debug_v1alpha.IPAllocLis
 	return nil
 }
 
-func (s *Server) Status(ctx context.Context, state *debug_v1alpha.IPAllocStatus) error {
+func (s *Server) Status(ctx context.Context, state *debug_v1alpha.NetDBStatus) error {
 	results := state.Results()
 
 	statuses, err := s.NetDB.GetSubnetStatus()
@@ -87,7 +87,7 @@ func (s *Server) Status(ctx context.Context, state *debug_v1alpha.IPAllocStatus)
 	return nil
 }
 
-func (s *Server) ReleaseIP(ctx context.Context, state *debug_v1alpha.IPAllocReleaseIP) error {
+func (s *Server) ReleaseIP(ctx context.Context, state *debug_v1alpha.NetDBReleaseIP) error {
 	args := state.Args()
 	results := state.Results()
 
@@ -100,7 +100,7 @@ func (s *Server) ReleaseIP(ctx context.Context, state *debug_v1alpha.IPAllocRele
 	return nil
 }
 
-func (s *Server) ReleaseSubnet(ctx context.Context, state *debug_v1alpha.IPAllocReleaseSubnet) error {
+func (s *Server) ReleaseSubnet(ctx context.Context, state *debug_v1alpha.NetDBReleaseSubnet) error {
 	args := state.Args()
 	results := state.Results()
 
@@ -113,7 +113,7 @@ func (s *Server) ReleaseSubnet(ctx context.Context, state *debug_v1alpha.IPAlloc
 	return nil
 }
 
-func (s *Server) ReleaseAll(ctx context.Context, state *debug_v1alpha.IPAllocReleaseAll) error {
+func (s *Server) ReleaseAll(ctx context.Context, state *debug_v1alpha.NetDBReleaseAll) error {
 	results := state.Results()
 
 	count, err := s.NetDB.ForceReleaseAll()
@@ -125,7 +125,7 @@ func (s *Server) ReleaseAll(ctx context.Context, state *debug_v1alpha.IPAllocRel
 	return nil
 }
 
-func (s *Server) Gc(ctx context.Context, state *debug_v1alpha.IPAllocGc) error {
+func (s *Server) Gc(ctx context.Context, state *debug_v1alpha.NetDBGc) error {
 	args := state.Args()
 	results := state.Results()
 

--- a/servers/debug/server.go
+++ b/servers/debug/server.go
@@ -23,12 +23,23 @@ type Server struct {
 
 var _ debug_v1alpha.NetDB = &Server{}
 
-func NewServer(log *slog.Logger, ndb *netdb.NetDB, eac *entityserver_v1alpha.EntityAccessClient) *Server {
+func NewServer(log *slog.Logger, netdbPath string, eac *entityserver_v1alpha.EntityAccessClient) (*Server, error) {
+	ndb, err := netdb.New(netdbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open netdb: %w", err)
+	}
 	return &Server{
 		Log:   log.With("module", "debug"),
 		NetDB: ndb,
 		EAC:   eac,
+	}, nil
+}
+
+func (s *Server) Close() error {
+	if s.NetDB != nil {
+		return s.NetDB.Close()
 	}
+	return nil
 }
 
 func (s *Server) ListLeases(ctx context.Context, state *debug_v1alpha.NetDBListLeases) error {

--- a/servers/debug/server.go
+++ b/servers/debug/server.go
@@ -2,164 +2,88 @@ package debug
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"log/slog"
 	"net/netip"
-	"path/filepath"
 	"strings"
-	"time"
 
-	_ "github.com/mattn/go-sqlite3"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/debug/debug_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc/standard"
 )
 
 type Server struct {
-	Log      *slog.Logger
-	DataPath string
-	EAC      *entityserver_v1alpha.EntityAccessClient
+	Log   *slog.Logger
+	NetDB *netdb.NetDB
+	EAC   *entityserver_v1alpha.EntityAccessClient
 }
 
 var _ debug_v1alpha.IPAlloc = &Server{}
 
-func NewServer(log *slog.Logger, dataPath string, eac *entityserver_v1alpha.EntityAccessClient) *Server {
+func NewServer(log *slog.Logger, ndb *netdb.NetDB, eac *entityserver_v1alpha.EntityAccessClient) *Server {
 	return &Server{
-		Log:      log.With("module", "debug"),
-		DataPath: dataPath,
-		EAC:      eac,
+		Log:   log.With("module", "debug"),
+		NetDB: ndb,
+		EAC:   eac,
 	}
-}
-
-func (s *Server) openDB() (*sql.DB, error) {
-	dbPath := filepath.Join(s.DataPath, "net.db")
-	db, err := sql.Open("sqlite3", dbPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open netdb at %s: %w", dbPath, err)
-	}
-	if err := db.Ping(); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("failed to connect to netdb at %s: %w", dbPath, err)
-	}
-	return db, nil
 }
 
 func (s *Server) ListLeases(ctx context.Context, state *debug_v1alpha.IPAllocListLeases) error {
 	args := state.Args()
 	results := state.Results()
 
-	db, err := s.openDB()
+	filter := netdb.LeaseFilter{
+		ReservedOnly: args.ReservedOnly(),
+		ReleasedOnly: args.ReleasedOnly(),
+	}
+	if args.HasSubnet() {
+		filter.Subnet = args.Subnet()
+	}
+
+	leases, err := s.NetDB.ListLeases(filter)
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
-	query := "SELECT ip, subnet, reserved, released_at FROM ips"
-	var conditions []string
-	var queryArgs []any
-
-	if args.HasSubnet() && args.Subnet() != "" {
-		conditions = append(conditions, "subnet = ?")
-		queryArgs = append(queryArgs, args.Subnet())
-	}
-	if args.ReservedOnly() {
-		conditions = append(conditions, "reserved = 1")
-	}
-	if args.ReleasedOnly() {
-		conditions = append(conditions, "reserved = 0")
-	}
-	if args.StuckOnly() {
-		conditions = append(conditions, "reserved = 1 AND released_at IS NULL")
-	}
-
-	if len(conditions) > 0 {
-		query += " WHERE " + strings.Join(conditions, " AND ")
-	}
-	query += " ORDER BY subnet, ip"
-
-	rows, err := db.QueryContext(ctx, query, queryArgs...)
-	if err != nil {
-		return fmt.Errorf("failed to query IPs: %w", err)
-	}
-	defer rows.Close()
-
-	var leases []*debug_v1alpha.IPLease
-	for rows.Next() {
-		var ip, subnet string
-		var reserved int
-		var releasedAt sql.NullInt64
-
-		if err := rows.Scan(&ip, &subnet, &reserved, &releasedAt); err != nil {
-			return fmt.Errorf("failed to scan row: %w", err)
+	rpcLeases := make([]*debug_v1alpha.IPLease, len(leases))
+	for i, lease := range leases {
+		rpcLease := &debug_v1alpha.IPLease{}
+		rpcLease.SetIp(lease.IP)
+		rpcLease.SetSubnet(lease.Subnet)
+		rpcLease.SetReserved(lease.Reserved)
+		if lease.ReleasedAt != nil {
+			rpcLease.SetReleasedAt(standard.ToTimestamp(*lease.ReleasedAt))
 		}
-
-		lease := &debug_v1alpha.IPLease{}
-		lease.SetIp(ip)
-		lease.SetSubnet(subnet)
-		lease.SetReserved(reserved == 1)
-		if releasedAt.Valid {
-			lease.SetReleasedAt(standard.ToTimestamp(time.Unix(releasedAt.Int64, 0)))
-		}
-		leases = append(leases, lease)
+		rpcLeases[i] = rpcLease
 	}
 
-	results.SetLeases(leases)
+	results.SetLeases(rpcLeases)
 	return nil
 }
 
 func (s *Server) Status(ctx context.Context, state *debug_v1alpha.IPAllocStatus) error {
 	results := state.Results()
 
-	db, err := s.openDB()
+	statuses, err := s.NetDB.GetSubnetStatus()
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
-	rows, err := db.QueryContext(ctx, `
-		SELECT
-			subnet,
-			COUNT(*) as total,
-			SUM(CASE WHEN reserved = 1 THEN 1 ELSE 0 END) as reserved,
-			SUM(CASE WHEN reserved = 0 THEN 1 ELSE 0 END) as released,
-			SUM(CASE WHEN reserved = 1 AND released_at IS NULL THEN 1 ELSE 0 END) as stuck
-		FROM ips
-		GROUP BY subnet
-		ORDER BY subnet
-	`)
-	if err != nil {
-		return fmt.Errorf("failed to query stats: %w", err)
-	}
-	defer rows.Close()
-
-	var subnets []*debug_v1alpha.SubnetStatus
-	for rows.Next() {
-		var subnet string
-		var total, reserved, released, stuck int32
-
-		if err := rows.Scan(&subnet, &total, &reserved, &released, &stuck); err != nil {
-			return fmt.Errorf("failed to scan row: %w", err)
-		}
-
-		status := &debug_v1alpha.SubnetStatus{}
-		status.SetSubnet(subnet)
-		status.SetTotal(total)
-		status.SetReserved(reserved)
-		status.SetReleased(released)
-		status.SetStuck(stuck)
-
-		// Calculate capacity
-		if prefix, err := netip.ParsePrefix(subnet); err == nil {
-			status.SetCapacity(int32(calculateCapacity(prefix)))
-		}
-
-		subnets = append(subnets, status)
+	rpcStatuses := make([]*debug_v1alpha.SubnetStatus, len(statuses))
+	for i, status := range statuses {
+		rpcStatus := &debug_v1alpha.SubnetStatus{}
+		rpcStatus.SetSubnet(status.Subnet)
+		rpcStatus.SetTotal(int32(status.Total))
+		rpcStatus.SetReserved(int32(status.Reserved))
+		rpcStatus.SetReleased(int32(status.Released))
+		rpcStatus.SetCapacity(int32(status.Capacity))
+		rpcStatuses[i] = rpcStatus
 	}
 
-	results.SetSubnets(subnets)
+	results.SetSubnets(rpcStatuses)
 	return nil
 }
 
@@ -167,21 +91,12 @@ func (s *Server) ReleaseIP(ctx context.Context, state *debug_v1alpha.IPAllocRele
 	args := state.Args()
 	results := state.Results()
 
-	db, err := s.openDB()
+	released, err := s.NetDB.ForceReleaseIP(args.Ip())
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
-	result, err := db.ExecContext(ctx,
-		"UPDATE ips SET reserved = 0, released_at = ? WHERE ip = ? AND reserved = 1",
-		time.Now().Unix(), args.Ip())
-	if err != nil {
-		return fmt.Errorf("failed to release IP: %w", err)
-	}
-
-	affected, _ := result.RowsAffected()
-	results.SetReleased(affected > 0)
+	results.SetReleased(released)
 	return nil
 }
 
@@ -189,42 +104,24 @@ func (s *Server) ReleaseSubnet(ctx context.Context, state *debug_v1alpha.IPAlloc
 	args := state.Args()
 	results := state.Results()
 
-	db, err := s.openDB()
+	count, err := s.NetDB.ForceReleaseSubnet(args.Subnet())
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
-	result, err := db.ExecContext(ctx,
-		"UPDATE ips SET reserved = 0, released_at = ? WHERE subnet = ? AND reserved = 1 AND released_at IS NULL",
-		time.Now().Unix(), args.Subnet())
-	if err != nil {
-		return fmt.Errorf("failed to release subnet IPs: %w", err)
-	}
-
-	affected, _ := result.RowsAffected()
-	results.SetCount(int32(affected))
+	results.SetCount(int32(count))
 	return nil
 }
 
 func (s *Server) ReleaseAll(ctx context.Context, state *debug_v1alpha.IPAllocReleaseAll) error {
 	results := state.Results()
 
-	db, err := s.openDB()
+	count, err := s.NetDB.ForceReleaseAll()
 	if err != nil {
 		return err
 	}
-	defer db.Close()
 
-	result, err := db.ExecContext(ctx,
-		"UPDATE ips SET reserved = 0, released_at = ? WHERE reserved = 1 AND released_at IS NULL",
-		time.Now().Unix())
-	if err != nil {
-		return fmt.Errorf("failed to release all IPs: %w", err)
-	}
-
-	affected, _ := result.RowsAffected()
-	results.SetCount(int32(affected))
+	results.SetCount(int32(count))
 	return nil
 }
 
@@ -257,31 +154,18 @@ func (s *Server) Gc(ctx context.Context, state *debug_v1alpha.IPAllocGc) error {
 	}
 
 	// Query reserved IPs from netdb
-	db, err := s.openDB()
+	var subnet string
+	if args.HasSubnet() {
+		subnet = args.Subnet()
+	}
+
+	reservedIPs, err := s.NetDB.GetReservedIPs(subnet)
 	if err != nil {
 		return err
 	}
-	defer db.Close()
-
-	query := "SELECT ip FROM ips WHERE reserved = 1"
-	var queryArgs []any
-	if args.HasSubnet() && args.Subnet() != "" {
-		query += " AND subnet = ?"
-		queryArgs = append(queryArgs, args.Subnet())
-	}
-
-	rows, err := db.QueryContext(ctx, query, queryArgs...)
-	if err != nil {
-		return fmt.Errorf("failed to query IPs: %w", err)
-	}
-	defer rows.Close()
 
 	var orphanedIPs []string
-	for rows.Next() {
-		var ip string
-		if err := rows.Scan(&ip); err != nil {
-			return fmt.Errorf("failed to scan row: %w", err)
-		}
+	for _, ip := range reservedIPs {
 		if !liveIPs[ip] {
 			orphanedIPs = append(orphanedIPs, ip)
 		}
@@ -294,47 +178,10 @@ func (s *Server) Gc(ctx context.Context, state *debug_v1alpha.IPAllocGc) error {
 		return nil
 	}
 
-	// Release orphaned IPs
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer tx.Rollback()
-
-	stmt, err := tx.PrepareContext(ctx, "UPDATE ips SET reserved = 0, released_at = ? WHERE ip = ?")
-	if err != nil {
-		return fmt.Errorf("failed to prepare statement: %w", err)
-	}
-	defer stmt.Close()
-
-	now := time.Now().Unix()
-	for _, ip := range orphanedIPs {
-		if _, err := stmt.ExecContext(ctx, now, ip); err != nil {
-			return fmt.Errorf("failed to release IP %s: %w", ip, err)
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
+	if err := s.NetDB.ForceReleaseIPs(orphanedIPs); err != nil {
+		return err
 	}
 
 	results.SetReleasedCount(int32(len(orphanedIPs)))
 	return nil
-}
-
-func calculateCapacity(prefix netip.Prefix) int {
-	bits := prefix.Bits()
-	if prefix.Addr().Is4() {
-		hostBits := 32 - bits
-		if hostBits <= 0 {
-			return 0
-		}
-		total := 1 << hostBits
-		return total - 3 // subtract network, broadcast, gateway
-	}
-	hostBits := 128 - bits
-	if hostBits > 16 {
-		hostBits = 16
-	}
-	return (1 << hostBits) - 1
 }

--- a/servers/debug/server.go
+++ b/servers/debug/server.go
@@ -1,0 +1,340 @@
+package debug
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/debug/debug_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/rpc/standard"
+)
+
+type Server struct {
+	Log      *slog.Logger
+	DataPath string
+	EAC      *entityserver_v1alpha.EntityAccessClient
+}
+
+var _ debug_v1alpha.IPAlloc = &Server{}
+
+func NewServer(log *slog.Logger, dataPath string, eac *entityserver_v1alpha.EntityAccessClient) *Server {
+	return &Server{
+		Log:      log.With("module", "debug"),
+		DataPath: dataPath,
+		EAC:      eac,
+	}
+}
+
+func (s *Server) openDB() (*sql.DB, error) {
+	dbPath := filepath.Join(s.DataPath, "net.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open netdb at %s: %w", dbPath, err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to connect to netdb at %s: %w", dbPath, err)
+	}
+	return db, nil
+}
+
+func (s *Server) ListLeases(ctx context.Context, state *debug_v1alpha.IPAllocListLeases) error {
+	args := state.Args()
+	results := state.Results()
+
+	db, err := s.openDB()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	query := "SELECT ip, subnet, reserved, released_at FROM ips"
+	var conditions []string
+	var queryArgs []any
+
+	if args.HasSubnet() && args.Subnet() != "" {
+		conditions = append(conditions, "subnet = ?")
+		queryArgs = append(queryArgs, args.Subnet())
+	}
+	if args.ReservedOnly() {
+		conditions = append(conditions, "reserved = 1")
+	}
+	if args.ReleasedOnly() {
+		conditions = append(conditions, "reserved = 0")
+	}
+	if args.StuckOnly() {
+		conditions = append(conditions, "reserved = 1 AND released_at IS NULL")
+	}
+
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	query += " ORDER BY subnet, ip"
+
+	rows, err := db.QueryContext(ctx, query, queryArgs...)
+	if err != nil {
+		return fmt.Errorf("failed to query IPs: %w", err)
+	}
+	defer rows.Close()
+
+	var leases []*debug_v1alpha.IPLease
+	for rows.Next() {
+		var ip, subnet string
+		var reserved int
+		var releasedAt sql.NullInt64
+
+		if err := rows.Scan(&ip, &subnet, &reserved, &releasedAt); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		lease := &debug_v1alpha.IPLease{}
+		lease.SetIp(ip)
+		lease.SetSubnet(subnet)
+		lease.SetReserved(reserved == 1)
+		if releasedAt.Valid {
+			lease.SetReleasedAt(standard.ToTimestamp(time.Unix(releasedAt.Int64, 0)))
+		}
+		leases = append(leases, lease)
+	}
+
+	results.SetLeases(leases)
+	return nil
+}
+
+func (s *Server) Status(ctx context.Context, state *debug_v1alpha.IPAllocStatus) error {
+	results := state.Results()
+
+	db, err := s.openDB()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT
+			subnet,
+			COUNT(*) as total,
+			SUM(CASE WHEN reserved = 1 THEN 1 ELSE 0 END) as reserved,
+			SUM(CASE WHEN reserved = 0 THEN 1 ELSE 0 END) as released,
+			SUM(CASE WHEN reserved = 1 AND released_at IS NULL THEN 1 ELSE 0 END) as stuck
+		FROM ips
+		GROUP BY subnet
+		ORDER BY subnet
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to query stats: %w", err)
+	}
+	defer rows.Close()
+
+	var subnets []*debug_v1alpha.SubnetStatus
+	for rows.Next() {
+		var subnet string
+		var total, reserved, released, stuck int32
+
+		if err := rows.Scan(&subnet, &total, &reserved, &released, &stuck); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		status := &debug_v1alpha.SubnetStatus{}
+		status.SetSubnet(subnet)
+		status.SetTotal(total)
+		status.SetReserved(reserved)
+		status.SetReleased(released)
+		status.SetStuck(stuck)
+
+		// Calculate capacity
+		if prefix, err := netip.ParsePrefix(subnet); err == nil {
+			status.SetCapacity(int32(calculateCapacity(prefix)))
+		}
+
+		subnets = append(subnets, status)
+	}
+
+	results.SetSubnets(subnets)
+	return nil
+}
+
+func (s *Server) ReleaseIP(ctx context.Context, state *debug_v1alpha.IPAllocReleaseIP) error {
+	args := state.Args()
+	results := state.Results()
+
+	db, err := s.openDB()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	result, err := db.ExecContext(ctx,
+		"UPDATE ips SET reserved = 0, released_at = ? WHERE ip = ? AND reserved = 1",
+		time.Now().Unix(), args.Ip())
+	if err != nil {
+		return fmt.Errorf("failed to release IP: %w", err)
+	}
+
+	affected, _ := result.RowsAffected()
+	results.SetReleased(affected > 0)
+	return nil
+}
+
+func (s *Server) ReleaseSubnet(ctx context.Context, state *debug_v1alpha.IPAllocReleaseSubnet) error {
+	args := state.Args()
+	results := state.Results()
+
+	db, err := s.openDB()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	result, err := db.ExecContext(ctx,
+		"UPDATE ips SET reserved = 0, released_at = ? WHERE subnet = ? AND reserved = 1 AND released_at IS NULL",
+		time.Now().Unix(), args.Subnet())
+	if err != nil {
+		return fmt.Errorf("failed to release subnet IPs: %w", err)
+	}
+
+	affected, _ := result.RowsAffected()
+	results.SetCount(int32(affected))
+	return nil
+}
+
+func (s *Server) ReleaseAll(ctx context.Context, state *debug_v1alpha.IPAllocReleaseAll) error {
+	results := state.Results()
+
+	db, err := s.openDB()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	result, err := db.ExecContext(ctx,
+		"UPDATE ips SET reserved = 0, released_at = ? WHERE reserved = 1 AND released_at IS NULL",
+		time.Now().Unix())
+	if err != nil {
+		return fmt.Errorf("failed to release all IPs: %w", err)
+	}
+
+	affected, _ := result.RowsAffected()
+	results.SetCount(int32(affected))
+	return nil
+}
+
+func (s *Server) Gc(ctx context.Context, state *debug_v1alpha.IPAllocGc) error {
+	args := state.Args()
+	results := state.Results()
+
+	// Get all sandbox IPs from entity store
+	sandboxRef := entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox)
+	sandboxes, err := s.EAC.List(ctx, sandboxRef)
+	if err != nil {
+		return fmt.Errorf("failed to list sandboxes: %w", err)
+	}
+
+	// Build set of IPs that are in use by sandboxes
+	liveIPs := make(map[string]bool)
+	for _, sbEnt := range sandboxes.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(sbEnt.Entity())
+
+		for _, net := range sb.Network {
+			addr := net.Address
+			if strings.Contains(addr, "/") {
+				if prefix, err := netip.ParsePrefix(addr); err == nil {
+					addr = prefix.Addr().String()
+				}
+			}
+			liveIPs[addr] = true
+		}
+	}
+
+	// Query reserved IPs from netdb
+	db, err := s.openDB()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	query := "SELECT ip FROM ips WHERE reserved = 1"
+	var queryArgs []any
+	if args.HasSubnet() && args.Subnet() != "" {
+		query += " AND subnet = ?"
+		queryArgs = append(queryArgs, args.Subnet())
+	}
+
+	rows, err := db.QueryContext(ctx, query, queryArgs...)
+	if err != nil {
+		return fmt.Errorf("failed to query IPs: %w", err)
+	}
+	defer rows.Close()
+
+	var orphanedIPs []string
+	for rows.Next() {
+		var ip string
+		if err := rows.Scan(&ip); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+		if !liveIPs[ip] {
+			orphanedIPs = append(orphanedIPs, ip)
+		}
+	}
+
+	results.SetOrphanedIps(orphanedIPs)
+
+	if args.DryRun() || len(orphanedIPs) == 0 {
+		results.SetReleasedCount(0)
+		return nil
+	}
+
+	// Release orphaned IPs
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, "UPDATE ips SET reserved = 0, released_at = ? WHERE ip = ?")
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	now := time.Now().Unix()
+	for _, ip := range orphanedIPs {
+		if _, err := stmt.ExecContext(ctx, now, ip); err != nil {
+			return fmt.Errorf("failed to release IP %s: %w", ip, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	results.SetReleasedCount(int32(len(orphanedIPs)))
+	return nil
+}
+
+func calculateCapacity(prefix netip.Prefix) int {
+	bits := prefix.Bits()
+	if prefix.Addr().Is4() {
+		hostBits := 32 - bits
+		if hostBits <= 0 {
+			return 0
+		}
+		total := 1 << hostBits
+		return total - 3 // subtract network, broadcast, gateway
+	}
+	hostBits := 128 - bits
+	if hostBits > 16 {
+		hostBits = 16
+	}
+	return (1 << hostBits) - 1
+}


### PR DESCRIPTION
## Summary
- Add `debug ipalloc` CLI commands to inspect and manage IP leases in the network database
- Implements an RPC service (`dev.miren.runtime/debug-ipalloc`) for remote access

Contributes to MIR-452. This provides tooling to diagnose and recover from IP exhaustion, but does not address the underlying leaks causing stuck leases. Follow-up PRs will chase down the leak sources.

## Commands
- `miren debug ipalloc list` - List IP leases with filters (`--subnet`, `--reserved`, `--released`, `--stuck`)
- `miren debug ipalloc status` - Show subnet utilization statistics (capacity, reserved, released, stuck, usage %)
- `miren debug ipalloc release` - Manually release IPs (`--ip`, `--subnet`, or `--all` with `--force`)
- `miren debug ipalloc gc` - Find and release orphaned IPs (reserved but no matching sandbox)

## Test plan
- [ ] Deploy to a cluster with stuck IP leases
- [ ] Verify `debug ipalloc status` shows correct utilization
- [ ] Verify `debug ipalloc list --stuck` identifies stuck leases
- [ ] Verify `debug ipalloc gc --dry-run` identifies orphaned IPs
- [ ] Verify `debug ipalloc gc --force` releases orphaned IPs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive debug CLI: list leases, view per‑subnet status, release IPs/subnets/all (confirmation/force), and garbage‑collect orphaned IPs (dry‑run support).
  * New NetDB debug RPC API with typed request/response models for lease listing, status, release, and GC, plus a client for remote calls.
  * Debug server exposing NetDB RPC and coordinator integration so CLI and services can operate remotely.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->