### PR TITLE
Poll the deployment status for manual cancellation

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -240,45 +240,18 @@ func Deploy(ctx *Context, opts struct {
 	buildCtx, cancelBuild := context.WithCancel(ctx.Context)
 	defer cancelBuild()
 
-	// Track if we were cancelled externally (vs user pressing CTRL-C)
-	var externallyCancelled bool
-	var cancelMu sync.Mutex
-
-	// Start goroutine to poll for external cancellation
+	// Start goroutine to poll for external cancellation using the cancellationPoller
+	statusGetter := newDepClientStatusGetter(depClient, ctx.Log)
+	poller := newCancellationPoller(deploymentId, statusGetter, 2*time.Second)
 	go func() {
-		ticker := time.NewTicker(2 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-buildCtx.Done():
-				return
-			case <-ticker.C:
-				// Use a fresh context for polling to avoid issues with cancelled parent
-				pollCtx, pollCancel := context.WithTimeout(context.Background(), 5*time.Second)
-				result, err := depClient.GetDeploymentById(pollCtx, deploymentId)
-				pollCancel()
-				if err != nil {
-					ctx.Log.Debug("Failed to poll deployment status", "error", err)
-					continue
-				}
-				if result.HasDeployment() && result.Deployment().Status() == "cancelled" {
-					cancelMu.Lock()
-					externallyCancelled = true
-					cancelMu.Unlock()
-					ctx.Log.Info("Deployment cancelled externally, stopping build")
-					cancelBuild()
-					return
-				}
-			}
-		}
+		poller.Start(buildCtx, func() {
+			ctx.Log.Info("Deployment cancelled externally, stopping build")
+			cancelBuild()
+		})
 	}()
 
 	// Helper to check if we were externally cancelled
-	wasExternallyCancelled := func() bool {
-		cancelMu.Lock()
-		defer cancelMu.Unlock()
-		return externallyCancelled
-	}
+	wasExternallyCancelled := poller.WasExternallyCancelled
 
 	// Parse environment variables to pass to build server
 	var envVars []*build_v1alpha.EnvironmentVariable
@@ -550,6 +523,9 @@ func Deploy(ctx *Context, opts struct {
 				}
 				if deployCtx.Err() != nil {
 					return deployCtx.Err()
+				}
+				if buildCtx.Err() != nil {
+					return buildCtx.Err()
 				}
 				return context.Canceled
 			}

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -236,6 +236,50 @@ func Deploy(ctx *Context, opts struct {
 	deploymentId := createResult.Deployment().Id()
 	ctx.Log.Info("Created deployment record", "deployment_id", deploymentId)
 
+	// Create a cancellable context for the build that can be cancelled externally
+	buildCtx, cancelBuild := context.WithCancel(ctx.Context)
+	defer cancelBuild()
+
+	// Track if we were cancelled externally (vs user pressing CTRL-C)
+	var externallyCancelled bool
+	var cancelMu sync.Mutex
+
+	// Start goroutine to poll for external cancellation
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-buildCtx.Done():
+				return
+			case <-ticker.C:
+				// Use a fresh context for polling to avoid issues with cancelled parent
+				pollCtx, pollCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				result, err := depClient.GetDeploymentById(pollCtx, deploymentId)
+				pollCancel()
+				if err != nil {
+					ctx.Log.Debug("Failed to poll deployment status", "error", err)
+					continue
+				}
+				if result.HasDeployment() && result.Deployment().Status() == "cancelled" {
+					cancelMu.Lock()
+					externallyCancelled = true
+					cancelMu.Unlock()
+					ctx.Log.Info("Deployment cancelled externally, stopping build")
+					cancelBuild()
+					return
+				}
+			}
+		}
+	}()
+
+	// Helper to check if we were externally cancelled
+	wasExternallyCancelled := func() bool {
+		cancelMu.Lock()
+		defer cancelMu.Unlock()
+		return externallyCancelled
+	}
+
 	// Parse environment variables to pass to build server
 	var envVars []*build_v1alpha.EnvironmentVariable
 	if len(opts.Env) > 0 || len(opts.Sensitive) > 0 {
@@ -373,23 +417,26 @@ func Deploy(ctx *Context, opts struct {
 			}
 
 			select {
-			case <-ctx.Done():
-				return ctx.Err()
+			case <-buildCtx.Done():
+				return buildCtx.Err()
 			case pw.Status() <- status:
 				// ok
 			}
 			return nil
 		}
 
-		cb = createBuildStatusCallback(ctx, nil, nil, nil, &buildErrors, nil, progressHandler)
+		cb = createBuildStatusCallback(buildCtx, nil, nil, nil, &buildErrors, nil, progressHandler)
 
-		results, err = bc.BuildFromTar(ctx, name, stream.ServeReader(ctx, r), cb, envVars)
+		results, err = bc.BuildFromTar(buildCtx, name, stream.ServeReader(buildCtx, r), cb, envVars)
 		if err != nil {
-			// Check if this was a context cancellation (user pressed CTRL-C)
-			if ctx.Err() != nil {
+			// Check if this was a context cancellation
+			if buildCtx.Err() != nil {
 				ctx.Printf("\n\n❌ Deploy cancelled.\n")
-				updateDeploymentOnError("Deploy cancelled by user")
-				return ctx.Err()
+				// Don't update deployment status - it's already cancelled
+				if !wasExternallyCancelled() {
+					updateDeploymentOnError("Deploy cancelled by user")
+				}
+				return buildCtx.Err()
 			}
 
 			// Check if this was a server panic
@@ -433,8 +480,8 @@ func Deploy(ctx *Context, opts struct {
 		})
 		r = progressReader
 
-		// Create a context that can be cancelled
-		deployCtx, cancelDeploy := context.WithCancel(ctx)
+		// Create a context that can be cancelled by UI (child of buildCtx for external cancellation)
+		deployCtx, cancelDeploy := context.WithCancel(buildCtx)
 		defer cancelDeploy()
 
 		model := initialModel(updateCh, transferCh, uploadProgressCh)
@@ -495,13 +542,16 @@ func Deploy(ctx *Context, opts struct {
 		if err != nil {
 			// Check if this was a user interruption (via UI flag or context cancellation)
 			dm, isDeploy := finalModel.(*deployInfo)
-			if (isDeploy && dm.interrupted) || ctx.Err() != nil {
+			if (isDeploy && dm.interrupted) || deployCtx.Err() != nil {
 				ctx.Printf("\n\n❌ Deploy cancelled.\n")
-				updateDeploymentOnError("Deploy cancelled by user")
+				// Don't update deployment status if externally cancelled - it's already cancelled
+				if !wasExternallyCancelled() {
+					updateDeploymentOnError("Deploy cancelled by user")
+				}
 				if deployCtx.Err() != nil {
 					return deployCtx.Err()
 				}
-				return ctx.Err()
+				return context.Canceled
 			}
 
 			// Check if this was a buildkit startup timeout (handled by UI)

--- a/cli/commands/deploy_cancel_test.go
+++ b/cli/commands/deploy_cancel_test.go
@@ -1,0 +1,211 @@
+package commands
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockStatusGetter is a test mock for deploymentStatusGetter
+type mockStatusGetter struct {
+	mu        sync.Mutex
+	statuses  []string // sequence of statuses to return
+	callCount int
+	errors    []error // sequence of errors to return (nil for success)
+}
+
+func (m *mockStatusGetter) GetStatus(ctx context.Context, deploymentId string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	idx := m.callCount
+	m.callCount++
+
+	if idx < len(m.errors) && m.errors[idx] != nil {
+		return "", m.errors[idx]
+	}
+
+	if idx < len(m.statuses) {
+		return m.statuses[idx], nil
+	}
+
+	// Default: return in_progress if no more statuses specified
+	return "in_progress", nil
+}
+
+func (m *mockStatusGetter) CallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
+}
+
+func TestCancellationPoller_DetectsCancellation(t *testing.T) {
+	mock := &mockStatusGetter{
+		statuses: []string{"in_progress", "in_progress", "cancelled"},
+	}
+
+	poller := newCancellationPoller("test-deployment", mock, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var cancelCalled atomic.Bool
+
+	done := make(chan struct{})
+	go func() {
+		poller.Start(ctx, func() {
+			cancelCalled.Store(true)
+		})
+		close(done)
+	}()
+
+	// Wait for poller to finish
+	select {
+	case <-done:
+		// Expected
+	case <-time.After(time.Second):
+		t.Fatal("poller did not stop after detecting cancellation")
+	}
+
+	if !poller.WasExternallyCancelled() {
+		t.Error("expected WasExternallyCancelled to be true")
+	}
+
+	if !cancelCalled.Load() {
+		t.Error("expected cancel function to be called")
+	}
+
+	if mock.CallCount() != 3 {
+		t.Errorf("expected 3 calls, got %d", mock.CallCount())
+	}
+}
+
+func TestCancellationPoller_StopsOnContextCancel(t *testing.T) {
+	mock := &mockStatusGetter{
+		// Never returns cancelled - poller should stop via context
+		statuses: []string{"in_progress", "in_progress", "in_progress", "in_progress", "in_progress"},
+	}
+
+	poller := newCancellationPoller("test-deployment", mock, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var cancelCalled atomic.Bool
+
+	done := make(chan struct{})
+	go func() {
+		poller.Start(ctx, func() {
+			cancelCalled.Store(true)
+		})
+		close(done)
+	}()
+
+	// Let it poll a few times
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel the context
+	cancel()
+
+	// Wait for poller to finish
+	select {
+	case <-done:
+		// Expected
+	case <-time.After(time.Second):
+		t.Fatal("poller did not stop after context cancellation")
+	}
+
+	if poller.WasExternallyCancelled() {
+		t.Error("expected WasExternallyCancelled to be false")
+	}
+
+	if cancelCalled.Load() {
+		t.Error("expected cancel function NOT to be called on context cancel")
+	}
+}
+
+func TestCancellationPoller_ContinuesOnError(t *testing.T) {
+	testErr := context.DeadlineExceeded
+
+	mock := &mockStatusGetter{
+		statuses: []string{"in_progress", "", "cancelled"},
+		errors:   []error{nil, testErr, nil},
+	}
+
+	poller := newCancellationPoller("test-deployment", mock, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var cancelCalled atomic.Bool
+
+	done := make(chan struct{})
+	go func() {
+		poller.Start(ctx, func() {
+			cancelCalled.Store(true)
+		})
+		close(done)
+	}()
+
+	// Wait for poller to finish
+	select {
+	case <-done:
+		// Expected
+	case <-time.After(time.Second):
+		t.Fatal("poller did not stop after detecting cancellation")
+	}
+
+	if !poller.WasExternallyCancelled() {
+		t.Error("expected WasExternallyCancelled to be true")
+	}
+
+	if !cancelCalled.Load() {
+		t.Error("expected cancel function to be called")
+	}
+
+	if mock.CallCount() != 3 {
+		t.Errorf("expected 3 calls (including error), got %d", mock.CallCount())
+	}
+}
+
+func TestCancellationPoller_ImmediateCancellation(t *testing.T) {
+	mock := &mockStatusGetter{
+		statuses: []string{"cancelled"},
+	}
+
+	poller := newCancellationPoller("test-deployment", mock, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var cancelCalled atomic.Bool
+
+	done := make(chan struct{})
+	go func() {
+		poller.Start(ctx, func() {
+			cancelCalled.Store(true)
+		})
+		close(done)
+	}()
+
+	// Wait for poller to finish
+	select {
+	case <-done:
+		// Expected
+	case <-time.After(time.Second):
+		t.Fatal("poller did not stop after detecting cancellation")
+	}
+
+	if !poller.WasExternallyCancelled() {
+		t.Error("expected WasExternallyCancelled to be true")
+	}
+
+	if !cancelCalled.Load() {
+		t.Error("expected cancel function to be called")
+	}
+
+	if mock.CallCount() != 1 {
+		t.Errorf("expected 1 call, got %d", mock.CallCount())
+	}
+}

--- a/cli/commands/deploy_poller.go
+++ b/cli/commands/deploy_poller.go
@@ -1,0 +1,97 @@
+package commands
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"miren.dev/runtime/api/deployment/deployment_v1alpha"
+)
+
+// deploymentStatusGetter is an interface for getting deployment status
+// This allows mocking the deployment client in tests
+type deploymentStatusGetter interface {
+	GetStatus(ctx context.Context, deploymentId string) (string, error)
+}
+
+// cancellationPoller polls for deployment cancellation
+type cancellationPoller struct {
+	deploymentId string
+	getter       deploymentStatusGetter
+	pollInterval time.Duration
+
+	mu                  sync.Mutex
+	externallyCancelled bool
+}
+
+func newCancellationPoller(deploymentId string, getter deploymentStatusGetter, pollInterval time.Duration) *cancellationPoller {
+	return &cancellationPoller{
+		deploymentId: deploymentId,
+		getter:       getter,
+		pollInterval: pollInterval,
+	}
+}
+
+// Start begins polling for cancellation. It returns when ctx is done or cancellation is detected.
+// When cancellation is detected, it calls cancelFunc.
+func (p *cancellationPoller) Start(ctx context.Context, cancelFunc func()) {
+	ticker := time.NewTicker(p.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Use a fresh context for polling to avoid issues with cancelled parent
+			pollCtx, pollCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			status, err := p.getter.GetStatus(pollCtx, p.deploymentId)
+			pollCancel()
+			if err != nil {
+				continue
+			}
+			if status == "cancelled" {
+				p.mu.Lock()
+				p.externallyCancelled = true
+				p.mu.Unlock()
+				cancelFunc()
+				return
+			}
+		}
+	}
+}
+
+// WasExternallyCancelled returns true if cancellation was detected
+func (p *cancellationPoller) WasExternallyCancelled() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.externallyCancelled
+}
+
+// logger is an interface for logging (allows mocking in tests)
+type logger interface {
+	Debug(msg string, args ...any)
+}
+
+// depClientStatusGetter wraps a deployment client to implement deploymentStatusGetter
+type depClientStatusGetter struct {
+	client *deployment_v1alpha.DeploymentClient
+	log    logger
+}
+
+func newDepClientStatusGetter(client *deployment_v1alpha.DeploymentClient, log logger) *depClientStatusGetter {
+	return &depClientStatusGetter{client: client, log: log}
+}
+
+func (d *depClientStatusGetter) GetStatus(ctx context.Context, deploymentId string) (string, error) {
+	result, err := d.client.GetDeploymentById(ctx, deploymentId)
+	if err != nil {
+		if d.log != nil {
+			d.log.Debug("Failed to poll deployment status", "error", err)
+		}
+		return "", err
+	}
+	if result.HasDeployment() && result.Deployment() != nil {
+		return result.Deployment().Status(), nil
+	}
+	return "", nil
+}


### PR DESCRIPTION
### Teresa's Notes

I think the proper way to do this would be to move deployments to a server-side managed entity and have the build server watch the deployment entity and abort the build if it detects the `status = cancelled`

However, the above change is a larger architectural change that i will do in a separate PR. For now, we'll poll the deployment status every 2 seconds and kill the deployment when the status changes.

The polling solution is temporary until it can be replaced by the larger architectural change described above. 

--------------------------------------------
This fixes [MIR-608](https://linear.app/miren/issue/MIR-608/manually-cancelling-a-deployment-should-kill-the-build-process)


### Summary

  - Added deployment cancellation polling in cancellationPoller component
  - Add unit tests for the polling logic (4 test cases)
  - Refactor deploy.go to use the extracted component

  Test plan

  - make lint passes
  - Manual test: run miren deploy, then miren deploy cancel in another terminal - verify deploy exits with "Deploy cancelled" message


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External cancellation support in the deploy flow with background monitoring and propagation through build and deploy phases.
  * Deployment status handling updated to avoid redundant or misleading status updates when cancellation is external.
  * App config include-pattern validation with invalid-pattern reporting during deploy.

* **Tests**
  * Added comprehensive tests for cancellation polling covering detection, errors, immediate cancellation, and context-cancel scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->