### PR TITLE
Fix disk space GC for BuildKit cache and registry blobs

### DIFF
--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -299,7 +299,6 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
   [[worker.oci.gcpolicy]]
     keepBytes = %d
     keepDuration = %d
-    filters = ["type==source.local", "type==exec.cachemount"]
 
 [registry."docker.io"]
   http = true

--- a/components/buildkit/config_test.go
+++ b/components/buildkit/config_test.go
@@ -1,0 +1,49 @@
+package buildkit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateConfig(t *testing.T) {
+	c := &Component{}
+	config := c.generateConfig(10*1024*1024*1024, 86400, "registry.example.com:5000")
+
+	t.Run("has single catch-all gcpolicy", func(t *testing.T) {
+		r := require.New(t)
+
+		count := strings.Count(config, "[[worker.oci.gcpolicy]]")
+		r.Equal(1, count, "should have exactly one gcpolicy block")
+	})
+
+	t.Run("policy has no filters (catch-all)", func(t *testing.T) {
+		r := require.New(t)
+
+		idx := strings.Index(config, "[[worker.oci.gcpolicy]]")
+		r.GreaterOrEqual(idx, 0, "gcpolicy block should be present in config")
+
+		block := config[idx:]
+		// Extract just the policy block (up to next section)
+		nextSection := strings.Index(block, "\n[registry")
+		if nextSection > 0 {
+			block = block[:nextSection]
+		}
+
+		r.NotContains(block, "filters")
+		r.Contains(block, "keepBytes")
+		r.Contains(block, "keepDuration")
+	})
+
+	t.Run("uses provided registry host", func(t *testing.T) {
+		r := require.New(t)
+		r.Contains(config, `[registry."registry.example.com:5000"]`)
+	})
+
+	t.Run("uses default registry host when empty", func(t *testing.T) {
+		r := require.New(t)
+		defaultConfig := c.generateConfig(10*1024*1024*1024, 86400, "")
+		r.Contains(defaultConfig, `[registry."cluster.local:5000"]`)
+	})
+}

--- a/controllers/sandbox/blob_gc.go
+++ b/controllers/sandbox/blob_gc.go
@@ -1,0 +1,138 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// BlobGCResult contains information about blobs cleaned up during GC.
+type BlobGCResult struct {
+	DeletedBlobs  []string
+	FailedBlobs   map[string]error
+	TotalBlobs    int
+	RetainedBlobs int
+}
+
+// ociManifest is a minimal OCI image manifest for extracting blob digests.
+type ociManifest struct {
+	Config ociDescriptor   `json:"config"`
+	Layers []ociDescriptor `json:"layers"`
+}
+
+type ociDescriptor struct {
+	Digest string `json:"digest"`
+}
+
+// RunBlobGC performs garbage collection of unreferenced registry blobs.
+// It compares blob files on disk against digests referenced by non-archived
+// artifacts and deletes any that are no longer needed.
+func (w *ImageWatchdog) RunBlobGC(ctx context.Context) (*BlobGCResult, error) {
+	result := &BlobGCResult{
+		DeletedBlobs: []string{},
+		FailedBlobs:  make(map[string]error),
+	}
+
+	blobsDir := filepath.Join(w.DataPath, "registry", "blobs")
+
+	entries, err := os.ReadDir(blobsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result, nil
+		}
+		return result, fmt.Errorf("failed to read blobs directory: %w", err)
+	}
+
+	result.TotalBlobs = len(entries)
+
+	referenced, err := w.collectReferencedBlobDigests(ctx)
+	if err != nil {
+		return result, fmt.Errorf("failed to collect referenced blob digests: %w", err)
+	}
+
+	now := time.Now()
+
+	for _, entry := range entries {
+		name := entry.Name()
+
+		// Skip recently modified files to guard against concurrent uploads
+		info, err := entry.Info()
+		if err != nil {
+			result.FailedBlobs[name] = err
+			result.RetainedBlobs++
+			continue
+		}
+		if now.Sub(info.ModTime()) < 1*time.Hour {
+			result.RetainedBlobs++
+			continue
+		}
+
+		if referenced[name] {
+			result.RetainedBlobs++
+			continue
+		}
+
+		// Blob is unreferenced and old enough - delete it
+		blobPath := filepath.Join(blobsDir, name)
+		if err := os.Remove(blobPath); err != nil {
+			result.FailedBlobs[name] = err
+		} else {
+			result.DeletedBlobs = append(result.DeletedBlobs, name)
+		}
+	}
+
+	return result, nil
+}
+
+// collectReferencedBlobDigests returns the set of blob digests referenced by
+// non-archived artifacts. Artifacts with empty status (legacy) are treated as
+// active to be safe.
+func (w *ImageWatchdog) collectReferencedBlobDigests(ctx context.Context) (map[string]bool, error) {
+	digests := make(map[string]bool)
+
+	resp, err := w.EAC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindArtifact))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list artifacts: %w", err)
+	}
+
+	for _, e := range resp.Values() {
+		var art core_v1alpha.Artifact
+		art.Decode(e.Entity())
+
+		// Only skip explicitly archived artifacts
+		if art.Status == core_v1alpha.ARCHIVED {
+			continue
+		}
+
+		if art.Manifest == "" {
+			continue
+		}
+
+		var manifest ociManifest
+		if err := json.Unmarshal([]byte(art.Manifest), &manifest); err != nil {
+			w.Log.Warn("failed to parse artifact manifest, skipping blob cleanup for this artifact",
+				"artifact", string(art.ID), "error", err)
+			// Skip this artifact - its blobs may be deleted if not referenced by other artifacts.
+			// This trades safety for availability: one bad manifest doesn't block all GC.
+			continue
+		}
+
+		if manifest.Config.Digest != "" {
+			digests[manifest.Config.Digest] = true
+		}
+		for _, layer := range manifest.Layers {
+			if layer.Digest != "" {
+				digests[layer.Digest] = true
+			}
+		}
+	}
+
+	w.Log.Debug("collected referenced blob digests", "count", len(digests))
+	return digests, nil
+}

