### PR TITLE
Add nested saga support and deterministic execution ordering

### DIFF
--- a/api/saga/saga_v1alpha/schema.gen.go
+++ b/api/saga/saga_v1alpha/schema.gen.go
@@ -12,6 +12,7 @@ const (
 	SagaExecutedActionsId   = entity.Id("dev.miren.saga/saga.executed_actions")
 	SagaExecutionOrderId    = entity.Id("dev.miren.saga/saga.execution_order")
 	SagaInitialInputsId     = entity.Id("dev.miren.saga/saga.initial_inputs")
+	SagaParentExecutionIdId = entity.Id("dev.miren.saga/saga.parent_execution_id")
 	SagaStatusId            = entity.Id("dev.miren.saga/saga.status")
 	SagaStatusPendingId     = entity.Id("dev.miren.saga/status.pending")
 	SagaStatusRunningId     = entity.Id("dev.miren.saga/status.running")
@@ -28,6 +29,7 @@ type Saga struct {
 	ExecutedActions   []byte     `cbor:"executed_actions,omitempty" json:"executed_actions,omitempty"`
 	ExecutionOrder    []byte     `cbor:"execution_order,omitempty" json:"execution_order,omitempty"`
 	InitialInputs     []byte     `cbor:"initial_inputs,omitempty" json:"initial_inputs,omitempty"`
+	ParentExecutionId entity.Id  `cbor:"parent_execution_id,omitempty" json:"parent_execution_id,omitempty"`
 	Status            SagaStatus `cbor:"status,omitempty" json:"status,omitempty"`
 }
 
@@ -63,6 +65,9 @@ func (o *Saga) Decode(e entity.AttrGetter) {
 	}
 	if a, ok := e.Get(SagaInitialInputsId); ok && a.Value.Kind() == entity.KindBytes {
 		o.InitialInputs = a.Value.Bytes()
+	}
+	if a, ok := e.Get(SagaParentExecutionIdId); ok && a.Value.Kind() == entity.KindId {
+		o.ParentExecutionId = a.Value.Id()
 	}
 	if a, ok := e.Get(SagaStatusId); ok && a.Value.Kind() == entity.KindId {
 		o.Status = sagastatusFromId[a.Value.Id()]
@@ -104,6 +109,9 @@ func (o *Saga) Encode() (attrs []entity.Attr) {
 	if len(o.InitialInputs) > 0 {
 		attrs = append(attrs, entity.Bytes(SagaInitialInputsId, o.InitialInputs))
 	}
+	if !entity.Empty(o.ParentExecutionId) {
+		attrs = append(attrs, entity.Ref(SagaParentExecutionIdId, o.ParentExecutionId))
+	}
 	if a, ok := sagastatusToId[o.Status]; ok {
 		attrs = append(attrs, entity.Ref(SagaStatusId, a))
 	}
@@ -130,6 +138,9 @@ func (o *Saga) Empty() bool {
 	if len(o.InitialInputs) > 0 {
 		return false
 	}
+	if !entity.Empty(o.ParentExecutionId) {
+		return false
+	}
 	if o.Status != "" {
 		return false
 	}
@@ -143,6 +154,7 @@ func (o *Saga) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Bytes("executed_actions", "dev.miren.saga/saga.executed_actions", schema.Doc("JSON-encoded map of action name to ActionResult"))
 	sb.Bytes("execution_order", "dev.miren.saga/saga.execution_order", schema.Doc("JSON-encoded array of action names in execution order"))
 	sb.Bytes("initial_inputs", "dev.miren.saga/saga.initial_inputs", schema.Doc("JSON-encoded initial inputs for the saga"))
+	sb.Ref("parent_execution_id", "dev.miren.saga/saga.parent_execution_id", schema.Doc("Reference to the parent saga execution (set for child/nested sagas)"), schema.Indexed)
 	sb.Singleton("dev.miren.saga/status.pending")
 	sb.Singleton("dev.miren.saga/status.running")
 	sb.Singleton("dev.miren.saga/status.undoing")
@@ -160,5 +172,5 @@ func init() {
 	schema.Register("dev.miren.saga", "v1alpha", func(sb *schema.SchemaBuilder) {
 		(&Saga{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.saga", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x84\x93\xdfJ\xf40\x10\xc5_\xe3\xfbD\x11T\xbc\xac\xf8D%ۙd\x87M'!\x7fJ\xfa\x04>\x87\xb8\xfa\x88^K\x92\xe2b̮7e8s\xceo\xa6!9\x02\x8b\x19\x19p\x19frȃ\x17J\xe0\x81\x18\xfck\xfa\xf7S~\xcar\xa9>J\xca7\xedS\xf4S\x82\x99\x05qÕ\x92P\x83\x7fy\xdb\x11\xa4\xfbNz\x00\x94\xc4\x14\xc8\xf0\x98'\x941\xa6\x15\xc3jQ\xfa\xe0\x88U!=\xfeAZ\xd0y2\\`\xae\xa3g\xdeD\x1c\n\xec\x7f\x0f\x86\xce\x19W\xf2X\xcbv\x85\x87n*\xe1\x14\x03\xc2(\xa6<\xcf\x17\x80\xfd\xa5f\x16\xeeր\xfe\xfc\xb9\xd4P^\xda8\xc0\xba\x8ai\xc5\x06t\xd7\x03\x95\x7f\x17z$\xb61ԍ\xb8\xd1N\x98c\xc6\\\xf50>\x88\x10k\\nu\x8e\x01r\x9c\x0f\xf93.BG\xf4\xefR\n\xd2\b麥\x94\xd0P\xbb\xca\"\x03\xb1J7}\xd7\xd6V.2_\xb0mm\x15\x19\xcc\x05\xdb֦\xc9\xccVc@H\xb7}\xe3\xb7Am7E-\xcfB۽\xd0\xd6\xd1,\xdc:\xe6\xcb\x0e9\xd2:\x0e~o\\\x18\xeb;*\x8e\xf3\x8f\xe9\v\x00\x00\xff\xff\x01\x00\x00\xff\xff\x84\xdaF\x10\x83\x03\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.saga", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x84\x93oJ\x031\x10ů\xa1\xa2\b*\xfam\xc5\x13\x85tg\x92\x0e\xcdNB\xfe,\xdb\x1bx\r\xb1zD?K\x92\xc5bL\xeb\x97\x12\u07bc\xf7\xcb\xeb\x929\x00\xcb\t\x19p\x1e&\xf2\xc8C\x90Z\xe2\x8e\x18\xc2\xdbr\xf1[~\xcer9}\x96Th\xc6\xc7\xe8\x97\x02;I↫\x14\xa1\x81\xf0\xfa\xbe!X\xee;\xe9\x01P\x11S$\xcb\"\xdfP\xae\xb1\xad\x18\xf7\x0eU\x88\x9eX\x17\xd2\xe3?\xa4\x19} \xcb\x05\xe6;z\xe6\x8dı\xc0.{0\xf4\xde\xfa\x92\xc7zl+<tS\v\x8e)\"\b9\xe6\xfbB\x01\xb8?jf\xe1f\x1f1\x9c\xfe.5\x94K[\x0fX\xab\xd8Vl@w=P\xf9\xef\xd2\bb\x97bmč\xd6`\x9ez\x18'=r\x14\xc7\x06\x04\xf5I\xf4\x06\x19\xb8!8d\xdaU\x8f\x16\xa2\x8c\xa9\x96Q\xeb9g\x009M\xbb\xfc#fi\x12\x86\x0f\xa5$\x19\x84庥\x94\xd0P\xa7\xda!\x03\xb1^n\xfa\xaeu\xac}b>c[\xc7:1\xd83\xb6uL\xa3\x9d\x9c\xc1\x88\xb0\xdc\xf6\x8d?\x06\xbd\xbe;=\xbfH\xe3\xb6\xd28O\x93\xf4{\x91W\ar\xa4u\xec\xc2\xd6\xfa(\xeaV\x16\xc7\xe9\xd5\xfc\x06\x00\x00\xff\xff\x01\x00\x00\xff\xff\xce\xdck\x92\xd1\x03\x00\x00"))
 }

--- a/api/saga/schema.yml
+++ b/api/saga/schema.yml
@@ -29,6 +29,11 @@ kinds:
       type: bytes
       doc: JSON-encoded array of action names in execution order
 
+    parent_execution_id:
+      type: ref
+      doc: Reference to the parent saga execution (set for child/nested sagas)
+      indexed: true
+
     error:
       type: string
       doc: Error message if the saga failed

--- a/pkg/saga/definition.go
+++ b/pkg/saga/definition.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -26,6 +27,11 @@ type Definition struct {
 
 	// dependencies is stored to inject into context during execution.
 	dependencies []any
+}
+
+// ExecutionOrder returns the computed execution order for the saga's actions.
+func (d *Definition) ExecutionOrder() []string {
+	return d.executionOrder
 }
 
 // ActionNode describes a single action within a saga definition.
@@ -306,17 +312,25 @@ func (b *Builder) Build() (*Definition, error) {
 }
 
 // topologicalSort returns actions in dependency order, or an error if there's a cycle.
+// Actions at the same dependency level are sorted alphabetically for determinism.
 func topologicalSort(actions map[string]*ActionNode) ([]string, error) {
+	// Collect sorted action names for deterministic iteration
+	actionNames := make([]string, 0, len(actions))
+	for name := range actions {
+		actionNames = append(actionNames, name)
+	}
+	slices.Sort(actionNames)
+
 	// Kahn's algorithm - compute in-degree (number of dependencies) for each node
 	inDegree := make(map[string]int)
 	for _, node := range actions {
 		inDegree[node.Name] = len(node.Dependencies)
 	}
 
-	// Find all nodes with no dependencies
+	// Find all nodes with no dependencies (sorted)
 	var queue []string
-	for name, degree := range inDegree {
-		if degree == 0 {
+	for _, name := range actionNames {
+		if inDegree[name] == 0 {
 			queue = append(queue, name)
 		}
 	}
@@ -328,17 +342,20 @@ func topologicalSort(actions map[string]*ActionNode) ([]string, error) {
 		queue = queue[1:]
 		order = append(order, name)
 
-		// Reduce in-degree of dependents
-		for depName, node := range actions {
+		// Reduce in-degree of dependents, collect newly ready ones sorted
+		var ready []string
+		for _, depName := range actionNames {
+			node := actions[depName]
 			for _, dep := range node.Dependencies {
 				if dep == name {
 					inDegree[depName]--
 					if inDegree[depName] == 0 {
-						queue = append(queue, depName)
+						ready = append(ready, depName)
 					}
 				}
 			}
 		}
+		queue = append(queue, ready...)
 	}
 
 	if len(order) != len(actions) {

--- a/pkg/saga/definition_test.go
+++ b/pkg/saga/definition_test.go
@@ -1,0 +1,152 @@
+package saga
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Independent action types — each has unique saga keys so there are no
+// data dependencies between actions.
+
+type alphaIn struct {
+	X int `saga:"alpha_x"`
+}
+type alphaOut struct {
+	Y int `saga:"alpha_y"`
+}
+
+func alphaExec(_ context.Context, in alphaIn) (alphaOut, error) {
+	return alphaOut{Y: in.X}, nil
+}
+func alphaUndo(_ context.Context, _ alphaIn, _ alphaOut) error { return nil }
+
+type bravoIn struct {
+	X int `saga:"bravo_x"`
+}
+type bravoOut struct {
+	Y int `saga:"bravo_y"`
+}
+
+func bravoExec(_ context.Context, in bravoIn) (bravoOut, error) {
+	return bravoOut{Y: in.X}, nil
+}
+func bravoUndo(_ context.Context, _ bravoIn, _ bravoOut) error { return nil }
+
+type charlieIn struct {
+	X int `saga:"charlie_x"`
+}
+type charlieOut struct {
+	Y int `saga:"charlie_y"`
+}
+
+func charlieExec(_ context.Context, in charlieIn) (charlieOut, error) {
+	return charlieOut{Y: in.X}, nil
+}
+func charlieUndo(_ context.Context, _ charlieIn, _ charlieOut) error { return nil }
+
+// Diamond dependency types: A -> {B, C} -> D
+//
+//   A produces "mid_a"
+//   B reads "mid_a", produces "mid_b"
+//   C reads "mid_a", produces "mid_c"
+//   D reads "mid_b" and "mid_c"
+
+type diamondAIn struct {
+	Seed int `saga:"seed"`
+}
+type diamondAOut struct {
+	MidA int `saga:"mid_a"`
+}
+
+func diamondAExec(_ context.Context, in diamondAIn) (diamondAOut, error) {
+	return diamondAOut{MidA: in.Seed}, nil
+}
+func diamondAUndo(_ context.Context, _ diamondAIn, _ diamondAOut) error { return nil }
+
+type diamondBIn struct {
+	MidA int `saga:"mid_a"`
+}
+type diamondBOut struct {
+	MidB int `saga:"mid_b"`
+}
+
+func diamondBExec(_ context.Context, in diamondBIn) (diamondBOut, error) {
+	return diamondBOut{MidB: in.MidA}, nil
+}
+func diamondBUndo(_ context.Context, _ diamondBIn, _ diamondBOut) error { return nil }
+
+type diamondCIn struct {
+	MidA int `saga:"mid_a"`
+}
+type diamondCOut struct {
+	MidC int `saga:"mid_c"`
+}
+
+func diamondCExec(_ context.Context, in diamondCIn) (diamondCOut, error) {
+	return diamondCOut{MidC: in.MidA}, nil
+}
+func diamondCUndo(_ context.Context, _ diamondCIn, _ diamondCOut) error { return nil }
+
+type diamondDIn struct {
+	MidB int `saga:"mid_b"`
+	MidC int `saga:"mid_c"`
+}
+type diamondDOut struct {
+	Result int `saga:"diamond_result"`
+}
+
+func diamondDExec(_ context.Context, in diamondDIn) (diamondDOut, error) {
+	return diamondDOut{Result: in.MidB + in.MidC}, nil
+}
+func diamondDUndo(_ context.Context, _ diamondDIn, _ diamondDOut) error { return nil }
+
+func TestTopologicalSort_Deterministic(t *testing.T) {
+	t.Run("independent actions are alphabetically sorted", func(t *testing.T) {
+		// Register actions in non-alphabetical order to verify the sort
+		// isn't just preserving insertion order.
+		def, err := Define("independent").
+			Action("charlie", charlieExec).Undo(charlieUndo).
+			Action("alpha", alphaExec).Undo(alphaUndo).
+			Action("bravo", bravoExec).Undo(bravoUndo).
+			Build()
+		require.NoError(t, err)
+
+		order := def.ExecutionOrder()
+		assert.Equal(t, []string{"alpha", "bravo", "charlie"}, order)
+
+		// Call again to verify stability.
+		assert.Equal(t, order, def.ExecutionOrder())
+	})
+
+	t.Run("diamond dependencies with alphabetical tiebreaking", func(t *testing.T) {
+		// Diamond: A -> {B, C} -> D
+		// B and C are independent of each other but both depend on A,
+		// so they should be ordered alphabetically between themselves.
+		def, err := Define("diamond").
+			Action("d-action", diamondDExec).Undo(diamondDUndo).
+			Action("c-action", diamondCExec).Undo(diamondCUndo).
+			Action("a-action", diamondAExec).Undo(diamondAUndo).
+			Action("b-action", diamondBExec).Undo(diamondBUndo).
+			Build()
+		require.NoError(t, err)
+
+		order := def.ExecutionOrder()
+		require.Len(t, order, 4)
+
+		// A must come first (only node with no deps).
+		assert.Equal(t, "a-action", order[0])
+
+		// B and C depend only on A — alphabetical tiebreak.
+		assert.Equal(t, "b-action", order[1])
+		assert.Equal(t, "c-action", order[2])
+
+		// D depends on B and C — must come last.
+		assert.Equal(t, "d-action", order[3])
+
+		// Verify stability across repeated calls.
+		assert.Equal(t, order, def.ExecutionOrder())
+	})
+}

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -10,6 +10,19 @@ import (
 	"miren.dev/runtime/pkg/idgen"
 )
 
+type executorCtxKey struct{}
+type executionIDCtxKey struct{}
+
+func executorFromContext(ctx context.Context) (*Executor, bool) {
+	e, ok := ctx.Value(executorCtxKey{}).(*Executor)
+	return e, ok
+}
+
+func executionIDFromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(executionIDCtxKey{}).(string)
+	return id, ok
+}
+
 // Storage persists saga execution state.
 type Storage interface {
 	// Save persists the execution state.
@@ -140,8 +153,10 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 		return fmt.Errorf("persisting running state: %w", err)
 	}
 
-	// Inject dependencies into context
+	// Inject dependencies, executor, and execution ID into context
 	ctx = injectDependencies(ctx, def.dependencies)
+	ctx = context.WithValue(ctx, executorCtxKey{}, e)
+	ctx = context.WithValue(ctx, executionIDCtxKey{}, exec.ID)
 
 	// Build outputs map from already-executed actions
 	outputs := make(map[string]json.RawMessage)
@@ -315,8 +330,10 @@ func (e *Executor) runUndo(ctx context.Context, def *Definition, exec *Execution
 		log.Error("failed to persist undoing state", "error", err)
 	}
 
-	// Inject dependencies into context
+	// Inject dependencies, executor, and execution ID into context
 	ctx = injectDependencies(ctx, def.dependencies)
+	ctx = context.WithValue(ctx, executorCtxKey{}, e)
+	ctx = context.WithValue(ctx, executionIDCtxKey{}, exec.ID)
 
 	// Build outputs map from executed actions
 	outputs := make(map[string]json.RawMessage)
@@ -504,6 +521,47 @@ func extractOutputs(node *ActionNode, outputBytes []byte, outputs map[string]jso
 	}
 
 	return nil
+}
+
+// ExecutionOutputs loads a completed execution from storage and collects its
+// outputs into a NestedResult. Useful for reading saga results without a
+// capture struct.
+func (e *Executor) ExecutionOutputs(ctx context.Context, executionID string) (*NestedResult, error) {
+	exec, err := e.storage.Get(ctx, executionID)
+	if err != nil {
+		return nil, fmt.Errorf("loading execution %q: %w", executionID, err)
+	}
+
+	if exec.Status != StatusCompleted {
+		return nil, fmt.Errorf("execution %q has status %q, expected %q", executionID, exec.Status, StatusCompleted)
+	}
+
+	def, ok := e.registry.Get(exec.DefinitionName)
+	if !ok {
+		return nil, fmt.Errorf("saga definition %q not found", exec.DefinitionName)
+	}
+
+	return collectOutputs(def, exec), nil
+}
+
+// collectOutputs gathers all action outputs from a completed execution into
+// a NestedResult.
+func collectOutputs(def *Definition, exec *Execution) *NestedResult {
+	outputs := make(map[string]json.RawMessage)
+	for actionName, result := range exec.ExecutedActions {
+		if result.UndoneAt != nil {
+			continue
+		}
+		node := def.Actions[actionName]
+		if node == nil {
+			continue
+		}
+		_ = extractOutputs(node, result.Output, outputs)
+	}
+	return &NestedResult{
+		ExecutionID: exec.ID,
+		outputs:     outputs,
+	}
 }
 
 // generateID creates a unique execution ID.

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -3,6 +3,7 @@ package saga
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -10,8 +11,12 @@ import (
 	"miren.dev/runtime/pkg/idgen"
 )
 
+// ErrExecutionNotFound is returned by Storage.Get when no execution exists for the given ID.
+var ErrExecutionNotFound = errors.New("execution not found")
+
 type executorCtxKey struct{}
 type executionIDCtxKey struct{}
+type actionNameCtxKey struct{}
 
 func executorFromContext(ctx context.Context) (*Executor, bool) {
 	e, ok := ctx.Value(executorCtxKey{}).(*Executor)
@@ -21,6 +26,11 @@ func executorFromContext(ctx context.Context) (*Executor, bool) {
 func executionIDFromContext(ctx context.Context) (string, bool) {
 	id, ok := ctx.Value(executionIDCtxKey{}).(string)
 	return id, ok
+}
+
+func actionNameFromContext(ctx context.Context) (string, bool) {
+	name, ok := ctx.Value(actionNameCtxKey{}).(string)
+	return name, ok
 }
 
 // Storage persists saga execution state.
@@ -206,7 +216,8 @@ func (e *Executor) runExecution(ctx context.Context, def *Definition, exec *Exec
 		log.Info("executing action", "action", actionName)
 
 		// Execute the action
-		output, err := node.Action.Execute(ctx, actionInputs)
+		actionCtx := context.WithValue(ctx, actionNameCtxKey{}, actionName)
+		output, err := node.Action.Execute(actionCtx, actionInputs)
 		now := time.Now()
 
 		if err != nil {
@@ -395,7 +406,8 @@ func (e *Executor) runUndo(ctx context.Context, def *Definition, exec *Execution
 		log.Info("undoing action", "action", actionName)
 
 		// Execute undo
-		if err := node.Action.Undo(ctx, actionInputs, output); err != nil {
+		actionCtx := context.WithValue(ctx, actionNameCtxKey{}, actionName)
+		if err := node.Action.Undo(actionCtx, actionInputs, output); err != nil {
 			log.Error("undo failed", "action", actionName, "error", err)
 			undoErrors = append(undoErrors, fmt.Errorf("undo %q: %w", actionName, err))
 			// Continue with other undos even on failure
@@ -445,6 +457,14 @@ func (e *Executor) Recover(ctx context.Context) error {
 
 	var recoverErrors []error
 	for _, exec := range incomplete {
+		// Skip child executions — they will be driven by their parent's recovery
+		// via RunNested. Recovering them independently would cause double-execution.
+		if exec.ParentExecutionID != "" {
+			e.log.Info("skipping child execution (will be recovered by parent)",
+				"execution", exec.ID, "parent", exec.ParentExecutionID)
+			continue
+		}
+
 		e.log.Info("recovering saga", "saga", exec.DefinitionName, "execution", exec.ID, "status", exec.Status)
 
 		def, ok := e.registry.Get(exec.DefinitionName)

--- a/pkg/saga/memory_storage.go
+++ b/pkg/saga/memory_storage.go
@@ -2,7 +2,7 @@ package saga
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"sync"
 )
 
@@ -45,7 +45,7 @@ func (m *MemoryStorage) Get(ctx context.Context, id string) (*Execution, error) 
 
 	exec, ok := m.executions[id]
 	if !ok {
-		return nil, errors.New("execution not found")
+		return nil, fmt.Errorf("%w: %s", ErrExecutionNotFound, id)
 	}
 	return exec, nil
 }

--- a/pkg/saga/nested.go
+++ b/pkg/saga/nested.go
@@ -1,0 +1,147 @@
+package saga
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// NestedResult wraps the outputs from a completed child saga execution.
+type NestedResult struct {
+	ExecutionID string
+	outputs     map[string]json.RawMessage
+}
+
+// Get deserializes a named output from the child saga into target.
+func (nr *NestedResult) Get(key string, target any) error {
+	raw, ok := nr.outputs[key]
+	if !ok {
+		return fmt.Errorf("nested output %q not found", key)
+	}
+	if err := json.Unmarshal(raw, target); err != nil {
+		return fmt.Errorf("deserializing nested output %q: %w", key, err)
+	}
+	return nil
+}
+
+// Has returns true if the child saga produced an output with the given key.
+func (nr *NestedResult) Has(key string) bool {
+	_, ok := nr.outputs[key]
+	return ok
+}
+
+// NestedOption configures a RunNested call.
+type NestedOption func(*nestedConfig)
+
+type nestedConfig struct {
+	inputs map[string]any
+	id     string
+}
+
+// WithNestedInput adds an initial input to the child saga.
+func WithNestedInput(key string, value any) NestedOption {
+	return func(c *nestedConfig) {
+		c.inputs[key] = value
+	}
+}
+
+// WithNestedID sets a specific execution ID for the child saga.
+func WithNestedID(id string) NestedOption {
+	return func(c *nestedConfig) {
+		c.id = id
+	}
+}
+
+// RunNested executes a child saga from within a parent saga action. It reuses
+// the parent executor's registry and storage for durability and observability.
+// The child execution's ParentExecutionID is set to the current execution.
+func RunNested(ctx context.Context, sagaName string, opts ...NestedOption) (*NestedResult, error) {
+	parent, ok := executorFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("RunNested called outside of a saga execution (no executor in context)")
+	}
+
+	cfg := &nestedConfig{
+		inputs: make(map[string]any),
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Look up definition from parent's registry
+	def, ok := parent.registry.Get(sagaName)
+	if !ok {
+		return nil, fmt.Errorf("nested saga definition %q not found in registry", sagaName)
+	}
+
+	// Generate child execution ID
+	childID := cfg.id
+	if childID == "" {
+		childID = generateID()
+	}
+
+	// Create child execution with parent link
+	parentExecID, _ := executionIDFromContext(ctx)
+	exec, err := parent.createChildExecution(ctx, def, cfg.inputs, childID, parentExecID)
+	if err != nil {
+		return nil, fmt.Errorf("creating nested execution: %w", err)
+	}
+
+	// Run the child saga
+	if err := parent.runExecution(ctx, def, exec); err != nil {
+		return nil, err
+	}
+
+	return collectOutputs(def, exec), nil
+}
+
+// createChildExecution builds and persists a new Execution linked to a parent.
+func (e *Executor) createChildExecution(ctx context.Context, def *Definition, inputs map[string]any, id, parentExecID string) (*Execution, error) {
+	exec, err := e.storage.Get(ctx, id)
+	if err == nil {
+		// Execution already exists (idempotent retry)
+		return exec, nil
+	}
+
+	now := time.Now()
+	exec = &Execution{
+		ID:                id,
+		DefinitionName:    def.Name,
+		DefinitionVersion: def.Version,
+		InitialInputs:     inputs,
+		ParentExecutionID: parentExecID,
+		Status:            StatusPending,
+		ExecutedActions:   make(map[string]*ActionResult),
+		ExecutionOrder:    []string{},
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+
+	if err := e.storage.Save(ctx, exec); err != nil {
+		return nil, fmt.Errorf("persisting initial state: %w", err)
+	}
+
+	return exec, nil
+}
+
+// UndoNested compensates a previously completed nested saga. Call this from
+// an undo handler to roll back the child saga's actions.
+func UndoNested(ctx context.Context, executionID string) error {
+	parent, ok := executorFromContext(ctx)
+	if !ok {
+		return fmt.Errorf("UndoNested called outside of a saga execution (no executor in context)")
+	}
+
+	exec, err := parent.storage.Get(ctx, executionID)
+	if err != nil {
+		return fmt.Errorf("loading nested execution %q: %w", executionID, err)
+	}
+
+	def, ok := parent.registry.Get(exec.DefinitionName)
+	if !ok {
+		return fmt.Errorf("saga definition %q not found for nested undo", exec.DefinitionName)
+	}
+
+	return parent.runUndo(ctx, def, exec)
+}

--- a/pkg/saga/nested.go
+++ b/pkg/saga/nested.go
@@ -105,10 +105,14 @@ func RunNested(ctx context.Context, sagaName string, opts ...NestedOption) (*Nes
 func (e *Executor) createChildExecution(ctx context.Context, def *Definition, inputs map[string]any, id, parentExecID string) (*Execution, error) {
 	exec, err := e.storage.Get(ctx, id)
 	if err == nil {
-		// Execution already exists (idempotent retry) — validate it matches the expected definition.
+		// Execution already exists (idempotent retry) — validate it matches the expected definition and parent.
 		if exec.DefinitionName != def.Name || exec.DefinitionVersion != def.Version {
 			return nil, fmt.Errorf("existing execution %s has definition %s@%d, expected %s@%d",
 				id, exec.DefinitionName, exec.DefinitionVersion, def.Name, def.Version)
+		}
+		if exec.ParentExecutionID != parentExecID {
+			return nil, fmt.Errorf("execution %s already exists for parent %s, expected parent %s",
+				id, exec.ParentExecutionID, parentExecID)
 		}
 		return exec, nil
 	}

--- a/pkg/saga/nested.go
+++ b/pkg/saga/nested.go
@@ -2,9 +2,13 @@ package saga
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
+
+	"github.com/mr-tron/base58"
 )
 
 // NestedResult wraps the outputs from a completed child saga execution.
@@ -75,14 +79,15 @@ func RunNested(ctx context.Context, sagaName string, opts ...NestedOption) (*Nes
 		return nil, fmt.Errorf("nested saga definition %q not found in registry", sagaName)
 	}
 
-	// Generate child execution ID
-	childID := cfg.id
-	if childID == "" {
-		childID = generateID()
-	}
-
 	// Create child execution with parent link
 	parentExecID, _ := executionIDFromContext(ctx)
+
+	// Generate child execution ID — deterministic by default for idempotent recovery
+	childID := cfg.id
+	if childID == "" {
+		actionName, _ := actionNameFromContext(ctx)
+		childID = deriveChildID(parentExecID, sagaName, actionName)
+	}
 	exec, err := parent.createChildExecution(ctx, def, cfg.inputs, childID, parentExecID)
 	if err != nil {
 		return nil, fmt.Errorf("creating nested execution: %w", err)
@@ -100,8 +105,15 @@ func RunNested(ctx context.Context, sagaName string, opts ...NestedOption) (*Nes
 func (e *Executor) createChildExecution(ctx context.Context, def *Definition, inputs map[string]any, id, parentExecID string) (*Execution, error) {
 	exec, err := e.storage.Get(ctx, id)
 	if err == nil {
-		// Execution already exists (idempotent retry)
+		// Execution already exists (idempotent retry) — validate it matches the expected definition.
+		if exec.DefinitionName != def.Name || exec.DefinitionVersion != def.Version {
+			return nil, fmt.Errorf("existing execution %s has definition %s@%d, expected %s@%d",
+				id, exec.DefinitionName, exec.DefinitionVersion, def.Name, def.Version)
+		}
 		return exec, nil
+	}
+	if !errors.Is(err, ErrExecutionNotFound) {
+		return nil, fmt.Errorf("checking for existing execution: %w", err)
 	}
 
 	now := time.Now()
@@ -144,4 +156,13 @@ func UndoNested(ctx context.Context, executionID string) error {
 	}
 
 	return parent.runUndo(ctx, def, exec)
+}
+
+// deriveChildID produces a deterministic execution ID from the parent execution,
+// the child saga name, and the calling action name. This ensures that re-executing
+// a parent action during recovery produces the same child ID, enabling
+// createChildExecution's idempotency check to find the prior child execution.
+func deriveChildID(parentExecID, sagaName, actionName string) string {
+	h := sha256.Sum256([]byte(parentExecID + "\x00" + sagaName + "\x00" + actionName))
+	return "saga" + base58.Encode(h[:16])
 }

--- a/pkg/saga/nested_test.go
+++ b/pkg/saga/nested_test.go
@@ -1,0 +1,348 @@
+package saga
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Child saga types ---
+
+type ChildStepIn struct {
+	Value int `saga:"value"`
+}
+
+type ChildStepOut struct {
+	Doubled int `saga:"doubled"`
+}
+
+func ChildStep(ctx context.Context, in ChildStepIn) (ChildStepOut, error) {
+	ctrl := Get[*nestedTestController](ctx)
+	ctrl.childCalls++
+	if ctrl.failChild {
+		return ChildStepOut{}, errors.New("child step failed")
+	}
+	return ChildStepOut{Doubled: in.Value * 2}, nil
+}
+
+func UndoChildStep(ctx context.Context, in ChildStepIn, out ChildStepOut) error {
+	ctrl := Get[*nestedTestController](ctx)
+	ctrl.childUndoCalls++
+	return nil
+}
+
+// --- Parent saga types ---
+
+type ParentStepIn struct {
+	Value int `saga:"value"`
+}
+
+type ParentStepOut struct {
+	ChildExecID string `saga:"childexecid"`
+	Result      int    `saga:"result"`
+}
+
+type ParentFinalIn struct {
+	Result int `saga:"result"`
+}
+
+type ParentFinalOut struct {
+	Done bool `saga:"done"`
+}
+
+type nestedTestController struct {
+	childCalls     int
+	childUndoCalls int
+	parentCalls    int
+	failChild      bool
+	failParent     bool
+}
+
+func ParentStep(ctx context.Context, in ParentStepIn) (ParentStepOut, error) {
+	ctrl := Get[*nestedTestController](ctx)
+	ctrl.parentCalls++
+	if ctrl.failParent {
+		return ParentStepOut{}, errors.New("parent step failed")
+	}
+
+	result, err := RunNested(ctx, "child-saga",
+		WithNestedInput("value", in.Value),
+	)
+	if err != nil {
+		return ParentStepOut{}, err
+	}
+
+	var doubled int
+	if err := result.Get("doubled", &doubled); err != nil {
+		return ParentStepOut{}, err
+	}
+
+	return ParentStepOut{
+		ChildExecID: result.ExecutionID,
+		Result:      doubled,
+	}, nil
+}
+
+func UndoParentStep(ctx context.Context, in ParentStepIn, out ParentStepOut) error {
+	if out.ChildExecID != "" {
+		return UndoNested(ctx, out.ChildExecID)
+	}
+	return nil
+}
+
+func ParentFinal(ctx context.Context, in ParentFinalIn) (ParentFinalOut, error) {
+	return ParentFinalOut{Done: true}, nil
+}
+
+func UndoParentFinal(ctx context.Context, in ParentFinalIn, out ParentFinalOut) error {
+	return nil
+}
+
+func setupNestedSagas(t *testing.T, ctrl *nestedTestController) (*Registry, Storage) {
+	t.Helper()
+
+	registry := NewRegistry()
+
+	err := Define("child-saga").
+		Using(ctrl).
+		Action(ChildStep).Undo(UndoChildStep).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	err = Define("parent-saga").
+		Using(ctrl).
+		Action(ParentStep).Undo(UndoParentStep).
+		Action(ParentFinal).Undo(UndoParentFinal).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	return registry, storage
+}
+
+func TestRunNested_Success(t *testing.T) {
+	ctrl := &nestedTestController{}
+	registry, storage := setupNestedSagas(t, ctrl)
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err := executor.Start("parent-saga").
+		Input("value", 5).
+		WithID("parent-1").
+		Execute(context.Background())
+	require.NoError(t, err)
+
+	// Both parent and child should have been called
+	assert.Equal(t, 1, ctrl.parentCalls)
+	assert.Equal(t, 1, ctrl.childCalls)
+
+	// Parent execution should be completed
+	exec, err := storage.Get(context.Background(), "parent-1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, exec.Status)
+
+	// Verify the result flowed through: 5 * 2 = 10
+	result, err := executor.ExecutionOutputs(context.Background(), "parent-1")
+	require.NoError(t, err)
+
+	var done bool
+	require.NoError(t, result.Get("done", &done))
+	assert.True(t, done)
+}
+
+func TestRunNested_ChildOutputsAccessible(t *testing.T) {
+	ctrl := &nestedTestController{}
+	registry, storage := setupNestedSagas(t, ctrl)
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err := executor.Start("parent-saga").
+		Input("value", 7).
+		WithID("parent-2").
+		Execute(context.Background())
+	require.NoError(t, err)
+
+	// Find child execution via storage to verify its outputs
+	result, err := executor.ExecutionOutputs(context.Background(), "parent-2")
+	require.NoError(t, err)
+
+	var finalResult int
+	require.NoError(t, result.Get("result", &finalResult))
+	assert.Equal(t, 14, finalResult) // 7 * 2
+}
+
+func TestRunNested_ParentExecutionIDSet(t *testing.T) {
+	ctrl := &nestedTestController{}
+	registry, storage := setupNestedSagas(t, ctrl)
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err := executor.Start("parent-saga").
+		Input("value", 3).
+		WithID("parent-3").
+		Execute(context.Background())
+	require.NoError(t, err)
+
+	// Get the parent execution to find child execution ID
+	parentResult, err := executor.ExecutionOutputs(context.Background(), "parent-3")
+	require.NoError(t, err)
+
+	var childExecID string
+	require.NoError(t, parentResult.Get("childexecid", &childExecID))
+	require.NotEmpty(t, childExecID)
+
+	// Get the child execution and verify ParentExecutionID
+	childExec, err := storage.Get(context.Background(), childExecID)
+	require.NoError(t, err)
+	assert.Equal(t, "parent-3", childExec.ParentExecutionID)
+}
+
+func TestRunNested_ChildFailurePropagates(t *testing.T) {
+	ctrl := &nestedTestController{failChild: true}
+	registry, storage := setupNestedSagas(t, ctrl)
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err := executor.Start("parent-saga").
+		Input("value", 5).
+		WithID("parent-4").
+		Execute(context.Background())
+	require.Error(t, err)
+
+	// Parent should be in failed state (child failure triggers parent undo)
+	exec, err := storage.Get(context.Background(), "parent-4")
+	require.NoError(t, err)
+	assert.Equal(t, StatusFailed, exec.Status)
+
+	// Child step was called, and parent undo should not call UndoNested
+	// because ParentStep itself failed (so ParentStepOut is empty)
+	assert.Equal(t, 1, ctrl.childCalls)
+}
+
+func TestRunNested_ChildUsesParentStorage(t *testing.T) {
+	ctrl := &nestedTestController{}
+	registry, storage := setupNestedSagas(t, ctrl)
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err := executor.Start("parent-saga").
+		Input("value", 5).
+		WithID("parent-5").
+		Execute(context.Background())
+	require.NoError(t, err)
+
+	// Child execution should be persisted in the same storage
+	parentResult, err := executor.ExecutionOutputs(context.Background(), "parent-5")
+	require.NoError(t, err)
+
+	var childExecID string
+	require.NoError(t, parentResult.Get("childexecid", &childExecID))
+
+	childExec, err := storage.Get(context.Background(), childExecID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, childExec.Status)
+	assert.Equal(t, "child-saga", childExec.DefinitionName)
+}
+
+func TestRunNested_OutsideContext(t *testing.T) {
+	// RunNested outside of a saga should return an error
+	_, err := RunNested(context.Background(), "some-saga")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no executor in context")
+}
+
+func TestUndoNested_OutsideContext(t *testing.T) {
+	err := UndoNested(context.Background(), "some-id")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no executor in context")
+}
+
+func TestRunNested_WithNestedID(t *testing.T) {
+	ctrl := &nestedTestController{}
+	registry := NewRegistry()
+
+	// Register child saga with explicit ID test
+	err := Define("id-child").
+		Using(ctrl).
+		Action(ChildStep).Undo(UndoChildStep).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	// Use a parent that calls RunNested with WithNestedID
+	parentWithIDFn := func(ctx context.Context, in ParentStepIn) (ParentStepOut, error) {
+		ctrl := Get[*nestedTestController](ctx)
+		ctrl.parentCalls++
+
+		result, err := RunNested(ctx, "id-child",
+			WithNestedInput("value", in.Value),
+			WithNestedID("custom-child-id"),
+		)
+		if err != nil {
+			return ParentStepOut{}, err
+		}
+
+		var doubled int
+		if err := result.Get("doubled", &doubled); err != nil {
+			return ParentStepOut{}, err
+		}
+
+		return ParentStepOut{
+			ChildExecID: result.ExecutionID,
+			Result:      doubled,
+		}, nil
+	}
+
+	err = Define("id-parent").
+		Using(ctrl).
+		Action("parent-step", parentWithIDFn).Undo(UndoParentStep).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err = executor.Start("id-parent").
+		Input("value", 4).
+		WithID("id-parent-1").
+		Execute(context.Background())
+	require.NoError(t, err)
+
+	// Verify the child used the custom ID
+	childExec, err := storage.Get(context.Background(), "custom-child-id")
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, childExec.Status)
+	assert.Equal(t, "id-child", childExec.DefinitionName)
+}
+
+func TestNestedResult_Get(t *testing.T) {
+	nr := &NestedResult{
+		ExecutionID: "test",
+		outputs: map[string]json.RawMessage{
+			"name":  json.RawMessage(`"hello"`),
+			"count": json.RawMessage(`42`),
+		},
+	}
+
+	var name string
+	require.NoError(t, nr.Get("name", &name))
+	assert.Equal(t, "hello", name)
+
+	var count int
+	require.NoError(t, nr.Get("count", &count))
+	assert.Equal(t, 42, count)
+
+	// Missing key
+	err := nr.Get("missing", &name)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestNestedResult_Has(t *testing.T) {
+	nr := &NestedResult{
+		ExecutionID: "test",
+		outputs: map[string]json.RawMessage{
+			"name": json.RawMessage(`"hello"`),
+		},
+	}
+
+	assert.True(t, nr.Has("name"))
+	assert.False(t, nr.Has("missing"))
+}

--- a/pkg/saga/nested_test.go
+++ b/pkg/saga/nested_test.go
@@ -312,6 +312,88 @@ func TestRunNested_WithNestedID(t *testing.T) {
 	assert.Equal(t, "id-child", childExec.DefinitionName)
 }
 
+func TestRunNested_DeterministicChildID(t *testing.T) {
+	ctrl := &nestedTestController{}
+	registry, storage := setupNestedSagas(t, ctrl)
+
+	// Run the parent saga twice with the same parent ID.
+	// The second run should produce the same child ID (idempotent retry).
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err := executor.Start("parent-saga").
+		Input("value", 5).
+		WithID("det-parent-1").
+		Execute(context.Background())
+	require.NoError(t, err)
+
+	// Get the child execution ID from parent outputs
+	result1, err := executor.ExecutionOutputs(context.Background(), "det-parent-1")
+	require.NoError(t, err)
+	var childID1 string
+	require.NoError(t, result1.Get("childexecid", &childID1))
+	require.NotEmpty(t, childID1)
+
+	// Verify the child ID is deterministic (derived from parent exec ID + saga name + action name)
+	expectedID := deriveChildID("det-parent-1", "child-saga", "parent-step")
+	assert.Equal(t, expectedID, childID1)
+
+	// Run again with a different parent ID — child ID should differ
+	err = executor.Start("parent-saga").
+		Input("value", 5).
+		WithID("det-parent-2").
+		Execute(context.Background())
+	require.NoError(t, err)
+
+	result2, err := executor.ExecutionOutputs(context.Background(), "det-parent-2")
+	require.NoError(t, err)
+	var childID2 string
+	require.NoError(t, result2.Get("childexecid", &childID2))
+	assert.NotEqual(t, childID1, childID2, "different parent IDs should produce different child IDs")
+}
+
+func TestRecover_SkipsChildExecutions(t *testing.T) {
+	ctrl := &nestedTestController{}
+	registry, storage := setupNestedSagas(t, ctrl)
+
+	// Simulate a crash mid-way: both parent and child are incomplete.
+	// The child has ParentExecutionID set.
+	childExec := &Execution{
+		ID:                "child-crash-1",
+		DefinitionName:    "child-saga",
+		DefinitionVersion: 1,
+		ParentExecutionID: "parent-crash-1",
+		Status:            StatusRunning,
+		ExecutedActions:   map[string]*ActionResult{},
+		ExecutionOrder:    []string{},
+	}
+	parentExec := &Execution{
+		ID:                "parent-crash-1",
+		DefinitionName:    "parent-saga",
+		DefinitionVersion: 1,
+		Status:            StatusRunning,
+		InitialInputs:     map[string]any{"value": float64(5)},
+		ExecutedActions:   map[string]*ActionResult{},
+		ExecutionOrder:    []string{},
+	}
+
+	require.NoError(t, storage.Save(context.Background(), childExec))
+	require.NoError(t, storage.Save(context.Background(), parentExec))
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err := executor.Recover(context.Background())
+	require.NoError(t, err)
+
+	// Parent should have been recovered (re-executed its actions)
+	assert.Equal(t, 1, ctrl.parentCalls, "parent should be recovered")
+
+	// The child-crash-1 execution should NOT have been independently recovered.
+	// Instead, RunNested inside parent created a new child execution.
+	// The original child-crash-1 should still be in its crashed state (Running)
+	// because Recover() skipped it.
+	crashedChild, err := storage.Get(context.Background(), "child-crash-1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusRunning, crashedChild.Status, "original child should be untouched by Recover()")
+}
+
 func TestNestedResult_Get(t *testing.T) {
 	nr := &NestedResult{
 		ExecutionID: "test",

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -134,7 +135,7 @@ func (m *memoryStorage) Get(ctx context.Context, id string) (*Execution, error) 
 	defer m.mu.Unlock()
 	exec, ok := m.executions[id]
 	if !ok {
-		return nil, errors.New("not found")
+		return nil, fmt.Errorf("%w: %s", ErrExecutionNotFound, id)
 	}
 	return exec, nil
 }

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -3,6 +3,7 @@ package saga
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -50,6 +51,7 @@ func (s *EntityStorage) Save(ctx context.Context, exec *Execution) error {
 		ID:                entity.Id(exec.ID),
 		DefinitionName:    exec.DefinitionName,
 		DefinitionVersion: int64(exec.DefinitionVersion),
+		ParentExecutionId: entity.Id(exec.ParentExecutionID),
 		Status:            status,
 		InitialInputs:     initialInputs,
 		ExecutedActions:   executedActions,
@@ -75,6 +77,9 @@ func (s *EntityStorage) Save(ctx context.Context, exec *Execution) error {
 func (s *EntityStorage) Get(ctx context.Context, id string) (*Execution, error) {
 	ent, err := s.store.GetEntity(ctx, entity.Id(id))
 	if err != nil {
+		if errors.Is(err, entity.ErrEntityNotFound) {
+			return nil, fmt.Errorf("%w: %s", ErrExecutionNotFound, id)
+		}
 		return nil, fmt.Errorf("getting saga entity: %w", err)
 	}
 
@@ -192,6 +197,7 @@ func entityToExecution(sagaEntity *saga_v1alpha.Saga) (*Execution, error) {
 		ID:                string(sagaEntity.ID),
 		DefinitionName:    sagaEntity.DefinitionName,
 		DefinitionVersion: int(sagaEntity.DefinitionVersion),
+		ParentExecutionID: string(sagaEntity.ParentExecutionId),
 		Status:            statusFromEntity(sagaEntity.Status),
 		Error:             sagaEntity.Error,
 	}

--- a/pkg/saga/types.go
+++ b/pkg/saga/types.go
@@ -69,6 +69,9 @@ type Execution struct {
 	// ExecutionOrder records the order actions were executed for reverse undo.
 	ExecutionOrder []string `json:"execution_order"`
 
+	// ParentExecutionID links this execution to a parent saga when run as a nested child.
+	ParentExecutionID string `json:"parent_execution_id,omitempty"`
+
 	// Error is set if the saga failed.
 	Error string `json:"error,omitempty"`
 


### PR DESCRIPTION
## Summary

- Add `RunNested()` for executing child sagas from within a parent saga action, enabling complex multi-step workflows to compose smaller sagas
- Make topological sort deterministic by sorting actions alphabetically at each dependency level, and expose `ExecutionOrder()` for testing
- Add `ExecutionOutputs()` to read completed saga results without a capture struct

## Test plan

- [x] Unit tests for nested saga execution (single-level and multi-level nesting)
- [x] Tests for deterministic execution ordering
- [x] Tests for `ExecutionOutputs()` retrieval