### PR TITLE
Fix PDS disk boot failures (MIR-788)

### DIFF
--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -98,6 +98,7 @@ func LoadAppConfig() (*AppConfig, error) {
 
 			var ac AppConfig
 			dec := toml.NewDecoder(fi)
+			dec.DisallowUnknownFields()
 			err = dec.Decode(&ac)
 			if err != nil {
 				return nil, err

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -1,6 +1,7 @@
 package appconfig
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -124,6 +125,7 @@ func LoadAppConfigUnder(dir string) (*AppConfig, error) {
 
 		var ac AppConfig
 		dec := toml.NewDecoder(fi)
+		dec.DisallowUnknownFields()
 		err = dec.Decode(&ac)
 		if err != nil {
 			return nil, err
@@ -142,7 +144,9 @@ func LoadAppConfigUnder(dir string) (*AppConfig, error) {
 
 func Parse(data []byte) (*AppConfig, error) {
 	var ac AppConfig
-	err := toml.Unmarshal(data, &ac)
+	dec := toml.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&ac)
 	if err != nil {
 		return nil, err
 	}

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -1136,3 +1136,65 @@ node_port = 443
 		require.Len(t, ac.Services["web"].Ports, 2)
 	})
 }
+
+func TestRejectUnknownFields(t *testing.T) {
+	t.Run("unknown top-level field", func(t *testing.T) {
+		config := `
+name = "test-app"
+unknown_field = "value"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "strict mode")
+	})
+
+	t.Run("size instead of size_gb in disk config", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[services.database.concurrency]
+mode = "fixed"
+num_instances = 1
+
+[[services.database.disks]]
+name = "data"
+mount_path = "/data"
+size = 20
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "strict mode")
+	})
+
+	t.Run("unknown field in service config", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[services.web]
+command = "server"
+bogus = true
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "strict mode")
+	})
+
+	t.Run("valid config still works", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[services.database.concurrency]
+mode = "fixed"
+num_instances = 1
+
+[[services.database.disks]]
+name = "data"
+mount_path = "/data"
+size_gb = 20
+`
+		ac, err := Parse([]byte(config))
+		require.NoError(t, err)
+		require.NotNil(t, ac)
+		assert.Equal(t, 20, ac.Services["database"].Disks[0].SizeGB)
+	})
+}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -838,8 +838,18 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 	}
 }
 
