### PR TITLE
Add MySQL addon support

### DIFF
--- a/api/addon/addon_v1alpha/schema.gen.go
+++ b/api/addon/addon_v1alpha/schema.gen.go
@@ -397,6 +397,252 @@ func (o *Variables) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 const (
+	MysqlDedicatedDataMysqlServerId = entity.Id("dev.miren.addon/mysql_dedicated_data.mysql_server")
+)
+
+type MysqlDedicatedData struct {
+	ID          entity.Id `json:"id"`
+	MysqlServer entity.Id `cbor:"mysql_server,omitempty" json:"mysql_server,omitempty"`
+}
+
+func (o *MysqlDedicatedData) Decode(e entity.AttrGetter) {
+	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(MysqlDedicatedDataMysqlServerId); ok && a.Value.Kind() == entity.KindId {
+		o.MysqlServer = a.Value.Id()
+	}
+}
+
+func (o *MysqlDedicatedData) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindMysqlDedicatedData)
+}
+
+func (o *MysqlDedicatedData) ShortKind() string {
+	return "mysql_dedicated_data"
+}
+
+func (o *MysqlDedicatedData) Kind() entity.Id {
+	return KindMysqlDedicatedData
+}
+
+func (o *MysqlDedicatedData) EntityId() entity.Id {
+	return o.ID
+}
+
+func (o *MysqlDedicatedData) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.MysqlServer) {
+		attrs = append(attrs, entity.Ref(MysqlDedicatedDataMysqlServerId, o.MysqlServer))
+	}
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindMysqlDedicatedData))
+	return
+}
+
+func (o *MysqlDedicatedData) Empty() bool {
+	return entity.Empty(o.MysqlServer)
+}
+
+func (o *MysqlDedicatedData) InitSchema(sb *schema.SchemaBuilder) {
+	sb.Ref("mysql_server", "dev.miren.addon/mysql_dedicated_data.mysql_server")
+}
+
+const (
+	MysqlServerAddonNameId        = entity.Id("dev.miren.addon/mysql_server.addon_name")
+	MysqlServerAssociationCountId = entity.Id("dev.miren.addon/mysql_server.association_count")
+	MysqlServerRootPasswordId     = entity.Id("dev.miren.addon/mysql_server.root_password")
+	MysqlServerSandboxPoolId      = entity.Id("dev.miren.addon/mysql_server.sandbox_pool")
+	MysqlServerServiceId          = entity.Id("dev.miren.addon/mysql_server.service")
+	MysqlServerStatusId           = entity.Id("dev.miren.addon/mysql_server.status")
+	MysqlServerVariantId          = entity.Id("dev.miren.addon/mysql_server.variant")
+)
+
+type MysqlServer struct {
+	ID               entity.Id `json:"id"`
+	AddonName        string    `cbor:"addon_name,omitempty" json:"addon_name,omitempty"`
+	AssociationCount int64     `cbor:"association_count,omitempty" json:"association_count,omitempty"`
+	RootPassword     string    `cbor:"root_password,omitempty" json:"root_password,omitempty"`
+	SandboxPool      entity.Id `cbor:"sandbox_pool,omitempty" json:"sandbox_pool,omitempty"`
+	Service          entity.Id `cbor:"service,omitempty" json:"service,omitempty"`
+	Status           string    `cbor:"status,omitempty" json:"status,omitempty"`
+	Variant          string    `cbor:"variant,omitempty" json:"variant,omitempty"`
+}
+
+func (o *MysqlServer) Decode(e entity.AttrGetter) {
+	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(MysqlServerAddonNameId); ok && a.Value.Kind() == entity.KindString {
+		o.AddonName = a.Value.String()
+	}
+	if a, ok := e.Get(MysqlServerAssociationCountId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.AssociationCount = a.Value.Int64()
+	}
+	if a, ok := e.Get(MysqlServerRootPasswordId); ok && a.Value.Kind() == entity.KindString {
+		o.RootPassword = a.Value.String()
+	}
+	if a, ok := e.Get(MysqlServerSandboxPoolId); ok && a.Value.Kind() == entity.KindId {
+		o.SandboxPool = a.Value.Id()
+	}
+	if a, ok := e.Get(MysqlServerServiceId); ok && a.Value.Kind() == entity.KindId {
+		o.Service = a.Value.Id()
+	}
+	if a, ok := e.Get(MysqlServerStatusId); ok && a.Value.Kind() == entity.KindString {
+		o.Status = a.Value.String()
+	}
+	if a, ok := e.Get(MysqlServerVariantId); ok && a.Value.Kind() == entity.KindString {
+		o.Variant = a.Value.String()
+	}
+}
+
+func (o *MysqlServer) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindMysqlServer)
+}
+
+func (o *MysqlServer) ShortKind() string {
+	return "mysql_server"
+}
+
+func (o *MysqlServer) Kind() entity.Id {
+	return KindMysqlServer
+}
+
+func (o *MysqlServer) EntityId() entity.Id {
+	return o.ID
+}
+
+func (o *MysqlServer) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.AddonName) {
+		attrs = append(attrs, entity.String(MysqlServerAddonNameId, o.AddonName))
+	}
+	if !entity.Empty(o.AssociationCount) {
+		attrs = append(attrs, entity.Int64(MysqlServerAssociationCountId, o.AssociationCount))
+	}
+	if !entity.Empty(o.RootPassword) {
+		attrs = append(attrs, entity.String(MysqlServerRootPasswordId, o.RootPassword))
+	}
+	if !entity.Empty(o.SandboxPool) {
+		attrs = append(attrs, entity.Ref(MysqlServerSandboxPoolId, o.SandboxPool))
+	}
+	if !entity.Empty(o.Service) {
+		attrs = append(attrs, entity.Ref(MysqlServerServiceId, o.Service))
+	}
+	if !entity.Empty(o.Status) {
+		attrs = append(attrs, entity.String(MysqlServerStatusId, o.Status))
+	}
+	if !entity.Empty(o.Variant) {
+		attrs = append(attrs, entity.String(MysqlServerVariantId, o.Variant))
+	}
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindMysqlServer))
+	return
+}
+
+func (o *MysqlServer) Empty() bool {
+	if !entity.Empty(o.AddonName) {
+		return false
+	}
+	if !entity.Empty(o.AssociationCount) {
+		return false
+	}
+	if !entity.Empty(o.RootPassword) {
+		return false
+	}
+	if !entity.Empty(o.SandboxPool) {
+		return false
+	}
+	if !entity.Empty(o.Service) {
+		return false
+	}
+	if !entity.Empty(o.Status) {
+		return false
+	}
+	if !entity.Empty(o.Variant) {
+		return false
+	}
+	return true
+}
+
+func (o *MysqlServer) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("addon_name", "dev.miren.addon/mysql_server.addon_name", schema.Indexed)
+	sb.Int64("association_count", "dev.miren.addon/mysql_server.association_count")
+	sb.String("root_password", "dev.miren.addon/mysql_server.root_password")
+	sb.Ref("sandbox_pool", "dev.miren.addon/mysql_server.sandbox_pool")
+	sb.Ref("service", "dev.miren.addon/mysql_server.service")
+	sb.String("status", "dev.miren.addon/mysql_server.status")
+	sb.String("variant", "dev.miren.addon/mysql_server.variant")
+}
+
+const (
+	MysqlSharedDataDatabaseNameId = entity.Id("dev.miren.addon/mysql_shared_data.database_name")
+	MysqlSharedDataMysqlServerId  = entity.Id("dev.miren.addon/mysql_shared_data.mysql_server")
+	MysqlSharedDataUsernameId     = entity.Id("dev.miren.addon/mysql_shared_data.username")
+)
+
+type MysqlSharedData struct {
+	ID           entity.Id `json:"id"`
+	DatabaseName string    `cbor:"database_name,omitempty" json:"database_name,omitempty"`
+	MysqlServer  entity.Id `cbor:"mysql_server,omitempty" json:"mysql_server,omitempty"`
+	Username     string    `cbor:"username,omitempty" json:"username,omitempty"`
+}
+
+func (o *MysqlSharedData) Decode(e entity.AttrGetter) {
+	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(MysqlSharedDataDatabaseNameId); ok && a.Value.Kind() == entity.KindString {
+		o.DatabaseName = a.Value.String()
+	}
+	if a, ok := e.Get(MysqlSharedDataMysqlServerId); ok && a.Value.Kind() == entity.KindId {
+		o.MysqlServer = a.Value.Id()
+	}
+	if a, ok := e.Get(MysqlSharedDataUsernameId); ok && a.Value.Kind() == entity.KindString {
+		o.Username = a.Value.String()
+	}
+}
+
+func (o *MysqlSharedData) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindMysqlSharedData)
+}
+
+func (o *MysqlSharedData) ShortKind() string {
+	return "mysql_shared_data"
+}
+
+func (o *MysqlSharedData) Kind() entity.Id {
+	return KindMysqlSharedData
+}
+
+func (o *MysqlSharedData) EntityId() entity.Id {
+	return o.ID
+}
+
+func (o *MysqlSharedData) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.DatabaseName) {
+		attrs = append(attrs, entity.String(MysqlSharedDataDatabaseNameId, o.DatabaseName))
+	}
+	if !entity.Empty(o.MysqlServer) {
+		attrs = append(attrs, entity.Ref(MysqlSharedDataMysqlServerId, o.MysqlServer))
+	}
+	if !entity.Empty(o.Username) {
+		attrs = append(attrs, entity.String(MysqlSharedDataUsernameId, o.Username))
+	}
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindMysqlSharedData))
+	return
+}
+
+func (o *MysqlSharedData) Empty() bool {
+	if !entity.Empty(o.DatabaseName) {
+		return false
+	}
+	if !entity.Empty(o.MysqlServer) {
+		return false
+	}
+	if !entity.Empty(o.Username) {
+		return false
+	}
+	return true
+}
+
+func (o *MysqlSharedData) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("database_name", "dev.miren.addon/mysql_shared_data.database_name")
+	sb.Ref("mysql_server", "dev.miren.addon/mysql_shared_data.mysql_server")
+	sb.String("username", "dev.miren.addon/mysql_shared_data.username")
+}
+
+const (
 	PostgresServerAddonNameId         = entity.Id("dev.miren.addon/postgres_server.addon_name")
 	PostgresServerAssociationCountId  = entity.Id("dev.miren.addon/postgres_server.association_count")
 	PostgresServerSandboxPoolId       = entity.Id("dev.miren.addon/postgres_server.sandbox_pool")
@@ -645,6 +891,9 @@ func (o *PostgresqlSharedData) InitSchema(sb *schema.SchemaBuilder) {
 var (
 	KindAddon                   = entity.Id("dev.miren.addon/kind.addon")
 	KindAddonAssociation        = entity.Id("dev.miren.addon/kind.addon_association")
+	KindMysqlDedicatedData      = entity.Id("dev.miren.addon/kind.mysql_dedicated_data")
+	KindMysqlServer             = entity.Id("dev.miren.addon/kind.mysql_server")
+	KindMysqlSharedData         = entity.Id("dev.miren.addon/kind.mysql_shared_data")
 	KindPostgresServer          = entity.Id("dev.miren.addon/kind.postgres_server")
 	KindPostgresqlDedicatedData = entity.Id("dev.miren.addon/kind.postgresql_dedicated_data")
 	KindPostgresqlSharedData    = entity.Id("dev.miren.addon/kind.postgresql_shared_data")
@@ -655,9 +904,12 @@ func init() {
 	schema.Register("dev.miren.addon", "v1alpha", func(sb *schema.SchemaBuilder) {
 		(&Addon{}).InitSchema(sb)
 		(&AddonAssociation{}).InitSchema(sb)
+		(&MysqlDedicatedData{}).InitSchema(sb)
+		(&MysqlServer{}).InitSchema(sb)
+		(&MysqlSharedData{}).InitSchema(sb)
 		(&PostgresServer{}).InitSchema(sb)
 		(&PostgresqlDedicatedData{}).InitSchema(sb)
 		(&PostgresqlSharedData{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.addon", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x9c\x97\xeb\xae\xd4 \x10ǟC\x8d\xf7\xfb%=9Ƙ\xf84\x84-\xb3]\\\n]\x86\xd6ݏj\xa2\x0f\xa2\xc77\xd4\xcf\x06\xe8n[腞/\x1b:a~0\xf3\x87\x19\xf67\x93\xb4\x04Š\xc9J\xaeAf\x941%a\xcf%Û\xe3\xdd\xc0~e\xed~\xf8\xc79\xd6ᄞ\xfb\xbf-S%\xe52\x84o\xb7\x1c\x04\xc3\x1f\xbf6\x9c\x1d\x9f\x8f\x022\x06[Z\vC\x1a\xaa9\x95\xe6\xbcɡќ*آ\xd1\\\x16\x8e\xf5x\x8a\x85\xb9\xe6\x95\xe1J:ξo\b\x19O&\x18\x1c+AO\xc4\xfa;\x88\x18XB\xca\xd3q\x8aP9\x15ܜH\xa9\x98ǔCSȉ\xf2\xef9\x97]\xb0p\xf5\x1b\xeb\xf5`ܫM\x1b\xb2\x92\xca\xd3_纻\xd8,\x83窬\x94\x04i\xba\x91\x979BfCd\x92\xe0\xdf]H\xcf\xc2͝\x19\xc9:\xb9\x18\x1f\xcd`\f\xe5\xa2\x1feq6-\x04\xf9b>\xc839)\xd8o.\xd8{\xe1.[D\xb6\x87\x93[3\xb7\x83P\xf5\xfbS^\r\x15\xb5\xd7\x1c\xfc\xb0\xe7Y4\xa0\x91+Y4\xd7TT;**\xcdK\xaaO\xc4\xee\xf6\x9c\x81q\xfc%\xc0\xe9s5K\xbf\x9c\xa2\xd9Y\xe0\x16\x8b\xf5w%\xa5Rh\n\rH\x10t\x03\xba\x15\xe4a87\x98\x96\xa4\xc4O\x17\xf4\x9b\x05\x94\xb7v\xf7\xfbs\xef;\xd4\xe7z\x91\x85\xa8rN\xed\xc1%\xb9\xaa\xdb\xfau\x88͖\x9csi\x1c\xf6\xdd\x12\x16\xa9d\x1bu$\x95R\xc2\x17\xa1\x81\xc5\xc26\x9c9\xd6\xcbE\x16\xe8\x86\xe7>\xd6\xe2\xfc\xd1'\x84\x97!&\x18jjt\x80m;\x0e\x13\xf5~\x91QW\xa0k\x04M*\x8a\xf8Ei\xe6xz\xc4\x1e\xb2\x17#췎b\xa4e\xcc\x1eV\x15\xd0\xe2tt\x9d\x90\xf4tm\x0f\xeex'\xeaO\\\xd1\"\xa3H#\x98\xb7\xfb\xc2\xe0\x87}%\xc7[\xecп\xaa|9\xb2\x83\xbe\xefղ/h\xad4)\x01\x91\x16mS\x1b\x9aB\xe5^-3\xe7ϖk\x00o\x97)N\xf4\x8d\x80~/\xe0\x9dq\xa1\x1b\x84\v\xc4bw\v\xac\xe8\x7f\xe3\xd5\xd7B\xe6\x9bB\xf4\xa4\xe8\xfc\x10$r\xc3\x1b\x9f}\xde}Z\x06\xdb(%\x1c!\xaa\xa6\x1d\xe1֍\xa5K\xa7[\xe2u\xa2(\xb7\xbd\x96\x87\x88\x17\x9f\x83A?9\b\x82;\xaa\x81\x11F\r\x9d\xe8\xf3W\xe3\xb3W\x88\xfa!\x8d\x98ٟ\rE\xe8\xfaL94\x85\xaa\x7fL\x04\a\xe5ʿ\x97C\xe3\xecŞ\x00\xdb\"|\xd9\xec\xee\xf2\x95*X3\x8e=fK\xaa1`<\xa7f(\\t\xbc&\x1d\x92\xb4\xfb\xea2\xf1)\x19\xba*˳i9ޙ\\$\xf4\xdb\xe3NiC\xfc\x1f\xb2\xf6\r5\xf3\xb7,j\\Iﭑ{\x95\xd8\xf0\xa6\x04^s-g\xb2\xb1\xf6\xa0\xfc\a\x00\x00\xff\xff\x01\x00\x00\xff\xffR\x9f\x1a\n\xcf\x0e\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.addon", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\xa4\x98َ\xdb,\x14ǟ\xe3[\xbb\xefUFSU\x95\xfa4\x161ġ\xc1\xe0\x01\xecƗm\xa5\xf6A\xba\xa8/\xd8^W\x80\x13\xb3\x1bgnF\xf8\x88\xf3c9\x7f\xce9\x93o\x90\x82\x161\x88\x86M\x8b9\xa2\x1b\x00!\xa3\xe8\x80)\x14?\x8f\x7f{\xf6+e7\xc3\x1fڱ\xf7'X\xee\xbfw\x90\xb5\x00S\x1f\xbe\xdbaD\xa0\xf8\xfcu\x8b\xe1\xf1Q\x14\xb0\x81h\az\"\xab\x01p\f\xa8<m\xd25ʱC;!9\xa6\x8df\xddK\xb1D\xcdq'1\xa3\x9as\xb0\r>\xe3~\x82\x81EG\xc0X)\x7f\r!\x8eŧ<\x88S\b\xab\x01\xc1r\xacZ\x06\r\xa6uM>'\xb8\x7f\xc39\xef\x02\xfa\xab\x7fW^\xffǽ\xa6k\x13\xb0\x05t\xfc\xa5]\xf7g\x9bb\xe0\x9a\xb5\x1d\xa3\x88\xcayd\xc2\x1c 7.\xb2(\xe0\x9f\xf4\x91\x1e\xfa\x9b;1\x8a\xe3\xa4\xcfx7\x83\x91\x00\x13\xfb\x94\xcdɴp\xc8\xc7\xf9C\x9e\xc8E\x87\xfd\xa8\x0f\xfb\x8f\xbf\xcb\t\xb19\xa0Q\xafY\xab\x81\x1f\xf5\xffR^\x03 \xbd\x8992C˳\x19\x10\x17\x98\xd1f\xb8\x06\xa4\xdb\x03\xd2q\xdc\x02>Vj\xb7\xa7\x1b\x88\xe3\xcf\aL\xeb*K?\xab(;\v\xe9\xc5\xc2G\xaaSJ;\x8a\x1bR\t\xc4\aħh\xfc\xebO\xb4\xe7\x14\xc5\xe0\x8b>\xee\x93\x1cǘ\xe6g\xfd\xce\xfa\xf6òɃ\x84`5\x06J\xacU\xcd\xfa)g݄f\x85\xad1\x95\x9a\xf9<\xcb\xe4\x8cɪ\x03B\xbcg\x1c\x9a|\xe1\x9a\xfc->\xcb\xe2\x04\xa0pˎU\xc7\x181I̱(\xd8\x16\xc3\xf8+uA\x88\x0f\xb867֜>l\xf7 \xff\xb9\xee\x12\xc8^h\xef\xdd4\xf6\x0f\x92_߮\nM\xa4\x1aduHlT\xb8\x90\x96cǄl8\x12\xae\"\xef\xf8s\xbdi+D\x19\xc4\xddC\xad\xd1\xe5\xf5\"\xeb\"i\xbe\\®\x90S\xf0\x06\x03֒\xa2\xfc\xdc\x1c\x12\x96E\xf5j\x91\xd1w\x88\xf7\x02q\xf7\xd1\xf1\x88\xddg/\x9e\xf0V\x9ae\x1e-\xbc\x8e\xb91\xab\xac\xb8N\u008d7F\xf6\xc4\x15\x1d[p\xd2\x00f\xec\xa6N\x99\xa1\x1d\xc9x\xc7\xe7\xfaw\x9d\xa9\x8ej`\xfb^-\xfb\"\xce\x19\xafZ$\x04h\xa6\x1e\xcb5\xf9\x91{\xba\xcc\xcckK\xf7#/\x96):\xe8[\x82\xec\xd6\x04\xcfƅ\xe6\xc4_ \f\xf6\xbc\xc0\x8av,\xde\f(H\xbeG\t2\xfc\xec'\x10\x15X\xe2\xc1\xdc>\x9e?\x15\x03n\x19#\x9a\x10dәpq\x9f3_g\xbc\x1c&\xee\xec\xd2gy\x13\xf0\x12\x0fs*9{\xc0\x11\xac \x90 \xf50\x83\x89+B\x19<\x8e\x00\xb6Q\x7f\xb6@\xa0\xb9\xb0\xb4\xae\xa9\xb4籘v95e\xc0\xb1\xd8\xcf7\xd5\xedX4\x95eϛ۟\xbf\x8a#\x12\x10C\x11X\x11\x81\b\xe2\x1aH7(\x89\xdeÝ[\x14\x97\x0f\xf1\xfa\x1c\xe3\x15^c\xf6\xf02\x06\x0e3\x93\xd3\xe1De\x99,\xb6\x17k\xf3u\x19q\xbd@\xdf\x14\x82\xbd\x02j~P\xf0\x8d\xd9R\x93\x00\xdfR\xb0C\x1c\x1b><?jQ\xe9\x06ZO:\xac\xd0\xef\xdbb\xe8\xaa[\xce^\xcb\xf1\xaf\xe4\"\xbe\xdfA\xec\x19\x97\x95\xf9\xc5j\xfa'3\xf3\xbb\x95\xdb\xfe/\xff7\x1a\xb4^E\xff1\x14W\x86`^$\x83\x15֔\xf8\xf3/O\x7f))\xaeI \x99\xb8\xad\x95\xf4\x1f\x00\x00\x00\xff\xff\x01\x00\x00\xff\xffc\x95\x1ds\x9a\x14\x00\x00"))
 }

--- a/api/addon/schema.yml
+++ b/api/addon/schema.yml
@@ -84,3 +84,32 @@ kinds:
   postgresql_dedicated_data:
     postgres_server:
       type: ref
+
+  mysql_server:
+    addon_name:
+      type: string
+      indexed: true
+    variant:
+      type: string
+    sandbox_pool:
+      type: ref
+    service:
+      type: ref
+    status:
+      type: string
+    association_count:
+      type: int
+    root_password:
+      type: string
+
+  mysql_shared_data:
+    mysql_server:
+      type: ref
+    database_name:
+      type: string
+    username:
+      type: string
+
+  mysql_dedicated_data:
+    mysql_server:
+      type: ref

--- a/api/entityserver/client.go
+++ b/api/entityserver/client.go
@@ -209,6 +209,10 @@ func (c *Client) Create(ctx context.Context, name string, sc SchemaEncoder, opts
 // CreateOrReplace creates a new entity or fully replaces an existing one.
 // Unlike CreateOrUpdate which merges attrs (appending to "many" component
 // fields), this method replaces all attrs atomically when the entity exists.
+// Note: not safe for concurrent use on the same entity — the Replace will
+// fail with a revision mismatch if another writer updates between Get and
+// Replace. This is fine for startup-time initialization but callers needing
+// concurrent safety should add retry logic.
 func (c *Client) CreateOrReplace(ctx context.Context, name string, sc SchemaEncoder, opts ...CreateOptions) (entity.Id, error) {
 	var op createOp
 	for _, opt := range opts {

--- a/api/entityserver/client.go
+++ b/api/entityserver/client.go
@@ -206,6 +206,61 @@ func (c *Client) Create(ctx context.Context, name string, sc SchemaEncoder, opts
 	return entity.Id(pr.Id()), nil
 }
 
+// CreateOrReplace creates a new entity or fully replaces an existing one.
+// Unlike CreateOrUpdate which merges attrs (appending to "many" component
+// fields), this method replaces all attrs atomically when the entity exists.
+func (c *Client) CreateOrReplace(ctx context.Context, name string, sc SchemaEncoder, opts ...CreateOptions) (entity.Id, error) {
+	var op createOp
+	for _, opt := range opts {
+		opt(&op)
+	}
+
+	gr, err := c.eac.Get(ctx, sc.ShortKind()+"/"+name)
+	if err == nil {
+		// Entity exists — build full attrs including metadata and identity,
+		// then replace atomically.
+		fullAttrs := entity.New(
+			(&core_v1alpha.Metadata{
+				Name:   name,
+				Labels: op.labels,
+			}).Encode,
+			sc.Encode,
+			entity.DBId, entity.Id(gr.Entity().Id()),
+			entity.Ident, types.Keyword(sc.ShortKind()+"/"+name),
+		).Attrs()
+
+		rr, err := c.eac.Replace(ctx, fullAttrs, gr.Entity().Revision())
+		if err != nil {
+			return "", err
+		}
+
+		return entity.Id(rr.Id()), nil
+	}
+
+	if !errors.Is(err, cond.ErrNotFound{}) {
+		return "", err
+	}
+
+	// Entity does not exist — create it.
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetAttrs(
+		entity.New(
+			(&core_v1alpha.Metadata{
+				Name:   name,
+				Labels: op.labels,
+			}).Encode,
+			sc.Encode,
+			entity.Ident, types.Keyword(sc.ShortKind()+"/"+name),
+		).Attrs())
+
+	pr, err := c.eac.Put(ctx, &rpcE)
+	if err != nil {
+		return "", err
+	}
+
+	return entity.Id(pr.Id()), nil
+}
+
 func (c *Client) CreateOrUpdate(ctx context.Context, name string, sc SchemaEncoder, opts ...CreateOptions) (entity.Id, error) {
 	var op createOp
 	for _, opt := range opts {

--- a/blackbox/addon_test.go
+++ b/blackbox/addon_test.go
@@ -16,6 +16,7 @@ func TestAddonListAvailable(t *testing.T) {
 
 	r := m.MustRun("addon", "list-available")
 	r.RequireContains(t, "miren-postgresql")
+	r.RequireContains(t, "miren-mysql")
 }
 
 func TestAddonVariants(t *testing.T) {
@@ -23,6 +24,10 @@ func TestAddonVariants(t *testing.T) {
 	m := harness.NewMiren(t, c)
 
 	r := m.MustRun("addon", "variants", "miren-postgresql")
+	r.RequireContains(t, "small")
+	r.RequireContains(t, "shared")
+
+	r = m.MustRun("addon", "variants", "miren-mysql")
 	r.RequireContains(t, "small")
 	r.RequireContains(t, "shared")
 }
@@ -110,6 +115,83 @@ func TestAddonDeployWithAppToml(t *testing.T) {
 	if code != 200 {
 		t.Fatalf("expected status 200, got %d: %s", code, body)
 	}
+}
+
+func TestMysqlAddonDeployWithAppToml(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.UniqueAppName(t, "bun-mysql")
+
+	hostDir := filepath.Join(c.TestdataDir, "bun-mysql")
+	containerDir := m.ContainerPath(hostDir)
+
+	t.Cleanup(func() {
+		t.Logf("cleaning up app %s", name)
+		m.Run("app", "delete", name, "-f")
+	})
+
+	// Deploy without waiting for healthy — the app depends on DATABASE_URL
+	// which is only injected after addon provisioning completes.
+	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
+
+	// Wait for addon provisioning to complete.
+	harness.WaitForAddonReady(t, m, name, "miren-mysql", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
+
+	// Now wait for the app to become healthy
+	harness.WaitForAppReady(t, m, name, 3*time.Minute)
+
+	// Verify addon is listed
+	r := m.MustRun("addon", "list", "-a", name, "--format", "json")
+	r.RequireContains(t, "miren-mysql")
+
+	// Set a route and verify the app responds with DB connectivity
+	host := name + ".test.local"
+	m.MustRun("route", "set", host, name)
+
+	harness.Poll(t, "app responds via route", 30*time.Second, 2*time.Second, func() (bool, string) {
+		code, body, err := harness.HTTPGet(m, host, "/health")
+		if err != nil {
+			return false, err.Error()
+		}
+		if code != 200 {
+			return false, "status " + body
+		}
+		return true, ""
+	})
+
+	// Verify the root endpoint works (exercises DB writes/reads)
+	code, body, err := harness.HTTPGet(m, host, "/")
+	if err != nil {
+		t.Fatalf("HTTP GET / failed: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected status 200, got %d: %s", code, body)
+	}
+}
+
+func TestMysqlAddonCreateListDestroy(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+
+	// Create a small (dedicated) MySQL addon on the app
+	m.MustRun("addon", "create", "miren-mysql:small", "-a", name)
+
+	// Wait for addon to appear and provisioning to complete.
+	harness.WaitForAddonReady(t, m, name, "miren-mysql", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
+
+	// Verify MySQL-specific env vars are injected
+	harness.WaitForEnvVar(t, m, name, "MYSQL_HOST", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "MYSQL_DATABASE", 30*time.Second)
+
+	// Destroy the addon
+	m.MustRun("addon", "destroy", "miren-mysql", "-a", name, "--force")
 }
 
 func TestAddonUnknownAddon(t *testing.T) {

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -50,6 +50,7 @@ import (
 	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/mysql"
 	"miren.dev/runtime/pkg/addon/postgresql"
 	"miren.dev/runtime/pkg/caauth"
 	"miren.dev/runtime/pkg/cloudauth"
@@ -865,6 +866,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	if labs.Addons() {
 		addonFw := addon.NewProviderFramework(c.Log, ec, eac, saga.NewEntityStorage(etcdStore, c.Log))
 		addonRegistry.Register(postgresql.AddonName, postgresql.NewProvider(addonFw), postgresql.Definition())
+		addonRegistry.Register(mysql.AddonName, mysql.NewProvider(addonFw), mysql.Definition())
 
 		if err := addonRegistry.EnsureEntities(ctx, ec); err != nil {
 			c.Log.Error("failed to ensure addon entities", "error", err)

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -861,17 +861,15 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		return err
 	}
 
-	// Set up addon registry; only register providers when the addons lab flag is enabled
+	// Set up addon registry and register providers.
 	addonRegistry := addon.NewRegistry()
-	if labs.Addons() {
-		addonFw := addon.NewProviderFramework(c.Log, ec, eac, saga.NewEntityStorage(etcdStore, c.Log))
-		addonRegistry.Register(postgresql.AddonName, postgresql.NewProvider(addonFw), postgresql.Definition())
-		addonRegistry.Register(mysql.AddonName, mysql.NewProvider(addonFw), mysql.Definition())
+	addonFw := addon.NewProviderFramework(c.Log, ec, eac, saga.NewEntityStorage(etcdStore, c.Log))
+	addonRegistry.Register(postgresql.AddonName, postgresql.NewProvider(addonFw), postgresql.Definition())
+	addonRegistry.Register(mysql.AddonName, mysql.NewProvider(addonFw), mysql.Definition())
 
-		if err := addonRegistry.EnsureEntities(ctx, ec); err != nil {
-			c.Log.Error("failed to ensure addon entities", "error", err)
-			return err
-		}
+	if err := addonRegistry.EnsureEntities(ctx, ec); err != nil {
+		c.Log.Error("failed to ensure addon entities", "error", err)
+		return err
 	}
 
 	// Migrate app versions before starting components that depend on them

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,11 @@ require (
 	miren.dev/mflags v0.0.0-20260313175018-d9ee90a8bb13
 )
 
-require github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
+require (
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
+	github.com/go-sql-driver/mysql v1.9.3 // indirect
+)
 
 require (
 	cel.dev/expr v0.24.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/logr v1.4.3
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
+	github.com/go-sql-driver/mysql v1.9.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/cel-go v0.24.1
 	github.com/google/gofuzz v1.2.0
@@ -131,7 +132,6 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
-	github.com/go-sql-driver/mysql v1.9.3 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ cyphar.com/go-pathrs v0.2.1/go.mod h1:y8f1EMG7r+hCuFf/rXsKqMJrJAUoADZGNh5/vZPKcG
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 h1:dIScnXFlF784X79oi7MzVT6GWqr/W1uUt0pB5CsDs9M=
@@ -495,6 +497,8 @@ github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
 github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
+github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
+github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=

--- a/pkg/addon/dbsaga/config.go
+++ b/pkg/addon/dbsaga/config.go
@@ -1,0 +1,12 @@
+package dbsaga
+
+import "time"
+
+// AddonConfig holds database-agnostic configuration that shared saga
+// actions use instead of referencing provider-specific package constants.
+// Inject via saga.Using() and retrieve with saga.Get[*AddonConfig](ctx).
+type AddonConfig struct {
+	AddonName    string
+	Port         int64
+	ReadyTimeout time.Duration
+}

--- a/pkg/addon/dbsaga/config.go
+++ b/pkg/addon/dbsaga/config.go
@@ -6,7 +6,8 @@ import "time"
 // actions use instead of referencing provider-specific package constants.
 // Inject via saga.Using() and retrieve with saga.Get[*AddonConfig](ctx).
 type AddonConfig struct {
-	AddonName    string
-	Port         int64
-	ReadyTimeout time.Duration
+	AddonName        string
+	SharedServerName string
+	Port             int64
+	ReadyTimeout     time.Duration
 }

--- a/pkg/addon/dbsaga/dedicated.go
+++ b/pkg/addon/dbsaga/dedicated.go
@@ -1,0 +1,158 @@
+package dbsaga
+
+import (
+	"context"
+	"fmt"
+
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// --- Shared Dedicated Saga Actions ---
+//
+// These actions are database-agnostic and shared by all on-cluster database
+// addon providers. They depend on *AddonConfig (injected via saga.Using)
+// for the addon name and port.
+
+// WaitForDedicatedPool waits for the dedicated sandbox pool to have at
+// least one ready instance.
+
+type WaitForDedicatedPoolIn struct {
+	PoolID entity.Id
+}
+
+type WaitForDedicatedPoolOut struct {
+	Ready bool
+}
+
+func WaitForDedicatedPool(ctx context.Context, in WaitForDedicatedPoolIn) (WaitForDedicatedPoolOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	cfg := saga.Get[*AddonConfig](ctx)
+
+	if err := fw.WaitForPool(ctx, in.PoolID, cfg.ReadyTimeout); err != nil {
+		return WaitForDedicatedPoolOut{}, fmt.Errorf("waiting for pool: %w", err)
+	}
+
+	return WaitForDedicatedPoolOut{Ready: true}, nil
+}
+
+func UndoWaitForDedicatedPool(ctx context.Context, in WaitForDedicatedPoolIn, out WaitForDedicatedPoolOut) error {
+	return nil
+}
+
+// CreateDedicatedService creates a network Service for the dedicated pool.
+
+type CreateDedicatedServiceIn struct {
+	ServiceName string
+	AppName     string
+	ServerName  string
+}
+
+type CreateDedicatedServiceOut struct {
+	ServiceID entity.Id
+}
+
+func CreateDedicatedService(ctx context.Context, in CreateDedicatedServiceIn) (CreateDedicatedServiceOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	cfg := saga.Get[*AddonConfig](ctx)
+
+	labels := types.LabelSet(
+		"addon", cfg.AddonName,
+		"app", in.AppName,
+		"server", in.ServerName,
+	)
+
+	svcID, err := fw.CreateService(ctx, in.ServiceName, labels, cfg.Port)
+	if err != nil {
+		return CreateDedicatedServiceOut{}, fmt.Errorf("creating service: %w", err)
+	}
+
+	return CreateDedicatedServiceOut{ServiceID: svcID}, nil
+}
+
+func UndoCreateDedicatedService(ctx context.Context, in CreateDedicatedServiceIn, out CreateDedicatedServiceOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.DeleteService(ctx, out.ServiceID)
+}
+
+// WaitForDedicatedService waits for the service to receive an IP address.
+
+type WaitForDedicatedServiceIn struct {
+	ServiceID entity.Id
+}
+
+type WaitForDedicatedServiceOut struct {
+	ServiceHost string
+}
+
+func WaitForDedicatedService(ctx context.Context, in WaitForDedicatedServiceIn) (WaitForDedicatedServiceOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	cfg := saga.Get[*AddonConfig](ctx)
+
+	serviceHost, err := fw.WaitForServiceAddress(ctx, in.ServiceID, cfg.ReadyTimeout)
+	if err != nil {
+		return WaitForDedicatedServiceOut{}, fmt.Errorf("waiting for dedicated service address: %w", err)
+	}
+
+	return WaitForDedicatedServiceOut{ServiceHost: serviceHost}, nil
+}
+
+func UndoWaitForDedicatedService(ctx context.Context, in WaitForDedicatedServiceIn, out WaitForDedicatedServiceOut) error {
+	return nil
+}
+
+// DeleteDedicatedService deletes the dedicated network Service.
+
+type DeleteDedicatedServiceIn struct {
+	DedicatedServiceID entity.Id
+}
+
+type DeleteDedicatedServiceOut struct {
+	ServiceDeleted bool
+}
+
+func DeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn) (DeleteDedicatedServiceOut, error) {
+	if in.DedicatedServiceID == "" {
+		return DeleteDedicatedServiceOut{ServiceDeleted: false}, nil
+	}
+
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	if err := fw.DeleteService(ctx, in.DedicatedServiceID); err != nil {
+		return DeleteDedicatedServiceOut{}, fmt.Errorf("deleting service: %w", err)
+	}
+
+	return DeleteDedicatedServiceOut{ServiceDeleted: true}, nil
+}
+
+func UndoDeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn, out DeleteDedicatedServiceOut) error {
+	return nil
+}
+
+// DeleteDedicatedPool deletes the dedicated sandbox pool.
+
+type DeleteDedicatedPoolIn struct {
+	DedicatedPoolID entity.Id
+}
+
+type DeleteDedicatedPoolOut struct {
+	PoolDeleted bool `saga:"dedicated_pool_deleted"`
+}
+
+func DeleteDedicatedPool(ctx context.Context, in DeleteDedicatedPoolIn) (DeleteDedicatedPoolOut, error) {
+	if in.DedicatedPoolID == "" {
+		return DeleteDedicatedPoolOut{PoolDeleted: false}, nil
+	}
+
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	if err := fw.DeleteSandboxPool(ctx, in.DedicatedPoolID); err != nil {
+		return DeleteDedicatedPoolOut{}, fmt.Errorf("deleting sandbox pool: %w", err)
+	}
+
+	return DeleteDedicatedPoolOut{PoolDeleted: true}, nil
+}
+
+func UndoDeleteDedicatedPool(ctx context.Context, in DeleteDedicatedPoolIn, out DeleteDedicatedPoolOut) error {
+	return nil
+}

--- a/pkg/addon/dbsaga/dedicated.go
+++ b/pkg/addon/dbsaga/dedicated.go
@@ -106,11 +106,11 @@ func UndoWaitForDedicatedService(ctx context.Context, in WaitForDedicatedService
 // DeleteDedicatedService deletes the dedicated network Service.
 
 type DeleteDedicatedServiceIn struct {
-	DedicatedServiceID entity.Id
+	DedicatedServiceID entity.Id `saga:"dedicatedserviceid"`
 }
 
 type DeleteDedicatedServiceOut struct {
-	ServiceDeleted bool
+	ServiceDeleted bool `saga:"dedicated_service_deleted"`
 }
 
 func DeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn) (DeleteDedicatedServiceOut, error) {
@@ -133,7 +133,7 @@ func UndoDeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn
 // DeleteDedicatedPool deletes the dedicated sandbox pool.
 
 type DeleteDedicatedPoolIn struct {
-	DedicatedPoolID entity.Id
+	DedicatedPoolID entity.Id `saga:"dedicatedpoolid"`
 }
 
 type DeleteDedicatedPoolOut struct {

--- a/pkg/addon/dbsaga/provider.go
+++ b/pkg/addon/dbsaga/provider.go
@@ -1,0 +1,24 @@
+package dbsaga
+
+import (
+	"context"
+	"log/slog"
+
+	"miren.dev/runtime/pkg/addon"
+)
+
+// BaseProvider holds fields and methods common to all on-cluster database
+// addon providers. Embed it in provider structs to avoid duplicating
+// LocalityMode and AdjustEnvVars.
+type BaseProvider struct {
+	Fw  *addon.ProviderFramework
+	Log *slog.Logger
+}
+
+func (p *BaseProvider) LocalityMode() addon.LocalityMode {
+	return addon.OnCluster
+}
+
+func (p *BaseProvider) AdjustEnvVars(_ context.Context, result *addon.ProvisionResult, _ addon.AddonAssociation, _ []string) ([]addon.Variable, error) {
+	return result.EnvVars, nil
+}

--- a/pkg/addon/dbsaga/shared.go
+++ b/pkg/addon/dbsaga/shared.go
@@ -3,6 +3,7 @@ package dbsaga
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"miren.dev/runtime/pkg/addon"
 	"miren.dev/runtime/pkg/entity"
@@ -48,9 +49,7 @@ func UndoWaitForSharedPool(ctx context.Context, in WaitForSharedPoolIn, out Wait
 
 // CreateSharedService creates a network Service for the shared pool.
 
-type CreateSharedServiceIn struct {
-	SharedServerName string
-}
+type CreateSharedServiceIn struct{}
 
 type CreateSharedServiceOut struct {
 	ServiceID entity.Id
@@ -62,11 +61,12 @@ func CreateSharedService(ctx context.Context, in CreateSharedServiceIn) (CreateS
 
 	labels := types.LabelSet(
 		"addon", cfg.AddonName,
-		"server", in.SharedServerName,
+		"server", cfg.SharedServerName,
 		"shared", "true",
 	)
 
-	serviceName := in.SharedServerName + "-" + cfg.AddonName[len("miren-"):]
+	suffix := strings.TrimPrefix(cfg.AddonName, "miren-")
+	serviceName := cfg.SharedServerName + "-" + suffix
 	svcID, err := fw.CreateService(ctx, serviceName, labels, cfg.Port)
 	if err != nil {
 		return CreateSharedServiceOut{}, fmt.Errorf("creating shared service: %w", err)

--- a/pkg/addon/dbsaga/shared.go
+++ b/pkg/addon/dbsaga/shared.go
@@ -1,0 +1,187 @@
+package dbsaga
+
+import (
+	"context"
+	"fmt"
+
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// ServerCounter abstracts reading and patching the association count on a
+// database server entity. Each provider implements this for its own entity
+// type. Inject via saga.UsingAs[ServerCounter] and retrieve with
+// saga.Get[ServerCounter](ctx).
+type ServerCounter interface {
+	GetAssociationCount(ctx context.Context, serverID entity.Id) (count int64, revision int64, err error)
+	PatchAssociationCount(ctx context.Context, serverID entity.Id, revision int64, newCount int64) error
+}
+
+// --- Shared Shared-Server Saga Actions ---
+
+// WaitForSharedPool waits for the shared sandbox pool to be ready.
+
+type WaitForSharedPoolIn struct {
+	PoolID entity.Id
+}
+
+type WaitForSharedPoolOut struct {
+	PoolReady bool
+}
+
+func WaitForSharedPool(ctx context.Context, in WaitForSharedPoolIn) (WaitForSharedPoolOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	cfg := saga.Get[*AddonConfig](ctx)
+
+	if err := fw.WaitForPool(ctx, in.PoolID, cfg.ReadyTimeout); err != nil {
+		return WaitForSharedPoolOut{}, fmt.Errorf("waiting for shared pool: %w", err)
+	}
+
+	return WaitForSharedPoolOut{PoolReady: true}, nil
+}
+
+func UndoWaitForSharedPool(ctx context.Context, in WaitForSharedPoolIn, out WaitForSharedPoolOut) error {
+	return nil
+}
+
+// CreateSharedService creates a network Service for the shared pool.
+
+type CreateSharedServiceIn struct {
+	SharedServerName string
+}
+
+type CreateSharedServiceOut struct {
+	ServiceID entity.Id
+}
+
+func CreateSharedService(ctx context.Context, in CreateSharedServiceIn) (CreateSharedServiceOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	cfg := saga.Get[*AddonConfig](ctx)
+
+	labels := types.LabelSet(
+		"addon", cfg.AddonName,
+		"server", in.SharedServerName,
+		"shared", "true",
+	)
+
+	serviceName := in.SharedServerName + "-" + cfg.AddonName[len("miren-"):]
+	svcID, err := fw.CreateService(ctx, serviceName, labels, cfg.Port)
+	if err != nil {
+		return CreateSharedServiceOut{}, fmt.Errorf("creating shared service: %w", err)
+	}
+
+	return CreateSharedServiceOut{ServiceID: svcID}, nil
+}
+
+func UndoCreateSharedService(ctx context.Context, in CreateSharedServiceIn, out CreateSharedServiceOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.DeleteService(ctx, out.ServiceID)
+}
+
+// WaitForSharedService waits for the service to receive an IP address.
+
+type WaitForSharedServiceIn struct {
+	ServiceID entity.Id
+}
+
+type WaitForSharedServiceOut struct {
+	ServiceHost string
+}
+
+func WaitForSharedService(ctx context.Context, in WaitForSharedServiceIn) (WaitForSharedServiceOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	cfg := saga.Get[*AddonConfig](ctx)
+
+	serviceHost, err := fw.WaitForServiceAddress(ctx, in.ServiceID, cfg.ReadyTimeout)
+	if err != nil {
+		return WaitForSharedServiceOut{}, fmt.Errorf("waiting for shared service address: %w", err)
+	}
+
+	return WaitForSharedServiceOut{ServiceHost: serviceHost}, nil
+}
+
+func UndoWaitForSharedService(ctx context.Context, in WaitForSharedServiceIn, out WaitForSharedServiceOut) error {
+	return nil
+}
+
+// IncrementAssociationCount bumps the association count on a shared server.
+
+type IncrementAssociationCountIn struct {
+	ServerID entity.Id
+}
+
+type IncrementAssociationCountOut struct {
+	Incremented bool
+}
+
+func IncrementAssociationCount(ctx context.Context, in IncrementAssociationCountIn) (IncrementAssociationCountOut, error) {
+	sc := saga.Get[ServerCounter](ctx)
+
+	count, rev, err := sc.GetAssociationCount(ctx, in.ServerID)
+	if err != nil {
+		return IncrementAssociationCountOut{}, fmt.Errorf("getting server for count increment: %w", err)
+	}
+
+	if err := sc.PatchAssociationCount(ctx, in.ServerID, rev, count+1); err != nil {
+		return IncrementAssociationCountOut{}, fmt.Errorf("updating association count: %w", err)
+	}
+
+	return IncrementAssociationCountOut{Incremented: true}, nil
+}
+
+func UndoIncrementAssociationCount(ctx context.Context, in IncrementAssociationCountIn, out IncrementAssociationCountOut) error {
+	if !out.Incremented {
+		return nil
+	}
+
+	sc := saga.Get[ServerCounter](ctx)
+
+	count, rev, err := sc.GetAssociationCount(ctx, in.ServerID)
+	if err != nil {
+		return err
+	}
+
+	newCount := count - 1
+	if newCount < 0 {
+		newCount = 0
+	}
+	return sc.PatchAssociationCount(ctx, in.ServerID, rev, newCount)
+}
+
+// DecrementAssociationCount decreases the association count on a shared server.
+
+type DecrementAssociationCountIn struct {
+	SharedServerRef entity.Id
+	DatabaseDropped bool
+	UserDropped     bool
+}
+
+type DecrementAssociationCountOut struct {
+	RemainingCount int64
+}
+
+func DecrementAssociationCount(ctx context.Context, in DecrementAssociationCountIn) (DecrementAssociationCountOut, error) {
+	sc := saga.Get[ServerCounter](ctx)
+
+	count, rev, err := sc.GetAssociationCount(ctx, in.SharedServerRef)
+	if err != nil {
+		return DecrementAssociationCountOut{}, fmt.Errorf("getting server: %w", err)
+	}
+
+	if count <= 0 {
+		return DecrementAssociationCountOut{RemainingCount: 0}, nil
+	}
+
+	newCount := count - 1
+	if err := sc.PatchAssociationCount(ctx, in.SharedServerRef, rev, newCount); err != nil {
+		return DecrementAssociationCountOut{}, fmt.Errorf("updating association count: %w", err)
+	}
+
+	return DecrementAssociationCountOut{RemainingCount: newCount}, nil
+}
+
+func UndoDecrementAssociationCount(ctx context.Context, in DecrementAssociationCountIn, out DecrementAssociationCountOut) error {
+	return nil
+}

--- a/pkg/addon/ident.go
+++ b/pkg/addon/ident.go
@@ -21,7 +21,7 @@ func SanitizeIdentifier(name string, maxLen int) string {
 		}
 	}
 	if len(result) == 0 {
-		return "app"
+		result = []byte("app")
 	}
 	if result[0] >= '0' && result[0] <= '9' {
 		result = append([]byte{'a'}, result...)

--- a/pkg/addon/ident.go
+++ b/pkg/addon/ident.go
@@ -1,0 +1,51 @@
+package addon
+
+import (
+	"strconv"
+	"strings"
+)
+
+// SanitizeIdentifier converts a name into a safe database identifier by
+// keeping only lowercase alphanumeric characters and underscores, converting
+// uppercase to lowercase and hyphens to underscores, and truncating to maxLen.
+func SanitizeIdentifier(name string, maxLen int) string {
+	result := make([]byte, 0, len(name))
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' {
+			result = append(result, c)
+		} else if c >= 'A' && c <= 'Z' {
+			result = append(result, c+32) // lowercase
+		} else if c == '-' {
+			result = append(result, '_')
+		}
+	}
+	if len(result) == 0 {
+		return "app"
+	}
+	if result[0] >= '0' && result[0] <= '9' {
+		result = append([]byte{'a'}, result...)
+	}
+	if maxLen > 0 && len(result) > maxLen {
+		result = result[:maxLen]
+	}
+	return string(result)
+}
+
+// ParseStorageGb converts a Kubernetes-style size string (e.g. "1Gi", "50Gi")
+// to an int64 value in gigabytes. Returns 1 if the string cannot be parsed.
+func ParseStorageGb(s string) int64 {
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "Gi") {
+		n, err := strconv.ParseInt(strings.TrimSuffix(s, "Gi"), 10, 64)
+		if err == nil && n > 0 {
+			return n
+		}
+	}
+	return 1
+}
+
+// IsSharedVariant returns true if the variant is a shared-server variant.
+func IsSharedVariant(variantName string) bool {
+	return variantName == "shared"
+}

--- a/pkg/addon/ident_test.go
+++ b/pkg/addon/ident_test.go
@@ -1,0 +1,47 @@
+package addon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeIdentifier(t *testing.T) {
+	tests := []struct {
+		input    string
+		maxLen   int
+		expected string
+	}{
+		{"my-app", 63, "my_app"},
+		{"MyApp", 63, "myapp"},
+		{"123app", 63, "a123app"},
+		{"app_name", 63, "app_name"},
+		{"app.name", 63, "appname"},
+		{"APP-NAME", 63, "app_name"},
+		{"", 63, "app"},
+		{"a", 63, "a"},
+		{"my-really-long-application-name-for-production", 32, "my_really_long_application_name_"},
+		{"a-very-long-name-that-exceeds-63", 63, "a_very_long_name_that_exceeds_63"},
+		{"no-limit", 0, "no_limit"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, SanitizeIdentifier(tt.input, tt.maxLen))
+		})
+	}
+}
+
+func TestParseStorageGb(t *testing.T) {
+	assert.Equal(t, int64(1), ParseStorageGb("1Gi"))
+	assert.Equal(t, int64(50), ParseStorageGb("50Gi"))
+	assert.Equal(t, int64(1), ParseStorageGb("bad"))
+	assert.Equal(t, int64(1), ParseStorageGb(""))
+	assert.Equal(t, int64(1), ParseStorageGb("0Gi"))
+}
+
+func TestIsSharedVariant(t *testing.T) {
+	assert.True(t, IsSharedVariant("shared"))
+	assert.False(t, IsSharedVariant("small"))
+	assert.False(t, IsSharedVariant(""))
+}

--- a/pkg/addon/mysql/dedicated.go
+++ b/pkg/addon/mysql/dedicated.go
@@ -8,6 +8,7 @@ import (
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/dbsaga"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
 	"miren.dev/runtime/pkg/idgen"
@@ -117,7 +118,7 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 		"server", in.ServerName,
 	)
 
-	sizeGb := parseStorageGb(in.VariantConfig[ConfigStorage])
+	sizeGb := addon.ParseStorageGb(in.VariantConfig[ConfigStorage])
 	diskName := fmt.Sprintf("my-%s-data", in.ServerName)
 	mountPath := "/var/lib/mysql"
 
@@ -161,83 +162,6 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 func UndoCreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn, out CreateDedicatedPoolOut) error {
 	fw := saga.Get[*addon.ProviderFramework](ctx)
 	return fw.DeleteSandboxPool(ctx, out.PoolID)
-}
-
-type WaitForDedicatedPoolIn struct {
-	PoolID entity.Id
-}
-
-type WaitForDedicatedPoolOut struct {
-	Ready bool
-}
-
-func WaitForDedicatedPool(ctx context.Context, in WaitForDedicatedPoolIn) (WaitForDedicatedPoolOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	if err := fw.WaitForPool(ctx, in.PoolID, poolReadyTimeout); err != nil {
-		return WaitForDedicatedPoolOut{}, fmt.Errorf("waiting for mysql pool: %w", err)
-	}
-
-	return WaitForDedicatedPoolOut{Ready: true}, nil
-}
-
-func UndoWaitForDedicatedPool(ctx context.Context, in WaitForDedicatedPoolIn, out WaitForDedicatedPoolOut) error {
-	return nil
-}
-
-type CreateDedicatedServiceIn struct {
-	ServiceName string
-	AppName     string
-	ServerName  string
-}
-
-type CreateDedicatedServiceOut struct {
-	ServiceID entity.Id
-}
-
-func CreateDedicatedService(ctx context.Context, in CreateDedicatedServiceIn) (CreateDedicatedServiceOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	labels := types.LabelSet(
-		"addon", AddonName,
-		"app", in.AppName,
-		"server", in.ServerName,
-	)
-
-	svcID, err := fw.CreateService(ctx, in.ServiceName, labels, mysqlPort)
-	if err != nil {
-		return CreateDedicatedServiceOut{}, fmt.Errorf("creating service: %w", err)
-	}
-
-	return CreateDedicatedServiceOut{ServiceID: svcID}, nil
-}
-
-func UndoCreateDedicatedService(ctx context.Context, in CreateDedicatedServiceIn, out CreateDedicatedServiceOut) error {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-	return fw.DeleteService(ctx, out.ServiceID)
-}
-
-type WaitForDedicatedServiceIn struct {
-	ServiceID entity.Id
-}
-
-type WaitForDedicatedServiceOut struct {
-	ServiceHost string
-}
-
-func WaitForDedicatedService(ctx context.Context, in WaitForDedicatedServiceIn) (WaitForDedicatedServiceOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	serviceHost, err := fw.WaitForServiceAddress(ctx, in.ServiceID, poolReadyTimeout)
-	if err != nil {
-		return WaitForDedicatedServiceOut{}, fmt.Errorf("waiting for dedicated service address: %w", err)
-	}
-
-	return WaitForDedicatedServiceOut{ServiceHost: serviceHost}, nil
-}
-
-func UndoWaitForDedicatedService(ctx context.Context, in WaitForDedicatedServiceIn, out WaitForDedicatedServiceOut) error {
-	return nil
 }
 
 type UpdateDedicatedServerIn struct {
@@ -311,15 +235,17 @@ func UndoBuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn, ou
 }
 
 func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+	cfg := &dbsaga.AddonConfig{AddonName: AddonName, Port: mysqlPort, ReadyTimeout: poolReadyTimeout}
 	return saga.Define("provision-dedicated-mysql").
 		Using(fw).
 		Using(rc).
+		Using(cfg).
 		Action(GenerateCredentials).Undo(UndoGenerateCredentials).
 		Action(CreateMysqlServer).Undo(UndoCreateMysqlServer).
 		Action(CreateDedicatedPool).Undo(UndoCreateDedicatedPool).
-		Action(WaitForDedicatedPool).Undo(UndoWaitForDedicatedPool).
-		Action(CreateDedicatedService).Undo(UndoCreateDedicatedService).
-		Action(WaitForDedicatedService).Undo(UndoWaitForDedicatedService).
+		Action(dbsaga.WaitForDedicatedPool).Undo(dbsaga.UndoWaitForDedicatedPool).
+		Action(dbsaga.CreateDedicatedService).Undo(dbsaga.UndoCreateDedicatedService).
+		Action(dbsaga.WaitForDedicatedService).Undo(dbsaga.UndoWaitForDedicatedService).
 		Action(UpdateDedicatedServer).Undo(UndoUpdateDedicatedServer).
 		Action(BuildDedicatedResult).Undo(UndoBuildDedicatedResult).
 		RegisterTo(registry)
@@ -386,56 +312,6 @@ func UndoLookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn, 
 	return nil
 }
 
-type DeleteDedicatedServiceIn struct {
-	DedicatedServiceID entity.Id
-}
-
-type DeleteDedicatedServiceOut struct {
-	ServiceDeleted bool
-}
-
-func DeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn) (DeleteDedicatedServiceOut, error) {
-	if in.DedicatedServiceID == "" {
-		return DeleteDedicatedServiceOut{ServiceDeleted: false}, nil
-	}
-
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-	if err := fw.DeleteService(ctx, in.DedicatedServiceID); err != nil {
-		return DeleteDedicatedServiceOut{}, fmt.Errorf("deleting service: %w", err)
-	}
-
-	return DeleteDedicatedServiceOut{ServiceDeleted: true}, nil
-}
-
-func UndoDeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn, out DeleteDedicatedServiceOut) error {
-	return nil
-}
-
-type DeleteDedicatedPoolIn struct {
-	DedicatedPoolID entity.Id
-}
-
-type DeleteDedicatedPoolOut struct {
-	PoolDeleted bool `saga:"dedicated_pool_deleted"`
-}
-
-func DeleteDedicatedPool(ctx context.Context, in DeleteDedicatedPoolIn) (DeleteDedicatedPoolOut, error) {
-	if in.DedicatedPoolID == "" {
-		return DeleteDedicatedPoolOut{PoolDeleted: false}, nil
-	}
-
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-	if err := fw.DeleteSandboxPool(ctx, in.DedicatedPoolID); err != nil {
-		return DeleteDedicatedPoolOut{}, fmt.Errorf("deleting sandbox pool: %w", err)
-	}
-
-	return DeleteDedicatedPoolOut{PoolDeleted: true}, nil
-}
-
-func UndoDeleteDedicatedPool(ctx context.Context, in DeleteDedicatedPoolIn, out DeleteDedicatedPoolOut) error {
-	return nil
-}
-
 type DeleteDedicatedServerEntityIn struct {
 	DedicatedServerID   entity.Id
 	DedicatedServerName string
@@ -473,26 +349,26 @@ func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.Provide
 		Using(fw).
 		Action(DecodeDedicatedAttrs).Undo(UndoDecodeDedicatedAttrs).
 		Action(LookupDedicatedServer).Undo(UndoLookupDedicatedServer).
-		Action(DeleteDedicatedService).Undo(UndoDeleteDedicatedService).
-		Action(DeleteDedicatedPool).Undo(UndoDeleteDedicatedPool).
+		Action(dbsaga.DeleteDedicatedService).Undo(dbsaga.UndoDeleteDedicatedService).
+		Action(dbsaga.DeleteDedicatedPool).Undo(dbsaga.UndoDeleteDedicatedPool).
 		Action(DeleteDedicatedServerEntity).Undo(UndoDeleteDedicatedServerEntity).
 		RegisterTo(registry)
 }
 
 func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
-	p.log.Info("provisioning dedicated MySQL",
+	p.Log.Info("provisioning dedicated MySQL",
 		"app", app.Name,
 		"variant", variant.Name)
 
 	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterDedicatedSaga(registry, p.fw, rc); err != nil {
+	if err := RegisterDedicatedSaga(registry, p.Fw, rc); err != nil {
 		return nil, fmt.Errorf("registering dedicated saga: %w", err)
 	}
 
-	storage := p.fw.Storage
-	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-dedicated-mysql").
 		Input("appname", app.Name).
@@ -507,21 +383,21 @@ func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, varian
 		return nil, fmt.Errorf("saga completed but no result was captured")
 	}
 
-	p.log.Info("dedicated MySQL provisioned", "app", app.Name)
+	p.Log.Info("dedicated MySQL provisioned", "app", app.Name)
 	return rc.Result, nil
 }
 
 func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAssociation) error {
-	p.log.Info("deprovisioning dedicated MySQL", "assoc", assoc.ID)
+	p.Log.Info("deprovisioning dedicated MySQL", "assoc", assoc.ID)
 
 	registry := saga.NewRegistry()
 
-	if err := RegisterDeprovisionDedicatedSaga(registry, p.fw); err != nil {
+	if err := RegisterDeprovisionDedicatedSaga(registry, p.Fw); err != nil {
 		return fmt.Errorf("registering deprovision saga: %w", err)
 	}
 
-	storage := p.fw.Storage
-	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-dedicated-mysql").
 		Input("assocentity", assoc.Entity).
@@ -530,6 +406,6 @@ func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAs
 		return err
 	}
 
-	p.log.Info("dedicated MySQL deprovisioned", "assoc", assoc.ID)
+	p.Log.Info("dedicated MySQL deprovisioned", "assoc", assoc.ID)
 	return nil
 }

--- a/pkg/addon/mysql/dedicated.go
+++ b/pkg/addon/mysql/dedicated.go
@@ -38,12 +38,12 @@ type GenerateCredentialsIn struct {
 }
 
 type GenerateCredentialsOut struct {
-	Password     string
-	RootPassword string
-	DatabaseName string
-	Username     string
-	ServiceName  string
-	ServerName   string
+	Password     string `saga:"password"`
+	RootPassword string `saga:"rootpassword"`
+	DatabaseName string `saga:"databasename"`
+	Username     string `saga:"username"`
+	ServiceName  string `saga:"servicename"`
+	ServerName   string `saga:"servername"`
 }
 
 func GenerateCredentials(ctx context.Context, in GenerateCredentialsIn) (GenerateCredentialsOut, error) {
@@ -62,13 +62,13 @@ func UndoGenerateCredentials(ctx context.Context, in GenerateCredentialsIn, out 
 }
 
 type CreateMysqlServerIn struct {
-	ServerName   string
-	VariantName  string
-	RootPassword string
+	ServerName   string `saga:"servername"`
+	VariantName  string `saga:"variantname"`
+	RootPassword string `saga:"rootpassword"`
 }
 
 type CreateMysqlServerOut struct {
-	ServerID entity.Id
+	ServerID entity.Id `saga:"serverid"`
 }
 
 func CreateMysqlServer(ctx context.Context, in CreateMysqlServerIn) (CreateMysqlServerOut, error) {
@@ -96,17 +96,17 @@ func UndoCreateMysqlServer(ctx context.Context, in CreateMysqlServerIn, out Crea
 }
 
 type CreateDedicatedPoolIn struct {
-	ServerName    string
-	AppName       string
-	DatabaseName  string
-	Username      string
-	Password      string
-	RootPassword  string
-	VariantConfig map[string]string
+	ServerName    string            `saga:"servername"`
+	AppName       string            `saga:"appname"`
+	DatabaseName  string            `saga:"databasename"`
+	Username      string            `saga:"username"`
+	Password      string            `saga:"password"`
+	RootPassword  string            `saga:"rootpassword"`
+	VariantConfig map[string]string `saga:"variantconfig"`
 }
 
 type CreateDedicatedPoolOut struct {
-	PoolID entity.Id
+	PoolID entity.Id `saga:"poolid"`
 }
 
 func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateDedicatedPoolOut, error) {
@@ -165,11 +165,11 @@ func UndoCreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn, out 
 }
 
 type UpdateDedicatedServerIn struct {
-	ServerID     entity.Id
-	PoolID       entity.Id
-	ServiceID    entity.Id
-	VariantName  string
-	RootPassword string
+	ServerID     entity.Id `saga:"serverid"`
+	PoolID       entity.Id `saga:"poolid"`
+	ServiceID    entity.Id `saga:"serviceid"`
+	VariantName  string    `saga:"variantname"`
+	RootPassword string    `saga:"rootpassword"`
 }
 
 type UpdateDedicatedServerOut struct {
@@ -202,11 +202,11 @@ func UndoUpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn, 
 }
 
 type BuildDedicatedResultIn struct {
-	ServiceHost  string
-	Username     string
-	Password     string
-	DatabaseName string
-	ServerID     entity.Id
+	ServiceHost  string    `saga:"servicehost"`
+	Username     string    `saga:"username"`
+	Password     string    `saga:"password"`
+	DatabaseName string    `saga:"databasename"`
+	ServerID     entity.Id `saga:"serverid"`
 }
 
 type BuildDedicatedResultOut struct {
@@ -258,7 +258,7 @@ type DecodeDedicatedAttrsIn struct {
 }
 
 type DecodeDedicatedAttrsOut struct {
-	DedicatedServerID entity.Id
+	DedicatedServerID entity.Id `saga:"dedicatedserverid"`
 }
 
 func DecodeDedicatedAttrs(ctx context.Context, in DecodeDedicatedAttrsIn) (DecodeDedicatedAttrsOut, error) {
@@ -279,13 +279,13 @@ func UndoDecodeDedicatedAttrs(ctx context.Context, in DecodeDedicatedAttrsIn, ou
 }
 
 type LookupDedicatedServerIn struct {
-	DedicatedServerID entity.Id
+	DedicatedServerID entity.Id `saga:"dedicatedserverid"`
 }
 
 type LookupDedicatedServerOut struct {
-	DedicatedServiceID  entity.Id
-	DedicatedPoolID     entity.Id
-	DedicatedServerName string
+	DedicatedServiceID  entity.Id `saga:"dedicatedserviceid"`
+	DedicatedPoolID     entity.Id `saga:"dedicatedpoolid"`
+	DedicatedServerName string    `saga:"dedicatedservername"`
 }
 
 func LookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn) (LookupDedicatedServerOut, error) {
@@ -313,8 +313,8 @@ func UndoLookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn, 
 }
 
 type DeleteDedicatedServerEntityIn struct {
-	DedicatedServerID   entity.Id
-	DedicatedServerName string
+	DedicatedServerID   entity.Id `saga:"dedicatedserverid"`
+	DedicatedServerName string    `saga:"dedicatedservername"`
 
 	PoolCleanedUp saga.Edge `saga:"dedicated_pool_deleted"`
 }

--- a/pkg/addon/mysql/dedicated.go
+++ b/pkg/addon/mysql/dedicated.go
@@ -161,13 +161,18 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 
 func UndoCreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn, out CreateDedicatedPoolOut) error {
 	fw := saga.Get[*addon.ProviderFramework](ctx)
-	return fw.DeleteSandboxPool(ctx, out.PoolID)
+	if err := fw.DeleteSandboxPool(ctx, out.PoolID); err != nil {
+		return err
+	}
+	diskName := fmt.Sprintf("my-%s-data", in.ServerName)
+	return fw.DeleteDiskByName(ctx, diskName)
 }
 
 type UpdateDedicatedServerIn struct {
 	ServerID     entity.Id `saga:"serverid"`
 	PoolID       entity.Id `saga:"poolid"`
 	ServiceID    entity.Id `saga:"serviceid"`
+	ServiceHost  string    `saga:"servicehost"`
 	VariantName  string    `saga:"variantname"`
 	RootPassword string    `saga:"rootpassword"`
 }

--- a/pkg/addon/mysql/dedicated.go
+++ b/pkg/addon/mysql/dedicated.go
@@ -1,0 +1,532 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/saga"
+)
+
+const mysqlPort = 3306
+
+func mysqlContainerPorts() []compute_v1alpha.SandboxSpecContainerPort {
+	return []compute_v1alpha.SandboxSpecContainerPort{
+		{
+			Name:     "mysql",
+			Port:     mysqlPort,
+			Protocol: compute_v1alpha.SandboxSpecContainerPortTCP,
+		},
+	}
+}
+
+type resultCapture struct {
+	Result *addon.ProvisionResult
+}
+
+// --- Dedicated Provisioning Saga Actions ---
+
+type GenerateCredentialsIn struct {
+	AppName string
+}
+
+type GenerateCredentialsOut struct {
+	Password     string
+	DatabaseName string
+	Username     string
+	ServiceName  string
+	ServerName   string
+}
+
+func GenerateCredentials(ctx context.Context, in GenerateCredentialsIn) (GenerateCredentialsOut, error) {
+	return GenerateCredentialsOut{
+		Password:     idgen.Gen("pw"),
+		DatabaseName: sanitizeIdentifier(in.AppName),
+		Username:     sanitizeIdentifier(in.AppName),
+		ServiceName:  fmt.Sprintf("%s-mysql", in.AppName),
+		ServerName:   fmt.Sprintf("my-%s-%s", in.AppName, idgen.Gen("s")),
+	}, nil
+}
+
+func UndoGenerateCredentials(ctx context.Context, in GenerateCredentialsIn, out GenerateCredentialsOut) error {
+	return nil
+}
+
+type CreateMysqlServerIn struct {
+	ServerName  string
+	VariantName string
+	Password    string
+}
+
+type CreateMysqlServerOut struct {
+	ServerID entity.Id
+}
+
+func CreateMysqlServer(ctx context.Context, in CreateMysqlServerIn) (CreateMysqlServerOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	server := &addon_v1alpha.MysqlServer{
+		AddonName:        AddonName,
+		Variant:          in.VariantName,
+		Status:           "provisioning",
+		AssociationCount: 1,
+		RootPassword:     in.Password,
+	}
+
+	serverID, err := fw.EC.Create(ctx, in.ServerName, server)
+	if err != nil {
+		return CreateMysqlServerOut{}, fmt.Errorf("creating mysql server entity: %w", err)
+	}
+
+	return CreateMysqlServerOut{ServerID: serverID}, nil
+}
+
+func UndoCreateMysqlServer(ctx context.Context, in CreateMysqlServerIn, out CreateMysqlServerOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.EC.Delete(ctx, out.ServerID)
+}
+
+type CreateDedicatedPoolIn struct {
+	ServerName    string
+	AppName       string
+	DatabaseName  string
+	Username      string
+	Password      string
+	VariantConfig map[string]string
+}
+
+type CreateDedicatedPoolOut struct {
+	PoolID entity.Id
+}
+
+func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateDedicatedPoolOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	labels := types.LabelSet(
+		"addon", AddonName,
+		"app", in.AppName,
+		"server", in.ServerName,
+	)
+
+	sizeGb := parseStorageGb(in.VariantConfig[ConfigStorage])
+	diskName := fmt.Sprintf("my-%s-data", in.ServerName)
+	mountPath := "/var/lib/mysql"
+
+	env := []string{
+		"MYSQL_ROOT_PASSWORD=" + in.Password,
+		"MYSQL_DATABASE=" + in.DatabaseName,
+		"MYSQL_USER=" + in.Username,
+		"MYSQL_PASSWORD=" + in.Password,
+	}
+
+	poolID, err := fw.CreateSandboxPool(ctx, addon.CreateSandboxPoolSpec{
+		Name:             in.ServerName,
+		Image:            DefaultImage,
+		Env:              env,
+		Ports:            mysqlContainerPorts(),
+		DesiredInstances: 1,
+		Labels:           labels,
+		SandboxPrefix:    fmt.Sprintf("%s-my", in.AppName),
+		Mounts: []compute_v1alpha.SandboxSpecContainerMount{
+			{Source: "mydata", Destination: mountPath},
+		},
+		Volumes: []compute_v1alpha.SandboxSpecVolume{
+			{
+				Name:         "mydata",
+				Provider:     "miren",
+				DiskName:     diskName,
+				MountPath:    mountPath,
+				SizeGb:       sizeGb,
+				Filesystem:   "ext4",
+				LeaseTimeout: "5m",
+			},
+		},
+	})
+	if err != nil {
+		return CreateDedicatedPoolOut{}, fmt.Errorf("creating sandbox pool: %w", err)
+	}
+
+	return CreateDedicatedPoolOut{PoolID: poolID}, nil
+}
+
+func UndoCreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn, out CreateDedicatedPoolOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.DeleteSandboxPool(ctx, out.PoolID)
+}
+
+type WaitForDedicatedPoolIn struct {
+	PoolID entity.Id
+}
+
+type WaitForDedicatedPoolOut struct {
+	Ready bool
+}
+
+func WaitForDedicatedPool(ctx context.Context, in WaitForDedicatedPoolIn) (WaitForDedicatedPoolOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	if err := fw.WaitForPool(ctx, in.PoolID, poolReadyTimeout); err != nil {
+		return WaitForDedicatedPoolOut{}, fmt.Errorf("waiting for mysql pool: %w", err)
+	}
+
+	return WaitForDedicatedPoolOut{Ready: true}, nil
+}
+
+func UndoWaitForDedicatedPool(ctx context.Context, in WaitForDedicatedPoolIn, out WaitForDedicatedPoolOut) error {
+	return nil
+}
+
+type CreateDedicatedServiceIn struct {
+	ServiceName string
+	AppName     string
+	ServerName  string
+}
+
+type CreateDedicatedServiceOut struct {
+	ServiceID entity.Id
+}
+
+func CreateDedicatedService(ctx context.Context, in CreateDedicatedServiceIn) (CreateDedicatedServiceOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	labels := types.LabelSet(
+		"addon", AddonName,
+		"app", in.AppName,
+		"server", in.ServerName,
+	)
+
+	svcID, err := fw.CreateService(ctx, in.ServiceName, labels, mysqlPort)
+	if err != nil {
+		return CreateDedicatedServiceOut{}, fmt.Errorf("creating service: %w", err)
+	}
+
+	return CreateDedicatedServiceOut{ServiceID: svcID}, nil
+}
+
+func UndoCreateDedicatedService(ctx context.Context, in CreateDedicatedServiceIn, out CreateDedicatedServiceOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.DeleteService(ctx, out.ServiceID)
+}
+
+type WaitForDedicatedServiceIn struct {
+	ServiceID entity.Id
+}
+
+type WaitForDedicatedServiceOut struct {
+	ServiceHost string
+}
+
+func WaitForDedicatedService(ctx context.Context, in WaitForDedicatedServiceIn) (WaitForDedicatedServiceOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	serviceHost, err := fw.WaitForServiceAddress(ctx, in.ServiceID, poolReadyTimeout)
+	if err != nil {
+		return WaitForDedicatedServiceOut{}, fmt.Errorf("waiting for dedicated service address: %w", err)
+	}
+
+	return WaitForDedicatedServiceOut{ServiceHost: serviceHost}, nil
+}
+
+func UndoWaitForDedicatedService(ctx context.Context, in WaitForDedicatedServiceIn, out WaitForDedicatedServiceOut) error {
+	return nil
+}
+
+type UpdateDedicatedServerIn struct {
+	ServerID    entity.Id
+	PoolID      entity.Id
+	ServiceID   entity.Id
+	VariantName string
+	Password    string
+}
+
+type UpdateDedicatedServerOut struct {
+	Updated bool
+}
+
+func UpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn) (UpdateDedicatedServerOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	server := &addon_v1alpha.MysqlServer{
+		AddonName:        AddonName,
+		Variant:          in.VariantName,
+		Status:           "active",
+		AssociationCount: 1,
+		RootPassword:     in.Password,
+		SandboxPool:      in.PoolID,
+		Service:          in.ServiceID,
+	}
+	server.ID = in.ServerID
+
+	if err := fw.EC.Update(ctx, server); err != nil {
+		return UpdateDedicatedServerOut{}, fmt.Errorf("updating mysql server: %w", err)
+	}
+
+	return UpdateDedicatedServerOut{Updated: true}, nil
+}
+
+func UndoUpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn, out UpdateDedicatedServerOut) error {
+	return nil
+}
+
+type BuildDedicatedResultIn struct {
+	ServiceHost  string
+	Username     string
+	Password     string
+	DatabaseName string
+	ServerID     entity.Id
+}
+
+type BuildDedicatedResultOut struct {
+	Done bool
+}
+
+func BuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn) (BuildDedicatedResultOut, error) {
+	rc := saga.Get[*resultCapture](ctx)
+
+	envVars := buildEnvVars(in.ServiceHost, mysqlPort, in.Username, in.Password, in.DatabaseName)
+
+	dedicatedData := &addon_v1alpha.MysqlDedicatedData{
+		MysqlServer: in.ServerID,
+	}
+
+	rc.Result = &addon.ProvisionResult{
+		EnvVars: envVars,
+		Attrs:   dedicatedData.Encode(),
+	}
+
+	return BuildDedicatedResultOut{Done: true}, nil
+}
+
+func UndoBuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn, out BuildDedicatedResultOut) error {
+	return nil
+}
+
+func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+	return saga.Define("provision-dedicated-mysql").
+		Using(fw).
+		Using(rc).
+		Action(GenerateCredentials).Undo(UndoGenerateCredentials).
+		Action(CreateMysqlServer).Undo(UndoCreateMysqlServer).
+		Action(CreateDedicatedPool).Undo(UndoCreateDedicatedPool).
+		Action(WaitForDedicatedPool).Undo(UndoWaitForDedicatedPool).
+		Action(CreateDedicatedService).Undo(UndoCreateDedicatedService).
+		Action(WaitForDedicatedService).Undo(UndoWaitForDedicatedService).
+		Action(UpdateDedicatedServer).Undo(UndoUpdateDedicatedServer).
+		Action(BuildDedicatedResult).Undo(UndoBuildDedicatedResult).
+		RegisterTo(registry)
+}
+
+// --- Dedicated Deprovisioning Saga Actions ---
+
+type DecodeDedicatedAttrsIn struct {
+	AssocEntity *entity.Entity `saga:"assocentity"`
+}
+
+type DecodeDedicatedAttrsOut struct {
+	DedicatedServerID entity.Id
+}
+
+func DecodeDedicatedAttrs(ctx context.Context, in DecodeDedicatedAttrsIn) (DecodeDedicatedAttrsOut, error) {
+	var data addon_v1alpha.MysqlDedicatedData
+	if in.AssocEntity != nil {
+		data.Decode(in.AssocEntity)
+	}
+
+	if data.MysqlServer == "" {
+		return DecodeDedicatedAttrsOut{}, fmt.Errorf("no mysql server ref found")
+	}
+
+	return DecodeDedicatedAttrsOut{DedicatedServerID: data.MysqlServer}, nil
+}
+
+func UndoDecodeDedicatedAttrs(ctx context.Context, in DecodeDedicatedAttrsIn, out DecodeDedicatedAttrsOut) error {
+	return nil
+}
+
+type LookupDedicatedServerIn struct {
+	DedicatedServerID entity.Id
+}
+
+type LookupDedicatedServerOut struct {
+	DedicatedServiceID  entity.Id
+	DedicatedPoolID     entity.Id
+	DedicatedServerName string
+}
+
+func LookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn) (LookupDedicatedServerOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.MysqlServer
+	if err := fw.EC.GetById(ctx, in.DedicatedServerID, &server); err != nil {
+		return LookupDedicatedServerOut{}, fmt.Errorf("looking up mysql server: %w", err)
+	}
+
+	var meta core_v1alpha.Metadata
+	if err := fw.EC.GetById(ctx, in.DedicatedServerID, &meta); err != nil {
+		return LookupDedicatedServerOut{}, fmt.Errorf("looking up server metadata: %w", err)
+	}
+
+	return LookupDedicatedServerOut{
+		DedicatedServiceID:  server.Service,
+		DedicatedPoolID:     server.SandboxPool,
+		DedicatedServerName: meta.Name,
+	}, nil
+}
+
+func UndoLookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn, out LookupDedicatedServerOut) error {
+	return nil
+}
+
+type DeleteDedicatedServiceIn struct {
+	DedicatedServiceID entity.Id
+}
+
+type DeleteDedicatedServiceOut struct {
+	ServiceDeleted bool
+}
+
+func DeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn) (DeleteDedicatedServiceOut, error) {
+	if in.DedicatedServiceID == "" {
+		return DeleteDedicatedServiceOut{ServiceDeleted: false}, nil
+	}
+
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	if err := fw.DeleteService(ctx, in.DedicatedServiceID); err != nil {
+		return DeleteDedicatedServiceOut{}, fmt.Errorf("deleting service: %w", err)
+	}
+
+	return DeleteDedicatedServiceOut{ServiceDeleted: true}, nil
+}
+
+func UndoDeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn, out DeleteDedicatedServiceOut) error {
+	return nil
+}
+
+type DeleteDedicatedPoolIn struct {
+	DedicatedPoolID entity.Id
+}
+
+type DeleteDedicatedPoolOut struct {
+	PoolDeleted bool `saga:"dedicated_pool_deleted"`
+}
+
+func DeleteDedicatedPool(ctx context.Context, in DeleteDedicatedPoolIn) (DeleteDedicatedPoolOut, error) {
+	if in.DedicatedPoolID == "" {
+		return DeleteDedicatedPoolOut{PoolDeleted: false}, nil
+	}
+
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	if err := fw.DeleteSandboxPool(ctx, in.DedicatedPoolID); err != nil {
+		return DeleteDedicatedPoolOut{}, fmt.Errorf("deleting sandbox pool: %w", err)
+	}
+
+	return DeleteDedicatedPoolOut{PoolDeleted: true}, nil
+}
+
+func UndoDeleteDedicatedPool(ctx context.Context, in DeleteDedicatedPoolIn, out DeleteDedicatedPoolOut) error {
+	return nil
+}
+
+type DeleteDedicatedServerEntityIn struct {
+	DedicatedServerID   entity.Id
+	DedicatedServerName string
+
+	PoolCleanedUp saga.Edge `saga:"dedicated_pool_deleted"`
+}
+
+type DeleteDedicatedServerEntityOut struct {
+	ServerDeleted bool
+}
+
+func DeleteDedicatedServerEntity(ctx context.Context, in DeleteDedicatedServerEntityIn) (DeleteDedicatedServerEntityOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	if in.DedicatedServerName != "" {
+		diskName := fmt.Sprintf("my-%s-data", in.DedicatedServerName)
+		if err := fw.DeleteDiskByName(ctx, diskName); err != nil {
+			return DeleteDedicatedServerEntityOut{}, fmt.Errorf("deleting dedicated data disk %s: %w", diskName, err)
+		}
+	}
+
+	if err := fw.EC.Delete(ctx, in.DedicatedServerID); err != nil {
+		return DeleteDedicatedServerEntityOut{}, fmt.Errorf("deleting mysql server: %w", err)
+	}
+
+	return DeleteDedicatedServerEntityOut{ServerDeleted: true}, nil
+}
+
+func UndoDeleteDedicatedServerEntity(ctx context.Context, in DeleteDedicatedServerEntityIn, out DeleteDedicatedServerEntityOut) error {
+	return nil
+}
+
+func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
+	return saga.Define("deprovision-dedicated-mysql").
+		Using(fw).
+		Action(DecodeDedicatedAttrs).Undo(UndoDecodeDedicatedAttrs).
+		Action(LookupDedicatedServer).Undo(UndoLookupDedicatedServer).
+		Action(DeleteDedicatedService).Undo(UndoDeleteDedicatedService).
+		Action(DeleteDedicatedPool).Undo(UndoDeleteDedicatedPool).
+		Action(DeleteDedicatedServerEntity).Undo(UndoDeleteDedicatedServerEntity).
+		RegisterTo(registry)
+}
+
+func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+	p.log.Info("provisioning dedicated MySQL",
+		"app", app.Name,
+		"variant", variant.Name)
+
+	rc := &resultCapture{}
+	registry := saga.NewRegistry()
+
+	if err := RegisterDedicatedSaga(registry, p.fw, rc); err != nil {
+		return nil, fmt.Errorf("registering dedicated saga: %w", err)
+	}
+
+	storage := p.fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+
+	err := executor.Start("provision-dedicated-mysql").
+		Input("appname", app.Name).
+		Input("variantname", variant.Name).
+		Input("variantconfig", variant.Config).
+		Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if rc.Result == nil {
+		return nil, fmt.Errorf("saga completed but no result was captured")
+	}
+
+	p.log.Info("dedicated MySQL provisioned", "app", app.Name)
+	return rc.Result, nil
+}
+
+func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAssociation) error {
+	p.log.Info("deprovisioning dedicated MySQL", "assoc", assoc.ID)
+
+	registry := saga.NewRegistry()
+
+	if err := RegisterDeprovisionDedicatedSaga(registry, p.fw); err != nil {
+		return fmt.Errorf("registering deprovision saga: %w", err)
+	}
+
+	storage := p.fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+
+	err := executor.Start("deprovision-dedicated-mysql").
+		Input("assocentity", assoc.Entity).
+		Execute(ctx)
+	if err != nil {
+		return err
+	}
+
+	p.log.Info("dedicated MySQL deprovisioned", "assoc", assoc.ID)
+	return nil
+}

--- a/pkg/addon/mysql/dedicated.go
+++ b/pkg/addon/mysql/dedicated.go
@@ -38,6 +38,7 @@ type GenerateCredentialsIn struct {
 
 type GenerateCredentialsOut struct {
 	Password     string
+	RootPassword string
 	DatabaseName string
 	Username     string
 	ServiceName  string
@@ -47,6 +48,7 @@ type GenerateCredentialsOut struct {
 func GenerateCredentials(ctx context.Context, in GenerateCredentialsIn) (GenerateCredentialsOut, error) {
 	return GenerateCredentialsOut{
 		Password:     idgen.Gen("pw"),
+		RootPassword: idgen.Gen("rt"),
 		DatabaseName: sanitizeIdentifier(in.AppName),
 		Username:     sanitizeIdentifier(in.AppName),
 		ServiceName:  fmt.Sprintf("%s-mysql", in.AppName),
@@ -59,9 +61,9 @@ func UndoGenerateCredentials(ctx context.Context, in GenerateCredentialsIn, out 
 }
 
 type CreateMysqlServerIn struct {
-	ServerName  string
-	VariantName string
-	Password    string
+	ServerName   string
+	VariantName  string
+	RootPassword string
 }
 
 type CreateMysqlServerOut struct {
@@ -76,7 +78,7 @@ func CreateMysqlServer(ctx context.Context, in CreateMysqlServerIn) (CreateMysql
 		Variant:          in.VariantName,
 		Status:           "provisioning",
 		AssociationCount: 1,
-		RootPassword:     in.Password,
+		RootPassword:     in.RootPassword,
 	}
 
 	serverID, err := fw.EC.Create(ctx, in.ServerName, server)
@@ -98,6 +100,7 @@ type CreateDedicatedPoolIn struct {
 	DatabaseName  string
 	Username      string
 	Password      string
+	RootPassword  string
 	VariantConfig map[string]string
 }
 
@@ -119,7 +122,7 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 	mountPath := "/var/lib/mysql"
 
 	env := []string{
-		"MYSQL_ROOT_PASSWORD=" + in.Password,
+		"MYSQL_ROOT_PASSWORD=" + in.RootPassword,
 		"MYSQL_DATABASE=" + in.DatabaseName,
 		"MYSQL_USER=" + in.Username,
 		"MYSQL_PASSWORD=" + in.Password,
@@ -238,11 +241,11 @@ func UndoWaitForDedicatedService(ctx context.Context, in WaitForDedicatedService
 }
 
 type UpdateDedicatedServerIn struct {
-	ServerID    entity.Id
-	PoolID      entity.Id
-	ServiceID   entity.Id
-	VariantName string
-	Password    string
+	ServerID     entity.Id
+	PoolID       entity.Id
+	ServiceID    entity.Id
+	VariantName  string
+	RootPassword string
 }
 
 type UpdateDedicatedServerOut struct {
@@ -257,7 +260,7 @@ func UpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn) (Upd
 		Variant:          in.VariantName,
 		Status:           "active",
 		AssociationCount: 1,
-		RootPassword:     in.Password,
+		RootPassword:     in.RootPassword,
 		SandboxPool:      in.PoolID,
 		Service:          in.ServiceID,
 	}

--- a/pkg/addon/mysql/dedicated_test.go
+++ b/pkg/addon/mysql/dedicated_test.go
@@ -1,0 +1,98 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/saga"
+)
+
+func TestRegisterDedicatedSaga(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+	rc := &resultCapture{}
+
+	err := RegisterDedicatedSaga(registry, fw, rc)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("provision-dedicated-mysql")
+	require.True(t, ok)
+	assert.Equal(t, "provision-dedicated-mysql", def.Name)
+	assert.Len(t, def.Actions, 8)
+}
+
+func TestRegisterDeprovisionDedicatedSaga(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+
+	err := RegisterDeprovisionDedicatedSaga(registry, fw)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("deprovision-dedicated-mysql")
+	require.True(t, ok)
+	assert.Equal(t, "deprovision-dedicated-mysql", def.Name)
+	assert.Len(t, def.Actions, 5)
+}
+
+func TestDeprovisionDedicatedSagaOrder(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+
+	err := RegisterDeprovisionDedicatedSaga(registry, fw)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("deprovision-dedicated-mysql")
+	require.True(t, ok)
+
+	order := def.ExecutionOrder()
+
+	indexOf := func(name string) int {
+		for i, n := range order {
+			if n == name {
+				return i
+			}
+		}
+		t.Fatalf("action %q not found in order %v", name, order)
+		return -1
+	}
+
+	assert.Less(t, indexOf("decode-dedicated-attrs"), indexOf("lookup-dedicated-server"),
+		"decode-dedicated-attrs must come before lookup-dedicated-server")
+	assert.Less(t, indexOf("lookup-dedicated-server"), indexOf("delete-dedicated-service"),
+		"lookup-dedicated-server must come before delete-dedicated-service")
+	assert.Less(t, indexOf("lookup-dedicated-server"), indexOf("delete-dedicated-pool"),
+		"lookup-dedicated-server must come before delete-dedicated-pool")
+	assert.Less(t, indexOf("delete-dedicated-pool"), indexOf("delete-dedicated-server-entity"),
+		"delete-dedicated-pool must come before delete-dedicated-server-entity")
+}
+
+func TestDedicatedSagaActionOrder(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+	rc := &resultCapture{}
+
+	err := RegisterDedicatedSaga(registry, fw, rc)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("provision-dedicated-mysql")
+	require.True(t, ok)
+
+	expectedActions := []string{
+		"generate-credentials",
+		"create-mysql-server",
+		"create-dedicated-pool",
+		"wait-for-dedicated-pool",
+		"create-dedicated-service",
+		"wait-for-dedicated-service",
+		"update-dedicated-server",
+		"build-dedicated-result",
+	}
+
+	for _, name := range expectedActions {
+		_, exists := def.Actions[name]
+		assert.True(t, exists, "expected action %q to exist", name)
+	}
+}

--- a/pkg/addon/mysql/myutil.go
+++ b/pkg/addon/mysql/myutil.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
+
+	"miren.dev/runtime/pkg/addon"
 )
 
 const (
@@ -18,27 +20,7 @@ const (
 const maxMysqlIdentLen = 32
 
 func sanitizeIdentifier(name string) string {
-	result := make([]byte, 0, len(name))
-	for i := 0; i < len(name); i++ {
-		c := name[i]
-		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' {
-			result = append(result, c)
-		} else if c >= 'A' && c <= 'Z' {
-			result = append(result, c+32) // lowercase
-		} else if c == '-' {
-			result = append(result, '_')
-		}
-	}
-	if len(result) == 0 {
-		return "app"
-	}
-	if result[0] >= '0' && result[0] <= '9' {
-		result = append([]byte{'a'}, result...)
-	}
-	if len(result) > maxMysqlIdentLen {
-		result = result[:maxMysqlIdentLen]
-	}
-	return string(result)
+	return addon.SanitizeIdentifier(name, maxMysqlIdentLen)
 }
 
 // quoteIdentifier wraps a MySQL identifier in backticks, escaping any

--- a/pkg/addon/mysql/myutil.go
+++ b/pkg/addon/mysql/myutil.go
@@ -55,17 +55,27 @@ func connectAsRoot(ctx context.Context, host string, password string) (*sql.DB, 
 	return connectMysql(ctx, host, mysqlPort, defaultMysqlUser, password, defaultMysqlDB)
 }
 
+// escapeMysqlString escapes a value for use in a MySQL single-quoted string
+// literal. Backslashes must be doubled first (MySQL treats \ as an escape
+// character by default), then single quotes are doubled.
+func escapeMysqlString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "'", "''")
+	return s
+}
+
 func createMysqlUser(ctx context.Context, db *sql.DB, username, password string) error {
+	escaped := escapeMysqlString(password)
 	_, err := db.ExecContext(ctx,
 		fmt.Sprintf("CREATE USER IF NOT EXISTS %s@'%%' IDENTIFIED BY '%s'",
-			quoteIdentifier(username), strings.ReplaceAll(password, "'", "''")))
+			quoteIdentifier(username), escaped))
 	if err != nil {
 		return fmt.Errorf("creating user %s: %w", username, err)
 	}
 	// Ensure password is current even if user already existed from a prior saga attempt.
 	_, err = db.ExecContext(ctx,
 		fmt.Sprintf("ALTER USER %s@'%%' IDENTIFIED BY '%s'",
-			quoteIdentifier(username), strings.ReplaceAll(password, "'", "''")))
+			quoteIdentifier(username), escaped))
 	if err != nil {
 		return fmt.Errorf("updating password for user %s: %w", username, err)
 	}

--- a/pkg/addon/mysql/myutil.go
+++ b/pkg/addon/mysql/myutil.go
@@ -14,6 +14,9 @@ const (
 	defaultMysqlUser = "root"
 )
 
+// maxMysqlIdentLen is the maximum length of a MySQL username or database name.
+const maxMysqlIdentLen = 32
+
 func sanitizeIdentifier(name string) string {
 	result := make([]byte, 0, len(name))
 	for i := 0; i < len(name); i++ {
@@ -31,6 +34,9 @@ func sanitizeIdentifier(name string) string {
 	}
 	if result[0] >= '0' && result[0] <= '9' {
 		result = append([]byte{'a'}, result...)
+	}
+	if len(result) > maxMysqlIdentLen {
+		result = result[:maxMysqlIdentLen]
 	}
 	return string(result)
 }

--- a/pkg/addon/mysql/myutil.go
+++ b/pkg/addon/mysql/myutil.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	_ "github.com/go-sql-driver/mysql"
+	"github.com/go-sql-driver/mysql"
 
 	"miren.dev/runtime/pkg/addon"
 )
@@ -30,8 +30,15 @@ func quoteIdentifier(name string) string {
 }
 
 func connectMysql(ctx context.Context, host string, port int, user, password, database string) (*sql.DB, error) {
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=false", user, password, host, port, database)
-	db, err := sql.Open("mysql", dsn)
+	cfg := mysql.NewConfig()
+	cfg.User = user
+	cfg.Passwd = password
+	cfg.Net = "tcp"
+	cfg.Addr = fmt.Sprintf("%s:%d", host, port)
+	cfg.DBName = database
+	cfg.TLSConfig = "false"
+
+	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return nil, fmt.Errorf("opening mysql connection to %s:%d: %w", host, port, err)
 	}
@@ -50,17 +57,24 @@ func connectAsRoot(ctx context.Context, host string, password string) (*sql.DB, 
 
 func createMysqlUser(ctx context.Context, db *sql.DB, username, password string) error {
 	_, err := db.ExecContext(ctx,
-		fmt.Sprintf("CREATE USER %s@'%%' IDENTIFIED BY '%s'",
+		fmt.Sprintf("CREATE USER IF NOT EXISTS %s@'%%' IDENTIFIED BY '%s'",
 			quoteIdentifier(username), strings.ReplaceAll(password, "'", "''")))
 	if err != nil {
 		return fmt.Errorf("creating user %s: %w", username, err)
+	}
+	// Ensure password is current even if user already existed from a prior saga attempt.
+	_, err = db.ExecContext(ctx,
+		fmt.Sprintf("ALTER USER %s@'%%' IDENTIFIED BY '%s'",
+			quoteIdentifier(username), strings.ReplaceAll(password, "'", "''")))
+	if err != nil {
+		return fmt.Errorf("updating password for user %s: %w", username, err)
 	}
 	return nil
 }
 
 func createMysqlDatabase(ctx context.Context, db *sql.DB, dbname, owner string) error {
 	_, err := db.ExecContext(ctx,
-		fmt.Sprintf("CREATE DATABASE %s", quoteIdentifier(dbname)))
+		fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteIdentifier(dbname)))
 	if err != nil {
 		return fmt.Errorf("creating database %s: %w", dbname, err)
 	}

--- a/pkg/addon/mysql/myutil.go
+++ b/pkg/addon/mysql/myutil.go
@@ -1,0 +1,130 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+const (
+	defaultMysqlDB   = "mysql"
+	defaultMysqlUser = "root"
+)
+
+func sanitizeIdentifier(name string) string {
+	result := make([]byte, 0, len(name))
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' {
+			result = append(result, c)
+		} else if c >= 'A' && c <= 'Z' {
+			result = append(result, c+32) // lowercase
+		} else if c == '-' {
+			result = append(result, '_')
+		}
+	}
+	if len(result) == 0 {
+		return "app"
+	}
+	if result[0] >= '0' && result[0] <= '9' {
+		result = append([]byte{'a'}, result...)
+	}
+	return string(result)
+}
+
+// quoteIdentifier wraps a MySQL identifier in backticks, escaping any
+// embedded backticks by doubling them.
+func quoteIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+func connectMysql(ctx context.Context, host string, port int, user, password, database string) (*sql.DB, error) {
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=false", user, password, host, port, database)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening mysql connection to %s:%d: %w", host, port, err)
+	}
+
+	if err := db.PingContext(ctx); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("connecting to mysql at %s:%d: %w", host, port, err)
+	}
+
+	return db, nil
+}
+
+func connectAsRoot(ctx context.Context, host string, password string) (*sql.DB, error) {
+	return connectMysql(ctx, host, mysqlPort, defaultMysqlUser, password, defaultMysqlDB)
+}
+
+func createMysqlUser(ctx context.Context, db *sql.DB, username, password string) error {
+	_, err := db.ExecContext(ctx,
+		fmt.Sprintf("CREATE USER %s@'%%' IDENTIFIED BY '%s'",
+			quoteIdentifier(username), strings.ReplaceAll(password, "'", "''")))
+	if err != nil {
+		return fmt.Errorf("creating user %s: %w", username, err)
+	}
+	return nil
+}
+
+func createMysqlDatabase(ctx context.Context, db *sql.DB, dbname, owner string) error {
+	_, err := db.ExecContext(ctx,
+		fmt.Sprintf("CREATE DATABASE %s", quoteIdentifier(dbname)))
+	if err != nil {
+		return fmt.Errorf("creating database %s: %w", dbname, err)
+	}
+
+	_, err = db.ExecContext(ctx,
+		fmt.Sprintf("GRANT ALL PRIVILEGES ON %s.* TO %s@'%%'",
+			quoteIdentifier(dbname), quoteIdentifier(owner)))
+	if err != nil {
+		return fmt.Errorf("granting privileges on %s to %s: %w", dbname, owner, err)
+	}
+
+	_, err = db.ExecContext(ctx, "FLUSH PRIVILEGES")
+	if err != nil {
+		return fmt.Errorf("flushing privileges: %w", err)
+	}
+
+	return nil
+}
+
+func dropMysqlDatabase(ctx context.Context, db *sql.DB, dbname string) error {
+	_, err := db.ExecContext(ctx,
+		fmt.Sprintf("DROP DATABASE IF EXISTS %s", quoteIdentifier(dbname)))
+	if err != nil {
+		return fmt.Errorf("dropping database %s: %w", dbname, err)
+	}
+	return nil
+}
+
+func dropMysqlUser(ctx context.Context, db *sql.DB, username string) error {
+	_, err := db.ExecContext(ctx,
+		fmt.Sprintf("DROP USER IF EXISTS %s@'%%'", quoteIdentifier(username)))
+	if err != nil {
+		return fmt.Errorf("dropping user %s: %w", username, err)
+	}
+	return nil
+}
+
+func terminateMysqlConnections(ctx context.Context, db *sql.DB, dbname string) error {
+	rows, err := db.QueryContext(ctx,
+		"SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE DB = ? AND ID != CONNECTION_ID()", dbname)
+	if err != nil {
+		return fmt.Errorf("listing connections to %s: %w", dbname, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("scanning process id: %w", err)
+		}
+		_, _ = db.ExecContext(ctx, fmt.Sprintf("KILL %d", id))
+	}
+
+	return rows.Err()
+}

