### PR TITLE
Restrict TLS cert provisioning to domains with configured routes

### DIFF
--- a/api/ingress/routewatcher.go
+++ b/api/ingress/routewatcher.go
@@ -19,14 +19,20 @@ type RouteWatcher struct {
 	log   *slog.Logger
 	eac   *entityserver_v1alpha.EntityAccessClient
 	hosts *autotls.RouteSet
+
+	// routeHosts tracks which host each route is configured for (route ID → host).
+	// This enables proper reference counting when routes are updated or deleted.
+	routeHosts   map[string]string
+	routeHostsMu sync.RWMutex
 }
 
 // NewRouteWatcher creates a new RouteWatcher.
 func NewRouteWatcher(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *RouteWatcher {
 	return &RouteWatcher{
-		log:   log.With("module", "route-watcher"),
-		eac:   eac,
-		hosts: autotls.NewRouteSet(),
+		log:        log.With("module", "route-watcher"),
+		eac:        eac,
+		hosts:      autotls.NewRouteSet(),
+		routeHosts: make(map[string]string),
 	}
 }
 
@@ -35,17 +41,19 @@ func (rw *RouteWatcher) RouteSet() *autotls.RouteSet {
 	return rw.hosts
 }
 
-// Start loads all existing routes and begins watching for changes.
-// It blocks until the context is cancelled.
-func (rw *RouteWatcher) Start(ctx context.Context) error {
-	// Load existing routes
-	if err := rw.loadExistingRoutes(ctx); err != nil {
-		return err
-	}
+// LoadExistingRoutes loads all existing http_route entities into the set.
+// This is synchronous and should be called before starting the TLS server
+// to avoid a race where cert requests arrive before routes are loaded.
+func (rw *RouteWatcher) LoadExistingRoutes(ctx context.Context) error {
+	return rw.loadExistingRoutes(ctx)
+}
 
+// Watch watches for route changes and updates the host set.
+// It blocks until the context is cancelled.
+// Call LoadExistingRoutes first to populate the initial set.
+func (rw *RouteWatcher) Watch(ctx context.Context) error {
 	rw.log.Info("starting route watcher")
 
-	// Watch for changes
 	index := entity.Ref(entity.EntityKind, ingress_v1alpha.KindHttpRoute)
 
 	_, err := rw.eac.WatchIndex(ctx, index, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
@@ -53,32 +61,120 @@ func (rw *RouteWatcher) Start(ctx context.Context) error {
 			return nil
 		}
 
+		routeID := op.EntityId()
+
 		var route ingress_v1alpha.HttpRoute
 		route.Decode(op.Entity().Entity())
 
 		host := strings.ToLower(strings.TrimSpace(route.Host))
-		if host == "" {
-			// Default routes have no host - skip them for cert provisioning purposes
-			return nil
-		}
 
 		switch op.OperationType() {
 		case entityserver_v1alpha.EntityOperationCreate:
-			rw.log.Debug("route created", "host", host)
-			rw.hosts.Add(host)
+			if host == "" {
+				return nil
+			}
+			rw.log.Debug("route created", "id", routeID, "host", host)
+			rw.recordRouteHost(routeID, host)
+
 		case entityserver_v1alpha.EntityOperationUpdate:
-			// For updates, we just make sure the host is in the set
-			// (host changes on a route are unlikely but handled)
-			rw.hosts.Add(host)
+			rw.updateRouteHost(routeID, host)
+
 		case entityserver_v1alpha.EntityOperationDelete:
-			rw.log.Debug("route deleted", "host", host)
-			rw.hosts.Remove(host)
+			rw.removeRouteHost(routeID)
 		}
 
 		return nil
 	}))
 
 	return err
+}
+
+// recordRouteHost records a new route's host and adds it to the host set.
+func (rw *RouteWatcher) recordRouteHost(routeID, host string) {
+	rw.routeHostsMu.Lock()
+	defer rw.routeHostsMu.Unlock()
+
+	rw.routeHosts[routeID] = host
+	rw.hosts.Add(host)
+}
+
+// updateRouteHost handles a route update, properly managing host changes.
+func (rw *RouteWatcher) updateRouteHost(routeID, newHost string) {
+	rw.routeHostsMu.Lock()
+	defer rw.routeHostsMu.Unlock()
+
+	oldHost, existed := rw.routeHosts[routeID]
+
+	// Handle case where route previously had no host (or wasn't tracked)
+	if !existed || oldHost == "" {
+		if newHost != "" {
+			rw.routeHosts[routeID] = newHost
+			rw.hosts.Add(newHost)
+			rw.log.Debug("route updated, host added", "id", routeID, "host", newHost)
+		}
+		return
+	}
+
+	// Handle case where route now has no host
+	if newHost == "" {
+		delete(rw.routeHosts, routeID)
+		if !rw.hostHasOtherRoutesLocked(oldHost, routeID) {
+			rw.hosts.Remove(oldHost)
+			rw.log.Debug("route updated, host removed", "id", routeID, "oldHost", oldHost)
+		}
+		return
+	}
+
+	// Host changed
+	if oldHost != newHost {
+		rw.routeHosts[routeID] = newHost
+		rw.hosts.Add(newHost)
+		if !rw.hostHasOtherRoutesLocked(oldHost, routeID) {
+			rw.hosts.Remove(oldHost)
+		}
+		rw.log.Debug("route updated, host changed", "id", routeID, "oldHost", oldHost, "newHost", newHost)
+	}
+}
+
+// removeRouteHost handles a route deletion, only removing the host if no other routes use it.
+func (rw *RouteWatcher) removeRouteHost(routeID string) {
+	rw.routeHostsMu.Lock()
+	defer rw.routeHostsMu.Unlock()
+
+	host, existed := rw.routeHosts[routeID]
+	if !existed || host == "" {
+		return
+	}
+
+	delete(rw.routeHosts, routeID)
+
+	if !rw.hostHasOtherRoutesLocked(host, routeID) {
+		rw.hosts.Remove(host)
+		rw.log.Debug("route deleted, host removed", "id", routeID, "host", host)
+	} else {
+		rw.log.Debug("route deleted, host retained (other routes exist)", "id", routeID, "host", host)
+	}
+}
+
+// hostHasOtherRoutesLocked checks if any route other than excludeID uses the given host.
+// Must be called with routeHostsMu held.
+func (rw *RouteWatcher) hostHasOtherRoutesLocked(host, excludeID string) bool {
+	for id, h := range rw.routeHosts {
+		if id != excludeID && h == host {
+			return true
+		}
+	}
+	return false
+}
+
+// Start loads all existing routes and begins watching for changes.
+// It blocks until the context is cancelled.
+// For more control over timing, use LoadExistingRoutes followed by Watch.
+func (rw *RouteWatcher) Start(ctx context.Context) error {
+	if err := rw.LoadExistingRoutes(ctx); err != nil {
+		return err
+	}
+	return rw.Watch(ctx)
 }
 
 // loadExistingRoutes loads all existing http_route entities into the set.
