### PR TITLE
Lower RPC Connect error logs from Error to Debug

### DIFF
--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -538,13 +538,13 @@ func (s *State) Connect(remote string, name string) (*NetworkClient, error) {
 
 	err = client.resolveCapability(name)
 	if err != nil {
-		s.log.Error("error resolving capability", "error", err)
+		s.log.Debug("error resolving capability", "error", err)
 		return nil, err
 	}
 
 	err = client.sendIdentity(s.top)
 	if err != nil {
-		s.log.Error("error sending identity", "error", err)
+		s.log.Debug("error sending identity", "error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Running `miren deploy` against a server that doesn't expose the telemetry capability was producing a loud `[ERROR] error resolving capability` message — even though the deploy command handles this gracefully and continues without tracing. The error was coming from `State.Connect()` in the RPC layer, which logged at ERROR level before returning the error to the caller.

The thing is, `Connect()` already returns the error, so callers can decide how to handle it. The deploy command treats telemetry as optional and logs the failure at Debug — but the ERROR from the RPC layer fired first, making it look like something was seriously wrong. Dropped both error logs in `Connect()` (capability resolution and identity) down to Debug so optional capability lookups degrade quietly.