### PR TITLE
Route env set/delete through deployment service for post-deploy UX

### DIFF
--- a/api/app/envvar.go
+++ b/api/app/envvar.go
@@ -1,0 +1,248 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	coreutil "miren.dev/runtime/api/core"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/idgen"
+)
+
+// EnvVarInput represents an env var to set.
+type EnvVarInput struct {
+	Key       string
+	Value     string
+	Sensitive bool
+}
+
+// MutateResult holds the result of an env var mutation.
+type MutateResult struct {
+	AppVersion *core_v1alpha.AppVersion
+	VersionID  string
+}
+
+// DeleteResult extends MutateResult with source tracking.
+type DeleteResult struct {
+	MutateResult
+	DeletedSources []string
+}
+
+// SetEnvVars resolves the config from baseVersion (or current active if nil),
+// merges env vars (with service scope), creates a new ConfigVersion + AppVersion,
+// and activates it. Returns the newly created AppVersion and its version string.
+func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
+	baseVersion *core_v1alpha.AppVersion, vars []EnvVarInput, service string) (*MutateResult, error) {
+
+	for _, v := range vars {
+		if strings.HasPrefix(v.Key, "MIREN_") {
+			return nil, fmt.Errorf("cannot set MIREN_ environment variables")
+		}
+	}
+
+	appVer, spec, appRec, err := resolveBaseVersion(ctx, ec, appName, baseVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range vars {
+		if service == "" {
+			found := false
+			for i, ev := range spec.Variables {
+				if ev.Key == v.Key {
+					spec.Variables[i].Value = v.Value
+					spec.Variables[i].Sensitive = v.Sensitive
+					spec.Variables[i].Source = "manual"
+					found = true
+					break
+				}
+			}
+			if !found {
+				spec.Variables = append(spec.Variables, core_v1alpha.ConfigSpecVariables{
+					Key:       v.Key,
+					Value:     v.Value,
+					Sensitive: v.Sensitive,
+					Source:    "manual",
+				})
+			}
+		} else {
+			svcFound := false
+			for i := range spec.Services {
+				if spec.Services[i].Name == service {
+					svcFound = true
+					envFound := false
+					for j, e := range spec.Services[i].Env {
+						if e.Key == v.Key {
+							spec.Services[i].Env[j].Value = v.Value
+							spec.Services[i].Env[j].Sensitive = v.Sensitive
+							spec.Services[i].Env[j].Source = "manual"
+							envFound = true
+							break
+						}
+					}
+					if !envFound {
+						spec.Services[i].Env = append(spec.Services[i].Env, core_v1alpha.ConfigSpecServicesEnv{
+							Key:       v.Key,
+							Value:     v.Value,
+							Sensitive: v.Sensitive,
+							Source:    "manual",
+						})
+					}
+					break
+				}
+			}
+			if !svcFound {
+				return nil, fmt.Errorf("service %q not found", service)
+			}
+		}
+	}
+
+	return createNewVersion(ctx, ec, appName, appVer, spec, appRec)
+}
+
+// DeleteEnvVars resolves the config from baseVersion (or current active if nil),
+// removes the specified keys, creates a new ConfigVersion + AppVersion, and
+// activates it. Returns the new version plus the source of each deleted var.
+func DeleteEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
+	baseVersion *core_v1alpha.AppVersion, keys []string, service string) (*DeleteResult, error) {
+
+	appVer, spec, appRec, err := resolveBaseVersion(ctx, ec, appName, baseVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	if appRec.ActiveVersion == "" {
+		return nil, fmt.Errorf("app has no active version")
+	}
+
+	var deletedSources []string
+
+	for _, key := range keys {
+		if service == "" {
+			found := false
+			newVars := make([]core_v1alpha.ConfigSpecVariables, 0, len(spec.Variables))
+			for _, v := range spec.Variables {
+				if v.Key == key {
+					found = true
+					deletedSources = append(deletedSources, v.Source)
+					continue
+				}
+				newVars = append(newVars, v)
+			}
+			if !found {
+				return nil, fmt.Errorf("environment variable %q not found", key)
+			}
+			spec.Variables = newVars
+		} else {
+			svcFound := false
+			for i := range spec.Services {
+				if spec.Services[i].Name == service {
+					svcFound = true
+					envFound := false
+					newEnvs := make([]core_v1alpha.ConfigSpecServicesEnv, 0, len(spec.Services[i].Env))
+					for _, e := range spec.Services[i].Env {
+						if e.Key == key {
+							envFound = true
+							deletedSources = append(deletedSources, e.Source)
+							continue
+						}
+						newEnvs = append(newEnvs, e)
+					}
+					if !envFound {
+						return nil, fmt.Errorf("environment variable %q not found in service %q", key, service)
+					}
+					spec.Services[i].Env = newEnvs
+					break
+				}
+			}
+			if !svcFound {
+				return nil, fmt.Errorf("service %q not found", service)
+			}
+		}
+	}
+
+	result, err := createNewVersion(ctx, ec, appName, appVer, spec, appRec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DeleteResult{
+		MutateResult:   *result,
+		DeletedSources: deletedSources,
+	}, nil
+}
+
+// resolveBaseVersion loads the app, resolves the base version and config spec.
+// If baseVersion is nil, the current active version is used.
+func resolveBaseVersion(ctx context.Context, ec *entityserver.Client, appName string,
+	baseVersion *core_v1alpha.AppVersion) (*core_v1alpha.AppVersion, *core_v1alpha.ConfigSpec, *core_v1alpha.App, error) {
+
+	var appRec core_v1alpha.App
+	err := ec.Get(ctx, appName, &appRec)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var appVer core_v1alpha.AppVersion
+	var spec core_v1alpha.ConfigSpec
+
+	if baseVersion != nil {
+		appVer = *baseVersion
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVer)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to resolve config: %w", err)
+		}
+		spec = *resolvedCfg
+	} else if appRec.ActiveVersion != "" {
+		err = ec.GetById(ctx, appRec.ActiveVersion, &appVer)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVer)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to resolve config: %w", err)
+		}
+		spec = *resolvedCfg
+	} else {
+		appVer.App = appRec.ID
+	}
+
+	return &appVer, &spec, &appRec, nil
+}
+
+// createNewVersion creates a ConfigVersion + AppVersion from the mutated spec and activates it.
+func createNewVersion(ctx context.Context, ec *entityserver.Client, appName string,
+	appVer *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec, appRec *core_v1alpha.App) (*MutateResult, error) {
+
+	appVer.Version = appName + "-" + idgen.Gen("v")
+
+	configVer := &core_v1alpha.ConfigVersion{
+		App:  appVer.App,
+		Spec: *spec,
+	}
+	cvName := appVer.Version + "-cfg"
+	cvid, err := ec.Create(ctx, cvName, configVer)
+	if err != nil {
+		return nil, fmt.Errorf("error creating config version: %w", err)
+	}
+	appVer.ConfigVersion = cvid
+	appVer.Config = core_v1alpha.Config{}
+
+	avid, err := ec.Create(ctx, appVer.Version, appVer)
+	if err != nil {
+		return nil, err
+	}
+
+	appRec.ActiveVersion = avid
+	err = ec.Update(ctx, appRec)
+	if err != nil {
+		return nil, fmt.Errorf("error updating app entity: %w", err)
+	}
+
+	return &MutateResult{
+		AppVersion: appVer,
+		VersionID:  appVer.Version,
+	}, nil
+}

