### PR TITLE
Rename network Service entity to Target

### DIFF
--- a/api/network/migrate.go
+++ b/api/network/migrate.go
@@ -1,0 +1,141 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/network/network_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// Old attribute IDs that no longer exist as constants after the rename.
+const (
+	oldKindService       = entity.Id("dev.miren.network/kind.service")
+	oldServiceIp         = entity.Id("dev.miren.network/service.ip")
+	oldServiceMatch      = entity.Id("dev.miren.network/service.match")
+	oldServicePort       = entity.Id("dev.miren.network/service.port")
+	oldEndpointsService  = entity.Id("dev.miren.network/endpoints.service")
+	oldServicePortPrefix = "dev.miren.network/service.port"
+)
+
+// MigrateServiceToTarget renames stored Service entities to Target entities
+// and updates Endpoints references from service to target.
+func MigrateServiceToTarget(ctx context.Context, log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) error {
+	log.Info("migrating network service entities to target")
+
+	if err := migrateServiceEntities(ctx, log, eac); err != nil {
+		return fmt.Errorf("failed to migrate service entities: %w", err)
+	}
+
+	if err := migrateEndpointsEntities(ctx, log, eac); err != nil {
+		return fmt.Errorf("failed to migrate endpoints entities: %w", err)
+	}
+
+	return nil
+}
+
+func migrateServiceEntities(ctx context.Context, log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) error {
+	resp, err := eac.List(ctx, entity.Ref(entity.EntityKind, oldKindService))
+	if err != nil {
+		return fmt.Errorf("failed to list service entities: %w", err)
+	}
+
+	migratedCount := 0
+
+	for _, e := range resp.Values() {
+		oldAttrs := e.Entity().Attrs()
+		newAttrs := make([]entity.Attr, 0, len(oldAttrs))
+
+		for _, attr := range oldAttrs {
+			switch attr.ID {
+			case entity.EntityKind:
+				// Change kind ref from service to target
+				if attr.Value.Id() == oldKindService {
+					newAttrs = append(newAttrs, entity.Ref(entity.EntityKind, network_v1alpha.KindTarget))
+				} else {
+					newAttrs = append(newAttrs, attr)
+				}
+			case oldServiceIp:
+				attr.ID = network_v1alpha.TargetIpId
+				newAttrs = append(newAttrs, attr)
+			case oldServiceMatch:
+				attr.ID = network_v1alpha.TargetMatchId
+				newAttrs = append(newAttrs, attr)
+			case oldServicePort:
+				attr.ID = network_v1alpha.TargetPortId
+				newAttrs = append(newAttrs, attr)
+			default:
+				// Rename sub-component builder paths: service.port.* → target.port.*
+				if strings.HasPrefix(string(attr.ID), oldServicePortPrefix) {
+					newID := "dev.miren.network/target.port" + strings.TrimPrefix(string(attr.ID), oldServicePortPrefix)
+					attr.ID = entity.Id(newID)
+				}
+				newAttrs = append(newAttrs, attr)
+			}
+		}
+
+		// Use Replace to do a full entity replacement. Put uses UpdateEntity
+		// which merges by attribute ID, leaving old renamed IDs in place.
+		if _, err := eac.Replace(ctx, newAttrs, e.Revision()); err != nil {
+			log.Error("failed to migrate service entity to target", "error", err, "id", e.Id())
+			continue
+		}
+
+		migratedCount++
+	}
+
+	if migratedCount > 0 {
+		log.Info("migrated service entities to target", "count", migratedCount)
+	}
+
+	return nil
+}
+
+func migrateEndpointsEntities(ctx context.Context, log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) error {
+	resp, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints))
+	if err != nil {
+		return fmt.Errorf("failed to list endpoints entities: %w", err)
+	}
+
+	migratedCount := 0
+
+	for _, e := range resp.Values() {
+		oldAttrs := e.Entity().Attrs()
+		needsMigration := false
+
+		for _, attr := range oldAttrs {
+			if attr.ID == oldEndpointsService {
+				needsMigration = true
+				break
+			}
+		}
+
+		if !needsMigration {
+			continue
+		}
+
+		newAttrs := make([]entity.Attr, 0, len(oldAttrs))
+		for _, attr := range oldAttrs {
+			if attr.ID == oldEndpointsService {
+				attr.ID = network_v1alpha.EndpointsTargetId
+			}
+			newAttrs = append(newAttrs, attr)
+		}
+
+		if _, err := eac.Replace(ctx, newAttrs, e.Revision()); err != nil {
+			log.Error("failed to migrate endpoints entity", "error", err, "id", e.Id())
+			continue
+		}
+
+		migratedCount++
+	}
+
+	if migratedCount > 0 {
+		log.Info("migrated endpoints entities (service → target)", "count", migratedCount)
+	}
+
+	return nil
+}

