### PR TITLE
Fix miren upgrade permission errors for non-root users

### DIFF
--- a/cli/commands/release_path.go
+++ b/cli/commands/release_path.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	systemReleasePath = "/var/lib/miren/release"
+	userMirenPath     = ".miren/release"
 )
 
 // FindReleasePath looks for an existing miren release directory.
@@ -56,4 +57,14 @@ func getUserHomeDir() (string, error) {
 		return u.HomeDir, nil
 	}
 	return "", nil
+}
+
+// getUserMirenPath returns the miren-specific user path (~/.miren/release/miren).
+// This is the standard location for user-installed miren binaries.
+func getUserMirenPath() (string, error) {
+	homeDir, err := getUserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, userMirenPath, "miren"), nil
 }

--- a/cli/commands/upgrade.go
+++ b/cli/commands/upgrade.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,29 +15,22 @@ func Upgrade(ctx *Context, opts struct {
 	Channel string `long:"channel" description:"Channel to use: 'latest' (stable releases, default) or 'main' (bleeding edge)"`
 	Check   bool   `short:"c" long:"check" description:"Check for available updates only"`
 	Force   bool   `short:"f" long:"force" description:"Force upgrade even if already up to date or server running"`
+	User    bool   `short:"u" long:"user" description:"Install to user directory (~/.miren/release/miren) instead of system location"`
 }) error {
-	// Check if server is running (unless forced or just checking)
-	if !opts.Force && !opts.Check && release.IsServerRunning() {
-		return fmt.Errorf("miren server is running. Use 'sudo miren server upgrade' to upgrade the server, or use --force to upgrade the CLI anyway")
-	}
-
-	// Determine installation path
+	// Determine current binary path for version checking
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("failed to determine current binary path: %w", err)
 	}
-
-	// Resolve any symlinks
 	exe, err = filepath.EvalSymlinks(exe)
 	if err != nil {
 		return fmt.Errorf("failed to resolve binary path: %w", err)
 	}
 
-	// Create manager with appropriate install path
+	// Create manager for version checking
 	mgrOpts := release.DefaultManagerOptions()
 	mgrOpts.InstallPath = exe
 	mgrOpts.SkipHealthCheck = true // CLI doesn't need health check
