### PR TITLE
Trim trailing newlines when reading env var value from file

### DIFF
--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -90,7 +90,7 @@ func parseEnvVarSpec(spec string, sensitive bool) (EnvVarSpec, error) {
 				}
 				return EnvVarSpec{}, fmt.Errorf("failed to read env var from file %s: %w", filename, err)
 			}
-			result.Value = string(data)
+			result.Value = strings.TrimRight(string(data), "\r\n")
 			result.FromFile = true
 			result.FromFile_ = filename
 		} else {

--- a/cli/commands/env_test.go
+++ b/cli/commands/env_test.go
@@ -77,6 +77,25 @@ func TestParseEnvVarSpecs(t *testing.T) {
 		}
 	})
 
+	t.Run("trims trailing newlines from file value", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "secret.txt")
+		if err := os.WriteFile(tmpFile, []byte("file-content\r\n\n"), 0644); err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+
+		specs, err := ParseEnvVarSpecs([]string{"VAR=@" + tmpFile}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(specs) != 1 {
+			t.Fatalf("expected 1 spec, got %d", len(specs))
+		}
+		if specs[0].Value != "file-content" {
+			t.Errorf("expected trimmed value %q, got %q", "file-content", specs[0].Value)
+		}
+	})
+
 	t.Run("returns error for nonexistent file", func(t *testing.T) {
 		_, err := ParseEnvVarSpecs([]string{"VAR=@/nonexistent/file.txt"}, nil)
 		if err == nil {


### PR DESCRIPTION
## Summary
- When using `KEY=@filepath` to set env vars from files, trailing newlines (`\r\n`) are now trimmed from the file contents
- Uses `strings.TrimRight` with `"\r\n"` to only strip line endings, preserving intentional leading/trailing spaces

Fixes MIR-259

## Test plan
- [x] Added test case `trims_trailing_newlines_from_file_value` that writes a file with `\r\n\n` suffix and verifies it's trimmed
- [x] All existing tests pass (`make test` — 3640 tests, 0 failures)