### PR TITLE
Implement short entity IDs (RFD-69)

### DIFF
--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -168,8 +168,13 @@ func SandboxList(ctx *Context, opts struct {
 		}
 
 		// Apply all UI formatting for table display
+		sandboxId := ui.CleanEntityID(sandbox.ID.String())
+		if !ctx.Verbose() {
+			sandboxId = ui.BriefId(e.Entity())
+		}
+
 		rows = append(rows, ui.Row{
-			ui.CleanEntityID(sandbox.ID.String()),
+			sandboxId,
 			ui.DisplayAppVersion(sandbox.Spec.Version.String()),
 			service,
 			poolLabelDisplay,

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -749,6 +749,17 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		c.Log.Info("entity migration completed", "migrated", migrated, "skipped", skipped)
 	}
 
+	// Backfill short-ids for entities that don't have one
+	sidMigrated, sidSkipped, sidErr := entity.MigrateShortIds(ctx, c.Log, client, entity.MigrateShortIdOptions{
+		Prefix: c.Prefix,
+		DryRun: false,
+	})
+	if sidErr != nil {
+		c.Log.Warn("short-id migration completed with errors", "migrated", sidMigrated, "skipped", sidSkipped, "error", sidErr)
+	} else if sidMigrated > 0 {
+		c.Log.Info("short-id migration completed", "migrated", sidMigrated, "skipped", sidSkipped)
+	}
+
 	// Check if indexes have changed and reindex if needed
 	if err := c.checkAndReindex(ctx, etcdStore, client); err != nil {
 		c.Log.Error("automatic reindex failed (will retry next startup)", "error", err)

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -25,6 +25,7 @@ var (
 	ErrAttributeNotFound   = errors.New("attribute not found")
 	ErrInvalidAttribute    = errors.New("invalid attribute")
 	ErrSchemaNotFound      = errors.New("schema not found")
+	ErrShortIdExhausted    = errors.New("failed to allocate unique short-id")
 )
 
 type uniq int

--- a/pkg/entity/shortid.go
+++ b/pkg/entity/shortid.go
@@ -1,0 +1,142 @@
+package entity
+
+import (
+	"crypto/rand"
+	"strings"
+)
+
+const base58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+// minBase58Len is the minimum length of a base58 segment to be considered
+// high-entropy (i.e., derived from a UUID rather than a human-chosen name).
+const minBase58Len = 10
+
+// defaultShortIdLen is the initial length of a short-id candidate.
+const defaultShortIdLen = 3
+
+// maxShortIdLen caps how long a short-id can grow before we give up.
+// At length 8, there are 58^8 ≈ 128 trillion possibilities.
+const maxShortIdLen = 8
+
+// knownPrefixes are 1-2 character prefixes that precede the base58 portion
+// in entity IDs of Category 2 (name + base58 suffix).
+var knownPrefixes = []string{"ob", "v", "a", "s", "t"}
+
+// isBase58 reports whether every character in s belongs to the Base58 alphabet.
+func isBase58(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if !strings.ContainsRune(base58Alphabet, rune(s[i])) {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+// ExtractBase58Suffix extracts the high-entropy base58 portion from an entity ID.
+// Returns the base58 portion and true if found, or empty string and false otherwise.
+//
+// Handles all entity ID categories:
+//   - Category 1 (named): "app/blog" → ("", false)
+//   - Category 2 (name+prefix+base58): "blog-vCZ1eUgSgNd28ed6vt2DgY" → ("CZ1eUgSgNd28ed6vt2DgY", true)
+//   - Category 3 (namespace/prefix-base58): "sandbox/blog-web-CZAtBvhsMNbG38MceikkB" → ("CZAtBvhsMNbG38MceikkB", true)
+//   - Category 4 (kind-base58): "deployment-CZ1eUgSgNd28ed6vt2DgY" → ("CZ1eUgSgNd28ed6vt2DgY", true)
+func ExtractBase58Suffix(entityId string) (string, bool) {
+	id := entityId
+
+	// Strip namespace prefix (everything before and including the last "/")
+	if idx := strings.LastIndex(id, "/"); idx >= 0 {
+		id = id[idx+1:]
+	}
+
+	// Split on "-" and take the last segment
+	if idx := strings.LastIndex(id, "-"); idx >= 0 {
+		id = id[idx+1:]
+	} else {
+		// No "-" at all — this is a purely named entity (Category 1)
+		return "", false
+	}
+
+	// Try stripping known prefixes
+	base58Part := id
+	for _, prefix := range knownPrefixes {
+		if strings.HasPrefix(id, prefix) {
+			candidate := id[len(prefix):]
+			if isBase58(candidate) && len(candidate) >= minBase58Len {
+				return candidate, true
+			}
+		}
+	}
+
+	// Check if the whole segment is base58
+	if isBase58(base58Part) && len(base58Part) >= minBase58Len {
+		return base58Part, true
+	}
+
+	return "", false
+}
+
+// ExistsCheck is a function that reports whether a given short-id candidate
+// is already in use.
+type ExistsCheck func(candidate string) (bool, error)
+
+// AllocateShortId generates a short, globally-unique identifier for an entity.
+// It first tries to derive the short-id from the entity's base58 suffix,
+// falling back to random generation if no suffix is available or all
+// suffix-derived candidates collide.
+func AllocateShortId(entityId string, exists ExistsCheck) (string, error) {
+	suffix, ok := ExtractBase58Suffix(entityId)
+	if ok && len(suffix) >= defaultShortIdLen {
+		// Try progressively longer suffixes starting from the end
+		for length := defaultShortIdLen; length <= min(len(suffix), maxShortIdLen); length++ {
+			candidate := suffix[len(suffix)-length:]
+			taken, err := exists(candidate)
+			if err != nil {
+				return "", err
+			}
+			if !taken {
+				return candidate, nil
+			}
+		}
+	}
+
+	// Fall back to random base58 generation
+	return allocateRandomShortId(exists)
+}
+
+func allocateRandomShortId(exists ExistsCheck) (string, error) {
+	for length := defaultShortIdLen; length <= maxShortIdLen; length++ {
+		for attempt := 0; attempt < 5; attempt++ {
+			candidate, err := randomBase58(length)
+			if err != nil {
+				return "", err
+			}
+			taken, err := exists(candidate)
+			if err != nil {
+				return "", err
+			}
+			if !taken {
+				return candidate, nil
+			}
+		}
+	}
+	return "", ErrShortIdExhausted
+}
+
+func randomBase58(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	for i := range b {
+		b[i] = base58Alphabet[int(b[i])%len(base58Alphabet)]
+	}
+	return string(b), nil
+}
+
+// ShortId returns the entity's short-id, or empty string if not set.
+func (e *Entity) ShortId() string {
+	if attr, ok := e.Get(DBShortId); ok {
+		return attr.Value.String()
+	}
+	return ""
+}

--- a/pkg/entity/shortid.go
+++ b/pkg/entity/shortid.go
@@ -122,6 +122,10 @@ func allocateRandomShortId(exists ExistsCheck) (string, error) {
 	return "", ErrShortIdExhausted
 }
 
+// randomBase58 generates a random string of the given length using base58
+// characters. Note: this is NOT a base58 encoding of the random bytes — the
+// result cannot be decoded back to the original bytes. We're just using the
+// base58 alphabet as a convenient source of human-friendly characters.
 func randomBase58(length int) (string, error) {
 	b := make([]byte, length)
 	if _, err := rand.Read(b); err != nil {

--- a/pkg/entity/shortid_migrate.go
+++ b/pkg/entity/shortid_migrate.go
@@ -20,7 +20,7 @@ type MigrateShortIdOptions struct {
 // This is idempotent — entities that already have a short-id are skipped.
 func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Client, opts MigrateShortIdOptions) (migrated int, skipped int, err error) {
 	prefix := path.Join(opts.Prefix, "entity")
-	refsPrefix := path.Join(opts.Prefix, "refs") + "/"
+	uniquePrefix := path.Join(opts.Prefix, "unique") + "/"
 
 	log.Info("starting short-id migration", "prefix", prefix, "dry_run", opts.DryRun)
 
@@ -31,16 +31,17 @@ func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Cli
 
 	log.Info("found entities to scan for short-id migration", "count", len(resp.Kvs))
 
-	// Build a set of existing refs for collision checking
-	refsResp, err := client.Get(ctx, refsPrefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
+	// Build a set of existing unique keys for collision checking.
+	// We use the full unique key (attrCAS-based) to avoid collisions
+	// between different unique attributes.
+	uniqueResp, err := client.Get(ctx, uniquePrefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to list existing refs: %w", err)
+		return 0, 0, fmt.Errorf("failed to list existing unique keys: %w", err)
 	}
 
-	existingRefs := make(map[string]struct{})
-	for _, kv := range refsResp.Kvs {
-		ref := strings.TrimPrefix(string(kv.Key), refsPrefix)
-		existingRefs[ref] = struct{}{}
+	existingUnique := make(map[string]struct{})
+	for _, kv := range uniqueResp.Kvs {
+		existingUnique[string(kv.Key)] = struct{}{}
 	}
 
 	var errorCount int
@@ -78,9 +79,13 @@ func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Cli
 			continue
 		}
 
-		// Allocate short-id using in-memory set for collision checking
+		// Allocate short-id using in-memory set for collision checking.
+		// We build the full unique key for each candidate to check against
+		// the in-memory set.
 		shortId, allocErr := AllocateShortId(entityId, func(candidate string) (bool, error) {
-			_, exists := existingRefs[candidate]
+			candidateAttr := String(DBShortId, candidate)
+			candidateKey := fmt.Sprintf("%s%s", uniquePrefix, candidateAttr.CAS())
+			_, exists := existingUnique[candidateKey]
 			return exists, nil
 		})
 		if allocErr != nil {
@@ -92,7 +97,8 @@ func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Cli
 		if opts.DryRun {
 			log.Info("dry-run: would assign short-id", "entity", entityId, "short_id", shortId)
 			migrated++
-			existingRefs[shortId] = struct{}{}
+			shortIdAttr := String(DBShortId, shortId)
+			existingUnique[fmt.Sprintf("%s%s", uniquePrefix, shortIdAttr.CAS())] = struct{}{}
 			continue
 		}
 
@@ -106,13 +112,18 @@ func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Cli
 			continue
 		}
 
-		// Write the updated entity and ref index entry atomically
-		refKey := refsPrefix + shortId
+		// Write the updated entity and unique key atomically.
+		// Guard with ModRevision to avoid clobbering concurrent updates.
+		shortIdAttr := String(DBShortId, shortId)
+		uniqueKey := fmt.Sprintf("%s%s", uniquePrefix, shortIdAttr.CAS())
 		txnResp, txnErr := client.Txn(ctx).
-			If(clientv3.Compare(clientv3.CreateRevision(refKey), "=", 0)).
+			If(
+				clientv3.Compare(clientv3.ModRevision(key), "=", kv.ModRevision),
+				clientv3.Compare(clientv3.CreateRevision(uniqueKey), "=", 0),
+			).
 			Then(
 				clientv3.OpPut(key, string(newData)),
-				clientv3.OpPut(refKey, entityId),
+				clientv3.OpPut(uniqueKey, entityId),
 			).
 			Commit()
 
@@ -123,13 +134,13 @@ func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Cli
 		}
 
 		if !txnResp.Succeeded {
-			// Ref was claimed by a concurrent operation; try again with a new id
-			log.Warn("short-id collision during migration, skipping", "entity", entityId, "short_id", shortId)
+			log.Warn("short-id migration skipped entity (concurrent modification or collision)",
+				"entity", entityId, "short_id", shortId)
 			errorCount++
 			continue
 		}
 
-		existingRefs[shortId] = struct{}{}
+		existingUnique[uniqueKey] = struct{}{}
 		migrated++
 
 		if migrated%100 == 0 {

--- a/pkg/entity/shortid_migrate.go
+++ b/pkg/entity/shortid_migrate.go
@@ -1,0 +1,148 @@
+package entity
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path"
+	"strings"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// MigrateShortIdOptions configures the short-id migration behavior.
+type MigrateShortIdOptions struct {
+	DryRun bool
+	Prefix string
+}
+
+// MigrateShortIds backfills db/short-id for all entities that don't have one.
+// This is idempotent — entities that already have a short-id are skipped.
+func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Client, opts MigrateShortIdOptions) (migrated int, skipped int, err error) {
+	prefix := path.Join(opts.Prefix, "entity")
+	refsPrefix := path.Join(opts.Prefix, "refs") + "/"
+
+	log.Info("starting short-id migration", "prefix", prefix, "dry_run", opts.DryRun)
+
+	resp, err := client.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to list entities: %w", err)
+	}
+
+	log.Info("found entities to scan for short-id migration", "count", len(resp.Kvs))
+
+	// Build a set of existing refs for collision checking
+	refsResp, err := client.Get(ctx, refsPrefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to list existing refs: %w", err)
+	}
+
+	existingRefs := make(map[string]struct{})
+	for _, kv := range refsResp.Kvs {
+		ref := strings.TrimPrefix(string(kv.Key), refsPrefix)
+		existingRefs[ref] = struct{}{}
+	}
+
+	var errorCount int
+
+	for _, kv := range resp.Kvs {
+		key := string(kv.Key)
+
+		// Skip session keys
+		if strings.Contains(key, "/session/") {
+			continue
+		}
+
+		var ent Entity
+		if err := Decode(kv.Value, &ent); err != nil {
+			log.Warn("failed to decode entity during short-id migration", "key", key, "error", err)
+			errorCount++
+			continue
+		}
+
+		// Skip entities that already have a short-id
+		if ent.ShortId() != "" {
+			skipped++
+			continue
+		}
+
+		// Skip system/schema entities (no entity/kind attribute)
+		if _, hasKind := ent.Get(EntityKind); !hasKind {
+			skipped++
+			continue
+		}
+
+		entityId := string(ent.Id())
+		if entityId == "" {
+			skipped++
+			continue
+		}
+
+		// Allocate short-id using in-memory set for collision checking
+		shortId, allocErr := AllocateShortId(entityId, func(candidate string) (bool, error) {
+			_, exists := existingRefs[candidate]
+			return exists, nil
+		})
+		if allocErr != nil {
+			log.Warn("failed to allocate short-id", "entity", entityId, "error", allocErr)
+			errorCount++
+			continue
+		}
+
+		if opts.DryRun {
+			log.Info("dry-run: would assign short-id", "entity", entityId, "short_id", shortId)
+			migrated++
+			existingRefs[shortId] = struct{}{}
+			continue
+		}
+
+		// Set the short-id on the entity
+		ent.Set(String(DBShortId, shortId))
+
+		newData, encErr := Encode(&ent)
+		if encErr != nil {
+			log.Warn("failed to encode entity with short-id", "entity", entityId, "error", encErr)
+			errorCount++
+			continue
+		}
+
+		// Write the updated entity and ref index entry atomically
+		refKey := refsPrefix + shortId
+		txnResp, txnErr := client.Txn(ctx).
+			If(clientv3.Compare(clientv3.CreateRevision(refKey), "=", 0)).
+			Then(
+				clientv3.OpPut(key, string(newData)),
+				clientv3.OpPut(refKey, entityId),
+			).
+			Commit()
+
+		if txnErr != nil {
+			log.Warn("failed to write short-id migration", "entity", entityId, "error", txnErr)
+			errorCount++
+			continue
+		}
+
+		if !txnResp.Succeeded {
+			// Ref was claimed by a concurrent operation; try again with a new id
+			log.Warn("short-id collision during migration, skipping", "entity", entityId, "short_id", shortId)
+			errorCount++
+			continue
+		}
+
+		existingRefs[shortId] = struct{}{}
+		migrated++
+
+		if migrated%100 == 0 {
+			log.Info("short-id migration progress", "migrated", migrated, "skipped", skipped)
+		}
+	}
+
+	if errorCount > 0 {
+		log.Warn("short-id migration completed with errors",
+			"migrated", migrated, "skipped", skipped, "errors", errorCount)
+		return migrated, skipped, fmt.Errorf("short-id migration completed with %d errors", errorCount)
+	}
+
+	log.Info("short-id migration completed", "migrated", migrated, "skipped", skipped)
+	return migrated, skipped, nil
+}

--- a/pkg/entity/shortid_migrate_test.go
+++ b/pkg/entity/shortid_migrate_test.go
@@ -47,9 +47,6 @@ func TestMigrateShortIds(t *testing.T) {
 	r.NoError(err)
 	_, err = client.Put(ctx, prefix+"entity/sandbox-blog-web-CZAtBvhsMNbG38MceikkB", string(data2))
 	r.NoError(err)
-	// Pre-populate its ref entry
-	_, err = client.Put(ctx, prefix+"refs/kkB", "sandbox/blog-web-CZAtBvhsMNbG38MceikkB")
-	r.NoError(err)
 
 	// Create a system entity with no entity/kind (should be skipped)
 	ent3 := New(
@@ -84,11 +81,13 @@ func TestMigrateShortIds(t *testing.T) {
 	// Should be derived from the base58 suffix "CZ1eUgSgNd28ed6vt2DgY" → last 3 chars "DgY"
 	r.Equal("DgY", shortId)
 
-	// Verify the ref index entry was created
-	refResp, err := client.Get(ctx, prefix+"refs/"+shortId)
+	// Verify the unique key was created
+	shortIdAttr := String(DBShortId, shortId)
+	uniqueKey := prefix + "unique/" + shortIdAttr.CAS()
+	uniqueResp, err := client.Get(ctx, uniqueKey)
 	r.NoError(err)
-	r.Len(refResp.Kvs, 1)
-	r.Equal("deployment-CZ1eUgSgNd28ed6vt2DgY", string(refResp.Kvs[0].Value))
+	r.Len(uniqueResp.Kvs, 1)
+	r.Equal("deployment-CZ1eUgSgNd28ed6vt2DgY", string(uniqueResp.Kvs[0].Value))
 
 	// Run migration again — should be idempotent
 	migrated2, skipped2, err := MigrateShortIds(ctx, log, client, MigrateShortIdOptions{
@@ -144,8 +143,8 @@ func TestMigrateShortIdsDryRun(t *testing.T) {
 	r.NoError(err)
 	r.Empty(unchangedEnt.ShortId(), "dry run should not write short-id")
 
-	// Verify no ref was created
-	refResp, err := client.Get(ctx, prefix+"refs/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+	// Verify no unique keys were created
+	uniqueResp, err := client.Get(ctx, prefix+"unique/", clientv3.WithPrefix(), clientv3.WithCountOnly())
 	r.NoError(err)
-	r.Equal(int64(0), refResp.Count, "dry run should not create ref entries")
+	r.Equal(int64(0), uniqueResp.Count, "dry run should not create unique entries")
 }

--- a/pkg/entity/shortid_migrate_test.go
+++ b/pkg/entity/shortid_migrate_test.go
@@ -1,0 +1,151 @@
+package entity
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func TestMigrateShortIds(t *testing.T) {
+	r := require.New(t)
+
+	client := setupTestEtcd(t)
+	ctx := context.Background()
+
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	prefix := "/test-migrate-shortids/"
+
+	// Clean up test data
+	_, err := client.Delete(ctx, prefix, clientv3.WithPrefix())
+	r.NoError(err)
+
+	// Create entity with entity/kind but no short-id (should get one)
+	ent1 := New(
+		Ref(DBId, "deployment-CZ1eUgSgNd28ed6vt2DgY"),
+		Ref(EntityKind, "core.deployment"),
+		String("deployment/name", "web"),
+	)
+	data1, err := Encode(ent1)
+	r.NoError(err)
+	_, err = client.Put(ctx, prefix+"entity/deployment-CZ1eUgSgNd28ed6vt2DgY", string(data1))
+	r.NoError(err)
+
+	// Create entity that already has a short-id (should be skipped)
+	ent2 := New(
+		Ref(DBId, "sandbox/blog-web-CZAtBvhsMNbG38MceikkB"),
+		Ref(EntityKind, "compute.sandbox"),
+		String(DBShortId, "kkB"),
+	)
+	data2, err := Encode(ent2)
+	r.NoError(err)
+	_, err = client.Put(ctx, prefix+"entity/sandbox-blog-web-CZAtBvhsMNbG38MceikkB", string(data2))
+	r.NoError(err)
+	// Pre-populate its ref entry
+	_, err = client.Put(ctx, prefix+"refs/kkB", "sandbox/blog-web-CZAtBvhsMNbG38MceikkB")
+	r.NoError(err)
+
+	// Create a system entity with no entity/kind (should be skipped)
+	ent3 := New(
+		Ref(DBId, "db/type.str"),
+		String(Doc, "String type"),
+	)
+	data3, err := Encode(ent3)
+	r.NoError(err)
+	_, err = client.Put(ctx, prefix+"entity/db-type-str", string(data3))
+	r.NoError(err)
+
+	// Run migration
+	migrated, skipped, err := MigrateShortIds(ctx, log, client, MigrateShortIdOptions{
+		Prefix: prefix,
+		DryRun: false,
+	})
+	r.NoError(err)
+	r.Equal(1, migrated, "should migrate 1 entity")
+	r.Equal(2, skipped, "should skip 2 entities (one with short-id, one system)")
+
+	// Verify the migrated entity got a short-id
+	resp, err := client.Get(ctx, prefix+"entity/deployment-CZ1eUgSgNd28ed6vt2DgY")
+	r.NoError(err)
+	r.Len(resp.Kvs, 1)
+
+	var migratedEnt Entity
+	err = Decode(resp.Kvs[0].Value, &migratedEnt)
+	r.NoError(err)
+
+	shortId := migratedEnt.ShortId()
+	r.NotEmpty(shortId, "migrated entity should have a short-id")
+	// Should be derived from the base58 suffix "CZ1eUgSgNd28ed6vt2DgY" → last 3 chars "DgY"
+	r.Equal("DgY", shortId)
+
+	// Verify the ref index entry was created
+	refResp, err := client.Get(ctx, prefix+"refs/"+shortId)
+	r.NoError(err)
+	r.Len(refResp.Kvs, 1)
+	r.Equal("deployment-CZ1eUgSgNd28ed6vt2DgY", string(refResp.Kvs[0].Value))
+
+	// Run migration again — should be idempotent
+	migrated2, skipped2, err := MigrateShortIds(ctx, log, client, MigrateShortIdOptions{
+		Prefix: prefix,
+		DryRun: false,
+	})
+	r.NoError(err)
+	r.Equal(0, migrated2, "second run should migrate 0 entities")
+	r.Equal(3, skipped2, "second run should skip all 3 entities")
+}
+
+func TestMigrateShortIdsDryRun(t *testing.T) {
+	r := require.New(t)
+
+	client := setupTestEtcd(t)
+	ctx := context.Background()
+
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	prefix := "/test-migrate-shortids-dry/"
+
+	// Clean up test data
+	_, err := client.Delete(ctx, prefix, clientv3.WithPrefix())
+	r.NoError(err)
+
+	// Create entity needing a short-id
+	ent := New(
+		Ref(DBId, "deployment-CZ1eUgSgNd28ed6vt2DgY"),
+		Ref(EntityKind, "core.deployment"),
+	)
+	data, err := Encode(ent)
+	r.NoError(err)
+	_, err = client.Put(ctx, prefix+"entity/deployment-CZ1eUgSgNd28ed6vt2DgY", string(data))
+	r.NoError(err)
+
+	// Dry run should report migration needed but not write
+	migrated, _, err := MigrateShortIds(ctx, log, client, MigrateShortIdOptions{
+		Prefix: prefix,
+		DryRun: true,
+	})
+	r.NoError(err)
+	r.Equal(1, migrated)
+
+	// Verify entity was NOT modified
+	resp, err := client.Get(ctx, prefix+"entity/deployment-CZ1eUgSgNd28ed6vt2DgY")
+	r.NoError(err)
+	r.Len(resp.Kvs, 1)
+
+	var unchangedEnt Entity
+	err = Decode(resp.Kvs[0].Value, &unchangedEnt)
+	r.NoError(err)
+	r.Empty(unchangedEnt.ShortId(), "dry run should not write short-id")
+
+	// Verify no ref was created
+	refResp, err := client.Get(ctx, prefix+"refs/", clientv3.WithPrefix(), clientv3.WithCountOnly())
+	r.NoError(err)
+	r.Equal(int64(0), refResp.Count, "dry run should not create ref entries")
+}

--- a/pkg/entity/shortid_test.go
+++ b/pkg/entity/shortid_test.go
@@ -1,0 +1,177 @@
+package entity
+
+import (
+	"testing"
+)
+
+func TestExtractBase58Suffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		entityId string
+		wantSfx  string
+		wantOk   bool
+	}{
+		// Category 1: Named entities — no base58 portion
+		{
+			name:     "named app",
+			entityId: "app/blog",
+			wantOk:   false,
+		},
+		{
+			name:     "named route",
+			entityId: "http_route/example.com",
+			wantOk:   false,
+		},
+		// Category 2: Name + prefix + base58 suffix
+		{
+			name:     "app version with v prefix",
+			entityId: "blog-vCZ1eUgSgNd28ed6vt2DgY",
+			wantSfx:  "CZ1eUgSgNd28ed6vt2DgY",
+			wantOk:   true,
+		},
+		{
+			name:     "artifact with a prefix",
+			entityId: "blog-aCZ5PZNZ4MPzoPPGLishEM",
+			wantSfx:  "CZ5PZNZ4MPzoPPGLishEM",
+			wantOk:   true,
+		},
+		{
+			name:     "oidc binding with ob prefix",
+			entityId: "oidcb-obA1b2c3d4e5f6g7h8j9k",
+			wantSfx:  "A1b2c3d4e5f6g7h8j9k",
+			wantOk:   true,
+		},
+		// Category 3: Namespace + prefix-base58
+		{
+			name:     "sandbox with namespace",
+			entityId: "sandbox/blog-web-CZAtBvhsMNbG38MceikkB",
+			wantSfx:  "CZAtBvhsMNbG38MceikkB",
+			wantOk:   true,
+		},
+		{
+			name:     "disk volume",
+			entityId: "disk_volume/disk-vol-CZAtBvhsMNbG38MceikkB",
+			wantSfx:  "CZAtBvhsMNbG38MceikkB",
+			wantOk:   true,
+		},
+		// Category 4: ForceID — kind-base58
+		{
+			name:     "deployment",
+			entityId: "deployment-CZ1eUgSgNd28ed6vt2DgY",
+			wantSfx:  "CZ1eUgSgNd28ed6vt2DgY",
+			wantOk:   true,
+		},
+		{
+			name:     "sandbox pool",
+			entityId: "sandbox_pool-CZ1eUgSgNd28ed6vt2DgY",
+			wantSfx:  "CZ1eUgSgNd28ed6vt2DgY",
+			wantOk:   true,
+		},
+		// Edge cases
+		{
+			name:     "short segment not base58 enough",
+			entityId: "app/my-app",
+			wantOk:   false,
+		},
+		{
+			name:     "empty string",
+			entityId: "",
+			wantOk:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSfx, gotOk := ExtractBase58Suffix(tt.entityId)
+			if gotOk != tt.wantOk {
+				t.Errorf("ExtractBase58Suffix(%q) ok = %v, want %v", tt.entityId, gotOk, tt.wantOk)
+			}
+			if gotSfx != tt.wantSfx {
+				t.Errorf("ExtractBase58Suffix(%q) suffix = %q, want %q", tt.entityId, gotSfx, tt.wantSfx)
+			}
+		})
+	}
+}
+
+func TestAllocateShortId(t *testing.T) {
+	t.Run("derives from suffix", func(t *testing.T) {
+		// Entity with base58 suffix ending in "DgY"
+		sid, err := AllocateShortId("blog-vCZ1eUgSgNd28ed6vt2DgY", func(candidate string) (bool, error) {
+			return false, nil // nothing exists
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if sid != "DgY" {
+			t.Errorf("got %q, want %q", sid, "DgY")
+		}
+	})
+
+	t.Run("grows on collision", func(t *testing.T) {
+		calls := 0
+		sid, err := AllocateShortId("blog-vCZ1eUgSgNd28ed6vt2DgY", func(candidate string) (bool, error) {
+			calls++
+			// First candidate "DgY" collides, second "2DgY" is free
+			return calls == 1, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if sid != "2DgY" {
+			t.Errorf("got %q, want %q", sid, "2DgY")
+		}
+	})
+
+	t.Run("falls back to random for named entities", func(t *testing.T) {
+		sid, err := AllocateShortId("app/blog", func(candidate string) (bool, error) {
+			return false, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(sid) < defaultShortIdLen {
+			t.Errorf("random short-id too short: %q", sid)
+		}
+		if !isBase58(sid) {
+			t.Errorf("random short-id contains non-base58 chars: %q", sid)
+		}
+	})
+
+	t.Run("falls back to random when all suffix candidates collide", func(t *testing.T) {
+		suffixCalls := 0
+		sid, err := AllocateShortId("blog-vCZ1eUgSgNd28ed6vt2DgY", func(candidate string) (bool, error) {
+			suffixCalls++
+			// All suffix-derived candidates collide (there are 21 chars in the suffix)
+			if suffixCalls <= 21-defaultShortIdLen+1 {
+				return true, nil
+			}
+			// Random ones succeed
+			return false, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(sid) < defaultShortIdLen {
+			t.Errorf("fallback short-id too short: %q", sid)
+		}
+	})
+}
+
+func TestIsBase58(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"123456789", true},
+		{"ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz", true},
+		{"", false},
+		{"0OIl", false},
+		{"hello world", false},
+	}
+	for _, tt := range tests {
+		got := isBase58(tt.input)
+		if got != tt.want {
+			t.Errorf("isBase58(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -668,6 +668,9 @@ func (s *EtcdStore) UpdateEntity(
 		return nil, cond.Conflict("entity", entity.Id())
 	}
 
+	// Snapshot original entity for unique-value diffing
+	originalEntity := entity.Clone()
+
 	// Keep track of original indexed attributes for removal (including nested ones)
 	originalIndexedAttrs, err := s.collectIndexedAttributes(ctx, entity.attrs)
 	if err != nil {
@@ -750,6 +753,13 @@ func (s *EtcdStore) UpdateEntity(
 		}
 	}
 
+	// Build unique-value update operations (release old, claim new)
+	uniqueOps, uniqueConditions, err := s.buildUniqueUpdateOps(ctx, entity.Id(), originalEntity, entity)
+	if err != nil {
+		return nil, err
+	}
+	coltxopt = append(coltxopt, uniqueOps...)
+
 	entity.attrs = primary
 
 	// Build entity save operations
@@ -763,15 +773,20 @@ func (s *EtcdStore) UpdateEntity(
 
 	var txnResp *clientv3.TxnResponse
 
-	// When using 0 as the from rev, we skip the revision check
-	if o.fromRevision == 0 {
+	// Build conditions: revision check + unique-value constraints
+	var conditions []clientv3.Cmp
+	if o.fromRevision != 0 {
+		conditions = append(conditions, clientv3.Compare(clientv3.ModRevision(key), "=", rev))
+	}
+	conditions = append(conditions, uniqueConditions...)
+
+	if len(conditions) > 0 {
 		txnResp, err = s.client.Txn(ctx).
+			If(conditions...).
 			Then(txopt...).
 			Commit()
 	} else {
-		// Use Txn to check that the key exists before updating
 		txnResp, err = s.client.Txn(ctx).
-			If(clientv3.Compare(clientv3.ModRevision(key), "=", rev)).
 			Then(txopt...).
 			Commit()
 	}
@@ -896,6 +911,50 @@ func (s *EtcdStore) buildCollectionOps(entity *Entity, originalIndexedAttrs, new
 	return ops
 }
 
+// buildUniqueUpdateOps compares the old and new unique-value attributes and
+// returns operations to release old unique keys and claim new ones, along with
+// conditions that ensure the new keys don't already exist.
+func (s *EtcdStore) buildUniqueUpdateOps(ctx context.Context, entityId Id, oldEntity, newEntity *Entity) (ops []clientv3.Op, conditions []clientv3.Cmp, err error) {
+	oldUnique, err := s.collectUniqueAttrs(ctx, oldEntity)
+	if err != nil {
+		return nil, nil, err
+	}
+	newUnique, err := s.collectUniqueAttrs(ctx, newEntity)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Build maps for comparison
+	oldByID := make(map[Id]Attr)
+	for _, attr := range oldUnique {
+		oldByID[attr.ID] = attr
+	}
+	newByID := make(map[Id]Attr)
+	for _, attr := range newUnique {
+		newByID[attr.ID] = attr
+	}
+
+	// Release old unique keys for values that changed or were removed
+	for id, oldAttr := range oldByID {
+		newAttr, exists := newByID[id]
+		if !exists || !oldAttr.Equal(newAttr) {
+			ops = append(ops, s.deleteUniqueOp(oldAttr))
+		}
+	}
+
+	// Claim new unique keys for values that changed or were added
+	for id, newAttr := range newByID {
+		oldAttr, exists := oldByID[id]
+		if !exists || !oldAttr.Equal(newAttr) {
+			uniqueKey := s.buildUniqueKey(newAttr)
+			conditions = append(conditions, clientv3.Compare(clientv3.CreateRevision(uniqueKey), "=", 0))
+			ops = append(ops, s.addUniqueOp(newAttr, entityId))
+		}
+	}
+
+	return ops, conditions, nil
+}
+
 // buildEntitySaveOps builds etcd operations for saving entity data (primary and session attributes)
 func (s *EtcdStore) buildEntitySaveOps(entity *Entity, key string, primary, session []Attr, o *entityOpts) ([]clientv3.Op, error) {
 	var ops []clientv3.Op
@@ -956,12 +1015,13 @@ func (s *EtcdStore) ReplaceEntity(
 		return nil, err
 	}
 
-	// Get current entity to check revision
+	// Get current entity to check revision and snapshot for unique-value diffing
 	entity, err := s.GetEntity(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
+	originalEntity := entity.Clone()
 	rev := entity.GetRevision()
 
 	repl := current.Clone()
@@ -1008,6 +1068,13 @@ func (s *EtcdStore) ReplaceEntity(
 	}
 	coltxopt := s.buildCollectionOps(repl, originalIndexedAttrs, newIndexedAttrs, sessPart, sid)
 
+	// Build unique-value update operations (release old, claim new)
+	uniqueOps, uniqueConditions, err := s.buildUniqueUpdateOps(ctx, repl.Id(), originalEntity, repl)
+	if err != nil {
+		return nil, err
+	}
+	coltxopt = append(coltxopt, uniqueOps...)
+
 	// Build entity save operations
 	key := s.buildKey(repl.Id())
 	txopt, err := s.buildEntitySaveOps(repl, key, primary, session, &o)
@@ -1019,15 +1086,20 @@ func (s *EtcdStore) ReplaceEntity(
 
 	var txnResp *clientv3.TxnResponse
 
-	// When using 0 as the from rev, we skip the revision check
-	if o.fromRevision == 0 {
+	// Build conditions: revision check + unique-value constraints
+	var conditions []clientv3.Cmp
+	if o.fromRevision != 0 {
+		conditions = append(conditions, clientv3.Compare(clientv3.ModRevision(key), "=", rev))
+	}
+	conditions = append(conditions, uniqueConditions...)
+
+	if len(conditions) > 0 {
 		txnResp, err = s.client.Txn(ctx).
+			If(conditions...).
 			Then(txopt...).
 			Commit()
 	} else {
-		// Use Txn to check that the entity hasn't changed
 		txnResp, err = s.client.Txn(ctx).
-			If(clientv3.Compare(clientv3.ModRevision(key), "=", rev)).
 			Then(txopt...).
 			Commit()
 	}
@@ -1066,11 +1138,13 @@ func (s *EtcdStore) PatchEntity(
 		return nil, err
 	}
 
-	// Get current entity
+	// Get current entity and snapshot for unique-value diffing
 	entity, err := s.GetEntity(ctx, id)
 	if err != nil {
 		return nil, err
 	}
+
+	originalEntity := entity.Clone()
 
 	// Check revision if specified
 	if err := s.checkRevisionConflict(entity, o.fromRevision); err != nil {
@@ -1131,6 +1205,13 @@ func (s *EtcdStore) PatchEntity(
 	}
 	coltxopt := s.buildCollectionOps(entity, originalIndexedAttrs, newIndexedAttrs, sessPart, sid)
 
+	// Build unique-value update operations (release old, claim new)
+	uniqueOps, uniqueConditions, err := s.buildUniqueUpdateOps(ctx, entity.Id(), originalEntity, entity)
+	if err != nil {
+		return nil, err
+	}
+	coltxopt = append(coltxopt, uniqueOps...)
+
 	entity.attrs = primary
 
 	// Build entity save operations
@@ -1144,15 +1225,20 @@ func (s *EtcdStore) PatchEntity(
 
 	var txnResp *clientv3.TxnResponse
 
-	// When using 0 as the from rev, we skip the revision check
-	if o.fromRevision == 0 {
+	// Build conditions: revision check + unique-value constraints
+	var conditions []clientv3.Cmp
+	if o.fromRevision != 0 {
+		conditions = append(conditions, clientv3.Compare(clientv3.ModRevision(key), "=", rev))
+	}
+	conditions = append(conditions, uniqueConditions...)
+
+	if len(conditions) > 0 {
 		txnResp, err = s.client.Txn(ctx).
+			If(conditions...).
 			Then(txopt...).
 			Commit()
 	} else {
-		// Use Txn to check that the key exists before updating
 		txnResp, err = s.client.Txn(ctx).
-			If(clientv3.Compare(clientv3.ModRevision(key), "=", rev)).
 			Then(txopt...).
 			Commit()
 	}

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -172,7 +172,7 @@ func (s *EtcdStore) CreateEntity(
 	if _, hasKind := entity.Get(EntityKind); hasKind {
 		if _, hasShortId := entity.Get(DBShortId); !hasShortId {
 			shortId, err := AllocateShortId(string(entity.Id()), func(candidate string) (bool, error) {
-				return s.refExists(ctx, candidate)
+				return s.uniqueExists(ctx, String(DBShortId, candidate))
 			})
 			if err != nil {
 				return nil, fmt.Errorf("failed to allocate short-id: %w", err)
@@ -224,12 +224,26 @@ func (s *EtcdStore) CreateEntity(
 		}
 	}
 
+	// Collect unique-value attributes and build transaction conditions + ops
+	uniqueAttrs, err := s.collectUniqueAttrs(ctx, entity)
+	if err != nil {
+		return nil, err
+	}
+
+	var uniqueConditions []clientv3.Cmp
+	for _, attr := range uniqueAttrs {
+		uniqueKey := s.buildUniqueKey(attr)
+		uniqueConditions = append(uniqueConditions, clientv3.Compare(clientv3.CreateRevision(uniqueKey), "=", 0))
+		coltxopt = append(coltxopt, s.addUniqueOp(attr, entity.Id()))
+	}
+
 	entity.attrs = primary
 	key := s.buildKey(entity.Id())
 
-	// Retry loop: if the create transaction fails due to a short-id ref
-	// collision (TOCTOU race), allocate a new short-id and try again.
-	const maxRefRetries = 3
+	// Retry loop: if the create transaction fails due to a unique-value
+	// collision (TOCTOU race on short-id or other unique attr), allocate
+	// a new value and try again.
+	const maxUniqueRetries = 3
 	for attempt := 0; ; attempt++ {
 		// Build entity save operations (must rebuild each attempt since
 		// short-id changes affect the serialized entity data)
@@ -240,15 +254,11 @@ func (s *EtcdStore) CreateEntity(
 
 		txopt = append(txopt, coltxopt...)
 
-		// Build transaction conditions and include ref uniqueness check
-		var conditions []clientv3.Cmp
-		conditions = append(conditions, clientv3.Compare(clientv3.CreateRevision(key), "=", 0))
-
-		if shortId := entity.ShortId(); shortId != "" {
-			refKey := s.buildRefKey(shortId)
-			conditions = append(conditions, clientv3.Compare(clientv3.CreateRevision(refKey), "=", 0))
-			txopt = append(txopt, s.addRefOp(shortId, entity.Id()))
+		// Build transaction conditions: entity must not exist + all unique values must be free
+		conditions := []clientv3.Cmp{
+			clientv3.Compare(clientv3.CreateRevision(key), "=", 0),
 		}
+		conditions = append(conditions, uniqueConditions...)
 
 		txnResp, err := s.client.Txn(ctx).
 			If(conditions...).
@@ -267,7 +277,7 @@ func (s *EtcdStore) CreateEntity(
 
 		// Transaction failed — figure out why.
 		// Check if the entity key already exists (genuine conflict) vs
-		// only the ref key was taken (short-id race, retryable).
+		// a unique-value condition failed (retryable).
 		if len(txnResp.Responses) == 1 {
 			rng := txnResp.Responses[0].GetResponseRange()
 			if len(rng.Kvs) > 0 {
@@ -283,9 +293,22 @@ func (s *EtcdStore) CreateEntity(
 				}
 
 				if o.overwrite {
+					// On overwrite, preserve the existing entity's short-id
+					// to avoid changing a stable identifier.
+					if existingShortId := curr.ShortId(); existingShortId != "" {
+						entity.Set(String(DBShortId, existingShortId))
+						primary = entity.Attrs()
+					}
+
+					txopt, err = s.buildEntitySaveOps(entity, key, primary, session, &o)
+					if err != nil {
+						return nil, err
+					}
+					// No unique ops needed on overwrite — values are already claimed
+					txopt = append(txopt, coltxopt...)
+
 					txnResp, err = s.client.Txn(ctx).
 						Then(txopt...).
-						Else(clientv3.OpGet(key)).
 						Commit()
 					if err != nil {
 						return nil, fmt.Errorf("failed to create entity in etcd (on overwrite): %w", err)
@@ -300,26 +323,47 @@ func (s *EtcdStore) CreateEntity(
 			}
 		}
 
-		// Entity key didn't exist, so the ref condition must have failed.
-		// Allocate a new short-id and retry.
-		if attempt >= maxRefRetries {
-			s.log.Error("short-id ref collision persisted after retries", "id", entity.Id())
-			return nil, fmt.Errorf("failed to create entity: short-id collision after %d retries", maxRefRetries)
+		// Entity key didn't exist, so a unique-value condition failed.
+		// Re-allocate the short-id and retry.
+		if attempt >= maxUniqueRetries {
+			s.log.Error("unique value collision persisted after retries", "id", entity.Id())
+			return nil, fmt.Errorf("failed to create entity: unique value collision after %d retries", maxUniqueRetries)
 		}
 
-		s.log.Info("short-id ref collision, retrying with new short-id",
+		s.log.Info("unique value collision, retrying with new short-id",
 			"id", entity.Id(), "old_short_id", entity.ShortId(), "attempt", attempt+1)
 
 		newShortId, err := AllocateShortId(string(entity.Id()), func(candidate string) (bool, error) {
-			return s.refExists(ctx, candidate)
+			return s.uniqueExists(ctx, String(DBShortId, candidate))
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to reallocate short-id: %w", err)
 		}
 		entity.Set(String(DBShortId, newShortId))
 
-		// Rebuild primary attrs with the new short-id
+		// Rebuild primary attrs and unique conditions with the new short-id
 		primary = entity.Attrs()
+
+		uniqueAttrs, err = s.collectUniqueAttrs(ctx, entity)
+		if err != nil {
+			return nil, err
+		}
+		uniqueConditions = nil
+		// Rebuild coltxopt without old unique ops — keep collection ops, replace unique ops
+		coltxopt = coltxopt[:0]
+		for _, attrs := range indexedAttrs {
+			for _, attr := range attrs {
+				coltxopt = append(coltxopt, s.addToCollectionOp(entity, attr.CAS()))
+				if sessPart != "" {
+					coltxopt = append(coltxopt, s.addToCollectionSessionOp(entity, attr.CAS(), sessPart, sid))
+				}
+			}
+		}
+		for _, attr := range uniqueAttrs {
+			uniqueKey := s.buildUniqueKey(attr)
+			uniqueConditions = append(uniqueConditions, clientv3.Compare(clientv3.CreateRevision(uniqueKey), "=", 0))
+			coltxopt = append(coltxopt, s.addUniqueOp(attr, entity.Id()))
+		}
 	}
 }
 
@@ -1196,19 +1240,23 @@ func (s *EtcdStore) DeleteEntity(ctx context.Context, id Id) error {
 		}
 	}
 
-	// Clean up ref index entries
-	if shortId := entity.ShortId(); shortId != "" {
-		if _, err := s.client.Delete(ctx, s.buildRefKey(shortId)); err != nil {
-			s.log.Warn("failed to delete short-id ref", "short_id", shortId, "error", err)
-		}
-	}
-
 	key := s.buildKey(id)
+
+	// Build delete operations: entity key + unique-value keys
+	ops := []clientv3.Op{clientv3.OpDelete(key)}
+
+	uniqueAttrs, err := s.collectUniqueAttrs(ctx, entity)
+	if err != nil {
+		return err
+	}
+	for _, attr := range uniqueAttrs {
+		ops = append(ops, s.deleteUniqueOp(attr))
+	}
 
 	// Use Txn to check that the key exists before deleting
 	txnResp, err := s.client.Txn(ctx).
 		If(clientv3.Compare(clientv3.ModRevision(key), "=", entity.GetRevision())).
-		Then(clientv3.OpDelete(key)).
+		Then(ops...).
 		Commit()
 
 	if err != nil {
@@ -1439,35 +1487,77 @@ func (s *EtcdStore) CollectionPrefix(ctx context.Context, collection string) (st
 	return fmt.Sprintf("%s/collections/%s/", s.prefix, colKey), nil
 }
 
-// buildRefKey returns the etcd key for a ref index entry.
-func (s *EtcdStore) buildRefKey(ref string) string {
-	return fmt.Sprintf("%s/refs/%s", s.prefix, ref)
+// BuildUniqueKeyForTest exposes buildUniqueKey for use in tests.
+func (s *EtcdStore) BuildUniqueKeyForTest(attr Attr) string {
+	return s.buildUniqueKey(attr)
 }
 
-// addRefOp returns an etcd put operation that maps a ref value to an entity ID.
-func (s *EtcdStore) addRefOp(ref string, entityId Id) clientv3.Op {
-	return clientv3.OpPut(s.buildRefKey(ref), string(entityId))
+// buildUniqueKey returns the etcd key for a unique-value constraint.
+// The key is namespaced by the attribute's CAS to avoid collisions
+// between different unique attributes that happen to share a value.
+func (s *EtcdStore) buildUniqueKey(attr Attr) string {
+	return fmt.Sprintf("%s/unique/%s", s.prefix, attr.CAS())
 }
 
-// refExists checks whether a ref value is already in the ref index.
-func (s *EtcdStore) refExists(ctx context.Context, ref string) (bool, error) {
-	resp, err := s.client.Get(ctx, s.buildRefKey(ref), clientv3.WithCountOnly())
+// addUniqueOp returns an etcd put operation that claims a unique value.
+func (s *EtcdStore) addUniqueOp(attr Attr, entityId Id) clientv3.Op {
+	return clientv3.OpPut(s.buildUniqueKey(attr), string(entityId))
+}
+
+// deleteUniqueOp returns an etcd delete operation that releases a unique value.
+func (s *EtcdStore) deleteUniqueOp(attr Attr) clientv3.Op {
+	return clientv3.OpDelete(s.buildUniqueKey(attr))
+}
+
+// uniqueExists checks whether a unique value is already claimed.
+func (s *EtcdStore) uniqueExists(ctx context.Context, attr Attr) (bool, error) {
+	resp, err := s.client.Get(ctx, s.buildUniqueKey(attr), clientv3.WithCountOnly())
 	if err != nil {
-		return false, fmt.Errorf("failed to check ref existence: %w", err)
+		return false, fmt.Errorf("failed to check unique value existence: %w", err)
 	}
 	return resp.Count > 0, nil
 }
 
-// ResolveRef looks up a ref string (short-id, name, etc.) in the ref index
-// and returns the corresponding entity ID if found.
-func (s *EtcdStore) ResolveRef(ctx context.Context, ref string) (Id, error) {
-	resp, err := s.client.Get(ctx, s.buildRefKey(ref))
+// collectUniqueAttrs returns all attributes on the entity that have
+// UniqueValue enforcement according to their schema.
+func (s *EtcdStore) collectUniqueAttrs(ctx context.Context, entity *Entity) ([]Attr, error) {
+	var unique []Attr
+	for _, attr := range entity.attrs {
+		schema, err := s.GetAttributeSchema(ctx, attr.ID)
+		if err != nil {
+			continue // schema entities won't have schemas for their own attrs
+		}
+		if schema.Unique == uniqVal {
+			unique = append(unique, attr)
+		}
+	}
+	return unique, nil
+}
+
+// GetOneIndex looks up a single entity by an indexed attribute value.
+// Returns the entity ID if exactly one match is found, or ErrNotFound.
+func (s *EtcdStore) GetOneIndex(ctx context.Context, attr Attr) (Id, error) {
+	schema, err := s.GetAttributeSchema(ctx, attr.ID)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve ref: %w", err)
+		return "", err
 	}
+
+	if !schema.Index {
+		return "", fmt.Errorf("attribute %s is not indexed", attr.ID)
+	}
+
+	colKey := tr.Replace(attr.CAS())
+	prefix := fmt.Sprintf("%s/collections/%s/", s.prefix, colKey)
+
+	resp, err := s.client.Get(ctx, prefix, clientv3.WithPrefix(), clientv3.WithLimit(1))
+	if err != nil {
+		return "", fmt.Errorf("failed to query index: %w", err)
+	}
+
 	if len(resp.Kvs) == 0 {
-		return "", cond.NotFound("ref", ref)
+		return "", cond.NotFound("entity", attr.Value.String())
 	}
+
 	return Id(resp.Kvs[0].Value), nil
 }
 

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -167,6 +167,20 @@ func (s *EtcdStore) CreateEntity(
 
 	entity.ForceID()
 
+	// Allocate a short-id for entities that have an entity/kind attribute
+	// (skip system/schema entities which are saved via basicSave)
+	if _, hasKind := entity.Get(EntityKind); hasKind {
+		if _, hasShortId := entity.Get(DBShortId); !hasShortId {
+			shortId, err := AllocateShortId(string(entity.Id()), func(candidate string) (bool, error) {
+				return s.refExists(ctx, candidate)
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to allocate short-id: %w", err)
+			}
+			entity.Set(String(DBShortId, shortId))
+		}
+	}
+
 	// Revision is an attr maintained by the store itself, so we remove it
 	// and allow it to be repopulated later. This is mostly to avoid confusion
 	// when retrieving an entity, before stamping it with the current etcd revision.
@@ -211,65 +225,102 @@ func (s *EtcdStore) CreateEntity(
 	}
 
 	entity.attrs = primary
-
-	// Build entity save operations
 	key := s.buildKey(entity.Id())
-	txopt, err := s.buildEntitySaveOps(entity, key, primary, session, &o)
-	if err != nil {
-		return nil, err
-	}
 
-	txopt = append(txopt, coltxopt...)
+	// Retry loop: if the create transaction fails due to a short-id ref
+	// collision (TOCTOU race), allocate a new short-id and try again.
+	const maxRefRetries = 3
+	for attempt := 0; ; attempt++ {
+		// Build entity save operations (must rebuild each attempt since
+		// short-id changes affect the serialized entity data)
+		txopt, err := s.buildEntitySaveOps(entity, key, primary, session, &o)
+		if err != nil {
+			return nil, err
+		}
 
-	// Use Txn to check that the key doesn't exist yet
-	txnResp, err := s.client.Txn(ctx).
-		If(clientv3.Compare(clientv3.CreateRevision(key), "=", 0)).
-		Then(txopt...).
-		Else(clientv3.OpGet(key)).
-		Commit()
+		txopt = append(txopt, coltxopt...)
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to create entity in etcd: %w", err)
-	}
+		// Build transaction conditions and include ref uniqueness check
+		var conditions []clientv3.Cmp
+		conditions = append(conditions, clientv3.Compare(clientv3.CreateRevision(key), "=", 0))
 
-	if !txnResp.Succeeded {
+		if shortId := entity.ShortId(); shortId != "" {
+			refKey := s.buildRefKey(shortId)
+			conditions = append(conditions, clientv3.Compare(clientv3.CreateRevision(refKey), "=", 0))
+			txopt = append(txopt, s.addRefOp(shortId, entity.Id()))
+		}
+
+		txnResp, err := s.client.Txn(ctx).
+			If(conditions...).
+			Then(txopt...).
+			Else(clientv3.OpGet(key)).
+			Commit()
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create entity in etcd: %w", err)
+		}
+
+		if txnResp.Succeeded {
+			entity.SetRevision(txnResp.Header.Revision)
+			return entity, nil
+		}
+
+		// Transaction failed — figure out why.
+		// Check if the entity key already exists (genuine conflict) vs
+		// only the ref key was taken (short-id race, retryable).
 		if len(txnResp.Responses) == 1 {
-			// If the current value of the entity has the same attributes as
-			// the entity we were trying to store, then we're all done!
 			rng := txnResp.Responses[0].GetResponseRange()
+			if len(rng.Kvs) > 0 {
+				// Entity key exists — this is a genuine entity conflict.
+				var curr Entity
+				if decoder.Unmarshal(rng.Kvs[0].Value, &curr) == nil {
+					if slices.EqualFunc(curr.attrs, entity.attrs, func(a, b Attr) bool {
+						return a.Equal(b)
+					}) {
+						entity.SetRevision(rng.Header.Revision)
+						return entity, nil
+					}
+				}
 
-			var curr Entity
+				if o.overwrite {
+					txnResp, err = s.client.Txn(ctx).
+						Then(txopt...).
+						Else(clientv3.OpGet(key)).
+						Commit()
+					if err != nil {
+						return nil, fmt.Errorf("failed to create entity in etcd (on overwrite): %w", err)
+					}
 
-			if decoder.Unmarshal(rng.Kvs[0].Value, &curr) == nil {
-				if slices.EqualFunc(curr.attrs, entity.attrs, func(a, b Attr) bool {
-					return a.Equal(b)
-				}) {
-					entity.SetRevision(rng.Header.Revision)
+					entity.SetRevision(txnResp.Header.Revision)
 					return entity, nil
 				}
-			}
 
-			if o.overwrite {
-				txnResp, err = s.client.Txn(ctx).
-					Then(txopt...).
-					Else(clientv3.OpGet(key)).
-					Commit()
-				if err != nil {
-					return nil, fmt.Errorf("failed to create entity in etcd (on overwrite): %w", err)
-				}
-
-				entity.SetRevision(txnResp.Header.Revision)
-				return entity, nil
+				s.log.Error("failed to create entity in etcd", "id", entity.Id())
+				return nil, cond.Conflict("entity", entity.Id())
 			}
 		}
 
-		s.log.Error("failed to create entity in etcd", "id", entity.Id())
-		return nil, cond.Conflict("entity", entity.Id())
+		// Entity key didn't exist, so the ref condition must have failed.
+		// Allocate a new short-id and retry.
+		if attempt >= maxRefRetries {
+			s.log.Error("short-id ref collision persisted after retries", "id", entity.Id())
+			return nil, fmt.Errorf("failed to create entity: short-id collision after %d retries", maxRefRetries)
+		}
+
+		s.log.Info("short-id ref collision, retrying with new short-id",
+			"id", entity.Id(), "old_short_id", entity.ShortId(), "attempt", attempt+1)
+
+		newShortId, err := AllocateShortId(string(entity.Id()), func(candidate string) (bool, error) {
+			return s.refExists(ctx, candidate)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to reallocate short-id: %w", err)
+		}
+		entity.Set(String(DBShortId, newShortId))
+
+		// Rebuild primary attrs with the new short-id
+		primary = entity.Attrs()
 	}
-
-	entity.SetRevision(txnResp.Header.Revision)
-
-	return entity, nil
 }
 
 // GetEntity implements Store interface
@@ -1145,6 +1196,13 @@ func (s *EtcdStore) DeleteEntity(ctx context.Context, id Id) error {
 		}
 	}
 
+	// Clean up ref index entries
+	if shortId := entity.ShortId(); shortId != "" {
+		if _, err := s.client.Delete(ctx, s.buildRefKey(shortId)); err != nil {
+			s.log.Warn("failed to delete short-id ref", "short_id", shortId, "error", err)
+		}
+	}
+
 	key := s.buildKey(id)
 
 	// Use Txn to check that the key exists before deleting
@@ -1379,6 +1437,38 @@ func (s *EtcdStore) CollectionPrefix(ctx context.Context, collection string) (st
 	colKey := tr.Replace(collection)
 
 	return fmt.Sprintf("%s/collections/%s/", s.prefix, colKey), nil
+}
+
+// buildRefKey returns the etcd key for a ref index entry.
+func (s *EtcdStore) buildRefKey(ref string) string {
+	return fmt.Sprintf("%s/refs/%s", s.prefix, ref)
+}
+
+// addRefOp returns an etcd put operation that maps a ref value to an entity ID.
+func (s *EtcdStore) addRefOp(ref string, entityId Id) clientv3.Op {
+	return clientv3.OpPut(s.buildRefKey(ref), string(entityId))
+}
+
+// refExists checks whether a ref value is already in the ref index.
+func (s *EtcdStore) refExists(ctx context.Context, ref string) (bool, error) {
+	resp, err := s.client.Get(ctx, s.buildRefKey(ref), clientv3.WithCountOnly())
+	if err != nil {
+		return false, fmt.Errorf("failed to check ref existence: %w", err)
+	}
+	return resp.Count > 0, nil
+}
+
+// ResolveRef looks up a ref string (short-id, name, etc.) in the ref index
+// and returns the corresponding entity ID if found.
+func (s *EtcdStore) ResolveRef(ctx context.Context, ref string) (Id, error) {
+	resp, err := s.client.Get(ctx, s.buildRefKey(ref))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve ref: %w", err)
+	}
+	if len(resp.Kvs) == 0 {
+		return "", cond.NotFound("ref", ref)
+	}
+	return Id(resp.Kvs[0].Value), nil
 }
 
 func (s *EtcdStore) CreateSession(ctx context.Context, ttl int64) ([]byte, error) {

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -2203,3 +2203,129 @@ func TestCreateEntity_UniqueValueCollisionRetry(t *testing.T) {
 	require.Len(t, resp.Kvs, 1)
 	assert.Equal(t, entityId, string(resp.Kvs[0].Value))
 }
+
+func TestCreateEntity_AllocatesShortId(t *testing.T) {
+	client := setupTestEtcd(t)
+
+	prefix := "/test-shortid-alloc"
+	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	// Create a kind entity
+	kind, err := store.CreateEntity(t.Context(), New(
+		Any(Ident, KeywordValue("test/sandboxkind")),
+	))
+	require.NoError(t, err)
+
+	// Create an entity with entity/kind — should get a short-id automatically
+	e, err := store.CreateEntity(t.Context(), New(
+		Ref(EntityKind, kind.Id()),
+	))
+	require.NoError(t, err)
+
+	shortId := e.ShortId()
+	require.NotEmpty(t, shortId, "entity with kind should get a short-id")
+
+	// Verify unique key was written
+	attr := String(DBShortId, shortId)
+	uniqueKey := store.BuildUniqueKeyForTest(attr)
+	resp, err := client.Get(t.Context(), uniqueKey)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1)
+	assert.Equal(t, string(e.Id()), string(resp.Kvs[0].Value))
+}
+
+func TestCreateEntity_NoShortIdForSystemEntities(t *testing.T) {
+	client := setupTestEtcd(t)
+
+	prefix := "/test-shortid-system"
+	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	// Create an entity without entity/kind — should NOT get a short-id
+	e, err := store.CreateEntity(t.Context(), New(
+		Any(Ident, KeywordValue("test/plainattr")),
+		String(Doc, "a plain attribute"),
+	))
+	require.NoError(t, err)
+	assert.Empty(t, e.ShortId(), "entity without kind should not get a short-id")
+}
+
+func TestDeleteEntity_CleansUpUniqueKey(t *testing.T) {
+	client := setupTestEtcd(t)
+
+	prefix := "/test-shortid-delete"
+	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	kind, err := store.CreateEntity(t.Context(), New(
+		Any(Ident, KeywordValue("test/delkind")),
+	))
+	require.NoError(t, err)
+
+	e, err := store.CreateEntity(t.Context(), New(
+		Ref(EntityKind, kind.Id()),
+	))
+	require.NoError(t, err)
+
+	shortId := e.ShortId()
+	require.NotEmpty(t, shortId)
+
+	// Verify unique key exists
+	attr := String(DBShortId, shortId)
+	uniqueKey := store.BuildUniqueKeyForTest(attr)
+	resp, err := client.Get(t.Context(), uniqueKey)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1)
+
+	// Delete the entity
+	err = store.DeleteEntity(t.Context(), e.Id())
+	require.NoError(t, err)
+
+	// Unique key should be gone
+	resp, err = client.Get(t.Context(), uniqueKey)
+	require.NoError(t, err)
+	assert.Len(t, resp.Kvs, 0, "unique key should be deleted with entity")
+}
+
+func TestGetOneIndex(t *testing.T) {
+	client := setupTestEtcd(t)
+
+	prefix := "/test-getoneindex"
+	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	kind, err := store.CreateEntity(t.Context(), New(
+		Any(Ident, KeywordValue("test/idxkind")),
+	))
+	require.NoError(t, err)
+
+	e, err := store.CreateEntity(t.Context(), New(
+		Ref(EntityKind, kind.Id()),
+	))
+	require.NoError(t, err)
+
+	shortId := e.ShortId()
+	require.NotEmpty(t, shortId)
+
+	// GetOneIndex should resolve the short-id back to the entity
+	resolvedId, err := store.GetOneIndex(t.Context(), String(DBShortId, shortId))
+	require.NoError(t, err)
+	assert.Equal(t, e.Id(), resolvedId)
+
+	// GetOneIndex with non-existent value should return not found
+	_, err = store.GetOneIndex(t.Context(), String(DBShortId, "nonexistent"))
+	assert.Error(t, err)
+}

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -2152,10 +2152,10 @@ func TestExtractEntityId(t *testing.T) {
 	})
 }
 
-func TestCreateEntity_ShortIdRefCollisionRetry(t *testing.T) {
+func TestCreateEntity_UniqueValueCollisionRetry(t *testing.T) {
 	client := setupTestEtcd(t)
 
-	prefix := "/test-shortid-retry"
+	prefix := "/test-unique-retry"
 	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
 	require.NoError(t, err)
 
@@ -2168,14 +2168,14 @@ func TestCreateEntity_ShortIdRefCollisionRetry(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	// Pre-populate a ref to simulate a concurrent create having claimed "DgY".
-	// Then pass db/short-id = "DgY" on the entity, which bypasses
-	// AllocateShortId (it skips when short-id is already set). This forces
-	// the collision to happen at the transaction level, exercising the retry
-	// path that detects the ref condition failure and re-allocates.
+	// Pre-populate the unique key for short-id "DgY" to simulate a concurrent
+	// create having claimed it. Then pass db/short-id = "DgY" on the entity,
+	// which bypasses AllocateShortId. This forces the collision to happen at
+	// the transaction level, exercising the retry path.
 	entityId := "mykind-vCZ1eUgSgNd28ed6vt2DgY"
-	refKey := prefix + "/refs/DgY"
-	_, err = client.Put(t.Context(), refKey, "some-other-entity")
+	claimedAttr := String(DBShortId, "DgY")
+	uniqueKey := store.BuildUniqueKeyForTest(claimedAttr)
+	_, err = client.Put(t.Context(), uniqueKey, "some-other-entity")
 	require.NoError(t, err)
 
 	e, err := store.CreateEntity(t.Context(), New(
@@ -2189,15 +2189,16 @@ func TestCreateEntity_ShortIdRefCollisionRetry(t *testing.T) {
 	require.NotEmpty(t, shortId, "entity should have a short-id")
 	require.NotEqual(t, "DgY", shortId, "should have picked a different short-id after collision")
 
-	// Verify the original ref is still intact (wasn't overwritten)
-	resp, err := client.Get(t.Context(), refKey)
+	// Verify the original unique key is still intact (wasn't overwritten)
+	resp, err := client.Get(t.Context(), uniqueKey)
 	require.NoError(t, err)
 	require.Len(t, resp.Kvs, 1)
 	assert.Equal(t, "some-other-entity", string(resp.Kvs[0].Value))
 
-	// Verify the new ref points to our entity
-	newRefKey := prefix + "/refs/" + shortId
-	resp, err = client.Get(t.Context(), newRefKey)
+	// Verify the new unique key points to our entity
+	newAttr := String(DBShortId, shortId)
+	newUniqueKey := store.BuildUniqueKeyForTest(newAttr)
+	resp, err = client.Get(t.Context(), newUniqueKey)
 	require.NoError(t, err)
 	require.Len(t, resp.Kvs, 1)
 	assert.Equal(t, entityId, string(resp.Kvs[0].Value))

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -2151,3 +2151,54 @@ func TestExtractEntityId(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid db/id attribute type")
 	})
 }
+
+func TestCreateEntity_ShortIdRefCollisionRetry(t *testing.T) {
+	client := setupTestEtcd(t)
+
+	prefix := "/test-shortid-retry"
+	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	// Create a kind entity so we can reference it
+	kind, err := store.CreateEntity(t.Context(), New(
+		Any(Ident, KeywordValue("test/mykind")),
+	))
+	require.NoError(t, err)
+
+	// Pre-populate a ref to simulate a concurrent create having claimed "DgY".
+	// Then pass db/short-id = "DgY" on the entity, which bypasses
+	// AllocateShortId (it skips when short-id is already set). This forces
+	// the collision to happen at the transaction level, exercising the retry
+	// path that detects the ref condition failure and re-allocates.
+	entityId := "mykind-vCZ1eUgSgNd28ed6vt2DgY"
+	refKey := prefix + "/refs/DgY"
+	_, err = client.Put(t.Context(), refKey, "some-other-entity")
+	require.NoError(t, err)
+
+	e, err := store.CreateEntity(t.Context(), New(
+		Ref(DBId, Id(entityId)),
+		Ref(EntityKind, kind.Id()),
+		String(DBShortId, "DgY"), // force the collision at txn level
+	))
+	require.NoError(t, err)
+
+	shortId := e.ShortId()
+	require.NotEmpty(t, shortId, "entity should have a short-id")
+	require.NotEqual(t, "DgY", shortId, "should have picked a different short-id after collision")
+
+	// Verify the original ref is still intact (wasn't overwritten)
+	resp, err := client.Get(t.Context(), refKey)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1)
+	assert.Equal(t, "some-other-entity", string(resp.Kvs[0].Value))
+
+	// Verify the new ref points to our entity
+	newRefKey := prefix + "/refs/" + shortId
+	resp, err = client.Get(t.Context(), newRefKey)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1)
+	assert.Equal(t, entityId, string(resp.Kvs[0].Value))
+}

--- a/pkg/entity/system.go
+++ b/pkg/entity/system.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	DBId           Id = "db/id"
+	DBShortId      Id = "db/short-id"
 	Ident          Id = "db/ident"
 	Doc            Id = "db/doc"
 	Uniq           Id = "db/uniq"
@@ -302,6 +303,15 @@ func InitSystemEntities(save func(*Entity) error) error {
 		Type, TypeRef,
 	)
 
+	dbShortId := New(
+		Ident, types.Keyword(DBShortId),
+		Doc, "Short, human-friendly entity identifier",
+		Uniq, UniqueValue,
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	)
+
 	entities := []*Entity{
 		dbid,
 		ident, doc, uniq, card, typ, enumValues, enumType,
@@ -312,6 +322,7 @@ func InitSystemEntities(save func(*Entity) error) error {
 		attrSession,
 		attrPred, program, predIP, predCidr, entityAttrs, entityPreds, entityEnsure,
 		entityKind, entitySchema, entityESchema, schemaKind,
+		dbShortId,
 	}
 
 	for _, entity := range entities {

--- a/pkg/ui/entity.go
+++ b/pkg/ui/entity.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"miren.dev/runtime/pkg/entity"
 )
 
 // CleanEntityID removes common entity type prefixes from entity IDs for cleaner display.
@@ -26,6 +27,35 @@ func CleanEntityID(id string) string {
 	}
 
 	return cleaned
+}
+
+// BriefId returns the shortest usable identifier for an entity: short-id > name > full id.
+func BriefId(e entity.AttrGetter) string {
+	if attr, ok := e.Get(entity.DBShortId); ok {
+		if s := attr.Value.String(); s != "" {
+			return s
+		}
+	}
+	return CleanEntityID(entityIdStr(e))
+}
+
+// FriendlyId returns the most human-readable identifier: name > short-id > full id.
+func FriendlyId(e entity.AttrGetter) string {
+	// Try db/name (stored as core/metadata.name label) — but entities don't have
+	// a standard name attribute at the entity layer, so we fall back to short-id.
+	if attr, ok := e.Get(entity.DBShortId); ok {
+		if s := attr.Value.String(); s != "" {
+			return s
+		}
+	}
+	return CleanEntityID(entityIdStr(e))
+}
+
+func entityIdStr(e entity.AttrGetter) string {
+	if attr, ok := e.Get(entity.DBId); ok {
+		return attr.Value.String()
+	}
+	return ""
 }
 
 // DisplayAppVersion formats an app version string by removing prefixes and bolding the app name.

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -61,9 +61,9 @@ func (e *EntityServer) Get(ctx context.Context, req *entityserver_v1alpha.Entity
 
 	ent, err := e.Store.GetEntity(ctx, entity.Id(args.Id()))
 	if err != nil {
-		// Try resolving as a ref (short-id, name, etc.)
+		// Try resolving as a short-id via the db/short-id index
 		if etcdStore, ok := e.Store.(*entity.EtcdStore); ok {
-			if resolvedId, refErr := etcdStore.ResolveRef(ctx, args.Id()); refErr == nil {
+			if resolvedId, idxErr := etcdStore.GetOneIndex(ctx, entity.String(entity.DBShortId, args.Id())); idxErr == nil {
 				ent, err = e.Store.GetEntity(ctx, resolvedId)
 			}
 		}

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -59,17 +59,25 @@ func (e *EntityServer) Get(ctx context.Context, req *entityserver_v1alpha.Entity
 		return cond.ValidationFailure("missing-field", "id")
 	}
 
-	entity, err := e.Store.GetEntity(ctx, entity.Id(args.Id()))
+	ent, err := e.Store.GetEntity(ctx, entity.Id(args.Id()))
 	if err != nil {
-		return cond.NotFound("entity", args.Id())
+		// Try resolving as a ref (short-id, name, etc.)
+		if etcdStore, ok := e.Store.(*entity.EtcdStore); ok {
+			if resolvedId, refErr := etcdStore.ResolveRef(ctx, args.Id()); refErr == nil {
+				ent, err = e.Store.GetEntity(ctx, resolvedId)
+			}
+		}
+		if err != nil {
+			return cond.NotFound("entity", args.Id())
+		}
 	}
 
 	var rpcEntity entityserver_v1alpha.Entity
-	rpcEntity.SetId(entity.Id().String())
-	rpcEntity.SetCreatedAt(entity.GetCreatedAt().UnixMilli())
-	rpcEntity.SetUpdatedAt(entity.GetUpdatedAt().UnixMilli())
-	rpcEntity.SetRevision(entity.GetRevision())
-	rpcEntity.SetAttrs(entity.Attrs())
+	rpcEntity.SetId(ent.Id().String())
+	rpcEntity.SetCreatedAt(ent.GetCreatedAt().UnixMilli())
+	rpcEntity.SetUpdatedAt(ent.GetUpdatedAt().UnixMilli())
+	rpcEntity.SetRevision(ent.GetRevision())
+	rpcEntity.SetAttrs(ent.Attrs())
 
 	req.Results().SetEntity(&rpcEntity)
 


### PR DESCRIPTION
Entity IDs in Miren are long Base58-encoded UUID v7 values — something like `blog-vCZ1eUgSgNd28ed6vt2DgY`. They push useful columns off-screen in CLI tables and are impossible to type from memory. RFD-69 introduces `db/short-id` to fix this.

Every entity with an `entity/kind` now gets a short (3–8 character) identifier allocated at creation time. The algorithm extracts the base58 suffix from the entity ID and takes the last 3 characters, growing on collision. Named entities without a base58 portion (like `app/blog`) get a random base58 short-id instead. The max length is capped at 8 characters — beyond that it stops being "short."

Uniqueness is enforced via an etcd ref index at `{prefix}/refs/{shortId}`. The create transaction checks both the entity key and the ref key atomically, so a concurrent create can't silently steal another entity's short-id. If a race does occur, the transaction detects it and retries with a freshly allocated short-id (up to 3 times).

The entity server's `Get()` now falls back to ref resolution when a direct ID lookup fails, so `m app inspect DgY` resolves to the right entity automatically. On the display side, `BriefId()` returns the short-id when available, and sandbox list uses it by default (full IDs with `-v`).

A boot-time migration backfills short-ids for all existing entities that don't have one, running after the existing entity format migration and before reindexing. It's idempotent — subsequent boots skip entities that already have a short-id.

MIR-864