### PR TITLE
Add --format json to app, app status, and app history (MIR-800)

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -722,7 +722,9 @@ func printAppJSON(status *app_v1alpha.ApplicationStatus, cfg *app_v1alpha.Config
 	if cfg != nil && cfg.HasEnvVars() {
 		for _, v := range cfg.EnvVars() {
 			value := v.Value()
-			if v.Sensitive() || (isSensitiveKey(v.Key()) && len(value) > 0) {
+			if v.Sensitive() {
+				value = "****"
+			} else if isSensitiveKey(v.Key()) && len(value) > 0 {
 				value = value[:1] + strings.Repeat("*", len(value)-1)
 			}
 			o.EnvVars = append(o.EnvVars, envVarJSON{Key: v.Key(), Value: value})

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -151,6 +151,7 @@ func MinuteLabeler(i int, v float64) string {
 
 func App(ctx *Context, opts struct {
 	AppCentric
+	FormatOptions
 	Watch bool `short:"w" long:"watch" description:"Watch the app stats"`
 	Graph bool `short:"g" long:"graph" description:"Graph the app stats"`
 
@@ -192,6 +193,10 @@ func App(ctx *Context, opts struct {
 	}
 
 	status := res.Status()
+
+	if opts.IsJSON() {
+		return printAppJSON(status, cfgres.Configuration())
+	}
 
 	//spew.Dump(status)
 	//windows := status.Pools()
@@ -629,4 +634,153 @@ func (m Model) View() string {
 	}
 
 	return frame
+}
+
+func printAppJSON(status *app_v1alpha.ApplicationStatus, cfg *app_v1alpha.Configuration) error {
+	type poolJSON struct {
+		Name      string `json:"name"`
+		Instances int    `json:"instances"`
+		Idle      int32  `json:"idle"`
+	}
+
+	type envVarJSON struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+
+	type requestStatJSON struct {
+		Timestamp     string  `json:"timestamp"`
+		Count         int64   `json:"count"`
+		AvgDurationMs float64 `json:"avg_duration_ms"`
+		P95DurationMs float64 `json:"p95_duration_ms,omitempty"`
+		P99DurationMs float64 `json:"p99_duration_ms,omitempty"`
+		ErrorRate     float64 `json:"error_rate"`
+	}
+
+	type pathStatJSON struct {
+		Path          string  `json:"path"`
+		Count         int64   `json:"count"`
+		AvgDurationMs float64 `json:"avg_duration_ms"`
+		ErrorRate     float64 `json:"error_rate"`
+	}
+
+	type errorBreakdownJSON struct {
+		StatusCode int32   `json:"status_code"`
+		Count      int64   `json:"count"`
+		Percentage float64 `json:"percentage"`
+	}
+
+	type output struct {
+		Name              string               `json:"name"`
+		ActiveVersion     string               `json:"active_version,omitempty"`
+		LastDeploy        string               `json:"last_deploy,omitempty"`
+		RequestsPerSecond float64              `json:"requests_per_second,omitempty"`
+		LastMinCPU        float64              `json:"last_min_cpu,omitempty"`
+		LastHourCPU       float64              `json:"last_hour_cpu,omitempty"`
+		Pools             []poolJSON           `json:"pools,omitempty"`
+		EnvVars           []envVarJSON         `json:"env_vars,omitempty"`
+		RequestStats      []requestStatJSON    `json:"request_stats,omitempty"`
+		TopPaths          []pathStatJSON       `json:"top_paths,omitempty"`
+		ErrorBreakdown    []errorBreakdownJSON `json:"error_breakdown,omitempty"`
+	}
+
+	o := output{
+		Name: status.Name(),
+	}
+
+	if status.HasActiveVersion() {
+		o.ActiveVersion = status.ActiveVersion()
+	}
+
+	if status.HasLastDeploy() && status.LastDeploy() != nil {
+		t := standard.FromTimestamp(status.LastDeploy())
+		if !t.IsZero() {
+			o.LastDeploy = t.UTC().Format(time.RFC3339)
+		}
+	}
+
+	if status.HasRequestsPerSecond() {
+		o.RequestsPerSecond = status.RequestsPerSecond()
+	}
+
+	if status.HasLastMinCPU() {
+		o.LastMinCPU = status.LastMinCPU()
+	}
+
+	if status.HasLastHourCPU() {
+		o.LastHourCPU = status.LastHourCPU()
+	}
+
+	for _, ps := range status.Pools() {
+		o.Pools = append(o.Pools, poolJSON{
+			Name:      ps.Name(),
+			Instances: len(ps.Windows()),
+			Idle:      ps.Idle(),
+		})
+	}
+
+	if cfg != nil && cfg.HasEnvVars() {
+		for _, v := range cfg.EnvVars() {
+			value := v.Value()
+			if v.Sensitive() || (isSensitiveKey(v.Key()) && len(value) > 0) {
+				value = value[:1] + strings.Repeat("*", len(value)-1)
+			}
+			o.EnvVars = append(o.EnvVars, envVarJSON{Key: v.Key(), Value: value})
+		}
+		sort.Slice(o.EnvVars, func(i, j int) bool {
+			return o.EnvVars[i].Key < o.EnvVars[j].Key
+		})
+	}
+
+	if status.HasRequestStats() {
+		// Collect non-zero samples, then keep only the last 5
+		var stats []requestStatJSON
+		for _, s := range status.RequestStats() {
+			if s.Count() == 0 {
+				continue
+			}
+			rs := requestStatJSON{
+				Count:         s.Count(),
+				AvgDurationMs: s.AvgDurationMs(),
+				ErrorRate:     s.ErrorRate(),
+			}
+			if s.HasTimestamp() && s.Timestamp() != nil {
+				rs.Timestamp = standard.FromTimestamp(s.Timestamp()).UTC().Format(time.RFC3339)
+			}
+			if s.HasP95DurationMs() {
+				rs.P95DurationMs = s.P95DurationMs()
+			}
+			if s.HasP99DurationMs() {
+				rs.P99DurationMs = s.P99DurationMs()
+			}
+			stats = append(stats, rs)
+		}
+		if len(stats) > 5 {
+			stats = stats[len(stats)-5:]
+		}
+		o.RequestStats = stats
+	}
+
+	if status.HasTopPaths() {
+		for _, p := range status.TopPaths() {
+			o.TopPaths = append(o.TopPaths, pathStatJSON{
+				Path:          p.Path(),
+				Count:         p.Count(),
+				AvgDurationMs: p.AvgDurationMs(),
+				ErrorRate:     p.ErrorRate(),
+			})
+		}
+	}
+
+	if status.HasErrorBreakdown() {
+		for _, e := range status.ErrorBreakdown() {
+			o.ErrorBreakdown = append(o.ErrorBreakdown, errorBreakdownJSON{
+				StatusCode: e.StatusCode(),
+				Count:      e.Count(),
+				Percentage: e.Percentage(),
+			})
+		}
+	}
+
+	return PrintJSON(o)
 }

--- a/cli/commands/app_history.go
+++ b/cli/commands/app_history.go
@@ -154,20 +154,12 @@ func AppHistory(ctx *Context, opts struct {
 	}
 
 	deployments := result.Deployments()
-	if len(deployments) == 0 {
-		printNoDeploymentsMessage(ctx, opts.App, opts.Status, false)
-		return nil
-	}
 
 	// Filter out failed deployments if requested
 	if opts.HideFailed {
 		deployments = filterDeployments(deployments, func(d *deployment_v1alpha.DeploymentInfo) bool {
 			return d.Status() != "failed"
 		})
-		if len(deployments) == 0 {
-			printNoDeploymentsMessage(ctx, opts.App, opts.Status, true)
-			return nil
-		}
 	}
 
 	// Sort by time (most recent first)
@@ -176,6 +168,11 @@ func AppHistory(ctx *Context, opts struct {
 	// JSON output
 	if opts.IsJSON() {
 		return printAppHistoryJSON(deployments, opts.App, ctx.ClusterName)
+	}
+
+	if len(deployments) == 0 {
+		printNoDeploymentsMessage(ctx, opts.App, opts.Status, opts.HideFailed)
+		return nil
 	}
 
 	// Print header

--- a/cli/commands/app_history.go
+++ b/cli/commands/app_history.go
@@ -11,6 +11,104 @@ import (
 	"miren.dev/runtime/pkg/ui"
 )
 
+func printAppHistoryJSON(deployments []*deployment_v1alpha.DeploymentInfo, app, cluster string) error {
+	type gitInfoJSON struct {
+		Sha               string `json:"sha,omitempty"`
+		Branch            string `json:"branch,omitempty"`
+		Repository        string `json:"repository,omitempty"`
+		IsDirty           bool   `json:"is_dirty,omitempty"`
+		CommitMessage     string `json:"commit_message,omitempty"`
+		CommitAuthorName  string `json:"commit_author_name,omitempty"`
+		CommitAuthorEmail string `json:"commit_author_email,omitempty"`
+	}
+	type deploymentJSON struct {
+		ID                 string       `json:"id"`
+		Status             string       `json:"status"`
+		AppVersionID       string       `json:"app_version_id,omitempty"`
+		DeployedAt         string       `json:"deployed_at,omitempty"`
+		DeployedByUserName string       `json:"deployed_by_user_name,omitempty"`
+		Phase              string       `json:"phase,omitempty"`
+		ErrorMessage       string       `json:"error_message,omitempty"`
+		GitInfo            *gitInfoJSON `json:"git_info,omitempty"`
+	}
+
+	var deps []deploymentJSON
+	for _, dep := range deployments {
+		d := deploymentJSON{
+			ID:           dep.Id(),
+			Status:       dep.Status(),
+			AppVersionID: dep.AppVersionId(),
+		}
+
+		if dep.HasDeployedByUserName() && dep.DeployedByUserName() != "" {
+			d.DeployedByUserName = dep.DeployedByUserName()
+		}
+
+		if dep.HasDeployedAt() && dep.DeployedAt() != nil {
+			d.DeployedAt = time.Unix(dep.DeployedAt().Seconds(), 0).UTC().Format(time.RFC3339)
+		}
+
+		if dep.HasPhase() && dep.Phase() != "" {
+			d.Phase = dep.Phase()
+		}
+
+		if dep.HasErrorMessage() && dep.ErrorMessage() != "" {
+			d.ErrorMessage = dep.ErrorMessage()
+		}
+
+		if dep.HasGitInfo() && dep.GitInfo() != nil {
+			git := dep.GitInfo()
+			gi := &gitInfoJSON{}
+			hasData := false
+			if git.HasSha() && git.Sha() != "" {
+				gi.Sha = git.Sha()
+				hasData = true
+			}
+			if git.HasBranch() && git.Branch() != "" {
+				gi.Branch = git.Branch()
+				hasData = true
+			}
+			if git.HasRepository() && git.Repository() != "" {
+				gi.Repository = git.Repository()
+				hasData = true
+			}
+			if git.HasIsDirty() && git.IsDirty() {
+				gi.IsDirty = true
+				hasData = true
+			}
+			if git.HasCommitMessage() && git.CommitMessage() != "" {
+				gi.CommitMessage = git.CommitMessage()
+				hasData = true
+			}
+			if git.HasCommitAuthorName() && git.CommitAuthorName() != "" {
+				gi.CommitAuthorName = git.CommitAuthorName()
+				hasData = true
+			}
+			if git.HasCommitAuthorEmail() && git.CommitAuthorEmail() != "" {
+				gi.CommitAuthorEmail = git.CommitAuthorEmail()
+				hasData = true
+			}
+			if hasData {
+				d.GitInfo = gi
+			}
+		}
+
+		deps = append(deps, d)
+	}
+
+	output := struct {
+		App         string           `json:"app"`
+		Cluster     string           `json:"cluster"`
+		Deployments []deploymentJSON `json:"deployments"`
+	}{
+		App:         app,
+		Cluster:     cluster,
+		Deployments: deps,
+	}
+
+	return PrintJSON(output)
+}
+
 // Deployment status styles
 var statusStyles = map[string]struct {
 	icon  string
@@ -31,6 +129,7 @@ type historyDisplayOpts struct {
 
 func AppHistory(ctx *Context, opts struct {
 	AppCentric
+	FormatOptions
 
 	Limit      int    `short:"n" long:"limit" description:"Maximum number of deployments to show" default:"10"`
 	All        bool   `long:"all" description:"Show all deployments (ignore limit)"`
@@ -73,6 +172,11 @@ func AppHistory(ctx *Context, opts struct {
 
 	// Sort by time (most recent first)
 	sortDeployments(deployments)
+
+	// JSON output
+	if opts.IsJSON() {
+		return printAppHistoryJSON(deployments, opts.App, ctx.ClusterName)
+	}
 
 	// Print header
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))

--- a/cli/commands/app_status.go
+++ b/cli/commands/app_status.go
@@ -399,7 +399,9 @@ func printAppStatusJSON(
 				if kv.HasKey() && kv.HasValue() {
 					value := kv.Value()
 					key := kv.Key()
-					if isSensitiveKey(key) && len(value) > 0 {
+					if kv.Sensitive() {
+						value = "****"
+					} else if isSensitiveKey(key) && len(value) > 0 {
 						value = value[:1] + strings.Repeat("*", len(value)-1)
 					}
 					cfg.EnvVars = append(cfg.EnvVars, envVar{Key: key, Value: value})

--- a/cli/commands/app_status.go
+++ b/cli/commands/app_status.go
@@ -12,6 +12,7 @@ import (
 
 func AppStatus(ctx *Context, opts struct {
 	AppCentric
+	FormatOptions
 }) error {
 	// Connect to app service
 	appCl, err := ctx.RPCClient("dev.miren.runtime/app")
@@ -51,6 +52,17 @@ func AppStatus(ctx *Context, opts struct {
 	if err != nil {
 		// It's okay if there's no active deployment
 		activeDeployment = nil
+	}
+
+	// Get last 5 deployments for recent activity
+	recentResult, err := depClient.ListDeployments(ctx, opts.App, clusterId, "", 5)
+	if err != nil {
+		recentResult = nil
+	}
+
+	// JSON output
+	if opts.IsJSON() {
+		return printAppStatusJSON(appResult, appConfig, activeDeployment, recentResult, opts.App, clusterId)
 	}
 
 	// Define styles
@@ -208,9 +220,7 @@ func AppStatus(ctx *Context, opts struct {
 	// Recent deployments summary
 	ctx.Printf("\n%s\n", labelStyle.Render("Recent Activity:"))
 
-	// Get last 5 deployments
-	recentResult, err := depClient.ListDeployments(ctx, opts.App, clusterId, "", 5)
-	if err == nil && recentResult.HasDeployments() && len(recentResult.Deployments()) > 0 {
+	if recentResult != nil && recentResult.HasDeployments() && len(recentResult.Deployments()) > 0 {
 		for i, dep := range recentResult.Deployments() {
 			if i >= 3 { // Only show top 3
 				break
@@ -257,6 +267,162 @@ func AppStatus(ctx *Context, opts struct {
 	ctx.Printf("\nUse 'miren app history %s' for full deployment history\n", opts.App)
 
 	return nil
+}
+
+func printAppStatusJSON(
+	appResult *app_v1alpha.CrudClientGetConfigurationResults,
+	appConfig *app_v1alpha.Configuration,
+	activeDeployment *deployment_v1alpha.DeploymentClientGetActiveDeploymentResults,
+	recentResult *deployment_v1alpha.DeploymentClientListDeploymentsResults,
+	app, cluster string,
+) error {
+	type envVar struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+	type gitInfo struct {
+		Sha               string `json:"sha,omitempty"`
+		Branch            string `json:"branch,omitempty"`
+		Repository        string `json:"repository,omitempty"`
+		IsDirty           bool   `json:"is_dirty,omitempty"`
+		CommitMessage     string `json:"commit_message,omitempty"`
+		CommitAuthorName  string `json:"commit_author_name,omitempty"`
+		CommitAuthorEmail string `json:"commit_author_email,omitempty"`
+	}
+	type configuration struct {
+		Concurrency int32    `json:"concurrency,omitempty"`
+		EnvVars     []envVar `json:"env_vars,omitempty"`
+	}
+	type deploymentJSON struct {
+		ID           string   `json:"id"`
+		Status       string   `json:"status"`
+		AppVersionID string   `json:"app_version_id,omitempty"`
+		DeployedBy   string   `json:"deployed_by,omitempty"`
+		DeployedAt   string   `json:"deployed_at,omitempty"`
+		Phase        string   `json:"phase,omitempty"`
+		ErrorMessage string   `json:"error_message,omitempty"`
+		GitInfo      *gitInfo `json:"git_info,omitempty"`
+	}
+
+	marshalDeployment := func(dep *deployment_v1alpha.DeploymentInfo) deploymentJSON {
+		d := deploymentJSON{
+			ID:           dep.Id(),
+			Status:       dep.Status(),
+			AppVersionID: dep.AppVersionId(),
+		}
+
+		// Deployed by: prefer username, fall back to email, then user ID
+		if dep.HasDeployedByUserName() && dep.DeployedByUserName() != "" {
+			d.DeployedBy = dep.DeployedByUserName()
+		} else if dep.HasDeployedByUserEmail() && dep.DeployedByUserEmail() != "" &&
+			dep.DeployedByUserEmail() != "unknown@example.com" && dep.DeployedByUserEmail() != "user@example.com" {
+			d.DeployedBy = dep.DeployedByUserEmail()
+		} else if dep.HasDeployedByUserId() && dep.DeployedByUserId() != "" {
+			d.DeployedBy = dep.DeployedByUserId()
+		}
+
+		if dep.HasDeployedAt() && dep.DeployedAt() != nil {
+			d.DeployedAt = time.Unix(dep.DeployedAt().Seconds(), 0).UTC().Format(time.RFC3339)
+		}
+
+		if dep.HasPhase() && dep.Phase() != "" {
+			d.Phase = dep.Phase()
+		}
+
+		if dep.HasErrorMessage() && dep.ErrorMessage() != "" {
+			d.ErrorMessage = dep.ErrorMessage()
+		}
+
+		if dep.HasGitInfo() && dep.GitInfo() != nil {
+			git := dep.GitInfo()
+			gi := &gitInfo{}
+			hasData := false
+			if git.HasSha() && git.Sha() != "" {
+				gi.Sha = git.Sha()
+				hasData = true
+			}
+			if git.HasBranch() && git.Branch() != "" {
+				gi.Branch = git.Branch()
+				hasData = true
+			}
+			if git.HasRepository() && git.Repository() != "" {
+				gi.Repository = git.Repository()
+				hasData = true
+			}
+			if git.HasIsDirty() && git.IsDirty() {
+				gi.IsDirty = true
+				hasData = true
+			}
+			if git.HasCommitMessage() && git.CommitMessage() != "" {
+				gi.CommitMessage = git.CommitMessage()
+				hasData = true
+			}
+			if git.HasCommitAuthorName() && git.CommitAuthorName() != "" {
+				gi.CommitAuthorName = git.CommitAuthorName()
+				hasData = true
+			}
+			if git.HasCommitAuthorEmail() && git.CommitAuthorEmail() != "" {
+				gi.CommitAuthorEmail = git.CommitAuthorEmail()
+				hasData = true
+			}
+			if hasData {
+				d.GitInfo = gi
+			}
+		}
+
+		return d
+	}
+
+	output := struct {
+		App               string           `json:"app"`
+		Cluster           string           `json:"cluster"`
+		CurrentVersion    string           `json:"current_version,omitempty"`
+		Configuration     *configuration   `json:"configuration,omitempty"`
+		ActiveDeployment  *deploymentJSON  `json:"active_deployment,omitempty"`
+		RecentDeployments []deploymentJSON `json:"recent_deployments,omitempty"`
+	}{
+		App:     app,
+		Cluster: cluster,
+	}
+
+	if appResult.HasVersionId() && appResult.VersionId() != "" {
+		output.CurrentVersion = appResult.VersionId()
+	}
+
+	if appConfig != nil {
+		cfg := &configuration{}
+		if appConfig.HasConcurrency() && appConfig.Concurrency() > 0 {
+			cfg.Concurrency = appConfig.Concurrency()
+		}
+		if appConfig.HasEnvVars() && len(appConfig.EnvVars()) > 0 {
+			for _, kv := range appConfig.EnvVars() {
+				if kv.HasKey() && kv.HasValue() {
+					value := kv.Value()
+					key := kv.Key()
+					if isSensitiveKey(key) && len(value) > 0 {
+						value = value[:1] + strings.Repeat("*", len(value)-1)
+					}
+					cfg.EnvVars = append(cfg.EnvVars, envVar{Key: key, Value: value})
+				}
+			}
+		}
+		if cfg.Concurrency > 0 || len(cfg.EnvVars) > 0 {
+			output.Configuration = cfg
+		}
+	}
+
+	if activeDeployment != nil && activeDeployment.HasDeployment() {
+		d := marshalDeployment(activeDeployment.Deployment())
+		output.ActiveDeployment = &d
+	}
+
+	if recentResult != nil && recentResult.HasDeployments() {
+		for _, dep := range recentResult.Deployments() {
+			output.RecentDeployments = append(output.RecentDeployments, marshalDeployment(dep))
+		}
+	}
+
+	return PrintJSON(output)
 }
 
 // isSensitiveKey checks if an environment variable key might contain sensitive data


### PR DESCRIPTION
## Summary
- Adds `--format json` flag to `miren app`, `miren app status`, and `miren app history` commands
- Follows the established pattern from `app list`: embed `FormatOptions`, check `IsJSON()`, output via `PrintJSON()`
- Sensitive env vars remain masked in JSON output
- Timestamps use RFC3339 format

### `miren app --format json`
Outputs app name, active version, last deploy, CPU stats, pools, env vars, request stats (last 5 non-zero samples), top paths, and error breakdown.

### `miren app status --format json`
Outputs app/cluster, current version, configuration, active deployment, and all 5 recent deployments with full git info.

### `miren app history --format json`
Outputs all deployments (after filtering/sorting) with all fields regardless of `--detailed` flag, including git info and error messages.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes
- [x] `miren app -a <app> --format json` returns valid JSON with traffic data
- [x] `miren app status -a <app> --format json` returns valid JSON
- [x] `miren app history -a <app> --format json` returns valid JSON
- [x] Existing text output unchanged for all three commands