-	mgr := release.NewManager(mgrOpts)
 
 	// Check mode - just report if update is available
 	if opts.Check {
@@ -47,7 +41,6 @@ func Upgrade(ctx *Context, opts struct {
 
 		PrintVersionComparison(current, latest)
 
-		// Use proper version comparison with build dates
 		if latest.IsNewer(current) {
 			fmt.Println("\nAn update is available! Run 'miren upgrade' to install it.")
 		} else {
@@ -55,6 +48,72 @@ func Upgrade(ctx *Context, opts struct {
 		}
 		return nil
 	}
+
+	// From here on, we're doing an actual upgrade
+
+	// Check if server is running (unless forced)
+	if !opts.Force && release.IsServerRunning() {
+		return fmt.Errorf("miren server is running. Use 'sudo miren server upgrade' to upgrade the server, or use --force to upgrade the CLI anyway")
+	}
+
+	// Determine installation path
+	var installPath string
+
+	if opts.User {
+		// User explicitly requested user directory installation
+		userPath, err := getUserMirenPath()
+		if err != nil {
+			return fmt.Errorf("failed to determine user install path: %w", err)
+		}
+		installPath = userPath
+	} else {
+		installPath = exe
+	}
+
+	// Check permissions before downloading
+	if err := checkInstallPermissions(installPath); err != nil {
+		var permErr *permissionError
+		if errors.As(err, &permErr) {
+			option, handleErr := handlePermissionError(ctx, installPath, permErr)
+			if handleErr != nil {
+				return handleErr
+			}
+
+			switch option {
+			case upgradeOptionSudo:
+				ctx.Info("")
+				ctx.Info("Please re-run with: sudo miren upgrade")
+				return nil
+			case upgradeOptionUser:
+				userPath, err := getUserMirenPath()
+				if err != nil {
+					return fmt.Errorf("failed to determine user install path: %w", err)
+				}
+				installPath = userPath
+			case upgradeOptionCancel:
+				return nil
+			}
+		} else {
+			return fmt.Errorf("permission check failed: %w", err)
+		}
+	}
+
+	// Ensure the install directory exists for user installs
+	needsPathUpdate, err := ensureUserInstallDir(installPath)
+	if err != nil {
+		return err
+	}
+
+	if needsPathUpdate {
+		ctx.Warn("Note: %s is not in your PATH", filepath.Dir(installPath))
+		ctx.Info("Add it to your shell configuration to use 'miren' directly:")
+		ctx.Info("  export PATH=\"%s:$PATH\"", filepath.Dir(installPath))
+		ctx.Info("")
+	}
+
+	// Update manager with final install path
+	mgrOpts.InstallPath = installPath
+	mgr := release.NewManager(mgrOpts)
 
 	// Determine version/channel
 	version := opts.Version

--- a/cli/commands/upgrade.go
+++ b/cli/commands/upgrade.go
@@ -58,6 +58,7 @@ func Upgrade(ctx *Context, opts struct {
 
 	// Determine installation path
 	var installPath string
+	isUserInstall := opts.User
 
 	if opts.User {
 		// User explicitly requested user directory installation
@@ -70,45 +71,59 @@ func Upgrade(ctx *Context, opts struct {
 		installPath = exe
 	}
 
-	// Check permissions before downloading
-	if err := checkInstallPermissions(installPath); err != nil {
-		var permErr *permissionError
-		if errors.As(err, &permErr) {
-			option, handleErr := handlePermissionError(ctx, installPath, permErr)
-			if handleErr != nil {
-				return handleErr
-			}
-
-			switch option {
-			case upgradeOptionSudo:
-				ctx.Info("")
-				ctx.Info("Please re-run with: sudo miren upgrade")
-				return nil
-			case upgradeOptionUser:
-				userPath, err := getUserMirenPath()
-				if err != nil {
-					return fmt.Errorf("failed to determine user install path: %w", err)
+	// Check permissions before downloading (skip if user already requested --user)
+	if !opts.User {
+		if err := checkInstallPermissions(installPath); err != nil {
+			var permErr *permissionError
+			if errors.As(err, &permErr) {
+				option, handleErr := handlePermissionError(ctx, installPath, permErr)
+				if handleErr != nil {
+					return handleErr
 				}
-				installPath = userPath
-			case upgradeOptionCancel:
-				return nil
+
+				switch option {
+				case upgradeOptionSudo:
+					ctx.Info("")
+					ctx.Info("Please re-run with: sudo miren upgrade")
+					return nil
+				case upgradeOptionUser:
+					userPath, err := getUserMirenPath()
+					if err != nil {
+						return fmt.Errorf("failed to determine user install path: %w", err)
+					}
+					installPath = userPath
+					isUserInstall = true
+				case upgradeOptionCancel:
+					return nil
+				}
+			} else {
+				return fmt.Errorf("permission check failed: %w", err)
 			}
-		} else {
-			return fmt.Errorf("permission check failed: %w", err)
 		}
 	}
 
 	// Ensure the install directory exists for user installs
-	needsPathUpdate, err := ensureUserInstallDir(installPath)
-	if err != nil {
-		return err
-	}
+	if isUserInstall {
+		needsPathUpdate, err := ensureUserInstallDir(installPath)
+		if err != nil {
+			return err
+		}
 
-	if needsPathUpdate {
-		ctx.Warn("Note: %s is not in your PATH", filepath.Dir(installPath))
-		ctx.Info("Add it to your shell configuration to use 'miren' directly:")
-		ctx.Info("  export PATH=\"%s:$PATH\"", filepath.Dir(installPath))
-		ctx.Info("")
+		if needsPathUpdate {
+			ctx.Warn("Note: %s is not in your PATH", filepath.Dir(installPath))
+			ctx.Info("Add it to your shell configuration to use 'miren' directly:")
+			ctx.Info("  export PATH=\"%s:$PATH\"", filepath.Dir(installPath))
+			ctx.Info("")
+		}
+
+		// Warn if there's an existing system binary that might take precedence
+		if exe != installPath {
+			if _, err := os.Stat(exe); err == nil {
+				ctx.Warn("Note: %s still exists and may take precedence over the user install", exe)
+				ctx.Info("You may need to remove it or ensure %s comes first in your PATH", filepath.Dir(installPath))
+				ctx.Info("")
+			}
+		}
 	}
 
 	// Update manager with final install path

--- a/cli/commands/upgrade_permissions.go
+++ b/cli/commands/upgrade_permissions.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// permissionError represents an error when the user lacks write permissions
+type permissionError struct {
+	path string
+	err  error
+}
+
+func (e *permissionError) Error() string {
+	return fmt.Sprintf("cannot write to %s: %v", e.path, e.err)
+}
+
+// checkInstallPermissions checks if the current user has write permissions
+// for the installation path. It checks both the directory (for creating new files)
+// and the file itself (for replacing existing files).
+func checkInstallPermissions(installPath string) error {
+	dir := filepath.Dir(installPath)
+
+	// Check if we can write to the directory
+	if err := unix.Access(dir, unix.W_OK); err != nil {
+		return &permissionError{path: dir, err: err}
+	}
+
+	// If the file exists, check if we can write to it
+	if _, err := os.Stat(installPath); err == nil {
+		if err := unix.Access(installPath, unix.W_OK); err != nil {
+			return &permissionError{path: installPath, err: err}
+		}
+	}
+
+	return nil
+}
+
+// upgradeInstallOption represents an option for handling permission errors
+type upgradeInstallOption int
+
+const (
+	upgradeOptionCancel upgradeInstallOption = iota
+	upgradeOptionSudo
+	upgradeOptionUser
+)
+
+// handlePermissionError handles permission errors by offering options to the user.
+// In interactive mode, it shows a picker menu. In non-interactive mode, it prints
+// helpful error messages with command suggestions.
+func handlePermissionError(ctx *Context, currentPath string, permErr error) (upgradeInstallOption, error) {
+	userPath, _ := getUserMirenPath()
+
+	if ui.IsInteractive() {
+		return handlePermissionErrorInteractive(ctx, currentPath, userPath)
+	}
+	return handlePermissionErrorNonInteractive(ctx, currentPath, userPath)
+}
+
+func handlePermissionErrorInteractive(ctx *Context, currentPath, userPath string) (upgradeInstallOption, error) {
+	ctx.Warn("Cannot write to %s: permission denied", filepath.Dir(currentPath))
+	ctx.Info("")
+	ctx.Info("The binary is installed in a location that requires elevated permissions.")
+	ctx.Info("Current location: %s", currentPath)
+	ctx.Info("")
+
+	items := []ui.PickerItem{
+		ui.SimplePickerItem{Text: "Cancel and re-run with sudo"},
+		ui.SimplePickerItem{Text: fmt.Sprintf("Install to %s (user directory)", userPath)},
+		ui.SimplePickerItem{Text: "Cancel"},
+	}
+
+	selected, err := ui.RunPicker(items,
+		ui.WithTitle("How would you like to proceed?"),
+	)
+	if err != nil {
+		return upgradeOptionCancel, fmt.Errorf("failed to run picker: %w", err)
+	}
+	if selected == nil {
+		return upgradeOptionCancel, nil
+	}
+
+	switch selected.ID() {
+	case "Cancel and re-run with sudo":
+		return upgradeOptionSudo, nil
+	case fmt.Sprintf("Install to %s (user directory)", userPath):
+		return upgradeOptionUser, nil
+	default:
+		return upgradeOptionCancel, nil
+	}
+}
+
+func handlePermissionErrorNonInteractive(ctx *Context, currentPath, userPath string) (upgradeInstallOption, error) {
+	ctx.Warn("Cannot write to %s: permission denied", filepath.Dir(currentPath))
+	ctx.Info("")
+	ctx.Info("To fix this, either:")
+	ctx.Info("  1. Run with sudo: sudo miren upgrade")
+	ctx.Info("  2. Install to user directory: miren upgrade --user")
+	ctx.Info("     (installs to %s)", userPath)
+	ctx.Info("")
+
+	return upgradeOptionCancel, fmt.Errorf("permission denied: cannot write to %s", filepath.Dir(currentPath))
+}
+
+// ensureUserInstallDir ensures the user install directory exists and returns
+// whether PATH needs to be updated.
+func ensureUserInstallDir(installPath string) (needsPathUpdate bool, err error) {
+	dir := filepath.Dir(installPath)
+
+	// Create directory if it doesn't exist
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return false, fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	// Check if the directory is in PATH
+	pathEnv := os.Getenv("PATH")
+	paths := strings.Split(pathEnv, ":")
+	for _, p := range paths {
+		if p == dir {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/cli/commands/upgrade_permissions.go
+++ b/cli/commands/upgrade_permissions.go
@@ -54,7 +54,10 @@ const (
 // In interactive mode, it shows a picker menu. In non-interactive mode, it prints
 // helpful error messages with command suggestions.
 func handlePermissionError(ctx *Context, currentPath string, permErr error) (upgradeInstallOption, error) {
-	userPath, _ := getUserMirenPath()
+	userPath, err := getUserMirenPath()
+	if err != nil {
+		return upgradeOptionCancel, fmt.Errorf("cannot determine user install path: %w", err)
+	}
 
 	if ui.IsInteractive() {
 		return handlePermissionErrorInteractive(ctx, currentPath, userPath)


### PR DESCRIPTION
## Summary

- Add permission checking before downloading during `miren upgrade`
- In interactive mode: show picker menu to choose between sudo or user install
- In non-interactive mode: print clear error message with command suggestions
- Add `--user` flag for explicit user-directory installation to `~/.miren/release/miren`

Fixes MIR-642

## Test plan

- [x] Test upgrade from `/usr/local/bin/miren` as normal user - should see picker options
- [x] Test `miren upgrade --user` - should install to `~/.miren/release/miren`
- [x] Test upgrade from `~/.miren/release/miren` - should work without sudo
- [x] Test non-interactive mode (pipe to /dev/null) - should show text options
- [x] Run `make lint` to verify code quality