### PR TITLE
Eliminate 502s during deployment rollovers

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -35,6 +36,10 @@ type Launcher struct {
 	Log *slog.Logger
 	EAC *entityserver_v1alpha.EntityAccessClient
 
+	// PoolReadyTimeout is how long to wait for new pools to have ready instances
+	// before proceeding with old pool cleanup. Defaults to 60s.
+	PoolReadyTimeout time.Duration
+
 	appMu sync.Map // per-app mutexes: app ID -> *sync.Mutex
 }
 
@@ -46,8 +51,9 @@ type PoolWithEntity struct {
 
 func NewLauncher(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *Launcher {
 	return &Launcher{
-		Log: log.With("module", "deployment"),
-		EAC: eac,
+		Log:              log.With("module", "deployment"),
+		EAC:              eac,
+		PoolReadyTimeout: 60 * time.Second,
 	}
 }
 
@@ -201,14 +207,31 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 		"version", ver.Version,
 		"services", len(spec.Services))
 
-	// For each service, ensure a pool exists
+	// For each service, ensure a pool exists. Collect IDs of newly created pools.
+	var newPoolIDs []entity.Id
 	for _, svc := range spec.Services {
-		if err := l.ensurePoolForService(ctx, app, &ver, spec, svc.Name); err != nil {
+		poolID, err := l.ensurePoolForService(ctx, app, &ver, spec, svc.Name)
+		if err != nil {
 			l.Log.Error("failed to ensure pool for service",
 				"app", app.ID,
 				"service", svc.Name,
 				"error", err)
 			// Continue with other services even if one fails
+			continue
+		}
+		if poolID != "" {
+			newPoolIDs = append(newPoolIDs, poolID)
+		}
+	}
+
+	// Wait for new pools to have ready instances before killing old ones.
+	// This prevents a gap where the old sandbox is dead but the new one
+	// isn't serving yet, which would cause 502s.
+	for _, poolID := range newPoolIDs {
+		if err := l.waitForPoolReady(ctx, poolID, l.PoolReadyTimeout); err != nil {
+			l.Log.Warn("timed out waiting for new pool to become ready, proceeding with cleanup",
+				"pool", poolID,
+				"error", err)
 		}
 	}
 
@@ -224,12 +247,14 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	return nil
 }
 
-// ensurePoolForService creates or reuses a pool for the given service
-func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.App, ver *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec, serviceName string) error {
+// ensurePoolForService creates or reuses a pool for the given service.
+// Returns the pool ID if a new pool was created (caller should wait for it
+// to become ready), or an empty ID if an existing pool was reused.
+func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.App, ver *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec, serviceName string) (entity.Id, error) {
 	// Get service config
 	svcConcurrency, err := coreutil.GetServiceConcurrency(spec, serviceName)
 	if err != nil {
-		return fmt.Errorf("failed to get service concurrency: %w", err)
+		return "", fmt.Errorf("failed to get service concurrency: %w", err)
 	}
 
 	// Determine which image to use
@@ -248,7 +273,7 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 	// Get app metadata for label
 	appResp, err := l.EAC.Get(ctx, app.ID.String())
 	if err != nil {
-		return fmt.Errorf("failed to get app metadata: %w", err)
+		return "", fmt.Errorf("failed to get app metadata: %w", err)
 	}
 
 	var appMD core_v1alpha.Metadata
@@ -257,7 +282,7 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 	// Build the desired sandbox spec
 	sbSpec, err := l.buildSandboxSpec(ctx, app, ver, spec, serviceName, image)
 	if err != nil {
-		return fmt.Errorf("failed to build sandbox spec: %w", err)
+		return "", fmt.Errorf("failed to build sandbox spec: %w", err)
 	}
 
 	// Calculate desired instances based on concurrency mode
@@ -272,11 +297,11 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 	// Try to find existing pool with matching spec
 	poolWithEntity, err := l.findMatchingPool(ctx, app.ID, serviceName, sbSpec)
 	if err != nil {
-		return fmt.Errorf("failed to find matching pool: %w", err)
+		return "", fmt.Errorf("failed to find matching pool: %w", err)
 	}
 
 	if poolWithEntity != nil {
-		// Reuse existing pool
+		// Reuse existing pool — sandboxes already running, no wait needed
 		l.Log.Info("reusing existing pool",
 			"pool", poolWithEntity.Pool.ID,
 			"service", serviceName,
@@ -308,11 +333,12 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 
 		if needsUpdate {
 			if err := l.updatePool(ctx, poolWithEntity); err != nil {
-				return fmt.Errorf("failed to update pool: %w", err)
+				return "", fmt.Errorf("failed to update pool: %w", err)
 			}
 		}
 
-		return nil
+		// Return empty ID — existing pool already has running sandboxes
+		return "", nil
 	}
 
 	// No matching pool found, create a new one
@@ -356,7 +382,7 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 		pool.Encode,
 	).Attrs())
 	if err != nil {
-		return fmt.Errorf("failed to create pool entity: %w", err)
+		return "", fmt.Errorf("failed to create pool entity: %w", err)
 	}
 
 	pool.ID = id
@@ -366,7 +392,8 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 		"service", serviceName,
 		"desired_instances", desiredInstances)
 
-	return nil
+	// Return the new pool ID — caller should wait for it to become ready
+	return id, nil
 }
 
 // buildSandboxSpec creates a SandboxSpec for the given service
@@ -804,6 +831,50 @@ func (l *Launcher) updatePool(ctx context.Context, poolWithEntity *PoolWithEntit
 	l.Log.Info("pool update successful", "pool", pool.ID)
 
 	return nil
+}
+
+// waitForPoolReady polls the pool entity until ReadyInstances > 0 or the timeout expires.
+// On timeout it returns an error, but the caller should proceed with cleanup anyway —
+// Fix 1's retry in httpingress handles any remaining gap.
+func (l *Launcher) waitForPoolReady(ctx context.Context, poolID entity.Id, timeout time.Duration) error {
+	pollInterval := 2 * time.Second
+	if timeout < pollInterval {
+		pollInterval = timeout / 2
+	}
+	deadline := time.Now().Add(timeout)
+
+	for {
+		resp, err := l.EAC.Get(ctx, poolID.String())
+		if err != nil {
+			return fmt.Errorf("failed to get pool %s: %w", poolID, err)
+		}
+
+		var pool compute_v1alpha.SandboxPool
+		pool.Decode(resp.Entity().Entity())
+
+		if pool.ReadyInstances > 0 {
+			l.Log.Info("new pool has ready instances",
+				"pool", poolID,
+				"ready_instances", pool.ReadyInstances)
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("pool %s not ready after %s (ready_instances=%d, current_instances=%d)",
+				poolID, timeout, pool.ReadyInstances, pool.CurrentInstances)
+		}
+
+		l.Log.Debug("waiting for pool to become ready",
+			"pool", poolID,
+			"ready_instances", pool.ReadyInstances,
+			"current_instances", pool.CurrentInstances)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
 }
 
 // cleanupOldVersionPools removes old version references from pools and scales down unreferenced pools

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -229,12 +229,13 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	// isn't serving yet, which would cause 502s.
 	for _, poolID := range newPoolIDs {
 		if err := l.waitForPoolReady(ctx, poolID, l.PoolReadyTimeout); err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
+			if errors.Is(err, context.DeadlineExceeded) {
+				l.Log.Warn("timed out waiting for new pool to become ready, proceeding with cleanup",
+					"pool", poolID,
+					"error", err)
+				continue
 			}
-			l.Log.Warn("new pool not confirmed ready, proceeding with cleanup",
-				"pool", poolID,
-				"error", err)
+			return fmt.Errorf("failed waiting for new pool readiness %s: %w", poolID, err)
 		}
 	}
 
