### PR TITLE
Speed up build-dist.sh with proper Docker layer caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
 tmp/
+dist/
+bin/
+.git/

--- a/hack/build-dist.sh
+++ b/hack/build-dist.sh
@@ -47,11 +47,12 @@ WORKDIR /build
 # Copy go mod files first for better caching
 COPY go.mod go.sum ./
 
-# Copy source code
-COPY . .
+# Download dependencies BEFORE copying source code
+# This layer is cached until go.mod/go.sum change
+RUN go mod download
 
-# Download dependencies if vendor directory doesn't exist
-RUN if [ ! -d vendor ]; then go mod download; fi
+# Copy source code (this invalidates cache, but deps are already downloaded)
+COPY . .
 
 # Build a binary
 # We need CGO enabled for flannel dependencies


### PR DESCRIPTION
## Summary
- Move `go mod download` before `COPY . .` so the dependency layer is cached until go.mod/go.sum actually change
- Expand `.dockerignore` to exclude `dist/`, `bin/`, and `.git/`

Previously, any source code change would invalidate the Docker layer cache and re-download all dependencies. Now subsequent builds skip straight to the compile step.

## Test plan
- [ ] Run `./hack/build-dist.sh` twice and confirm second run is faster (skips dependency download)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration for improved build efficiency and layer caching strategy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->