### PR TITLE
Fix panic in sandbox exec when stdin is not a TTY

### DIFF
--- a/cli/commands/sandbox_exec.go
+++ b/cli/commands/sandbox_exec.go
@@ -39,7 +39,8 @@ func SandboxExec(ctx *Context, opts struct {
 
 	opt.SetCommand(opts.Rest.Args)
 
-	if con := console.Current(); con != nil {
+	// Set up interactive console if available, otherwise use standard streams
+	if con, err := console.ConsoleFromFile(os.Stdin); err == nil {
 		in = con
 		out = con
 


### PR DESCRIPTION
## Summary

- Use `console.ConsoleFromFile()` instead of `console.Current()` to detect TTY availability
- `console.Current()` panics when no TTY is attached; `ConsoleFromFile()` returns an error instead
- Enables non-interactive use cases like piping input or running in CI

## Test plan

- [x] `make lint` passes
- [x] Tested sandbox exec with piped input (non-TTY) - no panic, command works
- [x] Tested sandbox exec interactively (TTY) - still works

Fixes MIR-599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console handling in sandbox execution, enabling better support for interactive terminal features including proper terminal size detection and resize handling when available, with automatic fallback to standard streams for compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->