### PR TITLE
Add CLI tracing proxy exporter

### DIFF
--- a/api/telemetry/rpc.yml
+++ b/api/telemetry/rpc.yml
@@ -1,0 +1,10 @@
+apiVersion: miren.dev/rpc/v1
+kind: IDL
+
+interfaces:
+  - name: Telemetry
+    methods:
+      - name: reportSpans
+        parameters:
+          - name: span_data
+            type: bytes

--- a/api/telemetry/telemetry.go
+++ b/api/telemetry/telemetry.go
@@ -1,0 +1,3 @@
+package telemetry
+
+//go:generate go run ../../pkg/rpc/cmd/rpcgen -pkg telemetry_v1alpha -input rpc.yml -output telemetry_v1alpha/rpc.gen.go

--- a/api/telemetry/telemetry_v1alpha/rpc.gen.go
+++ b/api/telemetry/telemetry_v1alpha/rpc.gen.go
@@ -1,0 +1,157 @@
+package telemetry_v1alpha
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/fxamacker/cbor/v2"
+	rpc "miren.dev/runtime/pkg/rpc"
+)
+
+type telemetryReportSpansArgsData struct {
+	SpanData *[]byte `cbor:"0,keyasint,omitempty" json:"span_data,omitempty"`
+}
+
+type TelemetryReportSpansArgs struct {
+	call rpc.Call
+	data telemetryReportSpansArgsData
+}
+
+func (v *TelemetryReportSpansArgs) HasSpanData() bool {
+	return v.data.SpanData != nil
+}
+
+func (v *TelemetryReportSpansArgs) SpanData() []byte {
+	if v.data.SpanData == nil {
+		return nil
+	}
+	return *v.data.SpanData
+}
+
+func (v *TelemetryReportSpansArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *TelemetryReportSpansArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *TelemetryReportSpansArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *TelemetryReportSpansArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type telemetryReportSpansResultsData struct{}
+
+type TelemetryReportSpansResults struct {
+	call rpc.Call
+	data telemetryReportSpansResultsData
+}
+
+func (v *TelemetryReportSpansResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *TelemetryReportSpansResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *TelemetryReportSpansResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *TelemetryReportSpansResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type TelemetryReportSpans struct {
+	rpc.Call
+	args    TelemetryReportSpansArgs
+	results TelemetryReportSpansResults
+}
+
+func (t *TelemetryReportSpans) Args() *TelemetryReportSpansArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *TelemetryReportSpans) Results() *TelemetryReportSpansResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type Telemetry interface {
+	ReportSpans(ctx context.Context, state *TelemetryReportSpans) error
+}
+
+type reexportTelemetry struct {
+	client rpc.Client
+}
+
+func (reexportTelemetry) ReportSpans(ctx context.Context, state *TelemetryReportSpans) error {
+	panic("not implemented")
+}
+
+func (t reexportTelemetry) CapabilityClient() rpc.Client {
+	return t.client
+}
+
+func AdaptTelemetry(t Telemetry) *rpc.Interface {
+	methods := []rpc.Method{
+		{
+			Name:          "reportSpans",
+			InterfaceName: "Telemetry",
+			Index:         0,
+			Public:        false,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ReportSpans(ctx, &TelemetryReportSpans{Call: call})
+			},
+		},
+	}
+
+	return rpc.NewInterface(methods, t)
+}
+
+type TelemetryClient struct {
+	rpc.Client
+}
+
+func NewTelemetryClient(client rpc.Client) *TelemetryClient {
+	return &TelemetryClient{Client: client}
+}
+
+func (c TelemetryClient) Export() Telemetry {
+	return reexportTelemetry{client: c.Client}
+}
+
+type TelemetryClientReportSpansResults struct {
+	client rpc.Client
+	data   telemetryReportSpansResultsData
+}
+
+func (v TelemetryClient) ReportSpans(ctx context.Context, span_data []byte) (*TelemetryClientReportSpansResults, error) {
+	args := TelemetryReportSpansArgs{}
+	args.data.SpanData = &span_data
+
+	var ret telemetryReportSpansResultsData
+
+	err := v.Call(ctx, "reportSpans", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TelemetryClientReportSpansResults{client: v.Client, data: ret}, nil
+}

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -29,8 +29,8 @@ import (
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/deploygating"
 	"miren.dev/runtime/pkg/git"
+	"miren.dev/runtime/pkg/otelproxy"
 	"miren.dev/runtime/pkg/progress/upload"
-	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/standard"
 	"miren.dev/runtime/pkg/rpc/stream"
 	"miren.dev/runtime/pkg/tarx"
@@ -189,11 +189,13 @@ func Deploy(ctx *Context, opts struct {
 		return nil
 	}
 
-	// Set up OTel tracing if an OTLP endpoint is configured
-	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
-		shutdown, tracingErr := rpc.SetupTracing(ctx.Context, semconv.ServiceName("miren-cli"))
-		if tracingErr != nil {
-			ctx.Log.Debug("Failed to set up tracing", "error", tracingErr)
+	// Set up OTel tracing via the server's telemetry proxy.
+	// Spans are shipped through the existing RPC connection — no client-side
+	// OTLP config needed. If the server isn't reachable, tracing is a no-op.
+	if proxyClient, err := ctx.RPCClient("dev.miren.runtime/telemetry"); err == nil {
+		shutdown, setupErr := otelproxy.SetupProxyTracing(ctx.Context, proxyClient, ctx.Log, semconv.ServiceName("miren-cli"))
+		if setupErr != nil {
+			ctx.Log.Debug("failed to set up proxy tracing", "error", setupErr)
 		} else {
 			defer func() {
 				shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -201,6 +203,8 @@ func Deploy(ctx *Context, opts struct {
 				_ = shutdown(shutdownCtx)
 			}()
 		}
+	} else {
+		ctx.Log.Debug("telemetry proxy unavailable", "error", err)
 	}
 
 	// Start root deploy span

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -30,6 +30,7 @@ import (
 	"miren.dev/runtime/api/exec/exec_v1alpha"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/api/runner/runner_v1alpha"
+	"miren.dev/runtime/api/telemetry/telemetry_v1alpha"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/components/activator"
 	"miren.dev/runtime/components/autotls"
@@ -60,6 +61,7 @@ import (
 	"miren.dev/runtime/servers/httpingress"
 	"miren.dev/runtime/servers/logs"
 	runnerserver "miren.dev/runtime/servers/runner"
+	telemetrysrv "miren.dev/runtime/servers/telemetry"
 	"miren.dev/runtime/version"
 )
 
@@ -881,6 +883,9 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	runnerReg := runnerserver.NewRegistrationServer(c.Log, c.authority, eac, c.Address, c.EtcdEndpoints, c.Prefix, c.NetworkBackend)
 	server.ExposeValue(rpc.ServiceRunner, runner_v1alpha.AdaptRunnerRegistration(runnerReg))
+
+	ts := telemetrysrv.NewServer(c.Log)
+	server.ExposeValue("dev.miren.runtime/telemetry", telemetry_v1alpha.AdaptTelemetry(ts))
 
 	c.Log.Info("started RPC server")
 

--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.21
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
 	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.14.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.33.0
@@ -103,6 +104,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.14.0
 	go.opentelemetry.io/otel/sdk/metric v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
+	go.opentelemetry.io/proto/otlp v1.7.1
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba
 	golang.org/x/crypto v0.43.0
 	golang.org/x/exp v0.0.0-20241210194714-1829a127f884
@@ -372,9 +374,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.56.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/pkg/otelproxy/proxy.go
+++ b/pkg/otelproxy/proxy.go
@@ -1,0 +1,98 @@
+package otelproxy
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/propagation"
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+
+	"miren.dev/runtime/api/telemetry/telemetry_v1alpha"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+// proxyClient implements otlptrace.Client by forwarding serialized spans
+// over the RPC telemetry service. Errors are swallowed (logged at debug)
+// so that the batcher never blocks the calling command.
+type proxyClient struct {
+	tc  *telemetry_v1alpha.TelemetryClient
+	log *slog.Logger
+}
+
+var _ otlptrace.Client = (*proxyClient)(nil)
+
+func (p *proxyClient) Start(context.Context) error { return nil }
+func (p *proxyClient) Stop(context.Context) error  { return nil }
+
+func (p *proxyClient) UploadTraces(ctx context.Context, protoSpans []*tracepb.ResourceSpans) error {
+	req := &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: protoSpans,
+	}
+
+	data, err := proto.Marshal(req)
+	if err != nil {
+		p.log.Debug("failed to marshal trace export request", "error", err)
+		return nil
+	}
+
+	_, err = p.tc.ReportSpans(ctx, data)
+	if err != nil {
+		p.log.Debug("failed to send spans via proxy", "error", err)
+	}
+	return nil
+}
+
+// SetupProxyTracing configures OpenTelemetry tracing that ships spans through
+// the server's RPC telemetry service. This allows CLI commands to export traces
+// without needing OTEL_EXPORTER_OTLP_ENDPOINT set locally.
+func SetupProxyTracing(ctx context.Context, rpcClient *rpc.NetworkClient, log *slog.Logger, attrs ...attribute.KeyValue) (shutdown func(context.Context) error, err error) {
+	tc := telemetry_v1alpha.NewTelemetryClient(rpcClient)
+
+	pc := &proxyClient{tc: tc, log: log}
+	exporter, err := otlptrace.New(ctx, pc)
+	if err != nil {
+		return nil, err
+	}
+
+	hasServiceName := false
+	for _, a := range attrs {
+		if a.Key == semconv.ServiceNameKey {
+			hasServiceName = true
+			break
+		}
+	}
+	resAttrs := make([]attribute.KeyValue, 0, len(attrs)+1)
+	if !hasServiceName {
+		resAttrs = append(resAttrs, semconv.ServiceName("miren-cli"))
+	}
+	resAttrs = append(resAttrs, attrs...)
+
+	res, err := sdkresource.New(ctx,
+		sdkresource.WithAttributes(resAttrs...),
+	)
+	if err != nil {
+		_ = exporter.Shutdown(ctx)
+		return nil, err
+	}
+
+	tp := trace.NewTracerProvider(
+		trace.WithBatcher(exporter),
+		trace.WithResource(res),
+	)
+
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return tp.Shutdown, nil
+}

--- a/servers/telemetry/server.go
+++ b/servers/telemetry/server.go
@@ -1,0 +1,95 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/telemetry/telemetry_v1alpha"
+)
+
+type Server struct {
+	log      *slog.Logger
+	endpoint string
+	headers  map[string]string
+	client   *http.Client
+}
+
+var _ telemetry_v1alpha.Telemetry = (*Server)(nil)
+
+func NewServer(log *slog.Logger) *Server {
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+	var headers map[string]string
+	if h := os.Getenv("OTEL_EXPORTER_OTLP_HEADERS"); h != "" {
+		headers = parseOTLPHeaders(h)
+	}
+
+	if endpoint != "" {
+		log.Info("telemetry proxy enabled", "endpoint", endpoint)
+	}
+
+	return &Server{
+		log:      log.With("module", "telemetry"),
+		endpoint: endpoint,
+		headers:  headers,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (s *Server) ReportSpans(ctx context.Context, state *telemetry_v1alpha.TelemetryReportSpans) error {
+	if s.endpoint == "" {
+		return nil
+	}
+
+	args := state.Args()
+	data := args.SpanData()
+	if len(data) == 0 {
+		return nil
+	}
+
+	url := strings.TrimRight(s.endpoint, "/") + "/v1/traces"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		s.log.Warn("failed to create OTLP request", "error", err)
+		return nil
+	}
+
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	for k, v := range s.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.log.Warn("failed to forward spans to collector", "error", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		s.log.Warn("collector returned error", "status", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// parseOTLPHeaders parses the OTEL_EXPORTER_OTLP_HEADERS env var format:
+// key1=value1,key2=value2
+func parseOTLPHeaders(raw string) map[string]string {
+	headers := make(map[string]string)
+	for _, pair := range strings.Split(raw, ",") {
+		k, v, ok := strings.Cut(strings.TrimSpace(pair), "=")
+		if ok {
+			headers[strings.TrimSpace(k)] = strings.TrimSpace(v)
+		}
+	}
+	return headers
+}


### PR DESCRIPTION
## Summary

- CLI deploy spans now ship through the server's existing RPC connection automatically — no `OTEL_EXPORTER_OTLP_ENDPOINT` needed on the client side
- New `Telemetry.reportSpans(bytes)` RPC endpoint receives serialized OTLP protobuf and forwards it to the server's configured collector
- Server silently drops spans when no collector is configured; RPC errors are swallowed so tracing never blocks deploys

## Design

Three layers, all simple:

| Layer | File(s) | What it does |
|-------|---------|-------------|
| Proxy client | `pkg/otelproxy/proxy.go` | Implements `otlptrace.Client`, marshals spans to protobuf, sends via RPC |
| RPC endpoint | `api/telemetry/` + `servers/telemetry/server.go` | Receives bytes, HTTP POSTs to `{OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces` |
| CLI integration | `cli/commands/deploy.go` | Connects to telemetry service, sets up proxy tracing. Falls back to no-op if server unreachable |

The proxy client lives in `pkg/otelproxy/` (not `pkg/rpc/`) to avoid an import cycle through the generated telemetry RPC code.

## Test plan

- [x] `go generate ./api/telemetry/...` succeeds
- [x] `make bin/miren` builds clean
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (3287 tests, 20 pre-existing skips)
- [ ] Manual: start dev server with `OTEL_EXPORTER_OTLP_ENDPOINT` pointed at a collector, run `m deploy` without any env vars on the CLI side, verify deploy+build spans appear in the collector