### PR TITLE
Add --service flag to filter logs by service name

### DIFF
--- a/cli/commands/logs_test.go
+++ b/cli/commands/logs_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import "testing"
+
+func TestBuildFilterWithService(t *testing.T) {
+	tests := []struct {
+		name       string
+		userFilter string
+		service    string
+		want       string
+	}{
+		{
+			name:       "no service, no filter",
+			userFilter: "",
+			service:    "",
+			want:       "",
+		},
+		{
+			name:       "service only",
+			userFilter: "",
+			service:    "web",
+			want:       `service:"web"`,
+		},
+		{
+			name:       "filter only",
+			userFilter: "error",
+			service:    "",
+			want:       "error",
+		},
+		{
+			name:       "service and filter",
+			userFilter: "error",
+			service:    "web",
+			want:       `service:"web" error`,
+		},
+		{
+			name:       "service with complex filter",
+			userFilter: `error -debug /timeout/`,
+			service:    "worker",
+			want:       `service:"worker" error -debug /timeout/`,
+		},
+		{
+			name:       "service with spaces needs quoting",
+			userFilter: "",
+			service:    "my service",
+			want:       `service:"my service"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildFilterWithService(tt.userFilter, tt.service)
+			if got != tt.want {
+				t.Errorf("buildFilterWithService(%q, %q) = %q, want %q",
+					tt.userFilter, tt.service, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSandboxID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"abc123", "sandbox/abc123"},
+		{"sandbox/abc123", "sandbox/abc123"},
+		{"", "sandbox/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeSandboxID(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeSandboxID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/docs/cli/logs.md
+++ b/docs/docs/cli/logs.md
@@ -24,6 +24,7 @@ miren logs [flags]
 - `--sandbox, -s` - Show logs for a specific sandbox ID
 - `--follow, -f` - Follow log output (live tail)
 - `--grep, -g` - Filter logs using the filter syntax
+- `--service` - Filter logs by service name (e.g., web, worker)
 
 ### Examples
 
@@ -48,6 +49,12 @@ miren logs --follow
 
 # Filter logs containing "error"
 miren logs -g error
+
+# Filter logs by service
+miren logs --service web
+
+# Combine service filter with text filter
+miren logs --service worker -g error
 ```
 
 ## Time Range
@@ -75,6 +82,21 @@ miren logs --follow
 
 # Follow logs for a specific app
 miren logs --app myapp -f
+```
+
+## Filtering by Service
+
+Use `--service` to filter logs by service name. This is useful for applications with multiple services (e.g., web, worker):
+
+```bash
+# Show only logs from the web service
+miren logs --service web
+
+# Show worker service logs containing "error"
+miren logs --service worker -g error
+
+# Follow web service logs
+miren logs --service web -f
 ```
 
 ## Filtering Logs


### PR DESCRIPTION
## Summary
- Adds `--service` flag to `miren logs` command for filtering by service name (e.g., `web`, `worker`)
- Service filter is combined with existing `--grep` filter for server-side LogsQL filtering
- Adds upgrade warning for users on older servers without optimized log streaming

## Usage
```bash
# Filter logs to only show 'web' service
miren logs --service web

# Combine with text filter
miren logs --service worker -g "error"

# With other options
miren logs -a myapp --service web -f --last 1h
```

## Test plan
- [x] Unit tests for `buildFilterWithService` helper
- [x] Unit tests for `normalizeSandboxID` helper
- [x] `go build` passes
- [x] `make lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--service` flag to filter logs by service name, enabling targeted log viewing.
  * Support for combining service filtering with existing text filters.

* **Documentation**
  * Updated with dedicated "Filtering by Service" section and usage examples.

* **Improvements**
  * Added server version compatibility check; warns if `--service` is used with older server versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->