### PR TITLE
Make server install and release download honor tagged version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -39,10 +39,13 @@ func GetInfo() Info {
 }
 
 // Branch returns the branch name if the binary was built from a branch (e.g. "main:abc123").
-// Returns empty string for tagged releases (e.g. "v0.2.0") or unknown versions.
+// Returns the tag name for tagged releases (e.g. "v0.2.0"), and empty for unknown versions.
 func Branch() string {
 	if branch, _, ok := strings.Cut(Version, ":"); ok {
 		return branch
+	}
+	if Version != "unknown" {
+		return Version
 	}
 	return ""
 }


### PR DESCRIPTION
In https://github.com/mirendev/runtime/pull/500 I mistakenly thought we
were talking about upgrade paths, but this was only about making sure
`server install` and `release download` were matching the installed
version.

This fixes the behavior to match what you'd expect for these commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified version branch handling to return tag names for tagged releases instead of empty strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->