### PR TITLE
fix(autotls): add HTTP→HTTPS redirect for DNS challenge mode

### DIFF
--- a/components/autotls/autotls.go
+++ b/components/autotls/autotls.go
@@ -220,17 +220,60 @@ func ServeTLSWithController(ctx context.Context, log *slog.Logger, certProvider 
 		}
 	}()
 
+	// Start HTTP server on port 80 for HTTP to HTTPS redirect
+	httpServer := &http.Server{
+		Addr: ":80",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			host := r.Host
+			if hostWithoutPort, _, err := net.SplitHostPort(host); err == nil {
+				host = hostWithoutPort
+			}
+
+			isLocalhost := host == "localhost" || host == "127.0.0.1" || host == "::1"
+			isIPAddress := net.ParseIP(host) != nil
+
+			if isLocalhost || isIPAddress {
+				h.ServeHTTP(w, r)
+				return
+			}
+
+			if r.Method != "GET" && r.Method != "HEAD" {
+				http.Error(w, "Use HTTPS", http.StatusBadRequest)
+				return
+			}
+
+			target := "https://" + host + r.URL.RequestURI()
+			http.Redirect(w, r, target, http.StatusFound)
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
+
+	go func() {
+		log.Info("starting HTTP server for HTTPS redirect", "addr", ":80")
+		err := httpServer.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("error serving HTTP", "error", err)
+		}
+	}()
+
 	// Monitor for context cancellation
 	go func() {
 		<-ctx.Done()
-		log.Info("shutting down HTTPS server")
+		log.Info("shutting down HTTPS and HTTP servers")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		if err := server.Shutdown(shutdownCtx); err != nil {
 			log.Error("HTTPS server shutdown error", "error", err)
 		}
-		log.Info("HTTPS server shutdown complete")
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			log.Error("HTTP server shutdown error", "error", err)
+		}
+		log.Info("HTTPS and HTTP servers shutdown complete")
 	}()
 
 	return nil