@@ -88,14 +184,23 @@ func (rw *RouteWatcher) loadExistingRoutes(ctx context.Context) error {
 		return err
 	}
 
+	rw.routeHostsMu.Lock()
+	defer rw.routeHostsMu.Unlock()
+
+	// Reset tracking state
+	rw.routeHosts = make(map[string]string)
+
 	var hosts []string
 	for _, ent := range res.Values() {
+		routeID := ent.Id()
+
 		var route ingress_v1alpha.HttpRoute
 		route.Decode(ent.Entity())
 
 		host := strings.ToLower(strings.TrimSpace(route.Host))
 		if host != "" {
 			hosts = append(hosts, host)
+			rw.routeHosts[routeID] = host
 		}
 	}
 

--- a/api/ingress/routewatcher.go
+++ b/api/ingress/routewatcher.go
@@ -1,0 +1,118 @@
+package ingress
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/components/autotls"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/rpc/stream"
+)
+
+// RouteWatcher watches http_route entities and maintains an in-memory set
+// of hosts with configured routes. It implements autotls.RouteWatcher.
+type RouteWatcher struct {
+	log   *slog.Logger
+	eac   *entityserver_v1alpha.EntityAccessClient
+	hosts *autotls.RouteSet
+}
+
+// NewRouteWatcher creates a new RouteWatcher.
+func NewRouteWatcher(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *RouteWatcher {
+	return &RouteWatcher{
+		log:   log.With("module", "route-watcher"),
+		eac:   eac,
+		hosts: autotls.NewRouteSet(),
+	}
+}
+
+// RouteSet returns the underlying RouteSet for use with autotls.ServeTLS.
+func (rw *RouteWatcher) RouteSet() *autotls.RouteSet {
+	return rw.hosts
+}
+
+// Start loads all existing routes and begins watching for changes.
+// It blocks until the context is cancelled.
+func (rw *RouteWatcher) Start(ctx context.Context) error {
+	// Load existing routes
+	if err := rw.loadExistingRoutes(ctx); err != nil {
+		return err
+	}
+
+	rw.log.Info("starting route watcher")
+
+	// Watch for changes
+	index := entity.Ref(entity.EntityKind, ingress_v1alpha.KindHttpRoute)
+
+	_, err := rw.eac.WatchIndex(ctx, index, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
+		if op == nil {
+			return nil
+		}
+
+		var route ingress_v1alpha.HttpRoute
+		route.Decode(op.Entity().Entity())
+
+		host := strings.ToLower(strings.TrimSpace(route.Host))
+		if host == "" {
+			// Default routes have no host - skip them for cert provisioning purposes
+			return nil
+		}
+
+		switch op.OperationType() {
+		case entityserver_v1alpha.EntityOperationCreate:
+			rw.log.Debug("route created", "host", host)
+			rw.hosts.Add(host)
+		case entityserver_v1alpha.EntityOperationUpdate:
+			// For updates, we just make sure the host is in the set
+			// (host changes on a route are unlikely but handled)
+			rw.hosts.Add(host)
+		case entityserver_v1alpha.EntityOperationDelete:
+			rw.log.Debug("route deleted", "host", host)
+			rw.hosts.Remove(host)
+		}
+
+		return nil
+	}))
+
+	return err
+}
+
+// loadExistingRoutes loads all existing http_route entities into the set.
+func (rw *RouteWatcher) loadExistingRoutes(ctx context.Context) error {
+	res, err := rw.eac.List(ctx, entity.Ref(entity.EntityKind, ingress_v1alpha.KindHttpRoute))
+	if err != nil {
+		return err
+	}
+
+	var hosts []string
+	for _, ent := range res.Values() {
+		var route ingress_v1alpha.HttpRoute
+		route.Decode(ent.Entity())
+
+		host := strings.ToLower(strings.TrimSpace(route.Host))
+		if host != "" {
+			hosts = append(hosts, host)
+		}
+	}
+
+	rw.hosts.Replace(hosts)
+	rw.log.Info("loaded existing routes", "count", len(hosts))
+
+	return nil
+}
+
+// StartBackground starts the watcher in a goroutine and returns immediately.
+// Use this when you need the watcher running but don't want to block.
+func (rw *RouteWatcher) StartBackground(ctx context.Context, wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := rw.Start(ctx); err != nil {
+			rw.log.Error("route watcher error", "error", err)
+		}
+	}()
+}

