### PR TITLE
Add per-app cluster pinning

### DIFF
--- a/appconfig/appstate.go
+++ b/appconfig/appstate.go
@@ -1,0 +1,118 @@
+package appconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	toml "github.com/pelletier/go-toml/v2"
+	"golang.org/x/sys/unix"
+)
+
+const appStateFile = "app-state.toml"
+
+type appStateStore struct {
+	Apps map[string]AppState `toml:"apps"`
+}
+
+type AppState struct {
+	Cluster string `toml:"cluster"`
+}
+
+func appStatePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "miren", appStateFile), nil
+}
+
+var appStatePathOverride string
+
+func resolveAppStatePath() (string, error) {
+	if appStatePathOverride != "" {
+		return appStatePathOverride, nil
+	}
+	return appStatePath()
+}
+
+func loadAppStateStore(path string) (*appStateStore, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &appStateStore{Apps: make(map[string]AppState)}, nil
+		}
+		return nil, err
+	}
+
+	var store appStateStore
+	if err := toml.Unmarshal(data, &store); err != nil {
+		return nil, err
+	}
+
+	if store.Apps == nil {
+		store.Apps = make(map[string]AppState)
+	}
+
+	return &store, nil
+}
+
+// LoadAppState reads the cluster state for the named app.
+// Returns nil, nil if no state has been saved for this app.
+func LoadAppState(appName string) (*AppState, error) {
+	path, err := resolveAppStatePath()
+	if err != nil {
+		return nil, err
+	}
+
+	store, err := loadAppStateStore(path)
+	if err != nil {
+		return nil, err
+	}
+
+	state, ok := store.Apps[appName]
+	if !ok {
+		return nil, nil
+	}
+
+	return &state, nil
+}
+
+// SaveAppState writes the cluster state for the named app.
+// Uses a file lock to make the read-modify-write atomic across processes.
+func SaveAppState(appName string, state *AppState) error {
+	path, err := resolveAppStatePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	lockPath := path + ".lock"
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer lockFile.Close()
+
+	if err := unix.Flock(int(lockFile.Fd()), unix.LOCK_EX); err != nil {
+		return err
+	}
+	defer unix.Flock(int(lockFile.Fd()), unix.LOCK_UN)
+
+	store, err := loadAppStateStore(path)
+	if err != nil {
+		return err
+	}
+
+	store.Apps[appName] = *state
+
+	data, err := toml.Marshal(store)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}

--- a/appconfig/appstate_test.go
+++ b/appconfig/appstate_test.go
@@ -1,0 +1,84 @@
+package appconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupStateTest(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	appStatePathOverride = filepath.Join(dir, appStateFile)
+	t.Cleanup(func() { appStatePathOverride = "" })
+}
+
+func TestAppStateRoundTrip(t *testing.T) {
+	setupStateTest(t)
+
+	require.NoError(t, SaveAppState("my-app", &AppState{Cluster: "prod-us-east"}))
+
+	loaded, err := LoadAppState("my-app")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, "prod-us-east", loaded.Cluster)
+}
+
+func TestLoadAppStateMissingApp(t *testing.T) {
+	setupStateTest(t)
+
+	state, err := LoadAppState("nonexistent")
+	assert.NoError(t, err)
+	assert.Nil(t, state)
+}
+
+func TestLoadAppStateMissingFile(t *testing.T) {
+	setupStateTest(t)
+
+	state, err := LoadAppState("any-app")
+	assert.NoError(t, err)
+	assert.Nil(t, state)
+}
+
+func TestSaveAppStateOverwrites(t *testing.T) {
+	setupStateTest(t)
+
+	require.NoError(t, SaveAppState("my-app", &AppState{Cluster: "old-cluster"}))
+	require.NoError(t, SaveAppState("my-app", &AppState{Cluster: "new-cluster"}))
+
+	loaded, err := LoadAppState("my-app")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, "new-cluster", loaded.Cluster)
+}
+
+func TestSaveAppStateMultipleApps(t *testing.T) {
+	setupStateTest(t)
+
+	require.NoError(t, SaveAppState("app-a", &AppState{Cluster: "cluster-1"}))
+	require.NoError(t, SaveAppState("app-b", &AppState{Cluster: "cluster-2"}))
+
+	a, err := LoadAppState("app-a")
+	require.NoError(t, err)
+	require.NotNil(t, a)
+	assert.Equal(t, "cluster-1", a.Cluster)
+
+	b, err := LoadAppState("app-b")
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	assert.Equal(t, "cluster-2", b.Cluster)
+}
+
+func TestSaveAppStateCreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	appStatePathOverride = filepath.Join(dir, "nested", "dir", appStateFile)
+	t.Cleanup(func() { appStatePathOverride = "" })
+
+	require.NoError(t, SaveAppState("my-app", &AppState{Cluster: "test"}))
+
+	_, err := os.Stat(appStatePathOverride)
+	require.NoError(t, err)
+}

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -14,6 +14,7 @@ import (
 
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/appconfig"
+	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/rpc/standard"
 	"miren.dev/runtime/pkg/units"
 )
@@ -50,6 +51,48 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 	}
 
 	return nil
