### PR TITLE
Release disk leases in periodic sandbox cleanup

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -2480,6 +2480,11 @@ func (c *SandboxController) Periodic(ctx context.Context, timeHorizon time.Durat
 					"updated_at", updatedAt.Format(time.RFC3339),
 					"age", now.Sub(updatedAt).String())
 
+				if err := c.releaseDiskLeases(ctx, sb.ID); err != nil {
+					c.Log.Error("failed to release disk leases during periodic cleanup", "id", sb.ID, "error", err)
+					continue
+				}
+
 				_, err := c.EAC.Delete(ctx, sb.ID.String())
 				if err != nil {
 					c.Log.Error("failed to delete dead sandbox", "id", sb.ID, "error", err)

--- a/controllers/sandbox/volume_test.go
+++ b/controllers/sandbox/volume_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	storage "miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
@@ -472,5 +473,162 @@ func TestReleaseDiskLeases(t *testing.T) {
 		updatedLease2.Decode(leaseResp.Entity().Entity())
 		r.Equal(storage.BOUND, updatedLease2.Status,
 			"other sandbox's lease should not be affected")
+	})
+}
+
+func TestPeriodicReleasesDiskLeases(t *testing.T) {
+	t.Run("releases disk leases before deleting dead sandbox", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node",
+		}
+
+		sandboxID := entity.Id("sandbox/dead-with-lease")
+		diskID := entity.Id("disk/test-disk")
+		leaseID := entity.Id("disk-lease/orphan-candidate")
+
+		// Create a DEAD sandbox entity
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, sandboxID,
+			(&compute.Sandbox{
+				ID:     sandboxID,
+				Status: compute.DEAD,
+			}).Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Create a BOUND disk lease pointing at the sandbox
+		_, err = es.EAC.Create(ctx, entity.New(
+			entity.DBId, leaseID,
+			(&storage.DiskLease{
+				ID:        leaseID,
+				DiskId:    diskID,
+				SandboxId: sandboxID,
+				NodeId:    entity.Id("node/test-node"),
+				Status:    storage.BOUND,
+			}).Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Run periodic cleanup with zero time horizon (everything eligible)
+		err = controller.Periodic(ctx, 0)
+		r.NoError(err)
+
+		// Verify the disk lease was released
+		leaseResp, err := es.EAC.Get(ctx, leaseID.String())
+		r.NoError(err)
+		var releasedLease storage.DiskLease
+		releasedLease.Decode(leaseResp.Entity().Entity())
+		r.Equal(storage.RELEASED, releasedLease.Status,
+			"disk lease should be released before sandbox deletion")
+
+		// Verify the sandbox entity was deleted
+		resp, err := es.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+		r.NoError(err)
+		r.Empty(resp.Values(), "dead sandbox should have been deleted")
+	})
+
+	t.Run("still deletes sandbox when no disk leases exist", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node",
+		}
+
+		sandboxID := entity.Id("sandbox/dead-no-lease")
+
+		// Create a DEAD sandbox entity with no disk leases
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, sandboxID,
+			(&compute.Sandbox{
+				ID:     sandboxID,
+				Status: compute.DEAD,
+			}).Encode,
+		).Attrs())
+		r.NoError(err)
+
+		err = controller.Periodic(ctx, 0)
+		r.NoError(err)
+
+		resp, err := es.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+		r.NoError(err)
+		r.Empty(resp.Values(), "dead sandbox should have been deleted")
+	})
+
+	t.Run("does not release leases for non-dead sandboxes", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		es, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		log := testutils.TestLogger(t)
+
+		controller := &SandboxController{
+			Log:    log,
+			EAC:    es.EAC,
+			NodeId: "test-node",
+		}
+
+		sandboxID := entity.Id("sandbox/running-with-lease")
+		diskID := entity.Id("disk/test-disk")
+		leaseID := entity.Id("disk-lease/should-stay-bound")
+
+		// Create a RUNNING sandbox
+		_, err := es.EAC.Create(ctx, entity.New(
+			entity.DBId, sandboxID,
+			(&compute.Sandbox{
+				ID:     sandboxID,
+				Status: compute.RUNNING,
+			}).Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Create a BOUND disk lease for the running sandbox
+		_, err = es.EAC.Create(ctx, entity.New(
+			entity.DBId, leaseID,
+			(&storage.DiskLease{
+				ID:        leaseID,
+				DiskId:    diskID,
+				SandboxId: sandboxID,
+				NodeId:    entity.Id("node/test-node"),
+				Status:    storage.BOUND,
+			}).Encode,
+		).Attrs())
+		r.NoError(err)
+
+		// Periodic should skip running sandboxes
+		err = controller.Periodic(ctx, 0)
+		r.NoError(err)
+
+		// Verify lease is still BOUND
+		leaseResp, err := es.EAC.Get(ctx, leaseID.String())
+		r.NoError(err)
+		var lease storage.DiskLease
+		lease.Decode(leaseResp.Entity().Entity())
+		r.Equal(storage.BOUND, lease.Status,
+			"lease for running sandbox should not be released")
+
+		// Verify sandbox still exists
+		resp, err := es.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+		r.NoError(err)
+		r.Len(resp.Values(), 1, "running sandbox should not be deleted")
 	})
 }


### PR DESCRIPTION
We discovered in one of our clusters that a handful of apps had sandboxes stuck pending for weeks. The root cause was that `Periodic()` — the background job that cleans up old dead sandbox entities — was calling `EAC.Delete()` directly without first releasing disk leases. The normal teardown path releases leases before cleanup, but the periodic path never got the same treatment.

This meant disk leases stayed in `status.bound` pointing at sandbox entities that no longer existed. When new sandboxes tried to start and needed those volumes, they'd see the active lease and stay pending forever, causing timeouts all the way up through the activator and HTTP ingress.

The fix is straightforward: call `releaseDiskLeases()` before `EAC.Delete()` in `Periodic()`, matching what the normal teardown already does. Added tests that exercise the periodic cleanup path with disk leases to make sure they get released, that sandboxes without leases still clean up fine, and that running sandboxes aren't touched.

Closes MIR-717