### PR TITLE
Preserve structured log attributes in `miren logs system`

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -3,6 +3,7 @@ package app_v1alpha
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"slices"
 
 	"github.com/fxamacker/cbor/v2"
@@ -1376,10 +1377,11 @@ func (v *ApplicationStatus) UnmarshalJSON(data []byte) error {
 }
 
 type logEntryData struct {
-	Timestamp *standard.Timestamp `cbor:"0,keyasint,omitempty" json:"timestamp,omitempty"`
-	Line      *string             `cbor:"1,keyasint,omitempty" json:"line,omitempty"`
-	Stream    *string             `cbor:"2,keyasint,omitempty" json:"stream,omitempty"`
-	Source    *string             `cbor:"3,keyasint,omitempty" json:"source,omitempty"`
+	Timestamp  *standard.Timestamp `cbor:"0,keyasint,omitempty" json:"timestamp,omitempty"`
+	Line       *string             `cbor:"1,keyasint,omitempty" json:"line,omitempty"`
+	Stream     *string             `cbor:"2,keyasint,omitempty" json:"stream,omitempty"`
+	Source     *string             `cbor:"3,keyasint,omitempty" json:"source,omitempty"`
+	Attributes *map[string]string  `cbor:"4,keyasint,omitempty" json:"attributes,omitempty"`
 }
 
 type LogEntry struct {
@@ -1441,6 +1443,22 @@ func (v *LogEntry) Source() string {
 
 func (v *LogEntry) SetSource(source string) {
 	v.data.Source = &source
+}
+
+func (v *LogEntry) HasAttributes() bool {
+	return v.data.Attributes != nil
+}
+
+func (v *LogEntry) Attributes() map[string]string {
+	if v.data.Attributes == nil {
+		return nil
+	}
+	return *v.data.Attributes
+}
+
+func (v *LogEntry) SetAttributes(attributes map[string]string) {
+	x := maps.Clone(attributes)
+	v.data.Attributes = &x
 }
 
 func (v *LogEntry) MarshalCBOR() ([]byte, error) {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -292,6 +292,11 @@ types:
       - name: source
         type: string
         index: 3
+      - name: attributes
+        type: map
+        key: string
+        value: string
+        index: 4
 
   - type: LogChunk
     fields:

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -238,11 +239,41 @@ func printLogEntry(ctx *Context, l *app_v1alpha.LogEntry) {
 		}
 		prefix = "[" + source + "] "
 	}
-	ctx.Printf("%s %s: %s%s\n",
+	attrs := ""
+	if l.HasAttributes() {
+		attrs = formatAttributes(l.Attributes())
+	}
+	ctx.Printf("%s %s: %s%s%s\n",
 		streamTypePrefixes[l.Stream()],
 		standard.FromTimestamp(l.Timestamp()).Format("2006-01-02 15:04:05"),
 		prefix,
-		l.Line())
+		l.Line(),
+		attrs)
+}
+
+func formatAttributes(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteByte(' ')
+		b.WriteString(k)
+		b.WriteByte('=')
+		v := m[k]
+		if strings.ContainsAny(v, " \t\"\n\r") {
+			fmt.Fprintf(&b, "%q", v)
+		} else {
+			b.WriteString(v)
+		}
+	}
+	return b.String()
 }
 
 func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *time.Duration, follow bool, filter *logfilter.Filter) error {

--- a/pkg/rpc/generator.go
+++ b/pkg/rpc/generator.go
@@ -279,6 +279,10 @@ func (g *Generator) properType(name string) *j.Statement {
 	return j.Id(name)
 }
 
+func (g *Generator) mapType(field *DescField) *j.Statement {
+	return j.Map(g.properType(field.Key)).Add(g.properType(field.Value))
+}
+
 func (g *Generator) deriveType(base, sub string) string {
 	bracket := strings.IndexByte(base, '[')
 
@@ -324,6 +328,11 @@ func (g *Generator) generateServerStructs(f *j.File, t *DescInterface) error {
 							"json": p.Name + ",omitempty",
 						})
 					}
