### PR TITLE
Add miren deploy cancel command for users to cancel stuck deployments

### DIFF
--- a/api/deployment/deployment_v1alpha/rpc.gen.go
+++ b/api/deployment/deployment_v1alpha/rpc.gen.go
@@ -1241,6 +1241,88 @@ func (v *DeploymentGetActiveDeploymentResults) UnmarshalJSON(data []byte) error 
 	return json.Unmarshal(data, &v.data)
 }
 
+type deploymentCancelDeploymentArgsData struct {
+	DeploymentId *string `cbor:"0,keyasint,omitempty" json:"deployment_id,omitempty"`
+	CallerUserId *string `cbor:"1,keyasint,omitempty" json:"caller_user_id,omitempty"`
+}
+
+type DeploymentCancelDeploymentArgs struct {
+	call rpc.Call
+	data deploymentCancelDeploymentArgsData
+}
+
+func (v *DeploymentCancelDeploymentArgs) HasDeploymentId() bool {
+	return v.data.DeploymentId != nil
+}
+
+func (v *DeploymentCancelDeploymentArgs) DeploymentId() string {
+	if v.data.DeploymentId == nil {
+		return ""
+	}
+	return *v.data.DeploymentId
+}
+
+func (v *DeploymentCancelDeploymentArgs) HasCallerUserId() bool {
+	return v.data.CallerUserId != nil
+}
+
+func (v *DeploymentCancelDeploymentArgs) CallerUserId() string {
+	if v.data.CallerUserId == nil {
+		return ""
+	}
+	return *v.data.CallerUserId
+}
+
+func (v *DeploymentCancelDeploymentArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *DeploymentCancelDeploymentArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *DeploymentCancelDeploymentArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *DeploymentCancelDeploymentArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type deploymentCancelDeploymentResultsData struct {
+	Success *bool   `cbor:"0,keyasint,omitempty" json:"success,omitempty"`
+	Error   *string `cbor:"1,keyasint,omitempty" json:"error,omitempty"`
+}
+
+type DeploymentCancelDeploymentResults struct {
+	call rpc.Call
+	data deploymentCancelDeploymentResultsData
+}
+
+func (v *DeploymentCancelDeploymentResults) SetSuccess(success bool) {
+	v.data.Success = &success
+}
+
+func (v *DeploymentCancelDeploymentResults) SetError(error string) {
+	v.data.Error = &error
+}
+
+func (v *DeploymentCancelDeploymentResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *DeploymentCancelDeploymentResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *DeploymentCancelDeploymentResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *DeploymentCancelDeploymentResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type DeploymentCreateDeployment struct {
 	rpc.Call
 	args    DeploymentCreateDeploymentArgs
@@ -1449,6 +1531,32 @@ func (t *DeploymentGetActiveDeployment) Results() *DeploymentGetActiveDeployment
 	return results
 }
 
+type DeploymentCancelDeployment struct {
+	rpc.Call
+	args    DeploymentCancelDeploymentArgs
+	results DeploymentCancelDeploymentResults
+}
+
+func (t *DeploymentCancelDeployment) Args() *DeploymentCancelDeploymentArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *DeploymentCancelDeployment) Results() *DeploymentCancelDeploymentResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type Deployment interface {
 	CreateDeployment(ctx context.Context, state *DeploymentCreateDeployment) error
 	UpdateDeploymentStatus(ctx context.Context, state *DeploymentUpdateDeploymentStatus) error
@@ -1458,6 +1566,7 @@ type Deployment interface {
 	ListDeployments(ctx context.Context, state *DeploymentListDeployments) error
 	GetDeploymentById(ctx context.Context, state *DeploymentGetDeploymentById) error
 	GetActiveDeployment(ctx context.Context, state *DeploymentGetActiveDeployment) error
+	CancelDeployment(ctx context.Context, state *DeploymentCancelDeployment) error
 }
 
 type reexportDeployment struct {
@@ -1493,6 +1602,10 @@ func (reexportDeployment) GetDeploymentById(ctx context.Context, state *Deployme
 }
 
 func (reexportDeployment) GetActiveDeployment(ctx context.Context, state *DeploymentGetActiveDeployment) error {
+	panic("not implemented")
+}
+
+func (reexportDeployment) CancelDeployment(ctx context.Context, state *DeploymentCancelDeployment) error {
 	panic("not implemented")
 }
 
@@ -1564,6 +1677,14 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Index:         7,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetActiveDeployment(ctx, &DeploymentGetActiveDeployment{Call: call})
+			},
+		},
+		{
+			Name:          "CancelDeployment",
+			InterfaceName: "Deployment",
+			Index:         8,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.CancelDeployment(ctx, &DeploymentCancelDeployment{Call: call})
 			},
 		},
 	}
@@ -1832,4 +1953,46 @@ func (v DeploymentClient) GetActiveDeployment(ctx context.Context, app_name stri
 	}
 
 	return &DeploymentClientGetActiveDeploymentResults{client: v.Client, data: ret}, nil
