### PR TITLE
Implement OIDC authentication for HTTP routes (MIR-675)

### DIFF
--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -34,6 +34,11 @@ func NewClient(log *slog.Logger, client rpc.Client) *Client {
 	}
 }
 
+// GetEntityStore returns the underlying entity store
+func (c *Client) GetEntityStore() *entityserver.Client {
+	return c.ec
+}
+
 // Lookup finds an http_route by hostname, returns nil if not found
 func (c *Client) Lookup(ctx context.Context, host string) (*ingress_v1alpha.HttpRoute, error) {
 	ia := entity.String(ingress_v1alpha.HttpRouteHostId, strings.ToLower(host))
@@ -195,8 +200,78 @@ func (c *Client) DeleteByHost(ctx context.Context, host string) error {
 	return nil
 }
 
-// UpdateOIDCConfig updates the OIDC configuration for a route
-func (c *Client) UpdateOIDCConfig(ctx context.Context, host string, config ingress_v1alpha.OidcConfig) (*ingress_v1alpha.HttpRoute, error) {
+// CreateOrUpdateOIDCProvider creates or updates an OIDC provider
+func (c *Client) CreateOrUpdateOIDCProvider(ctx context.Context, provider *ingress_v1alpha.OidcProvider) (*ingress_v1alpha.OidcProvider, error) {
+	if provider.Name == "" {
+		return nil, fmt.Errorf("provider name is required")
+	}
+
+	_, err := c.ec.CreateOrUpdate(ctx, provider.Name, provider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create/update OIDC provider: %w", err)
+	}
+
+	return provider, nil
+}
+
+// GetOIDCProvider looks up an OIDC provider by name
+func (c *Client) GetOIDCProvider(ctx context.Context, name string) (*ingress_v1alpha.OidcProvider, error) {
+	ia := entity.String(ingress_v1alpha.OidcProviderNameId, name)
+
+	var provider ingress_v1alpha.OidcProvider
+	err := c.ec.OneAtIndex(ctx, ia, &provider)
+	if err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to lookup OIDC provider %s: %w", name, err)
+	}
+
+	return &provider, nil
+}
+
+// ListOIDCProviders returns all OIDC providers
+func (c *Client) ListOIDCProviders(ctx context.Context) ([]*ingress_v1alpha.OidcProvider, error) {
+	kindRes, err := c.eac.LookupKind(ctx, "oidc_provider")
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup oidc_provider kind: %w", err)
+	}
+
+	res, err := c.eac.List(ctx, kindRes.Attr())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list OIDC providers: %w", err)
+	}
+
+	var providers []*ingress_v1alpha.OidcProvider
+	for _, e := range res.Values() {
+		var provider ingress_v1alpha.OidcProvider
+		provider.Decode(e.Entity())
+		providers = append(providers, &provider)
+	}
+
+	return providers, nil
+}
+
+// DeleteOIDCProvider deletes an OIDC provider by name
+func (c *Client) DeleteOIDCProvider(ctx context.Context, name string) error {
+	provider, err := c.GetOIDCProvider(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	if provider == nil {
+		return fmt.Errorf("OIDC provider not found: %s", name)
+	}
+
+	if err := c.ec.Delete(ctx, provider.ID); err != nil {
+		return fmt.Errorf("failed to delete OIDC provider: %w", err)
+	}
+
+	return nil
+}
+
+// AttachOIDCProvider associates an OIDC provider with a route and sets claim mappings
+func (c *Client) AttachOIDCProvider(ctx context.Context, host string, providerName string, claimMappings []ingress_v1alpha.ClaimMappings) (*ingress_v1alpha.HttpRoute, error) {
 	route, err := c.Lookup(ctx, host)
 	if err != nil {
 		return nil, err
@@ -206,19 +281,49 @@ func (c *Client) UpdateOIDCConfig(ctx context.Context, host string, config ingre
 		return nil, fmt.Errorf("route not found: %s", host)
 	}
 
-	// Update OIDC config
-	route.OidcConfig = config
+	// Look up provider
+	provider, err := c.GetOIDCProvider(ctx, providerName)
+	if err != nil {
+		return nil, err
+	}
+
+	if provider == nil {
+		return nil, fmt.Errorf("OIDC provider not found: %s", providerName)
+	}
+
+	// Update route with provider reference and claim mappings
+	route.OidcProvider = provider.ID
+	route.ClaimMappings = claimMappings
 
 	// Update the route
 	_, err = c.ec.CreateOrUpdate(ctx, string(route.ID), route)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update route OIDC config: %w", err)
+		return nil, fmt.Errorf("failed to attach OIDC provider to route: %w", err)
 	}
 
 	return route, nil
 }
 
-// ClearOIDCConfig removes OIDC configuration from a route
-func (c *Client) ClearOIDCConfig(ctx context.Context, host string) (*ingress_v1alpha.HttpRoute, error) {
-	return c.UpdateOIDCConfig(ctx, host, ingress_v1alpha.OidcConfig{})
+// DetachOIDCProvider removes OIDC provider association from a route
+func (c *Client) DetachOIDCProvider(ctx context.Context, host string) (*ingress_v1alpha.HttpRoute, error) {
+	route, err := c.Lookup(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	if route == nil {
+		return nil, fmt.Errorf("route not found: %s", host)
+	}
+
+	// Clear provider reference and claim mappings
+	route.OidcProvider = ""
+	route.ClaimMappings = nil
+
+	// Update the route
+	_, err = c.ec.CreateOrUpdate(ctx, string(route.ID), route)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detach OIDC provider from route: %w", err)
+	}
+
+	return route, nil
 }

--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -281,6 +281,11 @@ func (c *Client) AttachOIDCProvider(ctx context.Context, host string, providerNa
 		return nil, fmt.Errorf("route not found: %s", host)
 	}
 
+	return c.AttachOIDCProviderToRoute(ctx, route, providerName, claimMappings)
+}
+
+// AttachOIDCProviderToRoute associates an OIDC provider with an already-resolved route
+func (c *Client) AttachOIDCProviderToRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute, providerName string, claimMappings []ingress_v1alpha.ClaimMappings) (*ingress_v1alpha.HttpRoute, error) {
 	// Look up provider
 	provider, err := c.GetOIDCProvider(ctx, providerName)
 	if err != nil {
@@ -315,12 +320,17 @@ func (c *Client) DetachOIDCProvider(ctx context.Context, host string) (*ingress_
 		return nil, fmt.Errorf("route not found: %s", host)
 	}
 
+	return c.DetachOIDCProviderFromRoute(ctx, route)
+}
+
+// DetachOIDCProviderFromRoute removes OIDC provider association from an already-resolved route
+func (c *Client) DetachOIDCProviderFromRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
 	// Clear provider reference and claim mappings
 	route.OidcProvider = ""
 	route.ClaimMappings = nil
 
 	// Update the route
-	_, err = c.ec.CreateOrUpdate(ctx, string(route.ID), route)
+	_, err := c.ec.CreateOrUpdate(ctx, string(route.ID), route)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detach OIDC provider from route: %w", err)
 	}

--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -194,3 +194,31 @@ func (c *Client) DeleteByHost(ctx context.Context, host string) error {
 
 	return nil
 }
+
+// UpdateOIDCConfig updates the OIDC configuration for a route
+func (c *Client) UpdateOIDCConfig(ctx context.Context, host string, config ingress_v1alpha.OidcConfig) (*ingress_v1alpha.HttpRoute, error) {
+	route, err := c.Lookup(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	if route == nil {
+		return nil, fmt.Errorf("route not found: %s", host)
+	}
+
+	// Update OIDC config
+	route.OidcConfig = config
+
+	// Update the route
+	_, err = c.ec.CreateOrUpdate(ctx, string(route.ID), route)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update route OIDC config: %w", err)
+	}
+
+	return route, nil
+}
+
+// ClearOIDCConfig removes OIDC configuration from a route
+func (c *Client) ClearOIDCConfig(ctx context.Context, host string) (*ingress_v1alpha.HttpRoute, error) {
+	return c.UpdateOIDCConfig(ctx, host, ingress_v1alpha.OidcConfig{})
+}