+				} else if p.Type == "map" {
+					gr.Id(toCamal(p.Name)).Op("*").Map(g.properType(p.Key)).Add(g.properType(p.Value)).Tag(map[string]string{
+						"cbor": fmt.Sprintf("%d,keyasint,omitempty", idx),
+						"json": p.Name + ",omitempty",
+					})
 				} else {
 					gr.Id(capitalize(p.Name)).Op("*").Add(g.properType(p.Type)).Tag(map[string]string{
 						"cbor": fmt.Sprintf("%d,keyasint,omitempty", idx),
@@ -350,6 +359,8 @@ func (g *Generator) generateServerStructs(f *j.File, t *DescInterface) error {
 					Name:    p.Name,
 					Type:    p.Type,
 					Element: p.Element,
+					Key:     p.Key,
+					Value:   p.Value,
 					Index:   idx,
 				},
 			)
@@ -387,6 +398,11 @@ func (g *Generator) generateServerStructs(f *j.File, t *DescInterface) error {
 							"json": p.Name + ",omitempty",
 						})
 					}
+				} else if p.Type == "map" {
+					gr.Id(capitalize(p.Name)).Op("*").Map(g.properType(p.Key)).Add(g.properType(p.Value)).Tag(map[string]string{
+						"cbor": fmt.Sprintf("%d,keyasint,omitempty", idx),
+						"json": p.Name + ",omitempty",
+					})
 				} else {
 					gr.Id(capitalize(p.Name)).Op("*").Add(g.properType(p.Type)).Tag(map[string]string{
 						"cbor": fmt.Sprintf("%d,keyasint,omitempty", idx),
@@ -412,6 +428,8 @@ func (g *Generator) generateServerStructs(f *j.File, t *DescInterface) error {
 					Name:    p.Name,
 					Type:    p.Type,
 					Element: p.Element,
+					Key:     p.Key,
+					Value:   p.Value,
 					Index:   idx,
 				},
 			)
@@ -540,6 +558,25 @@ func (g *Generator) readForField(f *j.File, t *DescType, field *DescField) {
 				j.Return(j.Op("*").Id("v").Dot("data").Dot(name)),
 			)
 		}
+
+		f.Line()
+	case "map":
+		f.Func().Params(
+			j.Id("v").Op("*").Add(recv),
+		).Id("Has" + fname).Params().Bool().Block(
+			j.Return(j.Id("v").Dot("data").Dot(name).Op("!=").Nil()),
+		)
+
+		f.Line()
+
+		f.Func().Params(
+			j.Id("v").Op("*").Add(recv),
+		).Id(fname).Params().Add(g.mapType(field)).Block(
+			j.If(j.Id("v").Dot("data").Dot(name).Op("==").Nil()).Block(
+				j.Return(j.Nil()),
+			),
+			j.Return(j.Op("*").Id("v").Dot("data").Dot(name)),
+		)
 
 		f.Line()
 	default:
@@ -711,6 +748,16 @@ func (g *Generator) writeForField(f *j.File, t *DescType, field *DescField) {
 				j.Id("v").Dot("data").Dot(name).Op("=").Op("&").Id("x"),
 			)
 		}
+
+	case "map":
+		f.Func().Params(
+			j.Id("v").Op("*").Add(recv),
+		).Id("Set"+fname).Params(
+			j.Id(pname).Add(g.mapType(field)),
+		).Block(
+			j.Id("x").Op(":=").Qual("maps", "Clone").Call(j.Id(pname)),
+			j.Id("v").Dot("data").Dot(name).Op("=").Op("&").Id("x"),
+		)
 
 	default:
 		if g.ti(field.Type).isInterface {
@@ -909,6 +956,12 @@ func (g *Generator) generateCompactStruct(f *j.File, t *DescType) error {
 						"json": toSnake(field.Name) + ",omitempty",
 					})
 				}
