### PR TITLE
Unify CLI cluster resolution so all commands respect per-app state (MIR-832)

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -104,8 +104,9 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 
 // LoadCluster implements per-app cluster pinning. Resolution priority:
 //  1. -C flag (explicit override) — also saves to state
-//  2. Per-app cluster from ~/.config/miren/app-state.toml
-//  3. Global active_cluster from clientconfig (fallback)
+//  2. MIREN_CLUSTER env var
+//  3. Per-app cluster from ~/.config/miren/app-state.toml (handled by ConfigCentric)
+//  4. Global active_cluster from clientconfig (fallback)
 func (a *AppCentric) LoadCluster() (*clientconfig.ClusterConfig, string, error) {
 	// If -C flag was passed, use ConfigCentric's logic and persist the choice.
 	if a.Cluster != "" {
@@ -116,24 +117,7 @@ func (a *AppCentric) LoadCluster() (*clientconfig.ClusterConfig, string, error) 
 		return cc, name, err
 	}
 
-	// Check per-app state.
-	if a.App != "" {
-		state, err := appconfig.LoadAppState(a.App)
-		if err == nil && state != nil && state.Cluster != "" {
-			cfg, err := a.LoadConfig()
-			if err != nil {
-				return nil, "", err
-			}
-
-			cc, err := cfg.GetCluster(state.Cluster)
-			if err == nil && cc != nil {
-				return cc, state.Cluster, nil
-			}
-			// State references an unknown cluster; fall through to global default.
-		}
-	}
-
-	// Fall back to global default.
+	// Delegate to ConfigCentric which now handles per-app state.
 	return a.ConfigCentric.LoadCluster()
 }
 

