### PR TITLE
Fix saga entity ID type mismatch causing nested execution failures

### DIFF
--- a/controllers/sandbox/volume.go
+++ b/controllers/sandbox/volume.go
@@ -227,7 +227,7 @@ func (c *SandboxController) ensureDisk(ctx context.Context, diskName string, siz
 	name := idgen.GenNS("disk")
 
 	putResp, err := c.EAC.Create(ctx, entity.New(
-		entity.DBId, "disk/"+name,
+		entity.DBId, entity.Id("disk/"+name),
 		disk.Encode,
 	).Attrs())
 	if err != nil {

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -587,6 +587,13 @@ func (e *Entity) ForceID() {
 		return
 	}
 
+	// Catch mistyped db/id attributes: if a db/id exists but Id() returned "",
+	// the value was stored with the wrong kind (e.g. string instead of entity.Id).
+	// This is always a bug — fail loudly rather than silently generating a new ID.
+	if a, ok := e.Get(DBId); ok {
+		panic(fmt.Sprintf("entity has db/id attribute with value %v (kind %s) but it is not recognized as an Id — use entity.Id() to wrap the value", a.Value.Any(), a.Value.Kind()))
+	}
+
 	// Try to use entity kind as prefix for auto-generated ID
 	prefix := "e"
 	if kind, ok := e.Get(EntityKind); ok {

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	saga_v1alpha "miren.dev/runtime/api/saga/saga_v1alpha"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 )
 
@@ -61,7 +62,7 @@ func (s *EntityStorage) Save(ctx context.Context, exec *Execution) error {
 
 	// Create or update the entity
 	ent := entity.New(
-		entity.DBId, exec.ID,
+		entity.DBId, entity.Id(exec.ID),
 		sagaEntity.Encode(),
 	)
 
@@ -77,7 +78,7 @@ func (s *EntityStorage) Save(ctx context.Context, exec *Execution) error {
 func (s *EntityStorage) Get(ctx context.Context, id string) (*Execution, error) {
 	ent, err := s.store.GetEntity(ctx, entity.Id(id))
 	if err != nil {
-		if errors.Is(err, entity.ErrEntityNotFound) {
+		if errors.Is(err, entity.ErrEntityNotFound) || errors.Is(err, cond.ErrNotFound{}) {
 			return nil, fmt.Errorf("%w: %s", ErrExecutionNotFound, id)
 		}
 		return nil, fmt.Errorf("getting saga entity: %w", err)


### PR DESCRIPTION
The saga storage was passing exec.ID as a raw string to entity.New() for the db/id attribute. entity.New wraps strings as KindString, but Entity.Id() only recognizes KindId values. This caused ForceID() to silently generate a new auto-ID, storing the parent saga under a different ID than its execution ID. When a nested child saga tried to reference the parent via parent_execution_id, the ref validation couldn't find it.

Fix: use entity.Id(exec.ID) so the db/id value has the correct type.

Also add a panic guard in ForceID() to catch this class of bug: if a db/id attribute exists but has the wrong value kind, panic immediately instead of silently generating a new ID.

Also fix Get() to handle cond.ErrNotFound from EtcdStore (in addition to entity.ErrEntityNotFound from FileStore).