### PR TITLE
Suppress watchpack ENXIO errors from ancestor directory scanning

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -4,6 +4,47 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+// Webpack 5's module resolution walks up the entire directory tree looking for
+// node_modules/ directories. Ancestor directory paths that are visited during
+// this walk end up in the compilation's fileDependencies and
+// missingDependencies. Watchpack then creates a DirectoryWatcher on the parent
+// of each watched path, which causes it to scan directories like ~/ where it
+// hits Unix sockets and other special files, producing noisy ENXIO errors.
+//
+// This plugin intercepts the watch call to filter out any paths outside the
+// project directory so watchpack stays scoped to the project tree.
+// See: https://github.com/webpack/watchpack/issues/187
+function filterAncestorWatchesPlugin() {
+  return {
+    name: 'filter-ancestor-watches',
+    configureWebpack(config) {
+      config.plugins.push({
+        apply(compiler) {
+          const siteDir = compiler.context;
+          const origWatch = compiler.watchFileSystem.watch.bind(
+            compiler.watchFileSystem,
+          );
+          compiler.watchFileSystem.watch = (
+            files,
+            dirs,
+            missing,
+            ...rest
+          ) => {
+            const filteredFiles = [...files].filter((f) =>
+              f.startsWith(siteDir),
+            );
+            const filteredMissing = [...missing].filter((m) =>
+              m.startsWith(siteDir),
+            );
+            return origWatch(filteredFiles, dirs, filteredMissing, ...rest);
+          };
+        },
+      });
+      return {};
+    },
+  };
+}
+
 const config: Config = {
   title: 'Miren Docs',
   tagline: 'Enjoy the Deploy',
@@ -27,6 +68,8 @@ const config: Config = {
 
   // Prevent GitHub Pages from adding trailing slashes via redirects
   trailingSlash: false,
+
+  plugins: [filterAncestorWatchesPlugin],
 
   onBrokenLinks: 'throw',
 


### PR DESCRIPTION
Running `docusaurus start` in `docs/` was producing noisy errors like:

    Watchpack Error (watcher): Error: ENXIO: no such device or address, open '/home/user/.some-socket'

The dev server worked fine — the errors were just confusing clutter. Digging in, this turned out to be a known webpack 5 behavior (https://github.com/webpack/watchpack/issues/187) where module resolution walks up the entire directory tree looking for `node_modules/` directories, and all the ancestor paths it visits get added to both `fileDependencies` and `missingDependencies`. Watchpack then creates `DirectoryWatcher` instances on the parent directories of those paths, which means it ends up scanning `~/` and hitting Unix sockets.

The initial approach from the upstream issue — filtering `missingDependencies` in an `afterCompile` hook — turned out to only be half the story. The real culprit was `fileDependencies`, where webpack adds the entire ancestor directory chain (`/`, `/home`, `/home/user`, etc.) as file dependencies to track structural changes. Watching `/home/user/worktrees` as a "file" triggers a `DirectoryWatcher` on `/home/user/`, and that's what scans the home directory.

The fix intercepts `compiler.watchFileSystem.watch()` — the last point before paths reach watchpack — and filters both `files` and `missing` down to paths within the site directory. This keeps watchpack scoped to the project tree without any of the timing concerns that come with hook-based approaches.

Closes MIR-716