### PR TITLE
Fix miren app TUI showing auto for fixed-concurrency services

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -178,8 +178,10 @@ func (v *ServiceCommand) UnmarshalJSON(data []byte) error {
 }
 
 type serviceConfigData struct {
-	Service    *string        `cbor:"0,keyasint,omitempty" json:"service,omitempty"`
-	ServiceEnv *[]*NamedValue `cbor:"1,keyasint,omitempty" json:"service_env,omitempty"`
+	Service         *string        `cbor:"0,keyasint,omitempty" json:"service,omitempty"`
+	ServiceEnv      *[]*NamedValue `cbor:"1,keyasint,omitempty" json:"service_env,omitempty"`
+	ConcurrencyMode *string        `cbor:"2,keyasint,omitempty" json:"concurrency_mode,omitempty"`
+	NumInstances    *int32         `cbor:"3,keyasint,omitempty" json:"num_instances,omitempty"`
 }
 
 type ServiceConfig struct {
@@ -215,6 +217,36 @@ func (v *ServiceConfig) ServiceEnv() []*NamedValue {
 func (v *ServiceConfig) SetServiceEnv(service_env []*NamedValue) {
 	x := slices.Clone(service_env)
 	v.data.ServiceEnv = &x
+}
+
+func (v *ServiceConfig) HasConcurrencyMode() bool {
+	return v.data.ConcurrencyMode != nil
+}
+
+func (v *ServiceConfig) ConcurrencyMode() string {
+	if v.data.ConcurrencyMode == nil {
+		return ""
+	}
+	return *v.data.ConcurrencyMode
+}
+
+func (v *ServiceConfig) SetConcurrencyMode(concurrency_mode string) {
+	v.data.ConcurrencyMode = &concurrency_mode
+}
+
+func (v *ServiceConfig) HasNumInstances() bool {
+	return v.data.NumInstances != nil
+}
+
+func (v *ServiceConfig) NumInstances() int32 {
+	if v.data.NumInstances == nil {
+		return 0
+	}
+	return *v.data.NumInstances
+}
+
+func (v *ServiceConfig) SetNumInstances(num_instances int32) {
+	v.data.NumInstances = &num_instances
 }
 
 func (v *ServiceConfig) MarshalCBOR() ([]byte, error) {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -47,6 +47,12 @@ types:
         type: list
         element: NamedValue
         index: 1
+      - name: concurrency_mode
+        type: string
+        index: 2
+      - name: num_instances
+        type: int32
+        index: 3
 
   - type: Configuration
     fields:

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -407,20 +407,26 @@ func (m Model) View() string {
 
 	for _, ps := range m.status.Pools() {
 		instanceCount := len(ps.Windows())
-		instanceInfo := fmt.Sprintf("instances=%d (auto)", instanceCount)
+
+		isFixed := false
 		if m.cfg != nil {
-			if m.cfg.HasConcurrency() {
-				// Fixed mode
-				if instanceCount == 0 {
-					instanceInfo = "instances=0 (fixed)"
-				} else {
-					instanceInfo = fmt.Sprintf("instances=%d (fixed)", instanceCount)
+			for _, svc := range m.cfg.Services() {
+				if svc.Service() == ps.Name() && svc.ConcurrencyMode() == "fixed" {
+					isFixed = true
+					break
 				}
-			} else if instanceCount == 0 {
-				// Auto mode with 0 instances
-				instanceInfo = "instances=0 (idle, will scale on traffic)"
 			}
 		}
+
+		var instanceInfo string
+		if isFixed {
+			instanceInfo = fmt.Sprintf("instances=%d (fixed)", instanceCount)
+		} else if instanceCount == 0 {
+			instanceInfo = "instances=0 (idle, will scale on traffic)"
+		} else {
+			instanceInfo = fmt.Sprintf("instances=%d (auto)", instanceCount)
+		}
+
 		hdr += fmt.Sprintf("       pool: %s %s\n", bold.Render(ps.Name()), instanceInfo)
 	}
 

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -356,8 +356,12 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 	for _, svc := range spec.Services {
 		var sc app_v1alpha.ServiceConfig
 		sc.SetService(svc.Name)
-		sc.SetConcurrencyMode(svc.Concurrency.Mode)
-		sc.SetNumInstances(int32(svc.Concurrency.NumInstances))
+		if svc.Concurrency.Mode != "" {
+			sc.SetConcurrencyMode(svc.Concurrency.Mode)
+		}
+		if svc.Concurrency.NumInstances != 0 {
+			sc.SetNumInstances(int32(svc.Concurrency.NumInstances))
+		}
 
 		// Add service env vars
 		if len(svc.Env) > 0 {

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -356,6 +356,8 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 	for _, svc := range spec.Services {
 		var sc app_v1alpha.ServiceConfig
 		sc.SetService(svc.Name)
+		sc.SetConcurrencyMode(svc.Concurrency.Mode)
+		sc.SetNumInstances(int32(svc.Concurrency.NumInstances))
 
 		// Add service env vars
 		if len(svc.Env) > 0 {


### PR DESCRIPTION
## Summary
- Added `concurrency_mode` and `num_instances` fields to the `ServiceConfig` RPC type
- Populated these fields from the `ConfigSpec` in the `GetConfiguration` handler
- Fixed the `miren app` TUI View() to check per-service concurrency mode instead of the deprecated top-level `HasConcurrency()` which always returned false

## Test plan
- [x] `go generate ./api/app/` regenerates cleanly
- [x] `hack/it servers/app` — all 42 tests pass
- [ ] Deploy app with `[services.web.concurrency] mode = "fixed" num_instances = 2`, verify `miren app` shows "(fixed)"
- [ ] Verify `m app list` still shows "(fixed)" (regression check)
- [ ] Verify auto-concurrency apps still show "(auto)" or "(idle, will scale on traffic)"