### PR TITLE
Enable TOML syntax highlighting in docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -114,6 +114,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
+      additionalLanguages: ['toml'],
     },
   } satisfies Preset.ThemeConfig,
 };


### PR DESCRIPTION
## Summary

- Adds `toml` to Prism's `additionalLanguages` in the Docusaurus config
- Docusaurus's bundled Prism only ships a subset of languages, and TOML isn't included by default
- All our config code blocks are already correctly tagged with ` ```toml ` but were rendering as plain uncolored text
- This one-line change enables highlighting across ~28 TOML blocks in services, scaling, disks, languages, and getting-started docs

## Test plan

- [ ] Run docs dev server (`cd docs && npm start`) and verify TOML blocks have syntax highlighting
- [ ] Spot check: [/services#example-rails-with-sidekiq](/services#example-rails-with-sidekiq)