### PR TITLE
Add automatic reindexing system for schema changes

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -700,6 +700,11 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		c.Log.Info("entity migration completed", "migrated", migrated, "skipped", skipped)
 	}
 
+	// Check if indexes have changed and reindex if needed
+	if err := c.checkAndReindex(ctx, etcdStore, client); err != nil {
+		c.Log.Error("automatic reindex failed (will retry next startup)", "error", err)
+	}
+
 	ess, err := entityserver.NewEntityServer(c.Log, etcdStore)
 	if err != nil {
 		c.Log.Error("failed to create entity server", "error", err)
@@ -1042,4 +1047,52 @@ func (c *Coordinator) CertificateProvider() autotls.CertificateProvider {
 		return nil
 	}
 	return c.certController
+}
+
+// checkAndReindex compares the current index hash against the stored hash in etcd.
+// If they differ, it runs a reindex to rebuild missing collection entries.
+func (c *Coordinator) checkAndReindex(ctx context.Context, store *entity.EtcdStore, client *clientv3.Client) error {
+	currentHash := schema.IndexHash()
+	hashKey := c.Prefix + "/meta/index-hash"
+
+	resp, err := client.Get(ctx, hashKey)
+	if err != nil {
+		return fmt.Errorf("failed to read index hash: %w", err)
+	}
+
+	var storedHash string
+	if len(resp.Kvs) > 0 {
+		storedHash = string(resp.Kvs[0].Value)
+	}
+
+	if storedHash == currentHash {
+		c.Log.Debug("index hash unchanged, skipping reindex", "hash", currentHash)
+		return nil
+	}
+
+	c.Log.Info("index schema changed, starting automatic reindex",
+		"stored_hash", storedHash,
+		"current_hash", currentHash)
+
+	reindexCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	stats, err := store.Reindex(reindexCtx, c.Log, entity.ReindexOptions{
+		DryRun:       false,
+		CleanupStale: false,
+	})
+	if err != nil {
+		return fmt.Errorf("reindex failed: %w", err)
+	}
+
+	c.Log.Info("automatic reindex complete",
+		"entities_processed", stats.EntitiesProcessed,
+		"indexes_rebuilt", stats.IndexesRebuilt)
+
+	_, err = client.Put(ctx, hashKey, currentHash)
+	if err != nil {
+		return fmt.Errorf("failed to store index hash: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/entity/reindex.go
+++ b/pkg/entity/reindex.go
@@ -1,0 +1,193 @@
+package entity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/mr-tron/base58"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"miren.dev/runtime/pkg/cond"
+)
+
+// ReindexStats holds statistics about a reindex operation.
+type ReindexStats struct {
+	EntitiesProcessed        int64
+	IndexesRebuilt           int64
+	CollectionEntriesScanned int64
+	StaleEntriesFound        int64
+	StaleEntriesRemoved      int64
+}
+
+// ReindexOptions controls the behavior of a reindex operation.
+type ReindexOptions struct {
+	DryRun       bool
+	CleanupStale bool
+}
+
+// Reindex rebuilds all index (collection) entries for every entity in the store.
+// If opts.CleanupStale is true, it also scans for and removes stale collection entries
+// that point to non-existent entities.
+func (s *EtcdStore) Reindex(ctx context.Context, log *slog.Logger, opts ReindexOptions) (*ReindexStats, error) {
+	s.ClearSchemaCache()
+
+	stats := &ReindexStats{}
+
+	// Phase 1: List all entities and rebuild indexes
+	allEntityIDs, err := s.ListAllEntityIDs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list entities: %w", err)
+	}
+
+	log.Info("reindex: found entities", "count", len(allEntityIDs))
+
+	validEntityIDs := make(map[Id]bool, len(allEntityIDs))
+	for _, id := range allEntityIDs {
+		validEntityIDs[id] = true
+	}
+
+	log.Info("reindex: rebuilding indexes for current entities")
+	for i, id := range allEntityIDs {
+		select {
+		case <-ctx.Done():
+			return stats, ctx.Err()
+		default:
+		}
+
+		ent, err := s.GetEntity(ctx, id)
+		if err != nil {
+			if errors.Is(err, cond.ErrNotFound{}) {
+				delete(validEntityIDs, id)
+				continue
+			}
+			log.Warn("reindex: failed to get entity", "id", id, "error", err)
+			continue
+		}
+
+		if !opts.DryRun {
+			indexedAttrs := collectIndexedAttributesTolerant(ctx, s, ent.Attrs())
+			for _, attrs := range indexedAttrs {
+				for _, attr := range attrs {
+					err := s.addToCollectionDirect(ctx, ent, attr.CAS())
+					if err != nil {
+						log.Warn("reindex: failed to add to collection", "id", id, "attr", attr.ID, "error", err)
+					} else {
+						stats.IndexesRebuilt++
+					}
+				}
+			}
+		}
+
+		stats.EntitiesProcessed++
+
+		if (i+1)%100 == 0 {
+			log.Info("reindex: progress",
+				"processed", stats.EntitiesProcessed,
+				"total", len(allEntityIDs),
+				"percent", (i+1)*100/len(allEntityIDs))
+		}
+	}
+
+	// Phase 2: Clean up stale index entries (optional)
+	if opts.CleanupStale {
+		log.Info("reindex: cleaning up stale index entries")
+		collectionPrefix := s.prefix + "/collections/"
+
+		resp, err := s.client.Get(ctx, collectionPrefix, clientv3.WithPrefix())
+		if err != nil {
+			log.Warn("reindex: failed to list collection entries", "error", err)
+		} else {
+			stats.CollectionEntriesScanned = int64(len(resp.Kvs))
+
+			var staleKeys []string
+			for _, kv := range resp.Kvs {
+				select {
+				case <-ctx.Done():
+					return stats, ctx.Err()
+				default:
+				}
+
+				entityID := Id(kv.Value)
+				if !validEntityIDs[entityID] {
+					if _, err := s.GetEntity(ctx, entityID); err != nil {
+						if errors.Is(err, cond.ErrNotFound{}) {
+							staleKeys = append(staleKeys, string(kv.Key))
+						} else {
+							log.Warn("reindex: could not verify entity existence",
+								"entity_id", entityID,
+								"key", string(kv.Key),
+								"error", err)
+						}
+					}
+				}
+			}
+
+			stats.StaleEntriesFound = int64(len(staleKeys))
+
+			if !opts.DryRun && len(staleKeys) > 0 {
+				log.Info("reindex: removing stale entries", "count", len(staleKeys))
+				for i := 0; i < len(staleKeys); i += 100 {
+					end := i + 100
+					if end > len(staleKeys) {
+						end = len(staleKeys)
+					}
+					batch := staleKeys[i:end]
+
+					var ops []clientv3.Op
+					for _, key := range batch {
+						ops = append(ops, clientv3.OpDelete(key))
+					}
+
+					if len(ops) > 0 {
+						_, err := s.client.Txn(ctx).Then(ops...).Commit()
+						if err != nil {
+							log.Warn("reindex: failed to delete stale entries", "error", err)
+						} else {
+							stats.StaleEntriesRemoved += int64(len(ops))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	log.Info("reindex: complete",
+		"entities_processed", stats.EntitiesProcessed,
+		"indexes_rebuilt", stats.IndexesRebuilt,
+		"collection_entries_scanned", stats.CollectionEntriesScanned,
+		"stale_entries_found", stats.StaleEntriesFound,
+		"stale_entries_removed", stats.StaleEntriesRemoved)
+
+	return stats, nil
+}
+
+// collectIndexedAttributesTolerant is like EtcdStore.collectIndexedAttributes but
+// skips attributes whose schema cannot be looked up, rather than returning an error.
+// This is appropriate for reindex where some attribute schemas may be missing.
+func collectIndexedAttributesTolerant(ctx context.Context, store Store, attrs []Attr) map[Id][]Attr {
+	indexedAttrs := make(map[Id][]Attr)
+	allAttrs := enumerateAllAttrs(attrs)
+	for _, attr := range allAttrs {
+		schema, err := store.GetAttributeSchema(ctx, attr.ID)
+		if err != nil {
+			continue
+		}
+		if schema.Index {
+			indexedAttrs[attr.ID] = append(indexedAttrs[attr.ID], attr)
+		}
+	}
+	return indexedAttrs
+}
+
+// addToCollectionDirect writes a single collection entry for the given entity and collection key.
+func (s *EtcdStore) addToCollectionDirect(ctx context.Context, ent *Entity, collection string) error {
+	key := base58.Encode([]byte(ent.Id()))
+	colKey := strings.NewReplacer("/", "_", ":", "_").Replace(collection)
+
+	key = fmt.Sprintf("%s/collections/%s/%s", s.prefix, colKey, key)
+
+	_, err := s.client.Put(ctx, key, ent.Id().String())
+	return err
+}

--- a/pkg/entity/reindex.go
+++ b/pkg/entity/reindex.go
@@ -181,10 +181,12 @@ func collectIndexedAttributesTolerant(ctx context.Context, store Store, attrs []
 	return indexedAttrs
 }
 
+var colReplacer = strings.NewReplacer("/", "_", ":", "_")
+
 // addToCollectionDirect writes a single collection entry for the given entity and collection key.
 func (s *EtcdStore) addToCollectionDirect(ctx context.Context, ent *Entity, collection string) error {
 	key := base58.Encode([]byte(ent.Id()))
-	colKey := strings.NewReplacer("/", "_", ":", "_").Replace(collection)
+	colKey := colReplacer.Replace(collection)
 
 	key = fmt.Sprintf("%s/collections/%s/%s", s.prefix, colKey, key)
 

--- a/pkg/entity/reindex_test.go
+++ b/pkg/entity/reindex_test.go
@@ -1,0 +1,226 @@
+package entity
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func setupReindexTestStore(t *testing.T) (*EtcdStore, *clientv3.Client) {
+	t.Helper()
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:       []string{"etcd:2379"},
+		DialTimeout:     2 * time.Second,
+		MaxUnaryRetries: 2,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = client.Delete(ctx, "/test-reindex/", clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		client.Close()
+	})
+
+	store, err := NewEtcdStore(ctx, slog.Default(), client, "/test-reindex")
+	require.NoError(t, err)
+
+	return store, client
+}
+
+func TestReindex_BasicIndexing(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	// Create an indexed attribute schema
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	// Create entities with the indexed attribute
+	e1, err := store.CreateEntity(ctx, New(
+		Ident, "entity-1",
+		String(Id("test/kind"), "widget"),
+	))
+	require.NoError(t, err)
+
+	e2, err := store.CreateEntity(ctx, New(
+		Ident, "entity-2",
+		String(Id("test/kind"), "widget"),
+	))
+	require.NoError(t, err)
+
+	// Verify indexes exist via ListIndex
+	ids, err := store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	assert.Len(t, ids, 2)
+
+	// Now manually delete the collection entries to simulate missing indexes
+	collectionPrefix := store.Prefix() + "/collections/"
+	_, err = client.Delete(ctx, collectionPrefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	// Verify indexes are now gone
+	ids, err = store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	assert.Len(t, ids, 0)
+
+	// Run reindex
+	stats, err := store.Reindex(ctx, slog.Default(), ReindexOptions{
+		DryRun:       false,
+		CleanupStale: false,
+	})
+	require.NoError(t, err)
+	assert.Greater(t, stats.EntitiesProcessed, int64(0))
+	assert.Greater(t, stats.IndexesRebuilt, int64(0))
+
+	// Verify indexes are back
+	ids, err = store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	assert.Len(t, ids, 2)
+
+	foundIDs := map[Id]bool{ids[0]: true, ids[1]: true}
+	assert.True(t, foundIDs[e1.Id()])
+	assert.True(t, foundIDs[e2.Id()])
+}
+
+func TestReindex_Idempotent(t *testing.T) {
+	store, _ := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	// Create an indexed attribute schema
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	// Create entities
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "entity-1",
+		String(Id("test/kind"), "widget"),
+	))
+	require.NoError(t, err)
+
+	// Run reindex twice
+	stats1, err := store.Reindex(ctx, slog.Default(), ReindexOptions{
+		DryRun:       false,
+		CleanupStale: false,
+	})
+	require.NoError(t, err)
+
+	stats2, err := store.Reindex(ctx, slog.Default(), ReindexOptions{
+		DryRun:       false,
+		CleanupStale: false,
+	})
+	require.NoError(t, err)
+
+	// Same entities processed both times
+	assert.Equal(t, stats1.EntitiesProcessed, stats2.EntitiesProcessed)
+
+	// Verify indexes still work correctly
+	ids, err := store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	assert.Len(t, ids, 1)
+}
+
+func TestReindex_StaleCleanup(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	// Create an indexed attribute schema
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	// Create an entity
+	e1, err := store.CreateEntity(ctx, New(
+		Ident, "entity-1",
+		String(Id("test/kind"), "widget"),
+	))
+	require.NoError(t, err)
+
+	// Manually insert a stale collection entry pointing to a non-existent entity
+	fakeEntityID := Id("fake/nonexistent")
+	fakeKey := base58.Encode([]byte(fakeEntityID))
+	staleKey := store.Prefix() + "/collections/test_kind_widget/" + fakeKey
+	_, err = client.Put(ctx, staleKey, string(fakeEntityID))
+	require.NoError(t, err)
+
+	// Run reindex with stale cleanup
+	stats, err := store.Reindex(ctx, slog.Default(), ReindexOptions{
+		DryRun:       false,
+		CleanupStale: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.StaleEntriesFound)
+	assert.Equal(t, int64(1), stats.StaleEntriesRemoved)
+
+	// Verify only the real entity is in the index
+	ids, err := store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	assert.Len(t, ids, 1)
+	assert.Equal(t, e1.Id(), ids[0])
+}
+
+func TestReindex_DryRun(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	// Create an indexed attribute schema
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	// Create entities
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "entity-1",
+		String(Id("test/kind"), "widget"),
+	))
+	require.NoError(t, err)
+
+	// Delete all collection entries
+	collectionPrefix := store.Prefix() + "/collections/"
+	_, err = client.Delete(ctx, collectionPrefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	// Run dry-run reindex
+	stats, err := store.Reindex(ctx, slog.Default(), ReindexOptions{
+		DryRun:       true,
+		CleanupStale: false,
+	})
+	require.NoError(t, err)
+	assert.Greater(t, stats.EntitiesProcessed, int64(0))
+	assert.Equal(t, int64(0), stats.IndexesRebuilt) // No writes in dry-run
+
+	// Verify indexes are still missing (dry-run didn't write)
+	ids, err := store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	assert.Len(t, ids, 0)
+}

--- a/pkg/entity/schema/schema.go
+++ b/pkg/entity/schema/schema.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"sort"
 
+	"github.com/mr-tron/base58"
+	"golang.org/x/crypto/blake2b"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
 )
@@ -288,4 +291,43 @@ func (s *SchemaBuilder) Singleton(id string, opts ...AttrOption) entity.Id {
 
 func (b *SchemaBuilder) Builder(name string) *SchemaBuilder {
 	return Builder(b.domain+"."+name, b.version)
+}
+
+// IndexedAttributeIDs returns a sorted list of all attribute IDs that are marked
+// as indexed in the in-memory schema registry. This inspects the attribute entities
+// registered via Builder/Register, not etcd.
+func IndexedAttributeIDs() []entity.Id {
+	var ids []entity.Id
+
+	for _, sb := range defaultRegistry.schemas {
+		for eid, ent := range sb.attrs {
+			for _, attr := range ent.Attrs() {
+				if attr.ID == entity.Index && attr.Value.Kind() == entity.KindBool && attr.Value.Bool() {
+					ids = append(ids, eid)
+					break
+				}
+			}
+		}
+	}
+
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i] < ids[j]
+	})
+
+	return ids
+}
+
+// IndexHash computes a deterministic blake2b-256 hash of all indexed attribute IDs
+// from the in-memory schema registry, encoded as base58. The hash changes when
+// indexes are added or removed, enabling detection of schema changes at startup.
+func IndexHash() string {
+	ids := IndexedAttributeIDs()
+
+	h, _ := blake2b.New256(nil)
+	for _, id := range ids {
+		h.Write([]byte(id))
+		h.Write([]byte{0}) // separator
+	}
+
+	return base58.Encode(h.Sum(nil))
 }

--- a/pkg/entity/schema/schema_test.go
+++ b/pkg/entity/schema/schema_test.go
@@ -1,0 +1,75 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/entity"
+)
+
+func init() {
+	// Register a test schema with indexed attributes for testing
+	sb := &SchemaBuilder{
+		domain: "test-index-hash",
+		attrs:  make(map[entity.Id]*entity.Entity),
+	}
+
+	// Add an indexed attribute
+	sb.attrs[entity.Id("test-index-hash/name")] = entity.New(
+		entity.Ident, "test-index-hash/name",
+		entity.Type, entity.TypeStr,
+		entity.Cardinality, entity.CardinalityOne,
+		entity.Index, true,
+	)
+
+	// Add a non-indexed attribute
+	sb.attrs[entity.Id("test-index-hash/doc")] = entity.New(
+		entity.Ident, "test-index-hash/doc",
+		entity.Type, entity.TypeStr,
+		entity.Cardinality, entity.CardinalityOne,
+	)
+
+	// Add another indexed attribute
+	sb.attrs[entity.Id("test-index-hash/kind")] = entity.New(
+		entity.Ident, "test-index-hash/kind",
+		entity.Type, entity.TypeRef,
+		entity.Cardinality, entity.CardinalityOne,
+		entity.Index, true,
+	)
+
+	defaultRegistry.schemas["test-index-hash"] = sb
+}
+
+func TestIndexedAttributeIDs(t *testing.T) {
+	ids := IndexedAttributeIDs()
+
+	require.Greater(t, len(ids), 0, "should have at least one indexed attribute")
+
+	// Verify the list is sorted
+	for i := 1; i < len(ids); i++ {
+		assert.True(t, ids[i-1] < ids[i], "IDs should be sorted: %s >= %s", ids[i-1], ids[i])
+	}
+
+	// Verify no duplicates
+	seen := make(map[string]bool)
+	for _, id := range ids {
+		assert.False(t, seen[string(id)], "duplicate indexed attribute ID: %s", id)
+		seen[string(id)] = true
+	}
+
+	// Verify our test indexed attributes are present
+	assert.True(t, seen["test-index-hash/name"], "test-index-hash/name should be indexed")
+	assert.True(t, seen["test-index-hash/kind"], "test-index-hash/kind should be indexed")
+
+	// Verify non-indexed attribute is NOT present
+	assert.False(t, seen["test-index-hash/doc"], "test-index-hash/doc should not be indexed")
+}
+
+func TestIndexHash_Deterministic(t *testing.T) {
+	hash1 := IndexHash()
+	hash2 := IndexHash()
+
+	require.NotEmpty(t, hash1, "hash should not be empty")
+	assert.Equal(t, hash1, hash2, "hash should be deterministic across calls")
+}

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -1124,6 +1124,15 @@ func (s *EtcdStore) DeleteEntity(ctx context.Context, id Id) error {
 	return nil
 }
 
+// ClearSchemaCache clears the in-memory schema cache, forcing subsequent
+// GetAttributeSchema calls to re-read from etcd. This is used before reindexing
+// to ensure fresh schema definitions are used.
+func (s *EtcdStore) ClearSchemaCache() {
+	s.mu.Lock()
+	s.schemaCache = make(map[Id]*AttributeSchema)
+	s.mu.Unlock()
+}
+
 // GetAttributeSchema implements Store interface
 func (s *EtcdStore) GetAttributeSchema(ctx context.Context, id Id) (*AttributeSchema, error) {
 	// Check the cache first

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -875,180 +875,18 @@ func (e *EntityServer) Reindex(ctx context.Context, req *entityserver_v1alpha.En
 
 	e.Log.Info("starting entity reindex", "dry_run", dryRun)
 
-	var stats struct {
-		entitiesProcessed        int64
-		indexesRebuilt           int64
-		collectionEntriesScanned int64
-		staleEntriesFound        int64
-		staleEntriesRemoved      int64
-	}
-
 	store, ok := e.Store.(*entity.EtcdStore)
 	if !ok {
 		return fmt.Errorf("reindex requires EtcdStore")
 	}
 
-	// Step 1: List all entities
-	allEntityIDs, err := store.ListAllEntityIDs(ctx)
+	stats, err := store.Reindex(ctx, e.Log, entity.ReindexOptions{
+		DryRun:       dryRun,
+		CleanupStale: true,
+	})
 	if err != nil {
-		return fmt.Errorf("failed to list entities: %w", err)
+		return err
 	}
-
-	e.Log.Info("found entities", "count", len(allEntityIDs))
-
-	// Create a set of valid entity IDs for fast lookup
-	validEntityIDs := make(map[entity.Id]bool, len(allEntityIDs))
-	for _, id := range allEntityIDs {
-		validEntityIDs[id] = true
-	}
-
-	// Step 2: Rebuild indexes for all existing entities
-	// This overwrites correct entries and ensures all current entities are indexed
-	e.Log.Info("rebuilding indexes for current entities")
-	for i, id := range allEntityIDs {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		ent, err := e.Store.GetEntity(ctx, id)
-		if err != nil {
-			if errors.Is(err, cond.ErrNotFound{}) {
-				delete(validEntityIDs, id)
-				continue
-			}
-			e.Log.Warn("failed to get entity", "id", id, "error", err)
-			continue
-		}
-
-		if !dryRun {
-			// Collect indexed attributes (including nested ones)
-			indexedAttrs, err := collectIndexedAttributes(ctx, e.Store, ent.Attrs())
-			if err != nil {
-				e.Log.Warn("failed to collect indexed attrs", "id", id, "error", err)
-				continue
-			}
-
-			// Rebuild index entries for all indexed attributes
-			for _, attrs := range indexedAttrs {
-				for _, attr := range attrs {
-					err := addToCollection(ctx, store, ent, attr.CAS())
-					if err != nil {
-						e.Log.Warn("failed to add to collection", "id", id, "attr", attr.ID, "error", err)
-					} else {
-						stats.indexesRebuilt++
-					}
-				}
-			}
-		}
-
-		stats.entitiesProcessed++
-
-		// Log progress every 100 entities
-		if (i+1)%100 == 0 {
-			e.Log.Info("reindex progress",
-				"processed", stats.entitiesProcessed,
-				"total", len(allEntityIDs),
-				"percent", (i+1)*100/len(allEntityIDs))
-		}
-	}
-
-	// Step 3: Clean up stale index entries
-	// Iterate through all collection entries and remove those pointing to non-existent entities
-	e.Log.Info("cleaning up stale index entries")
-	collectionPrefix := store.Prefix() + "/collections/"
-	client := store.Client()
-
-	// Get all collection entries with their values
-	resp, err := client.Get(ctx, collectionPrefix, clientv3.WithPrefix())
-	if err != nil {
-		e.Log.Warn("failed to list collection entries", "error", err)
-	} else {
-		stats.collectionEntriesScanned = int64(len(resp.Kvs))
-
-		var staleKeys []string
-		staleEntries := make(map[entity.Id][]string) // Track which collections have stale entries per entity
-		for _, kv := range resp.Kvs {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-			}
-
-			// Collection entry value contains the entity ID
-			entityID := entity.Id(kv.Value)
-			if !validEntityIDs[entityID] {
-				// Re-check entity existence to handle entities created during reindex
-				// (race condition: entity created after Phase 1 but before Phase 2)
-				if _, err := e.Store.GetEntity(ctx, entityID); err != nil {
-					if errors.Is(err, cond.ErrNotFound{}) {
-						// Entity truly doesn't exist - this is a stale entry
-						key := string(kv.Key)
-						staleKeys = append(staleKeys, key)
-						staleEntries[entityID] = append(staleEntries[entityID], key)
-					} else {
-						// Unexpected error - log and skip this entry to be safe
-						e.Log.Warn("could not verify entity existence; skipping collection entry",
-							"entity_id", entityID,
-							"key", string(kv.Key),
-							"error", err)
-					}
-				}
-				// else: entity exists (created during reindex), skip - not stale
-			}
-		}
-
-		stats.staleEntriesFound = int64(len(staleKeys))
-
-		// Log details about stale entries for debugging
-		if len(staleEntries) > 0 {
-			e.Log.Info("found stale index entries details")
-			for entityID, keys := range staleEntries {
-				sampleKeys := keys
-				if len(keys) > 3 {
-					sampleKeys = keys[:3]
-				}
-				e.Log.Warn("stale index entries for deleted entity",
-					"entity_id", entityID,
-					"count", len(keys),
-					"sample_keys", sampleKeys)
-			}
-		}
-
-		// Delete stale entries in batches (only if not dry run)
-		if !dryRun && len(staleKeys) > 0 {
-			e.Log.Info("removing stale entries", "count", len(staleKeys))
-			for i := 0; i < len(staleKeys); i += 100 {
-				end := i + 100
-				if end > len(staleKeys) {
-					end = len(staleKeys)
-				}
-				batch := staleKeys[i:end]
-
-				var ops []clientv3.Op
-				for _, key := range batch {
-					ops = append(ops, clientv3.OpDelete(key))
-				}
-
-				if len(ops) > 0 {
-					_, err := client.Txn(ctx).Then(ops...).Commit()
-					if err != nil {
-						e.Log.Warn("failed to delete stale entries", "error", err)
-					} else {
-						stats.staleEntriesRemoved += int64(len(ops))
-					}
-				}
-			}
-		}
-	}
-
-	e.Log.Info("reindex complete",
-		"entities_processed", stats.entitiesProcessed,
-		"indexes_rebuilt", stats.indexesRebuilt,
-		"collection_entries_scanned", stats.collectionEntriesScanned,
-		"stale_entries_found", stats.staleEntriesFound,
-		"stale_entries_removed", stats.staleEntriesRemoved)
 
 	// Build response stats list
 	results := req.Results()
@@ -1057,11 +895,11 @@ func (e *EntityServer) Reindex(ctx context.Context, req *entityserver_v1alpha.En
 		name  string
 		value int64
 	}{
-		{"entities_processed", stats.entitiesProcessed},
-		{"indexes_rebuilt", stats.indexesRebuilt},
-		{"collection_entries_scanned", stats.collectionEntriesScanned},
-		{"stale_entries_found", stats.staleEntriesFound},
-		{"stale_entries_removed", stats.staleEntriesRemoved},
+		{"entities_processed", stats.EntitiesProcessed},
+		{"indexes_rebuilt", stats.IndexesRebuilt},
+		{"collection_entries_scanned", stats.CollectionEntriesScanned},
+		{"stale_entries_found", stats.StaleEntriesFound},
+		{"stale_entries_removed", stats.StaleEntriesRemoved},
 	}
 
 	var rpcStats []*entityserver_v1alpha.ReindexStat
@@ -1106,47 +944,4 @@ func (e *EntityServer) GetAttributesByTag(ctx context.Context, req *entityserver
 	results.SetSchemas(rpcSchemas)
 
 	return nil
-}
-
-func collectIndexedAttributes(ctx context.Context, store entity.Store, attrs []entity.Attr) (map[entity.Id][]entity.Attr, error) {
-	indexedAttrs := make(map[entity.Id][]entity.Attr)
-	allAttrs := enumerateAllAttrs(attrs)
-	for _, attr := range allAttrs {
-		schema, err := store.GetAttributeSchema(ctx, attr.ID)
-		if err != nil {
-			// Skip attributes with missing/invalid schemas during reindex
-			continue
-		}
-		if schema.Index {
-			indexedAttrs[attr.ID] = append(indexedAttrs[attr.ID], attr)
-		}
-	}
-	return indexedAttrs, nil
-}
-
-func enumerateAllAttrs(attrs []entity.Attr) []entity.Attr {
-	var result []entity.Attr
-	for _, attr := range attrs {
-		result = append(result, attr)
-
-		if attr.Value.Kind() == entity.KindComponent {
-			comp := attr.Value.Component()
-			if comp != nil {
-				nestedAttrs := comp.Attrs()
-				result = append(result, enumerateAllAttrs(nestedAttrs)...)
-			}
-		}
-	}
-	return result
-}
-
-func addToCollection(ctx context.Context, store *entity.EtcdStore, ent *entity.Entity, collection string) error {
-	key := base58.Encode([]byte(ent.Id()))
-	colKey := strings.NewReplacer("/", "_", ":", "_").Replace(collection)
-
-	key = fmt.Sprintf("%s/collections/%s/%s", store.Prefix(), colKey, key)
-
-	client := store.Client()
-	_, err := client.Put(ctx, key, ent.Id().String())
-	return err
 }


### PR DESCRIPTION
## Summary

- Automatically detects when indexed attributes are added/removed from schemas and rebuilds missing index entries at startup, eliminating the need to manually run `m debug reindex`
- Extracts reindex logic from the entityserver RPC into a shared `EtcdStore.Reindex()` method, removing ~200 lines of duplicated code
- Computes a deterministic blake2b-256 hash of all indexed attribute IDs from the schema registry, stored in etcd at `{prefix}/meta/index-hash` to detect changes across restarts

## Test plan

- [x] `hack/it ./pkg/entity/schema/...` — schema hash tests (2/2 pass)
- [x] `hack/it ./pkg/entity/...` — entity + reindex tests (234/234 pass)
- [x] `hack/it ./servers/entityserver/...` — RPC reindex still works (19/19 pass)
- [x] `make lint` — 0 issues
- [ ] Manual: `make dev`, verify server starts, check logs for reindex hash comparison