### PR TITLE
Add self-signed TLS option for dev environment

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -793,6 +793,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 			// Use self-signed certificate (for development/testing)
 			if err := autotls.ServeTLSSelfSigned(sub, ctx.Log, hs); err != nil {
 				ctx.Log.Error("failed to enable self-signed TLS", "error", err)
+				return err
 			}
 		} else {
 			email := cfg.TLS.GetAcmeEmail()

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -789,21 +789,28 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	}()
 
 	if cfg.TLS.GetStandardTLS() {
-		email := cfg.TLS.GetAcmeEmail()
-		dnsProvider := cfg.TLS.GetAcmeDNSProvider()
-		if dnsProvider != "" {
-			// Use DNS challenge via certificate controller
-			certProvider := co.CertificateProvider()
-			if certProvider == nil {
-				return fmt.Errorf("DNS provider configured (%s) but certificate controller failed to initialize", dnsProvider)
-			}
-			if err := autotls.ServeTLSWithController(sub, ctx.Log, certProvider, hs); err != nil {
-				ctx.Log.Error("failed to enable standard TLS with DNS challenge", "error", err)
+		if cfg.TLS.GetSelfSigned() {
+			// Use self-signed certificate (for development/testing)
+			if err := autotls.ServeTLSSelfSigned(sub, ctx.Log, hs); err != nil {
+				ctx.Log.Error("failed to enable self-signed TLS", "error", err)
 			}
 		} else {
-			// Use HTTP challenge (default - autocert)
-			if err := autotls.ServeTLS(sub, ctx.Log, cfg.Server.GetDataPath(), email, hs); err != nil {
-				ctx.Log.Error("failed to enable standard TLS", "error", err)
+			email := cfg.TLS.GetAcmeEmail()
+			dnsProvider := cfg.TLS.GetAcmeDNSProvider()
+			if dnsProvider != "" {
+				// Use DNS challenge via certificate controller
+				certProvider := co.CertificateProvider()
+				if certProvider == nil {
+					return fmt.Errorf("DNS provider configured (%s) but certificate controller failed to initialize", dnsProvider)
+				}
+				if err := autotls.ServeTLSWithController(sub, ctx.Log, certProvider, hs); err != nil {
+					ctx.Log.Error("failed to enable standard TLS with DNS challenge", "error", err)
+				}
+			} else {
+				// Use HTTP challenge (default - autocert)
+				if err := autotls.ServeTLS(sub, ctx.Log, cfg.Server.GetDataPath(), email, hs); err != nil {
+					ctx.Log.Error("failed to enable standard TLS", "error", err)
+				}
 			}
 		}
 	} else {

--- a/components/autotls/autotls.go
+++ b/components/autotls/autotls.go
@@ -146,5 +146,3 @@ func ServeTLSWithController(ctx context.Context, log *slog.Logger, certProvider 
 
 	return nil
 }
-
-// Removed old ServeTLSWithDNS and lego-specific code - now handled by certificate controller

--- a/components/autotls/selfsigned.go
+++ b/components/autotls/selfsigned.go
@@ -34,9 +34,10 @@ func ServeTLSSelfSigned(ctx context.Context, log *slog.Logger, h http.Handler) e
 	}
 
 	server := &http.Server{
-		Addr:      ":443",
-		Handler:   h,
-		TLSConfig: tlsConfig,
+		Addr:              ":443",
+		Handler:           h,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	go func() {
@@ -107,7 +108,7 @@ func generateSelfSignedCert() (tls.Certificate, error) {
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(365 * 24 * time.Hour), // valid for 1 year
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},

--- a/components/autotls/selfsigned.go
+++ b/components/autotls/selfsigned.go
@@ -1,0 +1,143 @@
+package autotls
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"math"
+	"math/big"
+	"net"
+	"net/http"
+	"time"
+)
+
+// ServeTLSSelfSigned serves HTTPS using a self-signed certificate.
+// This is intended for development and testing only.
+func ServeTLSSelfSigned(ctx context.Context, log *slog.Logger, h http.Handler) error {
+	log = log.With("module", "autotls", "mode", "self-signed")
+	log.Info("serving TLS with self-signed certificate (dev mode)")
+
+	cert, err := generateSelfSignedCert()
+	if err != nil {
+		return fmt.Errorf("failed to generate self-signed certificate: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	server := &http.Server{
+		Addr:      ":443",
+		Handler:   h,
+		TLSConfig: tlsConfig,
+	}
+
+	go func() {
+		log.Info("starting HTTPS server with self-signed cert", "addr", ":443")
+		err := server.ListenAndServeTLS("", "")
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("error serving HTTPS", "error", err)
+		}
+	}()
+
+	// Also start HTTP server on port 80 that redirects to HTTPS
+	httpServer := &http.Server{
+		Addr: ":80",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			host := r.Host
+			if hostWithoutPort, _, err := net.SplitHostPort(host); err == nil {
+				host = hostWithoutPort
+			}
+			target := "https://" + host + r.URL.RequestURI()
+			http.Redirect(w, r, target, http.StatusFound)
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		log.Info("starting HTTP server for HTTPS redirect", "addr", ":80")
+		err := httpServer.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("error serving HTTP", "error", err)
+		}
+	}()
+
+	// Monitor for context cancellation
+	go func() {
+		<-ctx.Done()
+		log.Info("shutting down HTTPS and HTTP servers")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Error("HTTPS server shutdown error", "error", err)
+		}
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			log.Error("HTTP server shutdown error", "error", err)
+		}
+		log.Info("HTTPS and HTTP servers shutdown complete")
+	}()
+
+	return nil
+}
+
+// generateSelfSignedCert creates an in-memory self-signed certificate
+func generateSelfSignedCert() (tls.Certificate, error) {
+	pubkey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	certTemplate := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Miren Dev"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour), // valid for 1 year
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
+		DNSNames:              []string{"localhost"},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, pubkey, privateKey)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	pkbytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: pkbytes,
+	})
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, privateKeyPEM)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to create x509 key pair: %w", err)
+	}
+
+	return tlsCert, nil
+}

