### PR TITLE
Fix stale pool reference causing "error acquiring lease" after pool deletion

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -548,7 +548,7 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 						// Fetch fresh pool state
 						freshPoolEnt, getErr := a.eac.Get(ctx, poolID.String())
 						if getErr != nil {
-							if errors.Is(getErr, entity.ErrNotFound) {
+							if errors.Is(getErr, cond.ErrNotFound{}) {
 								// Pool was deleted, clear cache and break out to outer loop
 								a.log.Info("pool was deleted during update, clearing stale reference",
 									"pool", poolID,
@@ -578,7 +578,7 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 					}
 
 					// If pool was deleted, clear stale reference and break to re-query
-					if errors.Is(err, entity.ErrNotFound) {
+					if errors.Is(err, cond.ErrNotFound{}) {
 						a.log.Info("pool was deleted, clearing stale reference",
 							"pool", poolID,
 							"service", service)
@@ -753,7 +753,7 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 					continue // Retry from the beginning
 				}
 				// If pool was deleted, clear cache and retry
-				if errors.Is(err, entity.ErrNotFound) {
+				if errors.Is(err, cond.ErrNotFound{}) {
 					a.log.Info("launcher-created pool was deleted, clearing cache",
 						"pool", poolID)
 					a.mu.Lock()


### PR DESCRIPTION
## Summary
- Fix activator to correctly detect deleted pools by checking for `cond.ErrNotFound{}` instead of `entity.ErrNotFound`
- Make MockStore return consistent errors with EtcdStore for accurate test coverage

## Description

### Problem
When a sandbox pool was deleted (e.g., during deployment cleanup after scaling to zero), the HTTP ingress would continue to return "error acquiring lease: failed to request pool capacity: failed to patch pool: not found" indefinitely until the server was restarted.

### Root Cause
The activator's `requestPoolCapacity` function had error handling to detect deleted pools and clear its cache, but the error type check was wrong:

```go
// Was checking for this (simple sentinel error):
if errors.Is(err, entity.ErrNotFound) { ... }

// But EtcdStore returns this (structured error type):
cond.NotFound("entity", id)  // returns cond.ErrNotFound{}
```

Since the error types didn't match, the cache was never cleared and the activator kept trying to patch a deleted pool.

### Fix
1. **activator.go**: Changed error checks from `entity.ErrNotFound` to `cond.ErrNotFound{}` at three locations in `requestPoolCapacity()`
2. **mock.go**: Updated MockStore to return `cond.NotFound()` instead of `entity.ErrNotFound` so tests accurately reflect production behavior

## Test plan
- [x] Existing `TestActivatorDeletedPoolDetection` now properly validates this fix
- [x] With MockStore returning consistent errors, test fails with old code and passes with fix
- [x] All activator tests pass
- [x] Linter passes

Thanks to @demophoon for reporting!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved consistency in error handling mechanisms for pool management operations to enhance system reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->