### PR TITLE
Switch binary release artifacts from .zip to .tar.gz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,14 +199,17 @@ jobs:
 
     - name: Package binary
       run: |
-        # Create a zip file with the binary
+        tar -czf miren-${{ matrix.os }}-${{ matrix.arch }}.tar.gz -C bin miren
+        # Transitional: also produce .zip for older clients
         zip -j miren-${{ matrix.os }}-${{ matrix.arch }}.zip bin/miren
 
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:
         name: miren-${{ matrix.os }}-${{ matrix.arch }}
-        path: miren-${{ matrix.os }}-${{ matrix.arch }}.zip
+        path: |
+          miren-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+          miren-${{ matrix.os }}-${{ matrix.arch }}.zip
         retention-days: 1
 
   build-and-push-docker:
@@ -415,9 +418,15 @@ jobs:
               "${arch}"
           done
 
-          # Upload binary artifacts
+          # Upload binary artifacts (.tar.gz is the primary format)
           for os in linux darwin; do
             for arch in amd64 arm64; do
+              upload_artifact \
+                "artifacts/miren-${os}-${arch}/miren-${os}-${arch}.tar.gz" \
+                "miren-${os}-${arch}.tar.gz" \
+                "${os}" \
+                "${arch}"
+              # Transitional: also upload .zip for older clients
               upload_artifact \
                 "artifacts/miren-${os}-${arch}/miren-${os}-${arch}.zip" \
                 "miren-${os}-${arch}.zip" \

