### PR TITLE
Fix rapid deploys causing orphaned sandboxes and stale routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,9 @@ Running commands:
 - Examples:
   - `./hack/dev-exec go test ./pkg/entity/...` - Run tests
   - `./hack/dev-exec m app list` - Use miren CLI
-  - `make bin/miren` - Rebuild binary (then `make dev-server-restart`)
+  - `./hack/dev-exec make bin/miren` - Rebuild binary inside dev container (then `make dev-server-restart`)
+
+**Important**: The miren binary must be built **inside** the dev container (not on the host) so it has the correct architecture. Use `./hack/dev-exec make bin/miren` instead of `make bin/miren`.
 
 **Managing the dev environment:**
 - `make dev-stop` - Stop and remove the persistent dev container
@@ -75,7 +77,7 @@ m app list                    # Works immediately!
 
 # Development iteration
 vim path/to/code.go           # Edit code
-make bin/miren                # Rebuild
+./hack/dev-exec make bin/miren # Rebuild inside container
 make dev-server-restart       # Bounce server with new code
 
 # Debugging

--- a/blackbox/harness/http.go
+++ b/blackbox/harness/http.go
@@ -1,0 +1,36 @@
+package harness
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// HTTPGet makes an HTTP GET request from inside the dev container via curl.
+// The host header is set to the given hostname so ingress routing works,
+// while the actual request goes to localhost:80.
+func HTTPGet(m *Miren, hostname, path string) (statusCode int, body string, err error) {
+	r := m.RunCmd("curl", "-s", "-o", "/dev/stdout", "-w", "\n%{http_code}",
+		"-H", fmt.Sprintf("Host: %s", hostname),
+		"--max-time", "10",
+		fmt.Sprintf("http://localhost:80%s", path))
+
+	if !r.Success() {
+		return 0, "", fmt.Errorf("curl failed (exit %d): %s", r.ExitCode, strings.TrimSpace(r.Stderr))
+	}
+
+	// Output format: body\nstatus_code
+	lines := strings.Split(strings.TrimRight(r.Stdout, "\n"), "\n")
+	if len(lines) < 1 {
+		return 0, "", fmt.Errorf("unexpected curl output: %q", r.Stdout)
+	}
+
+	statusStr := lines[len(lines)-1]
+	code, parseErr := strconv.Atoi(strings.TrimSpace(statusStr))
+	if parseErr != nil {
+		return 0, "", fmt.Errorf("failed to parse status code %q: %v", statusStr, parseErr)
+	}
+
+	bodyStr := strings.Join(lines[:len(lines)-1], "\n")
+	return code, bodyStr, nil
+}

