### PR TITLE
Prompt to initialize app when no config is found

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -11,11 +13,13 @@ import (
 	"github.com/NimbleMarkets/ntcharts/linechart/timeserieslinechart"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
 
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/rpc/standard"
+	"miren.dev/runtime/pkg/ui"
 	"miren.dev/runtime/pkg/units"
 )
 
@@ -49,7 +53,51 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 		if a.config != nil && a.config.Name != "" {
 			a.App = a.config.Name
 		} else {
-			return fmt.Errorf("app is required")
+			// No app name from flag or config — try to help the user.
+			workDir := a.Dir
+			if workDir == "." || workDir == "" {
+				wd, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("no app configured; run 'miren init' to set up your app, or use -a <name>")
+				}
+				workDir = wd
+			} else {
+				absDir, err := filepath.Abs(workDir)
+				if err == nil {
+					workDir = absDir
+				}
+			}
+
+			appName := inferAppName(workDir)
+
+			if !term.IsTerminal(int(os.Stdin.Fd())) {
+				return fmt.Errorf("no app configured; run 'miren init' to set up your app, or use -a <name>")
+			}
+
+			confirmed, err := ui.Confirm(
+				ui.WithMessage(fmt.Sprintf("No app configuration found. Initialize app %q in this directory?", appName)),
+				ui.WithDefault(true),
+				ui.WithIndent("  "),
+			)
+			if err != nil || !confirmed {
+				return fmt.Errorf("no app configured; run 'miren init' to set up your app, or use -a <name>")
+			}
+
+			if _, err := initApp(workDir, appName); err != nil {
+				return fmt.Errorf("failed to initialize app: %w", err)
+			}
+
+			// Reload the config we just created.
+			if a.Dir != "." && a.Dir != "" {
+				a.config, err = appconfig.LoadAppConfigUnder(a.Dir)
+			} else {
+				a.config, err = appconfig.LoadAppConfig()
+			}
+			if err != nil {
+				return fmt.Errorf("error loading %s: %w", appconfig.AppConfigPath, err)
+			}
+
+			a.App = appName
 		}
 	}
 

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -58,7 +58,7 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 			if workDir == "." || workDir == "" {
 				wd, err := os.Getwd()
 				if err != nil {
-					return fmt.Errorf("no app configured; run 'miren init' to set up your app, or use -a <name>")
+					return fmt.Errorf("no app configuration found — run 'miren init' to get started, or pass -a <name>")
 				}
 				workDir = wd
 			} else {
@@ -70,17 +70,19 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 
 			appName := inferAppName(workDir)
 
+			noAppMsg := "no app configuration found — run 'miren init' to get started, or pass -a <name>"
+
 			if !term.IsTerminal(int(os.Stdin.Fd())) {
-				return fmt.Errorf("no app configured; run 'miren init' to set up your app, or use -a <name>")
+				return fmt.Errorf("%s", noAppMsg)
 			}
 
 			confirmed, err := ui.Confirm(
-				ui.WithMessage(fmt.Sprintf("No app configuration found. Initialize app %q in this directory?", appName)),
+				ui.WithMessage(fmt.Sprintf("Looks like this directory isn't set up yet. Run 'miren init' to create app %q here?", appName)),
 				ui.WithDefault(true),
 				ui.WithIndent("  "),
 			)
 			if err != nil || !confirmed {
-				return fmt.Errorf("no app configured; run 'miren init' to set up your app, or use -a <name>")
+				return fmt.Errorf("%s", noAppMsg)
 			}
 
 			if _, err := initApp(workDir, appName); err != nil {

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -87,12 +87,8 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 				return fmt.Errorf("failed to initialize app: %w", err)
 			}
 
-			// Reload the config we just created.
-			if a.Dir != "." && a.Dir != "" {
-				a.config, err = appconfig.LoadAppConfigUnder(a.Dir)
-			} else {
-				a.config, err = appconfig.LoadAppConfig()
-			}
+			// Reload the config we just created. workDir is already absolute.
+			a.config, err = appconfig.LoadAppConfigUnder(workDir)
 			if err != nil {
 				return fmt.Errorf("error loading %s: %w", appconfig.AppConfigPath, err)
 			}

--- a/cli/commands/app_test.go
+++ b/cli/commands/app_test.go
@@ -18,6 +18,27 @@ func writeAppToml(t *testing.T, dir, content string) {
 	}
 }
 
