### PR TITLE
Track build step progress instead of layer transfers during deploy

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -523,7 +523,7 @@ func Deploy(ctx *Context, opts struct {
 			return nil
 		}
 
-		cb = createBuildStatusCallback(buildCtx, nil, nil, nil, &buildErrors, nil, progressHandler)
+		cb = createBuildStatusCallback(buildCtx, nil, nil, &buildErrors, nil, progressHandler)
 
 		results, err = bc.BuildFromTar(buildCtx, name, stream.ServeReader(buildCtx, r), cb, envVars)
 		if err != nil {
@@ -569,9 +569,8 @@ func Deploy(ctx *Context, opts struct {
 	} else {
 		var (
 			updateCh         = make(chan string, 1)
-			transferCh       = make(chan transferUpdate, 1)
+			buildCh          = make(chan buildProgress, 1)
 			uploadProgressCh = make(chan upload.Progress, 1)
-			transfers        = map[string]transfer{}
 			wg               sync.WaitGroup
 		)
 
@@ -589,7 +588,7 @@ func Deploy(ctx *Context, opts struct {
 		deployCtx, cancelDeploy := context.WithCancel(buildCtx)
 		defer cancelDeploy()
 
-		model := initialModel(updateCh, transferCh, uploadProgressCh)
+		model := initialModel(updateCh, buildCh, uploadProgressCh)
 		p := tea.NewProgram(model)
 
 		var finalModel tea.Model
@@ -619,7 +618,7 @@ func Deploy(ctx *Context, opts struct {
 			return nil
 		}
 
-		cb = createBuildStatusCallback(deployCtx, updateCh, transferCh, transfers, &buildErrors, &buildLogs, progressHandler)
+		cb = createBuildStatusCallback(deployCtx, updateCh, buildCh, &buildErrors, &buildLogs, progressHandler)
 
 		results, err = bc.BuildFromTar(deployCtx, name, stream.ServeReader(deployCtx, r), cb, envVars)
 
@@ -634,7 +633,7 @@ func Deploy(ctx *Context, opts struct {
 			buildPhase := phaseSummary{
 				name:     "Build & push image",
 				duration: duration,
-				details:  fmt.Sprintf("%d layers processed", m.parts),
+				details:  buildStepsSummary(m.buildSteps),
 			}
 
 			// Only print the final build phase summary (TEA UI already showed the others)
@@ -771,12 +770,12 @@ func printBuildErrors(ctx *Context, buildErrors []string, buildLogs []string) {
 func createBuildStatusCallback(
 	ctx context.Context,
 	updateCh chan<- string,
-	transferCh chan<- transferUpdate,
-	transfers map[string]transfer,
+	buildCh chan<- buildProgress,
 	buildErrors *[]string,
 	buildLogs *[]string,
 	progressHandler func(*client.SolveStatus) error,
 ) stream.SendStream[*build_v1alpha.Status] {
+	vertices := map[string]bool{} // digest → completed
 	return stream.Callback(func(su *build_v1alpha.Status) error {
 		update := su.Update()
 
@@ -789,24 +788,32 @@ func createBuildStatusCallback(
 				return err
 			}
 
-			// Handle transfers if we have a transfer channel
-			if transferCh != nil {
+			// Track build step progress via vertices
+			if buildCh != nil {
 				var updated bool
-				for _, st := range status.Statuses {
-					if st.Total != 0 {
+				for _, v := range status.Vertexes {
+					d := v.Digest.String()
+					if _, seen := vertices[d]; !seen {
 						updated = true
-						transfers[st.ID] = transfer{total: st.Total, current: st.Current}
 					}
+					done := v.Completed != nil
+					if done != vertices[d] {
+						updated = true
+					}
+					vertices[d] = done
 				}
 
 				if updated {
+					var completed int
+					for _, done := range vertices {
+						if done {
+							completed++
+						}
+					}
 					select {
 					case <-ctx.Done():
-						// UI/operation cancelled, drop the update
-					case transferCh <- transferUpdate{transfers: transfers}:
-						// ok
+					case buildCh <- buildProgress{total: len(vertices), completed: completed}:
 					default:
-						// channel full, drop to avoid blocking
 					}
 				}
 			}
@@ -859,6 +866,16 @@ func createBuildStatusCallback(
 
 		return nil
 	})
+}
+
+func buildStepsSummary(count int) string {
+	if count == 0 {
+		return "cached"
+	}
+	if count == 1 {
+		return "1 step completed"
+	}
+	return fmt.Sprintf("%d steps completed", count)
 }
 
 // displayAccessInfo shows how to access the deployed app using server-provided access info

--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -236,11 +236,6 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.message = msg.msg
 		m.lastActivity = time.Now() // Reset activity timer
 
-		// Any update during buildkit phase counts as activity
-		if m.currentPhase == "buildkit" && !m.buildkitStarted {
-			m.buildkitStarted = true
-		}
-
 		// Track phase transitions
 		if prevMessage != msg.msg {
 			// Complete the upload phase
@@ -268,6 +263,7 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Start tracking buildkit phase
 				m.phaseStart = time.Now()
 				m.currentPhase = "buildkit"
+				m.buildkitStarted = true
 			}
 
 		}
@@ -292,11 +288,6 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case buildProgress:
 		m.lastActivity = time.Now() // Reset activity timer
-
-		// Mark buildkit as started once we receive build progress
-		if m.currentPhase == "buildkit" && !m.buildkitStarted {
-			m.buildkitStarted = true
-		}
 
 		// Build progress means upload is complete (fallback if no "Launching builder" message)
 		if m.isUploading {
@@ -332,6 +323,7 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.phaseStart = time.Now()
 			m.currentPhase = "buildkit"
 		}
+		m.buildkitStarted = true
 
 		m.buildSteps = msg.total
 

--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -70,12 +70,9 @@ var Meter = spinner.Spinner{
 }
 
 // Data types for UI
-type transfer struct {
-	total, current int64
-}
-
-type transferUpdate struct {
-	transfers map[string]transfer
+type buildProgress struct {
+	total     int
+	completed int
 }
 
 type phaseSummary struct {
@@ -98,9 +95,10 @@ type deployInfo struct {
 	message string
 	update  chan string
 
-	transfers chan transferUpdate
-	prog      progress.Model
-	parts     int
+	buildCh    chan buildProgress
+	prog       progress.Model
+	buildSteps int
+	buildPct   float64
 
 	uploadProgress chan upload.Progress
 	uploadSpin     spinner.Model
@@ -125,7 +123,7 @@ type deployInfo struct {
 	bp           tea.Model
 }
 
-func initialModel(update chan string, transfers chan transferUpdate, uploadProgress chan upload.Progress) *deployInfo {
+func initialModel(update chan string, buildCh chan buildProgress, uploadProgress chan upload.Progress) *deployInfo {
 	s := spinner.New()
 	s.Spinner = Meter
 	s.Style = lipgloss.NewStyle()
@@ -143,7 +141,7 @@ func initialModel(update chan string, transfers chan transferUpdate, uploadProgr
 		spinner:         s,
 		message:         "Reading application data",
 		update:          update,
-		transfers:       transfers,
+		buildCh:         buildCh,
 		prog:            p,
 		uploadProgress:  uploadProgress,
 		uploadSpin:      uploadS,
@@ -173,9 +171,9 @@ func (m *deployInfo) Init() tea.Cmd {
 		})
 	}
 
-	if m.transfers != nil {
+	if m.buildCh != nil {
 		cmds = append(cmds, func() tea.Msg {
-			return <-m.transfers
+			return <-m.buildCh
 		})
 	}
 
@@ -238,6 +236,11 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.message = msg.msg
 		m.lastActivity = time.Now() // Reset activity timer
 
+		// Any update during buildkit phase counts as activity
+		if m.currentPhase == "buildkit" && !m.buildkitStarted {
+			m.buildkitStarted = true
+		}
+
 		// Track phase transitions
 		if prevMessage != msg.msg {
 			// Complete the upload phase
@@ -287,22 +290,21 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				})
 			}
 		}
-	case transferUpdate:
+	case buildProgress:
 		m.lastActivity = time.Now() // Reset activity timer
 
-		// Mark buildkit as started once we receive transfer updates
+		// Mark buildkit as started once we receive build progress
 		if m.currentPhase == "buildkit" && !m.buildkitStarted {
 			m.buildkitStarted = true
 		}
 
-		// Buildkit transfers mean upload is complete (fallback if no "Launching builder" message)
+		// Build progress means upload is complete (fallback if no "Launching builder" message)
 		if m.isUploading {
 			m.isUploading = false
 			duration := time.Since(m.phaseStart)
 			m.uploadDuration = duration
 
 			// Only create upload summary if we haven't already from "Launching builder" message
-			// Check both that we don't have phases OR the last phase isn't Upload artifacts
 			hasUploadPhase := false
 			for _, phase := range m.completedPhases {
 				if phase.name == "Upload artifacts" {
@@ -331,27 +333,14 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.currentPhase = "buildkit"
 		}
 
-		var total, current int64
-		for _, t := range msg.transfers {
-			total += t.total
-			current += t.current
+		m.buildSteps = msg.total
+
+		if msg.total > 0 {
+			m.buildPct = float64(msg.completed) / float64(msg.total)
 		}
-
-		m.parts = len(msg.transfers)
-
-		cmd := m.prog.SetPercent(float64(current) / float64(total))
-		cmds = append(cmds,
-			cmd,
-			func() tea.Msg {
-				return <-m.transfers
-			})
-	case progress.FrameMsg:
-		p, cmd := m.prog.Update(msg)
-		m.prog = p.(progress.Model)
-
-		if cmd != nil {
-			cmds = append(cmds, cmd)
-		}
+		cmds = append(cmds, func() tea.Msg {
+			return <-m.buildCh
+		})
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
@@ -386,8 +375,12 @@ func (m *deployInfo) View() string {
 		currentLine = fmt.Sprintf("  %s %s...\n      %s %s",
 			m.uploadSpin.View(), m.message, m.spinner.View(), speedInfo)
 	} else if m.currentPhase != "completed" {
-		fetch := deployPrefixStyle.Render(fmt.Sprintf("Fetching %d items:", m.parts))
-		currentLine = fmt.Sprintf("  %s %s...\n      %s %s", m.spinner.View(), m.message, fetch, m.prog.View())
+		if m.buildSteps > 0 {
+			steps := deployPrefixStyle.Render(fmt.Sprintf("Building %d steps:", m.buildSteps))
+			currentLine = fmt.Sprintf("  %s %s...\n      %s %s", m.spinner.View(), m.message, steps, m.prog.ViewAs(m.buildPct))
+		} else {
+			currentLine = fmt.Sprintf("  %s %s...", m.spinner.View(), m.message)
+		}
 	}
 
 	if currentLine != "" {


### PR DESCRIPTION
The deploy progress bar was wired up to buildkit's `VertexStatus` updates, which track byte-level progress on layer pulls from a registry. The problem is that once buildkit has the base image cached locally — which is every deploy after the very first one — there are no transfers to report. So the bar just sat there showing "Fetching 0 items: 0%" and then the summary would say "0 layers processed". Not great.

Switched the progress tracking to use buildkit's `Vertex` objects instead, which represent actual build steps (FROM, COPY, RUN, export, etc.) and always fire regardless of cache state. The bar now shows "Building 9 steps:" and ticks forward as each step completes. Since build steps are discrete (a step is either done or it isn't), we use `ViewAs` for instant rendering rather than the animated `SetPercent` — this also fixes the bar never quite reaching 100% before the UI exits. When everything is fully cached and buildkit doesn't report any vertices at all, we skip the progress bar entirely and the summary just reads "cached".