--- a/pkg/addon/mysql/plans.go
+++ b/pkg/addon/mysql/plans.go
@@ -1,9 +1,6 @@
 package mysql
 
 import (
-	"strconv"
-	"strings"
-
 	"miren.dev/runtime/pkg/addon"
 )
 
@@ -52,17 +49,6 @@ func Definition() addon.AddonDefinition {
 
 const sharedDefaultStorageGb int64 = 10
 
-func parseStorageGb(s string) int64 {
-	s = strings.TrimSpace(s)
-	if strings.HasSuffix(s, "Gi") {
-		n, err := strconv.ParseInt(strings.TrimSuffix(s, "Gi"), 10, 64)
-		if err == nil && n > 0 {
-			return n
-		}
-	}
-	return 1
-}
-
 func IsSharedVariant(variantName string) bool {
-	return variantName == "shared"
+	return addon.IsSharedVariant(variantName)
 }

--- a/pkg/addon/mysql/plans.go
+++ b/pkg/addon/mysql/plans.go
@@ -1,0 +1,68 @@
+package mysql
+
+import (
+	"strconv"
+	"strings"
+
+	"miren.dev/runtime/pkg/addon"
+)
+
+const (
+	AddonName    = "miren-mysql"
+	DefaultImage = "docker.io/library/mysql:8"
+)
+
+const (
+	ConfigStorage = "storage"
+	ConfigShared  = "shared"
+)
+
+func Definition() addon.AddonDefinition {
+	return addon.AddonDefinition{
+		Name:           AddonName,
+		DisplayName:    "Miren MySQL",
+		Description:    "Managed MySQL database",
+		DefaultVariant: "small",
+		Variants: []addon.VariantDefinition{
+			{
+				Name:        "small",
+				Description: "Dedicated MySQL server",
+				Details: map[string]string{
+					"Storage": "1 GB",
+				},
+				Config: map[string]string{
+					ConfigStorage: "1Gi",
+					ConfigShared:  "false",
+				},
+			},
+			{
+				Name:        "shared",
+				Description: "Multi-app shared server",
+				Details: map[string]string{
+					"Type": "Shared server",
+					"Note": "Multiple apps share one MySQL instance",
+				},
+				Config: map[string]string{
+					ConfigShared: "true",
+				},
+			},
+		},
+	}
+}
+
+const sharedDefaultStorageGb int64 = 10
+
+func parseStorageGb(s string) int64 {
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "Gi") {
+		n, err := strconv.ParseInt(strings.TrimSuffix(s, "Gi"), 10, 64)
+		if err == nil && n > 0 {
+			return n
+		}
+	}
+	return 1
+}
+
+func IsSharedVariant(variantName string) bool {
+	return variantName == "shared"
+}

