### PR TITLE
Refactor etcd, victorialogs, and victoriametrics to share base component

### DIFF
--- a/components/base/base.go
+++ b/components/base/base.go
@@ -243,8 +243,16 @@ func (b *BaseComponent) stopTask(ctx context.Context, task containerd.Task) {
 			if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
 				b.Log.Error("failed to send SIGKILL to "+b.ComponentName+" task", "error", err)
 			} else {
-				if _, waitErr := task.Wait(killCtx); waitErr != nil {
-					b.Log.Error(b.ComponentName+" task wait after SIGKILL failed", "error", waitErr)
+				statusCh, waitErr := task.Wait(killCtx)
+				if waitErr != nil {
+					b.Log.Error(b.ComponentName+" task wait channel after SIGKILL failed", "error", waitErr)
+				} else {
+					select {
+					case <-statusCh:
+						// Task exited
+					case <-killCtx.Done():
+						b.Log.Warn(b.ComponentName + " task did not exit after SIGKILL within timeout")
+					}
 				}
 			}
 		}

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -357,6 +357,13 @@ func (b *BaseComponent) StartExitMonitor(ctx context.Context) {
 	b.stopMonitor = make(chan struct{})
 	b.monitorDone = make(chan struct{})
 	task := b.task
+	if task == nil {
+		b.stopMonitor = nil
+		b.monitorDone = nil
+		b.stateMu.Unlock()
+		b.Log.Error(b.ComponentName + " cannot start exit monitor: task is nil")
+		return
+	}
 	// Capture channels before releasing lock to avoid race with stopInternal
 	stopMonitor := b.stopMonitor
 	monitorDone := b.monitorDone
@@ -427,6 +434,10 @@ func (b *BaseComponent) handleRestart(ctx context.Context, stopMonitor <-chan st
 	container := b.container
 	task := b.task
 	b.stateMu.Unlock()
+
+	if container == nil {
+		return fmt.Errorf("cannot restart %s: container is nil", b.ComponentName)
+	}
 
 	// Reset restart count if enough time has passed
 	if time.Since(lastRestartAt) > policy.ResetWindow {

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -19,19 +19,30 @@ import (
 
 // RestartPolicy configures the auto-restart behavior for a component.
 type RestartPolicy struct {
-	MaxRestarts int           // Maximum restart attempts before giving up (default: 5)
+	MaxRestarts int           // Maximum restart attempts before giving up (0 = unlimited)
 	BackoffBase time.Duration // Base delay for exponential backoff (default: 2s)
 	BackoffMax  time.Duration // Maximum backoff delay (default: 60s)
 	ResetWindow time.Duration // Time after which restart count resets (default: 5m)
 }
 
-// DefaultRestartPolicy returns the default restart policy.
+// DefaultRestartPolicy returns the default restart policy with unlimited restarts.
 func DefaultRestartPolicy() RestartPolicy {
 	return RestartPolicy{
-		MaxRestarts: 5,
+		MaxRestarts: 0, // Never give up
 		BackoffBase: 2 * time.Second,
 		BackoffMax:  60 * time.Second,
 		ResetWindow: 5 * time.Minute,
+	}
+}
+
+// AggressiveRestartPolicy returns a restart policy with shorter backoff times,
+// suitable for critical components like etcd that the system cannot run without.
+func AggressiveRestartPolicy() RestartPolicy {
+	return RestartPolicy{
+		MaxRestarts: 0, // Never give up
+		BackoffBase: 500 * time.Millisecond,
+		BackoffMax:  10 * time.Second,
+		ResetWindow: 2 * time.Minute,
 	}
 }
 
@@ -458,7 +469,7 @@ func (b *BaseComponent) handleRestart(ctx context.Context, stopMonitor <-chan st
 	}
 
 	restartCount++
-	if restartCount > policy.MaxRestarts {
+	if policy.MaxRestarts > 0 && restartCount > policy.MaxRestarts {
 		return fmt.Errorf("exceeded maximum restart attempts (%d)", policy.MaxRestarts)
 	}
 

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -1,0 +1,496 @@
+// Package base provides a shared framework for managing containerd-based service components.
+// Components like etcd, victorialogs, and victoriametrics embed BaseComponent to share
+// common functionality for container lifecycle, exit monitoring, and auto-restart.
+package base
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"golang.org/x/sys/unix"
+)
+
+// RestartPolicy configures the auto-restart behavior for a component.
+type RestartPolicy struct {
+	MaxRestarts int           // Maximum restart attempts before giving up (default: 5)
+	BackoffBase time.Duration // Base delay for exponential backoff (default: 2s)
+	BackoffMax  time.Duration // Maximum backoff delay (default: 60s)
+	ResetWindow time.Duration // Time after which restart count resets (default: 5m)
+}
+
+// DefaultRestartPolicy returns the default restart policy.
+func DefaultRestartPolicy() RestartPolicy {
+	return RestartPolicy{
+		MaxRestarts: 5,
+		BackoffBase: 2 * time.Second,
+		BackoffMax:  60 * time.Second,
+		ResetWindow: 5 * time.Minute,
+	}
+}
+
+// ReadyCheckConfig configures the readiness check behavior.
+type ReadyCheckConfig struct {
+	MaxAttempts int           // Maximum number of attempts (default: 30)
+	DialTimeout time.Duration // Timeout for each dial attempt (default: 2s)
+	Interval    time.Duration // Time between attempts (default: 2s)
+}
+
+// DefaultReadyCheckConfig returns the default readiness check configuration.
+func DefaultReadyCheckConfig() ReadyCheckConfig {
+	return ReadyCheckConfig{
+		MaxAttempts: 30,
+		DialTimeout: 2 * time.Second,
+		Interval:    2 * time.Second,
+	}
+}
+
+// TaskCreator is a callback that creates a new containerd task for the component.
+// Each component implements this to provide component-specific task creation (e.g., logging options).
+type TaskCreator func(ctx context.Context, container containerd.Container) (containerd.Task, error)
+
+// ReadyPortGetter is a callback that returns the port to check for readiness.
+type ReadyPortGetter func() int
+
+// BaseComponent provides shared functionality for containerd-based service components.
+type BaseComponent struct {
+	Log       *slog.Logger
+	CC        *containerd.Client
+	Namespace string
+	DataPath  string
+
+	// ComponentName is used in log messages to identify the component
+	ComponentName string
+
+	// Callbacks for component-specific behavior
+	CreateTask    TaskCreator
+	GetReadyPort  ReadyPortGetter
+	RestartPolicy RestartPolicy
+	ReadyConfig   ReadyCheckConfig
+
+	// opMu serializes major operations like Start and Stop
+	opMu sync.Mutex
+
+	// stateMu protects state fields (container, task, running, etc.)
+	stateMu       sync.Mutex
+	container     containerd.Container
+	task          containerd.Task
+	running       bool
+	stopMonitor   chan struct{}
+	monitorDone   chan struct{}
+	restartCount  int
+	lastRestartAt time.Time
+}
+
+// NewBaseComponent creates a new BaseComponent with default policies.
+func NewBaseComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath, componentName string) *BaseComponent {
+	return &BaseComponent{
+		Log:           log,
+		CC:            cc,
+		Namespace:     namespace,
+		DataPath:      dataPath,
+		ComponentName: componentName,
+		RestartPolicy: DefaultRestartPolicy(),
+		ReadyConfig:   DefaultReadyCheckConfig(),
+	}
+}
+
+// LockOp acquires the operation mutex for serializing major operations.
+func (b *BaseComponent) LockOp() {
+	b.opMu.Lock()
+}
+
+// UnlockOp releases the operation mutex.
+func (b *BaseComponent) UnlockOp() {
+	b.opMu.Unlock()
+}
+
+// SetContainer sets the container reference.
+func (b *BaseComponent) SetContainer(container containerd.Container) {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	b.container = container
+}
+
+// GetContainer returns the current container reference.
+func (b *BaseComponent) GetContainer() containerd.Container {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	return b.container
+}
+
+// SetTask sets the task reference and marks the component as running.
+func (b *BaseComponent) SetTask(task containerd.Task) {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	b.task = task
+	b.running = true
+}
+
+// GetTask returns the current task reference.
+func (b *BaseComponent) GetTask() containerd.Task {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	return b.task
+}
+
+// SetRunning sets the running state.
+func (b *BaseComponent) SetRunning(running bool) {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	b.running = running
+}
+
+// IsRunning returns whether the component is currently running.
+func (b *BaseComponent) IsRunning() bool {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	return b.running
+}
+
+// Stop stops the component, including the exit monitor, task, and container.
+// This method acquires the operation mutex.
+func (b *BaseComponent) Stop(ctx context.Context) error {
+	b.opMu.Lock()
+	defer b.opMu.Unlock()
+
+	return b.stopInternal(ctx)
+}
+
+// stopInternal performs the stop operation. Caller must hold opMu.
+func (b *BaseComponent) stopInternal(ctx context.Context) error {
+	b.stateMu.Lock()
+	if !b.running {
+		b.stateMu.Unlock()
+		return nil
+	}
+
+	// Stop the exit monitor first
+	stopMonitor := b.stopMonitor
+	monitorDone := b.monitorDone
+	// Clear the channels before releasing lock so new StartExitMonitor can run
+	b.stopMonitor = nil
+	b.monitorDone = nil
+	b.stateMu.Unlock()
+
+	// Signal the monitor goroutine to stop (must be done after releasing lock)
+	if stopMonitor != nil {
+		close(stopMonitor)
+	}
+
+	// Wait for monitor to finish
+	if monitorDone != nil {
+		<-monitorDone
+	}
+
+	b.stateMu.Lock()
+	task := b.task
+	container := b.container
+	b.stateMu.Unlock()
+
+	ctx = namespaces.WithNamespace(ctx, b.Namespace)
+
+	if task != nil {
+		b.stopTask(ctx, task)
+		b.stateMu.Lock()
+		b.task = nil
+		b.stateMu.Unlock()
+	}
+
+	if container != nil {
+		b.deleteContainerWithRetry(ctx, container)
+		b.stateMu.Lock()
+		b.container = nil
+		b.stateMu.Unlock()
+	}
+
+	b.stateMu.Lock()
+	b.running = false
+	b.stateMu.Unlock()
+
+	b.Log.Info(b.ComponentName + " server stopped")
+
+	return nil
+}
+
+// stopTask gracefully stops a task with SIGTERM, escalating to SIGKILL if needed.
+func (b *BaseComponent) stopTask(ctx context.Context, task containerd.Task) {
+	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := task.Kill(shutdownCtx, unix.SIGTERM); err != nil {
+		b.Log.Error("failed to send SIGTERM to "+b.ComponentName+" task", "error", err)
+		return
+	}
+
+	status, err := task.Wait(shutdownCtx)
+	if err == nil {
+		select {
+		case es := <-status:
+			b.Log.Info(b.ComponentName+" task exited", "code", es.ExitCode())
+
+		case <-shutdownCtx.Done():
+			b.Log.Warn(b.ComponentName + " task did not exit gracefully, sending SIGKILL")
+			killCtx, killCancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), b.Namespace), 10*time.Second)
+			defer killCancel()
+
+			if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
+				b.Log.Error("failed to send SIGKILL to "+b.ComponentName+" task", "error", err)
+			} else {
+				if _, waitErr := task.Wait(killCtx); waitErr != nil {
+					b.Log.Error(b.ComponentName+" task wait after SIGKILL failed", "error", waitErr)
+				}
+			}
+		}
+	}
+
+	deleteCtx, deleteCancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), b.Namespace), 10*time.Second)
+	defer deleteCancel()
+
+	if _, err := task.Delete(deleteCtx); err != nil {
+		b.Log.Error("failed to delete "+b.ComponentName+" task", "error", err)
+	}
+}
+
+// StopTask is the exported version of stopTask for use by components.
+func (b *BaseComponent) StopTask(ctx context.Context, task containerd.Task) {
+	b.stopTask(ctx, task)
+}
+
+// deleteContainerWithRetry deletes the container with retry logic.
+func (b *BaseComponent) deleteContainerWithRetry(ctx context.Context, container containerd.Container) {
+	const maxRetries = 3
+	const retryDelay = 2 * time.Second
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		err := container.Delete(deleteCtx, containerd.WithSnapshotCleanup)
+		cancel()
+
+		if err == nil {
+			b.Log.Info(b.ComponentName + " container deleted successfully")
+			return
+		}
+
+		b.Log.Error("failed to delete "+b.ComponentName+" container", "error", err, "attempt", attempt, "max_retries", maxRetries)
+
+		if attempt < maxRetries {
+			time.Sleep(retryDelay)
+		}
+	}
+
+	b.Log.Error("failed to delete " + b.ComponentName + " container after all retries, potential snapshot leak")
+}
+
+// DeleteContainerWithRetry is the exported version for use by components.
+func (b *BaseComponent) DeleteContainerWithRetry(ctx context.Context) {
+	b.stateMu.Lock()
+	container := b.container
+	b.stateMu.Unlock()
+	if container != nil {
+		b.deleteContainerWithRetry(ctx, container)
+	}
+}
+
+// CleanupExistingContainer stops the task and deletes a container during restart scenarios.
+func (b *BaseComponent) CleanupExistingContainer(ctx context.Context, container containerd.Container) {
+	task, err := container.Task(ctx, nil)
+	if err == nil {
+		b.stopTask(ctx, task)
+	}
+
+	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if err := container.Delete(deleteCtx, containerd.WithSnapshotCleanup); err != nil {
+		b.Log.Warn("failed to delete existing container during cleanup", "error", err)
+	}
+}
+
+// WaitForReady waits until the component is ready by checking TCP connectivity.
+func (b *BaseComponent) WaitForReady(ctx context.Context, host string, port int) error {
+	endpoint := net.JoinHostPort(host, strconv.Itoa(port))
+
+	for i := 0; i < b.ReadyConfig.MaxAttempts; i++ {
+		conn, err := net.DialTimeout("tcp", endpoint, b.ReadyConfig.DialTimeout)
+		if err == nil {
+			conn.Close()
+			b.Log.Info(b.ComponentName+" server is ready", "endpoint", endpoint)
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(b.ReadyConfig.Interval):
+			continue
+		}
+	}
+
+	b.Log.Warn(b.ComponentName+" server readiness check timed out", "endpoint", endpoint)
+	return fmt.Errorf("%s readiness check timed out after %d attempts", b.ComponentName, b.ReadyConfig.MaxAttempts)
+}
+
+// StartExitMonitor starts a goroutine that monitors for unexpected task exits.
+// If a monitor is already running, this is a no-op.
+func (b *BaseComponent) StartExitMonitor(ctx context.Context) {
+	b.stateMu.Lock()
+	// Check if monitor is already running
+	if b.stopMonitor != nil {
+		b.stateMu.Unlock()
+		b.Log.Debug(b.ComponentName + " exit monitor already running, skipping")
+		return
+	}
+	b.stopMonitor = make(chan struct{})
+	b.monitorDone = make(chan struct{})
+	task := b.task
+	// Capture channels before releasing lock to avoid race with stopInternal
+	stopMonitor := b.stopMonitor
+	monitorDone := b.monitorDone
+	b.stateMu.Unlock()
+
+	ctx = namespaces.WithNamespace(ctx, b.Namespace)
+
+	exitCh, err := task.Wait(ctx)
+	if err != nil {
+		b.Log.Error("failed to get exit channel for "+b.ComponentName+" task", "error", err)
+		b.stateMu.Lock()
+		b.stopMonitor = nil
+		b.monitorDone = nil
+		b.stateMu.Unlock()
+		close(monitorDone)
+		return
+	}
+
+	go b.monitorExit(ctx, exitCh, stopMonitor, monitorDone)
+}
+
+// monitorExit watches for task exits and triggers restarts.
+func (b *BaseComponent) monitorExit(ctx context.Context, exitCh <-chan containerd.ExitStatus, stopMonitor <-chan struct{}, monitorDone chan struct{}) {
+	defer close(monitorDone)
+
+	for {
+		select {
+		case <-stopMonitor:
+			b.Log.Debug(b.ComponentName + " exit monitor stopped")
+			return
+
+		case exitStatus := <-exitCh:
+			b.Log.Warn(b.ComponentName+" process exited unexpectedly",
+				"exit_code", exitStatus.ExitCode(),
+				"exit_time", exitStatus.ExitTime(),
+			)
+
+			// Attempt restart
+			if err := b.handleRestart(ctx, stopMonitor); err != nil {
+				b.Log.Error("failed to restart "+b.ComponentName, "error", err)
+				return
+			}
+
+			// Get new exit channel for the restarted task
+			b.stateMu.Lock()
+			task := b.task
+			b.stateMu.Unlock()
+
+			if task == nil {
+				return
+			}
+			newExitCh, err := task.Wait(ctx)
+			if err != nil {
+				b.Log.Error("failed to get exit channel after restart", "error", err)
+				return
+			}
+			exitCh = newExitCh
+		}
+	}
+}
+
+// handleRestart handles restarting the component after an unexpected exit.
+func (b *BaseComponent) handleRestart(ctx context.Context, stopMonitor <-chan struct{}) error {
+	b.stateMu.Lock()
+	policy := b.RestartPolicy
+	lastRestartAt := b.lastRestartAt
+	restartCount := b.restartCount
+	container := b.container
+	task := b.task
+	b.stateMu.Unlock()
+
+	// Reset restart count if enough time has passed
+	if time.Since(lastRestartAt) > policy.ResetWindow {
+		restartCount = 0
+	}
+
+	restartCount++
+	if restartCount > policy.MaxRestarts {
+		return fmt.Errorf("exceeded maximum restart attempts (%d)", policy.MaxRestarts)
+	}
+
+	// Calculate backoff
+	backoff := policy.BackoffBase * time.Duration(1<<(restartCount-1))
+	if backoff > policy.BackoffMax {
+		backoff = policy.BackoffMax
+	}
+
+	b.Log.Info("restarting "+b.ComponentName+" after backoff",
+		"restart_count", restartCount,
+		"backoff", backoff,
+	)
+
+	select {
+	case <-time.After(backoff):
+	case <-stopMonitor:
+		return fmt.Errorf("restart cancelled")
+	}
+
+	b.stateMu.Lock()
+	b.restartCount = restartCount
+	b.lastRestartAt = time.Now()
+	b.stateMu.Unlock()
+
+	ctx = namespaces.WithNamespace(ctx, b.Namespace)
+
+	// Clean up old task
+	if task != nil {
+		deleteCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		task.Delete(deleteCtx)
+		cancel()
+		b.stateMu.Lock()
+		b.task = nil
+		b.stateMu.Unlock()
+	}
+
+	// Create and start new task using the callback
+	if b.CreateTask == nil {
+		return fmt.Errorf("CreateTask callback not set")
+	}
+
+	newTask, err := b.CreateTask(ctx, container)
+	if err != nil {
+		return fmt.Errorf("failed to create new %s task: %w", b.ComponentName, err)
+	}
+
+	if err := newTask.Start(ctx); err != nil {
+		newTask.Delete(ctx)
+		return fmt.Errorf("failed to start new %s task: %w", b.ComponentName, err)
+	}
+
+	b.stateMu.Lock()
+	b.task = newTask
+	b.stateMu.Unlock()
+
+	// Wait for component to be ready
+	if b.GetReadyPort != nil {
+		port := b.GetReadyPort()
+		if err := b.WaitForReady(ctx, "localhost", port); err != nil {
+			b.Log.Warn(b.ComponentName+" readiness check failed after restart", "error", err)
+		}
+	}
+
+	b.Log.Info(b.ComponentName+" restarted successfully", "restart_count", restartCount)
+	return nil
+}

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -154,6 +154,19 @@ func (b *BaseComponent) IsRunning() bool {
 	return b.running
 }
 
