### PR TITLE
Check minimum system requirements during server install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ m app list
 - `cd docs && bun install && bun run build` - Build the documentation site (Docusaurus, uses bun NOT npm)
 - `cd docs && bun run start` - Start local dev server on port 3333
 - Docs source lives in `docs/docs/` as Markdown files; sidebar is configured in `docs/sidebars.ts`
+- **Published docs URL is `https://miren.md/`** (NOT `miren.dev/docs`). Use this when linking to docs from CLI output, error messages, or anywhere user-facing.
 
 ### Other Commands
 - `make image` - Export Docker image

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -15,7 +15,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/quic-go/quic-go/http3"
@@ -24,6 +26,118 @@ import (
 	"miren.dev/runtime/pkg/registration"
 	"miren.dev/runtime/version"
 )
+
+const (
+	minMemoryBytes          = 4 * 1024 * 1024 * 1024   // 4 GB
+	recommendedMemoryBytes  = 8 * 1024 * 1024 * 1024   // 8 GB
+	minStorageBytes         = 50 * 1024 * 1024 * 1024  // 50 GB
+	recommendedStorageBytes = 100 * 1024 * 1024 * 1024 // 100 GB
+
+	mirenDataDir = "/var/lib/miren"
+)
+
+// systemRequirements holds detected system resource information
+type systemRequirements struct {
+	totalMemoryBytes   int64
+	availStorageBytes  int64
+	storagePath        string
+	memoryCheckFailed  bool // true if we couldn't read memory info
+	storageCheckFailed bool // true if we couldn't read storage info
+}
+
+// checkSystemRequirements detects system resources for validation
+func checkSystemRequirements() systemRequirements {
+	reqs := systemRequirements{storagePath: mirenDataDir}
+
+	// Read total memory from /proc/meminfo
+	meminfoBytes, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		reqs.memoryCheckFailed = true
+	} else {
+		for _, line := range strings.Split(string(meminfoBytes), "\n") {
+			if strings.HasPrefix(line, "MemTotal:") {
+				fields := strings.Fields(line)
+				if len(fields) >= 2 {
+					if kb, err := strconv.ParseInt(fields[1], 10, 64); err == nil {
+						reqs.totalMemoryBytes = kb * 1024
+					}
+				}
+				break
+			}
+		}
+		if reqs.totalMemoryBytes == 0 {
+			reqs.memoryCheckFailed = true
+		}
+	}
+
+	// Check available disk space at the data directory (or its nearest existing parent)
+	checkPath := mirenDataDir
+	for checkPath != "/" {
+		if _, err := os.Stat(checkPath); err == nil {
+			break
+		}
+		checkPath = filepath.Dir(checkPath)
+	}
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(checkPath, &stat); err != nil {
+		reqs.storageCheckFailed = true
+	} else {
+		reqs.availStorageBytes = int64(stat.Bavail) * int64(stat.Bsize)
+	}
+
+	return reqs
+}
+
+// printSystemRequirementsGuidance prints warnings or errors about system requirements.
+// Returns true if installation should be blocked (below minimum).
+func printSystemRequirementsGuidance(ctx *Context, reqs systemRequirements) bool {
+	belowMinimum := false
+
+	fmt.Println()
+
+	if reqs.memoryCheckFailed {
+		ctx.Warn("Couldn't detect system memory — we recommend at least %s.", formatBytes(minMemoryBytes))
+	} else if reqs.totalMemoryBytes < minMemoryBytes {
+		belowMinimum = true
+		ctx.Warn("This machine has %s of memory, but Miren needs at least %s.",
+			formatBytes(reqs.totalMemoryBytes), formatBytes(minMemoryBytes))
+		fmt.Println("  Under the hood, Miren runs containerd, etcd, buildkit, and more — they use")
+		fmt.Println("  about 600 MB at idle and spike higher during builds. With this little memory,")
+		fmt.Println("  things will start failing when you deploy.")
+		fmt.Println()
+	} else if reqs.totalMemoryBytes < recommendedMemoryBytes {
+		ctx.Warn("This machine has %s of memory — it'll work, but we recommend %s.",
+			formatBytes(reqs.totalMemoryBytes), formatBytes(recommendedMemoryBytes))
+		fmt.Println("  You might run into trouble during builds for memory-hungry apps.")
+		fmt.Println()
+	}
+
+	if reqs.storageCheckFailed {
+		ctx.Warn("Couldn't detect available disk space — we recommend at least %s.", formatBytes(minStorageBytes))
+	} else if reqs.availStorageBytes < minStorageBytes {
+		belowMinimum = true
+		ctx.Warn("Only %s of disk space available at %s, but Miren needs at least %s.",
+			formatBytes(reqs.availStorageBytes), reqs.storagePath, formatBytes(minStorageBytes))
+		fmt.Println("  Container images, build caches, and app data add up fast — a single deploy")
+		fmt.Println("  can use 15-20 GB between images, build cache, and the registry.")
+		fmt.Println()
+	} else if reqs.availStorageBytes < recommendedStorageBytes {
+		ctx.Warn("Disk space is a bit tight: %s available at %s, we recommend %s.",
+			formatBytes(reqs.availStorageBytes), reqs.storagePath, formatBytes(recommendedStorageBytes))
+		fmt.Println("  With multiple apps and version history, storage fills up quicker than you'd expect.")
+		fmt.Println()
+	}
+
+	if belowMinimum {
+		ctx.Warn("This system doesn't meet the minimum requirements to run Miren reliably.")
+		fmt.Println("  More details: https://miren.md/system-requirements")
+		fmt.Println()
+		fmt.Println("  If you know what you're doing, you can skip this check with --skip-system-check")
+	}
+
+	fmt.Println()
+	return belowMinimum
+}
 
 // installPrerequisites holds information about the system's readiness for installation
 type installPrerequisites struct {
@@ -156,15 +270,16 @@ func fixSELinuxContext(ctx *Context, binaryPath string) {
 
 // ServerInstall sets up systemd units to run the miren server
 func ServerInstall(ctx *Context, opts struct {
-	Address      string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
-	Verbosity    string            `long:"verbosity" description:"Verbosity level" default:"-vv"`
-	Branch       string            `short:"b" long:"branch" description:"Branch to download if release not found"`
-	Force        bool              `short:"f" long:"force" description:"Overwrite existing service file"`
-	NoStart      bool              `long:"no-start" description:"Do not start the service after installation"`
-	WithoutCloud bool              `long:"without-cloud" description:"Skip cloud registration setup"`
-	ClusterName  string            `short:"n" long:"name" description:"Cluster name for cloud registration"`
-	CloudURL     string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
-	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
+	Address         string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
+	Verbosity       string            `long:"verbosity" description:"Verbosity level" default:"-vv"`
+	Branch          string            `short:"b" long:"branch" description:"Branch to download if release not found"`
+	Force           bool              `short:"f" long:"force" description:"Overwrite existing service file"`
+	NoStart         bool              `long:"no-start" description:"Do not start the service after installation"`
+	WithoutCloud    bool              `long:"without-cloud" description:"Skip cloud registration setup"`
+	ClusterName     string            `short:"n" long:"name" description:"Cluster name for cloud registration"`
+	CloudURL        string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
+	Tags            map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
+	SkipSystemCheck bool              `long:"skip-system-check" description:"Skip minimum system requirements check"`
 }) error {
 	if opts.Branch == "" {
 		if br := version.Branch(); br != "" {
@@ -186,6 +301,17 @@ func ServerInstall(ctx *Context, opts struct {
 	}
 
 	ctx.Completed("Prerequisites verified (root, systemd)")
+
+	// Check system requirements (memory, disk space)
+	if !opts.SkipSystemCheck {
+		sysReqs := checkSystemRequirements()
+		if printSystemRequirementsGuidance(ctx, sysReqs) {
+			return fmt.Errorf("system does not meet minimum requirements")
+		}
+		ctx.Completed("System requirements verified")
+	} else {
+		ctx.Info("Skipping system requirements check (--skip-system-check specified)")
+	}
 
 	// Check if miren binary exists, download if not
 	mirenPath := "/var/lib/miren/release/miren"

--- a/cli/commands/server_install_other.go
+++ b/cli/commands/server_install_other.go
@@ -9,15 +9,16 @@ import (
 
 // ServerInstall is not supported on non-Linux platforms
 func ServerInstall(ctx *Context, opts struct {
-	Address      string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
-	Verbosity    string            `long:"verbosity" description:"Verbosity level" default:"-vv"`
-	Branch       string            `short:"b" long:"branch" description:"Branch to download if release not found" default:"main"`
-	Force        bool              `short:"f" long:"force" description:"Overwrite existing service file"`
-	NoStart      bool              `long:"no-start" description:"Do not start the service after installation"`
-	WithoutCloud bool              `long:"without-cloud" description:"Skip cloud registration setup"`
-	ClusterName  string            `short:"n" long:"name" description:"Cluster name for cloud registration"`
-	CloudURL     string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
-	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
+	Address         string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
+	Verbosity       string            `long:"verbosity" description:"Verbosity level" default:"-vv"`
+	Branch          string            `short:"b" long:"branch" description:"Branch to download if release not found" default:"main"`
+	Force           bool              `short:"f" long:"force" description:"Overwrite existing service file"`
+	NoStart         bool              `long:"no-start" description:"Do not start the service after installation"`
+	WithoutCloud    bool              `long:"without-cloud" description:"Skip cloud registration setup"`
+	ClusterName     string            `short:"n" long:"name" description:"Cluster name for cloud registration"`
+	CloudURL        string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
+	Tags            map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
+	SkipSystemCheck bool              `long:"skip-system-check" description:"Skip minimum system requirements check"`
 }) error {
 	fmt.Println()
 	ctx.Warn("The 'server install' command is only available on Linux.")

--- a/cli/commands/server_install_test.go
+++ b/cli/commands/server_install_test.go
@@ -1,0 +1,99 @@
+//go:build linux
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintSystemRequirementsGuidance(t *testing.T) {
+	ctx := newTestContext()
+
+	tests := []struct {
+		name        string
+		reqs        systemRequirements
+		wantBlocked bool
+	}{
+		{
+			name: "all requirements met",
+			reqs: systemRequirements{
+				totalMemoryBytes:  16 * 1024 * 1024 * 1024,  // 16 GB
+				availStorageBytes: 200 * 1024 * 1024 * 1024, // 200 GB
+				storagePath:       "/var/lib/miren",
+			},
+			wantBlocked: false,
+		},
+		{
+			name: "memory below minimum blocks install",
+			reqs: systemRequirements{
+				totalMemoryBytes:  512 * 1024 * 1024, // 512 MB
+				availStorageBytes: 200 * 1024 * 1024 * 1024,
+				storagePath:       "/var/lib/miren",
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "storage below minimum blocks install",
+			reqs: systemRequirements{
+				totalMemoryBytes:  16 * 1024 * 1024 * 1024,
+				availStorageBytes: 10 * 1024 * 1024 * 1024, // 10 GB
+				storagePath:       "/var/lib/miren",
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "both below minimum blocks install",
+			reqs: systemRequirements{
+				totalMemoryBytes:  1 * 1024 * 1024 * 1024,  // 1 GB
+				availStorageBytes: 10 * 1024 * 1024 * 1024, // 10 GB
+				storagePath:       "/var/lib/miren",
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "memory below recommended does not block",
+			reqs: systemRequirements{
+				totalMemoryBytes:  6 * 1024 * 1024 * 1024, // 6 GB
+				availStorageBytes: 200 * 1024 * 1024 * 1024,
+				storagePath:       "/var/lib/miren",
+			},
+			wantBlocked: false,
+		},
+		{
+			name: "storage below recommended does not block",
+			reqs: systemRequirements{
+				totalMemoryBytes:  16 * 1024 * 1024 * 1024,
+				availStorageBytes: 75 * 1024 * 1024 * 1024, // 75 GB
+				storagePath:       "/var/lib/miren",
+			},
+			wantBlocked: false,
+		},
+		{
+			name: "memory check failed does not block",
+			reqs: systemRequirements{
+				memoryCheckFailed: true,
+				availStorageBytes: 200 * 1024 * 1024 * 1024,
+				storagePath:       "/var/lib/miren",
+			},
+			wantBlocked: false,
+		},
+		{
+			name: "storage check failed does not block",
+			reqs: systemRequirements{
+				totalMemoryBytes:   16 * 1024 * 1024 * 1024,
+				storageCheckFailed: true,
+				storagePath:        "/var/lib/miren",
+			},
+			wantBlocked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocked := printSystemRequirementsGuidance(ctx, tt.reqs)
+			assert.Equal(t, tt.wantBlocked, blocked)
+		})
+	}
+}

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -27,7 +27,7 @@ This script will:
 - **Memory**: 4GB minimum, 8GB recommended
 - **Storage**: 50GB minimum, 100GB recommended
 
-[Why these requirements?](#a-note-on-system-requirements)
+See [System Requirements](/system-requirements) for details on why these numbers matter.
 
 ### Verify Installation
 
@@ -277,14 +277,6 @@ miren route
 - Check the [CLI Reference](/commands) for command details
 - View the [FAQ](https://miren.dev/developer-preview#faq-1)
 - See [Troubleshooting](/troubleshooting) for diagnostics, bug reports, and community help
-
-## A Note on System Requirements
-
-Miren runs several components—containerd, etcd, buildkit, metrics, and logging—that together use around 600MB of memory at idle. During builds, memory usage spikes as buildkit compiles your application. A single Rails app with Postgres can push total usage past 1.3GB during deployment, which is why we recommend 4GB minimum.
-
-For storage, container images and build caches add up quickly. Base images for languages like Ruby or Python are 50-80MB compressed but expand on disk, and BuildKit caches intermediate build layers aggressively—keeping up to 10GB by default. A single Rails deployment can use 15-20GB between base images, build cache, and the container registry. With multiple apps and their version history, usage grows from there. Starting with 50GB gives you comfortable headroom; if you're tight on space, you'll see "no space left on device" errors during builds.
-
-We're still learning about system requirements as more users deploy Miren in different contexts. If you have an interesting deployment scenario or resource constraints you'd like to discuss, come chat with us on [Discord](https://miren.dev/discord)!
 
 ## Next Steps
 

--- a/docs/docs/system-requirements.md
+++ b/docs/docs/system-requirements.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 3
+---
+
+# System Requirements
+
+Miren needs a Linux server with enough memory and disk space to run its components and build your applications.
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| **Operating System** | Linux (kernel 5.10+) | |
+| **Architecture** | x86_64 or arm64 | |
+| **Memory** | 4 GB | 8 GB |
+| **Storage** | 50 GB | 100 GB |
+
+## Why these numbers?
+
+### Memory
+
+Miren runs several components — containerd, etcd, buildkit, metrics, and logging — that together use around 600 MB of memory at idle. During builds, memory usage spikes as buildkit compiles your application. A single Rails app with Postgres can push total usage past 1.3 GB during deployment, which is why we set the minimum at 4 GB.
+
+With 8 GB, you'll have comfortable headroom for running multiple apps and handling concurrent builds without things getting tight.
+
+### Storage
+
+Container images and build caches add up quickly. Base images for languages like Ruby or Python are 50-80 MB compressed but expand on disk, and BuildKit caches intermediate build layers aggressively — keeping up to 10 GB by default. A single Rails deployment can use 15-20 GB between base images, build cache, and the container registry. With multiple apps and their version history, usage grows from there.
+
+Starting with 50 GB gives you enough room to get going. With 100 GB you'll have space to grow without worrying about "no space left on device" errors during builds.
+
+## What happens if my system is too small?
+
+The `miren server install` command checks your system against these requirements before installing. If your machine doesn't meet the minimums, the installer will let you know what's short and point you here.
+
+If you're below the recommended thresholds but above the minimums, you'll see a heads-up but installation will proceed normally.
+
+If you know what you're doing and want to install anyway (say, for testing), you can bypass the check:
+
+```bash
+sudo miren server install --skip-system-check
+```
+
+## We'd love to hear from you
+
+We're still learning about system requirements as more people deploy Miren in different contexts. If you have an interesting deployment scenario or resource constraints you'd like to discuss, come chat with us on [Discord](https://miren.dev/discord)!

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -43,6 +43,7 @@ const sidebars: SidebarsConfig = {
       label: 'Reference',
       collapsed: false,
       items: [
+        'system-requirements',
         'app-toml',
         'server-config',
         {


### PR DESCRIPTION
Mary managed to install miren on a 512 MB server, which happily accepted the install and then promptly died during a deploy. The installer had no guardrails — it checked for root and systemd but never looked at whether the machine could actually run everything.

We already document minimum requirements in the getting-started guide (4 GB memory, 50 GB storage), so this wires those thresholds into the install flow right after the existing prerequisite checks. If you're below the minimums, the install stops with a clear message explaining what's needed and links to the docs. If you're in the "it'll probably work but we wouldn't recommend it" zone (between minimum and recommended), you get a warning but things keep moving.

For unusual environments where we can't read `/proc/meminfo` or stat the filesystem, we warn but don't block — no sense locking someone out just because their system is weird. And `--skip-system-check` is there for anyone who knows what they're doing and wants to push through anyway.

While we were at it, we moved the system requirements docs out of a buried anchor in getting-started and onto their own reference page, so the CLI has something stable to link to and users can actually find it. Also added a note to CLAUDE.md about the correct docs URL (`miren.md`, not `miren.dev/docs`) since we keep getting that wrong.

Only applies to the systemd (bare metal) install path for now — Docker installs are a different story.

Closes MIR-748