--- a/pkg/addon/mysql/plans_test.go
+++ b/pkg/addon/mysql/plans_test.go
@@ -1,0 +1,102 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefinitionHasAllVariants(t *testing.T) {
+	def := Definition()
+
+	assert.Equal(t, AddonName, def.Name)
+	assert.Equal(t, "Miren MySQL", def.DisplayName)
+	assert.Equal(t, "small", def.DefaultVariant)
+	assert.Len(t, def.Variants, 2)
+
+	variantNames := make(map[string]bool)
+	for _, v := range def.Variants {
+		variantNames[v.Name] = true
+	}
+
+	assert.True(t, variantNames["small"])
+	assert.True(t, variantNames["shared"])
+}
+
+func TestIsSharedVariant(t *testing.T) {
+	assert.True(t, IsSharedVariant("shared"))
+	assert.False(t, IsSharedVariant("small"))
+}
+
+func TestSanitizeIdentifier(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"my-app", "my_app"},
+		{"MyApp", "myapp"},
+		{"123app", "a123app"},
+		{"app_name", "app_name"},
+		{"app.name", "appname"},
+		{"APP-NAME", "app_name"},
+		{"", "app"},
+		{"a", "a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, sanitizeIdentifier(tt.input))
+		})
+	}
+}
+
+func TestBuildEnvVars(t *testing.T) {
+	vars := buildEnvVars("myhost", 3306, "myuser", "mypass", "mydb")
+
+	assert.Len(t, vars, 6)
+
+	varMap := make(map[string]string)
+	sensitiveMap := make(map[string]bool)
+	for _, v := range vars {
+		varMap[v.Key] = v.Value
+		sensitiveMap[v.Key] = v.Sensitive
+	}
+
+	assert.Equal(t, "mysql://myuser:mypass@myhost:3306/mydb", varMap["DATABASE_URL"])
+	assert.True(t, sensitiveMap["DATABASE_URL"])
+
+	assert.Equal(t, "myhost", varMap["MYSQL_HOST"])
+	assert.False(t, sensitiveMap["MYSQL_HOST"])
+
+	assert.Equal(t, "3306", varMap["MYSQL_PORT"])
+	assert.False(t, sensitiveMap["MYSQL_PORT"])
+
+	assert.Equal(t, "myuser", varMap["MYSQL_USER"])
+	assert.False(t, sensitiveMap["MYSQL_USER"])
+
+	assert.Equal(t, "mypass", varMap["MYSQL_PASSWORD"])
+	assert.True(t, sensitiveMap["MYSQL_PASSWORD"])
+
+	assert.Equal(t, "mydb", varMap["MYSQL_DATABASE"])
+	assert.False(t, sensitiveMap["MYSQL_DATABASE"])
+}
+
+func TestBuildDatabaseURL(t *testing.T) {
+	url := buildDatabaseURL("host.example.com", 3306, "user", "pass", "dbname")
+	assert.Equal(t, "mysql://user:pass@host.example.com:3306/dbname", url)
+}
+
+func TestVariantConfigContainsExpectedKeys(t *testing.T) {
+	def := Definition()
+
+	for _, variant := range def.Variants {
+		t.Run(variant.Name, func(t *testing.T) {
+			if variant.Name == "shared" {
+				assert.Equal(t, "true", variant.Config[ConfigShared])
+			} else {
+				assert.NotEmpty(t, variant.Config[ConfigStorage])
+				assert.Equal(t, "false", variant.Config[ConfigShared])
+			}
+		})
+	}
+}

