### PR TITLE
docs: expand sidebar sections by default

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -19,6 +19,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Core Concepts',
+      collapsed: false,
       items: [
         'terminology',
         'languages',
@@ -32,6 +33,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'CLI Reference',
+      collapsed: false,
       link: {
         type: 'doc',
         id: 'cli-reference',
@@ -47,6 +49,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Resources',
+      collapsed: false,
       items: [
         'changelog',
         'support',


### PR DESCRIPTION
## Summary
- Add `collapsed: false` to all category sections in the docs sidebar
- Users now see the full navigation structure when visiting docs

## Test plan
- [ ] Visit the docs site and verify all sidebar sections are expanded by default
- [ ] Verify sections can still be manually collapsed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the default expansion state of three sidebar categories (Core Concepts, CLI Reference, Resources) to ensure they display expanded by default in the documentation interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->