### PR TITLE
Default app name from .miren/app.toml for CLI commands

### DIFF
--- a/cli/commands/app_delete.go
+++ b/cli/commands/app_delete.go
@@ -15,7 +15,7 @@ func AppDelete(ctx *Context, opts struct {
 }) error {
 	appName := opts.AppName
 	if appName == "" {
-		if ac, err := appconfig.LoadAppConfig(); err == nil && ac.Name != "" {
+		if ac, err := appconfig.LoadAppConfig(); err == nil && ac != nil && ac.Name != "" {
 			appName = ac.Name
 		}
 	}

--- a/cli/commands/app_delete.go
+++ b/cli/commands/app_delete.go
@@ -4,15 +4,24 @@ import (
 	"fmt"
 
 	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/pkg/ui"
 )
 
 func AppDelete(ctx *Context, opts struct {
 	Force   bool   `short:"f" long:"force" description:"Force delete without confirmation"`
-	AppName string `position:"0" usage:"Name of the app to delete" required:"true"`
+	AppName string `position:"0" usage:"Name of the app to delete"`
 	ConfigCentric
 }) error {
 	appName := opts.AppName
+	if appName == "" {
+		if ac, err := appconfig.LoadAppConfig(); err == nil && ac.Name != "" {
+			appName = ac.Name
+		}
+	}
+	if appName == "" {
+		return fmt.Errorf("app is required")
+	}
 
 	crudcl, err := ctx.RPCClient("dev.miren.runtime/app")
 	if err != nil {

--- a/cli/commands/route_set.go
+++ b/cli/commands/route_set.go
@@ -15,7 +15,7 @@ func RouteSet(ctx *Context, opts struct {
 }) error {
 	appName := opts.AppName
 	if appName == "" {
-		if ac, err := appconfig.LoadAppConfig(); err == nil && ac.Name != "" {
+		if ac, err := appconfig.LoadAppConfig(); err == nil && ac != nil && ac.Name != "" {
 			appName = ac.Name
 		}
 	}

--- a/cli/commands/route_set.go
+++ b/cli/commands/route_set.go
@@ -5,13 +5,24 @@ import (
 
 	"miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/appconfig"
 )
 
 func RouteSet(ctx *Context, opts struct {
-	Host string `position:"0" usage:"Hostname for the route (e.g., example.com)" required:"true"`
-	App  string `position:"1" usage:"Application name to route to" required:"true"`
+	Host    string `position:"0" usage:"Hostname for the route (e.g., example.com)" required:"true"`
+	AppName string `position:"1" usage:"Application name to route to"`
 	ConfigCentric
 }) error {
+	appName := opts.AppName
+	if appName == "" {
+		if ac, err := appconfig.LoadAppConfig(); err == nil && ac.Name != "" {
+			appName = ac.Name
+		}
+	}
+	if appName == "" {
+		return fmt.Errorf("app is required")
+	}
+
 	client, err := ctx.RPCClient("entities")
 	if err != nil {
 		return err
@@ -19,9 +30,9 @@ func RouteSet(ctx *Context, opts struct {
 
 	// Look up the app by name
 	appClient := app.NewClient(ctx.Log, client)
-	appEntity, err := appClient.GetByName(ctx, opts.App)
+	appEntity, err := appClient.GetByName(ctx, appName)
 	if err != nil {
-		return fmt.Errorf("failed to find app %q: %w", opts.App, err)
+		return fmt.Errorf("failed to find app %q: %w", appName, err)
 	}
 
 	// Create/update the route
@@ -31,6 +42,6 @@ func RouteSet(ctx *Context, opts struct {
 		return err
 	}
 
-	ctx.Printf("Route set: %s → %s\n", opts.Host, opts.App)
+	ctx.Printf("Route set: %s → %s\n", opts.Host, appName)
 	return nil
 }

--- a/cli/commands/route_set_default.go
+++ b/cli/commands/route_set_default.go
@@ -14,7 +14,7 @@ func RouteSetDefault(ctx *Context, opts struct {
 }) error {
 	appName := opts.AppName
 	if appName == "" {
-		if ac, err := appconfig.LoadAppConfig(); err == nil && ac.Name != "" {
+		if ac, err := appconfig.LoadAppConfig(); err == nil && ac != nil && ac.Name != "" {
 			appName = ac.Name
 		}
 	}

--- a/cli/commands/route_set_default.go
+++ b/cli/commands/route_set_default.go
@@ -5,12 +5,23 @@ import (
 
 	apppkg "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/appconfig"
 )
 
 func RouteSetDefault(ctx *Context, opts struct {
-	App string `position:"0" usage:"Application name to set as default route" required:"true"`
+	AppName string `position:"0" usage:"Application name to set as default route"`
 	ConfigCentric
 }) error {
+	appName := opts.AppName
+	if appName == "" {
+		if ac, err := appconfig.LoadAppConfig(); err == nil && ac.Name != "" {
+			appName = ac.Name
+		}
+	}
+	if appName == "" {
+		return fmt.Errorf("app is required")
+	}
+
 	cl, err := ctx.RPCClient("entities")
 	if err != nil {
 		return err
@@ -19,9 +30,9 @@ func RouteSetDefault(ctx *Context, opts struct {
 	ingressClient := ingress.NewClient(ctx.Log, cl)
 
 	// Get the app to ensure it exists
-	app, err := appClient.GetByName(ctx, opts.App)
+	app, err := appClient.GetByName(ctx, appName)
 	if err != nil {
-		return fmt.Errorf("failed to get app %s: %w", opts.App, err)
+		return fmt.Errorf("failed to get app %s: %w", appName, err)
 	}
 
 	ctx.Log.Info("setting default route", "app", app.ID)
@@ -31,6 +42,6 @@ func RouteSetDefault(ctx *Context, opts struct {
 		return fmt.Errorf("failed to set default route: %w", err)
 	}
 
-	ctx.Printf("Set default route to: %s\n", opts.App)
+	ctx.Printf("Set default route to: %s\n", appName)
 	return nil
 }


### PR DESCRIPTION
## Summary
- Make `app delete`, `route set`, and `route set-default` commands default to the app name from `.miren/app.toml` when not provided as a positional argument
- Maintains backwards compatibility - positional arguments still work as before
- Improves UX when running commands from within an app directory

## Test plan
- [x] `make lint` passes
- [x] `hack/it ./cli/commands/...` tests pass
- [x] Manual testing in dev environment:
  - Create `.miren/app.toml` with `name = "testapp"`
  - Run `m route set example.com` (should use testapp)
  - Run `m route set-default` (should use testapp)
  - Run `m app delete` (should prompt for testapp)