### PR TITLE
Detect Bun runtime from package.json when no lockfile is present

### DIFF
--- a/pkg/stackbuild/bun.go
+++ b/pkg/stackbuild/bun.go
@@ -69,7 +69,7 @@ func (s *BunStack) detectPackageManagerBun() bool {
 	return strings.HasPrefix(pkg.PackageManager, "bun@")
 }
 
-var bunCommandRe = regexp.MustCompile(`(?:^|\s)bun(?:\s|$)`)
+var bunCommandRe = regexp.MustCompile(`(?:^|\s)bunx?(?:\s|$)`)
 
 func (s *BunStack) detectBunInScripts() bool {
 	scripts := s.getPackageScripts()

--- a/pkg/stackbuild/bun.go
+++ b/pkg/stackbuild/bun.go
@@ -2,6 +2,8 @@ package stackbuild
 
 import (
 	"encoding/json"
+	"regexp"
+	"strings"
 
 	"github.com/moby/buildkit/client/llb"
 	"miren.dev/runtime/pkg/imagerefs"
@@ -34,9 +36,47 @@ func (s *BunStack) Detect() bool {
 		s.Event("file", "bun.lockb", "Found bun.lockb (Bun runtime, legacy)")
 		return true
 	}
+	if s.hasFile("bunfig.toml") {
+		s.Event("file", "bunfig.toml", "Found bunfig.toml (Bun runtime)")
+		return true
+	}
+	if s.detectPackageManagerBun() {
+		s.Event("config", "packageManager", "package.json packageManager field specifies bun")
+		return true
+	}
+	if s.detectBunInScripts() {
+		s.Event("config", "scripts", "package.json scripts reference bun")
+		return true
+	}
 	if s.detectInFile("Procfile", `web:\s+bun`) {
 		s.Event("file", "Procfile", "Procfile references bun")
 		return true
+	}
+	return false
+}
+
+func (s *BunStack) detectPackageManagerBun() bool {
+	data, err := s.readFile("package.json")
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		PackageManager string `json:"packageManager"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	return strings.HasPrefix(pkg.PackageManager, "bun@")
+}
+
+var bunCommandRe = regexp.MustCompile(`(?:^|\s)bun(?:\s|$)`)
+
+func (s *BunStack) detectBunInScripts() bool {
+	scripts := s.getPackageScripts()
+	for _, cmd := range scripts {
+		if bunCommandRe.MatchString(cmd) {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -76,8 +76,8 @@ func DetectStack(dir string, opts BuildOptions) (Stack, error) {
 	stacks := []Stack{
 		&RubyStack{MetaStack: ms},
 		&PythonStack{MetaStack: ms},
-		&NodeStack{MetaStack: ms},
 		&BunStack{MetaStack: ms},
+		&NodeStack{MetaStack: ms},
 		&GoStack{MetaStack: ms},
 		&RustStack{MetaStack: ms},
 	}

--- a/pkg/stackbuild/stackbuild_test.go
+++ b/pkg/stackbuild/stackbuild_test.go
@@ -512,6 +512,13 @@ func TestBunDetect(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "bunx in scripts",
+			files: map[string]string{
+				"package.json": `{"name": "app", "scripts": {"test": "bunx vitest"}}`,
+			},
+			expected: true,
+		},
+		{
 			name: "bun at end of script command",
 			files: map[string]string{
 				"package.json": `{"name": "app", "scripts": {"start": "npx something && bun"}}`,

--- a/pkg/stackbuild/stackbuild_test.go
+++ b/pkg/stackbuild/stackbuild_test.go
@@ -438,6 +438,120 @@ func TestBun(t *testing.T) {
 	buildLLB(t, dir, state)
 }
 
+func TestBunDetect(t *testing.T) {
+	testCases := []struct {
+		name     string
+		files    map[string]string
+		expected bool
+	}{
+		{
+			name: "bun.lock",
+			files: map[string]string{
+				"package.json": `{"name": "app"}`,
+				"bun.lock":     "",
+			},
+			expected: true,
+		},
+		{
+			name: "bun.lockb legacy",
+			files: map[string]string{
+				"package.json": `{"name": "app"}`,
+				"bun.lockb":    "",
+			},
+			expected: true,
+		},
+		{
+			name: "bunfig.toml",
+			files: map[string]string{
+				"package.json": `{"name": "app"}`,
+				"bunfig.toml":  "[install]\noptional = true\n",
+			},
+			expected: true,
+		},
+		{
+			name: "packageManager field",
+			files: map[string]string{
+				"package.json": `{"name": "app", "packageManager": "bun@1.1.0"}`,
+			},
+			expected: true,
+		},
+		{
+			name: "bun in scripts",
+			files: map[string]string{
+				"package.json": `{"name": "app", "scripts": {"start": "bun run index.ts"}}`,
+			},
+			expected: true,
+		},
+		{
+			name: "bun as standalone command in scripts",
+			files: map[string]string{
+				"package.json": `{"name": "app", "scripts": {"dev": "bun --watch index.ts"}}`,
+			},
+			expected: true,
+		},
+		{
+			name: "Procfile with bun",
+			files: map[string]string{
+				"package.json": `{"name": "app"}`,
+				"Procfile":     "web: bun run start",
+			},
+			expected: true,
+		},
+		{
+			name: "plain package.json no bun signals",
+			files: map[string]string{
+				"package.json": `{"name": "app", "scripts": {"start": "node index.js"}}`,
+			},
+			expected: false,
+		},
+		{
+			name: "no package.json",
+			files: map[string]string{
+				"index.ts": "console.log('hi')",
+			},
+			expected: false,
+		},
+		{
+			name: "bun at end of script command",
+			files: map[string]string{
+				"package.json": `{"name": "app", "scripts": {"start": "npx something && bun"}}`,
+			},
+			expected: true,
+		},
+		{
+			name: "bundle in scripts is not bun",
+			files: map[string]string{
+				"package.json": `{"name": "app", "scripts": {"start": "bundle exec rails server"}}`,
+			},
+			expected: false,
+		},
+		{
+			name: "packageManager field for npm not bun",
+			files: map[string]string{
+				"package.json": `{"name": "app", "packageManager": "npm@10.0.0"}`,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			for name, content := range tc.files {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))
+			}
+
+			stack := &BunStack{
+				MetaStack: MetaStack{
+					dir: dir,
+				},
+			}
+			require.Equal(t, tc.expected, stack.Detect())
+		})
+	}
+}
+
 func TestGo(t *testing.T) {
 	if !checkDocker() {
 		t.Skip("Docker not available")


### PR DESCRIPTION
Stack detection was gated on finding a `bun.lock` or `bun.lockb` file, which works great when there are dependencies — but a Bun app with no deps never generates a lockfile. That meant deploys would either fail or fall back to the wrong runtime, which isn't a great experience for someone just trying to ship a simple Bun server.

We now pick up on three additional signals: a `bunfig.toml` config file, the `"packageManager": "bun@..."` field in package.json, and any package.json script that invokes `bun` as a command (using a word-boundary regex so things like `bundle` don't false-positive). The lock file checks are still there and still checked first, so existing projects are unaffected.

Also swapped the detection order so Bun runs before Node. Both stacks look for package.json, but since all of Bun's new signals are unambiguous and Node still requires its own lock files, there's no risk of a Node project accidentally matching as Bun.

Closes MIR-773