### PR TITLE
Support setting env vars at deploy time (`miren deploy -e/-s`)

### DIFF
--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -474,6 +474,77 @@ func (v *AnalysisResult) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type environmentVariableData struct {
+	Key       *string `cbor:"0,keyasint,omitempty" json:"key,omitempty"`
+	Value     *string `cbor:"1,keyasint,omitempty" json:"value,omitempty"`
+	Sensitive *bool   `cbor:"2,keyasint,omitempty" json:"sensitive,omitempty"`
+}
+
+type EnvironmentVariable struct {
+	data environmentVariableData
+}
+
+func (v *EnvironmentVariable) HasKey() bool {
+	return v.data.Key != nil
+}
+
+func (v *EnvironmentVariable) Key() string {
+	if v.data.Key == nil {
+		return ""
+	}
+	return *v.data.Key
+}
+
+func (v *EnvironmentVariable) SetKey(key string) {
+	v.data.Key = &key
+}
+
+func (v *EnvironmentVariable) HasValue() bool {
+	return v.data.Value != nil
+}
+
+func (v *EnvironmentVariable) Value() string {
+	if v.data.Value == nil {
+		return ""
+	}
+	return *v.data.Value
+}
+
+func (v *EnvironmentVariable) SetValue(value string) {
+	v.data.Value = &value
+}
+
+func (v *EnvironmentVariable) HasSensitive() bool {
+	return v.data.Sensitive != nil
+}
+
+func (v *EnvironmentVariable) Sensitive() bool {
+	if v.data.Sensitive == nil {
+		return false
+	}
+	return *v.data.Sensitive
+}
+
+func (v *EnvironmentVariable) SetSensitive(sensitive bool) {
+	v.data.Sensitive = &sensitive
+}
+
+func (v *EnvironmentVariable) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *EnvironmentVariable) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *EnvironmentVariable) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *EnvironmentVariable) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type streamRecvArgsData struct {
 	Count *int32 `cbor:"0,keyasint,omitempty" json:"count,omitempty"`
 }
