### PR TITLE
Default sandbox CWD to /app when directory is unset

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1970,9 +1970,11 @@ func (c *SandboxController) buildSubContainerSpec(
 		oci.WithEnv(envVars),
 	}
 
-	if co.Directory != "" {
-		specOpts = append(specOpts, oci.WithProcessCwd(co.Directory))
+	cwd := co.Directory
+	if cwd == "" {
+		cwd = "/app"
 	}
+	specOpts = append(specOpts, oci.WithProcessCwd(cwd))
 
 	if co.Command != "" {
 		specOpts = append(specOpts, oci.WithProcessArgs("/bin/sh", "-c", co.Command))


### PR DESCRIPTION
Follow-up to #621. That PR restored the `/app` default in the launcher and build server, which fixes new pool creation. But existing pools are persisted in etcd with no `directory` field in their sandbox spec — the deployment controller happily reuses them, so the launcher default never comes into play.

This adds the `/app` default in the sandbox controller itself, which is where `WithProcessCwd` actually gets called. When `co.Directory` is populated (new pools, apps with custom WORKDIR), it's used as-is. When it's empty (pre-fix pools), we fall back to `/app`.

Fixes MIR-727