### PR TITLE
Add Fathom Analytics to docs site

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -71,6 +71,14 @@ const config: Config = {
 
   plugins: [filterAncestorWatchesPlugin],
 
+  scripts: [
+    {
+      src: 'https://cdn.usefathom.com/script.js',
+      'data-site': 'MEHJPZGQ',
+      defer: true,
+    },
+  ],
+
   onBrokenLinks: 'throw',
 
   // Even if you don't use internationalization, you can use this field to set

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -75,6 +75,7 @@ const config: Config = {
     {
       src: 'https://cdn.usefathom.com/script.js',
       'data-site': 'MEHJPZGQ',
+      'data-spa': 'auto',
       defer: true,
     },
   ],


### PR DESCRIPTION
Right now we have zero visibility into how people use the docs site. We don't know which pages get traffic, where people enter, or what they never find. That makes it hard to know where to spend time improving things.

This adds Fathom Analytics to miren.md. We picked Fathom because it's privacy-respecting — no cookies, no personal data, GDPR compliant without a consent banner. As an OSS project we care about that: we want to know what docs need work, not build dossiers on our users.

Implementation-wise it's just the Docusaurus `scripts` config — one addition to `docusaurus.config.ts`, nothing else changes.

Closes MIR-892