--- a/pkg/addon/mysql/plans_test.go
+++ b/pkg/addon/mysql/plans_test.go
@@ -41,6 +41,7 @@ func TestSanitizeIdentifier(t *testing.T) {
 		{"APP-NAME", "app_name"},
 		{"", "app"},
 		{"a", "a"},
+		{"my-really-long-application-name-for-production", "my_really_long_application_name_"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/addon/mysql/provider.go
+++ b/pkg/addon/mysql/provider.go
@@ -3,26 +3,23 @@ package mysql
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/url"
 
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/dbsaga"
 )
 
 type Provider struct {
-	fw  *addon.ProviderFramework
-	log *slog.Logger
+	dbsaga.BaseProvider
 }
 
 func NewProvider(fw *addon.ProviderFramework) *Provider {
 	return &Provider{
-		fw:  fw,
-		log: fw.Log.With("addon", AddonName),
+		BaseProvider: dbsaga.BaseProvider{
+			Fw:  fw,
+			Log: fw.Log.With("addon", AddonName),
+		},
 	}
-}
-
-func (p *Provider) LocalityMode() addon.LocalityMode {
-	return addon.OnCluster
 }
 
 func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
@@ -30,10 +27,6 @@ func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.V
 		return p.provisionShared(ctx, app, variant)
 	}
 	return p.provisionDedicated(ctx, app, variant)
