### PR TITLE
Fix slice aliasing bug in buildEntitySaveOps that drops entity attrs on overwrite

### DIFF
--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -959,7 +959,7 @@ func (s *EtcdStore) buildUniqueUpdateOps(ctx context.Context, entityId Id, oldEn
 func (s *EtcdStore) buildEntitySaveOps(entity *Entity, key string, primary, session []Attr, o *entityOpts) ([]clientv3.Op, error) {
 	var ops []clientv3.Op
 
-	entity.attrs = primary
+	entity.attrs = slices.Clone(primary)
 	// Store manages UpdatedAt - set it on every save
 	entity.SetUpdatedAt(time.Now())
 
@@ -1374,7 +1374,7 @@ func (s *EtcdStore) GetAttributeSchema(ctx context.Context, id Id) (*AttributeSc
 
 	if ok {
 		if schema.Type == "" {
-			panic("attribute schema in cache has empty type")
+			panic(fmt.Sprintf("attribute schema %q in cache has empty type", id))
 		}
 		return schema, nil
 	}

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -2329,3 +2329,59 @@ func TestGetOneIndex(t *testing.T) {
 	_, err = store.GetOneIndex(t.Context(), String(DBShortId, "nonexistent"))
 	assert.Error(t, err)
 }
+
+// TestCreateEntity_OverwritePreservesAllAttrs verifies that CreateEntity with
+// WithOverwrite does not silently drop attributes when overwriting an existing
+// entity. This is a regression test for MIR-931, where buildEntitySaveOps
+// mutated a shared slice backing array via SetUpdatedAt + SortedAttrs, causing
+// attributes that sort after "db/entity.updated" (like "db/type") to be pushed
+// past the slice's length on the overwrite path.
+func TestCreateEntity_OverwritePreservesAllAttrs(t *testing.T) {
+	client := setupTestEtcd(t)
+
+	prefix := "/test-overwrite-attrs"
+	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	// Create a schema attribute entity (like schema.Apply does)
+	original := New(
+		Ident, "test/overwrite.attr",
+		Doc, "original doc",
+		Type, TypeStr,
+		Cardinality, CardinalityOne,
+	)
+
+	e1, err := store.CreateEntity(t.Context(), New(original.Attrs()), WithOverwrite)
+	require.NoError(t, err)
+	assert.Equal(t, Id("test/overwrite.attr"), e1.Id())
+
+	// Overwrite with changed doc — simulates schema.Apply on second boot
+	updated := New(
+		Ident, "test/overwrite.attr",
+		Doc, "updated doc",
+		Type, TypeStr,
+		Cardinality, CardinalityOne,
+	)
+
+	e2, err := store.CreateEntity(t.Context(), New(updated.Attrs()), WithOverwrite)
+	require.NoError(t, err)
+	assert.Equal(t, Id("test/overwrite.attr"), e2.Id())
+
+	// Read back from etcd and verify all attrs survived
+	fetched, err := store.GetEntity(t.Context(), Id("test/overwrite.attr"))
+	require.NoError(t, err)
+
+	// The critical check: db/type must still be present after overwrite.
+	// MIR-931 caused this attr to be silently dropped because buildEntitySaveOps
+	// mutated a shared slice, pushing later-sorted attrs past the slice length.
+	typeAttr, hasType := fetched.Get(Type)
+	require.True(t, hasType, "entity should still have db/type after overwrite")
+	assert.Equal(t, TypeStr, typeAttr.Value.Any(), "type should be preserved after overwrite")
+
+	docAttr, hasDoc := fetched.Get(Doc)
+	require.True(t, hasDoc, "entity should still have db/doc after overwrite")
+	assert.Equal(t, "updated doc", docAttr.Value.Any(), "doc should reflect the overwrite")
+}


### PR DESCRIPTION
Garden went down right after the short-id deploy landed. The server was crash-looping with `panic: attribute schema in cache has empty type` — every boot would run `schema.Apply`, overwrite the existing schema attribute entities, and silently lose their `db/type` attr in the process. Then `GetAttributeSchema` would fail and the coordinator couldn't even create the default project.

The root cause is a Go slice aliasing footgun in `buildEntitySaveOps`. It sets `entity.attrs = primary` (sharing the backing array), then `SetUpdatedAt` appends and `SortedAttrs` re-sorts in-place. Any attr that sorts after `db/entity.updated` — like `db/type` — gets shuffled past `primary`'s length. When `CreateEntity`'s retry loop reuses `primary` on the overwrite path, those attrs are gone. This was latent before #696 because `buildEntitySaveOps` was only called once; the retry loop made `primary` reusable across attempts.

The fix is `slices.Clone(primary)` to break the alias. Also improved the panic message in `GetAttributeSchema` to include the schema ID for easier debugging if we ever hit it again.

Regression test included — confirmed it fails without the fix and passes with it.

Closes MIR-931