+// IfRunning executes the given function while holding the state lock, but only if
+// the component is currently running. Returns empty string if not running.
+// This is useful for safely reading component state that should only be accessed
+// when the component is running.
+func (b *BaseComponent) IfRunning(fn func() string) string {
+	b.stateMu.Lock()
+	defer b.stateMu.Unlock()
+	if !b.running {
+		return ""
+	}
+	return fn()
+}
+
 // Stop stops the component, including the exit monitor, task, and container.
 // This method acquires the operation mutex.
 func (b *BaseComponent) Stop(ctx context.Context) error {
@@ -464,6 +477,8 @@ func (b *BaseComponent) handleRestart(ctx context.Context, stopMonitor <-chan st
 	case <-time.After(backoff):
 	case <-stopMonitor:
 		return fmt.Errorf("restart cancelled")
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
 	b.stateMu.Lock()

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -7,18 +7,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"os"
 	"path/filepath"
-	"strconv"
-	"sync"
-	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/sys/unix"
+	"miren.dev/runtime/components/base"
 	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/slogout"
 )
@@ -46,41 +42,44 @@ type EtcdConfig struct {
 }
 
 type EtcdComponent struct {
-	Log *slog.Logger
-	CC  *containerd.Client
+	*base.BaseComponent
 
-	Namespace string
-	DataPath  string
-
-	mu         sync.Mutex
-	container  containerd.Container
-	task       containerd.Task
-	running    bool
 	clientPort int
 	peerPort   int
-
-	// For exit monitoring and restart
-	stopMonitor   chan struct{}
-	monitorDone   chan struct{}
-	config        EtcdConfig
-	restartCount  int
-	lastRestartAt time.Time
+	config     EtcdConfig
 }
 
 func NewEtcdComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *EtcdComponent {
-	return &EtcdComponent{
-		Log:       log,
-		CC:        cc,
-		Namespace: namespace,
-		DataPath:  dataPath,
+	bc := base.NewBaseComponent(log, cc, namespace, dataPath, "etcd")
+	// etcd uses 1s dial timeout and 1s interval for readiness checks
+	bc.ReadyConfig.DialTimeout = 1e9 // 1 second in nanoseconds
+	bc.ReadyConfig.Interval = 1e9    // 1 second in nanoseconds
+
+	e := &EtcdComponent{
+		BaseComponent: bc,
 	}
+
+	// Set up callbacks for the base component
+	bc.CreateTask = e.createTask
+	bc.GetReadyPort = e.getReadyPort
+
+	return e
+}
+
+func (e *EtcdComponent) createTask(ctx context.Context, container containerd.Container) (containerd.Task, error) {
+	return container.NewTask(ctx, slogout.WithLogger(e.Log, "etcd",
+		slogout.WithJSONParsing(), slogout.WithMaxLevel(slog.LevelInfo)))
+}
+
+func (e *EtcdComponent) getReadyPort() int {
+	return e.clientPort
 }
 
 func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.LockOp()
+	defer e.UnlockOp()
 
-	if e.running {
+	if e.IsRunning() {
 		return fmt.Errorf("etcd component already running")
 	}
 
@@ -109,7 +108,7 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 		}
 		// If restart failed (e.g., port mismatch), try deleting the container and creating fresh
 		e.Log.Warn("restart of existing container failed, recreating", "error", err)
-		e.cleanupExistingContainer(ctx, existingContainer)
+		e.CleanupExistingContainer(ctx, existingContainer)
 	}
 
 	// Set defaults
@@ -135,6 +134,7 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	// Store ports for later use
 	e.clientPort = config.ClientPort
 	e.peerPort = config.PeerPort
+	e.config = config
 
 	e.Log.Info("starting etcd with host networking", "client_port", config.ClientPort, "peer_port", config.PeerPort)
 
@@ -144,11 +144,10 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 		return fmt.Errorf("failed to create etcd container: %w", err)
 	}
 