-}
-
-func (p *Provider) AdjustEnvVars(ctx context.Context, result *addon.ProvisionResult, assoc addon.AddonAssociation, collisions []string) ([]addon.Variable, error) {
-	return result.EnvVars, nil
 }
 
 func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation) error {
@@ -46,10 +39,10 @@ func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation
 
 func buildDatabaseURL(host string, port int, user, password, database string) string {
 	u := &url.URL{
-		Scheme:   "mysql",
-		User:     url.UserPassword(user, password),
-		Host:     fmt.Sprintf("%s:%d", host, port),
-		Path:     database,
+		Scheme: "mysql",
+		User:   url.UserPassword(user, password),
+		Host:   fmt.Sprintf("%s:%d", host, port),
+		Path:   database,
 	}
 	return u.String()
 }

--- a/pkg/addon/mysql/provider.go
+++ b/pkg/addon/mysql/provider.go
@@ -1,0 +1,66 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+
+	"miren.dev/runtime/pkg/addon"
+)
+
+type Provider struct {
+	fw  *addon.ProviderFramework
+	log *slog.Logger
+}
+
+func NewProvider(fw *addon.ProviderFramework) *Provider {
+	return &Provider{
+		fw:  fw,
+		log: fw.Log.With("addon", AddonName),
+	}
+}
+
+func (p *Provider) LocalityMode() addon.LocalityMode {
+	return addon.OnCluster
+}
+
+func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+	if IsSharedVariant(variant.Name) {
+		return p.provisionShared(ctx, app, variant)
+	}
+	return p.provisionDedicated(ctx, app, variant)
+}
+
+func (p *Provider) AdjustEnvVars(ctx context.Context, result *addon.ProvisionResult, assoc addon.AddonAssociation, collisions []string) ([]addon.Variable, error) {
+	return result.EnvVars, nil
+}
+
+func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation) error {
+	variant := assoc.Variant
+	if IsSharedVariant(variant) {
+		return p.deprovisionShared(ctx, assoc)
+	}
+	return p.deprovisionDedicated(ctx, assoc)
+}
+
+func buildDatabaseURL(host string, port int, user, password, database string) string {
+	u := &url.URL{
+		Scheme:   "mysql",
+		User:     url.UserPassword(user, password),
+		Host:     fmt.Sprintf("%s:%d", host, port),
+		Path:     database,
+	}
+	return u.String()
+}
+
+func buildEnvVars(host string, port int, user, password, database string) []addon.Variable {
+	return []addon.Variable{
+		{Key: "DATABASE_URL", Value: buildDatabaseURL(host, port, user, password, database), Sensitive: true},
+		{Key: "MYSQL_HOST", Value: host},
+		{Key: "MYSQL_PORT", Value: fmt.Sprintf("%d", port)},
+		{Key: "MYSQL_USER", Value: user},
+		{Key: "MYSQL_PASSWORD", Value: password, Sensitive: true},
+		{Key: "MYSQL_DATABASE", Value: database},
+	}
+}

--- a/pkg/addon/mysql/server_counter.go
+++ b/pkg/addon/mysql/server_counter.go
@@ -1,0 +1,34 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// mysqlServerCounter implements dbsaga.ServerCounter for MySQL.
+type mysqlServerCounter struct{}
+
+func (mysqlServerCounter) GetAssociationCount(ctx context.Context, serverID entity.Id) (int64, int64, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.MysqlServer
+	ent, err := fw.EC.GetByIdWithEntity(ctx, serverID, &server)
+	if err != nil {
+		return 0, 0, fmt.Errorf("getting mysql server: %w", err)
+	}
+
+	return server.AssociationCount, ent.Revision(), nil
+}
+
+func (mysqlServerCounter) PatchAssociationCount(ctx context.Context, serverID entity.Id, revision int64, newCount int64) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	return fw.EC.Patch(ctx, serverID, revision,
+		entity.Int64(addon_v1alpha.MysqlServerAssociationCountId, newCount),
+	)
+}

--- a/pkg/addon/mysql/shared.go
+++ b/pkg/addon/mysql/shared.go
@@ -11,6 +11,7 @@ import (
 	"miren.dev/runtime/api/addon/addon_v1alpha"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/dbsaga"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
@@ -123,80 +124,6 @@ func UndoCreateSharedPool(ctx context.Context, in CreateSharedPoolIn, out Create
 	return fw.DeleteSandboxPool(ctx, out.PoolID)
 }
 
-type WaitForSharedPoolIn struct {
-	PoolID entity.Id
-}
-
-type WaitForSharedPoolOut struct {
-	PoolReady bool
-}
-
-func WaitForSharedPool(ctx context.Context, in WaitForSharedPoolIn) (WaitForSharedPoolOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	if err := fw.WaitForPool(ctx, in.PoolID, poolReadyTimeout); err != nil {
-		return WaitForSharedPoolOut{}, fmt.Errorf("waiting for shared pool: %w", err)
-	}
-
-	return WaitForSharedPoolOut{PoolReady: true}, nil
-}
-
-func UndoWaitForSharedPool(ctx context.Context, in WaitForSharedPoolIn, out WaitForSharedPoolOut) error {
-	return nil
-}
-
-type CreateSharedServiceIn struct{}
-
-type CreateSharedServiceOut struct {
-	ServiceID entity.Id
-}
-
-func CreateSharedService(ctx context.Context, in CreateSharedServiceIn) (CreateSharedServiceOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	labels := types.LabelSet(
-		"addon", AddonName,
-		"server", sharedServerName,
-		"shared", "true",
-	)
-
-	serviceName := sharedServerName + "-mysql"
-	svcID, err := fw.CreateService(ctx, serviceName, labels, mysqlPort)
-	if err != nil {
-		return CreateSharedServiceOut{}, fmt.Errorf("creating shared service: %w", err)
-	}
-
-	return CreateSharedServiceOut{ServiceID: svcID}, nil
-}
-
-func UndoCreateSharedService(ctx context.Context, in CreateSharedServiceIn, out CreateSharedServiceOut) error {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-	return fw.DeleteService(ctx, out.ServiceID)
-}
-
-type WaitForSharedServiceIn struct {
-	ServiceID entity.Id
-}
-
-type WaitForSharedServiceOut struct {
-	ServiceHost string
-}
-
-func WaitForSharedService(ctx context.Context, in WaitForSharedServiceIn) (WaitForSharedServiceOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	serviceHost, err := fw.WaitForServiceAddress(ctx, in.ServiceID, poolReadyTimeout)
-	if err != nil {
-		return WaitForSharedServiceOut{}, fmt.Errorf("waiting for shared service address: %w", err)
-	}
-
-	return WaitForSharedServiceOut{ServiceHost: serviceHost}, nil
-}
-
-func UndoWaitForSharedService(ctx context.Context, in WaitForSharedServiceIn, out WaitForSharedServiceOut) error {
-	return nil
-}
-
 type ActivateSharedServerIn struct {
 	ServerID     entity.Id
 	PoolID       entity.Id
@@ -235,13 +162,15 @@ func UndoActivateSharedServer(ctx context.Context, in ActivateSharedServerIn, ou
 }
 
 func RegisterEnsureSharedServerSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
+	cfg := &dbsaga.AddonConfig{AddonName: AddonName, SharedServerName: sharedServerName, Port: mysqlPort, ReadyTimeout: poolReadyTimeout}
 	return saga.Define("ensure-shared-mysql-server").
 		Using(fw).
+		Using(cfg).
 		Action(CreateSharedServerEntity).Undo(UndoCreateSharedServerEntity).
 		Action(CreateSharedPool).Undo(UndoCreateSharedPool).
-		Action(WaitForSharedPool).Undo(UndoWaitForSharedPool).
-		Action(CreateSharedService).Undo(UndoCreateSharedService).
-		Action(WaitForSharedService).Undo(UndoWaitForSharedService).
+		Action(dbsaga.WaitForSharedPool).Undo(dbsaga.UndoWaitForSharedPool).
+		Action(dbsaga.CreateSharedService).Undo(dbsaga.UndoCreateSharedService).
+		Action(dbsaga.WaitForSharedService).Undo(dbsaga.UndoWaitForSharedService).
 		Action(ActivateSharedServer).Undo(UndoActivateSharedServer).
 		RegisterTo(registry)
 }
@@ -456,55 +385,6 @@ func UndoCreateSharedDatabase(ctx context.Context, in CreateSharedDatabaseIn, ou
 	return dropMysqlDatabase(ctx, db, in.SharedDatabaseName)
 }
 
-type IncrementAssociationCountIn struct {
-	ServerID entity.Id
-}
-
-type IncrementAssociationCountOut struct {
-	Incremented bool
-}
-
-func IncrementAssociationCount(ctx context.Context, in IncrementAssociationCountIn) (IncrementAssociationCountOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	var server addon_v1alpha.MysqlServer
-	ent, err := fw.EC.GetByIdWithEntity(ctx, in.ServerID, &server)
-	if err != nil {
-		return IncrementAssociationCountOut{}, fmt.Errorf("getting server for count increment: %w", err)
-	}
-
-	newCount := server.AssociationCount + 1
-	if err := fw.EC.Patch(ctx, in.ServerID, ent.Revision(),
-		entity.Int64(addon_v1alpha.MysqlServerAssociationCountId, newCount),
-	); err != nil {
-		return IncrementAssociationCountOut{}, fmt.Errorf("updating association count: %w", err)
-	}
-
-	return IncrementAssociationCountOut{Incremented: true}, nil
-}
-
-func UndoIncrementAssociationCount(ctx context.Context, in IncrementAssociationCountIn, out IncrementAssociationCountOut) error {
-	if !out.Incremented {
-		return nil
-	}
-
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	var server addon_v1alpha.MysqlServer
-	ent, err := fw.EC.GetByIdWithEntity(ctx, in.ServerID, &server)
-	if err != nil {
-		return err
-	}
-
-	newCount := server.AssociationCount - 1
-	if newCount < 0 {
-		newCount = 0
-	}
-	return fw.EC.Patch(ctx, in.ServerID, ent.Revision(),
-		entity.Int64(addon_v1alpha.MysqlServerAssociationCountId, newCount),
-	)
-}
-
 type BuildSharedResultIn struct {
 	ServerID           entity.Id
 	ServiceHost        string
@@ -545,14 +425,18 @@ func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc
 		return err
 	}
 
-	return saga.Define("provision-shared-mysql").
+	cfg := &dbsaga.AddonConfig{AddonName: AddonName, SharedServerName: sharedServerName, Port: mysqlPort, ReadyTimeout: poolReadyTimeout}
+	b := saga.Define("provision-shared-mysql").
 		Using(fw).
 		Using(rc).
+		Using(cfg)
+	saga.UsingAs[dbsaga.ServerCounter](b, mysqlServerCounter{})
+	return b.
 		Action(FindOrCreateSharedServer).Undo(UndoFindOrCreateSharedServer).
 		Action(GenerateSharedCredentials).Undo(UndoGenerateSharedCredentials).
 		Action(CreateSharedUser).Undo(UndoCreateSharedUser).
 		Action(CreateSharedDatabase).Undo(UndoCreateSharedDatabase).
-		Action(IncrementAssociationCount).Undo(UndoIncrementAssociationCount).
+		Action(dbsaga.IncrementAssociationCount).Undo(dbsaga.UndoIncrementAssociationCount).
 		Action(BuildSharedResult).Undo(UndoBuildSharedResult).
 		RegisterTo(registry)
 }
