### PR TITLE
Remove unused sidebar_position frontmatter from docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ clean: ## Remove built binaries
 # Code Quality
 #
 
-lint: ## Run golangci-lint
+lint: docs-lint ## Run all linters
 	golangci-lint run ./...
 
 lint-fix: ## Run golangci-lint with auto-fix
@@ -189,6 +189,9 @@ lint-fix: ## Run golangci-lint with auto-fix
 
 lint-pr: ## Run golangci-lint on changes from main
 	golangci-lint run --new-from-rev main ./...
+
+docs-lint: ## Lint docs (no JS toolchain needed)
+	@bash hack/docs-lint.sh
 
 generate-check: ## Verify go generate is up to date
 	@echo "Checking if go generate produces any changes..."
@@ -208,7 +211,7 @@ generate-check: ## Verify go generate is up to date
 	fi
 	@echo "✓ go generate is up to date"
 
-.PHONY: lint lint-fix lint-pr generate-check
+.PHONY: lint lint-fix lint-pr docs-lint generate-check
 
 #
 # Release Packaging

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,8 +83,7 @@ Runs TypeScript type checking without emitting files.
 docs/
 ├── docs/                  # Documentation markdown files
 │   ├── intro.md          # Home page
-│   ├── getting-started/  # Getting started guides
-│   └── cli/              # CLI reference documentation
+│   └── ...               # Feature, reference, and resource pages
 ├── src/
 │   ├── css/              # Custom CSS and theming
 │   ├── components/       # Custom React components
@@ -108,14 +107,9 @@ docs/
 
 ### Adding New Pages
 
