### PR TITLE
Fix deploy from subdirectory using wrong source directory

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -46,6 +46,10 @@ func (a *AppCentric) ResolvedDir() string {
 }
 
 func (a *AppCentric) Validate(glbl *GlobalFlags) error {
+	a.config = nil
+	a.resolvedDir = ""
+	a.foundInParent = false
+
 	var ac *appconfig.AppConfig
 	var err error
 
@@ -55,12 +59,11 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 		var configPath string
 		ac, configPath, err = appconfig.LoadAppConfigWithPath()
 		if err == nil && ac != nil && configPath != "" {
-			// Config was found — check if it's in a parent directory.
+			// Config was found — always record the resolved directory.
 			configDir := filepath.Dir(filepath.Dir(configPath)) // strip .miren/app.toml
-			cwd, wdErr := os.Getwd()
-			if wdErr == nil && configDir != cwd {
+			a.resolvedDir = configDir
+			if cwd, wdErr := os.Getwd(); wdErr == nil && configDir != cwd {
 				a.foundInParent = true
-				a.resolvedDir = configDir
 			}
 		}
 	}

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -30,7 +30,19 @@ type AppCentric struct {
 	App string   `short:"a" long:"app" env:"MIREN_APP" description:"Application name"`
 	Dir string   `short:"d" long:"dir" description:"Directory to run from" default:"."`
 
-	config *appconfig.AppConfig
+	config        *appconfig.AppConfig
+	resolvedDir   string // absolute path to the directory containing .miren/app.toml
+	foundInParent bool   // true when config was found by walking up from CWD
+}
+
+// ResolvedDir returns the directory that should be used as the app source.
+// When a config is found in a parent directory, this returns that parent
+// directory instead of the original Dir value.
+func (a *AppCentric) ResolvedDir() string {
+	if a.resolvedDir != "" {
+		return a.resolvedDir
+	}
+	return a.Dir
 }
 
 func (a *AppCentric) Validate(glbl *GlobalFlags) error {
@@ -40,7 +52,17 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 	if a.Dir != "." {
 		ac, err = appconfig.LoadAppConfigUnder(a.Dir)
 	} else {
-		ac, err = appconfig.LoadAppConfig()
+		var configPath string
+		ac, configPath, err = appconfig.LoadAppConfigWithPath()
+		if err == nil && ac != nil && configPath != "" {
+			// Config was found — check if it's in a parent directory.
+			configDir := filepath.Dir(filepath.Dir(configPath)) // strip .miren/app.toml
+			cwd, wdErr := os.Getwd()
+			if wdErr == nil && configDir != cwd {
+				a.foundInParent = true
+				a.resolvedDir = configDir
+			}
+		}
 	}
 
 	if err != nil {

--- a/cli/commands/app_test.go
+++ b/cli/commands/app_test.go
@@ -39,6 +39,19 @@ func TestInferAppName(t *testing.T) {
 	}
 }
 
+// chdir changes the working directory for the duration of the test and restores it on cleanup.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to chdir to %s: %v", dir, err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+}
+
 func TestAppCentricValidate(t *testing.T) {
 	t.Run("invalid TOML syntax returns parse error", func(t *testing.T) {
 		dir := t.TempDir()
@@ -134,6 +147,73 @@ command = ["foo", "bar"]
 		}
 		if a.App != "myapp" {
 			t.Errorf("expected App to be 'myapp', got %q", a.App)
+		}
+	})
+
+	t.Run("config in parent directory sets foundInParent", func(t *testing.T) {
+		parent := t.TempDir()
+		writeAppToml(t, parent, `name = "myapp"`)
+
+		sub := filepath.Join(parent, "scripts")
+		if err := os.MkdirAll(sub, 0755); err != nil {
+			t.Fatalf("failed to create subdirectory: %v", err)
+		}
+
+		chdir(t, sub)
+
+		a := AppCentric{Dir: "."}
+		err := a.Validate(&GlobalFlags{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.App != "myapp" {
+			t.Errorf("expected App to be 'myapp', got %q", a.App)
+		}
+		if !a.foundInParent {
+			t.Error("expected foundInParent to be true")
+		}
+		if a.ResolvedDir() != parent {
+			t.Errorf("expected ResolvedDir() = %q, got %q", parent, a.ResolvedDir())
+		}
+	})
+
+	t.Run("config in current directory does not set foundInParent", func(t *testing.T) {
+		dir := t.TempDir()
+		writeAppToml(t, dir, `name = "myapp"`)
+
+		chdir(t, dir)
+
+		a := AppCentric{Dir: "."}
+		err := a.Validate(&GlobalFlags{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.App != "myapp" {
+			t.Errorf("expected App to be 'myapp', got %q", a.App)
+		}
+		if a.foundInParent {
+			t.Error("expected foundInParent to be false")
+		}
+	})
+
+	t.Run("explicit dir flag does not walk parents", func(t *testing.T) {
+		parent := t.TempDir()
+		writeAppToml(t, parent, `name = "myapp"`)
+
+		sub := filepath.Join(parent, "scripts")
+		if err := os.MkdirAll(sub, 0755); err != nil {
+			t.Fatalf("failed to create subdirectory: %v", err)
+		}
+
+		// With explicit -d pointing at the subdirectory, we should NOT
+		// find the parent config.
+		a := AppCentric{Dir: sub}
+		err := a.Validate(&GlobalFlags{})
+		if err == nil {
+			t.Fatal("expected error when no app.toml in explicit dir")
+		}
+		if !strings.Contains(err.Error(), "miren init") {
+			t.Errorf("expected error to mention 'miren init', got: %v", err)
 		}
 	})
 }

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -53,7 +53,7 @@ func Deploy(ctx *Context, opts struct {
 	Sensitive     []string `short:"s" long:"sensitive" description:"Set sensitive environment variable (masked in output)"`
 }) error {
 	name := opts.App
-	dir := opts.Dir
+	dir := opts.ResolvedDir()
 
 	if ctx.ClientConfig == nil {
 		return fmt.Errorf("no client configuration available; run `miren login` to authenticate or install a server locally")
@@ -221,9 +221,15 @@ func Deploy(ctx *Context, opts struct {
 	// Replace the context so downstream calls inherit the trace
 	ctx.Context = deployCtxTraced
 
-	// Confirm deployment unless --force is used, stdin is not a TTY, or only one cluster is configured
+	// Confirm deployment unless --force is used or stdin is not a TTY.
+	// Always confirm when the app config was found in a parent directory,
+	// otherwise skip confirmation when only one cluster is configured.
 	hasSingleCluster := ctx.ClientConfig != nil && ctx.ClientConfig.GetClusterCount() == 1
-	if !opts.Force && isInteractive && !hasSingleCluster {
+	needsConfirm := opts.foundInParent || !hasSingleCluster
+	if !opts.Force && isInteractive && needsConfirm {
+		if opts.foundInParent {
+			ctx.Printf("  ℹ App config found in parent directory %s\n", dir)
+		}
 		message := fmt.Sprintf("Deploy app '%s' to cluster '%s'?", name, ctx.ClusterName)
 		confirmed, err := ui.Confirm(
 			ui.WithMessage(message),


### PR DESCRIPTION
@briancain ran into this one — he was in `project/scripts/` and ran `miren deploy`. The CLI found the parent's `.miren/app.toml` just fine (because `LoadAppConfig()` walks up parent directories), but then went ahead and tarred up the `scripts/` directory instead of the project root. The builder got a directory with no recognizable app stack and failed with "no supported stack detected" — pretty confusing if you're not expecting it.

The fix has two parts. First, `AppCentric.Validate()` now uses `LoadAppConfigWithPath()` to track *where* the config was found, and `ResolvedDir()` returns that directory so `deploy` tars the right thing. Second, when we detect the config came from a parent, we always show a confirmation prompt with an info line (`ℹ App config found in parent directory /path/to/project`) so the user knows what's about to happen. The `-f` flag skips it as usual.