### PR TITLE
Fix OIDC provider collision across routes sharing same provider URL

### DIFF
--- a/cli/commands/route_oidc_enable.go
+++ b/cli/commands/route_oidc_enable.go
@@ -68,10 +68,12 @@ func RouteOidcEnable(ctx *Context, opts struct {
 	if providerName == "" {
 		// If no provider name given and provider-url specified, generate a name
 		if opts.ProviderURL != "" {
-			// Use the host from the provider URL as the provider name
-			providerName = strings.ReplaceAll(opts.ProviderURL, "https://", "")
-			providerName = strings.ReplaceAll(providerName, "http://", "")
-			providerName = strings.Split(providerName, "/")[0]
+			// Include the route host to avoid collisions when multiple routes
+			// use the same OIDC provider URL with different credentials.
+			providerHost := strings.ReplaceAll(opts.ProviderURL, "https://", "")
+			providerHost = strings.ReplaceAll(providerHost, "http://", "")
+			providerHost = strings.Split(providerHost, "/")[0]
+			providerName = routeLabel + "/" + providerHost
 		} else {
 			return fmt.Errorf("either --provider or --provider-url must be specified")
 		}

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -328,18 +328,28 @@ func oidcProviderMatches(cached *oidcHandler, current *ingress_v1alpha.OidcProvi
 // creating one on first access. The handler (and its oidc.Client) is reused
 // across requests so that discovery and JWKS caches are effective.
 // If the provider config has changed since the handler was cached, the stale
-// handler is replaced with a new one.
-func (s *Server) getOrCreateOIDCHandler(route *ingress_v1alpha.HttpRoute, baseURL string) (*oidcHandler, error) {
+// handler is replaced with a new one. If the entity store is unreachable but
+// a cached handler exists, the cached handler is returned to avoid failing
+// open (serving requests without authentication).
+func (s *Server) getOrCreateOIDCHandler(ctx context.Context, route *ingress_v1alpha.HttpRoute, baseURL string) (*oidcHandler, error) {
 	// Key by route host; default routes use a sentinel.
 	key := route.Host
 	if route.Default {
 		key = "__default__"
 	}
 
-	// Resolve the OIDC provider entity before checking the cache so we can
-	// detect config changes.
-	resp, err := s.eac.Get(context.Background(), string(route.OidcProvider))
+	// Try to resolve the current provider config from the entity store.
+	resp, err := s.eac.Get(ctx, string(route.OidcProvider))
 	if err != nil {
+		// Entity store unavailable — return cached handler if we have one
+		// to avoid failing open (serving without auth).
+		s.oidcMu.RLock()
+		h, ok := s.oidcHandlers[key]
+		s.oidcMu.RUnlock()
+		if ok {
+			s.Log.Warn("entity store unavailable, using cached OIDC handler", "error", err, "host", key)
+			return h, nil
+		}
 		return nil, fmt.Errorf("failed to get OIDC provider: %w", err)
 	}
 
@@ -393,7 +403,7 @@ func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.Hand
 
 		s.oidcSessionManager.SetSecure(scheme == "https")
 
-		handler, err := s.getOrCreateOIDCHandler(route, baseURL)
+		handler, err := s.getOrCreateOIDCHandler(r.Context(), route, baseURL)
 		if err != nil {
 			s.Log.Error("failed to get OIDC handler", "error", err, "host", r.Host)
 			next(w, r)

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -313,9 +313,22 @@ func requestScheme(r *http.Request) string {
 	return "http"
 }
 
+// oidcProviderMatches returns true if the cached handler's provider config
+// matches the current provider entity from the store.
+func oidcProviderMatches(cached *oidcHandler, current *ingress_v1alpha.OidcProvider) bool {
+	cp := cached.provider
+	return cp.ID == current.ID &&
+		cp.ClientId == current.ClientId &&
+		cp.ClientSecret == current.ClientSecret &&
+		cp.ProviderUrl == current.ProviderUrl &&
+		cp.Scopes == current.Scopes
+}
+
 // getOrCreateOIDCHandler returns a cached oidcHandler for the given route,
 // creating one on first access. The handler (and its oidc.Client) is reused
 // across requests so that discovery and JWKS caches are effective.
+// If the provider config has changed since the handler was cached, the stale
+// handler is replaced with a new one.
 func (s *Server) getOrCreateOIDCHandler(route *ingress_v1alpha.HttpRoute, baseURL string) (*oidcHandler, error) {
 	// Key by route host; default routes use a sentinel.
 	key := route.Host
@@ -323,8 +336,18 @@ func (s *Server) getOrCreateOIDCHandler(route *ingress_v1alpha.HttpRoute, baseUR
 		key = "__default__"
 	}
 
+	// Resolve the OIDC provider entity before checking the cache so we can
+	// detect config changes.
+	resp, err := s.eac.Get(context.Background(), string(route.OidcProvider))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OIDC provider: %w", err)
+	}
+
+	var provider ingress_v1alpha.OidcProvider
+	provider.Decode(resp.Entity().Entity())
+
 	s.oidcMu.RLock()
-	if h, ok := s.oidcHandlers[key]; ok {
+	if h, ok := s.oidcHandlers[key]; ok && oidcProviderMatches(h, &provider) {
 		s.oidcMu.RUnlock()
 		return h, nil
 	}
@@ -334,18 +357,9 @@ func (s *Server) getOrCreateOIDCHandler(route *ingress_v1alpha.HttpRoute, baseUR
 	defer s.oidcMu.Unlock()
 
 	// Double-check after acquiring write lock
-	if h, ok := s.oidcHandlers[key]; ok {
+	if h, ok := s.oidcHandlers[key]; ok && oidcProviderMatches(h, &provider) {
 		return h, nil
 	}
-
-	// Resolve the OIDC provider entity
-	resp, err := s.eac.Get(context.Background(), string(route.OidcProvider))
-	if err != nil {
-		return nil, fmt.Errorf("failed to get OIDC provider: %w", err)
-	}
-
-	var provider ingress_v1alpha.OidcProvider
-	provider.Decode(resp.Entity().Entity())
 
 	var resource string
 	if route.Default {

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -332,10 +332,11 @@ func oidcProviderMatches(cached *oidcHandler, current *ingress_v1alpha.OidcProvi
 // a cached handler exists, the cached handler is returned to avoid failing
 // open (serving requests without authentication).
 func (s *Server) getOrCreateOIDCHandler(ctx context.Context, route *ingress_v1alpha.HttpRoute, baseURL string) (*oidcHandler, error) {
-	// Key by route host; default routes use a sentinel.
-	key := route.Host
+	// Key by route host + baseURL so that handlers with different redirect
+	// URIs (different scheme or host for default routes) are cached separately.
+	key := route.Host + "|" + baseURL
 	if route.Default {
-		key = "__default__"
+		key = "__default__|" + baseURL
 	}
 
 	// Try to resolve the current provider config from the entity store.
@@ -347,7 +348,7 @@ func (s *Server) getOrCreateOIDCHandler(ctx context.Context, route *ingress_v1al
 		h, ok := s.oidcHandlers[key]
 		s.oidcMu.RUnlock()
 		if ok {
-			s.Log.Warn("entity store unavailable, using cached OIDC handler", "error", err, "host", key)
+			s.Log.Warn("entity store unavailable, using cached OIDC handler", "error", err, "host", route.Host)
 			return h, nil
 		}
 		return nil, fmt.Errorf("failed to get OIDC provider: %w", err)

--- a/servers/httpingress/oidc_test.go
+++ b/servers/httpingress/oidc_test.go
@@ -1,10 +1,16 @@
 package httpingress
 
 import (
+	"log/slog"
 	"net/http/httptest"
 	"testing"
 
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/oidc"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/servers/entityserver"
 )
 
 func TestInjectClaims(t *testing.T) {
@@ -172,5 +178,144 @@ func TestInjectClaims(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestOidcProviderMatches(t *testing.T) {
+	base := &ingress_v1alpha.OidcProvider{
+		ID:           "provider-1",
+		ClientId:     "client-AAA",
+		ClientSecret: "secret-AAA",
+		ProviderUrl:  "https://auth.example.com",
+		Scopes:       "openid email",
+	}
+
+	handler := &oidcHandler{provider: base}
+
+	t.Run("identical provider matches", func(t *testing.T) {
+		same := &ingress_v1alpha.OidcProvider{
+			ID:           "provider-1",
+			ClientId:     "client-AAA",
+			ClientSecret: "secret-AAA",
+			ProviderUrl:  "https://auth.example.com",
+			Scopes:       "openid email",
+		}
+		if !oidcProviderMatches(handler, same) {
+			t.Error("expected match for identical provider")
+		}
+	})
+
+	t.Run("different client_id does not match", func(t *testing.T) {
+		different := &ingress_v1alpha.OidcProvider{
+			ID:           "provider-1",
+			ClientId:     "client-BBB",
+			ClientSecret: "secret-AAA",
+			ProviderUrl:  "https://auth.example.com",
+			Scopes:       "openid email",
+		}
+		if oidcProviderMatches(handler, different) {
+			t.Error("expected mismatch for different client_id")
+		}
+	})
+
+	t.Run("different provider ID does not match", func(t *testing.T) {
+		different := &ingress_v1alpha.OidcProvider{
+			ID:           "provider-2",
+			ClientId:     "client-AAA",
+			ClientSecret: "secret-AAA",
+			ProviderUrl:  "https://auth.example.com",
+			Scopes:       "openid email",
+		}
+		if oidcProviderMatches(handler, different) {
+			t.Error("expected mismatch for different provider ID")
+		}
+	})
+
+	t.Run("different secret does not match", func(t *testing.T) {
+		different := &ingress_v1alpha.OidcProvider{
+			ID:           "provider-1",
+			ClientId:     "client-AAA",
+			ClientSecret: "secret-BBB",
+			ProviderUrl:  "https://auth.example.com",
+			Scopes:       "openid email",
+		}
+		if oidcProviderMatches(handler, different) {
+			t.Error("expected mismatch for different client_secret")
+		}
+	})
+}
+
+// storeOIDCProvider adds or replaces an OidcProvider entity in the mock store.
+func storeOIDCProvider(store *entity.MockStore, ident, clientID, clientSecret, providerURL, scopes string) {
+	store.AddEntity(entity.Id(ident), entity.New([]entity.Attr{
+		{ID: entity.Ident, Value: entity.KeywordValue(ident)},
+		entity.String(ingress_v1alpha.OidcProviderClientIdId, clientID),
+		entity.String(ingress_v1alpha.OidcProviderClientSecretId, clientSecret),
+		entity.String(ingress_v1alpha.OidcProviderProviderUrlId, providerURL),
+		entity.String(ingress_v1alpha.OidcProviderScopesId, scopes),
+	}))
+}
+
+func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
+	store := entity.NewMockStore()
+	esrv := &entityserver.EntityServer{
+		Log:   slog.Default(),
+		Store: store,
+	}
+	eac := &entityserver_v1alpha.EntityAccessClient{
+		Client: rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(esrv)),
+	}
+
+	signingKey := make([]byte, 32)
+
+	srv := &Server{
+		Log:                slog.Default(),
+		eac:                eac,
+		oidcSessionManager: oidc.NewSessionManager(false, "", signingKey),
+		oidcHandlers:       make(map[string]*oidcHandler),
+	}
+
+	providerIdent := "test/oidc-provider"
+
+	storeOIDCProvider(store, providerIdent,
+		"client-AAA", "secret-AAA", "https://auth.example.com", "openid email")
+
+	route := &ingress_v1alpha.HttpRoute{
+		Host:         "socials.example.com",
+		OidcProvider: entity.Id(providerIdent),
+	}
+
+	// First call: creates and caches a handler
+	h1, err := srv.getOrCreateOIDCHandler(route, "https://socials.example.com")
+	if err != nil {
+		t.Fatalf("first getOrCreateOIDCHandler: %v", err)
+	}
+	if h1.provider.ClientId != "client-AAA" {
+		t.Fatalf("expected client_id=client-AAA, got %s", h1.provider.ClientId)
+	}
+
+	// Second call with same provider: should return cached handler
+	h2, err := srv.getOrCreateOIDCHandler(route, "https://socials.example.com")
+	if err != nil {
+		t.Fatalf("second getOrCreateOIDCHandler: %v", err)
+	}
+	if h1 != h2 {
+		t.Error("expected same handler instance on cache hit")
+	}
+
+	// Update the provider entity with a new client_id
+	storeOIDCProvider(store, providerIdent,
+		"client-BBB", "secret-AAA", "https://auth.example.com", "openid email")
+
+	// Third call: provider changed, should return a new handler
+	h3, err := srv.getOrCreateOIDCHandler(route, "https://socials.example.com")
+	if err != nil {
+		t.Fatalf("third getOrCreateOIDCHandler: %v", err)
+	}
+	if h3.provider.ClientId != "client-BBB" {
+		t.Fatalf("expected client_id=client-BBB after update, got %s", h3.provider.ClientId)
+	}
+	if h1 == h3 {
+		t.Error("expected different handler instance after provider change")
 	}
 }

--- a/servers/httpingress/oidc_test.go
+++ b/servers/httpingress/oidc_test.go
@@ -1,6 +1,7 @@
 package httpingress
 
 import (
+	"context"
 	"log/slog"
 	"net/http/httptest"
 	"testing"
@@ -286,7 +287,7 @@ func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
 	}
 
 	// First call: creates and caches a handler
-	h1, err := srv.getOrCreateOIDCHandler(route, "https://socials.example.com")
+	h1, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
 	if err != nil {
 		t.Fatalf("first getOrCreateOIDCHandler: %v", err)
 	}
@@ -295,7 +296,7 @@ func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
 	}
 
 	// Second call with same provider: should return cached handler
-	h2, err := srv.getOrCreateOIDCHandler(route, "https://socials.example.com")
+	h2, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
 	if err != nil {
 		t.Fatalf("second getOrCreateOIDCHandler: %v", err)
 	}
@@ -308,7 +309,7 @@ func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
 		"client-BBB", "secret-AAA", "https://auth.example.com", "openid email")
 
 	// Third call: provider changed, should return a new handler
-	h3, err := srv.getOrCreateOIDCHandler(route, "https://socials.example.com")
+	h3, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
 	if err != nil {
 		t.Fatalf("third getOrCreateOIDCHandler: %v", err)
 	}
@@ -317,5 +318,62 @@ func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
 	}
 	if h1 == h3 {
 		t.Error("expected different handler instance after provider change")
+	}
+}
+
+func TestGetOrCreateOIDCHandlerFailClosed(t *testing.T) {
+	store := entity.NewMockStore()
+	esrv := &entityserver.EntityServer{
+		Log:   slog.Default(),
+		Store: store,
+	}
+	eac := &entityserver_v1alpha.EntityAccessClient{
+		Client: rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(esrv)),
+	}
+
+	signingKey := make([]byte, 32)
+
+	srv := &Server{
+		Log:                slog.Default(),
+		eac:                eac,
+		oidcSessionManager: oidc.NewSessionManager(false, "", signingKey),
+		oidcHandlers:       make(map[string]*oidcHandler),
+	}
+
+	providerIdent := "test/oidc-provider"
+	storeOIDCProvider(store, providerIdent,
+		"client-AAA", "secret-AAA", "https://auth.example.com", "openid email")
+
+	route := &ingress_v1alpha.HttpRoute{
+		Host:         "socials.example.com",
+		OidcProvider: entity.Id(providerIdent),
+	}
+
+	// Warm the cache
+	h1, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
+	if err != nil {
+		t.Fatalf("initial getOrCreateOIDCHandler: %v", err)
+	}
+
+	// Remove the provider entity to simulate entity store being unavailable
+	store.RemoveEntity(entity.Id(providerIdent))
+
+	// Should return cached handler instead of failing open
+	h2, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
+	if err != nil {
+		t.Fatalf("expected cached handler on entity store failure, got error: %v", err)
+	}
+	if h1 != h2 {
+		t.Error("expected same cached handler instance on entity store failure")
+	}
+
+	// With no cache entry and no entity store, should error (not fail open)
+	routeNew := &ingress_v1alpha.HttpRoute{
+		Host:         "newsite.example.com",
+		OidcProvider: entity.Id(providerIdent),
+	}
+	_, err = srv.getOrCreateOIDCHandler(context.Background(), routeNew, "https://newsite.example.com")
+	if err == nil {
+		t.Error("expected error when entity store fails and no cached handler exists")
 	}
 }


### PR DESCRIPTION
## Summary

- **Provider name collision**: When two routes used the same OIDC provider URL (e.g. `multipass.miren.garden`) with different client credentials, the auto-generated provider name was based only on the URL hostname. The second `route oidc enable` would overwrite the first route's provider entity, scrambling credentials across routes. Provider names now include the route label (e.g. `socials.example.com/multipass.miren.garden`).
- **Stale handler cache**: OIDC handlers were cached by route hostname but never validated against the current provider config. Even after a provider entity was corrected, the old credentials persisted until server restart. The cache now checks provider config on each lookup and replaces stale handlers.

## Test plan

- [x] `TestOidcProviderMatches` — validates the config comparison helper
- [x] `TestGetOrCreateOIDCHandlerCacheInvalidation` — verifies cache returns new handler after provider update
- [x] `TestInjectClaims` — existing tests still pass
- [ ] Manual: enable OIDC on two routes with same provider URL but different client credentials, verify each route redirects with its own client_id