### PR TITLE
Panics during deployment should be marked as failed

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"miren.dev/runtime/api/deployment/deployment_v1alpha"
 	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/deploygating"
 	"miren.dev/runtime/pkg/git"
 	"miren.dev/runtime/pkg/progress/upload"
@@ -366,6 +368,17 @@ func Deploy(ctx *Context, opts struct {
 				updateDeploymentOnError("Deploy cancelled by user")
 				return ctx.Err()
 			}
+
+			// Check if this was a server panic
+			var panicErr cond.ErrPanic
+			if errors.As(err, &panicErr) {
+				ctx.Printf("\n\n❌ Build failed due to a server panic.\n")
+				ctx.Printf("The server encountered a panic: %s\n", panicErr.Message)
+				ctx.Printf("Check the server logs for more details.\n")
+				updateDeploymentOnError(fmt.Sprintf("Server panic: %s", panicErr.Message))
+				return err
+			}
+
 			ctx.Printf("\n\nBuild failed with the following errors:\n")
 			printBuildErrors(ctx, buildErrors, nil)
 			updateDeploymentOnError(fmt.Sprintf("Build failed: %v", err))
@@ -473,6 +486,16 @@ func Deploy(ctx *Context, opts struct {
 				// The UI already printed the timeout message
 				updateDeploymentOnError("Buildkit startup timeout")
 				return fmt.Errorf("buildkit startup timeout")
+			}
+
+			// Check if this was a server panic
+			var panicErr cond.ErrPanic
+			if errors.As(err, &panicErr) {
+				ctx.Printf("\n\n❌ Build failed due to a server panic.\n")
+				ctx.Printf("The server encountered a panic: %s\n", panicErr.Message)
+				ctx.Printf("Check the server logs for more details.\n")
+				updateDeploymentOnError(fmt.Sprintf("Server panic: %s", panicErr.Message))
+				return err
 			}
 
 			ctx.Printf("\n\nBuild failed.\n")

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -577,7 +577,7 @@ request:
 			return cond.RemoteError(category, code, errs)
 		case "panic":
 			errs := hr.Trailer.Get("rpc-error")
-			return cond.RemoteError("panic", "panic", errs)
+			return cond.Panic(errs)
 		}
 
 		return err

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -788,6 +788,9 @@ loop:
 		case "error":
 			err = cond.RemoteError(rs.Category, rs.Code, rs.Error)
 			break loop
+		case "panic":
+			err = cond.Panic(rs.Error)
+			break loop
 		default:
 			c.State.log.Error("rpc.callstream: unknown control stream request", "kind", rs.Kind)
 		}

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -2,6 +2,7 @@ package rpc_test
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/etcdreg"
 	"miren.dev/runtime/pkg/rpc/example"
@@ -64,6 +66,17 @@ func (m *exampleMeter) SetTemp(ctx context.Context, call *example.SetTempSetTemp
 	m.temp = float32(args.Temp())
 	res.SetTemp(args.Temp())
 	return nil
+}
+
+// panicMeter is a Meter implementation that panics, used for testing panic handling
+type panicMeter struct{}
+
+func (m *panicMeter) ReadTemperature(ctx context.Context, call *example.MeterReadTemperature) error {
+	panic("test panic message")
+}
+
+func (m *panicMeter) GetSetter(ctx context.Context, call *example.MeterGetSetter) error {
+	panic("test panic message")
 }
 
 type exampleUpdate struct {
@@ -363,6 +376,35 @@ func TestRPC(t *testing.T) {
 		r.NoError(err)
 
 		r.Equal(int32(100), res3.Temp())
+	})
+
+	t.Run("propagates panic errors to client", func(t *testing.T) {
+		r := require.New(t)
+		ctx := t.Context()
+
+		s := example.AdaptMeter(&panicMeter{})
+
+		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithLogLevel(slog.LevelDebug))
+		r.NoError(err)
+
+		serv := ss.Server()
+
+		serv.ExposeValue("meter", s)
+
+		cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+		r.NoError(err)
+
+		c, err := cs.Connect(ss.ListenAddr(), "meter")
+		r.NoError(err)
+
+		mc := &example.MeterClient{Client: c}
+
+		_, err = mc.ReadTemperature(context.Background(), "test")
+		r.Error(err)
+
+		var panicErr cond.ErrPanic
+		r.True(errors.As(err, &panicErr), "expected ErrPanic, got %T: %v", err, err)
+		r.Contains(panicErr.Message, "test panic message")
 	})
 }
 

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -980,11 +981,14 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 
 	defer func() {
 		if r := recover(); r != nil {
+			s.state.log.Error("panic in streaming RPC handler",
+				"panic", r,
+				"method", method,
+				"stack", string(debug.Stack()))
 			var sr streamRequest
 			sr.Kind = "panic"
 			sr.Error = fmt.Sprint(r)
 			cs.NoReply(sr, nil)
-			panic(r)
 		}
 	}()
 
@@ -1055,9 +1059,12 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 
 		defer func() {
 			if r := recover(); r != nil {
+				s.state.log.Error("panic in RPC handler",
+					"panic", r,
+					"method", method,
+					"stack", string(debug.Stack()))
 				w.Header().Add("rpc-status", "panic")
 				w.Header().Add("rpc-error", fmt.Sprint(r))
-				panic(r)
 			}
 		}()
 


### PR DESCRIPTION
Deployments that panic currently do not get marked as "failed" status. As a result, the app is then locked from further deployments until the lock times out after 30 mins. 

The RPC server has panic recovery, but the panic recover actually repanics so the panic itself is not properly surfaced.

- Updated the RPC server to properly handle panics by logging the error and letting it propogate up to the client.
- Updated client to handle panics in streaming responses.
- Added specific panic error handling to return helpful error messages to the user. 
- Fixed inconsistency where non-streaming RPC calls return RemoteError instead of cond.Panic(errs) like `CallWithCaps` does. 
- Added RPC test for panic error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-panic detection during deployment with clearer user-facing messages and updated deployment status handling
  * RPC handling now consistently propagates panic information so clients receive explicit panic errors
  * Server-side panics are logged with stack traces (no re-panicking), improving failure visibility

* **Tests**
  * Added tests to verify panic propagation from server to client

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->