+
+			case "map":
+				gr.Id(toCamal(field.Name)).Add(g.mapType(field)).Tag(map[string]string{
+					"cbor": fmt.Sprintf("%d,keyasint,omitempty", field.Index),
+					"json": toSnake(field.Name) + ",omitempty",
+				})
 
 			case "union":
 				gr.Id(private(t.Type) + toCamal(field.Name))
@@ -1111,6 +1164,34 @@ func (g *Generator) generateCompactStruct(f *j.File, t *DescType) error {
 					)
 				}
 			}
+		case "map":
+			if t.Readable() {
+				f.Func().Params(
+					j.Id("v").Op("*").Add(recv),
+				).Id("Has" + fname).Params().Bool().Block(
+					j.Return(j.True()),
+				)
+
+				f.Line()
+
+				f.Func().Params(
+					j.Id("v").Op("*").Add(recv),
+				).Id(fname).Params().Add(g.mapType(field)).Block(
+					j.Return(j.Id("v").Dot("data").Dot(name)),
+				)
+
+				f.Line()
+			}
+
+			if t.Writeable() {
+				f.Func().Params(
+					j.Id("v").Op("*").Add(recv),
+				).Id("Set" + fname).Params(
+					j.Id(pname).Add(g.mapType(field)),
+				).Block(
+					j.Id("v").Dot("data").Dot(name).Op("=").Qual("maps", "Clone").Call(j.Id(pname)),
+				)
+			}
 		case "union":
 			f.Func().Params(
 				j.Id("v").Op("*").Add(recv),
@@ -1244,6 +1325,12 @@ func (g *Generator) generateStruct(f *j.File) error {
 							"json": toSnake(field.Name) + ",omitempty",
 						})
 					}
+
+				case "map":
+					gr.Id(toCamal(field.Name)).Op("*").Add(g.mapType(field)).Tag(map[string]string{
+						"cbor": fmt.Sprintf("%d,keyasint,omitempty", field.Index),
+						"json": toSnake(field.Name) + ",omitempty",
+					})
 
 				case "union":
 					gr.Id(private(t.Type) + toCamal(field.Name))
@@ -1464,6 +1551,38 @@ func (g *Generator) generateStruct(f *j.File) error {
 						)
 					}
 				}
+			case "map":
+				if t.Readable() {
+					f.Func().Params(
+						j.Id("v").Op("*").Add(recv),
+					).Id("Has" + fname).Params().Bool().Block(
+						j.Return(j.Id("v").Dot("data").Dot(name).Op("!=").Nil()),
+					)
+
+					f.Line()
+
+					f.Func().Params(
+						j.Id("v").Op("*").Add(recv),
+					).Id(fname).Params().Add(g.mapType(field)).Block(
+						j.If(j.Id("v").Dot("data").Dot(name).Op("==").Nil()).Block(
+							j.Return(j.Nil()),
+						),
+						j.Return(j.Op("*").Id("v").Dot("data").Dot(name)),
+					)
+
+					f.Line()
+				}
+
+				if t.Writeable() {
+					f.Func().Params(
+						j.Id("v").Op("*").Add(recv),
+					).Id("Set"+fname).Params(
+						j.Id(pname).Add(g.mapType(field)),
+					).Block(
+						j.Id("x").Op(":=").Qual("maps", "Clone").Call(j.Id(pname)),
+						j.Id("v").Dot("data").Dot(name).Op("=").Op("&").Id("x"),
+					)
+				}
 			case "union":
 				f.Func().Params(
 					j.Id("v").Op("*").Add(recv),
@@ -1672,6 +1791,8 @@ func (g *Generator) generateClient(f *j.File, i *DescInterface) error {
 						Name:    p.Name,
 						Type:    p.Type,
 						Element: p.Element,
+						Key:     p.Key,
+						Value:   p.Value,
 						Index:   0,
 					})
 			}