--- a/blackbox/harness/http.go
+++ b/blackbox/harness/http.go
@@ -8,12 +8,14 @@ import (
 
 // HTTPGet makes an HTTP GET request from inside the dev container via curl.
 // The host header is set to the given hostname so ingress routing works,
-// while the actual request goes to localhost:80.
+// while the actual request goes to localhost:443 over HTTPS (with -k to
+// skip certificate verification). Port 80 redirects to HTTPS, so we
+// connect directly to avoid redirect resolution issues.
 func HTTPGet(m *Miren, hostname, path string) (statusCode int, body string, err error) {
-	r := m.RunCmd("curl", "-s", "-o", "/dev/stdout", "-w", "\n%{http_code}",
+	r := m.RunCmd("curl", "-sk", "-w", "\n%{http_code}",
 		"-H", fmt.Sprintf("Host: %s", hostname),
 		"--max-time", "10",
-		fmt.Sprintf("http://localhost:80%s", path))
+		fmt.Sprintf("https://localhost:443%s", path))
 
 	if !r.Success() {
 		return 0, "", fmt.Errorf("curl failed (exit %d): %s", r.ExitCode, strings.TrimSpace(r.Stderr))

--- a/blackbox/harness/miren.go
+++ b/blackbox/harness/miren.go
@@ -83,6 +83,58 @@ func (m *Miren) MustRun(args ...string) *Result {
 	return r
 }
 
+// RunCmd executes an arbitrary command (not miren CLI) in the dev container.
+// In local mode it runs the command directly on the host.
+func (m *Miren) RunCmd(args ...string) *Result {
+	m.t.Helper()
+
+	var cmd *exec.Cmd
+
+	switch m.cluster.Mode {
+	case ModeDev:
+		devExec := filepath.Join(m.cluster.RepoRoot, "hack", "dev-exec")
+		cmd = exec.Command(devExec, args...)
+		cmd.Dir = m.cluster.RepoRoot
+	case ModeLocal:
+		cmd = exec.Command(args[0], args[1:]...)
+	default:
+		m.t.Fatalf("unknown mode: %s", m.cluster.Mode)
+		return nil
+	}
+
+	cmd.Env = append(cmd.Environ(), "TERM=dumb")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			m.t.Fatalf("failed to execute command: %v", err)
+		}
+	}
+
+	r := &Result{
+		ExitCode: exitCode,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+	}
+
+	m.t.Logf("cmd %s → exit %d", strings.Join(args, " "), exitCode)
+	if r.Stdout != "" {
+		m.t.Logf("stdout: %s", r.Stdout)
+	}
+	if r.Stderr != "" {
+		m.t.Logf("stderr: %s", r.Stderr)
+	}
+
+	return r
+}
+
 // ContainerPath translates a host-side path to a container-internal path.
 // In dev mode, the repo is mounted at /src inside the iso container.
 func (m *Miren) ContainerPath(hostPath string) string {

--- a/blackbox/harness/miren.go
+++ b/blackbox/harness/miren.go
@@ -87,6 +87,10 @@ func (m *Miren) MustRun(args ...string) *Result {
 // In local mode it runs the command directly on the host.
 func (m *Miren) RunCmd(args ...string) *Result {
 	m.t.Helper()
+	if len(args) == 0 {
+		m.t.Fatalf("RunCmd requires at least one argument")
+		return nil
+	}
 
 	var cmd *exec.Cmd
 

--- a/blackbox/zero_downtime_test.go
+++ b/blackbox/zero_downtime_test.go
@@ -1,0 +1,112 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+// TestZeroDowntimeDeploy verifies that HTTP requests continue to succeed during
+// a redeploy. This exercises the proactive lease invalidation path: when old
+// sandboxes go STOPPED, httpingress should evict their cached leases before
+// any request hits a dead IP.
+func TestZeroDowntimeDeploy(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	// Deploy initial version
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+		Env:      []string{"DEPLOY_VERSION=v1"},
+	})
+
+	// Set a route so we can reach the app via HTTP ingress
+	host := name + ".test.local"
+	m.MustRun("route", "set", host, name)
+	t.Cleanup(func() {
+		m.Run("route", "remove", host)
+	})
+
+	// Verify HTTP works before we start
+	harness.Poll(t, "initial HTTP reachable", 30*time.Second, 2*time.Second, func() (bool, string) {
+		code, _, err := harness.HTTPGet(m, host, "/")
+		if err != nil {
+			return false, fmt.Sprintf("HTTP error: %v", err)
+		}
+		if code != 200 {
+			return false, fmt.Sprintf("HTTP status %d", code)
+		}
+		return true, ""
+	})
+
+	// Start continuous HTTP requests in background
+	var (
+		totalRequests atomic.Int64
+		failedResults []string
+		failMu        sync.Mutex
+		stop          = make(chan struct{})
+		done          = make(chan struct{})
+	)
+
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+
+			code, _, err := harness.HTTPGet(m, host, "/")
+			totalRequests.Add(1)
+
+			if err != nil || (code != 200 && code != 502 && code != 503) {
+				// 502/503 during brief transition are noted but may be acceptable
+				// in some edge cases; we track them all
+			}
+			if err != nil {
+				failMu.Lock()
+				failedResults = append(failedResults, fmt.Sprintf("request #%d: error: %v", totalRequests.Load(), err))
+				failMu.Unlock()
+			} else if code != 200 {
+				failMu.Lock()
+				failedResults = append(failedResults, fmt.Sprintf("request #%d: HTTP %d", totalRequests.Load(), code))
+				failMu.Unlock()
+			}
+
+			time.Sleep(200 * time.Millisecond)
+		}
+	}()
+
+	// Trigger a redeploy by changing an env var (forces new version + new sandbox)
+	t.Log("triggering redeploy...")
+	m.MustRun("deploy", "-a", name, "-d", m.ContainerPath(c.TestdataDir+"/go-server"), "-f", "-e", "DEPLOY_VERSION=v2")
+	harness.WaitForAppReady(t, m, name, 3*time.Minute)
+
+	// Let requests continue briefly after deploy settles to catch any stragglers
+	time.Sleep(3 * time.Second)
+
+	// Stop the request loop
+	close(stop)
+	<-done
+
+	total := totalRequests.Load()
+	t.Logf("total requests during deploy: %d", total)
+
+	failMu.Lock()
+	failures := failedResults
+	failMu.Unlock()
+
+	if len(failures) > 0 {
+		t.Errorf("had %d failed requests out of %d during deploy:", len(failures), total)
+		for _, f := range failures {
+			t.Logf("  %s", f)
+		}
+	}
+}

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -1099,7 +1099,7 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 
 				// Signal httpingress to invalidate cached leases for this sandbox
 				// when it transitions away from RUNNING
-				if oldStatus == compute_v1alpha.RUNNING && oldStatus != sb.Status {
+				if oldStatus == compute_v1alpha.RUNNING && sb.Status != compute_v1alpha.RUNNING {
 					select {
 					case a.invalidationCh <- SandboxInvalidation{SandboxID: sb.ID}:
 					default:

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -103,10 +103,21 @@ func (l *Lease) Pool() string {
 	return l.pool
 }
 
+// SandboxInvalidation is sent when a sandbox transitions away from RUNNING,
+// signaling that any cached leases pointing to it should be invalidated.
+type SandboxInvalidation struct {
+	SandboxID entity.Id
+}
+
 type AppActivator interface {
 	AcquireLease(ctx context.Context, ver *core_v1alpha.AppVersion, service string) (*Lease, error)
 	ReleaseLease(ctx context.Context, lease *Lease) error
 	RenewLease(ctx context.Context, lease *Lease) (*Lease, error)
+
+	// Invalidations returns a channel that receives notifications when
+	// sandboxes become non-RUNNING. Consumers should invalidate any cached
+	// leases referencing the invalidated sandbox.
+	Invalidations() <-chan SandboxInvalidation
 }
 
 type sandbox struct {
@@ -156,6 +167,9 @@ type localActivator struct {
 	// Map key is verKey (version + service), value is list of channels to notify
 	newSandboxChans map[verKey][]chan struct{}
 
+	// invalidationCh signals httpingress when a sandbox becomes non-RUNNING
+	invalidationCh chan SandboxInvalidation
+
 	log *slog.Logger
 	eac *entityserver_v1alpha.EntityAccessClient
 }
@@ -170,6 +184,7 @@ func NewLocalActivator(ctx context.Context, log *slog.Logger, eac *entityserver_
 		poolSandboxes:   make(map[entity.Id]*poolSandboxes),
 		pools:           make(map[verKey]*poolState),
 		newSandboxChans: make(map[verKey][]chan struct{}),
+		invalidationCh:  make(chan SandboxInvalidation, 64),
 	}
 
 	// Recover existing pools first (sandboxes need pools to exist)
@@ -963,12 +978,22 @@ func (a *localActivator) RenewLease(ctx context.Context, lease *Lease) (*Lease, 
 
 	for _, s := range ps.sandboxes {
 		if s.sandbox == lease.sandbox {
+			// Reject renewal if sandbox is no longer running.
+			// This ensures httpingress invalidates cached leases for
+			// stopped/dead sandboxes on the next renewal cycle.
+			if s.sandbox.Status != compute_v1alpha.RUNNING {
+				return nil, fmt.Errorf("sandbox %s is %s", s.sandbox.ID, s.sandbox.Status)
+			}
 			s.lastRenewal = time.Now()
 			return lease, nil
 		}
 	}
 
 	return nil, fmt.Errorf("sandbox not found")
+}
+
+func (a *localActivator) Invalidations() <-chan SandboxInvalidation {
+	return a.invalidationCh
 }
 
 func (a *localActivator) watchSandboxes(ctx context.Context) {
@@ -1069,6 +1094,16 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 								}
 							}
 						}
+					}
+				}
+
+				// Signal httpingress to invalidate cached leases for this sandbox
+				// when it transitions away from RUNNING
+				if oldStatus == compute_v1alpha.RUNNING && oldStatus != sb.Status {
+					select {
+					case a.invalidationCh <- SandboxInvalidation{SandboxID: sb.ID}:
+					default:
+						a.log.Warn("invalidation channel full, dropping notification", "sandbox", sb.ID)
 					}
 				}
 

