### PR TITLE
Surface app.toml parse errors instead of "app is required"

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -39,9 +39,11 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 		ac, err = appconfig.LoadAppConfig()
 	}
 
-	if err == nil {
-		a.config = ac
+	if err != nil {
+		return fmt.Errorf("error loading %s: %w", appconfig.AppConfigPath, err)
 	}
+
+	a.config = ac
 
 	if a.App == "" {
 		if a.config != nil && a.config.Name != "" {

--- a/cli/commands/app_test.go
+++ b/cli/commands/app_test.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeAppToml(t *testing.T, dir, content string) {
+	t.Helper()
+	mirenDir := filepath.Join(dir, ".miren")
+	if err := os.MkdirAll(mirenDir, 0755); err != nil {
+		t.Fatalf("failed to create .miren dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mirenDir, "app.toml"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write app.toml: %v", err)
+	}
+}
+
+func TestAppCentricValidate(t *testing.T) {
+	t.Run("invalid TOML syntax returns parse error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeAppToml(t, dir, `[[[`)
+
+		a := AppCentric{Dir: dir}
+		err := a.Validate(&GlobalFlags{})
+		if err == nil {
+			t.Fatal("expected error for invalid TOML syntax")
+		}
+		if strings.Contains(err.Error(), "app is required") {
+			t.Errorf("expected parse error, got generic 'app is required': %v", err)
+		}
+		if !strings.Contains(err.Error(), "error loading") {
+			t.Errorf("expected error to mention 'error loading', got: %v", err)
+		}
+	})
+
+	t.Run("type mismatch returns decode error", func(t *testing.T) {
+		dir := t.TempDir()
+		// command is a string field but we give it an array
+		writeAppToml(t, dir, `
+name = "myapp"
+
+[services.web]
+command = ["foo", "bar"]
+`)
+
+		a := AppCentric{Dir: dir}
+		err := a.Validate(&GlobalFlags{})
+		if err == nil {
+			t.Fatal("expected error for type mismatch")
+		}
+		if strings.Contains(err.Error(), "app is required") {
+			t.Errorf("expected decode error, got generic 'app is required': %v", err)
+		}
+		if !strings.Contains(err.Error(), "error loading") {
+			t.Errorf("expected error to mention 'error loading', got: %v", err)
+		}
+	})
+
+	t.Run("valid TOML with name populates App", func(t *testing.T) {
+		dir := t.TempDir()
+		writeAppToml(t, dir, `name = "myapp"`)
+
+		a := AppCentric{Dir: dir}
+		err := a.Validate(&GlobalFlags{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.App != "myapp" {
+			t.Errorf("expected App to be 'myapp', got %q", a.App)
+		}
+	})
+
+	t.Run("no app.toml returns app is required", func(t *testing.T) {
+		dir := t.TempDir()
+
+		a := AppCentric{Dir: dir}
+		err := a.Validate(&GlobalFlags{})
+		if err == nil {
+			t.Fatal("expected error when no app.toml exists")
+		}
+		if err.Error() != "app is required" {
+			t.Errorf("expected 'app is required', got: %v", err)
+		}
+	})
+
+	t.Run("app flag with invalid TOML still returns parse error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeAppToml(t, dir, `[[[`)
+
+		a := AppCentric{Dir: dir, App: "myapp"}
+		err := a.Validate(&GlobalFlags{})
+		if err == nil {
+			t.Fatal("expected error for invalid TOML even with -a flag")
+		}
+		if strings.Contains(err.Error(), "app is required") {
+			t.Errorf("expected parse error, got: %v", err)
+		}
+	})
+
+	t.Run("app flag with no app.toml succeeds", func(t *testing.T) {
+		dir := t.TempDir()
+
+		a := AppCentric{Dir: dir, App: "myapp"}
+		err := a.Validate(&GlobalFlags{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.App != "myapp" {
+			t.Errorf("expected App to be 'myapp', got %q", a.App)
+		}
+	})
+}


### PR DESCRIPTION
When your `.miren/app.toml` has a syntax error or type mismatch, the CLI was telling you "app is required" — which is confusing because the file is right there, it's just broken. The root cause was that `AppCentric.Validate()` silently discarded parse errors from `LoadAppConfig()` and fell through to the generic message.

The fix is straightforward: if loading the config returns an error, surface it instead of swallowing it. If the file simply doesn't exist (the `(nil, nil)` return), existing behavior is preserved.

Closes MIR-713