### PR TITLE
Support multiple ports and non-HTTP services per app

### DIFF
--- a/api/core/config_version.go
+++ b/api/core/config_version.go
@@ -46,6 +46,23 @@ func ConfigSpecFromConfig(cfg *core_v1alpha.Config) core_v1alpha.ConfigSpec {
 			},
 		}
 
+		// Convert ports array
+		for _, p := range svc.Ports {
+			sp := core_v1alpha.ConfigSpecServicesPorts{
+				Port:     p.Port,
+				Name:     p.Name,
+				Type:     p.Type,
+				NodePort: p.NodePort,
+			}
+			switch p.Protocol {
+			case core_v1alpha.TCP:
+				sp.Protocol = core_v1alpha.ConfigSpecServicesPortsTCP
+			case core_v1alpha.UDP:
+				sp.Protocol = core_v1alpha.ConfigSpecServicesPortsUDP
+			}
+			s.Ports = append(s.Ports, sp)
+		}
+
 		// Convert service-level env vars
 		for _, e := range svc.Env {
 			s.Env = append(s.Env, core_v1alpha.ConfigSpecServicesEnv(e))

--- a/api/core/core_v1alpha/schema.gen.go
+++ b/api/core/core_v1alpha/schema.gen.go
@@ -94,6 +94,7 @@ const (
 	ConfigSpecServicesPortId        = entity.Id("dev.miren.core/component.config_spec.services.port")
 	ConfigSpecServicesPortNameId    = entity.Id("dev.miren.core/component.config_spec.services.port_name")
 	ConfigSpecServicesPortTypeId    = entity.Id("dev.miren.core/component.config_spec.services.port_type")
+	ConfigSpecServicesPortsId       = entity.Id("dev.miren.core/component.config_spec.services.ports")
 )
 
 type ConfigSpecServices struct {
@@ -106,6 +107,7 @@ type ConfigSpecServices struct {
 	Port        int64                         `cbor:"port,omitempty" json:"port,omitempty"`
 	PortName    string                        `cbor:"port_name,omitempty" json:"port_name,omitempty"`
 	PortType    string                        `cbor:"port_type,omitempty" json:"port_type,omitempty"`
+	Ports       []ConfigSpecServicesPorts     `cbor:"ports,omitempty" json:"ports,omitempty"`
 }
 
 func (o *ConfigSpecServices) Decode(e entity.AttrGetter) {
@@ -144,6 +146,13 @@ func (o *ConfigSpecServices) Decode(e entity.AttrGetter) {
 	if a, ok := e.Get(ConfigSpecServicesPortTypeId); ok && a.Value.Kind() == entity.KindString {
 		o.PortType = a.Value.String()
 	}
+	for _, a := range e.GetAll(ConfigSpecServicesPortsId) {
+		if a.Value.Kind() == entity.KindComponent {
+			var v ConfigSpecServicesPorts
+			v.Decode(a.Value.Component())
+			o.Ports = append(o.Ports, v)
+		}
+	}
 }
 
 func (o *ConfigSpecServices) Encode() (attrs []entity.Attr) {
@@ -173,6 +182,9 @@ func (o *ConfigSpecServices) Encode() (attrs []entity.Attr) {
 	}
 	if !entity.Empty(o.PortType) {
 		attrs = append(attrs, entity.String(ConfigSpecServicesPortTypeId, o.PortType))
+	}
+	for _, v := range o.Ports {
+		attrs = append(attrs, entity.Component(ConfigSpecServicesPortsId, v.Encode()))
 	}
 	return
 }
@@ -205,6 +217,9 @@ func (o *ConfigSpecServices) Empty() bool {
 	if !entity.Empty(o.PortType) {
 		return false
 	}
+	if len(o.Ports) != 0 {
+		return false
+	}
 	return true
 }
 
@@ -221,6 +236,8 @@ func (o *ConfigSpecServices) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Int64("port", "dev.miren.core/component.config_spec.services.port", schema.Doc("The TCP port the service listens on"))
 	sb.String("port_name", "dev.miren.core/component.config_spec.services.port_name", schema.Doc("The name of the port (e.g. http, grpc)"))
 	sb.String("port_type", "dev.miren.core/component.config_spec.services.port_type", schema.Doc("The type of the port (e.g. http, tcp)"))
+	sb.Component("ports", "dev.miren.core/component.config_spec.services.ports", schema.Doc("Network ports this service listens on. Overrides scalar port/port_name/port_type."), schema.Many)
+	(&ConfigSpecServicesPorts{}).InitSchema(sb.Builder("component.config_spec.services.ports"))
 }
 
 const (
@@ -491,6 +508,98 @@ func (o *ConfigSpecServicesEnv) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Bool("sensitive", "dev.miren.core/component.config_spec.services.env.sensitive", schema.Doc("Whether or not the value is sensitive"))
 	sb.String("source", "dev.miren.core/component.config_spec.services.env.source", schema.Doc("The source of the variable (config or manual). Defaults to config for backward compatibility."))
 	sb.String("value", "dev.miren.core/component.config_spec.services.env.value", schema.Doc("The value of the variable"))
+}
+
+const (
+	ConfigSpecServicesPortsNameId        = entity.Id("dev.miren.core/component.config_spec.services.ports.name")
+	ConfigSpecServicesPortsNodePortId    = entity.Id("dev.miren.core/component.config_spec.services.ports.node_port")
+	ConfigSpecServicesPortsPortId        = entity.Id("dev.miren.core/component.config_spec.services.ports.port")
+	ConfigSpecServicesPortsProtocolId    = entity.Id("dev.miren.core/component.config_spec.services.ports.protocol")
+	ConfigSpecServicesPortsProtocolTcpId = entity.Id("dev.miren.core/component.config_spec.services.ports.protocol.tcp")
+	ConfigSpecServicesPortsProtocolUdpId = entity.Id("dev.miren.core/component.config_spec.services.ports.protocol.udp")
+	ConfigSpecServicesPortsTypeId        = entity.Id("dev.miren.core/component.config_spec.services.ports.type")
+)
+
+type ConfigSpecServicesPorts struct {
+	Name     string                          `cbor:"name" json:"name"`
+	NodePort int64                           `cbor:"node_port,omitempty" json:"node_port,omitempty"`
+	Port     int64                           `cbor:"port" json:"port"`
+	Protocol ConfigSpecServicesPortsProtocol `cbor:"protocol,omitempty" json:"protocol,omitempty"`
+	Type     string                          `cbor:"type,omitempty" json:"type,omitempty"`
+}
+
+type ConfigSpecServicesPortsProtocol string
+
+const (
+	ConfigSpecServicesPortsTCP ConfigSpecServicesPortsProtocol = "component.config_spec.services.ports.protocol.tcp"
+	ConfigSpecServicesPortsUDP ConfigSpecServicesPortsProtocol = "component.config_spec.services.ports.protocol.udp"
+)
+
+var ConfigSpecServicesPortsprotocolFromId = map[entity.Id]ConfigSpecServicesPortsProtocol{ConfigSpecServicesPortsProtocolTcpId: ConfigSpecServicesPortsTCP, ConfigSpecServicesPortsProtocolUdpId: ConfigSpecServicesPortsUDP}
+var ConfigSpecServicesPortsprotocolToId = map[ConfigSpecServicesPortsProtocol]entity.Id{ConfigSpecServicesPortsTCP: ConfigSpecServicesPortsProtocolTcpId, ConfigSpecServicesPortsUDP: ConfigSpecServicesPortsProtocolUdpId}
+
+func (o *ConfigSpecServicesPorts) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(ConfigSpecServicesPortsNameId); ok && a.Value.Kind() == entity.KindString {
+		o.Name = a.Value.String()
+	}
+	if a, ok := e.Get(ConfigSpecServicesPortsNodePortId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.NodePort = a.Value.Int64()
+	}
+	if a, ok := e.Get(ConfigSpecServicesPortsPortId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.Port = a.Value.Int64()
+	}
+	if a, ok := e.Get(ConfigSpecServicesPortsProtocolId); ok && a.Value.Kind() == entity.KindId {
+		o.Protocol = ConfigSpecServicesPortsprotocolFromId[a.Value.Id()]
+	}
+	if a, ok := e.Get(ConfigSpecServicesPortsTypeId); ok && a.Value.Kind() == entity.KindString {
+		o.Type = a.Value.String()
+	}
+}
+
+func (o *ConfigSpecServicesPorts) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Name) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesPortsNameId, o.Name))
+	}
+	if !entity.Empty(o.NodePort) {
+		attrs = append(attrs, entity.Int64(ConfigSpecServicesPortsNodePortId, o.NodePort))
+	}
+	attrs = append(attrs, entity.Int64(ConfigSpecServicesPortsPortId, o.Port))
+	if a, ok := ConfigSpecServicesPortsprotocolToId[o.Protocol]; ok {
+		attrs = append(attrs, entity.Ref(ConfigSpecServicesPortsProtocolId, a))
+	}
+	if !entity.Empty(o.Type) {
+		attrs = append(attrs, entity.String(ConfigSpecServicesPortsTypeId, o.Type))
+	}
+	return
+}
+
+func (o *ConfigSpecServicesPorts) Empty() bool {
+	if !entity.Empty(o.Name) {
+		return false
+	}
+	if !entity.Empty(o.NodePort) {
+		return false
+	}
+	if !entity.Empty(o.Port) {
+		return false
+	}
+	if o.Protocol != "" {
+		return false
+	}
+	if !entity.Empty(o.Type) {
+		return false
+	}
+	return true
+}
+
+func (o *ConfigSpecServicesPorts) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("name", "dev.miren.core/component.config_spec.services.ports.name", schema.Required)
+	sb.Int64("node_port", "dev.miren.core/component.config_spec.services.ports.node_port")
+	sb.Int64("port", "dev.miren.core/component.config_spec.services.ports.port", schema.Required)
+	sb.Singleton("dev.miren.core/component.config_spec.services.ports.protocol.tcp")
+	sb.Singleton("dev.miren.core/component.config_spec.services.ports.protocol.udp")
+	sb.Ref("protocol", "dev.miren.core/component.config_spec.services.ports.protocol", schema.Choices(ConfigSpecServicesPortsProtocolTcpId, ConfigSpecServicesPortsProtocolUdpId))
+	sb.String("type", "dev.miren.core/component.config_spec.services.ports.type")
 }
 
 const (
@@ -975,6 +1084,7 @@ const (
 	ServicesPortId               = entity.Id("dev.miren.core/services.port")
 	ServicesPortNameId           = entity.Id("dev.miren.core/services.port_name")
 	ServicesPortTypeId           = entity.Id("dev.miren.core/services.port_type")
+	ServicesPortsId              = entity.Id("dev.miren.core/services.ports")
 	ServicesServiceConcurrencyId = entity.Id("dev.miren.core/services.service_concurrency")
 )
 
@@ -986,6 +1096,7 @@ type Services struct {
 	Port               int64              `cbor:"port,omitempty" json:"port,omitempty"`
 	PortName           string             `cbor:"port_name,omitempty" json:"port_name,omitempty"`
 	PortType           string             `cbor:"port_type,omitempty" json:"port_type,omitempty"`
+	Ports              []Ports            `cbor:"ports,omitempty" json:"ports,omitempty"`
 	ServiceConcurrency ServiceConcurrency `cbor:"service_concurrency,omitempty" json:"service_concurrency,omitempty"`
 }
 
@@ -1019,6 +1130,13 @@ func (o *Services) Decode(e entity.AttrGetter) {
 	if a, ok := e.Get(ServicesPortTypeId); ok && a.Value.Kind() == entity.KindString {
 		o.PortType = a.Value.String()
 	}
+	for _, a := range e.GetAll(ServicesPortsId) {
+		if a.Value.Kind() == entity.KindComponent {
+			var v Ports
+			v.Decode(a.Value.Component())
+			o.Ports = append(o.Ports, v)
+		}
+	}
 	if a, ok := e.Get(ServicesServiceConcurrencyId); ok && a.Value.Kind() == entity.KindComponent {
 		o.ServiceConcurrency.Decode(a.Value.Component())
 	}
@@ -1045,6 +1163,9 @@ func (o *Services) Encode() (attrs []entity.Attr) {
 	}
 	if !entity.Empty(o.PortType) {
 		attrs = append(attrs, entity.String(ServicesPortTypeId, o.PortType))
+	}
+	for _, v := range o.Ports {
+		attrs = append(attrs, entity.Component(ServicesPortsId, v.Encode()))
 	}
 	if !o.ServiceConcurrency.Empty() {
 		attrs = append(attrs, entity.Component(ServicesServiceConcurrencyId, o.ServiceConcurrency.Encode()))
@@ -1074,6 +1195,9 @@ func (o *Services) Empty() bool {
 	if !entity.Empty(o.PortType) {
 		return false
 	}
+	if len(o.Ports) != 0 {
+		return false
+	}
 	if !o.ServiceConcurrency.Empty() {
 		return false
 	}
@@ -1090,6 +1214,8 @@ func (o *Services) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Int64("port", "dev.miren.core/services.port", schema.Doc("The TCP port the service listens on. For the web service, if not specified it falls back to the deprecated top-level port (if set) or 3000. Other services must specify services.port explicitly and do not inherit the top-level port."))
 	sb.String("port_name", "dev.miren.core/services.port_name", schema.Doc("The name of the port (e.g. http, grpc). Defaults to \"http\" if not specified."))
 	sb.String("port_type", "dev.miren.core/services.port_type", schema.Doc("The type of the port (e.g. http, tcp). Defaults to \"http\" if not specified."))
+	sb.Component("ports", "dev.miren.core/services.ports", schema.Doc("Network ports this service listens on. Overrides scalar port/port_name/port_type."), schema.Many)
+	(&Ports{}).InitSchema(sb.Builder("services.ports"))
 	sb.Component("service_concurrency", "dev.miren.core/services.service_concurrency", schema.Doc("Concurrency configuration for this service"))
 	(&ServiceConcurrency{}).InitSchema(sb.Builder("services.service_concurrency"))
 }
@@ -1282,6 +1408,98 @@ func (o *Env) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Bool("sensitive", "dev.miren.core/env.sensitive", schema.Doc("Whether or not the value is sensitive"))
 	sb.String("source", "dev.miren.core/env.source", schema.Doc("The source of the variable (config or manual). Defaults to config for backward compatibility."))
 	sb.String("value", "dev.miren.core/env.value", schema.Doc("The value of the variable"))
+}
+
+const (
+	PortsNameId        = entity.Id("dev.miren.core/ports.name")
+	PortsNodePortId    = entity.Id("dev.miren.core/ports.node_port")
+	PortsPortId        = entity.Id("dev.miren.core/ports.port")
+	PortsProtocolId    = entity.Id("dev.miren.core/ports.protocol")
+	PortsProtocolTcpId = entity.Id("dev.miren.core/protocol.tcp")
+	PortsProtocolUdpId = entity.Id("dev.miren.core/protocol.udp")
+	PortsTypeId        = entity.Id("dev.miren.core/ports.type")
+)
+
+type Ports struct {
+	Name     string        `cbor:"name" json:"name"`
+	NodePort int64         `cbor:"node_port,omitempty" json:"node_port,omitempty"`
+	Port     int64         `cbor:"port" json:"port"`
+	Protocol PortsProtocol `cbor:"protocol,omitempty" json:"protocol,omitempty"`
+	Type     string        `cbor:"type,omitempty" json:"type,omitempty"`
+}
+
+type PortsProtocol string
+
+const (
+	TCP PortsProtocol = "protocol.tcp"
+	UDP PortsProtocol = "protocol.udp"
+)
+
+var PortsprotocolFromId = map[entity.Id]PortsProtocol{PortsProtocolTcpId: TCP, PortsProtocolUdpId: UDP}
+var PortsprotocolToId = map[PortsProtocol]entity.Id{TCP: PortsProtocolTcpId, UDP: PortsProtocolUdpId}
+
+func (o *Ports) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(PortsNameId); ok && a.Value.Kind() == entity.KindString {
+		o.Name = a.Value.String()
+	}
+	if a, ok := e.Get(PortsNodePortId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.NodePort = a.Value.Int64()
+	}
+	if a, ok := e.Get(PortsPortId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.Port = a.Value.Int64()
+	}
+	if a, ok := e.Get(PortsProtocolId); ok && a.Value.Kind() == entity.KindId {
+		o.Protocol = PortsprotocolFromId[a.Value.Id()]
+	}
+	if a, ok := e.Get(PortsTypeId); ok && a.Value.Kind() == entity.KindString {
+		o.Type = a.Value.String()
+	}
+}
+
+func (o *Ports) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Name) {
+		attrs = append(attrs, entity.String(PortsNameId, o.Name))
+	}
+	if !entity.Empty(o.NodePort) {
+		attrs = append(attrs, entity.Int64(PortsNodePortId, o.NodePort))
+	}
+	attrs = append(attrs, entity.Int64(PortsPortId, o.Port))
+	if a, ok := PortsprotocolToId[o.Protocol]; ok {
+		attrs = append(attrs, entity.Ref(PortsProtocolId, a))
+	}
+	if !entity.Empty(o.Type) {
+		attrs = append(attrs, entity.String(PortsTypeId, o.Type))
+	}
+	return
+}
+
+func (o *Ports) Empty() bool {
+	if !entity.Empty(o.Name) {
+		return false
+	}
+	if !entity.Empty(o.NodePort) {
+		return false
+	}
+	if !entity.Empty(o.Port) {
+		return false
+	}
+	if o.Protocol != "" {
+		return false
+	}
+	if !entity.Empty(o.Type) {
+		return false
+	}
+	return true
+}
+
+func (o *Ports) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("name", "dev.miren.core/ports.name", schema.Required)
+	sb.Int64("node_port", "dev.miren.core/ports.node_port")
+	sb.Int64("port", "dev.miren.core/ports.port", schema.Required)
+	sb.Singleton("dev.miren.core/protocol.tcp")
+	sb.Singleton("dev.miren.core/protocol.udp")
+	sb.Ref("protocol", "dev.miren.core/ports.protocol", schema.Choices(PortsProtocolTcpId, PortsProtocolUdpId))
+	sb.String("type", "dev.miren.core/ports.type")
 }
 
 const (
@@ -2304,5 +2522,5 @@ func init() {
 		(&OidcBinding{}).InitSchema(sb)
 		(&Project{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.core", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\xac[Y\xaf\xec8\x11\xfe\x1bl\xc32\xec\x03d\xe62 \x18\x10#\xf1\x84\xc4\v?!r'\xeeħ\x13;c;}n\xf3\xc6\x0e\xe2_p\xefE\xfcAxF^\xe3T\x9c\xd8Ι\x97#\x97\x93\xfa\\\xa9ͮ\xf2\xe9\xb7-E#\xa6-\xbeW#\xe1\x98V\r\xe3\x18\xdf\bm\xc5\x7f\x9e׳\x1f\xaa\xd9\nMӿ5\x0f\aO\xd14\x19\xbe\xff][6\"B\x01\xe8\xf5J\xf0Њ?\xbd\xb9\x90\xf6\xf57\xb6\xcc\x15j$\xb9\xe3\xfa\x8e\xb9 \x8c\x1a\xb9\xc0\x9c|L\xf8B\xda]\bB\x89$h\xa8\x1bF\xaf\xa43\x10`.\x84\xf8R\x04b\xe2\xec\t7R\xf3v\x8e\xb0L\x9d\x95\xa3\xbb\xbfB\xc3ԣa\xe2dD\xfcQ\xab\xefn\xd04\xbd\xferLe\x16Ũ\xed\x0eް\x0fsT\xf7\a-\xf4W\xe2\x00\x15{\xa6\x98\xeb%\xb0\x19*\xa1\xafBrB\xbbC\xc1\xddWn\x90\x8d\xbd\xb9$W䤇.\xe1\x9e\xe6\x88\xffg->ԐCP\x8e\xa5\x97Pz\\Y\xe9\xeb{\x1c#\xa2䊅\xb1U\xef\xa9\xe0\xbb5\xffwS\xfcuK:\a\xc3\xe0d\x80\xf6V\xa1}u\x0fMH$g\xa1A\xaev\xacx[L\xe7\xf1\xa6\xfe\xd4w4\xccX\xfc\xebj\x9cz\xa3n\xc3dàG\xbc\xe9\xc9\x1do\x17t\xaf\xd9燦\xed\x9dtqێX\xa2\x16I\x14\xb7\xad{\x9a\x15\xd5Q\xdd8\x84j@\x17<\x88vD\xf4\xf1_\xa3!;\xa34\x84\xf58\xea\xdb\x1e@\xf1\xb4\xcb\x1fh\xe2\xaf\xed\xf1\x9d\x8e\xe6\xdeAl>Jk\xae\xc5\xd3\xc0\x1e#\xa66.^\x7f\x11\xbc\xb5\xbc\x90\xa3\xbe\x7f\xea\xafx\x7f\x17C\x05G\xed?\xbf\xf7\x14\xd4÷\x8f\x11\xc2\xd4z\v' η\xf6q.3\x19\xdaz`\x9dq\xf5\xa7\x80.@i\x86YH\xcck\xd2\x1a\x94\x80\x86(\xdf9@a\xe34`\x89\xdb\x1a\x19\x13\x0f\xab\x19\x18\xba\a\xda1C\xdc֗\x87\xd1N8\xa1p\x88Bf\x14S\xb9\x8c\xac\xe9\x01l\x15\x87\xcdϐq\xb5i\x90J\x92\x11\v\x89F\x93*\xc9B\xe6y\x82\x01\x99\x05\xe65\x1e\x11\x19\x8c\xf2\x03\x1a\xc2\xc4]2\x80\xb1\x06\xec\x1c\x91\xe7\x03\x01\x80\xf7j\xb2\x90\xb9;דC\xbb<\xa2\x99>\xb0\x04\xe6\x9c\xf1z\xc4B\xa0ά7\xae\xa7\xa0\xb3\x1c\x04cGdM蕙`\xf4T\xc2M\xde\xdfw\x13\a\x91\xe3#\xffx\x13˴\x0e\xa1B\xb3\xec\x999\x06\\\xed\x18\x9ad\x97\xf7\xc2\x11mz\xc3kǐ\xf7\a{\xbc\r\x1bG\"k\xb3d\xe0\\\"\xf6\x00\xa2~/\x81\xba\xf6\xfai3\v\xf1\xe0\x89\xc1\xe3\x11Q\xb7\x84K\x13㽧\xf4>}al\x88n&\x9e;\xf4\x9e.\xe27ш\xf1\xdc\x1cOL\x10ɸY\xfd)\xa0!\x06<#y\f\xd1#sFR\x03\xc8\xf5\xfd=\xaeg\xc6o\x84v\xb5\xe4\x18\xd7=\x12\xc6ğm\xa7\xb3O\x8c\x1d\x91\n9\xaa\xae\xc0\xaf\xa7\x1e\t\xa3.l\x86P\xe4j\x9fW\xb0\x997\xb8^f\\\xaa\x91\xd1')\x17\b\x91\xe3\a\xb5\x82\x84\xa3`6\xdf\xed\xaa#\xb7\xa9ڰ\x8f\xd4\x18\xee\x8d\xfcp\x87{`\x00R\xa1v$\xb4\x96\xec\x86\xdd\xc6\x1eL\xa4b\x7f\x05\xb4w\x00\xff\xe6\x11\x93=`ڃ\x89\xa3,\xfb\u06ddBͳ\a\x85\xda5(\xd0\x0e\xd2(@\xab\xb6h9j\xfd뻘6\f\xbf\xce:\x88\xb6\xe1y\xb5\xf7s\t\xf1>H\x8a\xe7\xe1s\xe4\xfcc4\xc4\x1c\x82\x832\x19\xc9\x11\xa9ñ\xe7\x16\x98\xdfIc\xf3\x99#rC\xc1k$\x1an\xf6S1\x95\xfc11B\x8d\x7f<\x054\x94\x12ƉE\x98\x187\xbc\xad\x1e)\xae\x86Pyd>\xfb%+\xf3\xf9\xb9\x97\x9b\xcfA\xe5\x98\xef\xefZ\xce\xf7`\x05g\x11\xaa\x96\x88[(&6\x13\t\x19?ʗѬ\x90\x15\x10\xf1\\\xaeث+\x19\xb0x\b\x89GcŀN\x9e\x175\xc0\x80\x91\xc0z\xbff\xb3\xb1渞J\xb9\xac\x81\x19\xd9Le=!i6\xb0\xa7\x80\x86\x00\x9brL\x03$\xaaH\xe8O\x86\x89c\xd4\u058c\x0ef\xdb&\v\xb9>5\xc0\xd2\xd50\v\xf2{\\w\x17\x1bb\x96pN|\x18_\xc6\x17\xdeŎ\x03\u07ba\x98\xde\x03\xefi\x14\x99\xf0\x9d\xaa\xc0w0\xbd\xe7x\xceߢ\xba\xc3\xf4^\xb5X4\x9cLҗ\x9c\xe1\x04P>l\x8b)\xfe\x1b6:o\xd4 ea\xc5\xc08\xe9\x88Y\xebjǩ\xa3\x95b\xe3\xf8\xb3\x99pl\xd2h\xef\xa9c\xfb*F\x81\xa9 \x92\xdcm\x01\xb3\x90k֘\xa8\xe6\x10c\x0f!f\fE\xfdB\x84M\xb7\x90L\xae0\xc3\xdct\xad\x9c\xe3\xcda2\"\xa3;\xdbb3\x84\xf2l\xfaU\x8e3\x11V\xbb|;\xb9=\xda\xdd]1\x05E\xe3B\xc2e\x8f\x11\xb4\x85\x16\x04M\xc2\x12\x10\x16;\x1e\xc1\x0e\xea\x86\xd1f\xe6\x1c\xd3\xc68\xaa\x88=HD\xe4\xa7\x05\x11\x19\x81ωпD\x8b\xe3\bX5\xb2\xd6\x1aQ\x8f\xa0J?ʀ\xa0\xf3X\x13*$\xa2j\xbbչ~=\xb52\xf3\xcf3\x10U@b!E=a\xeeq4\xf2\x1c\x7f\xb4Z\xe1\xe3\x8c\x15D\x83\x06\\\xb7\xec\x99\xd6-\x1e\x901洙\x85\xeaȂ\xeeg\xa9!\xc2\xddo\xda\xcc\xe6\x861\xb7k\x04K\x1c\x9fҜ\xefD\x9bBο$\xe2R\x95¸\xf1\xe5)\x83\x93\x81\x84G\x87\xaf;\xe2\x04]\x06\x1c\x1e\xbe\xfc\xdc\xcb\x0f_\x0e*\x7fc\x82ŋC(ڝ6ۆG9ܣ\xa0\x8e<W\xc6F\x05OԞ7k\xb7\x82\xc9\xcfsgnY\xbb\x92g\xec[p\x87\xf1\xbc\xa77/\xefA\x87o\xd9\x022\xda\vٺ\xd2\xfa\x9e\x11̅\xd5/\xec`\x86Pz\xa3\xacgnz]d!\xa1N\x8eJ\xe8\xcck\xac\x0f2 ro\xb2\xa2g\xf5\x100TN\x17\xb9%84Dx\xb5\xb0\xf1c\xdd&a\xa4m\xea\v\xa1-\xa1\x9d\r~\x18a\xe1+\xe7\v\x98\x10%\xda\xe0й\xec\x87G\\̀ȨrzKTj\b\xeb\xb5i\xf3,\x91\xe1\xc0B\xd5\xe1B\xf9\xfd\x01\xe8]\x10\xe98K\xc1\x83\xc1\x86{BRbn\x9d\xc1\x11\xb9\xce\xc04܂\x16]r\xa5\x87\xa2\xc4\f\x9dx\x85D\x84\x98\xed\x9d\xf8ՎS\xf7\x13+\xfe\x89\xb3;i-B\xef\xa9TS|\x85!\xe6\xcb\x13nt\x99\xea\x95\xc8\xe0d\xae2\x87\x10z\xf3\xed:\xb4֙\xcc\xfa\x1dL\xc9\xeb\x97\xf2\x1d\rn+k\x9ch\x80E/S\x00\x9f\x98pc\x8e\x9dz\x94\b\"h2\xff\xdc}\xbb\x02ɿn\xfb0\a.\xb3\x93\xa5\xb3ɏ\xb2\x00_ҥ\x02+T\xc7+䷙\x7fZ$y\xb2\xfb\xa8M\xffI)溤\xba\x15\x94R\x9f\x14\xa9\xa5:UE}z\xfasR\xc5\xd5o\xce#\x97\xd5\\\xbf;\xbf\xd0\xcbJ\xb1ߞ_\xf8d\x85\xf6\x92\x15?\xdf\xc2\xed\xf5{fE\xb5\xa0[/X\xee]\xac\x9eLH{\xae{\xfcqY\x90\x146\x90\vã\xb8\xbf\xfc\xeb3\xf8\xc5\xed\xe7S_QН\x86]\x8f,\xfcD\x97\xedWg03{ۿ<\x83}\xbe\xf5\xfd\xbc\r\x95\xa5\x19\xfe\xaaL\x96\xf2\x16\xf9\xab\xb2\x00)\xea\x92\x17\x1a\xa9\xb4\x89^\xba\x81'\x9b셎\x9aك\xffE9jVӣ\xd0M\v:\xf8'\xf4\x90\xd1(\xf9Y9\xea\xe9\x16ʼ\x8d)w#P\xb8\xed$\xef\t~\\\x86\x97\xc8k\x85hGw\n\x85\xfaξi8\x83\x9b\xb8\x7f8n\x02om\xa9\xe5\xf8I\x9e\x1cg\xba\xbd\xf0\x1fu\xe2ЮM\x17\x9eJ\xc82Yx7\x99X#?\xeb\xe6\xe5\x1b\x0f\\\x96r\xf3\xfcs\x01?̷y\xf9{\x01\xcbH\xb6yι@feڼ|\xb8\x80f\xa6\xd9\xd2\xcf\xcfȱy1\xb1@\x9eN\xb0b\tJ\x8fv\xdc%\r\x048|\x114\xa7\xe1\xbb7ѫ\fb~\xb2Ӡi\xda\xfbَ\xff\x9d\xc7яT\x12\xbf\x18pO\x97\x7f\x8f?\xfcaA\xf8\xffr\x89\xff\xa3_5\x8dS\xff[\xb7\xee\x83%[\xcc@\x839\x8d\xb3\xff\x03\x00\x00\xff\xff\x01\x00\x00\xff\xffX/c\x0e\x185\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.core", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\xac[I\x93\xe58\x11\xfe\x1bl\xc32\xec\x03x\xa6\x19\b\x18\x96\t8\x11\xc1\x85\x9f\xe0г\xf4lճ%\x8f$\xbf\xea\xe2\xc6\x1e\xc0\xbf\xa0\xab\t\xfe \x9c\tk\xb3\x9c\x96e\xc9\u0557\n\xa5\xec\xfc\x94\xceM)e\xbdg\xcc\xd0@\x18&\xf7j\xa0\x82\xb0\xaa႐\x1beX\xfe\xe7q=\xfb\xe1<[\xa1q\xfc\xb7\xe6\x11\xe0)\x1aG\xc3\xf7\xbf+\xe6\x03\xa2\f\x80^\xaf\x94\xf4X\xfe\xe9ͅ\xe2\xd7_\xdb2W\xa8Q\xf4N\xea;\x11\x92rf\xe4\x02s\xeai$\x17\x8aw!(\xa3\x8a\xa2\xben8\xbb\xd2\xd6@\x80\xb9\x10\xe2\v\x11\x88Q\xf0\a\xd2(\xcd\xdb:\xc22\xb5V\x8e\xf6\xfe\n\xf5c\x87\xfaQ\xd0\x01\x89\xa7z\xfe\xee\x06\x8d\xe3\xeb/\xc6TfQ\x8c\xda\xee\xe0\r\xfb0Gu\x7f\xd0B\x7f)\x0eP\xf1GF\x84^\x82\x98\xe1,\xf4U*AY\x9b\x14\xdc}\xe5\x06\xd9\xd8[(zENz\xe8\x12\xeei\x8e\xf8\x7f\xd6\xe2C\r9\x84ٱ\xf4\x12\xb3\x1eWV\xfa\xea\x1eǀ\x18\xbd\x12il\xd5y*\xf8n\xcd\xff\xed#\xfe\x1a\xd3\xd6\xc1p8\x19\xa0=\xcfh_\xdeC\x93\n\xa9Ij\x90\xab\x1dϼ\x98\xb0i\xb8\xcd\x7f\xea;\xea'\"\xffu5N\xbdQ\xb7a\xb2a\xd0!\xd1t\xf4N\xb6\v\xba\xd7\xec\xf3\xa4i;']ܶ\x03Q\b#\x85\xe2\xb6uO\xb3\xa2:\xaa\x1b\x87P\xf5\xe8Bz\x89\aĞ\xfek4dgf\r\x11=\x8e\xfa\xb6\a\x98y\xf0\xf2\a\x9a\xf8+{|\xa7\xa3\xb9s\x10\x9b\x8fҚ\xc3d\xec\xf9\xd3@\x98\x8d\x8bן\ao-/\xe4\xa8\xef\x9f\xfa+\xde\xdfŘ\x83\xa3\xf6\x9f\xdfy\n\xea\xe1\x9bi\x840\xb5\xde\xc2\t\x88\xf3\x8d}\x9c\xcbD{\\\xf7\xbc5\xae\xfe\x10\xd0\x05(M?IEDM\xb1A\th\x88\xf2\xad\x04\n\x1fƞ(\x82kdLܯf`\xe8&\xb4c\x86\x04ח'\xa3\x9dpbơ32g\x84\xa9edM\x0f`\xab8l~\x86\x8c\xabM\x83T\x8a\x0eD*4\x98TI\x172\xcf\x13\f\xc8$\x89\xa8ɀho\x94\x1f\xd0\x10&\xee\x92\x01\x8c5`\xeb\x88<\x1f\b\x00\xbcWӅ\xccݹ\x1e\x1c\xda\xe5)\x9a\xe9\x03K\x10!\xb8\xa8\a\"%j\xcdz\xc3z\n:K\"\x18[\xaajʮ\xdc\x04\xa3\xa7\x0e\xdc\xe4\xfd}7q\x109>\xf2\xf77\xb1L\xeb\x10*4\xa9\x8e\x9b2\xe0j\xc7\xd0$\xbb\xbc\x17\x81X\xd3\x19^;\x86\xbc\xdf\xdb\xe3m\xf80PU\x9b%\x03璱\a\x10\xf5;\a\xa8k\xaf\x1f7\xb3\x10\x0fV\f\x1e\x8f\xca\x1aS\xa1L\x8cw\x9e\xd2\xfb\xf4\x85\xf3>\xba\x99x\xee\xd0{ڈ\xdfD#\xc6s\v2rI\x15\x17f\xf5\x87\x80\x86\x18\xb0F\xf2\x18\xb2C\xa6F\x9a\a\x90\xeb\xbb{\\\x8f\\\xdc(kk%\b\xa9;$\x8d\x89?\xdbNgW\x8c-U3rT]\x81_\x8f\x1d\x92F]\xc4\f\xa1\xc8\xd5>\xaf\xe4\x93hH\xbd̸T\xa3\xa2O\x8e\\ D\x8e\x17j\x05\tg\x86\xd9|\xb7;\x1d\xb9MՆ}\xe4\x8c\xe1\xde\xc8\x0fw\xb8\a\x06 \x15\xc2\x03e\xb5\xe27\xe26\xf6`\xe2(\xf6W@{\x05\xf8\xd7SL\xb6\xc0\xb4\x85\x89\xa3,\xfb\xf3\xceAͳ\a\a\xb5kp@K\xa4Q\x80Vm\xd1r\xd4\xfa\u05f71m\x18~\x9du\x10\xc3a\xbd\xda\xf9\xb9\x03\xf1>8\x14\xcf\xc3\xe7\xc8\xf9\xc7h\x889\x04\ae2\x92#\x8e\x8ac\xcf-\x89\xb8\xd3\xc6\xe63G䆂\xd7H4\xdc\xec\xa7\x12\xa6\xc4\xd3\xc8)3\xfe\xf1\x10\xd0PJ\x18'\x16a\xe4\xc2\xf0b=\x9a\xb9\x1a\xcaT\xca|\xf6KV\xe6\xf3s/7\x9f\x83ʊ^-\xe7{\xf0\x04g\x11*L\xe5-\x14\x93\x98\x89\x03\x19?ʗѬ\x90\x15\x10\xf1\\>\xb3WW\xda\x13\xf9$\x15\x19\x8c\x15\x03\xfa\xb0^\xd4\x00=A\x92\xe8\xfd\x9aOƚ\xc3z\xea\xc8e\r\xcc\xc0'\xa6\xea\x11)\xb3\x81=\x044\x04\xd8\x1c\xc74\xc0\xc1)\x12\xfa\x93a\x12\x04ᚳ\xdel\xdbt!\xd7U\x03<\xba\x1afI\x7fO\xea\xf6bC\xcc\x12Ή\x93\xf1e|\xe1m\xac\x1c\xf0\xd6%\xec\x1exO3\x93\a\xbeS\x15\xf8\x0ea\xf7\x1c\xcf\xf9[Tw\x84\xdd+Ld#\xe8\xa8\xfc\x913\x9c\x00ʇ\xd7b3\xff\x8d\x18\x9d7\xf3\xe0\xc8\xc23\x03\x17\xb4\xa5f\xad\xab\x1d\x1f\x95V3\x9b \x9fMT\x10\x93F;O\xa5\xed;3J\xc2$U\xf4n\x0f0\v\xb9f\x8d\x89j\x8a\x18[\x84\x981\x14\xf5s\x116}\x85dr\x85\x19\xe6\xa6\xeb\xd99\xde$\x93\x11\x1d\\mK\xcc\x10ʳ\xb9\xafr\x9c\aa\xb5˷\x93ۣ\xb7\xbb+\xa6\xe0и\x90p\xd94\x82\xb6Ђ\xa0\xc9\x00!\x9d\xb7g\x96U\xde6\x13\xef0ok\xc0\x9c\xe8\xfbK\xd4\xc34{i\xba\xb3L\x1c\x93\xda[\x86.\xe4\xca<\xf1\x05w\f\xfa\x1cS\xa6\xe5\x10\\\U000466f3b\xe7\xa9\xf8\xc5i\xa3\x9a\xed\r\xbb\xe3\xa9T36\x13N\xbc0\xe11!\xbbw\b\f}!\x9d\xa65\xf7s\xecl\xec\x8di\au\xc3Y3\tAXc\xf2\x9a\x8c=8p\xa2O\v\x9c(\x02\x9f\xefR\xf0.%\x02V\r\x1c[\x9d\xe9\x11t\xb0\x8f2 f\xf3R&\x15bsu\xa6K\x83\xf5\xd4\xca\xed~\x9a\x818\xe7o\"\x95\xacG\"<\x8eF\x9e\xe2\x8fV+|\x9c\xb1\x82lPOj\xcc\x1fY\x8dI\x8f\x8c1\xc7\xcd,TG\x16t7)\r\x11\x16K\xe3f6\xd7;\x85]#X\"]\xd4;߉\xde!:\xffRH\xa8\x1aSA\x1a\x7f\x9b\xc1\xe1$̥;\xb5\xfa\x1d\t\x8a.=\tku?\xf7\xf2Z\xddA\xe5\xd71\xf0\xac\xeb\x10\x8a\x8a\x99M\x0e\xf2(ɒ\x06\xea\xc8se\xd45\xf0\x00\xe6y\xb3\x8a\x1b\xb8Wz\xee\xcc\ngW\xf2\x8c2\an\f\x9e\xf7t\xad\xe3=(\xf9\x96\xbdo\x88^\x9dm]iݖ\x06s\xe1e\t\xbc\xf0\x0e\xa1t]UO\xc2lwt!\xa1NR7.\x99]\xcf\x0f2 r\x1b\x9fѣ]\b\x18*\xa7\x8d4\x95\x92\x86\b;Q\x1b?ַj\x9c⦾P\x86)km\xf0\xc3\b\v_9\x7f\xde\rQ\xa2\xf7a:\x97}?\xc5\xd5\xf4\x88\x0esN\xc7tN\ra\x998n\x9e\x1dd8\xb0P\x95\\(\xff:\tz\x17DJg)X\x18l\xb8G\xa4\x14\x11\xd6\x19\x1c\x91\xeb\f\\\xc3-h\xd1%Wz(J\xccЉWHT\xca\xc9\xfe\v\xc5Վ\x8f\xdaY+\xfeQ\xf0;\xc5\x16\xa1\xf3\xd4Q\x0fe\x85!\xa7\xcb\x03i\xf4\xad\x86W\"\x87\x93\xb9\xca\xecC\xe8ͷ\xeb\xd0Zg2\xebw0%\xaf_\xcaw4\xb8\xad\xacq\xa2\x01\x16\xed\xbd\x01>9\x92Ɣ\x9dzt\x10D\xd0d\xfe\xb9\xfb\xf6\x19$\xbf;\xfba\x0e\\\xe6ŧ\xce&?\xc8\x02|ɥ&X\xa1J\xaf\x90\xa3\x8a\x7fhU\xfc\xb8H\xf2\xc3\xcbjm\xfaOJ1\xd7G\xaa[\xc1Q\xea\x93\"\xb5T\xa7NQ\x9f\x9e\xfe\x9c\xa3\xc3\xd5o\xce#\x97\x9d\xb9~w~\xa1\x97\x1d\xc5~{~\xe1\x93'\xb4\x97\xac\xf8n\x0fn\xaf\xdf3+\xce\v\xba\xf5\x82\xe5\xde\xc6Γ\aҞk6|\\\x16$\x85\xfd\x86\xc2\xf0(nG\xfc\xfa\f~q\xb7\xe2\xd4W\x1443\xe0\xadG\x16\xfe\xc1\xe5\xdf/\xcf`f\xb6B~~\x06\xfb|\xa7\xe4q\x1b*K\xef\xe4U\x99,\xe5\x1d\x95We\x01R\xd4T)4Riϥt\x03?\xec\xc9\x14:jf\xcb\xe6g\xe5\xa8Y\x97\x1e\x85nZ\xd0\xf09\xa1\x87\x8c\x8b\x92\x9f\x94\xa3\x9e\xbeB\x99\xb61\xe5\x1aH\x85\xdb\xcea[\xe9\x87ex\ay\xad\x10-Ղ*\xd4wvc\xea\fnN\xbb\xaa\xd00\xe7\x9aX\x85\xf5@a\x1f\xab0p\xb2\xda\\\x85I\xb4\xa4\vvJ\xdcT\x93\xec\x17\xa7\x00\x8b{h\xbfz\xc92\xbe\xd1\xf62\x14\u05cd;\xa5ÓͺH\xa5\xa0\xf1\xd2=\x94-\x93\x16\xfcGy\x82\x9fi\x96\xc0\x7f\x8b\x8cC\xbb[\xee0\x88\xe92Y\xf8\x9f \ak\xe4\x17-y۵\a.\xabX\xf2\xd2\xfb\x02\x9e,W\xf2ʟ\x05,\xa3V\xc9\xcb\xed\vdV\xa1\x92\x17\"\vhf\x95R\xfa\xf9\x19%J^L,\x90\xa7\xeb\x13\xb9\x04\xa5GK7\x19\x02\x01\x92/\x82\xde\x0e|\xf7&\xbby\x036?\x90l\xd08\xee\xfdH\xd2\xff\xaa.\xf5\x93\xc0\x83\xdfg\xb9\xa7ˏ\x91\x92?\xe3\n\xff;\xf9\xe0WK\xab\x9e\xcb\xd1\x7f2\xaf\xaf\x91\x0f;4@\x839\xf7\xce\xff\a\x00\x00\xff\xff\x01\x00\x00\xff\xff\xc0\x06\x7f%\x86:\x00\x00"))
 }

--- a/api/core/schema.yml
+++ b/api/core/schema.yml
@@ -105,6 +105,24 @@ kinds:
             port_type:
               type: string
               doc: The type of the port (e.g. http, tcp). Defaults to "http" if not specified.
+            ports:
+              type: component
+              doc: Network ports this service listens on. Overrides scalar port/port_name/port_type.
+              many: true
+              attrs:
+                port:
+                  type: int
+                  required: true
+                name:
+                  type: string
+                  required: true
+                protocol:
+                  type: enum
+                  choices: [tcp, udp]
+                type:
+                  type: string
+                node_port:
+                  type: int
             image:
               type: string
               doc: Optional container image for this service (e.g. postgres:16). If not specified, uses the app-level built image.
@@ -412,6 +430,24 @@ components:
         port_type:
           type: string
           doc: The type of the port (e.g. http, tcp)
+        ports:
+          type: component
+          doc: Network ports this service listens on. Overrides scalar port/port_name/port_type.
+          many: true
+          attrs:
+            port:
+              type: int
+              required: true
+            name:
+              type: string
+              required: true
+            protocol:
+              type: enum
+              choices: [tcp, udp]
+            type:
+              type: string
+            node_port:
+              type: int
         image:
           type: string
           doc: Optional container image for this service

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -226,7 +226,7 @@ func (ac *AppConfig) Validate() error {
 		// Validate ports configuration
 		if len(svcConfig.Ports) > 0 {
 			// Mutual exclusion: cannot use both ports[] and scalar port fields
-			if svcConfig.Port > 0 || svcConfig.PortName != "" || svcConfig.PortType != "" {
+			if svcConfig.Port != 0 || svcConfig.PortName != "" || svcConfig.PortType != "" {
 				return fmt.Errorf("service %s: cannot use both 'ports' array and scalar port/port_name/port_type fields", serviceName)
 			}
 

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -48,7 +48,6 @@ type DiskConfig struct {
 type PortConfig struct {
 	Port     int    `toml:"port"`
 	Name     string `toml:"name"`
-	Protocol string `toml:"protocol"`
 	Type     string `toml:"type"`
 	NodePort int    `toml:"node_port"`
 }
@@ -243,12 +242,12 @@ func (ac *AppConfig) Validate() error {
 				if p.Name == "" {
 					return fmt.Errorf("service %s: ports[%d] name is required", serviceName, i)
 				}
-				if p.Protocol != "" && p.Protocol != "tcp" && p.Protocol != "udp" {
-					return fmt.Errorf("service %s: ports[%d] protocol must be \"tcp\" or \"udp\"", serviceName, i)
+				if p.Type != "" && p.Type != "http" && p.Type != "tcp" && p.Type != "udp" {
+					return fmt.Errorf("service %s: ports[%d] type must be \"http\", \"tcp\", or \"udp\"", serviceName, i)
 				}
-				proto := p.Protocol
-				if proto == "" {
-					proto = "tcp"
+				proto := "tcp"
+				if p.Type == "udp" {
+					proto = "udp"
 				}
 				if p.NodePort < 0 || p.NodePort > 65535 {
 					return fmt.Errorf("service %s: ports[%d] node_port must be between 0 and 65535", serviceName, i)

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -44,12 +44,22 @@ type DiskConfig struct {
 	LeaseTimeout string `toml:"lease_timeout"`
 }
 
+// PortConfig represents a network port for a service
+type PortConfig struct {
+	Port     int    `toml:"port"`
+	Name     string `toml:"name"`
+	Protocol string `toml:"protocol"`
+	Type     string `toml:"type"`
+	NodePort int    `toml:"node_port"`
+}
+
 // ServiceConfig represents configuration for a specific service
 type ServiceConfig struct {
 	Command     string                    `toml:"command"`
 	Port        int                       `toml:"port"`
 	PortName    string                    `toml:"port_name"`
 	PortType    string                    `toml:"port_type"`
+	Ports       []PortConfig              `toml:"ports"`
 	Image       string                    `toml:"image"`
 	EnvVars     []AppEnvVar               `toml:"env"`
 	Concurrency *ServiceConcurrencyConfig `toml:"concurrency"`
@@ -210,6 +220,44 @@ func (ac *AppConfig) Validate() error {
 		for i, ev := range svcConfig.EnvVars {
 			if ev.Key == "" {
 				return fmt.Errorf("service %s: env[%d] key is required", serviceName, i)
+			}
+		}
+
+		// Validate ports configuration
+		if len(svcConfig.Ports) > 0 {
+			// Mutual exclusion: cannot use both ports[] and scalar port fields
+			if svcConfig.Port > 0 || svcConfig.PortName != "" || svcConfig.PortType != "" {
+				return fmt.Errorf("service %s: cannot use both 'ports' array and scalar port/port_name/port_type fields", serviceName)
+			}
+
+			seenNames := make(map[string]bool)
+			type portProto struct {
+				port     int
+				protocol string
+			}
+			seenPortProto := make(map[portProto]bool)
+			for i, p := range svcConfig.Ports {
+				if p.Port <= 0 || p.Port > 65535 {
+					return fmt.Errorf("service %s: ports[%d] port must be between 1 and 65535", serviceName, i)
+				}
+				if p.Name == "" {
+					return fmt.Errorf("service %s: ports[%d] name is required", serviceName, i)
+				}
+				if p.Protocol != "" && p.Protocol != "tcp" && p.Protocol != "udp" {
+					return fmt.Errorf("service %s: ports[%d] protocol must be \"tcp\" or \"udp\"", serviceName, i)
+				}
+				if p.NodePort < 0 || p.NodePort > 65535 {
+					return fmt.Errorf("service %s: ports[%d] node_port must be between 0 and 65535", serviceName, i)
+				}
+				if seenNames[p.Name] {
+					return fmt.Errorf("service %s: ports[%d] duplicate port name %q", serviceName, i, p.Name)
+				}
+				seenNames[p.Name] = true
+				pp := portProto{p.Port, p.Protocol}
+				if seenPortProto[pp] {
+					return fmt.Errorf("service %s: ports[%d] duplicate port number %d (protocol %q)", serviceName, i, p.Port, p.Protocol)
+				}
+				seenPortProto[pp] = true
 			}
 		}
 

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -246,6 +246,10 @@ func (ac *AppConfig) Validate() error {
 				if p.Protocol != "" && p.Protocol != "tcp" && p.Protocol != "udp" {
 					return fmt.Errorf("service %s: ports[%d] protocol must be \"tcp\" or \"udp\"", serviceName, i)
 				}
+				proto := p.Protocol
+				if proto == "" {
+					proto = "tcp"
+				}
 				if p.NodePort < 0 || p.NodePort > 65535 {
 					return fmt.Errorf("service %s: ports[%d] node_port must be between 0 and 65535", serviceName, i)
 				}
@@ -253,9 +257,9 @@ func (ac *AppConfig) Validate() error {
 					return fmt.Errorf("service %s: ports[%d] duplicate port name %q", serviceName, i, p.Name)
 				}
 				seenNames[p.Name] = true
-				pp := portProto{p.Port, p.Protocol}
+				pp := portProto{p.Port, proto}
 				if seenPortProto[pp] {
-					return fmt.Errorf("service %s: ports[%d] duplicate port number %d (protocol %q)", serviceName, i, p.Port, p.Protocol)
+					return fmt.Errorf("service %s: ports[%d] duplicate port number %d (protocol %q)", serviceName, i, p.Port, proto)
 				}
 				seenPortProto[pp] = true
 			}

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -972,6 +972,22 @@ name = "http"
 		assert.Contains(t, err.Error(), "cannot use both 'ports' array and scalar port/port_name/port_type fields")
 	})
 
+	t.Run("mutual exclusion with negative scalar port", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[services.web]
+port = -1
+
+[[services.web.ports]]
+port = 8080
+name = "http"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot use both 'ports' array and scalar port/port_name/port_type fields")
+	})
+
 	t.Run("port out of range", func(t *testing.T) {
 		config := `
 name = "test-app"

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -848,3 +848,256 @@ name = "my-app"
 		assert.Nil(t, ac.Addons)
 	})
 }
+
+func TestParseAppConfigWithPorts(t *testing.T) {
+	t.Run("multi-port parsing", func(t *testing.T) {
+		config := `
+name = "irc-app"
+
+[services.irc]
+command = "./ircd"
+
+[[services.irc.ports]]
+port = 6667
+name = "irc"
+type = "tcp"
+
+[[services.irc.ports]]
+port = 6697
+name = "irc-tls"
+type = "tcp"
+node_port = 6697
+
+[services.irc.concurrency]
+mode = "fixed"
+num_instances = 1
+`
+		ac, err := Parse([]byte(config))
+		require.NoError(t, err)
+		require.NotNil(t, ac)
+
+		ircSvc := ac.Services["irc"]
+		require.NotNil(t, ircSvc)
+		require.Len(t, ircSvc.Ports, 2)
+
+		assert.Equal(t, 6667, ircSvc.Ports[0].Port)
+		assert.Equal(t, "irc", ircSvc.Ports[0].Name)
+		assert.Equal(t, "tcp", ircSvc.Ports[0].Type)
+		assert.Equal(t, 0, ircSvc.Ports[0].NodePort)
+
+		assert.Equal(t, 6697, ircSvc.Ports[1].Port)
+		assert.Equal(t, "irc-tls", ircSvc.Ports[1].Name)
+		assert.Equal(t, "tcp", ircSvc.Ports[1].Type)
+		assert.Equal(t, 6697, ircSvc.Ports[1].NodePort)
+	})
+
+	t.Run("port with protocol", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[services.dns]
+command = "./dns-server"
+
+[[services.dns.ports]]
+port = 53
+name = "dns-udp"
+protocol = "udp"
+
+[[services.dns.ports]]
+port = 53
+name = "dns-tcp"
+protocol = "tcp"
+
+[services.dns.concurrency]
+mode = "fixed"
+num_instances = 1
+`
+		ac, err := Parse([]byte(config))
+		require.NoError(t, err)
+		require.NotNil(t, ac)
+
+		dnsSvc := ac.Services["dns"]
+		require.Len(t, dnsSvc.Ports, 2)
+		assert.Equal(t, "udp", dnsSvc.Ports[0].Protocol)
+		assert.Equal(t, "tcp", dnsSvc.Ports[1].Protocol)
+	})
+}
+
+func TestValidatePortsConfig(t *testing.T) {
+	t.Run("mutual exclusion with scalar port", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[services.web]
+port = 8080
+
+[[services.web.ports]]
+port = 8080
+name = "http"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot use both 'ports' array and scalar port/port_name/port_type fields")
+	})
+
+	t.Run("mutual exclusion with scalar port_name", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[services.web]
+port_name = "http"
+
+[[services.web.ports]]
+port = 8080
+name = "http"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot use both 'ports' array and scalar port/port_name/port_type fields")
+	})
+
+	t.Run("mutual exclusion with scalar port_type", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[services.web]
+port_type = "http"
+
+[[services.web.ports]]
+port = 8080
+name = "http"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot use both 'ports' array and scalar port/port_name/port_type fields")
+	})
+
+	t.Run("port out of range", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[[services.web.ports]]
+port = 70000
+name = "http"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "port must be between 1 and 65535")
+	})
+
+	t.Run("port zero", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[[services.web.ports]]
+port = 0
+name = "http"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "port must be between 1 and 65535")
+	})
+
+	t.Run("missing name", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[[services.web.ports]]
+port = 8080
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name is required")
+	})
+
+	t.Run("invalid protocol", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[[services.web.ports]]
+port = 8080
+name = "http"
+protocol = "sctp"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `protocol must be "tcp" or "udp"`)
+	})
+
+	t.Run("duplicate port name", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[[services.web.ports]]
+port = 8080
+name = "http"
+
+[[services.web.ports]]
+port = 8443
+name = "http"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `duplicate port name "http"`)
+	})
+
+	t.Run("duplicate port number same protocol", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[[services.web.ports]]
+port = 8080
+name = "http"
+protocol = "tcp"
+
+[[services.web.ports]]
+port = 8080
+name = "https"
+protocol = "tcp"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate port number 8080")
+	})
+
+	t.Run("same port different protocol is valid", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[[services.dns.ports]]
+port = 53
+name = "dns-udp"
+protocol = "udp"
+
+[[services.dns.ports]]
+port = 53
+name = "dns-tcp"
+protocol = "tcp"
+`
+		ac, err := Parse([]byte(config))
+		require.NoError(t, err)
+		require.NotNil(t, ac)
+		require.Len(t, ac.Services["dns"].Ports, 2)
+	})
+
+	t.Run("valid multi-port config", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[[services.web.ports]]
+port = 8080
+name = "http"
+type = "http"
+
+[[services.web.ports]]
+port = 8443
+name = "https"
+type = "http"
+node_port = 443
+`
+		ac, err := Parse([]byte(config))
+		require.NoError(t, err)
+		require.NotNil(t, ac)
+		require.Len(t, ac.Services["web"].Ports, 2)
+	})
+}

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -891,7 +891,7 @@ num_instances = 1
 		assert.Equal(t, 6697, ircSvc.Ports[1].NodePort)
 	})
 
