### PR TITLE
Implement ConfigSpec to hold app version config

### DIFF
--- a/api/core/config_version.go
+++ b/api/core/config_version.go
@@ -1,0 +1,95 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+)
+
+// ConfigSpecFromConfig converts the existing inline Config into a
+// ConfigSpec suitable for a ConfigVersion entity. This is used during
+// dual-write to create ConfigVersion entities alongside inline Config.
+func ConfigSpecFromConfig(cfg *core_v1alpha.Config) core_v1alpha.ConfigSpec {
+	spec := core_v1alpha.ConfigSpec{
+		Entrypoint:     cfg.Entrypoint,
+		StartDirectory: cfg.StartDirectory,
+	}
+
+	// Build a map of service -> command for merging into services
+	cmdMap := make(map[string]string, len(cfg.Commands))
+	for _, cmd := range cfg.Commands {
+		cmdMap[cmd.Service] = cmd.Command
+	}
+
+	// Convert variables
+	for _, v := range cfg.Variable {
+		spec.Variables = append(spec.Variables, core_v1alpha.ConfigSpecVariables(v))
+	}
+
+	// Convert services, merging in commands
+	for _, svc := range cfg.Services {
+		s := core_v1alpha.ConfigSpecServices{
+			Name:     svc.Name,
+			Command:  cmdMap[svc.Name],
+			Port:     svc.Port,
+			PortName: svc.PortName,
+			PortType: svc.PortType,
+			Image:    svc.Image,
+			Concurrency: core_v1alpha.ConfigSpecServicesConcurrency{
+				Mode:                svc.ServiceConcurrency.Mode,
+				NumInstances:        svc.ServiceConcurrency.NumInstances,
+				RequestsPerInstance: svc.ServiceConcurrency.RequestsPerInstance,
+				ScaleDownDelay:      svc.ServiceConcurrency.ScaleDownDelay,
+				ShutdownTimeout:     svc.ServiceConcurrency.ShutdownTimeout,
+			},
+		}
+
+		// Convert service-level env vars
+		for _, e := range svc.Env {
+			s.Env = append(s.Env, core_v1alpha.ConfigSpecServicesEnv(e))
+		}
+
+		// Convert disks
+		for _, d := range svc.Disks {
+			s.Disks = append(s.Disks, core_v1alpha.ConfigSpecServicesDisks(d))
+		}
+
+		spec.Services = append(spec.Services, s)
+	}
+
+	return spec
+}
+
+// ResolveConfig loads the configuration for an AppVersion. If the version has
+// a ConfigVersion, it loads the ConfigVersion entity and returns its spec directly.
+// Otherwise, it falls back to the inline Config field and converts it.
+func ResolveConfig(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, ver *core_v1alpha.AppVersion) (*core_v1alpha.ConfigSpec, error) {
+	if ver.ConfigVersion != "" {
+		ret, err := eac.Get(ctx, ver.ConfigVersion.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get config version %s: %w", ver.ConfigVersion, err)
+		}
+
+		var cv core_v1alpha.ConfigVersion
+		cv.Decode(ret.Entity().Entity())
+
+		return &cv.Spec, nil
+	}
+
+	// Fallback to inline config, converting to ConfigSpec
+	spec := ConfigSpecFromConfig(&ver.Config)
+	return &spec, nil
+}
+
+// GetServiceConcurrency returns the concurrency configuration for a
+// named service from a ConfigSpec.
+func GetServiceConcurrency(spec *core_v1alpha.ConfigSpec, serviceName string) (core_v1alpha.ConfigSpecServicesConcurrency, error) {
+	for _, svc := range spec.Services {
+		if svc.Name == serviceName {
+			return svc.Concurrency, nil
+		}
+	}
+	return core_v1alpha.ConfigSpecServicesConcurrency{}, fmt.Errorf("service %q not found in config (services should be hydrated with defaults)", serviceName)
+}

--- a/api/core/config_version_test.go
+++ b/api/core/config_version_test.go
@@ -1,0 +1,168 @@
+package compute
+
+import (
+	"testing"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigRoundTrip(t *testing.T) {
+	original := core_v1alpha.Config{
+		Entrypoint:     "/bin/app",
+		StartDirectory: "/app",
+		Port:           3000,
+		Commands: []core_v1alpha.Commands{
+			{Service: "web", Command: "serve"},
+			{Service: "worker", Command: "work"},
+		},
+		Variable: []core_v1alpha.Variable{
+			{Key: "FOO", Value: "bar", Source: "config"},
+			{Key: "SECRET", Value: "hidden", Sensitive: true, Source: "manual"},
+		},
+		Services: []core_v1alpha.Services{
+			{
+				Name:     "web",
+				Port:     8080,
+				PortName: "http",
+				PortType: "http",
+				ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+					Mode:                "auto",
+					RequestsPerInstance: 10,
+					ScaleDownDelay:      "5m",
+				},
+				Env: []core_v1alpha.Env{
+					{Key: "WEB_ONLY", Value: "yes", Source: "config"},
+				},
+				Disks: []core_v1alpha.Disks{
+					{Name: "data", MountPath: "/data", SizeGb: 10, Filesystem: "ext4"},
+				},
+			},
+			{
+				Name:  "worker",
+				Image: "postgres:16",
+				ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+					Mode:         "fixed",
+					NumInstances: 3,
+				},
+			},
+		},
+	}
+
+	spec := ConfigSpecFromConfig(&original)
+
+	// Check top-level fields
+	assert.Equal(t, original.Entrypoint, spec.Entrypoint)
+	assert.Equal(t, original.StartDirectory, spec.StartDirectory)
+
+	// Check commands merged into services
+	require.Len(t, spec.Services, 2)
+	svcMap := make(map[string]core_v1alpha.ConfigSpecServices)
+	for _, s := range spec.Services {
+		svcMap[s.Name] = s
+	}
+	assert.Equal(t, "serve", svcMap["web"].Command)
+	assert.Equal(t, "work", svcMap["worker"].Command)
+
+	// Check variables
+	require.Len(t, spec.Variables, 2)
+	varMap := make(map[string]core_v1alpha.ConfigSpecVariables)
+	for _, v := range spec.Variables {
+		varMap[v.Key] = v
+	}
+	assert.Equal(t, "bar", varMap["FOO"].Value)
+	assert.Equal(t, "config", varMap["FOO"].Source)
+	assert.Equal(t, "hidden", varMap["SECRET"].Value)
+	assert.True(t, varMap["SECRET"].Sensitive)
+	assert.Equal(t, "manual", varMap["SECRET"].Source)
+
+	// Check services
+	web := svcMap["web"]
+	assert.Equal(t, int64(8080), web.Port)
+	assert.Equal(t, "http", web.PortName)
+	assert.Equal(t, "http", web.PortType)
+	assert.Equal(t, "auto", web.Concurrency.Mode)
+	assert.Equal(t, int64(10), web.Concurrency.RequestsPerInstance)
+	assert.Equal(t, "5m", web.Concurrency.ScaleDownDelay)
+	require.Len(t, web.Env, 1)
+	assert.Equal(t, "WEB_ONLY", web.Env[0].Key)
+	require.Len(t, web.Disks, 1)
+	assert.Equal(t, "data", web.Disks[0].Name)
+	assert.Equal(t, "/data", web.Disks[0].MountPath)
+	assert.Equal(t, int64(10), web.Disks[0].SizeGb)
+
+	worker := svcMap["worker"]
+	assert.Equal(t, "postgres:16", worker.Image)
+	assert.Equal(t, "fixed", worker.Concurrency.Mode)
+	assert.Equal(t, int64(3), worker.Concurrency.NumInstances)
+}
+
+func TestConfigVersionFromConfigEmpty(t *testing.T) {
+	cfg := &core_v1alpha.Config{}
+	spec := ConfigSpecFromConfig(cfg)
+
+	assert.Empty(t, spec.Entrypoint)
+	assert.Empty(t, spec.StartDirectory)
+	assert.Empty(t, spec.Variables)
+	assert.Empty(t, spec.Services)
+}
+
+func TestGetServiceConcurrency(t *testing.T) {
+	spec := &core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{
+			{
+				Name: "web",
+				Concurrency: core_v1alpha.ConfigSpecServicesConcurrency{
+					Mode:                "auto",
+					RequestsPerInstance: 10,
+				},
+			},
+			{
+				Name: "worker",
+				Concurrency: core_v1alpha.ConfigSpecServicesConcurrency{
+					Mode:         "fixed",
+					NumInstances: 5,
+				},
+			},
+		},
+	}
+
+	sc, err := GetServiceConcurrency(spec, "web")
+	require.NoError(t, err)
+	assert.Equal(t, "auto", sc.Mode)
+	assert.Equal(t, int64(10), sc.RequestsPerInstance)
+
+	sc, err = GetServiceConcurrency(spec, "worker")
+	require.NoError(t, err)
+	assert.Equal(t, "fixed", sc.Mode)
+	assert.Equal(t, int64(5), sc.NumInstances)
+
+	_, err = GetServiceConcurrency(spec, "missing")
+	assert.Error(t, err)
+}
+
+func TestServiceCommandMerging(t *testing.T) {
+	cfg := &core_v1alpha.Config{
+		Commands: []core_v1alpha.Commands{
+			{Service: "web", Command: "serve --port 8080"},
+			{Service: "worker", Command: "run-worker"},
+		},
+		Services: []core_v1alpha.Services{
+			{Name: "web", Port: 8080},
+			{Name: "worker"},
+		},
+	}
+
+	spec := ConfigSpecFromConfig(cfg)
+
+	require.Len(t, spec.Services, 2)
+	svcMap := make(map[string]core_v1alpha.ConfigSpecServices)
+	for _, s := range spec.Services {
+		svcMap[s.Name] = s
+	}
+
+	assert.Equal(t, "serve --port 8080", svcMap["web"].Command)
+	assert.Equal(t, "run-worker", svcMap["worker"].Command)
+}

--- a/api/core/core_v1alpha/schema.gen.go
+++ b/api/core/core_v1alpha/schema.gen.go
@@ -7,13 +7,558 @@ import (
 )
 
 const (
+	ConfigSpecEntrypointId     = entity.Id("dev.miren.core/component.config_spec.entrypoint")
+	ConfigSpecServicesId       = entity.Id("dev.miren.core/component.config_spec.services")
+	ConfigSpecStartDirectoryId = entity.Id("dev.miren.core/component.config_spec.start_directory")
+	ConfigSpecVariablesId      = entity.Id("dev.miren.core/component.config_spec.variables")
+)
+
+type ConfigSpec struct {
+	Entrypoint     string                `cbor:"entrypoint,omitempty" json:"entrypoint,omitempty"`
+	Services       []ConfigSpecServices  `cbor:"services,omitempty" json:"services,omitempty"`
+	StartDirectory string                `cbor:"start_directory,omitempty" json:"start_directory,omitempty"`
+	Variables      []ConfigSpecVariables `cbor:"variables,omitempty" json:"variables,omitempty"`
+}
+
+func (o *ConfigSpec) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(ConfigSpecEntrypointId); ok && a.Value.Kind() == entity.KindString {
+		o.Entrypoint = a.Value.String()
+	}
+	for _, a := range e.GetAll(ConfigSpecServicesId) {
+		if a.Value.Kind() == entity.KindComponent {
+			var v ConfigSpecServices
+			v.Decode(a.Value.Component())
+			o.Services = append(o.Services, v)
+		}
+	}
+	if a, ok := e.Get(ConfigSpecStartDirectoryId); ok && a.Value.Kind() == entity.KindString {
+		o.StartDirectory = a.Value.String()
+	}
+	for _, a := range e.GetAll(ConfigSpecVariablesId) {
+		if a.Value.Kind() == entity.KindComponent {
+			var v ConfigSpecVariables
+			v.Decode(a.Value.Component())
+			o.Variables = append(o.Variables, v)
+		}
+	}
+}
+
+func (o *ConfigSpec) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Entrypoint) {
+		attrs = append(attrs, entity.String(ConfigSpecEntrypointId, o.Entrypoint))
+	}
+	for _, v := range o.Services {
+		attrs = append(attrs, entity.Component(ConfigSpecServicesId, v.Encode()))
+	}
+	if !entity.Empty(o.StartDirectory) {
+		attrs = append(attrs, entity.String(ConfigSpecStartDirectoryId, o.StartDirectory))
+	}
+	for _, v := range o.Variables {
+		attrs = append(attrs, entity.Component(ConfigSpecVariablesId, v.Encode()))
+	}
+	return
+}
+
+func (o *ConfigSpec) Empty() bool {
+	if !entity.Empty(o.Entrypoint) {
+		return false
+	}
+	if len(o.Services) != 0 {
+		return false
+	}
+	if !entity.Empty(o.StartDirectory) {
+		return false
+	}
+	if len(o.Variables) != 0 {
+		return false
+	}
+	return true
+}
+
+func (o *ConfigSpec) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("entrypoint", "dev.miren.core/component.config_spec.entrypoint", schema.Doc("The container entrypoint command"))
+	sb.Component("services", "dev.miren.core/component.config_spec.services", schema.Doc("Per-service configuration"), schema.Many)
+	(&ConfigSpecServices{}).InitSchema(sb.Builder("component.config_spec.services"))
+	sb.String("start_directory", "dev.miren.core/component.config_spec.start_directory", schema.Doc("Directory to start the process in (defaults to /app)"))
+	sb.Component("variables", "dev.miren.core/component.config_spec.variables", schema.Doc("Environment variables and configuration values"), schema.Many)
+	(&ConfigSpecVariables{}).InitSchema(sb.Builder("component.config_spec.variables"))
+}
+
+const (
+	ConfigSpecServicesCommandId     = entity.Id("dev.miren.core/component.config_spec.services.command")
+	ConfigSpecServicesConcurrencyId = entity.Id("dev.miren.core/component.config_spec.services.concurrency")
+	ConfigSpecServicesDisksId       = entity.Id("dev.miren.core/component.config_spec.services.disks")
+	ConfigSpecServicesEnvId         = entity.Id("dev.miren.core/component.config_spec.services.env")
+	ConfigSpecServicesImageId       = entity.Id("dev.miren.core/component.config_spec.services.image")
+	ConfigSpecServicesNameId        = entity.Id("dev.miren.core/component.config_spec.services.name")
+	ConfigSpecServicesPortId        = entity.Id("dev.miren.core/component.config_spec.services.port")
+	ConfigSpecServicesPortNameId    = entity.Id("dev.miren.core/component.config_spec.services.port_name")
+	ConfigSpecServicesPortTypeId    = entity.Id("dev.miren.core/component.config_spec.services.port_type")
+)
+
+type ConfigSpecServices struct {
+	Command     string                        `cbor:"command,omitempty" json:"command,omitempty"`
+	Concurrency ConfigSpecServicesConcurrency `cbor:"concurrency,omitempty" json:"concurrency,omitempty"`
+	Disks       []ConfigSpecServicesDisks     `cbor:"disks,omitempty" json:"disks,omitempty"`
+	Env         []ConfigSpecServicesEnv       `cbor:"env,omitempty" json:"env,omitempty"`
+	Image       string                        `cbor:"image,omitempty" json:"image,omitempty"`
+	Name        string                        `cbor:"name,omitempty" json:"name,omitempty"`
+	Port        int64                         `cbor:"port,omitempty" json:"port,omitempty"`
+	PortName    string                        `cbor:"port_name,omitempty" json:"port_name,omitempty"`
+	PortType    string                        `cbor:"port_type,omitempty" json:"port_type,omitempty"`
+}
+
+func (o *ConfigSpecServices) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(ConfigSpecServicesCommandId); ok && a.Value.Kind() == entity.KindString {
+		o.Command = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesConcurrencyId); ok && a.Value.Kind() == entity.KindComponent {
+		o.Concurrency.Decode(a.Value.Component())
+	}
+	for _, a := range e.GetAll(ConfigSpecServicesDisksId) {
+		if a.Value.Kind() == entity.KindComponent {
+			var v ConfigSpecServicesDisks
+			v.Decode(a.Value.Component())
+			o.Disks = append(o.Disks, v)
+		}
+	}
+	for _, a := range e.GetAll(ConfigSpecServicesEnvId) {
+		if a.Value.Kind() == entity.KindComponent {
+			var v ConfigSpecServicesEnv
+			v.Decode(a.Value.Component())
+			o.Env = append(o.Env, v)
+		}
+	}
+	if a, ok := e.Get(ConfigSpecServicesImageId); ok && a.Value.Kind() == entity.KindString {
+		o.Image = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesNameId); ok && a.Value.Kind() == entity.KindString {
+		o.Name = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesPortId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.Port = a.Value.Int64()
+	}
+	if a, ok := e.Get(ConfigSpecServicesPortNameId); ok && a.Value.Kind() == entity.KindString {
+		o.PortName = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesPortTypeId); ok && a.Value.Kind() == entity.KindString {
+		o.PortType = a.Value.String()
+	}
+}
+
+func (o *ConfigSpecServices) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Command) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesCommandId, o.Command))
+	}
+	if !o.Concurrency.Empty() {
+		attrs = append(attrs, entity.Component(ConfigSpecServicesConcurrencyId, o.Concurrency.Encode()))
+	}
+	for _, v := range o.Disks {
+		attrs = append(attrs, entity.Component(ConfigSpecServicesDisksId, v.Encode()))
+	}
+	for _, v := range o.Env {
+		attrs = append(attrs, entity.Component(ConfigSpecServicesEnvId, v.Encode()))
+	}
+	if !entity.Empty(o.Image) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesImageId, o.Image))
+	}
+	if !entity.Empty(o.Name) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesNameId, o.Name))
+	}
+	if !entity.Empty(o.Port) {
+		attrs = append(attrs, entity.Int64(ConfigSpecServicesPortId, o.Port))
+	}
+	if !entity.Empty(o.PortName) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesPortNameId, o.PortName))
+	}
+	if !entity.Empty(o.PortType) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesPortTypeId, o.PortType))
+	}
+	return
+}
+
+func (o *ConfigSpecServices) Empty() bool {
+	if !entity.Empty(o.Command) {
+		return false
+	}
+	if !o.Concurrency.Empty() {
+		return false
+	}
+	if len(o.Disks) != 0 {
+		return false
+	}
+	if len(o.Env) != 0 {
+		return false
+	}
+	if !entity.Empty(o.Image) {
+		return false
+	}
+	if !entity.Empty(o.Name) {
+		return false
+	}
+	if !entity.Empty(o.Port) {
+		return false
+	}
+	if !entity.Empty(o.PortName) {
+		return false
+	}
+	if !entity.Empty(o.PortType) {
+		return false
+	}
+	return true
+}
+
+func (o *ConfigSpecServices) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("command", "dev.miren.core/component.config_spec.services.command", schema.Doc("The command to run for the service"))
+	sb.Component("concurrency", "dev.miren.core/component.config_spec.services.concurrency", schema.Doc("Concurrency configuration for this service"))
+	(&ConfigSpecServicesConcurrency{}).InitSchema(sb.Builder("component.config_spec.services.concurrency"))
+	sb.Component("disks", "dev.miren.core/component.config_spec.services.disks", schema.Doc("Disk attachments for this service"), schema.Many)
+	(&ConfigSpecServicesDisks{}).InitSchema(sb.Builder("component.config_spec.services.disks"))
+	sb.Component("env", "dev.miren.core/component.config_spec.services.env", schema.Doc("Environment variables for this service only"), schema.Many)
+	(&ConfigSpecServicesEnv{}).InitSchema(sb.Builder("component.config_spec.services.env"))
+	sb.String("image", "dev.miren.core/component.config_spec.services.image", schema.Doc("Optional container image for this service"))
+	sb.String("name", "dev.miren.core/component.config_spec.services.name", schema.Doc("The service name (e.g. web, worker)"))
+	sb.Int64("port", "dev.miren.core/component.config_spec.services.port", schema.Doc("The TCP port the service listens on"))
+	sb.String("port_name", "dev.miren.core/component.config_spec.services.port_name", schema.Doc("The name of the port (e.g. http, grpc)"))
+	sb.String("port_type", "dev.miren.core/component.config_spec.services.port_type", schema.Doc("The type of the port (e.g. http, tcp)"))
+}
+
+const (
+	ConfigSpecServicesConcurrencyModeId                = entity.Id("dev.miren.core/component.config_spec.services.concurrency.mode")
+	ConfigSpecServicesConcurrencyNumInstancesId        = entity.Id("dev.miren.core/component.config_spec.services.concurrency.num_instances")
+	ConfigSpecServicesConcurrencyRequestsPerInstanceId = entity.Id("dev.miren.core/component.config_spec.services.concurrency.requests_per_instance")
+	ConfigSpecServicesConcurrencyScaleDownDelayId      = entity.Id("dev.miren.core/component.config_spec.services.concurrency.scale_down_delay")
+	ConfigSpecServicesConcurrencyShutdownTimeoutId     = entity.Id("dev.miren.core/component.config_spec.services.concurrency.shutdown_timeout")
+)
+
+type ConfigSpecServicesConcurrency struct {
+	Mode                string `cbor:"mode,omitempty" json:"mode,omitempty"`
+	NumInstances        int64  `cbor:"num_instances,omitempty" json:"num_instances,omitempty"`
+	RequestsPerInstance int64  `cbor:"requests_per_instance,omitempty" json:"requests_per_instance,omitempty"`
+	ScaleDownDelay      string `cbor:"scale_down_delay,omitempty" json:"scale_down_delay,omitempty"`
+	ShutdownTimeout     string `cbor:"shutdown_timeout,omitempty" json:"shutdown_timeout,omitempty"`
+}
+
+func (o *ConfigSpecServicesConcurrency) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(ConfigSpecServicesConcurrencyModeId); ok && a.Value.Kind() == entity.KindString {
+		o.Mode = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesConcurrencyNumInstancesId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.NumInstances = a.Value.Int64()
+	}
+	if a, ok := e.Get(ConfigSpecServicesConcurrencyRequestsPerInstanceId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.RequestsPerInstance = a.Value.Int64()
+	}
+	if a, ok := e.Get(ConfigSpecServicesConcurrencyScaleDownDelayId); ok && a.Value.Kind() == entity.KindString {
+		o.ScaleDownDelay = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesConcurrencyShutdownTimeoutId); ok && a.Value.Kind() == entity.KindString {
+		o.ShutdownTimeout = a.Value.String()
+	}
+}
+
+func (o *ConfigSpecServicesConcurrency) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Mode) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesConcurrencyModeId, o.Mode))
+	}
+	if !entity.Empty(o.NumInstances) {
+		attrs = append(attrs, entity.Int64(ConfigSpecServicesConcurrencyNumInstancesId, o.NumInstances))
+	}
+	if !entity.Empty(o.RequestsPerInstance) {
+		attrs = append(attrs, entity.Int64(ConfigSpecServicesConcurrencyRequestsPerInstanceId, o.RequestsPerInstance))
+	}
+	if !entity.Empty(o.ScaleDownDelay) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesConcurrencyScaleDownDelayId, o.ScaleDownDelay))
+	}
+	if !entity.Empty(o.ShutdownTimeout) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesConcurrencyShutdownTimeoutId, o.ShutdownTimeout))
+	}
+	return
+}
+
+func (o *ConfigSpecServicesConcurrency) Empty() bool {
+	if !entity.Empty(o.Mode) {
+		return false
+	}
+	if !entity.Empty(o.NumInstances) {
+		return false
+	}
+	if !entity.Empty(o.RequestsPerInstance) {
+		return false
+	}
+	if !entity.Empty(o.ScaleDownDelay) {
+		return false
+	}
+	if !entity.Empty(o.ShutdownTimeout) {
+		return false
+	}
+	return true
+}
+
+func (o *ConfigSpecServicesConcurrency) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("mode", "dev.miren.core/component.config_spec.services.concurrency.mode", schema.Doc("The concurrency mode (auto or fixed)"))
+	sb.Int64("num_instances", "dev.miren.core/component.config_spec.services.concurrency.num_instances", schema.Doc("For fixed mode, number of instances to maintain"))
+	sb.Int64("requests_per_instance", "dev.miren.core/component.config_spec.services.concurrency.requests_per_instance", schema.Doc("For auto mode, number of concurrent requests per instance"))
+	sb.String("scale_down_delay", "dev.miren.core/component.config_spec.services.concurrency.scale_down_delay", schema.Doc("For auto mode, delay before scaling down idle instances"))
+	sb.String("shutdown_timeout", "dev.miren.core/component.config_spec.services.concurrency.shutdown_timeout", schema.Doc("Time to wait for graceful shutdown before force-killing"))
+}
+
+const (
+	ConfigSpecServicesDisksFilesystemId   = entity.Id("dev.miren.core/component.config_spec.services.disks.filesystem")
+	ConfigSpecServicesDisksLeaseTimeoutId = entity.Id("dev.miren.core/component.config_spec.services.disks.lease_timeout")
+	ConfigSpecServicesDisksMountPathId    = entity.Id("dev.miren.core/component.config_spec.services.disks.mount_path")
+	ConfigSpecServicesDisksNameId         = entity.Id("dev.miren.core/component.config_spec.services.disks.name")
+	ConfigSpecServicesDisksReadOnlyId     = entity.Id("dev.miren.core/component.config_spec.services.disks.read_only")
+	ConfigSpecServicesDisksSizeGbId       = entity.Id("dev.miren.core/component.config_spec.services.disks.size_gb")
+)
+
+type ConfigSpecServicesDisks struct {
+	Filesystem   string `cbor:"filesystem,omitempty" json:"filesystem,omitempty"`
+	LeaseTimeout string `cbor:"lease_timeout,omitempty" json:"lease_timeout,omitempty"`
+	MountPath    string `cbor:"mount_path,omitempty" json:"mount_path,omitempty"`
+	Name         string `cbor:"name,omitempty" json:"name,omitempty"`
+	ReadOnly     bool   `cbor:"read_only,omitempty" json:"read_only,omitempty"`
+	SizeGb       int64  `cbor:"size_gb,omitempty" json:"size_gb,omitempty"`
+}
+
+func (o *ConfigSpecServicesDisks) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(ConfigSpecServicesDisksFilesystemId); ok && a.Value.Kind() == entity.KindString {
+		o.Filesystem = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesDisksLeaseTimeoutId); ok && a.Value.Kind() == entity.KindString {
+		o.LeaseTimeout = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesDisksMountPathId); ok && a.Value.Kind() == entity.KindString {
+		o.MountPath = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesDisksNameId); ok && a.Value.Kind() == entity.KindString {
+		o.Name = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesDisksReadOnlyId); ok && a.Value.Kind() == entity.KindBool {
+		o.ReadOnly = a.Value.Bool()
+	}
+	if a, ok := e.Get(ConfigSpecServicesDisksSizeGbId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.SizeGb = a.Value.Int64()
+	}
+}
+
+func (o *ConfigSpecServicesDisks) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Filesystem) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesDisksFilesystemId, o.Filesystem))
+	}
+	if !entity.Empty(o.LeaseTimeout) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesDisksLeaseTimeoutId, o.LeaseTimeout))
+	}
+	if !entity.Empty(o.MountPath) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesDisksMountPathId, o.MountPath))
+	}
+	if !entity.Empty(o.Name) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesDisksNameId, o.Name))
+	}
+	attrs = append(attrs, entity.Bool(ConfigSpecServicesDisksReadOnlyId, o.ReadOnly))
+	if !entity.Empty(o.SizeGb) {
+		attrs = append(attrs, entity.Int64(ConfigSpecServicesDisksSizeGbId, o.SizeGb))
+	}
+	return
+}
+
+func (o *ConfigSpecServicesDisks) Empty() bool {
+	if !entity.Empty(o.Filesystem) {
+		return false
+	}
+	if !entity.Empty(o.LeaseTimeout) {
+		return false
+	}
+	if !entity.Empty(o.MountPath) {
+		return false
+	}
+	if !entity.Empty(o.Name) {
+		return false
+	}
+	if !entity.Empty(o.ReadOnly) {
+		return false
+	}
+	if !entity.Empty(o.SizeGb) {
+		return false
+	}
+	return true
+}
+
+func (o *ConfigSpecServicesDisks) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("filesystem", "dev.miren.core/component.config_spec.services.disks.filesystem", schema.Doc("Filesystem type (ext4, xfs, btrfs) for auto-creating the disk"))
+	sb.String("lease_timeout", "dev.miren.core/component.config_spec.services.disks.lease_timeout", schema.Doc("Timeout for acquiring the disk lease"))
+	sb.String("mount_path", "dev.miren.core/component.config_spec.services.disks.mount_path", schema.Doc("The path inside the container where the disk will be mounted"))
+	sb.String("name", "dev.miren.core/component.config_spec.services.disks.name", schema.Doc("The name of the disk entity to attach"))
+	sb.Bool("read_only", "dev.miren.core/component.config_spec.services.disks.read_only", schema.Doc("Whether to mount the disk as read-only"))
+	sb.Int64("size_gb", "dev.miren.core/component.config_spec.services.disks.size_gb", schema.Doc("Size in GB for auto-creating the disk if it doesn't exist"))
+}
+
+const (
+	ConfigSpecServicesEnvKeyId       = entity.Id("dev.miren.core/component.config_spec.services.env.key")
+	ConfigSpecServicesEnvOriginId    = entity.Id("dev.miren.core/component.config_spec.services.env.origin")
+	ConfigSpecServicesEnvSensitiveId = entity.Id("dev.miren.core/component.config_spec.services.env.sensitive")
+	ConfigSpecServicesEnvSourceId    = entity.Id("dev.miren.core/component.config_spec.services.env.source")
+	ConfigSpecServicesEnvValueId     = entity.Id("dev.miren.core/component.config_spec.services.env.value")
+)
+
+type ConfigSpecServicesEnv struct {
+	Key       string `cbor:"key,omitempty" json:"key,omitempty"`
+	Origin    string `cbor:"origin,omitempty" json:"origin,omitempty"`
+	Sensitive bool   `cbor:"sensitive,omitempty" json:"sensitive,omitempty"`
+	Source    string `cbor:"source,omitempty" json:"source,omitempty"`
+	Value     string `cbor:"value,omitempty" json:"value,omitempty"`
+}
+
+func (o *ConfigSpecServicesEnv) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(ConfigSpecServicesEnvKeyId); ok && a.Value.Kind() == entity.KindString {
+		o.Key = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesEnvOriginId); ok && a.Value.Kind() == entity.KindString {
+		o.Origin = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesEnvSensitiveId); ok && a.Value.Kind() == entity.KindBool {
+		o.Sensitive = a.Value.Bool()
+	}
+	if a, ok := e.Get(ConfigSpecServicesEnvSourceId); ok && a.Value.Kind() == entity.KindString {
+		o.Source = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesEnvValueId); ok && a.Value.Kind() == entity.KindString {
+		o.Value = a.Value.String()
+	}
+}
+
+func (o *ConfigSpecServicesEnv) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Key) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesEnvKeyId, o.Key))
+	}
+	if !entity.Empty(o.Origin) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesEnvOriginId, o.Origin))
+	}
+	attrs = append(attrs, entity.Bool(ConfigSpecServicesEnvSensitiveId, o.Sensitive))
+	if !entity.Empty(o.Source) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesEnvSourceId, o.Source))
+	}
+	if !entity.Empty(o.Value) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesEnvValueId, o.Value))
+	}
+	return
+}
+
+func (o *ConfigSpecServicesEnv) Empty() bool {
+	if !entity.Empty(o.Key) {
+		return false
+	}
+	if !entity.Empty(o.Origin) {
+		return false
+	}
+	if !entity.Empty(o.Sensitive) {
+		return false
+	}
+	if !entity.Empty(o.Source) {
+		return false
+	}
+	if !entity.Empty(o.Value) {
+		return false
+	}
+	return true
+}
+
+func (o *ConfigSpecServicesEnv) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("key", "dev.miren.core/component.config_spec.services.env.key", schema.Doc("The name of the variable"))
+	sb.String("origin", "dev.miren.core/component.config_spec.services.env.origin", schema.Doc("The provenance of the variable (user, file, generated, detected)"))
+	sb.Bool("sensitive", "dev.miren.core/component.config_spec.services.env.sensitive", schema.Doc("Whether or not the value is sensitive"))
+	sb.String("source", "dev.miren.core/component.config_spec.services.env.source", schema.Doc("The source of the variable (config or manual). Defaults to config for backward compatibility."))
+	sb.String("value", "dev.miren.core/component.config_spec.services.env.value", schema.Doc("The value of the variable"))
+}
+
+const (
+	ConfigSpecVariablesKeyId       = entity.Id("dev.miren.core/component.config_spec.variables.key")
+	ConfigSpecVariablesOriginId    = entity.Id("dev.miren.core/component.config_spec.variables.origin")
+	ConfigSpecVariablesSensitiveId = entity.Id("dev.miren.core/component.config_spec.variables.sensitive")
+	ConfigSpecVariablesSourceId    = entity.Id("dev.miren.core/component.config_spec.variables.source")
+	ConfigSpecVariablesValueId     = entity.Id("dev.miren.core/component.config_spec.variables.value")
+)
+
+type ConfigSpecVariables struct {
+	Key       string `cbor:"key,omitempty" json:"key,omitempty"`
+	Origin    string `cbor:"origin,omitempty" json:"origin,omitempty"`
+	Sensitive bool   `cbor:"sensitive,omitempty" json:"sensitive,omitempty"`
+	Source    string `cbor:"source,omitempty" json:"source,omitempty"`
+	Value     string `cbor:"value,omitempty" json:"value,omitempty"`
+}
+
+func (o *ConfigSpecVariables) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(ConfigSpecVariablesKeyId); ok && a.Value.Kind() == entity.KindString {
+		o.Key = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecVariablesOriginId); ok && a.Value.Kind() == entity.KindString {
+		o.Origin = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecVariablesSensitiveId); ok && a.Value.Kind() == entity.KindBool {
+		o.Sensitive = a.Value.Bool()
+	}
+	if a, ok := e.Get(ConfigSpecVariablesSourceId); ok && a.Value.Kind() == entity.KindString {
+		o.Source = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecVariablesValueId); ok && a.Value.Kind() == entity.KindString {
+		o.Value = a.Value.String()
+	}
+}
+
+func (o *ConfigSpecVariables) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Key) {
+		attrs = append(attrs, entity.String(ConfigSpecVariablesKeyId, o.Key))
+	}
+	if !entity.Empty(o.Origin) {
+		attrs = append(attrs, entity.String(ConfigSpecVariablesOriginId, o.Origin))
+	}
+	attrs = append(attrs, entity.Bool(ConfigSpecVariablesSensitiveId, o.Sensitive))
+	if !entity.Empty(o.Source) {
+		attrs = append(attrs, entity.String(ConfigSpecVariablesSourceId, o.Source))
+	}
+	if !entity.Empty(o.Value) {
+		attrs = append(attrs, entity.String(ConfigSpecVariablesValueId, o.Value))
+	}
+	return
+}
+
+func (o *ConfigSpecVariables) Empty() bool {
+	if !entity.Empty(o.Key) {
+		return false
+	}
+	if !entity.Empty(o.Origin) {
+		return false
+	}
+	if !entity.Empty(o.Sensitive) {
+		return false
+	}
+	if !entity.Empty(o.Source) {
+		return false
+	}
+	if !entity.Empty(o.Value) {
+		return false
+	}
+	return true
+}
+
+func (o *ConfigSpecVariables) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("key", "dev.miren.core/component.config_spec.variables.key", schema.Doc("The name of the variable"))
+	sb.String("origin", "dev.miren.core/component.config_spec.variables.origin", schema.Doc("The provenance of the variable (user, file, generated, detected)."))
+	sb.Bool("sensitive", "dev.miren.core/component.config_spec.variables.sensitive", schema.Doc("Whether or not the value is sensitive"))
+	sb.String("source", "dev.miren.core/component.config_spec.variables.source", schema.Doc("The source of the variable (config or manual). Defaults to config for backward compatibility."))
+	sb.String("value", "dev.miren.core/component.config_spec.variables.value", schema.Doc("The value of the variable"))
+}
+
+const (
 	AppActiveVersionId = entity.Id("dev.miren.core/app.active_version")
+	AppInitialConfigId = entity.Id("dev.miren.core/app.initial_config")
 	AppProjectId       = entity.Id("dev.miren.core/app.project")
 )
 
 type App struct {
 	ID            entity.Id `json:"id"`
 	ActiveVersion entity.Id `cbor:"active_version,omitempty" json:"active_version,omitempty"`
+	InitialConfig entity.Id `cbor:"initial_config,omitempty" json:"initial_config,omitempty"`
 	Project       entity.Id `cbor:"project,omitempty" json:"project,omitempty"`
 }
 
