### PR TITLE
Optimize deploy upload with delta file transfer

### DIFF
--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -545,6 +545,161 @@ func (v *EnvironmentVariable) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type fileManifestEntryData struct {
+	Path *string `cbor:"0,keyasint,omitempty" json:"path,omitempty"`
+	Hash *string `cbor:"1,keyasint,omitempty" json:"hash,omitempty"`
+	Size *int64  `cbor:"2,keyasint,omitempty" json:"size,omitempty"`
+	Mode *int32  `cbor:"3,keyasint,omitempty" json:"mode,omitempty"`
+}
+
+type FileManifestEntry struct {
+	data fileManifestEntryData
+}
+
+func (v *FileManifestEntry) HasPath() bool {
+	return v.data.Path != nil
+}
+
+func (v *FileManifestEntry) Path() string {
+	if v.data.Path == nil {
+		return ""
+	}
+	return *v.data.Path
+}
+
+func (v *FileManifestEntry) SetPath(path string) {
+	v.data.Path = &path
+}
+
+func (v *FileManifestEntry) HasHash() bool {
+	return v.data.Hash != nil
+}
+
+func (v *FileManifestEntry) Hash() string {
+	if v.data.Hash == nil {
+		return ""
+	}
+	return *v.data.Hash
+}
+
+func (v *FileManifestEntry) SetHash(hash string) {
+	v.data.Hash = &hash
+}
+
+func (v *FileManifestEntry) HasSize() bool {
+	return v.data.Size != nil
+}
+
+func (v *FileManifestEntry) Size() int64 {
+	if v.data.Size == nil {
+		return 0
+	}
+	return *v.data.Size
+}
+
+func (v *FileManifestEntry) SetSize(size int64) {
+	v.data.Size = &size
+}
+
+func (v *FileManifestEntry) HasMode() bool {
+	return v.data.Mode != nil
+}
+
+func (v *FileManifestEntry) Mode() int32 {
+	if v.data.Mode == nil {
+		return 0
+	}
+	return *v.data.Mode
+}
+
+func (v *FileManifestEntry) SetMode(mode int32) {
+	v.data.Mode = &mode
+}
+
+func (v *FileManifestEntry) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *FileManifestEntry) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *FileManifestEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *FileManifestEntry) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type prepareUploadResultData struct {
+	SessionId   *string   `cbor:"0,keyasint,omitempty" json:"session_id,omitempty"`
+	NeededPaths *[]string `cbor:"1,keyasint,omitempty" json:"needed_paths,omitempty"`
+	CachedCount *int32    `cbor:"2,keyasint,omitempty" json:"cached_count,omitempty"`
+}
+
+type PrepareUploadResult struct {
+	data prepareUploadResultData
+}
+
+func (v *PrepareUploadResult) HasSessionId() bool {
+	return v.data.SessionId != nil
+}
+
+func (v *PrepareUploadResult) SessionId() string {
+	if v.data.SessionId == nil {
+		return ""
+	}
+	return *v.data.SessionId
+}
+
+func (v *PrepareUploadResult) SetSessionId(session_id string) {
+	v.data.SessionId = &session_id
+}
+
+func (v *PrepareUploadResult) HasNeededPaths() bool {
+	return v.data.NeededPaths != nil
+}
+
+func (v *PrepareUploadResult) NeededPaths() *[]string {
+	return v.data.NeededPaths
+}
+
+func (v *PrepareUploadResult) SetNeededPaths(needed_paths *[]string) {
+	v.data.NeededPaths = needed_paths
+}
+
+func (v *PrepareUploadResult) HasCachedCount() bool {
+	return v.data.CachedCount != nil
+}
+
+func (v *PrepareUploadResult) CachedCount() int32 {
+	if v.data.CachedCount == nil {
+		return 0
+	}
+	return *v.data.CachedCount
+}
+
+func (v *PrepareUploadResult) SetCachedCount(cached_count int32) {
+	v.data.CachedCount = &cached_count
+}
+
+func (v *PrepareUploadResult) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *PrepareUploadResult) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *PrepareUploadResult) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *PrepareUploadResult) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type streamRecvArgsData struct {
 	Count *int32 `cbor:"0,keyasint,omitempty" json:"count,omitempty"`
 }
