### PR TITLE
Add container exit monitoring and auto-restart for etcd and victorialogs

### DIFF
--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -54,9 +54,17 @@ type EtcdComponent struct {
 
 	mu         sync.Mutex
 	container  containerd.Container
+	task       containerd.Task
 	running    bool
 	clientPort int
 	peerPort   int
+
+	// For exit monitoring and restart
+	stopMonitor   chan struct{}
+	monitorDone   chan struct{}
+	config        EtcdConfig
+	restartCount  int
+	lastRestartAt time.Time
 }
 
 func NewEtcdComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *EtcdComponent {
@@ -94,8 +102,14 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	// Check if container already exists
 	existingContainer, err := e.CC.LoadContainer(ctx, etcdContainerName)
 	if err == nil {
-		e.Log.Info("found existing etcd container, restarting it", "container_id", existingContainer.ID())
-		return e.restartExistingContainer(ctx, existingContainer, config)
+		e.Log.Info("found existing etcd container, attempting restart", "container_id", existingContainer.ID())
+		err = e.restartExistingContainer(ctx, existingContainer, config)
+		if err == nil {
+			return nil
+		}
+		// If restart failed (e.g., port mismatch), try deleting the container and creating fresh
+		e.Log.Warn("restart of existing container failed, recreating", "error", err)
+		e.cleanupExistingContainer(ctx, existingContainer)
 	}
 
 	// Set defaults
@@ -147,37 +161,56 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 		return fmt.Errorf("failed to start etcd task: %w", err)
 	}
 
+	e.task = task
 	e.running = true
+	e.config = config
 	e.Log.Info("etcd server started", "container_id", container.ID(), "client_port", config.ClientPort)
 
-	// Wait for etcd to be ready
-	go e.waitForReady(ctx, "localhost", config.ClientPort)
+	// Wait for etcd to be ready before returning
+	if err := e.waitForReady(ctx, "localhost", config.ClientPort); err != nil {
+		e.Log.Warn("etcd readiness check failed, continuing anyway", "error", err)
+	}
+
+	// Start monitoring for unexpected exits
+	e.startExitMonitor(ctx)
 
 	return nil
 }
 
 func (e *EtcdComponent) Stop(ctx context.Context) error {
 	e.mu.Lock()
-	defer e.mu.Unlock()
 
 	if !e.running {
+		e.mu.Unlock()
 		return nil
 	}
 
+	// Stop the exit monitor first
+	if e.stopMonitor != nil {
+		close(e.stopMonitor)
+		e.stopMonitor = nil
+	}
+	monitorDone := e.monitorDone
+	e.mu.Unlock()
+
+	// Wait for monitor to finish (outside the lock)
+	if monitorDone != nil {
+		<-monitorDone
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	ctx = namespaces.WithNamespace(ctx, e.Namespace)
 
-	if e.container != nil {
-		// Stop and delete the task with timeout and graceful escalation
-		task, err := e.container.Task(ctx, nil)
-		if err == nil {
-			e.stopTask(ctx, task)
-		} else {
-			e.Log.Warn("failed to get etcd task for shutdown", "error", err)
-		}
+	if e.task != nil {
+		e.stopTask(ctx, e.task)
+		e.task = nil
+	}
 
+	if e.container != nil {
 		// Delete the container with retry logic
 		e.deleteContainerWithRetry(ctx)
-
 		e.container = nil
 	}
 
@@ -279,8 +312,22 @@ func (e *EtcdComponent) IsRunning() bool {
 	return e.running
 }
 
+func (e *EtcdComponent) cleanupExistingContainer(ctx context.Context, container containerd.Container) {
+	task, err := container.Task(ctx, nil)
+	if err == nil {
+		e.stopTask(ctx, task)
+	}
+
+	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if err := container.Delete(deleteCtx, containerd.WithSnapshotCleanup); err != nil {
+		e.Log.Warn("failed to delete existing container during cleanup", "error", err)
+	}
+}
+
 func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container containerd.Container, config EtcdConfig) error {
 	e.container = container
+	e.config = config
 
 	// Store ports for later use
 	e.clientPort = config.ClientPort
@@ -295,8 +342,12 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 			e.Log.Warn("failed to get task status", "error", err)
 		} else if status.Status == containerd.Running {
 			e.Log.Info("etcd container is already running")
+			e.task = task
 			e.running = true
-			go e.waitForReady(ctx, "localhost", config.ClientPort)
+			if err := e.waitForReady(ctx, "localhost", config.ClientPort); err != nil {
+				e.Log.Warn("etcd readiness check failed, continuing anyway", "error", err)
+			}
+			e.startExitMonitor(ctx)
 			return nil
 		}
 
@@ -304,9 +355,13 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 		e.Log.Info("starting existing etcd task")
 		err = task.Start(ctx)
 		if err == nil {
+			e.task = task
 			e.running = true
 			e.Log.Info("etcd server restarted", "container_id", container.ID(), "client_port", config.ClientPort)
-			go e.waitForReady(ctx, "localhost", config.ClientPort)
+			if err := e.waitForReady(ctx, "localhost", config.ClientPort); err != nil {
+				e.Log.Warn("etcd readiness check failed, continuing anyway", "error", err)
+			}
+			e.startExitMonitor(ctx)
 			return nil
 		}
 
@@ -329,11 +384,17 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 		return fmt.Errorf("failed to start new task for existing container: %w", err)
 	}
 
+	e.task = task
 	e.running = true
 	e.Log.Info("etcd server restarted with new task", "container_id", container.ID(), "client_port", config.ClientPort)
 
 	// Wait for etcd to be ready
-	go e.waitForReady(ctx, "localhost", config.ClientPort)
+	if err := e.waitForReady(ctx, "localhost", config.ClientPort); err != nil {
+		e.Log.Warn("etcd readiness check failed, continuing anyway", "error", err)
+	}
+
+	// Start monitoring for unexpected exits
+	e.startExitMonitor(ctx)
 
 	return nil
 }
