### PR TITLE
Fix orphaned app container shims during sandbox cleanup

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1704,6 +1704,9 @@ func (c *SandboxController) monitorTaskExit(
 				"exit_time", exitStatus.ExitTime(),
 			)
 
+			// We don't delete the task here so that our destroySubContainers function
+			// has a consistent view of the state of containers and tasks.
+
 			// Update sandbox status to STOPPED using Patch (only updating Status field)
 			// We use Patch instead of Put since we're only changing one field
 			// STOPPED status triggers cleanup in reconciliation (stopSandbox), which:
@@ -2193,8 +2196,19 @@ forceKill:
 	}
 
 cleanup:
-	// Delete all containers
+	// Delete all containers.
+	// We must delete the task before the container — containerd requires this.
+	// Tasks may still exist here if the process had already exited when we
+	// tried Kill(SIGTERM), since those containers were skipped in the
+	// graceful-shutdown loop above.
 	for _, info := range containers {
+		if info.task != nil {
+			if _, err := info.task.Delete(ctx, containerd.WithProcessKill); err != nil {
+				if !errdefs.IsNotFound(err) {
+					c.Log.Debug("failed to delete task during cleanup", "id", info.id, "err", err)
+				}
+			}
+		}
 		if err := info.container.Delete(ctx, containerd.WithSnapshotCleanup); err != nil {
 			if !errdefs.IsNotFound(err) {
 				c.Log.Debug("failed to delete container", "id", info.id, "err", err)


### PR DESCRIPTION
When an app container crashes (process exits), its containerd shim can be left behind while the pause container is successfully deleted. This results in shims with -app suffixes that have no matching -pause container.

Root cause: In destroySubContainers(), the graceful shutdown setup has three continue paths where info.task is set but the task is never added to tasksByID:

  1. task.Wait() fails - task exists but we can't monitor it
  2. task.Kill(SIGTERM) fails - most commonly because the process already exited/crashed

We've confirmed in the logs that we were trying to delete containers that still had tasks.

In both cases, the task object still exists in containerd but is never deleted. The cleanup phase only called container.Delete(), which fails silently because containerd requires the task to be deleted before the container. The error was logged at Debug level, destroySubContainers() returned nil, and stopSandbox() proceeded to successfully delete the pause container — leaving the app container shim orphaned.

Crash scenario:
  App crashes -> monitorTaskExit may fail to delete task -> sandbox
  marked STOPPED -> stopSandbox() runs -> destroySubContainers() finds
  container, Kill(SIGTERM) fails (process already dead), task never
  deleted, container.Delete() fails -> pause container deleted ->
  orphaned app container shim

Fix:
- In destroySubContainers() cleanup phase, attempt task.Delete() before container.Delete(). This mirrors what stopSandbox() already does for the pause container. Double-deletes are safe (NotFound is suppressed).
- In monitorTaskExit, proactively delete the task when process exit is detected, cleaning up the shim immediately rather than waiting for stopSandbox reconciliation.