### PR TITLE
Add consistent --format json support to CLI commands (MIR-662)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,18 @@ To get started with iso:
 - RPC interfaces → implementations: `pkg/rpc/cmd/rpcgen`
 - Generated files have `.gen.go` suffix
 
+### CLI JSON Output Pattern (FormatOptions)
+
+Commands that output lists or tables should support `--format json` using the `FormatOptions` pattern:
+
+1. Embed `FormatOptions` in the opts struct
+2. Check `opts.IsJSON()` before table rendering
+3. Define a command-specific JSON struct with `json:"snake_case"` tags (don't serialize internal types directly)
+4. Build a slice of the JSON structs and return `PrintJSON(items)`
+5. Use raw/machine-readable values in JSON (e.g., RFC3339 timestamps, numeric percentages) rather than human-formatted strings
+
+See `cli/commands/route_list.go` for a reference implementation.
+
 ### Code Style & Formatting
 
 - **ALWAYS run `make lint` before committing** - This runs golangci-lint on the entire codebase

--- a/cli/commands/debug_netdb.go
+++ b/cli/commands/debug_netdb.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/netip"
 	"slices"
+	"time"
 
 	"miren.dev/runtime/api/debug/debug_v1alpha"
 	"miren.dev/runtime/pkg/rpc/standard"
@@ -12,6 +13,7 @@ import (
 
 // DebugNetDBList lists all IP leases from the netdb
 func DebugNetDBList(ctx *Context, opts struct {
+	FormatOptions
 	ConfigCentric
 	Subnet   string `short:"s" long:"subnet" description:"Filter by subnet CIDR"`
 	Reserved bool   `short:"r" long:"reserved" description:"Show only reserved (in-use) IPs"`
@@ -41,6 +43,38 @@ func DebugNetDBList(ctx *Context, opts struct {
 		addrB, _ := netip.ParseAddr(b.Ip())
 		return addrA.Compare(addrB)
 	})
+
+	if opts.IsJSON() {
+		type LeaseJSON struct {
+			IP         string `json:"ip"`
+			Subnet     string `json:"subnet"`
+			Status     string `json:"status"`
+			SandboxID  string `json:"sandbox_id,omitempty"`
+			ReleasedAt string `json:"released_at,omitempty"`
+		}
+
+		items := make([]LeaseJSON, len(leases))
+		for i, lease := range leases {
+			status := "released"
+			if lease.Reserved() {
+				status = "reserved"
+			}
+
+			item := LeaseJSON{
+				IP:     lease.Ip(),
+				Subnet: lease.Subnet(),
+				Status: status,
+			}
+			if lease.HasSandboxId() {
+				item.SandboxID = lease.SandboxId()
+			}
+			if lease.HasReleasedAt() {
+				item.ReleasedAt = standard.FromTimestamp(lease.ReleasedAt()).Format(time.RFC3339)
+			}
+			items[i] = item
+		}
+		return PrintJSON(items)
+	}
 
 	headers := []string{"IP", "SUBNET", "STATUS", "SANDBOX", "RELEASED"}
 	rows := make([]ui.Row, len(leases))
@@ -78,6 +112,7 @@ func DebugNetDBList(ctx *Context, opts struct {
 
 // DebugNetDBStatus shows subnet utilization stats
 func DebugNetDBStatus(ctx *Context, opts struct {
+	FormatOptions
 	ConfigCentric
 }) error {
 	client, err := ctx.RPCClient("dev.miren.runtime/debug-netdb")
@@ -96,6 +131,34 @@ func DebugNetDBStatus(ctx *Context, opts struct {
 	if len(subnets) == 0 {
 		ctx.Info("No subnets found")
 		return nil
+	}
+
+	if opts.IsJSON() {
+		type SubnetJSON struct {
+			Subnet       string  `json:"subnet"`
+			Capacity     int32   `json:"capacity"`
+			Reserved     int32   `json:"reserved"`
+			Released     int32   `json:"released"`
+			UsagePercent float64 `json:"usage_percent"`
+		}
+
+		items := make([]SubnetJSON, len(subnets))
+		for i, subnet := range subnets {
+			capacity := subnet.Capacity()
+			reserved := subnet.Reserved()
+			usage := float64(0)
+			if capacity > 0 {
+				usage = float64(reserved) / float64(capacity) * 100
+			}
+			items[i] = SubnetJSON{
+				Subnet:       subnet.Subnet(),
+				Capacity:     capacity,
+				Reserved:     reserved,
+				Released:     subnet.Released(),
+				UsagePercent: usage,
+			}
+		}
+		return PrintJSON(items)
 	}
 
 	headers := []string{"SUBNET", "CAPACITY", "RESERVED", "RELEASED", "USAGE"}

--- a/cli/commands/doctor_config.go
+++ b/cli/commands/doctor_config.go
@@ -27,6 +27,7 @@ type clusterInfo struct {
 
 // DoctorConfig shows configuration file information
 func DoctorConfig(ctx *Context, opts struct {
+	FormatOptions
 	ConfigCentric
 }) error {
 	cfg, err := opts.LoadConfig()
@@ -62,6 +63,29 @@ func DoctorConfig(ctx *Context, opts struct {
 		}
 		return nil
 	})
+
+	if opts.IsJSON() {
+		type ClusterJSON struct {
+			Name    string `json:"name"`
+			Address string `json:"address"`
+			Source  string `json:"source"`
+			Active  bool   `json:"active"`
+			Local   bool   `json:"local"`
+		}
+
+		allClusters := append(localClusters, remoteClusters...)
+		items := make([]ClusterJSON, len(allClusters))
+		for i, c := range allClusters {
+			items[i] = ClusterJSON{
+				Name:    c.name,
+				Address: c.cluster.Hostname,
+				Source:  c.source,
+				Active:  c.name == activeCluster,
+				Local:   isLocalCluster(c.cluster.Hostname),
+			}
+		}
+		return PrintJSON(items)
+	}
 
 	// Shorten paths for display
 	homeDir, _ := os.UserHomeDir()

--- a/cli/commands/format.go
+++ b/cli/commands/format.go
@@ -9,7 +9,7 @@ import (
 
 // FormatOptions provides common output formatting options
 type FormatOptions struct {
-	Format string `long:"format" description:"Output format (table, json)" default:"table"`
+	Format string `long:"format" description:"Output format (text, json)" default:"text"`
 }
 
 // IsJSON returns true if JSON format is selected (case-insensitive)

--- a/cli/commands/format.go
+++ b/cli/commands/format.go
@@ -10,11 +10,12 @@ import (
 // FormatOptions provides common output formatting options
 type FormatOptions struct {
 	Format string `long:"format" description:"Output format (text, json)" default:"text"`
+	JSON   bool   `long:"json" description:"Shorthand for --format json"`
 }
 
 // IsJSON returns true if JSON format is selected (case-insensitive)
 func (f *FormatOptions) IsJSON() bool {
-	return strings.EqualFold(f.Format, "json")
+	return f.JSON || strings.EqualFold(f.Format, "json")
 }
 
 // PrintJSON prints data as formatted JSON to stdout

--- a/cli/commands/whoami.go
+++ b/cli/commands/whoami.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -12,8 +11,8 @@ import (
 
 // Whoami displays information about the current authenticated user
 func Whoami(ctx *Context, opts struct {
+	FormatOptions
 	ConfigCentric
-	JSON bool `long:"json" description:"Output as JSON"`
 }) error {
 	// Check if we have a configured cluster
 	if ctx.ClusterConfig == nil {
@@ -112,10 +111,8 @@ func Whoami(ctx *Context, opts struct {
 	}
 
 	// Output results
-	if opts.JSON {
-		encoder := json.NewEncoder(ctx.Stdout)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(output)
+	if opts.IsJSON() {
+		return PrintJSON(output)
 	}
 
 	// Human-readable output


### PR DESCRIPTION
## Summary

- Add `--format json` support to `debug netdb list`, `debug netdb status`, and `doctor config` commands using the established `FormatOptions` pattern
- Change `FormatOptions` default from `"table"` to `"text"` since not all commands using it render tables
- Add `--json` as a shorthand for `--format json` on all commands that embed `FormatOptions`
- Migrate `whoami` from its own `--json` flag to use `FormatOptions` for consistency
- Document the `FormatOptions` pattern in CLAUDE.md for future CLI commands

## Test plan

- [x] `go vet ./cli/commands/` passes
- [x] `make lint` passes with 0 issues
- [x] Manual: `m debug netdb list --format json` / `m debug netdb list --json`
- [x] Manual: `m debug netdb status --json`
- [x] Manual: `m doctor config --json`
- [x] Manual: `m whoami --json` (still works after migration)