### PR TITLE
Fix app delete race condition that left orphaned sandbox pools

### DIFF
--- a/api/entityserver/client.go
+++ b/api/entityserver/client.go
@@ -304,6 +304,15 @@ func (c *Client) Delete(ctx context.Context, id entity.Id) error {
 	return nil
 }
 
+// Patch updates specific attributes on an entity without replacing the entire entity.
+// Pass revision 0 to skip optimistic concurrency control, or a specific revision to
+// ensure the entity hasn't been modified since it was read.
+func (c *Client) Patch(ctx context.Context, id entity.Id, revision int64, attrs ...entity.Attr) error {
+	allAttrs := append([]entity.Attr{entity.Ref(entity.DBId, id)}, attrs...)
+	_, err := c.eac.Patch(ctx, allAttrs, revision)
+	return err
+}
+
 func (c *Client) GetAttributesByTag(ctx context.Context, tag string) (*entityserver_v1alpha.EntityAccessClientGetAttributesByTagResults, error) {
 	return c.eac.GetAttributesByTag(ctx, tag)
 }

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -1256,3 +1256,33 @@ func TestPortNameAndType(t *testing.T) {
 	assert.Equal(t, "http", webPort.Name, "web service should default to port name http")
 	assert.Equal(t, "http", webPort.Type, "web service should default to port type http")
 }
+
+// TestNoActiveVersionSkipsReconcile tests that the launcher returns early
+// without creating pools when an app has no active version set.
+// This behavior is critical for app deletion - we clear ActiveVersion first
+// to prevent the launcher from recreating pools during the deletion window.
+func TestNoActiveVersionSkipsReconcile(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app with no ActiveVersion
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// Create launcher and reconcile
+	launcher := NewLauncher(log, server.EAC)
+
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Verify no pools were created
+	pools := listAllPools(t, ctx, server)
+	assert.Empty(t, pools, "should not create any pools when ActiveVersion is empty")
+}

--- a/servers/app/delete.go
+++ b/servers/app/delete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/pkg/entity"
 )
@@ -16,6 +17,18 @@ const AppRefTag = "dev.miren.app_ref"
 // Other transitive resources (sandboxes referencing app_versions) are cleaned up by their controllers.
 func DeleteAppTransitive(ctx context.Context, client *entityserver.Client, log *slog.Logger, appId entity.Id) error {
 	log.Info("starting app deletion", "appId", appId)
+
+	// Clear ActiveVersion first to prevent the DeploymentLauncher from recreating
+	// pools during the deletion window. Without this, there's a race condition:
+	// 1. We delete pools
+	// 2. Launcher sees app has ActiveVersion but no pools
+	// 3. Launcher creates new pools
+	// 4. We delete the app
+	// 5. New pools are orphaned and keep trying to launch sandboxes
+	if err := client.Patch(ctx, appId, 0, entity.Ref(core_v1alpha.AppActiveVersionId, entity.Id(""))); err != nil {
+		log.Warn("failed to clear active version (app may already be deleted)", "appId", appId, "error", err)
+		// Continue anyway - the app might already be partially deleted
+	}
 
 	// Find all the attributes that reference apps by id
 	appRefResult, err := client.GetAttributesByTag(ctx, AppRefTag)


### PR DESCRIPTION
## Summary

- Fixes race condition where DeploymentLauncher could recreate pools during app deletion
- Clears `ActiveVersion` before deleting dependent entities to prevent the launcher from seeing an app that needs pools
- Adds `Patch` method to `entityserver.Client` for partial entity updates
- Adds test to verify launcher skips reconcile when `ActiveVersion` is empty

## Test plan

- [x] `./hack/it servers/app` - all tests pass
- [x] `./hack/run controllers/deployment TestNoActiveVersionSkipsReconcile` - new test passes  
- [x] `make lint` - no issues

Fixes MIR-583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Patch operation to enable targeted updates of specific entity attributes without requiring full entity replacement or revision conflicts.

* **Bug Fixes**
  * Fixed a race condition in app deletion where dependent resources could be inadvertently recreated during the deletion process. The system now clears the active version reference before removing related resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->