### PR TITLE
Add OTel tracing to the deploy/build path

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -14,6 +14,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/util/progress/progresswriter"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/term"
 
 	"miren.dev/runtime/api/app/app_v1alpha"
@@ -25,11 +30,14 @@ import (
 	"miren.dev/runtime/pkg/deploygating"
 	"miren.dev/runtime/pkg/git"
 	"miren.dev/runtime/pkg/progress/upload"
+	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/standard"
 	"miren.dev/runtime/pkg/rpc/stream"
 	"miren.dev/runtime/pkg/tarx"
 	"miren.dev/runtime/pkg/ui"
 )
+
+var deployTracer = otel.Tracer("miren.dev/runtime/cli/deploy")
 
 func Deploy(ctx *Context, opts struct {
 	AppCentric
@@ -181,6 +189,32 @@ func Deploy(ctx *Context, opts struct {
 		return nil
 	}
 
+	// Set up OTel tracing if an OTLP endpoint is configured
+	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
+		shutdown, tracingErr := rpc.SetupTracing(ctx.Context, semconv.ServiceName("miren-cli"))
+		if tracingErr != nil {
+			ctx.Log.Debug("Failed to set up tracing", "error", tracingErr)
+		} else {
+			defer func() {
+				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = shutdown(shutdownCtx)
+			}()
+		}
+	}
+
+	// Start root deploy span
+	deployCtxTraced, deploySpan := deployTracer.Start(ctx.Context, "deploy",
+		trace.WithAttributes(
+			attribute.String("miren.app.name", name),
+			attribute.String("miren.cluster", ctx.ClusterName),
+		),
+	)
+	defer deploySpan.End()
+
+	// Replace the context so downstream calls inherit the trace
+	ctx.Context = deployCtxTraced
+
 	// Confirm deployment unless --force is used, stdin is not a TTY, or only one cluster is configured
 	hasSingleCluster := ctx.ClientConfig != nil && ctx.ClientConfig.GetClusterCount() == 1
 	if !opts.Force && isInteractive && !hasSingleCluster {
@@ -258,10 +292,15 @@ func Deploy(ctx *Context, opts struct {
 	}
 
 	// Create deployment as "in_progress" with a temporary app version
-	createResult, err := depClient.CreateDeployment(ctx, name, ctx.ClusterName, "pending-build", deploymentGitInfo)
+	createDepCtx, createDepSpan := deployTracer.Start(ctx.Context, "deploy.create_deployment")
+	createResult, err := depClient.CreateDeployment(createDepCtx, name, ctx.ClusterName, "pending-build", deploymentGitInfo)
 	if err != nil {
+		createDepSpan.RecordError(err)
+		createDepSpan.SetStatus(codes.Error, err.Error())
+		createDepSpan.End()
 		return fmt.Errorf("failed to create deployment record: %w", err)
 	}
+	createDepSpan.End()
 
 	if createResult.HasError() && createResult.Error() != "" {
 		// Check if we have structured lock info
@@ -410,8 +449,14 @@ func Deploy(ctx *Context, opts struct {
 	// Update phase to building
 	updateDeploymentPhase("building")
 
+	// Start upload span covering tar creation + BuildFromTar
+	_, uploadSpan := deployTracer.Start(buildCtx, "deploy.upload")
+
 	r, err := tarx.MakeTar(dir, includePatterns)
 	if err != nil {
+		uploadSpan.RecordError(err)
+		uploadSpan.SetStatus(codes.Error, err.Error())
+		uploadSpan.End()
 		updateDeploymentOnError(fmt.Sprintf("Failed to create tar: %v", err))
 		return err
 	}
@@ -478,6 +523,10 @@ func Deploy(ctx *Context, opts struct {
 
 		results, err = bc.BuildFromTar(buildCtx, name, stream.ServeReader(buildCtx, r), cb, envVars)
 		if err != nil {
+			uploadSpan.RecordError(err)
+			uploadSpan.SetStatus(codes.Error, err.Error())
+			uploadSpan.End()
+
 			// Check if this was a context cancellation
 			if buildCtx.Err() != nil {
 				ctx.Printf("\n\n❌ Deploy cancelled.\n")
@@ -508,6 +557,9 @@ func Deploy(ctx *Context, opts struct {
 		<-pw.Done()
 
 		if pw.Err() != nil {
+			uploadSpan.RecordError(pw.Err())
+			uploadSpan.SetStatus(codes.Error, pw.Err().Error())
+			uploadSpan.End()
 			return pw.Err()
 		}
 	} else {
@@ -589,6 +641,10 @@ func Deploy(ctx *Context, opts struct {
 		}
 
 		if err != nil {
+			uploadSpan.RecordError(err)
+			uploadSpan.SetStatus(codes.Error, err.Error())
+			uploadSpan.End()
+
 			// Check if this was a user interruption (via UI flag or context cancellation)
 			dm, isDeploy := finalModel.(*deployInfo)
 			if (isDeploy && dm.interrupted) || deployCtx.Err() != nil {
@@ -632,11 +688,18 @@ func Deploy(ctx *Context, opts struct {
 	}
 
 	if results.Version() == "" {
+		noVersionErr := fmt.Errorf("build failed: no version returned")
+		uploadSpan.RecordError(noVersionErr)
+		uploadSpan.SetStatus(codes.Error, noVersionErr.Error())
+		uploadSpan.End()
 		ctx.Printf("\n\nError detected in building %s. No version returned.\n", name)
 		printBuildErrors(ctx, buildErrors, buildLogs)
 		updateDeploymentOnError("Build failed: no version returned")
-		return fmt.Errorf("build failed: no version returned")
+		return noVersionErr
 	}
+
+	// Upload + build completed successfully
+	uploadSpan.End()
 
 	ctx.Log.Debug("Build completed", "version", results.Version())
 
@@ -664,12 +727,16 @@ func Deploy(ctx *Context, opts struct {
 	// Update phase to activating
 	updateDeploymentPhase("activating")
 
+	// Wrap finalization in a span
+	finalizeCtx, finalizeSpan := deployTracer.Start(ctx.Context, "deploy.finalize")
+
 	// Mark deployment as active
-	_, err = depClient.UpdateDeploymentStatus(ctx, deploymentId, "active", "")
+	_, err = depClient.UpdateDeploymentStatus(finalizeCtx, deploymentId, "active", "")
 	if err != nil {
 		// Log error but don't fail - deployment is already done
 		ctx.Log.Error("Failed to update deployment status", "error", err)
 	}
+	finalizeSpan.End()
 
 	ctx.Printf("\n\nUpdated version %s deployed. All traffic moved to new version.\n", results.Version())
 

--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	buildkitclient "github.com/moby/buildkit/client"
+	"go.opentelemetry.io/otel"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
@@ -263,7 +264,9 @@ func (c *Component) Client(ctx context.Context) (*buildkitclient.Client, error) 
 		return nil, fmt.Errorf("buildkit component not running")
 	}
 
-	return buildkitclient.New(ctx, "unix://"+socketPath)
+	return buildkitclient.New(ctx, "unix://"+socketPath,
+		buildkitclient.WithTracerProvider(otel.GetTracerProvider()),
+	)
 }
 
 func (c *Component) generateConfig(gcKeepStorage, gcKeepDuration int64, registryHost string) string {
@@ -343,6 +346,20 @@ func (c *Component) SetRegistryIP(ip string) error {
 }
 
 func (c *Component) createContainer(ctx context.Context, image containerd.Image, dataPath, configPath, hostsPath string) (containerd.Container, error) {
+	// Collect OTEL env vars to forward to buildkitd so the daemon can export its internal spans.
+	// The daemon shares host network namespace so the collector is reachable.
+	var otelEnv []string
+	for _, key := range []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_HEADERS",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+	} {
+		if v := os.Getenv(key); v != "" {
+			otelEnv = append(otelEnv, key+"="+v)
+		}
+	}
+
 	opts := []oci.SpecOpts{
 		oci.WithImageConfig(image),
 		oci.WithHostNamespace(specs.NetworkNamespace), // Required for DNS resolution
@@ -386,6 +403,10 @@ func (c *Component) createContainer(ctx context.Context, image containerd.Image,
 				Options:     []string{"rbind", "rw"},
 			},
 		}),
+	}
+
+	if len(otelEnv) > 0 {
+		opts = append(opts, oci.WithEnv(otelEnv))
 	}
 
 	container, err := c.CC.NewContainer(

--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -354,6 +354,7 @@ func (c *Component) createContainer(ctx context.Context, image containerd.Image,
 		"OTEL_EXPORTER_OTLP_HEADERS",
 		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
 		"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+		"OTEL_SERVICE_NAME",
 	} {
 		if v := os.Getenv(key); v != "" {
 			otelEnv = append(otelEnv, key+"="+v)

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 	"sync"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -19,6 +24,8 @@ import (
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/labs"
 )
+
+var launcherTracer = otel.Tracer("miren.dev/runtime/deployment/launcher")
 
 // Launcher watches App entities and proactively creates SandboxPools when ActiveVersion changes.
 // This enables immediate startup for fixed-mode services and pool reuse across deployments.
@@ -48,6 +55,10 @@ func (l *Launcher) Init(ctx context.Context) error {
 }
 
 func (l *Launcher) Reconcile(ctx context.Context, app *core_v1alpha.App, meta *entity.Meta) error {
+	ctx, span := launcherTracer.Start(ctx, "launcher.reconcile",
+		trace.WithAttributes(attribute.String("miren.app.id", app.ID.String())))
+	defer span.End()
+
 	// Serialize reconciles for the same app to avoid races between rapid deploys.
 	val, _ := l.appMu.LoadOrStore(app.ID, &sync.Mutex{})
 	mu := val.(*sync.Mutex)
@@ -64,6 +75,8 @@ func (l *Launcher) Reconcile(ctx context.Context, app *core_v1alpha.App, meta *e
 			l.Log.Debug("app not found in store, skipping", "app", app.ID)
 			return nil
 		}
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("failed to get app from store: %w", err)
 	}
 
@@ -75,8 +88,15 @@ func (l *Launcher) Reconcile(ctx context.Context, app *core_v1alpha.App, meta *e
 		return nil
 	}
 
+	span.SetAttributes(attribute.String("miren.app.active_version", current.ActiveVersion.String()))
+
 	l.Log.Info("reconciling app", "app", current.ID, "version", current.ActiveVersion)
-	return l.reconcileAppVersion(ctx, &current)
+	err = l.reconcileAppVersion(ctx, &current)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
 }
 
 // reconcileAppVersion ensures pools exist for all services in the active version

--- a/pkg/rpc/otel.go
+++ b/pkg/rpc/otel.go
@@ -89,7 +89,20 @@ func SetupTracing(ctx context.Context, attrs ...attribute.KeyValue) (shutdown fu
 		return nil, err
 	}
 
-	resAttrs := append([]attribute.KeyValue{semconv.ServiceName("miren")}, attrs...)
+	// Only add default service name if the caller hasn't provided one
+	hasServiceName := false
+	for _, a := range attrs {
+		if a.Key == semconv.ServiceNameKey {
+			hasServiceName = true
+			break
+		}
+	}
+	resAttrs := make([]attribute.KeyValue, 0, len(attrs)+1)
+	if !hasServiceName {
+		resAttrs = append(resAttrs, semconv.ServiceName("miren"))
+	}
+	resAttrs = append(resAttrs, attrs...)
+
 	res, err := sdkresource.New(ctx,
 		sdkresource.WithAttributes(resAttrs...),
 	)

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -14,6 +14,10 @@ import (
 
 	"github.com/moby/buildkit/client"
 	"github.com/tonistiigi/fsutil"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/build/build_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
@@ -33,6 +37,8 @@ import (
 	"miren.dev/runtime/pkg/stackbuild"
 	"miren.dev/runtime/pkg/tarx"
 )
+
+var buildTracer = otel.Tracer("miren.dev/runtime/build")
 
 // buildLogWriter writes build log entries to VictoriaLogs with version metadata
 type buildLogWriter struct {
@@ -619,18 +625,28 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 
 	b.Log.Debug("receiving tar data", "app", name, "tempdir", path)
 
+	// -- build.receive_tar span
+	ctx, recvSpan := buildTracer.Start(ctx, "build.receive_tar",
+		trace.WithAttributes(attribute.String("miren.app.name", name)))
 	r := stream.ToReader(ctx, td)
 
 	tr, err := tarx.TarFS(r, path)
 	if err != nil {
+		recvSpan.RecordError(err)
+		recvSpan.SetStatus(codes.Error, err.Error())
+		recvSpan.End()
 		b.sendErrorStatus(ctx, status, "Error untaring data: %v", err)
 		return fmt.Errorf("error untaring data: %w", err)
 	}
+	recvSpan.End()
 
 	if status != nil {
 		so.Update().SetMessage("Launching builder")
 		_, _ = status.Send(ctx, so)
 	}
+
+	// -- build.setup span: app config, stack detection, buildkit connect
+	ctx, setupSpan := buildTracer.Start(ctx, "build.setup")
 
 	ac, err := b.loadAppConfig(tr)
 	if err != nil {
@@ -678,6 +694,9 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		}
 		_, err := stackbuild.DetectStack(buildStack.CodeDir, detectOpts)
 		if err != nil {
+			setupSpan.RecordError(err)
+			setupSpan.SetStatus(codes.Error, err.Error())
+			setupSpan.End()
 			b.Log.Error("stack detection failed", "error", err, "app", name, "codeDir", buildStack.CodeDir)
 			b.sendErrorStatus(ctx, status, "No supported stack detected for app %s: %v", name, err)
 			return fmt.Errorf("no supported stack detected for app %s: %w", name, err)
@@ -689,6 +708,9 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	b.Log.Debug("setting up buildkit")
 
 	if b.BuildKit == nil {
+		setupSpan.RecordError(fmt.Errorf("buildkit component not configured"))
+		setupSpan.SetStatus(codes.Error, "buildkit component not configured")
+		setupSpan.End()
 		b.Log.Error("buildkit component not configured")
 		b.sendErrorStatus(ctx, status, "BuildKit not configured - ensure server is running with BuildKit enabled")
 		return fmt.Errorf("buildkit component not configured")
@@ -697,6 +719,9 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	b.Log.Info("connecting to buildkit daemon")
 	bkc, err := b.BuildKit.Client(ctx)
 	if err != nil {
+		setupSpan.RecordError(err)
+		setupSpan.SetStatus(codes.Error, err.Error())
+		setupSpan.End()
 		b.Log.Error("failed to get buildkit client", "error", err)
 		b.sendErrorStatus(ctx, status, "Failed to connect to BuildKit: %v", err)
 		return err
@@ -710,6 +735,9 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	} else {
 		b.Log.Debug("buildkitd info", "version", ci.BuildkitVersion.Version, "rev", ci.BuildkitVersion.Revision)
 	}
+
+	setupSpan.SetAttributes(attribute.String("miren.build.stack", buildStack.Stack))
+	setupSpan.End()
 
 	bk := &Buildkit{
 		Client: bkc,
@@ -826,12 +854,19 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 
 	imgName := mrv.ImageUrl
 
-	res, err := bk.BuildImage(ctx, tr, buildStack, name, imgName, tos...)
+	// -- build.buildkit span
+	bkCtx, bkSpan := buildTracer.Start(ctx, "build.buildkit",
+		trace.WithAttributes(attribute.String("miren.build.image", imgName)))
+	res, err := bk.BuildImage(bkCtx, tr, buildStack, name, imgName, tos...)
 	if err != nil {
+		bkSpan.RecordError(err)
+		bkSpan.SetStatus(codes.Error, err.Error())
+		bkSpan.End()
 		b.Log.Error("error building image", "error", err)
 		b.sendErrorStatus(ctx, status, "Error building image: %v", err)
 		return err
 	}
+	bkSpan.End()
 
 	// Log detection events from stack analysis
 	for _, event := range res.DetectionEvents {
@@ -844,13 +879,21 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		return fmt.Errorf("build did not return manifest digest")
 	}
 
+	// -- build.locate_artifact span
+	_, locateSpan := buildTracer.Start(ctx, "build.locate_artifact",
+		trace.WithAttributes(attribute.String("miren.build.manifest_digest", res.ManifestDigest)))
+
 	var artifact core_v1alpha.Artifact
 
 	err = b.ec.OneAtIndex(ctx, entity.String(core_v1alpha.ArtifactManifestDigestId, res.ManifestDigest), &artifact)
 	if err != nil {
+		locateSpan.RecordError(err)
+		locateSpan.SetStatus(codes.Error, err.Error())
+		locateSpan.End()
 		b.Log.Error("error locating artifact by digest", "digest", res.ManifestDigest, "error", err)
 		return fmt.Errorf("error locating artifact by digest %s: %w", res.ManifestDigest, err)
 	}
+	locateSpan.End()
 
 	b.Log.Debug("located stored artifact", "artifact", artifact.ID, "digest", res.ManifestDigest)
 
@@ -897,6 +940,10 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		b.Log.Debug("no new env vars from app config, preserving existing variables")
 	}
 
+	// -- build.create_version span
+	_, createVerSpan := buildTracer.Start(ctx, "build.create_version",
+		trace.WithAttributes(attribute.String("miren.app.version", mrv.Version)))
+
 	// Create ConfigVersion as the sole config store (inline Config is no longer written)
 	configVer := &core_v1alpha.ConfigVersion{
 		App:  mrv.App,
@@ -905,6 +952,9 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	cvName := mrv.Version + "-cfg"
 	cvid, err := b.ec.Create(ctx, cvName, configVer)
 	if err != nil {
+		createVerSpan.RecordError(err)
+		createVerSpan.SetStatus(codes.Error, err.Error())
+		createVerSpan.End()
 		return fmt.Errorf("error creating config version: %w", err)
 	}
 	mrv.ConfigVersion = cvid
@@ -912,14 +962,24 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 
 	id, err := b.ec.Create(ctx, mrv.Version, mrv)
 	if err != nil {
+		createVerSpan.RecordError(err)
+		createVerSpan.SetStatus(codes.Error, err.Error())
+		createVerSpan.End()
 		return fmt.Errorf("error creating app version: %w", err)
 	}
+	createVerSpan.End()
 
+	// -- build.activate span
+	_, activateSpan := buildTracer.Start(ctx, "build.activate")
 	b.Log.Info("updating app entity with new version", "app", name, "version", mrv.Version)
 	err = b.appClient.SetActiveVersion(ctx, name, string(id))
 	if err != nil {
+		activateSpan.RecordError(err)
+		activateSpan.SetStatus(codes.Error, err.Error())
+		activateSpan.End()
 		return fmt.Errorf("error updating app entity: %w", err)
 	}
+	activateSpan.End()
 
 	b.Log.Info("app version updated", "app", name, "version", mrv.Version)
 

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -880,12 +880,12 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 
 	// -- build.locate_artifact span
-	_, locateSpan := buildTracer.Start(ctx, "build.locate_artifact",
+	locateCtx, locateSpan := buildTracer.Start(ctx, "build.locate_artifact",
 		trace.WithAttributes(attribute.String("miren.build.manifest_digest", res.ManifestDigest)))
 
 	var artifact core_v1alpha.Artifact
 
-	err = b.ec.OneAtIndex(ctx, entity.String(core_v1alpha.ArtifactManifestDigestId, res.ManifestDigest), &artifact)
+	err = b.ec.OneAtIndex(locateCtx, entity.String(core_v1alpha.ArtifactManifestDigestId, res.ManifestDigest), &artifact)
 	if err != nil {
 		locateSpan.RecordError(err)
 		locateSpan.SetStatus(codes.Error, err.Error())
@@ -941,7 +941,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 
 	// -- build.create_version span
-	_, createVerSpan := buildTracer.Start(ctx, "build.create_version",
+	createVerCtx, createVerSpan := buildTracer.Start(ctx, "build.create_version",
 		trace.WithAttributes(attribute.String("miren.app.version", mrv.Version)))
 
 	// Create ConfigVersion as the sole config store (inline Config is no longer written)
@@ -950,7 +950,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		Spec: configSpec,
 	}
 	cvName := mrv.Version + "-cfg"
-	cvid, err := b.ec.Create(ctx, cvName, configVer)
+	cvid, err := b.ec.Create(createVerCtx, cvName, configVer)
 	if err != nil {
 		createVerSpan.RecordError(err)
 		createVerSpan.SetStatus(codes.Error, err.Error())
@@ -960,7 +960,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	mrv.ConfigVersion = cvid
 	mrv.Config = core_v1alpha.Config{}
 
-	id, err := b.ec.Create(ctx, mrv.Version, mrv)
+	id, err := b.ec.Create(createVerCtx, mrv.Version, mrv)
 	if err != nil {
 		createVerSpan.RecordError(err)
 		createVerSpan.SetStatus(codes.Error, err.Error())
@@ -970,9 +970,9 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	createVerSpan.End()
 
 	// -- build.activate span
-	_, activateSpan := buildTracer.Start(ctx, "build.activate")
+	activateCtx, activateSpan := buildTracer.Start(ctx, "build.activate")
 	b.Log.Info("updating app entity with new version", "app", name, "version", mrv.Version)
-	err = b.appClient.SetActiveVersion(ctx, name, string(id))
+	err = b.appClient.SetActiveVersion(activateCtx, name, string(id))
 	if err != nil {
 		activateSpan.RecordError(err)
 		activateSpan.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
Building on the OTel infrastructure work, this lights up tracing for
the deploy path. With a collector running, `miren deploy` produces a
nice end-to-end trace showing how time breaks down across CLI, RPC,
server-side build phases, and BuildKit internals.

The CLI acts as the trace root and sets up tracing when
`OTEL_EXPORTER_OTLP_ENDPOINT` is set. The RPC framework propagates
context to the server automatically from there. On the server side,
`BuildFromTar` gets spans for each phase: tar receive, setup/stack
detection, buildkit build, artifact lookup, version creation, and
activation.

BuildKit gets two layers of tracing — the client gets the global
TracerProvider for gRPC spans, and the daemon container gets OTEL env
vars forwarded so it can export its own internal per-step spans
(dockerfile parse, layer pulls, RUN steps, etc).

The launcher controller gets standalone `launcher.reconcile` spans with
app/version attributes. These aren't connected to the deploy trace yet
(would need a data model change to thread context through), but the
attributes make correlation easy enough for now.

Everything is a no-op when `OTEL_EXPORTER_OTLP_ENDPOINT` isn't set.