### PR TITLE
Fix DNS failures during sandbox startup

### DIFF
--- a/api/compute/compute.go
+++ b/api/compute/compute.go
@@ -1,3 +1,17 @@
 package compute
 
+import "miren.dev/runtime/api/compute/compute_v1alpha"
+
 //go:generate go run ../../pkg/entity/cmd/schemagen -input schema.yml -output compute_v1alpha/schema.gen.go -pkg compute_v1alpha
+
+// SandboxActive reports whether a sandbox status indicates the sandbox
+// may be actively running (PENDING, NOT_READY, or RUNNING).
+func SandboxActive(status compute_v1alpha.SandboxStatus) bool {
+	return status == compute_v1alpha.PENDING || status == compute_v1alpha.NOT_READY || status == compute_v1alpha.RUNNING
+}
+
+// SandboxDead reports whether a sandbox status indicates the sandbox
+// has stopped or failed (STOPPED or DEAD).
+func SandboxDead(status compute_v1alpha.SandboxStatus) bool {
+	return status == compute_v1alpha.STOPPED || status == compute_v1alpha.DEAD
+}

--- a/api/compute/compute_test.go
+++ b/api/compute/compute_test.go
@@ -1,0 +1,32 @@
+package compute
+
+import (
+	"testing"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+)
+
+func TestSandboxStatusCoverage(t *testing.T) {
+	// Every SandboxStatus must be covered by exactly one of
+	// SandboxActive or SandboxDead. If a new status is added to the
+	// schema without updating these helpers, this test will fail.
+	allStatuses := []compute_v1alpha.SandboxStatus{
+		compute_v1alpha.PENDING,
+		compute_v1alpha.NOT_READY,
+		compute_v1alpha.RUNNING,
+		compute_v1alpha.STOPPED,
+		compute_v1alpha.DEAD,
+	}
+
+	for _, s := range allStatuses {
+		active := SandboxActive(s)
+		dead := SandboxDead(s)
+
+		if !active && !dead {
+			t.Errorf("status %q is neither Active nor Dead", s)
+		}
+		if active && dead {
+			t.Errorf("status %q is both Active and Dead", s)
+		}
+	}
+}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"miren.dev/runtime/api/compute"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/rpc/stream"
 
