### PR TITLE
Restore /app default for start directory

### DIFF
--- a/api/core/core_v1alpha/schema.gen.go
+++ b/api/core/core_v1alpha/schema.gen.go
@@ -79,7 +79,7 @@ func (o *ConfigSpec) InitSchema(sb *schema.SchemaBuilder) {
 	sb.String("entrypoint", "dev.miren.core/component.config_spec.entrypoint", schema.Doc("The container entrypoint command"))
 	sb.Component("services", "dev.miren.core/component.config_spec.services", schema.Doc("Per-service configuration"), schema.Many)
 	(&ConfigSpecServices{}).InitSchema(sb.Builder("component.config_spec.services"))
-	sb.String("start_directory", "dev.miren.core/component.config_spec.start_directory", schema.Doc("Directory to start the process in. If empty, uses the image's WORKDIR."))
+	sb.String("start_directory", "dev.miren.core/component.config_spec.start_directory", schema.Doc("Directory to start the process in; defaults to /app."))
 	sb.Component("variables", "dev.miren.core/component.config_spec.variables", schema.Doc("Environment variables and configuration values"), schema.Many)
 	(&ConfigSpecVariables{}).InitSchema(sb.Builder("component.config_spec.variables"))
 }
@@ -874,7 +874,7 @@ func (o *Config) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Int64("port", "dev.miren.core/config.port", schema.Doc("[DEPRECATED] Port used for the web service; defaults to 3000. Prefer per-service ports."))
 	sb.Component("services", "dev.miren.core/config.services", schema.Doc("Per-service configuration including concurrency controls"), schema.Many)
 	(&Services{}).InitSchema(sb.Builder("config.services"))
-	sb.String("start_directory", "dev.miren.core/config.start_directory", schema.Doc("Directory to start the process in. If empty, uses the image's WORKDIR."))
+	sb.String("start_directory", "dev.miren.core/config.start_directory", schema.Doc("Directory to start the process in; defaults to /app."))
 	sb.Component("variable", "dev.miren.core/config.variable", schema.Doc("A variable to be exposed to the app"), schema.Many)
 	(&Variable{}).InitSchema(sb.Builder("config.variable"))
 }

--- a/api/core/schema.yml
+++ b/api/core/schema.yml
@@ -175,7 +175,7 @@ kinds:
           doc: The container entrypoint command
         start_directory:
           type: string
-          doc: Directory to start the process in. If empty, uses the image's WORKDIR.
+          doc: Directory to start the process in; defaults to /app.
         commands:
           type: component
           doc: The command to run for a specific service type
@@ -428,4 +428,4 @@ components:
       doc: The container entrypoint command
     start_directory:
       type: string
-      doc: Directory to start the process in. If empty, uses the image's WORKDIR.
+      doc: Directory to start the process in; defaults to /app.

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -397,6 +397,9 @@ func (l *Launcher) buildSandboxSpec(
 	}
 
 	startDir := cfgSpec.StartDirectory
+	if startDir == "" {
+		startDir = "/app"
+	}
 
 	appCont := compute_v1alpha.SandboxSpecContainer{
 		Name:  "app",

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -324,9 +324,11 @@ func buildVersionConfig(inputs ConfigInputs) core_v1alpha.ConfigSpec {
 		spec.Entrypoint = res.Entrypoint
 	}
 
-	// Set start directory from build result
+	// Set start directory from build result, defaulting to /app
 	if res != nil && res.WorkingDir != "" {
 		spec.StartDirectory = res.WorkingDir
+	} else {
+		spec.StartDirectory = "/app"
 	}
 
 	// If no web service defined in app config or Procfile, but we have a command or entrypoint,

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -1195,7 +1195,7 @@ func TestBuildVersionConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "start directory is empty when not specified",
+			name: "default start directory is /app when not specified",
 			inputs: ConfigInputs{
 				BuildResult:      &BuildResult{},
 				AppConfig:        nil,
@@ -1203,7 +1203,7 @@ func TestBuildVersionConfig(t *testing.T) {
 				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
 			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
-				assert.Empty(t, spec.StartDirectory)
+				assert.Equal(t, "/app", spec.StartDirectory)
 			},
 		},
 		{

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -332,6 +332,9 @@ func (s *Server) buildSandboxSpec(
 	}
 
 	startDir := cfgSpec.StartDirectory
+	if startDir == "" {
+		startDir = "/app"
+	}
 
 	image := ver.ImageUrl
 


### PR DESCRIPTION
The WORKDIR fix (f24f27d7) did the right thing for new deploys — detect the image's WORKDIR at build time and store it in the config. But it also removed the runtime `/app` fallback from the deployment launcher, exec proxy, and build server. That's a problem for every existing app version that was built before the fix: they have no `start_directory` in their config at all, so they end up booting with CWD=`/` instead of `/app` and immediately crash.

This restores the `/app` default in all three places. The build server defaults new builds to `/app` when no WORKDIR is detected, and the launcher and exec proxy fall back to `/app` when the stored config is empty. The sandbox controller's conditional `WithProcessCwd` is left as-is since it's the correct behavior.

The launcher and exec proxy defaults are backward-compat scaffolding — once we run a boot migration to backfill `start_directory` on existing configs, those can be cleaned up.

Fixes MIR-727