### PR TITLE
Fail deploy when no services are defined

### DIFF
--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -23,6 +23,16 @@ Services can be defined in two ways:
 1. **Procfile** — Simple format for defining commands per service
 2. **`.miren/app.toml`** — Full configuration with scaling, env vars, and images
 
+### Service Detection
+
+Miren detects services in this order:
+
+1. **`.miren/app.toml`** — Services defined in the `[services.*]` sections
+2. **`Procfile`** — Services inferred from Procfile entries
+3. **Dockerfile `CMD`/`ENTRYPOINT`** — If no services are defined above, but your image has a default command, Miren creates a `web` service using that command
+
+If none of these provide a service definition, the deploy will fail with an error.
+
 ### Using a Procfile
 
 If your app has a `Procfile`, Miren automatically infers services from it:

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -116,7 +116,7 @@ func mergeServiceEnvVars(existingEnvs []core_v1alpha.Env, newEnvs []core_v1alpha
 }
 
 // errNoServices is returned when a build produces no services
-var errNoServices = errors.New("no services defined: please define at least one service in a Procfile or miren.toml")
+var errNoServices = errors.New("no services defined: please define at least one service in a Procfile or .miren/app.toml")
 
 // validateServicesExist checks that at least one service is defined in the config.
 // Returns an error if no services are found.

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -115,6 +115,18 @@ func mergeServiceEnvVars(existingEnvs []core_v1alpha.Env, newEnvs []core_v1alpha
 	return result
 }
 
+// errNoServices is returned when a build produces no services
+var errNoServices = errors.New("no services defined: please define at least one service in a Procfile or miren.toml")
+
+// validateServicesExist checks that at least one service is defined in the config.
+// Returns an error if no services are found.
+func validateServicesExist(cfg core_v1alpha.Config) error {
+	if len(cfg.Services) == 0 {
+		return errNoServices
+	}
+	return nil
+}
+
 // buildServicesConfig collects services from app config and procfile,
 // resolves defaults, and returns the final service configurations.
 // This is the core logic for determining which services exist in an app_version
@@ -760,6 +772,13 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		ExistingConfig:   mrv.Config,
 		CliEnvVars:       args.EnvVars(),
 	})
+
+	// Fail the deploy if no services are defined - this prevents deploying an app
+	// that can't serve any traffic
+	if err := validateServicesExist(mrv.Config); err != nil {
+		b.sendErrorStatus(ctx, status, "%s. See https://miren.md/services", err)
+		return err
+	}
 
 	if len(args.EnvVars()) > 0 {
 		b.Log.Info("applied CLI env vars", "count", len(args.EnvVars()))

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -1417,3 +1417,47 @@ func TestMergeCliEnvVars(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateServicesExist(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  core_v1alpha.Config
+		wantErr bool
+	}{
+		{
+			name:    "no services returns error",
+			config:  core_v1alpha.Config{Services: nil},
+			wantErr: true,
+		},
+		{
+			name:    "empty services returns error",
+			config:  core_v1alpha.Config{Services: []core_v1alpha.Services{}},
+			wantErr: true,
+		},
+		{
+			name: "one service passes",
+			config: core_v1alpha.Config{
+				Services: []core_v1alpha.Services{{Name: "web"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple services passes",
+			config: core_v1alpha.Config{
+				Services: []core_v1alpha.Services{{Name: "web"}, {Name: "worker"}},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServicesExist(tt.config)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, errNoServices)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ran into a confusing situation where an app deployed fine but couldn't
serve traffic. After digging in, found it had no services at all - no
Procfile, empty miren.toml, and no image entrypoint to fall back on.

The deploy happily completed, sandbox pools were created for zero
services, and HTTP requests failed with no obvious reason why.

This adds validation after we build the version config to catch this
case early and fail with a clear error + docs link. Also documented the
service detection order (miren.toml → Procfile → Dockerfile CMD) since
that wasn't covered in the docs.