### PR TITLE
Automate changelog update in release script

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 #   hack/release.sh v0.1.0           # Preview release
 #   hack/release.sh v1.0.0           # GA release
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHANGELOG="$REPO_ROOT/docs/docs/changelog.md"
+
 VERSION="${1:-}"
 
 if [ -z "$VERSION" ]; then
@@ -62,16 +66,31 @@ if git rev-parse "$VERSION" >/dev/null 2>&1; then
   exit 1
 fi
 
-# Determine release type
+# Determine release type and whether to update changelog
+UPDATE_CHANGELOG=true
 RELEASE_TYPE=""
 if [[ "$VERSION" =~ ^v0\.0\.0-test\. ]]; then
   RELEASE_TYPE="Test release"
+  UPDATE_CHANGELOG=false
 elif [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
   RELEASE_TYPE="Prerelease"
+  UPDATE_CHANGELOG=false
 elif [[ "$VERSION" =~ ^v0\. ]]; then
   RELEASE_TYPE="Preview release"
 else
   RELEASE_TYPE="GA release"
+fi
+
+# Validate changelog has Unreleased section (for releases that update it)
+if [ "$UPDATE_CHANGELOG" = true ]; then
+  if [ ! -f "$CHANGELOG" ]; then
+    echo "Error: Changelog not found at $CHANGELOG"
+    exit 1
+  fi
+  if ! grep -q "^## Unreleased" "$CHANGELOG"; then
+    echo "Error: Changelog missing '## Unreleased' section"
+    exit 1
+  fi
 fi
 
 # Show what we're about to do
@@ -81,6 +100,11 @@ echo "Creating $RELEASE_TYPE: $VERSION"
 echo "======================================"
 echo "Branch: $CURRENT_BRANCH"
 echo "Commit: $(git rev-parse --short HEAD)"
+if [ "$UPDATE_CHANGELOG" = true ]; then
+  echo "Changelog: Will update Unreleased → $VERSION"
+else
+  echo "Changelog: Skipped (test/prerelease)"
+fi
 echo ""
 
 # Ask for confirmation
@@ -89,6 +113,44 @@ echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
   echo "Aborted"
   exit 1
+fi
+
+# Update changelog if this is a real release
+if [ "$UPDATE_CHANGELOG" = true ]; then
+  echo ""
+  echo "Updating changelog..."
+
+  RELEASE_DATE=$(date +%Y-%m-%d)
+  TEMP_CHANGELOG=$(mktemp)
+  trap '[[ -n "$TEMP_CHANGELOG" && -e "$TEMP_CHANGELOG" ]] && rm -f "$TEMP_CHANGELOG"' EXIT
+
+  # Copy header (everything before "## Unreleased")
+  sed -n '1,/^## Unreleased$/{ /^## Unreleased$/!p }' "$CHANGELOG" > "$TEMP_CHANGELOG"
+
+  # Add fresh empty Unreleased section
+  cat >> "$TEMP_CHANGELOG" << 'EOF'
+## Unreleased
+*main*
+
+---
+
+EOF
+
+  # Append rest of changelog, converting old Unreleased to new version
+  sed -n '/^## Unreleased$/,$ {
+    s/^## Unreleased$/## '"$VERSION"'/
+    s/^\*main\*$/*'"$RELEASE_DATE"'*/
+    p
+  }' "$CHANGELOG" >> "$TEMP_CHANGELOG"
+
+  mv "$TEMP_CHANGELOG" "$CHANGELOG"
+  TEMP_CHANGELOG=""  # Clear so trap doesn't try to remove moved file
+
+  # Commit the changelog update
+  git add "$CHANGELOG"
+  git commit -m "Release $VERSION"
+
+  echo "✓ Changelog updated and committed"
 fi
 
 # Create annotated tag
@@ -102,8 +164,11 @@ echo ""
 echo "✓ Created annotated tag: $VERSION"
 echo ""
 
-# Push the tag
-echo "Pushing tag to origin..."
+# Push the commit (if we made one) and tag
+echo "Pushing to origin..."
+if [ "$UPDATE_CHANGELOG" = true ]; then
+  git push origin main
+fi
 git push origin "$VERSION"
 
 echo ""


### PR DESCRIPTION
When releasing, we had a small "mutex" problem: make a PR to update the changelog, merge it, then quickly tag before anything else lands. If something slips in after merge but before tag, the changelog is incomplete.

This eliminates that window by having the release script handle the changelog atomically. When you run `hack/release.sh v0.3.0`, it now:

1. Converts the `## Unreleased` section to `## v0.3.0` with today's date
2. Adds a fresh empty `## Unreleased` section at the top
3. Commits that change
4. Tags the commit
5. Pushes both together

Test releases (`v0.0.0-test.*`) and prereleases skip the changelog update since they're not user-facing.

The confirmation prompt shows you what's about to happen:
```
======================================
Creating Preview release: v0.3.0
======================================
Branch: main
Commit: abc1234
Changelog: Will update Unreleased → v0.3.0

Continue? (y/N)
```