--- a/components/activator/testing.go
+++ b/components/activator/testing.go
@@ -1,0 +1,13 @@
+package activator
+
+import "miren.dev/runtime/api/compute/compute_v1alpha"
+
+// NewTestLease creates a Lease with the given sandbox, size, and URL.
+// This is only intended for use in tests outside the activator package.
+func NewTestLease(sb *compute_v1alpha.Sandbox, size int, url string) *Lease {
+	return &Lease{
+		sandbox: sb,
+		Size:    size,
+		URL:     url,
+	}
+}

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -950,7 +950,12 @@ func (l *Launcher) waitForPoolReady(ctx context.Context, poolID entity.Id, timeo
 
 		// Check sandbox entities directly — they're updated immediately when
 		// the sandbox boots, without waiting for the pool controller to reconcile.
-		if l.hasRunningSandboxForPool(ctx, poolID, pool.Service) {
+		running, runErr := l.hasRunningSandboxForPool(ctx, poolID, pool.Service)
+		if runErr != nil {
+			l.Log.Warn("failed to query sandboxes while waiting for pool readiness",
+				"pool", poolID,
+				"error", runErr)
+		} else if running {
 			l.Log.Info("new pool has ready instances",
 				"pool", poolID,
 				"ready_instances", 1)
@@ -977,10 +982,10 @@ func (l *Launcher) waitForPoolReady(ctx context.Context, poolID entity.Id, timeo
 
 // hasRunningSandboxForPool checks if there is at least one RUNNING sandbox
 // with the given pool label, by querying sandbox entities directly.
-func (l *Launcher) hasRunningSandboxForPool(ctx context.Context, poolID entity.Id, service string) bool {
+func (l *Launcher) hasRunningSandboxForPool(ctx context.Context, poolID entity.Id, service string) (bool, error) {
 	resp, err := l.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
 	if err != nil {
-		return false
+		return false, fmt.Errorf("list sandboxes: %w", err)
 	}
 
 	for _, ent := range resp.Values() {
@@ -1004,10 +1009,10 @@ func (l *Launcher) hasRunningSandboxForPool(ctx context.Context, poolID entity.I
 			continue
 		}
 
-		return true
+		return true, nil
 	}
 
-	return false
+	return false, nil
 }
 
 // cleanupOldVersionPools removes old version references from pools and scales down unreferenced pools

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -923,17 +923,16 @@ func (l *Launcher) updatePool(ctx context.Context, poolWithEntity *PoolWithEntit
 	return nil
 }
 
-// waitForPoolReady polls the pool entity until ReadyInstances > 0 or the timeout expires.
-// On timeout it returns an error, but the caller should proceed with cleanup anyway —
-// the httpingress retry logic handles any remaining gap.
+// waitForPoolReady polls until at least one sandbox in the pool is RUNNING, or the timeout expires.
+// It checks both the pool's ReadyInstances field (updated by the pool controller on its
+// ~10s resync cycle) and sandbox entities directly (updated immediately when sandboxes boot).
+// This avoids a ~10s delay waiting for the pool controller to reconcile.
 func (l *Launcher) waitForPoolReady(ctx context.Context, poolID entity.Id, timeout time.Duration) error {
-	pollInterval := 2 * time.Second
-	if timeout < pollInterval {
-		pollInterval = timeout / 2
-	}
+	pollInterval := 500 * time.Millisecond
 	deadline := time.Now().Add(timeout)
 
 	for {
+		// Check pool's ReadyInstances first (fast path if pool controller already reconciled)
 		resp, err := l.EAC.Get(ctx, poolID.String())
 		if err != nil {
 			return fmt.Errorf("failed to get pool %s: %w", poolID, err)
@@ -946,6 +945,15 @@ func (l *Launcher) waitForPoolReady(ctx context.Context, poolID entity.Id, timeo
 			l.Log.Info("new pool has ready instances",
 				"pool", poolID,
 				"ready_instances", pool.ReadyInstances)
+			return nil
+		}
+
+		// Check sandbox entities directly — they're updated immediately when
+		// the sandbox boots, without waiting for the pool controller to reconcile.
+		if l.hasRunningSandboxForPool(ctx, poolID, pool.Service) {
+			l.Log.Info("new pool has ready instances",
+				"pool", poolID,
+				"ready_instances", 1)
 			return nil
 		}
 
@@ -965,6 +973,41 @@ func (l *Launcher) waitForPoolReady(ctx context.Context, poolID entity.Id, timeo
 		case <-time.After(pollInterval):
 		}
 	}
+}
+
+// hasRunningSandboxForPool checks if there is at least one RUNNING sandbox
+// with the given pool label, by querying sandbox entities directly.
+func (l *Launcher) hasRunningSandboxForPool(ctx context.Context, poolID entity.Id, service string) bool {
+	resp, err := l.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return false
+	}
+
+	for _, ent := range resp.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(ent.Entity())
+
+		if sb.Status != compute_v1alpha.RUNNING {
+			continue
+		}
+
+		var md core_v1alpha.Metadata
+		md.Decode(ent.Entity())
+
+		poolLabel, _ := md.Labels.Get("pool")
+		if poolLabel != poolID.String() {
+			continue
+		}
+
+		serviceLabel, _ := md.Labels.Get("service")
+		if serviceLabel != service {
+			continue
+		}
+
+		return true
+	}
+
+	return false
 }
 
 // cleanupOldVersionPools removes old version references from pools and scales down unreferenced pools

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -88,20 +88,23 @@ func (m *Manager) Reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPo
 		}
 	}
 
-	// Detect recent crashes (sandboxes that died within 60s of creation)
-	newCrashes := m.countQuickCrashes(sandboxes, pool.LastCrashTime)
-	if newCrashes > 0 {
-		pool.ConsecutiveCrashCount += int64(newCrashes)
-		pool.LastCrashTime = time.Now()
-		pool.CooldownUntil = m.calculateBackoff(pool.ConsecutiveCrashCount)
+	// Skip crash detection for decommissioned pools (desired=0, no references).
+	// Sandbox deaths during intentional scale-down are expected, not crashes.
+	if pool.DesiredInstances > 0 || len(pool.ReferencedByVersions) > 0 {
+		newCrashes := m.countQuickCrashes(sandboxes, pool.LastCrashTime)
+		if newCrashes > 0 {
+			pool.ConsecutiveCrashCount += int64(newCrashes)
+			pool.LastCrashTime = time.Now()
+			pool.CooldownUntil = m.calculateBackoff(pool.ConsecutiveCrashCount)
 
-		m.log.Warn("crash detected, entering cooldown",
-			"pool", pool.ID,
-			"new_crashes", newCrashes,
-			"consecutive_crashes", pool.ConsecutiveCrashCount,
-			"cooldown_until", pool.CooldownUntil)
+			m.log.Warn("crash detected, entering cooldown",
+				"pool", pool.ID,
+				"new_crashes", newCrashes,
+				"consecutive_crashes", pool.ConsecutiveCrashCount,
+				"cooldown_until", pool.CooldownUntil)
 
-		// Pool crash state fields are already updated, framework will apply via entity.Diff
+			// Pool crash state fields are already updated, framework will apply via entity.Diff
+		}
 	}
 
 	// Check if pool is in cooldown
@@ -318,14 +321,11 @@ type sandboxWithMeta struct {
 
 // listSandboxes returns all sandboxes for a pool with their metadata
 func (m *Manager) listSandboxes(ctx context.Context, pool *compute_v1alpha.SandboxPool) ([]*sandboxWithMeta, error) {
-	var indexAttr entity.Attr
-	if pool.SandboxSpec.Version != "" {
-		// Query by version index for app pools (reduces O(N) to O(N_version))
-		indexAttr = entity.Ref(compute_v1alpha.SandboxSpecVersionId, pool.SandboxSpec.Version)
-	} else {
-		// Addon pools have no version; fall back to listing all sandboxes by kind
-		indexAttr = entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox)
-	}
+	// Always query all sandboxes by kind and filter by pool label.
+	// We used to query by pool.SandboxSpec.Version, but that field changes
+	// during pool reuse (when a new deploy has identical specs), causing the
+	// pool to lose visibility of its existing sandboxes.
+	indexAttr := entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox)
 
 	resp, err := m.eac.List(ctx, indexAttr)
 	if err != nil {

--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -1303,8 +1303,16 @@ func TestManagerPoolReuse_NoOrphanedSandboxes(t *testing.T) {
 		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String(), "instance", "0")))
 	require.NoError(t, err)
 
-	// Simulate pool reuse: update SandboxSpec.Version to ver-2
+	// Simulate pool reuse: update SandboxSpec.Version to ver-2 in the store,
+	// matching what the deployment launcher does during pool reuse.
 	pool.SandboxSpec.Version = entity.Id("ver-2")
+	_, err = server.EAC.Patch(ctx, entity.New(
+		entity.DBId, poolID,
+		(&compute_v1alpha.SandboxPool{
+			SandboxSpec: pool.SandboxSpec,
+		}).Encode,
+	).Attrs(), 0)
+	require.NoError(t, err)
 
 	// Reconcile — pool should still see the ver-1 sandbox via pool label
 	manager := NewManager(log, server.EAC)

--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -205,8 +205,10 @@ func TestManagerServiceIsolation(t *testing.T) {
 	}
 }
 
-// TestManagerVersionFiltering tests that only sandboxes with matching
-// version are counted
+// TestManagerVersionFiltering tests that sandboxes with the correct pool label
+// are counted regardless of their spec version. This reflects pool-based membership:
+// when a pool's SandboxSpec.Version is updated during reuse, existing sandboxes
+// (with the old version) must still be visible to the pool.
 func TestManagerVersionFiltering(t *testing.T) {
 	ctx := context.Background()
 	log := testutils.TestLogger(t)
@@ -229,7 +231,8 @@ func TestManagerVersionFiltering(t *testing.T) {
 	require.NoError(t, err)
 	pool.ID = poolID
 
-	// Create 2 sandboxes with old version (should be ignored)
+	// Create 2 sandboxes with old version but correct pool label.
+	// These should be counted as pool members (pool label is authoritative).
 	for i := 0; i < 2; i++ {
 		sb := &compute_v1alpha.Sandbox{
 			Status: compute_v1alpha.RUNNING,
@@ -240,7 +243,7 @@ func TestManagerVersionFiltering(t *testing.T) {
 				},
 			},
 		}
-		_, err := server.Client.Create(ctx, "old-sb", sb,
+		_, err := server.Client.Create(ctx, fmt.Sprintf("old-sb-%d", i), sb,
 			entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
 		require.NoError(t, err)
 	}
@@ -249,20 +252,22 @@ func TestManagerVersionFiltering(t *testing.T) {
 	manager := NewManager(log, server.EAC)
 	reconcilePool(t, ctx, server, manager, pool)
 
-	// Should create 3 new sandboxes (old version doesn't count)
+	// Pool sees 2 existing RUNNING sandboxes (old version, correct pool label).
+	// It needs 3 total, so it creates 1 more.
 	sandboxes := listSandboxesForPool(t, ctx, server, pool)
+	assert.Equal(t, 3, len(sandboxes), "should have 3 total sandboxes (2 old + 1 new)")
+
 	ver2Count := 0
 	for _, sb := range sandboxes {
 		if sb.Spec.Version.String() == "ver-2" {
 			ver2Count++
 		}
 	}
+	assert.Equal(t, 1, ver2Count, "should create 1 new sandbox with new version")
 
-	assert.Equal(t, 3, ver2Count, "should create 3 sandboxes with new version")
-
-	// Verify pool status counts only ver-2 sandboxes
+	// Pool status should reflect all 3 sandboxes
 	updatedPool := getPool(t, ctx, server, poolID)
-	assert.Equal(t, int64(3), updatedPool.CurrentInstances, "should count only matching version")
+	assert.Equal(t, int64(3), updatedPool.CurrentInstances, "should count all pool-labeled sandboxes")
 }
 
 // TestManagerStatusOnlyUpdate tests that reconciliation doesn't create
@@ -665,22 +670,17 @@ func listSandboxesForPool(t *testing.T, ctx context.Context, server *testutils.I
 		var sb compute_v1alpha.Sandbox
 		sb.Decode(ent.Entity())
 
-		// Filter by version and service
-		if sb.Spec.Version.String() != pool.SandboxSpec.Version.String() {
-			continue
-		}
-
 		var md core_v1alpha.Metadata
 		md.Decode(ent.Entity())
 
-		serviceLabel := getLabel(md.Labels, "service")
-		if serviceLabel != pool.Service {
+		// Filter by pool label (authoritative for pool membership)
+		poolLabel := getLabel(md.Labels, "pool")
+		if poolLabel != pool.ID.String() {
 			continue
 		}
 
-		// Filter by pool ID to prevent cross-pool contamination
-		poolLabel := getLabel(md.Labels, "pool")
-		if poolLabel != pool.ID.String() {
+		serviceLabel := getLabel(md.Labels, "service")
+		if serviceLabel != pool.Service {
 			continue
 		}
 
@@ -1261,4 +1261,126 @@ func TestCleanupEmptyPoolsNotReferencedByActiveVersion(t *testing.T) {
 	// Test the helper function directly - should NOT be referenced by active
 	isReferenced := manager.isPoolReferencedByCurrentVersion(ctx, pool)
 	require.False(t, isReferenced, "Pool should NOT be recognized as referenced by active version")
+}
+
+// TestManagerPoolReuse_NoOrphanedSandboxes verifies that after a pool's
+// SandboxSpec.Version is updated (pool reuse during deploy), existing sandboxes
+// with the old version are still found by listSandboxes via pool label.
+func TestManagerPoolReuse_NoOrphanedSandboxes(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create pool with version 1
+	pool := &compute_v1alpha.SandboxPool{
+		Service:          "web",
+		DesiredInstances: 1,
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:v1"},
+			},
+		},
+	}
+
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Create a RUNNING sandbox with ver-1 and the correct pool label
+	sb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+		Spec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:v1"},
+			},
+		},
+	}
+	_, err = server.Client.Create(ctx, "sb-v1", sb,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String(), "instance", "0")))
+	require.NoError(t, err)
+
+	// Simulate pool reuse: update SandboxSpec.Version to ver-2
+	pool.SandboxSpec.Version = entity.Id("ver-2")
+
+	// Reconcile — pool should still see the ver-1 sandbox via pool label
+	manager := NewManager(log, server.EAC)
+	reconcilePool(t, ctx, server, manager, pool)
+
+	// Pool has desired=1, and the old sandbox counts as actual=1, so no new sandbox created
+	sandboxes := listSandboxesForPool(t, ctx, server, pool)
+	assert.Equal(t, 1, len(sandboxes), "existing sandbox should still be visible after version update")
+	assert.Equal(t, entity.Id("ver-1"), sandboxes[0].Spec.Version, "original sandbox should be the one found")
+
+	// Verify pool status reflects the existing sandbox
+	updatedPool := getPool(t, ctx, server, poolID)
+	assert.Equal(t, int64(1), updatedPool.CurrentInstances, "pool should count old-version sandbox")
+	assert.Equal(t, int64(1), updatedPool.ReadyInstances, "old-version sandbox is RUNNING and ready")
+}
+
+// TestManagerDecommissionedPool_NoCrashDetection verifies that DEAD sandboxes
+// in a decommissioned pool (desired=0, no references) don't trigger crash detection.
+func TestManagerDecommissionedPool_NoCrashDetection(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create a decommissioned pool (desired=0, no references)
+	pool := &compute_v1alpha.SandboxPool{
+		Service:              "web",
+		DesiredInstances:     0,
+		ReferencedByVersions: nil, // No references — fully decommissioned
+		SandboxSpec: compute_v1alpha.SandboxSpec{
+			Version: entity.Id("ver-1"),
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	// Create a DEAD sandbox that lived only 20 seconds (would normally trigger crash detection)
+	shortLivedTime := time.Now().Add(-30 * time.Second)
+	server.Store.NowFunc = func() time.Time { return shortLivedTime }
+
+	deadSb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.DEAD,
+		Spec:   pool.SandboxSpec,
+	}
+	deadSbID, err := server.Client.Create(ctx, "dead-sb", deadSb,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID.String())))
+	require.NoError(t, err)
+
+	// Patch to update updatedAt, simulating the sandbox dying 20s after creation
+	diedTime := shortLivedTime.Add(20 * time.Second)
+	server.Store.NowFunc = func() time.Time { return diedTime }
+
+	_, err = server.EAC.Patch(ctx, entity.New(
+		entity.DBId, deadSbID,
+		(&compute_v1alpha.Sandbox{
+			Status: compute_v1alpha.DEAD,
+		}).Encode,
+	).Attrs(), 0)
+	require.NoError(t, err)
+
+	server.Store.NowFunc = nil
+
+	// Reconcile the decommissioned pool
+	manager := NewManager(log, server.EAC)
+	reconcilePool(t, ctx, server, manager, pool)
+
+	// Pool should NOT have entered crash cooldown
+	updatedPool := getPool(t, ctx, server, poolID)
+	assert.Equal(t, int64(0), updatedPool.ConsecutiveCrashCount,
+		"decommissioned pool should not detect crashes")
+	assert.True(t, updatedPool.CooldownUntil.IsZero(),
+		"decommissioned pool should not enter cooldown")
 }

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -176,7 +176,10 @@ func (h *Server) watchInvalidations(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case inv := <-ch:
+		case inv, ok := <-ch:
+			if !ok {
+				return
+			}
 			h.invalidateSandboxLeases(ctx, inv.SandboxID)
 		}
 	}

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -162,8 +162,48 @@ func NewServer(
 	}
 
 	go serv.checkLeases(ctx)
