### PR TITLE
OTel Phase 2: inbound trace propagation, containerd instrumentation, observability docs

### DIFF
--- a/components/containerd/containerd.go
+++ b/components/containerd/containerd.go
@@ -14,6 +14,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"miren.dev/runtime/pkg/slogout"
 )
 
@@ -196,6 +197,7 @@ func (c *ContainerdComponent) Start(ctx context.Context, config *Config) error {
 	// Create client for the newly started containerd
 	client, err := containerd.New(config.SocketPath,
 		containerd.WithDialOpts([]grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 		}),
 	)

--- a/components/containerd/containerd.go
+++ b/components/containerd/containerd.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
 	"miren.dev/runtime/pkg/slogout"
 )
 
@@ -192,7 +194,11 @@ func (c *ContainerdComponent) Start(ctx context.Context, config *Config) error {
 	c.log.Info("containerd socket is ready", "socket", config.SocketPath)
 
 	// Create client for the newly started containerd
-	client, err := containerd.New(config.SocketPath)
+	client, err := containerd.New(config.SocketPath,
+		containerd.WithDialOpts([]grpc.DialOption{
+			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		}),
+	)
 	if err != nil {
 		c.log.Warn("failed to create containerd client", "error", err)
 		// Don't fail here, containerd is running

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -27,9 +27,11 @@ Miren participates in [W3C Trace Context](https://www.w3.org/TR/trace-context/) 
 
 ## Connecting Your App's Traces
 
-To participate in Miren's traces, configure your app with an OpenTelemetry SDK and point it at an OTLP-compatible backend. The SDK will automatically read the `traceparent` header from incoming requests and create child spans.
+Miren's tracing and your app's tracing are configured independently — Miren handles its own trace export, and your app handles its own. The `traceparent` header is what connects them: when both sides send traces to the same backend, they show up as one unified trace because they share the same trace ID.
 
-Set these environment variables on your app:
+To participate, add an OpenTelemetry SDK to your app and point it at your OTLP-compatible backend. The SDK will automatically read the `traceparent` header from incoming requests and create child spans.
+
+Set these environment variables on your app in `.miren/app.toml`:
 
 ```toml
 [[env]]
@@ -45,7 +47,7 @@ key = "OTEL_SERVICE_NAME"
 value = "my-app"
 ```
 
-This works with any OTel-compatible backend: Grafana Tempo, Honeycomb, Datadog, Jaeger, and others.
+This works with any OTel-compatible backend: Grafana Tempo, Honeycomb, Datadog, Jaeger, and others. You can use the same backend as your Miren cluster or a different one — as long as traces with the same trace ID end up in the same place, they'll be correlated.
 
 ### Python Example
 
@@ -101,7 +103,7 @@ The `--require` flag loads the auto-instrumentation before your app starts, auto
 
 A typical request trace shows the full path through Miren:
 
-```
+```text
 httpingress                          [350ms]
 ├─ httpingress.lease                 [200ms]  (cold start)
 │  ├─ rpc.call.AcquireLease         [195ms]
@@ -113,7 +115,7 @@ httpingress                          [350ms]
 
 On a warm request where a sandbox is already running:
 
-```
+```text
 httpingress                          [15ms]
 ├─ httpingress.lease                 [0.1ms]  (cached lease)
 ├─ [proxy to app]                   [14ms]

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -1,0 +1,126 @@
+---
+sidebar_position: 9
+---
+
+# Observability
+
+Miren instruments the request lifecycle with [OpenTelemetry](https://opentelemetry.io/) distributed tracing. Traces flow from the initial HTTP request through internal routing, sandbox management, and container operations, giving you visibility into what's happening at every layer.
+
+## What Miren Traces
+
+Every HTTP request that arrives at Miren generates a trace with spans covering:
+
+- **httpingress** — The full request lifecycle: routing, lease acquisition, and proxying to your app
+- **httpingress.lease** — Sandbox lease management, including whether a cached lease was used or a cold start was required
+- **RPC calls** — Internal service-to-service communication within Miren
+- **containerd gRPC** — Container operations like image pulls, container creation, and task management
+
+The most useful spans for app developers are `httpingress` (overall request latency) and `httpingress.lease` (cold start visibility). The RPC and containerd spans are primarily useful for operators debugging Miren itself.
+
+## Trace Context Propagation
+
+Miren participates in [W3C Trace Context](https://www.w3.org/TR/trace-context/) propagation in both directions:
+
+**Inbound:** If your request includes a `traceparent` header, Miren continues that trace rather than starting a new one. This means requests from an instrumented frontend or upstream service produce a single connected trace that includes Miren's processing.
+
+**Outbound:** When Miren forwards a request to your app, it injects a `traceparent` header. Your app can pick this up to create child spans that appear in the same trace as the Miren infrastructure spans.
+
+## Connecting Your App's Traces
+
+To participate in Miren's traces, configure your app with an OpenTelemetry SDK and point it at an OTLP-compatible backend. The SDK will automatically read the `traceparent` header from incoming requests and create child spans.
+
+Set these environment variables on your app:
+
+```toml
+[[env]]
+key = "OTEL_EXPORTER_OTLP_ENDPOINT"
+value = "https://your-otel-collector:4318"
+
+[[env]]
+key = "OTEL_EXPORTER_OTLP_HEADERS"
+value = "Authorization=Bearer your-api-key"
+
+[[env]]
+key = "OTEL_SERVICE_NAME"
+value = "my-app"
+```
+
+This works with any OTel-compatible backend: Grafana Tempo, Honeycomb, Datadog, Jaeger, and others.
+
+### Python Example
+
+Using the OpenTelemetry auto-instrumentation for Flask:
+
+```bash
+pip install opentelemetry-distro opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install
+```
+
+```toml
+[[env]]
+key = "OTEL_EXPORTER_OTLP_ENDPOINT"
+value = "https://your-otel-collector:4318"
+
+[[env]]
+key = "OTEL_SERVICE_NAME"
+value = "my-flask-app"
+```
+
+```text
+# Procfile
+web: opentelemetry-instrument flask run --host 0.0.0.0 --port 3000
+```
+
+The `opentelemetry-instrument` wrapper automatically reads the `traceparent` header from incoming requests and creates spans for your Flask routes.
+
+### Node.js Example
+
+Using the OpenTelemetry auto-instrumentation for Node.js:
+
+```bash
+npm install @opentelemetry/auto-instrumentations-node
+```
+
+```toml
+[[env]]
+key = "OTEL_EXPORTER_OTLP_ENDPOINT"
+value = "https://your-otel-collector:4318"
+
+[[env]]
+key = "OTEL_SERVICE_NAME"
+value = "my-node-app"
+
+[[env]]
+key = "NODE_OPTIONS"
+value = "--require @opentelemetry/auto-instrumentations-node/register"
+```
+
+The `--require` flag loads the auto-instrumentation before your app starts, automatically instrumenting HTTP, Express, and other common libraries.
+
+## What a Trace Looks Like
+
+A typical request trace shows the full path through Miren:
+
+```
+httpingress                          [350ms]
+├─ httpingress.lease                 [200ms]  (cold start)
+│  ├─ rpc.call.AcquireLease         [195ms]
+│  │  ├─ containerd...Images/Pull   [150ms]
+│  │  └─ containerd...Tasks/Create  [40ms]
+├─ [proxy to app]                   [150ms]
+│  └─ my-app: GET /api/users        [145ms]  (your app's span)
+```
+
+On a warm request where a sandbox is already running:
+
+```
+httpingress                          [15ms]
+├─ httpingress.lease                 [0.1ms]  (cached lease)
+├─ [proxy to app]                   [14ms]
+│  └─ my-app: GET /api/users        [12ms]
+```
+
+## Next Steps
+
+- [Services](/services) — Configure your app's services
+- [Application Scaling](/scaling) — Understand cold starts and autoscaling

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
         'route-oidc',
         'admin-interface',
         'working-with-miren-cloud',
+        'observability',
       ],
     },
     {

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	go.etcd.io/bbolt v1.3.11
 	go.etcd.io/etcd/api/v3 v3.5.21
 	go.etcd.io/etcd/client/v3 v3.5.21
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.14.0
@@ -114,6 +115,7 @@ require (
 	golang.org/x/time v0.14.0
 	golang.org/x/tools v0.37.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5
+	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.130.1
@@ -368,7 +370,6 @@ require (
 	go.mongodb.org/mongo-driver v1.13.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.56.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
@@ -383,7 +384,6 @@ require (
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6 // indirect
 	google.golang.org/api v0.254.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251022142026-3a174f9686a8 // indirect
-	google.golang.org/grpc v1.76.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/ns1/ns1-go.v2 v2.15.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -330,7 +330,10 @@ func (h *Server) handleRequest(w http.ResponseWriter, req *http.Request) {
 		}
 	}()
 
-	ctx, span := httpingressTracer.Start(req.Context(), "httpingress",
+	// Extract inbound trace context (traceparent/tracestate headers)
+	ctx := otel.GetTextMapPropagator().Extract(req.Context(), propagation.HeaderCarrier(req.Header))
+
+	ctx, span := httpingressTracer.Start(ctx, "httpingress",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
 			attribute.String("http.method", req.Method),


### PR DESCRIPTION
Phase 1 (#595) got OTLP export and httpingress spans flowing. This is the follow-up with three small pieces:

**Inbound propagation** — httpingress was ignoring `traceparent` headers from callers and always starting root spans. Now it extracts inbound trace context before creating the span, so external callers (or a user's instrumented frontend) get one connected trace through Miren. Same pattern we already use in the RPC server.

**Containerd gRPC instrumentation** — Added `otelgrpc` stats handler to the containerd client. Container operations like image pulls and task creation now show up as child spans, so you can see the full request→lease→containerd path in a single trace.

**Observability docs** — User-facing docs page explaining what Miren traces, how propagation works both directions, and how to connect your app's traces with auto-instrumentation examples for Python and Node.