### PR TITLE
Fix OIDC auth fallback when primary authenticator errors

### DIFF
--- a/pkg/oidcauth/composite.go
+++ b/pkg/oidcauth/composite.go
@@ -47,7 +47,7 @@ var oidcDeployRole = map[string]map[string]bool{
 // It tries the primary first and falls back to OIDC.
 type CompositeAuthenticator struct {
 	primary rpc.Authenticator
-	oidc    *OIDCAuthenticator
+	oidc    rpc.Authenticator
 }
 
 // NewCompositeAuthenticator creates a composite authenticator that chains primary and OIDC auth.
@@ -65,9 +65,13 @@ func (c *CompositeAuthenticator) Authenticate(ctx context.Context, r *http.Reque
 	// Fall back to OIDC authenticator. The primary may have returned an error
 	// because it couldn't validate a token that's actually meant for OIDC
 	// (e.g., cloud JWT validator failing on a GitHub Actions OIDC token).
-	oidcIdentity, oidcErr := c.oidc.Authenticate(ctx, r)
-	if oidcIdentity != nil {
-		return oidcIdentity, nil
+	var oidcIdentity *rpc.Identity
+	var oidcErr error
+	if c.oidc != nil {
+		oidcIdentity, oidcErr = c.oidc.Authenticate(ctx, r)
+		if oidcIdentity != nil {
+			return oidcIdentity, nil
+		}
 	}
 
 	// Neither succeeded. Return the primary error if there was one,

--- a/pkg/oidcauth/composite.go
+++ b/pkg/oidcauth/composite.go
@@ -58,15 +58,24 @@ func NewCompositeAuthenticator(primary rpc.Authenticator, oidc *OIDCAuthenticato
 func (c *CompositeAuthenticator) Authenticate(ctx context.Context, r *http.Request) (*rpc.Identity, error) {
 	// Try primary authenticator first
 	identity, err := c.primary.Authenticate(ctx, r)
-	if err != nil {
-		return nil, err
-	}
 	if identity != nil {
 		return identity, nil
 	}
 
-	// Fall back to OIDC authenticator
-	return c.oidc.Authenticate(ctx, r)
+	// Fall back to OIDC authenticator. The primary may have returned an error
+	// because it couldn't validate a token that's actually meant for OIDC
+	// (e.g., cloud JWT validator failing on a GitHub Actions OIDC token).
+	oidcIdentity, oidcErr := c.oidc.Authenticate(ctx, r)
+	if oidcIdentity != nil {
+		return oidcIdentity, nil
+	}
+
+	// Neither succeeded. Return the primary error if there was one,
+	// otherwise the OIDC error.
+	if err != nil {
+		return nil, err
+	}
+	return nil, oidcErr
 }
 
 // CompositeAuthorizer handles authorization for both primary and OIDC auth methods.

--- a/pkg/oidcauth/composite_test.go
+++ b/pkg/oidcauth/composite_test.go
@@ -75,37 +75,29 @@ func TestCompositeAuthenticator_PrimaryErrorOIDCSucceeds(t *testing.T) {
 	primary := &mockAuthenticator{
 		err: fmt.Errorf("key with ID xyz not found"),
 	}
-	oidcMock := &mockAuthenticator{
+	oidcStub := &mockAuthenticator{
 		identity: &rpc.Identity{
 			Subject: "repo:acme/app:ref:refs/heads/main",
 			Method:  rpc.AuthMethodOIDC,
 		},
 	}
 
-	comp := &CompositeAuthenticator{primary: primary, oidc: nil}
-	// We can't use a mock directly as oidc field since it's *OIDCAuthenticator.
-	// Instead, test via the full Authenticate method logic by verifying the
-	// behavior: primary error should not block OIDC fallback.
-
-	// Test the actual composite with a real OIDCAuthenticator that has no EAC:
-	// the important thing is that it TRIES oidc and doesn't short-circuit.
-	oidcAuth := NewOIDCAuthenticator(testutils.TestLogger(t))
-	comp = NewCompositeAuthenticator(primary, oidcAuth)
+	comp := &CompositeAuthenticator{primary: primary, oidc: oidcStub}
 
 	req := httptest.NewRequest("GET", "/", nil)
-	// OIDC won't match (no EAC, no Bearer token that OIDC recognizes),
-	// so primary error should still propagate.
-	_, err := comp.Authenticate(context.Background(), req)
-	if err == nil {
-		t.Fatal("expected error when both fail")
+	identity, err := comp.Authenticate(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected no error when OIDC succeeds, got: %v", err)
 	}
-
-	// Verify we didn't get an OIDC error — we should get the primary error
-	if err.Error() != "key with ID xyz not found" {
-		t.Errorf("expected primary error, got: %v", err)
+	if identity == nil {
+		t.Fatal("expected OIDC identity, got nil")
 	}
-
-	_ = oidcMock // used to show intent; full integration test requires a running OIDC validator
+	if identity.Subject != "repo:acme/app:ref:refs/heads/main" {
+		t.Errorf("subject = %q, want %q", identity.Subject, "repo:acme/app:ref:refs/heads/main")
+	}
+	if identity.Method != rpc.AuthMethodOIDC {
+		t.Errorf("method = %q, want %q", identity.Method, rpc.AuthMethodOIDC)
+	}
 }
 
 func TestCompositeAuthenticator_FallbackToOIDC(t *testing.T) {

--- a/pkg/oidcauth/composite_test.go
+++ b/pkg/oidcauth/composite_test.go
@@ -54,7 +54,8 @@ func TestCompositeAuthenticator_PrimarySucceeds(t *testing.T) {
 	}
 }
 
-func TestCompositeAuthenticator_PrimaryError(t *testing.T) {
+func TestCompositeAuthenticator_PrimaryErrorOIDCNil(t *testing.T) {
+	// When primary errors and OIDC returns nil, the primary error propagates.
 	primary := &mockAuthenticator{
 		err: fmt.Errorf("auth server unavailable"),
 	}
@@ -66,6 +67,45 @@ func TestCompositeAuthenticator_PrimaryError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error to propagate from primary")
 	}
+}
+
+func TestCompositeAuthenticator_PrimaryErrorOIDCSucceeds(t *testing.T) {
+	// When primary errors on a token it doesn't recognize, but OIDC succeeds,
+	// the OIDC identity should be returned (not the primary error).
+	primary := &mockAuthenticator{
+		err: fmt.Errorf("key with ID xyz not found"),
+	}
+	oidcMock := &mockAuthenticator{
+		identity: &rpc.Identity{
+			Subject: "repo:acme/app:ref:refs/heads/main",
+			Method:  rpc.AuthMethodOIDC,
+		},
+	}
+
+	comp := &CompositeAuthenticator{primary: primary, oidc: nil}
+	// We can't use a mock directly as oidc field since it's *OIDCAuthenticator.
+	// Instead, test via the full Authenticate method logic by verifying the
+	// behavior: primary error should not block OIDC fallback.
+
+	// Test the actual composite with a real OIDCAuthenticator that has no EAC:
+	// the important thing is that it TRIES oidc and doesn't short-circuit.
+	oidcAuth := NewOIDCAuthenticator(testutils.TestLogger(t))
+	comp = NewCompositeAuthenticator(primary, oidcAuth)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	// OIDC won't match (no EAC, no Bearer token that OIDC recognizes),
+	// so primary error should still propagate.
+	_, err := comp.Authenticate(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error when both fail")
+	}
+
+	// Verify we didn't get an OIDC error — we should get the primary error
+	if err.Error() != "key with ID xyz not found" {
+		t.Errorf("expected primary error, got: %v", err)
+	}
+
+	_ = oidcMock // used to show intent; full integration test requires a running OIDC validator
 }
 
 func TestCompositeAuthenticator_FallbackToOIDC(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix `CompositeAuthenticator` to try the OIDC authenticator even when the primary authenticator returns an error
- The primary (cloud JWT validator) was failing on GitHub Actions OIDC tokens because the token's key ID doesn't exist in miren.cloud's JWKS, and this error prevented the OIDC authenticator from ever being tried
- If OIDC succeeds after a primary error, the OIDC identity is returned; if both fail, the primary error is returned

## Test plan

- [x] Existing composite authenticator tests updated and passing
- [x] New test for primary-error-then-OIDC-fallback scenario
- [ ] Deploy from GitHub Actions with OIDC binding and verify auth succeeds