@@ -393,7 +454,7 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 	return container, nil
 }
 
-func (e *EtcdComponent) waitForReady(ctx context.Context, host string, port int) {
+func (e *EtcdComponent) waitForReady(ctx context.Context, host string, port int) error {
 	endpoint := net.JoinHostPort(host, strconv.Itoa(port))
 
 	for i := 0; i < 30; i++ {
@@ -401,16 +462,143 @@ func (e *EtcdComponent) waitForReady(ctx context.Context, host string, port int)
 		if err == nil {
 			conn.Close()
 			e.Log.Info("etcd server is ready", "endpoint", endpoint)
-			return
+			return nil
 		}
 
 		select {
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		case <-time.After(1 * time.Second):
 			continue
 		}
 	}
 
 	e.Log.Warn("etcd server readiness check timed out", "endpoint", endpoint)
+	return fmt.Errorf("etcd readiness check timed out after 30 seconds")
+}
+
+func (e *EtcdComponent) startExitMonitor(ctx context.Context) {
+	e.stopMonitor = make(chan struct{})
+	e.monitorDone = make(chan struct{})
+
+	ctx = namespaces.WithNamespace(ctx, e.Namespace)
+
+	exitCh, err := e.task.Wait(ctx)
+	if err != nil {
+		e.Log.Error("failed to get exit channel for etcd task", "error", err)
+		close(e.monitorDone)
+		return
+	}
+
+	go e.monitorExit(ctx, exitCh)
+}
+
+func (e *EtcdComponent) monitorExit(ctx context.Context, exitCh <-chan containerd.ExitStatus) {
+	defer close(e.monitorDone)
+
+	for {
+		select {
+		case <-e.stopMonitor:
+			e.Log.Debug("etcd exit monitor stopped")
+			return
+
+		case exitStatus := <-exitCh:
+			e.Log.Warn("etcd process exited unexpectedly",
+				"exit_code", exitStatus.ExitCode(),
+				"exit_time", exitStatus.ExitTime(),
+			)
+
+			// Attempt restart
+			if err := e.handleRestart(ctx); err != nil {
+				e.Log.Error("failed to restart etcd", "error", err)
+				return
+			}
+
+			// Get new exit channel for the restarted task
+			e.mu.Lock()
+			if e.task == nil {
+				e.mu.Unlock()
+				return
+			}
+			newExitCh, err := e.task.Wait(ctx)
+			e.mu.Unlock()
+			if err != nil {
+				e.Log.Error("failed to get exit channel after restart", "error", err)
+				return
+			}
+			exitCh = newExitCh
+		}
+	}
+}
+
+func (e *EtcdComponent) handleRestart(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// Apply exponential backoff for restarts
+	const maxRestarts = 5
+	const backoffBase = 2 * time.Second
+	const backoffMax = 60 * time.Second
+	const resetWindow = 5 * time.Minute
+
+	// Reset restart count if enough time has passed
+	if time.Since(e.lastRestartAt) > resetWindow {
+		e.restartCount = 0
+	}
+
+	e.restartCount++
+	if e.restartCount > maxRestarts {
+		return fmt.Errorf("exceeded maximum restart attempts (%d)", maxRestarts)
+	}
+
+	// Calculate backoff
+	backoff := backoffBase * time.Duration(1<<(e.restartCount-1))
+	if backoff > backoffMax {
+		backoff = backoffMax
+	}
+
+	e.Log.Info("restarting etcd after backoff",
+		"restart_count", e.restartCount,
+		"backoff", backoff,
+	)
+
+	select {
+	case <-time.After(backoff):
+	case <-e.stopMonitor:
+		return fmt.Errorf("restart cancelled")
+	}
+
+	e.lastRestartAt = time.Now()
+
+	ctx = namespaces.WithNamespace(ctx, e.Namespace)
+
+	// Clean up old task
+	if e.task != nil {
+		deleteCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		e.task.Delete(deleteCtx)
+		cancel()
+		e.task = nil
+	}
+
+	// Create and start new task
+	task, err := e.container.NewTask(ctx, slogout.WithLogger(e.Log, "etcd",
+		slogout.WithJSONParsing(), slogout.WithMaxLevel(slog.LevelInfo)))
+	if err != nil {
+		return fmt.Errorf("failed to create new etcd task: %w", err)
+	}
+
+	if err := task.Start(ctx); err != nil {
+		task.Delete(ctx)
+		return fmt.Errorf("failed to start new etcd task: %w", err)
+	}
+
+	e.task = task
+
+	// Wait for etcd to be ready
+	if err := e.waitForReady(ctx, "localhost", e.config.ClientPort); err != nil {
+		e.Log.Warn("etcd readiness check failed after restart", "error", err)
+	}
+
+	e.Log.Info("etcd restarted successfully", "restart_count", e.restartCount)
+	return nil
 }

--- a/components/etcd/integration_test.go
+++ b/components/etcd/integration_test.go
@@ -219,6 +219,160 @@ func TestEtcdComponentIntegration(t *testing.T) {
 	t.Log("Restart test completed successfully!")
 }
 
+func TestEtcdComponentAutoRestart(t *testing.T) {
+	testDeps, cleanup := testutils.NewTestDeps()
+	defer cleanup()
+
+	cc := testDeps.CC
+
+	// Create temporary directory for test data
+	tmpDir, err := os.MkdirTemp("", "etcd-restart-test")
+	require.NoError(t, err, "failed to create temp dir")
+	defer os.RemoveAll(tmpDir)
+
+	// Create logger
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Use dynamic namespace to avoid conflicts with parallel tests
+	testNamespace := fmt.Sprintf("miren-etcd-restart-test-%d", time.Now().UnixNano())
+
+	// Create etcd component
+	component := etcd.NewEtcdComponent(log, cc, testNamespace, tmpDir)
+
+	// Use dynamic ports to avoid conflicts
+	clientPort := testutils.GetFreePort(t)
+	peerPort := testutils.GetFreePort(t)
+	httpClientPort := testutils.GetFreePort(t)
+
+	config := etcd.EtcdConfig{
+		Name:           "test-etcd-restart",
+		ClientPort:     clientPort,
+		HTTPClientPort: httpClientPort,
+		PeerPort:       peerPort,
+		InitialToken:   "restart-test-cluster",
+		ClusterState:   "new",
+	}
+
+	// Ensure cleanup
+	defer func() {
+		if component.IsRunning() {
+			err := component.Stop(context.Background())
+			if err != nil {
+				t.Logf("failed to stop component: %v", err)
+			}
+		}
+		cleanupContainer(t, cc, testNamespace)
+	}()
+
+	// Start the etcd component
+	t.Log("Starting etcd component...")
+	err = component.Start(context.Background(), config)
+	if err != nil {
+		if strings.Contains(err.Error(), "permission denied") {
+			t.Skip("permission denied error, skipping test")
+		}
+		require.NoError(t, err, "failed to start etcd component")
+	}
+
+	assert.True(t, component.IsRunning(), "component should report as running")
+
+	// Wait for etcd to be fully ready
+	endpoint := component.ClientEndpoint()
+	var etcdClient *clientv3.Client
+	require.Eventually(t, func() bool {
+		var err error
+		etcdClient, err = clientv3.New(clientv3.Config{
+			Endpoints:   []string{endpoint},
+			DialTimeout: 1 * time.Second,
+		})
+		if err != nil {
+			return false
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		_, err = etcdClient.Get(ctx, "health-check")
+		if err != nil {
+			etcdClient.Close()
+			etcdClient = nil
+			return false
+		}
+		return true
+	}, 30*time.Second, 500*time.Millisecond, "etcd failed to become ready")
+	etcdClient.Close()
+
+	t.Log("etcd is ready, now killing the task to simulate crash...")
+
+	// Kill the etcd task directly using containerd to simulate a crash
+	ctx := namespaces.WithNamespace(context.Background(), testNamespace)
+	containers, err := cc.Containers(ctx)
+	require.NoError(t, err, "failed to list containers")
+
+	var etcdContainer containerd.Container
+	for _, c := range containers {
+		if strings.Contains(c.ID(), "etcd") {
+			etcdContainer = c
+			break
+		}
+	}
+	require.NotNil(t, etcdContainer, "should find etcd container")
+
+	task, err := etcdContainer.Task(ctx, nil)
+	require.NoError(t, err, "should get task")
+
+	// Kill the task with SIGKILL to simulate crash
+	err = task.Kill(ctx, unix.SIGKILL)
+	require.NoError(t, err, "should be able to kill task")
+
+	t.Log("Task killed, waiting for auto-restart...")
+
+	// Wait for the component to auto-restart and become ready again
+	// The restart has a 2 second backoff for the first restart
+	require.Eventually(t, func() bool {
+		// Try to connect to etcd
+		client, err := clientv3.New(clientv3.Config{
+			Endpoints:   []string{endpoint},
+			DialTimeout: 1 * time.Second,
+		})
+		if err != nil {
+			return false
+		}
+		defer client.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		_, err = client.Get(ctx, "restart-health-check")
+		return err == nil
+	}, 30*time.Second, 1*time.Second, "etcd should auto-restart and become ready")
+
+	t.Log("etcd auto-restarted successfully!")
+
+	// Verify the component still reports as running
+	assert.True(t, component.IsRunning(), "component should still report as running after auto-restart")
+
+	// Test that we can still perform operations
+	etcdClient2, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{endpoint},
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err, "should be able to create client after restart")
+	defer etcdClient2.Close()
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+
+	_, err = etcdClient2.Put(ctx2, "post-restart-key", "post-restart-value")
+	require.NoError(t, err, "should be able to write after auto-restart")
+
+	resp, err := etcdClient2.Get(ctx2, "post-restart-key")
+	require.NoError(t, err, "should be able to read after auto-restart")
+	require.Len(t, resp.Kvs, 1, "should have one key")
+	assert.Equal(t, "post-restart-value", string(resp.Kvs[0].Value), "value should match")
+
+	t.Log("Auto-restart test completed successfully!")
+}
+
 func cleanupContainer(t *testing.T, cc *containerd.Client, namespace string) {
 	ctx := context.Background()
 	ctx = namespaces.WithNamespace(ctx, namespace)

--- a/components/victorialogs/victorialogs.go
+++ b/components/victorialogs/victorialogs.go
@@ -45,8 +45,16 @@ type VictoriaLogsComponent struct {
 
 	mu        sync.Mutex
 	container containerd.Container
+	task      containerd.Task
 	running   bool
 	httpPort  int
+
+	// For exit monitoring and restart
+	stopMonitor   chan struct{}
+	monitorDone   chan struct{}
+	config        VictoriaLogsConfig
+	restartCount  int
+	lastRestartAt time.Time
 }
 
 func NewVictoriaLogsComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *VictoriaLogsComponent {
@@ -94,8 +102,14 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 	// Check if container already exists
 	existingContainer, err := c.CC.LoadContainer(ctx, victoriaLogsContainerName)
 	if err == nil {
-		c.Log.Info("found existing victorialogs container, restarting it", "container_id", existingContainer.ID())
-		return c.restartExistingContainer(ctx, existingContainer, config)
+		c.Log.Info("found existing victorialogs container, attempting restart", "container_id", existingContainer.ID())
+		err = c.restartExistingContainer(ctx, existingContainer, config)
+		if err == nil {
+			return nil
+		}
+		// If restart failed (e.g., port mismatch), try deleting the container and creating fresh
+		c.Log.Warn("restart of existing container failed, recreating", "error", err)
+		c.cleanupExistingContainer(ctx, existingContainer)
 	}
 
 	c.Log.Info("starting victorialogs with host networking", "http_port", config.HTTPPort)
@@ -129,32 +143,50 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 		return err
 	}
 
+	c.task = task
 	c.running = true
+	c.config = config
 	c.Log.Info("victorialogs server started", "container_id", container.ID(), "http_port", config.HTTPPort)
+
+	// Start monitoring for unexpected exits
+	c.startExitMonitor(ctx)
 
 	return nil
 }
 
 func (c *VictoriaLogsComponent) Stop(ctx context.Context) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
 	if !c.running {
+		c.mu.Unlock()
 		return nil
 	}
 
+	// Stop the exit monitor first
+	if c.stopMonitor != nil {
+		close(c.stopMonitor)
+		c.stopMonitor = nil
+	}
+	monitorDone := c.monitorDone
+	c.mu.Unlock()
+
+	// Wait for monitor to finish (outside the lock)
+	if monitorDone != nil {
+		<-monitorDone
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
+	if c.task != nil {
+		c.stopTask(ctx, c.task)
+		c.task = nil
+	}
+
 	if c.container != nil {
-		task, err := c.container.Task(ctx, nil)
-		if err == nil {
-			c.stopTask(ctx, task)
-		} else {
-			c.Log.Warn("failed to get victorialogs task for shutdown", "error", err)
-		}
-
 		c.deleteContainerWithRetry(ctx)
-
 		c.container = nil
 	}
 
@@ -241,9 +273,23 @@ func (c *VictoriaLogsComponent) IsRunning() bool {
 	return c.running
 }
 
+func (c *VictoriaLogsComponent) cleanupExistingContainer(ctx context.Context, container containerd.Container) {
+	task, err := container.Task(ctx, nil)
+	if err == nil {
+		c.stopTask(ctx, task)
+	}
+
+	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if err := container.Delete(deleteCtx, containerd.WithSnapshotCleanup); err != nil {
+		c.Log.Warn("failed to delete existing container during cleanup", "error", err)
+	}
+}
+
 func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, container containerd.Container, config VictoriaLogsConfig) error {
 	c.container = container
 	c.httpPort = config.HTTPPort
+	c.config = config
 
 	task, err := container.Task(ctx, nil)
 	if err == nil {
@@ -252,16 +298,26 @@ func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, co
 			c.Log.Warn("failed to get task status", "error", err)
 		} else if status.Status == containerd.Running {
 			c.Log.Info("victorialogs container is already running")
+			c.task = task
 			c.running = true
-			return c.waitForReady(ctx, "localhost", config.HTTPPort)
+			if err := c.waitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+				return err
+			}
+			c.startExitMonitor(ctx)
+			return nil
 		}
 
 		c.Log.Info("starting existing victorialogs task")
 		err = task.Start(ctx)
 		if err == nil {
+			c.task = task
 			c.running = true
 			c.Log.Info("victorialogs server restarted", "container_id", container.ID(), "http_port", config.HTTPPort)
-			return c.waitForReady(ctx, "localhost", config.HTTPPort)
+			if err := c.waitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+				return err
+			}
+			c.startExitMonitor(ctx)
+			return nil
 		}
 
 		c.Log.Warn("failed to start existing task, deleting it", "error", err)
