### PR TITLE
Add schema-driven public method support to RPC layer

### DIFF
--- a/api/admin/admin_v1alpha/rpc.gen.go
+++ b/api/admin/admin_v1alpha/rpc.gen.go
@@ -592,6 +592,7 @@ func AdaptAdmin(t Admin) *rpc.Interface {
 			Name:          "Invoke",
 			InterfaceName: "Admin",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Invoke(ctx, &AdminInvoke{Call: call})
 			},
@@ -600,6 +601,7 @@ func AdaptAdmin(t Admin) *rpc.Interface {
 			Name:          "ListMethods",
 			InterfaceName: "Admin",
 			Index:         1,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListMethods(ctx, &AdminListMethods{Call: call})
 			},
@@ -608,6 +610,7 @@ func AdaptAdmin(t Admin) *rpc.Interface {
 			Name:          "DescribeMethods",
 			InterfaceName: "Admin",
 			Index:         2,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DescribeMethods(ctx, &AdminDescribeMethods{Call: call})
 			},

--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -2512,6 +2512,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Name:          "new",
 			InterfaceName: "Crud",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.New(ctx, &CrudNew{Call: call})
 			},
@@ -2520,6 +2521,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Name:          "setConfiguration",
 			InterfaceName: "Crud",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetConfiguration(ctx, &CrudSetConfiguration{Call: call})
 			},
@@ -2528,6 +2530,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Name:          "getConfiguration",
 			InterfaceName: "Crud",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetConfiguration(ctx, &CrudGetConfiguration{Call: call})
 			},
@@ -2536,6 +2539,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Name:          "setHost",
 			InterfaceName: "Crud",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetHost(ctx, &CrudSetHost{Call: call})
 			},
@@ -2544,6 +2548,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Name:          "list",
 			InterfaceName: "Crud",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &CrudList{Call: call})
 			},
@@ -2552,6 +2557,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Name:          "destroy",
 			InterfaceName: "Crud",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Destroy(ctx, &CrudDestroy{Call: call})
 			},
@@ -2560,6 +2566,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Name:          "setEnvVar",
 			InterfaceName: "Crud",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetEnvVar(ctx, &CrudSetEnvVar{Call: call})
 			},
@@ -2568,6 +2575,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Name:          "deleteEnvVar",
 			InterfaceName: "Crud",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeleteEnvVar(ctx, &CrudDeleteEnvVar{Call: call})
 			},
@@ -2933,6 +2941,7 @@ func AdaptUserQuery(t UserQuery) *rpc.Interface {
 			Name:          "whoAmI",
 			InterfaceName: "UserQuery",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.WhoAmI(ctx, &UserQueryWhoAmI{Call: call})
 			},
@@ -3093,6 +3102,7 @@ func AdaptAppStatus(t AppStatus) *rpc.Interface {
 			Name:          "appInfo",
 			InterfaceName: "AppStatus",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AppInfo(ctx, &AppStatusAppInfo{Call: call})
 			},
@@ -3646,6 +3656,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			Name:          "appLogs",
 			InterfaceName: "Logs",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AppLogs(ctx, &LogsAppLogs{Call: call})
 			},
@@ -3654,6 +3665,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			Name:          "sandboxLogs",
 			InterfaceName: "Logs",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SandboxLogs(ctx, &LogsSandboxLogs{Call: call})
 			},
@@ -3662,6 +3674,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			Name:          "streamLogs",
 			InterfaceName: "Logs",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.StreamLogs(ctx, &LogsStreamLogs{Call: call})
 			},
@@ -3670,6 +3683,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			Name:          "streamLogChunks",
 			InterfaceName: "Logs",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.StreamLogChunks(ctx, &LogsStreamLogChunks{Call: call})
 			},
@@ -4301,6 +4315,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "new",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.New(ctx, &DisksNew{Call: call})
 			},
@@ -4309,6 +4324,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "getById",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetById(ctx, &DisksGetById{Call: call})
 			},
@@ -4317,6 +4333,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "getByName",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetByName(ctx, &DisksGetByName{Call: call})
 			},
@@ -4325,6 +4342,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "list",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &DisksList{Call: call})
 			},
@@ -4333,6 +4351,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "delete",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Delete(ctx, &DisksDelete{Call: call})
 			},
@@ -4835,6 +4854,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			Name:          "createInstance",
 			InterfaceName: "Addons",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CreateInstance(ctx, &AddonsCreateInstance{Call: call})
 			},
@@ -4843,6 +4863,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			Name:          "listInstances",
 			InterfaceName: "Addons",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListInstances(ctx, &AddonsListInstances{Call: call})
 			},
@@ -4851,6 +4872,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			Name:          "deleteInstance",
 			InterfaceName: "Addons",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeleteInstance(ctx, &AddonsDeleteInstance{Call: call})
 			},

--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -659,6 +659,7 @@ func AdaptStream(t Stream) *rpc.Interface {
 			Name:          "recv",
 			InterfaceName: "Stream",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Recv(ctx, &StreamRecv{Call: call})
 			},
@@ -960,6 +961,7 @@ func AdaptBuilder(t Builder) *rpc.Interface {
 			Name:          "buildFromTar",
 			InterfaceName: "Builder",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.BuildFromTar(ctx, &BuilderBuildFromTar{Call: call})
 			},
@@ -968,6 +970,7 @@ func AdaptBuilder(t Builder) *rpc.Interface {
 			Name:          "analyzeApp",
 			InterfaceName: "Builder",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AnalyzeApp(ctx, &BuilderAnalyzeApp{Call: call})
 			},

--- a/api/debug/debug_v1alpha/rpc.gen.go
+++ b/api/debug/debug_v1alpha/rpc.gen.go
@@ -824,6 +824,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			Name:          "listLeases",
 			InterfaceName: "NetDB",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListLeases(ctx, &NetDBListLeases{Call: call})
 			},
@@ -832,6 +833,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			Name:          "status",
 			InterfaceName: "NetDB",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Status(ctx, &NetDBStatus{Call: call})
 			},
@@ -840,6 +842,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			Name:          "releaseIP",
 			InterfaceName: "NetDB",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ReleaseIP(ctx, &NetDBReleaseIP{Call: call})
 			},
@@ -848,6 +851,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			Name:          "releaseSubnet",
 			InterfaceName: "NetDB",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ReleaseSubnet(ctx, &NetDBReleaseSubnet{Call: call})
 			},
@@ -856,6 +860,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			Name:          "releaseAll",
 			InterfaceName: "NetDB",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ReleaseAll(ctx, &NetDBReleaseAll{Call: call})
 			},
@@ -864,6 +869,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			Name:          "gc",
 			InterfaceName: "NetDB",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Gc(ctx, &NetDBGc{Call: call})
 			},

--- a/api/deployment/deployment_v1alpha/rpc.gen.go
+++ b/api/deployment/deployment_v1alpha/rpc.gen.go
@@ -1619,6 +1619,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Name:          "CreateDeployment",
 			InterfaceName: "Deployment",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CreateDeployment(ctx, &DeploymentCreateDeployment{Call: call})
 			},
@@ -1627,6 +1628,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Name:          "UpdateDeploymentStatus",
 			InterfaceName: "Deployment",
 			Index:         1,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.UpdateDeploymentStatus(ctx, &DeploymentUpdateDeploymentStatus{Call: call})
 			},
@@ -1635,6 +1637,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Name:          "UpdateDeploymentPhase",
 			InterfaceName: "Deployment",
 			Index:         2,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.UpdateDeploymentPhase(ctx, &DeploymentUpdateDeploymentPhase{Call: call})
 			},
@@ -1643,6 +1646,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Name:          "UpdateFailedDeployment",
 			InterfaceName: "Deployment",
 			Index:         3,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.UpdateFailedDeployment(ctx, &DeploymentUpdateFailedDeployment{Call: call})
 			},
@@ -1651,6 +1655,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Name:          "UpdateDeploymentAppVersion",
 			InterfaceName: "Deployment",
 			Index:         4,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.UpdateDeploymentAppVersion(ctx, &DeploymentUpdateDeploymentAppVersion{Call: call})
 			},
@@ -1659,6 +1664,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Name:          "ListDeployments",
 			InterfaceName: "Deployment",
 			Index:         5,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListDeployments(ctx, &DeploymentListDeployments{Call: call})
 			},
@@ -1667,6 +1673,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Name:          "GetDeploymentById",
 			InterfaceName: "Deployment",
 			Index:         6,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetDeploymentById(ctx, &DeploymentGetDeploymentById{Call: call})
 			},
@@ -1675,6 +1682,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Name:          "GetActiveDeployment",
 			InterfaceName: "Deployment",
 			Index:         7,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetActiveDeployment(ctx, &DeploymentGetActiveDeployment{Call: call})
 			},
@@ -1683,6 +1691,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Name:          "CancelDeployment",
 			InterfaceName: "Deployment",
 			Index:         8,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CancelDeployment(ctx, &DeploymentCancelDeployment{Call: call})
 			},

--- a/api/entityserver/entityserver_v1alpha/rpc.gen.go
+++ b/api/entityserver/entityserver_v1alpha/rpc.gen.go
@@ -560,6 +560,7 @@ func AdaptStream(t Stream) *rpc.Interface {
 			Name:          "recv",
 			InterfaceName: "Stream",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Recv(ctx, &StreamRecv{Call: call})
 			},
@@ -2632,6 +2633,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "get",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Get(ctx, &EntityAccessGet{Call: call})
 			},
@@ -2640,6 +2642,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "put",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Put(ctx, &EntityAccessPut{Call: call})
 			},
@@ -2648,6 +2651,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "create",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Create(ctx, &EntityAccessCreate{Call: call})
 			},
@@ -2656,6 +2660,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "replace",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Replace(ctx, &EntityAccessReplace{Call: call})
 			},
@@ -2664,6 +2669,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "patch",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Patch(ctx, &EntityAccessPatch{Call: call})
 			},
@@ -2672,6 +2678,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "ensure",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Ensure(ctx, &EntityAccessEnsure{Call: call})
 			},
@@ -2680,6 +2687,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "put_session",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.PutSession(ctx, &EntityAccessPutSession{Call: call})
 			},
@@ -2688,6 +2696,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "delete",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Delete(ctx, &EntityAccessDelete{Call: call})
 			},
@@ -2696,6 +2705,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "watch_index",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.WatchIndex(ctx, &EntityAccessWatchIndex{Call: call})
 			},
@@ -2704,6 +2714,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "watch_entity",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.WatchEntity(ctx, &EntityAccessWatchEntity{Call: call})
 			},
