### PR TITLE
Fix activator pool cache permanent lockout at MaxPoolSize

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -533,12 +533,55 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 			for attempt := 0; attempt < maxRetries; attempt++ {
 				a.mu.Lock()
 				if state.pool.DesiredInstances >= MaxPoolSize {
+					poolIDForMaxCheck := state.pool.ID
 					a.mu.Unlock()
-					a.log.Warn("pool at maximum size, cannot increment further",
-						"pool", state.pool.ID,
-						"max_size", MaxPoolSize,
-						"current", state.pool.DesiredInstances)
-					return state.pool, fmt.Errorf("pool has reached maximum size of %d", MaxPoolSize)
+
+					// Cache says we're at max, but it may be stale. Re-read from entity store
+					// to break potential deadlock where pool manager reset DesiredInstances externally.
+					freshPoolEnt, getErr := a.eac.Get(ctx, poolIDForMaxCheck.String())
+					if getErr != nil {
+						if errors.Is(getErr, cond.ErrNotFound{}) {
+							a.log.Info("pool was deleted while at max size, clearing stale reference",
+								"pool", poolIDForMaxCheck,
+								"service", service)
+							a.mu.Lock()
+							delete(a.pools, key)
+							a.mu.Unlock()
+							poolDeleted = true
+							break
+						}
+						a.log.Warn("pool at maximum size, cannot increment further (re-read failed)",
+							"pool", poolIDForMaxCheck,
+							"max_size", MaxPoolSize,
+							"error", getErr)
+						return state.pool, fmt.Errorf("pool has reached maximum size of %d", MaxPoolSize)
+					}
+
+					var freshPool compute_v1alpha.SandboxPool
+					freshPool.Decode(freshPoolEnt.Entity().Entity())
+
+					a.mu.Lock()
+					if freshPool.DesiredInstances >= MaxPoolSize {
+						a.mu.Unlock()
+						a.log.Warn("pool at maximum size, cannot increment further (confirmed by re-read)",
+							"pool", poolIDForMaxCheck,
+							"max_size", MaxPoolSize,
+							"current", freshPool.DesiredInstances)
+						return &freshPool, fmt.Errorf("pool has reached maximum size of %d", MaxPoolSize)
+					}
+
+					// Fresh state is below max - update cache and recalculate target
+					a.log.Info("stale cache showed pool at max size, but fresh state is below max",
+						"pool", poolIDForMaxCheck,
+						"cached_desired", state.pool.DesiredInstances,
+						"fresh_desired", freshPool.DesiredInstances)
+					state.pool = &freshPool
+					state.revision = freshPoolEnt.Entity().Revision()
+					a.pools[key] = state
+					newDesired = freshPool.DesiredInstances + 1
+					a.mu.Unlock()
+
+					continue
 				}
 
 				// Check if we've already reached our target (another goroutine may have incremented)
@@ -1681,7 +1724,8 @@ func (a *localActivator) removePoolFromTracking(poolID entity.Id) {
 	}
 }
 
