### PR TITLE
Dev environment QoL improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,22 @@ export DO_NOT_TRACK=1
 # Generate a unique session name based on the project directory
 ISO_SESSION ?= dev-$(shell basename "$$(pwd)")
 
+# Extract git info on the host for passing to container builds
+# These handle both regular repos and worktrees
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "dev")
+GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null || echo "")
+GIT_VERSION := $(shell \
+  if git describe --exact-match --tags HEAD 2>/dev/null; then \
+    git describe --exact-match --tags HEAD 2>/dev/null; \
+  elif echo "$(GIT_BRANCH)" | grep -q '^release/'; then \
+    echo "$(GIT_BRANCH)" | sed 's|^release/||'; \
+  elif [ -n "$(GIT_COMMIT)" ]; then \
+    echo "$(GIT_BRANCH):$$(echo $(GIT_COMMIT) | cut -c1-7)"; \
+  else \
+    echo "$(GIT_BRANCH)"; \
+  fi \
+)
+
 # Convert DEV_ENV_FILE relative paths to container paths (/src is the workdir)
 # If path starts with /, use as-is (absolute)
 # If path starts with ./ or is relative, prepend /src/
@@ -38,13 +54,15 @@ dev-shell: ## Open interactive shell in dev environment
 	@./hack/dev-exec bash
 
 dev-server-start: ## Start the miren server (supports DEV_ENV_FILE and DEV_SERVER_FLAGS)
-	./hack/dev-exec --root env DEV_ENV_FILE="$(DEV_ENV_FILE_CONTAINER)" DEV_SERVER_FLAGS="$(DEV_SERVER_FLAGS)" bash hack/dev-server start
+	@./hack/dev-exec --root env DEV_ENV_FILE="$(DEV_ENV_FILE_CONTAINER)" DEV_SERVER_FLAGS="$(DEV_SERVER_FLAGS)" bash hack/dev-server start
+	@./hack/dev-exec --root bash hack/dev-server wait-ready
 
 dev-server-stop: ## Stop the miren server
-	./hack/dev-exec --root bash hack/dev-server stop
+	@./hack/dev-exec --root bash hack/dev-server stop
 
 dev-server-restart: ## Restart the miren server (supports DEV_ENV_FILE and DEV_SERVER_FLAGS)
-	./hack/dev-exec --root env DEV_ENV_FILE="$(DEV_ENV_FILE_CONTAINER)" DEV_SERVER_FLAGS="$(DEV_SERVER_FLAGS)" bash hack/dev-server restart
+	@./hack/dev-exec --root env DEV_ENV_FILE="$(DEV_ENV_FILE_CONTAINER)" DEV_SERVER_FLAGS="$(DEV_SERVER_FLAGS)" bash hack/dev-server restart
+	@./hack/dev-exec --root bash hack/dev-server wait-ready
 
 dev-server-status: ## Check miren server status
 	./hack/dev-exec --root bash hack/dev-server status
@@ -55,7 +73,7 @@ dev-server-logs: ## View miren server logs
 dev-start: ## Start dev environment (internal - use 'dev' instead)
 	@if ! ISO_SESSION=$(ISO_SESSION) iso status 2>&1 | grep -q "Container is running"; then \
 		ISO_SESSION=$(ISO_SESSION) iso start && \
-		ISO_SESSION=$(ISO_SESSION) iso run bash hack/dev.sh; \
+		ISO_SESSION=$(ISO_SESSION) iso run GIT_BRANCH="$(GIT_BRANCH)" GIT_COMMIT="$(GIT_COMMIT)" GIT_VERSION="$(GIT_VERSION)" bash hack/dev.sh; \
 	else \
 		echo "✓ Container already running"; \
 	fi

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,18 +1,41 @@
 #!/bin/bash
 
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-commit=$(git rev-parse HEAD)
-build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# Use env vars if set (for CI/container builds), otherwise extract from git
+# This handles cases where git isn't available (e.g., inside iso container)
+build_date=${BUILD_DATE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
 
-# Check if current commit has a tag
-if git describe --exact-match --tags HEAD 2>/dev/null; then
-  version=$(git describe --exact-match --tags HEAD)
-# Check if on release branch
-elif [[ $current_branch =~ ^release/(.*) ]]; then
-  version="${BASH_REMATCH[1]}"
-# Fall back to branch:commit
+# Try to get git info, but don't fail if git isn't available
+if [ -n "${GIT_BRANCH:-}" ]; then
+  current_branch="$GIT_BRANCH"
+elif current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); then
+  : # got it from git
 else