-func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandbox, meta *entity.Meta, recreate bool) error {
+func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandbox, meta *entity.Meta, recreate bool) (err error) {
 	c.Log.Debug("creating sandbox", "id", co.ID)
+
+	// Catch-all: any error during sandbox creation marks it DEAD so the pool
+	// controller's crash-backoff logic kicks in instead of retrying forever.
+	defer func() {
+		if err != nil {
+			c.Log.Error("sandbox boot failed, marking DEAD", "id", co.ID, "err", err)
+			co.Status = compute.DEAD
+			meta.Update(co.Encode())
+		}
+	}()
 
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
@@ -894,7 +904,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 
 	defer func() {
 		if err != nil {
-			c.Log.Error("failed to create sandbox, cleaning up", "id", co.ID, "err", err)
+			c.Log.Error("failed to create sandbox, cleaning up container resources", "id", co.ID, "err", err)
 
 			// Be sure we have at least 60 seconds to do this action.
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
@@ -908,11 +918,6 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 
 			// Clean up the pause container using the common cleanup function
 			c.cleanupContainer(ctx, container)
-
-			// Update sandbox status to DEAD in entity store
-			co.Status = compute.DEAD
-			meta.Update(co.Encode())
-			c.Log.Info("marked sandbox as DEAD due to boot failure", "id", co.ID)
 		}
 	}()
 

--- a/controllers/sandbox/volume.go
+++ b/controllers/sandbox/volume.go
@@ -132,12 +132,6 @@ func (c *SandboxController) configureMirenVolume(ctx context.Context, sb *comput
 		leaseTimeout = duration
 	}
 
-	// Look up or create Disk entity using instance-specific name
-	diskID, err := c.ensureDisk(ctx, actualDiskName, sizeGB, filesystem)
-	if err != nil {
-		return "", fmt.Errorf("failed to ensure disk exists: %w", err)
-	}
-
 	// Resolve version to app ID if set
 	var appID entity.Id
 	if sb.Spec.Version != "" {
@@ -151,6 +145,12 @@ func (c *SandboxController) configureMirenVolume(ctx context.Context, sb *comput
 			version.Decode(versionResp.Entity().Entity())
 			appID = version.App
 		}
+	}
+
+	// Look up or create Disk entity using instance-specific name
+	diskID, err := c.ensureDisk(ctx, actualDiskName, sizeGB, filesystem, appID)
+	if err != nil {
+		return "", fmt.Errorf("failed to ensure disk exists: %w", err)
 	}
 
 	// Acquire a lease for this disk on this node (creates new or takes over existing)
@@ -174,7 +174,7 @@ func (c *SandboxController) configureMirenVolume(ctx context.Context, sb *comput
 	return diskMountPath, nil
 }
 
-func (c *SandboxController) ensureDisk(ctx context.Context, diskName string, sizeGB int64, filesystem string) (entity.Id, error) {
+func (c *SandboxController) ensureDisk(ctx context.Context, diskName string, sizeGB int64, filesystem string, appID entity.Id) (entity.Id, error) {
 	// Search for existing disk by name using the name index
 	listResp, err := c.EAC.List(ctx, entity.String(storage.DiskNameId, diskName))
 	if err != nil {
@@ -222,6 +222,7 @@ func (c *SandboxController) ensureDisk(ctx context.Context, diskName string, siz
 		SizeGb:     sizeGB,
 		Filesystem: fs,
 		Status:     storage.PROVISIONING,
+		CreatedBy:  appID,
 	}
 
 	name := idgen.GenNS("disk")

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -27,6 +27,7 @@ import (
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/ingress"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/components/buildkit"
 	"miren.dev/runtime/components/netresolve"
@@ -291,6 +292,28 @@ func validateNodePorts(ctx context.Context, eac *entityserver_v1alpha.EntityAcce
 		}
 	}
 
+	return nil
+}
+
+// validateDiskConfigs checks that disks referenced with size_gb=0 already exist
+// in the entity store. This catches missing disks at deploy time rather than
+// letting sandboxes fail at runtime with retry loops.
+func validateDiskConfigs(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, spec core_v1alpha.ConfigSpec) error {
+	for _, svc := range spec.Services {
+		for _, disk := range svc.Disks {
+			if disk.SizeGb > 0 || disk.Name == "" {
+				continue
+			}
+			// size_gb == 0 means we expect the disk to already exist
+			listResp, err := eac.List(ctx, entity.String(storage.DiskNameId, disk.Name))
+			if err != nil {
+				return fmt.Errorf("failed to query disk %q: %w", disk.Name, err)
+			}
+			if len(listResp.Values()) == 0 {
+				return fmt.Errorf("disk %q does not exist; set size_gb to auto-create it", disk.Name)
+			}
+		}
+	}
 	return nil
 }
 
@@ -1120,6 +1143,11 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 
 	if err := validateNodePorts(ctx, b.ec.EAC(), appRec.ID, configSpec); err != nil {
+		b.sendErrorStatus(ctx, status, "Deploy failed: %v", err)
+		return err
+	}
+
+	if err := validateDiskConfigs(ctx, b.ec.EAC(), configSpec); err != nil {
 		b.sendErrorStatus(ctx, status, "Deploy failed: %v", err)
 		return err
 	}

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -11,6 +11,7 @@ import (
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	storage "miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
@@ -2287,5 +2288,79 @@ func TestValidateNodePortsScaledDownPoolIgnored(t *testing.T) {
 	}
 
 	err = validateNodePorts(ctx, server.EAC, appBID, spec)
+	assert.NoError(t, err)
+}
+
+func TestValidateDiskConfigsMissingDisk(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Deploy with size_gb=0 and no existing disk — should fail
+	spec := core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "db",
+			Disks: []core_v1alpha.ConfigSpecServicesDisks{{
+				Name:      "data",
+				MountPath: "/data",
+				SizeGb:    0,
+			}},
+		}},
+	}
+
+	err := validateDiskConfigs(ctx, server.EAC, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `disk "data" does not exist`)
+	assert.Contains(t, err.Error(), "size_gb")
+}
+
+func TestValidateDiskConfigsExistingDisk(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create a disk entity so the lookup succeeds
+	disk := &storage.Disk{
+		Name:   "data",
+		SizeGb: 20,
+		Status: storage.PROVISIONED,
+	}
+	_, err := server.Client.Create(ctx, "data-disk", disk)
+	require.NoError(t, err)
+
+	// Deploy with size_gb=0 referencing an existing disk — should succeed
+	spec := core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "db",
+			Disks: []core_v1alpha.ConfigSpecServicesDisks{{
+				Name:      "data",
+				MountPath: "/data",
+				SizeGb:    0,
+			}},
+		}},
+	}
+
+	err = validateDiskConfigs(ctx, server.EAC, spec)
+	assert.NoError(t, err)
+}
+
+func TestValidateDiskConfigsAutoCreate(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Deploy with size_gb > 0 — should always succeed (will auto-create)
+	spec := core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "db",
+			Disks: []core_v1alpha.ConfigSpecServicesDisks{{
+				Name:      "new-disk",
+				MountPath: "/data",
+				SizeGb:    20,
+			}},
+		}},
+	}
+
+	err := validateDiskConfigs(ctx, server.EAC, spec)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

