### PR TITLE
Fix implicit HTTP port 3000 dropped when web service uses multi-port config

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -489,10 +489,14 @@ func (l *Launcher) buildSandboxSpec(
 			if len(svc.Ports) > 0 {
 				// Multi-port path: map each port entry
 				for _, p := range svc.Ports {
+					portType := p.Type
+					if portType == "" {
+						portType = "http"
+					}
 					cp := compute_v1alpha.SandboxSpecContainerPort{
 						Port:     p.Port,
 						Name:     p.Name,
-						Type:     p.Type,
+						Type:     portType,
 						NodePort: p.NodePort,
 					}
 					switch p.Protocol {
@@ -505,20 +509,20 @@ func (l *Launcher) buildSandboxSpec(
 				}
 
 				// PORT env var: first HTTP-typed port, or first port if none is HTTP
-				for _, p := range svc.Ports {
-					if p.Type == "http" {
-						portEnvValue = p.Port
+				for _, cp := range containerPorts {
+					if cp.Type == "http" {
+						portEnvValue = cp.Port
 						break
 					}
 				}
 				if portEnvValue == 0 {
-					portEnvValue = svc.Ports[0].Port
+					portEnvValue = containerPorts[0].Port
 				}
 
 				if serviceName == "web" {
 					hasHTTP := false
 					for _, cp := range containerPorts {
-						if cp.Type == "http" || cp.Type == "" {
+						if cp.Type == "http" {
 							hasHTTP = true
 							break
 						}

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -514,6 +514,22 @@ func (l *Launcher) buildSandboxSpec(
 				if portEnvValue == 0 {
 					portEnvValue = svc.Ports[0].Port
 				}
+
+				if serviceName == "web" {
+					hasHTTP := false
+					for _, cp := range containerPorts {
+						if cp.Type == "http" || cp.Type == "" {
+							hasHTTP = true
+							break
+						}
+					}
+					if !hasHTTP {
+						containerPorts = append(containerPorts, compute_v1alpha.SandboxSpecContainerPort{
+							Port: 3000, Name: "http", Type: "http",
+						})
+						portEnvValue = 3000
+					}
+				}
 			} else {
 				// Scalar port path (backward compat)
 				port := svc.Port

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -2188,3 +2188,75 @@ func TestNoServiceEntityForHTTPOnlyService(t *testing.T) {
 	services := listAllServices(t, ctx, server)
 	assert.Empty(t, services, "HTTP-only service should not create a Service entity")
 }
+
+// TestWebServiceImplicitHTTPPortWithMultiPort tests that a web service with only non-HTTP
+// ports configured still gets the implicit HTTP port 3000 injected, and PORT env var is
+// set to 3000.
+func TestWebServiceImplicitHTTPPortWithMultiPort(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					Ports: []core_v1alpha.Ports{
+						{Port: 6667, Name: "irc", Type: "tcp"},
+						{Port: 6697, Name: "irc-tls", Type: "tcp", NodePort: 6697},
+					},
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	container := pools[0].SandboxSpec.Container[0]
+	require.Len(t, container.Port, 3, "should have two explicit TCP ports + implicit HTTP port 3000")
+
+	assert.Equal(t, int64(6667), container.Port[0].Port)
+	assert.Equal(t, "irc", container.Port[0].Name)
+	assert.Equal(t, "tcp", container.Port[0].Type)
+
+	assert.Equal(t, int64(6697), container.Port[1].Port)
+	assert.Equal(t, "irc-tls", container.Port[1].Name)
+	assert.Equal(t, "tcp", container.Port[1].Type)
+	assert.Equal(t, int64(6697), container.Port[1].NodePort)
+
+	assert.Equal(t, int64(3000), container.Port[2].Port)
+	assert.Equal(t, "http", container.Port[2].Name)
+	assert.Equal(t, "http", container.Port[2].Type)
+
+	// PORT env var should be set to 3000 (the implicit HTTP port)
+	assert.Contains(t, container.Env, "PORT=3000")
+}


### PR DESCRIPTION
When an app's web service configures additional ports via `[[services.web.ports]]` — say, a couple of TCP ports for an IRC server alongside the default HTTP server — the multi-port code path in the launcher only mapped those explicit ports. It never injected the implicit HTTP port 3000 that web services are supposed to get. The scalar port path and the fallback path both handle this correctly, but the multi-port path was added without the same logic.

Without the implicit HTTP port in the sandbox spec, health checks targeted the wrong port and HTTP routing was never established, so the sandbox would never reach `running` state.

The fix is straightforward: after mapping the explicit ports, check whether any of them are HTTP-typed. If none are, append port 3000 with `type: http` and set `PORT=3000`. This matches what the scalar path already does for web services with no explicit port.

The new test (`TestWebServiceImplicitHTTPPortWithMultiPort`) reproduces the exact scenario from the issue — a web service with two TCP-only ports — and verifies all three ports show up in the sandbox spec with `PORT=3000` set correctly. Existing multi-port tests are unaffected since they either use a non-web service name or already include HTTP-typed ports.

Closes MIR-751