### PR TITLE
Map disk provider field in buildServicesConfig

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -330,6 +330,15 @@ func validateDiskConfigs(ctx context.Context, eac *entityserver_v1alpha.EntityAc
 	return nil
 }
 
+func mapDiskProvider(provider string) core_v1alpha.ConfigSpecServicesDisksProvider {
+	switch provider {
+	case "local":
+		return core_v1alpha.ConfigSpecServicesDisksLOCAL
+	default:
+		return core_v1alpha.ConfigSpecServicesDisksMIREN
+	}
+}
+
 // buildServicesConfig collects services from app config and procfile,
 // resolves defaults, and returns the final service configurations.
 // This is the core logic for determining which services exist in an app_version
@@ -446,6 +455,7 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 						SizeGb:       int64(disk.SizeGB),
 						Filesystem:   disk.Filesystem,
 						LeaseTimeout: disk.LeaseTimeout,
+						Provider:     mapDiskProvider(disk.Provider),
 					})
 				}
 			}

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -361,6 +361,69 @@ func TestBuildServicesConfig(t *testing.T) {
 				assert.Equal(t, "ext4", disk.Filesystem)
 				assert.Equal(t, "5m", disk.LeaseTimeout)
 				assert.False(t, disk.ReadOnly)
+				assert.Equal(t, core_v1alpha.ConfigSpecServicesDisksMIREN, disk.Provider, "default provider should be miren")
+			},
+		},
+		{
+			name: "service with local disk provider",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"web": {
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:         "fixed",
+							NumInstances: 1,
+						},
+						Disks: []appconfig.DiskConfig{
+							{
+								Name:      "cache",
+								MountPath: "/cache",
+								Provider:  "local",
+							},
+						},
+					},
+				},
+			},
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
+				require.Len(t, services, 1)
+				svc := services[0]
+
+				require.Len(t, svc.Disks, 1)
+				disk := svc.Disks[0]
+				assert.Equal(t, "cache", disk.Name)
+				assert.Equal(t, "/cache", disk.MountPath)
+				assert.Equal(t, core_v1alpha.ConfigSpecServicesDisksLOCAL, disk.Provider, "local provider should be mapped")
+			},
+		},
+		{
+			name: "service with explicit miren disk provider",
+			appConfig: &appconfig.AppConfig{
+				Services: map[string]*appconfig.ServiceConfig{
+					"db": {
+						Concurrency: &appconfig.ServiceConcurrencyConfig{
+							Mode:         "fixed",
+							NumInstances: 1,
+						},
+						Disks: []appconfig.DiskConfig{
+							{
+								Name:      "data",
+								MountPath: "/data",
+								SizeGB:    100,
+								Provider:  "miren",
+							},
+						},
+					},
+				},
+			},
+			procfileServices: nil,
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
+				require.Len(t, services, 1)
+				svc := services[0]
+
+				require.Len(t, svc.Disks, 1)
+				disk := svc.Disks[0]
+				assert.Equal(t, "data", disk.Name)
+				assert.Equal(t, core_v1alpha.ConfigSpecServicesDisksMIREN, disk.Provider, "explicit miren provider should be mapped")
 			},
 		},
 		{


### PR DESCRIPTION
`buildServicesConfig` was dutifully copying over every disk field from the appconfig — name, mount path, size, filesystem, lease timeout, read-only — but quietly skipping the `provider` field. So when you set `provider = "local"` in your app.toml, it'd just vanish into the ether. The entity would end up with an empty provider, and then `validateDiskConfigs` (which PR #703 taught to skip local disks) would never recognize it as local. You'd get the confusing `disk "data" does not exist; set size_gb to auto-create it` error even though you never wanted a network disk in the first place.

The fix is a small `mapDiskProvider` helper that translates the appconfig string (`"local"`, `"miren"`, or empty) into the entity enum, wired into the disk conversion loop. Discovered this while deploying the Around appcast server with an explicit local disk block.

Closes MIR-940