### PR TITLE
Clean up iptables DNAT rules on sandbox teardown

### DIFF
--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -217,7 +217,7 @@ func (r *Runner) Drain(ctx context.Context) error {
 		}
 
 		r.Log.Info("stopping sandbox", "id", md.ID)
-		err := r.sbController.Delete(ctx, md.ID)
+		err := r.sbController.Delete(ctx, md.ID, nil)
 		if err != nil {
 			r.Log.Error("failed to stop sandbox", "id", md.ID, "error", err)
 			drainErr = multierror.Append(drainErr, fmt.Errorf("failed to stop sandbox %s: %w", md.ID, err))

--- a/controllers/certificate/controller.go
+++ b/controllers/certificate/controller.go
@@ -232,7 +232,7 @@ func (c *Controller) Reconcile(ctx context.Context, route *ingress_v1alpha.HttpR
 }
 
 // Delete handles http_route deletion - we keep the cert in cache/disk for potential reuse
-func (c *Controller) Delete(ctx context.Context, id entity.Id) error {
+func (c *Controller) Delete(ctx context.Context, id entity.Id, obj *ingress_v1alpha.HttpRoute) error {
 	c.Log.Debug("http_route deleted, keeping certificate in cache", "route", id)
 	return nil
 }

--- a/controllers/disk/disk_controller.go
+++ b/controllers/disk/disk_controller.go
@@ -100,7 +100,7 @@ func (d *DiskController) Update(ctx context.Context, disk *storage_v1alpha.Disk,
 }
 
 // Delete handles deletion of a disk entity
-func (d *DiskController) Delete(ctx context.Context, id entity.Id) error {
+func (d *DiskController) Delete(ctx context.Context, id entity.Id, obj *storage_v1alpha.Disk) error {
 	d.Log.Info("Processing disk deletion", "disk", id)
 	// Deletion is handled through the DELETING status in reconcileDisk
 	return nil

--- a/controllers/disk/disk_lease_controller.go
+++ b/controllers/disk/disk_lease_controller.go
@@ -124,7 +124,7 @@ func (d *DiskLeaseController) Update(ctx context.Context, lease *storage_v1alpha
 }
 
 // Delete handles deletion of a disk lease entity
-func (d *DiskLeaseController) Delete(ctx context.Context, id entity.Id) error {
+func (d *DiskLeaseController) Delete(ctx context.Context, id entity.Id, obj *storage_v1alpha.DiskLease) error {
 	d.Log.Info("Processing lease deletion", "lease", id)
 
 	leaseId := id.String()

--- a/controllers/disk/disk_lease_controller_directory_test.go
+++ b/controllers/disk/disk_lease_controller_directory_test.go
@@ -240,7 +240,7 @@ func TestDiskLeaseController_DirectoryMode_Integration(t *testing.T) {
 		assert.False(t, exists)
 
 		// Step 3: Delete the lease
-		err = dlc.Delete(ctx, lease.ID)
+		err = dlc.Delete(ctx, lease.ID, nil)
 		require.NoError(t, err)
 
 		// Verify complete cleanup

--- a/controllers/disk/disk_lease_controller_test.go
+++ b/controllers/disk/disk_lease_controller_test.go
@@ -61,7 +61,7 @@ func TestDiskLeaseController_Delete(t *testing.T) {
 	}
 
 	// Process the deletion
-	err := dlc.Delete(context.Background(), entity.Id("disk-lease/test-lease"))
+	err := dlc.Delete(context.Background(), entity.Id("disk-lease/test-lease"), nil)
 	require.NoError(t, err)
 
 	// Should remove from active leases

--- a/controllers/disk/disk_watch_controller.go
+++ b/controllers/disk/disk_watch_controller.go
@@ -47,7 +47,7 @@ func (d *DiskWatchController) Update(ctx context.Context, disk *storage_v1alpha.
 }
 
 // Delete handles deletion of a disk entity
-func (d *DiskWatchController) Delete(ctx context.Context, id entity.Id) error {
+func (d *DiskWatchController) Delete(ctx context.Context, id entity.Id, obj *storage_v1alpha.Disk) error {
 	// Disk deleted - dependent leases will handle this
 	return nil
 }

--- a/controllers/disk/mount_watch_controller.go
+++ b/controllers/disk/mount_watch_controller.go
@@ -66,6 +66,6 @@ func (m *MountWatchController) Update(ctx context.Context, mount *storage_v1alph
 	return nil
 }
 
-func (m *MountWatchController) Delete(ctx context.Context, id entity.Id) error {
+func (m *MountWatchController) Delete(ctx context.Context, id entity.Id, obj *storage_v1alpha.LsvdMount) error {
 	return nil
 }

--- a/controllers/disk/volume_watch_controller.go
+++ b/controllers/disk/volume_watch_controller.go
@@ -66,6 +66,6 @@ func (v *VolumeWatchController) Update(ctx context.Context, vol *storage_v1alpha
 	return nil
 }
 
-func (v *VolumeWatchController) Delete(ctx context.Context, id entity.Id) error {
+func (v *VolumeWatchController) Delete(ctx context.Context, id entity.Id, obj *storage_v1alpha.LsvdVolume) error {
 	return nil
 }

--- a/controllers/ingress/defaultroute.go
+++ b/controllers/ingress/defaultroute.go
@@ -59,7 +59,7 @@ func (c *DefaultRouteController) Update(ctx context.Context, route *ingress_v1al
 }
 
 // Delete handles http_route deletion events
-func (c *DefaultRouteController) Delete(ctx context.Context, id entity.Id) error {
+func (c *DefaultRouteController) Delete(ctx context.Context, id entity.Id, obj *ingress_v1alpha.HttpRoute) error {
 	c.Log.Info("HttpRoute deleted; doing nothing", "route", id)
 	// Note: We don't automatically promote another route to default when
 	// the default route is deleted, as per the requirements

--- a/controllers/ingress/defaultrouteapp.go
+++ b/controllers/ingress/defaultrouteapp.go
@@ -69,7 +69,7 @@ func (c *DefaultRouteAppController) Update(ctx context.Context, app *core_v1alph
 }
 
 // Delete handles app deletion events
-func (c *DefaultRouteAppController) Delete(ctx context.Context, id entity.Id) error {
+func (c *DefaultRouteAppController) Delete(ctx context.Context, id entity.Id, obj *core_v1alpha.App) error {
 	c.Log.Info("App deleted", "app", id)
 
 	// Check if this app had a default route

--- a/controllers/sandbox/firewall.go
+++ b/controllers/sandbox/firewall.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/utils/sysctl"
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/network"
+	"miren.dev/runtime/pkg/netutil"
 )
 
 func (c *SandboxController) configureFirewall(sb *compute.Sandbox, ep *network.EndpointConfig) error {
@@ -39,7 +40,7 @@ func (c *SandboxController) configurePort(p compute.SandboxSpecContainerPort, ep
 
 		exe := exec.Command("iptables",
 			"-t", "nat",
-			"-A", "PREROUTING",
+			"-I", "PREROUTING",
 			"!", "-i", c.Bridge,
 			"-p", "tcp",
 			"-m", "tcp",
@@ -53,7 +54,7 @@ func (c *SandboxController) configurePort(p compute.SandboxSpecContainerPort, ep
 
 		exe = exec.Command("iptables",
 			"-t", "nat",
-			"-A", "OUTPUT",
+			"-I", "OUTPUT",
 			"-p", "tcp",
 			"-m", "tcp",
 			"-d", "127.0.0.1",
@@ -81,4 +82,70 @@ func (c *SandboxController) configurePort(p compute.SandboxSpecContainerPort, ep
 	}
 
 	return nil
+}
+
+func (c *SandboxController) unconfigureFirewall(sb *compute.Sandbox) {
+	if len(sb.Network) == 0 {
+		c.Log.Warn("no network info on sandbox, skipping firewall cleanup", "sandbox", sb.ID.String())
+		return
+	}
+
+	ip, err := netutil.ParseNetworkAddress(sb.Network[0].Address)
+	if err != nil {
+		c.Log.Warn("failed to parse sandbox network address for firewall cleanup", "sandbox", sb.ID.String(), "address", sb.Network[0].Address, "err", err)
+		return
+	}
+
+	for _, co := range sb.Spec.Container {
+		for _, p := range co.Port {
+			c.unconfigurePort(p, ip)
+		}
+	}
+}
+
+func (c *SandboxController) unconfigurePort(p compute.SandboxSpecContainerPort, ip string) {
+	if p.NodePort == 0 {
+		return
+	}
+
+	c.Log.Info("removing firewall rules", "nodePort", p.NodePort, "targetPort", p.Port, "ip", ip)
+
+	out, err := exec.Command("iptables",
+		"-t", "nat",
+		"-D", "PREROUTING",
+		"!", "-i", c.Bridge,
+		"-p", "tcp",
+		"-m", "tcp",
+		"--dport", strconv.Itoa(int(p.NodePort)),
+		"-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", ip, p.Port),
+	).CombinedOutput()
+	if err != nil {
+		c.Log.Warn("failed to remove PREROUTING rule", "nodePort", p.NodePort, "err", err, "output", string(out))
+	}
+
+	out, err = exec.Command("iptables",
+		"-t", "nat",
+		"-D", "OUTPUT",
+		"-p", "tcp",
+		"-m", "tcp",
+		"-d", "127.0.0.1",
+		"--dport", strconv.Itoa(int(p.NodePort)),
+		"-j", "DNAT", "--to-destination", fmt.Sprintf("%s:%d", ip, p.Port),
+	).CombinedOutput()
+	if err != nil {
+		c.Log.Warn("failed to remove OUTPUT rule", "nodePort", p.NodePort, "err", err, "output", string(out))
+	}
+
+	out, err = exec.Command("iptables",
+		"-t", "nat",
+		"-D", "POSTROUTING",
+		"-s", "127.0.0.1",
+		"-p", "tcp",
+		"-d", ip,
+		"--dport", strconv.Itoa(int(p.Port)),
+		"-j", "MASQUERADE",
+	).CombinedOutput()
+	if err != nil {
+		c.Log.Warn("failed to remove POSTROUTING rule", "nodePort", p.NodePort, "err", err, "output", string(out))
+	}
 }

--- a/controllers/sandbox/firewall_darwin.go
+++ b/controllers/sandbox/firewall_darwin.go
@@ -10,3 +10,6 @@ import (
 func (c *SandboxController) configureFirewall(sb *compute.Sandbox, ep *network.EndpointConfig) error {
 	return nil
 }
+
+func (c *SandboxController) unconfigureFirewall(sb *compute.Sandbox) {
+}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -358,7 +358,7 @@ func (c *SandboxController) reconcileSandboxesOnBoot(ctx context.Context) error 
 		c.Log.Info("marking unhealthy sandbox as DEAD and cleaning up", "id", id)
 
 		// Try to clean up the sandbox
-		err := c.Delete(ctx, id)
+		err := c.Delete(ctx, id, nil)
 		if err != nil {
 			c.Log.Error("failed to cleanup unhealthy sandbox", "id", id, "err", err)
 			// Continue with other sandboxes even if one fails
@@ -2229,10 +2229,11 @@ cleanup:
 	return nil
 }
 
-func (c *SandboxController) Delete(ctx context.Context, id entity.Id) error {
+func (c *SandboxController) Delete(ctx context.Context, id entity.Id, sb *compute.Sandbox) error {
 	c.Log.Debug("delete callback received, cleaning up sandbox", "id", id)
-	// Delete is called when an entity has been deleted from the store.
-	// Just pass through to stopSandbox which will discover everything from containerd.
+	if sb != nil {
+		c.unconfigureFirewall(sb)
+	}
 	return c.stopSandbox(ctx, id)
 }
 
@@ -2301,7 +2302,7 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 	} else if !errors.Is(entityErr, cond.ErrNotFound{}) {
 		c.Log.Warn("failed to get sandbox entity for cleanup", "id", id, "err", entityErr)
 	} else {
-		c.Log.Warn("sandbox entity already deleted, skipping firewall cleanup", "id", id)
+		c.Log.Debug("sandbox entity already deleted, firewall cleanup handled by DeleteEntity if available", "id", id)
 	}
 
 	// Fallback if we couldn't get LogEntity from labels

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -2270,13 +2270,17 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 		c.Log.Warn("failed to load pause container", "id", id, "err", err)
 	}
 
-	// Fallback: if we couldn't get IPs from container labels, try the entity store
-	if len(sandboxIPs) == 0 {
-		resp, err := c.EAC.Get(ctx, id.String())
-		if err == nil {
-			var sb compute.Sandbox
-			sb.Decode(resp.Entity().Entity())
+	// Fetch sandbox entity for firewall cleanup and as IP fallback
+	resp, entityErr := c.EAC.Get(ctx, id.String())
+	if entityErr == nil {
+		var sb compute.Sandbox
+		sb.Decode(resp.Entity().Entity())
 
+		// Clean up iptables DNAT rules before destroying containers
+		c.unconfigureFirewall(&sb)
+
+		// Use entity store IPs as fallback if container labels didn't have them
+		if len(sandboxIPs) == 0 {
 			sandboxIPs = make(map[string]bool)
 			for _, net := range sb.Network {
 				addr := net.Address
@@ -2293,9 +2297,11 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 			if len(sandboxIPs) > 0 {
 				c.Log.Debug("retrieved IPs from entity store for cleanup", "id", id, "ips", sandboxIPs)
 			}
-		} else if !errors.Is(err, cond.ErrNotFound{}) {
-			c.Log.Warn("failed to get sandbox entity for IP cleanup", "id", id, "err", err)
 		}
+	} else if !errors.Is(entityErr, cond.ErrNotFound{}) {
+		c.Log.Warn("failed to get sandbox entity for cleanup", "id", id, "err", entityErr)
+	} else {
+		c.Log.Warn("sandbox entity already deleted, skipping firewall cleanup", "id", id)
 	}
 
 	// Fallback if we couldn't get LogEntity from labels

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -771,7 +771,7 @@ func TestSandbox(t *testing.T) {
 		r.NoError(err)
 
 		// Stop the first sandbox (this should set status to DEAD)
-		err = sbc.Delete(ctx, sbID1)
+		err = sbc.Delete(ctx, sbID1, nil)
 		r.NoError(err)
 
 		// Manually update the UpdatedAt timestamp to be older than our test time horizon
@@ -816,7 +816,7 @@ func TestSandbox(t *testing.T) {
 		r.Equal(compute.RUNNING, remainingSb.Status)
 
 		// Clean up the remaining sandbox
-		err = sbc.Delete(ctx, sbID2)
+		err = sbc.Delete(ctx, sbID2, nil)
 		r.NoError(err)
 	})
 
@@ -930,7 +930,7 @@ func TestSandbox(t *testing.T) {
 		}
 
 		// Clean up
-		err = co.Delete(ctx, id)
+		err = co.Delete(ctx, id, nil)
 		r.NoError(err)
 
 		// NOTE we only track port binding now, not unbounding.
@@ -1050,7 +1050,7 @@ func TestSandbox(t *testing.T) {
 		}
 
 		// Clean up
-		err = co.Delete(ctx, id)
+		err = co.Delete(ctx, id, nil)
 		r.NoError(err)
 	})
 
@@ -1226,7 +1226,7 @@ func TestSandbox(t *testing.T) {
 		}, 15*time.Second, 500*time.Millisecond, "task should stay running and logs should be collected")
 
 		// Clean up
-		err = co1.Delete(ctx, id)
+		err = co1.Delete(ctx, id, nil)
 		r.NoError(err)
 	})
 

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -531,6 +531,6 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 	return nil
 }
 
-func (s *ServiceController) Delete(ctx context.Context, id entity.Id) error {
+func (s *ServiceController) Delete(ctx context.Context, id entity.Id, obj *network_v1alpha.Service) error {
 	return nil
 }

--- a/controllers/service/service_test.go
+++ b/controllers/service/service_test.go
@@ -241,7 +241,7 @@ func TestServiceController(t *testing.T) {
 		r.True(found, "Expected to find endpoints for service")
 
 		// Clean up
-		err = sbC.Delete(ctx, sbID)
+		err = sbC.Delete(ctx, sbID, nil)
 		r.NoError(err)
 	})
 
@@ -370,7 +370,7 @@ func TestServiceController(t *testing.T) {
 		r.NotEmpty(sandboxIP)
 
 		// Delete the sandbox
-		err = sbC.Delete(ctx, sbID)
+		err = sbC.Delete(ctx, sbID, nil)
 		r.NoError(err)
 
 		// Poll for endpoints to be created
@@ -611,7 +611,7 @@ func TestServiceController(t *testing.T) {
 		r.Equal(2, serviceEndpoints, "Expected to find 2 endpoint entities for service")
 
 		// Delete first sandbox
-		err = sbC.Delete(ctx, sbID1)
+		err = sbC.Delete(ctx, sbID1, nil)
 		r.NoError(err)
 
 		// Poll for endpoints to be created
@@ -638,7 +638,7 @@ func TestServiceController(t *testing.T) {
 		r.Equal(1, serviceEndpoints, "Expected to find 1 endpoint entity for service after deleting first sandbox")
 
 		// Clean up
-		err = sbC.Delete(ctx, sbID2)
+		err = sbC.Delete(ctx, sbID2, nil)
 		r.NoError(err)
 	})
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -537,7 +537,11 @@ type ControllerEntity interface {
 type GenericController[P ControllerEntity] interface {
 	Init(context.Context) error
 	Create(ctx context.Context, obj P, meta *entity.Meta) error
-	Delete(ctx context.Context, e entity.Id) error
+	// Delete is called when an entity is deleted. The obj parameter contains the
+	// entity data from before deletion (available since delete watch events now
+	// include the previous value). It may be nil if the entity data was unavailable
+	// (e.g., watch reconnect after etcd compaction).
+	Delete(ctx context.Context, id entity.Id, obj P) error
 }
 
 // UpdatingController is an optional interface that controllers can implement
@@ -609,8 +613,13 @@ func AdaptController[
 			return entity.Diff(meta.Entity, orig), err
 
 		case EventDeleted:
-			if err := cont.Delete(ctx, event.Id); err != nil {
-				return nil, fmt.Errorf("failed to create entity: %w", err)
+			var obj P
+			if event.Entity != nil {
+				obj = new(T)
+				obj.Decode(event.Entity)
+			}
+			if err := cont.Delete(ctx, event.Id, obj); err != nil {
+				return nil, fmt.Errorf("failed to delete entity: %w", err)
 			}
 		}
 
@@ -658,7 +667,6 @@ func AdaptReconcileController[
 			return entity.Diff(meta.Entity, orig), err
 
 		case EventDeleted:
-			// Check if the controller implements DeletingReconcileController
 			if deleter, ok := any(cont).(DeletingReconcileController); ok {
 				if err := deleter.Delete(ctx, event.Id); err != nil {
 					return nil, fmt.Errorf("failed to delete entity: %w", err)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -301,7 +301,7 @@ func (c *BasicController) Create(ctx context.Context, obj *TestEntity, meta *ent
 	return nil
 }
 
-func (c *BasicController) Delete(ctx context.Context, id entity.Id) error {
+func (c *BasicController) Delete(ctx context.Context, id entity.Id, obj *TestEntity) error {
 	c.DeleteCalls = append(c.DeleteCalls, string(id))
 	return nil
 }


### PR DESCRIPTION
`configurePort()` adds three iptables nat rules per NodePort (PREROUTING, OUTPUT, POSTROUTING) when a sandbox starts up, but nothing was cleaning them up on teardown. Since iptables evaluates first-match-wins, stale rules pointing at dead sandbox IPs shadow the new sandbox's rules, making the node port unreachable after the first redeploy. We found 25 stale DNAT entries for port 6667 on miren-club — every sandbox replacement was leaving behind three orphaned rules.

The fix adds `unconfigureFirewall` / `unconfigurePort` functions that mirror the creation path but use `-D` (delete). They're called from `stopSandbox` using the sandbox entity fetched from the entity store, which already has the network address and port specs we need. Cleanup errors are logged as warnings rather than returned — teardown must not fail because a rule is already gone.

As defense-in-depth, the creation path now uses `-I` (insert) instead of `-A` (append) for the PREROUTING and OUTPUT chains. `-I` prepends to the top of the chain, so the newest sandbox's rules always match first even if a prior cleanup was somehow missed.

Closes MIR-752