--- a/cli/commands/app_list.go
+++ b/cli/commands/app_list.go
@@ -26,24 +26,19 @@ func AppList(ctx *Context, opts struct {
 	FormatOptions
 	ConfigCentric
 }) error {
-	cfg, err := opts.LoadConfig()
+	cluster, _, err := opts.LoadCluster()
 	if err != nil {
-		if errors.Is(err, clientconfig.ErrNoConfig) {
+		if errors.Is(err, clientconfig.ErrNoConfig) || errors.Is(err, ErrNoConfig) {
 			ctx.Printf("No cluster configured\n")
 			ctx.Printf("\nUse 'miren cluster add' to add a cluster\n")
 			return nil
 		}
 		return err
 	}
-
-	clusterName := cfg.ActiveCluster()
-	if opts.Cluster != "" {
-		clusterName = opts.Cluster
-	}
-
-	cluster, err := cfg.GetCluster(clusterName)
-	if err != nil {
-		return err
+	if cluster == nil {
+		ctx.Printf("No cluster configured\n")
+		ctx.Printf("\nUse 'miren cluster add' to add a cluster\n")
+		return nil
 	}
 
 	client, err := ctx.RPCClient("entities")

--- a/cli/commands/cluster.go
+++ b/cli/commands/cluster.go
@@ -5,7 +5,6 @@ import (
 	"net"
 
 	"github.com/charmbracelet/lipgloss"
-	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/ui"
 )
@@ -48,14 +47,11 @@ func ClusterList(ctx *Context, opts struct {
 	var rows []ui.Row
 	headers := []string{"", "CLUSTER", "ADDRESS", "IDENTITY"}
 
-	// Determine the effective cluster for the current app context.
+	// Determine the effective cluster for the current context.
 	globalCluster := cfg.ActiveCluster()
-	effectiveCluster := globalCluster
-
-	if ac, _ := appconfig.LoadAppConfig(); ac != nil && ac.Name != "" {
-		if state, _ := appconfig.LoadAppState(ac.Name); state != nil && state.Cluster != "" {
-			effectiveCluster = state.Cluster
-		}
+	_, effectiveCluster, _ := opts.LoadCluster()
+	if effectiveCluster == "" {
+		effectiveCluster = globalCluster
 	}
 
 	err = cfg.IterateClusters(func(name string, ccfg *clientconfig.ClusterConfig) error {

--- a/cli/commands/cluster_current.go
+++ b/cli/commands/cluster_current.go
@@ -1,35 +1,20 @@
 package commands
 
-import (
-	"fmt"
-
-	"miren.dev/runtime/appconfig"
-)
+import "fmt"
 
 func ClusterCurrent(ctx *Context, opts struct {
 	AppCentric
 }) error {
-	state, err := appconfig.LoadAppState(opts.App)
-	if err != nil {
-		return fmt.Errorf("failed to load app state: %w", err)
-	}
-
-	if state != nil && state.Cluster != "" {
-		ctx.Printf("%s\n", state.Cluster)
-		return nil
-	}
-
-	cfg, err := opts.LoadConfig()
+	cc, name, err := opts.LoadCluster()
 	if err != nil {
 		return fmt.Errorf("no cluster configured: %w", err)
 	}
 
-	active := cfg.ActiveCluster()
-	if active == "" {
+	if cc == nil || name == "" {
 		ctx.Printf("No cluster configured\n")
 		return nil
 	}
 
-	ctx.Printf("%s (global default)\n", active)
+	ctx.Printf("%s\n", name)
 	return nil
 }

--- a/cli/commands/cluster_export.go
+++ b/cli/commands/cluster_export.go
@@ -10,25 +10,12 @@ import (
 func ClusterExportAddress(ctx *Context, opts struct {
 	ConfigCentric
 }) error {
-	cfg, err := opts.LoadConfig()
+	cc, name, err := opts.LoadCluster()
 	if err != nil {
 		return err
 	}
-
-	name := opts.Cluster
-	if name == "" {
-		name = cfg.ActiveCluster()
-	}
-	if name == "" {
+	if cc == nil || name == "" {
 		return fmt.Errorf("no cluster specified and no active cluster set; use -C to specify one")
-	}
-
-	cc, err := cfg.GetCluster(name)
-	if err != nil {
-		return fmt.Errorf("cluster %q not found: %w", name, err)
-	}
-	if cc == nil {
-		return fmt.Errorf("cluster %q not found", name)
 	}
 
 	block, _ := pem.Decode([]byte(cc.CACert))

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/clientconfig"
 )
 
@@ -99,6 +100,18 @@ func (c *ConfigCentric) LoadCluster() (*clientconfig.ClusterConfig, string, erro
 		}
 		return cc, name, nil
 	} else {
+		// Check per-app state if we're in an app directory.
+		if ac, _ := appconfig.LoadAppConfig(); ac != nil && ac.Name != "" {
+			state, err := appconfig.LoadAppState(ac.Name)
+			if err == nil && state != nil && state.Cluster != "" {
+				cc, err := cfg.GetCluster(state.Cluster)
+				if err == nil && cc != nil {
+					return cc, state.Cluster, nil
+				}
+				// State references unknown cluster; fall through to global default.
+			}
+		}
+
 		name = cfg.ActiveCluster()
 		if name == "" {
 			return nil, "", nil

--- a/cli/commands/config_test.go
+++ b/cli/commands/config_test.go
@@ -1,9 +1,12 @@
 package commands
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/clientconfig"
 )
 
@@ -97,5 +100,134 @@ func TestLoadClusterEnvVar(t *testing.T) {
 		r.Contains(err.Error(), "unknown-addr:8443")
 		// The fingerprint portion should not appear in the address part of the error
 		r.NotContains(err.Error(), `"unknown-addr:8443;sha1:abc"`)
+	})
+}
+
+// setupAppDir creates a temp directory with .miren/app.toml and changes into it.
+// It also sets HOME so appconfig.SaveAppState/LoadAppState use a temp location.
+// Returns a cleanup function that restores the original working directory and HOME.
+func setupAppDir(t *testing.T, appName string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	// Create .miren/app.toml so LoadAppConfig() finds it
+	mirenDir := filepath.Join(dir, ".miren")
+	require.NoError(t, os.MkdirAll(mirenDir, 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(mirenDir, "app.toml"),
+		[]byte("name = "+`"`+appName+`"`+"\n"),
+		0644,
+	))
+
+	// Set HOME so app state goes to our temp dir
+	t.Setenv("HOME", dir)
+
+	// Change into the app directory
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	return dir
+}
+
+func TestConfigCentricPerAppState(t *testing.T) {
+	t.Run("resolves per-app cluster in app directory", func(t *testing.T) {
+		r := require.New(t)
+		setupAppDir(t, "my-app")
+
+		// Save per-app state pointing to a specific cluster
+		r.NoError(appconfig.SaveAppState("my-app", &appconfig.AppState{Cluster: "app-cluster"}))
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("app-cluster", &clientconfig.ClusterConfig{Hostname: "10.0.0.1:8443"})
+		cfg.SetCluster("global-cluster", &clientconfig.ClusterConfig{Hostname: "10.0.0.2:8443"})
+		r.NoError(cfg.SetActiveCluster("global-cluster"))
+
+		cc := ConfigCentric{cfg: cfg}
+		cluster, name, err := cc.LoadCluster()
+		r.NoError(err)
+		r.Equal("app-cluster", name)
+		r.NotNil(cluster)
+		r.Equal("10.0.0.1:8443", cluster.Hostname)
+	})
+
+	t.Run("falls back to global default without app directory", func(t *testing.T) {
+		r := require.New(t)
+
+		// Use a temp dir without .miren/app.toml
+		dir := t.TempDir()
+		origDir, err := os.Getwd()
+		r.NoError(err)
+		r.NoError(os.Chdir(dir))
+		t.Cleanup(func() { os.Chdir(origDir) })
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("global-cluster", &clientconfig.ClusterConfig{Hostname: "10.0.0.2:8443"})
+		r.NoError(cfg.SetActiveCluster("global-cluster"))
+
+		cc := ConfigCentric{cfg: cfg}
+		cluster, name, err := cc.LoadCluster()
+		r.NoError(err)
+		r.Equal("global-cluster", name)
+		r.NotNil(cluster)
+		r.Equal("10.0.0.2:8443", cluster.Hostname)
+	})
+
+	t.Run("unknown cluster in app state falls through to global", func(t *testing.T) {
+		r := require.New(t)
+		setupAppDir(t, "my-app")
+
+		// Save per-app state with a cluster that doesn't exist in config
+		r.NoError(appconfig.SaveAppState("my-app", &appconfig.AppState{Cluster: "deleted-cluster"}))
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("global-cluster", &clientconfig.ClusterConfig{Hostname: "10.0.0.2:8443"})
+		r.NoError(cfg.SetActiveCluster("global-cluster"))
+
+		cc := ConfigCentric{cfg: cfg}
+		cluster, name, err := cc.LoadCluster()
+		r.NoError(err)
+		r.Equal("global-cluster", name)
+		r.NotNil(cluster)
+	})
+
+	t.Run("-C flag overrides per-app state", func(t *testing.T) {
+		r := require.New(t)
+		setupAppDir(t, "my-app")
+
+		r.NoError(appconfig.SaveAppState("my-app", &appconfig.AppState{Cluster: "app-cluster"}))
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("app-cluster", &clientconfig.ClusterConfig{Hostname: "10.0.0.1:8443"})
+		cfg.SetCluster("flag-cluster", &clientconfig.ClusterConfig{Hostname: "10.0.0.3:8443"})
+
+		cc := ConfigCentric{Cluster: "flag-cluster", cfg: cfg}
+		cluster, name, err := cc.LoadCluster()
+		r.NoError(err)
+		r.Equal("flag-cluster", name)
+		r.NotNil(cluster)
+		r.Equal("10.0.0.3:8443", cluster.Hostname)
+	})
+
+	t.Run("MIREN_CLUSTER env overrides per-app state", func(t *testing.T) {
+		r := require.New(t)
+		setupAppDir(t, "my-app")
+
+		r.NoError(appconfig.SaveAppState("my-app", &appconfig.AppState{Cluster: "app-cluster"}))
+
+		cfg := clientconfig.NewConfig()
+		cfg.SetCluster("app-cluster", &clientconfig.ClusterConfig{Hostname: "10.0.0.1:8443"})
+		cfg.SetCluster("env-cluster", &clientconfig.ClusterConfig{Hostname: "10.0.0.4:8443"})
+
+		cc := ConfigCentric{cfg: cfg}
+		t.Setenv("MIREN_CLUSTER", "env-cluster")
+
+		cluster, name, err := cc.LoadCluster()
+		r.NoError(err)
+		r.Equal("env-cluster", name)
+		r.NotNil(cluster)
+		r.Equal("10.0.0.4:8443", cluster.Hostname)
 	})
 }

--- a/cli/commands/doctor.go
+++ b/cli/commands/doctor.go
@@ -154,11 +154,11 @@ func Doctor(ctx *Context, opts struct {
 	}
 
 	// Configuration info
+	clusterCount := 0
 	if cfg == nil || errors.Is(err, clientconfig.ErrNoConfig) {
 		configuration.ok = false
 		configuration.message = "no clusters configured"
 	} else {
-		clusterCount := 0
 		cfg.IterateClusters(func(_ string, _ *clientconfig.ClusterConfig) error {
 			clusterCount++
 			return nil
@@ -169,15 +169,17 @@ func Doctor(ctx *Context, opts struct {
 			configuration.message = "no clusters configured"
 		} else {
 			configuration.ok = true
-			configuration.message = fmt.Sprintf("%s (%d clusters)", cfg.ActiveCluster(), clusterCount)
+			configuration.message = fmt.Sprintf("%d clusters configured", clusterCount)
 		}
 	}
 
 	// Server and auth info (only if configured)
 	if configuration.ok && cfg != nil {
-		clusterName := cfg.ActiveCluster()
-		cluster, err := cfg.GetCluster(clusterName)
-		if err == nil && cluster != nil {
+		cluster, clusterName, _ := opts.LoadCluster()
+		if clusterName != "" {
+			configuration.message = fmt.Sprintf("%s (%d clusters)", clusterName, clusterCount)
+		}
+		if cluster != nil {
 			// Try to connect
 			client, err := ctx.RPCClient("entities")
 			if err == nil {

--- a/cli/commands/doctor_auth.go
+++ b/cli/commands/doctor_auth.go
@@ -23,14 +23,13 @@ func DoctorAuth(ctx *Context, opts struct {
 		return err
 	}
 
-	clusterName := cfg.ActiveCluster()
-	if opts.Cluster != "" {
-		clusterName = opts.Cluster
-	}
-
-	cluster, err := cfg.GetCluster(clusterName)
+	cluster, clusterName, err := opts.LoadCluster()
 	if err != nil {
 		return err
+	}
+	if cluster == nil {
+		ctx.Printf("No cluster configured\n")
+		return nil
 	}
 
 	hostname := cluster.Hostname

--- a/cli/commands/doctor_server.go
+++ b/cli/commands/doctor_server.go
@@ -17,9 +17,9 @@ import (
 func DoctorServer(ctx *Context, opts struct {
 	ConfigCentric
 }) error {
-	cfg, err := opts.LoadConfig()
+	cluster, clusterName, err := opts.LoadCluster()
 	if err != nil {
-		if errors.Is(err, clientconfig.ErrNoConfig) {
+		if errors.Is(err, clientconfig.ErrNoConfig) || errors.Is(err, ErrNoConfig) {
 			ctx.Printf("No clusters configured\n")
 			ctx.Printf("\n%s\n", infoLabel.Render("To add a cluster:"))
 			ctx.Printf("  %s\n", infoGray.Render("miren cluster add"))
@@ -27,13 +27,12 @@ func DoctorServer(ctx *Context, opts struct {
 		}
 		return err
 	}
-
-	clusterName := cfg.ActiveCluster()
-	if opts.Cluster != "" {
-		clusterName = opts.Cluster
+	if cluster == nil {
+		ctx.Printf("No clusters configured\n")
+		return nil
 	}
 
-	cluster, err := cfg.GetCluster(clusterName)
+	cfg, err := opts.LoadConfig()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When a user runs `cluster switch` in an app directory, it saves the chosen cluster to both the global config and per-app state. Commands using `AppCentric` (like `cluster current`, `deploy`) would read that per-app state and target the right cluster. But commands using `ConfigCentric` (like `route list`, `sandbox list`, `app list`) skipped per-app state entirely and fell back to the global `active_cluster`. So you could see `cluster current` report "miren01" while `route list` silently hits a completely different cluster.

The fix teaches `ConfigCentric.LoadCluster()` itself to check per-app state when running in an app directory, slotted in between the explicit overrides (-C flag, MIREN_CLUSTER env) and the global fallback. This is the minimal change that fixes the inconsistency without restructuring the command hierarchy. With the logic centralized, `AppCentric.LoadCluster()` drops its parallel implementation and just delegates, and `cluster current` replaces its bespoke resolution with a `LoadCluster()` call.

A sweep of the rest of the CLI commands turned up several more that were doing their own ad-hoc resolution instead of going through `LoadCluster()` — `app list`, `cluster list`, `cluster export-address`, `doctor`, and `doctor auth` all got converted. The only intentional exception is `deploy`'s interactive "add a cluster" recovery path, which correctly reads the just-added cluster directly.

Note: `doctor` could use a deeper rework beyond this scope — it's doing a lot of manual wiring that doesn't quite fit the `LoadCluster()` model cleanly. Filing a follow-up for that.

Closes MIR-832