### PR TITLE
httpingress: add minimum lease TTL for low-traffic apps

### DIFF
--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -45,6 +45,11 @@ const (
 	// leaseAcquisitionTimeout is the maximum time to wait for sandbox boot
 	// This is longer than request timeout to prevent dangling resources
 	leaseAcquisitionTimeout = 2 * time.Minute
+	// minLeaseTTL is the minimum time a lease is kept in cache after its last
+	// use before it becomes eligible for eviction. This prevents low-traffic
+	// apps from having their leases evicted on every 30s tick, which would
+	// force every request through the full entity store + activator pipeline.
+	minLeaseTTL = 5 * time.Minute
 )
 
 type IngressConfig struct {
@@ -160,20 +165,25 @@ func (h *Server) expireLeases(ctx context.Context) {
 		var newLeases []*lease
 
 		for i, l := range ar.leases {
-			if l.Uses == 0 {
+			if l.Uses == 0 && time.Since(l.LastUsed) > minLeaseTTL {
 				h.Log.Debug("expiring lease", "app", app, "url", l.Lease.URL)
 				h.aa.ReleaseLease(ctx, l.Lease)
-			} else {
-				h.Log.Debug("lease still in use", "app", app, "url", l.Lease.URL, "uses", l.Uses)
-				lease, err := h.aa.RenewLease(ctx, l.Lease)
-				if err != nil {
-					h.Log.Error("error renewing lease", "error", err, "app", app, "url", l.Lease.URL)
-					continue
-				}
-
-				ar.leases[i].Lease = lease
-				newLeases = append(newLeases, ar.leases[i])
+				continue
 			}
+
+			// Renew all retained leases — both active (Uses > 0) and idle
+			// but within TTL. This validates with the activator that the
+			// sandbox is still alive, so we never serve a stale route.
+			h.Log.Debug("renewing lease", "app", app, "url", l.Lease.URL, "uses", l.Uses)
+			lease, err := h.aa.RenewLease(ctx, l.Lease)
+			if err != nil {
+				h.Log.Error("error renewing lease", "error", err, "app", app, "url", l.Lease.URL)
+				continue
+			}
+
+			ar.leases[i].Lease = lease
+			ar.leases[i].Uses = 0
+			newLeases = append(newLeases, ar.leases[i])
 		}
 
 		if len(newLeases) == 0 {
@@ -204,8 +214,9 @@ func (h *Server) DeriveApp(host string) (string, bool) {
 }
 
 type lease struct {
-	Uses  int
-	Lease *activator.Lease
+	Uses     int
+	LastUsed time.Time
+	Lease    *activator.Lease
 }
 
 func (h *Server) retainLease(ctx context.Context, app string, l *activator.Lease) *lease {
@@ -213,8 +224,9 @@ func (h *Server) retainLease(ctx context.Context, app string, l *activator.Lease
 	defer h.mu.Unlock()
 
 	ll := &lease{
-		Lease: l,
-		Uses:  1,
+		Lease:    l,
+		Uses:     1,
+		LastUsed: time.Now(),
 	}
 
 	ar, ok := h.apps[app]
@@ -245,6 +257,7 @@ func (h *Server) useLease(ctx context.Context, app string) (*lease, error) {
 	for _, l := range ar.leases {
 		if l.Uses <= l.Lease.Size {
 			l.Uses++
+			l.LastUsed = time.Now()
 			return l, nil
 		}
 	}

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -183,7 +183,6 @@ func (h *Server) expireLeases(ctx context.Context) {
 			}
 
 			ar.leases[i].Lease = lease
-			ar.leases[i].Uses = 0
 			newLeases = append(newLeases, ar.leases[i])
 		}
 

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -178,6 +178,7 @@ func (h *Server) expireLeases(ctx context.Context) {
 			lease, err := h.aa.RenewLease(ctx, l.Lease)
 			if err != nil {
 				h.Log.Error("error renewing lease", "error", err, "app", app, "url", l.Lease.URL)
+				h.aa.ReleaseLease(ctx, l.Lease)
 				continue
 			}
 

--- a/servers/httpingress/lease_test.go
+++ b/servers/httpingress/lease_test.go
@@ -1,0 +1,268 @@
+package httpingress
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/components/activator"
+)
+
+// mockActivator implements activator.AppActivator for testing lease behavior.
+type mockActivator struct {
+	mu           sync.Mutex
+	renewCount   int
+	releaseCount int
+	renewErr     error
+	releasedURLs []string
+	renewedURLs  []string
+}
+
+func (m *mockActivator) AcquireLease(ctx context.Context, ver *core_v1alpha.AppVersion, service string) (*activator.Lease, error) {
+	return &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}, nil
+}
+
+func (m *mockActivator) ReleaseLease(ctx context.Context, lease *activator.Lease) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releaseCount++
+	m.releasedURLs = append(m.releasedURLs, lease.URL)
+	return nil
+}
+
+func (m *mockActivator) RenewLease(ctx context.Context, lease *activator.Lease) (*activator.Lease, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.renewErr != nil {
+		return nil, m.renewErr
+	}
+	m.renewCount++
+	m.renewedURLs = append(m.renewedURLs, lease.URL)
+	return lease, nil
+}
+
+func newTestServer(aa *mockActivator) *Server {
+	return &Server{
+		Log:  slog.Default(),
+		aa:   aa,
+		apps: make(map[string]*appUsage),
+	}
+}
+
+func TestLeaseKeptAliveWithinTTL(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// Retain a lease (simulates a request acquiring one)
+	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	ll := srv.retainLease(ctx, "app/myapp", actLease)
+
+	// Simulate the request finishing — Uses goes to 0
+	srv.releaseLease(ctx, ll)
+
+	if ll.Uses != 0 {
+		t.Fatalf("expected Uses=0 after release, got %d", ll.Uses)
+	}
+
+	// Run expireLeases — lease should be renewed, not evicted (within TTL)
+	srv.expireLeases(ctx)
+
+	aa.mu.Lock()
+	defer aa.mu.Unlock()
+
+	if aa.releaseCount != 0 {
+		t.Errorf("expected 0 releases (lease within TTL), got %d", aa.releaseCount)
+	}
+	if aa.renewCount != 1 {
+		t.Errorf("expected 1 renewal, got %d", aa.renewCount)
+	}
+
+	// Verify the lease is still in cache
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if _, ok := srv.apps["app/myapp"]; !ok {
+		t.Error("expected app to still have cached leases")
+	}
+}
+
+func TestLeaseEvictedAfterTTL(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// Retain and release a lease
+	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	ll := srv.retainLease(ctx, "app/myapp", actLease)
+	srv.releaseLease(ctx, ll)
+
+	// Backdate LastUsed to beyond the TTL
+	srv.mu.Lock()
+	ll.LastUsed = time.Now().Add(-(minLeaseTTL + time.Minute))
+	srv.mu.Unlock()
+
+	// Run expireLeases — lease should be evicted
+	srv.expireLeases(ctx)
+
+	aa.mu.Lock()
+	defer aa.mu.Unlock()
+
+	if aa.releaseCount != 1 {
+		t.Errorf("expected 1 release (lease past TTL), got %d", aa.releaseCount)
+	}
+	if aa.renewCount != 0 {
+		t.Errorf("expected 0 renewals, got %d", aa.renewCount)
+	}
+
+	// Verify the app is removed from cache
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if _, ok := srv.apps["app/myapp"]; ok {
+		t.Error("expected app to be removed from cache after eviction")
+	}
+}
+
+func TestActiveLeaseRenewed(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// Retain a lease and keep it active (don't release — simulates in-flight request)
+	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	ll := srv.retainLease(ctx, "app/myapp", actLease)
+
+	if ll.Uses != 1 {
+		t.Fatalf("expected Uses=1 after retain, got %d", ll.Uses)
+	}
+
+	// Run expireLeases — active lease should be renewed
+	srv.expireLeases(ctx)
+
+	aa.mu.Lock()
+	defer aa.mu.Unlock()
+
+	if aa.releaseCount != 0 {
+		t.Errorf("expected 0 releases (lease is active), got %d", aa.releaseCount)
+	}
+	if aa.renewCount != 1 {
+		t.Errorf("expected 1 renewal, got %d", aa.renewCount)
+	}
+}
+
+func TestFailedRenewalEvictsLease(t *testing.T) {
+	aa := &mockActivator{renewErr: errors.New("sandbox gone")}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// Retain and release a lease (within TTL, so it would normally be renewed)
+	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	ll := srv.retainLease(ctx, "app/myapp", actLease)
+	srv.releaseLease(ctx, ll)
+
+	// Run expireLeases — renewal fails, lease should be dropped
+	srv.expireLeases(ctx)
+
+	// Verify the app is removed from cache (renewal failed, lease dropped)
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if _, ok := srv.apps["app/myapp"]; ok {
+		t.Error("expected app to be removed after failed renewal")
+	}
+}
+
+func TestUsageResetsAfterRenewal(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// Retain a lease — Uses starts at 1
+	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	srv.retainLease(ctx, "app/myapp", actLease)
+
+	// Run expireLeases — should renew and reset Uses to 0
+	srv.expireLeases(ctx)
+
+	srv.mu.Lock()
+	ar := srv.apps["app/myapp"]
+	if ar == nil || len(ar.leases) == 0 {
+		srv.mu.Unlock()
+		t.Fatal("expected lease to still be cached")
+	}
+	uses := ar.leases[0].Uses
+	srv.mu.Unlock()
+
+	if uses != 0 {
+		t.Errorf("expected Uses reset to 0 after renewal, got %d", uses)
+	}
+}
+
+func TestLastUsedUpdatedOnUse(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// Retain a lease
+	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	ll := srv.retainLease(ctx, "app/myapp", actLease)
+	srv.releaseLease(ctx, ll)
+
+	// Record the initial LastUsed
+	srv.mu.Lock()
+	initial := ll.LastUsed
+	srv.mu.Unlock()
+
+	// Small sleep to ensure time advances
+	time.Sleep(time.Millisecond)
+
+	// Use the lease again (simulates another request hitting the cache)
+	got, err := srv.useLease(ctx, "app/myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	switch {
+	case got == nil:
+		t.Fatal("expected to get a cached lease")
+	case !got.LastUsed.After(initial):
+		t.Errorf("expected LastUsed to advance on use, initial=%v updated=%v", initial, got.LastUsed)
+	}
+}
+
+func TestMultipleAppsIndependentTTL(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// App A: retain and release, then backdate past TTL
+	leaseA := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	llA := srv.retainLease(ctx, "app/a", leaseA)
+	srv.releaseLease(ctx, llA)
+	srv.mu.Lock()
+	llA.LastUsed = time.Now().Add(-(minLeaseTTL + time.Minute))
+	srv.mu.Unlock()
+
+	// App B: retain and release, still within TTL
+	leaseB := &activator.Lease{Size: 10, URL: "http://10.0.0.2:3000"}
+	llB := srv.retainLease(ctx, "app/b", leaseB)
+	srv.releaseLease(ctx, llB)
+
+	// Run expireLeases
+	srv.expireLeases(ctx)
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	// App A should be evicted
+	if _, ok := srv.apps["app/a"]; ok {
+		t.Error("expected app/a to be evicted (past TTL)")
+	}
+
+	// App B should be retained
+	if _, ok := srv.apps["app/b"]; !ok {
+		t.Error("expected app/b to still be cached (within TTL)")
+	}
+}

--- a/servers/httpingress/lease_test.go
+++ b/servers/httpingress/lease_test.go
@@ -182,16 +182,18 @@ func TestFailedRenewalEvictsLease(t *testing.T) {
 	}
 }
 
-func TestUsageResetsAfterRenewal(t *testing.T) {
+func TestUsagePreservedAfterRenewal(t *testing.T) {
 	aa := &mockActivator{}
 	srv := newTestServer(aa)
 	ctx := context.Background()
 
-	// Retain a lease — Uses starts at 1
+	// Retain a lease — Uses starts at 1 (simulates in-flight request)
 	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
 	srv.retainLease(ctx, "app/myapp", actLease)
 
-	// Run expireLeases — should renew and reset Uses to 0
+	// Run expireLeases — should renew but NOT reset Uses, since an
+	// in-flight request is still holding the lease. Resetting would
+	// cause releaseLease to decrement below zero.
 	srv.expireLeases(ctx)
 
 	srv.mu.Lock()
@@ -203,8 +205,8 @@ func TestUsageResetsAfterRenewal(t *testing.T) {
 	uses := ar.leases[0].Uses
 	srv.mu.Unlock()
 
-	if uses != 0 {
-		t.Errorf("expected Uses reset to 0 after renewal, got %d", uses)
+	if uses != 1 {
+		t.Errorf("expected Uses preserved at 1 after renewal, got %d", uses)
 	}
 }
 

--- a/servers/httpingress/lease_test.go
+++ b/servers/httpingress/lease_test.go
@@ -163,10 +163,18 @@ func TestFailedRenewalEvictsLease(t *testing.T) {
 	ll := srv.retainLease(ctx, "app/myapp", actLease)
 	srv.releaseLease(ctx, ll)
 
-	// Run expireLeases — renewal fails, lease should be dropped
+	// Run expireLeases — renewal fails, lease should be released and dropped
 	srv.expireLeases(ctx)
 
-	// Verify the app is removed from cache (renewal failed, lease dropped)
+	aa.mu.Lock()
+	defer aa.mu.Unlock()
+
+	// Verify ReleaseLease was called to clean up activator resources
+	if aa.releaseCount != 1 {
+		t.Errorf("expected 1 release on failed renewal, got %d", aa.releaseCount)
+	}
+
+	// Verify the app is removed from cache
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	if _, ok := srv.apps["app/myapp"]; ok {


### PR DESCRIPTION
## Summary

Fixes MIR-730: miren.dev downtime blip caused by aggressive lease eviction combined with TCP packet loss.

The httpingress lease cache evicts all leases with `Uses == 0` every 30 seconds. For low-traffic apps like mirendev (~1 req/min completing in 1-3ms), the lease is **always** evicted because the request finishes long before the next tick. This forces every single request through the full pipeline: entity store lookups (etcd) → route lookup (etcd) → activator → sandbox selection (~132ms), even though the sandboxes are persistent and healthy.

This PR adds a `LastUsed` timestamp and a 5-minute minimum TTL to the lease cache. Idle leases within the TTL are **renewed** (not evicted) on each 30s tick, which validates with the activator that the sandbox is still alive. This means:

- Low-traffic apps keep their leases cached, skipping the etcd/activator hot path
- Stale leases are caught by failed renewals (no user-visible request failures)
- Genuinely abandoned leases are still cleaned up after the TTL expires

## Context: What happened

On 2026-02-19, Uptime Kuma reported miren.dev down for ~1 minute. Investigation on the production box revealed:

1. **Lease eviction**: mirendev's lease was evicted every 30s (Uses == 0 at tick time). Every monitoring check had to re-acquire through the full pipeline.
2. **TCP packet loss**: The cross-region network path from the monitoring probe to the server has elevated packet loss and high latency. ~7 seconds of the 10s timeout were consumed by TCP SYN retransmissions before the TLS handshake even began.
3. **Server was healthy**: The box had negligible iowait, nearly idle CPU, and miren.cloud requests were completing in milliseconds throughout the incident. A new miren.cloud TLS handshake succeeded mid-incident.

The combination of "every request pays full pipeline cost" + "unlucky network packet loss eating most of the timeout budget" caused the single monitoring failure. With cached leases, the post-TLS work is near-instant, giving much more headroom for network variability.

## Changes

- `servers/httpingress/httpingress.go`: Add `LastUsed time.Time` to lease struct, 5-minute `minLeaseTTL` constant, stamp `LastUsed` on retain/use, change `expireLeases` to keep and renew leases within TTL
- `servers/httpingress/lease_test.go`: 7 new tests covering TTL retention, eviction after TTL, active lease renewal, failed renewal eviction, usage reset, LastUsed tracking, and multi-app independence

## Test plan

- [x] All existing httpingress tests pass
- [x] 7 new lease lifecycle tests pass
- [x] golangci-lint clean
- [ ] Deploy to eu1 and verify mirendev lease stays cached between monitoring checks (`miren logs` should show "using existing lease" for mirendev instead of activator re-acquire)