@@ -285,8 +341,12 @@ func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, co
 		return err
 	}
 
+	c.task = task
 	c.running = true
 	c.Log.Info("victorialogs server restarted with new task", "container_id", container.ID(), "http_port", config.HTTPPort)
+
+	// Start monitoring for unexpected exits
+	c.startExitMonitor(ctx)
 
 	return nil
 }
@@ -339,7 +399,7 @@ func (c *VictoriaLogsComponent) waitForReady(ctx context.Context, host string, p
 		if err == nil {
 			conn.Close()
 			c.Log.Info("victorialogs server is ready", "endpoint", endpoint)
-			return err
+			return nil
 		}
 
 		select {
@@ -351,5 +411,130 @@ func (c *VictoriaLogsComponent) waitForReady(ctx context.Context, host string, p
 	}
 
 	c.Log.Warn("victorialogs server readiness check timed out", "endpoint", endpoint)
+	return fmt.Errorf("victorialogs readiness check timed out after 30 seconds")
+}
+
+func (c *VictoriaLogsComponent) startExitMonitor(ctx context.Context) {
+	c.stopMonitor = make(chan struct{})
+	c.monitorDone = make(chan struct{})
+
+	ctx = namespaces.WithNamespace(ctx, c.Namespace)
+
+	exitCh, err := c.task.Wait(ctx)
+	if err != nil {
+		c.Log.Error("failed to get exit channel for victorialogs task", "error", err)
+		close(c.monitorDone)
+		return
+	}
+
+	go c.monitorExit(ctx, exitCh)
+}
+
+func (c *VictoriaLogsComponent) monitorExit(ctx context.Context, exitCh <-chan containerd.ExitStatus) {
+	defer close(c.monitorDone)
+
+	for {
+		select {
+		case <-c.stopMonitor:
+			c.Log.Debug("victorialogs exit monitor stopped")
+			return
+
+		case exitStatus := <-exitCh:
+			c.Log.Warn("victorialogs process exited unexpectedly",
+				"exit_code", exitStatus.ExitCode(),
+				"exit_time", exitStatus.ExitTime(),
+			)
+
+			// Attempt restart
+			if err := c.handleRestart(ctx); err != nil {
+				c.Log.Error("failed to restart victorialogs", "error", err)
+				return
+			}
+
+			// Get new exit channel for the restarted task
+			c.mu.Lock()
+			if c.task == nil {
+				c.mu.Unlock()
+				return
+			}
+			newExitCh, err := c.task.Wait(ctx)
+			c.mu.Unlock()
+			if err != nil {
+				c.Log.Error("failed to get exit channel after restart", "error", err)
+				return
+			}
+			exitCh = newExitCh
+		}
+	}
+}
+
+func (c *VictoriaLogsComponent) handleRestart(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Apply exponential backoff for restarts
+	const maxRestarts = 5
+	const backoffBase = 2 * time.Second
+	const backoffMax = 60 * time.Second
+	const resetWindow = 5 * time.Minute
+
+	// Reset restart count if enough time has passed
+	if time.Since(c.lastRestartAt) > resetWindow {
+		c.restartCount = 0
+	}
+
+	c.restartCount++
+	if c.restartCount > maxRestarts {
+		return fmt.Errorf("exceeded maximum restart attempts (%d)", maxRestarts)
+	}
+
+	// Calculate backoff
+	backoff := backoffBase * time.Duration(1<<(c.restartCount-1))
+	if backoff > backoffMax {
+		backoff = backoffMax
+	}
+
+	c.Log.Info("restarting victorialogs after backoff",
+		"restart_count", c.restartCount,
+		"backoff", backoff,
+	)
+
+	select {
+	case <-time.After(backoff):
+	case <-c.stopMonitor:
+		return fmt.Errorf("restart cancelled")
+	}
+
+	c.lastRestartAt = time.Now()
+
+	ctx = namespaces.WithNamespace(ctx, c.Namespace)
+
+	// Clean up old task
+	if c.task != nil {
+		deleteCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		c.task.Delete(deleteCtx)
+		cancel()
+		c.task = nil
+	}
+
+	// Create and start new task
+	task, err := c.container.NewTask(ctx, slogout.WithLogger(c.Log, "victorialogs"))
+	if err != nil {
+		return fmt.Errorf("failed to create new victorialogs task: %w", err)
+	}
+
+	if err := task.Start(ctx); err != nil {
+		task.Delete(ctx)
+		return fmt.Errorf("failed to start new victorialogs task: %w", err)
+	}
+
+	c.task = task
+
+	// Wait for victorialogs to be ready
+	if err := c.waitForReady(ctx, "localhost", c.config.HTTPPort); err != nil {
+		c.Log.Warn("victorialogs readiness check failed after restart", "error", err)
+	}
+
+	c.Log.Info("victorialogs restarted successfully", "restart_count", c.restartCount)
 	return nil
 }

--- a/components/victorialogs/victorialogs_test.go
+++ b/components/victorialogs/victorialogs_test.go
@@ -4,13 +4,19 @@ package victorialogs_test
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 	"miren.dev/runtime/components/victorialogs"
 	"miren.dev/runtime/pkg/containerdx"
 )
