### PR TITLE
Release disk leases when sandbox stops

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -43,6 +43,7 @@ import (
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/network/network_v1alpha"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
 )
 
 const (
@@ -2140,6 +2141,12 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 		c.Log.Info("container stopped", "id", id)
 	}
 
+	// Release disk leases owned by this sandbox
+	if err := c.releaseDiskLeases(ctx, id); err != nil {
+		c.Log.Error("failed to release disk leases", "id", id, "error", err)
+		// Continue with cleanup even if this fails
+	}
+
 	// Clean up temp directory
 	tmpDir := filepath.Join(c.Tempdir, "containerd", id.PathSafe())
 	_ = os.RemoveAll(tmpDir)
@@ -2167,6 +2174,56 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 	err = c.deleteEndpoints(ctx, id, sandboxIPs)
 	if err != nil {
 		c.Log.Error("failed to delete endpoints for sandbox", "id", id, "error", err)
+	}
+
+	return nil
+}
+
+// releaseDiskLeases releases all disk leases owned by the given sandbox.
+// This transitions leases to RELEASED status, which triggers the disk lease
+// controller to unmount the volumes and release the underlying resources.
+func (c *SandboxController) releaseDiskLeases(ctx context.Context, sandboxID entity.Id) error {
+	// Find all disk leases owned by this sandbox
+	listResp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, storage.KindDiskLease))
+	if err != nil {
+		return fmt.Errorf("failed to list disk leases: %w", err)
+	}
+
+	for _, e := range listResp.Values() {
+		var lease storage.DiskLease
+		lease.Decode(e.Entity())
+
+		if lease.SandboxId != sandboxID {
+			continue
+		}
+
+		// Skip if already released
+		if lease.Status == storage.RELEASED {
+			continue
+		}
+
+		c.Log.Info("releasing disk lease",
+			"lease", lease.ID,
+			"disk", lease.DiskId,
+			"sandbox", sandboxID)
+
+		_, err := c.EAC.Patch(ctx, entity.New(
+			entity.DBId, lease.ID,
+			(&storage.DiskLease{
+				Status: storage.RELEASED,
+			}).Encode,
+		).Attrs(), 0)
+		if err != nil {
+			c.Log.Error("failed to release disk lease",
+				"lease", lease.ID,
+				"error", err)
+			// Continue releasing other leases
+			continue
+		}
+
+		c.Log.Info("disk lease released",
+			"lease", lease.ID,
+			"disk", lease.DiskId)
 	}
 
 	return nil

--- a/controllers/sandbox/volume.go
+++ b/controllers/sandbox/volume.go
@@ -153,9 +153,9 @@ func (c *SandboxController) configureMirenVolume(ctx context.Context, sb *comput
 		}
 	}
 
-	// Check if there's already a lease for this disk on this node
+	// Acquire a lease for this disk on this node (creates new or takes over existing)
 	nodeID := entity.Id("node/" + c.NodeId)
-	leaseID, err := c.findOrCreateDiskLease(ctx, diskID, nodeID, sb.ID, appID, volume.MountPath, readOnly)
+	leaseID, err := c.acquireDiskLease(ctx, diskID, nodeID, sb.ID, appID, volume.MountPath, readOnly)
 	if err != nil {
 		return "", fmt.Errorf("failed to get or create disk lease: %w", err)
 	}
@@ -242,8 +242,13 @@ func (c *SandboxController) ensureDisk(ctx context.Context, diskName string, siz
 	return diskID, nil
 }
 