-// watchPools watches for pool entity deletions and cleans up stale cache entries.
+// watchPools watches for pool entity changes and keeps the in-memory cache in sync.
+// Handles deletions (cleanup stale entries) and updates (refresh DesiredInstances, etc.).
 func (a *localActivator) watchPools(ctx context.Context) {
 	for {
 		select {
@@ -1691,7 +1735,7 @@ func (a *localActivator) watchPools(ctx context.Context) {
 		default:
 		}
 
-		a.log.Info("starting pool deletion watch")
+		a.log.Info("starting pool watch")
 
 		_, err := a.eac.WatchIndex(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool), stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
 			if op.IsDelete() {
@@ -1701,7 +1745,40 @@ func (a *localActivator) watchPools(ctx context.Context) {
 					a.log.Info("pool deleted, cleaning up cache", "pool", poolID)
 					a.removePoolFromTracking(poolID)
 				}
+				return nil
 			}
+
+			if op.IsUpdate() && op.HasEntity() {
+				var freshPool compute_v1alpha.SandboxPool
+				freshPool.Decode(op.Entity().Entity())
+				freshRevision := op.Entity().Revision()
+
+				a.mu.Lock()
+
+				// Update pools cache entries that reference this pool
+				for key, state := range a.pools {
+					if state.pool != nil && state.pool.ID == freshPool.ID {
+						oldDesired := state.pool.DesiredInstances
+						state.pool = &freshPool
+						state.revision = freshRevision
+						a.pools[key] = state
+						if oldDesired != freshPool.DesiredInstances {
+							a.log.Info("pool watch updated DesiredInstances",
+								"pool", freshPool.ID,
+								"old_desired", oldDesired,
+								"new_desired", freshPool.DesiredInstances)
+						}
+					}
+				}
+
+				// Update poolSandboxes pool pointer
+				if ps, ok := a.poolSandboxes[freshPool.ID]; ok {
+					ps.pool = &freshPool
+				}
+
+				a.mu.Unlock()
+			}
+
 			return nil
 		}))
 

--- a/components/activator/activator_test.go
+++ b/components/activator/activator_test.go
@@ -2251,3 +2251,228 @@ func TestRemovePoolFromTrackingCleansAllCaches(t *testing.T) {
 	assert.True(t, pools2Exists, "pool-2 should still be in pools")
 	assert.True(t, poolSandboxes2Exists, "pool-2 should still be in poolSandboxes")
 }
