### PR TITLE
Fix runner join failing with "session ID is required for session attributes"

### DIFF
--- a/controllers/scheduler/scheduler_test.go
+++ b/controllers/scheduler/scheduler_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
@@ -46,6 +47,28 @@ func reconcileSandbox(t *testing.T, ctx context.Context, server *testutils.InMem
 	require.NoError(t, err)
 }
 
+// createReadyNode creates a node entity with Status: READY using a session,
+// matching the production pattern where the runner sets its own status via a
+// session-scoped attribute.
+func createReadyNode(t *testing.T, ctx context.Context, client *entityserver.Client, name string, node *compute_v1alpha.Node) entity.Id {
+	t.Helper()
+
+	// Create the node without the session-scoped status attribute
+	status := node.Status
+	node.Status = ""
+	nodeID, err := client.Create(ctx, name, node)
+	require.NoError(t, err)
+
+	// Set status via a session-enabled client (status is session-scoped)
+	_, sc, err := client.NewSession(ctx, "test node health")
+	require.NoError(t, err)
+
+	err = sc.UpdateAttrs(ctx, nodeID, (&compute_v1alpha.Node{Status: status}).Encode)
+	require.NoError(t, err)
+
+	return nodeID
+}
+
 // TestSchedulerAssignsUnscheduledSandbox tests that the scheduler assigns
 // a node to a sandbox that doesn't have a ScheduleKey
 func TestSchedulerAssignsUnscheduledSandbox(t *testing.T) {
@@ -55,16 +78,14 @@ func TestSchedulerAssignsUnscheduledSandbox(t *testing.T) {
 	server, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
 
-	// Create a ready node
-	node := &compute_v1alpha.Node{
+	// Create a ready node (status is session-scoped, so use the helper)
+	nodeID := createReadyNode(t, ctx, server.Client, "test-node", &compute_v1alpha.Node{
 		Status: compute_v1alpha.READY,
-	}
-	nodeID, err := server.Client.Create(ctx, "test-node", node)
-	require.NoError(t, err)
+	})
 
 	// Create scheduler and initialize (gathers nodes)
 	scheduler := NewController(log, server.EAC)
-	err = scheduler.Init(ctx)
+	err := scheduler.Init(ctx)
 	require.NoError(t, err)
 
 	// Create an unscheduled sandbox
@@ -103,17 +124,16 @@ func TestSchedulerSkipsAlreadyScheduledSandbox(t *testing.T) {
 	defer cleanup()
 
 	// Create two ready nodes
-	node1 := &compute_v1alpha.Node{Status: compute_v1alpha.READY}
-	node1ID, err := server.Client.Create(ctx, "node-1", node1)
-	require.NoError(t, err)
-
-	node2 := &compute_v1alpha.Node{Status: compute_v1alpha.READY}
-	_, err = server.Client.Create(ctx, "node-2", node2)
-	require.NoError(t, err)
+	node1ID := createReadyNode(t, ctx, server.Client, "node-1", &compute_v1alpha.Node{
+		Status: compute_v1alpha.READY,
+	})
+	createReadyNode(t, ctx, server.Client, "node-2", &compute_v1alpha.Node{
+		Status: compute_v1alpha.READY,
+	})
 
 	// Create scheduler and initialize
 	scheduler := NewController(log, server.EAC)
-	err = scheduler.Init(ctx)
+	err := scheduler.Init(ctx)
 	require.NoError(t, err)
 
 	// Create a sandbox that's already scheduled to node1
@@ -167,15 +187,13 @@ func TestSchedulerNoAvailableNodes(t *testing.T) {
 	defer cleanup()
 
 	// Create a node that's not ready
-	node := &compute_v1alpha.Node{
+	createReadyNode(t, ctx, server.Client, "disabled-node", &compute_v1alpha.Node{
 		Status: compute_v1alpha.DISABLED,
-	}
-	_, err := server.Client.Create(ctx, "disabled-node", node)
-	require.NoError(t, err)
+	})
 
 	// Create scheduler and initialize
 	scheduler := NewController(log, server.EAC)
-	err = scheduler.Init(ctx)
+	err := scheduler.Init(ctx)
 	require.NoError(t, err)
 
 	// Create an unscheduled sandbox
@@ -208,9 +226,9 @@ func TestSchedulerMultipleNodes(t *testing.T) {
 	// Create multiple ready nodes
 	nodeIDs := make(map[entity.Id]bool)
 	for i := 0; i < 3; i++ {
-		node := &compute_v1alpha.Node{Status: compute_v1alpha.READY}
-		nodeID, err := server.Client.Create(ctx, "", node)
-		require.NoError(t, err)
+		nodeID := createReadyNode(t, ctx, server.Client, "", &compute_v1alpha.Node{
+			Status: compute_v1alpha.READY,
+		})
 		nodeIDs[nodeID] = true
 	}
 
@@ -249,24 +267,20 @@ func TestSchedulerStatefulSandboxGoesToCoordinator(t *testing.T) {
 	defer cleanup()
 
 	// Create a coordinator node (role=coordinator constraint)
-	coordNode := &compute_v1alpha.Node{
+	coordNodeID := createReadyNode(t, ctx, server.Client, "coordinator", &compute_v1alpha.Node{
 		Status:      compute_v1alpha.READY,
 		Constraints: types.LabelSet("role", "coordinator"),
-	}
-	coordNodeID, err := server.Client.Create(ctx, "coordinator", coordNode)
-	require.NoError(t, err)
+	})
 
 	// Create a runner node
-	runnerNode := &compute_v1alpha.Node{
+	createReadyNode(t, ctx, server.Client, "runner", &compute_v1alpha.Node{
 		Status:   compute_v1alpha.READY,
 		RunnerId: "550e8400-e29b-41d4-a716-446655440000",
-	}
-	_, err = server.Client.Create(ctx, "runner", runnerNode)
-	require.NoError(t, err)
+	})
 
 	// Create scheduler and initialize
 	scheduler := NewController(log, server.EAC)
-	err = scheduler.Init(ctx)
+	err := scheduler.Init(ctx)
 	require.NoError(t, err)
 
 	// Create a stateful sandbox (has miren disk volume)
@@ -310,28 +324,24 @@ func TestSchedulerStatelessSandboxPrefersRunners(t *testing.T) {
 	defer cleanup()
 
 	// Create a coordinator node (role=coordinator constraint)
-	coordNode := &compute_v1alpha.Node{
+	coordNodeID := createReadyNode(t, ctx, server.Client, "coordinator", &compute_v1alpha.Node{
 		Status:      compute_v1alpha.READY,
 		Constraints: types.LabelSet("role", "coordinator"),
-	}
-	coordNodeID, err := server.Client.Create(ctx, "coordinator", coordNode)
-	require.NoError(t, err)
+	})
 
 	// Create multiple runner nodes
 	runnerIDs := make(map[entity.Id]bool)
 	for i := 0; i < 3; i++ {
-		runnerNode := &compute_v1alpha.Node{
+		runnerID := createReadyNode(t, ctx, server.Client, "", &compute_v1alpha.Node{
 			Status:   compute_v1alpha.READY,
 			RunnerId: "550e8400-e29b-41d4-a716-44665544000" + string(rune('0'+i)),
-		}
-		runnerID, err := server.Client.Create(ctx, "", runnerNode)
-		require.NoError(t, err)
+		})
 		runnerIDs[runnerID] = true
 	}
 
 	// Create scheduler and initialize
 	scheduler := NewController(log, server.EAC)
-	err = scheduler.Init(ctx)
+	err := scheduler.Init(ctx)
 	require.NoError(t, err)
 
 	// Create and schedule multiple stateless sandboxes
@@ -370,16 +380,14 @@ func TestSchedulerStatelessFallsBackToCoordinator(t *testing.T) {
 	defer cleanup()
 
 	// Create only a coordinator node (no runners)
-	coordNode := &compute_v1alpha.Node{
+	coordNodeID := createReadyNode(t, ctx, server.Client, "coordinator", &compute_v1alpha.Node{
 		Status:      compute_v1alpha.READY,
 		Constraints: types.LabelSet("role", "coordinator"),
-	}
-	coordNodeID, err := server.Client.Create(ctx, "coordinator", coordNode)
-	require.NoError(t, err)
+	})
 
 	// Create scheduler and initialize
 	scheduler := NewController(log, server.EAC)
-	err = scheduler.Init(ctx)
+	err := scheduler.Init(ctx)
 	require.NoError(t, err)
 
 	// Create a stateless sandbox

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -101,7 +102,34 @@ func (m *MockStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error
 	return entities, nil
 }
 
+// validateSessionAttrs checks that if any attributes are session-scoped,
+// a session ID was provided via EntityOption. This matches EtcdStore behavior.
+func (m *MockStore) validateSessionAttrs(ctx context.Context, attrs []Attr, opts []EntityOption) error {
+	var o entityOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	for _, attr := range attrs {
+		schema, err := m.GetAttributeSchema(ctx, attr.ID)
+		if err != nil {
+			continue
+		}
+		if schema.Session {
+			if len(o.session) == 0 {
+				return fmt.Errorf("session ID is required for session attributes")
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
 func (m *MockStore) CreateEntity(ctx context.Context, entity *Entity, opts ...EntityOption) (*Entity, error) {
+	if err := m.validateSessionAttrs(ctx, entity.attrs, opts); err != nil {
+		return nil, err
+	}
+
 	// Set CreatedAt if not already set (store manages this timestamp)
 	if entity.GetCreatedAt().IsZero() {
 		entity.SetCreatedAt(m.Now())
@@ -120,6 +148,10 @@ func (m *MockStore) CreateEntity(ctx context.Context, entity *Entity, opts ...En
 }
 
 func (m *MockStore) UpdateEntity(ctx context.Context, id Id, entity *Entity, opts ...EntityOption) (*Entity, error) {
+	if err := m.validateSessionAttrs(ctx, entity.attrs, opts); err != nil {
+		return nil, err
+	}
+
 	m.mu.Lock()
 	e, ok := m.Entities[id]
 	if !ok {
@@ -482,8 +514,18 @@ func (m *MockStore) RevokeSession(ctx context.Context, id []byte) error {
 }
 
 func (m *MockStore) GetAttributeSchema(ctx context.Context, id Id) (*AttributeSchema, error) {
-	// For simplicity, return a mock schema
-	return &AttributeSchema{
-		ID: id,
-	}, nil
+	// Look up the schema entity from the store, just like EtcdStore does.
+	// Schema entities are created by schema.Apply during test setup.
+	m.mu.RLock()
+	entity, ok := m.Entities[id]
+	m.mu.RUnlock()
+
+	if ok {
+		schema, err := convertEntityToSchema(ctx, m, entity)
+		if err == nil {
+			return schema, nil
+		}
+	}
+
+	return &AttributeSchema{ID: id}, nil
 }

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -212,7 +212,6 @@ func (s *RegistrationServer) Join(ctx context.Context, req *runner_v1alpha.Runne
 
 	node := &compute_v1alpha.Node{
 		RunnerId:     runnerID,
-		Status:       compute_v1alpha.READY,
 		ApiAddress:   listenAddr,
 		Version:      version,
 		RegisteredAt: time.Now(),

--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -1,9 +1,14 @@
 package runner
 
 import (
+	"context"
 	"testing"
 
+	"miren.dev/runtime/api/runner/runner_v1alpha"
+	"miren.dev/runtime/pkg/caauth"
+	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/joincode"
+	"miren.dev/runtime/pkg/rpc"
 )
 
 func TestJoinCodeIntegration(t *testing.T) {
@@ -23,5 +28,65 @@ func TestJoinCodeIntegration(t *testing.T) {
 
 	if len(hash) != 64 {
 		t.Errorf("Hash() returned string of length %d, expected 64", len(hash))
+	}
+}
+
+func TestJoinCreatesNodeEntity(t *testing.T) {
+	ctx := context.Background()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ca, err := caauth.New(caauth.Options{
+		CommonName:   "test-ca",
+		Organization: "test",
+	})
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	regServer := NewRegistrationServer(
+		testutils.TestLogger(t),
+		ca,
+		es.EAC,
+		"127.0.0.1:8443",
+		nil, "", "",
+	)
+
+	localClient := rpc.LocalClient(runner_v1alpha.AdaptRunnerRegistration(regServer))
+	client := runner_v1alpha.NewRunnerRegistrationClient(localClient)
+
+	// Create an invite
+	inviteResult, err := client.CreateInvite(ctx, nil, 1)
+	if err != nil {
+		t.Fatalf("CreateInvite failed: %v", err)
+	}
+
+	code := inviteResult.Code()
+	if code == "" {
+		t.Fatal("CreateInvite returned empty code")
+	}
+
+	// Join using the invite code — this was failing before the fix because
+	// the node entity included a session attribute (status) without a session ID.
+	joinResult, err := client.Join(ctx, code, "", "10.0.0.1:8443", "test-version", nil)
+	if err != nil {
+		t.Fatalf("Join RPC failed: %v", err)
+	}
+
+	if joinResult.HasError() {
+		t.Fatalf("Join returned error: %s", joinResult.Error())
+	}
+
+	if joinResult.RunnerId() == "" {
+		t.Error("Join did not return a runner ID")
+	}
+
+	if len(joinResult.CertPem()) == 0 {
+		t.Error("Join did not return a certificate")
+	}
+
+	if joinResult.CoordinatorAddr() != "127.0.0.1:8443" {
+		t.Errorf("Join returned coordinator addr %q, want %q", joinResult.CoordinatorAddr(), "127.0.0.1:8443")
 	}
 }


### PR DESCRIPTION
Runner registration was blowing up whenever a runner tried to join a coordinator with `distributedrunners` enabled. The coordinator's `Join` handler was creating a node entity with `Status: READY`, but `status` is a session-scoped attribute in the node schema — and the registration code path doesn't have a session. The EtcdStore rightfully rejected it.

The fix is just removing the status field from the registration path. The runner already sets its own status to READY when it boots up and creates a session in `setupEntity`, so the registration handler was doing redundant (and broken) work.

The more interesting question was why tests didn't catch this. Turns out the `MockStore` was returning blank attribute schemas from `GetAttributeSchema`, which meant it had no idea which attributes were session-scoped — so it never enforced the validation that the real store does. First commit fixes that gap so the in-memory entity server behaves like the real one for session attributes, and the second commit adds a regression test that exercises the full invite → join flow.

Closes MIR-894