### PR TITLE
Add timeout for sandboxes stuck in PENDING state

### DIFF
--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -22,6 +22,11 @@ const (
 	// MaxPoolSize is the maximum number of sandboxes allowed in a pool
 	// This prevents runaway growth even if there are bugs in scaling logic
 	MaxPoolSize = 20
+
+	// PendingSandboxTimeout is the maximum time a sandbox can stay in PENDING
+	// state before being marked STOPPED for cleanup. PENDING sandboxes count
+	// toward pool capacity, so stuck ones block new sandbox creation.
+	PendingSandboxTimeout = 5 * time.Minute
 )
 
 // Manager reconciles SandboxPool entities by ensuring the actual number of
@@ -559,6 +564,9 @@ func (m *Manager) runScaleDownMonitor(ctx context.Context) {
 			if err := m.cleanupEmptyPools(ctx); err != nil {
 				m.log.Error("pool cleanup failed", "error", err)
 			}
+			if err := m.checkForStalePendingSandboxes(ctx); err != nil {
+				m.log.Error("stale pending sandbox check failed", "error", err)
+			}
 		}
 	}
 }
@@ -750,6 +758,58 @@ func (m *Manager) cleanupEmptyPools(ctx context.Context) error {
 		}
 
 		m.log.Info("deleted empty pool", "pool", pool.ID)
+	}
+
+	return nil
+}
+
+// checkForStalePendingSandboxes finds sandboxes stuck in PENDING state longer
+// than PendingSandboxTimeout and marks them STOPPED. STOPPED triggers the
+// sandbox controller's cleanup path (container shutdown, IP release, etc.)
+// and removes them from pool capacity accounting.
+func (m *Manager) checkForStalePendingSandboxes(ctx context.Context) error {
+	resp, err := m.eac.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return fmt.Errorf("failed to list sandboxes: %w", err)
+	}
+
+	now := time.Now()
+	threshold := now.Add(-PendingSandboxTimeout)
+
+	for _, ent := range resp.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(ent.Entity())
+
+		if sb.Status != compute_v1alpha.PENDING {
+			continue
+		}
+
+		createdAt := time.UnixMilli(ent.CreatedAt())
+		if createdAt.After(threshold) {
+			continue
+		}
+
+		m.log.Warn("marking stale PENDING sandbox as STOPPED",
+			"sandbox", sb.ID,
+			"created_at", createdAt,
+			"age", now.Sub(createdAt))
+
+		if _, err := m.eac.Patch(ctx, entity.New(
+			entity.DBId, sb.ID,
+			(&compute_v1alpha.Sandbox{
+				Status: compute_v1alpha.STOPPED,
+			}).Encode,
+		).Attrs(), 0); err != nil {
+			if errors.Is(err, cond.ErrNotFound{}) {
+				m.log.Warn("sandbox already deleted during stale pending check",
+					"sandbox", sb.ID)
+			} else {
+				m.log.Error("failed to stop stale PENDING sandbox",
+					"sandbox", sb.ID,
+					"error", err)
+			}
+			continue
+		}
 	}
 
 	return nil

--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -1013,6 +1013,169 @@ func TestCleanupEmptyPoolsReferencedByActiveVersion(t *testing.T) {
 	require.NoError(t, err, "pool referenced by active version should not be deleted")
 }
 