@@ -714,44 +598,6 @@ func UndoDropSharedUser(ctx context.Context, in DropSharedUserIn, out DropShared
 	return nil
 }
 
-type DecrementAssociationCountIn struct {
-	SharedServerRef entity.Id
-	DatabaseDropped bool
-	UserDropped     bool
-}
-
-type DecrementAssociationCountOut struct {
-	RemainingCount int64
-}
-
-func DecrementAssociationCount(ctx context.Context, in DecrementAssociationCountIn) (DecrementAssociationCountOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	var server addon_v1alpha.MysqlServer
-	ent, err := fw.EC.GetByIdWithEntity(ctx, in.SharedServerRef, &server)
-	if err != nil {
-		return DecrementAssociationCountOut{}, fmt.Errorf("getting server: %w", err)
-	}
-
-	if server.AssociationCount <= 0 {
-		fw.Log.Warn("association count already zero, skipping decrement", "server", in.SharedServerRef)
-		return DecrementAssociationCountOut{RemainingCount: 0}, nil
-	}
-
-	newCount := server.AssociationCount - 1
-	if err := fw.EC.Patch(ctx, in.SharedServerRef, ent.Revision(),
-		entity.Int64(addon_v1alpha.MysqlServerAssociationCountId, newCount),
-	); err != nil {
-		return DecrementAssociationCountOut{}, fmt.Errorf("updating association count: %w", err)
-	}
-
-	return DecrementAssociationCountOut{RemainingCount: newCount}, nil
-}
-
-func UndoDecrementAssociationCount(ctx context.Context, in DecrementAssociationCountIn, out DecrementAssociationCountOut) error {
-	return nil
-}
-
 type CleanupSharedServerIn struct {
 	SharedServerRef    entity.Id
 	SharedServiceRef   entity.Id
@@ -802,14 +648,16 @@ func UndoCleanupSharedServer(ctx context.Context, in CleanupSharedServerIn, out 
 }
 
 func RegisterDeprovisionSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
-	return saga.Define("deprovision-shared-mysql").
-		Using(fw).
+	b := saga.Define("deprovision-shared-mysql").
+		Using(fw)
+	saga.UsingAs[dbsaga.ServerCounter](b, mysqlServerCounter{})
+	return b.
 		Action(DecodeSharedAttrs).Undo(UndoDecodeSharedAttrs).
 		Action(LookupSharedServer).Undo(UndoLookupSharedServer).
 		Action(TerminateConnections).Undo(UndoTerminateConnections).
 		Action(DropSharedDatabase).Undo(UndoDropSharedDatabase).
 		Action(DropSharedUser).Undo(UndoDropSharedUser).
-		Action(DecrementAssociationCount).Undo(UndoDecrementAssociationCount).
+		Action(dbsaga.DecrementAssociationCount).Undo(dbsaga.UndoDecrementAssociationCount).
 		Action(CleanupSharedServer).Undo(UndoCleanupSharedServer).
 		RegisterTo(registry)
 }

--- a/pkg/addon/mysql/shared.go
+++ b/pkg/addon/mysql/shared.go
@@ -1,0 +1,868 @@
+package mysql
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/saga"
+)
+
+const (
+	sharedServerName = "my-shared"
+	sharedDiskName   = "my-shared-data"
+	poolReadyTimeout = 5 * time.Minute
+)
+
+// --- EnsureSharedServerSaga Actions ---
+
+type CreateSharedServerEntityIn struct {
+	RootPassword string
+}
+
+type CreateSharedServerEntityOut struct {
+	ServerID entity.Id
+}
+
+func CreateSharedServerEntity(ctx context.Context, in CreateSharedServerEntityIn) (CreateSharedServerEntityOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	server := &addon_v1alpha.MysqlServer{
+		AddonName:        AddonName,
+		Variant:          "shared",
+		Status:           "provisioning",
+		AssociationCount: 0,
+		RootPassword:     in.RootPassword,
+	}
+
+	serverID, err := fw.EC.Create(ctx, sharedServerName, server)
+	if err != nil {
+		return CreateSharedServerEntityOut{}, fmt.Errorf("creating shared server entity: %w", err)
+	}
+
+	return CreateSharedServerEntityOut{ServerID: serverID}, nil
+}
+
+func UndoCreateSharedServerEntity(ctx context.Context, in CreateSharedServerEntityIn, out CreateSharedServerEntityOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.EC.Delete(ctx, out.ServerID)
+}
+
+type CreateSharedPoolIn struct {
+	RootPassword string
+}
+
+type CreateSharedPoolOut struct {
+	PoolID entity.Id
+}
+
+func sharedDiskNameForPassword(password string) string {
+	h := sha256.Sum256([]byte(password))
+	return sharedDiskName + "-" + hex.EncodeToString(h[:4])
+}
+
+func CreateSharedPool(ctx context.Context, in CreateSharedPoolIn) (CreateSharedPoolOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	labels := types.LabelSet(
+		"addon", AddonName,
+		"server", sharedServerName,
+		"shared", "true",
+	)
+
+	mountPath := "/var/lib/mysql"
+
+	env := []string{
+		"MYSQL_ROOT_PASSWORD=" + in.RootPassword,
+	}
+
+	diskName := sharedDiskNameForPassword(in.RootPassword)
+
+	poolID, err := fw.CreateSandboxPool(ctx, addon.CreateSandboxPoolSpec{
+		Name:             sharedServerName,
+		Image:            DefaultImage,
+		Env:              env,
+		Ports:            mysqlContainerPorts(),
+		DesiredInstances: 1,
+		Labels:           labels,
+		SandboxPrefix:    "my-shared",
+		Mounts: []compute_v1alpha.SandboxSpecContainerMount{
+			{Source: "mydata", Destination: mountPath},
+		},
+		Volumes: []compute_v1alpha.SandboxSpecVolume{
+			{
+				Name:         "mydata",
+				Provider:     "miren",
+				DiskName:     diskName,
+				MountPath:    mountPath,
+				SizeGb:       sharedDefaultStorageGb,
+				Filesystem:   "ext4",
+				LeaseTimeout: "5m",
+			},
+		},
+	})
+	if err != nil {
+		return CreateSharedPoolOut{}, fmt.Errorf("creating shared pool: %w", err)
+	}
+
+	return CreateSharedPoolOut{PoolID: poolID}, nil
+}
+
+func UndoCreateSharedPool(ctx context.Context, in CreateSharedPoolIn, out CreateSharedPoolOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.DeleteSandboxPool(ctx, out.PoolID)
+}
+
+type WaitForSharedPoolIn struct {
+	PoolID entity.Id
+}
+
+type WaitForSharedPoolOut struct {
+	PoolReady bool
+}
+
+func WaitForSharedPool(ctx context.Context, in WaitForSharedPoolIn) (WaitForSharedPoolOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	if err := fw.WaitForPool(ctx, in.PoolID, poolReadyTimeout); err != nil {
+		return WaitForSharedPoolOut{}, fmt.Errorf("waiting for shared pool: %w", err)
+	}
+
+	return WaitForSharedPoolOut{PoolReady: true}, nil
+}
+
+func UndoWaitForSharedPool(ctx context.Context, in WaitForSharedPoolIn, out WaitForSharedPoolOut) error {
+	return nil
+}
+
+type CreateSharedServiceIn struct{}
+
+type CreateSharedServiceOut struct {
+	ServiceID entity.Id
+}
+
+func CreateSharedService(ctx context.Context, in CreateSharedServiceIn) (CreateSharedServiceOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	labels := types.LabelSet(
+		"addon", AddonName,
+		"server", sharedServerName,
+		"shared", "true",
+	)
+
+	serviceName := sharedServerName + "-mysql"
+	svcID, err := fw.CreateService(ctx, serviceName, labels, mysqlPort)
+	if err != nil {
+		return CreateSharedServiceOut{}, fmt.Errorf("creating shared service: %w", err)
+	}
+
+	return CreateSharedServiceOut{ServiceID: svcID}, nil
+}
+
+func UndoCreateSharedService(ctx context.Context, in CreateSharedServiceIn, out CreateSharedServiceOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.DeleteService(ctx, out.ServiceID)
+}
+
+type WaitForSharedServiceIn struct {
+	ServiceID entity.Id
+}
+
+type WaitForSharedServiceOut struct {
+	ServiceHost string
+}
+
+func WaitForSharedService(ctx context.Context, in WaitForSharedServiceIn) (WaitForSharedServiceOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	serviceHost, err := fw.WaitForServiceAddress(ctx, in.ServiceID, poolReadyTimeout)
+	if err != nil {
+		return WaitForSharedServiceOut{}, fmt.Errorf("waiting for shared service address: %w", err)
+	}
+
+	return WaitForSharedServiceOut{ServiceHost: serviceHost}, nil
+}
+
+func UndoWaitForSharedService(ctx context.Context, in WaitForSharedServiceIn, out WaitForSharedServiceOut) error {
+	return nil
+}
+
+type ActivateSharedServerIn struct {
+	ServerID     entity.Id
+	PoolID       entity.Id
+	ServiceID    entity.Id
+	RootPassword string
+	ServiceHost  string
+}
+
+type ActivateSharedServerOut struct {
+	Activated bool
+}
+
+func ActivateSharedServer(ctx context.Context, in ActivateSharedServerIn) (ActivateSharedServerOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	server := &addon_v1alpha.MysqlServer{
+		AddonName:        AddonName,
+		Variant:          "shared",
+		Status:           "active",
+		AssociationCount: 0,
+		RootPassword:     in.RootPassword,
+		SandboxPool:      in.PoolID,
+		Service:          in.ServiceID,
+	}
+	server.ID = in.ServerID
+
+	if err := fw.EC.Update(ctx, server); err != nil {
+		return ActivateSharedServerOut{}, fmt.Errorf("activating shared server: %w", err)
+	}
+
+	return ActivateSharedServerOut{Activated: true}, nil
+}
+
+func UndoActivateSharedServer(ctx context.Context, in ActivateSharedServerIn, out ActivateSharedServerOut) error {
+	return nil
+}
+
+func RegisterEnsureSharedServerSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
+	return saga.Define("ensure-shared-mysql-server").
+		Using(fw).
+		Action(CreateSharedServerEntity).Undo(UndoCreateSharedServerEntity).
+		Action(CreateSharedPool).Undo(UndoCreateSharedPool).
+		Action(WaitForSharedPool).Undo(UndoWaitForSharedPool).
+		Action(CreateSharedService).Undo(UndoCreateSharedService).
+		Action(WaitForSharedService).Undo(UndoWaitForSharedService).
+		Action(ActivateSharedServer).Undo(UndoActivateSharedServer).
+		RegisterTo(registry)
+}
+
+// --- Shared Provisioning Saga Actions ---
+
+type FindOrCreateSharedServerIn struct {
+	AppName string
+}
+
+type FindOrCreateSharedServerOut struct {
+	ServerID     entity.Id
+	RootPassword string
+	ServiceHost  string
+}
+
+func isNotExist(err error) bool {
+	return errors.Is(err, cond.ErrNotFound{})
+}
+
+func cleanupStaleSharedServer(fw *addon.ProviderFramework, ctx context.Context, server *addon_v1alpha.MysqlServer) error {
+	if server.Service != "" {
+		if err := fw.DeleteService(ctx, server.Service); err != nil && !isNotExist(err) {
+			return fmt.Errorf("deleting stale shared service: %w", err)
+		}
+	}
+	if server.SandboxPool != "" {
+		if err := fw.DeleteSandboxPool(ctx, server.SandboxPool); err != nil && !isNotExist(err) {
+			return fmt.Errorf("deleting stale shared pool: %w", err)
+		}
+	}
+	if server.RootPassword != "" {
+		diskName := sharedDiskNameForPassword(server.RootPassword)
+		if err := fw.DeleteDiskByName(ctx, diskName); err != nil {
+			return fmt.Errorf("deleting stale shared data disk: %w", err)
+		}
+	}
+	return fw.EC.Delete(ctx, server.ID)
+}
+
+func FindOrCreateSharedServer(ctx context.Context, in FindOrCreateSharedServerIn) (FindOrCreateSharedServerOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.MysqlServer
+	err := fw.EC.Get(ctx, sharedServerName, &server)
+	if err == nil {
+		switch server.Status {
+		case "active":
+			serviceHost, err := fw.GetServiceAddress(ctx, server.Service)
+			if err != nil {
+				if !errors.Is(err, cond.ErrNotFound{}) {
+					return FindOrCreateSharedServerOut{}, fmt.Errorf("resolving existing shared service address: %w", err)
+				}
+				fw.Log.Warn("shared server active but service gone, cleaning up stale server",
+					"server", server.ID, "error", err)
+				if delErr := cleanupStaleSharedServer(fw, ctx, &server); delErr != nil {
+					return FindOrCreateSharedServerOut{}, fmt.Errorf("cleaning up stale shared server: %w", delErr)
+				}
+				break
+			}
+			return FindOrCreateSharedServerOut{
+				ServerID:     server.ID,
+				RootPassword: server.RootPassword,
+				ServiceHost:  serviceHost,
+			}, nil
+		default:
+			resp, lookupErr := fw.EAC.Get(ctx, server.ID.String())
+			if lookupErr != nil {
+				return FindOrCreateSharedServerOut{}, fmt.Errorf("looking up shared server entity: %w", lookupErr)
+			}
+			age := time.Since(resp.Entity().Entity().GetCreatedAt())
+			if age < 10*time.Minute {
+				return FindOrCreateSharedServerOut{}, fmt.Errorf("shared server exists but has status %q (age %s); retry later", server.Status, age.Truncate(time.Second))
+			}
+			fw.Log.Warn("shared server stale, cleaning up",
+				"server", server.ID, "status", server.Status, "age", age.Truncate(time.Second))
+			if delErr := cleanupStaleSharedServer(fw, ctx, &server); delErr != nil {
+				return FindOrCreateSharedServerOut{}, fmt.Errorf("cleaning up stale shared server: %w", delErr)
+			}
+		}
+	} else if !errors.Is(err, cond.ErrNotFound{}) {
+		return FindOrCreateSharedServerOut{}, fmt.Errorf("looking up shared server: %w", err)
+	}
+
+	rootPassword := idgen.Gen("rt")
+
+	result, err := saga.RunNested(ctx, "ensure-shared-mysql-server",
+		saga.WithNestedInput("rootpassword", rootPassword),
+	)
+	if err != nil {
+		return FindOrCreateSharedServerOut{}, fmt.Errorf("ensuring shared server: %w", err)
+	}
+
+	var serverID entity.Id
+	if err := result.Get("serverid", &serverID); err != nil {
+		return FindOrCreateSharedServerOut{}, fmt.Errorf("reading server ID from nested result: %w", err)
+	}
+
+	var serviceHost string
+	if err := result.Get("servicehost", &serviceHost); err != nil {
+		return FindOrCreateSharedServerOut{}, fmt.Errorf("reading service host from nested result: %w", err)
+	}
+
+	return FindOrCreateSharedServerOut{
+		ServerID:     serverID,
+		RootPassword: rootPassword,
+		ServiceHost:  serviceHost,
+	}, nil
+}
+
+func UndoFindOrCreateSharedServer(ctx context.Context, in FindOrCreateSharedServerIn, out FindOrCreateSharedServerOut) error {
+	return nil
+}
+
+type GenerateSharedCredentialsIn struct {
+	AppName string
+}
+
+type GenerateSharedCredentialsOut struct {
+	SharedPassword          string
+	SharedDatabaseName      string
+	GeneratedSharedUsername string
+}
+
+func GenerateSharedCredentials(ctx context.Context, in GenerateSharedCredentialsIn) (GenerateSharedCredentialsOut, error) {
+	return GenerateSharedCredentialsOut{
+		SharedPassword:          idgen.Gen("pw"),
+		SharedDatabaseName:      sanitizeIdentifier(in.AppName),
+		GeneratedSharedUsername: sanitizeIdentifier(in.AppName),
+	}, nil
+}
+
+func UndoGenerateSharedCredentials(ctx context.Context, in GenerateSharedCredentialsIn, out GenerateSharedCredentialsOut) error {
+	return nil
+}
+
+type CreateSharedUserIn struct {
+	ServiceHost             string
+	RootPassword            string
+	GeneratedSharedUsername string
+	SharedPassword          string
+}
+
+type CreateSharedUserOut struct {
+	SharedUsername string
+}
+
+func CreateSharedUser(ctx context.Context, in CreateSharedUserIn) (CreateSharedUserOut, error) {
+	db, err := connectAsRoot(ctx, in.ServiceHost, in.RootPassword)
+	if err != nil {
+		return CreateSharedUserOut{}, fmt.Errorf("connecting to shared server: %w", err)
+	}
+	defer db.Close()
+
+	if err := createMysqlUser(ctx, db, in.GeneratedSharedUsername, in.SharedPassword); err != nil {
+		return CreateSharedUserOut{}, err
+	}
+
+	return CreateSharedUserOut{SharedUsername: in.GeneratedSharedUsername}, nil
+}
+
+func UndoCreateSharedUser(ctx context.Context, in CreateSharedUserIn, out CreateSharedUserOut) error {
+	if out.SharedUsername == "" {
+		return nil
+	}
+
+	db, err := connectAsRoot(ctx, in.ServiceHost, in.RootPassword)
+	if err != nil {
+		return fmt.Errorf("connecting for user cleanup: %w", err)
+	}
+	defer db.Close()
+
+	return dropMysqlUser(ctx, db, in.GeneratedSharedUsername)
+}
+
+type CreateSharedDatabaseIn struct {
+	ServiceHost        string
+	RootPassword       string
+	SharedDatabaseName string
+	SharedUsername     string
+}
+
+type CreateSharedDatabaseOut struct {
+	DatabaseCreated bool
+}
+
+func CreateSharedDatabase(ctx context.Context, in CreateSharedDatabaseIn) (CreateSharedDatabaseOut, error) {
+	db, err := connectAsRoot(ctx, in.ServiceHost, in.RootPassword)
+	if err != nil {
+		return CreateSharedDatabaseOut{}, fmt.Errorf("connecting to shared server: %w", err)
+	}
+	defer db.Close()
+
+	if err := createMysqlDatabase(ctx, db, in.SharedDatabaseName, in.SharedUsername); err != nil {
+		return CreateSharedDatabaseOut{}, err
+	}
+
+	return CreateSharedDatabaseOut{DatabaseCreated: true}, nil
+}
+
+func UndoCreateSharedDatabase(ctx context.Context, in CreateSharedDatabaseIn, out CreateSharedDatabaseOut) error {
+	if !out.DatabaseCreated {
+		return nil
+	}
+
+	db, err := connectAsRoot(ctx, in.ServiceHost, in.RootPassword)
+	if err != nil {
+		return fmt.Errorf("connecting for database cleanup: %w", err)
+	}
+	defer db.Close()
+
+	return dropMysqlDatabase(ctx, db, in.SharedDatabaseName)
+}
+
+type IncrementAssociationCountIn struct {
+	ServerID entity.Id
+}
+
+type IncrementAssociationCountOut struct {
+	Incremented bool
+}
+
+func IncrementAssociationCount(ctx context.Context, in IncrementAssociationCountIn) (IncrementAssociationCountOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.MysqlServer
+	ent, err := fw.EC.GetByIdWithEntity(ctx, in.ServerID, &server)
+	if err != nil {
+		return IncrementAssociationCountOut{}, fmt.Errorf("getting server for count increment: %w", err)
+	}
+
+	newCount := server.AssociationCount + 1
+	if err := fw.EC.Patch(ctx, in.ServerID, ent.Revision(),
+		entity.Int64(addon_v1alpha.MysqlServerAssociationCountId, newCount),
+	); err != nil {
+		return IncrementAssociationCountOut{}, fmt.Errorf("updating association count: %w", err)
+	}
+
+	return IncrementAssociationCountOut{Incremented: true}, nil
+}
+
+func UndoIncrementAssociationCount(ctx context.Context, in IncrementAssociationCountIn, out IncrementAssociationCountOut) error {
+	if !out.Incremented {
+		return nil
+	}
+
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.MysqlServer
+	ent, err := fw.EC.GetByIdWithEntity(ctx, in.ServerID, &server)
+	if err != nil {
+		return err
+	}
+
+	newCount := server.AssociationCount - 1
+	if newCount < 0 {
+		newCount = 0
+	}
+	return fw.EC.Patch(ctx, in.ServerID, ent.Revision(),
+		entity.Int64(addon_v1alpha.MysqlServerAssociationCountId, newCount),
+	)
+}
+
+type BuildSharedResultIn struct {
+	ServerID           entity.Id
+	ServiceHost        string
+	SharedDatabaseName string
+	SharedUsername     string
+	SharedPassword     string
+}
+
+type BuildSharedResultOut struct {
+	Done bool
+}
+
+func BuildSharedResult(ctx context.Context, in BuildSharedResultIn) (BuildSharedResultOut, error) {
+	rc := saga.Get[*resultCapture](ctx)
+
+	envVars := buildEnvVars(in.ServiceHost, mysqlPort, in.SharedUsername, in.SharedPassword, in.SharedDatabaseName)
+
+	sharedData := &addon_v1alpha.MysqlSharedData{
+		MysqlServer:  in.ServerID,
+		DatabaseName: in.SharedDatabaseName,
+		Username:     in.SharedUsername,
+	}
+
+	rc.Result = &addon.ProvisionResult{
+		EnvVars: envVars,
+		Attrs:   sharedData.Encode(),
+	}
+
+	return BuildSharedResultOut{Done: true}, nil
+}
+
+func UndoBuildSharedResult(ctx context.Context, in BuildSharedResultIn, out BuildSharedResultOut) error {
+	return nil
+}
+
+func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+	if err := RegisterEnsureSharedServerSaga(registry, fw); err != nil {
+		return err
+	}
+
+	return saga.Define("provision-shared-mysql").
+		Using(fw).
+		Using(rc).
+		Action(FindOrCreateSharedServer).Undo(UndoFindOrCreateSharedServer).
+		Action(GenerateSharedCredentials).Undo(UndoGenerateSharedCredentials).
+		Action(CreateSharedUser).Undo(UndoCreateSharedUser).
+		Action(CreateSharedDatabase).Undo(UndoCreateSharedDatabase).
+		Action(IncrementAssociationCount).Undo(UndoIncrementAssociationCount).
+		Action(BuildSharedResult).Undo(UndoBuildSharedResult).
+		RegisterTo(registry)
+}
+
+// --- Shared Deprovisioning Saga Actions ---
+
+type DecodeSharedAttrsIn struct {
+	AssocEntity *entity.Entity `saga:"assocentity"`
+}
+
+type DecodeSharedAttrsOut struct {
+	SharedServerRef entity.Id
+	SharedDbName    string
+	SharedUserName  string
+}
+
+func DecodeSharedAttrs(ctx context.Context, in DecodeSharedAttrsIn) (DecodeSharedAttrsOut, error) {
+	var data addon_v1alpha.MysqlSharedData
+	if in.AssocEntity != nil {
+		data.Decode(in.AssocEntity)
+	}
+
+	if data.MysqlServer == "" {
+		return DecodeSharedAttrsOut{}, fmt.Errorf("no mysql server ref found")
+	}
+
+	return DecodeSharedAttrsOut{
+		SharedServerRef: data.MysqlServer,
+		SharedDbName:    data.DatabaseName,
+		SharedUserName:  data.Username,
+	}, nil
+}
+
+func UndoDecodeSharedAttrs(ctx context.Context, in DecodeSharedAttrsIn, out DecodeSharedAttrsOut) error {
+	return nil
+}
+
+type LookupSharedServerIn struct {
+	SharedServerRef entity.Id
+}
+
+type LookupSharedServerOut struct {
+	SharedRootPassword string
+	SharedServiceRef   entity.Id
+	SharedPoolRef      entity.Id
+	SharedAssocCount   int64
+	SharedServiceHost  string
+}
+
+func LookupSharedServer(ctx context.Context, in LookupSharedServerIn) (LookupSharedServerOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.MysqlServer
+	if err := fw.EC.GetById(ctx, in.SharedServerRef, &server); err != nil {
+		return LookupSharedServerOut{}, fmt.Errorf("looking up shared server: %w", err)
+	}
+
+	serviceHost, err := fw.GetServiceAddress(ctx, server.Service)
+	if err != nil {
+		return LookupSharedServerOut{}, fmt.Errorf("resolving shared service address: %w", err)
+	}
+
+	return LookupSharedServerOut{
+		SharedRootPassword: server.RootPassword,
+		SharedServiceRef:   server.Service,
+		SharedPoolRef:      server.SandboxPool,
+		SharedAssocCount:   server.AssociationCount,
+		SharedServiceHost:  serviceHost,
+	}, nil
+}
+
+func UndoLookupSharedServer(ctx context.Context, in LookupSharedServerIn, out LookupSharedServerOut) error {
+	return nil
+}
+
+type TerminateConnectionsIn struct {
+	SharedServiceHost  string
+	SharedRootPassword string
+	SharedDbName       string
+}
+
+type TerminateConnectionsOut struct {
+	ConnectionsTerminated bool
+}
+
+func TerminateConnections(ctx context.Context, in TerminateConnectionsIn) (TerminateConnectionsOut, error) {
+	db, err := connectAsRoot(ctx, in.SharedServiceHost, in.SharedRootPassword)
+	if err != nil {
+		return TerminateConnectionsOut{}, fmt.Errorf("connecting to terminate connections: %w", err)
+	}
+	defer db.Close()
+
+	if err := terminateMysqlConnections(ctx, db, in.SharedDbName); err != nil {
+		return TerminateConnectionsOut{}, err
+	}
+
+	return TerminateConnectionsOut{ConnectionsTerminated: true}, nil
+}
+
+func UndoTerminateConnections(ctx context.Context, in TerminateConnectionsIn, out TerminateConnectionsOut) error {
+	return nil
+}
+
+type DropSharedDatabaseIn struct {
+	SharedServiceHost     string
+	SharedRootPassword    string
+	SharedDbName          string
+	ConnectionsTerminated bool
+}
+
+type DropSharedDatabaseOut struct {
+	DatabaseDropped bool
+}
+
+func DropSharedDatabase(ctx context.Context, in DropSharedDatabaseIn) (DropSharedDatabaseOut, error) {
+	db, err := connectAsRoot(ctx, in.SharedServiceHost, in.SharedRootPassword)
+	if err != nil {
+		return DropSharedDatabaseOut{}, fmt.Errorf("connecting to drop database: %w", err)
+	}
+	defer db.Close()
+
+	if err := dropMysqlDatabase(ctx, db, in.SharedDbName); err != nil {
+		return DropSharedDatabaseOut{}, err
+	}
+
+	return DropSharedDatabaseOut{DatabaseDropped: true}, nil
+}
+
+func UndoDropSharedDatabase(ctx context.Context, in DropSharedDatabaseIn, out DropSharedDatabaseOut) error {
+	return nil
+}
+
+type DropSharedUserIn struct {
+	SharedServiceHost     string
+	SharedRootPassword    string
+	SharedUserName        string
+	ConnectionsTerminated bool
+}
+
+type DropSharedUserOut struct {
+	UserDropped bool
+}
+
+func DropSharedUser(ctx context.Context, in DropSharedUserIn) (DropSharedUserOut, error) {
+	db, err := connectAsRoot(ctx, in.SharedServiceHost, in.SharedRootPassword)
+	if err != nil {
+		return DropSharedUserOut{}, fmt.Errorf("connecting to drop user: %w", err)
+	}
+	defer db.Close()
+
+	if err := dropMysqlUser(ctx, db, in.SharedUserName); err != nil {
+		return DropSharedUserOut{}, err
+	}
+
+	return DropSharedUserOut{UserDropped: true}, nil
+}
+
+func UndoDropSharedUser(ctx context.Context, in DropSharedUserIn, out DropSharedUserOut) error {
+	return nil
+}
+
+type DecrementAssociationCountIn struct {
+	SharedServerRef entity.Id
+	DatabaseDropped bool
+	UserDropped     bool
+}
+
+type DecrementAssociationCountOut struct {
+	RemainingCount int64
+}
+
+func DecrementAssociationCount(ctx context.Context, in DecrementAssociationCountIn) (DecrementAssociationCountOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.MysqlServer
+	ent, err := fw.EC.GetByIdWithEntity(ctx, in.SharedServerRef, &server)
+	if err != nil {
+		return DecrementAssociationCountOut{}, fmt.Errorf("getting server: %w", err)
+	}
+
+	if server.AssociationCount <= 0 {
+		fw.Log.Warn("association count already zero, skipping decrement", "server", in.SharedServerRef)
+		return DecrementAssociationCountOut{RemainingCount: 0}, nil
+	}
+
+	newCount := server.AssociationCount - 1
+	if err := fw.EC.Patch(ctx, in.SharedServerRef, ent.Revision(),
+		entity.Int64(addon_v1alpha.MysqlServerAssociationCountId, newCount),
+	); err != nil {
+		return DecrementAssociationCountOut{}, fmt.Errorf("updating association count: %w", err)
+	}
+
+	return DecrementAssociationCountOut{RemainingCount: newCount}, nil
+}
+
+func UndoDecrementAssociationCount(ctx context.Context, in DecrementAssociationCountIn, out DecrementAssociationCountOut) error {
+	return nil
+}
+
+type CleanupSharedServerIn struct {
+	SharedServerRef    entity.Id
+	SharedServiceRef   entity.Id
+	SharedPoolRef      entity.Id
+	SharedRootPassword string
+	RemainingCount     int64
+}
+
+type CleanupSharedServerOut struct {
+	CleanedUp bool
+}
+
+func CleanupSharedServer(ctx context.Context, in CleanupSharedServerIn) (CleanupSharedServerOut, error) {
+	if in.RemainingCount > 0 {
+		return CleanupSharedServerOut{CleanedUp: false}, nil
+	}
+
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	if in.SharedServiceRef != "" {
+		if err := fw.DeleteService(ctx, in.SharedServiceRef); err != nil {
+			return CleanupSharedServerOut{}, fmt.Errorf("deleting shared service: %w", err)
+		}
+	}
+
+	if in.SharedPoolRef != "" {
+		if err := fw.DeleteSandboxPool(ctx, in.SharedPoolRef); err != nil {
+			return CleanupSharedServerOut{}, fmt.Errorf("deleting shared pool: %w", err)
+		}
+	}
+
+	if in.SharedRootPassword != "" {
+		diskName := sharedDiskNameForPassword(in.SharedRootPassword)
+		if err := fw.DeleteDiskByName(ctx, diskName); err != nil {
+			return CleanupSharedServerOut{}, fmt.Errorf("deleting shared data disk %s: %w", diskName, err)
+		}
+	}
+
+	if err := fw.EC.Delete(ctx, in.SharedServerRef); err != nil {
+		return CleanupSharedServerOut{}, fmt.Errorf("deleting shared server: %w", err)
+	}
+
+	return CleanupSharedServerOut{CleanedUp: true}, nil
+}
+
+func UndoCleanupSharedServer(ctx context.Context, in CleanupSharedServerIn, out CleanupSharedServerOut) error {
+	return nil
+}
+
+func RegisterDeprovisionSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
+	return saga.Define("deprovision-shared-mysql").
+		Using(fw).
+		Action(DecodeSharedAttrs).Undo(UndoDecodeSharedAttrs).
+		Action(LookupSharedServer).Undo(UndoLookupSharedServer).
+		Action(TerminateConnections).Undo(UndoTerminateConnections).
+		Action(DropSharedDatabase).Undo(UndoDropSharedDatabase).
+		Action(DropSharedUser).Undo(UndoDropSharedUser).
+		Action(DecrementAssociationCount).Undo(UndoDecrementAssociationCount).
+		Action(CleanupSharedServer).Undo(UndoCleanupSharedServer).
+		RegisterTo(registry)
+}
+
+func (p *Provider) provisionShared(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+	p.log.Info("provisioning shared MySQL",
+		"app", app.Name,
+		"variant", variant.Name)
+
+	rc := &resultCapture{}
+	registry := saga.NewRegistry()
+
+	if err := RegisterSharedSaga(registry, p.fw, rc); err != nil {
+		return nil, fmt.Errorf("registering shared saga: %w", err)
+	}
+
+	storage := p.fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+
+	err := executor.Start("provision-shared-mysql").
+		Input("appname", app.Name).
+		Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if rc.Result == nil {
+		return nil, fmt.Errorf("saga completed but no result was captured")
+	}
+
+	p.log.Info("shared MySQL provisioned", "app", app.Name)
+	return rc.Result, nil
+}
+
+func (p *Provider) deprovisionShared(ctx context.Context, assoc addon.AddonAssociation) error {
+	p.log.Info("deprovisioning shared MySQL", "assoc", assoc.ID)
+
+	registry := saga.NewRegistry()
+
+	if err := RegisterDeprovisionSharedSaga(registry, p.fw); err != nil {
+		return fmt.Errorf("registering deprovision saga: %w", err)
+	}
+
+	storage := p.fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+
+	err := executor.Start("deprovision-shared-mysql").
+		Input("assocentity", assoc.Entity).
+		Execute(ctx)
+	if err != nil {
+		return err
+	}
+
+	p.log.Info("shared MySQL deprovisioned", "assoc", assoc.ID)
+	return nil
+}

