### PR TITLE
Fix deployment cluster filter and improve app history defaults

### DIFF
--- a/cli/commands/app_history.go
+++ b/cli/commands/app_history.go
@@ -138,16 +138,7 @@ func buildDeploymentTable(deployments []*deployment_v1alpha.DeploymentInfo, opts
 		if opts.hasIdentity {
 			headers = append(headers, "DEPLOYED BY")
 		}
-		headers = append(headers, "WHEN", "GIT SHA", "BRANCH", "COMMIT MESSAGE")
-		builder = ui.Columns().
-			NoTruncate(0).               // STATUS
-			MaxWidth(len(headers)-1, 40) // COMMIT MESSAGE
-	} else {
-		headers = []string{"STATUS", "VERSION"}
-		if opts.hasIdentity {
-			headers = append(headers, "DEPLOYED BY")
-		}
-		headers = append(headers, "WHEN", "ID", "ERROR")
+		headers = append(headers, "WHEN", "ID", "ERROR", "GIT SHA", "BRANCH", "COMMIT MESSAGE")
 		// Find ID column index dynamically
 		idColIndex := -1
 		for i, h := range headers {
@@ -157,7 +148,16 @@ func buildDeploymentTable(deployments []*deployment_v1alpha.DeploymentInfo, opts
 			}
 		}
 		builder = ui.Columns().
-			NoTruncate(0, idColIndex) // STATUS and ID
+			NoTruncate(0, idColIndex).   // STATUS and ID
+			MaxWidth(len(headers)-1, 40) // COMMIT MESSAGE
+	} else {
+		headers = []string{"STATUS", "VERSION"}
+		if opts.hasIdentity {
+			headers = append(headers, "DEPLOYED BY")
+		}
+		headers = append(headers, "WHEN", "GIT SHA", "BRANCH")
+		builder = ui.Columns().
+			NoTruncate(0) // STATUS
 	}
 
 	for _, dep := range deployments {
@@ -184,9 +184,10 @@ func buildDeploymentRow(dep *deployment_v1alpha.DeploymentInfo, opts historyDisp
 
 	if opts.detailed {
 		gitSha, gitBranch, gitMessage := formatGitInfo(dep)
-		row = append(row, gitSha, gitBranch, gitMessage)
+		row = append(row, ui.CleanEntityID(dep.Id()), formatErrorInfo(dep, status), gitSha, gitBranch, gitMessage)
 	} else {
-		row = append(row, ui.CleanEntityID(dep.Id()), formatErrorInfo(dep, status))
+		gitSha, gitBranch, _ := formatGitInfo(dep)
+		row = append(row, gitSha, gitBranch)
 	}
 
 	return row

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -676,6 +676,9 @@ func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName,
 		if appName != "" && dep.AppName != appName {
 			continue
 		}
+		if clusterId != "" && dep.ClusterId != clusterId {
+			continue
+		}
 		if status != "" && dep.Status != status {
 			continue
 		}

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -832,3 +832,64 @@ func TestUpdateDeploymentStatusToInProgress(t *testing.T) {
 		t.Error("CompletedAt should not be set for in_progress deployment")
 	}
 }
+
+func TestListDeploymentsClusterFilter(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	logger := slog.Default()
+	server, err := NewDeploymentServer(logger, inmem.EAC)
+	if err != nil {
+		t.Fatalf("Failed to create deployment server: %v", err)
+	}
+
+	client := &deployment_v1alpha.DeploymentClient{
+		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
+	}
+
+	// Create deployments across different clusters
+	for _, d := range []*core_v1alpha.Deployment{
+		{AppName: "myapp", ClusterId: "cluster-a", AppVersion: "v1", Status: "active"},
+		{AppName: "myapp", ClusterId: "cluster-b", AppVersion: "v2", Status: "active"},
+		{AppName: "myapp", ClusterId: "cluster-a", AppVersion: "v3", Status: "succeeded"},
+	} {
+		name := d.AppName + "-" + d.ClusterId + "-" + d.AppVersion
+		if _, err := inmem.Client.Create(ctx, name, d); err != nil {
+			t.Fatalf("Failed to create deployment: %v", err)
+		}
+	}
+
+	// Without cluster filter: should return all 3
+	result, err := client.ListDeployments(ctx, "myapp", "", "", 0)
+	if err != nil {
+		t.Fatalf("ListDeployments failed: %v", err)
+	}
+	if len(result.Deployments()) != 3 {
+		t.Errorf("Expected 3 deployments without cluster filter, got %d", len(result.Deployments()))
+	}
+
+	// With cluster-a filter: should return 2
+	result, err = client.ListDeployments(ctx, "myapp", "cluster-a", "", 0)
+	if err != nil {
+		t.Fatalf("ListDeployments failed: %v", err)
+	}
+	if len(result.Deployments()) != 2 {
+		t.Errorf("Expected 2 deployments for cluster-a, got %d", len(result.Deployments()))
+	}
+	for _, dep := range result.Deployments() {
+		if dep.ClusterId() != "cluster-a" {
+			t.Errorf("Expected cluster-a, got %s", dep.ClusterId())
+		}
+	}
+
+	// With cluster-b filter: should return 1
+	result, err = client.ListDeployments(ctx, "myapp", "cluster-b", "", 0)
+	if err != nil {
+		t.Fatalf("ListDeployments failed: %v", err)
+	}
+	if len(result.Deployments()) != 1 {
+		t.Errorf("Expected 1 deployment for cluster-b, got %d", len(result.Deployments()))
+	}
+}


### PR DESCRIPTION
Two small fixes to deployment tracking:

`listDeploymentsInternal` accepted a `clusterId` param but never
actually filtered on it — so `app history` and all deployment queries
were happily returning results from every cluster. Fixed with one line.

Also updated the default `app history` columns. ID and ERROR aren't
that useful day-to-day — swapped them for GIT SHA and BRANCH which
give you much better context for "what code is behind this deployment".
The old columns are still there in `--detailed` view alongside the
full git info.