--- a/cli/commands/upgrade.go
+++ b/cli/commands/upgrade.go
@@ -156,7 +156,7 @@ func Upgrade(ctx *Context, opts struct {
 	current, _ := mgr.GetCurrentVersion(ctx)
 
 	// Create artifact descriptor - use binary type for CLI upgrades (just the miren binary)
-	// Binary artifacts are .zip files available for all platforms
+	// Binary artifacts are .tar.gz files available for all platforms
 	artifact := release.NewArtifact(release.ArtifactTypeBinary, version)
 
 	// Perform upgrade

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -20,37 +20,45 @@ dir="tmp/release/$version"
 
 mkdir -p $dir
 
-if ! test -f $dir/miren-darwin-arm64.zip; then
+if ! test -f $dir/miren-darwin-arm64.tar.gz; then
   echo "Darwin / arm64"
   GOOS=darwin GOARCH=arm64 go build -ldflags "-X miren.dev/runtime/version.Version=$version" -o $dir/miren ./cmd/miren
 
+  tar -czf $dir/miren-darwin-arm64.tar.gz -C $dir miren
+  # Transitional: also produce .zip for older clients
   zip -j $dir/miren-darwin-arm64.zip $dir/miren
 
   rm $dir/miren
 fi
 
-if ! test -f $dir/miren-darwin-amd64.zip; then
+if ! test -f $dir/miren-darwin-amd64.tar.gz; then
   echo "Darwin / amd64"
   GOOS=darwin GOARCH=amd64 go build -ldflags "-X miren.dev/runtime/version.Version=$version" -o $dir/miren ./cmd/miren
 
+  tar -czf $dir/miren-darwin-amd64.tar.gz -C $dir miren
+  # Transitional: also produce .zip for older clients
   zip -j $dir/miren-darwin-amd64.zip $dir/miren
 
   rm $dir/miren
 fi
 
-if ! test -f $dir/miren-linux-arm64.zip; then
+if ! test -f $dir/miren-linux-arm64.tar.gz; then
   echo "Linux / arm64"
   GOOS=linux GOARCH=arm64 go build -ldflags "-X miren.dev/runtime/version.Version=$version" -o $dir/miren ./cmd/miren
 
+  tar -czf $dir/miren-linux-arm64.tar.gz -C $dir miren
+  # Transitional: also produce .zip for older clients
   zip -j $dir/miren-linux-arm64.zip $dir/miren
 
   rm $dir/miren
 fi
 
-if ! test -f $dir/miren-linux-amd64.zip; then
+if ! test -f $dir/miren-linux-amd64.tar.gz; then
   echo "Linux / amd64"
   GOOS=linux GOARCH=amd64 go build -ldflags "-X miren.dev/runtime/version.Version=$version" -o $dir/miren ./cmd/miren
 
+  tar -czf $dir/miren-linux-amd64.tar.gz -C $dir miren
+  # Transitional: also produce .zip for older clients
   zip -j $dir/miren-linux-amd64.zip $dir/miren
 
   rm $dir/miren

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -20,7 +20,7 @@ dir="tmp/release/$version"
 
 mkdir -p $dir
 
-if ! test -f $dir/miren-darwin-arm64.tar.gz; then
+if ! test -f $dir/miren-darwin-arm64.tar.gz || ! test -f $dir/miren-darwin-arm64.zip; then
   echo "Darwin / arm64"
   GOOS=darwin GOARCH=arm64 go build -ldflags "-X miren.dev/runtime/version.Version=$version" -o $dir/miren ./cmd/miren
 
@@ -31,7 +31,7 @@ if ! test -f $dir/miren-darwin-arm64.tar.gz; then
   rm $dir/miren
 fi
 
-if ! test -f $dir/miren-darwin-amd64.tar.gz; then
+if ! test -f $dir/miren-darwin-amd64.tar.gz || ! test -f $dir/miren-darwin-amd64.zip; then
   echo "Darwin / amd64"
   GOOS=darwin GOARCH=amd64 go build -ldflags "-X miren.dev/runtime/version.Version=$version" -o $dir/miren ./cmd/miren
 
@@ -42,7 +42,7 @@ if ! test -f $dir/miren-darwin-amd64.tar.gz; then
   rm $dir/miren
 fi
 
-if ! test -f $dir/miren-linux-arm64.tar.gz; then
+if ! test -f $dir/miren-linux-arm64.tar.gz || ! test -f $dir/miren-linux-arm64.zip; then
   echo "Linux / arm64"
   GOOS=linux GOARCH=arm64 go build -ldflags "-X miren.dev/runtime/version.Version=$version" -o $dir/miren ./cmd/miren
 
@@ -53,7 +53,7 @@ if ! test -f $dir/miren-linux-arm64.tar.gz; then
   rm $dir/miren
 fi
 
-if ! test -f $dir/miren-linux-amd64.tar.gz; then
+if ! test -f $dir/miren-linux-amd64.tar.gz || ! test -f $dir/miren-linux-amd64.zip; then
   echo "Linux / amd64"
   GOOS=linux GOARCH=amd64 go build -ldflags "-X miren.dev/runtime/version.Version=$version" -o $dir/miren ./cmd/miren
 

--- a/hack/systemd/Dockerfile.systemd
+++ b/hack/systemd/Dockerfile.systemd
@@ -20,7 +20,6 @@ RUN apt-get update && apt-get install -y \
     net-tools \
     iptables \
     jq \
-    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Remove unnecessary systemd services for container

--- a/pkg/release/artifact.go
+++ b/pkg/release/artifact.go
@@ -10,7 +10,7 @@ import (
 type ArtifactType string
 
 const (
-	// ArtifactTypeBinary contains just the miren binary (.zip)
+	// ArtifactTypeBinary contains just the miren binary (.tar.gz)
 	ArtifactTypeBinary ArtifactType = "binary"
 	// ArtifactTypeBase contains miren plus supporting binaries (.tar.gz, Linux only)
 	ArtifactTypeBase ArtifactType = "base"
@@ -40,9 +40,9 @@ func NewArtifact(artifactType ArtifactType, version string) Artifact {
 func (a Artifact) GetDownloadURL() string {
 	baseURL := "https://api.miren.cloud/assets/release/miren"
 
-	// Binary artifacts (just the miren binary) - available for all platforms as .zip
+	// Binary artifacts (just the miren binary) - available for all platforms as .tar.gz
 	if a.Type == ArtifactTypeBinary {
-		filename := fmt.Sprintf("miren-%s-%s.zip", a.Platform, a.Arch)
+		filename := fmt.Sprintf("miren-%s-%s.tar.gz", a.Platform, a.Arch)
 		fullURL, _ := url.JoinPath(baseURL, a.Version, filename)
 		return fullURL
 	}
@@ -54,7 +54,7 @@ func (a Artifact) GetDownloadURL() string {
 			return fullURL
 		}
 		// Non-Linux platforms should use binary artifacts
-		filename := fmt.Sprintf("miren-%s-%s.zip", a.Platform, a.Arch)
+		filename := fmt.Sprintf("miren-%s-%s.tar.gz", a.Platform, a.Arch)
 		fullURL, _ := url.JoinPath(baseURL, a.Version, filename)
 		return fullURL
 	}

--- a/pkg/release/artifact_test.go
+++ b/pkg/release/artifact_test.go
@@ -82,14 +82,14 @@ func TestArtifact_GetDownloadURL(t *testing.T) {
 			want: "https://api.miren.cloud/assets/release/miren/v1.2.3/miren-base-linux-arm64.tar.gz",
 		},
 		{
-			name: "release artifact non-linux fallback to zip",
+			name: "release artifact non-linux fallback to tar.gz",
 			artifact: Artifact{
 				Type:     ArtifactTypeRelease,
 				Version:  "main",
 				Arch:     "amd64",
 				Platform: "darwin",
 			},
-			want: "https://api.miren.cloud/assets/release/miren/main/miren-darwin-amd64.zip",
+			want: "https://api.miren.cloud/assets/release/miren/main/miren-darwin-amd64.tar.gz",
 		},
 		{
 			name: "binary artifact linux",
@@ -99,7 +99,7 @@ func TestArtifact_GetDownloadURL(t *testing.T) {
 				Arch:     "amd64",
 				Platform: "linux",
 			},
-			want: "https://api.miren.cloud/assets/release/miren/main/miren-linux-amd64.zip",
+			want: "https://api.miren.cloud/assets/release/miren/main/miren-linux-amd64.tar.gz",
 		},
 		{
 			name: "binary artifact darwin",
@@ -109,7 +109,7 @@ func TestArtifact_GetDownloadURL(t *testing.T) {
 				Arch:     "arm64",
 				Platform: "darwin",
 			},
-			want: "https://api.miren.cloud/assets/release/miren/v1.0.0/miren-darwin-arm64.zip",
+			want: "https://api.miren.cloud/assets/release/miren/v1.0.0/miren-darwin-arm64.tar.gz",
 		},
 	}
 

--- a/pkg/release/downloader.go
+++ b/pkg/release/downloader.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"archive/tar"
-	"archive/zip"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -77,14 +76,9 @@ func (d *assetDownloader) Download(ctx context.Context, artifact Artifact, opts 
 		}
 	}
 
-	// Download artifact - preserve original extension
+	// Download artifact
 	downloadURL := artifact.GetDownloadURL()
-	var archivePath string
-	if strings.HasSuffix(downloadURL, ".zip") {
-		archivePath = filepath.Join(tmpDir, "artifact.zip")
-	} else {
-		archivePath = filepath.Join(tmpDir, "artifact.tar.gz")
-	}
+	archivePath := filepath.Join(tmpDir, "artifact.tar.gz")
 
 	size, err := d.downloadFile(ctx, downloadURL, archivePath, opts.ProgressWriter)
 	if err != nil {
@@ -98,13 +92,8 @@ func (d *assetDownloader) Download(ctx context.Context, artifact Artifact, opts 
 		}
 	}
 
-	// Extract the binary based on file type
-	var binaryPath string
-	if strings.HasSuffix(archivePath, ".zip") {
-		binaryPath, err = d.extractZip(archivePath, opts.TargetDir)
-	} else {
-		binaryPath, err = d.extractTarGz(archivePath, opts.TargetDir)
-	}
+	// Extract the binary
+	binaryPath, err := d.extractTarGz(archivePath, opts.TargetDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract binary: %w", err)
 	}
@@ -380,91 +369,3 @@ func (d *assetDownloader) extractTarGz(tarPath, targetDir string) (string, error
 	return "", fmt.Errorf("miren binary not found in archive")
 }
 
-// extractZip extracts the miren binary from a zip archive
-func (d *assetDownloader) extractZip(zipPath, targetDir string) (string, error) {
-	reader, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return "", err
-	}
-	defer reader.Close()
-
-	// Create temp extraction directory
-	extractDir, err := os.MkdirTemp(targetDir, "extract-*")
-	if err != nil {
-		return "", err
-	}
-	defer os.RemoveAll(extractDir)
-
-	// Look for the miren binary
-	for _, file := range reader.File {
-		// Sanitize and validate the path to prevent path traversal attacks
-		cleanName := filepath.Clean(file.Name)
-
-		// Skip entries with problematic names
-		if cleanName == "" || cleanName == "." || cleanName == ".." {
-			continue
-		}
-
-		// Reject absolute paths
-		if filepath.IsAbs(cleanName) {
-			return "", fmt.Errorf("zip contains absolute path: %s", file.Name)
-		}
-
-		// Check for path traversal by validating the target path
-		// This catches both ".." components and symlink-based escapes
-		targetPath := filepath.Join(extractDir, cleanName)
-		relPath, err := filepath.Rel(extractDir, targetPath)
-		if err != nil || strings.HasPrefix(relPath, "..") || filepath.IsAbs(relPath) {
-			return "", fmt.Errorf("zip contains path traversal: %s", file.Name)
-		}
-
-		if filepath.Base(cleanName) == "miren" {
-			// Open the file in the zip
-			rc, err := file.Open()
-			if err != nil {
-				return "", err
-			}
-			defer rc.Close()
-
-			// Create a temporary file in a private directory with restrictive permissions
-			tempFile, err := os.CreateTemp("", "miren-extract-*.tmp")
-			if err != nil {
-				return "", err
-			}
-			tempPath := tempFile.Name()
-
-			// Ensure cleanup on error
-			defer func() {
-				if err != nil {
-					os.Remove(tempPath)
-				}
-			}()
-
-			// Copy contents to temp file
-			if _, err := io.Copy(tempFile, rc); err != nil {
-				tempFile.Close()
-				return "", err
-			}
-
-			// Close the temp file before setting permissions and moving
-			if err := tempFile.Close(); err != nil {
-				return "", err
-			}
-
-			// Set executable permissions on temp file
-			if err := os.Chmod(tempPath, 0755); err != nil {
-				return "", err
-			}
-
-			// Atomically move temp file to final location
-			finalPath := filepath.Join(targetDir, "miren.new")
-			if err := os.Rename(tempPath, finalPath); err != nil {
-				return "", err
-			}
-
-			return finalPath, nil
-		}
-	}
-
-	return "", fmt.Errorf("miren binary not found in zip archive")
-}

--- a/pkg/release/downloader.go
+++ b/pkg/release/downloader.go
@@ -368,4 +368,3 @@ func (d *assetDownloader) extractTarGz(tarPath, targetDir string) (string, error
 
 	return "", fmt.Errorf("miren binary not found in archive")
 }
-

--- a/pkg/release/metadata_test.go
+++ b/pkg/release/metadata_test.go
@@ -14,7 +14,7 @@ func TestParseMetadata(t *testing.T) {
 		"artifacts": [
 			{"name": "miren-base-linux-amd64.tar.gz", "sha256": "sha256hash1", "size": 1024},
 			{"name": "miren-base-linux-arm64.tar.gz", "sha256": "sha256hash2", "size": 2048},
-			{"name": "miren-linux-amd64.zip", "sha256": "sha256hash3", "platform": "linux", "arch": "amd64"}
+			{"name": "miren-linux-amd64.tar.gz", "sha256": "sha256hash3", "platform": "linux", "arch": "amd64"}
 		]
 	}`
 


### PR DESCRIPTION
Our per-platform binary artifacts (`miren-linux-amd64.zip`, etc.) required `unzip` on the target system, which plenty of minimal Linux distributions don't include. Meanwhile `tar` is universal on both Linux and macOS, and the base release artifacts were already using tar.gz — so the binary artifacts were the odd ones out.

This switches the Go client code (`pkg/release/artifact.go`, `downloader.go`) to request and extract `.tar.gz` exclusively, removing the `extractZip()` code path entirely. The build scripts and CI pipeline now produce both `.tar.gz` and `.zip` during a transition period, so older clients that still ask for `.zip` can self-upgrade without breaking.

The systemd test Dockerfile also drops `unzip` from its package list since it's no longer needed.

Once old clients have aged out, a follow-up PR will stop producing `.zip` artifacts. There are also companion changes needed in `mirendev/cloud` (installer script) and `mirendev/mirendev` (website download URLs) to switch to the new filenames.

Closes MIR-768