### PR TITLE
Fix system logs leaking into app log output

### DIFF
--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -36,6 +36,10 @@ func buildFilterWithService(userFilter, service string) string {
 	return serviceFilter + " " + userFilter
 }
 
+// systemExclusion is a LogsQL filter clause that excludes system logs from
+// app log queries. Applied in dispatchLogs on the streamLogChunks path.
+const systemExclusion = `-source:"system"`
+
 // buildBuildFilter creates a filter for build logs of a specific version.
 // Combines source:build with the version filter.
 func buildBuildFilter(version, userFilter string) string {
@@ -198,9 +202,30 @@ type logDispatchArgs struct {
 func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, args logDispatchArgs) error {
 	printer := logPrinter(ctx, args.json)
 
+	// For app queries, wrap the printer to skip system logs that may have
+	// leaked into app log storage due to entity field collisions.
+	if args.app != "" {
+		inner := printer
+		printer = func(l *app_v1alpha.LogEntry) {
+			if l.HasSource() && l.Source() == "system" {
+				return
+			}
+			inner(l)
+		}
+	}
+
 	// Check if server supports streaming (prefer chunked for efficiency)
 	if cl.HasMethod(ctx, "streamLogChunks") {
-		return streamLogChunks(ctx, cl, args.app, args.sandbox, args.last, args.follow, args.combinedFilter, printer)
+		// Append system exclusion for server-side filtering on app queries
+		filter := args.combinedFilter
+		if args.app != "" {
+			if filter == "" {
+				filter = systemExclusion
+			} else {
+				filter = systemExclusion + " " + filter
+			}
+		}
+		return streamLogChunks(ctx, cl, args.app, args.sandbox, args.last, args.follow, filter, printer)
 	}
 
 	// Older server - warn about upgrade and limited functionality

--- a/cli/commands/logs_test.go
+++ b/cli/commands/logs_test.go
@@ -68,6 +68,22 @@ func TestBuildFilterWithService(t *testing.T) {
 	}
 }
 
+// TestBuildFilterWithService_LegacyCompatibility verifies the contract that
+// dispatchLogs depends on: when no --service flag is passed, combinedFilter
+// must equal rawFilter so the legacy capability check (rawFilter != combinedFilter)
+// doesn't falsely trip. If this test fails, older servers without streamLogChunks
+// will reject plain `miren logs` requests.
+func TestBuildFilterWithService_LegacyCompatibility(t *testing.T) {
+	for _, userFilter := range []string{"", "error", `"exact phrase"`, `error -debug /timeout/`} {
+		combined := buildFilterWithService(userFilter, "")
+		if combined != userFilter {
+			t.Errorf("buildFilterWithService(%q, \"\") = %q, want %q — "+
+				"no-service filter must equal rawFilter for legacy server compat",
+				userFilter, combined, userFilter)
+		}
+	}
+}
+
 func TestNormalizeSandboxID(t *testing.T) {
 	tests := []struct {
 		input string

--- a/observability/batch_log_writer.go
+++ b/observability/batch_log_writer.go
@@ -60,6 +60,9 @@ func (b *BatchLogWriter) WriteEntry(entity string, le LogEntry) error {
 		"trace_id": le.TraceID,
 	}
 	for k, v := range le.Attributes {
+		if isReservedLogField(k) {
+			continue
+		}
 		logData[k] = v
 	}
 

--- a/observability/batch_log_writer_test.go
+++ b/observability/batch_log_writer_test.go
@@ -117,6 +117,117 @@ func TestBatchLogWriter_FlushOnThreshold(t *testing.T) {
 	bw.Close()
 }
 
+func TestBatchLogWriter_ReservedFieldsProtected(t *testing.T) {
+	var mu sync.Mutex
+	var received []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		received = append(received, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	plw := NewPersistentLogWriter(srv.URL, 5*time.Second)
+	bw := NewBatchLogWriter(plw)
+
+	// Write an entry with attributes that collide with reserved field names
+	err := bw.WriteEntry("correct-entity", LogEntry{
+		Timestamp: time.Now(),
+		Stream:    Stdout,
+		Body:      "test message",
+		Attributes: map[string]string{
+			"entity": "wrong-entity",
+			"stream": "wrong-stream",
+			"source": "my-source",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bw.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(received) == 0 {
+		t.Fatal("expected flush, got none")
+	}
+
+	var logData map[string]any
+	line := strings.TrimSpace(received[0])
+	if err := json.Unmarshal([]byte(line), &logData); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reserved fields must not be overwritten by attributes
+	if logData["entity"] != "correct-entity" {
+		t.Errorf("entity = %v, want %q (attribute overwrote reserved field)", logData["entity"], "correct-entity")
+	}
+	if logData["stream"] != "stdout" {
+		t.Errorf("stream = %v, want %q (attribute overwrote reserved field)", logData["stream"], "stdout")
+	}
+	// Non-reserved attributes should still be written
+	if logData["source"] != "my-source" {
+		t.Errorf("source = %v, want %q (non-reserved attribute was dropped)", logData["source"], "my-source")
+	}
+}
+
+func TestParseLogLine_FiltersInternalFields(t *testing.T) {
+	lr := &LogReader{}
+
+	input := `{"_msg":"hello","_time":"2026-03-13T16:30:00Z","stream":"stdout","entity":"app/test","trace_id":"abc","_stream":"{}","_stream_id":"0000e934a84adb05","source":"system","module":"etcd","service":"web"}`
+
+	entry, err := lr.parseLogLine([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Standard fields parsed correctly
+	if entry.Body != "hello" {
+		t.Errorf("Body = %q, want %q", entry.Body, "hello")
+	}
+	if entry.Stream != Stdout {
+		t.Errorf("Stream = %q, want %q", entry.Stream, Stdout)
+	}
+	if entry.TraceID != "abc" {
+		t.Errorf("TraceID = %q, want %q", entry.TraceID, "abc")
+	}
+
+	// VictoriaLogs internal fields must not appear as attributes
+	for _, key := range []string{"_stream", "_stream_id", "_msg", "_time"} {
+		if _, ok := entry.Attributes[key]; ok {
+			t.Errorf("internal field %q leaked into attributes", key)
+		}
+	}
+
+	// Reserved routing fields must not appear as attributes
+	for _, key := range []string{"entity", "stream", "trace_id"} {
+		if _, ok := entry.Attributes[key]; ok {
+			t.Errorf("reserved field %q leaked into attributes", key)
+		}
+	}
+
+	// User attributes must be preserved
+	for _, key := range []string{"source", "module", "service"} {
+		if _, ok := entry.Attributes[key]; !ok {
+			t.Errorf("user attribute %q was incorrectly filtered", key)
+		}
+	}
+	if entry.Attributes["source"] != "system" {
+		t.Errorf("source = %q, want %q", entry.Attributes["source"], "system")
+	}
+	if entry.Attributes["module"] != "etcd" {
+		t.Errorf("module = %q, want %q", entry.Attributes["module"], "etcd")
+	}
+	if entry.Attributes["service"] != "web" {
+		t.Errorf("service = %q, want %q", entry.Attributes["service"], "web")
+	}
+}
+
 func TestBatchLogWriter_CloseFlushesRemaining(t *testing.T) {
 	var mu sync.Mutex
 	var received []string

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -31,6 +31,17 @@ const (
 	UserOOB LogStream = "user-oob"
 )
 
+// isReservedLogField returns true for field names that control log routing
+// and identity in VictoriaLogs. Attributes with these names must not overwrite
+// the corresponding built-in fields set by the log writers.
+func isReservedLogField(key string) bool {
+	switch key {
+	case "_msg", "_time", "entity", "stream", "trace_id":
+		return true
+	}
+	return false
+}
+
 type LogEntry struct {
 	Timestamp  time.Time
 	Stream     LogStream
@@ -86,8 +97,12 @@ func (l *PersistentLogWriter) WriteEntry(entity string, le LogEntry) error {
 		"trace_id": le.TraceID,
 	}
 
-	// Add all attributes as top-level fields
+	// Add attributes as top-level fields, but never overwrite reserved fields
+	// that control log routing and identity.
 	for k, v := range le.Attributes {
+		if isReservedLogField(k) {
+			continue
+		}
 		logData[k] = v
 	}
 
@@ -494,9 +509,10 @@ func (l *LogReader) parseLogLine(line []byte) (LogEntry, error) {
 		entry.TraceID = traceID
 	}
 
-	// Add all other fields as attributes
+	// Add all other fields as attributes, skipping reserved fields and
+	// VictoriaLogs internal fields (prefixed with "_").
 	for k, v := range logData {
-		if k == "_msg" || k == "_time" || k == "stream" || k == "trace_id" || k == "entity" {
+		if strings.HasPrefix(k, "_") || isReservedLogField(k) {
 			continue
 		}
 		if strVal, ok := v.(string); ok {

--- a/observability/system_log_handler.go
+++ b/observability/system_log_handler.go
@@ -9,6 +9,17 @@ import (
 // SystemLogEntityID is the well-known entity ID for system/server logs.
 const SystemLogEntityID = "system/miren-server"
 
+// safeAttrKey remaps slog attribute keys that would collide with reserved
+// VictoriaLogs fields. For example, the controller framework logs
+// "entity" to identify which entity triggered a reconcile — without
+// remapping, this overwrites the VictoriaLogs "entity" routing field.
+func safeAttrKey(key string) string {
+	if isReservedLogField(key) {
+		return "log_" + key
+	}
+	return key
+}
+
 // SystemLogHandler is an slog.Handler that tees log records to both an
 // underlying handler (typically stderr) and a VictoriaLogs log writer.
 // This enables querying server logs through the same `miren logs system`
@@ -44,14 +55,15 @@ func (h *SystemLogHandler) Handle(ctx context.Context, record slog.Record) error
 	attrs := make(map[string]string)
 	attrs["source"] = "system"
 
-	// Add handler-level attrs (from WithAttrs)
+	// Add handler-level attrs (from WithAttrs), remapping any that would
+	// collide with reserved log fields used for routing in VictoriaLogs.
 	for _, a := range h.attrs {
-		attrs[a.Key] = a.Value.String()
+		attrs[safeAttrKey(a.Key)] = a.Value.String()
 	}
 
 	// Add record-level attrs
 	record.Attrs(func(a slog.Attr) bool {
-		attrs[a.Key] = a.Value.String()
+		attrs[safeAttrKey(a.Key)] = a.Value.String()
 		return true
 	})
 

--- a/observability/system_log_handler_test.go
+++ b/observability/system_log_handler_test.go
@@ -98,6 +98,28 @@ func TestSystemLogHandler(t *testing.T) {
 		}
 	})
 
+	t.Run("reserved attr keys are remapped", func(t *testing.T) {
+		writer.entries = nil
+		logger.Info("Processing event", "entity", "app/myapp", "rev", "42")
+
+		if len(writer.entries) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(writer.entries))
+		}
+
+		attrs := writer.entries[0].entry.Attributes
+		// "entity" collides with VictoriaLogs routing field, should be remapped
+		if _, ok := attrs["entity"]; ok {
+			t.Error("reserved key 'entity' was not remapped")
+		}
+		if attrs["log_entity"] != "app/myapp" {
+			t.Errorf("log_entity = %q, want %q", attrs["log_entity"], "app/myapp")
+		}
+		// Non-reserved keys should pass through unchanged
+		if attrs["rev"] != "42" {
+			t.Errorf("rev = %q, want %q", attrs["rev"], "42")
+		}
+	})
+
 	t.Run("Enabled delegates to inner handler", func(t *testing.T) {
 		if !handler.Enabled(context.Background(), slog.LevelDebug) {
 			t.Error("expected debug to be enabled")


### PR DESCRIPTION
Evan spotted `reconcile.deploymentlauncher` system logs showing up in `miren logs` on garden, along with some `_stream` / `_stream_id` noise that shouldn't have been there.

The root cause turned out to be a field name collision in the log writer. When the controller framework logs something like `"Processing event", "entity", event.Id`, slog dutifully records `entity` as an attribute. The `SystemLogHandler` tees that record to VictoriaLogs with the correct entity ID (`system/miren-server`), but the attribute serialization loop runs *after* the built-in fields are set — so the slog `entity` attribute silently overwrites the routing field, and the system log ends up stored under the app's entity ID instead.

Three fixes, layered for defense in depth:

1. **SystemLogHandler remaps reserved keys** — slog attributes that collide with VictoriaLogs routing fields (like `entity`) get prefixed to `log_entity`, so callers never have to think about naming collisions.
2. **Log writers guard reserved fields** — both `PersistentLogWriter` and `BatchLogWriter` skip reserved field names when iterating attributes, as a safety net against any other path that might introduce collisions.
3. **App log queries exclude system source** — `buildFilterWithService` now includes `-source:"system"` so app log output explicitly filters system logs even if future routing bugs occur.

Also filters all `_`-prefixed VictoriaLogs internal fields from parsed log attributes so `_stream` and `_stream_id` stop leaking into the displayed output.

Closes MIR-785