+
+// TestActivatorRefreshesStaleMaxPoolSizeCache verifies that when the in-memory cache
+// shows DesiredInstances >= MaxPoolSize but the entity store has been reset to a lower
+// value, the activator re-reads from the store and continues rather than permanently
+// refusing to increment.
+func TestActivatorRefreshesStaleMaxPoolSizeCache(t *testing.T) {
+	ctx := context.Background()
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app and version
+	app := &core_v1alpha.App{}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	testVer := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", testVer)
+	require.NoError(t, err)
+	testVer.ID = verID
+
+	// Create pool in entity store with DesiredInstances = 0 (simulating pool manager reset)
+	pool := &compute_v1alpha.SandboxPool{
+		Service:              "web",
+		DesiredInstances:     0,
+		ReferencedByVersions: []entity.Id{testVer.ID},
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: testVer.ID,
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{
+					Name:  "app",
+					Image: "test:latest",
+					Port: []compute_v1alpha.SandboxSpecContainerPort{
+						{Port: 3000, Name: "http", Type: "http"},
+					},
+				},
+			},
+		},
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Get the current revision from the store
+	poolResp, err := server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+
+	log := testutils.TestLogger(t)
+	key := verKey{testVer.ID.String(), "web"}
+
+	// Set up activator with a STALE cache that thinks DesiredInstances = MaxPoolSize
+	stalePool := *pool
+	stalePool.DesiredInstances = MaxPoolSize
+
+	activator := &localActivator{
+		log: log,
+		eac: server.EAC,
+		versions: map[verKey]*versionPoolRef{
+			key: {
+				ver:      testVer,
+				poolID:   poolID,
+				service:  "web",
+				strategy: concurrency.NewStrategy(&testVer.Config.Services[0].ServiceConcurrency),
+			},
+		},
+		poolSandboxes: map[entity.Id]*poolSandboxes{
+			poolID: {
+				pool:    &stalePool,
+				service: "web",
+			},
+		},
+		pools: map[verKey]*poolState{
+			key: {
+				pool:     &stalePool,
+				revision: poolResp.Entity().Revision(),
+			},
+		},
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	// Call requestPoolCapacity - with the old code this would return
+	// "pool has reached maximum size" without consulting the entity store.
+	// With the fix, it should re-read, find DesiredInstances=0, and succeed.
+	resultPool, err := activator.requestPoolCapacity(ctx, testVer, "web")
+	require.NoError(t, err)
+	require.NotNil(t, resultPool)
+
+	// Verify the cache was updated with the fresh value + 1
+	activator.mu.RLock()
+	cachedState := activator.pools[key]
+	activator.mu.RUnlock()
+
+	assert.Equal(t, int64(1), cachedState.pool.DesiredInstances,
+		"cache should reflect the incremented value from the fresh store read")
+}
+
+// TestWatchPoolsUpdatesDesiredInstances verifies that the watchPools goroutine
+// updates the in-memory cache when a pool's DesiredInstances changes externally.
+func TestWatchPoolsUpdatesDesiredInstances(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app and version
+	app := &core_v1alpha.App{}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	testVer := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", testVer)
+	require.NoError(t, err)
+	testVer.ID = verID
+
+	// Create pool in entity store
+	pool := &compute_v1alpha.SandboxPool{
+		Service:              "web",
+		DesiredInstances:     5,
+		ReferencedByVersions: []entity.Id{testVer.ID},
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: testVer.ID,
+		},
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	poolResp, err := server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+
+	log := testutils.TestLogger(t)
+	key := verKey{testVer.ID.String(), "web"}
+
+	activator := &localActivator{
+		log: log,
+		eac: server.EAC,
+		versions: map[verKey]*versionPoolRef{
+			key: {
+				ver:      testVer,
+				poolID:   poolID,
+				service:  "web",
+				strategy: concurrency.NewStrategy(&testVer.Config.Services[0].ServiceConcurrency),
+			},
+		},
+		poolSandboxes: map[entity.Id]*poolSandboxes{
+			poolID: {
+				pool:    pool,
+				service: "web",
+			},
+		},
+		pools: map[verKey]*poolState{
+			key: {
+				pool:     pool,
+				revision: poolResp.Entity().Revision(),
+			},
+		},
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	// Start the watch in a goroutine
+	go activator.watchPools(ctx)
+
+	// Give the watch a moment to establish
+	time.Sleep(100 * time.Millisecond)
+
+	// Update DesiredInstances in the entity store externally
+	err = server.Client.Update(ctx, pool)
+	require.NoError(t, err)
+
+	// Patch to set new desired instances
+	pool.DesiredInstances = 2
+	err = server.Client.Update(ctx, pool)
+	require.NoError(t, err)
+
+	// Verify the cache is updated via the watch
+	require.Eventually(t, func() bool {
+		activator.mu.RLock()
+		defer activator.mu.RUnlock()
+		state, ok := activator.pools[key]
+		return ok && state.pool != nil && state.pool.DesiredInstances == 2
+	}, 5*time.Second, 50*time.Millisecond,
+		"pool cache should be updated by watch to DesiredInstances=2")
+
+	// Also verify poolSandboxes pool pointer was updated
+	activator.mu.RLock()
+	ps := activator.poolSandboxes[poolID]
+	activator.mu.RUnlock()
+	assert.Equal(t, int64(2), ps.pool.DesiredInstances,
+		"poolSandboxes pool pointer should reflect the updated DesiredInstances")
+}


### PR DESCRIPTION
The activator keeps an in-memory cache of each pool's `DesiredInstances` to avoid hitting the entity store on every request. Problem is, that cache only ever went up — once it reached `MaxPoolSize` (20), the activator would bail immediately without consulting the store. Since no store interaction meant no OCC conflict, the cache never got a chance to refresh. If the pool manager reset `DesiredInstances` to 0 externally (say, after a scale-down), the activator would never find out. Permanent deadlock.

Fixed with two complementary changes, defense-in-depth style. First, when the cache says we're at max, we now re-read from the entity store before giving up — if the fresh state is lower, we update the cache and continue the increment. This directly breaks the deadlock on the hot path. Second, `watchPools` now handles Update events in addition to Delete events, so `DesiredInstances` changes flow into the cache proactively. The re-read is a safety net for any remaining staleness window.

Closes MIR-721