### PR TITLE
Fix DNS server not watching sandbox entities

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -677,7 +677,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	hs := httpingress.NewServer(ctx, ctx.Log, ingressConfig, client, aa, httpMetrics, logWriter)
 
 	// Initialize remaining ServerState components
-	ctx.ServerState.InitNetServ(ctx.Log)
+	ctx.ServerState.InitNetServ(ctx.Log, eac)
 	ctx.ServerState.InitLogsMaintainer()
 	ctx.ServerState.InitStatusMonitor(ctx.Log)
 	ctx.ServerState.InitSandboxMetrics(ctx.Log)

--- a/cli/commands/server_state.go
+++ b/cli/commands/server_state.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/controllers/sandbox"
 	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/network"
@@ -121,11 +122,11 @@ func (s *ServerState) InitLogsMaintainer() {
 }
 
 // InitNetServ creates the network service manager if not already set.
-func (s *ServerState) InitNetServ(log *slog.Logger) {
+func (s *ServerState) InitNetServ(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) {
 	if s.NetServ != nil {
 		return
 	}
-	s.NetServ = network.NewServiceManager(log, nil)
+	s.NetServ = network.NewServiceManager(log, eac)
 }
 
 // InitSandboxMetrics creates the sandbox metrics if not already set.

--- a/testdata/dns-test/.miren/app.toml
+++ b/testdata/dns-test/.miren/app.toml
@@ -1,0 +1,15 @@
+name = "dns-test"
+
+[services.web]
+command = "/bin/app web"
+
+[services.web.concurrency]
+mode = "fixed"
+num_instances = 1
+
+[services.backend]
+command = "/bin/app backend"
+
+[services.backend.concurrency]
+mode = "fixed"
+num_instances = 1

--- a/testdata/dns-test/go.mod
+++ b/testdata/dns-test/go.mod
@@ -1,0 +1,3 @@
+module dns-test
+
+go 1.23

--- a/testdata/dns-test/main.go
+++ b/testdata/dns-test/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: dns-test <web|backend>")
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "web":
+		runWeb()
+	case "backend":
+		runBackend()
+	default:
+		fmt.Printf("Unknown command: %s\n", os.Args[1])
+		os.Exit(1)
+	}
+}
+
+func runBackend() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello from backend!")
+	})
+
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK")
+	})
+
+	fmt.Printf("Backend starting on port %s\n", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		fmt.Printf("Error starting backend: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runWeb() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
+
+	// The key test: can we resolve backend.app.miren?
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "DNS Test App\n")
+		fmt.Fprintf(w, "============\n\n")
+		fmt.Fprintf(w, "Use /dns-lookup to test DNS resolution\n")
+		fmt.Fprintf(w, "Use /call-backend to test HTTP call to backend\n")
+	})
+
+	http.HandleFunc("/dns-lookup", func(w http.ResponseWriter, r *http.Request) {
+		host := "backend.app.miren"
+		fmt.Fprintf(w, "DNS Lookup Test\n")
+		fmt.Fprintf(w, "===============\n\n")
+		fmt.Fprintf(w, "Looking up: %s\n\n", host)
+
+		ips, err := net.LookupHost(host)
+		if err != nil {
+			fmt.Fprintf(w, "ERROR: %v\n", err)
+			fmt.Fprintf(w, "\nThis is the MIR-634 bug - DNS watcher not started!\n")
+			return
+		}
+
+		fmt.Fprintf(w, "SUCCESS! Resolved to:\n")
+		for _, ip := range ips {
+			fmt.Fprintf(w, "  - %s\n", ip)
+		}
+	})
+
+	http.HandleFunc("/call-backend", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Backend Call Test\n")
+		fmt.Fprintf(w, "=================\n\n")
+
+		// Try to call backend.app.miren
+		url := "http://backend.app.miren:8080/"
+		fmt.Fprintf(w, "Calling: %s\n\n", url)
+
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get(url)
+		if err != nil {
+			fmt.Fprintf(w, "ERROR: %v\n", err)
+			fmt.Fprintf(w, "\nThis might be the MIR-634 bug - DNS watcher not started!\n")
+			return
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Fprintf(w, "ERROR reading response: %v\n", err)
+			return
+		}
+
+		fmt.Fprintf(w, "SUCCESS! Response from backend:\n")
+		fmt.Fprintf(w, "Status: %d\n", resp.StatusCode)
+		fmt.Fprintf(w, "Body: %s\n", string(body))
+	})
+
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "OK")
+	})
+
+	fmt.Printf("Web starting on port %s\n", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		fmt.Printf("Error starting web: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- Pass EntityAccessClient to `InitNetServ` so the DNS server can watch sandbox entities
- Add `testdata/dns-test` app for testing cross-service DNS resolution

## Problem
DNS queries for `*.app.miren` domains returned "no such host" because `InitNetServ` was passing `nil` for the EAC, so `server.Watch(ctx)` was never called and the DNS server never built the service→IP mappings.

Regression from #519 (not yet in a release).

## Fix
Pass the `eac` created in `server.go:657` through to `InitNetServ`, which passes it to `NewServiceManager`.

## Testing
Deployed `testdata/dns-test` which has two services (web and backend). Before fix, `/dns-lookup` returned "no such host". After fix, it resolves correctly and `/call-backend` successfully reaches the backend service.