### PR TITLE
Fix release workflow race condition and Slack notification text

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
         payload: |
           {
             "channel": "${{ vars.SLACK_CHANNEL_ID }}",
-            "text": "❌ Miren release packaging failed on main branch",
+            "text": "❌ Miren release packaging failed for ${{ github.event.workflow_run.head_branch }}",
             "blocks": [
               {
                 "type": "section",
@@ -308,7 +308,7 @@ jobs:
         retention-days: 1
 
   build-and-push-docker:
-    needs: [package]
+    needs: [package, upload-to-miren]
     runs-on: depot-ubuntu-latest
     permissions:
       contents: read
@@ -386,7 +386,7 @@ jobs:
           payload: |
             {
               "channel": "${{ vars.SLACK_CHANNEL_ID }}",
-              "text": "❌ Miren Docker build/push failed on main branch",
+              "text": "❌ Miren Docker build/push failed for ${{ github.event.workflow_run.head_branch }}",
               "blocks": [
                 {
                   "type": "section",
@@ -623,7 +623,7 @@ jobs:
           payload: |
             {
               "channel": "${{ vars.SLACK_CHANNEL_ID }}",
-              "text": "❌ Miren release upload failed on main branch",
+              "text": "❌ Miren release upload failed for ${{ github.event.workflow_run.head_branch }}",
               "blocks": [
                 {
                   "type": "section",


### PR DESCRIPTION
## Summary
- Fix race condition where Docker build fails trying to download release artifacts before they were uploaded
- Fix hardcoded "on main branch" text in Slack failure notifications to show actual branch/tag name

## Details
The `build-and-push-docker` job runs `miren download release -g` which fetches artifacts from the API. Previously this command was incorrectly defaulting to download `main`, but now that it's been corrected to download the current version, it depends on that version having been uploaded first. Added `upload-to-miren` as a dependency to ensure artifacts are available before the Docker build starts.

Also fixed three Slack notification messages that hardcoded "on main branch" - now they dynamically show the actual ref (e.g., `v0.2.1`).

## Test plan
- [ ] Merge and observe next tag release completes successfully
- [ ] Verify Slack notifications show correct branch/tag name on failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow notifications to include branch-specific context in Slack alerts for packaging, Docker builds, and release uploads.
  * Enhanced build job dependency sequencing to ensure proper execution order during the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->