@@ -164,4 +170,135 @@ func TestVictoriaLogsComponent(t *testing.T) {
 
 		r.True(component.IsRunning())
 	})
+}
+
+func TestVictoriaLogsComponentAutoRestart(t *testing.T) {
+	if os.Getenv("SKIP_COMPONENT_TEST") != "" {
+		t.Skip("Skipping component test")
+	}
+
+	r := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	cc, err := containerd.New(containerdx.DefaultSocket)
+	r.NoError(err)
+	defer cc.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	// Use a unique namespace to avoid conflicts
+	testNamespace := fmt.Sprintf("miren-vl-restart-test-%d", time.Now().UnixNano())
+	tmpDir := t.TempDir()
+
+	component := victorialogs.NewVictoriaLogsComponent(logger, cc, testNamespace, tmpDir)
+
+	// Use a unique port to avoid conflicts
+	httpPort := 9450
+
+	config := victorialogs.VictoriaLogsConfig{
+		HTTPPort:        httpPort,
+		RetentionPeriod: "7d",
+	}
+
+	// Ensure cleanup
+	defer func() {
+		if component.IsRunning() {
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer stopCancel()
+			if err := component.Stop(stopCtx); err != nil {
+				t.Logf("failed to stop component: %v", err)
+			}
+		}
+		cleanupContainers(t, cc, testNamespace)
+	}()
+
+	t.Log("Starting victorialogs component...")
+	err = component.Start(ctx, config)
+	r.NoError(err)
+	r.True(component.IsRunning())
+
+	endpoint := fmt.Sprintf("http://localhost:%d", httpPort)
+
+	// Wait for victorialogs to be fully ready
+	r.Eventually(func() bool {
+		resp, err := http.Get(endpoint + "/health")
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 30*time.Second, 500*time.Millisecond, "victorialogs should be healthy")
+
+	t.Log("victorialogs is ready, now killing the task to simulate crash...")
+
+	// Kill the victorialogs task directly using containerd to simulate a crash
+	nsCtx := namespaces.WithNamespace(context.Background(), testNamespace)
+	containers, err := cc.Containers(nsCtx)
+	r.NoError(err, "failed to list containers")
+
+	var vlContainer containerd.Container
+	for _, c := range containers {
+		if strings.Contains(c.ID(), "victorialogs") {
+			vlContainer = c
+			break
+		}
+	}
+	r.NotNil(vlContainer, "should find victorialogs container")
+
+	task, err := vlContainer.Task(nsCtx, nil)
+	r.NoError(err, "should get task")
+
+	// Kill the task with SIGKILL to simulate crash
+	err = task.Kill(nsCtx, unix.SIGKILL)
+	r.NoError(err, "should be able to kill task")
+
+	t.Log("Task killed, waiting for auto-restart...")
+
+	// Wait for the component to auto-restart and become ready again
+	// The restart has a 2 second backoff for the first restart
+	r.Eventually(func() bool {
+		resp, err := http.Get(endpoint + "/health")
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 45*time.Second, 1*time.Second, "victorialogs should auto-restart and become healthy")
+
+	t.Log("victorialogs auto-restarted successfully!")
+
+	// Verify the component still reports as running
+	assert.True(t, component.IsRunning(), "component should still report as running after auto-restart")
+
+	t.Log("Auto-restart test completed successfully!")
+}
+
+func cleanupContainers(t *testing.T, cc *containerd.Client, namespace string) {
+	ctx := namespaces.WithNamespace(context.Background(), namespace)
+
+	containers, err := cc.Containers(ctx)
+	if err != nil {
+		t.Logf("failed to list containers for cleanup: %v", err)
+		return
+	}
+
+	for _, container := range containers {
+		task, err := container.Task(ctx, nil)
+		if err == nil {
+			task.Kill(ctx, unix.SIGTERM)
+			task.Wait(ctx)
+			task.Delete(ctx)
+		}
+
+		err = container.Delete(ctx, containerd.WithSnapshotCleanup)
+		if err != nil {
+			t.Logf("failed to delete container %s: %v", container.ID(), err)
+		} else {
+			t.Logf("cleaned up container %s", container.ID())
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Add exit monitoring via `task.Wait()` channel for etcd and victorialogs components to detect unexpected crashes
- Implement automatic restart with exponential backoff (2s-60s, max 5 restarts in 5 minutes)
- Fix `waitForReady()` to block properly and return errors on timeout instead of silently succeeding
- Add `cleanupExistingContainer()` to handle config mismatches when restarting existing containers

## Test plan
- [x] Added `TestEtcdComponentAutoRestart` - kills task via containerd, verifies auto-restart and post-restart functionality
- [x] Added `TestVictoriaLogsComponentAutoRestart` - kills task via containerd, verifies auto-restart and health endpoint
- [x] All existing tests pass
- [x] Lint passes

Closes MIR-616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic restart capability for etcd and VictoriaLogs components with exponential backoff to improve reliability when services crash.
  * Added exit monitoring and task lifecycle management to detect and recover from unexpected service failures.

* **Tests**
  * Added integration tests for both components to verify auto-restart functionality following simulated crashes and validate operations remain functional post-restart.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->