--- a/pkg/addon/mysql/shared.go
+++ b/pkg/addon/mysql/shared.go
@@ -815,19 +815,19 @@ func RegisterDeprovisionSharedSaga(registry *saga.Registry, fw *addon.ProviderFr
 }
 
 func (p *Provider) provisionShared(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
-	p.log.Info("provisioning shared MySQL",
+	p.Log.Info("provisioning shared MySQL",
 		"app", app.Name,
 		"variant", variant.Name)
 
 	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterSharedSaga(registry, p.fw, rc); err != nil {
+	if err := RegisterSharedSaga(registry, p.Fw, rc); err != nil {
 		return nil, fmt.Errorf("registering shared saga: %w", err)
 	}
 
-	storage := p.fw.Storage
-	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-shared-mysql").
 		Input("appname", app.Name).
@@ -840,21 +840,21 @@ func (p *Provider) provisionShared(ctx context.Context, app addon.App, variant a
 		return nil, fmt.Errorf("saga completed but no result was captured")
 	}
 
-	p.log.Info("shared MySQL provisioned", "app", app.Name)
+	p.Log.Info("shared MySQL provisioned", "app", app.Name)
 	return rc.Result, nil
 }
 
 func (p *Provider) deprovisionShared(ctx context.Context, assoc addon.AddonAssociation) error {
-	p.log.Info("deprovisioning shared MySQL", "assoc", assoc.ID)
+	p.Log.Info("deprovisioning shared MySQL", "assoc", assoc.ID)
 
 	registry := saga.NewRegistry()
 
-	if err := RegisterDeprovisionSharedSaga(registry, p.fw); err != nil {
+	if err := RegisterDeprovisionSharedSaga(registry, p.Fw); err != nil {
 		return fmt.Errorf("registering deprovision saga: %w", err)
 	}
 
-	storage := p.fw.Storage
-	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-shared-mysql").
 		Input("assocentity", assoc.Entity).
@@ -863,6 +863,6 @@ func (p *Provider) deprovisionShared(ctx context.Context, assoc addon.AddonAssoc
 		return err
 	}
 
-	p.log.Info("shared MySQL deprovisioned", "assoc", assoc.ID)
+	p.Log.Info("shared MySQL deprovisioned", "assoc", assoc.ID)
 	return nil
 }

--- a/pkg/addon/mysql/shared_test.go
+++ b/pkg/addon/mysql/shared_test.go
@@ -1,0 +1,57 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/saga"
+)
+
+func TestRegisterSharedSaga(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+	rc := &resultCapture{}
+
+	err := RegisterSharedSaga(registry, fw, rc)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("provision-shared-mysql")
+	require.True(t, ok)
+	assert.Equal(t, "provision-shared-mysql", def.Name)
+	assert.Len(t, def.Actions, 6)
+}
+
+func TestRegisterEnsureSharedServerSaga(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+
+	err := RegisterEnsureSharedServerSaga(registry, fw)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("ensure-shared-mysql-server")
+	require.True(t, ok)
+	assert.Equal(t, "ensure-shared-mysql-server", def.Name)
+	assert.Len(t, def.Actions, 6)
+}
+
+func TestRegisterDeprovisionSharedSaga(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+
+	err := RegisterDeprovisionSharedSaga(registry, fw)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("deprovision-shared-mysql")
+	require.True(t, ok)
+	assert.Equal(t, "deprovision-shared-mysql", def.Name)
+	assert.Len(t, def.Actions, 7)
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	assert.Equal(t, "`mydb`", quoteIdentifier("mydb"))
+	assert.Equal(t, "`my``db`", quoteIdentifier("my`db"))
+	assert.Equal(t, "`my-app`", quoteIdentifier("my-app"))
+}

--- a/pkg/addon/postgresql/dedicated.go
+++ b/pkg/addon/postgresql/dedicated.go
@@ -8,6 +8,7 @@ import (
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/dbsaga"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
 	"miren.dev/runtime/pkg/idgen"
@@ -116,7 +117,7 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 		"server", in.ServerName,
 	)
 
-	sizeGb := parseStorageGb(in.VariantConfig[ConfigStorage])
+	sizeGb := addon.ParseStorageGb(in.VariantConfig[ConfigStorage])
 	diskName := fmt.Sprintf("pg-%s-data", in.ServerName)
 	mountPath := "/var/lib/postgresql/data"
 
@@ -160,83 +161,6 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 func UndoCreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn, out CreateDedicatedPoolOut) error {
 	fw := saga.Get[*addon.ProviderFramework](ctx)
 	return fw.DeleteSandboxPool(ctx, out.PoolID)
-}
-
-type WaitForDedicatedPoolIn struct {
-	PoolID entity.Id
-}
-
-type WaitForDedicatedPoolOut struct {
-	Ready bool
-}
-
-func WaitForDedicatedPool(ctx context.Context, in WaitForDedicatedPoolIn) (WaitForDedicatedPoolOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	if err := fw.WaitForPool(ctx, in.PoolID, poolReadyTimeout); err != nil {
-		return WaitForDedicatedPoolOut{}, fmt.Errorf("waiting for postgres pool: %w", err)
-	}
-
-	return WaitForDedicatedPoolOut{Ready: true}, nil
-}
-
-func UndoWaitForDedicatedPool(ctx context.Context, in WaitForDedicatedPoolIn, out WaitForDedicatedPoolOut) error {
-	return nil
-}
-
-type CreateDedicatedServiceIn struct {
-	ServiceName string
-	AppName     string
-	ServerName  string
-}
-
-type CreateDedicatedServiceOut struct {
-	ServiceID entity.Id
-}
-
-func CreateDedicatedService(ctx context.Context, in CreateDedicatedServiceIn) (CreateDedicatedServiceOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	labels := types.LabelSet(
-		"addon", AddonName,
-		"app", in.AppName,
-		"server", in.ServerName,
-	)
-
-	svcID, err := fw.CreateService(ctx, in.ServiceName, labels, postgresPort)
-	if err != nil {
-		return CreateDedicatedServiceOut{}, fmt.Errorf("creating service: %w", err)
-	}
-
-	return CreateDedicatedServiceOut{ServiceID: svcID}, nil
-}
-
-func UndoCreateDedicatedService(ctx context.Context, in CreateDedicatedServiceIn, out CreateDedicatedServiceOut) error {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-	return fw.DeleteService(ctx, out.ServiceID)
-}
-
-type WaitForDedicatedServiceIn struct {
-	ServiceID entity.Id
-}
-
-type WaitForDedicatedServiceOut struct {
-	ServiceHost string
-}
-
-func WaitForDedicatedService(ctx context.Context, in WaitForDedicatedServiceIn) (WaitForDedicatedServiceOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	serviceHost, err := fw.WaitForServiceAddress(ctx, in.ServiceID, poolReadyTimeout)
-	if err != nil {
-		return WaitForDedicatedServiceOut{}, fmt.Errorf("waiting for dedicated service address: %w", err)
-	}
-
-	return WaitForDedicatedServiceOut{ServiceHost: serviceHost}, nil
-}
-
-func UndoWaitForDedicatedService(ctx context.Context, in WaitForDedicatedServiceIn, out WaitForDedicatedServiceOut) error {
-	return nil
 }
 
 type UpdateDedicatedServerIn struct {
@@ -312,15 +236,17 @@ func UndoBuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn, ou
 
 // RegisterDedicatedSaga registers the dedicated PostgreSQL provisioning saga.
 func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+	cfg := &dbsaga.AddonConfig{AddonName: AddonName, Port: postgresPort, ReadyTimeout: poolReadyTimeout}
 	return saga.Define("provision-dedicated-postgresql").
 		Using(fw).
 		Using(rc).
+		Using(cfg).
 		Action(GenerateCredentials).Undo(UndoGenerateCredentials).
 		Action(CreatePostgresServer).Undo(UndoCreatePostgresServer).
 		Action(CreateDedicatedPool).Undo(UndoCreateDedicatedPool).
-		Action(WaitForDedicatedPool).Undo(UndoWaitForDedicatedPool).
-		Action(CreateDedicatedService).Undo(UndoCreateDedicatedService).
-		Action(WaitForDedicatedService).Undo(UndoWaitForDedicatedService).
+		Action(dbsaga.WaitForDedicatedPool).Undo(dbsaga.UndoWaitForDedicatedPool).
+		Action(dbsaga.CreateDedicatedService).Undo(dbsaga.UndoCreateDedicatedService).
+		Action(dbsaga.WaitForDedicatedService).Undo(dbsaga.UndoWaitForDedicatedService).
 		Action(UpdateDedicatedServer).Undo(UndoUpdateDedicatedServer).
 		Action(BuildDedicatedResult).Undo(UndoBuildDedicatedResult).
 		RegisterTo(registry)
@@ -388,56 +314,6 @@ func UndoLookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn, 
 	return nil
 }
 
-type DeleteDedicatedServiceIn struct {
-	DedicatedServiceID entity.Id
-}
-
-type DeleteDedicatedServiceOut struct {
-	ServiceDeleted bool
-}
-
-func DeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn) (DeleteDedicatedServiceOut, error) {
-	if in.DedicatedServiceID == "" {
-		return DeleteDedicatedServiceOut{ServiceDeleted: false}, nil
-	}
-
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-	if err := fw.DeleteService(ctx, in.DedicatedServiceID); err != nil {
-		return DeleteDedicatedServiceOut{}, fmt.Errorf("deleting service: %w", err)
-	}
-
-	return DeleteDedicatedServiceOut{ServiceDeleted: true}, nil
-}
-
-func UndoDeleteDedicatedService(ctx context.Context, in DeleteDedicatedServiceIn, out DeleteDedicatedServiceOut) error {
-	return nil
-}
-
-type DeleteDedicatedPoolIn struct {
-	DedicatedPoolID entity.Id
-}
-
-type DeleteDedicatedPoolOut struct {
-	PoolDeleted bool `saga:"dedicated_pool_deleted"`
-}
-
-func DeleteDedicatedPool(ctx context.Context, in DeleteDedicatedPoolIn) (DeleteDedicatedPoolOut, error) {
-	if in.DedicatedPoolID == "" {
-		return DeleteDedicatedPoolOut{PoolDeleted: false}, nil
-	}
-
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-	if err := fw.DeleteSandboxPool(ctx, in.DedicatedPoolID); err != nil {
-		return DeleteDedicatedPoolOut{}, fmt.Errorf("deleting sandbox pool: %w", err)
-	}
-
-	return DeleteDedicatedPoolOut{PoolDeleted: true}, nil
-}
-
-func UndoDeleteDedicatedPool(ctx context.Context, in DeleteDedicatedPoolIn, out DeleteDedicatedPoolOut) error {
-	return nil
-}
-
 type DeleteDedicatedServerEntityIn struct {
 	DedicatedServerID   entity.Id
 	DedicatedServerName string
@@ -481,8 +357,8 @@ func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.Provide
 		Using(fw).
 		Action(DecodeDedicatedAttrs).Undo(UndoDecodeDedicatedAttrs).
 		Action(LookupDedicatedServer).Undo(UndoLookupDedicatedServer).
-		Action(DeleteDedicatedService).Undo(UndoDeleteDedicatedService).
-		Action(DeleteDedicatedPool).Undo(UndoDeleteDedicatedPool).
+		Action(dbsaga.DeleteDedicatedService).Undo(dbsaga.UndoDeleteDedicatedService).
+		Action(dbsaga.DeleteDedicatedPool).Undo(dbsaga.UndoDeleteDedicatedPool).
 		Action(DeleteDedicatedServerEntity).Undo(UndoDeleteDedicatedServerEntity).
 		RegisterTo(registry)
 }
@@ -490,45 +366,24 @@ func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.Provide
 // maxPgIdentLen is the maximum length of a PostgreSQL identifier (NAMEDATALEN-1).
 const maxPgIdentLen = 63
 
-// sanitizeIdentifier ensures a name is safe for use as a PostgreSQL identifier.
 func sanitizeIdentifier(name string) string {
-	result := make([]byte, 0, len(name))
-	for i := 0; i < len(name); i++ {
-		c := name[i]
-		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' {
-			result = append(result, c)
-		} else if c >= 'A' && c <= 'Z' {
-			result = append(result, c+32) // lowercase
-		} else if c == '-' {
-			result = append(result, '_')
-		}
-	}
-	if len(result) == 0 {
-		return "app"
-	}
-	if result[0] >= '0' && result[0] <= '9' {
-		result = append([]byte{'a'}, result...)
-	}
-	if len(result) > maxPgIdentLen {
-		result = result[:maxPgIdentLen]
-	}
-	return string(result)
+	return addon.SanitizeIdentifier(name, maxPgIdentLen)
 }
 
 func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
-	p.log.Info("provisioning dedicated PostgreSQL",
+	p.Log.Info("provisioning dedicated PostgreSQL",
 		"app", app.Name,
 		"variant", variant.Name)
 
 	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterDedicatedSaga(registry, p.fw, rc); err != nil {
+	if err := RegisterDedicatedSaga(registry, p.Fw, rc); err != nil {
 		return nil, fmt.Errorf("registering dedicated saga: %w", err)
 	}
 
-	storage := p.fw.Storage
-	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-dedicated-postgresql").
 		Input("appname", app.Name).
@@ -543,21 +398,21 @@ func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, varian
 		return nil, fmt.Errorf("saga completed but no result was captured")
 	}
 
-	p.log.Info("dedicated PostgreSQL provisioned", "app", app.Name)
+	p.Log.Info("dedicated PostgreSQL provisioned", "app", app.Name)
 	return rc.Result, nil
 }
 
 func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAssociation) error {
-	p.log.Info("deprovisioning dedicated PostgreSQL", "assoc", assoc.ID)
+	p.Log.Info("deprovisioning dedicated PostgreSQL", "assoc", assoc.ID)
 
 	registry := saga.NewRegistry()
 
-	if err := RegisterDeprovisionDedicatedSaga(registry, p.fw); err != nil {
+	if err := RegisterDeprovisionDedicatedSaga(registry, p.Fw); err != nil {
 		return fmt.Errorf("registering deprovision saga: %w", err)
 	}
 
-	storage := p.fw.Storage
-	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-dedicated-postgresql").
 		Input("assocentity", assoc.Entity).
@@ -566,6 +421,6 @@ func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAs
 		return err
 	}
 
-	p.log.Info("dedicated PostgreSQL deprovisioned", "assoc", assoc.ID)
+	p.Log.Info("dedicated PostgreSQL deprovisioned", "assoc", assoc.ID)
 	return nil
 }

