### PR TITLE
fix(stackbuild): improve stack detection robustness

### DIFF
--- a/pkg/stackbuild/bun.go
+++ b/pkg/stackbuild/bun.go
@@ -30,6 +30,10 @@ func (s *BunStack) Detect() bool {
 		s.Event("file", "bun.lock", "Found bun.lock (Bun runtime)")
 		return true
 	}
+	if s.hasFile("bun.lockb") {
+		s.Event("file", "bun.lockb", "Found bun.lockb (Bun runtime, legacy)")
+		return true
+	}
 	if s.detectInFile("Procfile", `web:\s+bun`) {
 		s.Event("file", "Procfile", "Procfile references bun")
 		return true
@@ -76,7 +80,7 @@ func (s *BunStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error
 	base = s.addAppUser(base)
 
 	// Copy package files first for better caching
-	pkgFiles := []string{"package.json", "bun.lock"}
+	pkgFiles := []string{"package.json", "bun.lock", "bun.lockb"}
 	depState := base.File(llb.Copy(localCtx, "/", "/app", &llb.CopyInfo{
 		IncludePatterns: pkgFiles,
 	}))

--- a/pkg/stackbuild/golang.go
+++ b/pkg/stackbuild/golang.go
@@ -72,7 +72,7 @@ func (s *GoStack) commandDir(opts BuildOptions) string {
 		return ""
 	}
 
-	if len(entries) == 1 {
+	if len(entries) == 1 && entries[0].IsDir() {
 		return filepath.Join("cmd", entries[0].Name())
 	}
 

--- a/pkg/stackbuild/python.go
+++ b/pkg/stackbuild/python.go
@@ -59,8 +59,17 @@ func (s *PythonStack) Detect() bool {
 	}
 
 	if s.hasFile("pyproject.toml") {
-		s.packageManager = pythonPkgPoetry
-		s.Event("file", "pyproject.toml", "Found pyproject.toml (poetry)")
+		// Check if this is actually a Poetry project by looking for [tool.poetry]
+		if data, err := s.readFile("pyproject.toml"); err == nil {
+			if strings.Contains(string(data), "[tool.poetry]") {
+				s.packageManager = pythonPkgPoetry
+				s.Event("file", "pyproject.toml", "Found pyproject.toml (poetry)")
+				return true
+			}
+		}
+		// pyproject.toml without poetry - use pip
+		s.packageManager = pythonPkgPip
+		s.Event("file", "pyproject.toml", "Found pyproject.toml (pip)")
 		return true
 	}
 
@@ -402,10 +411,7 @@ func (s *PythonStack) WebCommand() string {
 		if s.wsgiModule != "" {
 			return "gunicorn " + s.wsgiModule + " -b 0.0.0.0:$PORT"
 		}
-		// Fallback: check common entry points
-		if s.hasFile("app.py") {
-			return "gunicorn app:app -b 0.0.0.0:$PORT"
-		}
+		// Fallback to common entry point
 		return "gunicorn app:app -b 0.0.0.0:$PORT"
 	}
 

--- a/pkg/stackbuild/ruby.go
+++ b/pkg/stackbuild/ruby.go
@@ -91,6 +91,10 @@ func (s *RubyStack) Gemfile() ([]byte, []byte, error) {
 	gemfileLockPath := "Gemfile.lock"
 	gemfileLockContent, err := os.ReadFile(filepath.Join(s.dir, gemfileLockPath))
 	if err != nil {
+		if os.IsNotExist(err) {
+			// Gemfile.lock is optional - proceed without it
+			return gemfileContent, nil, nil
+		}
 		return gemfileContent, nil, err
 	}
 


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from the stackbuild refactor PR:

- **Bun**: Add `bun.lockb` (legacy binary format) as fallback for pre-Bun 1.2 projects
- **Python**: Check for `[tool.poetry]` section before assuming Poetry—`pyproject.toml` is used by pip, flit, hatch, setuptools, etc.
- **Ruby**: Handle missing `Gemfile.lock` gracefully instead of failing gem detection
- **Go**: Guard against non-directory entries when `cmd/` has a single item (e.g., a README file)
- **Python**: Remove redundant conditional in `WebCommand` that returned the same value

## Test plan

- [ ] Verify Bun detection works with both `bun.lock` and `bun.lockb`
- [ ] Verify Python projects with `pyproject.toml` but no `[tool.poetry]` use pip
- [ ] Verify Ruby projects without `Gemfile.lock` still detect Rails/gems from Gemfile
- [ ] Verify Go projects with non-directory files in `cmd/` don't break