-1. Create a new `.md` or `.mdx` file in the appropriate directory under `docs/`
-2. Add frontmatter at the top:
-   ```md
-   ---
-   sidebar_position: 1
-   ---
-   ```
-3. The sidebar will auto-generate based on the file structure
+1. Create a new `.md` or `.mdx` file in `docs/`
+2. Add the page's doc ID to the appropriate section in `sidebars.ts`
+3. Run `make docs-lint` to verify the sidebar and doc files are in sync
 
 ### Styling
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,54 +4,15 @@ This directory contains the Miren documentation site built with [Docusaurus](htt
 
 ## Development Setup
 
-### For Nix Users (Recommended)
-
-If you have Nix installed, the development environment is automatically configured with bun:
+You'll need [bun](https://bun.sh) installed. If you use Nix, `nix develop` from the repo root will set that up for you.
 
 ```bash
-# Enter the Nix development shell (from repo root)
-nix develop
-
-# Navigate to docs directory
 cd docs
-
-# Install dependencies
 bun install
-
-# Start development server
 bun start
 ```
 
 The development server will be available at http://localhost:3333.
-
-### For Non-Nix Users
-
-If you don't use Nix, you'll need to install bun manually:
-
-**Requirements:**
-- Bun 1.0 or later
-
-**Installation:**
-
-1. Install bun from [bun.sh](https://bun.sh):
-   ```bash
-   # Linux/macOS
-   curl -fsSL https://bun.sh/install | bash
-
-   # Windows
-   powershell -c "irm bun.sh/install.ps1 | iex"
-   ```
-
-2. Install dependencies:
-   ```bash
-   cd docs
-   bun install
-   ```
-
-3. Start development server:
-   ```bash
-   bun start
-   ```
 
 ## Available Commands
 

--- a/docs/docs/admin-interface.md
+++ b/docs/docs/admin-interface.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 7
----
 
 # Admin Interface
 

--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 3
----
 
 # App Configuration
 

--- a/docs/docs/app-toml.md
+++ b/docs/docs/app-toml.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 20
 sidebar_label: app.toml
 ---
 

--- a/docs/docs/ci-deploy.md
+++ b/docs/docs/ci-deploy.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 9
----
 
 # CI/CD Deployment
 

--- a/docs/docs/disks.md
+++ b/docs/docs/disks.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 4
----
 
 # Persistent Storage
 

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 5
----
 
 # Firewall Configuration
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 2
----
 
 # Getting Started
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 slug: /
 ---
 

--- a/docs/docs/labs.md
+++ b/docs/docs/labs.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 1
----
 
 # Miren Labs
 

--- a/docs/docs/languages.md
+++ b/docs/docs/languages.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 3
----
 
 # Supported Languages
 

--- a/docs/docs/logs.md
+++ b/docs/docs/logs.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 10
----
 
 # Logs
 

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 9
----
 
 # Observability
 

--- a/docs/docs/route-oidc.md
+++ b/docs/docs/route-oidc.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 8
----
 
 # Route OIDC Authentication
 

--- a/docs/docs/scaling.md
+++ b/docs/docs/scaling.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 5
----
 
 # Application Scaling
 

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 21
 sidebar_label: server.toml
 ---
 

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 6
----
 
 # Services
 

--- a/docs/docs/system-requirements.md
+++ b/docs/docs/system-requirements.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 3
----
 
 # System Requirements
 

--- a/docs/docs/terminology.md
+++ b/docs/docs/terminology.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 4
----
 
 # Terminology
 

--- a/docs/docs/tls.md
+++ b/docs/docs/tls.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 5
----
 
 # TLS Certificates
 

--- a/docs/docs/traffic-routing.md
+++ b/docs/docs/traffic-routing.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 7
----
 
 # Traffic Routing
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 4
----
 
 # Troubleshooting
 

--- a/docs/docs/working-with-miren-cloud.md
+++ b/docs/docs/working-with-miren-cloud.md
@@ -1,6 +1,3 @@
----
-sidebar_position: 3
----
 
 # Working with Miren Cloud
 

--- a/hack/docs-lint.sh
+++ b/hack/docs-lint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+docs_dir="docs/docs"
+sidebars="docs/sidebars.ts"
+errors=0
+
+# 1. No sidebar_position frontmatter (ordering is controlled by sidebars.ts)
+if grep -rl 'sidebar_position' "$docs_dir"/*.md 2>/dev/null; then
+  echo "ERROR: sidebar_position found in the above files."
+  echo "  Sidebar ordering is controlled by sidebars.ts — remove sidebar_position from frontmatter."
+  errors=1
+fi
+
+# 2. Every hand-written doc file must appear in sidebars.ts (and vice versa).
+#    Generated files (commands.md, command/*) are excluded since they come from
+#    command-sidebar.json which is imported separately.
+
+# Doc IDs from the filesystem (filename without .md extension)
+fs_ids=$(ls "$docs_dir"/*.md 2>/dev/null | xargs -I{} basename {} .md | sort)
+
+# Doc IDs referenced as bare strings in sidebars.ts (skip command-sidebar entries)
+sidebar_ids=$(grep -oP "^\s+'(\K[a-z0-9-]+)" "$sidebars" | sort)
+
+orphaned=$(comm -23 <(echo "$fs_ids") <(echo "$sidebar_ids"))
+missing=$(comm -13 <(echo "$fs_ids") <(echo "$sidebar_ids"))
+
+if [ -n "$orphaned" ]; then
+  echo "ERROR: Doc files not listed in sidebars.ts:"
+  echo "$orphaned" | sed 's/^/  /'
+  errors=1
+fi
+
+if [ -n "$missing" ]; then
+  echo "ERROR: Sidebar entries with no matching doc file:"
+  echo "$missing" | sed 's/^/  /'
+  errors=1
+fi
+
+if [ "$errors" -eq 0 ]; then
+  echo "✓ docs lint passed"
+fi
+
+exit "$errors"


### PR DESCRIPTION
## Summary

Our docs sidebar ordering is explicitly defined in `sidebars.ts`, which means the `sidebar_position` frontmatter sprinkled across every doc page was completely ignored by Docusaurus. The values were also inconsistent (duplicate positions, numbering that didn't match the actual order), confirming nobody was maintaining them.

Swept all 22 doc pages to remove `sidebar_position`, then cleaned up the frontmatter blocks that became empty as a result. Files that had other meaningful frontmatter (`slug`, `sidebar_label`) kept theirs intact.

To hold the line, added a `make docs-lint` check (also wired into `make lint`) that fails if `sidebar_position` sneaks back in or if a doc file and its sidebar entry get out of sync. It's pure shell — no JS toolchain needed.

While we were in the README, cleaned up the stale "Adding New Pages" instructions that were still telling people to use `sidebar_position`, and collapsed the dev setup section down from two separate Nix/non-Nix walkthroughs to a simple "get bun, run three commands."