### PR TITLE
Add `miren app restart` and reset crash cooldown on deploy

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -2434,6 +2434,88 @@ func (v *CrudDeleteEnvVarResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type crudRestartArgsData struct {
+	App     *string `cbor:"0,keyasint,omitempty" json:"app,omitempty"`
+	Service *string `cbor:"1,keyasint,omitempty" json:"service,omitempty"`
+}
+
+type CrudRestartArgs struct {
+	call rpc.Call
+	data crudRestartArgsData
+}
+
+func (v *CrudRestartArgs) HasApp() bool {
+	return v.data.App != nil
+}
+
+func (v *CrudRestartArgs) App() string {
+	if v.data.App == nil {
+		return ""
+	}
+	return *v.data.App
+}
+
+func (v *CrudRestartArgs) HasService() bool {
+	return v.data.Service != nil
+}
+
+func (v *CrudRestartArgs) Service() string {
+	if v.data.Service == nil {
+		return ""
+	}
+	return *v.data.Service
+}
+
+func (v *CrudRestartArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CrudRestartArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CrudRestartArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CrudRestartArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type crudRestartResultsData struct {
+	RestartedPools   *int32 `cbor:"0,keyasint,omitempty" json:"restarted_pools,omitempty"`
+	StoppedSandboxes *int32 `cbor:"1,keyasint,omitempty" json:"stopped_sandboxes,omitempty"`
+}
+
+type CrudRestartResults struct {
+	call rpc.Call
+	data crudRestartResultsData
+}
+
+func (v *CrudRestartResults) SetRestartedPools(restarted_pools int32) {
+	v.data.RestartedPools = &restarted_pools
+}
+
+func (v *CrudRestartResults) SetStoppedSandboxes(stopped_sandboxes int32) {
+	v.data.StoppedSandboxes = &stopped_sandboxes
+}
+
+func (v *CrudRestartResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *CrudRestartResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *CrudRestartResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *CrudRestartResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type CrudNew struct {
 	rpc.Call
 	args    CrudNewArgs
@@ -2668,6 +2750,32 @@ func (t *CrudDeleteEnvVar) Results() *CrudDeleteEnvVarResults {
 	return results
 }
 
+type CrudRestart struct {
+	rpc.Call
+	args    CrudRestartArgs
+	results CrudRestartResults
+}
+
+func (t *CrudRestart) Args() *CrudRestartArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *CrudRestart) Results() *CrudRestartResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type Crud interface {
 	New(ctx context.Context, state *CrudNew) error
 	SetConfiguration(ctx context.Context, state *CrudSetConfiguration) error
@@ -2678,6 +2786,7 @@ type Crud interface {
 	SetEnvVar(ctx context.Context, state *CrudSetEnvVar) error
 	SetEnvVars(ctx context.Context, state *CrudSetEnvVars) error
 	DeleteEnvVar(ctx context.Context, state *CrudDeleteEnvVar) error
+	Restart(ctx context.Context, state *CrudRestart) error
 }
 
 type reexportCrud struct {
@@ -2717,6 +2826,10 @@ func (reexportCrud) SetEnvVars(ctx context.Context, state *CrudSetEnvVars) error
 }
 
 func (reexportCrud) DeleteEnvVar(ctx context.Context, state *CrudDeleteEnvVar) error {
+	panic("not implemented")
+}
+
+func (reexportCrud) Restart(ctx context.Context, state *CrudRestart) error {
 	panic("not implemented")
 }
 
@@ -2805,6 +2918,15 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeleteEnvVar(ctx, &CrudDeleteEnvVar{Call: call})
+			},
+		},
+		{
+			Name:          "restart",
+			InterfaceName: "Crud",
+			Index:         0,
+			Public:        false,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.Restart(ctx, &CrudRestart{Call: call})
 			},
 		},
 	}
@@ -3099,6 +3221,48 @@ func (v CrudClient) DeleteEnvVar(ctx context.Context, app string, key string, se
 	}
 
 	return &CrudClientDeleteEnvVarResults{client: v.Client, data: ret}, nil