--- a/api/ingress/routewatcher_test.go
+++ b/api/ingress/routewatcher_test.go
@@ -1,0 +1,149 @@
+package ingress
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"miren.dev/runtime/components/autotls"
+)
+
+func TestRouteWatcher_ReferenceCountingHelpers(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	t.Run("recordRouteHost adds host to set", func(t *testing.T) {
+		rw := &RouteWatcher{
+			log:        log,
+			hosts:      autotls.NewRouteSet(),
+			routeHosts: make(map[string]string),
+		}
+
+		rw.recordRouteHost("route-1", "example.com")
+
+		if !rw.hosts.HasRoute("example.com") {
+			t.Error("expected example.com to be in host set")
+		}
+		if rw.routeHosts["route-1"] != "example.com" {
+			t.Error("expected route-1 to be tracked")
+		}
+	})
+
+	t.Run("multiple routes same host", func(t *testing.T) {
+		rw := &RouteWatcher{
+			log:        log,
+			hosts:      autotls.NewRouteSet(),
+			routeHosts: make(map[string]string),
+		}
+
+		rw.recordRouteHost("route-1", "example.com")
+		rw.recordRouteHost("route-2", "example.com")
+
+		// Delete one route - host should remain
+		rw.removeRouteHost("route-1")
+
+		if !rw.hosts.HasRoute("example.com") {
+			t.Error("expected example.com to still be in host set after deleting one route")
+		}
+
+		// Delete second route - host should be removed
+		rw.removeRouteHost("route-2")
+
+		if rw.hosts.HasRoute("example.com") {
+			t.Error("expected example.com to be removed after deleting all routes")
+		}
+	})
+
+	t.Run("update route host changes tracking", func(t *testing.T) {
+		rw := &RouteWatcher{
+			log:        log,
+			hosts:      autotls.NewRouteSet(),
+			routeHosts: make(map[string]string),
+		}
+
+		rw.recordRouteHost("route-1", "old.example.com")
+
+		// Update to new host
+		rw.updateRouteHost("route-1", "new.example.com")
+
+		if rw.hosts.HasRoute("old.example.com") {
+			t.Error("expected old.example.com to be removed")
+		}
+		if !rw.hosts.HasRoute("new.example.com") {
+			t.Error("expected new.example.com to be added")
+		}
+		if rw.routeHosts["route-1"] != "new.example.com" {
+			t.Error("expected route tracking to be updated")
+		}
+	})
+
+	t.Run("update host shared by multiple routes", func(t *testing.T) {
+		rw := &RouteWatcher{
+			log:        log,
+			hosts:      autotls.NewRouteSet(),
+			routeHosts: make(map[string]string),
+		}
+
+		rw.recordRouteHost("route-1", "shared.example.com")
+		rw.recordRouteHost("route-2", "shared.example.com")
+
+		// Update route-1 to different host
+		rw.updateRouteHost("route-1", "new.example.com")
+
+		// shared.example.com should still exist (route-2 uses it)
+		if !rw.hosts.HasRoute("shared.example.com") {
+			t.Error("expected shared.example.com to remain (route-2 still uses it)")
+		}
+		if !rw.hosts.HasRoute("new.example.com") {
+			t.Error("expected new.example.com to be added")
+		}
+	})
+
+	t.Run("update removes host when going empty", func(t *testing.T) {
+		rw := &RouteWatcher{
+			log:        log,
+			hosts:      autotls.NewRouteSet(),
+			routeHosts: make(map[string]string),
+		}
+
+		rw.recordRouteHost("route-1", "example.com")
+
+		// Update to empty host (simulates removing host from route config)
+		rw.updateRouteHost("route-1", "")
+
+		if rw.hosts.HasRoute("example.com") {
+			t.Error("expected example.com to be removed when route host becomes empty")
+		}
+		if _, exists := rw.routeHosts["route-1"]; exists {
+			t.Error("expected route tracking to be removed")
+		}
+	})
+
+	t.Run("update adds host when previously empty", func(t *testing.T) {
+		rw := &RouteWatcher{
+			log:        log,
+			hosts:      autotls.NewRouteSet(),
+			routeHosts: make(map[string]string),
+		}
+
+		// Update a route that wasn't tracked (had no host)
+		rw.updateRouteHost("route-1", "example.com")
+
+		if !rw.hosts.HasRoute("example.com") {
+			t.Error("expected example.com to be added")
+		}
+		if rw.routeHosts["route-1"] != "example.com" {
+			t.Error("expected route to be tracked")
+		}
+	})
+
+	t.Run("delete untracked route is no-op", func(t *testing.T) {
+		rw := &RouteWatcher{
+			log:        log,
+			hosts:      autotls.NewRouteSet(),
+			routeHosts: make(map[string]string),
+		}
+
+		// This should not panic or cause issues
+		rw.removeRouteHost("nonexistent-route")
+	})
+}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog/v2"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/ingress"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/components/autotls"
 	"miren.dev/runtime/components/buildkit"