@@ -882,6 +1037,189 @@ func (v *BuilderAnalyzeAppResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type builderPrepareUploadArgsData struct {
+	Application *string               `cbor:"0,keyasint,omitempty" json:"application,omitempty"`
+	Manifest    *[]*FileManifestEntry `cbor:"1,keyasint,omitempty" json:"manifest,omitempty"`
+}
+
+type BuilderPrepareUploadArgs struct {
+	call rpc.Call
+	data builderPrepareUploadArgsData
+}
+
+func (v *BuilderPrepareUploadArgs) HasApplication() bool {
+	return v.data.Application != nil
+}
+
+func (v *BuilderPrepareUploadArgs) Application() string {
+	if v.data.Application == nil {
+		return ""
+	}
+	return *v.data.Application
+}
+
+func (v *BuilderPrepareUploadArgs) HasManifest() bool {
+	return v.data.Manifest != nil
+}
+
+func (v *BuilderPrepareUploadArgs) Manifest() []*FileManifestEntry {
+	if v.data.Manifest == nil {
+		return nil
+	}
+	return *v.data.Manifest
+}
+
+func (v *BuilderPrepareUploadArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *BuilderPrepareUploadArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *BuilderPrepareUploadArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *BuilderPrepareUploadArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type builderPrepareUploadResultsData struct {
+	Result **PrepareUploadResult `cbor:"0,keyasint,omitempty" json:"result,omitempty"`
+}
+
+type BuilderPrepareUploadResults struct {
+	call rpc.Call
+	data builderPrepareUploadResultsData
+}
+
+func (v *BuilderPrepareUploadResults) SetResult(result **PrepareUploadResult) {
+	v.data.Result = result
+}
+
+func (v *BuilderPrepareUploadResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *BuilderPrepareUploadResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *BuilderPrepareUploadResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *BuilderPrepareUploadResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type builderBuildFromPreparedArgsData struct {
+	SessionId *string                 `cbor:"0,keyasint,omitempty" json:"session_id,omitempty"`
+	Tardata   *rpc.Capability         `cbor:"1,keyasint,omitempty" json:"tardata,omitempty"`
+	Status    *rpc.Capability         `cbor:"2,keyasint,omitempty" json:"status,omitempty"`
+	EnvVars   *[]*EnvironmentVariable `cbor:"3,keyasint,omitempty" json:"envVars,omitempty"`
+}
+
+type BuilderBuildFromPreparedArgs struct {
+	call rpc.Call
+	data builderBuildFromPreparedArgsData
+}
+
+func (v *BuilderBuildFromPreparedArgs) HasSessionId() bool {
+	return v.data.SessionId != nil
+}
+
+func (v *BuilderBuildFromPreparedArgs) SessionId() string {
+	if v.data.SessionId == nil {
+		return ""
+	}
+	return *v.data.SessionId
+}
+
+func (v *BuilderBuildFromPreparedArgs) HasTardata() bool {
+	return v.data.Tardata != nil
+}
+
+func (v *BuilderBuildFromPreparedArgs) Tardata() *stream.RecvStreamClient[[]byte] {
+	if v.data.Tardata == nil {
+		return nil
+	}
+	return &stream.RecvStreamClient[[]byte]{Client: v.call.NewClient(v.data.Tardata)}
+}
+
+func (v *BuilderBuildFromPreparedArgs) HasStatus() bool {
+	return v.data.Status != nil
+}
+
+func (v *BuilderBuildFromPreparedArgs) Status() *stream.SendStreamClient[*Status] {
+	if v.data.Status == nil {
+		return nil
+	}
+	return &stream.SendStreamClient[*Status]{Client: v.call.NewClient(v.data.Status)}
+}
+
+func (v *BuilderBuildFromPreparedArgs) HasEnvVars() bool {
+	return v.data.EnvVars != nil
+}
+
+func (v *BuilderBuildFromPreparedArgs) EnvVars() []*EnvironmentVariable {
+	if v.data.EnvVars == nil {
+		return nil
+	}
+	return *v.data.EnvVars
+}
+
+func (v *BuilderBuildFromPreparedArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *BuilderBuildFromPreparedArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *BuilderBuildFromPreparedArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *BuilderBuildFromPreparedArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type builderBuildFromPreparedResultsData struct {
+	Version    *string      `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
+	AccessInfo **AccessInfo `cbor:"1,keyasint,omitempty" json:"access_info,omitempty"`
+}
+
+type BuilderBuildFromPreparedResults struct {
+	call rpc.Call
+	data builderBuildFromPreparedResultsData
+}
+
+func (v *BuilderBuildFromPreparedResults) SetVersion(version string) {
+	v.data.Version = &version
+}
+
+func (v *BuilderBuildFromPreparedResults) SetAccessInfo(access_info **AccessInfo) {
+	v.data.AccessInfo = access_info
+}
+
+func (v *BuilderBuildFromPreparedResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *BuilderBuildFromPreparedResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *BuilderBuildFromPreparedResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *BuilderBuildFromPreparedResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type BuilderBuildFromTar struct {
 	rpc.Call
 	args    BuilderBuildFromTarArgs
@@ -934,9 +1272,63 @@ func (t *BuilderAnalyzeApp) Results() *BuilderAnalyzeAppResults {
 	return results
 }
 
+type BuilderPrepareUpload struct {
+	rpc.Call
+	args    BuilderPrepareUploadArgs
+	results BuilderPrepareUploadResults
+}
+
+func (t *BuilderPrepareUpload) Args() *BuilderPrepareUploadArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *BuilderPrepareUpload) Results() *BuilderPrepareUploadResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type BuilderBuildFromPrepared struct {
+	rpc.Call
+	args    BuilderBuildFromPreparedArgs
+	results BuilderBuildFromPreparedResults
+}
+
+func (t *BuilderBuildFromPrepared) Args() *BuilderBuildFromPreparedArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *BuilderBuildFromPrepared) Results() *BuilderBuildFromPreparedResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type Builder interface {
 	BuildFromTar(ctx context.Context, state *BuilderBuildFromTar) error
 	AnalyzeApp(ctx context.Context, state *BuilderAnalyzeApp) error
+	PrepareUpload(ctx context.Context, state *BuilderPrepareUpload) error
+	BuildFromPrepared(ctx context.Context, state *BuilderBuildFromPrepared) error
 }
 
 type reexportBuilder struct {
@@ -948,6 +1340,14 @@ func (reexportBuilder) BuildFromTar(ctx context.Context, state *BuilderBuildFrom
 }
 
 func (reexportBuilder) AnalyzeApp(ctx context.Context, state *BuilderAnalyzeApp) error {
+	panic("not implemented")
+}
+
+func (reexportBuilder) PrepareUpload(ctx context.Context, state *BuilderPrepareUpload) error {
+	panic("not implemented")
+}
+
+func (reexportBuilder) BuildFromPrepared(ctx context.Context, state *BuilderBuildFromPrepared) error {
 	panic("not implemented")
 }
 
@@ -973,6 +1373,24 @@ func AdaptBuilder(t Builder) *rpc.Interface {
 			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AnalyzeApp(ctx, &BuilderAnalyzeApp{Call: call})
+			},
+		},
+		{
+			Name:          "prepareUpload",
+			InterfaceName: "Builder",
+			Index:         0,
+			Public:        false,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.PrepareUpload(ctx, &BuilderPrepareUpload{Call: call})
+			},
+		},
+		{
+			Name:          "buildFromPrepared",
+			InterfaceName: "Builder",
+			Index:         0,
+			Public:        false,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.BuildFromPrepared(ctx, &BuilderBuildFromPrepared{Call: call})
 			},
 		},
 	}
@@ -1078,4 +1496,88 @@ func (v BuilderClient) AnalyzeApp(ctx context.Context, tardata stream.RecvStream
 	}
 
 	return &BuilderClientAnalyzeAppResults{client: v.Client, data: ret}, nil
+}
+
+type BuilderClientPrepareUploadResults struct {
+	client rpc.Client
+	data   builderPrepareUploadResultsData
+}
+
+func (v *BuilderClientPrepareUploadResults) HasResult() bool {
+	return v.data.Result != nil
+}
+
+func (v *BuilderClientPrepareUploadResults) Result() *PrepareUploadResult {
+	if v.data.Result == nil {
+		return nil
+	}
+	return *v.data.Result
+}
+
+func (v BuilderClient) PrepareUpload(ctx context.Context, application string, manifest []*FileManifestEntry) (*BuilderClientPrepareUploadResults, error) {
+	args := BuilderPrepareUploadArgs{}
+	args.data.Application = &application
+	args.data.Manifest = &manifest
+
+	var ret builderPrepareUploadResultsData
+
+	err := v.Call(ctx, "prepareUpload", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BuilderClientPrepareUploadResults{client: v.Client, data: ret}, nil
+}
+
+type BuilderClientBuildFromPreparedResults struct {
+	client rpc.Client
+	data   builderBuildFromPreparedResultsData
+}
+
+func (v *BuilderClientBuildFromPreparedResults) HasVersion() bool {
+	return v.data.Version != nil
+}
+
+func (v *BuilderClientBuildFromPreparedResults) Version() string {
+	if v.data.Version == nil {
+		return ""
+	}
+	return *v.data.Version
+}
+
+func (v *BuilderClientBuildFromPreparedResults) HasAccessInfo() bool {
+	return v.data.AccessInfo != nil
+}
+
+func (v *BuilderClientBuildFromPreparedResults) AccessInfo() *AccessInfo {
+	if v.data.AccessInfo == nil {
+		return nil
+	}
+	return *v.data.AccessInfo
+}
+
+func (v BuilderClient) BuildFromPrepared(ctx context.Context, session_id string, tardata stream.RecvStream[[]byte], status stream.SendStream[*Status], envVars []*EnvironmentVariable) (*BuilderClientBuildFromPreparedResults, error) {
+	args := BuilderBuildFromPreparedArgs{}
+	caps := map[rpc.OID]*rpc.InlineCapability{}
+	args.data.SessionId = &session_id
+	{
+		ic, oid, c := v.NewInlineCapability(stream.AdaptRecvStream[[]byte](tardata), tardata)
+		args.data.Tardata = c
+		caps[oid] = ic
+	}
+	{
+		ic, oid, c := v.NewInlineCapability(stream.AdaptSendStream[*Status](status), status)
+		args.data.Status = c
+		caps[oid] = ic
+	}
+	args.data.EnvVars = &envVars
+
+	var ret builderBuildFromPreparedResultsData
+
+	err := v.CallWithCaps(ctx, "buildFromPrepared", &args, &ret, caps)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BuilderClientBuildFromPreparedResults{client: v.Client, data: ret}, nil
 }

--- a/api/build/rpc.yml
+++ b/api/build/rpc.yml
@@ -125,6 +125,42 @@ types:
         index: 2
         doc: Whether the value should be masked in logs and output
 
+  - type: FileManifestEntry
+    doc: A file entry in the upload manifest with its hash for delta comparison
+    fields:
+      - name: path
+        type: string
+        index: 0
+        doc: Relative file path
+      - name: hash
+        type: string
+        index: 1
+        doc: SHA-256 hash of the file contents
+      - name: size
+        type: int64
+        index: 2
+        doc: File size in bytes
+      - name: mode
+        type: int32
+        index: 3
+        doc: File permission mode
+
+  - type: PrepareUploadResult
+    doc: Result of preparing a delta upload session
+    fields:
+      - name: session_id
+        type: string
+        index: 0
+        doc: Session ID for the subsequent buildFromPrepared call
+      - name: needed_paths
+        type: '[]string'
+        index: 1
+        doc: File paths that need to be uploaded (not found in cache)
+      - name: cached_count
+        type: int32
+        index: 2
+        doc: Number of files reused from the previous deploy cache
+
 interfaces:
   - name: Stream
     methods:
@@ -164,4 +200,34 @@ interfaces:
         results:
           - name: result
             type: '*AnalysisResult'
+
+      - name: prepareUpload
+        doc: Prepare a delta upload session by comparing a file manifest against cached source code
+        parameters:
+          - name: application
+            type: string
+          - name: manifest
+            type: '[]*FileManifestEntry'
+        results:
+          - name: result
+            type: '*PrepareUploadResult'
+
+      - name: buildFromPrepared
+        doc: Build from a prepared upload session with only the changed files
+        parameters:
+          - name: session_id
+            type: string
+          - name: tardata
+            type: stream.RecvStream[[]byte]
+          - name: status
+            type: stream.SendStream[*Status]
+          - name: envVars
+            type: '[]*EnvironmentVariable'
+            doc: Environment variables to set on the app (optional, applied with source=manual)
+        results:
+          - name: version
+            type: string
+          - name: access_info
+            type: '*AccessInfo'
+            doc: Information about how to access the deployed app
 

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -453,10 +454,61 @@ func Deploy(ctx *Context, opts struct {
 	// Update phase to building
 	updateDeploymentPhase("building")
 
-	// Start upload span covering tar creation + BuildFromTar
+	// Start upload span covering tar creation + build
 	_, uploadSpan := deployTracer.Start(buildCtx, "deploy.upload")
 
-	r, err := tarx.MakeTar(dir, includePatterns)
+	// Try optimized delta upload: compute manifest, ask server what's cached
+	var (
+		sessionID    string
+		useOptimized bool
+		totalFiles   int
+		cachedFiles  int32
+		neededPaths  map[string]bool
+	)
+
+	manifest, manifestErr := tarx.ComputeManifest(dir, includePatterns)
+	if manifestErr == nil {
+		totalFiles = len(manifest)
+
+		// Convert to RPC manifest entries
+		rpcManifest := make([]*build_v1alpha.FileManifestEntry, len(manifest))
+		for i, m := range manifest {
+			entry := &build_v1alpha.FileManifestEntry{}
+			entry.SetPath(m.Path)
+			entry.SetHash(m.Hash)
+			entry.SetSize(m.Size)
+			entry.SetMode(m.Mode)
+			rpcManifest[i] = entry
+		}
+
+		prepResult, prepErr := bc.PrepareUpload(buildCtx, name, rpcManifest)
+		if prepErr == nil && prepResult.Result() != nil {
+			result := prepResult.Result()
+			sessionID = result.SessionId()
+			cachedFiles = result.CachedCount()
+			useOptimized = true
+
+			if result.HasNeededPaths() && result.NeededPaths() != nil {
+				neededPaths = make(map[string]bool)
+				for _, p := range *result.NeededPaths() {
+					neededPaths[p] = true
+				}
+			}
+		} else {
+			ctx.Log.Debug("prepareUpload unavailable, falling back to full upload", "error", prepErr)
+		}
+	} else {
+		ctx.Log.Debug("manifest computation failed, falling back to full upload", "error", manifestErr)
+	}
+
+	var r io.ReadCloser
+	if useOptimized && len(neededPaths) > 0 {
+		r, err = tarx.MakeFilteredTar(dir, includePatterns, neededPaths)
+	} else if useOptimized {
+		r = tarx.MakeEmptyTar()
+	} else {
+		r, err = tarx.MakeTar(dir, includePatterns)
+	}
 	if err != nil {
 		uploadSpan.RecordError(err)
 		uploadSpan.SetStatus(codes.Error, err.Error())
@@ -467,9 +519,23 @@ func Deploy(ctx *Context, opts struct {
 
 	defer r.Close()
 
+	// buildCall wraps either BuildFromTar or BuildFromPrepared
+	type buildResults interface {
+		Version() string
+		HasAccessInfo() bool
+		AccessInfo() *build_v1alpha.AccessInfo
+	}
+	buildCall := func(callCtx context.Context, tarReader io.ReadCloser, cb stream.SendStream[*build_v1alpha.Status]) (buildResults, error) {
+		if useOptimized {
+			tarStream := stream.ServeReader(callCtx, tarReader)
+			return bc.BuildFromPrepared(callCtx, sessionID, tarStream, cb, envVars)
+		}
+		return bc.BuildFromTar(callCtx, name, stream.ServeReader(callCtx, tarReader), cb, envVars)
+	}
+
 	var (
 		cb      stream.SendStream[*build_v1alpha.Status]
-		results *build_v1alpha.BuilderClientBuildFromTarResults
+		results buildResults
 	)
 
 	// Detect if we have a TTY - if not, force explain mode
@@ -477,6 +543,11 @@ func Deploy(ctx *Context, opts struct {
 	useExplainMode := opts.Explain || !isTTY
 
 	if useExplainMode {
+		if useOptimized && cachedFiles > 0 {
+			faintStyle := lipgloss.NewStyle().Faint(true)
+			ctx.Printf("  %s\n", faintStyle.Render(fmt.Sprintf("Reused %d/%d files from previous deploy, uploading %d", cachedFiles, totalFiles, len(neededPaths))))
+		}
+
 		// In explain mode, write to stderr
 		pw, err := progresswriter.NewPrinter(ctx, os.Stderr, opts.ExplainFormat)
 		if err != nil {
@@ -525,7 +596,7 @@ func Deploy(ctx *Context, opts struct {
 
 		cb = createBuildStatusCallback(buildCtx, nil, nil, &buildErrors, nil, progressHandler)
 
-		results, err = bc.BuildFromTar(buildCtx, name, stream.ServeReader(buildCtx, r), cb, envVars)
+		results, err = buildCall(buildCtx, r, cb)
 		if err != nil {
 			uploadSpan.RecordError(err)
 			uploadSpan.SetStatus(codes.Error, err.Error())
@@ -588,7 +659,7 @@ func Deploy(ctx *Context, opts struct {
 		deployCtx, cancelDeploy := context.WithCancel(buildCtx)
 		defer cancelDeploy()
 
-		model := initialModel(updateCh, buildCh, uploadProgressCh)
+		model := initialModel(updateCh, buildCh, uploadProgressCh, cachedFiles, totalFiles)
 		p := tea.NewProgram(model)
 
 		var finalModel tea.Model
@@ -620,7 +691,7 @@ func Deploy(ctx *Context, opts struct {
 
 		cb = createBuildStatusCallback(deployCtx, updateCh, buildCh, &buildErrors, &buildLogs, progressHandler)
 
-		results, err = bc.BuildFromTar(deployCtx, name, stream.ServeReader(deployCtx, r), cb, envVars)
+		results, err = buildCall(deployCtx, r, cb)
 
 		// Ensure the progress UI is shut down before printing
 		p.Quit()
@@ -878,8 +949,14 @@ func buildStepsSummary(count int) string {
 	return fmt.Sprintf("%d steps completed", count)
 }
 
+// deployAccessInfo provides access to build result access info for display purposes.
+type deployAccessInfo interface {
+	HasAccessInfo() bool
+	AccessInfo() *build_v1alpha.AccessInfo
+}
+
 // displayAccessInfo shows how to access the deployed app using server-provided access info
-func displayAccessInfo(ctx *Context, appName string, results *build_v1alpha.BuilderClientBuildFromTarResults) {
+func displayAccessInfo(ctx *Context, appName string, results deployAccessInfo) {
 	// Check if we have access info from the server
 	if !results.HasAccessInfo() {
 		ctx.Log.Debug("No access info returned from server")

--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -113,6 +113,10 @@ type deployInfo struct {
 	uploadDuration   time.Duration
 	finalUploadSpeed float64
 
+	// Source cache info
+	cachedFiles int32
+	totalFiles  int
+
 	// Timeout and interrupt handling
 	lastActivity    time.Time
 	buildkitTimeout time.Duration
@@ -123,7 +127,7 @@ type deployInfo struct {
 	bp           tea.Model
 }
 
-func initialModel(update chan string, buildCh chan buildProgress, uploadProgress chan upload.Progress) *deployInfo {
+func initialModel(update chan string, buildCh chan buildProgress, uploadProgress chan upload.Progress, cachedFiles int32, totalFiles int) *deployInfo {
 	s := spinner.New()
 	s.Spinner = Meter
 	s.Style = lipgloss.NewStyle()
@@ -149,11 +153,26 @@ func initialModel(update chan string, buildCh chan buildProgress, uploadProgress
 		uploadSpeed:     "calculating...",
 		phaseStart:      time.Now(),
 		currentPhase:    "upload",
+		cachedFiles:     cachedFiles,
+		totalFiles:      totalFiles,
 		lastActivity:    time.Now(),
 		buildkitTimeout: 60 * time.Second, // 60 second timeout for buildkit to start
 		buildkitStarted: false,
 		bp:              progressui.TeaModel(),
 	}
+}
+
+func (m *deployInfo) uploadDetails() string {
+	var parts []string
+	if m.cachedFiles > 0 {
+		parts = append(parts, fmt.Sprintf("reused %d/%d files", m.cachedFiles, m.totalFiles))
+	}
+	if m.uploadBytes > 0 {
+		parts = append(parts, fmt.Sprintf("%s at %s",
+			upload.FormatBytes(m.uploadBytes),
+			upload.FormatSpeed(m.finalUploadSpeed)))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func (m *deployInfo) Init() tea.Cmd {
@@ -244,20 +263,10 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				duration := time.Since(m.phaseStart)
 				m.uploadDuration = duration
 
-				// Create upload summary
-				var details string
-				if m.uploadBytes > 0 {
-					details = fmt.Sprintf("%s uploaded at %s",
-						upload.FormatBytes(m.uploadBytes),
-						upload.FormatSpeed(m.finalUploadSpeed))
-				} else if m.finalUploadSpeed > 0 {
-					details = fmt.Sprintf("Uploaded at %s", upload.FormatSpeed(m.finalUploadSpeed))
-				}
-
 				m.completedPhases = append(m.completedPhases, phaseSummary{
 					name:     "Upload artifacts",
 					duration: duration,
-					details:  details,
+					details:  m.uploadDetails(),
 				})
 
 				// Start tracking buildkit phase
@@ -305,17 +314,10 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			if !hasUploadPhase {
-				var details string
-				if m.uploadBytes > 0 {
-					details = fmt.Sprintf("%s uploaded at %s",
-						upload.FormatBytes(m.uploadBytes),
-						upload.FormatSpeed(m.finalUploadSpeed))
-				}
-
 				m.completedPhases = append(m.completedPhases, phaseSummary{
 					name:     "Upload artifacts",
 					duration: duration,
-					details:  details,
+					details:  m.uploadDetails(),
 				})
 			}
 

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -956,7 +956,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	// Create app client for the builder
 	appClient := appclient.NewClient(c.Log, loopback)
 
-	bs := build.NewBuilder(c.Log, eac, appClient, addonsClient, c.Resolver, c.TempDir, c.LogWriter, c.CloudAuth.DNSHostname, c.BuildKit)
+	bs := build.NewBuilder(c.Log, eac, appClient, addonsClient, c.Resolver, c.TempDir, c.LogWriter, c.CloudAuth.DNSHostname, c.BuildKit, c.DataPath)
 	server.ExposeValue("dev.miren.runtime/build", build_v1alpha.AdaptBuilder(bs))
 
 	ls := logs.NewServer(c.Log, ec, c.Logs)

--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -2,7 +2,10 @@ package tarx
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +15,14 @@ import (
 	"github.com/shibumi/go-pathspec"
 	"github.com/tonistiigi/fsutil"
 )
+
+// FileManifest represents a file's metadata for delta upload comparison.
+type FileManifest struct {
+	Path string
+	Hash string
+	Size int64
+	Mode int32
+}
 
 // parseGitignore reads a .gitignore file and returns its patterns.
 // Returns nil if the file doesn't exist or can't be read.
@@ -77,113 +88,7 @@ func ValidatePattern(pattern string) error {
 }
 
 func MakeTar(dir string, includePatterns []string) (io.ReadCloser, error) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		return nil, err
-	}
-
-	gzw := gzip.NewWriter(w)
-	tw := tar.NewWriter(gzw)
-
-	// Load gitignore patterns keyed by relative directory path ("." for root)
-	gitignoreMap := make(map[string][]string)
-	rootPatterns := parseGitignore(filepath.Join(dir, ".gitignore"))
-	rootPatterns = append(rootPatterns, ".git") // Always ignore .git directory
-	gitignoreMap["."] = rootPatterns
-
-	go func() {
-		defer w.Close()
-		defer tw.Close()
-		defer gzw.Close()
-
-		// tar up dir and output it to tw
-		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-
-			if dir == path {
-				return nil
-			}
-
-			rp, _ := filepath.Rel(dir, path)
-
-			// Skip all .gitignore files
-			if filepath.Base(rp) == ".gitignore" {
-				return nil
-			}
-
-			// Check if file matches include patterns first
-			isIncluded := false
-			if len(includePatterns) > 0 {
-				// Try both with and without trailing slash for directories
-				paths := []string{rp}
-				if info.IsDir() {
-					paths = append(paths, rp+"/")
-				}
-
-				for _, checkPath := range paths {
-					match, err := pathspec.GitIgnore(includePatterns, checkPath)
-					if err != nil {
-						return fmt.Errorf("invalid include pattern: %w", err)
-					}
-					if match {
-						isIncluded = true
-						break
-					}
-				}
-			}
-
-			// Skip gitignore check if file is explicitly included
-			if !isIncluded {
-				ignored, err := isGitignored(rp, info.IsDir(), gitignoreMap)
-				if err != nil {
-					return err
-				}
-				if ignored {
-					if info.IsDir() {
-						return filepath.SkipDir
-					}
-					return nil
-				}
-			}
-
-			// If this directory survived the ignore check, load its .gitignore
-			if info.IsDir() {
-				nestedGitignore := filepath.Join(path, ".gitignore")
-				if patterns := parseGitignore(nestedGitignore); patterns != nil {
-					gitignoreMap[rp] = patterns
-				}
-			}
-
-			hdr, err := tar.FileInfoHeader(info, "")
-			if err != nil {
-				return err
-			}
-
-			hdr.Name = rp
-
-			if err := tw.WriteHeader(hdr); err != nil {
-				return err
-			}
-
-			if info.Mode().IsRegular() {
-				f, err := os.Open(path)
-				if err != nil {
-					return err
-				}
-				defer f.Close()
-
-				if _, err := io.Copy(tw, f); err != nil {
-					return err
-				}
-			}
-
-			return nil
-		})
-	}()
-
-	return r, nil
+	return makeTarWithFilter(dir, includePatterns, func(string) bool { return true })
 }
 
 func TarToMap(r io.Reader) (map[string][]byte, error) {
@@ -218,6 +123,262 @@ func TarToMap(r io.Reader) (map[string][]byte, error) {
 	}
 
 	return m, nil
+}
+
+// ComputeManifest walks a directory using the same gitignore/include logic as MakeTar
+// and returns a manifest of all regular files with their SHA-256 hashes.
+func ComputeManifest(dir string, includePatterns []string) ([]FileManifest, error) {
+	gitignoreMap := make(map[string][]string)
+	rootPatterns := parseGitignore(filepath.Join(dir, ".gitignore"))
+	rootPatterns = append(rootPatterns, ".git")
+	gitignoreMap["."] = rootPatterns
+
+	var manifest []FileManifest
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if dir == path {
+			return nil
+		}
+
+		rp, _ := filepath.Rel(dir, path)
+
+		if filepath.Base(rp) == ".gitignore" {
+			return nil
+		}
+
+		isIncluded := false
+		if len(includePatterns) > 0 {
+			paths := []string{rp}
+			if info.IsDir() {
+				paths = append(paths, rp+"/")
+			}
+			for _, checkPath := range paths {
+				match, matchErr := pathspec.GitIgnore(includePatterns, checkPath)
+				if matchErr != nil {
+					return fmt.Errorf("invalid include pattern: %w", matchErr)
+				}
+				if match {
+					isIncluded = true
+					break
+				}
+			}
+		}
+
+		if !isIncluded {
+			ignored, ignoreErr := isGitignored(rp, info.IsDir(), gitignoreMap)
+			if ignoreErr != nil {
+				return ignoreErr
+			}
+			if ignored {
+				if info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+
+		if info.IsDir() {
+			nestedGitignore := filepath.Join(path, ".gitignore")
+			if patterns := parseGitignore(nestedGitignore); patterns != nil {
+				gitignoreMap[rp] = patterns
+			}
+			return nil
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		hash, hashErr := hashFile(path)
+		if hashErr != nil {
+			return fmt.Errorf("hashing %s: %w", rp, hashErr)
+		}
+
+		manifest = append(manifest, FileManifest{
+			Path: rp,
+			Hash: hash,
+			Size: info.Size(),
+			Mode: int32(info.Mode().Perm()),
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return manifest, nil
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// MakeEmptyTar returns a valid empty gzipped tar archive.
+func MakeEmptyTar() io.ReadCloser {
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	tw.Close()
+	gzw.Close()
+	return io.NopCloser(&buf)
+}
+
+// MakeFilteredTar creates a gzipped tar like MakeTar but only includes files
+// whose relative paths are in the onlyPaths set. Directory entries are included
+// as needed to contain the requested files.
+func MakeFilteredTar(dir string, includePatterns []string, onlyPaths map[string]bool) (io.ReadCloser, error) {
+	return makeTarWithFilter(dir, includePatterns, func(rp string) bool { return onlyPaths[rp] })
+}
+
+// makeTarWithFilter creates a gzipped tar of dir, applying gitignore/include logic,
+// and only including regular files for which accept returns true. Directory entries
+// are emitted lazily as needed to contain accepted files.
+func makeTarWithFilter(dir string, includePatterns []string, accept func(string) bool) (io.ReadCloser, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	gzw := gzip.NewWriter(w)
+	tw := tar.NewWriter(gzw)
+
+	gitignoreMap := make(map[string][]string)
+	rootPatterns := parseGitignore(filepath.Join(dir, ".gitignore"))
+	rootPatterns = append(rootPatterns, ".git")
+	gitignoreMap["."] = rootPatterns
+
+	go func() {
+		defer w.Close()
+		defer tw.Close()
+		defer gzw.Close()
+
+		emittedDirs := make(map[string]bool)
+
+		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if dir == path {
+				return nil
+			}
+
+			rp, _ := filepath.Rel(dir, path)
+
+			if filepath.Base(rp) == ".gitignore" {
+				return nil
+			}
+
+			isIncluded := false
+			if len(includePatterns) > 0 {
+				paths := []string{rp}
+				if info.IsDir() {
+					paths = append(paths, rp+"/")
+				}
+				for _, checkPath := range paths {
+					match, matchErr := pathspec.GitIgnore(includePatterns, checkPath)
+					if matchErr != nil {
+						return fmt.Errorf("invalid include pattern: %w", matchErr)
+					}
+					if match {
+						isIncluded = true
+						break
+					}
+				}
+			}
+
+			if !isIncluded {
+				ignored, ignoreErr := isGitignored(rp, info.IsDir(), gitignoreMap)
+				if ignoreErr != nil {
+					return ignoreErr
+				}
+				if ignored {
+					if info.IsDir() {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+			}
+
+			if info.IsDir() {
+				nestedGitignore := filepath.Join(path, ".gitignore")
+				if patterns := parseGitignore(nestedGitignore); patterns != nil {
+					gitignoreMap[rp] = patterns
+				}
+				return nil
+			}
+
+			if !accept(rp) {
+				return nil
+			}
+
+			// Emit parent directories if not yet emitted
+			parts := strings.Split(filepath.Dir(rp), string(filepath.Separator))
+			for i := range parts {
+				if parts[i] == "." {
+					continue
+				}
+				dirPath := strings.Join(parts[:i+1], string(filepath.Separator))
+				if emittedDirs[dirPath] {
+					continue
+				}
+				emittedDirs[dirPath] = true
+
+				dirInfo, dirErr := os.Stat(filepath.Join(dir, dirPath))
+				if dirErr != nil {
+					continue
+				}
+				dirHdr, hdrErr := tar.FileInfoHeader(dirInfo, "")
+				if hdrErr != nil {
+					continue
+				}
+				dirHdr.Name = dirPath
+				if err := tw.WriteHeader(dirHdr); err != nil {
+					return err
+				}
+			}
+
+			hdr, hdrErr := tar.FileInfoHeader(info, "")
+			if hdrErr != nil {
+				return hdrErr
+			}
+			hdr.Name = rp
+
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+
+			if info.Mode().IsRegular() {
+				f, fErr := os.Open(path)
+				if fErr != nil {
+					return fErr
+				}
+				defer f.Close()
+				if _, err := io.Copy(tw, f); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}()
+
+	return r, nil
 }
 
 func TarFS(r io.Reader, dir string) (fsutil.FS, error) {

--- a/pkg/tarx/tarx_test.go
+++ b/pkg/tarx/tarx_test.go
@@ -320,10 +320,191 @@ func TestMakeTarGitignoreNegation(t *testing.T) {
 	reader, err := MakeTar(tmpDir, nil)
 	require.NoError(t, err)
 
-	// Extract and verify only important.log and regular.txt are included
+	// Extract and verify only important.log and regular.txt are included.
+	// dir/ is not included because all files inside it are gitignored.
 	entries := extractTarEntries(t, reader)
-	expected := []string{"important.log", "regular.txt", "dir"}
+	expected := []string{"important.log", "regular.txt"}
 	require.ElementsMatch(t, expected, entries)
+}
+
+func TestComputeManifest(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tarx-manifest-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	files := map[string]string{
+		"main.go":       "package main",
+		"go.mod":        "module test",
+		"lib/util.go":   "package lib",
+		"ignored.log":   "log data",
+		".git/HEAD":     "ref: refs/heads/main",
+		"dist/build.js": "built",
+	}
+
+	for filename, content := range files {
+		fullPath := filepath.Join(tmpDir, filename)
+		dir := filepath.Dir(fullPath)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(fullPath, []byte(content), 0644))
+	}
+
+	// Gitignore excludes *.log and dist
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("*.log\ndist\n"), 0644))
+
+	manifest, err := ComputeManifest(tmpDir, nil)
+	require.NoError(t, err)
+
+	// Should include main.go, go.mod, lib/util.go (not .gitignore, not .git, not *.log, not dist)
+	paths := make(map[string]bool)
+	for _, m := range manifest {
+		paths[m.Path] = true
+		require.NotEmpty(t, m.Hash, "hash should be set for %s", m.Path)
+		require.True(t, m.Size > 0, "size should be positive for %s", m.Path)
+		require.True(t, m.Mode > 0, "mode should be set for %s", m.Path)
+	}
+
+	require.True(t, paths["main.go"])
+	require.True(t, paths["go.mod"])
+	require.True(t, paths["lib/util.go"])
+	require.False(t, paths["ignored.log"])
+	require.False(t, paths[".git/HEAD"])
+	require.False(t, paths["dist/build.js"])
+}
+
+func TestComputeManifestDeterministic(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tarx-manifest-det-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("hello"), 0644))
+
+	m1, err := ComputeManifest(tmpDir, nil)
+	require.NoError(t, err)
+
+	m2, err := ComputeManifest(tmpDir, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, len(m1), len(m2))
+	require.Equal(t, m1[0].Hash, m2[0].Hash)
+}
+
+func TestMakeFilteredTar(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tarx-filtered-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	files := map[string]string{
+		"main.go":     "package main",
+		"go.mod":      "module test",
+		"lib/util.go": "package lib",
+		"lib/db.go":   "package lib",
+	}
+
+	for filename, content := range files {
+		fullPath := filepath.Join(tmpDir, filename)
+		dir := filepath.Dir(fullPath)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(fullPath, []byte(content), 0644))
+	}
+
+	// Only include main.go and lib/db.go
+	onlyPaths := map[string]bool{
+		"main.go":   true,
+		"lib/db.go": true,
+	}
+
+	reader, err := MakeFilteredTar(tmpDir, nil, onlyPaths)
+	require.NoError(t, err)
+
+	entries := extractTarEntries(t, reader)
+
+	// Should contain the two requested files and the lib directory
+	require.Contains(t, entries, "main.go")
+	require.Contains(t, entries, "lib/db.go")
+	require.Contains(t, entries, "lib")
+
+	// Should NOT contain the excluded files
+	require.NotContains(t, entries, "go.mod")
+	require.NotContains(t, entries, "lib/util.go")
+}
+
+func TestMakeFilteredTarEmpty(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tarx-filtered-empty-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("hello"), 0644))
+
+	// Empty only-paths set => no files in tar
+	reader, err := MakeFilteredTar(tmpDir, nil, map[string]bool{})
+	require.NoError(t, err)
+
+	entries := extractTarEntries(t, reader)
+	require.Empty(t, entries)
+}
+
+func TestMakeTarOnlyIncludesDirectoriesWithAcceptedFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tarx-dir-filter-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	files := map[string]string{
+		"main.go":          "package main",
+		"lib/util.go":      "package lib",
+		"empty/readme.txt": "hello",
+		"deep/a/b/file.go": "package b",
+	}
+
+	for filename, content := range files {
+		fullPath := filepath.Join(tmpDir, filename)
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0755))
+		require.NoError(t, os.WriteFile(fullPath, []byte(content), 0644))
+	}
+
+	t.Run("unfiltered includes all directories", func(t *testing.T) {
+		reader, err := MakeTar(tmpDir, nil)
+		require.NoError(t, err)
+
+		entries := extractTarEntries(t, reader)
+		require.Contains(t, entries, "lib")
+		require.Contains(t, entries, "empty")
+		require.Contains(t, entries, "deep")
+		require.Contains(t, entries, "deep/a")
+		require.Contains(t, entries, "deep/a/b")
+	})
+
+	t.Run("filtered excludes directories with no accepted files", func(t *testing.T) {
+		onlyPaths := map[string]bool{
+			"main.go":     true,
+			"lib/util.go": true,
+		}
+
+		reader, err := MakeFilteredTar(tmpDir, nil, onlyPaths)
+		require.NoError(t, err)
+
+		entries := extractTarEntries(t, reader)
+		require.Contains(t, entries, "main.go")
+		require.Contains(t, entries, "lib")
+		require.Contains(t, entries, "lib/util.go")
+
+		// Directories with no accepted files should not appear
+		require.NotContains(t, entries, "empty")
+		require.NotContains(t, entries, "deep")
+		require.NotContains(t, entries, "deep/a")
+		require.NotContains(t, entries, "deep/a/b")
+	})
+
+	t.Run("filtered emits nested parent directories", func(t *testing.T) {
+		onlyPaths := map[string]bool{
+			"deep/a/b/file.go": true,
+		}
+
+		reader, err := MakeFilteredTar(tmpDir, nil, onlyPaths)
+		require.NoError(t, err)
+
+		entries := extractTarEntries(t, reader)
+		require.ElementsMatch(t, []string{"deep", "deep/a", "deep/a/b", "deep/a/b/file.go"}, entries)
+	})
 }
 
 func TestMakeTarWithIncludePatterns(t *testing.T) {

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/moby/buildkit/client"
@@ -70,6 +71,12 @@ func (w *buildLogWriter) write(msg string) {
 	}
 }
 
+type buildSession struct {
+	dir        string
+	appName    string
+	cancelFunc context.CancelFunc
+}
+
 type Builder struct {
 	Log           *slog.Logger
 	EAS           *entityserver_v1alpha.EntityAccessClient
@@ -80,6 +87,7 @@ type Builder struct {
 	TempDir       string
 	Registry      string
 	DNSHostname   string // Cloud-provisioned DNS hostname for default route display
+	DataPath      string
 
 	Resolver  netresolve.Resolver
 	LogWriter observability.LogWriter
@@ -87,9 +95,11 @@ type Builder struct {
 	// BuildKit is the persistent BuildKit component for container image builds.
 	// When set, uses the shared daemon instead of launching ephemeral sandboxes.
 	BuildKit *buildkit.Component
+
+	sessions sync.Map // sessionID → *buildSession
 }
 
-func NewBuilder(log *slog.Logger, eas *entityserver_v1alpha.EntityAccessClient, appClient *app.Client, addonsClient *app_v1alpha.AddonsClient, res netresolve.Resolver, tmpdir string, logWriter observability.LogWriter, dnsHostname string, bk *buildkit.Component) *Builder {
+func NewBuilder(log *slog.Logger, eas *entityserver_v1alpha.EntityAccessClient, appClient *app.Client, addonsClient *app_v1alpha.AddonsClient, res netresolve.Resolver, tmpdir string, logWriter observability.LogWriter, dnsHostname string, bk *buildkit.Component, dataPath string) *Builder {
 	return &Builder{
 		Log:           log.With("module", "builder"),
 		EAS:           eas,
@@ -102,6 +112,7 @@ func NewBuilder(log *slog.Logger, eas *entityserver_v1alpha.EntityAccessClient, 
 		LogWriter:     logWriter,
 		DNSHostname:   dnsHostname,
 		BuildKit:      bk,
+		DataPath:      dataPath,
 	}
 }
 
@@ -823,7 +834,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		trace.WithAttributes(attribute.String("miren.app.name", name)))
 	r := stream.ToReader(ctx, td)
 
-	tr, err := tarx.TarFS(r, path)
+	_, err = tarx.TarFS(r, path)
 	if err != nil {
 		recvSpan.RecordError(err)
 		recvSpan.SetStatus(codes.Error, err.Error())
@@ -833,13 +844,180 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 	recvSpan.End()
 
+	// Save source code cache for future delta uploads
+	if b.DataPath != "" {
+		cache := &sourceCache{dataPath: b.DataPath}
+		if err := cache.saveSourceImage(name, path); err != nil {
+			b.Log.Warn("failed to save source code cache", "error", err, "app", name)
+		}
+	}
+
 	if status != nil {
 		so.Update().SetMessage("Launching builder")
 		_, _ = status.Send(ctx, so)
 	}
 
+	result, err := b.buildFromDir(ctx, name, path, status, args.EnvVars())
+	if err != nil {
+		return err
+	}
+
+	state.Results().SetVersion(result.version)
+	state.Results().SetAccessInfo(&result.accessInfo)
+
+	return nil
+}
+
+func (b *Builder) PrepareUpload(ctx context.Context, state *build_v1alpha.BuilderPrepareUpload) error {
+	args := state.Args()
+
+	name := args.Application()
+
+	if !rpc.AllowApp(ctx, name) {
+		return rpc.AppAccessError(ctx, name)
+	}
+
+	if b.DataPath == "" {
+		return fmt.Errorf("data path not configured")
+	}
+
+	manifest := args.Manifest()
+
+	tempDir, err := os.MkdirTemp(b.TempDir, "buildkit-")
+	if err != nil {
+		return err
+	}
+
+	cache := &sourceCache{dataPath: b.DataPath}
+
+	matched, needed, err := cache.stageMatchingFiles(name, tempDir, manifest)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return fmt.Errorf("staging cached files: %w", err)
+	}
+
+	sessionID := idgen.Gen("s")
+
+	cleanupCtx, cancelCleanup := context.WithCancel(context.Background())
+
+	b.sessions.Store(sessionID, &buildSession{
+		dir:        tempDir,
+		appName:    name,
+		cancelFunc: cancelCleanup,
+	})
+
+	// Cleanup goroutine: remove session after 10 minutes if unused.
+	// When BuildFromPrepared claims the session, it cancels this context
+	// to stop the goroutine and prevent a race where cleanup runs mid-build.
+	go func() {
+		select {
+		case <-time.After(10 * time.Minute):
+			if val, loaded := b.sessions.LoadAndDelete(sessionID); loaded {
+				sess := val.(*buildSession)
+				os.RemoveAll(sess.dir)
+				b.Log.Info("cleaned up expired upload session", "session", sessionID)
+			}
+		case <-cleanupCtx.Done():
+		}
+	}()
+
+	b.Log.Info("prepared upload session",
+		"session", sessionID,
+		"app", name,
+		"cached", matched,
+		"needed", len(needed),
+		"total", len(manifest),
+	)
+
+	result := &build_v1alpha.PrepareUploadResult{}
+	result.SetSessionId(sessionID)
+	result.SetNeededPaths(&needed)
+	result.SetCachedCount(int32(matched))
+
+	state.Results().SetResult(&result)
+
+	return nil
+}
+
+func (b *Builder) BuildFromPrepared(ctx context.Context, state *build_v1alpha.BuilderBuildFromPrepared) error {
+	args := state.Args()
+	sessionID := args.SessionId()
+
+	val, ok := b.sessions.LoadAndDelete(sessionID)
+	if !ok {
+		return fmt.Errorf("unknown or expired upload session: %s", sessionID)
+	}
+
+	sess := val.(*buildSession)
+	sess.cancelFunc()
+	defer os.RemoveAll(sess.dir)
+
+	name := sess.appName
+	status := args.Status()
+
+	// Extract partial tar into the session directory if provided
+	td := args.Tardata()
+	if td != nil {
+		so := new(build_v1alpha.Status)
+		if status != nil {
+			so.Update().SetMessage("Receiving changed files")
+			_, _ = status.Send(ctx, so)
+		}
+
+		r := stream.ToReader(ctx, td)
+		_, err := tarx.TarFS(r, sess.dir)
+		if err != nil {
+			b.sendErrorStatus(ctx, status, "Error extracting changed files: %v", err)
+			return fmt.Errorf("error extracting changed files: %w", err)
+		}
+	}
+
+	// Save source code cache before building
+	if b.DataPath != "" {
+		cache := &sourceCache{dataPath: b.DataPath}
+		if err := cache.saveSourceImage(name, sess.dir); err != nil {
+			b.Log.Warn("failed to save source code cache", "error", err, "app", name)
+		}
+	}
+
+	if status != nil {
+		so := new(build_v1alpha.Status)
+		so.Update().SetMessage("Launching builder")
+		_, _ = status.Send(ctx, so)
+	}
+
+	result, err := b.buildFromDir(ctx, name, sess.dir, status, args.EnvVars())
+	if err != nil {
+		return err
+	}
+
+	state.Results().SetVersion(result.version)
+	state.Results().SetAccessInfo(&result.accessInfo)
+
+	return nil
+}
+
+type buildResult struct {
+	version    string
+	accessInfo *build_v1alpha.AccessInfo
+}
+
+func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
+	status *stream.SendStreamClient[*build_v1alpha.Status],
+	envVars []*build_v1alpha.EnvironmentVariable) (*buildResult, error) {
+
+	so := new(build_v1alpha.Status)
+
 	// -- build.setup span: app config, stack detection, buildkit connect
 	ctx, setupSpan := buildTracer.Start(ctx, "build.setup")
+
+	tr, err := fsutil.NewFS(path)
+	if err != nil {
+		setupSpan.RecordError(err)
+		setupSpan.SetStatus(codes.Error, err.Error())
+		setupSpan.End()
+		return nil, fmt.Errorf("error creating FS from build dir: %w", err)
+	}
 
 	ac, err := b.loadAppConfig(tr)
 	if err != nil {
@@ -892,7 +1070,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 			setupSpan.End()
 			b.Log.Error("stack detection failed", "error", err, "app", name, "codeDir", buildStack.CodeDir)
 			b.sendErrorStatus(ctx, status, "No supported stack detected for app %s: %v", name, err)
-			return fmt.Errorf("no supported stack detected for app %s: %w", name, err)
+			return nil, fmt.Errorf("no supported stack detected for app %s: %w", name, err)
 		}
 		b.Log.Debug("stack detection successful, proceeding with build")
 	}
@@ -906,7 +1084,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		setupSpan.End()
 		b.Log.Error("buildkit component not configured")
 		b.sendErrorStatus(ctx, status, "BuildKit not configured - ensure server is running with BuildKit enabled")
-		return fmt.Errorf("buildkit component not configured")
+		return nil, fmt.Errorf("buildkit component not configured")
 	}
 
 	b.Log.Info("connecting to buildkit daemon")
@@ -917,7 +1095,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		setupSpan.End()
 		b.Log.Error("failed to get buildkit client", "error", err)
 		b.sendErrorStatus(ctx, status, "Failed to connect to BuildKit: %v", err)
-		return err
+		return nil, err
 	}
 	defer bkc.Close()
 
@@ -941,7 +1119,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	if err != nil {
 		b.Log.Error("error getting next version", "error", err)
 		b.sendErrorStatus(ctx, status, "Error getting next version: %v", err)
-		return err
+		return nil, err
 	}
 
 	// Initialize build log writer for persisting build output to VictoriaLogs
@@ -953,7 +1131,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 
 	// Compute env vars to inject into the build process
-	buildEnvVars := computeBuildEnvVars(existingCfg.Variables, ac, args.EnvVars())
+	buildEnvVars := computeBuildEnvVars(existingCfg.Variables, ac, envVars)
 	if len(buildEnvVars) > 0 {
 		b.Log.Info("injecting env vars into build", "count", len(buildEnvVars))
 	}
@@ -1057,7 +1235,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		bkSpan.End()
 		b.Log.Error("error building image", "error", err)
 		b.sendErrorStatus(ctx, status, "Error building image: %v", err)
-		return err
+		return nil, err
 	}
 	bkSpan.End()
 
@@ -1069,7 +1247,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	if res.ManifestDigest == "" {
 		b.Log.Error("build did not return manifest digest")
 		b.sendErrorStatus(ctx, status, "Build did not return manifest digest")
-		return fmt.Errorf("build did not return manifest digest")
+		return nil, fmt.Errorf("build did not return manifest digest")
 	}
 
 	// -- build.locate_artifact span
@@ -1084,7 +1262,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		locateSpan.SetStatus(codes.Error, err.Error())
 		locateSpan.End()
 		b.Log.Error("error locating artifact by digest", "digest", res.ManifestDigest, "error", err)
-		return fmt.Errorf("error locating artifact by digest %s: %w", res.ManifestDigest, err)
+		return nil, fmt.Errorf("error locating artifact by digest %s: %w", res.ManifestDigest, err)
 	}
 	locateSpan.End()
 
@@ -1100,7 +1278,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 
 	procfileServices, err := b.readProcFile(tr)
 	if err != nil {
-		return fmt.Errorf("error reading procfile: %w", err)
+		return nil, fmt.Errorf("error reading procfile: %w", err)
 	} else if procfileServices == nil {
 		b.Log.Debug("no procfile found, using app config")
 	} else {
@@ -1113,14 +1291,14 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		AppConfig:        ac,
 		ProcfileServices: procfileServices,
 		ExistingConfig:   existingCfg,
-		CliEnvVars:       args.EnvVars(),
+		CliEnvVars:       envVars,
 	})
 
 	// Fail the deploy if no services are defined - this prevents deploying an app
 	// that can't serve any traffic
 	if err := validateServicesExist(configSpec); err != nil {
 		b.sendErrorStatus(ctx, status, "%s. See https://miren.md/services", err)
-		return err
+		return nil, err
 	}
 
 	// Fail the deploy if required env vars are missing values.
@@ -1139,21 +1317,21 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	// picture, matching how validateServicesExist works just above.
 	if err := validateRequiredVars(configSpec); err != nil {
 		b.sendErrorStatus(ctx, status, "%s", err)
-		return err
+		return nil, err
 	}
 
 	if err := validateNodePorts(ctx, b.ec.EAC(), appRec.ID, configSpec); err != nil {
 		b.sendErrorStatus(ctx, status, "Deploy failed: %v", err)
-		return err
+		return nil, err
 	}
 
 	if err := validateDiskConfigs(ctx, b.ec.EAC(), configSpec); err != nil {
 		b.sendErrorStatus(ctx, status, "Deploy failed: %v", err)
-		return err
+		return nil, err
 	}
 
-	if len(args.EnvVars()) > 0 {
-		b.Log.Info("applied CLI env vars", "count", len(args.EnvVars()))
+	if len(envVars) > 0 {
+		b.Log.Info("applied CLI env vars", "count", len(envVars))
 	}
 
 	if ac != nil && len(ac.EnvVars) > 0 {
@@ -1177,7 +1355,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		createVerSpan.RecordError(err)
 		createVerSpan.SetStatus(codes.Error, err.Error())
 		createVerSpan.End()
-		return fmt.Errorf("error creating config version: %w", err)
+		return nil, fmt.Errorf("error creating config version: %w", err)
 	}
 	mrv.ConfigVersion = cvid
 	mrv.Config = core_v1alpha.Config{}
@@ -1187,7 +1365,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		createVerSpan.RecordError(err)
 		createVerSpan.SetStatus(codes.Error, err.Error())
 		createVerSpan.End()
-		return fmt.Errorf("error creating app version: %w", err)
+		return nil, fmt.Errorf("error creating app version: %w", err)
 	}
 	createVerSpan.End()
 
@@ -1199,7 +1377,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	// a new AppVersion with addon vars once provisioning completes.
 	if ac != nil && b.addonsClient != nil {
 		if err := b.provisionAddons(ctx, name, ac); err != nil {
-			return fmt.Errorf("addon provisioning failed: %w", err)
+			return nil, fmt.Errorf("addon provisioning failed: %w", err)
 		}
 	}
 
@@ -1209,7 +1387,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 		activateSpan.RecordError(err)
 		activateSpan.SetStatus(codes.Error, err.Error())
 		activateSpan.End()
-		return fmt.Errorf("error updating app entity: %w", err)
+		return nil, fmt.Errorf("error updating app entity: %w", err)
 	}
 	activateSpan.End()
 
@@ -1218,17 +1396,12 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	// Log the deployment to the app's logs
 	b.logDeployment(ctx, name, mrv.Version, artifactName)
 
-	// Note: Old version pool cleanup is now handled by the DeploymentLauncher controller
-	// via the referenced_by_versions field. The launcher removes version references and
-	// scales down pools when they're no longer in use.
-
-	state.Results().SetVersion(mrv.Version)
-
-	// Get access info for the deployed app
 	accessInfo := b.getAccessInfo(ctx, name)
-	state.Results().SetAccessInfo(&accessInfo)
 
-	return nil
+	return &buildResult{
+		version:    mrv.Version,
+		accessInfo: accessInfo,
+	}, nil
 }
 
 // getAccessInfo queries routes to determine how the app can be accessed

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -96,7 +96,8 @@ type Builder struct {
 	// When set, uses the shared daemon instead of launching ephemeral sandboxes.
 	BuildKit *buildkit.Component
 
-	sessions sync.Map // sessionID → *buildSession
+	sessions   sync.Map // sessionID → *buildSession
+	cacheLocks *appLocks
 }
 
 func NewBuilder(log *slog.Logger, eas *entityserver_v1alpha.EntityAccessClient, appClient *app.Client, addonsClient *app_v1alpha.AddonsClient, res netresolve.Resolver, tmpdir string, logWriter observability.LogWriter, dnsHostname string, bk *buildkit.Component, dataPath string) *Builder {
@@ -113,6 +114,7 @@ func NewBuilder(log *slog.Logger, eas *entityserver_v1alpha.EntityAccessClient, 
 		DNSHostname:   dnsHostname,
 		BuildKit:      bk,
 		DataPath:      dataPath,
+		cacheLocks:    newAppLocks(),
 	}
 }
 
@@ -846,7 +848,7 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 
 	// Save source code cache for future delta uploads
 	if b.DataPath != "" {
-		cache := &sourceCache{dataPath: b.DataPath}
+		cache := &sourceCache{dataPath: b.DataPath, log: b.Log, locks: b.cacheLocks}
 		if err := cache.saveSourceImage(name, path); err != nil {
 			b.Log.Warn("failed to save source code cache", "error", err, "app", name)
 		}
@@ -888,7 +890,7 @@ func (b *Builder) PrepareUpload(ctx context.Context, state *build_v1alpha.Builde
 		return err
 	}
 
-	cache := &sourceCache{dataPath: b.DataPath}
+	cache := &sourceCache{dataPath: b.DataPath, log: b.Log, locks: b.cacheLocks}
 
 	matched, needed, err := cache.stageMatchingFiles(name, tempDir, manifest)
 	if err != nil {
@@ -953,6 +955,11 @@ func (b *Builder) BuildFromPrepared(ctx context.Context, state *build_v1alpha.Bu
 	defer os.RemoveAll(sess.dir)
 
 	name := sess.appName
+
+	if !rpc.AllowApp(ctx, name) {
+		return rpc.AppAccessError(ctx, name)
+	}
+
 	status := args.Status()
 
 	// Extract partial tar into the session directory if provided
@@ -974,7 +981,7 @@ func (b *Builder) BuildFromPrepared(ctx context.Context, state *build_v1alpha.Bu
 
 	// Save source code cache before building
 	if b.DataPath != "" {
-		cache := &sourceCache{dataPath: b.DataPath}
+		cache := &sourceCache{dataPath: b.DataPath, log: b.Log, locks: b.cacheLocks}
 		if err := cache.saveSourceImage(name, sess.dir); err != nil {
 			b.Log.Warn("failed to save source code cache", "error", err, "app", name)
 		}

--- a/servers/build/source_cache.go
+++ b/servers/build/source_cache.go
@@ -1,0 +1,267 @@
+package build
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"miren.dev/runtime/api/build/build_v1alpha"
+)
+
+type sourceCache struct {
+	dataPath string
+}
+
+type cachedFileInfo struct {
+	Hash string `json:"hash"`
+	Size int64  `json:"size"`
+	Mode int32  `json:"mode"`
+}
+
+func (sc *sourceCache) cacheDir(app string) (string, error) {
+	if strings.ContainsAny(app, "/\\") || strings.Contains(app, "..") || app == "" {
+		return "", fmt.Errorf("invalid app name for source cache: %q", app)
+	}
+	return filepath.Join(sc.dataPath, "source-code", app), nil
+}
+
+func (sc *sourceCache) loadManifest(app string) (map[string]cachedFileInfo, error) {
+	dir, err := sc.cacheDir(app)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]cachedFileInfo{}, nil
+		}
+		return nil, err
+	}
+
+	var manifest map[string]cachedFileInfo
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return map[string]cachedFileInfo{}, nil
+	}
+	return manifest, nil
+}
+
+// stageMatchingFiles compares the client manifest against the cached source code
+// and extracts matching files from the cache into buildDir. Returns the count of
+// matched files and the list of paths that still need to be uploaded.
+func (sc *sourceCache) stageMatchingFiles(app string, buildDir string, clientManifest []*build_v1alpha.FileManifestEntry) (matched int, needed []string, err error) {
+	cached, err := sc.loadManifest(app)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	if len(cached) == 0 {
+		// No cache — all files needed
+		for _, entry := range clientManifest {
+			needed = append(needed, entry.Path())
+		}
+		return 0, needed, nil
+	}
+
+	// Determine which files match
+	var matchedPaths []string
+	for _, entry := range clientManifest {
+		ci, ok := cached[entry.Path()]
+		if ok && ci.Hash == entry.Hash() {
+			matchedPaths = append(matchedPaths, entry.Path())
+		} else {
+			needed = append(needed, entry.Path())
+		}
+	}
+
+	if len(matchedPaths) == 0 {
+		return 0, needed, nil
+	}
+
+	// Extract matching files from the cached layer
+	dir, err := sc.cacheDir(app)
+	if err != nil {
+		return 0, nil, err
+	}
+	layerPath := filepath.Join(dir, "layer.tar.gz")
+	if err := extractFilesFromLayer(layerPath, buildDir, matchedPaths); err != nil {
+		// Cache is corrupt — fall back to full upload
+		needed = append(needed, matchedPaths...)
+		return 0, needed, nil
+	}
+
+	return len(matchedPaths), needed, nil
+}
+
+// safePath validates that joining base and rel stays within base, preventing path traversal.
+func safePath(base, rel string) (string, error) {
+	joined := filepath.Join(base, rel)
+	if !strings.HasPrefix(filepath.Clean(joined), filepath.Clean(base)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path escapes base directory: %q", rel)
+	}
+	return joined, nil
+}
+
+func extractFilesFromLayer(layerPath, buildDir string, paths []string) error {
+	f, err := os.Open(layerPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	wantSet := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		wantSet[p] = true
+	}
+
+	tr := tar.NewReader(gzr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if hdr.Typeflag != tar.TypeReg || !wantSet[hdr.Name] {
+			continue
+		}
+
+		outPath, pathErr := safePath(buildDir, hdr.Name)
+		if pathErr != nil {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+			return err
+		}
+
+		outFile, err := os.Create(outPath)
+		if err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(outFile, tr); err != nil {
+			outFile.Close()
+			return err
+		}
+		outFile.Chmod(os.FileMode(hdr.Mode) & os.ModePerm)
+		outFile.Close()
+	}
+
+	return nil
+}
+
+// saveSourceImage creates a cached source code layer from the build directory.
+// This should be called after all files are resolved but before the build starts.
+func (sc *sourceCache) saveSourceImage(app string, buildDir string) error {
+	dir, err := sc.cacheDir(app)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	// Write to temporary files and rename on success to avoid leaving
+	// a corrupt cache if we fail partway through.
+	manifest := make(map[string]cachedFileInfo)
+
+	tmpLayerPath := filepath.Join(dir, "layer.tar.gz.tmp")
+	layerFile, err := os.Create(tmpLayerPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		layerFile.Close()
+		os.Remove(tmpLayerPath) // no-op if already renamed
+	}()
+
+	gzw := gzip.NewWriter(layerFile)
+	tw := tar.NewWriter(gzw)
+
+	err = filepath.Walk(buildDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if path == buildDir {
+			return nil
+		}
+
+		rp, _ := filepath.Rel(buildDir, path)
+
+		hdr, hdrErr := tar.FileInfoHeader(info, "")
+		if hdrErr != nil {
+			return hdrErr
+		}
+		hdr.Name = rp
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+
+		if info.Mode().IsRegular() {
+			f, fErr := os.Open(path)
+			if fErr != nil {
+				return fErr
+			}
+			defer f.Close()
+
+			h := sha256.New()
+			w := io.MultiWriter(tw, h)
+
+			if _, err := io.Copy(w, f); err != nil {
+				return err
+			}
+
+			manifest[rp] = cachedFileInfo{
+				Hash: hex.EncodeToString(h.Sum(nil)),
+				Size: info.Size(),
+				Mode: int32(info.Mode().Perm()),
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	if err := gzw.Close(); err != nil {
+		return err
+	}
+
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("marshaling manifest: %w", err)
+	}
+
+	tmpManifestPath := filepath.Join(dir, "manifest.json.tmp")
+	if err := os.WriteFile(tmpManifestPath, manifestData, 0644); err != nil {
+		return err
+	}
+
+	// Atomic rename: both files are complete before becoming visible.
+	layerPath := filepath.Join(dir, "layer.tar.gz")
+	if err := os.Rename(tmpLayerPath, layerPath); err != nil {
+		os.Remove(tmpManifestPath)
+		return err
+	}
+	return os.Rename(tmpManifestPath, filepath.Join(dir, "manifest.json"))
+}

--- a/servers/build/source_cache.go
+++ b/servers/build/source_cache.go
@@ -8,15 +8,48 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"miren.dev/runtime/api/build/build_v1alpha"
 )
 
 type sourceCache struct {
 	dataPath string
+	log      *slog.Logger
+	locks    *appLocks
+}
+
+// appLocks provides per-app mutexes so concurrent builds for the same app
+// serialize their cache reads and writes.
+type appLocks struct {
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newAppLocks() *appLocks {
+	return &appLocks{locks: make(map[string]*sync.Mutex)}
+}
+
+func (al *appLocks) lock(app string) {
+	al.mu.Lock()
+	l, ok := al.locks[app]
+	if !ok {
+		l = &sync.Mutex{}
+		al.locks[app] = l
+	}
+	al.mu.Unlock()
+	l.Lock()
+}
+
+func (al *appLocks) unlock(app string) {
+	al.mu.Lock()
+	l := al.locks[app]
+	al.mu.Unlock()
+	l.Unlock()
 }
 
 type cachedFileInfo struct {
@@ -47,6 +80,7 @@ func (sc *sourceCache) loadManifest(app string) (map[string]cachedFileInfo, erro
 
 	var manifest map[string]cachedFileInfo
 	if err := json.Unmarshal(data, &manifest); err != nil {
+		sc.log.Debug("corrupt manifest.json in source cache, ignoring", "app", app, "error", err)
 		return map[string]cachedFileInfo{}, nil
 	}
 	return manifest, nil
@@ -56,6 +90,9 @@ func (sc *sourceCache) loadManifest(app string) (map[string]cachedFileInfo, erro
 // and extracts matching files from the cache into buildDir. Returns the count of
 // matched files and the list of paths that still need to be uploaded.
 func (sc *sourceCache) stageMatchingFiles(app string, buildDir string, clientManifest []*build_v1alpha.FileManifestEntry) (matched int, needed []string, err error) {
+	sc.locks.lock(app)
+	defer sc.locks.unlock(app)
+
 	cached, err := sc.loadManifest(app)
 	if err != nil {
 		return 0, nil, err
@@ -167,6 +204,9 @@ func extractFilesFromLayer(layerPath, buildDir string, paths []string) error {
 // saveSourceImage creates a cached source code layer from the build directory.
 // This should be called after all files are resolved but before the build starts.
 func (sc *sourceCache) saveSourceImage(app string, buildDir string) error {
+	sc.locks.lock(app)
+	defer sc.locks.unlock(app)
+
 	dir, err := sc.cacheDir(app)
 	if err != nil {
 		return err
@@ -218,13 +258,14 @@ func (sc *sourceCache) saveSourceImage(app string, buildDir string) error {
 			if fErr != nil {
 				return fErr
 			}
-			defer f.Close()
 
 			h := sha256.New()
 			w := io.MultiWriter(tw, h)
 
-			if _, err := io.Copy(w, f); err != nil {
-				return err
+			_, copyErr := io.Copy(w, f)
+			f.Close()
+			if copyErr != nil {
+				return copyErr
 			}
 
 			manifest[rp] = cachedFileInfo{
@@ -257,11 +298,13 @@ func (sc *sourceCache) saveSourceImage(app string, buildDir string) error {
 		return err
 	}
 
-	// Atomic rename: both files are complete before becoming visible.
-	layerPath := filepath.Join(dir, "layer.tar.gz")
-	if err := os.Rename(tmpLayerPath, layerPath); err != nil {
-		os.Remove(tmpManifestPath)
+	// Rename manifest first: if we crash between renames, the new manifest
+	// won't match the old layer's contents, causing cache misses (safe)
+	// rather than hash/content mismatch (corrupt).
+	if err := os.Rename(tmpManifestPath, filepath.Join(dir, "manifest.json")); err != nil {
+		os.Remove(tmpLayerPath)
 		return err
 	}
-	return os.Rename(tmpManifestPath, filepath.Join(dir, "manifest.json"))
+	layerPath := filepath.Join(dir, "layer.tar.gz")
+	return os.Rename(tmpLayerPath, layerPath)
 }

--- a/servers/build/source_cache_test.go
+++ b/servers/build/source_cache_test.go
@@ -1,0 +1,131 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/build/build_v1alpha"
+)
+
+func TestSourceCacheRoundtrip(t *testing.T) {
+	dataPath := t.TempDir()
+	cache := &sourceCache{dataPath: dataPath}
+
+	// Create a build directory with some files
+	buildDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "main.go"), []byte("package main"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(buildDir, "lib"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "lib/util.go"), []byte("package lib"), 0644))
+
+	// Save source image
+	err := cache.saveSourceImage("myapp", buildDir)
+	require.NoError(t, err)
+
+	// Verify files were created
+	require.FileExists(t, filepath.Join(dataPath, "source-code", "myapp", "layer.tar.gz"))
+	require.FileExists(t, filepath.Join(dataPath, "source-code", "myapp", "manifest.json"))
+
+	// Load manifest and verify contents
+	manifest, err := cache.loadManifest("myapp")
+	require.NoError(t, err)
+	require.Contains(t, manifest, "main.go")
+	require.Contains(t, manifest, "lib/util.go")
+	require.NotEmpty(t, manifest["main.go"].Hash)
+	require.Equal(t, int64(12), manifest["main.go"].Size) // "package main" = 12 bytes
+}
+
+func TestSourceCacheStageMatchingFiles(t *testing.T) {
+	dataPath := t.TempDir()
+	cache := &sourceCache{dataPath: dataPath}
+
+	// Create and save an initial source image
+	buildDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "main.go"), []byte("package main"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "config.go"), []byte("package config"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(buildDir, "lib"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "lib/util.go"), []byte("package lib"), 0644))
+	require.NoError(t, cache.saveSourceImage("myapp", buildDir))
+
+	// Load the manifest to get hashes
+	cachedManifest, err := cache.loadManifest("myapp")
+	require.NoError(t, err)
+
+	// Create client manifest: main.go unchanged, config.go changed, lib/util.go unchanged, new.go added
+	clientManifest := []*build_v1alpha.FileManifestEntry{
+		makeManifestEntry("main.go", cachedManifest["main.go"].Hash, 12, 0644),
+		makeManifestEntry("config.go", "different-hash", 20, 0644),
+		makeManifestEntry("lib/util.go", cachedManifest["lib/util.go"].Hash, 11, 0644),
+		makeManifestEntry("new.go", "brand-new-hash", 50, 0644),
+	}
+
+	// Stage matching files into a new directory
+	stageDir := t.TempDir()
+	matched, needed, err := cache.stageMatchingFiles("myapp", stageDir, clientManifest)
+	require.NoError(t, err)
+
+	// main.go and lib/util.go should be cached
+	require.Equal(t, 2, matched)
+
+	// config.go (changed) and new.go (new) should be needed
+	require.ElementsMatch(t, []string{"config.go", "new.go"}, needed)
+
+	// Verify cached files were extracted
+	mainContent, err := os.ReadFile(filepath.Join(stageDir, "main.go"))
+	require.NoError(t, err)
+	require.Equal(t, "package main", string(mainContent))
+
+	utilContent, err := os.ReadFile(filepath.Join(stageDir, "lib/util.go"))
+	require.NoError(t, err)
+	require.Equal(t, "package lib", string(utilContent))
+}
+
+func TestSourceCacheNoExistingCache(t *testing.T) {
+	dataPath := t.TempDir()
+	cache := &sourceCache{dataPath: dataPath}
+
+	clientManifest := []*build_v1alpha.FileManifestEntry{
+		makeManifestEntry("main.go", "some-hash", 12, 0644),
+		makeManifestEntry("lib/util.go", "another-hash", 11, 0644),
+	}
+
+	stageDir := t.TempDir()
+	matched, needed, err := cache.stageMatchingFiles("newapp", stageDir, clientManifest)
+	require.NoError(t, err)
+	require.Equal(t, 0, matched)
+	require.ElementsMatch(t, []string{"main.go", "lib/util.go"}, needed)
+}
+
+func TestSourceCacheOverwrite(t *testing.T) {
+	dataPath := t.TempDir()
+	cache := &sourceCache{dataPath: dataPath}
+
+	// Save first version
+	buildDir1 := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir1, "main.go"), []byte("v1"), 0644))
+	require.NoError(t, cache.saveSourceImage("myapp", buildDir1))
+
+	manifest1, err := cache.loadManifest("myapp")
+	require.NoError(t, err)
+
+	// Save second version
+	buildDir2 := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir2, "main.go"), []byte("v2"), 0644))
+	require.NoError(t, cache.saveSourceImage("myapp", buildDir2))
+
+	manifest2, err := cache.loadManifest("myapp")
+	require.NoError(t, err)
+
+	// Hashes should differ
+	require.NotEqual(t, manifest1["main.go"].Hash, manifest2["main.go"].Hash)
+}
+
+func makeManifestEntry(path, hash string, size int64, mode int32) *build_v1alpha.FileManifestEntry {
+	entry := &build_v1alpha.FileManifestEntry{}
+	entry.SetPath(path)
+	entry.SetHash(hash)
+	entry.SetSize(size)
+	entry.SetMode(mode)
+	return entry
+}

--- a/servers/build/source_cache_test.go
+++ b/servers/build/source_cache_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +12,7 @@ import (
 
 func TestSourceCacheRoundtrip(t *testing.T) {
 	dataPath := t.TempDir()
-	cache := &sourceCache{dataPath: dataPath}
+	cache := &sourceCache{dataPath: dataPath, log: slog.Default(), locks: newAppLocks()}
 
 	// Create a build directory with some files
 	buildDir := t.TempDir()
@@ -38,7 +39,7 @@ func TestSourceCacheRoundtrip(t *testing.T) {
 
 func TestSourceCacheStageMatchingFiles(t *testing.T) {
 	dataPath := t.TempDir()
-	cache := &sourceCache{dataPath: dataPath}
+	cache := &sourceCache{dataPath: dataPath, log: slog.Default(), locks: newAppLocks()}
 
 	// Create and save an initial source image
 	buildDir := t.TempDir()
@@ -83,7 +84,7 @@ func TestSourceCacheStageMatchingFiles(t *testing.T) {
 
 func TestSourceCacheNoExistingCache(t *testing.T) {
 	dataPath := t.TempDir()
-	cache := &sourceCache{dataPath: dataPath}
+	cache := &sourceCache{dataPath: dataPath, log: slog.Default(), locks: newAppLocks()}
 
 	clientManifest := []*build_v1alpha.FileManifestEntry{
 		makeManifestEntry("main.go", "some-hash", 12, 0644),
@@ -99,7 +100,7 @@ func TestSourceCacheNoExistingCache(t *testing.T) {
 
 func TestSourceCacheOverwrite(t *testing.T) {
 	dataPath := t.TempDir()
-	cache := &sourceCache{dataPath: dataPath}
+	cache := &sourceCache{dataPath: dataPath, log: slog.Default(), locks: newAppLocks()}
 
 	// Save first version
 	buildDir1 := t.TempDir()


### PR DESCRIPTION
## Summary

- Adds manifest-first deploy flow: client sends file hashes, server compares against cached source code image, client uploads only changed files
- New RPC methods `prepareUpload` and `buildFromPrepared` on the Builder service
- Source code cache stored per-app at `{DataPath}/source-code/{app}/` with atomic writes to prevent corruption
- Refactored `MakeTar`/`MakeFilteredTar` to share a common `makeTarWithFilter` implementation with lazy directory emission
- Deploy UI shows cache reuse stats on the "Upload artifacts" phase line
- Falls back gracefully to full upload if server doesn't support the new methods or if manifest computation fails

## Test plan

- [x] Unit tests for `ComputeManifest` and `MakeFilteredTar` in `pkg/tarx/tarx_test.go`
- [x] Unit tests for source cache roundtrip, staging, overwrite in `servers/build/source_cache_test.go`
- [x] Test for directory emission behavior (only dirs containing accepted files are included)
- [x] `make test` passes (3579 tests)
- [x] `make lint` clean
- [x] Manual test: deploy app twice, verify "Reused N/M files" on second deploy