@@ -1694,6 +1815,8 @@ func (g *Generator) generateClient(f *j.File, i *DescInterface) error {
 					} else {
 						gr.Id(private(p.Name)).Index().Id(p.Element)
 					}
+				} else if p.Type == "map" {
+					gr.Id(private(p.Name)).Map(g.properType(p.Key)).Add(g.properType(p.Value))
 				} else {
 					gr.Id(private(p.Name)).Add(g.properType(p.Type))
 				}
@@ -1730,6 +1853,9 @@ func (g *Generator) generateClient(f *j.File, i *DescInterface) error {
 					gr.Id("args").Dot("data").Dot(toCamal(p.Name)).Op("=").Id(private(p.Name))
 				} else if p.Type == "list" {
 					gr.Id("x").Op(":=").Qual("slices", "Clone").Call(j.Id(private(p.Name)))
+					gr.Id("args").Dot("data").Dot(toCamal(p.Name)).Op("=").Op("&").Id("x")
+				} else if p.Type == "map" {
+					gr.Id("x").Op(":=").Qual("maps", "Clone").Call(j.Id(private(p.Name)))
 					gr.Id("args").Dot("data").Dot(toCamal(p.Name)).Op("=").Op("&").Id("x")
 				} else {
 					gr.Id("args").Dot("data").Dot(toCamal(p.Name)).Op("=").Op("&").Id(private(p.Name))
@@ -2059,6 +2185,15 @@ func (t *DescType) Validate() error {
 			}
 			seen[field.Index] = struct{}{}
 		}
+
+		if field.Type == "list" && field.Element == "" {
+			return fmt.Errorf("field %q in type %s: list requires element", field.Name, t.Type)
+		}
+		if field.Type == "map" {
+			if field.Key == "" || field.Value == "" {
+				return fmt.Errorf("field %q in type %s: map requires key and value", field.Name, t.Type)
+			}
+		}
 	}
 
 	return nil
