### PR TITLE
Fix disk provider enum leak in launcher and config conversion

### DIFF
--- a/api/core/config_version.go
+++ b/api/core/config_version.go
@@ -70,7 +70,7 @@ func ConfigSpecFromConfig(cfg *core_v1alpha.Config) core_v1alpha.ConfigSpec {
 
 		// Convert disks (field-by-field since Provider enum types differ)
 		for _, d := range svc.Disks {
-			var provider core_v1alpha.ConfigSpecServicesDisksProvider
+			provider := core_v1alpha.ConfigSpecServicesDisksMIREN
 			switch d.Provider {
 			case core_v1alpha.LOCAL:
 				provider = core_v1alpha.ConfigSpecServicesDisksLOCAL

--- a/api/core/config_version.go
+++ b/api/core/config_version.go
@@ -70,9 +70,16 @@ func ConfigSpecFromConfig(cfg *core_v1alpha.Config) core_v1alpha.ConfigSpec {
 
 		// Convert disks (field-by-field since Provider enum types differ)
 		for _, d := range svc.Disks {
+			var provider core_v1alpha.ConfigSpecServicesDisksProvider
+			switch d.Provider {
+			case core_v1alpha.LOCAL:
+				provider = core_v1alpha.ConfigSpecServicesDisksLOCAL
+			case core_v1alpha.MIREN:
+				provider = core_v1alpha.ConfigSpecServicesDisksMIREN
+			}
 			s.Disks = append(s.Disks, core_v1alpha.ConfigSpecServicesDisks{
 				Name:         d.Name,
-				Provider:     core_v1alpha.ConfigSpecServicesDisksProvider(d.Provider),
+				Provider:     provider,
 				MountPath:    d.MountPath,
 				ReadOnly:     d.ReadOnly,
 				SizeGb:       d.SizeGb,

--- a/blackbox/local_disk_test.go
+++ b/blackbox/local_disk_test.go
@@ -1,0 +1,116 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+func TestLocalDiskPersistence(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "local-disk-app",
+	})
+
+	// Set a route so we can reach the app via HTTP ingress
+	host := name + ".test.local"
+	m.MustRun("route", "set", host, name)
+	t.Cleanup(func() {
+		m.Run("route", "remove", host)
+	})
+
+	// Wait for HTTP to be reachable
+	harness.Poll(t, "HTTP reachable", 30*time.Second, 2*time.Second, func() (bool, string) {
+		code, _, err := harness.HTTPGet(m, host, "/health")
+		if err != nil {
+			return false, fmt.Sprintf("HTTP error: %v", err)
+		}
+		if code != 200 {
+			return false, fmt.Sprintf("HTTP status %d", code)
+		}
+		return true, ""
+	})
+
+	// Write data to the local disk via the app
+	r := m.RunCmd("curl", "-sk", "-X", "POST", "-d", "hello-from-disk",
+		"-H", fmt.Sprintf("Host: %s", host),
+		"-w", "\n%{http_code}",
+		fmt.Sprintf("https://localhost:443/data"))
+	r.RequireSuccess(t)
+	r.RequireContains(t, "201")
+
+	// Read it back to confirm the write worked
+	code, body, err := harness.HTTPGet(m, host, "/data")
+	if err != nil {
+		t.Fatalf("failed to read data: %v", err)
+	}
+	if code != 200 || body != "hello-from-disk" {
+		t.Fatalf("expected 200/hello-from-disk, got %d/%q", code, body)
+	}
+
+	// Record the current version
+	versionBefore := getAppVersion(t, m, name)
+	t.Logf("version before redeploy: %s", versionBefore)
+
+	// Trigger a redeploy by setting an env var
+	m.MustRun("env", "set", "-a", name, "-e", "REDEPLOY_MARKER=v2")
+	harness.WaitForAppReady(t, m, name, 2*time.Minute)
+
+	// Verify we got a new version
+	versionAfter := getAppVersion(t, m, name)
+	t.Logf("version after redeploy: %s", versionAfter)
+	if versionBefore == versionAfter {
+		t.Fatalf("expected version to change after redeploy, still %s", versionBefore)
+	}
+
+	// Wait for the new version to be serving HTTP
+	harness.Poll(t, "new version HTTP reachable", 30*time.Second, 2*time.Second, func() (bool, string) {
+		code, _, err := harness.HTTPGet(m, host, "/health")
+		if err != nil {
+			return false, fmt.Sprintf("HTTP error: %v", err)
+		}
+		if code != 200 {
+			return false, fmt.Sprintf("HTTP status %d", code)
+		}
+		return true, ""
+	})
+
+	// Read data back — it should have survived the redeploy
+	code, body, err = harness.HTTPGet(m, host, "/data")
+	if err != nil {
+		t.Fatalf("failed to read data after redeploy: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected 200 after redeploy, got %d (body: %q)", code, body)
+	}
+	if body != "hello-from-disk" {
+		t.Fatalf("data did not survive redeploy: expected %q, got %q", "hello-from-disk", body)
+	}
+}
+
+func getAppVersion(t *testing.T, m *harness.Miren, appName string) string {
+	t.Helper()
+	r := m.MustRun("app", "list", "--format", "json")
+	var apps []struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(r.Stdout), &apps); err != nil {
+		t.Fatalf("failed to parse app list JSON: %v", err)
+	}
+	for _, app := range apps {
+		if strings.Contains(app.Name, appName) {
+			return app.Version
+		}
+	}
+	t.Fatalf("app %s not found in app list", appName)
+	return ""
+}

--- a/blackbox/local_disk_test.go
+++ b/blackbox/local_disk_test.go
@@ -5,7 +5,6 @@ package blackbox
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -107,7 +106,7 @@ func getAppVersion(t *testing.T, m *harness.Miren, appName string) string {
 		t.Fatalf("failed to parse app list JSON: %v", err)
 	}
 	for _, app := range apps {
-		if strings.Contains(app.Name, appName) {
+		if app.Name == appName {
 			return app.Version
 		}
 	}

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -656,8 +656,13 @@ func (l *Launcher) buildSandboxSpec(
 			}
 
 			for _, disk := range svc.Disks {
-				provider := string(disk.Provider)
-				if provider == "" {
+				var provider string
+				switch disk.Provider {
+				case core_v1alpha.ConfigSpecServicesDisksLOCAL:
+					provider = "local"
+				case core_v1alpha.ConfigSpecServicesDisksMIREN:
+					provider = "miren"
+				default:
 					provider = "miren"
 				}
 

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -2260,3 +2260,146 @@ func TestWebServiceImplicitHTTPPortWithMultiPort(t *testing.T) {
 	// PORT env var should be set to 3000 (the implicit HTTP port)
 	assert.Contains(t, container.Env, "PORT=3000")
 }
+
+// TestDiskProviderMapping verifies that disk provider enum values are mapped to
+// the short string form that the sandbox volume controller expects.
+func TestDiskProviderMapping(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "local-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/data",
+						},
+						{
+							Name:      "miren-data",
+							Provider:  core_v1alpha.MIREN,
+							MountPath: "/miren-data",
+							SizeGb:    1,
+						},
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1, "should create one pool")
+
+	volumes := pools[0].SandboxSpec.Volume
+	require.Len(t, volumes, 2, "should have two volumes")
+
+	// Volumes should have short provider strings, not full entity enum values
+	var localVol, mirenVol *compute_v1alpha.SandboxSpecVolume
+	for i := range volumes {
+		switch volumes[i].Name {
+		case "local-data":
+			localVol = &volumes[i]
+		case "miren-data":
+			mirenVol = &volumes[i]
+		}
+	}
+
+	require.NotNil(t, localVol, "should have local-data volume")
+	assert.Equal(t, "local", localVol.Provider, "local disk provider should be mapped to short string")
+	assert.Equal(t, "/data", localVol.MountPath)
+
+	require.NotNil(t, mirenVol, "should have miren-data volume")
+	assert.Equal(t, "miren", mirenVol.Provider, "miren disk provider should be mapped to short string")
+	assert.Equal(t, "/miren-data", mirenVol.MountPath)
+}
+
+// TestDiskProviderDefaultsToMiren verifies that an empty provider defaults to "miren".
+func TestDiskProviderDefaultsToMiren(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "default-disk",
+							MountPath: "/storage",
+							SizeGb:    1,
+						},
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	volumes := pools[0].SandboxSpec.Volume
+	require.Len(t, volumes, 1)
+	assert.Equal(t, "miren", volumes[0].Provider, "empty provider should default to miren")
+}

--- a/testdata/local-disk-app/.miren/app.toml
+++ b/testdata/local-disk-app/.miren/app.toml
@@ -1,0 +1,10 @@
+name = "local-disk-app"
+
+[services.web.concurrency]
+mode = "fixed"
+num_instances = 1
+
+[[services.web.disks]]
+name = "shared-data"
+provider = "local"
+mount_path = "/data"

--- a/testdata/local-disk-app/Procfile
+++ b/testdata/local-disk-app/Procfile
@@ -1,0 +1,1 @@
+web: /bin/app

--- a/testdata/local-disk-app/go.mod
+++ b/testdata/local-disk-app/go.mod
@@ -1,0 +1,3 @@
+module local-disk-app
+
+go 1.25

--- a/testdata/local-disk-app/main.go
+++ b/testdata/local-disk-app/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
+
+	// GET /data returns the contents of /data/value (or 404 if not written yet)
+	http.HandleFunc("/data", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			data, err := os.ReadFile("/data/value")
+			if err != nil {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			w.Write(data)
+		case http.MethodPost:
+			buf := make([]byte, 1024)
+			n, _ := r.Body.Read(buf)
+			if err := os.WriteFile("/data/value", buf[:n], 0644); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK\n")
+	})
+
+	fmt.Printf("Server starting on port %s\n", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		fmt.Printf("Error starting server: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/testdata/local-disk-app/main.go
+++ b/testdata/local-disk-app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 )
@@ -23,9 +24,12 @@ func main() {
 			}
 			w.Write(data)
 		case http.MethodPost:
-			buf := make([]byte, 1024)
-			n, _ := r.Body.Read(buf)
-			if err := os.WriteFile("/data/value", buf[:n], 0644); err != nil {
+			data, err := io.ReadAll(io.LimitReader(r.Body, 1024))
+			if err != nil {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+			if err := os.WriteFile("/data/value", data, 0644); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}


### PR DESCRIPTION
PR #713 fixed the first half of MIR-940 — `buildServicesConfig` wasn't mapping the `Provider` field at all. But when we went to actually deploy an app with `provider = "local"`, it still blew up with `unsupported volume provider: component.config_spec.services.disks.provider.local`. Turns out there were two more places where the entity enum's fully qualified name was leaking through to code that expects short strings like `"local"` and `"miren"`.

The main one was `launcher.go` doing `string(disk.Provider)` — a straight cast that passes the raw enum value into the sandbox spec. The subtler one was `ConfigSpecFromConfig` doing a Go type conversion between `DisksProvider` and `ConfigSpecServicesDisksProvider`, which are both `string` types but with different enum value namespaces, so you'd silently get a third wrong value that also doesn't match anything.

Both are now explicit switch statements that map enum constants to the short provider strings the sandbox volume controller expects. Added unit tests covering both provider values plus the empty-defaults-to-miren case, and a blackbox test that deploys an app with a local disk, writes data, redeploys, and reads it back to prove persistence works end to end.

Closes MIR-940