A user deployed with `size = 20` instead of `size_gb = 20` in their miren.toml disk config. TOML silently ignored the unknown field, leaving `SizeGB=0`. This caused a cascade of failures:

1. **Sandbox stuck PENDING forever**: `configureVolumes()` failed every boot attempt ("disk does not exist and no size specified"), but the sandbox was never marked DEAD. The pool controller counts PENDING sandboxes as "actual" capacity, so it didn't create replacements — but the stale-PENDING monitor would mark them STOPPED after 5 minutes, then the pool would create a new one. Since STOPPED sandboxes don't trigger the crash counter, the exponential backoff never kicked in.

2. **Lease carousel after fix**: After the user fixed the config, old stuck sandboxes' leases conflicted with new ones from the redeployment, causing ~6 minutes of lease churn before stabilizing.

3. **Orphaned disk on app delete**: `ensureDisk()` never set `CreatedBy` on disk entities, so `DeleteAppTransitive` couldn't find the disk when the app was deleted. The user had to manually clean up the disk and its lease.

## Changes

- **Reject unknown TOML fields** (`appconfig/appconfig.go`): Enable `DisallowUnknownFields()` on all decoder paths so typos like `size` instead of `size_gb` produce a clear parse error at deploy time.

- **Mark sandbox DEAD on any boot failure** (`controllers/sandbox/sandbox.go`): Restructured `createSandbox()` to use a named return with a top-level defer — every error path now transitions the sandbox to DEAD. This is a catch-all that covers `configureVolumes`, `buildSpec`, `NewContainer`, port health checks, and any future failure modes. The pool controller's existing exponential crash-backoff (10s → 20s → 40s → ... → 15min) then kicks in properly.

- **Set `CreatedBy` on disk entities** (`controllers/sandbox/volume.go`): Pass the app ID through to `ensureDisk()` so `DeleteAppTransitive` can find and clean up disks when an app is deleted.

- **Validate disk existence at deploy time** (`servers/build/build.go`): When `size_gb` is 0 (meaning "use existing disk"), query the entity store to verify the disk exists before creating any sandboxes. Fails with: `disk "X" does not exist; set size_gb to auto-create it`.

## Test plan

- [x] `go test ./appconfig/...` — unknown field rejection tests pass
- [x] `go test ./servers/build/...` — disk existence validation tests pass (missing disk, existing disk, auto-create)
- [x] `go vet` and `make lint` clean
- [ ] `make test` full suite in iso