### PR TITLE
Fix flannel etcd connection when distributedrunners is enabled

### DIFF
--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -126,11 +127,29 @@ func RunnerStart(ctx *Context, opts struct {
 		EtcdEndpoints:  cfg.EtcdEndpoints,
 		EtcdPrefix:     cfg.EtcdPrefix,
 		NetworkBackend: cfg.NetworkBackend,
+	}
 
-		// etcd TLS - use the same certs as RPC auth
-		EtcdTLSCert:   []byte(cfg.ClientCert),
-		EtcdTLSKey:    []byte(cfg.ClientKey),
-		EtcdTLSCACert: []byte(cfg.CACert),
+	// Write etcd TLS certs to disk for flannel (which requires file paths)
+	if cfg.ClientCert != "" && cfg.ClientKey != "" && cfg.CACert != "" {
+		etcdCertsDir := filepath.Join(opts.DataPath, "etcd-certs")
+		if err := os.MkdirAll(etcdCertsDir, 0700); err != nil {
+			return fmt.Errorf("failed to create etcd certs directory: %w", err)
+		}
+		certFile := filepath.Join(etcdCertsDir, "client.crt")
+		keyFile := filepath.Join(etcdCertsDir, "client.key")
+		caFile := filepath.Join(etcdCertsDir, "ca.crt")
+		if err := os.WriteFile(certFile, []byte(cfg.ClientCert), 0644); err != nil {
+			return fmt.Errorf("failed to write etcd client cert: %w", err)
+		}
+		if err := os.WriteFile(keyFile, []byte(cfg.ClientKey), 0600); err != nil {
+			return fmt.Errorf("failed to write etcd client key: %w", err)
+		}
+		if err := os.WriteFile(caFile, []byte(cfg.CACert), 0644); err != nil {
+			return fmt.Errorf("failed to write etcd CA cert: %w", err)
+		}
+		deps.EtcdTLSCertFile = certFile
+		deps.EtcdTLSKeyFile = keyFile
+		deps.EtcdTLSCAFile = caFile
 	}
 
 	// Initialize sandbox metrics

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -674,9 +674,9 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 
 	// Add TLS config when distributed runners is enabled
 	if etcdTLSSetup != nil {
-		grungeOpts.TLSCert = etcdTLSSetup.ClientTLS.CertPEM
-		grungeOpts.TLSKey = etcdTLSSetup.ClientTLS.KeyPEM
-		grungeOpts.TLSCACert = etcdTLSSetup.ClientTLS.CACert
+		grungeOpts.TLSCertFile = etcdTLSSetup.ClientCertFile
+		grungeOpts.TLSKeyFile = etcdTLSSetup.ClientKeyFile
+		grungeOpts.TLSCAFile = etcdTLSSetup.CAFile
 	}
 
 	gn, err := grunge.NewNetwork(ctx.Log, grungeOpts)

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -139,6 +139,12 @@ type EtcdTLSSetupResult struct {
 	CertsDir string
 	// ClientTLS is the TLS config for clients connecting to etcd
 	ClientTLS *EtcdTLSConfig
+	// ClientCertFile is the path to the client certificate on disk
+	ClientCertFile string
+	// ClientKeyFile is the path to the client private key on disk
+	ClientKeyFile string
+	// CAFile is the path to the CA certificate on disk
+	CAFile string
 }
 
 // SetupEtcdTLS loads the existing CA and issues certificates for etcd mTLS.
@@ -214,6 +220,18 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, ext
 		return nil, fmt.Errorf("failed to issue etcd client certificate: %w", err)
 	}
 
+	// Write client certs to disk alongside server certs
+	clientCertFile := filepath.Join(certsDir, "client.crt")
+	clientKeyFile := filepath.Join(certsDir, "client.key")
+	caFile := filepath.Join(certsDir, "ca.crt")
+
+	if err := os.WriteFile(clientCertFile, clientCert.CertPEM, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write etcd client cert: %w", err)
+	}
+	if err := os.WriteFile(clientKeyFile, clientCert.KeyPEM, 0600); err != nil {
+		return nil, fmt.Errorf("failed to write etcd client key: %w", err)
+	}
+
 	log.Info("etcd TLS certificates ready", "certs_dir", certsDir)
 
 	return &EtcdTLSSetupResult{
@@ -223,6 +241,9 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, ext
 			KeyPEM:  clientCert.KeyPEM,
 			CACert:  ca.GetCACertificate(),
 		},
+		ClientCertFile: clientCertFile,
+		ClientKeyFile:  clientKeyFile,
+		CAFile:         caFile,
 	}, nil
 }
 

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -101,10 +101,10 @@ type RunnerDeps struct {
 	EtcdPrefix     string
 	NetworkBackend string
 
-	// TLS configuration for etcd mTLS (for distributed runners)
-	EtcdTLSCert   []byte // Client certificate PEM
-	EtcdTLSKey    []byte // Client private key PEM
-	EtcdTLSCACert []byte // CA certificate PEM
+	// TLS configuration for etcd mTLS (for distributed runners, file paths)
+	EtcdTLSCertFile string // Client certificate file path
+	EtcdTLSKeyFile  string // Client private key file path
+	EtcdTLSCAFile   string // CA certificate file path
 }
 
 const (
@@ -459,10 +459,10 @@ func (r *Runner) initializeNetwork(ctx context.Context, eg ...*errgroup.Group) e
 	}
 
 	// Add TLS config if provided
