### PR TITLE
saga: implement saga framework foundation (RFD-35)

### DIFF
--- a/api/saga/saga.go
+++ b/api/saga/saga.go
@@ -1,0 +1,3 @@
+package saga
+
+//go:generate go run ../../pkg/entity/cmd/schemagen -input schema.yml -output saga_v1alpha/schema.gen.go -pkg saga_v1alpha

--- a/api/saga/saga_v1alpha/schema.gen.go
+++ b/api/saga/saga_v1alpha/schema.gen.go
@@ -1,0 +1,164 @@
+package saga_v1alpha
+
+import (
+	entity "miren.dev/runtime/pkg/entity"
+	schema "miren.dev/runtime/pkg/entity/schema"
+)
+
+const (
+	SagaDefinitionNameId    = entity.Id("dev.miren.saga/saga.definition_name")
+	SagaDefinitionVersionId = entity.Id("dev.miren.saga/saga.definition_version")
+	SagaErrorId             = entity.Id("dev.miren.saga/saga.error")
+	SagaExecutedActionsId   = entity.Id("dev.miren.saga/saga.executed_actions")
+	SagaExecutionOrderId    = entity.Id("dev.miren.saga/saga.execution_order")
+	SagaInitialInputsId     = entity.Id("dev.miren.saga/saga.initial_inputs")
+	SagaStatusId            = entity.Id("dev.miren.saga/saga.status")
+	SagaStatusPendingId     = entity.Id("dev.miren.saga/status.pending")
+	SagaStatusRunningId     = entity.Id("dev.miren.saga/status.running")
+	SagaStatusUndoingId     = entity.Id("dev.miren.saga/status.undoing")
+	SagaStatusCompletedId   = entity.Id("dev.miren.saga/status.completed")
+	SagaStatusFailedId      = entity.Id("dev.miren.saga/status.failed")
+)
+
+type Saga struct {
+	ID                entity.Id  `json:"id"`
+	DefinitionName    string     `cbor:"definition_name,omitempty" json:"definition_name,omitempty"`
+	DefinitionVersion int64      `cbor:"definition_version,omitempty" json:"definition_version,omitempty"`
+	Error             string     `cbor:"error,omitempty" json:"error,omitempty"`
+	ExecutedActions   []byte     `cbor:"executed_actions,omitempty" json:"executed_actions,omitempty"`
+	ExecutionOrder    []byte     `cbor:"execution_order,omitempty" json:"execution_order,omitempty"`
+	InitialInputs     []byte     `cbor:"initial_inputs,omitempty" json:"initial_inputs,omitempty"`
+	Status            SagaStatus `cbor:"status,omitempty" json:"status,omitempty"`
+}
+
+type SagaStatus string
+
+const (
+	PENDING   SagaStatus = "status.pending"
+	RUNNING   SagaStatus = "status.running"
+	UNDOING   SagaStatus = "status.undoing"
+	COMPLETED SagaStatus = "status.completed"
+	FAILED    SagaStatus = "status.failed"
+)
+
+var sagastatusFromId = map[entity.Id]SagaStatus{SagaStatusPendingId: PENDING, SagaStatusRunningId: RUNNING, SagaStatusUndoingId: UNDOING, SagaStatusCompletedId: COMPLETED, SagaStatusFailedId: FAILED}
+var sagastatusToId = map[SagaStatus]entity.Id{PENDING: SagaStatusPendingId, RUNNING: SagaStatusRunningId, UNDOING: SagaStatusUndoingId, COMPLETED: SagaStatusCompletedId, FAILED: SagaStatusFailedId}
+
+func (o *Saga) Decode(e entity.AttrGetter) {
+	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(SagaDefinitionNameId); ok && a.Value.Kind() == entity.KindString {
+		o.DefinitionName = a.Value.String()
+	}
+	if a, ok := e.Get(SagaDefinitionVersionId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.DefinitionVersion = a.Value.Int64()
+	}
+	if a, ok := e.Get(SagaErrorId); ok && a.Value.Kind() == entity.KindString {
+		o.Error = a.Value.String()
+	}
+	if a, ok := e.Get(SagaExecutedActionsId); ok && a.Value.Kind() == entity.KindBytes {
+		o.ExecutedActions = a.Value.Bytes()
+	}
+	if a, ok := e.Get(SagaExecutionOrderId); ok && a.Value.Kind() == entity.KindBytes {
+		o.ExecutionOrder = a.Value.Bytes()
+	}
+	if a, ok := e.Get(SagaInitialInputsId); ok && a.Value.Kind() == entity.KindBytes {
+		o.InitialInputs = a.Value.Bytes()
+	}
+	if a, ok := e.Get(SagaStatusId); ok && a.Value.Kind() == entity.KindId {
+		o.Status = sagastatusFromId[a.Value.Id()]
+	}
+}
+
+func (o *Saga) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindSaga)
+}
+
+func (o *Saga) ShortKind() string {
+	return "saga"
+}
+
+func (o *Saga) Kind() entity.Id {
+	return KindSaga
+}
+
+func (o *Saga) EntityId() entity.Id {
+	return o.ID
+}
+
+func (o *Saga) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.DefinitionName) {
+		attrs = append(attrs, entity.String(SagaDefinitionNameId, o.DefinitionName))
+	}
+	if !entity.Empty(o.DefinitionVersion) {
+		attrs = append(attrs, entity.Int64(SagaDefinitionVersionId, o.DefinitionVersion))
+	}
+	if !entity.Empty(o.Error) {
+		attrs = append(attrs, entity.String(SagaErrorId, o.Error))
+	}
+	if len(o.ExecutedActions) > 0 {
+		attrs = append(attrs, entity.Bytes(SagaExecutedActionsId, o.ExecutedActions))
+	}
+	if len(o.ExecutionOrder) > 0 {
+		attrs = append(attrs, entity.Bytes(SagaExecutionOrderId, o.ExecutionOrder))
+	}
+	if len(o.InitialInputs) > 0 {
+		attrs = append(attrs, entity.Bytes(SagaInitialInputsId, o.InitialInputs))
+	}
+	if a, ok := sagastatusToId[o.Status]; ok {
+		attrs = append(attrs, entity.Ref(SagaStatusId, a))
+	}
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindSaga))
+	return
+}
+
+func (o *Saga) Empty() bool {
+	if !entity.Empty(o.DefinitionName) {
+		return false
+	}
+	if !entity.Empty(o.DefinitionVersion) {
+		return false
+	}
+	if !entity.Empty(o.Error) {
+		return false
+	}
+	if len(o.ExecutedActions) > 0 {
+		return false
+	}
+	if len(o.ExecutionOrder) > 0 {
+		return false
+	}
+	if len(o.InitialInputs) > 0 {
+		return false
+	}
+	if o.Status != "" {
+		return false
+	}
+	return true
+}
+
+func (o *Saga) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("definition_name", "dev.miren.saga/saga.definition_name", schema.Doc("The name of the registered saga definition"), schema.Indexed)
+	sb.Int64("definition_version", "dev.miren.saga/saga.definition_version", schema.Doc("The version of the definition when this execution started"))
+	sb.String("error", "dev.miren.saga/saga.error", schema.Doc("Error message if the saga failed"))
+	sb.Bytes("executed_actions", "dev.miren.saga/saga.executed_actions", schema.Doc("JSON-encoded map of action name to ActionResult"))
+	sb.Bytes("execution_order", "dev.miren.saga/saga.execution_order", schema.Doc("JSON-encoded array of action names in execution order"))
+	sb.Bytes("initial_inputs", "dev.miren.saga/saga.initial_inputs", schema.Doc("JSON-encoded initial inputs for the saga"))
+	sb.Singleton("dev.miren.saga/status.pending")
+	sb.Singleton("dev.miren.saga/status.running")
+	sb.Singleton("dev.miren.saga/status.undoing")
+	sb.Singleton("dev.miren.saga/status.completed")
+	sb.Singleton("dev.miren.saga/status.failed")
+	sb.Ref("status", "dev.miren.saga/saga.status", schema.Doc("Current execution status"), schema.Indexed, schema.Choices(SagaStatusPendingId, SagaStatusRunningId, SagaStatusUndoingId, SagaStatusCompletedId, SagaStatusFailedId))
+}
+
+var (
+	KindSaga = entity.Id("dev.miren.saga/kind.saga")
+	Schema   = entity.Id("dev.miren.saga/schema.v1alpha")
+)
+
+func init() {
+	schema.Register("dev.miren.saga", "v1alpha", func(sb *schema.SchemaBuilder) {
+		(&Saga{}).InitSchema(sb)
+	})
+	schema.RegisterEncodedSchema("dev.miren.saga", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x84\x93\xdfJ\xf40\x10\xc5_\xe3\xfbD\x11T\xbc\xac\xf8D%ۙd\x87M'!\x7fJ\xfa\x04>\x87\xb8\xfa\x88^K\x92\xe2b̮7e8s\xceo\xa6!9\x02\x8b\x19\x19p\x19frȃ\x17J\xe0\x81\x18\xfck\xfa\xf7S~\xcar\xa9>J\xca7\xedS\xf4S\x82\x99\x05qÕ\x92P\x83\x7fy\xdb\x11\xa4\xfbNz\x00\x94\xc4\x14\xc8\xf0\x98'\x941\xa6\x15\xc3jQ\xfa\xe0\x88U!=\xfeAZ\xd0y2\\`\xae\xa3g\xdeD\x1c\n\xec\x7f\x0f\x86\xce\x19W\xf2X\xcbv\x85\x87n*\xe1\x14\x03\xc2(\xa6<\xcf\x17\x80\xfd\xa5f\x16\xeeր\xfe\xfc\xb9\xd4P^\xda8\xc0\xba\x8ai\xc5\x06t\xd7\x03\x95\x7f\x17z$\xb61ԍ\xb8\xd1N\x98c\xc6\\\xf50>\x88\x10k\\nu\x8e\x01r\x9c\x0f\xf93.BG\xf4\xefR\n\xd2\b麥\x94\xd0P\xbb\xca\"\x03\xb1J7}\xd7\xd6V.2_\xb0mm\x15\x19\xcc\x05\xdb֦\xc9\xccVc@H\xb7}\xe3\xb7Am7E-\xcfB۽\xd0\xd6\xd1,\xdc:\xe6\xcb\x0e9\xd2:\x0e~o\\\x18\xeb;*\x8e\xf3\x8f\xe9\v\x00\x00\xff\xff\x01\x00\x00\xff\xff\x84\xdaF\x10\x83\x03\x00\x00"))
+}

--- a/api/saga/schema.yml
+++ b/api/saga/schema.yml
@@ -1,0 +1,34 @@
+domain: dev.miren.saga
+version: v1alpha
+kinds:
+  saga:
+    definition_name:
+      type: string
+      doc: The name of the registered saga definition
+      indexed: true
+
+    definition_version:
+      type: int
+      doc: The version of the definition when this execution started
+
+    status:
+      type: enum
+      doc: Current execution status
+      choices: [pending, running, undoing, completed, failed]
+      indexed: true
+
+    initial_inputs:
+      type: bytes
+      doc: JSON-encoded initial inputs for the saga
+
+    executed_actions:
+      type: bytes
+      doc: JSON-encoded map of action name to ActionResult
+
+    execution_order:
+      type: bytes
+      doc: JSON-encoded array of action names in execution order
+
+    error:
+      type: string
+      doc: Error message if the saga failed

--- a/pkg/saga/action.go
+++ b/pkg/saga/action.go
@@ -1,0 +1,112 @@
+package saga
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Action represents a single step in a saga. Actions are stateless and
+// created by factories that are registered at application startup.
+// All runtime data flows through ActionInputs.
+type Action interface {
+	// Execute performs the action and returns an output that can be used
+	// by subsequent actions. The output must be JSON-serializable.
+	Execute(ctx context.Context, inputs ActionInputs) (output any, err error)
+
+	// Undo reverses the action. It receives the same inputs and the output
+	// that was produced by Execute. Undo should be idempotent.
+	Undo(ctx context.Context, inputs ActionInputs, output any) error
+}
+
+// ActionInputs provides access to initial saga inputs and outputs from
+// prior actions. All outputs live in a flat namespace.
+type ActionInputs interface {
+	// Get retrieves an input by key, deserializing it into target.
+	// Returns an error if the key doesn't exist or deserialization fails.
+	Get(key string, target any) error
+
+	// Has checks if an input exists (for optional inputs).
+	Has(key string) bool
+
+	// Keys returns all available input keys.
+	Keys() []string
+}
+
+// inputs implements ActionInputs by combining initial inputs with action outputs.
+type inputs struct {
+	initial map[string]any
+	outputs map[string]json.RawMessage
+}
+
+// newInputs creates an ActionInputs from initial inputs and prior action outputs.
+func newInputs(initial map[string]any, outputs map[string]json.RawMessage) ActionInputs {
+	return &inputs{
+		initial: initial,
+		outputs: outputs,
+	}
+}
+
+// Get retrieves a value by key, checking outputs first then initial inputs.
+func (i *inputs) Get(key string, target any) error {
+	// Check outputs first (from prior actions)
+	if raw, ok := i.outputs[key]; ok {
+		if err := json.Unmarshal(raw, target); err != nil {
+			return fmt.Errorf("deserializing output %q: %w", key, err)
+		}
+		return nil
+	}
+
+	// Check initial inputs
+	if val, ok := i.initial[key]; ok {
+		// Initial inputs may already be the correct type or need JSON round-trip
+		switch v := val.(type) {
+		case json.RawMessage:
+			if err := json.Unmarshal(v, target); err != nil {
+				return fmt.Errorf("deserializing input %q: %w", key, err)
+			}
+			return nil
+		default:
+			// For values that came from Go code (not persistence), do JSON round-trip
+			data, err := json.Marshal(v)
+			if err != nil {
+				return fmt.Errorf("serializing input %q: %w", key, err)
+			}
+			if err := json.Unmarshal(data, target); err != nil {
+				return fmt.Errorf("deserializing input %q: %w", key, err)
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("input %q not found", key)
+}
+
+// Has returns true if the key exists in outputs or initial inputs.
+func (i *inputs) Has(key string) bool {
+	if _, ok := i.outputs[key]; ok {
+		return true
+	}
+	_, ok := i.initial[key]
+	return ok
+}
+
+// Keys returns all available input keys.
+func (i *inputs) Keys() []string {
+	seen := make(map[string]bool)
+	var keys []string
+
+	for k := range i.outputs {
+		if !seen[k] {
+			keys = append(keys, k)
+			seen[k] = true
+		}
+	}
+	for k := range i.initial {
+		if !seen[k] {
+			keys = append(keys, k)
+			seen[k] = true
+		}
+	}
+	return keys
+}

--- a/pkg/saga/definition.go
+++ b/pkg/saga/definition.go
@@ -1,0 +1,328 @@
+package saga
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Definition describes a saga's structure - its actions and their dependencies.
+// Definitions are stateless and registered at application startup.
+type Definition struct {
+	// Name uniquely identifies this saga definition.
+	Name string
+
+	// Version is incremented for breaking changes. Defaults to 1.
+	Version int
+
+	// Actions in this saga, keyed by action name.
+	Actions map[string]*ActionNode
+
+	// executionOrder is the topologically sorted order for execution.
+	executionOrder []string
+
+	// dependencies is stored to inject into context during execution.
+	dependencies []any
+}
+
+// ActionNode describes a single action within a saga definition.
+type ActionNode struct {
+	// Name is the unique name of this action within the saga.
+	Name string
+
+	// Action is the stateless action implementation.
+	Action Action
+
+	// InputKeys are the saga keys this action reads from.
+	InputKeys []string
+
+	// OutputKeys are the saga keys this action writes to.
+	OutputKeys []string
+
+	// Dependencies are action names that must complete before this action.
+	// Computed from InputKeys and other actions' OutputKeys.
+	Dependencies []string
+}
+
+// Builder provides a fluent API for defining sagas.
+type Builder struct {
+	name         string
+	version      int
+	actions      []*pendingAction
+	dependencies []any
+	err          error
+}
+
+// pendingAction holds action info during builder construction.
+type pendingAction struct {
+	name     string
+	execute  any
+	undo     any
+	typedAct *typedAction
+}
+
+// Define starts building a new saga definition with the given name.
+func Define(name string) *Builder {
+	return &Builder{
+		name:    name,
+		version: 1,
+	}
+}
+
+// Version sets the definition version (defaults to 1).
+func (b *Builder) Version(v int) *Builder {
+	b.version = v
+	return b
+}
+
+// With adds dependencies that will be injected into the context during execution.
+// These can be retrieved using From[T](ctx) within action functions.
+func (b *Builder) With(deps ...any) *Builder {
+	b.dependencies = append(b.dependencies, deps...)
+	return b
+}
+
+// ActionBuilder provides a fluent API for defining a single action.
+type ActionBuilder struct {
+	builder *Builder
+	pending *pendingAction
+}
+
+// Action adds an action to the saga using a typed execute function.
+// The function signature must be: func(ctx context.Context, in InType) (OutType, error)
+func (b *Builder) Action(name string, execute any) *ActionBuilder {
+	pending := &pendingAction{
+		name:    name,
+		execute: execute,
+	}
+	b.actions = append(b.actions, pending)
+	return &ActionBuilder{
+		builder: b,
+		pending: pending,
+	}
+}
+
+// Undo sets the undo function for the action.
+// The function signature must be: func(ctx context.Context, in InType, out OutType) error
+func (ab *ActionBuilder) Undo(undo any) *Builder {
+	ab.pending.undo = undo
+	return ab.builder
+}
+
+// Register validates and registers the saga definition with the global registry.
+// Returns an error if validation fails (cycles, duplicate outputs, type mismatches).
+func (b *Builder) Register() error {
+	return b.RegisterTo(globalRegistry)
+}
+
+// RegisterTo validates and registers the saga definition with the given registry.
+// Useful for testing to avoid global state.
+func (b *Builder) RegisterTo(r *Registry) error {
+	if b.err != nil {
+		return b.err
+	}
+
+	def, err := b.Build()
+	if err != nil {
+		return err
+	}
+
+	return r.Register(def)
+}
+
+// Build constructs and validates the Definition without registering it.
+// Useful for testing.
+func (b *Builder) Build() (*Definition, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+
+	def := &Definition{
+		Name:         b.name,
+		Version:      b.version,
+		Actions:      make(map[string]*ActionNode),
+		dependencies: b.dependencies,
+	}
+
+	// Track which keys are produced by which actions
+	outputProducers := make(map[string]string)
+
+	// First pass: wrap all actions and collect their input/output keys
+	for _, pending := range b.actions {
+		if pending.undo == nil {
+			return nil, fmt.Errorf("action %q has no undo function", pending.name)
+		}
+
+		typed, err := wrapTypedAction(pending.name, pending.execute, pending.undo)
+		if err != nil {
+			return nil, fmt.Errorf("action %q: %w", pending.name, err)
+		}
+		pending.typedAct = typed
+
+		// Check for duplicate output keys
+		for _, key := range typed.outputKeys() {
+			if producer, exists := outputProducers[key]; exists {
+				return nil, fmt.Errorf("output key %q produced by both %q and %q",
+					key, producer, pending.name)
+			}
+			outputProducers[key] = pending.name
+		}
+
+		def.Actions[pending.name] = &ActionNode{
+			Name:       pending.name,
+			Action:     typed,
+			InputKeys:  typed.inputKeys(),
+			OutputKeys: typed.outputKeys(),
+		}
+	}
+
+	// Second pass: compute dependencies from input/output keys
+	for _, node := range def.Actions {
+		deps := make(map[string]bool)
+		for _, inputKey := range node.InputKeys {
+			if producer, exists := outputProducers[inputKey]; exists {
+				if producer != node.Name {
+					deps[producer] = true
+				}
+			}
+			// If no producer exists, it must come from InitialInputs (validated at runtime)
+		}
+		for dep := range deps {
+			node.Dependencies = append(node.Dependencies, dep)
+		}
+	}
+
+	// Third pass: topological sort to get execution order and detect cycles
+	order, err := topologicalSort(def.Actions)
+	if err != nil {
+		return nil, err
+	}
+	def.executionOrder = order
+
+	return def, nil
+}
+
+// topologicalSort returns actions in dependency order, or an error if there's a cycle.
+func topologicalSort(actions map[string]*ActionNode) ([]string, error) {
+	// Kahn's algorithm - compute in-degree (number of dependencies) for each node
+	inDegree := make(map[string]int)
+	for _, node := range actions {
+		inDegree[node.Name] = len(node.Dependencies)
+	}
+
+	// Find all nodes with no dependencies
+	var queue []string
+	for name, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, name)
+		}
+	}
+
+	var order []string
+	for len(queue) > 0 {
+		// Take from queue
+		name := queue[0]
+		queue = queue[1:]
+		order = append(order, name)
+
+		// Reduce in-degree of dependents
+		for depName, node := range actions {
+			for _, dep := range node.Dependencies {
+				if dep == name {
+					inDegree[depName]--
+					if inDegree[depName] == 0 {
+						queue = append(queue, depName)
+					}
+				}
+			}
+		}
+	}
+
+	if len(order) != len(actions) {
+		return nil, fmt.Errorf("dependency cycle detected in saga definition")
+	}
+
+	return order, nil
+}
+
+// Registry holds registered saga definitions.
+type Registry struct {
+	mu          sync.RWMutex
+	definitions map[string]*Definition
+}
+
+// NewRegistry creates a new empty registry.
+// Useful for testing to avoid global state.
+func NewRegistry() *Registry {
+	return &Registry{
+		definitions: make(map[string]*Definition),
+	}
+}
+
+// globalRegistry is the default registry used by Define().Register().
+var globalRegistry = NewRegistry()
+
+// Register adds a definition to the registry.
+func (r *Registry) Register(def *Definition) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.definitions[def.Name]; exists {
+		return fmt.Errorf("saga %q already registered", def.Name)
+	}
+
+	r.definitions[def.Name] = def
+	return nil
+}
+
+// Get retrieves a definition by name.
+func (r *Registry) Get(name string) (*Definition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	def, ok := r.definitions[name]
+	return def, ok
+}
+
+// GetDefinition retrieves a saga definition from the global registry.
+func GetDefinition(name string) (*Definition, bool) {
+	return globalRegistry.Get(name)
+}
+
+// contextKey is used to store dependencies in context.
+type contextKey struct {
+	typ string
+}
+
+// injectDependencies adds all dependencies to the context.
+func injectDependencies(ctx context.Context, deps []any) context.Context {
+	for _, dep := range deps {
+		key := contextKey{typ: fmt.Sprintf("%T", dep)}
+		ctx = context.WithValue(ctx, key, dep)
+	}
+	return ctx
+}
+
+// From retrieves a dependency of type T from the context.
+// Panics if the dependency is not found.
+func From[T any](ctx context.Context) T {
+	var zero T
+	key := contextKey{typ: fmt.Sprintf("%T", zero)}
+	val := ctx.Value(key)
+	if val == nil {
+		panic(fmt.Sprintf("saga dependency %T not found in context", zero))
+	}
+	return val.(T)
+}
+
+// TryFrom retrieves a dependency of type T from the context.
+// Returns the zero value and false if not found.
+func TryFrom[T any](ctx context.Context) (T, bool) {
+	var zero T
+	key := contextKey{typ: fmt.Sprintf("%T", zero)}
+	val := ctx.Value(key)
+	if val == nil {
+		return zero, false
+	}
+	return val.(T), true
+}

--- a/pkg/saga/definition.go
+++ b/pkg/saga/definition.go
@@ -3,6 +3,9 @@ package saga
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
 	"sync"
 )
 
@@ -90,7 +93,33 @@ type ActionBuilder struct {
 
 // Action adds an action to the saga using a typed execute function.
 // The function signature must be: func(ctx context.Context, in InType) (OutType, error)
-func (b *Builder) Action(name string, execute any) *ActionBuilder {
+//
+// Can be called two ways:
+//   - Action(GetBread) - name derived from function name ("getbread")
+//   - Action("custom-name", GetBread) - explicit name
+func (b *Builder) Action(args ...any) *ActionBuilder {
+	var name string
+	var execute any
+
+	switch len(args) {
+	case 1:
+		// Action(fn) - derive name from function
+		execute = args[0]
+		name = funcName(execute)
+	case 2:
+		// Action("name", fn) - explicit name
+		var ok bool
+		name, ok = args[0].(string)
+		if !ok {
+			b.err = fmt.Errorf("Action first argument must be a string name or a function")
+			return &ActionBuilder{builder: b, pending: &pendingAction{}}
+		}
+		execute = args[1]
+	default:
+		b.err = fmt.Errorf("Action requires 1 or 2 arguments")
+		return &ActionBuilder{builder: b, pending: &pendingAction{}}
+	}
+
 	pending := &pendingAction{
 		name:    name,
 		execute: execute,
@@ -100,6 +129,45 @@ func (b *Builder) Action(name string, execute any) *ActionBuilder {
 		builder: b,
 		pending: pending,
 	}
+}
+
+// funcName extracts a clean function name for use as an action name.
+// "github.com/foo/bar.GetBread" -> "get-bread"
+// "github.com/foo/bar.(*Type).Method" -> "method"
+func funcName(fn any) string {
+	ptr := reflect.ValueOf(fn).Pointer()
+	fullName := runtime.FuncForPC(ptr).Name()
+
+	// Get just the function/method name after the last dot
+	name := fullName
+	if idx := strings.LastIndex(fullName, "."); idx >= 0 {
+		name = fullName[idx+1:]
+	}
+
+	// Handle method receivers: "(*Type).Method" or "Type.Method"
+	if idx := strings.LastIndex(name, ")"); idx >= 0 {
+		name = name[idx+1:]
+		name = strings.TrimPrefix(name, ".")
+	}
+
+	// Strip "-fm" suffix that Go adds for method values
+	name = strings.TrimSuffix(name, "-fm")
+
+	return camelToKebab(name)
+}
+
+// camelToKebab converts CamelCase to kebab-case.
+// "GetBread" -> "get-bread"
+// "AddHTTPHeader" -> "add-http-header"
+func camelToKebab(s string) string {
+	var result strings.Builder
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			result.WriteByte('-')
+		}
+		result.WriteRune(r)
+	}
+	return strings.ToLower(result.String())
 }
 
 // Undo sets the undo function for the action.

--- a/pkg/saga/definition.go
+++ b/pkg/saga/definition.go
@@ -80,8 +80,28 @@ func (b *Builder) Version(v int) *Builder {
 
 // Using adds dependencies that will be injected into the context during execution.
 // These can be retrieved using Get[T](ctx) within action functions.
+// Note: Dependencies are keyed by their concrete type. To key by an interface type,
+// use UsingAs[T] instead.
 func (b *Builder) Using(deps ...any) *Builder {
 	b.dependencies = append(b.dependencies, deps...)
+	return b
+}
+
+// typedDep wraps a dependency with its intended key type.
+type typedDep struct {
+	keyType string
+	value   any
+}
+
+// UsingAs adds a dependency keyed by type T, allowing retrieval via Get[T](ctx).
+// This is useful for injecting implementations that should be retrieved by interface type.
+// For example: UsingAs[MyInterface](b, impl) allows Get[MyInterface](ctx).
+func UsingAs[T any](b *Builder, dep T) *Builder {
+	var zero T
+	b.dependencies = append(b.dependencies, typedDep{
+		keyType: fmt.Sprintf("%T", zero),
+		value:   dep,
+	})
 	return b
 }
 
@@ -380,8 +400,13 @@ type contextKey struct {
 // injectDependencies adds all dependencies to the context.
 func injectDependencies(ctx context.Context, deps []any) context.Context {
 	for _, dep := range deps {
-		key := contextKey{typ: fmt.Sprintf("%T", dep)}
-		ctx = context.WithValue(ctx, key, dep)
+		if td, ok := dep.(typedDep); ok {
+			// Use the explicitly specified key type
+			ctx = context.WithValue(ctx, contextKey{typ: td.keyType}, td.value)
+		} else {
+			// Use the concrete type as key
+			ctx = context.WithValue(ctx, contextKey{typ: fmt.Sprintf("%T", dep)}, dep)
+		}
 	}
 	return ctx
 }

--- a/pkg/saga/definition.go
+++ b/pkg/saga/definition.go
@@ -75,9 +75,9 @@ func (b *Builder) Version(v int) *Builder {
 	return b
 }
 
-// With adds dependencies that will be injected into the context during execution.
-// These can be retrieved using From[T](ctx) within action functions.
-func (b *Builder) With(deps ...any) *Builder {
+// Using adds dependencies that will be injected into the context during execution.
+// These can be retrieved using Get[T](ctx) within action functions.
+func (b *Builder) Using(deps ...any) *Builder {
 	b.dependencies = append(b.dependencies, deps...)
 	return b
 }
@@ -303,9 +303,9 @@ func injectDependencies(ctx context.Context, deps []any) context.Context {
 	return ctx
 }
 
-// From retrieves a dependency of type T from the context.
+// Get retrieves a dependency of type T from the context.
 // Panics if the dependency is not found.
-func From[T any](ctx context.Context) T {
+func Get[T any](ctx context.Context) T {
 	var zero T
 	key := contextKey{typ: fmt.Sprintf("%T", zero)}
 	val := ctx.Value(key)
@@ -315,9 +315,9 @@ func From[T any](ctx context.Context) T {
 	return val.(T)
 }
 
-// TryFrom retrieves a dependency of type T from the context.
+// TryGet retrieves a dependency of type T from the context.
 // Returns the zero value and false if not found.
-func TryFrom[T any](ctx context.Context) (T, bool) {
+func TryGet[T any](ctx context.Context) (T, bool) {
 	var zero T
 	key := contextKey{typ: fmt.Sprintf("%T", zero)}
 	val := ctx.Value(key)

--- a/pkg/saga/definition.go
+++ b/pkg/saga/definition.go
@@ -105,6 +105,11 @@ func (b *Builder) Action(args ...any) *ActionBuilder {
 	case 1:
 		// Action(fn) - derive name from function
 		execute = args[0]
+		t := reflect.TypeOf(execute)
+		if t == nil || t.Kind() != reflect.Func {
+			b.err = fmt.Errorf("Action argument must be a function")
+			return &ActionBuilder{builder: b, pending: &pendingAction{}}
+		}
 		name = funcName(execute)
 	case 2:
 		// Action("name", fn) - explicit name
@@ -158,7 +163,7 @@ func funcName(fn any) string {
 
 // camelToKebab converts CamelCase to kebab-case.
 // "GetBread" -> "get-bread"
-// "AddHTTPHeader" -> "add-http-header"
+// "AddHTTPHeader" -> "add-h-t-t-p-header" (consecutive caps get individual hyphens)
 func camelToKebab(s string) string {
 	var result strings.Builder
 	for i, r := range s {
@@ -226,6 +231,11 @@ func (b *Builder) Build() (*Definition, error) {
 			return nil, fmt.Errorf("action %q: %w", pending.name, err)
 		}
 		pending.typedAct = typed
+
+		// Check for duplicate action names
+		if _, exists := def.Actions[pending.name]; exists {
+			return nil, fmt.Errorf("duplicate action name %q", pending.name)
+		}
 
 		// Check for duplicate output keys
 		for _, key := range typed.outputKeys() {

--- a/pkg/saga/definition.go
+++ b/pkg/saga/definition.go
@@ -120,6 +120,11 @@ func (b *Builder) Action(args ...any) *ActionBuilder {
 			return &ActionBuilder{builder: b, pending: &pendingAction{}}
 		}
 		execute = args[1]
+		t := reflect.TypeOf(execute)
+		if t == nil || t.Kind() != reflect.Func {
+			b.err = fmt.Errorf("Action second argument must be a function")
+			return &ActionBuilder{builder: b, pending: &pendingAction{}}
+		}
 	default:
 		b.err = fmt.Errorf("Action requires 1 or 2 arguments")
 		return &ActionBuilder{builder: b, pending: &pendingAction{}}

--- a/pkg/saga/example_build_test.go
+++ b/pkg/saga/example_build_test.go
@@ -1,0 +1,843 @@
+// Example: Application Build & Deploy
+//
+// This example demonstrates realistic saga patterns using a simplified version
+// of our build/deploy pipeline. Unlike the sandwich example, this one exercises
+// the actual entity system (via in-memory server) and shows patterns you'd use
+// in production code.
+//
+// Key concepts demonstrated:
+//
+//   - Entity integration: Actions create/update/delete real entities (App,
+//     AppVersion, Artifact) using the in-memory entity server from testutils
+//
+//   - Non-serializable data: The SourceStager pattern shows how to handle
+//     io.Reader streams that can't be serialized into the saga log. The stream
+//     is registered before the saga starts, and the first action (StageSource)
+//     extracts it to durable storage. See RFD-35 "Handling Non-Serializable Data".
+//
+//   - Find-or-create with conditional undo: ResolveArtifact looks up an existing
+//     artifact by digest before creating one. The output includes a "Created" flag
+//     so UndoResolveArtifact knows whether to delete (we created it) or skip
+//     (it already existed).
+//
+//   - Previous state capture: ActivateVersion records the previous active version
+//     in its output so UndoActivateVersion can restore it.
+//
+// The saga models these steps from servers/build/build.go:
+//
+//	StageSource     → Extract tar stream to durable storage
+//	BuildImage      → Run BuildKit to produce container image
+//	ResolveArtifact → Find or create Artifact entity by manifest digest
+//	CreateVersion   → Create AppVersion entity with config
+//	ActivateVersion → Set as App's active version
+//
+// Run the tests:
+//
+//	go test -v ./pkg/saga/... -run TestBuildSaga
+//
+// See example_sandwich_test.go for a simpler introduction to saga mechanics.
+package saga_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	apiserver "miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// --- Stubbed Collaborators ---
+
+// SourceStager handles non-serializable stream data at saga boundaries.
+// This implements the pattern from the RFD for handling io.Reader streams:
+//  1. Entry point registers stream with a generated ID
+//  2. First action extracts stream to durable storage
+//  3. On recovery, action checks for staged path instead of stream
+type SourceStager struct {
+	mu sync.Mutex
+
+	// Active streams waiting to be staged (keyed by stream ID)
+	// These are ephemeral - lost on crash, which is fine because
+	// the saga will fail at StageSource and compensate
+	streams map[string]io.Reader
+
+	// Staged source directories (keyed by stream ID)
+	// These are "durable" - in real impl would be on disk
+	staged map[string]string
+
+	// Track operations for testing
+	events []string
+}
+
+func NewSourceStager() *SourceStager {
+	return &SourceStager{
+		streams: make(map[string]io.Reader),
+		staged:  make(map[string]string),
+	}
+}
+
+// RegisterStream registers a stream before starting a saga.
+// Returns a stream ID that can be passed as saga input.
+// The stream itself is NOT serializable - only the ID is.
+func (s *SourceStager) RegisterStream(streamID string, r io.Reader) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.streams[streamID] = r
+	s.events = append(s.events, fmt.Sprintf("Registered stream %s", streamID))
+}
+
+// Stage reads from the registered stream and "writes" to durable storage.
+// Returns the path where source was staged.
+// If the stream was already staged (recovery case), returns existing path.
+func (s *SourceStager) Stage(streamID string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if already staged (recovery case)
+	if path, ok := s.staged[streamID]; ok {
+		s.events = append(s.events, fmt.Sprintf("Found existing staged source at %s", path))
+		return path, nil
+	}
+
+	// Get the stream
+	stream, ok := s.streams[streamID]
+	if !ok {
+		// Stream not found - either never registered or we crashed and lost it
+		return "", fmt.Errorf("stream %s not found (may have been lost in crash)", streamID)
+	}
+
+	// "Read" from the stream (in real impl: extract tar to temp dir)
+	// For stub, we just consume it and pretend we wrote it somewhere
+	_, err := io.Copy(io.Discard, stream)
+	if err != nil {
+		return "", fmt.Errorf("failed to read stream: %w", err)
+	}
+
+	// Remove from active streams, add to staged
+	delete(s.streams, streamID)
+	path := fmt.Sprintf("/tmp/staged/%s", streamID)
+	s.staged[streamID] = path
+
+	s.events = append(s.events, fmt.Sprintf("Staged stream %s to %s", streamID, path))
+	return path, nil
+}
+
+// Cleanup removes staged source (for undo)
+func (s *SourceStager) Cleanup(streamID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if path, ok := s.staged[streamID]; ok {
+		delete(s.staged, streamID)
+		s.events = append(s.events, fmt.Sprintf("Cleaned up staged source at %s", path))
+	}
+	return nil
+}
+
+// BuildKit is a stubbed build system that produces container images.
+type BuildKit struct {
+	// Configure the stub's behavior
+	NextDigest   string
+	NextImageURL string
+	ShouldFail   bool
+	FailMessage  string
+
+	// Track what happened
+	BuildCalled  bool
+	BuiltFromDir string // Records which staged dir was used
+}
+
+func (bk *BuildKit) Build(appName, sourceDir string) (digest, imageURL string, err error) {
+	bk.BuildCalled = true
+	bk.BuiltFromDir = sourceDir
+	if bk.ShouldFail {
+		return "", "", errors.New(bk.FailMessage)
+	}
+	return bk.NextDigest, bk.NextImageURL, nil
+}
+
+// BuildLog tracks events during the build saga for observability.
+type BuildLog struct {
+	events []string
+}
+
+func (bl *BuildLog) record(event string) {
+	bl.events = append(bl.events, event)
+}
+
+// --- Saga Actions ---
+
+// StageSource extracts source from a non-serializable stream to durable storage.
+// This is the critical first action that converts ephemeral stream data into
+// a serializable path that can survive crashes.
+
+type StageSourceIn struct {
+	StreamID string
+}
+
+type StageSourceOut struct {
+	SourceDir string
+}
+
+func StageSource(ctx context.Context, in StageSourceIn) (StageSourceOut, error) {
+	stager := saga.Get[*SourceStager](ctx)
+	buildLog := saga.Get[*BuildLog](ctx)
+
+	sourceDir, err := stager.Stage(in.StreamID)
+	if err != nil {
+		buildLog.record(fmt.Sprintf("Failed to stage source: %v", err))
+		return StageSourceOut{}, err
+	}
+
+	buildLog.record(fmt.Sprintf("Staged source to %s", sourceDir))
+	return StageSourceOut{SourceDir: sourceDir}, nil
+}
+
+func UndoStageSource(ctx context.Context, in StageSourceIn, out StageSourceOut) error {
+	stager := saga.Get[*SourceStager](ctx)
+	buildLog := saga.Get[*BuildLog](ctx)
+
+	if err := stager.Cleanup(in.StreamID); err != nil {
+		return err
+	}
+
+	buildLog.record(fmt.Sprintf("Cleaned up staged source %s", out.SourceDir))
+	return nil
+}
+
+// BuildImage calls BuildKit to produce a container image.
+// Now takes SourceDir from StageSource instead of receiving stream directly.
+
+type BuildImageIn struct {
+	AppName   string
+	SourceDir string // From StageSource - serializable!
+}
+
+type BuildImageOut struct {
+	ManifestDigest string
+	ImageURL       string
+}
+
+func BuildImage(ctx context.Context, in BuildImageIn) (BuildImageOut, error) {
+	buildKit := saga.Get[*BuildKit](ctx)
+	buildLog := saga.Get[*BuildLog](ctx)
+
+	digest, imageURL, err := buildKit.Build(in.AppName, in.SourceDir)
+	if err != nil {
+		buildLog.record(fmt.Sprintf("Build failed: %v", err))
+		return BuildImageOut{}, err
+	}
+
+	buildLog.record(fmt.Sprintf("Built image %s with digest %s", imageURL, digest))
+	return BuildImageOut{
+		ManifestDigest: digest,
+		ImageURL:       imageURL,
+	}, nil
+}
+
+func UndoBuildImage(ctx context.Context, in BuildImageIn, out BuildImageOut) error {
+	buildLog := saga.Get[*BuildLog](ctx)
+	buildLog.record(fmt.Sprintf("Build artifacts cleaned up for %s", in.AppName))
+	return nil
+}
+
+// ResolveArtifact finds an existing artifact by digest or creates a new one.
+
+type ResolveArtifactIn struct {
+	AppName        string
+	ManifestDigest string
+}
+
+type ResolveArtifactOut struct {
+	ArtifactID string
+	Created    bool // true if we created a new artifact (vs found existing)
+}
+
+func ResolveArtifact(ctx context.Context, in ResolveArtifactIn) (ResolveArtifactOut, error) {
+	client := saga.Get[*apiserver.Client](ctx)
+	buildLog := saga.Get[*BuildLog](ctx)
+
+	// Try to find existing artifact by digest
+	var existing core_v1alpha.Artifact
+	err := client.OneAtIndex(ctx,
+		entity.String(core_v1alpha.ArtifactManifestDigestId, in.ManifestDigest),
+		&existing)
+
+	if err == nil {
+		buildLog.record(fmt.Sprintf("Found existing artifact %s for digest %s", existing.ID, in.ManifestDigest))
+		return ResolveArtifactOut{
+			ArtifactID: string(existing.ID),
+			Created:    false,
+		}, nil
+	}
+
+	// Look up app to get its ID for the artifact reference
+	var app core_v1alpha.App
+	if err := client.Get(ctx, in.AppName, &app); err != nil {
+		return ResolveArtifactOut{}, fmt.Errorf("app not found: %w", err)
+	}
+
+	// Create new artifact
+	artifact := &core_v1alpha.Artifact{
+		App:            app.ID,
+		ManifestDigest: in.ManifestDigest,
+		Status:         core_v1alpha.ACTIVE,
+	}
+
+	artifactName := fmt.Sprintf("%s-%s", in.AppName, in.ManifestDigest[:12])
+	id, err := client.Create(ctx, artifactName, artifact)
+	if err != nil {
+		return ResolveArtifactOut{}, fmt.Errorf("failed to create artifact: %w", err)
+	}
+
+	buildLog.record(fmt.Sprintf("Created artifact %s for digest %s", id, in.ManifestDigest))
+	return ResolveArtifactOut{
+		ArtifactID: string(id),
+		Created:    true,
+	}, nil
+}
+
+func UndoResolveArtifact(ctx context.Context, in ResolveArtifactIn, out ResolveArtifactOut) error {
+	if !out.Created {
+		// We didn't create it, nothing to undo
+		return nil
+	}
+
+	client := saga.Get[*apiserver.Client](ctx)
+	buildLog := saga.Get[*BuildLog](ctx)
+
+	if err := client.Delete(ctx, entity.Id(out.ArtifactID)); err != nil {
+		return fmt.Errorf("failed to delete artifact: %w", err)
+	}
+
+	buildLog.record(fmt.Sprintf("Deleted artifact %s", out.ArtifactID))
+	return nil
+}
+
+// CreateVersion creates a new AppVersion entity.
+
+type CreateVersionIn struct {
+	AppName    string
+	ArtifactID string
+	ImageURL   string
+}
+
+type CreateVersionOut struct {
+	VersionID string
+}
+
+func CreateVersion(ctx context.Context, in CreateVersionIn) (CreateVersionOut, error) {
+	client := saga.Get[*apiserver.Client](ctx)
+	buildLog := saga.Get[*BuildLog](ctx)
+
+	// Look up app
+	var app core_v1alpha.App
+	if err := client.Get(ctx, in.AppName, &app); err != nil {
+		return CreateVersionOut{}, fmt.Errorf("app not found: %w", err)
+	}
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Artifact: entity.Id(in.ArtifactID),
+		ImageUrl: in.ImageURL,
+		Version:  "v1", // simplified for example
+		Config: core_v1alpha.Config{
+			Commands: []core_v1alpha.Commands{
+				{Service: "web", Command: "node server.js"},
+			},
+		},
+	}
+
+	versionName := fmt.Sprintf("%s-v1", in.AppName)
+	id, err := client.Create(ctx, versionName, version)
+	if err != nil {
+		return CreateVersionOut{}, fmt.Errorf("failed to create version: %w", err)
+	}
+
+	buildLog.record(fmt.Sprintf("Created version %s", id))
+	return CreateVersionOut{VersionID: string(id)}, nil
+}
+
+func UndoCreateVersion(ctx context.Context, in CreateVersionIn, out CreateVersionOut) error {
+	client := saga.Get[*apiserver.Client](ctx)
+	buildLog := saga.Get[*BuildLog](ctx)
+
+	if err := client.Delete(ctx, entity.Id(out.VersionID)); err != nil {
+		return fmt.Errorf("failed to delete version: %w", err)
+	}
+
+	buildLog.record(fmt.Sprintf("Deleted version %s", out.VersionID))
+	return nil
+}
+
+// ActivateVersion sets the new version as the app's active version.
+
+type ActivateVersionIn struct {
+	AppName   string
+	VersionID string
+}
+
+type ActivateVersionOut struct {
+	PreviousVersionID string // for undo
+}
+
+func ActivateVersion(ctx context.Context, in ActivateVersionIn) (ActivateVersionOut, error) {
+	client := saga.Get[*apiserver.Client](ctx)
+	buildLog := saga.Get[*BuildLog](ctx)
+
+	// Get current app state to capture previous version
+	var app core_v1alpha.App
+	if err := client.Get(ctx, in.AppName, &app); err != nil {
+		return ActivateVersionOut{}, fmt.Errorf("app not found: %w", err)
+	}
+
+	previousVersion := string(app.ActiveVersion)
+
+	// Update to new version
+	app.ActiveVersion = entity.Id(in.VersionID)
+	if err := client.Update(ctx, &app); err != nil {
+		return ActivateVersionOut{}, fmt.Errorf("failed to activate version: %w", err)
+	}
+
+	buildLog.record(fmt.Sprintf("Activated version %s (previous: %s)", in.VersionID, previousVersion))
+	return ActivateVersionOut{PreviousVersionID: previousVersion}, nil
+}
+
+func UndoActivateVersion(ctx context.Context, in ActivateVersionIn, out ActivateVersionOut) error {
+	client := saga.Get[*apiserver.Client](ctx)
+	buildLog := saga.Get[*BuildLog](ctx)
+
+	var app core_v1alpha.App
+	if err := client.Get(ctx, in.AppName, &app); err != nil {
+		return fmt.Errorf("app not found: %w", err)
+	}
+
+	// Restore previous version (may be empty for first deploy)
+	app.ActiveVersion = entity.Id(out.PreviousVersionID)
+	if err := client.Update(ctx, &app); err != nil {
+		return fmt.Errorf("failed to restore version: %w", err)
+	}
+
+	buildLog.record(fmt.Sprintf("Restored previous version %s", out.PreviousVersionID))
+	return nil
+}
+
+// --- Tests ---
+
+func TestBuildSaga_Success(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up in-memory entity server
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create an app to deploy to
+	app := &core_v1alpha.App{}
+	_, err := inmem.Client.Create(ctx, "myapp", app)
+	if err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+
+	// Set up stubbed collaborators
+	stager := NewSourceStager()
+	buildKit := &BuildKit{
+		NextDigest:   "sha256:abc123def456",
+		NextImageURL: "registry.example.com/myapp:v1",
+	}
+	buildLog := &BuildLog{}
+
+	// Simulate: caller registers stream BEFORE starting saga
+	// The stream itself is non-serializable, but the ID is just a string
+	fakeStream := &fakeReader{data: []byte("fake tar data")}
+	stager.RegisterStream("stream-123", fakeStream)
+
+	// Define and register the saga
+	registry := saga.NewRegistry()
+	saga.Define("deploy-app").
+		Using(inmem.Client).
+		Using(stager).
+		Using(buildKit).
+		Using(buildLog).
+		Action(StageSource).Undo(UndoStageSource).
+		Action(BuildImage).Undo(UndoBuildImage).
+		Action(ResolveArtifact).Undo(UndoResolveArtifact).
+		Action(CreateVersion).Undo(UndoCreateVersion).
+		Action(ActivateVersion).Undo(UndoActivateVersion).
+		RegisterTo(registry)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	// Execute the saga - note we pass streamid, not the stream itself!
+	err = executor.Start("deploy-app").
+		Input("appname", "myapp").
+		Input("streamid", "stream-123").
+		WithID("deploy-1").
+		Execute(ctx)
+
+	if err != nil {
+		t.Fatalf("saga failed: %v", err)
+	}
+
+	// Verify the entities were created correctly
+	var finalApp core_v1alpha.App
+	if err := inmem.Client.Get(ctx, "myapp", &finalApp); err != nil {
+		t.Fatalf("failed to get app: %v", err)
+	}
+
+	if finalApp.ActiveVersion == "" {
+		t.Error("app should have an active version")
+	}
+
+	// Verify artifact was created
+	var artifact core_v1alpha.Artifact
+	err = inmem.Client.OneAtIndex(ctx,
+		entity.String(core_v1alpha.ArtifactManifestDigestId, "sha256:abc123def456"),
+		&artifact)
+	if err != nil {
+		t.Fatalf("artifact should exist: %v", err)
+	}
+
+	// Verify BuildKit received the staged path
+	if buildKit.BuiltFromDir != "/tmp/staged/stream-123" {
+		t.Errorf("expected build from /tmp/staged/stream-123, got %s", buildKit.BuiltFromDir)
+	}
+
+	// Check the build log
+	t.Log("Build log:")
+	for _, event := range buildLog.events {
+		t.Logf("  - %s", event)
+	}
+
+	if len(buildLog.events) != 5 {
+		t.Errorf("expected 5 events, got %d", len(buildLog.events))
+	}
+}
+
+// fakeReader is a simple io.Reader for testing
+type fakeReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *fakeReader) Read(p []byte) (n int, err error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n = copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func TestBuildSaga_BuildFailure_CompensatesStaging(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up in-memory entity server
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create an app
+	app := &core_v1alpha.App{}
+	_, err := inmem.Client.Create(ctx, "myapp", app)
+	if err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+
+	// Set up collaborators
+	stager := NewSourceStager()
+	stager.RegisterStream("stream-456", &fakeReader{data: []byte("tar data")})
+
+	// BuildKit will fail
+	buildKit := &BuildKit{
+		ShouldFail:  true,
+		FailMessage: "build timeout",
+	}
+	buildLog := &BuildLog{}
+
+	registry := saga.NewRegistry()
+	saga.Define("deploy-app-fail-build").
+		Using(inmem.Client).
+		Using(stager).
+		Using(buildKit).
+		Using(buildLog).
+		Action(StageSource).Undo(UndoStageSource).
+		Action(BuildImage).Undo(UndoBuildImage).
+		Action(ResolveArtifact).Undo(UndoResolveArtifact).
+		Action(CreateVersion).Undo(UndoCreateVersion).
+		Action(ActivateVersion).Undo(UndoActivateVersion).
+		RegisterTo(registry)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err = executor.Start("deploy-app-fail-build").
+		Input("appname", "myapp").
+		Input("streamid", "stream-456").
+		Execute(ctx)
+
+	if err == nil {
+		t.Fatal("saga should have failed")
+	}
+
+	t.Log("Build log:")
+	for _, event := range buildLog.events {
+		t.Logf("  - %s", event)
+	}
+
+	// Should have: stage success, build failure, then undo stage
+	// StageSource succeeded, BuildImage failed, UndoStageSource runs
+	if len(buildLog.events) != 3 {
+		t.Errorf("expected 3 events (stage, build fail, undo stage), got %d", len(buildLog.events))
+	}
+
+	// Verify staged source was cleaned up
+	if len(stager.staged) != 0 {
+		t.Error("staged source should have been cleaned up")
+	}
+
+	// App should have no active version
+	var finalApp core_v1alpha.App
+	if err := inmem.Client.Get(ctx, "myapp", &finalApp); err != nil {
+		t.Fatalf("failed to get app: %v", err)
+	}
+	if finalApp.ActiveVersion != "" {
+		t.Error("app should not have an active version after failed build")
+	}
+}
+
+func TestBuildSaga_ActivationFailure_Compensates(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up in-memory entity server
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app
+	app := &core_v1alpha.App{}
+	appID, err := inmem.Client.Create(ctx, "myapp", app)
+	if err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+
+	stager := NewSourceStager()
+	stager.RegisterStream("stream-789", &fakeReader{data: []byte("tar data")})
+
+	buildKit := &BuildKit{
+		NextDigest:   "sha256:abc123def456",
+		NextImageURL: "registry.example.com/myapp:v1",
+	}
+	buildLog := &BuildLog{}
+
+	// We'll use a custom ActivateVersion that fails
+	failingActivate := func(ctx context.Context, in ActivateVersionIn) (ActivateVersionOut, error) {
+		buildLog.record("Activation failed: simulated error")
+		return ActivateVersionOut{}, errors.New("simulated activation failure")
+	}
+
+	registry := saga.NewRegistry()
+	saga.Define("deploy-app-fail-late").
+		Using(inmem.Client).
+		Using(stager).
+		Using(buildKit).
+		Using(buildLog).
+		Action(StageSource).Undo(UndoStageSource).
+		Action(BuildImage).Undo(UndoBuildImage).
+		Action(ResolveArtifact).Undo(UndoResolveArtifact).
+		Action(CreateVersion).Undo(UndoCreateVersion).
+		Action("failing-activate", failingActivate).Undo(UndoActivateVersion).
+		RegisterTo(registry)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err = executor.Start("deploy-app-fail-late").
+		Input("appname", "myapp").
+		Input("streamid", "stream-789").
+		Execute(ctx)
+
+	if err == nil {
+		t.Fatal("saga should have failed")
+	}
+
+	t.Log("Build log:")
+	for _, event := range buildLog.events {
+		t.Logf("  - %s", event)
+	}
+
+	// Should have: stage, build, artifact, version, activation fail,
+	// then compensations: version deleted, artifact deleted, build cleanup, stage cleanup
+	if len(buildLog.events) < 8 {
+		t.Errorf("expected at least 8 events, got %d", len(buildLog.events))
+	}
+
+	// Verify cleanup: no artifact should exist
+	var artifact core_v1alpha.Artifact
+	err = inmem.Client.OneAtIndex(ctx,
+		entity.String(core_v1alpha.ArtifactManifestDigestId, "sha256:abc123def456"),
+		&artifact)
+	if err == nil {
+		t.Error("artifact should have been deleted during compensation")
+	}
+
+	// Verify staged source was cleaned up
+	if len(stager.staged) != 0 {
+		t.Error("staged source should have been cleaned up")
+	}
+
+	// App should still exist but have no active version
+	var finalApp core_v1alpha.App
+	if err := inmem.Client.GetById(ctx, appID, &finalApp); err != nil {
+		t.Fatalf("app should still exist: %v", err)
+	}
+	if finalApp.ActiveVersion != "" {
+		t.Error("app should not have an active version after rollback")
+	}
+}
+
+func TestBuildSaga_ExistingArtifact_Reused(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up in-memory entity server
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app
+	app := &core_v1alpha.App{}
+	appID, err := inmem.Client.Create(ctx, "myapp", app)
+	if err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+
+	// Pre-create an artifact with the same digest (simulating a rebuild)
+	existingArtifact := &core_v1alpha.Artifact{
+		App:            appID,
+		ManifestDigest: "sha256:abc123def456",
+		Status:         core_v1alpha.ACTIVE,
+	}
+	existingArtifactID, err := inmem.Client.Create(ctx, "myapp-existing", existingArtifact)
+	if err != nil {
+		t.Fatalf("failed to create existing artifact: %v", err)
+	}
+
+	stager := NewSourceStager()
+	stager.RegisterStream("stream-999", &fakeReader{data: []byte("tar data")})
+
+	buildKit := &BuildKit{
+		NextDigest:   "sha256:abc123def456", // Same digest
+		NextImageURL: "registry.example.com/myapp:v1",
+	}
+	buildLog := &BuildLog{}
+
+	registry := saga.NewRegistry()
+	saga.Define("deploy-app-reuse").
+		Using(inmem.Client).
+		Using(stager).
+		Using(buildKit).
+		Using(buildLog).
+		Action(StageSource).Undo(UndoStageSource).
+		Action(BuildImage).Undo(UndoBuildImage).
+		Action(ResolveArtifact).Undo(UndoResolveArtifact).
+		Action(CreateVersion).Undo(UndoCreateVersion).
+		Action(ActivateVersion).Undo(UndoActivateVersion).
+		RegisterTo(registry)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err = executor.Start("deploy-app-reuse").
+		Input("appname", "myapp").
+		Input("streamid", "stream-999").
+		Execute(ctx)
+
+	if err != nil {
+		t.Fatalf("saga failed: %v", err)
+	}
+
+	t.Log("Build log:")
+	for _, event := range buildLog.events {
+		t.Logf("  - %s", event)
+	}
+
+	// Verify the existing artifact was reused
+	found := false
+	for _, event := range buildLog.events {
+		if event == fmt.Sprintf("Found existing artifact %s for digest sha256:abc123def456", existingArtifactID) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("should have found and reused existing artifact")
+	}
+}
+
+// TestBuildSaga_StreamLost_FailsGracefully demonstrates what happens when we try
+// to recover a saga but the stream was lost (simulating a crash before staging completed)
+func TestBuildSaga_StreamLost_FailsGracefully(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{}
+	_, err := inmem.Client.Create(ctx, "myapp", app)
+	if err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+
+	// Stager with NO stream registered - simulates crash where stream was lost
+	stager := NewSourceStager()
+	// Note: NOT calling stager.RegisterStream()
+
+	buildKit := &BuildKit{
+		NextDigest:   "sha256:abc123def456",
+		NextImageURL: "registry.example.com/myapp:v1",
+	}
+	buildLog := &BuildLog{}
+
+	registry := saga.NewRegistry()
+	saga.Define("deploy-app-lost-stream").
+		Using(inmem.Client).
+		Using(stager).
+		Using(buildKit).
+		Using(buildLog).
+		Action(StageSource).Undo(UndoStageSource).
+		Action(BuildImage).Undo(UndoBuildImage).
+		Action(ResolveArtifact).Undo(UndoResolveArtifact).
+		Action(CreateVersion).Undo(UndoCreateVersion).
+		Action(ActivateVersion).Undo(UndoActivateVersion).
+		RegisterTo(registry)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err = executor.Start("deploy-app-lost-stream").
+		Input("appname", "myapp").
+		Input("streamid", "stream-gone").
+		Execute(ctx)
+
+	if err == nil {
+		t.Fatal("saga should have failed - stream was lost")
+	}
+
+	t.Logf("Expected failure: %v", err)
+
+	// The saga should fail at StageSource with "stream not found"
+	// Since StageSource is the first action, there's nothing to compensate
+	t.Log("Build log:")
+	for _, event := range buildLog.events {
+		t.Logf("  - %s", event)
+	}
+
+	// Only the failure should be logged
+	if len(buildLog.events) != 1 {
+		t.Errorf("expected 1 event (stage failure), got %d", len(buildLog.events))
+	}
+}

--- a/pkg/saga/example_sandbox_test.go
+++ b/pkg/saga/example_sandbox_test.go
@@ -1,0 +1,1057 @@
+// Example: Sandbox Creation
+//
+// This example demonstrates saga patterns for the sandbox creation flow from
+// controllers/sandbox/sandbox.go. It models the full 8-step process of bringing
+// up an isolated execution environment, showing how sagas handle complex
+// orchestration with multiple collaborators (containerd, networking, metrics).
+//
+// Key concepts demonstrated:
+//
+//   - Multi-collaborator orchestration: Network allocation, container runtime,
+//     metrics collection, and entity storage all coordinated in sequence
+//
+//   - Handle-based resources: Containerd returns handles (Container, Task) that
+//     aren't directly serializable. We store IDs in saga outputs and look up
+//     handles via the collaborator on recovery.
+//
+//   - Implicit vs explicit undo: Some actions (BuildSpec) have no side effects
+//     and need no undo. Others (CreateContainer) have explicit cleanup.
+//
+//   - Graceful degradation: BootContainers attempts SIGTERM before SIGKILL,
+//     showing that undos can have their own error handling.
+//
+// The saga models these steps from controllers/sandbox/sandbox.go:
+//
+//	AllocateNetwork  → Reserve IP from subnet
+//	BuildSpec        → Construct OCI container specification
+//	ConfigureVolumes → Prepare volume mounts, acquire disk leases
+//	CreateContainer  → Create pause container in containerd
+//	BootTask         → Start pause container, configure network namespace
+//	BootContainers   → Start application containers joined to pause
+//	AddMetrics       → Register with metrics collection system
+//	UpdateStatus     → Mark sandbox RUNNING in entity store
+//
+// Run the tests:
+//
+//	go test -v ./pkg/saga/... -run TestSandboxSaga
+//
+// See example_sandwich_test.go for a simpler introduction to saga mechanics,
+// and example_build_test.go for entity system integration patterns.
+package saga_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"miren.dev/runtime/pkg/saga"
+)
+
+// =============================================================================
+// Stubbed Collaborators
+// =============================================================================
+
+// Subnet manages IP address allocation for sandbox networking.
+type Subnet struct {
+	mu        sync.Mutex
+	available []string
+	allocated map[string]string // sandboxID -> IP
+	events    []string
+}
+
+func NewSubnet(ips ...string) *Subnet {
+	return &Subnet{
+		available: ips,
+		allocated: make(map[string]string),
+	}
+}
+
+func (s *Subnet) Allocate(sandboxID string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.available) == 0 {
+		s.events = append(s.events, fmt.Sprintf("Allocation failed for %s: no IPs available", sandboxID))
+		return "", errors.New("no IP addresses available")
+	}
+
+	ip := s.available[0]
+	s.available = s.available[1:]
+	s.allocated[sandboxID] = ip
+	s.events = append(s.events, fmt.Sprintf("Allocated %s to %s", ip, sandboxID))
+	return ip, nil
+}
+
+func (s *Subnet) Release(sandboxID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ip, ok := s.allocated[sandboxID]
+	if !ok {
+		return nil // Already released, idempotent
+	}
+
+	delete(s.allocated, sandboxID)
+	s.available = append(s.available, ip)
+	s.events = append(s.events, fmt.Sprintf("Released %s from %s", ip, sandboxID))
+	return nil
+}
+
+// Containerd is a stubbed container runtime.
+type Containerd struct {
+	mu         sync.Mutex
+	containers map[string]*FakeContainer
+	tasks      map[string]*FakeTask
+	events     []string
+
+	// Failure injection
+	CreateContainerErr error
+	BootTaskErr        error
+	BootContainersErr  error
+}
+
+func NewContainerd() *Containerd {
+	return &Containerd{
+		containers: make(map[string]*FakeContainer),
+		tasks:      make(map[string]*FakeTask),
+	}
+}
+
+type FakeContainer struct {
+	ID      string
+	Spec    string
+	Deleted bool
+}
+
+type FakeTask struct {
+	ContainerID string
+	PID         int
+	Running     bool
+}
+
+func (c *Containerd) CreateContainer(id, spec string) (*FakeContainer, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.CreateContainerErr != nil {
+		c.events = append(c.events, fmt.Sprintf("CreateContainer failed for %s: %v", id, c.CreateContainerErr))
+		return nil, c.CreateContainerErr
+	}
+
+	container := &FakeContainer{ID: id, Spec: spec}
+	c.containers[id] = container
+	c.events = append(c.events, fmt.Sprintf("Created container %s", id))
+	return container, nil
+}
+
+func (c *Containerd) DeleteContainer(id string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	container, ok := c.containers[id]
+	if !ok {
+		return nil // Already deleted, idempotent
+	}
+
+	container.Deleted = true
+	delete(c.containers, id)
+	c.events = append(c.events, fmt.Sprintf("Deleted container %s", id))
+	return nil
+}
+
+func (c *Containerd) StartTask(containerID string) (*FakeTask, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.BootTaskErr != nil {
+		c.events = append(c.events, fmt.Sprintf("StartTask failed for %s: %v", containerID, c.BootTaskErr))
+		return nil, c.BootTaskErr
+	}
+
+	task := &FakeTask{
+		ContainerID: containerID,
+		PID:         1000 + len(c.tasks),
+		Running:     true,
+	}
+	c.tasks[containerID] = task
+	c.events = append(c.events, fmt.Sprintf("Started task for %s (PID %d)", containerID, task.PID))
+	return task, nil
+}
+
+func (c *Containerd) KillTask(containerID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	task, ok := c.tasks[containerID]
+	if !ok {
+		return nil // Already killed, idempotent
+	}
+
+	task.Running = false
+	delete(c.tasks, containerID)
+	c.events = append(c.events, fmt.Sprintf("Killed task for %s", containerID))
+	return nil
+}
+
+func (c *Containerd) StartSubcontainers(pauseID string, names []string) ([]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.BootContainersErr != nil {
+		c.events = append(c.events, fmt.Sprintf("StartSubcontainers failed: %v", c.BootContainersErr))
+		return nil, c.BootContainersErr
+	}
+
+	var ids []string
+	for _, name := range names {
+		id := fmt.Sprintf("%s-%s", pauseID, name)
+		c.containers[id] = &FakeContainer{ID: id, Spec: "subcontainer"}
+		c.tasks[id] = &FakeTask{ContainerID: id, PID: 2000 + len(c.tasks), Running: true}
+		ids = append(ids, id)
+		c.events = append(c.events, fmt.Sprintf("Started subcontainer %s", id))
+	}
+	return ids, nil
+}
+
+func (c *Containerd) StopSubcontainers(ids []string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, id := range ids {
+		if task, ok := c.tasks[id]; ok {
+			task.Running = false
+			delete(c.tasks, id)
+		}
+		if container, ok := c.containers[id]; ok {
+			container.Deleted = true
+			delete(c.containers, id)
+		}
+		c.events = append(c.events, fmt.Sprintf("Stopped subcontainer %s", id))
+	}
+	return nil
+}
+
+// VolumeManager handles volume mounts and disk leases.
+type VolumeManager struct {
+	mu     sync.Mutex
+	leases map[string][]string // sandboxID -> disk names
+	events []string
+
+	ConfigureErr error
+}
+
+func NewVolumeManager() *VolumeManager {
+	return &VolumeManager{
+		leases: make(map[string][]string),
+	}
+}
+
+func (v *VolumeManager) ConfigureVolumes(sandboxID string, volumes []string) (map[string]string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if v.ConfigureErr != nil {
+		v.events = append(v.events, fmt.Sprintf("ConfigureVolumes failed for %s: %v", sandboxID, v.ConfigureErr))
+		return nil, v.ConfigureErr
+	}
+
+	mounts := make(map[string]string)
+	for _, vol := range volumes {
+		mounts[vol] = fmt.Sprintf("/mnt/%s", vol)
+	}
+	v.leases[sandboxID] = volumes
+	v.events = append(v.events, fmt.Sprintf("Configured volumes for %s: %v", sandboxID, volumes))
+	return mounts, nil
+}
+
+func (v *VolumeManager) ReleaseLeases(sandboxID string) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if leases, ok := v.leases[sandboxID]; ok {
+		v.events = append(v.events, fmt.Sprintf("Released leases for %s: %v", sandboxID, leases))
+		delete(v.leases, sandboxID)
+	}
+	return nil
+}
+
+// MetricsCollector manages metrics registration.
+type MetricsCollector struct {
+	mu         sync.Mutex
+	registered map[string]bool
+	events     []string
+
+	AddErr error
+}
+
+func NewMetricsCollector() *MetricsCollector {
+	return &MetricsCollector{
+		registered: make(map[string]bool),
+	}
+}
+
+func (m *MetricsCollector) Add(sandboxID string, cgroups string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.AddErr != nil {
+		m.events = append(m.events, fmt.Sprintf("Metrics registration failed for %s: %v", sandboxID, m.AddErr))
+		return m.AddErr
+	}
+
+	m.registered[sandboxID] = true
+	m.events = append(m.events, fmt.Sprintf("Registered metrics for %s (cgroups: %s)", sandboxID, cgroups))
+	return nil
+}
+
+func (m *MetricsCollector) Remove(sandboxID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.registered[sandboxID] {
+		delete(m.registered, sandboxID)
+		m.events = append(m.events, fmt.Sprintf("Deregistered metrics for %s", sandboxID))
+	}
+	return nil
+}
+
+// SandboxStore is a simple in-memory store for sandbox status.
+// In production this would be the entity system.
+type SandboxStore struct {
+	mu       sync.Mutex
+	statuses map[string]string
+	events   []string
+
+	UpdateErr error
+}
+
+func NewSandboxStore() *SandboxStore {
+	return &SandboxStore{
+		statuses: make(map[string]string),
+	}
+}
+
+func (s *SandboxStore) Create(sandboxID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statuses[sandboxID] = "pending"
+	s.events = append(s.events, fmt.Sprintf("Created sandbox %s with status pending", sandboxID))
+}
+
+func (s *SandboxStore) GetStatus(sandboxID string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.statuses[sandboxID]
+}
+
+func (s *SandboxStore) UpdateStatus(sandboxID, status string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.UpdateErr != nil {
+		s.events = append(s.events, fmt.Sprintf("Status update failed for %s: %v", sandboxID, s.UpdateErr))
+		return "", s.UpdateErr
+	}
+
+	previous := s.statuses[sandboxID]
+	s.statuses[sandboxID] = status
+	s.events = append(s.events, fmt.Sprintf("Updated %s: %s -> %s", sandboxID, previous, status))
+	return previous, nil
+}
+
+// SandboxLog collects all events for test verification.
+type SandboxLog struct {
+	events []string
+}
+
+func (l *SandboxLog) record(event string) {
+	l.events = append(l.events, event)
+}
+
+// =============================================================================
+// Saga Actions
+// =============================================================================
+
+// --- AllocateNetwork ---
+
+type AllocateNetworkIn struct {
+	SandboxID string
+}
+
+type AllocateNetworkOut struct {
+	IP        string
+	NetworkNS string // Would be real netns path in production
+}
+
+func AllocateNetwork(ctx context.Context, in AllocateNetworkIn) (AllocateNetworkOut, error) {
+	subnet := saga.Get[*Subnet](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	ip, err := subnet.Allocate(in.SandboxID)
+	if err != nil {
+		log.record(fmt.Sprintf("AllocateNetwork failed: %v", err))
+		return AllocateNetworkOut{}, err
+	}
+
+	netns := fmt.Sprintf("/var/run/netns/%s", in.SandboxID)
+	log.record(fmt.Sprintf("Allocated network: IP=%s, netns=%s", ip, netns))
+	return AllocateNetworkOut{IP: ip, NetworkNS: netns}, nil
+}
+
+func UndoAllocateNetwork(ctx context.Context, in AllocateNetworkIn, out AllocateNetworkOut) error {
+	subnet := saga.Get[*Subnet](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	if err := subnet.Release(in.SandboxID); err != nil {
+		return err
+	}
+	log.record(fmt.Sprintf("Released network: IP=%s", out.IP))
+	return nil
+}
+
+// --- BuildSpec ---
+
+type BuildSpecIn struct {
+	SandboxID string
+	IP        string
+	NetworkNS string
+	Image     string
+}
+
+type BuildSpecOut struct {
+	Spec string // JSON OCI spec in production
+}
+
+func BuildSpec(ctx context.Context, in BuildSpecIn) (BuildSpecOut, error) {
+	log := saga.Get[*SandboxLog](ctx)
+
+	// In production: pull image, construct full OCI spec with mounts, env, etc.
+	spec := fmt.Sprintf(`{"image":"%s","network":{"ip":"%s","netns":"%s"}}`, in.Image, in.IP, in.NetworkNS)
+	log.record(fmt.Sprintf("Built container spec for %s", in.SandboxID))
+	return BuildSpecOut{Spec: spec}, nil
+}
+
+func UndoBuildSpec(ctx context.Context, in BuildSpecIn, out BuildSpecOut) error {
+	// BuildSpec is read-only (constructs ephemeral data), nothing to undo
+	log := saga.Get[*SandboxLog](ctx)
+	log.record("BuildSpec undo: no-op (ephemeral)")
+	return nil
+}
+
+// --- ConfigureVolumes ---
+
+type ConfigureVolumesIn struct {
+	SandboxID string
+	Volumes   []string `saga:",optional"`
+}
+
+type ConfigureVolumesOut struct {
+	Mounts map[string]string // volume name -> mount path
+}
+
+func ConfigureVolumes(ctx context.Context, in ConfigureVolumesIn) (ConfigureVolumesOut, error) {
+	volumes := saga.Get[*VolumeManager](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	if len(in.Volumes) == 0 {
+		log.record("No volumes to configure")
+		return ConfigureVolumesOut{Mounts: map[string]string{}}, nil
+	}
+
+	mounts, err := volumes.ConfigureVolumes(in.SandboxID, in.Volumes)
+	if err != nil {
+		log.record(fmt.Sprintf("ConfigureVolumes failed: %v", err))
+		return ConfigureVolumesOut{}, err
+	}
+
+	log.record(fmt.Sprintf("Configured %d volumes", len(mounts)))
+	return ConfigureVolumesOut{Mounts: mounts}, nil
+}
+
+func UndoConfigureVolumes(ctx context.Context, in ConfigureVolumesIn, out ConfigureVolumesOut) error {
+	volumes := saga.Get[*VolumeManager](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	if err := volumes.ReleaseLeases(in.SandboxID); err != nil {
+		return err
+	}
+	log.record("Released volume leases")
+	return nil
+}
+
+// --- CreateContainer ---
+
+type CreateContainerIn struct {
+	SandboxID string
+	Spec      string
+}
+
+type CreateContainerOut struct {
+	ContainerID string
+}
+
+func CreateContainer(ctx context.Context, in CreateContainerIn) (CreateContainerOut, error) {
+	containerd := saga.Get[*Containerd](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	containerID := fmt.Sprintf("pause-%s", in.SandboxID)
+	_, err := containerd.CreateContainer(containerID, in.Spec)
+	if err != nil {
+		log.record(fmt.Sprintf("CreateContainer failed: %v", err))
+		return CreateContainerOut{}, err
+	}
+
+	log.record(fmt.Sprintf("Created pause container %s", containerID))
+	return CreateContainerOut{ContainerID: containerID}, nil
+}
+
+func UndoCreateContainer(ctx context.Context, in CreateContainerIn, out CreateContainerOut) error {
+	containerd := saga.Get[*Containerd](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	// Kill any running task first
+	_ = containerd.KillTask(out.ContainerID)
+
+	if err := containerd.DeleteContainer(out.ContainerID); err != nil {
+		return err
+	}
+	log.record(fmt.Sprintf("Deleted pause container %s", out.ContainerID))
+	return nil
+}
+
+// --- BootTask ---
+
+type BootTaskIn struct {
+	ContainerID string
+	NetworkNS   string
+}
+
+type BootTaskOut struct {
+	TaskPID int
+	Cgroups string
+}
+
+func BootTask(ctx context.Context, in BootTaskIn) (BootTaskOut, error) {
+	containerd := saga.Get[*Containerd](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	task, err := containerd.StartTask(in.ContainerID)
+	if err != nil {
+		log.record(fmt.Sprintf("BootTask failed: %v", err))
+		return BootTaskOut{}, err
+	}
+
+	cgroups := fmt.Sprintf("/sys/fs/cgroup/sandbox/%s", in.ContainerID)
+	log.record(fmt.Sprintf("Started pause task PID=%d, cgroups=%s", task.PID, cgroups))
+	return BootTaskOut{TaskPID: task.PID, Cgroups: cgroups}, nil
+}
+
+func UndoBootTask(ctx context.Context, in BootTaskIn, out BootTaskOut) error {
+	containerd := saga.Get[*Containerd](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	if err := containerd.KillTask(in.ContainerID); err != nil {
+		return err
+	}
+	log.record(fmt.Sprintf("Killed pause task PID=%d", out.TaskPID))
+	return nil
+}
+
+// --- BootContainers ---
+
+type BootContainersIn struct {
+	SandboxID   string
+	ContainerID string // Pause container to join
+	TaskPID     int
+	Mounts      map[string]string `saga:",optional"`
+	Containers  []string          `saga:",optional"` // Container names to start
+}
+
+type BootContainersOut struct {
+	SubcontainerIDs []string
+}
+
+func BootContainers(ctx context.Context, in BootContainersIn) (BootContainersOut, error) {
+	containerd := saga.Get[*Containerd](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	if len(in.Containers) == 0 {
+		log.record("No subcontainers to boot")
+		return BootContainersOut{}, nil
+	}
+
+	ids, err := containerd.StartSubcontainers(in.ContainerID, in.Containers)
+	if err != nil {
+		log.record(fmt.Sprintf("BootContainers failed: %v", err))
+		return BootContainersOut{}, err
+	}
+
+	log.record(fmt.Sprintf("Started %d subcontainers: %v", len(ids), ids))
+	return BootContainersOut{SubcontainerIDs: ids}, nil
+}
+
+func UndoBootContainers(ctx context.Context, in BootContainersIn, out BootContainersOut) error {
+	containerd := saga.Get[*Containerd](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	if len(out.SubcontainerIDs) == 0 {
+		return nil
+	}
+
+	// Graceful shutdown: SIGTERM then SIGKILL (simulated here)
+	if err := containerd.StopSubcontainers(out.SubcontainerIDs); err != nil {
+		return err
+	}
+	log.record(fmt.Sprintf("Stopped %d subcontainers", len(out.SubcontainerIDs)))
+	return nil
+}
+
+// --- AddMetrics ---
+
+type AddMetricsIn struct {
+	SandboxID string
+	Cgroups   string
+}
+
+type AddMetricsOut struct {
+	MetricsReady bool // Signal that metrics step is complete
+}
+
+func AddMetrics(ctx context.Context, in AddMetricsIn) (AddMetricsOut, error) {
+	metrics := saga.Get[*MetricsCollector](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	if err := metrics.Add(in.SandboxID, in.Cgroups); err != nil {
+		log.record(fmt.Sprintf("AddMetrics failed: %v", err))
+		return AddMetricsOut{}, err
+	}
+
+	log.record("Registered metrics collection")
+	return AddMetricsOut{MetricsReady: true}, nil
+}
+
+func UndoAddMetrics(ctx context.Context, in AddMetricsIn, out AddMetricsOut) error {
+	metrics := saga.Get[*MetricsCollector](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	if err := metrics.Remove(in.SandboxID); err != nil {
+		return err
+	}
+	log.record("Deregistered metrics collection")
+	return nil
+}
+
+// --- UpdateStatus ---
+
+type UpdateStatusIn struct {
+	SandboxID    string
+	MetricsReady bool // Creates dependency on AddMetrics
+}
+
+type UpdateStatusOut struct {
+	PreviousStatus string
+}
+
+func UpdateStatus(ctx context.Context, in UpdateStatusIn) (UpdateStatusOut, error) {
+	store := saga.Get[*SandboxStore](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	previous, err := store.UpdateStatus(in.SandboxID, "running")
+	if err != nil {
+		log.record(fmt.Sprintf("UpdateStatus failed: %v", err))
+		return UpdateStatusOut{}, err
+	}
+
+	log.record(fmt.Sprintf("Updated status: %s -> running", previous))
+	return UpdateStatusOut{PreviousStatus: previous}, nil
+}
+
+func UndoUpdateStatus(ctx context.Context, in UpdateStatusIn, out UpdateStatusOut) error {
+	store := saga.Get[*SandboxStore](ctx)
+	log := saga.Get[*SandboxLog](ctx)
+
+	// Mark as dead on rollback, not restore to previous
+	// (consistent with production behavior)
+	_, err := store.UpdateStatus(in.SandboxID, "dead")
+	if err != nil {
+		return err
+	}
+	log.record("Marked sandbox as dead")
+	return nil
+}
+
+// =============================================================================
+// Helper to define the sandbox saga
+// =============================================================================
+
+func defineSandboxSaga(
+	registry *saga.Registry,
+	subnet *Subnet,
+	containerd *Containerd,
+	volumes *VolumeManager,
+	metrics *MetricsCollector,
+	store *SandboxStore,
+	log *SandboxLog,
+) {
+	saga.Define("create-sandbox").
+		Using(subnet).
+		Using(containerd).
+		Using(volumes).
+		Using(metrics).
+		Using(store).
+		Using(log).
+		Action(AllocateNetwork).Undo(UndoAllocateNetwork).
+		Action(BuildSpec).Undo(UndoBuildSpec).
+		Action(ConfigureVolumes).Undo(UndoConfigureVolumes).
+		Action(CreateContainer).Undo(UndoCreateContainer).
+		Action(BootTask).Undo(UndoBootTask).
+		Action(BootContainers).Undo(UndoBootContainers).
+		Action(AddMetrics).Undo(UndoAddMetrics).
+		Action(UpdateStatus).Undo(UndoUpdateStatus).
+		RegisterTo(registry)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+func TestSandboxSaga_Success(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up collaborators
+	subnet := NewSubnet("10.0.0.1", "10.0.0.2", "10.0.0.3")
+	containerd := NewContainerd()
+	volumes := NewVolumeManager()
+	metrics := NewMetricsCollector()
+	store := NewSandboxStore()
+	log := &SandboxLog{}
+
+	// Pre-create sandbox entity
+	store.Create("sandbox-1")
+
+	registry := saga.NewRegistry()
+	defineSandboxSaga(registry, subnet, containerd, volumes, metrics, store, log)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err := executor.Start("create-sandbox").
+		Input("sandboxid", "sandbox-1").
+		Input("image", "pause:latest").
+		Input("volumes", []string{"data", "logs"}).
+		Input("containers", []string{"web", "worker"}).
+		WithID("create-sandbox-1").
+		Execute(ctx)
+
+	if err != nil {
+		t.Fatalf("saga failed: %v", err)
+	}
+
+	// Verify final state
+	if store.GetStatus("sandbox-1") != "running" {
+		t.Errorf("expected status running, got %s", store.GetStatus("sandbox-1"))
+	}
+
+	if len(subnet.allocated) != 1 {
+		t.Errorf("expected 1 IP allocated, got %d", len(subnet.allocated))
+	}
+
+	if len(containerd.containers) != 3 { // pause + 2 subcontainers
+		t.Errorf("expected 3 containers, got %d", len(containerd.containers))
+	}
+
+	if !metrics.registered["sandbox-1"] {
+		t.Error("expected metrics to be registered")
+	}
+
+	t.Log("Saga events:")
+	for _, event := range log.events {
+		t.Logf("  - %s", event)
+	}
+}
+
+func TestSandboxSaga_NetworkExhaustion(t *testing.T) {
+	ctx := context.Background()
+
+	// No IPs available!
+	subnet := NewSubnet()
+	containerd := NewContainerd()
+	volumes := NewVolumeManager()
+	metrics := NewMetricsCollector()
+	store := NewSandboxStore()
+	log := &SandboxLog{}
+
+	store.Create("sandbox-1")
+
+	registry := saga.NewRegistry()
+	defineSandboxSaga(registry, subnet, containerd, volumes, metrics, store, log)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err := executor.Start("create-sandbox").
+		Input("sandboxid", "sandbox-1").
+		Input("image", "pause:latest").
+		Input("containers", []string{"web"}).
+		Execute(ctx)
+
+	if err == nil {
+		t.Fatal("saga should have failed")
+	}
+
+	t.Logf("Expected failure: %v", err)
+
+	// Nothing should be allocated - failure at early step
+	if len(subnet.allocated) != 0 {
+		t.Errorf("expected no IPs allocated, got %d", len(subnet.allocated))
+	}
+
+	if len(containerd.containers) != 0 {
+		t.Errorf("expected no containers, got %d", len(containerd.containers))
+	}
+
+	// Status depends on what ran before failure
+	// ConfigureVolumes may have run (no dependencies), but UpdateStatus requires MetricsReady
+	// which never happened, so status should be pending
+	status := store.GetStatus("sandbox-1")
+	t.Logf("Final status: %s", status)
+
+	t.Log("Saga events:")
+	for _, event := range log.events {
+		t.Logf("  - %s", event)
+	}
+}
+
+func TestSandboxSaga_ContainerCreationFails(t *testing.T) {
+	ctx := context.Background()
+
+	subnet := NewSubnet("10.0.0.1")
+	containerd := NewContainerd()
+	containerd.CreateContainerErr = errors.New("image not found")
+	volumes := NewVolumeManager()
+	metrics := NewMetricsCollector()
+	store := NewSandboxStore()
+	log := &SandboxLog{}
+
+	store.Create("sandbox-1")
+
+	registry := saga.NewRegistry()
+	defineSandboxSaga(registry, subnet, containerd, volumes, metrics, store, log)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err := executor.Start("create-sandbox").
+		Input("sandboxid", "sandbox-1").
+		Input("image", "pause:latest").
+		Input("volumes", []string{"data"}).
+		Input("containers", []string{"web"}).
+		Execute(ctx)
+
+	if err == nil {
+		t.Fatal("saga should have failed")
+	}
+
+	t.Logf("Expected failure: %v", err)
+
+	// Network should be released (compensation ran)
+	if len(subnet.allocated) != 0 {
+		t.Errorf("expected IP released, got %d allocated", len(subnet.allocated))
+	}
+
+	// Volume leases should be released
+	if len(volumes.leases) != 0 {
+		t.Errorf("expected leases released, got %d", len(volumes.leases))
+	}
+
+	t.Log("Saga events:")
+	for _, event := range log.events {
+		t.Logf("  - %s", event)
+	}
+}
+
+func TestSandboxSaga_BootTaskFails(t *testing.T) {
+	ctx := context.Background()
+
+	subnet := NewSubnet("10.0.0.1")
+	containerd := NewContainerd()
+	containerd.BootTaskErr = errors.New("cgroup limit exceeded")
+	volumes := NewVolumeManager()
+	metrics := NewMetricsCollector()
+	store := NewSandboxStore()
+	log := &SandboxLog{}
+
+	store.Create("sandbox-1")
+
+	registry := saga.NewRegistry()
+	defineSandboxSaga(registry, subnet, containerd, volumes, metrics, store, log)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err := executor.Start("create-sandbox").
+		Input("sandboxid", "sandbox-1").
+		Input("image", "pause:latest").
+		Input("containers", []string{"web"}).
+		Execute(ctx)
+
+	if err == nil {
+		t.Fatal("saga should have failed")
+	}
+
+	// Container should be deleted (compensation ran)
+	if len(containerd.containers) != 0 {
+		t.Errorf("expected containers deleted, got %d", len(containerd.containers))
+	}
+
+	// Network should be released
+	if len(subnet.allocated) != 0 {
+		t.Errorf("expected IP released, got %d", len(subnet.allocated))
+	}
+
+	t.Log("Saga events:")
+	for _, event := range log.events {
+		t.Logf("  - %s", event)
+	}
+}
+
+func TestSandboxSaga_SubcontainersFail(t *testing.T) {
+	ctx := context.Background()
+
+	subnet := NewSubnet("10.0.0.1")
+	containerd := NewContainerd()
+	containerd.BootContainersErr = errors.New("port already in use")
+	volumes := NewVolumeManager()
+	metrics := NewMetricsCollector()
+	store := NewSandboxStore()
+	log := &SandboxLog{}
+
+	store.Create("sandbox-1")
+
+	registry := saga.NewRegistry()
+	defineSandboxSaga(registry, subnet, containerd, volumes, metrics, store, log)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err := executor.Start("create-sandbox").
+		Input("sandboxid", "sandbox-1").
+		Input("image", "pause:latest").
+		Input("containers", []string{"web", "worker"}).
+		Execute(ctx)
+
+	if err == nil {
+		t.Fatal("saga should have failed")
+	}
+
+	// Pause container and task should be cleaned up
+	if len(containerd.containers) != 0 {
+		t.Errorf("expected all containers deleted, got %d", len(containerd.containers))
+	}
+
+	if len(containerd.tasks) != 0 {
+		t.Errorf("expected all tasks killed, got %d", len(containerd.tasks))
+	}
+
+	t.Log("Saga events:")
+	for _, event := range log.events {
+		t.Logf("  - %s", event)
+	}
+}
+
+func TestSandboxSaga_MetricsFails_FullRollback(t *testing.T) {
+	ctx := context.Background()
+
+	subnet := NewSubnet("10.0.0.1")
+	containerd := NewContainerd()
+	volumes := NewVolumeManager()
+	metrics := NewMetricsCollector()
+	metrics.AddErr = errors.New("metrics service unavailable")
+	store := NewSandboxStore()
+	log := &SandboxLog{}
+
+	store.Create("sandbox-1")
+
+	registry := saga.NewRegistry()
+	defineSandboxSaga(registry, subnet, containerd, volumes, metrics, store, log)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	err := executor.Start("create-sandbox").
+		Input("sandboxid", "sandbox-1").
+		Input("image", "pause:latest").
+		Input("containers", []string{"web"}).
+		Execute(ctx)
+
+	if err == nil {
+		t.Fatal("saga should have failed")
+	}
+
+	// Everything should be rolled back
+	if len(containerd.containers) != 0 {
+		t.Errorf("expected containers deleted, got %d", len(containerd.containers))
+	}
+
+	if len(subnet.allocated) != 0 {
+		t.Errorf("expected IP released, got %d", len(subnet.allocated))
+	}
+
+	// Verify the sequence: lots of actions succeeded before metrics failed
+	t.Log("Saga events:")
+	for _, event := range log.events {
+		t.Logf("  - %s", event)
+	}
+
+	// Should see the full forward path then reverse compensation
+	if len(log.events) < 10 {
+		t.Errorf("expected many events showing forward+backward, got %d", len(log.events))
+	}
+}
+
+func TestSandboxSaga_NoVolumes_NoContainers(t *testing.T) {
+	ctx := context.Background()
+
+	// Minimal sandbox - just pause container, no app containers or volumes
+	subnet := NewSubnet("10.0.0.1")
+	containerd := NewContainerd()
+	volumes := NewVolumeManager()
+	metrics := NewMetricsCollector()
+	store := NewSandboxStore()
+	log := &SandboxLog{}
+
+	store.Create("sandbox-1")
+
+	registry := saga.NewRegistry()
+	defineSandboxSaga(registry, subnet, containerd, volumes, metrics, store, log)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	// No volumes, no containers inputs
+	err := executor.Start("create-sandbox").
+		Input("sandboxid", "sandbox-1").
+		Input("image", "pause:latest").
+		Execute(ctx)
+
+	if err != nil {
+		t.Fatalf("saga failed: %v", err)
+	}
+
+	// Should still succeed with just pause container
+	if store.GetStatus("sandbox-1") != "running" {
+		t.Errorf("expected status running, got %s", store.GetStatus("sandbox-1"))
+	}
+
+	// Only pause container
+	if len(containerd.containers) != 1 {
+		t.Errorf("expected 1 container (pause only), got %d", len(containerd.containers))
+	}
+
+	t.Log("Saga events:")
+	for _, event := range log.events {
+		t.Logf("  - %s", event)
+	}
+}

--- a/pkg/saga/example_sandwich_test.go
+++ b/pkg/saga/example_sandwich_test.go
@@ -1,0 +1,431 @@
+// Example: Sandwich Making
+//
+// This example demonstrates the fundamental mechanics of the saga framework
+// using a whimsical sandwich-making domain. It's designed to be approachable
+// and self-contained, showing how sagas work without requiring knowledge of
+// our production systems.
+//
+// Key concepts demonstrated:
+//
+//   - Action chaining: Each action's output flows to dependent actions via saga keys
+//   - Compensation: When AddProtein fails (out of turkey), completed actions are
+//     undone in reverse order (UndoAddCondiment, UndoGetBread)
+//   - Dependency injection: Collaborators (Kitchen, Pantry, Fridge) are injected
+//     via Using() and retrieved with saga.Get[T](ctx)
+//   - Optional inputs: The "toppings" input is marked optional, so the saga
+//     succeeds even when it's omitted
+//
+// Run the examples:
+//
+//	go test -v ./pkg/saga/... -run Example
+//
+// See example_build_test.go for a more realistic example using the entity system.
+package saga_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"miren.dev/runtime/pkg/saga"
+)
+
+// --- Collaborators ---
+
+// Kitchen tracks what happened during sandwich making.
+type Kitchen struct {
+	log []string
+}
+
+func (k *Kitchen) record(action string) {
+	k.log = append(k.log, action)
+}
+
+// Pantry holds bread and dry goods.
+type Pantry struct {
+	stock map[string]int
+}
+
+func NewPantry(stock map[string]int) *Pantry {
+	return &Pantry{stock: stock}
+}
+
+func (p *Pantry) Take(item string) error {
+	if p.stock[item] <= 0 {
+		return fmt.Errorf("out of %s", item)
+	}
+	p.stock[item]--
+	return nil
+}
+
+func (p *Pantry) Return(item string) {
+	p.stock[item]++
+}
+
+// Fridge holds proteins, condiments, and cold items.
+type Fridge struct {
+	stock map[string]int
+}
+
+func NewFridge(stock map[string]int) *Fridge {
+	return &Fridge{stock: stock}
+}
+
+func (f *Fridge) Take(item string) error {
+	if f.stock[item] <= 0 {
+		return fmt.Errorf("out of %s", item)
+	}
+	f.stock[item]--
+	return nil
+}
+
+func (f *Fridge) Return(item string) {
+	f.stock[item]++
+}
+
+// --- Actions ---
+
+// GetBread retrieves bread from the pantry.
+
+type GetBreadIn struct {
+	BreadType string
+}
+
+type GetBreadOut struct {
+	Bread string
+}
+
+func GetBread(ctx context.Context, in GetBreadIn) (GetBreadOut, error) {
+	kitchen := saga.Get[*Kitchen](ctx)
+	pantry := saga.Get[*Pantry](ctx)
+
+	if err := pantry.Take(in.BreadType); err != nil {
+		kitchen.record(fmt.Sprintf("Checked pantry - %v", err))
+		return GetBreadOut{}, err
+	}
+
+	kitchen.record(fmt.Sprintf("Got %s from pantry", in.BreadType))
+	return GetBreadOut{Bread: in.BreadType + " slice"}, nil
+}
+
+func UndoGetBread(ctx context.Context, in GetBreadIn, out GetBreadOut) error {
+	kitchen := saga.Get[*Kitchen](ctx)
+	pantry := saga.Get[*Pantry](ctx)
+
+	pantry.Return(in.BreadType)
+	kitchen.record(fmt.Sprintf("Returned %s to pantry", in.BreadType))
+	return nil
+}
+
+// AddCondiment spreads a condiment on the bread.
+
+type AddCondimentIn struct {
+	Bread     string
+	Condiment string
+}
+
+type AddCondimentOut struct {
+	PreparedBread string
+}
+
+func AddCondiment(ctx context.Context, in AddCondimentIn) (AddCondimentOut, error) {
+	kitchen := saga.Get[*Kitchen](ctx)
+	fridge := saga.Get[*Fridge](ctx)
+
+	if err := fridge.Take(in.Condiment); err != nil {
+		kitchen.record(fmt.Sprintf("Checked fridge - %v", err))
+		return AddCondimentOut{}, err
+	}
+
+	kitchen.record(fmt.Sprintf("Spread %s on %s", in.Condiment, in.Bread))
+	return AddCondimentOut{
+		PreparedBread: in.Bread + " with " + in.Condiment,
+	}, nil
+}
+
+func UndoAddCondiment(ctx context.Context, in AddCondimentIn, out AddCondimentOut) error {
+	kitchen := saga.Get[*Kitchen](ctx)
+	fridge := saga.Get[*Fridge](ctx)
+
+	fridge.Return(in.Condiment)
+	kitchen.record(fmt.Sprintf("Scraped %s back into jar", in.Condiment))
+	return nil
+}
+
+// AddProtein layers protein on the prepared bread.
+
+type AddProteinIn struct {
+	PreparedBread string
+	Protein       string
+}
+
+type AddProteinOut struct {
+	Stack string
+}
+
+func AddProtein(ctx context.Context, in AddProteinIn) (AddProteinOut, error) {
+	kitchen := saga.Get[*Kitchen](ctx)
+	fridge := saga.Get[*Fridge](ctx)
+
+	if err := fridge.Take(in.Protein); err != nil {
+		kitchen.record(fmt.Sprintf("Checked fridge - %v", err))
+		return AddProteinOut{}, err
+	}
+
+	kitchen.record(fmt.Sprintf("Layered %s on %s", in.Protein, in.PreparedBread))
+	return AddProteinOut{
+		Stack: in.PreparedBread + " + " + in.Protein,
+	}, nil
+}
+
+func UndoAddProtein(ctx context.Context, in AddProteinIn, out AddProteinOut) error {
+	kitchen := saga.Get[*Kitchen](ctx)
+	fridge := saga.Get[*Fridge](ctx)
+
+	fridge.Return(in.Protein)
+	kitchen.record(fmt.Sprintf("Put %s back in fridge", in.Protein))
+	return nil
+}
+
+// AddToppings adds optional toppings to the sandwich.
+
+type AddToppingsIn struct {
+	Stack    string
+	Toppings []string `saga:",optional"`
+}
+
+type AddToppingsOut struct {
+	OpenSandwich string
+}
+
+func AddToppings(ctx context.Context, in AddToppingsIn) (AddToppingsOut, error) {
+	kitchen := saga.Get[*Kitchen](ctx)
+
+	result := in.Stack
+	if len(in.Toppings) > 0 {
+		toppingList := strings.Join(in.Toppings, ", ")
+		kitchen.record(fmt.Sprintf("Added %s", toppingList))
+		result += " + " + toppingList
+	} else {
+		kitchen.record("No toppings requested")
+	}
+	return AddToppingsOut{OpenSandwich: result}, nil
+}
+
+func UndoAddToppings(ctx context.Context, in AddToppingsIn, out AddToppingsOut) error {
+	kitchen := saga.Get[*Kitchen](ctx)
+	if len(in.Toppings) > 0 {
+		kitchen.record(fmt.Sprintf("Removed %s", strings.Join(in.Toppings, ", ")))
+	}
+	return nil
+}
+
+// CloseSandwich adds the top slice to complete the sandwich.
+
+type CloseSandwichIn struct {
+	OpenSandwich string
+}
+
+type CloseSandwichOut struct {
+	Sandwich string
+}
+
+func CloseSandwich(ctx context.Context, in CloseSandwichIn) (CloseSandwichOut, error) {
+	kitchen := saga.Get[*Kitchen](ctx)
+	kitchen.record("Closed sandwich with top slice")
+	return CloseSandwichOut{
+		Sandwich: "[" + in.OpenSandwich + "]",
+	}, nil
+}
+
+func UndoCloseSandwich(ctx context.Context, in CloseSandwichIn, out CloseSandwichOut) error {
+	kitchen := saga.Get[*Kitchen](ctx)
+	kitchen.record("Opened sandwich back up")
+	return nil
+}
+
+// Example_makeSandwich demonstrates a successful sandwich-making saga.
+func Example_makeSandwich() {
+	kitchen := &Kitchen{}
+	pantry := NewPantry(map[string]int{
+		"sourdough": 2,
+		"wheat":     1,
+		"rye":       1,
+	})
+	fridge := NewFridge(map[string]int{
+		"mayo":     3,
+		"mustard":  2,
+		"ham":      4,
+		"turkey":   2,
+		"pastrami": 1,
+	})
+
+	registry := saga.NewRegistry()
+	saga.Define("make-sandwich").
+		Using(kitchen).
+		Using(pantry).
+		Using(fridge).
+		Action(GetBread).Undo(UndoGetBread).
+		Action(AddCondiment).Undo(UndoAddCondiment).
+		Action(AddProtein).Undo(UndoAddProtein).
+		Action(AddToppings).Undo(UndoAddToppings).
+		Action(CloseSandwich).Undo(UndoCloseSandwich).
+		RegisterTo(registry)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	ctx := context.Background()
+	err := executor.Start("make-sandwich").
+		Input("breadtype", "sourdough").
+		Input("condiment", "mayo").
+		Input("protein", "ham").
+		Input("toppings", []string{"lettuce", "tomato"}).
+		WithID("order-1").
+		Execute(ctx)
+
+	if err != nil {
+		fmt.Printf("Failed: %v\n", err)
+		return
+	}
+
+	// Get the final result
+	exec, _ := storage.Get(ctx, "order-1")
+	var result CloseSandwichOut
+	json.Unmarshal(exec.ExecutedActions["close-sandwich"].Output, &result)
+
+	fmt.Printf("Result: %s\n", result.Sandwich)
+
+	fmt.Println("\nKitchen log:")
+	for _, entry := range kitchen.log {
+		fmt.Println("  -", entry)
+	}
+
+	// Output:
+	// Result: [sourdough slice with mayo + ham + lettuce, tomato]
+	//
+	// Kitchen log:
+	//   - Got sourdough from pantry
+	//   - Spread mayo on sourdough slice
+	//   - Layered ham on sourdough slice with mayo
+	//   - Added lettuce, tomato
+	//   - Closed sandwich with top slice
+}
+
+// Example_outOfStock demonstrates saga compensation when the fridge is empty.
+func Example_outOfStock() {
+	kitchen := &Kitchen{}
+	pantry := NewPantry(map[string]int{
+		"wheat": 1,
+	})
+	fridge := NewFridge(map[string]int{
+		"mustard": 1,
+		"turkey":  0, // Out of turkey!
+	})
+
+	registry := saga.NewRegistry()
+	saga.Define("make-sandwich-fail").
+		Using(kitchen).
+		Using(pantry).
+		Using(fridge).
+		Action(GetBread).Undo(UndoGetBread).
+		Action(AddCondiment).Undo(UndoAddCondiment).
+		Action(AddProtein).Undo(UndoAddProtein).
+		Action(AddToppings).Undo(UndoAddToppings).
+		Action(CloseSandwich).Undo(UndoCloseSandwich).
+		RegisterTo(registry)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	ctx := context.Background()
+	err := executor.Start("make-sandwich-fail").
+		Input("breadtype", "wheat").
+		Input("condiment", "mustard").
+		Input("protein", "turkey").
+		Input("toppings", []string{"pickles"}).
+		Execute(ctx)
+
+	if err != nil {
+		fmt.Println("Sandwich failed - Loss Prevented")
+	}
+
+	fmt.Println("\nKitchen log:")
+	for _, entry := range kitchen.log {
+		fmt.Println("  -", entry)
+	}
+
+	fmt.Printf("\nInventory restored: wheat=%d, mustard=%d\n",
+		pantry.stock["wheat"], fridge.stock["mustard"])
+
+	// Output:
+	// Sandwich failed - Loss Prevented
+	//
+	// Kitchen log:
+	//   - Got wheat from pantry
+	//   - Spread mustard on wheat slice
+	//   - Checked fridge - out of turkey
+	//   - Scraped mustard back into jar
+	//   - Returned wheat to pantry
+	//
+	// Inventory restored: wheat=1, mustard=1
+}
+
+// Example_simpleSandwich demonstrates optional toppings.
+func Example_simpleSandwich() {
+	kitchen := &Kitchen{}
+	pantry := NewPantry(map[string]int{"rye": 1})
+	fridge := NewFridge(map[string]int{"butter": 1, "pastrami": 1})
+
+	registry := saga.NewRegistry()
+	saga.Define("simple-sandwich").
+		Using(kitchen).
+		Using(pantry).
+		Using(fridge).
+		Action(GetBread).Undo(UndoGetBread).
+		Action(AddCondiment).Undo(UndoAddCondiment).
+		Action(AddProtein).Undo(UndoAddProtein).
+		Action(AddToppings).Undo(UndoAddToppings).
+		Action(CloseSandwich).Undo(UndoCloseSandwich).
+		RegisterTo(registry)
+
+	storage := saga.NewMemoryStorage()
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry))
+
+	ctx := context.Background()
+	err := executor.Start("simple-sandwich").
+		Input("breadtype", "rye").
+		Input("condiment", "butter").
+		Input("protein", "pastrami").
+		// Note: no toppings - that's ok, it's optional!
+		WithID("order-3").
+		Execute(ctx)
+
+	if err != nil {
+		fmt.Printf("Failed: %v\n", err)
+		return
+	}
+
+	// Get the final result
+	exec, _ := storage.Get(ctx, "order-3")
+	var result CloseSandwichOut
+	json.Unmarshal(exec.ExecutedActions["close-sandwich"].Output, &result)
+
+	fmt.Printf("Result: %s\n", result.Sandwich)
+
+	fmt.Println("\nKitchen log:")
+	for _, entry := range kitchen.log {
+		fmt.Println("  -", entry)
+	}
+
+	// Output:
+	// Result: [rye slice with butter + pastrami]
+	//
+	// Kitchen log:
+	//   - Got rye from pantry
+	//   - Spread butter on rye slice
+	//   - Layered pastrami on rye slice with butter
+	//   - No toppings requested
+	//   - Closed sandwich with top slice
+}

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -354,9 +354,11 @@ func (e *Executor) runUndo(ctx context.Context, def *Definition, exec *Execution
 			log.Error("undo failed", "action", actionName, "error", err)
 			undoErrors = append(undoErrors, fmt.Errorf("undo %q: %w", actionName, err))
 			// Continue with other undos even on failure
+			// Don't mark as undone - recovery should retry this action
+			continue
 		}
 
-		// Record undo
+		// Record successful undo
 		now := time.Now()
 		result.UndoneAt = &now
 		exec.UpdatedAt = now

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -1,0 +1,443 @@
+package saga
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"miren.dev/runtime/pkg/idgen"
+)
+
+// Storage persists saga execution state.
+type Storage interface {
+	// Save persists the execution state.
+	Save(ctx context.Context, exec *Execution) error
+
+	// Get retrieves an execution by ID.
+	Get(ctx context.Context, id string) (*Execution, error)
+
+	// ListIncomplete returns all executions that need recovery (Running or Undoing).
+	ListIncomplete(ctx context.Context) ([]*Execution, error)
+}
+
+// Executor orchestrates saga execution with durable logging.
+type Executor struct {
+	storage  Storage
+	registry *Registry
+	log      *slog.Logger
+}
+
+// ExecutorOption configures an Executor.
+type ExecutorOption func(*Executor)
+
+// WithRegistry sets a custom registry for the executor.
+// Useful for testing to avoid global state.
+func WithRegistry(r *Registry) ExecutorOption {
+	return func(e *Executor) {
+		e.registry = r
+	}
+}
+
+// WithLogger sets a custom logger for the executor.
+func WithLogger(log *slog.Logger) ExecutorOption {
+	return func(e *Executor) {
+		e.log = log
+	}
+}
+
+// NewExecutor creates an executor with the given storage and options.
+func NewExecutor(storage Storage, opts ...ExecutorOption) *Executor {
+	e := &Executor{
+		storage:  storage,
+		registry: globalRegistry,
+		log:      slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// StartBuilder provides a fluent API for starting saga executions.
+type StartBuilder struct {
+	executor *Executor
+	defName  string
+	inputs   map[string]any
+	id       string
+}
+
+// Start begins building a saga execution.
+func (e *Executor) Start(definitionName string) *StartBuilder {
+	return &StartBuilder{
+		executor: e,
+		defName:  definitionName,
+		inputs:   make(map[string]any),
+	}
+}
+
+// With adds an initial input to the saga.
+func (sb *StartBuilder) With(key string, value any) *StartBuilder {
+	sb.inputs[key] = value
+	return sb
+}
+
+// WithID sets a specific execution ID (otherwise one is generated).
+func (sb *StartBuilder) WithID(id string) *StartBuilder {
+	sb.id = id
+	return sb
+}
+
+// Execute runs the saga to completion or failure.
+func (sb *StartBuilder) Execute(ctx context.Context) error {
+	return sb.executor.execute(ctx, sb.defName, sb.inputs, sb.id)
+}
+
+// execute runs a saga with the given definition and inputs.
+func (e *Executor) execute(ctx context.Context, defName string, inputs map[string]any, id string) error {
+	// Look up definition
+	def, ok := e.registry.Get(defName)
+	if !ok {
+		return fmt.Errorf("saga definition %q not found", defName)
+	}
+
+	// Generate ID if not provided
+	if id == "" {
+		id = generateID()
+	}
+
+	// Create execution
+	now := time.Now()
+	exec := &Execution{
+		ID:                id,
+		DefinitionName:    defName,
+		DefinitionVersion: def.Version,
+		InitialInputs:     inputs,
+		Status:            StatusPending,
+		ExecutedActions:   make(map[string]*ActionResult),
+		ExecutionOrder:    []string{},
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+
+	// Persist initial state
+	if err := e.storage.Save(ctx, exec); err != nil {
+		return fmt.Errorf("persisting initial state: %w", err)
+	}
+
+	return e.runExecution(ctx, def, exec)
+}
+
+// runExecution executes or resumes a saga.
+func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Execution) error {
+	log := e.log.With("saga", def.Name, "execution", exec.ID)
+
+	// Update status to running
+	exec.Status = StatusRunning
+	exec.UpdatedAt = time.Now()
+	if err := e.storage.Save(ctx, exec); err != nil {
+		return fmt.Errorf("persisting running state: %w", err)
+	}
+
+	// Inject dependencies into context
+	ctx = injectDependencies(ctx, def.dependencies)
+
+	// Build outputs map from already-executed actions
+	outputs := make(map[string]json.RawMessage)
+	for actionName, result := range exec.ExecutedActions {
+		if result.UndoneAt != nil {
+			continue // Skip undone actions
+		}
+		node := def.Actions[actionName]
+		if node == nil {
+			continue
+		}
+		// Extract output keys from the result
+		if err := extractOutputs(node, result.Output, outputs); err != nil {
+			log.Warn("failed to extract outputs from prior action", "action", actionName, "error", err)
+		}
+	}
+
+	// Execute actions in order
+	for _, actionName := range def.executionOrder {
+		// Check for context cancellation between actions
+		if err := ctx.Err(); err != nil {
+			log.Info("context cancelled, stopping execution", "error", err)
+			// Leave saga in Running state - recovery will resume it later
+			return fmt.Errorf("saga execution interrupted: %w", err)
+		}
+
+		// Skip already-executed actions
+		if result, exists := exec.ExecutedActions[actionName]; exists && result.UndoneAt == nil {
+			continue
+		}
+
+		node := def.Actions[actionName]
+		if node == nil {
+			return fmt.Errorf("action %q not found in definition", actionName)
+		}
+
+		// Check that dependencies are satisfied
+		for _, depName := range node.Dependencies {
+			if _, exists := exec.ExecutedActions[depName]; !exists {
+				return fmt.Errorf("action %q dependency %q not satisfied", actionName, depName)
+			}
+		}
+
+		// Build inputs for this action
+		actionInputs := newInputs(exec.InitialInputs, outputs)
+
+		log.Info("executing action", "action", actionName)
+
+		// Execute the action
+		output, err := node.Action.Execute(ctx, actionInputs)
+		now := time.Now()
+
+		if err != nil {
+			log.Error("action failed", "action", actionName, "error", err)
+
+			// Record the failure
+			exec.ExecutedActions[actionName] = &ActionResult{
+				ExecutedAt: now,
+				Error:      err.Error(),
+			}
+			exec.ExecutionOrder = append(exec.ExecutionOrder, actionName)
+			exec.Error = fmt.Sprintf("action %q failed: %v", actionName, err)
+			exec.UpdatedAt = now
+
+			if saveErr := e.storage.Save(ctx, exec); saveErr != nil {
+				log.Error("failed to persist failure state", "error", saveErr)
+			}
+
+			// Start compensation
+			return e.runUndo(ctx, def, exec)
+		}
+
+		// Serialize output
+		outputBytes, err := json.Marshal(output)
+		if err != nil {
+			log.Error("failed to serialize output", "action", actionName, "error", err)
+			exec.Error = fmt.Sprintf("action %q output serialization failed: %v", actionName, err)
+			exec.UpdatedAt = time.Now()
+			e.storage.Save(ctx, exec)
+			return e.runUndo(ctx, def, exec)
+		}
+
+		// Record success
+		exec.ExecutedActions[actionName] = &ActionResult{
+			Output:     outputBytes,
+			ExecutedAt: now,
+		}
+		exec.ExecutionOrder = append(exec.ExecutionOrder, actionName)
+		exec.UpdatedAt = now
+
+		// Persist after each action
+		if err := e.storage.Save(ctx, exec); err != nil {
+			return fmt.Errorf("persisting action result: %w", err)
+		}
+
+		// Add outputs to the map for subsequent actions
+		if err := extractOutputs(node, outputBytes, outputs); err != nil {
+			log.Warn("failed to extract outputs", "action", actionName, "error", err)
+		}
+
+		log.Info("action completed", "action", actionName)
+	}
+
+	// All actions completed successfully
+	exec.Status = StatusCompleted
+	exec.UpdatedAt = time.Now()
+	if err := e.storage.Save(ctx, exec); err != nil {
+		return fmt.Errorf("persisting completed state: %w", err)
+	}
+
+	log.Info("saga completed successfully")
+	return nil
+}
+
+// runUndo rolls back completed actions in reverse order.
+func (e *Executor) runUndo(ctx context.Context, def *Definition, exec *Execution) error {
+	log := e.log.With("saga", def.Name, "execution", exec.ID)
+
+	// Update status to undoing
+	exec.Status = StatusUndoing
+	exec.UpdatedAt = time.Now()
+	if err := e.storage.Save(ctx, exec); err != nil {
+		log.Error("failed to persist undoing state", "error", err)
+	}
+
+	// Inject dependencies into context
+	ctx = injectDependencies(ctx, def.dependencies)
+
+	// Build outputs map from executed actions
+	outputs := make(map[string]json.RawMessage)
+	for actionName, result := range exec.ExecutedActions {
+		if result.UndoneAt != nil {
+			continue
+		}
+		node := def.Actions[actionName]
+		if node == nil {
+			continue
+		}
+		if err := extractOutputs(node, result.Output, outputs); err != nil {
+			log.Warn("failed to extract outputs for undo", "action", actionName, "error", err)
+		}
+	}
+
+	// Undo in reverse execution order
+	var undoErrors []error
+	for i := len(exec.ExecutionOrder) - 1; i >= 0; i-- {
+		// Check for context cancellation between undos
+		if err := ctx.Err(); err != nil {
+			log.Info("context cancelled during undo, stopping", "error", err)
+			// Leave saga in Undoing state - recovery will continue later
+			return fmt.Errorf("saga undo interrupted: %w", err)
+		}
+
+		actionName := exec.ExecutionOrder[i]
+
+		result, exists := exec.ExecutedActions[actionName]
+		if !exists || result.UndoneAt != nil {
+			continue // Already undone or never executed
+		}
+
+		// Skip actions that failed (they have an error and no output to undo)
+		if result.Error != "" {
+			log.Info("skipping undo for failed action", "action", actionName, "error", result.Error)
+			continue
+		}
+
+		node := def.Actions[actionName]
+		if node == nil {
+			log.Warn("action not found in definition during undo", "action", actionName)
+			continue
+		}
+
+		// Build inputs for undo
+		actionInputs := newInputs(exec.InitialInputs, outputs)
+
+		// Deserialize the output
+		var output any
+		if len(result.Output) > 0 {
+			if err := json.Unmarshal(result.Output, &output); err != nil {
+				log.Warn("failed to deserialize output for undo", "action", actionName, "error", err)
+			}
+		}
+
+		log.Info("undoing action", "action", actionName)
+
+		// Execute undo
+		if err := node.Action.Undo(ctx, actionInputs, output); err != nil {
+			log.Error("undo failed", "action", actionName, "error", err)
+			undoErrors = append(undoErrors, fmt.Errorf("undo %q: %w", actionName, err))
+			// Continue with other undos even on failure
+		}
+
+		// Record undo
+		now := time.Now()
+		result.UndoneAt = &now
+		exec.UpdatedAt = now
+
+		if err := e.storage.Save(ctx, exec); err != nil {
+			log.Error("failed to persist undo state", "error", err)
+		}
+
+		log.Info("action undone", "action", actionName)
+	}
+
+	// Mark as failed
+	exec.Status = StatusFailed
+	exec.UpdatedAt = time.Now()
+	if err := e.storage.Save(ctx, exec); err != nil {
+		log.Error("failed to persist failed state", "error", err)
+	}
+
+	log.Info("saga failed and rolled back", "undo_errors", len(undoErrors))
+
+	if len(undoErrors) > 0 {
+		return fmt.Errorf("saga failed with %d undo errors: %v", len(undoErrors), undoErrors)
+	}
+	return fmt.Errorf("saga failed: %s", exec.Error)
+}
+
+// Recover finds and resumes incomplete sagas after a restart.
+func (e *Executor) Recover(ctx context.Context) error {
+	incomplete, err := e.storage.ListIncomplete(ctx)
+	if err != nil {
+		return fmt.Errorf("listing incomplete sagas: %w", err)
+	}
+
+	var recoverErrors []error
+	for _, exec := range incomplete {
+		e.log.Info("recovering saga", "saga", exec.DefinitionName, "execution", exec.ID, "status", exec.Status)
+
+		def, ok := e.registry.Get(exec.DefinitionName)
+		if !ok {
+			e.log.Error("saga definition not found for recovery", "saga", exec.DefinitionName)
+			recoverErrors = append(recoverErrors, fmt.Errorf("definition %q not found", exec.DefinitionName))
+			continue
+		}
+
+		// Check version compatibility
+		if def.Version != exec.DefinitionVersion {
+			e.log.Warn("saga definition version mismatch",
+				"saga", exec.DefinitionName,
+				"execution_version", exec.DefinitionVersion,
+				"current_version", def.Version)
+		}
+
+		switch exec.Status {
+		case StatusRunning:
+			// Resume execution
+			if err := e.runExecution(ctx, def, exec); err != nil {
+				recoverErrors = append(recoverErrors, err)
+			}
+		case StatusUndoing:
+			// Resume undo
+			if err := e.runUndo(ctx, def, exec); err != nil {
+				recoverErrors = append(recoverErrors, err)
+			}
+		}
+	}
+
+	if len(recoverErrors) > 0 {
+		return fmt.Errorf("recovery completed with %d errors", len(recoverErrors))
+	}
+	return nil
+}
+
+// extractOutputs extracts output key-value pairs from an action's output.
+func extractOutputs(node *ActionNode, outputBytes []byte, outputs map[string]json.RawMessage) error {
+	if len(outputBytes) == 0 {
+		return nil
+	}
+
+	// Parse the output as a map to extract individual fields
+	var outputMap map[string]json.RawMessage
+	if err := json.Unmarshal(outputBytes, &outputMap); err != nil {
+		// Not a map, store the whole thing under the action name
+		return nil
+	}
+
+	// Map output fields to saga keys based on the action's output mappings
+	typed, ok := node.Action.(*typedAction)
+	if !ok {
+		return nil
+	}
+
+	for _, mapping := range typed.outMappings {
+		// Look for the field in the output map
+		// Go's JSON encoder uses the field name as-is (capitalized) unless there's a json tag
+		if val, exists := outputMap[mapping.fieldName]; exists {
+			outputs[mapping.sagaKey] = val
+		}
+	}
+
+	return nil
+}
+
+// generateID creates a unique execution ID.
+func generateID() string {
+	return idgen.Gen("saga")
+}

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -210,7 +210,13 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 				log.Error("failed to persist failure state", "error", saveErr)
 			}
 
-			// Start compensation
+			// Set StatusUndoing before compensation so recovery knows to undo
+			exec.Status = StatusUndoing
+			exec.UpdatedAt = time.Now()
+			if saveErr := e.storage.Save(ctx, exec); saveErr != nil {
+				log.Error("failed to persist undoing state", "error", saveErr)
+			}
+
 			return e.runUndo(ctx, def, exec)
 		}
 
@@ -238,6 +244,14 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 			if saveErr := e.storage.Save(ctx, exec); saveErr != nil {
 				log.Error("failed to persist state after serialization error", "error", saveErr)
 			}
+
+			// Set StatusUndoing before compensation so recovery knows to undo
+			exec.Status = StatusUndoing
+			exec.UpdatedAt = time.Now()
+			if saveErr := e.storage.Save(ctx, exec); saveErr != nil {
+				log.Error("failed to persist undoing state", "error", saveErr)
+			}
+
 			return e.runUndo(ctx, def, exec)
 		}
 
@@ -254,6 +268,14 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 		if err := e.storage.Save(ctx, exec); err != nil {
 			log.Error("failed to persist action result, triggering undo", "action", actionName, "error", err)
 			exec.Error = fmt.Sprintf("failed to persist action %q result: %v", actionName, err)
+
+			// Try to set StatusUndoing before compensation (may fail if storage is down)
+			exec.Status = StatusUndoing
+			exec.UpdatedAt = time.Now()
+			if saveErr := e.storage.Save(ctx, exec); saveErr != nil {
+				log.Error("failed to persist undoing state", "error", saveErr)
+			}
+
 			return e.runUndo(ctx, def, exec)
 		}
 
@@ -370,18 +392,24 @@ func (e *Executor) runUndo(ctx context.Context, def *Definition, exec *Execution
 		log.Info("action undone", "action", actionName)
 	}
 
-	// Mark as failed
+	if len(undoErrors) > 0 {
+		// Keep StatusUndoing so recovery can retry failed undos
+		exec.UpdatedAt = time.Now()
+		if err := e.storage.Save(ctx, exec); err != nil {
+			log.Error("failed to persist undoing state", "error", err)
+		}
+		log.Info("saga undo incomplete, will retry on recovery", "undo_errors", len(undoErrors))
+		return fmt.Errorf("saga failed with %d undo errors: %v", len(undoErrors), undoErrors)
+	}
+
+	// All undos succeeded - mark as failed (terminal state)
 	exec.Status = StatusFailed
 	exec.UpdatedAt = time.Now()
 	if err := e.storage.Save(ctx, exec); err != nil {
 		log.Error("failed to persist failed state", "error", err)
 	}
 
-	log.Info("saga failed and rolled back", "undo_errors", len(undoErrors))
-
-	if len(undoErrors) > 0 {
-		return fmt.Errorf("saga failed with %d undo errors: %v", len(undoErrors), undoErrors)
-	}
+	log.Info("saga failed and rolled back")
 	return fmt.Errorf("saga failed: %s", exec.Error)
 }
 
@@ -413,9 +441,20 @@ func (e *Executor) Recover(ctx context.Context) error {
 
 		switch exec.Status {
 		case StatusPending, StatusRunning:
-			// Resume execution (pending means crashed before first action started)
-			if err := e.runExecution(ctx, def, exec); err != nil {
-				recoverErrors = append(recoverErrors, err)
+			// Check if there's a failed action that needs compensation.
+			// This handles the edge case where we crashed after recording failure
+			// but before persisting StatusUndoing.
+			if exec.Error != "" {
+				e.log.Info("found failed action during recovery, starting undo",
+					"saga", exec.DefinitionName, "error", exec.Error)
+				if err := e.runUndo(ctx, def, exec); err != nil {
+					recoverErrors = append(recoverErrors, err)
+				}
+			} else {
+				// Resume execution (pending means crashed before first action started)
+				if err := e.runExecution(ctx, def, exec); err != nil {
+					recoverErrors = append(recoverErrors, err)
+				}
 			}
 		case StatusUndoing:
 			// Resume undo

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -322,6 +322,8 @@ func (e *Executor) runUndo(ctx context.Context, def *Definition, exec *Execution
 		if len(result.Output) > 0 {
 			if err := json.Unmarshal(result.Output, &output); err != nil {
 				log.Warn("failed to deserialize output for undo", "action", actionName, "error", err)
+				undoErrors = append(undoErrors, fmt.Errorf("deserialize output for undo %q: %w", actionName, err))
+				continue
 			}
 		}
 

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -249,9 +249,12 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 		exec.ExecutionOrder = append(exec.ExecutionOrder, actionName)
 		exec.UpdatedAt = now
 
-		// Persist after each action
+		// Persist after each action - if we can't durably record progress,
+		// we must compensate to guarantee a clean terminal state.
 		if err := e.storage.Save(ctx, exec); err != nil {
-			return fmt.Errorf("persisting action result: %w", err)
+			log.Error("failed to persist action result, triggering undo", "action", actionName, "error", err)
+			exec.Error = fmt.Sprintf("failed to persist action %q result: %v", actionName, err)
+			return e.runUndo(ctx, def, exec)
 		}
 
 		// Add outputs to the map for subsequent actions

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -235,7 +235,9 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 				exec.ExecutionOrder = append(exec.ExecutionOrder, actionName)
 			}
 
-			e.storage.Save(ctx, exec)
+			if saveErr := e.storage.Save(ctx, exec); saveErr != nil {
+				log.Error("failed to persist state after serialization error", "error", saveErr)
+			}
 			return e.runUndo(ctx, def, exec)
 		}
 

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -77,8 +77,8 @@ func (e *Executor) Start(definitionName string) *StartBuilder {
 	}
 }
 
-// With adds an initial input to the saga.
-func (sb *StartBuilder) With(key string, value any) *StartBuilder {
+// Input adds an initial input value to the saga execution.
+func (sb *StartBuilder) Input(key string, value any) *StartBuilder {
 	sb.inputs[key] = value
 	return sb
 }

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -231,6 +231,12 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 			// Immediately undo this action with the in-memory output.
 			if undoErr := node.Action.Undo(ctx, actionInputs, output); undoErr != nil {
 				log.Error("undo failed after serialization error", "action", actionName, "error", undoErr)
+				// Record the action even though undo failed, so runUndo can retry.
+				// Output is nil since serialization failed.
+				exec.ExecutedActions[actionName] = &ActionResult{
+					ExecutedAt: now,
+				}
+				exec.ExecutionOrder = append(exec.ExecutionOrder, actionName)
 			} else {
 				// Record as executed and undone so runUndo skips it
 				undoneAt := time.Now()

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -18,7 +18,7 @@ type Storage interface {
 	// Get retrieves an execution by ID.
 	Get(ctx context.Context, id string) (*Execution, error)
 
-	// ListIncomplete returns all executions that need recovery (Running or Undoing).
+	// ListIncomplete returns all executions that need recovery (Pending, Running, or Undoing).
 	ListIncomplete(ctx context.Context) ([]*Execution, error)
 }
 
@@ -435,7 +435,7 @@ func extractOutputs(node *ActionNode, outputBytes []byte, outputs map[string]jso
 	// Parse the output as a map to extract individual fields
 	var outputMap map[string]json.RawMessage
 	if err := json.Unmarshal(outputBytes, &outputMap); err != nil {
-		// Not a map, store the whole thing under the action name
+		// Not a map; nothing to extract into keyed outputs.
 		return nil
 	}
 

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -220,6 +220,21 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 			log.Error("failed to serialize output", "action", actionName, "error", err)
 			exec.Error = fmt.Sprintf("action %q output serialization failed: %v", actionName, err)
 			exec.UpdatedAt = time.Now()
+
+			// The action ran but output can't be persisted for later recovery.
+			// Immediately undo this action with the in-memory output.
+			if undoErr := node.Action.Undo(ctx, actionInputs, output); undoErr != nil {
+				log.Error("undo failed after serialization error", "action", actionName, "error", undoErr)
+			} else {
+				// Record as executed and undone so runUndo skips it
+				undoneAt := time.Now()
+				exec.ExecutedActions[actionName] = &ActionResult{
+					ExecutedAt: now,
+					UndoneAt:   &undoneAt,
+				}
+				exec.ExecutionOrder = append(exec.ExecutionOrder, actionName)
+			}
+
 			e.storage.Save(ctx, exec)
 			return e.runUndo(ctx, def, exec)
 		}
@@ -429,9 +444,9 @@ func extractOutputs(node *ActionNode, outputBytes []byte, outputs map[string]jso
 	}
 
 	for _, mapping := range typed.outMappings {
-		// Look for the field in the output map
-		// Go's JSON encoder uses the field name as-is (capitalized) unless there's a json tag
-		if val, exists := outputMap[mapping.fieldName]; exists {
+		// Look for the field in the output map using the JSON key name
+		// (which accounts for json struct tags)
+		if val, exists := outputMap[mapping.jsonKey]; exists {
 			outputs[mapping.sagaKey] = val
 		}
 	}

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -407,8 +407,8 @@ func (e *Executor) Recover(ctx context.Context) error {
 		}
 
 		switch exec.Status {
-		case StatusRunning:
-			// Resume execution
+		case StatusPending, StatusRunning:
+			// Resume execution (pending means crashed before first action started)
 			if err := e.runExecution(ctx, def, exec); err != nil {
 				recoverErrors = append(recoverErrors, err)
 			}

--- a/pkg/saga/memory_storage.go
+++ b/pkg/saga/memory_storage.go
@@ -1,0 +1,65 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// MemoryStorage is a simple in-memory storage implementation for testing and examples.
+type MemoryStorage struct {
+	mu         sync.Mutex
+	executions map[string]*Execution
+}
+
+// NewMemoryStorage creates a new in-memory storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		executions: make(map[string]*Execution),
+	}
+}
+
+// Save persists an execution to memory.
+func (m *MemoryStorage) Save(ctx context.Context, exec *Execution) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Deep copy to simulate real storage behavior
+	copied := *exec
+	copied.ExecutedActions = make(map[string]*ActionResult)
+	for k, v := range exec.ExecutedActions {
+		copiedResult := *v
+		copied.ExecutedActions[k] = &copiedResult
+	}
+	copied.ExecutionOrder = make([]string, len(exec.ExecutionOrder))
+	copy(copied.ExecutionOrder, exec.ExecutionOrder)
+
+	m.executions[exec.ID] = &copied
+	return nil
+}
+
+// Get retrieves an execution by ID.
+func (m *MemoryStorage) Get(ctx context.Context, id string) (*Execution, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	exec, ok := m.executions[id]
+	if !ok {
+		return nil, errors.New("execution not found")
+	}
+	return exec, nil
+}
+
+// ListIncomplete returns all executions that are still running or undoing.
+func (m *MemoryStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var result []*Execution
+	for _, exec := range m.executions {
+		if exec.Status == StatusRunning || exec.Status == StatusUndoing {
+			result = append(result, exec)
+		}
+	}
+	return result, nil
+}

--- a/pkg/saga/memory_storage.go
+++ b/pkg/saga/memory_storage.go
@@ -50,14 +50,16 @@ func (m *MemoryStorage) Get(ctx context.Context, id string) (*Execution, error) 
 	return exec, nil
 }
 
-// ListIncomplete returns all executions that are still running or undoing.
+// ListIncomplete returns all executions that need recovery.
+// This includes pending (crashed before starting), running, and undoing sagas.
 func (m *MemoryStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	var result []*Execution
 	for _, exec := range m.executions {
-		if exec.Status == StatusRunning || exec.Status == StatusUndoing {
+		switch exec.Status {
+		case StatusPending, StatusRunning, StatusUndoing:
 			result = append(result, exec)
 		}
 	}

--- a/pkg/saga/reflect.go
+++ b/pkg/saga/reflect.go
@@ -1,0 +1,232 @@
+package saga
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// fieldMapping maps struct field names to saga keys based on struct tags.
+type fieldMapping struct {
+	fieldName string
+	sagaKey   string
+}
+
+// extractMappings extracts saga key mappings from a struct type's tags.
+// Uses the "saga" tag to specify the key name.
+func extractMappings(t reflect.Type) ([]fieldMapping, error) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected struct type, got %v", t.Kind())
+	}
+
+	var mappings []fieldMapping
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("saga")
+		if tag == "" {
+			// Use lowercase field name as default
+			tag = strings.ToLower(field.Name)
+		}
+		if tag == "-" {
+			continue // Skip this field
+		}
+		mappings = append(mappings, fieldMapping{
+			fieldName: field.Name,
+			sagaKey:   tag,
+		})
+	}
+	return mappings, nil
+}
+
+// typedAction wraps a typed execute/undo function pair as an Action.
+type typedAction struct {
+	name        string
+	executeFunc reflect.Value
+	undoFunc    reflect.Value
+	inType      reflect.Type
+	outType     reflect.Type
+	inMappings  []fieldMapping
+	outMappings []fieldMapping
+}
+
+// Execute calls the typed execute function, handling input/output marshaling.
+func (a *typedAction) Execute(ctx context.Context, inputs ActionInputs) (any, error) {
+	// Create input struct and populate from inputs
+	inVal := reflect.New(a.inType).Elem()
+	for _, m := range a.inMappings {
+		field := inVal.FieldByName(m.fieldName)
+		if !field.IsValid() || !field.CanSet() {
+			continue
+		}
+
+		// Create a pointer to the field type for unmarshaling
+		target := reflect.New(field.Type()).Interface()
+		if err := inputs.Get(m.sagaKey, target); err != nil {
+			// Check if the field is optional (has omitempty or similar)
+			if !inputs.Has(m.sagaKey) {
+				continue // Skip missing optional inputs
+			}
+			return nil, fmt.Errorf("getting input %q for field %q: %w", m.sagaKey, m.fieldName, err)
+		}
+		field.Set(reflect.ValueOf(target).Elem())
+	}
+
+	// Call the execute function
+	results := a.executeFunc.Call([]reflect.Value{
+		reflect.ValueOf(ctx),
+		inVal,
+	})
+
+	// Handle results: (output, error)
+	outVal := results[0]
+	errVal := results[1]
+
+	if !errVal.IsNil() {
+		return nil, errVal.Interface().(error)
+	}
+
+	return outVal.Interface(), nil
+}
+
+// Undo calls the typed undo function.
+func (a *typedAction) Undo(ctx context.Context, inputs ActionInputs, output any) error {
+	// Create input struct and populate from inputs
+	inVal := reflect.New(a.inType).Elem()
+	for _, m := range a.inMappings {
+		field := inVal.FieldByName(m.fieldName)
+		if !field.IsValid() || !field.CanSet() {
+			continue
+		}
+
+		target := reflect.New(field.Type()).Interface()
+		if err := inputs.Get(m.sagaKey, target); err != nil {
+			if !inputs.Has(m.sagaKey) {
+				continue
+			}
+			return fmt.Errorf("getting input %q for field %q: %w", m.sagaKey, m.fieldName, err)
+		}
+		field.Set(reflect.ValueOf(target).Elem())
+	}
+
+	// Convert output to the expected type
+	outVal := reflect.ValueOf(output)
+	if output != nil && a.outType.Kind() != reflect.Interface {
+		// If output came from JSON deserialization, it might need conversion
+		if outVal.Type() != a.outType {
+			// Try JSON round-trip for type conversion
+			data, err := json.Marshal(output)
+			if err != nil {
+				return fmt.Errorf("marshaling output for undo: %w", err)
+			}
+			newOut := reflect.New(a.outType).Interface()
+			if err := json.Unmarshal(data, newOut); err != nil {
+				return fmt.Errorf("unmarshaling output for undo: %w", err)
+			}
+			outVal = reflect.ValueOf(newOut).Elem()
+		}
+	}
+
+	// Call the undo function
+	results := a.undoFunc.Call([]reflect.Value{
+		reflect.ValueOf(ctx),
+		inVal,
+		outVal,
+	})
+
+	// Handle result: error
+	errVal := results[0]
+	if !errVal.IsNil() {
+		return errVal.Interface().(error)
+	}
+
+	return nil
+}
+
+// wrapTypedAction creates an Action from typed execute and undo functions.
+// executeFunc signature: func(ctx context.Context, in InType) (OutType, error)
+// undoFunc signature: func(ctx context.Context, in InType, out OutType) error
+func wrapTypedAction(name string, executeFunc, undoFunc any) (*typedAction, error) {
+	execVal := reflect.ValueOf(executeFunc)
+	undoVal := reflect.ValueOf(undoFunc)
+
+	// Validate execute function signature
+	execType := execVal.Type()
+	if execType.Kind() != reflect.Func {
+		return nil, fmt.Errorf("execute must be a function")
+	}
+	if execType.NumIn() != 2 {
+		return nil, fmt.Errorf("execute must have 2 parameters (ctx, input), got %d", execType.NumIn())
+	}
+	if execType.NumOut() != 2 {
+		return nil, fmt.Errorf("execute must return 2 values (output, error), got %d", execType.NumOut())
+	}
+
+	// Validate undo function signature
+	undoType := undoVal.Type()
+	if undoType.Kind() != reflect.Func {
+		return nil, fmt.Errorf("undo must be a function")
+	}
+	if undoType.NumIn() != 3 {
+		return nil, fmt.Errorf("undo must have 3 parameters (ctx, input, output), got %d", undoType.NumIn())
+	}
+	if undoType.NumOut() != 1 {
+		return nil, fmt.Errorf("undo must return 1 value (error), got %d", undoType.NumOut())
+	}
+
+	// Extract types
+	inType := execType.In(1)
+	outType := execType.Out(0)
+
+	// Validate type consistency between execute and undo
+	if undoType.In(1) != inType {
+		return nil, fmt.Errorf("undo input type %v doesn't match execute input type %v",
+			undoType.In(1), inType)
+	}
+	if undoType.In(2) != outType {
+		return nil, fmt.Errorf("undo output type %v doesn't match execute output type %v",
+			undoType.In(2), outType)
+	}
+
+	// Extract field mappings
+	inMappings, err := extractMappings(inType)
+	if err != nil {
+		return nil, fmt.Errorf("extracting input mappings: %w", err)
+	}
+	outMappings, err := extractMappings(outType)
+	if err != nil {
+		return nil, fmt.Errorf("extracting output mappings: %w", err)
+	}
+
+	return &typedAction{
+		name:        name,
+		executeFunc: execVal,
+		undoFunc:    undoVal,
+		inType:      inType,
+		outType:     outType,
+		inMappings:  inMappings,
+		outMappings: outMappings,
+	}, nil
+}
+
+// inputKeys returns the saga keys this action reads from.
+func (a *typedAction) inputKeys() []string {
+	keys := make([]string, len(a.inMappings))
+	for i, m := range a.inMappings {
+		keys[i] = m.sagaKey
+	}
+	return keys
+}
+
+// outputKeys returns the saga keys this action writes to.
+func (a *typedAction) outputKeys() []string {
+	keys := make([]string, len(a.outMappings))
+	for i, m := range a.outMappings {
+		keys[i] = m.sagaKey
+	}
+	return keys
+}

--- a/pkg/saga/reflect.go
+++ b/pkg/saga/reflect.go
@@ -12,10 +12,13 @@ import (
 type fieldMapping struct {
 	fieldName string
 	sagaKey   string
+	optional  bool
 }
 
 // extractMappings extracts saga key mappings from a struct type's tags.
-// Uses the "saga" tag to specify the key name.
+// Uses the "saga" tag to specify the key name and options.
+// Format: `saga:"keyname"` or `saga:"keyname,optional"`
+// Use `saga:"-"` to skip a field.
 func extractMappings(t reflect.Type) ([]fieldMapping, error) {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -28,16 +31,29 @@ func extractMappings(t reflect.Type) ([]fieldMapping, error) {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		tag := field.Tag.Get("saga")
+
+		// Parse tag: "keyname" or "keyname,optional"
+		var sagaKey string
+		var optional bool
 		if tag == "" {
 			// Use lowercase field name as default
-			tag = strings.ToLower(field.Name)
-		}
-		if tag == "-" {
+			sagaKey = strings.ToLower(field.Name)
+		} else if tag == "-" {
 			continue // Skip this field
+		} else {
+			parts := strings.Split(tag, ",")
+			sagaKey = parts[0]
+			for _, opt := range parts[1:] {
+				if opt == "optional" {
+					optional = true
+				}
+			}
 		}
+
 		mappings = append(mappings, fieldMapping{
 			fieldName: field.Name,
-			sagaKey:   tag,
+			sagaKey:   sagaKey,
+			optional:  optional,
 		})
 	}
 	return mappings, nil
@@ -64,13 +80,17 @@ func (a *typedAction) Execute(ctx context.Context, inputs ActionInputs) (any, er
 			continue
 		}
 
+		// Check if the input exists
+		if !inputs.Has(m.sagaKey) {
+			if m.optional {
+				continue // Skip missing optional inputs
+			}
+			return nil, fmt.Errorf("missing required input %q for field %q", m.sagaKey, m.fieldName)
+		}
+
 		// Create a pointer to the field type for unmarshaling
 		target := reflect.New(field.Type()).Interface()
 		if err := inputs.Get(m.sagaKey, target); err != nil {
-			// Check if the field is optional (has omitempty or similar)
-			if !inputs.Has(m.sagaKey) {
-				continue // Skip missing optional inputs
-			}
 			return nil, fmt.Errorf("getting input %q for field %q: %w", m.sagaKey, m.fieldName, err)
 		}
 		field.Set(reflect.ValueOf(target).Elem())
@@ -103,11 +123,16 @@ func (a *typedAction) Undo(ctx context.Context, inputs ActionInputs, output any)
 			continue
 		}
 
+		// Check if the input exists
+		if !inputs.Has(m.sagaKey) {
+			if m.optional {
+				continue // Skip missing optional inputs
+			}
+			return fmt.Errorf("missing required input %q for field %q", m.sagaKey, m.fieldName)
+		}
+
 		target := reflect.New(field.Type()).Interface()
 		if err := inputs.Get(m.sagaKey, target); err != nil {
-			if !inputs.Has(m.sagaKey) {
-				continue
-			}
 			return fmt.Errorf("getting input %q for field %q: %w", m.sagaKey, m.fieldName, err)
 		}
 		field.Set(reflect.ValueOf(target).Elem())

--- a/pkg/saga/reflect.go
+++ b/pkg/saga/reflect.go
@@ -43,6 +43,10 @@ func extractMappings(t reflect.Type) ([]fieldMapping, error) {
 		} else {
 			parts := strings.Split(tag, ",")
 			sagaKey = parts[0]
+			if sagaKey == "" {
+				// Tag like ",optional" - use default key name
+				sagaKey = strings.ToLower(field.Name)
+			}
 			for _, opt := range parts[1:] {
 				if opt == "optional" {
 					optional = true

--- a/pkg/saga/reflect.go
+++ b/pkg/saga/reflect.go
@@ -11,6 +11,7 @@ import (
 // fieldMapping maps struct field names to saga keys based on struct tags.
 type fieldMapping struct {
 	fieldName string
+	jsonKey   string // The JSON key name (from json tag or field name)
 	sagaKey   string
 	optional  bool
 }
@@ -54,8 +55,18 @@ func extractMappings(t reflect.Type) ([]fieldMapping, error) {
 			}
 		}
 
+		// Determine JSON key name from json tag or field name
+		jsonKey := field.Name
+		if jsonTag := field.Tag.Get("json"); jsonTag != "" && jsonTag != "-" {
+			parts := strings.Split(jsonTag, ",")
+			if parts[0] != "" {
+				jsonKey = parts[0]
+			}
+		}
+
 		mappings = append(mappings, fieldMapping{
 			fieldName: field.Name,
+			jsonKey:   jsonKey,
 			sagaKey:   sagaKey,
 			optional:  optional,
 		})
@@ -143,20 +154,25 @@ func (a *typedAction) Undo(ctx context.Context, inputs ActionInputs, output any)
 	}
 
 	// Convert output to the expected type
-	outVal := reflect.ValueOf(output)
-	if output != nil && a.outType.Kind() != reflect.Interface {
-		// If output came from JSON deserialization, it might need conversion
-		if outVal.Type() != a.outType {
-			// Try JSON round-trip for type conversion
-			data, err := json.Marshal(output)
-			if err != nil {
-				return fmt.Errorf("marshaling output for undo: %w", err)
+	var outVal reflect.Value
+	if output == nil {
+		outVal = reflect.Zero(a.outType)
+	} else {
+		outVal = reflect.ValueOf(output)
+		if a.outType.Kind() != reflect.Interface {
+			// If output came from JSON deserialization, it might need conversion
+			if outVal.Type() != a.outType {
+				// Try JSON round-trip for type conversion
+				data, err := json.Marshal(output)
+				if err != nil {
+					return fmt.Errorf("marshaling output for undo: %w", err)
+				}
+				newOut := reflect.New(a.outType).Interface()
+				if err := json.Unmarshal(data, newOut); err != nil {
+					return fmt.Errorf("unmarshaling output for undo: %w", err)
+				}
+				outVal = reflect.ValueOf(newOut).Elem()
 			}
-			newOut := reflect.New(a.outType).Interface()
-			if err := json.Unmarshal(data, newOut); err != nil {
-				return fmt.Errorf("unmarshaling output for undo: %w", err)
-			}
-			outVal = reflect.ValueOf(newOut).Elem()
 		}
 	}
 
@@ -183,6 +199,10 @@ func wrapTypedAction(name string, executeFunc, undoFunc any) (*typedAction, erro
 	execVal := reflect.ValueOf(executeFunc)
 	undoVal := reflect.ValueOf(undoFunc)
 
+	// Type references for validation
+	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
+	errType := reflect.TypeOf((*error)(nil)).Elem()
+
 	// Validate execute function signature
 	execType := execVal.Type()
 	if execType.Kind() != reflect.Func {
@@ -193,6 +213,12 @@ func wrapTypedAction(name string, executeFunc, undoFunc any) (*typedAction, erro
 	}
 	if execType.NumOut() != 2 {
 		return nil, fmt.Errorf("execute must return 2 values (output, error), got %d", execType.NumOut())
+	}
+	if !execType.In(0).Implements(ctxType) {
+		return nil, fmt.Errorf("execute first parameter must be context.Context")
+	}
+	if !execType.Out(1).Implements(errType) {
+		return nil, fmt.Errorf("execute second return must implement error")
 	}
 
 	// Validate undo function signature
@@ -206,10 +232,21 @@ func wrapTypedAction(name string, executeFunc, undoFunc any) (*typedAction, erro
 	if undoType.NumOut() != 1 {
 		return nil, fmt.Errorf("undo must return 1 value (error), got %d", undoType.NumOut())
 	}
+	if !undoType.In(0).Implements(ctxType) {
+		return nil, fmt.Errorf("undo first parameter must be context.Context")
+	}
+	if !undoType.Out(0).Implements(errType) {
+		return nil, fmt.Errorf("undo return must implement error")
+	}
 
 	// Extract types
 	inType := execType.In(1)
 	outType := execType.Out(0)
+
+	// Validate input type is a struct (not a pointer) to enable FieldByName in Execute/Undo
+	if inType.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("execute input must be a struct value, got %v", inType)
+	}
 
 	// Validate type consistency between execute and undo
 	if undoType.In(1) != inType {

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -1,0 +1,459 @@
+package saga
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test input/output types
+type AddNumbersIn struct {
+	A int `saga:"a"`
+	B int `saga:"b"`
+}
+
+type AddNumbersOut struct {
+	Sum int `saga:"sum"`
+}
+
+type MultiplyIn struct {
+	Sum    int `saga:"sum"`
+	Factor int `saga:"factor"`
+}
+
+type MultiplyOut struct {
+	Result int `saga:"result"`
+}
+
+// Test controller to track calls
+type testController struct {
+	mu            sync.Mutex
+	addCalls      []AddNumbersIn
+	multiplyCalls []MultiplyIn
+	undoAddCalls  []AddNumbersOut
+	undoMultCalls []MultiplyOut
+	failAdd       bool
+	failMultiply  bool
+}
+
+func (c *testController) recordAdd(in AddNumbersIn) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.addCalls = append(c.addCalls, in)
+}
+
+func (c *testController) recordMultiply(in MultiplyIn) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.multiplyCalls = append(c.multiplyCalls, in)
+}
+
+func (c *testController) recordUndoAdd(out AddNumbersOut) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.undoAddCalls = append(c.undoAddCalls, out)
+}
+
+func (c *testController) recordUndoMult(out MultiplyOut) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.undoMultCalls = append(c.undoMultCalls, out)
+}
+
+// Action functions
+func AddNumbers(ctx context.Context, in AddNumbersIn) (AddNumbersOut, error) {
+	ctrl := From[*testController](ctx)
+	ctrl.recordAdd(in)
+	if ctrl.failAdd {
+		return AddNumbersOut{}, errors.New("add failed")
+	}
+	return AddNumbersOut{Sum: in.A + in.B}, nil
+}
+
+func UndoAddNumbers(ctx context.Context, in AddNumbersIn, out AddNumbersOut) error {
+	ctrl := From[*testController](ctx)
+	ctrl.recordUndoAdd(out)
+	return nil
+}
+
+func Multiply(ctx context.Context, in MultiplyIn) (MultiplyOut, error) {
+	ctrl := From[*testController](ctx)
+	ctrl.recordMultiply(in)
+	if ctrl.failMultiply {
+		return MultiplyOut{}, errors.New("multiply failed")
+	}
+	return MultiplyOut{Result: in.Sum * in.Factor}, nil
+}
+
+func UndoMultiply(ctx context.Context, in MultiplyIn, out MultiplyOut) error {
+	ctrl := From[*testController](ctx)
+	ctrl.recordUndoMult(out)
+	return nil
+}
+
+// In-memory storage for testing
+type memoryStorage struct {
+	mu         sync.Mutex
+	executions map[string]*Execution
+}
+
+func newMemoryStorage() *memoryStorage {
+	return &memoryStorage{
+		executions: make(map[string]*Execution),
+	}
+}
+
+func (m *memoryStorage) Save(ctx context.Context, exec *Execution) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Deep copy to simulate real storage
+	copied := *exec
+	copied.ExecutedActions = make(map[string]*ActionResult)
+	for k, v := range exec.ExecutedActions {
+		copiedResult := *v
+		copied.ExecutedActions[k] = &copiedResult
+	}
+	copied.ExecutionOrder = make([]string, len(exec.ExecutionOrder))
+	copy(copied.ExecutionOrder, exec.ExecutionOrder)
+	m.executions[exec.ID] = &copied
+	return nil
+}
+
+func (m *memoryStorage) Get(ctx context.Context, id string) (*Execution, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	exec, ok := m.executions[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return exec, nil
+}
+
+func (m *memoryStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var result []*Execution
+	for _, exec := range m.executions {
+		if exec.Status == StatusRunning || exec.Status == StatusUndoing {
+			result = append(result, exec)
+		}
+	}
+	return result, nil
+}
+
+func TestBuilder_SingleAction(t *testing.T) {
+	// Clean up global registry
+	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+
+	ctrl := &testController{}
+	err := Define("single-action").
+		With(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Register()
+	require.NoError(t, err)
+
+	def, ok := GetDefinition("single-action")
+	require.True(t, ok)
+	assert.Equal(t, "single-action", def.Name)
+	assert.Len(t, def.Actions, 1)
+	assert.Contains(t, def.Actions, "add")
+}
+
+func TestBuilder_MultipleActionsWithDependencies(t *testing.T) {
+	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+
+	ctrl := &testController{}
+	err := Define("calc").
+		With(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		Register()
+	require.NoError(t, err)
+
+	def, ok := GetDefinition("calc")
+	require.True(t, ok)
+	assert.Len(t, def.Actions, 2)
+
+	// Multiply depends on add (because it needs "sum")
+	multNode := def.Actions["multiply"]
+	assert.Contains(t, multNode.Dependencies, "add")
+
+	// Execution order should have add before multiply
+	addIdx := -1
+	multIdx := -1
+	for i, name := range def.executionOrder {
+		if name == "add" {
+			addIdx = i
+		}
+		if name == "multiply" {
+			multIdx = i
+		}
+	}
+	assert.True(t, addIdx < multIdx, "add should come before multiply")
+}
+
+func TestBuilder_DuplicateOutputsError(t *testing.T) {
+	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+
+	ctrl := &testController{}
+	// Both actions produce "sum"
+	_, err := Define("duplicate").
+		With(ctrl).
+		Action("add1", AddNumbers).Undo(UndoAddNumbers).
+		Action("add2", AddNumbers).Undo(UndoAddNumbers).
+		Build()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sum")
+}
+
+func TestExecutor_Success(t *testing.T) {
+	registry := NewRegistry()
+
+	ctrl := &testController{}
+	err := Define("calc").
+		With(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+
+	ctx := context.Background()
+	err = executor.Start("calc").
+		With("a", 2).
+		With("b", 3).
+		With("factor", 4).
+		WithID("test-exec-1").
+		Execute(ctx)
+	require.NoError(t, err)
+
+	// Verify actions were called
+	assert.Len(t, ctrl.addCalls, 1)
+	assert.Equal(t, AddNumbersIn{A: 2, B: 3}, ctrl.addCalls[0])
+
+	assert.Len(t, ctrl.multiplyCalls, 1)
+	assert.Equal(t, MultiplyIn{Sum: 5, Factor: 4}, ctrl.multiplyCalls[0])
+
+	// Verify no undos
+	assert.Empty(t, ctrl.undoAddCalls)
+	assert.Empty(t, ctrl.undoMultCalls)
+
+	// Verify final state
+	exec, err := storage.Get(ctx, "test-exec-1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, exec.Status)
+	assert.Len(t, exec.ExecutionOrder, 2)
+}
+
+func TestExecutor_FailureAndUndo(t *testing.T) {
+	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+
+	ctrl := &testController{failMultiply: true}
+	err := Define("calc-fail").
+		With(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		Register()
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+	executor := NewExecutor(storage)
+
+	ctx := context.Background()
+	err = executor.Start("calc-fail").
+		With("a", 2).
+		With("b", 3).
+		With("factor", 4).
+		WithID("test-exec-2").
+		Execute(ctx)
+	require.Error(t, err)
+
+	// Verify add was called
+	assert.Len(t, ctrl.addCalls, 1)
+
+	// Verify multiply was attempted
+	assert.Len(t, ctrl.multiplyCalls, 1)
+
+	// Verify undo was called for add (not multiply since it failed)
+	assert.Len(t, ctrl.undoAddCalls, 1)
+	assert.Equal(t, AddNumbersOut{Sum: 5}, ctrl.undoAddCalls[0])
+
+	// Multiply doesn't produce output on failure, so no undo
+	assert.Empty(t, ctrl.undoMultCalls)
+
+	// Verify final state
+	exec, err := storage.Get(ctx, "test-exec-2")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, exec.Status)
+}
+
+func TestExecutor_Recovery(t *testing.T) {
+	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+
+	ctrl := &testController{}
+	err := Define("recoverable").
+		With(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		Register()
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+
+	// Simulate a crashed execution
+	crashedExec := &Execution{
+		ID:                "crashed-exec",
+		DefinitionName:    "recoverable",
+		DefinitionVersion: 1,
+		InitialInputs:     map[string]any{"a": float64(2), "b": float64(3), "factor": float64(4)},
+		Status:            StatusRunning,
+		ExecutedActions: map[string]*ActionResult{
+			"add": {
+				Output:     []byte(`{"sum":5}`),
+				ExecutedAt: time.Now(),
+			},
+		},
+		ExecutionOrder: []string{"add"},
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	storage.Save(context.Background(), crashedExec)
+
+	// Create new executor and recover
+	executor := NewExecutor(storage)
+	err = executor.Recover(context.Background())
+	require.NoError(t, err)
+
+	// Verify only multiply was called (add was already done)
+	assert.Empty(t, ctrl.addCalls) // add not called again
+	assert.Len(t, ctrl.multiplyCalls, 1)
+
+	// Verify final state
+	exec, err := storage.Get(context.Background(), "crashed-exec")
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, exec.Status)
+}
+
+func TestExecutor_ContextCancellation(t *testing.T) {
+	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+
+	ctrl := &testController{}
+	err := Define("cancellable").
+		With(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		Register()
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+	executor := NewExecutor(storage)
+
+	// Create an already-cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = executor.Start("cancellable").
+		With("a", 2).
+		With("b", 3).
+		With("factor", 4).
+		WithID("cancel-exec").
+		Execute(ctx)
+
+	// Should return an error due to cancellation
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "interrupted")
+
+	// Verify saga is left in Running state (no actions executed)
+	exec, err := storage.Get(context.Background(), "cancel-exec")
+	require.NoError(t, err)
+	assert.Equal(t, StatusRunning, exec.Status)
+	assert.Empty(t, exec.ExecutionOrder)
+
+	// No actions should have been called
+	assert.Empty(t, ctrl.addCalls)
+	assert.Empty(t, ctrl.multiplyCalls)
+}
+
+func TestFrom_Panic(t *testing.T) {
+	ctx := context.Background()
+	assert.Panics(t, func() {
+		From[*testController](ctx)
+	})
+}
+
+func TestTryFrom(t *testing.T) {
+	ctx := context.Background()
+
+	// Without dependency
+	ctrl, ok := TryFrom[*testController](ctx)
+	assert.False(t, ok)
+	assert.Nil(t, ctrl)
+
+	// With dependency
+	ctrl = &testController{}
+	ctx = injectDependencies(ctx, []any{ctrl})
+	got, ok := TryFrom[*testController](ctx)
+	assert.True(t, ok)
+	assert.Same(t, ctrl, got)
+}
+
+func TestInputs_Get(t *testing.T) {
+	initial := map[string]any{
+		"name":  "test",
+		"count": float64(42),
+	}
+	outputs := map[string]json.RawMessage{
+		"result": json.RawMessage(`"success"`),
+	}
+
+	inputs := newInputs(initial, outputs)
+
+	// Get from initial
+	var name string
+	err := inputs.Get("name", &name)
+	require.NoError(t, err)
+	assert.Equal(t, "test", name)
+
+	// Get from outputs (takes precedence)
+	var result string
+	err = inputs.Get("result", &result)
+	require.NoError(t, err)
+	assert.Equal(t, "success", result)
+
+	// Missing key
+	var missing string
+	err = inputs.Get("missing", &missing)
+	require.Error(t, err)
+}
+
+func TestInputs_Has(t *testing.T) {
+	initial := map[string]any{"a": 1}
+	outputs := map[string]json.RawMessage{"b": json.RawMessage("2")}
+
+	inputs := newInputs(initial, outputs)
+
+	assert.True(t, inputs.Has("a"))
+	assert.True(t, inputs.Has("b"))
+	assert.False(t, inputs.Has("c"))
+}
+
+func TestInputs_Keys(t *testing.T) {
+	initial := map[string]any{"a": 1, "b": 2}
+	outputs := map[string]json.RawMessage{"b": json.RawMessage("3"), "c": json.RawMessage("4")}
+
+	inputs := newInputs(initial, outputs)
+	keys := inputs.Keys()
+
+	assert.Len(t, keys, 3)
+	assert.Contains(t, keys, "a")
+	assert.Contains(t, keys, "b")
+	assert.Contains(t, keys, "c")
+}

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -40,6 +40,7 @@ type testController struct {
 	undoMultCalls []MultiplyOut
 	failAdd       bool
 	failMultiply  bool
+	failUndoAdd   bool
 }
 
 func (c *testController) recordAdd(in AddNumbersIn) {
@@ -79,6 +80,9 @@ func AddNumbers(ctx context.Context, in AddNumbersIn) (AddNumbersOut, error) {
 func UndoAddNumbers(ctx context.Context, in AddNumbersIn, out AddNumbersOut) error {
 	ctrl := Get[*testController](ctx)
 	ctrl.recordUndoAdd(out)
+	if ctrl.failUndoAdd {
+		return errors.New("undo add failed")
+	}
 	return nil
 }
 
@@ -632,4 +636,49 @@ func TestExecutor_StorageFailureTriggersUndo(t *testing.T) {
 	// where an action executed but wasn't recorded.
 	assert.Len(t, ctrl.undoMultCalls, 1, "multiply should be undone")
 	assert.Len(t, ctrl.undoAddCalls, 1, "add should be undone")
+}
+
+func TestExecutor_FailedUndoNotMarkedAsUndone(t *testing.T) {
+	registry := NewRegistry()
+
+	ctrl := &testController{
+		failMultiply: true, // multiply fails, triggering undo
+		failUndoAdd:  true, // undo of add also fails
+	}
+	err := Define("undo-fail-test").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+
+	err = executor.Start("undo-fail-test").
+		Input("a", 2).
+		Input("b", 3).
+		Input("factor", 4).
+		WithID("undo-fail-exec").
+		Execute(context.Background())
+
+	// Saga should return an error (with undo errors)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "undo errors")
+
+	// Add executed, multiply was attempted
+	assert.Len(t, ctrl.addCalls, 1)
+	assert.Len(t, ctrl.multiplyCalls, 1)
+
+	// Undo was attempted for add (multiply failed so no output to undo)
+	assert.Len(t, ctrl.undoAddCalls, 1)
+
+	// KEY ASSERTION: The "add" action should NOT be marked as undone
+	// because its undo failed. This ensures recovery will retry the undo.
+	exec, err := storage.Get(context.Background(), "undo-fail-exec")
+	require.NoError(t, err)
+
+	addResult := exec.ExecutedActions["add"]
+	require.NotNil(t, addResult)
+	assert.Nil(t, addResult.UndoneAt, "add should NOT be marked as undone since undo failed")
 }

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -681,4 +681,92 @@ func TestExecutor_FailedUndoNotMarkedAsUndone(t *testing.T) {
 	addResult := exec.ExecutedActions["add"]
 	require.NotNil(t, addResult)
 	assert.Nil(t, addResult.UndoneAt, "add should NOT be marked as undone since undo failed")
+
+	// KEY ASSERTION: Status should be Undoing (not Failed) so recovery can retry
+	assert.Equal(t, StatusUndoing, exec.Status, "saga should stay in Undoing status when undo fails")
+}
+
+// trackingStorage wraps memoryStorage and records the status at each Save call.
+type trackingStorage struct {
+	*memoryStorage
+	mu            sync.Mutex
+	statusHistory []Status
+}
+
+func newTrackingStorage() *trackingStorage {
+	return &trackingStorage{
+		memoryStorage: newMemoryStorage(),
+		statusHistory: []Status{},
+	}
+}
+
+func (t *trackingStorage) Save(ctx context.Context, exec *Execution) error {
+	t.mu.Lock()
+	t.statusHistory = append(t.statusHistory, exec.Status)
+	t.mu.Unlock()
+	return t.memoryStorage.Save(ctx, exec)
+}
+
+func (t *trackingStorage) getStatusHistory() []Status {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	result := make([]Status, len(t.statusHistory))
+	copy(result, t.statusHistory)
+	return result
+}
+
+func TestExecutor_RecoveryAfterActionFailure(t *testing.T) {
+	// This test simulates a crash after an action fails but before undo starts.
+	// Without the fix, recovery would incorrectly complete the saga instead of undoing.
+
+	registry := NewRegistry()
+
+	ctrl := &testController{}
+	err := Define("recovery-after-fail").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+
+	// Simulate a crashed execution where multiply failed but undo never started.
+	// This is the state we'd have if we crashed after recording the failure
+	// but before runUndo set StatusUndoing.
+	crashedExec := &Execution{
+		ID:                "crashed-after-fail",
+		DefinitionName:    "recovery-after-fail",
+		DefinitionVersion: 1,
+		InitialInputs:     map[string]any{"a": float64(2), "b": float64(3), "factor": float64(4)},
+		Status:            StatusRunning, // BUG: should be Undoing
+		Error:             "action \"multiply\" failed: multiply failed",
+		ExecutedActions: map[string]*ActionResult{
+			"add": {
+				Output:     []byte(`{"Sum":5}`),
+				ExecutedAt: time.Now(),
+			},
+			"multiply": {
+				ExecutedAt: time.Now(),
+				Error:      "multiply failed",
+			},
+		},
+		ExecutionOrder: []string{"add", "multiply"},
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+	storage.Save(context.Background(), crashedExec)
+
+	// Recover
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err = executor.Recover(context.Background())
+
+	// The saga had a failed action - recovery should have triggered undo
+	exec, _ := storage.Get(context.Background(), "crashed-after-fail")
+
+	// KEY ASSERTION: After recovery, the saga should be Failed (undone),
+	// not Completed. The "add" action should be undone.
+	assert.Equal(t, StatusFailed, exec.Status,
+		"Saga with failed action should be Failed after recovery, not %s", exec.Status)
+	assert.Len(t, ctrl.undoAddCalls, 1, "add should have been undone during recovery")
 }

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -148,17 +148,16 @@ func (m *memoryStorage) ListIncomplete(ctx context.Context) ([]*Execution, error
 }
 
 func TestBuilder_SingleAction(t *testing.T) {
-	// Clean up global registry
-	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+	registry := NewRegistry()
 
 	ctrl := &testController{}
 	err := Define("single-action").
 		With(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
-		Register()
+		RegisterTo(registry)
 	require.NoError(t, err)
 
-	def, ok := GetDefinition("single-action")
+	def, ok := registry.Get("single-action")
 	require.True(t, ok)
 	assert.Equal(t, "single-action", def.Name)
 	assert.Len(t, def.Actions, 1)
@@ -166,17 +165,17 @@ func TestBuilder_SingleAction(t *testing.T) {
 }
 
 func TestBuilder_MultipleActionsWithDependencies(t *testing.T) {
-	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+	registry := NewRegistry()
 
 	ctrl := &testController{}
 	err := Define("calc").
 		With(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		Action("multiply", Multiply).Undo(UndoMultiply).
-		Register()
+		RegisterTo(registry)
 	require.NoError(t, err)
 
-	def, ok := GetDefinition("calc")
+	def, ok := registry.Get("calc")
 	require.True(t, ok)
 	assert.Len(t, def.Actions, 2)
 
@@ -199,8 +198,6 @@ func TestBuilder_MultipleActionsWithDependencies(t *testing.T) {
 }
 
 func TestBuilder_DuplicateOutputsError(t *testing.T) {
-	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
-
 	ctrl := &testController{}
 	// Both actions produce "sum"
 	_, err := Define("duplicate").
@@ -254,18 +251,18 @@ func TestExecutor_Success(t *testing.T) {
 }
 
 func TestExecutor_FailureAndUndo(t *testing.T) {
-	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+	registry := NewRegistry()
 
 	ctrl := &testController{failMultiply: true}
 	err := Define("calc-fail").
 		With(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		Action("multiply", Multiply).Undo(UndoMultiply).
-		Register()
+		RegisterTo(registry)
 	require.NoError(t, err)
 
 	storage := newMemoryStorage()
-	executor := NewExecutor(storage)
+	executor := NewExecutor(storage, WithRegistry(registry))
 
 	ctx := context.Background()
 	err = executor.Start("calc-fail").
@@ -296,19 +293,20 @@ func TestExecutor_FailureAndUndo(t *testing.T) {
 }
 
 func TestExecutor_Recovery(t *testing.T) {
-	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+	registry := NewRegistry()
 
 	ctrl := &testController{}
 	err := Define("recoverable").
 		With(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		Action("multiply", Multiply).Undo(UndoMultiply).
-		Register()
+		RegisterTo(registry)
 	require.NoError(t, err)
 
 	storage := newMemoryStorage()
 
 	// Simulate a crashed execution
+	// Note: Output uses uppercase "Sum" because Go's json.Marshal uses field names as-is
 	crashedExec := &Execution{
 		ID:                "crashed-exec",
 		DefinitionName:    "recoverable",
@@ -317,7 +315,7 @@ func TestExecutor_Recovery(t *testing.T) {
 		Status:            StatusRunning,
 		ExecutedActions: map[string]*ActionResult{
 			"add": {
-				Output:     []byte(`{"sum":5}`),
+				Output:     []byte(`{"Sum":5}`),
 				ExecutedAt: time.Now(),
 			},
 		},
@@ -328,7 +326,7 @@ func TestExecutor_Recovery(t *testing.T) {
 	storage.Save(context.Background(), crashedExec)
 
 	// Create new executor and recover
-	executor := NewExecutor(storage)
+	executor := NewExecutor(storage, WithRegistry(registry))
 	err = executor.Recover(context.Background())
 	require.NoError(t, err)
 
@@ -343,18 +341,18 @@ func TestExecutor_Recovery(t *testing.T) {
 }
 
 func TestExecutor_ContextCancellation(t *testing.T) {
-	globalRegistry = &Registry{definitions: make(map[string]*Definition)}
+	registry := NewRegistry()
 
 	ctrl := &testController{}
 	err := Define("cancellable").
 		With(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		Action("multiply", Multiply).Undo(UndoMultiply).
-		Register()
+		RegisterTo(registry)
 	require.NoError(t, err)
 
 	storage := newMemoryStorage()
-	executor := NewExecutor(storage)
+	executor := NewExecutor(storage, WithRegistry(registry))
 
 	// Create an already-cancelled context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -456,4 +454,75 @@ func TestInputs_Keys(t *testing.T) {
 	assert.Contains(t, keys, "a")
 	assert.Contains(t, keys, "b")
 	assert.Contains(t, keys, "c")
+}
+
+// Test types for optional input testing
+type OptionalIn struct {
+	Required int `saga:"required"`
+	Optional int `saga:"optional,optional"`
+}
+
+type OptionalOut struct {
+	Result int `saga:"result"`
+}
+
+func OptionalAction(ctx context.Context, in OptionalIn) (OptionalOut, error) {
+	return OptionalOut{Result: in.Required + in.Optional}, nil
+}
+
+func UndoOptionalAction(ctx context.Context, in OptionalIn, out OptionalOut) error {
+	return nil
+}
+
+func TestExecutor_MissingRequiredInput(t *testing.T) {
+	registry := NewRegistry()
+
+	err := Define("required-test").
+		Action("optional-action", OptionalAction).Undo(UndoOptionalAction).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+
+	ctx := context.Background()
+	// Missing "required" input should cause an error
+	err = executor.Start("required-test").
+		With("optional", 10).
+		WithID("missing-required").
+		Execute(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required input")
+	assert.Contains(t, err.Error(), "required")
+}
+
+func TestExecutor_OptionalInput(t *testing.T) {
+	registry := NewRegistry()
+
+	err := Define("optional-test").
+		Action("optional-action", OptionalAction).Undo(UndoOptionalAction).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+
+	ctx := context.Background()
+	// Missing "optional" input should use zero value (0)
+	err = executor.Start("optional-test").
+		With("required", 5).
+		WithID("optional-missing").
+		Execute(ctx)
+	require.NoError(t, err)
+
+	// Verify execution completed
+	exec, err := storage.Get(ctx, "optional-missing")
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, exec.Status)
+
+	// Result should be 5 + 0 = 5
+	var output OptionalOut
+	err = json.Unmarshal(exec.ExecutedActions["optional-action"].Output, &output)
+	require.NoError(t, err)
+	assert.Equal(t, 5, output.Result)
 }

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -140,7 +140,7 @@ func (m *memoryStorage) ListIncomplete(ctx context.Context) ([]*Execution, error
 	defer m.mu.Unlock()
 	var result []*Execution
 	for _, exec := range m.executions {
-		if exec.Status == StatusRunning || exec.Status == StatusUndoing {
+		if exec.Status == StatusPending || exec.Status == StatusRunning || exec.Status == StatusUndoing {
 			result = append(result, exec)
 		}
 	}

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -403,6 +403,44 @@ func TestTryGet(t *testing.T) {
 	assert.Same(t, ctrl, got)
 }
 
+// testService is an interface for testing UsingAs.
+type testService interface {
+	DoWork() string
+}
+
+// testServiceImpl implements testService.
+type testServiceImpl struct {
+	name string
+}
+
+func (s *testServiceImpl) DoWork() string {
+	return s.name
+}
+
+func TestUsingAs_InterfaceInjection(t *testing.T) {
+	impl := &testServiceImpl{name: "test-impl"}
+
+	// Build a saga using UsingAs to key by interface type
+	b := Define("interface-test")
+	UsingAs[testService](b, impl)
+
+	// Verify the dependency is stored correctly
+	assert.Len(t, b.dependencies, 1)
+
+	// Inject and retrieve by interface type
+	ctx := context.Background()
+	ctx = injectDependencies(ctx, b.dependencies)
+
+	// Should be retrievable by interface type
+	svc, ok := TryGet[testService](ctx)
+	assert.True(t, ok, "should find dependency by interface type")
+	assert.Equal(t, "test-impl", svc.DoWork())
+
+	// Should NOT be retrievable by concrete type (different key)
+	_, ok = TryGet[*testServiceImpl](ctx)
+	assert.False(t, ok, "should not find dependency by concrete type when keyed by interface")
+}
+
 func TestInputs_Get(t *testing.T) {
 	initial := map[string]any{
 		"name":  "test",

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -564,3 +564,72 @@ func TestExecutor_OptionalInput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 5, output.Result)
 }
+
+// failingStorage wraps memoryStorage but fails Save after N successful calls.
+type failingStorage struct {
+	*memoryStorage
+	failAfter int
+	saveCount int
+	mu        sync.Mutex
+}
+
+func newFailingStorage(failAfter int) *failingStorage {
+	return &failingStorage{
+		memoryStorage: newMemoryStorage(),
+		failAfter:     failAfter,
+	}
+}
+
+func (f *failingStorage) Save(ctx context.Context, exec *Execution) error {
+	f.mu.Lock()
+	f.saveCount++
+	count := f.saveCount
+	f.mu.Unlock()
+
+	if count > f.failAfter {
+		return errors.New("simulated storage failure")
+	}
+	return f.memoryStorage.Save(ctx, exec)
+}
+
+func TestExecutor_StorageFailureTriggersUndo(t *testing.T) {
+	registry := NewRegistry()
+
+	ctrl := &testController{}
+	err := Define("storage-fail-test").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	// Storage that fails after 3 saves:
+	// 1. Initial save (StatusPending)
+	// 2. Status update (StatusRunning)
+	// 3. After "add" action succeeds
+	// 4. FAIL - after "multiply" action succeeds
+	storage := newFailingStorage(3)
+	executor := NewExecutor(storage, WithRegistry(registry))
+
+	err = executor.Start("storage-fail-test").
+		Input("a", 2).
+		Input("b", 3).
+		Input("factor", 4).
+		WithID("storage-fail-exec").
+		Execute(context.Background())
+
+	// Saga returns an error indicating it failed and was rolled back
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "saga failed")
+
+	// Both actions should have been executed
+	assert.Len(t, ctrl.addCalls, 1)
+	assert.Len(t, ctrl.multiplyCalls, 1)
+
+	// KEY ASSERTION: Both actions should have been undone because
+	// storage failure after multiply triggered compensation.
+	// This verifies the fix: we don't leave the saga in a broken state
+	// where an action executed but wasn't recorded.
+	assert.Len(t, ctrl.undoMultCalls, 1, "multiply should be undone")
+	assert.Len(t, ctrl.undoAddCalls, 1, "add should be undone")
+}

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -68,7 +68,7 @@ func (c *testController) recordUndoMult(out MultiplyOut) {
 
 // Action functions
 func AddNumbers(ctx context.Context, in AddNumbersIn) (AddNumbersOut, error) {
-	ctrl := From[*testController](ctx)
+	ctrl := Get[*testController](ctx)
 	ctrl.recordAdd(in)
 	if ctrl.failAdd {
 		return AddNumbersOut{}, errors.New("add failed")
@@ -77,13 +77,13 @@ func AddNumbers(ctx context.Context, in AddNumbersIn) (AddNumbersOut, error) {
 }
 
 func UndoAddNumbers(ctx context.Context, in AddNumbersIn, out AddNumbersOut) error {
-	ctrl := From[*testController](ctx)
+	ctrl := Get[*testController](ctx)
 	ctrl.recordUndoAdd(out)
 	return nil
 }
 
 func Multiply(ctx context.Context, in MultiplyIn) (MultiplyOut, error) {
-	ctrl := From[*testController](ctx)
+	ctrl := Get[*testController](ctx)
 	ctrl.recordMultiply(in)
 	if ctrl.failMultiply {
 		return MultiplyOut{}, errors.New("multiply failed")
@@ -92,7 +92,7 @@ func Multiply(ctx context.Context, in MultiplyIn) (MultiplyOut, error) {
 }
 
 func UndoMultiply(ctx context.Context, in MultiplyIn, out MultiplyOut) error {
-	ctrl := From[*testController](ctx)
+	ctrl := Get[*testController](ctx)
 	ctrl.recordUndoMult(out)
 	return nil
 }
@@ -152,7 +152,7 @@ func TestBuilder_SingleAction(t *testing.T) {
 
 	ctrl := &testController{}
 	err := Define("single-action").
-		With(ctrl).
+		Using(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		RegisterTo(registry)
 	require.NoError(t, err)
@@ -169,7 +169,7 @@ func TestBuilder_MultipleActionsWithDependencies(t *testing.T) {
 
 	ctrl := &testController{}
 	err := Define("calc").
-		With(ctrl).
+		Using(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		Action("multiply", Multiply).Undo(UndoMultiply).
 		RegisterTo(registry)
@@ -201,7 +201,7 @@ func TestBuilder_DuplicateOutputsError(t *testing.T) {
 	ctrl := &testController{}
 	// Both actions produce "sum"
 	_, err := Define("duplicate").
-		With(ctrl).
+		Using(ctrl).
 		Action("add1", AddNumbers).Undo(UndoAddNumbers).
 		Action("add2", AddNumbers).Undo(UndoAddNumbers).
 		Build()
@@ -214,7 +214,7 @@ func TestExecutor_Success(t *testing.T) {
 
 	ctrl := &testController{}
 	err := Define("calc").
-		With(ctrl).
+		Using(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		Action("multiply", Multiply).Undo(UndoMultiply).
 		RegisterTo(registry)
@@ -225,9 +225,9 @@ func TestExecutor_Success(t *testing.T) {
 
 	ctx := context.Background()
 	err = executor.Start("calc").
-		With("a", 2).
-		With("b", 3).
-		With("factor", 4).
+		Input("a", 2).
+		Input("b", 3).
+		Input("factor", 4).
 		WithID("test-exec-1").
 		Execute(ctx)
 	require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestExecutor_FailureAndUndo(t *testing.T) {
 
 	ctrl := &testController{failMultiply: true}
 	err := Define("calc-fail").
-		With(ctrl).
+		Using(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		Action("multiply", Multiply).Undo(UndoMultiply).
 		RegisterTo(registry)
@@ -266,9 +266,9 @@ func TestExecutor_FailureAndUndo(t *testing.T) {
 
 	ctx := context.Background()
 	err = executor.Start("calc-fail").
-		With("a", 2).
-		With("b", 3).
-		With("factor", 4).
+		Input("a", 2).
+		Input("b", 3).
+		Input("factor", 4).
 		WithID("test-exec-2").
 		Execute(ctx)
 	require.Error(t, err)
@@ -297,7 +297,7 @@ func TestExecutor_Recovery(t *testing.T) {
 
 	ctrl := &testController{}
 	err := Define("recoverable").
-		With(ctrl).
+		Using(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		Action("multiply", Multiply).Undo(UndoMultiply).
 		RegisterTo(registry)
@@ -345,7 +345,7 @@ func TestExecutor_ContextCancellation(t *testing.T) {
 
 	ctrl := &testController{}
 	err := Define("cancellable").
-		With(ctrl).
+		Using(ctrl).
 		Action("add", AddNumbers).Undo(UndoAddNumbers).
 		Action("multiply", Multiply).Undo(UndoMultiply).
 		RegisterTo(registry)
@@ -359,9 +359,9 @@ func TestExecutor_ContextCancellation(t *testing.T) {
 	cancel()
 
 	err = executor.Start("cancellable").
-		With("a", 2).
-		With("b", 3).
-		With("factor", 4).
+		Input("a", 2).
+		Input("b", 3).
+		Input("factor", 4).
 		WithID("cancel-exec").
 		Execute(ctx)
 
@@ -380,25 +380,25 @@ func TestExecutor_ContextCancellation(t *testing.T) {
 	assert.Empty(t, ctrl.multiplyCalls)
 }
 
-func TestFrom_Panic(t *testing.T) {
+func TestGet_Panic(t *testing.T) {
 	ctx := context.Background()
 	assert.Panics(t, func() {
-		From[*testController](ctx)
+		Get[*testController](ctx)
 	})
 }
 
-func TestTryFrom(t *testing.T) {
+func TestTryGet(t *testing.T) {
 	ctx := context.Background()
 
 	// Without dependency
-	ctrl, ok := TryFrom[*testController](ctx)
+	ctrl, ok := TryGet[*testController](ctx)
 	assert.False(t, ok)
 	assert.Nil(t, ctrl)
 
 	// With dependency
 	ctrl = &testController{}
 	ctx = injectDependencies(ctx, []any{ctrl})
-	got, ok := TryFrom[*testController](ctx)
+	got, ok := TryGet[*testController](ctx)
 	assert.True(t, ok)
 	assert.Same(t, ctrl, got)
 }
@@ -488,7 +488,7 @@ func TestExecutor_MissingRequiredInput(t *testing.T) {
 	ctx := context.Background()
 	// Missing "required" input should cause an error
 	err = executor.Start("required-test").
-		With("optional", 10).
+		Input("optional", 10).
 		WithID("missing-required").
 		Execute(ctx)
 	require.Error(t, err)
@@ -510,7 +510,7 @@ func TestExecutor_OptionalInput(t *testing.T) {
 	ctx := context.Background()
 	// Missing "optional" input should use zero value (0)
 	err = executor.Start("optional-test").
-		With("required", 5).
+		Input("required", 5).
 		WithID("optional-missing").
 		Execute(ctx)
 	require.NoError(t, err)

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -686,35 +686,6 @@ func TestExecutor_FailedUndoNotMarkedAsUndone(t *testing.T) {
 	assert.Equal(t, StatusUndoing, exec.Status, "saga should stay in Undoing status when undo fails")
 }
 
-// trackingStorage wraps memoryStorage and records the status at each Save call.
-type trackingStorage struct {
-	*memoryStorage
-	mu            sync.Mutex
-	statusHistory []Status
-}
-
-func newTrackingStorage() *trackingStorage {
-	return &trackingStorage{
-		memoryStorage: newMemoryStorage(),
-		statusHistory: []Status{},
-	}
-}
-
-func (t *trackingStorage) Save(ctx context.Context, exec *Execution) error {
-	t.mu.Lock()
-	t.statusHistory = append(t.statusHistory, exec.Status)
-	t.mu.Unlock()
-	return t.memoryStorage.Save(ctx, exec)
-}
-
-func (t *trackingStorage) getStatusHistory() []Status {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	result := make([]Status, len(t.statusHistory))
-	copy(result, t.statusHistory)
-	return result
-}
-
 func TestExecutor_RecoveryAfterActionFailure(t *testing.T) {
 	// This test simulates a crash after an action fails but before undo starts.
 	// Without the fix, recovery would incorrectly complete the saga instead of undoing.
@@ -759,7 +730,7 @@ func TestExecutor_RecoveryAfterActionFailure(t *testing.T) {
 
 	// Recover
 	executor := NewExecutor(storage, WithRegistry(registry))
-	err = executor.Recover(context.Background())
+	_ = executor.Recover(context.Background())
 
 	// The saga had a failed action - recovery should have triggered undo
 	exec, _ := storage.Get(context.Background(), "crashed-after-fail")
@@ -769,4 +740,75 @@ func TestExecutor_RecoveryAfterActionFailure(t *testing.T) {
 	assert.Equal(t, StatusFailed, exec.Status,
 		"Saga with failed action should be Failed after recovery, not %s", exec.Status)
 	assert.Len(t, ctrl.undoAddCalls, 1, "add should have been undone during recovery")
+}
+
+// UnserializableOut contains a channel which json.Marshal cannot serialize.
+type UnserializableOut struct {
+	Value int
+	Ch    chan int // channels can't be serialized
+}
+
+type unserializableController struct {
+	executeCalls int
+	undoCalls    int
+	failUndo     bool
+}
+
+func UnserializableAction(ctx context.Context, in AddNumbersIn) (UnserializableOut, error) {
+	ctrl := Get[*unserializableController](ctx)
+	ctrl.executeCalls++
+	return UnserializableOut{Value: in.A + in.B, Ch: make(chan int)}, nil
+}
+
+func UndoUnserializableAction(ctx context.Context, in AddNumbersIn, out UnserializableOut) error {
+	ctrl := Get[*unserializableController](ctx)
+	ctrl.undoCalls++
+	if ctrl.failUndo {
+		return errors.New("undo failed")
+	}
+	return nil
+}
+
+func TestExecutor_SerializationFailurePlusUndoFailure(t *testing.T) {
+	// This tests the edge case where:
+	// 1. Action executes successfully
+	// 2. Output serialization fails (contains channel)
+	// 3. Immediate undo also fails
+	// The action should still be recorded so runUndo can retry.
+
+	registry := NewRegistry()
+
+	ctrl := &unserializableController{failUndo: true}
+	err := Define("unserializable-test").
+		Using(ctrl).
+		Action("unserializable", UnserializableAction).Undo(UndoUnserializableAction).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+
+	err = executor.Start("unserializable-test").
+		Input("a", 2).
+		Input("b", 3).
+		WithID("unserializable-exec").
+		Execute(context.Background())
+
+	// Saga should fail (undo errors)
+	require.Error(t, err)
+
+	// Action was executed
+	assert.Equal(t, 1, ctrl.executeCalls)
+
+	// Undo was attempted twice:
+	// 1. Immediate undo after serialization failure (failed)
+	// 2. runUndo retry (also failed, but at least it was attempted)
+	assert.Equal(t, 2, ctrl.undoCalls, "undo should be attempted twice: immediate + runUndo retry")
+
+	// KEY ASSERTION: The action should be recorded even though immediate undo failed
+	exec, err := storage.Get(context.Background(), "unserializable-exec")
+	require.NoError(t, err)
+
+	_, recorded := exec.ExecutedActions["unserializable"]
+	assert.True(t, recorded, "action should be recorded even when immediate undo fails")
 }

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -1,0 +1,215 @@
+package saga
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	saga_v1alpha "miren.dev/runtime/api/saga/saga_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// EntityStorage implements Storage using the entity store.
+type EntityStorage struct {
+	store entity.Store
+	log   *slog.Logger
+}
+
+// NewEntityStorage creates a storage backed by an entity store.
+func NewEntityStorage(store entity.Store, log *slog.Logger) *EntityStorage {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &EntityStorage{store: store, log: log}
+}
+
+// Save persists the execution state as an entity.
+func (s *EntityStorage) Save(ctx context.Context, exec *Execution) error {
+	// Serialize complex fields to JSON
+	initialInputs, err := json.Marshal(exec.InitialInputs)
+	if err != nil {
+		return fmt.Errorf("marshaling initial inputs: %w", err)
+	}
+
+	executedActions, err := json.Marshal(exec.ExecutedActions)
+	if err != nil {
+		return fmt.Errorf("marshaling executed actions: %w", err)
+	}
+
+	executionOrder, err := json.Marshal(exec.ExecutionOrder)
+	if err != nil {
+		return fmt.Errorf("marshaling execution order: %w", err)
+	}
+
+	// Convert status
+	status := statusToEntity(exec.Status)
+
+	// Build saga entity
+	sagaEntity := &saga_v1alpha.Saga{
+		ID:                entity.Id(exec.ID),
+		DefinitionName:    exec.DefinitionName,
+		DefinitionVersion: int64(exec.DefinitionVersion),
+		Status:            status,
+		InitialInputs:     initialInputs,
+		ExecutedActions:   executedActions,
+		ExecutionOrder:    executionOrder,
+		Error:             exec.Error,
+	}
+
+	// Create or update the entity
+	ent := entity.New(
+		entity.DBId, exec.ID,
+		sagaEntity.Encode(),
+	)
+
+	_, _, err = s.store.EnsureEntity(ctx, ent)
+	if err != nil {
+		return fmt.Errorf("saving saga entity: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves an execution by ID.
+func (s *EntityStorage) Get(ctx context.Context, id string) (*Execution, error) {
+	ent, err := s.store.GetEntity(ctx, entity.Id(id))
+	if err != nil {
+		return nil, fmt.Errorf("getting saga entity: %w", err)
+	}
+
+	sagaEntity, ok := entity.As[saga_v1alpha.Saga](ent)
+	if !ok {
+		return nil, fmt.Errorf("entity %s is not a saga", id)
+	}
+
+	return entityToExecution(sagaEntity)
+}
+
+// ListIncomplete returns all executions that need recovery.
+func (s *EntityStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
+	// Query for running sagas
+	runningIds, err := s.store.ListIndex(ctx, entity.Ref(
+		saga_v1alpha.SagaStatusId,
+		saga_v1alpha.SagaStatusRunningId,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("listing running sagas: %w", err)
+	}
+
+	// Query for undoing sagas
+	undoingIds, err := s.store.ListIndex(ctx, entity.Ref(
+		saga_v1alpha.SagaStatusId,
+		saga_v1alpha.SagaStatusUndoingId,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("listing undoing sagas: %w", err)
+	}
+
+	// Combine IDs
+	allIds := append(runningIds, undoingIds...)
+	if len(allIds) == 0 {
+		return nil, nil
+	}
+
+	// Batch fetch all entities
+	entities, err := s.store.GetEntities(ctx, allIds)
+	if err != nil {
+		return nil, fmt.Errorf("fetching saga entities: %w", err)
+	}
+
+	// Convert to executions
+	var executions []*Execution
+	for _, ent := range entities {
+		if ent == nil {
+			continue
+		}
+		sagaEntity, ok := entity.As[saga_v1alpha.Saga](ent)
+		if !ok {
+			s.log.Warn("entity is not a saga, skipping", "id", ent.Id())
+			continue
+		}
+		exec, err := entityToExecution(sagaEntity)
+		if err != nil {
+			s.log.Warn("failed to convert saga entity, skipping", "id", ent.Id(), "error", err)
+			continue
+		}
+		executions = append(executions, exec)
+	}
+
+	return executions, nil
+}
+
+// statusToEntity converts saga.Status to the entity enum value.
+func statusToEntity(s Status) saga_v1alpha.SagaStatus {
+	switch s {
+	case StatusPending:
+		return saga_v1alpha.PENDING
+	case StatusRunning:
+		return saga_v1alpha.RUNNING
+	case StatusUndoing:
+		return saga_v1alpha.UNDOING
+	case StatusCompleted:
+		return saga_v1alpha.COMPLETED
+	case StatusFailed:
+		return saga_v1alpha.FAILED
+	default:
+		return saga_v1alpha.PENDING
+	}
+}
+
+// statusFromEntity converts the entity enum value to saga.Status.
+func statusFromEntity(s saga_v1alpha.SagaStatus) Status {
+	switch s {
+	case saga_v1alpha.PENDING:
+		return StatusPending
+	case saga_v1alpha.RUNNING:
+		return StatusRunning
+	case saga_v1alpha.UNDOING:
+		return StatusUndoing
+	case saga_v1alpha.COMPLETED:
+		return StatusCompleted
+	case saga_v1alpha.FAILED:
+		return StatusFailed
+	default:
+		return StatusPending
+	}
+}
+
+// entityToExecution converts a saga entity to an Execution.
+func entityToExecution(sagaEntity *saga_v1alpha.Saga) (*Execution, error) {
+	exec := &Execution{
+		ID:                string(sagaEntity.ID),
+		DefinitionName:    sagaEntity.DefinitionName,
+		DefinitionVersion: int(sagaEntity.DefinitionVersion),
+		Status:            statusFromEntity(sagaEntity.Status),
+		Error:             sagaEntity.Error,
+	}
+
+	// Deserialize initial inputs
+	if len(sagaEntity.InitialInputs) > 0 {
+		if err := json.Unmarshal(sagaEntity.InitialInputs, &exec.InitialInputs); err != nil {
+			return nil, fmt.Errorf("unmarshaling initial inputs: %w", err)
+		}
+	} else {
+		exec.InitialInputs = make(map[string]any)
+	}
+
+	// Deserialize executed actions
+	if len(sagaEntity.ExecutedActions) > 0 {
+		if err := json.Unmarshal(sagaEntity.ExecutedActions, &exec.ExecutedActions); err != nil {
+			return nil, fmt.Errorf("unmarshaling executed actions: %w", err)
+		}
+	} else {
+		exec.ExecutedActions = make(map[string]*ActionResult)
+	}
+
+	// Deserialize execution order
+	if len(sagaEntity.ExecutionOrder) > 0 {
+		if err := json.Unmarshal(sagaEntity.ExecutionOrder, &exec.ExecutionOrder); err != nil {
+			return nil, fmt.Errorf("unmarshaling execution order: %w", err)
+		}
+	}
+
+	return exec, nil
+}

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -88,6 +88,15 @@ func (s *EntityStorage) Get(ctx context.Context, id string) (*Execution, error) 
 
 // ListIncomplete returns all executions that need recovery.
 func (s *EntityStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
+	// Query for pending sagas (crashed between initial save and status transition)
+	pendingIds, err := s.store.ListIndex(ctx, entity.Ref(
+		saga_v1alpha.SagaStatusId,
+		saga_v1alpha.SagaStatusPendingId,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("listing pending sagas: %w", err)
+	}
+
 	// Query for running sagas
 	runningIds, err := s.store.ListIndex(ctx, entity.Ref(
 		saga_v1alpha.SagaStatusId,
@@ -107,7 +116,8 @@ func (s *EntityStorage) ListIncomplete(ctx context.Context) ([]*Execution, error
 	}
 
 	// Combine IDs
-	allIds := append(runningIds, undoingIds...)
+	allIds := append(pendingIds, runningIds...)
+	allIds = append(allIds, undoingIds...)
 	if len(allIds) == 0 {
 		return nil, nil
 	}

--- a/pkg/saga/types.go
+++ b/pkg/saga/types.go
@@ -1,0 +1,80 @@
+// Package saga implements the Saga pattern for distributed operations with
+// crash recovery. Each saga is a sequence of steps where each step has a
+// corresponding undo operation. The framework guarantees that either all
+// steps complete successfully or all completed steps are rolled back.
+//
+// See RFD-35 for detailed design documentation.
+package saga
+
+import (
+	"time"
+)
+
+// Status represents the current state of a saga execution.
+type Status string
+
+const (
+	// StatusPending indicates the saga has been created but not started.
+	StatusPending Status = "pending"
+
+	// StatusRunning indicates the saga is actively executing actions.
+	StatusRunning Status = "running"
+
+	// StatusUndoing indicates the saga is rolling back due to a failure.
+	StatusUndoing Status = "undoing"
+
+	// StatusCompleted indicates all actions completed successfully.
+	StatusCompleted Status = "completed"
+
+	// StatusFailed indicates the saga failed and all undos have been attempted.
+	StatusFailed Status = "failed"
+)
+
+// ActionResult stores the outcome of a single action execution.
+type ActionResult struct {
+	// Output is the JSON-serialized output from the action.
+	Output []byte `json:"output,omitempty"`
+
+	// ExecutedAt is when the action was executed.
+	ExecutedAt time.Time `json:"executed_at"`
+
+	// UndoneAt is when the action was undone (nil if not undone).
+	UndoneAt *time.Time `json:"undone_at,omitempty"`
+
+	// Error is set if the action failed during execution.
+	Error string `json:"error,omitempty"`
+}
+
+// Execution tracks the runtime state of a saga, persisted after each step.
+type Execution struct {
+	// ID is the unique identifier for this execution.
+	ID string `json:"id"`
+
+	// DefinitionName references the registered saga definition.
+	DefinitionName string `json:"definition_name"`
+
+	// DefinitionVersion is the version of the definition when started.
+	DefinitionVersion int `json:"definition_version"`
+
+	// InitialInputs contains the bootstrap data for the saga.
+	// All values must be JSON-serializable.
+	InitialInputs map[string]any `json:"initial_inputs"`
+
+	// Status is the current state of the execution.
+	Status Status `json:"status"`
+
+	// ExecutedActions maps action names to their results.
+	ExecutedActions map[string]*ActionResult `json:"executed_actions"`
+
+	// ExecutionOrder records the order actions were executed for reverse undo.
+	ExecutionOrder []string `json:"execution_order"`
+
+	// Error is set if the saga failed.
+	Error string `json:"error,omitempty"`
+
+	// CreatedAt is when the execution was created.
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is when the execution was last updated.
+	UpdatedAt time.Time `json:"updated_at"`
+}


### PR DESCRIPTION
This adds the saga pattern for distributed operations with crash recovery - Phase 1 of RFD-35's migration strategy.

The idea: define a sequence of steps where each has a corresponding undo. Either everything completes, or we roll back what we've done. State is persisted after each action so we can recover from crashes.

```go
saga.Define("create-sandbox").
    Using(controller).
    Action("allocate", AllocateNetwork).Undo(ReleaseNetwork).
    Action("build", BuildSpec).
    Register()

executor.Start("create-sandbox").
    Input("sandbox-id", id).
    Execute(ctx)
```

Actions are plain functions with struct inputs/outputs. The framework infers dependencies from data flow (if action B needs a key that action A produces, B waits for A). Dependencies like controllers get injected via `Using()` / `Get[T](ctx)`.

Three examples demonstrate the patterns:
- Sandwich making (the fun one)
- Build/deploy pipeline (entity integration, find-or-create, rollback to previous state)
- Sandbox creation (8-step orchestration matching the real controller flow)