### PR TITLE
Include entity data in delete watch events

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -199,8 +199,9 @@ func (c *ReconcileController) Start(top context.Context) error {
 					ev.Rev = aen.Revision()
 				}
 
-				// Skip watch events for revisions we recently wrote to reduce reconciliation noise
-				if ev.Rev > 0 && c.recentWrites.Contains(ev.Rev) {
+				// Skip watch events for revisions we recently wrote to reduce reconciliation noise.
+				// Never skip delete events — a delete is always meaningful regardless of who caused it.
+				if ev.Type != EventDeleted && ev.Rev > 0 && c.recentWrites.Contains(ev.Rev) {
 					return nil
 				}
 

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -13,6 +13,7 @@ import (
 type MockStore struct {
 	mu              sync.RWMutex
 	Entities        map[Id]*Entity
+	deletedEntities map[Id]*Entity // Tracks recently deleted entities for revision-based reads
 	OnWatchIndex    func(ctx context.Context, attr Attr) (clientv3.WatchChan, error)
 	GetEntitiesFunc func(ctx context.Context, ids []Id) ([]*Entity, error)
 	OnListIndex     func(ctx context.Context, attr Attr) ([]Id, error) // Hook to track ListIndex calls
@@ -32,9 +33,10 @@ var _ Store = &MockStore{}
 
 func NewMockStore() *MockStore {
 	return &MockStore{
-		Entities:      make(map[Id]*Entity),
-		watchers:      make(map[Id][]chan EntityOp),
-		indexWatchers: make(map[string][]chan clientv3.WatchResponse),
+		Entities:        make(map[Id]*Entity),
+		deletedEntities: make(map[Id]*Entity),
+		watchers:        make(map[Id][]chan EntityOp),
+		indexWatchers:   make(map[string][]chan clientv3.WatchResponse),
 	}
 }
 
@@ -49,6 +51,18 @@ func (m *MockStore) GetEntity(ctx context.Context, id Id) (*Entity, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if e, ok := m.Entities[id]; ok {
+		return e, nil
+	}
+	return nil, cond.NotFound("entity", id)
+}
+
+func (m *MockStore) GetEntityAtRevision(ctx context.Context, id Id, rev int64) (*Entity, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if e, ok := m.Entities[id]; ok {
+		return e, nil
+	}
+	if e, ok := m.deletedEntities[id]; ok {
 		return e, nil
 	}
 	return nil, cond.NotFound("entity", id)
@@ -221,10 +235,13 @@ func (m *MockStore) DeleteEntity(ctx context.Context, id Id) error {
 	m.mu.Lock()
 	entity, existed := m.Entities[id]
 	delete(m.Entities, id)
+	if existed {
+		m.deletedEntities[id] = entity
+	}
 	m.mu.Unlock()
 
-	// Notify index watchers of the deletion
 	if existed {
+		go m.notifyWatchers(id, EntityOp{Type: EntityOpDelete, Entity: entity})
 		go m.notifyIndexWatchers(entity, clientv3.EventTypeDelete, entity)
 	}
 
@@ -259,6 +276,27 @@ func (m *MockStore) WatchIndex(ctx context.Context, attr Attr) (clientv3.WatchCh
 	}()
 
 	return ch, nil
+}
+
+// WaitForEntityWatcher blocks until at least one watcher is registered for the given entity ID,
+// or the context is cancelled.
+func (m *MockStore) WaitForEntityWatcher(ctx context.Context, id Id) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			m.watchersMu.RLock()
+			hasWatcher := len(m.watchers[id]) > 0
+			m.watchersMu.RUnlock()
+			if hasWatcher {
+				return nil
+			}
+		}
+	}
 }
 
 // WaitForIndexWatcher blocks until at least one watcher is registered for the given attribute,

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -31,6 +31,7 @@ type EtcdStore struct {
 
 type Store interface {
 	GetEntity(ctx context.Context, id Id) (*Entity, error)
+	GetEntityAtRevision(ctx context.Context, id Id, rev int64) (*Entity, error)
 	GetEntities(ctx context.Context, ids []Id) ([]*Entity, error)
 	WatchEntity(ctx context.Context, id Id) (chan EntityOp, error)
 	GetAttributeSchema(ctx context.Context, name Id) (*AttributeSchema, error)
@@ -338,6 +339,34 @@ func (s *EtcdStore) GetEntity(ctx context.Context, id Id) (*Entity, error) {
 	return &entity, nil
 }
 
+// GetEntityAtRevision reads an entity at a specific etcd revision.
+// This is used to retrieve entity data for delete events where the entity
+// may no longer exist at the current revision.
+func (s *EtcdStore) GetEntityAtRevision(ctx context.Context, id Id, rev int64) (*Entity, error) {
+	key := s.buildKey(id)
+
+	resp, err := s.client.Get(ctx, key, clientv3.WithRev(rev))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get entity at revision %d: %w", rev, err)
+	}
+
+	if len(resp.Kvs) == 0 {
+		return nil, cond.NotFound("entity", id)
+	}
+
+	var entity Entity
+
+	err = decoder.Unmarshal(resp.Kvs[0].Value, &entity)
+	if err != nil {
+		return nil, cond.Corruption("entity", "failed to deserialize entity: %s", err)
+	}
+
+	entity.SetRevision(resp.Kvs[0].ModRevision)
+	entity.postUnmarshal()
+
+	return &entity, nil
+}
+
 func (s *EtcdStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error) {
 	if len(ids) == 0 {
 		return []*Entity{}, nil
@@ -441,7 +470,7 @@ type EntityOp struct {
 
 func (s *EtcdStore) WatchEntity(ctx context.Context, id Id) (chan EntityOp, error) {
 	key := s.buildKey(id)
-	wc := s.client.Watch(ctx, key)
+	wc := s.client.Watch(ctx, key, clientv3.WithPrevKV())
 
 	och := make(chan EntityOp)
 
@@ -491,6 +520,17 @@ func (s *EtcdStore) WatchEntity(ctx context.Context, id Id) (chan EntityOp, erro
 
 						entity.postUnmarshal()
 						op.Entity = &entity
+					} else if eventType == EntityOpDelete && event.PrevKv != nil {
+						var entity Entity
+
+						err := decoder.Unmarshal(event.PrevKv.Value, &entity)
+						if err != nil {
+							s.log.Error("failed to decode previous entity for delete event", "error", err)
+						} else {
+							entity.SetRevision(event.PrevKv.ModRevision)
+							entity.postUnmarshal()
+							op.Entity = &entity
+						}
 					}
 
 					select {

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -868,6 +868,41 @@ func TestWatchIndex(t *testing.T) {
 	}
 }
 
+func TestWatchEntity_DeleteIncludesEntity(t *testing.T) {
+	ctx := context.Background()
+	client := setupTestEtcd(t)
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
+	require.NoError(t, err)
+
+	// Create an entity
+	created, err := store.CreateEntity(ctx, New(
+		String(Ident, "test-watch-delete"),
+		String(Doc, "entity to be deleted"),
+	))
+	require.NoError(t, err)
+
+	// Start watching the entity
+	watcher, err := store.WatchEntity(ctx, created.Id())
+	require.NoError(t, err)
+
+	// Delete the entity
+	err = store.DeleteEntity(ctx, created.Id())
+	require.NoError(t, err)
+
+	// The delete event should include the entity data from before deletion
+	select {
+	case op := <-watcher:
+		assert.Equal(t, EntityOpDelete, op.Type)
+		require.NotNil(t, op.Entity, "delete event should include the entity")
+		assert.Equal(t, created.Id(), op.Id())
+		doc, ok := op.Get(Doc)
+		require.True(t, ok, "entity should have doc attribute")
+		assert.Equal(t, "entity to be deleted", doc.Value.String())
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for delete event")
+	}
+}
+
 func TestWatchIndex_DBID(t *testing.T) {
 	ctx := context.Background()
 	client := setupTestEtcd(t)

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -122,18 +122,13 @@ func (e *EntityServer) WatchEntity(ctx context.Context, req *entityserver_v1alph
 				return nil
 			}
 
-			var (
-				eventType int
-				read      bool
-			)
+			var eventType int
 
 			switch event.Type {
 			case entity.EntityOpCreate:
 				eventType = 1
-				read = true
 			case entity.EntityOpUpdate, entity.EntityOpStated:
 				eventType = 2
-				read = true
 			case entity.EntityOpDelete:
 				eventType = 3
 			default:
@@ -143,7 +138,7 @@ func (e *EntityServer) WatchEntity(ctx context.Context, req *entityserver_v1alph
 			var op entityserver_v1alpha.EntityOp
 			op.SetOperation(int64(eventType))
 
-			if read {
+			if event.Entity != nil {
 				en = event.Entity
 				var rpcEntity entityserver_v1alpha.Entity
 				rpcEntity.SetId(en.Id().String())
@@ -489,8 +484,29 @@ func (e *EntityServer) WatchIndex(ctx context.Context, req *entityserver_v1alpha
 
 					op.SetEntity(&rpcEntity)
 				} else if event.PrevKv != nil {
-					op.SetEntityId(string(event.PrevKv.Value))
+					entityId := entity.Id(event.PrevKv.Value)
+					op.SetEntityId(string(entityId))
 					op.SetPrevious(event.PrevKv.ModRevision)
+
+					// Try to fetch the entity data for the delete event.
+					// Index entries are deleted before the entity key, so the entity
+					// may still exist. Fall back to a revision-based read if not.
+					en, err := e.Store.GetEntity(ctx, entityId)
+					if err != nil {
+						en, err = e.Store.GetEntityAtRevision(ctx, entityId, event.Kv.ModRevision)
+					}
+					if err != nil {
+						e.Log.Error("failed to get entity for delete event", "error", err, "id", entityId)
+					} else {
+						var rpcEntity entityserver_v1alpha.Entity
+						rpcEntity.SetId(en.Id().String())
+						rpcEntity.SetCreatedAt(en.GetCreatedAt().UnixMilli())
+						rpcEntity.SetUpdatedAt(en.GetUpdatedAt().UnixMilli())
+						rpcEntity.SetRevision(en.GetRevision())
+						rpcEntity.SetAttrs(en.Attrs())
+
+						op.SetEntity(&rpcEntity)
+					}
 				}
 
 				_, err = send.Send(ctx, &op)

--- a/servers/entityserver/entityserver_test.go
+++ b/servers/entityserver/entityserver_test.go
@@ -282,6 +282,286 @@ func TestEntityServer_WatchIndex(t *testing.T) {
 	}
 }
 
+func TestEntityServer_WatchEntity_DeleteIncludesEntity(t *testing.T) {
+	r := require.New(t)
+
+	store := entity.NewMockStore()
+	server := &EntityServer{
+		Log:   slog.Default(),
+		Store: store,
+	}
+
+	sc := v1alpha.EntityAccessClient{
+		Client: rpc.LocalClient(v1alpha.AdaptEntityAccess(server)),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create an entity first
+	testEntity := entity.New(
+		entity.Ref(entity.DBId, "test/watch-delete"),
+		entity.Keyword(entity.Ident, "test/watch-delete"),
+		entity.String(entity.Doc, "entity to be deleted"),
+	)
+	created, err := store.CreateEntity(ctx, testEntity)
+	r.NoError(err)
+
+	// Track received events
+	var receivedOps []*v1alpha.EntityOp
+	deleteReceived := make(chan struct{})
+	watchDone := make(chan error, 1)
+
+	// Start watch in background
+	go func() {
+		_, err := sc.WatchEntity(ctx, created.Id().String(), stream.Callback(func(op *v1alpha.EntityOp) error {
+			receivedOps = append(receivedOps, op)
+			if op.Operation() == int64(v1alpha.EntityOperationDelete) {
+				close(deleteReceived)
+			}
+			return nil
+		}))
+		watchDone <- err
+	}()
+
+	// Wait for watch to be established
+	err = store.WaitForEntityWatcher(ctx, created.Id())
+	r.NoError(err)
+
+	// Delete the entity
+	err = store.DeleteEntity(ctx, created.Id())
+	r.NoError(err)
+
+	// Wait for delete event
+	select {
+	case <-deleteReceived:
+		// Find the delete event
+		var deleteOp *v1alpha.EntityOp
+		for _, op := range receivedOps {
+			if op.Operation() == int64(v1alpha.EntityOperationDelete) {
+				deleteOp = op
+				break
+			}
+		}
+		r.NotNil(deleteOp, "should have received a delete event")
+		r.True(deleteOp.HasEntity(), "delete event should include entity data")
+
+		ae := deleteOp.Entity()
+		r.Equal(created.Id().String(), ae.Id())
+		r.Contains(ae.Attrs(), entity.String(entity.Doc, "entity to be deleted"))
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for delete event")
+	}
+
+	select {
+	case <-watchDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for watch to finish")
+	}
+}
+
+func TestEntityServer_WatchIndex_DeleteIncludesEntity(t *testing.T) {
+	r := require.New(t)
+
+	store := entity.NewMockStore()
+	server := &EntityServer{
+		Log:   slog.Default(),
+		Store: store,
+	}
+
+	sc := v1alpha.EntityAccessClient{
+		Client: rpc.LocalClient(v1alpha.AdaptEntityAccess(server)),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	index := entity.Keyword(entity.Ident, "test/index-delete")
+
+	// Track received events
+	deleteReceived := make(chan *v1alpha.EntityOp, 1)
+	watchDone := make(chan error, 1)
+
+	// Start watch in background
+	go func() {
+		_, err := sc.WatchIndex(ctx, index, stream.Callback(func(op *v1alpha.EntityOp) error {
+			if op.Operation() == int64(v1alpha.EntityOperationDelete) {
+				deleteReceived <- op
+			}
+			return nil
+		}))
+		watchDone <- err
+	}()
+
+	// Wait for watch to be established
+	err := store.WaitForIndexWatcher(ctx, index)
+	r.NoError(err)
+
+	// Create an entity that matches the watch index
+	testEntity := entity.New(
+		entity.Ref(entity.DBId, "test/entity-delete"),
+		index,
+		entity.String(entity.Doc, "will be deleted"),
+	)
+	created, err := store.CreateEntity(ctx, testEntity)
+	r.NoError(err)
+
+	// Delete the entity
+	err = store.DeleteEntity(ctx, created.Id())
+	r.NoError(err)
+
+	// Wait for delete event
+	select {
+	case deleteOp := <-deleteReceived:
+		r.True(deleteOp.HasEntity(), "delete event should include entity data")
+
+		ae := deleteOp.Entity()
+		r.Equal(created.Id().String(), ae.Id())
+		r.Contains(ae.Attrs(), entity.String(entity.Doc, "will be deleted"))
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for delete event")
+	}
+
+	select {
+	case <-watchDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for watch to finish")
+	}
+}
+
+func TestEntityServer_WatchEntity_DeleteIncludesEntity_Etcd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, prefix := setupTestEtcd(t)
+	store, err := entity.NewEtcdStore(ctx, slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	server, err := NewEntityServer(slog.Default(), store)
+	require.NoError(t, err)
+
+	sc := v1alpha.EntityAccessClient{
+		Client: rpc.LocalClient(v1alpha.AdaptEntityAccess(server)),
+	}
+
+	// Create an entity
+	created, err := store.CreateEntity(ctx, entity.New(
+		entity.String(entity.Ident, "test-watch-delete-etcd"),
+		entity.String(entity.Doc, "entity for etcd delete test"),
+	))
+	require.NoError(t, err)
+
+	deleteReceived := make(chan *v1alpha.EntityOp, 1)
+	watchDone := make(chan error, 1)
+
+	go func() {
+		_, err := sc.WatchEntity(ctx, created.Id().String(), stream.Callback(func(op *v1alpha.EntityOp) error {
+			if op.Operation() == int64(v1alpha.EntityOperationDelete) {
+				deleteReceived <- op
+			}
+			return nil
+		}))
+		watchDone <- err
+	}()
+
+	// Give the watch time to establish
+	time.Sleep(100 * time.Millisecond)
+
+	// Delete the entity
+	err = store.DeleteEntity(ctx, created.Id())
+	require.NoError(t, err)
+
+	select {
+	case deleteOp := <-deleteReceived:
+		require.True(t, deleteOp.HasEntity(), "delete event should include entity data")
+		ae := deleteOp.Entity()
+		assert.Equal(t, created.Id().String(), ae.Id())
+		assert.Contains(t, ae.Attrs(), entity.String(entity.Doc, "entity for etcd delete test"))
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for delete event")
+	}
+
+	select {
+	case <-watchDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for watch to finish")
+	}
+}
+
+func TestEntityServer_WatchIndex_DeleteIncludesEntity_Etcd(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, prefix := setupTestEtcd(t)
+	store, err := entity.NewEtcdStore(ctx, slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	server, err := NewEntityServer(slog.Default(), store)
+	require.NoError(t, err)
+
+	sc := v1alpha.EntityAccessClient{
+		Client: rpc.LocalClient(v1alpha.AdaptEntityAccess(server)),
+	}
+
+	// Create an indexed attribute schema
+	indexAttr, err := store.CreateEntity(ctx, entity.New(
+		entity.String(entity.Ident, "test/watch-idx"),
+		entity.Ref(entity.Type, entity.TypeStr),
+		entity.Bool(entity.Index, true),
+	))
+	require.NoError(t, err)
+
+	index := entity.String(indexAttr.Id(), "watch-val")
+
+	deleteReceived := make(chan *v1alpha.EntityOp, 1)
+	watchDone := make(chan error, 1)
+
+	go func() {
+		_, err := sc.WatchIndex(ctx, index, stream.Callback(func(op *v1alpha.EntityOp) error {
+			if op.Operation() == int64(v1alpha.EntityOperationDelete) {
+				deleteReceived <- op
+			}
+			return nil
+		}))
+		watchDone <- err
+	}()
+
+	// Give the watch time to establish
+	time.Sleep(100 * time.Millisecond)
+
+	// Create an entity that matches the watch index
+	created, err := store.CreateEntity(ctx, entity.New(
+		entity.String(entity.Ident, "test-idx-delete-etcd"),
+		index,
+		entity.String(entity.Doc, "indexed entity for delete test"),
+	))
+	require.NoError(t, err)
+
+	// Delete the entity
+	err = store.DeleteEntity(ctx, created.Id())
+	require.NoError(t, err)
+
+	select {
+	case deleteOp := <-deleteReceived:
+		require.True(t, deleteOp.HasEntity(), "delete event should include entity data")
+		ae := deleteOp.Entity()
+		assert.Equal(t, created.Id().String(), ae.Id())
+		assert.Contains(t, ae.Attrs(), entity.String(entity.Doc, "indexed entity for delete test"))
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for delete event")
+	}
+
+	select {
+	case <-watchDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for watch to finish")
+	}
+}
+
 func TestEntityServer_List(t *testing.T) {
 	store := entity.NewMockStore()
 	server := &EntityServer{


### PR DESCRIPTION
## Summary
- When a watched entity is deleted, watchers now receive the full entity data from before deletion, eliminating the need for watchers to cache entities on their side
- `WatchEntity` uses etcd's `WithPrevKV()` to get the previous entity value directly from the watch event — no extra round-trip
- `WatchIndex` fetches the entity via `GetEntity` (entity still exists since index entries are deleted first), with a fallback to the new `GetEntityAtRevision` method for robustness
- Adds `GetEntityAtRevision` to the `Store` interface for revision-based reads from etcd

## Test plan
- [x] Store-level `TestWatchEntity_DeleteIncludesEntity` against real etcd
- [x] Server-level `TestEntityServer_WatchEntity_DeleteIncludesEntity` against mock
- [x] Server-level `TestEntityServer_WatchIndex_DeleteIncludesEntity` against mock
- [x] Server-level `TestEntityServer_WatchEntity_DeleteIncludesEntity_Etcd` against real etcd
- [x] Server-level `TestEntityServer_WatchIndex_DeleteIncludesEntity_Etcd` against real etcd
- [x] Full `pkg/entity` test suite (229 tests passing)
- [x] Full `servers/entityserver` test suite (23 tests passing)