@@ -761,7 +762,14 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 				}
 			} else {
 				// Use HTTP challenge (default - autocert)
-				if err := autotls.ServeTLS(sub, ctx.Log, cfg.Server.GetDataPath(), email, hs); err != nil {
+				// Start route watcher to track which hosts have configured routes
+				// This restricts cert provisioning to only domains with explicit routes
+				routeWatcher := ingress.NewRouteWatcher(ctx.Log, eac)
+				eg.Go(func() error {
+					return routeWatcher.Start(sub)
+				})
+
+				if err := autotls.ServeTLS(sub, ctx.Log, cfg.Server.GetDataPath(), email, routeWatcher.RouteSet(), hs); err != nil {
 					ctx.Log.Error("failed to enable standard TLS", "error", err)
 				}
 			}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -765,8 +765,17 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 				// Start route watcher to track which hosts have configured routes
 				// This restricts cert provisioning to only domains with explicit routes
 				routeWatcher := ingress.NewRouteWatcher(ctx.Log, eac)
+
+				// Load existing routes synchronously before starting TLS
+				// to avoid rejecting cert requests during startup
+				if err := routeWatcher.LoadExistingRoutes(sub); err != nil {
+					ctx.Log.Error("failed to load existing routes", "error", err)
+					return err
+				}
+
+				// Start watching for route changes in the background
 				eg.Go(func() error {
-					return routeWatcher.Start(sub)
+					return routeWatcher.Watch(sub)
 				})
 
 				if err := autotls.ServeTLS(sub, ctx.Log, cfg.Server.GetDataPath(), email, routeWatcher.RouteSet(), hs); err != nil {

--- a/components/autotls/autotls.go
+++ b/components/autotls/autotls.go
@@ -111,9 +111,10 @@ func ServeTLS(ctx context.Context, log *slog.Logger, dataPath string, email stri
 	log.Info("serving TLS with autocert (self-signed fallback for unconfigured hosts)")
 
 	server := &http.Server{
-		Addr:      ":443",
-		Handler:   h,
-		TLSConfig: tlsConfig,
+		Addr:              ":443",
+		Handler:           h,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	go func() {

--- a/components/autotls/autotls.go
+++ b/components/autotls/autotls.go
@@ -3,11 +3,11 @@ package autotls
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -69,30 +69,55 @@ func (rs *RouteSet) Replace(hosts []string) {
 }
 
 func ServeTLS(ctx context.Context, log *slog.Logger, dataPath string, email string, routeWatcher RouteWatcher, h http.Handler) error {
-	mgr := &autocert.Manager{
-		Prompt: autocert.AcceptTOS,
-		Cache:  autocert.DirCache(filepath.Join(dataPath, "certs")),
-		Email:  email,
-		HostPolicy: func(_ context.Context, host string) error {
-			if !routeWatcher.HasRoute(host) {
-				log.Warn("rejected cert request for host without configured route", "host", host)
-				return fmt.Errorf("no route configured for host: %s", host)
-			}
-			log.Debug("allowing cert provisioning for host with configured route", "host", host)
-			return nil
-		},
-	}
-
 	log = log.With("module", "autotls")
 
-	log.Info("serving TLS with autocert")
+	// Load or generate a self-signed fallback cert for hosts without configured routes.
+	// This allows default routes and unconfigured hosts to still work over HTTPS
+	// (with a browser warning) while only provisioning real ACME certs for
+	// explicitly configured domains. The cert is persisted to disk so users
+	// who accept the browser warning don't have to re-accept on every restart.
+	certsDir := filepath.Join(dataPath, "certs")
+	fallbackCert, err := loadOrGenerateFallbackCert(certsDir)
+	if err != nil {
+		return err
+	}
+	log.Info("loaded fallback self-signed certificate for unconfigured hosts")
+
+	mgr := &autocert.Manager{
+		Prompt: autocert.AcceptTOS,
+		Cache:  autocert.DirCache(certsDir),
+		Email:  email,
+	}
+
+	// Custom GetCertificate that falls back to self-signed for unconfigured hosts
+	getCertificate := func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		host := strings.ToLower(hello.ServerName)
+
+		if routeWatcher.HasRoute(host) {
+			log.Debug("using ACME cert for configured host", "host", host)
+			return mgr.GetCertificate(hello)
+		}
+
+		log.Debug("using self-signed fallback for unconfigured host", "host", host)
+		return &fallbackCert, nil
+	}
+
+	tlsConfig := &tls.Config{
+		GetCertificate: getCertificate,
+		NextProtos:     []string{"h2", "http/1.1", "acme-tls/1"},
+		MinVersion:     tls.VersionTLS12,
+	}
+
+	log.Info("serving TLS with autocert (self-signed fallback for unconfigured hosts)")
 
 	server := &http.Server{
-		Handler: h,
+		Addr:      ":443",
+		Handler:   h,
+		TLSConfig: tlsConfig,
 	}
 
 	go func() {
-		err := server.Serve(mgr.Listener())
+		err := server.ListenAndServeTLS("", "")
 		if err != nil && err != http.ErrServerClosed {
 			log.Error("error serving TLS", "error", err)
 		}

--- a/components/autotls/autotls.go
+++ b/components/autotls/autotls.go
@@ -3,21 +3,84 @@ package autotls
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"golang.org/x/crypto/acme/autocert"
 )
 
-func ServeTLS(ctx context.Context, log *slog.Logger, dataPath string, email string, h http.Handler) error {
+// RouteWatcher provides access to the set of hosts with configured routes.
+// Implementations should watch for route changes and keep the set current.
+type RouteWatcher interface {
+	// HasRoute returns true if a route exists for the given host.
+	// This should be a fast in-memory lookup.
+	HasRoute(host string) bool
+}
+
+// RouteSet is a thread-safe set of hosts with configured routes.
+// It implements RouteWatcher and can be updated as routes change.
+type RouteSet struct {
+	mu    sync.RWMutex
+	hosts map[string]struct{}
+}
+
+// NewRouteSet creates a new empty RouteSet.
+func NewRouteSet() *RouteSet {
+	return &RouteSet{
+		hosts: make(map[string]struct{}),
+	}
+}
+
+// HasRoute returns true if the host has a configured route.
+func (rs *RouteSet) HasRoute(host string) bool {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+	_, ok := rs.hosts[host]
+	return ok
+}
+
+// Add adds a host to the route set.
+func (rs *RouteSet) Add(host string) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.hosts[host] = struct{}{}
+}
+
+// Remove removes a host from the route set.
+func (rs *RouteSet) Remove(host string) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	delete(rs.hosts, host)
+}
+
+// Replace replaces all hosts in the set with the provided list.
+func (rs *RouteSet) Replace(hosts []string) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.hosts = make(map[string]struct{}, len(hosts))
+	for _, h := range hosts {
+		rs.hosts[h] = struct{}{}
+	}
+}
+
+func ServeTLS(ctx context.Context, log *slog.Logger, dataPath string, email string, routeWatcher RouteWatcher, h http.Handler) error {
 	mgr := &autocert.Manager{
 		Prompt: autocert.AcceptTOS,
 		Cache:  autocert.DirCache(filepath.Join(dataPath, "certs")),
 		Email:  email,
-		// TODO set HostPolicy to only allow certain domains
+		HostPolicy: func(_ context.Context, host string) error {
+			if !routeWatcher.HasRoute(host) {
+				log.Warn("rejected cert request for host without configured route", "host", host)
+				return fmt.Errorf("no route configured for host: %s", host)
+			}
+			log.Debug("allowing cert provisioning for host with configured route", "host", host)
+			return nil
+		},
 	}
 
 	log = log.With("module", "autotls")

--- a/components/autotls/selfsigned.go
+++ b/components/autotls/selfsigned.go
@@ -14,7 +14,16 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
+)
+
+const (
+	fallbackCertFile = "fallback-cert.pem"
+	fallbackKeyFile  = "fallback-key.pem"
+	// Regenerate the fallback cert if it expires within this duration
+	fallbackCertRenewalWindow = 30 * 24 * time.Hour
 )
 
 // ServeTLSSelfSigned serves HTTPS using a self-signed certificate.
@@ -141,4 +150,118 @@ func generateSelfSignedCert() (tls.Certificate, error) {
 	}
 
 	return tlsCert, nil
+}
+
+// loadOrGenerateFallbackCert loads a cached fallback certificate from disk,
+// or generates a new one if it doesn't exist or is expiring soon.
+// This ensures users who accept the browser warning don't have to re-accept
+// on every server restart.
+func loadOrGenerateFallbackCert(certsDir string) (tls.Certificate, error) {
+	certPath := filepath.Join(certsDir, fallbackCertFile)
+	keyPath := filepath.Join(certsDir, fallbackKeyFile)
+
+	// Try to load existing cert
+	cert, err := loadFallbackCert(certPath, keyPath)
+	if err == nil {
+		// Check if cert is expiring soon
+		if !certExpiringSoon(cert) {
+			return cert, nil
+		}
+		// Cert is expiring, fall through to regenerate
+	}
+
+	// Generate new cert
+	cert, certPEM, keyPEM, err := generateSelfSignedCertWithPEM()
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	// Ensure certs directory exists
+	if err := os.MkdirAll(certsDir, 0700); err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to create certs directory: %w", err)
+	}
+
+	// Save cert and key to disk
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to write fallback cert: %w", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		return tls.Certificate{}, fmt.Errorf("failed to write fallback key: %w", err)
+	}
+
+	return cert, nil
+}
+
+// loadFallbackCert loads a certificate from disk.
+func loadFallbackCert(certPath, keyPath string) (tls.Certificate, error) {
+	return tls.LoadX509KeyPair(certPath, keyPath)
+}
+
+// certExpiringSoon checks if a certificate is expiring within the renewal window.
+func certExpiringSoon(cert tls.Certificate) bool {
+	if len(cert.Certificate) == 0 {
+		return true
+	}
+
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return true
+	}
+
+	return time.Until(x509Cert.NotAfter) < fallbackCertRenewalWindow
+}
+
+// generateSelfSignedCertWithPEM creates a self-signed certificate and returns
+// both the tls.Certificate and the PEM-encoded cert and key for persistence.
+func generateSelfSignedCertWithPEM() (tls.Certificate, []byte, []byte, error) {
+	pubkey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		return tls.Certificate{}, nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	certTemplate := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Miren Dev"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
+		DNSNames:              []string{"localhost"},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, pubkey, privateKey)
+	if err != nil {
+		return tls.Certificate{}, nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	pkbytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return tls.Certificate{}, nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: pkbytes,
+	})
+
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	})
+
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, nil, nil, fmt.Errorf("failed to create x509 key pair: %w", err)
+	}
+
+	return tlsCert, certPEM, keyPEM, nil
 }