@@ -2712,6 +2723,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "list",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &EntityAccessList{Call: call})
 			},
@@ -2720,6 +2732,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "makeAttr",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.MakeAttr(ctx, &EntityAccessMakeAttr{Call: call})
 			},
@@ -2728,6 +2741,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "lookupKind",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.LookupKind(ctx, &EntityAccessLookupKind{Call: call})
 			},
@@ -2736,6 +2750,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "parse",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Parse(ctx, &EntityAccessParse{Call: call})
 			},
@@ -2744,6 +2759,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "format",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Format(ctx, &EntityAccessFormat{Call: call})
 			},
@@ -2752,6 +2768,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "create_session",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CreateSession(ctx, &EntityAccessCreateSession{Call: call})
 			},
@@ -2760,6 +2777,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "revoke_session",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.RevokeSession(ctx, &EntityAccessRevokeSession{Call: call})
 			},
@@ -2768,6 +2786,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "ping_session",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.PingSession(ctx, &EntityAccessPingSession{Call: call})
 			},
@@ -2776,6 +2795,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "reindex",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Reindex(ctx, &EntityAccessReindex{Call: call})
 			},
@@ -2784,6 +2804,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			Name:          "get_attributes_by_tag",
 			InterfaceName: "EntityAccess",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetAttributesByTag(ctx, &EntityAccessGetAttributesByTag{Call: call})
 			},

--- a/api/exec/exec_v1alpha/rpc.gen.go
+++ b/api/exec/exec_v1alpha/rpc.gen.go
@@ -349,6 +349,7 @@ func AdaptSandboxExec(t SandboxExec) *rpc.Interface {
 			Name:          "exec",
 			InterfaceName: "SandboxExec",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Exec(ctx, &SandboxExecExec{Call: call})
 			},

--- a/api/httpingress/httpingress_v1alpha/rpc.gen.go
+++ b/api/httpingress/httpingress_v1alpha/rpc.gen.go
@@ -392,6 +392,7 @@ func AdaptInternalHttp(t InternalHttp) *rpc.Interface {
 			Name:          "DoRequest",
 			InterfaceName: "InternalHttp",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DoRequest(ctx, &InternalHttpDoRequest{Call: call})
 			},

--- a/api/lsvd/lsvd_v1alpha/rpc.gen.go
+++ b/api/lsvd/lsvd_v1alpha/rpc.gen.go
@@ -661,6 +661,7 @@ func AdaptLsvdDebug(t LsvdDebug) *rpc.Interface {
 			Name:          "listVolumes",
 			InterfaceName: "LsvdDebug",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListVolumes(ctx, &LsvdDebugListVolumes{Call: call})
 			},
@@ -669,6 +670,7 @@ func AdaptLsvdDebug(t LsvdDebug) *rpc.Interface {
 			Name:          "listMounts",
 			InterfaceName: "LsvdDebug",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListMounts(ctx, &LsvdDebugListMounts{Call: call})
 			},
@@ -677,6 +679,7 @@ func AdaptLsvdDebug(t LsvdDebug) *rpc.Interface {
 			Name:          "getMetrics",
 			InterfaceName: "LsvdDebug",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetMetrics(ctx, &LsvdDebugGetMetrics{Call: call})
 			},

--- a/api/metric/metric_v1alpha/rpc.gen.go
+++ b/api/metric/metric_v1alpha/rpc.gen.go
@@ -313,6 +313,7 @@ func AdaptSandboxMetrics(t SandboxMetrics) *rpc.Interface {
 			Name:          "snapshot",
 			InterfaceName: "SandboxMetrics",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Snapshot(ctx, &SandboxMetricsSnapshot{Call: call})
 			},

--- a/api/outboard/outboard_v1alpha/rpc.gen.go
+++ b/api/outboard/outboard_v1alpha/rpc.gen.go
@@ -357,6 +357,7 @@ func AdaptOutboardControl(t OutboardControl) *rpc.Interface {
 			Name:          "health",
 			InterfaceName: "OutboardControl",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Health(ctx, &OutboardControlHealth{Call: call})
 			},
@@ -365,6 +366,7 @@ func AdaptOutboardControl(t OutboardControl) *rpc.Interface {
 			Name:          "checkVersion",
 			InterfaceName: "OutboardControl",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CheckVersion(ctx, &OutboardControlCheckVersion{Call: call})
 			},

--- a/api/rpc.gen.go
+++ b/api/rpc.gen.go
@@ -822,6 +822,7 @@ func AdaptUserQuery(t UserQuery) *rpc.Interface {
 			Name:          "whoAmI",
 			InterfaceName: "UserQuery",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.WhoAmI(ctx, &UserQueryWhoAmI{Call: call})
 			},
@@ -982,6 +983,7 @@ func AdaptAppInfo(t AppInfo) *rpc.Interface {
 			Name:          "appInfo",
 			InterfaceName: "AppInfo",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AppInfo(ctx, &AppInfoAppInfo{Call: call})
 			},
@@ -1165,6 +1167,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			Name:          "appLogs",
 			InterfaceName: "Logs",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AppLogs(ctx, &LogsAppLogs{Call: call})
 			},
@@ -1709,6 +1712,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "new",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.New(ctx, &DisksNew{Call: call})
 			},
@@ -1717,6 +1721,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "getById",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetById(ctx, &DisksGetById{Call: call})
 			},
@@ -1725,6 +1730,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "getByName",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetByName(ctx, &DisksGetByName{Call: call})
 			},
@@ -1733,6 +1739,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "list",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &DisksList{Call: call})
 			},
@@ -1741,6 +1748,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			Name:          "delete",
 			InterfaceName: "Disks",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Delete(ctx, &DisksDelete{Call: call})
 			},
@@ -2243,6 +2251,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			Name:          "createInstance",
 			InterfaceName: "Addons",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CreateInstance(ctx, &AddonsCreateInstance{Call: call})
 			},
@@ -2251,6 +2260,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			Name:          "listInstances",
 			InterfaceName: "Addons",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListInstances(ctx, &AddonsListInstances{Call: call})
 			},
