### PR TITLE
Enable BuildKit layer caching with persistent storage

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -607,7 +607,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	// Create app client for the builder
 	appClient := appclient.NewClient(c.Log, loopback)
 
-	bs := build.NewBuilder(c.Log, eac, appClient, c.Resolver, c.TempDir, c.LogWriter, c.CloudAuth.DNSHostname)
+	bs := build.NewBuilder(c.Log, eac, appClient, c.Resolver, c.TempDir, c.LogWriter, c.CloudAuth.DNSHostname, c.DataPath)
 	server.ExposeValue("dev.miren.runtime/build", build_v1alpha.AdaptBuilder(bs))
 
 	ai := app.NewAppInfo(c.Log, ec, c.Cpu, c.Mem, c.HTTP)

--- a/pkg/progress/progressui/display.go
+++ b/pkg/progress/progressui/display.go
@@ -827,7 +827,8 @@ func (t *trace) update(s *client.SolveStatus, termWidth int) {
 
 func (t *trace) printErrorLogs(f io.Writer) {
 	for _, v := range t.vertexes {
-		if v.Error != "" && !strings.HasSuffix(v.Error, context.Canceled.Error()) {
+		if v.Error != "" && !strings.HasSuffix(v.Error, context.Canceled.Error()) &&
+			!isCacheImportError(v.Name, v.Error) {
 			fmt.Fprintln(f, "------")
 			fmt.Fprintf(f, " > %s:\n", v.Name)
 			// tty keeps original logs
@@ -891,6 +892,9 @@ func (t *trace) displayInfo() (d displayInfo) {
 			if strings.HasSuffix(v.Error, context.Canceled.Error()) {
 				j.isCanceled = true
 				j.name = "CANCELED " + j.name
+			} else if isCacheImportError(v.Name, v.Error) {
+				// Cache import failures are expected when no cached image exists yet
+				// Don't mark these as errors in the UI
 			} else {
 				j.hasError = true
 				j.name = "ERROR " + j.name

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -362,23 +362,16 @@ func (b *Buildkit) BuildImage(
 
 	solveOpt.Exports = []client.ExportEntry{output}
 
-	if opts.cacheDir != "" {
-		solveOpt.CacheImports = []client.CacheOptionsEntry{
-			{
-				Type: "local",
-				Attrs: map[string]string{
-					"src": opts.cacheDir,
-				},
+	// Use registry-based inline caching: import cache from the image we're building
+	// (if it exists from a previous build). The BUILDKIT_INLINE_CACHE=1 build arg
+	// ensures cache metadata is embedded in the exported image.
+	solveOpt.CacheImports = []client.CacheOptionsEntry{
+		{
+			Type: "registry",
+			Attrs: map[string]string{
+				"ref": imageURL,
 			},
-		}
-		solveOpt.CacheExports = []client.CacheOptionsEntry{
-			{
-				Type: "local",
-				Attrs: map[string]string{
-					"dest": opts.cacheDir,
-				},
-			},
-		}
+		},
 	}
 
 	sreq := gateway.SolveRequest{


### PR DESCRIPTION
## Summary

BuildKit layer caching should make subsequent deploys fast by reusing cached build layers. However, caching wasn't working at all - every deploy was doing a full rebuild.

## What wasn't working

The previous implementation attempted local filesystem caching but had several issues:

1. **Inaccessible cache directory** - The cache dir was created on the host at `{tempDir}/buildkit-cache`, but BuildKit runs in an ephemeral sandbox that couldn't access this path
2. **Missing cache export mode** - BuildKit logs showed `skipping invalid cache export mode: ""` indicating misconfigured cache options
3. **Ephemeral sandboxes** - Even if the cache worked, BuildKit sandboxes are short-lived and any internal state was lost between builds

## What we changed

**Persistent BuildKit storage:**
- Mount a persistent host volume at `{dataPath}/buildkit` into the BuildKit sandbox at `/var/lib/buildkit`
- This preserves BuildKit's internal layer cache, snapshots, and build history across builds
- This is the primary mechanism for caching - BuildKit's internal layer cache now persists and subsequent builds show `CACHED` for unchanged layers

**Registry-based inline caching:**
- Enable `BUILDKIT_INLINE_CACHE=1` which embeds cache metadata in exported images
- Configure cache imports from the registry (attempts to pull cache from previously built image)
- Note: We generate a unique image tag for every deploy, so registry cache imports will currently always miss. The layer caching from persistent storage is what provides the speedup. Registry caching is configured for potential future use with stable tags.

**Friendlier error handling:**
- Cache import "not found" is expected on every build (since we use unique image tags)
- Changed output from `#1 ERROR: failed to configure registry cache importer...` to `#1 DONE (cache not found)`
- Switched to vendored progresswriter so these UI changes apply consistently

## Test plan
- [x] First deploy shows "cache not found" (expected)
- [x] Second deploy shows CACHED for unchanged build layers
- [x] Build output shows friendly "DONE (cache not found)" instead of ERROR
- [x] No error block printed at end of successful builds
- [x] `make lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Cache import failures no longer incorrectly trigger build errors; these are now handled gracefully during deployment.

* **New Features**
  * Persistent BuildKit state storage via host volumes for more efficient builds.
  * Registry-based inline caching for faster image rebuilds with improved cache efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->