### PR TITLE
Add batch SetEnvVars RPC to set multiple env vars in a single version

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -2153,6 +2153,95 @@ func (v *CrudSetEnvVarResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type crudSetEnvVarsArgsData struct {
+	App     *string        `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
+	Vars    *[]*NamedValue `cbor:"1,keyasint,omitempty" json:"vars,omitempty"`
+	Service *string        `cbor:"2,keyasint,omitempty" json:"service,omitempty"`
+}
+
+type CrudSetEnvVarsArgs struct {
+	call rpc.Call
+	data crudSetEnvVarsArgsData
+}
+
+func (v *CrudSetEnvVarsArgs) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *CrudSetEnvVarsArgs) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *CrudSetEnvVarsArgs) HasVars() bool {
+	return v.data.Vars != nil
+}
+
+func (v *CrudSetEnvVarsArgs) Vars() []*NamedValue {
+	if v.data.Vars == nil {
+		return nil
+	}
+	return *v.data.Vars
+}
+
+func (v *CrudSetEnvVarsArgs) HasService() bool {
+	return v.data.Service != nil
+}
+
+func (v *CrudSetEnvVarsArgs) Service() string {
+	if v.data.Service == nil {
+		return ""
+	}
+	return *v.data.Service
+}
+
+func (v *CrudSetEnvVarsArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CrudSetEnvVarsArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CrudSetEnvVarsArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CrudSetEnvVarsArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type crudSetEnvVarsResultsData struct {
+	VersionId *string `cbor:"0,keyasint,omitempty" json:"versionId,omitempty"`
+}
+
+type CrudSetEnvVarsResults struct {
+	call rpc.Call
+	data crudSetEnvVarsResultsData
+}
+
+func (v *CrudSetEnvVarsResults) SetVersionId(versionId string) {
+	v.data.VersionId = &versionId
+}
+
+func (v *CrudSetEnvVarsResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CrudSetEnvVarsResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CrudSetEnvVarsResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CrudSetEnvVarsResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type crudDeleteEnvVarArgsData struct {
 	App     *string `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
 	Key     *string `cbor:"1,keyasint,omitempty" json:"key,omitempty"`
@@ -2429,6 +2518,32 @@ func (t *CrudSetEnvVar) Results() *CrudSetEnvVarResults {
 	return results
 }
 
+type CrudSetEnvVars struct {
+	rpc.Call
+	args    CrudSetEnvVarsArgs
+	results CrudSetEnvVarsResults
+}
+
+func (t *CrudSetEnvVars) Args() *CrudSetEnvVarsArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *CrudSetEnvVars) Results() *CrudSetEnvVarsResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type CrudDeleteEnvVar struct {
 	rpc.Call
 	args    CrudDeleteEnvVarArgs
@@ -2463,6 +2578,7 @@ type Crud interface {
 	List(ctx context.Context, state *CrudList) error
 	Destroy(ctx context.Context, state *CrudDestroy) error
 	SetEnvVar(ctx context.Context, state *CrudSetEnvVar) error
+	SetEnvVars(ctx context.Context, state *CrudSetEnvVars) error
 	DeleteEnvVar(ctx context.Context, state *CrudDeleteEnvVar) error
 }
 
@@ -2495,6 +2611,10 @@ func (reexportCrud) Destroy(ctx context.Context, state *CrudDestroy) error {
 }
 
 func (reexportCrud) SetEnvVar(ctx context.Context, state *CrudSetEnvVar) error {
+	panic("not implemented")
+}
+
+func (reexportCrud) SetEnvVars(ctx context.Context, state *CrudSetEnvVars) error {
 	panic("not implemented")
 }
 
@@ -2569,6 +2689,15 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetEnvVar(ctx, &CrudSetEnvVar{Call: call})
+			},
+		},
+		{
+			Name:          "setEnvVars",
+			InterfaceName: "Crud",
+			Index:         0,
+			Public:        false,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.SetEnvVars(ctx, &CrudSetEnvVars{Call: call})
 			},
 		},
 		{
@@ -2796,6 +2925,39 @@ func (v CrudClient) SetEnvVar(ctx context.Context, app string, key string, value
 	}
 
 	return &CrudClientSetEnvVarResults{client: v.Client, data: ret}, nil
+}
+
+type CrudClientSetEnvVarsResults struct {
+	client rpc.Client
+	data   crudSetEnvVarsResultsData
+}
+
+func (v *CrudClientSetEnvVarsResults) HasVersionId() bool {
+	return v.data.VersionId != nil
+}
+
+func (v *CrudClientSetEnvVarsResults) VersionId() string {
+	if v.data.VersionId == nil {
+		return ""
+	}
+	return *v.data.VersionId
+}
+
+func (v CrudClient) SetEnvVars(ctx context.Context, app string, vars []*NamedValue, service string) (*CrudClientSetEnvVarsResults, error) {
+	args := CrudSetEnvVarsArgs{}
+	args.data.App = &app
+	x := slices.Clone(vars)
+	args.data.Vars = &x
+	args.data.Service = &service
+
+	var ret crudSetEnvVarsResultsData
+
+	err := v.Call(ctx, "setEnvVars", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CrudClientSetEnvVarsResults{client: v.Client, data: ret}, nil
 }
 
 type CrudClientDeleteEnvVarResults struct {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -381,6 +381,19 @@ interfaces:
         results:
           - name: versionId
             type: string
+      - name: setEnvVars
+        parameters:
+          - name: app
+            type: string
+          - name: vars
+            type: list
+            element: NamedValue
+          - name: service
+            type: string
+            doc: "Optional service name for per-service env vars. Empty means global."
+        results:
+          - name: versionId
+            type: string
       - name: deleteEnvVar
         parameters:
           - name: app

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -123,10 +123,9 @@ func EnvSet(ctx *Context, opts struct {
 
 	ac := app_v1alpha.NewCrudClient(cl)
 
-	var lastVersionId string
+	var vars []*app_v1alpha.NamedValue
 
 	for _, spec := range specs {
-		// Log what we're doing
 		if spec.FromFile {
 			ctx.Printf("setting %s from file %s...\n", spec.Key, spec.FromFile_)
 		} else if spec.Sensitive {
@@ -135,15 +134,19 @@ func EnvSet(ctx *Context, opts struct {
 			ctx.Printf("setting %s...\n", spec.Key)
 		}
 
-		// Use the targeted SetEnvVar RPC - server handles source tracking
-		res, err := ac.SetEnvVar(ctx, opts.App, spec.Key, spec.Value, spec.Sensitive, opts.Service)
-		if err != nil {
-			return err
-		}
-		lastVersionId = res.VersionId()
+		nv := &app_v1alpha.NamedValue{}
+		nv.SetKey(spec.Key)
+		nv.SetValue(spec.Value)
+		nv.SetSensitive(spec.Sensitive)
+		vars = append(vars, nv)
 	}
 
-	ctx.Printf("new version id: %s\n", lastVersionId)
+	res, err := ac.SetEnvVars(ctx, opts.App, vars, opts.Service)
+	if err != nil {
+		return err
+	}
+
+	ctx.Printf("new version id: %s\n", res.VersionId())
 	return nil
 }
 

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -490,6 +490,111 @@ func (r *AppInfo) SetEnvVar(ctx context.Context, state *app_v1alpha.CrudSetEnvVa
 	return nil
 }
 
+func (r *AppInfo) SetEnvVars(ctx context.Context, state *app_v1alpha.CrudSetEnvVars) error {
+	args := state.Args()
+	name := args.App()
+	vars := args.Vars()
+	service := args.Service()
+
+	if len(vars) == 0 {
+		return fmt.Errorf("no environment variables provided")
+	}
+
+	for _, v := range vars {
+		if strings.HasPrefix(v.Key(), "MIREN_") {
+			return fmt.Errorf("cannot set MIREN_ environment variables")
+		}
+	}
+
+	var appRec core_v1alpha.App
+	err := r.EC.Get(ctx, name, &appRec)
+	if err != nil {
+		return err
+	}
+
+	var appVer core_v1alpha.AppVersion
+	if appRec.ActiveVersion != "" {
+		err = r.EC.GetById(ctx, appRec.ActiveVersion, &appVer)
+		if err != nil {
+			return err
+		}
+	} else {
+		appVer.App = appRec.ID
+	}
+
+	for _, v := range vars {
+		key := v.Key()
+		value := v.Value()
+		sensitive := v.Sensitive()
+
+		if service == "" {
+			found := false
+			for i, ev := range appVer.Config.Variable {
+				if ev.Key == key {
+					appVer.Config.Variable[i].Value = value
+					appVer.Config.Variable[i].Sensitive = sensitive
+					appVer.Config.Variable[i].Source = "manual"
+					found = true
+					break
+				}
+			}
+			if !found {
+				appVer.Config.Variable = append(appVer.Config.Variable, core_v1alpha.Variable{
+					Key:       key,
+					Value:     value,
+					Sensitive: sensitive,
+					Source:    "manual",
+				})
+			}
+		} else {
+			svcFound := false
+			for i := range appVer.Config.Services {
+				if appVer.Config.Services[i].Name == service {
+					svcFound = true
+					envFound := false
+					for j, e := range appVer.Config.Services[i].Env {
+						if e.Key == key {
+							appVer.Config.Services[i].Env[j].Value = value
+							appVer.Config.Services[i].Env[j].Sensitive = sensitive
+							appVer.Config.Services[i].Env[j].Source = "manual"
+							envFound = true
+							break
+						}
+					}
+					if !envFound {
+						appVer.Config.Services[i].Env = append(appVer.Config.Services[i].Env, core_v1alpha.Env{
+							Key:       key,
+							Value:     value,
+							Sensitive: sensitive,
+							Source:    "manual",
+						})
+					}
+					break
+				}
+			}
+			if !svcFound {
+				return fmt.Errorf("service %q not found", service)
+			}
+		}
+	}
+
+	appVer.Version = name + "-" + idgen.Gen("v")
+
+	avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
+	if err != nil {
+		return err
+	}
+
+	appRec.ActiveVersion = avid
+	err = r.EC.Update(ctx, &appRec)
+	if err != nil {
+		return fmt.Errorf("error updating app entity: %w", err)
+	}
+
+	state.Results().SetVersionId(appVer.Version)
+	return nil
+}
+
 func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDeleteEnvVar) error {
 	args := state.Args()
 	name := args.App()

--- a/servers/app/app_test.go
+++ b/servers/app/app_test.go
@@ -354,3 +354,360 @@ func TestSetConfiguration_EnvVarDeletion(t *testing.T) {
 		}
 	})
 }
+
+func TestSetEnvVars_Batch(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+
+	appInfo := &AppInfo{
+		Log:  slog.Default(),
+		EC:   ec,
+		CPU:  &metrics.CPUUsage{},
+		Mem:  &metrics.MemoryUsage{},
+		HTTP: &metrics.HTTPMetrics{},
+	}
+
+	client := &app_v1alpha.CrudClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptCrud(appInfo)),
+	}
+
+	t.Run("SetMultipleVarsAtOnce", func(t *testing.T) {
+		appName := "test-batch-set"
+		app := &core_v1alpha.App{}
+		appID, err := inmem.Client.Create(ctx, appName, app)
+		if err != nil {
+			t.Fatalf("failed to create app: %v", err)
+		}
+		app.ID = appID
+
+		nv1 := &app_v1alpha.NamedValue{}
+		nv1.SetKey("A")
+		nv1.SetValue("1")
+		nv1.SetSensitive(false)
+
+		nv2 := &app_v1alpha.NamedValue{}
+		nv2.SetKey("B")
+		nv2.SetValue("2")
+		nv2.SetSensitive(false)
+
+		nv3 := &app_v1alpha.NamedValue{}
+		nv3.SetKey("C")
+		nv3.SetValue("3")
+		nv3.SetSensitive(true)
+
+		res, err := client.SetEnvVars(ctx, appName, []*app_v1alpha.NamedValue{nv1, nv2, nv3}, "")
+		if err != nil {
+			t.Fatalf("SetEnvVars failed: %v", err)
+		}
+
+		if res.VersionId() == "" {
+			t.Fatal("expected non-empty version ID")
+		}
+
+		var appCheck core_v1alpha.App
+		err = ec.Get(ctx, appName, &appCheck)
+		if err != nil {
+			t.Fatalf("failed to get app: %v", err)
+		}
+
+		var appVer core_v1alpha.AppVersion
+		err = ec.GetById(ctx, appCheck.ActiveVersion, &appVer)
+		if err != nil {
+			t.Fatalf("failed to get app version: %v", err)
+		}
+
+		if len(appVer.Config.Variable) != 3 {
+			t.Fatalf("expected 3 env vars, got %d", len(appVer.Config.Variable))
+		}
+
+		vars := map[string]core_v1alpha.Variable{}
+		for _, v := range appVer.Config.Variable {
+			vars[v.Key] = v
+		}
+
+		if vars["A"].Value != "1" || vars["A"].Sensitive {
+			t.Errorf("A: got value=%q sensitive=%v, want value=%q sensitive=%v", vars["A"].Value, vars["A"].Sensitive, "1", false)
+		}
+		if vars["B"].Value != "2" || vars["B"].Sensitive {
+			t.Errorf("B: got value=%q sensitive=%v, want value=%q sensitive=%v", vars["B"].Value, vars["B"].Sensitive, "2", false)
+		}
+		if vars["C"].Value != "3" || !vars["C"].Sensitive {
+			t.Errorf("C: got value=%q sensitive=%v, want value=%q sensitive=%v", vars["C"].Value, vars["C"].Sensitive, "3", true)
+		}
+		for _, v := range appVer.Config.Variable {
+			if v.Source != "manual" {
+				t.Errorf("var %s: expected source %q, got %q", v.Key, "manual", v.Source)
+			}
+		}
+	})
+
+	t.Run("CreatesOnlyOneVersion", func(t *testing.T) {
+		appName := "test-batch-single-version"
+		app := &core_v1alpha.App{}
+		appID, err := inmem.Client.Create(ctx, appName, app)
+		if err != nil {
+			t.Fatalf("failed to create app: %v", err)
+		}
+		app.ID = appID
+
+		nv1 := &app_v1alpha.NamedValue{}
+		nv1.SetKey("X")
+		nv1.SetValue("10")
+		nv1.SetSensitive(false)
+
+		nv2 := &app_v1alpha.NamedValue{}
+		nv2.SetKey("Y")
+		nv2.SetValue("20")
+		nv2.SetSensitive(false)
+
+		res, err := client.SetEnvVars(ctx, appName, []*app_v1alpha.NamedValue{nv1, nv2}, "")
+		if err != nil {
+			t.Fatalf("SetEnvVars failed: %v", err)
+		}
+		firstVersionId := res.VersionId()
+
+		var appCheck core_v1alpha.App
+		err = ec.Get(ctx, appName, &appCheck)
+		if err != nil {
+			t.Fatalf("failed to get app: %v", err)
+		}
+
+		var appVer core_v1alpha.AppVersion
+		err = ec.GetById(ctx, appCheck.ActiveVersion, &appVer)
+		if err != nil {
+			t.Fatalf("failed to get app version: %v", err)
+		}
+
+		if appVer.Version != firstVersionId {
+			t.Errorf("active version %q does not match returned version %q", appVer.Version, firstVersionId)
+		}
+	})
+
+	t.Run("UpdatesExistingVars", func(t *testing.T) {
+		appName := "test-batch-update"
+		app := &core_v1alpha.App{}
+		appID, err := inmem.Client.Create(ctx, appName, app)
+		if err != nil {
+			t.Fatalf("failed to create app: %v", err)
+		}
+		app.ID = appID
+
+		// Set initial vars
+		nv1 := &app_v1alpha.NamedValue{}
+		nv1.SetKey("KEY1")
+		nv1.SetValue("old1")
+		nv1.SetSensitive(false)
+
+		nv2 := &app_v1alpha.NamedValue{}
+		nv2.SetKey("KEY2")
+		nv2.SetValue("old2")
+		nv2.SetSensitive(false)
+
+		_, err = client.SetEnvVars(ctx, appName, []*app_v1alpha.NamedValue{nv1, nv2}, "")
+		if err != nil {
+			t.Fatalf("initial SetEnvVars failed: %v", err)
+		}
+
+		// Update KEY1 and add KEY3 in a single batch
+		upd1 := &app_v1alpha.NamedValue{}
+		upd1.SetKey("KEY1")
+		upd1.SetValue("new1")
+		upd1.SetSensitive(true)
+
+		upd3 := &app_v1alpha.NamedValue{}
+		upd3.SetKey("KEY3")
+		upd3.SetValue("val3")
+		upd3.SetSensitive(false)
+
+		_, err = client.SetEnvVars(ctx, appName, []*app_v1alpha.NamedValue{upd1, upd3}, "")
+		if err != nil {
+			t.Fatalf("update SetEnvVars failed: %v", err)
+		}
+
+		var appCheck core_v1alpha.App
+		err = ec.Get(ctx, appName, &appCheck)
+		if err != nil {
+			t.Fatalf("failed to get app: %v", err)
+		}
+
+		var appVer core_v1alpha.AppVersion
+		err = ec.GetById(ctx, appCheck.ActiveVersion, &appVer)
+		if err != nil {
+			t.Fatalf("failed to get app version: %v", err)
+		}
+
+		if len(appVer.Config.Variable) != 3 {
+			t.Fatalf("expected 3 env vars, got %d", len(appVer.Config.Variable))
+		}
+
+		vars := map[string]core_v1alpha.Variable{}
+		for _, v := range appVer.Config.Variable {
+			vars[v.Key] = v
+		}
+
+		if vars["KEY1"].Value != "new1" || !vars["KEY1"].Sensitive {
+			t.Errorf("KEY1: got value=%q sensitive=%v, want value=%q sensitive=%v", vars["KEY1"].Value, vars["KEY1"].Sensitive, "new1", true)
+		}
+		if vars["KEY2"].Value != "old2" {
+			t.Errorf("KEY2: got value=%q, want %q (should be unchanged)", vars["KEY2"].Value, "old2")
+		}
+		if vars["KEY3"].Value != "val3" {
+			t.Errorf("KEY3: got value=%q, want %q", vars["KEY3"].Value, "val3")
+		}
+	})
+
+	t.Run("RejectsMIRENPrefix", func(t *testing.T) {
+		appName := "test-batch-miren-reject"
+		app := &core_v1alpha.App{}
+		appID, err := inmem.Client.Create(ctx, appName, app)
+		if err != nil {
+			t.Fatalf("failed to create app: %v", err)
+		}
+		app.ID = appID
+
+		nv1 := &app_v1alpha.NamedValue{}
+		nv1.SetKey("GOOD_VAR")
+		nv1.SetValue("ok")
+		nv1.SetSensitive(false)
+
+		nv2 := &app_v1alpha.NamedValue{}
+		nv2.SetKey("MIREN_SECRET")
+		nv2.SetValue("bad")
+		nv2.SetSensitive(false)
+
+		_, err = client.SetEnvVars(ctx, appName, []*app_v1alpha.NamedValue{nv1, nv2}, "")
+		if err == nil {
+			t.Fatal("expected error for MIREN_ prefix, got nil")
+		}
+	})
+
+	t.Run("PerServiceEnvVars", func(t *testing.T) {
+		appName := "test-batch-service"
+		app := &core_v1alpha.App{}
+		appID, err := inmem.Client.Create(ctx, appName, app)
+		if err != nil {
+			t.Fatalf("failed to create app: %v", err)
+		}
+		app.ID = appID
+
+		// Create an initial version with a service defined
+		appVer := core_v1alpha.AppVersion{
+			App: appID,
+			Config: core_v1alpha.Config{
+				Services: []core_v1alpha.Services{
+					{Name: "web"},
+				},
+			},
+		}
+		appVer.Version = appName + "-v0"
+		avid, err := inmem.Client.Create(ctx, appVer.Version, &appVer)
+		if err != nil {
+			t.Fatalf("failed to create initial version: %v", err)
+		}
+
+		var appRec core_v1alpha.App
+		err = ec.Get(ctx, appName, &appRec)
+		if err != nil {
+			t.Fatalf("failed to get app: %v", err)
+		}
+		appRec.ActiveVersion = avid
+		err = ec.Update(ctx, &appRec)
+		if err != nil {
+			t.Fatalf("failed to update app: %v", err)
+		}
+
+		nv1 := &app_v1alpha.NamedValue{}
+		nv1.SetKey("DB_HOST")
+		nv1.SetValue("localhost")
+		nv1.SetSensitive(false)
+
+		nv2 := &app_v1alpha.NamedValue{}
+		nv2.SetKey("DB_PASS")
+		nv2.SetValue("secret")
+		nv2.SetSensitive(true)
+
+		_, err = client.SetEnvVars(ctx, appName, []*app_v1alpha.NamedValue{nv1, nv2}, "web")
+		if err != nil {
+			t.Fatalf("SetEnvVars for service failed: %v", err)
+		}
+
+		var appCheck core_v1alpha.App
+		err = ec.Get(ctx, appName, &appCheck)
+		if err != nil {
+			t.Fatalf("failed to get app: %v", err)
+		}
+
+		var ver core_v1alpha.AppVersion
+		err = ec.GetById(ctx, appCheck.ActiveVersion, &ver)
+		if err != nil {
+			t.Fatalf("failed to get app version: %v", err)
+		}
+
+		if len(ver.Config.Services) != 1 {
+			t.Fatalf("expected 1 service, got %d", len(ver.Config.Services))
+		}
+
+		svc := ver.Config.Services[0]
+		if len(svc.Env) != 2 {
+			t.Fatalf("expected 2 service env vars, got %d", len(svc.Env))
+		}
+
+		envMap := map[string]core_v1alpha.Env{}
+		for _, e := range svc.Env {
+			envMap[e.Key] = e
+		}
+
+		if envMap["DB_HOST"].Value != "localhost" || envMap["DB_HOST"].Sensitive {
+			t.Errorf("DB_HOST: got value=%q sensitive=%v, want value=%q sensitive=%v", envMap["DB_HOST"].Value, envMap["DB_HOST"].Sensitive, "localhost", false)
+		}
+		if envMap["DB_PASS"].Value != "secret" || !envMap["DB_PASS"].Sensitive {
+			t.Errorf("DB_PASS: got value=%q sensitive=%v, want value=%q sensitive=%v", envMap["DB_PASS"].Value, envMap["DB_PASS"].Sensitive, "secret", true)
+		}
+
+		if len(ver.Config.Variable) != 0 {
+			t.Errorf("expected 0 global env vars, got %d", len(ver.Config.Variable))
+		}
+	})
+
+	t.Run("ServiceNotFound", func(t *testing.T) {
+		appName := "test-batch-nosvc"
+		app := &core_v1alpha.App{}
+		appID, err := inmem.Client.Create(ctx, appName, app)
+		if err != nil {
+			t.Fatalf("failed to create app: %v", err)
+		}
+		app.ID = appID
+
+		appVer := core_v1alpha.AppVersion{App: appID}
+		appVer.Version = appName + "-v0"
+		avid, err := inmem.Client.Create(ctx, appVer.Version, &appVer)
+		if err != nil {
+			t.Fatalf("failed to create initial version: %v", err)
+		}
+
+		var appRec core_v1alpha.App
+		err = ec.Get(ctx, appName, &appRec)
+		if err != nil {
+			t.Fatalf("failed to get app: %v", err)
+		}
+		appRec.ActiveVersion = avid
+		err = ec.Update(ctx, &appRec)
+		if err != nil {
+			t.Fatalf("failed to update app: %v", err)
+		}
+
+		nv := &app_v1alpha.NamedValue{}
+		nv.SetKey("X")
+		nv.SetValue("1")
+		nv.SetSensitive(false)
+
+		_, err = client.SetEnvVars(ctx, appName, []*app_v1alpha.NamedValue{nv}, "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for nonexistent service, got nil")
+		}
+	})
+}


### PR DESCRIPTION
The existing SetEnvVar RPC sets one env var per call, creating a new AppVersion each time. When setting N vars, this produces N intermediate versions that each trigger pool reconciliation, compounding the churn problem with rapid AppVersion changes.

Add a SetEnvVars RPC that accepts a list of NamedValue and applies them all to a single new AppVersion. The CLI env set command now batches all vars into one call instead of looping over SetEnvVar.

- Add setEnvVars method to the Crud RPC schema and regenerate
- Implement SetEnvVars server handler with support for global and per-service env vars, including MIREN_ prefix validation
- Update CLI env set to collect vars and call SetEnvVars once
- Add tests covering batch set, single version creation, updates to existing vars, MIREN_ prefix rejection, per-service vars, and service-not-found error