--- a/api/network/migrate_test.go
+++ b/api/network/migrate_test.go
@@ -1,0 +1,195 @@
+package network
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/network/network_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+func TestMigrateServiceToTarget(t *testing.T) {
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+	eac := server.EAC
+
+	// Create a service entity with old-style attribute IDs directly in the store
+	svcID := entity.Id("target/test-svc-1")
+	svcEnt := entity.New(
+		entity.DBId, svcID,
+		entity.Ref(entity.EntityKind, oldKindService),
+		entity.String(oldServiceIp, "10.10.0.5"),
+		entity.String(oldServiceMatch, "app=web"),
+	)
+	server.AddEntity(svcEnt)
+
+	// Create an endpoints entity with old endpoints.service ref
+	epID := entity.Id("endpoints/test-ep-1")
+	epEnt := entity.New(
+		entity.DBId, epID,
+		entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints),
+		entity.Ref(oldEndpointsService, svcID),
+	)
+	server.AddEntity(epEnt)
+
+	// Run migration
+	err := MigrateServiceToTarget(ctx, log, eac)
+	require.NoError(t, err)
+
+	// Verify service entity was migrated to target
+	svcRes, err := eac.Get(ctx, string(svcID))
+	require.NoError(t, err)
+
+	migratedSvc := svcRes.Entity().Entity()
+
+	// EntityKind should now be KindTarget
+	kindAttr, ok := migratedSvc.Get(entity.EntityKind)
+	require.True(t, ok, "migrated entity should have EntityKind")
+	assert.Equal(t, network_v1alpha.KindTarget, kindAttr.Value.Id())
+
+	// IP should use target.ip ID
+	ipAttr, ok := migratedSvc.Get(network_v1alpha.TargetIpId)
+	require.True(t, ok, "migrated entity should have target.ip attr")
+	assert.Equal(t, "10.10.0.5", ipAttr.Value.String())
+
+	// Match should use target.match ID
+	matchAttr, ok := migratedSvc.Get(network_v1alpha.TargetMatchId)
+	require.True(t, ok, "migrated entity should have target.match attr")
+	assert.Equal(t, "app=web", matchAttr.Value.String())
+
+	// Old IDs should no longer be present
+	_, ok = migratedSvc.Get(oldServiceIp)
+	assert.False(t, ok, "old service.ip should not exist")
+	_, ok = migratedSvc.Get(oldServiceMatch)
+	assert.False(t, ok, "old service.match should not exist")
+
+	// Verify endpoints entity was migrated
+	epRes, err := eac.Get(ctx, string(epID))
+	require.NoError(t, err)
+
+	migratedEp := epRes.Entity().Entity()
+
+	// Should now have endpoints.target
+	targetRef, ok := migratedEp.Get(network_v1alpha.EndpointsTargetId)
+	require.True(t, ok, "migrated endpoints should have endpoints.target attr")
+	assert.Equal(t, svcID, targetRef.Value.Id())
+
+	// Old endpoints.service should not exist
+	_, ok = migratedEp.Get(oldEndpointsService)
+	assert.False(t, ok, "old endpoints.service should not exist")
+}
+
+func TestMigrateServiceToTarget_WithPort(t *testing.T) {
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+	eac := server.EAC
+
+	// Create a service entity with a port component using old attribute IDs.
+	// Ports are stored as component attrs whose children use port.* IDs.
+	svcID := entity.Id("target/test-svc-port")
+	portAttrs := []entity.Attr{
+		entity.String(network_v1alpha.PortNameId, "http"),
+		entity.Int64(network_v1alpha.PortPortId, 80),
+	}
+	svcEnt := entity.New(
+		entity.DBId, svcID,
+		entity.Ref(entity.EntityKind, oldKindService),
+		entity.String(oldServiceIp, "10.10.0.10"),
+		entity.Component(oldServicePort, portAttrs),
+	)
+	server.AddEntity(svcEnt)
+
+	err := MigrateServiceToTarget(ctx, log, eac)
+	require.NoError(t, err)
+
+	svcRes, err := eac.Get(ctx, string(svcID))
+	require.NoError(t, err)
+
+	migrated := svcRes.Entity().Entity()
+
+	// Decode as a Target and verify the port is fully populated
+	var target network_v1alpha.Target
+	target.Decode(migrated)
+
+	require.Len(t, target.Port, 1, "migrated target should have one port")
+	assert.Equal(t, "http", target.Port[0].Name)
+	assert.Equal(t, int64(80), target.Port[0].Port)
+
+	// Old service.port ID should not exist
+	_, ok := migrated.Get(oldServicePort)
+	assert.False(t, ok, "old service.port should not exist")
+}
+
+func TestMigrateServiceToTarget_AlreadyMigrated(t *testing.T) {
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+	eac := server.EAC
+
+	// Create an entity that already uses the new target IDs
+	targetID := entity.Id("target/already-migrated")
+	targetEnt := entity.New(
+		entity.DBId, targetID,
+		entity.Ref(entity.EntityKind, network_v1alpha.KindTarget),
+		entity.String(network_v1alpha.TargetIpId, "10.10.0.20"),
+	)
+	server.AddEntity(targetEnt)
+
+	// Create an endpoints entity already using endpoints.target
+	epID := entity.Id("endpoints/already-migrated")
+	epEnt := entity.New(
+		entity.DBId, epID,
+		entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints),
+		entity.Ref(network_v1alpha.EndpointsTargetId, targetID),
+	)
+	server.AddEntity(epEnt)
+
+	// Running migration should succeed without changing anything
+	err := MigrateServiceToTarget(ctx, log, eac)
+	require.NoError(t, err)
+
+	// Verify target entity is unchanged
+	res, err := eac.Get(ctx, string(targetID))
+	require.NoError(t, err)
+
+	ent := res.Entity().Entity()
+	ipAttr, ok := ent.Get(network_v1alpha.TargetIpId)
+	require.True(t, ok)
+	assert.Equal(t, "10.10.0.20", ipAttr.Value.String())
+
+	// Verify endpoints entity is unchanged
+	epRes, err := eac.Get(ctx, string(epID))
+	require.NoError(t, err)
+
+	epEnt2 := epRes.Entity().Entity()
+	ref, ok := epEnt2.Get(network_v1alpha.EndpointsTargetId)
+	require.True(t, ok)
+	assert.Equal(t, targetID, ref.Value.Id())
+
+	// Old attr should not appear
+	_, ok = epEnt2.Get(oldEndpointsService)
+	assert.False(t, ok)
+}
+
+func TestMigrateServiceToTarget_NoEntities(t *testing.T) {
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	// Running migration with no entities should succeed
+	err := MigrateServiceToTarget(ctx, log, server.EAC)
+	require.NoError(t, err)
+}