--- a/api/ingress/ingress_v1alpha/schema.gen.go
+++ b/api/ingress/ingress_v1alpha/schema.gen.go
@@ -6,18 +6,20 @@ import (
 )
 
 const (
-	HttpRouteAppId        = entity.Id("dev.miren.ingress/http_route.app")
-	HttpRouteDefaultId    = entity.Id("dev.miren.ingress/http_route.default")
-	HttpRouteHostId       = entity.Id("dev.miren.ingress/http_route.host")
-	HttpRouteOidcConfigId = entity.Id("dev.miren.ingress/http_route.oidc_config")
+	HttpRouteAppId           = entity.Id("dev.miren.ingress/http_route.app")
+	HttpRouteClaimMappingsId = entity.Id("dev.miren.ingress/http_route.claim_mappings")
+	HttpRouteDefaultId       = entity.Id("dev.miren.ingress/http_route.default")
+	HttpRouteHostId          = entity.Id("dev.miren.ingress/http_route.host")
+	HttpRouteOidcProviderId  = entity.Id("dev.miren.ingress/http_route.oidc_provider")
 )
 
 type HttpRoute struct {
-	ID         entity.Id  `json:"id"`
-	App        entity.Id  `cbor:"app,omitempty" json:"app,omitempty"`
-	Default    bool       `cbor:"default,omitempty" json:"default,omitempty"`
-	Host       string     `cbor:"host,omitempty" json:"host,omitempty"`
-	OidcConfig OidcConfig `cbor:"oidc_config,omitempty" json:"oidc_config,omitempty"`
+	ID            entity.Id       `json:"id"`
+	App           entity.Id       `cbor:"app,omitempty" json:"app,omitempty"`
+	ClaimMappings []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
+	Default       bool            `cbor:"default,omitempty" json:"default,omitempty"`
+	Host          string          `cbor:"host,omitempty" json:"host,omitempty"`
+	OidcProvider  entity.Id       `cbor:"oidc_provider,omitempty" json:"oidc_provider,omitempty"`
 }
 
 func (o *HttpRoute) Decode(e entity.AttrGetter) {
@@ -25,14 +27,21 @@ func (o *HttpRoute) Decode(e entity.AttrGetter) {
 	if a, ok := e.Get(HttpRouteAppId); ok && a.Value.Kind() == entity.KindId {
 		o.App = a.Value.Id()
 	}
+	for _, a := range e.GetAll(HttpRouteClaimMappingsId) {
+		if a.Value.Kind() == entity.KindComponent {
+			var v ClaimMappings
+			v.Decode(a.Value.Component())
+			o.ClaimMappings = append(o.ClaimMappings, v)
+		}
+	}
 	if a, ok := e.Get(HttpRouteDefaultId); ok && a.Value.Kind() == entity.KindBool {
 		o.Default = a.Value.Bool()
 	}
 	if a, ok := e.Get(HttpRouteHostId); ok && a.Value.Kind() == entity.KindString {
 		o.Host = a.Value.String()
 	}
-	if a, ok := e.Get(HttpRouteOidcConfigId); ok && a.Value.Kind() == entity.KindComponent {
-		o.OidcConfig.Decode(a.Value.Component())
+	if a, ok := e.Get(HttpRouteOidcProviderId); ok && a.Value.Kind() == entity.KindId {
+		o.OidcProvider = a.Value.Id()
 	}
 }
 
@@ -56,12 +65,15 @@ func (o *HttpRoute) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.App) {
 		attrs = append(attrs, entity.Ref(HttpRouteAppId, o.App))
 	}
+	for _, v := range o.ClaimMappings {
+		attrs = append(attrs, entity.Component(HttpRouteClaimMappingsId, v.Encode()))
+	}
 	attrs = append(attrs, entity.Bool(HttpRouteDefaultId, o.Default))
 	if !entity.Empty(o.Host) {
 		attrs = append(attrs, entity.String(HttpRouteHostId, o.Host))
 	}
-	if !o.OidcConfig.Empty() {
-		attrs = append(attrs, entity.Component(HttpRouteOidcConfigId, o.OidcConfig.Encode()))
+	if !entity.Empty(o.OidcProvider) {
+		attrs = append(attrs, entity.Ref(HttpRouteOidcProviderId, o.OidcProvider))
 	}
 	attrs = append(attrs, entity.Ref(entity.EntityKind, KindHttpRoute))
 	return
@@ -71,13 +83,16 @@ func (o *HttpRoute) Empty() bool {
 	if !entity.Empty(o.App) {
 		return false
 	}
+	if len(o.ClaimMappings) != 0 {
+		return false
+	}
 	if !entity.Empty(o.Default) {
 		return false
 	}
 	if !entity.Empty(o.Host) {
 		return false
 	}
-	if !o.OidcConfig.Empty() {
+	if !entity.Empty(o.OidcProvider) {
 		return false
 	}
 	return true
@@ -85,95 +100,11 @@ func (o *HttpRoute) Empty() bool {
 
 func (o *HttpRoute) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Ref("app", "dev.miren.ingress/http_route.app", schema.Doc("The application to route to"), schema.Indexed, schema.Tags("dev.miren.app_ref"))
+	sb.Component("claim_mappings", "dev.miren.ingress/http_route.claim_mappings", schema.Doc("Mappings from JWT claims to HTTP headers"), schema.Many)
+	(&ClaimMappings{}).InitSchema(sb.Builder("http_route.claim_mappings"))
 	sb.Bool("default", "dev.miren.ingress/http_route.default", schema.Doc("Whether this is the default route for routing"), schema.Indexed)
 	sb.String("host", "dev.miren.ingress/http_route.host", schema.Doc("The hostname to match on for the application"), schema.Indexed)
-	sb.Component("oidc_config", "dev.miren.ingress/http_route.oidc_config", schema.Doc("OIDC authentication configuration for this route"))
-	(&OidcConfig{}).InitSchema(sb.Builder("http_route.oidc_config"))
-}
-
-const (
-	OidcConfigClaimMappingsId = entity.Id("dev.miren.ingress/oidc_config.claim_mappings")
-	OidcConfigClientIdId      = entity.Id("dev.miren.ingress/oidc_config.client_id")
-	OidcConfigClientSecretId  = entity.Id("dev.miren.ingress/oidc_config.client_secret")
-	OidcConfigProviderUrlId   = entity.Id("dev.miren.ingress/oidc_config.provider_url")
-	OidcConfigScopesId        = entity.Id("dev.miren.ingress/oidc_config.scopes")
-)
-
-type OidcConfig struct {
-	ClaimMappings []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
-	ClientId      string          `cbor:"client_id,omitempty" json:"client_id,omitempty"`
-	ClientSecret  string          `cbor:"client_secret,omitempty" json:"client_secret,omitempty"`
-	ProviderUrl   string          `cbor:"provider_url,omitempty" json:"provider_url,omitempty"`
-	Scopes        string          `cbor:"scopes,omitempty" json:"scopes,omitempty"`
-}
-
-func (o *OidcConfig) Decode(e entity.AttrGetter) {
-	for _, a := range e.GetAll(OidcConfigClaimMappingsId) {
-		if a.Value.Kind() == entity.KindComponent {
-			var v ClaimMappings
-			v.Decode(a.Value.Component())
-			o.ClaimMappings = append(o.ClaimMappings, v)
-		}
-	}
-	if a, ok := e.Get(OidcConfigClientIdId); ok && a.Value.Kind() == entity.KindString {
-		o.ClientId = a.Value.String()
-	}
-	if a, ok := e.Get(OidcConfigClientSecretId); ok && a.Value.Kind() == entity.KindString {
-		o.ClientSecret = a.Value.String()
-	}
-	if a, ok := e.Get(OidcConfigProviderUrlId); ok && a.Value.Kind() == entity.KindString {
-		o.ProviderUrl = a.Value.String()
-	}
-	if a, ok := e.Get(OidcConfigScopesId); ok && a.Value.Kind() == entity.KindString {
-		o.Scopes = a.Value.String()
-	}
-}
-
-func (o *OidcConfig) Encode() (attrs []entity.Attr) {
-	for _, v := range o.ClaimMappings {
-		attrs = append(attrs, entity.Component(OidcConfigClaimMappingsId, v.Encode()))
-	}
-	if !entity.Empty(o.ClientId) {
-		attrs = append(attrs, entity.String(OidcConfigClientIdId, o.ClientId))
-	}
-	if !entity.Empty(o.ClientSecret) {
-		attrs = append(attrs, entity.String(OidcConfigClientSecretId, o.ClientSecret))
-	}
-	if !entity.Empty(o.ProviderUrl) {
-		attrs = append(attrs, entity.String(OidcConfigProviderUrlId, o.ProviderUrl))
-	}
-	if !entity.Empty(o.Scopes) {
-		attrs = append(attrs, entity.String(OidcConfigScopesId, o.Scopes))
-	}
-	return
-}
-
-func (o *OidcConfig) Empty() bool {
-	if len(o.ClaimMappings) != 0 {
-		return false
-	}
-	if !entity.Empty(o.ClientId) {
-		return false
-	}
-	if !entity.Empty(o.ClientSecret) {
-		return false
-	}
-	if !entity.Empty(o.ProviderUrl) {
-		return false
-	}
-	if !entity.Empty(o.Scopes) {
-		return false
-	}
-	return true
-}
-
-func (o *OidcConfig) InitSchema(sb *schema.SchemaBuilder) {
-	sb.Component("claim_mappings", "dev.miren.ingress/oidc_config.claim_mappings", schema.Doc("Mappings from JWT claims to HTTP headers"), schema.Many)
-	(&ClaimMappings{}).InitSchema(sb.Builder("oidc_config.claim_mappings"))
-	sb.String("client_id", "dev.miren.ingress/oidc_config.client_id", schema.Doc("The OAuth2 client ID"))
-	sb.String("client_secret", "dev.miren.ingress/oidc_config.client_secret", schema.Doc("The OAuth2 client secret"))
-	sb.String("provider_url", "dev.miren.ingress/oidc_config.provider_url", schema.Doc("The OIDC provider URL (e.g. https://accounts.google.com)"))
-	sb.String("scopes", "dev.miren.ingress/oidc_config.scopes", schema.Doc("Space-separated list of OAuth2 scopes (e.g. \"openid email profile\")"))
+	sb.Ref("oidc_provider", "dev.miren.ingress/http_route.oidc_provider", schema.Doc("Reference to an OIDC provider for authentication"), schema.Indexed)
 }
 
 const (
@@ -220,14 +151,115 @@ func (o *ClaimMappings) InitSchema(sb *schema.SchemaBuilder) {
 	sb.String("header", "dev.miren.ingress/claim_mappings.header", schema.Doc("The HTTP header name to inject (e.g. X-User-Email)"))
 }
 
+const (
+	OidcProviderClientIdId     = entity.Id("dev.miren.ingress/oidc_provider.client_id")
+	OidcProviderClientSecretId = entity.Id("dev.miren.ingress/oidc_provider.client_secret")
+	OidcProviderNameId         = entity.Id("dev.miren.ingress/oidc_provider.name")
+	OidcProviderProviderUrlId  = entity.Id("dev.miren.ingress/oidc_provider.provider_url")
+	OidcProviderScopesId       = entity.Id("dev.miren.ingress/oidc_provider.scopes")
+)
+
+type OidcProvider struct {
+	ID           entity.Id `json:"id"`
+	ClientId     string    `cbor:"client_id,omitempty" json:"client_id,omitempty"`
+	ClientSecret string    `cbor:"client_secret,omitempty" json:"client_secret,omitempty"`
+	Name         string    `cbor:"name,omitempty" json:"name,omitempty"`
+	ProviderUrl  string    `cbor:"provider_url,omitempty" json:"provider_url,omitempty"`
+	Scopes       string    `cbor:"scopes,omitempty" json:"scopes,omitempty"`
+}
+
+func (o *OidcProvider) Decode(e entity.AttrGetter) {
+	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(OidcProviderClientIdId); ok && a.Value.Kind() == entity.KindString {
+		o.ClientId = a.Value.String()
+	}
+	if a, ok := e.Get(OidcProviderClientSecretId); ok && a.Value.Kind() == entity.KindString {
+		o.ClientSecret = a.Value.String()
+	}
+	if a, ok := e.Get(OidcProviderNameId); ok && a.Value.Kind() == entity.KindString {
+		o.Name = a.Value.String()
+	}
+	if a, ok := e.Get(OidcProviderProviderUrlId); ok && a.Value.Kind() == entity.KindString {
+		o.ProviderUrl = a.Value.String()
+	}
+	if a, ok := e.Get(OidcProviderScopesId); ok && a.Value.Kind() == entity.KindString {
+		o.Scopes = a.Value.String()
+	}
+}
+
+func (o *OidcProvider) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindOidcProvider)
+}
+
+func (o *OidcProvider) ShortKind() string {
+	return "oidc_provider"
+}
+
+func (o *OidcProvider) Kind() entity.Id {
+	return KindOidcProvider
+}
+
+func (o *OidcProvider) EntityId() entity.Id {
+	return o.ID
+}
+
+func (o *OidcProvider) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.ClientId) {
+		attrs = append(attrs, entity.String(OidcProviderClientIdId, o.ClientId))
+	}
+	if !entity.Empty(o.ClientSecret) {
+		attrs = append(attrs, entity.String(OidcProviderClientSecretId, o.ClientSecret))
+	}
+	if !entity.Empty(o.Name) {
+		attrs = append(attrs, entity.String(OidcProviderNameId, o.Name))
+	}
+	if !entity.Empty(o.ProviderUrl) {
+		attrs = append(attrs, entity.String(OidcProviderProviderUrlId, o.ProviderUrl))
+	}
+	if !entity.Empty(o.Scopes) {
+		attrs = append(attrs, entity.String(OidcProviderScopesId, o.Scopes))
+	}
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindOidcProvider))
+	return
+}
+
+func (o *OidcProvider) Empty() bool {
+	if !entity.Empty(o.ClientId) {
+		return false
+	}
+	if !entity.Empty(o.ClientSecret) {
+		return false
+	}
+	if !entity.Empty(o.Name) {
+		return false
+	}
+	if !entity.Empty(o.ProviderUrl) {
+		return false
+	}
+	if !entity.Empty(o.Scopes) {
+		return false
+	}
+	return true
+}
+
+func (o *OidcProvider) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("client_id", "dev.miren.ingress/oidc_provider.client_id", schema.Doc("The OAuth2 client ID"))
+	sb.String("client_secret", "dev.miren.ingress/oidc_provider.client_secret", schema.Doc("The OAuth2 client secret"))
+	sb.String("name", "dev.miren.ingress/oidc_provider.name", schema.Doc("A unique name for this OIDC provider"), schema.Indexed)
+	sb.String("provider_url", "dev.miren.ingress/oidc_provider.provider_url", schema.Doc("The OIDC provider URL (e.g. https://accounts.google.com)"), schema.Indexed)
+	sb.String("scopes", "dev.miren.ingress/oidc_provider.scopes", schema.Doc("Space-separated list of OAuth2 scopes (e.g. \"openid email profile\")"))
+}
+
 var (
-	KindHttpRoute = entity.Id("dev.miren.ingress/kind.http_route")
-	Schema        = entity.Id("dev.miren.ingress/schema.v1alpha")
+	KindHttpRoute    = entity.Id("dev.miren.ingress/kind.http_route")
+	KindOidcProvider = entity.Id("dev.miren.ingress/kind.oidc_provider")
+	Schema           = entity.Id("dev.miren.ingress/schema.v1alpha")
 )
 
 func init() {
 	schema.Register("dev.miren.ingress", "v1alpha", func(sb *schema.SchemaBuilder) {
 		(&HttpRoute{}).InitSchema(sb)
+		(&OidcProvider{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x8c\x94\xdfN\xeb0\f\xc6_\xe4\\\x9c#\x1d\x01\x02T\xc4\x15\x8fSe\xb5ۚ\xe5\x1fIVm\xb7\b\x1e\x041xC\xb8Fq65mG\xd7;7\xf1\xf7\xf3g'\xcd\x1e\xb4P\xf8\x04\xd8\x15\x8a\x1c\xea\x82t\xe3\xd0{\\\x93\x06\xff\xb6\xfd7ٹ\x8b;E\x1b\x82-\x9d\xd9\x04\xfcd\xc2\xf6\xcf4\xb1\xcfI\xb4\xef\x1a\x8c\x12\xa4\xa7\xd5\xea\x9aP\x82\x7fy_\x11l\xffΑ\na-\x17\xacb\x10v\x16W\x04,\xfb?+\x03\xac\xc5F\x06\x966Ǐ(\x87\x951\x92\x01'Z\xcd\x00\xad\xf1I\r\x1cEi\xed\x83#\xdd\xec\xa3\xf8jVl\b\xaa\xb22\xba\xa6\x86\x19\xeb|!\xa2\xa82\xca\x1a\x8d:\xf4\xd1a\xb0Srq\x9a\xbcpȯ\x1f\xd1\xef\xed\xd4o\x86**)H\x95JXK\xba\xf1\xa0\x84\xde}\xb1\x1d=\xda9c\xfea\xa9\xf9QŅ\xbd<\xf3\xc1]L{\x19\xd2\x12\x9c\x1da\n\xb3\xe3c\xc4\xe5YD\x8b\x02\xd01\xa3>\xc4\x19\xa4\xe9\xd0y2\xba\xe9\ue174\xad\x90֑\x12nW\xc6>\x14\xa3\x8e\xa4\xdf\xea\r\x87A\xa8CI\xc0\xf5\xa8\xff\x1c\xfb\xbeY\xc4\xf1X9L\xb7W\r\x97Ƽ\xeby\x9eu\xa6#@Wn\x9cd\x9c\x1c\xac\x8ci'~ɜ\xe6+cѧ\x91\x1e\xe2\xa5#}\x8c\x9c\x84\x99\xcf\xebo\xdb8o\xed[\xe3B\x99\u07b9,o\xc1\x93\xf7\x03\x00\x00\xff\xff\x01\x00\x00\xff\xff\x15e\xa3%5\x05\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x94\x94\xdbN\x840\x10\x86_\xc4DM\x8c\xc6\x13\xc6'\"]f\x80q{\xb2\xed\x92\xdd[\x13_\xc4\xd3\x1b\xea\xb5a\x80\xb0\x05\x04\xbc\xd9\f\xed\xcc\xf7\xf7\xef\xce\xf4\x03\xb4P\xf8\fX%\x8a\x1c\xea\x84t\xe1\xd0{ܒ\x06\xff\xb6?\x1f\xed<\xd4;I\x19\x82M\x9d\xd9\x05\xfcb\xc2\xfed\x9c\xd8\xe74\xb4\x9f\x1c\x8c\x12\xa4\xc7jyN(\xc1\xbf\xbeo\b\xf6gs\xa4DX˂Y\x1d\x84\x83\xc5\r\xc1g]v;[\x96IA*U\xc2Z҅\a%\xf4\xe1\x9b9z\xb0S#)3\xca\x1a\x8d:\xf4Qks\xac\x92\xfc\xa9\xb2\xd2\xf5\v\xbb\xbe\x1c\x1f?\xa65p>\x056a}\xd4\xdc\aG\xba`\xc4\xd5\"\xa2D\x01蘑\xb7\xf1\x11\xa4\xa8\xd0y2\xba\xa8\x1e\x85\xb4\xa5\x90֑\x12\xee\x90\xd6>\x14\xa3:\x12\xeb]\xcc\xde8`.v2\xb0X\xd1}\xd4j\xb01F2`\xa2\xb9\x8e\x00\xa5\xf1M5p4t{3[l\b\xb2\xd4:SQgX\xc5Km\xeb\xccz~\xea\x81Sfy\x10\"j\xdb$\xa7\xe3\xdc(\xed_\xe3p\xbd\x00K2I\xa8CJ\xc0\xe2\xd4\x7f\x0eo\xec~%\xc9c氹z\x15/\r\x89\x13\x97\x12\x13\xf9\xef\xeb\x7f\x86\xf5wK\xf5]\x90\xee\x9cd\x84\x8cV\x86\xbc\x89!\x8ay>3\x16}3\x00m\xbcz\x00\"\xd20u\xebK\xe3Bڼ\x9a\xc7}\xb3\xfc\x80\xc6\xe0u\x8d\xf6\v\x00\x00\xff\xff\x01\x00\x00\xff\xff+\xdeU\"\xb7\x05\x00\x00"))
 }

--- a/api/ingress/ingress_v1alpha/schema.gen.go
+++ b/api/ingress/ingress_v1alpha/schema.gen.go
@@ -6,16 +6,18 @@ import (
 )
 
 const (
-	HttpRouteAppId     = entity.Id("dev.miren.ingress/http_route.app")
-	HttpRouteDefaultId = entity.Id("dev.miren.ingress/http_route.default")
-	HttpRouteHostId    = entity.Id("dev.miren.ingress/http_route.host")
+	HttpRouteAppId        = entity.Id("dev.miren.ingress/http_route.app")
+	HttpRouteDefaultId    = entity.Id("dev.miren.ingress/http_route.default")
+	HttpRouteHostId       = entity.Id("dev.miren.ingress/http_route.host")
+	HttpRouteOidcConfigId = entity.Id("dev.miren.ingress/http_route.oidc_config")
 )
 
 type HttpRoute struct {
-	ID      entity.Id `json:"id"`
-	App     entity.Id `cbor:"app,omitempty" json:"app,omitempty"`
-	Default bool      `cbor:"default,omitempty" json:"default,omitempty"`
-	Host    string    `cbor:"host,omitempty" json:"host,omitempty"`
+	ID         entity.Id  `json:"id"`
+	App        entity.Id  `cbor:"app,omitempty" json:"app,omitempty"`
+	Default    bool       `cbor:"default,omitempty" json:"default,omitempty"`
+	Host       string     `cbor:"host,omitempty" json:"host,omitempty"`
+	OidcConfig OidcConfig `cbor:"oidc_config,omitempty" json:"oidc_config,omitempty"`
 }
 
 func (o *HttpRoute) Decode(e entity.AttrGetter) {
@@ -28,6 +30,9 @@ func (o *HttpRoute) Decode(e entity.AttrGetter) {
 	}
 	if a, ok := e.Get(HttpRouteHostId); ok && a.Value.Kind() == entity.KindString {
 		o.Host = a.Value.String()
+	}
+	if a, ok := e.Get(HttpRouteOidcConfigId); ok && a.Value.Kind() == entity.KindComponent {
+		o.OidcConfig.Decode(a.Value.Component())
 	}
 }
 
@@ -55,6 +60,9 @@ func (o *HttpRoute) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.Host) {
 		attrs = append(attrs, entity.String(HttpRouteHostId, o.Host))
 	}
+	if !o.OidcConfig.Empty() {
+		attrs = append(attrs, entity.Component(HttpRouteOidcConfigId, o.OidcConfig.Encode()))
+	}
 	attrs = append(attrs, entity.Ref(entity.EntityKind, KindHttpRoute))
 	return
 }
@@ -69,6 +77,9 @@ func (o *HttpRoute) Empty() bool {
 	if !entity.Empty(o.Host) {
 		return false
 	}
+	if !o.OidcConfig.Empty() {
+		return false
+	}
 	return true
 }
 
@@ -76,6 +87,137 @@ func (o *HttpRoute) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Ref("app", "dev.miren.ingress/http_route.app", schema.Doc("The application to route to"), schema.Indexed, schema.Tags("dev.miren.app_ref"))
 	sb.Bool("default", "dev.miren.ingress/http_route.default", schema.Doc("Whether this is the default route for routing"), schema.Indexed)
 	sb.String("host", "dev.miren.ingress/http_route.host", schema.Doc("The hostname to match on for the application"), schema.Indexed)
+	sb.Component("oidc_config", "dev.miren.ingress/http_route.oidc_config", schema.Doc("OIDC authentication configuration for this route"))
+	(&OidcConfig{}).InitSchema(sb.Builder("http_route.oidc_config"))
+}
+
+const (
+	OidcConfigClaimMappingsId = entity.Id("dev.miren.ingress/oidc_config.claim_mappings")
+	OidcConfigClientIdId      = entity.Id("dev.miren.ingress/oidc_config.client_id")
+	OidcConfigClientSecretId  = entity.Id("dev.miren.ingress/oidc_config.client_secret")
+	OidcConfigProviderUrlId   = entity.Id("dev.miren.ingress/oidc_config.provider_url")
+	OidcConfigScopesId        = entity.Id("dev.miren.ingress/oidc_config.scopes")
+)
+
+type OidcConfig struct {
+	ClaimMappings []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
+	ClientId      string          `cbor:"client_id,omitempty" json:"client_id,omitempty"`
+	ClientSecret  string          `cbor:"client_secret,omitempty" json:"client_secret,omitempty"`
+	ProviderUrl   string          `cbor:"provider_url,omitempty" json:"provider_url,omitempty"`
+	Scopes        string          `cbor:"scopes,omitempty" json:"scopes,omitempty"`
+}
+
+func (o *OidcConfig) Decode(e entity.AttrGetter) {
+	for _, a := range e.GetAll(OidcConfigClaimMappingsId) {
+		if a.Value.Kind() == entity.KindComponent {
+			var v ClaimMappings
+			v.Decode(a.Value.Component())
+			o.ClaimMappings = append(o.ClaimMappings, v)
+		}
+	}
+	if a, ok := e.Get(OidcConfigClientIdId); ok && a.Value.Kind() == entity.KindString {
+		o.ClientId = a.Value.String()
+	}
+	if a, ok := e.Get(OidcConfigClientSecretId); ok && a.Value.Kind() == entity.KindString {
+		o.ClientSecret = a.Value.String()
+	}
+	if a, ok := e.Get(OidcConfigProviderUrlId); ok && a.Value.Kind() == entity.KindString {
+		o.ProviderUrl = a.Value.String()
+	}
+	if a, ok := e.Get(OidcConfigScopesId); ok && a.Value.Kind() == entity.KindString {
+		o.Scopes = a.Value.String()
+	}
+}
+
+func (o *OidcConfig) Encode() (attrs []entity.Attr) {
+	for _, v := range o.ClaimMappings {
+		attrs = append(attrs, entity.Component(OidcConfigClaimMappingsId, v.Encode()))
+	}
+	if !entity.Empty(o.ClientId) {
+		attrs = append(attrs, entity.String(OidcConfigClientIdId, o.ClientId))
+	}
+	if !entity.Empty(o.ClientSecret) {
+		attrs = append(attrs, entity.String(OidcConfigClientSecretId, o.ClientSecret))
+	}
+	if !entity.Empty(o.ProviderUrl) {
+		attrs = append(attrs, entity.String(OidcConfigProviderUrlId, o.ProviderUrl))
+	}
+	if !entity.Empty(o.Scopes) {
+		attrs = append(attrs, entity.String(OidcConfigScopesId, o.Scopes))
+	}
+	return
+}
+
+func (o *OidcConfig) Empty() bool {
+	if len(o.ClaimMappings) != 0 {
+		return false
+	}
+	if !entity.Empty(o.ClientId) {
+		return false
+	}
+	if !entity.Empty(o.ClientSecret) {
+		return false
+	}
+	if !entity.Empty(o.ProviderUrl) {
+		return false
+	}
+	if !entity.Empty(o.Scopes) {
+		return false
+	}
+	return true
+}
+
+func (o *OidcConfig) InitSchema(sb *schema.SchemaBuilder) {
+	sb.Component("claim_mappings", "dev.miren.ingress/oidc_config.claim_mappings", schema.Doc("Mappings from JWT claims to HTTP headers"), schema.Many)
+	(&ClaimMappings{}).InitSchema(sb.Builder("oidc_config.claim_mappings"))
+	sb.String("client_id", "dev.miren.ingress/oidc_config.client_id", schema.Doc("The OAuth2 client ID"))
+	sb.String("client_secret", "dev.miren.ingress/oidc_config.client_secret", schema.Doc("The OAuth2 client secret"))
+	sb.String("provider_url", "dev.miren.ingress/oidc_config.provider_url", schema.Doc("The OIDC provider URL (e.g. https://accounts.google.com)"))
+	sb.String("scopes", "dev.miren.ingress/oidc_config.scopes", schema.Doc("Space-separated list of OAuth2 scopes (e.g. \"openid email profile\")"))
+}
+
+const (
+	ClaimMappingsClaimId  = entity.Id("dev.miren.ingress/claim_mappings.claim")
+	ClaimMappingsHeaderId = entity.Id("dev.miren.ingress/claim_mappings.header")
+)
+
+type ClaimMappings struct {
+	Claim  string `cbor:"claim,omitempty" json:"claim,omitempty"`
+	Header string `cbor:"header,omitempty" json:"header,omitempty"`
+}
+
+func (o *ClaimMappings) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(ClaimMappingsClaimId); ok && a.Value.Kind() == entity.KindString {
+		o.Claim = a.Value.String()
+	}
+	if a, ok := e.Get(ClaimMappingsHeaderId); ok && a.Value.Kind() == entity.KindString {
+		o.Header = a.Value.String()
+	}
+}
+
+func (o *ClaimMappings) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Claim) {
+		attrs = append(attrs, entity.String(ClaimMappingsClaimId, o.Claim))
+	}
+	if !entity.Empty(o.Header) {
+		attrs = append(attrs, entity.String(ClaimMappingsHeaderId, o.Header))
+	}
+	return
+}
+
+func (o *ClaimMappings) Empty() bool {
+	if !entity.Empty(o.Claim) {
+		return false
+	}
+	if !entity.Empty(o.Header) {
+		return false
+	}
+	return true
+}
+
+func (o *ClaimMappings) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("claim", "dev.miren.ingress/claim_mappings.claim", schema.Doc("The JWT claim name (e.g. email, sub, name)"))
+	sb.String("header", "dev.miren.ingress/claim_mappings.header", schema.Doc("The HTTP header name to inject (e.g. X-User-Email)"))
 }
 
 var (
@@ -87,5 +229,5 @@ func init() {
 	schema.Register("dev.miren.ingress", "v1alpha", func(sb *schema.SchemaBuilder) {
 		(&HttpRoute{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x8c\x90MN\xc40\fF/\xc2\x02$\xd6A\x9c\xa8J\xb1\x93\x98\xe6\x0f;\xad\xda5'A \x8e\xc8\x1a%ը\xd5tT\xcdΖ\xbf\xf7,\xfb\a\xa2\x0e\xf8\x018\xa9@\x8cQQ\xb4\x8c\"8P\x04\xf9\x9a\x9f\x0e\x93\x97:Q\xae\x94\xdcq\x1a\v\xfe6\xc3\xfcp\fn\x99\xd5\xf6g \x05M\xf1\xb8\xcd\x18B\x0f\xf2\xf9\xdd\x13̏g&\xa5sn\v\xdfjQ\x96\x8c=AÞO1@\xa3G_\x1aj/MšO\xc97\xc1\x8dSw\x02\x97d\xa5\xa1U\x155R\x98\xa2\xb5\x13\xb2P\x8avz\xd5>;\xed3Sмt\xf5\xe8\xf7Mq\x9d\x1b\xc4%.\xdd\xfa\xe8]\ue39f\xff\x03\x00\x00\xff\xff\x01\x00\x00\xff\xff\xad\xbe\xa7\xab\xb6\x01\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x8c\x94\xdfN\xeb0\f\xc6_\xe4\\\x9c#\x1d\x01\x02T\xc4\x15\x8fSe\xb5ۚ\xe5\x1fIVm\xb7\b\x1e\x041xC\xb8Fq65mG\xd7;7\xf1\xf7\xf3g'\xcd\x1e\xb4P\xf8\x04\xd8\x15\x8a\x1c\xea\x82t\xe3\xd0{\\\x93\x06\xff\xb6\xfd7ٹ\x8b;E\x1b\x82-\x9d\xd9\x04\xfcd\xc2\xf6\xcf4\xb1\xcfI\xb4\xef\x1a\x8c\x12\xa4\xa7\xd5\xea\x9aP\x82\x7fy_\x11l\xffΑ\na-\x17\xacb\x10v\x16W\x04,\xfb?+\x03\xac\xc5F\x06\x966Ǐ(\x87\x951\x92\x01'Z\xcd\x00\xad\xf1I\r\x1cEi\xed\x83#\xdd\xec\xa3\xf8jVl\b\xaa\xb22\xba\xa6\x86\x19\xeb|!\xa2\xa82\xca\x1a\x8d:\xf4\xd1a\xb0Srq\x9a\xbcpȯ\x1f\xd1\xef\xed\xd4o\x86**)H\x95JXK\xba\xf1\xa0\x84\xde}\xb1\x1d=\xda9c\xfea\xa9\xf9QŅ\xbd<\xf3\xc1]L{\x19\xd2\x12\x9c\x1da\n\xb3\xe3c\xc4\xe5YD\x8b\x02\xd01\xa3>\xc4\x19\xa4\xe9\xd0y2\xba\xe9\ue174\xad\x90֑\x12nW\xc6>\x14\xa3\x8e\xa4\xdf\xea\r\x87A\xa8CI\xc0\xf5\xa8\xff\x1c\xfb\xbeY\xc4\xf1X9L\xb7W\r\x97Ƽ\xeby\x9eu\xa6#@Wn\x9cd\x9c\x1c\xac\x8ci'~ɜ\xe6+cѧ\x91\x1e\xe2\xa5#}\x8c\x9c\x84\x99\xcf\xebo\xdb8o\xed[\xe3B\x99\u07b9,o\xc1\x93\xf7\x03\x00\x00\xff\xff\x01\x00\x00\xff\xff\x15e\xa3%5\x05\x00\x00"))
 }

--- a/api/ingress/routewatcher.go
+++ b/api/ingress/routewatcher.go
@@ -63,6 +63,12 @@ func (rw *RouteWatcher) Watch(ctx context.Context) error {
 
 		routeID := op.EntityId()
 
+		// Delete events don't carry an entity payload
+		if op.OperationType() == entityserver_v1alpha.EntityOperationDelete {
+			rw.removeRouteHost(routeID)
+			return nil
+		}
+
 		var route ingress_v1alpha.HttpRoute
 		route.Decode(op.Entity().Entity())
 
@@ -78,9 +84,6 @@ func (rw *RouteWatcher) Watch(ctx context.Context) error {
 
 		case entityserver_v1alpha.EntityOperationUpdate:
 			rw.updateRouteHost(routeID, host)
-
-		case entityserver_v1alpha.EntityOperationDelete:
-			rw.removeRouteHost(routeID)
 		}
 
 		return nil

--- a/api/ingress/schema.yml
+++ b/api/ingress/schema.yml
@@ -15,30 +15,36 @@ kinds:
       type: bool
       indexed: true
       doc: Whether this is the default route for routing
-    oidc_config:
+    oidc_provider:
+      type: ref
+      doc: Reference to an OIDC provider for authentication
+      indexed: true
+    claim_mappings:
       type: component
-      doc: OIDC authentication configuration for this route
+      doc: Mappings from JWT claims to HTTP headers
+      many: true
       attrs:
-        provider_url:
+        claim:
           type: string
-          doc: The OIDC provider URL (e.g. https://accounts.google.com)
-        client_id:
+          doc: The JWT claim name (e.g. email, sub, name)
+        header:
           type: string
-          doc: The OAuth2 client ID
-        client_secret:
-          type: string
-          doc: The OAuth2 client secret
-        scopes:
-          type: string
-          doc: Space-separated list of OAuth2 scopes (e.g. "openid email profile")
-        claim_mappings:
-          type: component
-          doc: Mappings from JWT claims to HTTP headers
-          many: true
-          attrs:
-            claim:
-              type: string
-              doc: The JWT claim name (e.g. email, sub, name)
-            header:
-              type: string
-              doc: The HTTP header name to inject (e.g. X-User-Email)
+          doc: The HTTP header name to inject (e.g. X-User-Email)
+  oidc_provider:
+    name:
+      type: string
+      doc: A unique name for this OIDC provider
+      indexed: true
+    provider_url:
+      type: string
+      doc: The OIDC provider URL (e.g. https://accounts.google.com)
+      indexed: true
+    client_id:
+      type: string
+      doc: The OAuth2 client ID
+    client_secret:
+      type: string
+      doc: The OAuth2 client secret
+    scopes:
+      type: string
+      doc: Space-separated list of OAuth2 scopes (e.g. "openid email profile")

--- a/api/ingress/schema.yml
+++ b/api/ingress/schema.yml
@@ -15,3 +15,30 @@ kinds:
       type: bool
       indexed: true
       doc: Whether this is the default route for routing
+    oidc_config:
+      type: component
+      doc: OIDC authentication configuration for this route
+      attrs:
+        provider_url:
+          type: string
+          doc: The OIDC provider URL (e.g. https://accounts.google.com)
+        client_id:
+          type: string
+          doc: The OAuth2 client ID
+        client_secret:
+          type: string
+          doc: The OAuth2 client secret
+        scopes:
+          type: string
+          doc: Space-separated list of OAuth2 scopes (e.g. "openid email profile")
+        claim_mappings:
+          type: component
+          doc: Mappings from JWT claims to HTTP headers
+          many: true
+          attrs:
+            claim:
+              type: string
+              doc: The JWT claim name (e.g. email, sub, name)
+            header:
+              type: string
+              doc: The HTTP header name to inject (e.g. X-User-Email)

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -59,6 +59,14 @@ func RegisterAll(d *mflags.Dispatcher) {
 	d.Dispatch("route set-default", Infer("route set-default", "Set an app as the default route", RouteSetDefault))
 	d.Dispatch("route unset-default", Infer("route unset-default", "Remove the default route", RouteUnsetDefault))
 
+	// Route OIDC commands - behind feature flag
+	if labs.RouteOIDC() {
+		d.Dispatch("route oidc", Section("route oidc", "OIDC authentication management for routes", ""))
+		d.Dispatch("route oidc enable", Infer("route oidc enable", "Enable OIDC authentication for a route", RouteOidcEnable))
+		d.Dispatch("route oidc disable", Infer("route oidc disable", "Disable OIDC authentication for a route", RouteOidcDisable))
+		d.Dispatch("route oidc show", Infer("route oidc show", "Show OIDC configuration for a route", RouteOidcShow))
+	}
+
 	// Config commands
 	d.Dispatch("config", Section("config", "Configuration file management", ""))
 	d.Dispatch("config info", Infer("config info", "Show configuration file locations and format", ConfigInfo))

--- a/cli/commands/route_oidc_disable.go
+++ b/cli/commands/route_oidc_disable.go
@@ -4,13 +4,28 @@ import (
 	"fmt"
 
 	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/labs"
 )
 
 func RouteOidcDisable(ctx *Context, opts struct {
-	Host string `position:"0" usage:"Hostname for the route (e.g., example.com)" required:"true"`
+	Host    string `position:"0" usage:"Hostname for the route (e.g., example.com)"`
+	Default bool   `long:"default" description:"Disable OIDC on the default route"`
 	ConfigCentric
 }) error {
+	if !labs.RouteOIDC() {
+		return fmt.Errorf("OIDC authentication for routes is disabled. Enable with MIREN_LABS=routeoidc")
+	}
+
+	if opts.Host == "" && !opts.Default {
+		return fmt.Errorf("either a hostname or --default must be specified")
+	}
+
+	if opts.Host != "" && opts.Default {
+		return fmt.Errorf("--default cannot be used with a hostname")
+	}
+
 	client, err := ctx.RPCClient("entities")
 	if err != nil {
 		return err
@@ -18,28 +33,41 @@ func RouteOidcDisable(ctx *Context, opts struct {
 
 	ic := ingress.NewClient(ctx.Log, client)
 
-	// Look up existing route
-	route, err := ic.Lookup(ctx, opts.Host)
-	if err != nil {
-		return fmt.Errorf("failed to lookup route: %w", err)
-	}
+	var route *ingress_v1alpha.HttpRoute
+	var routeLabel string
 
-	if route == nil {
-		return fmt.Errorf("route not found for host: %s", opts.Host)
+	if opts.Default {
+		route, err = ic.LookupDefault(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to lookup default route: %w", err)
+		}
+		if route == nil {
+			return fmt.Errorf("no default route configured")
+		}
+		routeLabel = "default"
+	} else {
+		route, err = ic.Lookup(ctx, opts.Host)
+		if err != nil {
+			return fmt.Errorf("failed to lookup route: %w", err)
+		}
+		if route == nil {
+			return fmt.Errorf("route not found for host: %s", opts.Host)
+		}
+		routeLabel = opts.Host
 	}
 
 	// Check if OIDC is configured
 	if entity.Empty(route.OidcProvider) {
-		ctx.Printf("OIDC is not configured for route: %s\n", opts.Host)
+		ctx.Printf("OIDC is not configured for route: %s\n", routeLabel)
 		return nil
 	}
 
 	// Detach OIDC provider
-	_, err = ic.DetachOIDCProvider(ctx, opts.Host)
+	_, err = ic.DetachOIDCProviderFromRoute(ctx, route)
 	if err != nil {
 		return fmt.Errorf("failed to disable OIDC: %w", err)
 	}
 
-	ctx.Printf("OIDC disabled for route: %s\n", opts.Host)
+	ctx.Printf("OIDC disabled for route: %s\n", routeLabel)
 	return nil
 }

--- a/cli/commands/route_oidc_disable.go
+++ b/cli/commands/route_oidc_disable.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/pkg/entity"
 )
 
 func RouteOidcDisable(ctx *Context, opts struct {
@@ -28,13 +29,13 @@ func RouteOidcDisable(ctx *Context, opts struct {
 	}
 
 	// Check if OIDC is configured
-	if route.OidcConfig.Empty() {
+	if entity.Empty(route.OidcProvider) {
 		ctx.Printf("OIDC is not configured for route: %s\n", opts.Host)
 		return nil
 	}
 
-	// Clear OIDC config
-	_, err = ic.ClearOIDCConfig(ctx, opts.Host)
+	// Detach OIDC provider
+	_, err = ic.DetachOIDCProvider(ctx, opts.Host)
 	if err != nil {
 		return fmt.Errorf("failed to disable OIDC: %w", err)
 	}

--- a/cli/commands/route_oidc_disable.go
+++ b/cli/commands/route_oidc_disable.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/api/ingress"
+)
+
+func RouteOidcDisable(ctx *Context, opts struct {
+	Host string `position:"0" usage:"Hostname for the route (e.g., example.com)" required:"true"`
+	ConfigCentric
+}) error {
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	ic := ingress.NewClient(ctx.Log, client)
+
+	// Look up existing route
+	route, err := ic.Lookup(ctx, opts.Host)
+	if err != nil {
+		return fmt.Errorf("failed to lookup route: %w", err)
+	}
+
+	if route == nil {
+		return fmt.Errorf("route not found for host: %s", opts.Host)
+	}
+
+	// Check if OIDC is configured
+	if route.OidcConfig.Empty() {
+		ctx.Printf("OIDC is not configured for route: %s\n", opts.Host)
+		return nil
+	}
+
+	// Clear OIDC config
+	_, err = ic.ClearOIDCConfig(ctx, opts.Host)
+	if err != nil {
+		return fmt.Errorf("failed to disable OIDC: %w", err)
+	}
+
+	ctx.Printf("OIDC disabled for route: %s\n", opts.Host)
+	return nil
+}

--- a/cli/commands/route_oidc_enable.go
+++ b/cli/commands/route_oidc_enable.go
@@ -10,9 +10,10 @@ import (
 
 func RouteOidcEnable(ctx *Context, opts struct {
 	Host         string   `position:"0" usage:"Hostname for the route (e.g., example.com)" required:"true"`
-	ProviderURL  string   `flag:"provider-url" usage:"OIDC provider URL (e.g., https://accounts.google.com)" required:"true"`
-	ClientID     string   `flag:"client-id" usage:"OAuth2 client ID" required:"true"`
-	ClientSecret string   `flag:"client-secret" usage:"OAuth2 client secret" required:"true"`
+	Provider     string   `flag:"provider" usage:"Name of existing OIDC provider (use --provider-url for inline creation)"`
+	ProviderURL  string   `flag:"provider-url" usage:"OIDC provider URL (e.g., https://accounts.google.com) - creates provider if not exists"`
+	ClientID     string   `flag:"client-id" usage:"OAuth2 client ID (required with --provider-url)"`
+	ClientSecret string   `flag:"client-secret" usage:"OAuth2 client secret (required with --provider-url)"`
 	Scopes       []string `flag:"scope" usage:"OAuth2 scopes (can be specified multiple times)"`
 	ClaimHeader  []string `flag:"claim-header" usage:"Claim to header mapping in format 'claim:header' (e.g., 'email:X-User-Email')"`
 	ConfigCentric
@@ -34,6 +35,53 @@ func RouteOidcEnable(ctx *Context, opts struct {
 		return fmt.Errorf("route not found for host: %s", opts.Host)
 	}
 
+	// Determine provider name
+	providerName := opts.Provider
+	if providerName == "" {
+		// If no provider name given and provider-url specified, generate a name
+		if opts.ProviderURL != "" {
+			// Use the host from the provider URL as the provider name
+			providerName = strings.ReplaceAll(opts.ProviderURL, "https://", "")
+			providerName = strings.ReplaceAll(providerName, "http://", "")
+			providerName = strings.Split(providerName, "/")[0]
+		} else {
+			return fmt.Errorf("either --provider or --provider-url must be specified")
+		}
+	}
+
+	// If provider-url is specified, create or update the provider
+	if opts.ProviderURL != "" {
+		if opts.ClientID == "" || opts.ClientSecret == "" {
+			return fmt.Errorf("--client-id and --client-secret are required with --provider-url")
+		}
+
+		// Build scopes string
+		scopes := "openid"
+		if len(opts.Scopes) > 0 {
+			scopes = strings.Join(opts.Scopes, " ")
+			// Ensure openid is included
+			if !strings.Contains(scopes, "openid") {
+				scopes = "openid " + scopes
+			}
+		}
+
+		// Create or update provider
+		provider := &ingress_v1alpha.OidcProvider{
+			Name:         providerName,
+			ProviderUrl:  opts.ProviderURL,
+			ClientId:     opts.ClientID,
+			ClientSecret: opts.ClientSecret,
+			Scopes:       scopes,
+		}
+
+		_, err = ic.CreateOrUpdateOIDCProvider(ctx, provider)
+		if err != nil {
+			return fmt.Errorf("failed to create/update OIDC provider: %w", err)
+		}
+
+		ctx.Printf("Created/updated OIDC provider: %s\n", providerName)
+	}
+
 	// Parse claim mappings
 	var claimMappings []ingress_v1alpha.ClaimMappings
 	for _, mapping := range opts.ClaimHeader {
@@ -47,34 +95,14 @@ func RouteOidcEnable(ctx *Context, opts struct {
 		})
 	}
 
-	// Build scopes string
-	scopes := "openid"
-	if len(opts.Scopes) > 0 {
-		scopes = strings.Join(opts.Scopes, " ")
-		// Ensure openid is included
-		if !strings.Contains(scopes, "openid") {
-			scopes = "openid " + scopes
-		}
-	}
-
-	// Configure OIDC
-	oidcConfig := ingress_v1alpha.OidcConfig{
-		ProviderUrl:   opts.ProviderURL,
-		ClientId:      opts.ClientID,
-		ClientSecret:  opts.ClientSecret,
-		Scopes:        scopes,
-		ClaimMappings: claimMappings,
-	}
-
-	// Update the route with OIDC config
-	_, err = ic.UpdateOIDCConfig(ctx, opts.Host, oidcConfig)
+	// Attach provider to route
+	_, err = ic.AttachOIDCProvider(ctx, opts.Host, providerName, claimMappings)
 	if err != nil {
-		return fmt.Errorf("failed to update route OIDC config: %w", err)
+		return fmt.Errorf("failed to attach OIDC provider to route: %w", err)
 	}
 
 	ctx.Printf("OIDC enabled for route: %s\n", opts.Host)
-	ctx.Printf("Provider: %s\n", opts.ProviderURL)
-	ctx.Printf("Client ID: %s\n", opts.ClientID)
+	ctx.Printf("Provider: %s\n", providerName)
 	if len(claimMappings) > 0 {
 		ctx.Printf("Claim mappings:\n")
 		for _, mapping := range claimMappings {

--- a/cli/commands/route_oidc_enable.go
+++ b/cli/commands/route_oidc_enable.go
@@ -6,18 +6,33 @@ import (
 
 	"miren.dev/runtime/api/ingress"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/labs"
+	"miren.dev/runtime/pkg/ui"
 )
 
 func RouteOidcEnable(ctx *Context, opts struct {
-	Host         string   `position:"0" usage:"Hostname for the route (e.g., example.com)" required:"true"`
-	Provider     string   `flag:"provider" usage:"Name of existing OIDC provider (use --provider-url for inline creation)"`
-	ProviderURL  string   `flag:"provider-url" usage:"OIDC provider URL (e.g., https://accounts.google.com) - creates provider if not exists"`
-	ClientID     string   `flag:"client-id" usage:"OAuth2 client ID (required with --provider-url)"`
-	ClientSecret string   `flag:"client-secret" usage:"OAuth2 client secret (required with --provider-url)"`
-	Scopes       []string `flag:"scope" usage:"OAuth2 scopes (can be specified multiple times)"`
-	ClaimHeader  []string `flag:"claim-header" usage:"Claim to header mapping in format 'claim:header' (e.g., 'email:X-User-Email')"`
+	Host         string   `position:"0" usage:"Hostname for the route (e.g., example.com)"`
+	Default      bool     `long:"default" description:"Apply to the default route"`
+	Provider     string   `long:"provider" description:"Name of existing OIDC provider (use --provider-url for inline creation)"`
+	ProviderURL  string   `long:"provider-url" description:"OIDC provider URL (e.g., https://accounts.google.com) - creates provider if not exists"`
+	ClientID     string   `long:"client-id" description:"OAuth2 client ID (required with --provider-url)"`
+	ClientSecret string   `long:"client-secret" description:"OAuth2 client secret (required with --provider-url)"`
+	Scopes       []string `long:"scope" description:"OAuth2 scopes (can be specified multiple times)"`
+	ClaimHeader  []string `long:"claim-header" description:"Claim to header mapping in format 'claim:header' (e.g., 'email:X-User-Email')"`
 	ConfigCentric
 }) error {
+	if !labs.RouteOIDC() {
+		return fmt.Errorf("OIDC authentication for routes is disabled. Enable with MIREN_LABS=routeoidc")
+	}
+
+	if opts.Host == "" && !opts.Default {
+		return fmt.Errorf("either a hostname or --default must be specified")
+	}
+
+	if opts.Host != "" && opts.Default {
+		return fmt.Errorf("--default cannot be used with a hostname")
+	}
+
 	client, err := ctx.RPCClient("entities")
 	if err != nil {
 		return err
@@ -25,14 +40,27 @@ func RouteOidcEnable(ctx *Context, opts struct {
 
 	ic := ingress.NewClient(ctx.Log, client)
 
-	// Look up existing route
-	route, err := ic.Lookup(ctx, opts.Host)
-	if err != nil {
-		return fmt.Errorf("failed to lookup route: %w", err)
-	}
+	var route *ingress_v1alpha.HttpRoute
+	var routeLabel string
 
-	if route == nil {
-		return fmt.Errorf("route not found for host: %s", opts.Host)
+	if opts.Default {
+		route, err = ic.LookupDefault(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to lookup default route: %w", err)
+		}
+		if route == nil {
+			return fmt.Errorf("no default route configured")
+		}
+		routeLabel = "default"
+	} else {
+		route, err = ic.Lookup(ctx, opts.Host)
+		if err != nil {
+			return fmt.Errorf("failed to lookup route: %w", err)
+		}
+		if route == nil {
+			return fmt.Errorf("route not found for host: %s", opts.Host)
+		}
+		routeLabel = opts.Host
 	}
 
 	// Determine provider name
@@ -96,18 +124,35 @@ func RouteOidcEnable(ctx *Context, opts struct {
 	}
 
 	// Attach provider to route
-	_, err = ic.AttachOIDCProvider(ctx, opts.Host, providerName, claimMappings)
+	_, err = ic.AttachOIDCProviderToRoute(ctx, route, providerName, claimMappings)
 	if err != nil {
 		return fmt.Errorf("failed to attach OIDC provider to route: %w", err)
 	}
 
-	ctx.Printf("OIDC enabled for route: %s\n", opts.Host)
-	ctx.Printf("Provider: %s\n", providerName)
-	if len(claimMappings) > 0 {
-		ctx.Printf("Claim mappings:\n")
-		for _, mapping := range claimMappings {
-			ctx.Printf("  %s → %s\n", mapping.Claim, mapping.Header)
-		}
+	items := []ui.NamedValue{
+		ui.NewNamedValue("Route", routeLabel),
+		ui.NewNamedValue("OIDC", true),
+		ui.NewNamedValue("Provider", providerName),
 	}
+
+	ctx.Printf("%s\n", ui.NewNamedValueList(items).Render())
+
+	if len(claimMappings) > 0 {
+		var rows []ui.Row
+		for _, m := range claimMappings {
+			rows = append(rows, ui.Row{m.Claim, m.Header})
+		}
+
+		headers := []string{"CLAIM", "HEADER"}
+		columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0).NoTruncate(1))
+		table := ui.NewTable(
+			ui.WithTableTitle("Claim Mappings"),
+			ui.WithColumns(columns),
+			ui.WithRows(rows),
+		)
+
+		ctx.Printf("\n%s\n", table.Render())
+	}
+
 	return nil
 }

--- a/cli/commands/route_oidc_enable.go
+++ b/cli/commands/route_oidc_enable.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+)
+
+func RouteOidcEnable(ctx *Context, opts struct {
+	Host         string   `position:"0" usage:"Hostname for the route (e.g., example.com)" required:"true"`
+	ProviderURL  string   `flag:"provider-url" usage:"OIDC provider URL (e.g., https://accounts.google.com)" required:"true"`
+	ClientID     string   `flag:"client-id" usage:"OAuth2 client ID" required:"true"`
+	ClientSecret string   `flag:"client-secret" usage:"OAuth2 client secret" required:"true"`
+	Scopes       []string `flag:"scope" usage:"OAuth2 scopes (can be specified multiple times)"`
+	ClaimHeader  []string `flag:"claim-header" usage:"Claim to header mapping in format 'claim:header' (e.g., 'email:X-User-Email')"`
+	ConfigCentric
+}) error {
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	ic := ingress.NewClient(ctx.Log, client)
+
+	// Look up existing route
+	route, err := ic.Lookup(ctx, opts.Host)
+	if err != nil {
+		return fmt.Errorf("failed to lookup route: %w", err)
+	}
+
+	if route == nil {
+		return fmt.Errorf("route not found for host: %s", opts.Host)
+	}
+
+	// Parse claim mappings
+	var claimMappings []ingress_v1alpha.ClaimMappings
+	for _, mapping := range opts.ClaimHeader {
+		parts := strings.SplitN(mapping, ":", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid claim-header mapping format: %s (expected 'claim:header')", mapping)
+		}
+		claimMappings = append(claimMappings, ingress_v1alpha.ClaimMappings{
+			Claim:  strings.TrimSpace(parts[0]),
+			Header: strings.TrimSpace(parts[1]),
+		})
+	}
+
+	// Build scopes string
+	scopes := "openid"
+	if len(opts.Scopes) > 0 {
+		scopes = strings.Join(opts.Scopes, " ")
+		// Ensure openid is included
+		if !strings.Contains(scopes, "openid") {
+			scopes = "openid " + scopes
+		}
+	}
+
+	// Configure OIDC
+	oidcConfig := ingress_v1alpha.OidcConfig{
+		ProviderUrl:   opts.ProviderURL,
+		ClientId:      opts.ClientID,
+		ClientSecret:  opts.ClientSecret,
+		Scopes:        scopes,
+		ClaimMappings: claimMappings,
+	}
+
+	// Update the route with OIDC config
+	_, err = ic.UpdateOIDCConfig(ctx, opts.Host, oidcConfig)
+	if err != nil {
+		return fmt.Errorf("failed to update route OIDC config: %w", err)
+	}
+
+	ctx.Printf("OIDC enabled for route: %s\n", opts.Host)
+	ctx.Printf("Provider: %s\n", opts.ProviderURL)
+	ctx.Printf("Client ID: %s\n", opts.ClientID)
+	if len(claimMappings) > 0 {
+		ctx.Printf("Claim mappings:\n")
+		for _, mapping := range claimMappings {
+			ctx.Printf("  %s → %s\n", mapping.Claim, mapping.Header)
+		}
+	}
+	return nil
+}

--- a/cli/commands/route_oidc_enable.go
+++ b/cli/commands/route_oidc_enable.go
@@ -83,15 +83,19 @@ func RouteOidcEnable(ctx *Context, opts struct {
 			return fmt.Errorf("--client-id and --client-secret are required with --provider-url")
 		}
 
-		// Build scopes string
-		scopes := "openid"
-		if len(opts.Scopes) > 0 {
-			scopes = strings.Join(opts.Scopes, " ")
-			// Ensure openid is included
-			if !strings.Contains(scopes, "openid") {
-				scopes = "openid " + scopes
+		// Build scopes, ensuring "openid" is always included
+		hasOpenID := false
+		for _, s := range opts.Scopes {
+			if s == "openid" {
+				hasOpenID = true
+				break
 			}
 		}
+		scopeList := opts.Scopes
+		if !hasOpenID {
+			scopeList = append([]string{"openid"}, scopeList...)
+		}
+		scopes := strings.Join(scopeList, " ")
 
 		// Create or update provider
 		provider := &ingress_v1alpha.OidcProvider{

--- a/cli/commands/route_oidc_show.go
+++ b/cli/commands/route_oidc_show.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
 )
 
 func RouteOidcShow(ctx *Context, opts struct {
@@ -29,16 +31,23 @@ func RouteOidcShow(ctx *Context, opts struct {
 	}
 
 	// Check if OIDC is configured
-	if route.OidcConfig.Empty() {
+	if entity.Empty(route.OidcProvider) {
 		if opts.IsJSON() {
 			return PrintJSON(map[string]interface{}{
 				"host":         opts.Host,
 				"oidc_enabled": false,
-				"oidc_config":  nil,
+				"provider":     nil,
 			})
 		}
 		ctx.Printf("OIDC is not configured for route: %s\n", opts.Host)
 		return nil
+	}
+
+	// Look up the OIDC provider
+	var provider ingress_v1alpha.OidcProvider
+	err = ic.GetEntityStore().GetById(ctx, route.OidcProvider, &provider)
+	if err != nil {
+		return fmt.Errorf("failed to get OIDC provider: %w", err)
 	}
 
 	// Display OIDC config
@@ -46,6 +55,7 @@ func RouteOidcShow(ctx *Context, opts struct {
 		type OIDCConfigJSON struct {
 			Host          string              `json:"host"`
 			OIDCEnabled   bool                `json:"oidc_enabled"`
+			ProviderName  string              `json:"provider_name"`
 			ProviderURL   string              `json:"provider_url"`
 			ClientID      string              `json:"client_id"`
 			Scopes        string              `json:"scopes"`
@@ -53,7 +63,7 @@ func RouteOidcShow(ctx *Context, opts struct {
 		}
 
 		var mappings []map[string]string
-		for _, m := range route.OidcConfig.ClaimMappings {
+		for _, m := range route.ClaimMappings {
 			mappings = append(mappings, map[string]string{
 				"claim":  m.Claim,
 				"header": m.Header,
@@ -63,22 +73,24 @@ func RouteOidcShow(ctx *Context, opts struct {
 		return PrintJSON(OIDCConfigJSON{
 			Host:          opts.Host,
 			OIDCEnabled:   true,
-			ProviderURL:   route.OidcConfig.ProviderUrl,
-			ClientID:      route.OidcConfig.ClientId,
-			Scopes:        route.OidcConfig.Scopes,
+			ProviderName:  provider.Name,
+			ProviderURL:   provider.ProviderUrl,
+			ClientID:      provider.ClientId,
+			Scopes:        provider.Scopes,
 			ClaimMappings: mappings,
 		})
 	}
 
 	ctx.Printf("OIDC Configuration for route: %s\n\n", opts.Host)
 	ctx.Printf("Enabled:      Yes\n")
-	ctx.Printf("Provider URL: %s\n", route.OidcConfig.ProviderUrl)
-	ctx.Printf("Client ID:    %s\n", route.OidcConfig.ClientId)
-	ctx.Printf("Scopes:       %s\n", route.OidcConfig.Scopes)
+	ctx.Printf("Provider:     %s\n", provider.Name)
+	ctx.Printf("Provider URL: %s\n", provider.ProviderUrl)
+	ctx.Printf("Client ID:    %s\n", provider.ClientId)
+	ctx.Printf("Scopes:       %s\n", provider.Scopes)
 
-	if len(route.OidcConfig.ClaimMappings) > 0 {
+	if len(route.ClaimMappings) > 0 {
 		ctx.Printf("\nClaim Mappings:\n")
-		for _, mapping := range route.OidcConfig.ClaimMappings {
+		for _, mapping := range route.ClaimMappings {
 			ctx.Printf("  %s → %s\n", mapping.Claim, mapping.Header)
 		}
 	}

--- a/cli/commands/route_oidc_show.go
+++ b/cli/commands/route_oidc_show.go
@@ -6,13 +6,28 @@ import (
 	"miren.dev/runtime/api/ingress"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/labs"
+	"miren.dev/runtime/pkg/ui"
 )
 
 func RouteOidcShow(ctx *Context, opts struct {
-	Host string `position:"0" usage:"Hostname for the route (e.g., example.com)" required:"true"`
+	Host    string `position:"0" usage:"Hostname for the route (e.g., example.com)"`
+	Default bool   `long:"default" description:"Show OIDC config for the default route"`
 	FormatOptions
 	ConfigCentric
 }) error {
+	if !labs.RouteOIDC() {
+		return fmt.Errorf("OIDC authentication for routes is disabled. Enable with MIREN_LABS=routeoidc")
+	}
+
+	if opts.Host == "" && !opts.Default {
+		return fmt.Errorf("either a hostname or --default must be specified")
+	}
+
+	if opts.Host != "" && opts.Default {
+		return fmt.Errorf("--default cannot be used with a hostname")
+	}
+
 	client, err := ctx.RPCClient("entities")
 	if err != nil {
 		return err
@@ -20,26 +35,39 @@ func RouteOidcShow(ctx *Context, opts struct {
 
 	ic := ingress.NewClient(ctx.Log, client)
 
-	// Look up existing route
-	route, err := ic.Lookup(ctx, opts.Host)
-	if err != nil {
-		return fmt.Errorf("failed to lookup route: %w", err)
-	}
+	var route *ingress_v1alpha.HttpRoute
+	var routeLabel string
 
-	if route == nil {
-		return fmt.Errorf("route not found for host: %s", opts.Host)
+	if opts.Default {
+		route, err = ic.LookupDefault(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to lookup default route: %w", err)
+		}
+		if route == nil {
+			return fmt.Errorf("no default route configured")
+		}
+		routeLabel = "default"
+	} else {
+		route, err = ic.Lookup(ctx, opts.Host)
+		if err != nil {
+			return fmt.Errorf("failed to lookup route: %w", err)
+		}
+		if route == nil {
+			return fmt.Errorf("route not found for host: %s", opts.Host)
+		}
+		routeLabel = opts.Host
 	}
 
 	// Check if OIDC is configured
 	if entity.Empty(route.OidcProvider) {
 		if opts.IsJSON() {
 			return PrintJSON(map[string]interface{}{
-				"host":         opts.Host,
+				"host":         routeLabel,
 				"oidc_enabled": false,
 				"provider":     nil,
 			})
 		}
-		ctx.Printf("OIDC is not configured for route: %s\n", opts.Host)
+		ctx.Printf("OIDC is not configured for route: %s\n", routeLabel)
 		return nil
 	}
 
@@ -71,7 +99,7 @@ func RouteOidcShow(ctx *Context, opts struct {
 		}
 
 		return PrintJSON(OIDCConfigJSON{
-			Host:          opts.Host,
+			Host:          routeLabel,
 			OIDCEnabled:   true,
 			ProviderName:  provider.Name,
 			ProviderURL:   provider.ProviderUrl,
@@ -81,18 +109,32 @@ func RouteOidcShow(ctx *Context, opts struct {
 		})
 	}
 
-	ctx.Printf("OIDC Configuration for route: %s\n\n", opts.Host)
-	ctx.Printf("Enabled:      Yes\n")
-	ctx.Printf("Provider:     %s\n", provider.Name)
-	ctx.Printf("Provider URL: %s\n", provider.ProviderUrl)
-	ctx.Printf("Client ID:    %s\n", provider.ClientId)
-	ctx.Printf("Scopes:       %s\n", provider.Scopes)
+	items := []ui.NamedValue{
+		ui.NewNamedValue("Route", routeLabel),
+		ui.NewNamedValue("Enabled", true),
+		ui.NewNamedValue("Provider", provider.Name),
+		ui.NewNamedValue("Provider URL", provider.ProviderUrl),
+		ui.NewNamedValue("Client ID", provider.ClientId),
+		ui.NewNamedValue("Scopes", provider.Scopes),
+	}
+
+	ctx.Printf("%s\n", ui.NewNamedValueList(items).Render())
 
 	if len(route.ClaimMappings) > 0 {
-		ctx.Printf("\nClaim Mappings:\n")
-		for _, mapping := range route.ClaimMappings {
-			ctx.Printf("  %s → %s\n", mapping.Claim, mapping.Header)
+		var rows []ui.Row
+		for _, m := range route.ClaimMappings {
+			rows = append(rows, ui.Row{m.Claim, m.Header})
 		}
+
+		headers := []string{"CLAIM", "HEADER"}
+		columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0).NoTruncate(1))
+		table := ui.NewTable(
+			ui.WithTableTitle("Claim Mappings"),
+			ui.WithColumns(columns),
+			ui.WithRows(rows),
+		)
+
+		ctx.Printf("\n%s\n", table.Render())
 	}
 
 	return nil

--- a/cli/commands/route_oidc_show.go
+++ b/cli/commands/route_oidc_show.go
@@ -1,0 +1,87 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/api/ingress"
+)
+
+func RouteOidcShow(ctx *Context, opts struct {
+	Host string `position:"0" usage:"Hostname for the route (e.g., example.com)" required:"true"`
+	FormatOptions
+	ConfigCentric
+}) error {
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	ic := ingress.NewClient(ctx.Log, client)
+
+	// Look up existing route
+	route, err := ic.Lookup(ctx, opts.Host)
+	if err != nil {
+		return fmt.Errorf("failed to lookup route: %w", err)
+	}
+
+	if route == nil {
+		return fmt.Errorf("route not found for host: %s", opts.Host)
+	}
+
+	// Check if OIDC is configured
+	if route.OidcConfig.Empty() {
+		if opts.IsJSON() {
+			return PrintJSON(map[string]interface{}{
+				"host":         opts.Host,
+				"oidc_enabled": false,
+				"oidc_config":  nil,
+			})
+		}
+		ctx.Printf("OIDC is not configured for route: %s\n", opts.Host)
+		return nil
+	}
+
+	// Display OIDC config
+	if opts.IsJSON() {
+		type OIDCConfigJSON struct {
+			Host          string              `json:"host"`
+			OIDCEnabled   bool                `json:"oidc_enabled"`
+			ProviderURL   string              `json:"provider_url"`
+			ClientID      string              `json:"client_id"`
+			Scopes        string              `json:"scopes"`
+			ClaimMappings []map[string]string `json:"claim_mappings,omitempty"`
+		}
+
+		var mappings []map[string]string
+		for _, m := range route.OidcConfig.ClaimMappings {
+			mappings = append(mappings, map[string]string{
+				"claim":  m.Claim,
+				"header": m.Header,
+			})
+		}
+
+		return PrintJSON(OIDCConfigJSON{
+			Host:          opts.Host,
+			OIDCEnabled:   true,
+			ProviderURL:   route.OidcConfig.ProviderUrl,
+			ClientID:      route.OidcConfig.ClientId,
+			Scopes:        route.OidcConfig.Scopes,
+			ClaimMappings: mappings,
+		})
+	}
+
+	ctx.Printf("OIDC Configuration for route: %s\n\n", opts.Host)
+	ctx.Printf("Enabled:      Yes\n")
+	ctx.Printf("Provider URL: %s\n", route.OidcConfig.ProviderUrl)
+	ctx.Printf("Client ID:    %s\n", route.OidcConfig.ClientId)
+	ctx.Printf("Scopes:       %s\n", route.OidcConfig.Scopes)
+
+	if len(route.OidcConfig.ClaimMappings) > 0 {
+		ctx.Printf("\nClaim Mappings:\n")
+		for _, mapping := range route.OidcConfig.ClaimMappings {
+			ctx.Printf("  %s → %s\n", mapping.Claim, mapping.Header)
+		}
+	}
+
+	return nil
+}

--- a/cli/commands/server_install_docker.go
+++ b/cli/commands/server_install_docker.go
@@ -29,6 +29,7 @@ func ServerInstallDocker(ctx *Context, opts struct {
 	ClusterName  string            `long:"cluster-name" description:"Cluster name for cloud registration"`
 	CloudURL     string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
 	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
+	Labs         []string          `short:"l" long:"labs" description:"Miren Labs features to enable (e.g. routeoidc,adminapi). Prefix with - to disable."`
 }) error {
 	if opts.ClusterName == "" {
 		opts.ClusterName = opts.Name
@@ -95,6 +96,7 @@ func ServerInstallDocker(ctx *Context, opts struct {
 		HTTPPort:    opts.HTTPPort,
 		VolumeName:  volumeName,
 		HostNetwork: opts.HostNetwork,
+		Labs:        opts.Labs,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create container: %w", err)
@@ -290,6 +292,7 @@ type dockerContainerConfig struct {
 	HTTPPort    int
 	VolumeName  string
 	HostNetwork bool
+	Labs        []string
 }
 
 func checkDockerAvailable() error {
@@ -343,6 +346,10 @@ func dockerCreateContainer(name, image string, config dockerContainerConfig) (st
 			"-p", "8443:8443/udp",
 			"-p", "443:443/tcp",
 		)
+	}
+
+	if len(config.Labs) > 0 {
+		args = append(args, "-e", fmt.Sprintf("MIREN_LABS=%s", strings.Join(config.Labs, ",")))
 	}
 
 	// Add volume and image

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -725,6 +725,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	// Create httpingress server for internal HTTP requests
 	ingressConfig := httpingress.IngressConfig{
 		RequestTimeout: c.HTTPRequestTimeout,
+		DataPath:       c.DataPath,
 	}
 	c.hs = httpingress.NewServer(ctx, c.Log, ingressConfig, loopback, aa, c.HTTP, c.LogWriter)
 

--- a/components/lsvd/server/server_test.go
+++ b/components/lsvd/server/server_test.go
@@ -300,4 +300,3 @@ func TestServerReconcileWithEntities(t *testing.T) {
 	assert.Len(t, mockVolOps.createdDirs, 1)
 	assert.Len(t, mockVolOps.initedVolumes, 1)
 }
-

--- a/components/lsvd/server/volume_controller_test.go
+++ b/components/lsvd/server/volume_controller_test.go
@@ -484,4 +484,3 @@ func TestVolumeControllerMultipleVolumes(t *testing.T) {
 	assert.Len(t, ops.initedVolumes, 3)
 	assert.Len(t, state.Volumes, 3)
 }
-

--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -108,7 +108,11 @@ Cancel a stuck in-progress deployment. Get the deployment ID from `miren app his
 
 ## Route OIDC Authentication
 
-Enable OAuth2/OIDC authentication on HTTP routes to protect your applications with single sign-on.
+:::info Labs Feature
+Route OIDC authentication is a [labs feature](/labs) and is disabled by default. Enable it with `--labs routeoidc` or `MIREN_LABS=routeoidc` when starting the server.
+:::
+
+Enable OAuth2/OIDC authentication on HTTP routes to protect your applications with single sign-on. See the [Route OIDC Authentication guide](/route-oidc) for a conceptual overview and example provider setups.
 
 ### Enable OIDC on a Route
 

--- a/docs/docs/cli-reference.md
+++ b/docs/docs/cli-reference.md
@@ -52,6 +52,9 @@ Cancel a stuck in-progress deployment. Get the deployment ID from `miren app his
 
 - `miren logs` - Get logs for an application ([details](/cli/logs))
 - `miren route` - List all HTTP routes
+- `miren route oidc enable` - Enable OIDC authentication on a route
+- `miren route oidc disable` - Disable OIDC authentication on a route
+- `miren route oidc show` - Show OIDC configuration for a route
 
 ### Environment & Configuration
 
@@ -102,6 +105,54 @@ Cancel a stuck in-progress deployment. Get the deployment ID from `miren app his
 - `miren version` - Print the version
 - `miren upgrade` - Upgrade miren CLI to latest version
 - `miren server` - Start the miren server
+
+## Route OIDC Authentication
+
+Enable OAuth2/OIDC authentication on HTTP routes to protect your applications with single sign-on.
+
+### Enable OIDC on a Route
+
+```bash
+# Create new OIDC provider inline
+miren route oidc enable myapp.example.com \
+  --provider-url https://accounts.google.com \
+  --client-id YOUR_CLIENT_ID \
+  --client-secret YOUR_CLIENT_SECRET \
+  --scope openid email profile \
+  --claim-header email:X-User-Email \
+  --claim-header sub:X-User-ID
+
+# Use existing OIDC provider
+miren route oidc enable myapp.example.com \
+  --provider google-oauth \
+  --claim-header email:X-User-Email
+```
+
+When OIDC is enabled, unauthenticated requests are redirected to the OIDC provider for login. After successful authentication, JWT claims are extracted and injected as HTTP headers before proxying to your application.
+
+**Options:**
+- `--provider NAME` - Use an existing OIDC provider by name
+- `--provider-url URL` - OIDC provider URL (creates new provider if --provider not specified)
+- `--client-id ID` - OAuth2 client ID (required for new provider)
+- `--client-secret SECRET` - OAuth2 client secret (required for new provider)
+- `--scope SCOPE` - OAuth2 scopes (default: "openid", can be repeated)
+- `--claim-header CLAIM:HEADER` - Map JWT claim to HTTP header (can be repeated)
+
+### Show OIDC Configuration
+
+```bash
+miren route oidc show myapp.example.com
+```
+
+Displays the OIDC provider configuration and claim-to-header mappings for a route.
+
+### Disable OIDC on a Route
+
+```bash
+miren route oidc disable myapp.example.com
+```
+
+Removes OIDC authentication from a route. The OIDC provider entity is not deleted and can be reused.
 
 ## Global Flags
 

--- a/docs/docs/route-oidc.md
+++ b/docs/docs/route-oidc.md
@@ -1,0 +1,129 @@
+---
+sidebar_position: 8
+---
+
+# Route OIDC Authentication
+
+:::info Labs Feature
+Route OIDC authentication is a [labs feature](/labs) and is disabled by default. Enable it with `--labs routeoidc` or `MIREN_LABS=routeoidc` when starting the server.
+:::
+
+Route OIDC authentication lets you protect your applications with single sign-on at the routing layer. Unauthenticated requests are redirected to an OIDC provider for login, and after authentication, JWT claims are injected as HTTP headers before the request reaches your app.
+
+Your app receives identity information as plain HTTP headers (e.g., `X-User-Email`) — no in-app auth code required.
+
+## Authentication vs Authorization
+
+This feature handles **authentication** — verifying _who_ a user is — not **authorization** — deciding _what_ they can access.
+
+After authentication, your app receives claims as headers and decides what to do with them. For example, if you configure Google as your OIDC provider, your app receives the user's email address and can check the domain for basic access control.
+
+## Trust Model
+
+Your app trusts the claim headers (e.g., `X-User-Email`) because Miren is the only network path into the sandbox — external clients cannot reach your app directly. Miren validates the JWT from the OIDC provider and sets the headers before proxying the request.
+
+This "trust the proxy" model is the standard approach used by tools like OAuth2 Proxy, Traefik ForwardAuth, and nginx `auth_request`. It's simple and works well when the platform controls the network topology, which Miren does via sandbox isolation.
+
+Your app does not need to verify signatures or validate tokens — it can treat the claim headers as trusted input from the platform.
+
+## How Claim Mappings Work
+
+The `--claim-header` option maps JWT claims from the OIDC provider to HTTP headers that your app receives:
+
+```bash
+miren route oidc enable myapp.example.com \
+  --claim-header email:X-User-Email \
+  --claim-header sub:X-User-ID \
+  --claim-header name:X-User-Name
+```
+
+- Each `--claim-header` takes the form `CLAIM:HEADER`
+- Multiple mappings can be specified
+- Claims not present in the JWT are silently skipped
+- Your app receives these as regular request headers
+
+## Example Provider Setups
+
+### Google
+
+Google's OIDC provider works well when you want to restrict access by email domain.
+
+```bash
+miren route oidc enable myapp.example.com \
+  --provider-url https://accounts.google.com \
+  --client-id $GOOGLE_CLIENT_ID \
+  --client-secret $GOOGLE_CLIENT_SECRET \
+  --scope openid email profile \
+  --claim-header email:X-User-Email \
+  --claim-header name:X-User-Name
+```
+
+Your app can then check the `X-User-Email` header's domain for basic authorization (e.g., only allow `@yourcompany.com`).
+
+### GitHub (via federation)
+
+GitHub doesn't expose a native OIDC provider endpoint. To use GitHub for authentication, you'll need a federated OIDC provider like [Dex](https://dexidp.io/) that can use GitHub as an upstream identity source and encode org and team membership as JWT claims.
+
+### GitLab
+
+GitLab has a built-in OIDC provider — no federation layer needed. Register an application in your GitLab instance and point directly at it.
+
+```bash
+miren route oidc enable myapp.example.com \
+  --provider-url https://gitlab.com \
+  --client-id $GITLAB_CLIENT_ID \
+  --client-secret $GITLAB_CLIENT_SECRET \
+  --scope openid email profile \
+  --claim-header email:X-User-Email \
+  --claim-header name:X-User-Name
+```
+
+### Keycloak (self-hosted)
+
+[Keycloak](https://www.keycloak.org/) is an open-source identity provider you can run yourself. It supports user federation, identity brokering, and fine-grained claim configuration.
+
+```bash
+miren route oidc enable myapp.example.com \
+  --provider-url https://keycloak.example.com/realms/myrealm \
+  --client-id $KEYCLOAK_CLIENT_ID \
+  --client-secret $KEYCLOAK_CLIENT_SECRET \
+  --scope openid email profile \
+  --claim-header email:X-User-Email \
+  --claim-header preferred_username:X-User-Name
+```
+
+## Reusing Providers Across Routes
+
+The examples above create a new OIDC provider inline for each route. If you use the same provider for multiple routes, you can reference an existing provider by name instead of repeating the configuration:
+
+```bash
+miren route oidc enable another-app.example.com \
+  --provider google-oauth \
+  --claim-header email:X-User-Email
+```
+
+Providers created inline are preserved when you disable OIDC on a route, so they can be reused later.
+
+## Default Route Support
+
+All `miren route oidc` commands support the `--default` flag for the default route (which has no static hostname). When used with the default route, the OAuth2 redirect URL is derived from the request's `Host` header at runtime.
+
+```bash
+miren route oidc enable --default \
+  --provider-url https://accounts.google.com \
+  --client-id $GOOGLE_CLIENT_ID \
+  --client-secret $GOOGLE_CLIENT_SECRET \
+  --claim-header email:X-User-Email
+```
+
+## Managing OIDC on Routes
+
+```bash
+# Show current OIDC configuration for a route
+miren route oidc show myapp.example.com
+
+# Disable OIDC on a route (provider is preserved for reuse)
+miren route oidc disable myapp.example.com
+```
+
+See the [CLI reference](/cli-reference#route-oidc-authentication) for the full list of options.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -26,6 +26,7 @@ const sidebars: SidebarsConfig = {
         'scaling',
         'disks',
         'firewall',
+        'route-oidc',
         'admin-interface',
         'working-with-miren-cloud',
       ],

--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,7 @@ require (
 	golang.org/x/crypto v0.43.0
 	golang.org/x/exp v0.0.0-20241210194714-1829a127f884
 	golang.org/x/net v0.46.0
+	golang.org/x/oauth2 v0.32.0
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.36.0
@@ -376,7 +377,6 @@ require (
 	go.uber.org/ratelimit v0.3.1 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/mod v0.28.0 // indirect
-	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/flannel-io/flannel v0.26.7
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/go-acme/lego/v4 v4.28.1
+	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/logr v1.4.3
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
@@ -221,7 +222,6 @@ require (
 	github.com/go-acme/tencentclouddnspod v1.1.10 // indirect
 	github.com/go-acme/tencentedgdeone v1.1.48 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect

--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -18,3 +18,8 @@ features:
     predicate: AdminAPI
     description: Enable the admin API for application management functions
     default: false
+
+  - name: routeoidc
+    predicate: RouteOIDC
+    description: Enable OIDC authentication for HTTP routes
+    default: false

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -14,6 +14,7 @@ const (
 	FeatureDistributedRunners = "distributedrunners"
 	FeatureUserSubdomains     = "usersubdomains"
 	FeatureAdminAPI           = "adminapi"
+	FeatureRouteOIDC          = "routeoidc"
 )
 
 // AllFeatures returns a list of all known feature names
@@ -23,6 +24,7 @@ func AllFeatures() []string {
 		FeatureDistributedRunners,
 		FeatureUserSubdomains,
 		FeatureAdminAPI,
+		FeatureRouteOIDC,
 	}
 }
 
@@ -33,6 +35,7 @@ func FeatureDescriptions() map[string]string {
 		FeatureDistributedRunners: "Schedule jobs across multiple runner nodes",
 		FeatureUserSubdomains:     "Allow claiming custom subdomains",
 		FeatureAdminAPI:           "Enable the admin API for application management functions",
+		FeatureRouteOIDC:          "Enable OIDC authentication for HTTP routes",
 	}
 }
 
@@ -47,6 +50,7 @@ var featureDefaults = map[string]bool{
 	FeatureDistributedRunners: false,
 	FeatureUserSubdomains:     false,
 	FeatureAdminAPI:           false,
+	FeatureRouteOIDC:          false,
 }
 
 // Init initializes the labs feature flags from the provided flag strings.
@@ -145,4 +149,10 @@ func UserSubdomains() bool {
 // Enable the admin API for application management functions
 func AdminAPI() bool {
 	return IsEnabled(FeatureAdminAPI)
+}
+
+// RouteOIDC returns whether the routeoidc feature is enabled.
+// Enable OIDC authentication for HTTP routes
+func RouteOIDC() bool {
+	return IsEnabled(FeatureRouteOIDC)
 }

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -23,6 +23,9 @@ func TestDefaultFeatureValues(t *testing.T) {
 	if AdminAPI() {
 		t.Error("AdminAPI should be false by default")
 	}
+	if RouteOIDC() {
+		t.Error("RouteOIDC should be false by default")
+	}
 }
 
 func TestEnableFeatureViaInit(t *testing.T) {
@@ -120,11 +123,11 @@ func TestIsEnabledFunction(t *testing.T) {
 func TestAllFeatures(t *testing.T) {
 	features := AllFeatures()
 
-	if len(features) != 4 {
-		t.Errorf("Expected 4 features, got %d", len(features))
+	if len(features) != 5 {
+		t.Errorf("Expected 5 features, got %d", len(features))
 	}
 
-	expected := []string{"globalrouter", "distributedrunners", "usersubdomains", "adminapi"}
+	expected := []string{"globalrouter", "distributedrunners", "usersubdomains", "adminapi", "routeoidc"}
 	for _, name := range expected {
 		found := false
 		for _, f := range features {
@@ -142,8 +145,8 @@ func TestAllFeatures(t *testing.T) {
 func TestFeatureDescriptions(t *testing.T) {
 	descriptions := FeatureDescriptions()
 
-	if len(descriptions) != 4 {
-		t.Errorf("Expected 4 descriptions, got %d", len(descriptions))
+	if len(descriptions) != 5 {
+		t.Errorf("Expected 5 descriptions, got %d", len(descriptions))
 	}
 
 	if descriptions[FeatureGlobalRouter] == "" {
@@ -158,18 +161,21 @@ func TestFeatureDescriptions(t *testing.T) {
 	if descriptions[FeatureAdminAPI] == "" {
 		t.Error("AdminAPI description should not be empty")
 	}
+	if descriptions[FeatureRouteOIDC] == "" {
+		t.Error("RouteOIDC description should not be empty")
+	}
 }
 
 func TestResetFunction(t *testing.T) {
-	Init(nil, []string{"globalrouter", "distributedrunners", "usersubdomains", "adminapi"})
+	Init(nil, []string{"globalrouter", "distributedrunners", "usersubdomains", "adminapi", "routeoidc"})
 
-	if !GlobalRouter() || !DistributedRunners() || !UserSubdomains() || !AdminAPI() {
+	if !GlobalRouter() || !DistributedRunners() || !UserSubdomains() || !AdminAPI() || !RouteOIDC() {
 		t.Error("All features should be enabled before reset")
 	}
 
 	Reset()
 
-	if GlobalRouter() || DistributedRunners() || UserSubdomains() || AdminAPI() {
+	if GlobalRouter() || DistributedRunners() || UserSubdomains() || AdminAPI() || RouteOIDC() {
 		t.Error("All features should be back to defaults (false) after reset")
 	}
 }

--- a/pkg/oidc/client.go
+++ b/pkg/oidc/client.go
@@ -103,39 +103,19 @@ func (c *Client) ExchangeCode(ctx context.Context, code, pkceVerifier string) (*
 	return token, nil
 }
 
-// ParseIDToken parses and validates an ID token JWT without signature verification.
-// Signature verification should be done separately if needed using a JWT validator.
-func (c *Client) ParseIDToken(idToken string) (map[string]interface{}, error) {
-	// Parse without verification - just extract claims
-	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-	token, _, err := parser.ParseUnverified(idToken, jwt.MapClaims{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse ID token: %w", err)
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return nil, fmt.Errorf("failed to extract claims")
-	}
-
-	return claims, nil
-}
-
-// VerifyIDToken validates an ID token's signature and claims.
-// This performs full JWT validation including signature verification.
-func (c *Client) VerifyIDToken(ctx context.Context, idToken string) (map[string]interface{}, error) {
+// ParseIDToken validates an ID token's signature via the provider's JWKS
+// and checks standard claims (issuer, audience).
+func (c *Client) ParseIDToken(ctx context.Context, idToken string) (map[string]interface{}, error) {
 	discovery, err := c.getDiscovery(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get discovery data: %w", err)
 	}
 
-	// Get JWKS for signature verification
 	keyFunc, err := c.getJWKSKeyFunc(ctx, discovery.JwksURI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get JWKS key function: %w", err)
 	}
 
-	// Parse and verify token
 	token, err := jwt.Parse(idToken, keyFunc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to verify ID token: %w", err)
@@ -150,12 +130,10 @@ func (c *Client) VerifyIDToken(ctx context.Context, idToken string) (map[string]
 		return nil, fmt.Errorf("failed to extract claims")
 	}
 
-	// Validate issuer matches provider
 	if iss, ok := claims["iss"].(string); !ok || iss != discovery.Issuer {
 		return nil, fmt.Errorf("issuer mismatch: got %v, want %s", claims["iss"], discovery.Issuer)
 	}
 
-	// Validate audience contains our client ID
 	if err := c.validateAudience(claims); err != nil {
 		return nil, err
 	}

--- a/pkg/oidc/client.go
+++ b/pkg/oidc/client.go
@@ -60,8 +60,8 @@ func NewClient(providerURL, clientID, clientSecret, redirectURL string, scopes [
 }
 
 // AuthorizationURL generates the URL to redirect users to for authentication.
-// It includes PKCE challenge for added security.
-func (c *Client) AuthorizationURL(state, pkceVerifier string) (string, error) {
+// It includes PKCE challenge for added security and a resource indicator (RFC 8707).
+func (c *Client) AuthorizationURL(state, pkceVerifier, resource string) (string, error) {
 	config, err := c.getOAuth2Config(context.Background())
 	if err != nil {
 		return "", fmt.Errorf("failed to get OAuth2 config: %w", err)
@@ -70,11 +70,16 @@ func (c *Client) AuthorizationURL(state, pkceVerifier string) (string, error) {
 	// Generate PKCE challenge from verifier
 	pkceChallenge := generatePKCEChallenge(pkceVerifier)
 
-	// Build authorization URL with PKCE
-	url := config.AuthCodeURL(state,
+	// Build authorization URL with PKCE and resource indicator
+	opts := []oauth2.AuthCodeOption{
 		oauth2.SetAuthURLParam("code_challenge", pkceChallenge),
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
-	)
+	}
+	if resource != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("resource", resource))
+	}
+
+	url := config.AuthCodeURL(state, opts...)
 
 	return url, nil
 }

--- a/pkg/oidc/client.go
+++ b/pkg/oidc/client.go
@@ -1,0 +1,334 @@
+package oidc
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/oauth2"
+)
+
+// Client handles OIDC authentication flows with OAuth2 providers.
+// It implements the authorization code flow with PKCE (RFC 7636).
+type Client struct {
+	providerURL  string
+	clientID     string
+	clientSecret string
+	scopes       []string
+	redirectURL  string
+	logger       *slog.Logger
+
+	mu            sync.RWMutex
+	oauth2Config  *oauth2.Config
+	discoveryData *discoveryData
+	discoveryTime time.Time
+}
+
+// discoveryData contains OIDC provider configuration from .well-known/openid-configuration
+type discoveryData struct {
+	Issuer                string   `json:"issuer"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	UserinfoEndpoint      string   `json:"userinfo_endpoint"`
+	JwksURI               string   `json:"jwks_uri"`
+	ScopesSupported       []string `json:"scopes_supported"`
+}
+
+// NewClient creates a new OIDC client
+func NewClient(providerURL, clientID, clientSecret, redirectURL string, scopes []string, logger *slog.Logger) *Client {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &Client{
+		providerURL:  strings.TrimSuffix(providerURL, "/"),
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		scopes:       scopes,
+		redirectURL:  redirectURL,
+		logger:       logger.With("module", "oidc"),
+	}
+}
+
+// AuthorizationURL generates the URL to redirect users to for authentication.
+// It includes PKCE challenge for added security.
+func (c *Client) AuthorizationURL(state, pkceVerifier string) (string, error) {
+	config, err := c.getOAuth2Config(context.Background())
+	if err != nil {
+		return "", fmt.Errorf("failed to get OAuth2 config: %w", err)
+	}
+
+	// Generate PKCE challenge from verifier
+	pkceChallenge := generatePKCEChallenge(pkceVerifier)
+
+	// Build authorization URL with PKCE
+	url := config.AuthCodeURL(state,
+		oauth2.SetAuthURLParam("code_challenge", pkceChallenge),
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+	)
+
+	return url, nil
+}
+
+// ExchangeCode exchanges an authorization code for tokens using PKCE
+func (c *Client) ExchangeCode(ctx context.Context, code, pkceVerifier string) (*oauth2.Token, error) {
+	config, err := c.getOAuth2Config(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OAuth2 config: %w", err)
+	}
+
+	// Exchange code for tokens with PKCE verifier
+	token, err := config.Exchange(ctx, code,
+		oauth2.SetAuthURLParam("code_verifier", pkceVerifier),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange code: %w", err)
+	}
+
+	return token, nil
+}
+
+// ParseIDToken parses and validates an ID token JWT without signature verification.
+// Signature verification should be done separately if needed using a JWT validator.
+func (c *Client) ParseIDToken(idToken string) (map[string]interface{}, error) {
+	// Parse without verification - just extract claims
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	token, _, err := parser.ParseUnverified(idToken, jwt.MapClaims{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ID token: %w", err)
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("failed to extract claims")
+	}
+
+	return claims, nil
+}
+
+// VerifyIDToken validates an ID token's signature and claims.
+// This performs full JWT validation including signature verification.
+func (c *Client) VerifyIDToken(ctx context.Context, idToken string) (map[string]interface{}, error) {
+	discovery, err := c.getDiscovery(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get discovery data: %w", err)
+	}
+
+	// Get JWKS for signature verification
+	keyFunc, err := c.getJWKSKeyFunc(ctx, discovery.JwksURI)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get JWKS key function: %w", err)
+	}
+
+	// Parse and verify token
+	token, err := jwt.Parse(idToken, keyFunc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify ID token: %w", err)
+	}
+
+	if !token.Valid {
+		return nil, fmt.Errorf("ID token is invalid")
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, fmt.Errorf("failed to extract claims")
+	}
+
+	// Validate issuer matches provider
+	if iss, ok := claims["iss"].(string); !ok || iss != discovery.Issuer {
+		return nil, fmt.Errorf("issuer mismatch: got %v, want %s", claims["iss"], discovery.Issuer)
+	}
+
+	// Validate audience contains our client ID
+	if err := c.validateAudience(claims); err != nil {
+		return nil, err
+	}
+
+	return claims, nil
+}
+
+// validateAudience checks that the token audience includes our client ID
+func (c *Client) validateAudience(claims jwt.MapClaims) error {
+	aud, ok := claims["aud"]
+	if !ok {
+		return fmt.Errorf("audience (aud) claim missing")
+	}
+
+	// Audience can be a string or array of strings
+	switch v := aud.(type) {
+	case string:
+		if v == c.clientID {
+			return nil
+		}
+	case []interface{}:
+		for _, a := range v {
+			if s, ok := a.(string); ok && s == c.clientID {
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("audience does not include client ID")
+}
+
+// getOAuth2Config lazily initializes and caches the OAuth2 config
+func (c *Client) getOAuth2Config(ctx context.Context) (*oauth2.Config, error) {
+	c.mu.RLock()
+	if c.oauth2Config != nil {
+		config := c.oauth2Config
+		c.mu.RUnlock()
+		return config, nil
+	}
+	c.mu.RUnlock()
+
+	// Need to discover endpoints
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if c.oauth2Config != nil {
+		return c.oauth2Config, nil
+	}
+
+	discovery, err := c.getDiscoveryLocked(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.oauth2Config = &oauth2.Config{
+		ClientID:     c.clientID,
+		ClientSecret: c.clientSecret,
+		RedirectURL:  c.redirectURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  discovery.AuthorizationEndpoint,
+			TokenURL: discovery.TokenEndpoint,
+		},
+		Scopes: c.scopes,
+	}
+
+	return c.oauth2Config, nil
+}
+
+// getDiscovery fetches OIDC provider configuration with caching
+func (c *Client) getDiscovery(ctx context.Context) (*discoveryData, error) {
+	c.mu.RLock()
+	if c.discoveryData != nil && time.Since(c.discoveryTime) < time.Hour {
+		data := c.discoveryData
+		c.mu.RUnlock()
+		return data, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.getDiscoveryLocked(ctx)
+}
+
+// getDiscoveryLocked fetches OIDC provider configuration (caller must hold write lock)
+func (c *Client) getDiscoveryLocked(ctx context.Context) (*discoveryData, error) {
+	// Double-check cache after acquiring lock
+	if c.discoveryData != nil && time.Since(c.discoveryTime) < time.Hour {
+		return c.discoveryData, nil
+	}
+
+	// Fetch from well-known endpoint
+	discoveryURL := fmt.Sprintf("%s/.well-known/openid-configuration", c.providerURL)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", discoveryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovery request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch discovery document: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("discovery endpoint returned status %d", resp.StatusCode)
+	}
+
+	var data discoveryData
+	if err := parseJSON(resp.Body, &data); err != nil {
+		return nil, fmt.Errorf("failed to parse discovery document: %w", err)
+	}
+
+	// Validate required fields
+	if data.AuthorizationEndpoint == "" || data.TokenEndpoint == "" {
+		return nil, fmt.Errorf("discovery document missing required endpoints")
+	}
+
+	c.discoveryData = &data
+	c.discoveryTime = time.Now()
+
+	return &data, nil
+}
+
+// getJWKSKeyFunc returns a key function for JWT validation using JWKS
+func (c *Client) getJWKSKeyFunc(ctx context.Context, jwksURI string) (jwt.Keyfunc, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", jwksURI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWKS request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch JWKS: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("JWKS endpoint returned status %d", resp.StatusCode)
+	}
+
+	var jwks struct {
+		Keys []map[string]interface{} `json:"keys"`
+	}
+	if err := parseJSON(resp.Body, &jwks); err != nil {
+		return nil, fmt.Errorf("failed to parse JWKS: %w", err)
+	}
+
+	// Create key function that looks up keys by kid
+	return func(token *jwt.Token) (interface{}, error) {
+		kid, ok := token.Header["kid"].(string)
+		if !ok {
+			return nil, fmt.Errorf("token missing kid header")
+		}
+
+		// Find matching key
+		for _, key := range jwks.Keys {
+			if keyID, ok := key["kid"].(string); ok && keyID == kid {
+				// Return the key data for jwt library to parse
+				// The jwt library will handle RSA/EC key parsing
+				return key, nil
+			}
+		}
+
+		return nil, fmt.Errorf("key with kid %s not found in JWKS", kid)
+	}, nil
+}
+
+// generatePKCEChallenge creates a SHA256 hash of the verifier for PKCE
+func generatePKCEChallenge(verifier string) string {
+	hash := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// parseJSON is a helper to parse JSON from an io.Reader
+func parseJSON(r io.Reader, v interface{}) error {
+	return json.NewDecoder(r).Decode(v)
+}

--- a/pkg/oidc/client.go
+++ b/pkg/oidc/client.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 )
@@ -282,7 +283,9 @@ func (c *Client) getDiscoveryLocked(ctx context.Context) (*discoveryData, error)
 	return &data, nil
 }
 
-// getJWKSKeyFunc returns a key function for JWT validation using JWKS
+// getJWKSKeyFunc returns a key function for JWT validation using JWKS.
+// It fetches the JWKS document and parses keys into proper crypto types
+// using go-jose so that jwt-go can verify signatures.
 func (c *Client) getJWKSKeyFunc(ctx context.Context, jwksURI string) (jwt.Keyfunc, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", jwksURI, nil)
 	if err != nil {
@@ -300,30 +303,28 @@ func (c *Client) getJWKSKeyFunc(ctx context.Context, jwksURI string) (jwt.Keyfun
 		return nil, fmt.Errorf("JWKS endpoint returned status %d", resp.StatusCode)
 	}
 
-	var jwks struct {
-		Keys []map[string]interface{} `json:"keys"`
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read JWKS response: %w", err)
 	}
-	if err := parseJSON(resp.Body, &jwks); err != nil {
+
+	var jwks jose.JSONWebKeySet
+	if err := json.Unmarshal(body, &jwks); err != nil {
 		return nil, fmt.Errorf("failed to parse JWKS: %w", err)
 	}
 
-	// Create key function that looks up keys by kid
 	return func(token *jwt.Token) (interface{}, error) {
 		kid, ok := token.Header["kid"].(string)
 		if !ok {
 			return nil, fmt.Errorf("token missing kid header")
 		}
 
-		// Find matching key
-		for _, key := range jwks.Keys {
-			if keyID, ok := key["kid"].(string); ok && keyID == kid {
-				// Return the key data for jwt library to parse
-				// The jwt library will handle RSA/EC key parsing
-				return key, nil
-			}
+		keys := jwks.Key(kid)
+		if len(keys) == 0 {
+			return nil, fmt.Errorf("key with kid %s not found in JWKS", kid)
 		}
 
-		return nil, fmt.Errorf("key with kid %s not found in JWKS", kid)
+		return keys[0].Key, nil
 	}, nil
 }
 

--- a/pkg/oidc/client_test.go
+++ b/pkg/oidc/client_test.go
@@ -64,7 +64,7 @@ func TestClient_AuthorizationURL(t *testing.T) {
 
 	// Note: This test will fail without a real OIDC provider
 	// In a real test environment, we'd mock the HTTP client
-	_, err := client.AuthorizationURL("test-state", "test-verifier")
+	_, err := client.AuthorizationURL("test-state", "test-verifier", "app.example.com")
 	if err != nil {
 		// Expected to fail without real provider, but we can check error message
 		t.Logf("Expected error without provider: %v", err)

--- a/pkg/oidc/client_test.go
+++ b/pkg/oidc/client_test.go
@@ -1,7 +1,18 @@
 package oidc
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func TestGeneratePKCEChallenge(t *testing.T) {
@@ -30,26 +41,147 @@ func TestGeneratePKCEChallenge(t *testing.T) {
 	}
 }
 
-func TestParseIDToken_BasicParsing(t *testing.T) {
-	// This is a mock JWT token (header.payload.signature)
-	// Header: {"alg":"none","typ":"JWT"}
-	// Payload: {"sub":"1234567890","name":"Test User","iat":1516239022}
-	mockToken := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlRlc3QgVXNlciIsImlhdCI6MTUxNjIzOTAyMn0."
+// newTestProvider starts an httptest server that serves OIDC discovery and JWKS
+// endpoints backed by the given RSA key. It returns the server and the key ID
+// used in the JWKS.
+func newTestProvider(t *testing.T, key *rsa.PrivateKey) (*httptest.Server, string) {
+	t.Helper()
 
-	client := NewClient("https://provider.example.com", "client-id", "secret", "https://redirect.example.com", []string{"openid"}, nil)
+	kid := "test-key-1"
 
-	claims, err := client.ParseIDToken(mockToken)
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		// We need the server URL but don't have it yet during setup,
+		// so we read it from the request host.
+		baseURL := fmt.Sprintf("http://%s", r.Host)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                 baseURL,
+			"authorization_endpoint": baseURL + "/authorize",
+			"token_endpoint":         baseURL + "/token",
+			"jwks_uri":               baseURL + "/jwks",
+		})
+	})
+
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, r *http.Request) {
+		jwk := jose.JSONWebKey{
+			Key:       &key.PublicKey,
+			KeyID:     kid,
+			Algorithm: string(jose.RS256),
+			Use:       "sig",
+		}
+		json.NewEncoder(w).Encode(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, kid
+}
+
+// signToken creates a signed JWT with the given claims using RS256.
+func signToken(t *testing.T, key *rsa.PrivateKey, kid string, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(key)
 	if err != nil {
-		t.Fatalf("failed to parse ID token: %v", err)
+		t.Fatalf("failed to sign token: %v", err)
+	}
+	return signed
+}
+
+func TestParseIDToken(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
 	}
 
-	if claims["sub"] != "1234567890" {
-		t.Errorf("sub claim mismatch: got %v", claims["sub"])
-	}
+	srv, kid := newTestProvider(t, key)
 
-	if claims["name"] != "Test User" {
-		t.Errorf("name claim mismatch: got %v", claims["name"])
-	}
+	client := NewClient(srv.URL, "client-id", "secret", "https://redirect.example.com", []string{"openid"}, nil)
+
+	t.Run("valid token", func(t *testing.T) {
+		token := signToken(t, key, kid, jwt.MapClaims{
+			"iss":  srv.URL,
+			"aud":  "client-id",
+			"sub":  "user-123",
+			"name": "Test User",
+			"exp":  time.Now().Add(time.Hour).Unix(),
+			"iat":  time.Now().Unix(),
+		})
+
+		claims, err := client.ParseIDToken(context.Background(), token)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if claims["sub"] != "user-123" {
+			t.Errorf("sub claim mismatch: got %v", claims["sub"])
+		}
+		if claims["name"] != "Test User" {
+			t.Errorf("name claim mismatch: got %v", claims["name"])
+		}
+	})
+
+	t.Run("wrong issuer", func(t *testing.T) {
+		token := signToken(t, key, kid, jwt.MapClaims{
+			"iss": "https://evil.example.com",
+			"aud": "client-id",
+			"sub": "user-123",
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"iat": time.Now().Unix(),
+		})
+
+		_, err := client.ParseIDToken(context.Background(), token)
+		if err == nil {
+			t.Fatal("expected error for wrong issuer")
+		}
+	})
+
+	t.Run("wrong audience", func(t *testing.T) {
+		token := signToken(t, key, kid, jwt.MapClaims{
+			"iss": srv.URL,
+			"aud": "wrong-client",
+			"sub": "user-123",
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"iat": time.Now().Unix(),
+		})
+
+		_, err := client.ParseIDToken(context.Background(), token)
+		if err == nil {
+			t.Fatal("expected error for wrong audience")
+		}
+	})
+
+	t.Run("expired token", func(t *testing.T) {
+		token := signToken(t, key, kid, jwt.MapClaims{
+			"iss": srv.URL,
+			"aud": "client-id",
+			"sub": "user-123",
+			"exp": time.Now().Add(-time.Hour).Unix(),
+			"iat": time.Now().Add(-2 * time.Hour).Unix(),
+		})
+
+		_, err := client.ParseIDToken(context.Background(), token)
+		if err == nil {
+			t.Fatal("expected error for expired token")
+		}
+	})
+
+	t.Run("tampered signature", func(t *testing.T) {
+		otherKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+		token := signToken(t, otherKey, kid, jwt.MapClaims{
+			"iss": srv.URL,
+			"aud": "client-id",
+			"sub": "user-123",
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"iat": time.Now().Unix(),
+		})
+
+		_, err := client.ParseIDToken(context.Background(), token)
+		if err == nil {
+			t.Fatal("expected error for tampered signature")
+		}
+	})
 }
 
 func TestClient_AuthorizationURL(t *testing.T) {

--- a/pkg/oidc/client_test.go
+++ b/pkg/oidc/client_test.go
@@ -1,0 +1,99 @@
+package oidc
+
+import (
+	"testing"
+)
+
+func TestGeneratePKCEChallenge(t *testing.T) {
+	verifier := "test-verifier-123456789"
+	challenge := generatePKCEChallenge(verifier)
+
+	if challenge == "" {
+		t.Error("PKCE challenge is empty")
+	}
+
+	// Challenge should be different from verifier
+	if challenge == verifier {
+		t.Error("PKCE challenge should be hashed, not plain verifier")
+	}
+
+	// Should be deterministic
+	challenge2 := generatePKCEChallenge(verifier)
+	if challenge != challenge2 {
+		t.Error("PKCE challenge should be deterministic")
+	}
+
+	// Different verifiers should produce different challenges
+	challenge3 := generatePKCEChallenge("different-verifier")
+	if challenge == challenge3 {
+		t.Error("different verifiers should produce different challenges")
+	}
+}
+
+func TestParseIDToken_BasicParsing(t *testing.T) {
+	// This is a mock JWT token (header.payload.signature)
+	// Header: {"alg":"none","typ":"JWT"}
+	// Payload: {"sub":"1234567890","name":"Test User","iat":1516239022}
+	mockToken := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlRlc3QgVXNlciIsImlhdCI6MTUxNjIzOTAyMn0."
+
+	client := NewClient("https://provider.example.com", "client-id", "secret", "https://redirect.example.com", []string{"openid"}, nil)
+
+	claims, err := client.ParseIDToken(mockToken)
+	if err != nil {
+		t.Fatalf("failed to parse ID token: %v", err)
+	}
+
+	if claims["sub"] != "1234567890" {
+		t.Errorf("sub claim mismatch: got %v", claims["sub"])
+	}
+
+	if claims["name"] != "Test User" {
+		t.Errorf("name claim mismatch: got %v", claims["name"])
+	}
+}
+
+func TestClient_AuthorizationURL(t *testing.T) {
+	client := NewClient(
+		"https://provider.example.com",
+		"test-client-id",
+		"test-secret",
+		"https://app.example.com/callback",
+		[]string{"openid", "email", "profile"},
+		nil,
+	)
+
+	// Note: This test will fail without a real OIDC provider
+	// In a real test environment, we'd mock the HTTP client
+	_, err := client.AuthorizationURL("test-state", "test-verifier")
+	if err != nil {
+		// Expected to fail without real provider, but we can check error message
+		t.Logf("Expected error without provider: %v", err)
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	client := NewClient(
+		"https://provider.example.com",
+		"client-id",
+		"client-secret",
+		"https://redirect.example.com/callback",
+		[]string{"openid", "email"},
+		nil,
+	)
+
+	if client == nil {
+		t.Fatal("client is nil")
+	}
+
+	if client.clientID != "client-id" {
+		t.Errorf("client ID mismatch: got %s", client.clientID)
+	}
+
+	if client.providerURL != "https://provider.example.com" {
+		t.Errorf("provider URL mismatch: got %s", client.providerURL)
+	}
+
+	if len(client.scopes) != 2 {
+		t.Errorf("scopes length mismatch: got %d", len(client.scopes))
+	}
+}

--- a/pkg/oidc/session.go
+++ b/pkg/oidc/session.go
@@ -1,14 +1,14 @@
 package oidc
 
 import (
-	"crypto/hmac"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"golang.org/x/crypto/chacha20poly1305"
 )
 
 const (
@@ -22,12 +22,13 @@ const (
 	pkceVerifierLength = 64
 )
 
-// SessionManager handles OIDC session lifecycle using HMAC-signed cookies.
+// SessionManager handles OIDC session lifecycle using encrypted cookies.
+// Cookie values are encrypted and authenticated with XChaCha20-Poly1305.
 type SessionManager struct {
 	cookieSecure    bool
 	cookieDomain    string
 	sessionDuration time.Duration
-	signingKey      []byte
+	key             []byte
 }
 
 // SessionData contains the authenticated session information
@@ -69,68 +70,63 @@ func (sm *SessionManager) SetSecure(secure bool) {
 }
 
 // NewSessionManager creates a new session manager.
-// If signingKey is nil, a random 32-byte key is generated. This means sessions
+// If key is nil, a random 32-byte key is generated. This means sessions
 // won't survive server restarts; pass a persistent key for durable sessions.
-func NewSessionManager(cookieSecure bool, cookieDomain string, signingKey []byte) *SessionManager {
-	if signingKey == nil {
-		signingKey = make([]byte, 32)
-		rand.Read(signingKey)
+func NewSessionManager(cookieSecure bool, cookieDomain string, key []byte) *SessionManager {
+	if key == nil {
+		key = make([]byte, chacha20poly1305.KeySize)
+		rand.Read(key)
 	}
 	return &SessionManager{
 		cookieSecure:    cookieSecure,
 		cookieDomain:    cookieDomain,
 		sessionDuration: defaultSessionDuration,
-		signingKey:      signingKey,
+		key:             key,
 	}
 }
 
-// signCookie produces "base64(json).base64(hmac-sha256)" from data.
-func (sm *SessionManager) signCookie(data []byte) string {
-	encoded := base64.RawURLEncoding.EncodeToString(data)
-	mac := hmac.New(sha256.New, sm.signingKey)
-	mac.Write([]byte(encoded))
-	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
-	return encoded + "." + sig
-}
-
-// verifyCookie splits "payload.sig", verifies the HMAC, and returns the decoded payload.
-func (sm *SessionManager) verifyCookie(value string) ([]byte, error) {
-	parts := splitCookieValue(value)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("malformed signed cookie")
-	}
-
-	mac := hmac.New(sha256.New, sm.signingKey)
-	mac.Write([]byte(parts[0]))
-	expectedSig := mac.Sum(nil)
-
-	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+// sealCookie encrypts and authenticates data with XChaCha20-Poly1305,
+// returning base64(nonce || ciphertext).
+func (sm *SessionManager) sealCookie(plaintext []byte) (string, error) {
+	aead, err := chacha20poly1305.NewX(sm.key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode signature: %w", err)
+		return "", fmt.Errorf("creating AEAD: %w", err)
 	}
 
-	if !hmac.Equal(sig, expectedSig) {
-		return nil, fmt.Errorf("cookie signature verification failed")
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("generating nonce: %w", err)
 	}
 
-	data, err := base64.RawURLEncoding.DecodeString(parts[0])
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode cookie payload: %w", err)
-	}
-
-	return data, nil
+	// nonce is prepended to ciphertext
+	sealed := aead.Seal(nonce, nonce, plaintext, nil)
+	return base64.RawURLEncoding.EncodeToString(sealed), nil
 }
 
-// splitCookieValue splits on the last '.' to separate payload from signature.
-func splitCookieValue(s string) []string {
-	idx := len(s) - 1
-	for idx >= 0 && s[idx] != '.' {
-		idx--
+// openCookie decodes, decrypts, and verifies a cookie produced by sealCookie.
+func (sm *SessionManager) openCookie(value string) ([]byte, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode cookie: %w", err)
 	}
-	if idx <= 0 {
-		return nil
+
+	aead, err := chacha20poly1305.NewX(sm.key)
+	if err != nil {
+		return nil, fmt.Errorf("creating AEAD: %w", err)
 	}
-	return []string{s[:idx], s[idx+1:]}
+
+	nonceSize := aead.NonceSize()
+	if len(raw) < nonceSize {
+		return nil, fmt.Errorf("cookie value too short")
+	}
+
+	nonce, ciphertext := raw[:nonceSize], raw[nonceSize:]
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cookie decryption failed: %w", err)
+	}
+
+	return plaintext, nil
 }
 
 // GetSession retrieves the current session from cookies
@@ -143,7 +139,7 @@ func (sm *SessionManager) GetSession(r *http.Request) (*SessionData, error) {
 		return nil, fmt.Errorf("failed to read session cookie: %w", err)
 	}
 
-	data, err := sm.verifyCookie(cookie.Value)
+	data, err := sm.openCookie(cookie.Value)
 	if err != nil {
 		return nil, fmt.Errorf("invalid session cookie: %w", err)
 	}
@@ -160,7 +156,7 @@ func (sm *SessionManager) GetSession(r *http.Request) (*SessionData, error) {
 	return &session, nil
 }
 
-// SetSession stores a new session in an HMAC-signed cookie
+// SetSession stores a new session in an encrypted cookie
 func (sm *SessionManager) SetSession(w http.ResponseWriter, session *SessionData) error {
 	if session.ExpiresAt.IsZero() {
 		session.ExpiresAt = time.Now().Add(sm.sessionDuration)
@@ -171,9 +167,14 @@ func (sm *SessionManager) SetSession(w http.ResponseWriter, session *SessionData
 		return fmt.Errorf("failed to marshal session: %w", err)
 	}
 
+	sealed, err := sm.sealCookie(data)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt session: %w", err)
+	}
+
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,
-		Value:    sm.signCookie(data),
+		Value:    sealed,
 		Path:     "/",
 		Domain:   sm.cookieDomain,
 		Expires:  session.ExpiresAt,
@@ -223,16 +224,21 @@ func (sm *SessionManager) GenerateState(returnPath string) (*StateData, error) {
 	}, nil
 }
 
-// SetState stores OIDC flow state in an HMAC-signed cookie
+// SetState stores OIDC flow state in an encrypted cookie
 func (sm *SessionManager) SetState(w http.ResponseWriter, state *StateData) error {
 	data, err := json.Marshal(state)
 	if err != nil {
 		return fmt.Errorf("failed to marshal state: %w", err)
 	}
 
+	sealed, err := sm.sealCookie(data)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt state: %w", err)
+	}
+
 	http.SetCookie(w, &http.Cookie{
 		Name:     stateCookieName,
-		Value:    sm.signCookie(data),
+		Value:    sealed,
 		Path:     "/",
 		Domain:   sm.cookieDomain,
 		Expires:  state.ExpiresAt,
@@ -254,7 +260,7 @@ func (sm *SessionManager) GetState(r *http.Request) (*StateData, error) {
 		return nil, fmt.Errorf("failed to read state cookie: %w", err)
 	}
 
-	data, err := sm.verifyCookie(cookie.Value)
+	data, err := sm.openCookie(cookie.Value)
 	if err != nil {
 		return nil, fmt.Errorf("invalid state cookie: %w", err)
 	}

--- a/pkg/oidc/session.go
+++ b/pkg/oidc/session.go
@@ -1,7 +1,9 @@
 package oidc
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -20,17 +22,12 @@ const (
 	pkceVerifierLength = 64
 )
 
-// SessionManager handles OIDC session lifecycle using secure cookies.
-// Sessions are stored as encrypted cookies with HttpOnly and Secure flags.
+// SessionManager handles OIDC session lifecycle using HMAC-signed cookies.
 type SessionManager struct {
-	// cookieSecure controls whether cookies require HTTPS
-	cookieSecure bool
-
-	// cookieDomain is the domain for session cookies
-	cookieDomain string
-
-	// sessionDuration controls how long sessions last
+	cookieSecure    bool
+	cookieDomain    string
 	sessionDuration time.Duration
+	signingKey      []byte
 }
 
 // SessionData contains the authenticated session information
@@ -66,13 +63,74 @@ type StateData struct {
 	ExpiresAt time.Time `json:"expires_at"`
 }
 
-// NewSessionManager creates a new session manager
-func NewSessionManager(cookieSecure bool, cookieDomain string) *SessionManager {
+// SetSecure updates whether cookies should be marked Secure.
+func (sm *SessionManager) SetSecure(secure bool) {
+	sm.cookieSecure = secure
+}
+
+// NewSessionManager creates a new session manager.
+// If signingKey is nil, a random 32-byte key is generated. This means sessions
+// won't survive server restarts; pass a persistent key for durable sessions.
+func NewSessionManager(cookieSecure bool, cookieDomain string, signingKey []byte) *SessionManager {
+	if signingKey == nil {
+		signingKey = make([]byte, 32)
+		rand.Read(signingKey)
+	}
 	return &SessionManager{
 		cookieSecure:    cookieSecure,
 		cookieDomain:    cookieDomain,
 		sessionDuration: defaultSessionDuration,
+		signingKey:      signingKey,
 	}
+}
+
+// signCookie produces "base64(json).base64(hmac-sha256)" from data.
+func (sm *SessionManager) signCookie(data []byte) string {
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+	mac := hmac.New(sha256.New, sm.signingKey)
+	mac.Write([]byte(encoded))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return encoded + "." + sig
+}
+
+// verifyCookie splits "payload.sig", verifies the HMAC, and returns the decoded payload.
+func (sm *SessionManager) verifyCookie(value string) ([]byte, error) {
+	parts := splitCookieValue(value)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("malformed signed cookie")
+	}
+
+	mac := hmac.New(sha256.New, sm.signingKey)
+	mac.Write([]byte(parts[0]))
+	expectedSig := mac.Sum(nil)
+
+	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode signature: %w", err)
+	}
+
+	if !hmac.Equal(sig, expectedSig) {
+		return nil, fmt.Errorf("cookie signature verification failed")
+	}
+
+	data, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode cookie payload: %w", err)
+	}
+
+	return data, nil
+}
+
+// splitCookieValue splits on the last '.' to separate payload from signature.
+func splitCookieValue(s string) []string {
+	idx := len(s) - 1
+	for idx >= 0 && s[idx] != '.' {
+		idx--
+	}
+	if idx <= 0 {
+		return nil
+	}
+	return []string{s[:idx], s[idx+1:]}
 }
 
 // GetSession retrieves the current session from cookies
@@ -85,19 +143,16 @@ func (sm *SessionManager) GetSession(r *http.Request) (*SessionData, error) {
 		return nil, fmt.Errorf("failed to read session cookie: %w", err)
 	}
 
-	// Decode base64
-	data, err := base64.RawURLEncoding.DecodeString(cookie.Value)
+	data, err := sm.verifyCookie(cookie.Value)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode session cookie: %w", err)
+		return nil, fmt.Errorf("invalid session cookie: %w", err)
 	}
 
-	// Parse JSON
 	var session SessionData
 	if err := json.Unmarshal(data, &session); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal session: %w", err)
 	}
 
-	// Check expiration
 	if time.Now().After(session.ExpiresAt) {
 		return nil, nil
 	}
@@ -105,26 +160,20 @@ func (sm *SessionManager) GetSession(r *http.Request) (*SessionData, error) {
 	return &session, nil
 }
 
-// SetSession stores a new session in a secure cookie
+// SetSession stores a new session in an HMAC-signed cookie
 func (sm *SessionManager) SetSession(w http.ResponseWriter, session *SessionData) error {
-	// Set expiration if not set
 	if session.ExpiresAt.IsZero() {
 		session.ExpiresAt = time.Now().Add(sm.sessionDuration)
 	}
 
-	// Marshal to JSON
 	data, err := json.Marshal(session)
 	if err != nil {
 		return fmt.Errorf("failed to marshal session: %w", err)
 	}
 
-	// Encode as base64
-	encoded := base64.RawURLEncoding.EncodeToString(data)
-
-	// Set cookie
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,
-		Value:    encoded,
+		Value:    sm.signCookie(data),
 		Path:     "/",
 		Domain:   sm.cookieDomain,
 		Expires:  session.ExpiresAt,
@@ -174,21 +223,16 @@ func (sm *SessionManager) GenerateState(returnPath string) (*StateData, error) {
 	}, nil
 }
 
-// SetState stores OIDC flow state in a cookie
+// SetState stores OIDC flow state in an HMAC-signed cookie
 func (sm *SessionManager) SetState(w http.ResponseWriter, state *StateData) error {
-	// Marshal to JSON
 	data, err := json.Marshal(state)
 	if err != nil {
 		return fmt.Errorf("failed to marshal state: %w", err)
 	}
 
-	// Encode as base64
-	encoded := base64.RawURLEncoding.EncodeToString(data)
-
-	// Set cookie (shorter-lived than session)
 	http.SetCookie(w, &http.Cookie{
 		Name:     stateCookieName,
-		Value:    encoded,
+		Value:    sm.signCookie(data),
 		Path:     "/",
 		Domain:   sm.cookieDomain,
 		Expires:  state.ExpiresAt,
@@ -210,19 +254,16 @@ func (sm *SessionManager) GetState(r *http.Request) (*StateData, error) {
 		return nil, fmt.Errorf("failed to read state cookie: %w", err)
 	}
 
-	// Decode base64
-	data, err := base64.RawURLEncoding.DecodeString(cookie.Value)
+	data, err := sm.verifyCookie(cookie.Value)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode state cookie: %w", err)
+		return nil, fmt.Errorf("invalid state cookie: %w", err)
 	}
 
-	// Parse JSON
 	var state StateData
 	if err := json.Unmarshal(data, &state); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal state: %w", err)
 	}
 
-	// Check expiration
 	if time.Now().After(state.ExpiresAt) {
 		return nil, fmt.Errorf("state has expired")
 	}

--- a/pkg/oidc/session.go
+++ b/pkg/oidc/session.go
@@ -1,0 +1,245 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	sessionCookieName = "miren_oidc_session"
+	stateCookieName   = "miren_oidc_state"
+
+	// Default session lifetime
+	defaultSessionDuration = 24 * time.Hour
+
+	// PKCE challenge length (43-128 characters per RFC 7636)
+	pkceVerifierLength = 64
+)
+
+// SessionManager handles OIDC session lifecycle using secure cookies.
+// Sessions are stored as encrypted cookies with HttpOnly and Secure flags.
+type SessionManager struct {
+	// cookieSecure controls whether cookies require HTTPS
+	cookieSecure bool
+
+	// cookieDomain is the domain for session cookies
+	cookieDomain string
+
+	// sessionDuration controls how long sessions last
+	sessionDuration time.Duration
+}
+
+// SessionData contains the authenticated session information
+type SessionData struct {
+	// IDToken is the raw ID token JWT from the OIDC provider
+	IDToken string `json:"id_token"`
+
+	// AccessToken is the OAuth2 access token (optional)
+	AccessToken string `json:"access_token,omitempty"`
+
+	// RefreshToken is the OAuth2 refresh token (optional)
+	RefreshToken string `json:"refresh_token,omitempty"`
+
+	// Claims are the parsed JWT claims
+	Claims map[string]interface{} `json:"claims"`
+
+	// ExpiresAt is when this session expires
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// StateData contains OIDC flow state for CSRF protection
+type StateData struct {
+	// State is the random state parameter
+	State string `json:"state"`
+
+	// PKCEVerifier is the PKCE code verifier (RFC 7636)
+	PKCEVerifier string `json:"pkce_verifier"`
+
+	// ReturnPath is where to redirect after auth
+	ReturnPath string `json:"return_path"`
+
+	// ExpiresAt is when this state expires (short-lived)
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// NewSessionManager creates a new session manager
+func NewSessionManager(cookieSecure bool, cookieDomain string) *SessionManager {
+	return &SessionManager{
+		cookieSecure:    cookieSecure,
+		cookieDomain:    cookieDomain,
+		sessionDuration: defaultSessionDuration,
+	}
+}
+
+// GetSession retrieves the current session from cookies
+func (sm *SessionManager) GetSession(r *http.Request) (*SessionData, error) {
+	cookie, err := r.Cookie(sessionCookieName)
+	if err != nil {
+		if err == http.ErrNoCookie {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read session cookie: %w", err)
+	}
+
+	// Decode base64
+	data, err := base64.RawURLEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode session cookie: %w", err)
+	}
+
+	// Parse JSON
+	var session SessionData
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal session: %w", err)
+	}
+
+	// Check expiration
+	if time.Now().After(session.ExpiresAt) {
+		return nil, nil
+	}
+
+	return &session, nil
+}
+
+// SetSession stores a new session in a secure cookie
+func (sm *SessionManager) SetSession(w http.ResponseWriter, session *SessionData) error {
+	// Set expiration if not set
+	if session.ExpiresAt.IsZero() {
+		session.ExpiresAt = time.Now().Add(sm.sessionDuration)
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("failed to marshal session: %w", err)
+	}
+
+	// Encode as base64
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+
+	// Set cookie
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    encoded,
+		Path:     "/",
+		Domain:   sm.cookieDomain,
+		Expires:  session.ExpiresAt,
+		Secure:   sm.cookieSecure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	return nil
+}
+
+// ClearSession removes the session cookie
+func (sm *SessionManager) ClearSession(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		Domain:   sm.cookieDomain,
+		MaxAge:   -1,
+		Secure:   sm.cookieSecure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// GenerateState creates a new OIDC flow state with PKCE
+func (sm *SessionManager) GenerateState(returnPath string) (*StateData, error) {
+	// Generate random state
+	stateBytes := make([]byte, 32)
+	if _, err := rand.Read(stateBytes); err != nil {
+		return nil, fmt.Errorf("failed to generate state: %w", err)
+	}
+	state := base64.RawURLEncoding.EncodeToString(stateBytes)
+
+	// Generate PKCE verifier
+	verifierBytes := make([]byte, pkceVerifierLength)
+	if _, err := rand.Read(verifierBytes); err != nil {
+		return nil, fmt.Errorf("failed to generate PKCE verifier: %w", err)
+	}
+	verifier := base64.RawURLEncoding.EncodeToString(verifierBytes)
+
+	return &StateData{
+		State:        state,
+		PKCEVerifier: verifier,
+		ReturnPath:   returnPath,
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	}, nil
+}
+
+// SetState stores OIDC flow state in a cookie
+func (sm *SessionManager) SetState(w http.ResponseWriter, state *StateData) error {
+	// Marshal to JSON
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	// Encode as base64
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+
+	// Set cookie (shorter-lived than session)
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    encoded,
+		Path:     "/",
+		Domain:   sm.cookieDomain,
+		Expires:  state.ExpiresAt,
+		Secure:   sm.cookieSecure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	return nil
+}
+
+// GetState retrieves OIDC flow state from cookies
+func (sm *SessionManager) GetState(r *http.Request) (*StateData, error) {
+	cookie, err := r.Cookie(stateCookieName)
+	if err != nil {
+		if err == http.ErrNoCookie {
+			return nil, fmt.Errorf("state cookie not found")
+		}
+		return nil, fmt.Errorf("failed to read state cookie: %w", err)
+	}
+
+	// Decode base64
+	data, err := base64.RawURLEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode state cookie: %w", err)
+	}
+
+	// Parse JSON
+	var state StateData
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal state: %w", err)
+	}
+
+	// Check expiration
+	if time.Now().After(state.ExpiresAt) {
+		return nil, fmt.Errorf("state has expired")
+	}
+
+	return &state, nil
+}
+
+// ClearState removes the state cookie
+func (sm *SessionManager) ClearState(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     stateCookieName,
+		Value:    "",
+		Path:     "/",
+		Domain:   sm.cookieDomain,
+		MaxAge:   -1,
+		Secure:   sm.cookieSecure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}

--- a/pkg/oidc/session_test.go
+++ b/pkg/oidc/session_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSessionManager_SetAndGetSession(t *testing.T) {
-	sm := NewSessionManager(false, "")
+	sm := NewSessionManager(false, "", nil)
 
 	// Create test session
 	session := &SessionData{
@@ -58,7 +58,7 @@ func TestSessionManager_SetAndGetSession(t *testing.T) {
 }
 
 func TestSessionManager_ClearSession(t *testing.T) {
-	sm := NewSessionManager(false, "")
+	sm := NewSessionManager(false, "", nil)
 
 	// Set session first
 	session := &SessionData{
@@ -88,7 +88,7 @@ func TestSessionManager_ClearSession(t *testing.T) {
 }
 
 func TestSessionManager_GenerateState(t *testing.T) {
-	sm := NewSessionManager(false, "")
+	sm := NewSessionManager(false, "", nil)
 
 	state, err := sm.GenerateState("/return-path")
 	if err != nil {
@@ -113,7 +113,7 @@ func TestSessionManager_GenerateState(t *testing.T) {
 }
 
 func TestSessionManager_SetAndGetState(t *testing.T) {
-	sm := NewSessionManager(false, "")
+	sm := NewSessionManager(false, "", nil)
 
 	state := &StateData{
 		State:        "test-state",
@@ -161,7 +161,7 @@ func TestSessionManager_SetAndGetState(t *testing.T) {
 }
 
 func TestSessionManager_GetSession_NoSession(t *testing.T) {
-	sm := NewSessionManager(false, "")
+	sm := NewSessionManager(false, "", nil)
 
 	req := httptest.NewRequest("GET", "/", nil)
 
@@ -176,7 +176,7 @@ func TestSessionManager_GetSession_NoSession(t *testing.T) {
 }
 
 func TestSessionManager_GetSession_ExpiredSession(t *testing.T) {
-	sm := NewSessionManager(false, "")
+	sm := NewSessionManager(false, "", nil)
 
 	// Create expired session
 	session := &SessionData{

--- a/pkg/oidc/session_test.go
+++ b/pkg/oidc/session_test.go
@@ -1,0 +1,208 @@
+package oidc
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSessionManager_SetAndGetSession(t *testing.T) {
+	sm := NewSessionManager(false, "")
+
+	// Create test session
+	session := &SessionData{
+		IDToken: "test-id-token",
+		Claims: map[string]interface{}{
+			"sub":   "test-user",
+			"email": "test@example.com",
+		},
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	// Set session
+	w := httptest.NewRecorder()
+	err := sm.SetSession(w, session)
+	if err != nil {
+		t.Fatalf("failed to set session: %v", err)
+	}
+
+	// Get session cookie
+	cookies := w.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("no session cookie set")
+	}
+
+	// Create request with cookie
+	req := httptest.NewRequest("GET", "/", nil)
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+
+	// Get session
+	retrieved, err := sm.GetSession(req)
+	if err != nil {
+		t.Fatalf("failed to get session: %v", err)
+	}
+
+	if retrieved == nil {
+		t.Fatal("session is nil")
+	}
+
+	if retrieved.IDToken != session.IDToken {
+		t.Errorf("IDToken mismatch: got %s, want %s", retrieved.IDToken, session.IDToken)
+	}
+
+	if retrieved.Claims["sub"] != "test-user" {
+		t.Errorf("Claims mismatch: got %v", retrieved.Claims)
+	}
+}
+
+func TestSessionManager_ClearSession(t *testing.T) {
+	sm := NewSessionManager(false, "")
+
+	// Set session first
+	session := &SessionData{
+		IDToken:   "test-token",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	w := httptest.NewRecorder()
+	err := sm.SetSession(w, session)
+	if err != nil {
+		t.Fatalf("failed to set session: %v", err)
+	}
+
+	// Clear session
+	w = httptest.NewRecorder()
+	sm.ClearSession(w)
+
+	// Check that cookie is cleared (MaxAge=-1)
+	cookies := w.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("no cookie set")
+	}
+
+	if cookies[0].MaxAge != -1 {
+		t.Errorf("cookie not cleared: MaxAge=%d", cookies[0].MaxAge)
+	}
+}
+
+func TestSessionManager_GenerateState(t *testing.T) {
+	sm := NewSessionManager(false, "")
+
+	state, err := sm.GenerateState("/return-path")
+	if err != nil {
+		t.Fatalf("failed to generate state: %v", err)
+	}
+
+	if state.State == "" {
+		t.Error("state is empty")
+	}
+
+	if state.PKCEVerifier == "" {
+		t.Error("PKCE verifier is empty")
+	}
+
+	if state.ReturnPath != "/return-path" {
+		t.Errorf("return path mismatch: got %s, want /return-path", state.ReturnPath)
+	}
+
+	if state.ExpiresAt.IsZero() {
+		t.Error("expiration not set")
+	}
+}
+
+func TestSessionManager_SetAndGetState(t *testing.T) {
+	sm := NewSessionManager(false, "")
+
+	state := &StateData{
+		State:        "test-state",
+		PKCEVerifier: "test-verifier",
+		ReturnPath:   "/test-path",
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	}
+
+	// Set state
+	w := httptest.NewRecorder()
+	err := sm.SetState(w, state)
+	if err != nil {
+		t.Fatalf("failed to set state: %v", err)
+	}
+
+	// Get state cookie
+	cookies := w.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("no state cookie set")
+	}
+
+	// Create request with cookie
+	req := httptest.NewRequest("GET", "/", nil)
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+
+	// Get state
+	retrieved, err := sm.GetState(req)
+	if err != nil {
+		t.Fatalf("failed to get state: %v", err)
+	}
+
+	if retrieved.State != state.State {
+		t.Errorf("state mismatch: got %s, want %s", retrieved.State, state.State)
+	}
+
+	if retrieved.PKCEVerifier != state.PKCEVerifier {
+		t.Errorf("PKCE verifier mismatch: got %s, want %s", retrieved.PKCEVerifier, state.PKCEVerifier)
+	}
+
+	if retrieved.ReturnPath != state.ReturnPath {
+		t.Errorf("return path mismatch: got %s, want %s", retrieved.ReturnPath, state.ReturnPath)
+	}
+}
+
+func TestSessionManager_GetSession_NoSession(t *testing.T) {
+	sm := NewSessionManager(false, "")
+
+	req := httptest.NewRequest("GET", "/", nil)
+
+	session, err := sm.GetSession(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if session != nil {
+		t.Error("expected nil session, got non-nil")
+	}
+}
+
+func TestSessionManager_GetSession_ExpiredSession(t *testing.T) {
+	sm := NewSessionManager(false, "")
+
+	// Create expired session
+	session := &SessionData{
+		IDToken:   "test-token",
+		ExpiresAt: time.Now().Add(-time.Hour), // expired 1 hour ago
+	}
+
+	w := httptest.NewRecorder()
+	err := sm.SetSession(w, session)
+	if err != nil {
+		t.Fatalf("failed to set session: %v", err)
+	}
+
+	// Create request with cookie
+	req := httptest.NewRequest("GET", "/", nil)
+	for _, cookie := range w.Result().Cookies() {
+		req.AddCookie(cookie)
+	}
+
+	// Get session - should be nil due to expiration
+	retrieved, err := sm.GetSession(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if retrieved != nil {
+		t.Error("expected nil for expired session")
+	}
+}

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -79,6 +79,7 @@ type Row []string
 type Table struct {
 	columns []Column
 	rows    []Row
+	title   string
 	styles  TableStyles
 }
 
@@ -86,6 +87,7 @@ type Table struct {
 type TableStyles struct {
 	Header lipgloss.Style
 	Cell   lipgloss.Style
+	Title  lipgloss.Style
 }
 
 // DefaultTableStyles returns the default styling for tables
@@ -96,7 +98,8 @@ func DefaultTableStyles() TableStyles {
 			Underline(true).
 			UnderlineSpaces(true).
 			Foreground(lipgloss.Color("220")),
-		Cell: lipgloss.NewStyle(),
+		Cell:  lipgloss.NewStyle(),
+		Title: lipgloss.NewStyle().Bold(true),
 	}
 }
 
@@ -114,6 +117,13 @@ func WithColumns(cols []Column) TableOption {
 func WithRows(rows []Row) TableOption {
 	return func(t *Table) {
 		t.rows = rows
+	}
+}
+
+// WithTableTitle sets a title displayed above the table header
+func WithTableTitle(title string) TableOption {
+	return func(t *Table) {
+		t.title = title
 	}
 }
 
@@ -274,6 +284,11 @@ func (t *Table) Render() string {
 	}
 
 	var lines []string
+
+	// Render title if set
+	if t.title != "" {
+		lines = append(lines, t.styles.Title.Render(t.title))
+	}
 
 	// Render header
 	lines = append(lines, t.renderHeader())

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -285,15 +285,12 @@ func (t *Table) Render() string {
 
 	var lines []string
 
-	// Render title if set
 	if t.title != "" {
 		lines = append(lines, t.styles.Title.Render(t.title))
 	}
 
-	// Render header
 	lines = append(lines, t.renderHeader())
 
-	// Render rows
 	for _, row := range t.rows {
 		lines = append(lines, t.renderRow(row))
 	}

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -64,6 +64,8 @@ type Server struct {
 	apps map[string]*appUsage
 
 	oidcSessionManager *oidc.SessionManager
+	oidcMu             sync.RWMutex
+	oidcHandlers       map[string]*oidcHandler
 }
 
 type appUsage struct {
@@ -109,6 +111,7 @@ func NewServer(
 		logWriter:          logWriter,
 		apps:               make(map[string]*appUsage),
 		oidcSessionManager: oidc.NewSessionManager(false, "", signingKey),
+		oidcHandlers:       make(map[string]*oidcHandler),
 	}
 
 	// Build the timeout handler once at initialization

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -398,7 +398,7 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 		h.Log.Debug("using http route", "host", onlyHost, "app", targetAppId)
 
 		// Check if OIDC authentication is required
-		if !route.OidcConfig.Empty() {
+		if !entity.Empty(route.OidcProvider) {
 			// Wrap the request handler with OIDC middleware
 			oidcWrapped := h.oidcMiddleware(route, func(w http.ResponseWriter, r *http.Request) {
 				// Continue with normal request handling after auth
@@ -430,7 +430,7 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 		h.Log.Debug("using default route", "host", onlyHost, "app", targetAppId)
 
 		// Check if OIDC authentication is required for default route
-		if !defaultRoute.OidcConfig.Empty() {
+		if !entity.Empty(defaultRoute.OidcProvider) {
 			// Update route reference
 			route = defaultRoute
 			// Wrap with OIDC middleware

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -396,6 +396,17 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 		targetAppId = route.App
 		routeType = "route"
 		h.Log.Debug("using http route", "host", onlyHost, "app", targetAppId)
+
+		// Check if OIDC authentication is required
+		if !route.OidcConfig.Empty() {
+			// Wrap the request handler with OIDC middleware
+			oidcWrapped := h.oidcMiddleware(route, func(w http.ResponseWriter, r *http.Request) {
+				// Continue with normal request handling after auth
+				h.serveAuthenticatedRequest(w, r, targetAppId, routeType, appName)
+			})
+			oidcWrapped(w, req)
+			return
+		}
 	} else {
 		// No route found, try to find a default route
 		h.Log.Debug("no http route found, checking for default route", "host", onlyHost)
@@ -417,6 +428,30 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 		targetAppId = defaultRoute.App
 		routeType = "default"
 		h.Log.Debug("using default route", "host", onlyHost, "app", targetAppId)
+
+		// Check if OIDC authentication is required for default route
+		if !defaultRoute.OidcConfig.Empty() {
+			// Update route reference
+			route = defaultRoute
+			// Wrap with OIDC middleware
+			oidcWrapped := h.oidcMiddleware(route, func(w http.ResponseWriter, r *http.Request) {
+				h.serveAuthenticatedRequest(w, r, targetAppId, routeType, appName)
+			})
+			oidcWrapped(w, req)
+			return
+		}
+	}
+
+	// Continue with normal request handling
+	h.serveAuthenticatedRequest(w, req, targetAppId, routeType, appName)
+}
+
+// serveAuthenticatedRequest handles the request after authentication (if any)
+func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Request, targetAppId entity.Id, routeType string, appName *string) {
+	ctx := req.Context()
+	onlyHost, _, err := net.SplitHostPort(req.Host)
+	if err != nil {
+		onlyHost = req.Host
 	}
 
 	// Get app details first to have the name for metrics

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -29,6 +29,7 @@ import (
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/httputil"
+	"miren.dev/runtime/pkg/oidc"
 	"miren.dev/runtime/pkg/rpc"
 )
 
@@ -41,6 +42,7 @@ const (
 
 type IngressConfig struct {
 	RequestTimeout time.Duration
+	DataPath       string
 }
 
 type Server struct {
@@ -60,6 +62,8 @@ type Server struct {
 
 	mu   sync.Mutex
 	apps map[string]*appUsage
+
+	oidcSessionManager *oidc.SessionManager
 }
 
 type appUsage struct {
@@ -84,17 +88,27 @@ func NewServer(
 		config.RequestTimeout = 60 * time.Second
 	}
 
+	var signingKey []byte
+	if config.DataPath != "" {
+		var err error
+		signingKey, err = loadOrGenerateSigningKey(config.DataPath)
+		if err != nil {
+			log.Error("failed to load OIDC signing key, sessions will not survive restarts", "error", err)
+		}
+	}
+
 	serv := &Server{
-		Log:           log.With("module", "httpingress"),
-		config:        config,
-		rpcClient:     rpcClient,
-		eac:           eac,
-		ingressClient: ingress.NewClient(log, rpcClient),
-		appClient:     app.NewClient(log, rpcClient),
-		aa:            aa,
-		httpMetrics:   httpMetrics,
-		logWriter:     logWriter,
-		apps:          make(map[string]*appUsage),
+		Log:                log.With("module", "httpingress"),
+		config:             config,
+		rpcClient:          rpcClient,
+		eac:                eac,
+		ingressClient:      ingress.NewClient(log, rpcClient),
+		appClient:          app.NewClient(log, rpcClient),
+		aa:                 aa,
+		httpMetrics:        httpMetrics,
+		logWriter:          logWriter,
+		apps:               make(map[string]*appUsage),
+		oidcSessionManager: oidc.NewSessionManager(false, "", signingKey),
 	}
 
 	// Build the timeout handler once at initialization

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -9,6 +9,7 @@ import (
 
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/labs"
 	"miren.dev/runtime/pkg/oidc"
 )
 
@@ -23,11 +24,13 @@ type oidcHandler struct {
 	provider       *ingress_v1alpha.OidcProvider
 	client         *oidc.Client
 	sessionManager *oidc.SessionManager
+	resource       string
 	logger         *slog.Logger
 }
 
-// newOIDCHandler creates a new OIDC handler for a route with a resolved provider
-func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.OidcProvider, baseURL string, logger *slog.Logger) (*oidcHandler, error) {
+// newOIDCHandler creates a new OIDC handler for a route with a resolved provider.
+// The resource parameter is the RFC 8707 resource indicator for the authorization request.
+func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.OidcProvider, baseURL, resource string, logger *slog.Logger) (*oidcHandler, error) {
 	if provider.ProviderUrl == "" || provider.ClientId == "" {
 		return nil, fmt.Errorf("OIDC provider missing required fields")
 	}
@@ -61,6 +64,7 @@ func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.
 		provider:       provider,
 		client:         client,
 		sessionManager: sessionManager,
+		resource:       resource,
 		logger:         logger.With("module", "oidc", "host", route.Host, "provider", provider.Name),
 	}, nil
 }
@@ -107,8 +111,8 @@ func (h *oidcHandler) redirectToProvider(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Generate authorization URL
-	authURL, err := h.client.AuthorizationURL(state.State, state.PKCEVerifier)
+	// Generate authorization URL with resource indicator (RFC 8707)
+	authURL, err := h.client.AuthorizationURL(state.State, state.PKCEVerifier, h.resource)
 	if err != nil {
 		h.logger.Error("failed to generate auth URL", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -241,6 +245,11 @@ func (h *oidcHandler) injectClaims(r *http.Request, claims map[string]interface{
 
 // oidcMiddleware wraps the request handling with OIDC authentication
 func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
+	// Check if OIDC feature is enabled
+	if !labs.RouteOIDC() {
+		return next
+	}
+
 	// If no OIDC provider reference, just pass through
 	if entity.Empty(route.OidcProvider) {
 		return next
@@ -257,18 +266,27 @@ func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.Hand
 	var provider ingress_v1alpha.OidcProvider
 	provider.Decode(resp.Entity().Entity())
 
-	// Build base URL from host
-	// In production, this should use the actual scheme (http/https)
-	baseURL := fmt.Sprintf("https://%s", route.Host)
-
-	// Create OIDC handler
-	handler, err := newOIDCHandler(route, &provider, baseURL, s.Log)
-	if err != nil {
-		s.Log.Error("failed to create OIDC handler", "error", err, "host", route.Host)
-		return next
+	// Determine the resource indicator (RFC 8707) based on route type
+	var resource string
+	if route.Default {
+		resource = "cluster:default"
+	} else {
+		resource = route.Host
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Build base URL from the request host, which works for both
+		// named routes and the default route (which has no static host)
+		baseURL := fmt.Sprintf("https://%s", r.Host)
+
+		// Create OIDC handler per-request so the base URL matches the actual host
+		handler, err := newOIDCHandler(route, &provider, baseURL, resource, s.Log)
+		if err != nil {
+			s.Log.Error("failed to create OIDC handler", "error", err, "host", r.Host)
+			next(w, r)
+			return
+		}
+
 		// Handle callback path specially
 		if r.URL.Path == oidcCallbackPath {
 			handler.handleCallback(w, r)

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -115,8 +115,8 @@ func (h *oidcHandler) checkAuth(w http.ResponseWriter, r *http.Request) (authent
 			return true, session.Claims
 		}
 
-		// Fallback: parse claims from ID token
-		claims, err := h.client.ParseIDToken(session.IDToken)
+		// Fallback: validate and parse claims from ID token
+		claims, err := h.client.ParseIDToken(r.Context(), session.IDToken)
 		if err != nil {
 			h.logger.Error("failed to parse ID token", "error", err)
 			h.sessionManager.ClearSession(w)
@@ -131,7 +131,7 @@ func (h *oidcHandler) checkAuth(w http.ResponseWriter, r *http.Request) (authent
 // redirectToProvider redirects the user to the OIDC provider for authentication
 func (h *oidcHandler) redirectToProvider(w http.ResponseWriter, r *http.Request) {
 	// Generate state and PKCE verifier
-	state, err := h.sessionManager.GenerateState(r.URL.Path)
+	state, err := h.sessionManager.GenerateState(r.URL.RequestURI())
 	if err != nil {
 		h.logger.Error("failed to generate state", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -210,15 +210,11 @@ func (h *oidcHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify and parse claims from ID token
-	claims, err := h.client.VerifyIDToken(ctx, idToken)
+	claims, err := h.client.ParseIDToken(ctx, idToken)
 	if err != nil {
-		h.logger.Warn("ID token verification failed, falling back to unverified parse", "error", err)
-		claims, err = h.client.ParseIDToken(idToken)
-		if err != nil {
-			h.logger.Error("failed to parse ID token", "error", err)
-			http.Error(w, "Failed to parse ID token", http.StatusInternalServerError)
-			return
-		}
+		h.logger.Error("failed to parse ID token", "error", err)
+		http.Error(w, "Failed to verify ID token", http.StatusInternalServerError)
+		return
 	}
 
 	// Create session
@@ -317,30 +313,40 @@ func requestScheme(r *http.Request) string {
 	return "http"
 }
 
-// oidcMiddleware wraps the request handling with OIDC authentication
-func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
-	// Check if OIDC feature is enabled
-	if !labs.RouteOIDC() {
-		return next
+// getOrCreateOIDCHandler returns a cached oidcHandler for the given route,
+// creating one on first access. The handler (and its oidc.Client) is reused
+// across requests so that discovery and JWKS caches are effective.
+func (s *Server) getOrCreateOIDCHandler(route *ingress_v1alpha.HttpRoute, baseURL string) (*oidcHandler, error) {
+	// Key by route host; default routes use a sentinel.
+	key := route.Host
+	if route.Default {
+		key = "__default__"
 	}
 
-	// If no OIDC provider reference, just pass through
-	if entity.Empty(route.OidcProvider) {
-		return next
+	s.oidcMu.RLock()
+	if h, ok := s.oidcHandlers[key]; ok {
+		s.oidcMu.RUnlock()
+		return h, nil
+	}
+	s.oidcMu.RUnlock()
+
+	s.oidcMu.Lock()
+	defer s.oidcMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if h, ok := s.oidcHandlers[key]; ok {
+		return h, nil
 	}
 
 	// Resolve the OIDC provider entity
-	ctx := context.Background()
-	resp, err := s.eac.Get(ctx, string(route.OidcProvider))
+	resp, err := s.eac.Get(context.Background(), string(route.OidcProvider))
 	if err != nil {
-		s.Log.Error("failed to get OIDC provider", "error", err, "provider_id", route.OidcProvider)
-		return next
+		return nil, fmt.Errorf("failed to get OIDC provider: %w", err)
 	}
 
 	var provider ingress_v1alpha.OidcProvider
 	provider.Decode(resp.Entity().Entity())
 
-	// Determine the resource indicator (RFC 8707) based on route type
 	var resource string
 	if route.Default {
 		resource = "cluster:default"
@@ -348,16 +354,34 @@ func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.Hand
 		resource = route.Host
 	}
 
+	handler, err := newOIDCHandler(route, &provider, s.oidcSessionManager, baseURL, resource, s.Log)
+	if err != nil {
+		return nil, err
+	}
+
+	s.oidcHandlers[key] = handler
+	return handler, nil
+}
+
+// oidcMiddleware wraps the request handling with OIDC authentication
+func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
+	if !labs.RouteOIDC() {
+		return next
+	}
+
+	if entity.Empty(route.OidcProvider) {
+		return next
+	}
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		scheme := requestScheme(r)
 		baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
 
-		// Update cookie secure flag based on actual request scheme
 		s.oidcSessionManager.SetSecure(scheme == "https")
 
-		handler, err := newOIDCHandler(route, &provider, s.oidcSessionManager, baseURL, resource, s.Log)
+		handler, err := s.getOrCreateOIDCHandler(route, baseURL)
 		if err != nil {
-			s.Log.Error("failed to create OIDC handler", "error", err, "host", r.Host)
+			s.Log.Error("failed to get OIDC handler", "error", err, "host", r.Host)
 			next(w, r)
 			return
 		}

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -1,12 +1,14 @@
 package httpingress
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
 
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/oidc"
 )
 
@@ -18,22 +20,22 @@ const (
 // oidcHandler manages OIDC authentication for a route
 type oidcHandler struct {
 	route          *ingress_v1alpha.HttpRoute
+	provider       *ingress_v1alpha.OidcProvider
 	client         *oidc.Client
 	sessionManager *oidc.SessionManager
 	logger         *slog.Logger
 }
 
-// newOIDCHandler creates a new OIDC handler for a route
-func newOIDCHandler(route *ingress_v1alpha.HttpRoute, baseURL string, logger *slog.Logger) (*oidcHandler, error) {
-	config := route.OidcConfig
-	if config.ProviderUrl == "" || config.ClientId == "" {
-		return nil, fmt.Errorf("OIDC config missing required fields")
+// newOIDCHandler creates a new OIDC handler for a route with a resolved provider
+func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.OidcProvider, baseURL string, logger *slog.Logger) (*oidcHandler, error) {
+	if provider.ProviderUrl == "" || provider.ClientId == "" {
+		return nil, fmt.Errorf("OIDC provider missing required fields")
 	}
 
 	// Parse scopes
 	scopes := []string{"openid"}
-	if config.Scopes != "" {
-		scopes = strings.Fields(config.Scopes)
+	if provider.Scopes != "" {
+		scopes = strings.Fields(provider.Scopes)
 	}
 
 	// Build redirect URL
@@ -41,9 +43,9 @@ func newOIDCHandler(route *ingress_v1alpha.HttpRoute, baseURL string, logger *sl
 
 	// Create OIDC client
 	client := oidc.NewClient(
-		config.ProviderUrl,
-		config.ClientId,
-		config.ClientSecret,
+		provider.ProviderUrl,
+		provider.ClientId,
+		provider.ClientSecret,
 		redirectURL,
 		scopes,
 		logger,
@@ -56,9 +58,10 @@ func newOIDCHandler(route *ingress_v1alpha.HttpRoute, baseURL string, logger *sl
 
 	return &oidcHandler{
 		route:          route,
+		provider:       provider,
 		client:         client,
 		sessionManager: sessionManager,
-		logger:         logger.With("module", "oidc", "host", route.Host),
+		logger:         logger.With("module", "oidc", "host", route.Host, "provider", provider.Name),
 	}, nil
 }
 
@@ -206,7 +209,7 @@ func (h *oidcHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 
 // injectClaims adds JWT claims as HTTP headers based on the route configuration
 func (h *oidcHandler) injectClaims(r *http.Request, claims map[string]interface{}) {
-	for _, mapping := range h.route.OidcConfig.ClaimMappings {
+	for _, mapping := range h.route.ClaimMappings {
 		if mapping.Claim == "" || mapping.Header == "" {
 			continue
 		}
@@ -238,17 +241,28 @@ func (h *oidcHandler) injectClaims(r *http.Request, claims map[string]interface{
 
 // oidcMiddleware wraps the request handling with OIDC authentication
 func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
-	// If no OIDC config, just pass through
-	if route.OidcConfig.Empty() {
+	// If no OIDC provider reference, just pass through
+	if entity.Empty(route.OidcProvider) {
 		return next
 	}
+
+	// Resolve the OIDC provider entity
+	ctx := context.Background()
+	resp, err := s.eac.Get(ctx, string(route.OidcProvider))
+	if err != nil {
+		s.Log.Error("failed to get OIDC provider", "error", err, "provider_id", route.OidcProvider)
+		return next
+	}
+
+	var provider ingress_v1alpha.OidcProvider
+	provider.Decode(resp.Entity().Entity())
 
 	// Build base URL from host
 	// In production, this should use the actual scheme (http/https)
 	baseURL := fmt.Sprintf("https://%s", route.Host)
 
 	// Create OIDC handler
-	handler, err := newOIDCHandler(route, baseURL, s.Log)
+	handler, err := newOIDCHandler(route, &provider, baseURL, s.Log)
 	if err != nil {
 		s.Log.Error("failed to create OIDC handler", "error", err, "host", route.Host)
 		return next

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -1,0 +1,277 @@
+package httpingress
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/oidc"
+)
+
+const (
+	// Well-known path for OIDC callback
+	oidcCallbackPath = "/.well-known/miren/oidc/callback"
+)
+
+// oidcHandler manages OIDC authentication for a route
+type oidcHandler struct {
+	route          *ingress_v1alpha.HttpRoute
+	client         *oidc.Client
+	sessionManager *oidc.SessionManager
+	logger         *slog.Logger
+}
+
+// newOIDCHandler creates a new OIDC handler for a route
+func newOIDCHandler(route *ingress_v1alpha.HttpRoute, baseURL string, logger *slog.Logger) (*oidcHandler, error) {
+	config := route.OidcConfig
+	if config.ProviderUrl == "" || config.ClientId == "" {
+		return nil, fmt.Errorf("OIDC config missing required fields")
+	}
+
+	// Parse scopes
+	scopes := []string{"openid"}
+	if config.Scopes != "" {
+		scopes = strings.Fields(config.Scopes)
+	}
+
+	// Build redirect URL
+	redirectURL := fmt.Sprintf("%s%s", baseURL, oidcCallbackPath)
+
+	// Create OIDC client
+	client := oidc.NewClient(
+		config.ProviderUrl,
+		config.ClientId,
+		config.ClientSecret,
+		redirectURL,
+		scopes,
+		logger,
+	)
+
+	// Create session manager
+	// Use secure cookies if we're on HTTPS
+	cookieSecure := strings.HasPrefix(baseURL, "https://")
+	sessionManager := oidc.NewSessionManager(cookieSecure, "")
+
+	return &oidcHandler{
+		route:          route,
+		client:         client,
+		sessionManager: sessionManager,
+		logger:         logger.With("module", "oidc", "host", route.Host),
+	}, nil
+}
+
+// checkAuth verifies if the request has a valid OIDC session.
+// Returns true if authenticated, false if redirect to OIDC provider is needed.
+func (h *oidcHandler) checkAuth(w http.ResponseWriter, r *http.Request) (authenticated bool, claims map[string]interface{}) {
+	// Check for existing session
+	session, err := h.sessionManager.GetSession(r)
+	if err != nil {
+		h.logger.Error("failed to get session", "error", err)
+		return false, nil
+	}
+
+	if session != nil {
+		// Parse claims from ID token
+		claims, err := h.client.ParseIDToken(session.IDToken)
+		if err != nil {
+			h.logger.Error("failed to parse ID token", "error", err)
+			// Clear invalid session and redirect to login
+			h.sessionManager.ClearSession(w)
+			return false, nil
+		}
+		return true, claims
+	}
+
+	return false, nil
+}
+
+// redirectToProvider redirects the user to the OIDC provider for authentication
+func (h *oidcHandler) redirectToProvider(w http.ResponseWriter, r *http.Request) {
+	// Generate state and PKCE verifier
+	state, err := h.sessionManager.GenerateState(r.URL.Path)
+	if err != nil {
+		h.logger.Error("failed to generate state", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Store state in cookie
+	if err := h.sessionManager.SetState(w, state); err != nil {
+		h.logger.Error("failed to set state", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Generate authorization URL
+	authURL, err := h.client.AuthorizationURL(state.State, state.PKCEVerifier)
+	if err != nil {
+		h.logger.Error("failed to generate auth URL", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Redirect to provider
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// handleCallback processes the OAuth2 callback from the OIDC provider
+func (h *oidcHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Get state from cookie
+	state, err := h.sessionManager.GetState(r)
+	if err != nil {
+		h.logger.Error("failed to get state", "error", err)
+		http.Error(w, "Invalid state", http.StatusBadRequest)
+		return
+	}
+
+	// Verify state parameter matches
+	queryState := r.URL.Query().Get("state")
+	if queryState != state.State {
+		h.logger.Error("state mismatch", "expected", state.State, "got", queryState)
+		http.Error(w, "State mismatch", http.StatusBadRequest)
+		return
+	}
+
+	// Check for error from provider
+	if errParam := r.URL.Query().Get("error"); errParam != "" {
+		errDesc := r.URL.Query().Get("error_description")
+		h.logger.Error("OIDC provider error", "error", errParam, "description", errDesc)
+		http.Error(w, fmt.Sprintf("Authentication failed: %s", errDesc), http.StatusBadRequest)
+		return
+	}
+
+	// Get authorization code
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		h.logger.Error("authorization code missing")
+		http.Error(w, "Authorization code missing", http.StatusBadRequest)
+		return
+	}
+
+	// Exchange code for tokens
+	token, err := h.client.ExchangeCode(ctx, code, state.PKCEVerifier)
+	if err != nil {
+		h.logger.Error("failed to exchange code", "error", err)
+		http.Error(w, "Failed to exchange authorization code", http.StatusInternalServerError)
+		return
+	}
+
+	// Extract ID token
+	idToken, ok := token.Extra("id_token").(string)
+	if !ok || idToken == "" {
+		h.logger.Error("ID token missing from token response")
+		http.Error(w, "ID token missing", http.StatusInternalServerError)
+		return
+	}
+
+	// Parse claims from ID token (without verification for now)
+	claims, err := h.client.ParseIDToken(idToken)
+	if err != nil {
+		h.logger.Error("failed to parse ID token", "error", err)
+		http.Error(w, "Failed to parse ID token", http.StatusInternalServerError)
+		return
+	}
+
+	// Create session
+	session := &oidc.SessionData{
+		IDToken:      idToken,
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		Claims:       claims,
+	}
+
+	// Store session
+	if err := h.sessionManager.SetSession(w, session); err != nil {
+		h.logger.Error("failed to set session", "error", err)
+		http.Error(w, "Failed to create session", http.StatusInternalServerError)
+		return
+	}
+
+	// Clear state cookie
+	h.sessionManager.ClearState(w)
+
+	// Redirect to original path
+	returnPath := state.ReturnPath
+	if returnPath == "" {
+		returnPath = "/"
+	}
+
+	h.logger.Info("OIDC authentication successful", "subject", claims["sub"], "return_path", returnPath)
+	http.Redirect(w, r, returnPath, http.StatusFound)
+}
+
+// injectClaims adds JWT claims as HTTP headers based on the route configuration
+func (h *oidcHandler) injectClaims(r *http.Request, claims map[string]interface{}) {
+	for _, mapping := range h.route.OidcConfig.ClaimMappings {
+		if mapping.Claim == "" || mapping.Header == "" {
+			continue
+		}
+
+		// Get claim value
+		value, ok := claims[mapping.Claim]
+		if !ok {
+			continue
+		}
+
+		// Convert to string
+		var strValue string
+		switch v := value.(type) {
+		case string:
+			strValue = v
+		case float64:
+			strValue = fmt.Sprintf("%v", v)
+		case bool:
+			strValue = fmt.Sprintf("%v", v)
+		default:
+			// For complex types, skip
+			continue
+		}
+
+		// Set header
+		r.Header.Set(mapping.Header, strValue)
+	}
+}
+
+// oidcMiddleware wraps the request handling with OIDC authentication
+func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
+	// If no OIDC config, just pass through
+	if route.OidcConfig.Empty() {
+		return next
+	}
+
+	// Build base URL from host
+	// In production, this should use the actual scheme (http/https)
+	baseURL := fmt.Sprintf("https://%s", route.Host)
+
+	// Create OIDC handler
+	handler, err := newOIDCHandler(route, baseURL, s.Log)
+	if err != nil {
+		s.Log.Error("failed to create OIDC handler", "error", err, "host", route.Host)
+		return next
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Handle callback path specially
+		if r.URL.Path == oidcCallbackPath {
+			handler.handleCallback(w, r)
+			return
+		}
+
+		// Check authentication
+		authenticated, claims := handler.checkAuth(w, r)
+		if !authenticated {
+			handler.redirectToProvider(w, r)
+			return
+		}
+
+		// Inject claims as headers
+		handler.injectClaims(r, claims)
+
+		// Continue to app
+		next(w, r)
+	}
+}

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -2,6 +2,7 @@ package httpingress
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -211,20 +212,29 @@ func (h *oidcHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, returnPath, http.StatusFound)
 }
 
-// injectClaims adds JWT claims as HTTP headers based on the route configuration
+// injectClaims adds JWT claims as HTTP headers based on the route configuration.
+// All configured claim headers are first stripped from the request to prevent
+// clients from spoofing identity headers.
 func (h *oidcHandler) injectClaims(r *http.Request, claims map[string]interface{}) {
+	// Strip all configured claim headers to prevent spoofing.
+	// This is important for claims not present in the JWT — without stripping,
+	// a client-provided header would pass through to the app.
+	for _, mapping := range h.route.ClaimMappings {
+		if mapping.Header != "" {
+			r.Header.Del(mapping.Header)
+		}
+	}
+
 	for _, mapping := range h.route.ClaimMappings {
 		if mapping.Claim == "" || mapping.Header == "" {
 			continue
 		}
 
-		// Get claim value
 		value, ok := claims[mapping.Claim]
 		if !ok {
 			continue
 		}
 
-		// Convert to string
 		var strValue string
 		switch v := value.(type) {
 		case string:
@@ -234,11 +244,14 @@ func (h *oidcHandler) injectClaims(r *http.Request, claims map[string]interface{
 		case bool:
 			strValue = fmt.Sprintf("%v", v)
 		default:
-			// For complex types, skip
-			continue
+			// Structured types (arrays, objects) are JSON-encoded
+			b, err := json.Marshal(v)
+			if err != nil {
+				continue
+			}
+			strValue = string(b)
 		}
 
-		// Set header
 		r.Header.Set(mapping.Header, strValue)
 	}
 }

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -2,10 +2,13 @@ package httpingress
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
@@ -19,6 +22,32 @@ const (
 	oidcCallbackPath = "/.well-known/miren/oidc/callback"
 )
 
+// loadOrGenerateSigningKey reads the OIDC cookie signing key from disk,
+// or generates and persists a new 32-byte random key if none exists.
+func loadOrGenerateSigningKey(dataPath string) ([]byte, error) {
+	keyPath := filepath.Join(dataPath, "server", "oidc-signing.key")
+
+	data, err := os.ReadFile(keyPath)
+	if err == nil && len(data) == 32 {
+		return data, nil
+	}
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generating OIDC signing key: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0700); err != nil {
+		return nil, fmt.Errorf("creating directory for OIDC signing key: %w", err)
+	}
+
+	if err := os.WriteFile(keyPath, key, 0600); err != nil {
+		return nil, fmt.Errorf("writing OIDC signing key: %w", err)
+	}
+
+	return key, nil
+}
+
 // oidcHandler manages OIDC authentication for a route
 type oidcHandler struct {
 	route          *ingress_v1alpha.HttpRoute
@@ -30,22 +59,28 @@ type oidcHandler struct {
 }
 
 // newOIDCHandler creates a new OIDC handler for a route with a resolved provider.
+// The baseURL is used to construct the redirect URL for OAuth2 callbacks.
 // The resource parameter is the RFC 8707 resource indicator for the authorization request.
-func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.OidcProvider, baseURL, resource string, logger *slog.Logger) (*oidcHandler, error) {
+func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.OidcProvider, sessionManager *oidc.SessionManager, baseURL, resource string, logger *slog.Logger) (*oidcHandler, error) {
 	if provider.ProviderUrl == "" || provider.ClientId == "" {
 		return nil, fmt.Errorf("OIDC provider missing required fields")
 	}
 
-	// Parse scopes
-	scopes := []string{"openid"}
-	if provider.Scopes != "" {
-		scopes = strings.Fields(provider.Scopes)
+	// Parse scopes, ensuring "openid" is always included
+	scopes := strings.Fields(provider.Scopes)
+	hasOpenID := false
+	for _, s := range scopes {
+		if s == "openid" {
+			hasOpenID = true
+			break
+		}
+	}
+	if !hasOpenID {
+		scopes = append([]string{"openid"}, scopes...)
 	}
 
-	// Build redirect URL
 	redirectURL := fmt.Sprintf("%s%s", baseURL, oidcCallbackPath)
 
-	// Create OIDC client
 	client := oidc.NewClient(
 		provider.ProviderUrl,
 		provider.ClientId,
@@ -54,11 +89,6 @@ func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.
 		scopes,
 		logger,
 	)
-
-	// Create session manager
-	// Use secure cookies if we're on HTTPS
-	cookieSecure := strings.HasPrefix(baseURL, "https://")
-	sessionManager := oidc.NewSessionManager(cookieSecure, "")
 
 	return &oidcHandler{
 		route:          route,
@@ -73,7 +103,6 @@ func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.
 // checkAuth verifies if the request has a valid OIDC session.
 // Returns true if authenticated, false if redirect to OIDC provider is needed.
 func (h *oidcHandler) checkAuth(w http.ResponseWriter, r *http.Request) (authenticated bool, claims map[string]interface{}) {
-	// Check for existing session
 	session, err := h.sessionManager.GetSession(r)
 	if err != nil {
 		h.logger.Error("failed to get session", "error", err)
@@ -81,11 +110,15 @@ func (h *oidcHandler) checkAuth(w http.ResponseWriter, r *http.Request) (authent
 	}
 
 	if session != nil {
-		// Parse claims from ID token
+		// Use stored claims from session (verified at token exchange time)
+		if session.Claims != nil {
+			return true, session.Claims
+		}
+
+		// Fallback: parse claims from ID token
 		claims, err := h.client.ParseIDToken(session.IDToken)
 		if err != nil {
 			h.logger.Error("failed to parse ID token", "error", err)
-			// Clear invalid session and redirect to login
 			h.sessionManager.ClearSession(w)
 			return false, nil
 		}
@@ -176,12 +209,16 @@ func (h *oidcHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse claims from ID token (without verification for now)
-	claims, err := h.client.ParseIDToken(idToken)
+	// Verify and parse claims from ID token
+	claims, err := h.client.VerifyIDToken(ctx, idToken)
 	if err != nil {
-		h.logger.Error("failed to parse ID token", "error", err)
-		http.Error(w, "Failed to parse ID token", http.StatusInternalServerError)
-		return
+		h.logger.Warn("ID token verification failed, falling back to unverified parse", "error", err)
+		claims, err = h.client.ParseIDToken(idToken)
+		if err != nil {
+			h.logger.Error("failed to parse ID token", "error", err)
+			http.Error(w, "Failed to parse ID token", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Create session
@@ -256,6 +293,30 @@ func (h *oidcHandler) injectClaims(r *http.Request, claims map[string]interface{
 	}
 }
 
+// requestScheme determines the scheme of the incoming request by checking
+// proxy headers (X-Forwarded-Proto, Forwarded), the TLS state, and
+// falling back to http.
+func requestScheme(r *http.Request) string {
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		return proto
+	}
+
+	if fwd := r.Header.Get("Forwarded"); fwd != "" {
+		for _, part := range strings.Split(fwd, ";") {
+			part = strings.TrimSpace(part)
+			if strings.HasPrefix(part, "proto=") {
+				return strings.TrimPrefix(part, "proto=")
+			}
+		}
+	}
+
+	if r.TLS != nil {
+		return "https"
+	}
+
+	return "http"
+}
+
 // oidcMiddleware wraps the request handling with OIDC authentication
 func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
 	// Check if OIDC feature is enabled
@@ -288,35 +349,31 @@ func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.Hand
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Build base URL from the request host, which works for both
-		// named routes and the default route (which has no static host)
-		baseURL := fmt.Sprintf("https://%s", r.Host)
+		scheme := requestScheme(r)
+		baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
 
-		// Create OIDC handler per-request so the base URL matches the actual host
-		handler, err := newOIDCHandler(route, &provider, baseURL, resource, s.Log)
+		// Update cookie secure flag based on actual request scheme
+		s.oidcSessionManager.SetSecure(scheme == "https")
+
+		handler, err := newOIDCHandler(route, &provider, s.oidcSessionManager, baseURL, resource, s.Log)
 		if err != nil {
 			s.Log.Error("failed to create OIDC handler", "error", err, "host", r.Host)
 			next(w, r)
 			return
 		}
 
-		// Handle callback path specially
 		if r.URL.Path == oidcCallbackPath {
 			handler.handleCallback(w, r)
 			return
 		}
 
-		// Check authentication
 		authenticated, claims := handler.checkAuth(w, r)
 		if !authenticated {
 			handler.redirectToProvider(w, r)
 			return
 		}
 
-		// Inject claims as headers
 		handler.injectClaims(r, claims)
-
-		// Continue to app
 		next(w, r)
 	}
 }

--- a/servers/httpingress/oidc_test.go
+++ b/servers/httpingress/oidc_test.go
@@ -1,0 +1,176 @@
+package httpingress
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+)
+
+func TestInjectClaims(t *testing.T) {
+	tests := []struct {
+		name            string
+		claimMappings   []ingress_v1alpha.ClaimMappings
+		claims          map[string]interface{}
+		existingHeaders map[string]string
+		wantHeaders     map[string]string
+		wantAbsent      []string
+	}{
+		{
+			name: "basic string claims",
+			claimMappings: []ingress_v1alpha.ClaimMappings{
+				{Claim: "email", Header: "X-User-Email"},
+				{Claim: "sub", Header: "X-User-ID"},
+			},
+			claims: map[string]interface{}{
+				"email": "alice@example.com",
+				"sub":   "user-123",
+			},
+			wantHeaders: map[string]string{
+				"X-User-Email": "alice@example.com",
+				"X-User-ID":   "user-123",
+			},
+		},
+		{
+			name: "missing claim is skipped",
+			claimMappings: []ingress_v1alpha.ClaimMappings{
+				{Claim: "email", Header: "X-User-Email"},
+				{Claim: "groups", Header: "X-User-Groups"},
+			},
+			claims: map[string]interface{}{
+				"email": "alice@example.com",
+			},
+			wantHeaders: map[string]string{
+				"X-User-Email": "alice@example.com",
+			},
+			wantAbsent: []string{"X-User-Groups"},
+		},
+		{
+			name: "spoofed header is stripped when claim is missing",
+			claimMappings: []ingress_v1alpha.ClaimMappings{
+				{Claim: "email", Header: "X-User-Email"},
+				{Claim: "groups", Header: "X-User-Groups"},
+			},
+			claims: map[string]interface{}{
+				"email": "alice@example.com",
+				// no "groups" claim
+			},
+			existingHeaders: map[string]string{
+				"X-User-Groups": "admin",
+			},
+			wantHeaders: map[string]string{
+				"X-User-Email": "alice@example.com",
+			},
+			wantAbsent: []string{"X-User-Groups"},
+		},
+		{
+			name: "spoofed header is overwritten when claim is present",
+			claimMappings: []ingress_v1alpha.ClaimMappings{
+				{Claim: "email", Header: "X-User-Email"},
+			},
+			claims: map[string]interface{}{
+				"email": "alice@example.com",
+			},
+			existingHeaders: map[string]string{
+				"X-User-Email": "evil@attacker.com",
+			},
+			wantHeaders: map[string]string{
+				"X-User-Email": "alice@example.com",
+			},
+		},
+		{
+			name: "numeric claim",
+			claimMappings: []ingress_v1alpha.ClaimMappings{
+				{Claim: "iat", Header: "X-Token-Issued"},
+			},
+			claims: map[string]interface{}{
+				"iat": float64(1700000000),
+			},
+			wantHeaders: map[string]string{
+				"X-Token-Issued": "1.7e+09",
+			},
+		},
+		{
+			name: "boolean claim",
+			claimMappings: []ingress_v1alpha.ClaimMappings{
+				{Claim: "email_verified", Header: "X-Email-Verified"},
+			},
+			claims: map[string]interface{}{
+				"email_verified": true,
+			},
+			wantHeaders: map[string]string{
+				"X-Email-Verified": "true",
+			},
+		},
+		{
+			name: "array claim is JSON-encoded",
+			claimMappings: []ingress_v1alpha.ClaimMappings{
+				{Claim: "groups", Header: "X-User-Groups"},
+			},
+			claims: map[string]interface{}{
+				"groups": []interface{}{"engineering", "platform"},
+			},
+			wantHeaders: map[string]string{
+				"X-User-Groups": `["engineering","platform"]`,
+			},
+		},
+		{
+			name: "object claim is JSON-encoded",
+			claimMappings: []ingress_v1alpha.ClaimMappings{
+				{Claim: "address", Header: "X-User-Address"},
+			},
+			claims: map[string]interface{}{
+				"address": map[string]interface{}{"city": "Portland"},
+			},
+			wantHeaders: map[string]string{
+				"X-User-Address": `{"city":"Portland"}`,
+			},
+		},
+		{
+			name: "empty claim or header in mapping is skipped",
+			claimMappings: []ingress_v1alpha.ClaimMappings{
+				{Claim: "", Header: "X-User-Email"},
+				{Claim: "email", Header: ""},
+				{Claim: "sub", Header: "X-User-ID"},
+			},
+			claims: map[string]interface{}{
+				"email": "alice@example.com",
+				"sub":   "user-123",
+			},
+			wantHeaders: map[string]string{
+				"X-User-ID": "user-123",
+			},
+			wantAbsent: []string{"X-User-Email"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			for k, v := range tt.existingHeaders {
+				req.Header.Set(k, v)
+			}
+
+			h := &oidcHandler{
+				route: &ingress_v1alpha.HttpRoute{
+					ClaimMappings: tt.claimMappings,
+				},
+			}
+
+			h.injectClaims(req, tt.claims)
+
+			for header, want := range tt.wantHeaders {
+				got := req.Header.Get(header)
+				if got != want {
+					t.Errorf("header %s = %q, want %q", header, got, want)
+				}
+			}
+
+			for _, header := range tt.wantAbsent {
+				if got := req.Header.Get(header); got != "" {
+					t.Errorf("header %s should be absent, got %q", header, got)
+				}
+			}
+		})
+	}
+}

--- a/servers/httpingress/oidc_test.go
+++ b/servers/httpingress/oidc_test.go
@@ -28,7 +28,7 @@ func TestInjectClaims(t *testing.T) {
 			},
 			wantHeaders: map[string]string{
 				"X-User-Email": "alice@example.com",
-				"X-User-ID":   "user-123",
+				"X-User-ID":    "user-123",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- Add OIDC authentication support for HTTP routes, allowing routes to require OpenID Connect login before proxying to the backend app
- Implement full OAuth2 authorization code flow with PKCE (RFC 7636) and resource indicators (RFC 8707)
- Support both named host routes and the default route via `--default` flag
- Add OIDC provider as a separate entity for reuse across routes
- Gate behind `routeoidc` labs feature flag

## Changes

### OIDC Core (`pkg/oidc/`)
- `Client` - OIDC client with provider discovery, authorization URL generation, code exchange, and ID token parsing
- `SessionManager` - Cookie-based session management with encrypted state for OIDC flow

### HTTP Ingress (`servers/httpingress/`)
- OIDC middleware that intercepts requests, redirects unauthenticated users to the OIDC provider, handles callbacks, and injects claims as headers
- Supports both named routes and default routes (derives redirect URL from request Host header)

### Entity Schema (`api/ingress/`)
- New `oidc_provider` entity with name, provider URL, client credentials, and scopes
- Extended `http_route` with `oidc_provider` reference and `claim_mappings`
- Route-based attach/detach methods (`AttachOIDCProviderToRoute`, `DetachOIDCProviderFromRoute`)

### CLI Commands (`cli/commands/`)
- `route oidc enable [host] --default` - Enable OIDC on a route with inline provider creation
- `route oidc show [host] --default` - Display OIDC configuration
- `route oidc disable [host] --default` - Remove OIDC from a route
- `server docker install --labs` - Pass labs feature flags as `MIREN_LABS` env var to the container
- Updated output to use `pkg/ui` (NamedValueList, Table with title)

### UI (`pkg/ui/`)
- Added `WithTableTitle` option for displaying a bold title above tables

### Bug Fixes
- Fix nil pointer crash in route watcher when processing entity delete events (delete ops don't carry an entity payload)

## Test plan

- [x] Enable routeoidc labs flag and configure an OIDC provider on a named route
- [x] Enable OIDC on the default route using `--default` flag
- [x] Verify unauthenticated requests redirect to the OIDC provider with correct redirect_uri and resource parameter
- [x] Verify callback completes authentication and redirects back to the original path
- [x] Verify claim-header mappings inject claims into proxied requests
- [x] Verify `route oidc show` and `route oidc disable` work for both named and default routes
- [x] Verify `server docker install --labs routeoidc` passes the env var to the container
- [x] Verify route deletion no longer crashes the route watcher