### PR TITLE
install: Default to the branch the binary uses (or latest)

### DIFF
--- a/cli/commands/download_release.go
+++ b/cli/commands/download_release.go
@@ -15,6 +15,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"miren.dev/runtime/version"
 )
 
 // DownloadReleaseOptions contains options for downloading a release
@@ -142,11 +144,19 @@ func PerformDownloadRelease(ctx *Context, opts DownloadReleaseOptions) error {
 
 // DownloadRelease is the CLI command handler for downloading a release
 func DownloadRelease(ctx *Context, opts struct {
-	Branch string `short:"b" long:"branch" description:"Branch name to download" default:"main"`
+	Branch string `short:"b" long:"branch" description:"Branch name to download"`
 	Global bool   `short:"g" long:"global" description:"Install globally to /var/lib/miren/release"`
 	Force  bool   `short:"f" long:"force" description:"Force download even if release directory exists"`
 	Output string `short:"o" long:"output" description:"Custom output directory"`
 }) error {
+	if opts.Branch == "" {
+		if br := version.Branch(); br != "unknown" {
+			opts.Branch = br
+		} else {
+			opts.Branch = "latest"
+		}
+	}
+
 	return PerformDownloadRelease(ctx, DownloadReleaseOptions{
 		Branch: opts.Branch,
 		Global: opts.Global,

--- a/cli/commands/download_release.go
+++ b/cli/commands/download_release.go
@@ -150,7 +150,7 @@ func DownloadRelease(ctx *Context, opts struct {
 	Output string `short:"o" long:"output" description:"Custom output directory"`
 }) error {
 	if opts.Branch == "" {
-		if br := version.Branch(); br != "unknown" {
+		if br := version.Branch(); br != "" {
 			opts.Branch = br
 		} else {
 			opts.Branch = "latest"

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -121,9 +121,14 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 					return fmt.Errorf("unable to create /var/lib/miren and no user path available: %w", err)
 				}
 
+				branch := "latest"
+				if br := version.Branch(); br != "unknown" {
+					branch = br
+				}
+
 				// Download the release
 				if err := PerformDownloadRelease(ctx, DownloadReleaseOptions{
-					Branch: "main",
+					Branch: branch,
 					Global: downloadGlobal,
 					Force:  false,
 					Output: downloadPath,

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -122,7 +122,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 				}
 
 				branch := "latest"
-				if br := version.Branch(); br != "unknown" {
+				if br := version.Branch(); br != "" {
 					branch = br
 				}
 

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -167,7 +167,7 @@ func ServerInstall(ctx *Context, opts struct {
 	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
 }) error {
 	if opts.Branch == "" {
-		if br := version.Branch(); br != "unknown" {
+		if br := version.Branch(); br != "" {
 			opts.Branch = br
 		} else {
 			opts.Branch = "latest"

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/yaml.v3"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/registration"
+	"miren.dev/runtime/version"
 )
 
 // installPrerequisites holds information about the system's readiness for installation
@@ -157,7 +158,7 @@ func fixSELinuxContext(ctx *Context, binaryPath string) {
 func ServerInstall(ctx *Context, opts struct {
 	Address      string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
 	Verbosity    string            `short:"v" long:"verbosity" description:"Verbosity level" default:"-vv"`
-	Branch       string            `short:"b" long:"branch" description:"Branch to download if release not found" default:"main"`
+	Branch       string            `short:"b" long:"branch" description:"Branch to download if release not found"`
 	Force        bool              `short:"f" long:"force" description:"Overwrite existing service file"`
 	NoStart      bool              `long:"no-start" description:"Do not start the service after installation"`
 	WithoutCloud bool              `long:"without-cloud" description:"Skip cloud registration setup"`
@@ -165,6 +166,14 @@ func ServerInstall(ctx *Context, opts struct {
 	CloudURL     string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
 	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
 }) error {
+	if opts.Branch == "" {
+		if br := version.Branch(); br != "unknown" {
+			opts.Branch = br
+		} else {
+			opts.Branch = "latest"
+		}
+	}
+
 	// Check all prerequisites upfront
 	prereqs := checkInstallPrerequisites()
 

--- a/version/version.go
+++ b/version/version.go
@@ -38,21 +38,13 @@ func GetInfo() Info {
 	return info
 }
 
-// Returns the branch that the version was built from
+// Branch returns the branch name if the binary was built from a branch (e.g. "main:abc123").
+// Returns empty string for tagged releases (e.g. "v0.2.0") or unknown versions.
 func Branch() string {
-	if Version == "unknown" {
-		return "unknown"
-	}
-
 	if branch, _, ok := strings.Cut(Version, ":"); ok {
 		return branch
 	}
-
-	if strings.HasPrefix(Version, "v") {
-		return Version
-	}
-
-	return "unknown"
+	return ""
 }
 
 // String returns the version info as a formatted string

--- a/version/version.go
+++ b/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -35,6 +36,23 @@ func GetInfo() Info {
 	}
 
 	return info
+}
+
+// Returns the branch that the version was built from
+func Branch() string {
+	if Version == "unknown" {
+		return "unknown"
+	}
+
+	if branch, _, ok := strings.Cut(Version, ":"); ok {
+		return branch
+	}
+
+	if strings.HasPrefix(Version, "v") {
+		return Version
+	}
+
+	return "unknown"
 }
 
 // String returns the version info as a formatted string


### PR DESCRIPTION
The code originally default to main, even when using a proper release binary. This updates the process to download the base code that matches the same release by default, while leaving the ability for the user to specific indicate they want main, latest, or a specific version by specifying it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch selection for release downloads and server installations: the CLI now derives the branch from runtime version metadata when not explicitly provided, and falls back to "latest" if no branch information exists. This replaces previous hardcoded defaults and ensures consistent behavior across download and install workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->