--- a/controllers/sandbox/blob_gc_test.go
+++ b/controllers/sandbox/blob_gc_test.go
@@ -1,0 +1,287 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	entitytestutils "miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/idgen"
+)
+
+func makeManifest(t *testing.T, configDigest string, layerDigests ...string) string {
+	t.Helper()
+	m := ociManifest{
+		Config: ociDescriptor{Digest: configDigest},
+	}
+	for _, d := range layerDigests {
+		m.Layers = append(m.Layers, ociDescriptor{Digest: d})
+	}
+	b, err := json.Marshal(m)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func createArtifact(t *testing.T, eac *entityserver_v1alpha.EntityAccessClient, status core_v1alpha.ArtifactStatus, manifest string) entity.Id {
+	t.Helper()
+	name := idgen.GenNS("a")
+	artID := entity.Id("artifact/" + name)
+	art := &core_v1alpha.Artifact{
+		ID:       artID,
+		Manifest: manifest,
+		Status:   status,
+	}
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetId(artID.String())
+	rpcE.SetAttrs(entity.New(entity.DBId, artID, art.Encode).Attrs())
+	_, err := eac.Put(context.Background(), &rpcE)
+	require.NoError(t, err)
+	return artID
+}
+
+func createBlobFile(t *testing.T, blobsDir, digest string, modTime time.Time) {
+	t.Helper()
+	path := filepath.Join(blobsDir, digest)
+	require.NoError(t, os.WriteFile(path, []byte("blob-content"), 0644))
+	require.NoError(t, os.Chtimes(path, modTime, modTime))
+}
+
+func TestRunBlobGC(t *testing.T) {
+	entServer, cleanup := entitytestutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	eac := entServer.EAC
+	log := entitytestutils.TestLogger(t)
+	oldTime := time.Now().Add(-2 * time.Hour)
+
+	t.Run("deletes unreferenced blobs", func(t *testing.T) {
+		r := require.New(t)
+		tmpDir := t.TempDir()
+		blobsDir := filepath.Join(tmpDir, "registry", "blobs")
+		r.NoError(os.MkdirAll(blobsDir, 0755))
+
+		createBlobFile(t, blobsDir, "sha256:orphan1", oldTime)
+		createBlobFile(t, blobsDir, "sha256:orphan2", oldTime)
+
+		watchdog := &ImageWatchdog{
+			Log:      log,
+			EAC:      eac,
+			DataPath: tmpDir,
+			Config:   DefaultImageGCConfig(),
+		}
+
+		result, err := watchdog.RunBlobGC(context.Background())
+		r.NoError(err)
+		r.ElementsMatch([]string{"sha256:orphan1", "sha256:orphan2"}, result.DeletedBlobs)
+		r.Equal(0, result.RetainedBlobs)
+		r.Equal(2, result.TotalBlobs)
+	})
+
+	t.Run("keeps blobs referenced by active artifacts", func(t *testing.T) {
+		r := require.New(t)
+		tmpDir := t.TempDir()
+		blobsDir := filepath.Join(tmpDir, "registry", "blobs")
+		r.NoError(os.MkdirAll(blobsDir, 0755))
+
+		manifest := makeManifest(t, "sha256:config1", "sha256:layer1", "sha256:layer2")
+		createArtifact(t, eac, core_v1alpha.ACTIVE, manifest)
+
+		createBlobFile(t, blobsDir, "sha256:config1", oldTime)
+		createBlobFile(t, blobsDir, "sha256:layer1", oldTime)
+		createBlobFile(t, blobsDir, "sha256:layer2", oldTime)
+		createBlobFile(t, blobsDir, "sha256:orphan", oldTime)
+
+		watchdog := &ImageWatchdog{
+			Log:      log,
+			EAC:      eac,
+			DataPath: tmpDir,
+			Config:   DefaultImageGCConfig(),
+		}
+
+		result, err := watchdog.RunBlobGC(context.Background())
+		r.NoError(err)
+		r.Equal([]string{"sha256:orphan"}, result.DeletedBlobs)
+		r.Equal(3, result.RetainedBlobs)
+	})
+
+	t.Run("keeps blobs referenced by legacy (empty status) artifacts", func(t *testing.T) {
+		r := require.New(t)
+		tmpDir := t.TempDir()
+		blobsDir := filepath.Join(tmpDir, "registry", "blobs")
+		r.NoError(os.MkdirAll(blobsDir, 0755))
+
+		manifest := makeManifest(t, "sha256:legacyconfig", "sha256:legacylayer")
+		createArtifact(t, eac, "", manifest) // Empty status = legacy
+
+		createBlobFile(t, blobsDir, "sha256:legacyconfig", oldTime)
+		createBlobFile(t, blobsDir, "sha256:legacylayer", oldTime)
+
+		watchdog := &ImageWatchdog{
+			Log:      log,
+			EAC:      eac,
+			DataPath: tmpDir,
+			Config:   DefaultImageGCConfig(),
+		}
+
+		result, err := watchdog.RunBlobGC(context.Background())
+		r.NoError(err)
+		r.Empty(result.DeletedBlobs)
+		r.Equal(2, result.RetainedBlobs)
+	})
+
+	t.Run("deletes blobs only referenced by archived artifacts", func(t *testing.T) {
+		r := require.New(t)
+		tmpDir := t.TempDir()
+		blobsDir := filepath.Join(tmpDir, "registry", "blobs")
+		r.NoError(os.MkdirAll(blobsDir, 0755))
+
+		manifest := makeManifest(t, "sha256:archivedconfig", "sha256:archivedlayer")
+		createArtifact(t, eac, core_v1alpha.ARCHIVED, manifest)
+
+		createBlobFile(t, blobsDir, "sha256:archivedconfig", oldTime)
+		createBlobFile(t, blobsDir, "sha256:archivedlayer", oldTime)
+
+		watchdog := &ImageWatchdog{
+			Log:      log,
+			EAC:      eac,
+			DataPath: tmpDir,
+			Config:   DefaultImageGCConfig(),
+		}
+
+		result, err := watchdog.RunBlobGC(context.Background())
+		r.NoError(err)
+		r.ElementsMatch([]string{"sha256:archivedconfig", "sha256:archivedlayer"}, result.DeletedBlobs)
+	})
+
+	t.Run("shared blobs retained if any active reference exists", func(t *testing.T) {
+		r := require.New(t)
+		tmpDir := t.TempDir()
+		blobsDir := filepath.Join(tmpDir, "registry", "blobs")
+		r.NoError(os.MkdirAll(blobsDir, 0755))
+
+		sharedLayer := "sha256:sharedlayer"
+
+		// Active artifact references the shared layer
+		activeManifest := makeManifest(t, "sha256:activeconf", sharedLayer)
+		createArtifact(t, eac, core_v1alpha.ACTIVE, activeManifest)
+
+		// Archived artifact also references the shared layer
+		archivedManifest := makeManifest(t, "sha256:archconf", sharedLayer)
+		createArtifact(t, eac, core_v1alpha.ARCHIVED, archivedManifest)
+
+		createBlobFile(t, blobsDir, "sha256:activeconf", oldTime)
+		createBlobFile(t, blobsDir, sharedLayer, oldTime)
+		createBlobFile(t, blobsDir, "sha256:archconf", oldTime)
+
+		watchdog := &ImageWatchdog{
+			Log:      log,
+			EAC:      eac,
+			DataPath: tmpDir,
+			Config:   DefaultImageGCConfig(),
+		}
+
+		result, err := watchdog.RunBlobGC(context.Background())
+		r.NoError(err)
+		// Shared layer retained because active artifact references it
+		r.NotContains(result.DeletedBlobs, sharedLayer)
+		// Active artifact's config retained
+		r.NotContains(result.DeletedBlobs, "sha256:activeconf")
+		// Archived artifact's exclusive config deleted
+		r.Contains(result.DeletedBlobs, "sha256:archconf")
+	})
+
+	t.Run("handles empty blobs directory", func(t *testing.T) {
+		r := require.New(t)
+		tmpDir := t.TempDir()
+		blobsDir := filepath.Join(tmpDir, "registry", "blobs")
+		r.NoError(os.MkdirAll(blobsDir, 0755))
+
+		watchdog := &ImageWatchdog{
+			Log:      log,
+			EAC:      eac,
+			DataPath: tmpDir,
+			Config:   DefaultImageGCConfig(),
+		}
+
+		result, err := watchdog.RunBlobGC(context.Background())
+		r.NoError(err)
+		r.Empty(result.DeletedBlobs)
+		r.Equal(0, result.TotalBlobs)
+	})
+
+	t.Run("handles missing blobs directory", func(t *testing.T) {
+		r := require.New(t)
+		tmpDir := t.TempDir()
+
+		watchdog := &ImageWatchdog{
+			Log:      log,
+			EAC:      eac,
+			DataPath: tmpDir,
+			Config:   DefaultImageGCConfig(),
+		}
+
+		result, err := watchdog.RunBlobGC(context.Background())
+		r.NoError(err)
+		r.Empty(result.DeletedBlobs)
+		r.Equal(0, result.TotalBlobs)
+	})
+
+	t.Run("handles malformed manifest", func(t *testing.T) {
+		r := require.New(t)
+		tmpDir := t.TempDir()
+		blobsDir := filepath.Join(tmpDir, "registry", "blobs")
+		r.NoError(os.MkdirAll(blobsDir, 0755))
+
+		// Create artifact with invalid manifest - since we can't parse what it
+		// references, its blobs may be deleted if not referenced elsewhere
+		createArtifact(t, eac, core_v1alpha.ACTIVE, "not-valid-json{{{")
+
+		createBlobFile(t, blobsDir, "sha256:someblob", oldTime)
+
+		watchdog := &ImageWatchdog{
+			Log:      log,
+			EAC:      eac,
+			DataPath: tmpDir,
+			Config:   DefaultImageGCConfig(),
+		}
+
+		result, err := watchdog.RunBlobGC(context.Background())
+		r.NoError(err)
+		// The orphan blob is deleted because we couldn't parse the manifest
+		// (malformed manifest is skipped, not treated as referencing all blobs)
+		r.Contains(result.DeletedBlobs, "sha256:someblob")
+	})
+
+	t.Run("skips recently modified blobs", func(t *testing.T) {
+		r := require.New(t)
+		tmpDir := t.TempDir()
+		blobsDir := filepath.Join(tmpDir, "registry", "blobs")
+		r.NoError(os.MkdirAll(blobsDir, 0755))
+
+		// Recent blob (within 1 hour) should be kept even if unreferenced
+		recentTime := time.Now().Add(-30 * time.Minute)
+		createBlobFile(t, blobsDir, "sha256:recent", recentTime)
+		createBlobFile(t, blobsDir, "sha256:old", oldTime)
+
+		watchdog := &ImageWatchdog{
+			Log:      log,
+			EAC:      eac,
+			DataPath: tmpDir,
+			Config:   DefaultImageGCConfig(),
+		}
+
+		result, err := watchdog.RunBlobGC(context.Background())
+		r.NoError(err)
+		r.NotContains(result.DeletedBlobs, "sha256:recent")
+		r.Contains(result.DeletedBlobs, "sha256:old")
+		r.Equal(1, result.RetainedBlobs)
+	})
+}

--- a/controllers/sandbox/image_gc.go
+++ b/controllers/sandbox/image_gc.go
@@ -133,10 +133,7 @@ func (w *ImageWatchdog) runGCWithLogging(ctx context.Context, trigger string) {
 	result, err := w.RunGC(ctx)
 	if err != nil {
 		w.Log.Error("image GC failed", "trigger", trigger, "error", err)
-		return
-	}
-
-	if len(result.DeletedImages) > 0 || len(result.FailedImages) > 0 {
+	} else if len(result.DeletedImages) > 0 || len(result.FailedImages) > 0 {
 		w.Log.Info("image GC complete",
 			"trigger", trigger,
 			"deleted", len(result.DeletedImages),
@@ -155,6 +152,31 @@ func (w *ImageWatchdog) runGCWithLogging(ctx context.Context, trigger string) {
 			"trigger", trigger,
 			"retained", result.RetainedImages,
 			"total", result.TotalImages)
+	}
+
+	// Run blob GC independently of image GC
+	blobResult, blobErr := w.RunBlobGC(ctx)
+	if blobErr != nil {
+		w.Log.Error("blob GC failed", "trigger", trigger, "error", blobErr)
+	} else if len(blobResult.DeletedBlobs) > 0 || len(blobResult.FailedBlobs) > 0 {
+		w.Log.Info("blob GC complete",
+			"trigger", trigger,
+			"deleted", len(blobResult.DeletedBlobs),
+			"failed", len(blobResult.FailedBlobs),
+			"retained", blobResult.RetainedBlobs,
+			"total", blobResult.TotalBlobs)
+
+		for _, blob := range blobResult.DeletedBlobs {
+			w.Log.Debug("deleted blob", "blob", blob)
+		}
+		for blob, err := range blobResult.FailedBlobs {
+			w.Log.Warn("failed to delete blob", "blob", blob, "error", err)
+		}
+	} else {
+		w.Log.Debug("blob GC complete, no blobs deleted",
+			"trigger", trigger,
+			"retained", blobResult.RetainedBlobs,
+			"total", blobResult.TotalBlobs)
 	}
 }
 


### PR DESCRIPTION
One of our internal clusters filled up — uncollected BuildKit cache and
orphaned registry blobs with no cleanup path.

**BuildKit cache**: The gcpolicy only had filters for `source.local` and
`exec.cachemount`, so regular build layers never got collected. Removed
the filters to make it a catch-all — the filtered types were a subset
anyway.

**Registry blobs**: Artifact GC archives artifacts and image GC cleans
up containerd images, but the actual blob files on disk were never
reaped. Added blob GC to the existing ImageWatchdog so it runs on the
same schedule (pressure checks + weekly). It collects digests referenced
by non-archived artifacts and deletes everything else, with a 1-hour
grace period for in-flight uploads.