### PR TITLE
Release subnet IPs even when pause container is already gone

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -2353,22 +2353,23 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 			c.Log.Error("failed to delete pause container", "id", id, "err", err)
 		}
 
-		// Release IPs
-		for ipStr := range sandboxIPs {
-			addr, err := netip.ParseAddr(ipStr)
-			if err == nil {
-				err = c.Subnet.ReleaseAddr(addr)
-				if err != nil {
-					c.Log.Error("failed to release IP", "addr", addr, "err", err)
-				} else {
-					c.Log.Debug("released IP", "addr", addr)
-				}
-			} else {
-				c.Log.Error("failed to parse IP", "addr", ipStr, "err", err)
-			}
-		}
-
 		c.Log.Info("container stopped", "id", id)
+	}
+
+	// Release IPs — runs even if pause container was already gone,
+	// since sandboxIPs may have been recovered from the entity store.
+	for ipStr := range sandboxIPs {
+		addr, err := netip.ParseAddr(ipStr)
+		if err == nil {
+			err = c.Subnet.ReleaseAddr(addr)
+			if err != nil {
+				c.Log.Error("failed to release IP", "addr", addr, "err", err)
+			} else {
+				c.Log.Debug("released IP", "addr", addr)
+			}
+		} else {
+			c.Log.Error("failed to parse IP", "addr", ipStr, "err", err)
+		}
 	}
 
 	// Clean up temp directory


### PR DESCRIPTION
There was a subtle leak in `stopSandbox` where subnet IPs could get stuck in the allocator permanently. The IP release loop was nested inside the `if container != nil` block, but earlier in the function, `sandboxIPs` gets populated from the entity store as a fallback when the container is already gone. So if something else cleaned up the pause container first, we'd skip right past the release code and those IPs would never come back.

The fix is just moving the release loop outside the container-existence check. It's always safe to run — if `sandboxIPs` is empty, it's a no-op, and if it has entries recovered from the entity store, we properly return them to the pool.

Closes MIR-754