### PR TITLE
Compare volumes and mounts in specsMatch to prevent stale pool reuse

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -791,6 +791,9 @@ func specsMatch(spec1, spec2 *compute_v1alpha.SandboxSpec) (string, bool) {
 		if c1.Directory != c2.Directory {
 			return fmt.Sprintf("container[%d] directory mismatch: %s vs %s", i, c1.Directory, c2.Directory), false
 		}
+		if c1.ShutdownTimeout != c2.ShutdownTimeout {
+			return fmt.Sprintf("container[%d] shutdown timeout mismatch: %s vs %s", i, c1.ShutdownTimeout, c2.ShutdownTimeout), false
+		}
 
 		// Compare env vars (order-independent)
 		if !envVarsEqual(c1.Env, c2.Env) {
@@ -817,7 +820,6 @@ func specsMatch(spec1, spec2 *compute_v1alpha.SandboxSpec) (string, bool) {
 	return "", true
 }
 
-// volumesEqual compares two volume slices
 func volumesEqual(vols1, vols2 []compute_v1alpha.SandboxSpecVolume) bool {
 	if len(vols1) != len(vols2) {
 		return false
@@ -846,7 +848,6 @@ func volumesEqual(vols1, vols2 []compute_v1alpha.SandboxSpecVolume) bool {
 	return true
 }
 
-// labelsEqual compares two label slices
 func labelsEqual(l1, l2 types.Labels) bool {
 	if len(l1) != len(l2) {
 		return false
@@ -861,7 +862,6 @@ func labelsEqual(l1, l2 types.Labels) bool {
 	return true
 }
 
-// mountsEqual compares two mount slices
 func mountsEqual(mounts1, mounts2 []compute_v1alpha.SandboxSpecContainerMount) bool {
 	if len(mounts1) != len(mounts2) {
 		return false

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -753,7 +753,7 @@ func (l *Launcher) findMatchingPool(ctx context.Context, appID entity.Id, servic
 		}
 
 		// Check if specs match
-		reason, matches := l.specsMatch(&pool.SandboxSpec, desiredSpec)
+		reason, matches := specsMatch(&pool.SandboxSpec, desiredSpec)
 		if matches {
 			return &PoolWithEntity{
 				Pool:   &pool,
@@ -768,7 +768,7 @@ func (l *Launcher) findMatchingPool(ctx context.Context, appID entity.Id, servic
 
 // specsMatch compares two SandboxSpecs, ignoring the version field
 // Returns (reason, matches) where reason explains why specs don't match (empty if they do match)
-func (l *Launcher) specsMatch(spec1, spec2 *compute_v1alpha.SandboxSpec) (string, bool) {
+func specsMatch(spec1, spec2 *compute_v1alpha.SandboxSpec) (string, bool) {
 	// Quick checks first
 	if len(spec1.Container) != len(spec2.Container) {
 		return fmt.Sprintf("container count mismatch: %d vs %d", len(spec1.Container), len(spec2.Container)), false
@@ -801,10 +801,80 @@ func (l *Launcher) specsMatch(spec1, spec2 *compute_v1alpha.SandboxSpec) (string
 		if !portsEqual(c1.Port, c2.Port) {
 			return fmt.Sprintf("container[%d] ports mismatch", i), false
 		}
+
+		// Compare mounts
+		if !mountsEqual(c1.Mount, c2.Mount) {
+			return fmt.Sprintf("container[%d] mounts mismatch", i), false
+		}
+	}
+
+	// Compare volumes
+	if !volumesEqual(spec1.Volume, spec2.Volume) {
+		return "volume mismatch", false
 	}
 
 	// All fields match (excluding version)
 	return "", true
+}
+
+// volumesEqual compares two volume slices
+func volumesEqual(vols1, vols2 []compute_v1alpha.SandboxSpecVolume) bool {
+	if len(vols1) != len(vols2) {
+		return false
+	}
+
+	for i := range vols1 {
+		v1 := &vols1[i]
+		v2 := &vols2[i]
+
+		if v1.Name != v2.Name ||
+			v1.DiskName != v2.DiskName ||
+			v1.Provider != v2.Provider ||
+			v1.MountPath != v2.MountPath ||
+			v1.SizeGb != v2.SizeGb ||
+			v1.Filesystem != v2.Filesystem ||
+			v1.ReadOnly != v2.ReadOnly ||
+			v1.LeaseTimeout != v2.LeaseTimeout {
+			return false
+		}
+
+		if !labelsEqual(v1.Labels, v2.Labels) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// labelsEqual compares two label slices
+func labelsEqual(l1, l2 types.Labels) bool {
+	if len(l1) != len(l2) {
+		return false
+	}
+
+	for i := range l1 {
+		if l1[i].Key != l2[i].Key || l1[i].Value != l2[i].Value {
+			return false
+		}
+	}
+
+	return true
+}
+
+// mountsEqual compares two mount slices
+func mountsEqual(mounts1, mounts2 []compute_v1alpha.SandboxSpecContainerMount) bool {
+	if len(mounts1) != len(mounts2) {
+		return false
+	}
+
+	for i := range mounts1 {
+		if mounts1[i].Source != mounts2[i].Source ||
+			mounts1[i].Destination != mounts2[i].Destination {
+			return false
+		}
+	}
+
+	return true
 }
 
 // envVarsEqual compares two env var slices in an order-independent way,

--- a/controllers/deployment/specs_match_test.go
+++ b/controllers/deployment/specs_match_test.go
@@ -17,18 +17,21 @@ import (
 func structFingerprint(t reflect.Type) string {
 	var walk func(reflect.Type) string
 	walk = func(t reflect.Type) string {
-		if t.Kind() == reflect.Slice {
-			t = t.Elem()
+		switch t.Kind() {
+		case reflect.Slice, reflect.Array, reflect.Pointer:
+			return t.Kind().String() + "<" + walk(t.Elem()) + ">"
+		case reflect.Map:
+			return "map<" + walk(t.Key()) + "," + walk(t.Elem()) + ">"
+		case reflect.Struct:
+			var parts []string
+			for i := range t.NumField() {
+				f := t.Field(i)
+				parts = append(parts, f.Name+":"+walk(f.Type))
+			}
+			return "struct{" + strings.Join(parts, ",") + "}"
+		default:
+			return t.String()
 		}
-		if t.Kind() != reflect.Struct {
-			return t.Name()
-		}
-		var parts []string
-		for i := range t.NumField() {
-			f := t.Field(i)
-			parts = append(parts, f.Name+":"+walk(f.Type))
-		}
-		return strings.Join(parts, ",")
 	}
 	h := sha256.Sum256([]byte(walk(t)))
 	return fmt.Sprintf("%x", h[:8])
@@ -39,7 +42,7 @@ func structFingerprint(t reflect.Type) string {
 // fails, update specsMatch to handle the new field (or explicitly skip it),
 // then update the expected hash here.
 func TestSpecsMatchCoversAllFields(t *testing.T) {
-	assert.Equal(t, "5f449fa70a9f419f", structFingerprint(reflect.TypeOf(compute_v1alpha.SandboxSpec{})),
+	assert.Equal(t, "c265eaf0ef8b8bdb", structFingerprint(reflect.TypeOf(compute_v1alpha.SandboxSpec{})),
 		"SandboxSpec struct tree changed — update specsMatch and this hash")
 }
 
@@ -78,6 +81,15 @@ func TestSpecsMatch(t *testing.T) {
 			},
 			wantMatch:  false,
 			wantReason: "image mismatch",
+		},
+		{
+			name: "shutdown timeout change does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Container[0].ShutdownTimeout = "5s"
+				b.Container[0].ShutdownTimeout = "30s"
+			},
+			wantMatch:  false,
+			wantReason: "shutdown timeout mismatch",
 		},
 		{
 			name: "different versions are ignored",

--- a/controllers/deployment/specs_match_test.go
+++ b/controllers/deployment/specs_match_test.go
@@ -1,0 +1,276 @@
+package deployment
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/pkg/entity/types"
+)
+
+// structFingerprint recursively builds a string from a type's field names and
+// their types, so that adding a field at any depth changes the hash.
+func structFingerprint(t reflect.Type) string {
+	var walk func(reflect.Type) string
+	walk = func(t reflect.Type) string {
+		if t.Kind() == reflect.Slice {
+			t = t.Elem()
+		}
+		if t.Kind() != reflect.Struct {
+			return t.Name()
+		}
+		var parts []string
+		for i := range t.NumField() {
+			f := t.Field(i)
+			parts = append(parts, f.Name+":"+walk(f.Type))
+		}
+		return strings.Join(parts, ",")
+	}
+	h := sha256.Sum256([]byte(walk(t)))
+	return fmt.Sprintf("%x", h[:8])
+}
+
+// TestSpecsMatchCoversAllFields is a tripwire that fires when fields are added
+// to or removed from SandboxSpec or any of its nested structs. When this test
+// fails, update specsMatch to handle the new field (or explicitly skip it),
+// then update the expected hash here.
+func TestSpecsMatchCoversAllFields(t *testing.T) {
+	assert.Equal(t, "5f449fa70a9f419f", structFingerprint(reflect.TypeOf(compute_v1alpha.SandboxSpec{})),
+		"SandboxSpec struct tree changed — update specsMatch and this hash")
+}
+
+func baseSpec() *compute_v1alpha.SandboxSpec {
+	return &compute_v1alpha.SandboxSpec{
+		Container: []compute_v1alpha.SandboxSpecContainer{
+			{
+				Name:    "web",
+				Image:   "app:v1",
+				Command: "./start",
+				Env:     []string{"FOO=bar"},
+				Port: []compute_v1alpha.SandboxSpecContainerPort{
+					{Port: 8080, Name: "http"},
+				},
+			},
+		},
+	}
+}
+
+func TestSpecsMatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		modify     func(a, b *compute_v1alpha.SandboxSpec)
+		wantMatch  bool
+		wantReason string // substring to check in reason when !wantMatch
+	}{
+		{
+			name:      "identical specs match",
+			modify:    func(a, b *compute_v1alpha.SandboxSpec) {},
+			wantMatch: true,
+		},
+		{
+			name: "different images do not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				b.Container[0].Image = "app:v2"
+			},
+			wantMatch:  false,
+			wantReason: "image mismatch",
+		},
+		{
+			name: "different versions are ignored",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Version = "ver-1"
+				b.Version = "ver-2"
+			},
+			wantMatch: true,
+		},
+
+		// Volume tests — these capture the bug in MIR-944
+		{
+			name: "adding a volume does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				b.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "local", MountPath: "/data", SizeGb: 10},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "volume",
+		},
+		{
+			name: "removing a volume does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "local", MountPath: "/data", SizeGb: 10},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "volume",
+		},
+		{
+			name: "same volumes match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				vol := compute_v1alpha.SandboxSpecVolume{
+					Name: "data", Provider: "miren", MountPath: "/miren/data", SizeGb: 5,
+				}
+				a.Volume = []compute_v1alpha.SandboxSpecVolume{vol}
+				b.Volume = []compute_v1alpha.SandboxSpecVolume{vol}
+			},
+			wantMatch: true,
+		},
+		{
+			name: "volume size change does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "miren", MountPath: "/miren/data", SizeGb: 5},
+				}
+				b.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "miren", MountPath: "/miren/data", SizeGb: 10},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "volume",
+		},
+		{
+			name: "volume provider change does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "local", MountPath: "/data", SizeGb: 10},
+				}
+				b.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "miren", MountPath: "/data", SizeGb: 10},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "volume",
+		},
+		{
+			name: "volume mount path change does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "local", MountPath: "/data"},
+				}
+				b.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "local", MountPath: "/mnt/data"},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "volume",
+		},
+		{
+			name: "volume read-only change does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "local", MountPath: "/data"},
+				}
+				b.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "local", MountPath: "/data", ReadOnly: true},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "volume",
+		},
+		{
+			name: "volume label change does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "miren", MountPath: "/data", Labels: types.Labels{{Key: "env", Value: "prod"}}},
+				}
+				b.Volume = []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "miren", MountPath: "/data", Labels: types.Labels{{Key: "env", Value: "staging"}}},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "volume",
+		},
+		{
+			name: "multiple volumes same match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				vols := []compute_v1alpha.SandboxSpecVolume{
+					{Name: "data", Provider: "miren", MountPath: "/miren/data", SizeGb: 5},
+					{Name: "cache", Provider: "local", MountPath: "/cache", SizeGb: 1},
+				}
+				a.Volume = vols
+				b.Volume = vols
+			},
+			wantMatch: true,
+		},
+
+		// Container mount tests — also part of MIR-944
+		{
+			name: "adding a container mount does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				b.Container[0].Mount = []compute_v1alpha.SandboxSpecContainerMount{
+					{Source: "data", Destination: "/data"},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "mount",
+		},
+		{
+			name: "removing a container mount does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Container[0].Mount = []compute_v1alpha.SandboxSpecContainerMount{
+					{Source: "data", Destination: "/data"},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "mount",
+		},
+		{
+			name: "same container mounts match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				mnt := []compute_v1alpha.SandboxSpecContainerMount{
+					{Source: "data", Destination: "/data"},
+				}
+				a.Container[0].Mount = mnt
+				b.Container[0].Mount = mnt
+			},
+			wantMatch: true,
+		},
+		{
+			name: "container mount destination change does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Container[0].Mount = []compute_v1alpha.SandboxSpecContainerMount{
+					{Source: "data", Destination: "/data"},
+				}
+				b.Container[0].Mount = []compute_v1alpha.SandboxSpecContainerMount{
+					{Source: "data", Destination: "/mnt/data"},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "mount",
+		},
+		{
+			name: "container mount source change does not match",
+			modify: func(a, b *compute_v1alpha.SandboxSpec) {
+				a.Container[0].Mount = []compute_v1alpha.SandboxSpecContainerMount{
+					{Source: "data", Destination: "/data"},
+				}
+				b.Container[0].Mount = []compute_v1alpha.SandboxSpecContainerMount{
+					{Source: "cache", Destination: "/data"},
+				}
+			},
+			wantMatch:  false,
+			wantReason: "mount",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := baseSpec()
+			b := baseSpec()
+			tt.modify(a, b)
+
+			reason, match := specsMatch(a, b)
+			assert.Equal(t, tt.wantMatch, match, "specsMatch result")
+			if !tt.wantMatch {
+				assert.Contains(t, reason, tt.wantReason, "mismatch reason")
+			} else {
+				assert.Empty(t, reason, "reason should be empty on match")
+			}
+		})
+	}
+}


### PR DESCRIPTION
`specsMatch` decides whether the deployment launcher can reuse an existing sandbox pool across deploys. It was comparing the usual suspects — image, command, env vars, ports — but completely ignoring volumes and container mounts. So if you added a `[[services.web.disks]]` block and redeployed, the launcher would happily say "specs match!" and hand you back the old pool with no volume configuration. Your app would crash because the mount path didn't exist.

The fix adds volume and mount comparison following the same pattern as the existing `portsEqual` helper. We also pulled `specsMatch` off the `Launcher` receiver since it's a pure function that doesn't touch any instance state.

On the testing side, we went TDD — wrote the failing volume/mount cases first, confirmed they were red, then made them green. There's also a fun little struct fingerprint test that recursively hashes field names across the entire `SandboxSpec` type tree. If someone adds a field to any of the compared structs, the hash changes and the test breaks, reminding them to go update `specsMatch`. No more silent gaps.

Fixes MIR-944