### PR TITLE
Add saga-based sandbox creation for reliable rollback

### DIFF
--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -38,9 +38,11 @@ import (
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
 	"miren.dev/runtime/pkg/grunge"
+	"miren.dev/runtime/pkg/labs"
 	"miren.dev/runtime/pkg/multierror"
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/saga"
 	"miren.dev/runtime/servers/exec"
 )
 
@@ -153,7 +155,7 @@ type Runner struct {
 
 	namespace string
 
-	sbController *sandbox.SandboxController
+	sbController sandbox.SandboxLifecycle
 
 	// Disk controllers, stored for SetRestartMode propagation
 	dvc *diskio.DiskVolumeController
@@ -552,7 +554,7 @@ func (r *Runner) SetupControllers(
 	cm := controller.NewControllerManager()
 
 	// Create sandbox controller with explicit dependencies
-	sbc, err := sandbox.NewSandboxController(sandbox.SandboxControllerDeps{
+	sbcDeps := sandbox.SandboxControllerDeps{
 		Log:            r.Log,
 		CC:             r.deps.CC,
 		EAC:            eas,
@@ -568,14 +570,31 @@ func (r *Runner) SetupControllers(
 		StatusMon:      r.deps.StatusMon,
 		Resolver:       r.deps.Resolver,
 		Metrics:        r.deps.SandboxMetrics,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create sandbox controller: %w", err)
+	}
+
+	var sbc sandbox.SandboxLifecycle
+	var sbcHandler controller.HandlerFunc
+
+	if labs.Sagas() {
+		sagaStorage := saga.NewEACStorage(eas, r.Log)
+		sagaSbc, sagaErr := sandbox.NewSagaSandboxController(sbcDeps, sagaStorage, r.Log)
+		if sagaErr != nil {
+			return nil, fmt.Errorf("failed to create saga sandbox controller: %w", sagaErr)
+		}
+		sbc = sagaSbc
+		sbcHandler = controller.AdaptController(sagaSbc)
+	} else {
+		origSbc, origErr := sandbox.NewSandboxController(sbcDeps)
+		if origErr != nil {
+			return nil, fmt.Errorf("failed to create sandbox controller: %w", origErr)
+		}
+		sbc = origSbc
+		sbcHandler = controller.AdaptController(origSbc)
 	}
 
 	r.closers = append(r.closers, sbc)
 
-	rs.ExposeValue("dev.miren.runtime/sandbox.metrics", metric_v1alpha.AdaptSandboxMetrics(sbc.Metrics))
+	rs.ExposeValue("dev.miren.runtime/sandbox.metrics", metric_v1alpha.AdaptSandboxMetrics(sbcDeps.Metrics))
 
 	// Create service controller with explicit dependencies
 	serviceController, err := service.NewServiceController(service.ServiceControllerDeps{
@@ -753,8 +772,8 @@ func (r *Runner) SetupControllers(
 		return nil, err
 	}
 
-	r.cc = sbc.CC
-	r.namespace = sbc.Namespace
+	r.cc = r.deps.CC
+	r.namespace = r.deps.Namespace
 	r.sbController = sbc
 
 	sbController := controller.NewReconcileController(
@@ -762,7 +781,7 @@ func (r *Runner) SetupControllers(
 		log,
 		compute_v1alpha.Index(compute_v1alpha.KindSandbox, entity.Id("node/"+r.Id)),
 		eas,
-		controller.AdaptController(sbc),
+		sbcHandler,
 		time.Minute,
 		workers,
 	)

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -7,12 +7,9 @@ import (
 	"net/netip"
 	"time"
 
-	"github.com/containerd/containerd/namespaces"
 	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/errdefs"
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
-	"miren.dev/runtime/network"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/saga"
 )
@@ -33,11 +30,11 @@ const (
 
 // createSandboxDeps holds the dependencies injected into the saga context.
 // These are retrieved via saga.Get[*createSandboxDeps](ctx) within actions.
-// Note: writeTracker is accessed via ctrl.writeTracker rather than captured
-// separately, because SetWriteTracker is called after Init when the saga
-// definition is registered.
 type createSandboxDeps struct {
-	ctrl *SandboxController
+	entities   SandboxEntityStore
+	networking SandboxNetworking
+	runtime    SandboxContainerRuntime
+	obs        SandboxObservability
 }
 
 // --- Action input/output types ---
@@ -54,15 +51,12 @@ func allocNetwork(ctx context.Context, in allocNetworkIn) (allocNetworkOut, erro
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	// Fetch sandbox entity to pass to allocateNetwork
-	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	sb, _, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err != nil {
 		return allocNetworkOut{}, fmt.Errorf("fetching sandbox: %w", err)
 	}
-	var co compute.Sandbox
-	co.Decode(resp.Entity().Entity())
 
-	ep, err := deps.ctrl.allocateNetwork(ctx, &co)
+	ep, err := deps.networking.AllocateNetwork(ctx, sb)
 	if err != nil {
 		return allocNetworkOut{}, fmt.Errorf("allocating network: %w", err)
 	}
@@ -76,7 +70,7 @@ func allocNetwork(ctx context.Context, in allocNetworkIn) (allocNetworkOut, erro
 	return allocNetworkOut{Addresses: addrs}, nil
 }
 
-func undoAllocNetwork(ctx context.Context, in allocNetworkIn, out allocNetworkOut) error {
+func undoAllocNetwork(ctx context.Context, _ allocNetworkIn, out allocNetworkOut) error {
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
@@ -86,7 +80,7 @@ func undoAllocNetwork(ctx context.Context, in allocNetworkIn, out allocNetworkOu
 			log.Error("saga undo: failed to parse address", "addr", addrStr, "error", err)
 			continue
 		}
-		if err := deps.ctrl.Subnet.ReleaseAddr(prefix.Addr()); err != nil {
+		if err := deps.networking.ReleaseAddr(prefix.Addr()); err != nil {
 			log.Error("saga undo: failed to release IP", "addr", prefix.Addr(), "error", err)
 		} else {
 			log.Debug("saga undo: released IP", "addr", prefix.Addr())
@@ -109,33 +103,28 @@ type patchNetworkOut struct {
 func patchNetwork(ctx context.Context, in patchNetworkIn) (patchNetworkOut, error) {
 	deps := saga.Get[*createSandboxDeps](ctx)
 
-	// Build network components from addresses
 	var networkAttrs []any
 	networkAttrs = append(networkAttrs, entity.Ref(entity.DBId, entity.Id(in.SandboxID)))
 
+	bridgeName := deps.networking.BridgeName()
 	for _, addrStr := range in.Addresses {
 		net := compute.Network{
 			Address: addrStr,
-			Subnet:  deps.ctrl.Bridge,
+			Subnet:  bridgeName,
 		}
 		networkAttrs = append(networkAttrs, entity.Component(compute.SandboxNetworkId, net.Encode()))
 	}
 
 	patchEnt := entity.New(networkAttrs...)
-	res, err := deps.ctrl.EAC.Patch(ctx, patchEnt.Attrs(), 0)
+	revision, err := deps.entities.PatchSandbox(ctx, patchEnt.Attrs(), 0)
 	if err != nil {
 		return patchNetworkOut{}, fmt.Errorf("patching sandbox with network: %w", err)
 	}
 
-	if deps.ctrl.writeTracker != nil && res.HasRevision() {
-		deps.ctrl.writeTracker.RecordWrite(res.Revision())
-	}
-
-	return patchNetworkOut{Revision: res.Revision()}, nil
+	return patchNetworkOut{Revision: revision}, nil
 }
 
 func undoPatchNetwork(_ context.Context, _ patchNetworkIn, _ patchNetworkOut) error {
-	// Entity patches don't need explicit undo; the sandbox will be marked DEAD
 	return nil
 }
 
@@ -155,39 +144,28 @@ func createContainer(ctx context.Context, in createContainerIn) (createContainer
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
-
-	// Fetch current sandbox state
-	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	sb, meta, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err != nil {
 		return createContainerOut{}, fmt.Errorf("fetching sandbox: %w", err)
 	}
-	var co compute.Sandbox
-	co.Decode(resp.Entity().Entity())
 
-	// Rebuild endpoint config from stored addresses
-	ep, err := rebuildEndpointConfig(deps.ctrl, in.Addresses)
+	ep, err := deps.networking.RebuildEndpointConfig(in.Addresses)
 	if err != nil {
 		return createContainerOut{}, fmt.Errorf("rebuilding endpoint config: %w", err)
 	}
 
-	// Build entity meta for buildSpec
-	meta := &entity.Meta{
-		Entity:   resp.Entity().Entity(),
-		Revision: in.Revision,
+	if in.Revision != 0 {
+		meta.Revision = in.Revision
 	}
 
-	// Build OCI spec
-	opts, err := deps.ctrl.buildSpec(ctx, &co, ep, meta)
+	opts, err := deps.runtime.BuildSpec(ctx, sb, ep, meta)
 	if err != nil {
 		return createContainerOut{}, fmt.Errorf("building spec: %w", err)
 	}
 
-	// Create pause container (idempotent for crash replay)
-	cid := pauseContainerId(co.ID)
-	_, err = deps.ctrl.CC.NewContainer(ctx, cid, opts...)
-	if err != nil && !errdefs.IsAlreadyExists(err) {
-		return createContainerOut{}, fmt.Errorf("creating container %s: %w", co.ID, err)
+	cid, err := deps.runtime.CreateContainer(ctx, string(sb.ID), opts...)
+	if err != nil {
+		return createContainerOut{}, fmt.Errorf("creating container %s: %w", sb.ID, err)
 	}
 
 	log.Debug("saga: created container", "sandbox", in.SandboxID, "container", cid)
@@ -202,13 +180,12 @@ func undoCreateContainer(ctx context.Context, _ createContainerIn, out createCon
 		return nil
 	}
 
-	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
-	container, err := deps.ctrl.CC.LoadContainer(ctx, out.ContainerID)
+	container, err := deps.runtime.LoadContainer(ctx, out.ContainerID)
 	if err != nil {
 		log.Debug("saga undo: container not found, already cleaned up", "id", out.ContainerID)
 		return nil
 	}
-	deps.ctrl.cleanupContainer(ctx, container)
+	deps.runtime.CleanupContainer(ctx, container)
 	log.Debug("saga undo: deleted container", "id", out.ContainerID)
 	return nil
 }
@@ -230,35 +207,26 @@ func bootTask(ctx context.Context, in bootTaskIn) (bootTaskOut, error) {
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
-
-	// Fetch sandbox
-	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	sb, _, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err != nil {
 		return bootTaskOut{}, fmt.Errorf("fetching sandbox: %w", err)
 	}
-	var co compute.Sandbox
-	co.Decode(resp.Entity().Entity())
 
-	// Rebuild endpoint config
-	ep, err := rebuildEndpointConfig(deps.ctrl, in.Addresses)
+	ep, err := deps.networking.RebuildEndpointConfig(in.Addresses)
 	if err != nil {
 		return bootTaskOut{}, fmt.Errorf("rebuilding endpoint config: %w", err)
 	}
 
-	// Load container
-	container, err := deps.ctrl.CC.LoadContainer(ctx, in.ContainerID)
+	container, err := deps.runtime.LoadContainer(ctx, in.ContainerID)
 	if err != nil {
 		return bootTaskOut{}, fmt.Errorf("loading container: %w", err)
 	}
 
-	// Boot initial task
-	task, err := deps.ctrl.bootInitialTask(ctx, &co, ep, container)
+	task, err := deps.runtime.BootInitialTask(ctx, sb, ep, container)
 	if err != nil {
 		return bootTaskOut{}, fmt.Errorf("booting task: %w", err)
 	}
 
-	// Get cgroups path from container spec
 	rootSpec, err := container.Spec(ctx)
 	if err != nil {
 		return bootTaskOut{}, fmt.Errorf("getting container spec: %w", err)
@@ -273,18 +241,12 @@ func undoBootTask(ctx context.Context, in bootTaskIn, _ bootTaskOut) error {
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
-
-	// Unconfigure firewall for this sandbox
-	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	sb, _, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err == nil {
-		var co compute.Sandbox
-		co.Decode(resp.Entity().Entity())
-		deps.ctrl.unconfigureFirewall(&co)
+		deps.runtime.UnconfigureFirewall(sb)
 	}
 
-	// Kill task via container
-	container, err := deps.ctrl.CC.LoadContainer(ctx, in.ContainerID)
+	container, err := deps.runtime.LoadContainer(ctx, in.ContainerID)
 	if err != nil {
 		log.Debug("saga undo: container not found for task kill", "id", in.ContainerID)
 		return nil
@@ -324,39 +286,29 @@ func bootContainers(ctx context.Context, in bootContainersIn) (bootContainersOut
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
-
-	// Fetch sandbox
-	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	sb, meta, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err != nil {
 		return bootContainersOut{}, fmt.Errorf("fetching sandbox: %w", err)
 	}
-	var co compute.Sandbox
-	co.Decode(resp.Entity().Entity())
 
-	// Rebuild endpoint config
-	ep, err := rebuildEndpointConfig(deps.ctrl, in.Addresses)
+	ep, err := deps.networking.RebuildEndpointConfig(in.Addresses)
 	if err != nil {
 		return bootContainersOut{}, fmt.Errorf("rebuilding endpoint config: %w", err)
 	}
 
-	// Build cgroups map
 	cgroups := map[string]string{"": in.Cgroups}
 
-	// Build meta
-	meta := &entity.Meta{
-		Entity:   resp.Entity().Entity(),
-		Revision: in.Revision,
+	// Use meta from entity store, override revision from saga input if provided
+	if in.Revision != 0 {
+		meta.Revision = in.Revision
 	}
 
-	// Configure volumes
-	volumeMounts, err := deps.ctrl.configureVolumes(ctx, &co, meta)
+	volumeMounts, err := deps.runtime.ConfigureVolumes(ctx, sb, meta)
 	if err != nil {
 		return bootContainersOut{}, fmt.Errorf("configuring volumes: %w", err)
 	}
 
-	// Boot app containers
-	waitPorts, err := deps.ctrl.bootContainers(ctx, &co, ep, in.TaskPID, cgroups, meta, volumeMounts)
+	waitPorts, err := deps.runtime.BootContainers(ctx, sb, ep, in.TaskPID, cgroups, meta, volumeMounts)
 	if err != nil {
 		return bootContainersOut{}, fmt.Errorf("booting containers: %w", err)
 	}
@@ -364,8 +316,8 @@ func bootContainers(ctx context.Context, in bootContainersIn) (bootContainersOut
 	var wpIDs []string
 	var wpPorts []int
 	for _, wp := range waitPorts {
-		wpIDs = append(wpIDs, wp.id)
-		wpPorts = append(wpPorts, wp.port)
+		wpIDs = append(wpIDs, wp.ID)
+		wpPorts = append(wpPorts, wp.Port)
 	}
 
 	log.Debug("saga: booted containers", "sandbox", in.SandboxID, "ports", len(waitPorts))
@@ -376,12 +328,10 @@ func undoBootContainers(ctx context.Context, in bootContainersIn, _ bootContaine
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
-	deps.ctrl.destroySubContainers(ctx, entity.Id(in.SandboxID))
+	deps.runtime.DestroySubContainers(ctx, entity.Id(in.SandboxID))
 	log.Debug("saga undo: destroyed subcontainers", "sandbox", in.SandboxID)
 
-	// Release disk leases
-	if err := deps.ctrl.releaseDiskLeases(ctx, entity.Id(in.SandboxID)); err != nil {
+	if err := deps.runtime.ReleaseDiskLeases(ctx, entity.Id(in.SandboxID)); err != nil {
 		log.Error("saga undo: failed to release disk leases", "sandbox", in.SandboxID, "error", err)
 	}
 	return nil
@@ -401,29 +351,26 @@ type addMetricsOut struct {
 func addMetrics(ctx context.Context, in addMetricsIn) (addMetricsOut, error) {
 	deps := saga.Get[*createSandboxDeps](ctx)
 
-	// Fetch sandbox for spec info
-	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	sb, _, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err != nil {
 		return addMetricsOut{}, fmt.Errorf("fetching sandbox: %w", err)
 	}
-	var co compute.Sandbox
-	co.Decode(resp.Entity().Entity())
 
-	le := co.Spec.LogEntity
+	le := sb.Spec.LogEntity
 	if le == "" {
-		le = co.ID.String()
+		le = sb.ID.String()
 	}
 
-	attrs := map[string]string{"sandbox": co.ID.String()}
-	if co.Spec.Version != "" {
-		attrs["version"] = co.Spec.Version.String()
+	attrs := map[string]string{"sandbox": sb.ID.String()}
+	if sb.Spec.Version != "" {
+		attrs["version"] = sb.Spec.Version.String()
 	}
-	for _, lbl := range co.Spec.LogAttribute {
+	for _, lbl := range sb.Spec.LogAttribute {
 		attrs[lbl.Key] = lbl.Value
 	}
 
 	cgroups := map[string]string{"": in.Cgroups}
-	if err := deps.ctrl.Metrics.Add(le, cgroups, attrs); err != nil {
+	if err := deps.obs.AddMetrics(le, cgroups, attrs); err != nil {
 		return addMetricsOut{}, fmt.Errorf("adding metrics: %w", err)
 	}
 
@@ -433,7 +380,7 @@ func addMetrics(ctx context.Context, in addMetricsIn) (addMetricsOut, error) {
 func undoAddMetrics(ctx context.Context, _ addMetricsIn, out addMetricsOut) error {
 	deps := saga.Get[*createSandboxDeps](ctx)
 	if out.LogEntity != "" {
-		deps.ctrl.Metrics.Remove(out.LogEntity)
+		deps.obs.RemoveMetrics(out.LogEntity)
 	}
 	return nil
 }
@@ -461,7 +408,7 @@ func waitPorts(ctx context.Context, in waitPortsIn) (waitPortsOut, error) {
 	}
 	for i := range in.WaitPortIDs {
 		log.Info("saga: waiting for port", "sandbox", in.SandboxID, "port", in.WaitPortPorts[i])
-		if err := deps.ctrl.waitForPort(ctx, in.WaitPortIDs[i], in.WaitPortPorts[i], portTimeout); err != nil {
+		if err := deps.runtime.WaitForPort(ctx, in.WaitPortIDs[i], in.WaitPortPorts[i], portTimeout); err != nil {
 			return waitPortsOut{}, fmt.Errorf("port %d not reachable: %w", in.WaitPortPorts[i], err)
 		}
 	}
@@ -484,31 +431,24 @@ func setRunning(ctx context.Context, in setRunningIn) (setRunningOut, error) {
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	// Fetch current status to avoid race condition
-	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	sb, _, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err != nil {
 		log.Warn("saga: failed to fetch sandbox status", "id", in.SandboxID, "error", err)
 	} else {
-		var currentSandbox compute.Sandbox
-		currentSandbox.Decode(resp.Entity().Entity())
-		if currentSandbox.Status == compute.DEAD || currentSandbox.Status == compute.STOPPED {
+		if sb.Status == compute.DEAD || sb.Status == compute.STOPPED {
 			log.Info("saga: sandbox already in terminal state",
-				"id", in.SandboxID, "status", currentSandbox.Status)
+				"id", in.SandboxID, "status", sb.Status)
 			return setRunningOut{}, nil
 		}
 	}
 
-	// Update status to RUNNING
-	result, err := deps.ctrl.EAC.Patch(ctx, entity.New(
+	patchAttrs := entity.New(
 		entity.Ref(entity.DBId, entity.Id(in.SandboxID)),
 		(&compute.Sandbox{Status: compute.RUNNING}).Encode,
-	).Attrs(), 0)
+	)
+	_, err = deps.entities.PatchSandbox(ctx, patchAttrs.Attrs(), 0)
 	if err != nil {
 		return setRunningOut{}, fmt.Errorf("setting status to RUNNING: %w", err)
-	}
-
-	if deps.ctrl.writeTracker != nil && result.HasRevision() {
-		deps.ctrl.writeTracker.RecordWrite(result.Revision())
 	}
 
 	log.Info("saga: sandbox set to RUNNING", "id", in.SandboxID)
@@ -519,17 +459,14 @@ func undoSetRunning(ctx context.Context, in setRunningIn, _ setRunningOut) error
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	result, err := deps.ctrl.EAC.Patch(ctx, entity.New(
+	patchAttrs := entity.New(
 		entity.Ref(entity.DBId, entity.Id(in.SandboxID)),
 		(&compute.Sandbox{Status: compute.DEAD}).Encode,
-	).Attrs(), 0)
+	)
+	_, err := deps.entities.PatchSandbox(ctx, patchAttrs.Attrs(), 0)
 	if err != nil {
 		log.Error("saga undo: failed to set status to DEAD", "id", in.SandboxID, "error", err)
 		return nil // best-effort
-	}
-
-	if deps.ctrl.writeTracker != nil && result.HasRevision() {
-		deps.ctrl.writeTracker.RecordWrite(result.Revision())
 	}
 	return nil
 }
@@ -547,26 +484,21 @@ type updateServicesOut struct{}
 func updateServices(ctx context.Context, in updateServicesIn) (updateServicesOut, error) {
 	deps := saga.Get[*createSandboxDeps](ctx)
 
-	// Fetch sandbox
-	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	sb, meta, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err != nil {
 		return updateServicesOut{}, fmt.Errorf("fetching sandbox: %w", err)
 	}
-	var co compute.Sandbox
-	co.Decode(resp.Entity().Entity())
 
-	// Rebuild endpoint config
-	ep, err := rebuildEndpointConfig(deps.ctrl, in.Addresses)
+	ep, err := deps.networking.RebuildEndpointConfig(in.Addresses)
 	if err != nil {
 		return updateServicesOut{}, fmt.Errorf("rebuilding endpoint config: %w", err)
 	}
 
-	meta := &entity.Meta{
-		Entity:   resp.Entity().Entity(),
-		Revision: in.Revision,
+	if in.Revision != 0 {
+		meta.Revision = in.Revision
 	}
 
-	if err := deps.ctrl.updateServices(ctx, &co, meta, ep); err != nil {
+	if err := deps.obs.UpdateServices(ctx, sb, meta, ep); err != nil {
 		return updateServicesOut{}, fmt.Errorf("updating services: %w", err)
 	}
 
@@ -574,34 +506,7 @@ func updateServices(ctx context.Context, in updateServicesIn) (updateServicesOut
 }
 
 func undoUpdateServices(_ context.Context, _ updateServicesIn, _ updateServicesOut) error {
-	// Services reconcile themselves; no explicit undo needed
 	return nil
-}
-
-// --- Helpers ---
-
-// rebuildEndpointConfig reconstructs a network.EndpointConfig from stored address strings.
-func rebuildEndpointConfig(ctrl *SandboxController, addresses []string) (*network.EndpointConfig, error) {
-	ep := &network.EndpointConfig{
-		Bridge: &network.BridgeConfig{
-			Name:      ctrl.Bridge,
-			Addresses: []netip.Prefix{ctrl.Subnet.Router()},
-		},
-	}
-
-	for _, addrStr := range addresses {
-		prefix, err := netip.ParsePrefix(addrStr)
-		if err != nil {
-			return nil, fmt.Errorf("parsing address %q: %w", addrStr, err)
-		}
-		ep.Addresses = append(ep.Addresses, prefix)
-	}
-
-	if err := ep.DeriveDefaultGateway(); err != nil {
-		return nil, fmt.Errorf("deriving default gateway: %w", err)
-	}
-
-	return ep, nil
 }
 
 // portWaitTimeout is the timeout for waiting for ports to bind.
@@ -610,14 +515,19 @@ var portWaitTimeout = 15 * time.Second
 // registerCreateSandboxSaga registers the saga definition for sandbox creation.
 func registerCreateSandboxSaga(
 	registry *saga.Registry,
-	ctrl *SandboxController,
+	entities SandboxEntityStore,
+	networking SandboxNetworking,
+	runtime SandboxContainerRuntime,
+	obs SandboxObservability,
 	log *slog.Logger,
 ) error {
 	deps := &createSandboxDeps{
-		ctrl: ctrl,
+		entities:   entities,
+		networking: networking,
+		runtime:    runtime,
+		obs:        obs,
 	}
 
-	// Build and register the saga definition
 	return saga.Define(sagaCreateSandbox).
 		Using(deps).
 		Using(log).

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -13,7 +13,6 @@ import (
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/network"
-	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/saga"
 )
@@ -34,9 +33,11 @@ const (
 
 // createSandboxDeps holds the dependencies injected into the saga context.
 // These are retrieved via saga.Get[*createSandboxDeps](ctx) within actions.
+// Note: writeTracker is accessed via ctrl.writeTracker rather than captured
+// separately, because SetWriteTracker is called after Init when the saga
+// definition is registered.
 type createSandboxDeps struct {
-	ctrl         *SandboxController
-	writeTracker controller.WriteTracker
+	ctrl *SandboxController
 }
 
 // --- Action input/output types ---
@@ -126,8 +127,8 @@ func patchNetwork(ctx context.Context, in patchNetworkIn) (patchNetworkOut, erro
 		return patchNetworkOut{}, fmt.Errorf("patching sandbox with network: %w", err)
 	}
 
-	if deps.writeTracker != nil && res.HasRevision() {
-		deps.writeTracker.RecordWrite(res.Revision())
+	if deps.ctrl.writeTracker != nil && res.HasRevision() {
+		deps.ctrl.writeTracker.RecordWrite(res.Revision())
 	}
 
 	return patchNetworkOut{Revision: res.Revision()}, nil
@@ -506,8 +507,8 @@ func setRunning(ctx context.Context, in setRunningIn) (setRunningOut, error) {
 		return setRunningOut{}, fmt.Errorf("setting status to RUNNING: %w", err)
 	}
 
-	if deps.writeTracker != nil && result.HasRevision() {
-		deps.writeTracker.RecordWrite(result.Revision())
+	if deps.ctrl.writeTracker != nil && result.HasRevision() {
+		deps.ctrl.writeTracker.RecordWrite(result.Revision())
 	}
 
 	log.Info("saga: sandbox set to RUNNING", "id", in.SandboxID)
@@ -527,8 +528,8 @@ func undoSetRunning(ctx context.Context, in setRunningIn, _ setRunningOut) error
 		return nil // best-effort
 	}
 
-	if deps.writeTracker != nil && result.HasRevision() {
-		deps.writeTracker.RecordWrite(result.Revision())
+	if deps.ctrl.writeTracker != nil && result.HasRevision() {
+		deps.ctrl.writeTracker.RecordWrite(result.Revision())
 	}
 	return nil
 }
@@ -610,12 +611,10 @@ var portWaitTimeout = 15 * time.Second
 func registerCreateSandboxSaga(
 	registry *saga.Registry,
 	ctrl *SandboxController,
-	writeTracker controller.WriteTracker,
 	log *slog.Logger,
 ) error {
 	deps := &createSandboxDeps{
-		ctrl:         ctrl,
-		writeTracker: writeTracker,
+		ctrl: ctrl,
 	}
 
 	// Build and register the saga definition

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -1,0 +1,631 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"time"
+
+	"github.com/containerd/containerd/namespaces"
+	containerd "github.com/containerd/containerd/v2/client"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/network"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// Saga action names
+const (
+	sagaCreateSandbox  = "create-sandbox"
+	actionAllocNetwork = "alloc-network"
+	actionPatchNetwork = "patch-network"
+	actionCreateCtr    = "create-container"
+	actionBootTask     = "boot-task"
+	actionBootCtrs     = "boot-containers"
+	actionAddMetrics   = "add-metrics"
+	actionWaitPorts    = "wait-ports"
+	actionSetRunning   = "set-running"
+	actionUpdateSvcs   = "update-services"
+)
+
+// createSandboxDeps holds the dependencies injected into the saga context.
+// These are retrieved via saga.Get[*createSandboxDeps](ctx) within actions.
+type createSandboxDeps struct {
+	ctrl         *SandboxController
+	writeTracker controller.WriteTracker
+}
+
+// --- Action input/output types ---
+
+type allocNetworkIn struct {
+	SandboxID string `json:"sandbox_id" saga:"sandbox_id"`
+}
+
+type allocNetworkOut struct {
+	Addresses []string `json:"addresses" saga:"addresses"`
+}
+
+func allocNetwork(ctx context.Context, in allocNetworkIn) (allocNetworkOut, error) {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	// Fetch sandbox entity to pass to allocateNetwork
+	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	if err != nil {
+		return allocNetworkOut{}, fmt.Errorf("fetching sandbox: %w", err)
+	}
+	var co compute.Sandbox
+	co.Decode(resp.Entity().Entity())
+
+	ep, err := deps.ctrl.allocateNetwork(ctx, &co)
+	if err != nil {
+		return allocNetworkOut{}, fmt.Errorf("allocating network: %w", err)
+	}
+
+	addrs := make([]string, len(ep.Addresses))
+	for i, a := range ep.Addresses {
+		addrs[i] = a.String()
+	}
+
+	log.Debug("saga: allocated network", "sandbox", in.SandboxID, "addresses", addrs)
+	return allocNetworkOut{Addresses: addrs}, nil
+}
+
+func undoAllocNetwork(ctx context.Context, in allocNetworkIn, out allocNetworkOut) error {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	for _, addrStr := range out.Addresses {
+		prefix, err := netip.ParsePrefix(addrStr)
+		if err != nil {
+			log.Error("saga undo: failed to parse address", "addr", addrStr, "error", err)
+			continue
+		}
+		if err := deps.ctrl.Subnet.ReleaseAddr(prefix.Addr()); err != nil {
+			log.Error("saga undo: failed to release IP", "addr", prefix.Addr(), "error", err)
+		} else {
+			log.Debug("saga undo: released IP", "addr", prefix.Addr())
+		}
+	}
+	return nil
+}
+
+// --- Patch network entity ---
+
+type patchNetworkIn struct {
+	SandboxID string   `json:"sandbox_id" saga:"sandbox_id"`
+	Addresses []string `json:"addresses" saga:"addresses"`
+}
+
+type patchNetworkOut struct {
+	Revision int64 `json:"revision" saga:"revision"`
+}
+
+func patchNetwork(ctx context.Context, in patchNetworkIn) (patchNetworkOut, error) {
+	deps := saga.Get[*createSandboxDeps](ctx)
+
+	// Build network components from addresses
+	var networkAttrs []any
+	networkAttrs = append(networkAttrs, entity.Ref(entity.DBId, entity.Id(in.SandboxID)))
+
+	for _, addrStr := range in.Addresses {
+		net := compute.Network{
+			Address: addrStr,
+			Subnet:  deps.ctrl.Bridge,
+		}
+		networkAttrs = append(networkAttrs, entity.Component(compute.SandboxNetworkId, net.Encode()))
+	}
+
+	patchEnt := entity.New(networkAttrs...)
+	res, err := deps.ctrl.EAC.Patch(ctx, patchEnt.Attrs(), 0)
+	if err != nil {
+		return patchNetworkOut{}, fmt.Errorf("patching sandbox with network: %w", err)
+	}
+
+	if deps.writeTracker != nil && res.HasRevision() {
+		deps.writeTracker.RecordWrite(res.Revision())
+	}
+
+	return patchNetworkOut{Revision: res.Revision()}, nil
+}
+
+func undoPatchNetwork(_ context.Context, _ patchNetworkIn, _ patchNetworkOut) error {
+	// Entity patches don't need explicit undo; the sandbox will be marked DEAD
+	return nil
+}
+
+// --- Create container (includes build spec) ---
+
+type createContainerIn struct {
+	SandboxID string   `json:"sandbox_id" saga:"sandbox_id"`
+	Addresses []string `json:"addresses" saga:"addresses"`
+	Revision  int64    `json:"revision" saga:"revision"`
+}
+
+type createContainerOut struct {
+	ContainerID string `json:"container_id" saga:"container_id"`
+}
+
+func createContainer(ctx context.Context, in createContainerIn) (createContainerOut, error) {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
+
+	// Fetch current sandbox state
+	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	if err != nil {
+		return createContainerOut{}, fmt.Errorf("fetching sandbox: %w", err)
+	}
+	var co compute.Sandbox
+	co.Decode(resp.Entity().Entity())
+
+	// Rebuild endpoint config from stored addresses
+	ep, err := rebuildEndpointConfig(deps.ctrl, in.Addresses)
+	if err != nil {
+		return createContainerOut{}, fmt.Errorf("rebuilding endpoint config: %w", err)
+	}
+
+	// Build entity meta for buildSpec
+	meta := &entity.Meta{
+		Entity:   resp.Entity().Entity(),
+		Revision: in.Revision,
+	}
+
+	// Build OCI spec
+	opts, err := deps.ctrl.buildSpec(ctx, &co, ep, meta)
+	if err != nil {
+		return createContainerOut{}, fmt.Errorf("building spec: %w", err)
+	}
+
+	// Create pause container
+	cid := pauseContainerId(co.ID)
+	_, err = deps.ctrl.CC.NewContainer(ctx, cid, opts...)
+	if err != nil {
+		return createContainerOut{}, fmt.Errorf("creating container %s: %w", co.ID, err)
+	}
+
+	log.Debug("saga: created container", "sandbox", in.SandboxID, "container", cid)
+	return createContainerOut{ContainerID: cid}, nil
+}
+
+func undoCreateContainer(ctx context.Context, _ createContainerIn, out createContainerOut) error {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	if out.ContainerID == "" {
+		return nil
+	}
+
+	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
+	container, err := deps.ctrl.CC.LoadContainer(ctx, out.ContainerID)
+	if err != nil {
+		log.Debug("saga undo: container not found, already cleaned up", "id", out.ContainerID)
+		return nil
+	}
+	deps.ctrl.cleanupContainer(ctx, container)
+	log.Debug("saga undo: deleted container", "id", out.ContainerID)
+	return nil
+}
+
+// --- Boot task ---
+
+type bootTaskIn struct {
+	SandboxID   string   `json:"sandbox_id" saga:"sandbox_id"`
+	ContainerID string   `json:"container_id" saga:"container_id"`
+	Addresses   []string `json:"addresses" saga:"addresses"`
+}
+
+type bootTaskOut struct {
+	TaskPID int    `json:"task_pid" saga:"task_pid"`
+	Cgroups string `json:"cgroups" saga:"cgroups"`
+}
+
+func bootTask(ctx context.Context, in bootTaskIn) (bootTaskOut, error) {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
+
+	// Fetch sandbox
+	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	if err != nil {
+		return bootTaskOut{}, fmt.Errorf("fetching sandbox: %w", err)
+	}
+	var co compute.Sandbox
+	co.Decode(resp.Entity().Entity())
+
+	// Rebuild endpoint config
+	ep, err := rebuildEndpointConfig(deps.ctrl, in.Addresses)
+	if err != nil {
+		return bootTaskOut{}, fmt.Errorf("rebuilding endpoint config: %w", err)
+	}
+
+	// Load container
+	container, err := deps.ctrl.CC.LoadContainer(ctx, in.ContainerID)
+	if err != nil {
+		return bootTaskOut{}, fmt.Errorf("loading container: %w", err)
+	}
+
+	// Boot initial task
+	task, err := deps.ctrl.bootInitialTask(ctx, &co, ep, container)
+	if err != nil {
+		return bootTaskOut{}, fmt.Errorf("booting task: %w", err)
+	}
+
+	// Get cgroups path from container spec
+	rootSpec, err := container.Spec(ctx)
+	if err != nil {
+		return bootTaskOut{}, fmt.Errorf("getting container spec: %w", err)
+	}
+
+	cgroups := rootSpec.Linux.CgroupsPath
+	log.Debug("saga: booted task", "sandbox", in.SandboxID, "pid", task.Pid(), "cgroups", cgroups)
+	return bootTaskOut{TaskPID: int(task.Pid()), Cgroups: cgroups}, nil
+}
+
+func undoBootTask(ctx context.Context, in bootTaskIn, _ bootTaskOut) error {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
+
+	// Unconfigure firewall for this sandbox
+	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	if err == nil {
+		var co compute.Sandbox
+		co.Decode(resp.Entity().Entity())
+		deps.ctrl.unconfigureFirewall(&co)
+	}
+
+	// Kill task via container
+	container, err := deps.ctrl.CC.LoadContainer(ctx, in.ContainerID)
+	if err != nil {
+		log.Debug("saga undo: container not found for task kill", "id", in.ContainerID)
+		return nil
+	}
+
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		log.Debug("saga undo: task not found", "id", in.ContainerID)
+		return nil
+	}
+
+	_, err = task.Delete(ctx, containerd.WithProcessKill)
+	if err != nil {
+		log.Error("saga undo: failed to kill task", "id", in.ContainerID, "error", err)
+	}
+	log.Debug("saga undo: killed task", "id", in.ContainerID)
+	return nil
+}
+
+// --- Boot containers ---
+
+type bootContainersIn struct {
+	SandboxID   string   `json:"sandbox_id" saga:"sandbox_id"`
+	ContainerID string   `json:"container_id" saga:"container_id"`
+	Addresses   []string `json:"addresses" saga:"addresses"`
+	TaskPID     int      `json:"task_pid" saga:"task_pid"`
+	Cgroups     string   `json:"cgroups" saga:"cgroups"`
+	Revision    int64    `json:"revision" saga:"revision"`
+}
+
+type bootContainersOut struct {
+	WaitPortIDs   []string `json:"wait_port_ids" saga:"wait_port_ids"`
+	WaitPortPorts []int    `json:"wait_port_ports" saga:"wait_port_ports"`
+}
+
+func bootContainers(ctx context.Context, in bootContainersIn) (bootContainersOut, error) {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
+
+	// Fetch sandbox
+	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	if err != nil {
+		return bootContainersOut{}, fmt.Errorf("fetching sandbox: %w", err)
+	}
+	var co compute.Sandbox
+	co.Decode(resp.Entity().Entity())
+
+	// Rebuild endpoint config
+	ep, err := rebuildEndpointConfig(deps.ctrl, in.Addresses)
+	if err != nil {
+		return bootContainersOut{}, fmt.Errorf("rebuilding endpoint config: %w", err)
+	}
+
+	// Build cgroups map
+	cgroups := map[string]string{"": in.Cgroups}
+
+	// Build meta
+	meta := &entity.Meta{
+		Entity:   resp.Entity().Entity(),
+		Revision: in.Revision,
+	}
+
+	// Configure volumes
+	volumeMounts, err := deps.ctrl.configureVolumes(ctx, &co, meta)
+	if err != nil {
+		return bootContainersOut{}, fmt.Errorf("configuring volumes: %w", err)
+	}
+
+	// Boot app containers
+	waitPorts, err := deps.ctrl.bootContainers(ctx, &co, ep, in.TaskPID, cgroups, meta, volumeMounts)
+	if err != nil {
+		return bootContainersOut{}, fmt.Errorf("booting containers: %w", err)
+	}
+
+	var wpIDs []string
+	var wpPorts []int
+	for _, wp := range waitPorts {
+		wpIDs = append(wpIDs, wp.id)
+		wpPorts = append(wpPorts, wp.port)
+	}
+
+	log.Debug("saga: booted containers", "sandbox", in.SandboxID, "ports", len(waitPorts))
+	return bootContainersOut{WaitPortIDs: wpIDs, WaitPortPorts: wpPorts}, nil
+}
+
+func undoBootContainers(ctx context.Context, in bootContainersIn, _ bootContainersOut) error {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	ctx = namespaces.WithNamespace(ctx, deps.ctrl.Namespace)
+	deps.ctrl.destroySubContainers(ctx, entity.Id(in.SandboxID))
+	log.Debug("saga undo: destroyed subcontainers", "sandbox", in.SandboxID)
+
+	// Release disk leases
+	if err := deps.ctrl.releaseDiskLeases(ctx, entity.Id(in.SandboxID)); err != nil {
+		log.Error("saga undo: failed to release disk leases", "sandbox", in.SandboxID, "error", err)
+	}
+	return nil
+}
+
+// --- Add metrics ---
+
+type addMetricsIn struct {
+	SandboxID string `json:"sandbox_id" saga:"sandbox_id"`
+	Cgroups   string `json:"cgroups" saga:"cgroups"`
+}
+
+type addMetricsOut struct {
+	LogEntity string `json:"log_entity" saga:"log_entity"`
+}
+
+func addMetrics(ctx context.Context, in addMetricsIn) (addMetricsOut, error) {
+	deps := saga.Get[*createSandboxDeps](ctx)
+
+	// Fetch sandbox for spec info
+	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	if err != nil {
+		return addMetricsOut{}, fmt.Errorf("fetching sandbox: %w", err)
+	}
+	var co compute.Sandbox
+	co.Decode(resp.Entity().Entity())
+
+	le := co.Spec.LogEntity
+	if le == "" {
+		le = co.ID.String()
+	}
+
+	attrs := map[string]string{"sandbox": co.ID.String()}
+	if co.Spec.Version != "" {
+		attrs["version"] = co.Spec.Version.String()
+	}
+	for _, lbl := range co.Spec.LogAttribute {
+		attrs[lbl.Key] = lbl.Value
+	}
+
+	cgroups := map[string]string{"": in.Cgroups}
+	if err := deps.ctrl.Metrics.Add(le, cgroups, attrs); err != nil {
+		return addMetricsOut{}, fmt.Errorf("adding metrics: %w", err)
+	}
+
+	return addMetricsOut{LogEntity: le}, nil
+}
+
+func undoAddMetrics(ctx context.Context, _ addMetricsIn, out addMetricsOut) error {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	if out.LogEntity != "" {
+		deps.ctrl.Metrics.Remove(out.LogEntity)
+	}
+	return nil
+}
+
+// --- Wait ports ---
+
+type waitPortsIn struct {
+	SandboxID     string   `json:"sandbox_id" saga:"sandbox_id"`
+	WaitPortIDs   []string `json:"wait_port_ids" saga:"wait_port_ids"`
+	WaitPortPorts []int    `json:"wait_port_ports" saga:"wait_port_ports"`
+}
+
+type waitPortsOut struct{}
+
+func waitPorts(ctx context.Context, in waitPortsIn) (waitPortsOut, error) {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	portTimeout := portWaitTimeout
+	for i := range in.WaitPortIDs {
+		if i >= len(in.WaitPortPorts) {
+			break
+		}
+		log.Info("saga: waiting for port", "sandbox", in.SandboxID, "port", in.WaitPortPorts[i])
+		if err := deps.ctrl.waitForPort(ctx, in.WaitPortIDs[i], in.WaitPortPorts[i], portTimeout); err != nil {
+			return waitPortsOut{}, fmt.Errorf("port %d not reachable: %w", in.WaitPortPorts[i], err)
+		}
+	}
+	return waitPortsOut{}, nil
+}
+
+func undoWaitPorts(_ context.Context, _ waitPortsIn, _ waitPortsOut) error {
+	return nil
+}
+
+// --- Set running ---
+
+type setRunningIn struct {
+	SandboxID string `json:"sandbox_id" saga:"sandbox_id"`
+}
+
+type setRunningOut struct{}
+
+func setRunning(ctx context.Context, in setRunningIn) (setRunningOut, error) {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	// Fetch current status to avoid race condition
+	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	if err != nil {
+		log.Warn("saga: failed to fetch sandbox status", "id", in.SandboxID, "error", err)
+	} else {
+		var currentSandbox compute.Sandbox
+		currentSandbox.Decode(resp.Entity().Entity())
+		if currentSandbox.Status == compute.DEAD || currentSandbox.Status == compute.STOPPED {
+			log.Info("saga: sandbox already in terminal state",
+				"id", in.SandboxID, "status", currentSandbox.Status)
+			return setRunningOut{}, nil
+		}
+	}
+
+	// Update status to RUNNING
+	result, err := deps.ctrl.EAC.Patch(ctx, entity.New(
+		entity.Ref(entity.DBId, entity.Id(in.SandboxID)),
+		(&compute.Sandbox{Status: compute.RUNNING}).Encode,
+	).Attrs(), 0)
+	if err != nil {
+		return setRunningOut{}, fmt.Errorf("setting status to RUNNING: %w", err)
+	}
+
+	if deps.writeTracker != nil && result.HasRevision() {
+		deps.writeTracker.RecordWrite(result.Revision())
+	}
+
+	log.Info("saga: sandbox set to RUNNING", "id", in.SandboxID)
+	return setRunningOut{}, nil
+}
+
+func undoSetRunning(ctx context.Context, in setRunningIn, _ setRunningOut) error {
+	deps := saga.Get[*createSandboxDeps](ctx)
+	log := saga.Get[*slog.Logger](ctx)
+
+	result, err := deps.ctrl.EAC.Patch(ctx, entity.New(
+		entity.Ref(entity.DBId, entity.Id(in.SandboxID)),
+		(&compute.Sandbox{Status: compute.DEAD}).Encode,
+	).Attrs(), 0)
+	if err != nil {
+		log.Error("saga undo: failed to set status to DEAD", "id", in.SandboxID, "error", err)
+		return nil // best-effort
+	}
+
+	if deps.writeTracker != nil && result.HasRevision() {
+		deps.writeTracker.RecordWrite(result.Revision())
+	}
+	return nil
+}
+
+// --- Update services ---
+
+type updateServicesIn struct {
+	SandboxID string   `json:"sandbox_id" saga:"sandbox_id"`
+	Addresses []string `json:"addresses" saga:"addresses"`
+	Revision  int64    `json:"revision" saga:"revision"`
+}
+
+type updateServicesOut struct{}
+
+func updateServices(ctx context.Context, in updateServicesIn) (updateServicesOut, error) {
+	deps := saga.Get[*createSandboxDeps](ctx)
+
+	// Fetch sandbox
+	resp, err := deps.ctrl.EAC.Get(ctx, in.SandboxID)
+	if err != nil {
+		return updateServicesOut{}, fmt.Errorf("fetching sandbox: %w", err)
+	}
+	var co compute.Sandbox
+	co.Decode(resp.Entity().Entity())
+
+	// Rebuild endpoint config
+	ep, err := rebuildEndpointConfig(deps.ctrl, in.Addresses)
+	if err != nil {
+		return updateServicesOut{}, fmt.Errorf("rebuilding endpoint config: %w", err)
+	}
+
+	meta := &entity.Meta{
+		Entity:   resp.Entity().Entity(),
+		Revision: in.Revision,
+	}
+
+	if err := deps.ctrl.updateServices(ctx, &co, meta, ep); err != nil {
+		return updateServicesOut{}, fmt.Errorf("updating services: %w", err)
+	}
+
+	return updateServicesOut{}, nil
+}
+
+func undoUpdateServices(_ context.Context, _ updateServicesIn, _ updateServicesOut) error {
+	// Services reconcile themselves; no explicit undo needed
+	return nil
+}
+
+// --- Helpers ---
+
+// rebuildEndpointConfig reconstructs a network.EndpointConfig from stored address strings.
+func rebuildEndpointConfig(ctrl *SandboxController, addresses []string) (*network.EndpointConfig, error) {
+	ep := &network.EndpointConfig{
+		Bridge: &network.BridgeConfig{
+			Name:      ctrl.Bridge,
+			Addresses: []netip.Prefix{ctrl.Subnet.Router()},
+		},
+	}
+
+	for _, addrStr := range addresses {
+		prefix, err := netip.ParsePrefix(addrStr)
+		if err != nil {
+			return nil, fmt.Errorf("parsing address %q: %w", addrStr, err)
+		}
+		ep.Addresses = append(ep.Addresses, prefix)
+	}
+
+	if err := ep.DeriveDefaultGateway(); err != nil {
+		return nil, fmt.Errorf("deriving default gateway: %w", err)
+	}
+
+	return ep, nil
+}
+
+// portWaitTimeout is the timeout for waiting for ports to bind.
+var portWaitTimeout = 15 * time.Second
+
+// registerCreateSandboxSaga registers the saga definition for sandbox creation.
+func registerCreateSandboxSaga(
+	registry *saga.Registry,
+	ctrl *SandboxController,
+	writeTracker controller.WriteTracker,
+	log *slog.Logger,
+) error {
+	deps := &createSandboxDeps{
+		ctrl:         ctrl,
+		writeTracker: writeTracker,
+	}
+
+	// Build and register the saga definition
+	return saga.Define(sagaCreateSandbox).
+		Using(deps).
+		Using(log).
+		Action(actionAllocNetwork, allocNetwork).Undo(undoAllocNetwork).
+		Action(actionPatchNetwork, patchNetwork).Undo(undoPatchNetwork).
+		Action(actionCreateCtr, createContainer).Undo(undoCreateContainer).
+		Action(actionBootTask, bootTask).Undo(undoBootTask).
+		Action(actionBootCtrs, bootContainers).Undo(undoBootContainers).
+		Action(actionAddMetrics, addMetrics).Undo(undoAddMetrics).
+		Action(actionWaitPorts, waitPorts).Undo(undoWaitPorts).
+		Action(actionSetRunning, setRunning).Undo(undoSetRunning).
+		Action(actionUpdateSvcs, updateServices).Undo(undoUpdateServices).
+		RegisterTo(registry)
+}

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -74,20 +74,27 @@ func allocNetwork(ctx context.Context, in allocNetworkIn) (allocNetworkOut, erro
 func undoAllocNetwork(ctx context.Context, _ allocNetworkIn, out allocNetworkOut) error {
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
+	var undoErr error
 
 	for _, addrStr := range out.Addresses {
 		prefix, err := netip.ParsePrefix(addrStr)
 		if err != nil {
 			log.Error("saga undo: failed to parse address", "addr", addrStr, "error", err)
+			if undoErr == nil {
+				undoErr = fmt.Errorf("parsing address %q: %w", addrStr, err)
+			}
 			continue
 		}
 		if err := deps.networking.ReleaseAddr(prefix.Addr()); err != nil {
 			log.Error("saga undo: failed to release IP", "addr", prefix.Addr(), "error", err)
+			if undoErr == nil {
+				undoErr = fmt.Errorf("releasing IP %s: %w", prefix.Addr(), err)
+			}
 		} else {
 			log.Debug("saga undo: released IP", "addr", prefix.Addr())
 		}
 	}
-	return nil
+	return undoErr
 }
 
 // --- Patch network entity ---
@@ -339,7 +346,7 @@ func undoBootContainers(ctx context.Context, in bootContainersIn, _ bootContaine
 	log.Debug("saga undo: destroyed subcontainers", "sandbox", in.SandboxID)
 
 	if err := deps.runtime.ReleaseDiskLeases(ctx, entity.Id(in.SandboxID)); err != nil {
-		log.Error("saga undo: failed to release disk leases", "sandbox", in.SandboxID, "error", err)
+		return fmt.Errorf("saga undo: releasing disk leases for %s: %w", in.SandboxID, err)
 	}
 	return nil
 }

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -173,6 +173,10 @@ func createContainer(ctx context.Context, in createContainerIn) (createContainer
 
 	cid, err := deps.runtime.CreateContainer(ctx, string(sb.ID), opts...)
 	if err != nil {
+		if errdefs.IsAlreadyExists(err) {
+			log.Debug("saga: container already exists", "sandbox", in.SandboxID)
+			return createContainerOut{ContainerID: pauseContainerId(sb.ID)}, nil
+		}
 		return createContainerOut{}, fmt.Errorf("creating container %s: %w", sb.ID, err)
 	}
 
@@ -271,7 +275,7 @@ func undoBootTask(ctx context.Context, in bootTaskIn, _ bootTaskOut) error {
 
 	_, err = task.Delete(ctx, containerd.WithProcessKill)
 	if err != nil {
-		log.Error("saga undo: failed to kill task", "id", in.ContainerID, "error", err)
+		return fmt.Errorf("saga undo: killing task %s: %w", in.ContainerID, err)
 	}
 	log.Debug("saga undo: killed task", "id", in.ContainerID)
 	return nil

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -278,8 +278,9 @@ type bootContainersIn struct {
 }
 
 type bootContainersOut struct {
-	WaitPortIDs   []string `json:"wait_port_ids" saga:"wait_port_ids"`
-	WaitPortPorts []int    `json:"wait_port_ports" saga:"wait_port_ports"`
+	WaitPortIDs   []string          `json:"wait_port_ids" saga:"wait_port_ids"`
+	WaitPortPorts []int             `json:"wait_port_ports" saga:"wait_port_ports"`
+	AllCgroups    map[string]string `json:"all_cgroups" saga:"all_cgroups"`
 }
 
 func bootContainers(ctx context.Context, in bootContainersIn) (bootContainersOut, error) {
@@ -321,7 +322,7 @@ func bootContainers(ctx context.Context, in bootContainersIn) (bootContainersOut
 	}
 
 	log.Debug("saga: booted containers", "sandbox", in.SandboxID, "ports", len(waitPorts))
-	return bootContainersOut{WaitPortIDs: wpIDs, WaitPortPorts: wpPorts}, nil
+	return bootContainersOut{WaitPortIDs: wpIDs, WaitPortPorts: wpPorts, AllCgroups: cgroups}, nil
 }
 
 func undoBootContainers(ctx context.Context, in bootContainersIn, _ bootContainersOut) error {
@@ -340,8 +341,8 @@ func undoBootContainers(ctx context.Context, in bootContainersIn, _ bootContaine
 // --- Add metrics ---
 
 type addMetricsIn struct {
-	SandboxID string `json:"sandbox_id" saga:"sandbox_id"`
-	Cgroups   string `json:"cgroups" saga:"cgroups"`
+	SandboxID  string            `json:"sandbox_id" saga:"sandbox_id"`
+	AllCgroups map[string]string `json:"all_cgroups" saga:"all_cgroups"`
 }
 
 type addMetricsOut struct {
@@ -369,8 +370,7 @@ func addMetrics(ctx context.Context, in addMetricsIn) (addMetricsOut, error) {
 		attrs[lbl.Key] = lbl.Value
 	}
 
-	cgroups := map[string]string{"": in.Cgroups}
-	if err := deps.obs.AddMetrics(le, cgroups, attrs); err != nil {
+	if err := deps.obs.AddMetrics(le, in.AllCgroups, attrs); err != nil {
 		return addMetricsOut{}, fmt.Errorf("adding metrics: %w", err)
 	}
 

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -406,7 +406,9 @@ type waitPortsIn struct {
 	WaitPortPorts []int    `json:"wait_port_ports" saga:"wait_port_ports"`
 }
 
-type waitPortsOut struct{}
+type waitPortsOut struct {
+	PortsReady saga.Edge `saga:"ports_ready"`
+}
 
 func waitPorts(ctx context.Context, in waitPortsIn) (waitPortsOut, error) {
 	deps := saga.Get[*createSandboxDeps](ctx)
@@ -435,7 +437,8 @@ func undoWaitPorts(_ context.Context, _ waitPortsIn, _ waitPortsOut) error {
 // --- Set running ---
 
 type setRunningIn struct {
-	SandboxID string `json:"sandbox_id" saga:"sandbox_id"`
+	SandboxID  string    `json:"sandbox_id" saga:"sandbox_id"`
+	PortsReady saga.Edge `saga:"ports_ready"`
 }
 
 type setRunningOut struct{}
@@ -476,9 +479,10 @@ func undoSetRunning(_ context.Context, _ setRunningIn, _ setRunningOut) error {
 // --- Update services ---
 
 type updateServicesIn struct {
-	SandboxID string   `json:"sandbox_id" saga:"sandbox_id"`
-	Addresses []string `json:"addresses" saga:"addresses"`
-	Revision  int64    `json:"revision" saga:"revision"`
+	SandboxID  string    `json:"sandbox_id" saga:"sandbox_id"`
+	Addresses  []string  `json:"addresses" saga:"addresses"`
+	Revision   int64     `json:"revision" saga:"revision"`
+	PortsReady saga.Edge `saga:"ports_ready"`
 }
 
 type updateServicesOut struct{}

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/errdefs"
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/pkg/entity"
@@ -182,8 +183,11 @@ func undoCreateContainer(ctx context.Context, _ createContainerIn, out createCon
 
 	container, err := deps.runtime.LoadContainer(ctx, out.ContainerID)
 	if err != nil {
-		log.Debug("saga undo: container not found, already cleaned up", "id", out.ContainerID)
-		return nil
+		if errdefs.IsNotFound(err) {
+			log.Debug("saga undo: container not found, already cleaned up", "id", out.ContainerID)
+			return nil
+		}
+		return fmt.Errorf("saga undo: loading container %s: %w", out.ContainerID, err)
 	}
 	deps.runtime.CleanupContainer(ctx, container)
 	log.Debug("saga undo: deleted container", "id", out.ContainerID)
@@ -329,7 +333,9 @@ func undoBootContainers(ctx context.Context, in bootContainersIn, _ bootContaine
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	deps.runtime.DestroySubContainers(ctx, entity.Id(in.SandboxID))
+	if err := deps.runtime.DestroySubContainers(ctx, entity.Id(in.SandboxID)); err != nil {
+		return fmt.Errorf("saga undo: destroying subcontainers for %s: %w", in.SandboxID, err)
+	}
 	log.Debug("saga undo: destroyed subcontainers", "sandbox", in.SandboxID)
 
 	if err := deps.runtime.ReleaseDiskLeases(ctx, entity.Id(in.SandboxID)); err != nil {
@@ -431,22 +437,21 @@ func setRunning(ctx context.Context, in setRunningIn) (setRunningOut, error) {
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	sb, _, err := deps.entities.GetSandbox(ctx, in.SandboxID)
+	sb, meta, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err != nil {
-		log.Warn("saga: failed to fetch sandbox status", "id", in.SandboxID, "error", err)
-	} else {
-		if sb.Status == compute.DEAD || sb.Status == compute.STOPPED {
-			log.Info("saga: sandbox already in terminal state",
-				"id", in.SandboxID, "status", sb.Status)
-			return setRunningOut{}, nil
-		}
+		return setRunningOut{}, fmt.Errorf("fetching sandbox status: %w", err)
+	}
+	if sb.Status == compute.DEAD || sb.Status == compute.STOPPED {
+		log.Info("saga: sandbox already in terminal state",
+			"id", in.SandboxID, "status", sb.Status)
+		return setRunningOut{}, nil
 	}
 
 	patchAttrs := entity.New(
 		entity.Ref(entity.DBId, entity.Id(in.SandboxID)),
 		(&compute.Sandbox{Status: compute.RUNNING}).Encode,
 	)
-	_, err = deps.entities.PatchSandbox(ctx, patchAttrs.Attrs(), 0)
+	_, err = deps.entities.PatchSandbox(ctx, patchAttrs.Attrs(), meta.Revision)
 	if err != nil {
 		return setRunningOut{}, fmt.Errorf("setting status to RUNNING: %w", err)
 	}

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -455,19 +455,9 @@ func setRunning(ctx context.Context, in setRunningIn) (setRunningOut, error) {
 	return setRunningOut{}, nil
 }
 
-func undoSetRunning(ctx context.Context, in setRunningIn, _ setRunningOut) error {
-	deps := saga.Get[*createSandboxDeps](ctx)
-	log := saga.Get[*slog.Logger](ctx)
-
-	patchAttrs := entity.New(
-		entity.Ref(entity.DBId, entity.Id(in.SandboxID)),
-		(&compute.Sandbox{Status: compute.DEAD}).Encode,
-	)
-	_, err := deps.entities.PatchSandbox(ctx, patchAttrs.Attrs(), 0)
-	if err != nil {
-		log.Error("saga undo: failed to set status to DEAD", "id", in.SandboxID, "error", err)
-		return nil // best-effort
-	}
+func undoSetRunning(_ context.Context, _ setRunningIn, _ setRunningOut) error {
+	// The controller marks the sandbox DEAD after saga failure;
+	// the undo actions only handle resource cleanup.
 	return nil
 }
 

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containerd/containerd/namespaces"
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/errdefs"
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/network"
@@ -181,10 +182,10 @@ func createContainer(ctx context.Context, in createContainerIn) (createContainer
 		return createContainerOut{}, fmt.Errorf("building spec: %w", err)
 	}
 
-	// Create pause container
+	// Create pause container (idempotent for crash replay)
 	cid := pauseContainerId(co.ID)
 	_, err = deps.ctrl.CC.NewContainer(ctx, cid, opts...)
-	if err != nil {
+	if err != nil && !errdefs.IsAlreadyExists(err) {
 		return createContainerOut{}, fmt.Errorf("creating container %s: %w", co.ID, err)
 	}
 
@@ -451,10 +452,13 @@ func waitPorts(ctx context.Context, in waitPortsIn) (waitPortsOut, error) {
 	log := saga.Get[*slog.Logger](ctx)
 
 	portTimeout := portWaitTimeout
+	if len(in.WaitPortIDs) != len(in.WaitPortPorts) {
+		return waitPortsOut{}, fmt.Errorf(
+			"wait port ids/ports mismatch: %d != %d",
+			len(in.WaitPortIDs), len(in.WaitPortPorts),
+		)
+	}
 	for i := range in.WaitPortIDs {
-		if i >= len(in.WaitPortPorts) {
-			break
-		}
 		log.Info("saga: waiting for port", "sandbox", in.SandboxID, "port", in.WaitPortPorts[i])
 		if err := deps.ctrl.waitForPort(ctx, in.WaitPortIDs[i], in.WaitPortPorts[i], portTimeout); err != nil {
 			return waitPortsOut{}, fmt.Errorf("port %d not reachable: %w", in.WaitPortPorts[i], err)

--- a/controllers/sandbox/create_saga_test.go
+++ b/controllers/sandbox/create_saga_test.go
@@ -526,8 +526,7 @@ func TestCreateSandboxSaga_CreateContainerFails(t *testing.T) {
 	exec := h.execution(t)
 	assert.Equal(t, saga.StatusFailed, exec.Status)
 
-	// allocNetwork, setRunning, patchNetwork all ran before createContainer
-	// (setRunning has no data deps beyond sandbox_id so it runs early)
+	// allocNetwork and patchNetwork ran before createContainer
 	assert.Equal(t, 1, h.networking.allocateCalls)
 	assert.GreaterOrEqual(t, len(h.entities.patchCalls), 1)
 
@@ -599,17 +598,18 @@ func TestCreateSandboxSaga_WaitPortsFails(t *testing.T) {
 	exec := h.execution(t)
 	assert.Equal(t, saga.StatusFailed, exec.Status)
 
-	// All 8 prior forward actions completed (including setRunning and updateServices
-	// which run early due to topological ordering)
+	// All prior forward actions up through wait-ports completed;
+	// set-running and update-services depend on wait-ports via Edge
+	// so they did NOT run before wait-ports failed.
 	assert.Equal(t, 1, h.networking.allocateCalls)
 	assert.Equal(t, 1, h.runtime.createContainerCalls)
 	assert.Equal(t, 1, h.runtime.bootInitialTaskCalls)
 	assert.Equal(t, 1, h.runtime.bootContainersCalls)
 	assert.Equal(t, 1, h.obs.addMetricsCalls)
+	assert.Equal(t, 0, h.obs.updateSvcsCalls, "update-services should not run before wait-ports")
 
 	// Undos run in reverse: metrics removed, subcontainers destroyed,
-	// task killed, container cleaned, IP released (plus no-op undos for
-	// setRunning, updateServices, patchNetwork)
+	// task killed, container cleaned, IP released (plus no-op undos for patchNetwork)
 	assert.Equal(t, 1, h.obs.removeMetricsCalls)
 	assert.Equal(t, 1, h.runtime.destroySubCtrsCalls)
 	assert.Equal(t, 1, h.runtime.releaseDiskLeasesCalls)

--- a/controllers/sandbox/create_saga_test.go
+++ b/controllers/sandbox/create_saga_test.go
@@ -1,0 +1,62 @@
+package sandbox
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRebuildEndpointConfigParseAddresses(t *testing.T) {
+	t.Run("valid addresses are parsed", func(t *testing.T) {
+		// We can't easily create a full SandboxController without real deps,
+		// so test the address parsing logic directly
+		addresses := []string{"10.0.0.5/32", "10.0.0.6/32"}
+		var parsed []netip.Prefix
+		for _, addrStr := range addresses {
+			prefix, err := netip.ParsePrefix(addrStr)
+			assert.NoError(t, err)
+			parsed = append(parsed, prefix)
+		}
+		assert.Equal(t, 2, len(parsed))
+		assert.Equal(t, netip.MustParsePrefix("10.0.0.5/32"), parsed[0])
+		assert.Equal(t, netip.MustParsePrefix("10.0.0.6/32"), parsed[1])
+	})
+
+	t.Run("invalid address fails", func(t *testing.T) {
+		_, err := netip.ParsePrefix("not-an-address")
+		assert.Error(t, err)
+	})
+}
+
+func TestSagaActionTypes(t *testing.T) {
+	t.Run("allocNetworkOut holds addresses", func(t *testing.T) {
+		out := allocNetworkOut{Addresses: []string{"10.0.0.1/32"}}
+		assert.Equal(t, 1, len(out.Addresses))
+	})
+
+	t.Run("createContainerOut holds container ID", func(t *testing.T) {
+		out := createContainerOut{ContainerID: "test-container"}
+		assert.Equal(t, "test-container", out.ContainerID)
+	})
+
+	t.Run("bootTaskOut holds PID and cgroups", func(t *testing.T) {
+		out := bootTaskOut{TaskPID: 1234, Cgroups: "/sys/fs/cgroup/test"}
+		assert.Equal(t, 1234, out.TaskPID)
+		assert.Equal(t, "/sys/fs/cgroup/test", out.Cgroups)
+	})
+
+	t.Run("bootContainersOut holds wait port info", func(t *testing.T) {
+		out := bootContainersOut{
+			WaitPortIDs:   []string{"id1", "id2"},
+			WaitPortPorts: []int{8080, 8443},
+		}
+		assert.Equal(t, 2, len(out.WaitPortIDs))
+		assert.Equal(t, 2, len(out.WaitPortPorts))
+	})
+}
+
+func TestSandboxLifecycleInterface(t *testing.T) {
+	var _ SandboxLifecycle = (*SandboxController)(nil)
+	var _ SandboxLifecycle = (*SagaSandboxController)(nil)
+}

--- a/controllers/sandbox/create_saga_test.go
+++ b/controllers/sandbox/create_saga_test.go
@@ -9,8 +9,6 @@ import (
 
 func TestRebuildEndpointConfigParseAddresses(t *testing.T) {
 	t.Run("valid addresses are parsed", func(t *testing.T) {
-		// We can't easily create a full SandboxController without real deps,
-		// so test the address parsing logic directly
 		addresses := []string{"10.0.0.5/32", "10.0.0.6/32"}
 		var parsed []netip.Prefix
 		for _, addrStr := range addresses {
@@ -54,9 +52,23 @@ func TestSagaActionTypes(t *testing.T) {
 		assert.Equal(t, 2, len(out.WaitPortIDs))
 		assert.Equal(t, 2, len(out.WaitPortPorts))
 	})
+
+	t.Run("WaitPort has exported fields", func(t *testing.T) {
+		wp := WaitPort{ID: "test-id", Port: 8080}
+		assert.Equal(t, "test-id", wp.ID)
+		assert.Equal(t, 8080, wp.Port)
+	})
 }
 
 func TestSandboxLifecycleInterface(t *testing.T) {
 	var _ SandboxLifecycle = (*SandboxController)(nil)
 	var _ SandboxLifecycle = (*SagaSandboxController)(nil)
 }
+
+// Compile-time interface satisfaction checks for sandboxOps.
+var (
+	_ SandboxEntityStore      = (*sandboxOps)(nil)
+	_ SandboxNetworking       = (*sandboxOps)(nil)
+	_ SandboxContainerRuntime = (*sandboxOps)(nil)
+	_ SandboxObservability    = (*sandboxOps)(nil)
+)

--- a/controllers/sandbox/create_saga_test.go
+++ b/controllers/sandbox/create_saga_test.go
@@ -1,74 +1,723 @@
 package sandbox
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"net/netip"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 
+	apitypes "github.com/containerd/containerd/api/types"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/errdefs"
+	typeurl "github.com/containerd/typeurl/v2"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/network"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/saga"
 )
 
-func TestRebuildEndpointConfigParseAddresses(t *testing.T) {
-	t.Run("valid addresses are parsed", func(t *testing.T) {
-		addresses := []string{"10.0.0.5/32", "10.0.0.6/32"}
-		var parsed []netip.Prefix
-		for _, addrStr := range addresses {
-			prefix, err := netip.ParsePrefix(addrStr)
-			assert.NoError(t, err)
-			parsed = append(parsed, prefix)
+// =============================================================================
+// Mock domain interfaces
+// =============================================================================
+
+type mockEntityStore struct {
+	mu       sync.Mutex
+	sandbox  *compute.Sandbox
+	meta     *entity.Meta
+	getCalls int
+	// patchCalls tracks each PatchSandbox call's attrs
+	patchCalls [][]entity.Attr
+	getErr     error
+	patchErr   error
+	// getSandboxFunc allows overriding GetSandbox behavior per-call
+	getSandboxFunc func(ctx context.Context, id string) (*compute.Sandbox, *entity.Meta, error)
+}
+
+func (m *mockEntityStore) GetSandbox(ctx context.Context, id string) (*compute.Sandbox, *entity.Meta, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.getCalls++
+	if m.getSandboxFunc != nil {
+		return m.getSandboxFunc(ctx, id)
+	}
+	if m.getErr != nil {
+		return nil, nil, m.getErr
+	}
+	sb := *m.sandbox
+	meta := *m.meta
+	return &sb, &meta, nil
+}
+
+func (m *mockEntityStore) PatchSandbox(ctx context.Context, attrs []entity.Attr, revision int64) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.patchErr != nil {
+		return 0, m.patchErr
+	}
+	m.patchCalls = append(m.patchCalls, attrs)
+	return revision + 1, nil
+}
+
+type mockNetworking struct {
+	mu            sync.Mutex
+	allocateCalls int
+	releaseCalls  int
+	rebuildCalls  int
+	bridgeCalls   int
+	allocateErr   error
+	releaseErr    error
+	rebuildErr    error
+	releasedAddrs []netip.Addr
+}
+
+func (m *mockNetworking) AllocateNetwork(ctx context.Context, sb *compute.Sandbox) (*network.EndpointConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.allocateCalls++
+	if m.allocateErr != nil {
+		return nil, m.allocateErr
+	}
+	return &network.EndpointConfig{
+		Addresses: []netip.Prefix{netip.MustParsePrefix("10.0.0.5/32")},
+	}, nil
+}
+
+func (m *mockNetworking) ReleaseAddr(addr netip.Addr) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releaseCalls++
+	m.releasedAddrs = append(m.releasedAddrs, addr)
+	return m.releaseErr
+}
+
+func (m *mockNetworking) RebuildEndpointConfig(addresses []string) (*network.EndpointConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rebuildCalls++
+	if m.rebuildErr != nil {
+		return nil, m.rebuildErr
+	}
+	var addrs []netip.Prefix
+	for _, a := range addresses {
+		p, err := netip.ParsePrefix(a)
+		if err != nil {
+			return nil, err
 		}
-		assert.Equal(t, 2, len(parsed))
-		assert.Equal(t, netip.MustParsePrefix("10.0.0.5/32"), parsed[0])
-		assert.Equal(t, netip.MustParsePrefix("10.0.0.6/32"), parsed[1])
-	})
-
-	t.Run("invalid address fails", func(t *testing.T) {
-		_, err := netip.ParsePrefix("not-an-address")
-		assert.Error(t, err)
-	})
+		addrs = append(addrs, p)
+	}
+	return &network.EndpointConfig{Addresses: addrs}, nil
 }
 
-func TestSagaActionTypes(t *testing.T) {
-	t.Run("allocNetworkOut holds addresses", func(t *testing.T) {
-		out := allocNetworkOut{Addresses: []string{"10.0.0.1/32"}}
-		assert.Equal(t, 1, len(out.Addresses))
-	})
+func (m *mockNetworking) BridgeName() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bridgeCalls++
+	return "br0"
+}
 
-	t.Run("createContainerOut holds container ID", func(t *testing.T) {
-		out := createContainerOut{ContainerID: "test-container"}
-		assert.Equal(t, "test-container", out.ContainerID)
-	})
+type mockContainerRuntime struct {
+	mu                       sync.Mutex
+	buildSpecCalls           int
+	createContainerCalls     int
+	loadContainerCalls       int
+	cleanupContainerCalls    int
+	bootInitialTaskCalls     int
+	configureVolumesCalls    int
+	bootContainersCalls      int
+	destroySubCtrsCalls      int
+	releaseDiskLeasesCalls   int
+	unconfigureFirewallCalls int
+	waitForPortCalls         int
 
-	t.Run("bootTaskOut holds PID and cgroups", func(t *testing.T) {
-		out := bootTaskOut{TaskPID: 1234, Cgroups: "/sys/fs/cgroup/test"}
-		assert.Equal(t, 1234, out.TaskPID)
-		assert.Equal(t, "/sys/fs/cgroup/test", out.Cgroups)
-	})
+	buildSpecErr         error
+	createContainerErr   error
+	loadContainerErr     error
+	bootInitialTaskErr   error
+	configureVolumesErr  error
+	bootContainersErr    error
+	destroySubCtrsErr    error
+	releaseDiskLeasesErr error
+	waitForPortErr       error
 
-	t.Run("bootContainersOut holds wait port info", func(t *testing.T) {
-		out := bootContainersOut{
-			WaitPortIDs:   []string{"id1", "id2"},
-			WaitPortPorts: []int{8080, 8443},
+	// loadContainerErrFunc allows per-call error control (e.g. succeed on first, ErrNotFound on second)
+	loadContainerErrFunc func(call int) error
+
+	mockContainer *sagaMockContainer
+	mockTask      *sagaMockTask
+}
+
+func (m *mockContainerRuntime) BuildSpec(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, meta *entity.Meta) ([]containerd.NewContainerOpts, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.buildSpecCalls++
+	if m.buildSpecErr != nil {
+		return nil, m.buildSpecErr
+	}
+	return []containerd.NewContainerOpts{}, nil
+}
+
+func (m *mockContainerRuntime) CreateContainer(ctx context.Context, id string, opts ...containerd.NewContainerOpts) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createContainerCalls++
+	if m.createContainerErr != nil {
+		return "", m.createContainerErr
+	}
+	return id, nil
+}
+
+func (m *mockContainerRuntime) LoadContainer(ctx context.Context, id string) (containerd.Container, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.loadContainerCalls++
+	if m.loadContainerErrFunc != nil {
+		if err := m.loadContainerErrFunc(m.loadContainerCalls); err != nil {
+			return nil, err
 		}
-		assert.Equal(t, 2, len(out.WaitPortIDs))
-		assert.Equal(t, 2, len(out.WaitPortPorts))
-	})
-
-	t.Run("WaitPort has exported fields", func(t *testing.T) {
-		wp := WaitPort{ID: "test-id", Port: 8080}
-		assert.Equal(t, "test-id", wp.ID)
-		assert.Equal(t, 8080, wp.Port)
-	})
+	}
+	if m.loadContainerErr != nil {
+		return nil, m.loadContainerErr
+	}
+	return m.mockContainer, nil
 }
 
-func TestSandboxLifecycleInterface(t *testing.T) {
-	var _ SandboxLifecycle = (*SandboxController)(nil)
-	var _ SandboxLifecycle = (*SagaSandboxController)(nil)
+func (m *mockContainerRuntime) CleanupContainer(ctx context.Context, cont containerd.Container) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cleanupContainerCalls++
 }
 
-// Compile-time interface satisfaction checks for sandboxOps.
-var (
-	_ SandboxEntityStore      = (*sandboxOps)(nil)
-	_ SandboxNetworking       = (*sandboxOps)(nil)
-	_ SandboxContainerRuntime = (*sandboxOps)(nil)
-	_ SandboxObservability    = (*sandboxOps)(nil)
-)
+func (m *mockContainerRuntime) BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container) (containerd.Task, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bootInitialTaskCalls++
+	if m.bootInitialTaskErr != nil {
+		return nil, m.bootInitialTaskErr
+	}
+	return m.mockTask, nil
+}
+
+func (m *mockContainerRuntime) ConfigureVolumes(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) (map[string]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.configureVolumesCalls++
+	if m.configureVolumesErr != nil {
+		return nil, m.configureVolumesErr
+	}
+	return map[string]string{}, nil
+}
+
+func (m *mockContainerRuntime) BootContainers(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, sbPid int, cgroups map[string]string, meta *entity.Meta, volumeMounts map[string]string) ([]WaitPort, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bootContainersCalls++
+	if m.bootContainersErr != nil {
+		return nil, m.bootContainersErr
+	}
+	return []WaitPort{{ID: "web", Port: 8080}}, nil
+}
+
+func (m *mockContainerRuntime) DestroySubContainers(ctx context.Context, id entity.Id) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.destroySubCtrsCalls++
+	return m.destroySubCtrsErr
+}
+
+func (m *mockContainerRuntime) ReleaseDiskLeases(ctx context.Context, sandboxID entity.Id) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releaseDiskLeasesCalls++
+	return m.releaseDiskLeasesErr
+}
+
+func (m *mockContainerRuntime) UnconfigureFirewall(sb *compute.Sandbox) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.unconfigureFirewallCalls++
+}
+
+func (m *mockContainerRuntime) WaitForPort(ctx context.Context, id string, port int, timeout time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.waitForPortCalls++
+	return m.waitForPortErr
+}
+
+type mockObservability struct {
+	mu                 sync.Mutex
+	addMetricsCalls    int
+	removeMetricsCalls int
+	updateSvcsCalls    int
+	addMetricsErr      error
+	updateSvcsErr      error
+
+	lastLogEntity string
+	lastCgroups   map[string]string
+	lastAttrs     map[string]string
+}
+
+func (m *mockObservability) AddMetrics(logEntity string, cgroups map[string]string, attrs map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.addMetricsCalls++
+	m.lastLogEntity = logEntity
+	m.lastCgroups = cgroups
+	m.lastAttrs = attrs
+	if m.addMetricsErr != nil {
+		return m.addMetricsErr
+	}
+	return nil
+}
+
+func (m *mockObservability) RemoveMetrics(logEntity string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removeMetricsCalls++
+}
+
+func (m *mockObservability) UpdateServices(ctx context.Context, co *compute.Sandbox, meta *entity.Meta, ep *network.EndpointConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.updateSvcsCalls++
+	return m.updateSvcsErr
+}
+
+// =============================================================================
+// Containerd mock types
+// =============================================================================
+
+type sagaMockContainer struct {
+	id     string
+	spec   *oci.Spec
+	taskFn func(context.Context, cio.Attach) (containerd.Task, error)
+}
+
+func (c *sagaMockContainer) ID() string { return c.id }
+func (c *sagaMockContainer) Info(context.Context, ...containerd.InfoOpts) (containers.Container, error) {
+	return containers.Container{}, nil
+}
+func (c *sagaMockContainer) Delete(context.Context, ...containerd.DeleteOpts) error { return nil }
+func (c *sagaMockContainer) NewTask(context.Context, cio.Creator, ...containerd.NewTaskOpts) (containerd.Task, error) {
+	return nil, nil
+}
+func (c *sagaMockContainer) Spec(ctx context.Context) (*oci.Spec, error) {
+	return c.spec, nil
+}
+func (c *sagaMockContainer) Task(ctx context.Context, attach cio.Attach) (containerd.Task, error) {
+	if c.taskFn != nil {
+		return c.taskFn(ctx, attach)
+	}
+	return nil, errdefs.ErrNotFound
+}
+func (c *sagaMockContainer) Image(context.Context) (containerd.Image, error)   { return nil, nil }
+func (c *sagaMockContainer) Labels(context.Context) (map[string]string, error) { return nil, nil }
+func (c *sagaMockContainer) SetLabels(context.Context, map[string]string) (map[string]string, error) {
+	return nil, nil
+}
+func (c *sagaMockContainer) Extensions(context.Context) (map[string]typeurl.Any, error) {
+	return nil, nil
+}
+func (c *sagaMockContainer) Update(context.Context, ...containerd.UpdateContainerOpts) error {
+	return nil
+}
+func (c *sagaMockContainer) Checkpoint(context.Context, string, ...containerd.CheckpointOpts) (containerd.Image, error) {
+	return nil, nil
+}
+
+type sagaMockTask struct {
+	pid       uint32
+	deleteErr error
+}
+
+func (t *sagaMockTask) ID() string                  { return "mock-task" }
+func (t *sagaMockTask) Pid() uint32                 { return t.pid }
+func (t *sagaMockTask) Start(context.Context) error { return nil }
+func (t *sagaMockTask) Delete(_ context.Context, _ ...containerd.ProcessDeleteOpts) (*containerd.ExitStatus, error) {
+	if t.deleteErr != nil {
+		return nil, t.deleteErr
+	}
+	return nil, nil
+}
+func (t *sagaMockTask) Kill(context.Context, syscall.Signal, ...containerd.KillOpts) error {
+	return nil
+}
+func (t *sagaMockTask) Wait(context.Context) (<-chan containerd.ExitStatus, error) {
+	return nil, nil
+}
+func (t *sagaMockTask) CloseIO(context.Context, ...containerd.IOCloserOpts) error { return nil }
+func (t *sagaMockTask) Resize(_ context.Context, _, _ uint32) error               { return nil }
+func (t *sagaMockTask) IO() cio.IO                                                { return nil }
+func (t *sagaMockTask) Status(context.Context) (containerd.Status, error) {
+	return containerd.Status{}, nil
+}
+func (t *sagaMockTask) Pause(context.Context) error  { return nil }
+func (t *sagaMockTask) Resume(context.Context) error { return nil }
+func (t *sagaMockTask) Exec(context.Context, string, *specs.Process, cio.Creator) (containerd.Process, error) {
+	return nil, nil
+}
+func (t *sagaMockTask) Pids(context.Context) ([]containerd.ProcessInfo, error) { return nil, nil }
+func (t *sagaMockTask) Checkpoint(context.Context, ...containerd.CheckpointTaskOpts) (containerd.Image, error) {
+	return nil, nil
+}
+func (t *sagaMockTask) Update(context.Context, ...containerd.UpdateTaskOpts) error { return nil }
+func (t *sagaMockTask) LoadProcess(context.Context, string, cio.Attach) (containerd.Process, error) {
+	return nil, nil
+}
+func (t *sagaMockTask) Metrics(context.Context) (*apitypes.Metric, error) { return nil, nil }
+func (t *sagaMockTask) Spec(context.Context) (*oci.Spec, error)           { return nil, nil }
+
+// =============================================================================
+// Test harness
+// =============================================================================
+
+type testHarness struct {
+	t          *testing.T
+	entities   *mockEntityStore
+	networking *mockNetworking
+	runtime    *mockContainerRuntime
+	obs        *mockObservability
+	registry   *saga.Registry
+	storage    *saga.MemoryStorage
+	executor   *saga.Executor
+	sandboxID  string
+}
+
+func newTestHarness(t *testing.T) *testHarness {
+	t.Helper()
+
+	sandboxID := "test-sandbox-1"
+
+	mockCtr := &sagaMockContainer{
+		id: sandboxID,
+		spec: &oci.Spec{
+			Linux: &specs.Linux{
+				CgroupsPath: "/sys/fs/cgroup/sandbox/test-sandbox-1",
+			},
+		},
+	}
+	mockTsk := &sagaMockTask{pid: 4242}
+
+	sb := &compute.Sandbox{
+		ID:     entity.Id(sandboxID),
+		Status: compute.PENDING,
+		Spec: compute.SandboxSpec{
+			Version: entity.Id("v1"),
+		},
+	}
+
+	meta := &entity.Meta{
+		Entity:   entity.New(entity.Ref(entity.DBId, entity.Id(sandboxID))),
+		Revision: 1,
+	}
+
+	h := &testHarness{
+		t:         t,
+		sandboxID: sandboxID,
+		entities: &mockEntityStore{
+			sandbox: sb,
+			meta:    meta,
+		},
+		networking: &mockNetworking{},
+		runtime: &mockContainerRuntime{
+			mockContainer: mockCtr,
+			mockTask:      mockTsk,
+		},
+		obs:      &mockObservability{},
+		registry: saga.NewRegistry(),
+		storage:  saga.NewMemoryStorage(),
+	}
+
+	// Register the saga definition
+	log := slog.Default()
+	err := registerCreateSandboxSaga(h.registry, h.entities, h.networking, h.runtime, h.obs, log)
+	require.NoError(t, err)
+
+	h.executor = saga.NewExecutor(h.storage, saga.WithRegistry(h.registry), saga.WithLogger(log))
+	return h
+}
+
+func (h *testHarness) execute(t *testing.T) error {
+	t.Helper()
+	ctx := context.Background()
+	return h.executor.Start(sagaCreateSandbox).
+		Input("sandbox_id", h.sandboxID).
+		WithID("test-exec-1").
+		Execute(ctx)
+}
+
+func (h *testHarness) execution(t *testing.T) *saga.Execution {
+	t.Helper()
+	exec, err := h.storage.Get(context.Background(), "test-exec-1")
+	require.NoError(t, err)
+	return exec
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+func TestCreateSandboxSaga_HappyPath(t *testing.T) {
+	h := newTestHarness(t)
+
+	err := h.execute(t)
+	require.NoError(t, err)
+
+	exec := h.execution(t)
+	assert.Equal(t, saga.StatusCompleted, exec.Status)
+
+	// All forward actions called
+	assert.Equal(t, 1, h.networking.allocateCalls)
+	assert.GreaterOrEqual(t, h.entities.getCalls, 1)
+	assert.GreaterOrEqual(t, len(h.entities.patchCalls), 1) // patchNetwork + setRunning
+	assert.Equal(t, 1, h.runtime.createContainerCalls)
+	assert.Equal(t, 1, h.runtime.bootInitialTaskCalls)
+	assert.Equal(t, 1, h.runtime.configureVolumesCalls)
+	assert.Equal(t, 1, h.runtime.bootContainersCalls)
+	assert.Equal(t, 1, h.runtime.waitForPortCalls)
+	assert.Equal(t, 1, h.obs.addMetricsCalls)
+	assert.Equal(t, 1, h.obs.updateSvcsCalls)
+
+	// No undo actions called
+	assert.Equal(t, 0, h.networking.releaseCalls)
+	assert.Equal(t, 0, h.runtime.cleanupContainerCalls)
+	assert.Equal(t, 0, h.runtime.destroySubCtrsCalls)
+	assert.Equal(t, 0, h.obs.removeMetricsCalls)
+}
+
+func TestCreateSandboxSaga_AllocNetworkFails(t *testing.T) {
+	h := newTestHarness(t)
+	h.networking.allocateErr = fmt.Errorf("no IPs available")
+
+	err := h.execute(t)
+	require.Error(t, err)
+
+	exec := h.execution(t)
+	assert.Equal(t, saga.StatusFailed, exec.Status)
+
+	// Only allocNetwork was attempted
+	assert.Equal(t, 1, h.networking.allocateCalls)
+	// No later forward actions ran
+	assert.Equal(t, 0, h.runtime.createContainerCalls)
+	assert.Equal(t, 0, h.runtime.bootInitialTaskCalls)
+	// No undos needed (nothing to compensate)
+	assert.Equal(t, 0, h.networking.releaseCalls)
+}
+
+func TestCreateSandboxSaga_CreateContainerFails(t *testing.T) {
+	h := newTestHarness(t)
+	h.runtime.createContainerErr = fmt.Errorf("image not found")
+
+	err := h.execute(t)
+	require.Error(t, err)
+
+	exec := h.execution(t)
+	assert.Equal(t, saga.StatusFailed, exec.Status)
+
+	// allocNetwork, setRunning, patchNetwork all ran before createContainer
+	// (setRunning has no data deps beyond sandbox_id so it runs early)
+	assert.Equal(t, 1, h.networking.allocateCalls)
+	assert.GreaterOrEqual(t, len(h.entities.patchCalls), 1)
+
+	// createContainer failed, no later actions
+	assert.Equal(t, 1, h.runtime.createContainerCalls)
+	assert.Equal(t, 0, h.runtime.bootInitialTaskCalls)
+
+	// Undo: IP released (undoAllocNetwork); other undos are no-ops
+	assert.Equal(t, 1, h.networking.releaseCalls)
+}
+
+func TestCreateSandboxSaga_BootTaskFails(t *testing.T) {
+	h := newTestHarness(t)
+	h.runtime.bootInitialTaskErr = fmt.Errorf("cgroup limit exceeded")
+
+	err := h.execute(t)
+	require.Error(t, err)
+
+	exec := h.execution(t)
+	assert.Equal(t, saga.StatusFailed, exec.Status)
+
+	// Container was created, bootTask loaded it then failed
+	assert.Equal(t, 1, h.runtime.createContainerCalls)
+	assert.GreaterOrEqual(t, h.runtime.loadContainerCalls, 1)
+
+	// bootTask failed so its undo is skipped. undoCreateContainer runs
+	// (loads container again + cleans up), and undoAllocNetwork releases IP.
+	assert.Equal(t, 1, h.runtime.cleanupContainerCalls)
+	assert.Equal(t, 1, h.networking.releaseCalls)
+}
+
+func TestCreateSandboxSaga_BootContainersFails(t *testing.T) {
+	h := newTestHarness(t)
+	h.runtime.bootContainersErr = fmt.Errorf("port already in use")
+
+	// Set up container mock's Task() to return the mock task for undo
+	h.runtime.mockContainer.taskFn = func(ctx context.Context, attach cio.Attach) (containerd.Task, error) {
+		return h.runtime.mockTask, nil
+	}
+
+	err := h.execute(t)
+	require.Error(t, err)
+
+	exec := h.execution(t)
+	assert.Equal(t, saga.StatusFailed, exec.Status)
+
+	// undoBootTask: firewall unconfigured, task killed
+	assert.Equal(t, 1, h.runtime.unconfigureFirewallCalls)
+
+	// undoCreateContainer: container cleaned up
+	assert.Equal(t, 1, h.runtime.cleanupContainerCalls)
+
+	// undoAllocNetwork: IP released
+	assert.Equal(t, 1, h.networking.releaseCalls)
+}
+
+func TestCreateSandboxSaga_WaitPortsFails(t *testing.T) {
+	h := newTestHarness(t)
+	h.runtime.waitForPortErr = fmt.Errorf("port 8080 not reachable")
+
+	// Set up container Task() for undo
+	h.runtime.mockContainer.taskFn = func(ctx context.Context, attach cio.Attach) (containerd.Task, error) {
+		return h.runtime.mockTask, nil
+	}
+
+	err := h.execute(t)
+	require.Error(t, err)
+
+	exec := h.execution(t)
+	assert.Equal(t, saga.StatusFailed, exec.Status)
+
+	// All 8 prior forward actions completed (including setRunning and updateServices
+	// which run early due to topological ordering)
+	assert.Equal(t, 1, h.networking.allocateCalls)
+	assert.Equal(t, 1, h.runtime.createContainerCalls)
+	assert.Equal(t, 1, h.runtime.bootInitialTaskCalls)
+	assert.Equal(t, 1, h.runtime.bootContainersCalls)
+	assert.Equal(t, 1, h.obs.addMetricsCalls)
+
+	// Undos run in reverse: metrics removed, subcontainers destroyed,
+	// task killed, container cleaned, IP released (plus no-op undos for
+	// setRunning, updateServices, patchNetwork)
+	assert.Equal(t, 1, h.obs.removeMetricsCalls)
+	assert.Equal(t, 1, h.runtime.destroySubCtrsCalls)
+	assert.Equal(t, 1, h.runtime.releaseDiskLeasesCalls)
+	assert.Equal(t, 1, h.runtime.unconfigureFirewallCalls)
+	assert.Equal(t, 1, h.runtime.cleanupContainerCalls)
+	assert.Equal(t, 1, h.networking.releaseCalls)
+}
+
+func TestCreateSandboxSaga_UndoContainerAlreadyGone(t *testing.T) {
+	h := newTestHarness(t)
+	h.runtime.bootInitialTaskErr = fmt.Errorf("task boot failed")
+
+	// LoadContainer succeeds on first call (forward bootTask), returns NotFound on second (undo)
+	h.runtime.loadContainerErrFunc = func(call int) error {
+		if call >= 2 {
+			return errdefs.ErrNotFound
+		}
+		return nil
+	}
+
+	err := h.execute(t)
+	require.Error(t, err)
+
+	exec := h.execution(t)
+	assert.Equal(t, saga.StatusFailed, exec.Status)
+
+	// undoCreateContainer ran but container was not found — should not panic
+	// IP still released
+	assert.Equal(t, 1, h.networking.releaseCalls)
+	// CleanupContainer was not called since container was not found
+	assert.Equal(t, 0, h.runtime.cleanupContainerCalls)
+}
+
+func TestCreateSandboxSaga_UndoTaskAlreadyGone(t *testing.T) {
+	h := newTestHarness(t)
+	h.runtime.bootContainersErr = fmt.Errorf("containers failed")
+
+	// Task() returns NotFound during undo (task already gone)
+	h.runtime.mockContainer.taskFn = func(ctx context.Context, attach cio.Attach) (containerd.Task, error) {
+		return nil, errdefs.ErrNotFound
+	}
+
+	err := h.execute(t)
+	require.Error(t, err)
+
+	exec := h.execution(t)
+	assert.Equal(t, saga.StatusFailed, exec.Status)
+
+	// undoBootTask ran: firewall still unconfigured even though task not found
+	assert.Equal(t, 1, h.runtime.unconfigureFirewallCalls)
+
+	// Other undos still ran
+	assert.Equal(t, 1, h.runtime.cleanupContainerCalls)
+	assert.Equal(t, 1, h.networking.releaseCalls)
+}
+
+func TestCreateSandboxSaga_SetRunningSkipsTerminalStatus(t *testing.T) {
+	h := newTestHarness(t)
+
+	// Sandbox is already DEAD — setRunning should skip the RUNNING patch
+	h.entities.sandbox.Status = compute.DEAD
+
+	err := h.execute(t)
+	require.NoError(t, err)
+
+	exec := h.execution(t)
+	assert.Equal(t, saga.StatusCompleted, exec.Status)
+
+	// Verify setRunning actually executed (it's in the execution log)
+	assert.Contains(t, exec.ExecutionOrder, actionSetRunning,
+		"setRunning should have executed")
+
+	// Check that no RUNNING status patch was issued.
+	// patchNetwork always runs; setRunning should have skipped the patch
+	// because the sandbox was in terminal DEAD state.
+	runningPatchFound := false
+	for _, attrs := range h.entities.patchCalls {
+		for _, attr := range attrs {
+			if attr.ID == compute.SandboxStatusRunningId {
+				runningPatchFound = true
+			}
+		}
+	}
+	assert.False(t, runningPatchFound, "should not have patched RUNNING status when sandbox is DEAD")
+}
+
+func TestCreateSandboxSaga_MetricsAttributes(t *testing.T) {
+	h := newTestHarness(t)
+
+	// Configure sandbox with specific log attributes
+	h.entities.sandbox.Spec.LogEntity = "my-app"
+	h.entities.sandbox.Spec.Version = entity.Id("v42")
+	h.entities.sandbox.Spec.LogAttribute = types.Labels{
+		{Key: "env", Value: "production"},
+		{Key: "region", Value: "us-east"},
+	}
+
+	err := h.execute(t)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, h.obs.addMetricsCalls)
+	assert.Equal(t, "my-app", h.obs.lastLogEntity)
+	assert.Equal(t, h.sandboxID, h.obs.lastAttrs["sandbox"])
+	assert.Equal(t, "v42", h.obs.lastAttrs["version"])
+	assert.Equal(t, "production", h.obs.lastAttrs["env"])
+	assert.Equal(t, "us-east", h.obs.lastAttrs["region"])
+
+	// Verify cgroups map includes root cgroup
+	assert.Contains(t, h.obs.lastCgroups, "")
+	assert.Equal(t, "/sys/fs/cgroup/sandbox/test-sandbox-1", h.obs.lastCgroups[""])
+}

--- a/controllers/sandbox/firewall.go
+++ b/controllers/sandbox/firewall.go
@@ -84,7 +84,7 @@ func (c *SandboxController) configurePort(p compute.SandboxSpecContainerPort, ep
 	return nil
 }
 
-func (c *SandboxController) unconfigureFirewall(sb *compute.Sandbox) {
+func (c *SandboxController) UnconfigureFirewall(sb *compute.Sandbox) {
 	if len(sb.Network) == 0 {
 		c.Log.Warn("no network info on sandbox, skipping firewall cleanup", "sandbox", sb.ID.String())
 		return

--- a/controllers/sandbox/firewall_darwin.go
+++ b/controllers/sandbox/firewall_darwin.go
@@ -11,5 +11,5 @@ func (c *SandboxController) configureFirewall(sb *compute.Sandbox, ep *network.E
 	return nil
 }
 
-func (c *SandboxController) unconfigureFirewall(sb *compute.Sandbox) {
+func (c *SandboxController) UnconfigureFirewall(sb *compute.Sandbox) {
 }

--- a/controllers/sandbox/interface.go
+++ b/controllers/sandbox/interface.go
@@ -2,9 +2,13 @@ package sandbox
 
 import (
 	"context"
+	"net/netip"
 	"time"
 
+	containerd "github.com/containerd/containerd/v2/client"
+
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/network"
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
@@ -20,4 +24,40 @@ type SandboxLifecycle interface {
 	Periodic(ctx context.Context, timeHorizon time.Duration) error
 	SetWriteTracker(wt controller.WriteTracker)
 	SetPortStatus(id string, port observability.BoundPort, status observability.PortStatus)
+}
+
+// SandboxEntityStore provides entity read/write operations with write tracking.
+type SandboxEntityStore interface {
+	GetSandbox(ctx context.Context, id string) (*compute.Sandbox, *entity.Meta, error)
+	PatchSandbox(ctx context.Context, attrs []entity.Attr, revision int64) (int64, error)
+}
+
+// SandboxNetworking provides network allocation and configuration.
+type SandboxNetworking interface {
+	AllocateNetwork(ctx context.Context, sb *compute.Sandbox) (*network.EndpointConfig, error)
+	ReleaseAddr(addr netip.Addr) error
+	RebuildEndpointConfig(addresses []string) (*network.EndpointConfig, error)
+	BridgeName() string
+}
+
+// SandboxContainerRuntime provides containerd container operations.
+type SandboxContainerRuntime interface {
+	BuildSpec(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, meta *entity.Meta) ([]containerd.NewContainerOpts, error)
+	CreateContainer(ctx context.Context, id string, opts ...containerd.NewContainerOpts) (string, error)
+	LoadContainer(ctx context.Context, id string) (containerd.Container, error)
+	CleanupContainer(ctx context.Context, cont containerd.Container)
+	BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container) (containerd.Task, error)
+	ConfigureVolumes(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) (map[string]string, error)
+	BootContainers(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, sbPid int, cgroups map[string]string, meta *entity.Meta, volumeMounts map[string]string) ([]WaitPort, error)
+	DestroySubContainers(ctx context.Context, id entity.Id) error
+	ReleaseDiskLeases(ctx context.Context, sandboxID entity.Id) error
+	UnconfigureFirewall(sb *compute.Sandbox)
+	WaitForPort(ctx context.Context, id string, port int, timeout time.Duration) error
+}
+
+// SandboxObservability provides metrics and service management.
+type SandboxObservability interface {
+	AddMetrics(logEntity string, cgroups map[string]string, attrs map[string]string) error
+	RemoveMetrics(logEntity string)
+	UpdateServices(ctx context.Context, co *compute.Sandbox, meta *entity.Meta, ep *network.EndpointConfig) error
 }

--- a/controllers/sandbox/interface.go
+++ b/controllers/sandbox/interface.go
@@ -1,0 +1,23 @@
+package sandbox
+
+import (
+	"context"
+	"time"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/observability"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// SandboxLifecycle defines the interface for sandbox lifecycle management.
+// Both SandboxController and SagaSandboxController implement this interface.
+type SandboxLifecycle interface {
+	Init(ctx context.Context) error
+	Create(ctx context.Context, co *compute.Sandbox, meta *entity.Meta) error
+	Delete(ctx context.Context, id entity.Id, sb *compute.Sandbox) error
+	Close() error
+	Periodic(ctx context.Context, timeHorizon time.Duration) error
+	SetWriteTracker(wt controller.WriteTracker)
+	SetPortStatus(id string, port observability.BoundPort, status observability.PortStatus)
+}

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -19,6 +19,7 @@ import (
 // saga-based implementation.
 type SagaSandboxController struct {
 	inner    *SandboxController
+	ops      *sandboxOps
 	executor *saga.Executor
 	registry *saga.Registry
 	log      *slog.Logger
@@ -30,7 +31,6 @@ func NewSagaSandboxController(
 	storage saga.Storage,
 	log *slog.Logger,
 ) (*SagaSandboxController, error) {
-	// Create the inner controller
 	inner, err := NewSandboxController(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating inner controller: %w", err)
@@ -44,6 +44,7 @@ func NewSagaSandboxController(
 
 	return &SagaSandboxController{
 		inner:    inner,
+		ops:      &sandboxOps{ctrl: inner},
 		executor: executor,
 		registry: registry,
 		log:      log.With("module", "saga-sandbox-controller"),
@@ -56,17 +57,13 @@ func (s *SagaSandboxController) Init(ctx context.Context) error {
 		return err
 	}
 
-	// Register saga definition — writeTracker is resolved at execution time
-	// via deps.ctrl.writeTracker since SetWriteTracker is called after Init.
-	if err := registerCreateSandboxSaga(s.registry, s.inner, s.log); err != nil {
+	if err := registerCreateSandboxSaga(s.registry, s.ops, s.ops, s.ops, s.ops, s.log); err != nil {
 		return fmt.Errorf("registering create-sandbox saga: %w", err)
 	}
 
 	// Recover any incomplete sagas from a previous crash
 	if err := s.executor.Recover(ctx); err != nil {
 		s.log.Error("saga recovery completed with errors", "error", err)
-		// Don't fail Init - we want the controller to start even if some
-		// recovery operations failed. They'll be retried on the next restart.
 	}
 
 	return nil
@@ -82,15 +79,14 @@ func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox,
 		return nil
 	case compute.STOPPED:
 		s.log.Debug("sandbox is stopped, verifying it is no longer running")
-		return s.inner.stopSandbox(ctx, co.ID)
+		return s.inner.StopSandbox(ctx, co.ID)
 	case "", compute.PENDING, compute.RUNNING:
-		searchRes, err := s.inner.checkSandbox(ctx, co, meta)
+		searchRes, err := s.inner.CheckSandbox(ctx, co, meta)
 		if err != nil {
 			s.log.Error("error checking sandbox, proceeding with create", "err", err)
 		} else {
 			switch searchRes {
 			case same:
-				// Handle stale PENDING status correction
 				if co.Status == compute.PENDING {
 					createdAt := meta.GetCreatedAt()
 					age := time.Since(createdAt)
@@ -103,12 +99,9 @@ func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox,
 							entity.Ref(entity.DBId, co.ID),
 							(&compute.Sandbox{Status: compute.RUNNING}).Encode,
 						)
-						result, err := s.inner.EAC.Patch(ctx, patchAttrs.Attrs(), meta.Revision)
+						_, err := s.ops.PatchSandbox(ctx, patchAttrs.Attrs(), meta.Revision)
 						if err != nil {
 							return fmt.Errorf("failed to update sandbox status to RUNNING: %w", err)
-						}
-						if s.inner.writeTracker != nil && result.HasRevision() {
-							s.inner.writeTracker.RecordWrite(result.Revision())
 						}
 						return nil
 					}
@@ -127,16 +120,13 @@ func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox,
 						entity.Ref(entity.DBId, co.ID),
 						(&compute.Sandbox{Status: compute.DEAD}).Encode,
 					)
-					result, err := s.inner.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
+					_, err := s.ops.PatchSandbox(ctx, patchAttrs.Attrs(), 0)
 					if err != nil {
 						return fmt.Errorf("failed to mark sandbox as DEAD: %w", err)
 					}
-					if s.inner.writeTracker != nil && result.HasRevision() {
-						s.inner.writeTracker.RecordWrite(result.Revision())
-					}
 				}
 
-				if err := s.inner.stopSandbox(ctx, co.ID); err != nil {
+				if err := s.inner.StopSandbox(ctx, co.ID); err != nil {
 					return fmt.Errorf("failed to cleanup unhealthy sandbox: %w", err)
 				}
 				return nil

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -1,0 +1,189 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/observability"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// SagaSandboxController implements SandboxLifecycle using the saga pattern
+// for crash-recoverable sandbox creation. It wraps an inner SandboxController
+// and delegates most operations to it, replacing only createSandbox with a
+// saga-based implementation.
+type SagaSandboxController struct {
+	inner    *SandboxController
+	executor *saga.Executor
+	registry *saga.Registry
+	log      *slog.Logger
+}
+
+// NewSagaSandboxController creates a saga-based sandbox controller.
+func NewSagaSandboxController(
+	cfg SandboxControllerDeps,
+	storage saga.Storage,
+	log *slog.Logger,
+) (*SagaSandboxController, error) {
+	// Create the inner controller
+	inner, err := NewSandboxController(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating inner controller: %w", err)
+	}
+
+	registry := saga.NewRegistry()
+	executor := saga.NewExecutor(storage,
+		saga.WithRegistry(registry),
+		saga.WithLogger(log.With("module", "saga-sandbox")),
+	)
+
+	return &SagaSandboxController{
+		inner:    inner,
+		executor: executor,
+		registry: registry,
+		log:      log.With("module", "saga-sandbox-controller"),
+	}, nil
+}
+
+// Init initializes the sandbox controller and registers saga definitions.
+func (s *SagaSandboxController) Init(ctx context.Context) error {
+	if err := s.inner.Init(ctx); err != nil {
+		return err
+	}
+
+	// Register saga definition after Init so writeTracker is available
+	if err := registerCreateSandboxSaga(s.registry, s.inner, s.inner.writeTracker, s.log); err != nil {
+		return fmt.Errorf("registering create-sandbox saga: %w", err)
+	}
+
+	// Recover any incomplete sagas from a previous crash
+	if err := s.executor.Recover(ctx); err != nil {
+		s.log.Error("saga recovery completed with errors", "error", err)
+		// Don't fail Init - we want the controller to start even if some
+		// recovery operations failed. They'll be retried on the next restart.
+	}
+
+	return nil
+}
+
+// Create handles sandbox create/update events. For new sandboxes, it uses
+// the saga-based creation flow.
+func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox, meta *entity.Meta) error {
+	s.log.Info("considering sandbox create or update (saga)", "id", co.ID, "status", co.Status)
+
+	switch co.Status {
+	case compute.DEAD:
+		return nil
+	case compute.STOPPED:
+		s.log.Debug("sandbox is stopped, verifying it is no longer running")
+		return s.inner.stopSandbox(ctx, co.ID)
+	case "", compute.PENDING, compute.RUNNING:
+		searchRes, err := s.inner.checkSandbox(ctx, co, meta)
+		if err != nil {
+			s.log.Error("error checking sandbox, proceeding with create", "err", err)
+		} else {
+			switch searchRes {
+			case same:
+				// Handle stale PENDING status correction
+				if co.Status == compute.PENDING {
+					createdAt := meta.GetCreatedAt()
+					age := time.Since(createdAt)
+					const staleThreshold = 2 * time.Minute
+
+					if age > staleThreshold {
+						s.log.Info("sandbox exists and is healthy but status is PENDING (stale), updating to RUNNING",
+							"id", co.ID, "createdAt", createdAt, "age", age)
+						patchAttrs := entity.New(
+							entity.Ref(entity.DBId, co.ID),
+							(&compute.Sandbox{Status: compute.RUNNING}).Encode,
+						)
+						_, err := s.inner.EAC.Patch(ctx, patchAttrs.Attrs(), meta.Revision)
+						if err != nil {
+							return fmt.Errorf("failed to update sandbox status to RUNNING: %w", err)
+						}
+						return nil
+					}
+					s.log.Debug("sandbox is PENDING but recently created, skipping",
+						"id", co.ID, "age", age)
+					return nil
+				}
+				s.log.Debug("sandbox already exists, skipping create")
+				return nil
+			case unhealthy:
+				s.log.Info("sandbox container exists but is unhealthy", "id", co.ID)
+
+				if co.Status == compute.RUNNING {
+					s.log.Info("marking unhealthy sandbox as DEAD", "id", co.ID)
+					patchAttrs := entity.New(
+						entity.Ref(entity.DBId, co.ID),
+						(&compute.Sandbox{Status: compute.DEAD}).Encode,
+					)
+					result, err := s.inner.EAC.Patch(ctx, patchAttrs.Attrs(), 0)
+					if err != nil {
+						return fmt.Errorf("failed to mark sandbox as DEAD: %w", err)
+					}
+					if s.inner.writeTracker != nil && result.HasRevision() {
+						s.inner.writeTracker.RecordWrite(result.Revision())
+					}
+				}
+
+				if err := s.inner.stopSandbox(ctx, co.ID); err != nil {
+					return fmt.Errorf("failed to cleanup unhealthy sandbox: %w", err)
+				}
+				return nil
+			}
+		}
+
+		return s.createSandboxViaSaga(ctx, co)
+	default:
+		s.log.Warn("ignoring sandbox status", "status", co.Status)
+		return nil
+	}
+}
+
+// createSandboxViaSaga runs sandbox creation as a saga for crash recovery.
+func (s *SagaSandboxController) createSandboxViaSaga(ctx context.Context, co *compute.Sandbox) error {
+	s.log.Info("creating sandbox via saga", "id", co.ID)
+
+	err := s.executor.Start(sagaCreateSandbox).
+		Input("sandbox_id", co.ID.String()).
+		WithID(fmt.Sprintf("create-sandbox-%s", co.ID)).
+		Execute(ctx)
+
+	if err != nil {
+		s.log.Error("saga sandbox creation failed", "id", co.ID, "error", err)
+		return fmt.Errorf("saga sandbox creation failed: %w", err)
+	}
+
+	return nil
+}
+
+// Delete delegates to the inner controller.
+func (s *SagaSandboxController) Delete(ctx context.Context, id entity.Id, sb *compute.Sandbox) error {
+	return s.inner.Delete(ctx, id, sb)
+}
+
+// Close shuts down the inner controller.
+func (s *SagaSandboxController) Close() error {
+	return s.inner.Close()
+}
+
+// Periodic delegates to the inner controller.
+func (s *SagaSandboxController) Periodic(ctx context.Context, timeHorizon time.Duration) error {
+	return s.inner.Periodic(ctx, timeHorizon)
+}
+
+// SetWriteTracker sets the write tracker on both the saga controller and inner controller.
+func (s *SagaSandboxController) SetWriteTracker(wt controller.WriteTracker) {
+	s.inner.SetWriteTracker(wt)
+}
+
+// SetPortStatus delegates to the inner controller.
+func (s *SagaSandboxController) SetPortStatus(id string, port observability.BoundPort, status observability.PortStatus) {
+	s.inner.SetPortStatus(id, port, status)
+}

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -56,8 +56,9 @@ func (s *SagaSandboxController) Init(ctx context.Context) error {
 		return err
 	}
 
-	// Register saga definition after Init so writeTracker is available
-	if err := registerCreateSandboxSaga(s.registry, s.inner, s.inner.writeTracker, s.log); err != nil {
+	// Register saga definition — writeTracker is resolved at execution time
+	// via deps.ctrl.writeTracker since SetWriteTracker is called after Init.
+	if err := registerCreateSandboxSaga(s.registry, s.inner, s.log); err != nil {
 		return fmt.Errorf("registering create-sandbox saga: %w", err)
 	}
 

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -150,7 +150,22 @@ func (s *SagaSandboxController) createSandboxViaSaga(ctx context.Context, co *co
 		Execute(ctx)
 
 	if err != nil {
-		s.log.Error("saga sandbox creation failed", "id", co.ID, "error", err)
+		s.log.Error("saga sandbox creation failed, marking DEAD", "id", co.ID, "error", err)
+
+		// Saga compensating actions handle resource cleanup. The controller
+		// owns the domain-level outcome: mark the sandbox DEAD so the pool
+		// replaces it rather than retrying the same entity.
+		// NOTE: this runs at the call site, so a crash between saga completion
+		// and this patch leaves the entity PENDING (retried by reconciler).
+		// Durable saga outcome declaration is future work.
+		patchAttrs := entity.New(
+			entity.Ref(entity.DBId, co.ID),
+			(&compute.Sandbox{Status: compute.DEAD}).Encode,
+		)
+		if _, patchErr := s.ops.PatchSandbox(ctx, patchAttrs.Attrs(), 0); patchErr != nil {
+			s.log.Error("failed to mark sandbox DEAD after saga failure", "id", co.ID, "error", patchErr)
+		}
+
 		return fmt.Errorf("saga sandbox creation failed: %w", err)
 	}
 

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -102,9 +102,12 @@ func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox,
 							entity.Ref(entity.DBId, co.ID),
 							(&compute.Sandbox{Status: compute.RUNNING}).Encode,
 						)
-						_, err := s.inner.EAC.Patch(ctx, patchAttrs.Attrs(), meta.Revision)
+						result, err := s.inner.EAC.Patch(ctx, patchAttrs.Attrs(), meta.Revision)
 						if err != nil {
 							return fmt.Errorf("failed to update sandbox status to RUNNING: %w", err)
+						}
+						if s.inner.writeTracker != nil && result.HasRevision() {
+							s.inner.writeTracker.RecordWrite(result.Revision())
 						}
 						return nil
 					}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -209,7 +209,7 @@ func (c *SandboxController) SetPortStatus(id string, port observability.BoundPor
 	c.portCond.Broadcast()
 }
 
-func (c *SandboxController) waitForPort(ctx context.Context, id string, port int, timeout time.Duration) error {
+func (c *SandboxController) WaitForPort(ctx context.Context, id string, port int, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 
 	// Create a channel to signal when port is ready
@@ -529,7 +529,7 @@ func PauseContainerID(id entity.Id) string {
 	return containerPrefix(id) + "_pause"
 }
 
-func (c *SandboxController) checkSandbox(ctx context.Context, co *compute.Sandbox, meta *entity.Meta) (int, error) {
+func (c *SandboxController) CheckSandbox(ctx context.Context, co *compute.Sandbox, meta *entity.Meta) (int, error) {
 	c.Log.Debug("checking for existing sandbox", "id", co.ID)
 
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
@@ -752,9 +752,9 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 		return nil
 	case compute.STOPPED:
 		c.Log.Debug("sandbox is stopped, verifying it is no longer running")
-		return c.stopSandbox(ctx, co.ID)
+		return c.StopSandbox(ctx, co.ID)
 	case "", compute.PENDING, compute.RUNNING:
-		searchRes, err := c.checkSandbox(ctx, co, meta)
+		searchRes, err := c.CheckSandbox(ctx, co, meta)
 		if err != nil {
 			c.Log.Error("error checking sandbox, proceeding with create", "err", err)
 		} else {
@@ -821,7 +821,7 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 				}
 
 				// Clean up the unhealthy sandbox
-				err := c.stopSandbox(ctx, co.ID)
+				err := c.StopSandbox(ctx, co.ID)
 				if err != nil {
 					c.Log.Error("failed to cleanup unhealthy sandbox", "id", co.ID, "err", err)
 					return fmt.Errorf("failed to cleanup unhealthy sandbox: %w", err)
@@ -853,7 +853,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
-	ep, err := c.allocateNetwork(ctx, co)
+	ep, err := c.AllocateNetwork(ctx, co)
 	if err != nil {
 		return fmt.Errorf("failed to allocate network: %w", err)
 	}
@@ -882,13 +882,13 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 		c.writeTracker.RecordWrite(res.Revision())
 	}
 
-	opts, err := c.buildSpec(ctx, co, ep, meta)
+	opts, err := c.BuildSpec(ctx, co, ep, meta)
 	if err != nil {
 		c.deallocateNetwork(ctx, ep)
 		return fmt.Errorf("failed to build container spec: %w", err)
 	}
 
-	volumeMounts, err := c.configureVolumes(ctx, co, meta)
+	volumeMounts, err := c.ConfigureVolumes(ctx, co, meta)
 	if err != nil {
 		c.deallocateNetwork(ctx, ep)
 		return fmt.Errorf("failed to configure volumes: %w", err)
@@ -914,14 +914,19 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 			c.deallocateNetwork(ctx, ep)
 
 			// Clean up any subcontainers that might have been created
-			c.destroySubContainers(ctx, co.ID)
+			c.DestroySubContainers(ctx, co.ID)
 
 			// Clean up the pause container using the common cleanup function
-			c.cleanupContainer(ctx, container)
+			c.CleanupContainer(ctx, container)
+
+			// Update sandbox status to DEAD in entity store
+			co.Status = compute.DEAD
+			meta.Update(co.Encode())
+			c.Log.Info("marked sandbox as DEAD due to boot failure", "id", co.ID)
 		}
 	}()
 
-	task, err := c.bootInitialTask(ctx, co, ep, container)
+	task, err := c.BootInitialTask(ctx, co, ep, container)
 	if err != nil {
 		return err
 	}
@@ -935,7 +940,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 		"": rootSpec.Linux.CgroupsPath,
 	}
 
-	waitPorts, err := c.bootContainers(ctx, co, ep, int(task.Pid()), cgroups, meta, volumeMounts)
+	waitPorts, err := c.BootContainers(ctx, co, ep, int(task.Pid()), cgroups, meta, volumeMounts)
 	if err != nil {
 		return err
 	}
@@ -970,10 +975,10 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 	// Fail-hard: if ports never bind, fail the sandbox so pool can retry
 	portTimeout := 15 * time.Second
 	for _, wp := range waitPorts {
-		c.Log.Info("waiting for ports to be bound", "id", cid, "port", wp.port, "timeout", portTimeout)
-		if err := c.waitForPort(ctx, wp.id, wp.port, portTimeout); err != nil {
+		c.Log.Info("waiting for ports to be bound", "id", cid, "port", wp.Port, "timeout", portTimeout)
+		if err := c.WaitForPort(ctx, wp.ID, wp.Port, portTimeout); err != nil {
 			return fmt.Errorf("sandbox failed network health check: port %d not reachable after %v: %w",
-				wp.port, portTimeout, err)
+				wp.Port, portTimeout, err)
 		}
 	}
 
@@ -1006,7 +1011,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 		return fmt.Errorf("failed to update entity metadata: %w", err)
 	}
 
-	err = c.updateServices(ctx, co, meta, ep)
+	err = c.UpdateServices(ctx, co, meta, ep)
 	if err != nil {
 		return fmt.Errorf("failed to update services: %w", err)
 	}
@@ -1014,7 +1019,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 	return nil
 }
 
-func (c *SandboxController) updateServices(
+func (c *SandboxController) UpdateServices(
 	ctx context.Context,
 	co *compute.Sandbox,
 	meta *entity.Meta,
@@ -1149,7 +1154,7 @@ func (c *SandboxController) deallocateNetwork(ctx context.Context, ep *network.E
 	}
 }
 
-func (c *SandboxController) allocateNetwork(
+func (c *SandboxController) AllocateNetwork(
 	ctx context.Context,
 	co *compute.Sandbox,
 ) (*network.EndpointConfig, error) {
@@ -1268,7 +1273,7 @@ func (c *SandboxController) resolver() remotes.Resolver {
 	})
 }
 
-func (c *SandboxController) buildSpec(
+func (c *SandboxController) BuildSpec(
 	ctx context.Context,
 	sb *compute.Sandbox,
 	ep *network.EndpointConfig,
@@ -1466,7 +1471,7 @@ func (c *SandboxController) logConsumer(sb *compute.Sandbox, container string) *
 	return NewSandboxLogs(c.Log, le, attrs, c.LogWriter)
 }
 
-func (c *SandboxController) bootInitialTask(
+func (c *SandboxController) BootInitialTask(
 	ctx context.Context,
 	sb *compute.Sandbox,
 	ep *network.EndpointConfig,
@@ -1500,13 +1505,14 @@ func (c *SandboxController) bootInitialTask(
 	return task, nil
 }
 
-type waitPort struct {
-	id   string
-	port int
+// WaitPort describes a container port to wait for during sandbox creation.
+type WaitPort struct {
+	ID   string
+	Port int
 }
 
-// cleanupContainer removes a container and its snapshot during failure scenarios
-func (c *SandboxController) cleanupContainer(ctx context.Context, cont containerd.Container) {
+// CleanupContainer removes a container and its snapshot during failure scenarios
+func (c *SandboxController) CleanupContainer(ctx context.Context, cont containerd.Container) {
 	if cont == nil {
 		return
 	}
@@ -1563,12 +1569,12 @@ func (c *SandboxController) cleanupContainer(ctx context.Context, cont container
 func (c *SandboxController) cleanupContainers(ctx context.Context, containers []containerd.Container) {
 	for _, cont := range containers {
 		if cont != nil {
-			c.cleanupContainer(ctx, cont)
+			c.CleanupContainer(ctx, cont)
 		}
 	}
 }
 
-func (c *SandboxController) bootContainers(
+func (c *SandboxController) BootContainers(
 	ctx context.Context,
 	sb *compute.Sandbox,
 	ep *network.EndpointConfig,
@@ -1576,12 +1582,12 @@ func (c *SandboxController) bootContainers(
 	cgroups map[string]string,
 	meta *entity.Meta,
 	volumeMounts map[string]string,
-) ([]waitPort, error) {
+) ([]WaitPort, error) {
 	c.Log.Info("booting containers", "count", len(sb.Spec.Container))
 
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
-	var ret []waitPort
+	var ret []WaitPort
 	var createdContainers []containerd.Container
 
 	// Clean up any created containers on failure
@@ -1605,9 +1611,9 @@ func (c *SandboxController) bootContainers(
 		var ports []int
 		for _, port := range container.Port {
 			ports = append(ports, int(port.Port))
-			ret = append(ret, waitPort{
-				id:   id,
-				port: int(port.Port),
+			ret = append(ret, WaitPort{
+				ID:   id,
+				Port: int(port.Port),
 			})
 		}
 
@@ -2053,7 +2059,7 @@ func getShutdownTimeout(ctx context.Context, cont containerd.Container) time.Dur
 	return timeout
 }
 
-func (c *SandboxController) destroySubContainers(ctx context.Context, id entity.Id) error {
+func (c *SandboxController) DestroySubContainers(ctx context.Context, id entity.Id) error {
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
 	// Discover subcontainers from containerd
@@ -2237,12 +2243,12 @@ cleanup:
 func (c *SandboxController) Delete(ctx context.Context, id entity.Id, sb *compute.Sandbox) error {
 	c.Log.Debug("delete callback received, cleaning up sandbox", "id", id)
 	if sb != nil {
-		c.unconfigureFirewall(sb)
+		c.UnconfigureFirewall(sb)
 	}
-	return c.stopSandbox(ctx, id)
+	return c.StopSandbox(ctx, id)
 }
 
-func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error {
+func (c *SandboxController) StopSandbox(ctx context.Context, id entity.Id) error {
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
 	c.Log.Debug("stopping sandbox", "id", id)
@@ -2283,7 +2289,7 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 		sb.Decode(resp.Entity().Entity())
 
 		// Clean up iptables DNAT rules before destroying containers
-		c.unconfigureFirewall(&sb)
+		c.UnconfigureFirewall(&sb)
 
 		// Use entity store IPs as fallback if container labels didn't have them
 		if len(sandboxIPs) == 0 {
@@ -2323,14 +2329,14 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 
 	// Release disk leases early so replacement sandboxes can acquire them
 	// while we wait for container shutdown
-	if err := c.releaseDiskLeases(ctx, id); err != nil {
+	if err := c.ReleaseDiskLeases(ctx, id); err != nil {
 		c.Log.Error("failed to release disk leases", "id", id, "error", err)
 		// Continue with cleanup even if this fails
 	}
 
 	// Destroy subcontainers - this will discover them from containerd
 	c.Log.Debug("destroying subcontainers", "id", id)
-	err = c.destroySubContainers(ctx, id)
+	err = c.DestroySubContainers(ctx, id)
 	if err != nil {
 		c.Log.Error("failed to destroy subcontainers", "id", id, "err", err)
 		// Continue with cleanup even if this fails
@@ -2412,7 +2418,7 @@ func (c *SandboxController) stopSandbox(ctx context.Context, id entity.Id) error
 // releaseDiskLeases releases all disk leases owned by the given sandbox.
 // This transitions leases to RELEASED status, which triggers the disk lease
 // controller to unmount the volumes and release the underlying resources.
-func (c *SandboxController) releaseDiskLeases(ctx context.Context, sandboxID entity.Id) error {
+func (c *SandboxController) ReleaseDiskLeases(ctx context.Context, sandboxID entity.Id) error {
 	// Find all disk leases owned by this sandbox
 	listResp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, storage.KindDiskLease))
 	if err != nil {
@@ -2493,7 +2499,7 @@ func (c *SandboxController) Periodic(ctx context.Context, timeHorizon time.Durat
 					"updated_at", updatedAt.Format(time.RFC3339),
 					"age", now.Sub(updatedAt).String())
 
-				if err := c.releaseDiskLeases(ctx, sb.ID); err != nil {
+				if err := c.ReleaseDiskLeases(ctx, sb.ID); err != nil {
 					c.Log.Error("failed to release disk leases during periodic cleanup", "id", sb.ID, "error", err)
 					continue
 				}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,8 +24,8 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "e89c3b0a223a1ede6e71d45b792d555a643e338a6700b278b9c5aebd2fdd164e",
-		"volume.go":   "c8e2969a6d0b17e79962041d9389676eb57b3b1c81365e9fb9c49f4e6c4270ae",
+		"sandbox.go":  "0c5a659a9bd1b6265969329c1479ceb0b25b5ddd6b971e5c73cab730224aaad1",
+		"volume.go":   "8b967c2c92cd1a8ba7d9a50b05131cff72c8609359b0dad23283df817b21aca5",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}
 

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -1,0 +1,60 @@
+package sandbox
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestSandboxControllerFrozen guards against accidental modifications to the
+// original sandbox controller files while the saga-based replacement is being
+// developed.
+//
+// If this test fails, it means one of the frozen files was modified. Before
+// updating the hash, please:
+//
+//  1. Audit the saga controller (saga_controller.go, create_saga.go) to ensure
+//     it reflects the same behavioral change.
+//  2. Consider whether the change can wait until we fully cut over to sagas,
+//     which would avoid maintaining two code paths.
+//
+// To update hashes after an intentional change:
+//
+//	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
+func TestSandboxControllerFrozen(t *testing.T) {
+	frozen := map[string]string{
+		"sandbox.go":  "e89c3b0a223a1ede6e71d45b792d555a643e338a6700b278b9c5aebd2fdd164e",
+		"volume.go":   "c8e2969a6d0b17e79962041d9389676eb57b3b1c81365e9fb9c49f4e6c4270ae",
+		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
+	}
+
+	for file, expectedHash := range frozen {
+		t.Run(file, func(t *testing.T) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("reading %s: %v", file, err)
+			}
+
+			actual := fmt.Sprintf("%x", sha256.Sum256(data))
+			if actual != expectedHash {
+				t.Fatalf(`%s has been modified (hash mismatch).
+
+  expected: %s
+  actual:   %s
+
+This file is frozen while the saga-based sandbox controller is being developed.
+Before updating the hash, please:
+
+  1. Audit saga_controller.go and create_saga.go to ensure they reflect
+     the same behavioral change you're making here.
+  2. Consider holding off on this change until we fully switch over to sagas,
+     so we don't have to maintain two code paths.
+
+To update hashes:
+  sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go`,
+					file, expectedHash, actual)
+			}
+		})
+	}
+}

--- a/controllers/sandbox/sandbox_ops.go
+++ b/controllers/sandbox/sandbox_ops.go
@@ -1,0 +1,157 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"time"
+
+	"github.com/containerd/containerd/namespaces"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/errdefs"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/network"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// sandboxOps adapts a *SandboxController to the saga domain interfaces.
+// It is the bridge between the saga actions and the controller's resources.
+type sandboxOps struct {
+	ctrl *SandboxController
+}
+
+// --- SandboxEntityStore ---
+
+func (o *sandboxOps) GetSandbox(ctx context.Context, id string) (*compute.Sandbox, *entity.Meta, error) {
+	resp, err := o.ctrl.EAC.Get(ctx, id)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching sandbox %s: %w", id, err)
+	}
+	var co compute.Sandbox
+	co.Decode(resp.Entity().Entity())
+	meta := &entity.Meta{
+		Entity:   resp.Entity().Entity(),
+		Revision: resp.Entity().Revision(),
+	}
+	return &co, meta, nil
+}
+
+func (o *sandboxOps) PatchSandbox(ctx context.Context, attrs []entity.Attr, revision int64) (int64, error) {
+	result, err := o.ctrl.EAC.Patch(ctx, attrs, revision)
+	if err != nil {
+		return 0, err
+	}
+	if o.ctrl.writeTracker != nil && result.HasRevision() {
+		o.ctrl.writeTracker.RecordWrite(result.Revision())
+	}
+	return result.Revision(), nil
+}
+
+// --- SandboxNetworking ---
+
+func (o *sandboxOps) AllocateNetwork(ctx context.Context, sb *compute.Sandbox) (*network.EndpointConfig, error) {
+	return o.ctrl.AllocateNetwork(ctx, sb)
+}
+
+func (o *sandboxOps) ReleaseAddr(addr netip.Addr) error {
+	return o.ctrl.Subnet.ReleaseAddr(addr)
+}
+
+func (o *sandboxOps) RebuildEndpointConfig(addresses []string) (*network.EndpointConfig, error) {
+	ep := &network.EndpointConfig{
+		Bridge: &network.BridgeConfig{
+			Name:      o.ctrl.Bridge,
+			Addresses: []netip.Prefix{o.ctrl.Subnet.Router()},
+		},
+	}
+
+	for _, addrStr := range addresses {
+		prefix, err := netip.ParsePrefix(addrStr)
+		if err != nil {
+			return nil, fmt.Errorf("parsing address %q: %w", addrStr, err)
+		}
+		ep.Addresses = append(ep.Addresses, prefix)
+	}
+
+	if err := ep.DeriveDefaultGateway(); err != nil {
+		return nil, fmt.Errorf("deriving default gateway: %w", err)
+	}
+
+	return ep, nil
+}
+
+func (o *sandboxOps) BridgeName() string {
+	return o.ctrl.Bridge
+}
+
+// --- SandboxContainerRuntime ---
+
+func (o *sandboxOps) BuildSpec(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, meta *entity.Meta) ([]containerd.NewContainerOpts, error) {
+	ctx = namespaces.WithNamespace(ctx, o.ctrl.Namespace)
+	return o.ctrl.BuildSpec(ctx, sb, ep, meta)
+}
+
+func (o *sandboxOps) CreateContainer(ctx context.Context, id string, opts ...containerd.NewContainerOpts) (string, error) {
+	ctx = namespaces.WithNamespace(ctx, o.ctrl.Namespace)
+	cid := pauseContainerId(entity.Id(id))
+	_, err := o.ctrl.CC.NewContainer(ctx, cid, opts...)
+	if err != nil && !errdefs.IsAlreadyExists(err) {
+		return "", fmt.Errorf("creating container %s: %w", id, err)
+	}
+	return cid, nil
+}
+
+func (o *sandboxOps) LoadContainer(ctx context.Context, id string) (containerd.Container, error) {
+	ctx = namespaces.WithNamespace(ctx, o.ctrl.Namespace)
+	return o.ctrl.CC.LoadContainer(ctx, id)
+}
+
+func (o *sandboxOps) CleanupContainer(ctx context.Context, cont containerd.Container) {
+	ctx = namespaces.WithNamespace(ctx, o.ctrl.Namespace)
+	o.ctrl.CleanupContainer(ctx, cont)
+}
+
+func (o *sandboxOps) BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container) (containerd.Task, error) {
+	ctx = namespaces.WithNamespace(ctx, o.ctrl.Namespace)
+	return o.ctrl.BootInitialTask(ctx, sb, ep, container)
+}
+
+func (o *sandboxOps) ConfigureVolumes(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) (map[string]string, error) {
+	return o.ctrl.ConfigureVolumes(ctx, sb, meta)
+}
+
+func (o *sandboxOps) BootContainers(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, sbPid int, cgroups map[string]string, meta *entity.Meta, volumeMounts map[string]string) ([]WaitPort, error) {
+	return o.ctrl.BootContainers(ctx, sb, ep, sbPid, cgroups, meta, volumeMounts)
+}
+
+func (o *sandboxOps) DestroySubContainers(ctx context.Context, id entity.Id) error {
+	ctx = namespaces.WithNamespace(ctx, o.ctrl.Namespace)
+	return o.ctrl.DestroySubContainers(ctx, id)
+}
+
+func (o *sandboxOps) ReleaseDiskLeases(ctx context.Context, sandboxID entity.Id) error {
+	return o.ctrl.ReleaseDiskLeases(ctx, sandboxID)
+}
+
+func (o *sandboxOps) UnconfigureFirewall(sb *compute.Sandbox) {
+	o.ctrl.UnconfigureFirewall(sb)
+}
+
+func (o *sandboxOps) WaitForPort(ctx context.Context, id string, port int, timeout time.Duration) error {
+	return o.ctrl.WaitForPort(ctx, id, port, timeout)
+}
+
+// --- SandboxObservability ---
+
+func (o *sandboxOps) AddMetrics(logEntity string, cgroups map[string]string, attrs map[string]string) error {
+	return o.ctrl.Metrics.Add(logEntity, cgroups, attrs)
+}
+
+func (o *sandboxOps) RemoveMetrics(logEntity string) {
+	o.ctrl.Metrics.Remove(logEntity)
+}
+
+func (o *sandboxOps) UpdateServices(ctx context.Context, co *compute.Sandbox, meta *entity.Meta, ep *network.EndpointConfig) error {
+	return o.ctrl.UpdateServices(ctx, co, meta, ep)
+}

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -253,7 +253,7 @@ func TestSandbox(t *testing.T) {
 		r.Equal(ca.Addr().String()+"/24", addr, "address doesn't match")
 
 		t.Run("create on existing sandbox is no-op", func(t *testing.T) {
-			searchRes, err := co.checkSandbox(ctx, &sb, meta)
+			searchRes, err := co.CheckSandbox(ctx, &sb, meta)
 			r.NoError(err)
 
 			r.Equal(same, searchRes)
@@ -1071,12 +1071,12 @@ func TestSandbox(t *testing.T) {
 			Ports: []observability.BoundPort{{Port: 8080}},
 		}
 
-		err := c.waitForPort(ctx, "test-id", 8080, 5*time.Second)
+		err := c.WaitForPort(ctx, "test-id", 8080, 5*time.Second)
 		r.NoError(err, "should return immediately when port is already bound")
 
 		// Test timeout when port never binds
 		start := time.Now()
-		err = c.waitForPort(ctx, "test-id", 9999, 100*time.Millisecond)
+		err = c.WaitForPort(ctx, "test-id", 9999, 100*time.Millisecond)
 		elapsed := time.Since(start)
 
 		r.Error(err, "should timeout when port never binds")
@@ -1091,7 +1091,7 @@ func TestSandbox(t *testing.T) {
 		}()
 
 		start = time.Now()
-		err = c.waitForPort(ctx, "test-id", 7777, 5*time.Second)
+		err = c.WaitForPort(ctx, "test-id", 7777, 5*time.Second)
 		elapsed = time.Since(start)
 
 		r.NoError(err, "should return when port is bound during wait")
@@ -1106,7 +1106,7 @@ func TestSandbox(t *testing.T) {
 		}()
 
 		start = time.Now()
-		err = c.waitForPort(ctx, "test-id", 6666, 5*time.Second)
+		err = c.WaitForPort(ctx, "test-id", 6666, 5*time.Second)
 		elapsed = time.Since(start)
 
 		r.Error(err, "should error on context cancellation")

--- a/controllers/sandbox/volume.go
+++ b/controllers/sandbox/volume.go
@@ -15,8 +15,8 @@ import (
 	"miren.dev/runtime/pkg/idgen"
 )
 
-// configureVolumes prepares volumes and returns a map of volume name to actual mount path
-func (c *SandboxController) configureVolumes(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) (map[string]string, error) {
+// ConfigureVolumes prepares volumes and returns a map of volume name to actual mount path
+func (c *SandboxController) ConfigureVolumes(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) (map[string]string, error) {
 	volumeMounts := make(map[string]string)
 
 	for _, volume := range sb.Spec.Volume {

--- a/controllers/sandbox/volume.go
+++ b/controllers/sandbox/volume.go
@@ -73,6 +73,13 @@ func (c *SandboxController) configureHostVolume(sb *compute.Sandbox, volume comp
 
 	c.Log.Debug("creating host volume symlink", "path", path, "host-path", rawPath)
 
+	if existing, err := os.Readlink(rawPath); err == nil {
+		if existing == path {
+			return path, nil
+		}
+		return "", fmt.Errorf("host volume symlink %s already exists but points to %s, expected %s", rawPath, existing, path)
+	}
+
 	if err := os.Symlink(path, rawPath); err != nil {
 		return "", err
 	}

--- a/controllers/sandbox/volume_test.go
+++ b/controllers/sandbox/volume_test.go
@@ -395,7 +395,7 @@ func TestReleaseDiskLeases(t *testing.T) {
 		r.Equal(storage.BOUND, storedLease.Status)
 
 		// Act: Release disk leases for the sandbox
-		err = controller.releaseDiskLeases(ctx, sandboxID)
+		err = controller.ReleaseDiskLeases(ctx, sandboxID)
 		r.NoError(err)
 
 		// Assert: Lease should now be RELEASED
@@ -456,7 +456,7 @@ func TestReleaseDiskLeases(t *testing.T) {
 		r.NoError(err)
 
 		// Act: Release leases for sandbox1 only
-		err = controller.releaseDiskLeases(ctx, sandbox1ID)
+		err = controller.ReleaseDiskLeases(ctx, sandbox1ID)
 		r.NoError(err)
 
 		// Assert: sandbox1's lease should be RELEASED

--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -28,3 +28,8 @@ features:
     predicate: Addons
     description: Enable the addon system for managed backing services
     default: false
+
+  - name: sagas
+    predicate: Sagas
+    description: Use saga-based crash-recoverable workflows for sandbox lifecycle
+    default: false

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -16,6 +16,7 @@ const (
 	FeatureAdminAPI           = "adminapi"
 	FeatureRouteOIDC          = "routeoidc"
 	FeatureAddons             = "addons"
+	FeatureSagas              = "sagas"
 )
 
 // AllFeatures returns a list of all known feature names
@@ -27,6 +28,7 @@ func AllFeatures() []string {
 		FeatureAdminAPI,
 		FeatureRouteOIDC,
 		FeatureAddons,
+		FeatureSagas,
 	}
 }
 
@@ -39,6 +41,7 @@ func FeatureDescriptions() map[string]string {
 		FeatureAdminAPI:           "Enable the admin API for application management functions",
 		FeatureRouteOIDC:          "Enable OIDC authentication for HTTP routes",
 		FeatureAddons:             "Enable the addon system for managed backing services",
+		FeatureSagas:              "Use saga-based crash-recoverable workflows for sandbox lifecycle",
 	}
 }
 
@@ -55,6 +58,7 @@ var featureDefaults = map[string]bool{
 	FeatureAdminAPI:           false,
 	FeatureRouteOIDC:          false,
 	FeatureAddons:             false,
+	FeatureSagas:              false,
 }
 
 // Init initializes the labs feature flags from the provided flag strings.
@@ -165,4 +169,10 @@ func RouteOIDC() bool {
 // Enable the addon system for managed backing services
 func Addons() bool {
 	return IsEnabled(FeatureAddons)
+}
+
+// Sagas returns whether the sagas feature is enabled.
+// Use saga-based crash-recoverable workflows for sandbox lifecycle
+func Sagas() bool {
+	return IsEnabled(FeatureSagas)
 }

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -123,11 +123,11 @@ func TestIsEnabledFunction(t *testing.T) {
 func TestAllFeatures(t *testing.T) {
 	features := AllFeatures()
 
-	if len(features) != 6 {
-		t.Errorf("Expected 6 features, got %d", len(features))
+	if len(features) != 7 {
+		t.Errorf("Expected 7 features, got %d", len(features))
 	}
 
-	expected := []string{"globalrouter", "distributedrunners", "usersubdomains", "adminapi", "routeoidc", "addons"}
+	expected := []string{"globalrouter", "distributedrunners", "usersubdomains", "adminapi", "routeoidc", "addons", "sagas"}
 	for _, name := range expected {
 		found := false
 		for _, f := range features {
@@ -145,8 +145,8 @@ func TestAllFeatures(t *testing.T) {
 func TestFeatureDescriptions(t *testing.T) {
 	descriptions := FeatureDescriptions()
 
-	if len(descriptions) != 6 {
-		t.Errorf("Expected 6 descriptions, got %d", len(descriptions))
+	if len(descriptions) != 7 {
+		t.Errorf("Expected 7 descriptions, got %d", len(descriptions))
 	}
 
 	if descriptions[FeatureGlobalRouter] == "" {
@@ -166,6 +166,9 @@ func TestFeatureDescriptions(t *testing.T) {
 	}
 	if descriptions[FeatureAddons] == "" {
 		t.Error("Addons description should not be empty")
+	}
+	if descriptions[FeatureSagas] == "" {
+		t.Error("Sagas description should not be empty")
 	}
 }
 

--- a/pkg/saga/definition_test.go
+++ b/pkg/saga/definition_test.go
@@ -103,6 +103,56 @@ func diamondDExec(_ context.Context, in diamondDIn) (diamondDOut, error) {
 }
 func diamondDUndo(_ context.Context, _ diamondDIn, _ diamondDOut) error { return nil }
 
+// Edge-linked action types — the only dependency is an Edge key.
+
+type edgeProducerIn struct {
+	Seed int `saga:"seed"`
+}
+type edgeProducerOut struct {
+	Value int  `saga:"edge_value"`
+	Done  Edge `saga:"producer_done"`
+}
+
+func edgeProducerExec(_ context.Context, in edgeProducerIn) (edgeProducerOut, error) {
+	return edgeProducerOut{Value: in.Seed * 2}, nil
+}
+func edgeProducerUndo(_ context.Context, _ edgeProducerIn, _ edgeProducerOut) error { return nil }
+
+type edgeConsumerIn struct {
+	X    int  `saga:"consumer_x"`
+	Done Edge `saga:"producer_done"`
+}
+type edgeConsumerOut struct {
+	Y int `saga:"consumer_y"`
+}
+
+func edgeConsumerExec(_ context.Context, in edgeConsumerIn) (edgeConsumerOut, error) {
+	return edgeConsumerOut{Y: in.X}, nil
+}
+func edgeConsumerUndo(_ context.Context, _ edgeConsumerIn, _ edgeConsumerOut) error { return nil }
+
+func TestEdge_CreatesDependencyWithoutData(t *testing.T) {
+	// producer outputs an Edge key "producer_done"
+	// consumer reads "producer_done" — this should create a dependency edge
+	// even though no real data flows through it.
+	def, err := Define("edge-test").
+		Action("consumer", edgeConsumerExec).Undo(edgeConsumerUndo).
+		Action("producer", edgeProducerExec).Undo(edgeProducerUndo).
+		Build()
+	require.NoError(t, err)
+
+	order := def.ExecutionOrder()
+	require.Len(t, order, 2)
+
+	// producer must come before consumer because of the Edge dependency
+	assert.Equal(t, "producer", order[0])
+	assert.Equal(t, "consumer", order[1])
+
+	// Verify the dependency is recorded
+	consumerNode := def.Actions["consumer"]
+	assert.Contains(t, consumerNode.Dependencies, "producer")
+}
+
 func TestTopologicalSort_Deterministic(t *testing.T) {
 	t.Run("independent actions are alphabetically sorted", func(t *testing.T) {
 		// Register actions in non-alphabetical order to verify the sort

--- a/pkg/saga/eac_storage.go
+++ b/pkg/saga/eac_storage.go
@@ -1,0 +1,136 @@
+package saga
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	saga_v1alpha "miren.dev/runtime/api/saga/saga_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+
+	es "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/cond"
+)
+
+// EACStorage implements Storage using an EntityAccessClient RPC connection.
+// This is used by runners which don't have direct entity.Store access.
+type EACStorage struct {
+	eac *es.EntityAccessClient
+	log *slog.Logger
+}
+
+// NewEACStorage creates a storage backed by an EntityAccessClient.
+func NewEACStorage(eac *es.EntityAccessClient, log *slog.Logger) *EACStorage {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &EACStorage{eac: eac, log: log}
+}
+
+// Save persists the execution state as an entity via EAC.
+func (s *EACStorage) Save(ctx context.Context, exec *Execution) error {
+	initialInputs, err := json.Marshal(exec.InitialInputs)
+	if err != nil {
+		return fmt.Errorf("marshaling initial inputs: %w", err)
+	}
+
+	executedActions, err := json.Marshal(exec.ExecutedActions)
+	if err != nil {
+		return fmt.Errorf("marshaling executed actions: %w", err)
+	}
+
+	executionOrder, err := json.Marshal(exec.ExecutionOrder)
+	if err != nil {
+		return fmt.Errorf("marshaling execution order: %w", err)
+	}
+
+	status := statusToEntity(exec.Status)
+
+	sagaEntity := &saga_v1alpha.Saga{
+		ID:                entity.Id(exec.ID),
+		DefinitionName:    exec.DefinitionName,
+		DefinitionVersion: int64(exec.DefinitionVersion),
+		ParentExecutionId: entity.Id(exec.ParentExecutionID),
+		Status:            status,
+		InitialInputs:     initialInputs,
+		ExecutedActions:   executedActions,
+		ExecutionOrder:    executionOrder,
+		Error:             exec.Error,
+	}
+
+	ent := entity.New(
+		entity.DBId, exec.ID,
+		sagaEntity.Encode(),
+	)
+
+	_, err = s.eac.Ensure(ctx, ent.Attrs())
+	if err != nil {
+		return fmt.Errorf("saving saga entity via EAC: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves an execution by ID via EAC.
+func (s *EACStorage) Get(ctx context.Context, id string) (*Execution, error) {
+	resp, err := s.eac.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			return nil, fmt.Errorf("%w: %s", ErrExecutionNotFound, id)
+		}
+		return nil, fmt.Errorf("getting saga entity via EAC: %w", err)
+	}
+
+	ent := resp.Entity().Entity()
+	sagaEntity, ok := entity.As[saga_v1alpha.Saga](ent)
+	if !ok {
+		return nil, fmt.Errorf("entity %s is not a saga", id)
+	}
+
+	return entityToExecution(sagaEntity)
+}
+
+// ListIncomplete returns all executions that need recovery via EAC.
+func (s *EACStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
+	// Query for each incomplete status
+	var allEntities []*es.Entity
+
+	for _, statusRef := range []entity.Id{
+		saga_v1alpha.SagaStatusPendingId,
+		saga_v1alpha.SagaStatusRunningId,
+		saga_v1alpha.SagaStatusUndoingId,
+	} {
+		resp, err := s.eac.List(ctx, entity.Ref(
+			saga_v1alpha.SagaStatusId,
+			statusRef,
+		))
+		if err != nil {
+			return nil, fmt.Errorf("listing sagas with status %s: %w", statusRef, err)
+		}
+		allEntities = append(allEntities, resp.Values()...)
+	}
+
+	if len(allEntities) == 0 {
+		return nil, nil
+	}
+
+	var executions []*Execution
+	for _, eacEnt := range allEntities {
+		ent := eacEnt.Entity()
+		sagaEntity, ok := entity.As[saga_v1alpha.Saga](ent)
+		if !ok {
+			s.log.Warn("entity is not a saga, skipping", "id", eacEnt.Id())
+			continue
+		}
+		exec, err := entityToExecution(sagaEntity)
+		if err != nil {
+			s.log.Warn("failed to convert saga entity, skipping", "id", eacEnt.Id(), "error", err)
+			continue
+		}
+		executions = append(executions, exec)
+	}
+
+	return executions, nil
+}

--- a/pkg/saga/eac_storage_test.go
+++ b/pkg/saga/eac_storage_test.go
@@ -1,0 +1,19 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEACStorageNewNilLogger verifies that NewEACStorage handles a nil logger.
+func TestEACStorageNewNilLogger(t *testing.T) {
+	s := NewEACStorage(nil, nil)
+	assert.NotNil(t, s)
+	assert.NotNil(t, s.log)
+}
+
+// TestEACStorageImplementsStorage verifies the interface compliance at compile time.
+func TestEACStorageImplementsStorage(t *testing.T) {
+	var _ Storage = (*EACStorage)(nil)
+}

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -533,6 +533,9 @@ func extractOutputs(node *ActionNode, outputBytes []byte, outputs map[string]jso
 	}
 
 	for _, mapping := range typed.outMappings {
+		if mapping.isEdge {
+			continue // Edge fields carry no data
+		}
 		// Look for the field in the output map using the JSON key name
 		// (which accounts for json struct tags)
 		if val, exists := outputMap[mapping.jsonKey]; exists {

--- a/pkg/saga/reflect.go
+++ b/pkg/saga/reflect.go
@@ -8,12 +8,16 @@ import (
 	"strings"
 )
 
+// edgeType is the reflect.Type of saga.Edge, used to detect ordering-only fields.
+var edgeType = reflect.TypeOf(Edge{})
+
 // fieldMapping maps struct field names to saga keys based on struct tags.
 type fieldMapping struct {
 	fieldName string
 	jsonKey   string // The JSON key name (from json tag or field name)
 	sagaKey   string
 	optional  bool
+	isEdge    bool // true for saga.Edge fields (ordering-only, no data)
 }
 
 // extractMappings extracts saga key mappings from a struct type's tags.
@@ -69,6 +73,7 @@ func extractMappings(t reflect.Type) ([]fieldMapping, error) {
 			jsonKey:   jsonKey,
 			sagaKey:   sagaKey,
 			optional:  optional,
+			isEdge:    field.Type == edgeType,
 		})
 	}
 	return mappings, nil
@@ -90,6 +95,9 @@ func (a *typedAction) Execute(ctx context.Context, inputs ActionInputs) (any, er
 	// Create input struct and populate from inputs
 	inVal := reflect.New(a.inType).Elem()
 	for _, m := range a.inMappings {
+		if m.isEdge {
+			continue // Edge fields are ordering-only, no data to populate
+		}
 		field := inVal.FieldByName(m.fieldName)
 		if !field.IsValid() || !field.CanSet() {
 			continue
@@ -133,6 +141,9 @@ func (a *typedAction) Undo(ctx context.Context, inputs ActionInputs, output any)
 	// Create input struct and populate from inputs
 	inVal := reflect.New(a.inType).Elem()
 	for _, m := range a.inMappings {
+		if m.isEdge {
+			continue // Edge fields are ordering-only, no data to populate
+		}
 		field := inVal.FieldByName(m.fieldName)
 		if !field.IsValid() || !field.CanSet() {
 			continue

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -813,3 +813,76 @@ func TestExecutor_SerializationFailurePlusUndoFailure(t *testing.T) {
 	_, recorded := exec.ExecutedActions["unserializable"]
 	assert.True(t, recorded, "action should be recorded even when immediate undo fails")
 }
+
+// Edge dependency test types
+
+type edgeStepAIn struct {
+	Val int `saga:"val"`
+}
+type edgeStepAOut struct {
+	AResult int  `saga:"a_result"`
+	ADone   Edge `saga:"a_done"`
+}
+
+type edgeStepBIn struct {
+	Val   int  `saga:"val"`
+	ADone Edge `saga:"a_done"`
+}
+type edgeStepBOut struct {
+	BResult int `saga:"b_result"`
+}
+
+type edgeTestController struct {
+	mu    sync.Mutex
+	order []string
+}
+
+func (c *edgeTestController) record(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.order = append(c.order, name)
+}
+
+func edgeStepAExec(ctx context.Context, in edgeStepAIn) (edgeStepAOut, error) {
+	Get[*edgeTestController](ctx).record("A")
+	return edgeStepAOut{AResult: in.Val * 10}, nil
+}
+
+func edgeStepAUndo(_ context.Context, _ edgeStepAIn, _ edgeStepAOut) error { return nil }
+
+func edgeStepBExec(ctx context.Context, in edgeStepBIn) (edgeStepBOut, error) {
+	Get[*edgeTestController](ctx).record("B")
+	return edgeStepBOut{BResult: in.Val + 1}, nil
+}
+
+func edgeStepBUndo(_ context.Context, _ edgeStepBIn, _ edgeStepBOut) error { return nil }
+
+func TestExecutor_EdgeDependency(t *testing.T) {
+	registry := NewRegistry()
+
+	ctrl := &edgeTestController{}
+	err := Define("edge-exec").
+		Using(ctrl).
+		Action("step-b", edgeStepBExec).Undo(edgeStepBUndo).
+		Action("step-a", edgeStepAExec).Undo(edgeStepAUndo).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := newMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+
+	err = executor.Start("edge-exec").
+		Input("val", 5).
+		WithID("edge-exec-1").
+		Execute(context.Background())
+	require.NoError(t, err)
+
+	// Verify B ran after A (Edge dependency)
+	assert.Equal(t, []string{"A", "B"}, ctrl.order)
+
+	// Verify execution completed
+	exec, err := storage.Get(context.Background(), "edge-exec-1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, exec.Status)
+	assert.Equal(t, []string{"step-a", "step-b"}, exec.ExecutionOrder)
+}

--- a/pkg/saga/types.go
+++ b/pkg/saga/types.go
@@ -10,6 +10,12 @@ import (
 	"time"
 )
 
+// Edge is a zero-size type used to declare ordering dependencies between saga
+// actions without carrying data. Edge fields participate in the dependency
+// graph (via saga struct tags) but are skipped during serialization and
+// deserialization at runtime.
+type Edge struct{}
+
 // Status represents the current state of a saga execution.
 type Status string
 


### PR DESCRIPTION
Sandbox creation today is a long chain of steps — network allocation, container creation, task booting, port waiting, status updates — all held together with defer-based cleanup. If the server crashes halfway through, those defers never run and resources leak. Not great.

This PR introduces the first real-world saga using the framework from RFD-35. The creation flow is decomposed into 9 actions, each with a compensating undo, so the saga executor can recover and roll back partial work after a crash. The whole thing lives behind a `sagas` labs flag so we can land it dark and enable it when we're confident.

The approach is to extract a `SandboxLifecycle` interface and build a new `SagaSandboxController` alongside the original. The labs flag switches which one gets wired up in the runner. The saga controller wraps the original, replacing only `createSandbox` with the saga-based flow while delegating stop/delete/periodic to the inner controller. This means zero changes to the existing path — both implementations coexist until we're ready to cut over.

Also adds `EACStorage`, a runner-side `saga.Storage` implementation that works over the EntityAccessClient RPC layer (the existing `EntityStorage` only works coordinator-side with direct store access).

### Saga steps

| Step | Action | Compensating Undo |
|------|--------|-------------------|
| 1 | **alloc-network** — Allocate IP addresses from subnet | Release allocated IPs back to subnet |
| 2 | **patch-network** — Write network addresses to sandbox entity | *(no-op)* |
| 3 | **create-container** — Build OCI spec and create pause container | Delete container and snapshot |
| 4 | **boot-task** — Start initial task in container, configure firewall | Kill task, unconfigure firewall |
| 5 | **boot-containers** — Configure volumes, start user containers | Destroy subcontainers, release disk leases |
| 6 | **add-metrics** — Register cgroup metrics for observability | Remove metrics |
| 7 | **wait-ports** — Wait for container ports to bind (≤15s) | *(no-op)* |
| 8 | **set-running** — Patch sandbox status to RUNNING | *(no-op — controller marks DEAD after saga failure)* |
| 9 | **update-services** — Notify service discovery of new endpoints | *(no-op)* |

### What's next

This is the first step toward replacing `SandboxController` entirely. The plan is: exercise this behind the feature flag, port the remaining lifecycle operations (stop, delete, periodic) to sagas, then delete the original controller.

### Design notes

**Undo actions are purely resource cleanup.** Compensating actions handle releasing IPs, killing tasks, destroying containers, etc. They don't touch sandbox entity status — that's a domain-level outcome decision owned by the controller.

**Saga failure → DEAD.** When the saga fails and undos complete, the controller marks the sandbox DEAD. This matches the original `createSandbox` defer behavior and means the pool replaces the sandbox rather than the reconciler retrying the same entity.

**Frozen original controller.** The original `SandboxController` files (`sandbox.go`, `volume.go`, `firewall.go`) are guarded by a hash-based test (`sandbox_frozen_test.go`). Any modification to these files will fail the test with instructions to audit the saga path for parity. The intent is to discourage changes to the original controller while the saga replacement is being developed — either port the change to the saga path, or wait for the full cutover.

### Known limitation: durable outcome declaration

RFD-35 doesn't address who declares the domain outcome (e.g., marking a sandbox DEAD) after saga failure. Today, the caller (`createSandboxViaSaga`) handles this at the call site after `Execute` returns. This works for the normal case, but if the runner crashes between saga completion and the DEAD patch, the entity stays PENDING and the reconciler retries creation — which succeeds (resources were cleaned up) but isn't the "let it crash" behavior we want.

Closing this gap requires the saga framework itself to support durable outcome declaration — something like an `OnError` callback that's persisted in the saga log and executed as part of recovery. This is a meaningful design project (likely involving a dedicated saga executor component at both runner and cluster level) and is future RFD material, not something to bolt on in the first real saga usage.

Relates to MIR-440