-	t.Run("port with protocol", func(t *testing.T) {
+	t.Run("port with udp type", func(t *testing.T) {
 		config := `
 name = "test-app"
 
@@ -901,12 +901,12 @@ command = "./dns-server"
 [[services.dns.ports]]
 port = 53
 name = "dns-udp"
-protocol = "udp"
+type = "udp"
 
 [[services.dns.ports]]
 port = 53
 name = "dns-tcp"
-protocol = "tcp"
+type = "tcp"
 
 [services.dns.concurrency]
 mode = "fixed"
@@ -918,8 +918,8 @@ num_instances = 1
 
 		dnsSvc := ac.Services["dns"]
 		require.Len(t, dnsSvc.Ports, 2)
-		assert.Equal(t, "udp", dnsSvc.Ports[0].Protocol)
-		assert.Equal(t, "tcp", dnsSvc.Ports[1].Protocol)
+		assert.Equal(t, "udp", dnsSvc.Ports[0].Type)
+		assert.Equal(t, "tcp", dnsSvc.Ports[1].Type)
 	})
 }
 
@@ -1026,18 +1026,18 @@ port = 8080
 		assert.Contains(t, err.Error(), "name is required")
 	})
 
-	t.Run("invalid protocol", func(t *testing.T) {
+	t.Run("invalid type", func(t *testing.T) {
 		config := `
 name = "test-app"
 
 [[services.web.ports]]
 port = 8080
 name = "http"
-protocol = "sctp"
+type = "sctp"
 `
 		_, err := Parse([]byte(config))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), `protocol must be "tcp" or "udp"`)
+		assert.Contains(t, err.Error(), `type must be "http", "tcp", or "udp"`)
 	})
 
 	t.Run("duplicate port name", func(t *testing.T) {
@@ -1057,56 +1057,57 @@ name = "http"
 		assert.Contains(t, err.Error(), `duplicate port name "http"`)
 	})
 
-	t.Run("duplicate port number same protocol", func(t *testing.T) {
+	t.Run("duplicate port number same type", func(t *testing.T) {
 		config := `
 name = "test-app"
 
 [[services.web.ports]]
 port = 8080
 name = "http"
-protocol = "tcp"
+type = "tcp"
 
 [[services.web.ports]]
 port = 8080
 name = "https"
-protocol = "tcp"
+type = "tcp"
 `
 		_, err := Parse([]byte(config))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate port number 8080")
 	})
 
-	t.Run("duplicate port empty protocol treated as tcp", func(t *testing.T) {
+	t.Run("duplicate port http type treated as tcp protocol", func(t *testing.T) {
 		config := `
 name = "test-app"
 
 [[services.web.ports]]
 port = 8080
 name = "http"
+type = "http"
 
 [[services.web.ports]]
 port = 8080
 name = "also-http"
-protocol = "tcp"
+type = "tcp"
 `
 		_, err := Parse([]byte(config))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate port number 8080")
 	})
 
-	t.Run("same port different protocol is valid", func(t *testing.T) {
+	t.Run("same port different type is valid", func(t *testing.T) {
 		config := `
 name = "test-app"
 
 [[services.dns.ports]]
 port = 53
 name = "dns-udp"
-protocol = "udp"
+type = "udp"
 
 [[services.dns.ports]]
 port = 53
 name = "dns-tcp"
-protocol = "tcp"
+type = "tcp"
 `
 		ac, err := Parse([]byte(config))
 		require.NoError(t, err)

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -1060,6 +1060,24 @@ protocol = "tcp"
 		assert.Contains(t, err.Error(), "duplicate port number 8080")
 	})
 
+	t.Run("duplicate port empty protocol treated as tcp", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[[services.web.ports]]
+port = 8080
+name = "http"
+
+[[services.web.ports]]
+port = 8080
+name = "also-http"
+protocol = "tcp"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate port number 8080")
+	})
+
 	t.Run("same port different protocol is valid", func(t *testing.T) {
 		config := `
 name = "test-app"

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -443,50 +443,81 @@ func (l *Launcher) buildSandboxSpec(
 	}
 
 	// Determine port configuration from service config
-	port := int64(0)
-	portName := ""
-	portType := ""
+	var containerPorts []compute_v1alpha.SandboxSpecContainerPort
+	portEnvValue := int64(0)
 	shutdownTimeout := ""
 
 	for _, svc := range cfgSpec.Services {
 		if svc.Name == serviceName {
-			if svc.Port > 0 {
-				port = svc.Port
-			}
-			if svc.PortName != "" {
-				portName = svc.PortName
-			}
-			if svc.PortType != "" {
-				portType = svc.PortType
-			}
 			if svc.Concurrency.ShutdownTimeout != "" {
 				shutdownTimeout = svc.Concurrency.ShutdownTimeout
+			}
+
+			if len(svc.Ports) > 0 {
+				// Multi-port path: map each port entry
+				for _, p := range svc.Ports {
+					cp := compute_v1alpha.SandboxSpecContainerPort{
+						Port:     p.Port,
+						Name:     p.Name,
+						Type:     p.Type,
+						NodePort: p.NodePort,
+					}
+					switch p.Protocol {
+					case core_v1alpha.ConfigSpecServicesPortsTCP:
+						cp.Protocol = compute_v1alpha.SandboxSpecContainerPortTCP
+					case core_v1alpha.ConfigSpecServicesPortsUDP:
+						cp.Protocol = compute_v1alpha.SandboxSpecContainerPortUDP
+					}
+					containerPorts = append(containerPorts, cp)
+				}
+
+				// PORT env var: first HTTP-typed port, or first port if none is HTTP
+				for _, p := range svc.Ports {
+					if p.Type == "http" {
+						portEnvValue = p.Port
+						break
+					}
+				}
+				if portEnvValue == 0 {
+					portEnvValue = svc.Ports[0].Port
+				}
+			} else {
+				// Scalar port path (backward compat)
+				port := svc.Port
+				portName := svc.PortName
+				portType := svc.PortType
+
+				if port == 0 && serviceName == "web" {
+					port = 3000
+				}
+
+				if port > 0 {
+					if portName == "" {
+						portName = "http"
+					}
+					if portType == "" {
+						portType = "http"
+					}
+					containerPorts = []compute_v1alpha.SandboxSpecContainerPort{
+						{Port: port, Name: portName, Type: portType},
+					}
+					portEnvValue = port
+				}
 			}
 			break
 		}
 	}
 
-	// Default to 3000 for web service if still no port configured
-	if port == 0 && serviceName == "web" {
-		port = 3000
+	// Default to 3000 for web service if no service config matched at all
+	if len(containerPorts) == 0 && serviceName == "web" {
+		containerPorts = []compute_v1alpha.SandboxSpecContainerPort{
+			{Port: 3000, Name: "http", Type: "http"},
+		}
+		portEnvValue = 3000
 	}
 
-	// Add port configuration if a port was determined
-	if port > 0 {
-		if portName == "" {
-			portName = "http"
-		}
-		if portType == "" {
-			portType = "http"
-		}
-
-		appCont.Port = []compute_v1alpha.SandboxSpecContainerPort{
-			{
-				Port: port,
-				Name: portName,
-				Type: portType,
-			},
-		}
+	if len(containerPorts) > 0 {
+		appCont.Port = containerPorts
 	}
 
 	// Add user-supplied config env vars, stripping any system-managed keys
@@ -515,8 +546,8 @@ func (l *Launcher) buildSandboxSpec(
 	}
 
 	// Append system-managed env vars last so they cannot be overridden
-	if port > 0 {
-		appCont.Env = append(appCont.Env, fmt.Sprintf("PORT=%d", port))
+	if portEnvValue > 0 {
+		appCont.Env = append(appCont.Env, fmt.Sprintf("PORT=%d", portEnvValue))
 	}
 	if labs.AdminAPI() && ver.AdminToken != "" {
 		appCont.Env = append(appCont.Env, "ADMIN_TOKEN="+ver.AdminToken)
@@ -737,7 +768,9 @@ func portsEqual(ports1, ports2 []compute_v1alpha.SandboxSpecContainerPort) bool 
 
 		if p1.Port != p2.Port ||
 			p1.Name != p2.Name ||
-			p1.Type != p2.Type {
+			p1.Type != p2.Type ||
+			p1.NodePort != p2.NodePort ||
+			p1.Protocol != p2.Protocol {
 			return false
 		}
 	}

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -235,6 +235,7 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	appMD.Decode(appResp.Entity().Entity())
 
 	var desiredServices []string
+	serviceSyncFailed := false
 	for _, svc := range spec.Services {
 		svcID, err := l.ensureServiceForPorts(ctx, app, &appMD, spec, svc.Name)
 		if err != nil {
@@ -242,6 +243,7 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 				"app", app.ID,
 				"service", svc.Name,
 				"error", err)
+			serviceSyncFailed = true
 			continue
 		}
 		if svcID != "" {
@@ -249,7 +251,11 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 		}
 	}
 
-	l.cleanupStaleServices(ctx, app, desiredServices)
+	if serviceSyncFailed {
+		l.Log.Warn("skipping stale service cleanup due to ensure failures", "app", app.ID)
+	} else {
+		l.cleanupStaleServices(ctx, app, desiredServices)
+	}
 
 	// Wait for new pools to have ready instances before killing old ones.
 	// This prevents a gap where the old sandbox is dead but the new one
@@ -1037,11 +1043,27 @@ func (l *Launcher) cleanupOldVersionPools(ctx context.Context, app *core_v1alpha
 // that has non-HTTP ports. Returns the service entity ID if one was created/updated,
 // or empty string if the service doesn't need a Service entity (all ports are HTTP).
 func (l *Launcher) ensureServiceForPorts(ctx context.Context, app *core_v1alpha.App, appMD *core_v1alpha.Metadata, spec *core_v1alpha.ConfigSpec, serviceName string) (string, error) {
-	// Find the service's ports from ConfigSpec
+	// Find the service's ports from ConfigSpec.
+	// Handles both the ports[] array and legacy scalar Port/PortName/PortType fields.
 	var ports []core_v1alpha.ConfigSpecServicesPorts
 	for _, svc := range spec.Services {
 		if svc.Name == serviceName {
 			ports = svc.Ports
+			// Backfill from scalar fields when ports[] is empty
+			if len(ports) == 0 && svc.Port > 0 {
+				p := core_v1alpha.ConfigSpecServicesPorts{
+					Port: svc.Port,
+					Name: svc.PortName,
+					Type: svc.PortType,
+				}
+				if p.Name == "" {
+					p.Name = serviceName
+				}
+				if p.Type == "" {
+					p.Type = "http"
+				}
+				ports = []core_v1alpha.ConfigSpecServicesPorts{p}
+			}
 			break
 		}
 	}

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -19,6 +19,7 @@ import (
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/network/network_v1alpha"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/controller"
@@ -223,6 +224,32 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 			newPoolIDs = append(newPoolIDs, poolID)
 		}
 	}
+
+	// Ensure Service entities for services with non-HTTP ports.
+	// These are needed for L4 (TCP/UDP) traffic routing via ipalloc → ServiceController → nftables.
+	appResp, err := l.EAC.Get(ctx, app.ID.String())
+	if err != nil {
+		return fmt.Errorf("failed to get app metadata for service entities: %w", err)
+	}
+	var appMD core_v1alpha.Metadata
+	appMD.Decode(appResp.Entity().Entity())
+
+	var desiredServices []string
+	for _, svc := range spec.Services {
+		svcID, err := l.ensureServiceForPorts(ctx, app, &appMD, spec, svc.Name)
+		if err != nil {
+			l.Log.Error("failed to ensure service entity",
+				"app", app.ID,
+				"service", svc.Name,
+				"error", err)
+			continue
+		}
+		if svcID != "" {
+			desiredServices = append(desiredServices, svc.Name)
+		}
+	}
+
+	l.cleanupStaleServices(ctx, app, desiredServices)
 
 	// Wait for new pools to have ready instances before killing old ones.
 	// This prevents a gap where the old sandbox is dead but the new one
@@ -1004,4 +1031,202 @@ func (l *Launcher) cleanupOldVersionPools(ctx context.Context, app *core_v1alpha
 	}
 
 	return nil
+}
+
+// ensureServiceForPorts creates or updates a network Service entity for a service
+// that has non-HTTP ports. Returns the service entity ID if one was created/updated,
+// or empty string if the service doesn't need a Service entity (all ports are HTTP).
+func (l *Launcher) ensureServiceForPorts(ctx context.Context, app *core_v1alpha.App, appMD *core_v1alpha.Metadata, spec *core_v1alpha.ConfigSpec, serviceName string) (string, error) {
+	// Find the service's ports from ConfigSpec
+	var ports []core_v1alpha.ConfigSpecServicesPorts
+	for _, svc := range spec.Services {
+		if svc.Name == serviceName {
+			ports = svc.Ports
+			break
+		}
+	}
+
+	// Filter: only act on services with at least one non-HTTP port
+	hasNonHTTP := false
+	for _, p := range ports {
+		if p.Type != "http" {
+			hasNonHTTP = true
+			break
+		}
+	}
+	if !hasNonHTTP {
+		return "", nil
+	}
+
+	// Map ConfigSpec ports to network Service ports
+	var svcPorts []network_v1alpha.Port
+	for _, p := range ports {
+		np := network_v1alpha.Port{
+			Port:     p.Port,
+			Name:     p.Name,
+			Type:     p.Type,
+			NodePort: p.NodePort,
+		}
+		switch p.Protocol {
+		case core_v1alpha.ConfigSpecServicesPortsUDP:
+			np.Protocol = network_v1alpha.UDP
+		default:
+			np.Protocol = network_v1alpha.TCP
+		}
+		svcPorts = append(svcPorts, np)
+	}
+
+	svcEntityID := fmt.Sprintf("svc/%s-%s", appMD.Name, serviceName)
+
+	existing, err := l.EAC.Get(ctx, svcEntityID)
+	if err != nil {
+		if !errors.Is(err, cond.ErrNotFound{}) {
+			return "", fmt.Errorf("failed to get service entity %s: %w", svcEntityID, err)
+		}
+
+		// Not found — create new Service entity
+		svc := &network_v1alpha.Service{
+			Port: svcPorts,
+			Match: types.LabelSet(
+				"app", appMD.Name,
+			),
+		}
+
+		_, err := l.EAC.Create(ctx, entity.New(
+			(&core_v1alpha.Metadata{
+				Name: fmt.Sprintf("%s-%s", appMD.Name, serviceName),
+				Labels: types.LabelSet(
+					"app", app.ID.String(),
+					"service", serviceName,
+					"managed-by", "launcher",
+				),
+			}).Encode,
+			entity.DBId, entity.Id(svcEntityID),
+			svc.Encode,
+		).Attrs())
+		if err != nil {
+			return "", fmt.Errorf("failed to create service entity %s: %w", svcEntityID, err)
+		}
+
+		l.Log.Info("created service entity",
+			"service_entity", svcEntityID,
+			"app", app.ID,
+			"service", serviceName,
+			"ports", len(svcPorts))
+
+		return svcEntityID, nil
+	}
+
+	// Found — check if ports changed
+	var existingSvc network_v1alpha.Service
+	existingSvc.Decode(existing.Entity().Entity())
+
+	if servicePortsEqual(existingSvc.Port, svcPorts) {
+		return svcEntityID, nil
+	}
+
+	// Ports changed — update the Service entity, preserving existing IPs
+	updatedSvc := &network_v1alpha.Service{
+		Ip:   existingSvc.Ip,
+		Port: svcPorts,
+		Match: types.LabelSet(
+			"app", appMD.Name,
+		),
+	}
+
+	newAttrs := updatedSvc.Encode()
+
+	// Preserve existing entity attrs that we're not replacing
+	replacingIDs := make(map[entity.Id]bool)
+	for _, attr := range newAttrs {
+		replacingIDs[attr.ID] = true
+	}
+
+	var finalAttrs []entity.Attr
+	for _, attr := range existing.Entity().Entity().Attrs() {
+		if !replacingIDs[attr.ID] {
+			finalAttrs = append(finalAttrs, attr)
+		}
+	}
+	finalAttrs = append(finalAttrs, newAttrs...)
+
+	_, err = l.EAC.Replace(ctx, finalAttrs, 0)
+	if err != nil {
+		return "", fmt.Errorf("failed to update service entity %s: %w", svcEntityID, err)
+	}
+
+	l.Log.Info("updated service entity",
+		"service_entity", svcEntityID,
+		"app", app.ID,
+		"service", serviceName,
+		"ports", len(svcPorts))
+
+	return svcEntityID, nil
+}
+
+// servicePortsEqual compares two network Service port slices for equality
+func servicePortsEqual(a, b []network_v1alpha.Port) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Port != b[i].Port ||
+			a[i].Name != b[i].Name ||
+			a[i].Protocol != b[i].Protocol ||
+			a[i].Type != b[i].Type ||
+			a[i].NodePort != b[i].NodePort {
+			return false
+		}
+	}
+	return true
+}
+
+// cleanupStaleServices removes Service entities that are no longer needed.
+// This handles: services removed from config, services changed from non-HTTP to HTTP-only,
+// and all ports removed from a service.
+func (l *Launcher) cleanupStaleServices(ctx context.Context, app *core_v1alpha.App, desiredServices []string) {
+	results, err := l.EAC.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindService))
+	if err != nil {
+		l.Log.Error("failed to list service entities for cleanup", "error", err)
+		return
+	}
+
+	desiredSet := make(map[string]bool)
+	for _, s := range desiredServices {
+		desiredSet[s] = true
+	}
+
+	for _, ent := range results.Values() {
+		var meta core_v1alpha.Metadata
+		meta.Decode(ent.Entity())
+
+		managedBy, _ := meta.Labels.Get("managed-by")
+		if managedBy != "launcher" {
+			continue
+		}
+
+		appLabel, _ := meta.Labels.Get("app")
+		if appLabel != app.ID.String() {
+			continue
+		}
+
+		serviceLabel, _ := meta.Labels.Get("service")
+		if desiredSet[serviceLabel] {
+			continue
+		}
+
+		var svc network_v1alpha.Service
+		svc.Decode(ent.Entity())
+
+		l.Log.Info("deleting stale service entity",
+			"service_entity", svc.ID,
+			"app", app.ID,
+			"service", serviceLabel)
+
+		if _, err := l.EAC.Delete(ctx, svc.ID.String()); err != nil {
+			l.Log.Error("failed to delete stale service entity",
+				"service_entity", svc.ID,
+				"error", err)
+		}
+	}
 }

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -2075,6 +2075,66 @@ func TestServiceEntityDeletedWhenServiceRemoved(t *testing.T) {
 
 // TestNoServiceEntityForHTTPOnlyService verifies that services with only HTTP
 // ports do not get a Service entity created (they use httpingress instead).
+// TestServiceEntityCreatedForScalarNonHTTPPort tests that the launcher creates a
+// Service entity when scalar port fields (Port/PortType) specify a non-HTTP port.
+func TestServiceEntityCreatedForScalarNonHTTPPort(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "legacy-tcp", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// Use scalar Port/PortType fields instead of Ports[] array
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "legacy:latest",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name:     "worker",
+					Port:     9000,
+					PortName: "data",
+					PortType: "tcp",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Verify Service entity was created from scalar port fields
+	services := listAllServices(t, ctx, server)
+	require.Len(t, services, 1, "should create service entity for scalar non-HTTP port")
+
+	svc := services[0]
+	assert.Equal(t, entity.Id("svc/legacy-tcp-worker"), svc.ID)
+	require.Len(t, svc.Port, 1, "service should have 1 port backfilled from scalar fields")
+	assert.Equal(t, int64(9000), svc.Port[0].Port)
+	assert.Equal(t, "data", svc.Port[0].Name)
+	assert.Equal(t, "tcp", svc.Port[0].Type)
+}
+
 func TestNoServiceEntityForHTTPOnlyService(t *testing.T) {
 	ctx := context.Background()
 	log := testutils.TestLogger(t)

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -1547,3 +1547,191 @@ func TestCleanupWaitsForNewPool(t *testing.T) {
 		assert.Equal(t, int64(0), oldPool.DesiredInstances, "old pool should be scaled down")
 	}
 }
+
+// TestMultiPortServiceConfiguration tests that the launcher correctly maps multiple ports
+// from the config spec to the sandbox spec.
+func TestMultiPortServiceConfiguration(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "irc",
+					Ports: []core_v1alpha.Ports{
+						{Port: 6667, Name: "irc", Type: "tcp"},
+						{Port: 6697, Name: "irc-tls", Type: "tcp", NodePort: 6697},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	pool := pools[0]
+	require.Len(t, pool.SandboxSpec.Container, 1)
+
+	container := pool.SandboxSpec.Container[0]
+	require.Len(t, container.Port, 2, "should have two ports")
+
+	assert.Equal(t, int64(6667), container.Port[0].Port)
+	assert.Equal(t, "irc", container.Port[0].Name)
+	assert.Equal(t, "tcp", container.Port[0].Type)
+	assert.Equal(t, int64(0), container.Port[0].NodePort)
+
+	assert.Equal(t, int64(6697), container.Port[1].Port)
+	assert.Equal(t, "irc-tls", container.Port[1].Name)
+	assert.Equal(t, "tcp", container.Port[1].Type)
+	assert.Equal(t, int64(6697), container.Port[1].NodePort)
+
+	// PORT env var should be set to first port (no HTTP type, so first port wins)
+	assert.Contains(t, container.Env, "PORT=6667")
+}
+
+// TestMultiPortHTTPPortEnvVar tests that PORT env var is set to the first HTTP-typed port
+// when multiple ports are configured.
+func TestMultiPortHTTPPortEnvVar(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					Ports: []core_v1alpha.Ports{
+						{Port: 9090, Name: "metrics", Type: "tcp"},
+						{Port: 8080, Name: "http", Type: "http"},
+						{Port: 9443, Name: "https", Type: "http"},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	container := pools[0].SandboxSpec.Container[0]
+	require.Len(t, container.Port, 3, "should have three ports")
+
+	// PORT env var should be set to the first HTTP-typed port (8080), not the first port overall
+	assert.Contains(t, container.Env, "PORT=8080")
+}
+
+// TestScalarPortBackwardCompatWithMultiPort tests that scalar port fields still work
+// alongside services that use the new ports array.
+func TestScalarPortBackwardCompatWithMultiPort(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name:     "web",
+					Port:     8080,
+					PortName: "http",
+					PortType: "http",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	container := pools[0].SandboxSpec.Container[0]
+	require.Len(t, container.Port, 1, "should have one port from scalar fields")
+	assert.Equal(t, int64(8080), container.Port[0].Port)
+	assert.Equal(t, "http", container.Port[0].Name)
+	assert.Equal(t, "http", container.Port[0].Type)
+	assert.Contains(t, container.Env, "PORT=8080")
+}

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -13,6 +13,7 @@ import (
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/network/network_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 )
@@ -1734,4 +1735,396 @@ func TestScalarPortBackwardCompatWithMultiPort(t *testing.T) {
 	assert.Equal(t, "http", container.Port[0].Name)
 	assert.Equal(t, "http", container.Port[0].Type)
 	assert.Contains(t, container.Env, "PORT=8080")
+}
+
+// listAllServices lists all network Service entities from the in-mem store
+func listAllServices(t *testing.T, ctx context.Context, server *testutils.InMemEntityServer) []network_v1alpha.Service {
+	t.Helper()
+
+	resp, err := server.EAC.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindService))
+	require.NoError(t, err)
+
+	var services []network_v1alpha.Service
+	for _, ent := range resp.Values() {
+		var svc network_v1alpha.Service
+		svc.Decode(ent.Entity())
+		services = append(services, svc)
+	}
+
+	return services
+}
+
+// TestServiceEntityCreatedForNonHTTPPorts tests that the launcher creates a network
+// Service entity for services that have non-HTTP ports (e.g., TCP/UDP).
+func TestServiceEntityCreatedForNonHTTPPorts(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "tcp-echo", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "tcp-echo:latest",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "echo",
+					Ports: []core_v1alpha.Ports{
+						{
+							Port:     3000,
+							Name:     "health",
+							Type:     "http",
+							Protocol: core_v1alpha.TCP,
+						},
+						{
+							Port:     7000,
+							Name:     "echo",
+							Type:     "tcp",
+							Protocol: core_v1alpha.TCP,
+							NodePort: 7000,
+						},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Verify Service entity was created
+	services := listAllServices(t, ctx, server)
+	require.Len(t, services, 1, "should create one service entity")
+
+	svc := services[0]
+	assert.Equal(t, entity.Id("svc/tcp-echo-echo"), svc.ID)
+	require.Len(t, svc.Port, 2, "service should have 2 ports")
+
+	assert.Equal(t, int64(3000), svc.Port[0].Port)
+	assert.Equal(t, "health", svc.Port[0].Name)
+	assert.Equal(t, "http", svc.Port[0].Type)
+	assert.Equal(t, network_v1alpha.TCP, svc.Port[0].Protocol)
+
+	assert.Equal(t, int64(7000), svc.Port[1].Port)
+	assert.Equal(t, "echo", svc.Port[1].Name)
+	assert.Equal(t, "tcp", svc.Port[1].Type)
+	assert.Equal(t, int64(7000), svc.Port[1].NodePort)
+	assert.Equal(t, network_v1alpha.TCP, svc.Port[1].Protocol)
+
+	// Verify match labels on the service
+	appLabel, ok := svc.Match.Get("app")
+	assert.True(t, ok, "service should have app match label")
+	assert.Equal(t, "tcp-echo", appLabel)
+
+	// Verify metadata labels
+	svcResp, err := server.EAC.Get(ctx, "svc/tcp-echo-echo")
+	require.NoError(t, err)
+	var meta core_v1alpha.Metadata
+	meta.Decode(svcResp.Entity().Entity())
+	managedBy, _ := meta.Labels.Get("managed-by")
+	assert.Equal(t, "launcher", managedBy)
+	svcLabel, _ := meta.Labels.Get("service")
+	assert.Equal(t, "echo", svcLabel)
+}
+
+// TestServiceEntityUpdatedWhenPortsChange tests that deploying a new version
+// with changed ports updates the existing Service entity.
+func TestServiceEntityUpdatedWhenPortsChange(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "irc-server", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// v1: single TCP port
+	v1 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "irc:v1",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "irc",
+					Ports: []core_v1alpha.Ports{
+						{
+							Port:     6667,
+							Name:     "plaintext",
+							Type:     "tcp",
+							Protocol: core_v1alpha.TCP,
+						},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	v1ID, err := server.Client.Create(ctx, "test-v1", v1)
+	require.NoError(t, err)
+	v1.ID = v1ID
+
+	app.ActiveVersion = v1.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	services := listAllServices(t, ctx, server)
+	require.Len(t, services, 1)
+	require.Len(t, services[0].Port, 1, "v1 should have 1 port")
+	assert.Equal(t, int64(6667), services[0].Port[0].Port)
+
+	// v2: add a second TCP port (TLS)
+	v2 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v2",
+		ImageUrl: "irc:v2",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "irc",
+					Ports: []core_v1alpha.Ports{
+						{
+							Port:     6667,
+							Name:     "plaintext",
+							Type:     "tcp",
+							Protocol: core_v1alpha.TCP,
+						},
+						{
+							Port:     6697,
+							Name:     "tls",
+							Type:     "tcp",
+							Protocol: core_v1alpha.TCP,
+							NodePort: 6697,
+						},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	v2ID, err := server.Client.Create(ctx, "test-v2", v2)
+	require.NoError(t, err)
+	v2.ID = v2ID
+
+	app.ActiveVersion = v2.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Verify Service entity was updated with 2 ports
+	services = listAllServices(t, ctx, server)
+	require.Len(t, services, 1, "should still have one service entity")
+	assert.Equal(t, entity.Id("svc/irc-server-irc"), services[0].ID)
+	require.Len(t, services[0].Port, 2, "v2 should have 2 ports")
+	assert.Equal(t, int64(6667), services[0].Port[0].Port)
+	assert.Equal(t, int64(6697), services[0].Port[1].Port)
+	assert.Equal(t, int64(6697), services[0].Port[1].NodePort)
+}
+
+// TestServiceEntityDeletedWhenServiceRemoved tests that Service entities are
+// cleaned up when a service is removed or all its ports become HTTP-only.
+func TestServiceEntityDeletedWhenServiceRemoved(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "tcp-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// v1: has TCP service
+	v1 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "app:v1",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "tcp-svc",
+					Ports: []core_v1alpha.Ports{
+						{
+							Port:     9000,
+							Name:     "data",
+							Type:     "tcp",
+							Protocol: core_v1alpha.TCP,
+						},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+				{
+					Name: "web",
+					Ports: []core_v1alpha.Ports{
+						{
+							Port:     3000,
+							Name:     "http",
+							Type:     "http",
+							Protocol: core_v1alpha.TCP,
+						},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+				},
+			},
+		},
+	}
+	v1ID, err := server.Client.Create(ctx, "test-v1", v1)
+	require.NoError(t, err)
+	v1.ID = v1ID
+
+	app.ActiveVersion = v1.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Verify: tcp-svc service entity exists, web does not (HTTP-only)
+	services := listAllServices(t, ctx, server)
+	require.Len(t, services, 1, "should have one service entity (tcp-svc)")
+	assert.Equal(t, entity.Id("svc/tcp-app-tcp-svc"), services[0].ID)
+
+	// v2: remove tcp-svc, only keep web
+	v2 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v2",
+		ImageUrl: "app:v2",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					Ports: []core_v1alpha.Ports{
+						{
+							Port:     3000,
+							Name:     "http",
+							Type:     "http",
+							Protocol: core_v1alpha.TCP,
+						},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+				},
+			},
+		},
+	}
+	v2ID, err := server.Client.Create(ctx, "test-v2", v2)
+	require.NoError(t, err)
+	v2.ID = v2ID
+
+	app.ActiveVersion = v2.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Verify: tcp-svc service entity was deleted
+	services = listAllServices(t, ctx, server)
+	assert.Empty(t, services, "service entity should be deleted when service is removed")
+}
+
+// TestNoServiceEntityForHTTPOnlyService verifies that services with only HTTP
+// ports do not get a Service entity created (they use httpingress instead).
+func TestNoServiceEntityForHTTPOnlyService(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "web-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "web:latest",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					Ports: []core_v1alpha.Ports{
+						{
+							Port:     3000,
+							Name:     "http",
+							Type:     "http",
+							Protocol: core_v1alpha.TCP,
+						},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	services := listAllServices(t, ctx, server)
+	assert.Empty(t, services, "HTTP-only service should not create a Service entity")
 }

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -139,23 +139,32 @@ func (n *nftCommands) append(cmd string, args ...any) {
 	n.commands = append(n.commands, fmt.Sprintf(cmd, args...))
 }
 
-func (s *ServiceController) serviceChain(ip netip.Addr, port uint16) string {
-	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%d", ip.String(), port)))
+// nftProto converts a network_v1alpha.PortProtocol to the nftables protocol string.
+// Defaults to "tcp" for empty or unrecognized values.
+func nftProto(p network_v1alpha.PortProtocol) string {
+	if p == network_v1alpha.UDP {
+		return "udp"
+	}
+	return "tcp"
+}
+
+func (s *ServiceController) serviceChain(ip netip.Addr, port uint16, proto string) string {
+	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%s:%d", ip.String(), proto, port)))
 	return fmt.Sprintf("service_%s", base58.Encode(x[:]))
 }
 
-func (s *ServiceController) endpointChain(ip netip.Addr, port uint16) string {
-	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%d", ip.String(), port)))
+func (s *ServiceController) endpointChain(ip netip.Addr, port uint16, proto string) string {
+	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%s:%d", ip.String(), proto, port)))
 	return fmt.Sprintf("endpoint_%s", base58.Encode(x[:]))
 }
 
-func (s *ServiceController) nodeportChain(ip netip.Addr, port uint16) string {
-	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%d", ip.String(), port)))
+func (s *ServiceController) nodeportChain(ip netip.Addr, port uint16, proto string) string {
+	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%s:%d", ip.String(), proto, port)))
 	return fmt.Sprintf("nodeport_%s", base58.Encode(x[:]))
 }
 
-func (s *ServiceController) createServiceChain(cmd *nftCommands, ip netip.Addr, port int) error {
-	srv := s.serviceChain(ip, uint16(port))
+func (s *ServiceController) createServiceChain(cmd *nftCommands, ip netip.Addr, port int, proto string) error {
+	srv := s.serviceChain(ip, uint16(port), proto)
 	if cmd.knownChains.Contains(srv) {
 		return nil
 	}
@@ -164,19 +173,19 @@ func (s *ServiceController) createServiceChain(cmd *nftCommands, ip netip.Addr, 
 
 	cmd.append("add chain inet %s %s", s.table, srv)
 	if ip.Is4() {
-		cmd.append("add element inet %s service_ip4s { %s . tcp . %d : goto %s }", s.table, ip.String(), port, srv)
+		cmd.append("add element inet %s service_ip4s { %s . %s . %d : goto %s }", s.table, ip.String(), proto, port, srv)
 	} else {
-		cmd.append("add element inet %s service_ip6s { %s . tcp . %d : goto %s }", s.table, ip.String(), port, srv)
+		cmd.append("add element inet %s service_ip6s { %s . %s . %d : goto %s }", s.table, ip.String(), proto, port, srv)
 	}
 	return nil
 }
 
-func (s *ServiceController) updateServiceEndpoints(cmd *nftCommands, sip netip.Addr, sport int, endpoints []string) error {
+func (s *ServiceController) updateServiceEndpoints(cmd *nftCommands, sip netip.Addr, sport int, proto string, endpoints []string) error {
 	if len(endpoints) == 0 {
 		return nil
 	}
 
-	srv := s.serviceChain(sip, uint16(sport))
+	srv := s.serviceChain(sip, uint16(sport), proto)
 
 	slices.Sort(endpoints)
 
@@ -208,8 +217,8 @@ func (s *ServiceController) updateServiceEndpoints(cmd *nftCommands, sip netip.A
 	return nil
 }
 
-func (s *ServiceController) setupNodePort(cmd *nftCommands, nport int, sip netip.Addr, sport int) error {
-	chain := s.nodeportChain(sip, uint16(sport))
+func (s *ServiceController) setupNodePort(cmd *nftCommands, nport int, sip netip.Addr, sport int, proto string) error {
+	chain := s.nodeportChain(sip, uint16(sport), proto)
 
 	if cmd.knownChains.Contains(chain) {
 		return nil
@@ -219,24 +228,24 @@ func (s *ServiceController) setupNodePort(cmd *nftCommands, nport int, sip netip
 
 	cmd.append("add chain inet %s %s", s.table, chain)
 
-	cmd.append("add element inet %s service_nodeports { tcp . %d : goto %s }", s.table, nport, chain)
+	cmd.append("add element inet %s service_nodeports { %s . %d : goto %s }", s.table, proto, nport, chain)
 
 	cmd.append("add rule inet %s %s counter name \"nodeports\"", s.table, chain)
 	for _, rp := range s.routablePrefixes {
 		if rp.Addr().Is4() {
-			cmd.append("add rule inet %s %s ip saddr == %s goto %s", s.table, chain, rp.String(), s.serviceChain(sip, uint16(sport)))
+			cmd.append("add rule inet %s %s ip saddr == %s goto %s", s.table, chain, rp.String(), s.serviceChain(sip, uint16(sport), proto))
 		} else {
-			cmd.append("add rule inet %s %s ip6 saddr == %s goto %s", s.table, chain, rp.String(), s.serviceChain(sip, uint16(sport)))
+			cmd.append("add rule inet %s %s ip6 saddr == %s goto %s", s.table, chain, rp.String(), s.serviceChain(sip, uint16(sport), proto))
 		}
 	}
 
 	cmd.append("add rule inet %s %s fib saddr type local counter jump mark-for-masq", s.table, chain)
-	cmd.append("add rule inet %s %s fib saddr type local counter goto %s", s.table, chain, s.serviceChain(sip, uint16(sport)))
+	cmd.append("add rule inet %s %s fib saddr type local counter goto %s", s.table, chain, s.serviceChain(sip, uint16(sport), proto))
 	return nil
 }
 
-func (s *ServiceController) setupEndpointChain(cmd *nftCommands, ip netip.Addr, port uint16) (string, error) {
-	endpoint := s.endpointChain(ip, port)
+func (s *ServiceController) setupEndpointChain(cmd *nftCommands, ip netip.Addr, port uint16, proto string) (string, error) {
+	endpoint := s.endpointChain(ip, port, proto)
 	if cmd.knownChains.Contains(endpoint) {
 		return endpoint, nil
 	}
@@ -246,10 +255,10 @@ func (s *ServiceController) setupEndpointChain(cmd *nftCommands, ip netip.Addr, 
 	cmd.append("add chain inet %s %s", s.table, endpoint)
 	if ip.Is4() {
 		cmd.append("add rule inet %s %s ip saddr %s jump mark-for-masq", s.table, endpoint, ip.String())
-		cmd.append("add rule inet %s %s meta l4proto tcp counter dnat ip to %s:%d", s.table, endpoint, ip.String(), port)
+		cmd.append("add rule inet %s %s meta l4proto %s counter dnat ip to %s:%d", s.table, endpoint, proto, ip.String(), port)
 	} else {
 		cmd.append("add rule inet %s %s ip6 saddr %s jump mark-for-masq", s.table, endpoint, ip.String())
-		cmd.append("add rule inet %s %s meta l4proto tcp counter dnat ip6 to %s:%d", s.table, endpoint, ip.String(), port)
+		cmd.append("add rule inet %s %s meta l4proto %s counter dnat ip6 to %s:%d", s.table, endpoint, proto, ip.String(), port)
 	}
 	return endpoint, nil
 }
@@ -474,6 +483,7 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 			if target == 0 {
 				target = tp.Port
 			}
+			proto := nftProto(tp.Protocol)
 
 			var epChains []string
 			for _, ent := range lr.Values() {
@@ -486,7 +496,7 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 						return fmt.Errorf("failed to parse endpoint IP address: %v", err)
 					}
 
-					chain, err := s.setupEndpointChain(cmd, destIP, uint16(target))
+					chain, err := s.setupEndpointChain(cmd, destIP, uint16(target), proto)
 					if err != nil {
 						return fmt.Errorf("failed to setup endpoint chain: %w", err)
 					}
@@ -495,11 +505,11 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 				}
 			}
 
-			if err := s.createServiceChain(cmd, ip, int(tp.Port)); err != nil {
+			if err := s.createServiceChain(cmd, ip, int(tp.Port), proto); err != nil {
 				return fmt.Errorf("failed to create service chain: %w", err)
 			}
 
-			if err := s.updateServiceEndpoints(cmd, ip, int(tp.Port), epChains); err != nil {
+			if err := s.updateServiceEndpoints(cmd, ip, int(tp.Port), proto, epChains); err != nil {
 				return fmt.Errorf("failed to update service endpoints: %w", err)
 			}
 		}
@@ -507,7 +517,8 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 
 	for _, tp := range srv.Port {
 		if tp.NodePort != 0 {
-			if err := s.setupNodePort(cmd, int(tp.NodePort), firstIp, int(tp.Port)); err != nil {
+			proto := nftProto(tp.Protocol)
+			if err := s.setupNodePort(cmd, int(tp.NodePort), firstIp, int(tp.Port), proto); err != nil {
 				return fmt.Errorf("failed to setup node port: %w", err)
 			}
 		}

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -455,35 +455,7 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 		return fmt.Errorf("failed to list endpoints: %w", err)
 	}
 
-	tp := srv.Port[0]
-
-	var epChains []string
-
 	cmd := s.cmd.Clone()
-
-	for _, ent := range lr.Values() {
-		var eps network_v1alpha.Endpoints
-		eps.Decode(ent.Entity())
-
-		for _, ep := range eps.Endpoint {
-			destIP, err := netip.ParseAddr(ep.Ip)
-			if err != nil {
-				return fmt.Errorf("failed to parse endpoint IP address: %v", err)
-			}
-
-			target := tp.TargetPort
-			if target == 0 {
-				target = tp.Port
-			}
-
-			ep, err := s.setupEndpointChain(cmd, destIP, uint16(target))
-			if err != nil {
-				return fmt.Errorf("failed to setup endpoint chain: %w", err)
-			}
-
-			epChains = append(epChains, ep)
-		}
-	}
 
 	var firstIp netip.Addr
 
@@ -498,6 +470,31 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 		}
 
 		for _, tp := range srv.Port {
+			target := tp.TargetPort
+			if target == 0 {
+				target = tp.Port
+			}
+
+			var epChains []string
+			for _, ent := range lr.Values() {
+				var eps network_v1alpha.Endpoints
+				eps.Decode(ent.Entity())
+
+				for _, ep := range eps.Endpoint {
+					destIP, err := netip.ParseAddr(ep.Ip)
+					if err != nil {
+						return fmt.Errorf("failed to parse endpoint IP address: %v", err)
+					}
+
+					chain, err := s.setupEndpointChain(cmd, destIP, uint16(target))
+					if err != nil {
+						return fmt.Errorf("failed to setup endpoint chain: %w", err)
+					}
+
+					epChains = append(epChains, chain)
+				}
+			}
+
 			if err := s.createServiceChain(cmd, ip, int(tp.Port)); err != nil {
 				return fmt.Errorf("failed to create service chain: %w", err)
 			}

--- a/controllers/service/service_test.go
+++ b/controllers/service/service_test.go
@@ -977,8 +977,8 @@ func TestServiceController(t *testing.T) {
 		svcIP := netip.MustParseAddr("10.10.0.1")
 		epIP := netip.MustParseAddr("10.8.0.5")
 
-		chain3000 := sc.serviceChain(svcIP, 3000)
-		chain7000 := sc.serviceChain(svcIP, 7000)
+		chain3000 := sc.serviceChain(svcIP, 3000, "tcp")
+		chain7000 := sc.serviceChain(svcIP, 7000, "tcp")
 		r.NotEqual(chain3000, chain7000, "service chains for different ports should differ")
 
 		sc.mu.Lock()
@@ -992,11 +992,99 @@ func TestServiceController(t *testing.T) {
 		r.Len(eps7000, 1, "port 7000 should have one endpoint chain")
 
 		// The endpoint chains should differ because they target different ports
-		ep3000 := sc.endpointChain(epIP, 3000)
-		ep7000 := sc.endpointChain(epIP, 7000)
+		ep3000 := sc.endpointChain(epIP, 3000, "tcp")
+		ep7000 := sc.endpointChain(epIP, 7000, "tcp")
 		r.Equal(ep3000, eps3000[0], "port 3000 endpoint chain should DNAT to :3000")
 		r.Equal(ep7000, eps7000[0], "port 7000 endpoint chain should DNAT to :7000")
 		r.NotEqual(eps3000[0], eps7000[0], "endpoint chains for different ports must differ")
+	})
+
+	t.Run("uses correct protocol in nft rules for UDP ports", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		testDeps, cleanup := testutils.NewTestDeps()
+		defer cleanup()
+
+		eac := testDeps.EAC
+
+		sc, err := newServiceController(testDeps)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Ip: []string{"10.10.0.1"},
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "dns"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name:     "dns-udp",
+					Port:     53,
+					Type:     "tcp",
+					Protocol: network_v1alpha.UDP,
+				},
+				{
+					Name:     "dns-tcp",
+					Port:     53,
+					Type:     "tcp",
+					Protocol: network_v1alpha.TCP,
+				},
+			},
+		}
+
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetAttrs(entity.New(
+			entity.Keyword(entity.Ident, svcID.String()),
+			svc.Encode).Attrs())
+		_, err = eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		eps := &network_v1alpha.Endpoints{
+			ID:      entity.Id("endpoints-" + svcID.String()),
+			Service: svcID,
+			Endpoint: []network_v1alpha.Endpoint{
+				{Ip: "10.8.0.5", Port: 53},
+			},
+		}
+
+		var epRPC entityserver_v1alpha.Entity
+		epRPC.SetAttrs(entity.New(
+			entity.Keyword(entity.Ident, eps.ID.String()),
+			eps.Encode).Attrs())
+		_, err = eac.Put(ctx, &epRPC)
+		r.NoError(err)
+
+		svcEntity := entity.New(svc.Encode)
+		meta := &entity.Meta{Entity: svcEntity, Revision: 1}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		// UDP and TCP on port 53 should produce different service chains
+		svcIP := netip.MustParseAddr("10.10.0.1")
+		chainUDP := sc.serviceChain(svcIP, 53, "udp")
+		chainTCP := sc.serviceChain(svcIP, 53, "tcp")
+		r.NotEqual(chainUDP, chainTCP, "same port with different protocols should have different chains")
+
+		sc.mu.Lock()
+		_, okUDP := sc.chainEndpoints[chainUDP]
+		_, okTCP := sc.chainEndpoints[chainTCP]
+		sc.mu.Unlock()
+
+		r.True(okUDP, "should have endpoint chains for UDP port 53")
+		r.True(okTCP, "should have endpoint chains for TCP port 53")
+
+		// Endpoint chains should also differ by protocol
+		epIP := netip.MustParseAddr("10.8.0.5")
+		epUDP := sc.endpointChain(epIP, 53, "udp")
+		epTCP := sc.endpointChain(epIP, 53, "tcp")
+		r.NotEqual(epUDP, epTCP, "endpoint chains for same port different protocol must differ")
 	})
 
 	t.Run("handles service IP allocation", func(t *testing.T) {

--- a/controllers/service/service_test.go
+++ b/controllers/service/service_test.go
@@ -893,6 +893,112 @@ func TestServiceController(t *testing.T) {
 		r.NoError(err)
 	})
 
+	t.Run("creates per-port endpoint chains for multi-port services", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		testDeps, cleanup := testutils.NewTestDeps()
+		defer cleanup()
+
+		eac := testDeps.EAC
+
+		sc, err := newServiceController(testDeps)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		// Create a multi-port service (like tcp-echo: HTTP health + TCP echo)
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Ip: []string{"10.10.0.1"},
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "tcp-echo"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name: "health",
+					Port: 3000,
+					Type: "http",
+				},
+				{
+					Name:     "echo",
+					Port:     7000,
+					Type:     "tcp",
+					NodePort: 7000,
+				},
+			},
+		}
+
+		// Store the service in entity store
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetAttrs(entity.New(
+			entity.Keyword(entity.Ident, svcID.String()),
+			svc.Encode).Attrs())
+		_, err = eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		// Create endpoints for the service (simulating a sandbox at 10.8.0.5)
+		epID := entity.Id("endpoints-" + svcID.String())
+		eps := &network_v1alpha.Endpoints{
+			ID:      epID,
+			Service: svcID,
+			Endpoint: []network_v1alpha.Endpoint{
+				{
+					Ip:   "10.8.0.5",
+					Port: 3000,
+				},
+			},
+		}
+
+		var epRPC entityserver_v1alpha.Entity
+		epRPC.SetAttrs(entity.New(
+			entity.Keyword(entity.Ident, epID.String()),
+			eps.Encode).Attrs())
+		_, err = eac.Put(ctx, &epRPC)
+		r.NoError(err)
+
+		svcEntity := entity.New(svc.Encode)
+		meta := &entity.Meta{
+			Entity:   svcEntity,
+			Revision: 1,
+		}
+
+		// Create should succeed and set up per-port endpoint chains.
+		// Before the fix, all endpoint chains would DNAT to port 3000 (srv.Port[0]).
+		// After the fix, port 3000's chain DNATs to :3000 and port 7000's chain DNATs to :7000.
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		// Verify per-port endpoint chains via the internal chainEndpoints map.
+		// Each service port gets its own service chain, each with its own endpoint chains.
+		svcIP := netip.MustParseAddr("10.10.0.1")
+		epIP := netip.MustParseAddr("10.8.0.5")
+
+		chain3000 := sc.serviceChain(svcIP, 3000)
+		chain7000 := sc.serviceChain(svcIP, 7000)
+		r.NotEqual(chain3000, chain7000, "service chains for different ports should differ")
+
+		sc.mu.Lock()
+		eps3000, ok3000 := sc.chainEndpoints[chain3000]
+		eps7000, ok7000 := sc.chainEndpoints[chain7000]
+		sc.mu.Unlock()
+
+		r.True(ok3000, "should have endpoint chains for port 3000")
+		r.True(ok7000, "should have endpoint chains for port 7000")
+		r.Len(eps3000, 1, "port 3000 should have one endpoint chain")
+		r.Len(eps7000, 1, "port 7000 should have one endpoint chain")
+
+		// The endpoint chains should differ because they target different ports
+		ep3000 := sc.endpointChain(epIP, 3000)
+		ep7000 := sc.endpointChain(epIP, 7000)
+		r.Equal(ep3000, eps3000[0], "port 3000 endpoint chain should DNAT to :3000")
+		r.Equal(ep7000, eps7000[0], "port 7000 endpoint chain should DNAT to :7000")
+		r.NotEqual(eps3000[0], eps7000[0], "endpoint chains for different ports must differ")
+	})
+
 	t.Run("handles service IP allocation", func(t *testing.T) {
 		r := require.New(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -134,6 +134,23 @@ description = "Third-party API key for payment processing"
 
 The `required` flag is useful for variables whose values differ per environment—declare them in `app.toml` with an empty value and `required = true`, then set the actual value with `miren env set` before deploying. The `sensitive` flag ensures secrets aren't accidentally exposed in terminal output.
 
+### Traffic Routing
+
+For HTTP services, Miren handles routing automatically. For non-HTTP services (TCP/UDP), you can expose ports directly using the `ports` array:
+
+```toml
+[services.irc]
+command = "./ircd"
+
+[[services.irc.ports]]
+port = 6667
+name = "irc"
+type = "tcp"
+node_port = 6667
+```
+
+See [Traffic Routing](/traffic-routing) for the full picture — HTTP ingress, TCP/UDP routing, multi-port services, and the `PORT` environment variable.
+
 ## Complete Example
 
 ```toml

--- a/docs/docs/app-toml.md
+++ b/docs/docs/app-toml.md
@@ -133,13 +133,18 @@ image = "postgres:16"
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
 | `command` | string | Command to run | Image's default entrypoint |
-| `port` | int | Port the service listens on (web service only) | `3000` |
-| `port_name` | string | Named port identifier | — |
-| `port_type` | string | Port protocol type | — |
+| `port` | int | Port the service listens on (single-port shorthand) | `3000` (web only) |
+| `port_name` | string | Named port identifier (single-port shorthand) | Service name |
+| `port_type` | string | `"http"` or `"tcp"` (single-port shorthand) | `"http"` |
+| `ports` | [[port]](#ports) | Multi-port configuration array | — |
 | `image` | string | Container image to use instead of the app's built image | App's built image |
 | `env` | [[env]](#env) | Service-specific environment variables (same schema as global `[[env]]`) | — |
 | `concurrency` | [concurrency](#concurrency) | Scaling configuration | See defaults below |
 | `disks` | [[disk]](#disks) | Persistent disk attachments | — |
+
+:::note
+You cannot mix the single-port fields (`port`, `port_name`, `port_type`) with the `ports` array on the same service.
+:::
 
 ### `[services.<name>.concurrency]` — Scaling {#concurrency}
 
@@ -177,6 +182,38 @@ shutdown_timeout = "10s"
 - In **auto** mode: `requests_per_instance` must be non-negative, `scale_down_delay` must be a valid Go duration, and `num_instances` must not be set.
 - In **fixed** mode: `num_instances` must be at least 1, and `requests_per_instance` / `scale_down_delay` must not be set.
 - `shutdown_timeout` must be a valid Go duration (e.g. `"10s"`, `"30s"`).
+:::
+
+### `[[services.<name>.ports]]` — Ports {#ports}
+
+Configures network ports for a service. Use this when a service needs multiple ports or non-HTTP protocols. See [Traffic Routing](/traffic-routing) for usage patterns and examples.
+
+```toml
+[[services.app.ports]]
+port = 3000
+name = "http"
+type = "http"
+
+[[services.app.ports]]
+port = 7000
+name = "data"
+type = "tcp"
+node_port = 7000
+```
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| `port` | int | Port your process listens on (1–65535). **Required.** | — |
+| `name` | string | Unique name for this port. **Required.** | — |
+| `type` | string | `"http"` for web traffic, `"tcp"` for raw TCP, `"udp"` for UDP | `"http"` |
+| `node_port` | int | Port to expose on the host machine (1–65535) | (none) |
+
+:::note Validation
+- `port` must be between 1 and 65535.
+- `name` is required and must be unique within the service.
+- `type` must be `"http"`, `"tcp"`, or `"udp"`.
+- Each `(port, type)` pair must be unique within the service (`"tcp"` and `"http"` share the TCP transport, so port 8080 with type `"http"` and port 8080 with type `"tcp"` conflict, but port 53 with `"tcp"` and port 53 with `"udp"` are allowed).
+- `node_port` must be between 1 and 65535 and unique across the cluster.
 :::
 
 ### `[[services.<name>.disks]]` — Persistent Disks {#disks}

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -49,10 +49,13 @@ If you're running Miren on a cloud provider, you'll need to configure security g
 | 8443 | UDP | Miren API (QUIC) - CLI and client connections | Yes |
 | 80 | TCP | HTTP traffic to your applications (redirects to HTTPS) | Yes |
 | 443 | TCP | HTTPS traffic to your applications | Yes |
+| NodePorts | TCP/UDP | Direct L4 traffic to non-HTTP services (see [Traffic Routing](/traffic-routing)) | If using TCP/UDP services |
 
 **Miren API (UDP 8443):** The Miren API uses QUIC (HTTP/3) over UDP. This is how the CLI communicates with the server and how remote clients connect to your cluster.
 
 **HTTP Ingress (TCP 80/443):** Application traffic uses standard HTTP/HTTPS. Port 80 handles ACME certificate challenges and redirects to HTTPS. Port 443 serves your applications over TLS.
+
+**NodePorts:** If your app exposes non-HTTP services with `node_port` in the port configuration, those ports must also be open. For example, an IRC server with `node_port = 6667` requires TCP port 6667 to be reachable.
 
 ### Outbound Connectivity
 

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -179,7 +179,7 @@ Each service can configure:
 |--------|-------------|---------|
 | `command` | Command to run | Image's default entrypoint |
 | `image` | Container image to use | App's built image |
-| `port` | Port the service listens on (scalar, single-port) | 3000 (web only) |
+| `port` | Port the service listens on (single-port shorthand) | 3000 (web only) |
 | `ports` | Port configuration array (multi-port, see [Traffic Routing](/traffic-routing)) | (none) |
 | `env` | Service-specific environment variables | (none) |
 | `concurrency` | Scaling configuration | See [Scaling](/scaling) |

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -179,7 +179,8 @@ Each service can configure:
 |--------|-------------|---------|
 | `command` | Command to run | Image's default entrypoint |
 | `image` | Container image to use | App's built image |
-| `port` | Port the web service listens on | 3000 (web only) |
+| `port` | Port the service listens on (scalar, single-port) | 3000 (web only) |
+| `ports` | Port configuration array (multi-port, see [Traffic Routing](/traffic-routing)) | (none) |
 | `env` | Service-specific environment variables | (none) |
 | `concurrency` | Scaling configuration | See [Scaling](/scaling) |
 | `concurrency.shutdown_timeout` | Time to wait for graceful shutdown during redeploy | `10s` |
@@ -256,16 +257,13 @@ num_instances = 1
 
 Connect to other services using their DNS name and standard port—`postgres.app.miren:5432` for PostgreSQL, `redis.app.miren:6379` for Redis. The container images listen on their standard ports by default; Miren doesn't manage these ports.
 
-## HTTP Routing
+## Traffic Routing
 
-Only the `web` service receives external HTTP traffic. When you create a route to your app, requests go to the web service:
+The `web` service receives external HTTP traffic through Miren's HTTP ingress. Create a route to make your app reachable:
 
 ```bash
-# Creates route to the web service
 miren route add myapp.example.com --app myapp
 ```
-
-Other services (workers, databases) are internal—they can't be reached from outside your app.
 
 The web service defaults to port 3000. Override it if your app listens elsewhere:
 
@@ -274,6 +272,8 @@ The web service defaults to port 3000. Override it if your app listens elsewhere
 command = "gunicorn app:app --bind 0.0.0.0:8000"
 port = 8000
 ```
+
+For non-HTTP services (TCP/UDP), you can expose ports directly using the `ports` array and `node_port`. See [Traffic Routing](/traffic-routing) for the full picture — HTTP ingress, L4 routing, multi-port services, and the `PORT` environment variable.
 
 ## Service Scaling
 
@@ -489,6 +489,7 @@ num_instances = 1
 
 - [App Configuration](/app-configuration) — Overview of the configuration model
 - [app.toml Reference](/app-toml) — Complete field reference for `.miren/app.toml`
+- [Traffic Routing](/traffic-routing) — HTTP ingress, TCP/UDP routing, multi-port services
 - [Persistent Storage](/disks) — Local storage and disk options for databases
 - [Application Scaling](/scaling) — Configure how each service scales
 - [Getting Started](/getting-started) — Deploy your first app

--- a/docs/docs/traffic-routing.md
+++ b/docs/docs/traffic-routing.md
@@ -269,6 +269,7 @@ num_instances = 1
 
 ## Next Steps
 
+- [app.toml Reference](/app-toml#ports) — Complete field reference for port configuration
 - [Services](/services) — Defining services, commands, images, and scaling
 - [TLS Certificates](/tls) — How HTTPS works for HTTP services
 - [Firewall Configuration](/firewall) — Host-level firewall rules and cloud provider setup

--- a/docs/docs/traffic-routing.md
+++ b/docs/docs/traffic-routing.md
@@ -4,54 +4,33 @@ sidebar_position: 7
 
 # Traffic Routing
 
-Miren routes traffic to your application through two mechanisms depending on the type of service:
+Miren handles getting traffic to your app. For HTTP apps, this works automatically — deploy and add a route. For non-HTTP services like IRC servers, game servers, or custom TCP/UDP protocols, you configure ports explicitly.
 
-- **HTTP services** are routed at Layer 7 through Miren's HTTP ingress (reverse proxy)
-- **TCP/UDP services** are routed at Layer 4 through nftables NAT rules
+## Web Traffic (HTTP)
 
-Most apps only need HTTP routing, which works automatically. TCP/UDP routing is for services like databases, game servers, IRC, or anything that speaks a non-HTTP protocol.
+When you deploy an app, the `web` service automatically receives HTTP traffic. No port configuration is needed — Miren handles TLS, routing, and load balancing.
 
-## HTTP Routing
+### Adding a Route
 
-HTTP routing is the default and requires no special configuration. When you deploy an app with a `web` service, Miren's HTTP ingress handles TLS termination, hostname-based routing, and reverse proxying.
-
-### How It Works
-
-1. A request arrives at the node on port 80 or 443
-2. The HTTP ingress extracts the hostname and looks up the matching route
-3. The activator finds (or starts) a sandbox running the `web` service
-4. The ingress reverse-proxies the request to the sandbox's HTTP port
-
-```
-Client → :443 → HTTP Ingress → Route Lookup → Activator → Sandbox :3000
-```
-
-### Routes
-
-Routes map hostnames to apps. Create one with the CLI:
+Map a hostname to your app:
 
 ```bash
 miren route add myapp.example.com --app myapp
 ```
 
-Each hostname routes to the app's `web` service. TLS certificates are provisioned automatically via Let's Encrypt (see [TLS Certificates](/tls)).
+Requests to that hostname are forwarded to your `web` service. TLS certificates are provisioned automatically (see [TLS Certificates](/tls)).
 
-### The `web` Service
+### Choosing a Port
 
-The `web` service is special:
-
-- It's the only service that receives HTTP traffic from the ingress
-- If no port is configured, it defaults to port 3000
-- The `PORT` environment variable is set automatically so your app knows which port to listen on
-- It uses `auto` scaling by default (scale-to-zero when idle, scale up on traffic)
+Miren sets the `PORT` environment variable to tell your app which port to listen on. Your app should bind to `PORT`:
 
 ```toml
 [services.web]
 command = "node server.js"
-# Listens on PORT=3000 by default
+# App reads process.env.PORT and listens there
 ```
 
-To use a different port:
+To choose a specific port, set it in `.miren/app.toml`:
 
 ```toml
 [services.web]
@@ -59,26 +38,11 @@ command = "gunicorn app:app --bind 0.0.0.0:8000"
 port = 8000
 ```
 
-### The `PORT` Environment Variable
+Miren sets `PORT=8000` and routes traffic there.
 
-Miren sets `PORT` automatically based on your port configuration:
+## Non-HTTP Services (TCP/UDP)
 
-| Configuration | `PORT` value |
-|---------------|-------------|
-| No port configured (web service) | `3000` |
-| Scalar `port = 8000` | `8000` |
-| `ports[]` with an `http`-typed port | First `http`-typed port |
-| `ports[]` with no `http`-typed port | First port in the array |
-
-`PORT` is a system-managed variable and cannot be overridden by user env config.
-
-## TCP/UDP Routing
-
-For non-HTTP services — databases, game servers, IRC, gRPC without HTTP/2, raw TCP/UDP protocols — Miren routes traffic at Layer 4 using nftables NAT rules.
-
-### Configuring Ports
-
-Use the `ports` array in `app.toml` to expose non-HTTP ports:
+To expose services that don't speak HTTP — an IRC server, a game server, a custom protocol — use the `ports` array in `.miren/app.toml` with a `node_port` to make the port reachable from outside the cluster.
 
 ```toml
 [services.irc]
@@ -88,6 +52,7 @@ command = "./ircd"
 port = 6667
 name = "irc"
 type = "tcp"
+node_port = 6667
 
 [[services.irc.ports]]
 port = 6697
@@ -96,73 +61,47 @@ type = "tcp"
 node_port = 6697
 ```
 
-Each port entry has these fields:
+With this config:
+- The IRC server listens on ports 6667 and 6697 inside its container
+- Clients connect to those same ports on your Miren host
+- Miren forwards the traffic and load-balances across instances
+
+### Port Configuration
+
+Each entry in `ports` accepts:
 
 | Field | Required | Description | Default |
 |-------|----------|-------------|---------|
-| `port` | Yes | Port the process listens on inside the container (1–65535) | — |
-| `name` | Yes | Unique name for this port | — |
-| `type` | No | `"http"` or `"tcp"` | `"http"` |
-| `protocol` | No | `"tcp"` or `"udp"` | `"tcp"` |
-| `node_port` | No | Port to expose on the host (0–65535) | (none) |
+| `port` | Yes | Port your process listens on (1–65535) | — |
+| `name` | Yes | A unique name for this port | — |
+| `type` | No | `"http"` for web traffic, `"tcp"` for raw TCP, `"udp"` for UDP | `"http"` |
+| `node_port` | No | Port to expose on the host machine (1–65535) | (none) |
 
-### Port Types
+### Node Ports
 
-The `type` field determines how traffic is routed:
+The `node_port` is what makes a non-HTTP service reachable from outside. Without it, the port is only accessible to other services within the app.
 
-- **`http`** — Routed through the HTTP ingress (L7 reverse proxy). Only meaningful on the `web` service.
-- **`tcp`** — Routed through nftables NAT rules (L4). Requires a `node_port` for external access.
+Node port constraints:
+- Must be unique across all apps on the cluster — Miren checks for conflicts at deploy time
+- Cannot overlap with ports Miren uses (80, 443, 8443)
 
-### How L4 Routing Works
+If your cloud provider uses security groups or network ACLs, you'll need to allow traffic on your node ports (see [Firewall Configuration](/firewall)).
 
-When a service has non-HTTP ports, Miren creates a Service entity that triggers the L4 routing pipeline:
+## Multiple Ports per Service
 
-1. **IP allocation** — The service gets a cluster-internal IP from the service prefix pool
-2. **nftables rules** — The ServiceController programs NAT rules:
-   - A service chain that load-balances across sandbox endpoints
-   - Endpoint chains that DNAT traffic to individual sandbox IPs
-   - NodePort rules that forward host-port traffic to the service chain
-3. **Endpoints** — As sandboxes start and stop, endpoint entries are updated and nftables rules are reprogrammed
-
-```
-Client → :6697 (node_port) → nftables PREROUTING → Service Chain
-    → Load Balance → Endpoint Chain → DNAT → Sandbox :6697
-```
-
-### NodePorts
-
-A `node_port` exposes a service port directly on the host machine. This is how external clients reach non-HTTP services.
-
-```toml
-[[services.game.ports]]
-port = 27015
-name = "game"
-type = "tcp"
-protocol = "udp"
-node_port = 27015
-```
-
-NodePort constraints:
-- Must be unique across all apps on the cluster — Miren validates this at deploy time
-- Cannot conflict with ports used by Miren itself (80, 443, 8443)
-
-Without a `node_port`, L4 service ports are only reachable from within the cluster (useful for internal services like databases).
-
-## Multi-Port Services
-
-A single service can expose multiple ports with different types and protocols:
+A single service can expose a mix of HTTP and non-HTTP ports. This is useful when a service needs an HTTP endpoint for health checks or an API alongside a raw protocol port:
 
 ```toml
 [services.app]
 command = "./server"
 
-# HTTP health/API endpoint — routed through HTTP ingress
+# HTTP endpoint for health checks and API
 [[services.app.ports]]
 port = 3000
 name = "http"
 type = "http"
 
-# TCP data port — routed through nftables
+# TCP port for the data protocol
 [[services.app.ports]]
 port = 7000
 name = "data"
@@ -170,36 +109,39 @@ type = "tcp"
 node_port = 7000
 ```
 
-This is common for services that need both an HTTP endpoint (for health checks, metrics, or API) and a raw protocol port (for data transfer).
+The HTTP port is routed through Miren's web traffic pipeline (routes, TLS, autoscaling). The TCP port is exposed directly via the node port. Both reach the same running process.
 
-### DNS Service (TCP + UDP on same port)
+### Same Port, Different Protocols
 
-Some protocols like DNS require the same port on both TCP and UDP:
+Some protocols need both TCP and UDP on the same port number. Declare them as separate entries:
 
 ```toml
-[services.dns]
-command = "./dns-server"
-
 [[services.dns.ports]]
 port = 53
 name = "dns-udp"
-type = "tcp"
-protocol = "udp"
+type = "udp"
 node_port = 53
 
 [[services.dns.ports]]
 port = 53
 name = "dns-tcp"
 type = "tcp"
-protocol = "tcp"
 node_port = 5353
 ```
 
-The same container port can be used for different protocols. Each `(port, protocol)` combination must be unique within a service.
+Port numbers can repeat as long as each port/type pair is unique within the service (since `"tcp"` and `"udp"` use different transport protocols).
 
-## Internal Service Communication
+### The `PORT` Environment Variable
 
-Services within the same app communicate over the internal network using DNS names. Every service is reachable at `<service>.app.miren`:
+When using the `ports` array, Miren sets `PORT` to:
+1. The first port with `type = "http"`, if one exists
+2. Otherwise, the first port in the array
+
+`PORT` is managed by Miren and can't be overridden.
+
+## Service-to-Service Communication
+
+Services within the same app can talk to each other using internal DNS. Each service is reachable at `<service>.app.miren`:
 
 ```toml
 name = "myapp"
@@ -219,15 +161,15 @@ mode = "fixed"
 num_instances = 1
 ```
 
-Internal communication uses direct container-to-container networking through the bridge — no NAT rules or ingress are involved. Services connect using standard ports (5432 for PostgreSQL, 6379 for Redis, etc.) without any Miren port configuration.
+Internal traffic goes directly between containers — it doesn't pass through Miren's routing layer. Services connect on their standard ports (5432 for PostgreSQL, 6379 for Redis) without any Miren port configuration needed.
 
-Internal DNS is for services **within the same app**. Cross-app communication is not currently supported.
+:::note
+Internal DNS only works between services in the same app. Cross-app communication is not currently supported.
+:::
 
-## Port Configuration Reference
+## Simple Port Configuration
 
-### Scalar Fields (backward compatible)
-
-For simple single-port services, you can use the scalar fields:
+If your service only has one port, you can use the simpler single-field syntax instead of the `ports` array:
 
 ```toml
 [services.web]
@@ -238,29 +180,21 @@ port_type = "http"
 
 | Field | Description | Default |
 |-------|-------------|---------|
-| `port` | Port the process listens on | `3000` (web only) |
+| `port` | Port your process listens on | Set by `PORT` env var |
 | `port_name` | Name for the port | Service name |
 | `port_type` | `"http"` or `"tcp"` | `"http"` |
 
-### `ports[]` Array (multi-port)
+You can't mix these fields with the `ports` array on the same service.
 
-For services with multiple ports or non-HTTP protocols, use the `ports` array:
+## How It Works Under the Hood
 
-```toml
-[[services.myservice.ports]]
-port = 3000
-name = "http"
-type = "http"
+:::info
+You don't need to understand these details to use Miren. This section is for the curious.
+:::
 
-[[services.myservice.ports]]
-port = 7000
-name = "grpc"
-type = "tcp"
-protocol = "tcp"
-node_port = 7000
-```
+**HTTP traffic** flows through Miren's HTTP ingress — a reverse proxy that listens on ports 80 and 443. When a request arrives, the ingress looks up the hostname to find the matching app, ensures a sandbox is running, and proxies the request to the sandbox's HTTP port.
 
-You cannot mix scalar port fields and the `ports[]` array on the same service — Miren rejects this at deploy time.
+**Non-HTTP traffic** is routed by the kernel using nftables NAT rules. When you deploy a service with non-HTTP ports, Miren allocates an internal IP for the service and programs firewall rules that forward matching traffic (by port and protocol) to the running sandboxes. As instances scale up and down, these rules are updated automatically to load-balance across available endpoints.
 
 ## Examples
 
@@ -301,8 +235,7 @@ type = "http"
 [[services.game.ports]]
 port = 27015
 name = "game"
-type = "tcp"
-protocol = "udp"
+type = "udp"
 node_port = 27015
 
 [services.game.concurrency]
@@ -310,7 +243,7 @@ mode = "fixed"
 num_instances = 1
 ```
 
-### TCP Echo Server (testing multi-port)
+### TCP Echo Server
 
 ```toml
 name = "tcp-echo"

--- a/docs/docs/traffic-routing.md
+++ b/docs/docs/traffic-routing.md
@@ -1,0 +1,342 @@
+---
+sidebar_position: 7
+---
+
+# Traffic Routing
+
+Miren routes traffic to your application through two mechanisms depending on the type of service:
+
+- **HTTP services** are routed at Layer 7 through Miren's HTTP ingress (reverse proxy)
+- **TCP/UDP services** are routed at Layer 4 through nftables NAT rules
+
+Most apps only need HTTP routing, which works automatically. TCP/UDP routing is for services like databases, game servers, IRC, or anything that speaks a non-HTTP protocol.
+
+## HTTP Routing
+
+HTTP routing is the default and requires no special configuration. When you deploy an app with a `web` service, Miren's HTTP ingress handles TLS termination, hostname-based routing, and reverse proxying.
+
+### How It Works
+
+1. A request arrives at the node on port 80 or 443
+2. The HTTP ingress extracts the hostname and looks up the matching route
+3. The activator finds (or starts) a sandbox running the `web` service
+4. The ingress reverse-proxies the request to the sandbox's HTTP port
+
+```
+Client → :443 → HTTP Ingress → Route Lookup → Activator → Sandbox :3000
+```
+
+### Routes
+
+Routes map hostnames to apps. Create one with the CLI:
+
+```bash
+miren route add myapp.example.com --app myapp
+```
+
+Each hostname routes to the app's `web` service. TLS certificates are provisioned automatically via Let's Encrypt (see [TLS Certificates](/tls)).
+
+### The `web` Service
+
+The `web` service is special:
+
+- It's the only service that receives HTTP traffic from the ingress
+- If no port is configured, it defaults to port 3000
+- The `PORT` environment variable is set automatically so your app knows which port to listen on
+- It uses `auto` scaling by default (scale-to-zero when idle, scale up on traffic)
+
+```toml
+[services.web]
+command = "node server.js"
+# Listens on PORT=3000 by default
+```
+
+To use a different port:
+
+```toml
+[services.web]
+command = "gunicorn app:app --bind 0.0.0.0:8000"
+port = 8000
+```
+
+### The `PORT` Environment Variable
+
+Miren sets `PORT` automatically based on your port configuration:
+
+| Configuration | `PORT` value |
+|---------------|-------------|
+| No port configured (web service) | `3000` |
+| Scalar `port = 8000` | `8000` |
+| `ports[]` with an `http`-typed port | First `http`-typed port |
+| `ports[]` with no `http`-typed port | First port in the array |
+
+`PORT` is a system-managed variable and cannot be overridden by user env config.
+
+## TCP/UDP Routing
+
+For non-HTTP services — databases, game servers, IRC, gRPC without HTTP/2, raw TCP/UDP protocols — Miren routes traffic at Layer 4 using nftables NAT rules.
+
+### Configuring Ports
+
+Use the `ports` array in `app.toml` to expose non-HTTP ports:
+
+```toml
+[services.irc]
+command = "./ircd"
+
+[[services.irc.ports]]
+port = 6667
+name = "irc"
+type = "tcp"
+
+[[services.irc.ports]]
+port = 6697
+name = "irc-tls"
+type = "tcp"
+node_port = 6697
+```
+
+Each port entry has these fields:
+
+| Field | Required | Description | Default |
+|-------|----------|-------------|---------|
+| `port` | Yes | Port the process listens on inside the container (1–65535) | — |
+| `name` | Yes | Unique name for this port | — |
+| `type` | No | `"http"` or `"tcp"` | `"http"` |
+| `protocol` | No | `"tcp"` or `"udp"` | `"tcp"` |
+| `node_port` | No | Port to expose on the host (0–65535) | (none) |
+
+### Port Types
+
+The `type` field determines how traffic is routed:
+
+- **`http`** — Routed through the HTTP ingress (L7 reverse proxy). Only meaningful on the `web` service.
+- **`tcp`** — Routed through nftables NAT rules (L4). Requires a `node_port` for external access.
+
+### How L4 Routing Works
+
+When a service has non-HTTP ports, Miren creates a Service entity that triggers the L4 routing pipeline:
+
+1. **IP allocation** — The service gets a cluster-internal IP from the service prefix pool
+2. **nftables rules** — The ServiceController programs NAT rules:
+   - A service chain that load-balances across sandbox endpoints
+   - Endpoint chains that DNAT traffic to individual sandbox IPs
+   - NodePort rules that forward host-port traffic to the service chain
+3. **Endpoints** — As sandboxes start and stop, endpoint entries are updated and nftables rules are reprogrammed
+
+```
+Client → :6697 (node_port) → nftables PREROUTING → Service Chain
+    → Load Balance → Endpoint Chain → DNAT → Sandbox :6697
+```
+
+### NodePorts
+
+A `node_port` exposes a service port directly on the host machine. This is how external clients reach non-HTTP services.
+
+```toml
+[[services.game.ports]]
+port = 27015
+name = "game"
+type = "tcp"
+protocol = "udp"
+node_port = 27015
+```
+
+NodePort constraints:
+- Must be unique across all apps on the cluster — Miren validates this at deploy time
+- Cannot conflict with ports used by Miren itself (80, 443, 8443)
+
+Without a `node_port`, L4 service ports are only reachable from within the cluster (useful for internal services like databases).
+
+## Multi-Port Services
+
+A single service can expose multiple ports with different types and protocols:
+
+```toml
+[services.app]
+command = "./server"
+
+# HTTP health/API endpoint — routed through HTTP ingress
+[[services.app.ports]]
+port = 3000
+name = "http"
+type = "http"
+
+# TCP data port — routed through nftables
+[[services.app.ports]]
+port = 7000
+name = "data"
+type = "tcp"
+node_port = 7000
+```
+
+This is common for services that need both an HTTP endpoint (for health checks, metrics, or API) and a raw protocol port (for data transfer).
+
+### DNS Service (TCP + UDP on same port)
+
+Some protocols like DNS require the same port on both TCP and UDP:
+
+```toml
+[services.dns]
+command = "./dns-server"
+
+[[services.dns.ports]]
+port = 53
+name = "dns-udp"
+type = "tcp"
+protocol = "udp"
+node_port = 53
+
+[[services.dns.ports]]
+port = 53
+name = "dns-tcp"
+type = "tcp"
+protocol = "tcp"
+node_port = 5353
+```
+
+The same container port can be used for different protocols. Each `(port, protocol)` combination must be unique within a service.
+
+## Internal Service Communication
+
+Services within the same app communicate over the internal network using DNS names. Every service is reachable at `<service>.app.miren`:
+
+```toml
+name = "myapp"
+
+[[env]]
+key = "DATABASE_URL"
+value = "postgres://user:pass@postgres.app.miren:5432/mydb"
+
+[services.web]
+command = "node server.js"
+
+[services.postgres]
+image = "postgres:16"
+
+[services.postgres.concurrency]
+mode = "fixed"
+num_instances = 1
+```
+
+Internal communication uses direct container-to-container networking through the bridge — no NAT rules or ingress are involved. Services connect using standard ports (5432 for PostgreSQL, 6379 for Redis, etc.) without any Miren port configuration.
+
+Internal DNS is for services **within the same app**. Cross-app communication is not currently supported.
+
+## Port Configuration Reference
+
+### Scalar Fields (backward compatible)
+
+For simple single-port services, you can use the scalar fields:
+
+```toml
+[services.web]
+port = 8000
+port_name = "http"
+port_type = "http"
+```
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `port` | Port the process listens on | `3000` (web only) |
+| `port_name` | Name for the port | Service name |
+| `port_type` | `"http"` or `"tcp"` | `"http"` |
+
+### `ports[]` Array (multi-port)
+
+For services with multiple ports or non-HTTP protocols, use the `ports` array:
+
+```toml
+[[services.myservice.ports]]
+port = 3000
+name = "http"
+type = "http"
+
+[[services.myservice.ports]]
+port = 7000
+name = "grpc"
+type = "tcp"
+protocol = "tcp"
+node_port = 7000
+```
+
+You cannot mix scalar port fields and the `ports[]` array on the same service — Miren rejects this at deploy time.
+
+## Examples
+
+### IRC Server
+
+```toml
+name = "irc"
+
+[services.irc]
+command = "./ircd"
+
+[[services.irc.ports]]
+port = 6667
+name = "irc"
+type = "tcp"
+node_port = 6667
+
+[[services.irc.ports]]
+port = 6697
+name = "irc-tls"
+type = "tcp"
+node_port = 6697
+```
+
+### Game Server with HTTP Admin Panel
+
+```toml
+name = "gameserver"
+
+[services.game]
+command = "./server"
+
+[[services.game.ports]]
+port = 3000
+name = "admin"
+type = "http"
+
+[[services.game.ports]]
+port = 27015
+name = "game"
+type = "tcp"
+protocol = "udp"
+node_port = 27015
+
+[services.game.concurrency]
+mode = "fixed"
+num_instances = 1
+```
+
+### TCP Echo Server (testing multi-port)
+
+```toml
+name = "tcp-echo"
+
+[services.echo]
+command = "./tcp-echo"
+
+[[services.echo.ports]]
+port = 3000
+name = "health"
+type = "http"
+
+[[services.echo.ports]]
+port = 7000
+name = "echo"
+type = "tcp"
+node_port = 7000
+
+[services.echo.concurrency]
+mode = "fixed"
+num_instances = 1
+```
+
+## Next Steps
+
+- [Services](/services) — Defining services, commands, images, and scaling
+- [TLS Certificates](/tls) — How HTTPS works for HTTP services
+- [Firewall Configuration](/firewall) — Host-level firewall rules and cloud provider setup
+- [Application Scaling](/scaling) — How services scale up and down

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
         'app-configuration',
         'languages',
         'services',
+        'traffic-routing',
         'scaling',
         'disks',
         'tls',

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -21,6 +21,7 @@ import (
 	"miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/api/build/build_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
@@ -214,6 +215,85 @@ func validateRequiredVars(spec core_v1alpha.ConfigSpec) error {
 	return fmt.Errorf("%s", b.String())
 }
 
+// nodePortKey uniquely identifies a node port allocation by port number and protocol.
+type nodePortKey struct {
+	port     int64
+	protocol string
+}
+
+// validateNodePorts checks for node port conflicts both within the config being
+// deployed and against existing sandbox pools in the cluster. This catches
+// collisions at deploy time rather than letting them fail at runtime in nftables.
+func validateNodePorts(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, appID entity.Id, spec core_v1alpha.ConfigSpec) error {
+	// Collect all (node_port, protocol) pairs from the new config
+	newPorts := map[nodePortKey]string{} // key → service name
+	for _, svc := range spec.Services {
+		for _, p := range svc.Ports {
+			if p.NodePort <= 0 {
+				continue
+			}
+			proto := "tcp"
+			if p.Protocol == core_v1alpha.ConfigSpecServicesPortsUDP {
+				proto = "udp"
+			}
+			key := nodePortKey{port: p.NodePort, protocol: proto}
+			if existing, ok := newPorts[key]; ok {
+				return fmt.Errorf("services %q and %q both claim node_port %d/%s", existing, svc.Name, p.NodePort, proto)
+			}
+			newPorts[key] = svc.Name
+		}
+	}
+
+	if len(newPorts) == 0 {
+		return nil
+	}
+
+	// List all SandboxPool entities to check for cross-app conflicts
+	resp, err := eac.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool))
+	if err != nil {
+		return fmt.Errorf("failed to list sandbox pools: %w", err)
+	}
+
+	for _, ent := range resp.Values() {
+		var pool compute_v1alpha.SandboxPool
+		pool.Decode(ent.Entity())
+
+		// Skip pools belonging to the app being deployed
+		if pool.App == appID {
+			continue
+		}
+
+		// Skip scaled-down pools
+		if pool.DesiredInstances <= 0 {
+			continue
+		}
+
+		// Get the app name from sandbox labels for error messages
+		appName, _ := pool.SandboxLabels.Get("app")
+		if appName == "" {
+			appName = pool.App.String()
+		}
+
+		for _, container := range pool.SandboxSpec.Container {
+			for _, p := range container.Port {
+				if p.NodePort <= 0 {
+					continue
+				}
+				proto := "tcp"
+				if p.Protocol == compute_v1alpha.SandboxSpecContainerPortUDP {
+					proto = "udp"
+				}
+				key := nodePortKey{port: p.NodePort, protocol: proto}
+				if svcName, ok := newPorts[key]; ok {
+					return fmt.Errorf("node_port %d/%s (service %q) is already in use by app %q service %q", p.NodePort, proto, svcName, appName, pool.Service)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // buildServicesConfig collects services from app config and procfile,
 // resolves defaults, and returns the final service configurations.
 // This is the core logic for determining which services exist in an app_version
@@ -280,19 +360,34 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 				svc.Image = serviceConfig.Image
 			}
 
-			// Copy port if specified
-			if serviceConfig.Port > 0 {
-				svc.Port = int64(serviceConfig.Port)
-			}
-
-			// Copy port name if specified
-			if serviceConfig.PortName != "" {
-				svc.PortName = serviceConfig.PortName
-			}
-
-			// Copy port type if specified
-			if serviceConfig.PortType != "" {
-				svc.PortType = serviceConfig.PortType
+			// Copy port configuration: prefer ports[] array over scalar fields
+			if len(serviceConfig.Ports) > 0 {
+				svc.Ports = make([]core_v1alpha.ConfigSpecServicesPorts, 0, len(serviceConfig.Ports))
+				for _, p := range serviceConfig.Ports {
+					sp := core_v1alpha.ConfigSpecServicesPorts{
+						Port:     int64(p.Port),
+						Name:     p.Name,
+						Type:     p.Type,
+						NodePort: int64(p.NodePort),
+					}
+					switch p.Protocol {
+					case "tcp":
+						sp.Protocol = core_v1alpha.ConfigSpecServicesPortsTCP
+					case "udp":
+						sp.Protocol = core_v1alpha.ConfigSpecServicesPortsUDP
+					}
+					svc.Ports = append(svc.Ports, sp)
+				}
+			} else {
+				if serviceConfig.Port > 0 {
+					svc.Port = int64(serviceConfig.Port)
+				}
+				if serviceConfig.PortName != "" {
+					svc.PortName = serviceConfig.PortName
+				}
+				if serviceConfig.PortType != "" {
+					svc.PortType = serviceConfig.PortType
+				}
 			}
 
 			if serviceConfig.Concurrency != nil {
@@ -1022,6 +1117,11 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	// picture, matching how validateServicesExist works just above.
 	if err := validateRequiredVars(configSpec); err != nil {
 		b.sendErrorStatus(ctx, status, "%s", err)
+		return err
+	}
+
+	if err := validateNodePorts(ctx, b.ec.EAC(), appRec.ID, configSpec); err != nil {
+		b.sendErrorStatus(ctx, status, "Deploy failed: %v", err)
 		return err
 	}
 

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -370,11 +370,10 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 						Type:     p.Type,
 						NodePort: int64(p.NodePort),
 					}
-					switch p.Protocol {
-					case "tcp":
-						sp.Protocol = core_v1alpha.ConfigSpecServicesPortsTCP
-					case "udp":
+					if p.Type == "udp" {
 						sp.Protocol = core_v1alpha.ConfigSpecServicesPortsUDP
+					} else {
+						sp.Protocol = core_v1alpha.ConfigSpecServicesPortsTCP
 					}
 					svc.Ports = append(svc.Ports, sp)
 				}

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"context"
 	"encoding/json"
 	"sort"
 	"testing"
@@ -8,8 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/build/build_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/appconfig"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
 )
 
 func TestBuildVariablesFromAppConfig(t *testing.T) {
@@ -523,6 +528,98 @@ func TestBuildServicesConfig(t *testing.T) {
 				require.Contains(t, serviceMap, "scheduler")
 				schedulerSvc := serviceMap["scheduler"]
 				assert.Len(t, schedulerSvc.Env, 0, "scheduler should have no env vars")
+			},
+		},
+		{
+			name: "service with ports array",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"irc": {
+						Command: "./ircd",
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:         "fixed",
+							NumInstances: 1,
+						},
+						Ports: []appconfig.PortConfig{
+							{Port: 6667, Name: "irc", Type: "tcp"},
+							{Port: 6697, Name: "irc-tls", Type: "tcp", NodePort: 6697},
+						},
+					},
+				},
+			},
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
+				require.Len(t, services, 1)
+				svc := services[0]
+				assert.Equal(t, "irc", svc.Name)
+
+				// Should use ports array, not scalar fields
+				require.Len(t, svc.Ports, 2, "should have two ports")
+				assert.Equal(t, int64(6667), svc.Ports[0].Port)
+				assert.Equal(t, "irc", svc.Ports[0].Name)
+				assert.Equal(t, "tcp", svc.Ports[0].Type)
+				assert.Equal(t, int64(0), svc.Ports[0].NodePort)
+
+				assert.Equal(t, int64(6697), svc.Ports[1].Port)
+				assert.Equal(t, "irc-tls", svc.Ports[1].Name)
+				assert.Equal(t, "tcp", svc.Ports[1].Type)
+				assert.Equal(t, int64(6697), svc.Ports[1].NodePort)
+
+				// Scalar fields should be zero
+				assert.Equal(t, int64(0), svc.Port)
+				assert.Equal(t, "", svc.PortName)
+				assert.Equal(t, "", svc.PortType)
+			},
+		},
+		{
+			name: "service with ports array and protocol",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"dns": {
+						Command: "./dns-server",
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:         "fixed",
+							NumInstances: 1,
+						},
+						Ports: []appconfig.PortConfig{
+							{Port: 53, Name: "dns-udp", Protocol: "udp"},
+							{Port: 53, Name: "dns-tcp", Protocol: "tcp"},
+						},
+					},
+				},
+			},
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
+				require.Len(t, services, 1)
+				svc := services[0]
+				require.Len(t, svc.Ports, 2)
+				assert.Equal(t, core_v1alpha.ConfigSpecServicesPortsUDP, svc.Ports[0].Protocol)
+				assert.Equal(t, core_v1alpha.ConfigSpecServicesPortsTCP, svc.Ports[1].Protocol)
+			},
+		},
+		{
+			name: "service with scalar port (backward compat)",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"web": {
+						Port:     8080,
+						PortName: "http",
+						PortType: "http",
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:                "auto",
+							RequestsPerInstance: 10,
+						},
+					},
+				},
+			},
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
+				require.Len(t, services, 1)
+				svc := services[0]
+				assert.Equal(t, int64(8080), svc.Port)
+				assert.Equal(t, "http", svc.PortName)
+				assert.Equal(t, "http", svc.PortType)
+				assert.Len(t, svc.Ports, 0, "ports array should be empty when using scalar fields")
 			},
 		},
 		{
@@ -1959,4 +2056,236 @@ func TestValidateRequiredVars(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateNodePortsConflictBetweenApps(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create app A with a pool claiming node_port 6697
+	appA := &core_v1alpha.App{}
+	appAID, err := server.Client.Create(ctx, "app-a", appA)
+	require.NoError(t, err)
+
+	pool := &compute_v1alpha.SandboxPool{
+		App:              appAID,
+		Service:          "irc",
+		DesiredInstances: 1,
+		SandboxLabels:    types.LabelSet("app", "app-a"),
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Container: []compute_v1alpha.SandboxSpecContainer{{
+				Image: "test:latest",
+				Port: []compute_v1alpha.SandboxSpecContainerPort{{
+					Name:     "irc",
+					Port:     6697,
+					NodePort: 6697,
+				}},
+			}},
+		},
+	}
+	_, err = server.Client.Create(ctx, "app-a-irc-pool", pool)
+	require.NoError(t, err)
+
+	// Deploy app B claiming the same node_port 6697
+	appB := &core_v1alpha.App{}
+	appBID, err := server.Client.Create(ctx, "app-b", appB)
+	require.NoError(t, err)
+
+	spec := core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "chat",
+			Ports: []core_v1alpha.ConfigSpecServicesPorts{{
+				Name:     "chat",
+				Port:     6697,
+				NodePort: 6697,
+			}},
+		}},
+	}
+
+	err = validateNodePorts(ctx, server.EAC, appBID, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "6697")
+	assert.Contains(t, err.Error(), "app-a")
+	assert.Contains(t, err.Error(), "irc")
+	assert.Contains(t, err.Error(), "chat")
+}
+
+func TestValidateNodePortsNoConflictSameApp(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create an app with a pool claiming node_port 6697
+	app := &core_v1alpha.App{}
+	appID, err := server.Client.Create(ctx, "my-app", app)
+	require.NoError(t, err)
+
+	pool := &compute_v1alpha.SandboxPool{
+		App:              appID,
+		Service:          "irc",
+		DesiredInstances: 1,
+		SandboxLabels:    types.LabelSet("app", "my-app"),
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Container: []compute_v1alpha.SandboxSpecContainer{{
+				Image: "test:latest",
+				Port: []compute_v1alpha.SandboxSpecContainerPort{{
+					Name:     "irc",
+					Port:     6697,
+					NodePort: 6697,
+				}},
+			}},
+		},
+	}
+	_, err = server.Client.Create(ctx, "my-app-irc-pool", pool)
+	require.NoError(t, err)
+
+	// Redeploy the same app with the same node_port — should succeed
+	spec := core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "irc",
+			Ports: []core_v1alpha.ConfigSpecServicesPorts{{
+				Name:     "irc",
+				Port:     6697,
+				NodePort: 6697,
+			}},
+		}},
+	}
+
+	err = validateNodePorts(ctx, server.EAC, appID, spec)
+	assert.NoError(t, err)
+}
+
+func TestValidateNodePortsIntraAppDuplicate(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	appID := entity.Id("app/test-app")
+
+	// Two services in the same config both claim node_port 6697
+	spec := core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{
+			{
+				Name: "irc",
+				Ports: []core_v1alpha.ConfigSpecServicesPorts{{
+					Name:     "irc",
+					Port:     6697,
+					NodePort: 6697,
+				}},
+			},
+			{
+				Name: "chat",
+				Ports: []core_v1alpha.ConfigSpecServicesPorts{{
+					Name:     "chat",
+					Port:     6697,
+					NodePort: 6697,
+				}},
+			},
+		},
+	}
+
+	err := validateNodePorts(ctx, server.EAC, appID, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "irc")
+	assert.Contains(t, err.Error(), "chat")
+	assert.Contains(t, err.Error(), "6697")
+}
+
+func TestValidateNodePortsNoConflictDifferentPorts(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// App A claims node_port 6697
+	appA := &core_v1alpha.App{}
+	appAID, err := server.Client.Create(ctx, "app-a", appA)
+	require.NoError(t, err)
+
+	pool := &compute_v1alpha.SandboxPool{
+		App:              appAID,
+		Service:          "irc",
+		DesiredInstances: 1,
+		SandboxLabels:    types.LabelSet("app", "app-a"),
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Container: []compute_v1alpha.SandboxSpecContainer{{
+				Image: "test:latest",
+				Port: []compute_v1alpha.SandboxSpecContainerPort{{
+					Name:     "irc",
+					Port:     6697,
+					NodePort: 6697,
+				}},
+			}},
+		},
+	}
+	_, err = server.Client.Create(ctx, "app-a-irc-pool", pool)
+	require.NoError(t, err)
+
+	// App B claims node_port 8080 — different port, no conflict
+	appB := &core_v1alpha.App{}
+	appBID, err := server.Client.Create(ctx, "app-b", appB)
+	require.NoError(t, err)
+
+	spec := core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "web",
+			Ports: []core_v1alpha.ConfigSpecServicesPorts{{
+				Name:     "http",
+				Port:     8080,
+				NodePort: 8080,
+			}},
+		}},
+	}
+
+	err = validateNodePorts(ctx, server.EAC, appBID, spec)
+	assert.NoError(t, err)
+}
+
+func TestValidateNodePortsScaledDownPoolIgnored(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// App A has a pool with node_port 6697 but scaled to zero
+	appA := &core_v1alpha.App{}
+	appAID, err := server.Client.Create(ctx, "app-a", appA)
+	require.NoError(t, err)
+
+	pool := &compute_v1alpha.SandboxPool{
+		App:              appAID,
+		Service:          "irc",
+		DesiredInstances: 0,
+		SandboxLabels:    types.LabelSet("app", "app-a"),
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Container: []compute_v1alpha.SandboxSpecContainer{{
+				Image: "test:latest",
+				Port: []compute_v1alpha.SandboxSpecContainerPort{{
+					Name:     "irc",
+					Port:     6697,
+					NodePort: 6697,
+				}},
+			}},
+		},
+	}
+	_, err = server.Client.Create(ctx, "app-a-irc-pool", pool)
+	require.NoError(t, err)
+
+	// App B claims node_port 6697 — should succeed since app A's pool is scaled down
+	appB := &core_v1alpha.App{}
+	appBID, err := server.Client.Create(ctx, "app-b", appB)
+	require.NoError(t, err)
+
+	spec := core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "chat",
+			Ports: []core_v1alpha.ConfigSpecServicesPorts{{
+				Name:     "chat",
+				Port:     6697,
+				NodePort: 6697,
+			}},
+		}},
+	}
+
+	err = validateNodePorts(ctx, server.EAC, appBID, spec)
+	assert.NoError(t, err)
 }

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -572,7 +572,7 @@ func TestBuildServicesConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "service with ports array and protocol",
+			name: "service with ports array and udp type",
 			appConfig: &appconfig.AppConfig{
 				Services: map[string]*appconfig.ServiceConfig{
 					"dns": {
@@ -582,8 +582,8 @@ func TestBuildServicesConfig(t *testing.T) {
 							NumInstances: 1,
 						},
 						Ports: []appconfig.PortConfig{
-							{Port: 53, Name: "dns-udp", Protocol: "udp"},
-							{Port: 53, Name: "dns-tcp", Protocol: "tcp"},
+							{Port: 53, Name: "dns-udp", Type: "udp"},
+							{Port: 53, Name: "dns-tcp", Type: "tcp"},
 						},
 					},
 				},

--- a/testdata/tcp-echo/.miren/app.toml
+++ b/testdata/tcp-echo/.miren/app.toml
@@ -1,0 +1,19 @@
+name = "tcp-echo"
+
+[services.echo]
+command = "/bin/app"
+
+[[services.echo.ports]]
+port = 3000
+name = "health"
+type = "http"
+
+[[services.echo.ports]]
+port = 7000
+name = "echo"
+type = "tcp"
+node_port = 7000
+
+[services.echo.concurrency]
+mode = "fixed"
+num_instances = 1

--- a/testdata/tcp-echo/go.mod
+++ b/testdata/tcp-echo/go.mod
@@ -1,0 +1,3 @@
+module tcp-echo
+
+go 1.25

--- a/testdata/tcp-echo/main.go
+++ b/testdata/tcp-echo/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+)
+
+func main() {
+	// TCP echo server on port 7000
+	go func() {
+		ln, err := net.Listen("tcp", ":7000")
+		if err != nil {
+			log.Fatal("tcp listen:", err)
+		}
+		log.Println("TCP echo server listening on :7000")
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				log.Println("tcp accept:", err)
+				continue
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				io.Copy(c, c)
+			}(conn)
+		}
+	}()
+
+	// HTTP health endpoint on port 3000
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+	log.Printf("HTTP health server listening on :%s\n", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}


### PR DESCRIPTION
Users have been asking to deploy non-HTTP services — the immediate motivation was wanting to run an IRC server on Miren with ports 6667 and 6697 exposed. Today the app config layer only supports a single port per service, and there's no way to specify `node_port` or `protocol`.

The fun part is that all the hard infrastructure work was already done. The sandbox container spec, firewall rules, and service controller all handle multi-port just fine. The bottleneck was the app config layer: one `port` integer per service, no array, no `node_port`, no `protocol`.

## Config layer (`appconfig`)

Adds a `ports[]` array to the config spec schema and wires it through the full pipeline — TOML parsing with validation in appconfig, mapping through the build server's `buildServicesConfig`, config version conversion, and the deployment launcher's `buildSandboxSpec`. The existing scalar `port`/`port_name`/`port_type` fields are preserved for backward compat; `ports[]` takes precedence when present, and mixing the two styles is a validation error. The `PORT` env var picks the first HTTP-typed port, or falls back to the first port in the array.

Also adds a deploy-time guardrail: since `node_port` is now a first-class config field, two apps could silently claim the same host port and only find out when nftables blew up at runtime. The new `validateNodePorts` check runs during `BuildFromTar` and catches both intra-app duplicates and cross-app conflicts with clear error messages.

Empty protocol is now normalized to `"tcp"` before duplicate `(port, protocol)` validation.

## Service entity lifecycle (`controllers/deployment/launcher`)

HTTP services are proxied at L7 via httpingress, but non-HTTP services (TCP/UDP) need L4 routing through the ipalloc → ServiceController → nftables pipeline. That pipeline requires a `network_v1alpha.Service` entity to exist — without one, no IP is allocated and no firewall rules are created.

The launcher now manages Service entities for app services that have at least one non-HTTP port:

- **`ensureServiceForPorts`** — creates or updates a Service entity with the correct ports, match labels, and metadata. On update, preserves existing IPs so ipalloc doesn't need to re-allocate.
- **`cleanupStaleServices`** — deletes orphaned Service entities when services are removed from config or become HTTP-only.
- Deterministic entity IDs (`svc/<appname>-<servicename>`) for stable identity across deploys.

## ServiceController per-port endpoint chain fix (`controllers/service`)

The ServiceController had a bug where `Create()` used `srv.Port[0]` to determine the DNAT target port for **all** endpoint chains. For multi-port services, this meant all traffic was forwarded to the first port regardless of the original destination port — e.g., TCP traffic arriving on port 7000 would get DNAT'd to port 3000.

Moved endpoint chain setup inside the per-port loop so each service port gets its own endpoint chains targeting the correct port.

## Test app

Adds `testdata/tcp-echo/` — a minimal Go app with a TCP echo server on port 7000 and an HTTP health endpoint on port 3000, for validating multi-port service behavior end-to-end.

Example app config for an IRC server:
```toml
[services.irc]
command = "./ircd"

[[services.irc.ports]]
port = 6667
name = "irc"
type = "tcp"

[[services.irc.ports]]
port = 6697
name = "irc-tls"
type = "tcp"
node_port = 6697
```

Closes MIR-745