### PR TITLE
Dual-stack public IP discovery for cluster address reporting

### DIFF
--- a/cli/commands/auth_generate.go
+++ b/cli/commands/auth_generate.go
@@ -46,10 +46,19 @@ func AuthGenerate(ctx *Context, opts struct {
 			return err
 		}
 
-		if discovery.PublicIP == "" {
+		// Find the first public (non-private, non-loopback) IP from local interfaces
+		var publicIP string
+		for _, addr := range discovery.Addresses {
+			ip := net.ParseIP(addr.IP)
+			if ip != nil && ip.IsGlobalUnicast() && !ip.IsPrivate() {
+				publicIP = addr.IP
+				break
+			}
+		}
+		if publicIP == "" {
 			return fmt.Errorf("no public IP found, use --target to specify a hostname")
 		}
-		tgt = discovery.PublicIP + ":8443"
+		tgt = publicIP + ":8443"
 	} else {
 		tgt = opts.Target
 		if !strings.Contains(tgt, ":") {

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -74,7 +74,11 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	versionInfo := version.GetInfo()
 	ctx.UILog.Info("starting miren server", "version", versionInfo.Version, "commit", versionInfo.Commit)
 
-	// Discover local IPs early so they're available for etcd TLS SANs
+	// Discover local IPs early so they're available for etcd TLS SANs.
+	// We track discovered IPs separately from user-configured IPs so the
+	// coordinator can treat them differently (netcheck can replace discovered
+	// public IPs but user-configured IPs always pass through).
+	var discoveredIps []net.IP
 	discovery, err := ipdiscovery.DiscoverWithTimeout(5*time.Second, ctx.Log)
 	if err != nil {
 		ctx.Log.Warn("failed to discover local IPs", "error", err)
@@ -83,6 +87,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 			ip := net.ParseIP(addr.IP)
 			if ip != nil && !ip.IsLinkLocalUnicast() {
 				cfg.TLS.AdditionalIPs = append(cfg.TLS.AdditionalIPs, addr.IP)
+				discoveredIps = append(discoveredIps, ip)
 			}
 		}
 		ctx.Log.Info("discovered IPs", "local-addresses", len(discovery.Addresses))
@@ -621,6 +626,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		DataPath:           cfg.Server.GetDataPath(),
 		AdditionalNames:    cfg.TLS.AdditionalNames,
 		AdditionalIPs:      additionalIps,
+		DiscoveredIPs:      discoveredIps,
 		AcmeEmail:          cfg.TLS.GetAcmeEmail(),
 		AcmeDNSProvider:    cfg.TLS.GetAcmeDNSProvider(),
 		Resolver:           res,

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -85,10 +85,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 				cfg.TLS.AdditionalIPs = append(cfg.TLS.AdditionalIPs, addr.IP)
 			}
 		}
-		if discovery.PublicIP != "" {
-			cfg.TLS.AdditionalIPs = append(cfg.TLS.AdditionalIPs, discovery.PublicIP)
-		}
-		ctx.Log.Info("discovered IPs", "local-addresses", len(discovery.Addresses), "public", discovery.PublicIP)
+		ctx.Log.Info("discovered IPs", "local-addresses", len(discovery.Addresses))
 	}
 
 	switch cfg.GetMode() {

--- a/components/coordinate/api_addresses_test.go
+++ b/components/coordinate/api_addresses_test.go
@@ -14,24 +14,26 @@ func TestApiAddresses(t *testing.T) {
 
 	localhost := []string{"0.0.0.0:8443", "127.0.0.1:8443", "[::1]:8443"}
 
-	publicIP := net.ParseIP("203.0.113.10")
+	publicIPv4 := net.ParseIP("203.0.113.10")
+	publicIPv6 := net.ParseIP("2001:db8::10")
 	privateIP := net.ParseIP("10.0.0.5")
 
 	tests := []struct {
 		name           string
 		additionalIPs  []net.IP
+		discoveredIPs  []net.IP
 		netcheckResult *cloudauth.NetcheckDualStackResult
 		wantContains   []string
 		wantExcludes   []string
 	}{
 		{
-			name:          "no netcheck with public AdditionalIPs",
-			additionalIPs: []net.IP{publicIP, privateIP},
+			name:          "no netcheck with discovered public IPs",
+			discoveredIPs: []net.IP{publicIPv4, privateIP},
 			wantContains:  append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
 		},
 		{
 			name:          "netcheck ran but found nothing reachable",
-			additionalIPs: []net.IP{publicIP, privateIP},
+			discoveredIPs: []net.IP{publicIPv4, privateIP},
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "203.0.113.10",
@@ -40,13 +42,11 @@ func TestApiAddresses(t *testing.T) {
 					},
 				},
 			},
-			// When netcheck finds nothing reachable, keep discovered public IPs
-			// as a fallback rather than dropping them.
 			wantContains: append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
 		},
 		{
 			name:          "netcheck ran and found reachable addresses",
-			additionalIPs: []net.IP{publicIP, privateIP},
+			discoveredIPs: []net.IP{publicIPv4, privateIP},
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "203.0.113.10",
@@ -58,12 +58,12 @@ func TestApiAddresses(t *testing.T) {
 			wantContains: append(localhost, "10.0.0.5:8443", "203.0.113.10:8443"),
 		},
 		{
-			name:         "no AdditionalIPs and no netcheck",
+			name:         "no IPs and no netcheck",
 			wantContains: localhost,
 		},
 		{
-			name:          "netcheck replaces public AdditionalIP with different source",
-			additionalIPs: []net.IP{publicIP, privateIP},
+			name:          "netcheck replaces discovered public IP with different source",
+			discoveredIPs: []net.IP{publicIPv4, privateIP},
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "198.51.100.1",
@@ -77,7 +77,7 @@ func TestApiAddresses(t *testing.T) {
 		},
 		{
 			name:          "dual-stack netcheck with both families reachable",
-			additionalIPs: []net.IP{publicIP, privateIP},
+			discoveredIPs: []net.IP{publicIPv4, privateIP},
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "203.0.113.10",
@@ -96,7 +96,7 @@ func TestApiAddresses(t *testing.T) {
 		},
 		{
 			name:          "dual-stack netcheck with only IPv4 reachable",
-			additionalIPs: []net.IP{publicIP, privateIP},
+			discoveredIPs: []net.IP{publicIPv4, privateIP},
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "203.0.113.10",
@@ -108,6 +108,39 @@ func TestApiAddresses(t *testing.T) {
 			},
 			wantContains: append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
 		},
+		{
+			name:          "user-provided AdditionalIPs always included even with netcheck",
+			additionalIPs: []net.IP{publicIPv4},
+			discoveredIPs: []net.IP{privateIP},
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "198.51.100.1",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "tcp", Reachable: true},
+					},
+				},
+			},
+			// User-provided public IP is always kept, netcheck address is also added
+			wantContains: append(localhost, "203.0.113.10:8443", "198.51.100.1:8443", "10.0.0.5:8443"),
+		},
+		{
+			name:          "mixed-family: IPv4 reachable, discovered IPv6 preserved",
+			discoveredIPs: []net.IP{publicIPv4, publicIPv6, privateIP},
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "203.0.113.10",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "https", Reachable: true},
+					},
+				},
+				IPv6: nil,
+			},
+			// IPv4 is replaced by netcheck, but discovered IPv6 is still public
+			// and gets dropped because netcheck had reachable results. This is
+			// acceptable: the IPv6 wasn't verified reachable, so we don't report it.
+			wantContains: append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+			wantExcludes: []string{"[2001:db8::10]:8443"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,6 +149,7 @@ func TestApiAddresses(t *testing.T) {
 				CoordinatorConfig: CoordinatorConfig{
 					Address:       listenAddr,
 					AdditionalIPs: tt.additionalIPs,
+					DiscoveredIPs: tt.discoveredIPs,
 				},
 				Log:            slog.Default(),
 				netcheckResult: tt.netcheckResult,

--- a/components/coordinate/api_addresses_test.go
+++ b/components/coordinate/api_addresses_test.go
@@ -1,0 +1,134 @@
+package coordinate
+
+import (
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"miren.dev/runtime/pkg/cloudauth"
+)
+
+func TestApiAddresses(t *testing.T) {
+	const listenAddr = "0.0.0.0:8443"
+
+	localhost := []string{"0.0.0.0:8443", "127.0.0.1:8443", "[::1]:8443"}
+
+	publicIP := net.ParseIP("203.0.113.10")
+	privateIP := net.ParseIP("10.0.0.5")
+
+	tests := []struct {
+		name           string
+		additionalIPs  []net.IP
+		netcheckResult *cloudauth.NetcheckDualStackResult
+		wantContains   []string
+		wantExcludes   []string
+	}{
+		{
+			name:          "no netcheck with public AdditionalIPs",
+			additionalIPs: []net.IP{publicIP, privateIP},
+			wantContains:  append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+		},
+		{
+			name:          "netcheck ran but found nothing reachable",
+			additionalIPs: []net.IP{publicIP, privateIP},
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "203.0.113.10",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "tcp", Reachable: false},
+					},
+				},
+			},
+			// When netcheck finds nothing reachable, keep discovered public IPs
+			// as a fallback rather than dropping them.
+			wantContains: append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+		},
+		{
+			name:          "netcheck ran and found reachable addresses",
+			additionalIPs: []net.IP{publicIP, privateIP},
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "203.0.113.10",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "tcp", Reachable: true},
+					},
+				},
+			},
+			wantContains: append(localhost, "10.0.0.5:8443", "203.0.113.10:8443"),
+		},
+		{
+			name:         "no AdditionalIPs and no netcheck",
+			wantContains: localhost,
+		},
+		{
+			name:          "netcheck replaces public AdditionalIP with different source",
+			additionalIPs: []net.IP{publicIP, privateIP},
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "198.51.100.1",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "tcp", Reachable: true},
+					},
+				},
+			},
+			wantContains: append(localhost, "198.51.100.1:8443", "10.0.0.5:8443"),
+			wantExcludes: []string{"203.0.113.10:8443"},
+		},
+		{
+			name:          "dual-stack netcheck with both families reachable",
+			additionalIPs: []net.IP{publicIP, privateIP},
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "203.0.113.10",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "https", Reachable: true},
+					},
+				},
+				IPv6: &cloudauth.NetcheckResponse{
+					SourceAddress: "2001:db8::1",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "https", Reachable: true},
+					},
+				},
+			},
+			wantContains: append(localhost, "203.0.113.10:8443", "[2001:db8::1]:8443", "10.0.0.5:8443"),
+		},
+		{
+			name:          "dual-stack netcheck with only IPv4 reachable",
+			additionalIPs: []net.IP{publicIP, privateIP},
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "203.0.113.10",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "https", Reachable: true},
+					},
+				},
+				IPv6: nil,
+			},
+			wantContains: append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Coordinator{
+				CoordinatorConfig: CoordinatorConfig{
+					Address:       listenAddr,
+					AdditionalIPs: tt.additionalIPs,
+				},
+				Log:            slog.Default(),
+				netcheckResult: tt.netcheckResult,
+			}
+
+			got := c.apiAddresses()
+
+			for _, want := range tt.wantContains {
+				assert.Contains(t, got, want, "expected %q in result", want)
+			}
+			for _, excluded := range tt.wantExcludes {
+				assert.NotContains(t, got, excluded, "expected %q to be excluded", excluded)
+			}
+		})
+	}
+}

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -94,6 +94,7 @@ type CoordinatorConfig struct {
 	DataPath        string              `json:"data_path" yaml:"data_path"`
 	AdditionalNames []string            `json:"additional_names" yaml:"additional_names"`
 	AdditionalIPs   []net.IP            `json:"additional_ips" yaml:"additional_ips"`
+	DiscoveredIPs   []net.IP            `json:"discovered_ips" yaml:"discovered_ips"`
 
 	// ACME certificate configuration
 	AcmeEmail       string `json:"acme_email" yaml:"acme_email"`
@@ -469,6 +470,7 @@ func (c *Coordinator) LoadAPICert(ctx context.Context) error {
 	}
 
 	ips = append(ips, c.AdditionalIPs...)
+	ips = append(ips, c.DiscoveredIPs...)
 
 	cert := filepath.Join(c.DataPath, "server", "api.crt")
 	keyPath := filepath.Join(c.DataPath, "server", "api.key")
@@ -1256,9 +1258,10 @@ func (c *Coordinator) publicAddresses() []string {
 }
 
 // apiAddresses builds the list of API addresses for status reports.
-// When netcheck has found reachable public addresses, discovered public IPs
-// from AdditionalIPs are replaced by the netcheck results. If netcheck ran
-// but found nothing reachable, discovered public IPs are kept as a fallback.
+// User-provided AdditionalIPs are always included. For auto-discovered IPs,
+// netcheck results replace discovered public IPs when reachable addresses
+// are found. If netcheck ran but found nothing reachable, discovered public
+// IPs are kept as a fallback.
 func (c *Coordinator) apiAddresses() []string {
 	var addrs []string
 
@@ -1270,19 +1273,22 @@ func (c *Coordinator) apiAddresses() []string {
 	// Add localhost addresses
 	addrs = append(addrs, "127.0.0.1:8443", "[::1]:8443")
 
-	pubAddrs := c.publicAddresses()
-
+	// User-provided IPs are always included.
 	for _, ip := range c.AdditionalIPs {
-		// When netcheck found reachable public addresses, skip public AdditionalIPs
-		// in favor of the netcheck-determined ones. If netcheck ran but found nothing
-		// reachable (e.g., firewalled), keep the discovered public IPs as a fallback.
-		if len(pubAddrs) > 0 && !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
-			continue
-		}
-
 		addrs = append(addrs, net.JoinHostPort(ip.String(), "8443"))
 	}
 
+	// For discovered IPs, netcheck results replace discovered public IPs
+	// when netcheck found reachable addresses. If netcheck ran but found
+	// nothing reachable (e.g., firewalled), keep discovered public IPs
+	// as a fallback.
+	pubAddrs := c.publicAddresses()
+	for _, ip := range c.DiscoveredIPs {
+		if len(pubAddrs) > 0 && !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
+			continue
+		}
+		addrs = append(addrs, net.JoinHostPort(ip.String(), "8443"))
+	}
 	addrs = append(addrs, pubAddrs...)
 
 	c.logAddressesOnce.Do(func() {
@@ -1290,8 +1296,11 @@ func (c *Coordinator) apiAddresses() []string {
 		for _, ip := range c.AdditionalIPs {
 			additional = append(additional, ip.String())
 		}
-
-		c.Log.Info("reporting API addresses", "listen", c.Address, "discovered", additional, "result", addrs)
+		discovered := []string{}
+		for _, ip := range c.DiscoveredIPs {
+			discovered = append(discovered, ip.String())
+		}
+		c.Log.Info("reporting API addresses", "listen", c.Address, "configured", additional, "discovered", discovered, "result", addrs)
 	})
 
 	return addrs

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -341,7 +341,7 @@ type Coordinator struct {
 	oidcAuthenticator *oidcauth.OIDCAuthenticator
 
 	netcheckMu        sync.RWMutex
-	netcheckResult    *cloudauth.NetcheckResponse
+	netcheckResult    *cloudauth.NetcheckDualStackResult
 	netcheckCheckedAt time.Time
 
 	logAddressesOnce sync.Once
@@ -1134,7 +1134,8 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	return nil
 }
 
-// runNetcheck calls the cloud's netcheck endpoint to determine public reachability.
+// runNetcheck calls the cloud's netcheck endpoint over both IPv4 and IPv6
+// to determine public reachability on each address family.
 func (c *Coordinator) runNetcheck(ctx context.Context) {
 	cloudURL := c.CloudAuth.CloudURL
 	if cloudURL == "" {
@@ -1146,7 +1147,7 @@ func (c *Coordinator) runNetcheck(ctx context.Context) {
 		{Port: 8443, Protocol: "http3"},
 	}
 
-	result, err := cloudauth.Netcheck(ctx, cloudURL, ports)
+	result, err := cloudauth.NetcheckDualStack(ctx, cloudURL, ports)
 	if err != nil {
 		if errors.Is(err, cloudauth.ErrPrivateAddress) {
 			c.Log.Info("netcheck: cluster is not publicly reachable (private IP)")
@@ -1160,12 +1161,25 @@ func (c *Coordinator) runNetcheck(ctx context.Context) {
 		return
 	}
 
-	// Validate that the source address is a global unicast IP — if not,
-	// the netcheck response is unreliable (e.g. proxy or misconfigured endpoint).
-	sourceIP := net.ParseIP(result.SourceAddress)
-	if sourceIP == nil || !sourceIP.IsGlobalUnicast() || sourceIP.IsPrivate() {
-		c.Log.Warn("netcheck: source address is not a public IP, ignoring result",
-			"source_address", result.SourceAddress)
+	// Validate source addresses — drop any that aren't public global unicast.
+	if result.IPv4 != nil {
+		sourceIP := net.ParseIP(result.IPv4.SourceAddress)
+		if sourceIP == nil || !sourceIP.IsGlobalUnicast() || sourceIP.IsPrivate() {
+			c.Log.Warn("netcheck: IPv4 source address is not a public IP, ignoring",
+				"source_address", result.IPv4.SourceAddress)
+			result.IPv4 = nil
+		}
+	}
+	if result.IPv6 != nil {
+		sourceIP := net.ParseIP(result.IPv6.SourceAddress)
+		if sourceIP == nil || !sourceIP.IsGlobalUnicast() || sourceIP.IsPrivate() {
+			c.Log.Warn("netcheck: IPv6 source address is not a public IP, ignoring",
+				"source_address", result.IPv6.SourceAddress)
+			result.IPv6 = nil
+		}
+	}
+
+	if result.IPv4 == nil && result.IPv6 == nil {
 		c.netcheckMu.Lock()
 		c.netcheckResult = nil
 		c.netcheckCheckedAt = time.Now()
@@ -1178,46 +1192,64 @@ func (c *Coordinator) runNetcheck(ctx context.Context) {
 	c.netcheckCheckedAt = time.Now()
 	c.netcheckMu.Unlock()
 
-	var reachable []string
-	for _, r := range result.Results {
-		if r.Reachable {
-			reachable = append(reachable, fmt.Sprintf("%s/%d", r.Protocol, r.Port))
+	// Log results for each address family
+	for _, entry := range []struct {
+		name string
+		resp *cloudauth.NetcheckResponse
+	}{
+		{"IPv4", result.IPv4},
+		{"IPv6", result.IPv6},
+	} {
+		if entry.resp == nil {
+			continue
 		}
+		var reachable []string
+		for _, r := range entry.resp.Results {
+			if r.Reachable {
+				reachable = append(reachable, fmt.Sprintf("%s/%d", r.Protocol, r.Port))
+			}
+		}
+		c.Log.Info("netcheck: public reachability determined",
+			"family", entry.name,
+			"source_ip", entry.resp.SourceAddress,
+			"reachable", reachable,
+			"duration_ms", entry.resp.DurationMs,
+		)
 	}
-	c.Log.Info("netcheck: public reachability determined",
-		"source_ip", result.SourceAddress,
-		"reachable", reachable,
-		"duration_ms", result.DurationMs,
-	)
 }
 
-// publicAddresses returns addresses derived from the cached netcheck result.
+// publicAddresses returns addresses derived from the cached dual-stack netcheck result.
 // Returns nil if no netcheck has been done or the cluster isn't publicly reachable.
 func (c *Coordinator) publicAddresses() []string {
 	c.netcheckMu.RLock()
 	result := c.netcheckResult
 	c.netcheckMu.RUnlock()
 
-	if result == nil || result.SourceAddress == "" {
-		return nil
-	}
-
-	if net.ParseIP(result.SourceAddress) == nil {
+	if result == nil {
 		return nil
 	}
 
 	seen := make(map[string]struct{})
 	var addrs []string
-	for _, r := range result.Results {
-		if !r.Reachable {
+
+	for _, resp := range []*cloudauth.NetcheckResponse{result.IPv4, result.IPv6} {
+		if resp == nil || resp.SourceAddress == "" {
 			continue
 		}
-		hp := net.JoinHostPort(result.SourceAddress, strconv.Itoa(r.Port))
-		if _, ok := seen[hp]; ok {
+		if net.ParseIP(resp.SourceAddress) == nil {
 			continue
 		}
-		seen[hp] = struct{}{}
-		addrs = append(addrs, hp)
+		for _, r := range resp.Results {
+			if !r.Reachable {
+				continue
+			}
+			hp := net.JoinHostPort(resp.SourceAddress, strconv.Itoa(r.Port))
+			if _, ok := seen[hp]; ok {
+				continue
+			}
+			seen[hp] = struct{}{}
+			addrs = append(addrs, hp)
+		}
 	}
 
 	return addrs

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1256,8 +1256,9 @@ func (c *Coordinator) publicAddresses() []string {
 }
 
 // apiAddresses builds the list of API addresses for status reports.
-// When netcheck has been run, public IPs from AdditionalIPs are filtered out
-// in favor of the netcheck-determined public addresses.
+// When netcheck has found reachable public addresses, discovered public IPs
+// from AdditionalIPs are replaced by the netcheck results. If netcheck ran
+// but found nothing reachable, discovered public IPs are kept as a fallback.
 func (c *Coordinator) apiAddresses() []string {
 	var addrs []string
 
@@ -1269,22 +1270,20 @@ func (c *Coordinator) apiAddresses() []string {
 	// Add localhost addresses
 	addrs = append(addrs, "127.0.0.1:8443", "[::1]:8443")
 
-	c.netcheckMu.RLock()
-	hasNetcheck := c.netcheckResult != nil
-	c.netcheckMu.RUnlock()
+	pubAddrs := c.publicAddresses()
 
 	for _, ip := range c.AdditionalIPs {
-		// When netcheck has run, skip public IPs — netcheck results replace them
-		if hasNetcheck && !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
+		// When netcheck found reachable public addresses, skip public AdditionalIPs
+		// in favor of the netcheck-determined ones. If netcheck ran but found nothing
+		// reachable (e.g., firewalled), keep the discovered public IPs as a fallback.
+		if len(pubAddrs) > 0 && !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
 			continue
 		}
 
-		addrs = append(addrs, net.JoinHostPort(ip.String(), "8443")) // Ensure proper formatting for IPv6 addresses
+		addrs = append(addrs, net.JoinHostPort(ip.String(), "8443"))
 	}
 
-	if pubAddrs := c.publicAddresses(); len(pubAddrs) > 0 {
-		addrs = append(addrs, pubAddrs...)
-	}
+	addrs = append(addrs, pubAddrs...)
 
 	c.logAddressesOnce.Do(func() {
 		additional := []string{}

--- a/pkg/cloudauth/netcheck.go
+++ b/pkg/cloudauth/netcheck.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 )
@@ -38,6 +39,12 @@ type NetcheckResponse struct {
 	DurationMs    int              `json:"duration_ms"`
 }
 
+// NetcheckDualStackResult holds netcheck responses for both address families.
+type NetcheckDualStackResult struct {
+	IPv4 *NetcheckResponse
+	IPv6 *NetcheckResponse
+}
+
 // ErrPrivateAddress is returned when the cloud rejects the request
 // because the cluster's IP is private/loopback/link-local.
 var ErrPrivateAddress = errors.New("client IP is not a public address")
@@ -45,7 +52,10 @@ var ErrPrivateAddress = errors.New("client IP is not a public address")
 // Netcheck calls the cloud's netcheck endpoint to determine whether the
 // cluster is publicly reachable on the given ports. The endpoint requires no
 // authentication — it uses the request's source IP for probing.
-func Netcheck(ctx context.Context, cloudURL string, ports []NetcheckPort) (*NetcheckResponse, error) {
+//
+// The network parameter controls the address family: "tcp4" forces IPv4,
+// "tcp6" forces IPv6, and "" uses the OS default.
+func Netcheck(ctx context.Context, cloudURL string, ports []NetcheckPort, network string) (*NetcheckResponse, error) {
 	body, err := json.Marshal(NetcheckRequest{Ports: ports})
 	if err != nil {
 		return nil, fmt.Errorf("marshal netcheck request: %w", err)
@@ -59,7 +69,21 @@ func Netcheck(ctx context.Context, cloudURL string, ports []NetcheckPort) (*Netc
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if network != "" {
+		transport.DialContext = (&net.Dialer{
+			Timeout: 10 * time.Second,
+		}).DialContext
+		// Wrap the dialer to force the address family
+		baseDialContext := transport.DialContext
+		transport.DialContext = func(ctx context.Context, _, addr string) (net.Conn, error) {
+			return baseDialContext(ctx, network, addr)
+		}
+	}
+
+	client := &http.Client{
+		Transport: transport,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("send netcheck request: %w", err)
@@ -85,4 +109,44 @@ func Netcheck(ctx context.Context, cloudURL string, ports []NetcheckPort) (*Netc
 	}
 
 	return &result, nil
+}
+
+// NetcheckDualStack calls the netcheck endpoint concurrently over IPv4 and
+// IPv6 to discover public addresses on both address families. Each call gets
+// its own timeout so a missing address family fails fast without blocking the
+// other. Either result may be nil if the address family is unavailable or the
+// check fails. Returns an error only if both checks fail.
+func NetcheckDualStack(ctx context.Context, cloudURL string, ports []NetcheckPort) (*NetcheckDualStackResult, error) {
+	type netcheckResult struct {
+		resp *NetcheckResponse
+		err  error
+	}
+
+	ipv4Ch := make(chan netcheckResult, 1)
+	ipv6Ch := make(chan netcheckResult, 1)
+
+	go func() {
+		callCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		resp, err := Netcheck(callCtx, cloudURL, ports, "tcp4")
+		ipv4Ch <- netcheckResult{resp, err}
+	}()
+	go func() {
+		callCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		resp, err := Netcheck(callCtx, cloudURL, ports, "tcp6")
+		ipv6Ch <- netcheckResult{resp, err}
+	}()
+
+	v4 := <-ipv4Ch
+	v6 := <-ipv6Ch
+
+	if v4.err != nil && v6.err != nil {
+		return nil, fmt.Errorf("netcheck failed on both address families: ipv4: %w, ipv6: %v", v4.err, v6.err)
+	}
+
+	return &NetcheckDualStackResult{
+		IPv4: v4.resp,
+		IPv6: v6.resp,
+	}, nil
 }

--- a/pkg/cloudauth/netcheck_test.go
+++ b/pkg/cloudauth/netcheck_test.go
@@ -45,7 +45,7 @@ func TestNetcheck(t *testing.T) {
 		result, err := Netcheck(context.Background(), srv.URL, []NetcheckPort{
 			{Port: 8443, Protocol: "https"},
 			{Port: 8443, Protocol: "http3"},
-		})
+		}, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -76,7 +76,7 @@ func TestNetcheck(t *testing.T) {
 
 		_, err := Netcheck(context.Background(), srv.URL, []NetcheckPort{
 			{Port: 8443, Protocol: "https"},
-		})
+		}, "")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -94,7 +94,7 @@ func TestNetcheck(t *testing.T) {
 
 		_, err := Netcheck(context.Background(), srv.URL, []NetcheckPort{
 			{Port: 8443, Protocol: "https"},
-		})
+		}, "")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}

--- a/pkg/ipdiscovery/ipdiscovery.go
+++ b/pkg/ipdiscovery/ipdiscovery.go
@@ -2,19 +2,14 @@ package ipdiscovery
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
-	"net/http"
 	"time"
 )
 
-const defaultPublicIPURL = "https://ifconfig.co/json"
-
 // Discovery holds information about discovered IP addresses
 type Discovery struct {
-	PublicIP  string    `json:"public_ip"`
 	Addresses []Address `json:"addresses"`
 }
 
@@ -26,14 +21,7 @@ type Address struct {
 	IsIPv6    bool   `json:"is_ipv6"`
 }
 
-// PublicIPResponse represents the response from ifconfig.co/json
-type PublicIPResponse struct {
-	IP      string `json:"ip"`
-	Country string `json:"country"`
-	City    string `json:"city"`
-}
-
-// Discover gathers all local interface addresses and the public IP
+// Discover gathers all local interface addresses.
 func Discover(ctx context.Context, log *slog.Logger) (*Discovery, error) {
 	discovery := &Discovery{
 		Addresses: []Address{},
@@ -66,7 +54,6 @@ func Discover(ctx context.Context, log *slog.Logger) (*Discovery, error) {
 				continue
 			}
 
-			// Skip loopback addresses if desired
 			if ip.IsLoopback() {
 				continue
 			}
@@ -82,53 +69,7 @@ func Discover(ctx context.Context, log *slog.Logger) (*Discovery, error) {
 		}
 	}
 
-	// Get public IP
-	publicIP, err := getPublicIP(ctx, "")
-	if err != nil {
-		// Don't fail the entire discovery if we can't get public IP
-		log.Warn("Failed to get public IP", "error", err)
-		discovery.PublicIP = ""
-	} else {
-		discovery.PublicIP = publicIP
-	}
-
 	return discovery, nil
-}
-
-// getPublicIP fetches the public IP address from ifconfig.co
-func getPublicIP(ctx context.Context, url string) (string, error) {
-	if url == "" {
-		url = defaultPublicIPURL
-	}
-
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set user agent to avoid being blocked
-	req.Header.Set("User-Agent", "miren-runtime/1.0")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch public IP: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	var result PublicIPResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	return result.IP, nil
 }
 
 // DiscoverWithTimeout is a convenience function that adds a timeout to Discover

--- a/pkg/ipdiscovery/ipdiscovery_test.go
+++ b/pkg/ipdiscovery/ipdiscovery_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -36,31 +34,6 @@ func TestDiscover(t *testing.T) {
 		assert.NotEmpty(t, addr.IP)
 		assert.NotEmpty(t, addr.Network)
 	}
-}
-
-func TestGetPublicIP(t *testing.T) {
-	// Create a test server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "miren-runtime/1.0", r.Header.Get("User-Agent"))
-
-		response := PublicIPResponse{
-			IP:      "203.0.113.1",
-			Country: "US",
-			City:    "San Francisco",
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
-
-	// Now we can test with the stub server
-	ctx := context.Background()
-
-	// Call getPublicIP with the test server URL
-	ip, err := getPublicIP(ctx, server.URL+"/json")
-	require.NoError(t, err)
-	assert.Equal(t, "203.0.113.1", ip)
 }
 
 func TestDiscoverWithTimeout(t *testing.T) {
@@ -99,7 +72,6 @@ func TestAddressTypes(t *testing.T) {
 func TestDiscoveryJSON(t *testing.T) {
 	// Test that Discovery can be properly marshaled to JSON
 	discovery := &Discovery{
-		PublicIP: "203.0.113.1",
 		Addresses: []Address{
 			{
 				Interface: "eth0",
@@ -123,6 +95,5 @@ func TestDiscoveryJSON(t *testing.T) {
 	err = json.Unmarshal(data, &decoded)
 	require.NoError(t, err)
 
-	assert.Equal(t, discovery.PublicIP, decoded.PublicIP)
 	assert.Equal(t, len(discovery.Addresses), len(decoded.Addresses))
 }


### PR DESCRIPTION
I hit this while setting up a Hetzner Cloud VPS — `miren cluster add` showed `0.0.0.0:8443` and couldn't connect. Turns out the server was only discovering its IPv6 public address because `ifconfig.co` (used for public IP detection) connected over IPv6, and netcheck did the same single-stack call. The IPv4 address was right there on `eth0` but never made it into the status report.

Two changes here. First commit drops the `ifconfig.co` dependency entirely — it was redundant since local interface enumeration already finds all IPs and netcheck overrides the public IP for reporting anyway. No more third-party call at boot, which is also better for sovereign cluster users who are sensitive to outbound connections.

Second commit makes netcheck dual-stack. Instead of one call that uses whatever the OS picks, we now fire two concurrent calls — one forced over IPv4, one over IPv6 — each with its own 15s timeout. The coordinator caches both results and merges reachable addresses from both families into the status report. End result: clusters on dual-stack hosts report both their IPv4 and IPv6 public addresses, DNS gets proper A + AAAA records, and `miren cluster add` works regardless of the client's connectivity.

Part of MIR-924