+}
+
+type CrudClientRestartResults struct {
+	client rpc.Client
+	data   crudRestartResultsData
+}
+
+func (v *CrudClientRestartResults) HasRestartedPools() bool {
+	return v.data.RestartedPools != nil
+}
+
+func (v *CrudClientRestartResults) RestartedPools() int32 {
+	if v.data.RestartedPools == nil {
+		return 0
+	}
+	return *v.data.RestartedPools
+}
+
+func (v *CrudClientRestartResults) HasStoppedSandboxes() bool {
+	return v.data.StoppedSandboxes != nil
+}
+
+func (v *CrudClientRestartResults) StoppedSandboxes() int32 {
+	if v.data.StoppedSandboxes == nil {
+		return 0
+	}
+	return *v.data.StoppedSandboxes
+}
+
+func (v CrudClient) Restart(ctx context.Context, app string, service string) (*CrudClientRestartResults, error) {
+	args := CrudRestartArgs{}
+	args.data.App = &app
+	args.data.Service = &service
+
+	var ret crudRestartResultsData
+
+	err := v.Call(ctx, "restart", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CrudClientRestartResults{client: v.Client, data: ret}, nil
 }
 
 type userQueryWhoAmIArgsData struct{}

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -430,6 +430,18 @@ interfaces:
           - name: deletedSource
             type: string
             doc: "The source of the deleted variable (config or manual)"
+      - name: restart
+        parameters:
+          - name: app
+            type: string
+          - name: service
+            type: string
+            doc: "Optional service name to restart only a specific service. Empty restarts all services."
+        results:
+          - name: restarted_pools
+            type: int32
+          - name: stopped_sandboxes
+            type: int32
 
   - name: UserQuery
     methods:

--- a/cli/commands/app_restart.go
+++ b/cli/commands/app_restart.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"miren.dev/runtime/api/app/app_v1alpha"
+)
+
+func AppRestart(ctx *Context, opts struct {
+	Service string `short:"s" long:"service" description:"Restart only a specific service"`
+	AppCentric
+}) error {
+	crudcl, err := ctx.RPCClient("dev.miren.runtime/app")
+	if err != nil {
+		return err
+	}
+
+	crud := app_v1alpha.NewCrudClient(crudcl)
+
+	result, err := crud.Restart(ctx, opts.App, opts.Service)
+	if err != nil {
+		return err
+	}
+
+	if opts.Service != "" {
+		ctx.Printf("Restarted service %s of app %s", opts.Service, opts.App)
+	} else {
+		ctx.Printf("Restarted app %s", opts.App)
+	}
+
+	ctx.Printf(" (stopped %d sandboxes across %d pools)\n",
+		result.StoppedSandboxes(), result.RestartedPools())
+
+	return nil
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -241,6 +241,16 @@ miren deploy --analyze
 			Body: "miren app history --status active --limit 5",
 		}),
 	))
