### PR TITLE
Add --yes flag to release scripts

### DIFF
--- a/hack/release-tag.sh
+++ b/hack/release-tag.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 # Push a release tag after the release PR has been merged
-# Usage: hack/release-tag.sh <version> [--force]
+# Usage: hack/release-tag.sh <version> [--force] [--yes]
 # Examples:
 #   hack/release-tag.sh v0.3.0
 #   hack/release-tag.sh v0.3.0 --force   # Skip safety checks
+#   hack/release-tag.sh v0.3.0 --yes     # Skip confirmation prompt
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -13,12 +14,16 @@ CHANGELOG="$REPO_ROOT/docs/docs/changelog.md"
 
 VERSION=""
 FORCE=false
+YES=false
 
 # Parse arguments
 for arg in "$@"; do
   case "$arg" in
     --force|-f)
       FORCE=true
+      ;;
+    --yes|-y)
+      YES=true
       ;;
     -*)
       echo "Error: Unknown flag: $arg"
@@ -37,11 +42,12 @@ done
 
 if [ -z "$VERSION" ]; then
   echo "Error: Version required"
-  echo "Usage: $0 <version> [--force]"
+  echo "Usage: $0 <version> [--force] [--yes]"
   echo ""
   echo "Examples:"
   echo "  $0 v0.3.0"
   echo "  $0 v0.3.0 --force   # Skip safety checks"
+  echo "  $0 v0.3.0 --yes     # Skip confirmation prompt"
   exit 1
 fi
 
@@ -115,11 +121,15 @@ echo "Commit: $(git rev-parse --short HEAD)"
 echo ""
 
 # Ask for confirmation
-read -p "Create and push tag $VERSION? (y/N) " -n 1 -r
-echo
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-  echo "Aborted"
-  exit 1
+if [ "$YES" = true ]; then
+  echo "Continuing (--yes)"
+else
+  read -p "Create and push tag $VERSION? (y/N) " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted"
+    exit 1
+  fi
 fi
 
 # Create and push tag

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,21 +2,44 @@
 set -euo pipefail
 
 # Release script for stable releases following RFD-40 conventions
-# Usage: hack/release.sh <version>
+# Usage: hack/release.sh <version> [--yes]
 # Examples:
 #   hack/release.sh v0.1.0           # Preview release
 #   hack/release.sh v1.0.0           # GA release
+#   hack/release.sh v0.1.0 --yes     # Skip confirmation prompt
 # For prerelease tags, use hack/release-prerelease.sh instead
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CHANGELOG="$REPO_ROOT/docs/docs/changelog.md"
 
-VERSION="${1:-}"
+VERSION=""
+YES=false
+
+# Parse arguments
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y)
+      YES=true
+      ;;
+    -*)
+      echo "Error: Unknown flag: $arg"
+      exit 1
+      ;;
+    *)
+      if [ -z "$VERSION" ]; then
+        VERSION="$arg"
+      else
+        echo "Error: Unexpected argument: $arg"
+        exit 1
+      fi
+      ;;
+  esac
+done
 
 if [ -z "$VERSION" ]; then
   echo "Error: Version required"
-  echo "Usage: $0 <version>"
+  echo "Usage: $0 <version> [--yes]"
   echo ""
   echo "Examples:"
   echo "  $0 v0.1.0           # Preview release"
@@ -94,11 +117,15 @@ echo "Changelog: Will update Unreleased → $VERSION"
 echo ""
 
 # Ask for confirmation
-read -p "Continue? (y/N) " -n 1 -r
-echo
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-  echo "Aborted"
-  exit 1
+if [ "$YES" = true ]; then
+  echo "Continuing (--yes)"
+else
+  read -p "Continue? (y/N) " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted"
+    exit 1
+  fi
 fi
 
 # Update changelog


### PR DESCRIPTION
Our release scripts have interactive `read -p` confirmation prompts, which is fine for humans but blocks non-interactive callers from running them directly. This adds `--yes`/`-y` to both `hack/release.sh` and `hack/release-tag.sh` to skip the confirmation prompt. All the actual safety checks (clean working directory, on main, up to date with origin, changelog validation) still run — we're only skipping the "are you sure?" prompt, not the guardrails.