### PR TITLE
Fix saga EACStorage entity ID type causing sandbox creation panic

### DIFF
--- a/pkg/saga/eac_storage.go
+++ b/pkg/saga/eac_storage.go
@@ -61,7 +61,7 @@ func (s *EACStorage) Save(ctx context.Context, exec *Execution) error {
 	}
 
 	ent := entity.New(
-		entity.DBId, exec.ID,
+		entity.DBId, entity.Id(exec.ID),
 		sagaEntity.Encode(),
 	)
 

--- a/pkg/saga/eac_storage_test.go
+++ b/pkg/saga/eac_storage_test.go
@@ -1,9 +1,13 @@
 package saga
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/entity/testutils"
 )
 
 // TestEACStorageNewNilLogger verifies that NewEACStorage handles a nil logger.
@@ -16,4 +20,81 @@ func TestEACStorageNewNilLogger(t *testing.T) {
 // TestEACStorageImplementsStorage verifies the interface compliance at compile time.
 func TestEACStorageImplementsStorage(t *testing.T) {
 	var _ Storage = (*EACStorage)(nil)
+}
+
+// TestEACStorageSaveAndGet verifies that Save persists a saga execution with a
+// properly typed entity ID and that Get can retrieve it. This is a regression
+// test for MIR-820 where Save passed a raw string instead of entity.Id(),
+// causing a panic in ForceID.
+func TestEACStorageSaveAndGet(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	log := testutils.TestLogger(t)
+	storage := NewEACStorage(inmem.EAC, log)
+
+	exec := &Execution{
+		ID:              "create-sandbox-sandbox/my-app-web-abc123",
+		DefinitionName:  "create-sandbox",
+		Status:          StatusPending,
+		InitialInputs:   map[string]any{"sandbox_id": "sandbox/my-app-web-abc123"},
+		ExecutedActions: map[string]*ActionResult{},
+		ExecutionOrder:  []string{},
+	}
+
+	// Save should not panic (the bug was a panic in ForceID due to wrong ID type).
+	err := storage.Save(ctx, exec)
+	require.NoError(t, err)
+
+	// Round-trip: Get should return the same execution.
+	got, err := storage.Get(ctx, exec.ID)
+	require.NoError(t, err)
+	assert.Equal(t, exec.ID, got.ID)
+	assert.Equal(t, exec.DefinitionName, got.DefinitionName)
+	assert.Equal(t, exec.Status, got.Status)
+}
+
+// TestEACStorageSaveIdempotent verifies that saving the same execution twice
+// does not error (Ensure is idempotent).
+func TestEACStorageSaveIdempotent(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	log := testutils.TestLogger(t)
+	storage := NewEACStorage(inmem.EAC, log)
+
+	exec := &Execution{
+		ID:              "create-sandbox-sandbox/my-app-web-xyz789",
+		DefinitionName:  "create-sandbox",
+		Status:          StatusPending,
+		InitialInputs:   map[string]any{},
+		ExecutedActions: map[string]*ActionResult{},
+		ExecutionOrder:  []string{},
+	}
+
+	require.NoError(t, storage.Save(ctx, exec))
+	require.NoError(t, storage.Save(ctx, exec))
+
+	got, err := storage.Get(ctx, exec.ID)
+	require.NoError(t, err)
+	assert.Equal(t, exec.ID, got.ID)
+}
+
+// TestEACStorageGetNotFound verifies that Get returns ErrExecutionNotFound for
+// an unknown ID.
+func TestEACStorageGetNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	log := testutils.TestLogger(t)
+	storage := NewEACStorage(inmem.EAC, log)
+
+	_, err := storage.Get(ctx, "nonexistent-saga-id")
+	assert.ErrorIs(t, err, ErrExecutionNotFound)
 }


### PR DESCRIPTION
When running with `--labs sagas`, every sandbox creation panicked because the saga's EAC-backed storage was passing the execution ID as a raw string to `entity.New()` instead of wrapping it with `entity.Id()`. The `ForceID` panic guard (added alongside the earlier fix in b63368dc) caught the type mismatch and blew up, leaving every sandbox marked DEAD before it ever started.

The earlier commit had fixed the same bug in the direct `EntityStorage` path, but `EACStorage` — which is the one runners actually use over RPC — was missed. One-line fix, same pattern.

Added proper regression tests for `EACStorage` using a real in-memory entity server. `TestEACStorageSaveAndGet` specifically reproduces the panic — confirmed it fails without the fix and passes with it.

Closes MIR-820