@@ -490,9 +491,11 @@ func (s *Server) watchSandboxes(ctx context.Context) {
 }
 
 func (s *Server) handleSandboxUpdate(ctx context.Context, sb *compute_v1alpha.Sandbox, en *entity.Entity) {
-	// Only track RUNNING sandboxes - this matches recoverSandboxes() behavior
-	if sb.Status != compute_v1alpha.RUNNING {
-		// Sandbox is not running - remove from DNS if we were tracking it
+	// Track PENDING and RUNNING sandboxes so DNS works during startup.
+	// Containers can make DNS queries while still in PENDING state, before
+	// the sandbox transitions to RUNNING.
+	if !compute.SandboxActive(sb.Status) {
+		// Sandbox is stopped/dead - remove from DNS if we were tracking it
 		s.handleSandboxDeleteByID(sb.ID.String())
 		return
 	}
@@ -502,7 +505,7 @@ func (s *Server) handleSandboxUpdate(ctx context.Context, sb *compute_v1alpha.Sa
 	s.mu.Unlock()
 
 	if tracked {
-		// Already tracked and still RUNNING, skip
+		// Already tracked, skip
 		return
 	}
 
@@ -768,8 +771,8 @@ func (s *Server) recoverSandboxes(ctx context.Context) error {
 		var sb compute_v1alpha.Sandbox
 		sb.Decode(ent.Entity())
 
-		// Only recover RUNNING sandboxes
-		if sb.Status != compute_v1alpha.RUNNING {
+		// Only recover PENDING and RUNNING sandboxes
+		if !compute.SandboxActive(sb.Status) {
 			continue
 		}
 

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -169,13 +169,22 @@ func (s *Server) handleServiceListQuery(w dns.ResponseWriter, r *dns.Msg) {
 	appName, found := s.ipToApp[sourceIP]
 	if !found {
 		s.mu.RUnlock()
-		// Source IP not from any known sandbox, return empty response
-		s.log.Debug("service list query from unknown IP", "ip", sourceIP)
-		w.WriteMsg(response)
-		return
+		// Try resolving via entity store lookup
+		if s.resolveUnknownIP(sourceIP) {
+			s.mu.RLock()
+			appName = s.ipToApp[sourceIP]
+			s.mu.RUnlock()
+		} else {
+			s.log.Debug("service list query from unknown IP", "ip", sourceIP)
+			w.WriteMsg(response)
+			return
+		}
+	} else {
+		s.mu.RUnlock()
 	}
 
 	// Get all services for this app
+	s.mu.RLock()
 	var services []string
 	if serviceMap, ok := s.appServiceToIPs[appName]; ok {
 		for service := range serviceMap {
@@ -239,12 +248,21 @@ func (s *Server) handlePTRQuery(w dns.ResponseWriter, r *dns.Msg, qname string) 
 	sourceAppName, foundSource := s.ipToApp[sourceIP]
 	if !foundSource {
 		s.mu.RUnlock()
-		// Source IP not from any known sandbox, forward to upstream
-		s.forwardToUpstream(w, r)
-		return
+		// Try resolving via entity store lookup
+		if s.resolveUnknownIP(sourceIP) {
+			s.mu.RLock()
+			sourceAppName = s.ipToApp[sourceIP]
+			s.mu.RUnlock()
+		} else {
+			s.forwardToUpstream(w, r)
+			return
+		}
+	} else {
+		s.mu.RUnlock()
 	}
 
 	// Look up which app the queried IP belongs to
+	s.mu.RLock()
 	targetAppName, foundTarget := s.ipToApp[ip]
 	if !foundTarget {
 		s.mu.RUnlock()
@@ -348,13 +366,22 @@ func (s *Server) handleAppMirenQuery(w dns.ResponseWriter, r *dns.Msg, qname str
 	appName, found := s.ipToApp[sourceIP]
 	if !found {
 		s.mu.RUnlock()
-		// Source IP not from any known sandbox, return empty response
-		s.log.Debug("dns query from unknown IP", "ip", sourceIP, "query", qname)
-		w.WriteMsg(response)
-		return
+		// Try resolving via entity store lookup
+		if s.resolveUnknownIP(sourceIP) {
+			s.mu.RLock()
+			appName = s.ipToApp[sourceIP]
+			s.mu.RUnlock()
+		} else {
+			s.log.Debug("dns query from unknown IP", "ip", sourceIP, "query", qname)
+			w.WriteMsg(response)
+			return
+		}
+	} else {
+		s.mu.RUnlock()
 	}
 
 	// Get IPs for this app+service
+	s.mu.RLock()
 	var ips []string
 	if serviceMap, ok := s.appServiceToIPs[appName]; ok {
 		ips = serviceMap[serviceName]
@@ -569,6 +596,87 @@ func (s *Server) addSandboxMappingLocked(sandboxID, ipAddr, appName, service str
 		s.appServiceToIPs[appName][service] = append(existingIPs, ipAddr)
 		s.log.Info("added sandbox to DNS mapping", "sandbox", sandboxID, "app", appName, "service", service, "ip", ipAddr)
 	}
+}
+
+// resolveUnknownIP searches the entity store for a sandbox with the given IP address
+// and registers it for DNS resolution if found. This handles the race where a sandbox
+// container starts making DNS queries before the entity watcher processes the RUNNING
+// status update. The lookup registers sandboxes regardless of status since the container
+// is clearly running if it's making DNS queries.
+func (s *Server) resolveUnknownIP(sourceIP string) bool {
+	if s.entityClient == nil {
+		return false
+	}
+
+	// Give the watcher a moment to catch up — if it processes the sandbox
+	// update in this window we avoid the full entity scan.
+	time.Sleep(200 * time.Millisecond)
+
+	s.mu.RLock()
+	_, found := s.ipToApp[sourceIP]
+	s.mu.RUnlock()
+	if found {
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := s.entityClient.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		s.log.Debug("failed to list sandboxes for unknown IP resolution", "ip", sourceIP, "error", err)
+		return false
+	}
+
+	for _, ent := range resp.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(ent.Entity())
+
+		if len(sb.Network) == 0 {
+			continue
+		}
+
+		ipAddr := sb.Network[0].Address
+		if strings.Contains(ipAddr, "/") {
+			ipAddr = strings.Split(ipAddr, "/")[0]
+		}
+
+		if ipAddr != sourceIP {
+			continue
+		}
+
+		var md core_v1alpha.Metadata
+		md.Decode(ent.Entity())
+
+		service, _ := md.Labels.Get("service")
+		if service == "" {
+			return false
+		}
+
+		verResp, err := s.entityClient.Get(ctx, sb.Spec.Version.String())
+		if err != nil {
+			s.log.Debug("failed to get version for unknown IP sandbox", "ip", sourceIP, "error", err)
+			return false
+		}
+
+		var appVer core_v1alpha.AppVersion
+		appVer.Decode(verResp.Entity().Entity())
+
+		appResp, err := s.entityClient.Get(ctx, appVer.App.String())
+		if err != nil {
+			s.log.Debug("failed to get app for unknown IP sandbox", "ip", sourceIP, "error", err)
+			return false
+		}
+
+		var appMD core_v1alpha.Metadata
+		appMD.Decode(appResp.Entity().Entity())
+
+		s.addSandboxMapping(sb.ID.String(), ipAddr, appMD.Name, service)
+		s.log.Info("resolved unknown IP to sandbox via entity lookup", "ip", sourceIP, "sandbox", sb.ID, "app", appMD.Name, "service", service)
+		return true
+	}
+
+	return false
 }
 
 // lookupAppForIP returns the app name associated with the given IP address.

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -295,8 +295,8 @@ func TestResolveUnknownIPNoMatchingIP(t *testing.T) {
 		"resolveUnknownIP should return false for non-matching IP")
 }
 
-func TestNonRunningStatusNeverAdded(t *testing.T) {
-	// Sandboxes that are not RUNNING should never be added to DNS,
+func TestStoppedStatusNeverAdded(t *testing.T) {
+	// Sandboxes that are STOPPED or DEAD should never be added to DNS,
 	// even if they have network info.
 
 	s := newTestServer(t)
@@ -304,19 +304,19 @@ func TestNonRunningStatusNeverAdded(t *testing.T) {
 
 	const (
 		ip        = "10.8.24.32"
-		sandboxID = "sandbox/testapp-pending"
+		sandboxID = "sandbox/testapp-stopped"
 	)
 
-	// A PENDING sandbox with network info should not be tracked
-	pendingSandbox := &compute_v1alpha.Sandbox{
+	// A STOPPED sandbox with network info should not be tracked
+	stoppedSandbox := &compute_v1alpha.Sandbox{
 		ID:     entity.Id(sandboxID),
-		Status: compute_v1alpha.PENDING,
+		Status: compute_v1alpha.STOPPED,
 		Network: []compute_v1alpha.Network{
 			{Address: ip + "/24"},
 		},
 	}
-	s.handleSandboxUpdate(ctx, pendingSandbox, nil)
+	s.handleSandboxUpdate(ctx, stoppedSandbox, nil)
 
 	assert.Empty(t, s.lookupAppForIP(ip),
-		"PENDING sandbox should not be added to DNS")
+		"STOPPED sandbox should not be added to DNS")
 }

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	compute_v1alpha "miren.dev/runtime/api/compute/compute_v1alpha"
+	core_v1alpha "miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
 	"miren.dev/runtime/pkg/slogfmt"
 )
 
@@ -167,6 +171,128 @@ func TestSandboxDeadStatusRemovesFromDNS(t *testing.T) {
 
 	assert.Empty(t, s.lookupAppForIP(ip),
 		"sandbox should be removed from DNS when status changes to DEAD")
+}
+
+func TestResolveUnknownIPWithoutEntityClient(t *testing.T) {
+	// resolveUnknownIP should return false gracefully when entityClient is nil
+	s := newTestServer(t)
+	assert.False(t, s.resolveUnknownIP("10.8.24.50"),
+		"resolveUnknownIP should return false when entityClient is nil")
+}
+
+func TestResolveUnknownIPFindsAndRegistersSandbox(t *testing.T) {
+	// When a sandbox container makes DNS queries before the entity watcher
+	// processes the RUNNING status update, resolveUnknownIP should find
+	// the sandbox in the entity store and register it for DNS.
+
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	const (
+		sandboxIP   = "10.8.24.60"
+		appName     = "myapp"
+		serviceName = "web"
+		versionName = "myapp-v1"
+		sandboxName = "myapp-web-1"
+	)
+
+	// Create app entity
+	app := &core_v1alpha.App{}
+	appID, err := inmem.Client.Create(ctx, appName, app)
+	assert.NoError(t, err)
+
+	// Create app version entity referencing the app
+	appVer := &core_v1alpha.AppVersion{App: appID}
+	_, err = inmem.Client.Create(ctx, versionName, appVer)
+	assert.NoError(t, err)
+
+	// Create sandbox entity in PENDING status with network info and service label.
+	// The sandbox is PENDING (not RUNNING) to test that resolveUnknownIP
+	// works regardless of status — the container is clearly running if it's
+	// making DNS queries.
+	sb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.PENDING,
+		Network: []compute_v1alpha.Network{
+			{Address: sandboxIP + "/24"},
+		},
+		Spec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("app_version/" + versionName),
+		},
+	}
+	_, err = inmem.Client.Create(ctx, sandboxName, sb,
+		entityserver.WithLabels(types.Labels{
+			{Key: "service", Value: serviceName},
+		}),
+	)
+	assert.NoError(t, err)
+
+	// Create DNS server with the entity client
+	log := slog.New(slogfmt.NewTestHandler(t, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	s := &Server{
+		log:             log,
+		entityClient:    inmem.EAC,
+		ipToApp:         make(map[string]string),
+		ipToService:     make(map[string]string),
+		appServiceToIPs: make(map[string]map[string][]string),
+		entityToIP:      make(map[string]string),
+	}
+
+	// IP should not be registered yet
+	assert.Empty(t, s.lookupAppForIP(sandboxIP))
+
+	// resolveUnknownIP should find the sandbox and register it
+	assert.True(t, s.resolveUnknownIP(sandboxIP),
+		"resolveUnknownIP should find and register the sandbox")
+
+	// Verify the sandbox is now registered
+	assert.Equal(t, appName, s.lookupAppForIP(sandboxIP),
+		"sandbox should be registered with correct app name")
+
+	// Verify service mapping
+	s.mu.RLock()
+	assert.Equal(t, serviceName, s.ipToService[sandboxIP],
+		"service mapping should be registered")
+	assert.Contains(t, s.appServiceToIPs[appName][serviceName], sandboxIP,
+		"app+service to IP mapping should be registered")
+	s.mu.RUnlock()
+}
+
+func TestResolveUnknownIPNoMatchingIP(t *testing.T) {
+	// resolveUnknownIP should return false when no sandbox has the queried IP.
+
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create a sandbox with a different IP
+	sb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+		Network: []compute_v1alpha.Network{
+			{Address: "10.8.24.99/24"},
+		},
+	}
+	_, err := inmem.Client.Create(ctx, "other-sandbox", sb,
+		entityserver.WithLabels(types.Labels{
+			{Key: "service", Value: "web"},
+		}),
+	)
+	assert.NoError(t, err)
+
+	log := slog.New(slogfmt.NewTestHandler(t, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	s := &Server{
+		log:             log,
+		entityClient:    inmem.EAC,
+		ipToApp:         make(map[string]string),
+		ipToService:     make(map[string]string),
+		appServiceToIPs: make(map[string]map[string][]string),
+		entityToIP:      make(map[string]string),
+	}
+
+	assert.False(t, s.resolveUnknownIP("10.8.24.100"),
+		"resolveUnknownIP should return false for non-matching IP")
 }
 
 func TestNonRunningStatusNeverAdded(t *testing.T) {


### PR DESCRIPTION
## Summary

- When a sandbox starts, its containers begin making DNS queries before the entity watcher processes the RUNNING status update, causing DNS to return empty responses from unknown source IPs
- Added lazy resolution: when the DNS server sees an unknown source IP, it sleeps 200ms to let the watcher catch up, then falls back to searching the entity store for a matching sandbox
- The entity lookup registers sandboxes regardless of status (not just RUNNING), since the container is clearly running if it's making DNS queries

## Test plan

- [x] `TestResolveUnknownIPWithoutEntityClient` — graceful no-op when entity client is nil
- [x] `TestResolveUnknownIPFindsAndRegistersSandbox` — full integration test with in-memory entity server, creates app/version/sandbox entities and verifies lazy lookup registers all DNS mappings
- [x] `TestResolveUnknownIPNoMatchingIP` — returns false when no sandbox matches the IP
- [x] All existing DNS tests continue to pass
- [x] `make lint` clean