--- a/api/deployment/deployment_v1alpha/rpc.gen.go
+++ b/api/deployment/deployment_v1alpha/rpc.gen.go
@@ -1606,6 +1606,253 @@ func (v *DeploymentDeployVersionResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type deploymentSetEnvVarsArgsData struct {
+	AppName   *string                 `cbor:"0,keyasint,omitempty" json:"app_name,omitempty"`
+	ClusterId *string                 `cbor:"1,keyasint,omitempty" json:"cluster_id,omitempty"`
+	Vars      *[]*EnvironmentVariable `cbor:"2,keyasint,omitempty" json:"vars,omitempty"`
+	Service   *string                 `cbor:"3,keyasint,omitempty" json:"service,omitempty"`
+}
+
+type DeploymentSetEnvVarsArgs struct {
+	call rpc.Call
+	data deploymentSetEnvVarsArgsData
+}
+
+func (v *DeploymentSetEnvVarsArgs) HasAppName() bool {
+	return v.data.AppName != nil
+}
+
+func (v *DeploymentSetEnvVarsArgs) AppName() string {
+	if v.data.AppName == nil {
+		return ""
+	}
+	return *v.data.AppName
+}
+
+func (v *DeploymentSetEnvVarsArgs) HasClusterId() bool {
+	return v.data.ClusterId != nil
+}
+
+func (v *DeploymentSetEnvVarsArgs) ClusterId() string {
+	if v.data.ClusterId == nil {
+		return ""
+	}
+	return *v.data.ClusterId
+}
+
+func (v *DeploymentSetEnvVarsArgs) HasVars() bool {
+	return v.data.Vars != nil
+}
+
+func (v *DeploymentSetEnvVarsArgs) Vars() []*EnvironmentVariable {
+	if v.data.Vars == nil {
+		return nil
+	}
+	return *v.data.Vars
+}
+
+func (v *DeploymentSetEnvVarsArgs) HasService() bool {
+	return v.data.Service != nil
+}
+
+func (v *DeploymentSetEnvVarsArgs) Service() string {
+	if v.data.Service == nil {
+		return ""
+	}
+	return *v.data.Service
+}
+
+func (v *DeploymentSetEnvVarsArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *DeploymentSetEnvVarsArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *DeploymentSetEnvVarsArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *DeploymentSetEnvVarsArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type deploymentSetEnvVarsResultsData struct {
+	VersionId  *string             `cbor:"0,keyasint,omitempty" json:"version_id,omitempty"`
+	Deployment *DeploymentInfo     `cbor:"1,keyasint,omitempty" json:"deployment,omitempty"`
+	Error      *string             `cbor:"2,keyasint,omitempty" json:"error,omitempty"`
+	LockInfo   *DeploymentLockInfo `cbor:"3,keyasint,omitempty" json:"lock_info,omitempty"`
+	AccessInfo **AccessInfo        `cbor:"4,keyasint,omitempty" json:"access_info,omitempty"`
+}
+
+type DeploymentSetEnvVarsResults struct {
+	call rpc.Call
+	data deploymentSetEnvVarsResultsData
+}
+
+func (v *DeploymentSetEnvVarsResults) SetVersionId(version_id string) {
+	v.data.VersionId = &version_id
+}
+
+func (v *DeploymentSetEnvVarsResults) SetDeployment(deployment *DeploymentInfo) {
+	v.data.Deployment = deployment
+}
+
+func (v *DeploymentSetEnvVarsResults) SetError(error string) {
+	v.data.Error = &error
+}
+
+func (v *DeploymentSetEnvVarsResults) SetLockInfo(lock_info *DeploymentLockInfo) {
+	v.data.LockInfo = lock_info
+}
+
+func (v *DeploymentSetEnvVarsResults) SetAccessInfo(access_info **AccessInfo) {
+	v.data.AccessInfo = access_info
+}
+
+func (v *DeploymentSetEnvVarsResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *DeploymentSetEnvVarsResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *DeploymentSetEnvVarsResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *DeploymentSetEnvVarsResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type deploymentDeleteEnvVarsArgsData struct {
+	AppName   *string   `cbor:"0,keyasint,omitempty" json:"app_name,omitempty"`
+	ClusterId *string   `cbor:"1,keyasint,omitempty" json:"cluster_id,omitempty"`
+	Keys      *[]string `cbor:"2,keyasint,omitempty" json:"keys,omitempty"`
+	Service   *string   `cbor:"3,keyasint,omitempty" json:"service,omitempty"`
+}
+
+type DeploymentDeleteEnvVarsArgs struct {
+	call rpc.Call
+	data deploymentDeleteEnvVarsArgsData
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) HasAppName() bool {
+	return v.data.AppName != nil
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) AppName() string {
+	if v.data.AppName == nil {
+		return ""
+	}
+	return *v.data.AppName
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) HasClusterId() bool {
+	return v.data.ClusterId != nil
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) ClusterId() string {
+	if v.data.ClusterId == nil {
+		return ""
+	}
+	return *v.data.ClusterId
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) HasKeys() bool {
+	return v.data.Keys != nil
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) Keys() []string {
+	if v.data.Keys == nil {
+		return nil
+	}
+	return *v.data.Keys
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) HasService() bool {
+	return v.data.Service != nil
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) Service() string {
+	if v.data.Service == nil {
+		return ""
+	}
+	return *v.data.Service
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *DeploymentDeleteEnvVarsArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type deploymentDeleteEnvVarsResultsData struct {
+	VersionId      *string             `cbor:"0,keyasint,omitempty" json:"version_id,omitempty"`
+	Deployment     *DeploymentInfo     `cbor:"1,keyasint,omitempty" json:"deployment,omitempty"`
+	Error          *string             `cbor:"2,keyasint,omitempty" json:"error,omitempty"`
+	LockInfo       *DeploymentLockInfo `cbor:"3,keyasint,omitempty" json:"lock_info,omitempty"`
+	AccessInfo     **AccessInfo        `cbor:"4,keyasint,omitempty" json:"access_info,omitempty"`
+	DeletedSources *[]string           `cbor:"5,keyasint,omitempty" json:"deleted_sources,omitempty"`
+}
+
+type DeploymentDeleteEnvVarsResults struct {
+	call rpc.Call
+	data deploymentDeleteEnvVarsResultsData
+}
+
+func (v *DeploymentDeleteEnvVarsResults) SetVersionId(version_id string) {
+	v.data.VersionId = &version_id
+}
+
+func (v *DeploymentDeleteEnvVarsResults) SetDeployment(deployment *DeploymentInfo) {
+	v.data.Deployment = deployment
+}
+
+func (v *DeploymentDeleteEnvVarsResults) SetError(error string) {
+	v.data.Error = &error
+}
+
+func (v *DeploymentDeleteEnvVarsResults) SetLockInfo(lock_info *DeploymentLockInfo) {
+	v.data.LockInfo = lock_info
+}
+
+func (v *DeploymentDeleteEnvVarsResults) SetAccessInfo(access_info **AccessInfo) {
+	v.data.AccessInfo = access_info
+}
+
+func (v *DeploymentDeleteEnvVarsResults) SetDeletedSources(deleted_sources *[]string) {
+	v.data.DeletedSources = deleted_sources
+}
+
+func (v *DeploymentDeleteEnvVarsResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *DeploymentDeleteEnvVarsResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *DeploymentDeleteEnvVarsResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *DeploymentDeleteEnvVarsResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type DeploymentCreateDeployment struct {
 	rpc.Call
 	args    DeploymentCreateDeploymentArgs
@@ -1866,6 +2113,58 @@ func (t *DeploymentDeployVersion) Results() *DeploymentDeployVersionResults {
 	return results
 }
 
+type DeploymentSetEnvVars struct {
+	rpc.Call
+	args    DeploymentSetEnvVarsArgs
+	results DeploymentSetEnvVarsResults
+}
+
+func (t *DeploymentSetEnvVars) Args() *DeploymentSetEnvVarsArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *DeploymentSetEnvVars) Results() *DeploymentSetEnvVarsResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type DeploymentDeleteEnvVars struct {
+	rpc.Call
+	args    DeploymentDeleteEnvVarsArgs
+	results DeploymentDeleteEnvVarsResults
+}
+
+func (t *DeploymentDeleteEnvVars) Args() *DeploymentDeleteEnvVarsArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *DeploymentDeleteEnvVars) Results() *DeploymentDeleteEnvVarsResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type Deployment interface {
 	CreateDeployment(ctx context.Context, state *DeploymentCreateDeployment) error
 	UpdateDeploymentStatus(ctx context.Context, state *DeploymentUpdateDeploymentStatus) error
@@ -1877,6 +2176,8 @@ type Deployment interface {
 	GetActiveDeployment(ctx context.Context, state *DeploymentGetActiveDeployment) error
 	CancelDeployment(ctx context.Context, state *DeploymentCancelDeployment) error
 	DeployVersion(ctx context.Context, state *DeploymentDeployVersion) error
+	SetEnvVars(ctx context.Context, state *DeploymentSetEnvVars) error
+	DeleteEnvVars(ctx context.Context, state *DeploymentDeleteEnvVars) error
 }
 
 type reexportDeployment struct {
@@ -1920,6 +2221,14 @@ func (reexportDeployment) CancelDeployment(ctx context.Context, state *Deploymen
 }
 
 func (reexportDeployment) DeployVersion(ctx context.Context, state *DeploymentDeployVersion) error {
+	panic("not implemented")
+}
+
+func (reexportDeployment) SetEnvVars(ctx context.Context, state *DeploymentSetEnvVars) error {
+	panic("not implemented")
+}
+
+func (reexportDeployment) DeleteEnvVars(ctx context.Context, state *DeploymentDeleteEnvVars) error {
 	panic("not implemented")
 }
 
@@ -2017,6 +2326,24 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeployVersion(ctx, &DeploymentDeployVersion{Call: call})
+			},
+		},
+		{
+			Name:          "SetEnvVars",
+			InterfaceName: "Deployment",
+			Index:         10,
+			Public:        false,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.SetEnvVars(ctx, &DeploymentSetEnvVars{Call: call})
+			},
+		},
+		{
+			Name:          "DeleteEnvVars",
+			InterfaceName: "Deployment",
+			Index:         11,
+			Public:        false,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.DeleteEnvVars(ctx, &DeploymentDeleteEnvVars{Call: call})
 			},
 		},
 	}
@@ -2388,4 +2715,157 @@ func (v DeploymentClient) DeployVersion(ctx context.Context, app_name string, cl
 	}
 
 	return &DeploymentClientDeployVersionResults{client: v.Client, data: ret}, nil
+}
+
+type DeploymentClientSetEnvVarsResults struct {
+	client rpc.Client
+	data   deploymentSetEnvVarsResultsData
+}
+
+func (v *DeploymentClientSetEnvVarsResults) HasVersionId() bool {
+	return v.data.VersionId != nil
+}
+
+func (v *DeploymentClientSetEnvVarsResults) VersionId() string {
+	if v.data.VersionId == nil {
+		return ""
+	}
+	return *v.data.VersionId
+}
+
+func (v *DeploymentClientSetEnvVarsResults) HasDeployment() bool {
+	return v.data.Deployment != nil
+}
+
+func (v *DeploymentClientSetEnvVarsResults) Deployment() *DeploymentInfo {
+	return v.data.Deployment
+}
+
+func (v *DeploymentClientSetEnvVarsResults) HasError() bool {
+	return v.data.Error != nil
+}
+
+func (v *DeploymentClientSetEnvVarsResults) Error() string {
+	if v.data.Error == nil {
+		return ""
+	}
+	return *v.data.Error
+}
+
+func (v *DeploymentClientSetEnvVarsResults) HasLockInfo() bool {
+	return v.data.LockInfo != nil
+}
+
+func (v *DeploymentClientSetEnvVarsResults) LockInfo() *DeploymentLockInfo {
+	return v.data.LockInfo
+}
+
+func (v *DeploymentClientSetEnvVarsResults) HasAccessInfo() bool {
+	return v.data.AccessInfo != nil
+}
+
+func (v *DeploymentClientSetEnvVarsResults) AccessInfo() *AccessInfo {
+	if v.data.AccessInfo == nil {
+		return nil
+	}
+	return *v.data.AccessInfo
+}
+
+func (v DeploymentClient) SetEnvVars(ctx context.Context, app_name string, cluster_id string, vars []*EnvironmentVariable, service string) (*DeploymentClientSetEnvVarsResults, error) {
+	args := DeploymentSetEnvVarsArgs{}
+	args.data.AppName = &app_name
+	args.data.ClusterId = &cluster_id
+	args.data.Vars = &vars
+	args.data.Service = &service
+
+	var ret deploymentSetEnvVarsResultsData
+
+	err := v.Call(ctx, "SetEnvVars", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DeploymentClientSetEnvVarsResults{client: v.Client, data: ret}, nil
+}
+
+type DeploymentClientDeleteEnvVarsResults struct {
+	client rpc.Client
+	data   deploymentDeleteEnvVarsResultsData
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) HasVersionId() bool {
+	return v.data.VersionId != nil
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) VersionId() string {
+	if v.data.VersionId == nil {
+		return ""
+	}
+	return *v.data.VersionId
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) HasDeployment() bool {
+	return v.data.Deployment != nil
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) Deployment() *DeploymentInfo {
+	return v.data.Deployment
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) HasError() bool {
+	return v.data.Error != nil
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) Error() string {
+	if v.data.Error == nil {
+		return ""
+	}
+	return *v.data.Error
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) HasLockInfo() bool {
+	return v.data.LockInfo != nil
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) LockInfo() *DeploymentLockInfo {
+	return v.data.LockInfo
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) HasAccessInfo() bool {
+	return v.data.AccessInfo != nil
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) AccessInfo() *AccessInfo {
+	if v.data.AccessInfo == nil {
+		return nil
+	}
+	return *v.data.AccessInfo
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) HasDeletedSources() bool {
+	return v.data.DeletedSources != nil
+}
+
+func (v *DeploymentClientDeleteEnvVarsResults) DeletedSources() []string {
+	if v.data.DeletedSources == nil {
+		return nil
+	}
+	return *v.data.DeletedSources
+}
+
+func (v DeploymentClient) DeleteEnvVars(ctx context.Context, app_name string, cluster_id string, keys []string, service string) (*DeploymentClientDeleteEnvVarsResults, error) {
+	args := DeploymentDeleteEnvVarsArgs{}
+	args.data.AppName = &app_name
+	args.data.ClusterId = &cluster_id
+	args.data.Keys = &keys
+	args.data.Service = &service
+
+	var ret deploymentDeleteEnvVarsResultsData
+
+	err := v.Call(ctx, "DeleteEnvVars", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DeploymentClientDeleteEnvVarsResults{client: v.Client, data: ret}, nil
 }

--- a/api/deployment/rpc.yml
+++ b/api/deployment/rpc.yml
@@ -204,6 +204,75 @@ interfaces:
             type: '*AccessInfo'
             doc: Information about how to access the deployed app
 
+      - name: SetEnvVars
+        index: 10
+        doc: Set environment variables on an app, creating a new version and deployment record. Returns deployment info for activation polling.
+        parameters:
+          - name: app_name
+            type: string
+            doc: The application name
+          - name: cluster_id
+            type: string
+            doc: The cluster where deployment is happening
+          - name: vars
+            type: '[]*EnvironmentVariable'
+            doc: Environment variables to set
+          - name: service
+            type: string
+            doc: Service name to scope env vars to (optional, empty means global)
+        results:
+          - name: version_id
+            type: string
+            doc: The new version string
+          - name: deployment
+            type: DeploymentInfo
+            doc: The deployment record
+          - name: error
+            type: string
+            doc: Error message if operation failed
+          - name: lock_info
+            type: DeploymentLockInfo
+            doc: Structured information about the deployment lock (if blocked)
+          - name: access_info
+            type: '*AccessInfo'
+            doc: Information about how to access the deployed app
+
+      - name: DeleteEnvVars
+        index: 11
+        doc: Delete environment variables from an app, creating a new version and deployment record. Returns deployment info for activation polling.
+        parameters:
+          - name: app_name
+            type: string
+            doc: The application name
+          - name: cluster_id
+            type: string
+            doc: The cluster where deployment is happening
+          - name: keys
+            type: '[]string'
+            doc: Environment variable keys to delete
+          - name: service
+            type: string
+            doc: Service name to scope deletion to (optional, empty means global)
+        results:
+          - name: version_id
+            type: string
+            doc: The new version string
+          - name: deployment
+            type: DeploymentInfo
+            doc: The deployment record
+          - name: error
+            type: string
+            doc: Error message if operation failed
+          - name: lock_info
+            type: DeploymentLockInfo
+            doc: Structured information about the deployment lock (if blocked)
+          - name: access_info
+            type: '*AccessInfo'
+            doc: Information about how to access the deployed app
+          - name: deleted_sources
+            type: '[]string'
+            doc: Source of each deleted variable (config or manual)
+
 types:
   - type: DeploymentInfo
     doc: Information about a deployment

--- a/cli/commands/activation_poller.go
+++ b/cli/commands/activation_poller.go
@@ -97,6 +97,21 @@ func checkVersionActive(ctx context.Context, getter appInfoGetter, appName, vers
 	return true, fmt.Sprintf(" — %d pool(s) assigned", len(pools))
 }
 
+// displayLockInfo shows a deployment lock error message with structured details.
+func displayLockInfo(ctx *Context, operation string, lockInfo *deployment_v1alpha.DeploymentLockInfo) {
+	ctx.Printf("\n❌ %s blocked:\n\n", operation)
+	ctx.Printf("Another deployment is already in progress for app '%s' on cluster '%s'.\n\n",
+		lockInfo.AppName(), lockInfo.ClusterId())
+	ctx.Printf("  • Started by: %s\n", lockInfo.StartedBy())
+	if lockInfo.HasStartedAt() && lockInfo.StartedAt() != nil {
+		startedAt := time.Unix(lockInfo.StartedAt().Seconds(), 0)
+		ctx.Printf("  • Started at: %s (%s ago)\n",
+			startedAt.Format("2006-01-02 15:04:05 MST"),
+			time.Since(startedAt).Round(time.Second))
+	}
+	ctx.Printf("  • Current phase: %s\n", lockInfo.CurrentPhase())
+}
+
 // displayDeployVersionAccessInfo shows route/access information from the
 // DeployVersion RPC response, mirroring the displayAccessInfo function
 // used by the full deploy path.

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/api/deployment/deployment_v1alpha"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -116,14 +117,13 @@ func EnvSet(ctx *Context, opts struct {
 		return err
 	}
 
-	cl, err := ctx.RPCClient("dev.miren.runtime/app")
+	depCl, err := ctx.RPCClient("dev.miren.runtime/deployment")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to connect to deployment service: %w", err)
 	}