@@ -863,8 +864,8 @@ func (l *Launcher) waitForPoolReady(ctx context.Context, poolID entity.Id, timeo
 		}
 
 		if time.Now().After(deadline) {
-			return fmt.Errorf("pool %s not ready after %s (ready_instances=%d, current_instances=%d)",
-				poolID, timeout, pool.ReadyInstances, pool.CurrentInstances)
+			return fmt.Errorf("pool %s not ready after %s (ready_instances=%d, current_instances=%d): %w",
+				poolID, timeout, pool.ReadyInstances, pool.CurrentInstances, context.DeadlineExceeded)
 		}
 
 		l.Log.Debug("waiting for pool to become ready",

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -835,7 +835,7 @@ func (l *Launcher) updatePool(ctx context.Context, poolWithEntity *PoolWithEntit
 
 // waitForPoolReady polls the pool entity until ReadyInstances > 0 or the timeout expires.
 // On timeout it returns an error, but the caller should proceed with cleanup anyway —
-// Fix 1's retry in httpingress handles any remaining gap.
+// the httpingress retry logic handles any remaining gap.
 func (l *Launcher) waitForPoolReady(ctx context.Context, poolID entity.Id, timeout time.Duration) error {
 	pollInterval := 2 * time.Second
 	if timeout < pollInterval {

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -229,7 +229,10 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	// isn't serving yet, which would cause 502s.
 	for _, poolID := range newPoolIDs {
 		if err := l.waitForPoolReady(ctx, poolID, l.PoolReadyTimeout); err != nil {
-			l.Log.Warn("timed out waiting for new pool to become ready, proceeding with cleanup",
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			l.Log.Warn("new pool not confirmed ready, proceeding with cleanup",
 				"pool", poolID,
 				"error", err)
 		}

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -17,7 +17,6 @@ import (
 	"miren.dev/runtime/pkg/entity/testutils"
 )
 
-// newTestLauncher creates a Launcher with a short pool-ready timeout for fast tests.
 func newTestLauncher(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *Launcher {
 	l := NewLauncher(log, eac)
 	l.PoolReadyTimeout = 100 * time.Millisecond
@@ -68,7 +67,6 @@ func TestPoolCreationFixedMode(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	// Create launcher and handle reconcile
 	launcher := newTestLauncher(log, server.EAC)
 
 	err = launcher.Reconcile(ctx, app, nil)
@@ -132,7 +130,6 @@ func TestPoolCreationAutoMode(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	// Create launcher and handle reconcile
 	launcher := newTestLauncher(log, server.EAC)
 
 	err = launcher.Reconcile(ctx, app, nil)
@@ -514,7 +511,6 @@ func TestMultipleServices(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	// Create launcher and handle reconcile
 	launcher := newTestLauncher(log, server.EAC)
 
 	err = launcher.Reconcile(ctx, app, nil)
@@ -871,7 +867,6 @@ func TestPerServiceEnvVarsDoNotRestartOtherServices(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	// Create launcher and reconcile to create pools
 	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
@@ -1061,7 +1056,6 @@ func TestPerServicePortConfiguration(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	// Create launcher and reconcile
 	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
@@ -1157,7 +1151,6 @@ func TestWebServiceDefaultPort(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	// Create launcher and reconcile
 	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
@@ -1229,7 +1222,6 @@ func TestPortNameAndType(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	// Create launcher and reconcile
 	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
@@ -1380,7 +1372,6 @@ func TestNoActiveVersionSkipsReconcile(t *testing.T) {
 	require.NoError(t, err)
 	app.ID = appID
 
-	// Create launcher and reconcile
 	launcher := newTestLauncher(log, server.EAC)
 
 	err = launcher.Reconcile(ctx, app, nil)
@@ -1391,8 +1382,6 @@ func TestNoActiveVersionSkipsReconcile(t *testing.T) {
 	assert.Empty(t, pools, "should not create any pools when ActiveVersion is empty")
 }
 
-// TestWaitForPoolReadySuccess verifies that waitForPoolReady returns immediately
-// when ReadyInstances > 0.
 func TestWaitForPoolReadySuccess(t *testing.T) {
 	ctx := context.Background()
 	log := testutils.TestLogger(t)
@@ -1402,7 +1391,6 @@ func TestWaitForPoolReadySuccess(t *testing.T) {
 
 	launcher := newTestLauncher(log, server.EAC)
 
-	// Create a pool with ReadyInstances > 0
 	pool := &compute_v1alpha.SandboxPool{
 		Service:          "web",
 		DesiredInstances: 1,
@@ -1411,13 +1399,10 @@ func TestWaitForPoolReadySuccess(t *testing.T) {
 	poolID, err := server.Client.Create(ctx, "test-pool", pool)
 	require.NoError(t, err)
 
-	// Should return immediately
 	err = launcher.waitForPoolReady(ctx, poolID, 5*time.Second)
 	assert.NoError(t, err)
 }
 
-// TestWaitForPoolReadyTimeout verifies that waitForPoolReady returns an error
-// when the pool never becomes ready within the timeout.
 func TestWaitForPoolReadyTimeout(t *testing.T) {
 	ctx := context.Background()
 	log := testutils.TestLogger(t)
@@ -1427,7 +1412,6 @@ func TestWaitForPoolReadyTimeout(t *testing.T) {
 
 	launcher := newTestLauncher(log, server.EAC)
 
-	// Create a pool with ReadyInstances = 0
 	pool := &compute_v1alpha.SandboxPool{
 		Service:          "web",
 		DesiredInstances: 1,
@@ -1436,14 +1420,11 @@ func TestWaitForPoolReadyTimeout(t *testing.T) {
 	poolID, err := server.Client.Create(ctx, "test-pool", pool)
 	require.NoError(t, err)
 
-	// Should timeout quickly (using a very short timeout for test speed)
 	err = launcher.waitForPoolReady(ctx, poolID, 100*time.Millisecond)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not ready after")
 }
 
-// TestWaitForPoolReadyContextCancelled verifies that waitForPoolReady respects
-// context cancellation.
 func TestWaitForPoolReadyContextCancelled(t *testing.T) {
 	log := testutils.TestLogger(t)
 
@@ -1454,7 +1435,6 @@ func TestWaitForPoolReadyContextCancelled(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Create a pool with ReadyInstances = 0
 	pool := &compute_v1alpha.SandboxPool{
 		Service:          "web",
 		DesiredInstances: 1,
@@ -1463,15 +1443,12 @@ func TestWaitForPoolReadyContextCancelled(t *testing.T) {
 	poolID, err := server.Client.Create(ctx, "test-pool", pool)
 	require.NoError(t, err)
 
-	// Cancel context immediately
 	cancel()
 
 	err = launcher.waitForPoolReady(ctx, poolID, 60*time.Second)
 	assert.Error(t, err)
 }
 
-// TestCleanupWaitsForNewPool verifies that reconcileAppVersion waits for new pools
-// to become ready before cleaning up old version pools.
 func TestCleanupWaitsForNewPool(t *testing.T) {
 	ctx := context.Background()
 	log := testutils.TestLogger(t)
@@ -1479,7 +1456,6 @@ func TestCleanupWaitsForNewPool(t *testing.T) {
 	server, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
 
-	// Create app
 	app := &core_v1alpha.App{
 		Project: entity.Id("project-1"),
 	}
@@ -1487,7 +1463,6 @@ func TestCleanupWaitsForNewPool(t *testing.T) {
 	require.NoError(t, err)
 	app.ID = appID
 
-	// Create v1
 	v1 := &core_v1alpha.AppVersion{
 		App:      app.ID,
 		Version:  "v1",
@@ -1509,7 +1484,6 @@ func TestCleanupWaitsForNewPool(t *testing.T) {
 	require.NoError(t, err)
 	v1.ID = v1ID
 
-	// Deploy v1
 	app.ActiveVersion = v1.ID
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
@@ -1518,11 +1492,10 @@ func TestCleanupWaitsForNewPool(t *testing.T) {
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
-	// Verify v1 pool exists
 	poolsV1 := listAllPools(t, ctx, server)
 	require.Len(t, poolsV1, 1)
 
-	// Create v2 with different image (forces new pool)
+	// Different image forces a new pool, triggering the wait-then-cleanup flow
 	v2 := &core_v1alpha.AppVersion{
 		App:      app.ID,
 		Version:  "v2",
@@ -1544,23 +1517,18 @@ func TestCleanupWaitsForNewPool(t *testing.T) {
 	require.NoError(t, err)
 	v2.ID = v2ID
 
-	// Deploy v2
 	app.ActiveVersion = v2.ID
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	// Reconcile v2 — this will create a new pool and wait for it, then clean up.
-	// Since the new pool's ReadyInstances won't be set by anything in the test,
-	// waitForPoolReady will timeout (100ms from newTestLauncher), log a warning,
-	// and proceed with cleanup.
+	// waitForPoolReady will timeout (nothing sets ReadyInstances in unit tests)
+	// and proceed with cleanup — this is the expected path.
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
-	// Verify we have 2 pools total (old scaled down, new created)
 	pools := listAllPools(t, ctx, server)
 	require.Len(t, pools, 2, "should have both old and new pools")
 
-	// Find old and new pools
 	var oldPool, newPool *compute_v1alpha.SandboxPool
 	for i := range pools {
 		if pools[i].SandboxSpec.Version == v1.ID {
@@ -1574,7 +1542,6 @@ func TestCleanupWaitsForNewPool(t *testing.T) {
 	require.NotNil(t, newPool, "new pool should exist")
 	assert.Equal(t, int64(1), newPool.DesiredInstances)
 
-	// Old pool should be scaled down (DesiredInstances=0)
 	if oldPool != nil {
 		assert.Equal(t, int64(0), oldPool.DesiredInstances, "old pool should be scaled down")
 	}

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -1423,6 +1423,7 @@ func TestWaitForPoolReadyTimeout(t *testing.T) {
 	err = launcher.waitForPoolReady(ctx, poolID, 100*time.Millisecond)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not ready after")
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestWaitForPoolReadyContextCancelled(t *testing.T) {

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -6,14 +6,23 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 )
+
+// newTestLauncher creates a Launcher with a short pool-ready timeout for fast tests.
+func newTestLauncher(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *Launcher {
+	l := NewLauncher(log, eac)
+	l.PoolReadyTimeout = 100 * time.Millisecond
+	return l
+}
 
 // TestPoolCreationFixedMode tests that DeploymentLauncher creates pools with
 // correct desired_instances for fixed-mode services
@@ -60,7 +69,7 @@ func TestPoolCreationFixedMode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create launcher and handle reconcile
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
@@ -124,7 +133,7 @@ func TestPoolCreationAutoMode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create launcher and handle reconcile
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
@@ -186,7 +195,7 @@ func TestPoolReuseOnConfigChange(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
@@ -287,7 +296,7 @@ func TestNewPoolOnImageChange(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
@@ -401,7 +410,7 @@ func TestServiceRemoval(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
@@ -506,7 +515,7 @@ func TestMultipleServices(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create launcher and handle reconcile
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
@@ -682,7 +691,7 @@ func TestUpdatePoolPreservesMetadata(t *testing.T) {
 	pool.ReadyInstances = 0
 	pool.ReferencedByVersions = []entity.Id{} // Empty refs
 
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 	poolWithEntity := &PoolWithEntity{
 		Pool:   pool,
 		Entity: *initialEntity,
@@ -758,7 +767,7 @@ func TestAutoModePoolReusePreservesDesiredInstances(t *testing.T) {
 	require.NoError(t, err)
 
 	// First reconciliation - creates pool with desired=1 (boots immediately after deploy)
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
@@ -863,7 +872,7 @@ func TestPerServiceEnvVarsDoNotRestartOtherServices(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create launcher and reconcile to create pools
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
@@ -1053,7 +1062,7 @@ func TestPerServicePortConfiguration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create launcher and reconcile
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
@@ -1149,7 +1158,7 @@ func TestWebServiceDefaultPort(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create launcher and reconcile
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
@@ -1221,7 +1230,7 @@ func TestPortNameAndType(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create launcher and reconcile
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
@@ -1311,7 +1320,7 @@ func TestRapidVersionChangesCreateSinglePool(t *testing.T) {
 	// At this point ActiveVersion points to v3.
 	// Simulate the controller framework dispatching events for v1, v2, v3.
 	// Each event carries a stale App snapshot from when it was dispatched.
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 
 	// Simulate stale v1 event: app snapshot has ActiveVersion=v1
 	staleAppV1 := &core_v1alpha.App{
@@ -1372,7 +1381,7 @@ func TestNoActiveVersionSkipsReconcile(t *testing.T) {
 	app.ID = appID
 
 	// Create launcher and reconcile
-	launcher := NewLauncher(log, server.EAC)
+	launcher := newTestLauncher(log, server.EAC)
 
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
@@ -1380,4 +1389,193 @@ func TestNoActiveVersionSkipsReconcile(t *testing.T) {
 	// Verify no pools were created
 	pools := listAllPools(t, ctx, server)
 	assert.Empty(t, pools, "should not create any pools when ActiveVersion is empty")
+}
+
+// TestWaitForPoolReadySuccess verifies that waitForPoolReady returns immediately
+// when ReadyInstances > 0.
+func TestWaitForPoolReadySuccess(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	launcher := newTestLauncher(log, server.EAC)
+
+	// Create a pool with ReadyInstances > 0
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 1,
+		ReadyInstances:   1,
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+
+	// Should return immediately
+	err = launcher.waitForPoolReady(ctx, poolID, 5*time.Second)
+	assert.NoError(t, err)
+}
+
+// TestWaitForPoolReadyTimeout verifies that waitForPoolReady returns an error
+// when the pool never becomes ready within the timeout.
+func TestWaitForPoolReadyTimeout(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	launcher := newTestLauncher(log, server.EAC)
+
+	// Create a pool with ReadyInstances = 0
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 1,
+		ReadyInstances:   0,
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+
+	// Should timeout quickly (using a very short timeout for test speed)
+	err = launcher.waitForPoolReady(ctx, poolID, 100*time.Millisecond)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not ready after")
+}
+
+// TestWaitForPoolReadyContextCancelled verifies that waitForPoolReady respects
+// context cancellation.
+func TestWaitForPoolReadyContextCancelled(t *testing.T) {
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	launcher := newTestLauncher(log, server.EAC)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Create a pool with ReadyInstances = 0
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 1,
+		ReadyInstances:   0,
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+
+	// Cancel context immediately
+	cancel()
+
+	err = launcher.waitForPoolReady(ctx, poolID, 60*time.Second)
+	assert.Error(t, err)
+}
+
+// TestCleanupWaitsForNewPool verifies that reconcileAppVersion waits for new pools
+// to become ready before cleaning up old version pools.
+func TestCleanupWaitsForNewPool(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// Create v1
+	v1 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:v1",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	v1ID, err := server.Client.Create(ctx, "test-v1", v1)
+	require.NoError(t, err)
+	v1.ID = v1ID
+
+	// Deploy v1
+	app.ActiveVersion = v1.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Verify v1 pool exists
+	poolsV1 := listAllPools(t, ctx, server)
+	require.Len(t, poolsV1, 1)
+
+	// Create v2 with different image (forces new pool)
+	v2 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v2",
+		ImageUrl: "test:v2",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	v2ID, err := server.Client.Create(ctx, "test-v2", v2)
+	require.NoError(t, err)
+	v2.ID = v2ID
+
+	// Deploy v2
+	app.ActiveVersion = v2.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	// Reconcile v2 — this will create a new pool and wait for it, then clean up.
+	// Since the new pool's ReadyInstances won't be set by anything in the test,
+	// waitForPoolReady will timeout (100ms from newTestLauncher), log a warning,
+	// and proceed with cleanup.
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Verify we have 2 pools total (old scaled down, new created)
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 2, "should have both old and new pools")
+
+	// Find old and new pools
+	var oldPool, newPool *compute_v1alpha.SandboxPool
+	for i := range pools {
+		if pools[i].SandboxSpec.Version == v1.ID {
+			oldPool = &pools[i]
+		}
+		if pools[i].SandboxSpec.Version == v2.ID {
+			newPool = &pools[i]
+		}
+	}
+
+	require.NotNil(t, newPool, "new pool should exist")
+	assert.Equal(t, int64(1), newPool.DesiredInstances)
+
+	// Old pool should be scaled down (DesiredInstances=0)
+	if oldPool != nil {
+		assert.Equal(t, int64(0), oldPool.DesiredInstances, "old pool should be scaled down")
+	}
 }

--- a/controllers/integration/redeploy_test.go
+++ b/controllers/integration/redeploy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -362,6 +363,7 @@ func TestRapidRedeployWithDisk(t *testing.T) {
 
 	// Create Launcher and Manager (the real deployment machinery)
 	launcher := deployment.NewLauncher(h.Log, h.EAC)
+	launcher.PoolReadyTimeout = 100 * time.Millisecond
 	launcher.Init(ctx) //nolint:errcheck
 
 	mgr := sandboxpool.NewManager(h.Log, h.EAC)

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -518,82 +518,105 @@ func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Requ
 		))
 	defer leaseSpan.End()
 
-	// Common lease handling logic
-	curLease, err := h.useLease(ctx, targetAppId.String())
-	if err != nil {
-		h.Log.Error("error taking lease", "error", err, "app", targetAppId)
-		http.Error(w, fmt.Sprintf("error taking lease: %s", targetAppId), http.StatusInternalServerError)
-		return
-	}
-
-	if curLease != nil {
-		leaseSpan.SetAttributes(
-			attribute.Bool("miren.lease.cached", true),
-			attribute.String("miren.lease.url", curLease.Lease.URL),
-		)
-		req = req.WithContext(ctx)
-		h.forwardToLease(ctx, w, req, curLease, targetAppId.String(), *appName)
-		return
-	}
-
-	leaseSpan.SetAttributes(attribute.Bool("miren.lease.cached", false))
-
-	if app.ActiveVersion == "" {
-		h.Log.Debug("no active version for app", "app", targetAppId)
-		http.Error(w, fmt.Sprintf("no active version for app: %s", targetAppId), http.StatusNotFound)
-		return
-	}
-
-	vr, err := h.eac.Get(ctx, app.ActiveVersion.String())
-	if err != nil {
-		h.Log.Error("error looking up application version", "error", err, "version", app.ActiveVersion)
-		http.Error(w, fmt.Sprintf("error looking up application version: %s", app.ActiveVersion), http.StatusInternalServerError)
-		return
-	}
-
-	var av core_v1alpha.AppVersion
-	av.Decode(vr.Entity().Entity())
-
-	leaseSpan.SetAttributes(
-		attribute.String("miren.app.version", app.ActiveVersion.String()),
-	)
-
-	// Give lease acquisition a generous timeout to complete sandbox boot
-	// even if the client request times out. This prevents dangling resources.
-	actContext, actCancel := context.WithTimeout(context.Background(), leaseAcquisitionTimeout)
-	defer actCancel()
-
-	actLease, err := h.aa.AcquireLease(actContext, &av, "web")
-	if err != nil {
-		if errors.Is(err, activator.ErrSandboxDiedEarly) {
-			h.Log.Error("sandbox died early while acquiring lease", "error", err, "app", targetAppId)
-			http.Error(w, fmt.Sprintf("The application %s failed to boot. Please check the applications logs.\n", targetAppId), http.StatusRequestTimeout)
-		} else {
-			h.Log.Error("error acquiring lease", "error", err, "app", targetAppId)
-			http.Error(w, fmt.Sprintf("error acquiring lease: %s", targetAppId), http.StatusInternalServerError)
+	// Retry loop: if a cached lease fails with a connection error (stale sandbox),
+	// invalidate it and retry once — the next iteration acquires a fresh lease.
+	const maxRetries = 1
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		// Try to use a cached lease
+		curLease, err := h.useLease(ctx, targetAppId.String())
+		if err != nil {
+			h.Log.Error("error taking lease", "error", err, "app", targetAppId)
+			http.Error(w, fmt.Sprintf("error taking lease: %s", targetAppId), http.StatusInternalServerError)
+			return
 		}
 
+		if curLease != nil {
+			leaseSpan.SetAttributes(
+				attribute.Bool("miren.lease.cached", true),
+				attribute.String("miren.lease.url", curLease.Lease.URL),
+			)
+			req = req.WithContext(ctx)
+			// On non-final attempts, suppress error response so we can retry
+			writeErr := attempt == maxRetries
+			err = h.proxyToLease(w, req, curLease.Lease.URL, targetAppId.String(), *appName, writeErr)
+			if err != nil && isProxyConnectionError(err) {
+				// Cached lease pointed at a dead sandbox — invalidate and retry
+				h.invalidateLease(context.Background(), targetAppId.String(), curLease)
+				h.Log.Warn("stale lease, retrying with fresh lease",
+					"stale_url", curLease.Lease.URL,
+					"attempt", attempt,
+					"app", targetAppId)
+				continue
+			}
+			if err != nil {
+				h.invalidateLease(context.Background(), targetAppId.String(), curLease)
+			} else {
+				h.releaseLease(ctx, curLease)
+			}
+			return
+		}
+
+		// No cached lease — acquire a fresh one
+		leaseSpan.SetAttributes(attribute.Bool("miren.lease.cached", false))
+
+		if app.ActiveVersion == "" {
+			h.Log.Debug("no active version for app", "app", targetAppId)
+			http.Error(w, fmt.Sprintf("no active version for app: %s", targetAppId), http.StatusNotFound)
+			return
+		}
+
+		vr, err := h.eac.Get(ctx, app.ActiveVersion.String())
+		if err != nil {
+			h.Log.Error("error looking up application version", "error", err, "version", app.ActiveVersion)
+			http.Error(w, fmt.Sprintf("error looking up application version: %s", app.ActiveVersion), http.StatusInternalServerError)
+			return
+		}
+
+		var av core_v1alpha.AppVersion
+		av.Decode(vr.Entity().Entity())
+
+		leaseSpan.SetAttributes(
+			attribute.String("miren.app.version", app.ActiveVersion.String()),
+		)
+
+		// Give lease acquisition a generous timeout to complete sandbox boot
+		// even if the client request times out. This prevents dangling resources.
+		actContext, actCancel := context.WithTimeout(context.Background(), leaseAcquisitionTimeout)
+		defer actCancel()
+
+		actLease, err := h.aa.AcquireLease(actContext, &av, "web")
+		if err != nil {
+			if errors.Is(err, activator.ErrSandboxDiedEarly) {
+				h.Log.Error("sandbox died early while acquiring lease", "error", err, "app", targetAppId)
+				http.Error(w, fmt.Sprintf("The application %s failed to boot. Please check the applications logs.\n", targetAppId), http.StatusRequestTimeout)
+			} else {
+				h.Log.Error("error acquiring lease", "error", err, "app", targetAppId)
+				http.Error(w, fmt.Sprintf("error acquiring lease: %s", targetAppId), http.StatusInternalServerError)
+			}
+			return
+		}
+
+		if actLease == nil {
+			h.Log.Debug("no lease available for app", "app", targetAppId)
+			http.Error(w, fmt.Sprintf("no lease available for app: %s", targetAppId), http.StatusServiceUnavailable)
+			return
+		}
+
+		leaseSpan.SetAttributes(attribute.String("miren.lease.url", actLease.URL))
+
+		localLease := h.retainLease(ctx, targetAppId.String(), actLease)
+
+		req = req.WithContext(ctx)
+		// Fresh lease — always write error response (no retry on fresh lease failure)
+		err = h.proxyToLease(w, req, actLease.URL, targetAppId.String(), *appName, true)
+		if err != nil {
+			// Connection error on a fresh lease - the sandbox may have died
+			// between lease acquisition and proxy. Invalidate immediately.
+			h.invalidateLease(context.Background(), targetAppId.String(), localLease)
+		} else {
+			h.releaseLease(ctx, localLease)
+		}
 		return
-	}
-
-	if actLease == nil {
-		h.Log.Debug("no lease available for app", "app", targetAppId)
-		http.Error(w, fmt.Sprintf("no lease available for app: %s", targetAppId), http.StatusServiceUnavailable)
-		return
-	}
-
-	leaseSpan.SetAttributes(attribute.String("miren.lease.url", actLease.URL))
-
-	localLease := h.retainLease(ctx, targetAppId.String(), actLease)
-
-	req = req.WithContext(ctx)
-	err = h.proxyToLease(w, req, actLease.URL, targetAppId.String(), *appName)
-	if err != nil {
-		// Connection error on a fresh lease - the sandbox may have died
-		// between lease acquisition and proxy. Invalidate immediately.
-		h.invalidateLease(context.Background(), targetAppId.String(), localLease)
-	} else {
-		h.releaseLease(ctx, localLease)
 	}
 }
 
@@ -632,7 +655,12 @@ func (h *Server) logRequestFromStats(appEntityID, appName string, stats httputil
 // proxyToLease proxies the request to the target URL and returns any connection error.
 // If the proxy fails with a connection error (connection refused, no route to host, etc.),
 // it returns the error so the caller can invalidate the lease.
-func (h *Server) proxyToLease(w http.ResponseWriter, req *http.Request, targetURL, appEntityID, appName string) error {
+//
+// When writeErrorResponse is false and a connection error occurs, the ErrorHandler
+// captures the error but does NOT write to the ResponseWriter, allowing the caller
+// to retry with a fresh lease. This is safe because connection errors happen during
+// TCP dial, before any response bytes are sent.
+func (h *Server) proxyToLease(w http.ResponseWriter, req *http.Request, targetURL, appEntityID, appName string, writeErrorResponse bool) error {
 	targetParsed, err := url.Parse(targetURL)
 	if err != nil {
 		h.Log.Error("failed to parse target URL", "error", err, "url", targetURL)
@@ -666,6 +694,13 @@ func (h *Server) proxyToLease(w http.ResponseWriter, req *http.Request, targetUR
 		},
 		ErrorHandler: func(rw http.ResponseWriter, r *http.Request, err error) {
 			proxyErr = err
+			// When writeErrorResponse is false and we have a connection error,
+			// suppress the response so the caller can retry with a fresh lease.
+			// Connection errors happen during TCP dial before any bytes are sent.
+			if !writeErrorResponse && isProxyConnectionError(err) {
+				h.Log.Warn("proxy connection error to sandbox (will retry)", "error", err, "url", targetURL, "app", appName)
+				return
+			}
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				h.Log.Warn("request timeout", "url", targetURL, "app", appName)
@@ -691,20 +726,6 @@ func (h *Server) proxyToLease(w http.ResponseWriter, req *http.Request, targetUR
 		return proxyErr
 	}
 	return nil
-}
-
-func (h *Server) forwardToLease(ctx context.Context, w http.ResponseWriter, req *http.Request, lease *lease, appEntityID, appName string) {
-	err := h.proxyToLease(w, req, lease.Lease.URL, appEntityID, appName)
-	if err != nil {
-		// Connection error indicates the sandbox is dead - invalidate the lease
-		// so subsequent requests will acquire a fresh lease to a healthy sandbox.
-		// Use background context since request context may be cancelled.
-		h.invalidateLease(context.Background(), appEntityID, lease)
-	} else {
-		// Only release (decrement use count) if the proxy succeeded.
-		// If we invalidated, the lease is already removed from cache.
-		h.releaseLease(ctx, lease)
-	}
 }
 
 /*
@@ -909,42 +930,61 @@ func (h *Server) DoRequest(ctx context.Context, req *httpingress_v1alpha.Interna
 	var av core_v1alpha.AppVersion
 	av.Decode(vr.Entity().Entity())
 
-	// Try to use an existing lease
+	// Try to use an existing lease, with retry on stale cached lease
 	curLease, err := h.useLease(ctx, appId)
 	if err != nil {
 		resp.SetError(fmt.Sprintf("error taking lease: %v", err))
 		return resp, nil
 	}
 
-	if curLease == nil {
-		// Need to acquire a new lease
-		actContext, actCancel := context.WithTimeout(context.Background(), leaseAcquisitionTimeout)
-		defer actCancel()
-
-		actLease, err := h.aa.AcquireLease(actContext, &av, service)
-		if err != nil {
-			if errors.Is(err, activator.ErrSandboxDiedEarly) {
-				resp.SetError("sandbox died early while acquiring lease")
+	// If we got a cached lease, try it — but retry with a fresh one on connection error
+	if curLease != nil {
+		httpResp, err := h.executeInternalRequest(ctx, curLease, req, method, path, appId)
+		if err != nil && isProxyConnectionError(err) {
+			// Stale cached lease — invalidate and fall through to acquire fresh
+			h.invalidateLease(context.Background(), appId, curLease)
+			h.Log.Warn("stale lease on internal request, retrying with fresh lease",
+				"stale_url", curLease.Lease.URL, "app", appId)
+			curLease = nil
+		} else if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				h.releaseLease(ctx, curLease)
 			} else {
-				resp.SetError(fmt.Sprintf("error acquiring lease: %v", err))
+				h.releaseLease(ctx, curLease)
 			}
+			resp.SetError(fmt.Sprintf("request failed: %v", err))
 			return resp, nil
+		} else {
+			defer httpResp.Body.Close()
+			h.releaseLease(ctx, curLease)
+			return h.buildInternalResponse(resp, httpResp, appId, method, path, startTime)
 		}
-
-		if actLease == nil {
-			resp.SetError("no lease available for app")
-			return resp, nil
-		}
-
-		curLease = h.retainLease(ctx, appId, actLease)
 	}
 
-	// Execute the HTTP request
+	// No cached lease (or stale one was invalidated) — acquire fresh
+	actContext, actCancel := context.WithTimeout(context.Background(), leaseAcquisitionTimeout)
+	defer actCancel()
+
+	actLease, err := h.aa.AcquireLease(actContext, &av, service)
+	if err != nil {
+		if errors.Is(err, activator.ErrSandboxDiedEarly) {
+			resp.SetError("sandbox died early while acquiring lease")
+		} else {
+			resp.SetError(fmt.Sprintf("error acquiring lease: %v", err))
+		}
+		return resp, nil
+	}
+
+	if actLease == nil {
+		resp.SetError("no lease available for app")
+		return resp, nil
+	}
+
+	curLease = h.retainLease(ctx, appId, actLease)
+
+	// Execute the HTTP request with fresh lease (no retry)
 	httpResp, err := h.executeInternalRequest(ctx, curLease, req, method, path, appId)
 	if err != nil {
-		// Context errors (timeout, cancellation) are not connection failures —
-		// the sandbox is likely still healthy, so just release the lease.
-		// Only invalidate for actual connection errors (refused, no route, etc).
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			h.releaseLease(ctx, curLease)
 		} else if isProxyConnectionError(err) {
@@ -960,7 +1000,16 @@ func (h *Server) DoRequest(ctx context.Context, req *httpingress_v1alpha.Interna
 	// Release the lease on success
 	h.releaseLease(ctx, curLease)
 
-	// Build the response
+	return h.buildInternalResponse(resp, httpResp, appId, method, path, startTime)
+}
+
+// buildInternalResponse populates the InternalHttpResponse from the HTTP response.
+func (h *Server) buildInternalResponse(
+	resp *httpingress_v1alpha.InternalHttpResponse,
+	httpResp *http.Response,
+	appId, method, path string,
+	startTime time.Time,
+) (*httpingress_v1alpha.InternalHttpResponse, error) {
 	resp.SetStatusCode(int32(httpResp.StatusCode))
 
 	// Copy response headers

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -694,9 +694,6 @@ func (h *Server) proxyToLease(w http.ResponseWriter, req *http.Request, targetUR
 		},
 		ErrorHandler: func(rw http.ResponseWriter, r *http.Request, err error) {
 			proxyErr = err
-			// When writeErrorResponse is false and we have a connection error,
-			// suppress the response so the caller can retry with a fresh lease.
-			// Connection errors happen during TCP dial before any bytes are sent.
 			if !writeErrorResponse && isProxyConnectionError(err) {
 				h.Log.Warn("proxy connection error to sandbox (will retry)", "error", err, "url", targetURL, "app", appName)
 				return
@@ -947,11 +944,7 @@ func (h *Server) DoRequest(ctx context.Context, req *httpingress_v1alpha.Interna
 				"stale_url", curLease.Lease.URL, "app", appId)
 			curLease = nil
 		} else if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				h.releaseLease(ctx, curLease)
-			} else {
-				h.releaseLease(ctx, curLease)
-			}
+			h.releaseLease(ctx, curLease)
 			resp.SetError(fmt.Sprintf("request failed: %v", err))
 			return resp, nil
 		} else {

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -959,8 +959,8 @@ func (h *Server) DoRequest(ctx context.Context, req *httpingress_v1alpha.Interna
 	if curLease != nil {
 		httpResp, err := h.executeInternalRequest(ctx, curLease, req, method, path, appId)
 		if err != nil && isProxyConnectionError(err) {
-			// Stale cached lease — invalidate and fall through to acquire fresh
-			h.invalidateLease(context.Background(), appId, curLease)
+			// Stale cached lease — invalidate all app leases and fall through to acquire fresh
+			h.invalidateAppLeases(context.Background(), appId)
 			h.Log.Warn("stale lease on internal request, retrying with fresh lease",
 				"stale_url", curLease.Lease.URL, "app", appId)
 			curLease = nil

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -322,6 +322,26 @@ func (h *Server) invalidateLease(ctx context.Context, app string, lease *lease) 
 	}
 }
 
+// invalidateAppLeases removes all cached leases for an app.
+// During rollover, multiple cached leases may point to the same dead sandbox,
+// so invalidating all of them ensures the retry acquires a fresh lease.
+func (h *Server) invalidateAppLeases(ctx context.Context, app string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	ar, ok := h.apps[app]
+	if !ok {
+		return
+	}
+
+	for _, l := range ar.leases {
+		h.Log.Info("invalidating stale lease due to proxy error", "app", app, "url", l.Lease.URL)
+		h.aa.ReleaseLease(ctx, l.Lease)
+	}
+
+	delete(h.apps, app)
+}
+
 func (h *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	h.handleRequest(w, req)
 }
@@ -519,7 +539,7 @@ func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Requ
 	defer leaseSpan.End()
 
 	// Retry loop: if a cached lease fails with a connection error (stale sandbox),
-	// invalidate it and retry once — the next iteration acquires a fresh lease.
+	// invalidate all cached leases and retry once to acquire a fresh lease.
 	const maxRetries = 1
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		// Try to use a cached lease
@@ -540,8 +560,9 @@ func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Requ
 			writeErr := attempt == maxRetries
 			err = h.proxyToLease(w, req, curLease.Lease.URL, targetAppId.String(), *appName, writeErr)
 			if err != nil && isProxyConnectionError(err) {
-				// Cached lease pointed at a dead sandbox — invalidate and retry
-				h.invalidateLease(context.Background(), targetAppId.String(), curLease)
+				// Cached lease pointed at a dead sandbox — invalidate all app
+				// leases (they likely all point to the same dead sandbox) and retry
+				h.invalidateAppLeases(context.Background(), targetAppId.String())
 				h.Log.Warn("stale lease, retrying with fresh lease",
 					"stale_url", curLease.Lease.URL,
 					"attempt", attempt,

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -803,9 +803,11 @@ func (rw *responseWriter) Unwrap() http.ResponseWriter {
 	return rw.ResponseWriter
 }
 
-// isProxyConnectionError checks if an error indicates the backend is unreachable.
-// This includes connection refused, no route to host, and similar network failures
-// that indicate the sandbox is dead or gone.
+// isProxyConnectionError checks if an error indicates the backend is unreachable
+// because a TCP connection was never established. This is used to trigger retries
+// on stale cached leases, so it intentionally excludes ECONNRESET/ECONNABORTED —
+// those indicate a connection that *was* established and may have partially
+// processed the request, making it unsafe to retry non-idempotent methods.
 func isProxyConnectionError(err error) bool {
 	if err == nil {
 		return false
@@ -824,10 +826,6 @@ func isProxyConnectionError(err error) bool {
 				case syscall.EHOSTUNREACH: // no route to host
 					return true
 				case syscall.ENETUNREACH: // network unreachable
-					return true
-				case syscall.ECONNRESET: // connection reset by peer
-					return true
-				case syscall.ECONNABORTED: // connection aborted
 					return true
 				}
 			}

--- a/servers/httpingress/httpingress_test.go
+++ b/servers/httpingress/httpingress_test.go
@@ -417,10 +417,7 @@ func TestWebSocketUpgrade(t *testing.T) {
 	}
 }
 
-// TestProxyToLeaseRetrySuppress verifies that proxyToLease with writeErrorResponse=false
-// does not write to the ResponseWriter on connection error, enabling retry.
 func TestProxyToLeaseRetrySuppress(t *testing.T) {
-	// Use a URL that will immediately refuse connections
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.ResponseHeaderTimeout = 1 * time.Second
 
@@ -432,10 +429,9 @@ func TestProxyToLeaseRetrySuppress(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/test", nil)
 
-	// Target a port that definitely isn't listening
+	// Port 1 is not listening — triggers ECONNREFUSED
 	err := h.proxyToLease(rec, req, "http://127.0.0.1:1", "app/test", "test-app", false)
 
-	// Should return a connection error
 	if err == nil {
 		t.Fatal("expected connection error, got nil")
 	}
@@ -443,7 +439,7 @@ func TestProxyToLeaseRetrySuppress(t *testing.T) {
 		t.Fatalf("expected proxy connection error, got: %v", err)
 	}
 
-	// With writeErrorResponse=false, the ResponseWriter should NOT have been written to
+	// writeErrorResponse=false should leave the ResponseWriter untouched
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected no status written (default 200), got %d", rec.Code)
 	}
@@ -452,8 +448,6 @@ func TestProxyToLeaseRetrySuppress(t *testing.T) {
 	}
 }
 
-// TestProxyToLeaseWriteErrorOnFinalAttempt verifies that proxyToLease with
-// writeErrorResponse=true writes a 502 on connection error.
 func TestProxyToLeaseWriteErrorOnFinalAttempt(t *testing.T) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.ResponseHeaderTimeout = 1 * time.Second
@@ -466,24 +460,17 @@ func TestProxyToLeaseWriteErrorOnFinalAttempt(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/test", nil)
 
-	// Target a port that definitely isn't listening
 	err := h.proxyToLease(rec, req, "http://127.0.0.1:1", "app/test", "test-app", true)
 
-	// Should return a connection error
 	if err == nil {
 		t.Fatal("expected connection error, got nil")
 	}
-
-	// With writeErrorResponse=true, should have written a 502
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("expected 502, got %d", rec.Code)
 	}
 }
 
-// TestProxyToLeaseNoRetryOnTimeout verifies that timeouts don't trigger retry
-// (only connection errors should).
 func TestProxyToLeaseNoRetryOnTimeout(t *testing.T) {
-	// Backend that never responds
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
 	}))
@@ -502,13 +489,10 @@ func TestProxyToLeaseNoRetryOnTimeout(t *testing.T) {
 
 	err := h.proxyToLease(rec, req, backend.URL, "app/test", "test-app", false)
 
-	// Timeout is NOT a connection error — should return nil (error was handled by writing 503)
+	// Timeouts are not connection errors — writeErrorResponse only suppresses connection errors
 	if err != nil {
 		t.Errorf("expected nil (timeout handled inline), got: %v", err)
 	}
-
-	// Timeout should write 503 even with writeErrorResponse=false
-	// (writeErrorResponse only suppresses connection errors)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503 for timeout, got %d", rec.Code)
 	}

--- a/servers/httpingress/httpingress_test.go
+++ b/servers/httpingress/httpingress_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -413,5 +414,102 @@ func TestWebSocketUpgrade(t *testing.T) {
 
 	if resp.StatusCode != http.StatusSwitchingProtocols {
 		t.Errorf("Expected 101 Switching Protocols, got %d", resp.StatusCode)
+	}
+}
+
+// TestProxyToLeaseRetrySuppress verifies that proxyToLease with writeErrorResponse=false
+// does not write to the ResponseWriter on connection error, enabling retry.
+func TestProxyToLeaseRetrySuppress(t *testing.T) {
+	// Use a URL that will immediately refuse connections
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = 1 * time.Second
+
+	h := &Server{
+		Log:       slog.Default(),
+		transport: transport,
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+
+	// Target a port that definitely isn't listening
+	err := h.proxyToLease(rec, req, "http://127.0.0.1:1", "app/test", "test-app", false)
+
+	// Should return a connection error
+	if err == nil {
+		t.Fatal("expected connection error, got nil")
+	}
+	if !isProxyConnectionError(err) {
+		t.Fatalf("expected proxy connection error, got: %v", err)
+	}
+
+	// With writeErrorResponse=false, the ResponseWriter should NOT have been written to
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected no status written (default 200), got %d", rec.Code)
+	}
+	if rec.Body.Len() > 0 {
+		t.Errorf("expected no body written, got %d bytes: %s", rec.Body.Len(), rec.Body.String())
+	}
+}
+
+// TestProxyToLeaseWriteErrorOnFinalAttempt verifies that proxyToLease with
+// writeErrorResponse=true writes a 502 on connection error.
+func TestProxyToLeaseWriteErrorOnFinalAttempt(t *testing.T) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = 1 * time.Second
+
+	h := &Server{
+		Log:       slog.Default(),
+		transport: transport,
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+
+	// Target a port that definitely isn't listening
+	err := h.proxyToLease(rec, req, "http://127.0.0.1:1", "app/test", "test-app", true)
+
+	// Should return a connection error
+	if err == nil {
+		t.Fatal("expected connection error, got nil")
+	}
+
+	// With writeErrorResponse=true, should have written a 502
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", rec.Code)
+	}
+}
+
+// TestProxyToLeaseNoRetryOnTimeout verifies that timeouts don't trigger retry
+// (only connection errors should).
+func TestProxyToLeaseNoRetryOnTimeout(t *testing.T) {
+	// Backend that never responds
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer backend.Close()
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = 50 * time.Millisecond
+
+	h := &Server{
+		Log:       slog.Default(),
+		transport: transport,
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+
+	err := h.proxyToLease(rec, req, backend.URL, "app/test", "test-app", false)
+
+	// Timeout is NOT a connection error — should return nil (error was handled by writing 503)
+	if err != nil {
+		t.Errorf("expected nil (timeout handled inline), got: %v", err)
+	}
+
+	// Timeout should write 503 even with writeErrorResponse=false
+	// (writeErrorResponse only suppresses connection errors)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 for timeout, got %d", rec.Code)
 	}
 }

--- a/servers/httpingress/httpingress_test.go
+++ b/servers/httpingress/httpingress_test.go
@@ -283,7 +283,7 @@ func TestIsProxyConnectionError(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "connection reset",
+			name: "connection reset (not treated as connection error - request may have been processed)",
 			err: &net.OpError{
 				Op:  "read",
 				Net: "tcp",
@@ -292,10 +292,10 @@ func TestIsProxyConnectionError(t *testing.T) {
 					Err:     syscall.ECONNRESET,
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
-			name: "connection aborted",
+			name: "connection aborted (not treated as connection error - request may have been processed)",
 			err: &net.OpError{
 				Op:  "read",
 				Net: "tcp",
@@ -304,7 +304,7 @@ func TestIsProxyConnectionError(t *testing.T) {
 					Err:     syscall.ECONNABORTED,
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 		{
 			name: "net.OpError without syscall error",

--- a/servers/httpingress/lease_test.go
+++ b/servers/httpingress/lease_test.go
@@ -282,14 +282,10 @@ func TestInvalidateLeaseRemovesFromCache(t *testing.T) {
 	srv := newTestServer(aa)
 	ctx := context.Background()
 
-	// Retain a lease
 	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
 	ll := srv.retainLease(ctx, "app/myapp", actLease)
-
-	// Invalidate it (simulates connection error path)
 	srv.invalidateLease(ctx, "app/myapp", ll)
 
-	// Verify the lease was released to the activator
 	aa.mu.Lock()
 	releaseCount := aa.releaseCount
 	aa.mu.Unlock()
@@ -297,7 +293,6 @@ func TestInvalidateLeaseRemovesFromCache(t *testing.T) {
 		t.Errorf("expected 1 release on invalidation, got %d", releaseCount)
 	}
 
-	// Verify the app is removed from cache
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	if _, ok := srv.apps["app/myapp"]; ok {
@@ -306,18 +301,15 @@ func TestInvalidateLeaseRemovesFromCache(t *testing.T) {
 }
 
 func TestInvalidateAndReacquire(t *testing.T) {
-	// This tests the retry scenario: after invalidating a stale lease,
-	// useLease returns nil, forcing the caller to acquire fresh.
 	aa := &mockActivator{}
 	srv := newTestServer(aa)
 	ctx := context.Background()
 
-	// Retain and then invalidate a lease
 	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
 	ll := srv.retainLease(ctx, "app/myapp", actLease)
 	srv.invalidateLease(ctx, "app/myapp", ll)
 
-	// Now useLease should return nil (cache is empty)
+	// After invalidation, cache is empty
 	got, err := srv.useLease(ctx, "app/myapp")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -326,11 +318,10 @@ func TestInvalidateAndReacquire(t *testing.T) {
 		t.Error("expected nil lease after invalidation, got non-nil")
 	}
 
-	// Simulate acquiring a fresh lease (as the retry loop would)
+	// Retain a fresh lease (simulates the retry path acquiring a new one)
 	freshLease := &activator.Lease{Size: 10, URL: "http://10.0.0.2:3000"}
 	freshLL := srv.retainLease(ctx, "app/myapp", freshLease)
 
-	// The fresh lease should now be usable
 	got2, err := srv.useLease(ctx, "app/myapp")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -342,7 +333,6 @@ func TestInvalidateAndReacquire(t *testing.T) {
 		t.Errorf("expected fresh lease URL, got %s", got2.Lease.URL)
 	}
 
-	// Clean up
 	srv.releaseLease(ctx, freshLL)
 	srv.releaseLease(ctx, got2)
 }

--- a/servers/httpingress/lease_test.go
+++ b/servers/httpingress/lease_test.go
@@ -276,3 +276,73 @@ func TestMultipleAppsIndependentTTL(t *testing.T) {
 		t.Error("expected app/b to still be cached (within TTL)")
 	}
 }
+
+func TestInvalidateLeaseRemovesFromCache(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// Retain a lease
+	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	ll := srv.retainLease(ctx, "app/myapp", actLease)
+
+	// Invalidate it (simulates connection error path)
+	srv.invalidateLease(ctx, "app/myapp", ll)
+
+	// Verify the lease was released to the activator
+	aa.mu.Lock()
+	releaseCount := aa.releaseCount
+	aa.mu.Unlock()
+	if releaseCount != 1 {
+		t.Errorf("expected 1 release on invalidation, got %d", releaseCount)
+	}
+
+	// Verify the app is removed from cache
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if _, ok := srv.apps["app/myapp"]; ok {
+		t.Error("expected app to be removed from cache after invalidation")
+	}
+}
+
+func TestInvalidateAndReacquire(t *testing.T) {
+	// This tests the retry scenario: after invalidating a stale lease,
+	// useLease returns nil, forcing the caller to acquire fresh.
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// Retain and then invalidate a lease
+	actLease := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	ll := srv.retainLease(ctx, "app/myapp", actLease)
+	srv.invalidateLease(ctx, "app/myapp", ll)
+
+	// Now useLease should return nil (cache is empty)
+	got, err := srv.useLease(ctx, "app/myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil lease after invalidation, got non-nil")
+	}
+
+	// Simulate acquiring a fresh lease (as the retry loop would)
+	freshLease := &activator.Lease{Size: 10, URL: "http://10.0.0.2:3000"}
+	freshLL := srv.retainLease(ctx, "app/myapp", freshLease)
+
+	// The fresh lease should now be usable
+	got2, err := srv.useLease(ctx, "app/myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got2 == nil {
+		t.Fatal("expected to get fresh lease")
+	}
+	if got2.Lease.URL != "http://10.0.0.2:3000" {
+		t.Errorf("expected fresh lease URL, got %s", got2.Lease.URL)
+	}
+
+	// Clean up
+	srv.releaseLease(ctx, freshLL)
+	srv.releaseLease(ctx, got2)
+}

--- a/servers/httpingress/lease_test.go
+++ b/servers/httpingress/lease_test.go
@@ -300,6 +300,39 @@ func TestInvalidateLeaseRemovesFromCache(t *testing.T) {
 	}
 }
 
+func TestInvalidateAppLeasesRemovesAll(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	// Retain two leases for the same app (simulates multiple cached connections)
+	lease1 := &activator.Lease{Size: 10, URL: "http://10.0.0.1:3000"}
+	srv.retainLease(ctx, "app/myapp", lease1)
+	lease2 := &activator.Lease{Size: 10, URL: "http://10.0.0.2:3000"}
+	srv.retainLease(ctx, "app/myapp", lease2)
+
+	srv.invalidateAppLeases(ctx, "app/myapp")
+
+	aa.mu.Lock()
+	releaseCount := aa.releaseCount
+	releasedURLs := aa.releasedURLs
+	aa.mu.Unlock()
+
+	if releaseCount != 2 {
+		t.Errorf("expected 2 releases on app invalidation, got %d", releaseCount)
+	}
+	if len(releasedURLs) != 2 {
+		t.Errorf("expected 2 released URLs, got %v", releasedURLs)
+	}
+
+	// Cache should be fully cleared
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if _, ok := srv.apps["app/myapp"]; ok {
+		t.Error("expected app to be removed from cache after invalidateAppLeases")
+	}
+}
+
 func TestInvalidateAndReacquire(t *testing.T) {
 	aa := &mockActivator{}
 	srv := newTestServer(aa)


### PR DESCRIPTION
I deployed a service and hit a 502 during the rollover. The httpingress was holding a cached lease to the old sandbox's IP, which had already been killed. The new sandbox was running fine, but the ingress didn't know about it yet — the very next request after the 502 would've succeeded, but the unlucky one got an error page.

Two things conspired to cause this: the httpingress would proxy to a cached lease, get a connection error, invalidate the lease, and immediately return 502 without retrying. And over in the launcher, `reconcileAppVersion` was scaling down the old pool the instant it created the new one, without waiting for the new sandbox to actually boot.

The fix is two complementary changes. First, the httpingress now retries once when a cached lease fails with a connection error — it invalidates the stale lease and loops back, which acquires a fresh lease to the new sandbox. The `proxyToLease` method gains a `writeErrorResponse` flag so the first attempt can suppress the 502 and give the retry a chance. `DoRequest` (the internal/non-proxy path) gets the same treatment.

Second, the launcher now waits for new pools to have at least one ready instance before scaling down old version pools. `ensurePoolForService` returns the new pool ID so `reconcileAppVersion` can poll `ReadyInstances` before calling `cleanupOldVersionPools`. If it times out (60s default), it logs a warning and proceeds — the httpingress retry covers any remaining gap.

Together these mean you should never see a 502 during a normal rollover: the launcher won't kill the old sandbox until the new one is ready, and even if something slips through the cracks, the ingress retries transparently.