### PR TITLE
Add simple disk undelete with soft-delete and background GC

### DIFF
--- a/blackbox/disk_undelete_test.go
+++ b/blackbox/disk_undelete_test.go
@@ -1,0 +1,227 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+func TestDiskUndelete(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	diskName := harness.UniqueAppName(t, "undel-disk")
+
+	// Step 1: Create a test disk
+	t.Log("Creating test disk...")
+	r := m.MustRun("debug", "disk", "create", "-n", diskName, "-s", "1")
+	r.RequireContains(t, diskName)
+
+	// Step 2: Wait for disk to be provisioned
+	t.Log("Waiting for disk to be provisioned...")
+	harness.Poll(t, "disk provisioned", 60*time.Second, 2*time.Second,
+		func() (bool, string) {
+			r := m.Run("debug", "disk", "list")
+			if !r.Success() {
+				return false, "debug disk list failed"
+			}
+			if r.OutputContains(diskName) && r.OutputContains("provisioned") {
+				return true, ""
+			}
+			return false, "disk not yet provisioned"
+		},
+	)
+
+	// Step 3: Get the disk ID so we can delete it
+	r = m.MustRun("debug", "disk", "list")
+	diskID := extractDiskID(t, r, diskName)
+	t.Logf("Disk ID: %s", diskID)
+
+	// Step 4: Delete the disk
+	t.Log("Deleting disk...")
+	m.MustRun("debug", "disk", "delete", "-i", diskID)
+
+	// Step 5: Wait for the disk entity to be fully removed by the controller
+	t.Log("Waiting for disk deletion to complete...")
+	harness.Poll(t, "disk deleted", 60*time.Second, 2*time.Second,
+		func() (bool, string) {
+			r := m.Run("debug", "disk", "list")
+			if !r.Success() {
+				return false, "debug disk list failed"
+			}
+			if !r.OutputContains(diskID) {
+				return true, ""
+			}
+			return false, "disk entity still exists"
+		},
+	)
+
+	// Step 6: Verify the disk appears in list-deleted
+	// These commands need sudo because /var/lib/miren/disk-data is owned by root
+	t.Log("Checking list-deleted...")
+	r = m.RunCmd("sudo", "m", "disk", "list-deleted")
+	r.RequireSuccess(t)
+	r.RequireContains(t, diskName)
+
+	// Step 7: Undelete the disk
+	t.Log("Undeleting disk...")
+	r = m.RunCmd("sudo", "m", "disk", "undelete", "-n", diskName)
+	r.RequireSuccess(t)
+	r.RequireContains(t, "Disk restored successfully")
+
+	// Step 8: Verify the disk is back and provisioned
+	t.Log("Verifying restored disk...")
+	harness.Poll(t, "disk restored", 30*time.Second, 2*time.Second,
+		func() (bool, string) {
+			r := m.Run("debug", "disk", "list")
+			if !r.Success() {
+				return false, "debug disk list failed"
+			}
+			if r.OutputContains(diskName) && r.OutputContains("provisioned") {
+				return true, ""
+			}
+			return false, "restored disk not yet provisioned"
+		},
+	)
+
+	// Step 9: Verify it's no longer in list-deleted
+	r = m.RunCmd("sudo", "m", "disk", "list-deleted")
+	if r.OutputContains(diskName) {
+		t.Error("disk should no longer appear in list-deleted after undelete")
+	}
+
+	// Step 10: Verify the restored disk can be leased
+	t.Log("Creating lease on restored disk...")
+	r = m.MustRun("debug", "disk", "list")
+	restoredID := extractDiskID(t, r, diskName)
+
+	r = m.MustRun("debug", "disk", "lease", "-d", restoredID)
+	r.RequireContains(t, "Disk lease created successfully")
+	leaseID := extractLeaseID(t, r)
+	t.Logf("Lease ID: %s", leaseID)
+
+	// Wait for lease to become bound
+	t.Log("Waiting for lease to bind...")
+	harness.Poll(t, "lease bound", 60*time.Second, 2*time.Second,
+		func() (bool, string) {
+			r := m.Run("debug", "disk", "lease-status", "-i", leaseID)
+			if !r.Success() {
+				return false, "lease-status failed"
+			}
+			if r.OutputContains("bound") {
+				return true, ""
+			}
+			if r.OutputContains("failed") {
+				return false, "lease failed"
+			}
+			return false, "lease not yet bound"
+		},
+	)
+
+	// Step 11: Verify the disk is actually mounted
+	t.Log("Verifying disk is mounted...")
+	r = m.RunCmd("sudo", "m", "debug", "disk", "mounts")
+	r.RequireSuccess(t)
+	// The mount output shows loop devices under /var/lib/miren/disks/<volume-id>
+	// Extract the volume ID from the restored disk
+	r2 := m.MustRun("debug", "disk", "list")
+	volID := extractVolumeID(t, r2, diskName)
+	if !r.OutputContains(volID) {
+		t.Errorf("expected disk mount for volume %s, got:\n%s", volID, r.Stdout+r.Stderr)
+	}
+
+	// Cleanup: release the lease, then delete the disk
+	t.Log("Cleaning up...")
+	m.Run("debug", "disk", "lease-release", "-i", leaseID)
+	// Wait briefly for release to process before deleting
+	harness.Poll(t, "lease released", 30*time.Second, 2*time.Second,
+		func() (bool, string) {
+			r := m.Run("debug", "disk", "lease-list", "-d", restoredID)
+			if !r.Success() {
+				return true, "" // list failed, probably no leases
+			}
+			if !r.OutputContains("bound") {
+				return true, ""
+			}
+			return false, "lease still bound"
+		},
+	)
+	m.Run("debug", "disk", "delete", "-i", restoredID)
+}
+
+// extractVolumeID parses the debug disk list output to find the Volume ID for a given disk name.
+func extractVolumeID(t *testing.T, r *harness.Result, diskName string) string {
+	t.Helper()
+
+	output := r.Stdout + r.Stderr
+	lines := strings.Split(output, "\n")
+	// Find the disk by name, then look for the Volume ID line after it
+	inDisk := false
+	for _, line := range lines {
+		if strings.Contains(line, "Name:") && strings.Contains(line, diskName) {
+			inDisk = true
+			continue
+		}
+		if inDisk && strings.Contains(line, "Volume ID:") {
+			_, after, ok := strings.Cut(line, "Volume ID:")
+			if ok {
+				return strings.TrimSpace(after)
+			}
+		}
+		// Next disk entry starts with "ID:"
+		if inDisk && strings.Contains(line, "ID:") {
+			break
+		}
+	}
+	t.Fatalf("could not find Volume ID for disk %q in output:\n%s", diskName, output)
+	return ""
+}
+
+// extractLeaseID parses the debug disk lease output to find the lease ID.
+// The output contains: "Lease ID: disk_lease/disk-lease-xxx"
+func extractLeaseID(t *testing.T, r *harness.Result) string {
+	t.Helper()
+
+	output := r.Stdout + r.Stderr
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "Lease ID:") {
+			_, after, ok := strings.Cut(line, "Lease ID:")
+			if ok {
+				return strings.TrimSpace(after)
+			}
+		}
+	}
+	t.Fatalf("could not find Lease ID in output:\n%s", output)
+	return ""
+}
+
+// extractDiskID parses the debug disk list output to find the ID for a given disk name.
+// The output format is:
+//
+//	ID: disk/disk-xxx
+//	  Name: my-disk
+func extractDiskID(t *testing.T, r *harness.Result, diskName string) string {
+	t.Helper()
+
+	output := r.Stdout + r.Stderr
+	lines := strings.Split(output, "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "Name:") && strings.Contains(line, diskName) {
+			if i > 0 {
+				idLine := lines[i-1]
+				if strings.Contains(idLine, "ID:") {
+					_, after, ok := strings.Cut(idLine, "ID:")
+					if ok {
+						return strings.TrimSpace(after)
+					}
+				}
+			}
+		}
+	}
+	t.Fatalf("could not find disk ID for %q in output:\n%s", diskName, output)
+	return ""
+}

