### PR TITLE
Add MIREN_CLUSTER targeting and cluster export-address command

### DIFF
--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -49,34 +49,50 @@ func addCluster(ctx *Context, identityName, clusterName, address string, force b
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Check if the identity exists
-	if mainConfig == nil || !mainConfig.HasIdentities() {
-		return fmt.Errorf("no identities configured. Please run 'miren login' first")
-	}
+	// Detect manual mode: both --cluster and --address provided
+	manualMode := clusterName != "" && address != ""
 
-	// If no identity specified, check if we can auto-select
-	if identityName == "" {
-		availableIdentities := mainConfig.GetIdentityNames()
-		if len(availableIdentities) == 1 {
-			// Auto-select the only identity
-			identityName = availableIdentities[0]
-			ctx.Info("Using identity '%s' (only one available)", identityName)
-		} else if len(availableIdentities) > 1 {
-			// Multiple identities available, user must specify
-			return fmt.Errorf("multiple identities available, please specify one with --identity: %s", strings.Join(availableIdentities, ", "))
-		} else {
-			return fmt.Errorf("no identities configured. Please run 'miren login' first")
+	// In manual mode, identity is optional (OIDC/environment auth can be used).
+	// In discovery mode, identity is required to fetch available clusters.
+	if !manualMode {
+		// Discovery mode — identity is required
+		if mainConfig == nil || !mainConfig.HasIdentities() {
+			return fmt.Errorf("no identities configured. Please run 'miren login' first, or use --cluster and --address to add a cluster directly")
+		}
+
+		if identityName == "" {
+			availableIdentities := mainConfig.GetIdentityNames()
+			if len(availableIdentities) == 1 {
+				identityName = availableIdentities[0]
+				ctx.Info("Using identity '%s' (only one available)", identityName)
+			} else if len(availableIdentities) > 1 {
+				return fmt.Errorf("multiple identities available, please specify one with --identity: %s", strings.Join(availableIdentities, ", "))
+			} else {
+				return fmt.Errorf("no identities configured. Please run 'miren login' first, or use --cluster and --address to add a cluster directly")
+			}
+		}
+	} else if identityName != "" {
+		// Manual mode with explicit --identity: validate it exists
+		if mainConfig == nil || !mainConfig.HasIdentities() {
+			return fmt.Errorf("identity %q not found: no identities configured", identityName)
 		}
 	}
 
-	identity, err := mainConfig.GetIdentity(identityName)
-	if err != nil {
-		// List available identities to help the user
-		availableIdentities := mainConfig.GetIdentityNames()
-		if len(availableIdentities) > 0 {
-			return fmt.Errorf("identity %q not found. Available identities: %v", identityName, availableIdentities)
+	// Look up identity if one was specified (skip if manual mode with no identity)
+	var identity *clientconfig.IdentityConfig
+	if identityName != "" {
+		if mainConfig == nil {
+			return fmt.Errorf("identity %q not found in configuration", identityName)
 		}
-		return fmt.Errorf("identity %q not found in configuration", identityName)
+		var err error
+		identity, err = mainConfig.GetIdentity(identityName)
+		if err != nil {
+			availableIdentities := mainConfig.GetIdentityNames()
+			if len(availableIdentities) > 0 {
+				return fmt.Errorf("identity %q not found. Available identities: %v", identityName, availableIdentities)
+			}
+			return fmt.Errorf("identity %q not found in configuration", identityName)
+		}
 	}
 
 	// If no cluster name or address provided, query the identity server for available clusters
@@ -201,7 +217,11 @@ func addCluster(ctx *Context, identityName, clusterName, address string, force b
 		return fmt.Errorf("failed to save cluster configuration: %w", err)
 	}
 
-	ctx.Completed("Successfully added cluster %q with identity %q at %s", clusterName, identityName, address)
+	if identityName != "" {
+		ctx.Completed("Successfully added cluster %q with identity %q at %s", clusterName, identityName, address)
+	} else {
+		ctx.Completed("Successfully added cluster %q at %s (using environment auth)", clusterName, address)
+	}
 	ctx.Info("Configuration saved to clientconfig.d/%s.yaml", clusterName)
 
 	// If there's no active cluster set, suggest setting this one
@@ -267,7 +287,7 @@ func normalizeAddress(address string) (normalizedAddr, sniHost string, err error
 
 // extractTLSCertificate connects to the server via QUIC and extracts the TLS certificate
 // Returns the PEM-encoded certificate and its SHA1 fingerprint (hex-encoded)
-func extractTLSCertificate(ctx *Context, address string) (string, string, error) {
+func extractTLSCertificate(ctx context.Context, address string) (string, string, error) {
 	// Normalize the address with robust parsing
 	normalizedAddr, sniHost, err := normalizeAddress(address)
 	if err != nil {

--- a/cli/commands/cluster_export.go
+++ b/cli/commands/cluster_export.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+)
+
+func ClusterExportAddress(ctx *Context, opts struct {
+	ConfigCentric
+}) error {
+	cfg, err := opts.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	name := opts.Cluster
+	if name == "" {
+		name = cfg.ActiveCluster()
+	}
+	if name == "" {
+		return fmt.Errorf("no cluster specified and no active cluster set; use -C to specify one")
+	}
+
+	cc, err := cfg.GetCluster(name)
+	if err != nil {
+		return fmt.Errorf("cluster %q not found: %w", name, err)
+	}
+	if cc == nil {
+		return fmt.Errorf("cluster %q not found", name)
+	}
+
+	block, _ := pem.Decode([]byte(cc.CACert))
+	if block == nil {
+		return fmt.Errorf("cluster %q has no valid CA certificate", name)
+	}
+
+	sum := sha1.Sum(block.Bytes)
+	fingerprint := hex.EncodeToString(sum[:])
+
+	ctx.Printf("%s;sha1:%s\n", cc.Hostname, fingerprint)
+	return nil
+}

--- a/cli/commands/cluster_export_test.go
+++ b/cli/commands/cluster_export_test.go
@@ -1,0 +1,157 @@
+package commands
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/clientconfig"
+)
+
+func generateTestCert(t *testing.T) (string, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	sum := sha1.Sum(derBytes)
+	fingerprint := hex.EncodeToString(sum[:])
+
+	return string(pemBytes), fingerprint
+}
+
+func testContext(t *testing.T) (*Context, *bytes.Buffer) {
+	t.Helper()
+	var stdout bytes.Buffer
+	ctx := &Context{
+		Stdout: &stdout,
+		Stderr: &bytes.Buffer{},
+	}
+	return ctx, &stdout
+}
+
+func TestClusterExportAddress(t *testing.T) {
+	t.Run("active cluster", func(t *testing.T) {
+		r := require.New(t)
+		certPEM, fingerprint := generateTestCert(t)
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("my-cluster", &clientconfig.ClusterConfig{
+			Hostname: "10.0.0.1:8443",
+			CACert:   certPEM,
+		})
+		cfg.SetActiveCluster("my-cluster")
+
+		ctx, stdout := testContext(t)
+		err := ClusterExportAddress(ctx, struct{ ConfigCentric }{
+			ConfigCentric: ConfigCentric{cfg: cfg},
+		})
+		r.NoError(err)
+		r.Equal("10.0.0.1:8443;sha1:"+fingerprint+"\n", stdout.String())
+	})
+
+	t.Run("cluster via -C flag", func(t *testing.T) {
+		r := require.New(t)
+		certPEM, fingerprint := generateTestCert(t)
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("other-cluster", &clientconfig.ClusterConfig{
+			Hostname: "10.0.0.2:8443",
+			CACert:   certPEM,
+		})
+
+		ctx, stdout := testContext(t)
+		err := ClusterExportAddress(ctx, struct{ ConfigCentric }{
+			ConfigCentric: ConfigCentric{Cluster: "other-cluster", cfg: cfg},
+		})
+		r.NoError(err)
+		r.Equal("10.0.0.2:8443;sha1:"+fingerprint+"\n", stdout.String())
+	})
+
+	t.Run("-C takes priority over active cluster", func(t *testing.T) {
+		r := require.New(t)
+		certPEM, fingerprint := generateTestCert(t)
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("active-cluster", &clientconfig.ClusterConfig{
+			Hostname: "10.0.0.1:8443",
+			CACert:   certPEM,
+		})
+		cfg.SetCluster("target-cluster", &clientconfig.ClusterConfig{
+			Hostname: "10.0.0.2:8443",
+			CACert:   certPEM,
+		})
+		cfg.SetActiveCluster("active-cluster")
+
+		ctx, stdout := testContext(t)
+		err := ClusterExportAddress(ctx, struct{ ConfigCentric }{
+			ConfigCentric: ConfigCentric{Cluster: "target-cluster", cfg: cfg},
+		})
+		r.NoError(err)
+		r.Equal("10.0.0.2:8443;sha1:"+fingerprint+"\n", stdout.String())
+	})
+
+	t.Run("no cluster specified and no active", func(t *testing.T) {
+		r := require.New(t)
+
+		cfg := clientconfig.NewConfig()
+
+		ctx, _ := testContext(t)
+		err := ClusterExportAddress(ctx, struct{ ConfigCentric }{
+			ConfigCentric: ConfigCentric{cfg: cfg},
+		})
+		r.Error(err)
+		r.Contains(err.Error(), "no cluster specified")
+	})
+
+	t.Run("cluster not found", func(t *testing.T) {
+		r := require.New(t)
+
+		cfg := clientconfig.NewConfig()
+
+		ctx, _ := testContext(t)
+		err := ClusterExportAddress(ctx, struct{ ConfigCentric }{
+			ConfigCentric: ConfigCentric{Cluster: "nonexistent", cfg: cfg},
+		})
+		r.Error(err)
+		r.Contains(err.Error(), "nonexistent")
+	})
+
+	t.Run("cluster with invalid CA cert", func(t *testing.T) {
+		r := require.New(t)
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("bad-cert", &clientconfig.ClusterConfig{
+			Hostname: "10.0.0.3:8443",
+			CACert:   "not-a-pem",
+		})
+
+		ctx, _ := testContext(t)
+		err := ClusterExportAddress(ctx, struct{ ConfigCentric }{
+			ConfigCentric: ConfigCentric{Cluster: "bad-cert", cfg: cfg},
+		})
+		r.Error(err)
+		r.Contains(err.Error(), "no valid CA certificate")
+	})
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -537,6 +537,18 @@ miren deploy --analyze
 			Body: "miren cluster current",
 		}),
 	))
+	d.Dispatch("cluster export-address", Infer("cluster export-address",
+		"Export cluster address with TLS fingerprint for MIREN_CLUSTER",
+		ClusterExportAddress,
+		WithExample(mflags.Example{
+			Name: "Export active cluster",
+			Body: "miren cluster export-address",
+		}),
+		WithExample(mflags.Example{
+			Name: "Export specific cluster",
+			Body: "miren cluster export-address -C my-cluster",
+		}),
+	))
 
 	// Runner commands (distributed runners) - behind feature flag
 	if labs.DistributedRunners() {

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"miren.dev/runtime/clientconfig"
@@ -34,10 +36,18 @@ func (c *ConfigCentric) LoadConfig() (*clientconfig.Config, error) {
 	}
 
 	if err != nil {
+		if err == clientconfig.ErrNoConfig && os.Getenv("MIREN_CLUSTER") != "" {
+			c.cfg = clientconfig.NewConfig()
+			return c.cfg, nil
+		}
 		return nil, err
 	}
 
 	if cfg == nil {
+		if os.Getenv("MIREN_CLUSTER") != "" {
+			c.cfg = clientconfig.NewConfig()
+			return c.cfg, nil
+		}
 		return nil, ErrNoConfig
 	}
 
@@ -64,13 +74,35 @@ func (c *ConfigCentric) LoadCluster() (*clientconfig.ClusterConfig, string, erro
 		name string
 	)
 
-	if c.Cluster == "" {
+	if c.Cluster != "" {
+		// -C flag takes priority
+		name = c.Cluster
+	} else if envCluster := os.Getenv("MIREN_CLUSTER"); envCluster != "" {
+		// Check if the full value matches a known cluster name first
+		cc, err := cfg.GetCluster(envCluster)
+		if err == nil && cc != nil {
+			return cc, envCluster, nil
+		}
+
+		// Parse optional fingerprint: "address;sha1:abcdef..."
+		address := envCluster
+		var fingerprint string
+		if idx := strings.Index(envCluster, ";"); idx >= 0 {
+			address = envCluster[:idx]
+			fingerprint = envCluster[idx+1:]
+		}
+
+		// Not a known cluster name — treat as an address and probe it
+		cc, name, err := setupClusterFromAddress(cfg, address, fingerprint)
+		if err != nil {
+			return nil, "", fmt.Errorf("MIREN_CLUSTER: failed to connect to %q: %w", address, err)
+		}
+		return cc, name, nil
+	} else {
 		name = cfg.ActiveCluster()
 		if name == "" {
 			return nil, "", nil
 		}
-	} else {
-		name = c.Cluster
 	}
 
 	cc, err := cfg.GetCluster(name)
@@ -83,6 +115,53 @@ func (c *ConfigCentric) LoadCluster() (*clientconfig.ClusterConfig, string, erro
 	}
 
 	return cc, name, nil
+}
+
+// checkFingerprint verifies that actual matches expected.
+// The expected value may carry a "sha1:" prefix, which is stripped before comparison.
+// An empty expected string means no verification (returns nil).
+// Comparison is case-insensitive.
+func checkFingerprint(expected, actual string) error {
+	if expected == "" {
+		return nil
+	}
+	expected = strings.TrimPrefix(expected, "sha1:")
+	if !strings.EqualFold(expected, actual) {
+		return fmt.Errorf("TLS certificate fingerprint mismatch: got %s, expected %s", actual, expected)
+	}
+	return nil
+}
+
+// setupClusterFromAddress probes an address via QUIC to extract its TLS certificate,
+// then creates an in-memory cluster config and adds it to the config.
+// If expectedFingerprint is non-empty, the probed certificate's SHA1 fingerprint
+// is verified against it (with optional "sha1:" prefix).
+func setupClusterFromAddress(cfg *clientconfig.Config, address, expectedFingerprint string) (*clientconfig.ClusterConfig, string, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cert, fingerprint, err := extractTLSCertificate(ctx, address)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if err := checkFingerprint(expectedFingerprint, fingerprint); err != nil {
+		return nil, "", err
+	}
+
+	cc := &clientconfig.ClusterConfig{
+		Hostname: address,
+		CACert:   cert,
+	}
+
+	leafData := &clientconfig.ConfigData{
+		Clusters: map[string]*clientconfig.ClusterConfig{
+			address: cc,
+		},
+	}
+	cfg.SetLeafConfig(address, leafData)
+
+	return cc, address, nil
 }
 
 func ConfigInfo(ctx *Context, opts struct {

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -36,7 +36,7 @@ func (c *ConfigCentric) LoadConfig() (*clientconfig.Config, error) {
 	}
 
 	if err != nil {
-		if err == clientconfig.ErrNoConfig && os.Getenv("MIREN_CLUSTER") != "" {
+		if errors.Is(err, clientconfig.ErrNoConfig) && os.Getenv("MIREN_CLUSTER") != "" {
 			c.cfg = clientconfig.NewConfig()
 			return c.cfg, nil
 		}

--- a/cli/commands/config_test.go
+++ b/cli/commands/config_test.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/clientconfig"
+)
+
+func TestCheckFingerprint(t *testing.T) {
+	t.Run("prefix stripped", func(t *testing.T) {
+		r := require.New(t)
+		r.NoError(checkFingerprint("sha1:abcdef", "abcdef"))
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		r := require.New(t)
+		r.NoError(checkFingerprint("ABCDEF", "abcdef"))
+	})
+
+	t.Run("prefix and case insensitive", func(t *testing.T) {
+		r := require.New(t)
+		r.NoError(checkFingerprint("sha1:ABCDEF", "abcdef"))
+	})
+
+	t.Run("mismatch error", func(t *testing.T) {
+		r := require.New(t)
+		err := checkFingerprint("wrong", "abcdef")
+		r.Error(err)
+		r.Contains(err.Error(), "abcdef")
+		r.Contains(err.Error(), "wrong")
+	})
+
+	t.Run("empty expected skips verification", func(t *testing.T) {
+		r := require.New(t)
+		r.NoError(checkFingerprint("", "abcdef"))
+	})
+}
+
+func TestLoadClusterEnvVar(t *testing.T) {
+	t.Run("known cluster name", func(t *testing.T) {
+		r := require.New(t)
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("known-name", &clientconfig.ClusterConfig{
+			Hostname: "10.0.0.1:8443",
+		})
+
+		cc := ConfigCentric{cfg: cfg}
+		t.Setenv("MIREN_CLUSTER", "known-name")
+
+		cluster, name, err := cc.LoadCluster()
+		r.NoError(err)
+		r.Equal("known-name", name)
+		r.NotNil(cluster)
+		r.Equal("10.0.0.1:8443", cluster.Hostname)
+	})
+
+	t.Run("known name with fingerprint suffix still matches", func(t *testing.T) {
+		r := require.New(t)
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("known-name;sha1:extra", &clientconfig.ClusterConfig{
+			Hostname: "10.0.0.1:8443",
+		})
+
+		cc := ConfigCentric{cfg: cfg}
+		t.Setenv("MIREN_CLUSTER", "known-name;sha1:extra")
+
+		cluster, name, err := cc.LoadCluster()
+		r.NoError(err)
+		r.Equal("known-name;sha1:extra", name)
+		r.NotNil(cluster)
+	})
+
+	t.Run("unknown address falls through", func(t *testing.T) {
+		r := require.New(t)
+
+		cfg := clientconfig.NewConfig()
+		cc := ConfigCentric{cfg: cfg}
+		t.Setenv("MIREN_CLUSTER", "unknown-addr:8443")
+
+		_, _, err := cc.LoadCluster()
+		r.Error(err)
+		r.Contains(err.Error(), "unknown-addr:8443")
+	})
+
+	t.Run("unknown address with fingerprint uses only address", func(t *testing.T) {
+		r := require.New(t)
+
+		cfg := clientconfig.NewConfig()
+		cc := ConfigCentric{cfg: cfg}
+		t.Setenv("MIREN_CLUSTER", "unknown-addr:8443;sha1:abc")
+
+		_, _, err := cc.LoadCluster()
+		r.Error(err)
+		r.Contains(err.Error(), "unknown-addr:8443")
+		// The fingerprint portion should not appear in the address part of the error
+		r.NotContains(err.Error(), `"unknown-addr:8443;sha1:abc"`)
+	})
+}


### PR DESCRIPTION
## Summary

- **MIREN_CLUSTER env var support**: `LoadCluster` now parses `MIREN_CLUSTER` with optional `address;sha1:fingerprint` format for targeting clusters without a config file, with TLS certificate fingerprint verification (TOFU protection)
- **`cluster export-address` command**: Exports a cluster's address and CA cert fingerprint in the format consumed by `MIREN_CLUSTER`. Honors the `-C` flag (not a positional arg) and falls back to the active cluster
- **`cluster add` manual mode**: When both `--cluster` and `--address` are provided, identity is no longer required — supports OIDC and environment-based auth
- **`checkFingerprint` helper**: Extracted from `setupClusterFromAddress` for direct unit testing of the security-critical fingerprint comparison logic
- **Tests**: `TestCheckFingerprint` (prefix stripping, case insensitivity, mismatch errors), `TestLoadClusterEnvVar` (known names, address fallthrough, fingerprint splitting), `TestClusterExportAddress` (active cluster, `-C` flag, `-C` priority, error cases)

## Test plan

- [x] `go test ./cli/commands/... -run 'TestCheckFingerprint|TestLoadClusterEnvVar|TestClusterExportAddress' -v` — all 15 tests pass
- [x] Full `go test ./cli/commands/...` suite passes
- [x] Manual: `miren cluster export-address` outputs correct fingerprint for active cluster
- [x] Manual: `miren cluster export-address -C <name>` targets the right cluster
- [ ] Manual: `MIREN_CLUSTER=<exported-value> miren app list` connects to the expected cluster