### PR TITLE
Fix delta deploy failure when cached and changed files share directories

### DIFF
--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -416,7 +416,7 @@ func TarFS(r io.Reader, dir string) (fsutil.FS, error) {
 
 		path := filepath.Join(dir, th.Name)
 		if th.Typeflag == tar.TypeDir {
-			if err := os.Mkdir(path, 0755); err != nil {
+			if err := os.Mkdir(path, 0755); err != nil && !os.IsExist(err) {
 				return nil, err
 			}
 		}

--- a/pkg/tarx/tarx_test.go
+++ b/pkg/tarx/tarx_test.go
@@ -2,6 +2,7 @@ package tarx
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"io"
 	"os"
@@ -505,6 +506,43 @@ func TestMakeTarOnlyIncludesDirectoriesWithAcceptedFiles(t *testing.T) {
 		entries := extractTarEntries(t, reader)
 		require.ElementsMatch(t, []string{"deep", "deep/a", "deep/a/b", "deep/a/b/file.go"}, entries)
 	})
+}
+
+func TestTarFS_PreExistingDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-create directories that also appear in the tar, simulating the
+	// delta deploy case where stageMatchingFiles already created them.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "db", "migrations"), 0755))
+
+	// Build a gzipped tar containing the same directory entries plus a file.
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "db/", Typeflag: tar.TypeDir, Mode: 0755}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "db/migrations/", Typeflag: tar.TypeDir, Mode: 0755}))
+
+	content := []byte("CREATE TABLE test;")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "db/migrations/001_init.sql",
+		Typeflag: tar.TypeReg,
+		Mode:     0644,
+		Size:     int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	// TarFS should succeed despite the directories already existing.
+	_, err = TarFS(&buf, dir)
+	require.NoError(t, err, "TarFS should tolerate pre-existing directories")
+
+	got, err := os.ReadFile(filepath.Join(dir, "db", "migrations", "001_init.sql"))
+	require.NoError(t, err)
+	require.Equal(t, string(content), string(got))
 }
 
 func TestMakeTarWithIncludePatterns(t *testing.T) {


### PR DESCRIPTION
We hit this in prod deploying cloud to a cluster running v0.6.0 — the deploy failed with `error extracting changed files: mkdir /tmp/buildkit-3500590234/db: file exists`. The workaround was to SSH in and nuke the source code cache, which forced a full upload instead of a delta.

The issue is a collision between the two phases of a delta deploy. `PrepareUpload` stages cached files into a temp directory, creating parent directories as needed with `os.MkdirAll`. Then `BuildFromPrepared` extracts the changed-files tar into that same directory using `TarFS`, which calls bare `os.Mkdir` — no tolerance for directories that already exist. If any directory appears in both the cached and changed file sets (like `db/` in this case), boom.

One-line fix: add an `os.IsExist` check so `TarFS` skips directory entries that are already present, just like `extractFilesFromLayer` already does. Added a test that reproduces the exact scenario.