### PR TITLE
Fix `app run` panic when stdin isn't a terminal

### DIFF
--- a/cli/commands/app_run.go
+++ b/cli/commands/app_run.go
@@ -31,7 +31,7 @@ func AppRun(ctx *Context, opts struct {
 		out io.Writer
 	)
 
-	if con := console.Current(); con != nil {
+	if con, err := console.ConsoleFromFile(os.Stdin); err == nil {
 		in = con
 		out = con
 


### PR DESCRIPTION
`miren app run` was using `console.Current()` to grab a terminal handle, but that function panics when stdin isn't a TTY — so any non-interactive use (piped input, non-interactive SSH, CI) would blow up. The sibling command `sandbox exec` already handled this correctly by using `console.ConsoleFromFile(os.Stdin)`, which returns an error instead of panicking and lets the else branch fall through to raw stdin/stdout.

One-line fix to match the existing pattern. The server side already does the right thing — it only sets `proc.Terminal = true` when `WinSize` is present, which only gets set in the TTY branch.

Closes MIR-714