--- a/blackbox/disk_undelete_test.go
+++ b/blackbox/disk_undelete_test.go
@@ -90,6 +90,7 @@ func TestDiskUndelete(t *testing.T) {
 
 	// Step 9: Verify it's no longer in list-deleted
 	r = m.RunCmd("sudo", "m", "disk", "list-deleted")
+	r.RequireSuccess(t)
 	if r.OutputContains(diskName) {
 		t.Error("disk should no longer appear in list-deleted after undelete")
 	}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -813,6 +813,8 @@ Warning: These commands are intended for advanced users and developers. They may
 	// Disk commands
 	d.Dispatch("disk backup", Infer("disk backup", "Backup a disk to a snapshot file", DiskBackup))
 	d.Dispatch("disk restore", Infer("disk restore", "Restore a disk from a snapshot file", DiskRestore))
+	d.Dispatch("disk undelete", Infer("disk undelete", "Restore a recently deleted disk", DiskUndelete))
+	d.Dispatch("disk list-deleted", Infer("disk list-deleted", "List deleted disks available for recovery", DiskListDeleted))
 
 	// Debug disk commands
 	d.Dispatch("debug disk", Section("debug disk", "Disk entity debug commands", "", WithSectionDescription(diskSectionDescription)))

--- a/cli/commands/disk_list_deleted.go
+++ b/cli/commands/disk_list_deleted.go
@@ -12,6 +12,7 @@ import (
 // DiskListDeleted lists disks that have been soft-deleted and are available
 // for recovery via disk undelete.
 func DiskListDeleted(ctx *Context, opts struct {
+	FormatOptions
 	ConfigCentric
 	DataPath string `long:"data-path" description:"Path to miren data directory" default:"/var/lib/miren"`
 }) error {
@@ -25,6 +26,37 @@ func DiskListDeleted(ctx *Context, opts struct {
 		return fmt.Errorf("listing deleted volumes: %w", err)
 	}
 
+	retentionDays := diskio.DefaultDeletedVolumeGCConfig().RetentionDays
+
+	if opts.IsJSON() {
+		type deletedDiskJSON struct {
+			DiskName      string `json:"disk_name"`
+			VolumeID      string `json:"volume_id"`
+			SizeGB        int64  `json:"size_gb"`
+			Filesystem    string `json:"filesystem"`
+			DeletedAt     string `json:"deleted_at"`
+			ExpiresAt     string `json:"expires_at"`
+			RetentionDays int    `json:"retention_days"`
+		}
+
+		var items []deletedDiskJSON
+		for _, e := range entries {
+			meta := e.Metadata
+			expiresAt := meta.DeletedAt.Add(time.Duration(retentionDays) * 24 * time.Hour)
+			items = append(items, deletedDiskJSON{
+				DiskName:      meta.DiskName,
+				VolumeID:      meta.VolumeID,
+				SizeGB:        meta.SizeGb,
+				Filesystem:    meta.Filesystem,
+				DeletedAt:     meta.DeletedAt.Format(time.RFC3339),
+				ExpiresAt:     expiresAt.Format(time.RFC3339),
+				RetentionDays: retentionDays,
+			})
+		}
+
+		return PrintJSON(items)
+	}
+
 	if len(entries) == 0 {
 		ctx.Info("No deleted disks found")
 		return nil
@@ -32,8 +64,6 @@ func DiskListDeleted(ctx *Context, opts struct {
 
 	ctx.Info("Deleted disks available for recovery:")
 	ctx.Info("")
-
-	retentionDays := diskio.DefaultDeletedVolumeGCConfig().RetentionDays
 
 	for _, e := range entries {
 		meta := e.Metadata

--- a/cli/commands/disk_list_deleted.go
+++ b/cli/commands/disk_list_deleted.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"miren.dev/runtime/components/diskio"
+)
+
+// DiskListDeleted lists disks that have been soft-deleted and are available
+// for recovery via disk undelete.
+func DiskListDeleted(ctx *Context, opts struct {
+	ConfigCentric
+	DataPath string `long:"data-path" description:"Path to miren data directory" default:"/var/lib/miren"`
+}) error {
+	diskDataPath := filepath.Join(opts.DataPath, "disk-data")
+	if _, err := os.Stat(diskDataPath); err != nil {
+		return fmt.Errorf("data path %s not found — this command must be run on the server", diskDataPath)
+	}
+
+	entries, err := diskio.ListDeletedVolumes(diskDataPath)
+	if err != nil {
+		return fmt.Errorf("listing deleted volumes: %w", err)
+	}
+
+	if len(entries) == 0 {
+		ctx.Info("No deleted disks found")
+		return nil
+	}
+
+	ctx.Info("Deleted disks available for recovery:")
+	ctx.Info("")
+
+	retentionDays := diskio.DefaultDeletedVolumeGCConfig().RetentionDays
+
+	for _, e := range entries {
+		meta := e.Metadata
+		age := time.Since(meta.DeletedAt)
+		remaining := time.Duration(retentionDays)*24*time.Hour - age
+
+		ctx.Info("Name: %s", meta.DiskName)
+		ctx.Info("  Volume ID:  %s", meta.VolumeID)
+		ctx.Info("  Size:       %d GB", meta.SizeGb)
+		ctx.Info("  Filesystem: %s", meta.Filesystem)
+		ctx.Info("  Deleted:    %s (%s ago)", meta.DeletedAt.Format(time.RFC3339), age.Truncate(time.Minute))
+		if remaining > 0 {
+			ctx.Info("  Expires in: %s", remaining.Truncate(time.Minute))
+		} else {
+			ctx.Info("  Expires in: imminent (past retention period)")
+		}
+		ctx.Info("")
+	}
+
+	ctx.Info("To restore: miren disk undelete --name <disk-name>")
+
+	return nil
+}

--- a/cli/commands/disk_undelete.go
+++ b/cli/commands/disk_undelete.go
@@ -1,0 +1,202 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/components/diskio"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/idgen"
+)
+
+// DiskUndelete restores a recently deleted disk from the soft-delete holding area.
+func DiskUndelete(ctx *Context, opts struct {
+	ConfigCentric
+	Name     string `short:"n" long:"name" description:"Disk name to undelete" required:"true"`
+	VolumeID string `short:"V" long:"volume-id" description:"Volume ID to restore (when multiple deleted disks share a name)"`
+	DataPath string `long:"data-path" description:"Path to miren data directory" default:"/var/lib/miren"`
+}) error {
+	diskDataPath := filepath.Join(opts.DataPath, "disk-data")
+	if _, err := os.Stat(diskDataPath); err != nil {
+		return fmt.Errorf("data path %s not found — disk undelete must be run on the server", diskDataPath)
+	}
+
+	entries, err := diskio.ListDeletedVolumes(diskDataPath)
+	if err != nil {
+		return fmt.Errorf("listing deleted volumes: %w", err)
+	}
+
+	// Filter by name
+	var matches []diskio.DeletedVolumeEntry
+	for _, e := range entries {
+		if e.Metadata.DiskName == opts.Name {
+			if opts.VolumeID == "" || e.Metadata.VolumeID == opts.VolumeID {
+				matches = append(matches, e)
+			}
+		}
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("no deleted disk found with name %q", opts.Name)
+	}
+
+	if len(matches) > 1 {
+		ctx.Info("Multiple deleted disks found with name %q:", opts.Name)
+		for _, m := range matches {
+			age := time.Since(m.Metadata.DeletedAt).Truncate(time.Minute)
+			ctx.Info("  Volume ID: %s  (deleted %s ago, %d GB, %s)",
+				m.Metadata.VolumeID, age, m.Metadata.SizeGb, m.Metadata.Filesystem)
+		}
+		return fmt.Errorf("specify --volume-id to select which disk to restore")
+	}
+
+	entry := matches[0]
+	meta := entry.Metadata
+
+	ctx.Info("Restoring deleted disk:")
+	ctx.Info("  Name:       %s", meta.DiskName)
+	ctx.Info("  Size:       %d GB", meta.SizeGb)
+	ctx.Info("  Filesystem: %s", meta.Filesystem)
+	ctx.Info("  Deleted:    %s", meta.DeletedAt.Format(time.RFC3339))
+
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+	ec := entityserver.NewClient(ctx.Log, eac)
+	resolver := newEntityDiskResolver(eac, ec)
+
+	// Check if a disk with this name already exists
+	if _, err := resolver.FindDisk(context.Background(), meta.DiskName); err == nil {
+		return fmt.Errorf("a disk named %q already exists — rename or delete it before restoring", meta.DiskName)
+	}
+
+	// Normalize filesystem
+	filesystem := strings.TrimPrefix(strings.ToLower(meta.Filesystem), "filesystem.")
+
+	var fs storage_v1alpha.DiskFilesystem
+	switch filesystem {
+	case "ext4":
+		fs = storage_v1alpha.EXT4
+	case "xfs":
+		fs = storage_v1alpha.XFS
+	case "btrfs":
+		fs = storage_v1alpha.BTRFS
+	default:
+		fs = storage_v1alpha.EXT4
+	}
+
+	// Create the disk entity in RESTORING state
+	diskId := idgen.GenNS("disk")
+	disk := &storage_v1alpha.Disk{
+		Name:       meta.DiskName,
+		SizeGb:     meta.SizeGb,
+		Filesystem: fs,
+		Status:     storage_v1alpha.RESTORING,
+	}
+
+	diskEntityId, err := ec.Create(context.Background(), diskId, disk)
+	if err != nil {
+		return fmt.Errorf("creating disk entity: %w", err)
+	}
+
+	ctx.Info("Created disk entity: %s", diskEntityId)
+
+	// Move the volume directory back
+	volId := meta.VolumeID
+	destPath := filepath.Join(diskDataPath, "volumes", volId)
+
+	if err := os.Rename(entry.Path, destPath); err != nil {
+		// Clean up the disk entity we just created
+		if _, derr := eac.Delete(context.Background(), string(diskEntityId)); derr != nil {
+			ctx.Warn("Failed to clean up disk entity: %v", derr)
+		}
+		return fmt.Errorf("moving volume back to %s: %w", destPath, err)
+	}
+
+	// Remove metadata.json from the restored volume directory
+	metadataPath := filepath.Join(destPath, "metadata.json")
+	os.Remove(metadataPath)
+
+	// Find the node ID
+	nodeId, err := resolver.findNodeId(context.Background())
+	if err != nil {
+		ctx.Warn("Failed to find node ID, using stored value: %v", err)
+		nodeId = entity.Id(meta.NodeID)
+	}
+
+	imagePath := filepath.Join(destPath, "disk.img")
+
+	// Verify the disk image actually exists before creating entities
+	if _, err := os.Stat(imagePath); err != nil {
+		// Move the directory back to deleted-volumes so GC can handle it
+		if rerr := os.Rename(destPath, entry.Path); rerr != nil {
+			ctx.Warn("Failed to move volume back to deleted-volumes: %v", rerr)
+		}
+		// Clean up the disk entity
+		if _, derr := eac.Delete(context.Background(), string(diskEntityId)); derr != nil {
+			ctx.Warn("Failed to clean up disk entity: %v", derr)
+		}
+		return fmt.Errorf("disk image not found at %s — deleted volume may be corrupted", imagePath)
+	}
+
+	// Create disk_volume entity
+	volEntityId := entity.Id("disk_volume/" + volId)
+	vol := &storage_v1alpha.DiskVolume{
+		Name:         meta.DiskName,
+		DiskId:       diskEntityId,
+		VolumeId:     volId,
+		SizeGb:       meta.SizeGb,
+		Filesystem:   filesystem,
+		VolumeMode:   storage_v1alpha.DiskVolumeVolumeMode(meta.VolumeMode),
+		DesiredState: storage_v1alpha.DV_PRESENT,
+		ActualState:  storage_v1alpha.DV_READY,
+		ImagePath:    imagePath,
+		NodeId:       nodeId,
+	}
+
+	_, err = eac.Create(context.Background(), entity.New(
+		entity.DBId, volEntityId,
+		vol.Encode,
+	).Attrs())
+	if err != nil {
+		// Clean up the disk entity since we can't complete the restore
+		if _, derr := eac.Delete(context.Background(), string(diskEntityId)); derr != nil {
+			ctx.Warn("Failed to clean up disk entity: %v", derr)
+		}
+		return fmt.Errorf("creating disk_volume entity: %w", err)
+	}
+
+	// Transition disk to PROVISIONED
+	_, err = eac.Patch(context.Background(), []entity.Attr{
+		entity.Ref(entity.DBId, diskEntityId),
+		entity.Ref(storage_v1alpha.DiskStatusId, storage_v1alpha.DiskStatusProvisionedId),
+		entity.String(storage_v1alpha.DiskVolumeIdId, volId),
+	}, 0)
+	if err != nil {
+		// Clean up both entities since the disk is stuck in RESTORING
+		if _, derr := eac.Delete(context.Background(), string(volEntityId)); derr != nil {
+			ctx.Warn("Failed to clean up disk_volume entity: %v", derr)
+		}
+		if _, derr := eac.Delete(context.Background(), string(diskEntityId)); derr != nil {
+			ctx.Warn("Failed to clean up disk entity: %v", derr)
+		}
+		return fmt.Errorf("updating disk to provisioned: %w", err)
+	}
+
+	ctx.Info("Disk restored successfully")
+	ctx.Info("  Disk ID:   %s", diskEntityId)
+	ctx.Info("  Volume ID: %s", volId)
+	ctx.Info("  Image:     %s", imagePath)
+
+	return nil
+}

--- a/cli/commands/disk_undelete.go
+++ b/cli/commands/disk_undelete.go
@@ -123,9 +123,21 @@ func DiskUndelete(ctx *Context, opts struct {
 		return fmt.Errorf("moving volume back to %s: %w", destPath, err)
 	}
 
-	// Remove metadata.json from the restored volume directory
-	metadataPath := filepath.Join(destPath, "metadata.json")
-	os.Remove(metadataPath)
+	// Deferred rollback: if we don't reach the final commit, move the
+	// volume back to deleted-volumes (with its metadata intact) and clean
+	// up any entities we created.
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		if rerr := os.Rename(destPath, entry.Path); rerr != nil {
+			ctx.Warn("Failed to move volume back to deleted-volumes: %v", rerr)
+		}
+		if _, derr := eac.Delete(context.Background(), string(diskEntityId)); derr != nil {
+			ctx.Warn("Failed to clean up disk entity: %v", derr)
+		}
+	}()
 
 	// Find the node ID
 	nodeId, err := resolver.findNodeId(context.Background())
@@ -138,14 +150,6 @@ func DiskUndelete(ctx *Context, opts struct {
 
 	// Verify the disk image actually exists before creating entities
 	if _, err := os.Stat(imagePath); err != nil {
-		// Move the directory back to deleted-volumes so GC can handle it
-		if rerr := os.Rename(destPath, entry.Path); rerr != nil {
-			ctx.Warn("Failed to move volume back to deleted-volumes: %v", rerr)
-		}
-		// Clean up the disk entity
-		if _, derr := eac.Delete(context.Background(), string(diskEntityId)); derr != nil {
-			ctx.Warn("Failed to clean up disk entity: %v", derr)
-		}
 		return fmt.Errorf("disk image not found at %s — deleted volume may be corrupted", imagePath)
 	}
 
@@ -169,10 +173,6 @@ func DiskUndelete(ctx *Context, opts struct {
 		vol.Encode,
 	).Attrs())
 	if err != nil {
-		// Clean up the disk entity since we can't complete the restore
-		if _, derr := eac.Delete(context.Background(), string(diskEntityId)); derr != nil {
-			ctx.Warn("Failed to clean up disk entity: %v", derr)
-		}
 		return fmt.Errorf("creating disk_volume entity: %w", err)
 	}
 
@@ -183,15 +183,16 @@ func DiskUndelete(ctx *Context, opts struct {
 		entity.String(storage_v1alpha.DiskVolumeIdId, volId),
 	}, 0)
 	if err != nil {
-		// Clean up both entities since the disk is stuck in RESTORING
+		// Also clean up the volume entity
 		if _, derr := eac.Delete(context.Background(), string(volEntityId)); derr != nil {
 			ctx.Warn("Failed to clean up disk_volume entity: %v", derr)
 		}
-		if _, derr := eac.Delete(context.Background(), string(diskEntityId)); derr != nil {
-			ctx.Warn("Failed to clean up disk entity: %v", derr)
-		}
 		return fmt.Errorf("updating disk to provisioned: %w", err)
 	}
+
+	// All entities committed — remove leftover metadata and disarm rollback
+	os.Remove(filepath.Join(destPath, "metadata.json"))
+	committed = true
 
 	ctx.Info("Disk restored successfully")
 	ctx.Info("  Disk ID:   %s", diskEntityId)

--- a/components/diskio/deleted_volume.go
+++ b/components/diskio/deleted_volume.go
@@ -1,0 +1,105 @@
+package diskio
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	deletedVolumesDir = "deleted-volumes"
+	metadataFilename  = "metadata.json"
+	defaultRetainDays = 7
+)
+
+// DeletedVolumeMetadata stores information about a soft-deleted disk volume
+// so it can be restored via the undelete command.
+type DeletedVolumeMetadata struct {
+	DiskID     string    `json:"disk_id"`
+	DiskName   string    `json:"disk_name"`
+	SizeGb     int64     `json:"size_gb"`
+	Filesystem string    `json:"filesystem"`
+	VolumeID   string    `json:"volume_id"`
+	VolumeMode string    `json:"volume_mode"`
+	CreatedBy  string    `json:"created_by,omitempty"`
+	NodeID     string    `json:"node_id"`
+	DeletedAt  time.Time `json:"deleted_at"`
+}
+
+// DeletedVolumesPath returns the path to the deleted-volumes directory.
+func DeletedVolumesPath(dataPath string) string {
+	return filepath.Join(dataPath, deletedVolumesDir)
+}
+
+// SaveDeletedVolumeMetadata writes metadata to a JSON file inside the given directory.
+func SaveDeletedVolumeMetadata(dir string, meta *DeletedVolumeMetadata) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling deleted volume metadata: %w", err)
+	}
+
+	path := filepath.Join(dir, metadataFilename)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("writing deleted volume metadata to %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// LoadDeletedVolumeMetadata reads metadata from a JSON file inside the given directory.
+func LoadDeletedVolumeMetadata(dir string) (*DeletedVolumeMetadata, error) {
+	path := filepath.Join(dir, metadataFilename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading deleted volume metadata from %s: %w", path, err)
+	}
+
+	var meta DeletedVolumeMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("unmarshaling deleted volume metadata from %s: %w", path, err)
+	}
+
+	return &meta, nil
+}
+
+// DeletedVolumeEntry combines metadata with its directory path.
+type DeletedVolumeEntry struct {
+	Metadata *DeletedVolumeMetadata
+	Path     string
+}
+
+// ListDeletedVolumes scans the deleted-volumes directory and returns all entries
+// with valid metadata.
+func ListDeletedVolumes(dataPath string) ([]DeletedVolumeEntry, error) {
+	dir := DeletedVolumesPath(dataPath)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading deleted volumes directory: %w", err)
+	}
+
+	var result []DeletedVolumeEntry
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		entryPath := filepath.Join(dir, entry.Name())
+		meta, err := LoadDeletedVolumeMetadata(entryPath)
+		if err != nil {
+			continue
+		}
+
+		result = append(result, DeletedVolumeEntry{
+			Metadata: meta,
+			Path:     entryPath,
+		})
+	}
+
+	return result, nil
+}

--- a/components/diskio/deleted_volume_gc.go
+++ b/components/diskio/deleted_volume_gc.go
@@ -1,0 +1,136 @@
+package diskio
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// DeletedVolumeGCConfig holds configuration for deleted volume garbage collection.
+type DeletedVolumeGCConfig struct {
+	CheckInterval time.Duration
+	RetentionDays int
+}
+
+// DefaultDeletedVolumeGCConfig returns the default GC configuration.
+func DefaultDeletedVolumeGCConfig() DeletedVolumeGCConfig {
+	return DeletedVolumeGCConfig{
+		CheckInterval: 1 * time.Hour,
+		RetentionDays: defaultRetainDays,
+	}
+}
+
+// DeletedVolumeGCResult contains information about volumes processed during GC.
+type DeletedVolumeGCResult struct {
+	Purged   int
+	Retained int
+	Errors   int
+}
+
+// DeletedVolumeGC periodically purges soft-deleted disk volumes that have
+// exceeded the retention period.
+type DeletedVolumeGC struct {
+	Log      *slog.Logger
+	DataPath string
+	Config   DeletedVolumeGCConfig
+
+	cancel context.CancelFunc
+}
+
+// Start begins the periodic GC process.
+func (g *DeletedVolumeGC) Start(ctx context.Context) {
+	g.Log.Info("starting deleted volume GC",
+		"check_interval", g.Config.CheckInterval,
+		"retention_days", g.Config.RetentionDays)
+
+	ctx, g.cancel = context.WithCancel(ctx)
+	go g.run(ctx)
+}
+
+// Stop gracefully stops the controller.
+func (g *DeletedVolumeGC) Stop() {
+	if g.cancel != nil {
+		g.cancel()
+	}
+}
+
+func (g *DeletedVolumeGC) run(ctx context.Context) {
+	ticker := time.NewTicker(g.Config.CheckInterval)
+	defer ticker.Stop()
+
+	// Run an initial GC after a short delay
+	select {
+	case <-time.After(30 * time.Second):
+		g.runGCWithLogging()
+	case <-ctx.Done():
+		g.Log.Info("deleted volume GC stopped")
+		return
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			g.runGCWithLogging()
+		case <-ctx.Done():
+			g.Log.Info("deleted volume GC stopped")
+			return
+		}
+	}
+}
+
+func (g *DeletedVolumeGC) runGCWithLogging() {
+	result, err := g.RunGC()
+	if err != nil {
+		g.Log.Error("deleted volume GC failed", "error", err)
+		return
+	}
+
+	if result.Purged > 0 || result.Errors > 0 {
+		g.Log.Info("deleted volume GC complete",
+			"purged", result.Purged,
+			"retained", result.Retained,
+			"errors", result.Errors)
+	} else {
+		g.Log.Debug("deleted volume GC complete, nothing to purge",
+			"retained", result.Retained)
+	}
+}
+
+// RunGC scans the deleted-volumes directory and removes entries that have
+// exceeded the retention period.
+func (g *DeletedVolumeGC) RunGC() (*DeletedVolumeGCResult, error) {
+	result := &DeletedVolumeGCResult{}
+
+	entries, err := ListDeletedVolumes(g.DataPath)
+	if err != nil {
+		return result, fmt.Errorf("listing deleted volumes: %w", err)
+	}
+
+	now := time.Now()
+	retentionCutoff := now.Add(-time.Duration(g.Config.RetentionDays) * 24 * time.Hour)
+
+	for _, entry := range entries {
+		if entry.Metadata.DeletedAt.After(retentionCutoff) {
+			result.Retained++
+			continue
+		}
+
+		g.Log.Info("purging expired deleted volume",
+			"disk_name", entry.Metadata.DiskName,
+			"volume_id", entry.Metadata.VolumeID,
+			"deleted_at", entry.Metadata.DeletedAt)
+
+		if err := os.RemoveAll(entry.Path); err != nil {
+			g.Log.Warn("failed to purge deleted volume",
+				"path", entry.Path, "error", err)
+			result.Errors++
+			continue
+		}
+
+		result.Purged++
+	}
+
+	return result, nil
+}

--- a/components/diskio/deleted_volume_gc_test.go
+++ b/components/diskio/deleted_volume_gc_test.go
@@ -1,0 +1,103 @@
+package diskio
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeletedVolumeGC_PurgesExpired(t *testing.T) {
+	dataPath := t.TempDir()
+	deletedDir := filepath.Join(dataPath, deletedVolumesDir)
+	require.NoError(t, os.MkdirAll(deletedDir, 0755))
+
+	// Create an expired entry (8 days old)
+	expiredDir := filepath.Join(deletedDir, "vol-expired")
+	require.NoError(t, os.MkdirAll(expiredDir, 0755))
+	require.NoError(t, SaveDeletedVolumeMetadata(expiredDir, &DeletedVolumeMetadata{
+		DiskName:  "old-disk",
+		VolumeID:  "vol-expired",
+		DeletedAt: time.Now().Add(-8 * 24 * time.Hour),
+	}))
+	// Add a fake disk.img so we can verify it's deleted
+	require.NoError(t, os.WriteFile(filepath.Join(expiredDir, "disk.img"), []byte("data"), 0644))
+
+	// Create a recent entry (1 day old)
+	recentDir := filepath.Join(deletedDir, "vol-recent")
+	require.NoError(t, os.MkdirAll(recentDir, 0755))
+	require.NoError(t, SaveDeletedVolumeMetadata(recentDir, &DeletedVolumeMetadata{
+		DiskName:  "new-disk",
+		VolumeID:  "vol-recent",
+		DeletedAt: time.Now().Add(-1 * 24 * time.Hour),
+	}))
+
+	gc := &DeletedVolumeGC{
+		Log:      slog.Default(),
+		DataPath: dataPath,
+		Config: DeletedVolumeGCConfig{
+			CheckInterval: time.Hour,
+			RetentionDays: 7,
+		},
+	}
+
+	result, err := gc.RunGC()
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Purged)
+	assert.Equal(t, 1, result.Retained)
+	assert.Equal(t, 0, result.Errors)
+
+	// Verify expired dir is gone
+	_, err = os.Stat(expiredDir)
+	assert.True(t, os.IsNotExist(err))
+
+	// Verify recent dir still exists
+	_, err = os.Stat(recentDir)
+	assert.NoError(t, err)
+}
+
+func TestDeletedVolumeGC_EmptyDir(t *testing.T) {
+	dataPath := t.TempDir()
+
+	gc := &DeletedVolumeGC{
+		Log:      slog.Default(),
+		DataPath: dataPath,
+		Config:   DefaultDeletedVolumeGCConfig(),
+	}
+
+	result, err := gc.RunGC()
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Purged)
+	assert.Equal(t, 0, result.Retained)
+}
+
+func TestDeletedVolumeGC_AllRetained(t *testing.T) {
+	dataPath := t.TempDir()
+	deletedDir := filepath.Join(dataPath, deletedVolumesDir)
+	require.NoError(t, os.MkdirAll(deletedDir, 0755))
+
+	// Create a recent entry
+	dir := filepath.Join(deletedDir, "vol-new")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, SaveDeletedVolumeMetadata(dir, &DeletedVolumeMetadata{
+		DiskName:  "recent-disk",
+		VolumeID:  "vol-new",
+		DeletedAt: time.Now().Add(-1 * time.Hour),
+	}))
+
+	gc := &DeletedVolumeGC{
+		Log:      slog.Default(),
+		DataPath: dataPath,
+		Config:   DefaultDeletedVolumeGCConfig(),
+	}
+
+	result, err := gc.RunGC()
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Purged)
+	assert.Equal(t, 1, result.Retained)
+}

