### PR TITLE
Skip entity store disk check for local provider

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -314,7 +314,7 @@ func validateNodePorts(ctx context.Context, eac *entityserver_v1alpha.EntityAcce
 func validateDiskConfigs(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, spec core_v1alpha.ConfigSpec) error {
 	for _, svc := range spec.Services {
 		for _, disk := range svc.Disks {
-			if disk.SizeGb > 0 || disk.Name == "" {
+			if disk.SizeGb > 0 || disk.Name == "" || disk.Provider == core_v1alpha.ConfigSpecServicesDisksLOCAL {
 				continue
 			}
 			// size_gb == 0 means we expect the disk to already exist

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -2344,6 +2344,29 @@ func TestValidateDiskConfigsExistingDisk(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidateDiskConfigsLocalDiskSkipsCheck(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Local disk with size_gb=0 and no existing entity — should succeed
+	// because local disks are managed by the node, not the entity store
+	spec := core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "web",
+			Disks: []core_v1alpha.ConfigSpecServicesDisks{{
+				Name:      "data",
+				MountPath: "/miren/data/local",
+				Provider:  core_v1alpha.ConfigSpecServicesDisksLOCAL,
+				SizeGb:    0,
+			}},
+		}},
+	}
+
+	err := validateDiskConfigs(ctx, server.EAC, spec)
+	assert.NoError(t, err)
+}
+
 func TestValidateDiskConfigsAutoCreate(t *testing.T) {
 	ctx := context.Background()
 	server, cleanup := testutils.NewInMemEntityServer(t)


### PR DESCRIPTION
We had a fun contradiction where it was impossible to create a new local disk. The client-side validation (correctly) rejects `size_gb` for `provider = "local"` since local disks don't have a configurable size. But the server-side deploy validation interprets `size_gb=0` as "this disk must already exist in the entity store" and errors out when it doesn't find one — telling you to set `size_gb` to fix it. Ouroboros.

The fix is straightforward: the `validateDiskConfigs` check in the build server now skips local disks entirely, since they're managed by the node and don't go through the entity store. Added a test to make sure we don't regress on this.

Closes MIR-915