--- a/docs/docs/tls.md
+++ b/docs/docs/tls.md
@@ -1,0 +1,138 @@
+---
+sidebar_position: 5
+---
+
+# TLS Certificates
+
+Miren automatically provisions TLS certificates for your applications using [Let's Encrypt](https://letsencrypt.org/). By default, no configuration is needed — when you set a route for your app, Miren obtains a certificate automatically.
+
+## How It Works
+
+When a request arrives for a hostname with a configured route, Miren provisions a TLS certificate from Let's Encrypt using the ACME protocol. Certificates are cached on disk and renewed automatically before they expire.
+
+Hostnames without a configured route are served with a self-signed fallback certificate (browsers will show a warning).
+
+## Challenge Types
+
+Let's Encrypt needs to verify that you control the domain before issuing a certificate. Miren supports two verification methods.
+
+### HTTP-01 Challenge (Default)
+
+The default method. Let's Encrypt makes an HTTP request to your server on port 80 to verify domain ownership.
+
+**Requirements:**
+- Your server must be reachable from the public internet on ports 80 and 443
+- DNS for your domain must point to the server's public IP
+
+This is the zero-configuration option — it works out of the box with `miren server install`.
+
+### DNS-01 Challenge
+
+If your server isn't publicly reachable (e.g., it's behind a VPN like Tailscale, on a private network, or doesn't have ports 80/443 open to the internet), you can use DNS-01 challenges instead. This method proves domain ownership by creating a DNS TXT record, so it works regardless of whether your server is reachable from the internet.
+
+Miren uses [lego](https://go-acme.github.io/lego/) for DNS challenges, which supports [90+ DNS providers](https://go-acme.github.io/lego/dns/).
+
+#### Configuration
+
+Add the DNS provider and ACME email to your server config file:
+
+```toml title="/var/lib/miren/server/config.toml"
+[tls]
+acme_dns_provider = "dnsimple"
+acme_email = "you@example.com"
+```
+
+Each DNS provider requires credentials passed via environment variables. Create an environment file for the Miren service:
+
+```bash title="/var/lib/miren/server/env"
+DNSIMPLE_OAUTH_TOKEN=your-token-here
+```
+
+Then update the systemd service to load the environment file and config:
+
+```bash
+sudo systemctl edit miren --force
+```
+
+Add the environment file:
+
+```ini
+[Service]
+EnvironmentFile=/var/lib/miren/server/env
+```
+
+Restart to pick up the changes:
+
+```bash
+sudo systemctl restart miren
+```
+
+#### Provider Examples
+
+Each provider needs different environment variables. Here are a few common ones:
+
+**DNSimple:**
+```toml
+acme_dns_provider = "dnsimple"
+```
+```bash
+DNSIMPLE_OAUTH_TOKEN=your-token
+```
+
+**Cloudflare:**
+```toml
+acme_dns_provider = "cloudflare"
+```
+```bash
+CF_DNS_API_TOKEN=your-token
+```
+
+**Route 53 (AWS):**
+```toml
+acme_dns_provider = "route53"
+```
+```bash
+AWS_ACCESS_KEY_ID=your-key
+AWS_SECRET_ACCESS_KEY=your-secret
+AWS_REGION=us-east-1
+```
+
+See the [lego DNS provider documentation](https://go-acme.github.io/lego/dns/) for the full list of supported providers and their required environment variables.
+
+## Server Configuration Reference
+
+All TLS settings live under the `[tls]` section of the server config file (typically `/var/lib/miren/server/config.toml`):
+
+| Setting | CLI Flag | Description |
+|---------|----------|-------------|
+| `acme_email` | `--acme-email` | Email for Let's Encrypt account registration and expiry notifications |
+| `acme_dns_provider` | `--acme-dns-provider` | DNS provider name for DNS-01 challenges (e.g., `cloudflare`, `route53`, `dnsimple`) |
+| `standard_tls` | `--serve-tls` | Enable TLS on ports 443/80 (default: `true`) |
+
+## Troubleshooting
+
+### Certificate Not Provisioning
+
+Check the server logs for ACME errors:
+
+```bash
+sudo journalctl -u miren | grep -i acme
+```
+
+**HTTP-01 challenges:** Ensure ports 80 and 443 are reachable from the public internet. See [Firewall Configuration](/firewall) for cloud provider-specific guidance.
+
+**DNS-01 challenges:** Verify your DNS provider credentials are correct and the environment file is loaded:
+
+```bash
+sudo systemctl show miren | grep EnvironmentFile
+```
+
+### Wrong Certificate / Self-Signed Warning
+
+If you're seeing a self-signed certificate warning for a domain that should have a real certificate, check that a route is configured for that hostname:
+
+```bash
+miren route
+```
+
+Miren only provisions ACME certificates for hostnames with explicitly configured routes. All other hostnames get the self-signed fallback.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
         'services',
         'scaling',
         'disks',
+        'tls',
         'firewall',
         'route-oidc',
         'admin-interface',


### PR DESCRIPTION
## Summary

- `ServeTLSWithController` (DNS challenge path) was only listening on port 443, missing the port 80 HTTP→HTTPS redirect that both `ServeTLS` and `ServeTLSSelfSigned` have
- Adds the same redirect handler pattern used by the other TLS modes, including localhost/IP passthrough and graceful shutdown

## Context

Discovered while setting up a personal server using `acme_dns_provider = "dnsimple"` for DNS-01 challenges (server is behind Tailscale, not publicly reachable on 80/443). HTTP requests to port 80 were failing with connection refused instead of redirecting to HTTPS.

## Test plan

- [ ] Deploy to a server using DNS challenge mode and verify port 80 opens
- [ ] Verify `curl -I http://<host>` returns 302 redirect to HTTPS
- [ ] Verify localhost/IP requests pass through without redirect