### PR TITLE
Fix disk ID parsing in debug commands

### DIFF
--- a/cli/commands/debug_disk.go
+++ b/cli/commands/debug_disk.go
@@ -35,8 +35,8 @@ func DebugDiskCreate(ctx *Context, opts struct {
 	eac := entityserver_v1alpha.NewEntityAccessClient(client)
 	ec := entityserver.NewClient(ctx.Log, eac)
 
-	// Generate disk ID
-	diskId := idgen.Gen("disk")
+	// Generate disk ID (format: disk-<base58>)
+	diskId := idgen.GenNS("disk")
 
 	// Determine filesystem type
 	var fs storage_v1alpha.DiskFilesystem
@@ -164,11 +164,7 @@ func DebugDiskDelete(ctx *Context, opts struct {
 	eac := entityserver_v1alpha.NewEntityAccessClient(client)
 	ec := entityserver.NewClient(slog.Default(), eac)
 
-	// Validate disk ID format
 	diskId := entity.Id(opts.ID)
-	if len(opts.ID) < 5 || string(diskId)[:5] != "disk/" {
-		diskId = entity.Id("disk/" + opts.ID)
-	}
 
 	// First, update the disk status to DELETING
 	ctx.Info("Marking disk for deletion...")
@@ -206,13 +202,8 @@ func DebugDiskStatus(ctx *Context, opts struct {
 	// Create entity access client
 	eac := entityserver_v1alpha.NewEntityAccessClient(client)
 
-	// Validate disk ID format
-	diskId := entity.Id(opts.ID)
-	if len(opts.ID) < 5 || string(diskId)[:5] != "disk/" {
-		diskId = entity.Id("disk/" + opts.ID)
-	}
-
 	// Get the disk entity
+	diskId := entity.Id(opts.ID)
 	result, err := eac.Get(context.Background(), string(diskId))
 	if err != nil {
 		return fmt.Errorf("failed to get disk entity: %w", err)

--- a/cli/commands/debug_disk_lease.go
+++ b/cli/commands/debug_disk_lease.go
@@ -35,8 +35,8 @@ func DebugDiskLease(ctx *Context, opts struct {
 	// Validate disk ID format
 	diskId := entity.Id(opts.DiskID)
 
-	// Generate lease ID
-	leaseId := idgen.Gen("disk-lease")
+	// Generate lease ID (format: disk-lease-<base58>)
+	leaseId := idgen.GenNS("disk-lease")
 
 	// Create disk lease entity
 	lease := &storage_v1alpha.DiskLease{
@@ -112,21 +112,13 @@ func DebugDiskLeaseList(ctx *Context, opts struct {
 
 			// Apply filters
 			if opts.DiskID != "" {
-				diskId := entity.Id(opts.DiskID)
-				if len(opts.DiskID) < 5 || string(diskId)[:5] != "disk/" {
-					diskId = entity.Id("disk/" + opts.DiskID)
-				}
-				if lease.DiskId != diskId {
+				if lease.DiskId != entity.Id(opts.DiskID) {
 					continue
 				}
 			}
 
 			if opts.SandboxID != "" {
-				sandboxId := entity.Id(opts.SandboxID)
-				if len(opts.SandboxID) < 8 || string(sandboxId)[:8] != "sandbox/" {
-					sandboxId = entity.Id("sandbox/" + opts.SandboxID)
-				}
-				if lease.SandboxId != sandboxId {
+				if lease.SandboxId != entity.Id(opts.SandboxID) {
 					continue
 				}
 			}
@@ -279,11 +271,7 @@ func DebugDiskLeaseStatus(ctx *Context, opts struct {
 	// Create entity access client
 	eac := entityserver_v1alpha.NewEntityAccessClient(client)
 
-	// Validate lease ID format
 	leaseId := entity.Id(opts.ID)
-	if len(opts.ID) < 11 || string(leaseId)[:11] != "disk-lease/" {
-		leaseId = entity.Id("disk-lease/" + opts.ID)
-	}
 
 	// Get the lease entity
 	result, err := eac.Get(context.Background(), string(leaseId))


### PR DESCRIPTION
## Summary
- Remove erroneous `disk/` and `disk-lease/` prefix logic from status/delete/list commands - entity IDs don't have this format
- Change ID generation to use `GenNS` instead of `Gen` to match how the sandbox controller creates disk IDs (e.g., `disk-ABC123` with hyphen, not `diskABC123`)

## Test plan
- [x] Verified `miren debug disk list` works against live cluster
- [x] Verified `miren debug disk status -i disk-CW3Xr8ZvkBVWcaJQn2HNJ` now works (was failing with "not found: disk/disk-...")
- [x] Build passes
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated disk and disk lease ID generation to use new format patterns (disk-<base58> and disk-lease-<base58>)
  * Removed automatic ID prefix normalization in debug disk and lease commands; IDs must now be provided in the correct format

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->