### PR TITLE
Fix flaky TestEtcdStore_ReplaceEntity revision test

### DIFF
--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -1326,10 +1326,13 @@ func TestEtcdStore_ReplaceEntity(t *testing.T) {
 		))
 		require.NoError(t, err)
 
+		// Use a revision that's definitely wrong (one more than current)
+		wrongRevision := initial.GetRevision() + 1
+
 		_, err = store.ReplaceEntity(t.Context(), New(
 			Any(DBId, initial.Id()),
 			Any(Doc, "Will fail"),
-		), WithFromRevision(9999))
+		), WithFromRevision(wrongRevision))
 		assert.Error(t, err)
 	})
 
@@ -1476,10 +1479,13 @@ func TestEtcdStore_PatchEntity(t *testing.T) {
 		))
 		require.NoError(t, err)
 
+		// Use a revision that's definitely wrong (one more than current)
+		wrongRevision := initial.GetRevision() + 1
+
 		_, err = store.PatchEntity(t.Context(), New(
 			Any(DBId, initial.Id()),
 			Any(Doc, "Will fail"),
-		), WithFromRevision(9999))
+		), WithFromRevision(wrongRevision))
 		assert.Error(t, err)
 	})
 


### PR DESCRIPTION
## Summary
- Fix flaky tests that used hardcoded revision `9999` as the "wrong" revision
- Since etcd revisions are global counters, tests would fail if the revision happened to equal 9999
- Now uses `initial.GetRevision() + 1` which is guaranteed to be wrong

Affected tests:
- `TestEtcdStore_ReplaceEntity/replace_with_wrong_revision_fails`
- `TestEtcdStore_PatchEntity/patch_with_wrong_revision_fails`

## Test plan
- [x] Both wrong revision tests pass