### PR TITLE
Close channel in ChanWriter when RPC stream ends

### DIFF
--- a/pkg/rpc/inline.go
+++ b/pkg/rpc/inline.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -10,6 +11,8 @@ import (
 	"github.com/quic-go/webtransport-go"
 	"miren.dev/runtime/pkg/cond"
 )
+
+var errInlineClientClosed = errors.New("inline client closed")
 
 const inlineStreamPoolSize = 10
 
@@ -33,25 +36,35 @@ type inlineClient struct {
 }
 
 // initPool initializes the stream pool
-func (c *inlineClient) initPool() {
+func (c *inlineClient) initPool() error {
 	c.poolMu.Lock()
 	defer c.poolMu.Unlock()
 
+	if c.closed {
+		return errInlineClientClosed
+	}
+
 	if c.pool != nil {
-		return
+		return nil
 	}
 
 	c.pool = make(chan *streamConn, inlineStreamPoolSize)
+	return nil
 }
 
 // getStream gets a stream from the pool or creates a new one if pool is not full
 func (c *inlineClient) getStream(ctx context.Context) (*streamConn, error) {
 	// Ensure pool is initialized
-	c.initPool()
+	if err := c.initPool(); err != nil {
+		return nil, err
+	}
 
 	// Try to get an existing stream from the pool
 	select {
-	case conn := <-c.pool:
+	case conn, ok := <-c.pool:
+		if !ok {
+			return nil, errInlineClientClosed
+		}
 		return conn, nil
 	default:
 		// Pool is empty, check if we can create a new stream
@@ -82,7 +95,10 @@ func (c *inlineClient) getStream(ctx context.Context) (*streamConn, error) {
 
 		// Pool is at capacity, wait for a stream to become available
 		select {
-		case conn := <-c.pool:
+		case conn, ok := <-c.pool:
+			if !ok {
+				return nil, errInlineClientClosed
+			}
 			return conn, nil
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -195,8 +211,10 @@ func (c *inlineClient) Close() error {
 	}
 
 	// Close all streams in the pool
-	close(c.pool)
-	for conn := range c.pool {
+	ch := c.pool
+	c.pool = nil
+	close(ch)
+	for conn := range ch {
 		_ = conn.stream.Close()
 		c.activeCount--
 	}

--- a/pkg/rpc/stream/stream.go
+++ b/pkg/rpc/stream/stream.go
@@ -225,6 +225,7 @@ func ChanReader[T any](ch <-chan T) RecvStream[T] {
 
 func ChanWriter[T any](ctx context.Context, rs *RecvStreamClient[T], ch chan<- T) {
 	go func() {
+		defer close(ch)
 		defer rs.Close()
 
 		for {

--- a/pkg/rpc/stream/stream_test.go
+++ b/pkg/rpc/stream/stream_test.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	rpc "miren.dev/runtime/pkg/rpc"
@@ -80,5 +81,54 @@ func TestStream(t *testing.T) {
 			{Name: "foo"},
 		}, vals)
 
+	})
+
+	t.Run("ChanWriter closes output channel when stream ends", func(t *testing.T) {
+		r := require.New(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Server side: expose a RecvStream backed by a channel
+		sourceCh := make(chan int)
+
+		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+		r.NoError(err)
+
+		serv := ss.Server()
+		serv.ExposeValue("stream", AdaptRecvStream(ChanReader(sourceCh)))
+
+		// Client side: connect and wrap as RecvStreamClient
+		cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+		r.NoError(err)
+
+		c, err := cs.Connect(ss.ListenAddr(), "stream")
+		r.NoError(err)
+
+		rsc := NewRecvStreamClient[int](c)
+
+		// Wire ChanWriter: reads from rsc, writes to outputCh
+		outputCh := make(chan int, 10)
+		ChanWriter(ctx, rsc, outputCh)
+
+		// Send a value through and verify it arrives
+		sourceCh <- 42
+		select {
+		case v := <-outputCh:
+			r.Equal(42, v)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for value")
+		}
+
+		// Close the source channel, which should cause ChanWriter to
+		// close the output channel (this is the bug fix for MIR-622)
+		close(sourceCh)
+
+		select {
+		case _, ok := <-outputCh:
+			r.False(ok, "output channel should be closed")
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for output channel to close")
+		}
 	})
 }


### PR DESCRIPTION
`miren exec` (and `miren app run`, which goes through the same server path) would panic with "close of closed channel" after the command finished. The exec output came back fine, but then the RPC handler blew up — not great for service stability.

There were actually two bugs conspiring here. The first was `ChanWriter` in `pkg/rpc/stream/stream.go` — it spawns a goroutine that reads from an RPC stream and forwards values into a Go channel, but when the stream ended it just returned without closing the output channel. Since `ChanWriter` is the only sender, it owns channel closure by Go convention. Added `defer close(ch)` and a test that wires up a full RPC pipeline to verify the channel gets closed when the source goes away.

The second (and the one actually producing the panic in the stacktrace) was `inlineClient.Close()` in `pkg/rpc/inline.go`. It calls `close(c.pool)` but never nils out `c.pool` afterwards. When the RPC framework tears down a streaming call, both the handler's defers and the framework's own cleanup end up calling `Close()` on the same client — the second call sees `c.pool != nil`, tries to close it again, and panics. The fix nils out `c.pool` before closing so the second call is a no-op.

Confirmed the fix by deploying a test app in the dev environment and running `sandbox exec` repeatedly — zero panics across multiple runs, where before it panicked every time.

Closes MIR-622