+// TestCheckForStalePendingSandboxes tests that PENDING sandboxes older than
+// PendingSandboxTimeout are marked STOPPED, while fresh PENDING and RUNNING
+// sandboxes are left alone.
+func TestCheckForStalePendingSandboxes(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 3,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Create a stale PENDING sandbox (6 minutes old)
+	// Set NowFunc to 6 minutes ago, create the sandbox, then reset
+	staleTime := time.Now().Add(-6 * time.Minute)
+	server.Store.NowFunc = func() time.Time { return staleTime }
+
+	staleSb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.PENDING,
+		Spec:   pool.SandboxSpec,
+	}
+	staleSbID, err := server.Client.Create(ctx, "stale-sb", staleSb,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
+	require.NoError(t, err)
+
+	// Create a fresh PENDING sandbox (1 minute old)
+	freshTime := time.Now().Add(-1 * time.Minute)
+	server.Store.NowFunc = func() time.Time { return freshTime }
+
+	freshSb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.PENDING,
+		Spec:   pool.SandboxSpec,
+	}
+	freshSbID, err := server.Client.Create(ctx, "fresh-sb", freshSb,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
+	require.NoError(t, err)
+
+	// Create a RUNNING sandbox (10 minutes old — should not be affected)
+	oldRunningTime := time.Now().Add(-10 * time.Minute)
+	server.Store.NowFunc = func() time.Time { return oldRunningTime }
+
+	runningSb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+		Spec:   pool.SandboxSpec,
+	}
+	runningSbID, err := server.Client.Create(ctx, "running-sb", runningSb,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
+	require.NoError(t, err)
+
+	// Reset NowFunc to real time
+	server.Store.NowFunc = nil
+
+	// Run the stale pending check
+	manager := NewManager(log, server.EAC)
+	err = manager.checkForStalePendingSandboxes(ctx)
+	require.NoError(t, err)
+
+	// Verify the stale PENDING sandbox was marked STOPPED
+	getSandbox := func(id entity.Id) *compute_v1alpha.Sandbox {
+		t.Helper()
+		resp, err := server.EAC.Get(ctx, id.String())
+		require.NoError(t, err)
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(resp.Entity().Entity())
+		return &sb
+	}
+
+	staleSbAfter := getSandbox(staleSbID)
+	assert.Equal(t, compute_v1alpha.STOPPED, staleSbAfter.Status,
+		"stale PENDING sandbox should be marked STOPPED")
+
+	freshSbAfter := getSandbox(freshSbID)
+	assert.Equal(t, compute_v1alpha.PENDING, freshSbAfter.Status,
+		"fresh PENDING sandbox should remain PENDING")
+
+	runningSbAfter := getSandbox(runningSbID)
+	assert.Equal(t, compute_v1alpha.RUNNING, runningSbAfter.Status,
+		"RUNNING sandbox should remain RUNNING")
+}
+
+// TestStalePendingSandboxUnblocksPoolCapacity tests that marking a stale
+// PENDING sandbox as STOPPED frees pool capacity, allowing the pool to
+// create a replacement sandbox on the next reconcile.
+func TestStalePendingSandboxUnblocksPoolCapacity(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 1,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Create a stuck PENDING sandbox (6 minutes old)
+	staleTime := time.Now().Add(-6 * time.Minute)
+	server.Store.NowFunc = func() time.Time { return staleTime }
+
+	stuckSb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.PENDING,
+		Spec:   pool.SandboxSpec,
+	}
+	_, err = server.Client.Create(ctx, "stuck-sb", stuckSb,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String(), "instance", "0")))
+	require.NoError(t, err)
+
+	server.Store.NowFunc = nil
+
+	manager := NewManager(log, server.EAC)
+
+	// Reconcile: the stuck PENDING sandbox counts as actual=1, desired=1,
+	// so no new sandbox is created
+	reconcilePool(t, ctx, server, manager, pool)
+
+	updatedPool := getPool(t, ctx, server, poolID)
+	assert.Equal(t, int64(1), updatedPool.CurrentInstances,
+		"stuck PENDING sandbox should count as current")
+
+	// Run stale pending cleanup — marks the stuck sandbox STOPPED
+	err = manager.checkForStalePendingSandboxes(ctx)
+	require.NoError(t, err)
+
+	// Reconcile again: STOPPED sandbox no longer counts as actual,
+	// so pool creates a replacement
+	reconcilePool(t, ctx, server, manager, pool)
+
+	updatedPool = getPool(t, ctx, server, poolID)
+	assert.Equal(t, int64(1), updatedPool.CurrentInstances,
+		"pool should have created a replacement sandbox")
+
+	// Verify: there should be 1 PENDING (new replacement) sandbox in the pool
+	// listSandboxesForPool excludes STOPPED, so we only see active ones
+	sandboxes := listSandboxesForPool(t, ctx, server, pool)
+	assert.Equal(t, 1, len(sandboxes),
+		"pool should have exactly 1 active sandbox after cleanup and reconcile")
+	assert.Equal(t, compute_v1alpha.PENDING, sandboxes[0].Status,
+		"replacement sandbox should be PENDING")
+}
+
 // TestCleanupEmptyPoolsNotReferencedByActiveVersion tests that pools ARE deleted
 // when they're not referenced by any app's active version.
 func TestCleanupEmptyPoolsNotReferencedByActiveVersion(t *testing.T) {


### PR DESCRIPTION
Sandboxes can get stuck in PENDING indefinitely — maybe the image pull hangs, maybe containerd hiccups, whatever the cause. The problem is that PENDING sandboxes count toward pool capacity (`actual` includes both RUNNING and PENDING), so a stuck one permanently blocks that capacity slot. The pool thinks it has a sandbox, the sandbox never boots, and nobody gets a replacement.

The fix adds a `checkForStalePendingSandboxes()` check to the pool manager's existing background loop (which already ticks every 30s for scale-down and empty pool cleanup). Any PENDING sandbox older than 5 minutes gets marked STOPPED. We deliberately chose STOPPED over DEAD because a PENDING sandbox may have partially booted — network allocated, pause container started, etc. STOPPED triggers the sandbox controller's full cleanup path (container shutdown, IP release, disk lease release) before it eventually transitions to DEAD. And since the pool only counts RUNNING + PENDING as "actual", the STOPPED sandbox immediately frees up that capacity slot so the pool can create a replacement on the next reconcile.

Closes MIR-627