### PR TITLE
Fix lsvd_volume entities using wrong entity ID format

### DIFF
--- a/controllers/disk/disk_controller.go
+++ b/controllers/disk/disk_controller.go
@@ -222,7 +222,7 @@ func (d *DiskController) handleProvisioning(ctx context.Context, disk *storage_v
 	// Build entity with id and encoded attributes
 	volumeId := idgen.GenNS("lsvd-vol")
 	createAttrs := entity.New(
-		entity.DBId, entity.Id(storage_v1alpha.KindLsvdVolume.String()+"/"+volumeId),
+		entity.DBId, entity.Id("lsvd_volume/"+volumeId),
 		lsvdVolume.Encode,
 	).Attrs()
 

--- a/controllers/integration/harness.go
+++ b/controllers/integration/harness.go
@@ -174,9 +174,9 @@ func (h *TestHarness) controllerForEntity(id entity.Id) *controller.ReconcileCon
 		return h.DiskLeaseRC
 	case hasPrefix(s, "disk/"):
 		return h.DiskRC
-	case hasPrefix(s, "lsvd_volume/"), hasPrefix(s, "dev.miren.storage/kind.lsvd_volume/"):
+	case hasPrefix(s, "lsvd_volume/"):
 		return h.LsvdVolRC
-	case hasPrefix(s, "lsvd_mount/"), hasPrefix(s, "dev.miren.storage/kind.lsvd_mount/"):
+	case hasPrefix(s, "lsvd_mount/"):
 		return h.LsvdMntRC
 	default:
 		return nil

--- a/controllers/integration/reconcile_system_test.go
+++ b/controllers/integration/reconcile_system_test.go
@@ -24,7 +24,7 @@ func TestReconcileWithSystemSkipsUnmountingMounts(t *testing.T) {
 	h := NewTestHarness(t)
 
 	// Set up volume state in LSVD state so reconnectNBD can find the volume
-	volumeEntityId := "dev.miren.storage/kind.lsvd_volume/test-vol-1"
+	volumeEntityId := "lsvd_volume/test-vol-1"
 	h.LsvdState.SetVolume(volumeEntityId, &lsvdserver.VolumeState{
 		EntityId:   volumeEntityId,
 		VolumeId:   "cloud-vol-1",
@@ -90,7 +90,7 @@ func TestReconcileWithSystemReconnectsWantedMounts(t *testing.T) {
 
 	h := NewTestHarness(t)
 
-	volumeEntityId := "dev.miren.storage/kind.lsvd_volume/test-vol-2"
+	volumeEntityId := "lsvd_volume/test-vol-2"
 	h.LsvdState.SetVolume(volumeEntityId, &lsvdserver.VolumeState{
 		EntityId:   volumeEntityId,
 		VolumeId:   "cloud-vol-2",
@@ -150,7 +150,7 @@ func TestReconcileWithSystemSkipsDeletedMountEntity(t *testing.T) {
 
 	h := NewTestHarness(t)
 
-	volumeEntityId := "dev.miren.storage/kind.lsvd_volume/test-vol-3"
+	volumeEntityId := "lsvd_volume/test-vol-3"
 	h.LsvdState.SetVolume(volumeEntityId, &lsvdserver.VolumeState{
 		EntityId:   volumeEntityId,
 		VolumeId:   "cloud-vol-3",


### PR DESCRIPTION
## Summary
- Fixed volume entity ID creation in `disk_controller.go` which used `KindLsvdVolume.String()` as the ID prefix, producing IDs like `dev.miren.storage/kind.lsvd_volume/lsvd-vol-xxx` instead of the correct `lsvd_volume/lsvd-vol-xxx`
- Updated test volume entity IDs in `reconcile_system_test.go` to use the correct format
- Cleaned up stale old-format fallbacks in the integration test harness

## Test plan
- [x] `hack/it ./controllers/disk/...` — 44 tests pass
- [x] `hack/it ./controllers/integration/...` — 29 tests pass
- [x] `hack/it ./components/lsvd/server/...` — 114 tests pass

Closes MIR-706