-	e.container = container
+	e.SetContainer(container)
 
 	// Start container with structured logging for JSON output
-	task, err := container.NewTask(ctx, slogout.WithLogger(e.Log, "etcd",
-		slogout.WithJSONParsing(), slogout.WithMaxLevel(slog.LevelInfo)))
+	task, err := e.createTask(ctx, container)
 	if err != nil {
 		container.Delete(ctx, containerd.WithSnapshotCleanup)
 		return fmt.Errorf("failed to create etcd task: %w", err)
@@ -161,172 +160,36 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 		return fmt.Errorf("failed to start etcd task: %w", err)
 	}
 
-	e.task = task
-	e.running = true
-	e.config = config
+	e.SetTask(task)
 	e.Log.Info("etcd server started", "container_id", container.ID(), "client_port", config.ClientPort)
 
 	// Wait for etcd to be ready before returning
-	if err := e.waitForReady(ctx, "localhost", config.ClientPort); err != nil {
+	if err := e.WaitForReady(ctx, "localhost", config.ClientPort); err != nil {
 		e.Log.Warn("etcd readiness check failed, continuing anyway", "error", err)
 	}
 
 	// Start monitoring for unexpected exits
-	e.startExitMonitor(ctx)
+	e.StartExitMonitor(ctx)
 
 	return nil
-}
-
-func (e *EtcdComponent) Stop(ctx context.Context) error {
-	e.mu.Lock()
-
-	if !e.running {
-		e.mu.Unlock()
-		return nil
-	}
-
-	// Stop the exit monitor first
-	if e.stopMonitor != nil {
-		close(e.stopMonitor)
-		e.stopMonitor = nil
-	}
-	monitorDone := e.monitorDone
-	e.mu.Unlock()
-
-	// Wait for monitor to finish (outside the lock)
-	if monitorDone != nil {
-		<-monitorDone
-	}
-
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	ctx = namespaces.WithNamespace(ctx, e.Namespace)
-
-	if e.task != nil {
-		e.stopTask(ctx, e.task)
-		e.task = nil
-	}
-
-	if e.container != nil {
-		// Delete the container with retry logic
-		e.deleteContainerWithRetry(ctx)
-		e.container = nil
-	}
-
-	e.running = false
-	e.Log.Info("etcd server stopped")
-
-	return nil
-}
-
-func (e *EtcdComponent) stopTask(ctx context.Context, task containerd.Task) {
-	// Create a timeout context for graceful shutdown
-	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	// First attempt: graceful shutdown with SIGTERM
-	if err := task.Kill(shutdownCtx, unix.SIGTERM); err != nil {
-		e.Log.Error("failed to send SIGTERM to etcd task", "error", err)
-		return
-	}
-
-	// Wait for graceful exit with timeout
-	status, err := task.Wait(shutdownCtx)
-	if err == nil {
-		select {
-		case es := <-status:
-			e.Log.Info("etcd task exited", "code", es.ExitCode())
-
-		case <-shutdownCtx.Done():
-			// Timeout reached, escalate to SIGKILL
-			e.Log.Warn("etcd task did not exit gracefully, sending SIGKILL")
-			killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer killCancel()
-
-			if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
-				e.Log.Error("failed to send SIGKILL to etcd task", "error", err)
-			} else {
-				// Wait for forced exit
-				if _, waitErr := task.Wait(killCtx); waitErr != nil {
-					e.Log.Error("etcd task wait after SIGKILL failed", "error", waitErr)
-				}
-			}
-		}
-	}
-
-	// Delete the task
-	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer deleteCancel()
-
-	if _, err := task.Delete(deleteCtx); err != nil {
-		e.Log.Error("failed to delete etcd task", "error", err)
-	}
-}
-
-func (e *EtcdComponent) deleteContainerWithRetry(ctx context.Context) {
-	const maxRetries = 3
-	const retryDelay = 2 * time.Second
-
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		err := e.container.Delete(deleteCtx, containerd.WithSnapshotCleanup)
-		cancel()
-
-		if err == nil {
-			e.Log.Info("etcd container deleted successfully")
-			return
-		}
-
-		e.Log.Error("failed to delete etcd container", "error", err, "attempt", attempt, "max_retries", maxRetries)
-
-		if attempt < maxRetries {
-			time.Sleep(retryDelay)
-		}
-	}
-
-	e.Log.Error("failed to delete etcd container after all retries, potential snapshot leak")
 }
 
 func (e *EtcdComponent) ClientEndpoint() string {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if !e.running {
+	if !e.IsRunning() {
 		return ""
 	}
 	return fmt.Sprintf("http://localhost:%d", e.clientPort)
 }
 
 func (e *EtcdComponent) PeerEndpoint() string {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	if !e.running {
+	if !e.IsRunning() {
 		return ""
 	}
 	return fmt.Sprintf("http://localhost:%d", e.peerPort)
 }
 
-func (e *EtcdComponent) IsRunning() bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	return e.running
-}
-
-func (e *EtcdComponent) cleanupExistingContainer(ctx context.Context, container containerd.Container) {
-	task, err := container.Task(ctx, nil)
-	if err == nil {
-		e.stopTask(ctx, task)
-	}
-
-	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	if err := container.Delete(deleteCtx, containerd.WithSnapshotCleanup); err != nil {
-		e.Log.Warn("failed to delete existing container during cleanup", "error", err)
-	}
-}
-
 func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container containerd.Container, config EtcdConfig) error {
-	e.container = container
+	e.SetContainer(container)
 	e.config = config
 
 	// Store ports for later use
@@ -342,12 +205,11 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 			e.Log.Warn("failed to get task status", "error", err)
 		} else if status.Status == containerd.Running {
 			e.Log.Info("etcd container is already running")
-			e.task = task
-			e.running = true
-			if err := e.waitForReady(ctx, "localhost", config.ClientPort); err != nil {
+			e.SetTask(task)
+			if err := e.WaitForReady(ctx, "localhost", config.ClientPort); err != nil {
 				e.Log.Warn("etcd readiness check failed, continuing anyway", "error", err)
 			}
-			e.startExitMonitor(ctx)
+			e.StartExitMonitor(ctx)
 			return nil
 		}
 
@@ -355,13 +217,12 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 		e.Log.Info("starting existing etcd task")
 		err = task.Start(ctx)
 		if err == nil {
-			e.task = task
-			e.running = true
+			e.SetTask(task)
 			e.Log.Info("etcd server restarted", "container_id", container.ID(), "client_port", config.ClientPort)
-			if err := e.waitForReady(ctx, "localhost", config.ClientPort); err != nil {
+			if err := e.WaitForReady(ctx, "localhost", config.ClientPort); err != nil {
 				e.Log.Warn("etcd readiness check failed, continuing anyway", "error", err)
 			}
-			e.startExitMonitor(ctx)
+			e.StartExitMonitor(ctx)
 			return nil
 		}
 
@@ -372,8 +233,7 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 
 	// Create and start new task with structured logging for JSON output
 	e.Log.Info("creating new task for existing container")
-	task, err = container.NewTask(ctx, slogout.WithLogger(e.Log, "etcd",
-		slogout.WithJSONParsing(), slogout.WithMaxLevel(slog.LevelInfo)))
+	task, err = e.createTask(ctx, container)
 	if err != nil {
 		return fmt.Errorf("failed to create new task for existing container: %w", err)
 	}
@@ -384,17 +244,16 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 		return fmt.Errorf("failed to start new task for existing container: %w", err)
 	}
 
-	e.task = task
-	e.running = true
+	e.SetTask(task)
 	e.Log.Info("etcd server restarted with new task", "container_id", container.ID(), "client_port", config.ClientPort)
 
 	// Wait for etcd to be ready
-	if err := e.waitForReady(ctx, "localhost", config.ClientPort); err != nil {
+	if err := e.WaitForReady(ctx, "localhost", config.ClientPort); err != nil {
 		e.Log.Warn("etcd readiness check failed, continuing anyway", "error", err)
 	}
 
 	// Start monitoring for unexpected exits
-	e.startExitMonitor(ctx)
+	e.StartExitMonitor(ctx)
 
 	return nil
 }
@@ -452,153 +311,4 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 	}
 
 	return container, nil
