### PR TITLE
Add Miren Labs docs page and document admin as labs feature

### DIFF
--- a/docs/docs/admin-interface.md
+++ b/docs/docs/admin-interface.md
@@ -4,6 +4,10 @@ sidebar_position: 7
 
 # Admin Interface
 
+:::info Labs Feature
+The admin interface is a [labs feature](/labs) and is disabled by default. Enable it with `--labs adminapi` or `MIREN_LABS=adminapi` when starting the server.
+:::
+
 The admin interface allows you to expose custom administrative functions in your application that can be called from the CLI or other tooling. This is useful for user management, cache clearing, database operations, and other maintenance tasks.
 
 ## How It Works

--- a/docs/docs/cli/admin.md
+++ b/docs/docs/cli/admin.md
@@ -4,6 +4,10 @@ sidebar_position: 6
 
 # Admin Commands
 
+:::info Labs Feature
+The admin interface is a [labs feature](/labs) and is disabled by default. Enable it with `--labs adminapi` or `MIREN_LABS=adminapi` when starting the server.
+:::
+
 Commands for calling admin functions on your applications.
 
 The admin interface allows you to execute custom administrative functions in your running application—useful for user management, cache clearing, database operations, and other maintenance tasks.

--- a/docs/docs/labs.md
+++ b/docs/docs/labs.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 1
+---
+
+# Miren Labs
+
+Miren Labs is where we ship experimental features that aren't quite ready for prime time. These are capabilities we're actively developing and want to get into your hands early for feedback.
+
+## What to Expect
+
+Labs features are:
+
+- **Experimental** — APIs and behavior may change based on feedback
+- **Opt-in** — Disabled by default, you choose when to try them
+- **Supported** — We want to hear about bugs and rough edges
+- **On a path** — Most labs features are headed toward stable release
+
+## Enabling Labs Features
+
+Labs features are controlled via the `--labs` flag or `MIREN_LABS` environment variable when starting the Miren server.
+
+```bash
+# Enable a single labs feature
+miren server --labs adminapi
+
+# Enable multiple features
+miren server --labs adminapi --labs usersubdomains
+
+# Via environment variable
+MIREN_LABS=adminapi miren server
+
+# Multiple features via environment variable (comma-separated)
+MIREN_LABS=adminapi,usersubdomains miren server
+```
+
+## Giving Feedback
+
+We'd love to hear how labs features work for you:
+
+- **What's working well** — Helps us know we're on the right track
+- **What's confusing** — Documentation gaps, unclear behavior
+- **What's broken** — Bugs, crashes, unexpected behavior
+- **What's missing** — Features that would make it useful for your use case
+
+Reach out via [support](/support) or open an issue on GitHub.
+
+## Current Labs Features
+
+Individual labs features are documented alongside their related functionality. Look for the "Labs Feature" callout in the docs.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
         'scaling',
         'disks',
         'firewall',
+        'admin-interface',
       ],
     },
     'working-with-miren-cloud',
@@ -43,6 +44,7 @@ const sidebars: SidebarsConfig = {
         'cli/logs',
         'cli/sandbox',
         'cli/disk',
+        'cli/admin',
         'cli/entity',
       ],
     },
@@ -51,6 +53,7 @@ const sidebars: SidebarsConfig = {
       label: 'Resources',
       collapsed: false,
       items: [
+        'labs',
         'changelog',
         'cloud-updates',
         'support',


### PR DESCRIPTION
The admin API just shipped behind the `adminapi` labs flag, but users
reading the docs wouldn't know they need to enable it first.

Added a new "Miren Labs" page under Resources that explains what labs
features are, how to opt in, and encourages feedback. The admin docs
now have a short callout linking to it.

While I was in there, noticed the admin docs weren't in the sidebar at
all - fixed that too.