+}
+
+// LoadCluster implements per-app cluster pinning. Resolution priority:
+//  1. -C flag (explicit override) — also saves to state
+//  2. Per-app cluster from ~/.config/miren/app-state.toml
+//  3. Global active_cluster from clientconfig (fallback)
+func (a *AppCentric) LoadCluster() (*clientconfig.ClusterConfig, string, error) {
+	// If -C flag was passed, use ConfigCentric's logic and persist the choice.
+	if a.Cluster != "" {
+		cc, name, err := a.ConfigCentric.LoadCluster()
+		if err == nil && cc != nil {
+			a.saveClusterState(name)
+		}
+		return cc, name, err
+	}
+
+	// Check per-app state.
+	if a.App != "" {
+		state, err := appconfig.LoadAppState(a.App)
+		if err == nil && state != nil && state.Cluster != "" {
+			cfg, err := a.LoadConfig()
+			if err != nil {
+				return nil, "", err
+			}
+
+			cc, err := cfg.GetCluster(state.Cluster)
+			if err == nil && cc != nil {
+				return cc, state.Cluster, nil
+			}
+			// State references an unknown cluster; fall through to global default.
+		}
+	}
+
+	// Fall back to global default.
+	return a.ConfigCentric.LoadCluster()
+}
+
+func (a *AppCentric) saveClusterState(name string) {
+	if a.App == "" {
+		return
+	}
+	_ = appconfig.SaveAppState(a.App, &appconfig.AppState{Cluster: name})
 }
 
 func MinuteLabeler(i int, v float64) string {

--- a/cli/commands/cluster.go
+++ b/cli/commands/cluster.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/charmbracelet/lipgloss"
+	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/ui"
 )
@@ -47,20 +48,26 @@ func ClusterList(ctx *Context, opts struct {
 	var rows []ui.Row
 	headers := []string{"", "CLUSTER", "ADDRESS", "IDENTITY"}
 
+	// Determine the effective cluster for the current app context.
+	globalCluster := cfg.ActiveCluster()
+	effectiveCluster := globalCluster
+
+	if ac, _ := appconfig.LoadAppConfig(); ac != nil && ac.Name != "" {
+		if state, _ := appconfig.LoadAppState(ac.Name); state != nil && state.Cluster != "" {
+			effectiveCluster = state.Cluster
+		}
+	}
+
 	err = cfg.IterateClusters(func(name string, ccfg *clientconfig.ClusterConfig) error {
-		// Determine if this is the active cluster
-		isActive := false
-		if opts.Cluster != "" {
-			isActive = (name == opts.Cluster)
-		} else {
-			isActive = (name == cfg.ActiveCluster())
+		// Use a star for the effective cluster, g for the global default when it differs.
+		prefix := " "
+		if name == effectiveCluster {
+			prefix = "*"
+		} else if name == globalCluster && effectiveCluster != globalCluster {
+			prefix = "g"
 		}
 
-		// Use a star for active cluster
-		prefix := " "
-		if isActive {
-			prefix = "*"
-		}
+		isActive := name == effectiveCluster
 
 		// Get identity info if present
 		identity := ccfg.Identity

--- a/cli/commands/cluster_current.go
+++ b/cli/commands/cluster_current.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/appconfig"
+)
+
+func ClusterCurrent(ctx *Context, opts struct {
+	AppCentric
+}) error {
+	state, err := appconfig.LoadAppState(opts.App)
+	if err != nil {
+		return fmt.Errorf("failed to load app state: %w", err)
+	}
+
+	if state != nil && state.Cluster != "" {
+		ctx.Printf("%s\n", state.Cluster)
+		return nil
+	}
+
+	cfg, err := opts.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("no cluster configured: %w", err)
+	}
+
+	active := cfg.ActiveCluster()
+	if active == "" {
+		ctx.Printf("No cluster configured\n")
+		return nil
+	}
+
+	ctx.Printf("%s (global default)\n", active)
+	return nil
+}

--- a/cli/commands/cluster_switch.go
+++ b/cli/commands/cluster_switch.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/cloudauth"
 	"miren.dev/runtime/pkg/ui"
@@ -97,6 +98,12 @@ func ClusterSwitch(ctx *Context, opts struct {
 	}
 
 	ctx.Printf("Switched to cluster: %s\n", clusterName)
+
+	// Also update per-app state if we're in an app directory.
+	if ac, _ := appconfig.LoadAppConfig(); ac != nil && ac.Name != "" {
+		_ = appconfig.SaveAppState(ac.Name, &appconfig.AppState{Cluster: clusterName})
+	}
+
 	return nil
 }
 

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -79,6 +79,7 @@ func RegisterAll(d *mflags.Dispatcher) {
 	d.Dispatch("cluster switch", Infer("cluster switch", "Switch to a different cluster", ClusterSwitch))
 	d.Dispatch("cluster add", Infer("cluster add", "Add a new cluster configuration", ClusterAdd))
 	d.Dispatch("cluster remove", Infer("cluster remove", "Remove a cluster from the configuration", ClusterRemove))
+	d.Dispatch("cluster current", Infer("cluster current", "Show the pinned cluster for this app", ClusterCurrent))
 
 	// Runner commands (distributed runners) - behind feature flag
 	if labs.DistributedRunners() {


### PR DESCRIPTION
## Summary
- Store per-app cluster state in `~/.config/miren/app-state.toml` so each app remembers which cluster it targets, removing the need to constantly switch the global cluster or pass `-C` on every command
- Cluster resolution for AppCentric commands: `-C` flag > per-app pinned cluster > global default
- `cluster switch` updates both global and per-app state when run inside an app directory
- `cluster list` shows `*` for the effective cluster and `g` for the global default when they differ
- `cluster current` shows which cluster an app is targeting

## Test plan
- [x] Unit tests for app state load/save round-trip, multiple apps, missing file, overwrite
- [x] `make lint` passes with 0 issues
- [ ] Manual: run `miren cluster switch` in an app dir, verify `app-state.toml` is created
- [ ] Manual: run app command, verify pinned cluster is used over global default
- [ ] Manual: use `-C other` flag, verify state updates to new cluster