-}
-
-func (e *EtcdComponent) waitForReady(ctx context.Context, host string, port int) error {
-	endpoint := net.JoinHostPort(host, strconv.Itoa(port))
-
-	for i := 0; i < 30; i++ {
-		conn, err := net.DialTimeout("tcp", endpoint, 1*time.Second)
-		if err == nil {
-			conn.Close()
-			e.Log.Info("etcd server is ready", "endpoint", endpoint)
-			return nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(1 * time.Second):
-			continue
-		}
-	}
-
-	e.Log.Warn("etcd server readiness check timed out", "endpoint", endpoint)
-	return fmt.Errorf("etcd readiness check timed out after 30 seconds")
-}
-
-func (e *EtcdComponent) startExitMonitor(ctx context.Context) {
-	e.stopMonitor = make(chan struct{})
-	e.monitorDone = make(chan struct{})
-
-	ctx = namespaces.WithNamespace(ctx, e.Namespace)
-
-	exitCh, err := e.task.Wait(ctx)
-	if err != nil {
-		e.Log.Error("failed to get exit channel for etcd task", "error", err)
-		close(e.monitorDone)
-		return
-	}
-
-	go e.monitorExit(ctx, exitCh)
-}
-
-func (e *EtcdComponent) monitorExit(ctx context.Context, exitCh <-chan containerd.ExitStatus) {
-	defer close(e.monitorDone)
-
-	for {
-		select {
-		case <-e.stopMonitor:
-			e.Log.Debug("etcd exit monitor stopped")
-			return
-
-		case exitStatus := <-exitCh:
-			e.Log.Warn("etcd process exited unexpectedly",
-				"exit_code", exitStatus.ExitCode(),
-				"exit_time", exitStatus.ExitTime(),
-			)
-
-			// Attempt restart
-			if err := e.handleRestart(ctx); err != nil {
-				e.Log.Error("failed to restart etcd", "error", err)
-				return
-			}
-
-			// Get new exit channel for the restarted task
-			e.mu.Lock()
-			if e.task == nil {
-				e.mu.Unlock()
-				return
-			}
-			newExitCh, err := e.task.Wait(ctx)
-			e.mu.Unlock()
-			if err != nil {
-				e.Log.Error("failed to get exit channel after restart", "error", err)
-				return
-			}
-			exitCh = newExitCh
-		}
-	}
-}
-
-func (e *EtcdComponent) handleRestart(ctx context.Context) error {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	// Apply exponential backoff for restarts
-	const maxRestarts = 5
-	const backoffBase = 2 * time.Second
-	const backoffMax = 60 * time.Second
-	const resetWindow = 5 * time.Minute
-
-	// Reset restart count if enough time has passed
-	if time.Since(e.lastRestartAt) > resetWindow {
-		e.restartCount = 0
-	}
-
-	e.restartCount++
-	if e.restartCount > maxRestarts {
-		return fmt.Errorf("exceeded maximum restart attempts (%d)", maxRestarts)
-	}
-
-	// Calculate backoff
-	backoff := backoffBase * time.Duration(1<<(e.restartCount-1))
-	if backoff > backoffMax {
-		backoff = backoffMax
-	}
-
-	e.Log.Info("restarting etcd after backoff",
-		"restart_count", e.restartCount,
-		"backoff", backoff,
-	)
-
-	select {
-	case <-time.After(backoff):
-	case <-e.stopMonitor:
-		return fmt.Errorf("restart cancelled")
-	}
-
-	e.lastRestartAt = time.Now()
-
-	ctx = namespaces.WithNamespace(ctx, e.Namespace)
-
-	// Clean up old task
-	if e.task != nil {
-		deleteCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		e.task.Delete(deleteCtx)
-		cancel()
-		e.task = nil
-	}
-
-	// Create and start new task
-	task, err := e.container.NewTask(ctx, slogout.WithLogger(e.Log, "etcd",
-		slogout.WithJSONParsing(), slogout.WithMaxLevel(slog.LevelInfo)))
-	if err != nil {
-		return fmt.Errorf("failed to create new etcd task: %w", err)
-	}
-
-	if err := task.Start(ctx); err != nil {
-		task.Delete(ctx)
-		return fmt.Errorf("failed to start new etcd task: %w", err)
-	}
-
-	e.task = task
-
-	// Wait for etcd to be ready
-	if err := e.waitForReady(ctx, "localhost", e.config.ClientPort); err != nil {
-		e.Log.Warn("etcd readiness check failed after restart", "error", err)
-	}
-
-	e.Log.Info("etcd restarted successfully", "restart_count", e.restartCount)
-	return nil
 }

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -52,6 +52,8 @@ type EtcdComponent struct {
 
 func NewEtcdComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *EtcdComponent {
 	bc := base.NewBaseComponent(log, cc, namespace, dataPath, "etcd")
+	// etcd is critical - the system cannot run without it, so use aggressive restart policy
+	bc.RestartPolicy = base.AggressiveRestartPolicy()
 	// etcd uses 1s dial timeout and 1s interval for readiness checks
 	bc.ReadyConfig.DialTimeout = 1 * time.Second
 	bc.ReadyConfig.Interval = 1 * time.Second

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
@@ -52,8 +53,8 @@ type EtcdComponent struct {
 func NewEtcdComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *EtcdComponent {
 	bc := base.NewBaseComponent(log, cc, namespace, dataPath, "etcd")
 	// etcd uses 1s dial timeout and 1s interval for readiness checks
-	bc.ReadyConfig.DialTimeout = 1e9 // 1 second in nanoseconds
-	bc.ReadyConfig.Interval = 1e9    // 1 second in nanoseconds
+	bc.ReadyConfig.DialTimeout = 1 * time.Second
+	bc.ReadyConfig.Interval = 1 * time.Second
 
 	e := &EtcdComponent{
 		BaseComponent: bc,
@@ -175,17 +176,15 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 }
 
 func (e *EtcdComponent) ClientEndpoint() string {
-	if !e.IsRunning() {
-		return ""
-	}
-	return fmt.Sprintf("http://localhost:%d", e.clientPort)
+	return e.IfRunning(func() string {
+		return fmt.Sprintf("http://localhost:%d", e.clientPort)
+	})
 }
 
 func (e *EtcdComponent) PeerEndpoint() string {
-	if !e.IsRunning() {
-		return ""
-	}
-	return fmt.Sprintf("http://localhost:%d", e.peerPort)
+	return e.IfRunning(func() string {
+		return fmt.Sprintf("http://localhost:%d", e.peerPort)
+	})
 }
 
 func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container containerd.Container, config EtcdConfig) error {

--- a/components/victorialogs/victorialogs.go
+++ b/components/victorialogs/victorialogs.go
@@ -150,10 +150,9 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 }
 
 func (c *VictoriaLogsComponent) HTTPEndpoint() string {
-	if !c.IsRunning() {
-		return ""
-	}
-	return fmt.Sprintf("localhost:%d", c.httpPort)
+	return c.IfRunning(func() string {
+		return fmt.Sprintf("localhost:%d", c.httpPort)
+	})
 }
 
 func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, container containerd.Container, config VictoriaLogsConfig) error {

--- a/components/victorialogs/victorialogs.go
+++ b/components/victorialogs/victorialogs.go
@@ -6,17 +6,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"os"
 	"path/filepath"
-	"sync"
-	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/sys/unix"
+	"miren.dev/runtime/components/base"
 	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/slogout"
 )
@@ -37,40 +34,39 @@ type VictoriaLogsConfig struct {
 }
 
 type VictoriaLogsComponent struct {
-	Log *slog.Logger
-	CC  *containerd.Client
+	*base.BaseComponent
 
-	Namespace string
-	DataPath  string
-
-	mu        sync.Mutex
-	container containerd.Container
-	task      containerd.Task
-	running   bool
-	httpPort  int
-
-	// For exit monitoring and restart
-	stopMonitor   chan struct{}
-	monitorDone   chan struct{}
-	config        VictoriaLogsConfig
-	restartCount  int
-	lastRestartAt time.Time
+	httpPort int
+	config   VictoriaLogsConfig
 }
 
 func NewVictoriaLogsComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *VictoriaLogsComponent {
-	return &VictoriaLogsComponent{
-		Log:       log,
-		CC:        cc,
-		Namespace: namespace,
-		DataPath:  dataPath,
+	bc := base.NewBaseComponent(log, cc, namespace, dataPath, "victorialogs")
+
+	c := &VictoriaLogsComponent{
+		BaseComponent: bc,
 	}
+
+	// Set up callbacks for the base component
+	bc.CreateTask = c.createTask
+	bc.GetReadyPort = c.getReadyPort
+
+	return c
+}
+
+func (c *VictoriaLogsComponent) createTask(ctx context.Context, container containerd.Container) (containerd.Task, error) {
+	return container.NewTask(ctx, slogout.WithLogger(c.Log, "victorialogs"))
+}
+
+func (c *VictoriaLogsComponent) getReadyPort() int {
+	return c.httpPort
 }
 
 func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsConfig) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.LockOp()
+	defer c.UnlockOp()
 
-	if c.running {
+	if c.IsRunning() {
 		return fmt.Errorf("victorialogs component already running")
 	}
 
@@ -98,6 +94,7 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 	}
 
 	c.httpPort = config.HTTPPort
+	c.config = config
 
 	// Check if container already exists
 	existingContainer, err := c.CC.LoadContainer(ctx, victoriaLogsContainerName)
@@ -109,7 +106,7 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 		}
 		// If restart failed (e.g., port mismatch), try deleting the container and creating fresh
 		c.Log.Warn("restart of existing container failed, recreating", "error", err)
-		c.cleanupExistingContainer(ctx, existingContainer)
+		c.CleanupExistingContainer(ctx, existingContainer)
 	}
 
 	c.Log.Info("starting victorialogs with host networking", "http_port", config.HTTPPort)
