### PR TITLE
Fix IP address leaks in sandbox lifecycle

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -364,6 +364,7 @@ func (c *SandboxController) Init(ctx context.Context) error {
 		EAC:           c.EAC,
 		Namespace:     c.Namespace,
 		CheckInterval: 5 * time.Minute,
+		Subnet:        c.Subnet,
 	}
 	c.watchdog.Start(c.topCtx)
 

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -765,6 +765,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 	// here. This update must go through.
 	res, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
 	if err != nil {
+		c.deallocateNetwork(ctx, ep)
 		return fmt.Errorf("failed to patch sandbox with network address: %w", err)
 	}
 

--- a/controllers/sandbox/watchdog.go
+++ b/controllers/sandbox/watchdog.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/netip"
+	"strings"
 	"time"
 
 	"github.com/containerd/containerd/namespaces"
@@ -13,6 +15,7 @@ import (
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/netdb"
 )
 
 // CleanupResult contains information about containers cleaned up during orphan removal
@@ -36,6 +39,8 @@ type ContainerWatchdog struct {
 	CheckInterval time.Duration
 	// GraceWindow is how long to wait before removing containers from non-running sandboxes
 	GraceWindow time.Duration
+	// Subnet is used to release IP addresses when removing orphaned containers
+	Subnet *netdb.Subnet
 
 	cancel context.CancelFunc
 }
@@ -168,8 +173,12 @@ func (w *ContainerWatchdog) cleanupOrphanedContainers(ctx context.Context) (*Cle
 		}
 	}
 
-	// Identify orphaned containers
-	var orphanedContainers []containerd.Container
+	// Identify orphaned containers and store their labels for IP cleanup
+	type orphanedContainer struct {
+		container containerd.Container
+		labels    map[string]string
+	}
+	var orphanedContainers []orphanedContainer
 	for _, container := range containerList {
 		containerID := container.ID()
 
@@ -191,7 +200,7 @@ func (w *ContainerWatchdog) cleanupOrphanedContainers(ctx context.Context) (*Cle
 		}
 
 		w.Log.Info("watchdog found orphaned container", "id", containerID, "labels", labels)
-		orphanedContainers = append(orphanedContainers, container)
+		orphanedContainers = append(orphanedContainers, orphanedContainer{container: container, labels: labels})
 	}
 
 	if len(orphanedContainers) == 0 {
@@ -200,9 +209,9 @@ func (w *ContainerWatchdog) cleanupOrphanedContainers(ctx context.Context) (*Cle
 
 	// Phase 1: Send SIGQUIT to all orphaned containers to give them a chance to shutdown gracefully
 	w.Log.Info("sending SIGQUIT to orphaned containers", "count", len(orphanedContainers))
-	for _, container := range orphanedContainers {
-		containerID := container.ID()
-		task, err := container.Task(cleanupCtx, nil)
+	for _, oc := range orphanedContainers {
+		containerID := oc.container.ID()
+		task, err := oc.container.Task(cleanupCtx, nil)
 		if err == nil && task != nil {
 			if killErr := task.Kill(cleanupCtx, 3); killErr != nil { // SIGQUIT = 3
 				w.Log.Debug("failed to send SIGQUIT to task", "id", containerID, "error", killErr)
@@ -217,10 +226,10 @@ func (w *ContainerWatchdog) cleanupOrphanedContainers(ctx context.Context) (*Cle
 	time.Sleep(5 * time.Second)
 
 	// Phase 3: Check which containers are still alive and force kill them
-	for _, container := range orphanedContainers {
-		containerID := container.ID()
+	for _, oc := range orphanedContainers {
+		containerID := oc.container.ID()
 
-		task, err := container.Task(cleanupCtx, nil)
+		task, err := oc.container.Task(cleanupCtx, nil)
 		stillAlive := err == nil && task != nil
 
 		if stillAlive {
@@ -231,8 +240,23 @@ func (w *ContainerWatchdog) cleanupOrphanedContainers(ctx context.Context) (*Cle
 			}
 		}
 
+		// Release IPs from container labels before removing the container
+		if w.Subnet != nil {
+			for label, value := range oc.labels {
+				if strings.HasPrefix(label, "runtime.computer/ip") {
+					if addr, err := netip.ParseAddr(value); err == nil {
+						if err := w.Subnet.ReleaseAddr(addr); err != nil {
+							w.Log.Error("watchdog failed to release IP", "id", containerID, "addr", addr, "error", err)
+						} else {
+							w.Log.Debug("watchdog released IP", "id", containerID, "addr", addr)
+						}
+					}
+				}
+			}
+		}
+
 		// Aggressively remove the container
-		if err := w.removeContainer(cleanupCtx, container); err != nil {
+		if err := w.removeContainer(cleanupCtx, oc.container); err != nil {
 			w.Log.Error("watchdog failed to remove orphaned container", "id", containerID, "error", err)
 			result.FailedContainers[containerID] = err
 		} else {


### PR DESCRIPTION
## Summary

Fixes multiple IP address leak scenarios that cause IP exhaustion during sandbox boot loops. This PR addresses the root causes identified in MIR-452.

### Fix 1: Entity patch failure during sandbox creation
When `createSandbox` allocates a network address but fails to patch the entity (e.g., context canceled during shutdown), the IP was never released. This was the primary cause of leaks during service restarts.

### Fix 2: Missing container during sandbox cleanup  
When `stopSandbox` runs but the container no longer exists, IPs couldn't be retrieved from container labels. Added fallback to get IPs from the entity store.

### Fix 3: Watchdog orphan cleanup
The container watchdog removes orphaned containers but wasn't releasing their IPs. Now extracts IPs from container labels before removal.

## Evidence

Production logs from miren-garden showed ~90 "failed to patch sandbox with network address: context canceled" errors in 2 seconds during a service restart, each leaking an IP:

```
Dec 10 22:04:21 miren-garden systemd[1]: Stopping miren.service...
Dec 10 22:04:21 miren-garden miren[2575496]: Signal received, shutting down
Dec 10 22:04:21 miren-garden miren[2575496]: [ERROR] failed to patch sandbox with network address: context canceled
... (repeated ~90 times for same 2 sandboxes)
```

## Test plan

- [ ] Verify lint passes (`make lint`)
- [ ] Run sandbox controller tests
- [ ] Deploy to miren-garden and verify no new IP leaks during restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented network resource leaks by ensuring allocated IPs are released when sandbox setup fails.
  * Improved IP retrieval during shutdown with additional fallback lookups so cleanup reliably removes network endpoints.

* **Refactor**
  * Reworked orphaned-container tracking and cleanup flow to preserve container labels and enable per-container IP release.
  * Propagated network context into watchdog routines for more reliable IP management and logging during cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->