--- a/components/autotls/selfsigned.go
+++ b/components/autotls/selfsigned.go
@@ -100,56 +100,8 @@ func ServeTLSSelfSigned(ctx context.Context, log *slog.Logger, h http.Handler) e
 
 // generateSelfSignedCert creates an in-memory self-signed certificate
 func generateSelfSignedCert() (tls.Certificate, error) {
-	pubkey, privateKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("failed to generate private key: %w", err)
-	}
-
-	serialNumber, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("failed to generate serial number: %w", err)
-	}
-
-	certTemplate := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-			Organization: []string{"Miren Dev"},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(365 * 24 * time.Hour), // valid for 1 year
-		KeyUsage:              x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback},
-		DNSNames:              []string{"localhost"},
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, pubkey, privateKey)
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("failed to create certificate: %w", err)
-	}
-
-	pkbytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("failed to marshal private key: %w", err)
-	}
-
-	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: pkbytes,
-	})
-
-	certPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: derBytes,
-	})
-
-	tlsCert, err := tls.X509KeyPair(certPEM, privateKeyPEM)
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("failed to create x509 key pair: %w", err)
-	}
-
-	return tlsCert, nil
+	cert, _, _, err := generateSelfSignedCertWithPEM()
+	return cert, err
 }
 
 // loadOrGenerateFallbackCert loads a cached fallback certificate from disk,

