### PR TITLE
Skip build jobs when test.yml called from release.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
         echo "Coverage: $COVERAGE%"
 
     - name: Upload Coverage Report
+      if: github.event_name != 'workflow_call'
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,6 +183,8 @@ jobs:
       run: make test-e2e
 
   build-binaries:
+    # Skip when called from release.yml - it has its own build-binaries with signing
+    if: github.event_name != 'workflow_call'
     strategy:
       matrix:
         include:
@@ -218,6 +220,8 @@ jobs:
           zip -j miren-${{ matrix.os }}-${{ matrix.arch }}.zip bin/miren
 
   build:
+    # Skip when called from release.yml - it has its own build jobs
+    if: github.event_name != 'workflow_call'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

When release.yml calls test.yml as a reusable workflow, the `build-binaries` and `build` jobs were running redundantly:

- **test.yml's build-binaries**: Builds 4 platforms, just zips (for validation)
- **release.yml's build-binaries**: Builds same 4 platforms with macOS signing/notarization

This adds `if: github.event_name != 'workflow_call'` to skip these jobs when called from release.yml, while still running them on PRs and merge_group to catch platform-specific build issues early.

## Test plan

- [ ] PR builds still run build-binaries (4 platform matrix)
- [ ] Release workflow skips test.yml's build jobs, uses its own