### PR TITLE
Bump system requirements: 4GB RAM, 20GB disk

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -24,8 +24,10 @@ This script will:
 
 - **Operating System**: Linux (kernel 5.10+)
 - **Architecture**: x86_64 or arm64
-- **Memory**: 2GB minimum, 4GB recommended
-- **Storage**: 10GB minimum free space
+- **Memory**: 4GB minimum, 8GB recommended
+- **Storage**: 20GB minimum, 50GB recommended
+
+[Why these requirements?](#a-note-on-system-requirements)
 
 ### Verify Installation
 
@@ -261,6 +263,14 @@ miren route
 - Check the [CLI Reference](/cli-reference) for command details
 - View the [FAQ](https://miren.dev/developer-preview#faq-1)
 - See [Support](/support) for bug reports, feature requests, and community help
+
+## A Note on System Requirements
+
+Miren runs several components—containerd, etcd, buildkit, metrics, and logging—that together use around 600MB of memory at idle. During builds, memory usage spikes as buildkit compiles your application. A single Rails app with Postgres can push total usage past 1.3GB during deployment, which is why we recommend 4GB minimum.
+
+For storage, container images and build caches add up quickly. Base images for languages like Ruby or Python are 50-80MB compressed but expand on disk, and buildkit caches intermediate build layers aggressively. A Rails deployment can easily use 15-20GB between base images, build cache, and the container registry. If you're tight on space, you'll see "no space left on device" errors during builds.
+
+We're still learning about system requirements as more users deploy Miren in different contexts. If you have an interesting deployment scenario or resource constraints you'd like to discuss, come chat with us on [Discord](https://miren.dev/discord)!
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- Update memory requirements from 2GB/4GB to 4GB/8GB (min/recommended)
- Update storage requirements from 10GB to 20GB/50GB (min/recommended)
- Add detailed explanation section with real-world data backing the recommendations

## Context
Users were hitting "no space left on device" errors on small VPSes (e.g., 5GB). 
Analysis showed:
- Miren infrastructure uses ~600MB RAM at idle, 1.3GB+ during builds
- A single Rails + Postgres deployment can use 15-20GB of disk between base 
  images, build cache, and the container registry

## Changes
- Keeps the requirements section clean with just bullet points
- Adds "A Note on System Requirements" section near the bottom explaining the why
- Invites users with interesting deployment scenarios to chat on Discord

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system requirements: Memory minimum increased from 2GB to 4GB; storage minimum increased from 10GB to 20GB.
  * Added detailed guidance on memory usage during idle (~600MB) and build times (up to 1.3GB for complex deployments) and storage considerations (15-20GB practical usage with caches).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->