### PR TITLE
Improve disk mount lifecycle robustness and add integration tests

### DIFF
--- a/components/lsvd/server/mount_controller.go
+++ b/components/lsvd/server/mount_controller.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -13,6 +14,7 @@ import (
 
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 )
 
@@ -982,11 +984,17 @@ func (c *MountController) reconnectNBD(ctx context.Context, entityId string, mou
 func (c *MountController) shouldSkipReconnect(ctx context.Context, entityId string) bool {
 	resp, err := c.eac.Get(ctx, entityId)
 	if err != nil {
-		c.log.Info("mount entity not found, skipping reconnect",
+		if errors.Is(err, cond.ErrNotFound{}) {
+			c.log.Info("mount entity not found, skipping reconnect",
+				"entity_id", entityId,
+			)
+			return true
+		}
+		c.log.Warn("failed to check mount entity, allowing reconnect",
 			"entity_id", entityId,
 			"error", err,
 		)
-		return true
+		return false
 	}
 
 	var mount storage_v1alpha.LsvdMount

--- a/components/lsvd/server/mount_controller.go
+++ b/components/lsvd/server/mount_controller.go
@@ -232,7 +232,11 @@ func (c *MountController) reconcileMountMounted(ctx context.Context, mount *stor
 	case storage_v1alpha.MNT_ERROR:
 		// Error state, try to recover
 		c.log.Info("mount in error state, attempting recovery", "entity_id", entityId)
-		// Clean up any existing handler before retrying to avoid leaking NBD devices
+		c.cleanupHandler(ctx, entityId)
+		return c.attachAndMount(ctx, mount)
+	case storage_v1alpha.MNT_DETACHED:
+		// Detached but desired mounted — recover by re-attaching from scratch
+		c.log.Info("mount detached but desired mounted, recovering", "entity_id", entityId)
 		c.cleanupHandler(ctx, entityId)
 		return c.attachAndMount(ctx, mount)
 	default:
@@ -596,11 +600,30 @@ func (c *MountController) unmountAndDetach(ctx context.Context, mount *storage_v
 		return nil
 	}
 
-	// Unmount if mounted
+	// Unmount if mounted, but skip the filesystem unmount if another mount
+	// entity is actively using the same path (e.g., during rapid sandbox
+	// replacement where two mount entities reference the same disk/volume).
 	if mountState.Mounted {
-		if err := c.ops.Unmount(mountState.MountPath); err != nil {
-			c.log.Warn("failed to unmount", "error", err)
-			return fmt.Errorf("failed to unmount: %w", err)
+		skipUnmount := false
+		for _, otherMount := range c.state.ListMounts() {
+			if otherMount.EntityId != entityId && otherMount.MountPath == mountState.MountPath && otherMount.Mounted {
+				c.log.Info("skipping unmount, path in use by another mount",
+					"entity_id", entityId,
+					"other_entity_id", otherMount.EntityId,
+					"mount_path", mountState.MountPath,
+				)
+				skipUnmount = true
+				break
+			}
+		}
+
+		if !skipUnmount {
+			c.log.Debug("unmounting filesystem", "entity_id", entityId, "mount_path", mountState.MountPath)
+			if err := c.ops.Unmount(mountState.MountPath); err != nil {
+				c.log.Warn("failed to unmount", "error", err)
+				return fmt.Errorf("failed to unmount: %w", err)
+			}
+			c.log.Debug("filesystem unmounted", "entity_id", entityId, "mount_path", mountState.MountPath)
 		}
 		mountState.Mounted = false
 		c.state.SetMount(entityId, mountState)
@@ -622,19 +645,27 @@ func (c *MountController) unmountAndDetach(ctx context.Context, mount *storage_v
 	}
 	c.handlersMu.Unlock()
 
-	// Wait for handler goroutine to exit before closing disk
+	// Disconnect NBD device BEFORE waiting for handler — this unblocks
+	// HandleNBD's read loop (HandleTransport polls with 500ms deadlines
+	// and only exits when the connection breaks).
+	if mountState.DevicePath != "" {
+		if err := c.ops.NBDDisconnect(mountState.NbdIndex); err != nil {
+			c.log.Warn("failed to disconnect NBD", "error", err)
+		}
+	}
+
+	// Now safe to wait for handler goroutine to exit
 	if hasHandler && h.done != nil {
+		c.log.Info("waiting for NBD handler to exit", "entity_id", entityId)
 		<-h.done
+		c.log.Info("NBD handler exited", "entity_id", entityId)
 	}
 	if hasHandler && h.disk != nil {
 		h.disk.Close(ctx)
 	}
 
-	// Disconnect NBD device and remove device node
+	// Remove device node
 	if mountState.DevicePath != "" {
-		if err := c.ops.NBDDisconnect(mountState.NbdIndex); err != nil {
-			c.log.Warn("failed to disconnect NBD", "error", err)
-		}
 		c.ops.RemoveFile(mountState.DevicePath)
 	}
 
@@ -684,7 +715,16 @@ func (c *MountController) cleanupHandler(ctx context.Context, entityId string) {
 	}
 	c.handlersMu.Unlock()
 
-	// Wait for handler goroutine to exit before closing disk
+	// Disconnect NBD device BEFORE waiting for handler — this unblocks
+	// HandleNBD's read loop.
+	mountState := c.state.GetMount(entityId)
+	if mountState != nil && mountState.DevicePath != "" {
+		c.log.Info("disconnecting stale NBD device", "entity_id", entityId, "nbd_index", mountState.NbdIndex)
+		_ = c.ops.NBDDisconnect(mountState.NbdIndex)
+		c.ops.RemoveFile(mountState.DevicePath)
+	}
+
+	// Now safe to wait for handler goroutine to exit
 	if ok && h.done != nil {
 		c.log.Info("waiting for NBD handler to exit", "entity_id", entityId)
 		<-h.done
@@ -693,14 +733,6 @@ func (c *MountController) cleanupHandler(ctx context.Context, entityId string) {
 	// Now safe to close the disk
 	if ok && h.disk != nil {
 		h.disk.Close(ctx)
-	}
-
-	// Also clean up the NBD device if we have mount state with an assigned device
-	mountState := c.state.GetMount(entityId)
-	if mountState != nil && mountState.DevicePath != "" {
-		c.log.Info("disconnecting stale NBD device", "entity_id", entityId, "nbd_index", mountState.NbdIndex)
-		_ = c.ops.NBDDisconnect(mountState.NbdIndex)
-		c.ops.RemoveFile(mountState.DevicePath)
 	}
 
 	// Release lease if present
@@ -728,7 +760,11 @@ func (c *MountController) runNBDHandler(ctx context.Context, entityId string, di
 	defer conn.Close()
 
 	if err := disk.HandleNBD(ctx, conn, clientFile); err != nil {
-		c.log.Warn("NBD handler error", "entity_id", entityId, "error", err)
+		if ctx.Err() != nil {
+			c.log.Debug("NBD handler stopped due to context cancellation", "entity_id", entityId)
+		} else {
+			c.log.Warn("NBD handler error", "entity_id", entityId, "error", err)
+		}
 	}
 }
 
@@ -759,6 +795,16 @@ func (c *MountController) ReconcileWithSystem(ctx context.Context) error {
 		c.handlersMu.RUnlock()
 
 		if !hasHandler {
+			// Before reconnecting, check whether this mount is being unmounted.
+			// There is a race window where unmountAndDetach has deleted the handler
+			// from the map but hasn't yet cleaned up local state. Reconnecting
+			// in that window wastes time and can leak NBD devices.
+			if c.eac != nil {
+				if skip := c.shouldSkipReconnect(ctx, entityId); skip {
+					continue
+				}
+			}
+
 			c.log.Info("no NBD handler found, reconnecting",
 				"entity_id", entityId,
 				"nbd_index", mountState.NbdIndex,
@@ -832,17 +878,18 @@ func (c *MountController) reconnectNBD(ctx context.Context, entityId string, mou
 	}
 	c.handlersMu.Unlock()
 
-	// Wait for handler goroutine to exit before closing disk
+	// Disconnect old NBD device BEFORE waiting for handler — this unblocks
+	// HandleNBD's read loop.
+	if mountState.DevicePath != "" {
+		_ = c.ops.NBDDisconnect(mountState.NbdIndex)
+	}
+
+	// Now safe to wait for handler goroutine to exit
 	if hasHandler && h.done != nil {
 		<-h.done
 	}
 	if hasHandler && h.disk != nil {
 		h.disk.Close(context.Background())
-	}
-
-	// Disconnect old NBD device if still partially connected
-	if mountState.DevicePath != "" {
-		_ = c.ops.NBDDisconnect(mountState.NbdIndex)
 	}
 
 	// Open LSVD disk with stored lease nonce
@@ -927,6 +974,32 @@ func (c *MountController) reconnectNBD(ctx context.Context, entityId string, mou
 	)
 
 	return nil
+}
+
+// shouldSkipReconnect checks the entity store to determine if a mount should
+// not be reconnected. Returns true if the entity doesn't exist (already cleaned
+// up) or has desired_state=MNT_WANT_UNMOUNTED (being torn down).
+func (c *MountController) shouldSkipReconnect(ctx context.Context, entityId string) bool {
+	resp, err := c.eac.Get(ctx, entityId)
+	if err != nil {
+		c.log.Info("mount entity not found, skipping reconnect",
+			"entity_id", entityId,
+			"error", err,
+		)
+		return true
+	}
+
+	var mount storage_v1alpha.LsvdMount
+	mount.Decode(resp.Entity().Entity())
+
+	if mount.DesiredState == storage_v1alpha.MNT_WANT_UNMOUNTED {
+		c.log.Info("mount is being unmounted, skipping reconnect",
+			"entity_id", entityId,
+		)
+		return true
+	}
+
+	return false
 }
 
 // remountFilesystem remounts the filesystem after recovery

--- a/components/lsvd/server/mount_controller_test.go
+++ b/components/lsvd/server/mount_controller_test.go
@@ -611,8 +611,23 @@ func TestMountControllerReconcileWithSystemNBDDisconnected(t *testing.T) {
 
 	mc := newTestMountController(log, dataPath, nodeId, es.EAC, state, ops)
 
+	// Create entity in store with desired_state=MNT_WANT_MOUNTED so that
+	// ReconcileWithSystem knows this mount should be reconnected (not being torn down).
+	mount := &storage_v1alpha.LsvdMount{
+		DesiredState: storage_v1alpha.MNT_WANT_MOUNTED,
+		ActualState:  storage_v1alpha.MNT_MOUNTED,
+		NodeId:       entity.Id("node/" + nodeId),
+		VolumeId:     "lsvd_volume/vol-sys",
+		MountPath:    "/mnt/sys",
+	}
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, entity.Id("lsvd_mount/mnt-sys"),
+		mount.Encode,
+	).Attrs())
+	require.NoError(t, err)
+
 	// Run system reconciliation
-	err := mc.ReconcileWithSystem(ctx)
+	err = mc.ReconcileWithSystem(ctx)
 	require.NoError(t, err)
 
 	// Verify reconnection was attempted (no handler exists, so reconnect triggers)

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -24,6 +24,7 @@ import (
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/components/coordinate"
 	"miren.dev/runtime/components/lsvd"
+	lsvdserver "miren.dev/runtime/components/lsvd/server"
 	"miren.dev/runtime/components/netresolve"
 	"miren.dev/runtime/controllers/disk"
 	"miren.dev/runtime/controllers/ingress"
@@ -86,7 +87,8 @@ type RunnerDeps struct {
 	// Entity server address for lsvd-server (required for disk operations)
 	EntityServerAddr string
 
-	// SkipLSVD skips starting the lsvd-server component (for tests that don't need disk)
+	// SkipLSVD skips starting the lsvd-server as an outboard process
+	// and instead runs the LSVD volume and mount controllers in-process.
 	SkipLSVD bool
 
 	// IsCoordinator indicates this runner is the coordinator node.
@@ -108,6 +110,10 @@ type RunnerDeps struct {
 const (
 	DefaulWorkers = 3
 )
+
+type shutdownCloser struct{ s interface{ Shutdown() } }
+
+func (c shutdownCloser) Close() error { c.s.Shutdown(); return nil }
 
 func NewRunner(log *slog.Logger, deps RunnerDeps, cfg RunnerConfig) (*Runner, error) {
 	if cfg.DataPath == "" {
@@ -481,9 +487,6 @@ func (r *Runner) SetupControllers(
 		return nil, fmt.Errorf("failed to create disk data path: %w", err)
 	}
 
-	var diskController *disk.DiskController
-	var diskLeaseController *disk.DiskLeaseController
-
 	// Start lsvd component unless explicitly skipped (for tests)
 	if !r.deps.SkipLSVD {
 		if r.deps.EntityServerAddr == "" {
@@ -542,12 +545,36 @@ func (r *Runner) SetupControllers(
 
 		r.closers = append(r.closers, lsvdComp)
 	} else {
-		log.Info("Skipping LSVD component (test mode)")
+		log.Info("Running LSVD controllers in-process")
+
+		volumeOps := lsvdserver.NewRealVolumeOps(log, nil, "")
+		mountOps := lsvdserver.NewRealMountOps(log, nil, "")
+
+		lsvdState := lsvdserver.NewState()
+		lsvdState.SetPath(dataPath)
+
+		vc := lsvdserver.NewVolumeController(log, dataPath, r.Id, lsvdState, volumeOps)
+		vc.SetEAC(eas)
+
+		mc := lsvdserver.NewMountController(log, dataPath, r.Id, lsvdState, mountOps)
+		mc.SetEAC(eas)
+
+		r.closers = append(r.closers, shutdownCloser{mc})
+
+		volHandler := controller.AdaptReconcileController[storage_v1alpha.LsvdVolume](vc)
+		cm.AddController(controller.NewReconcileController(
+			"lsvd-volume", log, vc.Index(), eas, volHandler, 0, 1,
+		))
+
+		mntHandler := controller.AdaptReconcileController[storage_v1alpha.LsvdMount](mc)
+		cm.AddController(controller.NewReconcileController(
+			"lsvd-mount", log, mc.Index(), eas, mntHandler, 0, 1,
+		))
 	}
 
 	// Use entity mode controllers
-	diskController = disk.NewDiskController(log, eas, r.Id)
-	diskLeaseController = disk.NewDiskLeaseController(log, eas, r.Id)
+	diskController := disk.NewDiskController(log, eas, r.Id)
+	diskLeaseController := disk.NewDiskLeaseController(log, eas, r.Id)
 
 	// Add disk controller to closers list so it gets cleaned up on shutdown
 	r.closers = append(r.closers, diskController)
@@ -703,6 +730,21 @@ func (r *Runner) SetupControllers(
 			eas,
 			controller.AdaptController(volumeWatchController),
 			0, // No periodic resync needed
+			1,
+		),
+	)
+
+	// Add mount watch controller to trigger disk lease re-reconciliation when
+	// lsvd_mount entities change (e.g. mount becomes MNT_MOUNTED after mounting)
+	mountWatchController := disk.NewMountWatchController(log, eas, diskLeaseRC)
+	cm.AddController(
+		controller.NewReconcileController(
+			"mount-watch",
+			log,
+			entity.Ref(entity.EntityKind, storage_v1alpha.KindLsvdMount),
+			eas,
+			controller.AdaptController(mountWatchController),
+			0,
 			1,
 		),
 	)

--- a/controllers/disk/disk_controller.go
+++ b/controllers/disk/disk_controller.go
@@ -62,6 +62,13 @@ func NewDiskController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessC
 	}
 }
 
+// ForceLSVDMode forces the controller to use lsvd_volume entities instead of
+// directory mode, regardless of NBD availability. This is used by integration
+// tests where the LSVD volume/mount ops are mocked.
+func (d *DiskController) ForceLSVDMode() {
+	d.directoryMode = false
+}
+
 // Init initializes the disk controller
 func (d *DiskController) Init(ctx context.Context) error {
 	// Check if NBD is available

--- a/controllers/disk/disk_controller.go
+++ b/controllers/disk/disk_controller.go
@@ -215,7 +215,7 @@ func (d *DiskController) handleProvisioning(ctx context.Context, disk *storage_v
 	// Build entity with id and encoded attributes
 	volumeId := idgen.GenNS("lsvd-vol")
 	createAttrs := entity.New(
-		entity.DBId, storage_v1alpha.KindLsvdVolume.String()+"/"+volumeId,
+		entity.DBId, entity.Id(storage_v1alpha.KindLsvdVolume.String()+"/"+volumeId),
 		lsvdVolume.Encode,
 	).Attrs()
 

--- a/controllers/disk/disk_lease_controller.go
+++ b/controllers/disk/disk_lease_controller.go
@@ -84,6 +84,13 @@ func (d *DiskLeaseController) GetTestDisk(diskId entity.Id) *storage_v1alpha.Dis
 	return d.testDiskCache[diskId.String()]
 }
 
+// ForceLSVDMode forces the controller to use lsvd_mount entities instead of
+// directory mode, regardless of NBD availability. This is used by integration
+// tests where the LSVD volume/mount ops are mocked.
+func (d *DiskLeaseController) ForceLSVDMode() {
+	d.directoryMode = false
+}
+
 // Init initializes the disk lease controller
 func (d *DiskLeaseController) Init(ctx context.Context) error {
 	// Check if NBD is available

--- a/controllers/disk/disk_lease_controller.go
+++ b/controllers/disk/disk_lease_controller.go
@@ -399,9 +399,11 @@ func (d *DiskLeaseController) handlePendingLease(ctx context.Context, lease *sto
 				"lease", leaseId,
 				"lsvd_mount", existingMount.ID)
 			if _, err := d.EAC.Delete(ctx, existingMount.ID.String()); err != nil {
-				d.Log.Warn("failed to delete stale lsvd_mount",
+				d.Log.Warn("failed to delete stale lsvd_mount, aborting mount creation",
 					"lsvd_mount", existingMount.ID,
 					"error", err)
+				d.cleanupLeaseReservation(diskId)
+				return nil
 			}
 			// Fall through to create a new mount entity
 

--- a/controllers/disk/disk_lease_controller.go
+++ b/controllers/disk/disk_lease_controller.go
@@ -193,8 +193,7 @@ func (d *DiskLeaseController) reconcileLease(ctx context.Context, lease *storage
 		// Update lease details for expiry tracking
 		d.updateLeaseDetails(lease)
 	case storage_v1alpha.FAILED:
-		// Failed state is terminal
-		return nil
+		err = d.handleFailedLease(ctx, lease)
 	default:
 		d.Log.Warn("Unknown lease status", "lease", lease.ID, "status", lease.Status)
 		return nil
@@ -228,24 +227,19 @@ func (d *DiskLeaseController) handlePendingLease(ctx context.Context, lease *sto
 
 	// Check if disk is already leased (with lock)
 	d.mu.Lock()
-	if existingLease, exists := d.activeLeases[diskId]; exists {
-		if existingLease != leaseId {
-			// Conflict - disk is already leased
-			d.Log.Warn("Lease conflict detected",
-				"disk", diskId,
-				"requested_lease", leaseId,
-				"existing_lease", existingLease)
-
-			lease.Status = storage_v1alpha.FAILED
-			lease.ErrorMessage = fmt.Sprintf("Disk %s is already leased by %s", diskId, existingLease)
-		}
-
-		// Already bound by this lease
+	if existingLease, exists := d.activeLeases[diskId]; exists && existingLease != leaseId {
+		// Conflict - disk is already leased by a different lease that is being released.
+		// Leave the new lease as PENDING so the periodic resync will retry it
+		// after the old lease cleanup completes.
+		d.Log.Info("disk has active lease being released, will retry",
+			"disk", diskId,
+			"requested_lease", leaseId,
+			"existing_lease", existingLease)
 		d.mu.Unlock()
 		return nil
 	}
 
-	// Reserve the lease immediately to prevent races
+	// Reserve the lease (or confirm existing reservation)
 	d.activeLeases[diskId] = leaseId
 	d.mu.Unlock()
 
@@ -284,22 +278,20 @@ func (d *DiskLeaseController) handlePendingLease(ctx context.Context, lease *sto
 
 			return nil
 		}
+
 	}
 
 	// Check disk provisioning status
 	if disk.Status != storage_v1alpha.PROVISIONED {
-		// If disk is still provisioning, wait for it to complete
 		if disk.Status == storage_v1alpha.PROVISIONING {
 			d.cleanupLeaseReservation(diskId)
 			d.Log.Info("Disk is still provisioning, lease will retry",
 				"disk", diskId,
 				"lease", leaseId,
 				"disk_status", disk.Status)
-			// Leave lease in PENDING state - it will be reconciled again when disk becomes PROVISIONED
 			return nil
 		}
 
-		// Disk is in failed or unexpected state
 		d.cleanupLeaseReservation(diskId)
 
 		lease.Status = storage_v1alpha.FAILED
@@ -400,6 +392,19 @@ func (d *DiskLeaseController) handlePendingLease(ctx context.Context, lease *sto
 			lease.ErrorMessage = fmt.Sprintf("Mount failed: %s", existingMount.ErrorMessage)
 			return nil
 
+		case storage_v1alpha.MNT_DETACHED:
+			// Mount is in terminal DETACHED state — delete stale entity
+			// and fall through to create a fresh mount.
+			d.Log.Info("existing lsvd_mount in DETACHED state, deleting stale mount",
+				"lease", leaseId,
+				"lsvd_mount", existingMount.ID)
+			if _, err := d.EAC.Delete(ctx, existingMount.ID.String()); err != nil {
+				d.Log.Warn("failed to delete stale lsvd_mount",
+					"lsvd_mount", existingMount.ID,
+					"error", err)
+			}
+			// Fall through to create a new mount entity
+
 		default:
 			// Mount is still in progress, wait
 			d.Log.Debug("lsvd_mount still in progress",
@@ -462,7 +467,7 @@ func (d *DiskLeaseController) handlePendingLease(ctx context.Context, lease *sto
 
 	// Build entity with id and encoded attributes
 	mountId := idgen.GenNS("lsvd-mnt")
-	mountEntityId := "lsvd_mount/" + mountId
+	mountEntityId := entity.Id("lsvd_mount/" + mountId)
 	createAttrs := entity.New(
 		entity.DBId, mountEntityId,
 		lsvdMount.Encode,
@@ -565,6 +570,11 @@ func (d *DiskLeaseController) handleBoundLease(ctx context.Context, lease *stora
 		if mount.ActualState == storage_v1alpha.MNT_ERROR {
 			lease.Status = storage_v1alpha.FAILED
 			lease.ErrorMessage = fmt.Sprintf("Mount failed: %s", mount.ErrorMessage)
+		} else if mount.ActualState == storage_v1alpha.MNT_DETACHED {
+			d.Log.Warn("lsvd_mount detached for bound lease, reverting to pending",
+				"lease", leaseId,
+				"lsvd_mount", mount.ID)
+			lease.Status = storage_v1alpha.PENDING
 		} else {
 			d.Log.Debug("lsvd_mount not yet mounted for bound lease",
 				"lease", leaseId,
@@ -585,17 +595,21 @@ func (d *DiskLeaseController) handleReleasedLease(ctx context.Context, lease *st
 	d.mu.Lock()
 	currentLease, exists := d.activeLeases[diskId]
 	isActiveForThisLease := exists && currentLease == leaseId
+
+	// Release the lease from local tracking immediately so new leases for the
+	// same disk can proceed. The mount cleanup below continues independently
+	// via lsvd_mount entities.
+	if isActiveForThisLease {
+		d.releaseLease(leaseId, diskId)
+	}
 	d.mu.Unlock()
 
 	if !isActiveForThisLease {
 		return nil
 	}
 
-	// In directory mode, just release the lease
+	// In directory mode, nothing more to do
 	if d.directoryMode {
-		d.mu.Lock()
-		defer d.mu.Unlock()
-		d.releaseLease(leaseId, diskId)
 		return nil
 	}
 
@@ -633,24 +647,73 @@ func (d *DiskLeaseController) handleReleasedLease(ctx context.Context, lease *st
 					"lsvd_mount", mount.ID,
 					"error", err)
 			}
-
-			// Wait for lsvd-server to unmount
-			return nil
 		} else {
-			// Already marked for unmount, wait for it
 			d.Log.Debug("lsvd_mount already marked for unmount",
 				"lease", leaseId,
 				"lsvd_mount", mount.ID,
 				"actual_state", mount.ActualState)
-			return nil
 		}
 	}
 
-	// Release the lease from local tracking
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	return nil
+}
 
-	d.releaseLease(leaseId, diskId)
+// handleFailedLease cleans up the lsvd_mount entity for a failed lease.
+// FAILED is a terminal state, but we still need to ensure the mount is unmounted
+// to avoid leaking mounted resources.
+func (d *DiskLeaseController) handleFailedLease(ctx context.Context, lease *storage_v1alpha.DiskLease) error {
+	leaseId := lease.ID.String()
+	diskId := lease.DiskId.String()
+
+	// Release from active tracking if still tracked
+	d.mu.Lock()
+	currentLease, exists := d.activeLeases[diskId]
+	if exists && currentLease == leaseId {
+		d.releaseLease(leaseId, diskId)
+	}
+	d.mu.Unlock()
+
+	if d.directoryMode {
+		return nil
+	}
+
+	// Find and clean up the lsvd_mount entity
+	mount, err := d.getLsvdMountForLease(ctx, lease.ID)
+	if err != nil {
+		d.Log.Warn("Error looking up lsvd_mount for failed lease", "lease", leaseId, "error", err)
+		return nil
+	}
+
+	if mount == nil {
+		return nil
+	}
+
+	if mount.ActualState == storage_v1alpha.MNT_DETACHED {
+		d.Log.Info("lsvd_mount already detached for failed lease, cleaning up",
+			"lease", leaseId,
+			"lsvd_mount", mount.ID)
+
+		if _, err := d.EAC.Delete(ctx, mount.ID.String()); err != nil {
+			d.Log.Warn("Failed to delete lsvd_mount entity",
+				"lsvd_mount", mount.ID,
+				"error", err)
+		}
+	} else if mount.DesiredState != storage_v1alpha.MNT_WANT_UNMOUNTED {
+		d.Log.Info("Setting lsvd_mount desired_state to unmounted for failed lease",
+			"lease", leaseId,
+			"lsvd_mount", mount.ID)
+
+		updateAttrs := []entity.Attr{
+			entity.Ref(entity.DBId, mount.ID),
+			entity.Ref(storage_v1alpha.LsvdMountDesiredStateId, storage_v1alpha.LsvdMountDesiredStateMntWantUnmountedId),
+		}
+		if _, err := d.EAC.Patch(ctx, updateAttrs, 0); err != nil {
+			d.Log.Error("Failed to update lsvd_mount desired_state",
+				"lsvd_mount", mount.ID,
+				"error", err)
+		}
+	}
+
 	return nil
 }
 

--- a/controllers/disk/disk_lease_controller_test.go
+++ b/controllers/disk/disk_lease_controller_test.go
@@ -43,21 +43,9 @@ func TestDiskLeaseController_LeaseConflict(t *testing.T) {
 	err := dlc.Create(context.Background(), conflictingLease, meta)
 	require.NoError(t, err)
 
-	// Should update status to FAILED with error message
-	hasStatus := false
-	hasError := false
-	for _, attr := range meta.Attrs() {
-		if attr.ID == storage_v1alpha.DiskLeaseStatusId {
-			hasStatus = true
-			assert.Equal(t, storage_v1alpha.DiskLeaseStatusFailedId, attr.Value.Id())
-		}
-		if attr.ID == storage_v1alpha.DiskLeaseErrorMessageId {
-			hasError = true
-			assert.Contains(t, attr.Value.String(), "already leased")
-		}
-	}
-	assert.True(t, hasStatus, "Should update status to FAILED")
-	assert.True(t, hasError, "Should include error message")
+	// Should stay PENDING for retry (not FAILED), since the existing lease
+	// may be in the process of being released
+	assert.Equal(t, storage_v1alpha.PENDING, conflictingLease.Status, "Conflicting lease should stay PENDING for retry")
 }
 
 func TestDiskLeaseController_Delete(t *testing.T) {

--- a/controllers/disk/integration_test.go
+++ b/controllers/disk/integration_test.go
@@ -54,18 +54,9 @@ func TestDiskAndLeaseIntegration(t *testing.T) {
 		err := leaseController.Create(ctx, conflictLease, conflictMeta)
 		require.NoError(t, err)
 
-		// Should fail with conflict
-		hasFailure := false
-		for _, attr := range conflictMeta.Attrs() {
-			if attr.ID == storage_v1alpha.DiskLeaseStatusId {
-				assert.Equal(t, storage_v1alpha.DiskLeaseStatusFailedId, attr.Value.Id())
-				hasFailure = true
-			}
-			if attr.ID == storage_v1alpha.DiskLeaseErrorMessageId {
-				assert.Contains(t, attr.Value.String(), "already leased")
-			}
-		}
-		assert.True(t, hasFailure, "Conflicting lease should fail")
+		// Should stay PENDING for retry (not FAILED), since the existing lease
+		// may be in the process of being released
+		assert.Equal(t, storage_v1alpha.PENDING, conflictLease.Status, "Conflicting lease should stay PENDING for retry")
 	})
 
 	t.Run("lease release flow", func(t *testing.T) {

--- a/controllers/disk/mount_watch_controller.go
+++ b/controllers/disk/mount_watch_controller.go
@@ -1,0 +1,71 @@
+package disk
+
+import (
+	"context"
+	"log/slog"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// MountWatchController watches for lsvd_mount state changes and triggers
+// re-reconciliation of the parent disk_lease entity. This bridges the gap where
+// the disk lease controller creates an lsvd_mount and needs to know when the
+// mount controller finishes mounting it.
+type MountWatchController struct {
+	Log *slog.Logger
+	EAC *entityserver_v1alpha.EntityAccessClient
+
+	LeaseController *controller.ReconcileController
+}
+
+// NewMountWatchController creates a new mount watch controller.
+func NewMountWatchController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, leaseController *controller.ReconcileController) *MountWatchController {
+	return &MountWatchController{
+		Log:             log.With("module", "mount-watch"),
+		EAC:             eac,
+		LeaseController: leaseController,
+	}
+}
+
+func (m *MountWatchController) Init(ctx context.Context) error {
+	return nil
+}
+
+func (m *MountWatchController) Create(ctx context.Context, mount *storage_v1alpha.LsvdMount, meta *entity.Meta) error {
+	return nil
+}
+
+func (m *MountWatchController) Update(ctx context.Context, mount *storage_v1alpha.LsvdMount, meta *entity.Meta) error {
+	if mount.DiskLeaseId == "" {
+		return nil
+	}
+
+	m.Log.Debug("lsvd_mount changed, re-reconciling parent disk lease",
+		"mount", mount.ID,
+		"lease", mount.DiskLeaseId,
+		"actual_state", mount.ActualState)
+
+	resp, err := m.EAC.Get(ctx, string(mount.DiskLeaseId))
+	if err != nil {
+		m.Log.Warn("failed to get parent disk lease for mount change",
+			"mount", mount.ID,
+			"lease", mount.DiskLeaseId,
+			"error", err)
+		return nil
+	}
+
+	m.LeaseController.Enqueue(controller.Event{
+		Type:   controller.EventUpdated,
+		Id:     mount.DiskLeaseId,
+		Entity: resp.Entity().Entity(),
+	})
+
+	return nil
+}
+
+func (m *MountWatchController) Delete(ctx context.Context, id entity.Id) error {
+	return nil
+}

--- a/controllers/disk/sandbox_integration_test.go
+++ b/controllers/disk/sandbox_integration_test.go
@@ -138,15 +138,8 @@ func TestSandboxDiskIntegration(t *testing.T) {
 		err = leaseController.Create(ctx, conflictLease, conflictMeta)
 		require.NoError(t, err)
 
-		// Verify conflict was detected
-		hasFailure := false
-		for _, attr := range conflictMeta.Attrs() {
-			if attr.ID == storage_v1alpha.DiskLeaseStatusId {
-				hasFailure = true
-				assert.Equal(t, storage_v1alpha.DiskLeaseStatusFailedId, attr.Value.Id())
-			}
-		}
-		assert.True(t, hasFailure)
+		// Verify conflict was detected — lease stays PENDING for retry
+		assert.Equal(t, storage_v1alpha.PENDING, conflictLease.Status, "Conflicting lease should stay PENDING for retry")
 
 		// Step 6: Sandbox releases the disk
 		lease.Status = storage_v1alpha.RELEASED

--- a/controllers/integration/chaos_test.go
+++ b/controllers/integration/chaos_test.go
@@ -359,7 +359,7 @@ func faultRestartSandbox(t *testing.T, ctx context.Context, h *TestHarness, rng 
 
 	leaseID, err := h.FakeSandbox.AcquireDiskLease(ctx, slot.diskID, newSbID, "", "/data", false)
 	if err != nil {
-		return true
+		return false
 	}
 
 	cs.newSlot(newSbID, slot.diskID, slot.diskName, leaseID)
@@ -544,10 +544,10 @@ func validateChaosInvariants(t *testing.T, ctx context.Context, h *TestHarness, 
 		leaseByID[l.ID] = l
 	}
 
-	mountByLeaseID := make(map[entity.Id]*storage.LsvdMount)
+	mountsByLeaseID := make(map[entity.Id][]*storage.LsvdMount)
 	for _, m := range allMounts {
 		if m.DiskLeaseId != "" {
-			mountByLeaseID[m.DiskLeaseId] = m
+			mountsByLeaseID[m.DiskLeaseId] = append(mountsByLeaseID[m.DiskLeaseId], m)
 		}
 	}
 
@@ -587,12 +587,15 @@ func validateChaosInvariants(t *testing.T, ctx context.Context, h *TestHarness, 
 		if lease.Status != storage.BOUND {
 			continue
 		}
-		mount := mountByLeaseID[lease.ID]
-		if mount == nil {
+		mounts := mountsByLeaseID[lease.ID]
+		if len(mounts) == 0 {
 			t.Errorf("INVARIANT 2 violated: BOUND lease %s has no mount", lease.ID)
 			violations++
-		} else if mount.ActualState != storage.MNT_MOUNTED {
-			t.Errorf("INVARIANT 2 violated: BOUND lease %s mount %s is %s (expected MNT_MOUNTED)", lease.ID, mount.ID, mount.ActualState)
+		} else if len(mounts) > 1 {
+			t.Errorf("INVARIANT 2 violated: BOUND lease %s has %d mounts (expected 1)", lease.ID, len(mounts))
+			violations++
+		} else if mounts[0].ActualState != storage.MNT_MOUNTED {
+			t.Errorf("INVARIANT 2 violated: BOUND lease %s mount %s is %s (expected MNT_MOUNTED)", lease.ID, mounts[0].ID, mounts[0].ActualState)
 			violations++
 		}
 	}

--- a/controllers/integration/chaos_test.go
+++ b/controllers/integration/chaos_test.go
@@ -1,0 +1,653 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/idgen"
+)
+
+// chaosReport collects statistics throughout the chaos test for a final summary.
+type chaosReport struct {
+	seed           int64
+	duration       time.Duration
+	iterations     int
+	faultAttempts  map[string]int
+	faultSuccesses map[string]int
+	sandboxSpawns  int
+
+	// Entity counts at convergence
+	totalDisks  int
+	totalLeases int
+	totalMounts int
+
+	// Lease status breakdown at convergence
+	boundLeases    int
+	releasedLeases int
+	failedLeases   int
+	pendingLeases  int
+
+	// Disk status breakdown at convergence
+	provisionedDisks int
+	errorDisks       int
+	otherDisks       int
+
+	// Mount status breakdown at convergence
+	mountedMounts  int
+	detachedMounts int
+	otherMounts    int
+
+	// Invariant results
+	invariantViolations int
+}
+
+func newChaosReport(seed int64, duration time.Duration) *chaosReport {
+	return &chaosReport{
+		seed:           seed,
+		duration:       duration,
+		faultAttempts:  make(map[string]int),
+		faultSuccesses: make(map[string]int),
+	}
+}
+
+func (r *chaosReport) recordAttempt(name string, succeeded bool) {
+	r.faultAttempts[name]++
+	if succeeded {
+		r.faultSuccesses[name]++
+	}
+}
+
+func (r *chaosReport) collectEntityStats(t *testing.T, ctx context.Context, h *TestHarness) {
+	t.Helper()
+
+	disks := listDisks(t, ctx, h)
+	leases := listLeases(t, ctx, h)
+	mounts := listLsvdMounts(t, ctx, h)
+
+	r.totalDisks = len(disks)
+	r.totalLeases = len(leases)
+	r.totalMounts = len(mounts)
+
+	for _, d := range disks {
+		switch d.Status {
+		case storage.PROVISIONED:
+			r.provisionedDisks++
+		case storage.ERROR:
+			r.errorDisks++
+		default:
+			r.otherDisks++
+		}
+	}
+
+	for _, l := range leases {
+		switch l.Status {
+		case storage.BOUND:
+			r.boundLeases++
+		case storage.RELEASED:
+			r.releasedLeases++
+		case storage.FAILED:
+			r.failedLeases++
+		case storage.PENDING:
+			r.pendingLeases++
+		}
+	}
+
+	for _, m := range mounts {
+		switch m.ActualState {
+		case storage.MNT_MOUNTED:
+			r.mountedMounts++
+		case storage.MNT_DETACHED:
+			r.detachedMounts++
+		default:
+			r.otherMounts++
+		}
+	}
+}
+
+func (r *chaosReport) emit(t *testing.T) {
+	t.Helper()
+
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString("╔══════════════════════════════════════════════╗\n")
+	b.WriteString("║          CHAOS CONVERGENCE REPORT            ║\n")
+	b.WriteString("╚══════════════════════════════════════════════╝\n")
+
+	fmt.Fprintf(&b, "\nSeed: %d\n", r.seed)
+	fmt.Fprintf(&b, "Duration: %s\n", r.duration)
+	fmt.Fprintf(&b, "Iterations: %d\n", r.iterations)
+	fmt.Fprintf(&b, "Sandboxes spawned mid-test: %d\n", r.sandboxSpawns)
+
+	b.WriteString("\n── Fault Injection ─────────────────────────────\n")
+	b.WriteString(fmt.Sprintf("  %-25s %8s %8s %7s\n", "Fault", "Attempts", "Injected", "Rate"))
+	b.WriteString(fmt.Sprintf("  %-25s %8s %8s %7s\n", "─────", "────────", "────────", "────"))
+
+	// Sort fault names for deterministic output
+	var names []string
+	for name := range r.faultAttempts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	totalAttempts := 0
+	totalSuccesses := 0
+	for _, name := range names {
+		attempts := r.faultAttempts[name]
+		successes := r.faultSuccesses[name]
+		totalAttempts += attempts
+		totalSuccesses += successes
+		rate := 0
+		if attempts > 0 {
+			rate = successes * 100 / attempts
+		}
+		fmt.Fprintf(&b, "  %-25s %8d %8d %6d%%\n", name, attempts, successes, rate)
+	}
+	fmt.Fprintf(&b, "  %-25s %8d %8d\n", "TOTAL", totalAttempts, totalSuccesses)
+
+	b.WriteString("\n── Entities at Convergence ─────────────────────\n")
+	fmt.Fprintf(&b, "  Disks:  %d total  (provisioned=%d, error=%d, other=%d)\n",
+		r.totalDisks, r.provisionedDisks, r.errorDisks, r.otherDisks)
+	fmt.Fprintf(&b, "  Leases: %d total  (bound=%d, released=%d, failed=%d, pending=%d)\n",
+		r.totalLeases, r.boundLeases, r.releasedLeases, r.failedLeases, r.pendingLeases)
+	fmt.Fprintf(&b, "  Mounts: %d total  (mounted=%d, detached=%d, other=%d)\n",
+		r.totalMounts, r.mountedMounts, r.detachedMounts, r.otherMounts)
+
+	b.WriteString("\n── Invariants ─────────────────────────────────\n")
+	if r.invariantViolations == 0 {
+		b.WriteString("  All 6 invariants passed\n")
+	} else {
+		fmt.Fprintf(&b, "  VIOLATIONS: %d (see errors above)\n", r.invariantViolations)
+	}
+
+	t.Log(b.String())
+}
+
+// chaosSlot tracks a sandbox and its associated disk resources.
+type chaosSlot struct {
+	sandboxID entity.Id
+	diskID    entity.Id
+	diskName  string
+	leaseID   entity.Id
+	alive     bool
+}
+
+// chaosState tracks all sandboxes created during the chaos test.
+type chaosState struct {
+	slots   []chaosSlot
+	nextIdx int
+}
+
+func (cs *chaosState) newSlot(sandboxID, diskID entity.Id, diskName string, leaseID entity.Id) {
+	cs.slots = append(cs.slots, chaosSlot{
+		sandboxID: sandboxID,
+		diskID:    diskID,
+		diskName:  diskName,
+		leaseID:   leaseID,
+		alive:     true,
+	})
+}
+
+func (cs *chaosState) aliveSlots() []int {
+	var indices []int
+	for i, s := range cs.slots {
+		if s.alive {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
+// chaosFault defines a named fault injection function.
+type chaosFault struct {
+	name   string
+	weight int
+	fn     func(t *testing.T, ctx context.Context, h *TestHarness, rng *rand.Rand, cs *chaosState) bool
+}
+
+func chaosFaultCatalog() []chaosFault {
+	return []chaosFault{
+		{"faultDeleteMount", 3, faultDeleteMount},
+		{"faultMountError", 3, faultMountError},
+		{"faultDiskError", 1, faultDiskError},
+		{"faultDeleteLease", 2, faultDeleteLease},
+		{"faultStopSandbox", 3, faultStopSandbox},
+		{"faultRestartSandbox", 3, faultRestartSandbox},
+		{"faultDuplicateLease", 1, faultDuplicateLease},
+	}
+}
+
+// pickFault selects a random fault using weighted selection.
+func pickFault(rng *rand.Rand, catalog []chaosFault) *chaosFault {
+	totalWeight := 0
+	for _, f := range catalog {
+		totalWeight += f.weight
+	}
+	pick := rng.Intn(totalWeight)
+	for i := range catalog {
+		pick -= catalog[i].weight
+		if pick < 0 {
+			return &catalog[i]
+		}
+	}
+	return &catalog[len(catalog)-1]
+}
+
+// faultDeleteMount deletes a random MNT_MOUNTED mount entity.
+func faultDeleteMount(t *testing.T, ctx context.Context, h *TestHarness, rng *rand.Rand, _ *chaosState) bool {
+	t.Helper()
+	mounts := listLsvdMounts(t, ctx, h)
+	var mounted []*storage.LsvdMount
+	for _, m := range mounts {
+		if m.ActualState == storage.MNT_MOUNTED {
+			mounted = append(mounted, m)
+		}
+	}
+	if len(mounted) == 0 {
+		return false
+	}
+	target := mounted[rng.Intn(len(mounted))]
+	deleteMountEntity(t, ctx, h, target.ID)
+	return true
+}
+
+// faultMountError patches a random mount to MNT_ERROR.
+func faultMountError(t *testing.T, ctx context.Context, h *TestHarness, rng *rand.Rand, _ *chaosState) bool {
+	t.Helper()
+	mounts := listLsvdMounts(t, ctx, h)
+	var mounted []*storage.LsvdMount
+	for _, m := range mounts {
+		if m.ActualState == storage.MNT_MOUNTED {
+			mounted = append(mounted, m)
+		}
+	}
+	if len(mounted) == 0 {
+		return false
+	}
+	target := mounted[rng.Intn(len(mounted))]
+	patchMountError(t, ctx, h, target.ID, "chaos: injected error")
+	return true
+}
+
+// faultDiskError patches a random PROVISIONED disk to ERROR.
+func faultDiskError(t *testing.T, ctx context.Context, h *TestHarness, rng *rand.Rand, _ *chaosState) bool {
+	t.Helper()
+	disks := listDisks(t, ctx, h)
+	var provisioned []*storage.Disk
+	for _, d := range disks {
+		if d.Status == storage.PROVISIONED {
+			provisioned = append(provisioned, d)
+		}
+	}
+	if len(provisioned) == 0 {
+		return false
+	}
+	target := provisioned[rng.Intn(len(provisioned))]
+	patchDiskStatus(t, ctx, h, target.ID, storage.ERROR)
+	return true
+}
+
+// faultDeleteLease deletes a random BOUND lease entity and fires the delete event
+// so the controller can clean up the associated mount.
+func faultDeleteLease(t *testing.T, ctx context.Context, h *TestHarness, rng *rand.Rand, _ *chaosState) bool {
+	t.Helper()
+	leases := listLeases(t, ctx, h)
+	var bound []*storage.DiskLease
+	for _, l := range leases {
+		if l.Status == storage.BOUND {
+			bound = append(bound, l)
+		}
+	}
+	if len(bound) == 0 {
+		return false
+	}
+	target := bound[rng.Intn(len(bound))]
+	deleteLeaseEntity(t, ctx, h, target.ID)
+
+	// Fire delete event so the controller processes mount cleanup
+	deleteEvent := controller.Event{
+		Type: controller.EventDeleted,
+		Id:   target.ID,
+	}
+	_ = h.DiskLeaseRC.ProcessEventForTest(ctx, deleteEvent)
+	return true
+}
+
+// faultStopSandbox stops a random alive sandbox.
+func faultStopSandbox(t *testing.T, ctx context.Context, h *TestHarness, rng *rand.Rand, cs *chaosState) bool {
+	t.Helper()
+	alive := cs.aliveSlots()
+	if len(alive) == 0 {
+		return false
+	}
+	idx := alive[rng.Intn(len(alive))]
+	slot := &cs.slots[idx]
+	_ = h.FakeSandbox.ReleaseDiskLeases(ctx, slot.sandboxID)
+	markSandboxDead(t, ctx, h, slot.sandboxID)
+	slot.alive = false
+	return true
+}
+
+// faultRestartSandbox stops a sandbox then boots a replacement with the same disk.
+func faultRestartSandbox(t *testing.T, ctx context.Context, h *TestHarness, rng *rand.Rand, cs *chaosState) bool {
+	t.Helper()
+	alive := cs.aliveSlots()
+	if len(alive) == 0 {
+		return false
+	}
+	idx := alive[rng.Intn(len(alive))]
+	slot := &cs.slots[idx]
+
+	_ = h.FakeSandbox.ReleaseDiskLeases(ctx, slot.sandboxID)
+	markSandboxDead(t, ctx, h, slot.sandboxID)
+	slot.alive = false
+
+	h.ReconcileAll(ctx, 5)
+
+	newSbID := entity.Id(fmt.Sprintf("sandbox/chaos-r-%d", cs.nextIdx))
+	cs.nextIdx++
+	createSandboxEntity(t, ctx, h, newSbID, compute.PENDING)
+
+	leaseID, err := h.FakeSandbox.AcquireDiskLease(ctx, slot.diskID, newSbID, "", "/data", false)
+	if err != nil {
+		return true
+	}
+
+	cs.newSlot(newSbID, slot.diskID, slot.diskName, leaseID)
+	return true
+}
+
+// faultDuplicateLease creates a conflicting BOUND lease for a disk that already has one.
+func faultDuplicateLease(t *testing.T, ctx context.Context, h *TestHarness, rng *rand.Rand, cs *chaosState) bool {
+	t.Helper()
+	leases := listLeases(t, ctx, h)
+	var bound []*storage.DiskLease
+	for _, l := range leases {
+		if l.Status == storage.BOUND {
+			bound = append(bound, l)
+		}
+	}
+	if len(bound) == 0 {
+		return false
+	}
+	target := bound[rng.Intn(len(bound))]
+
+	conflictSbID := entity.Id(fmt.Sprintf("sandbox/chaos-dup-%d", cs.nextIdx))
+	cs.nextIdx++
+	createSandboxEntity(t, ctx, h, conflictSbID, compute.RUNNING)
+
+	conflictLease := &storage.DiskLease{
+		DiskId:     target.DiskId,
+		SandboxId:  conflictSbID,
+		Status:     storage.BOUND,
+		AcquiredAt: time.Now(),
+		Mount: storage.Mount{
+			Path:    "/data",
+			Options: "rw",
+		},
+		NodeId: entity.Id("node/" + testNodeId),
+	}
+
+	conflictLeaseID := entity.Id("disk-lease/" + idgen.GenNS("disk-lease"))
+	_, err := h.EAC.Create(ctx, entity.New(
+		entity.DBId, conflictLeaseID,
+		conflictLease.Encode,
+	).Attrs())
+	if err != nil {
+		return false
+	}
+
+	_ = conflictLeaseID
+	return true
+}
+
+// chaosReconcileRound runs each controller 1-3 times in random order.
+func chaosReconcileRound(ctx context.Context, h *TestHarness, rng *rand.Rand) {
+	nodeId := entity.Id("node/" + testNodeId)
+
+	type ctrlDef struct {
+		index entity.Attr
+		rc    *controller.ReconcileController
+	}
+
+	controllers := []ctrlDef{
+		{entity.Ref(entity.EntityKind, storage.KindDisk), h.DiskRC},
+		{entity.Ref(storage.LsvdVolumeNodeIdId, nodeId), h.LsvdVolRC},
+		{entity.Ref(storage.LsvdMountNodeIdId, nodeId), h.LsvdMntRC},
+		{entity.Ref(entity.EntityKind, storage.KindDiskLease), h.DiskLeaseRC},
+	}
+
+	rng.Shuffle(len(controllers), func(i, j int) {
+		controllers[i], controllers[j] = controllers[j], controllers[i]
+	})
+
+	for _, c := range controllers {
+		passes := rng.Intn(3) + 1
+		for i := 0; i < passes; i++ {
+			h.reconcileByIndex(ctx, c.index, c.rc)
+		}
+	}
+}
+
+func TestChaosConvergence(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Determine test duration
+	duration := 30 * time.Second
+	if testing.Short() {
+		duration = 5 * time.Second
+	}
+	if envDur := os.Getenv("CHAOS_DURATION"); envDur != "" {
+		d, err := time.ParseDuration(envDur)
+		if err != nil {
+			t.Fatalf("invalid CHAOS_DURATION %q: %v", envDur, err)
+		}
+		duration = d
+	}
+
+	seed := time.Now().UnixNano()
+	rng := rand.New(rand.NewSource(seed))
+	report := newChaosReport(seed, duration)
+
+	cs := &chaosState{}
+
+	// Phase 1: Boot N sandboxes with individual disks
+	const numSandboxes = 3
+	for i := 0; i < numSandboxes; i++ {
+		sbID := entity.Id(fmt.Sprintf("sandbox/chaos-%d", i))
+		diskName := fmt.Sprintf("chaos-disk-%d", i)
+		diskID, leaseID := bootSandboxWithDisk(t, ctx, h, sbID, diskName, 10)
+		cs.newSlot(sbID, diskID, diskName, leaseID)
+		cs.nextIdx = i + 1
+	}
+	cs.nextIdx = numSandboxes
+
+	for _, slot := range cs.slots {
+		lease := getLease(t, ctx, h, slot.leaseID)
+		if lease.Status != storage.BOUND {
+			t.Fatalf("initial sandbox %s lease not BOUND: %s", slot.sandboxID, lease.Status)
+		}
+	}
+
+	// Phase 2: Fault injection loop
+	catalog := chaosFaultCatalog()
+
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		report.iterations++
+
+		fault := pickFault(rng, catalog)
+		ok := fault.fn(t, ctx, h, rng, cs)
+		report.recordAttempt(fault.name, ok)
+
+		rounds := rng.Intn(5) + 1
+		for r := 0; r < rounds; r++ {
+			chaosReconcileRound(ctx, h, rng)
+		}
+
+		// Occasionally boot a new sandbox with a new disk
+		if rng.Intn(10) == 0 && len(cs.aliveSlots()) < 6 {
+			newIdx := cs.nextIdx
+			cs.nextIdx++
+			sbID := entity.Id(fmt.Sprintf("sandbox/chaos-new-%d", newIdx))
+			diskName := fmt.Sprintf("chaos-disk-new-%d", newIdx)
+
+			createSandboxEntity(t, ctx, h, sbID, compute.PENDING)
+			diskID, err := h.FakeSandbox.EnsureDisk(ctx, diskName, 10, "ext4")
+			if err != nil {
+				continue
+			}
+			leaseID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sbID, "", "/data", false)
+			if err != nil {
+				continue
+			}
+			cs.newSlot(sbID, diskID, diskName, leaseID)
+			report.sandboxSpawns++
+		}
+	}
+
+	// Phase 3: Converge to stable state
+	h.ReconcileAll(ctx, 100)
+
+	// Phase 4: Validate invariants and collect final stats
+	report.collectEntityStats(t, ctx, h)
+	report.invariantViolations = validateChaosInvariants(t, ctx, h, cs)
+	report.emit(t)
+}
+
+func validateChaosInvariants(t *testing.T, ctx context.Context, h *TestHarness, cs *chaosState) int {
+	t.Helper()
+	violations := 0
+
+	allLeases := listLeases(t, ctx, h)
+	allMounts := listLsvdMounts(t, ctx, h)
+	allDisks := listDisks(t, ctx, h)
+
+	// Build lookup maps
+	diskByID := make(map[entity.Id]*storage.Disk)
+	for _, d := range allDisks {
+		diskByID[d.ID] = d
+	}
+
+	leaseByID := make(map[entity.Id]*storage.DiskLease)
+	for _, l := range allLeases {
+		leaseByID[l.ID] = l
+	}
+
+	mountByLeaseID := make(map[entity.Id]*storage.LsvdMount)
+	for _, m := range allMounts {
+		if m.DiskLeaseId != "" {
+			mountByLeaseID[m.DiskLeaseId] = m
+		}
+	}
+
+	// Build set of alive sandbox IDs
+	aliveSandboxes := make(map[entity.Id]bool)
+	for _, slot := range cs.slots {
+		if slot.alive {
+			aliveSandboxes[slot.sandboxID] = true
+		}
+	}
+
+	// Track which disks have BOUND leases (for exclusive access check)
+	boundLeasesByDisk := make(map[entity.Id][]entity.Id)
+
+	for _, lease := range allLeases {
+		if lease.Status == storage.BOUND {
+			boundLeasesByDisk[lease.DiskId] = append(boundLeasesByDisk[lease.DiskId], lease.ID)
+		}
+	}
+
+	// Invariant 1: Every non-FAILED, non-RELEASED lease for a live sandbox is BOUND
+	for _, lease := range allLeases {
+		if !aliveSandboxes[lease.SandboxId] {
+			continue
+		}
+		if lease.Status == storage.FAILED || lease.Status == storage.RELEASED {
+			continue
+		}
+		if lease.Status != storage.BOUND {
+			t.Errorf("INVARIANT 1 violated: lease %s for live sandbox %s is %s (expected BOUND)", lease.ID, lease.SandboxId, lease.Status)
+			violations++
+		}
+	}
+
+	// Invariant 2: Every BOUND lease has exactly 1 MNT_MOUNTED mount
+	for _, lease := range allLeases {
+		if lease.Status != storage.BOUND {
+			continue
+		}
+		mount := mountByLeaseID[lease.ID]
+		if mount == nil {
+			t.Errorf("INVARIANT 2 violated: BOUND lease %s has no mount", lease.ID)
+			violations++
+		} else if mount.ActualState != storage.MNT_MOUNTED {
+			t.Errorf("INVARIANT 2 violated: BOUND lease %s mount %s is %s (expected MNT_MOUNTED)", lease.ID, mount.ID, mount.ActualState)
+			violations++
+		}
+	}
+
+	// Invariant 3: No two BOUND leases share the same disk
+	for diskID, leaseIDs := range boundLeasesByDisk {
+		if len(leaseIDs) > 1 {
+			t.Errorf("INVARIANT 3 violated: disk %s has %d BOUND leases: %v", diskID, len(leaseIDs), leaseIDs)
+			violations++
+		}
+	}
+
+	// Invariant 4: Every BOUND lease's disk is PROVISIONED
+	for _, lease := range allLeases {
+		if lease.Status != storage.BOUND {
+			continue
+		}
+		disk := diskByID[lease.DiskId]
+		if disk == nil {
+			t.Errorf("INVARIANT 4 violated: BOUND lease %s references missing disk %s", lease.ID, lease.DiskId)
+			violations++
+		} else if disk.Status != storage.PROVISIONED {
+			t.Errorf("INVARIANT 4 violated: BOUND lease %s disk %s is %s (expected PROVISIONED)", lease.ID, lease.DiskId, disk.Status)
+			violations++
+		}
+	}
+
+	// Invariant 5: No orphaned mounts — every MNT_MOUNTED mount has a corresponding BOUND lease.
+	// NOTE: If this invariant is violated by a FAILED lease with a mounted mount, it indicates
+	// a real controller bug — FAILED leases are terminal and never trigger mount cleanup,
+	// leaking the mount resource.
+	for _, mount := range allMounts {
+		if mount.ActualState != storage.MNT_MOUNTED {
+			continue
+		}
+		lease := leaseByID[mount.DiskLeaseId]
+		if lease == nil {
+			t.Errorf("INVARIANT 5 violated: MNT_MOUNTED mount %s references missing lease %s", mount.ID, mount.DiskLeaseId)
+			violations++
+		} else if lease.Status != storage.BOUND {
+			t.Errorf("INVARIANT 5 violated: MNT_MOUNTED mount %s lease %s is %s (expected BOUND)", mount.ID, mount.DiskLeaseId, lease.Status)
+			violations++
+		}
+	}
+
+	// Invariant 6: Disks in ERROR have no BOUND leases
+	for _, disk := range allDisks {
+		if disk.Status != storage.ERROR {
+			continue
+		}
+		if leaseIDs, ok := boundLeasesByDisk[disk.ID]; ok && len(leaseIDs) > 0 {
+			t.Errorf("INVARIANT 6 violated: ERROR disk %s has BOUND leases: %v", disk.ID, leaseIDs)
+			violations++
+		}
+	}
+
+	return violations
+}

--- a/controllers/integration/fake_sandbox.go
+++ b/controllers/integration/fake_sandbox.go
@@ -1,0 +1,178 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/idgen"
+)
+
+// FakeSandboxController replicates the disk management logic from
+// controllers/sandbox/volume.go without requiring containerd or real networking.
+// It creates/acquires disks and leases through the entity store, then relies on
+// the harness's ReconcileAll to drive the disk controllers to completion.
+type FakeSandboxController struct {
+	Log    *slog.Logger
+	EAC    *entityserver_v1alpha.EntityAccessClient
+	NodeId string
+}
+
+// NewFakeSandboxController creates a new fake sandbox controller.
+func NewFakeSandboxController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, nodeId string) *FakeSandboxController {
+	return &FakeSandboxController{
+		Log:    log.With("module", "fake-sandbox"),
+		EAC:    eac,
+		NodeId: nodeId,
+	}
+}
+
+// EnsureDisk looks up or creates a Disk entity by name.
+// Mirrors controllers/sandbox/volume.go:ensureDisk.
+func (f *FakeSandboxController) EnsureDisk(ctx context.Context, diskName string, sizeGB int64, filesystem string) (entity.Id, error) {
+	// Search for existing disk by name
+	listResp, err := f.EAC.List(ctx, entity.String(storage.DiskNameId, diskName))
+	if err != nil {
+		return "", fmt.Errorf("failed to query disks by name: %w", err)
+	}
+
+	if len(listResp.Values()) > 0 {
+		e := listResp.Values()[0]
+		var disk storage.Disk
+		disk.Decode(e.Entity())
+		f.Log.Info("found existing disk", "disk", disk.ID, "name", diskName)
+		return disk.ID, nil
+	}
+
+	if sizeGB <= 0 {
+		return "", fmt.Errorf("disk %q does not exist and no size specified", diskName)
+	}
+
+	var fs storage.DiskFilesystem
+	switch filesystem {
+	case "ext4":
+		fs = storage.EXT4
+	case "xfs":
+		fs = storage.XFS
+	default:
+		fs = storage.EXT4
+	}
+
+	disk := &storage.Disk{
+		Name:       diskName,
+		SizeGb:     sizeGB,
+		Filesystem: fs,
+		Status:     storage.PROVISIONING,
+	}
+
+	name := idgen.GenNS("disk")
+	diskID := entity.Id("disk/" + name)
+	putResp, err := f.EAC.Create(ctx, entity.New(
+		entity.DBId, diskID,
+		disk.Encode,
+	).Attrs())
+	if err != nil {
+		return "", fmt.Errorf("failed to create disk entity: %w", err)
+	}
+
+	f.Log.Info("created disk", "disk", diskID, "resp_id", putResp.Id(), "name", diskName)
+	return diskID, nil
+}
+
+// AcquireDiskLease creates a new DiskLease entity for the given sandbox.
+// Mirrors controllers/sandbox/volume.go:acquireDiskLease.
+func (f *FakeSandboxController) AcquireDiskLease(ctx context.Context, diskID, sandboxID, appID entity.Id, mountPath string, readOnly bool) (entity.Id, error) {
+	// Check for existing lease for this sandbox
+	listResp, err := f.EAC.List(ctx, entity.Ref(entity.EntityKind, storage.KindDiskLease))
+	if err != nil {
+		return "", fmt.Errorf("failed to list disk leases: %w", err)
+	}
+
+	nodeID := entity.Id("node/" + f.NodeId)
+
+	for _, e := range listResp.Values() {
+		var lease storage.DiskLease
+		lease.Decode(e.Entity())
+
+		if lease.DiskId == diskID && lease.NodeId == nodeID {
+			if lease.SandboxId == sandboxID {
+				f.Log.Info("found existing lease", "lease", lease.ID)
+				return lease.ID, nil
+			}
+
+			if lease.Status == storage.PENDING || lease.Status == storage.BOUND {
+				return "", fmt.Errorf("disk %s has active lease (%s) for sandbox %s", diskID, lease.Status, lease.SandboxId)
+			}
+		}
+	}
+
+	// Create new lease
+	lease := &storage.DiskLease{
+		DiskId:    diskID,
+		SandboxId: sandboxID,
+		AppId:     appID,
+		Status:    storage.PENDING,
+		Mount: storage.Mount{
+			Path:     mountPath,
+			ReadOnly: readOnly,
+			Options:  "rw",
+		},
+		NodeId: nodeID,
+	}
+
+	if readOnly {
+		lease.Mount.Options = "ro"
+	}
+
+	name := idgen.GenNS("disk-lease")
+	leaseID := entity.Id("disk-lease/" + name)
+	_, err = f.EAC.Create(ctx, entity.New(
+		entity.DBId, leaseID,
+		lease.Encode,
+	).Attrs())
+	if err != nil {
+		return "", fmt.Errorf("failed to create disk lease: %w", err)
+	}
+
+	f.Log.Info("created disk lease", "lease", leaseID, "disk", diskID, "sandbox", sandboxID)
+	return leaseID, nil
+}
+
+// ReleaseDiskLeases releases all disk leases owned by the given sandbox.
+// Mirrors controllers/sandbox/sandbox.go:releaseDiskLeases.
+func (f *FakeSandboxController) ReleaseDiskLeases(ctx context.Context, sandboxID entity.Id) error {
+	listResp, err := f.EAC.List(ctx, entity.Ref(entity.EntityKind, storage.KindDiskLease))
+	if err != nil {
+		return fmt.Errorf("failed to list disk leases: %w", err)
+	}
+
+	for _, e := range listResp.Values() {
+		var lease storage.DiskLease
+		lease.Decode(e.Entity())
+
+		if lease.SandboxId != sandboxID {
+			continue
+		}
+
+		if lease.Status == storage.RELEASED {
+			continue
+		}
+
+		f.Log.Info("releasing disk lease", "lease", lease.ID, "disk", lease.DiskId, "sandbox", sandboxID)
+
+		_, err := f.EAC.Patch(ctx, entity.New(
+			entity.DBId, lease.ID,
+			(&storage.DiskLease{
+				Status: storage.RELEASED,
+			}).Encode,
+		).Attrs(), 0)
+		if err != nil {
+			f.Log.Error("failed to release lease", "lease", lease.ID, "error", err)
+		}
+	}
+
+	return nil
+}

--- a/controllers/integration/harness.go
+++ b/controllers/integration/harness.go
@@ -72,11 +72,15 @@ func NewTestHarness(t *testing.T) *TestHarness {
 	lsvdMntCtrl := lsvdserver.NewMountController(log, dataPath, testNodeId, lsvdState, mntOps)
 	lsvdMntCtrl.SetEAC(eac)
 
-	// Create disk controllers
+	// Create disk controllers and force LSVD mode so they create lsvd_volume
+	// and lsvd_mount entities instead of falling back to directory mode.
+	// The mock ops above handle the actual volume/mount operations.
 	diskCtrl := disk.NewDiskController(log, eac, testNodeId)
 	diskCtrl.Init(ctx) //nolint:errcheck
+	diskCtrl.ForceLSVDMode()
 	diskLeaseCtrl := disk.NewDiskLeaseController(log, eac, testNodeId)
 	diskLeaseCtrl.Init(ctx) //nolint:errcheck
+	diskLeaseCtrl.ForceLSVDMode()
 
 	// Create ReconcileControllers for each.
 	// We do NOT create watch controllers because ReconcileAll already reconciles

--- a/controllers/integration/harness.go
+++ b/controllers/integration/harness.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -155,7 +156,7 @@ func (h *TestHarness) ReconcileEntity(ctx context.Context, id entity.Id) error {
 
 	rc := h.controllerForEntity(id)
 	if rc == nil {
-		return nil
+		return fmt.Errorf("no controller for entity %s", id)
 	}
 
 	return rc.ProcessEventForTest(ctx, event)
@@ -221,6 +222,7 @@ func (h *TestHarness) ReconcileAll(ctx context.Context, maxIterations int) {
 func (h *TestHarness) reconcileByIndex(ctx context.Context, index entity.Attr, rc *controller.ReconcileController) {
 	resp, err := h.EAC.List(ctx, index)
 	if err != nil {
+		h.T.Errorf("reconcileByIndex: List(%s) failed: %v", index, err)
 		return
 	}
 

--- a/controllers/integration/harness.go
+++ b/controllers/integration/harness.go
@@ -1,0 +1,288 @@
+package integration
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/storage/storage_v1alpha"
+	lsvdserver "miren.dev/runtime/components/lsvd/server"
+	"miren.dev/runtime/controllers/disk"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+const testNodeId = "test-node-1"
+
+// TestHarness wires all disk-lifecycle controllers together with a shared
+// in-memory entity server for integration testing.
+type TestHarness struct {
+	T      *testing.T
+	Server *testutils.InMemEntityServer
+	Log    *slog.Logger
+	EAC    *entityserver_v1alpha.EntityAccessClient
+
+	// Runner-side controllers
+	DiskCtrl      *disk.DiskController
+	DiskLeaseCtrl *disk.DiskLeaseController
+
+	// LSVD controllers (with mock ops)
+	LsvdVolumeCtrl *lsvdserver.VolumeController
+	LsvdMountCtrl  *lsvdserver.MountController
+	LsvdState      *lsvdserver.State
+
+	// Fake sandbox
+	FakeSandbox *FakeSandboxController
+
+	// ReconcileControllers (for ProcessEventForTest)
+	DiskRC      *controller.ReconcileController
+	DiskLeaseRC *controller.ReconcileController
+	LsvdVolRC   *controller.ReconcileController
+	LsvdMntRC   *controller.ReconcileController
+
+	// Mock ops for test inspection
+	MockVolumeOps *mockVolumeOps
+	MockMountOps  *mockMountOps
+}
+
+// NewTestHarness creates a fully wired test harness for disk lifecycle integration tests.
+func NewTestHarness(t *testing.T) *TestHarness {
+	ctx := context.Background()
+	log := testutils.TestDebugLogger(t)
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	eac := es.EAC
+
+	// Create LSVD state backed by a temp file so Save() succeeds
+	dataPath := t.TempDir()
+	lsvdState := lsvdserver.NewState()
+	lsvdState.SetPath(dataPath)
+
+	// Create mock ops
+	volOps := newMockVolumeOps()
+	mntOps := newMockMountOps()
+	lsvdVolCtrl := lsvdserver.NewVolumeController(log, dataPath, testNodeId, lsvdState, volOps)
+	lsvdVolCtrl.SetEAC(eac)
+
+	lsvdMntCtrl := lsvdserver.NewMountController(log, dataPath, testNodeId, lsvdState, mntOps)
+	lsvdMntCtrl.SetEAC(eac)
+
+	// Create disk controllers
+	diskCtrl := disk.NewDiskController(log, eac, testNodeId)
+	diskCtrl.Init(ctx) //nolint:errcheck
+	diskLeaseCtrl := disk.NewDiskLeaseController(log, eac, testNodeId)
+	diskLeaseCtrl.Init(ctx) //nolint:errcheck
+
+	// Create ReconcileControllers for each.
+	// We do NOT create watch controllers because ReconcileAll already reconciles
+	// all entity kinds each iteration, making the watch→Enqueue pattern unnecessary.
+	diskRC := controller.NewReconcileController(
+		"disk",
+		log,
+		entity.Ref(entity.EntityKind, storage_v1alpha.KindDisk),
+		eac,
+		controller.AdaptController(diskCtrl),
+		0, 1,
+	)
+
+	diskLeaseRC := controller.NewReconcileController(
+		"disk-lease",
+		log,
+		entity.Ref(entity.EntityKind, storage_v1alpha.KindDiskLease),
+		eac,
+		controller.AdaptController(diskLeaseCtrl),
+		0, 1,
+	)
+
+	lsvdVolRC := controller.NewReconcileController(
+		"lsvd-volume",
+		log,
+		lsvdVolCtrl.Index(),
+		eac,
+		controller.AdaptReconcileController(lsvdVolCtrl),
+		0, 1,
+	)
+
+	lsvdMntRC := controller.NewReconcileController(
+		"lsvd-mount",
+		log,
+		lsvdMntCtrl.Index(),
+		eac,
+		controller.AdaptReconcileController(lsvdMntCtrl),
+		0, 1,
+	)
+
+	// Create fake sandbox controller
+	fakeSandbox := NewFakeSandboxController(log, eac, testNodeId)
+
+	return &TestHarness{
+		T:              t,
+		Server:         es,
+		Log:            log,
+		EAC:            eac,
+		DiskCtrl:       diskCtrl,
+		DiskLeaseCtrl:  diskLeaseCtrl,
+		LsvdVolumeCtrl: lsvdVolCtrl,
+		LsvdMountCtrl:  lsvdMntCtrl,
+		LsvdState:      lsvdState,
+		FakeSandbox:    fakeSandbox,
+		DiskRC:         diskRC,
+		DiskLeaseRC:    diskLeaseRC,
+		LsvdVolRC:      lsvdVolRC,
+		LsvdMntRC:      lsvdMntRC,
+		MockVolumeOps:  volOps,
+		MockMountOps:   mntOps,
+	}
+}
+
+// ReconcileEntity fetches an entity by ID and processes it through the appropriate controller.
+func (h *TestHarness) ReconcileEntity(ctx context.Context, id entity.Id) error {
+	resp, err := h.EAC.Get(ctx, id.String())
+	if err != nil {
+		return err
+	}
+
+	ent := resp.Entity().Entity()
+	event := controller.Event{
+		Type:   controller.EventUpdated,
+		Id:     id,
+		Entity: ent,
+	}
+
+	rc := h.controllerForEntity(id)
+	if rc == nil {
+		return nil
+	}
+
+	return rc.ProcessEventForTest(ctx, event)
+}
+
+// controllerForEntity returns the appropriate ReconcileController based on entity kind prefix.
+func (h *TestHarness) controllerForEntity(id entity.Id) *controller.ReconcileController {
+	s := id.String()
+	switch {
+	case hasPrefix(s, "disk-lease/"):
+		return h.DiskLeaseRC
+	case hasPrefix(s, "disk/"):
+		return h.DiskRC
+	case hasPrefix(s, "lsvd_volume/"), hasPrefix(s, "dev.miren.storage/kind.lsvd_volume/"):
+		return h.LsvdVolRC
+	case hasPrefix(s, "lsvd_mount/"), hasPrefix(s, "dev.miren.storage/kind.lsvd_mount/"):
+		return h.LsvdMntRC
+	default:
+		return nil
+	}
+}
+
+// ReconcileAll reconciles all disk-related entities across all controllers until
+// the system converges (no entity revisions change) or maxIterations is reached.
+func (h *TestHarness) ReconcileAll(ctx context.Context, maxIterations int) {
+	h.T.Helper()
+
+	if maxIterations <= 0 {
+		maxIterations = 20
+	}
+
+	nodeId := entity.Id("node/" + testNodeId)
+
+	indexes := []struct {
+		index entity.Attr
+		rc    *controller.ReconcileController
+	}{
+		{entity.Ref(entity.EntityKind, storage_v1alpha.KindDisk), h.DiskRC},
+		{entity.Ref(storage_v1alpha.LsvdVolumeNodeIdId, nodeId), h.LsvdVolRC},
+		{entity.Ref(storage_v1alpha.LsvdMountNodeIdId, nodeId), h.LsvdMntRC},
+		{entity.Ref(entity.EntityKind, storage_v1alpha.KindDiskLease), h.DiskLeaseRC},
+	}
+
+	for i := 0; i < maxIterations; i++ {
+		before := h.snapshotRevisions(ctx)
+
+		for _, idx := range indexes {
+			h.reconcileByIndex(ctx, idx.index, idx.rc)
+		}
+
+		after := h.snapshotRevisions(ctx)
+
+		if revisionsEqual(before, after) {
+			h.Log.Info("ReconcileAll converged", "iterations", i+1)
+			return
+		}
+	}
+
+	h.Log.Warn("ReconcileAll hit max iterations", "max", maxIterations)
+}
+
+// reconcileByIndex lists all entities matching the given index attr and processes each through the controller.
+func (h *TestHarness) reconcileByIndex(ctx context.Context, index entity.Attr, rc *controller.ReconcileController) {
+	resp, err := h.EAC.List(ctx, index)
+	if err != nil {
+		return
+	}
+
+	for _, e := range resp.Values() {
+		ent := e.Entity()
+		id := ent.Id()
+		if id == "" {
+			continue
+		}
+
+		event := controller.Event{
+			Type:   controller.EventUpdated,
+			Id:     id,
+			Entity: ent,
+		}
+
+		if err := rc.ProcessEventForTest(ctx, event); err != nil {
+			h.Log.Debug("reconcile error", "id", id, "error", err)
+		}
+	}
+}
+
+// snapshotRevisions returns a map of entity ID → revision for all disk-related entities.
+func (h *TestHarness) snapshotRevisions(ctx context.Context) map[string]int64 {
+	snap := make(map[string]int64)
+
+	for _, kind := range []entity.Id{
+		storage_v1alpha.KindDisk,
+		storage_v1alpha.KindDiskLease,
+		storage_v1alpha.KindLsvdVolume,
+		storage_v1alpha.KindLsvdMount,
+	} {
+		resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, kind))
+		if err != nil {
+			continue
+		}
+		for _, e := range resp.Values() {
+			snap[e.Id()] = e.Revision()
+		}
+	}
+
+	return snap
+}
+
+// reconcileKind is a convenience for reconciling by EntityKind index.
+func (h *TestHarness) reconcileKind(ctx context.Context, kind entity.Id, rc *controller.ReconcileController) {
+	h.reconcileByIndex(ctx, entity.Ref(entity.EntityKind, kind), rc)
+}
+
+// revisionsEqual returns true if two revision snapshots are identical.
+func revisionsEqual(a, b map[string]int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/controllers/integration/helpers.go
+++ b/controllers/integration/helpers.go
@@ -45,18 +45,6 @@ func getSandbox(t *testing.T, ctx context.Context, h *TestHarness, id entity.Id)
 	return &sb
 }
 
-// getPool fetches a SandboxPool entity by ID.
-func getPool(t *testing.T, ctx context.Context, h *TestHarness, id entity.Id) *compute.SandboxPool {
-	t.Helper()
-	resp, err := h.EAC.Get(ctx, id.String())
-	if err != nil {
-		t.Fatalf("getPool(%s): %v", id, err)
-	}
-	var pool compute.SandboxPool
-	pool.Decode(resp.Entity().Entity())
-	return &pool
-}
-
 // listLeases lists all DiskLease entities in the store.
 func listLeases(t *testing.T, ctx context.Context, h *TestHarness) []*storage.DiskLease {
 	t.Helper()
@@ -132,19 +120,6 @@ func leasesForSandbox(t *testing.T, ctx context.Context, h *TestHarness, sandbox
 	var result []*storage.DiskLease
 	for _, l := range all {
 		if l.SandboxId == sandboxID {
-			result = append(result, l)
-		}
-	}
-	return result
-}
-
-// leasesForDisk returns all leases for a specific disk.
-func leasesForDisk(t *testing.T, ctx context.Context, h *TestHarness, diskID entity.Id) []*storage.DiskLease {
-	t.Helper()
-	all := listLeases(t, ctx, h)
-	var result []*storage.DiskLease
-	for _, l := range all {
-		if l.DiskId == diskID {
 			result = append(result, l)
 		}
 	}

--- a/controllers/integration/helpers.go
+++ b/controllers/integration/helpers.go
@@ -1,0 +1,330 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// getDisk fetches a Disk entity by ID.
+func getDisk(t *testing.T, ctx context.Context, h *TestHarness, id entity.Id) *storage.Disk {
+	t.Helper()
+	resp, err := h.EAC.Get(ctx, id.String())
+	if err != nil {
+		t.Fatalf("getDisk(%s): %v", id, err)
+	}
+	var disk storage.Disk
+	disk.Decode(resp.Entity().Entity())
+	return &disk
+}
+
+// getLease fetches a DiskLease entity by ID.
+func getLease(t *testing.T, ctx context.Context, h *TestHarness, id entity.Id) *storage.DiskLease {
+	t.Helper()
+	resp, err := h.EAC.Get(ctx, id.String())
+	if err != nil {
+		t.Fatalf("getLease(%s): %v", id, err)
+	}
+	var lease storage.DiskLease
+	lease.Decode(resp.Entity().Entity())
+	return &lease
+}
+
+// getSandbox fetches a Sandbox entity by ID.
+func getSandbox(t *testing.T, ctx context.Context, h *TestHarness, id entity.Id) *compute.Sandbox {
+	t.Helper()
+	resp, err := h.EAC.Get(ctx, id.String())
+	if err != nil {
+		t.Fatalf("getSandbox(%s): %v", id, err)
+	}
+	var sb compute.Sandbox
+	sb.Decode(resp.Entity().Entity())
+	return &sb
+}
+
+// getPool fetches a SandboxPool entity by ID.
+func getPool(t *testing.T, ctx context.Context, h *TestHarness, id entity.Id) *compute.SandboxPool {
+	t.Helper()
+	resp, err := h.EAC.Get(ctx, id.String())
+	if err != nil {
+		t.Fatalf("getPool(%s): %v", id, err)
+	}
+	var pool compute.SandboxPool
+	pool.Decode(resp.Entity().Entity())
+	return &pool
+}
+
+// listLeases lists all DiskLease entities in the store.
+func listLeases(t *testing.T, ctx context.Context, h *TestHarness) []*storage.DiskLease {
+	t.Helper()
+	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, storage.KindDiskLease))
+	if err != nil {
+		t.Fatalf("listLeases: %v", err)
+	}
+
+	var leases []*storage.DiskLease
+	for _, e := range resp.Values() {
+		var lease storage.DiskLease
+		lease.Decode(e.Entity())
+		leases = append(leases, &lease)
+	}
+	return leases
+}
+
+// listDisks lists all Disk entities in the store.
+func listDisks(t *testing.T, ctx context.Context, h *TestHarness) []*storage.Disk {
+	t.Helper()
+	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, storage.KindDisk))
+	if err != nil {
+		t.Fatalf("listDisks: %v", err)
+	}
+
+	var disks []*storage.Disk
+	for _, e := range resp.Values() {
+		var disk storage.Disk
+		disk.Decode(e.Entity())
+		disks = append(disks, &disk)
+	}
+	return disks
+}
+
+// listLsvdVolumes lists all LsvdVolume entities in the store.
+func listLsvdVolumes(t *testing.T, ctx context.Context, h *TestHarness) []*storage.LsvdVolume {
+	t.Helper()
+	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, storage.KindLsvdVolume))
+	if err != nil {
+		t.Fatalf("listLsvdVolumes: %v", err)
+	}
+
+	var vols []*storage.LsvdVolume
+	for _, e := range resp.Values() {
+		var vol storage.LsvdVolume
+		vol.Decode(e.Entity())
+		vols = append(vols, &vol)
+	}
+	return vols
+}
+
+// listLsvdMounts lists all LsvdMount entities in the store.
+func listLsvdMounts(t *testing.T, ctx context.Context, h *TestHarness) []*storage.LsvdMount {
+	t.Helper()
+	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, storage.KindLsvdMount))
+	if err != nil {
+		t.Fatalf("listLsvdMounts: %v", err)
+	}
+
+	var mounts []*storage.LsvdMount
+	for _, e := range resp.Values() {
+		var mount storage.LsvdMount
+		mount.Decode(e.Entity())
+		mounts = append(mounts, &mount)
+	}
+	return mounts
+}
+
+// leasesForSandbox returns all leases owned by a specific sandbox.
+func leasesForSandbox(t *testing.T, ctx context.Context, h *TestHarness, sandboxID entity.Id) []*storage.DiskLease {
+	t.Helper()
+	all := listLeases(t, ctx, h)
+	var result []*storage.DiskLease
+	for _, l := range all {
+		if l.SandboxId == sandboxID {
+			result = append(result, l)
+		}
+	}
+	return result
+}
+
+// leasesForDisk returns all leases for a specific disk.
+func leasesForDisk(t *testing.T, ctx context.Context, h *TestHarness, diskID entity.Id) []*storage.DiskLease {
+	t.Helper()
+	all := listLeases(t, ctx, h)
+	var result []*storage.DiskLease
+	for _, l := range all {
+		if l.DiskId == diskID {
+			result = append(result, l)
+		}
+	}
+	return result
+}
+
+// createSandboxEntity creates a minimal sandbox entity in the store.
+func createSandboxEntity(t *testing.T, ctx context.Context, h *TestHarness, sandboxID entity.Id, status compute.SandboxStatus) {
+	t.Helper()
+	sb := &compute.Sandbox{
+		Status: status,
+	}
+	_, err := h.EAC.Create(ctx, entity.New(
+		entity.DBId, sandboxID,
+		sb.Encode,
+	).Attrs())
+	if err != nil {
+		t.Fatalf("createSandboxEntity(%s): %v", sandboxID, err)
+	}
+}
+
+// markSandboxDead patches a sandbox entity to DEAD status.
+func markSandboxDead(t *testing.T, ctx context.Context, h *TestHarness, sandboxID entity.Id) {
+	t.Helper()
+	_, err := h.EAC.Patch(ctx, entity.New(
+		entity.DBId, sandboxID,
+		(&compute.Sandbox{
+			Status: compute.DEAD,
+		}).Encode,
+	).Attrs(), 0)
+	if err != nil {
+		t.Fatalf("markSandboxDead(%s): %v", sandboxID, err)
+	}
+}
+
+// markSandboxStopped patches a sandbox entity to STOPPED status.
+func markSandboxStopped(t *testing.T, ctx context.Context, h *TestHarness, sandboxID entity.Id) {
+	t.Helper()
+	_, err := h.EAC.Patch(ctx, entity.New(
+		entity.DBId, sandboxID,
+		(&compute.Sandbox{
+			Status: compute.STOPPED,
+		}).Encode,
+	).Attrs(), 0)
+	if err != nil {
+		t.Fatalf("markSandboxStopped(%s): %v", sandboxID, err)
+	}
+}
+
+// markSandboxRunning patches a sandbox entity to RUNNING status.
+func markSandboxRunning(t *testing.T, ctx context.Context, h *TestHarness, sandboxID entity.Id) {
+	t.Helper()
+	_, err := h.EAC.Patch(ctx, entity.New(
+		entity.DBId, sandboxID,
+		(&compute.Sandbox{
+			Status: compute.RUNNING,
+		}).Encode,
+	).Attrs(), 0)
+	if err != nil {
+		t.Fatalf("markSandboxRunning(%s): %v", sandboxID, err)
+	}
+}
+
+// deleteSandboxEntity deletes a sandbox entity from the store.
+func deleteSandboxEntity(t *testing.T, ctx context.Context, h *TestHarness, sandboxID entity.Id) {
+	t.Helper()
+	_, err := h.EAC.Delete(ctx, sandboxID.String())
+	if err != nil {
+		t.Fatalf("deleteSandboxEntity(%s): %v", sandboxID, err)
+	}
+}
+
+// deleteLeaseEntity deletes a lease entity from the store.
+func deleteLeaseEntity(t *testing.T, ctx context.Context, h *TestHarness, leaseID entity.Id) {
+	t.Helper()
+	_, err := h.EAC.Delete(ctx, leaseID.String())
+	if err != nil {
+		t.Fatalf("deleteLeaseEntity(%s): %v", leaseID, err)
+	}
+}
+
+// patchLeaseStatus patches a lease entity to the given status.
+func patchLeaseStatus(t *testing.T, ctx context.Context, h *TestHarness, leaseID entity.Id, status storage.DiskLeaseStatus) {
+	t.Helper()
+	_, err := h.EAC.Patch(ctx, entity.New(
+		entity.DBId, leaseID,
+		(&storage.DiskLease{
+			Status: status,
+		}).Encode,
+	).Attrs(), 0)
+	if err != nil {
+		t.Fatalf("patchLeaseStatus(%s, %s): %v", leaseID, status, err)
+	}
+}
+
+// countMountedMounts returns the number of lsvd_mount entities in MNT_MOUNTED state.
+func countMountedMounts(t *testing.T, ctx context.Context, h *TestHarness) int {
+	t.Helper()
+	mounts := listLsvdMounts(t, ctx, h)
+	count := 0
+	for _, m := range mounts {
+		if m.ActualState == storage.MNT_MOUNTED {
+			count++
+		}
+	}
+	return count
+}
+
+// getMountForLease returns the lsvd_mount entity for a given lease, or nil if not found.
+func getMountForLease(t *testing.T, ctx context.Context, h *TestHarness, leaseID entity.Id) *storage.LsvdMount {
+	t.Helper()
+	resp, err := h.EAC.List(ctx, entity.Ref(storage.LsvdMountDiskLeaseIdId, leaseID))
+	if err != nil {
+		t.Fatalf("getMountForLease(%s): %v", leaseID, err)
+	}
+	values := resp.Values()
+	if len(values) == 0 {
+		return nil
+	}
+	var mount storage.LsvdMount
+	mount.Decode(values[0].Entity())
+	return &mount
+}
+
+// patchDiskStatus patches a disk entity to the given status.
+func patchDiskStatus(t *testing.T, ctx context.Context, h *TestHarness, diskID entity.Id, status storage.DiskStatus) {
+	t.Helper()
+	_, err := h.EAC.Patch(ctx, entity.New(
+		entity.DBId, diskID,
+		(&storage.Disk{
+			Status: status,
+		}).Encode,
+	).Attrs(), 0)
+	if err != nil {
+		t.Fatalf("patchDiskStatus(%s, %s): %v", diskID, status, err)
+	}
+}
+
+// patchMountActualState patches an lsvd_mount entity's actual_state.
+func patchMountActualState(t *testing.T, ctx context.Context, h *TestHarness, mountID entity.Id, stateId entity.Id) {
+	t.Helper()
+	_, err := h.EAC.Patch(ctx, []entity.Attr{
+		entity.Ref(entity.DBId, mountID),
+		entity.Ref(storage.LsvdMountActualStateId, stateId),
+	}, 0)
+	if err != nil {
+		t.Fatalf("patchMountActualState(%s): %v", mountID, err)
+	}
+}
+
+// patchMountError patches an lsvd_mount entity to MNT_ERROR with an error message.
+func patchMountError(t *testing.T, ctx context.Context, h *TestHarness, mountID entity.Id, errorMsg string) {
+	t.Helper()
+	_, err := h.EAC.Patch(ctx, []entity.Attr{
+		entity.Ref(entity.DBId, mountID),
+		entity.Ref(storage.LsvdMountActualStateId, storage.LsvdMountActualStateMntErrorId),
+		entity.String(storage.LsvdMountErrorMessageId, errorMsg),
+	}, 0)
+	if err != nil {
+		t.Fatalf("patchMountError(%s): %v", mountID, err)
+	}
+}
+
+// getMountByID fetches an LsvdMount entity by its entity ID.
+func getMountByID(t *testing.T, ctx context.Context, h *TestHarness, id entity.Id) *storage.LsvdMount {
+	t.Helper()
+	resp, err := h.EAC.Get(ctx, id.String())
+	if err != nil {
+		t.Fatalf("getMountByID(%s): %v", id, err)
+	}
+	var mount storage.LsvdMount
+	mount.Decode(resp.Entity().Entity())
+	return &mount
+}
+
+// deleteMountEntity deletes an lsvd_mount entity from the store.
+func deleteMountEntity(t *testing.T, ctx context.Context, h *TestHarness, mountID entity.Id) {
+	t.Helper()
+	_, err := h.EAC.Delete(ctx, mountID.String())
+	if err != nil {
+		t.Fatalf("deleteMountEntity(%s): %v", mountID, err)
+	}
+}

--- a/controllers/integration/lifecycle_test.go
+++ b/controllers/integration/lifecycle_test.go
@@ -1,0 +1,846 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/idgen"
+)
+
+// bootSandboxWithDisk creates a sandbox entity, ensures a disk, acquires a lease,
+// then runs ReconcileAll until the lease becomes BOUND. Returns all created IDs.
+func bootSandboxWithDisk(t *testing.T, ctx context.Context, h *TestHarness, sandboxID entity.Id, diskName string, sizeGB int64) (diskID, leaseID entity.Id) {
+	t.Helper()
+
+	// Create sandbox entity
+	createSandboxEntity(t, ctx, h, sandboxID, compute.PENDING)
+
+	// Ensure disk exists
+	var err error
+	diskID, err = h.FakeSandbox.EnsureDisk(ctx, diskName, sizeGB, "ext4")
+	require.NoError(t, err, "EnsureDisk failed")
+
+	// Acquire lease
+	leaseID, err = h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxID, "", "/data", false)
+	require.NoError(t, err, "AcquireDiskLease failed")
+
+	// ReconcileAll until the system converges
+	h.ReconcileAll(ctx, 20)
+
+	// Mark sandbox running once lease is bound
+	lease := getLease(t, ctx, h, leaseID)
+	if lease.Status == storage.BOUND {
+		markSandboxRunning(t, ctx, h, sandboxID)
+	}
+
+	return diskID, leaseID
+}
+
+// stopSandbox releases disk leases for a sandbox and marks it DEAD.
+func stopSandbox(t *testing.T, ctx context.Context, h *TestHarness, sandboxID entity.Id) {
+	t.Helper()
+
+	err := h.FakeSandbox.ReleaseDiskLeases(ctx, sandboxID)
+	require.NoError(t, err)
+
+	markSandboxDead(t, ctx, h, sandboxID)
+}
+
+func TestSandboxStartWithDisk(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/test-start-1")
+	diskID, leaseID := bootSandboxWithDisk(t, ctx, h, sandboxID, "test-disk", 10)
+
+	// Verify final state
+	disk := getDisk(t, ctx, h, diskID)
+	assert.Equal(t, storage.PROVISIONED, disk.Status, "disk should be PROVISIONED")
+	assert.NotEmpty(t, disk.LsvdVolumeId, "disk should have an LsvdVolumeId")
+
+	lease := getLease(t, ctx, h, leaseID)
+	assert.Equal(t, storage.BOUND, lease.Status, "lease should be BOUND")
+	assert.Equal(t, diskID, lease.DiskId)
+	assert.Equal(t, sandboxID, lease.SandboxId)
+
+	// Verify lsvd entities
+	vols := listLsvdVolumes(t, ctx, h)
+	assert.Len(t, vols, 1, "should have exactly 1 lsvd_volume")
+	assert.Equal(t, storage.VOL_READY, vols[0].ActualState)
+
+	mounts := listLsvdMounts(t, ctx, h)
+	assert.Len(t, mounts, 1, "should have exactly 1 lsvd_mount")
+	assert.Equal(t, storage.MNT_MOUNTED, mounts[0].ActualState)
+
+	sb := getSandbox(t, ctx, h, sandboxID)
+	assert.Equal(t, compute.RUNNING, sb.Status)
+}
+
+func TestSandboxStopReleasesLease(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/test-stop-1")
+	diskID, leaseID := bootSandboxWithDisk(t, ctx, h, sandboxID, "test-disk-stop", 10)
+
+	// Verify lease is bound before stop
+	lease := getLease(t, ctx, h, leaseID)
+	require.Equal(t, storage.BOUND, lease.Status)
+
+	// Stop the sandbox
+	stopSandbox(t, ctx, h, sandboxID)
+
+	// Verify lease is RELEASED
+	lease = getLease(t, ctx, h, leaseID)
+	assert.Equal(t, storage.RELEASED, lease.Status)
+
+	// ReconcileAll to process the release
+	h.ReconcileAll(ctx, 20)
+
+	// Verify disk is still PROVISIONED (not deleted)
+	disk := getDisk(t, ctx, h, diskID)
+	assert.Equal(t, storage.PROVISIONED, disk.Status)
+
+	// Verify the lsvd_mount has been unmounted
+	mounts := listLsvdMounts(t, ctx, h)
+	for _, m := range mounts {
+		// Mount should be detached or deleted
+		assert.True(t,
+			m.ActualState == storage.MNT_DETACHED ||
+				m.DesiredState == storage.MNT_WANT_UNMOUNTED,
+			"mount should be detached or want unmounted, got actual=%s desired=%s",
+			m.ActualState, m.DesiredState)
+	}
+}
+
+func TestSandboxReplacementAcquiresDisk(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot first sandbox
+	sandbox1 := entity.Id("sandbox/replace-1")
+	diskID, lease1ID := bootSandboxWithDisk(t, ctx, h, sandbox1, "test-disk-replace", 10)
+
+	// Verify first sandbox is running with bound lease
+	lease1 := getLease(t, ctx, h, lease1ID)
+	require.Equal(t, storage.BOUND, lease1.Status)
+
+	// Stop first sandbox (releases lease)
+	stopSandbox(t, ctx, h, sandbox1)
+
+	// ReconcileAll to process the release
+	h.ReconcileAll(ctx, 20)
+
+	// Boot replacement sandbox with the same disk
+	sandbox2 := entity.Id("sandbox/replace-2")
+	createSandboxEntity(t, ctx, h, sandbox2, compute.PENDING)
+
+	// Acquire lease for same disk (should succeed since old lease is released)
+	lease2ID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandbox2, "", "/data", false)
+	require.NoError(t, err, "replacement should acquire disk")
+
+	// ReconcileAll until new lease binds
+	h.ReconcileAll(ctx, 20)
+
+	// Verify new lease is BOUND
+	lease2 := getLease(t, ctx, h, lease2ID)
+	assert.Equal(t, storage.BOUND, lease2.Status, "replacement lease should be BOUND")
+	assert.Equal(t, sandbox2, lease2.SandboxId)
+
+	// Mark sandbox2 running
+	markSandboxRunning(t, ctx, h, sandbox2)
+
+	// Verify old lease is still RELEASED
+	lease1 = getLease(t, ctx, h, lease1ID)
+	assert.Equal(t, storage.RELEASED, lease1.Status)
+}
+
+func TestSandboxCrashAndReplace(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot first sandbox
+	sandbox1 := entity.Id("sandbox/crash-1")
+	diskID, lease1ID := bootSandboxWithDisk(t, ctx, h, sandbox1, "test-disk-crash", 10)
+
+	lease1 := getLease(t, ctx, h, lease1ID)
+	require.Equal(t, storage.BOUND, lease1.Status)
+
+	// Simulate crash: mark sandbox DEAD directly, then release leases
+	// (mimics the real flow where the sandbox controller detects the crash)
+	markSandboxDead(t, ctx, h, sandbox1)
+	err := h.FakeSandbox.ReleaseDiskLeases(ctx, sandbox1)
+	require.NoError(t, err)
+
+	h.ReconcileAll(ctx, 20)
+
+	// Boot replacement
+	sandbox2 := entity.Id("sandbox/crash-2")
+	createSandboxEntity(t, ctx, h, sandbox2, compute.PENDING)
+
+	lease2ID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandbox2, "", "/data", false)
+	require.NoError(t, err)
+
+	h.ReconcileAll(ctx, 20)
+
+	lease2 := getLease(t, ctx, h, lease2ID)
+	assert.Equal(t, storage.BOUND, lease2.Status, "crash replacement lease should be BOUND")
+	assert.Equal(t, sandbox2, lease2.SandboxId)
+}
+
+func TestMultipleSandboxesDifferentDisks(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot two sandboxes each with their own disk
+	sandbox1 := entity.Id("sandbox/multi-1")
+	disk1ID, lease1ID := bootSandboxWithDisk(t, ctx, h, sandbox1, "disk-alpha", 10)
+
+	sandbox2 := entity.Id("sandbox/multi-2")
+	disk2ID, lease2ID := bootSandboxWithDisk(t, ctx, h, sandbox2, "disk-beta", 20)
+
+	// Verify both are running with bound leases
+	lease1 := getLease(t, ctx, h, lease1ID)
+	assert.Equal(t, storage.BOUND, lease1.Status)
+	lease2 := getLease(t, ctx, h, lease2ID)
+	assert.Equal(t, storage.BOUND, lease2.Status)
+
+	// Disks should be different
+	assert.NotEqual(t, disk1ID, disk2ID)
+
+	// Stop one sandbox
+	stopSandbox(t, ctx, h, sandbox1)
+	h.ReconcileAll(ctx, 20)
+
+	// The other sandbox should be unaffected
+	lease2After := getLease(t, ctx, h, lease2ID)
+	assert.Equal(t, storage.BOUND, lease2After.Status, "surviving sandbox's lease should still be BOUND")
+
+	sb2 := getSandbox(t, ctx, h, sandbox2)
+	assert.Equal(t, compute.RUNNING, sb2.Status, "surviving sandbox should still be RUNNING")
+}
+
+func TestDiskProvisioningRace(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/race-1")
+	createSandboxEntity(t, ctx, h, sandboxID, compute.PENDING)
+
+	// Create disk and lease
+	diskID, err := h.FakeSandbox.EnsureDisk(ctx, "test-disk-race", 10, "ext4")
+	require.NoError(t, err)
+
+	leaseID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxID, "", "/data", false)
+	require.NoError(t, err)
+
+	// Only reconcile disk (not lsvd volumes yet) — disk should still be PROVISIONING
+	h.reconcileKind(ctx, storage.KindDisk, h.DiskRC)
+
+	disk := getDisk(t, ctx, h, diskID)
+	// After one reconcile the disk creates the lsvd_volume but stays PROVISIONING
+	assert.Equal(t, storage.PROVISIONING, disk.Status, "disk should still be PROVISIONING before volume is ready")
+
+	// Lease should still be PENDING because disk isn't provisioned yet
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+	lease := getLease(t, ctx, h, leaseID)
+	assert.Equal(t, storage.PENDING, lease.Status, "lease should be PENDING while disk provisions")
+
+	// Now run full reconciliation to completion
+	h.ReconcileAll(ctx, 20)
+
+	// Verify everything converges
+	disk = getDisk(t, ctx, h, diskID)
+	assert.Equal(t, storage.PROVISIONED, disk.Status)
+
+	lease = getLease(t, ctx, h, leaseID)
+	assert.Equal(t, storage.BOUND, lease.Status)
+}
+
+func TestRapidStopAndRestart(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot sandbox A with disk
+	sandboxA := entity.Id("sandbox/rapid-a")
+	diskID, leaseAID := bootSandboxWithDisk(t, ctx, h, sandboxA, "test-disk-rapid", 10)
+
+	leaseA := getLease(t, ctx, h, leaseAID)
+	require.Equal(t, storage.BOUND, leaseA.Status)
+
+	// Release A's leases and mark DEAD (but do NOT ReconcileAll yet)
+	err := h.FakeSandbox.ReleaseDiskLeases(ctx, sandboxA)
+	require.NoError(t, err)
+	markSandboxDead(t, ctx, h, sandboxA)
+
+	// Reconcile only the disk-lease controller for A's lease
+	// This processes handleReleasedLease which removes from activeLeases
+	// and sets mount to MNT_WANT_UNMOUNTED, but does NOT unmount yet.
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+
+	// Verify A's lease is RELEASED and mount is marked for unmount
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.RELEASED, leaseA.Status)
+
+	// Create sandbox B and acquire the same disk (should succeed since activeLeases cleared)
+	sandboxB := entity.Id("sandbox/rapid-b")
+	createSandboxEntity(t, ctx, h, sandboxB, compute.PENDING)
+
+	leaseBID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.NoError(t, err, "B should acquire disk while A's mount is still unwinding")
+
+	// Now ReconcileAll to converge everything:
+	// A's mount unmounts, B's mount mounts, B's lease becomes BOUND
+	h.ReconcileAll(ctx, 20)
+
+	// Verify final state
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.RELEASED, leaseA.Status, "A's lease should stay RELEASED")
+
+	leaseB := getLease(t, ctx, h, leaseBID)
+	assert.Equal(t, storage.BOUND, leaseB.Status, "B's lease should be BOUND")
+	assert.Equal(t, sandboxB, leaseB.SandboxId)
+
+	// Exactly 1 mounted lsvd_mount should exist (B's)
+	assert.Equal(t, 1, countMountedMounts(t, ctx, h), "should have exactly 1 mounted lsvd_mount")
+}
+
+func TestAcquireBlockedByBoundLease(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot sandbox A with disk
+	sandboxA := entity.Id("sandbox/block-a")
+	diskID, leaseAID := bootSandboxWithDisk(t, ctx, h, sandboxA, "test-disk-block", 10)
+
+	leaseA := getLease(t, ctx, h, leaseAID)
+	require.Equal(t, storage.BOUND, leaseA.Status)
+
+	// Create sandbox B and try to acquire the same disk — should fail
+	sandboxB := entity.Id("sandbox/block-b")
+	createSandboxEntity(t, ctx, h, sandboxB, compute.PENDING)
+
+	_, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.Error(t, err, "AcquireDiskLease should fail when BOUND lease exists")
+	assert.Contains(t, err.Error(), "active lease")
+
+	// Stop sandbox A (release leases)
+	stopSandbox(t, ctx, h, sandboxA)
+	h.ReconcileAll(ctx, 20)
+
+	// Retry — should succeed now
+	leaseBID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.NoError(t, err, "B should acquire disk after A released")
+
+	h.ReconcileAll(ctx, 20)
+
+	leaseB := getLease(t, ctx, h, leaseBID)
+	assert.Equal(t, storage.BOUND, leaseB.Status, "B's lease should be BOUND")
+
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.RELEASED, leaseA.Status, "A's lease should be RELEASED")
+}
+
+func TestCrashWithoutReleaseBeforeReplace(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot sandbox A with disk
+	sandboxA := entity.Id("sandbox/crash-nr-a")
+	diskID, leaseAID := bootSandboxWithDisk(t, ctx, h, sandboxA, "test-disk-crash-nr", 10)
+
+	leaseA := getLease(t, ctx, h, leaseAID)
+	require.Equal(t, storage.BOUND, leaseA.Status)
+
+	// Simulate crash: mark A DEAD directly, do NOT release leases
+	markSandboxDead(t, ctx, h, sandboxA)
+
+	// Create sandbox B, try to acquire — should fail (lease still BOUND for A)
+	sandboxB := entity.Id("sandbox/crash-nr-b")
+	createSandboxEntity(t, ctx, h, sandboxB, compute.PENDING)
+
+	_, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.Error(t, err, "AcquireDiskLease should fail when unreleased BOUND lease exists")
+	assert.Contains(t, err.Error(), "active lease")
+
+	// Now simulate delayed cleanup: release A's leases
+	err = h.FakeSandbox.ReleaseDiskLeases(ctx, sandboxA)
+	require.NoError(t, err)
+	h.ReconcileAll(ctx, 20)
+
+	// Retry — should succeed now
+	leaseBID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.NoError(t, err, "B should acquire disk after delayed cleanup")
+
+	h.ReconcileAll(ctx, 20)
+
+	leaseB := getLease(t, ctx, h, leaseBID)
+	assert.Equal(t, storage.BOUND, leaseB.Status, "B's lease should be BOUND")
+	assert.Equal(t, sandboxB, leaseB.SandboxId)
+
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.RELEASED, leaseA.Status, "A's lease should be RELEASED")
+}
+
+func TestDeleteSandboxEntityOrphanedLease(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot sandbox A with disk
+	sandboxA := entity.Id("sandbox/orphan-a")
+	diskID, leaseAID := bootSandboxWithDisk(t, ctx, h, sandboxA, "test-disk-orphan", 10)
+
+	leaseA := getLease(t, ctx, h, leaseAID)
+	require.Equal(t, storage.BOUND, leaseA.Status)
+
+	// Delete the sandbox entity (NOT stop, NOT release leases)
+	deleteSandboxEntity(t, ctx, h, sandboxA)
+
+	// Lease should still be BOUND (orphaned)
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.BOUND, leaseA.Status, "orphaned lease should still be BOUND")
+
+	// Sandbox B can't acquire the disk — orphaned BOUND lease blocks it
+	sandboxB := entity.Id("sandbox/orphan-b")
+	createSandboxEntity(t, ctx, h, sandboxB, compute.PENDING)
+
+	_, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.Error(t, err, "AcquireDiskLease should fail with orphaned BOUND lease")
+
+	// Manually patch the orphaned lease to RELEASED
+	patchLeaseStatus(t, ctx, h, leaseAID, storage.RELEASED)
+	h.ReconcileAll(ctx, 20)
+
+	// Now B can acquire the disk
+	leaseBID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.NoError(t, err, "B should acquire disk after orphaned lease released")
+
+	h.ReconcileAll(ctx, 20)
+
+	leaseB := getLease(t, ctx, h, leaseBID)
+	assert.Equal(t, storage.BOUND, leaseB.Status, "B's lease should be BOUND")
+
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.RELEASED, leaseA.Status, "orphaned lease should be RELEASED")
+}
+
+func TestLeaseReleaseIdempotent(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot sandbox A with disk
+	sandboxA := entity.Id("sandbox/idempotent-a")
+	_, leaseAID := bootSandboxWithDisk(t, ctx, h, sandboxA, "test-disk-idempotent", 10)
+
+	leaseA := getLease(t, ctx, h, leaseAID)
+	require.Equal(t, storage.BOUND, leaseA.Status)
+
+	// Release leases — first time
+	err := h.FakeSandbox.ReleaseDiskLeases(ctx, sandboxA)
+	require.NoError(t, err)
+
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.RELEASED, leaseA.Status)
+
+	// Release leases — second time (should be a no-op)
+	err = h.FakeSandbox.ReleaseDiskLeases(ctx, sandboxA)
+	require.NoError(t, err)
+
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.RELEASED, leaseA.Status, "lease should still be RELEASED after double release")
+
+	// ReconcileAll should converge normally
+	h.ReconcileAll(ctx, 20)
+
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.RELEASED, leaseA.Status, "lease should remain RELEASED")
+}
+
+func TestDeleteLeaseEntity(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot sandbox A with disk
+	sandboxA := entity.Id("sandbox/dellease-a")
+	diskID, leaseAID := bootSandboxWithDisk(t, ctx, h, sandboxA, "test-disk-dellease", 10)
+
+	leaseA := getLease(t, ctx, h, leaseAID)
+	require.Equal(t, storage.BOUND, leaseA.Status)
+
+	// Verify mount exists and is mounted
+	assert.Equal(t, 1, countMountedMounts(t, ctx, h))
+
+	// Delete the lease entity from the store
+	deleteLeaseEntity(t, ctx, h, leaseAID)
+
+	// Fire a delete event to the DiskLeaseController so it processes cleanup
+	deleteEvent := controller.Event{
+		Type: controller.EventDeleted,
+		Id:   leaseAID,
+	}
+	err := h.DiskLeaseRC.ProcessEventForTest(ctx, deleteEvent)
+	require.NoError(t, err)
+
+	// ReconcileAll to process mount cleanup
+	h.ReconcileAll(ctx, 20)
+
+	// Disk should still be PROVISIONED
+	disk := getDisk(t, ctx, h, diskID)
+	assert.Equal(t, storage.PROVISIONED, disk.Status, "disk should still be PROVISIONED")
+
+	// New sandbox B should be able to acquire the disk
+	sandboxB := entity.Id("sandbox/dellease-b")
+	createSandboxEntity(t, ctx, h, sandboxB, compute.PENDING)
+
+	leaseBID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.NoError(t, err, "B should acquire disk after lease entity deleted")
+
+	h.ReconcileAll(ctx, 20)
+
+	leaseB := getLease(t, ctx, h, leaseBID)
+	assert.Equal(t, storage.BOUND, leaseB.Status, "B's lease should be BOUND")
+}
+
+func TestPoolScaleDownReleasesDisks(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Set up 3 running sandboxes with disks
+	type sbInfo struct {
+		id      entity.Id
+		diskID  entity.Id
+		leaseID entity.Id
+	}
+
+	var sandboxes []sbInfo
+	for i := 0; i < 3; i++ {
+		sbID := entity.Id(entity.Id("sandbox/scale-" + string(rune('a'+i))))
+		diskName := "scale-disk-" + string(rune('a'+i))
+		diskID, leaseID := bootSandboxWithDisk(t, ctx, h, sbID, diskName, 10)
+		sandboxes = append(sandboxes, sbInfo{id: sbID, diskID: diskID, leaseID: leaseID})
+	}
+
+	// Verify all 3 have bound leases
+	for _, sb := range sandboxes {
+		lease := getLease(t, ctx, h, sb.leaseID)
+		require.Equal(t, storage.BOUND, lease.Status, "sandbox %s lease should be BOUND", sb.id)
+	}
+
+	// Simulate pool scale-down: stop 2 sandboxes (keep the first)
+	for _, sb := range sandboxes[1:] {
+		stopSandbox(t, ctx, h, sb.id)
+	}
+	h.ReconcileAll(ctx, 20)
+
+	// Verify: first sandbox still running with BOUND lease
+	lease0 := getLease(t, ctx, h, sandboxes[0].leaseID)
+	assert.Equal(t, storage.BOUND, lease0.Status, "surviving sandbox's lease should be BOUND")
+
+	sb0 := getSandbox(t, ctx, h, sandboxes[0].id)
+	assert.Equal(t, compute.RUNNING, sb0.Status)
+
+	// Verify: stopped sandboxes have RELEASED leases
+	for _, sb := range sandboxes[1:] {
+		lease := getLease(t, ctx, h, sb.leaseID)
+		assert.Equal(t, storage.RELEASED, lease.Status, "stopped sandbox %s lease should be RELEASED", sb.id)
+	}
+}
+
+func TestBoundLeaseSelfHealsAfterMountDeleted(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/self-heal-1")
+	diskID, leaseID := bootSandboxWithDisk(t, ctx, h, sandboxID, "test-disk-selfheal", 10)
+
+	// Verify initial state
+	lease := getLease(t, ctx, h, leaseID)
+	require.Equal(t, storage.BOUND, lease.Status)
+	assert.Equal(t, 1, countMountedMounts(t, ctx, h))
+
+	// Find and delete the lsvd_mount entity
+	mount := getMountForLease(t, ctx, h, leaseID)
+	require.NotNil(t, mount, "should have an lsvd_mount")
+	deleteMountEntity(t, ctx, h, mount.ID)
+
+	// Reconcile disk-lease controller — handleBoundLease sees no mount, reverts to PENDING
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+
+	lease = getLease(t, ctx, h, leaseID)
+	assert.Equal(t, storage.PENDING, lease.Status, "lease should revert to PENDING when mount is deleted")
+
+	// ReconcileAll — system should self-heal: create new mount, re-bind lease
+	h.ReconcileAll(ctx, 20)
+
+	lease = getLease(t, ctx, h, leaseID)
+	assert.Equal(t, storage.BOUND, lease.Status, "lease should self-heal back to BOUND")
+	assert.Equal(t, 1, countMountedMounts(t, ctx, h), "should have exactly 1 mounted mount after self-heal")
+
+	disk := getDisk(t, ctx, h, diskID)
+	assert.Equal(t, storage.PROVISIONED, disk.Status)
+}
+
+func TestBoundLeaseMountError(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot sandbox A with disk
+	sandboxA := entity.Id("sandbox/mnterr-a")
+	diskID, leaseAID := bootSandboxWithDisk(t, ctx, h, sandboxA, "test-disk-mnterr", 10)
+
+	lease := getLease(t, ctx, h, leaseAID)
+	require.Equal(t, storage.BOUND, lease.Status)
+
+	// Patch mount to MNT_ERROR
+	mount := getMountForLease(t, ctx, h, leaseAID)
+	require.NotNil(t, mount)
+	patchMountError(t, ctx, h, mount.ID, "disk I/O error")
+
+	// Reconcile disk-lease — handleBoundLease detects MNT_ERROR
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+
+	lease = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.FAILED, lease.Status, "lease should be FAILED when mount errors")
+	assert.Contains(t, lease.ErrorMessage, "Mount failed")
+
+	// Stop sandbox A so its FAILED lease gets released from tracking
+	stopSandbox(t, ctx, h, sandboxA)
+	h.ReconcileAll(ctx, 20)
+
+	// New sandbox B should be able to acquire the disk
+	sandboxB := entity.Id("sandbox/mnterr-b")
+	createSandboxEntity(t, ctx, h, sandboxB, compute.PENDING)
+
+	leaseBID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.NoError(t, err, "B should acquire disk after A's lease failed")
+
+	h.ReconcileAll(ctx, 20)
+
+	leaseB := getLease(t, ctx, h, leaseBID)
+	assert.Equal(t, storage.BOUND, leaseB.Status, "B's lease should be BOUND")
+}
+
+func TestPendingLeaseMountError(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/pendmnterr-1")
+	createSandboxEntity(t, ctx, h, sandboxID, compute.PENDING)
+
+	// Create disk and lease
+	diskID, err := h.FakeSandbox.EnsureDisk(ctx, "test-disk-pendmnterr", 10, "ext4")
+	require.NoError(t, err)
+
+	leaseID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxID, "", "/data", false)
+	require.NoError(t, err)
+
+	// ReconcileAll to drive disk to PROVISIONED and create the lsvd_mount entity
+	h.ReconcileAll(ctx, 20)
+
+	// If the lease is already BOUND, the mount was created and is MNT_MOUNTED.
+	// Revert to PENDING to test the pending-lease mount-error path.
+	lease := getLease(t, ctx, h, leaseID)
+	if lease.Status == storage.BOUND {
+		// Patch lease back to PENDING
+		patchLeaseStatus(t, ctx, h, leaseID, storage.PENDING)
+	}
+
+	// Find the mount and patch it to MNT_ERROR
+	mount := getMountForLease(t, ctx, h, leaseID)
+	require.NotNil(t, mount, "should have an lsvd_mount")
+	patchMountError(t, ctx, h, mount.ID, "filesystem corruption detected")
+
+	// Reconcile disk-lease — handlePendingLease sees existing mount in MNT_ERROR
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+
+	lease = getLease(t, ctx, h, leaseID)
+	assert.Equal(t, storage.FAILED, lease.Status, "lease should be FAILED when mount has error")
+	assert.Contains(t, lease.ErrorMessage, "Mount failed")
+
+	// Disk should still be PROVISIONED
+	disk := getDisk(t, ctx, h, diskID)
+	assert.Equal(t, storage.PROVISIONED, disk.Status, "disk should still be PROVISIONED")
+}
+
+func TestDiskDeletionLifecycle(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/diskdel-1")
+	diskID, leaseID := bootSandboxWithDisk(t, ctx, h, sandboxID, "test-disk-del", 10)
+
+	lease := getLease(t, ctx, h, leaseID)
+	require.Equal(t, storage.BOUND, lease.Status)
+
+	// Stop sandbox, reconcile to release lease and unmount
+	stopSandbox(t, ctx, h, sandboxID)
+	h.ReconcileAll(ctx, 20)
+
+	lease = getLease(t, ctx, h, leaseID)
+	require.Equal(t, storage.RELEASED, lease.Status)
+
+	// Patch disk to DELETING
+	patchDiskStatus(t, ctx, h, diskID, storage.DELETING)
+
+	// Reconcile disk controller — should set lsvd_volume desired_state to VOL_ABSENT
+	h.reconcileKind(ctx, storage.KindDisk, h.DiskRC)
+
+	// Check that volume desired_state is VOL_ABSENT
+	vols := listLsvdVolumes(t, ctx, h)
+	require.NotEmpty(t, vols, "should still have lsvd_volume")
+	assert.Equal(t, storage.VOL_ABSENT, vols[0].DesiredState, "volume desired_state should be VOL_ABSENT")
+
+	// Reconcile lsvd-volume — volume controller processes deletion
+	nodeId := entity.Id("node/" + testNodeId)
+	h.reconcileByIndex(ctx, entity.Ref(storage.LsvdVolumeNodeIdId, nodeId), h.LsvdVolRC)
+
+	// Volume should now be VOL_DELETED
+	vols = listLsvdVolumes(t, ctx, h)
+	require.NotEmpty(t, vols, "volume entity should still exist")
+	assert.Equal(t, storage.VOL_DELETED, vols[0].ActualState, "volume actual_state should be VOL_DELETED")
+
+	// Reconcile disk again — should delete the volume entity and then the disk entity
+	h.reconcileKind(ctx, storage.KindDisk, h.DiskRC)
+	// The first reconcile deletes the volume entity. The disk entity may need another pass.
+	h.reconcileKind(ctx, storage.KindDisk, h.DiskRC)
+
+	// Verify cleanup
+	disks := listDisks(t, ctx, h)
+	assert.Empty(t, disks, "all disks should be deleted")
+
+	vols = listLsvdVolumes(t, ctx, h)
+	assert.Empty(t, vols, "all lsvd_volumes should be deleted")
+}
+
+func TestDiskErrorBlocksLease(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/diskerr-1")
+	createSandboxEntity(t, ctx, h, sandboxID, compute.PENDING)
+
+	// Create disk (starts as PROVISIONING) and lease (starts as PENDING)
+	diskID, err := h.FakeSandbox.EnsureDisk(ctx, "test-disk-err", 10, "ext4")
+	require.NoError(t, err)
+
+	leaseID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxID, "", "/data", false)
+	require.NoError(t, err)
+
+	// Patch disk to ERROR before it finishes provisioning
+	patchDiskStatus(t, ctx, h, diskID, storage.ERROR)
+
+	// Reconcile disk-lease — handlePendingLease sees ERROR disk
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+
+	lease := getLease(t, ctx, h, leaseID)
+	assert.Equal(t, storage.FAILED, lease.Status, "lease should be FAILED when disk is in ERROR")
+	assert.Contains(t, lease.ErrorMessage, "not provisioned")
+
+	// Disk should still be ERROR (unchanged)
+	disk := getDisk(t, ctx, h, diskID)
+	assert.Equal(t, storage.ERROR, disk.Status)
+}
+
+func TestLeaseConflictDetection(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot sandbox A with disk — lease A is BOUND and tracked in activeLeases
+	sandboxA := entity.Id("sandbox/conflict-a")
+	diskID, leaseAID := bootSandboxWithDisk(t, ctx, h, sandboxA, "test-disk-conflict", 10)
+
+	leaseA := getLease(t, ctx, h, leaseAID)
+	require.Equal(t, storage.BOUND, leaseA.Status)
+
+	// Directly create a second lease entity for the same disk/node, different sandbox,
+	// with BOUND status (simulates entity corruption or race)
+	sandboxB := entity.Id("sandbox/conflict-b")
+	createSandboxEntity(t, ctx, h, sandboxB, compute.PENDING)
+
+	conflictLease := &storage.DiskLease{
+		DiskId:     diskID,
+		SandboxId:  sandboxB,
+		Status:     storage.BOUND,
+		AcquiredAt: time.Now(),
+		Mount: storage.Mount{
+			Path:    "/data",
+			Options: "rw",
+		},
+		NodeId: entity.Id("node/" + testNodeId),
+	}
+
+	conflictLeaseID := entity.Id("disk-lease/" + idgen.GenNS("disk-lease"))
+	_, err := h.EAC.Create(ctx, entity.New(
+		entity.DBId, conflictLeaseID,
+		conflictLease.Encode,
+	).Attrs())
+	require.NoError(t, err, "should be able to create conflicting lease entity")
+
+	// Reconcile disk-lease controller — handleBoundLease should detect conflict
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+
+	// The conflicting lease (the one NOT tracked in activeLeases) should be FAILED
+	conflictResult := getLease(t, ctx, h, conflictLeaseID)
+	assert.Equal(t, storage.FAILED, conflictResult.Status, "conflicting lease should be FAILED")
+	assert.Contains(t, conflictResult.ErrorMessage, "conflict", "error should mention conflict")
+
+	// Lease A should still be BOUND
+	leaseA = getLease(t, ctx, h, leaseAID)
+	assert.Equal(t, storage.BOUND, leaseA.Status, "original lease should still be BOUND")
+
+	// Mount should still be healthy
+	assert.Equal(t, 1, countMountedMounts(t, ctx, h), "should still have exactly 1 mounted mount")
+}
+
+func TestConvergenceStability(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/stable-1")
+	diskID, leaseID := bootSandboxWithDisk(t, ctx, h, sandboxID, "test-disk-stable", 10)
+
+	// Snapshot entity states
+	disk := getDisk(t, ctx, h, diskID)
+	require.Equal(t, storage.PROVISIONED, disk.Status)
+
+	lease := getLease(t, ctx, h, leaseID)
+	require.Equal(t, storage.BOUND, lease.Status)
+
+	vols := listLsvdVolumes(t, ctx, h)
+	require.Len(t, vols, 1)
+	volState := vols[0].ActualState
+	volDesired := vols[0].DesiredState
+
+	mounts := listLsvdMounts(t, ctx, h)
+	require.Len(t, mounts, 1)
+	mountActual := mounts[0].ActualState
+	mountDesired := mounts[0].DesiredState
+
+	// Run reconciliation again (5 iterations)
+	h.ReconcileAll(ctx, 5)
+
+	// Re-read all entities and assert no state changes
+	disk2 := getDisk(t, ctx, h, diskID)
+	assert.Equal(t, disk.Status, disk2.Status, "disk status should not change on re-reconcile")
+
+	lease2 := getLease(t, ctx, h, leaseID)
+	assert.Equal(t, lease.Status, lease2.Status, "lease status should not change on re-reconcile")
+
+	vols2 := listLsvdVolumes(t, ctx, h)
+	require.Len(t, vols2, 1)
+	assert.Equal(t, volState, vols2[0].ActualState, "volume actual_state should not change")
+	assert.Equal(t, volDesired, vols2[0].DesiredState, "volume desired_state should not change")
+
+	mounts2 := listLsvdMounts(t, ctx, h)
+	require.Len(t, mounts2, 1)
+	assert.Equal(t, mountActual, mounts2[0].ActualState, "mount actual_state should not change")
+	assert.Equal(t, mountDesired, mounts2[0].DesiredState, "mount desired_state should not change")
+}

--- a/controllers/integration/mock_ops.go
+++ b/controllers/integration/mock_ops.go
@@ -92,6 +92,7 @@ func (m *mockMountOps) NBDLoopback(_ context.Context, _ uint64) (uint32, net.Con
 	cleanup := func() error {
 		clientConn.Close()
 		serverConn.Close()
+		_ = tmpFile.Close()
 		os.Remove(tmpFile.Name())
 		return nil
 	}

--- a/controllers/integration/mock_ops.go
+++ b/controllers/integration/mock_ops.go
@@ -1,0 +1,173 @@
+package integration
+
+import (
+	"context"
+	"net"
+	"os"
+
+	lsvdserver "miren.dev/runtime/components/lsvd/server"
+	"miren.dev/runtime/pkg/units"
+)
+
+// mockVolumeOps implements lsvdserver.VolumeOps for testing.
+type mockVolumeOps struct {
+	createdDirs   []string
+	existingPaths map[string]bool
+}
+
+func newMockVolumeOps() *mockVolumeOps {
+	return &mockVolumeOps{
+		existingPaths: make(map[string]bool),
+	}
+}
+
+func (m *mockVolumeOps) CreateVolumeDir(path string) error {
+	m.createdDirs = append(m.createdDirs, path)
+	m.existingPaths[path] = true
+	return nil
+}
+
+func (m *mockVolumeOps) RemoveVolumeDir(path string) error {
+	delete(m.existingPaths, path)
+	return nil
+}
+
+func (m *mockVolumeOps) VolumePathExists(path string) bool {
+	return m.existingPaths[path]
+}
+
+func (m *mockVolumeOps) InitLSVDVolume(_ context.Context, _, volumeId string, _ units.Bytes, _ map[string]any, _ bool) (string, error) {
+	return volumeId, nil
+}
+
+// Verify interface compliance
+var _ lsvdserver.VolumeOps = (*mockVolumeOps)(nil)
+
+// mockMountOps implements lsvdserver.MountOps for testing.
+// In integration tests we use directory-mode on the DiskController/DiskLeaseController
+// side, so the MountController's ops are only called for lsvd_mount entity reconciliation.
+// The mock ops simulate successful NBD attach/mount/format flows without real OS interaction.
+type mockMountOps struct {
+	existingMounts map[string]bool
+	formattedDisks map[string]string // device -> filesystem
+	nbdStatuses    map[uint32]error
+	nextNBDIndex   uint32
+	openDiskCalls  int
+
+	mockDisk *mockLSVDDisk
+}
+
+func newMockMountOps() *mockMountOps {
+	return &mockMountOps{
+		existingMounts: make(map[string]bool),
+		formattedDisks: make(map[string]string),
+		nbdStatuses:    make(map[uint32]error),
+		nextNBDIndex:   1,
+		mockDisk:       &mockLSVDDisk{size: 10 * 1024 * 1024 * 1024}, // 10GB
+	}
+}
+
+func (m *mockMountOps) CreateDir(_ string, _ os.FileMode) error {
+	return nil
+}
+
+func (m *mockMountOps) RemoveFile(_ string) error {
+	return nil
+}
+
+func (m *mockMountOps) NBDLoopback(_ context.Context, _ uint64) (uint32, net.Conn, *os.File, func() error, error) {
+	idx := m.nextNBDIndex
+	m.nextNBDIndex++
+	m.nbdStatuses[idx] = nil
+
+	// Create a pipe for mock conn
+	serverConn, clientConn := net.Pipe()
+	_ = serverConn // not used in tests
+
+	tmpFile, err := os.CreateTemp("", "mock-nbd-*")
+	if err != nil {
+		return 0, nil, nil, nil, err
+	}
+
+	cleanup := func() error {
+		clientConn.Close()
+		serverConn.Close()
+		os.Remove(tmpFile.Name())
+		return nil
+	}
+
+	return idx, clientConn, tmpFile, cleanup, nil
+}
+
+func (m *mockMountOps) NBDStatus(idx uint32) error {
+	if err, ok := m.nbdStatuses[idx]; ok {
+		return err
+	}
+	return nil
+}
+
+func (m *mockMountOps) NBDDisconnect(_ uint32) error {
+	return nil
+}
+
+func (m *mockMountOps) CreateDeviceNode(_ string, _ uint32) error {
+	return nil
+}
+
+func (m *mockMountOps) Mount(_, mountPath, _ string, _ bool) error {
+	m.existingMounts[mountPath] = true
+	return nil
+}
+
+func (m *mockMountOps) Unmount(path string) error {
+	delete(m.existingMounts, path)
+	return nil
+}
+
+func (m *mockMountOps) IsMounted(path string) bool {
+	return m.existingMounts[path]
+}
+
+func (m *mockMountOps) IsFormatted(device, _ string) (bool, error) {
+	_, ok := m.formattedDisks[device]
+	return ok, nil
+}
+
+func (m *mockMountOps) FormatDevice(_ context.Context, device, filesystem string) error {
+	m.formattedDisks[device] = filesystem
+	return nil
+}
+
+func (m *mockMountOps) OpenLSVDDisk(_ context.Context, _, _ string, _ bool, _ string) (lsvdserver.LSVDDisk, error) {
+	m.openDiskCalls++
+	return m.mockDisk, nil
+}
+
+func (m *mockMountOps) AcquireVolumeLease(_ context.Context, _ string, _ map[string]any) (string, error) {
+	return "mock-nonce", nil
+}
+
+func (m *mockMountOps) ReleaseVolumeLease(_ context.Context, _, _ string) error {
+	return nil
+}
+
+// Verify interface compliance
+var _ lsvdserver.MountOps = (*mockMountOps)(nil)
+
+// mockLSVDDisk implements lsvdserver.LSVDDisk for testing.
+type mockLSVDDisk struct {
+	size int64
+}
+
+func (d *mockLSVDDisk) Close(_ context.Context) error {
+	return nil
+}
+
+func (d *mockLSVDDisk) Size() int64 {
+	return d.size
+}
+
+func (d *mockLSVDDisk) HandleNBD(ctx context.Context, _ net.Conn, _ *os.File) error {
+	<-ctx.Done()
+	return ctx.Err()
+}

--- a/controllers/integration/overlapping_test.go
+++ b/controllers/integration/overlapping_test.go
@@ -162,7 +162,7 @@ func TestStopDuringMountCreation(t *testing.T) {
 			h.reconcileByIndex(ctx, entity.Ref(storage.LsvdVolumeNodeIdId, nodeId), h.LsvdVolRC)
 			h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
 		}
-		mount = getMountForLease(t, ctx, h, leaseID)
+		_ = getMountForLease(t, ctx, h, leaseID)
 	}
 
 	// Stop sandbox BEFORE mount controller runs
@@ -257,9 +257,7 @@ func TestReplacementMountPathCollision(t *testing.T) {
 	// This is the worst case ordering that exposes the path collision bug.
 	for i := 0; i < 3; i++ {
 		err = h.ReconcileEntity(ctx, mountBID)
-		if err != nil {
-			break
-		}
+		require.NoError(t, err, "ReconcileEntity for mount-B should not fail")
 		bState := getMountByID(t, ctx, h, mountBID)
 		if bState.ActualState == storage.MNT_MOUNTED {
 			break

--- a/controllers/integration/overlapping_test.go
+++ b/controllers/integration/overlapping_test.go
@@ -1,0 +1,290 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// Tests in this file verify invariants under overlapping and dependent events.
+// Each test creates a specific interleaving of controller actions that can
+// expose bugs in how controllers handle concurrent state transitions.
+
+// TestBoundLeaseRecoverFromDetachedMount verifies that a BOUND lease
+// recovers when its mount reaches MNT_DETACHED.
+//
+// Invariant: A BOUND lease must always have a MNT_MOUNTED mount. If the
+// mount reaches a terminal non-mounted state, the lease must revert to
+// PENDING so a new mount is created.
+//
+// Scenario: NBD handler crashes → mount cleanup transitions the mount
+// entity to MNT_DETACHED, but the lease wasn't updated. The lease
+// controller should detect the dead mount and trigger recovery.
+//
+// Bug: handleBoundLease only checks for nil mount (→ PENDING) and
+// MNT_ERROR (→ FAILED). MNT_DETACHED falls into the else branch which
+// just logs a debug message, leaving the lease BOUND with no working mount.
+// The mount controller also doesn't handle MNT_DETACHED in
+// reconcileMountMounted, so neither controller self-heals.
+func TestBoundLeaseRecoverFromDetachedMount(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/recover-detach-1")
+	_, leaseID := bootSandboxWithDisk(t, ctx, h, sandboxID, "disk-recover-detach", 10)
+
+	lease := getLease(t, ctx, h, leaseID)
+	require.Equal(t, storage.BOUND, lease.Status)
+
+	mount := getMountForLease(t, ctx, h, leaseID)
+	require.NotNil(t, mount)
+	require.Equal(t, storage.MNT_MOUNTED, mount.ActualState)
+
+	// Simulate mount cleanup without lease update: patch mount to MNT_DETACHED.
+	// desired_state stays MNT_WANT_MOUNTED (as it was when the lease was BOUND).
+	patchMountActualState(t, ctx, h, mount.ID, storage.LsvdMountActualStateMntDetachedId)
+
+	// Run full reconciliation — both controllers get a chance to react
+	h.ReconcileAll(ctx, 20)
+
+	// Invariant: lease should have self-healed back to BOUND with a working mount.
+	lease = getLease(t, ctx, h, leaseID)
+	if lease.Status == storage.BOUND {
+		currentMount := getMountForLease(t, ctx, h, leaseID)
+		if currentMount != nil {
+			assert.Equal(t, storage.MNT_MOUNTED, currentMount.ActualState,
+				"BOUND lease's mount should be MNT_MOUNTED, not %s — "+
+					"neither handleBoundLease nor reconcileMountMounted recovers from MNT_DETACHED",
+				currentMount.ActualState)
+		} else {
+			t.Error("BOUND lease has no mount entity — stuck without self-healing")
+		}
+	}
+	// If lease reverted to PENDING, that's an acceptable intermediate step
+	// as long as ReconcileAll eventually drives it back to BOUND.
+	// The key failure is staying BOUND with a DETACHED mount.
+}
+
+// TestPendingLeaseNotStuckOnDetachedMount verifies that a PENDING lease
+// does not wait indefinitely on an existing mount in MNT_DETACHED.
+//
+// Invariant: A PENDING lease must either progress toward BOUND or transition
+// to FAILED. It must not wait forever on a mount that will never progress.
+//
+// Scenario: A mount was created for the lease, but something went wrong
+// and the mount ended up DETACHED. The lease was reverted to PENDING for
+// retry. The stale mount entity in DETACHED state blocks the lease.
+//
+// Bug: handlePendingLease's switch on existingMount.ActualState has cases
+// for MNT_MOUNTED (bind) and MNT_ERROR (fail). The default returns nil
+// ("wait"), but MNT_DETACHED is a terminal state that never progresses.
+func TestPendingLeaseNotStuckOnDetachedMount(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/stuck-detach-1")
+	_, leaseID := bootSandboxWithDisk(t, ctx, h, sandboxID, "disk-stuck-detach", 10)
+
+	lease := getLease(t, ctx, h, leaseID)
+	require.Equal(t, storage.BOUND, lease.Status)
+
+	mount := getMountForLease(t, ctx, h, leaseID)
+	require.NotNil(t, mount)
+
+	// Simulate: mount cleanup completed, lease reverted to PENDING for retry.
+	patchMountActualState(t, ctx, h, mount.ID, storage.LsvdMountActualStateMntDetachedId)
+	patchLeaseStatus(t, ctx, h, leaseID, storage.PENDING)
+
+	// Run full reconciliation
+	h.ReconcileAll(ctx, 20)
+
+	// Invariant: lease should have progressed past PENDING.
+	lease = getLease(t, ctx, h, leaseID)
+	assert.NotEqual(t, storage.PENDING, lease.Status,
+		"PENDING lease with MNT_DETACHED mount should not stay PENDING — "+
+			"handlePendingLease treats MNT_DETACHED as 'in progress' but it's terminal")
+
+	// Best case: lease is BOUND with a fresh mount
+	if lease.Status == storage.BOUND {
+		currentMount := getMountForLease(t, ctx, h, leaseID)
+		require.NotNil(t, currentMount)
+		assert.Equal(t, storage.MNT_MOUNTED, currentMount.ActualState)
+	}
+}
+
+// TestStopDuringMountCreation verifies that stopping a sandbox while its
+// disk mount entity has been created but not yet processed by the mount
+// controller results in clean convergence with no leaked resources.
+//
+// Invariant: After stopping a sandbox and running reconciliation to
+// convergence, there must be no MNT_MOUNTED mounts and no stuck leases.
+//
+// Scenario:
+//  1. Lease controller creates lsvd_mount entity (MNT_PENDING)
+//  2. Before mount controller processes it, sandbox is stopped
+//  3. Lease goes RELEASED → mount desired becomes MNT_WANT_UNMOUNTED
+//  4. Mount controller sees desired=UNMOUNTED, actual=PENDING → cleans up
+func TestStopDuringMountCreation(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	sandboxID := entity.Id("sandbox/stopcreate-1")
+	createSandboxEntity(t, ctx, h, sandboxID, compute.PENDING)
+
+	diskID, err := h.FakeSandbox.EnsureDisk(ctx, "disk-stopcreate", 10, "ext4")
+	require.NoError(t, err)
+
+	leaseID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxID, "", "/data", false)
+	require.NoError(t, err)
+
+	// Drive disk to PROVISIONED without processing the mount
+	nodeId := entity.Id("node/" + testNodeId)
+	for i := 0; i < 5; i++ {
+		h.reconcileKind(ctx, storage.KindDisk, h.DiskRC)
+		h.reconcileByIndex(ctx, entity.Ref(storage.LsvdVolumeNodeIdId, nodeId), h.LsvdVolRC)
+	}
+
+	// Reconcile ONLY the lease controller to create mount entity
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+
+	// Verify mount entity exists but hasn't been mounted
+	mount := getMountForLease(t, ctx, h, leaseID)
+	// If mount wasn't created (disk still provisioning), drive more reconciliation
+	if mount == nil {
+		for i := 0; i < 3; i++ {
+			h.reconcileKind(ctx, storage.KindDisk, h.DiskRC)
+			h.reconcileByIndex(ctx, entity.Ref(storage.LsvdVolumeNodeIdId, nodeId), h.LsvdVolRC)
+			h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+		}
+		mount = getMountForLease(t, ctx, h, leaseID)
+	}
+
+	// Stop sandbox BEFORE mount controller runs
+	err = h.FakeSandbox.ReleaseDiskLeases(ctx, sandboxID)
+	require.NoError(t, err)
+	markSandboxDead(t, ctx, h, sandboxID)
+
+	// Reconcile everything to convergence
+	h.ReconcileAll(ctx, 20)
+
+	// Invariant: lease should be RELEASED
+	lease := getLease(t, ctx, h, leaseID)
+	assert.Equal(t, storage.RELEASED, lease.Status, "lease should be RELEASED after stop")
+
+	// Invariant: no mounted mounts should exist
+	assert.Equal(t, 0, countMountedMounts(t, ctx, h),
+		"no mounts should be MOUNTED after sandbox stopped before mount completed")
+}
+
+// TestReplacementMountPathCollision verifies that when a replacement
+// sandbox acquires the same disk, the old mount's unmount doesn't destroy
+// the new mount at the shared filesystem path.
+//
+// Invariant: After convergence, the replacement sandbox should have a
+// BOUND lease and a functioning MNT_MOUNTED mount.
+//
+// Scenario:
+//  1. Sandbox A running → BOUND lease, MNT_MOUNTED at path P
+//  2. A stopped → lease RELEASED, mount desired=UNMOUNTED (actual still MOUNTED)
+//  3. B created → acquires same disk → new mount entity at same path P
+//  4. Mount controller processes both: if B's mount is processed first, B
+//     mounts at P, then A unmounts P → B's mount is destroyed
+//
+// Bug: The mount controller uses path-based unmount (Unmount(mountPath)) but
+// entity-based state tracking. Two mount entities can share the same path
+// when they reference the same disk. Unmounting one destroys the other.
+func TestReplacementMountPathCollision(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	// Boot sandbox A
+	sandboxA := entity.Id("sandbox/pathcol-a")
+	diskID, leaseAID := bootSandboxWithDisk(t, ctx, h, sandboxA, "disk-pathcol", 10)
+
+	leaseA := getLease(t, ctx, h, leaseAID)
+	require.Equal(t, storage.BOUND, leaseA.Status)
+
+	mountA := getMountForLease(t, ctx, h, leaseAID)
+	require.NotNil(t, mountA)
+	require.Equal(t, storage.MNT_MOUNTED, mountA.ActualState)
+	mountAID := mountA.ID
+	sharedMountPath := mountA.MountPath
+	require.NotEmpty(t, sharedMountPath)
+
+	// Stop A: release lease, do NOT reconcile mount controller yet
+	err := h.FakeSandbox.ReleaseDiskLeases(ctx, sandboxA)
+	require.NoError(t, err)
+	markSandboxDead(t, ctx, h, sandboxA)
+
+	// Reconcile ONLY lease controller — marks mount-A for unmount but
+	// mount controller hasn't run so mount-A is still "mounted" in the mock
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+
+	mountAEntity := getMountByID(t, ctx, h, mountAID)
+	require.Equal(t, storage.MNT_WANT_UNMOUNTED, mountAEntity.DesiredState,
+		"mount-A should be marked for unmount")
+
+	// Boot sandbox B with same disk
+	sandboxB := entity.Id("sandbox/pathcol-b")
+	createSandboxEntity(t, ctx, h, sandboxB, compute.PENDING)
+
+	leaseBID, err := h.FakeSandbox.AcquireDiskLease(ctx, diskID, sandboxB, "", "/data", false)
+	require.NoError(t, err)
+
+	// Reconcile lease controller to create mount-B
+	h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+
+	mountB := getMountForLease(t, ctx, h, leaseBID)
+	// May need more reconcile rounds if disk provisioning check deferred
+	if mountB == nil {
+		h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
+		mountB = getMountForLease(t, ctx, h, leaseBID)
+	}
+	require.NotNil(t, mountB, "mount-B should have been created")
+	mountBID := mountB.ID
+
+	// Both mounts should target the same path (same underlying disk/volume)
+	assert.Equal(t, sharedMountPath, mountB.MountPath,
+		"both mounts should share the same path since they reference the same disk")
+
+	// KEY INTERLEAVING: Process mount-B first (attach+mount), then mount-A (unmount).
+	// This is the worst case ordering that exposes the path collision bug.
+	for i := 0; i < 3; i++ {
+		err = h.ReconcileEntity(ctx, mountBID)
+		if err != nil {
+			break
+		}
+		bState := getMountByID(t, ctx, h, mountBID)
+		if bState.ActualState == storage.MNT_MOUNTED {
+			break
+		}
+	}
+
+	// Verify mount-B is mounted in the mock
+	require.True(t, h.MockMountOps.IsMounted(sharedMountPath),
+		"mount-B should have mounted at the shared path")
+
+	// Now process mount-A's unmount — this is where the collision happens
+	err = h.ReconcileEntity(ctx, mountAID)
+	require.NoError(t, err)
+
+	// Check: A's unmount should NOT have destroyed B's mount
+	assert.True(t, h.MockMountOps.IsMounted(sharedMountPath),
+		"mount-B's path should still be mounted after mount-A's unmount — "+
+			"A's unmount at the shared path destroyed B's active mount")
+
+	// Even if the above fails, run ReconcileAll to check convergence
+	h.ReconcileAll(ctx, 20)
+
+	// After convergence, B should be fully functional
+	leaseB := getLease(t, ctx, h, leaseBID)
+	assert.Equal(t, storage.BOUND, leaseB.Status, "B's lease should be BOUND")
+	assert.Equal(t, 1, countMountedMounts(t, ctx, h),
+		"should have exactly 1 mounted mount after convergence")
+}

--- a/controllers/integration/reconcile_system_test.go
+++ b/controllers/integration/reconcile_system_test.go
@@ -1,0 +1,187 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
+	lsvdserver "miren.dev/runtime/components/lsvd/server"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// TestReconcileWithSystemSkipsUnmountingMounts verifies that ReconcileWithSystem
+// does NOT attempt to reconnect NBD devices for mounts whose entity has
+// desired_state=MNT_WANT_UNMOUNTED. This prevents a race condition where:
+//
+//  1. unmountAndDetach() deletes the handler from the map but hasn't yet cleaned
+//     up local state
+//  2. ReconcileWithSystem fires on its 30s timer, finds the mount state with no
+//     handler, and wastes time reconnecting a mount that's being torn down
+func TestReconcileWithSystemSkipsUnmountingMounts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	h := NewTestHarness(t)
+
+	// Set up volume state in LSVD state so reconnectNBD can find the volume
+	volumeEntityId := "dev.miren.storage/kind.lsvd_volume/test-vol-1"
+	h.LsvdState.SetVolume(volumeEntityId, &lsvdserver.VolumeState{
+		EntityId:   volumeEntityId,
+		VolumeId:   "cloud-vol-1",
+		DiskPath:   "/tmp/test-vol",
+		SizeBytes:  10 * 1024 * 1024 * 1024,
+		Filesystem: "ext4",
+	})
+
+	// Create lsvd_mount entity with desired_state=MNT_WANT_UNMOUNTED.
+	// This simulates the state during unmount: the disk lease controller has
+	// already set desired_state to MNT_WANT_UNMOUNTED but the mount controller
+	// is partway through unmountAndDetach.
+	mountEntityId := entity.Id("lsvd_mount/test-mnt-1")
+	mount := &storage.LsvdMount{
+		DesiredState: storage.MNT_WANT_UNMOUNTED,
+		ActualState:  storage.MNT_MOUNTED,
+		NodeId:       entity.Id("node/" + testNodeId),
+		VolumeId:     entity.Id(volumeEntityId),
+		MountPath:    "/mnt/test",
+	}
+	_, err := h.EAC.Create(ctx, entity.New(
+		entity.DBId, mountEntityId,
+		mount.Encode,
+	).Attrs())
+	if err != nil {
+		t.Fatalf("failed to create lsvd_mount entity: %v", err)
+	}
+
+	// Set mount state in LSVD local state with NO handler in the handlers map.
+	// This simulates the race window: unmountAndDetach has cancelled the handler
+	// and deleted it from the map, but hasn't yet cleaned up local state.
+	h.LsvdState.SetMount(string(mountEntityId), &lsvdserver.MountState{
+		EntityId:   string(mountEntityId),
+		VolumeId:   volumeEntityId,
+		NbdIndex:   5,
+		DevicePath: "/dev/nbd5",
+		MountPath:  "/mnt/test",
+		Mounted:    true,
+		LeaseNonce: "old-nonce",
+	})
+
+	callsBefore := h.MockMountOps.openDiskCalls
+
+	// ReconcileWithSystem should see the mount state with no handler but
+	// skip reconnection because the entity's desired_state is MNT_WANT_UNMOUNTED.
+	err = h.LsvdMountCtrl.ReconcileWithSystem(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileWithSystem failed: %v", err)
+	}
+
+	newCalls := h.MockMountOps.openDiskCalls - callsBefore
+	if newCalls != 0 {
+		t.Errorf("ReconcileWithSystem reconnected a mount being unmounted: OpenLSVDDisk called %d time(s), want 0", newCalls)
+	}
+}
+
+// TestReconcileWithSystemReconnectsWantedMounts verifies that ReconcileWithSystem
+// still reconnects mounts whose entity has desired_state=MNT_WANT_MOUNTED
+// (the normal process-restart recovery path).
+func TestReconcileWithSystemReconnectsWantedMounts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	h := NewTestHarness(t)
+
+	volumeEntityId := "dev.miren.storage/kind.lsvd_volume/test-vol-2"
+	h.LsvdState.SetVolume(volumeEntityId, &lsvdserver.VolumeState{
+		EntityId:   volumeEntityId,
+		VolumeId:   "cloud-vol-2",
+		DiskPath:   "/tmp/test-vol-2",
+		SizeBytes:  10 * 1024 * 1024 * 1024,
+		Filesystem: "ext4",
+	})
+
+	// Create lsvd_mount entity with desired_state=MNT_WANT_MOUNTED.
+	// This simulates a process restart where the mount should be reconnected.
+	mountEntityId := entity.Id("lsvd_mount/test-mnt-2")
+	mount := &storage.LsvdMount{
+		DesiredState: storage.MNT_WANT_MOUNTED,
+		ActualState:  storage.MNT_MOUNTED,
+		NodeId:       entity.Id("node/" + testNodeId),
+		VolumeId:     entity.Id(volumeEntityId),
+		MountPath:    "/mnt/test-2",
+	}
+	_, err := h.EAC.Create(ctx, entity.New(
+		entity.DBId, mountEntityId,
+		mount.Encode,
+	).Attrs())
+	if err != nil {
+		t.Fatalf("failed to create lsvd_mount entity: %v", err)
+	}
+
+	h.LsvdState.SetMount(string(mountEntityId), &lsvdserver.MountState{
+		EntityId:   string(mountEntityId),
+		VolumeId:   volumeEntityId,
+		NbdIndex:   5,
+		DevicePath: "/dev/nbd5",
+		MountPath:  "/mnt/test-2",
+		Mounted:    true,
+		LeaseNonce: "old-nonce",
+	})
+
+	callsBefore := h.MockMountOps.openDiskCalls
+
+	err = h.LsvdMountCtrl.ReconcileWithSystem(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileWithSystem failed: %v", err)
+	}
+
+	newCalls := h.MockMountOps.openDiskCalls - callsBefore
+	if newCalls == 0 {
+		t.Errorf("ReconcileWithSystem should reconnect mounts with desired_state=MNT_WANT_MOUNTED, but OpenLSVDDisk was not called")
+	}
+}
+
+// TestReconcileWithSystemSkipsDeletedMountEntity verifies that ReconcileWithSystem
+// does NOT attempt to reconnect mounts whose entity no longer exists in the
+// entity store. This handles the case where the mount entity was already cleaned
+// up but local state lingers.
+func TestReconcileWithSystemSkipsDeletedMountEntity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	h := NewTestHarness(t)
+
+	volumeEntityId := "dev.miren.storage/kind.lsvd_volume/test-vol-3"
+	h.LsvdState.SetVolume(volumeEntityId, &lsvdserver.VolumeState{
+		EntityId:   volumeEntityId,
+		VolumeId:   "cloud-vol-3",
+		DiskPath:   "/tmp/test-vol-3",
+		SizeBytes:  10 * 1024 * 1024 * 1024,
+		Filesystem: "ext4",
+	})
+
+	// Set mount state in LSVD local state but do NOT create the entity.
+	// This simulates a case where the entity was deleted but local state wasn't
+	// cleaned up yet.
+	mountEntityId := "lsvd_mount/test-mnt-3"
+	h.LsvdState.SetMount(mountEntityId, &lsvdserver.MountState{
+		EntityId:   mountEntityId,
+		VolumeId:   volumeEntityId,
+		NbdIndex:   5,
+		DevicePath: "/dev/nbd5",
+		MountPath:  "/mnt/test-3",
+		Mounted:    true,
+		LeaseNonce: "old-nonce",
+	})
+
+	callsBefore := h.MockMountOps.openDiskCalls
+
+	err := h.LsvdMountCtrl.ReconcileWithSystem(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileWithSystem failed: %v", err)
+	}
+
+	newCalls := h.MockMountOps.openDiskCalls - callsBefore
+	if newCalls != 0 {
+		t.Errorf("ReconcileWithSystem reconnected a mount with deleted entity: OpenLSVDDisk called %d time(s), want 0", newCalls)
+	}
+}

--- a/controllers/integration/redeploy_test.go
+++ b/controllers/integration/redeploy_test.go
@@ -26,6 +26,7 @@ func concurrentReconcileEntities(ctx context.Context, h *TestHarness, index enti
 
 	resp, err := h.EAC.List(ctx, index)
 	if err != nil {
+		h.T.Errorf("concurrentReconcileEntities: List(%s) failed: %v", index, err)
 		return
 	}
 
@@ -55,7 +56,9 @@ func concurrentReconcileEntities(ctx context.Context, h *TestHarness, index enti
 		go func() {
 			defer wg.Done()
 			for event := range ch {
-				_ = rc.ProcessEventForTest(ctx, event)
+				if err := rc.ProcessEventForTest(ctx, event); err != nil {
+					h.T.Errorf("concurrentReconcileEntities: ProcessEventForTest(%s) failed: %v", event.Id, err)
+				}
 			}
 		}()
 	}
@@ -175,7 +178,9 @@ func reconcileAllPools(t *testing.T, ctx context.Context, h *TestHarness, mgr *s
 	for _, e := range resp.Values() {
 		var pool compute.SandboxPool
 		pool.Decode(e.Entity())
-		_ = mgr.Reconcile(ctx, &pool, nil)
+		if err := mgr.Reconcile(ctx, &pool, nil); err != nil {
+			t.Errorf("reconcileAllPools: Reconcile(%s) failed: %v", pool.ID, err)
+		}
 	}
 }
 
@@ -339,24 +344,6 @@ func markPendingSandboxesRunning(t *testing.T, ctx context.Context, h *TestHarne
 			markSandboxRunning(t, ctx, h, sb.ID)
 		}
 	}
-}
-
-// poolForLabel returns the first pool matching the given metadata label.
-func poolForLabel(t *testing.T, ctx context.Context, h *TestHarness, key, value string) *compute.SandboxPool {
-	t.Helper()
-	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandboxPool))
-	require.NoError(t, err)
-
-	for _, e := range resp.Values() {
-		var pool compute.SandboxPool
-		pool.Decode(e.Entity())
-		var md core.Metadata
-		md.Decode(e.Entity())
-		if v, ok := md.Labels.Get(key); ok && v == value {
-			return &pool
-		}
-	}
-	return nil
 }
 
 func TestRapidRedeployWithDisk(t *testing.T) {

--- a/controllers/integration/redeploy_test.go
+++ b/controllers/integration/redeploy_test.go
@@ -1,0 +1,549 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	core "miren.dev/runtime/api/core/core_v1alpha"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/controllers/deployment"
+	"miren.dev/runtime/controllers/sandboxpool"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// concurrentReconcileEntities lists all entities matching the index and processes
+// them concurrently using the given number of worker goroutines, mimicking the
+// production ReconcileController's multi-worker dispatch.
+func concurrentReconcileEntities(ctx context.Context, h *TestHarness, index entity.Attr,
+	rc *controller.ReconcileController, workers int) {
+
+	resp, err := h.EAC.List(ctx, index)
+	if err != nil {
+		return
+	}
+
+	values := resp.Values()
+	if len(values) == 0 {
+		return
+	}
+
+	ch := make(chan controller.Event, len(values))
+	for _, e := range values {
+		ent := e.Entity()
+		id := ent.Id()
+		if id == "" {
+			continue
+		}
+		ch <- controller.Event{
+			Type:   controller.EventUpdated,
+			Id:     id,
+			Entity: ent,
+		}
+	}
+	close(ch)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for event := range ch {
+				_ = rc.ProcessEventForTest(ctx, event)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// concurrentReconcileRound runs all four disk-lifecycle controller types concurrently,
+// each with multiple worker goroutines processing their entities.
+func concurrentReconcileRound(ctx context.Context, h *TestHarness, workers int) {
+	nodeId := entity.Id("node/" + testNodeId)
+
+	type ctrlDef struct {
+		index entity.Attr
+		rc    *controller.ReconcileController
+	}
+
+	controllers := []ctrlDef{
+		{entity.Ref(entity.EntityKind, storage.KindDisk), h.DiskRC},
+		{entity.Ref(storage.LsvdVolumeNodeIdId, nodeId), h.LsvdVolRC},
+		{entity.Ref(storage.LsvdMountNodeIdId, nodeId), h.LsvdMntRC},
+		{entity.Ref(entity.EntityKind, storage.KindDiskLease), h.DiskLeaseRC},
+	}
+
+	var wg sync.WaitGroup
+	for _, c := range controllers {
+		wg.Add(1)
+		go func(idx entity.Attr, rc *controller.ReconcileController) {
+			defer wg.Done()
+			concurrentReconcileEntities(ctx, h, idx, rc, workers)
+		}(c.index, c.rc)
+	}
+	wg.Wait()
+}
+
+// createAppEntity creates an App entity in the store.
+func createAppEntity(t *testing.T, ctx context.Context, h *TestHarness, appID entity.Id, appName string) {
+	t.Helper()
+	app := &core.App{}
+	_, err := h.EAC.Create(ctx, entity.New(
+		entity.DBId, appID,
+		(&core.Metadata{
+			Name: appName,
+		}).Encode,
+		app.Encode,
+	).Attrs())
+	require.NoError(t, err, "createAppEntity(%s)", appID)
+}
+
+// createAppVersion creates an AppVersion entity with a service that has a disk attached.
+func createAppVersion(t *testing.T, ctx context.Context, h *TestHarness,
+	verID entity.Id, appID entity.Id, version string, image string,
+	diskName string, diskSizeGB int64,
+) {
+	t.Helper()
+	ver := &core.AppVersion{
+		App:      appID,
+		Version:  version,
+		ImageUrl: image,
+		Config: core.Config{
+			Services: []core.Services{
+				{
+					Name: "web",
+					Disks: []core.Disks{
+						{
+							Name:      diskName,
+							MountPath: "/data",
+							SizeGb:    diskSizeGB,
+						},
+					},
+					ServiceConcurrency: core.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+			Commands: []core.Commands{
+				{
+					Service: "web",
+					Command: "start",
+				},
+			},
+		},
+	}
+	_, err := h.EAC.Create(ctx, entity.New(
+		entity.DBId, verID,
+		ver.Encode,
+	).Attrs())
+	require.NoError(t, err, "createAppVersion(%s)", verID)
+}
+
+// setActiveVersion patches an App entity to set its ActiveVersion.
+func setActiveVersion(t *testing.T, ctx context.Context, h *TestHarness, appID entity.Id, verID entity.Id) {
+	t.Helper()
+	_, err := h.EAC.Patch(ctx, entity.New(
+		entity.DBId, appID,
+		(&core.App{
+			ActiveVersion: verID,
+		}).Encode,
+	).Attrs(), 0)
+	require.NoError(t, err, "setActiveVersion(%s -> %s)", appID, verID)
+}
+
+// reconcileLauncher calls Launcher.Reconcile for the given app.
+func reconcileLauncher(t *testing.T, ctx context.Context, launcher *deployment.Launcher, appID entity.Id) {
+	t.Helper()
+	app := &core.App{ID: appID}
+	err := launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err, "reconcileLauncher(%s)", appID)
+}
+
+// reconcileAllPools lists all SandboxPool entities and reconciles each through the Manager.
+func reconcileAllPools(t *testing.T, ctx context.Context, h *TestHarness, mgr *sandboxpool.Manager) {
+	t.Helper()
+	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandboxPool))
+	require.NoError(t, err, "listing pools")
+
+	for _, e := range resp.Values() {
+		var pool compute.SandboxPool
+		pool.Decode(e.Entity())
+		_ = mgr.Reconcile(ctx, &pool, nil)
+	}
+}
+
+// listSandboxes returns all Sandbox entities in the store.
+func listAllSandboxes(t *testing.T, ctx context.Context, h *TestHarness) []*compute.Sandbox {
+	t.Helper()
+	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+	require.NoError(t, err, "listAllSandboxes")
+
+	var sandboxes []*compute.Sandbox
+	for _, e := range resp.Values() {
+		var sb compute.Sandbox
+		sb.Decode(e.Entity())
+		sbCopy := sb
+		sandboxes = append(sandboxes, &sbCopy)
+	}
+	return sandboxes
+}
+
+// listPools returns all SandboxPool entities in the store.
+func listPools(t *testing.T, ctx context.Context, h *TestHarness) []*compute.SandboxPool {
+	t.Helper()
+	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandboxPool))
+	require.NoError(t, err, "listPools")
+
+	var pools []*compute.SandboxPool
+	for _, e := range resp.Values() {
+		var pool compute.SandboxPool
+		pool.Decode(e.Entity())
+		poolCopy := pool
+		pools = append(pools, &poolCopy)
+	}
+	return pools
+}
+
+// retireOldSandboxes finds sandboxes in pools with DesiredInstances==0,
+// releases their disk leases, and marks them STOPPED. This matches the
+// production flow: Manager.scaleDown marks RUNNING→STOPPED, then
+// SandboxController releases leases and transitions STOPPED→DEAD.
+// We mark STOPPED (not DEAD) so the Manager's countQuickCrashes doesn't
+// misinterpret intentional retirements as crash-loops.
+func retireOldSandboxes(t *testing.T, ctx context.Context, h *TestHarness) {
+	t.Helper()
+
+	// Build a set of pool IDs that are scaled to 0
+	scaledDownPools := make(map[string]bool)
+	pools := listPools(t, ctx, h)
+	for _, pool := range pools {
+		if pool.DesiredInstances == 0 {
+			scaledDownPools[pool.ID.String()] = true
+		}
+	}
+
+	if len(scaledDownPools) == 0 {
+		return
+	}
+
+	// Find sandboxes belonging to scaled-down pools
+	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+	require.NoError(t, err)
+
+	for _, e := range resp.Values() {
+		var sb compute.Sandbox
+		sb.Decode(e.Entity())
+
+		// Skip non-active sandboxes
+		if sb.Status != compute.RUNNING && sb.Status != compute.PENDING {
+			continue
+		}
+
+		var md core.Metadata
+		md.Decode(e.Entity())
+		poolLabel, _ := md.Labels.Get("pool")
+
+		if !scaledDownPools[poolLabel] {
+			continue
+		}
+
+		// Release disk leases and mark STOPPED (not DEAD — matches scaleDown)
+		_ = h.FakeSandbox.ReleaseDiskLeases(ctx, sb.ID)
+		markSandboxStopped(t, ctx, h, sb.ID)
+	}
+}
+
+// finalizeStoppedSandboxes transitions all STOPPED sandboxes to DEAD.
+// In production the SandboxController does this after cleanup; we call it
+// during convergence to complete the lifecycle.
+func finalizeStoppedSandboxes(t *testing.T, ctx context.Context, h *TestHarness) {
+	t.Helper()
+
+	sandboxes := listAllSandboxes(t, ctx, h)
+	for _, sb := range sandboxes {
+		if sb.Status == compute.STOPPED {
+			markSandboxDead(t, ctx, h, sb.ID)
+		}
+	}
+}
+
+// bootPendingSandboxes finds PENDING sandboxes with disk volumes and
+// acquires disk leases for them, simulating what the real SandboxController does.
+func bootPendingSandboxes(t *testing.T, ctx context.Context, h *TestHarness, appID entity.Id) {
+	t.Helper()
+
+	sandboxes := listAllSandboxes(t, ctx, h)
+	for _, sb := range sandboxes {
+		if sb.Status != compute.PENDING {
+			continue
+		}
+
+		// Process disk volumes from the sandbox's spec
+		for _, vol := range sb.Spec.Volume {
+			if vol.Provider != "miren" {
+				continue
+			}
+
+			diskID, err := h.FakeSandbox.EnsureDisk(ctx, vol.DiskName, vol.SizeGb, vol.Filesystem)
+			if err != nil {
+				t.Logf("bootPendingSandboxes: EnsureDisk(%s) failed: %v", vol.DiskName, err)
+				continue
+			}
+
+			_, err = h.FakeSandbox.AcquireDiskLease(ctx, diskID, sb.ID, appID, vol.MountPath, vol.ReadOnly)
+			if err != nil {
+				t.Logf("bootPendingSandboxes: AcquireDiskLease(%s, %s) failed: %v", diskID, sb.ID, err)
+				continue
+			}
+		}
+	}
+}
+
+// markPendingSandboxesRunning marks PENDING sandboxes as RUNNING if all their
+// disk leases are BOUND. This simulates the sandbox boot completing.
+func markPendingSandboxesRunning(t *testing.T, ctx context.Context, h *TestHarness) {
+	t.Helper()
+
+	sandboxes := listAllSandboxes(t, ctx, h)
+	for _, sb := range sandboxes {
+		if sb.Status != compute.PENDING {
+			continue
+		}
+
+		// Check if all disk leases for this sandbox are BOUND
+		sbLeases := leasesForSandbox(t, ctx, h, sb.ID)
+		if len(sbLeases) == 0 {
+			// No disks — sandbox with no volumes can be marked running
+			if len(sb.Spec.Volume) == 0 {
+				markSandboxRunning(t, ctx, h, sb.ID)
+			}
+			continue
+		}
+
+		allBound := true
+		for _, l := range sbLeases {
+			if l.Status != storage.BOUND {
+				allBound = false
+				break
+			}
+		}
+
+		if allBound {
+			markSandboxRunning(t, ctx, h, sb.ID)
+		}
+	}
+}
+
+// poolForLabel returns the first pool matching the given metadata label.
+func poolForLabel(t *testing.T, ctx context.Context, h *TestHarness, key, value string) *compute.SandboxPool {
+	t.Helper()
+	resp, err := h.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandboxPool))
+	require.NoError(t, err)
+
+	for _, e := range resp.Values() {
+		var pool compute.SandboxPool
+		pool.Decode(e.Entity())
+		var md core.Metadata
+		md.Decode(e.Entity())
+		if v, ok := md.Labels.Get(key); ok && v == value {
+			return &pool
+		}
+	}
+	return nil
+}
+
+func TestRapidRedeployWithDisk(t *testing.T) {
+	ctx := context.Background()
+	h := NewTestHarness(t)
+
+	const (
+		numRedeploys = 10
+		concWorkers  = 3
+		diskName     = "redeploy-disk"
+		diskSizeGB   = 10
+	)
+
+	appID := entity.Id("app/redeploy-test")
+	appName := "redeploy-test"
+
+	// Create Launcher and Manager (the real deployment machinery)
+	launcher := deployment.NewLauncher(h.Log, h.EAC)
+	launcher.Init(ctx) //nolint:errcheck
+
+	mgr := sandboxpool.NewManager(h.Log, h.EAC)
+	// Don't call mgr.Init — it starts a background scale-down goroutine we don't need.
+
+	// Create App entity
+	createAppEntity(t, ctx, h, appID, appName)
+
+	// Phase 1: Deploy v1 through the real Launcher + Manager pipeline
+	ver1ID := entity.Id("app-version/redeploy-test-v1")
+	createAppVersion(t, ctx, h, ver1ID, appID, "v1", "test:v1", diskName, diskSizeGB)
+	setActiveVersion(t, ctx, h, appID, ver1ID)
+
+	// Launcher creates pool
+	reconcileLauncher(t, ctx, launcher, appID)
+
+	// Manager creates sandbox
+	reconcileAllPools(t, ctx, h, mgr)
+
+	// FakeSandbox acquires disk leases for PENDING sandboxes
+	bootPendingSandboxes(t, ctx, h, appID)
+
+	// Disk controllers converge: disk provisions, volume ready, mount mounted, lease BOUND
+	h.ReconcileAll(ctx, 20)
+
+	// Mark sandboxes running
+	markPendingSandboxesRunning(t, ctx, h)
+
+	// Verify Phase 1 state
+	allLeases := listLeases(t, ctx, h)
+	require.Len(t, allLeases, 1, "v1: should have 1 lease")
+	require.Equal(t, storage.BOUND, allLeases[0].Status, "v1 lease should be BOUND")
+	assert.Equal(t, 1, countMountedMounts(t, ctx, h), "v1: should have 1 mounted mount")
+
+	v1Sandboxes := listAllSandboxes(t, ctx, h)
+	require.Len(t, v1Sandboxes, 1, "v1: should have 1 sandbox")
+	assert.Equal(t, compute.RUNNING, v1Sandboxes[0].Status, "v1 sandbox should be RUNNING")
+
+	t.Log("Phase 1 complete: v1 deployed and running with BOUND lease")
+
+	// Phase 2: Rapid redeployments v2 through v(N+1)
+	// Each version uses a different image so the Launcher creates a new pool
+	// (specsMatch compares images, different image = new pool).
+	for v := 2; v <= numRedeploys+1; v++ {
+		version := fmt.Sprintf("v%d", v)
+		verID := entity.Id(fmt.Sprintf("app-version/redeploy-test-%s", version))
+		image := fmt.Sprintf("test:%s", version)
+
+		// Create new AppVersion and set as active
+		createAppVersion(t, ctx, h, verID, appID, version, image, diskName, diskSizeGB)
+		setActiveVersion(t, ctx, h, appID, verID)
+
+		// Launcher reconcile: creates new pool, scales old pool(s) to 0
+		reconcileLauncher(t, ctx, launcher, appID)
+
+		// Retire sandboxes in scaled-down pools (release leases + mark DEAD)
+		retireOldSandboxes(t, ctx, h)
+
+		// Manager reconcile: creates sandbox for the new pool
+		reconcileAllPools(t, ctx, h, mgr)
+
+		// Run 0-2 concurrent disk controller reconciliation rounds per iteration
+		// to create varying interleaving patterns
+		reconcileRounds := v % 3
+		for r := 0; r < reconcileRounds; r++ {
+			concurrentReconcileRound(ctx, h, concWorkers)
+		}
+
+		// Boot pending sandboxes (acquire disk leases)
+		bootPendingSandboxes(t, ctx, h, appID)
+
+		t.Logf("  %s: created version, launched pool+sandbox (%d concurrent rounds)", version, reconcileRounds)
+	}
+
+	t.Logf("Phase 2 complete: %d rapid redeployments done", numRedeploys)
+
+	// Phase 3: Convergence
+	// First, finalize stopped sandboxes → DEAD (simulates SandboxController cleanup)
+	finalizeStoppedSandboxes(t, ctx, h)
+
+	// Concurrent disk controller rounds
+	for i := 0; i < 5; i++ {
+		concurrentReconcileRound(ctx, h, concWorkers)
+	}
+	h.ReconcileAll(ctx, 30)
+
+	// Mark any remaining PENDING sandboxes as RUNNING if their leases are BOUND
+	markPendingSandboxesRunning(t, ctx, h)
+
+	// One more convergence pass now that sandboxes are RUNNING
+	h.ReconcileAll(ctx, 10)
+
+	t.Log("Phase 3 complete: convergence rounds done")
+
+	// Phase 4: Invariant validation
+	finalLeases := listLeases(t, ctx, h)
+	finalMounts := listLsvdMounts(t, ctx, h)
+	finalSandboxes := listAllSandboxes(t, ctx, h)
+	finalPools := listPools(t, ctx, h)
+
+	// 4a: Exactly 1 BOUND lease exists (exclusive disk access)
+	boundCount := 0
+	var boundLease *storage.DiskLease
+	for _, l := range finalLeases {
+		if l.Status == storage.BOUND {
+			boundCount++
+			boundLease = l
+			t.Logf("  BOUND lease: %s (sandbox=%s, disk=%s)", l.ID, l.SandboxId, l.DiskId)
+		}
+	}
+	assert.Equal(t, 1, boundCount, "should have exactly 1 BOUND lease, got %d", boundCount)
+
+	// 4b: BOUND lease has exactly 1 MNT_MOUNTED mount
+	if boundLease != nil {
+		latestMount := getMountForLease(t, ctx, h, boundLease.ID)
+		if assert.NotNil(t, latestMount, "BOUND lease should have a mount") {
+			assert.Equal(t, storage.MNT_MOUNTED, latestMount.ActualState,
+				"BOUND lease mount should be MNT_MOUNTED, got %s", latestMount.ActualState)
+		}
+	}
+
+	// 4c: All non-BOUND leases are RELEASED or FAILED
+	for _, l := range finalLeases {
+		if boundLease != nil && l.ID == boundLease.ID {
+			continue
+		}
+		assert.True(t, l.Status == storage.RELEASED || l.Status == storage.FAILED,
+			"non-BOUND lease %s should be RELEASED or FAILED, got %s (sandbox=%s)",
+			l.ID, l.Status, l.SandboxId)
+	}
+
+	// 4d: Exactly 1 MNT_MOUNTED mount exists (no orphans)
+	mountedCount := 0
+	for _, m := range finalMounts {
+		if m.ActualState == storage.MNT_MOUNTED {
+			mountedCount++
+		}
+	}
+	assert.Equal(t, 1, mountedCount, "should have exactly 1 MNT_MOUNTED mount, got %d", mountedCount)
+
+	// 4e: Disk is still PROVISIONED
+	disks := listDisks(t, ctx, h)
+	require.Len(t, disks, 1, "should have exactly 1 disk")
+	assert.Equal(t, storage.PROVISIONED, disks[0].Status,
+		"disk should still be PROVISIONED after all redeployments")
+
+	// 4f: Exactly 1 active pool with DesiredInstances > 0
+	activePoolCount := 0
+	for _, pool := range finalPools {
+		if pool.DesiredInstances > 0 {
+			activePoolCount++
+		}
+	}
+	assert.Equal(t, 1, activePoolCount,
+		"should have exactly 1 active pool, got %d (total pools: %d)", activePoolCount, len(finalPools))
+
+	// 4g: Exactly 1 RUNNING sandbox
+	runningCount := 0
+	for _, sb := range finalSandboxes {
+		if sb.Status == compute.RUNNING {
+			runningCount++
+		}
+	}
+	assert.Equal(t, 1, runningCount,
+		"should have exactly 1 RUNNING sandbox, got %d", runningCount)
+
+	// Summary
+	t.Logf("Final state: %d leases, %d mounts, %d sandboxes, %d pools | "+
+		"%d BOUND, %d MNT_MOUNTED, %d RUNNING",
+		len(finalLeases), len(finalMounts), len(finalSandboxes), len(finalPools),
+		boundCount, mountedCount, runningCount)
+}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1021,7 +1021,7 @@ func (c *SandboxController) updateServices(
 		var srv network_v1alpha.Service
 		srv.Decode(ent.Entity())
 
-		if !srv.Match.Equal(md.Labels) {
+		if !srv.Match.SubsetOf(md.Labels) {
 			c.Log.Debug("skipping service, labels do not match", "service", srv.ID, "labels", srv.Match, "entity", md.Labels)
 			continue
 		}
@@ -2302,6 +2302,13 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 		c.Log.Error("failed to remove monitoring metrics", "id", id, "error", err)
 	}
 
+	// Release disk leases early so replacement sandboxes can acquire them
+	// while we wait for container shutdown
+	if err := c.releaseDiskLeases(ctx, id); err != nil {
+		c.Log.Error("failed to release disk leases", "id", id, "error", err)
+		// Continue with cleanup even if this fails
+	}
+
 	// Destroy subcontainers - this will discover them from containerd
 	c.Log.Debug("destroying subcontainers", "id", id)
 	err = c.destroySubContainers(ctx, id)
@@ -2348,12 +2355,6 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 		}
 
 		c.Log.Info("container stopped", "id", id)