@@ -120,10 +117,10 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 		return fmt.Errorf("failed to create victorialogs container: %w", err)
 	}
 
-	c.container = container
+	c.SetContainer(container)
 
 	// Start container with structured logging
-	task, err := container.NewTask(ctx, slogout.WithLogger(c.Log, "victorialogs"))
+	task, err := c.createTask(ctx, container)
 	if err != nil {
 		container.Delete(ctx, containerd.WithSnapshotCleanup)
 		return fmt.Errorf("failed to create victorialogs task: %w", err)
@@ -137,157 +134,30 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 	}
 
 	// Wait for VictoriaLogs to be ready
-	if err := c.waitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+	if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
 		task.Delete(ctx)
 		container.Delete(ctx, containerd.WithSnapshotCleanup)
 		return err
 	}
 
-	c.task = task
-	c.running = true
-	c.config = config
+	c.SetTask(task)
 	c.Log.Info("victorialogs server started", "container_id", container.ID(), "http_port", config.HTTPPort)
 
 	// Start monitoring for unexpected exits
-	c.startExitMonitor(ctx)
+	c.StartExitMonitor(ctx)
 
 	return nil
-}
-
-func (c *VictoriaLogsComponent) Stop(ctx context.Context) error {
-	c.mu.Lock()
-
-	if !c.running {
-		c.mu.Unlock()
-		return nil
-	}
-
-	// Stop the exit monitor first
-	if c.stopMonitor != nil {
-		close(c.stopMonitor)
-		c.stopMonitor = nil
-	}
-	monitorDone := c.monitorDone
-	c.mu.Unlock()
-
-	// Wait for monitor to finish (outside the lock)
-	if monitorDone != nil {
-		<-monitorDone
-	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	ctx = namespaces.WithNamespace(ctx, c.Namespace)
-
-	if c.task != nil {
-		c.stopTask(ctx, c.task)
-		c.task = nil
-	}
-
-	if c.container != nil {
-		c.deleteContainerWithRetry(ctx)
-		c.container = nil
-	}
-
-	c.running = false
-	c.Log.Info("victorialogs server stopped")
-
-	return nil
-}
-
-func (c *VictoriaLogsComponent) stopTask(ctx context.Context, task containerd.Task) {
-	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	if err := task.Kill(shutdownCtx, unix.SIGTERM); err != nil {
-		c.Log.Error("failed to send SIGTERM to victorialogs task", "error", err)
-		return
-	}
-
-	status, err := task.Wait(shutdownCtx)
-	if err == nil {
-		select {
-		case es := <-status:
-			c.Log.Info("victorialogs task exited", "code", es.ExitCode())
-
-		case <-shutdownCtx.Done():
-			c.Log.Warn("victorialogs task did not exit gracefully, sending SIGKILL")
-			killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer killCancel()
-
-			if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
-				c.Log.Error("failed to send SIGKILL to victorialogs task", "error", err)
-			} else {
-				if _, waitErr := task.Wait(killCtx); waitErr != nil {
-					c.Log.Error("victorialogs task wait after SIGKILL failed", "error", waitErr)
-				}
-			}
-		}
-	}
-
-	deleteCtx, deleteCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer deleteCancel()
-
-	if _, err := task.Delete(deleteCtx); err != nil {
-		c.Log.Error("failed to delete victorialogs task", "error", err)
-	}
-}
-
-func (c *VictoriaLogsComponent) deleteContainerWithRetry(ctx context.Context) {
-	const maxRetries = 3
-	const retryDelay = 2 * time.Second
-
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		err := c.container.Delete(deleteCtx, containerd.WithSnapshotCleanup)
-		cancel()
-
-		if err == nil {
-			c.Log.Info("victorialogs container deleted successfully")
-			return
-		}
-
-		c.Log.Error("failed to delete victorialogs container", "error", err, "attempt", attempt, "max_retries", maxRetries)
-
-		if attempt < maxRetries {
-			time.Sleep(retryDelay)
-		}
-	}
-
-	c.Log.Error("failed to delete victorialogs container after all retries, potential snapshot leak")
 }
 
 func (c *VictoriaLogsComponent) HTTPEndpoint() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.running {
+	if !c.IsRunning() {
 		return ""
 	}
 	return fmt.Sprintf("localhost:%d", c.httpPort)
 }
 
