### PR TITLE
Fix reusable workflow permissions for test.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,13 @@ concurrency:
   group: release-${{ inputs.ref || github.ref_name }}
   cancel-in-progress: true
 
+# Permissions needed for reusable workflow (test.yml) and release jobs
+permissions:
+  contents: write        # For package job
+  pull-requests: read    # For golangci-lint in test.yml
+  id-token: write        # For OIDC auth and attestations
+  attestations: write    # For build artifact attestations
+
 jobs:
   init:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes the workflow validation error when release.yml calls test.yml as a reusable workflow:

```
Error calling workflow 'mirendev/runtime/.github/workflows/test.yml@...'. 
The workflow is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.
```

When a reusable workflow is called, it inherits permissions from the caller. This adds workflow-level permissions to release.yml that satisfy all requirements from test.yml:

- `contents: write` (for package job)
- `pull-requests: read` (for golangci-lint in test.yml)  
- `id-token: write` (for OIDC auth and attestations)
- `attestations: write` (for build artifact attestations)

## Test plan

- [ ] Workflow validation passes
- [ ] Release workflow runs successfully on main