+}
+
+type DeploymentClientCancelDeploymentResults struct {
+	client rpc.Client
+	data   deploymentCancelDeploymentResultsData
+}
+
+func (v *DeploymentClientCancelDeploymentResults) HasSuccess() bool {
+	return v.data.Success != nil
+}
+
+func (v *DeploymentClientCancelDeploymentResults) Success() bool {
+	if v.data.Success == nil {
+		return false
+	}
+	return *v.data.Success
+}
+
+func (v *DeploymentClientCancelDeploymentResults) HasError() bool {
+	return v.data.Error != nil
+}
+
+func (v *DeploymentClientCancelDeploymentResults) Error() string {
+	if v.data.Error == nil {
+		return ""
+	}
+	return *v.data.Error
+}
+
+func (v DeploymentClient) CancelDeployment(ctx context.Context, deployment_id string, caller_user_id string) (*DeploymentClientCancelDeploymentResults, error) {
+	args := DeploymentCancelDeploymentArgs{}
+	args.data.DeploymentId = &deployment_id
+	args.data.CallerUserId = &caller_user_id
+
+	var ret deploymentCancelDeploymentResultsData
+
+	err := v.Call(ctx, "CancelDeployment", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DeploymentClientCancelDeploymentResults{client: v.Client, data: ret}, nil
 }

--- a/api/deployment/rpc.yml
+++ b/api/deployment/rpc.yml
@@ -153,6 +153,24 @@ interfaces:
             type: DeploymentInfo
             doc: The active deployment (if any)
 
+      - name: CancelDeployment
+        index: 8
+        doc: Cancel an in-progress deployment
+        parameters:
+          - name: deployment_id
+            type: string
+            doc: The ID of the deployment to cancel
+          - name: caller_user_id
+            type: string
+            doc: User ID of the caller (from JWT claims, empty if no auth)
+        results:
+          - name: success
+            type: bool
+            doc: Whether cancellation succeeded
+          - name: error
+            type: string
+            doc: Error message if cancellation failed
+
 types:
   - type: DeploymentInfo
     doc: Information about a deployment

--- a/cli/commands/app_history.go
+++ b/cli/commands/app_history.go
@@ -91,9 +91,9 @@ func AppHistory(ctx *Context, opts struct {
 			"STATUS", "CLUSTER", "VERSION", "DEPLOYED BY", "WHEN", "GIT SHA", "BRANCH", "COMMIT MESSAGE")
 		ctx.Printf("%s\n", strings.Repeat("-", 160))
 	} else {
-		ctx.Printf("%-12s %-25s %-25s %-15s\n",
-			"STATUS", "VERSION", "DEPLOYED BY", "WHEN")
-		ctx.Printf("%s\n", strings.Repeat("-", 80))
+		ctx.Printf("%-12s %-25s %-25s %-15s %s\n",
+			"STATUS", "VERSION", "DEPLOYED BY", "WHEN", "ID")
+		ctx.Printf("%s\n", strings.Repeat("-", 110))
 	}
 
 	// Status colors
@@ -102,6 +102,7 @@ func AppHistory(ctx *Context, opts struct {
 	failedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))      // Red
 	rolledBackStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("11")) // Yellow
 	inProgressStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("14")) // Cyan