-	}
-
-	// Release disk leases owned by this sandbox
-	if err := c.releaseDiskLeases(ctx, id); err != nil {
-		c.Log.Error("failed to release disk leases", "id", id, "error", err)
-		// Continue with cleanup even if this fails
 	}
 
 	// Clean up temp directory

--- a/pkg/entity/types/types.go
+++ b/pkg/entity/types/types.go
@@ -51,6 +51,16 @@ func (l Labels) Equal(o Labels) bool {
 	return true
 }
 
+// SubsetOf reports whether every label in l exists in o.
+func (l Labels) SubsetOf(o Labels) bool {
+	for _, a := range l {
+		if !slices.Contains(o, a) {
+			return false
+		}
+	}
+	return true
+}
+
 func LabelSet(vals ...string) Labels {
 	if len(vals)%2 != 0 {
 		panic("LabelSet must have even number of values")


### PR DESCRIPTION
## Summary
- Improve disk mount lifecycle handling: recover from error/detached states, skip unmount when another mount entity shares the same path, and add a mount-watch controller for disk lease awareness
- Run LSVD controllers in-process when SkipLSVD is set, enabling full integration testing without a separate LSVD server
- Add comprehensive integration test harness with tests covering lifecycle, chaos/failure injection, overlapping mounts, redeployment, and reconciliation scenarios
- Integration tests cause an incorrect use of Labels.Equal which was changed to Labels.SubsetOf, as that's the correct behavior for labels rather than exact equality. 

## Test plan
- [x] Existing unit tests pass (`make test`)
- [x] New integration tests in `controllers/integration/` pass
- [x] Verify disk mount recovery from error and detached states
- [x] Verify overlapping mount cleanup during rapid sandbox replacement