-func (c *SandboxController) findOrCreateDiskLease(ctx context.Context, diskID entity.Id, nodeID entity.Id, sandboxID entity.Id, appID entity.Id, mountPath string, readOnly bool) (entity.Id, error) {
-	// Check if there's already a lease for this disk on this node
+// acquireDiskLease gets or creates a disk lease for the given sandbox.
+// If this sandbox already has a lease for this disk on this node (e.g., from a
+// previous attempt), that lease is returned. Otherwise a new lease is created.
+// Note: Old sandbox leases are released by stopSandbox() when sandboxes die,
+// so we don't need transfer logic here.
+func (c *SandboxController) acquireDiskLease(ctx context.Context, diskID entity.Id, nodeID entity.Id, sandboxID entity.Id, appID entity.Id, mountPath string, readOnly bool) (entity.Id, error) {
+	// Check if we already have a lease for this disk on this node
 	listResp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, storage.KindDiskLease))
 	if err != nil {
 		return entity.Id(""), fmt.Errorf("failed to list disk leases: %w", err)
@@ -255,16 +260,37 @@ func (c *SandboxController) findOrCreateDiskLease(ctx context.Context, diskID en
 
 		// Check if this lease is for our disk and node
 		if lease.DiskId == diskID && lease.NodeId == nodeID {
-			c.Log.Info("found existing disk lease",
+			// If the lease is owned by this sandbox, return it (retry case)
+			if lease.SandboxId == sandboxID {
+				c.Log.Info("found existing disk lease for this sandbox",
+					"lease", lease.ID,
+					"disk", diskID,
+					"node", nodeID,
+					"status", lease.Status)
+				return lease.ID, nil
+			}
+
+			// If there's an active lease (PENDING or BOUND) owned by another sandbox,
+			// that sandbox hasn't been cleaned up yet - the new sandbox shouldn't start
+			if lease.Status == storage.PENDING || lease.Status == storage.BOUND {
+				c.Log.Warn("disk lease still active for another sandbox",
+					"lease", lease.ID,
+					"disk", diskID,
+					"owner", lease.SandboxId,
+					"requester", sandboxID,
+					"status", lease.Status)
+				return entity.Id(""), fmt.Errorf("disk %s has an active lease (%s) for sandbox %s", diskID, lease.Status, lease.SandboxId)
+			}
+
+			// Lease is in a terminal state (RELEASED, FAILED) - ignore it
+			// and create a new one. The disk controller will clean up old leases.
+			c.Log.Debug("ignoring lease in terminal state",
 				"lease", lease.ID,
-				"disk", diskID,
-				"node", nodeID,
 				"status", lease.Status)
-			return lease.ID, nil
 		}
 	}
 
-	// No existing lease found, create a new one
+	// No usable lease found, create a new one
 	return c.createDiskLease(ctx, diskID, sandboxID, appID, mountPath, readOnly)
 }
 
@@ -296,9 +322,10 @@ func (c *SandboxController) createDiskLease(ctx context.Context, diskID entity.I
 	}
 
 	name := idgen.GenNS("disk-lease")
+	leaseEntityID := entity.Id("disk-lease/" + name)
 
 	putResp, err := c.EAC.Create(ctx, entity.New(
-		entity.DBId, "disk-lease/"+name,
+		entity.DBId, leaseEntityID,
 		lease.Encode,
 	).Attrs())
 	if err != nil {

--- a/controllers/sandbox/volume_test.go
+++ b/controllers/sandbox/volume_test.go
@@ -1,0 +1,476 @@
+package sandbox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+func TestAcquireDiskLease(t *testing.T) {
+	t.Run("creates new lease when none exists", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node",
+		}
+
+		// Setup: Create a disk entity
+		diskID := entity.Id("disk/test-disk")
+		disk := &storage.Disk{
+			ID:           diskID,
+			Name:         "test-disk",
+			SizeGb:       10,
+			Status:       storage.PROVISIONED,
+			LsvdVolumeId: "vol-123",
+		}
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, diskID,
+			disk.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Act: Request a lease when none exists
+		sandboxID := entity.Id("sandbox/new-sandbox")
+		nodeID := entity.Id("node/test-node")
+		appID := entity.Id("app/test-app")
+
+		leaseID, err := controller.acquireDiskLease(ctx, diskID, nodeID, sandboxID, appID, "/data", false)
+		r.NoError(err)
+		r.NotEmpty(leaseID, "should create a new lease")
+
+		// Verify the created lease
+		leaseResp, err := es.EAC.Get(ctx, leaseID.String())
+		r.NoError(err)
+		var createdLease storage.DiskLease
+		createdLease.Decode(leaseResp.Entity().Entity())
+
+		r.Equal(diskID, createdLease.DiskId)
+		r.Equal(sandboxID, createdLease.SandboxId)
+		r.Equal(nodeID, createdLease.NodeId)
+		r.Equal(storage.PENDING, createdLease.Status)
+		r.Equal("/data", createdLease.Mount.Path)
+	})
+
+	t.Run("returns existing lease if owned by same sandbox", func(t *testing.T) {
+		// This tests the retry case where sandbox creation is retried
+		// and the lease already exists from a previous attempt
+
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node",
+		}
+
+		// Setup: Create a disk entity
+		diskID := entity.Id("disk/test-disk")
+		disk := &storage.Disk{
+			ID:           diskID,
+			Name:         "test-disk",
+			SizeGb:       10,
+			Status:       storage.PROVISIONED,
+			LsvdVolumeId: "vol-123",
+		}
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, diskID,
+			disk.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Setup: Create an existing lease owned by our sandbox
+		sandboxID := entity.Id("sandbox/my-sandbox")
+		nodeID := entity.Id("node/test-node")
+		existingLeaseID := entity.Id("disk-lease/existing-lease")
+
+		existingLease := &storage.DiskLease{
+			ID:        existingLeaseID,
+			DiskId:    diskID,
+			SandboxId: sandboxID,
+			NodeId:    nodeID,
+			Status:    storage.BOUND,
+			Mount: storage.Mount{
+				Path:     "/data",
+				Options:  "rw",
+				ReadOnly: false,
+			},
+		}
+		_, err = es.EAC.Create(ctx, entity.New(
+			entity.DBId, existingLeaseID,
+			existingLease.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Act: Request a lease for the same disk/node/sandbox
+		appID := entity.Id("app/test-app")
+		foundLeaseID, err := controller.acquireDiskLease(ctx, diskID, nodeID, sandboxID, appID, "/data", false)
+		r.NoError(err)
+		r.Equal(existingLeaseID, foundLeaseID, "should return the existing lease")
+	})
+
+	t.Run("fails if lease is active for another sandbox", func(t *testing.T) {
+		// If another sandbox has a PENDING or BOUND lease, we shouldn't
+		// create a new one (indicates that sandbox hasn't been cleaned up)
+
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node",
+		}
+
+		// Setup: Create a disk entity
+		diskID := entity.Id("disk/test-disk")
+		disk := &storage.Disk{
+			ID:           diskID,
+			Name:         "test-disk",
+			SizeGb:       10,
+			Status:       storage.PROVISIONED,
+			LsvdVolumeId: "vol-123",
+		}
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, diskID,
+			disk.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		nodeID := entity.Id("node/test-node")
+		otherSandboxID := entity.Id("sandbox/other-sandbox")
+		mySandboxID := entity.Id("sandbox/my-sandbox")
+		appID := entity.Id("app/test-app")
+
+		// Test both PENDING and BOUND states block new leases
+		for _, status := range []storage.DiskLeaseStatus{storage.PENDING, storage.BOUND} {
+			// Create an existing lease owned by another sandbox
+			existingLeaseID := entity.Id("disk-lease/other-lease-" + string(status))
+			existingLease := &storage.DiskLease{
+				ID:        existingLeaseID,
+				DiskId:    diskID,
+				SandboxId: otherSandboxID,
+				NodeId:    nodeID,
+				Status:    status,
+				Mount: storage.Mount{
+					Path:     "/data",
+					Options:  "rw",
+					ReadOnly: false,
+				},
+			}
+			_, err = es.EAC.Create(ctx, entity.New(
+				entity.DBId, existingLeaseID,
+				existingLease.Encode,
+			).Attrs())
+			r.NoError(err)
+
+			// Try to acquire a lease - should fail
+			_, err = controller.acquireDiskLease(ctx, diskID, nodeID, mySandboxID, appID, "/data", false)
+			r.Error(err, "should fail when another sandbox has a %s lease", status)
+			r.Contains(err.Error(), "active lease")
+
+			// Clean up for next iteration
+			_, _ = es.EAC.Delete(ctx, existingLeaseID.String())
+		}
+	})
+
+	t.Run("creates new lease if existing lease is released", func(t *testing.T) {
+		// This tests the case where an old sandbox's lease was released
+		// and a new sandbox should be able to create a fresh lease
+
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node",
+		}
+
+		// Setup: Create a disk entity
+		diskID := entity.Id("disk/test-disk")
+		disk := &storage.Disk{
+			ID:           diskID,
+			Name:         "test-disk",
+			SizeGb:       10,
+			Status:       storage.PROVISIONED,
+			LsvdVolumeId: "vol-123",
+		}
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, diskID,
+			disk.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Setup: Create an existing RELEASED lease (from a dead sandbox)
+		oldSandboxID := entity.Id("sandbox/old-sandbox")
+		nodeID := entity.Id("node/test-node")
+		releasedLeaseID := entity.Id("disk-lease/released-lease")
+
+		releasedLease := &storage.DiskLease{
+			ID:        releasedLeaseID,
+			DiskId:    diskID,
+			SandboxId: oldSandboxID,
+			NodeId:    nodeID,
+			Status:    storage.RELEASED, // Already released
+			Mount: storage.Mount{
+				Path:     "/data",
+				Options:  "rw",
+				ReadOnly: false,
+			},
+		}
+		_, err = es.EAC.Create(ctx, entity.New(
+			entity.DBId, releasedLeaseID,
+			releasedLease.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Act: A new sandbox should be able to create a new lease
+		newSandboxID := entity.Id("sandbox/new-sandbox")
+		appID := entity.Id("app/test-app")
+		newLeaseID, err := controller.acquireDiskLease(ctx, diskID, nodeID, newSandboxID, appID, "/data", false)
+
+		r.NoError(err)
+		r.NotEqual(releasedLeaseID, newLeaseID, "should create a new lease, not reuse released one")
+
+		// Verify it's a new lease owned by the new sandbox
+		leaseResp, err := es.EAC.Get(ctx, newLeaseID.String())
+		r.NoError(err)
+		var newLease storage.DiskLease
+		newLease.Decode(leaseResp.Entity().Entity())
+
+		r.Equal(newSandboxID, newLease.SandboxId)
+		r.Equal(storage.PENDING, newLease.Status)
+	})
+
+	t.Run("does not reuse lease from different node", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node-2",
+		}
+
+		// Setup: Create a disk entity
+		diskID := entity.Id("disk/test-disk")
+		disk := &storage.Disk{
+			ID:           diskID,
+			Name:         "test-disk",
+			SizeGb:       10,
+			Status:       storage.PROVISIONED,
+			LsvdVolumeId: "vol-123",
+		}
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, diskID,
+			disk.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Setup: Create an existing lease on a DIFFERENT node
+		sandbox1ID := entity.Id("sandbox/sandbox-on-node1")
+		node1ID := entity.Id("node/test-node-1")
+		existingLeaseID := entity.Id("disk-lease/node1-lease")
+
+		existingLease := &storage.DiskLease{
+			ID:        existingLeaseID,
+			DiskId:    diskID,
+			SandboxId: sandbox1ID,
+			NodeId:    node1ID, // Different node
+			Status:    storage.BOUND,
+			Mount: storage.Mount{
+				Path:     "/data",
+				Options:  "rw",
+				ReadOnly: false,
+			},
+		}
+		_, err = es.EAC.Create(ctx, entity.New(
+			entity.DBId, existingLeaseID,
+			existingLease.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Act: Request a lease on node2 (controller.NodeId = "test-node-2")
+		sandbox2ID := entity.Id("sandbox/sandbox-on-node2")
+		node2ID := entity.Id("node/test-node-2")
+		appID := entity.Id("app/test-app")
+
+		newLeaseID, err := controller.acquireDiskLease(ctx, diskID, node2ID, sandbox2ID, appID, "/data", false)
+		r.NoError(err)
+
+		// Should have created a NEW lease, not affected by the one from node1
+		r.NotEqual(existingLeaseID, newLeaseID, "should create new lease for different node")
+
+		// Verify the new lease
+		leaseResp, err := es.EAC.Get(ctx, newLeaseID.String())
+		r.NoError(err)
+		var createdLease storage.DiskLease
+		createdLease.Decode(leaseResp.Entity().Entity())
+
+		r.Equal(diskID, createdLease.DiskId)
+		r.Equal(sandbox2ID, createdLease.SandboxId)
+		r.Equal(node2ID, createdLease.NodeId)
+	})
+}
+
+func TestReleaseDiskLeases(t *testing.T) {
+	t.Run("releases leases owned by sandbox", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node",
+		}
+
+		// Setup: Create a sandbox and its disk lease
+		sandboxID := entity.Id("sandbox/dying-sandbox")
+		nodeID := entity.Id("node/test-node")
+		diskID := entity.Id("disk/test-disk")
+		leaseID := entity.Id("disk-lease/to-be-released")
+
+		lease := &storage.DiskLease{
+			ID:        leaseID,
+			DiskId:    diskID,
+			SandboxId: sandboxID,
+			NodeId:    nodeID,
+			Status:    storage.BOUND,
+			Mount: storage.Mount{
+				Path:     "/data",
+				Options:  "rw",
+				ReadOnly: false,
+			},
+		}
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, leaseID,
+			lease.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Verify lease is initially BOUND
+		leaseResp, err := es.EAC.Get(ctx, leaseID.String())
+		r.NoError(err)
+		var storedLease storage.DiskLease
+		storedLease.Decode(leaseResp.Entity().Entity())
+		r.Equal(storage.BOUND, storedLease.Status)
+
+		// Act: Release disk leases for the sandbox
+		err = controller.releaseDiskLeases(ctx, sandboxID)
+		r.NoError(err)
+
+		// Assert: Lease should now be RELEASED
+		leaseResp, err = es.EAC.Get(ctx, leaseID.String())
+		r.NoError(err)
+		var releasedLease storage.DiskLease
+		releasedLease.Decode(leaseResp.Entity().Entity())
+		r.Equal(storage.RELEASED, releasedLease.Status,
+			"lease should be transitioned to RELEASED status")
+	})
+
+	t.Run("does not affect leases owned by other sandboxes", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node",
+		}
+
+		// Setup: Create two sandboxes with their own leases
+		sandbox1ID := entity.Id("sandbox/sandbox-1")
+		sandbox2ID := entity.Id("sandbox/sandbox-2")
+		nodeID := entity.Id("node/test-node")
+
+		lease1ID := entity.Id("disk-lease/lease-1")
+		lease1 := &storage.DiskLease{
+			ID:        lease1ID,
+			DiskId:    entity.Id("disk/disk-1"),
+			SandboxId: sandbox1ID,
+			NodeId:    nodeID,
+			Status:    storage.BOUND,
+		}
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, lease1ID,
+			lease1.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		lease2ID := entity.Id("disk-lease/lease-2")
+		lease2 := &storage.DiskLease{
+			ID:        lease2ID,
+			DiskId:    entity.Id("disk/disk-2"),
+			SandboxId: sandbox2ID,
+			NodeId:    nodeID,
+			Status:    storage.BOUND,
+		}
+		_, err = es.EAC.Create(ctx, entity.New(
+			entity.DBId, lease2ID,
+			lease2.Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Act: Release leases for sandbox1 only
+		err = controller.releaseDiskLeases(ctx, sandbox1ID)
+		r.NoError(err)
+
+		// Assert: sandbox1's lease should be RELEASED
+		leaseResp, err := es.EAC.Get(ctx, lease1ID.String())
+		r.NoError(err)
+		var updatedLease1 storage.DiskLease
+		updatedLease1.Decode(leaseResp.Entity().Entity())
+		r.Equal(storage.RELEASED, updatedLease1.Status)
+
+		// Assert: sandbox2's lease should still be BOUND
+		leaseResp, err = es.EAC.Get(ctx, lease2ID.String())
+		r.NoError(err)
+		var updatedLease2 storage.DiskLease
+		updatedLease2.Decode(leaseResp.Entity().Entity())
+		r.Equal(storage.BOUND, updatedLease2.Status,
+			"other sandbox's lease should not be affected")
+	})
+}


