### PR TITLE
Restructure `miren logs` into subcommands and add system log ingestion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,11 @@ m app list
 - `make dev-dagger` - Start development environment with Dagger
 - `make services-dagger` - Run services container for debugging
 
+### Documentation
+- `cd docs && bun install && bun run build` - Build the documentation site (Docusaurus, uses bun NOT npm)
+- `cd docs && bun run start` - Start local dev server on port 3333
+- Docs source lives in `docs/docs/` as Markdown files; sidebar is configured in `docs/sidebars.ts`
+
 ### Other Commands
 - `make image` - Export Docker image
 - `make release-data` - Create release package tar.gz

--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -14,6 +14,7 @@ import (
 type logTargetData struct {
 	App     *string `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
 	Sandbox *string `cbor:"1,keyasint,omitempty" json:"sandbox,omitempty"`
+	System  *bool   `cbor:"2,keyasint,omitempty" json:"system,omitempty"`
 }
 
 type LogTarget struct {
@@ -48,6 +49,21 @@ func (v *LogTarget) Sandbox() string {
 
 func (v *LogTarget) SetSandbox(sandbox string) {
 	v.data.Sandbox = &sandbox
+}
+
+func (v *LogTarget) HasSystem() bool {
+	return v.data.System != nil
+}
+
+func (v *LogTarget) System() bool {
+	if v.data.System == nil {
+		return false
+	}
+	return *v.data.System
+}
+
+func (v *LogTarget) SetSystem(system bool) {
+	v.data.System = &system
 }
 
 func (v *LogTarget) MarshalCBOR() ([]byte, error) {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -17,6 +17,10 @@ types:
         type: string
         index: 1
         optional: true
+      - name: system
+        type: bool
+        index: 2
+        optional: true
 
 
   - type: AutoConcurrency

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -123,7 +123,7 @@ miren deploy --analyze
 			Body: "miren rollback -a myapp",
 		}),
 	))
-	d.Dispatch("logs", Infer("logs", "Get logs for an application", Logs,
+	d.Dispatch("logs", Infer("logs", "View logs (defaults to app logs)", LogsApp,
 		WithDescription(logsDescription),
 		WithExample(mflags.Example{
 			Name: "View logs for the current app",
@@ -137,9 +137,54 @@ miren deploy --analyze
 			Name: "Show logs from the last 5 minutes, filtered for errors",
 			Body: "miren logs --last 5m -g error",
 		}),
+	))
+	d.Dispatch("logs app", Infer("logs app", "View application logs", LogsApp,
+		WithDescription(logsDescription),
+		WithExample(mflags.Example{
+			Name: "View logs for the current app",
+			Body: "miren logs app",
+		}),
+		WithExample(mflags.Example{
+			Name: "Follow logs for a specific app",
+			Body: "miren logs app -a myapp -f",
+		}),
 		WithExample(mflags.Example{
 			Name: "Filter logs by service",
-			Body: "miren logs --service web -f",
+			Body: "miren logs app --service web -f",
+		}),
+	))
+	d.Dispatch("logs sandbox", Infer("logs sandbox", "View sandbox logs", LogsSandbox,
+		WithExample(mflags.Example{
+			Name: "View logs for a sandbox",
+			Body: "miren logs sandbox sb_abc123",
+		}),
+		WithExample(mflags.Example{
+			Name: "Follow sandbox logs",
+			Body: "miren logs sandbox sb_abc123 -f",
+		}),
+	))
+	d.Dispatch("logs build", Infer("logs build", "View build logs", LogsBuild,
+		WithExample(mflags.Example{
+			Name: "View build logs for a version",
+			Body: "miren logs build v3",
+		}),
+		WithExample(mflags.Example{
+			Name: "View build logs for a specific app",
+			Body: "miren logs build v3 -a myapp",
+		}),
+	))
+	d.Dispatch("logs system", Infer("logs system", "View system logs", LogsSystem,
+		WithExample(mflags.Example{
+			Name: "View all system logs",
+			Body: "miren logs system",
+		}),
+		WithExample(mflags.Example{
+			Name: "View logs for a specific component",
+			Body: "miren logs system etcd",
+		}),
+		WithExample(mflags.Example{
+			Name: "Follow system logs",
+			Body: "miren logs system -f",
 		}),
 	))
 

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"miren.dev/runtime/api/app/app_v1alpha"
-	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/pkg/logfilter"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/standard"
@@ -57,51 +56,28 @@ func buildSystemFilter(component, userFilter string) string {
 	return filter
 }
 
-// resolveAppName resolves the application name from explicit flag, directory
-// context, or returns an error if it can't be determined.
-func resolveAppName(app, dir string) (string, error) {
-	if app != "" {
-		return app, nil
-	}
-
-	var ac *appconfig.AppConfig
-	var err error
-
-	if dir != "." {
-		ac, err = appconfig.LoadAppConfigUnder(dir)
-	} else {
-		ac, err = appconfig.LoadAppConfig()
-	}
-
-	if err == nil && ac != nil && ac.Name != "" {
-		return ac.Name, nil
-	}
-	return "", fmt.Errorf("must specify --app or run from an app directory")
-}
-
 // LogsApp shows application logs. This is the default subcommand for `miren logs`.
 func LogsApp(ctx *Context, opts struct {
-	ConfigCentric
+	AppCentric
 
-	App     string         `short:"a" long:"app" description:"Application to get logs for" env:"MIREN_APP"`
-	Dir     string         `short:"d" long:"dir" description:"Directory to run from" default:"."`
 	Last    *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
 	Follow  bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
 	Filter  string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
 	Service string         `long:"service" description:"Filter logs by service name (e.g., 'web', 'worker')"`
 }) error {
-	app, err := resolveAppName(opts.App, opts.Dir)
-	if err != nil {
-		return err
-	}
-
 	cl, err := ctx.RPCClient("dev.miren.runtime/logs")
 	if err != nil {
 		return err
 	}
 
 	combinedFilter := buildFilterWithService(opts.Filter, opts.Service)
-	return dispatchLogs(ctx, cl, app, "", opts.Last, opts.Follow, opts.Filter, combinedFilter)
+	return dispatchLogs(ctx, cl, logDispatchArgs{
+		app:            opts.App,
+		last:           opts.Last,
+		follow:         opts.Follow,
+		rawFilter:      opts.Filter,
+		combinedFilter: combinedFilter,
+	})
 }
 
 // LogsSandbox shows logs for a specific sandbox.
@@ -120,32 +96,37 @@ func LogsSandbox(ctx *Context, opts struct {
 		return err
 	}
 
-	return dispatchLogs(ctx, cl, "", sandbox, opts.Last, opts.Follow, opts.Filter, opts.Filter)
+	return dispatchLogs(ctx, cl, logDispatchArgs{
+		sandbox:        sandbox,
+		last:           opts.Last,
+		follow:         opts.Follow,
+		rawFilter:      opts.Filter,
+		combinedFilter: opts.Filter,
+	})
 }
 
 // LogsBuild shows build logs for a specific version.
 func LogsBuild(ctx *Context, opts struct {
-	ConfigCentric
+	AppCentric
 
-	App     string         `short:"a" long:"app" description:"Application to get logs for" env:"MIREN_APP"`
-	Dir     string         `short:"d" long:"dir" description:"Directory to run from" default:"."`
 	Version string         `position:"0" usage:"Build version (e.g., v3)" required:"true"`
 	Last    *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
 	Follow  bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
 	Filter  string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
 }) error {
-	app, err := resolveAppName(opts.App, opts.Dir)
-	if err != nil {
-		return err
-	}
-
 	cl, err := ctx.RPCClient("dev.miren.runtime/logs")
 	if err != nil {
 		return err
 	}
 
 	combinedFilter := buildBuildFilter(opts.Version, opts.Filter)
-	return dispatchLogs(ctx, cl, app, "", opts.Last, opts.Follow, opts.Filter, combinedFilter)
+	return dispatchLogs(ctx, cl, logDispatchArgs{
+		app:            opts.App,
+		last:           opts.Last,
+		follow:         opts.Follow,
+		rawFilter:      opts.Filter,
+		combinedFilter: combinedFilter,
+	})
 }
 
 // LogsSystem shows system/server logs, optionally filtered by component.
@@ -189,12 +170,23 @@ func LogsSystem(ctx *Context, opts struct {
 	return err
 }
 
+// logDispatchArgs holds the parameters for dispatching log requests across
+// different server protocol versions.
+type logDispatchArgs struct {
+	app            string
+	sandbox        string
+	last           *time.Duration
+	follow         bool
+	rawFilter      string
+	combinedFilter string
+}
+
 // dispatchLogs handles protocol negotiation and dispatches to the appropriate
 // log streaming method based on server capabilities.
-func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *time.Duration, follow bool, rawFilter, combinedFilter string) error {
+func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, args logDispatchArgs) error {
 	// Check if server supports streaming (prefer chunked for efficiency)
 	if cl.HasMethod(ctx, "streamLogChunks") {
-		return streamLogChunks(ctx, cl, app, sandbox, last, follow, combinedFilter)
+		return streamLogChunks(ctx, cl, args.app, args.sandbox, args.last, args.follow, args.combinedFilter)
 	}
 
 	// Older server - warn about upgrade and limited functionality
@@ -203,31 +195,31 @@ func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last
 	// Server-side filtering (--service, --build) requires streamLogChunks.
 	// If the combined filter differs from the raw user filter, one of these
 	// was applied and we must error rather than silently dropping it.
-	if rawFilter != combinedFilter {
+	if args.rawFilter != args.combinedFilter {
 		return fmt.Errorf("--service and --build filtering require a newer server version")
 	}
 
 	// Parse filter for client-side filtering on older protocol
 	var filter *logfilter.Filter
-	if rawFilter != "" {
+	if args.rawFilter != "" {
 		var err error
-		filter, err = logfilter.Parse(rawFilter)
+		filter, err = logfilter.Parse(args.rawFilter)
 		if err != nil {
 			return fmt.Errorf("invalid filter: %w", err)
 		}
 	}
 
 	if cl.HasMethod(ctx, "streamLogs") {
-		return streamLogs(ctx, cl, app, sandbox, last, follow, filter)
+		return streamLogs(ctx, cl, args.app, args.sandbox, args.last, args.follow, filter)
 	}
 
 	// Warn if --follow requested but not supported
-	if follow {
+	if args.follow {
 		ctx.Printf("Warning: server does not support --follow, showing recent logs only\n")
 	}
 
 	// Fall back to legacy pagination
-	return legacyLogs(ctx, cl, app, sandbox, last, filter)
+	return legacyLogs(ctx, cl, args.app, args.sandbox, args.last, filter)
 }
 
 var streamTypePrefixes = map[string]string{

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -45,45 +45,54 @@ func buildBuildFilter(version, userFilter string) string {
 	return buildFilter + " " + userFilter
 }
 
-func Logs(ctx *Context, opts struct {
+// buildSystemFilter creates a filter for system logs, optionally scoped to a component.
+func buildSystemFilter(component, userFilter string) string {
+	filter := `source:"system"`
+	if component != "" {
+		filter += fmt.Sprintf(" module:%q", component)
+	}
+	if userFilter != "" {
+		filter += " " + userFilter
+	}
+	return filter
+}
+
+// resolveAppName resolves the application name from explicit flag, directory
+// context, or returns an error if it can't be determined.
+func resolveAppName(app, dir string) (string, error) {
+	if app != "" {
+		return app, nil
+	}
+
+	var ac *appconfig.AppConfig
+	var err error
+
+	if dir != "." {
+		ac, err = appconfig.LoadAppConfigUnder(dir)
+	} else {
+		ac, err = appconfig.LoadAppConfig()
+	}
+
+	if err == nil && ac != nil && ac.Name != "" {
+		return ac.Name, nil
+	}
+	return "", fmt.Errorf("must specify --app or run from an app directory")
+}
+
+// LogsApp shows application logs. This is the default subcommand for `miren logs`.
+func LogsApp(ctx *Context, opts struct {
 	ConfigCentric
 
-	App     string         `short:"a" long:"app" description:"Application get logs for" env:"MIREN_APP"`
+	App     string         `short:"a" long:"app" description:"Application to get logs for" env:"MIREN_APP"`
 	Dir     string         `short:"d" long:"dir" description:"Directory to run from" default:"."`
 	Last    *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
-	Sandbox string         `short:"s" long:"sandbox" description:"Show logs for a specific sandbox ID"`
-	Build   string         `short:"b" long:"build" description:"Show build logs for a specific version"`
 	Follow  bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
 	Filter  string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
 	Service string         `long:"service" description:"Filter logs by service name (e.g., 'web', 'worker')"`
 }) error {
-	// Check for conflicting options
-	if opts.App != "" && opts.Sandbox != "" {
-		return fmt.Errorf("cannot specify both --app and --sandbox")
-	}
-	if opts.Build != "" && opts.Sandbox != "" {
-		return fmt.Errorf("cannot specify both --build and --sandbox")
-	}
-	if opts.Build != "" && opts.Service != "" {
-		return fmt.Errorf("cannot specify both --build and --service")
-	}
-
-	// If neither is specified, try to load app from directory context
-	if opts.App == "" && opts.Sandbox == "" {
-		var ac *appconfig.AppConfig
-		var err error
-
-		if opts.Dir != "." {
-			ac, err = appconfig.LoadAppConfigUnder(opts.Dir)
-		} else {
-			ac, err = appconfig.LoadAppConfig()
-		}
-
-		if err == nil && ac != nil && ac.Name != "" {
-			opts.App = ac.Name
-		} else {
-			return fmt.Errorf("must specify either --app or --sandbox, or run from an app directory")
-		}
+	app, err := resolveAppName(opts.App, opts.Dir)
+	if err != nil {
+		return err
 	}
 
 	cl, err := ctx.RPCClient("dev.miren.runtime/logs")
@@ -91,54 +100,127 @@ func Logs(ctx *Context, opts struct {
 		return err
 	}
 
-	// Normalize sandbox ID to include the "sandbox/" prefix for log queries
-	if opts.Sandbox != "" {
-		opts.Sandbox = normalizeSandboxID(opts.Sandbox)
+	combinedFilter := buildFilterWithService(opts.Filter, opts.Service)
+	return dispatchLogs(ctx, cl, app, "", opts.Last, opts.Follow, opts.Filter, combinedFilter)
+}
+
+// LogsSandbox shows logs for a specific sandbox.
+func LogsSandbox(ctx *Context, opts struct {
+	ConfigCentric
+
+	SandboxID string         `position:"0" usage:"Sandbox ID" required:"true"`
+	Last      *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
+	Follow    bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
+	Filter    string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
+}) error {
+	sandbox := normalizeSandboxID(opts.SandboxID)
+
+	cl, err := ctx.RPCClient("dev.miren.runtime/logs")
+	if err != nil {
+		return err
 	}
 
-	// Parse filter early to validate syntax
+	return dispatchLogs(ctx, cl, "", sandbox, opts.Last, opts.Follow, opts.Filter, opts.Filter)
+}
+
+// LogsBuild shows build logs for a specific version.
+func LogsBuild(ctx *Context, opts struct {
+	ConfigCentric
+
+	App     string         `short:"a" long:"app" description:"Application to get logs for" env:"MIREN_APP"`
+	Dir     string         `short:"d" long:"dir" description:"Directory to run from" default:"."`
+	Version string         `position:"0" usage:"Build version (e.g., v3)" required:"true"`
+	Last    *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
+	Follow  bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
+	Filter  string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
+}) error {
+	app, err := resolveAppName(opts.App, opts.Dir)
+	if err != nil {
+		return err
+	}
+
+	cl, err := ctx.RPCClient("dev.miren.runtime/logs")
+	if err != nil {
+		return err
+	}
+
+	combinedFilter := buildBuildFilter(opts.Version, opts.Filter)
+	return dispatchLogs(ctx, cl, app, "", opts.Last, opts.Follow, opts.Filter, combinedFilter)
+}
+
+// LogsSystem shows system/server logs, optionally filtered by component.
+func LogsSystem(ctx *Context, opts struct {
+	ConfigCentric
+
+	Component string         `position:"0" usage:"System component to filter by (e.g., 'etcd', 'scheduler')"`
+	Last      *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
+	Follow    bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
+	Filter    string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
+}) error {
+	cl, err := ctx.RPCClient("dev.miren.runtime/logs")
+	if err != nil {
+		return err
+	}
+
+	if !cl.HasMethod(ctx, "streamLogChunks") {
+		return fmt.Errorf("system logs require a newer server version")
+	}
+
+	target := &app_v1alpha.LogTarget{}
+	target.SetSystem(true)
+
+	combinedFilter := buildSystemFilter(opts.Component, opts.Filter)
+
+	var ts *standard.Timestamp
+	if opts.Last != nil {
+		ts = standard.ToTimestamp(time.Now().Add(-*opts.Last))
+	}
+	// When no --last and no --follow, ts is nil → server returns last 100 lines
+
+	ac := app_v1alpha.LogsClient{Client: cl}
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
+		for _, l := range chunk.Entries() {
+			printLogEntry(ctx, l)
+		}
+		return nil
+	})
+
+	_, err = ac.StreamLogChunks(ctx, target, ts, opts.Follow, combinedFilter, callback)
+	return err
+}
+
+// dispatchLogs handles protocol negotiation and dispatches to the appropriate
+// log streaming method based on server capabilities.
+func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *time.Duration, follow bool, rawFilter, combinedFilter string) error {
+	// Check if server supports streaming (prefer chunked for efficiency)
+	if cl.HasMethod(ctx, "streamLogChunks") {
+		return streamLogChunks(ctx, cl, app, sandbox, last, follow, combinedFilter)
+	}
+
+	// Older server - warn about upgrade and limited functionality
+	ctx.Printf("Warning: server does not support optimized log streaming. Upgrade your server for better performance and --service/--build filtering.\n")
+
+	// Parse filter for client-side filtering on older protocol
 	var filter *logfilter.Filter
-	if opts.Filter != "" {
+	if rawFilter != "" {
 		var err error
-		filter, err = logfilter.Parse(opts.Filter)
+		filter, err = logfilter.Parse(rawFilter)
 		if err != nil {
 			return fmt.Errorf("invalid filter: %w", err)
 		}
 	}
 
-	// Build combined filter for server-side filtering
-	var combinedFilter string
-	if opts.Build != "" {
-		combinedFilter = buildBuildFilter(opts.Build, opts.Filter)
-	} else {
-		combinedFilter = buildFilterWithService(opts.Filter, opts.Service)
-	}
-
-	// Check if server supports streaming (prefer chunked for efficiency)
-	if cl.HasMethod(ctx, "streamLogChunks") {
-		return streamLogChunks(ctx, cl, opts.App, opts.Sandbox, opts.Last, opts.Follow, combinedFilter)
-	}
-
-	// Older server - warn about upgrade and limited functionality
-	ctx.Printf("Warning: server does not support optimized log streaming. Upgrade your server for better performance and --service/--build filtering.\n")
-	if opts.Service != "" {
-		return fmt.Errorf("--service filtering requires a newer server version")
-	}
-	if opts.Build != "" {
-		return fmt.Errorf("--build filtering requires a newer server version")
-	}
-
 	if cl.HasMethod(ctx, "streamLogs") {
-		return streamLogs(ctx, cl, opts.App, opts.Sandbox, opts.Last, opts.Follow, filter)
+		return streamLogs(ctx, cl, app, sandbox, last, follow, filter)
 	}
 
 	// Warn if --follow requested but not supported
-	if opts.Follow {
+	if follow {
 		ctx.Printf("Warning: server does not support --follow, showing recent logs only\n")
 	}
 
 	// Fall back to legacy pagination
-	return legacyLogs(ctx, cl, opts.App, opts.Sandbox, opts.Last, filter)
+	return legacyLogs(ctx, cl, app, sandbox, last, filter)
 }
 
 var streamTypePrefixes = map[string]string{
@@ -146,6 +228,22 @@ var streamTypePrefixes = map[string]string{
 	"stderr":   "E",
 	"error":    "ERR",
 	"user-oob": "U",
+}
+
+func printLogEntry(ctx *Context, l *app_v1alpha.LogEntry) {
+	prefix := ""
+	if l.HasSource() && l.Source() != "" {
+		source := l.Source()
+		if len(source) > 12 {
+			source = source[:3] + "…" + source[len(source)-8:]
+		}
+		prefix = "[" + source + "] "
+	}
+	ctx.Printf("%s %s: %s%s\n",
+		streamTypePrefixes[l.Stream()],
+		standard.FromTimestamp(l.Timestamp()).Format("2006-01-02 15:04:05"),
+		prefix,
+		l.Line())
 }
 
 func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *time.Duration, follow bool, filter *logfilter.Filter) error {
@@ -163,13 +261,10 @@ func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *
 	var ts *standard.Timestamp
 	if last != nil {
 		ts = standard.ToTimestamp(time.Now().Add(-*last))
-	} else if !follow {
-		// For non-follow mode without explicit --last, default to today
-		start := time.Now()
-		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
-		ts = standard.ToTimestamp(start)
 	}
-	// For follow mode without --last, ts is nil which means start from now
+	// When no --last: ts is nil
+	// - follow mode: start from now
+	// - non-follow: server returns last 100 lines
 
 	// Create callback to print logs as they arrive
 	callback := stream.Callback(func(l *app_v1alpha.LogEntry) error {
@@ -178,19 +273,7 @@ func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *
 			return nil
 		}
 
-		prefix := ""
-		if l.HasSource() && l.Source() != "" {
-			source := l.Source()
-			if len(source) > 12 {
-				source = source[:3] + "…" + source[len(source)-8:]
-			}
-			prefix = "[" + source + "] "
-		}
-		ctx.Printf("%s %s: %s%s\n",
-			streamTypePrefixes[l.Stream()],
-			standard.FromTimestamp(l.Timestamp()).Format("2006-01-02 15:04:05"),
-			prefix,
-			l.Line())
+		printLogEntry(ctx, l)
 		return nil
 	})
 
@@ -213,30 +296,15 @@ func streamLogChunks(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, l
 	var ts *standard.Timestamp
 	if last != nil {
 		ts = standard.ToTimestamp(time.Now().Add(-*last))
-	} else if !follow {
-		// For non-follow mode without explicit --last, default to today
-		start := time.Now()
-		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
-		ts = standard.ToTimestamp(start)
 	}
-	// For follow mode without --last, ts is nil which means start from now
+	// When no --last: ts is nil
+	// - follow mode: start from now
+	// - non-follow: server returns last 100 lines
 
 	// Create callback to print logs as they arrive in chunks
 	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
 		for _, l := range chunk.Entries() {
-			prefix := ""
-			if l.HasSource() && l.Source() != "" {
-				source := l.Source()
-				if len(source) > 12 {
-					source = source[:3] + "…" + source[len(source)-8:]
-				}
-				prefix = "[" + source + "] "
-			}
-			ctx.Printf("%s %s: %s%s\n",
-				streamTypePrefixes[l.Stream()],
-				standard.FromTimestamp(l.Timestamp()).Format("2006-01-02 15:04:05"),
-				prefix,
-				l.Line())
+			printLogEntry(ctx, l)
 		}
 		return nil
 	})
@@ -284,19 +352,7 @@ func legacyLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *
 				continue
 			}
 
-			prefix := ""
-			if l.HasSource() && l.Source() != "" {
-				source := l.Source()
-				if len(source) > 12 {
-					source = source[:3] + "…" + source[len(source)-8:]
-				}
-				prefix = "[" + source + "] "
-			}
-			ctx.Printf("%s %s: %s%s\n",
-				streamTypePrefixes[l.Stream()],
-				standard.FromTimestamp(l.Timestamp()).Format("2006-01-02 15:04:05"),
-				prefix,
-				l.Line())
+			printLogEntry(ctx, l)
 		}
 
 		if len(logs) != 100 {

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -200,6 +200,13 @@ func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last
 	// Older server - warn about upgrade and limited functionality
 	ctx.Printf("Warning: server does not support optimized log streaming. Upgrade your server for better performance and --service/--build filtering.\n")
 
+	// Server-side filtering (--service, --build) requires streamLogChunks.
+	// If the combined filter differs from the raw user filter, one of these
+	// was applied and we must error rather than silently dropping it.
+	if rawFilter != combinedFilter {
+		return fmt.Errorf("--service and --build filtering require a newer server version")
+	}
+
 	// Parse filter for client-side filtering on older protocol
 	var filter *logfilter.Filter
 	if rawFilter != "" {
@@ -321,9 +328,9 @@ func legacyLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *
 	if last != nil {
 		ts = standard.ToTimestamp(time.Now().Add(-*last))
 	} else {
-		start := time.Now()
-		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
-		ts = standard.ToTimestamp(start)
+		// Legacy protocol can't do server-side limit=100, so default to
+		// last 1 hour as a reasonable bounded window of recent logs.
+		ts = standard.ToTimestamp(time.Now().Add(-1 * time.Hour))
 	}
 
 	for {

--- a/cli/commands/logs_doc.go
+++ b/cli/commands/logs_doc.go
@@ -1,8 +1,21 @@
 package commands
 
-const logsDescription = `## Time Range
+const logsDescription = `## Subcommands
 
-By default, logs show entries from today. Use ` + "`" + `--last` + "`" + ` to specify a different time range:
+` + "`" + `miren logs` + "`" + ` has subcommands for different log sources:
+
+` + "```" + `bash
+miren logs app       # Application logs (default)
+miren logs sandbox   # Sandbox logs
+miren logs build     # Build logs
+miren logs system    # System/server logs
+` + "```" + `
+
+Running ` + "`" + `miren logs` + "`" + ` without a subcommand shows app logs (backward compatible).
+
+## Time Range
+
+By default, logs show the last 100 lines. Use ` + "`" + `--last` + "`" + ` to specify a time range:
 
 ` + "```" + `bash
 # Show logs from the last 5 minutes
@@ -21,25 +34,22 @@ Use ` + "`" + `--follow` + "`" + ` (or ` + "`" + `-f` + "`" + `) to stream logs 
 
 ` + "```" + `bash
 # Follow logs as they arrive
-miren logs --follow
+miren logs -f
 
 # Follow logs for a specific app
-miren logs --app myapp -f
+miren logs app -a myapp -f
 ` + "```" + `
 
 ## Filtering by Service
 
-Use ` + "`" + `--service` + "`" + ` to filter logs by service name. This is useful for applications with multiple services (e.g., web, worker):
+Use ` + "`" + `--service` + "`" + ` to filter logs by service name (app logs only):
 
 ` + "```" + `bash
 # Show only logs from the web service
-miren logs --service web
+miren logs app --service web
 
 # Show worker service logs containing "error"
-miren logs --service worker -g error
-
-# Follow web service logs
-miren logs --service web -f
+miren logs app --service worker -g error
 ` + "```" + `
 
 ## Filtering Logs

--- a/cli/commands/logs_test.go
+++ b/cli/commands/logs_test.go
@@ -77,3 +77,74 @@ func TestNormalizeSandboxID(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildBuildFilter(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		userFilter string
+		want       string
+	}{
+		{
+			name:    "version only",
+			version: "v3",
+			want:    `source:build version:"v3"`,
+		},
+		{
+			name:       "version with filter",
+			version:    "v3",
+			userFilter: "error",
+			want:       `source:build version:"v3" error`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildBuildFilter(tt.version, tt.userFilter)
+			if got != tt.want {
+				t.Errorf("buildBuildFilter(%q, %q) = %q, want %q",
+					tt.version, tt.userFilter, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSystemFilter(t *testing.T) {
+	tests := []struct {
+		name       string
+		component  string
+		userFilter string
+		want       string
+	}{
+		{
+			name: "no component, no filter",
+			want: `source:"system"`,
+		},
+		{
+			name:      "component only",
+			component: "etcd",
+			want:      `source:"system" module:"etcd"`,
+		},
+		{
+			name:       "filter only",
+			userFilter: "error",
+			want:       `source:"system" error`,
+		},
+		{
+			name:       "component and filter",
+			component:  "scheduler",
+			userFilter: "error",
+			want:       `source:"system" module:"scheduler" error`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSystemFilter(tt.component, tt.userFilter)
+			if got != tt.want {
+				t.Errorf("buildSystemFilter(%q, %q) = %q, want %q",
+					tt.component, tt.userFilter, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -492,6 +492,12 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	logs := observability.NewLogReader(ctx.ServerState.VictorialogsAddress, ctx.ServerState.VictorialogsTimeout)
 	ctx.ServerState.Logs = logs
 
+	// Wait for VictoriaLogs to be ready before teeing server logs to it.
+	// VictoriaLogs Start() is async, so it may not be accepting HTTP yet.
+	if !observability.WaitForVictoriaLogs(sub, ctx.ServerState.VictorialogsAddress, 30*time.Second) {
+		ctx.Log.Warn("VictoriaLogs not ready after 30s, system log ingestion may be delayed")
+	}
+
 	// Tee server logs to VictoriaLogs so they're queryable via `miren logs system`
 	systemHandler := observability.NewSystemLogHandler(ctx.Log.Handler(), logWriter)
 	ctx.Log = slog.New(systemHandler)

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -492,6 +492,10 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	logs := observability.NewLogReader(ctx.ServerState.VictorialogsAddress, ctx.ServerState.VictorialogsTimeout)
 	ctx.ServerState.Logs = logs
 
+	// Tee server logs to VictoriaLogs so they're queryable via `miren logs system`
+	systemHandler := observability.NewSystemLogHandler(ctx.Log.Handler(), logWriter)
+	ctx.Log = slog.New(systemHandler)
+
 	// Discover local IPs using ipdiscovery
 	discovery, err := ipdiscovery.DiscoverWithTimeout(5*time.Second, ctx.Log)
 	if err != nil {

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -498,8 +498,11 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		ctx.Log.Warn("VictoriaLogs not ready after 30s, system log ingestion may be delayed")
 	}
 
-	// Tee server logs to VictoriaLogs so they're queryable via `miren logs system`
-	systemHandler := observability.NewSystemLogHandler(ctx.Log.Handler(), logWriter)
+	// Tee server logs to VictoriaLogs so they're queryable via `miren logs system`.
+	// Batch writes to reduce the number of HTTP POSTs under high log volume.
+	batchWriter := observability.NewBatchLogWriter(logWriter)
+	defer batchWriter.Close()
+	systemHandler := observability.NewSystemLogHandler(ctx.Log.Handler(), batchWriter)
 	ctx.Log = slog.New(systemHandler)
 
 	// Discover local IPs using ipdiscovery

--- a/components/victorialogs/victorialogs.go
+++ b/components/victorialogs/victorialogs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"miren.dev/runtime/components/base"
+	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/slogout"
 )
@@ -232,6 +233,7 @@ func (c *VictoriaLogsComponent) createContainer(ctx context.Context, image conta
 		),
 		oci.WithHostHostsFile,
 		oci.WithHostResolvconf,
+		containerdx.WithRlimitNOFILE(65536),
 
 		oci.WithMounts([]specs.Mount{
 			{

--- a/components/victoriametrics/victoriametrics.go
+++ b/components/victoriametrics/victoriametrics.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"miren.dev/runtime/components/base"
+	"miren.dev/runtime/pkg/containerdx"
 	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/slogout"
 )
@@ -233,6 +234,7 @@ func (c *VictoriaMetricsComponent) createContainer(ctx context.Context, image co
 		),
 		oci.WithHostHostsFile,
 		oci.WithHostResolvconf,
+		containerdx.WithRlimitNOFILE(65536),
 
 		oci.WithMounts([]specs.Mount{
 			{

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -167,7 +167,7 @@ miren logs
 View logs for a specific app:
 
 ```bash
-miren logs --app myapp
+miren logs app -a myapp
 ```
 
 Show logs from the last 5 minutes:
@@ -175,6 +175,8 @@ Show logs from the last 5 minutes:
 ```bash
 miren logs --last 5m
 ```
+
+See [Logs](/logs) for the full reference on filtering, build logs, system logs, and more.
 
 ## Managing Applications
 

--- a/docs/docs/logs.md
+++ b/docs/docs/logs.md
@@ -1,0 +1,151 @@
+---
+sidebar_position: 10
+---
+
+# Logs
+
+Miren captures logs from your applications, sandboxes, builds, and the system itself. Logs are stored in [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) and queryable through the `miren logs` command and its subcommands.
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `miren logs app` | Application logs (default when no subcommand is given) |
+| `miren logs sandbox` | Logs from a specific sandbox instance |
+| `miren logs build` | Build output for a specific app version |
+| `miren logs system` | Miren server internal logs |
+
+Running `miren logs` without a subcommand shows app logs (backward compatible).
+
+## Viewing app logs
+
+App logs are the most common use case. By default, `miren logs` shows the last 100 lines from your current app:
+
+```bash
+# Show recent logs for the current app
+miren logs
+
+# Show logs for a specific app
+miren logs app -a myapp
+
+# Filter by service
+miren logs app -a myapp --service web
+
+# Show logs from the last 30 minutes
+miren logs app --last 30m
+
+# Follow logs in real-time
+miren logs app -a myapp -f
+```
+
+## Build logs
+
+View the output from a specific build to debug deployment failures:
+
+```bash
+# Show build logs for the latest version
+miren logs build -a myapp
+
+# Show build logs for a specific version
+miren logs build -a myapp VERSION
+```
+
+Replace `VERSION` with the version from `miren app history`.
+
+## Sandbox logs
+
+View logs from a specific sandbox instance, useful for debugging issues in individual containers:
+
+```bash
+# Show logs for a specific sandbox
+miren logs sandbox -s SANDBOX_ID
+```
+
+Use `miren sandbox list` to find sandbox IDs.
+
+## System logs
+
+View Miren server internal logs for debugging server-level behavior:
+
+```bash
+miren logs system
+```
+
+System logs contain output from the Miren server process itself — controller reconciliation, RPC calls, sandbox lifecycle events, and other internal operations. Use these when debugging server behavior rather than application issues.
+
+## Filtering with grep
+
+Use `--grep` (or `-g`) to filter log output. The filter supports multiple syntax options:
+
+| Syntax | Description | Example |
+|--------|-------------|---------|
+| `word` | Match logs containing "word" (case-insensitive) | `error` |
+| `"phrase"` | Match logs containing exact phrase | `"connection failed"` |
+| `'phrase'` | Match logs containing exact phrase (alternate) | `'connection failed'` |
+| `/regex/` | Match logs matching regex pattern | `/err(or)?/` |
+| `-term` | Exclude logs matching term | `-debug` |
+| `term1 term2` | Match logs containing ALL terms (AND) | `error timeout` |
+
+- **Case-insensitive**: All word and phrase matches are case-insensitive
+- **AND logic**: Multiple terms must all match for a log line to be included
+- **Negation**: Prefix any term with `-` to exclude matching lines
+- **Quotes**: Use double (`"`) or single (`'`) quotes for phrases with spaces
+- **Regex**: Enclose patterns in forward slashes (`/pattern/`) for regex matching
+
+```bash
+# Filter for errors
+miren logs -g error
+
+# Exclude debug lines
+miren logs -g "-debug"
+
+# Match a phrase
+miren logs -g '"connection refused"'
+
+# Combine filters (must match both)
+miren logs -g "error timeout"
+```
+
+## Time ranges
+
+By default, logs show the last 100 lines. Use `--last` to specify a time range:
+
+```bash
+# Last 5 minutes
+miren logs --last 5m
+
+# Last hour
+miren logs --last 1h
+
+# Last 24 hours
+miren logs --last 24h
+```
+
+## Following logs
+
+Use `--follow` (or `-f`) to stream logs in real-time:
+
+```bash
+# Follow all logs
+miren logs -f
+
+# Follow logs for a specific app
+miren logs app -a myapp -f
+```
+
+## Output format
+
+Log entries are displayed with the following format:
+
+```
+S 2024-01-15 10:30:45: [source] Log message here
+```
+
+| Prefix | Meaning |
+|--------|---------|
+| `S` | stdout |
+| `E` | stderr |
+| `ERR` | error |
+| `U` | user out-of-band |
+
+Each entry includes a timestamp and an optional source identifier (such as a truncated sandbox ID) to help you trace which instance produced the log line.

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -124,5 +124,6 @@ httpingress                          [15ms]
 
 ## Next Steps
 
+- [Logs](/logs) — View and filter application, build, and system logs
 - [Services](/services) — Configure your app's services
 - [Application Scaling](/scaling) — Understand cold starts and autoscaling

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -71,10 +71,10 @@ Failed deployments are marked with a red `✗`. Use `--detailed` for more info i
 **2. Check build logs**
 
 ```bash
-miren logs -a myapp --build VERSION
+miren logs build -a myapp VERSION
 ```
 
-Replace `VERSION` with the version from the deployment history. This shows the build output so you can see where things went wrong.
+Replace `VERSION` with the version from the deployment history. This shows the build output so you can see where things went wrong. See [Logs](/logs) for more on filtering and following logs.
 
 ## Server-level issues
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -34,6 +34,7 @@ const sidebars: SidebarsConfig = {
         'admin-interface',
         'working-with-miren-cloud',
         'observability',
+        'logs',
       ],
     },
     {

--- a/observability/batch_log_writer.go
+++ b/observability/batch_log_writer.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"sync"
 	"time"
 )
@@ -25,9 +24,10 @@ type BatchLogWriter struct {
 	buf   bytes.Buffer
 	count int
 
-	flushCh chan struct{}
-	done    chan struct{}
-	wg      sync.WaitGroup
+	flushCh   chan struct{}
+	done      chan struct{}
+	wg        sync.WaitGroup
+	closeOnce sync.Once
 }
 
 // NewBatchLogWriter wraps a PersistentLogWriter with batching. Entries are
@@ -86,8 +86,11 @@ func (b *BatchLogWriter) WriteEntry(entity string, le LogEntry) error {
 }
 
 // Close signals the background goroutine to perform a final flush and stop.
+// It is safe to call multiple times.
 func (b *BatchLogWriter) Close() {
-	close(b.done)
+	b.closeOnce.Do(func() {
+		close(b.done)
+	})
 	b.wg.Wait()
 }
 
@@ -129,7 +132,5 @@ func (b *BatchLogWriter) flush() {
 		return
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		io.Copy(io.Discard, resp.Body)
-	}
+	_, _ = io.Copy(io.Discard, resp.Body)
 }