-func (c *VictoriaLogsComponent) IsRunning() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.running
-}
-
-func (c *VictoriaLogsComponent) cleanupExistingContainer(ctx context.Context, container containerd.Container) {
-	task, err := container.Task(ctx, nil)
-	if err == nil {
-		c.stopTask(ctx, task)
-	}
-
-	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	if err := container.Delete(deleteCtx, containerd.WithSnapshotCleanup); err != nil {
-		c.Log.Warn("failed to delete existing container during cleanup", "error", err)
-	}
-}
-
 func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, container containerd.Container, config VictoriaLogsConfig) error {
-	c.container = container
+	c.SetContainer(container)
 	c.httpPort = config.HTTPPort
 	c.config = config
 
@@ -298,25 +168,23 @@ func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, co
 			c.Log.Warn("failed to get task status", "error", err)
 		} else if status.Status == containerd.Running {
 			c.Log.Info("victorialogs container is already running")
-			c.task = task
-			c.running = true
-			if err := c.waitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+			c.SetTask(task)
+			if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
 				return err
 			}
-			c.startExitMonitor(ctx)
+			c.StartExitMonitor(ctx)
 			return nil
 		}
 
 		c.Log.Info("starting existing victorialogs task")
 		err = task.Start(ctx)
 		if err == nil {
-			c.task = task
-			c.running = true
+			c.SetTask(task)
 			c.Log.Info("victorialogs server restarted", "container_id", container.ID(), "http_port", config.HTTPPort)
-			if err := c.waitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+			if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
 				return err
 			}
-			c.startExitMonitor(ctx)
+			c.StartExitMonitor(ctx)
 			return nil
 		}
 
@@ -325,7 +193,7 @@ func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, co
 	}
 
 	c.Log.Info("creating new task for existing container")
-	task, err = container.NewTask(ctx, slogout.WithLogger(c.Log, "victorialogs"))
+	task, err = c.createTask(ctx, container)
 	if err != nil {
 		return fmt.Errorf("failed to create new task for existing container: %w", err)
 	}
@@ -336,17 +204,16 @@ func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, co
 		return fmt.Errorf("failed to start new task for existing container: %w", err)
 	}
 
-	if err := c.waitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+	if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
 		task.Delete(ctx)
 		return err
 	}
 
-	c.task = task
-	c.running = true
+	c.SetTask(task)
 	c.Log.Info("victorialogs server restarted with new task", "container_id", container.ID(), "http_port", config.HTTPPort)
 
 	// Start monitoring for unexpected exits
-	c.startExitMonitor(ctx)
+	c.StartExitMonitor(ctx)
 
 	return nil
 }
@@ -389,152 +256,4 @@ func (c *VictoriaLogsComponent) createContainer(ctx context.Context, image conta
 	}
 
 	return container, nil
