### PR TITLE
Speed up log queries by dropping server-side sort pipes

### DIFF
--- a/observability/logs.go
+++ b/observability/logs.go
@@ -337,17 +337,17 @@ func (l *LogReader) executeStreamQuery(ctx context.Context, query string, logCh 
 	baseURL := normalizeBaseURL(l.Address)
 	queryURL := baseURL + "/select/logsql/query"
 
-	var sortedQuery string
-	if o.Limit > 0 {
-		// Get the most recent N entries by sorting descending with limit,
-		// then reverse client-side to display in chronological order.
-		sortedQuery = fmt.Sprintf("%s | sort by (_time) desc | limit %d", query, o.Limit)
-	} else {
-		sortedQuery = query + " | sort by (_time) asc"
-	}
-
+	// Avoid sort pipes — they force VictoriaLogs to buffer and sort all
+	// matching entries server-side before returning results. Instead, use
+	// the native limit query parameter (returns most recent N) and accept
+	// VictoriaLogs' ingestion order, which is approximately chronological
+	// for a single-writer server.
 	params := url.Values{}
-	params.Set("query", sortedQuery)
+	params.Set("query", query)
+
+	if o.Limit > 0 {
+		params.Set("limit", fmt.Sprintf("%d", o.Limit))
+	}
 
 	startTime := o.From
 	if startTime.IsZero() {
@@ -376,43 +376,7 @@ func (l *LogReader) executeStreamQuery(ctx context.Context, query string, logCh 
 		return fmt.Errorf("victorialogs returned status %d: %s", resp.StatusCode, string(body))
 	}
 
-	if o.Limit > 0 {
-		// Results are in reverse chronological order; buffer and reverse.
-		return l.parseLogStreamReversed(ctx, resp.Body, logCh)
-	}
 	return l.parseLogStream(ctx, resp.Body, logCh)
-}
-
-// parseLogStreamReversed collects all entries from the stream, reverses them,
-// and sends them to the channel in chronological order. Used for limited queries
-// where results arrive in descending time order.
-func (l *LogReader) parseLogStreamReversed(ctx context.Context, body io.Reader, logCh chan<- LogEntry) error {
-	var entries []LogEntry
-	scanner := bufio.NewScanner(body)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(bytes.TrimSpace(line)) == 0 {
-			continue
-		}
-		entry, err := l.parseLogLine(line)
-		if err != nil {
-			continue
-		}
-		entries = append(entries, entry)
-	}
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-
-	// Reverse to chronological order
-	for i := len(entries) - 1; i >= 0; i-- {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case logCh <- entries[i]:
-		}
-	}
-	return nil
 }
 
 func (l *LogReader) executeTailQuery(ctx context.Context, query string, logCh chan<- LogEntry, opts ...LogReaderOption) error {
@@ -528,11 +492,8 @@ func (l *LogReader) executeQuery(ctx context.Context, query string, limit int, s
 	baseURL := normalizeBaseURL(l.Address)
 	queryURL := baseURL + "/select/logsql/query"
 
-	// Sort by time ascending so older logs appear first
-	sortedQuery := query + " | sort by (_time) asc"
-
 	params := url.Values{}
-	params.Set("query", sortedQuery)
+	params.Set("query", query)
 	params.Set("limit", fmt.Sprintf("%d", limit))
 	// Add time range - VictoriaLogs uses RFC3339 timestamps
 	params.Set("start", start.Format(time.RFC3339Nano))

--- a/servers/logs/logs_test.go
+++ b/servers/logs/logs_test.go
@@ -31,21 +31,10 @@ type mockLogEntry struct {
 
 func createMockVictoriaLogs(t *testing.T, entries []mockLogEntry, delay time.Duration) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		query := r.URL.Query().Get("query")
-
-		// Simulate VictoriaLogs returning results in desc order when requested
-		ordered := entries
-		if strings.Contains(query, "desc") {
-			ordered = make([]mockLogEntry, len(entries))
-			for i, e := range entries {
-				ordered[len(entries)-1-i] = e
-			}
-		}
-
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		w.WriteHeader(http.StatusOK)
 
-		for _, entry := range ordered {
+		for _, entry := range entries {
 			if delay > 0 {
 				time.Sleep(delay)
 			}
@@ -69,14 +58,7 @@ func createFilteringMockVictoriaLogs(t *testing.T, entries []mockLogEntry) *http
 		query := r.URL.Query().Get("query")
 		t.Logf("Received query: %s", query)
 
-		descOrder := strings.Contains(query, "desc")
-
-		// Strip pipe operators (like "| sort by (_time)")
-		if pipeIdx := strings.Index(query, " |"); pipeIdx != -1 {
-			query = query[:pipeIdx]
-		}
-
-		// Filter entries first
+		// Filter entries based on query terms
 		var filtered []mockLogEntry
 		for _, entry := range entries {
 			parts := strings.Split(query, " ")
@@ -89,13 +71,6 @@ func createFilteringMockVictoriaLogs(t *testing.T, entries []mockLogEntry) *http
 			}
 			if shouldInclude {
 				filtered = append(filtered, entry)
-			}
-		}
-
-		// Simulate VictoriaLogs returning results in desc order when requested
-		if descOrder {
-			for i, j := 0, len(filtered)-1; i < j; i, j = i+1, j-1 {
-				filtered[i], filtered[j] = filtered[j], filtered[i]
 			}
 		}
 
@@ -889,4 +864,97 @@ func TestStreamLogChunks_FilterWithNegation(t *testing.T) {
 	// Verify the query contains negation
 	r.Contains(capturedQuery, "error")
 	r.Contains(capturedQuery, "-debug")
+}
+
+func TestStreamLogChunks_QueryContract(t *testing.T) {
+	// Verifies that queries sent to VictoriaLogs never contain sort pipes,
+	// and use the limit query parameter for bounded queries. Sort pipes
+	// force VictoriaLogs to buffer and sort all matching entries server-side,
+	// which is extremely slow on large datasets.
+
+	r := require.New(t)
+
+	now := time.Now()
+	entries := []mockLogEntry{
+		{Time: now.Add(-2 * time.Second).Format(time.RFC3339Nano), Msg: "line 1", Stream: "stdout"},
+		{Time: now.Add(-1 * time.Second).Format(time.RFC3339Nano), Msg: "line 2", Stream: "stdout"},
+		{Time: now.Format(time.RFC3339Nano), Msg: "line 3", Stream: "stdout"},
+	}
+
+	var capturedQueries []string
+	var capturedLimits []string
+	var mu sync.Mutex
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		capturedQueries = append(capturedQueries, r.URL.Query().Get("query"))
+		capturedLimits = append(capturedLimits, r.URL.Query().Get("limit"))
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+
+		for _, entry := range entries {
+			data, _ := json.Marshal(entry)
+			w.Write(data)
+			w.Write([]byte("\n"))
+		}
+	}))
+	defer mockServer.Close()
+
+	server, ec, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	app := &core_v1alpha.App{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err := ec.Create(ctx, "test-app", app)
+	r.NoError(err)
+
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	noop := stream.Callback(func(chunk *app_v1alpha.LogChunk) error { return nil })
+
+	t.Run("default query uses limit param not sort pipe", func(t *testing.T) {
+		mu.Lock()
+		capturedQueries = nil
+		capturedLimits = nil
+		mu.Unlock()
+
+		target := &app_v1alpha.LogTarget{}
+		target.SetApp("test-app")
+
+		// No from time, no follow → server applies default limit
+		_, err := client.StreamLogChunks(ctx, target, nil, false, "", noop)
+		r.NoError(err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		r.NotEmpty(capturedQueries)
+		r.NotContains(capturedQueries[0], "sort", "query must not contain sort pipe")
+		r.NotContains(capturedQueries[0], "|", "query must not contain pipe operators")
+		r.Equal("100", capturedLimits[0], "default query should set limit=100")
+	})
+
+	t.Run("time-bounded query has no limit param", func(t *testing.T) {
+		mu.Lock()
+		capturedQueries = nil
+		capturedLimits = nil
+		mu.Unlock()
+
+		target := &app_v1alpha.LogTarget{}
+		target.SetApp("test-app")
+
+		fromTime := standard.ToTimestamp(now.Add(-5 * time.Minute))
+		_, err := client.StreamLogChunks(ctx, target, fromTime, false, "", noop)
+		r.NoError(err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		r.NotEmpty(capturedQueries)
+		r.NotContains(capturedQueries[0], "sort", "query must not contain sort pipe")
+		r.Empty(capturedLimits[0], "time-bounded query should not set limit param")
+	})
 }


### PR DESCRIPTION
`m logs system` on garden was taking ~10 seconds to show 100 lines, scaling linearly with the time window (~16s for `--last 1h`). The culprit was `| sort by (_time)` in the LogsQL query pipe — this forces VictoriaLogs to scan, buffer, and sort *every* matching entry in the time window before it can return anything. For system logs on a busy cluster, that's hundreds of thousands of entries getting sorted just to return 100.

Turns out VictoriaLogs already has a built-in `limit` query parameter that returns the N most recent entries without needing a sort pipe at all. We just weren't using it — instead we had `sort by (_time) desc | limit 100` in the query string, which defeats the optimization entirely.

The fix drops the sort pipes from both `executeStreamQuery` and `executeQuery`, uses the native `limit` param, and accepts VictoriaLogs' ingestion order as-is. For a single-writer server the logs come back approximately chronological anyway, so there's no need to sort client-side either. Tested on garden — default query goes from ~10s to under 1s.