### PR TITLE
Clarify scaling mode in CLI output

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -314,7 +314,22 @@ func (m Model) View() string {
 	)
 
 	for _, ps := range m.status.Pools() {
-		hdr += fmt.Sprintf("       pool: %s instances=%d\n", bold.Render(ps.Name()), len(ps.Windows()))
+		instanceCount := len(ps.Windows())
+		instanceInfo := fmt.Sprintf("instances=%d (auto)", instanceCount)
+		if m.cfg != nil {
+			if m.cfg.HasConcurrency() {
+				// Fixed mode
+				if instanceCount == 0 {
+					instanceInfo = "instances=0 (fixed)"
+				} else {
+					instanceInfo = fmt.Sprintf("instances=%d (fixed)", instanceCount)
+				}
+			} else if instanceCount == 0 {
+				// Auto mode with 0 instances
+				instanceInfo = "instances=0 (idle, will scale on traffic)"
+			}
+		}
+		hdr += fmt.Sprintf("       pool: %s %s\n", bold.Render(ps.Name()), instanceInfo)
 	}
 
 	var (

--- a/cli/commands/app_list.go
+++ b/cli/commands/app_list.go
@@ -160,6 +160,7 @@ func AppList(ctx *Context, opts struct {
 		inCooldown   bool
 		crashCount   int64
 		cooldownLeft time.Duration
+		isAutoscale  bool // true if any service uses autoscaling mode
 	}
 	poolStateMap := make(map[string]*appPoolState)
 	now := time.Now()
@@ -169,7 +170,9 @@ func AppList(ctx *Context, opts struct {
 
 		appName := ui.CleanEntityID(pool.App.String())
 		if poolStateMap[appName] == nil {
-			poolStateMap[appName] = &appPoolState{}
+			poolStateMap[appName] = &appPoolState{
+				isAutoscale: true, // default to autoscale, set to false if ANY service uses fixed mode
+			}
 		}
 		state := poolStateMap[appName]
 		state.ready += int(pool.ReadyInstances)
@@ -178,6 +181,15 @@ func AppList(ctx *Context, opts struct {
 			state.inCooldown = true
 			state.crashCount = pool.ConsecutiveCrashCount
 			state.cooldownLeft = pool.CooldownUntil.Sub(now)
+		}
+
+		// Check concurrency mode from the app's active version config
+		if version, ok := versionMap[pool.SandboxSpec.Version.String()]; ok {
+			for _, svc := range version.Config.Services {
+				if svc.Name == pool.Service && svc.ServiceConcurrency.Mode == "fixed" {
+					state.isAutoscale = false
+				}
+			}
 		}
 	}
 
@@ -188,6 +200,7 @@ func AppList(ctx *Context, opts struct {
 			ReadyInstances   int      `json:"ready_instances"`
 			DesiredInstances int      `json:"desired_instances"`
 			Health           string   `json:"health"`
+			ScalingMode      string   `json:"scaling_mode,omitempty"`
 			Routes           []string `json:"routes,omitempty"`
 		}
 
@@ -204,6 +217,7 @@ func AppList(ctx *Context, opts struct {
 				ReadyInstances   int      `json:"ready_instances"`
 				DesiredInstances int      `json:"desired_instances"`
 				Health           string   `json:"health"`
+				ScalingMode      string   `json:"scaling_mode,omitempty"`
 				Routes           []string `json:"routes,omitempty"`
 			}{
 				Name:   md.Name,
@@ -219,6 +233,12 @@ func AppList(ctx *Context, opts struct {
 			if state, ok := poolStateMap[md.Name]; ok {
 				appData.ReadyInstances = state.ready
 				appData.DesiredInstances = state.desired
+
+				if state.isAutoscale {
+					appData.ScalingMode = "auto"
+				} else {
+					appData.ScalingMode = "fixed"
+				}
 
 				if state.inCooldown {
 					appData.Health = "crashed"
@@ -248,7 +268,7 @@ func AppList(ctx *Context, opts struct {
 	}
 
 	var rows []ui.Row
-	headers := []string{"NAME", "VERSION", "STATUS", "ROUTE"}
+	headers := []string{"NAME", "VERSION", "SCALE", "ROUTE"}
 
 	for _, e := range res.Values() {
 		var app core_v1alpha.App
@@ -270,15 +290,24 @@ func AppList(ctx *Context, opts struct {
 
 		// Runtime status from pool state
 		if state, ok := poolStateMap[md.Name]; ok {
+			modeSuffix := " (auto)"
+			if !state.isAutoscale {
+				modeSuffix = " (fixed)"
+			}
+
 			if state.inCooldown {
 				retryIn := formatDuration(state.cooldownLeft)
 				status = infoRed.Render(fmt.Sprintf("crashed (%dx, retry %s)", state.crashCount, retryIn))
 			} else if state.desired == 0 {
-				status = infoGray.Render("💤 idle")
+				if state.isAutoscale {
+					status = infoGray.Render("💤 idle")
+				} else {
+					status = infoYellow.Render("⚠️ 0 (fixed)")
+				}
 			} else if state.ready == state.desired {
-				status = infoGreen.Render(fmt.Sprintf("%d", state.ready))
+				status = infoGreen.Render(fmt.Sprintf("%d%s", state.ready, modeSuffix))
 			} else {
-				status = infoLabel.Render(fmt.Sprintf("%d/%d", state.ready, state.desired))
+				status = infoLabel.Render(fmt.Sprintf("%d/%d%s", state.ready, state.desired, modeSuffix))
 			}
 		}
 

--- a/cli/commands/doctor.go
+++ b/cli/commands/doctor.go
@@ -17,11 +17,12 @@ import (
 )
 
 var (
-	infoGreen = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
-	infoRed   = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
-	infoGray  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	infoLabel = lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
-	infoBold  = lipgloss.NewStyle().Bold(true)
+	infoGreen  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	infoRed    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	infoYellow = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	infoGray   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	infoLabel  = lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
+	infoBold   = lipgloss.NewStyle().Bold(true)
 )
 
 type cloudUserInfo struct {

--- a/cli/commands/sandbox_pool_list.go
+++ b/cli/commands/sandbox_pool_list.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/ui"
 )
@@ -30,6 +31,25 @@ func SandboxPoolList(ctx *Context, opts struct {
 		return err
 	}
 
+	// Fetch app versions to determine concurrency mode
+	versionKindRes, err := eac.LookupKind(ctx, "app_version")
+	if err != nil {
+		return err
+	}
+
+	versionsRes, err := eac.List(ctx, versionKindRes.Attr())
+	if err != nil {
+		return err
+	}
+
+	// Build version map for lookup
+	versionMap := make(map[string]*core_v1alpha.AppVersion)
+	for _, e := range versionsRes.Values() {
+		v := new(core_v1alpha.AppVersion)
+		v.Decode(e.Entity())
+		versionMap[v.ID.String()] = v
+	}
+
 	if opts.IsJSON() {
 		var pools []compute_v1alpha.SandboxPool
 
@@ -43,16 +63,28 @@ func SandboxPoolList(ctx *Context, opts struct {
 	}
 
 	var rows []ui.Row
-	headers := []string{"ID", "VERSION", "SERVICE", "DESIRED", "CURRENT", "READY", "CREATED", "UPDATED"}
+	headers := []string{"ID", "VERSION", "SERVICE", "MODE", "DESIRED", "CURRENT", "READY", "CREATED", "UPDATED"}
 
 	for _, e := range res.Values() {
 		var pool compute_v1alpha.SandboxPool
 		pool.Decode(e.Entity())
 
+		// Determine scaling mode from version config
+		mode := "auto"
+		if version, ok := versionMap[pool.SandboxSpec.Version.String()]; ok {
+			for _, svc := range version.Config.Services {
+				if svc.Name == pool.Service && svc.ServiceConcurrency.Mode == "fixed" {
+					mode = "fixed"
+					break
+				}
+			}
+		}
+
 		rows = append(rows, ui.Row{
 			ui.CleanEntityID(pool.ID.String()),
 			ui.DisplayAppVersion(pool.SandboxSpec.Version.String()),
 			pool.Service,
+			mode,
 			fmt.Sprintf("%d", pool.DesiredInstances),
 			fmt.Sprintf("%d", pool.CurrentInstances),
 			fmt.Sprintf("%d", pool.ReadyInstances),


### PR DESCRIPTION
## Summary

- Display `(auto)` or `(fixed)` suffix on instance counts in CLI output to help users distinguish between autoscaling apps that are idle vs fixed mode apps with 0 instances configured
- Rename STATUS column to SCALE in `app list`
- Add MODE column to `sandbox-pool list`
- Add `scaling_mode` field to JSON output

## Test plan

- [x] Deploy an app with autoscaling mode, verify `m app list` shows `N (auto)` when running and `💤 idle` when scaled to zero
- [x] Deploy an app with fixed mode, verify `m app list` shows `N (fixed)` or `⚠️ 0 (fixed)`
- [x] Run `m app <name>` and verify pool display shows scaling mode
- [x] Run `m sandbox-pool list` and verify MODE column appears
- [x] Run `m app list --json` and verify `scaling_mode` field is present