### PR TITLE
Support `--labs all` to enable every labs feature at once

### DIFF
--- a/pkg/labs/cmd/labsgen/main.go
+++ b/pkg/labs/cmd/labsgen/main.go
@@ -159,6 +159,17 @@ func Init(log *slog.Logger, flags []string) {
 		// Normalize to lowercase for lookup
 		name = strings.ToLower(name)
 
+		// Handle the special "all" keyword
+		if name == "all" {
+			for featureName := range featureDefaults {
+				enabledFeatures[featureName] = !disable
+			}
+			if log != nil {
+				log.Info("labs feature configured", "feature", "all", "enabled", !disable)
+			}
+			continue
+		}
+
 		// Check if it's a known feature
 		if _, known := featureDefaults[name]; !known {
 			if log != nil {

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -90,6 +90,17 @@ func Init(log *slog.Logger, flags []string) {
 		// Normalize to lowercase for lookup
 		name = strings.ToLower(name)
 
+		// Handle the special "all" keyword
+		if name == "all" {
+			for featureName := range featureDefaults {
+				enabledFeatures[featureName] = !disable
+			}
+			if log != nil {
+				log.Info("labs feature configured", "feature", "all", "enabled", !disable)
+			}
+			continue
+		}
+
 		// Check if it's a known feature
 		if _, known := featureDefaults[name]; !known {
 			if log != nil {

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -196,6 +196,60 @@ func TestEmptyAndWhitespaceFlags(t *testing.T) {
 	}
 }
 
+func TestAllKeywordEnablesAllFeatures(t *testing.T) {
+	Reset()
+
+	Init(nil, []string{"all"})
+
+	for _, name := range AllFeatures() {
+		if !IsEnabled(name) {
+			t.Errorf("Feature %q should be enabled after Init with 'all'", name)
+		}
+	}
+}
+
+func TestAllKeywordWithExclusion(t *testing.T) {
+	Reset()
+
+	Init(nil, []string{"all", "-addons"})
+
+	for _, name := range AllFeatures() {
+		if name == FeatureAddons {
+			if IsEnabled(name) {
+				t.Error("Addons should be disabled after 'all,-addons'")
+			}
+		} else {
+			if !IsEnabled(name) {
+				t.Errorf("Feature %q should be enabled after 'all,-addons'", name)
+			}
+		}
+	}
+}
+
+func TestNegativeAllDisablesAll(t *testing.T) {
+	Reset()
+
+	Init(nil, []string{"globalrouter", "usersubdomains", "-all"})
+
+	for _, name := range AllFeatures() {
+		if IsEnabled(name) {
+			t.Errorf("Feature %q should be disabled after '-all'", name)
+		}
+	}
+}
+
+func TestAllKeywordCaseInsensitive(t *testing.T) {
+	Reset()
+
+	Init(nil, []string{"ALL"})
+
+	for _, name := range AllFeatures() {
+		if !IsEnabled(name) {
+			t.Errorf("Feature %q should be enabled after Init with 'ALL'", name)
+		}
+	}
+}
+
 func TestInitLogsEnabledFeatures(t *testing.T) {
 	Reset()
 


### PR DESCRIPTION
We hit this on garden — `routeoidc` was properly configured on a route but the middleware was a no-op because nobody remembered to add it to the `--labs` flag. For internal/dogfood clusters where we always want the latest and greatest, having to manually enumerate every labs feature is just asking for this kind of thing to happen again every time we add a new flag.

This adds a special `all` keyword to the labs flag parser. `--labs all` (or `MIREN_LABS=all`) enables every defined labs feature. Since flags are processed in order, you can still opt out of specific features with the existing `-` prefix syntax — `--labs all,-addons` enables everything except addons.

The change lives entirely in the `Init()` function (and the codegen template that produces it), so it works automatically everywhere labs flags are accepted: CLI flags, env vars, and config file.

Closes MIR-778