### PR TITLE
Inject user env vars into build process

### DIFF
--- a/pkg/stackbuild/ruby.go
+++ b/pkg/stackbuild/ruby.go
@@ -156,12 +156,18 @@ func (s *RubyStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 	if s.hasRakefile {
 		base = base.Dir("/app").
 			AddEnv("RAILS_ENV", "production").
-			AddEnv("RACK_ENV", "production").
-			Run(
-				llb.Shlex(`sh -c 'bundle exec rake -T | grep -q "rake assets:precompile" && bundle exec rake assets:precompile || echo "no assets:precompile"'`),
-				llb.AddEnv("SECRET_KEY_BASE_DUMMY", "1"),
-				llb.WithCustomName("[phase] Precompiling assets"),
-			).State
+			AddEnv("RACK_ENV", "production")
+
+		// Inject user env vars so they're available during asset precompilation
+		for k, v := range opts.EnvVars {
+			base = base.AddEnv(k, v)
+		}
+
+		base = base.Run(
+			llb.Shlex(`sh -c 'bundle exec rake -T | grep -q "rake assets:precompile" && bundle exec rake assets:precompile || echo "no assets:precompile"'`),
+			llb.AddEnv("SECRET_KEY_BASE_DUMMY", "1"),
+			llb.WithCustomName("[phase] Precompiling assets"),
+		).State
 	}
 
 	base = s.applyOnBuild(base, opts)

--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -33,6 +33,11 @@ type BuildOptions struct {
 	AlpineImage string
 
 	OnBuild []string
+
+	// EnvVars are user-configured environment variables to inject into build steps
+	// (onBuild commands, asset precompilation). These are set on intermediate LLB
+	// states only and do not persist to the final image config.
+	EnvVars map[string]string
 }
 
 // DetectionEvent represents something detected during stack analysis
@@ -176,6 +181,11 @@ func (s *MetaStack) detectInFile(path, re string) bool {
 }
 
 func (s *MetaStack) applyOnBuild(cur llb.State, opts BuildOptions) llb.State {
+	// Inject user env vars so they're available to onBuild commands
+	for k, v := range opts.EnvVars {
+		cur = cur.AddEnv(k, v)
+	}
+
 	for _, sh := range opts.OnBuild {
 		cur = cur.Dir("/app").Run(
 			llb.Args([]string{"/bin/sh", "-c", sh}),

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -582,6 +582,37 @@ func (b *Builder) sendErrorStatus(ctx context.Context, status *stream.SendStream
 	}
 }
 
+// isSystemEnvVar returns true if the given key is a system-managed env var
+// that should not be injected as a build arg.
+func isSystemEnvVar(key string) bool {
+	switch key {
+	case "MIREN_VERSION", "MIREN_APP", "MIREN_INSTANCE_NUM", "PORT", "ADMIN_TOKEN":
+		return true
+	}
+	return strings.HasPrefix(key, "MIREN_")
+}
+
+// computeBuildEnvVars computes the merged set of environment variables to inject
+// into the build process. It reuses the same merge logic as runtime config:
+// existing config vars + app.toml vars + CLI vars, then filters out system-managed vars.
+func computeBuildEnvVars(
+	existingVars []core_v1alpha.Variable,
+	ac *appconfig.AppConfig,
+	cliVars []*build_v1alpha.EnvironmentVariable,
+) map[string]string {
+	merged := mergeVariablesFromAppConfig(existingVars, ac)
+	merged = mergeCliEnvVars(merged, cliVars)
+
+	result := make(map[string]string)
+	for _, v := range merged {
+		if isSystemEnvVar(v.Key) {
+			continue
+		}
+		result[v.Key] = v.Value
+	}
+	return result
+}
+
 func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.BuilderBuildFromTar) error {
 	args := state.Args()
 
@@ -718,11 +749,25 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		version:  mrv.Version,
 	}
 
+	// Compute env vars to inject into the build process
+	buildEnvVars := computeBuildEnvVars(mrv.Config.Variable, ac, args.EnvVars())
+	if len(buildEnvVars) > 0 {
+		b.Log.Info("injecting env vars into build", "count", len(buildEnvVars))
+	}
+
 	var tos []TransformOptions
 
 	tos = append(tos,
 		WithBuildArg("MIREN_VERSION", mrv.Version),
 	)
+
+	// Inject user env vars as build args (for Dockerfile builds)
+	if len(buildEnvVars) > 0 {
+		tos = append(tos, WithBuildArgs(buildEnvVars))
+	}
+
+	// Pass env vars for auto-stack builds
+	buildStack.EnvVars = buildEnvVars
 
 	// Track vertices we've already logged to avoid duplicates
 	vertexStarted := make(map[string]bool)

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -1418,6 +1418,151 @@ func TestMergeCliEnvVars(t *testing.T) {
 	}
 }
 
+func TestIsSystemEnvVar(t *testing.T) {
+	tests := []struct {
+		key      string
+		isSystem bool
+	}{
+		{"MIREN_VERSION", true},
+		{"MIREN_APP", true},
+		{"MIREN_INSTANCE_NUM", true},
+		{"MIREN_CUSTOM", true},
+		{"PORT", true},
+		{"ADMIN_TOKEN", true},
+		{"DATABASE_URL", false},
+		{"API_KEY", false},
+		{"NODE_ENV", false},
+		{"SECRET_KEY_BASE", false},
+		{"MY_PORT", false},
+		{"PORTNAME", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, tt.isSystem, isSystemEnvVar(tt.key))
+		})
+	}
+}
+
+func TestComputeBuildEnvVars(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingVars []core_v1alpha.Variable
+		appConfig    *appconfig.AppConfig
+		cliVars      []*build_v1alpha.EnvironmentVariable
+		wantVars     map[string]string
+	}{
+		{
+			name:         "empty inputs",
+			existingVars: nil,
+			appConfig:    nil,
+			cliVars:      nil,
+			wantVars:     map[string]string{},
+		},
+		{
+			name: "existing config vars are included",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "DATABASE_URL", Value: "postgres://localhost/db", Source: "manual"},
+				{Key: "API_KEY", Value: "secret123", Source: "config"},
+			},
+			appConfig: nil,
+			cliVars:   nil,
+			wantVars: map[string]string{
+				"DATABASE_URL": "postgres://localhost/db",
+				"API_KEY":      "secret123",
+			},
+		},
+		{
+			name: "app config vars merged in",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "EXISTING", Value: "value", Source: "manual"},
+			},
+			appConfig: &appconfig.AppConfig{
+				EnvVars: []appconfig.AppEnvVar{
+					{Key: "FROM_CONFIG", Value: "config_value"},
+				},
+			},
+			cliVars: nil,
+			wantVars: map[string]string{
+				"EXISTING":    "value",
+				"FROM_CONFIG": "config_value",
+			},
+		},
+		{
+			name:         "CLI vars override config vars",
+			existingVars: nil,
+			appConfig: &appconfig.AppConfig{
+				EnvVars: []appconfig.AppEnvVar{
+					{Key: "FOO", Value: "from-config"},
+				},
+			},
+			cliVars: []*build_v1alpha.EnvironmentVariable{
+				makeEnvVar("FOO", "from-cli", false),
+			},
+			wantVars: map[string]string{
+				"FOO": "from-cli",
+			},
+		},
+		{
+			name: "system vars are filtered out",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "DATABASE_URL", Value: "postgres://localhost/db", Source: "manual"},
+				{Key: "MIREN_VERSION", Value: "v1", Source: "config"},
+				{Key: "MIREN_APP", Value: "myapp", Source: "config"},
+				{Key: "PORT", Value: "8080", Source: "manual"},
+				{Key: "ADMIN_TOKEN", Value: "token123", Source: "manual"},
+				{Key: "MIREN_CUSTOM", Value: "custom", Source: "config"},
+			},
+			appConfig: nil,
+			cliVars:   nil,
+			wantVars: map[string]string{
+				"DATABASE_URL": "postgres://localhost/db",
+			},
+		},
+		{
+			name: "sensitive vars are included",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "SECRET_KEY", Value: "super-secret", Sensitive: true, Source: "manual"},
+			},
+			appConfig: nil,
+			cliVars:   nil,
+			wantVars: map[string]string{
+				"SECRET_KEY": "super-secret",
+			},
+		},
+		{
+			name: "full merge: existing + app config + CLI with system filtering",
+			existingVars: []core_v1alpha.Variable{
+				{Key: "EXISTING_MANUAL", Value: "m1", Source: "manual"},
+				{Key: "EXISTING_CONFIG", Value: "c1", Source: "config"},
+				{Key: "PORT", Value: "3000", Source: "manual"},
+			},
+			appConfig: &appconfig.AppConfig{
+				EnvVars: []appconfig.AppEnvVar{
+					{Key: "EXISTING_CONFIG", Value: "c1-updated"},
+					{Key: "NEW_CONFIG", Value: "new"},
+				},
+			},
+			cliVars: []*build_v1alpha.EnvironmentVariable{
+				makeEnvVar("CLI_VAR", "cli-val", false),
+			},
+			wantVars: map[string]string{
+				"EXISTING_MANUAL": "m1",
+				"EXISTING_CONFIG": "c1-updated",
+				"NEW_CONFIG":      "new",
+				"CLI_VAR":         "cli-val",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computeBuildEnvVars(tt.existingVars, tt.appConfig, tt.cliVars)
+			assert.Equal(t, tt.wantVars, result)
+		})
+	}
+}
+
 func TestValidateServicesExist(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -275,6 +275,11 @@ type BuildStack struct {
 	Version     string
 	OnBuild     []string
 	AlpineImage string
+
+	// EnvVars are user-configured environment variables to inject into the build.
+	// For auto-stack builds, these are set on intermediate LLB states before
+	// onBuild commands and asset precompilation steps.
+	EnvVars map[string]string
 }
 
 type ImageConfig struct {
@@ -401,6 +406,7 @@ func (b *Buildkit) BuildImage(
 			OnBuild:     bs.OnBuild,
 			Version:     bs.Version,
 			AlpineImage: bs.AlpineImage,
+			EnvVars:     bs.EnvVars,
 		}
 
 		stack, err := stackbuild.DetectStack(bs.CodeDir, buildOpts)


### PR DESCRIPTION
## Summary

Env vars from app.toml, existing config, and CLI flags are now available
during builds — not just at runtime. This means `npm run build`,
`rake assets:precompile`, and other build-time commands can access things
like API keys, database URLs, etc.

We merge the vars using the same precedence logic as runtime (existing
config < app.toml < CLI flags), filter out system vars like MIREN_* and
PORT, then inject them:

- **Dockerfile builds**: passed as build args via `FrontendAttrs`
- **Auto-stack builds**: set on LLB state before onBuild commands and
  Ruby asset precompilation

Env vars are only set on intermediate build states — they don't leak
into the final image config (that's still controlled separately by the
deployment launcher).