### PR TITLE
Docs: changelog catchup and storage docs restructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,10 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code.
+      description: |
+        Please copy and paste any relevant log output. This will be automatically formatted into code.
+
+        Tip: Run `miren debug bundle` to collect system info, logs, and container state into a single archive for troubleshooting.
       render: shell
 
   - type: input

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -2,6 +2,33 @@
 
 All notable changes to Miren Runtime will be documented in this file.
 
+## Unreleased
+*main*
+
+**Features**
+
+- **Automatic image garbage collection** - Container images are now automatically garbage collected to prevent disk exhaustion. Images are kept if less than 30 days old or within the last 20 releases per app. Garbage collection runs weekly or immediately when disk usage exceeds 80%. ([#544](https://github.com/mirendev/runtime/pull/544))
+- **Deploy-time environment variables** - Set environment variables atomically with your deployment using `miren deploy -e KEY=VALUE` or `-s SECRET=value` for sensitive values. Supports reading from files with `@file` syntax and interactive prompts. ([#521](https://github.com/mirendev/runtime/pull/521))
+- **Graceful shutdown during redeploy** - Apps now receive proper graceful shutdown time during redeploy instead of being force-killed. Configure per-service with `shutdown_timeout` in app.toml (default 10 seconds). ([#520](https://github.com/mirendev/runtime/pull/520))
+- **`miren deploy cancel`** - Cancel stuck in-progress deployments without waiting for the 30-minute lock expiry. ([#517](https://github.com/mirendev/runtime/pull/517))
+- **`miren debug bundle`** - New diagnostic command that collects system info, logs, container state, and process info into a tar.gz archive for troubleshooting. ([#531](https://github.com/mirendev/runtime/pull/531))
+- **Domain allow list for TLS** - Automatic TLS certificate provisioning is now restricted to domains with explicitly configured routes, preventing certificate issuance for arbitrary domains pointed at the server. ([#542](https://github.com/mirendev/runtime/pull/542))
+
+**Improvements**
+
+- **Better app history display** - The `miren app history` command now shows deployment IDs (useful for `deploy cancel`) and improved status formatting. ([#529](https://github.com/mirendev/runtime/pull/529), [#532](https://github.com/mirendev/runtime/pull/532))
+
+**Bug Fixes**
+
+- **Fixed server restart killing all sandboxes** - Sandbox recovery no longer incorrectly kills all sandboxes when the server restarts. ([#546](https://github.com/mirendev/runtime/pull/546))
+- **Fixed disk lease transfers** - Disk leases are now properly released when sandboxes stop, allowing new sandboxes to acquire them. ([#516](https://github.com/mirendev/runtime/pull/516))
+- **Fixed sandbox exec issues** - Fixed panic when running `sandbox exec` without a TTY and fixed wrong entrypoint being applied to service containers. ([#515](https://github.com/mirendev/runtime/pull/515), [#518](https://github.com/mirendev/runtime/pull/518))
+- **Fixed deployment panic handling** - Panics during deployment are now properly marked as failed instead of leaving deployments stuck. ([#513](https://github.com/mirendev/runtime/pull/513))
+- **Fixed WebSocket 502 errors** - WebSocket connections no longer fail with 502 Bad Gateway. ([#507](https://github.com/mirendev/runtime/pull/507))
+- **Fixed cluster switch for multi-identity setups** - Improved identity handling and UX when switching between clusters. ([#535](https://github.com/mirendev/runtime/pull/535))
+
+---
+
 ## v0.2.1
 *2025-12-19*
 

--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -18,9 +18,19 @@ The Miren CLI (`miren`) provides commands for managing applications and deployme
 
 | Flag | Description |
 |------|-------------|
+| `-e KEY=VALUE` | Set environment variable for this deployment. Can be repeated. Use `KEY=@file` to read from file, or `KEY` alone to prompt interactively. |
+| `-s KEY=VALUE` | Set sensitive environment variable (masked in output). Same syntax as `-e`. |
 | `--analyze` | Analyze the app without building or deploying. Shows detected stack, services, and configuration. |
 | `--force` | Force deployment even if no changes detected |
 | `--wait` | Wait for deployment to complete |
+
+#### Cancel a Deployment
+
+```bash
+miren deploy cancel <deployment-id>
+```
+
+Cancel a stuck in-progress deployment. Get the deployment ID from `miren app history`.
 
 ### Server Install
 
@@ -81,6 +91,11 @@ The Miren CLI (`miren`) provides commands for managing applications and deployme
 - `miren debug disk lease-status` - Show status of a disk lease
 - `miren debug disk lease-release` - Release a disk lease
 - `miren debug disk mounts` - List mounted disks
+
+### Diagnostics
+
+- `miren debug bundle` - Collect system info, logs, and container state into a tar.gz archive for troubleshooting
+- `miren doctor` - Run diagnostic checks on your Miren setup
 
 ### Utility Commands
 

--- a/docs/docs/cloud-updates.md
+++ b/docs/docs/cloud-updates.md
@@ -1,0 +1,15 @@
+# Miren Cloud Updates
+
+Updates to Miren Cloud, the hosted management service for Miren clusters.
+
+## January 2026
+
+- Fixed registration expiration display showing incorrect dates
+
+## December 2025
+
+*Developer Preview launch!*
+
+- **Organizations and RBAC** - Clusters are organized under organizations with role-based access control
+- **Cluster DNS hostnames** - Clusters get auto-provisioned DNS hostnames with easy copy-to-clipboard in the UI
+- **Cluster registration** - Register your Miren cluster with the cloud for centralized management

--- a/docs/docs/disks.md
+++ b/docs/docs/disks.md
@@ -2,18 +2,78 @@
 sidebar_position: 4
 ---
 
-# Disks
+# Persistent Storage
 
-Miren Disks provide persistent storage for your applications. Unlike ephemeral container storage that disappears when your app restarts, disks preserve your data across deployments, restarts, and even cluster migrations.
+Miren provides two options for persistent storage: **Local Shared Storage** (recommended for most use cases) and **Miren Disks** (experimental, for advanced scenarios).
 
-## Why Use Disks?
+## Local Shared Storage
 
-- **Persistent data**: Store databases, uploads, cache files, or any data that needs to survive restarts
+Every Miren app automatically gets persistent storage at `/miren/data/local`. This is the simplest way to persist data across restarts and deployments.
+
+### How It Works
+
+- **Automatic**: No configuration needed—just write to `/miren/data/local`
+- **Persistent**: Data survives container restarts and redeployments
+- **Shared**: All containers within your app share the same storage
+- **Host-local**: Data lives on the server's filesystem
+
+### Example: SQLite Database
+
+```javascript
+const sqlite3 = require('sqlite3');
+const path = require('path');
+
+// Database persists at /miren/data/local/app.db
+const dbPath = path.join('/miren/data/local', 'app.db');
+const db = new sqlite3.Database(dbPath);
+```
+
+### Example: File Uploads
+
+```python
+import os
+
+UPLOAD_DIR = '/miren/data/local/uploads'
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+def save_upload(file):
+    path = os.path.join(UPLOAD_DIR, file.filename)
+    file.save(path)
+```
+
+### When to Use Local Shared Storage
+
+- SQLite databases
+- File uploads and user content
+- Application cache
+- Session storage
+- Any data that needs to persist across restarts
+
+### Limitations
+
+- **Host-local**: Data is tied to the server. If you move your app to a different server, you'll need to migrate the data manually.
+- **No automatic backups**: Unlike Miren Disks, local storage isn't replicated to Miren Cloud.
+- **Shared access**: All containers in your app can read/write simultaneously—your application needs to handle concurrent access (SQLite handles this well when configured with `PRAGMA journal_mode=WAL`).
+
+---
+
+## Miren Disks
+
+:::info Experimental Feature
+We're excited about Miren Disks—cloud-synced storage that travels with your app is a powerful capability we're actively building toward. That said, we're still working out the kinks, so for data you care about today, [Local Shared Storage](#local-shared-storage) is the safer choice.
+
+We'd love to have you try Disks and share your feedback as we work toward making this a production-grade feature!
+:::
+
+Miren Disks provide cloud-synced persistent storage with automatic replication to Miren Cloud. This enables data portability across clusters but adds complexity.
+
+### Why Use Disks?
+
 - **Portable across clusters**: Your disk data is automatically synced to Miren Cloud and can be restored on any cluster
 - **Automatic backups**: Data is replicated to Miren Cloud, giving you peace of mind
-- **Simple configuration**: Just specify a disk name and mount path in your app config
+- **Configurable size and filesystem**: Specify exactly what you need
 
-## How Disks Work
+### How Disks Work
 
 When you configure a disk for your application:
 
@@ -27,15 +87,15 @@ When your app stops or restarts:
 - Data remains on the disk
 - Your next instance can acquire the lease and continue where it left off
 
-## How Much Storage Does Miren Provide?
+### How Much Storage Does Miren Provide?
 
 During the Developer Preview, we're providing unmetered storage. The intention is to implement a free tier
-and usage based pricing on the storage. We'll be sure to communicate often and clearly how we intend
+and usage-based pricing on the storage. We'll be sure to communicate often and clearly how we intend
 to proceed.
 
 The feature is designed to keep our costs low, and our intention is to pass that low cost on to our users.
 
-## Configuring Disks
+### Configuring Disks
 
 Add a disk to your application by including a `disks` section in your service configuration in `.miren/app.toml`:
 
@@ -50,7 +110,7 @@ size_gb = 10
 filesystem = "ext4"
 ```
 
-### Configuration Options
+#### Configuration Options
 
 | Option | Required | Description |
 |--------|----------|-------------|
@@ -62,7 +122,7 @@ filesystem = "ext4"
 
 *`size_gb` is required when the disk doesn't already exist. If the disk exists, this field is ignored.
 
-## Example: PostgreSQL with Persistent Storage
+### Example: PostgreSQL with Persistent Storage
 
 ```toml
 [services.db]
@@ -83,7 +143,7 @@ size_gb = 20
 filesystem = "ext4"
 ```
 
-## Example: File Upload Storage
+### Example: File Upload Storage
 
 ```toml
 [services.web]
@@ -95,20 +155,20 @@ mount_path = "/app/uploads"
 size_gb = 50
 ```
 
-## Disk Lifecycle
+### Disk Lifecycle
 
-### Creation
+#### Creation
 
 Disks are automatically created when your app first deploys with a volume configuration that includes `size_gb`. The disk is provisioned with the specified size and filesystem.
 
-### Reuse
+#### Reuse
 
-If you deploy an app with a `disk_name` that already exists, Miren will attach the existing disk instead of creating a new one. This allows you to:
+If you deploy an app with a `name` that matches an existing disk, Miren will attach that disk instead of creating a new one. This allows you to:
 - Share data between app versions
 - Preserve data across complete redeployments
 - Reference disks created by other apps
 
-### Deletion
+#### Deletion
 
 Disks are **not** automatically deleted when you delete an app. This is intentional - your data is precious. To delete a disk:
 
@@ -116,7 +176,7 @@ Disks are **not** automatically deleted when you delete an app. This is intentio
 miren debug disk delete -i <disk-id>
 ```
 
-## Viewing Disks in Miren Cloud
+### Viewing Disks in Miren Cloud
 
 When connected to Miren Cloud, you can view and monitor your disks:
 
@@ -126,7 +186,7 @@ When connected to Miren Cloud, you can view and monitor your disks:
 
 Visit [miren.cloud](https://miren.cloud) and navigate to your cluster to view disk details.
 
-## Inspecting Disks via CLI
+### Inspecting Disks via CLI
 
 List all disks:
 
@@ -148,28 +208,28 @@ miren debug disk lease-list
 
 See [CLI Reference - Disk Commands](/cli/disk) for complete command documentation.
 
-## Important Considerations
+### Important Considerations
 
-### One Instance per Disk
+#### One Instance per Disk
 
 Disks use exclusive leasing - only one app instance can mount a disk at a time. This ensures data consistency but means:
 
 - Multiple replicas of your app cannot share the same disk
 - If you need shared storage, use separate disks per instance or external storage
 
-### Disk Sizing
+#### Disk Sizing
 
-- Disks use a "thin provisioning" technology, enabling it to only allocated storage when needed
+- Disks use thin provisioning, so storage is only allocated as needed
 - Choose a size that accommodates growth
 
-### Filesystem Choice
+#### Filesystem Choice
 
 - **ext4**: Best general-purpose choice, widely compatible
 - **xfs**: Better for large files and high-throughput workloads
 
 **NOTE:** Your server must have the mkfs tools to format the disk types.
 
-## Next Steps
+### Next Steps
 
 - [Getting Started](/getting-started) - Deploy your first app
 - [CLI Reference - Disk Commands](/cli/disk) - Complete disk CLI reference

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -174,6 +174,7 @@ Each service can configure:
 | `port` | Port the web service listens on | 3000 (web only) |
 | `env` | Service-specific environment variables | (none) |
 | `concurrency` | Scaling configuration | See [Scaling](/scaling) |
+| `concurrency.shutdown_timeout` | Time to wait for graceful shutdown during redeploy | `10s` |
 | `disks` | Persistent disk attachments | (none) |
 
 ### Environment Variables

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -52,6 +52,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'changelog',
+        'cloud-updates',
         'support',
         'conduct',
         {


### PR DESCRIPTION
## Summary

It's been a while since v0.2.1 and we've shipped a lot! This PR catches up the docs:

- Adds an "Unreleased" section to the changelog so we can maintain rolling notes and just flip the header when we cut a release
- Introduces a Miren Cloud Updates page with a lighter monthly format (since it's continuously deployed SaaS, not versioned releases)
- Documents new CLI features like deploy-time env vars and deploy cancel

Also restructures the storage docs: Local Shared Storage (`/miren/data/local`) is now the recommended path for persistence, with Miren Disks marked as experimental while we work toward making it production-grade.