### PR TITLE
Check port binding via /proc/net/tcp instead of TCP dial

### DIFF
--- a/controllers/sandbox/portmonitor.go
+++ b/controllers/sandbox/portmonitor.go
@@ -1,11 +1,14 @@
 package sandbox
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/netip"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,6 +30,7 @@ type PortMonitor struct {
 type monitorTask struct {
 	containerID string
 	ip          string
+	pid         int
 	ports       []int
 	cancel      context.CancelFunc
 }
@@ -43,8 +47,11 @@ func NewPortMonitor(log *slog.Logger, ports observability.PortTracker) *PortMoni
 	}
 }
 
-// MonitorContainer starts monitoring ports for a container
-func (pm *PortMonitor) MonitorContainer(containerID string, ip string, ports []int) {
+// MonitorContainer starts monitoring ports for a container.
+// It checks port binding by reading /proc/<pid>/net/tcp from the container's
+// network namespace (via the pause container's PID) rather than doing a TCP
+// dial from the host, which can be interfered with by iptables DNAT rules.
+func (pm *PortMonitor) MonitorContainer(containerID string, ip string, pid int, ports []int) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
@@ -58,6 +65,7 @@ func (pm *PortMonitor) MonitorContainer(containerID string, ip string, ports []i
 	task := &monitorTask{
 		containerID: containerID,
 		ip:          ip,
+		pid:         pid,
 		ports:       ports,
 		cancel:      taskCancel,
 	}
@@ -146,7 +154,7 @@ func (pm *PortMonitor) monitorPorts(ctx context.Context, task *monitorTask) {
 					continue // Already bound
 				}
 
-				isBound := pm.checkPort(task.ip, port)
+				isBound := checkPort(task.pid, port)
 				if !isBound {
 					continue // Still unbound
 				}
@@ -166,12 +174,69 @@ func (pm *PortMonitor) monitorPorts(ctx context.Context, task *monitorTask) {
 	}
 }
 
-func (pm *PortMonitor) checkPort(ip string, port int) bool {
-	address := net.JoinHostPort(ip, fmt.Sprintf("%d", port))
-	conn, err := net.DialTimeout("tcp", address, 100*time.Millisecond)
+// checkPort checks whether the given port is in LISTEN state inside the
+// network namespace of the given PID by reading /proc/<pid>/net/tcp{,6}.
+// This avoids TCP dials from the host which can be interfered with by
+// iptables DNAT rules for node_port mappings.
+func checkPort(pid int, port int) bool {
+	for _, proto := range []string{"tcp", "tcp6"} {
+		path := fmt.Sprintf("/proc/%d/net/%s", pid, proto)
+		if portListening(path, port) {
+			return true
+		}
+	}
+	return false
+}
+
+// portListening parses a /proc/net/tcp{,6} file and returns true if any entry
+// has the given local port in LISTEN state (0A).
+//
+// The file format has a header line followed by entries like:
+//
+//	sl  local_address rem_address   st tx_queue rx_queue ...
+//	0: 00000000:0CEA 00000000:0000 0A 00000000:00000000 ...
+//
+// Field 1 (local_address) contains host:port in hex; field 3 (st) is the state.
+func portListening(path string, port int) bool {
+	f, err := os.Open(path)
 	if err != nil {
 		return false
 	}
-	_ = conn.Close()
-	return true
+	defer f.Close()
+
+	portHex := fmt.Sprintf("%04X", port)
+
+	scanner := bufio.NewScanner(f)
+	// Skip header line
+	if !scanner.Scan() {
+		return false
+	}
+
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 4 {
+			continue
+		}
+
+		// fields[1] is local_address "ADDR:PORT", fields[3] is state
+		localAddr := fields[1]
+		state := fields[3]
+
+		// State 0A = LISTEN
+		if state != "0A" {
+			continue
+		}
+
+		// Extract port from local_address (everything after the last colon)
+		idx := strings.LastIndex(localAddr, ":")
+		if idx < 0 {
+			continue
+		}
+
+		if strings.EqualFold(localAddr[idx+1:], portHex) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/controllers/sandbox/portmonitor_test.go
+++ b/controllers/sandbox/portmonitor_test.go
@@ -1,0 +1,89 @@
+package sandbox
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPortListening(t *testing.T) {
+	// Sample /proc/net/tcp content with a listener on port 6667 (0x1A0B)
+	// and an established connection on port 3000 (0x0BB8)
+	content := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000:1A0B 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:0BB8 0100007F:C000 01 00000000:00000000 00:00000000 00000000  1000        0 67890 1 0000000000000000 20 0 0 10 -1
+`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tcp")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		port int
+		want bool
+	}{
+		{6667, true},  // listening (state 0A)
+		{3000, false}, // established (state 01), not listening
+		{8080, false}, // not present at all
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("port_%d", tt.port), func(t *testing.T) {
+			got := portListening(path, tt.port)
+			if got != tt.want {
+				t.Errorf("portListening(path, %d) = %v, want %v", tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPortListeningIPv6(t *testing.T) {
+	// Sample /proc/net/tcp6 content with a listener on port 3000
+	content := `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000000000000:0BB8 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tcp6")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !portListening(path, 3000) {
+		t.Error("expected port 3000 to be listening in tcp6")
+	}
+
+	if portListening(path, 8080) {
+		t.Error("expected port 8080 to not be listening in tcp6")
+	}
+}
+
+func TestPortListeningMissingFile(t *testing.T) {
+	if portListening("/nonexistent/path/tcp", 80) {
+		t.Error("expected false for missing file")
+	}
+}
+
+func TestCheckPortWithCurrentProcess(t *testing.T) {
+	// Listen on a random port and verify checkPort finds it via our own PID
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	pid := os.Getpid()
+
+	if !checkPort(pid, port) {
+		t.Errorf("checkPort(%d, %d) = false, want true for listening port", pid, port)
+	}
+
+	if checkPort(pid, port+1) {
+		t.Errorf("checkPort(%d, %d) = true, want false for non-listening port", pid, port+1)
+	}
+}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1660,7 +1660,7 @@ func (c *SandboxController) bootContainers(
 		// Start port monitoring for this container if it has ports
 		if len(ports) > 0 && len(ep.Addresses) > 0 {
 			ip := ep.Addresses[0].Addr().String()
-			c.portMonitor.MonitorContainer(id, ip, ports)
+			c.portMonitor.MonitorContainer(id, ip, sbPid, ports)
 		}
 	}
 


### PR DESCRIPTION
During sandbox boot, the port monitor verifies all declared ports are reachable by doing a `net.DialTimeout` from the host network namespace. This works great for HTTP ports, but for TCP ports with a `node_port` (e.g., port 6667 with node_port 30667), the dial consistently fails for ~15 seconds even though the app is already listening.

The culprit is the POSTROUTING MASQUERADE rule that `configureFirewall` sets up for node_port mappings. It matches traffic from `127.0.0.1` destined for `container_ip:internal_port`, so the health check probes (which originate from the host loopback) get caught up in it. Importantly, this does *not* affect real user traffic — external clients arrive on the node_port (e.g., 30667) via PREROUTING DNAT and never hit the POSTROUTING rule, so the forwarding path works correctly end-to-end. The issue is specific to host-originated probes against the internal port.

The fix sidesteps the network entirely. Instead of dialing from the host, we read `/proc/<pid>/net/tcp` (and `tcp6`) from the pause container's PID, which shares a network namespace with all the sandbox's sub-containers. This tells us directly whether a socket is in LISTEN state on the port we care about — no network path required, no iptables interference possible. The pause PID was already available in `bootContainers`, so we just thread it through to `MonitorContainer`.

Closes MIR-755