### PR TITLE
Add upload progress bar and caching summary to deploy (MIR-798)

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -501,13 +502,34 @@ func Deploy(ctx *Context, opts struct {
 		ctx.Log.Debug("manifest computation failed, falling back to full upload", "error", manifestErr)
 	}
 
+	// Compute uncompressed totals for progress estimation and cached bytes for the summary.
+	var totalUncompressed int64
+	var cachedBytes int64
+	if manifest != nil {
+		var totalManifestBytes int64
+		for _, m := range manifest {
+			totalManifestBytes += m.Size
+		}
+		if useOptimized && neededPaths != nil {
+			for _, m := range manifest {
+				if neededPaths[m.Path] {
+					totalUncompressed += m.Size
+				}
+			}
+			cachedBytes = totalManifestBytes - totalUncompressed
+		} else {
+			totalUncompressed = totalManifestBytes
+		}
+	}
+
+	var uncompressedWritten atomic.Int64
 	var r io.ReadCloser
 	if useOptimized && len(neededPaths) > 0 {
-		r, err = tarx.MakeFilteredTar(dir, includePatterns, neededPaths)
+		r, err = tarx.MakeFilteredTar(dir, includePatterns, neededPaths, &uncompressedWritten)
 	} else if useOptimized {
 		r = tarx.MakeEmptyTar()
 	} else {
-		r, err = tarx.MakeTar(dir, includePatterns)
+		r, err = tarx.MakeTar(dir, includePatterns, &uncompressedWritten)
 	}
 	if err != nil {
 		uploadSpan.RecordError(err)
@@ -560,13 +582,16 @@ func Deploy(ctx *Context, opts struct {
 		var lastPrintTime time.Time
 
 		progressReader := upload.NewProgressReader(r, func(progress upload.Progress) {
+			enrichUploadProgress(&progress, &uncompressedWritten, totalUncompressed)
 			uploadBytes = progress.BytesRead
 			// Print progress every 500ms to avoid spamming
-			if time.Since(lastPrintTime) >= 500*time.Millisecond {
+			if progress.Fraction > 0 && time.Since(lastPrintTime) >= 500*time.Millisecond {
 				lastPrintTime = time.Now()
 				fmt.Fprintf(os.Stderr, "\r\033[K") // Clear to end of line
-				fmt.Fprintf(os.Stderr, "Uploading artifacts: %s at %s",
+				fmt.Fprintf(os.Stderr, "Uploading artifacts: %d%% — %s / ~%s at %s",
+					int(progress.Fraction*100),
 					upload.FormatBytes(progress.BytesRead),
+					upload.FormatBytes(progress.EstimatedTotalBytes),
 					upload.FormatSpeed(progress.BytesPerSecond))
 			}
 		})
@@ -578,10 +603,17 @@ func Deploy(ctx *Context, opts struct {
 			if uploadBytes > 0 {
 				uploadDuration := time.Since(uploadStartTime)
 				avgSpeed := float64(uploadBytes) / uploadDuration.Seconds()
-				fmt.Fprintf(os.Stderr, "\rUpload complete: %s in %.1fs at %s\n",
+				summary := fmt.Sprintf("\rUpload complete: %s in %.1fs at %s",
 					upload.FormatBytes(uploadBytes),
 					uploadDuration.Seconds(),
 					upload.FormatSpeed(avgSpeed))
+				if useOptimized && cachedFiles > 0 {
+					summary += fmt.Sprintf(", reused %d/%d files", cachedFiles, totalFiles)
+					if cachedBytes > 0 {
+						summary += fmt.Sprintf(" (saved %s)", upload.FormatBytes(cachedBytes))
+					}
+				}
+				fmt.Fprintf(os.Stderr, "%s\n", summary)
 				uploadBytes = 0 // Only print once
 			}
 
@@ -648,6 +680,7 @@ func Deploy(ctx *Context, opts struct {
 		defer wg.Wait()
 
 		progressReader := upload.NewProgressReader(r, func(progress upload.Progress) {
+			enrichUploadProgress(&progress, &uncompressedWritten, totalUncompressed)
 			select {
 			case uploadProgressCh <- progress:
 			default:
@@ -659,7 +692,7 @@ func Deploy(ctx *Context, opts struct {
 		deployCtx, cancelDeploy := context.WithCancel(buildCtx)
 		defer cancelDeploy()
 
-		model := initialModel(updateCh, buildCh, uploadProgressCh, cachedFiles, totalFiles)
+		model := initialModel(updateCh, buildCh, uploadProgressCh, cachedFiles, totalFiles, cachedBytes)
 		p := tea.NewProgram(model)
 
 		var finalModel tea.Model
@@ -670,11 +703,9 @@ func Deploy(ctx *Context, opts struct {
 			defer wg.Done()
 			finalModel, runErr = p.Run()
 			if runErr == nil {
-				// Check if we exited due to interrupt or actual timeout
 				if dm, ok := finalModel.(*deployInfo); ok && dm.interrupted {
-					cancelDeploy() // Cancel the deployment context
+					cancelDeploy()
 				}
-				// Note: we don't cancel on timeout phase anymore as that's handled by the UI
 			} else {
 				// UI died; ensure we don't keep uploading/building
 				cancelDeploy()
@@ -734,13 +765,6 @@ func Deploy(ctx *Context, opts struct {
 					return buildCtx.Err()
 				}
 				return context.Canceled
-			}
-
-			// Check if this was a buildkit startup timeout (handled by UI)
-			if isDeploy && dm.currentPhase == "timeout" {
-				// The UI already printed the timeout message
-				updateDeploymentOnError("Buildkit startup timeout")
-				return fmt.Errorf("buildkit startup timeout")
 			}
 
 			// Check if this was a server panic
@@ -818,6 +842,18 @@ func Deploy(ctx *Context, opts struct {
 	displayAccessInfo(ctx, name, results)
 
 	return nil
+}
+
+// enrichUploadProgress fills in Fraction and EstimatedTotalBytes on a Progress
+// snapshot using the atomic uncompressed-byte counter and the known total.
+func enrichUploadProgress(p *upload.Progress, written *atomic.Int64, totalUncompressed int64) {
+	if totalUncompressed <= 0 {
+		return
+	}
+	p.Fraction = float64(written.Load()) / float64(totalUncompressed)
+	if p.Fraction > 0 {
+		p.EstimatedTotalBytes = int64(float64(p.BytesRead) / p.Fraction)
+	}
 }
 
 // Helper function to print build errors and logs
@@ -1139,7 +1175,7 @@ func analyzeApp(ctx *Context, bc *build_v1alpha.BuilderClient, dir string) error
 		includePatterns = ac.Include
 	}
 
-	r, err := tarx.MakeTar(dir, includePatterns)
+	r, err := tarx.MakeTar(dir, includePatterns, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create tar: %w", err)
 	}

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -609,7 +609,10 @@ func Deploy(ctx *Context, opts struct {
 					upload.FormatSpeed(avgSpeed))
 				if useOptimized && cachedFiles > 0 {
 					summary += fmt.Sprintf(", reused %d/%d files", cachedFiles, totalFiles)
-					if cachedBytes > 0 {
+					if cachedBytes > 0 && avgSpeed > 0 {
+						savedSec := float64(cachedBytes) / avgSpeed
+						summary += fmt.Sprintf(" (saved %s, ~%s)", upload.FormatBytes(cachedBytes), upload.FormatDuration(time.Duration(savedSec*float64(time.Second))))
+					} else if cachedBytes > 0 {
 						summary += fmt.Sprintf(" (saved %s)", upload.FormatBytes(cachedBytes))
 					}
 				}

--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -86,8 +86,6 @@ type updateMsg struct {
 	msg string
 }
 
-type timeoutCheckMsg struct{}
-
 // deployInfo is the TEA model for the deploy UI
 type deployInfo struct {
 	spinner spinner.Model
@@ -113,21 +111,22 @@ type deployInfo struct {
 	uploadDuration   time.Duration
 	finalUploadSpeed float64
 
+	// Upload progress estimation
+	uploadPct      float64 // 0.0–1.0 fraction, -1 if unknown
+	uploadEstTotal int64   // estimated compressed total bytes
+
 	// Source cache info
 	cachedFiles int32
 	totalFiles  int
+	cachedBytes int64
 
-	// Timeout and interrupt handling
-	lastActivity    time.Time
-	buildkitTimeout time.Duration
-	buildkitStarted bool // Track if buildkit has shown any activity
-	interrupted     bool
+	interrupted bool
 
 	showProgress bool
 	bp           tea.Model
 }
 
-func initialModel(update chan string, buildCh chan buildProgress, uploadProgress chan upload.Progress, cachedFiles int32, totalFiles int) *deployInfo {
+func initialModel(update chan string, buildCh chan buildProgress, uploadProgress chan upload.Progress, cachedFiles int32, totalFiles int, cachedBytes int64) *deployInfo {
 	s := spinner.New()
 	s.Spinner = Meter
 	s.Style = lipgloss.NewStyle()
@@ -142,35 +141,42 @@ func initialModel(update chan string, buildCh chan buildProgress, uploadProgress
 	uploadS.Style = lipgloss.NewStyle()
 
 	return &deployInfo{
-		spinner:         s,
-		message:         "Reading application data",
-		update:          update,
-		buildCh:         buildCh,
-		prog:            p,
-		uploadProgress:  uploadProgress,
-		uploadSpin:      uploadS,
-		isUploading:     true,
-		uploadSpeed:     "calculating...",
-		phaseStart:      time.Now(),
-		currentPhase:    "upload",
-		cachedFiles:     cachedFiles,
-		totalFiles:      totalFiles,
-		lastActivity:    time.Now(),
-		buildkitTimeout: 60 * time.Second, // 60 second timeout for buildkit to start
-		buildkitStarted: false,
-		bp:              progressui.TeaModel(),
+		spinner:        s,
+		message:        "Reading application data",
+		update:         update,
+		buildCh:        buildCh,
+		prog:           p,
+		uploadProgress: uploadProgress,
+		uploadSpin:     uploadS,
+		isUploading:    true,
+		uploadSpeed:    "calculating...",
+		phaseStart:     time.Now(),
+		currentPhase:   "upload",
+		cachedFiles:    cachedFiles,
+		totalFiles:     totalFiles,
+		cachedBytes:    cachedBytes,
+		bp:             progressui.TeaModel(),
 	}
 }
 
 func (m *deployInfo) uploadDetails() string {
-	var parts []string
-	if m.cachedFiles > 0 {
-		parts = append(parts, fmt.Sprintf("reused %d/%d files", m.cachedFiles, m.totalFiles))
+	// All files cached — special case
+	if m.cachedFiles > 0 && m.cachedFiles == int32(m.totalFiles) {
+		return fmt.Sprintf("all %d files reused from previous deploy", m.totalFiles)
 	}
+
+	var parts []string
 	if m.uploadBytes > 0 {
 		parts = append(parts, fmt.Sprintf("%s at %s",
 			upload.FormatBytes(m.uploadBytes),
 			upload.FormatSpeed(m.finalUploadSpeed)))
+	}
+	if m.cachedFiles > 0 {
+		detail := fmt.Sprintf("reused %d/%d files", m.cachedFiles, m.totalFiles)
+		if m.cachedBytes > 0 {
+			detail += fmt.Sprintf(" (saved %s)", upload.FormatBytes(m.cachedBytes))
+		}
+		parts = append(parts, detail)
 	}
 	return strings.Join(parts, ", ")
 }
@@ -180,7 +186,6 @@ func (m *deployInfo) Init() tea.Cmd {
 		m.bp.Init(),
 		m.spinner.Tick,
 		m.uploadSpin.Tick,
-		m.checkTimeout(), // Start timeout monitoring
 	}
 
 	// Only wait for channels that are expected to have data
@@ -204,12 +209,6 @@ func (m *deployInfo) Init() tea.Cmd {
 	}
 
 	return tea.Batch(cmds...)
-}
-
-func (m *deployInfo) checkTimeout() tea.Cmd {
-	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
-		return timeoutCheckMsg{}
-	})
 }
 
 func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -239,21 +238,9 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter:
 			m.showProgress = !m.showProgress
 		}
-	case timeoutCheckMsg:
-		// Only check for timeout if buildkit hasn't started yet
-		if m.currentPhase == "buildkit" && !m.buildkitStarted && time.Since(m.lastActivity) > m.buildkitTimeout {
-			m.currentPhase = "timeout"
-			return m, tea.Sequence(
-				tea.Println("\n\n❌ Buildkit failed to start after 60 seconds. This may indicate a server issue."),
-				tea.Quit,
-			)
-		}
-		// Continue checking
-		cmds = append(cmds, m.checkTimeout())
 	case updateMsg:
 		prevMessage := m.message
 		m.message = msg.msg
-		m.lastActivity = time.Now() // Reset activity timer
 
 		// Track phase transitions
 		if prevMessage != msg.msg {
@@ -272,7 +259,6 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Start tracking buildkit phase
 				m.phaseStart = time.Now()
 				m.currentPhase = "buildkit"
-				m.buildkitStarted = true
 			}
 
 		}
@@ -281,13 +267,13 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return updateMsg{msg: <-m.update}
 		})
 	case upload.Progress:
-		m.lastActivity = time.Now() // Reset activity timer
 		if m.isUploading {
 			m.uploadSpeed = upload.FormatSpeed(msg.BytesPerSecond)
 			m.uploadBytes = msg.BytesRead
 			m.finalUploadSpeed = msg.BytesPerSecond
+			m.uploadPct = msg.Fraction
+			m.uploadEstTotal = msg.EstimatedTotalBytes
 
-			// Spinner tick is already handled in the Update method
 			// Continue reading upload progress
 			if m.uploadProgress != nil {
 				cmds = append(cmds, func() tea.Msg {
@@ -296,7 +282,6 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case buildProgress:
-		m.lastActivity = time.Now() // Reset activity timer
 
 		// Build progress means upload is complete (fallback if no "Launching builder" message)
 		if m.isUploading {
@@ -325,8 +310,6 @@ func (m *deployInfo) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.phaseStart = time.Now()
 			m.currentPhase = "buildkit"
 		}
-		m.buildkitStarted = true
-
 		m.buildSteps = msg.total
 
 		if msg.total > 0 {
@@ -364,10 +347,16 @@ func (m *deployInfo) View() string {
 	// Show current progress
 	var currentLine string
 	if m.isUploading {
-		bytesInfo := upload.FormatBytes(m.uploadBytes)
-		speedInfo := deployPrefixStyle.Render(fmt.Sprintf("%s uploaded at %s", bytesInfo, m.uploadSpeed))
-		currentLine = fmt.Sprintf("  %s %s...\n      %s %s",
-			m.uploadSpin.View(), m.message, m.spinner.View(), speedInfo)
+		pct := m.uploadPct
+		if pct < 0 {
+			pct = 0
+		}
+		pctStr := deployPrefixStyle.Render(fmt.Sprintf("%d%% — %s at %s",
+			int(pct*100),
+			upload.FormatBytes(m.uploadBytes),
+			m.uploadSpeed))
+		currentLine = fmt.Sprintf("  %s Uploading artifacts...\n      %s %s",
+			m.uploadSpin.View(), m.prog.ViewAs(pct), pctStr)
 	} else if m.currentPhase != "completed" {
 		if m.buildSteps > 0 {
 			steps := deployPrefixStyle.Render(fmt.Sprintf("Building %d steps:", m.buildSteps))

--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -173,7 +173,10 @@ func (m *deployInfo) uploadDetails() string {
 	}
 	if m.cachedFiles > 0 {
 		detail := fmt.Sprintf("reused %d/%d files", m.cachedFiles, m.totalFiles)
-		if m.cachedBytes > 0 {
+		if m.cachedBytes > 0 && m.finalUploadSpeed > 0 {
+			savedSec := float64(m.cachedBytes) / m.finalUploadSpeed
+			detail += fmt.Sprintf(" (saved %s, ~%s)", upload.FormatBytes(m.cachedBytes), upload.FormatDuration(time.Duration(savedSec*float64(time.Second))))
+		} else if m.cachedBytes > 0 {
 			detail += fmt.Sprintf(" (saved %s)", upload.FormatBytes(m.cachedBytes))
 		}
 		parts = append(parts, detail)

--- a/pkg/buildkit/build_test.go
+++ b/pkg/buildkit/build_test.go
@@ -41,7 +41,7 @@ func TestBuildKitLocal(t *testing.T) {
 
 		r := require.New(t)
 
-		dfr, err := tarx.MakeTar("testdata/df1", nil)
+		dfr, err := tarx.MakeTar("testdata/df1", nil, nil)
 		r.NoError(err)
 
 		datafs, err := tarx.TarFS(dfr, t.TempDir())

--- a/pkg/progress/upload/upload.go
+++ b/pkg/progress/upload/upload.go
@@ -19,9 +19,11 @@ type ProgressReader struct {
 
 // Progress represents a snapshot of the current upload stats.
 type Progress struct {
-	BytesRead      int64
-	BytesPerSecond float64
-	Duration       time.Duration
+	BytesRead           int64
+	BytesPerSecond      float64
+	Duration            time.Duration
+	Fraction            float64 // 0.0–1.0 upload fraction complete
+	EstimatedTotalBytes int64   // projected total compressed bytes; 0 if unknown
 }
 
 // NewProgressReader creates a new progress tracking reader that wraps the given io.Reader.

--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/shibumi/go-pathspec"
 	"github.com/tonistiigi/fsutil"
@@ -87,8 +88,8 @@ func ValidatePattern(pattern string) error {
 	return nil
 }
 
-func MakeTar(dir string, includePatterns []string) (io.ReadCloser, error) {
-	return makeTarWithFilter(dir, includePatterns, func(string) bool { return true })
+func MakeTar(dir string, includePatterns []string, uncompressedBytes *atomic.Int64) (io.ReadCloser, error) {
+	return makeTarWithFilter(dir, includePatterns, func(string) bool { return true }, uncompressedBytes)
 }
 
 func TarToMap(r io.Reader) (map[string][]byte, error) {
@@ -240,15 +241,16 @@ func MakeEmptyTar() io.ReadCloser {
 
 // MakeFilteredTar creates a gzipped tar like MakeTar but only includes files
 // whose relative paths are in the onlyPaths set. Directory entries are included
-// as needed to contain the requested files.
-func MakeFilteredTar(dir string, includePatterns []string, onlyPaths map[string]bool) (io.ReadCloser, error) {
-	return makeTarWithFilter(dir, includePatterns, func(rp string) bool { return onlyPaths[rp] })
+// as needed to contain the requested files. If uncompressedBytes is non-nil,
+// each file's uncompressed size is atomically added after it is written.
+func MakeFilteredTar(dir string, includePatterns []string, onlyPaths map[string]bool, uncompressedBytes *atomic.Int64) (io.ReadCloser, error) {
+	return makeTarWithFilter(dir, includePatterns, func(rp string) bool { return onlyPaths[rp] }, uncompressedBytes)
 }
 
 // makeTarWithFilter creates a gzipped tar of dir, applying gitignore/include logic,
 // and only including regular files for which accept returns true. Directory entries
 // are emitted lazily as needed to contain accepted files.
-func makeTarWithFilter(dir string, includePatterns []string, accept func(string) bool) (io.ReadCloser, error) {
+func makeTarWithFilter(dir string, includePatterns []string, accept func(string) bool, uncompressedBytes *atomic.Int64) (io.ReadCloser, error) {
 	r, w, err := os.Pipe()
 	if err != nil {
 		return nil, err
@@ -369,7 +371,7 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 					return fErr
 				}
 				defer f.Close()
-				if _, err := io.Copy(tw, f); err != nil {
+				if _, err := io.Copy(tw, &countingReader{r: f, counter: uncompressedBytes}); err != nil {
 					return err
 				}
 			}
@@ -379,6 +381,20 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 	}()
 
 	return r, nil
+}
+
+// countingReader wraps an io.Reader and atomically adds bytes read to a counter.
+type countingReader struct {
+	r       io.Reader
+	counter *atomic.Int64
+}
+
+func (cr *countingReader) Read(p []byte) (int, error) {
+	n, err := cr.r.Read(p)
+	if n > 0 && cr.counter != nil {
+		cr.counter.Add(int64(n))
+	}
+	return n, err
 }
 
 func TarFS(r io.Reader, dir string) (fsutil.FS, error) {

--- a/pkg/tarx/tarx_test.go
+++ b/pkg/tarx/tarx_test.go
@@ -176,7 +176,7 @@ func TestMakeTar(t *testing.T) {
 			}
 
 			// Create tar
-			reader, err := MakeTar(tmpDir, nil)
+			reader, err := MakeTar(tmpDir, nil, nil)
 			require.NoError(t, err)
 
 			// Extract and verify contents
@@ -208,7 +208,7 @@ func TestMakeTarWithoutGitignore(t *testing.T) {
 	}
 
 	// Create tar (no .gitignore file)
-	reader, err := MakeTar(tmpDir, nil)
+	reader, err := MakeTar(tmpDir, nil, nil)
 	require.NoError(t, err)
 
 	// Extract and verify all files are included
@@ -224,7 +224,7 @@ func TestMakeTarEmptyDirectory(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create tar of empty directory
-	reader, err := MakeTar(tmpDir, nil)
+	reader, err := MakeTar(tmpDir, nil, nil)
 	require.NoError(t, err)
 
 	// Verify no entries
@@ -271,7 +271,7 @@ func TestMakeTarVerifyContent(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte(testContent), 0644))
 
 	// Create tar
-	reader, err := MakeTar(tmpDir, nil)
+	reader, err := MakeTar(tmpDir, nil, nil)
 	require.NoError(t, err)
 
 	// Extract and verify content
@@ -317,7 +317,7 @@ func TestMakeTarGitignoreNegation(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(gitignore), 0644))
 
 	// Create tar
-	reader, err := MakeTar(tmpDir, nil)
+	reader, err := MakeTar(tmpDir, nil, nil)
 	require.NoError(t, err)
 
 	// Extract and verify only important.log and regular.txt are included.
@@ -413,7 +413,7 @@ func TestMakeFilteredTar(t *testing.T) {
 		"lib/db.go": true,
 	}
 
-	reader, err := MakeFilteredTar(tmpDir, nil, onlyPaths)
+	reader, err := MakeFilteredTar(tmpDir, nil, onlyPaths, nil)
 	require.NoError(t, err)
 
 	entries := extractTarEntries(t, reader)
@@ -436,7 +436,7 @@ func TestMakeFilteredTarEmpty(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("hello"), 0644))
 
 	// Empty only-paths set => no files in tar
-	reader, err := MakeFilteredTar(tmpDir, nil, map[string]bool{})
+	reader, err := MakeFilteredTar(tmpDir, nil, map[string]bool{}, nil)
 	require.NoError(t, err)
 
 	entries := extractTarEntries(t, reader)
@@ -462,7 +462,7 @@ func TestMakeTarOnlyIncludesDirectoriesWithAcceptedFiles(t *testing.T) {
 	}
 
 	t.Run("unfiltered includes all directories", func(t *testing.T) {
-		reader, err := MakeTar(tmpDir, nil)
+		reader, err := MakeTar(tmpDir, nil, nil)
 		require.NoError(t, err)
 
 		entries := extractTarEntries(t, reader)
@@ -479,7 +479,7 @@ func TestMakeTarOnlyIncludesDirectoriesWithAcceptedFiles(t *testing.T) {
 			"lib/util.go": true,
 		}
 
-		reader, err := MakeFilteredTar(tmpDir, nil, onlyPaths)
+		reader, err := MakeFilteredTar(tmpDir, nil, onlyPaths, nil)
 		require.NoError(t, err)
 
 		entries := extractTarEntries(t, reader)
@@ -499,7 +499,7 @@ func TestMakeTarOnlyIncludesDirectoriesWithAcceptedFiles(t *testing.T) {
 			"deep/a/b/file.go": true,
 		}
 
-		reader, err := MakeFilteredTar(tmpDir, nil, onlyPaths)
+		reader, err := MakeFilteredTar(tmpDir, nil, onlyPaths, nil)
 		require.NoError(t, err)
 
 		entries := extractTarEntries(t, reader)
@@ -542,7 +542,7 @@ func TestMakeTarWithIncludePatterns(t *testing.T) {
 	// Test with include patterns that override gitignore
 	// Using gitignore-style patterns including the ** pattern
 	includePatterns := []string{"dist", "dist/**", "*.log", "**/*.generated"}
-	reader, err := MakeTar(tmpDir, includePatterns)
+	reader, err := MakeTar(tmpDir, includePatterns, nil)
 	require.NoError(t, err)
 
 	// Extract and verify dist files and log files are included despite gitignore


### PR DESCRIPTION
With the delta file transfer work from MIR-668, deploys compute a manifest, ask the server which files are cached, and only upload what changed. But the UI was still showing a spinner with raw byte count — no sense of progress toward completion, and no indication of how much the caching actually saved you.

Now during upload you get a real progress bar with percentage, bytes transferred, and speed. The bar is driven by an atomic counter that tracks uncompressed bytes as they stream into the tar — it increments per read chunk rather than per file, so even a single large file shows smooth progress instead of jumping from 0% to 100%.

When upload finishes, the summary line tells you what happened: `142KB at 68KB/s, reused 14/22 files (saved 2.1MB)`. If everything was cached, you just get `all 22 files reused from previous deploy`. Both interactive and explain/non-TTY modes got the treatment.

While in the neighborhood, removed the client-side buildkit startup timeout machinery. Buildkit doesn't launch per-deploy anymore, so the 60-second watchdog was monitoring a ghost. Timeout detection belongs server-side.