-	if r.deps.EtcdTLSCert != nil && r.deps.EtcdTLSKey != nil && r.deps.EtcdTLSCACert != nil {
-		grungeOpts.TLSCert = r.deps.EtcdTLSCert
-		grungeOpts.TLSKey = r.deps.EtcdTLSKey
-		grungeOpts.TLSCACert = r.deps.EtcdTLSCACert
+	if r.deps.EtcdTLSCertFile != "" && r.deps.EtcdTLSKeyFile != "" && r.deps.EtcdTLSCAFile != "" {
+		grungeOpts.TLSCertFile = r.deps.EtcdTLSCertFile
+		grungeOpts.TLSKeyFile = r.deps.EtcdTLSKeyFile
+		grungeOpts.TLSCAFile = r.deps.EtcdTLSCAFile
 	}
 
 	gn, err := grunge.NewNetwork(r.Log, grungeOpts)

--- a/pkg/grunge/grunge.go
+++ b/pkg/grunge/grunge.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -54,10 +55,10 @@ type NetworkOptions struct {
 	PrevIPv4 netip.Prefix
 	PrevIPv6 netip.Prefix
 
-	// TLS configuration for etcd mTLS (optional)
-	TLSCert   []byte // Client certificate PEM
-	TLSKey    []byte // Client private key PEM
-	TLSCACert []byte // CA certificate PEM
+	// TLS configuration for etcd mTLS (optional, file paths)
+	TLSCertFile string // Client certificate file path
+	TLSKeyFile  string // Client private key file path
+	TLSCAFile   string // CA certificate file path
 }
 
 func NewNetwork(log *slog.Logger, opts NetworkOptions) (*Network, error) {
@@ -65,9 +66,9 @@ func NewNetwork(log *slog.Logger, opts NetworkOptions) (*Network, error) {
 		Endpoints: opts.EtcdEndpoints,
 	}
 
-	// Configure TLS if certificates are provided
-	if opts.TLSCert != nil && opts.TLSKey != nil && opts.TLSCACert != nil {
-		tlsConfig, err := buildTLSConfig(opts.TLSCert, opts.TLSKey, opts.TLSCACert)
+	// Configure TLS if certificate files are provided
+	if opts.TLSCertFile != "" && opts.TLSKeyFile != "" && opts.TLSCAFile != "" {
+		tlsConfig, err := buildTLSConfigFromFiles(opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCAFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build etcd TLS config: %w", err)
 		}
@@ -87,15 +88,20 @@ func NewNetwork(log *slog.Logger, opts NetworkOptions) (*Network, error) {
 	}, nil
 }
 
-// buildTLSConfig creates a tls.Config from PEM-encoded certificates.
-func buildTLSConfig(certPEM, keyPEM, caCertPEM []byte) (*tls.Config, error) {
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+// buildTLSConfigFromFiles creates a tls.Config by reading PEM files from disk.
+func buildTLSConfigFromFiles(certFile, keyFile, caFile string) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load client certificate: %w", err)
 	}
 
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+	}
+
 	caCertPool := x509.NewCertPool()
-	if !caCertPool.AppendCertsFromPEM(caCertPEM) {
+	if !caCertPool.AppendCertsFromPEM(caCert) {
 		return nil, fmt.Errorf("failed to parse CA certificate")
 	}
 
@@ -243,6 +249,13 @@ func (n *Network) Start(ctx context.Context, eg *errgroup.Group) error {
 	cfg := &fetcd.EtcdConfig{
 		Endpoints: n.EtcdEndpoints,
 		Prefix:    n.EtcdPrefix,
+	}
+
+	if n.TLSCertFile != "" && n.TLSKeyFile != "" && n.TLSCAFile != "" {
+		cfg.Certfile = n.TLSCertFile
+		cfg.Keyfile = n.TLSKeyFile
+		cfg.CAFile = n.TLSCAFile
+		n.log.Info("flannel subnet manager using mTLS for etcd connection")
 	}
 
 	var (


### PR DESCRIPTION
When `distributedrunners` is enabled (directly or via `--labs all`), etcd starts with mTLS required. The grunge network layer had a split personality about this — `NewNetwork()` would connect to etcd with proper TLS credentials, but `Start()` created a separate flannel subnet manager that connected *without* any certs. Flannel would log "no certificate provided: connecting to etcd with http" and hang, which meant the runner and HTTP ingress never started. Ports 443/80 never bound, deploys failed.

The existing TLS plumbing was passing PEM bytes through several layers (`SetupEtcdTLS` → `server.go` → `grunge.NetworkOptions`), but flannel's `EtcdConfig` wants file paths (`Certfile`, `Keyfile`, `CAFile`). The initial fix wrote temp files to bridge the gap, but that's unnecessary — the certs originate from disk in the first place. So instead, `SetupEtcdTLS` now writes the client cert and key to the `etcd-certs/` directory alongside the server certs it was already writing, and the whole grunge interface switches from `[]byte` to file paths. For the distributed runner case where certs arrive over the wire in config, `runner_start.go` writes them to the runner's data directory with proper permissions before passing paths through.

Red-green tested with `DEV_SERVER_FLAGS="--labs distributedrunners"` — `TestDeployGoServer` fails without the fix (registry push fails because flannel networking is down) and passes with it.

Closes MIR-819