### PR TITLE
Scope sandbox controller queries to local node in distributed setups

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -280,8 +280,11 @@ func (c *SandboxController) reconcileSandboxesOnBoot(ctx context.Context) error 
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	// List all sandboxes
-	resp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+	// List sandboxes scheduled to this node only. Using the same node-scoped
+	// index as the controller watch (see runner.go) ensures we don't
+	// accidentally mark sandboxes on other nodes as unhealthy because their
+	// containers don't exist in our local containerd.
+	resp, err := c.EAC.List(ctx, compute.Index(compute.KindSandbox, entity.Id("node/"+c.NodeId)))
 	if err != nil {
 		return fmt.Errorf("failed to list sandboxes: %w", err)
 	}
@@ -435,6 +438,7 @@ func (c *SandboxController) Init(ctx context.Context) error {
 		CC:            c.CC,
 		EAC:           c.EAC,
 		Namespace:     c.Namespace,
+		NodeId:        c.NodeId,
 		CheckInterval: 5 * time.Minute,
 		Subnet:        c.Subnet,
 	}
@@ -2434,8 +2438,9 @@ func (c *SandboxController) ReleaseDiskLeases(ctx context.Context, sandboxID ent
 func (c *SandboxController) Periodic(ctx context.Context, timeHorizon time.Duration) error {
 	c.Log.Info("running periodic cleanup of dead sandboxes", "time_horizon", timeHorizon)
 
-	// List all sandboxes
-	resp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+	// List sandboxes scheduled to this node only so we don't delete
+	// sandbox entities that belong to other runners.
+	resp, err := c.EAC.List(ctx, compute.Index(compute.KindSandbox, entity.Id("node/"+c.NodeId)))
 	if err != nil {
 		return fmt.Errorf("failed to list sandboxes: %w", err)
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "15532b2466be230e3b450ed4602265bdc44db7c7985b4f7cfedb5aca76de8563",
+		"sandbox.go":  "f101ffe2d0ef275079ad73875dc559fd53f3c7bfac9f676e4b45a14c19d0d335",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -95,6 +95,19 @@ func TestSandbox(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Create a node entity so sandbox ScheduleKeys can reference it.
+	// The test sandbox controller uses NodeId "test-node".
+	// Only set the kind — Status is a session attribute and can't be set via Put.
+	{
+		nodeId := entity.Id("node/test-node")
+		node := &compute.Node{}
+		var nodeE entityserver_v1alpha.Entity
+		nodeE.SetId(nodeId.String())
+		nodeE.SetAttrs(entity.New(entity.DBId, nodeId, node.Encode).Attrs())
+		_, err := testDeps.EAC.Put(setupCtx, &nodeE)
+		require.NoError(t, err)
+	}
+
 	sbName := func() string {
 		return idgen.GenNS("sb")
 	}
@@ -714,6 +727,14 @@ func TestSandbox(t *testing.T) {
 		err = sbc.Init(ctx)
 		r.NoError(err)
 
+		// Schedule key so sandboxes match the node-scoped index used by Periodic.
+		schedule := compute.Schedule{
+			Key: compute.Key{
+				Kind: compute.KindSandbox,
+				Node: entity.Id("node/test-node"),
+			},
+		}
+
 		// Create a few sandboxes
 		sbID1 := entity.Id(sbName())
 		sb1 := &compute.Sandbox{
@@ -726,7 +747,9 @@ func TestSandbox(t *testing.T) {
 		rpcE1.SetId(sbID1.String())
 		rpcE1.SetAttrs(entity.New(
 			entity.Keyword(entity.Ident, sbID1.String()),
-			sb1.Encode).Attrs())
+			sb1.Encode,
+			schedule.Encode,
+		).Attrs())
 		_, err = sbc.EAC.Put(ctx, &rpcE1)
 		r.NoError(err)
 
@@ -754,7 +777,9 @@ func TestSandbox(t *testing.T) {
 		rpcE2.SetId(sbID2.String())
 		rpcE2.SetAttrs(entity.New(
 			entity.Keyword(entity.Ident, sbID2.String()),
-			sb2.Encode).Attrs())
+			sb2.Encode,
+			schedule.Encode,
+		).Attrs())
 		_, err = sbc.EAC.Put(ctx, &rpcE2)
 		r.NoError(err)
 
@@ -784,6 +809,7 @@ func TestSandbox(t *testing.T) {
 			(&compute.Sandbox{
 				Status: compute.DEAD,
 			}).Encode,
+			schedule.Encode,
 		).Attrs())
 
 		_, err = sbc.EAC.Put(ctx, &rpcE)

--- a/controllers/sandbox/volume_test.go
+++ b/controllers/sandbox/volume_test.go
@@ -476,6 +476,17 @@ func TestReleaseDiskLeases(t *testing.T) {
 	})
 }
 
+// testSchedule returns a Schedule encoder that assigns sandboxes to the
+// test node, matching the node-scoped index used by Periodic.
+func testSchedule() compute.Schedule {
+	return compute.Schedule{
+		Key: compute.Key{
+			Kind: compute.KindSandbox,
+			Node: entity.Id("node/test-node"),
+		},
+	}
+}
+
 func TestPeriodicReleasesDiskLeases(t *testing.T) {
 	t.Run("releases disk leases before deleting dead sandbox", func(t *testing.T) {
 		r := require.New(t)
@@ -497,12 +508,14 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 		leaseID := entity.Id("disk-lease/orphan-candidate")
 
 		// Create a DEAD sandbox entity
+		schedule := testSchedule()
 		_, err := es.EAC.Create(ctx, entity.New(
 			entity.DBId, sandboxID,
 			(&compute.Sandbox{
 				ID:     sandboxID,
 				Status: compute.DEAD,
 			}).Encode,
+			schedule.Encode,
 		).Attrs())
 		r.NoError(err)
 
@@ -555,12 +568,14 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 		sandboxID := entity.Id("sandbox/dead-no-lease")
 
 		// Create a DEAD sandbox entity with no disk leases
+		schedule := testSchedule()
 		_, err := es.EAC.Create(ctx, entity.New(
 			entity.DBId, sandboxID,
 			(&compute.Sandbox{
 				ID:     sandboxID,
 				Status: compute.DEAD,
 			}).Encode,
+			schedule.Encode,
 		).Attrs())
 		r.NoError(err)
 
@@ -592,12 +607,14 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 		leaseID := entity.Id("disk-lease/should-stay-bound")
 
 		// Create a RUNNING sandbox
+		schedule := testSchedule()
 		_, err := es.EAC.Create(ctx, entity.New(
 			entity.DBId, sandboxID,
 			(&compute.Sandbox{
 				ID:     sandboxID,
 				Status: compute.RUNNING,
 			}).Encode,
+			schedule.Encode,
 		).Attrs())
 		r.NoError(err)
 

--- a/controllers/sandbox/watchdog.go
+++ b/controllers/sandbox/watchdog.go
@@ -111,6 +111,10 @@ func (w *ContainerWatchdog) CleanupOrphanedContainers(ctx context.Context) (*Cle
 		FailedContainers:  make(map[string]error),
 	}
 
+	if w.NodeId == "" {
+		return result, fmt.Errorf("watchdog: NodeId is required for cleanup")
+	}
+
 	// Create a timeout for the cleanup operation
 	cleanupCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()

--- a/controllers/sandbox/watchdog.go
+++ b/controllers/sandbox/watchdog.go
@@ -35,6 +35,9 @@ type ContainerWatchdog struct {
 	EAC *entityserver_v1alpha.EntityAccessClient
 
 	Namespace string
+	// NodeId scopes sandbox lookups to this node so we only consider
+	// sandboxes that are scheduled here when building the valid set.
+	NodeId string
 	// CheckInterval is how often to check for orphaned containers
 	CheckInterval time.Duration
 	// GraceWindow is how long to wait before removing containers from non-running sandboxes
@@ -120,10 +123,10 @@ func (w *ContainerWatchdog) CleanupOrphanedContainers(ctx context.Context) (*Cle
 		return result, fmt.Errorf("failed to list containers: %w", err)
 	}
 
-	// Build a set of valid container IDs from Running sandboxes
+	// Build a set of valid container IDs from sandboxes scheduled to this node.
 	validContainers := make(map[string]bool)
 
-	resp, err := w.EAC.List(cleanupCtx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+	resp, err := w.EAC.List(cleanupCtx, compute.Index(compute.KindSandbox, entity.Id("node/"+w.NodeId)))
 	if err != nil {
 		return result, fmt.Errorf("failed to list sandboxes: %w", err)
 	}

--- a/controllers/sandbox/watchdogtest/container_test.go
+++ b/controllers/sandbox/watchdogtest/container_test.go
@@ -20,6 +20,8 @@ import (
 	"miren.dev/runtime/pkg/testutils"
 )
 
+const testNodeId = "test-node"
+
 func TestContainerWatchdog(t *testing.T) {
 	testDeps, cleanup := testutils.NewTestDeps()
 	defer cleanup()
@@ -46,18 +48,27 @@ func TestContainerWatchdog(t *testing.T) {
 
 		ctx = namespaces.WithNamespace(ctx, ns)
 
-		// Create a sandbox entity in the store
+		// Create a sandbox entity in the store with a schedule key so it
+		// matches the watchdog's node-scoped query.
 		sbID := entity.Id(idgen.GenNS("sb"))
 		sb := &compute.Sandbox{
 			ID:     sbID,
 			Status: compute.RUNNING,
+		}
+		schedule := compute.Schedule{
+			Key: compute.Key{
+				Kind: compute.KindSandbox,
+				Node: entity.Id("node/" + testNodeId),
+			},
 		}
 
 		var rpcE entityserver_v1alpha.Entity
 		rpcE.SetId(sbID.String())
 		rpcE.SetAttrs(entity.New(
 			entity.DBId, sbID,
-			sb.Encode).Attrs())
+			sb.Encode,
+			schedule.Encode,
+		).Attrs())
 		_, err := eac.Put(ctx, &rpcE)
 		r.NoError(err)
 
@@ -87,6 +98,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:            cc,
 			EAC:           eac,
 			Namespace:     ns,
+			NodeId:        testNodeId,
 			CheckInterval: 100 * time.Millisecond,
 		}
 
@@ -130,6 +142,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:        cc,
 			EAC:       eac,
 			Namespace: ns,
+			NodeId:    testNodeId,
 		}
 
 		// Run cleanup
@@ -159,12 +172,20 @@ func TestContainerWatchdog(t *testing.T) {
 			ID:     oldDeadSbID,
 			Status: compute.DEAD,
 		}
+		schedule := compute.Schedule{
+			Key: compute.Key{
+				Kind: compute.KindSandbox,
+				Node: entity.Id("node/" + testNodeId),
+			},
+		}
 
 		var rpcE entityserver_v1alpha.Entity
 		rpcE.SetId(oldDeadSbID.String())
 		rpcE.SetAttrs(entity.New(
 			entity.DBId, oldDeadSbID,
-			oldDeadSb.Encode).Attrs())
+			oldDeadSb.Encode,
+			schedule.Encode,
+		).Attrs())
 		_, err := eac.Put(ctx, &rpcE)
 		r.NoError(err)
 
@@ -186,14 +207,13 @@ func TestContainerWatchdog(t *testing.T) {
 
 		// Create the watchdog
 		watchdog := &sandbox.ContainerWatchdog{
-			Log:       slog.Default(),
-			CC:        cc,
-			EAC:       eac,
-			Namespace: ns,
+			Log:         slog.Default(),
+			CC:          cc,
+			EAC:         eac,
+			Namespace:   ns,
+			NodeId:      testNodeId,
+			GraceWindow: 10 * time.Millisecond,
 		}
-
-		// Create the watchdog with a very short grace window
-		watchdog.GraceWindow = 10 * time.Millisecond
 
 		// Run cleanup
 		result, err := watchdog.CleanupOrphanedContainers(ctx)
@@ -223,12 +243,20 @@ func TestContainerWatchdog(t *testing.T) {
 			ID:     recentDeadSbID,
 			Status: compute.DEAD,
 		}
+		schedule := compute.Schedule{
+			Key: compute.Key{
+				Kind: compute.KindSandbox,
+				Node: entity.Id("node/" + testNodeId),
+			},
+		}
 
 		var rpcE entityserver_v1alpha.Entity
 		rpcE.SetId(recentDeadSbID.String())
 		rpcE.SetAttrs(entity.New(
 			entity.DBId, recentDeadSbID,
-			recentDeadSb.Encode).Attrs())
+			recentDeadSb.Encode,
+			schedule.Encode,
+		).Attrs())
 		_, err := eac.Put(ctx, &rpcE)
 		r.NoError(err)
 
@@ -252,6 +280,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:          cc,
 			EAC:         eac,
 			Namespace:   ns,
+			NodeId:      testNodeId,
 			GraceWindow: 10 * time.Second,
 		}
 
