### PR TITLE
Add watchPools to proactively clean activator caches on pool deletion

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -1641,14 +1641,16 @@ func (a *localActivator) watchPools(ctx context.Context) {
 			return nil
 		}))
 
+		if ctx.Err() != nil {
+			a.log.Info("pool watch stopped due to context cancellation")
+			return
+		}
 		if err != nil {
-			if ctx.Err() != nil {
-				a.log.Info("pool watch stopped due to context cancellation")
-				return
-			}
 			a.log.Error("pool watch ended with error, will restart", "error", err)
 			time.Sleep(5 * time.Second)
 			continue
 		}
+		a.log.Warn("pool watch ended without error, will restart")
+		time.Sleep(5 * time.Second)
 	}
 }


### PR DESCRIPTION
## Summary

The activator maintains three internal caches for pool/sandbox state:
- `versions` - maps version+service → pool reference
- `pools` - maps version+service → pool state (including `DesiredInstances`)
- `poolSandboxes` - maps pool ID → list of sandboxes

**Former behavior:** When a pool entity was deleted from the store, these caches retained stale references. The activator would only detect and clean up stale entries reactively during `AcquireLease` when operations failed. This could cause errors like "pool has reached maximum size" for pools that no longer exist, if the cached `DesiredInstances` was at the limit.

**New behavior:** A `watchPools` background goroutine watches for SandboxPool entity deletions and proactively cleans up all related cache entries immediately. This ensures the activator always has a consistent view of pool state, regardless of when or why a pool is deleted.

**Changes:**
- `watchPools()` - watches SandboxPool entity kind for deletions, calls cleanup on delete events
- `removePoolFromTracking()` - atomically cleans all three cache maps for a deleted pool

**Related:** #497 fixes premature pool deletion in the sandboxpool manager. This PR handles cache cleanup for any legitimate pool deletion.

## Test plan

- [x] `TestWatchPoolsCleansUpCacheOnDeletion` - integration test verifying watch cleans caches
- [x] `TestRemovePoolFromTrackingCleansAllCaches` - unit test for the cleanup helper
- [x] `make lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pool deletions are now observed and fully purge related in-memory state and mappings, preventing stale pool/version/sandbox data and keeping lifecycle state consistent.

* **Tests**
  * Added tests validating that pool deletion triggers complete cache cleanup and that targeted pool removal preserves unrelated entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->