### PR TITLE
Fix distributed runner startup and scheduling safety

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -624,6 +624,13 @@ miren deploy --analyze
 				Body: "miren runner list",
 			}),
 		))
+		d.Dispatch("runner status", Infer("runner status", "Show runner health and configuration", RunnerStatus,
+			WithLabsFeature(labs.FeatureDistributedRunners),
+			WithExample(mflags.Example{
+				Name: "Check runner status",
+				Body: "miren runner status",
+			}),
+		))
 		d.Dispatch("runner revoke", Infer("runner revoke", "Revoke a runner invitation", RunnerRevoke,
 			WithLabsFeature(labs.FeatureDistributedRunners),
 			WithExample(mflags.Example{

--- a/cli/commands/runner_join.go
+++ b/cli/commands/runner_join.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"bufio"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 
 	"miren.dev/runtime/api/runner/runner_v1alpha"
@@ -15,6 +17,7 @@ import (
 
 func RunnerJoin(ctx *Context, opts struct {
 	Coordinator string   `short:"c" long:"coordinator" description:"Coordinator address (host:port)"`
+	Code        string   `long:"code" description:"Join code (or pass via stdin)"`
 	ListenAddr  string   `short:"l" long:"listen" description:"Address this runner will listen on"`
 	Labels      []string `long:"labels" description:"Additional labels for the runner (key=value)"`
 	ConfigPath  string   `long:"config" description:"Path to save runner config" default:"/var/lib/miren/runner/config.yaml"`
@@ -43,7 +46,20 @@ func RunnerJoin(ctx *Context, opts struct {
 
 	ctx.Printf("Joining coordinator at %s\n", coordinator)
 
-	code := opts.Args.JoinCode
+	// Resolve join code: --code flag > positional arg > stdin pipe > TTY prompt
+	code := opts.Code
+	if code == "" {
+		code = opts.Args.JoinCode
+	}
+	if code == "" {
+		if stat, _ := os.Stdin.Stat(); stat.Mode()&os.ModeCharDevice == 0 {
+			// stdin is a pipe, read the code from it
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				code = strings.TrimSpace(scanner.Text())
+			}
+		}
+	}
 	if code == "" {
 		var err error
 		code, err = ui.PromptForInput(
@@ -93,14 +109,26 @@ func RunnerJoin(ctx *Context, opts struct {
 		}
 	}
 
+	// Use the address the runner actually connected to rather than the
+	// coordinator's bind address (which may be 0.0.0.0 or localhost).
+	coordinatorHost, _, _ := net.SplitHostPort(coordinator)
+
+	// Rewrite loopback/unspecified hosts in etcd endpoints with the
+	// coordinator host. For embedded etcd (the common case with distributed
+	// runners), etcd is colocated with the coordinator.
+	etcdEndpoints := res.EtcdEndpoints()
+	for i, ep := range etcdEndpoints {
+		etcdEndpoints[i] = rewriteLoopbackEndpoint(ep, coordinatorHost)
+	}
+
 	cfg := &runnerconfig.Config{
 		RunnerID:           runnerID,
-		CoordinatorAddress: res.CoordinatorAddr(),
+		CoordinatorAddress: coordinator,
 		CACert:             string(res.CaPem()),
 		ClientCert:         string(res.CertPem()),
 		ClientKey:          string(res.KeyPem()),
 		Labels:             labels,
-		EtcdEndpoints:      res.EtcdEndpoints(),
+		EtcdEndpoints:      etcdEndpoints,
 		EtcdPrefix:         res.EtcdPrefix(),
 		NetworkBackend:     res.NetworkBackend(),
 	}
@@ -114,4 +142,37 @@ func RunnerJoin(ctx *Context, opts struct {
 	ctx.Printf("  miren runner start\n")
 
 	return nil
+}
+
+// rewriteLoopbackEndpoint replaces loopback or unspecified hosts in an
+// endpoint URL with the given replacement host. Endpoints may be bare
+// host:port or have a scheme (e.g. "https://localhost:12379").
+func rewriteLoopbackEndpoint(endpoint, replaceHost string) string {
+	host := endpoint
+	scheme := ""
+
+	// Strip scheme if present
+	if idx := strings.Index(endpoint, "://"); idx != -1 {
+		scheme = endpoint[:idx+3]
+		host = endpoint[idx+3:]
+	}
+
+	h, port, err := net.SplitHostPort(host)
+	if err != nil {
+		return endpoint
+	}
+
+	if isLoopbackOrUnspecified(h) {
+		return scheme + net.JoinHostPort(replaceHost, port)
+	}
+
+	return endpoint
+}
+
+func isLoopbackOrUnspecified(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1", "0.0.0.0", "::":
+		return true
+	}
+	return false
 }

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -72,18 +72,18 @@ func RunnerStart(ctx *Context, opts struct {
 		)
 
 		if releasePath := FindReleasePath(); releasePath != "" {
-			binDir = releasePath
-			containerdBinary = filepath.Join(releasePath, "containerd")
-		} else {
+			candidate := filepath.Join(releasePath, "containerd")
+			if _, err := os.Stat(candidate); err == nil {
+				binDir = releasePath
+				containerdBinary = candidate
+			}
+		}
+		if containerdBinary == "" {
 			var err error
 			containerdBinary, err = exec.LookPath("containerd")
 			if err != nil {
 				return fmt.Errorf("containerd binary not found in PATH or release directory: %w", err)
 			}
-		}
-
-		if _, err := os.Stat(containerdBinary); err != nil {
-			return fmt.Errorf("containerd binary not found at %s: %w", containerdBinary, err)
 		}
 
 		containerdComponent := containerdcomp.NewContainerdComponent(ctx.Log, opts.DataPath)
@@ -142,13 +142,12 @@ func RunnerStart(ctx *Context, opts struct {
 	listenAddr := opts.ListenAddr
 	if listenAddr == "" {
 		port := "8444"
-		if ip, err := discoverOutboundIP(cfg.CoordinatorAddress); err == nil {
-			listenAddr = net.JoinHostPort(ip.String(), port)
-			ctx.Log.Info("discovered listen address", "addr", listenAddr)
-		} else {
-			listenAddr = ":" + port
-			ctx.Log.Warn("could not discover outbound IP, using bind-all address", "addr", listenAddr, "error", err)
+		ip, err := discoverOutboundIP(cfg.CoordinatorAddress)
+		if err != nil {
+			return fmt.Errorf("could not discover outbound IP for listen address (use --listen to set manually): %w", err)
 		}
+		listenAddr = net.JoinHostPort(ip.String(), port)
+		ctx.Log.Info("discovered listen address", "addr", listenAddr)
 	}
 
 	// Build runner configuration
@@ -276,5 +275,9 @@ func discoverOutboundIP(remoteAddr string) (netip.Addr, error) {
 	if !ok {
 		return netip.Addr{}, fmt.Errorf("unexpected local address type")
 	}
-	return netip.AddrFrom4([4]byte(addr.IP.To4())), nil
+	ip4 := addr.IP.To4()
+	if ip4 == nil {
+		return netip.Addr{}, fmt.Errorf("discovered non-IPv4 address: %s", addr.IP)
+	}
+	return netip.AddrFrom4([4]byte(ip4)), nil
 }

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/netip"
 	"os"
 	"os/exec"
@@ -151,8 +152,14 @@ func RunnerStart(ctx *Context, opts struct {
 		DiskMode:      cfg.DiskMode,
 	}
 
-	// Create resolver for network operations
-	resolver, _ := netresolve.NewLocalResolver()
+	// Create resolver for network operations and map cluster.local to the
+	// coordinator so the runner can pull images from the coordinator's registry.
+	resolver, hostMapper := netresolve.NewLocalResolver()
+	coordinatorHost, _, _ := net.SplitHostPort(cfg.CoordinatorAddress)
+	if addr, err := netip.ParseAddr(coordinatorHost); err == nil {
+		hostMapper.SetHost("cluster.local", addr)
+		ctx.Log.Info("mapped cluster.local to coordinator", "addr", addr)
+	}
 
 	// Build runner dependencies
 	// Note: Some deps like NetServ require entity access client which we get after connecting

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -65,19 +65,40 @@ func RunnerStart(ctx *Context, opts struct {
 		defer cc.Close()
 	} else {
 		// Start embedded containerd (same as server standalone mode)
-		containerdBinary, err := exec.LookPath("containerd")
-		if err != nil {
-			return fmt.Errorf("containerd binary not found in PATH: %w", err)
+		var (
+			containerdBinary string
+			binDir           string
+		)
+
+		if releasePath := FindReleasePath(); releasePath != "" {
+			binDir = releasePath
+			containerdBinary = filepath.Join(releasePath, "containerd")
+		} else {
+			var err error
+			containerdBinary, err = exec.LookPath("containerd")
+			if err != nil {
+				return fmt.Errorf("containerd binary not found in PATH or release directory: %w", err)
+			}
+		}
+
+		if _, err := os.Stat(containerdBinary); err != nil {
+			return fmt.Errorf("containerd binary not found at %s: %w", containerdBinary, err)
 		}
 
 		containerdComponent := containerdcomp.NewContainerdComponent(ctx.Log, opts.DataPath)
+
+		envPath := os.Getenv("PATH")
+		if binDir != "" {
+			envPath = binDir + ":" + envPath
+		}
 
 		baseDir := filepath.Join(opts.DataPath, "containerd")
 		containerdConfig := &containerdcomp.Config{
 			BinaryPath: containerdBinary,
 			BaseDir:    baseDir,
+			BinDir:     binDir,
 			SocketPath: filepath.Join(baseDir, "containerd.sock"),
-			Env:        []string{"PATH=" + os.Getenv("PATH")},
+			Env:        []string{"PATH=" + envPath},
 		}
 
 		if err := containerdComponent.Start(ctx, containerdConfig); err != nil {

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -136,10 +136,19 @@ func RunnerStart(ctx *Context, opts struct {
 	// Create errgroup for background tasks
 	eg, egCtx := errgroup.WithContext(sigCtx)
 
-	// Determine listen address
+	// Determine listen address. If no explicit address is given, discover the
+	// machine's outbound IP (the one that would route to the coordinator) and
+	// advertise that so the coordinator knows how to reach this runner.
 	listenAddr := opts.ListenAddr
 	if listenAddr == "" {
-		listenAddr = ":8444" // Default runner listen port
+		port := "8444"
+		if ip, err := discoverOutboundIP(cfg.CoordinatorAddress); err == nil {
+			listenAddr = net.JoinHostPort(ip.String(), port)
+			ctx.Log.Info("discovered listen address", "addr", listenAddr)
+		} else {
+			listenAddr = ":" + port
+			ctx.Log.Warn("could not discover outbound IP, using bind-all address", "addr", listenAddr, "error", err)
+		}
 	}
 
 	// Build runner configuration
@@ -252,4 +261,20 @@ func RunnerStart(ctx *Context, opts struct {
 
 	ctx.Log.Info("runner stopped")
 	return nil
+}
+
+// discoverOutboundIP finds the local IP that would be used to reach the given
+// remote address. This gives us the machine's IP on the right interface without
+// actually connecting.
+func discoverOutboundIP(remoteAddr string) (netip.Addr, error) {
+	conn, err := net.Dial("udp4", remoteAddr)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	defer conn.Close()
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("unexpected local address type")
+	}
+	return netip.AddrFrom4([4]byte(addr.IP.To4())), nil
 }

--- a/cli/commands/runner_status.go
+++ b/cli/commands/runner_status.go
@@ -24,15 +24,14 @@ func RunnerStatus(ctx *Context, opts struct {
 	}
 
 	ctx.Printf("Runner ID:    %s\n", cfg.RunnerID)
-	ctx.Printf("Coordinator:  %s\n", cfg.CoordinatorAddress)
 
 	// Check coordinator reachability
 	conn, err := net.DialTimeout("tcp", cfg.CoordinatorAddress, 3*time.Second)
 	if err != nil {
-		ctx.Printf("Coordinator:  unreachable (%s)\n", err)
+		ctx.Printf("Coordinator:  %s (unreachable)\n", cfg.CoordinatorAddress)
 	} else {
 		conn.Close()
-		ctx.Printf("Coordinator:  reachable\n")
+		ctx.Printf("Coordinator:  %s (reachable)\n", cfg.CoordinatorAddress)
 	}
 
 	// Check containerd

--- a/cli/commands/runner_status.go
+++ b/cli/commands/runner_status.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"miren.dev/runtime/pkg/runnerconfig"
+)
+
+func RunnerStatus(ctx *Context, opts struct {
+	ConfigPath string `long:"config" description:"Path to runner config" default:"/var/lib/miren/runner/config.yaml"`
+	DataPath   string `long:"data-path" description:"Path to runner data" default:"/var/lib/miren/runner"`
+}) error {
+	// Check if runner is configured
+	cfg, err := runnerconfig.Load(opts.ConfigPath)
+	if err != nil {
+		ctx.Printf("Runner:       not configured\n")
+		ctx.Printf("  (no config at %s)\n", opts.ConfigPath)
+		return fmt.Errorf("runner not configured: %w", err)
+	}
+
+	ctx.Printf("Runner ID:    %s\n", cfg.RunnerID)
+	ctx.Printf("Coordinator:  %s\n", cfg.CoordinatorAddress)
+
+	// Check coordinator reachability
+	conn, err := net.DialTimeout("tcp", cfg.CoordinatorAddress, 3*time.Second)
+	if err != nil {
+		ctx.Printf("Coordinator:  unreachable (%s)\n", err)
+	} else {
+		conn.Close()
+		ctx.Printf("Coordinator:  reachable\n")
+	}
+
+	// Check containerd
+	socketPath := filepath.Join(opts.DataPath, "containerd", "containerd.sock")
+	if info, err := os.Stat(socketPath); err == nil && info.Mode()&os.ModeSocket != 0 {
+		// Try to find the containerd PID from its pidfile or by checking the socket
+		ctx.Printf("Containerd:   running (socket %s)\n", socketPath)
+	} else {
+		ctx.Printf("Containerd:   not running\n")
+	}
+
+	// Check etcd connectivity
+	if len(cfg.EtcdEndpoints) > 0 {
+		ctx.Printf("Etcd:         %s\n", cfg.EtcdEndpoints)
+	}
+
+	// Check flannel subnet
+	netdbPath := filepath.Join(opts.DataPath, "net.db")
+	if _, err := os.Stat(netdbPath); err == nil {
+		ctx.Printf("Network DB:   %s\n", netdbPath)
+	}
+
+	// Check if the runner process is running by looking for a pidfile
+	pidFile := filepath.Join(opts.DataPath, "runner.pid")
+	if data, err := os.ReadFile(pidFile); err == nil {
+		var pid int
+		if _, err := fmt.Sscanf(string(data), "%d", &pid); err == nil {
+			process, err := os.FindProcess(pid)
+			if err == nil {
+				if err := process.Signal(syscall.Signal(0)); err == nil {
+					ctx.Printf("Status:       running (pid %d)\n", pid)
+				} else {
+					ctx.Printf("Status:       stale pid %d (%s)\n", pid, err)
+				}
+			}
+		}
+	} else {
+		// No pidfile, check if containerd socket exists as a proxy
+		if _, err := os.Stat(socketPath); err == nil {
+			ctx.Printf("Status:       running (no pidfile, socket present)\n")
+		} else {
+			ctx.Printf("Status:       stopped\n")
+		}
+	}
+
+	// Check sandboxes
+	sandboxDir := filepath.Join(opts.DataPath, "containerd", "io.containerd.runtime.v2.task", "miren")
+	if entries, err := os.ReadDir(sandboxDir); err == nil {
+		ctx.Printf("Sandboxes:    %d running\n", len(entries))
+	} else {
+		ctx.Printf("Sandboxes:    0 running\n")
+	}
+
+	return nil
+}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -74,6 +74,23 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	versionInfo := version.GetInfo()
 	ctx.UILog.Info("starting miren server", "version", versionInfo.Version, "commit", versionInfo.Commit)
 
+	// Discover local IPs early so they're available for etcd TLS SANs
+	discovery, err := ipdiscovery.DiscoverWithTimeout(5*time.Second, ctx.Log)
+	if err != nil {
+		ctx.Log.Warn("failed to discover local IPs", "error", err)
+	} else {
+		for _, addr := range discovery.Addresses {
+			ip := net.ParseIP(addr.IP)
+			if ip != nil && !ip.IsLinkLocalUnicast() {
+				cfg.TLS.AdditionalIPs = append(cfg.TLS.AdditionalIPs, addr.IP)
+			}
+		}
+		if discovery.PublicIP != "" {
+			cfg.TLS.AdditionalIPs = append(cfg.TLS.AdditionalIPs, discovery.PublicIP)
+		}
+		ctx.Log.Info("discovered IPs", "local-addresses", len(discovery.Addresses), "public", discovery.PublicIP)
+	}
+
 	switch cfg.GetMode() {
 	case "standalone":
 		// Mode defaults are already applied by serverconfig.Load
@@ -503,29 +520,6 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	defer batchWriter.Close()
 	systemHandler := observability.NewSystemLogHandler(ctx.Log.Handler(), batchWriter)
 	ctx.Log = slog.New(systemHandler)
-
-	// Discover local IPs using ipdiscovery
-	discovery, err := ipdiscovery.DiscoverWithTimeout(5*time.Second, ctx.Log)
-	if err != nil {
-		ctx.Log.Warn("failed to discover local IPs", "error", err)
-		// Don't fail if IP discovery fails, just log it
-	} else {
-		// Add discovered IPs to the additional IPs list
-		for _, addr := range discovery.Addresses {
-			// Skip IPv6 link-local addresses
-			ip := net.ParseIP(addr.IP)
-			if ip != nil && !ip.IsLinkLocalUnicast() {
-				cfg.TLS.AdditionalIPs = append(cfg.TLS.AdditionalIPs, addr.IP)
-			}
-		}
-
-		// Add public IP if available
-		if discovery.PublicIP != "" {
-			cfg.TLS.AdditionalIPs = append(cfg.TLS.AdditionalIPs, discovery.PublicIP)
-		}
-
-		ctx.Log.Info("discovered IPs", "local-addresses", len(discovery.Addresses), "public", discovery.PublicIP)
-	}
 
 	var additionalIps []net.IP
 	seen := make(map[string]struct{})

--- a/components/containerd/containerd.go
+++ b/components/containerd/containerd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -324,7 +325,9 @@ func (c *ContainerdComponent) Client() (*containerd.Client, error) {
 	return c.client, nil
 }
 
-// waitForSocket waits for the containerd socket to be available
+// waitForSocket waits for the containerd socket to be accepting connections.
+// Checking file existence alone is insufficient — containerd creates the
+// socket file before it starts listening, causing a race on fast machines.
 func (c *ContainerdComponent) waitForSocket(ctx context.Context, socketPath string) error {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
@@ -339,13 +342,11 @@ func (c *ContainerdComponent) waitForSocket(ctx context.Context, socketPath stri
 		case <-timeout:
 			return fmt.Errorf("timeout waiting for containerd socket at %s", socketPath)
 		case <-ticker.C:
-			if _, err := os.Stat(socketPath); err == nil {
-				// Socket exists, give it a moment to be ready
-				time.Sleep(100 * time.Millisecond)
-				c.log.Info("containerd socket found", "path", socketPath, "waited", time.Since(startTime))
+			conn, err := net.DialTimeout("unix", socketPath, 500*time.Millisecond)
+			if err == nil {
+				conn.Close()
+				c.log.Info("containerd socket is accepting connections", "path", socketPath, "waited", time.Since(startTime))
 				return nil
-			} else if !os.IsNotExist(err) {
-				c.log.Warn("error checking socket", "path", socketPath, "error", err)
 			}
 		}
 	}

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -209,8 +209,16 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, ext
 						"server_expires", existing.NotAfter.Format(time.RFC3339),
 						"sans_ips", existing.IPAddresses)
 
-					clientPEM, _ := os.ReadFile(clientCertFile)
-					clientKey, _ := os.ReadFile(clientKeyFile)
+					clientPEM, err := os.ReadFile(clientCertFile)
+					if err != nil {
+						log.Info("etcd client cert unreadable, regenerating", "error", err)
+						goto regenerate
+					}
+					clientKey, err := os.ReadFile(clientKeyFile)
+					if err != nil {
+						log.Info("etcd client key unreadable, regenerating", "error", err)
+						goto regenerate
+					}
 					caCert := ca.GetCACertificate()
 
 					return &EtcdTLSSetupResult{
@@ -231,6 +239,7 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, ext
 		}
 	}
 
+regenerate:
 	log.Info("generating etcd TLS certificates", "dns_names", dnsNames, "ips", ips)
 
 	// Issue etcd server certificate

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -151,8 +151,9 @@ type EtcdTLSSetupResult struct {
 	CAFile string
 }
 
-// SetupEtcdTLS loads the existing CA and issues certificates for etcd mTLS.
-// This must be called before starting the etcd component when TLS is desired.
+// SetupEtcdTLS loads the existing CA and ensures valid etcd mTLS certificates.
+// Existing certificates are reused if their SANs match and they aren't near
+// expiry; otherwise they are regenerated.
 // The dataPath should be the same path used for CoordinatorConfig.DataPath.
 // The CA must already exist (created by the coordinator's LoadCA).
 // Additional DNS names and IPs are included in the server certificate SANs
@@ -184,12 +185,53 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, ext
 		return nil, fmt.Errorf("failed to create etcd certs directory: %w", err)
 	}
 
-	// Build server cert SANs: always include localhost + loopback, plus any extras
+	// Build expected server cert SANs
 	dnsNames := []string{"localhost"}
 	dnsNames = append(dnsNames, extraDNSNames...)
 
 	ips := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
 	ips = append(ips, extraIPs...)
+
+	serverCertFile := filepath.Join(certsDir, "server.crt")
+	serverKeyFile := filepath.Join(certsDir, "server.key")
+	clientCertFile := filepath.Join(certsDir, "client.crt")
+	clientKeyFile := filepath.Join(certsDir, "client.key")
+	caFile := filepath.Join(certsDir, "ca.crt")
+
+	// Check if existing certs are still valid
+	if existing, err := loadX509Cert(serverCertFile); err == nil {
+		if err := validateAPICertificate(existing, dnsNames, ips); err == nil {
+			// Also check client cert exists and isn't expired
+			if clientExisting, err := loadX509Cert(clientCertFile); err == nil {
+				horizon := time.Now().Add(48 * time.Hour)
+				if clientExisting.NotAfter.After(horizon) {
+					log.Info("etcd TLS certificates valid, reusing", "certs_dir", certsDir,
+						"server_expires", existing.NotAfter.Format(time.RFC3339),
+						"sans_ips", existing.IPAddresses)
+
+					clientPEM, _ := os.ReadFile(clientCertFile)
+					clientKey, _ := os.ReadFile(clientKeyFile)
+					caCert := ca.GetCACertificate()
+
+					return &EtcdTLSSetupResult{
+						CertsDir: certsDir,
+						ClientTLS: &EtcdTLSConfig{
+							CertPEM: clientPEM,
+							KeyPEM:  clientKey,
+							CACert:  caCert,
+						},
+						ClientCertFile: clientCertFile,
+						ClientKeyFile:  clientKeyFile,
+						CAFile:         caFile,
+					}, nil
+				}
+			}
+		} else {
+			log.Info("etcd server cert needs regeneration", "reason", err)
+		}
+	}
+
+	log.Info("generating etcd TLS certificates", "dns_names", dnsNames, "ips", ips)
 
 	// Issue etcd server certificate
 	serverCert, err := ca.IssueCertificate(caauth.Options{
@@ -204,13 +246,13 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, ext
 	}
 
 	// Write etcd server certs
-	if err := os.WriteFile(filepath.Join(certsDir, "ca.crt"), ca.GetCACertificate(), 0644); err != nil {
+	if err := os.WriteFile(caFile, ca.GetCACertificate(), 0644); err != nil {
 		return nil, fmt.Errorf("failed to write etcd CA cert: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(certsDir, "server.crt"), serverCert.CertPEM, 0644); err != nil {
+	if err := os.WriteFile(serverCertFile, serverCert.CertPEM, 0644); err != nil {
 		return nil, fmt.Errorf("failed to write etcd server cert: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(certsDir, "server.key"), serverCert.KeyPEM, 0600); err != nil {
+	if err := os.WriteFile(serverKeyFile, serverCert.KeyPEM, 0600); err != nil {
 		return nil, fmt.Errorf("failed to write etcd server key: %w", err)
 	}
 
@@ -224,11 +266,6 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, ext
 		return nil, fmt.Errorf("failed to issue etcd client certificate: %w", err)
 	}
 
-	// Write client certs to disk alongside server certs
-	clientCertFile := filepath.Join(certsDir, "client.crt")
-	clientKeyFile := filepath.Join(certsDir, "client.key")
-	caFile := filepath.Join(certsDir, "ca.crt")
-
 	if err := os.WriteFile(clientCertFile, clientCert.CertPEM, 0644); err != nil {
 		return nil, fmt.Errorf("failed to write etcd client cert: %w", err)
 	}
@@ -236,7 +273,7 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, ext
 		return nil, fmt.Errorf("failed to write etcd client key: %w", err)
 	}
 
-	log.Info("etcd TLS certificates ready", "certs_dir", certsDir)
+	log.Info("etcd TLS certificates generated", "certs_dir", certsDir)
 
 	return &EtcdTLSSetupResult{
 		CertsDir: certsDir,
@@ -249,6 +286,18 @@ func SetupEtcdTLS(log *slog.Logger, dataPath string, extraDNSNames []string, ext
 		ClientKeyFile:  clientKeyFile,
 		CAFile:         caFile,
 	}, nil
+}
+
+func loadX509Cert(path string) (*x509.Certificate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %s", path)
+	}
+	return x509.ParseCertificate(block.Bytes)
 }
 
 func NewCoordinator(log *slog.Logger, cfg CoordinatorConfig) *Coordinator {

--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -44,8 +44,9 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 
 	// Setup runner config
 	runnerCfg := RunnerConfig{
-		Id:      "test-runner",
-		Workers: 2,
+		Id:            "test-runner",
+		ListenAddress: "localhost:0",
+		Workers:       2,
 	}
 
 	// Create contexts

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -934,7 +934,7 @@ func (r *Runner) SetupControllers(
 
 	// Add disk_volume watch controller to trigger disk re-reconciliation when
 	// disk_volume entities change (e.g. volume becomes DV_READY after provisioning)
-	diskVolumeWatchController := disk.NewDiskVolumeWatchController(log, eas, diskRC)
+	diskVolumeWatchController := disk.NewDiskVolumeWatchController(log, eas, diskRC, r.Id)
 	cm.AddController(
 		controller.NewReconcileController(
 			"disk-volume-watch",
@@ -949,7 +949,7 @@ func (r *Runner) SetupControllers(
 
 	// Add disk_mount watch controller to trigger disk lease re-reconciliation when
 	// disk_mount entities change (e.g. mount becomes DM_MOUNTED after mounting)
-	diskMountWatchController := disk.NewDiskMountWatchController(log, eas, diskLeaseRC)
+	diskMountWatchController := disk.NewDiskMountWatchController(log, eas, diskLeaseRC, r.Id)
 	cm.AddController(
 		controller.NewReconcileController(
 			"disk-mount-watch",

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -395,6 +395,8 @@ func (r *Runner) Start(ctx context.Context, eg ...*errgroup.Group) error {
 		client *rpc.NetworkClient
 	)
 
+	r.Log.Info("Establishing RPC connection", "listen", r.ListenAddress, "distributed", r.Config != nil)
+
 	if r.Config == nil {
 		rs, err = rpc.NewState(ctx, rpc.WithLogger(r.Log), rpc.WithBindAddr(r.ListenAddress), rpc.WithSkipVerify)
 		if err != nil {
@@ -417,6 +419,8 @@ func (r *Runner) Start(ctx context.Context, eg ...*errgroup.Group) error {
 		}
 	}
 
+	r.Log.Info("Connected to entity server")
+
 	eas := es.NewEntityAccessClient(client)
 
 	ec := entityserver.NewClient(r.Log, eas)
@@ -425,6 +429,8 @@ func (r *Runner) Start(ctx context.Context, eg ...*errgroup.Group) error {
 	if err != nil {
 		return err
 	}
+
+	r.Log.Info("Controllers initialized")
 
 	err = r.setupEntity(ctx, ec)
 	if err != nil {
@@ -465,6 +471,7 @@ func (r *Runner) initializeNetwork(ctx context.Context, eg ...*errgroup.Group) e
 
 	// Add TLS config if provided
 	if r.deps.EtcdTLSCertFile != "" && r.deps.EtcdTLSKeyFile != "" && r.deps.EtcdTLSCAFile != "" {
+		r.Log.Info("Using etcd TLS", "cert", r.deps.EtcdTLSCertFile, "ca", r.deps.EtcdTLSCAFile)
 		grungeOpts.TLSCertFile = r.deps.EtcdTLSCertFile
 		grungeOpts.TLSKeyFile = r.deps.EtcdTLSKeyFile
 		grungeOpts.TLSCAFile = r.deps.EtcdTLSCAFile
@@ -499,9 +506,21 @@ func (r *Runner) initializeNetwork(ctx context.Context, eg ...*errgroup.Group) e
 		}()
 	}
 
-	// Update deps with the leased IP
+	// Update deps with the leased IP and subnet
 	lease := gn.Lease()
 	r.deps.IPv4Routable = lease.IPv4()
+
+	// Initialize netdb subnet from the flannel lease so the sandbox
+	// controller can allocate IPs within this runner's subnet.
+	ndb, err := netdb.New(filepath.Join(r.DataPath, "net.db"))
+	if err != nil {
+		return fmt.Errorf("failed to open netdb: %w", err)
+	}
+	subnet, err := ndb.Subnet(lease.IPv4().String())
+	if err != nil {
+		return fmt.Errorf("failed to create subnet from lease: %w", err)
+	}
+	r.deps.Subnet = subnet
 
 	r.Log.Info("Joined Flannel network", "ipv4", lease.IPv4().String())
 
@@ -512,6 +531,8 @@ func (r *Runner) setupEntity(ctx context.Context, ec *entityserver.Client) error
 	if r.Id == "" {
 		return nil
 	}
+
+	r.Log.Info("Creating health session")
 
 	sess, ec, err := ec.NewSession(ctx, "runner health")
 	if err != nil {
@@ -527,9 +548,12 @@ func (r *Runner) setupEntity(ctx context.Context, ec *entityserver.Client) error
 	}
 
 	node := compute_v1alpha.Node{
+		RunnerId:    r.Id,
 		Constraints: types.LabelSet("compute", "generic", "role", role),
 		ApiAddress:  r.ListenAddress,
 	}
+
+	r.Log.Info("Registering node entity", "role", role, "address", r.ListenAddress)
 
 	res, err := ec.CreateOrUpdate(ctx, r.Id, &node)
 	if err != nil {
@@ -543,7 +567,7 @@ func (r *Runner) setupEntity(ctx context.Context, ec *entityserver.Client) error
 		return err
 	}
 
-	r.Log.Info("Registered runner", "id", res)
+	r.Log.Info("Runner registered and ready", "id", res, "status", "ready")
 
 	return nil
 }
@@ -557,6 +581,11 @@ func (r *Runner) SetupControllers(
 	retErr error,
 ) {
 	cm := controller.NewControllerManager()
+
+	// Initialize NetServ if not provided (distributed runner mode)
+	if r.deps.NetServ == nil {
+		r.deps.NetServ = network.NewServiceManager(r.Log, eas)
+	}
 
 	// Create sandbox controller with explicit dependencies
 	sbcDeps := sandbox.SandboxControllerDeps{

--- a/controllers/disk/disk_controller.go
+++ b/controllers/disk/disk_controller.go
@@ -156,6 +156,17 @@ func (d *DiskController) handleProvisioning(ctx context.Context, disk *storage_v
 	}
 
 	if existingVolume != nil {
+		// If the volume belongs to a different node, don't touch it
+		myNodeId := entity.Id("node/" + strings.TrimPrefix(d.NodeId, "node/"))
+		if existingVolume.NodeId != "" && existingVolume.NodeId != myNodeId {
+			d.Log.Debug("disk_volume belongs to another node, skipping",
+				"disk", disk.ID,
+				"disk_volume", existingVolume.ID,
+				"volume_node", existingVolume.NodeId,
+				"my_node", myNodeId)
+			return nil
+		}
+
 		d.Log.Debug("found existing disk_volume for disk",
 			"disk", disk.ID,
 			"disk_volume", existingVolume.ID,

--- a/controllers/disk/disk_lease_controller.go
+++ b/controllers/disk/disk_lease_controller.go
@@ -162,6 +162,12 @@ func (d *DiskLeaseController) cleanupDiskMountForLease(ctx context.Context, leas
 
 // reconcileLease reconciles the lease state
 func (d *DiskLeaseController) reconcileLease(ctx context.Context, lease *storage_v1alpha.DiskLease, meta *entity.Meta) error {
+	// Only reconcile leases assigned to this node
+	myNodeId := entity.Id("node/" + d.NodeId)
+	if lease.NodeId != "" && lease.NodeId != myNodeId {
+		return nil
+	}
+
 	var err error
 
 	switch lease.Status {

--- a/controllers/disk/disk_mount_watch_controller.go
+++ b/controllers/disk/disk_mount_watch_controller.go
@@ -15,18 +15,20 @@ import (
 // the disk lease controller creates a disk_mount and needs to know when the
 // mount controller finishes mounting it.
 type DiskMountWatchController struct {
-	Log *slog.Logger
-	EAC *entityserver_v1alpha.EntityAccessClient
+	Log    *slog.Logger
+	EAC    *entityserver_v1alpha.EntityAccessClient
+	NodeId string
 
 	LeaseController *controller.ReconcileController
 }
 
 // NewDiskMountWatchController creates a new disk mount watch controller.
-func NewDiskMountWatchController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, leaseController *controller.ReconcileController) *DiskMountWatchController {
+func NewDiskMountWatchController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, leaseController *controller.ReconcileController, nodeId string) *DiskMountWatchController {
 	return &DiskMountWatchController{
 		Log:             log.With("module", "disk-mount-watch"),
 		EAC:             eac,
 		LeaseController: leaseController,
+		NodeId:          nodeId,
 	}
 }
 
@@ -39,6 +41,10 @@ func (m *DiskMountWatchController) Create(ctx context.Context, mount *storage_v1
 }
 
 func (m *DiskMountWatchController) Update(ctx context.Context, mount *storage_v1alpha.DiskMount, meta *entity.Meta) error {
+	// Only process mounts assigned to this node
+	if mount.NodeId != "" && mount.NodeId != entity.Id("node/"+m.NodeId) {
+		return nil
+	}
 	if mount.DiskLeaseId == "" {
 		return nil
 	}

--- a/controllers/disk/disk_volume_watch_controller.go
+++ b/controllers/disk/disk_volume_watch_controller.go
@@ -15,18 +15,20 @@ import (
 // the disk controller creates a disk_volume and needs to know when the
 // volume controller finishes provisioning it.
 type DiskVolumeWatchController struct {
-	Log *slog.Logger
-	EAC *entityserver_v1alpha.EntityAccessClient
+	Log    *slog.Logger
+	EAC    *entityserver_v1alpha.EntityAccessClient
+	NodeId string
 
 	DiskController *controller.ReconcileController
 }
 
 // NewDiskVolumeWatchController creates a new disk volume watch controller.
-func NewDiskVolumeWatchController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, diskController *controller.ReconcileController) *DiskVolumeWatchController {
+func NewDiskVolumeWatchController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, diskController *controller.ReconcileController, nodeId string) *DiskVolumeWatchController {
 	return &DiskVolumeWatchController{
 		Log:            log.With("module", "disk-volume-watch"),
 		EAC:            eac,
 		DiskController: diskController,
+		NodeId:         nodeId,
 	}
 }
 
@@ -39,6 +41,9 @@ func (v *DiskVolumeWatchController) Create(ctx context.Context, vol *storage_v1a
 }
 
 func (v *DiskVolumeWatchController) Update(ctx context.Context, vol *storage_v1alpha.DiskVolume, meta *entity.Meta) error {
+	if vol.NodeId != "" && vol.NodeId != entity.Id("node/"+v.NodeId) {
+		return nil
+	}
 	if vol.DiskId == "" {
 		return nil
 	}

--- a/controllers/disk/sandbox_integration_test.go
+++ b/controllers/disk/sandbox_integration_test.go
@@ -167,7 +167,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 				ReadOnly: false,
 			},
 			AcquiredAt: now,
-			NodeId:     entity.Id("node/worker-1"),
+			NodeId:     entity.Id("node/test-node"),
 		}
 
 		// Process lease binding - creates disk_mount entity, stays PENDING
@@ -205,7 +205,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 				Path: "/mnt/data",
 			},
 			AcquiredAt: now,
-			NodeId:     entity.Id("node/worker-2"),
+			NodeId:     entity.Id("node/test-node"),
 		}
 
 		conflictMeta := &entity.Meta{}
@@ -232,7 +232,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 				Path: "/mnt/data",
 			},
 			AcquiredAt: time.Now(),
-			NodeId:     entity.Id("node/worker-2"),
+			NodeId:     entity.Id("node/test-node"),
 		}
 
 		newMeta := &entity.Meta{}
@@ -370,7 +370,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 					ReadOnly: false,
 				},
 				AcquiredAt: now,
-				NodeId:     entity.Id("node/multi-disk-node"),
+				NodeId:     entity.Id("node/test-node"),
 			}
 
 			meta := &entity.Meta{}

--- a/controllers/scheduler/scheduler.go
+++ b/controllers/scheduler/scheduler.go
@@ -58,10 +58,13 @@ func (c *Controller) Reconcile(ctx context.Context, sandbox *compute_v1alpha.San
 		return err
 	}
 
-	// Find available READY nodes
+	// Find available READY nodes with a valid address.
+	// Both conditions are required: status=READY (session-scoped, proves the
+	// runner process is alive) and a non-empty ApiAddress (proves the runner
+	// has fully started and is reachable).
 	var nodes []*compute_v1alpha.Node
 	for _, node := range allNodes {
-		if node.Status == compute_v1alpha.READY {
+		if node.Status == compute_v1alpha.READY && node.ApiAddress != "" {
 			nodes = append(nodes, node)
 		}
 	}

--- a/controllers/scheduler/scheduler_test.go
+++ b/controllers/scheduler/scheduler_test.go
@@ -56,6 +56,9 @@ func createReadyNode(t *testing.T, ctx context.Context, client *entityserver.Cli
 	// Create the node without the session-scoped status attribute
 	status := node.Status
 	node.Status = ""
+	if node.ApiAddress == "" {
+		node.ApiAddress = ":8444"
+	}
 	nodeID, err := client.Create(ctx, name, node)
 	require.NoError(t, err)
 

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/runner/runner_v1alpha"
 	"miren.dev/runtime/pkg/caauth"
@@ -218,9 +219,14 @@ func (s *RegistrationServer) Join(ctx context.Context, req *runner_v1alpha.Runne
 		Constraints:  labels,
 	}
 
-	nodeAttrs := node.Encode()
+	// Create node entity with an ident so setupEntity can find it via CreateOrUpdate
 	nodeEntity := &entityserver_v1alpha.Entity{}
-	nodeEntity.SetAttrs(nodeAttrs)
+	nodeEntity.SetAttrs(
+		entity.New(
+			(&core_v1alpha.Metadata{Name: runnerID}).Encode,
+			node.Encode,
+			entity.Ident, types.Keyword(node.ShortKind()+"/"+runnerID),
+		).Attrs())
 
 	nodePutResp, err := s.EAC.Put(ctx, nodeEntity)
 	if err != nil {


### PR DESCRIPTION
This is the big pile of fixes that got distributed runners from "joins but can't do anything" to "serving production traffic on Garden." Everything here was discovered during a day of dogfooding on the Garden cluster with two runner nodes.

The journey went roughly like this: runners couldn't connect to etcd (cert SANs were localhost-only), then couldn't find containerd (release dir not on PATH), then crashed on startup (missing subnet and network service init), then created duplicate node entities (no ident on join), then took down the entire cluster twice (once by getting scheduled work they couldn't handle, once by reconciling disk mounts for other nodes), then couldn't pull images (no registry resolution), and finally advertised `:8444` instead of a real IP. Each fix unlocked the next failure.

## What's in here

The first commit is the bulk — issues 1 through 13 from the Linear ticket, squashed into one since they were developed iteratively. The remaining commits are the fixes that came after the first deploy:

- **Runner join address rewriting** — use the coordinator address the runner actually connected to instead of the server's bind address; rewrite loopback etcd endpoints
- **Containerd release dir lookup** — mirror the server's `FindReleasePath()` pattern so runners find containerd in `/var/lib/miren/release/`
- **Join code via flag/stdin** — `--code` flag and stdin pipe so joins work in non-interactive shells
- **Etcd cert SANs** — include discovered IPs in the etcd server cert; validate and reuse existing certs across restarts
- **Runner logging** — INFO-level logs for RPC connection, entity registration, session, network TLS
- **Subnet and NetServ init** — initialize netdb subnet from flannel lease; lazy-init NetServ for distributed runners
- **Node entity identity** — add ident to Join-created entities so setupEntity finds the same entity instead of creating duplicates
- **`miren runner status` command** — new command for local health inspection
- **Containerd socket readiness** — dial the socket instead of checking file existence
- **Scheduler safety** — require both status=READY and non-empty ApiAddress before scheduling
- **Disk controller node scoping** — filter disk lease, mount, and volume controllers to only act on entities assigned to this node
- **Image pull resolution** — map `cluster.local` to coordinator IP so runners can pull from the registry
- **Listen address discovery** — discover outbound IP and advertise full address instead of bare port

Follow-up issues split out to separate tickets: MIR-917 (runner remove), MIR-918 (version update on restart), MIR-919 (human-readable names), MIR-920 (API cert IP SANs).

Closes MIR-903