@@ -2138,6 +2273,10 @@ func (t *DescType) CalculateOffsets(usertypes map[string]*DescType) {
 			field.wordOffset = wordOffset
 			t.pointers++
 			wordOffset++
+		case "map":
+			field.wordOffset = wordOffset
+			t.pointers++
+			wordOffset++
 		default:
 			if ut, ok := usertypes[field.Type]; ok {
 				field.wordOffset = wordOffset
@@ -2156,6 +2295,8 @@ type DescField struct {
 
 	Element string       `yaml:"element"`
 	Union   []UnionField `yaml:"union,omitempty"`
+	Key     string       `yaml:"key,omitempty"`
+	Value   string       `yaml:"value,omitempty"`
 
 	dataOffset int
 	wordOffset int
@@ -2192,4 +2333,6 @@ type DescParamater struct {
 	Name    string `yaml:"name"`
 	Type    string `yaml:"type"`
 	Element string `yaml:"element,omitempty"`
+	Key     string `yaml:"key,omitempty"`
+	Value   string `yaml:"value,omitempty"`
 }

--- a/pkg/rpc/generator_test.go
+++ b/pkg/rpc/generator_test.go
@@ -98,6 +98,24 @@ func TestGenerator(t *testing.T) {
 		r.Equal(string(data), output)
 	})
 
+	t.Run("can generate code for a message with map fields", func(t *testing.T) {
+		r := require.New(t)
+
+		g, err := NewGenerator()
+		r.NoError(err)
+
+		err = g.Read("testdata/map.yml")
+		r.NoError(err)
+
+		output, err := g.Generate("maptype")
+		r.NoError(err)
+
+		data, err := os.ReadFile("testdata/map.go")
+		r.NoError(err)
+
+		r.Equal(string(data), output)
+	})
+
 	t.Run("can generate code for an interface", func(t *testing.T) {
 		r := require.New(t)
 

--- a/pkg/rpc/testdata/map.go
+++ b/pkg/rpc/testdata/map.go
@@ -1,0 +1,80 @@
+package maptype
+
+import (
+	"encoding/json"
+	"maps"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+type heroData struct {
+	Age    *int32             `cbor:"0,keyasint,omitempty" json:"age,omitempty"`
+	Name   *string            `cbor:"1,keyasint,omitempty" json:"name,omitempty"`
+	Traits *map[string]string `cbor:"2,keyasint,omitempty" json:"traits,omitempty"`
+}
+
+type Hero struct {
+	data heroData
+}
+
+func (v *Hero) HasAge() bool {
+	return v.data.Age != nil
+}
+
+func (v *Hero) Age() int32 {
+	if v.data.Age == nil {
+		return 0
+	}
+	return *v.data.Age
+}
+
+func (v *Hero) SetAge(age int32) {
+	v.data.Age = &age
+}
+
+func (v *Hero) HasName() bool {
+	return v.data.Name != nil
+}
+
+func (v *Hero) Name() string {
+	if v.data.Name == nil {
+		return ""
+	}
+	return *v.data.Name
+}
+
+func (v *Hero) SetName(name string) {
+	v.data.Name = &name
+}
+
+func (v *Hero) HasTraits() bool {
+	return v.data.Traits != nil
+}
+
+func (v *Hero) Traits() map[string]string {
+	if v.data.Traits == nil {
+		return nil
+	}
+	return *v.data.Traits
+}
+
+func (v *Hero) SetTraits(traits map[string]string) {
+	x := maps.Clone(traits)
+	v.data.Traits = &x
+}
+
+func (v *Hero) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *Hero) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *Hero) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *Hero) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}

--- a/pkg/rpc/testdata/map.yml
+++ b/pkg/rpc/testdata/map.yml
@@ -1,0 +1,14 @@
+types:
+- type: Hero
+  fields:
+    - name: age
+      type: int32
+      index: 0
+    - name: name
+      type: string
+      index: 1
+    - name: traits
+      type: map
+      key: string
+      value: string
+      index: 2

--- a/servers/logs/logs.go
+++ b/servers/logs/logs.go
@@ -31,6 +31,18 @@ func toLogEntry(entry observability.LogEntry) *app_v1alpha.LogEntry {
 	if source, ok := entry.Attributes["source"]; ok {
 		le.SetSource(source)
 	}
+	if len(entry.Attributes) > 0 {
+		attrs := make(map[string]string, len(entry.Attributes))
+		for k, v := range entry.Attributes {
+			if k == "source" {
+				continue
+			}
+			attrs[k] = v
+		}
+		if len(attrs) > 0 {
+			le.SetAttributes(attrs)
+		}
+	}
 	return le
 }
 


### PR DESCRIPTION
`miren logs system` was showing bare messages without any of the structured context that slog attaches — no `module`, `level`, `err`, nothing. If you wanted to see what was actually going on, you had to SSH in and read journalctl. The data was there in VictoriaLogs the whole time; it just got dropped on the way out to the CLI.

The root cause was two layers deep. The `LogEntry` RPC type had no way to carry arbitrary key-value metadata, and `toLogEntry()` was only plucking out the `source` attribute and throwing the rest away.

Fixing this properly meant giving the RPC system native map support — something we'd been working around with list-of-struct patterns (like `NamedValue` and `HttpHeader`) but never actually had. The first commit adds `type: map` with `key`/`value` fields to rpcgen, so you can write `type: map, key: string, value: string` in a schema and get an idiomatic `map[string]string` in Go with proper CBOR/JSON serialization. The second commit uses that to thread attributes through the full pipeline: `toLogEntry()` populates them, the wire format carries them, and `printLogEntry()` renders them as sorted `key=value` pairs after the message.

Fixes MIR-776