@@ -21,6 +566,9 @@ func (o *App) Decode(e entity.AttrGetter) {
 	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
 	if a, ok := e.Get(AppActiveVersionId); ok && a.Value.Kind() == entity.KindId {
 		o.ActiveVersion = a.Value.Id()
+	}
+	if a, ok := e.Get(AppInitialConfigId); ok && a.Value.Kind() == entity.KindId {
+		o.InitialConfig = a.Value.Id()
 	}
 	if a, ok := e.Get(AppProjectId); ok && a.Value.Kind() == entity.KindId {
 		o.Project = a.Value.Id()
@@ -47,6 +595,9 @@ func (o *App) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.ActiveVersion) {
 		attrs = append(attrs, entity.Ref(AppActiveVersionId, o.ActiveVersion))
 	}
+	if !entity.Empty(o.InitialConfig) {
+		attrs = append(attrs, entity.Ref(AppInitialConfigId, o.InitialConfig))
+	}
 	if !entity.Empty(o.Project) {
 		attrs = append(attrs, entity.Ref(AppProjectId, o.Project))
 	}
@@ -58,6 +609,9 @@ func (o *App) Empty() bool {
 	if !entity.Empty(o.ActiveVersion) {
 		return false
 	}
+	if !entity.Empty(o.InitialConfig) {
+		return false
+	}
 	if !entity.Empty(o.Project) {
 		return false
 	}
@@ -66,6 +620,7 @@ func (o *App) Empty() bool {
 
 func (o *App) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Ref("active_version", "dev.miren.core/app.active_version", schema.Doc("The version of the project that should be used"))
+	sb.Ref("initial_config", "dev.miren.core/app.initial_config", schema.Doc("Reference to the initial ConfigVersion entity created before the first deploy"))
 	sb.Ref("project", "dev.miren.core/app.project", schema.Doc("The project that the app belongs to"))
 }
 
@@ -74,6 +629,7 @@ const (
 	AppVersionAppId            = entity.Id("dev.miren.core/app_version.app")
 	AppVersionArtifactId       = entity.Id("dev.miren.core/app_version.artifact")
 	AppVersionConfigId         = entity.Id("dev.miren.core/app_version.config")
+	AppVersionConfigVersionId  = entity.Id("dev.miren.core/app_version.config_version")
 	AppVersionImageUrlId       = entity.Id("dev.miren.core/app_version.image_url")
 	AppVersionManifestId       = entity.Id("dev.miren.core/app_version.manifest")
 	AppVersionManifestDigestId = entity.Id("dev.miren.core/app_version.manifest_digest")
@@ -86,6 +642,7 @@ type AppVersion struct {
 	App            entity.Id `cbor:"app,omitempty" json:"app,omitempty"`
 	Artifact       entity.Id `cbor:"artifact,omitempty" json:"artifact,omitempty"`
 	Config         Config    `cbor:"config,omitempty" json:"config,omitempty"`
+	ConfigVersion  entity.Id `cbor:"config_version,omitempty" json:"config_version,omitempty"`
 	ImageUrl       string    `cbor:"image_url,omitempty" json:"image_url,omitempty"`
 	Manifest       string    `cbor:"manifest,omitempty" json:"manifest,omitempty"`
 	ManifestDigest string    `cbor:"manifest_digest,omitempty" json:"manifest_digest,omitempty"`
@@ -105,6 +662,9 @@ func (o *AppVersion) Decode(e entity.AttrGetter) {
 	}
 	if a, ok := e.Get(AppVersionConfigId); ok && a.Value.Kind() == entity.KindComponent {
 		o.Config.Decode(a.Value.Component())
+	}
+	if a, ok := e.Get(AppVersionConfigVersionId); ok && a.Value.Kind() == entity.KindId {
+		o.ConfigVersion = a.Value.Id()
 	}
 	if a, ok := e.Get(AppVersionImageUrlId); ok && a.Value.Kind() == entity.KindString {
 		o.ImageUrl = a.Value.String()
@@ -149,6 +709,9 @@ func (o *AppVersion) Encode() (attrs []entity.Attr) {
 	if !o.Config.Empty() {
 		attrs = append(attrs, entity.Component(AppVersionConfigId, o.Config.Encode()))
 	}
+	if !entity.Empty(o.ConfigVersion) {
+		attrs = append(attrs, entity.Ref(AppVersionConfigVersionId, o.ConfigVersion))
+	}
 	if !entity.Empty(o.ImageUrl) {
 		attrs = append(attrs, entity.String(AppVersionImageUrlId, o.ImageUrl))
 	}
@@ -178,6 +741,9 @@ func (o *AppVersion) Empty() bool {
 	if !o.Config.Empty() {
 		return false
 	}
+	if !entity.Empty(o.ConfigVersion) {
+		return false
+	}
 	if !entity.Empty(o.ImageUrl) {
 		return false
 	}
@@ -199,6 +765,7 @@ func (o *AppVersion) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Ref("artifact", "dev.miren.core/app_version.artifact", schema.Doc("The artifact to deploy for the version"))
 	sb.Component("config", "dev.miren.core/app_version.config", schema.Doc("The configuration of the version"))
 	(&Config{}).InitSchema(sb.Builder("app_version.config"))
+	sb.Ref("config_version", "dev.miren.core/app_version.config_version", schema.Doc("Reference to the ConfigVersion entity containing the resolved configuration for this version"))
 	sb.String("image_url", "dev.miren.core/app_version.image_url", schema.Doc("The OCI url for the versions code"))
 	sb.String("manifest", "dev.miren.core/app_version.manifest", schema.Doc("The OCI image manifest for the version"))
 	sb.String("manifest_digest", "dev.miren.core/app_version.manifest_digest", schema.Doc("The digest of the manifest"), schema.Indexed)
@@ -575,6 +1142,7 @@ func (o *Disks) InitSchema(sb *schema.SchemaBuilder) {
 
 const (
 	EnvKeyId       = entity.Id("dev.miren.core/env.key")
+	EnvOriginId    = entity.Id("dev.miren.core/env.origin")
 	EnvSensitiveId = entity.Id("dev.miren.core/env.sensitive")
 	EnvSourceId    = entity.Id("dev.miren.core/env.source")
 	EnvValueId     = entity.Id("dev.miren.core/env.value")
@@ -582,6 +1150,7 @@ const (
 
 type Env struct {
 	Key       string `cbor:"key,omitempty" json:"key,omitempty"`
+	Origin    string `cbor:"origin,omitempty" json:"origin,omitempty"`
 	Sensitive bool   `cbor:"sensitive,omitempty" json:"sensitive,omitempty"`
 	Source    string `cbor:"source,omitempty" json:"source,omitempty"`
 	Value     string `cbor:"value,omitempty" json:"value,omitempty"`
@@ -590,6 +1159,9 @@ type Env struct {
 func (o *Env) Decode(e entity.AttrGetter) {
 	if a, ok := e.Get(EnvKeyId); ok && a.Value.Kind() == entity.KindString {
 		o.Key = a.Value.String()
+	}
+	if a, ok := e.Get(EnvOriginId); ok && a.Value.Kind() == entity.KindString {
+		o.Origin = a.Value.String()
 	}
 	if a, ok := e.Get(EnvSensitiveId); ok && a.Value.Kind() == entity.KindBool {
 		o.Sensitive = a.Value.Bool()
@@ -606,6 +1178,9 @@ func (o *Env) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.Key) {
 		attrs = append(attrs, entity.String(EnvKeyId, o.Key))
 	}
+	if !entity.Empty(o.Origin) {
+		attrs = append(attrs, entity.String(EnvOriginId, o.Origin))
+	}
 	attrs = append(attrs, entity.Bool(EnvSensitiveId, o.Sensitive))
 	if !entity.Empty(o.Source) {
 		attrs = append(attrs, entity.String(EnvSourceId, o.Source))
@@ -618,6 +1193,9 @@ func (o *Env) Encode() (attrs []entity.Attr) {
 
 func (o *Env) Empty() bool {
 	if !entity.Empty(o.Key) {
+		return false
+	}
+	if !entity.Empty(o.Origin) {
 		return false
 	}
 	if !entity.Empty(o.Sensitive) {
@@ -634,6 +1212,7 @@ func (o *Env) Empty() bool {
 
 func (o *Env) InitSchema(sb *schema.SchemaBuilder) {
 	sb.String("key", "dev.miren.core/env.key", schema.Doc("The name of the variable"))
+	sb.String("origin", "dev.miren.core/env.origin", schema.Doc("The provenance of the variable (user, file, generated, detected)."))
 	sb.Bool("sensitive", "dev.miren.core/env.sensitive", schema.Doc("Whether or not the value is sensitive"))
 	sb.String("source", "dev.miren.core/env.source", schema.Doc("The source of the variable (config or manual). Defaults to config for backward compatibility."))
 	sb.String("value", "dev.miren.core/env.value", schema.Doc("The value of the variable"))
@@ -721,6 +1300,7 @@ func (o *ServiceConcurrency) InitSchema(sb *schema.SchemaBuilder) {
 
 const (
 	VariableKeyId       = entity.Id("dev.miren.core/variable.key")
+	VariableOriginId    = entity.Id("dev.miren.core/variable.origin")
 	VariableSensitiveId = entity.Id("dev.miren.core/variable.sensitive")
 	VariableSourceId    = entity.Id("dev.miren.core/variable.source")
 	VariableValueId     = entity.Id("dev.miren.core/variable.value")
@@ -728,6 +1308,7 @@ const (
 
 type Variable struct {
 	Key       string `cbor:"key,omitempty" json:"key,omitempty"`
+	Origin    string `cbor:"origin,omitempty" json:"origin,omitempty"`
 	Sensitive bool   `cbor:"sensitive,omitempty" json:"sensitive,omitempty"`
 	Source    string `cbor:"source,omitempty" json:"source,omitempty"`
 	Value     string `cbor:"value,omitempty" json:"value,omitempty"`
@@ -736,6 +1317,9 @@ type Variable struct {
 func (o *Variable) Decode(e entity.AttrGetter) {
 	if a, ok := e.Get(VariableKeyId); ok && a.Value.Kind() == entity.KindString {
 		o.Key = a.Value.String()
+	}
+	if a, ok := e.Get(VariableOriginId); ok && a.Value.Kind() == entity.KindString {
+		o.Origin = a.Value.String()
 	}
 	if a, ok := e.Get(VariableSensitiveId); ok && a.Value.Kind() == entity.KindBool {
 		o.Sensitive = a.Value.Bool()
@@ -752,6 +1336,9 @@ func (o *Variable) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.Key) {
 		attrs = append(attrs, entity.String(VariableKeyId, o.Key))
 	}
+	if !entity.Empty(o.Origin) {
+		attrs = append(attrs, entity.String(VariableOriginId, o.Origin))
+	}
 	attrs = append(attrs, entity.Bool(VariableSensitiveId, o.Sensitive))
 	if !entity.Empty(o.Source) {
 		attrs = append(attrs, entity.String(VariableSourceId, o.Source))
@@ -764,6 +1351,9 @@ func (o *Variable) Encode() (attrs []entity.Attr) {
 
 func (o *Variable) Empty() bool {
 	if !entity.Empty(o.Key) {
+		return false
+	}
+	if !entity.Empty(o.Origin) {
 		return false
 	}
 	if !entity.Empty(o.Sensitive) {
@@ -780,6 +1370,7 @@ func (o *Variable) Empty() bool {
 
 func (o *Variable) InitSchema(sb *schema.SchemaBuilder) {
 	sb.String("key", "dev.miren.core/variable.key", schema.Doc("The name of the variable"))
+	sb.String("origin", "dev.miren.core/variable.origin", schema.Doc("The provenance of the variable (user, file, generated, detected)."))
 	sb.Bool("sensitive", "dev.miren.core/variable.sensitive", schema.Doc("Whether or not the value is sensitive"))
 	sb.String("source", "dev.miren.core/variable.source", schema.Doc("The source of the variable (config or manual). Defaults to config for backward compatibility."))
 	sb.String("value", "dev.miren.core/variable.value", schema.Doc("The value of the value"))
@@ -884,6 +1475,69 @@ func (o *Artifact) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Singleton("dev.miren.core/status.active")
 	sb.Singleton("dev.miren.core/status.archived")
 	sb.Ref("status", "dev.miren.core/artifact.status", schema.Doc("Artifact lifecycle status"), schema.Indexed, schema.Choices(ArtifactStatusActiveId, ArtifactStatusArchivedId))
+}
+
+const (
+	ConfigVersionAppId  = entity.Id("dev.miren.core/config_version.app")
+	ConfigVersionSpecId = entity.Id("dev.miren.core/config_version.spec")
+)
+
+type ConfigVersion struct {
+	ID   entity.Id  `json:"id"`
+	App  entity.Id  `cbor:"app,omitempty" json:"app,omitempty"`
+	Spec ConfigSpec `cbor:"spec,omitempty" json:"spec,omitempty"`
+}
+
+func (o *ConfigVersion) Decode(e entity.AttrGetter) {
+	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(ConfigVersionAppId); ok && a.Value.Kind() == entity.KindId {
+		o.App = a.Value.Id()
+	}
+	if a, ok := e.Get(ConfigVersionSpecId); ok && a.Value.Kind() == entity.KindComponent {
+		o.Spec.Decode(a.Value.Component())
+	}
+}
+
+func (o *ConfigVersion) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindConfigVersion)
+}
+
+func (o *ConfigVersion) ShortKind() string {
+	return "config_version"
+}
+
+func (o *ConfigVersion) Kind() entity.Id {
+	return KindConfigVersion
+}
+
+func (o *ConfigVersion) EntityId() entity.Id {
+	return o.ID
+}
+
+func (o *ConfigVersion) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.App) {
+		attrs = append(attrs, entity.Ref(ConfigVersionAppId, o.App))
+	}
+	if !o.Spec.Empty() {
+		attrs = append(attrs, entity.Component(ConfigVersionSpecId, o.Spec.Encode()))
+	}
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindConfigVersion))
+	return
+}
+
+func (o *ConfigVersion) Empty() bool {
+	if !entity.Empty(o.App) {
+		return false
+	}
+	if !o.Spec.Empty() {
+		return false
+	}
+	return true
+}
+
+func (o *ConfigVersion) InitSchema(sb *schema.SchemaBuilder) {
+	sb.Ref("app", "dev.miren.core/config_version.app", schema.Doc("The application this config version belongs to"), schema.Indexed, schema.Tags("dev.miren.app_ref"))
+	sb.Component("spec", "dev.miren.core/config_version.spec", schema.Doc("The configuration specification"))
 }
 
 const (
@@ -1382,23 +2036,26 @@ func (o *Project) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 var (
-	KindApp        = entity.Id("dev.miren.core/kind.app")
-	KindAppVersion = entity.Id("dev.miren.core/kind.app_version")
-	KindArtifact   = entity.Id("dev.miren.core/kind.artifact")
-	KindDeployment = entity.Id("dev.miren.core/kind.deployment")
-	KindMetadata   = entity.Id("dev.miren.core/kind.metadata")
-	KindProject    = entity.Id("dev.miren.core/kind.project")
-	Schema         = entity.Id("dev.miren.core/schema.v1alpha")
+	KindApp           = entity.Id("dev.miren.core/kind.app")
+	KindAppVersion    = entity.Id("dev.miren.core/kind.app_version")
+	KindArtifact      = entity.Id("dev.miren.core/kind.artifact")
+	KindConfigVersion = entity.Id("dev.miren.core/kind.config_version")
+	KindDeployment    = entity.Id("dev.miren.core/kind.deployment")
+	KindMetadata      = entity.Id("dev.miren.core/kind.metadata")
+	KindProject       = entity.Id("dev.miren.core/kind.project")
+	Schema            = entity.Id("dev.miren.core/schema.v1alpha")
 )
 
 func init() {
 	schema.Register("dev.miren.core", "v1alpha", func(sb *schema.SchemaBuilder) {
+		(&ConfigSpec{}).InitSchema(sb)
 		(&App{}).InitSchema(sb)
 		(&AppVersion{}).InitSchema(sb)
 		(&Artifact{}).InitSchema(sb)
+		(&ConfigVersion{}).InitSchema(sb)
 		(&Deployment{}).InitSchema(sb)
 		(&Metadata{}).InitSchema(sb)
 		(&Project{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.core", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\xa4Y˲\xe3&\x13~\x8d\xff\xcf=\x93\xfb\xa4J\x99T6Y\xe5U(,\xda\x12\xc7\x12h\x00\xf9\x8c\xb3˵\x92\xca[d.o\x98\xacSЀ\x11F\x12\xe7\xcc\xc6E\xb7\xdc\x1f\xd07\xba\xe1\x15\x13t\x04\xc1\xe0܌\\\x81hZ\xa9\x00N\\0\xfd\xe6~\xc9\xfd\xc6r\x1b:Mo\x9c\x8cʾ\xd2iB\xb9\x7f\x8fL\x8e\x94\x8b\f\xf4x\xe400\xfd\xf3\xcb\x03g/>\xbe\x15nhk\xf8\x19\xc8\x19\x94\xe6R\xe0\xba2\x9e\xb9Lp\xe0\xccA\xbcS\x80\x98\x94\xbc\x83\xd68\xd9.\x10^\xa8\xf3 \xdd\xf9[:L=\x1d&\xc5G\xaa.\xc4.\xba\xa5\xd3\xf4\xe2\xdd\xd2~=\n\xee\xf9\x9c\xfd\xc3\x7f\xac\xd9\xf7On\xd1\xef\x95\x01\x1ay/@\xb9)\x00\x87v\xd1Gm\x14\x17\xdd\xe6\xc2\xc3.o\x90\xd1X\xca\xf0#\r\xab\xcf\xed\x19\xbe\xd6,\xffW\xb7\xfc\\C\x01\xc1z\x85\x9b\xc2\xeaqa\xa5\x8f\xd6$F*\xf8\x114ڪ\x8fT\xb2o'\xffŞ<a\xbc\v02g&h\xaf,\xda\akh\xdaP3k\ar\xf4c+\xcb@\xcc\xe3\xc9\xfe\x903\x1df\xd0\x7f\x1f\xd1#oԍBއ{\xaaڞ\x9f\xe1v\xc2\xf07\xff}Ӵ}X]ٶ#\x18ʨ\xa1eۆ\xaf5\xb6\xfd\xa5\xa8\x9b\x80\xd0\f\xf4\x00\x83f#\x15\x97\x7fPC\x9ec5\x04n\\\xf4\xed\b`e\xd8\xf5'7\xf1\x87kr\x8f\x8e\xe6>@\xdcl\xcai\x8e\xc14\xc8\xcb\b\xc2\xc7ŋ\xffg\xff\xba\xfe\xa1F}\x7f\xb9]<YŰ\xc1A\xe2\xf6\xfbH\xe5z\xf8l\x1b!͋\xa7\x94\x91\xe3|\xba\x8es\x98\xf9\xc0\xc8 ;t\xf5\xbb\x84~\x00J;\xccڀ\"\x9c!JB\xe7(\x9fo\xa0\xc8q\x1a\xc0\x00#\x14M<,8y\xe8nh\a\x87\xc0\xc8\xe1\x82\xdaI\x19\x16\x87[d)@\x98\xebț>\x83mʰ\xf5\x19\xb2\xac6\a\xd2\x18>\x826t\xc4Tɯd\x9d' ȬA\x11\x18)\x1fP\xf9\t\x9dÔ]2\x81\xf1\x06\xec\x02Q\xe7\x03\t@\xf4j~%kO\xae\xbb\x80v\xb8\x143}b\tPJ*2\x82ִ\xc3\xf9\xc6%+w\x96\x8d`\xec\xb8!\\\x1c%\x06c\xa4v\xdc\xe4ɺ\x9b\x04\x88\x1a\x1f\xf9\xf3e)\xd3\x06\x84\x86Φ\x97X\x06\x1c\xfd87ɪ\xecAQ\xd1\xf6(\xebǹ\xec\xd7k\xb2\xad\x1cGn\bN\x998\x97.}\xc8Q\xbf\xdcA]z\xfdt\xc3\xcd\xf1\xf2\x8a!\xe2qM\x18W\x06c\xbc\x8f\x94;\xa7\x0fR\x0e\xc5\xc3$J\xa7\xde\xd3\x15\xfc\xa6\x181QZ\xc1$57R\xe1\xecw\t\x9dc\xe45R\xc4\xd0=\xc5\x1a\xc9\x0er\xa9\xaf֤\xee\xa5:q\xd1\x11\xa3\x00HO5\x9a\xf8\xf9-\xbb\xbab츱\xc8Eu%~=\xf5T\xa3\xba\x00\x87\xf9\x92\x9buY-g\xd5\x02\xb9rB\xaa1\xc5/{.\x90\"\x97\v\xb5\a$\x1c\vs\xb3\xef\xd0ڄCՇ}\xa1\xc7\b\xff\xa8\t\xf7?\x8ag`\x02\xd2P6rA\x8c<A8\xd8\x13\xc6^\xec/\x80\xd6\n\xf0O\xb6\x84|\x81\xe9\v\x93@y\xf1W+\x8dZ\x14o\xa58\xf2\x0em\xe1\xc7;i4Ckn\xd1j\xd4\xfa\xfb\xeb\x926P\xdee\x1d*XZ\xaf\xf6\x91\xb7\xb3\xbc\xa7\xbbˋ\xf0\xf5\xadn\xeej\x01!@aF\n\xc4^q\x1c\xa55\xa83o}>\vDm(D\x8d\x14\xc3\xcdo\x15\x84Q\x97Ir\x81\xfeq\x97\xd0\xf9*\xf38\xf1\b\x93T(\xcb\xdc\xc8J\xb5\\\x98-\xf3\xf9\x9d,\xcc\x17yoo\xbe\x00U\x15\xbdn\x9d\xef\xe7\x1d\x9cGh\x18קt\x99\x80\x8c\x9d5>\xab_#\xceP\x15\x10\xe5\\nś#\x1f@_\xb4\x81\x11\xad\x98л\xf5\xa2\x03\x18\x80jp絜њ㒵\xe7\xb2\b3\xcaY\x182Q\x83\a\xd8]B\xe7\x007\xed\x98\x03\xd8\xe9\"s\x7fB!\x05\x94\x11)\x06<\xb6\xf9\x95\\V\ry\xeb\x8a\u009a\xff\b\xa4;\xf8\x10\xf3Dp\xe2\xcd\xf8B_x]*\a\xa2uA\x9c\x13\xefi-\xb9\xe3;\xcd\x03|\aĹ\xbai\xc9o\xb5@\x9c\x9b\x13\xa0\xcaZ;\xc8u\x9d\xab\xcb\nh\x10\x9a\x1b~\xf6\xfd\xc0\x95\\j:\xb7\xad\x13u5\x81?\xd3q\x9c\xcf\xf8\xbf\x82\x98\xbb\x91\xc1\xd0\xc3am\xf6\xb3\xba~\xb9\x19\xdb|\f\xa5\"\xe0pO\x03Qr\xc7KW\xe5VRe\xf1\xb2t!\x94\xf4`W2\x9fv\x1b\xc1Y\xe8\x8a\xe0ȼ\xa3\xca{\x87\x88\xe0\a\xa4\x95\xa2\x9d\x95\x02Ѣ\xe3\xe8҇\x1d\a\xff\xe1\x01\x0e^\x80\xafq\xf8ߊ\xbdf\x01\xac\x19%\xf3Ft\xa3\\\xa5\xcf* \xc4<\x12.\xb4\xa1\u009e^.u.Y\v3\x7f_\x81\xa8\xe0\xf9\f\xdah2َ\xdd\xe38\xe4\xb9\xfci1\xc3w\x153\xe8\x96\x0e@\x98\xbc\x17\x84\xc1@ј\xd3\r7WG\x15t?\x1b\a\x91\x1e&\xd3\r\xb76\x8c\x95\x9f#\x99b\xbb\xe8\t\xbeS\xbcc\t\xfee\xa82\xb6\xb3\x846v{2g&+ܪe\xceTqz\x18 \xade\"\xef\xedk\x99\x00\xf5\xf8\xeb\xfb\x80\xb0\x9d\xed\xf3\xe4\x11\xa5*S~\xae\x9d\xab\xfc~\xde\xcf3t\x94}t\xf2\x8f\x16\xd8\xfc\x97\xefg\x8a\xb7`\xa9)\xdc\xe9@f\x85\xf7%\xfcJ\xe6\x1b\xd9j\xc3*\x9fB\x9eV@Ծ\x86\x14\xeb\xbd\x140\xbdm\xee\n7͛\xdaK\xaf\xa7\xf3?\x9eto\x0f\x19|a\xb4\xdd\xea\xda+c|\xd9\xdaz\x96\xdby#\t_\xaf\x0f\x02\x9bO)\xe9\r\xc1\xce\xcbA\xba\xc5\xddۄ\xff\x00\x00\x00\xff\xff\x01\x00\x00\xff\xff5J5ke\x1d\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.core", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\xacZ\xdb\xce\xdc4\x10~\rN\xe5P\xceE\xa4-\x05A\x85\xa8\xc4\x15\x127<B\xe4Mf\x13\xff\x9bة\xed\xec\xff/w\x1c\x05\xe2-h\vO\b\xd7(>$\xce\xc4I\x9c\xfcܬl'\xf3y<'\xcf\xcc\xe6y\xceH\r,\x87sRS\x01,ɸ\x008Q\x96˿\xafǫ\xf7\xbbՄ4\xcd_\x9aF\xa0\xa7\xa4i\fݿǜׄ2\x04z<R\xa8r\xf9ӳ\x03\xcdoޚ\x12'$S\xf4\f\xe9\x19\x84\xa4\x9c\x19\xbeК\xba4p\xa0\xf9,\x04eTQR\xa5\x19gGZ\x18\b\xb4\xe6C\xbc\x12\x80h\x04\xbf\x82Li\xda\xc2M,Qa\xf9(\xce\x0fIՔ\xa4j\x04\xad\x89\xb8\xa4ݹ3\xd247\xaf\x86DfQ\x8c\xd8\xce\xe8\r\xfb0Ft?h\xa6_\v\x03$\xfc\x9a\x81\xd0[\x80\x19vL\x1f\xa5\x12\x94\x15\x8b\x8c\xbbSN\x90\x8d\xbe\x85\xa2G\xe2\xb8\xc7&\xe1\x9eư\xff\xb3f\x1fK\xc8!t\x86\xa5\xb7\xe8\xe48\xd2қs\x145a\xf4\b\xd2\xe8\xaa\xecg\u07b95\xfd\xfbk\xf4iN\v\a\xc3\xf1\xa2\x87\xf6\xbcC{}\x0eM*\xa2Z\xa9A\x8ev\xdc\xd1\xe6\xc0\xda\xfa\xd4\xfd\xa4gR\xb5 \xff<\x1a\xa3\x9e\x88\xdb\x10Y7(\x89\xc8Jz\x86\xe9\x86\xee5\xfb|Q\xb5\xa5\xe3.\xac\xdb\x1a\x14ɉ\"aݺ\xa7Q^\x1d\x94\x8dCH*r\x80J\xe65a\x97\x7f\x8c\x84\xecJ'!\xd0\xe3\xa0m\xf7\x00\x1dM>\xfc`\x15\xbf1G\xb7ۛK\a19\x94\x96\\\x0eM\xc5/50\xeb\x177/\xa3\xb7\x86\x17b\xc4\xf7\x87>\xc5\xddY\x8c\xce9\xd2\xfe\xf8e?\xc3rxw\x19\xc1\x0f\xad'\x7f\x01\xe3\xbc3\x8fshi\x95\xa7\x15/\x8c\xa9_y\xf3\r(Y\xd5J\x05\"\xa5\xb9A\xf1\xe6\x18\xe5\xbd\x05\x14^7\x15(\xc8SbT\\\x8dV\xb0\xeb.H\xc7\f!O\x0f\x17#\x1d\x7f\xa1á\x1d2g\xc0\xd40\xb2\xaaG\xb0I\x186>B\x86ŦA\x12Ek\x90\x8a\xd4&T\xd2a\x1ag\t\x06\xa4\x95 R\xa8\t\xad\x8c\xf0\xbd9\x86\t\x9b\xa4\ac\x15X\xb8I\x9c\rx\x00\xbdU\xd3a\x1a{s]9\xb4\xc3%\x18\xe9=M\x80\x10\\\xa45HI\n\xb3_=^\xc2Ʋ\xe0\x8c\x05U)eGn\x9c\xb1\x9f\xad\x98\xc9\xddy3q\x1016\xf2\xfb\xb3P\xa4u\b\tiU\xc9M\x1ap\xb4c\xac\x92Yڃ ,+\r\xad\x1dcڏ\xe6h3^\xd7T\xa5fKϸd\xe8\x01F\xfd`\x05ul\xf5\xcdd\x15\xe3ጡǣ2ͩP\xc6\xc7\xcb~\xa6\xef\xe9\x03\xe7U\xf02\xe9\xa9}\xeb)\x02v\x13\xf4\x98\x9eZ@\xc3%U\\\x98ݯ\xbc9\xc6\xc09R\x8f!Kbr\xa4n\x80\xa9>\x9c\xa3\xba\xe6\xe2DY\x91*\x01\x90\x96D\x1a\x15?\x9d.Gg\x8c\x05U\x1drP\\\x9e]7%\x91F\\`\x86\x98\xe5d\x9eV\xf2Vd\x90\x0e+.Ԩ\xe0\x935\x13\xf0\x91Éچ\x80\xd3\xc1L\xce\xed\xaa#w\xa9Z\xb7\x0f\xd4\x18\xee\x8dxw\xc7w\xa0\a\x92\x90\xbc\xa6,U\xfc\x04\xeeb\xf7\x16\xd6|\x7f\x044\x97\x80\xbf\xbdDd\x13L\x9b\x98\xb8\x99%\x7f>S\xa8\xf5\xe4^\xa1v\xf4\n\xb4\x850\x8aВ)Z\x8cX\x7f}\x11\x92\x86\xa1\xd7Q\x87\xb0\xdc\xcfW\xcb~m\x85\xbd{\xab\xec\xf5\xf01|\xfe\x18t1\x87\xe0\xa0LDr\x93\xb5丧\x96 \xce4\xb3\xf1\xccMb]\xa1\x97H\xd0\xdd\xecQ\x81)qi8e\xc6>\xae\xbc9\xe6\x12\xfb\x89Eh\xb80\xb4\xb9\x1euT\x19ejI}\xf6$#\xf5\xf5k\xb7W\x9f\x83\x8aQ\xdfo\x9a\xcf;\xb8\x82\xb3\bIN\xe5\xc9g\x13\xcc\xc2\n\x8f\x0f\xe2y4;D9D8\x96w\xe4ɑV /RAm\xb4\xe8\xcdW\xf3E\rP\x01\x91\xa0\xefk\xde\x1am\xd6\xe3\xa55\x93505o\x99J\x1b\xa2\xcc\x05v\xe5\xcd1\xc0\xa4\x1c\xd3\x00+U$\xb6'C$\x80\xe4)g\x95\xb9\xb6\xe90\x1dg\r\xb8t5Ē~\x0fiq\xb0.f'Έ\x17\xfd\xcb\xd8\u008bP:\xd0k\x17\xd8ٳ\x9e\xac\x9b\xae\xd8N\xb2\xc1v\x80\x9dc,\xe7\x97\xee\xf8\xb8\xab\x05윜\xc0\x88,\xeb\x06k\n\xea\b\xb8\xa0\x055\x97\xd8ю1\x19\x96rG&\x81I\xaa\xe8ٖ\x11\xc3t\xac\xa0Ў&\x95\xb0\xa9\x80\x19\xe3\x1d_\n\x90\xe9F\x8e\xf1X3\x8c\r\x9a\x9d\x8a\x9e-\x86\x04Z\xbb\f\x13\xccpM\x02=\xe5\x8aq\xcf\xd2\xcdD\xd8`\x8fuD\xe4\x95n\xc3\x14o\xbb\x8c\xa054 \xe8).\xc4p\xc9\xd1#\xd8A\x9aq\x96\xb5B\x00ˌ\xbd\xc9Ѓ\x15\xbfx\xb2\xc1/\x02\xf0\xd1~2)Q\x03`I\xcds\xabD=\xc2\"}\x10\x01\xc1\xda:\xa5L*ºKOG\xdc\xf1\xd2H\xcd_D \nxڂT2m\xbaB\xdf\xe2h\xe46\xfch\xb4ã\x88\x1ddF*Hs~\xcd\xd2\x1c*b\x94\xd9LV\xb18\xa2\xa0\xcbVi\b\xff\x0ej&\xab\xb1n,\xec\x1e\xde\x16˹\x92\xb3\x9d`k\xc6ٗ\"Bu\x05)d}\x91\xc8\xf1\xa2\xc7\xe1R\nt&\x82\x92C\x05~\nԯ\xdd>\x05rP\xf1f\x8f\xaf0\x87\xb0|I\xe0\xd3\xf5T\x117\x05\x0e<=m\xe4u1\xbbwĝ\x81\xa3{O\xbb\xfb\xe2起\xf8\x96-\xa1\x82݀\xa9\x1a\xc7\xff\xb4\xa15\xbf\xfe\xc3=<\x1fJ_Ri+L\xb7\x87\x0eS,\x93\xa5\"2\xf2\x8f\x9c{\x11\x10\xb1\xff\xe5\x04\xb3U\x1f\xd0\x17N\x11\xe8\x93/*\xc2o\xaeOvэ\x82\xb1\xb8\xad\xeba\xbb\x19\xbf\x14_/b\xdb\x1f\xe3\x04\v\xfd`\xcf\x13\xd1\xc9\x062s/\xe9\xd1J\x1c\xc1V\xd3?wg\xef@\xe2\xbb\xe2\xf7c\xe0\"\vN\x1d:?\x8e\x02\xbcM1\x89vH\x96w\x88\xef\x06}\xb6\x89\xf3\xd5&\x81V\xfd㭘\xe3\x9c\xeb\xb4!\xd7z\xbcI,ɮ4\xeb\xc9\xee\xe3\xace_\xdf\xecGޖ\x94}\xb7\x7f\xa3\xdb\xe5j\xdf\xee\xdfxg\nw\x9b\x1d\xff\xdf\xcc\xee\xe6\x8eٱ\xdb\xd0\xed\xe7m\xf7\"\x94p\xaep\xbb\xaf\xc9\xf3h\x9b\x93l\xec\xf3lt\x8f\xcdm\xa0\xaf\xf7\xe0o\xee\x12\xed:ņ&\x12.\x8b\xa2\xf0W\xca\xf0\xaf\xf6`F\xb6\xa0\xbe܃\xbd\xbfCu=u\x95\xa1g\xf5p\x1b/\xdb;Y\x0f\xb79Ȗf\xd6\xd6\vv\xb5ٵѐ\"{a\x1bս\xa1U\xb6\x83߈\xaa\xe8\xf3\xed\xa8\xbb\xeb\xa5vj\x9b\xae\xf5\xb61|\xaf6\xe4>ن\xb7\x12\x1f6\xa2-5\xef6\xca;\xba\xa5\xb7\aw\xa5ѷ\xdcm\x99\xeaR\xf3\xf1i\x1c\x1f{\xda*\xf8\x7f\xe90\xb4\xab\xc9\xfd\u06dd\x0e\x8b\x1b[\xf1+{\xc4G\xaf8\x13ꁗCW\\(\x1c\xc0\"\xe2V\\t\x19 #\x83\xd6VN#\"V\x9c\x85\r\x90\xbbÕ\x1cL\xbcG[n0x\f,\xbe\x88\xfa:\xf8ݓ,;\x7f4\xdf{g\xa4i\xe6\xbe\xf9\xee?\x12^\xfa\xc2y\xe5sS\xf7t\xf8\xb6r\xf1\xabT\xffc\x8b\x95\x8f0G\xfd\x96\xb5\x0f3\x90Hb\xfa3\xff\x01\x00\x00\xff\xff\x01\x00\x00\xff\xff\x1e/\xde.&/\x00\x00"))
 }

--- a/api/core/migrate.go
+++ b/api/core/migrate.go
@@ -1,0 +1,96 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
+)
+
+// MigrateAppVersionToConfigVersion creates ConfigVersion entities for
+// existing AppVersion entities that still use inline Config (no ConfigVersion).
+// This allows old entities to work after Phase 4 stops writing inline Config.
+func MigrateAppVersionToConfigVersion(ctx context.Context, log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) error {
+	log.Info("migrating app versions to use ConfigVersion entities")
+
+	resp, err := eac.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion))
+	if err != nil {
+		return fmt.Errorf("failed to list app versions for migration: %w", err)
+	}
+
+	migratedCount := 0
+	skippedCount := 0
+
+	for _, e := range resp.Values() {
+		var ver core_v1alpha.AppVersion
+		ver.Decode(e.Entity())
+
+		// Skip versions that already have a ConfigVersion
+		if ver.ConfigVersion != "" {
+			skippedCount++
+			continue
+		}
+
+		// Skip versions with empty config (nothing to migrate)
+		if len(ver.Config.Services) == 0 && len(ver.Config.Variable) == 0 &&
+			len(ver.Config.Commands) == 0 && ver.Config.Port == 0 &&
+			ver.Config.Entrypoint == "" && ver.Config.StartDirectory == "" {
+			skippedCount++
+			continue
+		}
+
+		log.Info("migrating app version to ConfigVersion",
+			"version", ver.ID,
+			"app_version", ver.Version)
+
+		// Convert inline config to ConfigVersion
+		configSpec := ConfigSpecFromConfig(&ver.Config)
+		configVer := &core_v1alpha.ConfigVersion{
+			App:  ver.App,
+			Spec: configSpec,
+		}
+
+		// Create the ConfigVersion entity using the AppVersion's unique ID
+		cvName := ver.ID.String() + "-cfg"
+		var cvEntity entityserver_v1alpha.Entity
+		cvEntity.SetAttrs(entity.New(
+			(&core_v1alpha.Metadata{Name: cvName}).Encode,
+			configVer.Encode,
+			entity.Ident, types.Keyword("config_version/"+cvName),
+		).Attrs())
+
+		pr, err := eac.Put(ctx, &cvEntity)
+		if err != nil {
+			log.Error("failed to create ConfigVersion for app version",
+				"version", ver.ID,
+				"error", err)
+			continue
+		}
+
+		// Update the AppVersion to reference the new ConfigVersion
+		ver.ConfigVersion = entity.Id(pr.Id())
+
+		var verEntity entityserver_v1alpha.Entity
+		verEntity.SetId(ver.ID.String())
+		verEntity.SetAttrs(entity.New(ver.Encode).Attrs())
+
+		if _, err := eac.Put(ctx, &verEntity); err != nil {
+			log.Error("failed to update app version with ConfigVersion",
+				"version", ver.ID,
+				"error", err)
+			continue
+		}
+
+		migratedCount++
+	}
+
+	log.Info("completed app version to ConfigVersion migration",
+		"migrated", migratedCount,
+		"skipped", skippedCount)
+
+	return nil
+}

--- a/api/core/schema.yml
+++ b/api/core/schema.yml
@@ -27,6 +27,10 @@ kinds:
       type: ref
       doc: The version of the project that should be used
 
+    initial_config:
+      type: ref
+      doc: Reference to the initial ConfigVersion entity created before the first deploy
+
   artifact:
     app:
       type: ref
@@ -121,6 +125,9 @@ kinds:
                 source:
                   type: string
                   doc: The source of the variable (config or manual). Defaults to config for backward compatibility.
+                origin:
+                  type: string
+                  doc: The provenance of the variable (user, file, generated, detected).
             service_concurrency:
               type: component
               doc: Concurrency configuration for this service
@@ -197,6 +204,13 @@ kinds:
             source:
               type: string
               doc: The source of the variable (config or manual). Defaults to config for backward compatibility.
+            origin:
+              type: string
+              doc: The provenance of the variable (user, file, generated, detected).
+
+    config_version:
+      type: ref
+      doc: Reference to the ConfigVersion entity containing the resolved configuration for this version
 
     admin_token:
       type: string
@@ -291,4 +305,127 @@ kinds:
           type: string
           doc: Git repository remote URL
 
+  config_version:
+    app:
+      type: ref
+      doc: The application this config version belongs to
+      indexed: true
+      tags: [dev.miren.app_ref]
 
+    spec:
+      type: config_spec
+      doc: The configuration specification
+
+components:
+  config_spec:
+    variables:
+      type: component
+      doc: Environment variables and configuration values
+      many: true
+      attrs:
+        key:
+          type: string
+          doc: The name of the variable
+        value:
+          type: string
+          doc: The value of the variable
+        sensitive:
+          type: bool
+          doc: Whether or not the value is sensitive
+        source:
+          type: string
+          doc: The source of the variable (config or manual). Defaults to config for backward compatibility.
+        origin:
+          type: string
+          doc: The provenance of the variable (user, file, generated, detected).
+    services:
+      type: component
+      doc: Per-service configuration
+      many: true
+      attrs:
+        name:
+          type: string
+          doc: The service name (e.g. web, worker)
+        command:
+          type: string
+          doc: The command to run for the service
+        port:
+          type: int
+          doc: The TCP port the service listens on
+        port_name:
+          type: string
+          doc: The name of the port (e.g. http, grpc)
+        port_type:
+          type: string
+          doc: The type of the port (e.g. http, tcp)
+        image:
+          type: string
+          doc: Optional container image for this service
+        env:
+          type: component
+          doc: Environment variables for this service only
+          many: true
+          attrs:
+            key:
+              type: string
+              doc: The name of the variable
+            value:
+              type: string
+              doc: The value of the variable
+            sensitive:
+              type: bool
+              doc: Whether or not the value is sensitive
+            source:
+              type: string
+              doc: The source of the variable (config or manual). Defaults to config for backward compatibility.
+            origin:
+              type: string
+              doc: The provenance of the variable (user, file, generated, detected)
+        concurrency:
+          type: component
+          doc: Concurrency configuration for this service
+          attrs:
+            mode:
+              type: string
+              doc: The concurrency mode (auto or fixed)
+            requests_per_instance:
+              type: int
+              doc: For auto mode, number of concurrent requests per instance
+            scale_down_delay:
+              type: string
+              doc: For auto mode, delay before scaling down idle instances
+            num_instances:
+              type: int
+              doc: For fixed mode, number of instances to maintain
+            shutdown_timeout:
+              type: string
+              doc: Time to wait for graceful shutdown before force-killing
+        disks:
+          type: component
+          doc: Disk attachments for this service
+          many: true
+          attrs:
+            name:
+              type: string
+              doc: The name of the disk entity to attach
+            mount_path:
+              type: string
+              doc: The path inside the container where the disk will be mounted
+            read_only:
+              type: bool
+              doc: Whether to mount the disk as read-only
+            size_gb:
+              type: int
+              doc: Size in GB for auto-creating the disk if it doesn't exist
+            filesystem:
+              type: string
+              doc: Filesystem type (ext4, xfs, btrfs) for auto-creating the disk
+            lease_timeout:
+              type: string
+              doc: Timeout for acquiring the disk lease
+    entrypoint:
+      type: string
+      doc: The container entrypoint command
+    start_directory:
+      type: string
+      doc: Directory to start the process in (defaults to /app)

--- a/api/entityserver/client.go
+++ b/api/entityserver/client.go
@@ -29,6 +29,11 @@ func NewClient(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *
 	}
 }
 
+// EAC returns the underlying EntityAccessClient.
+func (c *Client) EAC() *entityserver_v1alpha.EntityAccessClient {
+	return c.eac
+}
+
 type SchemaEncoder interface {
 	ShortKind() string
 	Kind() entity.Id

--- a/cli/commands/app_list.go
+++ b/cli/commands/app_list.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/ingress"
@@ -111,12 +112,16 @@ func AppList(ctx *Context, opts struct {
 		return err
 	}
 
-	// Build version map
+	// Build version map and resolved config spec map
 	versionMap := make(map[string]*core_v1alpha.AppVersion)
+	specMap := make(map[string]*core_v1alpha.ConfigSpec)
 	for _, e := range versionsRes.Values() {
 		v := new(core_v1alpha.AppVersion)
 		v.Decode(e.Entity())
 		versionMap[v.ID.String()] = v
+		if resolvedCfg, err := coreutil.ResolveConfig(ctx, eac, v); err == nil {
+			specMap[v.ID.String()] = resolvedCfg
+		}
 	}
 
 	// Build deployment map (most recent deployment per app)
@@ -184,9 +189,9 @@ func AppList(ctx *Context, opts struct {
 		}
 
 		// Check concurrency mode from the app's active version config
-		if version, ok := versionMap[pool.SandboxSpec.Version.String()]; ok {
-			for _, svc := range version.Config.Services {
-				if svc.Name == pool.Service && svc.ServiceConcurrency.Mode == "fixed" {
+		if spec, ok := specMap[pool.SandboxSpec.Version.String()]; ok {
+			for _, svc := range spec.Services {
+				if svc.Name == pool.Service && svc.Concurrency.Mode == "fixed" {
 					state.isAutoscale = false
 				}
 			}

--- a/cli/commands/sandbox_pool_list.go
+++ b/cli/commands/sandbox_pool_list.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/ui"
@@ -42,12 +43,14 @@ func SandboxPoolList(ctx *Context, opts struct {
 		return err
 	}
 
-	// Build version map for lookup
-	versionMap := make(map[string]*core_v1alpha.AppVersion)
+	// Build resolved config spec map for lookup
+	specMap := make(map[string]*core_v1alpha.ConfigSpec)
 	for _, e := range versionsRes.Values() {
 		v := new(core_v1alpha.AppVersion)
 		v.Decode(e.Entity())
-		versionMap[v.ID.String()] = v
+		if resolvedCfg, err := coreutil.ResolveConfig(ctx, eac, v); err == nil {
+			specMap[v.ID.String()] = resolvedCfg
+		}
 	}
 
 	if opts.IsJSON() {
@@ -71,9 +74,9 @@ func SandboxPoolList(ctx *Context, opts struct {
 
 		// Determine scaling mode from version config
 		mode := "auto"
-		if version, ok := versionMap[pool.SandboxSpec.Version.String()]; ok {
-			for _, svc := range version.Config.Services {
-				if svc.Name == pool.Service && svc.ServiceConcurrency.Mode == "fixed" {
+		if spec, ok := specMap[pool.SandboxSpec.Version.String()]; ok {
+			for _, svc := range spec.Services {
+				if svc.Name == pool.Service && svc.Concurrency.Mode == "fixed" {
 					mode = "fixed"
 					break
 				}

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -40,6 +40,7 @@ import (
 	"time"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/concurrency"
@@ -725,12 +726,18 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 			poolID := foundPool.ID
 
 			// Get service concurrency and create strategy for version->pool mapping
-			svcConcurrency, err := core_v1alpha.GetServiceConcurrency(ver, service)
+			spec, err := coreutil.ResolveConfig(ctx, a.eac, ver)
+			if err != nil {
+				a.mu.Unlock()
+				return nil, fmt.Errorf("failed to resolve config: %w", err)
+			}
+			svcConcurrency, err := coreutil.GetServiceConcurrency(spec, service)
 			if err != nil {
 				a.mu.Unlock()
 				return nil, fmt.Errorf("failed to get service concurrency: %w", err)
 			}
-			strategy := concurrency.NewStrategy(&svcConcurrency)
+			sc := core_v1alpha.ServiceConcurrency(svcConcurrency)
+			strategy := concurrency.NewStrategy(&sc)
 
 			// Cache the pool state before releasing lock
 			a.pools[key] = &poolState{
@@ -1075,6 +1082,13 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 			var appVer core_v1alpha.AppVersion
 			appVer.Decode(verResp.Entity().Entity())
 
+			// Resolve config from ConfigVersion if available
+			spec, err := coreutil.ResolveConfig(ctx, a.eac, &appVer)
+			if err != nil {
+				a.log.Error("failed to resolve config for sandbox", "error", err, "sandbox", sb.ID)
+				return nil
+			}
+
 			// Build HTTP URL
 			// For PENDING sandboxes, we track them even without network addresses
 			// so we can notify waiters if they crash during boot
@@ -1092,8 +1106,11 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 				}
 			} else {
 				port := int64(3000)
-				if appVer.Config.Port > 0 {
-					port = appVer.Config.Port
+				for _, svc := range spec.Services {
+					if svc.Name == "web" && svc.Port > 0 {
+						port = svc.Port
+						break
+					}
 				}
 
 				var err error
@@ -1105,12 +1122,13 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 			}
 
 			// Get service concurrency and create strategy/tracker
-			svcConcurrency, err := core_v1alpha.GetServiceConcurrency(&appVer, service)
+			svcConcurrency, err := coreutil.GetServiceConcurrency(spec, service)
 			if err != nil {
 				a.log.Error("failed to get service concurrency", "error", err, "sandbox", sb.ID, "service", service)
 				return nil
 			}
-			strategy := concurrency.NewStrategy(&svcConcurrency)
+			sc := core_v1alpha.ServiceConcurrency(svcConcurrency)
+			strategy := concurrency.NewStrategy(&sc)
 			tracker := strategy.InitializeTracker()
 
 			lsb := &sandbox{
@@ -1257,6 +1275,13 @@ func (a *localActivator) recoverSandboxes(ctx context.Context) error {
 		var appVer core_v1alpha.AppVersion
 		appVer.Decode(verResp.Entity().Entity())
 
+		// Resolve config from ConfigVersion if available
+		spec, err := coreutil.ResolveConfig(ctx, a.eac, &appVer)
+		if err != nil {
+			a.log.Error("failed to resolve config for sandbox", "error", err, "sandbox", sb.ID)
+			continue
+		}
+
 		// Extract HTTP port from sandbox spec (canonical source of truth)
 		port, found := extractHTTPPort(&sb.Spec)
 		if !found {
@@ -1276,12 +1301,13 @@ func (a *localActivator) recoverSandboxes(ctx context.Context) error {
 		}
 
 		// Get service-specific concurrency configuration and create strategy
-		svcConcurrency, err := core_v1alpha.GetServiceConcurrency(&appVer, service)
+		svcConcurrency, err := coreutil.GetServiceConcurrency(spec, service)
 		if err != nil {
 			a.log.Error("failed to get service concurrency for sandbox", "error", err, "sandbox", sb.ID, "service", service)
 			continue
 		}
-		strategy := concurrency.NewStrategy(&svcConcurrency)
+		sc := core_v1alpha.ServiceConcurrency(svcConcurrency)
+		strategy := concurrency.NewStrategy(&sc)
 
 		// Initialize tracker for recovered sandbox (starts empty)
 		tracker := strategy.InitializeTracker()
@@ -1362,13 +1388,21 @@ func (a *localActivator) recoverPools(ctx context.Context) error {
 		var appVer core_v1alpha.AppVersion
 		appVer.Decode(verResp.Entity().Entity())
 
+		// Resolve config from ConfigVersion if available
+		spec, err := coreutil.ResolveConfig(ctx, a.eac, &appVer)
+		if err != nil {
+			a.log.Error("failed to resolve config for pool", "error", err, "pool", pool.ID)
+			continue
+		}
+
 		// Get service concurrency and create strategy
-		svcConcurrency, err := core_v1alpha.GetServiceConcurrency(&appVer, pool.Service)
+		svcConcurrency, err := coreutil.GetServiceConcurrency(spec, pool.Service)
 		if err != nil {
 			a.log.Error("failed to get service concurrency for pool", "pool", pool.ID, "service", pool.Service, "error", err)
 			continue
 		}
-		strategy := concurrency.NewStrategy(&svcConcurrency)
+		sc := core_v1alpha.ServiceConcurrency(svcConcurrency)
+		strategy := concurrency.NewStrategy(&sc)
 
 		a.mu.Lock()
 

--- a/controllers/deployment/disk_integration_test.go
+++ b/controllers/deployment/disk_integration_test.go
@@ -26,23 +26,23 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 			App:      app.ID,
 			Version:  "v1",
 			ImageUrl: "test:latest",
-			Config: core_v1alpha.Config{
-				Port: 3000,
-				Services: []core_v1alpha.Services{
-					{
-						Name: "web",
-						ServiceConcurrency: core_v1alpha.ServiceConcurrency{
-							Mode:         "fixed",
-							NumInstances: 1,
-						},
-						Disks: []core_v1alpha.Disks{
-							{
-								Name:         "postgres-data",
-								MountPath:    "/var/lib/postgresql/data",
-								SizeGb:       100,
-								Filesystem:   "ext4",
-								LeaseTimeout: "5m",
-							},
+		}
+
+		cfgSpec := &core_v1alpha.ConfigSpec{
+			Services: []core_v1alpha.ConfigSpecServices{
+				{
+					Name: "web",
+					Concurrency: core_v1alpha.ConfigSpecServicesConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.ConfigSpecServicesDisks{
+						{
+							Name:         "postgres-data",
+							MountPath:    "/var/lib/postgresql/data",
+							SizeGb:       100,
+							Filesystem:   "ext4",
+							LeaseTimeout: "5m",
 						},
 					},
 				},
@@ -52,7 +52,7 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 		// Create a mock launcher with minimal setup
 		// Note: In a real test, we'd need to set up EAC properly
 		// For now, we test the spec building logic directly
-		spec, err := buildSandboxSpecForTest(ctx, app, ver, "web", "test:latest")
+		spec, err := buildSandboxSpecForTest(ctx, app, cfgSpec, ver, "web", "test:latest")
 		require.NoError(t, err)
 
 		// Verify volume was added
@@ -91,36 +91,36 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 			App:      app.ID,
 			Version:  "v1",
 			ImageUrl: "test:latest",
-			Config: core_v1alpha.Config{
-				Port: 3000,
-				Services: []core_v1alpha.Services{
-					{
-						Name: "database",
-						ServiceConcurrency: core_v1alpha.ServiceConcurrency{
-							Mode:         "fixed",
-							NumInstances: 1,
+		}
+
+		cfgSpec := &core_v1alpha.ConfigSpec{
+			Services: []core_v1alpha.ConfigSpecServices{
+				{
+					Name: "database",
+					Concurrency: core_v1alpha.ConfigSpecServicesConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.ConfigSpecServicesDisks{
+						{
+							Name:       "db-data",
+							MountPath:  "/data",
+							SizeGb:     200,
+							Filesystem: "ext4",
 						},
-						Disks: []core_v1alpha.Disks{
-							{
-								Name:       "db-data",
-								MountPath:  "/data",
-								SizeGb:     200,
-								Filesystem: "ext4",
-							},
-							{
-								Name:       "db-wal",
-								MountPath:  "/wal",
-								SizeGb:     50,
-								Filesystem: "xfs",
-								ReadOnly:   false,
-							},
+						{
+							Name:       "db-wal",
+							MountPath:  "/wal",
+							SizeGb:     50,
+							Filesystem: "xfs",
+							ReadOnly:   false,
 						},
 					},
 				},
 			},
 		}
 
-		spec, err := buildSandboxSpecForTest(ctx, app, ver, "database", "test:latest")
+		spec, err := buildSandboxSpecForTest(ctx, app, cfgSpec, ver, "database", "test:latest")
 		require.NoError(t, err)
 
 		// Verify both volumes were added
@@ -161,28 +161,29 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 			App:      app.ID,
 			Version:  "v1",
 			ImageUrl: "test:latest",
-			Config: core_v1alpha.Config{
-				Services: []core_v1alpha.Services{
-					{
-						Name: "reader",
-						ServiceConcurrency: core_v1alpha.ServiceConcurrency{
-							Mode:         "fixed",
-							NumInstances: 1,
-						},
-						Disks: []core_v1alpha.Disks{
-							{
-								Name:      "shared-data",
-								MountPath: "/data",
-								ReadOnly:  true,
-								SizeGb:    50,
-							},
+		}
+
+		cfgSpec := &core_v1alpha.ConfigSpec{
+			Services: []core_v1alpha.ConfigSpecServices{
+				{
+					Name: "reader",
+					Concurrency: core_v1alpha.ConfigSpecServicesConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.ConfigSpecServicesDisks{
+						{
+							Name:      "shared-data",
+							MountPath: "/data",
+							ReadOnly:  true,
+							SizeGb:    50,
 						},
 					},
 				},
 			},
 		}
 
-		spec, err := buildSandboxSpecForTest(ctx, app, ver, "reader", "test:latest")
+		spec, err := buildSandboxSpecForTest(ctx, app, cfgSpec, ver, "reader", "test:latest")
 		require.NoError(t, err)
 
 		// Verify read-only flag in volume field
@@ -203,16 +204,17 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 			App:      app.ID,
 			Version:  "v1",
 			ImageUrl: "test:latest",
-			Config: core_v1alpha.Config{
-				Services: []core_v1alpha.Services{
-					{
-						Name: "stateless",
-					},
+		}
+
+		cfgSpec := &core_v1alpha.ConfigSpec{
+			Services: []core_v1alpha.ConfigSpecServices{
+				{
+					Name: "stateless",
 				},
 			},
 		}
 
-		spec, err := buildSandboxSpecForTest(ctx, app, ver, "stateless", "test:latest")
+		spec, err := buildSandboxSpecForTest(ctx, app, cfgSpec, ver, "stateless", "test:latest")
 		require.NoError(t, err)
 
 		// Verify no volumes
@@ -236,20 +238,21 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 			App:      app.ID,
 			Version:  "v1",
 			ImageUrl: "test:latest",
-			Config: core_v1alpha.Config{
-				Services: []core_v1alpha.Services{
-					{
-						Name: "auto-service",
-						ServiceConcurrency: core_v1alpha.ServiceConcurrency{
-							Mode:                "auto",
-							RequestsPerInstance: 10,
-						},
-						Disks: []core_v1alpha.Disks{
-							{
-								Name:      "data",
-								MountPath: "/data",
-								SizeGb:    50,
-							},
+		}
+
+		cfgSpec := &core_v1alpha.ConfigSpec{
+			Services: []core_v1alpha.ConfigSpecServices{
+				{
+					Name: "auto-service",
+					Concurrency: core_v1alpha.ConfigSpecServicesConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+					Disks: []core_v1alpha.ConfigSpecServicesDisks{
+						{
+							Name:      "data",
+							MountPath: "/data",
+							SizeGb:    50,
 						},
 					},
 				},
@@ -257,7 +260,7 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 		}
 
 		// This should not add any volumes because the service is auto mode
-		spec, err := buildSandboxSpecForTest(ctx, app, ver, "auto-service", "test:latest")
+		spec, err := buildSandboxSpecForTest(ctx, app, cfgSpec, ver, "auto-service", "test:latest")
 		require.NoError(t, err)
 
 		// Verify no volumes were added (they were skipped due to auto mode)
@@ -278,21 +281,22 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 			App:      app.ID,
 			Version:  "v1",
 			ImageUrl: "test:latest",
-			Config: core_v1alpha.Config{
-				Services: []core_v1alpha.Services{
-					{
-						Name: "database",
-						ServiceConcurrency: core_v1alpha.ServiceConcurrency{
-							Mode:         "fixed",
-							NumInstances: 3,
-						},
-						Disks: []core_v1alpha.Disks{
-							{
-								Name:       "production",
-								MountPath:  "/data",
-								SizeGb:     100,
-								Filesystem: "ext4",
-							},
+		}
+
+		cfgSpec := &core_v1alpha.ConfigSpec{
+			Services: []core_v1alpha.ConfigSpecServices{
+				{
+					Name: "database",
+					Concurrency: core_v1alpha.ConfigSpecServicesConcurrency{
+						Mode:         "fixed",
+						NumInstances: 3,
+					},
+					Disks: []core_v1alpha.ConfigSpecServicesDisks{
+						{
+							Name:       "production",
+							MountPath:  "/data",
+							SizeGb:     100,
+							Filesystem: "ext4",
 						},
 					},
 				},
@@ -300,7 +304,7 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 		}
 
 		// Build spec for the service
-		spec, err := buildSandboxSpecForTest(ctx, app, ver, "database", "test:latest")
+		spec, err := buildSandboxSpecForTest(ctx, app, cfgSpec, ver, "database", "test:latest")
 		require.NoError(t, err)
 
 		// Verify the disk volume was added
@@ -317,7 +321,7 @@ func TestBuildSandboxSpecWithDisks(t *testing.T) {
 
 // buildSandboxSpecForTest is a test helper that calls the private buildSandboxSpec logic
 // without requiring a full EAC setup
-func buildSandboxSpecForTest(ctx context.Context, app *core_v1alpha.App, ver *core_v1alpha.AppVersion, serviceName string, image string) (*compute_v1alpha.SandboxSpec, error) {
+func buildSandboxSpecForTest(ctx context.Context, app *core_v1alpha.App, cfgSpec *core_v1alpha.ConfigSpec, ver *core_v1alpha.AppVersion, serviceName string, image string) (*compute_v1alpha.SandboxSpec, error) {
 	// This would need to be refactored to make buildSandboxSpec testable
 	// For now, we'll inline the disk-related logic
 	spec := &compute_v1alpha.SandboxSpec{
@@ -327,9 +331,6 @@ func buildSandboxSpecForTest(ctx context.Context, app *core_v1alpha.App, ver *co
 	}
 
 	port := int64(3000)
-	if ver.Config.Port > 0 {
-		port = ver.Config.Port
-	}
 
 	appCont := compute_v1alpha.SandboxSpecContainer{
 		Name:      "app",
@@ -345,12 +346,12 @@ func buildSandboxSpecForTest(ctx context.Context, app *core_v1alpha.App, ver *co
 	}
 
 	// Add disk volumes and mounts for this service (copied from buildSandboxSpec)
-	for _, svc := range ver.Config.Services {
+	for _, svc := range cfgSpec.Services {
 		if svc.Name == serviceName {
 			// Only add disks for fixed concurrency services
 			if len(svc.Disks) > 0 {
 				// Skip if not fixed mode
-				if svc.ServiceConcurrency.Mode != "fixed" {
+				if svc.Concurrency.Mode != "fixed" {
 					break
 				}
 			}

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/cond"
@@ -89,14 +90,20 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	var ver core_v1alpha.AppVersion
 	ver.Decode(verResp.Entity().Entity())
 
+	// Resolve config from ConfigVersion if available, otherwise use inline
+	spec, err := coreutil.ResolveConfig(ctx, l.EAC, &ver)
+	if err != nil {
+		return fmt.Errorf("failed to resolve config: %w", err)
+	}
+
 	l.Log.Info("reconciling app version",
 		"app", app.ID,
 		"version", ver.Version,
-		"services", len(ver.Config.Services))
+		"services", len(spec.Services))
 
 	// For each service, ensure a pool exists
-	for _, svc := range ver.Config.Services {
-		if err := l.ensurePoolForService(ctx, app, &ver, svc.Name); err != nil {
+	for _, svc := range spec.Services {
+		if err := l.ensurePoolForService(ctx, app, &ver, spec, svc.Name); err != nil {
 			l.Log.Error("failed to ensure pool for service",
 				"app", app.ID,
 				"service", svc.Name,
@@ -118,16 +125,16 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 }
 
 // ensurePoolForService creates or reuses a pool for the given service
-func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.App, ver *core_v1alpha.AppVersion, serviceName string) error {
+func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.App, ver *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec, serviceName string) error {
 	// Get service config
-	svcConcurrency, err := core_v1alpha.GetServiceConcurrency(ver, serviceName)
+	svcConcurrency, err := coreutil.GetServiceConcurrency(spec, serviceName)
 	if err != nil {
 		return fmt.Errorf("failed to get service concurrency: %w", err)
 	}
 
 	// Determine which image to use
 	image := ver.ImageUrl
-	for _, svc := range ver.Config.Services {
+	for _, svc := range spec.Services {
 		if svc.Name == serviceName && svc.Image != "" {
 			image = containerdx.NormalizeImageReference(svc.Image)
 			l.Log.Info("using custom image for service",
@@ -148,7 +155,7 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 	appMD.Decode(appResp.Entity().Entity())
 
 	// Build the desired sandbox spec
-	spec, err := l.buildSandboxSpec(ctx, app, ver, serviceName, image)
+	sbSpec, err := l.buildSandboxSpec(ctx, app, ver, spec, serviceName, image)
 	if err != nil {
 		return fmt.Errorf("failed to build sandbox spec: %w", err)
 	}
@@ -163,7 +170,7 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 	}
 
 	// Try to find existing pool with matching spec
-	poolWithEntity, err := l.findMatchingPool(ctx, app.ID, serviceName, spec)
+	poolWithEntity, err := l.findMatchingPool(ctx, app.ID, serviceName, sbSpec)
 	if err != nil {
 		return fmt.Errorf("failed to find matching pool: %w", err)
 	}
@@ -176,6 +183,12 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 			"app", app.ID)
 
 		needsUpdate := false
+
+		// Update the pool's sandbox spec version to track the current AppVersion
+		if poolWithEntity.Pool.SandboxSpec.Version != ver.ID {
+			poolWithEntity.Pool.SandboxSpec.Version = ver.ID
+			needsUpdate = true
+		}
 
 		// Add this version to referenced_by_versions if not already present
 		if !containsRef(poolWithEntity.Pool.ReferencedByVersions, ver.ID) {
@@ -218,7 +231,7 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 	pool := &compute_v1alpha.SandboxPool{
 		App:                  app.ID,
 		Service:              serviceName,
-		SandboxSpec:          *spec,
+		SandboxSpec:          *sbSpec,
 		DesiredInstances:     desiredInstances,
 		ReferencedByVersions: []entity.Id{ver.ID},
 		SandboxLabels: types.LabelSet(
@@ -261,6 +274,7 @@ func (l *Launcher) buildSandboxSpec(
 	ctx context.Context,
 	app *core_v1alpha.App,
 	ver *core_v1alpha.AppVersion,
+	cfgSpec *core_v1alpha.ConfigSpec,
 	serviceName string,
 	image string,
 ) (
@@ -276,14 +290,14 @@ func (l *Launcher) buildSandboxSpec(
 	var appMD core_v1alpha.Metadata
 	appMD.Decode(appResp.Entity().Entity())
 
-	spec := &compute_v1alpha.SandboxSpec{
+	sbSpec := &compute_v1alpha.SandboxSpec{
 		Version:      ver.ID,
 		LogEntity:    app.ID.String(),
 		LogAttribute: types.LabelSet("stage", "app-run", "service", serviceName),
 	}
 
 	// Determine start directory, defaulting to /app
-	startDir := ver.Config.StartDirectory
+	startDir := cfgSpec.StartDirectory
 	if startDir == "" {
 		startDir = "/app"
 	}
@@ -298,14 +312,13 @@ func (l *Launcher) buildSandboxSpec(
 		Directory: startDir,
 	}
 
-	// Determine port configuration from service config, falling back to global config, then defaults
+	// Determine port configuration from service config
 	port := int64(0)
 	portName := ""
 	portType := ""
 	shutdownTimeout := ""
 
-	// Check for per-service configuration
-	for _, svc := range ver.Config.Services {
+	for _, svc := range cfgSpec.Services {
 		if svc.Name == serviceName {
 			if svc.Port > 0 {
 				port = svc.Port
@@ -316,17 +329,11 @@ func (l *Launcher) buildSandboxSpec(
 			if svc.PortType != "" {
 				portType = svc.PortType
 			}
-			if svc.ServiceConcurrency.ShutdownTimeout != "" {
-				shutdownTimeout = svc.ServiceConcurrency.ShutdownTimeout
+			if svc.Concurrency.ShutdownTimeout != "" {
+				shutdownTimeout = svc.Concurrency.ShutdownTimeout
 			}
 			break
 		}
-	}
-
-	// Fall back to global port config (for web service only)
-	// Background services (worker, etc) don't get the global port automatically
-	if port == 0 && serviceName == "web" && ver.Config.Port > 0 {
-		port = ver.Config.Port
 	}
 
 	// Default to 3000 for web service if still no port configured
@@ -336,7 +343,6 @@ func (l *Launcher) buildSandboxSpec(
 
 	// Add port configuration if a port was determined
 	if port > 0 {
-		// Default port name and type to "http" if not specified
 		if portName == "" {
 			portName = "http"
 		}
@@ -355,14 +361,14 @@ func (l *Launcher) buildSandboxSpec(
 
 	// Add user-supplied config env vars, stripping any system-managed keys
 	envMap := make(map[string]string)
-	for _, x := range ver.Config.Variable {
+	for _, x := range cfgSpec.Variables {
 		if !isSystemEnvVar(x.Key) {
 			envMap[x.Key] = x.Value
 		}
 	}
 
 	// Find and merge per-service env vars (these override global vars)
-	for _, svc := range ver.Config.Services {
+	for _, svc := range cfgSpec.Services {
 		if svc.Name == serviceName {
 			for _, x := range svc.Env {
 				if !isSystemEnvVar(x.Key) {
@@ -387,24 +393,22 @@ func (l *Launcher) buildSandboxSpec(
 	}
 
 	// Find service command
-	for _, s := range ver.Config.Commands {
-		if s.Service == serviceName && s.Command != "" {
-			if ver.Config.Entrypoint != "" {
-				appCont.Command = ver.Config.Entrypoint + " " + s.Command
+	for _, svc := range cfgSpec.Services {
+		if svc.Name == serviceName && svc.Command != "" {
+			if cfgSpec.Entrypoint != "" {
+				appCont.Command = cfgSpec.Entrypoint + " " + svc.Command
 			} else {
-				appCont.Command = s.Command
+				appCont.Command = svc.Command
 			}
 			break
 		}
 	}
 
 	// Add disk volumes and mounts for this service
-	for _, svc := range ver.Config.Services {
+	for _, svc := range cfgSpec.Services {
 		if svc.Name == serviceName {
-			// Only add disks for fixed concurrency services
 			if len(svc.Disks) > 0 {
-				// Verify this is a fixed mode service
-				svcConcurrency, err := core_v1alpha.GetServiceConcurrency(ver, serviceName)
+				svcConcurrency, err := coreutil.GetServiceConcurrency(cfgSpec, serviceName)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get service concurrency: %w", err)
 				}
@@ -418,7 +422,7 @@ func (l *Launcher) buildSandboxSpec(
 			}
 
 			for _, disk := range svc.Disks {
-				spec.Volume = append(spec.Volume, compute_v1alpha.SandboxSpecVolume{
+				sbSpec.Volume = append(sbSpec.Volume, compute_v1alpha.SandboxSpecVolume{
 					Name:         disk.Name,
 					Provider:     "miren",
 					DiskName:     disk.Name,
@@ -429,7 +433,6 @@ func (l *Launcher) buildSandboxSpec(
 					LeaseTimeout: disk.LeaseTimeout,
 				})
 
-				// Add mount to container
 				appCont.Mount = append(appCont.Mount, compute_v1alpha.SandboxSpecContainerMount{
 					Source:      disk.Name,
 					Destination: disk.MountPath,
@@ -439,14 +442,13 @@ func (l *Launcher) buildSandboxSpec(
 		}
 	}
 
-	// Set shutdown timeout if configured
 	if shutdownTimeout != "" {
 		appCont.ShutdownTimeout = shutdownTimeout
 	}
 
-	spec.Container = []compute_v1alpha.SandboxSpecContainer{appCont}
+	sbSpec.Container = []compute_v1alpha.SandboxSpecContainer{appCont}
 
-	return spec, nil
+	return sbSpec, nil
 }
 
 // findMatchingPool searches for an existing pool with matching spec

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/concurrency"
@@ -577,15 +578,23 @@ func (m *Manager) checkAllPoolsForScaleDown(ctx context.Context) error {
 		var ver core_v1alpha.AppVersion
 		ver.Decode(verResp.Entity().Entity())
 
+		// Resolve config from ConfigVersion if available
+		spec, err := coreutil.ResolveConfig(ctx, m.eac, &ver)
+		if err != nil {
+			m.log.Error("failed to resolve config for pool", "pool", pool.ID, "error", err)
+			continue
+		}
+
 		// Get service concurrency config
-		svcConcurrency, err := core_v1alpha.GetServiceConcurrency(&ver, pool.Service)
+		svcConcurrency, err := coreutil.GetServiceConcurrency(spec, pool.Service)
 		if err != nil {
 			m.log.Error("failed to get service concurrency", "pool", pool.ID, "error", err)
 			continue
 		}
 
 		// Use concurrency strategy to determine scale-down delay
-		strategy := concurrency.NewStrategy(&svcConcurrency)
+		sc := core_v1alpha.ServiceConcurrency(svcConcurrency)
+		strategy := concurrency.NewStrategy(&sc)
 		scaleDownDelay := strategy.ScaleDownDelay()
 
 		// Skip pools that never scale down (fixed mode)

--- a/e2e/sandbox_lifecycle_test.go
+++ b/e2e/sandbox_lifecycle_test.go
@@ -96,6 +96,21 @@ metadata:
 spec:
   project: project/sample
 ---
+kind: dev.miren.core/config_version
+version: v1alpha
+metadata:
+  name: abcdef-cfg
+spec:
+  app: app/nginx
+  spec:
+    services:
+      - name: web
+        port: 80
+        concurrency:
+          mode: auto
+          requests_per_instance: 10
+          scale_down_delay: "15m"
+---
 kind: dev.miren.core/app_version
 version: v1alpha
 metadata:
@@ -104,14 +119,7 @@ spec:
   app: app/nginx
   version: abcdef
   image_url: docker.io/library/nginx:latest
-  config:
-    port: 80
-    services:
-      - name: web
-        service_concurrency:
-          mode: auto
-          requests_per_instance: 10
-          scale_down_delay: "15m"
+  config_version: config_version/abcdef-cfg
 ---
 kind: dev.miren.ingress/http_route
 version: v1alpha

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 	"strings"
 
 	"miren.dev/runtime/api/app/app_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
@@ -143,12 +143,18 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 	}
 
 	var appVer core_v1alpha.AppVersion
+	var spec core_v1alpha.ConfigSpec
 
 	if appRec.ActiveVersion != "" {
 		err = r.EC.GetById(ctx, appRec.ActiveVersion, &appVer)
 		if err != nil {
 			return err
 		}
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
+		if err != nil {
+			return fmt.Errorf("failed to resolve config: %w", err)
+		}
+		spec = *resolvedCfg
 	} else {
 		appVer.App = appRec.ID
 	}
@@ -163,34 +169,37 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 		}
 	}
 
+	// Set commands directly on services
 	for _, s := range cfg.Commands() {
-		cmd := core_v1alpha.Commands{
-			Service: s.Service(),
-			Command: s.Command(),
+		found := false
+		for i := range spec.Services {
+			if spec.Services[i].Name == s.Service() {
+				spec.Services[i].Command = s.Command()
+				found = true
+				break
+			}
 		}
-
-		if !slices.Contains(appVer.Config.Commands, cmd) {
-			appVer.Config.Commands = append(appVer.Config.Commands, cmd)
+		if !found {
+			spec.Services = append(spec.Services, core_v1alpha.ConfigSpecServices{
+				Name:    s.Service(),
+				Command: s.Command(),
+			})
 		}
 	}
 
 	// Replace the entire env var list with the new one from the client
 	// The client is responsible for sending the complete desired state
-	// Use the source field from the client, or default to "manual" for backward compatibility
 	if cfg.HasEnvVars() {
-		appVer.Config.Variable = nil
+		spec.Variables = nil
 		for _, ev := range cfg.EnvVars() {
 			source := ev.Source()
-			if source == "" {
-				source = "manual"
-			}
-			nv := core_v1alpha.Variable{
+			nv := core_v1alpha.ConfigSpecVariables{
 				Key:       ev.Key(),
 				Value:     ev.Value(),
 				Sensitive: ev.Sensitive(),
 				Source:    source,
 			}
-			appVer.Config.Variable = append(appVer.Config.Variable, nv)
+			spec.Variables = append(spec.Variables, nv)
 		}
 	}
 
@@ -206,26 +215,21 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 				}
 			}
 
-			// Find or create the service in appVer.Config.Services
+			// Find or create the service in spec.Services
 			var found bool
-			for i := range appVer.Config.Services {
-				if appVer.Config.Services[i].Name == svcCfg.Service() {
-					// Update existing service's env vars
-					// Use the source field from the client, or default to "manual" for backward compatibility
-					appVer.Config.Services[i].Env = nil
+			for i := range spec.Services {
+				if spec.Services[i].Name == svcCfg.Service() {
+					spec.Services[i].Env = nil
 					if svcCfg.HasServiceEnv() {
 						for _, ev := range svcCfg.ServiceEnv() {
 							source := ev.Source()
-							if source == "" {
-								source = "manual"
-							}
-							nv := core_v1alpha.Env{
+							nv := core_v1alpha.ConfigSpecServicesEnv{
 								Key:       ev.Key(),
 								Value:     ev.Value(),
 								Sensitive: ev.Sensitive(),
 								Source:    source,
 							}
-							appVer.Config.Services[i].Env = append(appVer.Config.Services[i].Env, nv)
+							spec.Services[i].Env = append(spec.Services[i].Env, nv)
 						}
 					}
 					found = true
@@ -233,18 +237,13 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 				}
 			}
 
-			// If service doesn't exist yet, create it
-			// Use the source field from the client, or default to "manual" for backward compatibility
 			if !found && svcCfg.HasServiceEnv() {
-				svc := core_v1alpha.Services{
+				svc := core_v1alpha.ConfigSpecServices{
 					Name: svcCfg.Service(),
 				}
 				for _, ev := range svcCfg.ServiceEnv() {
 					source := ev.Source()
-					if source == "" {
-						source = "manual"
-					}
-					nv := core_v1alpha.Env{
+					nv := core_v1alpha.ConfigSpecServicesEnv{
 						Key:       ev.Key(),
 						Value:     ev.Value(),
 						Sensitive: ev.Sensitive(),
@@ -252,30 +251,27 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 					}
 					svc.Env = append(svc.Env, nv)
 				}
-				appVer.Config.Services = append(appVer.Config.Services, svc)
+				spec.Services = append(spec.Services, svc)
 			}
 		}
 	}
 
-	appVer.Config.Entrypoint = cfg.Entrypoint()
+	spec.Entrypoint = cfg.Entrypoint()
 
 	appVer.Version = name + "-" + idgen.Gen("v")
+
+	// Create ConfigVersion as the sole config store
+	cvid, err := r.createConfigVersion(ctx, &spec, appVer.App, appVer.Version)
+	if err != nil {
+		return fmt.Errorf("error creating config version: %w", err)
+	}
+	appVer.ConfigVersion = cvid
+	appVer.Config = core_v1alpha.Config{}
 
 	avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
 	if err != nil {
 		return err
 	}
-
-	// By updating the existing version, we're implicitly reusing the same
-	// image_id as the prev version, which is what we want.
-
-	/*
-		r.Log.Info("clearing old version", "app", name, "new-ver", ver.Version)
-		err = r.CV.ClearOldVersions(ctx, ver)
-		if err != nil {
-			return err
-		}
-	*/
 
 	appRec.ActiveVersion = avid
 	err = r.EC.Update(ctx, &appRec)
@@ -309,21 +305,28 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 		return fmt.Errorf("app has no active version")
 	}
 
+	spec, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
+	if err != nil {
+		return fmt.Errorf("failed to resolve config: %w", err)
+	}
+
 	var cfg app_v1alpha.Configuration
 
+	// Build commands from services that have commands
 	var commands []*app_v1alpha.ServiceCommand
-	for _, s := range appVer.Config.Commands {
-		var sc app_v1alpha.ServiceCommand
-		sc.SetService(s.Service)
-		sc.SetCommand(s.Command)
-
-		commands = append(commands, &sc)
+	for _, svc := range spec.Services {
+		if svc.Command != "" {
+			var sc app_v1alpha.ServiceCommand
+			sc.SetService(svc.Name)
+			sc.SetCommand(svc.Command)
+			commands = append(commands, &sc)
+		}
 	}
 
 	cfg.SetCommands(commands)
 
 	var envVars []*app_v1alpha.NamedValue
-	for _, ev := range appVer.Config.Variable {
+	for _, ev := range spec.Variables {
 		var env app_v1alpha.NamedValue
 		env.SetKey(ev.Key)
 		env.SetValue(ev.Value)
@@ -336,7 +339,7 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 
 	// Add per-service configurations
 	var services []*app_v1alpha.ServiceConfig
-	for _, svc := range appVer.Config.Services {
+	for _, svc := range spec.Services {
 		var sc app_v1alpha.ServiceConfig
 		sc.SetService(svc.Name)
 
@@ -358,7 +361,7 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 	}
 	cfg.SetServices(services)
 
-	cfg.SetEntrypoint(appVer.Config.Entrypoint)
+	cfg.SetEntrypoint(spec.Entrypoint)
 
 	state.Results().SetConfiguration(&cfg)
 
@@ -393,179 +396,81 @@ func (r *AppInfo) SetHost(ctx context.Context, state *app_v1alpha.CrudSetHost) e
 	return nil
 }
 
-func (r *AppInfo) SetEnvVar(ctx context.Context, state *app_v1alpha.CrudSetEnvVar) error {
-	args := state.Args()
-	name := args.App()
-	key := args.Key()
-	value := args.Value()
-	sensitive := args.Sensitive()
-	service := args.Service()
-
-	if strings.HasPrefix(key, "MIREN_") {
-		return fmt.Errorf("cannot set MIREN_ environment variables")
-	}
-
-	var appRec core_v1alpha.App
-	err := r.EC.Get(ctx, name, &appRec)
-	if err != nil {
-		return err
-	}
-
-	var appVer core_v1alpha.AppVersion
-	if appRec.ActiveVersion != "" {
-		err = r.EC.GetById(ctx, appRec.ActiveVersion, &appVer)
-		if err != nil {
-			return err
-		}
-	} else {
-		appVer.App = appRec.ID
-	}
-
-	if service == "" {
-		// Global env var
-		found := false
-		for i, v := range appVer.Config.Variable {
-			if v.Key == key {
-				appVer.Config.Variable[i].Value = value
-				appVer.Config.Variable[i].Sensitive = sensitive
-				appVer.Config.Variable[i].Source = "manual"
-				found = true
-				break
-			}
-		}
-		if !found {
-			appVer.Config.Variable = append(appVer.Config.Variable, core_v1alpha.Variable{
-				Key:       key,
-				Value:     value,
-				Sensitive: sensitive,
-				Source:    "manual",
-			})
-		}
-	} else {
-		// Per-service env var
-		svcFound := false
-		for i := range appVer.Config.Services {
-			if appVer.Config.Services[i].Name == service {
-				svcFound = true
-				envFound := false
-				for j, e := range appVer.Config.Services[i].Env {
-					if e.Key == key {
-						appVer.Config.Services[i].Env[j].Value = value
-						appVer.Config.Services[i].Env[j].Sensitive = sensitive
-						appVer.Config.Services[i].Env[j].Source = "manual"
-						envFound = true
-						break
-					}
-				}
-				if !envFound {
-					appVer.Config.Services[i].Env = append(appVer.Config.Services[i].Env, core_v1alpha.Env{
-						Key:       key,
-						Value:     value,
-						Sensitive: sensitive,
-						Source:    "manual",
-					})
-				}
-				break
-			}
-		}
-		if !svcFound {
-			return fmt.Errorf("service %q not found", service)
-		}
-	}
-
-	appVer.Version = name + "-" + idgen.Gen("v")
-
-	avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
-	if err != nil {
-		return err
-	}
-
-	appRec.ActiveVersion = avid
-	err = r.EC.Update(ctx, &appRec)
-	if err != nil {
-		return fmt.Errorf("error updating app entity: %w", err)
-	}
-
-	state.Results().SetVersionId(appVer.Version)
-	return nil
+type envVar struct {
+	Key       string
+	Value     string
+	Sensitive bool
 }
 
-func (r *AppInfo) SetEnvVars(ctx context.Context, state *app_v1alpha.CrudSetEnvVars) error {
-	args := state.Args()
-	name := args.App()
-	vars := args.Vars()
-	service := args.Service()
-
-	if len(vars) == 0 {
-		return fmt.Errorf("no environment variables provided")
-	}
-
+func (r *AppInfo) setEnvVars(ctx context.Context, name string, vars []envVar, service string) (string, error) {
 	for _, v := range vars {
-		if strings.HasPrefix(v.Key(), "MIREN_") {
-			return fmt.Errorf("cannot set MIREN_ environment variables")
+		if strings.HasPrefix(v.Key, "MIREN_") {
+			return "", fmt.Errorf("cannot set MIREN_ environment variables")
 		}
 	}
 
 	var appRec core_v1alpha.App
 	err := r.EC.Get(ctx, name, &appRec)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var appVer core_v1alpha.AppVersion
+	var spec core_v1alpha.ConfigSpec
 	if appRec.ActiveVersion != "" {
 		err = r.EC.GetById(ctx, appRec.ActiveVersion, &appVer)
 		if err != nil {
-			return err
+			return "", err
 		}
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve config: %w", err)
+		}
+		spec = *resolvedCfg
 	} else {
 		appVer.App = appRec.ID
 	}
 
 	for _, v := range vars {
-		key := v.Key()
-		value := v.Value()
-		sensitive := v.Sensitive()
-
 		if service == "" {
 			found := false
-			for i, ev := range appVer.Config.Variable {
-				if ev.Key == key {
-					appVer.Config.Variable[i].Value = value
-					appVer.Config.Variable[i].Sensitive = sensitive
-					appVer.Config.Variable[i].Source = "manual"
+			for i, ev := range spec.Variables {
+				if ev.Key == v.Key {
+					spec.Variables[i].Value = v.Value
+					spec.Variables[i].Sensitive = v.Sensitive
+					spec.Variables[i].Source = "manual"
 					found = true
 					break
 				}
 			}
 			if !found {
-				appVer.Config.Variable = append(appVer.Config.Variable, core_v1alpha.Variable{
-					Key:       key,
-					Value:     value,
-					Sensitive: sensitive,
+				spec.Variables = append(spec.Variables, core_v1alpha.ConfigSpecVariables{
+					Key:       v.Key,
+					Value:     v.Value,
+					Sensitive: v.Sensitive,
 					Source:    "manual",
 				})
 			}
 		} else {
 			svcFound := false
-			for i := range appVer.Config.Services {
-				if appVer.Config.Services[i].Name == service {
+			for i := range spec.Services {
+				if spec.Services[i].Name == service {
 					svcFound = true
 					envFound := false
-					for j, e := range appVer.Config.Services[i].Env {
-						if e.Key == key {
-							appVer.Config.Services[i].Env[j].Value = value
-							appVer.Config.Services[i].Env[j].Sensitive = sensitive
-							appVer.Config.Services[i].Env[j].Source = "manual"
+					for j, e := range spec.Services[i].Env {
+						if e.Key == v.Key {
+							spec.Services[i].Env[j].Value = v.Value
+							spec.Services[i].Env[j].Sensitive = v.Sensitive
+							spec.Services[i].Env[j].Source = "manual"
 							envFound = true
 							break
 						}
 					}
 					if !envFound {
-						appVer.Config.Services[i].Env = append(appVer.Config.Services[i].Env, core_v1alpha.Env{
-							Key:       key,
-							Value:     value,
-							Sensitive: sensitive,
+						spec.Services[i].Env = append(spec.Services[i].Env, core_v1alpha.ConfigSpecServicesEnv{
+							Key:       v.Key,
+							Value:     v.Value,
+							Sensitive: v.Sensitive,
 							Source:    "manual",
 						})
 					}
@@ -573,25 +478,67 @@ func (r *AppInfo) SetEnvVars(ctx context.Context, state *app_v1alpha.CrudSetEnvV
 				}
 			}
 			if !svcFound {
-				return fmt.Errorf("service %q not found", service)
+				return "", fmt.Errorf("service %q not found", service)
 			}
 		}
 	}
 
 	appVer.Version = name + "-" + idgen.Gen("v")
 
+	cvid, err := r.createConfigVersion(ctx, &spec, appVer.App, appVer.Version)
+	if err != nil {
+		return "", fmt.Errorf("error creating config version: %w", err)
+	}
+	appVer.ConfigVersion = cvid
+	appVer.Config = core_v1alpha.Config{}
+
 	avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	appRec.ActiveVersion = avid
 	err = r.EC.Update(ctx, &appRec)
 	if err != nil {
-		return fmt.Errorf("error updating app entity: %w", err)
+		return "", fmt.Errorf("error updating app entity: %w", err)
 	}
 
-	state.Results().SetVersionId(appVer.Version)
+	return appVer.Version, nil
+}
+
+func (r *AppInfo) SetEnvVar(ctx context.Context, state *app_v1alpha.CrudSetEnvVar) error {
+	args := state.Args()
+
+	versionId, err := r.setEnvVars(ctx, args.App(), []envVar{
+		{Key: args.Key(), Value: args.Value(), Sensitive: args.Sensitive()},
+	}, args.Service())
+	if err != nil {
+		return err
+	}
+
+	state.Results().SetVersionId(versionId)
+	return nil
+}
+
+func (r *AppInfo) SetEnvVars(ctx context.Context, state *app_v1alpha.CrudSetEnvVars) error {
+	args := state.Args()
+	rpcVars := args.Vars()
+
+	if len(rpcVars) == 0 {
+		return fmt.Errorf("no environment variables provided")
+	}
+
+	vars := make([]envVar, len(rpcVars))
+	for i, v := range rpcVars {
+		vars[i] = envVar{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive()}
+	}
+
+	versionId, err := r.setEnvVars(ctx, args.App(), vars, args.Service())
+	if err != nil {
+		return err
+	}
+
+	state.Results().SetVersionId(versionId)
 	return nil
 }
 
@@ -608,11 +555,17 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 	}
 
 	var appVer core_v1alpha.AppVersion
+	var spec core_v1alpha.ConfigSpec
 	if appRec.ActiveVersion != "" {
 		err = r.EC.GetById(ctx, appRec.ActiveVersion, &appVer)
 		if err != nil {
 			return err
 		}
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
+		if err != nil {
+			return fmt.Errorf("failed to resolve config: %w", err)
+		}
+		spec = *resolvedCfg
 	} else {
 		return fmt.Errorf("app has no active version")
 	}
@@ -622,14 +575,11 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 	if service == "" {
 		// Global env var
 		found := false
-		newVars := make([]core_v1alpha.Variable, 0, len(appVer.Config.Variable))
-		for _, v := range appVer.Config.Variable {
+		newVars := make([]core_v1alpha.ConfigSpecVariables, 0, len(spec.Variables))
+		for _, v := range spec.Variables {
 			if v.Key == key {
 				found = true
 				deletedSource = v.Source
-				if deletedSource == "" {
-					deletedSource = "config" // backward compatibility
-				}
 				continue
 			}
 			newVars = append(newVars, v)
@@ -637,22 +587,19 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 		if !found {
 			return fmt.Errorf("environment variable %q not found", key)
 		}
-		appVer.Config.Variable = newVars
+		spec.Variables = newVars
 	} else {
 		// Per-service env var
 		svcFound := false
-		for i := range appVer.Config.Services {
-			if appVer.Config.Services[i].Name == service {
+		for i := range spec.Services {
+			if spec.Services[i].Name == service {
 				svcFound = true
 				envFound := false
-				newEnvs := make([]core_v1alpha.Env, 0, len(appVer.Config.Services[i].Env))
-				for _, e := range appVer.Config.Services[i].Env {
+				newEnvs := make([]core_v1alpha.ConfigSpecServicesEnv, 0, len(spec.Services[i].Env))
+				for _, e := range spec.Services[i].Env {
 					if e.Key == key {
 						envFound = true
 						deletedSource = e.Source
-						if deletedSource == "" {
-							deletedSource = "config" // backward compatibility
-						}
 						continue
 					}
 					newEnvs = append(newEnvs, e)
@@ -660,7 +607,7 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 				if !envFound {
 					return fmt.Errorf("environment variable %q not found in service %q", key, service)
 				}
-				appVer.Config.Services[i].Env = newEnvs
+				spec.Services[i].Env = newEnvs
 				break
 			}
 		}
@@ -670,6 +617,14 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 	}
 
 	appVer.Version = name + "-" + idgen.Gen("v")
+
+	// Create ConfigVersion as the sole config store
+	cvid, err := r.createConfigVersion(ctx, &spec, appVer.App, appVer.Version)
+	if err != nil {
+		return fmt.Errorf("error creating config version: %w", err)
+	}
+	appVer.ConfigVersion = cvid
+	appVer.Config = core_v1alpha.Config{}
 
 	avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
 	if err != nil {
@@ -685,4 +640,14 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 	state.Results().SetVersionId(appVer.Version)
 	state.Results().SetDeletedSource(deletedSource)
 	return nil
+}
+
+// createConfigVersion creates a ConfigVersion entity from a ConfigSpec.
+func (r *AppInfo) createConfigVersion(ctx context.Context, spec *core_v1alpha.ConfigSpec, appID entity.Id, versionName string) (entity.Id, error) {
+	configVer := &core_v1alpha.ConfigVersion{
+		App:  appID,
+		Spec: *spec,
+	}
+	cvName := versionName + "-cfg"
+	return r.EC.Create(ctx, cvName, configVer)
 }

--- a/servers/app/app_test.go
+++ b/servers/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"miren.dev/runtime/api/app/app_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/metrics"
@@ -80,8 +81,13 @@ func TestSetConfiguration_DuplicateEnvVars(t *testing.T) {
 			t.Fatalf("failed to get app version: %v", err)
 		}
 
-		if len(appVerCheck.Config.Variable) != 2 {
-			t.Errorf("expected 2 env vars, got %d", len(appVerCheck.Config.Variable))
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVerCheck)
+		if err != nil {
+			t.Fatalf("failed to resolve config: %v", err)
+		}
+
+		if len(resolvedCfg.Variables) != 2 {
+			t.Errorf("expected 2 env vars, got %d", len(resolvedCfg.Variables))
 		}
 	})
 
@@ -115,7 +121,12 @@ func TestSetConfiguration_DuplicateEnvVars(t *testing.T) {
 			t.Fatalf("failed to get app version: %v", err)
 		}
 
-		envVars := appVerCheck.Config.Variable
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVerCheck)
+		if err != nil {
+			t.Fatalf("failed to resolve config: %v", err)
+		}
+
+		envVars := resolvedCfg.Variables
 
 		// Count FOO occurrences
 		fooCount := 0
@@ -166,7 +177,12 @@ func TestSetConfiguration_DuplicateEnvVars(t *testing.T) {
 			t.Fatalf("failed to get app version: %v", err)
 		}
 
-		envVars := appVerCheck.Config.Variable
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVerCheck)
+		if err != nil {
+			t.Fatalf("failed to resolve config: %v", err)
+		}
+
+		envVars := resolvedCfg.Variables
 
 		// Count SECRET occurrences
 		secretCount := 0
@@ -254,8 +270,13 @@ func TestSetConfiguration_EnvVarDeletion(t *testing.T) {
 			t.Fatalf("failed to get app version: %v", err)
 		}
 
-		if len(appVerCheck.Config.Variable) != 3 {
-			t.Errorf("expected 3 env vars, got %d", len(appVerCheck.Config.Variable))
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVerCheck)
+		if err != nil {
+			t.Fatalf("failed to resolve config: %v", err)
+		}
+
+		if len(resolvedCfg.Variables) != 3 {
+			t.Errorf("expected 3 env vars, got %d", len(resolvedCfg.Variables))
 		}
 	})
 
@@ -293,12 +314,17 @@ func TestSetConfiguration_EnvVarDeletion(t *testing.T) {
 			t.Fatalf("failed to get app version: %v", err)
 		}
 
-		if len(appVerCheck.Config.Variable) != 2 {
-			t.Errorf("expected 2 env vars after deletion, got %d", len(appVerCheck.Config.Variable))
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVerCheck)
+		if err != nil {
+			t.Fatalf("failed to resolve config: %v", err)
+		}
+
+		if len(resolvedCfg.Variables) != 2 {
+			t.Errorf("expected 2 env vars after deletion, got %d", len(resolvedCfg.Variables))
 		}
 
 		// Check that VAR2 is specifically gone
-		for _, ev := range appVerCheck.Config.Variable {
+		for _, ev := range resolvedCfg.Variables {
 			if ev.Key == "VAR2" {
 				t.Errorf("VAR2 should have been deleted but still exists")
 			}
@@ -306,7 +332,7 @@ func TestSetConfiguration_EnvVarDeletion(t *testing.T) {
 
 		// Check that VAR1 and VAR3 still exist
 		hasVar1, hasVar3 := false, false
-		for _, ev := range appVerCheck.Config.Variable {
+		for _, ev := range resolvedCfg.Variables {
 			if ev.Key == "VAR1" && ev.Value == "value1" {
 				hasVar1 = true
 			}
@@ -346,9 +372,14 @@ func TestSetConfiguration_EnvVarDeletion(t *testing.T) {
 			t.Fatalf("failed to get app version: %v", err)
 		}
 
-		if len(appVerCheck.Config.Variable) != 0 {
-			t.Errorf("expected 0 env vars after deleting all, got %d", len(appVerCheck.Config.Variable))
-			for _, ev := range appVerCheck.Config.Variable {
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVerCheck)
+		if err != nil {
+			t.Fatalf("failed to resolve config: %v", err)
+		}
+
+		if len(resolvedCfg.Variables) != 0 {
+			t.Errorf("expected 0 env vars after deleting all, got %d", len(resolvedCfg.Variables))
+			for _, ev := range resolvedCfg.Variables {
 				t.Errorf("  unexpected var: %s = %s", ev.Key, ev.Value)
 			}
 		}
@@ -420,12 +451,17 @@ func TestSetEnvVars_Batch(t *testing.T) {
 			t.Fatalf("failed to get app version: %v", err)
 		}
 
-		if len(appVer.Config.Variable) != 3 {
-			t.Fatalf("expected 3 env vars, got %d", len(appVer.Config.Variable))
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVer)
+		if err != nil {
+			t.Fatalf("failed to resolve config: %v", err)
 		}
 
-		vars := map[string]core_v1alpha.Variable{}
-		for _, v := range appVer.Config.Variable {
+		if len(resolvedCfg.Variables) != 3 {
+			t.Fatalf("expected 3 env vars, got %d", len(resolvedCfg.Variables))
+		}
+
+		vars := map[string]core_v1alpha.ConfigSpecVariables{}
+		for _, v := range resolvedCfg.Variables {
 			vars[v.Key] = v
 		}
 
@@ -438,7 +474,7 @@ func TestSetEnvVars_Batch(t *testing.T) {
 		if vars["C"].Value != "3" || !vars["C"].Sensitive {
 			t.Errorf("C: got value=%q sensitive=%v, want value=%q sensitive=%v", vars["C"].Value, vars["C"].Sensitive, "3", true)
 		}
-		for _, v := range appVer.Config.Variable {
+		for _, v := range resolvedCfg.Variables {
 			if v.Source != "manual" {
 				t.Errorf("var %s: expected source %q, got %q", v.Key, "manual", v.Source)
 			}
@@ -540,12 +576,17 @@ func TestSetEnvVars_Batch(t *testing.T) {
 			t.Fatalf("failed to get app version: %v", err)
 		}
 
-		if len(appVer.Config.Variable) != 3 {
-			t.Fatalf("expected 3 env vars, got %d", len(appVer.Config.Variable))
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVer)
+		if err != nil {
+			t.Fatalf("failed to resolve config: %v", err)
 		}
 
-		vars := map[string]core_v1alpha.Variable{}
-		for _, v := range appVer.Config.Variable {
+		if len(resolvedCfg.Variables) != 3 {
+			t.Fatalf("expected 3 env vars, got %d", len(resolvedCfg.Variables))
+		}
+
+		vars := map[string]core_v1alpha.ConfigSpecVariables{}
+		for _, v := range resolvedCfg.Variables {
 			vars[v.Key] = v
 		}
 
@@ -647,16 +688,21 @@ func TestSetEnvVars_Batch(t *testing.T) {
 			t.Fatalf("failed to get app version: %v", err)
 		}
 
-		if len(ver.Config.Services) != 1 {
-			t.Fatalf("expected 1 service, got %d", len(ver.Config.Services))
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &ver)
+		if err != nil {
+			t.Fatalf("failed to resolve config: %v", err)
 		}
 
-		svc := ver.Config.Services[0]
+		if len(resolvedCfg.Services) != 1 {
+			t.Fatalf("expected 1 service, got %d", len(resolvedCfg.Services))
+		}
+
+		svc := resolvedCfg.Services[0]
 		if len(svc.Env) != 2 {
 			t.Fatalf("expected 2 service env vars, got %d", len(svc.Env))
 		}
 
-		envMap := map[string]core_v1alpha.Env{}
+		envMap := map[string]core_v1alpha.ConfigSpecServicesEnv{}
 		for _, e := range svc.Env {
 			envMap[e.Key] = e
 		}
@@ -668,8 +714,8 @@ func TestSetEnvVars_Batch(t *testing.T) {
 			t.Errorf("DB_PASS: got value=%q sensitive=%v, want value=%q sensitive=%v", envMap["DB_PASS"].Value, envMap["DB_PASS"].Sensitive, "secret", true)
 		}
 
-		if len(ver.Config.Variable) != 0 {
-			t.Errorf("expected 0 global env vars, got %d", len(ver.Config.Variable))
+		if len(resolvedCfg.Variables) != 0 {
+			t.Errorf("expected 0 global env vars, got %d", len(resolvedCfg.Variables))
 		}
 	})
 
@@ -708,6 +754,376 @@ func TestSetEnvVars_Batch(t *testing.T) {
 		_, err = client.SetEnvVars(ctx, appName, []*app_v1alpha.NamedValue{nv}, "nonexistent")
 		if err == nil {
 			t.Fatal("expected error for nonexistent service, got nil")
+		}
+	})
+}
+
+// setupAppWithConfig creates a test app with the given global vars and services via SetConfiguration.
+// Returns the app name and the CrudClient.
+func setupAppWithConfig(
+	t *testing.T,
+	ctx context.Context,
+	ec *entityserver.Client,
+	appInfo *AppInfo,
+	appName string,
+	globalVars []*app_v1alpha.NamedValue,
+	commands []*app_v1alpha.ServiceCommand,
+	services []*app_v1alpha.ServiceConfig,
+) *app_v1alpha.CrudClient {
+	t.Helper()
+
+	client := &app_v1alpha.CrudClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptCrud(appInfo)),
+	}
+
+	app := &core_v1alpha.App{}
+	appID, err := ec.Create(ctx, appName, app)
+	if err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+	_ = appID
+
+	cfg := &app_v1alpha.Configuration{}
+	if globalVars != nil {
+		cfg.SetEnvVars(globalVars)
+	}
+	if commands != nil {
+		cfg.SetCommands(commands)
+	}
+	if services != nil {
+		cfg.SetServices(services)
+	}
+
+	_, err = client.SetConfiguration(ctx, appName, cfg)
+	if err != nil {
+		t.Fatalf("failed to set initial configuration: %v", err)
+	}
+
+	return client
+}
+
+func resolveAppConfig(t *testing.T, ctx context.Context, ec *entityserver.Client, appName string) *core_v1alpha.ConfigSpec {
+	t.Helper()
+
+	var appCheck core_v1alpha.App
+	err := ec.Get(ctx, appName, &appCheck)
+	if err != nil {
+		t.Fatalf("failed to get app: %v", err)
+	}
+
+	var appVerCheck core_v1alpha.AppVersion
+	err = ec.GetById(ctx, appCheck.ActiveVersion, &appVerCheck)
+	if err != nil {
+		t.Fatalf("failed to get app version: %v", err)
+	}
+
+	resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVerCheck)
+	if err != nil {
+		t.Fatalf("failed to resolve config: %v", err)
+	}
+
+	return resolvedCfg
+}
+
+func makeNamedValue(key, value string, sensitive bool) *app_v1alpha.NamedValue {
+	nv := &app_v1alpha.NamedValue{}
+	nv.SetKey(key)
+	nv.SetValue(value)
+	nv.SetSensitive(sensitive)
+	return nv
+}
+
+func TestSetEnvVar(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+
+	appInfo := &AppInfo{
+		Log:  slog.Default(),
+		EC:   ec,
+		CPU:  &metrics.CPUUsage{},
+		Mem:  &metrics.MemoryUsage{},
+		HTTP: &metrics.HTTPMetrics{},
+	}
+
+	t.Run("adds global var preserving existing vars", func(t *testing.T) {
+		appName := "test-setenv-add"
+		client := setupAppWithConfig(t, ctx, ec, appInfo, appName,
+			[]*app_v1alpha.NamedValue{
+				makeNamedValue("FOO", "foo_val", false),
+				makeNamedValue("BAR", "bar_val", false),
+			},
+			nil, nil,
+		)
+
+		_, err := client.SetEnvVar(ctx, appName, "BAZ", "baz_val", false, "")
+		if err != nil {
+			t.Fatalf("SetEnvVar failed: %v", err)
+		}
+
+		cfg := resolveAppConfig(t, ctx, ec, appName)
+		if len(cfg.Variables) != 3 {
+			t.Fatalf("expected 3 vars, got %d", len(cfg.Variables))
+		}
+
+		varMap := make(map[string]core_v1alpha.ConfigSpecVariables)
+		for _, v := range cfg.Variables {
+			varMap[v.Key] = v
+		}
+
+		for _, key := range []string{"FOO", "BAR", "BAZ"} {
+			if _, ok := varMap[key]; !ok {
+				t.Errorf("expected var %s to be present", key)
+			}
+		}
+		if varMap["BAZ"].Source != "manual" {
+			t.Errorf("expected BAZ source=manual, got %q", varMap["BAZ"].Source)
+		}
+	})
+
+	t.Run("updates existing global var", func(t *testing.T) {
+		appName := "test-setenv-update"
+		client := setupAppWithConfig(t, ctx, ec, appInfo, appName,
+			[]*app_v1alpha.NamedValue{
+				makeNamedValue("FOO", "old_val", false),
+				makeNamedValue("BAR", "bar_val", false),
+			},
+			nil, nil,
+		)
+
+		_, err := client.SetEnvVar(ctx, appName, "FOO", "new_val", true, "")
+		if err != nil {
+			t.Fatalf("SetEnvVar failed: %v", err)
+		}
+
+		cfg := resolveAppConfig(t, ctx, ec, appName)
+		if len(cfg.Variables) != 2 {
+			t.Fatalf("expected 2 vars, got %d", len(cfg.Variables))
+		}
+
+		varMap := make(map[string]core_v1alpha.ConfigSpecVariables)
+		for _, v := range cfg.Variables {
+			varMap[v.Key] = v
+		}
+
+		if varMap["FOO"].Value != "new_val" {
+			t.Errorf("expected FOO value=new_val, got %q", varMap["FOO"].Value)
+		}
+		if varMap["FOO"].Sensitive != true {
+			t.Errorf("expected FOO sensitive=true")
+		}
+		if varMap["FOO"].Source != "manual" {
+			t.Errorf("expected FOO source=manual, got %q", varMap["FOO"].Source)
+		}
+		if varMap["BAR"].Value != "bar_val" {
+			t.Errorf("expected BAR to be unchanged, got %q", varMap["BAR"].Value)
+		}
+	})
+
+	t.Run("adds per-service var preserving global vars", func(t *testing.T) {
+		appName := "test-setenv-svc"
+
+		// Create a service via Commands so it exists in spec.Services
+		cmd := &app_v1alpha.ServiceCommand{}
+		cmd.SetService("web")
+		cmd.SetCommand("./start-web")
+
+		client := setupAppWithConfig(t, ctx, ec, appInfo, appName,
+			[]*app_v1alpha.NamedValue{
+				makeNamedValue("GLOBAL1", "g1", false),
+			},
+			[]*app_v1alpha.ServiceCommand{cmd},
+			nil,
+		)
+
+		_, err := client.SetEnvVar(ctx, appName, "SVC_KEY", "svc_val", false, "web")
+		if err != nil {
+			t.Fatalf("SetEnvVar failed: %v", err)
+		}
+
+		cfg := resolveAppConfig(t, ctx, ec, appName)
+
+		// Global var preserved
+		if len(cfg.Variables) != 1 {
+			t.Fatalf("expected 1 global var, got %d", len(cfg.Variables))
+		}
+		if cfg.Variables[0].Key != "GLOBAL1" || cfg.Variables[0].Value != "g1" {
+			t.Errorf("global var changed: %+v", cfg.Variables[0])
+		}
+
+		// Service var added
+		var webSvc *core_v1alpha.ConfigSpecServices
+		for i := range cfg.Services {
+			if cfg.Services[i].Name == "web" {
+				webSvc = &cfg.Services[i]
+				break
+			}
+		}
+		if webSvc == nil {
+			t.Fatal("web service not found")
+		}
+		if len(webSvc.Env) != 1 {
+			t.Fatalf("expected 1 service env var, got %d", len(webSvc.Env))
+		}
+		if webSvc.Env[0].Key != "SVC_KEY" || webSvc.Env[0].Value != "svc_val" {
+			t.Errorf("unexpected service env var: %+v", webSvc.Env[0])
+		}
+		if webSvc.Env[0].Source != "manual" {
+			t.Errorf("expected service env source=manual, got %q", webSvc.Env[0].Source)
+		}
+	})
+
+	t.Run("error on non-existent service", func(t *testing.T) {
+		appName := "test-setenv-nosvc"
+		client := setupAppWithConfig(t, ctx, ec, appInfo, appName,
+			[]*app_v1alpha.NamedValue{
+				makeNamedValue("FOO", "bar", false),
+			},
+			nil, nil,
+		)
+
+		_, err := client.SetEnvVar(ctx, appName, "KEY", "val", false, "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for non-existent service")
+		}
+	})
+}
+
+func TestDeleteEnvVar(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+
+	appInfo := &AppInfo{
+		Log:  slog.Default(),
+		EC:   ec,
+		CPU:  &metrics.CPUUsage{},
+		Mem:  &metrics.MemoryUsage{},
+		HTTP: &metrics.HTTPMetrics{},
+	}
+
+	t.Run("deletes global var preserving others", func(t *testing.T) {
+		appName := "test-delenv-global"
+		client := setupAppWithConfig(t, ctx, ec, appInfo, appName,
+			[]*app_v1alpha.NamedValue{
+				makeNamedValue("FOO", "foo_val", false),
+				makeNamedValue("BAR", "bar_val", false),
+				makeNamedValue("BAZ", "baz_val", true),
+			},
+			nil, nil,
+		)
+
+		_, err := client.DeleteEnvVar(ctx, appName, "BAR", "")
+		if err != nil {
+			t.Fatalf("DeleteEnvVar failed: %v", err)
+		}
+
+		cfg := resolveAppConfig(t, ctx, ec, appName)
+		if len(cfg.Variables) != 2 {
+			t.Fatalf("expected 2 vars, got %d", len(cfg.Variables))
+		}
+
+		varMap := make(map[string]core_v1alpha.ConfigSpecVariables)
+		for _, v := range cfg.Variables {
+			varMap[v.Key] = v
+		}
+
+		if _, ok := varMap["BAR"]; ok {
+			t.Error("BAR should have been deleted")
+		}
+		if varMap["FOO"].Value != "foo_val" {
+			t.Errorf("FOO should be preserved, got %q", varMap["FOO"].Value)
+		}
+		if varMap["BAZ"].Value != "baz_val" {
+			t.Errorf("BAZ should be preserved, got %q", varMap["BAZ"].Value)
+		}
+	})
+
+	t.Run("deletes per-service var preserving others", func(t *testing.T) {
+		appName := "test-delenv-svc"
+
+		cmd := &app_v1alpha.ServiceCommand{}
+		cmd.SetService("web")
+		cmd.SetCommand("./start")
+
+		svcEnv1 := makeNamedValue("SVC_A", "a", false)
+		svcEnv2 := makeNamedValue("SVC_B", "b", false)
+		svcCfg := &app_v1alpha.ServiceConfig{}
+		svcCfg.SetService("web")
+		svcCfg.SetServiceEnv([]*app_v1alpha.NamedValue{svcEnv1, svcEnv2})
+
+		client := setupAppWithConfig(t, ctx, ec, appInfo, appName,
+			[]*app_v1alpha.NamedValue{
+				makeNamedValue("GLOBAL", "gval", false),
+			},
+			[]*app_v1alpha.ServiceCommand{cmd},
+			[]*app_v1alpha.ServiceConfig{svcCfg},
+		)
+
+		_, err := client.DeleteEnvVar(ctx, appName, "SVC_A", "web")
+		if err != nil {
+			t.Fatalf("DeleteEnvVar failed: %v", err)
+		}
+
+		cfg := resolveAppConfig(t, ctx, ec, appName)
+
+		// Global var preserved
+		if len(cfg.Variables) != 1 || cfg.Variables[0].Key != "GLOBAL" {
+			t.Errorf("global var should be preserved: %+v", cfg.Variables)
+		}
+
+		// Service var SVC_B preserved, SVC_A removed
+		var webSvc *core_v1alpha.ConfigSpecServices
+		for i := range cfg.Services {
+			if cfg.Services[i].Name == "web" {
+				webSvc = &cfg.Services[i]
+				break
+			}
+		}
+		if webSvc == nil {
+			t.Fatal("web service not found")
+		}
+		if len(webSvc.Env) != 1 {
+			t.Fatalf("expected 1 service env var, got %d", len(webSvc.Env))
+		}
+		if webSvc.Env[0].Key != "SVC_B" {
+			t.Errorf("expected SVC_B to remain, got %s", webSvc.Env[0].Key)
+		}
+	})
+
+	t.Run("error on non-existent var", func(t *testing.T) {
+		appName := "test-delenv-novar"
+		client := setupAppWithConfig(t, ctx, ec, appInfo, appName,
+			[]*app_v1alpha.NamedValue{
+				makeNamedValue("FOO", "bar", false),
+			},
+			nil, nil,
+		)
+
+		_, err := client.DeleteEnvVar(ctx, appName, "NONEXISTENT", "")
+		if err == nil {
+			t.Fatal("expected error for non-existent var")
+		}
+	})
+
+	t.Run("error on non-existent service", func(t *testing.T) {
+		appName := "test-delenv-nosvc"
+		client := setupAppWithConfig(t, ctx, ec, appInfo, appName,
+			[]*app_v1alpha.NamedValue{
+				makeNamedValue("FOO", "bar", false),
+			},
+			nil, nil,
+		)
+
+		_, err := client.DeleteEnvVar(ctx, appName, "KEY", "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for non-existent service")
 		}
 	})
 }

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tonistiigi/fsutil"
 	"miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/build/build_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -97,20 +98,20 @@ func NewBuilder(log *slog.Logger, eas *entityserver_v1alpha.EntityAccessClient, 
 // - Manual vars (source="manual") always persist and shadow config vars with the same key
 // - app.toml vars (source="config") override existing config vars but never manual vars
 // - Removing a var from app.toml only deletes it if source="config"
-func mergeServiceEnvVars(existingEnvs []core_v1alpha.Env, newEnvs []core_v1alpha.Env) []core_v1alpha.Env {
+func mergeServiceEnvVars(existingEnvs []core_v1alpha.ConfigSpecServicesEnv, newEnvs []core_v1alpha.ConfigSpecServicesEnv) []core_v1alpha.ConfigSpecServicesEnv {
 	// If no new env vars from app.toml, preserve all existing
 	if len(newEnvs) == 0 {
 		return existingEnvs
 	}
 
 	// Build map of app.toml env vars
-	newEnvMap := make(map[string]core_v1alpha.Env)
+	newEnvMap := make(map[string]core_v1alpha.ConfigSpecServicesEnv)
 	for _, e := range newEnvs {
 		newEnvMap[e.Key] = e
 	}
 
 	// Build result by merging
-	envMap := make(map[string]core_v1alpha.Env)
+	envMap := make(map[string]core_v1alpha.ConfigSpecServicesEnv)
 
 	// Keep manual vars - they shadow config vars with the same key
 	for _, e := range existingEnvs {
@@ -119,7 +120,8 @@ func mergeServiceEnvVars(existingEnvs []core_v1alpha.Env, newEnvs []core_v1alpha
 			source = "manual" // backward compatibility: preserve unknown-source vars
 		}
 
-		if source == "manual" {
+		isManual := source == "manual"
+		if isManual {
 			envMap[e.Key] = e
 		}
 		// config vars only kept if still in app.toml (checked below)
@@ -133,7 +135,7 @@ func mergeServiceEnvVars(existingEnvs []core_v1alpha.Env, newEnvs []core_v1alpha
 	}
 
 	// Convert back to slice
-	result := make([]core_v1alpha.Env, 0, len(envMap))
+	result := make([]core_v1alpha.ConfigSpecServicesEnv, 0, len(envMap))
 	for _, e := range envMap {
 		result = append(result, e)
 	}
@@ -146,8 +148,8 @@ var errNoServices = errors.New("no services defined: please define at least one 
 
 // validateServicesExist checks that at least one service is defined in the config.
 // Returns an error if no services are found.
-func validateServicesExist(cfg core_v1alpha.Config) error {
-	if len(cfg.Services) == 0 {
+func validateServicesExist(spec core_v1alpha.ConfigSpec) error {
+	if len(spec.Services) == 0 {
 		return errNoServices
 	}
 	return nil
@@ -157,7 +159,7 @@ func validateServicesExist(cfg core_v1alpha.Config) error {
 // resolves defaults, and returns the final service configurations.
 // This is the core logic for determining which services exist in an app_version
 // and what their concurrency settings should be.
-func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[string]string) []core_v1alpha.Services {
+func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[string]string) []core_v1alpha.ConfigSpecServices {
 	// Build command map from app config
 	srvMap := map[string]string{}
 	if appConfig != nil {
@@ -201,13 +203,14 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 		ac.ResolveDefaults(allServiceNames)
 	}
 
-	// Build Config.Services[] from fully-resolved appconfig
+	// Build ConfigSpec.Services[] from fully-resolved appconfig
 	// IMPORTANT: Iterate over allServiceNames, not srvMap, because services
 	// may have concurrency config without commands
-	var services []core_v1alpha.Services
+	var services []core_v1alpha.ConfigSpecServices
 	for _, serviceName := range allServiceNames {
-		svc := core_v1alpha.Services{
-			Name: serviceName,
+		svc := core_v1alpha.ConfigSpecServices{
+			Name:    serviceName,
+			Command: srvMap[serviceName],
 		}
 
 		// Map from appconfig to entity schema
@@ -234,7 +237,7 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 			}
 
 			if serviceConfig.Concurrency != nil {
-				svc.ServiceConcurrency = core_v1alpha.ServiceConcurrency{
+				svc.Concurrency = core_v1alpha.ConfigSpecServicesConcurrency{
 					Mode:                serviceConfig.Concurrency.Mode,
 					NumInstances:        int64(serviceConfig.Concurrency.NumInstances),
 					RequestsPerInstance: int64(serviceConfig.Concurrency.RequestsPerInstance),
@@ -245,9 +248,9 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 
 			// Convert disk configurations
 			if len(serviceConfig.Disks) > 0 {
-				svc.Disks = make([]core_v1alpha.Disks, 0, len(serviceConfig.Disks))
+				svc.Disks = make([]core_v1alpha.ConfigSpecServicesDisks, 0, len(serviceConfig.Disks))
 				for _, disk := range serviceConfig.Disks {
-					svc.Disks = append(svc.Disks, core_v1alpha.Disks{
+					svc.Disks = append(svc.Disks, core_v1alpha.ConfigSpecServicesDisks{
 						Name:         disk.Name,
 						MountPath:    disk.MountPath,
 						ReadOnly:     disk.ReadOnly,
@@ -260,9 +263,9 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 
 			// Convert service-specific environment variables
 			if len(serviceConfig.EnvVars) > 0 {
-				svc.Env = make([]core_v1alpha.Env, 0, len(serviceConfig.EnvVars))
+				svc.Env = make([]core_v1alpha.ConfigSpecServicesEnv, 0, len(serviceConfig.EnvVars))
 				for _, envVar := range serviceConfig.EnvVars {
-					svc.Env = append(svc.Env, core_v1alpha.Env{
+					svc.Env = append(svc.Env, core_v1alpha.ConfigSpecServicesEnv{
 						Key:    envVar.Key,
 						Value:  envVar.Value,
 						Source: "config",
@@ -289,7 +292,7 @@ type ConfigInputs struct {
 	ProcfileServices map[string]string
 
 	// ExistingConfig is the current config to preserve manual env vars from
-	ExistingConfig core_v1alpha.Config
+	ExistingConfig core_v1alpha.ConfigSpec
 
 	// CliEnvVars are environment variables passed via CLI flags (e.g., miren deploy -e KEY=VALUE)
 	// These are applied with source="manual" and take precedence over app.toml vars
@@ -298,26 +301,26 @@ type ConfigInputs struct {
 
 // buildVersionConfig builds the app version config from all inputs.
 // This is a pure function that can be easily tested.
-func buildVersionConfig(inputs ConfigInputs) core_v1alpha.Config {
-	var cfg core_v1alpha.Config
+func buildVersionConfig(inputs ConfigInputs) core_v1alpha.ConfigSpec {
+	var spec core_v1alpha.ConfigSpec
 
 	res := inputs.BuildResult
 	ac := inputs.AppConfig
 	procfileServices := inputs.ProcfileServices
 
 	// Preserve existing variables for merging later
-	cfg.Variable = inputs.ExistingConfig.Variable
+	spec.Variables = inputs.ExistingConfig.Variables
 
 	// Set entrypoint from stack build result
 	if res != nil && res.Entrypoint != "" {
-		cfg.Entrypoint = res.Entrypoint
+		spec.Entrypoint = res.Entrypoint
 	}
 
 	// Set start directory from build result, defaulting to /app
 	if res != nil && res.WorkingDir != "" {
-		cfg.StartDirectory = res.WorkingDir
+		spec.StartDirectory = res.WorkingDir
 	} else {
-		cfg.StartDirectory = "/app"
+		spec.StartDirectory = "/app"
 	}
 
 	// If no web service defined in app config or Procfile, but we have a command or entrypoint,
@@ -339,67 +342,41 @@ func buildVersionConfig(inputs ConfigInputs) core_v1alpha.Config {
 	}
 
 	// Build service configurations with concurrency settings from app.toml/Procfile
-	cfg.Services = buildServicesConfig(ac, procfileServices)
+	// Commands are set directly on each service (svc.Command) by buildServicesConfig
+	spec.Services = buildServicesConfig(ac, procfileServices)
 
 	// Merge env vars: preserve manual vars from existing services
-	existingServices := inputs.ExistingConfig.Services
-	for i := range cfg.Services {
-		serviceName := cfg.Services[i].Name
+	for i := range spec.Services {
+		serviceName := spec.Services[i].Name
 
 		// Find matching service in existing config
-		for _, existingSvc := range existingServices {
+		for _, existingSvc := range inputs.ExistingConfig.Services {
 			if existingSvc.Name == serviceName {
 				// Merge env vars: app.toml vars override, but manual vars persist
-				cfg.Services[i].Env = mergeServiceEnvVars(existingSvc.Env, cfg.Services[i].Env)
+				spec.Services[i].Env = mergeServiceEnvVars(existingSvc.Env, spec.Services[i].Env)
 				break
 			}
 		}
 	}
 
-	// Build commands list for services that have explicit commands
-	var serviceCmds []core_v1alpha.Commands
-	for _, svc := range cfg.Services {
-		// Check if this service has a command from app config or procfile
-		var cmd string
-		if ac != nil {
-			if svcConfig, ok := ac.Services[svc.Name]; ok && svcConfig != nil && svcConfig.Command != "" {
-				cmd = svcConfig.Command
-			}
-		}
-		if cmd == "" {
-			if procCmd, ok := procfileServices[svc.Name]; ok {
-				cmd = procCmd
-			}
-		}
-
-		if cmd != "" {
-			serviceCmds = append(serviceCmds, core_v1alpha.Commands{
-				Service: svc.Name,
-				Command: cmd,
-			})
-		}
-	}
-
-	cfg.Commands = serviceCmds
-
 	// Merge environment variables from app config
 	// Preserves existing variables when app.toml has no [[env]] section
-	cfg.Variable = mergeVariablesFromAppConfig(cfg.Variable, ac)
+	spec.Variables = mergeVariablesFromAppConfig(spec.Variables, ac)
 
 	// Apply CLI-provided env vars last (highest precedence, always source="manual")
-	cfg.Variable = mergeCliEnvVars(cfg.Variable, inputs.CliEnvVars)
+	spec.Variables = mergeCliEnvVars(spec.Variables, inputs.CliEnvVars)
 
-	return cfg
+	return spec
 }
 
-func buildVariablesFromAppConfig(appConfig *appconfig.AppConfig) []core_v1alpha.Variable {
+func buildVariablesFromAppConfig(appConfig *appconfig.AppConfig) []core_v1alpha.ConfigSpecVariables {
 	if appConfig == nil || len(appConfig.EnvVars) == 0 {
 		return nil
 	}
 
-	variables := make([]core_v1alpha.Variable, 0, len(appConfig.EnvVars))
+	variables := make([]core_v1alpha.ConfigSpecVariables, 0, len(appConfig.EnvVars))
 	for _, envVar := range appConfig.EnvVars {
-		variables = append(variables, core_v1alpha.Variable{
+		variables = append(variables, core_v1alpha.ConfigSpecVariables{
 			Key:    envVar.Key,
 			Value:  envVar.Value,
 			Source: "config",
@@ -414,7 +391,7 @@ func buildVariablesFromAppConfig(appConfig *appconfig.AppConfig) []core_v1alpha.
 // - Variables from app.toml (source="config") override existing config vars but never manual vars
 // - If a variable is removed from app.toml, it's only deleted if it was originally from config
 // - If appConfig is nil or has no env vars, all existing variables are preserved.
-func mergeVariablesFromAppConfig(existingVars []core_v1alpha.Variable, appConfig *appconfig.AppConfig) []core_v1alpha.Variable {
+func mergeVariablesFromAppConfig(existingVars []core_v1alpha.ConfigSpecVariables, appConfig *appconfig.AppConfig) []core_v1alpha.ConfigSpecVariables {
 	appConfigVars := buildVariablesFromAppConfig(appConfig)
 
 	// If no app.toml vars, preserve all existing vars
@@ -423,13 +400,13 @@ func mergeVariablesFromAppConfig(existingVars []core_v1alpha.Variable, appConfig
 	}
 
 	// Build a map of app.toml variables for quick lookup
-	appConfigMap := make(map[string]core_v1alpha.Variable)
+	appConfigMap := make(map[string]core_v1alpha.ConfigSpecVariables)
 	for _, v := range appConfigVars {
 		appConfigMap[v.Key] = v
 	}
 
 	// Build result by merging
-	varMap := make(map[string]core_v1alpha.Variable)
+	varMap := make(map[string]core_v1alpha.ConfigSpecVariables)
 
 	// First, add all existing manual variables - these always persist
 	for _, v := range existingVars {
@@ -454,7 +431,7 @@ func mergeVariablesFromAppConfig(existingVars []core_v1alpha.Variable, appConfig
 	}
 
 	// Convert map back to slice
-	result := make([]core_v1alpha.Variable, 0, len(varMap))
+	result := make([]core_v1alpha.ConfigSpecVariables, 0, len(varMap))
 	for _, v := range varMap {
 		result = append(result, v)
 	}
@@ -464,20 +441,20 @@ func mergeVariablesFromAppConfig(existingVars []core_v1alpha.Variable, appConfig
 
 // mergeCliEnvVars merges CLI-provided environment variables into the existing config.
 // CLI vars are always marked with source="manual" and override any existing var with the same key.
-func mergeCliEnvVars(existingVars []core_v1alpha.Variable, cliVars []*build_v1alpha.EnvironmentVariable) []core_v1alpha.Variable {
+func mergeCliEnvVars(existingVars []core_v1alpha.ConfigSpecVariables, cliVars []*build_v1alpha.EnvironmentVariable) []core_v1alpha.ConfigSpecVariables {
 	if len(cliVars) == 0 {
 		return existingVars
 	}
 
 	// Build a map of existing vars
-	varMap := make(map[string]core_v1alpha.Variable)
+	varMap := make(map[string]core_v1alpha.ConfigSpecVariables)
 	for _, v := range existingVars {
 		varMap[v.Key] = v
 	}
 
-	// CLI vars always override (marked as manual)
+	// CLI vars always override (marked as user-provided)
 	for _, cv := range cliVars {
-		varMap[cv.Key()] = core_v1alpha.Variable{
+		varMap[cv.Key()] = core_v1alpha.ConfigSpecVariables{
 			Key:       cv.Key(),
 			Value:     cv.Value(),
 			Sensitive: cv.Sensitive(),
@@ -486,7 +463,7 @@ func mergeCliEnvVars(existingVars []core_v1alpha.Variable, cliVars []*build_v1al
 	}
 
 	// Convert map back to slice
-	result := make([]core_v1alpha.Variable, 0, len(varMap))
+	result := make([]core_v1alpha.ConfigSpecVariables, 0, len(varMap))
 	for _, v := range varMap {
 		result = append(result, v)
 	}
@@ -497,6 +474,7 @@ func mergeCliEnvVars(existingVars []core_v1alpha.Variable, cliVars []*build_v1al
 func (b *Builder) nextVersion(ctx context.Context, name string) (
 	*core_v1alpha.App,
 	*core_v1alpha.AppVersion,
+	core_v1alpha.ConfigSpec,
 	string,
 	error,
 ) {
@@ -505,29 +483,34 @@ func (b *Builder) nextVersion(ctx context.Context, name string) (
 	err := b.ec.Get(ctx, name, &appRec)
 	if err != nil {
 		if !errors.Is(err, cond.ErrNotFound{}) {
-			return nil, nil, "", err
+			return nil, nil, core_v1alpha.ConfigSpec{}, "", err
 		}
 
 		appRec.Project = "project/default"
 
 		id, err := b.ec.Create(ctx, name, &appRec)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, core_v1alpha.ConfigSpec{}, "", err
 		}
 		appRec.ID = id
 	}
 
-	var currentCfg core_v1alpha.Config
+	var currentCfg core_v1alpha.ConfigSpec
 
 	if appRec.ActiveVersion != "" {
 		var verRec core_v1alpha.AppVersion
 
 		err := b.ec.GetById(ctx, appRec.ActiveVersion, &verRec)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, core_v1alpha.ConfigSpec{}, "", err
 		}
 
-		currentCfg = verRec.Config
+		// Resolve config from ConfigVersion if available, otherwise use inline
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, b.ec.EAC(), &verRec)
+		if err != nil {
+			return nil, nil, core_v1alpha.ConfigSpec{}, "", fmt.Errorf("failed to resolve config: %w", err)
+		}
+		currentCfg = *resolvedCfg
 	}
 
 	ver := name + "-" + idgen.Gen("v")
@@ -539,10 +522,9 @@ func (b *Builder) nextVersion(ctx context.Context, name string) (
 	av.App = appRec.ID
 	av.Version = ver
 	av.ImageUrl = "cluster.local:5000/" + name + ":" + art
-	av.Config = currentCfg
 	av.AdminToken = idgen.GenAdminToken()
 
-	return &appRec, &av, art, nil
+	return &appRec, &av, currentCfg, art, nil
 }
 
 func (b *Builder) loadAppConfig(dfs fsutil.FS) (*appconfig.AppConfig, error) {
@@ -596,7 +578,7 @@ func isSystemEnvVar(key string) bool {
 // into the build process. It reuses the same merge logic as runtime config:
 // existing config vars + app.toml vars + CLI vars, then filters out system-managed vars.
 func computeBuildEnvVars(
-	existingVars []core_v1alpha.Variable,
+	existingVars []core_v1alpha.ConfigSpecVariables,
 	ac *appconfig.AppConfig,
 	cliVars []*build_v1alpha.EnvironmentVariable,
 ) map[string]string {
@@ -734,7 +716,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		Log:    b.Log,
 	}
 
-	appRec, mrv, _, err := b.nextVersion(ctx, name)
+	appRec, mrv, existingCfg, _, err := b.nextVersion(ctx, name)
 	if err != nil {
 		b.Log.Error("error getting next version", "error", err)
 		b.sendErrorStatus(ctx, status, "Error getting next version: %v", err)
@@ -750,7 +732,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 
 	// Compute env vars to inject into the build process
-	buildEnvVars := computeBuildEnvVars(mrv.Config.Variable, ac, args.EnvVars())
+	buildEnvVars := computeBuildEnvVars(existingCfg.Variables, ac, args.EnvVars())
 	if len(buildEnvVars) > 0 {
 		b.Log.Info("injecting env vars into build", "count", len(buildEnvVars))
 	}
@@ -890,17 +872,17 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 
 	// Build the version config from all inputs
-	mrv.Config = buildVersionConfig(ConfigInputs{
+	configSpec := buildVersionConfig(ConfigInputs{
 		BuildResult:      res,
 		AppConfig:        ac,
 		ProcfileServices: procfileServices,
-		ExistingConfig:   mrv.Config,
+		ExistingConfig:   existingCfg,
 		CliEnvVars:       args.EnvVars(),
 	})
 
 	// Fail the deploy if no services are defined - this prevents deploying an app
 	// that can't serve any traffic
-	if err := validateServicesExist(mrv.Config); err != nil {
+	if err := validateServicesExist(configSpec); err != nil {
 		b.sendErrorStatus(ctx, status, "%s. See https://miren.md/services", err)
 		return err
 	}
@@ -914,6 +896,19 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	} else {
 		b.Log.Debug("no new env vars from app config, preserving existing variables")
 	}
+
+	// Create ConfigVersion as the sole config store (inline Config is no longer written)
+	configVer := &core_v1alpha.ConfigVersion{
+		App:  mrv.App,
+		Spec: configSpec,
+	}
+	cvName := mrv.Version + "-cfg"
+	cvid, err := b.ec.Create(ctx, cvName, configVer)
+	if err != nil {
+		return fmt.Errorf("error creating config version: %w", err)
+	}
+	mrv.ConfigVersion = cvid
+	mrv.Config = core_v1alpha.Config{}
 
 	id, err := b.ec.Create(ctx, mrv.Version, mrv)
 	if err != nil {
@@ -1191,31 +1186,25 @@ func (b *Builder) AnalyzeApp(ctx context.Context, state *build_v1alpha.BuilderAn
 	}
 
 	// Use buildVersionConfig to compute services - same logic as BuildFromTar
-	cfg := buildVersionConfig(ConfigInputs{
+	spec := buildVersionConfig(ConfigInputs{
 		BuildResult:      &buildResult,
 		AppConfig:        ac,
 		ProcfileServices: procfileServices,
 	})
 
-	result.SetWorkingDir(cfg.StartDirectory)
+	result.SetWorkingDir(spec.StartDirectory)
 
-	// Build a map of commands for quick lookup
-	commandMap := make(map[string]string)
-	for _, cmd := range cfg.Commands {
-		commandMap[cmd.Service] = cmd.Command
-	}
-
-	// Convert cfg.Services to ServiceInfo with source tracking
+	// Convert spec.Services to ServiceInfo with source tracking
 	// This includes ALL services, even those without explicit commands (they use image default)
 	var services []build_v1alpha.ServiceInfo
-	for _, svc := range cfg.Services {
+	for _, svc := range spec.Services {
 		var svcInfo build_v1alpha.ServiceInfo
 		svcInfo.SetName(svc.Name)
 
-		if cmd, hasCommand := commandMap[svc.Name]; hasCommand {
-			svcInfo.SetCommand(cmd)
+		if svc.Command != "" {
+			svcInfo.SetCommand(svc.Command)
 			// Determine source for this service
-			source := determineServiceSource(svc.Name, cmd, ac, procfileServices, &buildResult)
+			source := determineServiceSource(svc.Name, svc.Command, ac, procfileServices, &buildResult)
 			svcInfo.SetSource(source)
 
 			// Add event when we inject a synthetic web service from stack detection

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -16,7 +16,7 @@ func TestBuildVariablesFromAppConfig(t *testing.T) {
 	tests := []struct {
 		name          string
 		appConfig     *appconfig.AppConfig
-		wantVariables []core_v1alpha.Variable
+		wantVariables []core_v1alpha.ConfigSpecVariables
 	}{
 		{
 			name:          "nil app config",
@@ -37,8 +37,8 @@ func TestBuildVariablesFromAppConfig(t *testing.T) {
 					{Key: "DATABASE_URL", Value: "postgres://localhost/db"},
 				},
 			},
-			wantVariables: []core_v1alpha.Variable{
-				{Key: "DATABASE_URL", Value: "postgres://localhost/db"},
+			wantVariables: []core_v1alpha.ConfigSpecVariables{
+				{Key: "DATABASE_URL", Value: "postgres://localhost/db", Source: "config"},
 			},
 		},
 		{
@@ -50,10 +50,10 @@ func TestBuildVariablesFromAppConfig(t *testing.T) {
 					{Key: "PORT", Value: "8080"},
 				},
 			},
-			wantVariables: []core_v1alpha.Variable{
-				{Key: "DATABASE_URL", Value: "postgres://localhost/db"},
-				{Key: "API_KEY", Value: "secret123"},
-				{Key: "PORT", Value: "8080"},
+			wantVariables: []core_v1alpha.ConfigSpecVariables{
+				{Key: "DATABASE_URL", Value: "postgres://localhost/db", Source: "config"},
+				{Key: "API_KEY", Value: "secret123", Source: "config"},
+				{Key: "PORT", Value: "8080", Source: "config"},
 			},
 		},
 	}
@@ -80,7 +80,7 @@ func TestBuildServicesConfig(t *testing.T) {
 		name             string
 		appConfig        *appconfig.AppConfig
 		procfileServices map[string]string
-		validateServices func(t *testing.T, services []core_v1alpha.Services)
+		validateServices func(t *testing.T, services []core_v1alpha.ConfigSpecServices)
 	}{
 		{
 			name: "service with only concurrency config (no command) - uptime-kuma case",
@@ -96,11 +96,11 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1, "should have one service")
 				assert.Equal(t, "web", services[0].Name)
-				assert.Equal(t, "fixed", services[0].ServiceConcurrency.Mode)
-				assert.Equal(t, int64(1), services[0].ServiceConcurrency.NumInstances)
+				assert.Equal(t, "fixed", services[0].Concurrency.Mode)
+				assert.Equal(t, int64(1), services[0].Concurrency.NumInstances)
 			},
 		},
 		{
@@ -118,12 +118,12 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				assert.Equal(t, "web", services[0].Name)
-				assert.Equal(t, "auto", services[0].ServiceConcurrency.Mode)
-				assert.Equal(t, int64(10), services[0].ServiceConcurrency.RequestsPerInstance)
-				assert.Equal(t, "15m", services[0].ServiceConcurrency.ScaleDownDelay)
+				assert.Equal(t, "auto", services[0].Concurrency.Mode)
+				assert.Equal(t, int64(10), services[0].Concurrency.RequestsPerInstance)
+				assert.Equal(t, "15m", services[0].Concurrency.ScaleDownDelay)
 			},
 		},
 		{
@@ -132,13 +132,13 @@ func TestBuildServicesConfig(t *testing.T) {
 			procfileServices: map[string]string{
 				"web": "npm start",
 			},
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				assert.Equal(t, "web", services[0].Name)
 				// Web service should get auto mode defaults
-				assert.Equal(t, "auto", services[0].ServiceConcurrency.Mode)
-				assert.Equal(t, int64(10), services[0].ServiceConcurrency.RequestsPerInstance)
-				assert.Equal(t, "15m", services[0].ServiceConcurrency.ScaleDownDelay)
+				assert.Equal(t, "auto", services[0].Concurrency.Mode)
+				assert.Equal(t, int64(10), services[0].Concurrency.RequestsPerInstance)
+				assert.Equal(t, "15m", services[0].Concurrency.ScaleDownDelay)
 			},
 		},
 		{
@@ -164,29 +164,29 @@ func TestBuildServicesConfig(t *testing.T) {
 			procfileServices: map[string]string{
 				"cron": "node cron.js",
 			},
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 3, "should have three services")
 
 				// Find each service and validate
-				serviceMap := make(map[string]core_v1alpha.Services)
+				serviceMap := make(map[string]core_v1alpha.ConfigSpecServices)
 				for _, svc := range services {
 					serviceMap[svc.Name] = svc
 				}
 
 				// Web service
 				require.Contains(t, serviceMap, "web")
-				assert.Equal(t, "fixed", serviceMap["web"].ServiceConcurrency.Mode)
-				assert.Equal(t, int64(1), serviceMap["web"].ServiceConcurrency.NumInstances)
+				assert.Equal(t, "fixed", serviceMap["web"].Concurrency.Mode)
+				assert.Equal(t, int64(1), serviceMap["web"].Concurrency.NumInstances)
 
 				// Worker service
 				require.Contains(t, serviceMap, "worker")
-				assert.Equal(t, "fixed", serviceMap["worker"].ServiceConcurrency.Mode)
-				assert.Equal(t, int64(2), serviceMap["worker"].ServiceConcurrency.NumInstances)
+				assert.Equal(t, "fixed", serviceMap["worker"].Concurrency.Mode)
+				assert.Equal(t, int64(2), serviceMap["worker"].Concurrency.NumInstances)
 
 				// Cron service (from procfile, gets default fixed mode)
 				require.Contains(t, serviceMap, "cron")
-				assert.Equal(t, "fixed", serviceMap["cron"].ServiceConcurrency.Mode)
-				assert.Equal(t, int64(1), serviceMap["cron"].ServiceConcurrency.NumInstances)
+				assert.Equal(t, "fixed", serviceMap["cron"].Concurrency.Mode)
+				assert.Equal(t, int64(1), serviceMap["cron"].Concurrency.NumInstances)
 			},
 		},
 		{
@@ -206,13 +206,13 @@ func TestBuildServicesConfig(t *testing.T) {
 			procfileServices: map[string]string{
 				"web": "npm start",
 			},
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				assert.Equal(t, "web", services[0].Name)
 				// Should get app config concurrency, not defaults
-				assert.Equal(t, "auto", services[0].ServiceConcurrency.Mode)
-				assert.Equal(t, int64(20), services[0].ServiceConcurrency.RequestsPerInstance)
-				assert.Equal(t, "5m", services[0].ServiceConcurrency.ScaleDownDelay)
+				assert.Equal(t, "auto", services[0].Concurrency.Mode)
+				assert.Equal(t, int64(20), services[0].Concurrency.RequestsPerInstance)
+				assert.Equal(t, "5m", services[0].Concurrency.ScaleDownDelay)
 			},
 		},
 		{
@@ -226,12 +226,12 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				assert.Equal(t, "worker", services[0].Name)
 				// No concurrency will be empty since ResolveDefaults skips existing services
-				assert.Equal(t, "", services[0].ServiceConcurrency.Mode)
-				assert.Equal(t, int64(0), services[0].ServiceConcurrency.NumInstances)
+				assert.Equal(t, "", services[0].Concurrency.Mode)
+				assert.Equal(t, int64(0), services[0].Concurrency.NumInstances)
 			},
 		},
 		{
@@ -248,7 +248,7 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				assert.Equal(t, "postgres", services[0].Name)
 				assert.Equal(t, "oci.miren.cloud/postgres:15", services[0].Image)
@@ -267,7 +267,7 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				assert.Equal(t, "web", services[0].Name)
 				assert.Equal(t, "", services[0].Image, "image should be empty when not specified")
@@ -300,10 +300,10 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 3)
 
-				serviceMap := make(map[string]core_v1alpha.Services)
+				serviceMap := make(map[string]core_v1alpha.ConfigSpecServices)
 				for _, svc := range services {
 					serviceMap[svc.Name] = svc
 				}
@@ -341,7 +341,7 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				svc := services[0]
 				assert.Equal(t, "postgres", svc.Name)
@@ -385,7 +385,7 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				svc := services[0]
 				assert.Equal(t, "database", svc.Name)
@@ -426,7 +426,7 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				svc := services[0]
 
@@ -454,7 +454,7 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 1)
 				svc := services[0]
 				assert.Equal(t, "web", svc.Name)
@@ -498,10 +498,10 @@ func TestBuildServicesConfig(t *testing.T) {
 				},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				require.Len(t, services, 3)
 
-				serviceMap := make(map[string]core_v1alpha.Services)
+				serviceMap := make(map[string]core_v1alpha.ConfigSpecServices)
 				for _, svc := range services {
 					serviceMap[svc.Name] = svc
 				}
@@ -529,7 +529,7 @@ func TestBuildServicesConfig(t *testing.T) {
 			name:             "no config no procfile",
 			appConfig:        nil,
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				assert.Len(t, services, 0, "should have no services")
 			},
 		},
@@ -539,7 +539,7 @@ func TestBuildServicesConfig(t *testing.T) {
 				Services: map[string]*appconfig.ServiceConfig{},
 			},
 			procfileServices: nil,
-			validateServices: func(t *testing.T, services []core_v1alpha.Services) {
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
 				assert.Len(t, services, 0, "should have no services")
 			},
 		},
@@ -556,37 +556,37 @@ func TestBuildServicesConfig(t *testing.T) {
 func TestMergeVariablesFromAppConfig(t *testing.T) {
 	tests := []struct {
 		name         string
-		existingVars []core_v1alpha.Variable
+		existingVars []core_v1alpha.ConfigSpecVariables
 		appConfig    *appconfig.AppConfig
-		wantVars     []core_v1alpha.Variable
+		wantVars     []core_v1alpha.ConfigSpecVariables
 	}{
 		{
 			name: "preserve existing vars when app.toml has no env section",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "API_KEY", Value: "secret123", Source: "manual"},
 				{Key: "DATABASE_URL", Value: "postgres://localhost/db", Source: "config"},
 			},
 			appConfig: nil,
-			wantVars: []core_v1alpha.Variable{
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "API_KEY", Value: "secret123", Source: "manual"},
 				{Key: "DATABASE_URL", Value: "postgres://localhost/db", Source: "config"},
 			},
 		},
 		{
 			name: "preserve existing vars when app.toml has empty env section",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "API_KEY", Value: "secret123", Source: "manual"},
 			},
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{},
 			},
-			wantVars: []core_v1alpha.Variable{
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "API_KEY", Value: "secret123", Source: "manual"},
 			},
 		},
 		{
 			name: "manual vars persist when removed from app.toml",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "MANUAL_VAR", Value: "manual_value", Source: "manual"},
 				{Key: "CONFIG_VAR", Value: "config_value", Source: "config"},
 			},
@@ -595,14 +595,14 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 					{Key: "NEW_VAR", Value: "new_value"},
 				},
 			},
-			wantVars: []core_v1alpha.Variable{
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "MANUAL_VAR", Value: "manual_value", Source: "manual"},
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
 		},
 		{
 			name: "config vars removed when removed from app.toml",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "CONFIG_VAR_1", Value: "value1", Source: "config"},
 				{Key: "CONFIG_VAR_2", Value: "value2", Source: "config"},
 			},
@@ -611,13 +611,13 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 					{Key: "CONFIG_VAR_1", Value: "value1"},
 				},
 			},
-			wantVars: []core_v1alpha.Variable{
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "CONFIG_VAR_1", Value: "value1", Source: "config"},
 			},
 		},
 		{
 			name: "app.toml vars override config vars per-key",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "VAR1", Value: "old_value", Source: "config"},
 				{Key: "VAR2", Value: "keep_value", Source: "manual"},
 			},
@@ -626,14 +626,14 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 					{Key: "VAR1", Value: "new_value"},
 				},
 			},
-			wantVars: []core_v1alpha.Variable{
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "VAR1", Value: "new_value", Source: "config"},
 				{Key: "VAR2", Value: "keep_value", Source: "manual"},
 			},
 		},
 		{
 			name: "backward compatibility - empty source preserved as manual",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "OLD_VAR", Value: "old_value", Source: ""},
 			},
 			appConfig: &appconfig.AppConfig{
@@ -641,14 +641,14 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 					{Key: "NEW_VAR", Value: "new_value"},
 				},
 			},
-			wantVars: []core_v1alpha.Variable{
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "OLD_VAR", Value: "old_value", Source: ""},
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
 		},
 		{
 			name: "manual var shadows config var with same key",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "DATABASE_URL", Value: "manually_set", Source: "manual"},
 			},
 			appConfig: &appconfig.AppConfig{
@@ -656,31 +656,30 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 					{Key: "DATABASE_URL", Value: "from_config"},
 				},
 			},
-			wantVars: []core_v1alpha.Variable{
-				// Manual wins - user intent takes precedence over config
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "DATABASE_URL", Value: "manually_set", Source: "manual"},
 			},
 		},
 		{
 			name: "config cannot override existing manual var",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "SECRET", Value: "user_secret", Source: "manual"},
 				{Key: "LOG_LEVEL", Value: "debug", Source: "config"},
 			},
 			appConfig: &appconfig.AppConfig{
 				EnvVars: []appconfig.AppEnvVar{
-					{Key: "SECRET", Value: "default_secret"}, // Should NOT override manual
-					{Key: "LOG_LEVEL", Value: "info"},        // Should override config
+					{Key: "SECRET", Value: "default_secret"},
+					{Key: "LOG_LEVEL", Value: "info"},
 				},
 			},
-			wantVars: []core_v1alpha.Variable{
-				{Key: "SECRET", Value: "user_secret", Source: "manual"}, // Manual preserved
-				{Key: "LOG_LEVEL", Value: "info", Source: "config"},     // Config updated
+			wantVars: []core_v1alpha.ConfigSpecVariables{
+				{Key: "SECRET", Value: "user_secret", Source: "manual"},
+				{Key: "LOG_LEVEL", Value: "info", Source: "config"},
 			},
 		},
 		{
 			name: "complex mix of manual and config vars",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "MANUAL_1", Value: "m1", Source: "manual"},
 				{Key: "CONFIG_1", Value: "c1", Source: "config"},
 				{Key: "MANUAL_2", Value: "m2", Source: "manual"},
@@ -692,7 +691,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 					{Key: "CONFIG_3", Value: "c3"},
 				},
 			},
-			wantVars: []core_v1alpha.Variable{
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "MANUAL_1", Value: "m1", Source: "manual"},
 				{Key: "MANUAL_2", Value: "m2", Source: "manual"},
 				{Key: "CONFIG_1", Value: "c1_updated", Source: "config"},
@@ -701,7 +700,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 		},
 		{
 			name: "empty source vars preserved when app.toml adds env",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "LEGACY_DB_URL", Value: "postgres://old/db", Source: ""},
 				{Key: "LEGACY_API_KEY", Value: "key123", Source: ""},
 				{Key: "MANUAL_SECRET", Value: "secret", Source: "manual"},
@@ -711,7 +710,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 					{Key: "NEW_CONFIG_VAR", Value: "new_value"},
 				},
 			},
-			wantVars: []core_v1alpha.Variable{
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "LEGACY_DB_URL", Value: "postgres://old/db", Source: ""},
 				{Key: "LEGACY_API_KEY", Value: "key123", Source: ""},
 				{Key: "MANUAL_SECRET", Value: "secret", Source: "manual"},
@@ -726,9 +725,9 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 		},
 		{
 			name:         "handle empty existing vars with no app config",
-			existingVars: []core_v1alpha.Variable{},
+			existingVars: []core_v1alpha.ConfigSpecVariables{},
 			appConfig:    nil,
-			wantVars:     []core_v1alpha.Variable{},
+			wantVars:     []core_v1alpha.ConfigSpecVariables{},
 		},
 		{
 			name:         "set new vars when there are no existing vars",
@@ -738,7 +737,7 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 					{Key: "NEW_VAR", Value: "new_value"},
 				},
 			},
-			wantVars: []core_v1alpha.Variable{
+			wantVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
 		},
@@ -751,13 +750,13 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 				assert.Nil(t, result)
 			} else {
 				// Sort both slices by key for consistent comparison
-				sortVarsByKey := func(vars []core_v1alpha.Variable) {
+				sortVarsByKey := func(vars []core_v1alpha.ConfigSpecVariables) {
 					sort.Slice(vars, func(i, j int) bool {
 						return vars[i].Key < vars[j].Key
 					})
 				}
 				sortVarsByKey(result)
-				wantSorted := make([]core_v1alpha.Variable, len(tt.wantVars))
+				wantSorted := make([]core_v1alpha.ConfigSpecVariables, len(tt.wantVars))
 				copy(wantSorted, tt.wantVars)
 				sortVarsByKey(wantSorted)
 
@@ -775,91 +774,90 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 func TestMergeServiceEnvVars(t *testing.T) {
 	tests := []struct {
 		name         string
-		existingEnvs []core_v1alpha.Env
-		newEnvs      []core_v1alpha.Env
-		wantEnvs     []core_v1alpha.Env
+		existingEnvs []core_v1alpha.ConfigSpecServicesEnv
+		newEnvs      []core_v1alpha.ConfigSpecServicesEnv
+		wantEnvs     []core_v1alpha.ConfigSpecServicesEnv
 	}{
 		{
 			name: "manual vars persist when removed from app.toml",
-			existingEnvs: []core_v1alpha.Env{
+			existingEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "MANUAL_VAR", Value: "manual_value", Source: "manual"},
 				{Key: "CONFIG_VAR", Value: "config_value", Source: "config"},
 			},
-			newEnvs: []core_v1alpha.Env{
+			newEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
-			wantEnvs: []core_v1alpha.Env{
+			wantEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "MANUAL_VAR", Value: "manual_value", Source: "manual"},
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
 		},
 		{
 			name: "config vars removed when removed from app.toml",
-			existingEnvs: []core_v1alpha.Env{
+			existingEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "CONFIG_VAR_1", Value: "value1", Source: "config"},
 				{Key: "CONFIG_VAR_2", Value: "value2", Source: "config"},
 			},
-			newEnvs: []core_v1alpha.Env{
+			newEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "CONFIG_VAR_1", Value: "value1", Source: "config"},
 			},
-			wantEnvs: []core_v1alpha.Env{
+			wantEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "CONFIG_VAR_1", Value: "value1", Source: "config"},
 			},
 		},
 		{
 			name: "backward compatibility - empty source preserved as manual",
-			existingEnvs: []core_v1alpha.Env{
+			existingEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "OLD_VAR", Value: "old_value", Source: ""},
 			},
-			newEnvs: []core_v1alpha.Env{
+			newEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
-			wantEnvs: []core_v1alpha.Env{
+			wantEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "OLD_VAR", Value: "old_value", Source: ""},
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
 		},
 		{
 			name: "manual var shadows config var with same key",
-			existingEnvs: []core_v1alpha.Env{
+			existingEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "DATABASE_URL", Value: "manually_set", Source: "manual"},
 			},
-			newEnvs: []core_v1alpha.Env{
+			newEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "DATABASE_URL", Value: "from_config", Source: "config"},
 			},
-			wantEnvs: []core_v1alpha.Env{
-				// Manual wins - user intent takes precedence over config
+			wantEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "DATABASE_URL", Value: "manually_set", Source: "manual"},
 			},
 		},
 		{
 			name: "config cannot override existing manual var",
-			existingEnvs: []core_v1alpha.Env{
+			existingEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "SECRET", Value: "user_secret", Source: "manual"},
 				{Key: "LOG_LEVEL", Value: "debug", Source: "config"},
 			},
-			newEnvs: []core_v1alpha.Env{
-				{Key: "SECRET", Value: "default_secret", Source: "config"}, // Should NOT override manual
-				{Key: "LOG_LEVEL", Value: "info", Source: "config"},        // Should override config
+			newEnvs: []core_v1alpha.ConfigSpecServicesEnv{
+				{Key: "SECRET", Value: "default_secret", Source: "config"},
+				{Key: "LOG_LEVEL", Value: "info", Source: "config"},
 			},
-			wantEnvs: []core_v1alpha.Env{
-				{Key: "SECRET", Value: "user_secret", Source: "manual"}, // Manual preserved
-				{Key: "LOG_LEVEL", Value: "info", Source: "config"},     // Config updated
+			wantEnvs: []core_v1alpha.ConfigSpecServicesEnv{
+				{Key: "SECRET", Value: "user_secret", Source: "manual"},
+				{Key: "LOG_LEVEL", Value: "info", Source: "config"},
 			},
 		},
 		{
 			name: "complex mix of manual and config vars",
-			existingEnvs: []core_v1alpha.Env{
+			existingEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "MANUAL_1", Value: "m1", Source: "manual"},
 				{Key: "CONFIG_1", Value: "c1", Source: "config"},
 				{Key: "MANUAL_2", Value: "m2", Source: "manual"},
 				{Key: "CONFIG_2", Value: "c2", Source: "config"},
 			},
-			newEnvs: []core_v1alpha.Env{
+			newEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "CONFIG_1", Value: "c1_updated", Source: "config"},
 				{Key: "CONFIG_3", Value: "c3", Source: "config"},
 			},
-			wantEnvs: []core_v1alpha.Env{
+			wantEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "MANUAL_1", Value: "m1", Source: "manual"},
 				{Key: "MANUAL_2", Value: "m2", Source: "manual"},
 				{Key: "CONFIG_1", Value: "c1_updated", Source: "config"},
@@ -868,15 +866,15 @@ func TestMergeServiceEnvVars(t *testing.T) {
 		},
 		{
 			name: "empty source vars preserved when app.toml adds env",
-			existingEnvs: []core_v1alpha.Env{
+			existingEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "LEGACY_DB_URL", Value: "postgres://old/db", Source: ""},
 				{Key: "LEGACY_API_KEY", Value: "key123", Source: ""},
 				{Key: "MANUAL_SECRET", Value: "secret", Source: "manual"},
 			},
-			newEnvs: []core_v1alpha.Env{
+			newEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "NEW_CONFIG_VAR", Value: "new_value", Source: "config"},
 			},
-			wantEnvs: []core_v1alpha.Env{
+			wantEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "LEGACY_DB_URL", Value: "postgres://old/db", Source: ""},
 				{Key: "LEGACY_API_KEY", Value: "key123", Source: ""},
 				{Key: "MANUAL_SECRET", Value: "secret", Source: "manual"},
@@ -886,20 +884,20 @@ func TestMergeServiceEnvVars(t *testing.T) {
 		{
 			name:         "nil existing envs",
 			existingEnvs: nil,
-			newEnvs: []core_v1alpha.Env{
+			newEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
-			wantEnvs: []core_v1alpha.Env{
+			wantEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "NEW_VAR", Value: "new_value", Source: "config"},
 			},
 		},
 		{
 			name: "nil new envs preserves manual vars",
-			existingEnvs: []core_v1alpha.Env{
+			existingEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "MANUAL_VAR", Value: "manual_value", Source: "manual"},
 			},
 			newEnvs: nil,
-			wantEnvs: []core_v1alpha.Env{
+			wantEnvs: []core_v1alpha.ConfigSpecServicesEnv{
 				{Key: "MANUAL_VAR", Value: "manual_value", Source: "manual"},
 			},
 		},
@@ -910,13 +908,13 @@ func TestMergeServiceEnvVars(t *testing.T) {
 			result := mergeServiceEnvVars(tt.existingEnvs, tt.newEnvs)
 
 			// Sort both slices by key for consistent comparison
-			sortEnvsByKey := func(envs []core_v1alpha.Env) {
+			sortEnvsByKey := func(envs []core_v1alpha.ConfigSpecServicesEnv) {
 				sort.Slice(envs, func(i, j int) bool {
 					return envs[i].Key < envs[j].Key
 				})
 			}
 			sortEnvsByKey(result)
-			wantSorted := make([]core_v1alpha.Env, len(tt.wantEnvs))
+			wantSorted := make([]core_v1alpha.ConfigSpecServicesEnv, len(tt.wantEnvs))
 			copy(wantSorted, tt.wantEnvs)
 			sortEnvsByKey(wantSorted)
 
@@ -1005,7 +1003,7 @@ func TestBuildVersionConfig(t *testing.T) {
 	tests := []struct {
 		name     string
 		inputs   ConfigInputs
-		validate func(t *testing.T, cfg core_v1alpha.Config)
+		validate func(t *testing.T, spec core_v1alpha.ConfigSpec)
 	}{
 		{
 			name: "image entrypoint creates web service when no services configured",
@@ -1016,15 +1014,13 @@ func TestBuildVersionConfig(t *testing.T) {
 				},
 				AppConfig:        nil,
 				ProcfileServices: nil,
-				ExistingConfig:   core_v1alpha.Config{},
+				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				require.Len(t, cfg.Services, 1, "should have one service")
-				assert.Equal(t, "web", cfg.Services[0].Name)
-				require.Len(t, cfg.Commands, 1, "should have one command")
-				assert.Equal(t, "web", cfg.Commands[0].Service)
-				assert.Equal(t, "node server.js", cfg.Commands[0].Command)
-				assert.Equal(t, "/app", cfg.StartDirectory)
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				require.Len(t, spec.Services, 1, "should have one service")
+				assert.Equal(t, "web", spec.Services[0].Name)
+				assert.Equal(t, "node server.js", spec.Services[0].Command)
+				assert.Equal(t, "/app", spec.StartDirectory)
 			},
 		},
 		{
@@ -1038,29 +1034,23 @@ func TestBuildVersionConfig(t *testing.T) {
 				ProcfileServices: map[string]string{
 					"worker": "node worker.js",
 				},
-				ExistingConfig: core_v1alpha.Config{},
+				ExistingConfig: core_v1alpha.ConfigSpec{},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				require.Len(t, cfg.Services, 2, "should have two services")
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				require.Len(t, spec.Services, 2, "should have two services")
 
 				// Find services by name
-				serviceMap := make(map[string]core_v1alpha.Services)
-				for _, svc := range cfg.Services {
+				serviceMap := make(map[string]core_v1alpha.ConfigSpecServices)
+				for _, svc := range spec.Services {
 					serviceMap[svc.Name] = svc
 				}
 
 				require.Contains(t, serviceMap, "web")
 				require.Contains(t, serviceMap, "worker")
 
-				// Find commands by service
-				cmdMap := make(map[string]string)
-				for _, cmd := range cfg.Commands {
-					cmdMap[cmd.Service] = cmd.Command
-				}
-
-				assert.Equal(t, "npm start", cmdMap["web"])
-				assert.Equal(t, "node worker.js", cmdMap["worker"])
-				assert.Equal(t, "/myapp", cfg.StartDirectory)
+				assert.Equal(t, "npm start", serviceMap["web"].Command)
+				assert.Equal(t, "node worker.js", serviceMap["worker"].Command)
+				assert.Equal(t, "/myapp", spec.StartDirectory)
 			},
 		},
 		{
@@ -1074,13 +1064,12 @@ func TestBuildVersionConfig(t *testing.T) {
 				ProcfileServices: map[string]string{
 					"web": "npm run production",
 				},
-				ExistingConfig: core_v1alpha.Config{},
+				ExistingConfig: core_v1alpha.ConfigSpec{},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				require.Len(t, cfg.Services, 1)
-				assert.Equal(t, "web", cfg.Services[0].Name)
-				require.Len(t, cfg.Commands, 1)
-				assert.Equal(t, "npm run production", cfg.Commands[0].Command)
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				require.Len(t, spec.Services, 1)
+				assert.Equal(t, "web", spec.Services[0].Name)
+				assert.Equal(t, "npm run production", spec.Services[0].Command)
 			},
 		},
 		{
@@ -1097,13 +1086,12 @@ func TestBuildVersionConfig(t *testing.T) {
 					},
 				},
 				ProcfileServices: nil,
-				ExistingConfig:   core_v1alpha.Config{},
+				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				require.Len(t, cfg.Services, 1)
-				assert.Equal(t, "web", cfg.Services[0].Name)
-				require.Len(t, cfg.Commands, 1)
-				assert.Equal(t, "npm run app-config", cfg.Commands[0].Command)
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				require.Len(t, spec.Services, 1)
+				assert.Equal(t, "web", spec.Services[0].Name)
+				assert.Equal(t, "npm run app-config", spec.Services[0].Command)
 			},
 		},
 		{
@@ -1114,12 +1102,11 @@ func TestBuildVersionConfig(t *testing.T) {
 				},
 				AppConfig:        nil,
 				ProcfileServices: nil,
-				ExistingConfig:   core_v1alpha.Config{},
+				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				assert.Len(t, cfg.Services, 0, "should have no services")
-				assert.Len(t, cfg.Commands, 0, "should have no commands")
-				assert.Equal(t, "/app", cfg.StartDirectory)
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				assert.Len(t, spec.Services, 0, "should have no services")
+				assert.Equal(t, "/app", spec.StartDirectory)
 			},
 		},
 		{
@@ -1131,10 +1118,10 @@ func TestBuildVersionConfig(t *testing.T) {
 				},
 				AppConfig:        nil,
 				ProcfileServices: nil,
-				ExistingConfig:   core_v1alpha.Config{},
+				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				assert.Equal(t, "/app/bin/start", cfg.Entrypoint)
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				assert.Equal(t, "/app/bin/start", spec.Entrypoint)
 			},
 		},
 		{
@@ -1143,10 +1130,10 @@ func TestBuildVersionConfig(t *testing.T) {
 				BuildResult:      &BuildResult{},
 				AppConfig:        nil,
 				ProcfileServices: nil,
-				ExistingConfig:   core_v1alpha.Config{},
+				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				assert.Equal(t, "/app", cfg.StartDirectory)
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				assert.Equal(t, "/app", spec.StartDirectory)
 			},
 		},
 		{
@@ -1157,11 +1144,11 @@ func TestBuildVersionConfig(t *testing.T) {
 				ProcfileServices: map[string]string{
 					"web": "npm start",
 				},
-				ExistingConfig: core_v1alpha.Config{
-					Services: []core_v1alpha.Services{
+				ExistingConfig: core_v1alpha.ConfigSpec{
+					Services: []core_v1alpha.ConfigSpecServices{
 						{
 							Name: "web",
-							Env: []core_v1alpha.Env{
+							Env: []core_v1alpha.ConfigSpecServicesEnv{
 								{Key: "MANUAL_VAR", Value: "manual_value", Source: "manual"},
 								{Key: "CONFIG_VAR", Value: "old_config", Source: "config"},
 							},
@@ -1169,13 +1156,13 @@ func TestBuildVersionConfig(t *testing.T) {
 					},
 				},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				require.Len(t, cfg.Services, 1)
-				assert.Equal(t, "web", cfg.Services[0].Name)
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				require.Len(t, spec.Services, 1)
+				assert.Equal(t, "web", spec.Services[0].Name)
 
 				// Should preserve manual var
-				envMap := make(map[string]core_v1alpha.Env)
-				for _, env := range cfg.Services[0].Env {
+				envMap := make(map[string]core_v1alpha.ConfigSpecServicesEnv)
+				for _, env := range spec.Services[0].Env {
 					envMap[env.Key] = env
 				}
 
@@ -1202,26 +1189,21 @@ func TestBuildVersionConfig(t *testing.T) {
 					},
 				},
 				ProcfileServices: nil,
-				ExistingConfig:   core_v1alpha.Config{},
+				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				require.Len(t, cfg.Services, 2, "should have two services")
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				require.Len(t, spec.Services, 2, "should have two services")
 
-				serviceMap := make(map[string]core_v1alpha.Services)
-				for _, svc := range cfg.Services {
+				serviceMap := make(map[string]core_v1alpha.ConfigSpecServices)
+				for _, svc := range spec.Services {
 					serviceMap[svc.Name] = svc
 				}
 
 				require.Contains(t, serviceMap, "web")
 				require.Contains(t, serviceMap, "worker")
 
-				cmdMap := make(map[string]string)
-				for _, cmd := range cfg.Commands {
-					cmdMap[cmd.Service] = cmd.Command
-				}
-
-				assert.Equal(t, "python app.py", cmdMap["web"])
-				assert.Equal(t, "celery worker", cmdMap["worker"])
+				assert.Equal(t, "python app.py", serviceMap["web"].Command)
+				assert.Equal(t, "celery worker", serviceMap["worker"].Command)
 			},
 		},
 		{
@@ -1234,21 +1216,20 @@ func TestBuildVersionConfig(t *testing.T) {
 				},
 				AppConfig:        nil,
 				ProcfileServices: nil,
-				ExistingConfig:   core_v1alpha.Config{},
+				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
-			validate: func(t *testing.T, cfg core_v1alpha.Config) {
-				require.Len(t, cfg.Services, 1, "should have one service")
-				assert.Equal(t, "web", cfg.Services[0].Name)
-				require.Len(t, cfg.Commands, 1, "should have one command")
-				assert.Equal(t, "server.js", cfg.Commands[0].Command)
+			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
+				require.Len(t, spec.Services, 1, "should have one service")
+				assert.Equal(t, "web", spec.Services[0].Name)
+				assert.Equal(t, "server.js", spec.Services[0].Command)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := buildVersionConfig(tt.inputs)
-			tt.validate(t, cfg)
+			spec := buildVersionConfig(tt.inputs)
+			tt.validate(t, spec)
 		})
 	}
 }
@@ -1348,15 +1329,15 @@ func makeEnvVar(key, value string, sensitive bool) *build_v1alpha.EnvironmentVar
 func TestMergeCliEnvVars(t *testing.T) {
 	tests := []struct {
 		name          string
-		existingVars  []core_v1alpha.Variable
+		existingVars  []core_v1alpha.ConfigSpecVariables
 		cliVars       []*build_v1alpha.EnvironmentVariable
-		wantVariables []core_v1alpha.Variable
+		wantVariables []core_v1alpha.ConfigSpecVariables
 	}{
 		{
 			name:          "empty CLI vars returns existing unchanged",
-			existingVars:  []core_v1alpha.Variable{{Key: "FOO", Value: "bar", Source: "config"}},
+			existingVars:  []core_v1alpha.ConfigSpecVariables{{Key: "FOO", Value: "bar", Source: "config"}},
 			cliVars:       nil,
-			wantVariables: []core_v1alpha.Variable{{Key: "FOO", Value: "bar", Source: "config"}},
+			wantVariables: []core_v1alpha.ConfigSpecVariables{{Key: "FOO", Value: "bar", Source: "config"}},
 		},
 		{
 			name:         "CLI vars added to empty existing",
@@ -1364,56 +1345,56 @@ func TestMergeCliEnvVars(t *testing.T) {
 			cliVars: []*build_v1alpha.EnvironmentVariable{
 				makeEnvVar("FOO", "bar", false),
 			},
-			wantVariables: []core_v1alpha.Variable{
+			wantVariables: []core_v1alpha.ConfigSpecVariables{
 				{Key: "FOO", Value: "bar", Sensitive: false, Source: "manual"},
 			},
 		},
 		{
 			name: "CLI vars override existing config vars",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "FOO", Value: "old", Source: "config"},
 			},
 			cliVars: []*build_v1alpha.EnvironmentVariable{
 				makeEnvVar("FOO", "new", false),
 			},
-			wantVariables: []core_v1alpha.Variable{
+			wantVariables: []core_v1alpha.ConfigSpecVariables{
 				{Key: "FOO", Value: "new", Sensitive: false, Source: "manual"},
 			},
 		},
 		{
 			name: "CLI vars override existing manual vars",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "FOO", Value: "old-manual", Source: "manual"},
 			},
 			cliVars: []*build_v1alpha.EnvironmentVariable{
 				makeEnvVar("FOO", "new-manual", false),
 			},
-			wantVariables: []core_v1alpha.Variable{
+			wantVariables: []core_v1alpha.ConfigSpecVariables{
 				{Key: "FOO", Value: "new-manual", Sensitive: false, Source: "manual"},
 			},
 		},
 		{
 			name: "CLI vars merge with existing - different keys",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "EXISTING", Value: "value", Source: "config"},
 			},
 			cliVars: []*build_v1alpha.EnvironmentVariable{
 				makeEnvVar("NEW", "cli-value", false),
 			},
-			wantVariables: []core_v1alpha.Variable{
+			wantVariables: []core_v1alpha.ConfigSpecVariables{
 				{Key: "EXISTING", Value: "value", Source: "config"},
 				{Key: "NEW", Value: "cli-value", Sensitive: false, Source: "manual"},
 			},
 		},
 		{
 			name: "sensitive flag preserved from CLI",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "SECRET", Value: "old", Sensitive: false, Source: "config"},
 			},
 			cliVars: []*build_v1alpha.EnvironmentVariable{
 				makeEnvVar("SECRET", "new-secret", true),
 			},
-			wantVariables: []core_v1alpha.Variable{
+			wantVariables: []core_v1alpha.ConfigSpecVariables{
 				{Key: "SECRET", Value: "new-secret", Sensitive: true, Source: "manual"},
 			},
 		},
@@ -1425,7 +1406,7 @@ func TestMergeCliEnvVars(t *testing.T) {
 				makeEnvVar("BAR", "bar-val", false),
 				makeEnvVar("SECRET", "secret-val", true),
 			},
-			wantVariables: []core_v1alpha.Variable{
+			wantVariables: []core_v1alpha.ConfigSpecVariables{
 				{Key: "FOO", Value: "foo-val", Sensitive: false, Source: "manual"},
 				{Key: "BAR", Value: "bar-val", Sensitive: false, Source: "manual"},
 				{Key: "SECRET", Value: "secret-val", Sensitive: true, Source: "manual"},
@@ -1485,7 +1466,7 @@ func TestIsSystemEnvVar(t *testing.T) {
 func TestComputeBuildEnvVars(t *testing.T) {
 	tests := []struct {
 		name         string
-		existingVars []core_v1alpha.Variable
+		existingVars []core_v1alpha.ConfigSpecVariables
 		appConfig    *appconfig.AppConfig
 		cliVars      []*build_v1alpha.EnvironmentVariable
 		wantVars     map[string]string
@@ -1499,7 +1480,7 @@ func TestComputeBuildEnvVars(t *testing.T) {
 		},
 		{
 			name: "existing config vars are included",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "DATABASE_URL", Value: "postgres://localhost/db", Source: "manual"},
 				{Key: "API_KEY", Value: "secret123", Source: "config"},
 			},
@@ -1512,7 +1493,7 @@ func TestComputeBuildEnvVars(t *testing.T) {
 		},
 		{
 			name: "app config vars merged in",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "EXISTING", Value: "value", Source: "manual"},
 			},
 			appConfig: &appconfig.AppConfig{
@@ -1543,7 +1524,7 @@ func TestComputeBuildEnvVars(t *testing.T) {
 		},
 		{
 			name: "system vars are filtered out",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "DATABASE_URL", Value: "postgres://localhost/db", Source: "manual"},
 				{Key: "MIREN_VERSION", Value: "v1", Source: "config"},
 				{Key: "MIREN_APP", Value: "myapp", Source: "config"},
@@ -1559,7 +1540,7 @@ func TestComputeBuildEnvVars(t *testing.T) {
 		},
 		{
 			name: "sensitive vars are included",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "SECRET_KEY", Value: "super-secret", Sensitive: true, Source: "manual"},
 			},
 			appConfig: nil,
@@ -1570,7 +1551,7 @@ func TestComputeBuildEnvVars(t *testing.T) {
 		},
 		{
 			name: "full merge: existing + app config + CLI with system filtering",
-			existingVars: []core_v1alpha.Variable{
+			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "EXISTING_MANUAL", Value: "m1", Source: "manual"},
 				{Key: "EXISTING_CONFIG", Value: "c1", Source: "config"},
 				{Key: "PORT", Value: "3000", Source: "manual"},
@@ -1604,30 +1585,30 @@ func TestComputeBuildEnvVars(t *testing.T) {
 func TestValidateServicesExist(t *testing.T) {
 	tests := []struct {
 		name    string
-		config  core_v1alpha.Config
+		config  core_v1alpha.ConfigSpec
 		wantErr bool
 	}{
 		{
 			name:    "no services returns error",
-			config:  core_v1alpha.Config{Services: nil},
+			config:  core_v1alpha.ConfigSpec{Services: nil},
 			wantErr: true,
 		},
 		{
 			name:    "empty services returns error",
-			config:  core_v1alpha.Config{Services: []core_v1alpha.Services{}},
+			config:  core_v1alpha.ConfigSpec{Services: []core_v1alpha.ConfigSpecServices{}},
 			wantErr: true,
 		},
 		{
 			name: "one service passes",
-			config: core_v1alpha.Config{
-				Services: []core_v1alpha.Services{{Name: "web"}},
+			config: core_v1alpha.ConfigSpec{
+				Services: []core_v1alpha.ConfigSpecServices{{Name: "web"}},
 			},
 			wantErr: false,
 		},
 		{
 			name: "multiple services passes",
-			config: core_v1alpha.Config{
-				Services: []core_v1alpha.Services{{Name: "web"}, {Name: "worker"}},
+			config: core_v1alpha.ConfigSpec{
+				Services: []core_v1alpha.ConfigSpecServices{{Name: "web"}, {Name: "worker"}},
 			},
 			wantErr: false,
 		},

--- a/servers/exec/exec.go
+++ b/servers/exec/exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/exec/exec_v1alpha"
@@ -104,7 +105,7 @@ func (s *Server) Exec(ctx context.Context, req *exec_v1alpha.SandboxExecExec) er
 		return err
 	}
 
-	var ver *core_v1alpha.AppVersion
+	var cfgSpec *core_v1alpha.ConfigSpec
 
 	if verId != "" {
 		res, err := s.EAC.Get(ctx, verId)
@@ -115,27 +116,31 @@ func (s *Server) Exec(ctx context.Context, req *exec_v1alpha.SandboxExecExec) er
 		var v core_v1alpha.AppVersion
 		v.Decode(res.Entity().Entity())
 
-		s.Log.Debug("found version", "id", verId)
-
-		// Only use the app version config (entrypoint, console command) if the container
-		// is using the app's built image. Service containers with custom images
-		// (like postgres) should not have the app's entrypoint applied.
-		containerImage, err := firstContainer.Image(ctx)
+		// Resolve config from ConfigVersion if available
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, s.EAC, &v)
 		if err == nil {
-			containerImageName := containerImage.Name()
-			if imageMatchesAppVersion(containerImageName, v.ImageUrl) {
-				ver = &v
+			s.Log.Debug("found version", "id", verId)
+
+			// Only use the app version config (entrypoint, console command) if the container
+			// is using the app's built image. Service containers with custom images
+			// (like postgres) should not have the app's entrypoint applied.
+			containerImage, err := firstContainer.Image(ctx)
+			if err == nil {
+				containerImageName := containerImage.Name()
+				if imageMatchesAppVersion(containerImageName, v.ImageUrl) {
+					cfgSpec = resolvedCfg
+				} else {
+					s.Log.Debug("container image differs from app version, skipping entrypoint",
+						"container_image", containerImageName,
+						"app_image", v.ImageUrl)
+				}
 			} else {
-				s.Log.Debug("container image differs from app version, skipping entrypoint",
-					"container_image", containerImageName,
-					"app_image", v.ImageUrl)
+				s.Log.Debug("failed to get container image, skipping entrypoint", "error", err)
 			}
-		} else {
-			s.Log.Debug("failed to get container image, skipping entrypoint", "error", err)
 		}
 	}
 
-	pspec, err := s.spec(args.Options(), spec, ver)
+	pspec, err := s.spec(args.Options(), spec, cfgSpec)
 	if err != nil {
 		return err
 	}
@@ -208,20 +213,20 @@ func (s *Server) Exec(ctx context.Context, req *exec_v1alpha.SandboxExecExec) er
 	return nil
 }
 
-func (e *Server) command(ver *core_v1alpha.AppVersion, service string) string {
-	for _, cmd := range ver.Config.Commands {
-		if cmd.Service == service && cmd.Command != "" {
-			if ver.Config.Entrypoint != "" {
-				return ver.Config.Entrypoint + " " + cmd.Command
+func (e *Server) command(cfgSpec *core_v1alpha.ConfigSpec, service string) string {
+	for _, svc := range cfgSpec.Services {
+		if svc.Name == service && svc.Command != "" {
+			if cfgSpec.Entrypoint != "" {
+				return cfgSpec.Entrypoint + " " + svc.Command
 			}
-			return cmd.Command
+			return svc.Command
 		}
 	}
 
 	return ""
 }
 
-func (e *Server) spec(opts *exec_v1alpha.ShellOptions, spec *oci.Spec, ver *core_v1alpha.AppVersion) (*specs.Process, error) {
+func (e *Server) spec(opts *exec_v1alpha.ShellOptions, spec *oci.Spec, cfgSpec *core_v1alpha.ConfigSpec) (*specs.Process, error) {
 	proc := &specs.Process{
 		Cwd:  spec.Process.Cwd,
 		Env:  spec.Process.Env,
@@ -229,15 +234,15 @@ func (e *Server) spec(opts *exec_v1alpha.ShellOptions, spec *oci.Spec, ver *core
 	}
 
 	var ep string
-	if ver != nil {
-		ep = ver.Config.Entrypoint
+	if cfgSpec != nil {
+		ep = cfgSpec.Entrypoint
 	}
 
 	args := opts.Command()
 
 	if len(args) == 0 {
-		if ver != nil {
-			if con := e.command(ver, "console"); con != "" {
+		if cfgSpec != nil {
+			if con := e.command(cfgSpec, "console"); con != "" {
 				// CommandFor already prepends the entrypoint
 				args = []string{"/bin/sh", "-c", "exec " + con}
 			} else if ep != "" {

--- a/servers/exec/exec_test.go
+++ b/servers/exec/exec_test.go
@@ -16,18 +16,16 @@ func TestCommand(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		ver      *core_v1alpha.AppVersion
+		cfgSpec  *core_v1alpha.ConfigSpec
 		service  string
 		expected string
 	}{
 		{
 			name: "console command with entrypoint",
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{
-					Entrypoint: "mise exec --",
-					Commands: []core_v1alpha.Commands{
-						{Service: "console", Command: "bin/rails console"},
-					},
+			cfgSpec: &core_v1alpha.ConfigSpec{
+				Entrypoint: "mise exec --",
+				Services: []core_v1alpha.ConfigSpecServices{
+					{Name: "console", Command: "bin/rails console"},
 				},
 			},
 			service:  "console",
@@ -35,11 +33,9 @@ func TestCommand(t *testing.T) {
 		},
 		{
 			name: "console command without entrypoint",
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{
-					Commands: []core_v1alpha.Commands{
-						{Service: "console", Command: "bin/rails console"},
-					},
+			cfgSpec: &core_v1alpha.ConfigSpec{
+				Services: []core_v1alpha.ConfigSpecServices{
+					{Name: "console", Command: "bin/rails console"},
 				},
 			},
 			service:  "console",
@@ -47,12 +43,10 @@ func TestCommand(t *testing.T) {
 		},
 		{
 			name: "no matching service",
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{
-					Entrypoint: "mise exec --",
-					Commands: []core_v1alpha.Commands{
-						{Service: "web", Command: "bin/rails server"},
-					},
+			cfgSpec: &core_v1alpha.ConfigSpec{
+				Entrypoint: "mise exec --",
+				Services: []core_v1alpha.ConfigSpecServices{
+					{Name: "web", Command: "bin/rails server"},
 				},
 			},
 			service:  "console",
@@ -60,11 +54,9 @@ func TestCommand(t *testing.T) {
 		},
 		{
 			name: "empty command for service",
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{
-					Commands: []core_v1alpha.Commands{
-						{Service: "console", Command: ""},
-					},
+			cfgSpec: &core_v1alpha.ConfigSpec{
+				Services: []core_v1alpha.ConfigSpecServices{
+					{Name: "console", Command: ""},
 				},
 			},
 			service:  "console",
@@ -74,7 +66,7 @@ func TestCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := server.command(tt.ver, tt.service)
+			result := server.command(tt.cfgSpec, tt.service)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -97,98 +89,86 @@ func TestSpec(t *testing.T) {
 	tests := []struct {
 		name         string
 		opts         *exec_v1alpha.ShellOptions
-		ver          *core_v1alpha.AppVersion
+		cfgSpec      *core_v1alpha.ConfigSpec
 		expectedArgs []string
 		description  string
 	}{
 		{
-			name:         "nil version, no command - defaults to /bin/sh",
+			name:         "nil config, no command - defaults to /bin/sh",
 			opts:         &exec_v1alpha.ShellOptions{},
-			ver:          nil,
+			cfgSpec:      nil,
 			expectedArgs: []string{"/bin/sh"},
 			description:  "Non-app containers (like postgres) should get plain shell",
 		},
 		{
-			name: "nil version, with command - runs command directly",
+			name: "nil config, with command - runs command directly",
 			opts: func() *exec_v1alpha.ShellOptions {
 				o := &exec_v1alpha.ShellOptions{}
 				o.SetCommand([]string{"psql", "-U", "postgres"})
 				return o
 			}(),
-			ver:          nil,
+			cfgSpec:      nil,
 			expectedArgs: []string{"psql", "-U", "postgres"},
 			description:  "Non-app containers should run commands without entrypoint",
 		},
 		{
-			name: "version with entrypoint, no command - wraps shell with entrypoint",
+			name: "config with entrypoint, no command - wraps shell with entrypoint",
 			opts: &exec_v1alpha.ShellOptions{},
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{
-					Entrypoint: "mise exec --",
-				},
+			cfgSpec: &core_v1alpha.ConfigSpec{
+				Entrypoint: "mise exec --",
 			},
 			expectedArgs: []string{"/bin/sh", "-c", "exec mise exec -- /bin/sh"},
 			description:  "App containers should have entrypoint applied to shell",
 		},
 		{
-			name: "version with entrypoint, with command - wraps command with entrypoint",
+			name: "config with entrypoint, with command - wraps command with entrypoint",
 			opts: func() *exec_v1alpha.ShellOptions {
 				o := &exec_v1alpha.ShellOptions{}
 				o.SetCommand([]string{"bin/rails", "runner", "puts 'hello'"})
 				return o
 			}(),
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{
-					Entrypoint: "mise exec --",
-				},
+			cfgSpec: &core_v1alpha.ConfigSpec{
+				Entrypoint: "mise exec --",
 			},
 			expectedArgs: []string{"/bin/sh", "-c", "exec mise exec -- bin/rails runner puts 'hello'"},
 			description:  "App containers should have entrypoint applied to commands",
 		},
 		{
-			name: "version without entrypoint, no command - plain shell",
-			opts: &exec_v1alpha.ShellOptions{},
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{},
-			},
+			name:         "config without entrypoint, no command - plain shell",
+			opts:         &exec_v1alpha.ShellOptions{},
+			cfgSpec:      &core_v1alpha.ConfigSpec{},
 			expectedArgs: []string{"/bin/sh"},
 			description:  "App containers without entrypoint get plain shell",
 		},
 		{
-			name: "version without entrypoint, with command - runs command directly",
+			name: "config without entrypoint, with command - runs command directly",
 			opts: func() *exec_v1alpha.ShellOptions {
 				o := &exec_v1alpha.ShellOptions{}
 				o.SetCommand([]string{"ls", "-la"})
 				return o
 			}(),
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{},
-			},
+			cfgSpec:      &core_v1alpha.ConfigSpec{},
 			expectedArgs: []string{"ls", "-la"},
 			description:  "App containers without entrypoint run commands directly",
 		},
 		{
-			name: "version with console command, no user command - uses console command",
+			name: "config with console command, no user command - uses console command",
 			opts: &exec_v1alpha.ShellOptions{},
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{
-					Entrypoint: "mise exec --",
-					Commands: []core_v1alpha.Commands{
-						{Service: "console", Command: "bin/rails console"},
-					},
+			cfgSpec: &core_v1alpha.ConfigSpec{
+				Entrypoint: "mise exec --",
+				Services: []core_v1alpha.ConfigSpecServices{
+					{Name: "console", Command: "bin/rails console"},
 				},
 			},
 			expectedArgs: []string{"/bin/sh", "-c", "exec mise exec -- bin/rails console"},
 			description:  "Interactive exec should use configured console command",
 		},
 		{
-			name: "version with console command but no entrypoint",
+			name: "config with console command but no entrypoint",
 			opts: &exec_v1alpha.ShellOptions{},
-			ver: &core_v1alpha.AppVersion{
-				Config: core_v1alpha.Config{
-					Commands: []core_v1alpha.Commands{
-						{Service: "console", Command: "bin/rails console"},
-					},
+			cfgSpec: &core_v1alpha.ConfigSpec{
+				Services: []core_v1alpha.ConfigSpecServices{
+					{Name: "console", Command: "bin/rails console"},
 				},
 			},
 			expectedArgs: []string{"/bin/sh", "-c", "exec bin/rails console"},
@@ -198,7 +178,7 @@ func TestSpec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			proc, err := server.spec(tt.opts, baseOCISpec, tt.ver)
+			proc, err := server.spec(tt.opts, baseOCISpec, tt.cfgSpec)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedArgs, proc.Args, tt.description)
 
@@ -279,17 +259,14 @@ func TestEntrypointNotAppliedToCustomImageContainers(t *testing.T) {
 	})
 
 	t.Run("app container with same image gets entrypoint", func(t *testing.T) {
-		// When exec'ing into an app container, ver is populated
+		// When exec'ing into an app container, cfgSpec is populated
 		// because the container's image matches the app's image
 		opts := &exec_v1alpha.ShellOptions{}
-		ver := &core_v1alpha.AppVersion{
-			ImageUrl: "myapp:latest",
-			Config: core_v1alpha.Config{
-				Entrypoint: "mise exec --",
-			},
+		cfgSpec := &core_v1alpha.ConfigSpec{
+			Entrypoint: "mise exec --",
 		}
 
-		proc, err := server.spec(opts, baseOCISpec, ver)
+		proc, err := server.spec(opts, baseOCISpec, cfgSpec)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"/bin/sh", "-c", "exec mise exec -- /bin/sh"}, proc.Args,
 			"App container should have entrypoint applied")

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/exec/exec_v1alpha"
@@ -88,8 +89,14 @@ func (s *Server) Exec(ctx context.Context, req *exec_v1alpha.SandboxExecExec) er
 		var appVer core_v1alpha.AppVersion
 		appVer.Decode(verEnt.Entity().Entity())
 
+		// Resolve config from ConfigVersion if available
+		cfgSpec, err := coreutil.ResolveConfig(ctx, s.EAC, &appVer)
+		if err != nil {
+			return fmt.Errorf("failed to resolve config for app version %s: %w", appVer.ID, err)
+		}
+
 		// Create ephemeral sandbox for this console session
-		sbEnt, cleanupFn, err := s.createEphemeralSandbox(ctx, &appEnt, &appVer)
+		sbEnt, cleanupFn, err := s.createEphemeralSandbox(ctx, &appEnt, &appVer, cfgSpec)
 		if err != nil {
 			return fmt.Errorf("failed to create ephemeral sandbox: %w", err)
 		}
@@ -164,9 +171,10 @@ func (s *Server) createEphemeralSandbox(
 	ctx context.Context,
 	app *core_v1alpha.App,
 	ver *core_v1alpha.AppVersion,
+	cfgSpec *core_v1alpha.ConfigSpec,
 ) (*entity.Entity, func(), error) {
 	// Build sandbox spec
-	spec, err := s.buildSandboxSpec(ctx, app, ver)
+	spec, err := s.buildSandboxSpec(ctx, app, ver, cfgSpec)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build sandbox spec: %w", err)
 	}
@@ -306,6 +314,7 @@ func (s *Server) buildSandboxSpec(
 	ctx context.Context,
 	app *core_v1alpha.App,
 	ver *core_v1alpha.AppVersion,
+	cfgSpec *core_v1alpha.ConfigSpec,
 ) (*compute_v1alpha.SandboxSpec, error) {
 	// Get app metadata
 	appResp, err := s.EAC.Get(ctx, app.ID.String())
@@ -323,7 +332,7 @@ func (s *Server) buildSandboxSpec(
 	}
 
 	// Determine start directory, defaulting to /app
-	startDir := ver.Config.StartDirectory
+	startDir := cfgSpec.StartDirectory
 	if startDir == "" {
 		startDir = "/app"
 	}
@@ -342,7 +351,7 @@ func (s *Server) buildSandboxSpec(
 
 	// Add global config env vars
 	envMap := make(map[string]string)
-	for _, x := range ver.Config.Variable {
+	for _, x := range cfgSpec.Variables {
 		envMap[x.Key] = x.Value
 	}
 

--- a/servers/exec_proxy/exec_proxy_test.go
+++ b/servers/exec_proxy/exec_proxy_test.go
@@ -32,6 +32,7 @@ func TestBuildSandboxSpec(t *testing.T) {
 		name          string
 		app           *core_v1alpha.App
 		ver           *core_v1alpha.AppVersion
+		cfgSpec       *core_v1alpha.ConfigSpec
 		expectedImage string
 		expectedEnvs  []string
 	}{
@@ -45,11 +46,11 @@ func TestBuildSandboxSpec(t *testing.T) {
 				App:      "app/basic-app",
 				Version:  "v1",
 				ImageUrl: "basic-image:latest",
-				Config: core_v1alpha.Config{
-					StartDirectory: "/workspace",
-					Variable: []core_v1alpha.Variable{
-						{Key: "GLOBAL_VAR", Value: "global_value"},
-					},
+			},
+			cfgSpec: &core_v1alpha.ConfigSpec{
+				StartDirectory: "/workspace",
+				Variables: []core_v1alpha.ConfigSpecVariables{
+					{Key: "GLOBAL_VAR", Value: "global_value"},
 				},
 			},
 			expectedImage: "basic-image:latest",
@@ -69,7 +70,7 @@ func TestBuildSandboxSpec(t *testing.T) {
 			).Attrs())
 			require.NoError(t, err, "Failed to create app entity")
 
-			spec, err := server.buildSandboxSpec(ctx, tt.app, tt.ver)
+			spec, err := server.buildSandboxSpec(ctx, tt.app, tt.ver, tt.cfgSpec)
 			require.NoError(t, err, "buildSandboxSpec failed")
 			require.NotNil(t, spec, "Expected spec to be returned")
 
@@ -123,11 +124,12 @@ func TestCreateEphemeralSandbox(t *testing.T) {
 		App:      "app/test-app",
 		Version:  "v1",
 		ImageUrl: "test-image:latest",
-		Config: core_v1alpha.Config{
-			StartDirectory: "/app",
-			Variable: []core_v1alpha.Variable{
-				{Key: "ENV", Value: "test"},
-			},
+	}
+
+	cfgSpec := &core_v1alpha.ConfigSpec{
+		StartDirectory: "/app",
+		Variables: []core_v1alpha.ConfigSpecVariables{
+			{Key: "ENV", Value: "test"},
 		},
 	}
 
@@ -142,7 +144,7 @@ func TestCreateEphemeralSandbox(t *testing.T) {
 	require.NoError(t, err, "Failed to create app entity")
 
 	// Create ephemeral sandbox - should succeed with mock controller
-	sbEnt, cleanupFn, createErr := server.createEphemeralSandbox(ctx, app, ver)
+	sbEnt, cleanupFn, createErr := server.createEphemeralSandbox(ctx, app, ver, cfgSpec)
 	require.NoError(t, createErr, "createEphemeralSandbox failed")
 	defer cleanupFn()
 
@@ -200,8 +202,10 @@ func TestCreateEphemeralSandbox_Timeout(t *testing.T) {
 	shortCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
 
+	cfgSpec := &core_v1alpha.ConfigSpec{}
+
 	// This will timeout because there's no sandbox controller
-	_, _, createErr := server.createEphemeralSandbox(shortCtx, app, ver)
+	_, _, createErr := server.createEphemeralSandbox(shortCtx, app, ver, cfgSpec)
 	require.Error(t, createErr, "Expected error due to timeout")
 
 	// Verify the error is a timeout error
@@ -252,8 +256,10 @@ func TestCreateEphemeralSandbox_Failure(t *testing.T) {
 	).Attrs())
 	require.NoError(t, err, "Failed to create app entity")
 
+	cfgSpec := &core_v1alpha.ConfigSpec{}
+
 	// This should fail because sandbox transitions to DEAD
-	_, _, createErr := server.createEphemeralSandbox(ctx, app, ver)
+	_, _, createErr := server.createEphemeralSandbox(ctx, app, ver, cfgSpec)
 	require.Error(t, createErr, "Expected error for failed sandbox")
 
 	// Verify the error mentions the dead status


### PR DESCRIPTION
## Summary

This PR introduces a ConfigVersion entity to hold the configuration that we previously held on an AppVersion. This lets us directly share the ConfigVersion between AppVersions if needed, as well as let's us setup Config before AppVersions exist.

- Eliminate the conversion layer between `ConfigSpec` (stored in `ConfigVersion` entities) and the old `Config` type
- `ResolveConfig` now returns `*ConfigSpec` directly instead of converting back to `Config`
- All readers (launcher, activator, exec, exec_proxy, CLI) use `ConfigSpec` fields natively (`Services[].Command`, `Services[].Concurrency`, `Variables`, etc.)
- All writers (build server, app server) build `ConfigSpec` natively instead of building `Config` then converting
- Add `ConfigVersion` schema with standalone components to avoid type name collisions with inline types
- Add migration helper (`MigrateAppVersionToConfigVersion`) for existing `AppVersion` entities without `ConfigRef`
- Add `EAC()` accessor to `entityserver.Client` for direct entity access needed by `ResolveConfig`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./api/core/...` passes
- [x] `go test ./servers/build/...` passes
- [x] `go test ./servers/app/...` passes
- [x] `go test ./servers/exec/...` passes
- [x] `go test ./servers/exec_proxy/...` passes
- [x] `go test ./controllers/deployment/...` passes
- [x] `go test ./controllers/sandboxpool/...` passes
- [x] `go test ./components/activator/...` passes (unit tests; `TestConcurrentPoolIncrement` excluded - pre-existing etcd infra issue)
- [x] `go test ./cli/commands/...` passes
- [x] `make lint` — 0 issues