+	cancelledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("11"))  // Yellow
 
 	for _, dep := range deployments {
 		// Format status with color and icons
@@ -118,6 +119,8 @@ func AppHistory(ctx *Context, opts struct {
 			styledStatus = rolledBackStyle.Render("↩ " + status)
 		case "in_progress":
 			styledStatus = inProgressStyle.Render("⟳ " + status)
+		case "cancelled":
+			styledStatus = cancelledStyle.Render("⊘ " + status)
 		default:
 			styledStatus = status
 		}
@@ -205,11 +208,13 @@ func AppHistory(ctx *Context, opts struct {
 				gitBranch,
 				gitMessage)
 		} else {
-			ctx.Printf("%-12s %-25s %-25s %-15s\n",
+			deploymentId := strings.TrimPrefix(dep.Id(), "deployment/")
+			ctx.Printf("%-12s %-25s %-25s %-15s %s\n",
 				styledStatus,
 				version,
 				user,
-				timeStr)
+				timeStr,
+				deploymentId)
 		}
 
 		// Show phase for in-progress deployments
@@ -218,8 +223,8 @@ func AppHistory(ctx *Context, opts struct {
 			ctx.Printf("             %s\n", phaseStyle.Render("Phase: "+dep.Phase()))
 		}
 
-		// Show error message if failed
-		if status == "failed" && dep.HasErrorMessage() && dep.ErrorMessage() != "" {
+		// Show error message if failed or cancelled
+		if (status == "failed" || status == "cancelled") && dep.HasErrorMessage() && dep.ErrorMessage() != "" {
 			errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Italic(true)
 			ctx.Printf("             %s\n", errorStyle.Render("Error: "+dep.ErrorMessage()))
 		}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -20,6 +20,7 @@ func RegisterAll(d *mflags.Dispatcher) {
 	// App lifecycle commands
 	d.Dispatch("init", Infer("init", "Initialize a new application", Init))
 	d.Dispatch("deploy", Infer("deploy", "Deploy an application", Deploy))
+	d.Dispatch("deploy cancel", Infer("deploy cancel", "Cancel an in-progress deployment", DeployCancel))
 	d.Dispatch("logs", Infer("logs", "Get logs for an application", Logs))
 
 	// App management commands

--- a/cli/commands/deploy_cancel.go
+++ b/cli/commands/deploy_cancel.go
@@ -12,9 +12,6 @@ func DeployCancel(ctx *Context, opts struct {
 		DeploymentID string `positional-arg-name:"deployment-id" description:"ID of the deployment to cancel"`
 	} `positional-args:"yes" required:"yes"`
 }) error {
-	// Get current user ID from JWT claims (if authenticated)
-	callerUserId := ctx.GetCurrentUserID()
-
 	client, err := ctx.RPCClient("deployment")
 	if err != nil {
 		return err
@@ -23,7 +20,7 @@ func DeployCancel(ctx *Context, opts struct {
 
 	depClient := &deployment_v1alpha.DeploymentClient{Client: client}
 
-	result, err := depClient.CancelDeployment(ctx, opts.Args.DeploymentID, callerUserId)
+	result, err := depClient.CancelDeployment(ctx, opts.Args.DeploymentID, "")
 	if err != nil {
 		return err
 	}

--- a/cli/commands/deploy_cancel.go
+++ b/cli/commands/deploy_cancel.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"fmt"
+	"errors"
 
 	"miren.dev/runtime/api/deployment/deployment_v1alpha"
 )
@@ -29,7 +29,7 @@ func DeployCancel(ctx *Context, opts struct {
 	}
 
 	if result.Error() != "" {
-		return fmt.Errorf("%s", result.Error())
+		return errors.New(result.Error())
 	}
 
 	ctx.Printf("Cancelled deployment %s\n", opts.Args.DeploymentID)

--- a/cli/commands/deploy_cancel.go
+++ b/cli/commands/deploy_cancel.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/api/deployment/deployment_v1alpha"
+)
+
+func DeployCancel(ctx *Context, opts struct {
+	ConfigCentric
+	Args struct {
+		DeploymentID string `positional-arg-name:"deployment-id" description:"ID of the deployment to cancel"`
+	} `positional-args:"yes" required:"yes"`
+}) error {
+	// Get current user ID from JWT claims (if authenticated)
+	callerUserId := ctx.GetCurrentUserID()
+
+	client, err := ctx.RPCClient("deployment")
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	depClient := &deployment_v1alpha.DeploymentClient{Client: client}
+
+	result, err := depClient.CancelDeployment(ctx, opts.Args.DeploymentID, callerUserId)
+	if err != nil {
+		return err
+	}
+
+	if result.Error() != "" {
+		return fmt.Errorf("%s", result.Error())
+	}
+
+	ctx.Printf("Cancelled deployment %s\n", opts.Args.DeploymentID)
+	return nil
+}

--- a/cli/commands/deploy_cancel.go
+++ b/cli/commands/deploy_cancel.go
@@ -8,19 +8,17 @@ import (
 
 func DeployCancel(ctx *Context, opts struct {
 	ConfigCentric
-	Args struct {
-		DeploymentID string `positional-arg-name:"deployment-id" description:"ID of the deployment to cancel"`
-	} `positional-args:"yes" required:"yes"`
+	DeploymentID string `short:"d" long:"deployment" description:"ID of the deployment to cancel" required:"true"`
 }) error {
-	client, err := ctx.RPCClient("deployment")
+	client, err := ctx.RPCClient("dev.miren.runtime/deployment")
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
-	depClient := &deployment_v1alpha.DeploymentClient{Client: client}
+	depClient := deployment_v1alpha.NewDeploymentClient(client)
 
-	result, err := depClient.CancelDeployment(ctx, opts.Args.DeploymentID, "")
+	result, err := depClient.CancelDeployment(ctx, opts.DeploymentID, "")
 	if err != nil {
 		return err
 	}
@@ -29,6 +27,6 @@ func DeployCancel(ctx *Context, opts struct {
 		return errors.New(result.Error())
 	}
 
-	ctx.Printf("Cancelled deployment %s\n", opts.Args.DeploymentID)
+	ctx.Printf("Cancelled deployment %s\n", opts.DeploymentID)
 	return nil
 }

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -15,8 +15,6 @@ import (
 	"golang.org/x/sys/unix"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/asm"
-	"miren.dev/runtime/pkg/auth"
-	"miren.dev/runtime/pkg/cloudauth"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/slogfmt"
 	"miren.dev/runtime/pkg/slogrus"
@@ -437,51 +435,4 @@ func (c *Context) wrapRPCError(err error) error {
 		return ErrAccessDenied
 	}
 	return err
-}
-
-// GetCurrentUserID returns the current user's ID from JWT claims if authenticated,
-// or an empty string if not authenticated or if authentication fails.
-func (c *Context) GetCurrentUserID() string {
-	if c.ClusterConfig == nil || c.ClusterConfig.Identity == "" || c.ClientConfig == nil {
-		return ""
-	}
-
-	identity, err := c.ClientConfig.GetIdentity(c.ClusterConfig.Identity)
-	if err != nil || identity == nil || identity.Type != "keypair" {
-		return ""
-	}
-
-	privateKeyPEM, err := c.ClientConfig.GetPrivateKeyPEM(identity)
-	if err != nil {
-		return ""
-	}
-
-	keyPair, err := cloudauth.LoadKeyPairFromPEM(privateKeyPEM)
-	if err != nil {
-		return ""
-	}
-
-	authServer := identity.Issuer
-	if authServer == "" {
-		authServer = c.ClusterConfig.Hostname
-	}
-	if !strings.HasPrefix(authServer, "http") {
-		if strings.Contains(authServer, "localhost") || strings.Contains(authServer, "127.0.0.1") {
-			authServer = "http://" + authServer
-		} else {
-			authServer = "https://" + authServer
-		}
-	}
-
-	token, err := clientconfig.AuthenticateWithKey(c, authServer, keyPair)
-	if err != nil {
-		return ""
-	}
-
-	claims, err := auth.ParseUnverifiedClaims(token)
-	if err != nil {
-		return ""
-	}
-
-	return claims.UserID
 }

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -15,6 +15,8 @@ import (
 	"golang.org/x/sys/unix"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/asm"
+	"miren.dev/runtime/pkg/auth"
+	"miren.dev/runtime/pkg/cloudauth"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/slogfmt"
 	"miren.dev/runtime/pkg/slogrus"
@@ -435,4 +437,51 @@ func (c *Context) wrapRPCError(err error) error {
 		return ErrAccessDenied
 	}
 	return err
+}
+
+// GetCurrentUserID returns the current user's ID from JWT claims if authenticated,
+// or an empty string if not authenticated or if authentication fails.
+func (c *Context) GetCurrentUserID() string {
+	if c.ClusterConfig == nil || c.ClusterConfig.Identity == "" || c.ClientConfig == nil {
+		return ""
+	}
+
+	identity, err := c.ClientConfig.GetIdentity(c.ClusterConfig.Identity)
+	if err != nil || identity == nil || identity.Type != "keypair" {
+		return ""
+	}
+
+	privateKeyPEM, err := c.ClientConfig.GetPrivateKeyPEM(identity)
+	if err != nil {
+		return ""
+	}
+
+	keyPair, err := cloudauth.LoadKeyPairFromPEM(privateKeyPEM)
+	if err != nil {
+		return ""
+	}
+
+	authServer := identity.Issuer
+	if authServer == "" {
+		authServer = c.ClusterConfig.Hostname
+	}
+	if !strings.HasPrefix(authServer, "http") {
+		if strings.Contains(authServer, "localhost") || strings.Contains(authServer, "127.0.0.1") {
+			authServer = "http://" + authServer
+		} else {
+			authServer = "https://" + authServer
+		}
+	}
+
+	token, err := clientconfig.AuthenticateWithKey(c, authServer, keyPair)
+	if err != nil {
+		return ""
+	}
+
+	claims, err := auth.ParseUnverifiedClaims(token)
+	if err != nil {
+		return ""
+	}
+
+	return claims.UserID
 }

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -605,8 +606,12 @@ func (d *DeploymentServer) CancelDeployment(ctx context.Context, req *deployment
 	// Get the deployment by ID
 	deploymentResp, err := d.EAC.Get(ctx, deploymentId)
 	if err != nil {
-		d.Log.Error("Failed to get deployment", "deployment_id", deploymentId, "error", err)
-		results.SetError("deployment not found")
+		if errors.Is(err, cond.ErrNotFound{}) {
+			results.SetError("deployment not found")
+		} else {
+			d.Log.Error("Failed to get deployment", "deployment_id", deploymentId, "error", err)
+			results.SetError("failed to get deployment")
+		}
 		return nil
 	}
 
@@ -620,26 +625,13 @@ func (d *DeploymentServer) CancelDeployment(ctx context.Context, req *deployment
 		return nil
 	}
 
-	// Check ownership if deployment has an owner
-	ownerUserId := deployment.DeployedBy.UserId
-	if ownerUserId != "" {
-		// Deployment has an owner  - require matching user
-		if callerUserId == "" {
-			results.SetError(fmt.Sprintf("deployment owned by %s - authentication required to cancel",
-				deployment.DeployedBy.UserEmail))
-			return nil
-		}
-		if callerUserId != ownerUserId {
-			results.SetError(fmt.Sprintf("deployment owned by %s - only the owner can cancel",
-				deployment.DeployedBy.UserEmail))
-			return nil
-		}
-	}
-	// If no owner (unregistered cluster), allow anyone
-
 	// Mark as cancelled
 	deployment.Status = "cancelled"
-	deployment.ErrorMessage = "Deployment cancelled by user"
+	if callerUserId != "" {
+		deployment.ErrorMessage = fmt.Sprintf("Deployment cancelled by user %s", callerUserId)
+	} else {
+		deployment.ErrorMessage = "Deployment cancelled by user"
+	}
 	deployment.CompletedAt = time.Now().Format(time.RFC3339)
 
 	// Update entity

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -598,10 +598,6 @@ func (d *DeploymentServer) CancelDeployment(ctx context.Context, req *deployment
 	}
 
 	deploymentId := args.DeploymentId()
-	callerUserId := ""
-	if args.HasCallerUserId() {
-		callerUserId = args.CallerUserId()
-	}
 
 	// Get the deployment by ID
 	deploymentResp, err := d.EAC.Get(ctx, deploymentId)
@@ -627,11 +623,7 @@ func (d *DeploymentServer) CancelDeployment(ctx context.Context, req *deployment
 
 	// Mark as cancelled
 	deployment.Status = "cancelled"
-	if callerUserId != "" {
-		deployment.ErrorMessage = fmt.Sprintf("Deployment cancelled by user %s", callerUserId)
-	} else {
-		deployment.ErrorMessage = "Deployment cancelled by user"
-	}
+	deployment.ErrorMessage = "Deployment cancelled by user"
 	deployment.CompletedAt = time.Now().Format(time.RFC3339)
 
 	// Update entity
@@ -652,8 +644,7 @@ func (d *DeploymentServer) CancelDeployment(ctx context.Context, req *deployment
 
 	d.Log.Info("Cancelled deployment",
 		"deployment_id", deploymentId,
-		"app", deployment.AppName,
-		"cancelled_by", callerUserId)
+		"app", deployment.AppName)
 
 	return nil
 }

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -404,7 +404,10 @@ func (d *DeploymentServer) UpdateFailedDeployment(ctx context.Context, req *depl
 	decodeEntity(deploymentResp.Entity(), &deployment)
 
 	// Update deployment with failure information
-	deployment.Status = "failed"
+	// Don't overwrite cancelled status
+	if deployment.Status != "cancelled" {
+		deployment.Status = "failed"
+	}
 	deployment.ErrorMessage = errorMessage
 	deployment.BuildLogs = buildLogs
 	deployment.CompletedAt = time.Now().Format(time.RFC3339)

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -229,6 +229,7 @@ func (d *DeploymentServer) UpdateDeploymentStatus(ctx context.Context, req *depl
 		"succeeded":   true,
 		"failed":      true,
 		"rolled_back": true,
+		"cancelled":   true,
 	}
 	if !validStatuses[newStatus] {
 		return cond.ValidationFailure("invalid-status",
@@ -581,6 +582,86 @@ func (d *DeploymentServer) GetActiveDeployment(ctx context.Context, req *deploym
 	deployment := deployments[0]
 	deploymentInfo := d.toDeploymentInfo(deployment)
 	results.SetDeployment(deploymentInfo)
+
+	return nil
+}
+
+func (d *DeploymentServer) CancelDeployment(ctx context.Context, req *deployment_v1alpha.DeploymentCancelDeployment) error {
+	args := req.Args()
+	results := req.Results()
+
+	// Validate required fields
+	if !args.HasDeploymentId() || args.DeploymentId() == "" {
+		results.SetError("deployment_id is required")
+		return nil
+	}
+
+	deploymentId := args.DeploymentId()
+	callerUserId := ""
+	if args.HasCallerUserId() {
+		callerUserId = args.CallerUserId()
+	}
+
+	// Get the deployment by ID
+	deploymentResp, err := d.EAC.Get(ctx, deploymentId)
+	if err != nil {
+		d.Log.Error("Failed to get deployment", "deployment_id", deploymentId, "error", err)
+		results.SetError("deployment not found")
+		return nil
+	}
+
+	// Decode to Deployment struct
+	var deployment core_v1alpha.Deployment
+	decodeEntity(deploymentResp.Entity(), &deployment)
+
+	// Verify deployment is in_progress
+	if deployment.Status != "in_progress" {
+		results.SetError(fmt.Sprintf("deployment is not in progress (status: %s)", deployment.Status))
+		return nil
+	}
+
+	// Check ownership if deployment has an owner
+	ownerUserId := deployment.DeployedBy.UserId
+	if ownerUserId != "" {
+		// Deployment has an owner  - require matching user
+		if callerUserId == "" {
+			results.SetError(fmt.Sprintf("deployment owned by %s - authentication required to cancel",
+				deployment.DeployedBy.UserEmail))
+			return nil
+		}
+		if callerUserId != ownerUserId {
+			results.SetError(fmt.Sprintf("deployment owned by %s - only the owner can cancel",
+				deployment.DeployedBy.UserEmail))
+			return nil
+		}
+	}
+	// If no owner (unregistered cluster), allow anyone
+
+	// Mark as cancelled
+	deployment.Status = "cancelled"
+	deployment.ErrorMessage = "Deployment cancelled by user"
+	deployment.CompletedAt = time.Now().Format(time.RFC3339)
+
+	// Update entity
+	updateAttrs := deployment.Encode()
+	updateEntity := &entityserver_v1alpha.Entity{}
+	updateEntity.SetId(deploymentId)
+	updateEntity.SetAttrs(updateAttrs)
+	updateEntity.SetRevision(deploymentResp.Entity().Revision())
+
+	_, err = d.EAC.Put(ctx, updateEntity)
+	if err != nil {
+		d.Log.Error("Failed to cancel deployment", "deployment_id", deploymentId, "error", err)
+		results.SetError("failed to cancel deployment")
+		return nil
+	}
+
+	results.SetSuccess(true)
+
+	d.Log.Info("Cancelled deployment",
+		"deployment_id", deploymentId,
+		"app", deployment.AppName,
+		"cancelled_by", callerUserId)
 
 	return nil
 }

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -647,11 +647,12 @@ func TestCancelDeployment(t *testing.T) {
 		}
 	})
 
-	t.Run("cancel in-progress deployment as owner succeeds", func(t *testing.T) {
+	t.Run("cancel owned deployment as different user succeeds", func(t *testing.T) {
+		// Any user with cluster access can cancel any deployment (permissive model)
 		ownerId := "user-123"
 		ownerEmail := "owner@example.com"
+		differentUserId := "user-other"
 
-		// Create an in-progress deployment with an owner
 		deployment := &core_v1alpha.Deployment{
 			AppName:    "test-app-owned",
 			ClusterId:  "test-cluster",
@@ -669,8 +670,8 @@ func TestCancelDeployment(t *testing.T) {
 			t.Fatalf("Failed to create test deployment: %v", err)
 		}
 
-		// Cancel as owner (should succeed)
-		result, err := client.CancelDeployment(ctx, string(deploymentId), ownerId)
+		// Cancel as different user (should succeed - permissive model)
+		result, err := client.CancelDeployment(ctx, string(deploymentId), differentUserId)
 		if err != nil {
 			t.Fatalf("Unexpected RPC error: %v", err)
 		}
@@ -688,83 +689,6 @@ func TestCancelDeployment(t *testing.T) {
 		}
 		if getResult.Deployment().Status() != "cancelled" {
 			t.Errorf("Expected status 'cancelled', got '%s'", getResult.Deployment().Status())
-		}
-	})
-
-	t.Run("cancel owned deployment without caller id returns error", func(t *testing.T) {
-		ownerId := "user-456"
-		ownerEmail := "owner2@example.com"
-
-		// Create an in-progress deployment with an owner
-		deployment := &core_v1alpha.Deployment{
-			AppName:    "test-app-owned-2",
-			ClusterId:  "test-cluster",
-			AppVersion: "v1.0.0",
-			Status:     "in_progress",
-			Phase:      "building",
-			DeployedBy: core_v1alpha.DeployedBy{
-				UserId:    ownerId,
-				UserEmail: ownerEmail,
-				Timestamp: time.Now().Format(time.RFC3339),
-			},
-		}
-		deploymentId, err := inmem.Client.Create(ctx, "owned-deployment-2", deployment)
-		if err != nil {
-			t.Fatalf("Failed to create test deployment: %v", err)
-		}
-
-		// Try to cancel without providing caller ID (should fail - auth required)
-		result, err := client.CancelDeployment(ctx, string(deploymentId), "")
-		if err != nil {
-			t.Fatalf("Unexpected RPC error: %v", err)
-		}
-		if !result.HasError() || result.Error() == "" {
-			t.Fatal("Expected error when cancelling owned deployment without auth")
-		}
-		if !containsString(result.Error(), "authentication required to cancel") {
-			t.Errorf("Expected error containing 'authentication required to cancel', got '%s'", result.Error())
-		}
-		if !containsString(result.Error(), ownerEmail) {
-			t.Errorf("Expected error to mention owner email '%s', got '%s'", ownerEmail, result.Error())
-		}
-	})
-
-	t.Run("cancel owned deployment as different user returns error", func(t *testing.T) {
-		ownerId := "user-789"
-		ownerEmail := "owner3@example.com"
-		differentUserId := "user-other"
-
-		// Create an in-progress deployment with an owner
-		deployment := &core_v1alpha.Deployment{
-			AppName:    "test-app-owned-3",
-			ClusterId:  "test-cluster",
-			AppVersion: "v1.0.0",
-			Status:     "in_progress",
-			Phase:      "building",
-			DeployedBy: core_v1alpha.DeployedBy{
-				UserId:    ownerId,
-				UserEmail: ownerEmail,
-				Timestamp: time.Now().Format(time.RFC3339),
-			},
-		}
-		deploymentId, err := inmem.Client.Create(ctx, "owned-deployment-3", deployment)
-		if err != nil {
-			t.Fatalf("Failed to create test deployment: %v", err)
-		}
-
-		// Try to cancel as different user (should fail)
-		result, err := client.CancelDeployment(ctx, string(deploymentId), differentUserId)
-		if err != nil {
-			t.Fatalf("Unexpected RPC error: %v", err)
-		}
-		if !result.HasError() || result.Error() == "" {
-			t.Fatal("Expected error when cancelling deployment owned by different user")
-		}
-		if !containsString(result.Error(), "only the owner can cancel") {
-			t.Errorf("Expected error containing 'only the owner can cancel', got '%s'", result.Error())
-		}
-		if !containsString(result.Error(), ownerEmail) {
-			t.Errorf("Expected error to mention owner email '%s', got '%s'", ownerEmail, result.Error())
 		}
 	})
 

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -11,6 +11,7 @@ import (
 	deployment_v1alpha "miren.dev/runtime/api/deployment/deployment_v1alpha"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/standard"
 )
 
 func TestCreateDeploymentWithGitInfo(t *testing.T) {
@@ -532,6 +533,283 @@ func indexString(s, substr string) int {
 		}
 	}
 	return -1
+}
+
+func TestCancelDeployment(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup in-memory entity server
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create deployment server
+	logger := slog.Default()
+	server, err := NewDeploymentServer(logger, inmem.EAC)
+	if err != nil {
+		t.Fatalf("Failed to create deployment server: %v", err)
+	}
+
+	// Create RPC client
+	client := &deployment_v1alpha.DeploymentClient{
+		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
+	}
+
+	t.Run("empty deployment id returns error", func(t *testing.T) {
+		result, err := client.CancelDeployment(ctx, "", "")
+		if err != nil {
+			t.Fatalf("Unexpected RPC error: %v", err)
+		}
+		if !result.HasError() || result.Error() == "" {
+			t.Fatal("Expected error for empty deployment ID")
+		}
+		if result.Error() != "deployment_id is required" {
+			t.Errorf("Expected 'deployment_id is required', got '%s'", result.Error())
+		}
+	})
+
+	t.Run("non-existent deployment returns error", func(t *testing.T) {
+		result, err := client.CancelDeployment(ctx, "nonexistent-deployment-id", "")
+		if err != nil {
+			t.Fatalf("Unexpected RPC error: %v", err)
+		}
+		if !result.HasError() || result.Error() == "" {
+			t.Fatal("Expected error for non-existent deployment")
+		}
+		if result.Error() != "deployment not found" {
+			t.Errorf("Expected 'deployment not found', got '%s'", result.Error())
+		}
+	})
+
+	t.Run("cancel deployment not in progress returns error", func(t *testing.T) {
+		// Create a completed (active) deployment
+		deployment := &core_v1alpha.Deployment{
+			AppName:     "test-app-completed",
+			ClusterId:   "test-cluster",
+			AppVersion:  "v1.0.0",
+			Status:      "active",
+			CompletedAt: time.Now().Format(time.RFC3339),
+		}
+		deploymentId, err := inmem.Client.Create(ctx, "completed-deployment", deployment)
+		if err != nil {
+			t.Fatalf("Failed to create test deployment: %v", err)
+		}
+
+		result, err := client.CancelDeployment(ctx, string(deploymentId), "")
+		if err != nil {
+			t.Fatalf("Unexpected RPC error: %v", err)
+		}
+		if !result.HasError() || result.Error() == "" {
+			t.Fatal("Expected error for completed deployment")
+		}
+		if !containsString(result.Error(), "deployment is not in progress") {
+			t.Errorf("Expected error containing 'deployment is not in progress', got '%s'", result.Error())
+		}
+	})
+
+	t.Run("cancel in-progress deployment with no owner succeeds", func(t *testing.T) {
+		// Create an in-progress deployment with no owner (unregistered cluster scenario)
+		deployment := &core_v1alpha.Deployment{
+			AppName:    "test-app-no-owner",
+			ClusterId:  "test-cluster",
+			AppVersion: "v1.0.0",
+			Status:     "in_progress",
+			Phase:      "building",
+			DeployedBy: core_v1alpha.DeployedBy{
+				// No UserId set - simulates unregistered cluster
+				UserEmail: "",
+				Timestamp: time.Now().Format(time.RFC3339),
+			},
+		}
+		deploymentId, err := inmem.Client.Create(ctx, "no-owner-deployment", deployment)
+		if err != nil {
+			t.Fatalf("Failed to create test deployment: %v", err)
+		}
+
+		// Cancel without providing caller ID (should succeed for unregistered cluster)
+		result, err := client.CancelDeployment(ctx, string(deploymentId), "")
+		if err != nil {
+			t.Fatalf("Unexpected RPC error: %v", err)
+		}
+		if result.HasError() && result.Error() != "" {
+			t.Fatalf("Expected success, got error: %s", result.Error())
+		}
+		if !result.Success() {
+			t.Error("Expected Success() to be true")
+		}
+
+		// Verify deployment is now cancelled
+		getResult, err := client.GetDeploymentById(ctx, string(deploymentId))
+		if err != nil {
+			t.Fatalf("Failed to get deployment: %v", err)
+		}
+		if getResult.Deployment().Status() != "cancelled" {
+			t.Errorf("Expected status 'cancelled', got '%s'", getResult.Deployment().Status())
+		}
+	})
+
+	t.Run("cancel in-progress deployment as owner succeeds", func(t *testing.T) {
+		ownerId := "user-123"
+		ownerEmail := "owner@example.com"
+
+		// Create an in-progress deployment with an owner
+		deployment := &core_v1alpha.Deployment{
+			AppName:    "test-app-owned",
+			ClusterId:  "test-cluster",
+			AppVersion: "v1.0.0",
+			Status:     "in_progress",
+			Phase:      "building",
+			DeployedBy: core_v1alpha.DeployedBy{
+				UserId:    ownerId,
+				UserEmail: ownerEmail,
+				Timestamp: time.Now().Format(time.RFC3339),
+			},
+		}
+		deploymentId, err := inmem.Client.Create(ctx, "owned-deployment", deployment)
+		if err != nil {
+			t.Fatalf("Failed to create test deployment: %v", err)
+		}
+
+		// Cancel as owner (should succeed)
+		result, err := client.CancelDeployment(ctx, string(deploymentId), ownerId)
+		if err != nil {
+			t.Fatalf("Unexpected RPC error: %v", err)
+		}
+		if result.HasError() && result.Error() != "" {
+			t.Fatalf("Expected success, got error: %s", result.Error())
+		}
+		if !result.Success() {
+			t.Error("Expected Success() to be true")
+		}
+
+		// Verify deployment is now cancelled
+		getResult, err := client.GetDeploymentById(ctx, string(deploymentId))
+		if err != nil {
+			t.Fatalf("Failed to get deployment: %v", err)
+		}
+		if getResult.Deployment().Status() != "cancelled" {
+			t.Errorf("Expected status 'cancelled', got '%s'", getResult.Deployment().Status())
+		}
+	})
+
+	t.Run("cancel owned deployment without caller id returns error", func(t *testing.T) {
+		ownerId := "user-456"
+		ownerEmail := "owner2@example.com"
+
+		// Create an in-progress deployment with an owner
+		deployment := &core_v1alpha.Deployment{
+			AppName:    "test-app-owned-2",
+			ClusterId:  "test-cluster",
+			AppVersion: "v1.0.0",
+			Status:     "in_progress",
+			Phase:      "building",
+			DeployedBy: core_v1alpha.DeployedBy{
+				UserId:    ownerId,
+				UserEmail: ownerEmail,
+				Timestamp: time.Now().Format(time.RFC3339),
+			},
+		}
+		deploymentId, err := inmem.Client.Create(ctx, "owned-deployment-2", deployment)
+		if err != nil {
+			t.Fatalf("Failed to create test deployment: %v", err)
+		}
+
+		// Try to cancel without providing caller ID (should fail - auth required)
+		result, err := client.CancelDeployment(ctx, string(deploymentId), "")
+		if err != nil {
+			t.Fatalf("Unexpected RPC error: %v", err)
+		}
+		if !result.HasError() || result.Error() == "" {
+			t.Fatal("Expected error when cancelling owned deployment without auth")
+		}
+		if !containsString(result.Error(), "authentication required to cancel") {
+			t.Errorf("Expected error containing 'authentication required to cancel', got '%s'", result.Error())
+		}
+		if !containsString(result.Error(), ownerEmail) {
+			t.Errorf("Expected error to mention owner email '%s', got '%s'", ownerEmail, result.Error())
+		}
+	})
+
+	t.Run("cancel owned deployment as different user returns error", func(t *testing.T) {
+		ownerId := "user-789"
+		ownerEmail := "owner3@example.com"
+		differentUserId := "user-other"
+
+		// Create an in-progress deployment with an owner
+		deployment := &core_v1alpha.Deployment{
+			AppName:    "test-app-owned-3",
+			ClusterId:  "test-cluster",
+			AppVersion: "v1.0.0",
+			Status:     "in_progress",
+			Phase:      "building",
+			DeployedBy: core_v1alpha.DeployedBy{
+				UserId:    ownerId,
+				UserEmail: ownerEmail,
+				Timestamp: time.Now().Format(time.RFC3339),
+			},
+		}
+		deploymentId, err := inmem.Client.Create(ctx, "owned-deployment-3", deployment)
+		if err != nil {
+			t.Fatalf("Failed to create test deployment: %v", err)
+		}
+
+		// Try to cancel as different user (should fail)
+		result, err := client.CancelDeployment(ctx, string(deploymentId), differentUserId)
+		if err != nil {
+			t.Fatalf("Unexpected RPC error: %v", err)
+		}
+		if !result.HasError() || result.Error() == "" {
+			t.Fatal("Expected error when cancelling deployment owned by different user")
+		}
+		if !containsString(result.Error(), "only the owner can cancel") {
+			t.Errorf("Expected error containing 'only the owner can cancel', got '%s'", result.Error())
+		}
+		if !containsString(result.Error(), ownerEmail) {
+			t.Errorf("Expected error to mention owner email '%s', got '%s'", ownerEmail, result.Error())
+		}
+	})
+
+	t.Run("cancel sets correct fields on deployment", func(t *testing.T) {
+		// Create an in-progress deployment
+		deployment := &core_v1alpha.Deployment{
+			AppName:    "test-app-fields",
+			ClusterId:  "test-cluster",
+			AppVersion: "v1.0.0",
+			Status:     "in_progress",
+			Phase:      "activating",
+		}
+		deploymentId, err := inmem.Client.Create(ctx, "fields-deployment", deployment)
+		if err != nil {
+			t.Fatalf("Failed to create test deployment: %v", err)
+		}
+
+		result, err := client.CancelDeployment(ctx, string(deploymentId), "")
+		if err != nil {
+			t.Fatalf("Unexpected RPC error: %v", err)
+		}
+		if result.HasError() && result.Error() != "" {
+			t.Fatalf("Expected success, got error: %s", result.Error())
+		}
+
+		// Verify all fields are set correctly
+		getResult, err := client.GetDeploymentById(ctx, string(deploymentId))
+		if err != nil {
+			t.Fatalf("Failed to get deployment: %v", err)
+		}
+
+		dep := getResult.Deployment()
+		if dep.Status() != "cancelled" {
+			t.Errorf("Expected status 'cancelled', got '%s'", dep.Status())
+		}
+		if !dep.HasCompletedAt() {
+			t.Error("Expected CompletedAt to be set")
+		}
+
+		// Verify CompletedAt is recent (within last minute)
+		completedAt := standard.FromTimestamp(dep.CompletedAt())
+		if time.Since(completedAt) > time.Minute {
+			t.Errorf("CompletedAt (%v) should be recent", completedAt)
+		}
+	})
 }
 
 func TestUpdateDeploymentStatusToInProgress(t *testing.T) {


### PR DESCRIPTION
### Summary

Originally we proposed that there should be a `force unlock` command for the user to unlock deployments. But within the context of the user, they understand that there is another deployment in-progress, not that they are locked from deploying. So this feature allows them to "cancel a deployment" which i think makes more sense from a user business-logic perspective? Happy to discuss! 

 Adds miren deploy cancel <deployment-id> command that allows users to cancel stuck in-progress deployments without waiting for the 30-minute lock expiry.

  Permission model:
  - Registered clusters (with miren.cloud auth): Only the deployment owner can cancel their deployment
  - Unregistered clusters (no auth): Anyone can cancel

  Changes:
  - Add CancelDeployment RPC method to deployment service
  - Create deploy_cancel.go CLI command
  - Add comprehensive test coverage (6 test cases)


This resolves [MIR-534](https://linear.app/miren/issue/MIR-534/deployment-lock-should-have-force-unlock)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cancel-deployment operation and CLI command ("deploy cancel") to cancel in-progress deployments; returns success or error.
* **Bug Fixes**
  * Cancellation is a terminal state and is preserved (not overwritten by later failure updates).
* **UX**
  * App history shows deployment IDs and a styled "cancelled" status; errors now display for cancelled deployments.
* **Tests**
  * Added tests covering cancellation scenarios and post-cancellation state validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->