+	go serv.watchInvalidations(ctx)
 
 	return serv
+}
+
+// watchInvalidations listens for sandbox invalidation signals from the
+// activator and immediately drops any cached leases pointing to dead sandboxes.
+// This prevents requests from being routed to sandboxes that are shutting down.
+func (h *Server) watchInvalidations(ctx context.Context) {
+	ch := h.aa.Invalidations()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case inv := <-ch:
+			h.invalidateSandboxLeases(ctx, inv.SandboxID)
+		}
+	}
+}
+
+// invalidateSandboxLeases removes all cached leases that point to the given sandbox.
+func (h *Server) invalidateSandboxLeases(ctx context.Context, sandboxID entity.Id) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for app, ar := range h.apps {
+		var kept []*lease
+		for _, l := range ar.leases {
+			if l.Lease.Sandbox().ID == sandboxID {
+				h.Log.Info("invalidating cached lease for stopped sandbox",
+					"app", app, "sandbox", sandboxID, "url", l.Lease.URL)
+				h.aa.ReleaseLease(ctx, l.Lease)
+			} else {
+				kept = append(kept, l)
+			}
+		}
+		if len(kept) == 0 {
+			delete(h.apps, app)
+		} else {
+			ar.leases = kept
+		}
+	}
 }
 
 func (h *Server) checkLeases(ctx context.Context) {

--- a/servers/httpingress/lease_test.go
+++ b/servers/httpingress/lease_test.go
@@ -45,6 +45,10 @@ func (m *mockActivator) RenewLease(ctx context.Context, lease *activator.Lease) 
 	return lease, nil
 }
 