--- a/api/network/network_v1alpha/schema.gen.go
+++ b/api/network/network_v1alpha/schema.gen.go
@@ -8,13 +8,13 @@ import (
 
 const (
 	EndpointsEndpointId = entity.Id("dev.miren.network/endpoints.endpoint")
-	EndpointsServiceId  = entity.Id("dev.miren.network/endpoints.service")
+	EndpointsTargetId   = entity.Id("dev.miren.network/endpoints.target")
 )
 
 type Endpoints struct {
 	ID       entity.Id  `json:"id"`
 	Endpoint []Endpoint `cbor:"endpoint,omitempty" json:"endpoint,omitempty"`
-	Service  entity.Id  `cbor:"service,omitempty" json:"service,omitempty"`
+	Target   entity.Id  `cbor:"target,omitempty" json:"target,omitempty"`
 }
 
 func (o *Endpoints) Decode(e entity.AttrGetter) {
@@ -26,8 +26,8 @@ func (o *Endpoints) Decode(e entity.AttrGetter) {
 			o.Endpoint = append(o.Endpoint, v)
 		}
 	}
-	if a, ok := e.Get(EndpointsServiceId); ok && a.Value.Kind() == entity.KindId {
-		o.Service = a.Value.Id()
+	if a, ok := e.Get(EndpointsTargetId); ok && a.Value.Kind() == entity.KindId {
+		o.Target = a.Value.Id()
 	}
 }
 
@@ -51,8 +51,8 @@ func (o *Endpoints) Encode() (attrs []entity.Attr) {
 	for _, v := range o.Endpoint {
 		attrs = append(attrs, entity.Component(EndpointsEndpointId, v.Encode()))
 	}
-	if !entity.Empty(o.Service) {
-		attrs = append(attrs, entity.Ref(EndpointsServiceId, o.Service))
+	if !entity.Empty(o.Target) {
+		attrs = append(attrs, entity.Ref(EndpointsTargetId, o.Target))
 	}
 	attrs = append(attrs, entity.Ref(entity.EntityKind, KindEndpoints))
 	return
@@ -62,7 +62,7 @@ func (o *Endpoints) Empty() bool {
 	if len(o.Endpoint) != 0 {
 		return false
 	}
-	if !entity.Empty(o.Service) {
+	if !entity.Empty(o.Target) {
 		return false
 	}
 	return true
@@ -71,7 +71,7 @@ func (o *Endpoints) Empty() bool {
 func (o *Endpoints) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Component("endpoint", "dev.miren.network/endpoints.endpoint", schema.Doc("The endpoint configuration, per endpoint"), schema.Many)
 	(&Endpoint{}).InitSchema(sb.Builder("endpoints.endpoint"))
-	sb.Ref("service", "dev.miren.network/endpoints.service", schema.Doc("The service that uses these endpoints"), schema.Indexed)
+	sb.Ref("target", "dev.miren.network/endpoints.target", schema.Doc("The target that uses these endpoints"), schema.Indexed)
 }
 
 const (
@@ -119,31 +119,31 @@ func (o *Endpoint) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 const (
-	ServiceIpId    = entity.Id("dev.miren.network/service.ip")
-	ServiceMatchId = entity.Id("dev.miren.network/service.match")
-	ServicePortId  = entity.Id("dev.miren.network/service.port")
+	TargetIpId    = entity.Id("dev.miren.network/target.ip")
+	TargetMatchId = entity.Id("dev.miren.network/target.match")
+	TargetPortId  = entity.Id("dev.miren.network/target.port")
 )
 
-type Service struct {
+type Target struct {
 	ID    entity.Id    `json:"id"`
 	Ip    []string     `cbor:"ip,omitempty" json:"ip,omitempty"`
 	Match types.Labels `cbor:"match,omitempty" json:"match,omitempty"`
 	Port  []Port       `cbor:"port,omitempty" json:"port,omitempty"`
 }
 
-func (o *Service) Decode(e entity.AttrGetter) {
+func (o *Target) Decode(e entity.AttrGetter) {
 	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
-	for _, a := range e.GetAll(ServiceIpId) {
+	for _, a := range e.GetAll(TargetIpId) {
 		if a.Value.Kind() == entity.KindString {
 			o.Ip = append(o.Ip, a.Value.String())
 		}
 	}
-	for _, a := range e.GetAll(ServiceMatchId) {
+	for _, a := range e.GetAll(TargetMatchId) {
 		if a.Value.Kind() == entity.KindLabel {
 			o.Match = append(o.Match, a.Value.Label())
 		}
 	}
-	for _, a := range e.GetAll(ServicePortId) {
+	for _, a := range e.GetAll(TargetPortId) {
 		if a.Value.Kind() == entity.KindComponent {
 			var v Port
 			v.Decode(a.Value.Component())
@@ -152,37 +152,37 @@ func (o *Service) Decode(e entity.AttrGetter) {
 	}
 }
 
-func (o *Service) Is(e entity.AttrGetter) bool {
-	return entity.Is(e, KindService)
+func (o *Target) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindTarget)
 }
 
-func (o *Service) ShortKind() string {
-	return "service"
+func (o *Target) ShortKind() string {
+	return "target"
 }
 
-func (o *Service) Kind() entity.Id {
-	return KindService
+func (o *Target) Kind() entity.Id {
+	return KindTarget
 }
 
-func (o *Service) EntityId() entity.Id {
+func (o *Target) EntityId() entity.Id {
 	return o.ID
 }
 
-func (o *Service) Encode() (attrs []entity.Attr) {
+func (o *Target) Encode() (attrs []entity.Attr) {
 	for _, v := range o.Ip {
-		attrs = append(attrs, entity.String(ServiceIpId, v))
+		attrs = append(attrs, entity.String(TargetIpId, v))
 	}
 	for _, v := range o.Match {
-		attrs = append(attrs, entity.Label(ServiceMatchId, v.Key, v.Value))
+		attrs = append(attrs, entity.Label(TargetMatchId, v.Key, v.Value))
 	}
 	for _, v := range o.Port {
-		attrs = append(attrs, entity.Component(ServicePortId, v.Encode()))
+		attrs = append(attrs, entity.Component(TargetPortId, v.Encode()))
 	}
-	attrs = append(attrs, entity.Ref(entity.EntityKind, KindService))
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindTarget))
 	return
 }
 
-func (o *Service) Empty() bool {
+func (o *Target) Empty() bool {
 	if len(o.Ip) != 0 {
 		return false
 	}
@@ -195,11 +195,11 @@ func (o *Service) Empty() bool {
 	return true
 }
 
-func (o *Service) InitSchema(sb *schema.SchemaBuilder) {
-	sb.String("ip", "dev.miren.network/service.ip", schema.Doc("The IP allocated to the service"), schema.Many)
-	sb.Label("match", "dev.miren.network/service.match", schema.Doc("A label to match against a sandbox"), schema.Many)
-	sb.Component("port", "dev.miren.network/service.port", schema.Doc("A network port the service exposes"), schema.Many)
-	(&Port{}).InitSchema(sb.Builder("service.port"))
+func (o *Target) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("ip", "dev.miren.network/target.ip", schema.Doc("The IP allocated to the target"), schema.Many)
+	sb.Label("match", "dev.miren.network/target.match", schema.Doc("A label to match against a sandbox"), schema.Many)
+	sb.Component("port", "dev.miren.network/target.port", schema.Doc("A network port the target exposes"), schema.Many)
+	(&Port{}).InitSchema(sb.Builder("target.port"))
 }
 
 const (
@@ -308,14 +308,14 @@ func (o *Port) InitSchema(sb *schema.SchemaBuilder) {
 
 var (
 	KindEndpoints = entity.Id("dev.miren.network/kind.endpoints")
-	KindService   = entity.Id("dev.miren.network/kind.service")
+	KindTarget    = entity.Id("dev.miren.network/kind.target")
 	Schema        = entity.Id("dev.miren.network/schema.v1alpha")
 )
 
 func init() {
 	schema.Register("dev.miren.network", "v1alpha", func(sb *schema.SchemaBuilder) {
 		(&Endpoints{}).InitSchema(sb)
-		(&Service{}).InitSchema(sb)
+		(&Target{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.network", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x8cT\xddҔ0\f}\x0e\xc7\xdfQ\xaf\xeb\xf8D;\xdd&@\x06\xfac[p\xf7Vg|\x90\xef[}C\xbdv\x1a\u0602BYn\x18\xda朤礹\x81\x91\x1a\xbf\x00\x0eB\x93G#\fƯַؒ\x81\xf0ty\xb3:\xf9\x94ND@?\x90\xc2_\f\xbf\xbcXGM\x01#ϟ\n\xac\x96d\xd6y\xaa\x8a\xb0\x83\xf0\xfdv&\xb8\xbc*\xd2\br\xa0\xa5\xb9\xfe\xe6|gr\x10\xaf\x0e\xab\x10=\x99\x9a\xb1o\xcbX-\xa3j\x16p\x1c7\x12\x03v\xf2\x8c\xdd\xcfD\xb0q\xd3;\x81\xb3>.\xf0\xc0\xeb\x04'e\xb5\xb3\x06M\x9c\xff&I\xd6tbIwP\x97\x1fϩ\xb4\x97\xeb\xd2\x12\x87\xe0b\xe6\xcfB\x12\x86\xbd+\xc1,\xe0\x89\xef\x90`4/\x13\x81\"\x13w\x93f \xfc\x83)\x990b\xbc\x8dVَqM^%,\xa0\xe9u\x9b>\xa7Av=\x86'\x15\x95\xdbr\xe3\x0e\x13Q9\xd5\xc3~L\x0f\x8eo\xf1\xbePQ\x94\xbe\xc68\xab\xd0.7\x0e\xe9\xc0\xc5gݗ\xe2\xd7\x03\xfa@\xd6\xd4\xc3gٹFvΓ\x96\xfezJ\x9e\xb3j\xbb\x11\xf5\xd4'[\xfe\xf1\xdbC\x03Β\x89aj\xb5\x8d\ns\xc8\xc1>\xfb\xc6O\xe0\xe3\x0eQκx\bM\xde{\xf0\x18\xd6\xc4bM|\xb4Tv\xe5u\xb9\xd44+6\xa6\xc4s\xa1A3\xac\xd0ػ^e\x05\x98\xfdÞ~\x93\xab\x9c\xe1n1'9\x13\xec\xe6\xa0\xcc\xf1\x7fX\x1b\x1a\xeb\xe3i\x1cչm\x1e\x8c\xec\x99\xeeq\x83\xfd\x05\x00\x00\xff\xff\x01\x00\x00\xff\xff\xa7\xb2\x19\xcc\x1e\x06\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.network", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x8c\x94\xdb\xee\x940\x10\xc6_\xc3\xc4x\x88\xf1\xba\xc6'\"\xa53\xc0\x04z\xb0\x14ܽ\xd5\xc4\a\xf9\xef\xea\x1b\xea\xb5\xe9\xc0\x16\x14\xcarC\xe8\xe1\xf7\xcd\xf4\x9bi\xef`\xa4\xc6/\x80\xa3\xd0\xe4\xd1\b\x83\xe1\xab\xf5-\xb6d\xa0\x7f\xb9\xbc٬|\x8a+\"H_c\xf8\xc5\xf4\xe5\xd5vӴ>\xa9\xfc\xa9\xc0jIf\x1b\xa5\xaa\b;\xe8\xbf\xdfK\x82\xcb뜊 \aZ\x9a\xebo\x8eV\x92\x83puX\xf5\xc1\x93\xa9\x19}\x9bE\xb5\f\xaaY\xd18MD\x01\xecd\x89\xdd\xcf\xc8\xef\x9cr\xe6\x9d\xf5a\x85\x03\x8f#M\xcajg\r\x9a\xb0\xfc\xcdvl\xd5\xc4J\xed\xa4'?n\x19O\xa2\x86\xe0\\\x96\xcf\xca\x0f\xc6\xde\xe70\vX\xf0\x11\"F\xcb0\n(2\xe10h\x02\xe1\x1f\x86+\xf0.\xc7x\x1b\xac\xb2\x1dsM\x1aE\x16\xd0\f\xba\x8d\x9fb\x94݀\xfd\x8b\n\xca\xed\xd5\U00081260\x9c\x1a\xe0x\xcf\x00\x8eO\xf1!\x93\xd1T\x8aŅv=q\xca\aN>\xf9\xbe6\xbf\x1e\xd1\xf7dM=~\x96\x9dkd\xe7<i\xe9\xafE\xac9\xbbv\xb8\xa3\x9aR\xd9+\x1f_:4\xe0,\x99\xd0ύ\xb6\x93`\xdar\xb2;q\xff\x7f<\x10JQWנIsO\xae\xc2VXl\x85Ϧz\xcb\\ՇN|'v^\x88[\xa6?\x13\x96\xe9\xeb\xc3R%\ar\xbd\xb6\x1cs**\a\x98\v\xcc!J\x82\xc3\b\x94\x14\xfe\xdf\xd6\xf6\x8d\xf5\xa1\x98^\xe8G\xcf\x1c?ԋ\xd8\xf3\xe6\xfa\v\x00\x00\xff\xff\x01\x00\x00\xff\xff@\xd7\xc1\xe4\x13\x06\x00\x00"))
 }

--- a/api/network/schema.yml
+++ b/api/network/schema.yml
@@ -1,7 +1,7 @@
 domain: dev.miren.network
 version: v1alpha
 kinds:
-  service:
+  target:
     match:
       type: label
       doc: A label to match against a sandbox
@@ -9,12 +9,12 @@ kinds:
 
     ip:
       type: string
-      doc: The IP allocated to the service
+      doc: The IP allocated to the target
       many: true
 
     port:
       type: component
-      doc: A network port the service exposes
+      doc: A network port the target exposes
       many: true
       attrs:
         port:
@@ -41,9 +41,9 @@ kinds:
           doc: The port number that should be forwarded from the node to the container
 
   endpoints:
-    service:
+    target:
       type: ref
-      doc: The service that uses these endpoints
+      doc: The target that uses these endpoints
       indexed: true
 
     endpoint:

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -114,9 +114,9 @@ func RunnerStart(ctx *Context, opts struct {
 		// Resolver for network operations
 		Resolver: resolver,
 
-		// Service prefixes - same as coordinator
+		// Target prefixes - same as coordinator
 		// TODO: These should come from join response
-		ServicePrefixes: []netip.Prefix{
+		TargetPrefixes: []netip.Prefix{
 			netip.MustParsePrefix("10.10.0.0/16"),
 			netip.MustParsePrefix("fd47:cafe:d00d::/64"),
 		},

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -649,7 +649,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	time.Sleep(time.Second)
 
 	// Set service prefixes in ServerState
-	ctx.ServerState.ServicePrefixes = []netip.Prefix{
+	ctx.ServerState.TargetPrefixes = []netip.Prefix{
 		netip.MustParsePrefix("10.10.0.0/16"),
 		netip.MustParsePrefix("fd47:cafe:d00d::/64"),
 	}
@@ -736,7 +736,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	eac := entityserver_v1alpha.NewEntityAccessClient(client)
 	ec := entityserver.NewClient(ctx.Log, eac)
 
-	ipa := ipalloc.NewAllocator(ctx.Log, ctx.ServerState.ServicePrefixes)
+	ipa := ipalloc.NewAllocator(ctx.Log, ctx.ServerState.TargetPrefixes)
 	eg.Go(func() error {
 		return ipa.Watch(sub, eac)
 	})
@@ -782,7 +782,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		LogWriter:        logWriter,
 		StatusMon:        ctx.ServerState.StatusMon,
 		IPv4Routable:     ctx.ServerState.IPv4Routable,
-		ServicePrefixes:  ctx.ServerState.ServicePrefixes,
+		TargetPrefixes:   ctx.ServerState.TargetPrefixes,
 		DisableLocalNet:  false,
 		Resolver:         res,
 		SandboxMetrics:   ctx.ServerState.SandboxMetrics,

--- a/cli/commands/server_state.go
+++ b/cli/commands/server_state.go
@@ -26,11 +26,11 @@ type ServerState struct {
 	Namespace        string
 
 	// Network
-	Bridge          string
-	Subnet          *netdb.Subnet
-	ServicePrefixes []netip.Prefix
-	NetServ         *network.ServiceManager
-	IPv4Routable    netip.Prefix
+	Bridge         string
+	Subnet         *netdb.Subnet
+	TargetPrefixes []netip.Prefix
+	NetServ        *network.ServiceManager
+	IPv4Routable   netip.Prefix
 
 	// Paths
 	DataPath string

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -29,6 +29,7 @@ import (
 	esv1 "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/exec/exec_v1alpha"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	networkmigrate "miren.dev/runtime/api/network"
 	"miren.dev/runtime/api/runner/runner_v1alpha"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/components/activator"
@@ -734,6 +735,11 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	defer cancel()
 	if err := core_v1alpha.MigrateAppVersionConcurrency(migrationCtx, c.Log, eac); err != nil {
 		c.Log.Error("failed to migrate app versions", "error", err)
+		// Continue even if migration fails
+	}
+
+	if err := networkmigrate.MigrateServiceToTarget(migrationCtx, c.Log, eac); err != nil {
+		c.Log.Error("failed to migrate service entities to target", "error", err)
 		// Continue even if migration fails
 	}
 

--- a/components/ipalloc/ipalloc.go
+++ b/components/ipalloc/ipalloc.go
@@ -37,7 +37,7 @@ func NewAllocator(log *slog.Logger, subnets []netip.Prefix) *Allocator {
 }
 
 func (a *Allocator) Refresh(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient) error {
-	res, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindService))
+	res, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindTarget))
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func (a *Allocator) Refresh(ctx context.Context, eac *entityserver_v1alpha.Entit
 	var rerr error
 
 	for _, ent := range res.Values() {
-		var serv network_v1alpha.Service
+		var serv network_v1alpha.Target
 		serv.Decode(ent.Entity())
 
 		for _, ip := range serv.Ip {
@@ -157,9 +157,9 @@ func generateRandomIPInSubnet(r *mrand.Rand, prefix netip.Prefix) (netip.Addr, e
 }
 
 func (a *Allocator) Watch(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient) error {
-	a.log.Info("watching for service changes")
+	a.log.Info("watching for target changes")
 
-	index := entity.Ref(entity.EntityKind, network_v1alpha.KindService)
+	index := entity.Ref(entity.EntityKind, network_v1alpha.KindTarget)
 
 	_, err := eac.WatchIndex(ctx, index, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
 		if op == nil {
@@ -173,9 +173,9 @@ func (a *Allocator) Watch(ctx context.Context, eac *entityserver_v1alpha.EntityA
 			return nil
 		}
 
-		err := a.assignService(ctx, op.Entity().Entity(), eac)
+		err := a.assignTarget(ctx, op.Entity().Entity(), eac)
 		if err != nil {
-			a.log.Error("failed to assign sandbox", "error", err, "sandbox", op.Entity().Id())
+			a.log.Error("failed to assign target", "error", err, "target", op.Entity().Id())
 		}
 
 		return nil
@@ -183,13 +183,13 @@ func (a *Allocator) Watch(ctx context.Context, eac *entityserver_v1alpha.EntityA
 	return err
 }
 
-type service struct {
-	network_v1alpha.Service
+type tgt struct {
+	network_v1alpha.Target
 	*entity.Entity
 }
 
-func (a *Allocator) assignService(ctx context.Context, ent *entity.Entity, eac *entityserver_v1alpha.EntityAccessClient) error {
-	var srv service
+func (a *Allocator) assignTarget(ctx context.Context, ent *entity.Entity, eac *entityserver_v1alpha.EntityAccessClient) error {
+	var srv tgt
 	srv.Entity = ent
 	srv.Decode(srv.Entity)
 
@@ -211,7 +211,7 @@ func (a *Allocator) assignService(ctx context.Context, ent *entity.Entity, eac *
 	rpcE.SetAttrs(srv.Encode())
 
 	if _, err := eac.Put(ctx, &rpcE); err != nil {
-		a.log.Error("failed to assign service ips", "error", err, "service", srv.Id())
+		a.log.Error("failed to assign target ips", "error", err, "target", srv.Id())
 		return err
 	}
 

--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -85,7 +85,7 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 		LogWriter:       testDeps.LogWriter,
 		StatusMon:       testDeps.StatusMon,
 		IPv4Routable:    testDeps.IPv4Routable,
-		ServicePrefixes: testDeps.ServicePrefixes,
+		TargetPrefixes:  testDeps.TargetPrefixes,
 		DisableLocalNet: false,
 		Resolver:        res,
 		SandboxMetrics:  sbMetrics,

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -29,7 +29,7 @@ import (
 	"miren.dev/runtime/controllers/disk"
 	"miren.dev/runtime/controllers/ingress"
 	"miren.dev/runtime/controllers/sandbox"
-	"miren.dev/runtime/controllers/service"
+	"miren.dev/runtime/controllers/target"
 	"miren.dev/runtime/network"
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/controller"
@@ -75,7 +75,7 @@ type RunnerDeps struct {
 
 	// Network config
 	IPv4Routable    netip.Prefix
-	ServicePrefixes []netip.Prefix
+	TargetPrefixes  []netip.Prefix
 	DisableLocalNet bool
 
 	// Resolver
@@ -462,16 +462,16 @@ func (r *Runner) SetupControllers(
 
 	rs.ExposeValue("dev.miren.runtime/sandbox.metrics", metric_v1alpha.AdaptSandboxMetrics(sbc.Metrics))
 
-	// Create service controller with explicit dependencies
-	serviceController, err := service.NewServiceController(service.ServiceControllerDeps{
+	// Create target controller with explicit dependencies
+	targetController, err := target.NewTargetController(target.TargetControllerDeps{
 		Log:             r.Log,
 		EAC:             eas,
 		IPv4Routable:    r.deps.IPv4Routable,
-		ServicePrefixes: r.deps.ServicePrefixes,
+		TargetPrefixes:  r.deps.TargetPrefixes,
 		DisableLocalNet: r.deps.DisableLocalNet,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create service controller: %w", err)
+		return nil, fmt.Errorf("failed to create target controller: %w", err)
 	}
 
 	log := r.Log
@@ -584,7 +584,7 @@ func (r *Runner) SetupControllers(
 		return nil, err
 	}
 
-	err = serviceController.Init(ctx)
+	err = targetController.Init(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -629,11 +629,11 @@ func (r *Runner) SetupControllers(
 
 	cm.AddController(
 		controller.NewReconcileController(
-			"service",
+			"target",
 			log,
-			entity.Ref(entity.EntityKind, network_v1alpha.KindService),
+			entity.Ref(entity.EntityKind, network_v1alpha.KindTarget),
 			eas,
-			controller.AdaptController(serviceController),
+			controller.AdaptController(targetController),
 			time.Minute,
 			workers,
 		),
@@ -645,7 +645,7 @@ func (r *Runner) SetupControllers(
 			log,
 			entity.Ref(entity.EntityKind, network_v1alpha.KindEndpoints),
 			eas,
-			serviceController.UpdateEndpoints,
+			targetController.UpdateEndpoints,
 			0,
 			workers,
 		),

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1008,7 +1008,7 @@ func (c *SandboxController) updateServices(
 	meta *entity.Meta,
 	ep *network.EndpointConfig,
 ) error {
-	sresp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindService))
+	sresp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindTarget))
 	if err != nil {
 		return err
 	}
@@ -1018,7 +1018,7 @@ func (c *SandboxController) updateServices(
 	c.Log.Debug("updating services", "id", co.ID, "labels", md.Labels, "services", len(sresp.Values()))
 
 	for _, ent := range sresp.Values() {
-		var srv network_v1alpha.Service
+		var srv network_v1alpha.Target
 		srv.Decode(ent.Entity())
 
 		if !srv.Match.SubsetOf(md.Labels) {
@@ -1039,7 +1039,7 @@ func (c *SandboxController) addEndpoint(
 	ctx context.Context,
 	sb *compute.Sandbox,
 	ep *network.EndpointConfig,
-	srv *network_v1alpha.Service,
+	srv *network_v1alpha.Target,
 ) error {
 	c.Log.Debug("adding endpoint to service", "service", srv.ID, "sandbox", sb.ID, "containers", len(sb.Spec.Container))
 
@@ -1060,7 +1060,7 @@ func (c *SandboxController) addEndpoint(
 
 			var eps network_v1alpha.Endpoints
 
-			eps.Service = srv.ID
+			eps.Target = srv.ID
 			eps.Endpoint = append(eps.Endpoint, network_v1alpha.Endpoint{
 				Ip:   ep.Addresses[0].Addr().String(),
 				Port: p.Port,
@@ -1074,7 +1074,7 @@ func (c *SandboxController) addEndpoint(
 				return fmt.Errorf("failed to update service: %w", err)
 			}
 
-			c.Log.Debug("updated service", "id", pr.Id(), "service", eps.Service)
+			c.Log.Debug("updated service", "id", pr.Id(), "service", eps.Target)
 		}
 	}
 

--- a/controllers/target/target.go
+++ b/controllers/target/target.go
@@ -1,4 +1,4 @@
-package service
+package target
 
 import (
 	"bytes"
@@ -23,20 +23,20 @@ import (
 	"miren.dev/runtime/pkg/set"
 )
 
-// ServiceControllerDeps holds required dependencies for ServiceController.
-type ServiceControllerDeps struct {
+// TargetControllerDeps holds required dependencies for TargetController.
+type TargetControllerDeps struct {
 	Log             *slog.Logger
 	EAC             *entityserver_v1alpha.EntityAccessClient
 	IPv4Routable    netip.Prefix
-	ServicePrefixes []netip.Prefix
+	TargetPrefixes  []netip.Prefix
 	DisableLocalNet bool
 }
 
-type ServiceController struct {
-	Log             *slog.Logger
-	EAC             *entityserver_v1alpha.EntityAccessClient
-	IPv4Routable    netip.Prefix
-	ServicePrefixes []netip.Prefix
+type TargetController struct {
+	Log            *slog.Logger
+	EAC            *entityserver_v1alpha.EntityAccessClient
+	IPv4Routable   netip.Prefix
+	TargetPrefixes []netip.Prefix
 
 	DisableLocalNet bool
 
@@ -49,73 +49,73 @@ type ServiceController struct {
 	chainEndpoints map[string][]string
 }
 
-// NewServiceController creates a new ServiceController with validated dependencies.
-func NewServiceController(cfg ServiceControllerDeps) (*ServiceController, error) {
+// NewTargetController creates a new TargetController with validated dependencies.
+func NewTargetController(cfg TargetControllerDeps) (*TargetController, error) {
 	if cfg.Log == nil {
-		return nil, fmt.Errorf("service: Log is required")
+		return nil, fmt.Errorf("target: Log is required")
 	}
 	if cfg.EAC == nil {
-		return nil, fmt.Errorf("service: entity access client is required")
+		return nil, fmt.Errorf("target: entity access client is required")
 	}
 	if !cfg.IPv4Routable.IsValid() {
-		return nil, fmt.Errorf("service: IPv4Routable must be a valid prefix")
+		return nil, fmt.Errorf("target: IPv4Routable must be a valid prefix")
 	}
 
-	return &ServiceController{
+	return &TargetController{
 		Log:             cfg.Log,
 		EAC:             cfg.EAC,
 		IPv4Routable:    cfg.IPv4Routable,
-		ServicePrefixes: cfg.ServicePrefixes,
+		TargetPrefixes:  cfg.TargetPrefixes,
 		DisableLocalNet: cfg.DisableLocalNet,
 	}, nil
 }
 
-func (s *ServiceController) UpdateEndpoints(ctx context.Context, event controller.Event) ([]entity.Attr, error) {
+func (s *TargetController) UpdateEndpoints(ctx context.Context, event controller.Event) ([]entity.Attr, error) {
 	if event.Type != controller.EventDeleted {
 		var eps network_v1alpha.Endpoints
 		eps.Decode(event.Entity)
 
-		gr, err := s.EAC.Get(ctx, eps.Service.String())
+		gr, err := s.EAC.Get(ctx, eps.Target.String())
 		if err != nil {
-			return nil, fmt.Errorf("failed to get service: %w", err)
+			return nil, fmt.Errorf("failed to get target: %w", err)
 		}
 
-		var srv network_v1alpha.Service
+		var srv network_v1alpha.Target
 		srv.Decode(gr.Entity().Entity())
 
 		meta := &entity.Meta{
 			Entity: gr.Entity().Entity(),
 		}
 
-		s.Log.Info("Endpoint updated, triggering service update", "service", srv.ID)
+		s.Log.Info("Endpoint updated, triggering target update", "target", srv.ID)
 
 		return nil, s.Create(ctx, &srv, meta)
 	}
 
 	// TODO when WatchIndex gives us the entities value pre-delete, we can use the
-	// same above logic. Until then, we just loop over all the services and update
+	// same above logic. Until then, we just loop over all the targets and update
 	// them all.
 
-	// List all services
-	serviceList, err := s.EAC.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindService))
+	// List all targets
+	targetList, err := s.EAC.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindTarget))
 	if err != nil {
-		return nil, fmt.Errorf("failed to list services: %w", err)
+		return nil, fmt.Errorf("failed to list targets: %w", err)
 	}
 
-	// Loop through all services and trigger an update
-	for _, srvEntity := range serviceList.Values() {
-		var srv network_v1alpha.Service
+	// Loop through all targets and trigger an update
+	for _, srvEntity := range targetList.Values() {
+		var srv network_v1alpha.Target
 		srv.Decode(srvEntity.Entity())
 
 		meta := &entity.Meta{
 			Entity: srvEntity.Entity(),
 		}
 
-		s.Log.Info("Endpoint deleted, triggering service update", "service", srv.ID)
+		s.Log.Info("Endpoint deleted, triggering target update", "target", srv.ID)
 
 		if err := s.Create(ctx, &srv, meta); err != nil {
-			s.Log.Error("Failed to update service after endpoint deletion", "service", srv.ID, "error", err)
-			// Continue updating other services even if one fails
+			s.Log.Error("Failed to update target after endpoint deletion", "target", srv.ID, "error", err)
+			// Continue updating other targets even if one fails
 		}
 	}
 
@@ -139,22 +139,22 @@ func (n *nftCommands) append(cmd string, args ...any) {
 	n.commands = append(n.commands, fmt.Sprintf(cmd, args...))
 }
 
-func (s *ServiceController) serviceChain(ip netip.Addr, port uint16) string {
+func (s *TargetController) serviceChain(ip netip.Addr, port uint16) string {
 	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%d", ip.String(), port)))
 	return fmt.Sprintf("service_%s", base58.Encode(x[:]))
 }
 
-func (s *ServiceController) endpointChain(ip netip.Addr, port uint16) string {
+func (s *TargetController) endpointChain(ip netip.Addr, port uint16) string {
 	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%d", ip.String(), port)))
 	return fmt.Sprintf("endpoint_%s", base58.Encode(x[:]))
 }
 
-func (s *ServiceController) nodeportChain(ip netip.Addr, port uint16) string {
+func (s *TargetController) nodeportChain(ip netip.Addr, port uint16) string {
 	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%d", ip.String(), port)))
 	return fmt.Sprintf("nodeport_%s", base58.Encode(x[:]))
 }
 
-func (s *ServiceController) createServiceChain(cmd *nftCommands, ip netip.Addr, port int) error {
+func (s *TargetController) createServiceChain(cmd *nftCommands, ip netip.Addr, port int) error {
 	srv := s.serviceChain(ip, uint16(port))
 	if cmd.knownChains.Contains(srv) {
 		return nil
@@ -171,7 +171,7 @@ func (s *ServiceController) createServiceChain(cmd *nftCommands, ip netip.Addr, 
 	return nil
 }
 
-func (s *ServiceController) updateServiceEndpoints(cmd *nftCommands, sip netip.Addr, sport int, endpoints []string) error {
+func (s *TargetController) updateServiceEndpoints(cmd *nftCommands, sip netip.Addr, sport int, endpoints []string) error {
 	if len(endpoints) == 0 {
 		return nil
 	}
@@ -208,7 +208,7 @@ func (s *ServiceController) updateServiceEndpoints(cmd *nftCommands, sip netip.A
 	return nil
 }
 
-func (s *ServiceController) setupNodePort(cmd *nftCommands, nport int, sip netip.Addr, sport int) error {
+func (s *TargetController) setupNodePort(cmd *nftCommands, nport int, sip netip.Addr, sport int) error {
 	chain := s.nodeportChain(sip, uint16(sport))
 
 	if cmd.knownChains.Contains(chain) {
@@ -235,7 +235,7 @@ func (s *ServiceController) setupNodePort(cmd *nftCommands, nport int, sip netip
 	return nil
 }
 
-func (s *ServiceController) setupEndpointChain(cmd *nftCommands, ip netip.Addr, port uint16) (string, error) {
+func (s *TargetController) setupEndpointChain(cmd *nftCommands, ip netip.Addr, port uint16) (string, error) {
 	endpoint := s.endpointChain(ip, port)
 	if cmd.knownChains.Contains(endpoint) {
 		return endpoint, nil
@@ -254,7 +254,7 @@ func (s *ServiceController) setupEndpointChain(cmd *nftCommands, ip netip.Addr, 
 	return endpoint, nil
 }
 
-func (s *ServiceController) systemTables() ([]string, error) {
+func (s *TargetController) systemTables() ([]string, error) {
 	cmd := exec.Command("nft", "-j", "list", "tables")
 	out, err := cmd.Output()
 	if err != nil {
@@ -285,7 +285,7 @@ func (s *ServiceController) systemTables() ([]string, error) {
 	return tables, nil
 }
 
-func (s *ServiceController) initNFT(table string, nc *nftCommands) error {
+func (s *TargetController) initNFT(table string, nc *nftCommands) error {
 	s.table = table
 
 	tables, err := s.systemTables()
@@ -395,9 +395,9 @@ func (s *ServiceController) initNFT(table string, nc *nftCommands) error {
 	return nil
 }
 
-func (s *ServiceController) Init(ctx context.Context) error {
+func (s *TargetController) Init(ctx context.Context) error {
 	s.chainEndpoints = make(map[string][]string)
-	s.routablePrefixes = append([]netip.Prefix{s.IPv4Routable}, s.ServicePrefixes...)
+	s.routablePrefixes = append([]netip.Prefix{s.IPv4Routable}, s.TargetPrefixes...)
 
 	s.Log.Info("Initializing service controller")
 
@@ -418,7 +418,7 @@ func (s *ServiceController) Init(ctx context.Context) error {
 	return s.apply(ctx, cmd)
 }
 
-func (s *ServiceController) apply(ctx context.Context, cmd *nftCommands) error {
+func (s *TargetController) apply(ctx context.Context, cmd *nftCommands) error {
 	if len(cmd.commands) == 0 {
 		return nil
 	}
@@ -443,14 +443,14 @@ func (s *ServiceController) apply(ctx context.Context, cmd *nftCommands) error {
 	return nil
 }
 
-func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Service, meta *entity.Meta) error {
-	s.Log.Info("Creating service", "service", srv)
+func (s *TargetController) Create(ctx context.Context, srv *network_v1alpha.Target, meta *entity.Meta) error {
+	s.Log.Info("Creating target", "target", srv)
 
 	if len(srv.Ip) == 0 {
 		return nil
 	}
 
-	lr, err := s.EAC.List(ctx, entity.Ref(network_v1alpha.EndpointsServiceId, srv.ID))
+	lr, err := s.EAC.List(ctx, entity.Ref(network_v1alpha.EndpointsTargetId, srv.ID))
 	if err != nil {
 		return fmt.Errorf("failed to list endpoints: %w", err)
 	}
@@ -523,6 +523,6 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 	return nil
 }
 
-func (s *ServiceController) Delete(ctx context.Context, id entity.Id) error {
+func (s *TargetController) Delete(ctx context.Context, id entity.Id) error {
 	return nil
 }

--- a/controllers/target/target_test.go
+++ b/controllers/target/target_test.go
@@ -1,4 +1,4 @@
-package service
+package target
 
 import (
 	"context"
@@ -22,16 +22,17 @@ import (
 	"miren.dev/runtime/pkg/testutils"
 )
 
-// newServiceController creates a ServiceController from TestDeps for testing.
-func newServiceController(d *testutils.TestDeps) (*ServiceController, error) {
-	cfg := ServiceControllerDeps{
-		Log:             d.Log,
-		EAC:             d.EAC,
-		IPv4Routable:    d.IPv4Routable,
-		ServicePrefixes: d.ServicePrefixes,
+// newTargetController creates a TargetController from TestDeps for testing.
+func newTargetController(d *testutils.TestDeps) (*TargetController, error) {
+	cfg := TargetControllerDeps{
+		Log:            d.Log,
+		EAC:            d.EAC,
+		IPv4Routable:   d.IPv4Routable,
+		TargetPrefixes: d.TargetPrefixes,
+
 		DisableLocalNet: false,
 	}
-	return NewServiceController(cfg)
+	return NewTargetController(cfg)
 }
 
 // newSandboxController creates a SandboxController from TestDeps for testing.
@@ -85,7 +86,7 @@ func TestServiceController(t *testing.T) {
 		testDeps, cleanup := testutils.NewTestDeps()
 		defer cleanup()
 
-		sc, err := newServiceController(testDeps)
+		sc, err := newTargetController(testDeps)
 		r.NoError(err)
 
 		err = sc.Init(ctx)
@@ -93,7 +94,7 @@ func TestServiceController(t *testing.T) {
 
 		// Create a service
 		svcID := entity.Id(svcName())
-		svc := &network_v1alpha.Service{
+		svc := &network_v1alpha.Target{
 			ID: svcID,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "test"},
@@ -127,7 +128,7 @@ func TestServiceController(t *testing.T) {
 
 		eac := testDeps.EAC
 
-		sc, err := newServiceController(testDeps)
+		sc, err := newTargetController(testDeps)
 		r.NoError(err)
 
 		sbC, err := newSandboxController(testDeps)
@@ -143,7 +144,7 @@ func TestServiceController(t *testing.T) {
 
 		// Create a service
 		svcID := entity.Id(svcName())
-		svc := &network_v1alpha.Service{
+		svc := &network_v1alpha.Target{
 			ID: svcID,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "nginx"},
@@ -230,7 +231,7 @@ func TestServiceController(t *testing.T) {
 		for _, epEntity := range endpoints.Values() {
 			var ep network_v1alpha.Endpoints
 			ep.Decode(epEntity.Entity())
-			if ep.Service == svcID {
+			if ep.Target == svcID {
 				found = true
 				r.Len(ep.Endpoint, 1)
 				r.NotEmpty(ep.Endpoint[0].Ip)
@@ -255,7 +256,7 @@ func TestServiceController(t *testing.T) {
 
 		eac := testDeps.EAC
 
-		sc, err := newServiceController(testDeps)
+		sc, err := newTargetController(testDeps)
 		r.NoError(err)
 
 		sbC, err := newSandboxController(testDeps)
@@ -271,7 +272,7 @@ func TestServiceController(t *testing.T) {
 
 		// Create a service
 		svcID := entity.Id(svcName())
-		svc := &network_v1alpha.Service{
+		svc := &network_v1alpha.Target{
 			ID: svcID,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "nginx"},
@@ -358,7 +359,7 @@ func TestServiceController(t *testing.T) {
 		for _, epEntity := range endpoints.Values() {
 			var ep network_v1alpha.Endpoints
 			ep.Decode(epEntity.Entity())
-			if ep.Service == svcID {
+			if ep.Target == svcID {
 				found = true
 				endpointID = ep.ID
 				r.Len(ep.Endpoint, 1)
@@ -403,7 +404,7 @@ func TestServiceController(t *testing.T) {
 		testDeps, cleanup := testutils.NewTestDeps()
 		defer cleanup()
 
-		sc, err := newServiceController(testDeps)
+		sc, err := newTargetController(testDeps)
 		r.NoError(err)
 
 		err = sc.Init(ctx)
@@ -411,7 +412,7 @@ func TestServiceController(t *testing.T) {
 
 		// Create initial service
 		svcID := entity.Id(svcName())
-		svc := &network_v1alpha.Service{
+		svc := &network_v1alpha.Target{
 			ID: svcID,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "nginx"},
@@ -458,7 +459,7 @@ func TestServiceController(t *testing.T) {
 
 		eac := testDeps.EAC
 
-		sc, err := newServiceController(testDeps)
+		sc, err := newTargetController(testDeps)
 		r.NoError(err)
 
 		sbC, err := newSandboxController(testDeps)
@@ -474,7 +475,7 @@ func TestServiceController(t *testing.T) {
 
 		// Create a service
 		svcID := entity.Id(svcName())
-		svc := &network_v1alpha.Service{
+		svc := &network_v1alpha.Target{
 			ID: svcID,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "nginx"},
@@ -601,7 +602,7 @@ func TestServiceController(t *testing.T) {
 		for _, epEntity := range endpoints.Values() {
 			var ep network_v1alpha.Endpoints
 			ep.Decode(epEntity.Entity())
-			if ep.Service == svcID {
+			if ep.Target == svcID {
 				serviceEndpoints++
 				// Each endpoint entity should have 1 endpoint (for one sandbox)
 				r.Len(ep.Endpoint, 1)
@@ -628,7 +629,7 @@ func TestServiceController(t *testing.T) {
 		for _, epEntity := range endpoints.Values() {
 			var ep network_v1alpha.Endpoints
 			ep.Decode(epEntity.Entity())
-			if ep.Service == svcID {
+			if ep.Target == svcID {
 				serviceEndpoints++
 				// Each endpoint entity should have 1 endpoint (for one sandbox)
 				r.Len(ep.Endpoint, 1)
@@ -652,7 +653,7 @@ func TestServiceController(t *testing.T) {
 
 		eac := testDeps.EAC
 
-		sc, err := newServiceController(testDeps)
+		sc, err := newTargetController(testDeps)
 		r.NoError(err)
 
 		err = sc.Init(ctx)
@@ -660,7 +661,7 @@ func TestServiceController(t *testing.T) {
 
 		// Create a service
 		svcID := entity.Id(svcName())
-		svc := &network_v1alpha.Service{
+		svc := &network_v1alpha.Target{
 			ID: svcID,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "nginx"},
@@ -694,8 +695,8 @@ func TestServiceController(t *testing.T) {
 		// Create endpoints
 		epID := entity.Id("endpoints-" + svcID.String())
 		eps := &network_v1alpha.Endpoints{
-			ID:      epID,
-			Service: svcID,
+			ID:     epID,
+			Target: svcID,
 			Endpoint: []network_v1alpha.Endpoint{
 				{
 					Ip:   "10.0.0.1",
@@ -727,7 +728,7 @@ func TestServiceController(t *testing.T) {
 
 		eac := testDeps.EAC
 
-		sc, err := newServiceController(testDeps)
+		sc, err := newTargetController(testDeps)
 		r.NoError(err)
 
 		err = sc.Init(ctx)
@@ -735,7 +736,7 @@ func TestServiceController(t *testing.T) {
 
 		// Create multiple services
 		svcID1 := entity.Id(svcName())
-		svc1 := &network_v1alpha.Service{
+		svc1 := &network_v1alpha.Target{
 			ID: svcID1,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "nginx"},
@@ -749,7 +750,7 @@ func TestServiceController(t *testing.T) {
 		}
 
 		svcID2 := entity.Id(svcName())
-		svc2 := &network_v1alpha.Service{
+		svc2 := &network_v1alpha.Target{
 			ID: svcID2,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "apache"},
@@ -799,8 +800,8 @@ func TestServiceController(t *testing.T) {
 		// Create endpoints for first service
 		epID := entity.Id("endpoints-" + svcID1.String())
 		eps := &network_v1alpha.Endpoints{
-			ID:      epID,
-			Service: svcID1,
+			ID:     epID,
+			Target: svcID1,
 			Endpoint: []network_v1alpha.Endpoint{
 				{
 					Ip:   "10.0.0.1",
@@ -860,7 +861,7 @@ func TestServiceController(t *testing.T) {
 		testDeps, cleanup := testutils.NewTestDeps()
 		defer cleanup()
 
-		sc, err := newServiceController(testDeps)
+		sc, err := newTargetController(testDeps)
 		r.NoError(err)
 
 		err = sc.Init(ctx)
@@ -868,7 +869,7 @@ func TestServiceController(t *testing.T) {
 
 		// Create a service with nodeport
 		svcID := entity.Id(svcName())
-		svc := &network_v1alpha.Service{
+		svc := &network_v1alpha.Target{
 			ID: svcID,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "nginx"},
@@ -903,14 +904,14 @@ func TestServiceController(t *testing.T) {
 
 		eac := testDeps.EAC
 
-		sc, err := newServiceController(testDeps)
+		sc, err := newTargetController(testDeps)
 		r.NoError(err)
 
 		// Set service prefixes for IP allocation
 		servicePrefixes := []netip.Prefix{
 			netip.MustParsePrefix("10.96.0.0/16"),
 		}
-		sc.ServicePrefixes = servicePrefixes
+		sc.TargetPrefixes = servicePrefixes
 
 		err = sc.Init(ctx)
 		r.NoError(err)
@@ -931,7 +932,7 @@ func TestServiceController(t *testing.T) {
 
 		// Create a service
 		svcID := entity.Id(svcName())
-		svc := &network_v1alpha.Service{
+		svc := &network_v1alpha.Target{
 			ID: svcID,
 			Match: types.Labels{
 				types.Label{Key: "app", Value: "nginx"},
@@ -969,14 +970,14 @@ func TestServiceController(t *testing.T) {
 		result, err := eac.Get(ctx, svcID.String())
 		r.NoError(err)
 
-		var updatedSvc network_v1alpha.Service
+		var updatedSvc network_v1alpha.Target
 		updatedSvc.Decode(result.Entity().Entity())
 
-		// Verify service was allocated an IP
+		// Verify target was allocated an IP
 		r.NotEmpty(updatedSvc.Ip)
 		r.Greater(len(updatedSvc.Ip), 0)
 		ip, err := netip.ParseAddr(updatedSvc.Ip[0])
 		r.NoError(err)
-		r.True(sc.ServicePrefixes[0].Contains(ip))
+		r.True(sc.TargetPrefixes[0].Contains(ip))
 	})
 }

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -118,7 +118,7 @@ func TestServer(t *testing.T) error {
 	eac := entityserver_v1alpha.NewEntityAccessClient(client)
 	ec := entityserver.NewClient(log, eac)
 
-	ipa := ipalloc.NewAllocator(log, testDeps.ServicePrefixes)
+	ipa := ipalloc.NewAllocator(log, testDeps.TargetPrefixes)
 	eg.Go(func() error {
 		defer t.Log("ipallocator watch complete")
 		return ipa.Watch(ctx, eac)
@@ -160,7 +160,7 @@ func TestServer(t *testing.T) error {
 		LogWriter:       logWriter,
 		StatusMon:       statusMon,
 		IPv4Routable:    testDeps.IPv4Routable,
-		ServicePrefixes: testDeps.ServicePrefixes,
+		TargetPrefixes:  testDeps.TargetPrefixes,
 		DisableLocalNet: false,
 		Resolver:        res,
 		SandboxMetrics:  sbMetrics,

--- a/pkg/testutils/reg.go
+++ b/pkg/testutils/reg.go
@@ -35,12 +35,12 @@ type TestDeps struct {
 	Namespace string
 
 	// Network
-	Bridge          string
-	Subnet          *netdb.Subnet
-	IPv4Routable    netip.Prefix
-	ServicePrefixes []netip.Prefix
-	NetServ         *network.ServiceManager
-	Resolver        netresolve.Resolver
+	Bridge         string
+	Subnet         *netdb.Subnet
+	IPv4Routable   netip.Prefix
+	TargetPrefixes []netip.Prefix
+	NetServ        *network.ServiceManager
+	Resolver       netresolve.Resolver
 
 	// Paths
 	DataPath string
@@ -226,7 +226,7 @@ func NewTestDeps() (*TestDeps, func()) {
 		Bridge:       iface,
 		Subnet:       subnet,
 		IPv4Routable: subnet.Prefix(),
-		ServicePrefixes: []netip.Prefix{
+		TargetPrefixes: []netip.Prefix{
 			netip.MustParsePrefix("10.10.0.0/16"),
 			netip.MustParsePrefix("fd47:cafe:d00d::/64"),
 		},


### PR DESCRIPTION
## Summary

- Renames the network "Service" entity to "Target" to eliminate naming confusion with app-level services (web, worker processes in AppVersion configs)
- Renames `controllers/service` package to `controllers/target`, updating all types (`ServiceController` → `TargetController`, etc.)
- Updates all consumers: runner, sandbox controller, ipalloc, CLI config (`ServicePrefixes` → `TargetPrefixes`)
- Adds `MigrateServiceToTarget()` migration to rename stored entities in etcd (attribute IDs, kind refs, endpoints references), using `Replace` for full entity replacement

## What's NOT changed

- nftables chain/set names (`service_ip4s`, `services` chain) — internal kernel identifiers
- `network.ServiceManager` — unrelated DNS/network management concept
- App-level `services` in AppVersion configs

## Test plan

- [x] Migration unit tests pass (basic rename, port component, already-migrated, empty store)
- [ ] `make lint` passes
- [ ] `make test` passes