### PR TITLE
Fix adding [[env]] to app.toml wiping existing env vars

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -116,7 +116,7 @@ func mergeServiceEnvVars(existingEnvs []core_v1alpha.Env, newEnvs []core_v1alpha
 	for _, e := range existingEnvs {
 		source := e.Source
 		if source == "" {
-			source = "config" // backward compatibility
+			source = "manual" // backward compatibility: preserve unknown-source vars
 		}
 
 		if source == "manual" {
@@ -433,10 +433,10 @@ func mergeVariablesFromAppConfig(existingVars []core_v1alpha.Variable, appConfig
 
 	// First, add all existing manual variables - these always persist
 	for _, v := range existingVars {
-		// Backward compatibility: empty source is treated as "config"
+		// Backward compatibility: preserve unknown-source vars as manual
 		source := v.Source
 		if source == "" {
-			source = "config"
+			source = "manual"
 		}
 
 		// Keep manual vars - they shadow config vars with the same key

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -632,7 +632,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "backward compatibility - empty source treated as config",
+			name: "backward compatibility - empty source preserved as manual",
 			existingVars: []core_v1alpha.Variable{
 				{Key: "OLD_VAR", Value: "old_value", Source: ""},
 			},
@@ -642,6 +642,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 				},
 			},
 			wantVars: []core_v1alpha.Variable{
+				{Key: "OLD_VAR", Value: "old_value", Source: ""},
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
 		},
@@ -696,6 +697,25 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 				{Key: "MANUAL_2", Value: "m2", Source: "manual"},
 				{Key: "CONFIG_1", Value: "c1_updated", Source: "config"},
 				{Key: "CONFIG_3", Value: "c3", Source: "config"},
+			},
+		},
+		{
+			name: "empty source vars preserved when app.toml adds env",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "LEGACY_DB_URL", Value: "postgres://old/db", Source: ""},
+				{Key: "LEGACY_API_KEY", Value: "key123", Source: ""},
+				{Key: "MANUAL_SECRET", Value: "secret", Source: "manual"},
+			},
+			appConfig: &appconfig.AppConfig{
+				EnvVars: []appconfig.AppEnvVar{
+					{Key: "NEW_CONFIG_VAR", Value: "new_value"},
+				},
+			},
+			wantVars: []core_v1alpha.Variable{
+				{Key: "LEGACY_DB_URL", Value: "postgres://old/db", Source: ""},
+				{Key: "LEGACY_API_KEY", Value: "key123", Source: ""},
+				{Key: "MANUAL_SECRET", Value: "secret", Source: "manual"},
+				{Key: "NEW_CONFIG_VAR", Value: "new_value", Source: "config"},
 			},
 		},
 		{
@@ -787,7 +807,7 @@ func TestMergeServiceEnvVars(t *testing.T) {
 			},
 		},
 		{
-			name: "backward compatibility - empty source treated as config",
+			name: "backward compatibility - empty source preserved as manual",
 			existingEnvs: []core_v1alpha.Env{
 				{Key: "OLD_VAR", Value: "old_value", Source: ""},
 			},
@@ -795,6 +815,7 @@ func TestMergeServiceEnvVars(t *testing.T) {
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
 			wantEnvs: []core_v1alpha.Env{
+				{Key: "OLD_VAR", Value: "old_value", Source: ""},
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
 		},
@@ -843,6 +864,23 @@ func TestMergeServiceEnvVars(t *testing.T) {
 				{Key: "MANUAL_2", Value: "m2", Source: "manual"},
 				{Key: "CONFIG_1", Value: "c1_updated", Source: "config"},
 				{Key: "CONFIG_3", Value: "c3", Source: "config"},
+			},
+		},
+		{
+			name: "empty source vars preserved when app.toml adds env",
+			existingEnvs: []core_v1alpha.Env{
+				{Key: "LEGACY_DB_URL", Value: "postgres://old/db", Source: ""},
+				{Key: "LEGACY_API_KEY", Value: "key123", Source: ""},
+				{Key: "MANUAL_SECRET", Value: "secret", Source: "manual"},
+			},
+			newEnvs: []core_v1alpha.Env{
+				{Key: "NEW_CONFIG_VAR", Value: "new_value", Source: "config"},
+			},
+			wantEnvs: []core_v1alpha.Env{
+				{Key: "LEGACY_DB_URL", Value: "postgres://old/db", Source: ""},
+				{Key: "LEGACY_API_KEY", Value: "key123", Source: ""},
+				{Key: "MANUAL_SECRET", Value: "secret", Source: "manual"},
+				{Key: "NEW_CONFIG_VAR", Value: "new_value", Source: "config"},
 			},
 		},
 		{


### PR DESCRIPTION
When a user added their first [[env]] entry to app.toml and deployed, all existing environment variables with Source="" were silently lost.

The root cause was in the merge logic: mergeVariablesFromAppConfig() and mergeServiceEnvVars() treated empty-source vars as Source="config". When app.toml had no [[env]] section the merge short-circuited and all vars were preserved. But as soon as any [[env]] entry appeared, the full merge ran — classifying Source="" vars as "config" and dropping them because they weren't in the new app.toml config.

Env vars created before source tracking was added, or through code paths that don't explicitly set Source, all have Source="". Changing the backward-compatibility default from "config" to "manual" ensures these unknown-source vars are preserved rather than silently deleted.