### PR TITLE
Nice config parse errors with source locations, suggestions, and color

### DIFF
--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -109,15 +109,18 @@ func LoadAppConfigWithPath() (*AppConfig, string, error) {
 	for dir != "/" {
 		path := filepath.Join(dir, AppConfigPath)
 		data, err := os.ReadFile(path)
-		if err == nil {
-			ac, parseErr := decodeAndValidate(data, path)
-			if parseErr != nil {
-				return nil, "", parseErr
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, "", err
 			}
-			return ac, path, nil
+			dir = filepath.Dir(dir)
+			continue
 		}
-
-		dir = filepath.Dir(dir)
+		ac, parseErr := decodeAndValidate(data, path)
+		if parseErr != nil {
+			return nil, "", parseErr
+		}
+		return ac, path, nil
 	}
 
 	return nil, "", nil

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -108,24 +108,13 @@ func LoadAppConfigWithPath() (*AppConfig, string, error) {
 
 	for dir != "/" {
 		path := filepath.Join(dir, AppConfigPath)
-		fi, err := os.Open(path)
+		data, err := os.ReadFile(path)
 		if err == nil {
-			defer fi.Close()
-
-			var ac AppConfig
-			dec := toml.NewDecoder(fi)
-			dec.DisallowUnknownFields()
-			err = dec.Decode(&ac)
-			if err != nil {
-				return nil, "", err
+			ac, parseErr := decodeAndValidate(data, path)
+			if parseErr != nil {
+				return nil, "", parseErr
 			}
-
-			// Validate the configuration
-			if err := ac.Validate(); err != nil {
-				return nil, "", err
-			}
-
-			return &ac, path, nil
+			return ac, path, nil
 		}
 
 		dir = filepath.Dir(dir)
@@ -136,52 +125,42 @@ func LoadAppConfigWithPath() (*AppConfig, string, error) {
 
 func LoadAppConfigUnder(dir string) (*AppConfig, error) {
 	path := filepath.Join(dir, AppConfigPath)
-	fi, err := os.Open(path)
-	if err == nil {
-		defer fi.Close()
-
-		var ac AppConfig
-		dec := toml.NewDecoder(fi)
-		dec.DisallowUnknownFields()
-		err = dec.Decode(&ac)
-		if err != nil {
-			return nil, err
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
 		}
-
-		// Validate the configuration
-		if err := ac.Validate(); err != nil {
-			return nil, err
-		}
-
-		return &ac, nil
+		return nil, err
 	}
-
-	return nil, nil
+	return decodeAndValidate(data, path)
 }
 
 func Parse(data []byte) (*AppConfig, error) {
+	return decodeAndValidate(data, "<input>")
+}
+
+// decodeAndValidate decodes TOML data into an AppConfig and validates it,
+// enriching any errors with file path, source locations, and suggestions.
+func decodeAndValidate(data []byte, filePath string) (*AppConfig, error) {
 	var ac AppConfig
 	dec := toml.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
-	err := dec.Decode(&ac)
-	if err != nil {
-		return nil, err
+	if err := dec.Decode(&ac); err != nil {
+		return nil, enrichDecodeError(filePath, data, err)
 	}
-
-	// Validate the configuration
 	if err := ac.Validate(); err != nil {
-		return nil, err
+		return nil, enrichValidationError(filePath, data, err)
 	}
-
 	return &ac, nil
 }
 
-// Validate checks that the AppConfig has valid values
+// Validate checks that the AppConfig has valid values.
+// Returns *ValidationError with a key path for AST-based line resolution.
 func (ac *AppConfig) Validate() error {
 	// Validate global environment variables
 	for i, ev := range ac.EnvVars {
 		if ev.Key == "" {
-			return fmt.Errorf("env[%d]: key is required", i)
+			return &ValidationError{KeyPath: "env", Message: fmt.Sprintf("env[%d]: key is required", i)}
 		}
 	}
 
@@ -191,47 +170,74 @@ func (ac *AppConfig) Validate() error {
 			continue
 		}
 
+		svcPrefix := "services." + serviceName
+
 		// Validate concurrency if present
 		if svcConfig.Concurrency != nil {
 			concurrency := svcConfig.Concurrency
+			concurrencyPath := svcPrefix + ".concurrency"
 
 			// Validate mode
 			if concurrency.Mode != "" && concurrency.Mode != "auto" && concurrency.Mode != "fixed" {
-				return fmt.Errorf("service %s: invalid concurrency mode %q, must be \"auto\" or \"fixed\"", serviceName, concurrency.Mode)
+				return &ValidationError{
+					KeyPath: concurrencyPath + ".mode",
+					Message: fmt.Sprintf("service %s: invalid concurrency mode %q, must be \"auto\" or \"fixed\"", serviceName, concurrency.Mode),
+				}
 			}
 
 			// Validate auto mode settings
 			if concurrency.Mode == "auto" || concurrency.Mode == "" {
 				if concurrency.RequestsPerInstance < 0 {
-					return fmt.Errorf("service %s: requests_per_instance must be non-negative", serviceName)
+					return &ValidationError{
+						KeyPath: concurrencyPath + ".requests_per_instance",
+						Message: fmt.Sprintf("service %s: requests_per_instance must be non-negative", serviceName),
+					}
 				}
 				if concurrency.ScaleDownDelay != "" {
 					if _, err := time.ParseDuration(concurrency.ScaleDownDelay); err != nil {
-						return fmt.Errorf("service %s: invalid scale_down_delay %q: %v", serviceName, concurrency.ScaleDownDelay, err)
+						return &ValidationError{
+							KeyPath: concurrencyPath + ".scale_down_delay",
+							Message: fmt.Sprintf("service %s: invalid scale_down_delay %q: %v", serviceName, concurrency.ScaleDownDelay, err),
+						}
 					}
 				}
 				if concurrency.NumInstances > 0 {
-					return fmt.Errorf("service %s: num_instances cannot be set in auto mode", serviceName)
+					return &ValidationError{
+						KeyPath: concurrencyPath + ".num_instances",
+						Message: fmt.Sprintf("service %s: num_instances cannot be set in auto mode", serviceName),
+					}
 				}
 			}
 
 			// Validate fixed mode settings
 			if concurrency.Mode == "fixed" {
 				if concurrency.NumInstances <= 0 {
-					return fmt.Errorf("service %s: num_instances must be at least 1 for fixed mode", serviceName)
+					return &ValidationError{
+						KeyPath: concurrencyPath + ".num_instances",
+						Message: fmt.Sprintf("service %s: num_instances must be at least 1 for fixed mode", serviceName),
+					}
 				}
 				if concurrency.RequestsPerInstance > 0 {
-					return fmt.Errorf("service %s: requests_per_instance cannot be set in fixed mode", serviceName)
+					return &ValidationError{
+						KeyPath: concurrencyPath + ".requests_per_instance",
+						Message: fmt.Sprintf("service %s: requests_per_instance cannot be set in fixed mode", serviceName),
+					}
 				}
 				if concurrency.ScaleDownDelay != "" {
-					return fmt.Errorf("service %s: scale_down_delay cannot be set in fixed mode", serviceName)
+					return &ValidationError{
+						KeyPath: concurrencyPath + ".scale_down_delay",
+						Message: fmt.Sprintf("service %s: scale_down_delay cannot be set in fixed mode", serviceName),
+					}
 				}
 			}
 
 			// Validate shutdown_timeout (applies to both modes)
 			if concurrency.ShutdownTimeout != "" {
 				if _, err := time.ParseDuration(concurrency.ShutdownTimeout); err != nil {
-					return fmt.Errorf("service %s: invalid shutdown_timeout %q: %v", serviceName, concurrency.ShutdownTimeout, err)
+					return &ValidationError{
+						KeyPath: concurrencyPath + ".shutdown_timeout",
+						Message: fmt.Sprintf("service %s: invalid shutdown_timeout %q: %v", serviceName, concurrency.ShutdownTimeout, err),
+					}
 				}
 			}
 		}
@@ -239,7 +245,10 @@ func (ac *AppConfig) Validate() error {
 		// Validate service environment variables
 		for i, ev := range svcConfig.EnvVars {
 			if ev.Key == "" {
-				return fmt.Errorf("service %s: env[%d] key is required", serviceName, i)
+				return &ValidationError{
+					KeyPath: svcPrefix + ".env",
+					Message: fmt.Sprintf("service %s: env[%d] key is required", serviceName, i),
+				}
 			}
 		}
 
@@ -247,7 +256,10 @@ func (ac *AppConfig) Validate() error {
 		if len(svcConfig.Ports) > 0 {
 			// Mutual exclusion: cannot use both ports[] and scalar port fields
 			if svcConfig.Port != 0 || svcConfig.PortName != "" || svcConfig.PortType != "" {
-				return fmt.Errorf("service %s: cannot use both 'ports' array and scalar port/port_name/port_type fields", serviceName)
+				return &ValidationError{
+					KeyPath: svcPrefix + ".ports",
+					Message: fmt.Sprintf("service %s: cannot use both 'ports' array and scalar port/port_name/port_type fields", serviceName),
+				}
 			}
 
 			seenNames := make(map[string]bool)
@@ -258,28 +270,46 @@ func (ac *AppConfig) Validate() error {
 			seenPortProto := make(map[portProto]bool)
 			for i, p := range svcConfig.Ports {
 				if p.Port <= 0 || p.Port > 65535 {
-					return fmt.Errorf("service %s: ports[%d] port must be between 1 and 65535", serviceName, i)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".ports",
+						Message: fmt.Sprintf("service %s: ports[%d] port must be between 1 and 65535", serviceName, i),
+					}
 				}
 				if p.Name == "" {
-					return fmt.Errorf("service %s: ports[%d] name is required", serviceName, i)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".ports",
+						Message: fmt.Sprintf("service %s: ports[%d] name is required", serviceName, i),
+					}
 				}
 				if p.Type != "" && p.Type != "http" && p.Type != "tcp" && p.Type != "udp" {
-					return fmt.Errorf("service %s: ports[%d] type must be \"http\", \"tcp\", or \"udp\"", serviceName, i)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".ports",
+						Message: fmt.Sprintf("service %s: ports[%d] type must be \"http\", \"tcp\", or \"udp\"", serviceName, i),
+					}
 				}
 				proto := "tcp"
 				if p.Type == "udp" {
 					proto = "udp"
 				}
 				if p.NodePort < 0 || p.NodePort > 65535 {
-					return fmt.Errorf("service %s: ports[%d] node_port must be between 0 and 65535", serviceName, i)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".ports",
+						Message: fmt.Sprintf("service %s: ports[%d] node_port must be between 0 and 65535", serviceName, i),
+					}
 				}
 				if seenNames[p.Name] {
-					return fmt.Errorf("service %s: ports[%d] duplicate port name %q", serviceName, i, p.Name)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".ports",
+						Message: fmt.Sprintf("service %s: ports[%d] duplicate port name %q", serviceName, i, p.Name),
+					}
 				}
 				seenNames[p.Name] = true
 				pp := portProto{p.Port, proto}
 				if seenPortProto[pp] {
-					return fmt.Errorf("service %s: ports[%d] duplicate port number %d (protocol %q)", serviceName, i, p.Port, proto)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".ports",
+						Message: fmt.Sprintf("service %s: ports[%d] duplicate port number %d (protocol %q)", serviceName, i, p.Port, proto),
+					}
 				}
 				seenPortProto[pp] = true
 			}
@@ -289,40 +319,70 @@ func (ac *AppConfig) Validate() error {
 		hasMirenDisks := false
 		for i, disk := range svcConfig.Disks {
 			if disk.Provider != "" && disk.Provider != "miren" && disk.Provider != "local" {
-				return fmt.Errorf("service %s: disk[%d] (%s) has invalid provider %q, must be \"miren\" or \"local\"", serviceName, i, disk.Name, disk.Provider)
+				return &ValidationError{
+					KeyPath: svcPrefix + ".disks",
+					Message: fmt.Sprintf("service %s: disk[%d] (%s) has invalid provider %q, must be \"miren\" or \"local\"", serviceName, i, disk.Name, disk.Provider),
+				}
 			}
 			if disk.Provider == "" || disk.Provider == "miren" {
 				hasMirenDisks = true
 			}
 			if disk.Name == "" {
-				return fmt.Errorf("service %s: disk[%d] must have a name", serviceName, i)
+				return &ValidationError{
+					KeyPath: svcPrefix + ".disks",
+					Message: fmt.Sprintf("service %s: disk[%d] must have a name", serviceName, i),
+				}
 			}
 			if disk.MountPath == "" {
-				return fmt.Errorf("service %s: disk[%d] (%s) must have a mount_path", serviceName, i, disk.Name)
+				return &ValidationError{
+					KeyPath: svcPrefix + ".disks",
+					Message: fmt.Sprintf("service %s: disk[%d] (%s) must have a mount_path", serviceName, i, disk.Name),
+				}
 			}
 			if !filepath.IsAbs(disk.MountPath) {
-				return fmt.Errorf("service %s: disk[%d] (%s) mount_path must be an absolute path", serviceName, i, disk.Name)
+				return &ValidationError{
+					KeyPath: svcPrefix + ".disks",
+					Message: fmt.Sprintf("service %s: disk[%d] (%s) mount_path must be an absolute path", serviceName, i, disk.Name),
+				}
 			}
 			if disk.Provider == "local" {
 				if disk.SizeGB != 0 {
-					return fmt.Errorf("service %s: disk[%d] (%s) size_gb is not supported for local disks", serviceName, i, disk.Name)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".disks",
+						Message: fmt.Sprintf("service %s: disk[%d] (%s) size_gb is not supported for local disks", serviceName, i, disk.Name),
+					}
 				}
 				if disk.Filesystem != "" {
-					return fmt.Errorf("service %s: disk[%d] (%s) filesystem is not supported for local disks", serviceName, i, disk.Name)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".disks",
+						Message: fmt.Sprintf("service %s: disk[%d] (%s) filesystem is not supported for local disks", serviceName, i, disk.Name),
+					}
 				}
 				if disk.LeaseTimeout != "" {
-					return fmt.Errorf("service %s: disk[%d] (%s) lease_timeout is not supported for local disks", serviceName, i, disk.Name)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".disks",
+						Message: fmt.Sprintf("service %s: disk[%d] (%s) lease_timeout is not supported for local disks", serviceName, i, disk.Name),
+					}
 				}
 			} else {
 				if disk.Filesystem != "" && disk.Filesystem != "ext4" && disk.Filesystem != "xfs" && disk.Filesystem != "btrfs" {
-					return fmt.Errorf("service %s: disk[%d] (%s) has invalid filesystem %q, must be ext4, xfs, or btrfs", serviceName, i, disk.Name, disk.Filesystem)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".disks",
+						Message: fmt.Sprintf("service %s: disk[%d] (%s) has invalid filesystem %q, must be ext4, xfs, or btrfs", serviceName, i, disk.Name, disk.Filesystem),
+					}
 				}
 				if disk.SizeGB < 0 {
-					return fmt.Errorf("service %s: disk[%d] (%s) size_gb must be non-negative", serviceName, i, disk.Name)
+					return &ValidationError{
+						KeyPath: svcPrefix + ".disks",
+						Message: fmt.Sprintf("service %s: disk[%d] (%s) size_gb must be non-negative", serviceName, i, disk.Name),
+					}
 				}
 				if disk.LeaseTimeout != "" {
 					if _, err := time.ParseDuration(disk.LeaseTimeout); err != nil {
-						return fmt.Errorf("service %s: disk[%d] (%s) invalid lease_timeout %q: %v", serviceName, i, disk.Name, disk.LeaseTimeout, err)
+						return &ValidationError{
+							KeyPath: svcPrefix + ".disks",
+							Message: fmt.Sprintf("service %s: disk[%d] (%s) invalid lease_timeout %q: %v", serviceName, i, disk.Name, disk.LeaseTimeout, err),
+						}
 					}
 				}
 			}
@@ -331,10 +391,16 @@ func (ac *AppConfig) Validate() error {
 		// Miren disks require fixed concurrency with a single instance
 		if hasMirenDisks {
 			if svcConfig.Concurrency == nil || svcConfig.Concurrency.Mode != "fixed" {
-				return fmt.Errorf("service %s: miren disks can only be attached to services with fixed concurrency mode", serviceName)
+				return &ValidationError{
+					KeyPath: svcPrefix + ".concurrency",
+					Message: fmt.Sprintf("service %s: miren disks can only be attached to services with fixed concurrency mode", serviceName),
+				}
 			}
 			if svcConfig.Concurrency.NumInstances != 1 {
-				return fmt.Errorf("service %s: miren disks can only be attached to services with fixed concurrency mode and num_instances=1", serviceName)
+				return &ValidationError{
+					KeyPath: svcPrefix + ".concurrency.num_instances",
+					Message: fmt.Sprintf("service %s: miren disks can only be attached to services with fixed concurrency mode and num_instances=1", serviceName),
+				}
 			}
 		}
 	}
@@ -342,15 +408,24 @@ func (ac *AppConfig) Validate() error {
 	for name, target := range ac.Aliases {
 		words := strings.Fields(name)
 		if len(words) == 0 {
-			return fmt.Errorf("alias %q: name must not be empty", name)
+			return &ValidationError{
+				KeyPath: "aliases",
+				Message: fmt.Sprintf("alias %q: name must not be empty", name),
+			}
 		}
 		for _, word := range words {
 			if !aliasWordRegexp.MatchString(word) {
-				return fmt.Errorf("alias %q: each word must start with a lowercase letter and contain only lowercase letters, numbers, dashes, and underscores", name)
+				return &ValidationError{
+					KeyPath: "aliases." + name,
+					Message: fmt.Sprintf("alias %q: each word must start with a lowercase letter and contain only lowercase letters, numbers, dashes, and underscores", name),
+				}
 			}
 		}
 		if strings.TrimSpace(target) == "" {
-			return fmt.Errorf("alias %q: command must not be empty", name)
+			return &ValidationError{
+				KeyPath: "aliases." + name,
+				Message: fmt.Sprintf("alias %q: command must not be empty", name),
+			}
 		}
 	}
 

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -1209,7 +1209,8 @@ unknown_field = "value"
 `
 		_, err := Parse([]byte(config))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "strict mode")
+		assert.Contains(t, err.Error(), "unknown field")
+		assert.Contains(t, err.Error(), "unknown_field")
 	})
 
 	t.Run("size instead of size_gb in disk config", func(t *testing.T) {
@@ -1227,7 +1228,8 @@ size = 20
 `
 		_, err := Parse([]byte(config))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "strict mode")
+		assert.Contains(t, err.Error(), "unknown field")
+		assert.Contains(t, err.Error(), `did you mean "size_gb"`)
 	})
 
 	t.Run("unknown field in service config", func(t *testing.T) {
@@ -1240,7 +1242,8 @@ bogus = true
 `
 		_, err := Parse([]byte(config))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "strict mode")
+		assert.Contains(t, err.Error(), "unknown field")
+		assert.Contains(t, err.Error(), "bogus")
 	})
 
 	t.Run("valid config still works", func(t *testing.T) {

--- a/appconfig/configerror.go
+++ b/appconfig/configerror.go
@@ -216,7 +216,15 @@ func walkAST(p *tomlast.Parser, parts []string, depth int) int {
 				keyName := string(n.Data)
 
 				if keyIdx < depth {
-					// Skip already-matched prefix components
+					// Verify skipped prefix components still match the
+					// already-resolved path — prevents sibling tables like
+					// [services.api.concurrency] from matching when we're
+					// looking for services.web.concurrency.
+					wantPrefix := parts[keyIdx]
+					if wantPrefix != "*" && keyName != wantPrefix {
+						matched = false
+						break
+					}
 					keyIdx++
 					continue
 				}

--- a/appconfig/configerror.go
+++ b/appconfig/configerror.go
@@ -203,27 +203,41 @@ func walkAST(p *tomlast.Parser, parts []string, depth int) int {
 		switch node.Kind {
 		case tomlast.Table, tomlast.ArrayTable:
 			keyIter := node.Key()
+			// Table headers contain the full key path (e.g. [services.web.concurrency]).
+			// When we're at depth > 0, the first `depth` components were already
+			// matched by a parent table — skip them and only compare the remainder.
+			keyIdx := 0
 			matchDepth := depth
 			matched := true
 			var lastKeyNode *tomlast.Node
 
 			for keyIter.Next() {
+				n := keyIter.Node()
+				keyName := string(n.Data)
+
+				if keyIdx < depth {
+					// Skip already-matched prefix components
+					keyIdx++
+					continue
+				}
+
 				if matchDepth >= len(parts) {
 					matched = false
 					break
 				}
-				n := keyIter.Node()
 				lastKeyNode = n
-				keyName := string(n.Data)
 				wantKey := parts[matchDepth]
 				if wantKey != "*" && keyName != wantKey {
 					matched = false
 					break
 				}
 				matchDepth++
+				keyIdx++
 			}
 
-			if !matched {
+			if !matched || keyIdx < depth {
+				// keyIdx < depth means the table header had fewer components
+				// than our current depth — it's an unrelated table.
 				continue
 			}
 

--- a/appconfig/configerror.go
+++ b/appconfig/configerror.go
@@ -1,0 +1,378 @@
+package appconfig
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+	tomlast "github.com/pelletier/go-toml/v2/unstable"
+
+	"miren.dev/runtime/pkg/color"
+)
+
+// ConfigError is returned from config loading when the TOML file has problems.
+// It renders compiler-style diagnostics with file:line references.
+type ConfigError struct {
+	FilePath    string
+	Diagnostics []Diagnostic
+}
+
+// Diagnostic represents a single error within a config file.
+type Diagnostic struct {
+	Line    int    // 1-indexed, 0 if unknown
+	Column  int    // 1-indexed, 0 if unknown
+	Message string // the core error message
+	Context string // visual context from go-toml (if available)
+	Hint    string // e.g. "did you mean \"command\"?"
+}
+
+func (e *ConfigError) Error() string {
+	var b strings.Builder
+	for i, d := range e.Diagnostics {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		// file:line: message
+		if d.Line > 0 {
+			fmt.Fprintf(&b, "%s:%d: %s", e.FilePath, d.Line, d.Message)
+		} else {
+			fmt.Fprintf(&b, "%s: %s", e.FilePath, d.Message)
+		}
+		// Visual context from go-toml (already includes line numbers and tildes)
+		if d.Context != "" {
+			b.WriteByte('\n')
+			b.WriteString(d.Context)
+		}
+		if d.Hint != "" {
+			b.WriteByte('\n')
+			fmt.Fprintf(&b, "  hint: %s", d.Hint)
+		}
+	}
+	return b.String()
+}
+
+// WriteForTerminal renders a colorized, multi-line diagnostic to w.
+// Implements ui.TerminalError.
+func (e *ConfigError) WriteForTerminal(w io.Writer) {
+	red := color.New(color.FgRed, color.Bold)
+	yellow := color.New(color.FgYellow)
+	faint := color.New(color.Faint)
+
+	for i, d := range e.Diagnostics {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		// file:line: message — header in red
+		if d.Line > 0 {
+			red.Fprintf(w, "%s:%d: ", e.FilePath, d.Line)
+		} else {
+			red.Fprintf(w, "%s: ", e.FilePath)
+		}
+		fmt.Fprintln(w, d.Message)
+
+		// Visual context from go-toml (line numbers + tildes) — dimmed
+		if d.Context != "" {
+			faint.Fprintln(w, d.Context)
+		}
+
+		// Hint — yellow
+		if d.Hint != "" {
+			yellow.Fprintf(w, "  hint: %s\n", d.Hint)
+		}
+	}
+}
+
+// ValidationError is a structured error from Validate() that carries
+// the TOML key path for AST-based line number resolution.
+type ValidationError struct {
+	KeyPath string // e.g. "services.web.concurrency.mode"
+	Message string
+}
+
+func (e *ValidationError) Error() string { return e.Message }
+
+// enrichDecodeError wraps go-toml decode errors with file path, source context,
+// and "did you mean?" suggestions for unknown fields.
+func enrichDecodeError(filePath string, _ []byte, err error) error {
+	switch e := err.(type) {
+	case *toml.StrictMissingError:
+		return enrichStrictMissingError(filePath, e)
+	case *toml.DecodeError:
+		return enrichSingleDecodeError(filePath, e)
+	default:
+		return fmt.Errorf("%s: %w", filePath, err)
+	}
+}
+
+func enrichStrictMissingError(filePath string, sme *toml.StrictMissingError) *ConfigError {
+	ce := &ConfigError{FilePath: filePath}
+	for _, de := range sme.Errors {
+		row, col := de.Position()
+		key := de.Key()
+		unknown := ""
+		var parentPath string
+		if len(key) > 0 {
+			unknown = key[len(key)-1]
+			parentPath = keyParentPath(key)
+		}
+
+		d := Diagnostic{
+			Line:    row,
+			Column:  col,
+			Message: fmt.Sprintf("unknown field %q", unknown),
+			Context: indentContext(de.String()),
+		}
+
+		if unknown != "" {
+			if candidates, ok := validFieldsForPath(parentPath); ok {
+				if suggestion := suggestField(unknown, candidates); suggestion != "" {
+					d.Hint = fmt.Sprintf("did you mean %q?", suggestion)
+				}
+			}
+		}
+
+		ce.Diagnostics = append(ce.Diagnostics, d)
+	}
+	return ce
+}
+
+func enrichSingleDecodeError(filePath string, de *toml.DecodeError) *ConfigError {
+	row, _ := de.Position()
+	return &ConfigError{
+		FilePath: filePath,
+		Diagnostics: []Diagnostic{{
+			Line:    row,
+			Message: de.Error(),
+			Context: indentContext(de.String()),
+		}},
+	}
+}
+
+// enrichValidationError wraps a ValidationError with file path and
+// AST-resolved line numbers.
+func enrichValidationError(filePath string, raw []byte, err error) error {
+	ve, ok := err.(*ValidationError)
+	if !ok {
+		return fmt.Errorf("%s: %w", filePath, err)
+	}
+
+	d := Diagnostic{
+		Message: ve.Message,
+	}
+
+	if ve.KeyPath != "" && len(raw) > 0 {
+		if line := resolveKeyLine(raw, ve.KeyPath); line > 0 {
+			d.Line = line
+			d.Context = extractSourceLine(raw, line)
+		}
+	}
+
+	return &ConfigError{
+		FilePath:    filePath,
+		Diagnostics: []Diagnostic{d},
+	}
+}
+
+// resolveKeyLine uses the go-toml/v2 unstable AST parser to find the line
+// number of a dotted key path (e.g. "services.web.concurrency.mode").
+func resolveKeyLine(data []byte, keyPath string) int {
+	parts := strings.Split(keyPath, ".")
+
+	var p tomlast.Parser
+	p.Reset(data)
+
+	return walkAST(&p, parts, 0)
+}
+
+// walkAST recursively searches the TOML AST for a key path and returns the
+// line number where the final key is defined.
+func walkAST(p *tomlast.Parser, parts []string, depth int) int {
+	if depth >= len(parts) {
+		return 0
+	}
+
+	target := parts[depth]
+	isLast := depth == len(parts)-1
+	// For wildcard segments (service names, addon names), match any key
+	isWild := target == "*"
+
+	for p.NextExpression() {
+		node := p.Expression()
+
+		switch node.Kind {
+		case tomlast.Table, tomlast.ArrayTable:
+			keyIter := node.Key()
+			matchDepth := depth
+			matched := true
+			var lastKeyNode *tomlast.Node
+
+			for keyIter.Next() {
+				if matchDepth >= len(parts) {
+					matched = false
+					break
+				}
+				n := keyIter.Node()
+				lastKeyNode = n
+				keyName := string(n.Data)
+				wantKey := parts[matchDepth]
+				if wantKey != "*" && keyName != wantKey {
+					matched = false
+					break
+				}
+				matchDepth++
+			}
+
+			if !matched {
+				continue
+			}
+
+			if matchDepth >= len(parts) && lastKeyNode != nil {
+				// The table header itself matches the full key path
+				shape := p.Shape(lastKeyNode.Raw)
+				return shape.Start.Line
+			}
+
+			// Continue scanning expressions under this table for remaining parts
+			return walkAST(p, parts, matchDepth)
+
+		case tomlast.KeyValue:
+			keyIter := node.Key()
+			if !keyIter.Next() {
+				continue
+			}
+			keyNode := keyIter.Node()
+			keyName := string(keyNode.Data)
+
+			if (isWild || keyName == target) && isLast {
+				shape := p.Shape(keyNode.Raw)
+				return shape.Start.Line
+			}
+		}
+	}
+
+	return 0
+}
+
+// extractSourceLine returns a formatted context line for display.
+func extractSourceLine(data []byte, line int) string {
+	lines := strings.Split(string(data), "\n")
+	if line < 1 || line > len(lines) {
+		return ""
+	}
+	return fmt.Sprintf("  %d | %s", line, lines[line-1])
+}
+
+// indentContext adds two spaces of indentation to each line of a go-toml
+// context string for nested display.
+func indentContext(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = "  " + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+// keyParentPath returns the section path for looking up valid fields.
+// For example, Key{"services", "web", "comand"} → "services.*"
+// Key{"services", "database", "disks", "size"} → "services.*.disks"
+func keyParentPath(key toml.Key) string {
+	if len(key) <= 1 {
+		return ""
+	}
+	// Build the parent path (everything except the unknown field itself),
+	// replacing dynamic map/array names with "*".
+	var parts []string
+	for i, k := range key[:len(key)-1] {
+		if i > 0 && isMapSection(parts) {
+			// This segment is a dynamic key (e.g., service name, addon name)
+			parts = append(parts, "*")
+		} else {
+			parts = append(parts, k)
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
+// isMapSection returns true if the last element of the path represents a
+// section where the next key is a dynamic name.
+func isMapSection(path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	last := path[len(path)-1]
+	return last == "services" || last == "addons"
+}
+
+// validFieldsForPath returns the valid field names for a given section path.
+func validFieldsForPath(path string) ([]string, bool) {
+	fields, ok := validFields[path]
+	return fields, ok
+}
+
+// validFields maps section paths to their valid field names.
+var validFields = map[string][]string{
+	"":                       {"name", "post_import", "env", "concurrency", "services", "build", "include", "addons", "aliases"},
+	"services.*":             {"command", "port", "port_name", "port_type", "ports", "image", "env", "concurrency", "disks"},
+	"services.*.concurrency": {"mode", "requests_per_instance", "scale_down_delay", "num_instances", "shutdown_timeout"},
+	"services.*.disks":       {"name", "provider", "mount_path", "read_only", "size_gb", "filesystem", "lease_timeout"},
+	"services.*.ports":       {"port", "name", "type", "node_port"},
+	"build":                  {"dockerfile", "onbuild", "version", "alpine_image"},
+	"addons.*":               {"variant"},
+	"env":                    {"key", "value", "required", "sensitive", "description"},
+	"services.*.env":         {"key", "value", "required", "sensitive", "description"},
+}
+
+// suggestField returns the best matching field name if similar enough,
+// or empty string if no good match exists. Prioritizes substring matches
+// over pure edit distance.
+func suggestField(unknown string, candidates []string) string {
+	// First check substring containment — these are high-confidence matches
+	for _, c := range candidates {
+		if strings.Contains(c, unknown) || strings.Contains(unknown, c) {
+			return c
+		}
+	}
+
+	// Fall back to Levenshtein distance (threshold: 3)
+	bestDist := 4
+	bestMatch := ""
+	for _, c := range candidates {
+		d := levenshteinDistance(unknown, c)
+		if d < bestDist {
+			bestDist = d
+			bestMatch = c
+		}
+	}
+	return bestMatch
+}
+
+func levenshteinDistance(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(curr[j-1]+1, min(prev[j]+1, prev[j-1]+cost))
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[lb]
+}

--- a/appconfig/configerror_test.go
+++ b/appconfig/configerror_test.go
@@ -186,6 +186,27 @@ requests_per_instance = 10
 	assert.Equal(t, 5, resolveKeyLine(data, "services.web.port"))
 }
 
+func TestResolveKeyLine_SiblingTables(t *testing.T) {
+	// Regression: sibling tables like [services.api.concurrency] must not
+	// match when looking for services.web.concurrency.mode — the skipped
+	// prefix components must be verified against the expected path.
+	data := []byte(`
+name = "test"
+
+[services.api.concurrency]
+mode = "fixed"
+num_instances = 1
+
+[services.web.concurrency]
+mode = "auto"
+requests_per_instance = 10
+`)
+	// Should find the web service's mode, not the api service's
+	assert.Equal(t, 9, resolveKeyLine(data, "services.web.concurrency.mode"))
+	// Should find the api service's mode
+	assert.Equal(t, 5, resolveKeyLine(data, "services.api.concurrency.mode"))
+}
+
 func TestKeyParentPath(t *testing.T) {
 	tests := []struct {
 		name string

--- a/appconfig/configerror_test.go
+++ b/appconfig/configerror_test.go
@@ -167,6 +167,25 @@ requests_per_instance = 10
 	assert.Equal(t, 0, resolveKeyLine(data, "nonexistent.key"))
 }
 
+func TestResolveKeyLine_ParentChildTables(t *testing.T) {
+	// Regression: when a parent table [services.web] appears before a child
+	// table [services.web.concurrency], the AST walker must skip the
+	// already-matched prefix components when comparing table header keys.
+	data := []byte(`
+name = "test"
+
+[services.web]
+port = 8080
+
+[services.web.concurrency]
+mode = "auto"
+requests_per_instance = 10
+`)
+	assert.Equal(t, 8, resolveKeyLine(data, "services.web.concurrency.mode"))
+	assert.Equal(t, 9, resolveKeyLine(data, "services.web.concurrency.requests_per_instance"))
+	assert.Equal(t, 5, resolveKeyLine(data, "services.web.port"))
+}
+
 func TestKeyParentPath(t *testing.T) {
 	tests := []struct {
 		name string

--- a/appconfig/configerror_test.go
+++ b/appconfig/configerror_test.go
@@ -1,0 +1,188 @@
+package appconfig
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"", "abc", 3},
+		{"abc", "", 3},
+		{"abc", "abc", 0},
+		{"size", "size_gb", 3},
+		{"comand", "command", 1},
+		{"siz_gb", "size_gb", 1},
+		{"port", "ports", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.a+"→"+tt.b, func(t *testing.T) {
+			assert.Equal(t, tt.want, levenshteinDistance(tt.a, tt.b))
+		})
+	}
+}
+
+func TestSuggestField(t *testing.T) {
+	diskFields := []string{"name", "provider", "mount_path", "read_only", "size_gb", "filesystem", "lease_timeout"}
+
+	tests := []struct {
+		unknown    string
+		candidates []string
+		want       string
+	}{
+		// Substring match (high confidence)
+		{"size", diskFields, "size_gb"},
+		{"mount", diskFields, "mount_path"},
+		// Levenshtein match
+		{"comand", []string{"command", "port", "image"}, "command"},
+		{"naem", []string{"name", "provider"}, "name"},
+		// No match
+		{"zzzzz", []string{"name", "port"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.unknown, func(t *testing.T) {
+			assert.Equal(t, tt.want, suggestField(tt.unknown, tt.candidates))
+		})
+	}
+}
+
+func TestConfigErrorFormat(t *testing.T) {
+	ce := &ConfigError{
+		FilePath: ".miren/app.toml",
+		Diagnostics: []Diagnostic{
+			{Line: 5, Message: `unknown field "comand"`, Hint: `did you mean "command"?`},
+		},
+	}
+	errStr := ce.Error()
+	assert.Contains(t, errStr, ".miren/app.toml:5:")
+	assert.Contains(t, errStr, `unknown field "comand"`)
+	assert.Contains(t, errStr, `did you mean "command"?`)
+}
+
+func TestConfigErrorMultipleDiagnostics(t *testing.T) {
+	ce := &ConfigError{
+		FilePath: "app.toml",
+		Diagnostics: []Diagnostic{
+			{Line: 3, Message: `unknown field "a"`},
+			{Line: 7, Message: `unknown field "b"`},
+		},
+	}
+	errStr := ce.Error()
+	assert.Contains(t, errStr, "app.toml:3:")
+	assert.Contains(t, errStr, "app.toml:7:")
+}
+
+func TestEnrichDecodeError_UnknownField(t *testing.T) {
+	config := `
+name = "test-app"
+
+[services.web]
+comand = "server"
+`
+	_, err := Parse([]byte(config))
+	require.Error(t, err)
+
+	var ce *ConfigError
+	require.True(t, errors.As(err, &ce), "expected *ConfigError, got %T", err)
+	assert.Equal(t, "<input>", ce.FilePath)
+	require.Len(t, ce.Diagnostics, 1)
+	assert.Contains(t, ce.Diagnostics[0].Message, "comand")
+	assert.Contains(t, ce.Diagnostics[0].Hint, `"command"`)
+	assert.Greater(t, ce.Diagnostics[0].Line, 0)
+}
+
+func TestEnrichDecodeError_SyntaxError(t *testing.T) {
+	config := `name = "unterminated`
+	_, err := Parse([]byte(config))
+	require.Error(t, err)
+
+	var ce *ConfigError
+	require.True(t, errors.As(err, &ce), "expected *ConfigError, got %T", err)
+	assert.Greater(t, ce.Diagnostics[0].Line, 0)
+	assert.Contains(t, ce.Diagnostics[0].Context, "unterminated")
+}
+
+func TestEnrichDecodeError_TypeMismatch(t *testing.T) {
+	config := `name = 42`
+	_, err := Parse([]byte(config))
+	require.Error(t, err)
+
+	var ce *ConfigError
+	require.True(t, errors.As(err, &ce), "expected *ConfigError, got %T", err)
+	assert.Contains(t, ce.Error(), "cannot decode")
+}
+
+func TestEnrichValidationError_WithLineNumber(t *testing.T) {
+	config := `
+name = "test-app"
+
+[services.web.concurrency]
+mode = "invalid"
+`
+	_, err := Parse([]byte(config))
+	require.Error(t, err)
+
+	var ce *ConfigError
+	require.True(t, errors.As(err, &ce), "expected *ConfigError, got %T", err)
+	assert.Contains(t, ce.Error(), `invalid concurrency mode "invalid"`)
+	// Should resolve line number for the mode key
+	require.Len(t, ce.Diagnostics, 1)
+	assert.Equal(t, 5, ce.Diagnostics[0].Line)
+}
+
+func TestEnrichValidationError_AliasError(t *testing.T) {
+	config := `
+name = "test-app"
+
+[aliases]
+Console = "app exec"
+`
+	_, err := Parse([]byte(config))
+	require.Error(t, err)
+
+	var ce *ConfigError
+	require.True(t, errors.As(err, &ce), "expected *ConfigError, got %T", err)
+	assert.Contains(t, ce.Error(), "each word must start with a lowercase letter")
+	// Should have a line number for the alias
+	assert.Greater(t, ce.Diagnostics[0].Line, 0)
+}
+
+func TestResolveKeyLine(t *testing.T) {
+	data := []byte(`
+name = "test"
+
+[services.web.concurrency]
+mode = "auto"
+requests_per_instance = 10
+`)
+	assert.Equal(t, 5, resolveKeyLine(data, "services.web.concurrency.mode"))
+	assert.Equal(t, 6, resolveKeyLine(data, "services.web.concurrency.requests_per_instance"))
+	assert.Equal(t, 0, resolveKeyLine(data, "nonexistent.key"))
+}
+
+func TestKeyParentPath(t *testing.T) {
+	tests := []struct {
+		name string
+		key  []string
+		want string
+	}{
+		{"top-level", []string{"unknown"}, ""},
+		{"service field", []string{"services", "web", "comand"}, "services.*"},
+		{"service nested", []string{"services", "web", "concurrency", "mode"}, "services.*.concurrency"},
+		{"disk field", []string{"services", "db", "disks", "size"}, "services.*.disks"},
+		{"addon field", []string{"addons", "pg", "unknown"}, "addons.*"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// keyParentPath expects a toml.Key which is []string
+			assert.Equal(t, tt.want, keyParentPath(tt.key))
+		})
+	}
+}

--- a/cli/alias.go
+++ b/cli/alias.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"miren.dev/mflags"
 	"miren.dev/runtime/appconfig"
+	"miren.dev/runtime/pkg/ui"
 )
 
 // expandAlias checks if the given args match a configured alias and expands it.
