### PR TITLE
Pivot `miren oidc` to `miren auth ci`

### DIFF
--- a/cli/commands/auth_ci.go
+++ b/cli/commands/auth_ci.go
@@ -10,7 +10,7 @@ import (
 
 const gitHubActionsIssuer = "https://token.actions.githubusercontent.com"
 
-func OidcAdd(ctx *Context, opts struct {
+func AuthCI(ctx *Context, opts struct {
 	GitHub        string `long:"github" description:"GitHub owner/repo shorthand (sets issuer, subject, provider)"`
 	Issuer        string `long:"issuer" description:"OIDC issuer URL"`
 	Subject       string `long:"subject" description:"Glob pattern for the token subject"`
@@ -111,7 +111,7 @@ func OidcAdd(ctx *Context, opts struct {
 	return nil
 }
 
-func OidcList(ctx *Context, opts struct {
+func AuthCIList(ctx *Context, opts struct {
 	AppCentric
 }) error {
 	client, err := ctx.RPCClient("dev.miren.runtime/oidc-bindings")
@@ -129,7 +129,7 @@ func OidcList(ctx *Context, opts struct {
 
 	bindings := resp.Bindings()
 	if len(bindings) == 0 {
-		ctx.Printf("No OIDC bindings found for app %s\n", opts.App)
+		ctx.Printf("No CI authentication bindings found for app %s\n", opts.App)
 		return nil
 	}
 
@@ -162,8 +162,8 @@ func OidcList(ctx *Context, opts struct {
 	return nil
 }
 
-func OidcRemove(ctx *Context, opts struct {
-	ID string `position:"0" usage:"ID of the OIDC binding to remove"`
+func AuthCIRemove(ctx *Context, opts struct {
+	ID string `position:"0" usage:"ID of the CI authentication binding to remove"`
 	ConfigCentric
 }) error {
 	if opts.ID == "" {
@@ -187,7 +187,7 @@ func OidcRemove(ctx *Context, opts struct {
 		return fmt.Errorf("%s", resp.Error())
 	}
 
-	ctx.Printf("Removed OIDC binding %s\n", opts.ID)
+	ctx.Printf("Removed CI authentication binding %s\n", opts.ID)
 	return nil
 }
 

--- a/cli/commands/auth_ci.go
+++ b/cli/commands/auth_ci.go
@@ -10,7 +10,7 @@ import (
 
 const gitHubActionsIssuer = "https://token.actions.githubusercontent.com"
 
-func AuthCI(ctx *Context, opts struct {
+func AuthCIAdd(ctx *Context, opts struct {
 	GitHub        string `long:"github" description:"GitHub owner/repo shorthand (sets issuer, subject, provider)"`
 	Issuer        string `long:"issuer" description:"OIDC issuer URL"`
 	Subject       string `long:"subject" description:"Glob pattern for the token subject"`

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -512,12 +512,6 @@ miren deploy --analyze
 		))
 	}
 
-	// OIDC binding commands
-	d.Dispatch("oidc", Section("oidc", "OIDC authentication binding management", ""))
-	d.Dispatch("oidc add", Infer("oidc add", "Add an OIDC binding to an application", OidcAdd))
-	d.Dispatch("oidc list", Infer("oidc list", "List OIDC bindings for an application", OidcList))
-	d.Dispatch("oidc remove", Infer("oidc remove", "Remove an OIDC binding", OidcRemove))
-
 	// Config commands
 	d.Dispatch("config", Section("config", "Configuration file management", ""))
 	d.Dispatch("config info", Infer("config info", "Show configuration file locations and format", ConfigInfo,
@@ -757,6 +751,9 @@ miren deploy --analyze
 			Body: "miren auth generate",
 		}),
 	))
+	d.Dispatch("auth ci", Infer("auth ci", "Add a CI authentication binding to an application", AuthCI))
+	d.Dispatch("auth ci list", Infer("auth ci list", "List CI authentication bindings for an application", AuthCIList))
+	d.Dispatch("auth ci remove", Infer("auth ci remove", "Remove a CI authentication binding", AuthCIRemove))
 
 	// Admin commands
 	d.Dispatch("admin", Infer("admin", "Call an admin method on an application", Admin,

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -751,7 +751,8 @@ miren deploy --analyze
 			Body: "miren auth generate",
 		}),
 	))
-	d.Dispatch("auth ci", Infer("auth ci", "Add a CI authentication binding to an application", AuthCI))
+	d.Dispatch("auth ci", Section("auth ci", "CI authentication binding management", ""))
+	d.Dispatch("auth ci add", Infer("auth ci add", "Add a CI authentication binding to an application", AuthCIAdd))
 	d.Dispatch("auth ci list", Infer("auth ci list", "List CI authentication bindings for an application", AuthCIList))
 	d.Dispatch("auth ci remove", Infer("auth ci remove", "Remove a CI authentication binding", AuthCIRemove))
 


### PR DESCRIPTION
## Summary

- Move CI authentication binding commands from top-level `miren oidc` to `miren auth ci` for a clearer CLI hierarchy
- Rename `oidc.go` → `auth_ci.go` and update function names (`OidcAdd` → `AuthCI`, `OidcList` → `AuthCIList`, `OidcRemove` → `AuthCIRemove`)
- Update user-facing strings ("OIDC binding" → "CI authentication binding")
- `route oidc` commands (HTTP route auth, labs-gated) and all server-side code remain unchanged

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (3546 tests, 0 failures)
- [x] Verify `miren auth ci --help`, `miren auth ci list --help`, `miren auth ci remove --help` show correct descriptions
- [x] Verify `miren oidc` no longer appears in top-level help

Closes MIR-769