### PR TITLE
Fix sandbox recovery killing all sandboxes on server restart

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -714,7 +714,7 @@ func (c *SandboxController) reattachLogs(ctx context.Context, sb *compute.Sandbo
 		c.Log.Warn("failed to set up task wait during reattach", "id", containerID, "error", err)
 	} else {
 		// Launch goroutine to monitor process exit
-		go c.monitorTaskExit(sb, containerID, exitCh)
+		go c.monitorTaskExit(sb, containerID, task, exitCh)
 		c.Log.Debug("re-established task exit monitoring", "sandbox", sb.ID, "container", containerID)
 	}
 
@@ -1631,7 +1631,7 @@ func (c *SandboxController) bootContainers(
 			c.Log.Warn("failed to set up task wait", "id", cc.ID(), "error", err)
 		} else {
 			// Launch goroutine to monitor process exit
-			go c.monitorTaskExit(sb, cc.ID(), exitCh)
+			go c.monitorTaskExit(sb, cc.ID(), task, exitCh)
 		}
 
 		// Start port monitoring for this container if it has ports
@@ -1647,51 +1647,82 @@ func (c *SandboxController) bootContainers(
 func (c *SandboxController) monitorTaskExit(
 	sb *compute.Sandbox,
 	containerID string,
+	task containerd.Task,
 	exitCh <-chan containerd.ExitStatus,
 ) {
 	c.Log.Debug("monitoring task for exit", "sandbox", sb.ID, "container", containerID)
 
-	select {
-	case exitStatus := <-exitCh:
-		c.Log.Info("container process exited",
-			"sandbox", sb.ID,
-			"container", containerID,
-			"exit_code", exitStatus.ExitCode(),
-			"exit_time", exitStatus.ExitTime(),
-		)
-
-		// Update sandbox status to STOPPED using Patch (only updating Status field)
-		// We use Patch instead of Put since we're only changing one field
-		// STOPPED status triggers cleanup in reconciliation (stopSandbox), which:
-		// - Releases IPs immediately
-		// - Cleans up containers
-		// - Marks as DEAD afterward
-		patchAttrs := entity.New(
-			entity.Ref(entity.DBId, sb.ID),
-			(&compute.Sandbox{
-				Status: compute.STOPPED,
-			}).Encode,
-		)
-
-		ctx := context.Background()
-		result, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
-		if err != nil {
-			if !errors.Is(err, cond.ErrNotFound{}) {
-				c.Log.Error("failed to update sandbox status to STOPPED",
+	for {
+		select {
+		case exitStatus := <-exitCh:
+			// Check if the exit status contains an error. Per containerd docs:
+			// "ExitCode() is only valid if Error() returns nil" and
+			// "If an error is returned, the process may still be running."
+			// This can happen when re-establishing task monitoring after server restart,
+			// where containerd returns an ExitStatus with UnknownExitStatus (255) and
+			// zero exit time because the task state is uncertain.
+			if err := exitStatus.Error(); err != nil {
+				c.Log.Warn("received exit status with error, attempting to re-establish monitoring",
 					"sandbox", sb.ID,
+					"container", containerID,
 					"error", err,
 				)
+				// Try to re-establish monitoring since the process may still be running
+				newExitCh, waitErr := task.Wait(c.topCtx)
+				if waitErr != nil {
+					c.Log.Warn("failed to re-establish task monitoring after error status",
+						"sandbox", sb.ID,
+						"container", containerID,
+						"error", waitErr,
+					)
+					return
+				}
+				exitCh = newExitCh
+				continue
 			}
+
+			c.Log.Info("container process exited",
+				"sandbox", sb.ID,
+				"container", containerID,
+				"exit_code", exitStatus.ExitCode(),
+				"exit_time", exitStatus.ExitTime(),
+			)
+
+			// Update sandbox status to STOPPED using Patch (only updating Status field)
+			// We use Patch instead of Put since we're only changing one field
+			// STOPPED status triggers cleanup in reconciliation (stopSandbox), which:
+			// - Releases IPs immediately
+			// - Cleans up containers
+			// - Marks as DEAD afterward
+			patchAttrs := entity.New(
+				entity.Ref(entity.DBId, sb.ID),
+				(&compute.Sandbox{
+					Status: compute.STOPPED,
+				}).Encode,
+			)
+
+			ctx := context.Background()
+			result, err := c.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
+			if err != nil {
+				if !errors.Is(err, cond.ErrNotFound{}) {
+					c.Log.Error("failed to update sandbox status to STOPPED",
+						"sandbox", sb.ID,
+						"error", err,
+					)
+				}
+				return
+			}
+			if c.writeTracker != nil && result.HasRevision() {
+				c.writeTracker.RecordWrite(result.Revision())
+			}
+
+			c.Log.Info("marked sandbox as STOPPED due to process exit, cleanup will be triggered by reconciliation", "sandbox", sb.ID)
+			return
+
+		case <-c.topCtx.Done():
+			c.Log.Debug("task monitoring cancelled", "sandbox", sb.ID, "container", containerID)
 			return
 		}
-		if c.writeTracker != nil && result.HasRevision() {
-			c.writeTracker.RecordWrite(result.Revision())
-		}
-
-		c.Log.Info("marked sandbox as STOPPED due to process exit, cleanup will be triggered by reconciliation", "sandbox", sb.ID)
-
-	case <-c.topCtx.Done():
-		c.Log.Debug("task monitoring cancelled", "sandbox", sb.ID, "container", containerID)
 	}
 }
 

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -13,9 +13,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
+	apitypes "github.com/containerd/containerd/api/types"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
@@ -1591,4 +1593,167 @@ func TestSandbox(t *testing.T) {
 		r.Equal(compute.RUNNING, finalSb.Status, "sandbox should transition from PENDING to RUNNING when containers are healthy")
 	})
 
+}
+
+// mockTask implements containerd.Task for testing monitorTaskExit
+type mockTask struct {
+	waitCalls int
+	waitErr   error
+	waitCh    chan containerd.ExitStatus
+}
+
+func (m *mockTask) ID() string                  { return "mock-task" }
+func (m *mockTask) Pid() uint32                 { return 1234 }
+func (m *mockTask) Start(context.Context) error { return nil }
+func (m *mockTask) Delete(context.Context, ...containerd.ProcessDeleteOpts) (*containerd.ExitStatus, error) {
+	return nil, nil
+}
+func (m *mockTask) Kill(context.Context, syscall.Signal, ...containerd.KillOpts) error { return nil }
+func (m *mockTask) Wait(context.Context) (<-chan containerd.ExitStatus, error) {
+	m.waitCalls++
+	if m.waitCalls > 1 {
+		// After the first call, return an error to simulate failed re-establishment
+		return nil, m.waitErr
+	}
+	return m.waitCh, nil
+}
+func (m *mockTask) CloseIO(context.Context, ...containerd.IOCloserOpts) error { return nil }
+func (m *mockTask) Resize(ctx context.Context, w, h uint32) error             { return nil }
+func (m *mockTask) IO() cio.IO                                                { return nil }
+func (m *mockTask) Status(context.Context) (containerd.Status, error) {
+	return containerd.Status{}, nil
+}
+func (m *mockTask) Pause(context.Context) error  { return nil }
+func (m *mockTask) Resume(context.Context) error { return nil }
+func (m *mockTask) Exec(context.Context, string, *specs.Process, cio.Creator) (containerd.Process, error) {
+	return nil, nil
+}
+func (m *mockTask) Pids(context.Context) ([]containerd.ProcessInfo, error) { return nil, nil }
+func (m *mockTask) Checkpoint(context.Context, ...containerd.CheckpointTaskOpts) (containerd.Image, error) {
+	return nil, nil
+}
+func (m *mockTask) Update(context.Context, ...containerd.UpdateTaskOpts) error { return nil }
+func (m *mockTask) LoadProcess(context.Context, string, cio.Attach) (containerd.Process, error) {
+	return nil, nil
+}
+func (m *mockTask) Metrics(context.Context) (*apitypes.Metric, error) { return nil, nil }
+func (m *mockTask) Spec(context.Context) (*oci.Spec, error)           { return nil, nil }
+
+// TestMonitorTaskExitIgnoresErrorStatus verifies that monitorTaskExit does not
+// mark a sandbox as STOPPED when the exit status contains an error.
+// This is critical for server restart scenarios where containerd may return
+// spurious exit events with UnknownExitStatus (255) and zero exit time.
+func TestMonitorTaskExitIgnoresErrorStatus(t *testing.T) {
+	r := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	testDeps, cleanup := testutils.NewTestDeps()
+	defer cleanup()
+
+	co, err := newSandboxController(testDeps)
+	r.NoError(err)
+	defer co.Close()
+
+	r.NoError(co.Init(ctx))
+
+	// Create a sandbox entity with RUNNING status
+	id := entity.Id(idgen.GenNS("sb"))
+
+	var sb compute.Sandbox
+	sb.ID = id
+	sb.Status = compute.RUNNING
+	sb.Labels = append(sb.Labels, "runtime.computer/app=test-app")
+
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetId(id.String())
+	rpcE.SetAttrs(entity.New(entity.DBId, id, sb.Encode).Attrs())
+	_, err = co.EAC.Put(ctx, &rpcE)
+	r.NoError(err)
+
+	// Create an exit channel and send an ExitStatus WITH an error
+	// This simulates what happens during server restart when containerd
+	// returns spurious exit events
+	exitCh := make(chan containerd.ExitStatus, 1)
+	testErr := fmt.Errorf("simulated containerd error during restart")
+	exitStatus := containerd.NewExitStatus(containerd.UnknownExitStatus, time.Time{}, testErr)
+	exitCh <- *exitStatus
+
+	// Create a mock task that will fail to re-establish monitoring
+	// Set waitCalls to 1 so the first call to Wait() from inside monitorTaskExit
+	// (which happens when trying to re-establish after the error status)
+	// will return an error immediately
+	task := &mockTask{
+		waitCalls: 1,
+		waitErr:   fmt.Errorf("task not found"),
+	}
+
+	// Call monitorTaskExit - it should ignore the error status and fail to re-establish
+	co.monitorTaskExit(&sb, "test-container", task, exitCh)
+
+	// Give a moment for any async operations
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the sandbox status was NOT changed to STOPPED
+	result, err := co.EAC.Get(ctx, id.String())
+	r.NoError(err)
+
+	var checkSb compute.Sandbox
+	checkSb.Decode(result.Entity().Entity())
+	r.Equal(compute.RUNNING, checkSb.Status, "sandbox should remain RUNNING when exit status has an error")
+}
+
+// TestMonitorTaskExitHandlesValidExit verifies that monitorTaskExit correctly
+// marks a sandbox as STOPPED when receiving a valid exit status (no error).
+func TestMonitorTaskExitHandlesValidExit(t *testing.T) {
+	r := require.New(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	testDeps, cleanup := testutils.NewTestDeps()
+	defer cleanup()
+
+	co, err := newSandboxController(testDeps)
+	r.NoError(err)
+	defer co.Close()
+
+	r.NoError(co.Init(ctx))
+
+	// Create a sandbox entity with RUNNING status
+	id := entity.Id(idgen.GenNS("sb"))
+
+	var sb compute.Sandbox
+	sb.ID = id
+	sb.Status = compute.RUNNING
+	sb.Labels = append(sb.Labels, "runtime.computer/app=test-app")
+
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetId(id.String())
+	rpcE.SetAttrs(entity.New(entity.DBId, id, sb.Encode).Attrs())
+	_, err = co.EAC.Put(ctx, &rpcE)
+	r.NoError(err)
+
+	// Create an exit channel and send a valid ExitStatus (no error)
+	exitCh := make(chan containerd.ExitStatus, 1)
+	exitStatus := containerd.NewExitStatus(0, time.Now(), nil)
+	exitCh <- *exitStatus
+
+	// Create a mock task (not used for valid exits, but required by interface)
+	task := &mockTask{waitCh: exitCh}
+
+	// Call monitorTaskExit - it should process the valid exit and mark as STOPPED
+	co.monitorTaskExit(&sb, "test-container", task, exitCh)
+
+	// Give a moment for the patch operation
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the sandbox status was changed to STOPPED
+	result, err := co.EAC.Get(ctx, id.String())
+	r.NoError(err)
+
+	var checkSb compute.Sandbox
+	checkSb.Decode(result.Entity().Entity())
+	r.Equal(compute.STOPPED, checkSb.Status, "sandbox should be STOPPED after valid exit event")
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/containerd/cgroups/v3 v3.0.5
 	github.com/containerd/console v1.0.4
 	github.com/containerd/containerd v1.7.23
+	github.com/containerd/containerd/api v1.8.0
 	github.com/containerd/containerd/v2 v2.0.2
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/log v0.1.0
@@ -191,7 +192,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.4.5 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
-	github.com/containerd/containerd/api v1.8.0 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect


### PR DESCRIPTION
## Summary

Fixes bug where all sandboxes were killed and relaunched on miren server restart instead of being recovered.

Root cause: containerd returns ExitStatus events with errors (UnknownExitStatus=255, zero exit time) when re-establishing task monitoring after restart. The `monitorTaskExit` function wasn't checking `ExitStatus.Error()` before acting on exit events.

Per [containerd docs](https://pkg.go.dev/github.com/containerd/containerd/v2/client#ExitStatus.Result):

> An error may be returned here which indicates there was an error at some point while waiting for the exit status. It does not signify an error with the process itself. **If an error is returned, the process may still be running.**

The fix adds error checking and re-establishes monitoring when spurious error events are received.