+	d.Dispatch("app restart", Infer("app restart", "Restart an application", AppRestart,
+		WithExample(mflags.Example{
+			Name: "Restart the current app",
+			Body: "miren app restart",
+		}),
+		WithExample(mflags.Example{
+			Name: "Restart a specific service",
+			Body: "miren app restart -s web",
+		}),
+	))
 	d.Dispatch("app delete", Infer("app delete", "Delete an application and all its resources", AppDelete,
 		WithExample(mflags.Example{
 			Name: "Delete an app (with confirmation prompt)",

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -937,6 +937,17 @@ func (l *Launcher) updatePool(ctx context.Context, poolWithEntity *PoolWithEntit
 		newAttrs = append(newAttrs, entity.Int64(compute_v1alpha.SandboxPoolReadyInstancesId, 0))
 	}
 
+	// Always include crash cooldown fields when zeroed (e.g. after deploy reset)
+	if pool.ConsecutiveCrashCount == 0 {
+		newAttrs = append(newAttrs, entity.Int64(compute_v1alpha.SandboxPoolConsecutiveCrashCountId, 0))
+	}
+	if pool.LastCrashTime.IsZero() {
+		newAttrs = append(newAttrs, entity.Time(compute_v1alpha.SandboxPoolLastCrashTimeId, time.Time{}))
+	}
+	if pool.CooldownUntil.IsZero() {
+		newAttrs = append(newAttrs, entity.Time(compute_v1alpha.SandboxPoolCooldownUntilId, time.Time{}))
+	}
+
 	// Build the final attribute list: metadata from existing + new pool attrs
 	finalAttrs := make([]entity.Attr, 0, len(ent.Attrs())+len(newAttrs))
 

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -358,6 +358,18 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 			needsUpdate = true
 		}
 
+		// A deploy is an explicit operator action — reset crash cooldown so
+		// stale backoff from a previous version doesn't block the new one.
+		if poolWithEntity.Pool.ConsecutiveCrashCount > 0 || !poolWithEntity.Pool.CooldownUntil.IsZero() {
+			l.Log.Info("resetting crash cooldown on pool reuse",
+				"pool", poolWithEntity.Pool.ID,
+				"previous_crash_count", poolWithEntity.Pool.ConsecutiveCrashCount)
+			poolWithEntity.Pool.ConsecutiveCrashCount = 0
+			poolWithEntity.Pool.LastCrashTime = time.Time{}
+			poolWithEntity.Pool.CooldownUntil = time.Time{}
+			needsUpdate = true
+		}
+
 		// For fixed mode services, update desired instances if they've changed
 		// For auto mode, the activator manages desired instances - don't touch it
 		if fixedMode && poolWithEntity.Pool.DesiredInstances != desiredInstances {

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -496,7 +496,7 @@ func (r *AppInfo) Restart(ctx context.Context, state *app_v1alpha.CrudRestart) e
 	var configSpec *core_v1alpha.ConfigSpec
 	if appRec.ActiveVersion != "" {
 		var ver core_v1alpha.AppVersion
-		if err := r.EC.Get(ctx, appRec.ActiveVersion.String(), &ver); err != nil {
+		if err := r.EC.GetById(ctx, appRec.ActiveVersion, &ver); err != nil {
 			r.Log.Warn("failed to get active version, skipping desired instance restore",
 				"version", appRec.ActiveVersion, "error", err)
 		} else {
@@ -573,8 +573,17 @@ func (r *AppInfo) Restart(ctx context.Context, state *app_v1alpha.CrudRestart) e
 		}
 
 		// Restore DesiredInstances for fixed-mode pools that were capped to 1
-		// during crash cooldown
-		if configSpec != nil {
+		// during crash cooldown. Only do this for pools that reference the
+		// active version — stale pools from old deployments were intentionally
+		// scaled to 0 and should not be resurrected.
+		isActivePool := false
+		for _, ref := range pool.ReferencedByVersions {
+			if ref == appRec.ActiveVersion {
+				isActivePool = true
+				break
+			}
+		}
+		if isActivePool && configSpec != nil {
 			svcConc, err := coreutil.GetServiceConcurrency(configSpec, pool.Service)
 			if err == nil && svcConc.Mode == "fixed" && svcConc.NumInstances > 0 {
 				if pool.DesiredInstances != svcConc.NumInstances {

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
@@ -474,6 +476,136 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 	if len(result.DeletedSources) > 0 {
 		state.Results().SetDeletedSource(result.DeletedSources[0])
 	}
+	return nil
+}
+
+func (r *AppInfo) Restart(ctx context.Context, state *app_v1alpha.CrudRestart) error {
+	args := state.Args()
+	name := args.App()
+	service := args.Service()
+
+	var appRec core_v1alpha.App
+	if err := r.EC.Get(ctx, name, &appRec); err != nil {
+		return fmt.Errorf("app %q not found: %w", name, err)
+	}
+
+	// Resolve the config to restore DesiredInstances for fixed-mode pools.
+	// During crash cooldown the pool manager resets DesiredInstances to 1;
+	// we need to restore the configured value so fixed-mode pools come back
+	// at the right scale.
+	var configSpec *core_v1alpha.ConfigSpec
+	if appRec.ActiveVersion != "" {
+		var ver core_v1alpha.AppVersion
+		if err := r.EC.Get(ctx, appRec.ActiveVersion.String(), &ver); err != nil {
+			r.Log.Warn("failed to get active version, skipping desired instance restore",
+				"version", appRec.ActiveVersion, "error", err)
+		} else {
+			spec, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &ver)
+			if err != nil {
+				r.Log.Warn("failed to resolve config, skipping desired instance restore", "error", err)
+			} else {
+				configSpec = spec
+			}
+		}
+	}
+
+	// Find all sandbox pools for this app
+	poolList, err := r.EC.List(ctx, entity.Ref(compute_v1alpha.SandboxPoolAppId, appRec.ID))
+	if err != nil {
+		return fmt.Errorf("listing pools: %w", err)
+	}
+
+	var restartedPools int32
+	var stoppedSandboxes int32
+
+	for poolList.Next() {
+		var pool compute_v1alpha.SandboxPool
+		if err := poolList.Read(&pool); err != nil {
+			continue
+		}
+
+		// Filter by service if specified
+		if service != "" && pool.Service != service {
+			continue
+		}
+
+		// Find and stop all RUNNING/PENDING sandboxes for this pool
+		sbList, err := r.EC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+		if err != nil {
+			r.Log.Warn("failed to list sandboxes", "pool", pool.ID, "error", err)
+			continue
+		}
+
+		for sbList.Next() {
+			var sb compute_v1alpha.Sandbox
+			if err := sbList.Read(&sb); err != nil {
+				continue
+			}
+
+			// Filter by pool label
+			md := sbList.Metadata()
+			if md == nil {
+				continue
+			}
+			poolLabel, _ := md.Labels.Get("pool")
+			if poolLabel != pool.ID.String() {
+				continue
+			}
+
+			if sb.Status != compute_v1alpha.RUNNING && sb.Status != compute_v1alpha.PENDING {
+				continue
+			}
+
+			if err := r.EC.Patch(ctx, sb.ID, 0,
+				entity.Ref(compute_v1alpha.SandboxStatusId, entity.Id(compute_v1alpha.STOPPED)),
+			); err != nil {
+				r.Log.Warn("failed to stop sandbox", "sandbox", sb.ID, "error", err)
+				continue
+			}
+			stoppedSandboxes++
+		}
+
+		// Build patch attrs: always reset crash cooldown fields
+		patchAttrs := []entity.Attr{
+			entity.Int64(compute_v1alpha.SandboxPoolConsecutiveCrashCountId, 0),
+			entity.Time(compute_v1alpha.SandboxPoolLastCrashTimeId, time.Time{}),
+			entity.Time(compute_v1alpha.SandboxPoolCooldownUntilId, time.Time{}),
+		}
+
+		// Restore DesiredInstances for fixed-mode pools that were capped to 1
+		// during crash cooldown
+		if configSpec != nil {
+			svcConc, err := coreutil.GetServiceConcurrency(configSpec, pool.Service)
+			if err == nil && svcConc.Mode == "fixed" && svcConc.NumInstances > 0 {
+				if pool.DesiredInstances != svcConc.NumInstances {
+					patchAttrs = append(patchAttrs,
+						entity.Int64(compute_v1alpha.SandboxPoolDesiredInstancesId, svcConc.NumInstances))
+				}
+			}
+		}
+
+		if err := r.EC.Patch(ctx, pool.ID, 0, patchAttrs...); err != nil {
+			r.Log.Warn("failed to patch pool", "pool", pool.ID, "error", err)
+		}
+
+		restartedPools++
+	}
+
+	if restartedPools == 0 {
+		if service != "" {
+			return fmt.Errorf("no pools found for service %q of app %q", service, name)
+		}
+		return fmt.Errorf("no pools found for app %q", name)
+	}
+
+	r.Log.Info("app restarted",
+		"app", name,
+		"service", service,
+		"pools", restartedPools,
+		"sandboxes_stopped", stoppedSandboxes)
+
+	state.Results().SetRestartedPools(restartedPools)
+	state.Results().SetStoppedSandboxes(stoppedSandboxes)
 	return nil
 }
 


### PR DESCRIPTION
After a server crash or bad deploy, apps enter exponential backoff cooldown (up to 15 minutes). Once the underlying issue is resolved, there was no way to tell the system "it's fixed, try again now" — you just had to wait it out. This came up during MIR-890 dogfooding when a dev build regression crashed Garden and all apps were stuck in cooldown even after rolling back to a healthy build.

This PR addresses the problem from two angles. First, deploys now reset crash cooldown when reusing a pool — a deploy is an explicit operator action and shouldn't be blocked by stale backoff from a previous version's crashes (MIR-906). Second, there's a new `miren app restart` command for when you want to bounce everything without deploying (MIR-905). It stops all running sandboxes, clears crash cooldown, restores the configured instance count for fixed-mode pools, and lets the reconciliation loop spin up fresh sandboxes.

While working on this we also discovered that fixed-mode pools don't restore their `DesiredInstances` after crash cooldown expires naturally — filed as MIR-916. The restart command handles this correctly, but the organic recovery path still has the bug.

Fixes MIR-905, MIR-906