-}
-
-func (c *VictoriaLogsComponent) waitForReady(ctx context.Context, host string, port int) error {
-	endpoint := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-
-	for i := 0; i < 30; i++ {
-		conn, err := net.DialTimeout("tcp", endpoint, 2*time.Second)
-		if err == nil {
-			conn.Close()
-			c.Log.Info("victorialogs server is ready", "endpoint", endpoint)
-			return nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(2 * time.Second):
-			continue
-		}
-	}
-
-	c.Log.Warn("victorialogs server readiness check timed out", "endpoint", endpoint)
-	return fmt.Errorf("victorialogs readiness check timed out after 30 seconds")
-}
-
-func (c *VictoriaLogsComponent) startExitMonitor(ctx context.Context) {
-	c.stopMonitor = make(chan struct{})
-	c.monitorDone = make(chan struct{})
-
-	ctx = namespaces.WithNamespace(ctx, c.Namespace)
-
-	exitCh, err := c.task.Wait(ctx)
-	if err != nil {
-		c.Log.Error("failed to get exit channel for victorialogs task", "error", err)
-		close(c.monitorDone)
-		return
-	}
-
-	go c.monitorExit(ctx, exitCh)
-}
-
-func (c *VictoriaLogsComponent) monitorExit(ctx context.Context, exitCh <-chan containerd.ExitStatus) {
-	defer close(c.monitorDone)
-
-	for {
-		select {
-		case <-c.stopMonitor:
-			c.Log.Debug("victorialogs exit monitor stopped")
-			return
-
-		case exitStatus := <-exitCh:
-			c.Log.Warn("victorialogs process exited unexpectedly",
-				"exit_code", exitStatus.ExitCode(),
-				"exit_time", exitStatus.ExitTime(),
-			)
-
-			// Attempt restart
-			if err := c.handleRestart(ctx); err != nil {
-				c.Log.Error("failed to restart victorialogs", "error", err)
-				return
-			}
-
-			// Get new exit channel for the restarted task
-			c.mu.Lock()
-			if c.task == nil {
-				c.mu.Unlock()
-				return
-			}
-			newExitCh, err := c.task.Wait(ctx)
-			c.mu.Unlock()
-			if err != nil {
-				c.Log.Error("failed to get exit channel after restart", "error", err)
-				return
-			}
-			exitCh = newExitCh
-		}
-	}
-}
-
-func (c *VictoriaLogsComponent) handleRestart(ctx context.Context) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	// Apply exponential backoff for restarts
-	const maxRestarts = 5
-	const backoffBase = 2 * time.Second
-	const backoffMax = 60 * time.Second
-	const resetWindow = 5 * time.Minute
-
-	// Reset restart count if enough time has passed
-	if time.Since(c.lastRestartAt) > resetWindow {
-		c.restartCount = 0
-	}
-
-	c.restartCount++
-	if c.restartCount > maxRestarts {
-		return fmt.Errorf("exceeded maximum restart attempts (%d)", maxRestarts)
-	}
-
-	// Calculate backoff
-	backoff := backoffBase * time.Duration(1<<(c.restartCount-1))
-	if backoff > backoffMax {
-		backoff = backoffMax
-	}
-
-	c.Log.Info("restarting victorialogs after backoff",
-		"restart_count", c.restartCount,
-		"backoff", backoff,
-	)
-
-	select {
-	case <-time.After(backoff):
-	case <-c.stopMonitor:
-		return fmt.Errorf("restart cancelled")
-	}
-
-	c.lastRestartAt = time.Now()
-
-	ctx = namespaces.WithNamespace(ctx, c.Namespace)
-
-	// Clean up old task
-	if c.task != nil {
-		deleteCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		c.task.Delete(deleteCtx)
-		cancel()
-		c.task = nil
-	}
-
-	// Create and start new task
-	task, err := c.container.NewTask(ctx, slogout.WithLogger(c.Log, "victorialogs"))
-	if err != nil {
-		return fmt.Errorf("failed to create new victorialogs task: %w", err)
-	}
-
-	if err := task.Start(ctx); err != nil {
-		task.Delete(ctx)
-		return fmt.Errorf("failed to start new victorialogs task: %w", err)
-	}
-
-	c.task = task
-
-	// Wait for victorialogs to be ready
-	if err := c.waitForReady(ctx, "localhost", c.config.HTTPPort); err != nil {
-		c.Log.Warn("victorialogs readiness check failed after restart", "error", err)
-	}
-
-	c.Log.Info("victorialogs restarted successfully", "restart_count", c.restartCount)
-	return nil
 }

--- a/components/victoriametrics/victoriametrics.go
+++ b/components/victoriametrics/victoriametrics.go
@@ -150,10 +150,9 @@ func (c *VictoriaMetricsComponent) Start(ctx context.Context, config VictoriaMet
 }
 
 func (c *VictoriaMetricsComponent) HTTPEndpoint() string {
-	if !c.IsRunning() {
-		return ""
-	}
-	return fmt.Sprintf("localhost:%d", c.httpPort)
+	return c.IfRunning(func() string {
+		return fmt.Sprintf("localhost:%d", c.httpPort)
+	})
 }
 
 func (c *VictoriaMetricsComponent) restartExistingContainer(ctx context.Context, container containerd.Container, config VictoriaMetricsConfig) error {

--- a/components/victoriametrics/victoriametrics.go
+++ b/components/victoriametrics/victoriametrics.go
@@ -6,17 +6,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"os"
 	"path/filepath"
-	"sync"
-	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/sys/unix"
+	"miren.dev/runtime/components/base"
 	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/slogout"
 )
