### PR TITLE
Discover public IPs via netcheck for TLS cert SANs

### DIFF
--- a/cli/commands/auth_generate.go
+++ b/cli/commands/auth_generate.go
@@ -41,7 +41,9 @@ func AuthGenerate(ctx *Context, opts struct {
 	var tgt string
 
 	if opts.PublicIP {
-		discovery, err := ipdiscovery.DiscoverWithTimeout(5*time.Second, ctx.Log, ipdiscovery.Options{})
+		discovery, err := ipdiscovery.DiscoverWithTimeout(10*time.Second, ctx.Log, ipdiscovery.Options{
+			NetcheckURL: coordinate.DefaultCloudURL,
+		})
 		if err != nil {
 			return err
 		}

--- a/cli/commands/auth_generate.go
+++ b/cli/commands/auth_generate.go
@@ -41,7 +41,7 @@ func AuthGenerate(ctx *Context, opts struct {
 	var tgt string
 
 	if opts.PublicIP {
-		discovery, err := ipdiscovery.DiscoverWithTimeout(5*time.Second, ctx.Log)
+		discovery, err := ipdiscovery.DiscoverWithTimeout(5*time.Second, ctx.Log, ipdiscovery.Options{})
 		if err != nil {
 			return err
 		}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -88,7 +88,6 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		for _, addr := range discovery.Addresses {
 			ip := net.ParseIP(addr.IP)
 			if ip != nil && !ip.IsLinkLocalUnicast() {
-				cfg.TLS.AdditionalIPs = append(cfg.TLS.AdditionalIPs, addr.IP)
 				discoveredIps = append(discoveredIps, ip)
 			}
 		}
@@ -296,16 +295,8 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		if labs.DistributedRunners() {
 			ctx.Log.Info("setting up etcd mTLS for distributed runners")
 
-			// Parse additional IPs for etcd server cert SANs
-			var etcdExtraIPs []net.IP
-			for _, ipStr := range cfg.TLS.AdditionalIPs {
-				if ip := net.ParseIP(ipStr); ip != nil {
-					etcdExtraIPs = append(etcdExtraIPs, ip)
-				}
-			}
-
 			var err error
-			etcdTLSSetup, err = coordinate.SetupEtcdTLS(ctx.Log, cfg.Server.GetDataPath(), cfg.TLS.AdditionalNames, etcdExtraIPs)
+			etcdTLSSetup, err = coordinate.SetupEtcdTLS(ctx.Log, cfg.Server.GetDataPath(), cfg.TLS.AdditionalNames, discoveredIps)
 			if err != nil {
 				ctx.Log.Error("failed to set up etcd TLS", "error", err)
 				return err

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -74,14 +74,16 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	versionInfo := version.GetInfo()
 	ctx.UILog.Info("starting miren server", "version", versionInfo.Version, "commit", versionInfo.Commit)
 
-	// Discover local IPs early so they're available for etcd TLS SANs.
+	// Discover local and public IPs early so they're available for TLS cert SANs.
 	// We track discovered IPs separately from user-configured IPs so the
 	// coordinator can treat them differently (netcheck can replace discovered
 	// public IPs but user-configured IPs always pass through).
 	var discoveredIps []net.IP
-	discovery, err := ipdiscovery.DiscoverWithTimeout(5*time.Second, ctx.Log)
+	discovery, err := ipdiscovery.DiscoverWithTimeout(10*time.Second, ctx.Log, ipdiscovery.Options{
+		NetcheckURL: coordinate.DefaultCloudURL,
+	})
 	if err != nil {
-		ctx.Log.Warn("failed to discover local IPs", "error", err)
+		ctx.Log.Warn("failed to discover IPs", "error", err)
 	} else {
 		for _, addr := range discovery.Addresses {
 			ip := net.ParseIP(addr.IP)
@@ -90,7 +92,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 				discoveredIps = append(discoveredIps, ip)
 			}
 		}
-		ctx.Log.Info("discovered IPs", "local-addresses", len(discovery.Addresses))
+		ctx.Log.Info("discovered IPs", "addresses", len(discovery.Addresses))
 	}
 
 	switch cfg.GetMode() {

--- a/pkg/ipdiscovery/ipdiscovery.go
+++ b/pkg/ipdiscovery/ipdiscovery.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net"
 	"time"
+
+	"miren.dev/runtime/pkg/cloudauth"
 )
 
 // Discovery holds information about discovered IP addresses
@@ -21,8 +23,17 @@ type Address struct {
 	IsIPv6    bool   `json:"is_ipv6"`
 }
 
-// Discover gathers all local interface addresses.
-func Discover(ctx context.Context, log *slog.Logger) (*Discovery, error) {
+// Options configures IP discovery behavior.
+type Options struct {
+	// NetcheckURL, when set, enables public IP discovery via a zero-port
+	// netcheck request to the given URL. On cloud providers the external IP
+	// isn't on any local interface, so this is the only way to find it.
+	NetcheckURL string
+}
+
+// Discover gathers IP addresses from local interfaces and, when configured,
+// from an external netcheck service for public IP discovery.
+func Discover(ctx context.Context, log *slog.Logger, opts Options) (*Discovery, error) {
 	discovery := &Discovery{
 		Addresses: []Address{},
 	}
@@ -69,12 +80,35 @@ func Discover(ctx context.Context, log *slog.Logger) (*Discovery, error) {
 		}
 	}
 
+	// Discover public IPs via netcheck if configured
+	if opts.NetcheckURL != "" {
+		result, err := cloudauth.NetcheckDualStack(ctx, opts.NetcheckURL, nil)
+		if err != nil {
+			log.Warn("public IP discovery failed", "error", err)
+		} else {
+			for _, resp := range []*cloudauth.NetcheckResponse{result.IPv4, result.IPv6} {
+				if resp == nil {
+					continue
+				}
+				ip := net.ParseIP(resp.SourceAddress)
+				if ip != nil && ip.IsGlobalUnicast() && !ip.IsPrivate() {
+					log.Info("discovered public IP via netcheck", "ip", ip)
+					discovery.Addresses = append(discovery.Addresses, Address{
+						Interface: "netcheck",
+						IP:        ip.String(),
+						IsIPv6:    ip.To4() == nil,
+					})
+				}
+			}
+		}
+	}
+
 	return discovery, nil
 }
 
 // DiscoverWithTimeout is a convenience function that adds a timeout to Discover
-func DiscoverWithTimeout(timeout time.Duration, log *slog.Logger) (*Discovery, error) {
+func DiscoverWithTimeout(timeout time.Duration, log *slog.Logger, opts Options) (*Discovery, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	return Discover(ctx, log)
+	return Discover(ctx, log, opts)
 }

--- a/pkg/ipdiscovery/ipdiscovery_test.go
+++ b/pkg/ipdiscovery/ipdiscovery_test.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/cloudauth"
 	"miren.dev/runtime/pkg/slogfmt"
 )
 
@@ -21,7 +24,7 @@ func testLogger(t *testing.T) *slog.Logger {
 func TestDiscover(t *testing.T) {
 	ctx := context.Background()
 	log := testLogger(t)
-	discovery, err := Discover(ctx, log)
+	discovery, err := Discover(ctx, log, Options{})
 	require.NoError(t, err)
 	require.NotNil(t, discovery)
 
@@ -38,7 +41,7 @@ func TestDiscover(t *testing.T) {
 
 func TestDiscoverWithTimeout(t *testing.T) {
 	log := testLogger(t)
-	discovery, err := DiscoverWithTimeout(5*time.Second, log)
+	discovery, err := DiscoverWithTimeout(5*time.Second, log, Options{})
 	require.NoError(t, err)
 	require.NotNil(t, discovery)
 
@@ -49,7 +52,7 @@ func TestDiscoverWithTimeout(t *testing.T) {
 func TestAddressTypes(t *testing.T) {
 	ctx := context.Background()
 	log := testLogger(t)
-	discovery, err := Discover(ctx, log)
+	discovery, err := Discover(ctx, log, Options{})
 	require.NoError(t, err)
 
 	var hasIPv4 bool
@@ -67,6 +70,102 @@ func TestAddressTypes(t *testing.T) {
 
 	// Most systems should have at least IPv4
 	assert.True(t, hasIPv4)
+}
+
+func fakeNetcheckServer(t *testing.T, resp cloudauth.NetcheckResponse) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/api/v1/netcheck" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestDiscoverWithNetcheck(t *testing.T) {
+	srv := fakeNetcheckServer(t, cloudauth.NetcheckResponse{
+		SourceAddress: "203.0.113.42",
+	})
+
+	log := testLogger(t)
+	discovery, err := Discover(context.Background(), log, Options{
+		NetcheckURL: srv.URL,
+	})
+	require.NoError(t, err)
+
+	var found bool
+	for _, addr := range discovery.Addresses {
+		if addr.IP == "203.0.113.42" {
+			found = true
+			assert.Equal(t, "netcheck", addr.Interface)
+			assert.False(t, addr.IsIPv6)
+			break
+		}
+	}
+	assert.True(t, found, "expected netcheck-discovered public IP in addresses")
+}
+
+func TestDiscoverWithNetcheckIPv6(t *testing.T) {
+	srv := fakeNetcheckServer(t, cloudauth.NetcheckResponse{
+		SourceAddress: "2001:db8::1",
+	})
+
+	log := testLogger(t)
+	discovery, err := Discover(context.Background(), log, Options{
+		NetcheckURL: srv.URL,
+	})
+	require.NoError(t, err)
+
+	var found bool
+	for _, addr := range discovery.Addresses {
+		if addr.IP == "2001:db8::1" {
+			found = true
+			assert.Equal(t, "netcheck", addr.Interface)
+			assert.True(t, addr.IsIPv6)
+			break
+		}
+	}
+	assert.True(t, found, "expected netcheck-discovered IPv6 address in addresses")
+}
+
+func TestDiscoverWithNetcheckPrivateIPFiltered(t *testing.T) {
+	srv := fakeNetcheckServer(t, cloudauth.NetcheckResponse{
+		SourceAddress: "10.0.0.1",
+	})
+
+	log := testLogger(t)
+	discovery, err := Discover(context.Background(), log, Options{
+		NetcheckURL: srv.URL,
+	})
+	require.NoError(t, err)
+
+	for _, addr := range discovery.Addresses {
+		if addr.Interface == "netcheck" {
+			t.Errorf("private IP %s should not appear as netcheck address", addr.IP)
+		}
+	}
+}
+
+func TestDiscoverWithNetcheckFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	log := testLogger(t)
+	discovery, err := Discover(context.Background(), log, Options{
+		NetcheckURL: srv.URL,
+	})
+	require.NoError(t, err)
+	// Should still return local addresses even when netcheck fails
+	assert.NotEmpty(t, discovery.Addresses)
+	for _, addr := range discovery.Addresses {
+		assert.NotEqual(t, "netcheck", addr.Interface)
+	}
 }
 
 func TestDiscoveryJSON(t *testing.T) {


### PR DESCRIPTION
After PR #708 replaced the `ifconfig.co` lookup with netcheck-based public IP discovery, the server TLS cert stopped including the external IP in its SANs. The problem is a chicken-and-egg: netcheck needs to probe ports, so it runs after the server is listening, but the cert is generated before that. On cloud providers like GCP the external IP isn't on any local interface (it's VPC-level NAT), so the local interface scan can't find it either.

The fix brings public IP discovery back into `ipdiscovery.Discover()` where it used to live — just using our own netcheck service instead of `ifconfig.co`. A new `NetcheckURL` option triggers a zero-port netcheck request that returns just the source address without probing any ports, so it works before the server is listening. This runs for all servers, not just cloud-registered ones, since the netcheck endpoint is unauthenticated and essentially a public "what's my IP" service.

Fixes MIR-936