@@ -2259,6 +2269,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			Name:          "deleteInstance",
 			InterfaceName: "Addons",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeleteInstance(ctx, &AddonsDeleteInstance{Call: call})
 			},

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -502,8 +502,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 			"cloud_url", authCloudURL)
 	} else if c.NoAuth {
 		// Use NoOpAuthenticator when explicitly disabled (for testing)
-		// Also skip verification to bypass public method auth checks
-		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(&rpc.NoOpAuthenticator{}), rpc.WithSkipVerify)
+		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(&rpc.NoOpAuthenticator{}))
 		c.Log.Warn("authentication disabled (NoOpAuthenticator)")
 	} else {
 		// Use LocalOnlyAuthenticator when cloud auth is not enabled

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -497,7 +497,8 @@ func (c *Coordinator) Start(ctx context.Context) error {
 			return err
 		}
 
-		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(authenticator))
+		// RPCAuthenticator implements both Authenticator and Authorizer
+		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(authenticator), rpc.WithAuthorizer(authenticator))
 		c.Log.Info("cloud authentication enabled",
 			"cloud_url", authCloudURL)
 	} else if c.NoAuth {

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -502,7 +502,8 @@ func (c *Coordinator) Start(ctx context.Context) error {
 			"cloud_url", authCloudURL)
 	} else if c.NoAuth {
 		// Use NoOpAuthenticator when explicitly disabled (for testing)
-		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(&rpc.NoOpAuthenticator{}))
+		// Also skip verification to bypass public method auth checks
+		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(&rpc.NoOpAuthenticator{}), rpc.WithSkipVerify)
 		c.Log.Warn("authentication disabled (NoOpAuthenticator)")
 	} else {
 		// Use LocalOnlyAuthenticator when cloud auth is not enabled

--- a/pkg/cloudauth/rpc_authenticator.go
+++ b/pkg/cloudauth/rpc_authenticator.go
@@ -109,10 +109,11 @@ func NewRPCAuthenticator(ctx context.Context, config Config) (*RPCAuthenticator,
 
 // Authenticate implements rpc.Authenticator.
 // It tries JWT authentication first, then falls back to TLS client certificate.
+// Authorization (RBAC) is handled separately via the Authorize method.
 func (a *RPCAuthenticator) Authenticate(ctx context.Context, r *http.Request) (*rpc.Identity, error) {
 	// Try JWT authentication first if Authorization header is present
 	if authHeader := r.Header.Get("Authorization"); authHeader != "" {
-		identity, err := a.authenticateJWT(ctx, r, authHeader)
+		identity, err := a.authenticateJWT(ctx, authHeader)
 		if err != nil {
 			return nil, err
 		}
@@ -135,8 +136,9 @@ func (a *RPCAuthenticator) Authenticate(ctx context.Context, r *http.Request) (*
 	return nil, nil
 }
 
-// authenticateJWT validates a JWT token and performs RBAC evaluation
-func (a *RPCAuthenticator) authenticateJWT(ctx context.Context, r *http.Request, authHeader string) (*rpc.Identity, error) {
+// authenticateJWT validates a JWT token and returns the caller's identity.
+// Authorization (RBAC) is handled separately in the Authorize method.
+func (a *RPCAuthenticator) authenticateJWT(ctx context.Context, authHeader string) (*rpc.Identity, error) {
 	if !strings.HasPrefix(authHeader, "Bearer ") {
 		return nil, nil // Invalid format, not a JWT
 	}
@@ -159,36 +161,6 @@ func (a *RPCAuthenticator) authenticateJWT(ctx context.Context, r *http.Request,
 		a.tokenCache.Set(token, claims)
 	}
 
-	// Perform RBAC evaluation
-	// TODO: For now we hardcode the resource and action as "cluster access".
-	// In the future, we'll make this per-method for more granular authorization.
-	req := &rbac.Request{
-		Subject:  claims.Subject,
-		Groups:   claims.GroupIDs,
-		Resource: "cluster",
-		Action:   "access",
-		Tags:     a.tags,
-		Context: map[string]any{
-			"organization_id": claims.OrganizationID,
-		},
-	}
-
-	decision := a.rbacEval.Evaluate(req)
-	if decision == rbac.DecisionDeny {
-		a.logger.Warn("authorization denied",
-			"subject", claims.Subject,
-			"groups", claims.GroupIDs,
-			"resource", r.URL.Path,
-			"action", r.Method,
-			"tags", a.tags,
-		)
-
-		// Trigger a refresh of RBAC rules (with 30-second cooldown)
-		a.policyFetcher.RefreshIfNeeded(ctx)
-
-		return nil, fmt.Errorf("access denied by RBAC policy")
-	}
-
 	a.logger.Debug("JWT authentication successful",
 		"subject", claims.Subject,
 		"organization_id", claims.OrganizationID,
@@ -202,6 +174,50 @@ func (a *RPCAuthenticator) authenticateJWT(ctx context.Context, r *http.Request,
 			"organization_id": claims.OrganizationID,
 		},
 	}, nil
+}
+
+// Authorize implements rpc.Authorizer.
+// It performs RBAC evaluation to determine if the identity can perform the action.
+func (a *RPCAuthenticator) Authorize(ctx context.Context, identity *rpc.Identity, resource, action string) error {
+	// Cert-authenticated callers (local/internal) bypass RBAC
+	if identity.Method == rpc.AuthMethodCert {
+		return nil
+	}
+
+	// Build RBAC request using the provided resource and action
+	req := &rbac.Request{
+		Subject:  identity.Subject,
+		Groups:   identity.Groups,
+		Resource: resource,
+		Action:   action,
+		Tags:     a.tags,
+		Context:  map[string]any{},
+	}
+
+	// Add organization_id from metadata if present
+	if identity.Metadata != nil {
+		if orgID, ok := identity.Metadata["organization_id"]; ok {
+			req.Context["organization_id"] = orgID
+		}
+	}
+
+	decision := a.rbacEval.Evaluate(req)
+	if decision == rbac.DecisionDeny {
+		a.logger.Warn("authorization denied",
+			"subject", identity.Subject,
+			"groups", identity.Groups,
+			"resource", resource,
+			"action", action,
+			"tags", a.tags,
+		)
+
+		// Trigger a refresh of RBAC rules (with 30-second cooldown)
+		a.policyFetcher.RefreshIfNeeded(ctx)
+
+		return fmt.Errorf("access denied by RBAC policy")
+	}
+
+	return nil
 }
 
 // Stop stops background tasks

--- a/pkg/cloudauth/rpc_authenticator.go
+++ b/pkg/cloudauth/rpc_authenticator.go
@@ -9,6 +9,7 @@ import (
 
 	"miren.dev/runtime/pkg/auth"
 	"miren.dev/runtime/pkg/rbac"
+	"miren.dev/runtime/pkg/rpc"
 )
 
 // DefaultCloudURL is the default URL for miren.cloud
@@ -106,21 +107,38 @@ func NewRPCAuthenticator(ctx context.Context, config Config) (*RPCAuthenticator,
 	return a, nil
 }
 
-// AuthenticateRequest implements rpc.Authenticator
-// This is called before any RPC method is invoked. It's not currently wired
-// into the RPC layer at the method call layer, but it's also ONLY used to
-// authenticate HTTP requests that are routed to RPC methods.
-func (a *RPCAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Request) (bool, string, error) {
-	// Extract token from Authorization header
-	authHeader := r.Header.Get("Authorization")
-	if authHeader == "" {
-		// No auth header - shouldn't happen because rpc server only calls
-		// this method if an auth header is present
-		return false, "", fmt.Errorf("missing authorization header")
+// Authenticate implements rpc.Authenticator.
+// It tries JWT authentication first, then falls back to TLS client certificate.
+func (a *RPCAuthenticator) Authenticate(ctx context.Context, r *http.Request) (*rpc.Identity, error) {
+	// Try JWT authentication first if Authorization header is present
+	if authHeader := r.Header.Get("Authorization"); authHeader != "" {
+		identity, err := a.authenticateJWT(ctx, r, authHeader)
+		if err != nil {
+			return nil, err
+		}
+		if identity != nil {
+			return identity, nil
+		}
+		// Invalid JWT format, fall through to cert check
 	}
 
+	// Fall back to TLS client certificate
+	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+		cert := r.TLS.PeerCertificates[0]
+		return &rpc.Identity{
+			Subject: cert.Subject.CommonName,
+			Method:  rpc.AuthMethodCert,
+		}, nil
+	}
+
+	// No valid credentials
+	return nil, nil
+}
+
+// authenticateJWT validates a JWT token and performs RBAC evaluation
+func (a *RPCAuthenticator) authenticateJWT(ctx context.Context, r *http.Request, authHeader string) (*rpc.Identity, error) {
 	if !strings.HasPrefix(authHeader, "Bearer ") {
-		return false, "", fmt.Errorf("invalid authorization header format")
+		return nil, nil // Invalid format, not a JWT
 	}
 
 	token := strings.TrimPrefix(authHeader, "Bearer ")
@@ -133,7 +151,7 @@ func (a *RPCAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Requ
 	} else {
 		validated, err := a.jwtValidator.ValidateToken(ctx, token)
 		if err != nil {
-			return false, "", fmt.Errorf("token validation failed: %w", err)
+			return nil, fmt.Errorf("token validation failed: %w", err)
 		}
 		claims = validated
 
@@ -141,19 +159,15 @@ func (a *RPCAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Requ
 		a.tokenCache.Set(token, claims)
 	}
 
-	// TODO For now we're going to hardcode the resource and action
-	// as being related to cluster access. In the future, we'll make changes
-	// to this where we request authorization for specific high level actions,
-	// like "deploy", "manage", etc.
-	// At that point, we'll rewire this method to be called post-RPC invoke
-	// inside the handler for the method itself.
-
+	// Perform RBAC evaluation
+	// TODO: For now we hardcode the resource and action as "cluster access".
+	// In the future, we'll make this per-method for more granular authorization.
 	req := &rbac.Request{
 		Subject:  claims.Subject,
 		Groups:   claims.GroupIDs,
 		Resource: "cluster",
 		Action:   "access",
-		Tags:     a.tags, // Use the configured tags
+		Tags:     a.tags,
 		Context: map[string]any{
 			"organization_id": claims.OrganizationID,
 		},
@@ -172,7 +186,7 @@ func (a *RPCAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Requ
 		// Trigger a refresh of RBAC rules (with 30-second cooldown)
 		a.policyFetcher.RefreshIfNeeded(ctx)
 
-		return false, "", fmt.Errorf("access denied by RBAC policy")
+		return nil, fmt.Errorf("access denied by RBAC policy")
 	}
 
 	a.logger.Debug("JWT authentication successful",
@@ -180,20 +194,14 @@ func (a *RPCAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Requ
 		"organization_id", claims.OrganizationID,
 	)
 
-	return true, claims.Subject, nil
-}
-
-// NoAuthorization implements rpc.Authenticator
-func (a *RPCAuthenticator) NoAuthorization(ctx context.Context, r *http.Request) (bool, string, error) {
-	// Check if we have client certificates (already validated by TLS layer)
-	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
-		cert := r.TLS.PeerCertificates[0]
-		return true, cert.Subject.CommonName, nil
-	}
-
-	// No valid auth provided, deny the request
-	a.logger.Debug("request denied - authentication required", "path", r.URL.Path)
-	return false, "", fmt.Errorf("authentication required")
+	return &rpc.Identity{
+		Subject: claims.Subject,
+		Groups:  claims.GroupIDs,
+		Method:  rpc.AuthMethodJWT,
+		Metadata: map[string]any{
+			"organization_id": claims.OrganizationID,
+		},
+	}, nil
 }
 
 // Stop stops background tasks

--- a/pkg/outboard/outboard_test.go
+++ b/pkg/outboard/outboard_test.go
@@ -64,10 +64,10 @@ func TestTokenAuthenticatorValid(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer secret-token")
 
-	ok, identity, err := auth.AuthenticateRequest(context.Background(), req)
+	identity, err := auth.Authenticate(context.Background(), req)
 	assert.NoError(t, err)
-	assert.True(t, ok)
-	assert.Equal(t, "outboard", identity)
+	assert.NotNil(t, identity)
+	assert.Equal(t, "outboard", identity.Subject)
 }
 
 func TestTokenAuthenticatorInvalid(t *testing.T) {
@@ -76,9 +76,9 @@ func TestTokenAuthenticatorInvalid(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer wrong-token")
 
-	ok, _, err := auth.AuthenticateRequest(context.Background(), req)
-	assert.Error(t, err)
-	assert.False(t, ok)
+	identity, err := auth.Authenticate(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Nil(t, identity, "invalid token should return nil identity")
 }
 
 func TestTokenAuthenticatorMissing(t *testing.T) {
@@ -86,19 +86,9 @@ func TestTokenAuthenticatorMissing(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/", nil)
 
-	ok, _, err := auth.AuthenticateRequest(context.Background(), req)
-	assert.Error(t, err)
-	assert.False(t, ok)
-}
-
-func TestTokenAuthenticatorNoAuthorization(t *testing.T) {
-	auth := NewTokenAuthenticator("secret-token")
-
-	req, _ := http.NewRequest("GET", "/", nil)
-
-	ok, _, err := auth.NoAuthorization(context.Background(), req)
-	assert.Error(t, err)
-	assert.False(t, ok)
+	identity, err := auth.Authenticate(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Nil(t, identity, "missing auth header should return nil identity")
 }
 
 func TestTokenAuthenticatorBadScheme(t *testing.T) {
@@ -107,9 +97,9 @@ func TestTokenAuthenticatorBadScheme(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
 
-	ok, _, err := auth.AuthenticateRequest(context.Background(), req)
-	assert.Error(t, err)
-	assert.False(t, ok)
+	identity, err := auth.Authenticate(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Nil(t, identity, "non-bearer auth should return nil identity")
 }
 
 func TestCreateFIFO(t *testing.T) {

--- a/pkg/outboard/token_auth.go
+++ b/pkg/outboard/token_auth.go
@@ -3,9 +3,10 @@ package outboard
 import (
 	"context"
 	"crypto/subtle"
-	"fmt"
 	"net/http"
 	"strings"
+
+	"miren.dev/runtime/pkg/rpc"
 )
 
 // TokenAuthenticator implements rpc.Authenticator using a shared bearer token.
@@ -19,25 +20,24 @@ func NewTokenAuthenticator(token string) *TokenAuthenticator {
 	return &TokenAuthenticator{token: token}
 }
 
-func (t *TokenAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Request) (bool, string, error) {
+func (t *TokenAuthenticator) Authenticate(ctx context.Context, r *http.Request) (*rpc.Identity, error) {
 	auth := r.Header.Get("Authorization")
 	if auth == "" {
-		return false, "", fmt.Errorf("missing authorization header")
+		return nil, nil // No credentials
 	}
 
 	const prefix = "Bearer "
 	if !strings.HasPrefix(auth, prefix) {
-		return false, "", fmt.Errorf("invalid authorization scheme")
+		return nil, nil // Invalid scheme, treat as no credentials
 	}
 
 	provided := auth[len(prefix):]
 	if subtle.ConstantTimeCompare([]byte(provided), []byte(t.token)) != 1 {
-		return false, "", fmt.Errorf("invalid token")
+		return nil, nil // Invalid token
 	}
 
-	return true, "outboard", nil
-}
-
-func (t *TokenAuthenticator) NoAuthorization(ctx context.Context, r *http.Request) (bool, string, error) {
-	return false, "", fmt.Errorf("authorization required")
+	return &rpc.Identity{
+		Subject: "outboard",
+		Method:  rpc.AuthMethodToken,
+	}, nil
 }

--- a/pkg/rpc/actor.go
+++ b/pkg/rpc/actor.go
@@ -140,6 +140,11 @@ func (a *ActorCall) NewClient(capa *Capability) Client {
 	return nil
 }
 
+// IsAuthenticated returns true for actor calls since they are local and implicitly trusted.
+func (a *ActorCall) IsAuthenticated() bool {
+	return true
+}
+
 type ActorClient struct {
 	oid OID
 	reg *LocalActorRegistry

--- a/pkg/rpc/authenticator.go
+++ b/pkg/rpc/authenticator.go
@@ -61,6 +61,15 @@ type Authenticator interface {
 	Authenticate(ctx context.Context, r *http.Request) (*Identity, error)
 }
 
+// Authorizer checks if an identity is allowed to perform an action on a resource
+type Authorizer interface {
+	// Authorize checks if the identity is allowed to perform the action on the resource.
+	// For RPC methods, resource is typically the interface name (lowercase) and
+	// action is the method name (lowercase).
+	// Returns nil if allowed, or an error describing why access was denied.
+	Authorize(ctx context.Context, identity *Identity, resource, action string) error
+}
+
 // NoOpAuthenticator allows all requests without checking credentials.
 // Used for testing only.
 type NoOpAuthenticator struct{}

--- a/pkg/rpc/authenticator.go
+++ b/pkg/rpc/authenticator.go
@@ -47,17 +47,22 @@ func (l *LocalOnlyAuthenticator) AuthenticateRequest(ctx context.Context, r *htt
 }
 
 func (l *LocalOnlyAuthenticator) NoAuthorization(ctx context.Context, r *http.Request) (bool, string, error) {
+	// Extract identity from cert if present
+	var identity string
+	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+		identity = r.TLS.PeerCertificates[0].Subject.CommonName
+	}
+
 	// Allow RPC paths through - the RPC layer handles auth:
 	// - Capability signature auth is always enforced
 	// - Method-level auth rejects unauthenticated calls to non-public methods
 	if strings.HasPrefix(r.URL.Path, "/_rpc/") {
-		return true, "", nil
+		return true, identity, nil
 	}
 
 	// For non-RPC paths, require a valid client certificate
-	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
-		cert := r.TLS.PeerCertificates[0]
-		return true, cert.Subject.CommonName, nil
+	if identity != "" {
+		return true, identity, nil
 	}
 	return false, "", fmt.Errorf("authentication required")
 }

--- a/pkg/rpc/authenticator.go
+++ b/pkg/rpc/authenticator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // Authenticator is an interface for authenticating RPC requests
@@ -29,9 +30,15 @@ func (n *NoOpAuthenticator) NoAuthorization(ctx context.Context, r *http.Request
 	return true, "anonymous", nil
 }
 
-// LocalOnlyAuthenticator requires a valid client certificate for all requests.
+// LocalOnlyAuthenticator requires a valid client certificate for most requests.
 // This is used when cloud authentication is not enabled, ensuring that only
 // clients with certificates issued by the local CA can access the server.
+//
+// RPC paths (/_rpc/) are allowed through without TLS certs at this layer because
+// the RPC layer handles authentication:
+// - Capability-based auth (Ed25519 signatures) is always enforced
+// - Per-method auth checks TLS certs for non-public methods
+// - Only methods marked public: true in the schema allow unauthenticated access
 type LocalOnlyAuthenticator struct{}
 
 func (l *LocalOnlyAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Request) (bool, string, error) {
@@ -40,7 +47,14 @@ func (l *LocalOnlyAuthenticator) AuthenticateRequest(ctx context.Context, r *htt
 }
 
 func (l *LocalOnlyAuthenticator) NoAuthorization(ctx context.Context, r *http.Request) (bool, string, error) {
-	// Require a valid client certificate
+	// Allow RPC paths through - the RPC layer handles auth:
+	// - Capability signature auth is always enforced
+	// - Method-level auth rejects unauthenticated calls to non-public methods
+	if strings.HasPrefix(r.URL.Path, "/_rpc/") {
+		return true, "", nil
+	}
+
+	// For non-RPC paths, require a valid client certificate
 	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
 		cert := r.TLS.PeerCertificates[0]
 		return true, cert.Subject.CommonName, nil

--- a/pkg/rpc/authenticator.go
+++ b/pkg/rpc/authenticator.go
@@ -2,67 +2,90 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"strings"
 )
 
-// Authenticator is an interface for authenticating RPC requests
-type Authenticator interface {
-	// AuthenticateRequest authenticates an HTTP request and returns whether it's allowed
-	// It can check JWT tokens, certificates, or other authentication methods
-	AuthenticateRequest(ctx context.Context, r *http.Request) (authenticated bool, identity string, err error)
+// contextKey is a private type for context keys to avoid collisions
+type contextKey string
 
-	// NoAuthorization is called when a request has no Authorization header
-	// This allows the authenticator to decide if such requests should be allowed
-	// (e.g., based on client certificates or to enforce mandatory authentication)
-	NoAuthorization(ctx context.Context, r *http.Request) (allowed bool, identity string, err error)
+const (
+	// identityContextKey is the context key for storing the authenticated Identity
+	identityContextKey contextKey = "rpc-identity"
+)
+
+// IdentityFromContext retrieves the Identity from the context, if present
+func IdentityFromContext(ctx context.Context) *Identity {
+	if id, ok := ctx.Value(identityContextKey).(*Identity); ok {
+		return id
+	}
+	return nil
 }
 
-// NoOpAuthenticator is a no-op authenticator that allows all requests
+// ContextWithIdentity returns a new context with the Identity stored
+func ContextWithIdentity(ctx context.Context, identity *Identity) context.Context {
+	return context.WithValue(ctx, identityContextKey, identity)
+}
+
+// AuthMethod indicates how a caller was authenticated
+type AuthMethod string
+
+const (
+	AuthMethodCert      AuthMethod = "cert"      // TLS client certificate
+	AuthMethodJWT       AuthMethod = "jwt"       // JWT token (e.g., from Miren Cloud)
+	AuthMethodAnonymous AuthMethod = "anonymous" // No authentication (public methods)
+	AuthMethodToken     AuthMethod = "token"     // Bearer token (e.g., outboard)
+)
+
+// Identity represents an authenticated caller
+type Identity struct {
+	// Subject is the primary identifier (cert CN, JWT subject, etc.)
+	Subject string
+
+	// Groups contains group memberships (from JWT claims, etc.)
+	Groups []string
+
+	// Method indicates how the caller was authenticated
+	Method AuthMethod
+
+	// Metadata holds auth-method-specific data (e.g., OrganizationID for cloud auth)
+	Metadata map[string]any
+}
+
+// Authenticator validates credentials and returns caller identity
+type Authenticator interface {
+	// Authenticate validates the request's credentials and returns the caller's identity.
+	// Returns:
+	//   - (*Identity, nil) if credentials are valid
+	//   - (nil, nil) if no credentials present or credentials are invalid
+	//   - (nil, error) if an error occurred during authentication
+	Authenticate(ctx context.Context, r *http.Request) (*Identity, error)
+}
+
+// NoOpAuthenticator allows all requests without checking credentials.
+// Used for testing only.
 type NoOpAuthenticator struct{}
 
-func (n *NoOpAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Request) (bool, string, error) {
-	return true, "anonymous", nil
+func (n *NoOpAuthenticator) Authenticate(ctx context.Context, r *http.Request) (*Identity, error) {
+	return &Identity{
+		Subject: "anonymous",
+		Method:  AuthMethodAnonymous,
+	}, nil
 }
 
-func (n *NoOpAuthenticator) NoAuthorization(ctx context.Context, r *http.Request) (bool, string, error) {
-	return true, "anonymous", nil
-}
-
-// LocalOnlyAuthenticator requires a valid client certificate for most requests.
-// This is used when cloud authentication is not enabled, ensuring that only
-// clients with certificates issued by the local CA can access the server.
-//
-// RPC paths (/_rpc/) are allowed through without TLS certs at this layer because
-// the RPC layer handles authentication:
-// - Capability-based auth (Ed25519 signatures) is always enforced
-// - Per-method auth checks TLS certs for non-public methods
-// - Only methods marked public: true in the schema allow unauthenticated access
+// LocalOnlyAuthenticator requires a valid TLS client certificate.
+// Used when cloud authentication is not enabled.
 type LocalOnlyAuthenticator struct{}
 
-func (l *LocalOnlyAuthenticator) AuthenticateRequest(ctx context.Context, r *http.Request) (bool, string, error) {
-	// Even with an Authorization header, we require a valid client certificate
-	return l.NoAuthorization(ctx, r)
-}
-
-func (l *LocalOnlyAuthenticator) NoAuthorization(ctx context.Context, r *http.Request) (bool, string, error) {
-	// Extract identity from cert if present
-	var identity string
+func (l *LocalOnlyAuthenticator) Authenticate(ctx context.Context, r *http.Request) (*Identity, error) {
+	// Check for TLS client certificate
 	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
-		identity = r.TLS.PeerCertificates[0].Subject.CommonName
+		cert := r.TLS.PeerCertificates[0]
+		return &Identity{
+			Subject: cert.Subject.CommonName,
+			Method:  AuthMethodCert,
+		}, nil
 	}
 
-	// Allow RPC paths through - the RPC layer handles auth:
-	// - Capability signature auth is always enforced
-	// - Method-level auth rejects unauthenticated calls to non-public methods
-	if strings.HasPrefix(r.URL.Path, "/_rpc/") {
-		return true, identity, nil
-	}
-
-	// For non-RPC paths, require a valid client certificate
-	if identity != "" {
-		return true, identity, nil
-	}
-	return false, "", fmt.Errorf("authentication required")
+	// No valid credentials
+	return nil, nil
 }

--- a/pkg/rpc/authenticator_test.go
+++ b/pkg/rpc/authenticator_test.go
@@ -80,36 +80,59 @@ func TestLocalOnlyAuthenticator(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		path           string
 		authHeader     string
 		hasCert        bool
 		expectAllowed  bool
 		expectIdentity string
 		expectError    bool
 	}{
+		// Non-RPC paths require certificates
 		{
-			name:          "rejects request without certificate",
+			name:          "rejects non-RPC request without certificate",
+			path:          "/api/health",
 			authHeader:    "",
 			hasCert:       false,
 			expectAllowed: false,
 			expectError:   true,
 		},
 		{
-			name:          "rejects request with auth header but no certificate",
+			name:          "rejects non-RPC request with auth header but no certificate",
+			path:          "/api/health",
 			authHeader:    "Bearer token123",
 			hasCert:       false,
 			expectAllowed: false,
 			expectError:   true,
 		},
 		{
-			name:           "allows request with certificate",
+			name:           "allows non-RPC request with certificate",
+			path:           "/api/health",
 			authHeader:     "",
 			hasCert:        true,
 			expectAllowed:  true,
 			expectIdentity: "test-client",
 		},
 		{
-			name:           "allows request with certificate and auth header",
+			name:           "allows non-RPC request with certificate and auth header",
+			path:           "/api/health",
 			authHeader:     "Bearer token123",
+			hasCert:        true,
+			expectAllowed:  true,
+			expectIdentity: "test-client",
+		},
+		// RPC paths are allowed through (RPC layer handles auth)
+		{
+			name:           "allows RPC request without certificate (RPC layer handles auth)",
+			path:           "/_rpc/call/test/method",
+			authHeader:     "",
+			hasCert:        false,
+			expectAllowed:  true,
+			expectIdentity: "",
+		},
+		{
+			name:           "allows RPC request with certificate",
+			path:           "/_rpc/call/test/method",
+			authHeader:     "",
 			hasCert:        true,
 			expectAllowed:  true,
 			expectIdentity: "test-client",
@@ -120,7 +143,7 @@ func TestLocalOnlyAuthenticator(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+			req, err := http.NewRequest("POST", tt.path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/rpc/authenticator_test.go
+++ b/pkg/rpc/authenticator_test.go
@@ -9,25 +9,25 @@ import (
 	"testing"
 )
 
-// TestAuthenticator verifies the authenticator integration
-func TestAuthenticator(t *testing.T) {
+// TestNoOpAuthenticator verifies that NoOpAuthenticator always returns an anonymous identity
+func TestNoOpAuthenticator(t *testing.T) {
+	auth := &NoOpAuthenticator{}
+
 	tests := []struct {
-		name          string
-		authHeader    string
-		expectAllowed bool
-		authenticator Authenticator
+		name       string
+		authHeader string
 	}{
 		{
-			name:          "NoOpAuthenticator allows all requests",
-			authHeader:    "",
-			expectAllowed: true,
-			authenticator: &NoOpAuthenticator{},
+			name:       "no auth header",
+			authHeader: "",
 		},
 		{
-			name:          "NoOpAuthenticator allows with auth header",
-			authHeader:    "Bearer token123",
-			expectAllowed: true,
-			authenticator: &NoOpAuthenticator{},
+			name:       "with bearer token",
+			authHeader: "Bearer token123",
+		},
+		{
+			name:       "with basic auth",
+			authHeader: "Basic dXNlcjpwYXNz",
 		},
 	}
 
@@ -42,28 +42,19 @@ func TestAuthenticator(t *testing.T) {
 				req.Header.Set("Authorization", tt.authHeader)
 			}
 
-			if tt.authHeader != "" {
-				allowed, identity, err := tt.authenticator.AuthenticateRequest(context.Background(), req)
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				if allowed != tt.expectAllowed {
-					t.Errorf("expected allowed=%v, got %v", tt.expectAllowed, allowed)
-				}
-				if allowed && identity == "" {
-					t.Error("expected non-empty identity for allowed request")
-				}
-			} else {
-				allowed, identity, err := tt.authenticator.NoAuthorization(context.Background(), req)
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				if allowed != tt.expectAllowed {
-					t.Errorf("expected allowed=%v, got %v", tt.expectAllowed, allowed)
-				}
-				if allowed && identity == "" {
-					t.Error("expected non-empty identity for allowed request")
-				}
+			identity, err := auth.Authenticate(context.Background(), req)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if identity == nil {
+				t.Error("expected non-nil identity")
+				return
+			}
+			if identity.Subject != "anonymous" {
+				t.Errorf("expected subject=anonymous, got %q", identity.Subject)
+			}
+			if identity.Method != AuthMethodAnonymous {
+				t.Errorf("expected method=%v, got %v", AuthMethodAnonymous, identity.Method)
 			}
 		})
 	}
@@ -71,7 +62,6 @@ func TestAuthenticator(t *testing.T) {
 
 // TestLocalOnlyAuthenticator verifies the LocalOnlyAuthenticator behavior
 func TestLocalOnlyAuthenticator(t *testing.T) {
-	// Create a mock certificate for testing
 	mockCert := &x509.Certificate{
 		Subject: pkix.Name{
 			CommonName: "test-client",
@@ -80,158 +70,31 @@ func TestLocalOnlyAuthenticator(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		path           string
-		authHeader     string
 		hasCert        bool
-		expectAllowed  bool
-		expectIdentity string
-		expectError    bool
+		expectIdentity bool
+		expectSubject  string
+		expectMethod   AuthMethod
 	}{
-		// Non-RPC paths require certificates
 		{
-			name:          "rejects non-RPC request without certificate",
-			path:          "/api/health",
-			authHeader:    "",
-			hasCert:       false,
-			expectAllowed: false,
-			expectError:   true,
-		},
-		{
-			name:          "rejects non-RPC request with auth header but no certificate",
-			path:          "/api/health",
-			authHeader:    "Bearer token123",
-			hasCert:       false,
-			expectAllowed: false,
-			expectError:   true,
-		},
-		{
-			name:           "allows non-RPC request with certificate",
-			path:           "/api/health",
-			authHeader:     "",
+			name:           "with certificate returns identity",
 			hasCert:        true,
-			expectAllowed:  true,
-			expectIdentity: "test-client",
+			expectIdentity: true,
+			expectSubject:  "test-client",
+			expectMethod:   AuthMethodCert,
 		},
 		{
-			name:           "allows non-RPC request with certificate and auth header",
-			path:           "/api/health",
-			authHeader:     "Bearer token123",
-			hasCert:        true,
-			expectAllowed:  true,
-			expectIdentity: "test-client",
-		},
-		// RPC paths are allowed through (RPC layer handles auth)
-		{
-			name:           "allows RPC request without certificate (RPC layer handles auth)",
-			path:           "/_rpc/call/test/method",
-			authHeader:     "",
+			name:           "without certificate returns nil",
 			hasCert:        false,
-			expectAllowed:  true,
-			expectIdentity: "",
+			expectIdentity: false,
 		},
 		{
-			name:           "allows RPC request with certificate",
-			path:           "/_rpc/call/test/method",
-			authHeader:     "",
-			hasCert:        true,
-			expectAllowed:  true,
-			expectIdentity: "test-client",
+			name:           "TLS without peer certs returns nil",
+			hasCert:        false,
+			expectIdentity: false,
 		},
 	}
 
 	auth := &LocalOnlyAuthenticator{}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req, err := http.NewRequest("POST", tt.path, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if tt.authHeader != "" {
-				req.Header.Set("Authorization", tt.authHeader)
-			}
-
-			if tt.hasCert {
-				req.TLS = &tls.ConnectionState{
-					PeerCertificates: []*x509.Certificate{mockCert},
-				}
-			}
-
-			var allowed bool
-			var identity string
-
-			if tt.authHeader != "" {
-				allowed, identity, err = auth.AuthenticateRequest(context.Background(), req)
-			} else {
-				allowed, identity, err = auth.NoAuthorization(context.Background(), req)
-			}
-
-			if err != nil {
-				if !tt.expectError {
-					t.Errorf("unexpected error: %v", err)
-				}
-			}
-			if allowed != tt.expectAllowed {
-				t.Errorf("expected allowed=%v, got %v", tt.expectAllowed, allowed)
-			}
-			if tt.expectAllowed && identity != tt.expectIdentity {
-				t.Errorf("expected identity=%q, got %q", tt.expectIdentity, identity)
-			}
-		})
-	}
-}
-
-// TestIsRequestAuthenticated verifies the isRequestAuthenticated helper function
-// that determines if a request should be allowed to call non-public methods.
-func TestIsRequestAuthenticated(t *testing.T) {
-	mockCert := &x509.Certificate{
-		Subject: pkix.Name{CommonName: "test-client"},
-	}
-
-	tests := []struct {
-		name          string
-		hasTLS        bool
-		hasCert       bool
-		hasAuthHeader bool
-		expectAuth    bool
-	}{
-		{
-			name:          "no TLS at all - authenticated (behind proxy)",
-			hasTLS:        false,
-			hasCert:       false,
-			hasAuthHeader: false,
-			expectAuth:    true,
-		},
-		{
-			name:          "TLS with client cert - authenticated",
-			hasTLS:        true,
-			hasCert:       true,
-			hasAuthHeader: false,
-			expectAuth:    true,
-		},
-		{
-			name:          "TLS with Authorization header (JWT) - authenticated",
-			hasTLS:        true,
-			hasCert:       false,
-			hasAuthHeader: true,
-			expectAuth:    true,
-		},
-		{
-			name:          "TLS with both cert and auth header - authenticated",
-			hasTLS:        true,
-			hasCert:       true,
-			hasAuthHeader: true,
-			expectAuth:    true,
-		},
-		{
-			name:          "TLS without cert or auth header - NOT authenticated",
-			hasTLS:        true,
-			hasCert:       false,
-			hasAuthHeader: false,
-			expectAuth:    false,
-		},
-	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -240,21 +103,78 @@ func TestIsRequestAuthenticated(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if tt.hasTLS {
-				req.TLS = &tls.ConnectionState{}
-				if tt.hasCert {
-					req.TLS.PeerCertificates = []*x509.Certificate{mockCert}
+			if tt.hasCert {
+				req.TLS = &tls.ConnectionState{
+					PeerCertificates: []*x509.Certificate{mockCert},
 				}
+			} else if tt.name == "TLS without peer certs returns nil" {
+				// TLS connection but no peer certificates
+				req.TLS = &tls.ConnectionState{}
 			}
 
-			if tt.hasAuthHeader {
-				req.Header.Set("Authorization", "Bearer test-token")
+			identity, err := auth.Authenticate(context.Background(), req)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 
-			result := isRequestAuthenticated(req)
-			if result != tt.expectAuth {
-				t.Errorf("expected authenticated=%v, got %v", tt.expectAuth, result)
+			if tt.expectIdentity {
+				if identity == nil {
+					t.Error("expected non-nil identity")
+					return
+				}
+				if identity.Subject != tt.expectSubject {
+					t.Errorf("expected subject=%q, got %q", tt.expectSubject, identity.Subject)
+				}
+				if identity.Method != tt.expectMethod {
+					t.Errorf("expected method=%v, got %v", tt.expectMethod, identity.Method)
+				}
+			} else {
+				if identity != nil {
+					t.Errorf("expected nil identity, got %+v", identity)
+				}
 			}
 		})
 	}
+}
+
+// TestIdentityContext verifies the context helpers for identity propagation
+func TestIdentityContext(t *testing.T) {
+	t.Run("stores and retrieves identity", func(t *testing.T) {
+		identity := &Identity{
+			Subject: "test-user",
+			Groups:  []string{"admin", "users"},
+			Method:  AuthMethodJWT,
+			Metadata: map[string]any{
+				"organization_id": "org-123",
+			},
+		}
+
+		ctx := ContextWithIdentity(context.Background(), identity)
+		retrieved := IdentityFromContext(ctx)
+
+		if retrieved == nil {
+			t.Fatal("expected non-nil identity from context")
+		}
+		if retrieved.Subject != identity.Subject {
+			t.Errorf("expected subject=%q, got %q", identity.Subject, retrieved.Subject)
+		}
+		if len(retrieved.Groups) != len(identity.Groups) {
+			t.Errorf("expected %d groups, got %d", len(identity.Groups), len(retrieved.Groups))
+		}
+		if retrieved.Method != identity.Method {
+			t.Errorf("expected method=%v, got %v", identity.Method, retrieved.Method)
+		}
+		if retrieved.Metadata["organization_id"] != identity.Metadata["organization_id"] {
+			t.Errorf("expected org_id=%v, got %v",
+				identity.Metadata["organization_id"],
+				retrieved.Metadata["organization_id"])
+		}
+	})
+
+	t.Run("returns nil for empty context", func(t *testing.T) {
+		retrieved := IdentityFromContext(context.Background())
+		if retrieved != nil {
+			t.Errorf("expected nil identity, got %+v", retrieved)
+		}
+	})
 }

--- a/pkg/rpc/authenticator_test.go
+++ b/pkg/rpc/authenticator_test.go
@@ -181,3 +181,80 @@ func TestLocalOnlyAuthenticator(t *testing.T) {
 		})
 	}
 }
+
+// TestIsRequestAuthenticated verifies the isRequestAuthenticated helper function
+// that determines if a request should be allowed to call non-public methods.
+func TestIsRequestAuthenticated(t *testing.T) {
+	mockCert := &x509.Certificate{
+		Subject: pkix.Name{CommonName: "test-client"},
+	}
+
+	tests := []struct {
+		name          string
+		hasTLS        bool
+		hasCert       bool
+		hasAuthHeader bool
+		expectAuth    bool
+	}{
+		{
+			name:          "no TLS at all - authenticated (behind proxy)",
+			hasTLS:        false,
+			hasCert:       false,
+			hasAuthHeader: false,
+			expectAuth:    true,
+		},
+		{
+			name:          "TLS with client cert - authenticated",
+			hasTLS:        true,
+			hasCert:       true,
+			hasAuthHeader: false,
+			expectAuth:    true,
+		},
+		{
+			name:          "TLS with Authorization header (JWT) - authenticated",
+			hasTLS:        true,
+			hasCert:       false,
+			hasAuthHeader: true,
+			expectAuth:    true,
+		},
+		{
+			name:          "TLS with both cert and auth header - authenticated",
+			hasTLS:        true,
+			hasCert:       true,
+			hasAuthHeader: true,
+			expectAuth:    true,
+		},
+		{
+			name:          "TLS without cert or auth header - NOT authenticated",
+			hasTLS:        true,
+			hasCert:       false,
+			hasAuthHeader: false,
+			expectAuth:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.hasTLS {
+				req.TLS = &tls.ConnectionState{}
+				if tt.hasCert {
+					req.TLS.PeerCertificates = []*x509.Certificate{mockCert}
+				}
+			}
+
+			if tt.hasAuthHeader {
+				req.Header.Set("Authorization", "Bearer test-token")
+			}
+
+			result := isRequestAuthenticated(req)
+			if result != tt.expectAuth {
+				t.Errorf("expected authenticated=%v, got %v", tt.expectAuth, result)
+			}
+		})
+	}
+}

--- a/pkg/rpc/call.go
+++ b/pkg/rpc/call.go
@@ -15,6 +15,11 @@ type Call interface {
 	Args(v any)
 	Results(v any)
 	NewCapability(i *Interface) *Capability
+	// IsAuthenticated returns true if the caller presented a valid TLS client certificate.
+	// This is used by methods that need to distinguish between authenticated and
+	// unauthenticated callers (e.g., runner registration allows unauthenticated Join
+	// but requires authentication for admin operations like CreateInvite).
+	IsAuthenticated() bool
 }
 
 type NetworkCall struct {
@@ -76,6 +81,12 @@ func (c *NetworkCall) Results(v any) {
 
 func (c *NetworkCall) RemoteAddr() string {
 	return c.r.RemoteAddr
+}
+
+// IsAuthenticated returns true if the caller presented a valid TLS client certificate,
+// or if this is a local call (used in tests).
+func (c *NetworkCall) IsAuthenticated() bool {
+	return c.peer != nil || c.local != nil
 }
 
 func (c *NetworkCall) NewCapability(i *Interface) *Capability {

--- a/pkg/rpc/example/rpc.go
+++ b/pkg/rpc/example/rpc.go
@@ -364,6 +364,7 @@ func AdaptMeter(t Meter) *rpc.Interface {
 			Name:          "readTemperature",
 			InterfaceName: "Meter",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ReadTemperature(ctx, &MeterReadTemperature{Call: call})
 			},
@@ -372,6 +373,7 @@ func AdaptMeter(t Meter) *rpc.Interface {
 			Name:          "getSetter",
 			InterfaceName: "Meter",
 			Index:         1,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetSetter(ctx, &MeterGetSetter{Call: call})
 			},
@@ -558,6 +560,7 @@ func AdaptSetTemp(t SetTemp) *rpc.Interface {
 			Name:          "setTemp",
 			InterfaceName: "SetTemp",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetTemp(ctx, &SetTempSetTemp{Call: call})
 			},
@@ -713,6 +716,7 @@ func AdaptUpdateReceiver(t UpdateReceiver) *rpc.Interface {
 			Name:          "update",
 			InterfaceName: "UpdateReceiver",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Update(ctx, &UpdateReceiverUpdate{Call: call})
 			},
@@ -860,6 +864,7 @@ func AdaptMeterUpdates(t MeterUpdates) *rpc.Interface {
 			Name:          "registerUpdates",
 			InterfaceName: "MeterUpdates",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.RegisterUpdates(ctx, &MeterUpdatesRegisterUpdates{Call: call})
 			},
@@ -1012,6 +1017,7 @@ func AdaptAdjustTemp(t AdjustTemp) *rpc.Interface {
 			Name:          "adjust",
 			InterfaceName: "AdjustTemp",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Adjust(ctx, &AdjustTempAdjust{Call: call})
 			},
@@ -1164,6 +1170,7 @@ func AdaptSetTempG[T any](t SetTempG[T]) *rpc.Interface {
 			Name:          "setTemp",
 			InterfaceName: "SetTempG",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetTemp(ctx, &SetTempGSetTemp[T]{Call: call})
 			},
@@ -1311,6 +1318,7 @@ func AdaptEmitTemps(t EmitTemps) *rpc.Interface {
 			Name:          "emit",
 			InterfaceName: "EmitTemps",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Emit(ctx, &EmitTempsEmit{Call: call})
 			},

--- a/pkg/rpc/generator.go
+++ b/pkg/rpc/generator.go
@@ -1886,6 +1886,7 @@ func (g *Generator) generateInterfaces(f *j.File) error {
 						g.Line().Id("Name").Op(":").Lit(m.Name)
 						g.Line().Id("InterfaceName").Op(":").Lit(i.Name)
 						g.Line().Id("Index").Op(":").Lit(m.Index)
+						g.Line().Id("Public").Op(":").Lit(m.Public)
 						g.Line().Id("Handler").Op(":").Func().Params(
 							j.Id("ctx").Qual("context", "Context"),
 							j.Id("call").Qual(rpc, "Call"),
@@ -2181,6 +2182,10 @@ type DescMethods struct {
 	Index      int              `yaml:"index"`
 	Parameters []*DescParamater `yaml:"parameters"`
 	Results    []*DescParamater `yaml:"results"`
+	// Public marks this method as accessible without TLS client certificate authentication.
+	// Public methods still require capability-level auth (Ed25519 signatures) but allow
+	// unauthenticated callers (e.g., for registration flows where the client doesn't have certs yet).
+	Public bool `yaml:"public,omitempty"`
 }
 
 type DescParamater struct {

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -322,6 +322,39 @@ func TestRPC(t *testing.T) {
 		r.Equal([]float32{42, 100}, vals)
 	})
 
+	t.Run("rejects unauthenticated streaming calls to non-public methods", func(t *testing.T) {
+		r := require.New(t)
+		ctx := t.Context()
+
+		s := example.AdaptEmitTemps(&exampleEmit{})
+
+		// Server with LocalOnlyAuthenticator - requires TLS client certs
+		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify,
+			rpc.WithAuthenticator(&rpc.LocalOnlyAuthenticator{}))
+		r.NoError(err)
+
+		serv := ss.Server()
+		serv.ExposeValue("meter", s)
+
+		// Client without certs - won't be authenticated
+		cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+		r.NoError(err)
+
+		c, err := cs.Connect(ss.ListenAddr(), "meter")
+		r.NoError(err)
+
+		mc := &example.EmitTempsClient{Client: c}
+
+		recv := stream.StreamRecv(func(val float32) error {
+			return nil
+		})
+
+		// Should fail with auth error since Emit is not a public method
+		_, err = mc.Emit(ctx, recv)
+		r.Error(err)
+		r.Contains(err.Error(), "401")
+	})
+
 	t.Run("can reresolve a capability", func(t *testing.T) {
 		r := require.New(t)
 		ctx := t.Context()

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"runtime/debug"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1035,6 +1036,20 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 				w.Header().Add("rpc-error", "authentication required")
 				w.WriteHeader(http.StatusUnauthorized)
 				return
+			}
+
+			// Check authorization if an authorizer is configured
+			if s.state.authorizer != nil {
+				resource := strings.ToLower(mm.InterfaceName)
+				action := strings.ToLower(mm.Name)
+				if err := s.state.authorizer.Authorize(ctx, identity, resource, action); err != nil {
+					s.state.log.Warn("authorization denied",
+						"resource", resource, "action", action, "subject", identity.Subject, "error", err)
+					w.Header().Add("rpc-status", "forbidden")
+					w.Header().Add("rpc-error", err.Error())
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
 			}
 		}
 

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -303,46 +303,43 @@ func (s *Server) setupMux() {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// If no authenticator configured, allow all requests
 	if s.state.authenticator == nil {
 		s.mux.ServeHTTP(w, r)
 		return
 	}
 
-	// Check for JWT token in Authorization header
-	authHeader := r.Header.Get("Authorization")
-	if authHeader != "" {
-		// Try JWT authentication
-		authenticated, identity, err := s.state.authenticator.AuthenticateRequest(r.Context(), r)
-		if err != nil {
-			s.state.log.Warn("authentication failed", "error", err, "path", r.URL.Path)
-			http.Error(w, "authentication failed", http.StatusUnauthorized)
-			return
-		}
-		if !authenticated {
-			s.state.log.Warn("request not authenticated", "path", r.URL.Path)
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		s.state.log.Debug("request authenticated", "identity", identity, "path", r.URL.Path)
-	} else {
-		// No Authorization header - let authenticator decide if this is allowed
-		allowed, _, err := s.state.authenticator.NoAuthorization(r.Context(), r)
-		if err != nil {
-			s.state.log.Warn("authentication check failed", "error", err, "path", r.URL.Path)
-			http.Error(w, "authentication failed", http.StatusUnauthorized)
-			return
-		}
-		if !allowed {
-			// NOTE: This is a change from the old behavior. Previously during early development,
-			// the authentication was "best attempt" and we didn't reject requests that didn't
-			// present creds. We've since changed that to require	authentication.
-			s.state.log.Warn("request requires authentication", "path", r.URL.Path)
-			http.Error(w, "authentication required", http.StatusUnauthorized)
-			return
-		}
+	// Try to authenticate the request
+	identity, err := s.state.authenticator.Authenticate(ctx, r)
+	if err != nil {
+		s.state.log.Warn("authentication failed", "error", err, "path", r.URL.Path)
+		http.Error(w, "authentication failed", http.StatusUnauthorized)
+		return
+	}
+
+	// Store identity in context if authenticated
+	if identity != nil {
+		ctx = ContextWithIdentity(ctx, identity)
+		r = r.WithContext(ctx)
+		s.state.log.Debug("request authenticated", "subject", identity.Subject, "method", identity.Method, "path", r.URL.Path)
+	}
+
+	// For RPC paths, let the method-level check in handleCalls decide based on public flag
+	// For non-RPC paths, require authentication
+	if identity == nil && !isRPCPath(r.URL.Path) {
+		s.state.log.Warn("request requires authentication", "path", r.URL.Path)
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
 	}
 
 	s.mux.ServeHTTP(w, r)
+}
+
+// isRPCPath returns true if the path is an RPC endpoint
+func isRPCPath(path string) bool {
+	return len(path) >= 6 && path[:6] == "/_rpc/"
 }
 
 type identifyResponse struct {
@@ -445,60 +442,30 @@ func (s *Server) handleDebugAuth(w http.ResponseWriter, r *http.Request) {
 		UserInfo:      make(map[string]string),
 	}
 
-	// Check authentication
-	authHeader := r.Header.Get("Authorization")
-	if authHeader != "" {
-		// Has authentication header
-		if s.state.authenticator != nil {
-			authenticated, identity, err := s.state.authenticator.AuthenticateRequest(r.Context(), r)
-			if err != nil {
-				resp.Success = false
-				resp.Message = fmt.Sprintf("Authentication failed: %v", err)
-				w.WriteHeader(http.StatusUnauthorized)
-			} else if !authenticated {
-				resp.Success = false
-				resp.Message = "Authentication failed"
-				w.WriteHeader(http.StatusUnauthorized)
-			} else {
-				resp.AuthMethod = "bearer"
-				resp.Identity = identity
-				resp.UserInfo["authenticated"] = "true"
-				resp.UserInfo["identity"] = identity
+	// Check authentication using the new Authenticate interface
+	if s.state.authenticator != nil {
+		identity, err := s.state.authenticator.Authenticate(r.Context(), r)
+		if err != nil {
+			resp.Success = false
+			resp.Message = fmt.Sprintf("Authentication failed: %v", err)
+			w.WriteHeader(http.StatusUnauthorized)
+		} else if identity != nil {
+			resp.AuthMethod = string(identity.Method)
+			resp.Identity = identity.Subject
+			resp.UserInfo["authenticated"] = "true"
+			resp.UserInfo["subject"] = identity.Subject
+			resp.UserInfo["method"] = string(identity.Method)
+			if len(identity.Groups) > 0 {
+				resp.UserInfo["groups"] = fmt.Sprintf("%v", identity.Groups)
 			}
 		} else {
-			resp.AuthMethod = "none"
-			resp.Message = "Server has no authenticator configured"
+			resp.Success = false
+			resp.Message = "Authentication required"
+			w.WriteHeader(http.StatusUnauthorized)
 		}
 	} else {
-		// Check client certificate
-		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
-			cert := r.TLS.PeerCertificates[0]
-			resp.AuthMethod = "certificate"
-			resp.Identity = cert.Subject.String()
-			resp.UserInfo["cert_subject"] = cert.Subject.String()
-			resp.UserInfo["cert_issuer"] = cert.Issuer.String()
-		} else {
-			// No authentication
-			if s.state.authenticator != nil {
-				allowed, identity, err := s.state.authenticator.NoAuthorization(r.Context(), r)
-				if err != nil {
-					resp.Success = false
-					resp.Message = fmt.Sprintf("Authentication check failed: %v", err)
-					w.WriteHeader(http.StatusUnauthorized)
-				} else if !allowed {
-					resp.Success = false
-					resp.Message = "Authentication required"
-					w.WriteHeader(http.StatusUnauthorized)
-				} else {
-					resp.AuthMethod = "none"
-					resp.Identity = identity
-					resp.Message = "No authentication provided, but allowed by server policy"
-				}
-			} else {
-				resp.AuthMethod = "none"
-				resp.Message = "No authentication configured"
-			}
-		}
+		resp.AuthMethod = "none"
+		resp.Message = "No authentication configured"
 	}
 
 	// Add connection information
@@ -1027,22 +994,6 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// isRequestAuthenticated checks if an HTTP request has valid authentication.
-// Authentication can be via:
-// - TLS client certificate (r.TLS.PeerCertificates)
-// - JWT token (Authorization header, already validated by ServeHTTP)
-// - No TLS at all (server behind auth proxy that handles auth)
-//
-// Returns false only when: TLS is enabled, no client cert, AND no Authorization header.
-func isRequestAuthenticated(r *http.Request) bool {
-	hasCert := r.TLS != nil && len(r.TLS.PeerCertificates) > 0
-	hasAuthHeader := r.Header.Get("Authorization") != ""
-	noTLS := r.TLS == nil
-
-	// Authenticated if any of these are true
-	return hasCert || hasAuthHeader || noTLS
-}
-
 func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 	oid := OID(r.PathValue("oid"))
 
@@ -1075,9 +1026,9 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Enforce authentication for non-public methods
-		// Skip this check if skipVerify is set (test mode)
-		if !mm.Public && !s.state.opts.skipVerify {
-			if !isRequestAuthenticated(r) {
+		if !mm.Public {
+			identity := IdentityFromContext(ctx)
+			if identity == nil {
 				s.state.log.Warn("authentication required for non-public method",
 					"method", method, "interface", mm.InterfaceName)
 				w.Header().Add("rpc-status", "unauthorized")

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -113,6 +113,9 @@ type Method struct {
 	InterfaceName string
 	Index         int
 	Handler       func(ctx context.Context, call Call) error
+	// Public marks this method as accessible without TLS client certificate authentication.
+	// The RPC layer will reject unauthenticated calls to non-public methods automatically.
+	Public bool
 }
 
 type HasRestoreState interface {
@@ -1053,6 +1056,20 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add("rpc-status", "unknown")
 			w.Header().Add("rpc-error", "unknown method: "+method)
 			return
+		}
+
+		// Enforce authentication for non-public methods
+		// Public methods can be called without a TLS client certificate
+		if !mm.Public {
+			hasCert := r.TLS != nil && len(r.TLS.PeerCertificates) > 0
+			if !hasCert {
+				s.state.log.Warn("authentication required for non-public method",
+					"method", method, "interface", mm.InterfaceName)
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Header().Add("rpc-status", "unauthorized")
+				w.Header().Add("rpc-error", "authentication required")
+				return
+			}
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -1059,15 +1059,20 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Enforce authentication for non-public methods
-		// Public methods can be called without a TLS client certificate
+		// Public methods can be called without authentication
 		// Skip this check if skipVerify is set (test mode)
 		if !mm.Public && !s.state.opts.skipVerify {
-			// Authentication check:
-			// - If TLS is enabled but no client cert: reject (client should have authenticated)
-			// - If TLS with client cert: allow (authenticated)
-			// - If no TLS at all: allow (server behind auth proxy)
-			tlsWithoutCert := r.TLS != nil && len(r.TLS.PeerCertificates) == 0
-			if tlsWithoutCert {
+			// Authentication can be via:
+			// - TLS client certificate (r.TLS.PeerCertificates)
+			// - JWT token (Authorization header, already validated by ServeHTTP)
+			// - No TLS at all (server behind auth proxy)
+			//
+			// Only reject if: TLS is enabled, no client cert, AND no Authorization header
+			hasCert := r.TLS != nil && len(r.TLS.PeerCertificates) > 0
+			hasAuthHeader := r.Header.Get("Authorization") != ""
+			noTLS := r.TLS == nil
+
+			if !hasCert && !hasAuthHeader && !noTLS {
 				s.state.log.Warn("authentication required for non-public method",
 					"method", method, "interface", mm.InterfaceName)
 				w.Header().Add("rpc-status", "unauthorized")

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -911,9 +911,9 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 	iface, ok := s.objects[oid]
 	s.mu.Unlock()
 	if !ok {
-		w.WriteHeader(http.StatusNotFound)
 		w.Header().Add("rpc-status", "unknown-capability")
 		w.Header().Add("rpc-error", "unknown object: "+string(oid))
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
@@ -921,9 +921,9 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 
 	mm := iface.methods[method]
 	if mm.Handler == nil {
-		w.WriteHeader(http.StatusNotFound)
 		w.Header().Add("rpc-status", "unknown")
 		w.Header().Add("rpc-error", "unknown method: "+method)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
@@ -1052,22 +1052,27 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 
 		mm := iface.methods[method]
 		if mm.Handler == nil {
-			w.WriteHeader(http.StatusNotFound)
 			w.Header().Add("rpc-status", "unknown")
 			w.Header().Add("rpc-error", "unknown method: "+method)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 
 		// Enforce authentication for non-public methods
 		// Public methods can be called without a TLS client certificate
-		if !mm.Public {
-			hasCert := r.TLS != nil && len(r.TLS.PeerCertificates) > 0
-			if !hasCert {
+		// Skip this check if skipVerify is set (test mode)
+		if !mm.Public && !s.state.opts.skipVerify {
+			// Authentication check:
+			// - If TLS is enabled but no client cert: reject (client should have authenticated)
+			// - If TLS with client cert: allow (authenticated)
+			// - If no TLS at all: allow (server behind auth proxy)
+			tlsWithoutCert := r.TLS != nil && len(r.TLS.PeerCertificates) == 0
+			if tlsWithoutCert {
 				s.state.log.Warn("authentication required for non-public method",
 					"method", method, "interface", mm.InterfaceName)
-				w.WriteHeader(http.StatusUnauthorized)
 				w.Header().Add("rpc-status", "unauthorized")
 				w.Header().Add("rpc-error", "authentication required")
+				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
 		}
@@ -1142,9 +1147,9 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 		cbor.NewEncoder(w).Encode(call.results)
 		w.Header().Add("rpc-status", "ok")
 	} else {
-		w.WriteHeader(http.StatusNotFound)
 		w.Header().Add("rpc-status", "unknown-capability")
 		w.Header().Add("rpc-error", "unknown object: "+string(oid))
+		w.WriteHeader(http.StatusNotFound)
 	}
 }
 

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -895,6 +895,33 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce authentication for non-public methods
+	if !mm.Public {
+		identity := IdentityFromContext(ctx)
+		if identity == nil {
+			s.state.log.Warn("authentication required for non-public method",
+				"method", method, "interface", mm.InterfaceName)
+			w.Header().Add("rpc-status", "unauthorized")
+			w.Header().Add("rpc-error", "authentication required")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Check authorization if an authorizer is configured
+		if s.state.authorizer != nil {
+			resource := strings.ToLower(mm.InterfaceName)
+			action := strings.ToLower(mm.Name)
+			if err := s.state.authorizer.Authorize(ctx, identity, resource, action); err != nil {
+				s.state.log.Warn("authorization denied",
+					"resource", resource, "action", action, "subject", identity.Subject, "error", err)
+				w.Header().Add("rpc-status", "forbidden")
+				w.Header().Add("rpc-error", err.Error())
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+		}
+	}
+
 	w.WriteHeader(http.StatusOK)
 
 	ctx = Propagator().Extract(ctx, propagation.HeaderCarrier(r.Header))

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -1027,6 +1027,22 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// isRequestAuthenticated checks if an HTTP request has valid authentication.
+// Authentication can be via:
+// - TLS client certificate (r.TLS.PeerCertificates)
+// - JWT token (Authorization header, already validated by ServeHTTP)
+// - No TLS at all (server behind auth proxy that handles auth)
+//
+// Returns false only when: TLS is enabled, no client cert, AND no Authorization header.
+func isRequestAuthenticated(r *http.Request) bool {
+	hasCert := r.TLS != nil && len(r.TLS.PeerCertificates) > 0
+	hasAuthHeader := r.Header.Get("Authorization") != ""
+	noTLS := r.TLS == nil
+
+	// Authenticated if any of these are true
+	return hasCert || hasAuthHeader || noTLS
+}
+
 func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 	oid := OID(r.PathValue("oid"))
 
@@ -1059,20 +1075,9 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Enforce authentication for non-public methods
-		// Public methods can be called without authentication
 		// Skip this check if skipVerify is set (test mode)
 		if !mm.Public && !s.state.opts.skipVerify {
-			// Authentication can be via:
-			// - TLS client certificate (r.TLS.PeerCertificates)
-			// - JWT token (Authorization header, already validated by ServeHTTP)
-			// - No TLS at all (server behind auth proxy)
-			//
-			// Only reject if: TLS is enabled, no client cert, AND no Authorization header
-			hasCert := r.TLS != nil && len(r.TLS.PeerCertificates) > 0
-			hasAuthHeader := r.Header.Get("Authorization") != ""
-			noTLS := r.TLS == nil
-
-			if !hasCert && !hasAuthHeader && !noTLS {
+			if !isRequestAuthenticated(r) {
 				s.state.log.Warn("authentication required for non-public method",
 					"method", method, "interface", mm.InterfaceName)
 				w.Header().Add("rpc-status", "unauthorized")

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -79,6 +79,7 @@ type StateCommon struct {
 	cert         tls.Certificate
 
 	authenticator Authenticator
+	authorizer    Authorizer
 
 	privkey ed25519.PrivateKey
 	pubkey  ed25519.PublicKey
@@ -138,6 +139,7 @@ type stateOptions struct {
 	clientLocalAddr string
 
 	authenticator Authenticator
+	authorizer    Authorizer
 	bearerToken   string // JWT or other bearer token for authentication
 }
 
@@ -213,6 +215,12 @@ func WithEndpoint(endpoint string) StateOption {
 func WithAuthenticator(auth Authenticator) StateOption {
 	return func(o *stateOptions) {
 		o.authenticator = auth
+	}
+}
+
+func WithAuthorizer(authz Authorizer) StateOption {
+	return func(o *stateOptions) {
+		o.authorizer = authz
 	}
 }
 
@@ -311,6 +319,7 @@ func NewState(ctx context.Context, opts ...StateOption) (*State, error) {
 			privkey:       priv,
 			pubkey:        pub,
 			authenticator: authenticator,
+			authorizer:    so.authorizer,
 		},
 
 		defaultEndpoint: so.endpoint,

--- a/pkg/rpc/stream/stream.gen.go
+++ b/pkg/rpc/stream/stream.gen.go
@@ -121,6 +121,7 @@ func AdaptSendStream[T any](t SendStream[T]) *rpc.Interface {
 			Name:          "send",
 			InterfaceName: "SendStream",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Send(ctx, &SendStreamSend[T]{Call: call})
 			},
@@ -285,6 +286,7 @@ func AdaptRecvStream[T any](t RecvStream[T]) *rpc.Interface {
 			Name:          "recv",
 			InterfaceName: "RecvStream",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Recv(ctx, &RecvStreamRecv[T]{Call: call})
 			},

--- a/pkg/rpc/testdata/generic.go
+++ b/pkg/rpc/testdata/generic.go
@@ -164,6 +164,7 @@ func AdaptReader[T any](t Reader[T]) *rpc.Interface {
 			Name:          "read",
 			InterfaceName: "Reader",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Read(ctx, &ReaderRead[T]{Call: call})
 			},

--- a/pkg/rpc/testdata/rpc.go
+++ b/pkg/rpc/testdata/rpc.go
@@ -277,6 +277,7 @@ func AdaptTown(t Town) *rpc.Interface {
 			Name:          "getHero",
 			InterfaceName: "Town",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetHero(ctx, &TownGetHero{Call: call})
 			},
@@ -285,6 +286,7 @@ func AdaptTown(t Town) *rpc.Interface {
 			Name:          "hireHero",
 			InterfaceName: "Town",
 			Index:         1,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.HireHero(ctx, &TownHireHero{Call: call})
 			},
@@ -482,6 +484,7 @@ func AdaptEmpower(t Empower) *rpc.Interface {
 			Name:          "increasePower",
 			InterfaceName: "Empower",
 			Index:         0,
+			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.IncreasePower(ctx, &EmpowerIncreasePower{Call: call})
 			},

--- a/pkg/rpc/testdata/rpc.go
+++ b/pkg/rpc/testdata/rpc.go
@@ -277,7 +277,7 @@ func AdaptTown(t Town) *rpc.Interface {
 			Name:          "getHero",
 			InterfaceName: "Town",
 			Index:         0,
-			Public:        false,
+			Public:        true,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetHero(ctx, &TownGetHero{Call: call})
 			},

--- a/pkg/rpc/testdata/rpc.yml
+++ b/pkg/rpc/testdata/rpc.yml
@@ -15,6 +15,7 @@ interfaces:
     methods:
       - name: getHero
         index: 0
+        public: true
         parameters:
           - name: name
             type: string


### PR DESCRIPTION
For distributed runners, we need the `Join` RPC method to be callable without a TLS client cert - it's a bootstrap flow where the runner doesn't have certs yet (that's the whole point of joining).

Previously all RPC methods required TLS client certs. Now you can mark individual methods as `public: true` in the schema and they'll allow unauthenticated callers. Everything else stays locked down, and capability-based auth (Ed25519 signatures) is still always enforced.

```yaml
methods:
  - name: Join
    public: true  # bootstrap flow, no certs yet
  - name: CreateInvite
    # default: requires TLS client cert
```

## Authenticator/Authorizer Interface Refactor

This PR also refactors the auth interfaces to cleanly separate authentication from authorization:

**Authentication** (`rpc.Authenticator`):
- Single method: `Authenticate(ctx, req) (*Identity, error)`
- Returns `*Identity` for authenticated callers, `nil` for no credentials
- `Identity` includes Subject, Groups, Method (cert/jwt/token/anonymous), and Metadata

**Authorization** (`rpc.Authorizer`):
- Single method: `Authorize(ctx, identity, resource, action) error`
- Matches Miren Cloud RBAC semantics (resource + action)
- For RPC methods: resource = interface name, action = method name (both lowercase)

**Auth flow is now:**
1. `ServeHTTP` calls `Authenticate` once, stores Identity in context
2. `handleCalls` checks if Identity is present for non-public methods
3. If authorizer configured, calls `Authorize(identity, resource, action)`
4. `NoOpAuthenticator` returns anonymous identity (tests always pass)
5. `LocalOnlyAuthenticator` returns cert identity or nil (no authorizer needed)
6. `cloudauth.RPCAuthenticator` implements both - JWT validation + RBAC

Cert-authenticated callers bypass RBAC (local/internal trust model).

---

**Also fixes a pre-existing bug:** Several RPC error paths were setting HTTP headers *after* calling `WriteHeader()`, which meant clients never received the `rpc-status` and `rpc-error` headers on error responses. This affected unknown method, unknown capability, and auth rejection paths in both `handleCalls` and `startCallStream`. Now headers are set before `WriteHeader()` so clients get proper error details.