@@ -37,32 +34,39 @@ type VictoriaMetricsConfig struct {
 }
 
 type VictoriaMetricsComponent struct {
-	Log *slog.Logger
-	CC  *containerd.Client
+	*base.BaseComponent
 
-	Namespace string
-	DataPath  string
-
-	mu        sync.Mutex
-	container containerd.Container
-	running   bool
-	httpPort  int
+	httpPort int
+	config   VictoriaMetricsConfig
 }
 
 func NewVictoriaMetricsComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *VictoriaMetricsComponent {
-	return &VictoriaMetricsComponent{
-		Log:       log,
-		CC:        cc,
-		Namespace: namespace,
-		DataPath:  dataPath,
+	bc := base.NewBaseComponent(log, cc, namespace, dataPath, "victoriametrics")
+
+	c := &VictoriaMetricsComponent{
+		BaseComponent: bc,
 	}
+
+	// Set up callbacks for the base component
+	bc.CreateTask = c.createTask
+	bc.GetReadyPort = c.getReadyPort
+
+	return c
+}
+
+func (c *VictoriaMetricsComponent) createTask(ctx context.Context, container containerd.Container) (containerd.Task, error) {
+	return container.NewTask(ctx, slogout.WithLogger(c.Log, "victoriametrics"))
+}
+
+func (c *VictoriaMetricsComponent) getReadyPort() int {
+	return c.httpPort
 }
 
 func (c *VictoriaMetricsComponent) Start(ctx context.Context, config VictoriaMetricsConfig) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.LockOp()
+	defer c.UnlockOp()
 
-	if c.running {
+	if c.IsRunning() {
 		return fmt.Errorf("victoriametrics component already running")
 	}
 
@@ -90,12 +94,19 @@ func (c *VictoriaMetricsComponent) Start(ctx context.Context, config VictoriaMet
 	}
 
 	c.httpPort = config.HTTPPort
+	c.config = config
 
 	// Check if container already exists
 	existingContainer, err := c.CC.LoadContainer(ctx, victoriaMetricsContainerName)
 	if err == nil {
-		c.Log.Info("found existing victoriametrics container, restarting it", "container_id", existingContainer.ID())
-		return c.restartExistingContainer(ctx, existingContainer, config)
+		c.Log.Info("found existing victoriametrics container, attempting restart", "container_id", existingContainer.ID())
+		err = c.restartExistingContainer(ctx, existingContainer, config)
+		if err == nil {
+			return nil
+		}
+		// If restart failed, try deleting the container and creating fresh
+		c.Log.Warn("restart of existing container failed, recreating", "error", err)
+		c.CleanupExistingContainer(ctx, existingContainer)
 	}
 
 	c.Log.Info("starting victoriametrics with host networking", "http_port", config.HTTPPort)
@@ -106,10 +117,10 @@ func (c *VictoriaMetricsComponent) Start(ctx context.Context, config VictoriaMet
 		return fmt.Errorf("failed to create victoriametrics container: %w", err)
 	}
 
-	c.container = container
+	c.SetContainer(container)
 
 	// Start container with structured logging
-	task, err := container.NewTask(ctx, slogout.WithLogger(c.Log, "victoriametrics"))
+	task, err := c.createTask(ctx, container)
 	if err != nil {
 		container.Delete(ctx, containerd.WithSnapshotCleanup)
 		return fmt.Errorf("failed to create victoriametrics task: %w", err)
@@ -123,135 +134,32 @@ func (c *VictoriaMetricsComponent) Start(ctx context.Context, config VictoriaMet
 	}
 
 	// Wait for VictoriaMetrics to be ready
-	if err := c.waitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+	if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
 		task.Delete(ctx)
 		container.Delete(ctx, containerd.WithSnapshotCleanup)
 		return err
 	}
 
-	c.running = true
+	c.SetTask(task)
 	c.Log.Info("victoriametrics server started", "container_id", container.ID(), "http_port", config.HTTPPort)
 
-	return nil
-}
-
-func (c *VictoriaMetricsComponent) Stop(ctx context.Context) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if !c.running {
-		return nil
-	}
-
-	ctx = namespaces.WithNamespace(ctx, c.Namespace)
-
-	if c.container != nil {
-		task, err := c.container.Task(ctx, nil)
-		if err == nil {
-			c.stopTask(ctx, task)
-		} else {
-			c.Log.Warn("failed to get victoriametrics task for shutdown", "error", err)
-		}
-
-		c.deleteContainerWithRetry(ctx)
-
-		c.container = nil
-	}
-
-	c.running = false
-	c.Log.Info("victoriametrics server stopped")
+	// Start monitoring for unexpected exits
+	c.StartExitMonitor(ctx)
 
 	return nil
-}
-
-func (c *VictoriaMetricsComponent) stopTask(ctx context.Context, task containerd.Task) {
-	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	if err := task.Kill(shutdownCtx, unix.SIGTERM); err != nil {
-		c.Log.Error("failed to send SIGTERM to victoriametrics task", "error", err)
-		return
-	}
-
-	status, err := task.Wait(shutdownCtx)
-	if err == nil {
-		select {
-		case es := <-status:
-			c.Log.Info("victoriametrics task exited", "code", es.ExitCode())
-
-		case <-shutdownCtx.Done():
-			c.Log.Warn("victoriametrics task did not exit gracefully, sending SIGKILL")
-			killCtx, killCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer killCancel()
-
-			if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
-				c.Log.Error("failed to send SIGKILL to victoriametrics task", "error", err)
-			} else {
-				statusChan, waitErr := task.Wait(killCtx)
-				if waitErr != nil {
-					c.Log.Error("victoriametrics task wait after SIGKILL failed", "error", waitErr)
-				} else {
-					select {
-					case es := <-statusChan:
-						c.Log.Info("victoriametrics task exited after SIGKILL", "code", es.ExitCode())
-					case <-killCtx.Done():
-						c.Log.Error("victoriametrics task did not exit after SIGKILL timeout")
-					}
-				}
-			}
-		}
-	}
-
-	deleteCtx, deleteCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer deleteCancel()
-
-	if _, err := task.Delete(deleteCtx); err != nil {
-		c.Log.Error("failed to delete victoriametrics task", "error", err)
-	}
-}
-
-func (c *VictoriaMetricsComponent) deleteContainerWithRetry(ctx context.Context) {
-	const maxRetries = 3
-	const retryDelay = 2 * time.Second
-
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		err := c.container.Delete(deleteCtx, containerd.WithSnapshotCleanup)
-		cancel()
-
-		if err == nil {
-			c.Log.Info("victoriametrics container deleted successfully")
-			return
-		}
-
-		c.Log.Error("failed to delete victoriametrics container", "error", err, "attempt", attempt, "max_retries", maxRetries)
-
-		if attempt < maxRetries {
-			time.Sleep(retryDelay)
-		}
-	}
-
-	c.Log.Error("failed to delete victoriametrics container after all retries, potential snapshot leak")
 }
 
 func (c *VictoriaMetricsComponent) HTTPEndpoint() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if !c.running {
+	if !c.IsRunning() {
 		return ""
 	}
 	return fmt.Sprintf("localhost:%d", c.httpPort)
 }
 
-func (c *VictoriaMetricsComponent) IsRunning() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.running
-}
-
 func (c *VictoriaMetricsComponent) restartExistingContainer(ctx context.Context, container containerd.Container, config VictoriaMetricsConfig) error {
-	c.container = container
+	c.SetContainer(container)
 	c.httpPort = config.HTTPPort
+	c.config = config
 
 	task, err := container.Task(ctx, nil)
 	if err == nil {
@@ -260,16 +168,24 @@ func (c *VictoriaMetricsComponent) restartExistingContainer(ctx context.Context,
 			c.Log.Warn("failed to get task status", "error", err)
 		} else if status.Status == containerd.Running {
 			c.Log.Info("victoriametrics container is already running")
-			c.running = true
-			return c.waitForReady(ctx, "localhost", config.HTTPPort)
+			c.SetTask(task)
+			if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+				return err
+			}
+			c.StartExitMonitor(ctx)
+			return nil
 		}
 
 		c.Log.Info("starting existing victoriametrics task")
 		err = task.Start(ctx)
 		if err == nil {
-			c.running = true
+			c.SetTask(task)
 			c.Log.Info("victoriametrics server restarted", "container_id", container.ID(), "http_port", config.HTTPPort)
-			return c.waitForReady(ctx, "localhost", config.HTTPPort)
+			if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+				return err
+			}
+			c.StartExitMonitor(ctx)
+			return nil
 		}
 
 		c.Log.Warn("failed to start existing task, deleting it", "error", err)
@@ -277,7 +193,7 @@ func (c *VictoriaMetricsComponent) restartExistingContainer(ctx context.Context,
 	}
 
 	c.Log.Info("creating new task for existing container")
-	task, err = container.NewTask(ctx, slogout.WithLogger(c.Log, "victoriametrics"))
+	task, err = c.createTask(ctx, container)
 	if err != nil {
 		return fmt.Errorf("failed to create new task for existing container: %w", err)
 	}
@@ -288,13 +204,16 @@ func (c *VictoriaMetricsComponent) restartExistingContainer(ctx context.Context,
 		return fmt.Errorf("failed to start new task for existing container: %w", err)
 	}
 
-	if err := c.waitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+	if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
 		task.Delete(ctx)
 		return err
 	}
 
-	c.running = true
+	c.SetTask(task)
 	c.Log.Info("victoriametrics server restarted with new task", "container_id", container.ID(), "http_port", config.HTTPPort)
+
+	// Start monitoring for unexpected exits
+	c.StartExitMonitor(ctx)
 
 	return nil
 }
@@ -338,27 +257,4 @@ func (c *VictoriaMetricsComponent) createContainer(ctx context.Context, image co
 	}
 
 	return container, nil
-}
-
-func (c *VictoriaMetricsComponent) waitForReady(ctx context.Context, host string, port int) error {
-	endpoint := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-
-	for i := 0; i < 30; i++ {
-		conn, err := net.DialTimeout("tcp", endpoint, 2*time.Second)
-		if err == nil {
-			conn.Close()
-			c.Log.Info("victoriametrics server is ready", "endpoint", endpoint)
-			return nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(2 * time.Second):
-			continue
-		}
-	}
-
-	c.Log.Error("victoriametrics server readiness check timed out", "endpoint", endpoint)
-	return fmt.Errorf("victoriametrics server readiness check timed out after 60s on endpoint %s", endpoint)
 }


### PR DESCRIPTION
## Summary

- Extract common container lifecycle management into `components/base` package
- Refactor etcd, victorialogs, and victoriametrics to embed `BaseComponent`
- Add auto-restart capability to victoriametrics (previously missing)
- Eliminate ~700 lines of duplicated code across the three components

The `BaseComponent` provides shared functionality for:
- Container and task lifecycle (Start/Stop)
- Exit monitoring with auto-restart and exponential backoff
- Readiness checking via TCP connectivity
- Graceful shutdown with SIGTERM/SIGKILL escalation

Each component embeds `BaseComponent` and provides callbacks for component-specific behavior (task creation, ready port).

## Test plan

- [x] All existing tests pass for etcd, victorialogs, and victoriametrics
- [x] Auto-restart tests pass for all three components
- [x] Linting passes