--- a/observability/batch_log_writer.go
+++ b/observability/batch_log_writer.go
@@ -1,0 +1,135 @@
+package observability
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	defaultFlushInterval = 250 * time.Millisecond
+	defaultFlushCount    = 50
+)
+
+// BatchLogWriter implements LogWriter by buffering entries and flushing them
+// as a single NDJSON HTTP POST to VictoriaLogs. This reduces write pressure
+// compared to one POST per log record.
+type BatchLogWriter struct {
+	writer *PersistentLogWriter
+
+	mu    sync.Mutex
+	buf   bytes.Buffer
+	count int
+
+	flushCh chan struct{}
+	done    chan struct{}
+	wg      sync.WaitGroup
+}
+
+// NewBatchLogWriter wraps a PersistentLogWriter with batching. Entries are
+// buffered and flushed either every 250ms or when 50 entries accumulate,
+// whichever comes first.
+func NewBatchLogWriter(writer *PersistentLogWriter) *BatchLogWriter {
+	b := &BatchLogWriter{
+		writer:  writer,
+		flushCh: make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	b.wg.Add(1)
+	go b.run()
+	return b
+}
+
+// WriteEntry marshals the entry to NDJSON and appends it to the internal
+// buffer. It never blocks the caller — writes are best-effort.
+func (b *BatchLogWriter) WriteEntry(entity string, le LogEntry) error {
+	msg := le.Body
+	if msg == "" {
+		msg = " "
+	}
+
+	logData := map[string]any{
+		"_msg":     msg,
+		"_time":    le.Timestamp.UTC().Format(time.RFC3339Nano),
+		"entity":   entity,
+		"stream":   string(le.Stream),
+		"trace_id": le.TraceID,
+	}
+	for k, v := range le.Attributes {
+		logData[k] = v
+	}
+
+	jsonData, err := json.Marshal(logData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal log entry: %w", err)
+	}
+
+	b.mu.Lock()
+	b.buf.Write(jsonData)
+	b.buf.WriteByte('\n')
+	b.count++
+	shouldFlush := b.count >= defaultFlushCount
+	b.mu.Unlock()
+
+	if shouldFlush {
+		select {
+		case b.flushCh <- struct{}{}:
+		default:
+		}
+	}
+
+	return nil
+}
+
+// Close signals the background goroutine to perform a final flush and stop.
+func (b *BatchLogWriter) Close() {
+	close(b.done)
+	b.wg.Wait()
+}
+
+func (b *BatchLogWriter) run() {
+	defer b.wg.Done()
+	ticker := time.NewTicker(defaultFlushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			b.flush()
+		case <-b.flushCh:
+			b.flush()
+		case <-b.done:
+			b.flush()
+			return
+		}
+	}
+}
+
+func (b *BatchLogWriter) flush() {
+	b.mu.Lock()
+	if b.count == 0 {
+		b.mu.Unlock()
+		return
+	}
+	data := make([]byte, b.buf.Len())
+	copy(data, b.buf.Bytes())
+	b.buf.Reset()
+	b.count = 0
+	b.mu.Unlock()
+
+	baseURL := normalizeBaseURL(b.writer.Address)
+	insertURL := baseURL + "/insert/jsonline"
+
+	resp, err := b.writer.Client().Post(insertURL, "application/x-ndjson", bytes.NewReader(data))
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		io.Copy(io.Discard, resp.Body)
+	}
+}

