### PR TITLE
Persist build logs to VictoriaLogs with version metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ ISO_SESSION ?= dev-$(shell basename "$$(pwd)")
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "dev")
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "")
 GIT_VERSION := $(shell \
-  if git describe --exact-match --tags HEAD 2>/dev/null; then \
-    git describe --exact-match --tags HEAD 2>/dev/null; \
+  if git describe --exact-match --tags HEAD >/dev/null 2>&1; then \
+    git describe --exact-match --tags HEAD; \
   elif echo "$(GIT_BRANCH)" | grep -q '^release/'; then \
     echo "$(GIT_BRANCH)" | sed 's|^release/||'; \
   elif [ -n "$(GIT_COMMIT)" ]; then \

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -35,6 +35,16 @@ func buildFilterWithService(userFilter, service string) string {
 	return serviceFilter + " " + userFilter
 }
 
+// buildBuildFilter creates a filter for build logs of a specific version.
+// Combines source:build with the version filter.
+func buildBuildFilter(version, userFilter string) string {
+	buildFilter := fmt.Sprintf("source:build version:%q", version)
+	if userFilter == "" {
+		return buildFilter
+	}
+	return buildFilter + " " + userFilter
+}
+
 func Logs(ctx *Context, opts struct {
 	ConfigCentric
 
@@ -42,6 +52,7 @@ func Logs(ctx *Context, opts struct {
 	Dir     string         `short:"d" long:"dir" description:"Directory to run from" default:"."`
 	Last    *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
 	Sandbox string         `short:"s" long:"sandbox" description:"Show logs for a specific sandbox ID"`
+	Build   string         `short:"b" long:"build" description:"Show build logs for a specific version"`
 	Follow  bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
 	Filter  string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
 	Service string         `long:"service" description:"Filter logs by service name (e.g., 'web', 'worker')"`
@@ -49,6 +60,9 @@ func Logs(ctx *Context, opts struct {
 	// Check for conflicting options
 	if opts.App != "" && opts.Sandbox != "" {
 		return fmt.Errorf("cannot specify both --app and --sandbox")
+	}
+	if opts.Build != "" && opts.Sandbox != "" {
+		return fmt.Errorf("cannot specify both --build and --sandbox")
 	}
 
 	// If neither is specified, try to load app from directory context
@@ -89,8 +103,13 @@ func Logs(ctx *Context, opts struct {
 		}
 	}
 
-	// Build combined filter with service filter for server-side filtering
-	combinedFilter := buildFilterWithService(opts.Filter, opts.Service)
+	// Build combined filter for server-side filtering
+	var combinedFilter string
+	if opts.Build != "" {
+		combinedFilter = buildBuildFilter(opts.Build, opts.Filter)
+	} else {
+		combinedFilter = buildFilterWithService(opts.Filter, opts.Service)
+	}
 
 	// Check if server supports streaming (prefer chunked for efficiency)
 	if cl.HasMethod(ctx, "streamLogChunks") {
@@ -98,9 +117,12 @@ func Logs(ctx *Context, opts struct {
 	}
 
 	// Older server - warn about upgrade and limited functionality
-	ctx.Printf("Warning: server does not support optimized log streaming. Upgrade your server for better performance and --service filtering.\n")
+	ctx.Printf("Warning: server does not support optimized log streaming. Upgrade your server for better performance and --service/--build filtering.\n")
 	if opts.Service != "" {
 		return fmt.Errorf("--service filtering requires a newer server version")
+	}
+	if opts.Build != "" {
+		return fmt.Errorf("--build filtering requires a newer server version")
 	}
 
 	if cl.HasMethod(ctx, "streamLogs") {

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -64,6 +64,9 @@ func Logs(ctx *Context, opts struct {
 	if opts.Build != "" && opts.Sandbox != "" {
 		return fmt.Errorf("cannot specify both --build and --sandbox")
 	}
+	if opts.Build != "" && opts.Service != "" {
+		return fmt.Errorf("cannot specify both --build and --service")
+	}
 
 	// If neither is specified, try to load app from directory context
 	if opts.App == "" && opts.Sandbox == "" {

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -33,6 +33,28 @@ import (
 	"miren.dev/runtime/pkg/tarx"
 )
 
+// buildLogWriter writes build log entries to VictoriaLogs with version metadata
+type buildLogWriter struct {
+	writer   observability.LogWriter
+	entityID string
+	version  string
+}
+
+func (w *buildLogWriter) write(msg string) {
+	if w.writer == nil || w.entityID == "" {
+		return
+	}
+	w.writer.WriteEntry(w.entityID, observability.LogEntry{
+		Timestamp: time.Now(),
+		Stream:    observability.UserOOB,
+		Body:      msg,
+		Attributes: map[string]string{
+			"source":  "build",
+			"version": w.version,
+		},
+	})
+}
+
 type Builder struct {
 	Log           *slog.Logger
 	EAS           *entityserver_v1alpha.EntityAccessClient
@@ -664,11 +686,18 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		Log:    b.Log,
 	}
 
-	_, mrv, _, err := b.nextVersion(ctx, name)
+	appRec, mrv, _, err := b.nextVersion(ctx, name)
 	if err != nil {
 		b.Log.Error("error getting next version", "error", err)
 		b.sendErrorStatus(ctx, status, "Error getting next version: %v", err)
 		return err
+	}
+
+	// Initialize build log writer for persisting build output to VictoriaLogs
+	buildLog := &buildLogWriter{
+		writer:   b.LogWriter,
+		entityID: appRec.ID.String(),
+		version:  mrv.Version,
 	}
 
 	var tos []TransformOptions
@@ -702,6 +731,19 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 			if err != nil {
 				b.Log.Warn("error sending status update", "error", err)
 			}
+
+			// Log command output from RUN steps to VictoriaLogs
+			for _, log := range ss.Logs {
+				if log.Data != nil {
+					lines := strings.Split(string(log.Data), "\n")
+					for _, line := range lines {
+						line = strings.TrimSpace(line)
+						if line != "" {
+							buildLog.write(line)
+						}
+					}
+				}
+			}
 		}))
 	}
 
@@ -717,6 +759,11 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		b.Log.Error("error building image", "error", err)
 		b.sendErrorStatus(ctx, status, "Error building image: %v", err)
 		return err
+	}
+
+	// Log detection events from stack analysis
+	for _, event := range res.DetectionEvents {
+		buildLog.write(fmt.Sprintf("[detect] %s: %s", event.Name, event.Message))
 	}
 
 	if res.ManifestDigest == "" {
@@ -866,7 +913,7 @@ func (b *Builder) logDeployment(ctx context.Context, appName, version, artifact 
 		Stream:    observability.UserOOB,
 		Body:      logMsg,
 		Attributes: map[string]string{
-			"source":   "builder",
+			"source":   "build",
 			"version":  version,
 			"artifact": artifact,
 		},

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -35,6 +35,7 @@ import (
 
 // buildLogWriter writes build log entries to VictoriaLogs with version metadata
 type buildLogWriter struct {
+	log      *slog.Logger
 	writer   observability.LogWriter
 	entityID string
 	version  string
@@ -44,7 +45,7 @@ func (w *buildLogWriter) write(msg string) {
 	if w.writer == nil || w.entityID == "" {
 		return
 	}
-	w.writer.WriteEntry(w.entityID, observability.LogEntry{
+	err := w.writer.WriteEntry(w.entityID, observability.LogEntry{
 		Timestamp: time.Now(),
 		Stream:    observability.UserOOB,
 		Body:      msg,
@@ -53,6 +54,9 @@ func (w *buildLogWriter) write(msg string) {
 			"version": w.version,
 		},
 	})
+	if err != nil {
+		w.log.Warn("failed to write build log entry", "error", err)
+	}
 }
 
 type Builder struct {
@@ -695,6 +699,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 
 	// Initialize build log writer for persisting build output to VictoriaLogs
 	buildLog := &buildLogWriter{
+		log:      b.Log,
 		writer:   b.LogWriter,
 		entityID: appRec.ID.String(),
 		version:  mrv.Version,

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -711,6 +711,21 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		WithBuildArg("MIREN_VERSION", mrv.Version),
 	)
 
+	// Always persist build logs to VictoriaLogs, regardless of status stream
+	tos = append(tos, WithStatusUpdates(func(ss *client.SolveStatus, _ []byte) {
+		for _, log := range ss.Logs {
+			if log.Data != nil {
+				lines := strings.Split(string(log.Data), "\n")
+				for _, line := range lines {
+					line = strings.TrimSpace(line)
+					if line != "" {
+						buildLog.write(line)
+					}
+				}
+			}
+		}
+	}))
+
 	if status != nil {
 		tos = append(tos, WithPhaseUpdates(func(phase string) {
 			switch phase {
@@ -729,25 +744,12 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 			}
 		}))
 
-		tos = append(tos, WithStatusUpdates(func(ss *client.SolveStatus, sj []byte) {
+		tos = append(tos, WithStatusUpdates(func(_ *client.SolveStatus, sj []byte) {
 			so := new(build_v1alpha.Status)
 			so.Update().SetBuildkit(sj)
 			_, err := status.Send(ctx, so)
 			if err != nil {
 				b.Log.Warn("error sending status update", "error", err)
-			}
-
-			// Log command output from RUN steps to VictoriaLogs
-			for _, log := range ss.Logs {
-				if log.Data != nil {
-					lines := strings.Split(string(log.Data), "\n")
-					for _, line := range lines {
-						line = strings.TrimSpace(line)
-						if line != "" {
-							buildLog.write(line)
-						}
-					}
-				}
 			}
 		}))
 	}

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -282,10 +282,11 @@ type ImageConfig struct {
 }
 
 type BuildResult struct {
-	Entrypoint     string // The entrypoint (from stack or image ENTRYPOINT)
-	Command        string // The command (from image CMD)
-	ManifestDigest string
-	WorkingDir     string
+	Entrypoint      string // The entrypoint (from stack or image ENTRYPOINT)
+	Command         string // The command (from image CMD)
+	ManifestDigest  string
+	WorkingDir      string
+	DetectionEvents []stackbuild.DetectionEvent
 }
 
 // fetchImageConfigFromRegistry fetches the image config JSON from a registry using the config digest.
@@ -413,6 +414,7 @@ func (b *Buildkit) BuildImage(
 		}
 
 		res.Entrypoint = stack.Entrypoint()
+		res.DetectionEvents = stack.Events()
 
 		if wc := stack.WebCommand(); wc != "" {
 			res.Command = wc


### PR DESCRIPTION
When buildkit ran inside sandboxes, we got log retention for free - the
sandbox captured all output and it went to VictoriaLogs like any other
sandbox logs. Switching to a central buildkit daemon was a win for build
robustness and caching, but we lost build log retention in the process.
You'd see output stream by during deploy, but once the CLI disconnected
those logs were gone.

Now we write build logs to VictoriaLogs during the build with version
metadata. Adds `miren logs --app myapp --build myapp-v-abc123` to retrieve
build logs for a specific version - shows RUN command output and stack
detection events.