### PR TITLE
Fix DNS watcher not removing non-RUNNING sandboxes

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -463,12 +463,19 @@ func (s *Server) watchSandboxes(ctx context.Context) {
 }
 
 func (s *Server) handleSandboxUpdate(ctx context.Context, sb *compute_v1alpha.Sandbox, en *entity.Entity) {
+	// Only track RUNNING sandboxes - this matches recoverSandboxes() behavior
+	if sb.Status != compute_v1alpha.RUNNING {
+		// Sandbox is not running - remove from DNS if we were tracking it
+		s.handleSandboxDeleteByID(sb.ID.String())
+		return
+	}
+
 	s.mu.Lock()
 	_, tracked := s.entityToIP[sb.ID.String()]
 	s.mu.Unlock()
 
 	if tracked {
-		// Already tracked, skip
+		// Already tracked and still RUNNING, skip
 		return
 	}
 

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -1,11 +1,14 @@
 package dns
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	compute_v1alpha "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/slogfmt"
 )
 
@@ -96,4 +99,98 @@ func TestDeleteSandboxWithDifferentIPs(t *testing.T) {
 
 	assert.Empty(t, s.lookupAppForIP(ip1), "ip1 should not resolve after deletion")
 	assert.Equal(t, appName, s.lookupAppForIP(ip2), "ip2 should still resolve")
+}
+
+func TestSandboxStatusTransitionRemovesFromDNS(t *testing.T) {
+	// This test verifies that when a sandbox transitions from RUNNING to
+	// STOPPED or DEAD, it is immediately removed from DNS mappings.
+	// Previously, UPDATE events for non-RUNNING sandboxes were ignored,
+	// causing stale IPs to remain in DNS until the entity DELETE (up to 1 hour).
+
+	s := newTestServer(t)
+	ctx := context.Background()
+
+	const (
+		ip        = "10.8.24.30"
+		appName   = "testapp"
+		service   = "web"
+		sandboxID = "sandbox/testapp-web-status-test"
+	)
+
+	// Simulate a sandbox that was previously RUNNING and tracked
+	s.addSandboxMapping(sandboxID, ip, appName, service)
+	assert.Equal(t, appName, s.lookupAppForIP(ip), "sandbox should be tracked initially")
+
+	// Sandbox transitions to STOPPED (e.g., process exited)
+	stoppedSandbox := &compute_v1alpha.Sandbox{
+		ID:     entity.Id(sandboxID),
+		Status: compute_v1alpha.STOPPED,
+	}
+	s.handleSandboxUpdate(ctx, stoppedSandbox, nil)
+
+	// The sandbox should be removed from DNS immediately
+	assert.Empty(t, s.lookupAppForIP(ip),
+		"sandbox should be removed from DNS when status changes to STOPPED")
+
+	// Verify all mappings are cleaned up
+	s.mu.RLock()
+	_, hasEntityMapping := s.entityToIP[sandboxID]
+	_, hasServiceMapping := s.ipToService[ip]
+	s.mu.RUnlock()
+
+	assert.False(t, hasEntityMapping, "entityToIP mapping should be removed")
+	assert.False(t, hasServiceMapping, "ipToService mapping should be removed")
+}
+
+func TestSandboxDeadStatusRemovesFromDNS(t *testing.T) {
+	// Same as above but for DEAD status
+
+	s := newTestServer(t)
+	ctx := context.Background()
+
+	const (
+		ip        = "10.8.24.31"
+		appName   = "testapp"
+		service   = "api"
+		sandboxID = "sandbox/testapp-api-dead-test"
+	)
+
+	s.addSandboxMapping(sandboxID, ip, appName, service)
+	assert.Equal(t, appName, s.lookupAppForIP(ip))
+
+	// Sandbox marked as DEAD (e.g., health check failed)
+	deadSandbox := &compute_v1alpha.Sandbox{
+		ID:     entity.Id(sandboxID),
+		Status: compute_v1alpha.DEAD,
+	}
+	s.handleSandboxUpdate(ctx, deadSandbox, nil)
+
+	assert.Empty(t, s.lookupAppForIP(ip),
+		"sandbox should be removed from DNS when status changes to DEAD")
+}
+
+func TestNonRunningStatusNeverAdded(t *testing.T) {
+	// Sandboxes that are not RUNNING should never be added to DNS,
+	// even if they have network info.
+
+	s := newTestServer(t)
+	ctx := context.Background()
+
+	const (
+		ip        = "10.8.24.32"
+		sandboxID = "sandbox/testapp-pending"
+	)
+
+	// A PENDING sandbox with network info should not be tracked
+	pendingSandbox := &compute_v1alpha.Sandbox{
+		ID:     entity.Id(sandboxID),
+		Status: compute_v1alpha.PENDING,
+		Network: []compute_v1alpha.Network{
+			{Address: ip + "/24"},
+		},
+	}
+	s.handleSandboxUpdate(ctx, pendingSandbox, nil)
+
+	assert.Empty(t, s.lookupAppForIP(ip),
+		"PENDING sandbox should not be added to DNS")
 }


### PR DESCRIPTION
## Summary
- Fix DNS watcher to immediately remove sandbox IPs when status changes to STOPPED or DEAD
- Previously, stale IPs remained in DNS for up to 1 hour until entity garbage collection
- Observed via log lines showing `result_count: 8` for a service with only 1 running instance after repeated deploys