### PR TITLE
chown during copy to avoid OCI layer duplication

### DIFF
--- a/pkg/stackbuild/bun.go
+++ b/pkg/stackbuild/bun.go
@@ -100,8 +100,6 @@ func (s *BunStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error
 
 	state = s.applyOnBuild(state, opts)
 
-	state = s.chownApp(state)
-
 	return &state, nil
 }
 

--- a/pkg/stackbuild/golang.go
+++ b/pkg/stackbuild/golang.go
@@ -131,7 +131,10 @@ func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
 	// Install git for private dependencies
 	state := h.apkAdd(base, "git", "ca-certificates")
 
-	// Copy the rest of the application code
+	// Add app user before copying code so copyApp can set ownership
+	state = s.addAppUser(state)
+
+	// Copy the application code (now owned by app user)
 	appState := h.copyApp(state, localCtx)
 
 	// Use the pre-computed cmdDir from Init()
@@ -161,9 +164,7 @@ func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
 
 	state = state.AddEnv("APP", "/bin/app")
 
-	state = s.addAppUser(state)
 	state = s.applyOnBuild(state, opts)
-	state = s.chownApp(state)
 
 	return &state, nil
 }

--- a/pkg/stackbuild/node.go
+++ b/pkg/stackbuild/node.go
@@ -133,8 +133,6 @@ func (s *NodeStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 
 	state = s.applyOnBuild(state, opts)
 
-	state = s.chownApp(state)
-
 	return &state, nil
 }
 

--- a/pkg/stackbuild/python.go
+++ b/pkg/stackbuild/python.go
@@ -277,8 +277,6 @@ func (s *PythonStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, er
 
 	state = s.applyOnBuild(state, opts)
 
-	state = s.chownApp(state)
-
 	return &state, nil
 }
 

--- a/pkg/stackbuild/ruby.go
+++ b/pkg/stackbuild/ruby.go
@@ -162,8 +162,6 @@ func (s *RubyStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 
 	base = s.applyOnBuild(base, opts)
 
-	base = s.chownApp(base)
-
 	s.AddEnv("BUNDLE_PATH", "/usr/local/bundle")
 	s.AddEnv("BUNDLE_WITHOUT", "development")
 	s.AddEnv("RACK_ENV", "production")

--- a/pkg/stackbuild/rust.go
+++ b/pkg/stackbuild/rust.go
@@ -135,7 +135,6 @@ func (s *RustStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 	state = state.AddEnv("APP", "/bin/app")
 
 	state = s.applyOnBuild(state, opts)
-	state = s.chownApp(state)
 
 	return &state, nil
 }

--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -272,6 +272,12 @@ func (h *highlevelBuilder) bootsnap(cur llb.State, args ...string) llb.State {
 	).State
 }
 
+// appChown specifies ownership for app files (UID 2010, GID 2011)
+var appChown = llb.ChownOpt{
+	User:  &llb.UserOpt{UID: 2010},
+	Group: &llb.UserOpt{UID: 2011},
+}
+
 func (h *highlevelBuilder) copyApp(cur, mnt llb.State) llb.State {
 	origin := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)
 	return cur.File(
@@ -282,6 +288,7 @@ func (h *highlevelBuilder) copyApp(cur, mnt llb.State) llb.State {
 			AllowWildcard:       true,
 			AllowEmptyWildcard:  true,
 			CreatedTime:         &origin,
+			ChownOpt:            &appChown,
 		}),
 		llb.WithCustomName("[phase] Copying application code"),
 	)


### PR DESCRIPTION
Turns out our `chown -R app:app /app` after copying code was silently doubling our layer size.

In overlayfs, changing file metadata (even just ownership) [triggers a full copy-up of the file contents](https://docs.kernel.org/filesystems/overlayfs.html#non-standard-behavior):

> The copy_up process... creates the object with the same metadata... and then if the object is a file, the data is copied from the lower to the upper filesystem.

So we were storing every app file twice - once from the copy, once from the chown.

The fix: use buildkit's `ChownOpt` to set ownership during the copy itself. One operation, one layer.

There's a kernel feature called `metacopy` (4.19+) that would let overlayfs do metadata-only changes, but it's not on by default in container runtimes. See [containerd#6310](https://github.com/containerd/containerd/issues/6310) for the saga.

**What changed:**
- `copyApp()` now sets ownership via `ChownOpt`
- Removed post-copy `chownApp()` from all stacks
- Moved `addAppUser()` before `copyApp()` in Go (it was after, oops)
- Kept `chownApp()` for Python/uv - it needs to chown before `uv sync` runs as the app user

Stacked on #548.