@@ -640,9 +711,10 @@ func (v StreamClient) Recv(ctx context.Context, count int32) (*StreamClientRecvR
 }
 
 type builderBuildFromTarArgsData struct {
-	Application *string         `cbor:"0,keyasint,omitempty" json:"application,omitempty"`
-	Tardata     *rpc.Capability `cbor:"1,keyasint,omitempty" json:"tardata,omitempty"`
-	Status      *rpc.Capability `cbor:"2,keyasint,omitempty" json:"status,omitempty"`
+	Application *string                 `cbor:"0,keyasint,omitempty" json:"application,omitempty"`
+	Tardata     *rpc.Capability         `cbor:"1,keyasint,omitempty" json:"tardata,omitempty"`
+	Status      *rpc.Capability         `cbor:"2,keyasint,omitempty" json:"status,omitempty"`
+	EnvVars     *[]*EnvironmentVariable `cbor:"3,keyasint,omitempty" json:"envVars,omitempty"`
 }
 
 type BuilderBuildFromTarArgs struct {
@@ -681,6 +753,14 @@ func (v *BuilderBuildFromTarArgs) Status() *stream.SendStreamClient[*Status] {
 		return nil
 	}
 	return &stream.SendStreamClient[*Status]{Client: v.call.NewClient(v.data.Status)}
+}
+
+func (v *BuilderBuildFromTarArgs) HasEnvVars() bool {
+	return v.data.EnvVars != nil
+}
+
+func (v *BuilderBuildFromTarArgs) EnvVars() []*EnvironmentVariable {
+	return *v.data.EnvVars
 }
 
 func (v *BuilderBuildFromTarArgs) MarshalCBOR() ([]byte, error) {
@@ -930,7 +1010,7 @@ func (v *BuilderClientBuildFromTarResults) AccessInfo() *AccessInfo {
 	return *v.data.AccessInfo
 }
 
-func (v BuilderClient) BuildFromTar(ctx context.Context, application string, tardata stream.RecvStream[[]byte], status stream.SendStream[*Status]) (*BuilderClientBuildFromTarResults, error) {
+func (v BuilderClient) BuildFromTar(ctx context.Context, application string, tardata stream.RecvStream[[]byte], status stream.SendStream[*Status], envVars []*EnvironmentVariable) (*BuilderClientBuildFromTarResults, error) {
 	args := BuilderBuildFromTarArgs{}
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	args.data.Application = &application
@@ -944,6 +1024,7 @@ func (v BuilderClient) BuildFromTar(ctx context.Context, application string, tar
 		args.data.Status = c
 		caps[oid] = ic
 	}
+	args.data.EnvVars = &envVars
 
 	var ret builderBuildFromTarResultsData
 

--- a/api/build/rpc.yml
+++ b/api/build/rpc.yml
@@ -109,6 +109,22 @@ types:
         index: 7
         doc: Detection events from stack analysis
 
+  - type: EnvironmentVariable
+    doc: An environment variable to set on the app during deploy
+    fields:
+      - name: key
+        type: string
+        index: 0
+        doc: Environment variable name
+      - name: value
+        type: string
+        index: 1
+        doc: Environment variable value
+      - name: sensitive
+        type: bool
+        index: 2
+        doc: Whether the value should be masked in logs and output
+
 interfaces:
   - name: Stream
     methods:
@@ -130,6 +146,9 @@ interfaces:
             type: stream.RecvStream[[]byte]
           - name: status
             type: stream.SendStream[*Status]
+          - name: envVars
+            type: '[]*EnvironmentVariable'
+            doc: Environment variables to set on the app (optional, applied with source=manual)
         results:
           - name: version
             type: string

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -33,10 +33,12 @@ import (
 func Deploy(ctx *Context, opts struct {
 	AppCentric
 
-	Analyze       bool   `long:"analyze" description:"Analyze the app without building (show detected stack, services, etc.)"`
-	Explain       bool   `short:"x" long:"explain" description:"Explain the build process"`
-	ExplainFormat string `long:"explain-format" description:"Explain format" choice:"auto" choice:"plain" choice:"tty" choice:"rawjson" default:"auto"` //nolint
-	Force         bool   `short:"f" long:"force" description:"Skip confirmation prompt"`
+	Analyze       bool     `long:"analyze" description:"Analyze the app without building (show detected stack, services, etc.)"`
+	Explain       bool     `short:"x" long:"explain" description:"Explain the build process"`
+	ExplainFormat string   `long:"explain-format" description:"Explain format" choice:"auto" choice:"plain" choice:"tty" choice:"rawjson" default:"auto"` //nolint
+	Force         bool     `short:"f" long:"force" description:"Skip confirmation prompt"`
+	Env           []string `short:"e" long:"env" description:"Set environment variable (KEY=VALUE, KEY=@file, or KEY to prompt)"`
+	Sensitive     []string `short:"s" long:"sensitive" description:"Set sensitive environment variable (masked in output)"`
 }) error {
 	name := opts.App
 	dir := opts.Dir
@@ -234,6 +236,27 @@ func Deploy(ctx *Context, opts struct {
 	deploymentId := createResult.Deployment().Id()
 	ctx.Log.Info("Created deployment record", "deployment_id", deploymentId)
 
+	// Parse environment variables to pass to build server
+	var envVars []*build_v1alpha.EnvironmentVariable
+	if len(opts.Env) > 0 || len(opts.Sensitive) > 0 {
+		envSpecs, err := ParseEnvVarSpecs(opts.Env, opts.Sensitive)
+		if err != nil {
+			return err
+		}
+
+		// Convert to build_v1alpha.EnvironmentVariable for RPC
+		envVars = make([]*build_v1alpha.EnvironmentVariable, len(envSpecs))
+		for i, spec := range envSpecs {
+			ev := &build_v1alpha.EnvironmentVariable{}
+			ev.SetKey(spec.Key)
+			ev.SetValue(spec.Value)
+			ev.SetSensitive(spec.Sensitive)
+			envVars[i] = ev
+		}
+
+		ctx.Printf("  Setting %d environment variable(s)...\n", len(envVars))
+	}
+
 	// Initialize build error/log tracking
 	var buildErrors []string
 	var buildLogs []string
@@ -360,7 +383,7 @@ func Deploy(ctx *Context, opts struct {
 
 		cb = createBuildStatusCallback(ctx, nil, nil, nil, &buildErrors, nil, progressHandler)
 
-		results, err = bc.BuildFromTar(ctx, name, stream.ServeReader(ctx, r), cb)
+		results, err = bc.BuildFromTar(ctx, name, stream.ServeReader(ctx, r), cb, envVars)
 		if err != nil {
 			// Check if this was a context cancellation (user pressed CTRL-C)
 			if ctx.Err() != nil {
@@ -446,7 +469,7 @@ func Deploy(ctx *Context, opts struct {
 
 		cb = createBuildStatusCallback(deployCtx, updateCh, transferCh, transfers, &buildErrors, &buildLogs, progressHandler)
 
-		results, err = bc.BuildFromTar(deployCtx, name, stream.ServeReader(deployCtx, r), cb)
+		results, err = bc.BuildFromTar(deployCtx, name, stream.ServeReader(deployCtx, r), cb, envVars)
 
 		// Ensure the progress UI is shut down before printing
 		p.Quit()

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -11,12 +11,111 @@ import (
 	"miren.dev/runtime/pkg/ui"
 )
 
+// EnvVarSpec represents a parsed environment variable specification
+type EnvVarSpec struct {
+	Key       string
+	Value     string
+	Sensitive bool
+	FromFile  bool   // true if value was read from a file
+	FromFile_ string // original filename if FromFile is true
+}
+
+// ParseEnvVarSpecs parses environment variable specifications from -e and -s flags.
+// Each spec can be: KEY=VALUE, KEY=@file, or KEY (to prompt interactively).
+func ParseEnvVarSpecs(envSpecs, sensitiveSpecs []string) ([]EnvVarSpec, error) {
+	var specs []EnvVarSpec
+
+	// Process regular env vars
+	for _, spec := range envSpecs {
+		parsed, err := parseEnvVarSpec(spec, false)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, parsed)
+	}
+
+	// Process sensitive env vars
+	for _, spec := range sensitiveSpecs {
+		parsed, err := parseEnvVarSpec(spec, true)
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, parsed)
+	}
+
+	return specs, nil
+}
+
+// parseEnvVarSpec parses a single env var spec (KEY, KEY=VALUE, or KEY=@file)
+func parseEnvVarSpec(spec string, sensitive bool) (EnvVarSpec, error) {
+	parts := strings.SplitN(spec, "=", 2)
+	key := parts[0]
+
+	if key == "" {
+		return EnvVarSpec{}, fmt.Errorf("invalid environment variable: key cannot be empty")
+	}
+
+	result := EnvVarSpec{
+		Key:       key,
+		Sensitive: sensitive,
+	}
+
+	if len(parts) == 1 {
+		// No value provided - will need to prompt
+		var label string
+		if sensitive {
+			label = fmt.Sprintf("Enter value for sensitive variable '%s'", key)
+		} else {
+			label = fmt.Sprintf("Enter value for variable '%s'", key)
+		}
+
+		promptedValue, err := ui.PromptForInput(
+			ui.WithLabel(label),
+			ui.WithSensitive(sensitive),
+		)
+		if err != nil {
+			return EnvVarSpec{}, fmt.Errorf("failed to read value for %s: %w", key, err)
+		}
+		result.Value = promptedValue
+	} else {
+		value := parts[1]
+
+		if strings.HasPrefix(value, "@") {
+			filename := value[1:]
+			data, err := os.ReadFile(filename)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return EnvVarSpec{}, fmt.Errorf("env var references file %s which does not exist", filename)
+				}
+				return EnvVarSpec{}, fmt.Errorf("failed to read env var from file %s: %w", filename, err)
+			}
+			result.Value = string(data)
+			result.FromFile = true
+			result.FromFile_ = filename
+		} else {
+			result.Value = value
+		}
+	}
+
+	return result, nil
+}
+
 func EnvSet(ctx *Context, opts struct {
 	AppCentric
 	Service   string   `short:"S" long:"service" description:"Set env var for specific service only (if not specified, sets for all services)"`
 	Env       []string `short:"e" long:"env" description:"Set environment variables (use KEY to prompt, KEY=VALUE to set directly, KEY=@file to read from file)"`
 	Sensitive []string `short:"s" long:"sensitive" description:"Set sensitive environment variables (use KEY to prompt with masking, KEY=VALUE to set directly, KEY=@file to read from file)"`
 }) error {
+	if len(opts.Env) == 0 && len(opts.Sensitive) == 0 {
+		return fmt.Errorf("no environment variables specified")
+	}
+
+	// Parse all env var specs
+	specs, err := ParseEnvVarSpecs(opts.Env, opts.Sensitive)
+	if err != nil {
+		return err
+	}
+
 	cl, err := ctx.RPCClient("dev.miren.runtime/app")
 	if err != nil {
 		return err
@@ -24,91 +123,20 @@ func EnvSet(ctx *Context, opts struct {
 
 	ac := app_v1alpha.NewCrudClient(cl)
 
-	// Collect all env vars to set
-	type envVar struct {
-		spec      string
-		sensitive bool
-	}
-
-	var allVars []envVar
-	for _, v := range opts.Env {
-		allVars = append(allVars, envVar{spec: v, sensitive: false})
-	}
-	for _, v := range opts.Sensitive {
-		allVars = append(allVars, envVar{spec: v, sensitive: true})
-	}
-
-	if len(allVars) == 0 {
-		return fmt.Errorf("no environment variables specified")
-	}
-
 	var lastVersionId string
 
-	for _, ev := range allVars {
-		var key, value string
-		var wasFile, wasPrompt bool
-
-		parts := strings.SplitN(ev.spec, "=", 2)
-		key = parts[0]
-
-		if key == "" {
-			return fmt.Errorf("invalid environment variable: key cannot be empty")
-		}
-
-		if len(parts) == 1 {
-			// Prompt for value
-			var label string
-			if ev.sensitive {
-				label = fmt.Sprintf("Enter value for sensitive variable '%s'", key)
-			} else {
-				label = fmt.Sprintf("Enter value for variable '%s'", key)
-			}
-
-			promptedValue, err := ui.PromptForInput(
-				ui.WithLabel(label),
-				ui.WithSensitive(ev.sensitive),
-			)
-			if err != nil {
-				return fmt.Errorf("failed to read value for %s: %w", key, err)
-			}
-			value = promptedValue
-			wasPrompt = true
-		} else {
-			value = parts[1]
-
-			if strings.HasPrefix(value, "@") {
-				filename := value[1:]
-				data, err := os.ReadFile(filename)
-				if err != nil {
-					if os.IsNotExist(err) {
-						return fmt.Errorf("env var references file %s which does not exist", filename)
-					}
-					return fmt.Errorf("failed to read env var from file %s: %w", filename, err)
-				}
-				wasFile = true
-				value = string(data)
-			}
-		}
-
+	for _, spec := range specs {
 		// Log what we're doing
-		if wasFile {
-			ctx.Printf("setting %s from file %s...\n", key, parts[1][1:])
-		} else if wasPrompt {
-			if ev.sensitive {
-				ctx.Printf("setting %s (sensitive, from prompt)...\n", key)
-			} else {
-				ctx.Printf("setting %s (from prompt)...\n", key)
-			}
+		if spec.FromFile {
+			ctx.Printf("setting %s from file %s...\n", spec.Key, spec.FromFile_)
+		} else if spec.Sensitive {
+			ctx.Printf("setting %s (sensitive)...\n", spec.Key)
 		} else {
-			if ev.sensitive {
-				ctx.Printf("setting %s (sensitive)...\n", key)
-			} else {
-				ctx.Printf("setting %s...\n", key)
-			}
+			ctx.Printf("setting %s...\n", spec.Key)
 		}
 
 		// Use the targeted SetEnvVar RPC - server handles source tracking
-		res, err := ac.SetEnvVar(ctx, opts.App, key, value, ev.sensitive, opts.Service)
+		res, err := ac.SetEnvVar(ctx, opts.App, spec.Key, spec.Value, spec.Sensitive, opts.Service)
 		if err != nil {
 			return err
 		}

--- a/cli/commands/env_test.go
+++ b/cli/commands/env_test.go
@@ -1,0 +1,119 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseEnvVarSpecs(t *testing.T) {
+	t.Run("parses KEY=VALUE format", func(t *testing.T) {
+		specs, err := ParseEnvVarSpecs([]string{"FOO=bar", "BAZ=qux"}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 2 {
+			t.Fatalf("expected 2 specs, got %d", len(specs))
+		}
+		if specs[0].Key != "FOO" || specs[0].Value != "bar" || specs[0].Sensitive {
+			t.Errorf("unexpected first spec: %+v", specs[0])
+		}
+		if specs[1].Key != "BAZ" || specs[1].Value != "qux" || specs[1].Sensitive {
+			t.Errorf("unexpected second spec: %+v", specs[1])
+		}
+	})
+
+	t.Run("parses sensitive vars", func(t *testing.T) {
+		specs, err := ParseEnvVarSpecs(nil, []string{"SECRET=hidden"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 1 {
+			t.Fatalf("expected 1 spec, got %d", len(specs))
+		}
+		if specs[0].Key != "SECRET" || specs[0].Value != "hidden" || !specs[0].Sensitive {
+			t.Errorf("unexpected spec: %+v", specs[0])
+		}
+	})
+
+	t.Run("combines regular and sensitive vars", func(t *testing.T) {
+		specs, err := ParseEnvVarSpecs([]string{"FOO=bar"}, []string{"SECRET=hidden"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 2 {
+			t.Fatalf("expected 2 specs, got %d", len(specs))
+		}
+		// Regular vars come first
+		if specs[0].Key != "FOO" || specs[0].Sensitive {
+			t.Errorf("expected first spec to be regular var FOO: %+v", specs[0])
+		}
+		// Sensitive vars come after
+		if specs[1].Key != "SECRET" || !specs[1].Sensitive {
+			t.Errorf("expected second spec to be sensitive var SECRET: %+v", specs[1])
+		}
+	})
+
+	t.Run("reads value from file with @", func(t *testing.T) {
+		// Create a temp file with content
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "secret.txt")
+		if err := os.WriteFile(tmpFile, []byte("file-content"), 0644); err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+
+		specs, err := ParseEnvVarSpecs([]string{"VAR=@" + tmpFile}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 1 {
+			t.Fatalf("expected 1 spec, got %d", len(specs))
+		}
+		if specs[0].Key != "VAR" || specs[0].Value != "file-content" {
+			t.Errorf("unexpected spec: %+v", specs[0])
+		}
+		if !specs[0].FromFile {
+			t.Error("expected FromFile to be true")
+		}
+	})
+
+	t.Run("returns error for nonexistent file", func(t *testing.T) {
+		_, err := ParseEnvVarSpecs([]string{"VAR=@/nonexistent/file.txt"}, nil)
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+	})
+
+	t.Run("returns error for empty key", func(t *testing.T) {
+		_, err := ParseEnvVarSpecs([]string{"=value"}, nil)
+		if err == nil {
+			t.Fatal("expected error for empty key")
+		}
+	})
+
+	t.Run("handles value with equals sign", func(t *testing.T) {
+		specs, err := ParseEnvVarSpecs([]string{"URL=http://example.com?a=1&b=2"}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 1 {
+			t.Fatalf("expected 1 spec, got %d", len(specs))
+		}
+		if specs[0].Key != "URL" || specs[0].Value != "http://example.com?a=1&b=2" {
+			t.Errorf("unexpected spec: %+v", specs[0])
+		}
+	})
+
+	t.Run("handles empty value", func(t *testing.T) {
+		specs, err := ParseEnvVarSpecs([]string{"EMPTY="}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 1 {
+			t.Fatalf("expected 1 spec, got %d", len(specs))
+		}
+		if specs[0].Key != "EMPTY" || specs[0].Value != "" {
+			t.Errorf("unexpected spec: %+v", specs[0])
+		}
+	})
+}

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -251,6 +251,10 @@ type ConfigInputs struct {
 
 	// ExistingConfig is the current config to preserve manual env vars from
 	ExistingConfig core_v1alpha.Config
+
+	// CliEnvVars are environment variables passed via CLI flags (e.g., miren deploy -e KEY=VALUE)
+	// These are applied with source="manual" and take precedence over app.toml vars
+	CliEnvVars []*build_v1alpha.EnvironmentVariable
 }
 
 // buildVersionConfig builds the app version config from all inputs.
@@ -343,6 +347,9 @@ func buildVersionConfig(inputs ConfigInputs) core_v1alpha.Config {
 	// Preserves existing variables when app.toml has no [[env]] section
 	cfg.Variable = mergeVariablesFromAppConfig(cfg.Variable, ac)
 
+	// Apply CLI-provided env vars last (highest precedence, always source="manual")
+	cfg.Variable = mergeCliEnvVars(cfg.Variable, inputs.CliEnvVars)
+
 	return cfg
 }
 
@@ -404,6 +411,38 @@ func mergeVariablesFromAppConfig(existingVars []core_v1alpha.Variable, appConfig
 	for key, v := range appConfigMap {
 		if _, hasManual := varMap[key]; !hasManual {
 			varMap[key] = v
+		}
+	}
+
+	// Convert map back to slice
+	result := make([]core_v1alpha.Variable, 0, len(varMap))
+	for _, v := range varMap {
+		result = append(result, v)
+	}
+
+	return result
+}
+
+// mergeCliEnvVars merges CLI-provided environment variables into the existing config.
+// CLI vars are always marked with source="manual" and override any existing var with the same key.
+func mergeCliEnvVars(existingVars []core_v1alpha.Variable, cliVars []*build_v1alpha.EnvironmentVariable) []core_v1alpha.Variable {
+	if len(cliVars) == 0 {
+		return existingVars
+	}
+
+	// Build a map of existing vars
+	varMap := make(map[string]core_v1alpha.Variable)
+	for _, v := range existingVars {
+		varMap[v.Key] = v
+	}
+
+	// CLI vars always override (marked as manual)
+	for _, cv := range cliVars {
+		varMap[cv.Key()] = core_v1alpha.Variable{
+			Key:       cv.Key(),
+			Value:     cv.Value(),
+			Sensitive: cv.Sensitive(),
+			Source:    "manual",
 		}
 	}
 
@@ -718,7 +757,12 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		AppConfig:        ac,
 		ProcfileServices: procfileServices,
 		ExistingConfig:   mrv.Config,
+		CliEnvVars:       args.EnvVars(),
 	})
+
+	if len(args.EnvVars()) > 0 {
+		b.Log.Info("applied CLI env vars", "count", len(args.EnvVars()))
+	}
 
 	if ac != nil && len(ac.EnvVars) > 0 {
 		b.Log.Info("merged env vars from app config", "count", len(ac.EnvVars))

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/appconfig"
 )
@@ -1293,6 +1294,126 @@ func TestExtractWorkingDirFromImageConfig(t *testing.T) {
 			err := json.Unmarshal([]byte(tt.configJSON), &imgConfig)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantDir, imgConfig.Config.WorkingDir)
+		})
+	}
+}
+
+// Helper to create a build_v1alpha.EnvironmentVariable for testing
+func makeEnvVar(key, value string, sensitive bool) *build_v1alpha.EnvironmentVariable {
+	ev := &build_v1alpha.EnvironmentVariable{}
+	ev.SetKey(key)
+	ev.SetValue(value)
+	ev.SetSensitive(sensitive)
+	return ev
+}
+
+func TestMergeCliEnvVars(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingVars  []core_v1alpha.Variable
+		cliVars       []*build_v1alpha.EnvironmentVariable
+		wantVariables []core_v1alpha.Variable
+	}{
+		{
+			name:          "empty CLI vars returns existing unchanged",
+			existingVars:  []core_v1alpha.Variable{{Key: "FOO", Value: "bar", Source: "config"}},
+			cliVars:       nil,
+			wantVariables: []core_v1alpha.Variable{{Key: "FOO", Value: "bar", Source: "config"}},
+		},
+		{
+			name:         "CLI vars added to empty existing",
+			existingVars: nil,
+			cliVars: []*build_v1alpha.EnvironmentVariable{
+				makeEnvVar("FOO", "bar", false),
+			},
+			wantVariables: []core_v1alpha.Variable{
+				{Key: "FOO", Value: "bar", Sensitive: false, Source: "manual"},
+			},
+		},
+		{
+			name: "CLI vars override existing config vars",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "FOO", Value: "old", Source: "config"},
+			},
+			cliVars: []*build_v1alpha.EnvironmentVariable{
+				makeEnvVar("FOO", "new", false),
+			},
+			wantVariables: []core_v1alpha.Variable{
+				{Key: "FOO", Value: "new", Sensitive: false, Source: "manual"},
+			},
+		},
+		{
+			name: "CLI vars override existing manual vars",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "FOO", Value: "old-manual", Source: "manual"},
+			},
+			cliVars: []*build_v1alpha.EnvironmentVariable{
+				makeEnvVar("FOO", "new-manual", false),
+			},
+			wantVariables: []core_v1alpha.Variable{
+				{Key: "FOO", Value: "new-manual", Sensitive: false, Source: "manual"},
+			},
+		},
+		{
+			name: "CLI vars merge with existing - different keys",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "EXISTING", Value: "value", Source: "config"},
+			},
+			cliVars: []*build_v1alpha.EnvironmentVariable{
+				makeEnvVar("NEW", "cli-value", false),
+			},
+			wantVariables: []core_v1alpha.Variable{
+				{Key: "EXISTING", Value: "value", Source: "config"},
+				{Key: "NEW", Value: "cli-value", Sensitive: false, Source: "manual"},
+			},
+		},
+		{
+			name: "sensitive flag preserved from CLI",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "SECRET", Value: "old", Sensitive: false, Source: "config"},
+			},
+			cliVars: []*build_v1alpha.EnvironmentVariable{
+				makeEnvVar("SECRET", "new-secret", true),
+			},
+			wantVariables: []core_v1alpha.Variable{
+				{Key: "SECRET", Value: "new-secret", Sensitive: true, Source: "manual"},
+			},
+		},
+		{
+			name:         "multiple CLI vars",
+			existingVars: nil,
+			cliVars: []*build_v1alpha.EnvironmentVariable{
+				makeEnvVar("FOO", "foo-val", false),
+				makeEnvVar("BAR", "bar-val", false),
+				makeEnvVar("SECRET", "secret-val", true),
+			},
+			wantVariables: []core_v1alpha.Variable{
+				{Key: "FOO", Value: "foo-val", Sensitive: false, Source: "manual"},
+				{Key: "BAR", Value: "bar-val", Sensitive: false, Source: "manual"},
+				{Key: "SECRET", Value: "secret-val", Sensitive: true, Source: "manual"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeCliEnvVars(tt.existingVars, tt.cliVars)
+
+			// Sort both for comparison since map iteration is non-deterministic
+			sort.Slice(result, func(i, j int) bool {
+				return result[i].Key < result[j].Key
+			})
+			sort.Slice(tt.wantVariables, func(i, j int) bool {
+				return tt.wantVariables[i].Key < tt.wantVariables[j].Key
+			})
+
+			require.Len(t, result, len(tt.wantVariables))
+			for i, want := range tt.wantVariables {
+				assert.Equal(t, want.Key, result[i].Key, "key mismatch at index %d", i)
+				assert.Equal(t, want.Value, result[i].Value, "value mismatch at index %d", i)
+				assert.Equal(t, want.Sensitive, result[i].Sensitive, "sensitive mismatch at index %d", i)
+				assert.Equal(t, want.Source, result[i].Source, "source mismatch at index %d", i)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Add `-e` and `-s` flags to `miren deploy` for setting environment variables atomically with the deploy. This ensures env vars are available to the very first sandbox, solving ordering issues where apps need env vars present at initial startup.

**Example use case:** Grafana's `GF_SECURITY_ADMIN_PASSWORD` must be set before the first DB creation - setting it after deploy is too late.

## Syntax

```bash
miren deploy -e KEY=VALUE        # Regular env var
miren deploy -s SECRET=value     # Sensitive (masked in output)
miren deploy -e KEY=@file        # Read value from file
miren deploy -e KEY              # Prompt interactively

# Multiple vars
miren deploy -e FOO=bar -e BAZ=qux -s API_KEY=secret
```

## Implementation

- Extends `buildFromTar` RPC to accept `envVars` parameter
- Adds `mergeCliEnvVars()` helper that applies CLI vars with `source="manual"`
- CLI vars merged last in `buildVersionConfig()` (highest precedence)
- Creates single atomic `AppVersion` with merged config (no intermediate versions)

**Merge order:**
1. Existing config from previous version
2. app.toml vars (`source="config"`)
3. CLI vars (`source="manual"`) - always wins

## Test plan

- [x] Unit tests for `ParseEnvVarSpecs()` (KEY=VALUE, KEY=@file, errors)
- [x] Unit tests for `mergeCliEnvVars()` (override, merge, sensitive flag)
- [x] Manual test: `miren deploy -e FOO=bar` sets env var on first sandbox
- [x] Manual test: `miren deploy -s SECRET=x` masks value in output
- [x] Manual test: env vars persist across redeploys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables can now be passed during deployments.
  * Sensitive environment variables are supported for secure handling.
  * CLI-provided environment variables override existing configuration settings.

* **Tests**
  * Added tests for environment variable parsing and merging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->