@@ -17,7 +19,15 @@ func expandAlias(d *mflags.Dispatcher, args []string) ([]string, error) {
 	}
 
 	ac, err := appconfig.LoadAppConfig()
-	if err != nil || ac == nil || len(ac.Aliases) == 0 {
+	if err != nil {
+		if te, ok := err.(ui.TerminalError); ok {
+			te.WriteForTerminal(os.Stderr)
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: could not load %s: %v\n", appconfig.AppConfigPath, err)
+		}
+		return args, nil
+	}
+	if ac == nil || len(ac.Aliases) == 0 {
 		return args, nil
 	}
 

--- a/cli/alias.go
+++ b/cli/alias.go
@@ -21,6 +21,7 @@ func expandAlias(d *mflags.Dispatcher, args []string) ([]string, error) {
 	ac, err := appconfig.LoadAppConfig()
 	if err != nil {
 		if te, ok := err.(ui.TerminalError); ok {
+			fmt.Fprint(os.Stderr, "warning: ")
 			te.WriteForTerminal(os.Stderr)
 		} else {
 			fmt.Fprintf(os.Stderr, "warning: could not load %s: %v\n", appconfig.AppConfigPath, err)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"miren.dev/mflags"
 	"miren.dev/runtime/cli/commands"
 	"miren.dev/runtime/pkg/labs"
+	"miren.dev/runtime/pkg/ui"
 	"miren.dev/runtime/version"
 )
 
@@ -34,7 +35,7 @@ func Run(args []string) int {
 	if helpJSON {
 		data, err := d.HelpJSON()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+			printError(err)
 			return 1
 		}
 		fmt.Println(string(data))
@@ -43,7 +44,7 @@ func Run(args []string) int {
 
 	execArgs, err := expandAlias(d, args[1:])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		printError(err)
 		return 1
 	}
 
@@ -58,11 +59,24 @@ func Run(args []string) int {
 			return int(exitErr)
 		}
 
-		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		printError(err)
 		return 1
 	}
 
 	return 0
+}
+
+// printError renders an error to stderr. If the error implements
+// ui.TerminalError, it gets colorized multi-line output; otherwise
+// it falls back to a plain "ERROR: ..." line.
+func printError(err error) {
+	var te ui.TerminalError
+	if errors.As(err, &te) {
+		fmt.Fprintf(os.Stderr, "ERROR: ")
+		te.WriteForTerminal(os.Stderr)
+	} else {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+	}
 }
 
 // Version returns the version string

--- a/cli/commands/app_delete.go
+++ b/cli/commands/app_delete.go
@@ -15,7 +15,10 @@ func AppDelete(ctx *Context, opts struct {
 }) error {
 	appName := opts.AppName
 	if appName == "" {
-		if ac, err := appconfig.LoadAppConfig(); err == nil && ac != nil && ac.Name != "" {
+		ac, err := appconfig.LoadAppConfig()
+		if err != nil {
+			printConfigWarning(err)
+		} else if ac != nil && ac.Name != "" {
 			appName = ac.Name
 		}
 	}

--- a/cli/commands/cluster_switch.go
+++ b/cli/commands/cluster_switch.go
@@ -100,7 +100,9 @@ func ClusterSwitch(ctx *Context, opts struct {
 	ctx.Printf("Switched to cluster: %s\n", clusterName)
 
 	// Also update per-app state if we're in an app directory.
-	if ac, _ := appconfig.LoadAppConfig(); ac != nil && ac.Name != "" {
+	if ac, err := appconfig.LoadAppConfig(); err != nil {
+		printConfigWarning(err)
+	} else if ac != nil && ac.Name != "" {
 		_ = appconfig.SaveAppState(ac.Name, &appconfig.AppState{Cluster: clusterName})
 	}
 

--- a/cli/commands/config.go
+++ b/cli/commands/config.go
@@ -101,7 +101,9 @@ func (c *ConfigCentric) LoadCluster() (*clientconfig.ClusterConfig, string, erro
 		return cc, name, nil
 	} else {
 		// Check per-app state if we're in an app directory.
-		if ac, _ := appconfig.LoadAppConfig(); ac != nil && ac.Name != "" {
+		if ac, err := appconfig.LoadAppConfig(); err != nil {
+			printConfigWarning(err)
+		} else if ac != nil && ac.Name != "" {
 			state, err := appconfig.LoadAppState(ac.Name)
 			if err == nil && state != nil && state.Cluster != "" {
 				cc, err := cfg.GetCluster(state.Cluster)

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -226,6 +226,16 @@ func (c *Context) Warn(format string, args ...interface{}) {
 	fmt.Fprintf(c.Stdout, "W "+format+"\n", args...)
 }
 
+// printConfigWarning renders a config error to stderr. Uses TerminalError
+// for rich output when available, otherwise falls back to a plain warning.
+func printConfigWarning(err error) {
+	if te, ok := err.(ui.TerminalError); ok {
+		te.WriteForTerminal(os.Stderr)
+	} else {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+	}
+}
+
 func (c *Context) Begin(format string, args ...interface{}) {
 	fmt.Fprintf(c.Stderr, ui.Play+" "+format+"\n", args...)
 }

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -230,6 +230,7 @@ func (c *Context) Warn(format string, args ...interface{}) {
 // for rich output when available, otherwise falls back to a plain warning.
 func printConfigWarning(err error) {
 	if te, ok := err.(ui.TerminalError); ok {
+		fmt.Fprint(os.Stderr, "warning: ")
 		te.WriteForTerminal(os.Stderr)
 	} else {
 		fmt.Fprintf(os.Stderr, "warning: %v\n", err)

--- a/cli/commands/help_alias.go
+++ b/cli/commands/help_alias.go
@@ -58,6 +58,8 @@ func HelpAlias(ctx *Context, opts helpAliasOpts) error {
 
 	ac, err := appconfig.LoadAppConfig()
 	if err != nil {
+		printConfigWarning(err)
+		fmt.Println()
 		return nil
 	}
 

--- a/cli/commands/route_set.go
+++ b/cli/commands/route_set.go
@@ -23,7 +23,10 @@ func RouteSet(ctx *Context, opts struct {
 
 	appName := opts.AppName
 	if appName == "" {
-		if ac, err := appconfig.LoadAppConfig(); err == nil && ac != nil && ac.Name != "" {
+		ac, err := appconfig.LoadAppConfig()
+		if err != nil {
+			printConfigWarning(err)
+		} else if ac != nil && ac.Name != "" {
 			appName = ac.Name
 		}
 	}

--- a/cli/commands/route_set_default.go
+++ b/cli/commands/route_set_default.go
@@ -14,7 +14,10 @@ func RouteSetDefault(ctx *Context, opts struct {
 }) error {
 	appName := opts.AppName
 	if appName == "" {
-		if ac, err := appconfig.LoadAppConfig(); err == nil && ac != nil && ac.Name != "" {
+		ac, err := appconfig.LoadAppConfig()
+		if err != nil {
+			printConfigWarning(err)
+		} else if ac != nil && ac.Name != "" {
 			appName = ac.Name
 		}
 	}

--- a/pkg/ui/terminal_error.go
+++ b/pkg/ui/terminal_error.go
@@ -1,0 +1,24 @@
+package ui
+
+import "io"
+
+// TerminalError is an optional interface for errors that can render a rich,
+// human-friendly representation to a terminal. Errors that implement this
+// interface get colorized, multi-line output with source context when
+// displayed through the CLI.
+//
+// The Error() method should still return a plain-text representation suitable
+// for logging and wrapping. WriteForTerminal provides the enhanced version
+// for interactive use.
+//
+// This follows the same pattern as io.WriterTo and http.Flusher — a type
+// assertion at the display boundary unlocks richer behavior.
+//
+// Design note: this interface is rendering-only. The underlying error type
+// should carry structured data (source locations, hints, etc.) as exported
+// fields so that the data can be serialized over RPC. Client-side code can
+// then reconstruct a TerminalError from the wire data for local rendering.
+type TerminalError interface {
+	error
+	WriteForTerminal(w io.Writer)
+}


### PR DESCRIPTION
Config parse errors from `.miren/app.toml` were pretty rough. A typo like `comand` in a service block would produce the unhelpful `"strict mode: fields in the document are missing in the target struct"`. Validation errors like `mode = "invalid"` had no file or line info at all. And several commands silently swallowed parse failures — `miren help alias` would show "No aliases configured" when the real problem was a broken TOML file.

This PR does a full sweep to make config errors actually nice. go-toml/v2 already provides rich `DecodeError` output with line numbers and tilde underlines — we leverage that and layer on file paths, "did you mean?" suggestions (via Levenshtein distance + substring matching against a registry of valid fields), and AST-based line resolution for validation errors (reusing the `tomlast.Parser` approach from `AliasLineNumbers`).

The second piece is a new `ui.TerminalError` interface — any error type can implement `WriteForTerminal(w io.Writer)` to get colorized rendering at the CLI boundary. It follows the same Go pattern as `io.WriterTo` and `http.Flusher`: a type assertion at the display boundary unlocks richer behavior. `ConfigError` implements it with red headers, dimmed source context, and yellow hints. The interface is designed with RPC in mind — rendering is client-side only, and the structured diagnostic data lives in exported fields for future wire serialization.

Finally, all seven callers that were silently eating config errors now surface them as warnings. Commands that use config just for optional context (app name, cluster) warn and continue gracefully.

### Examples

**Unknown field with suggestion:**
```
.miren/app.toml:4: unknown field "comand"
  1| name = "my-app"
  2|
  3| [services.web]
  4| comand = "bundle exec rails s"
   | ~~~~~~ missing field
  hint: did you mean "command"?
```

**Syntax error:**
```
.miren/app.toml:1: toml: basic strings cannot have new lines
  1| name = "my-app
   |               ~ basic strings cannot have new lines
```

**Validation error with source location:**
```
.miren/app.toml:4: service web: invalid concurrency mode "turbo", must be "auto" or "fixed"
  4 | mode = "turbo"
```

Closes MIR-874