### PR TITLE
Add distributed runners Phase 2: WireGuard networking and scheduling

### DIFF
--- a/api/runner/rpc.yml
+++ b/api/runner/rpc.yml
@@ -67,6 +67,16 @@ interfaces:
           - name: runner_id
             type: string
             doc: The assigned or confirmed runner ID
+          - name: etcd_endpoints
+            type: list
+            element: string
+            doc: etcd endpoints for Flannel coordination
+          - name: etcd_prefix
+            type: string
+            doc: etcd prefix for Flannel network
+          - name: network_backend
+            type: string
+            doc: Network backend type (vxlan or wireguard)
           - name: error
             type: string
             doc: Error message if join failed

--- a/api/runner/rpc.yml
+++ b/api/runner/rpc.yml
@@ -32,7 +32,7 @@ interfaces:
 
       - name: Join
         index: 1
-        public: true
+        public: true  # Allow unauthenticated access - join code provides authentication
         doc: Join a runner to the coordinator using an invite code
         parameters:
           - name: code

--- a/api/runner/runner_v1alpha/rpc.gen.go
+++ b/api/runner/runner_v1alpha/rpc.gen.go
@@ -453,12 +453,15 @@ func (v *RunnerRegistrationJoinArgs) UnmarshalJSON(data []byte) error {
 }
 
 type runnerRegistrationJoinResultsData struct {
-	CertPem         *[]byte `cbor:"0,keyasint,omitempty" json:"cert_pem,omitempty"`
-	KeyPem          *[]byte `cbor:"1,keyasint,omitempty" json:"key_pem,omitempty"`
-	CaPem           *[]byte `cbor:"2,keyasint,omitempty" json:"ca_pem,omitempty"`
-	CoordinatorAddr *string `cbor:"3,keyasint,omitempty" json:"coordinator_addr,omitempty"`
-	RunnerId        *string `cbor:"4,keyasint,omitempty" json:"runner_id,omitempty"`
-	Error           *string `cbor:"5,keyasint,omitempty" json:"error,omitempty"`
+	CertPem         *[]byte   `cbor:"0,keyasint,omitempty" json:"cert_pem,omitempty"`
+	KeyPem          *[]byte   `cbor:"1,keyasint,omitempty" json:"key_pem,omitempty"`
+	CaPem           *[]byte   `cbor:"2,keyasint,omitempty" json:"ca_pem,omitempty"`
+	CoordinatorAddr *string   `cbor:"3,keyasint,omitempty" json:"coordinator_addr,omitempty"`
+	RunnerId        *string   `cbor:"4,keyasint,omitempty" json:"runner_id,omitempty"`
+	EtcdEndpoints   *[]string `cbor:"5,keyasint,omitempty" json:"etcd_endpoints,omitempty"`
+	EtcdPrefix      *string   `cbor:"6,keyasint,omitempty" json:"etcd_prefix,omitempty"`
+	NetworkBackend  *string   `cbor:"7,keyasint,omitempty" json:"network_backend,omitempty"`
+	Error           *string   `cbor:"8,keyasint,omitempty" json:"error,omitempty"`
 }
 
 type RunnerRegistrationJoinResults struct {
@@ -487,6 +490,19 @@ func (v *RunnerRegistrationJoinResults) SetCoordinatorAddr(coordinator_addr stri
 
 func (v *RunnerRegistrationJoinResults) SetRunnerId(runner_id string) {
 	v.data.RunnerId = &runner_id
+}
+
+func (v *RunnerRegistrationJoinResults) SetEtcdEndpoints(etcd_endpoints []string) {
+	x := slices.Clone(etcd_endpoints)
+	v.data.EtcdEndpoints = &x
+}
+
+func (v *RunnerRegistrationJoinResults) SetEtcdPrefix(etcd_prefix string) {
+	v.data.EtcdPrefix = &etcd_prefix
+}
+
+func (v *RunnerRegistrationJoinResults) SetNetworkBackend(network_backend string) {
+	v.data.NetworkBackend = &network_backend
 }
 
 func (v *RunnerRegistrationJoinResults) SetError(error string) {
@@ -1013,6 +1029,39 @@ func (v *RunnerRegistrationClientJoinResults) RunnerId() string {
 		return ""
 	}
 	return *v.data.RunnerId
+}
+
+func (v *RunnerRegistrationClientJoinResults) HasEtcdEndpoints() bool {
+	return v.data.EtcdEndpoints != nil
+}
+
+func (v *RunnerRegistrationClientJoinResults) EtcdEndpoints() []string {
+	if v.data.EtcdEndpoints == nil {
+		return nil
+	}
+	return *v.data.EtcdEndpoints
+}
+
+func (v *RunnerRegistrationClientJoinResults) HasEtcdPrefix() bool {
+	return v.data.EtcdPrefix != nil
+}
+
+func (v *RunnerRegistrationClientJoinResults) EtcdPrefix() string {
+	if v.data.EtcdPrefix == nil {
+		return ""
+	}
+	return *v.data.EtcdPrefix
+}
+
+func (v *RunnerRegistrationClientJoinResults) HasNetworkBackend() bool {
+	return v.data.NetworkBackend != nil
+}
+
+func (v *RunnerRegistrationClientJoinResults) NetworkBackend() string {
+	if v.data.NetworkBackend == nil {
+		return ""
+	}
+	return *v.data.NetworkBackend
 }
 
 func (v *RunnerRegistrationClientJoinResults) HasError() bool {

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -76,6 +76,7 @@ func RegisterAll(d *mflags.Dispatcher) {
 		d.Dispatch("runner", Section("runner", "Runner management commands", ""))
 		d.Dispatch("runner invite", Infer("runner invite", "Create a join code for a new runner", RunnerInvite))
 		d.Dispatch("runner join", Infer("runner join", "Join this machine to a coordinator as a runner", RunnerJoin))
+		d.Dispatch("runner start", Infer("runner start", "Start this machine as a distributed runner", RunnerStart))
 		d.Dispatch("runner list", Infer("runner list", "List all registered runners", RunnerList))
 		d.Dispatch("runner revoke", Infer("runner revoke", "Revoke a runner invitation", RunnerRevoke))
 		d.Dispatch("runner invite list", Infer("runner invite list", "List all runner invitations", RunnerInviteList))

--- a/cli/commands/runner_join.go
+++ b/cli/commands/runner_join.go
@@ -100,6 +100,9 @@ func RunnerJoin(ctx *Context, opts struct {
 		ClientCert:         string(res.CertPem()),
 		ClientKey:          string(res.KeyPem()),
 		Labels:             labels,
+		EtcdEndpoints:      res.EtcdEndpoints(),
+		EtcdPrefix:         res.EtcdPrefix(),
+		NetworkBackend:     res.NetworkBackend(),
 	}
 
 	if err := cfg.Save(opts.ConfigPath); err != nil {

--- a/cli/commands/runner_join.go
+++ b/cli/commands/runner_join.go
@@ -111,7 +111,7 @@ func RunnerJoin(ctx *Context, opts struct {
 
 	ctx.Printf("Config saved to %s\n", opts.ConfigPath)
 	ctx.Printf("\nTo start this runner, run:\n")
-	ctx.Printf("  miren server --runner\n")
+	ctx.Printf("  miren runner start\n")
 
 	return nil
 }

--- a/cli/commands/runner_join.go
+++ b/cli/commands/runner_join.go
@@ -59,7 +59,7 @@ func RunnerJoin(ctx *Context, opts struct {
 		return fmt.Errorf("invalid join code format")
 	}
 
-	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithLogger(ctx.Log))
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithLogger(ctx.Log), rpc.WithBindAddr("[::]:0"))
 	if err != nil {
 		return fmt.Errorf("failed to create RPC state: %w", err)
 	}

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -1,0 +1,169 @@
+//go:build linux
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"os"
+	"os/signal"
+	"syscall"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"golang.org/x/sync/errgroup"
+	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/components/netresolve"
+	"miren.dev/runtime/components/runner"
+	"miren.dev/runtime/controllers/sandbox"
+	"miren.dev/runtime/observability"
+	"miren.dev/runtime/pkg/containerdx"
+	"miren.dev/runtime/pkg/runnerconfig"
+)
+
+func RunnerStart(ctx *Context, opts struct {
+	ConfigPath       string `long:"config" description:"Path to runner config" default:"/var/lib/miren/runner/config.yaml"`
+	DataPath         string `long:"data-path" description:"Path to store runner data" default:"/var/lib/miren/runner"`
+	ContainerdSocket string `long:"containerd-socket" description:"Path to containerd socket"`
+	ListenAddr       string `short:"l" long:"listen" description:"Address this runner will listen on (overrides config)"`
+}) error {
+	// Load saved runner configuration
+	cfg, err := runnerconfig.Load(opts.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load runner config: %w (did you run 'miren runner join' first?)", err)
+	}
+
+	ctx.Log.Info("starting distributed runner",
+		"runner_id", cfg.RunnerID,
+		"coordinator", cfg.CoordinatorAddress,
+		"etcd_endpoints", cfg.EtcdEndpoints,
+		"network_backend", cfg.NetworkBackend)
+
+	// Create clientconfig from saved certs for RPC authentication
+	clientCfg := clientconfig.NewConfig()
+	clientCfg.SetCluster("coordinator", &clientconfig.ClusterConfig{
+		Hostname:   cfg.CoordinatorAddress,
+		CACert:     cfg.CACert,
+		ClientCert: cfg.ClientCert,
+		ClientKey:  cfg.ClientKey,
+	})
+	clientCfg.SetActiveCluster("coordinator")
+
+	// Determine containerd socket
+	containerdSocket := opts.ContainerdSocket
+	if containerdSocket == "" {
+		containerdSocket = containerdx.DefaultSocket
+	}
+
+	// Initialize containerd client
+	cc, err := containerd.New(containerdSocket,
+		containerd.WithDefaultNamespace("miren"))
+	if err != nil {
+		return fmt.Errorf("failed to connect to containerd: %w", err)
+	}
+	defer cc.Close()
+
+	// Ensure data directory exists
+	if err := os.MkdirAll(opts.DataPath, 0755); err != nil {
+		return fmt.Errorf("failed to create data directory: %w", err)
+	}
+
+	// Set up signal handling
+	sigCtx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// Create errgroup for background tasks
+	eg, egCtx := errgroup.WithContext(sigCtx)
+
+	// Determine listen address
+	listenAddr := opts.ListenAddr
+	if listenAddr == "" {
+		listenAddr = ":8444" // Default runner listen port
+	}
+
+	// Build runner configuration
+	runnerCfg := runner.RunnerConfig{
+		Id:            cfg.RunnerID,
+		ListenAddress: listenAddr,
+		Workers:       runner.DefaulWorkers,
+		DataPath:      opts.DataPath,
+		Config:        clientCfg,
+	}
+
+	// Create resolver for network operations
+	resolver, _ := netresolve.NewLocalResolver()
+
+	// Build runner dependencies
+	// Note: Some deps like NetServ require entity access client which we get after connecting
+	// The runner will set up its own entity client connection via RPC
+	deps := runner.RunnerDeps{
+		CC:        cc,
+		Namespace: "miren",
+		Bridge:    "rt0",
+		Tempdir:   os.TempDir(),
+
+		// Distributed runner doesn't use local network for sandboxes
+		DisableLocalNet: true,
+
+		// Observability - create minimal instances
+		LogsMaintainer: observability.NewLogsMaintainer(),
+		LogWriter:      observability.NewDebugLogWriter(ctx.Log),
+		StatusMon:      observability.NewStatusMonitor(ctx.Log),
+		SandboxMetrics: sandbox.NewMetrics(),
+
+		// Resolver for network operations
+		Resolver: resolver,
+
+		// Service prefixes - same as coordinator
+		// TODO: These should come from join response
+		ServicePrefixes: []netip.Prefix{
+			netip.MustParsePrefix("10.10.0.0/16"),
+			netip.MustParsePrefix("fd47:cafe:d00d::/64"),
+		},
+
+		// Flannel network configuration
+		EtcdEndpoints:  cfg.EtcdEndpoints,
+		EtcdPrefix:     cfg.EtcdPrefix,
+		NetworkBackend: cfg.NetworkBackend,
+
+		// etcd TLS - use the same certs as RPC auth
+		EtcdTLSCert:   []byte(cfg.ClientCert),
+		EtcdTLSKey:    []byte(cfg.ClientKey),
+		EtcdTLSCACert: []byte(cfg.CACert),
+	}
+
+	// Initialize sandbox metrics
+	deps.SandboxMetrics.Log = ctx.Log
+
+	// Create runner
+	r, err := runner.NewRunner(ctx.Log, deps, runnerCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create runner: %w", err)
+	}
+
+	// Start runner with errgroup for background network tasks
+	if err := r.Start(egCtx, eg); err != nil {
+		return fmt.Errorf("failed to start runner: %w", err)
+	}
+
+	ctx.Log.Info("runner started successfully",
+		"runner_id", cfg.RunnerID,
+		"listen_address", listenAddr)
+
+	// Wait for shutdown signal or error
+	<-egCtx.Done()
+	ctx.Log.Info("shutting down runner")
+
+	// Close runner
+	if err := r.Close(); err != nil {
+		ctx.Log.Error("error closing runner", "error", err)
+	}
+
+	// Wait for background tasks to complete
+	if err := eg.Wait(); err != nil && err != context.Canceled {
+		ctx.Log.Error("background task error", "error", err)
+	}
+
+	ctx.Log.Info("runner stopped")
+	return nil
+}

--- a/cli/commands/runner_start_other.go
+++ b/cli/commands/runner_start_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package commands
+
+import "fmt"
+
+// RunnerStart is not supported on non-Linux platforms
+func RunnerStart(ctx *Context, opts struct {
+	ConfigPath       string `long:"config" description:"Path to runner config" default:"/var/lib/miren/runner/config.yaml"`
+	DataPath         string `long:"data-path" description:"Path to store runner data" default:"/var/lib/miren/runner"`
+	ContainerdSocket string `long:"containerd-socket" description:"Path to containerd socket"`
+	ListenAddr       string `short:"l" long:"listen" description:"Address this runner will listen on (overrides config)"`
+}) error {
+	return fmt.Errorf("runner start is only available on Linux")
+}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -254,6 +254,9 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		return err
 	}
 
+	// etcdTLSSetup holds etcd TLS configuration when distributed runners is enabled
+	var etcdTLSSetup *coordinate.EtcdTLSSetupResult
+
 	// Start embedded etcd server if requested
 	if cfg.Etcd.GetStartEmbedded() {
 		ctx.Log.Info("starting embedded etcd server", "client-port", cfg.Etcd.GetClientPort(), "peer-port", cfg.Etcd.GetPeerPort())
@@ -266,6 +269,20 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 			HTTPClientPort: cfg.Etcd.GetHTTPClientPort(),
 			PeerPort:       cfg.Etcd.GetPeerPort(),
 			ClusterState:   "new",
+		}
+
+		// Set up etcd TLS when distributed runners feature is enabled
+		if labs.DistributedRunners() {
+			ctx.Log.Info("setting up etcd mTLS for distributed runners")
+			var err error
+			etcdTLSSetup, err = coordinate.SetupEtcdTLS(ctx.Log, cfg.Server.GetDataPath())
+			if err != nil {
+				ctx.Log.Error("failed to set up etcd TLS", "error", err)
+				return err
+			}
+			etcdConfig.TLS = &etcd.TLSConfig{
+				CertsDir: etcdTLSSetup.CertsDir,
+			}
 		}
 
 		err = etcdComponent.Start(sub, etcdConfig)
@@ -554,8 +571,8 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		}
 	}
 
-	// Create coordinator
-	co := coordinate.NewCoordinator(ctx.Log, coordinate.CoordinatorConfig{
+	// Build coordinator config
+	coordConfig := coordinate.CoordinatorConfig{
 		Address:            srvaddr,
 		EtcdEndpoints:      cfg.Etcd.Endpoints,
 		Prefix:             cfg.Etcd.GetPrefix(),
@@ -575,7 +592,15 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		LogWriter:          logWriter,
 		BuildKit:           buildkitComponent,
 		HTTPRequestTimeout: cfg.Server.HTTPRequestTimeoutDuration(),
-	})
+	}
+
+	// Pass etcd TLS config when distributed runners is enabled
+	if etcdTLSSetup != nil {
+		coordConfig.EtcdTLS = etcdTLSSetup.ClientTLS
+	}
+
+	// Create coordinator
+	co := coordinate.NewCoordinator(ctx.Log, coordConfig)
 
 	err = co.Start(sub)
 	if err != nil {
@@ -591,11 +616,20 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		netip.MustParsePrefix("fd47:cafe:d00d::/64"),
 	}
 
-	gn, err := grunge.NewNetwork(ctx.Log, grunge.NetworkOptions{
+	grungeOpts := grunge.NetworkOptions{
 		EtcdEndpoints: cfg.Etcd.Endpoints,
 		EtcdPrefix:    cfg.Etcd.GetPrefix() + "/sub/flannel",
 		BackendType:   cfg.Server.GetNetworkBackend(),
-	})
+	}
+
+	// Add TLS config when distributed runners is enabled
+	if etcdTLSSetup != nil {
+		grungeOpts.TLSCert = etcdTLSSetup.ClientTLS.CertPEM
+		grungeOpts.TLSKey = etcdTLSSetup.ClientTLS.KeyPEM
+		grungeOpts.TLSCACert = etcdTLSSetup.ClientTLS.CACert
+	}
+
+	gn, err := grunge.NewNetwork(ctx.Log, grungeOpts)
 	if err != nil {
 		ctx.Log.Error("failed to create grunge network", "error", err)
 		return err

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -559,6 +559,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		Address:            srvaddr,
 		EtcdEndpoints:      cfg.Etcd.Endpoints,
 		Prefix:             cfg.Etcd.GetPrefix(),
+		NetworkBackend:     cfg.Server.GetNetworkBackend(),
 		DataPath:           cfg.Server.GetDataPath(),
 		AdditionalNames:    cfg.TLS.AdditionalNames,
 		AdditionalIPs:      additionalIps,
@@ -593,6 +594,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	gn, err := grunge.NewNetwork(ctx.Log, grunge.NetworkOptions{
 		EtcdEndpoints: cfg.Etcd.Endpoints,
 		EtcdPrefix:    cfg.Etcd.GetPrefix() + "/sub/flannel",
+		BackendType:   cfg.Server.GetNetworkBackend(),
 	})
 	if err != nil {
 		ctx.Log.Error("failed to create grunge network", "error", err)
@@ -723,8 +725,8 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		return err
 	}
 
-	// Start runner
-	err = r.Start(sub)
+	// Start runner (pass errgroup for network background tasks)
+	err = r.Start(sub, eg)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -274,8 +274,17 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		// Set up etcd TLS when distributed runners feature is enabled
 		if labs.DistributedRunners() {
 			ctx.Log.Info("setting up etcd mTLS for distributed runners")
+
+			// Parse additional IPs for etcd server cert SANs
+			var etcdExtraIPs []net.IP
+			for _, ipStr := range cfg.TLS.AdditionalIPs {
+				if ip := net.ParseIP(ipStr); ip != nil {
+					etcdExtraIPs = append(etcdExtraIPs, ip)
+				}
+			}
+
 			var err error
-			etcdTLSSetup, err = coordinate.SetupEtcdTLS(ctx.Log, cfg.Server.GetDataPath())
+			etcdTLSSetup, err = coordinate.SetupEtcdTLS(ctx.Log, cfg.Server.GetDataPath(), cfg.TLS.AdditionalNames, etcdExtraIPs)
 			if err != nil {
 				ctx.Log.Error("failed to set up etcd TLS", "error", err)
 				return err
@@ -749,6 +758,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		Resolver:         res,
 		SandboxMetrics:   ctx.ServerState.SandboxMetrics,
 		EntityServerAddr: normalizeServerAddr(srvaddr),
+		IsCoordinator:    true,
 	}
 
 	rc.DataPath = cfg.Server.GetDataPath()

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -3,6 +3,7 @@ package coordinate
 import (
 	"context"
 	"crypto/sha1"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
@@ -62,6 +63,13 @@ import (
 	"miren.dev/runtime/version"
 )
 
+// EtcdTLSConfig holds TLS configuration for connecting to etcd with mTLS.
+type EtcdTLSConfig struct {
+	CertPEM []byte // Client certificate PEM
+	KeyPEM  []byte // Client private key PEM
+	CACert  []byte // CA certificate PEM for verifying server
+}
+
 type CoordinatorConfig struct {
 	Address         string              `json:"address" yaml:"address"`
 	EtcdEndpoints   []string            `json:"etcd_endpoints" yaml:"etcd_endpoints"`
@@ -82,6 +90,10 @@ type CoordinatorConfig struct {
 
 	// NoAuth disables authentication entirely (for testing only)
 	NoAuth bool `json:"no_auth" yaml:"no_auth"`
+
+	// EtcdTLS holds mTLS configuration for etcd connections (optional).
+	// When set, the coordinator will use mTLS to connect to etcd.
+	EtcdTLS *EtcdTLSConfig `json:"etcd_tls" yaml:"etcd_tls"`
 
 	Mem       *metrics.MemoryUsage
 	Cpu       *metrics.CPUUsage
@@ -110,6 +122,119 @@ const (
 	DefaultProjectOwner = "miren.system@miren.dev"
 	DefaultCloudURL     = "https://api.miren.cloud"
 )
+
+// EtcdTLSSetupResult contains the results of setting up etcd TLS.
+type EtcdTLSSetupResult struct {
+	// CertsDir is the directory containing etcd server certs (ca.crt, server.crt, server.key)
+	CertsDir string
+	// ClientTLS is the TLS config for clients connecting to etcd
+	ClientTLS *EtcdTLSConfig
+}
+
+// SetupEtcdTLS loads or creates the CA and issues certificates for etcd mTLS.
+// This must be called before starting the etcd component when TLS is desired.
+// The dataPath should be the same path used for CoordinatorConfig.DataPath.
+func SetupEtcdTLS(log *slog.Logger, dataPath string) (*EtcdTLSSetupResult, error) {
+	// Load or create CA (same logic as Coordinator.LoadCA)
+	certPath := filepath.Join(dataPath, "server", "ca.crt")
+	keyPath := filepath.Join(dataPath, "server", "ca.key")
+
+	var ca *caauth.Authority
+
+	if data, err := os.ReadFile(certPath); err == nil {
+		log.Info("loading existing CA for etcd TLS", "path", certPath)
+
+		key, err := os.ReadFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("missing key for CA: %w", err)
+		}
+
+		ca, err = caauth.LoadFromPEM(data, key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load CA: %w", err)
+		}
+	} else {
+		log.Info("generating new CA for etcd TLS", "path", certPath)
+
+		var err error
+		ca, err = caauth.New(caauth.Options{
+			CommonName:   "miren-server",
+			Organization: "miren",
+			ValidFor:     10 * year,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate CA: %w", err)
+		}
+
+		err = os.MkdirAll(filepath.Dir(certPath), 0755)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create CA directory: %w", err)
+		}
+
+		cd, kd, err := ca.ExportPEM()
+		if err != nil {
+			return nil, fmt.Errorf("failed to export CA: %w", err)
+		}
+
+		if err := os.WriteFile(certPath, cd, 0644); err != nil {
+			return nil, fmt.Errorf("failed to write CA cert: %w", err)
+		}
+
+		if err := os.WriteFile(keyPath, kd, 0600); err != nil {
+			return nil, fmt.Errorf("failed to write CA key: %w", err)
+		}
+	}
+
+	// Create etcd certs directory
+	certsDir := filepath.Join(dataPath, "etcd-certs")
+	if err := os.MkdirAll(certsDir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create etcd certs directory: %w", err)
+	}
+
+	// Issue etcd server certificate
+	serverCert, err := ca.IssueCertificate(caauth.Options{
+		CommonName:   "etcd-server",
+		Organization: "miren",
+		ValidFor:     1 * year,
+		DNSNames:     []string{"localhost"},
+		IPs:          []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to issue etcd server certificate: %w", err)
+	}
+
+	// Write etcd server certs
+	if err := os.WriteFile(filepath.Join(certsDir, "ca.crt"), ca.GetCACertificate(), 0644); err != nil {
+		return nil, fmt.Errorf("failed to write etcd CA cert: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(certsDir, "server.crt"), serverCert.CertPEM, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write etcd server cert: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(certsDir, "server.key"), serverCert.KeyPEM, 0600); err != nil {
+		return nil, fmt.Errorf("failed to write etcd server key: %w", err)
+	}
+
+	// Issue coordinator client certificate
+	clientCert, err := ca.IssueCertificate(caauth.Options{
+		CommonName:   "etcd-client-coordinator",
+		Organization: "miren",
+		ValidFor:     1 * year,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to issue etcd client certificate: %w", err)
+	}
+
+	log.Info("etcd TLS certificates ready", "certs_dir", certsDir)
+
+	return &EtcdTLSSetupResult{
+		CertsDir: certsDir,
+		ClientTLS: &EtcdTLSConfig{
+			CertPEM: clientCert.CertPEM,
+			KeyPEM:  clientCert.KeyPEM,
+			CACert:  ca.GetCACertificate(),
+		},
+	}, nil
+}
 
 func NewCoordinator(log *slog.Logger, cfg CoordinatorConfig) *Coordinator {
 	return &Coordinator{
@@ -324,6 +449,30 @@ regen:
 	return nil
 }
 
+// buildEtcdTLSConfig creates a tls.Config from the EtcdTLS configuration.
+func (c *Coordinator) buildEtcdTLSConfig() (*tls.Config, error) {
+	if c.EtcdTLS == nil {
+		return nil, fmt.Errorf("etcd TLS config not set")
+	}
+
+	// Load client certificate
+	cert, err := tls.X509KeyPair(c.EtcdTLS.CertPEM, c.EtcdTLS.KeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load etcd client certificate: %w", err)
+	}
+
+	// Create CA cert pool
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(c.EtcdTLS.CACert) {
+		return nil, fmt.Errorf("failed to parse etcd CA certificate")
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}, nil
+}
+
 func (c *Coordinator) LocalConfig() (*clientconfig.Config, error) {
 	return c.NamedConfig("miren-user")
 }
@@ -524,10 +673,24 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	server := rs.Server()
 
-	client, err := clientv3.New(clientv3.Config{
+	// Build etcd client config
+	etcdConfig := clientv3.Config{
 		Endpoints:        c.EtcdEndpoints,
 		AutoSyncInterval: time.Minute,
-	})
+	}
+
+	// Add TLS config if configured
+	if c.EtcdTLS != nil {
+		tlsConfig, err := c.buildEtcdTLSConfig()
+		if err != nil {
+			c.Log.Error("failed to build etcd TLS config", "error", err)
+			return err
+		}
+		etcdConfig.TLS = tlsConfig
+		c.Log.Info("etcd client using mTLS")
+	}
+
+	client, err := clientv3.New(etcdConfig)
 	if err != nil {
 		c.Log.Error("failed to create etcd client", "error", err)
 		return err

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -66,6 +66,7 @@ type CoordinatorConfig struct {
 	Address         string              `json:"address" yaml:"address"`
 	EtcdEndpoints   []string            `json:"etcd_endpoints" yaml:"etcd_endpoints"`
 	Prefix          string              `json:"prefix" yaml:"prefix"`
+	NetworkBackend  string              `json:"network_backend" yaml:"network_backend"`
 	Resolver        netresolve.Resolver `json:"resolver" yaml:"resolver"`
 	TempDir         string              `json:"temp_dir" yaml:"temp_dir"`
 	DataPath        string              `json:"data_path" yaml:"data_path"`
@@ -733,7 +734,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		server.ExposeValue("dev.miren.runtime/admin", admin_v1alpha.AdaptAdmin(adminServer))
 	}
 
-	runnerReg := runnerserver.NewRegistrationServer(c.Log, c.authority, eac, c.Address)
+	runnerReg := runnerserver.NewRegistrationServer(c.Log, c.authority, eac, c.Address, c.EtcdEndpoints, c.Prefix, c.NetworkBackend)
 	server.ExposeValue(rpc.ServiceRunner, runner_v1alpha.AdaptRunnerRegistration(runnerReg))
 
 	c.Log.Info("started RPC server")

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -135,7 +135,9 @@ type EtcdTLSSetupResult struct {
 // This must be called before starting the etcd component when TLS is desired.
 // The dataPath should be the same path used for CoordinatorConfig.DataPath.
 // The CA must already exist (created by the coordinator's LoadCA).
-func SetupEtcdTLS(log *slog.Logger, dataPath string) (*EtcdTLSSetupResult, error) {
+// Additional DNS names and IPs are included in the server certificate SANs
+// so that distributed runners can connect to etcd over the network.
+func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, extraIPs []net.IP) (*EtcdTLSSetupResult, error) {
 	certPath := filepath.Join(dataPath, "server", "ca.crt")
 	keyPath := filepath.Join(dataPath, "server", "ca.key")
 
@@ -162,13 +164,20 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string) (*EtcdTLSSetupResult, error
 		return nil, fmt.Errorf("failed to create etcd certs directory: %w", err)
 	}
 
+	// Build server cert SANs: always include localhost + loopback, plus any extras
+	dnsNames := []string{"localhost"}
+	dnsNames = append(dnsNames, extraDNSNames...)
+
+	ips := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
+	ips = append(ips, extraIPs...)
+
 	// Issue etcd server certificate
 	serverCert, err := ca.IssueCertificate(caauth.Options{
 		CommonName:   "etcd-server",
 		Organization: "miren",
 		ValidFor:     1 * year,
-		DNSNames:     []string{"localhost"},
-		IPs:          []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		DNSNames:     dnsNames,
+		IPs:          ips,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to issue etcd server certificate: %w", err)

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -131,58 +131,29 @@ type EtcdTLSSetupResult struct {
 	ClientTLS *EtcdTLSConfig
 }
 
-// SetupEtcdTLS loads or creates the CA and issues certificates for etcd mTLS.
+// SetupEtcdTLS loads the existing CA and issues certificates for etcd mTLS.
 // This must be called before starting the etcd component when TLS is desired.
 // The dataPath should be the same path used for CoordinatorConfig.DataPath.
+// The CA must already exist (created by the coordinator's LoadCA).
 func SetupEtcdTLS(log *slog.Logger, dataPath string) (*EtcdTLSSetupResult, error) {
-	// Load or create CA (same logic as Coordinator.LoadCA)
 	certPath := filepath.Join(dataPath, "server", "ca.crt")
 	keyPath := filepath.Join(dataPath, "server", "ca.key")
 
-	var ca *caauth.Authority
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("CA certificate not found at %s: %w (CA must be created before setting up etcd TLS)", certPath, err)
+	}
 
-	if data, err := os.ReadFile(certPath); err == nil {
-		log.Info("loading existing CA for etcd TLS", "path", certPath)
+	log.Info("loading existing CA for etcd TLS", "path", certPath)
 
-		key, err := os.ReadFile(keyPath)
-		if err != nil {
-			return nil, fmt.Errorf("missing key for CA: %w", err)
-		}
+	key, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("missing key for CA: %w", err)
+	}
 
-		ca, err = caauth.LoadFromPEM(data, key)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load CA: %w", err)
-		}
-	} else {
-		log.Info("generating new CA for etcd TLS", "path", certPath)
-
-		var err error
-		ca, err = caauth.New(caauth.Options{
-			CommonName:   "miren-server",
-			Organization: "miren",
-			ValidFor:     10 * year,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate CA: %w", err)
-		}
-
-		err = os.MkdirAll(filepath.Dir(certPath), 0755)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create CA directory: %w", err)
-		}
-
-		cd, kd, err := ca.ExportPEM()
-		if err != nil {
-			return nil, fmt.Errorf("failed to export CA: %w", err)
-		}
-
-		if err := os.WriteFile(certPath, cd, 0644); err != nil {
-			return nil, fmt.Errorf("failed to write CA cert: %w", err)
-		}
-
-		if err := os.WriteFile(keyPath, kd, 0600); err != nil {
-			return nil, fmt.Errorf("failed to write CA key: %w", err)
-		}
+	ca, err := caauth.LoadFromPEM(data, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load CA: %w", err)
 	}
 
 	// Create etcd certs directory
@@ -468,6 +439,7 @@ func (c *Coordinator) buildEtcdTLSConfig() (*tls.Config, error) {
 	}
 
 	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 	}, nil

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -5,6 +5,7 @@ package etcd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -23,14 +24,21 @@ import (
 const (
 	etcdContainerName   = "miren-etcd"
 	etcdDataDir         = "/etcd-data"
-	defaultEtcdPort     = 12379 // Non-default port to avoid conflicts
-	defaultEtcdHTTPPort = 12381 // Non-default port to avoid conflicts
-	defaultPeerPort     = 12380 // Non-default port to avoid conflicts
+	defaultEtcdPort     = 12379             // Non-default port to avoid conflicts
+	defaultEtcdHTTPPort = 12381             // Non-default port to avoid conflicts
+	defaultPeerPort     = 12380             // Non-default port to avoid conflicts
+	etcdStateFile       = "etcd-state.json" // Tracks container config state
 )
 
 var (
 	etcdImage = imagerefs.Etcd
 )
+
+// etcdState tracks the configuration state of the etcd container.
+// This is persisted to detect when configuration changes require container recreation.
+type etcdState struct {
+	TLSEnabled bool `json:"tls_enabled"`
+}
 
 // TLSConfig holds TLS certificate paths for etcd mTLS.
 // When configured, etcd will require client certificate authentication.
@@ -86,6 +94,37 @@ func (e *EtcdComponent) getReadyPort() int {
 	return e.clientPort
 }
 
+// stateFilePath returns the path to the etcd state file.
+func (e *EtcdComponent) stateFilePath() string {
+	return filepath.Join(e.DataPath, "etcd", etcdStateFile)
+}
+
+// loadState loads the persisted etcd state, returning nil if not found.
+func (e *EtcdComponent) loadState() *etcdState {
+	data, err := os.ReadFile(e.stateFilePath())
+	if err != nil {
+		return nil
+	}
+	var state etcdState
+	if err := json.Unmarshal(data, &state); err != nil {
+		e.Log.Warn("failed to parse etcd state file, will recreate container", "error", err)
+		return nil
+	}
+	return &state
+}
+
+// saveState persists the etcd state to disk.
+func (e *EtcdComponent) saveState(state *etcdState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal etcd state: %w", err)
+	}
+	if err := os.WriteFile(e.stateFilePath(), data, 0600); err != nil {
+		return fmt.Errorf("failed to write etcd state file: %w", err)
+	}
+	return nil
+}
+
 func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	e.LockOp()
 	defer e.UnlockOp()
@@ -109,17 +148,46 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 		return fmt.Errorf("failed to create data directory: %w", err)
 	}
 
+	// Check if TLS configuration has changed since the container was created.
+	// If so, we must recreate the container since TLS settings are baked into the args.
+	requestedTLSEnabled := config.TLS != nil
+	prevState := e.loadState()
+
+	// Determine if we need to recreate the container due to TLS config mismatch.
+	// If there's no state file but there IS an existing container, we must also
+	// recreate because we can't verify the container's TLS config matches.
+	var tlsConfigMismatch bool
+	if prevState == nil {
+		// No state file - if TLS is requested, we must recreate to ensure TLS is enabled
+		tlsConfigMismatch = requestedTLSEnabled
+	} else {
+		// Have state file - check if TLS setting changed
+		tlsConfigMismatch = prevState.TLSEnabled != requestedTLSEnabled
+	}
+
 	// Check if container already exists
 	existingContainer, err := e.CC.LoadContainer(ctx, etcdContainerName)
 	if err == nil {
-		e.Log.Info("found existing etcd container, attempting restart", "container_id", existingContainer.ID())
-		err = e.restartExistingContainer(ctx, existingContainer, config)
-		if err == nil {
-			return nil
+		if tlsConfigMismatch {
+			previousTLS := false
+			if prevState != nil {
+				previousTLS = prevState.TLSEnabled
+			}
+			e.Log.Info("etcd TLS configuration changed, recreating container",
+				"previous_tls", previousTLS,
+				"requested_tls", requestedTLSEnabled,
+				"had_state_file", prevState != nil)
+			e.CleanupExistingContainer(ctx, existingContainer)
+		} else {
+			e.Log.Info("found existing etcd container, attempting restart", "container_id", existingContainer.ID())
+			err = e.restartExistingContainer(ctx, existingContainer, config)
+			if err == nil {
+				return nil
+			}
+			// If restart failed (e.g., port mismatch), try deleting the container and creating fresh
+			e.Log.Warn("restart of existing container failed, recreating", "error", err)
+			e.CleanupExistingContainer(ctx, existingContainer)
 		}
-		// If restart failed (e.g., port mismatch), try deleting the container and creating fresh
-		e.Log.Warn("restart of existing container failed, recreating", "error", err)
-		e.CleanupExistingContainer(ctx, existingContainer)
 	}
 
 	// Set defaults
@@ -182,6 +250,11 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 
 	// Start monitoring for unexpected exits
 	e.StartExitMonitor(ctx)
+
+	// Persist the TLS state so we can detect config changes on restart
+	if err := e.saveState(&etcdState{TLSEnabled: e.tlsEnabled}); err != nil {
+		e.Log.Warn("failed to save etcd state", "error", err)
+	}
 
 	return nil
 }

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -32,6 +32,12 @@ var (
 	etcdImage = imagerefs.Etcd
 )
 
+// TLSConfig holds TLS certificate paths for etcd mTLS.
+// When configured, etcd will require client certificate authentication.
+type TLSConfig struct {
+	CertsDir string // Directory containing ca.crt, server.crt, server.key
+}
+
 type EtcdConfig struct {
 	Name           string
 	DataDir        string
@@ -40,6 +46,7 @@ type EtcdConfig struct {
 	PeerPort       int
 	InitialToken   string
 	ClusterState   string
+	TLS            *TLSConfig // If set, enables mTLS for client connections
 }
 
 type EtcdComponent struct {
@@ -47,6 +54,7 @@ type EtcdComponent struct {
 
 	clientPort int
 	peerPort   int
+	tlsEnabled bool
 	config     EtcdConfig
 }
 
@@ -134,12 +142,13 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 		config.ClusterState = "new"
 	}
 
-	// Store ports for later use
+	// Store ports and TLS state for later use
 	e.clientPort = config.ClientPort
 	e.peerPort = config.PeerPort
+	e.tlsEnabled = config.TLS != nil
 	e.config = config
 
-	e.Log.Info("starting etcd with host networking", "client_port", config.ClientPort, "peer_port", config.PeerPort)
+	e.Log.Info("starting etcd with host networking", "client_port", config.ClientPort, "peer_port", config.PeerPort, "tls", e.tlsEnabled)
 
 	// Create container
 	container, err := e.createContainer(ctx, image, config)
@@ -179,8 +188,17 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 
 func (e *EtcdComponent) ClientEndpoint() string {
 	return e.IfRunning(func() string {
-		return fmt.Sprintf("http://localhost:%d", e.clientPort)
+		scheme := "http"
+		if e.tlsEnabled {
+			scheme = "https"
+		}
+		return fmt.Sprintf("%s://localhost:%d", scheme, e.clientPort)
 	})
+}
+
+// TLSEnabled returns whether TLS is enabled for client connections.
+func (e *EtcdComponent) TLSEnabled() bool {
+	return e.tlsEnabled
 }
 
 func (e *EtcdComponent) PeerEndpoint() string {
@@ -193,9 +211,10 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 	e.SetContainer(container)
 	e.config = config
 
-	// Store ports for later use
+	// Store ports and TLS state for later use
 	e.clientPort = config.ClientPort
 	e.peerPort = config.PeerPort
+	e.tlsEnabled = config.TLS != nil
 
 	// Check if there's already a running task
 	task, err := container.Task(ctx, nil)
@@ -261,13 +280,20 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 
 func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Image, config EtcdConfig) (containerd.Container, error) {
 	dataPath := filepath.Join(e.DataPath, "etcd")
+
+	// Determine URL scheme based on TLS config
+	scheme := "http"
+	if config.TLS != nil {
+		scheme = "https"
+	}
+
 	args := []string{
 		"/usr/local/bin/etcd",
 		"--name", config.Name,
 		"--data-dir", config.DataDir,
-		"--listen-client-urls", fmt.Sprintf("http://0.0.0.0:%d", config.ClientPort),
+		"--listen-client-urls", fmt.Sprintf("%s://0.0.0.0:%d", scheme, config.ClientPort),
 		"--listen-client-http-urls", fmt.Sprintf("http://0.0.0.0:%d", config.HTTPClientPort),
-		"--advertise-client-urls", fmt.Sprintf("http://localhost:%d", config.ClientPort),
+		"--advertise-client-urls", fmt.Sprintf("%s://localhost:%d", scheme, config.ClientPort),
 		"--listen-peer-urls", fmt.Sprintf("http://0.0.0.0:%d", config.PeerPort),
 		"--initial-advertise-peer-urls", fmt.Sprintf("http://localhost:%d", config.PeerPort),
 		"--initial-cluster", fmt.Sprintf("%s=http://localhost:%d", config.Name, config.PeerPort),
@@ -276,6 +302,36 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 
 	if config.InitialToken != "" {
 		args = append(args, "--initial-cluster-token", config.InitialToken)
+	}
+
+	// Add TLS flags when configured
+	if config.TLS != nil {
+		args = append(args,
+			"--cert-file", "/certs/server.crt",
+			"--key-file", "/certs/server.key",
+			"--client-cert-auth",
+			"--trusted-ca-file", "/certs/ca.crt",
+		)
+	}
+
+	// Build mounts list
+	mounts := []specs.Mount{
+		{
+			Destination: config.DataDir,
+			Type:        "bind",
+			Source:      dataPath,
+			Options:     []string{"rbind", "rw"},
+		},
+	}
+
+	// Add certs mount when TLS is configured
+	if config.TLS != nil {
+		mounts = append(mounts, specs.Mount{
+			Destination: "/certs",
+			Type:        "bind",
+			Source:      config.TLS.CertsDir,
+			Options:     []string{"rbind", "ro"},
+		})
 	}
 
 	// Create container spec with etcd configuration using host networking
@@ -289,14 +345,7 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 			"ETCD_AUTO_COMPACTION_MODE=periodic",
 			"ETCD_AUTO_COMPACTION_RETENTION=1h",
 		}),
-		oci.WithMounts([]specs.Mount{
-			{
-				Destination: config.DataDir,
-				Type:        "bind",
-				Source:      dataPath,
-				Options:     []string{"rbind", "rw"},
-			},
-		}),
+		oci.WithMounts(mounts),
 	}
 
 	// Create container

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -94,6 +94,11 @@ type RunnerDeps struct {
 	EtcdEndpoints  []string
 	EtcdPrefix     string
 	NetworkBackend string
+
+	// TLS configuration for etcd mTLS (for distributed runners)
+	EtcdTLSCert   []byte // Client certificate PEM
+	EtcdTLSKey    []byte // Client private key PEM
+	EtcdTLSCACert []byte // CA certificate PEM
 }
 
 const (
@@ -319,12 +324,21 @@ func (r *Runner) initializeNetwork(ctx context.Context, eg ...*errgroup.Group) e
 		"etcd_prefix", r.deps.EtcdPrefix,
 		"backend", r.deps.NetworkBackend)
 
-	gn, err := grunge.NewNetwork(r.Log, grunge.NetworkOptions{
+	grungeOpts := grunge.NetworkOptions{
 		EtcdEndpoints: r.deps.EtcdEndpoints,
 		EtcdPrefix:    r.deps.EtcdPrefix,
 		BackendType:   r.deps.NetworkBackend,
 		PrevIPv4:      r.deps.IPv4Routable,
-	})
+	}
+
+	// Add TLS config if provided
+	if r.deps.EtcdTLSCert != nil && r.deps.EtcdTLSKey != nil && r.deps.EtcdTLSCACert != nil {
+		grungeOpts.TLSCert = r.deps.EtcdTLSCert
+		grungeOpts.TLSKey = r.deps.EtcdTLSKey
+		grungeOpts.TLSCACert = r.deps.EtcdTLSCACert
+	}
+
+	gn, err := grunge.NewNetwork(r.Log, grungeOpts)
 	if err != nil {
 		return fmt.Errorf("failed to create grunge network: %w", err)
 	}

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"golang.org/x/sync/errgroup"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
@@ -33,6 +34,7 @@ import (
 	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/grunge"
 	"miren.dev/runtime/pkg/multierror"
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc"
@@ -86,6 +88,12 @@ type RunnerDeps struct {
 
 	// SkipLSVD skips starting the lsvd-server component (for tests that don't need disk)
 	SkipLSVD bool
+
+	// Flannel network configuration (for distributed runners)
+	// If EtcdEndpoints is non-empty, the runner will join the Flannel network
+	EtcdEndpoints  []string
+	EtcdPrefix     string
+	NetworkBackend string
 }
 
 const (
@@ -231,8 +239,18 @@ func (r *Runner) ContainerdContainerForSandbox(ctx context.Context, id entity.Id
 	return nil, nil
 }
 
-func (r *Runner) Start(ctx context.Context) error {
+// Start initializes and starts the runner.
+// The optional errgroup parameter is used for running background tasks like the Flannel network.
+// If eg is nil and the runner needs to join a Flannel network, an internal errgroup will be created.
+func (r *Runner) Start(ctx context.Context, eg ...*errgroup.Group) error {
 	r.Log.Info("Starting runner", "id", r.Id)
+
+	// Initialize Flannel/WireGuard network if distributed runner configuration is provided
+	if len(r.deps.EtcdEndpoints) > 0 {
+		if err := r.initializeNetwork(ctx, eg...); err != nil {
+			return fmt.Errorf("failed to initialize network: %w", err)
+		}
+	}
 
 	var (
 		rs     *rpc.State
@@ -289,6 +307,46 @@ func (r *Runner) Start(ctx context.Context) error {
 	}
 
 	r.Log.Info("Runner running", "id", r.Id)
+
+	return nil
+}
+
+// initializeNetwork sets up the Flannel network for distributed runners.
+// This is only called when EtcdEndpoints are configured (distributed runner mode).
+func (r *Runner) initializeNetwork(ctx context.Context, eg ...*errgroup.Group) error {
+	r.Log.Info("Initializing distributed runner network",
+		"etcd_endpoints", r.deps.EtcdEndpoints,
+		"etcd_prefix", r.deps.EtcdPrefix,
+		"backend", r.deps.NetworkBackend)
+
+	gn, err := grunge.NewNetwork(r.Log, grunge.NetworkOptions{
+		EtcdEndpoints: r.deps.EtcdEndpoints,
+		EtcdPrefix:    r.deps.EtcdPrefix,
+		BackendType:   r.deps.NetworkBackend,
+		PrevIPv4:      r.deps.IPv4Routable,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create grunge network: %w", err)
+	}
+
+	// Get or create an errgroup for running the network
+	var runGroup *errgroup.Group
+	if len(eg) > 0 && eg[0] != nil {
+		runGroup = eg[0]
+	} else {
+		runGroup, ctx = errgroup.WithContext(ctx)
+	}
+
+	// Start the network (joins the Flannel mesh, doesn't setup config - coordinator did that)
+	if err := gn.Start(ctx, runGroup); err != nil {
+		return fmt.Errorf("failed to start grunge network: %w", err)
+	}
+
+	// Update deps with the leased IP
+	lease := gn.Lease()
+	r.deps.IPv4Routable = lease.IPv4()
+
+	r.Log.Info("Joined Flannel network", "ipv4", lease.IPv4().String())
 
 	return nil
 }

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -89,6 +89,10 @@ type RunnerDeps struct {
 	// SkipLSVD skips starting the lsvd-server component (for tests that don't need disk)
 	SkipLSVD bool
 
+	// IsCoordinator indicates this runner is the coordinator node.
+	// Affects scheduling: stateful sandboxes are routed to the coordinator.
+	IsCoordinator bool
+
 	// Flannel network configuration (for distributed runners)
 	// If EtcdEndpoints is non-empty, the runner will join the Flannel network
 	EtcdEndpoints  []string
@@ -345,15 +349,26 @@ func (r *Runner) initializeNetwork(ctx context.Context, eg ...*errgroup.Group) e
 
 	// Get or create an errgroup for running the network
 	var runGroup *errgroup.Group
+	localGroup := false
 	if len(eg) > 0 && eg[0] != nil {
 		runGroup = eg[0]
 	} else {
 		runGroup, ctx = errgroup.WithContext(ctx)
+		localGroup = true
 	}
 
 	// Start the network (joins the Flannel mesh, doesn't setup config - coordinator did that)
 	if err := gn.Start(ctx, runGroup); err != nil {
 		return fmt.Errorf("failed to start grunge network: %w", err)
+	}
+
+	// If we created a local errgroup, monitor it so errors aren't silently lost
+	if localGroup {
+		go func() {
+			if err := runGroup.Wait(); err != nil {
+				r.Log.Error("network errgroup failed", "error", err)
+			}
+		}()
 	}
 
 	// Update deps with the leased IP
@@ -378,8 +393,13 @@ func (r *Runner) setupEntity(ctx context.Context, ec *entityserver.Client) error
 	r.ec = ec
 	r.se = sess
 
+	role := "runner"
+	if r.deps.IsCoordinator {
+		role = "coordinator"
+	}
+
 	node := compute_v1alpha.Node{
-		Constraints: types.LabelSet("compute", "generic", "role", "coordinator"),
+		Constraints: types.LabelSet("compute", "generic", "role", role),
 		ApiAddress:  r.ListenAddress,
 	}
 

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -379,7 +379,7 @@ func (r *Runner) setupEntity(ctx context.Context, ec *entityserver.Client) error
 	r.se = sess
 
 	node := compute_v1alpha.Node{
-		Constraints: types.LabelSet("compute", "generic"),
+		Constraints: types.LabelSet("compute", "generic", "role", "coordinator"),
 		ApiAddress:  r.ListenAddress,
 	}
 

--- a/controllers/scheduler/scheduler.go
+++ b/controllers/scheduler/scheduler.go
@@ -8,11 +8,15 @@ import (
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/joincode"
 )
 
 // Controller assigns sandboxes to nodes for execution.
 // It watches sandbox entities and adds a ScheduleKey attribute to assign
 // each sandbox to an available node.
+//
+// Stateful sandboxes (those with miren disk volumes) are scheduled to the
+// coordinator node, while stateless sandboxes prefer runner nodes when available.
 //
 // Implements controller.ReconcileControllerI[*compute_v1alpha.Sandbox]
 type Controller struct {
@@ -68,13 +72,39 @@ func (c *Controller) Reconcile(ctx context.Context, sandbox *compute_v1alpha.San
 		return nil
 	}
 
-	// Pick a random ready node
-	// TODO: implement smarter scheduling (load balancing, affinity, etc.)
-	assignedNode := nodes[rand.Intn(len(nodes))]
+	var assignedNode *compute_v1alpha.Node
+
+	if c.isStateful(sandbox) {
+		// Stateful sandboxes must run on the coordinator (for disk access)
+		assignedNode = c.findCoordinatorNode(nodes)
+		if assignedNode == nil {
+			c.log.Error("no coordinator node available for stateful sandbox", "sandbox", sandbox.ID)
+			return nil
+		}
+		c.log.Debug("scheduling stateful sandbox to coordinator",
+			"sandbox", sandbox.ID,
+			"node", assignedNode.ID)
+	} else {
+		// Stateless sandboxes prefer runner nodes when available
+		runnerNodes := c.filterRunnerNodes(nodes)
+		if len(runnerNodes) > 0 {
+			assignedNode = runnerNodes[rand.Intn(len(runnerNodes))]
+			c.log.Debug("scheduling stateless sandbox to runner",
+				"sandbox", sandbox.ID,
+				"node", assignedNode.ID)
+		} else {
+			// Fall back to any available node (including coordinator)
+			assignedNode = nodes[rand.Intn(len(nodes))]
+			c.log.Debug("scheduling stateless sandbox to available node (no runners)",
+				"sandbox", sandbox.ID,
+				"node", assignedNode.ID)
+		}
+	}
 
 	c.log.Info("assigning sandbox to node",
 		"sandbox", sandbox.ID,
-		"node", assignedNode.ID)
+		"node", assignedNode.ID,
+		"stateful", c.isStateful(sandbox))
 
 	// Add schedule key to the entity
 	schedule := compute_v1alpha.Schedule{
@@ -90,6 +120,49 @@ func (c *Controller) Reconcile(ctx context.Context, sandbox *compute_v1alpha.San
 	}
 
 	return nil
+}
+
+// isStateful determines if a sandbox is stateful based on its volume configuration.
+// A sandbox is considered stateful if it has volumes with provider="miren" (disk volumes).
+func (c *Controller) isStateful(sandbox *compute_v1alpha.Sandbox) bool {
+	// Check volumes in spec (new-style sandboxes)
+	for _, vol := range sandbox.Spec.Volume {
+		if vol.Provider == "miren" {
+			return true
+		}
+	}
+
+	// Check legacy volume field (old-style sandboxes)
+	for _, vol := range sandbox.Volume {
+		if vol.Provider == "miren" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// findCoordinatorNode finds the coordinator node among the available nodes.
+// The coordinator is identified by having a non-UUID runner_id (e.g., "miren" or empty).
+func (c *Controller) findCoordinatorNode(nodes []*compute_v1alpha.Node) *compute_v1alpha.Node {
+	for _, node := range nodes {
+		// Coordinator has non-UUID runner_id (e.g., "miren") or empty runner_id
+		if !joincode.IsUUID(node.RunnerId) {
+			return node
+		}
+	}
+	return nil
+}
+
+// filterRunnerNodes returns only nodes that are distributed runners (have UUID runner_id).
+func (c *Controller) filterRunnerNodes(nodes []*compute_v1alpha.Node) []*compute_v1alpha.Node {
+	var runners []*compute_v1alpha.Node
+	for _, node := range nodes {
+		if joincode.IsUUID(node.RunnerId) {
+			runners = append(runners, node)
+		}
+	}
+	return runners
 }
 
 // gatherNodes fetches all node entities from the entity store

--- a/controllers/scheduler/scheduler.go
+++ b/controllers/scheduler/scheduler.go
@@ -8,7 +8,6 @@ import (
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
-	"miren.dev/runtime/pkg/joincode"
 )
 
 // Controller assigns sandboxes to nodes for execution.
@@ -143,22 +142,21 @@ func (c *Controller) isStateful(sandbox *compute_v1alpha.Sandbox) bool {
 }
 
 // findCoordinatorNode finds the coordinator node among the available nodes.
-// The coordinator is identified by having a non-UUID runner_id (e.g., "miren" or empty).
+// The coordinator is identified by having a "role=coordinator" constraint label.
 func (c *Controller) findCoordinatorNode(nodes []*compute_v1alpha.Node) *compute_v1alpha.Node {
 	for _, node := range nodes {
-		// Coordinator has non-UUID runner_id (e.g., "miren") or empty runner_id
-		if !joincode.IsUUID(node.RunnerId) {
+		if role, ok := node.Constraints.Get("role"); ok && role == "coordinator" {
 			return node
 		}
 	}
 	return nil
 }
 
-// filterRunnerNodes returns only nodes that are distributed runners (have UUID runner_id).
+// filterRunnerNodes returns only nodes that are distributed runners (not the coordinator).
 func (c *Controller) filterRunnerNodes(nodes []*compute_v1alpha.Node) []*compute_v1alpha.Node {
 	var runners []*compute_v1alpha.Node
 	for _, node := range nodes {
-		if joincode.IsUUID(node.RunnerId) {
+		if role, ok := node.Constraints.Get("role"); !ok || role != "coordinator" {
 			runners = append(runners, node)
 		}
 	}

--- a/controllers/scheduler/scheduler_test.go
+++ b/controllers/scheduler/scheduler_test.go
@@ -237,3 +237,244 @@ func TestSchedulerMultipleNodes(t *testing.T) {
 		assert.True(t, nodeIDs[schedule.Key.Node], "sandbox should be assigned to one of our nodes")
 	}
 }
+
+// TestSchedulerStatefulSandboxGoesToCoordinator tests that stateful sandboxes
+// (those with miren disk volumes) are scheduled to the coordinator node
+func TestSchedulerStatefulSandboxGoesToCoordinator(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create a coordinator node (non-UUID runner_id)
+	coordNode := &compute_v1alpha.Node{
+		Status:   compute_v1alpha.READY,
+		RunnerId: "miren", // Coordinator has non-UUID runner_id
+	}
+	coordNodeID, err := server.Client.Create(ctx, "coordinator", coordNode)
+	require.NoError(t, err)
+
+	// Create a runner node (UUID runner_id)
+	runnerNode := &compute_v1alpha.Node{
+		Status:   compute_v1alpha.READY,
+		RunnerId: "550e8400-e29b-41d4-a716-446655440000", // Runner has UUID
+	}
+	_, err = server.Client.Create(ctx, "runner", runnerNode)
+	require.NoError(t, err)
+
+	// Create scheduler and initialize
+	scheduler := NewController(log, server.EAC)
+	err = scheduler.Init(ctx)
+	require.NoError(t, err)
+
+	// Create a stateful sandbox (has miren disk volume)
+	sandbox := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.PENDING,
+		Spec: compute_v1alpha.SandboxSpec{
+			Volume: []compute_v1alpha.SandboxSpecVolume{
+				{
+					Name:     "data",
+					Provider: "miren",
+					DiskName: "my-disk",
+				},
+			},
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+	sandboxID, err := server.Client.Create(ctx, "stateful-sandbox", sandbox)
+	require.NoError(t, err)
+
+	// Run reconciliation
+	reconcileSandbox(t, ctx, server, scheduler, sandboxID)
+
+	// Verify the stateful sandbox was assigned to the coordinator
+	resp, err := server.EAC.Get(ctx, sandboxID.String())
+	require.NoError(t, err)
+
+	var schedule compute_v1alpha.Schedule
+	schedule.Decode(resp.Entity().Entity())
+	assert.Equal(t, coordNodeID, schedule.Key.Node, "stateful sandbox should be assigned to coordinator")
+}
+
+// TestSchedulerStatelessSandboxPrefersRunners tests that stateless sandboxes
+// prefer runner nodes over the coordinator when runners are available
+func TestSchedulerStatelessSandboxPrefersRunners(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create a coordinator node (non-UUID runner_id)
+	coordNode := &compute_v1alpha.Node{
+		Status:   compute_v1alpha.READY,
+		RunnerId: "miren",
+	}
+	coordNodeID, err := server.Client.Create(ctx, "coordinator", coordNode)
+	require.NoError(t, err)
+
+	// Create multiple runner nodes (UUID runner_id)
+	runnerIDs := make(map[entity.Id]bool)
+	for i := 0; i < 3; i++ {
+		runnerNode := &compute_v1alpha.Node{
+			Status:   compute_v1alpha.READY,
+			RunnerId: "550e8400-e29b-41d4-a716-44665544000" + string(rune('0'+i)),
+		}
+		runnerID, err := server.Client.Create(ctx, "", runnerNode)
+		require.NoError(t, err)
+		runnerIDs[runnerID] = true
+	}
+
+	// Create scheduler and initialize
+	scheduler := NewController(log, server.EAC)
+	err = scheduler.Init(ctx)
+	require.NoError(t, err)
+
+	// Create and schedule multiple stateless sandboxes
+	for i := 0; i < 10; i++ {
+		sandbox := &compute_v1alpha.Sandbox{
+			Status: compute_v1alpha.PENDING,
+			Spec: compute_v1alpha.SandboxSpec{
+				Container: []compute_v1alpha.SandboxSpecContainer{
+					{Image: "test:latest"},
+				},
+			},
+		}
+		sandboxID, err := server.Client.Create(ctx, "", sandbox)
+		require.NoError(t, err)
+
+		reconcileSandbox(t, ctx, server, scheduler, sandboxID)
+
+		// Verify the stateless sandbox was assigned to a runner, not the coordinator
+		resp, err := server.EAC.Get(ctx, sandboxID.String())
+		require.NoError(t, err)
+
+		var schedule compute_v1alpha.Schedule
+		schedule.Decode(resp.Entity().Entity())
+		assert.True(t, runnerIDs[schedule.Key.Node], "stateless sandbox should be assigned to a runner")
+		assert.NotEqual(t, coordNodeID, schedule.Key.Node, "stateless sandbox should NOT be assigned to coordinator")
+	}
+}
+
+// TestSchedulerStatelessFallsBackToCoordinator tests that stateless sandboxes
+// fall back to the coordinator when no runners are available
+func TestSchedulerStatelessFallsBackToCoordinator(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create only a coordinator node (no runners)
+	coordNode := &compute_v1alpha.Node{
+		Status:   compute_v1alpha.READY,
+		RunnerId: "miren",
+	}
+	coordNodeID, err := server.Client.Create(ctx, "coordinator", coordNode)
+	require.NoError(t, err)
+
+	// Create scheduler and initialize
+	scheduler := NewController(log, server.EAC)
+	err = scheduler.Init(ctx)
+	require.NoError(t, err)
+
+	// Create a stateless sandbox
+	sandbox := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.PENDING,
+		Spec: compute_v1alpha.SandboxSpec{
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+	sandboxID, err := server.Client.Create(ctx, "stateless-sandbox", sandbox)
+	require.NoError(t, err)
+
+	// Run reconciliation
+	reconcileSandbox(t, ctx, server, scheduler, sandboxID)
+
+	// Verify the stateless sandbox falls back to coordinator when no runners available
+	resp, err := server.EAC.Get(ctx, sandboxID.String())
+	require.NoError(t, err)
+
+	var schedule compute_v1alpha.Schedule
+	schedule.Decode(resp.Entity().Entity())
+	assert.Equal(t, coordNodeID, schedule.Key.Node, "stateless sandbox should fall back to coordinator when no runners")
+}
+
+// TestIsStatefulDetection tests the isStateful helper function
+func TestIsStatefulDetection(t *testing.T) {
+	log := testutils.TestLogger(t)
+	scheduler := NewController(log, nil)
+
+	tests := []struct {
+		name     string
+		sandbox  *compute_v1alpha.Sandbox
+		expected bool
+	}{
+		{
+			name: "stateful - spec volume with miren provider",
+			sandbox: &compute_v1alpha.Sandbox{
+				Spec: compute_v1alpha.SandboxSpec{
+					Volume: []compute_v1alpha.SandboxSpecVolume{
+						{Name: "data", Provider: "miren"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "stateful - legacy volume with miren provider",
+			sandbox: &compute_v1alpha.Sandbox{
+				Volume: []compute_v1alpha.Volume{
+					{Name: "data", Provider: "miren"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "stateless - no volumes",
+			sandbox: &compute_v1alpha.Sandbox{
+				Spec: compute_v1alpha.SandboxSpec{
+					Container: []compute_v1alpha.SandboxSpecContainer{
+						{Image: "test:latest"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "stateless - volume with different provider",
+			sandbox: &compute_v1alpha.Sandbox{
+				Spec: compute_v1alpha.SandboxSpec{
+					Volume: []compute_v1alpha.SandboxSpecVolume{
+						{Name: "data", Provider: "local"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "stateful - mixed volumes with one miren",
+			sandbox: &compute_v1alpha.Sandbox{
+				Spec: compute_v1alpha.SandboxSpec{
+					Volume: []compute_v1alpha.SandboxSpecVolume{
+						{Name: "cache", Provider: "local"},
+						{Name: "data", Provider: "miren"},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := scheduler.isStateful(tt.sandbox)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/controllers/scheduler/scheduler_test.go
+++ b/controllers/scheduler/scheduler_test.go
@@ -10,6 +10,7 @@ import (
 	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
 )
 
 // reconcileSandbox is a test helper that processes a sandbox through the real controller framework.
@@ -247,18 +248,18 @@ func TestSchedulerStatefulSandboxGoesToCoordinator(t *testing.T) {
 	server, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
 
-	// Create a coordinator node (non-UUID runner_id)
+	// Create a coordinator node (role=coordinator constraint)
 	coordNode := &compute_v1alpha.Node{
-		Status:   compute_v1alpha.READY,
-		RunnerId: "miren", // Coordinator has non-UUID runner_id
+		Status:      compute_v1alpha.READY,
+		Constraints: types.LabelSet("role", "coordinator"),
 	}
 	coordNodeID, err := server.Client.Create(ctx, "coordinator", coordNode)
 	require.NoError(t, err)
 
-	// Create a runner node (UUID runner_id)
+	// Create a runner node
 	runnerNode := &compute_v1alpha.Node{
 		Status:   compute_v1alpha.READY,
-		RunnerId: "550e8400-e29b-41d4-a716-446655440000", // Runner has UUID
+		RunnerId: "550e8400-e29b-41d4-a716-446655440000",
 	}
 	_, err = server.Client.Create(ctx, "runner", runnerNode)
 	require.NoError(t, err)
@@ -308,15 +309,15 @@ func TestSchedulerStatelessSandboxPrefersRunners(t *testing.T) {
 	server, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
 
-	// Create a coordinator node (non-UUID runner_id)
+	// Create a coordinator node (role=coordinator constraint)
 	coordNode := &compute_v1alpha.Node{
-		Status:   compute_v1alpha.READY,
-		RunnerId: "miren",
+		Status:      compute_v1alpha.READY,
+		Constraints: types.LabelSet("role", "coordinator"),
 	}
 	coordNodeID, err := server.Client.Create(ctx, "coordinator", coordNode)
 	require.NoError(t, err)
 
-	// Create multiple runner nodes (UUID runner_id)
+	// Create multiple runner nodes
 	runnerIDs := make(map[entity.Id]bool)
 	for i := 0; i < 3; i++ {
 		runnerNode := &compute_v1alpha.Node{
@@ -370,8 +371,8 @@ func TestSchedulerStatelessFallsBackToCoordinator(t *testing.T) {
 
 	// Create only a coordinator node (no runners)
 	coordNode := &compute_v1alpha.Node{
-		Status:   compute_v1alpha.READY,
-		RunnerId: "miren",
+		Status:      compute_v1alpha.READY,
+		Constraints: types.LabelSet("role", "coordinator"),
 	}
 	coordNodeID, err := server.Client.Create(ctx, "coordinator", coordNode)
 	require.NoError(t, err)

--- a/pkg/grunge/grunge.go
+++ b/pkg/grunge/grunge.go
@@ -2,6 +2,8 @@ package grunge
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -51,12 +53,29 @@ type NetworkOptions struct {
 
 	PrevIPv4 netip.Prefix
 	PrevIPv6 netip.Prefix
+
+	// TLS configuration for etcd mTLS (optional)
+	TLSCert   []byte // Client certificate PEM
+	TLSKey    []byte // Client private key PEM
+	TLSCACert []byte // CA certificate PEM
 }
 
 func NewNetwork(log *slog.Logger, opts NetworkOptions) (*Network, error) {
-	ec, err := clientv3.New(clientv3.Config{
+	etcdConfig := clientv3.Config{
 		Endpoints: opts.EtcdEndpoints,
-	})
+	}
+
+	// Configure TLS if certificates are provided
+	if opts.TLSCert != nil && opts.TLSKey != nil && opts.TLSCACert != nil {
+		tlsConfig, err := buildTLSConfig(opts.TLSCert, opts.TLSKey, opts.TLSCACert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build etcd TLS config: %w", err)
+		}
+		etcdConfig.TLS = tlsConfig
+		log.Info("grunge using mTLS for etcd connection")
+	}
+
+	ec, err := clientv3.New(etcdConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -65,6 +84,24 @@ func NewNetwork(log *slog.Logger, opts NetworkOptions) (*Network, error) {
 		NetworkOptions: opts,
 		log:            log,
 		ec:             ec,
+	}, nil
+}
+
+// buildTLSConfig creates a tls.Config from PEM-encoded certificates.
+func buildTLSConfig(certPEM, keyPEM, caCertPEM []byte) (*tls.Config, error) {
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCertPEM) {
+		return nil, fmt.Errorf("failed to parse CA certificate")
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
 	}, nil
 }
 

--- a/pkg/grunge/grunge.go
+++ b/pkg/grunge/grunge.go
@@ -69,11 +69,16 @@ func NewNetwork(log *slog.Logger, opts NetworkOptions) (*Network, error) {
 }
 
 func (n *Network) SetupConfig(ctx context.Context, v4, v6 netip.Prefix) error {
-	var vxlanBackend struct {
+	var backend struct {
 		Type string
 	}
 
-	vxlanBackend.Type = "vxlan"
+	// Use configured backend type, defaulting to vxlan for backward compatibility
+	backendType := n.BackendType
+	if backendType == "" {
+		backendType = "vxlan"
+	}
+	backend.Type = backendType
 
 	var config subnet.Config
 	config.EnableIPv4 = true
@@ -82,7 +87,7 @@ func (n *Network) SetupConfig(ctx context.Context, v4, v6 netip.Prefix) error {
 	config.Network = ip.FromIPNet(netipx.PrefixIPNet(v4))
 	//config.IPv6Network = ip.FromIP6Net(netipx.PrefixIPNet(v6))
 
-	data, err := json.Marshal(vxlanBackend)
+	data, err := json.Marshal(backend)
 	if err != nil {
 		n.log.Error("Failed to marshal config", "error", err)
 		return err
@@ -237,9 +242,16 @@ func (n *Network) Start(ctx context.Context, eg *errgroup.Group) error {
 	}
 
 	bm := backend.NewManager(ctx, sm, extIface)
-	be, err := bm.GetBackend("vxlan")
+
+	// Use configured backend type, defaulting to vxlan for backward compatibility
+	backendType := n.BackendType
+	if backendType == "" {
+		backendType = "vxlan"
+	}
+
+	be, err := bm.GetBackend(backendType)
 	if err != nil {
-		n.log.Error("Failed to get backend", "error", err)
+		n.log.Error("Failed to get backend", "backend", backendType, "error", err)
 		return err
 	}
 

--- a/pkg/joincode/joincode.go
+++ b/pkg/joincode/joincode.go
@@ -8,6 +8,8 @@ import (
 	"math/big"
 	"regexp"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 const alphanumChars = "abcdefghjkmnpqrstuvwxyz23456789"
@@ -62,4 +64,12 @@ func randomAlphanumeric(length int) (string, error) {
 		result[i] = alphanumChars[n.Int64()]
 	}
 	return string(result), nil
+}
+
+// IsUUID checks if the string is a valid UUID.
+// This is used to distinguish coordinator nodes (non-UUID runner_id like "miren")
+// from runner nodes (UUID runner_id generated during join).
+func IsUUID(s string) bool {
+	_, err := uuid.Parse(s)
+	return err == nil
 }

--- a/pkg/joincode/joincode_test.go
+++ b/pkg/joincode/joincode_test.go
@@ -113,3 +113,28 @@ func TestWordlistsLowercase(t *testing.T) {
 		}
 	}
 }
+
+func TestIsUUID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"550e8400-e29b-41d4-a716-446655440000", true},
+		{"550E8400-E29B-41D4-A716-446655440000", true},
+		{"6ba7b810-9dad-11d1-80b4-00c04fd430c8", true},
+		{"550e8400e29b41d4a716446655440000", true}, // UUID without hyphens is valid
+		{"miren", false},
+		{"", false},
+		{"not-a-uuid", false},
+		{"calm-river-x7k2", false},
+		{"550e8400-e29b-41d4-a716", false}, // truncated UUID
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := IsUUID(tt.input); got != tt.expected {
+				t.Errorf("IsUUID(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/runnerconfig/config.go
+++ b/pkg/runnerconfig/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	ClientCert         string            `yaml:"client_cert" json:"client_cert"`
 	ClientKey          string            `yaml:"client_key" json:"client_key"`
 	Labels             map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
+	// Network configuration for distributed runners
+	EtcdEndpoints  []string `yaml:"etcd_endpoints,omitempty" json:"etcd_endpoints,omitempty"`
+	EtcdPrefix     string   `yaml:"etcd_prefix,omitempty" json:"etcd_prefix,omitempty"`
+	NetworkBackend string   `yaml:"network_backend,omitempty" json:"network_backend,omitempty"`
 }
 
 func Load(path string) (*Config, error) {

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -26,6 +26,7 @@ type CLIFlags struct {
 	ServerConfigConfigClusterName        *string  `long:"config-cluster-name" short:"C" description:"Name of the cluster in client config"`
 	ServerConfigDataPath                 *string  `long:"data-path" short:"d" description:"Data path"`
 	ServerConfigHTTPRequestTimeout       *int     `long:"http-request-timeout" description:"HTTP request timeout in seconds"`
+	ServerConfigNetworkBackend           *string  `long:"network-backend" description:"Network backend for sandbox connectivity: vxlan (default) or wireguard"`
 	ServerConfigReleasePath              *string  `long:"release-path" description:"Path to release directory containing binaries"`
 	ServerConfigRunnerAddress            *string  `long:"runner-address" description:"Runner address (host:port). For IPv6 use brackets, e.g. \"[::1]:8444\"."`
 	ServerConfigRunnerID                 *string  `long:"runner-id" short:"r" description:"Runner ID"`

--- a/pkg/serverconfig/config.gen.go
+++ b/pkg/serverconfig/config.gen.go
@@ -233,6 +233,7 @@ type ServerConfig struct {
 	ConfigClusterName       *string `toml:"config_cluster_name" env:"MIREN_SERVER_CONFIG_CLUSTER_NAME"`
 	DataPath                *string `toml:"data_path" env:"MIREN_SERVER_DATA_PATH"`
 	HTTPRequestTimeout      *int    `toml:"http_request_timeout" env:"MIREN_SERVER_HTTP_REQUEST_TIMEOUT"`
+	NetworkBackend          *string `toml:"network_backend" env:"MIREN_SERVER_NETWORK_BACKEND"`
 	ReleasePath             *string `toml:"release_path" env:"MIREN_SERVER_RELEASE_PATH"`
 	RunnerAddress           *string `toml:"runner_address" env:"MIREN_SERVER_RUNNER_ADDRESS"`
 	RunnerID                *string `toml:"runner_id" env:"MIREN_SERVER_RUNNER_ID"`
@@ -290,6 +291,19 @@ func (c *ServerConfig) GetHTTPRequestTimeout() int {
 // SetHTTPRequestTimeout sets the value of HTTPRequestTimeout
 func (c *ServerConfig) SetHTTPRequestTimeout(v int) {
 	c.HTTPRequestTimeout = &v
+}
+
+// GetNetworkBackend returns the value of NetworkBackend or its zero value if nil
+func (c *ServerConfig) GetNetworkBackend() string {
+	if c.NetworkBackend != nil {
+		return *c.NetworkBackend
+	}
+	return ""
+}
+
+// SetNetworkBackend sets the value of NetworkBackend
+func (c *ServerConfig) SetNetworkBackend(v string) {
+	c.NetworkBackend = &v
 }
 
 // GetReleasePath returns the value of ReleasePath or its zero value if nil

--- a/pkg/serverconfig/defaults.gen.go
+++ b/pkg/serverconfig/defaults.gen.go
@@ -61,6 +61,7 @@ func DefaultServerConfig() ServerConfig {
 		ConfigClusterName:       strPtr("local"),
 		DataPath:                strPtr("/var/lib/miren"),
 		HTTPRequestTimeout:      intPtr(60),
+		NetworkBackend:          strPtr("vxlan"),
 		ReleasePath:             strPtr(""),
 		RunnerAddress:           strPtr("localhost:8444"),
 		RunnerID:                strPtr("miren"),

--- a/pkg/serverconfig/env.gen.go
+++ b/pkg/serverconfig/env.gen.go
@@ -230,6 +230,14 @@ func applyEnvironmentVariables(cfg *Config, log *slog.Logger) error {
 
 	}
 
+	// Apply MIREN_SERVER_NETWORK_BACKEND
+	if val := os.Getenv("MIREN_SERVER_NETWORK_BACKEND"); val != "" {
+
+		cfg.Server.NetworkBackend = &val
+		log.Debug("applied env var", "key", "MIREN_SERVER_NETWORK_BACKEND")
+
+	}
+
 	// Apply MIREN_SERVER_RELEASE_PATH
 	if val := os.Getenv("MIREN_SERVER_RELEASE_PATH"); val != "" {
 

--- a/pkg/serverconfig/loader.gen.go
+++ b/pkg/serverconfig/loader.gen.go
@@ -230,6 +230,10 @@ func applyCLIFlags(cfg *Config, flags *CLIFlags) {
 		cfg.Server.HTTPRequestTimeout = flags.ServerConfigHTTPRequestTimeout
 	}
 
+	if flags.ServerConfigNetworkBackend != nil && *flags.ServerConfigNetworkBackend != "" {
+		cfg.Server.NetworkBackend = flags.ServerConfigNetworkBackend
+	}
+
 	if flags.ServerConfigReleasePath != nil && *flags.ServerConfigReleasePath != "" {
 		cfg.Server.ReleasePath = flags.ServerConfigReleasePath
 	}

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -161,6 +161,17 @@ configs:
         env: MIREN_SERVER_STOP_SANDBOXES_ON_SHUTDOWN
         toml: stop_sandboxes_on_shutdown
 
+      network_backend:
+        type: string
+        default: vxlan
+        cli:
+          long: network-backend
+          description: "Network backend for sandbox connectivity: vxlan (default) or wireguard"
+        env: MIREN_SERVER_NETWORK_BACKEND
+        toml: network_backend
+        validation:
+          enum: [vxlan, wireguard]
+
   TLSConfig:
     description: TLS/certificate settings
     fields:

--- a/pkg/serverconfig/validation.gen.go
+++ b/pkg/serverconfig/validation.gen.go
@@ -129,6 +129,17 @@ func (c *ServerConfig) Validate() error {
 		return fmt.Errorf("http_request_timeout must be at least 1, got %d", *c.HTTPRequestTimeout)
 	}
 
+	// Validate network_backend enum
+	if c.NetworkBackend != nil {
+		validNetworkBackend := map[string]bool{
+			"vxlan":     true,
+			"wireguard": true,
+		}
+		if !validNetworkBackend[*c.NetworkBackend] {
+			return fmt.Errorf("invalid network_backend %q: must be one of [vxlan wireguard]", *c.NetworkBackend)
+		}
+	}
+
 	// Validate runner_address
 	if c.RunnerAddress != nil && *c.RunnerAddress != "" {
 		if _, _, err := net.SplitHostPort(*c.RunnerAddress); err != nil {

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -179,7 +179,7 @@ func TestServer(t *testing.T) error {
 		return err
 	}
 
-	err = r.Start(sub)
+	err = r.Start(sub, eg)
 	if err != nil {
 		ctxCancel()
 		return err

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -29,16 +29,22 @@ type RegistrationServer struct {
 	Authority       *caauth.Authority
 	EAC             *entityserver_v1alpha.EntityAccessClient
 	CoordinatorAddr string
+	EtcdEndpoints   []string
+	EtcdPrefix      string
+	NetworkBackend  string
 }
 
 var _ runner_v1alpha.RunnerRegistration = (*RegistrationServer)(nil)
 
-func NewRegistrationServer(log *slog.Logger, authority *caauth.Authority, eac *entityserver_v1alpha.EntityAccessClient, coordinatorAddr string) *RegistrationServer {
+func NewRegistrationServer(log *slog.Logger, authority *caauth.Authority, eac *entityserver_v1alpha.EntityAccessClient, coordinatorAddr string, etcdEndpoints []string, etcdPrefix string, networkBackend string) *RegistrationServer {
 	return &RegistrationServer{
 		Log:             log.With("module", "runner-registration"),
 		Authority:       authority,
 		EAC:             eac,
 		CoordinatorAddr: coordinatorAddr,
+		EtcdEndpoints:   etcdEndpoints,
+		EtcdPrefix:      etcdPrefix,
+		NetworkBackend:  networkBackend,
 	}
 }
 
@@ -236,6 +242,17 @@ func (s *RegistrationServer) Join(ctx context.Context, req *runner_v1alpha.Runne
 	results.SetCaPem(cc.CACert)
 	results.SetCoordinatorAddr(s.CoordinatorAddr)
 	results.SetRunnerId(runnerID)
+
+	// Provide network configuration for distributed runners
+	if len(s.EtcdEndpoints) > 0 {
+		results.SetEtcdEndpoints(s.EtcdEndpoints)
+	}
+	if s.EtcdPrefix != "" {
+		results.SetEtcdPrefix(s.EtcdPrefix + "/sub/flannel")
+	}
+	if s.NetworkBackend != "" {
+		results.SetNetworkBackend(s.NetworkBackend)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

This PR adds Phase 2 of the distributed runners feature, building on Phase 1 (#556):

- **Configurable network backend**: Grunge now supports both vxlan and wireguard backends
- **Network config in join response**: Runners receive etcd endpoints and network backend type when joining
- **Runner network initialization**: Distributed runners join the Flannel mesh on startup
- **Stateful/stateless scheduling**: 
  - Sandboxes with miren disk volumes are scheduled to the coordinator
  - Stateless sandboxes prefer runner nodes when available
- **etcd mTLS security**: When `DistributedRunners` feature flag is enabled, all etcd connections use mutual TLS

## Security Architecture

The etcd security concern from the initial implementation has been addressed:

| Component | etcd Auth |
|-----------|-----------|
| etcd server | Starts with `--client-cert-auth` and `--trusted-ca-file` |
| Coordinator | Uses client cert issued by cluster CA |
| Grunge (Flannel) | Uses same client cert for network coordination |
| Runners | Will use join-issued cert (when `runner start` implemented) |

All certificates are issued by the same CA used for RPC authentication, so the PKI is unified.

**Remaining consideration**: Runners still have direct etcd access (read/write). For now this is acceptable since runners are authenticated. Future work could proxy Flannel coordination through the Miren RPC layer for finer-grained access control.

## Test plan

- [x] Lint passes
- [x] Unit tests for IsUUID helper
- [x] Unit tests for stateful/stateless scheduling
- [x] etcd TLS config builds and integrates correctly
- [ ] Manual testing with coordinator + runner
- [ ] Test WireGuard connectivity across nodes
- [ ] Implement `runner start` command to test full distributed flow