--- a/components/diskio/deleted_volume_test.go
+++ b/components/diskio/deleted_volume_test.go
@@ -1,0 +1,98 @@
+package diskio
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveAndLoadDeletedVolumeMetadata(t *testing.T) {
+	dir := t.TempDir()
+
+	meta := &DeletedVolumeMetadata{
+		DiskID:     "disk/disk-abc123",
+		DiskName:   "my-database",
+		SizeGb:     10,
+		Filesystem: "ext4",
+		VolumeID:   "disk-vol-xyz",
+		VolumeMode: "volume_mode.vm_universal",
+		CreatedBy:  "user/user-1",
+		NodeID:     "node/node-1",
+		DeletedAt:  time.Now().Truncate(time.Millisecond),
+	}
+
+	err := SaveDeletedVolumeMetadata(dir, meta)
+	require.NoError(t, err)
+
+	// Verify file exists
+	_, err = os.Stat(filepath.Join(dir, metadataFilename))
+	require.NoError(t, err)
+
+	loaded, err := LoadDeletedVolumeMetadata(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, meta.DiskID, loaded.DiskID)
+	assert.Equal(t, meta.DiskName, loaded.DiskName)
+	assert.Equal(t, meta.SizeGb, loaded.SizeGb)
+	assert.Equal(t, meta.Filesystem, loaded.Filesystem)
+	assert.Equal(t, meta.VolumeID, loaded.VolumeID)
+	assert.Equal(t, meta.VolumeMode, loaded.VolumeMode)
+	assert.Equal(t, meta.CreatedBy, loaded.CreatedBy)
+	assert.Equal(t, meta.NodeID, loaded.NodeID)
+	assert.True(t, meta.DeletedAt.Equal(loaded.DeletedAt))
+}
+
+func TestLoadDeletedVolumeMetadata_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadDeletedVolumeMetadata(dir)
+	assert.Error(t, err)
+}
+
+func TestListDeletedVolumes(t *testing.T) {
+	dataPath := t.TempDir()
+	deletedDir := filepath.Join(dataPath, deletedVolumesDir)
+	require.NoError(t, os.MkdirAll(deletedDir, 0755))
+
+	// Create two deleted volume entries
+	vol1Dir := filepath.Join(deletedDir, "vol-1")
+	require.NoError(t, os.MkdirAll(vol1Dir, 0755))
+	require.NoError(t, SaveDeletedVolumeMetadata(vol1Dir, &DeletedVolumeMetadata{
+		DiskName:  "db-disk",
+		VolumeID:  "vol-1",
+		DeletedAt: time.Now().Add(-1 * time.Hour),
+	}))
+
+	vol2Dir := filepath.Join(deletedDir, "vol-2")
+	require.NoError(t, os.MkdirAll(vol2Dir, 0755))
+	require.NoError(t, SaveDeletedVolumeMetadata(vol2Dir, &DeletedVolumeMetadata{
+		DiskName:  "cache-disk",
+		VolumeID:  "vol-2",
+		DeletedAt: time.Now().Add(-48 * time.Hour),
+	}))
+
+	// Create a directory without metadata (should be skipped)
+	badDir := filepath.Join(deletedDir, "no-metadata")
+	require.NoError(t, os.MkdirAll(badDir, 0755))
+
+	entries, err := ListDeletedVolumes(dataPath)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+
+	names := make(map[string]bool)
+	for _, e := range entries {
+		names[e.Metadata.DiskName] = true
+	}
+	assert.True(t, names["db-disk"])
+	assert.True(t, names["cache-disk"])
+}
+
+func TestListDeletedVolumes_EmptyDir(t *testing.T) {
+	dataPath := t.TempDir()
+	entries, err := ListDeletedVolumes(dataPath)
+	require.NoError(t, err)
+	assert.Nil(t, entries)
+}