### PR DESCRIPTION
## Summary

Disk leases were not being released when sandboxes died, leaving orphaned BOUND leases pointing to dead sandboxes. When a new sandbox tried to use the same disk (e.g., after a version change), it would find the stale lease and fail.

**Root cause**: `stopSandbox()` released network IPs but not disk leases.

**Fix**: Release disk leases during sandbox cleanup, following the same pattern as network IP cleanup.

## Changes

- Add `releaseDiskLeases()` to transition leases to RELEASED status
- Call it from `stopSandbox()` alongside IP release
- Simplify `acquireDiskLease()` - no transfer logic needed since leases are properly released
- Add tests for lease acquisition and release

## Test plan

- [x] New unit tests for `acquireDiskLease()` covering:
  - Creating new lease when none exists
  - Reusing own lease (retry case)
  - Failing if another sandbox has a BOUND lease
  - Creating new lease when existing lease is RELEASED
  - Not reusing lease from different node
- [x] New unit tests for `releaseDiskLeases()` covering:
  - Releasing leases owned by sandbox
  - Not affecting leases owned by other sandboxes
- [ ] Manual testing with app version change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandboxes can acquire or take over disk leases and release their leases during shutdown.

* **Improvements**
  * Leases use generated unique IDs and binding is awaited before use.
  * Stale non-bound leases are ignored; leases aren’t reused across nodes.
  * Active lease conflicts are detected and surfaced; shutdown proceeds even if lease release errors occur.

* **Tests**
  * Added tests covering acquire, reuse, conflict, release, and node-specific lease behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->