--- a/hack/dev-server
+++ b/hack/dev-server
@@ -10,6 +10,9 @@ LOGFILE="/tmp/miren-server.log"
 ENV_FILE="${DEV_ENV_FILE:-}"
 EXTRA_FLAGS="${DEV_SERVER_FLAGS:-}"
 
+# Dev environment defaults: use self-signed TLS (ACME/autocert doesn't work with localhost)
+DEFAULT_FLAGS="--self-signed-tls"
+
 case "${1:-}" in
   start)
     if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
@@ -33,7 +36,7 @@ case "${1:-}" in
     echo "Starting miren server in standalone mode..."
     # Use nohup and disown to fully detach from the shell
     # (Script runs as root for process management privileges)
-    nohup ./bin/miren server -vv --mode standalone $EXTRA_FLAGS >"$LOGFILE" 2>&1 </dev/null &
+    nohup ./bin/miren server -vv --mode standalone $DEFAULT_FLAGS $EXTRA_FLAGS >"$LOGFILE" 2>&1 </dev/null &
     pid=$!
     disown
     echo $pid > "$PIDFILE"

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -34,6 +34,7 @@ type CLIFlags struct {
 	TLSConfigAcmeEmail                   *string  `long:"acme-email" description:"Email address for ACME account registration (recommended for account recovery and notifications)"`
 	TLSConfigAdditionalIPs               []string `long:"ips" description:"Additional IPs assigned to the server cert"`
 	TLSConfigAdditionalNames             []string `long:"dns-names" description:"Additional DNS names assigned to the server cert"`
+	TLSConfigSelfSigned                  *bool    `long:"self-signed-tls" description:"Use self-signed certificates for TLS (for development/testing only)"`
 	TLSConfigStandardTLS                 *bool    `long:"serve-tls" description:"Expose the http ingress on standard TLS ports"`
 	VictoriaLogsConfigAddress            *string  `long:"victorialogs-addr" description:"VictoriaLogs address (when not using embedded)"`
 	VictoriaLogsConfigHTTPPort           *int     `long:"victorialogs-http-port" description:"VictoriaLogs HTTP port in embedded mode"`

--- a/pkg/serverconfig/config.gen.go
+++ b/pkg/serverconfig/config.gen.go
@@ -362,6 +362,7 @@ type TLSConfig struct {
 	AcmeEmail       *string  `toml:"acme_email" env:"MIREN_TLS_ACME_EMAIL"`
 	AdditionalIPs   []string `toml:"additional_ips" env:"MIREN_TLS_ADDITIONAL_IPS"`
 	AdditionalNames []string `toml:"additional_names" env:"MIREN_TLS_ADDITIONAL_NAMES"`
+	SelfSigned      *bool    `toml:"self_signed" env:"MIREN_TLS_SELF_SIGNED"`
 	StandardTLS     *bool    `toml:"standard_tls" env:"MIREN_TLS_STANDARD_TLS"`
 }
 
@@ -389,6 +390,19 @@ func (c *TLSConfig) GetAcmeEmail() string {
 // SetAcmeEmail sets the value of AcmeEmail
 func (c *TLSConfig) SetAcmeEmail(v string) {
 	c.AcmeEmail = &v
+}
+
+// GetSelfSigned returns the value of SelfSigned or its zero value if nil
+func (c *TLSConfig) GetSelfSigned() bool {
+	if c.SelfSigned != nil {
+		return *c.SelfSigned
+	}
+	return false
+}
+
+// SetSelfSigned sets the value of SelfSigned
+func (c *TLSConfig) SetSelfSigned(v bool) {
+	c.SelfSigned = &v
 }
 
 // GetStandardTLS returns the value of StandardTLS or its zero value if nil

--- a/pkg/serverconfig/defaults.gen.go
+++ b/pkg/serverconfig/defaults.gen.go
@@ -75,6 +75,7 @@ func DefaultTLSConfig() TLSConfig {
 		AcmeEmail:       strPtr(""),
 		AdditionalIPs:   []string{},
 		AdditionalNames: []string{},
+		SelfSigned:      boolPtr(false),
 		StandardTLS:     boolPtr(true),
 	}
 }

--- a/pkg/serverconfig/env.gen.go
+++ b/pkg/serverconfig/env.gen.go
@@ -317,6 +317,18 @@ func applyEnvironmentVariables(cfg *Config, log *slog.Logger) error {
 
 	}
 
+	// Apply MIREN_TLS_SELF_SIGNED
+	if val := os.Getenv("MIREN_TLS_SELF_SIGNED"); val != "" {
+
+		if b, err := strconv.ParseBool(val); err == nil {
+			cfg.TLS.SelfSigned = &b
+			log.Debug("applied env var", "key", "MIREN_TLS_SELF_SIGNED")
+		} else {
+			log.Warn("invalid MIREN_TLS_SELF_SIGNED value", "value", val, "error", err)
+		}
+
+	}
+
 	// Apply MIREN_TLS_STANDARD_TLS
 	if val := os.Getenv("MIREN_TLS_STANDARD_TLS"); val != "" {
 

--- a/pkg/serverconfig/loader.gen.go
+++ b/pkg/serverconfig/loader.gen.go
@@ -262,6 +262,10 @@ func applyCLIFlags(cfg *Config, flags *CLIFlags) {
 		cfg.TLS.AdditionalNames = flags.TLSConfigAdditionalNames
 	}
 
+	if flags.TLSConfigSelfSigned != nil {
+		cfg.TLS.SelfSigned = flags.TLSConfigSelfSigned
+	}
+
 	if flags.TLSConfigStandardTLS != nil {
 		cfg.TLS.StandardTLS = flags.TLSConfigStandardTLS
 	}

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -202,6 +202,15 @@ configs:
         env: MIREN_TLS_ACME_EMAIL
         toml: acme_email
 
+      self_signed:
+        type: bool
+        default: false
+        cli:
+          long: self-signed-tls
+          description: Use self-signed certificates for TLS (for development/testing only)
+        env: MIREN_TLS_SELF_SIGNED
+        toml: self_signed
+
   EtcdConfig:
     description: Etcd configuration
     fields:


### PR DESCRIPTION
## Summary

- Adds `--self-signed-tls` config option to use self-signed certificates instead of ACME/autocert
- Fixes TLS handshake errors in dev environment (autocert doesn't work with localhost)
- Enables self-signed TLS by default in `hack/dev-server`

## Changes

- `pkg/serverconfig/schema.yml` - Added `self_signed` field to TLSConfig
- `components/autotls/selfsigned.go` - New file with `ServeTLSSelfSigned()` function
- `cli/commands/server.go` - Check for self-signed mode before ACME
- `hack/dev-server` - Add `--self-signed-tls` as default flag

## Test plan

- [x] `make dev` and verify server starts without TLS errors
- [x] `curl -k https://localhost` works from inside dev container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-signed TLS mode for secure local HTTPS (one-year cert) and a new --self-signed-tls flag / MIREN_TLS_SELF_SIGNED env var.
  * Development server startup now enables self-signed TLS by default via dev settings.

* **Behavior Change**
  * TLS setup is now explicit: DNS-challenge TLS is used only when a DNS provider is configured; otherwise ACME/HTTP (autocert) is used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->