--- a/pkg/addon/postgresql/dedicated.go
+++ b/pkg/addon/postgresql/dedicated.go
@@ -160,13 +160,18 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 
 func UndoCreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn, out CreateDedicatedPoolOut) error {
 	fw := saga.Get[*addon.ProviderFramework](ctx)
-	return fw.DeleteSandboxPool(ctx, out.PoolID)
+	if err := fw.DeleteSandboxPool(ctx, out.PoolID); err != nil {
+		return err
+	}
+	diskName := fmt.Sprintf("pg-%s-data", in.ServerName)
+	return fw.DeleteDiskByName(ctx, diskName)
 }
 
 type UpdateDedicatedServerIn struct {
 	ServerID    entity.Id
 	PoolID      entity.Id
 	ServiceID   entity.Id
+	ServiceHost string
 	VariantName string
 	Password    string
 }

--- a/pkg/addon/postgresql/dedicated.go
+++ b/pkg/addon/postgresql/dedicated.go
@@ -487,6 +487,9 @@ func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.Provide
 		RegisterTo(registry)
 }
 
+// maxPgIdentLen is the maximum length of a PostgreSQL identifier (NAMEDATALEN-1).
+const maxPgIdentLen = 63
+
 // sanitizeIdentifier ensures a name is safe for use as a PostgreSQL identifier.
 func sanitizeIdentifier(name string) string {
 	result := make([]byte, 0, len(name))
@@ -505,6 +508,9 @@ func sanitizeIdentifier(name string) string {
 	}
 	if result[0] >= '0' && result[0] <= '9' {
 		result = append([]byte{'a'}, result...)
+	}
+	if len(result) > maxPgIdentLen {
+		result = result[:maxPgIdentLen]
 	}
 	return string(result)
 }

--- a/pkg/addon/postgresql/plans.go
+++ b/pkg/addon/postgresql/plans.go
@@ -1,9 +1,6 @@
 package postgresql
 
 import (
-	"strconv"
-	"strings"
-
 	"miren.dev/runtime/pkg/addon"
 )
 
@@ -54,20 +51,7 @@ func Definition() addon.AddonDefinition {
 
 const sharedDefaultStorageGb int64 = 10
 
-// parseStorageGb converts a Kubernetes-style size string (e.g. "1Gi", "50Gi")
-// to an int64 value in gigabytes. Returns 1 if the string cannot be parsed.
-func parseStorageGb(s string) int64 {
-	s = strings.TrimSpace(s)
-	if strings.HasSuffix(s, "Gi") {
-		n, err := strconv.ParseInt(strings.TrimSuffix(s, "Gi"), 10, 64)
-		if err == nil && n > 0 {
-			return n
-		}
-	}
-	return 1
-}
-
 // IsSharedVariant returns true if the variant is a shared-server variant.
 func IsSharedVariant(variantName string) bool {
-	return variantName == "shared"
+	return addon.IsSharedVariant(variantName)
 }

--- a/pkg/addon/postgresql/plans_test.go
+++ b/pkg/addon/postgresql/plans_test.go
@@ -41,6 +41,7 @@ func TestSanitizeIdentifier(t *testing.T) {
 		{"APP-NAME", "app_name"},
 		{"", "app"},
 		{"a", "a"},
+		{"a-very-long-application-name-that-exceeds-the-postgres-identifier-limit-of-63-chars", "a_very_long_application_name_that_exceeds_the_postgres_identifi"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/addon/postgresql/provider.go
+++ b/pkg/addon/postgresql/provider.go
@@ -3,28 +3,25 @@ package postgresql
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/url"
 
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/dbsaga"
 )
 
 // Provider implements the AddonProvider interface for PostgreSQL.
 type Provider struct {
-	fw  *addon.ProviderFramework
-	log *slog.Logger
+	dbsaga.BaseProvider
 }
 
 // NewProvider creates a new PostgreSQL addon provider.
 func NewProvider(fw *addon.ProviderFramework) *Provider {
 	return &Provider{
-		fw:  fw,
-		log: fw.Log.With("addon", AddonName),
+		BaseProvider: dbsaga.BaseProvider{
+			Fw:  fw,
+			Log: fw.Log.With("addon", AddonName),
+		},
 	}
-}
-
-func (p *Provider) LocalityMode() addon.LocalityMode {
-	return addon.OnCluster
 }
 
 func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
@@ -32,13 +29,6 @@ func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.V
 		return p.provisionShared(ctx, app, variant)
 	}
 	return p.provisionDedicated(ctx, app, variant)
-}
-
-func (p *Provider) AdjustEnvVars(ctx context.Context, result *addon.ProvisionResult, assoc addon.AddonAssociation, collisions []string) ([]addon.Variable, error) {
-	// For PostgreSQL, we don't adjust variable names on collision.
-	// The addon's vars take priority and the user should rename their
-	// conflicting manual vars instead.
-	return result.EnvVars, nil
 }
 
 func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/postgresql/server_counter.go
+++ b/pkg/addon/postgresql/server_counter.go
@@ -1,0 +1,34 @@
+package postgresql
+
+import (
+	"context"
+	"fmt"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// pgServerCounter implements dbsaga.ServerCounter for PostgreSQL.
+type pgServerCounter struct{}
+
+func (pgServerCounter) GetAssociationCount(ctx context.Context, serverID entity.Id) (int64, int64, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.PostgresServer
+	ent, err := fw.EC.GetByIdWithEntity(ctx, serverID, &server)
+	if err != nil {
+		return 0, 0, fmt.Errorf("getting postgres server: %w", err)
+	}
+
+	return server.AssociationCount, ent.Revision(), nil
+}
+
+func (pgServerCounter) PatchAssociationCount(ctx context.Context, serverID entity.Id, revision int64, newCount int64) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	return fw.EC.Patch(ctx, serverID, revision,
+		entity.Int64(addon_v1alpha.PostgresServerAssociationCountId, newCount),
+	)
+}

--- a/pkg/addon/postgresql/shared.go
+++ b/pkg/addon/postgresql/shared.go
@@ -11,6 +11,7 @@ import (
 	"miren.dev/runtime/api/addon/addon_v1alpha"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/dbsaga"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
@@ -139,80 +140,6 @@ func UndoCreateSharedPool(ctx context.Context, in CreateSharedPoolIn, out Create
 	return fw.DeleteSandboxPool(ctx, out.PoolID)
 }
 
-type WaitForSharedPoolIn struct {
-	PoolID entity.Id
-}
-
-type WaitForSharedPoolOut struct {
-	PoolReady bool
-}
-
-func WaitForSharedPool(ctx context.Context, in WaitForSharedPoolIn) (WaitForSharedPoolOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	if err := fw.WaitForPool(ctx, in.PoolID, poolReadyTimeout); err != nil {
-		return WaitForSharedPoolOut{}, fmt.Errorf("waiting for shared pool: %w", err)
-	}
-
-	return WaitForSharedPoolOut{PoolReady: true}, nil
-}
-
-func UndoWaitForSharedPool(ctx context.Context, in WaitForSharedPoolIn, out WaitForSharedPoolOut) error {
-	return nil
-}
-
-type CreateSharedServiceIn struct{}
-
-type CreateSharedServiceOut struct {
-	ServiceID entity.Id
-}
-
-func CreateSharedService(ctx context.Context, in CreateSharedServiceIn) (CreateSharedServiceOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	labels := types.LabelSet(
-		"addon", AddonName,
-		"server", sharedServerName,
-		"shared", "true",
-	)
-
-	serviceName := sharedServerName + "-postgresql"
-	svcID, err := fw.CreateService(ctx, serviceName, labels, postgresPort)
-	if err != nil {
-		return CreateSharedServiceOut{}, fmt.Errorf("creating shared service: %w", err)
-	}
-
-	return CreateSharedServiceOut{ServiceID: svcID}, nil
-}
-
-func UndoCreateSharedService(ctx context.Context, in CreateSharedServiceIn, out CreateSharedServiceOut) error {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-	return fw.DeleteService(ctx, out.ServiceID)
-}
-
-type WaitForSharedServiceIn struct {
-	ServiceID entity.Id
-}
-
-type WaitForSharedServiceOut struct {
-	ServiceHost string
-}
-
-func WaitForSharedService(ctx context.Context, in WaitForSharedServiceIn) (WaitForSharedServiceOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	serviceHost, err := fw.WaitForServiceAddress(ctx, in.ServiceID, poolReadyTimeout)
-	if err != nil {
-		return WaitForSharedServiceOut{}, fmt.Errorf("waiting for shared service address: %w", err)
-	}
-
-	return WaitForSharedServiceOut{ServiceHost: serviceHost}, nil
-}
-
-func UndoWaitForSharedService(ctx context.Context, in WaitForSharedServiceIn, out WaitForSharedServiceOut) error {
-	return nil
-}
-
 type ActivateSharedServerIn struct {
 	ServerID          entity.Id
 	PoolID            entity.Id
@@ -253,13 +180,15 @@ func UndoActivateSharedServer(ctx context.Context, in ActivateSharedServerIn, ou
 // RegisterEnsureSharedServerSaga registers the saga that creates the shared
 // PostgreSQL server infrastructure (entity, pool, service).
 func RegisterEnsureSharedServerSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
+	cfg := &dbsaga.AddonConfig{AddonName: AddonName, SharedServerName: sharedServerName, Port: postgresPort, ReadyTimeout: poolReadyTimeout}
 	return saga.Define("ensure-shared-server").
 		Using(fw).
+		Using(cfg).
 		Action(CreateSharedServerEntity).Undo(UndoCreateSharedServerEntity).
 		Action(CreateSharedPool).Undo(UndoCreateSharedPool).
-		Action(WaitForSharedPool).Undo(UndoWaitForSharedPool).
-		Action(CreateSharedService).Undo(UndoCreateSharedService).
-		Action(WaitForSharedService).Undo(UndoWaitForSharedService).
+		Action(dbsaga.WaitForSharedPool).Undo(dbsaga.UndoWaitForSharedPool).
+		Action(dbsaga.CreateSharedService).Undo(dbsaga.UndoCreateSharedService).
+		Action(dbsaga.WaitForSharedService).Undo(dbsaga.UndoWaitForSharedService).
 		Action(ActivateSharedServer).Undo(UndoActivateSharedServer).
 		RegisterTo(registry)
 }
@@ -501,56 +430,7 @@ func UndoCreateSharedDatabase(ctx context.Context, in CreateSharedDatabaseIn, ou
 	return dropPostgresDatabase(ctx, conn, in.SharedDatabaseName)
 }
 
-// Step 5: Increment association_count on the shared PostgresServer.
-
-type IncrementAssociationCountIn struct {
-	ServerID entity.Id
-}
-
-type IncrementAssociationCountOut struct {
-	Incremented bool
-}
-
-func IncrementAssociationCount(ctx context.Context, in IncrementAssociationCountIn) (IncrementAssociationCountOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	var server addon_v1alpha.PostgresServer
-	ent, err := fw.EC.GetByIdWithEntity(ctx, in.ServerID, &server)
-	if err != nil {
-		return IncrementAssociationCountOut{}, fmt.Errorf("getting server for count increment: %w", err)
-	}
-
-	newCount := server.AssociationCount + 1
-	if err := fw.EC.Patch(ctx, in.ServerID, ent.Revision(),
-		entity.Int64(addon_v1alpha.PostgresServerAssociationCountId, newCount),
-	); err != nil {
-		return IncrementAssociationCountOut{}, fmt.Errorf("updating association count: %w", err)
-	}
-
-	return IncrementAssociationCountOut{Incremented: true}, nil
-}
-
-func UndoIncrementAssociationCount(ctx context.Context, in IncrementAssociationCountIn, out IncrementAssociationCountOut) error {
-	if !out.Incremented {
-		return nil
-	}
-
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	var server addon_v1alpha.PostgresServer
-	ent, err := fw.EC.GetByIdWithEntity(ctx, in.ServerID, &server)
-	if err != nil {
-		return err
-	}
-
-	newCount := server.AssociationCount - 1
-	if newCount < 0 {
-		newCount = 0
-	}
-	return fw.EC.Patch(ctx, in.ServerID, ent.Revision(),
-		entity.Int64(addon_v1alpha.PostgresServerAssociationCountId, newCount),
-	)
-}
+// Step 5 (IncrementAssociationCount) is in dbsaga.
 
 // Step 6: Build the ProvisionResult.
 
@@ -596,14 +476,18 @@ func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc
 		return err
 	}
 
-	return saga.Define("provision-shared-postgresql").
+	cfg := &dbsaga.AddonConfig{AddonName: AddonName, SharedServerName: sharedServerName, Port: postgresPort, ReadyTimeout: poolReadyTimeout}
+	b := saga.Define("provision-shared-postgresql").
 		Using(fw).
 		Using(rc).
+		Using(cfg)
+	saga.UsingAs[dbsaga.ServerCounter](b, pgServerCounter{})
+	return b.
 		Action(FindOrCreateSharedServer).Undo(UndoFindOrCreateSharedServer).
 		Action(GenerateSharedCredentials).Undo(UndoGenerateSharedCredentials).
 		Action(CreateSharedUser).Undo(UndoCreateSharedUser).
 		Action(CreateSharedDatabase).Undo(UndoCreateSharedDatabase).
-		Action(IncrementAssociationCount).Undo(UndoIncrementAssociationCount).
+		Action(dbsaga.IncrementAssociationCount).Undo(dbsaga.UndoIncrementAssociationCount).
 		Action(BuildSharedResult).Undo(UndoBuildSharedResult).
 		RegisterTo(registry)
 }
@@ -765,44 +649,6 @@ func UndoDropSharedUser(ctx context.Context, in DropSharedUserIn, out DropShared
 	return nil
 }
 
-type DecrementAssociationCountIn struct {
-	SharedServerRef entity.Id
-	DatabaseDropped bool
-	UserDropped     bool
-}
-
-type DecrementAssociationCountOut struct {
-	RemainingCount int64
-}
-
-func DecrementAssociationCount(ctx context.Context, in DecrementAssociationCountIn) (DecrementAssociationCountOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
-	var server addon_v1alpha.PostgresServer
-	ent, err := fw.EC.GetByIdWithEntity(ctx, in.SharedServerRef, &server)
-	if err != nil {
-		return DecrementAssociationCountOut{}, fmt.Errorf("getting server: %w", err)
-	}
-
-	if server.AssociationCount <= 0 {
-		fw.Log.Warn("association count already zero, skipping decrement", "server", in.SharedServerRef)
-		return DecrementAssociationCountOut{RemainingCount: 0}, nil
-	}
-
-	newCount := server.AssociationCount - 1
-	if err := fw.EC.Patch(ctx, in.SharedServerRef, ent.Revision(),
-		entity.Int64(addon_v1alpha.PostgresServerAssociationCountId, newCount),
-	); err != nil {
-		return DecrementAssociationCountOut{}, fmt.Errorf("updating association count: %w", err)
-	}
-
-	return DecrementAssociationCountOut{RemainingCount: newCount}, nil
-}
-
-func UndoDecrementAssociationCount(ctx context.Context, in DecrementAssociationCountIn, out DecrementAssociationCountOut) error {
-	return nil
-}
-
 type CleanupSharedServerIn struct {
 	SharedServerRef         entity.Id
 	SharedServiceRef        entity.Id
@@ -857,14 +703,16 @@ func UndoCleanupSharedServer(ctx context.Context, in CleanupSharedServerIn, out 
 
 // RegisterDeprovisionSharedSaga registers the shared deprovisioning saga.
 func RegisterDeprovisionSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
-	return saga.Define("deprovision-shared-postgresql").
-		Using(fw).
+	b := saga.Define("deprovision-shared-postgresql").
+		Using(fw)
+	saga.UsingAs[dbsaga.ServerCounter](b, pgServerCounter{})
+	return b.
 		Action(DecodeSharedAttrs).Undo(UndoDecodeSharedAttrs).
 		Action(LookupSharedServer).Undo(UndoLookupSharedServer).
 		Action(TerminateConnections).Undo(UndoTerminateConnections).
 		Action(DropSharedDatabase).Undo(UndoDropSharedDatabase).
 		Action(DropSharedUser).Undo(UndoDropSharedUser).
-		Action(DecrementAssociationCount).Undo(UndoDecrementAssociationCount).
+		Action(dbsaga.DecrementAssociationCount).Undo(dbsaga.UndoDecrementAssociationCount).
 		Action(CleanupSharedServer).Undo(UndoCleanupSharedServer).
 		RegisterTo(registry)
 }

--- a/pkg/addon/postgresql/shared.go
+++ b/pkg/addon/postgresql/shared.go
@@ -870,19 +870,19 @@ func RegisterDeprovisionSharedSaga(registry *saga.Registry, fw *addon.ProviderFr
 }
 
 func (p *Provider) provisionShared(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
-	p.log.Info("provisioning shared PostgreSQL",
+	p.Log.Info("provisioning shared PostgreSQL",
 		"app", app.Name,
 		"variant", variant.Name)
 
 	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterSharedSaga(registry, p.fw, rc); err != nil {
+	if err := RegisterSharedSaga(registry, p.Fw, rc); err != nil {
 		return nil, fmt.Errorf("registering shared saga: %w", err)
 	}
 
-	storage := p.fw.Storage
-	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-shared-postgresql").
 		Input("appname", app.Name).
@@ -895,21 +895,21 @@ func (p *Provider) provisionShared(ctx context.Context, app addon.App, variant a
 		return nil, fmt.Errorf("saga completed but no result was captured")
 	}
 
-	p.log.Info("shared PostgreSQL provisioned", "app", app.Name)
+	p.Log.Info("shared PostgreSQL provisioned", "app", app.Name)
 	return rc.Result, nil
 }
 
 func (p *Provider) deprovisionShared(ctx context.Context, assoc addon.AddonAssociation) error {
-	p.log.Info("deprovisioning shared PostgreSQL", "assoc", assoc.ID)
+	p.Log.Info("deprovisioning shared PostgreSQL", "assoc", assoc.ID)
 
 	registry := saga.NewRegistry()
 
-	if err := RegisterDeprovisionSharedSaga(registry, p.fw); err != nil {
+	if err := RegisterDeprovisionSharedSaga(registry, p.Fw); err != nil {
 		return fmt.Errorf("registering deprovision saga: %w", err)
 	}
 
-	storage := p.fw.Storage
-	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.log))
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-shared-postgresql").
 		Input("assocentity", assoc.Entity).
@@ -918,6 +918,6 @@ func (p *Provider) deprovisionShared(ctx context.Context, assoc addon.AddonAssoc
 		return err
 	}
 
-	p.log.Info("shared PostgreSQL deprovisioned", "assoc", assoc.ID)
+	p.Log.Info("shared PostgreSQL deprovisioned", "assoc", assoc.ID)
 	return nil
 }

--- a/pkg/addon/registry.go
+++ b/pkg/addon/registry.go
@@ -83,7 +83,7 @@ func (r *Registry) EnsureEntities(ctx context.Context, ec *entityserver.Client) 
 			Variants:       variants,
 		}
 
-		_, err := ec.CreateOrUpdate(ctx, name, addonEntity)
+		_, err := ec.CreateOrReplace(ctx, name, addonEntity)
 		if err != nil {
 			return fmt.Errorf("ensuring addon entity %q: %w", name, err)
 		}

--- a/testdata/bun-mysql/.gitignore
+++ b/testdata/bun-mysql/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/testdata/bun-mysql/.miren/app.toml
+++ b/testdata/bun-mysql/.miren/app.toml
@@ -1,0 +1,7 @@
+name = "bun-mysql"
+
+[services.web]
+command = "bun run index.ts"
+
+[addons.miren-mysql]
+variant = "shared"

--- a/testdata/bun-mysql/bun.lock
+++ b/testdata/bun-mysql/bun.lock
@@ -1,0 +1,9 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "bun-mysql-example"
+    }
+  },
+  "packages": {}
+}

--- a/testdata/bun-mysql/index.ts
+++ b/testdata/bun-mysql/index.ts
@@ -1,0 +1,53 @@
+import { SQL } from "bun";
+
+const sql = new SQL({
+  url: process.env.DATABASE_URL,
+  tls: { rejectUnauthorized: false },
+});
+
+await sql`
+  CREATE TABLE IF NOT EXISTS visits (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    path TEXT NOT NULL,
+    visited_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  )
+`;
+
+const server = Bun.serve({
+  port: process.env.PORT || 3000,
+
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/") {
+      const path = "/";
+      await sql`INSERT INTO visits (path) VALUES (${path})`;
+
+      const rows = await sql`SELECT COUNT(*) as count FROM visits`;
+      const count = rows[0].count;
+
+      return new Response(`Hello! This page has been visited ${count} times.\n`);
+    }
+
+    if (url.pathname === "/visits") {
+      const rows = await sql`
+        SELECT path, visited_at FROM visits ORDER BY visited_at DESC LIMIT 20
+      `;
+
+      return Response.json(rows);
+    }
+
+    if (url.pathname === "/health") {
+      try {
+        await sql`SELECT 1`;
+        return new Response("ok\n");
+      } catch {
+        return new Response("database unavailable\n", { status: 503 });
+      }
+    }
+
+    return new Response("not found\n", { status: 404 });
+  },
+});
+
+console.log(`Listening on http://localhost:${server.port}`);

--- a/testdata/bun-mysql/package.json
+++ b/testdata/bun-mysql/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bun-mysql-example",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "bun run index.ts"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `miren-mysql` addon provider with dedicated and shared variants, mirroring the PostgreSQL addon pattern
- Fix `EnsureEntities` to use `CreateOrReplace` instead of `CreateOrUpdate`, preventing duplicate component entries from accumulating on server restarts
- Extract shared database addon scaffolding into `pkg/addon/dbsaga/` to eliminate ~400 lines of duplication between providers

## Changes

**New MySQL addon** (`pkg/addon/mysql/`):
- Dedicated and shared provisioning/deprovisioning sagas
- MySQL-specific env vars: `DATABASE_URL`, `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_DATABASE`
- Connection utilities using `github.com/go-sql-driver/mysql`
- Unit tests for plans, saga registration, and action ordering

**Entity store fix** (`api/entityserver/client.go`):
- New `CreateOrReplace` method that uses `Replace` instead of `Put` on update, preventing "many" component fields from appending duplicates

**Shared addon framework** (`pkg/addon/dbsaga/`, `pkg/addon/ident.go`):
- `BaseProvider` with shared `LocalityMode` and `AdjustEnvVars`
- `AddonConfig` for injecting addon-specific constants into shared saga actions
- 10 shared saga actions (wait, service, pool lifecycle + association counting)
- `SanitizeIdentifier`, `ParseStorageGb`, `IsSharedVariant` utilities

**Blackbox tests** (`blackbox/addon_test.go`, `testdata/bun-mysql/`):
- `TestMysqlAddonCreateListDestroy` — dedicated addon lifecycle
- `TestMysqlAddonDeployWithAppToml` — end-to-end shared addon via app.toml with DB connectivity verification
- Updated `TestAddonListAvailable` and `TestAddonVariants` to cover MySQL

Closes MIR-901

## Test plan

- [x] `make test` — 3786 tests pass
- [x] `make test-blackbox` — 17/17 tests pass (including new MySQL tests)
- [x] `golangci-lint run` — no issues