### PR TITLE
Pre-populate allowed hosts at startup to avoid fallback cert race

### DIFF
--- a/controllers/certificate/autocert_controller.go
+++ b/controllers/certificate/autocert_controller.go
@@ -65,7 +65,41 @@ func (c *AutocertController) Init(ctx context.Context) error {
 		},
 	}
 
+	// Pre-populate allowedHosts from existing http_route entities so the
+	// isAllowedHost guard in GetCertificate works immediately — before the
+	// controller manager starts reconciling routes one by one.
+	if err := c.loadExistingRoutes(ctx); err != nil {
+		c.log.Warn("failed to pre-populate allowed hosts from existing routes", "error", err)
+	}
+
 	c.log.Info("autocert controller initialized")
+	return nil
+}
+
+// loadExistingRoutes queries all http_route entities and adds their hosts to allowedHosts.
+func (c *AutocertController) loadExistingRoutes(ctx context.Context) error {
+	if c.eac == nil {
+		return nil
+	}
+	res, err := c.eac.List(ctx, entity.Ref(entity.EntityKind, ingress_v1alpha.KindHttpRoute))
+	if err != nil {
+		return fmt.Errorf("failed to list http_route entities: %w", err)
+	}
+
+	count := 0
+	for _, ent := range res.Values() {
+		var route ingress_v1alpha.HttpRoute
+		route.Decode(ent.Entity())
+		domain := strings.ToLower(strings.TrimSpace(route.Host))
+		if domain != "" {
+			c.allowedHosts.Store(domain, struct{}{})
+			count++
+		}
+	}
+
+	if count > 0 {
+		c.log.Info("pre-populated allowed hosts from existing routes", "count", count)
+	}
 	return nil
 }
 

--- a/controllers/certificate/autocert_controller_test.go
+++ b/controllers/certificate/autocert_controller_test.go
@@ -9,6 +9,7 @@ import (
 
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
 )
 
 func newTestAutocertController(t *testing.T) *AutocertController {
@@ -181,6 +182,48 @@ func TestAutocertController_HostPolicy_WildcardMatching(t *testing.T) {
 	// Unrelated domain should be rejected
 	if err := c.mgr.HostPolicy(context.Background(), "other.com"); err == nil {
 		t.Error("expected host policy to reject other.com")
+	}
+}
+
+func TestAutocertController_Init_PrePopulatesAllowedHosts(t *testing.T) {
+	ctx := context.Background()
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create http_route entities before Init
+	routes := []struct {
+		id   string
+		host string
+	}{
+		{"route-1", "example.com"},
+		{"route-2", "api.example.com"},
+		{"route-3", "*.staging.example.com"},
+	}
+	for _, r := range routes {
+		route := &ingress_v1alpha.HttpRoute{Host: r.host}
+		if _, err := server.Client.Create(ctx, r.id, route); err != nil {
+			t.Fatalf("failed to create route %s: %v", r.id, err)
+		}
+	}
+
+	// Create controller with real EAC and init
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	c := NewAutocertController(log, server.EAC, t.TempDir(), "test@example.com")
+	if err := c.Init(ctx); err != nil {
+		t.Fatalf("failed to init: %v", err)
+	}
+
+	// Verify all hosts were pre-populated
+	for _, r := range routes {
+		if _, ok := c.allowedHosts.Load(r.host); !ok {
+			t.Errorf("expected %q to be in allowed hosts after Init", r.host)
+		}
+	}
+
+	// Verify unknown hosts are NOT in allowedHosts
+	if _, ok := c.allowedHosts.Load("unknown.com"); ok {
+		t.Error("unexpected host in allowed hosts")
 	}
 }
 


### PR DESCRIPTION
After a server restart, there's a window where the TLS server is already accepting connections but the autocert controller hasn't reconciled all its routes yet. Any request that arrives during that window for a domain whose `Reconcile` hasn't run gets the self-signed fallback cert — even though the real ACME cert is sitting right there in the DirCache. The `isAllowedHost` guard (from #542) rejects the domain because `allowedHosts` is still empty, so autocert never gets a chance to serve the cached cert.

We hit this in practice when an OIDC discovery request landed a few seconds after a restart. The cert came back with `localhost` in its SANs instead of the actual domain, and the TLS handshake failed. Five seconds later, once reconciliation caught up, everything was fine — but that's a rough experience for the first request.

The fix is to query all existing `http_route` entities during `Init()` and seed `allowedHosts` before the TLS server starts. This way the guard works from the very first handshake, and the controller's reconcile loop still handles new routes and cert provisioning as before.

Closes MIR-786