### PR TITLE
Enable OIDC authentication in local-only mode

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -656,10 +656,11 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(&rpc.NoOpAuthenticator{}))
 		c.Log.Warn("authentication disabled (NoOpAuthenticator)")
 	} else {
-		// Use LocalOnlyAuthenticator when cloud auth is not enabled
-		// This requires valid client certificates for all requests
-		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(&rpc.LocalOnlyAuthenticator{}))
-		c.Log.Info("local-only authentication enabled (client certificates required)")
+		c.oidcAuthenticator = oidcauth.NewOIDCAuthenticator(c.Log)
+		compositeAuth := oidcauth.NewCompositeAuthenticator(&rpc.LocalOnlyAuthenticator{}, c.oidcAuthenticator)
+		compositeAuthz := oidcauth.NewCompositeAuthorizer(nil)
+		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(compositeAuth), rpc.WithAuthorizer(compositeAuthz))
+		c.Log.Info("local-only authentication enabled with OIDC support")
 	}
 
 	rs, err := rpc.NewState(ctx, rpcOpts...)


### PR DESCRIPTION
## Summary

- OIDC authentication (e.g., GitHub Actions tokens) was only available when the cluster was registered with Miren Cloud
- Wraps `LocalOnlyAuthenticator` with `CompositeAuthenticator` so OIDC works as a fallback alongside client certificate auth in local-only mode
- Mirrors the existing CloudAuth pattern using the same `CompositeAuthenticator`/`CompositeAuthorizer` types

Fixes MIR-792

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `hack/it ./components/coordinate/...` — 8 tests pass
- [x] `hack/it ./pkg/oidcauth/...` — 52 tests pass