+	depClient := deployment_v1alpha.NewDeploymentClient(depCl)
 
-	ac := app_v1alpha.NewCrudClient(cl)
-
-	var vars []*app_v1alpha.NamedValue
+	var vars []*deployment_v1alpha.EnvironmentVariable
 
 	for _, spec := range specs {
 		if spec.FromFile {
@@ -134,19 +134,39 @@ func EnvSet(ctx *Context, opts struct {
 			ctx.Printf("setting %s...\n", spec.Key)
 		}
 
-		nv := &app_v1alpha.NamedValue{}
-		nv.SetKey(spec.Key)
-		nv.SetValue(spec.Value)
-		nv.SetSensitive(spec.Sensitive)
-		vars = append(vars, nv)
+		ev := &deployment_v1alpha.EnvironmentVariable{}
+		ev.SetKey(spec.Key)
+		ev.SetValue(spec.Value)
+		ev.SetSensitive(spec.Sensitive)
+		vars = append(vars, ev)
 	}
 
-	res, err := ac.SetEnvVars(ctx, opts.App, vars, opts.Service)
+	res, err := depClient.SetEnvVars(ctx, opts.App, ctx.ClusterName, vars, opts.Service)
 	if err != nil {
 		return err
 	}
 
-	ctx.Printf("new version id: %s\n", res.VersionId())
+	if res.HasError() && res.Error() != "" {
+		if res.HasLockInfo() && res.LockInfo() != nil {
+			displayLockInfo(ctx, "env set", res.LockInfo())
+		} else {
+			ctx.Printf("\nenv set failed: %s\n", res.Error())
+		}
+		return fmt.Errorf("env set failed")
+	}
+
+	ctx.Printf("✓ Set env vars on %s — new version: %s\n", opts.App, res.VersionId())
+
+	appCl, appErr := ctx.RPCClient(rpcAppStatus)
+	if appErr == nil {
+		appStatusClient := app_v1alpha.NewAppStatusClient(appCl)
+		waitForActivation(ctx, appStatusClient, opts.App, res.VersionId())
+	}
+
+	if res.HasAccessInfo() && res.AccessInfo() != nil {
+		displayDeployVersionAccessInfo(ctx, opts.App, res.AccessInfo())
+	}
+
 	return nil
 }
 
@@ -328,13 +348,6 @@ func EnvDelete(ctx *Context, opts struct {
 		return fmt.Errorf("no environment variables specified")
 	}
 
-	cl, err := ctx.RPCClient("dev.miren.runtime/app")
-	if err != nil {
-		return err
-	}
-
-	ac := app_v1alpha.NewCrudClient(cl)
-
 	// Ask for confirmation unless --force is used
 	if !opts.Force {
 		var message string
@@ -358,35 +371,61 @@ func EnvDelete(ctx *Context, opts struct {
 		}
 	}
 
-	var lastVersionId string
-	var configVarsDeleted []string
+	depCl, err := ctx.RPCClient("dev.miren.runtime/deployment")
+	if err != nil {
+		return fmt.Errorf("failed to connect to deployment service: %w", err)
+	}
+	depClient := deployment_v1alpha.NewDeploymentClient(depCl)
 
-	// Delete each variable using the targeted RPC
 	for _, key := range opts.Keys {
 		ctx.Printf("deleting %s...\n", key)
-		res, err := ac.DeleteEnvVar(ctx, opts.App, key, opts.Service)
-		if err != nil {
-			return err
-		}
-		lastVersionId = res.VersionId()
+	}
 
-		// Track config-sourced vars for warning
-		if res.DeletedSource() == "config" {
-			configVarsDeleted = append(configVarsDeleted, key)
+	res, err := depClient.DeleteEnvVars(ctx, opts.App, ctx.ClusterName, opts.Keys, opts.Service)
+	if err != nil {
+		return err
+	}
+
+	if res.HasError() && res.Error() != "" {
+		if res.HasLockInfo() && res.LockInfo() != nil {
+			displayLockInfo(ctx, "env delete", res.LockInfo())
+		} else {
+			ctx.Printf("\nenv delete failed: %s\n", res.Error())
+		}
+		return fmt.Errorf("env delete failed")
+	}
+
+	ctx.Printf("✓ Deleted env vars from %s — new version: %s\n", opts.App, res.VersionId())
+
+	// Warn about config vars that will reappear on next deploy
+	if res.HasDeletedSources() {
+		var configVarsDeleted []string
+		deletedSources := res.DeletedSources()
+		for i, source := range deletedSources {
+			if source == "config" && i < len(opts.Keys) {
+				configVarsDeleted = append(configVarsDeleted, opts.Keys[i])
+			}
+		}
+
+		if len(configVarsDeleted) > 0 {
+			if len(configVarsDeleted) == 1 {
+				ctx.Printf("\nWarning: %s was defined in app.toml and will reappear on next deploy.\n", configVarsDeleted[0])
+				ctx.Printf("To permanently remove it, delete it from .miren/app.toml.\n")
+			} else {
+				ctx.Printf("\nWarning: %s were defined in app.toml and will reappear on next deploy.\n", strings.Join(configVarsDeleted, ", "))
+				ctx.Printf("To permanently remove them, delete them from .miren/app.toml.\n")
+			}
 		}
 	}
 
-	ctx.Printf("new version id: %s\n", lastVersionId)
+	appCl, appErr := ctx.RPCClient(rpcAppStatus)
+	if appErr == nil {
+		appStatusClient := app_v1alpha.NewAppStatusClient(appCl)
+		waitForActivation(ctx, appStatusClient, opts.App, res.VersionId())
+	}
 
-	// Warn about config vars that will reappear on next deploy
-	if len(configVarsDeleted) > 0 {
-		if len(configVarsDeleted) == 1 {
-			ctx.Printf("\nWarning: %s was defined in app.toml and will reappear on next deploy.\n", configVarsDeleted[0])
-			ctx.Printf("To permanently remove it, delete it from .miren/app.toml.\n")
-		} else {
-			ctx.Printf("\nWarning: %s were defined in app.toml and will reappear on next deploy.\n", strings.Join(configVarsDeleted, ", "))
-			ctx.Printf("To permanently remove them, delete them from .miren/app.toml.\n")
-		}
+	if res.HasAccessInfo() && res.AccessInfo() != nil {
+		displayDeployVersionAccessInfo(ctx, opts.App, res.AccessInfo())
 	}
 
 	return nil

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 
+	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/app/app_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -396,120 +397,18 @@ func (r *AppInfo) SetHost(ctx context.Context, state *app_v1alpha.CrudSetHost) e
 	return nil
 }
 
-type envVar struct {
-	Key       string
-	Value     string
-	Sensitive bool
-}
-
-func (r *AppInfo) setEnvVars(ctx context.Context, name string, vars []envVar, service string) (string, error) {
-	for _, v := range vars {
-		if strings.HasPrefix(v.Key, "MIREN_") {
-			return "", fmt.Errorf("cannot set MIREN_ environment variables")
-		}
-	}
-
-	var appRec core_v1alpha.App
-	err := r.EC.Get(ctx, name, &appRec)
+func (r *AppInfo) setEnvVars(ctx context.Context, name string, vars []appclient.EnvVarInput, service string) (string, error) {
+	result, err := appclient.SetEnvVars(ctx, r.EC, name, nil, vars, service)
 	if err != nil {
 		return "", err
 	}
-
-	var appVer core_v1alpha.AppVersion
-	var spec core_v1alpha.ConfigSpec
-	if appRec.ActiveVersion != "" {
-		err = r.EC.GetById(ctx, appRec.ActiveVersion, &appVer)
-		if err != nil {
-			return "", err
-		}
-		resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
-		if err != nil {
-			return "", fmt.Errorf("failed to resolve config: %w", err)
-		}
-		spec = *resolvedCfg
-	} else {
-		appVer.App = appRec.ID
-	}
-
-	for _, v := range vars {
-		if service == "" {
-			found := false
-			for i, ev := range spec.Variables {
-				if ev.Key == v.Key {
-					spec.Variables[i].Value = v.Value
-					spec.Variables[i].Sensitive = v.Sensitive
-					spec.Variables[i].Source = "manual"
-					found = true
-					break
-				}
-			}
-			if !found {
-				spec.Variables = append(spec.Variables, core_v1alpha.ConfigSpecVariables{
-					Key:       v.Key,
-					Value:     v.Value,
-					Sensitive: v.Sensitive,
-					Source:    "manual",
-				})
-			}
-		} else {
-			svcFound := false
-			for i := range spec.Services {
-				if spec.Services[i].Name == service {
-					svcFound = true
-					envFound := false
-					for j, e := range spec.Services[i].Env {
-						if e.Key == v.Key {
-							spec.Services[i].Env[j].Value = v.Value
-							spec.Services[i].Env[j].Sensitive = v.Sensitive
-							spec.Services[i].Env[j].Source = "manual"
-							envFound = true
-							break
-						}
-					}
-					if !envFound {
-						spec.Services[i].Env = append(spec.Services[i].Env, core_v1alpha.ConfigSpecServicesEnv{
-							Key:       v.Key,
-							Value:     v.Value,
-							Sensitive: v.Sensitive,
-							Source:    "manual",
-						})
-					}
-					break
-				}
-			}
-			if !svcFound {
-				return "", fmt.Errorf("service %q not found", service)
-			}
-		}
-	}
-
-	appVer.Version = name + "-" + idgen.Gen("v")
-
-	cvid, err := r.createConfigVersion(ctx, &spec, appVer.App, appVer.Version)
-	if err != nil {
-		return "", fmt.Errorf("error creating config version: %w", err)
-	}
-	appVer.ConfigVersion = cvid
-	appVer.Config = core_v1alpha.Config{}
-
-	avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
-	if err != nil {
-		return "", err
-	}
-
-	appRec.ActiveVersion = avid
-	err = r.EC.Update(ctx, &appRec)
-	if err != nil {
-		return "", fmt.Errorf("error updating app entity: %w", err)
-	}
-
-	return appVer.Version, nil
+	return result.VersionID, nil
 }
 
 func (r *AppInfo) SetEnvVar(ctx context.Context, state *app_v1alpha.CrudSetEnvVar) error {
 	args := state.Args()
 
-	versionId, err := r.setEnvVars(ctx, args.App(), []envVar{
+	versionId, err := r.setEnvVars(ctx, args.App(), []appclient.EnvVarInput{
 		{Key: args.Key(), Value: args.Value(), Sensitive: args.Sensitive()},
 	}, args.Service())
 	if err != nil {
@@ -528,9 +427,9 @@ func (r *AppInfo) SetEnvVars(ctx context.Context, state *app_v1alpha.CrudSetEnvV
 		return fmt.Errorf("no environment variables provided")
 	}
 
-	vars := make([]envVar, len(rpcVars))
+	vars := make([]appclient.EnvVarInput, len(rpcVars))
 	for i, v := range rpcVars {
-		vars[i] = envVar{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive()}
+		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive()}
 	}
 
 	versionId, err := r.setEnvVars(ctx, args.App(), vars, args.Service())
@@ -544,101 +443,16 @@ func (r *AppInfo) SetEnvVars(ctx context.Context, state *app_v1alpha.CrudSetEnvV
 
 func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDeleteEnvVar) error {
 	args := state.Args()
-	name := args.App()
-	key := args.Key()
-	service := args.Service()
 
-	var appRec core_v1alpha.App
-	err := r.EC.Get(ctx, name, &appRec)
+	result, err := appclient.DeleteEnvVars(ctx, r.EC, args.App(), nil, []string{args.Key()}, args.Service())
 	if err != nil {
 		return err
 	}
 
-	var appVer core_v1alpha.AppVersion
-	var spec core_v1alpha.ConfigSpec
-	if appRec.ActiveVersion != "" {
-		err = r.EC.GetById(ctx, appRec.ActiveVersion, &appVer)
-		if err != nil {
-			return err
-		}
-		resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
-		if err != nil {
-			return fmt.Errorf("failed to resolve config: %w", err)
-		}
-		spec = *resolvedCfg
-	} else {
-		return fmt.Errorf("app has no active version")
+	state.Results().SetVersionId(result.VersionID)
+	if len(result.DeletedSources) > 0 {
+		state.Results().SetDeletedSource(result.DeletedSources[0])
 	}
-
-	var deletedSource string
-
-	if service == "" {
-		// Global env var
-		found := false
-		newVars := make([]core_v1alpha.ConfigSpecVariables, 0, len(spec.Variables))
-		for _, v := range spec.Variables {
-			if v.Key == key {
-				found = true
-				deletedSource = v.Source
-				continue
-			}
-			newVars = append(newVars, v)
-		}
-		if !found {
-			return fmt.Errorf("environment variable %q not found", key)
-		}
-		spec.Variables = newVars
-	} else {
-		// Per-service env var
-		svcFound := false
-		for i := range spec.Services {
-			if spec.Services[i].Name == service {
-				svcFound = true
-				envFound := false
-				newEnvs := make([]core_v1alpha.ConfigSpecServicesEnv, 0, len(spec.Services[i].Env))
-				for _, e := range spec.Services[i].Env {
-					if e.Key == key {
-						envFound = true
-						deletedSource = e.Source
-						continue
-					}
-					newEnvs = append(newEnvs, e)
-				}
-				if !envFound {
-					return fmt.Errorf("environment variable %q not found in service %q", key, service)
-				}
-				spec.Services[i].Env = newEnvs
-				break
-			}
-		}
-		if !svcFound {
-			return fmt.Errorf("service %q not found", service)
-		}
-	}
-
-	appVer.Version = name + "-" + idgen.Gen("v")
-
-	// Create ConfigVersion as the sole config store
-	cvid, err := r.createConfigVersion(ctx, &spec, appVer.App, appVer.Version)
-	if err != nil {
-		return fmt.Errorf("error creating config version: %w", err)
-	}
-	appVer.ConfigVersion = cvid
-	appVer.Config = core_v1alpha.Config{}
-
-	avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
-	if err != nil {
-		return err
-	}
-
-	appRec.ActiveVersion = avid
-	err = r.EC.Update(ctx, &appRec)
-	if err != nil {
-		return fmt.Errorf("error updating app entity: %w", err)
-	}
-
-	state.Results().SetVersionId(appVer.Version)
-	state.Results().SetDeletedSource(deletedSource)
 	return nil
 }
 

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -883,6 +883,220 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	return nil
 }
 
+func (d *DeploymentServer) SetEnvVars(ctx context.Context, req *deployment_v1alpha.DeploymentSetEnvVars) error {
+	args := req.Args()
+	results := req.Results()
+
+	if !args.HasAppName() || args.AppName() == "" {
+		return cond.ValidationFailure("missing-field", "app_name is required")
+	}
+	if !args.HasClusterId() || args.ClusterId() == "" {
+		return cond.ValidationFailure("missing-field", "cluster_id is required")
+	}
+	if !args.HasVars() || len(args.Vars()) == 0 {
+		return cond.ValidationFailure("missing-field", "vars is required")
+	}
+
+	appName := args.AppName()
+	clusterId := args.ClusterId()
+	service := ""
+	if args.HasService() {
+		service = args.Service()
+	}
+
+	// Convert RPC vars to shared helper input
+	vars := make([]appclient.EnvVarInput, len(args.Vars()))
+	for i, v := range args.Vars() {
+		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive()}
+	}
+
+	// Call shared helper to create new version
+	mutResult, err := appclient.SetEnvVars(ctx, d.EC, appName, nil, vars, service)
+	if err != nil {
+		d.Log.Error("Failed to set env vars", "error", err, "app", appName)
+		results.SetError(fmt.Sprintf("failed to set env vars: %v", err))
+		return nil
+	}
+
+	results.SetVersionId(mutResult.VersionID)
+
+	// Create deployment record and handle lock/activation (shared with DeployVersion)
+	deployErr := d.createEnvVarDeployment(ctx, appName, clusterId, mutResult, results)
+	if deployErr != nil {
+		return deployErr
+	}
+
+	return nil
+}
+
+func (d *DeploymentServer) DeleteEnvVars(ctx context.Context, req *deployment_v1alpha.DeploymentDeleteEnvVars) error {
+	args := req.Args()
+	results := req.Results()
+
+	if !args.HasAppName() || args.AppName() == "" {
+		return cond.ValidationFailure("missing-field", "app_name is required")
+	}
+	if !args.HasClusterId() || args.ClusterId() == "" {
+		return cond.ValidationFailure("missing-field", "cluster_id is required")
+	}
+	if !args.HasKeys() || len(args.Keys()) == 0 {
+		return cond.ValidationFailure("missing-field", "keys is required")
+	}
+
+	appName := args.AppName()
+	clusterId := args.ClusterId()
+	service := ""
+	if args.HasService() {
+		service = args.Service()
+	}
+
+	// Call shared helper to create new version
+	delResult, err := appclient.DeleteEnvVars(ctx, d.EC, appName, nil, args.Keys(), service)
+	if err != nil {
+		d.Log.Error("Failed to delete env vars", "error", err, "app", appName)
+		results.SetError(fmt.Sprintf("failed to delete env vars: %v", err))
+		return nil
+	}
+
+	results.SetVersionId(delResult.VersionID)
+	deletedSources := delResult.DeletedSources
+	results.SetDeletedSources(&deletedSources)
+
+	// Create deployment record and handle lock/activation
+	deployErr := d.createEnvVarDeployment(ctx, appName, clusterId, &delResult.MutateResult, results)
+	if deployErr != nil {
+		return deployErr
+	}
+
+	return nil
+}
+
+// envVarDeployResults is the subset of result setters needed by createEnvVarDeployment.
+type envVarDeployResults interface {
+	SetDeployment(*deployment_v1alpha.DeploymentInfo)
+	SetError(string)
+	SetLockInfo(*deployment_v1alpha.DeploymentLockInfo)
+	SetAccessInfo(**deployment_v1alpha.AccessInfo)
+}
+
+// createEnvVarDeployment handles the deployment record creation, lock checking,
+// and access info population shared by SetEnvVars and DeleteEnvVars.
+func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, clusterId string,
+	mutResult *appclient.MutateResult, results envVarDeployResults) error {
+
+	appVersionId := mutResult.VersionID
+
+	// Check for existing in_progress deployments (deployment lock)
+	existingDeployments, err := d.listDeploymentsInternal(ctx, appName, clusterId, "in_progress", 1)
+	if err != nil {
+		d.Log.Error("Failed to check for existing deployments", "error", err)
+		results.SetError("failed to check deployment lock")
+		return nil
+	}
+
+	if len(existingDeployments) > 0 {
+		existing := existingDeployments[0]
+
+		deploymentTime, parseErr := time.Parse(time.RFC3339, existing.DeployedBy.Timestamp)
+		if parseErr != nil {
+			deploymentTime = time.Time{}
+		}
+
+		isExpired := deploymentTime.IsZero() || time.Since(deploymentTime) >= deploymentLockTimeout
+		if !isExpired {
+			lockExpiresAt := deploymentTime.Add(deploymentLockTimeout)
+
+			displayEmail := existing.DeployedBy.UserEmail
+			if displayEmail == "" || displayEmail == "unknown@example.com" || displayEmail == "user@example.com" {
+				displayEmail = "-"
+			}
+
+			lockInfo := &deployment_v1alpha.DeploymentLockInfo{}
+			lockInfo.SetAppName(appName)
+			lockInfo.SetClusterId(clusterId)
+			lockInfo.SetBlockingDeploymentId(string(existing.ID))
+			lockInfo.SetStartedBy(displayEmail)
+			lockInfo.SetStartedAt(standard.ToTimestamp(deploymentTime))
+			lockInfo.SetCurrentPhase(existing.Phase)
+			lockInfo.SetLockExpiresAt(standard.ToTimestamp(lockExpiresAt))
+
+			results.SetLockInfo(lockInfo)
+			results.SetError("deployment blocked by existing in-progress deployment")
+			return nil
+		}
+
+		// Expired lock — mark as failed and continue
+		d.Log.Warn("Found expired in_progress deployment, marking as failed",
+			"deployment_id", string(existing.ID),
+			"age", time.Since(deploymentTime))
+
+		existing.Status = "failed"
+		existing.ErrorMessage = fmt.Sprintf("Deployment timed out after %v", deploymentLockTimeout)
+		existing.CompletedAt = time.Now().Format(time.RFC3339)
+
+		updateAttrs := existing.Encode()
+		updateEntity := &entityserver_v1alpha.Entity{}
+		updateEntity.SetId(string(existing.ID))
+		updateEntity.SetAttrs(updateAttrs)
+
+		if existingEntity, getErr := d.EAC.Get(ctx, string(existing.ID)); getErr == nil {
+			updateEntity.SetRevision(existingEntity.Entity().Revision())
+			if _, putErr := d.EAC.Put(ctx, updateEntity); putErr != nil {
+				d.Log.Error("Failed to mark expired deployment as failed", "error", putErr)
+			}
+		}
+	}
+
+	// Create new deployment entity
+	now := time.Now()
+
+	deployment := &core_v1alpha.Deployment{
+		AppName:    appName,
+		AppVersion: appVersionId,
+		ClusterId:  clusterId,
+		Status:     "active",
+		Phase:      "activating",
+		DeployedBy: core_v1alpha.DeployedBy{
+			Timestamp: now.Format(time.RFC3339),
+		},
+		CompletedAt: now.Format(time.RFC3339),
+	}
+
+	// Create entity
+	attrs := deployment.Encode()
+	rpcEntity := &entityserver_v1alpha.Entity{}
+	rpcEntity.SetAttrs(attrs)
+
+	putResp, err := d.EAC.Put(ctx, rpcEntity)
+	if err != nil {
+		d.Log.Error("Failed to create deployment entity", "error", err)
+		results.SetError("failed to create deployment")
+		return nil
+	}
+
+	deployment.ID = entity.Id(putResp.Id())
+	newDeploymentId := putResp.Id()
+
+	// Mark previous active deployments as succeeded
+	if err := d.markPreviousActiveAs(ctx, appName, clusterId, newDeploymentId, "succeeded"); err != nil {
+		d.Log.Error("Failed to mark previous active deployments", "error", err)
+	}
+
+	deploymentInfo := d.toDeploymentInfo(deployment)
+	results.SetDeployment(deploymentInfo)
+
+	accessInfo := d.getAccessInfo(ctx, appName)
+	results.SetAccessInfo(&accessInfo)
+
+	d.Log.Info("Env var deployment completed",
+		"deployment_id", newDeploymentId,
+		"app", appName,
+		"cluster", clusterId,
+		"version", appVersionId)
+
+	return nil
+}
+
 // getAccessInfo queries routes to determine how the app can be accessed
 func (d *DeploymentServer) getAccessInfo(ctx context.Context, appName string) *deployment_v1alpha.AccessInfo {
 	info := &deployment_v1alpha.AccessInfo{}


### PR DESCRIPTION
## Summary

`env set` and `env delete` were the odd ones out — they'd create a new version and bail, while `deploy` and `rollback` both watch activation and print routes. Now they all behave the same way.

- Added `SetEnvVars` and `DeleteEnvVars` RPCs to the deployment service
- Extracted shared env var mutation logic into `api/app/envvar.go`
- CLI now gets back deployment records, polls for activation, and shows routes
- Old Crud interface still works (thin wrappers over the shared helper)

Closes MIR-701