### PR TITLE
Validate empty host in route set and route show commands

### DIFF
--- a/cli/commands/route_set.go
+++ b/cli/commands/route_set.go
@@ -13,6 +13,10 @@ func RouteSet(ctx *Context, opts struct {
 	AppName string `position:"1" usage:"Application name to route to"`
 	ConfigCentric
 }) error {
+	if opts.Host == "" {
+		return fmt.Errorf("host is required")
+	}
+
 	appName := opts.AppName
 	if appName == "" {
 		if ac, err := appconfig.LoadAppConfig(); err == nil && ac != nil && ac.Name != "" {

--- a/cli/commands/route_show.go
+++ b/cli/commands/route_show.go
@@ -12,6 +12,10 @@ func RouteShow(ctx *Context, opts struct {
 	FormatOptions
 	ConfigCentric
 }) error {
+	if opts.Host == "" {
+		return fmt.Errorf("host is required")
+	}
+
 	client, err := ctx.RPCClient("entities")
 	if err != nil {
 		return err


### PR DESCRIPTION
The `required:"true"` struct tag on the `Host` positional arg isn't
actually enforced by `mflags`, so `m route set` with no host would
silently succeed and create a route with an empty hostname. `route show`
had the same issue — you'd get a confusing "route not found: " error
instead of something helpful.

Added explicit empty-string checks for `Host` in both handlers, same
pattern already used for `appName` validation in `route_set`.