--- a/components/autotls/selfsigned_test.go
+++ b/components/autotls/selfsigned_test.go
@@ -1,0 +1,123 @@
+package autotls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadOrGenerateFallbackCert(t *testing.T) {
+	t.Run("generates new cert when none exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cert, err := loadOrGenerateFallbackCert(tmpDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Verify cert is valid
+		if len(cert.Certificate) == 0 {
+			t.Fatal("expected cert to have certificate data")
+		}
+
+		// Verify files were created
+		certPath := filepath.Join(tmpDir, fallbackCertFile)
+		keyPath := filepath.Join(tmpDir, fallbackKeyFile)
+
+		if _, err := os.Stat(certPath); os.IsNotExist(err) {
+			t.Error("expected cert file to be created")
+		}
+		if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+			t.Error("expected key file to be created")
+		}
+	})
+
+	t.Run("loads existing valid cert", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Generate initial cert
+		cert1, err := loadOrGenerateFallbackCert(tmpDir)
+		if err != nil {
+			t.Fatalf("unexpected error generating cert: %v", err)
+		}
+
+		// Get the serial number of first cert
+		x509Cert1, err := x509.ParseCertificate(cert1.Certificate[0])
+		if err != nil {
+			t.Fatalf("failed to parse first cert: %v", err)
+		}
+
+		// Load again - should return same cert
+		cert2, err := loadOrGenerateFallbackCert(tmpDir)
+		if err != nil {
+			t.Fatalf("unexpected error loading cert: %v", err)
+		}
+
+		x509Cert2, err := x509.ParseCertificate(cert2.Certificate[0])
+		if err != nil {
+			t.Fatalf("failed to parse second cert: %v", err)
+		}
+
+		// Serial numbers should match (same cert loaded from disk)
+		if x509Cert1.SerialNumber.Cmp(x509Cert2.SerialNumber) != 0 {
+			t.Error("expected same cert to be loaded, but serial numbers differ")
+		}
+	})
+
+	t.Run("creates certs directory if missing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		nestedDir := filepath.Join(tmpDir, "nested", "certs", "dir")
+
+		_, err := loadOrGenerateFallbackCert(nestedDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, err := os.Stat(nestedDir); os.IsNotExist(err) {
+			t.Error("expected nested directory to be created")
+		}
+	})
+}
+
+func TestCertExpiringSoon(t *testing.T) {
+	t.Run("returns true for empty cert", func(t *testing.T) {
+		var emptyCert tls.Certificate
+		if !certExpiringSoon(emptyCert) {
+			t.Error("expected empty cert to be considered expiring")
+		}
+	})
+
+	t.Run("returns false for fresh cert", func(t *testing.T) {
+		// Generate a fresh cert (valid for 1 year)
+		cert, err := generateSelfSignedCert()
+		if err != nil {
+			t.Fatalf("failed to generate cert: %v", err)
+		}
+
+		if certExpiringSoon(cert) {
+			t.Error("expected fresh cert (1 year validity) to not be expiring soon")
+		}
+	})
+
+	t.Run("correctly checks expiry window", func(t *testing.T) {
+		cert, err := generateSelfSignedCert()
+		if err != nil {
+			t.Fatalf("failed to generate cert: %v", err)
+		}
+
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			t.Fatalf("failed to parse cert: %v", err)
+		}
+
+		// Cert should expire in ~365 days, which is > 30 day renewal window
+		timeUntilExpiry := time.Until(x509Cert.NotAfter)
+		if timeUntilExpiry < fallbackCertRenewalWindow {
+			t.Errorf("expected cert to expire in > %v, but expires in %v",
+				fallbackCertRenewalWindow, timeUntilExpiry)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Restrict automatic TLS cert provisioning to only domains with explicit routes configured
- Add RouteWatcher that watches http_route entities and maintains in-memory host set
- Instant lookups (map check) with immediate updates via etcd watch

## Important Consideration
This implementation does NOT allow cert provisioning for domains relying on default routes.
Since default routes are auto-assigned to all servers, this is a behavioral change that
should be discussed. Options include:
- Removing auto-assignment of default routes
- Adding an explicit "allow arbitrary certs" config flag
- Reconsidering the default route concept

## Test plan
- [ ] Deploy app with explicit route, verify cert provisioning works
- [ ] Point unknown domain at server, verify cert is rejected (check logs for warning)
- [ ] Add new route, verify cert can be provisioned immediately (no delay)
- [ ] Remove route, verify cert requests are rejected

Fixes MIR-45