### PR TITLE
Re-read App from store in Launcher.Reconcile to coalesce rapid deploys

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -23,6 +24,8 @@ import (
 type Launcher struct {
 	Log *slog.Logger
 	EAC *entityserver_v1alpha.EntityAccessClient
+
+	appMu sync.Map // per-app mutexes: app ID -> *sync.Mutex
 }
 
 // PoolWithEntity wraps a SandboxPool with its entity, allowing updates without re-fetching
@@ -44,6 +47,12 @@ func (l *Launcher) Init(ctx context.Context) error {
 }
 
 func (l *Launcher) Reconcile(ctx context.Context, app *core_v1alpha.App, meta *entity.Meta) error {
+	// Serialize reconciles for the same app to avoid races between rapid deploys.
+	val, _ := l.appMu.LoadOrStore(app.ID, &sync.Mutex{})
+	mu := val.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+
 	// Re-read from store to get latest state, coalescing rapid updates.
 	// The controller framework embeds the entity snapshot at dispatch time,
 	// so the app passed here may have a stale ActiveVersion if multiple

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
@@ -42,13 +44,29 @@ func (l *Launcher) Init(ctx context.Context) error {
 }
 
 func (l *Launcher) Reconcile(ctx context.Context, app *core_v1alpha.App, meta *entity.Meta) error {
-	if app.ActiveVersion == "" {
-		l.Log.Debug("app has no active version, skipping", "app", app.ID)
+	// Re-read from store to get latest state, coalescing rapid updates.
+	// The controller framework embeds the entity snapshot at dispatch time,
+	// so the app passed here may have a stale ActiveVersion if multiple
+	// versions were created in quick succession.
+	appResp, err := l.EAC.Get(ctx, app.ID.String())
+	if err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			l.Log.Debug("app not found in store, skipping", "app", app.ID)
+			return nil
+		}
+		return fmt.Errorf("failed to get app from store: %w", err)
+	}
+
+	var current core_v1alpha.App
+	current.Decode(appResp.Entity().Entity())
+
+	if current.ActiveVersion == "" {
+		l.Log.Debug("app has no active version, skipping", "app", current.ID)
 		return nil
 	}
 
-	l.Log.Info("reconciling app", "app", app.ID, "version", app.ActiveVersion)
-	return l.reconcileAppVersion(ctx, app)
+	l.Log.Info("reconciling app", "app", current.ID, "version", current.ActiveVersion)
+	return l.reconcileAppVersion(ctx, &current)
 }
 
 // reconcileAppVersion ensures pools exist for all services in the active version

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -1255,6 +1256,100 @@ func TestPortNameAndType(t *testing.T) {
 	assert.Equal(t, int64(8080), webPort.Port, "web service should use port 8080")
 	assert.Equal(t, "http", webPort.Name, "web service should default to port name http")
 	assert.Equal(t, "http", webPort.Type, "web service should default to port type http")
+}
+
+// TestRapidVersionChangesCreateSinglePool tests that when multiple AppVersions
+// are created in quick succession, the launcher only creates a pool for the
+// latest ActiveVersion. This verifies that Reconcile() re-reads the App from
+// the store (coalescing stale events) rather than using the event-embedded snapshot.
+func TestRapidVersionChangesCreateSinglePool(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// Create 3 versions rapidly with the same spec (same image, same config)
+	versions := make([]*core_v1alpha.AppVersion, 3)
+	for i := range versions {
+		ver := &core_v1alpha.AppVersion{
+			App:      app.ID,
+			Version:  fmt.Sprintf("v%d", i+1),
+			ImageUrl: "test:latest",
+			Config: core_v1alpha.Config{
+				Port: 3000,
+				Services: []core_v1alpha.Services{
+					{
+						Name: "web",
+						ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+							Mode:                "auto",
+							RequestsPerInstance: 10,
+						},
+					},
+				},
+			},
+		}
+		verID, err := server.Client.Create(ctx, fmt.Sprintf("test-ver-v%d", i+1), ver)
+		require.NoError(t, err)
+		ver.ID = verID
+		versions[i] = ver
+
+		// Set each version as active (simulating rapid deploys)
+		app.ActiveVersion = ver.ID
+		err = server.Client.Update(ctx, app)
+		require.NoError(t, err)
+	}
+
+	// At this point ActiveVersion points to v3.
+	// Simulate the controller framework dispatching events for v1, v2, v3.
+	// Each event carries a stale App snapshot from when it was dispatched.
+	launcher := NewLauncher(log, server.EAC)
+
+	// Simulate stale v1 event: app snapshot has ActiveVersion=v1
+	staleAppV1 := &core_v1alpha.App{
+		ID:            app.ID,
+		Project:       app.Project,
+		ActiveVersion: versions[0].ID, // stale: points to v1
+	}
+	err = launcher.Reconcile(ctx, staleAppV1, nil)
+	require.NoError(t, err)
+
+	// Simulate stale v2 event
+	staleAppV2 := &core_v1alpha.App{
+		ID:            app.ID,
+		Project:       app.Project,
+		ActiveVersion: versions[1].ID, // stale: points to v2
+	}
+	err = launcher.Reconcile(ctx, staleAppV2, nil)
+	require.NoError(t, err)
+
+	// Simulate v3 event (current)
+	staleAppV3 := &core_v1alpha.App{
+		ID:            app.ID,
+		Project:       app.Project,
+		ActiveVersion: versions[2].ID,
+	}
+	err = launcher.Reconcile(ctx, staleAppV3, nil)
+	require.NoError(t, err)
+
+	// All three reconciles should have seen ActiveVersion=v3 (the latest)
+	// and created/reused a single pool for it.
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1, "should create only one pool despite 3 reconcile calls with stale events")
+
+	pool := pools[0]
+	assert.Equal(t, "web", pool.Service)
+	assert.Equal(t, int64(1), pool.DesiredInstances, "auto mode should have desired_instances=1")
+	// The pool should reference v3 (the latest version)
+	assert.Contains(t, pool.ReferencedByVersions, versions[2].ID, "pool should reference the latest version v3")
 }
 
 // TestNoActiveVersionSkipsReconcile tests that the launcher returns early


### PR DESCRIPTION
When multiple AppVersions are created in quick succession (rapid deploys, batch env var sets, programmatic API calls), the controller framework dispatches a watch event for each change. Each event embeds the App entity snapshot from dispatch time, so processing the v2 event always sees ActiveVersion=v2 even if v3 is already committed.

This causes the launcher to create an intermediate SandboxPool for every version, only to immediately scale each to 0 and replace it with the next. N rapid versions = N pools created, N-1 immediately torn down.

Fix by re-reading the App from the entity store at the start of Reconcile(), ignoring the stale event snapshot. Every reconciliation now sees the latest ActiveVersion. When events for v1, v2, v3 queue up, the first reconcile re-reads and sees v3, creates one pool. The subsequent reconciles also re-read, see v3, find the pool already exists, and no-op.

The extra Get has negligible cost — the launcher already does a Get for the AppVersion and the App metadata on every reconcile.