### PR TITLE
Move app list aggregation server-side for speed

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -556,9 +556,16 @@ func (v *VersionInfo) UnmarshalJSON(data []byte) error {
 }
 
 type appInfoData struct {
-	Name           *string             `cbor:"0,keyasint,omitempty" json:"name,omitempty"`
-	CreatedAt      *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"created_at,omitempty"`
-	CurrentVersion *VersionInfo        `cbor:"2,keyasint,omitempty" json:"current_version,omitempty"`
+	Name             *string             `cbor:"0,keyasint,omitempty" json:"name,omitempty"`
+	CreatedAt        *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"created_at,omitempty"`
+	CurrentVersion   *VersionInfo        `cbor:"2,keyasint,omitempty" json:"current_version,omitempty"`
+	Health           *string             `cbor:"3,keyasint,omitempty" json:"health,omitempty"`
+	ReadyInstances   *int32              `cbor:"4,keyasint,omitempty" json:"ready_instances,omitempty"`
+	DesiredInstances *int32              `cbor:"5,keyasint,omitempty" json:"desired_instances,omitempty"`
+	ScalingMode      *string             `cbor:"6,keyasint,omitempty" json:"scaling_mode,omitempty"`
+	Routes           *[]string           `cbor:"7,keyasint,omitempty" json:"routes,omitempty"`
+	CrashCount       *int64              `cbor:"8,keyasint,omitempty" json:"crash_count,omitempty"`
+	CooldownSeconds  *int32              `cbor:"9,keyasint,omitempty" json:"cooldown_seconds,omitempty"`
 }
 
 type AppInfo struct {
@@ -602,6 +609,112 @@ func (v *AppInfo) CurrentVersion() *VersionInfo {
 
 func (v *AppInfo) SetCurrentVersion(current_version *VersionInfo) {
 	v.data.CurrentVersion = current_version
+}
+
+func (v *AppInfo) HasHealth() bool {
+	return v.data.Health != nil
+}
+
+func (v *AppInfo) Health() string {
+	if v.data.Health == nil {
+		return ""
+	}
+	return *v.data.Health
+}
+
+func (v *AppInfo) SetHealth(health string) {
+	v.data.Health = &health
+}
+
+func (v *AppInfo) HasReadyInstances() bool {
+	return v.data.ReadyInstances != nil
+}
+
+func (v *AppInfo) ReadyInstances() int32 {
+	if v.data.ReadyInstances == nil {
+		return 0
+	}
+	return *v.data.ReadyInstances
+}
+
+func (v *AppInfo) SetReadyInstances(ready_instances int32) {
+	v.data.ReadyInstances = &ready_instances
+}
+
+func (v *AppInfo) HasDesiredInstances() bool {
+	return v.data.DesiredInstances != nil
+}
+
+func (v *AppInfo) DesiredInstances() int32 {
+	if v.data.DesiredInstances == nil {
+		return 0
+	}
+	return *v.data.DesiredInstances
+}
+
+func (v *AppInfo) SetDesiredInstances(desired_instances int32) {
+	v.data.DesiredInstances = &desired_instances
+}
+
+func (v *AppInfo) HasScalingMode() bool {
+	return v.data.ScalingMode != nil
+}
+
+func (v *AppInfo) ScalingMode() string {
+	if v.data.ScalingMode == nil {
+		return ""
+	}
+	return *v.data.ScalingMode
+}
+
+func (v *AppInfo) SetScalingMode(scaling_mode string) {
+	v.data.ScalingMode = &scaling_mode
+}
+
+func (v *AppInfo) HasRoutes() bool {
+	return v.data.Routes != nil
+}
+
+func (v *AppInfo) Routes() []string {
+	if v.data.Routes == nil {
+		return nil
+	}
+	return *v.data.Routes
+}
+
+func (v *AppInfo) SetRoutes(routes []string) {
+	x := slices.Clone(routes)
+	v.data.Routes = &x
+}
+
+func (v *AppInfo) HasCrashCount() bool {
+	return v.data.CrashCount != nil
+}
+
+func (v *AppInfo) CrashCount() int64 {
+	if v.data.CrashCount == nil {
+		return 0
+	}
+	return *v.data.CrashCount
+}
+
+func (v *AppInfo) SetCrashCount(crash_count int64) {
+	v.data.CrashCount = &crash_count
+}
+
+func (v *AppInfo) HasCooldownSeconds() bool {
+	return v.data.CooldownSeconds != nil
+}
+
+func (v *AppInfo) CooldownSeconds() int32 {
+	if v.data.CooldownSeconds == nil {
+		return 0
+	}
+	return *v.data.CooldownSeconds
+}
+
+func (v *AppInfo) SetCooldownSeconds(cooldown_seconds int32) {
+	v.data.CooldownSeconds = &cooldown_seconds
 }
 
 func (v *AppInfo) MarshalCBOR() ([]byte, error) {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -121,6 +121,28 @@ types:
       - name: current_version
         type: VersionInfo
         index: 2
+      - name: health
+        type: string
+        index: 3
+      - name: ready_instances
+        type: int32
+        index: 4
+      - name: desired_instances
+        type: int32
+        index: 5
+      - name: scaling_mode
+        type: string
+        index: 6
+      - name: routes
+        type: list
+        element: string
+        index: 7
+      - name: crash_count
+        type: int64
+        index: 8
+      - name: cooldown_seconds
+        type: int32
+        index: 9
 
   - type: CpuUsage
     fields:

--- a/cli/commands/app_list.go
+++ b/cli/commands/app_list.go
@@ -8,11 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"miren.dev/runtime/api/compute/compute_v1alpha"
-	coreutil "miren.dev/runtime/api/core"
-	"miren.dev/runtime/api/core/core_v1alpha"
-	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
-	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/ui"
 )
@@ -41,155 +37,26 @@ func AppList(ctx *Context, opts struct {
 		return nil
 	}
 
-	client, err := ctx.RPCClient("entities")
+	crudcl, err := ctx.RPCClient("dev.miren.runtime/app")
 	if err != nil {
 		return err
 	}
-	defer client.Close()
+	defer crudcl.Close()
+
+	crud := app_v1alpha.NewCrudClient(crudcl)
+	result, err := crud.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	appList := result.Apps()
 
 	// Get default hostname for routes display
 	defaultHost := ""
 	if cluster.Hostname != "" {
 		defaultHost = cluster.Hostname
-		// Strip port if present (handles IPv6)
 		if h, _, err := net.SplitHostPort(defaultHost); err == nil {
 			defaultHost = h
-		}
-	}
-
-	eac := entityserver_v1alpha.NewEntityAccessClient(client)
-
-	kindRes, err := eac.LookupKind(ctx, "app")
-	if err != nil {
-		return err
-	}
-
-	res, err := eac.List(ctx, kindRes.Attr())
-	if err != nil {
-		return err
-	}
-
-	versionKindRes, err := eac.LookupKind(ctx, "app_version")
-	if err != nil {
-		return err
-	}
-
-	versionsRes, err := eac.List(ctx, versionKindRes.Attr())
-	if err != nil {
-		return err
-	}
-
-	deploymentKindRes, err := eac.LookupKind(ctx, "deployment")
-	if err != nil {
-		return err
-	}
-
-	deploymentsRes, err := eac.List(ctx, deploymentKindRes.Attr())
-	if err != nil {
-		return err
-	}
-
-	// Get routes
-	ic := ingress.NewClient(ctx.Log, client)
-	routes, err := ic.List(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Get sandbox pools for runtime state
-	poolKindRes, err := eac.LookupKind(ctx, "sandbox_pool")
-	if err != nil {
-		return err
-	}
-
-	poolsRes, err := eac.List(ctx, poolKindRes.Attr())
-	if err != nil {
-		return err
-	}
-
-	// Build version map and resolved config spec map
-	versionMap := make(map[string]*core_v1alpha.AppVersion)
-	specMap := make(map[string]*core_v1alpha.ConfigSpec)
-	for _, e := range versionsRes.Values() {
-		v := new(core_v1alpha.AppVersion)
-		v.Decode(e.Entity())
-		versionMap[v.ID.String()] = v
-		if resolvedCfg, err := coreutil.ResolveConfig(ctx, eac, v); err == nil {
-			specMap[v.ID.String()] = resolvedCfg
-		}
-	}
-
-	// Build deployment map (most recent deployment per app)
-	deploymentMap := make(map[string]*core_v1alpha.Deployment)
-	for _, e := range deploymentsRes.Values() {
-		d := new(core_v1alpha.Deployment)
-		d.Decode(e.Entity())
-
-		if existing, ok := deploymentMap[d.AppName]; ok {
-			existingTime, existingErr := time.Parse(time.RFC3339, existing.CompletedAt)
-			newTime, newErr := time.Parse(time.RFC3339, d.CompletedAt)
-
-			// Replace if: new has valid time and (existing invalid OR new is later)
-			if newErr == nil && (existingErr != nil || newTime.After(existingTime)) {
-				deploymentMap[d.AppName] = d
-			}
-		} else {
-			deploymentMap[d.AppName] = d
-		}
-	}
-
-	// Build routes map (app name -> routes)
-	routeMap := make(map[string][]string)
-	for _, r := range routes {
-		appName := ui.CleanEntityID(string(r.Route.App))
-		host := r.Route.Host
-		if host == "" && r.Route.Default {
-			if defaultHost != "" {
-				host = defaultHost
-			}
-		}
-		if host != "" {
-			routeMap[appName] = append(routeMap[appName], host)
-		}
-	}
-
-	// Aggregate pool state per app (sum across all services)
-	type appPoolState struct {
-		ready        int
-		desired      int
-		inCooldown   bool
-		crashCount   int64
-		cooldownLeft time.Duration
-		isAutoscale  bool // true if any service uses autoscaling mode
-	}
-	poolStateMap := make(map[string]*appPoolState)
-	now := time.Now()
-	for _, e := range poolsRes.Values() {
-		var pool compute_v1alpha.SandboxPool
-		pool.Decode(e.Entity())
-
-		appName := ui.CleanEntityID(pool.App.String())
-		if poolStateMap[appName] == nil {
-			poolStateMap[appName] = &appPoolState{
-				isAutoscale: true, // default to autoscale, set to false if ANY service uses fixed mode
-			}
-		}
-		state := poolStateMap[appName]
-		state.ready += int(pool.ReadyInstances)
-		state.desired += int(pool.DesiredInstances)
-		if !pool.CooldownUntil.IsZero() && pool.CooldownUntil.After(now) {
-			state.inCooldown = true
-			state.crashCount = pool.ConsecutiveCrashCount
-			state.cooldownLeft = pool.CooldownUntil.Sub(now)
-		}
-
-		// Check concurrency mode from the app's active version config
-		if spec, ok := specMap[pool.SandboxSpec.Version.String()]; ok {
-			for _, svc := range spec.Services {
-				if svc.Name == pool.Service && svc.Concurrency.Mode == "fixed" {
-					state.isAutoscale = false
-				}
-			}
 		}
 	}
 
@@ -197,64 +64,37 @@ func AppList(ctx *Context, opts struct {
 		var apps []struct {
 			Name             string   `json:"name"`
 			Version          string   `json:"version,omitempty"`
-			ReadyInstances   int      `json:"ready_instances"`
-			DesiredInstances int      `json:"desired_instances"`
+			ReadyInstances   int32    `json:"ready_instances"`
+			DesiredInstances int32    `json:"desired_instances"`
 			Health           string   `json:"health"`
 			ScalingMode      string   `json:"scaling_mode,omitempty"`
 			Routes           []string `json:"routes,omitempty"`
 		}
 
-		for _, e := range res.Values() {
-			var app core_v1alpha.App
-			app.Decode(e.Entity())
-
-			var md core_v1alpha.Metadata
-			md.Decode(e.Entity())
-
+		for _, a := range appList {
 			appData := struct {
 				Name             string   `json:"name"`
 				Version          string   `json:"version,omitempty"`
-				ReadyInstances   int      `json:"ready_instances"`
-				DesiredInstances int      `json:"desired_instances"`
+				ReadyInstances   int32    `json:"ready_instances"`
+				DesiredInstances int32    `json:"desired_instances"`
 				Health           string   `json:"health"`
 				ScalingMode      string   `json:"scaling_mode,omitempty"`
 				Routes           []string `json:"routes,omitempty"`
 			}{
-				Name:   md.Name,
-				Health: "unknown",
+				Name:             a.Name(),
+				Health:           a.Health(),
+				ReadyInstances:   a.ReadyInstances(),
+				DesiredInstances: a.DesiredInstances(),
+				ScalingMode:      a.ScalingMode(),
 			}
 
-			if app.ActiveVersion.String() != "" {
-				if version, ok := versionMap[app.ActiveVersion.String()]; ok {
-					appData.Version = version.Version
-				}
+			if a.HasCurrentVersion() {
+				appData.Version = a.CurrentVersion().Version()
 			}
 
-			if state, ok := poolStateMap[md.Name]; ok {
-				appData.ReadyInstances = state.ready
-				appData.DesiredInstances = state.desired
-
-				if state.isAutoscale {
-					appData.ScalingMode = "auto"
-				} else {
-					appData.ScalingMode = "fixed"
-				}
-
-				if state.inCooldown {
-					appData.Health = "crashed"
-				} else if state.desired == 0 {
-					appData.Health = "idle"
-				} else if state.ready == state.desired {
-					appData.Health = "healthy"
-				} else if state.ready > 0 {
-					appData.Health = "degraded"
-				} else {
-					appData.Health = "starting"
-				}
-			}
-
-			if appRoutes, ok := routeMap[md.Name]; ok {
-				appData.Routes = appRoutes
+			routes := resolveRoutes(a.Routes(), defaultHost)
+			if len(routes) > 0 {
+				appData.Routes = routes
 			}
 
 			apps = append(apps, appData)
@@ -270,52 +110,45 @@ func AppList(ctx *Context, opts struct {
 	var rows []ui.Row
 	headers := []string{"NAME", "VERSION", "SCALE", "ROUTE"}
 
-	for _, e := range res.Values() {
-		var app core_v1alpha.App
-		app.Decode(e.Entity())
-
-		var md core_v1alpha.Metadata
-		md.Decode(e.Entity())
-
-		name := md.Name
+	for _, a := range appList {
+		name := a.Name()
 		version := "-"
 		status := "-"
 		routeDisplay := "-"
 
-		if app.ActiveVersion.String() != "" {
-			if appVersion, ok := versionMap[app.ActiveVersion.String()]; ok {
-				version = ui.DisplayAppVersion(appVersion.Version)
-			}
+		if a.HasCurrentVersion() {
+			version = ui.DisplayAppVersion(a.CurrentVersion().Version())
 		}
 
-		// Runtime status from pool state
-		if state, ok := poolStateMap[md.Name]; ok {
+		// Runtime status from server-aggregated pool state
+		if a.HasHealth() && a.Health() != "unknown" {
 			modeSuffix := " (auto)"
-			if !state.isAutoscale {
+			if a.ScalingMode() == "fixed" {
 				modeSuffix = " (fixed)"
 			}
 
-			if state.inCooldown {
-				retryIn := formatDuration(state.cooldownLeft)
-				status = infoRed.Render(fmt.Sprintf("crashed (%dx, retry %s)", state.crashCount, retryIn))
-			} else if state.desired == 0 {
-				if state.isAutoscale {
+			switch a.Health() {
+			case "crashed":
+				retryIn := formatDuration(time.Duration(a.CooldownSeconds()) * time.Second)
+				status = infoRed.Render(fmt.Sprintf("crashed (%dx, retry %s)", a.CrashCount(), retryIn))
+			case "idle":
+				if a.ScalingMode() == "auto" {
 					status = infoGray.Render("💤 idle")
 				} else {
 					status = infoYellow.Render("⚠️ 0 (fixed)")
 				}
-			} else if state.ready == state.desired {
-				status = infoGreen.Render(fmt.Sprintf("%d%s", state.ready, modeSuffix))
-			} else {
-				status = infoLabel.Render(fmt.Sprintf("%d/%d%s", state.ready, state.desired, modeSuffix))
+			case "healthy":
+				status = infoGreen.Render(fmt.Sprintf("%d%s", a.ReadyInstances(), modeSuffix))
+			case "degraded", "starting":
+				status = infoLabel.Render(fmt.Sprintf("%d/%d%s", a.ReadyInstances(), a.DesiredInstances(), modeSuffix))
 			}
 		}
 
 		// Build clickable route
-		if appRoutes, ok := routeMap[md.Name]; ok && len(appRoutes) > 0 {
-			host := appRoutes[0]
+		routes := resolveRoutes(a.Routes(), defaultHost)
+		if len(routes) > 0 {
+			host := routes[0]
 			displayHost := strings.ReplaceAll(host, "127.0.0.1", "localhost")
-			// Use http for localhost/local domains, https for others
 			scheme := "https://"
 			if strings.Contains(host, "localhost") || strings.HasPrefix(host, "127.") {
 				scheme = "http://"
@@ -348,4 +181,20 @@ func AppList(ctx *Context, opts struct {
 
 	ctx.Printf("%s\n", table.Render())
 	return nil
+}
+
+// resolveRoutes fills in the default host for default routes (empty strings).
+func resolveRoutes(routes []string, defaultHost string) []string {
+	if len(routes) == 0 {
+		return nil
+	}
+	var resolved []string
+	for _, host := range routes {
+		if host != "" {
+			resolved = append(resolved, host)
+		} else if defaultHost != "" {
+			resolved = append(resolved, defaultHost)
+		}
+	}
+	return resolved
 }

--- a/cli/commands/app_list.go
+++ b/cli/commands/app_list.go
@@ -69,6 +69,8 @@ func AppList(ctx *Context, opts struct {
 			Health           string   `json:"health"`
 			ScalingMode      string   `json:"scaling_mode,omitempty"`
 			Routes           []string `json:"routes,omitempty"`
+			CrashCount       int64    `json:"crash_count"`
+			CooldownSeconds  int32    `json:"cooldown_seconds"`
 		}
 
 		for _, a := range appList {
@@ -80,12 +82,16 @@ func AppList(ctx *Context, opts struct {
 				Health           string   `json:"health"`
 				ScalingMode      string   `json:"scaling_mode,omitempty"`
 				Routes           []string `json:"routes,omitempty"`
+				CrashCount       int64    `json:"crash_count"`
+				CooldownSeconds  int32    `json:"cooldown_seconds"`
 			}{
 				Name:             a.Name(),
 				Health:           a.Health(),
 				ReadyInstances:   a.ReadyInstances(),
 				DesiredInstances: a.DesiredInstances(),
 				ScalingMode:      a.ScalingMode(),
+				CrashCount:       a.CrashCount(),
+				CooldownSeconds:  a.CooldownSeconds(),
 			}
 
 			if a.HasCurrentVersion() {

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
@@ -18,6 +20,7 @@ import (
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/ui"
 )
 
 // TODO: Removed broken go:generate directive - no rpc.yml file exists in servers/app/
@@ -96,35 +99,149 @@ func (r *AppInfo) List(ctx context.Context, state *app_v1alpha.CrudList) error {
 		return err
 	}
 
-	var ai []*app_v1alpha.AppInfo
+	// Collect apps and resolve their active versions
+	type appEntry struct {
+		name          string
+		app           core_v1alpha.App
+		activeVersion *core_v1alpha.AppVersion
+	}
+
+	var apps []appEntry
+	specMap := make(map[string]*core_v1alpha.ConfigSpec)
 
 	for list.Next() {
 		var app core_v1alpha.App
 		list.Read(&app)
-
 		md := list.Metadata()
 
-		var a app_v1alpha.AppInfo
-
-		a.SetName(md.Name)
-		//a.SetCreatedAt(standard.ToTimestamp(list.Entity().CreatedAt))
+		entry := appEntry{name: md.Name, app: app}
 
 		if app.ActiveVersion != "" {
 			var appVer core_v1alpha.AppVersion
-			err = r.EC.GetById(ctx, app.ActiveVersion, &appVer)
-			if err != nil {
-				return err
+			if err := r.EC.GetById(ctx, app.ActiveVersion, &appVer); err == nil {
+				entry.activeVersion = &appVer
+				if resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer); err == nil {
+					specMap[appVer.ID.String()] = resolvedCfg
+				}
 			}
+		}
 
+		apps = append(apps, entry)
+	}
+
+	// Aggregate sandbox pool state per app
+	type appPoolState struct {
+		ready        int
+		desired      int
+		inCooldown   bool
+		crashCount   int64
+		cooldownLeft time.Duration
+		isAutoscale  bool
+	}
+	poolStateMap := make(map[string]*appPoolState)
+
+	poolList, err := r.EC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool))
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	for poolList.Next() {
+		var pool compute_v1alpha.SandboxPool
+		poolList.Read(&pool)
+
+		appName := ui.CleanEntityID(pool.App.String())
+		if poolStateMap[appName] == nil {
+			poolStateMap[appName] = &appPoolState{isAutoscale: true}
+		}
+		ps := poolStateMap[appName]
+		ps.ready += int(pool.ReadyInstances)
+		ps.desired += int(pool.DesiredInstances)
+		if !pool.CooldownUntil.IsZero() && pool.CooldownUntil.After(now) {
+			ps.inCooldown = true
+			ps.crashCount = pool.ConsecutiveCrashCount
+			ps.cooldownLeft = pool.CooldownUntil.Sub(now)
+		}
+
+		if spec, ok := specMap[pool.SandboxSpec.Version.String()]; ok {
+			for _, svc := range spec.Services {
+				if svc.Name == pool.Service && svc.Concurrency.Mode == "fixed" {
+					ps.isAutoscale = false
+				}
+			}
+		}
+	}
+
+	// Collect routes per app
+	routeMap := make(map[string][]string)
+
+	routeList, err := r.EC.List(ctx, entity.Ref(entity.EntityKind, ingress_v1alpha.KindHttpRoute))
+	if err != nil {
+		return err
+	}
+
+	for routeList.Next() {
+		var route ingress_v1alpha.HttpRoute
+		routeList.Read(&route)
+
+		appName := ui.CleanEntityID(route.App.String())
+		if route.Host != "" {
+			routeMap[appName] = append(routeMap[appName], route.Host)
+		} else if route.Default {
+			routeMap[appName] = append(routeMap[appName], "")
+		}
+	}
+
+	// Build response
+	var results []*app_v1alpha.AppInfo
+
+	for _, entry := range apps {
+		var a app_v1alpha.AppInfo
+		a.SetName(entry.name)
+
+		if entry.activeVersion != nil {
 			var vi app_v1alpha.VersionInfo
-			vi.SetVersion(appVer.Version)
+			vi.SetVersion(entry.activeVersion.Version)
 			a.SetCurrentVersion(&vi)
 		}
 
-		ai = append(ai, &a)
+		// Pool state → health, instances, scaling
+		if ps, ok := poolStateMap[entry.name]; ok {
+			a.SetReadyInstances(int32(ps.ready))
+			a.SetDesiredInstances(int32(ps.desired))
+
+			if ps.isAutoscale {
+				a.SetScalingMode("auto")
+			} else {
+				a.SetScalingMode("fixed")
+			}
+
+			if ps.inCooldown {
+				a.SetHealth("crashed")
+				a.SetCrashCount(ps.crashCount)
+				a.SetCooldownSeconds(int32(ps.cooldownLeft.Seconds()))
+			} else if ps.desired == 0 {
+				a.SetHealth("idle")
+			} else if ps.ready == ps.desired {
+				a.SetHealth("healthy")
+			} else if ps.ready > 0 {
+				a.SetHealth("degraded")
+			} else {
+				a.SetHealth("starting")
+			}
+		} else {
+			a.SetHealth("unknown")
+		}
+
+		// Routes
+		if routes, ok := routeMap[entry.name]; ok {
+			a.SetRoutes(routes)
+		}
+
+		results = append(results, &a)
 	}
 
-	state.Results().SetApps(ai)
+	state.Results().SetApps(results)
 
 	return nil
 }

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -159,8 +159,12 @@ func (r *AppInfo) List(ctx context.Context, state *app_v1alpha.CrudList) error {
 		ps.desired += int(pool.DesiredInstances)
 		if !pool.CooldownUntil.IsZero() && pool.CooldownUntil.After(now) {
 			ps.inCooldown = true
-			ps.crashCount = pool.ConsecutiveCrashCount
-			ps.cooldownLeft = pool.CooldownUntil.Sub(now)
+			if pool.ConsecutiveCrashCount > ps.crashCount {
+				ps.crashCount = pool.ConsecutiveCrashCount
+			}
+			if left := pool.CooldownUntil.Sub(now); left > ps.cooldownLeft {
+				ps.cooldownLeft = left
+			}
 		}
 
 		if spec, ok := specMap[pool.SandboxSpec.Version.String()]; ok {


### PR DESCRIPTION
`m app list` was doing a lot of heavy lifting on the client side — five separate EntityAccess round-trips to fetch apps, versions, deployments, routes, and sandbox pools, plus an N+1 loop calling ResolveConfig for every app version. All sequential, all over the wire. With a handful of apps you'd never notice, but once you have a bunch it got painfully slow with no feedback about what was happening.

The fix follows the Tier 1 RPC evolution pattern from RFD 0067: move the aggregation into the server where entity access is local and cheap. The existing `Crud.List` RPC already existed but only returned app name and version — now it also returns health status, instance counts, scaling mode, routes, and crash info. The CLI goes from ~350 lines of entity wrangling down to a single RPC call plus rendering.

This is wire-compatible in both directions. New CBOR field indices (3-9) are ignored by old clients, and a new CLI talking to an old server just gets zero values for the new fields (degraded display, but no errors).

Closes MIR-791