### PR TITLE
Fix release workflow to checkout triggering commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     - name: Set up Go
       uses: actions/setup-go@v6
@@ -219,7 +219,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
@@ -317,7 +317,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Download amd64 package
         uses: actions/download-artifact@v4
@@ -438,7 +438,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Checkout was using `head_branch` which resolves to the branch tip at checkout time
- When commits merge in quick succession, both workflows would build whatever was at HEAD of main
- This caused duplicate builds of the same commit (e.g., both `aee75d8` and `57fbcb8` triggering builds that built `57fbcb8`)

## Fix
Use `head_sha` instead of `head_branch` to checkout the exact commit that triggered each workflow run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow configuration to ensure consistent and reliable deployments across build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->