@@ -278,6 +307,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:            cc,
 			EAC:           eac,
 			Namespace:     ns,
+			NodeId:        testNodeId,
 			CheckInterval: 100 * time.Millisecond,
 		}
 

--- a/controllers/sandbox/watchdogtest/container_test.go
+++ b/controllers/sandbox/watchdogtest/container_test.go
@@ -40,6 +40,18 @@ func TestContainerWatchdog(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// Create the node entity so sandbox ScheduleKeys can reference it.
+	// Only set the kind — Status is a session attribute and can't be set via Put.
+	{
+		nodeId := entity.Id("node/" + testNodeId)
+		node := &compute.Node{}
+		var nodeE entityserver_v1alpha.Entity
+		nodeE.SetId(nodeId.String())
+		nodeE.SetAttrs(entity.New(entity.DBId, nodeId, node.Encode).Attrs())
+		_, err := eac.Put(context.Background(), &nodeE)
+		require.NoError(t, err)
+	}
+
 	t.Run("removes orphaned containers", func(t *testing.T) {
 		r := require.New(t)
 


### PR DESCRIPTION
We hit a fun one on miren.garden — every app was crash-looping with no errors in app logs or the system journal. Sandboxes would start up perfectly fine (DB init, ports bound, health checks passing) and then just... die. Consistently, about a second after reaching RUNNING.

Turns out a distributed runner (`runner-8a91ac2a` from MIR-890 testing) was the culprit. Three methods in the sandbox controller — `reconcileSandboxesOnBoot`, `CleanupOrphanedContainers`, and `Periodic` — were listing *all* sandboxes system-wide and then checking them against the local containerd. The runner's normal watch loop was already properly scoped to its own node via `compute.Index`, but these three paths bypassed that filter.

So every time the remote runner connected (25 times in the window we checked), it would run boot reconciliation, see the coordinator's sandboxes, fail to find their containers locally, and dutifully patch them all to DEAD. The pool manager would spin up replacements, and the runner would kill those too. A nice little murder loop.

The fix scopes all three methods to use the same `compute.Index(KindSandbox, "node/"+nodeId)` query the watch loop already uses. Each runner now only touches sandboxes that are actually scheduled to it.

Closes MIR-921