-  version="$current_branch:$(git rev-parse --short HEAD)"
+  current_branch="dev"
+fi
+
+if [ -n "${GIT_COMMIT:-}" ]; then
+  commit="$GIT_COMMIT"
+elif commit=$(git rev-parse HEAD 2>/dev/null); then
+  : # got it from git
+else
+  commit=""
+fi
+
+# Determine version string
+if [ -n "${GIT_VERSION:-}" ]; then
+  # Explicit version override
+  version="$GIT_VERSION"
+elif version=$(git describe --exact-match --tags HEAD 2>/dev/null); then
+  : # Current commit has a tag
+elif [[ $current_branch =~ ^release/(.*) ]]; then
+  # On release branch
+  version="${BASH_REMATCH[1]}"
+elif [ -n "$commit" ]; then
+  # Fall back to branch:short-commit
+  version="$current_branch:${commit:0:7}"
+else
+  # No git info available
+  version="$current_branch"
 fi
 
 echo "Building version $version"

--- a/hack/dev-server
+++ b/hack/dev-server
@@ -53,6 +53,36 @@ case "${1:-}" in
     fi
     ;;
 
+  wait-ready)
+    # Wait for server to be fully ready (for use in scripts)
+    TIMEOUT=${2:-30}
+    # Poll every 100ms, print dot every second
+    MAX_ITERATIONS=$((TIMEOUT * 10))
+    DOT_INTERVAL=10
+
+    echo -n "Waiting for server to be ready"
+    for i in $(seq 1 "$MAX_ITERATIONS"); do
+      if grep -q "Miren server started" "$LOGFILE" 2>/dev/null; then
+        echo " ready!"
+        exit 0
+      fi
+      # Check if server process died
+      if [ -f "$PIDFILE" ] && ! kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+        echo " failed!"
+        echo "Error: Server process died. Check $LOGFILE"
+        exit 1
+      fi
+      # Print a dot every second for visual feedback
+      if [ $((i % DOT_INTERVAL)) -eq 0 ]; then
+        echo -n "."
+      fi
+      sleep 0.1
+    done
+    echo " timeout!"
+    echo "Error: Server did not become ready within ${TIMEOUT}s. Check $LOGFILE"
+    exit 1
+    ;;
+
   stop)
     if [ ! -f "$PIDFILE" ]; then
       echo "Server not running (no PID file)"
@@ -106,7 +136,7 @@ case "${1:-}" in
     ;;
 
   *)
-    echo "Usage: $0 {start|stop|restart|status|logs}"
+    echo "Usage: $0 {start|stop|restart|status|logs|wait-ready [timeout]}"
     exit 1
     ;;
 esac

--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -16,9 +16,10 @@ chown -R "$HOST_UID:$HOST_GID" /go/build-cache /go/pkg 2>/dev/null || true
 chmod -R 770 /go/build-cache /go/pkg 2>/dev/null || true
 
 echo "Building miren as host user (UID ${ISO_UID})..."
-su -s /bin/bash "$HOST_USER" -c "make bin/miren"
+su -s /bin/bash "$HOST_USER" -c "GIT_BRANCH='$GIT_BRANCH' GIT_COMMIT='$GIT_COMMIT' GIT_VERSION='$GIT_VERSION' bash ./hack/build.sh"
 
-ln -sf "$PWD"/bin/miren /bin/m
+ln -sf "$PWD"/bin/miren /usr/local/bin/miren
+ln -sf "$PWD"/bin/miren /usr/local/bin/m
 
 mkdir -p /var/lib/miren/server
 chown -R "$HOST_UID:$HOST_GID" /var/lib/miren


### PR DESCRIPTION
## Summary
- Fix git version info not appearing in builds when using worktrees
- Wait for server readiness before yielding shell in `make dev`
- Add `miren` command alias (in addition to `m`)

## Test plan
- [ ] Run `make dev` from a worktree and verify version shows branch:commit
- [ ] Verify `make dev` waits for server to be ready before showing shell
- [ ] Verify both `m` and `miren` commands work in dev shell