--- a/components/diskio/disk_ops.go
+++ b/components/diskio/disk_ops.go
@@ -10,6 +10,7 @@ import (
 type DiskVolumeOps interface {
 	CreateVolumeDir(path string) error
 	RemoveVolumeDir(path string) error
+	MoveVolumeDir(src, dst string) error
 	VolumePathExists(path string) bool
 	CreateDiskImage(path string, sizeBytes int64) error
 	RemoveDiskImage(path string) error

--- a/components/diskio/disk_ops_darwin.go
+++ b/components/diskio/disk_ops_darwin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 )
 
 type stubDiskVolumeOps struct{}
@@ -19,6 +20,13 @@ func (s *stubDiskVolumeOps) CreateVolumeDir(path string) error {
 
 func (s *stubDiskVolumeOps) RemoveVolumeDir(path string) error {
 	return os.RemoveAll(path)
+}
+
+func (s *stubDiskVolumeOps) MoveVolumeDir(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("failed to create parent directory for %s: %w", dst, err)
+	}
+	return os.Rename(src, dst)
 }
 
 func (s *stubDiskVolumeOps) VolumePathExists(path string) bool {

--- a/components/diskio/disk_ops_linux.go
+++ b/components/diskio/disk_ops_linux.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -36,6 +37,13 @@ func (r *realDiskVolumeOps) CreateVolumeDir(path string) error {
 
 func (r *realDiskVolumeOps) RemoveVolumeDir(path string) error {
 	return os.RemoveAll(path)
+}
+
+func (r *realDiskVolumeOps) MoveVolumeDir(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("failed to create parent directory for %s: %w", dst, err)
+	}
+	return os.Rename(src, dst)
 }
 
 func (r *realDiskVolumeOps) VolumePathExists(path string) bool {

--- a/components/diskio/disk_ops_mock_test.go
+++ b/components/diskio/disk_ops_mock_test.go
@@ -7,15 +7,22 @@ import (
 )
 
 // mockDiskVolumeOps implements DiskVolumeOps for testing
+type mockDirMove struct {
+	src string
+	dst string
+}
+
 type mockDiskVolumeOps struct {
 	createdDirs   []string
 	removedDirs   []string
+	movedDirs     []mockDirMove
 	existingPaths map[string]bool
 	createdImages []mockDiskImage
 	removedImages []string
 
 	createDirErr   error
 	removeDirErr   error
+	moveDirErr     error
 	createImageErr error
 	removeImageErr error
 }
@@ -46,6 +53,16 @@ func (m *mockDiskVolumeOps) RemoveVolumeDir(path string) error {
 	}
 	m.removedDirs = append(m.removedDirs, path)
 	delete(m.existingPaths, path)
+	return nil
+}
+
+func (m *mockDiskVolumeOps) MoveVolumeDir(src, dst string) error {
+	if m.moveDirErr != nil {
+		return m.moveDirErr
+	}
+	m.movedDirs = append(m.movedDirs, mockDirMove{src: src, dst: dst})
+	delete(m.existingPaths, src)
+	m.existingPaths[dst] = true
 	return nil
 }
 

--- a/components/diskio/disk_volume_controller.go
+++ b/components/diskio/disk_volume_controller.go
@@ -581,13 +581,17 @@ func (c *DiskVolumeController) softDeleteVolume(ctx context.Context, volume *sto
 		}
 	}
 
-	if err := c.ops.MoveVolumeDir(diskPath, destPath); err != nil {
-		return fmt.Errorf("moving volume to deleted-volumes: %w", err)
+	// Write metadata before the move so the rename carries both the volume
+	// data and the metadata atomically (same filesystem).  If the write
+	// fails we abort — moving without metadata would leave an invisible,
+	// un-restorable directory.
+	if err := SaveDeletedVolumeMetadata(diskPath, meta); err != nil {
+		return fmt.Errorf("writing deleted volume metadata: %w", err)
 	}
 
-	if err := SaveDeletedVolumeMetadata(destPath, meta); err != nil {
-		c.log.Warn("failed to write deleted volume metadata, volume is still preserved",
-			"path", destPath, "error", err)
+	if err := c.ops.MoveVolumeDir(diskPath, destPath); err != nil {
+		_ = os.Remove(filepath.Join(diskPath, metadataFilename))
+		return fmt.Errorf("moving volume to deleted-volumes: %w", err)
 	}
 
 	c.log.Info("volume soft-deleted",

--- a/components/diskio/disk_volume_controller.go
+++ b/components/diskio/disk_volume_controller.go
@@ -523,7 +523,7 @@ func (c *DiskVolumeController) deleteVolume(ctx context.Context, volume *storage
 	}
 
 	if volState.DiskPath != "" {
-		if err := c.softDeleteVolume(ctx, volume, volState.DiskPath); err != nil {
+		if err := c.softDeleteVolume(ctx, volume, volState); err != nil {
 			c.log.Warn("soft-delete failed, falling back to hard delete",
 				"entity_id", entityId, "error", err)
 			if err := c.ops.RemoveVolumeDir(volState.DiskPath); err != nil {
@@ -549,8 +549,11 @@ func (c *DiskVolumeController) deleteVolume(ctx context.Context, volume *storage
 }
 
 // softDeleteVolume moves the volume directory to the deleted-volumes holding area
-// and writes metadata so it can be restored later.
-func (c *DiskVolumeController) softDeleteVolume(ctx context.Context, volume *storage_v1alpha.DiskVolume, diskPath string) error {
+// and writes metadata so it can be restored later. Metadata is written into the
+// source directory before the move so the rename carries both data and metadata
+// atomically.
+func (c *DiskVolumeController) softDeleteVolume(ctx context.Context, volume *storage_v1alpha.DiskVolume, volState *VolumeState) error {
+	diskPath := volState.DiskPath
 	dirName := filepath.Base(diskPath)
 	destPath := filepath.Join(c.dataPath, deletedVolumesDir, dirName)
 
@@ -564,7 +567,7 @@ func (c *DiskVolumeController) softDeleteVolume(ctx context.Context, volume *sto
 		DiskName:   volume.Name,
 		SizeGb:     volume.SizeGb,
 		Filesystem: volume.Filesystem,
-		VolumeID:   volume.VolumeId,
+		VolumeID:   volState.VolumeId,
 		VolumeMode: string(volume.VolumeMode),
 		NodeID:     string(volume.NodeId),
 		DeletedAt:  time.Now(),

--- a/components/diskio/disk_volume_controller.go
+++ b/components/diskio/disk_volume_controller.go
@@ -523,9 +523,13 @@ func (c *DiskVolumeController) deleteVolume(ctx context.Context, volume *storage
 	}
 
 	if volState.DiskPath != "" {
-		if err := c.ops.RemoveVolumeDir(volState.DiskPath); err != nil {
-			if !os.IsNotExist(err) {
-				return fmt.Errorf("failed to remove volume directory %s: %w", volState.DiskPath, err)
+		if err := c.softDeleteVolume(ctx, volume, volState.DiskPath); err != nil {
+			c.log.Warn("soft-delete failed, falling back to hard delete",
+				"entity_id", entityId, "error", err)
+			if err := c.ops.RemoveVolumeDir(volState.DiskPath); err != nil {
+				if !os.IsNotExist(err) {
+					return fmt.Errorf("failed to remove volume directory %s: %w", volState.DiskPath, err)
+				}
 			}
 		}
 	}
@@ -540,6 +544,56 @@ func (c *DiskVolumeController) deleteVolume(ctx context.Context, volume *storage
 	if err := c.updateVolumeState(ctx, volume.ID, storage_v1alpha.DV_DELETED, "", ""); err != nil {
 		c.log.Warn("failed to update volume state to deleted", "error", err)
 	}
+
+	return nil
+}
+
+// softDeleteVolume moves the volume directory to the deleted-volumes holding area
+// and writes metadata so it can be restored later.
+func (c *DiskVolumeController) softDeleteVolume(ctx context.Context, volume *storage_v1alpha.DiskVolume, diskPath string) error {
+	dirName := filepath.Base(diskPath)
+	destPath := filepath.Join(c.dataPath, deletedVolumesDir, dirName)
+
+	// Avoid collision if the destination already exists (e.g., from a prior failed attempt)
+	if _, err := os.Stat(destPath); err == nil {
+		destPath = fmt.Sprintf("%s-%d", destPath, time.Now().UnixMilli())
+	}
+
+	meta := &DeletedVolumeMetadata{
+		DiskID:     string(volume.DiskId),
+		DiskName:   volume.Name,
+		SizeGb:     volume.SizeGb,
+		Filesystem: volume.Filesystem,
+		VolumeID:   volume.VolumeId,
+		VolumeMode: string(volume.VolumeMode),
+		NodeID:     string(volume.NodeId),
+		DeletedAt:  time.Now(),
+	}
+
+	// Try to enrich metadata from the disk entity
+	if c.eac != nil && volume.DiskId != "" {
+		result, err := c.eac.Get(ctx, string(volume.DiskId))
+		if err == nil && result.Entity() != nil {
+			var disk storage_v1alpha.Disk
+			disk.Decode(result.Entity().Entity())
+			meta.DiskName = disk.Name
+			meta.CreatedBy = string(disk.CreatedBy)
+		}
+	}
+
+	if err := c.ops.MoveVolumeDir(diskPath, destPath); err != nil {
+		return fmt.Errorf("moving volume to deleted-volumes: %w", err)
+	}
+
+	if err := SaveDeletedVolumeMetadata(destPath, meta); err != nil {
+		c.log.Warn("failed to write deleted volume metadata, volume is still preserved",
+			"path", destPath, "error", err)
+	}
+
+	c.log.Info("volume soft-deleted",
+		"from", diskPath,
+		"to", destPath,
+		"disk_name", meta.DiskName)
 
 	return nil
 }

--- a/components/diskio/disk_volume_controller_test.go
+++ b/components/diskio/disk_volume_controller_test.go
@@ -124,9 +124,10 @@ func TestDiskVolumeControllerReconcileVolumeAbsent(t *testing.T) {
 	err := vc.ReconcileWithEntities(ctx)
 	require.NoError(t, err)
 
-	// Verify volume directory was removed
-	assert.Len(t, ops.removedDirs, 1)
-	assert.Equal(t, "/data/volumes/vol-456", ops.removedDirs[0])
+	// Verify volume directory was soft-deleted (moved, not removed)
+	assert.Len(t, ops.movedDirs, 1)
+	assert.Equal(t, "/data/volumes/vol-456", ops.movedDirs[0].src)
+	assert.Contains(t, ops.movedDirs[0].dst, "deleted-volumes")
 
 	// Verify state was cleaned up
 	assert.Nil(t, state.GetVolume("disk_volume/vol-456"))
@@ -1369,8 +1370,10 @@ func TestDiskVolumeControllerUniversalUnmountOnDelete(t *testing.T) {
 	assert.Contains(t, mntOps.unmounts, mountPath)
 	// Verify loop detach was called
 	assert.Contains(t, mntOps.detachedLoops, "/dev/loop3")
-	// Verify volume directory was removed
-	assert.Contains(t, volOps.removedDirs, "/data/volumes/vol-del")
+	// Verify volume directory was soft-deleted (moved, not removed)
+	require.Len(t, volOps.movedDirs, 1)
+	assert.Equal(t, "/data/volumes/vol-del", volOps.movedDirs[0].src)
+	assert.Contains(t, volOps.movedDirs[0].dst, "deleted-volumes")
 }
 
 func TestDiskVolumeControllerShutdown(t *testing.T) {

--- a/components/diskio/disk_volume_controller_test.go
+++ b/components/diskio/disk_volume_controller_test.go
@@ -99,15 +99,19 @@ func TestDiskVolumeControllerReconcileVolumeAbsent(t *testing.T) {
 	state := NewState()
 	ops := newMockDiskVolumeOps()
 
-	// Pre-populate state with existing volume
+	// Pre-populate state with existing volume using a real temp directory
+	// so that metadata can be written before the move.
+	volDir := filepath.Join(dataPath, "volumes", "vol-456")
+	require.NoError(t, os.MkdirAll(volDir, 0755))
+
 	state.SetVolume("disk_volume/vol-456", &VolumeState{
 		EntityId:   "disk_volume/vol-456",
 		VolumeId:   "vol-456",
-		DiskPath:   "/data/volumes/vol-456",
+		DiskPath:   volDir,
 		SizeBytes:  5 * 1024 * 1024 * 1024,
 		Filesystem: "xfs",
 	})
-	ops.existingPaths["/data/volumes/vol-456"] = true
+	ops.existingPaths[volDir] = true
 
 	vc := newTestDiskVolumeController(log, dataPath, nodeId, es.EAC, state, ops)
 
@@ -126,7 +130,7 @@ func TestDiskVolumeControllerReconcileVolumeAbsent(t *testing.T) {
 
 	// Verify volume directory was soft-deleted (moved, not removed)
 	assert.Len(t, ops.movedDirs, 1)
-	assert.Equal(t, "/data/volumes/vol-456", ops.movedDirs[0].src)
+	assert.Equal(t, volDir, ops.movedDirs[0].src)
 	assert.Contains(t, ops.movedDirs[0].dst, "deleted-volumes")
 
 	// Verify state was cleaned up
@@ -1334,11 +1338,14 @@ func TestDiskVolumeControllerUniversalUnmountOnDelete(t *testing.T) {
 	volOps := newMockDiskVolumeOps()
 	mntOps := newMockDiskMountOps()
 
+	volDir := filepath.Join(dataPath, "volumes", "vol-del")
+	require.NoError(t, os.MkdirAll(volDir, 0755))
+
 	mountPath := filepath.Join(dataPath, "vol-del")
 	state.SetVolume("disk_volume/vol-del", &VolumeState{
 		EntityId:   "disk_volume/vol-del",
 		VolumeId:   "vol-del",
-		DiskPath:   "/data/volumes/vol-del",
+		DiskPath:   volDir,
 		SizeBytes:  10 * 1024 * 1024 * 1024,
 		Filesystem: "ext4",
 		Mode:       storage_v1alpha.VM_UNIVERSAL,
@@ -1346,7 +1353,7 @@ func TestDiskVolumeControllerUniversalUnmountOnDelete(t *testing.T) {
 		MountPath:  mountPath,
 		Mounted:    true,
 	})
-	volOps.existingPaths["/data/volumes/vol-del"] = true
+	volOps.existingPaths[volDir] = true
 	mntOps.mountedPaths[mountPath] = true
 
 	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
@@ -1372,7 +1379,7 @@ func TestDiskVolumeControllerUniversalUnmountOnDelete(t *testing.T) {
 	assert.Contains(t, mntOps.detachedLoops, "/dev/loop3")
 	// Verify volume directory was soft-deleted (moved, not removed)
 	require.Len(t, volOps.movedDirs, 1)
-	assert.Equal(t, "/data/volumes/vol-del", volOps.movedDirs[0].src)
+	assert.Equal(t, volDir, volOps.movedDirs[0].src)
 	assert.Contains(t, volOps.movedDirs[0].dst, "deleted-volumes")
 }
 

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -119,6 +119,10 @@ type waitCloser struct{ s interface{ Wait() } }
 
 func (c waitCloser) Close() error { c.s.Wait(); return nil }
 
+type stopCloser struct{ s interface{ Stop() } }
+
+func (c stopCloser) Close() error { c.s.Stop(); return nil }
+
 func NewRunner(log *slog.Logger, deps RunnerDeps, cfg RunnerConfig) (*Runner, error) {
 	if cfg.DataPath == "" {
 		return nil, fmt.Errorf("data_path is required")
@@ -158,8 +162,9 @@ type Runner struct {
 	sbController sandbox.SandboxLifecycle
 
 	// Disk controllers, stored for SetRestartMode propagation
-	dvc *diskio.DiskVolumeController
-	dmc *diskio.DiskMountController
+	dvc    *diskio.DiskVolumeController
+	dmc    *diskio.DiskMountController
+	diskGC *diskio.DeletedVolumeGC
 }
 
 func (r *Runner) Close() error {
@@ -678,6 +683,15 @@ func (r *Runner) SetupControllers(
 	if err := r.dmc.ReconcileWithEntities(ctx); err != nil {
 		log.Warn("failed to reconcile disk mounts on startup", "error", err)
 	}
+
+	// Start deleted volume GC to purge soft-deleted disk volumes after retention period
+	r.diskGC = &diskio.DeletedVolumeGC{
+		Log:      log.With("module", "deleted-volume-gc"),
+		DataPath: dataPath,
+		Config:   diskio.DefaultDeletedVolumeGCConfig(),
+	}
+	r.diskGC.Start(ctx)
+	r.closers = append(r.closers, stopCloser{r.diskGC})
 
 	// Register volume controller shutdown before mount controller so mounts
 	// owned by the volume controller are cleaned up first

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -684,14 +684,12 @@ func (r *Runner) SetupControllers(
 		log.Warn("failed to reconcile disk mounts on startup", "error", err)
 	}
 
-	// Start deleted volume GC to purge soft-deleted disk volumes after retention period
+	// Prepare deleted volume GC (started after all controller init succeeds)
 	r.diskGC = &diskio.DeletedVolumeGC{
 		Log:      log.With("module", "deleted-volume-gc"),
 		DataPath: dataPath,
 		Config:   diskio.DefaultDeletedVolumeGCConfig(),
 	}
-	r.diskGC.Start(ctx)
-	r.closers = append(r.closers, stopCloser{r.diskGC})
 
 	// Register volume controller shutdown before mount controller so mounts
 	// owned by the volume controller are cleaned up first
@@ -785,6 +783,10 @@ func (r *Runner) SetupControllers(
 	if err != nil {
 		return nil, err
 	}
+
+	// All controllers initialized — safe to start the GC goroutine now
+	r.diskGC.Start(ctx)
+	r.closers = append(r.closers, stopCloser{r.diskGC})
 
 	r.cc = r.deps.CC
 	r.namespace = r.deps.Namespace

--- a/controllers/integration/mock_ops.go
+++ b/controllers/integration/mock_ops.go
@@ -31,6 +31,12 @@ func (m *mockDiskVolumeOps) RemoveVolumeDir(path string) error {
 	return nil
 }
 
+func (m *mockDiskVolumeOps) MoveVolumeDir(src, dst string) error {
+	delete(m.existingPaths, src)
+	m.existingPaths[dst] = true
+	return nil
+}
+
 func (m *mockDiskVolumeOps) VolumePathExists(path string) bool {
 	return m.existingPaths[path]
 }


### PR DESCRIPTION
## Summary

- When a disk is deleted, the volume directory is now **moved** to a `deleted-volumes/` holding area instead of being immediately removed
- A background **GC controller** purges soft-deleted volumes after 7 days (configurable), checking hourly
- New **`disk undelete --name <name>`** CLI command restores a deleted disk by recreating entities and moving the volume back
- New **`disk list-deleted`** CLI command shows recoverable disks with expiration times

Closes MIR-847

## Details

**Soft-delete mechanism:**
- `deleteVolume()` calls `softDeleteVolume()` which moves the directory via `os.Rename` (atomic, same filesystem)
- Falls back to hard delete if the move fails — deletion is never blocked
- Writes `metadata.json` alongside the volume with disk name, size, filesystem, volume mode, etc.
- Handles destination collisions by appending a timestamp suffix

**Undelete safety:**
- Verifies `disk.img` exists before recreating entities
- Checks for name conflicts (errors if a disk with the same name already exists)
- Cleans up entities on partial failure at every step

**Files changed:**
- `components/diskio/disk_ops.go` — `MoveVolumeDir` added to interface
- `components/diskio/disk_volume_controller.go` — soft-delete logic
- `components/diskio/deleted_volume.go` — metadata type and helpers
- `components/diskio/deleted_volume_gc.go` — GC controller
- `components/runner/runner.go` — GC wiring
- `cli/commands/disk_undelete.go` — undelete command
- `cli/commands/disk_list_deleted.go` — list-deleted command
- `cli/commands/commands.go` — command registration

## Test plan

- [x] All 3721 existing tests pass (`make test`)
- [x] New unit tests for metadata save/load/list
- [x] New unit tests for GC (purge expired, retain recent, empty dir)
- [x] Updated existing controller tests to verify soft-delete (move) instead of hard delete
- [x] Blackbox end-to-end test: create → delete → list-deleted → undelete → lease → verify mounted
- [x] `golangci-lint` clean