+func TestInferAppName(t *testing.T) {
+	tests := []struct {
+		dir  string
+		want string
+	}{
+		{"/home/user/my-app", "my-app"},
+		{"/home/user/My App", "my-app"},
+		{"/home/user/my_app", "my-app"},
+		{"/home/user/MyApp", "myapp"},
+		{"/home/user/HELLO", "hello"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dir, func(t *testing.T) {
+			got := inferAppName(tt.dir)
+			if got != tt.want {
+				t.Errorf("inferAppName(%q) = %q, want %q", tt.dir, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAppCentricValidate(t *testing.T) {
 	t.Run("invalid TOML syntax returns parse error", func(t *testing.T) {
 		dir := t.TempDir()
@@ -73,7 +94,7 @@ command = ["foo", "bar"]
 		}
 	})
 
-	t.Run("no app.toml returns app is required", func(t *testing.T) {
+	t.Run("no app.toml returns helpful error mentioning miren init", func(t *testing.T) {
 		dir := t.TempDir()
 
 		a := AppCentric{Dir: dir}
@@ -81,8 +102,11 @@ command = ["foo", "bar"]
 		if err == nil {
 			t.Fatal("expected error when no app.toml exists")
 		}
-		if err.Error() != "app is required" {
-			t.Errorf("expected 'app is required', got: %v", err)
+		if !strings.Contains(err.Error(), "miren init") {
+			t.Errorf("expected error to mention 'miren init', got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "-a") {
+			t.Errorf("expected error to mention '-a' flag, got: %v", err)
 		}
 	})
 

--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -10,12 +10,54 @@ import (
 	"miren.dev/runtime/appconfig"
 )
 
+// inferAppName derives a sanitized app name from a directory path.
+func inferAppName(dir string) string {
+	name := filepath.Base(dir)
+	name = strings.ToLower(name)
+	name = strings.ReplaceAll(name, " ", "-")
+	name = strings.ReplaceAll(name, "_", "-")
+	return name
+}
+
+// initApp creates a .miren/app.toml in dir with the given app name.
+// It returns the path to the created file.
+func initApp(dir, name string) (string, error) {
+	appTomlPath := filepath.Join(dir, appconfig.AppConfigPath)
+	runtimeDir := filepath.Dir(appTomlPath)
+
+	if _, err := os.Stat(appTomlPath); err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("failed to check for existing app.toml: %w", err)
+		}
+	} else {
+		return "", fmt.Errorf("app.toml already exists in %s - app already initialized", runtimeDir)
+	}
+
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create .miren directory: %w", err)
+	}
+
+	appConfig := &appconfig.AppConfig{
+		Name: name,
+	}
+
+	content, err := toml.Marshal(appConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal app config: %w", err)
+	}
+
+	if err := os.WriteFile(appTomlPath, content, 0644); err != nil {
+		return "", fmt.Errorf("failed to write app.toml: %w", err)
+	}
+
+	return appTomlPath, nil
+}
+
 func Init(ctx *Context, opts struct {
 	Name string `short:"n" long:"name" description:"Application name (defaults to directory name)"`
 	Dir  string `short:"d" long:"dir" description:"Application directory (defaults to current directory)"`
 	ConfigCentric
 }) error {
-	// Determine working directory
 	workDir := opts.Dir
 	if workDir == "" {
 		wd, err := os.Getwd()
@@ -24,7 +66,6 @@ func Init(ctx *Context, opts struct {
 		}
 		workDir = wd
 	} else {
-		// Convert to absolute path
 		absDir, err := filepath.Abs(workDir)
 		if err != nil {
 			return fmt.Errorf("failed to resolve directory path: %w", err)
@@ -32,51 +73,14 @@ func Init(ctx *Context, opts struct {
 		workDir = absDir
 	}
 
-	// Determine app name
 	appName := opts.Name
 	if appName == "" {
-		// Use directory name as default
-		appName = filepath.Base(workDir)
-
-		// Sanitize the app name - replace spaces and special chars with hyphens
-		appName = strings.ToLower(appName)
-		appName = strings.ReplaceAll(appName, " ", "-")
-		appName = strings.ReplaceAll(appName, "_", "-")
+		appName = inferAppName(workDir)
 	}
 
-	// Check if already initialized
-	appTomlPath := filepath.Join(workDir, appconfig.AppConfigPath)
-	runtimeDir := filepath.Dir(appTomlPath)
-	if _, err := os.Stat(appTomlPath); err != nil {
-		if !os.IsNotExist(err) {
-			// Return unexpected errors (permission denied, IO errors, etc.)
-			return fmt.Errorf("failed to check for existing app.toml: %w", err)
-		}
-		// File doesn't exist, continue with initialization
-	} else {
-		// File exists
-		return fmt.Errorf("app.toml already exists in %s - app already initialized", runtimeDir)
-	}
-
-	// Create .miren directory
-	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
-		return fmt.Errorf("failed to create .miren directory: %w", err)
-	}
-
-	// Create app config with just the name
-	appConfig := &appconfig.AppConfig{
-		Name: appName,
-	}
-
-	// Marshal to TOML
-	content, err := toml.Marshal(appConfig)
+	appTomlPath, err := initApp(workDir, appName)
 	if err != nil {
-		return fmt.Errorf("failed to marshal app config: %w", err)
-	}
-
-	// Write app.toml
-	if err := os.WriteFile(appTomlPath, content, 0644); err != nil {
-		return fmt.Errorf("failed to write app.toml: %w", err)
+		return err
 	}
 
 	ctx.Printf("Initialized Miren app '%s' in %s\n", appName, appTomlPath)


### PR DESCRIPTION
Running any app command without a `.miren/app.toml` used to give you a pretty unhelpful "app is required" error. Now it meets you where you are — if you're on a TTY, it infers an app name from your directory, offers to run `miren init` for you, and gets on with it. In CI or piped contexts, the error message tells you what to do next.

The init logic got pulled into shared `inferAppName` and `initApp` helpers so both the `miren init` command and the `AppCentric.Validate` prompt go through the same path. This lives in Validate rather than just Deploy, so every app command gets the zero-config onramp for free.

## UX Demo

**Interactive (TTY) — no config, first deploy:**
```
~/my-cool-app $ miren deploy
  Looks like this directory isn't set up yet. Run 'miren init' to create app "my-cool-app" here? (Y/n)
Deploying my-cool-app...
```

**Non-interactive (CI/piped) — clear guidance:**
```
$ miren deploy 2>&1
error: no app configuration found — run 'miren init' to get started, or pass -a <name>
```

**Already initialized — no change, works as before:**
```
~/my-cool-app $ cat .miren/app.toml
name = "my-cool-app"
~/my-cool-app $ miren deploy
Deploying my-cool-app...
```

Closes MIR-518