### PR TITLE
Fix nil pointer dereference in generated RPC accessors

### DIFF
--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -760,6 +760,9 @@ func (v *BuilderBuildFromTarArgs) HasEnvVars() bool {
 }
 
 func (v *BuilderBuildFromTarArgs) EnvVars() []*EnvironmentVariable {
+	if v.data.EnvVars == nil {
+		return nil
+	}
 	return *v.data.EnvVars
 }
 
@@ -1007,6 +1010,9 @@ func (v *BuilderClientBuildFromTarResults) HasAccessInfo() bool {
 }
 
 func (v *BuilderClientBuildFromTarResults) AccessInfo() *AccessInfo {
+	if v.data.AccessInfo == nil {
+		return nil
+	}
 	return *v.data.AccessInfo
 }
 
@@ -1046,6 +1052,9 @@ func (v *BuilderClientAnalyzeAppResults) HasResult() bool {
 }
 
 func (v *BuilderClientAnalyzeAppResults) Result() *AnalysisResult {
+	if v.data.Result == nil {
+		return nil
+	}
 	return *v.data.Result
 }
 

--- a/pkg/rpc/generator.go
+++ b/pkg/rpc/generator.go
@@ -617,11 +617,25 @@ func (g *Generator) readForField(f *j.File, t *DescType, field *DescField) {
 
 			f.Line()
 
-			f.Func().Params(
-				j.Id("v").Op("*").Add(recv),
-			).Id(fname).Params().Add(g.properType(field.Type)).Block(
-				j.Return(j.Op("*").Id("v").Dot("data").Dot(name)),
-			)
+			// Check if the type is nillable (slice or pointer) to determine if we can return nil
+			isNillable := strings.HasPrefix(field.Type, "[]") || strings.HasPrefix(field.Type, "*")
+
+			if isNillable {
+				f.Func().Params(
+					j.Id("v").Op("*").Add(recv),
+				).Id(fname).Params().Add(g.properType(field.Type)).Block(
+					j.If(j.Id("v").Dot("data").Dot(name).Op("==").Nil()).Block(
+						j.Return(j.Nil()),
+					),
+					j.Return(j.Op("*").Id("v").Dot("data").Dot(name)),
+				)
+			} else {
+				f.Func().Params(
+					j.Id("v").Op("*").Add(recv),
+				).Id(fname).Params().Add(g.properType(field.Type)).Block(
+					j.Return(j.Op("*").Id("v").Dot("data").Dot(name)),
+				)
+			}
 		}
 
 		f.Line()


### PR DESCRIPTION
## Summary

Remember when CodeRabbit flagged a nil pointer dereference in #521 and I said 
["Not worrying about this for now - callers can be safe by using HasEnvVars()"](https://github.com/mirendev/runtime/pull/521#discussion_r2670084040)?

Yeah, about that.

Turns out the caller *didn't* use `HasEnvVars()`, and the server panicked on any 
deploy without env vars explicitly set—wreaking havoc on one of our internal 
environments. The cheeky rabbit was right.

## The Bug

The RPC generator produces unsafe accessors for fields defined with raw Go type 
strings (e.g., `type: '[]*EnvironmentVariable'`). These accessors dereference 
pointers without nil checks, causing panics when the field isn't set.

## The Fix

Exactly what CodeRabbit suggested:

```go
func (v *BuilderBuildFromTarArgs) EnvVars() []*EnvironmentVariable {
    if v.data.EnvVars == nil {
        return nil
    }
    return *v.data.EnvVars
}
```

Now baked into the generator for all slice and pointer types.

## Lessons Learned

Listen to the robot.

## Test plan
- [x] `go build ./...` passes
- [x] `make lint` passes  
- [x] `make test`
- [ ] Deploy with `-e FOO=bar`, then deploy again without `-e` — no panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added nil-safety validation to public API accessor methods to improve stability and reliability.
  * Enhanced handling of optional fields to ensure consistent, predictable responses when accessing null or absent data values, reducing potential runtime errors in applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->