### PR TITLE
Enable IPv6 listening for VictoriaMetrics and VictoriaLogs

### DIFF
--- a/components/victorialogs/victorialogs.go
+++ b/components/victorialogs/victorialogs.go
@@ -302,6 +302,7 @@ func (c *VictoriaLogsComponent) createContainer(ctx context.Context, image conta
 			"-storageDataPath=/victoria-logs-data",
 			"-retentionPeriod="+config.RetentionPeriod,
 			"-httpListenAddr="+listenAddr,
+			"-enableTCP6",
 		),
 		oci.WithHostHostsFile,
 		oci.WithHostResolvconf,

--- a/components/victoriametrics/victoriametrics.go
+++ b/components/victoriametrics/victoriametrics.go
@@ -311,6 +311,7 @@ func (c *VictoriaMetricsComponent) createContainer(ctx context.Context, image co
 			"-retentionPeriod="+config.RetentionPeriod,
 			"-httpListenAddr="+listenAddr,
 			"-search.latencyOffset=2s",
+			"-enableTCP6",
 		),
 		oci.WithHostHostsFile,
 		oci.WithHostResolvconf,


### PR DESCRIPTION
## Summary
- Add `-enableTCP6` flag to VictoriaMetrics and VictoriaLogs containers to enable dual-stack (IPv4 + IPv6) listening

## Problem
Go's HTTP client uses "Happy Eyeballs" (RFC 6555) when connecting to `localhost`, which resolves to both `::1` (IPv6) and `127.0.0.1` (IPv4). The algorithm typically tries IPv6 first. Since VictoriaMetrics was only listening on IPv4 (`0.0.0.0:8428`), connections would fail when the client chose IPv6:

```
[ERROR] failed to send metrics to victoriametrics │ error: "failed to send metrics: Post \"http://localhost:8428/api/v1/import/prometheus\": dial tcp [::1]:8428: connect: connection refused"
```

## Fix
VictoriaMetrics defaults to IPv4-only listening. Adding the `-enableTCP6` flag enables dual-stack mode, allowing it to accept connections on both IPv4 and IPv6.

## Test plan
- Deploy updated runtime and verify VictoriaMetrics listens on both IPv4 and IPv6:
  ```
  ss -tlnp | grep 8428
  # Should show both 0.0.0.0:8428 and [::]:8428
  ```
- Verify `curl -6 http://localhost:8428/health` succeeds
- Verify metrics writer no longer logs connection refused errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled IPv6 TCP support for VictoriaLogs and VictoriaMetrics services, allowing these components to communicate over IPv6 networks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->