+func (m *mockActivator) Invalidations() <-chan activator.SandboxInvalidation {
+	return make(chan activator.SandboxInvalidation)
+}
+
 func newTestServer(aa *mockActivator) *Server {
 	return &Server{
 		Log:  slog.Default(),

--- a/servers/httpingress/lease_test.go
+++ b/servers/httpingress/lease_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/components/activator"
+	"miren.dev/runtime/pkg/entity"
 )
 
 // mockActivator implements activator.AppActivator for testing lease behavior.
@@ -372,4 +374,155 @@ func TestInvalidateAndReacquire(t *testing.T) {
 
 	srv.releaseLease(ctx, freshLL)
 	srv.releaseLease(ctx, got2)
+}
+
+func TestSandboxDeathInvalidatesCachedLease(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	sandboxID := entity.Id("sandbox/sb-1234")
+
+	// Cache a lease whose underlying sandbox is sb-1234
+	actLease := activator.NewTestLease(
+		&compute_v1alpha.Sandbox{ID: sandboxID, Status: compute_v1alpha.RUNNING},
+		10, "http://10.0.0.1:3000",
+	)
+	srv.retainLease(ctx, "app/myapp", actLease)
+
+	// Verify the lease is cached
+	got, err := srv.useLease(ctx, "app/myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected cached lease before sandbox death")
+	}
+	srv.releaseLease(ctx, got)
+
+	// Simulate sandbox going STOPPED — invalidate its leases
+	srv.invalidateSandboxLeases(ctx, sandboxID)
+
+	// Lease should be evicted
+	got, err = srv.useLease(ctx, "app/myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Error("expected lease to be evicted after sandbox death, but got non-nil")
+	}
+
+	// ReleaseLease should have been called on the activator
+	aa.mu.Lock()
+	defer aa.mu.Unlock()
+	if aa.releaseCount != 1 {
+		t.Errorf("expected 1 ReleaseLease call, got %d", aa.releaseCount)
+	}
+}
+
+func TestSandboxDeathOnlyInvalidatesMatchingLeases(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	sandbox1 := entity.Id("sandbox/sb-1111")
+	sandbox2 := entity.Id("sandbox/sb-2222")
+
+	// Cache leases for two different sandboxes under the same app
+	lease1 := activator.NewTestLease(
+		&compute_v1alpha.Sandbox{ID: sandbox1, Status: compute_v1alpha.RUNNING},
+		10, "http://10.0.0.1:3000",
+	)
+	srv.retainLease(ctx, "app/myapp", lease1)
+
+	lease2 := activator.NewTestLease(
+		&compute_v1alpha.Sandbox{ID: sandbox2, Status: compute_v1alpha.RUNNING},
+		10, "http://10.0.0.2:3000",
+	)
+	srv.retainLease(ctx, "app/myapp", lease2)
+
+	// Kill sandbox1 only
+	srv.invalidateSandboxLeases(ctx, sandbox1)
+
+	// sandbox2's lease should still be usable
+	got, err := srv.useLease(ctx, "app/myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected sandbox2 lease to survive")
+	}
+	if got.Lease.URL != "http://10.0.0.2:3000" {
+		t.Errorf("expected sandbox2 URL, got %s", got.Lease.URL)
+	}
+	srv.releaseLease(ctx, got)
+
+	// Only 1 release call (for sandbox1)
+	aa.mu.Lock()
+	defer aa.mu.Unlock()
+	if aa.releaseCount != 1 {
+		t.Errorf("expected 1 ReleaseLease call, got %d", aa.releaseCount)
+	}
+}
+
+func TestSandboxDeathAcrossMultipleApps(t *testing.T) {
+	aa := &mockActivator{}
+	srv := newTestServer(aa)
+	ctx := context.Background()
+
+	sharedSandbox := entity.Id("sandbox/sb-shared")
+	otherSandbox := entity.Id("sandbox/sb-other")
+
+	// Two apps happen to have leases pointing at the same sandbox
+	lease1 := activator.NewTestLease(
+		&compute_v1alpha.Sandbox{ID: sharedSandbox, Status: compute_v1alpha.RUNNING},
+		10, "http://10.0.0.1:3000",
+	)
+	srv.retainLease(ctx, "app/alpha", lease1)
+
+	lease2 := activator.NewTestLease(
+		&compute_v1alpha.Sandbox{ID: sharedSandbox, Status: compute_v1alpha.RUNNING},
+		10, "http://10.0.0.1:3000",
+	)
+	srv.retainLease(ctx, "app/beta", lease2)
+
+	// A third app has a lease for a different sandbox
+	lease3 := activator.NewTestLease(
+		&compute_v1alpha.Sandbox{ID: otherSandbox, Status: compute_v1alpha.RUNNING},
+		10, "http://10.0.0.2:3000",
+	)
+	srv.retainLease(ctx, "app/gamma", lease3)
+
+	// Kill the shared sandbox
+	srv.invalidateSandboxLeases(ctx, sharedSandbox)
+
+	// alpha and beta should be evicted
+	for _, appKey := range []string{"app/alpha", "app/beta"} {
+		got, err := srv.useLease(ctx, appKey)
+		if err != nil {
+			t.Fatalf("unexpected error for %s: %v", appKey, err)
+		}
+		if got != nil {
+			t.Errorf("expected %s lease to be evicted, but got %s", appKey, got.Lease.URL)
+		}
+	}
+
+	// gamma should survive
+	got, err := srv.useLease(ctx, "app/gamma")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected app/gamma lease to survive")
+	}
+	if got.Lease.URL != "http://10.0.0.2:3000" {
+		t.Errorf("expected gamma URL, got %s", got.Lease.URL)
+	}
+	srv.releaseLease(ctx, got)
+
+	aa.mu.Lock()
+	defer aa.mu.Unlock()
+	if aa.releaseCount != 2 {
+		t.Errorf("expected 2 ReleaseLease calls, got %d", aa.releaseCount)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes multiple bugs that manifest during rapid successive deploys. The scenario: deploy an app 3 times in quick succession — deploy 1 (initial), deploy 2 (identical code, reuses pool), deploy 3 (changed code, new pool).

### Bug 1: Pool loses visibility of its own sandboxes during reuse

**Root cause**: `listSandboxes()` in the sandbox pool controller queried sandboxes by `pool.SandboxSpec.Version` (an indexed ref). During pool reuse, the deployment launcher updates `SandboxSpec.Version` to the new deploy's version. This made the pool **lose visibility of its existing sandboxes** — they still had the old version in their spec but the query was now looking for the new version.

**Consequence**: The pool thinks `current=0`, creates a duplicate sandbox. The original sandbox becomes orphaned — still running, still in DNS, but invisible to its pool and never cleaned up.

**Fix**: `listSandboxes()` now always queries sandboxes by entity kind and filters by pool label. The pool label is set at sandbox creation and never changes, making it a reliable membership indicator. The version-based query was an optimization that broke correctness during pool reuse.

### Bug 2: False crash detection on decommissioned pools

**Root cause**: When the old pool is decommissioned (desired=0, no version references), its short-lived duplicate sandbox (created by bug 1, lived ~20s) is retired. The crash detection logic counts any sandbox that died within 60s of creation as a "quick crash" — it doesn't distinguish between intentional retirement and actual crashes.

**Consequence**: The pool enters crash cooldown with exponential backoff, even though no actual crash occurred. This is cosmetic in isolation but could delay future pool reuse.

**Fix**: Skip crash detection entirely when a pool is being intentionally decommissioned (`DesiredInstances == 0` AND `len(ReferencedByVersions) == 0`). All sandbox deaths in this state are expected, not crashes.

### Bug 3: httpingress routes to dead sandboxes for up to 30+ seconds

**Root cause**: httpingress caches leases (sandbox routing info) and only invalidates them in two ways: (a) when a proxy attempt fails with a connection error, or (b) on a 30-second periodic renewal cycle. Additionally, `RenewLease()` in the activator didn't check sandbox status — it only verified the sandbox was still tracked. Since STOPPED/DEAD sandboxes are deliberately kept in tracking for fail-fast detection, renewals always succeeded even for dead sandboxes.

**Consequence**: After old sandboxes are retired, httpingress continues routing requests to the dead IP for up to 30+ seconds. Users see "Empty reply from server" (curl error 52), timeouts, and "no route to host" errors until the lease finally expires or a connection error triggers invalidation.

**Fix** (three layers):
1. **Proactive invalidation**: Added `SandboxInvalidation` event type and `Invalidations()` channel to the `AppActivator` interface. When `watchSandboxes()` detects a sandbox transitioning from RUNNING to any other state, it pushes a notification. httpingress runs a `watchInvalidations()` goroutine that listens on this channel and immediately drops all cached leases pointing to the invalidated sandbox.
2. **RenewLease status check**: `RenewLease()` now rejects leases for non-RUNNING sandboxes, so the 30s periodic renewal acts as a backup invalidation mechanism.
3. **Existing retry logic**: The existing cached-lease retry path (invalidate + acquire fresh on connection error) continues to work as a last resort.

### Bug 4: ~10 second delay before traffic shifts to new version

**Root cause**: `waitForPoolReady()` in the deployment launcher polls `pool.ReadyInstances` every 2 seconds. But `ReadyInstances` is only updated when the sandbox pool controller reconciles, which happens on a 10-second resync interval. So even though the new sandbox becomes RUNNING almost immediately (~200ms after container start), the deployment launcher doesn't see it for up to 10 seconds.

**Consequence**: Old pool cleanup (and thus old sandbox retirement) is delayed by ~10 seconds after the new sandbox is ready. During this window, the old sandbox is still serving traffic with stale code.

**Fix**: `waitForPoolReady()` now also calls `hasRunningSandboxForPool()`, which queries sandbox entities directly. Sandbox status is updated immediately when the sandbox boots, bypassing the pool controller's 10s resync cycle. Poll interval reduced from 2s to 500ms since the entity queries are cheap.

### Bug sequence (from server logs)

```
Deploy 1: Pool A (v1) → S1 (v1) created, boots, serves traffic ✓
Deploy 2: Pool A reused, SandboxSpec.Version updated to v2
         → listSandboxes queries v2, misses S1 (has v1) → creates S2 (v2)
         → S1 still running, serving traffic, but invisible to pool
Deploy 3: Pool B (v3) → S3 (v3) created (new pool because code changed)
         → Pool A decommissioned (desired=0)
         → S2 retired (lived ~20s) → crash detection triggers falsely
         → S1 STILL RUNNING, orphaned, in DNS, never cleaned up
         → httpingress still has cached lease for S1's IP
         → ~10s delay before Pool B's ReadyInstances updates
         → requests to dead S1 IP return empty replies / timeouts
```

## Files changed

| File | Change |
|------|--------|
| `controllers/sandboxpool/manager.go` | Fix `listSandboxes` to query by kind+pool label instead of version; skip crash detection for decommissioned pools |
| `controllers/sandboxpool/manager_test.go` | Update `TestManagerVersionFiltering` for new pool-label-based membership; update `listSandboxesForPool` helper; add `TestManagerPoolReuse_NoOrphanedSandboxes` and `TestManagerDecommissionedPool_NoCrashDetection` |
| `components/activator/activator.go` | Add `SandboxInvalidation` type and `Invalidations()` to `AppActivator` interface; send invalidation when sandbox leaves RUNNING; reject `RenewLease` for non-RUNNING sandboxes |
| `controllers/deployment/launcher.go` | `waitForPoolReady` checks sandbox entities directly via `hasRunningSandboxForPool`; reduce poll interval to 500ms |
| `servers/httpingress/httpingress.go` | Add `watchInvalidations` goroutine and `invalidateSandboxLeases` to immediately drop cached leases for dead sandboxes |
| `servers/httpingress/lease_test.go` | Add `Invalidations()` to mock activator |

## Test plan

- [x] All existing sandboxpool tests pass (18 tests)
- [x] All existing httpingress lease tests pass
- [x] All existing deployment launcher tests pass
- [x] New test: `TestManagerPoolReuse_NoOrphanedSandboxes` — verifies old-version sandboxes remain visible after pool version update
- [x] New test: `TestManagerDecommissionedPool_NoCrashDetection` — verifies DEAD sandboxes in decommissioned pools don't trigger crash detection
- [x] `make lint` clean (0 issues)
- [x] Manual test: 3 rapid deploys in dev environment — no orphaned sandboxes, no false crashes, immediate lease invalidation visible in logs, traffic shifts to new version within ~1s