### PR TITLE
Respect Dockerfile WORKDIR when running app containers

### DIFF
--- a/api/core/core_v1alpha/schema.gen.go
+++ b/api/core/core_v1alpha/schema.gen.go
@@ -79,7 +79,7 @@ func (o *ConfigSpec) InitSchema(sb *schema.SchemaBuilder) {
 	sb.String("entrypoint", "dev.miren.core/component.config_spec.entrypoint", schema.Doc("The container entrypoint command"))
 	sb.Component("services", "dev.miren.core/component.config_spec.services", schema.Doc("Per-service configuration"), schema.Many)
 	(&ConfigSpecServices{}).InitSchema(sb.Builder("component.config_spec.services"))
-	sb.String("start_directory", "dev.miren.core/component.config_spec.start_directory", schema.Doc("Directory to start the process in (defaults to /app)"))
+	sb.String("start_directory", "dev.miren.core/component.config_spec.start_directory", schema.Doc("Directory to start the process in. If empty, uses the image's WORKDIR."))
 	sb.Component("variables", "dev.miren.core/component.config_spec.variables", schema.Doc("Environment variables and configuration values"), schema.Many)
 	(&ConfigSpecVariables{}).InitSchema(sb.Builder("component.config_spec.variables"))
 }
@@ -874,7 +874,7 @@ func (o *Config) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Int64("port", "dev.miren.core/config.port", schema.Doc("[DEPRECATED] Port used for the web service; defaults to 3000. Prefer per-service ports."))
 	sb.Component("services", "dev.miren.core/config.services", schema.Doc("Per-service configuration including concurrency controls"), schema.Many)
 	(&Services{}).InitSchema(sb.Builder("config.services"))
-	sb.String("start_directory", "dev.miren.core/config.start_directory", schema.Doc("Directory to start the process in (defaults to /app)"))
+	sb.String("start_directory", "dev.miren.core/config.start_directory", schema.Doc("Directory to start the process in. If empty, uses the image's WORKDIR."))
 	sb.Component("variable", "dev.miren.core/config.variable", schema.Doc("A variable to be exposed to the app"), schema.Many)
 	(&Variable{}).InitSchema(sb.Builder("config.variable"))
 }

--- a/api/core/schema.yml
+++ b/api/core/schema.yml
@@ -175,7 +175,7 @@ kinds:
           doc: The container entrypoint command
         start_directory:
           type: string
-          doc: Directory to start the process in (defaults to /app)
+          doc: Directory to start the process in. If empty, uses the image's WORKDIR.
         commands:
           type: component
           doc: The command to run for a specific service type
@@ -428,4 +428,4 @@ components:
       doc: The container entrypoint command
     start_directory:
       type: string
-      doc: Directory to start the process in (defaults to /app)
+      doc: Directory to start the process in. If empty, uses the image's WORKDIR.

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -396,11 +396,7 @@ func (l *Launcher) buildSandboxSpec(
 		LogAttribute: types.LabelSet("stage", "app-run", "service", serviceName),
 	}
 
-	// Determine start directory, defaulting to /app
 	startDir := cfgSpec.StartDirectory
-	if startDir == "" {
-		startDir = "/app"
-	}
 
 	appCont := compute_v1alpha.SandboxSpecContainer{
 		Name:  "app",

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1940,11 +1940,6 @@ func (c *SandboxController) buildSubContainerSpec(
 		})
 	}
 
-	dir := co.Directory
-	if dir == "" {
-		dir = "/"
-	}
-
 	// Extract instance number from metadata labels and inject MIREN_INSTANCE_NUM
 	envVars := co.Env
 	var md core_v1alpha.Metadata
@@ -1960,7 +1955,6 @@ func (c *SandboxController) buildSubContainerSpec(
 		oci.WithDefaultUnixDevices,
 		oci.WithoutMounts("/sys"),
 		oci.WithMounts(mounts),
-		oci.WithProcessCwd(dir),
 		oci.WithLinuxNamespace(specs.LinuxNamespace{
 			Type: specs.NetworkNamespace,
 			Path: fmt.Sprintf("/proc/%d/ns/net", sbPid),
@@ -1974,6 +1968,10 @@ func (c *SandboxController) buildSubContainerSpec(
 			Path: fmt.Sprintf("/proc/%d/ns/time", sbPid),
 		}),
 		oci.WithEnv(envVars),
+	}
+
+	if co.Directory != "" {
+		specOpts = append(specOpts, oci.WithProcessCwd(co.Directory))
 	}
 
 	if co.Command != "" {

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -324,11 +324,9 @@ func buildVersionConfig(inputs ConfigInputs) core_v1alpha.ConfigSpec {
 		spec.Entrypoint = res.Entrypoint
 	}
 
-	// Set start directory from build result, defaulting to /app
+	// Set start directory from build result
 	if res != nil && res.WorkingDir != "" {
 		spec.StartDirectory = res.WorkingDir
-	} else {
-		spec.StartDirectory = "/app"
 	}
 
 	// If no web service defined in app config or Procfile, but we have a command or entrypoint,
@@ -1285,7 +1283,9 @@ func (b *Builder) AnalyzeApp(ctx context.Context, state *build_v1alpha.BuilderAn
 		ProcfileServices: procfileServices,
 	})
 
-	result.SetWorkingDir(spec.StartDirectory)
+	if spec.StartDirectory != "" {
+		result.SetWorkingDir(spec.StartDirectory)
+	}
 
 	// Convert spec.Services to ServiceInfo with source tracking
 	// This includes ALL services, even those without explicit commands (they use image default)

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -1195,7 +1195,7 @@ func TestBuildVersionConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "default start directory is /app when not specified",
+			name: "start directory is empty when not specified",
 			inputs: ConfigInputs{
 				BuildResult:      &BuildResult{},
 				AppConfig:        nil,
@@ -1203,7 +1203,7 @@ func TestBuildVersionConfig(t *testing.T) {
 				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
 			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
-				assert.Equal(t, "/app", spec.StartDirectory)
+				assert.Empty(t, spec.StartDirectory)
 			},
 		},
 		{

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -331,11 +331,7 @@ func (s *Server) buildSandboxSpec(
 		LogAttribute: types.LabelSet("stage", "console", "service", "web"),
 	}
 
-	// Determine start directory, defaulting to /app
 	startDir := cfgSpec.StartDirectory
-	if startDir == "" {
-		startDir = "/app"
-	}
 
 	image := ver.ImageUrl
 


### PR DESCRIPTION
When you set `WORKDIR /src` in a Dockerfile, you'd expect your app to start in `/src`. Instead, we were always landing in `/app` — or `/` in some cases — because the working directory got overridden at every layer on its way down to the container runtime.

The problem was a chain of well-intentioned defaults. The build server would stuff `/app` into `StartDirectory` when the build result didn't have a working dir. The deployment launcher and exec proxy would each independently fall back to `/app` if it was still empty. And at the bottom of the stack, the sandbox controller always called `oci.WithProcessCwd()` — even with a default of `/` — which clobbered the correct WORKDIR that `oci.WithImageConfig()` had already set from the image metadata.

The fix is to let empty mean "use what the image says." We stop inserting `/app` as a default at the build, deployment, and exec layers, and the sandbox controller now only calls `WithProcessCwd` when an explicit directory is configured. This lets `oci.WithImageConfig()` do its thing, which reads WORKDIR from the image per the OCI spec and defaults to `/` when none is set.

Existing apps that already have a `StartDirectory` stored in their config entity are unaffected — their value flows through as before. Images without a WORKDIR still get `/` per the OCI spec, which is correct.

Closes MIR-715