--- a/observability/batch_log_writer_test.go
+++ b/observability/batch_log_writer_test.go
@@ -1,0 +1,167 @@
+package observability
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBatchLogWriter_FlushOnTimer(t *testing.T) {
+	var mu sync.Mutex
+	var received []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		received = append(received, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	plw := NewPersistentLogWriter(srv.URL, 5*time.Second)
+	bw := NewBatchLogWriter(plw)
+
+	// Write a single entry — below the count threshold
+	err := bw.WriteEntry("test-entity", LogEntry{
+		Timestamp: time.Now(),
+		Stream:    Stdout,
+		Body:      "hello timer",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the timer to flush (defaultFlushInterval is 250ms)
+	time.Sleep(500 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(received) == 0 {
+		t.Fatal("expected at least one flush from timer, got none")
+	}
+
+	// Verify the NDJSON content
+	lines := strings.Split(strings.TrimSpace(received[0]), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+
+	var logData map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &logData); err != nil {
+		t.Fatal(err)
+	}
+	if logData["_msg"] != "hello timer" {
+		t.Fatalf("expected _msg=hello timer, got %v", logData["_msg"])
+	}
+	if logData["entity"] != "test-entity" {
+		t.Fatalf("expected entity=test-entity, got %v", logData["entity"])
+	}
+
+	bw.Close()
+}
+
+func TestBatchLogWriter_FlushOnThreshold(t *testing.T) {
+	var mu sync.Mutex
+	var received []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		received = append(received, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	plw := NewPersistentLogWriter(srv.URL, 5*time.Second)
+	bw := NewBatchLogWriter(plw)
+
+	// Write exactly defaultFlushCount entries to trigger threshold flush
+	for i := range defaultFlushCount {
+		err := bw.WriteEntry("test-entity", LogEntry{
+			Timestamp: time.Now(),
+			Stream:    Stdout,
+			Body:      "entry " + time.Now().Format(time.RFC3339Nano),
+		})
+		if err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	// Give the background goroutine a moment to process
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	count := len(received)
+	mu.Unlock()
+
+	if count == 0 {
+		t.Fatal("expected threshold flush, got no POSTs")
+	}
+
+	// The first POST should contain at least defaultFlushCount lines
+	mu.Lock()
+	lines := strings.Split(strings.TrimSpace(received[0]), "\n")
+	mu.Unlock()
+	if len(lines) < defaultFlushCount {
+		t.Fatalf("expected at least %d lines in first POST, got %d", defaultFlushCount, len(lines))
+	}
+
+	bw.Close()
+}
+
+func TestBatchLogWriter_CloseFlushesRemaining(t *testing.T) {
+	var mu sync.Mutex
+	var received []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		received = append(received, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	plw := NewPersistentLogWriter(srv.URL, 5*time.Second)
+	bw := NewBatchLogWriter(plw)
+
+	// Write a few entries (below threshold)
+	for i := range 3 {
+		err := bw.WriteEntry("drain-entity", LogEntry{
+			Timestamp: time.Now(),
+			Stream:    Stdout,
+			Body:      "drain entry",
+		})
+		if err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	// Close immediately — should drain the buffer
+	bw.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(received) == 0 {
+		t.Fatal("expected Close() to flush remaining entries, got none")
+	}
+
+	// Count total lines across all POSTs
+	total := 0
+	for _, body := range received {
+		lines := strings.Split(strings.TrimSpace(body), "\n")
+		total += len(lines)
+	}
+	if total != 3 {
+		t.Fatalf("expected 3 entries flushed on close, got %d", total)
+	}
+}

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -322,12 +322,17 @@ func (l *LogReader) executeStreamQuery(ctx context.Context, query string, logCh 
 	baseURL := normalizeBaseURL(l.Address)
 	queryURL := baseURL + "/select/logsql/query"
 
-	// Sort by time ascending so older logs appear first
-	sortedQuery := query + " | sort by (_time) asc"
+	var sortedQuery string
+	if o.Limit > 0 {
+		// Get the most recent N entries by sorting descending with limit,
+		// then reverse client-side to display in chronological order.
+		sortedQuery = fmt.Sprintf("%s | sort by (_time) desc | limit %d", query, o.Limit)
+	} else {
+		sortedQuery = query + " | sort by (_time) asc"
+	}
 
 	params := url.Values{}
 	params.Set("query", sortedQuery)
-	// No limit - stream all results
 
 	startTime := o.From
 	if startTime.IsZero() {
@@ -356,7 +361,43 @@ func (l *LogReader) executeStreamQuery(ctx context.Context, query string, logCh 
 		return fmt.Errorf("victorialogs returned status %d: %s", resp.StatusCode, string(body))
 	}
 
+	if o.Limit > 0 {
+		// Results are in reverse chronological order; buffer and reverse.
+		return l.parseLogStreamReversed(ctx, resp.Body, logCh)
+	}
 	return l.parseLogStream(ctx, resp.Body, logCh)
+}
+
+// parseLogStreamReversed collects all entries from the stream, reverses them,
+// and sends them to the channel in chronological order. Used for limited queries
+// where results arrive in descending time order.
+func (l *LogReader) parseLogStreamReversed(ctx context.Context, body io.Reader, logCh chan<- LogEntry) error {
+	var entries []LogEntry
+	scanner := bufio.NewScanner(body)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		entry, err := l.parseLogLine(line)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	// Reverse to chronological order
+	for i := len(entries) - 1; i >= 0; i-- {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case logCh <- entries[i]:
+		}
+	}
+	return nil
 }
 
 func (l *LogReader) executeTailQuery(ctx context.Context, query string, logCh chan<- LogEntry, opts ...LogReaderOption) error {

--- a/observability/system_log_handler.go
+++ b/observability/system_log_handler.go
@@ -1,0 +1,118 @@
+package observability
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// SystemLogEntityID is the well-known entity ID for system/server logs.
+const SystemLogEntityID = "system/miren-server"
+
+// SystemLogHandler is an slog.Handler that tees log records to both an
+// underlying handler (typically stderr) and a VictoriaLogs log writer.
+// This enables querying server logs through the same `miren logs system`
+// interface used for application and sandbox logs.
+type SystemLogHandler struct {
+	inner  slog.Handler
+	writer LogWriter
+	attrs  []slog.Attr
+	groups []string
+}
+
+// NewSystemLogHandler wraps an existing handler, adding a tee to the given
+// log writer. All log records are written to VictoriaLogs under the
+// SystemLogEntityID entity with source:"system".
+func NewSystemLogHandler(inner slog.Handler, writer LogWriter) *SystemLogHandler {
+	return &SystemLogHandler{
+		inner:  inner,
+		writer: writer,
+	}
+}
+
+func (h *SystemLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *SystemLogHandler) Handle(ctx context.Context, record slog.Record) error {
+	// Always forward to the underlying handler first
+	if err := h.inner.Handle(ctx, record); err != nil {
+		return err
+	}
+
+	// Build attributes map from handler-level and record-level attrs
+	attrs := make(map[string]string)
+	attrs["source"] = "system"
+
+	// Add handler-level attrs (from WithAttrs)
+	for _, a := range h.attrs {
+		attrs[a.Key] = a.Value.String()
+	}
+
+	// Add record-level attrs
+	record.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.String()
+		return true
+	})
+
+	// Map slog level to stream (stdout for info/debug, stderr for warn/error)
+	stream := Stdout
+	if record.Level >= slog.LevelWarn {
+		stream = Stderr
+	}
+
+	entry := LogEntry{
+		Timestamp:  record.Time.UTC(),
+		Stream:     stream,
+		Attributes: attrs,
+		Body:       record.Message,
+	}
+
+	// Best-effort write — don't block the logging pipeline
+	_ = h.writer.WriteEntry(SystemLogEntityID, entry)
+
+	return nil
+}
+
+func (h *SystemLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &SystemLogHandler{
+		inner:  h.inner.WithAttrs(attrs),
+		writer: h.writer,
+		attrs:  append(h.attrs[:len(h.attrs):len(h.attrs)], attrs...),
+		groups: h.groups,
+	}
+}
+
+func (h *SystemLogHandler) WithGroup(name string) slog.Handler {
+	return &SystemLogHandler{
+		inner:  h.inner.WithGroup(name),
+		writer: h.writer,
+		attrs:  h.attrs,
+		groups: append(h.groups[:len(h.groups):len(h.groups)], name),
+	}
+}
+
+// WaitForVictoriaLogs blocks until VictoriaLogs is reachable or the context
+// is cancelled. Returns true if VictoriaLogs became available.
+func WaitForVictoriaLogs(ctx context.Context, address string, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	reader := NewLogReader(address, 5*time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline:
+			return false
+		case <-ticker.C:
+			// Try a simple query to check if VictoriaLogs is up
+			_, err := reader.Read(ctx, "health-check", WithLimit(1))
+			if err == nil {
+				return true
+			}
+		}
+	}
+}

--- a/observability/system_log_handler.go
+++ b/observability/system_log_handler.go
@@ -95,7 +95,9 @@ func (h *SystemLogHandler) WithGroup(name string) slog.Handler {
 // WaitForVictoriaLogs blocks until VictoriaLogs is reachable or the context
 // is cancelled. Returns true if VictoriaLogs became available.
 func WaitForVictoriaLogs(ctx context.Context, address string, timeout time.Duration) bool {
-	deadline := time.After(timeout)
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	ticker := time.NewTicker(250 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -103,13 +105,10 @@ func WaitForVictoriaLogs(ctx context.Context, address string, timeout time.Durat
 
 	for {
 		select {
-		case <-ctx.Done():
-			return false
-		case <-deadline:
+		case <-waitCtx.Done():
 			return false
 		case <-ticker.C:
-			// Try a simple query to check if VictoriaLogs is up
-			_, err := reader.Read(ctx, "health-check", WithLimit(1))
+			_, err := reader.Read(waitCtx, "health-check", WithLimit(1))
 			if err == nil {
 				return true
 			}

--- a/observability/system_log_handler_test.go
+++ b/observability/system_log_handler_test.go
@@ -1,0 +1,110 @@
+package observability
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// mockLogWriter captures WriteEntry calls for testing.
+type mockLogWriter struct {
+	entries []struct {
+		entity string
+		entry  LogEntry
+	}
+}
+
+func (m *mockLogWriter) WriteEntry(entity string, le LogEntry) error {
+	m.entries = append(m.entries, struct {
+		entity string
+		entry  LogEntry
+	}{entity, le})
+	return nil
+}
+
+func TestSystemLogHandler(t *testing.T) {
+	writer := &mockLogWriter{}
+	inner := slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	handler := NewSystemLogHandler(inner, writer)
+	logger := slog.New(handler)
+
+	t.Run("info message maps to stdout", func(t *testing.T) {
+		writer.entries = nil
+		logger.Info("server started", "port", "8443")
+
+		if len(writer.entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(writer.entries))
+		}
+
+		e := writer.entries[0]
+		if e.entity != SystemLogEntityID {
+			t.Errorf("entity = %q, want %q", e.entity, SystemLogEntityID)
+		}
+		if e.entry.Stream != Stdout {
+			t.Errorf("stream = %q, want %q", e.entry.Stream, Stdout)
+		}
+		if e.entry.Body != "server started" {
+			t.Errorf("body = %q, want %q", e.entry.Body, "server started")
+		}
+		if e.entry.Attributes["source"] != "system" {
+			t.Errorf("source attr = %q, want %q", e.entry.Attributes["source"], "system")
+		}
+	})
+
+	t.Run("error message maps to stderr", func(t *testing.T) {
+		writer.entries = nil
+		logger.Error("connection failed")
+
+		if len(writer.entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(writer.entries))
+		}
+
+		if writer.entries[0].entry.Stream != Stderr {
+			t.Errorf("stream = %q, want %q", writer.entries[0].entry.Stream, Stderr)
+		}
+	})
+
+	t.Run("WithAttrs preserves attributes", func(t *testing.T) {
+		writer.entries = nil
+		moduleLogger := slog.New(handler.WithAttrs([]slog.Attr{
+			slog.String("module", "etcd"),
+		}))
+		moduleLogger.Info("peer connected")
+
+		if len(writer.entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(writer.entries))
+		}
+
+		if writer.entries[0].entry.Attributes["module"] != "etcd" {
+			t.Errorf("module attr = %q, want %q", writer.entries[0].entry.Attributes["module"], "etcd")
+		}
+	})
+
+	t.Run("timestamp is set", func(t *testing.T) {
+		writer.entries = nil
+		before := time.Now().UTC()
+		logger.Info("test")
+		after := time.Now().UTC()
+
+		if len(writer.entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(writer.entries))
+		}
+
+		ts := writer.entries[0].entry.Timestamp
+		if ts.Before(before) || ts.After(after) {
+			t.Errorf("timestamp %v not between %v and %v", ts, before, after)
+		}
+	})
+
+	t.Run("Enabled delegates to inner handler", func(t *testing.T) {
+		if !handler.Enabled(context.Background(), slog.LevelDebug) {
+			t.Error("expected debug to be enabled")
+		}
+	})
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/pkg/containerdx/opts.go
+++ b/pkg/containerdx/opts.go
@@ -654,10 +654,18 @@ func WithoutRoot(ctx context.Context, client oci.Client, c *containers.Container
 }
 
 // WithRlimitNOFILE sets the RLIMIT_NOFILE (max open files) for the container process.
+// Uses upsert semantics to avoid duplicate entries, which violate the OCI spec.
 func WithRlimitNOFILE(n uint64) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
 		if s.Process == nil {
 			s.Process = &runtimespec.Process{}
+		}
+		for i := range s.Process.Rlimits {
+			if s.Process.Rlimits[i].Type == "RLIMIT_NOFILE" {
+				s.Process.Rlimits[i].Soft = n
+				s.Process.Rlimits[i].Hard = n
+				return nil
+			}
 		}
 		s.Process.Rlimits = append(s.Process.Rlimits, runtimespec.POSIXRlimit{
 			Type: "RLIMIT_NOFILE",

--- a/pkg/containerdx/opts.go
+++ b/pkg/containerdx/opts.go
@@ -653,6 +653,21 @@ func WithoutRoot(ctx context.Context, client oci.Client, c *containers.Container
 	return nil
 }
 
+// WithRlimitNOFILE sets the RLIMIT_NOFILE (max open files) for the container process.
+func WithRlimitNOFILE(n uint64) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
+		if s.Process == nil {
+			s.Process = &runtimespec.Process{}
+		}
+		s.Process.Rlimits = append(s.Process.Rlimits, runtimespec.POSIXRlimit{
+			Type: "RLIMIT_NOFILE",
+			Hard: n,
+			Soft: n,
+		})
+		return nil
+	}
+}
+
 // WithAnnotation sets the provided annotation
 func WithAnnotation(k, v string) oci.SpecOpts {
 	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) error {

--- a/servers/logs/logs.go
+++ b/servers/logs/logs.go
@@ -131,27 +131,15 @@ func (s *Server) StreamLogs(ctx context.Context, state *app_v1alpha.LogsStreamLo
 	if args.HasFrom() {
 		fromTime := standard.FromTimestamp(args.From())
 		opts = append(opts, observability.WithFromTime(fromTime))
+	} else if !args.Follow() {
+		opts = append(opts, observability.WithLimit(defaultTailLimit))
 	}
 
-	// Build log target from RPC target
-	var logTarget observability.LogTarget
-
-	if target.HasSandbox() && target.Sandbox() != "" {
-		logTarget.SandboxID = target.Sandbox()
-		s.Log.Debug("streaming logs by sandbox", "sandbox", logTarget.SandboxID, "follow", args.Follow())
-	} else if target.HasApp() && target.App() != "" {
-		// Resolve app to entity ID
-		var appRec core_v1alpha.App
-		err := s.EC.Get(ctx, target.App(), &appRec)
-		if err != nil {
-			s.Log.Error("failed to get app", "app", target.App(), "err", err)
-			return err
-		}
-		logTarget.EntityID = appRec.EntityId().String()
-		s.Log.Debug("streaming logs by app", "app", target.App(), "entityID", logTarget.EntityID, "follow", args.Follow())
-	} else {
-		return fmt.Errorf("target must specify either app or sandbox")
+	logTarget, err := s.resolveLogTarget(ctx, target)
+	if err != nil {
+		return err
 	}
+	s.Log.Debug("streaming logs", "target", logTarget, "follow", args.Follow())
 
 	// Create channel for log entries
 	logCh := make(chan observability.LogEntry, 100)
@@ -189,6 +177,36 @@ func (s *Server) StreamLogs(ctx context.Context, state *app_v1alpha.LogsStreamLo
 }
 
 const defaultChunkSize = 100
+const defaultTailLimit = 100
+
+// resolveLogTarget converts an RPC LogTarget into an observability.LogTarget,
+// resolving app names to entity IDs as needed.
+func (s *Server) resolveLogTarget(ctx context.Context, target *app_v1alpha.LogTarget) (observability.LogTarget, error) {
+	var logTarget observability.LogTarget
+
+	if target.HasSystem() && target.System() {
+		logTarget.EntityID = observability.SystemLogEntityID
+		return logTarget, nil
+	}
+
+	if target.HasSandbox() && target.Sandbox() != "" {
+		logTarget.SandboxID = target.Sandbox()
+		return logTarget, nil
+	}
+
+	if target.HasApp() && target.App() != "" {
+		var appRec core_v1alpha.App
+		err := s.EC.Get(ctx, target.App(), &appRec)
+		if err != nil {
+			s.Log.Error("failed to get app", "app", target.App(), "err", err)
+			return logTarget, err
+		}
+		logTarget.EntityID = appRec.EntityId().String()
+		return logTarget, nil
+	}
+
+	return logTarget, fmt.Errorf("target must specify app, sandbox, or system")
+}
 
 func (s *Server) StreamLogChunks(ctx context.Context, state *app_v1alpha.LogsStreamLogChunks) error {
 	args := state.Args()
@@ -199,7 +217,7 @@ func (s *Server) StreamLogChunks(ctx context.Context, state *app_v1alpha.LogsStr
 		if !rpc.AllowApp(ctx, target.App()) {
 			return rpc.AppAccessError(ctx, target.App())
 		}
-	} else if rpc.BoundApp(ctx) != "" {
+	} else if !target.HasSystem() && rpc.BoundApp(ctx) != "" {
 		return fmt.Errorf("%w: app-scoped caller must specify app target", rpc.ErrUnauthorized)
 	}
 
@@ -207,27 +225,15 @@ func (s *Server) StreamLogChunks(ctx context.Context, state *app_v1alpha.LogsStr
 	if args.HasFrom() {
 		fromTime := standard.FromTimestamp(args.From())
 		opts = append(opts, observability.WithFromTime(fromTime))
+	} else if !args.Follow() {
+		opts = append(opts, observability.WithLimit(defaultTailLimit))
 	}
 
-	// Build log target from RPC target
-	var logTarget observability.LogTarget
-
-	if target.HasSandbox() && target.Sandbox() != "" {
-		logTarget.SandboxID = target.Sandbox()
-		s.Log.Debug("streaming log chunks by sandbox", "sandbox", logTarget.SandboxID, "follow", args.Follow())
-	} else if target.HasApp() && target.App() != "" {
-		// Resolve app to entity ID
-		var appRec core_v1alpha.App
-		err := s.EC.Get(ctx, target.App(), &appRec)
-		if err != nil {
-			s.Log.Error("failed to get app", "app", target.App(), "err", err)
-			return err
-		}
-		logTarget.EntityID = appRec.EntityId().String()
-		s.Log.Debug("streaming log chunks by app", "app", target.App(), "entityID", logTarget.EntityID, "follow", args.Follow())
-	} else {
-		return fmt.Errorf("target must specify either app or sandbox")
+	logTarget, err := s.resolveLogTarget(ctx, target)
+	if err != nil {
+		return err
 	}
+	s.Log.Debug("streaming log chunks", "target", logTarget, "follow", args.Follow())
 
 	// Parse and compile filter to LogsQL for VictoriaLogs
 	if args.HasFilter() && args.Filter() != "" {

--- a/servers/logs/logs.go
+++ b/servers/logs/logs.go
@@ -217,7 +217,7 @@ func (s *Server) StreamLogChunks(ctx context.Context, state *app_v1alpha.LogsStr
 		if !rpc.AllowApp(ctx, target.App()) {
 			return rpc.AppAccessError(ctx, target.App())
 		}
-	} else if !target.HasSystem() && rpc.BoundApp(ctx) != "" {
+	} else if rpc.BoundApp(ctx) != "" {
 		return fmt.Errorf("%w: app-scoped caller must specify app target", rpc.ErrUnauthorized)
 	}
 

--- a/servers/logs/logs.go
+++ b/servers/logs/logs.go
@@ -184,28 +184,42 @@ const defaultTailLimit = 100
 func (s *Server) resolveLogTarget(ctx context.Context, target *app_v1alpha.LogTarget) (observability.LogTarget, error) {
 	var logTarget observability.LogTarget
 
-	if target.HasSystem() && target.System() {
+	hasSystem := target.HasSystem() && target.System()
+	hasSandbox := target.HasSandbox() && target.Sandbox() != ""
+	hasApp := target.HasApp() && target.App() != ""
+
+	selected := 0
+	if hasSystem {
+		selected++
+	}
+	if hasSandbox {
+		selected++
+	}
+	if hasApp {
+		selected++
+	}
+	if selected != 1 {
+		return logTarget, fmt.Errorf("target must specify exactly one of app, sandbox, or system")
+	}
+
+	if hasSystem {
 		logTarget.EntityID = observability.SystemLogEntityID
 		return logTarget, nil
 	}
 
-	if target.HasSandbox() && target.Sandbox() != "" {
+	if hasSandbox {
 		logTarget.SandboxID = target.Sandbox()
 		return logTarget, nil
 	}
 
-	if target.HasApp() && target.App() != "" {
-		var appRec core_v1alpha.App
-		err := s.EC.Get(ctx, target.App(), &appRec)
-		if err != nil {
-			s.Log.Error("failed to get app", "app", target.App(), "err", err)
-			return logTarget, err
-		}
-		logTarget.EntityID = appRec.EntityId().String()
-		return logTarget, nil
+	var appRec core_v1alpha.App
+	err := s.EC.Get(ctx, target.App(), &appRec)
+	if err != nil {
+		s.Log.Error("failed to get app", "app", target.App(), "err", err)
+		return logTarget, err
 	}
-
-	return logTarget, fmt.Errorf("target must specify app, sandbox, or system")
+	logTarget.EntityID = appRec.EntityId().String()
+	return logTarget, nil
 }
 
 func (s *Server) StreamLogChunks(ctx context.Context, state *app_v1alpha.LogsStreamLogChunks) error {

--- a/servers/logs/logs_test.go
+++ b/servers/logs/logs_test.go
@@ -430,7 +430,7 @@ func TestStreamLogChunks_ErrorNoTarget(t *testing.T) {
 
 	_, err := client.StreamLogChunks(ctx, target, nil, false, "", callback)
 	r.Error(err)
-	r.Contains(err.Error(), "target must specify either app or sandbox")
+	r.Contains(err.Error(), "target must specify app, sandbox, or system")
 }
 
 func TestStreamLogChunks_AppNotFound(t *testing.T) {

--- a/servers/logs/logs_test.go
+++ b/servers/logs/logs_test.go
@@ -31,10 +31,21 @@ type mockLogEntry struct {
 
 func createMockVictoriaLogs(t *testing.T, entries []mockLogEntry, delay time.Duration) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+
+		// Simulate VictoriaLogs returning results in desc order when requested
+		ordered := entries
+		if strings.Contains(query, "desc") {
+			ordered = make([]mockLogEntry, len(entries))
+			for i, e := range entries {
+				ordered[len(entries)-1-i] = e
+			}
+		}
+
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		w.WriteHeader(http.StatusOK)
 
-		for _, entry := range entries {
+		for _, entry := range ordered {
 			if delay > 0 {
 				time.Sleep(delay)
 			}
@@ -58,17 +69,16 @@ func createFilteringMockVictoriaLogs(t *testing.T, entries []mockLogEntry) *http
 		query := r.URL.Query().Get("query")
 		t.Logf("Received query: %s", query)
 
+		descOrder := strings.Contains(query, "desc")
+
 		// Strip pipe operators (like "| sort by (_time)")
 		if pipeIdx := strings.Index(query, " |"); pipeIdx != -1 {
 			query = query[:pipeIdx]
 		}
 
-		w.Header().Set("Content-Type", "application/x-ndjson")
-		w.WriteHeader(http.StatusOK)
-
+		// Filter entries first
+		var filtered []mockLogEntry
 		for _, entry := range entries {
-			// Simple filter simulation: if query contains a word filter, check if msg contains it
-			// This simulates VictoriaLogs LogsQL word filtering
 			parts := strings.Split(query, " ")
 			shouldInclude := true
 			for _, part := range parts[1:] { // Skip the entity/sandbox part
@@ -77,16 +87,29 @@ func createFilteringMockVictoriaLogs(t *testing.T, entries []mockLogEntry) *http
 					break
 				}
 			}
-
 			if shouldInclude {
-				data, err := json.Marshal(entry)
-				if err != nil {
-					t.Errorf("failed to marshal entry: %v", err)
-					return
-				}
-				w.Write(data)
-				w.Write([]byte("\n"))
+				filtered = append(filtered, entry)
 			}
+		}
+
+		// Simulate VictoriaLogs returning results in desc order when requested
+		if descOrder {
+			for i, j := 0, len(filtered)-1; i < j; i, j = i+1, j-1 {
+				filtered[i], filtered[j] = filtered[j], filtered[i]
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+
+		for _, entry := range filtered {
+			data, err := json.Marshal(entry)
+			if err != nil {
+				t.Errorf("failed to marshal entry: %v", err)
+				return
+			}
+			w.Write(data)
+			w.Write([]byte("\n"))
 		}
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()

--- a/servers/logs/logs_test.go
+++ b/servers/logs/logs_test.go
@@ -453,7 +453,7 @@ func TestStreamLogChunks_ErrorNoTarget(t *testing.T) {
 
 	_, err := client.StreamLogChunks(ctx, target, nil, false, "", callback)
 	r.Error(err)
-	r.Contains(err.Error(), "target must specify app, sandbox, or system")
+	r.Contains(err.Error(), "target must specify exactly one of app, sandbox, or system")
 }
 
 func TestStreamLogChunks_AppNotFound(t *testing.T) {


### PR DESCRIPTION
`miren logs` had grown into a single command trying to do too many things — app logs, sandbox logs, build logs — with a pile of mutually-exclusive flags and validation logic to keep them from stepping on each other. Adding system log querying on top of that would've made it worse, so this felt like the right time to break things up.

The first commit splits `miren logs` into proper subcommands: `miren logs app`, `miren logs sandbox`, `miren logs build`, and the new `miren logs system`. Each subcommand gets its own opts struct with only the flags that make sense for it. Bare `miren logs` still works as a shorthand for `miren logs app` so existing muscle memory isn't disrupted. While in there, the default output window was changed from "since midnight" to "last 100 lines" which is a much more useful default for the common "what just happened" workflow.

The system log ingestion works by teeing server logs through a new `SystemLogHandler` (an `slog.Handler` that writes to VictoriaLogs under a well-known entity ID). This means all server logs are queryable through the same interface as app logs — `miren logs system --last 5m --follow` just works.

The second commit fixes a few bugs found during review — a startup race where writes could silently fail before VictoriaLogs was ready, stale filter validation, and a test assertion that needed updating.

The third commit addresses a crash we hit during manual testing: VictoriaLogs would die with `FATAL: too many open files` during small-parts merge. The root cause was the container inheriting the system default 1024 fd limit, which is way too low for a storage engine doing compaction. We raise RLIMIT_NOFILE to 65536 via a new `WithRlimitNOFILE` helper in `pkg/containerdx` (applied to both VictoriaLogs and VictoriaMetrics since they share the same architecture). As defense in depth, we also wrap the system log path in a `BatchLogWriter` that buffers entries and flushes as a single NDJSON POST every 250ms or 50 entries, cutting down the number of small parts VictoriaLogs has to manage.