### PR TITLE
Return error from GetConfiguration when app not found

### DIFF
--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -295,11 +295,6 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 
 	err := r.EC.Get(ctx, name, &appRec)
 	if err != nil {
-		if errors.Is(err, cond.ErrNotFound{}) {
-			// No app, no problem.
-			return nil
-		}
-
 		return err
 	}
 
@@ -311,7 +306,7 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 			return err
 		}
 	} else {
-		return nil
+		return fmt.Errorf("app has no active version")
 	}
 
 	var cfg app_v1alpha.Configuration


### PR DESCRIPTION
Hit a panic running `miren env list` on an app that wasn't deployed to
the current cluster. Traced it to GetConfiguration returning success
with a nil configuration instead of an error.

The old code had a "No app, no problem" comment and silently returned
nil. But that's actually a problem - 3 out of 5 callers were dereferencing
the result without checking, causing panics.

Fixed by making GetConfiguration consistent with SetEnvVar and DeleteEnvVar,
which already return errors for missing apps.