### PR TITLE
Improve local storage transitional behavior: auto-mount when host directory has existing data

### DIFF
--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -18,12 +18,15 @@ type StatusUpdate interface {
 	SetBuildkit([]byte)
 	Error() string
 	SetError(string)
+	Log() *LogEntry
+	SetLog(*LogEntry)
 }
 
 type statusUpdate struct {
-	U_Message  *string `cbor:"1,keyasint,omitempty" json:"message,omitempty"`
-	U_Buildkit *[]byte `cbor:"2,keyasint,omitempty" json:"buildkit,omitempty"`
-	U_Error    *string `cbor:"3,keyasint,omitempty" json:"error,omitempty"`
+	U_Message  *string    `cbor:"1,keyasint,omitempty" json:"message,omitempty"`
+	U_Buildkit *[]byte    `cbor:"2,keyasint,omitempty" json:"buildkit,omitempty"`
+	U_Error    *string    `cbor:"3,keyasint,omitempty" json:"error,omitempty"`
+	U_Log      **LogEntry `cbor:"4,keyasint,omitempty" json:"log,omitempty"`
 }
 
 func (v *statusUpdate) Which() string {
@@ -35,6 +38,9 @@ func (v *statusUpdate) Which() string {
 	}
 	if v.U_Error != nil {
 		return "error"
+	}
+	if v.U_Log != nil {
+		return "log"
 	}
 	return ""
 }
@@ -49,6 +55,7 @@ func (v *statusUpdate) Message() string {
 func (v *statusUpdate) SetMessage(val string) {
 	v.U_Buildkit = nil
 	v.U_Error = nil
+	v.U_Log = nil
 	v.U_Message = &val
 }
 
@@ -62,6 +69,7 @@ func (v *statusUpdate) Buildkit() []byte {
 func (v *statusUpdate) SetBuildkit(val []byte) {
 	v.U_Message = nil
 	v.U_Error = nil
+	v.U_Log = nil
 	v.U_Buildkit = &val
 }
 
@@ -75,7 +83,22 @@ func (v *statusUpdate) Error() string {
 func (v *statusUpdate) SetError(val string) {
 	v.U_Message = nil
 	v.U_Buildkit = nil
+	v.U_Log = nil
 	v.U_Error = &val
+}
+
+func (v *statusUpdate) Log() *LogEntry {
+	if v.U_Log == nil {
+		return nil
+	}
+	return *v.U_Log
+}
+
+func (v *statusUpdate) SetLog(val *LogEntry) {
+	v.U_Message = nil
+	v.U_Buildkit = nil
+	v.U_Error = nil
+	v.U_Log = &val
 }
 
 type statusData struct {
@@ -119,6 +142,133 @@ func (v *Status) MarshalJSON() ([]byte, error) {
 }
 
 func (v *Status) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type logEntryData struct {
+	Level  *string      `cbor:"0,keyasint,omitempty" json:"level,omitempty"`
+	Text   *string      `cbor:"1,keyasint,omitempty" json:"text,omitempty"`
+	Fields *[]*LogField `cbor:"2,keyasint,omitempty" json:"fields,omitempty"`
+}
+
+type LogEntry struct {
+	data logEntryData
+}
+
+func (v *LogEntry) HasLevel() bool {
+	return v.data.Level != nil
+}
+
+func (v *LogEntry) Level() string {
+	if v.data.Level == nil {
+		return ""
+	}
+	return *v.data.Level
+}
+
+func (v *LogEntry) SetLevel(level string) {
+	v.data.Level = &level
+}
+
+func (v *LogEntry) HasText() bool {
+	return v.data.Text != nil
+}
+
+func (v *LogEntry) Text() string {
+	if v.data.Text == nil {
+		return ""
+	}
+	return *v.data.Text
+}
+
+func (v *LogEntry) SetText(text string) {
+	v.data.Text = &text
+}
+
+func (v *LogEntry) HasFields() bool {
+	return v.data.Fields != nil
+}
+
+func (v *LogEntry) Fields() []*LogField {
+	if v.data.Fields == nil {
+		return nil
+	}
+	return *v.data.Fields
+}
+
+func (v *LogEntry) SetFields(fields []*LogField) {
+	x := slices.Clone(fields)
+	v.data.Fields = &x
+}
+
+func (v *LogEntry) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *LogEntry) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *LogEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *LogEntry) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type logFieldData struct {
+	Key   *string `cbor:"0,keyasint,omitempty" json:"key,omitempty"`
+	Value *string `cbor:"1,keyasint,omitempty" json:"value,omitempty"`
+}
+
+type LogField struct {
+	data logFieldData
+}
+
+func (v *LogField) HasKey() bool {
+	return v.data.Key != nil
+}
+
+func (v *LogField) Key() string {
+	if v.data.Key == nil {
+		return ""
+	}
+	return *v.data.Key
+}
+
+func (v *LogField) SetKey(key string) {
+	v.data.Key = &key
+}
+
+func (v *LogField) HasValue() bool {
+	return v.data.Value != nil
+}
+
+func (v *LogField) Value() string {
+	if v.data.Value == nil {
+		return ""
+	}
+	return *v.data.Value
+}
+
+func (v *LogField) SetValue(value string) {
+	v.data.Value = &value
+}
+
+func (v *LogField) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *LogField) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *LogField) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *LogField) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 

--- a/api/build/rpc.yml
+++ b/api/build/rpc.yml
@@ -24,6 +24,36 @@ types:
           - name: error
             type: string
             index: 3
+          - name: log
+            type: LogEntry
+            index: 4
+
+  - type: LogEntry
+    doc: A structured log message with severity level and extensible fields
+    fields:
+      - name: level
+        type: string
+        index: 0
+        doc: Log level (info, warn)
+      - name: text
+        type: string
+        index: 1
+        doc: Short summary line
+      - name: fields
+        type: list
+        element: LogField
+        index: 2
+        doc: Extensible key-value pairs for display (detail, link, etc.)
+
+  - type: LogField
+    doc: A key-value pair for structured log metadata
+    fields:
+      - name: key
+        type: string
+        index: 0
+      - name: value
+        type: string
+        index: 1
 
   - type: AccessInfo
     doc: Information about how to access the deployed application

--- a/cli/commands/app_list.go
+++ b/cli/commands/app_list.go
@@ -13,11 +13,6 @@ import (
 	"miren.dev/runtime/pkg/ui"
 )
 
-// hyperlink creates a clickable terminal hyperlink using OSC 8 escape sequence
-func hyperlink(url, text string) string {
-	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", url, text)
-}
-
 func AppList(ctx *Context, opts struct {
 	FormatOptions
 	ConfigCentric
@@ -159,7 +154,7 @@ func AppList(ctx *Context, opts struct {
 			if strings.Contains(host, "localhost") || strings.HasPrefix(host, "127.") {
 				scheme = "http://"
 			}
-			routeDisplay = hyperlink(scheme+host, displayHost)
+			routeDisplay = ui.Hyperlink(scheme+host, displayHost)
 		}
 
 		rows = append(rows, ui.Row{

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -401,9 +401,10 @@ func Deploy(ctx *Context, opts struct {
 		ctx.Printf("  Setting %d environment variable(s)...\n", len(envVars))
 	}
 
-	// Initialize build error/log tracking
+	// Initialize build error/log/warning tracking
 	var buildErrors []string
 	var buildLogs []string
+	var deployWarnings []*build_v1alpha.LogEntry
 
 	// Helper function to update deployment phase
 	updateDeploymentPhase := func(phase string) {
@@ -635,7 +636,7 @@ func Deploy(ctx *Context, opts struct {
 			return nil
 		}
 
-		cb = createBuildStatusCallback(buildCtx, nil, nil, &buildErrors, nil, progressHandler)
+		cb = createBuildStatusCallback(buildCtx, nil, nil, &buildErrors, nil, &deployWarnings, progressHandler)
 
 		results, err = buildCall(buildCtx, r, cb)
 		if err != nil {
@@ -729,7 +730,7 @@ func Deploy(ctx *Context, opts struct {
 			return nil
 		}
 
-		cb = createBuildStatusCallback(deployCtx, updateCh, buildCh, &buildErrors, &buildLogs, progressHandler)
+		cb = createBuildStatusCallback(deployCtx, updateCh, buildCh, &buildErrors, &buildLogs, &deployWarnings, progressHandler)
 
 		results, err = buildCall(deployCtx, r, cb)
 
@@ -847,6 +848,14 @@ func Deploy(ctx *Context, opts struct {
 
 	ctx.Printf("\n\nUpdated version %s deployed. All traffic moved to new version.\n", results.Version())
 
+	if len(deployWarnings) > 0 {
+		warnHeaderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("208")).Bold(true)
+		ctx.Printf("\n%s\n", warnHeaderStyle.Render("Warnings:"))
+		for _, entry := range deployWarnings {
+			renderDeployWarning(ctx, entry)
+		}
+	}
+
 	// Show route/access information using server-provided data
 	displayAccessInfo(ctx, name, results)
 
@@ -889,6 +898,7 @@ func createBuildStatusCallback(
 	buildCh chan<- buildProgress,
 	buildErrors *[]string,
 	buildLogs *[]string,
+	deployWarnings *[]*build_v1alpha.LogEntry,
 	progressHandler func(*client.SolveStatus) error,
 ) stream.SendStream[*build_v1alpha.Status] {
 	vertices := map[string]bool{} // digest → completed
@@ -978,10 +988,56 @@ func createBuildStatusCallback(
 			}
 		case "error":
 			*buildErrors = append(*buildErrors, update.Error())
+		case "log":
+			if entry := update.Log(); entry != nil {
+				switch entry.Level() {
+				case "warn":
+					if deployWarnings != nil {
+						*deployWarnings = append(*deployWarnings, entry)
+					}
+				case "info":
+					if updateCh != nil {
+						select {
+						case updateCh <- entry.Text():
+						default:
+						}
+					}
+				}
+			}
 		}
 
 		return nil
 	})
+}
+
+func renderDeployWarning(ctx *Context, entry *build_v1alpha.LogEntry) {
+	orange := lipgloss.Color("208")
+	headerStyle := lipgloss.NewStyle().Foreground(orange).Bold(true)
+	linkStyle := lipgloss.NewStyle().Foreground(orange).Faint(true)
+
+	// Compute wrap width: terminal width minus indent (4 chars), capped at 76
+	const indent = 4
+	const maxWidth = 76
+	detailWidth := maxWidth
+	if tw := ui.TerminalWidth(); tw > 0 {
+		detailWidth = min(tw-indent, maxWidth)
+	}
+	detailStyle := lipgloss.NewStyle().Foreground(orange).Width(detailWidth).PaddingLeft(indent)
+
+	ctx.Printf("  %s\n", headerStyle.Render("⚠ "+entry.Text()))
+
+	// Index fields by key for controlled rendering order
+	fields := make(map[string]string)
+	for _, f := range entry.Fields() {
+		fields[f.Key()] = f.Value()
+	}
+
+	if detail, ok := fields["detail"]; ok {
+		ctx.Printf("%s\n", detailStyle.Render(detail))
+	}
+	if link, ok := fields["link"]; ok {
+		ctx.Printf("    %s%s\n", linkStyle.Render("See: "), ui.RenderMarkdownLink(link, 208))
+	}
 }
 
 func buildStepsSummary(count int) string {

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -1020,7 +1020,9 @@ func renderDeployWarning(ctx *Context, entry *build_v1alpha.LogEntry) {
 	const maxWidth = 76
 	detailWidth := maxWidth
 	if tw := ui.TerminalWidth(); tw > 0 {
-		detailWidth = min(tw-indent, maxWidth)
+		if available := tw - indent; available > 0 {
+			detailWidth = min(available, maxWidth)
+		}
 	}
 	detailStyle := lipgloss.NewStyle().Foreground(orange).Width(detailWidth).PaddingLeft(indent)
 

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -894,6 +894,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	// Create DeploymentLauncher to watch App entities and create pools
 	launcher := deploymentctrl.NewLauncher(c.Log, eac)
+	launcher.DataPath = c.DataPath
 	if err := launcher.Init(ctx); err != nil {
 		c.Log.Error("failed to initialize deployment launcher", "error", err)
 		return err

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +38,9 @@ var launcherTracer = otel.Tracer("miren.dev/runtime/deployment/launcher")
 type Launcher struct {
 	Log *slog.Logger
 	EAC *entityserver_v1alpha.EntityAccessClient
+
+	// DataPath is the root data directory for local storage checks.
+	DataPath string
 
 	// PoolReadyTimeout is how long to wait for new pools to have ready instances
 	// before proceeding with old pool cleanup. Defaults to 60s.
@@ -691,32 +696,30 @@ func (l *Launcher) buildSandboxSpec(
 		}
 	}
 
-	// Auto-add local storage volume if any env var references /miren/data/local
-	// but no local disk is explicitly configured. This eases migration from the
-	// old automatic mount behavior.
-	hasLocalDisk := false
-	for _, vol := range sbSpec.Volume {
-		if vol.Provider == "local" {
-			hasLocalDisk = true
-			break
-		}
-	}
-	if !hasLocalDisk {
-		for _, v := range envMap {
-			if strings.Contains(v, "/miren/data/local") {
-				l.Log.Info("auto-adding local storage volume (env var references /miren/data/local)",
-					"service", serviceName)
-				sbSpec.Volume = append(sbSpec.Volume, compute_v1alpha.SandboxSpecVolume{
-					Name:      "local-data",
-					Provider:  "local",
-					MountPath: "/miren/data/local",
-				})
-				appCont.Mount = append(appCont.Mount, compute_v1alpha.SandboxSpecContainerMount{
-					Source:      "local-data",
-					Destination: "/miren/data/local",
-				})
+	// Transitional: auto-mount local storage if the host directory has existing
+	// data but no explicit disk config. This prevents data loss for apps that
+	// relied on the old implicit mount behavior. Will be removed in a future release.
+	if l.DataPath != "" {
+		hasLocalDisk := false
+		for _, vol := range sbSpec.Volume {
+			if vol.Provider == "local" {
+				hasLocalDisk = true
 				break
 			}
+		}
+		if !hasLocalDisk && dirHasData(filepath.Join(l.DataPath, "data", "local", app.ID.String())) {
+			l.Log.Warn("auto-mounting local storage for app with existing data but no disk config",
+				"service", serviceName,
+				"app", app.ID)
+			sbSpec.Volume = append(sbSpec.Volume, compute_v1alpha.SandboxSpecVolume{
+				Name:      "local-data",
+				Provider:  "local",
+				MountPath: "/miren/data/local",
+			})
+			appCont.Mount = append(appCont.Mount, compute_v1alpha.SandboxSpecContainerMount{
+				Source:      "local-data",
+				Destination: "/miren/data/local",
+			})
 		}
 	}
 
@@ -727,6 +730,12 @@ func (l *Launcher) buildSandboxSpec(
 	sbSpec.Container = []compute_v1alpha.SandboxSpecContainer{appCont}
 
 	return sbSpec, nil
+}
+
+// dirHasData returns true if the directory exists and contains at least one entry.
+func dirHasData(path string) bool {
+	entries, err := os.ReadDir(path)
+	return err == nil && len(entries) > 0
 }
 
 // findMatchingPool searches for an existing pool with matching spec

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -700,14 +700,14 @@ func (l *Launcher) buildSandboxSpec(
 	// data but no explicit disk config. This prevents data loss for apps that
 	// relied on the old implicit mount behavior. Will be removed in a future release.
 	if l.DataPath != "" {
-		hasLocalDisk := false
-		for _, vol := range sbSpec.Volume {
-			if vol.Provider == "local" {
-				hasLocalDisk = true
+		hasLocalMount := false
+		for _, m := range appCont.Mount {
+			if m.Destination == "/miren/data/local" {
+				hasLocalMount = true
 				break
 			}
 		}
-		if !hasLocalDisk && dirHasData(filepath.Join(l.DataPath, "data", "local", app.ID.String())) {
+		if !hasLocalMount && dirHasData(filepath.Join(l.DataPath, "data", "local", app.ID.String())) {
 			l.Log.Warn("auto-mounting local storage for app with existing data but no disk config",
 				"service", serviceName,
 				"app", app.ID)

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +23,7 @@ import (
 func newTestLauncher(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *Launcher {
 	l := NewLauncher(log, eac)
 	l.PoolReadyTimeout = 100 * time.Millisecond
+	l.DataPath = os.TempDir()
 	return l
 }
 
@@ -2541,4 +2544,189 @@ func TestMirenDisksSkippedForAutoScalingWebService(t *testing.T) {
 	require.Len(t, volumes, 1, "only local disk should be attached, miren disk should be skipped")
 	assert.Equal(t, "local", volumes[0].Provider)
 	assert.Equal(t, "local-data", volumes[0].Name)
+}
+
+func TestAutoMountLocalStorageWithExistingData(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	// Create a temp DataPath with existing data for this app
+	dataPath := t.TempDir()
+	localDir := filepath.Join(dataPath, "data", "local", app.ID.String())
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "data.db"), []byte("test"), 0644))
+
+	launcher := newTestLauncher(log, server.EAC)
+	launcher.DataPath = dataPath
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	// Should have auto-mounted the local volume
+	volumes := pools[0].SandboxSpec.Volume
+	require.Len(t, volumes, 1, "should auto-mount local storage when data exists")
+	assert.Equal(t, "local-data", volumes[0].Name)
+	assert.Equal(t, "local", volumes[0].Provider)
+	assert.Equal(t, "/miren/data/local", volumes[0].MountPath)
+
+	mounts := pools[0].SandboxSpec.Container[0].Mount
+	require.Len(t, mounts, 1)
+	assert.Equal(t, "local-data", mounts[0].Source)
+	assert.Equal(t, "/miren/data/local", mounts[0].Destination)
+}
+
+func TestNoAutoMountWhenNoExistingData(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	// DataPath exists but no local data for this app
+	launcher := newTestLauncher(log, server.EAC)
+	launcher.DataPath = t.TempDir()
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	// Should NOT auto-mount since there's no existing data
+	assert.Empty(t, pools[0].SandboxSpec.Volume, "should not auto-mount when no existing data")
+}
+
+func TestNoAutoMountWhenExplicitDiskConfig(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "my-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/data",
+						},
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	// Create existing data even though explicit config exists
+	dataPath := t.TempDir()
+	localDir := filepath.Join(dataPath, "data", "local", app.ID.String())
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "data.db"), []byte("test"), 0644))
+
+	launcher := newTestLauncher(log, server.EAC)
+	launcher.DataPath = dataPath
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	// Should only have the explicit disk, not the auto-mounted one
+	volumes := pools[0].SandboxSpec.Volume
+	require.Len(t, volumes, 1, "should only have explicit disk config")
+	assert.Equal(t, "my-data", volumes[0].Name)
+	assert.Equal(t, "local", volumes[0].Provider)
 }

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -23,7 +23,6 @@ import (
 func newTestLauncher(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *Launcher {
 	l := NewLauncher(log, eac)
 	l.PoolReadyTimeout = 100 * time.Millisecond
-	l.DataPath = os.TempDir()
 	return l
 }
 

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -2695,7 +2695,7 @@ func TestNoAutoMountWhenExplicitDiskConfig(t *testing.T) {
 						{
 							Name:      "my-data",
 							Provider:  core_v1alpha.LOCAL,
-							MountPath: "/data",
+							MountPath: "/miren/data/local",
 						},
 					},
 				},

--- a/pkg/ui/terminal.go
+++ b/pkg/ui/terminal.go
@@ -1,0 +1,65 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"golang.org/x/term"
+)
+
+var mdLinkPattern = regexp.MustCompile(`^\[(.+)\]\((.+)\)$`)
+
+// IsTTY reports whether stdout is connected to a terminal.
+func IsTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// TerminalWidth returns the current terminal width, or 0 if stdout is not a TTY.
+func TerminalWidth() int {
+	if !IsTTY() {
+		return 0
+	}
+	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && width > 0 {
+		return width
+	}
+	return 80
+}
+
+// Hyperlink creates a clickable terminal hyperlink using the OSC 8 escape sequence
+// with dotted underline styling. Raw SGR sequences are used so the result can be
+// safely combined with lipgloss-rendered text without interference.
+//
+// When stdout is not a TTY, returns just the text with no escape sequences.
+func Hyperlink(url, text string) string {
+	if !IsTTY() {
+		return text
+	}
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\\x1b[4:4m%s\x1b[24m\x1b]8;;\x1b\\", url, text)
+}
+
+// HyperlinkStyled is like Hyperlink but also applies a foreground color (256-color index).
+//
+// When stdout is not a TTY, returns just the text with no escape sequences.
+func HyperlinkStyled(url, text string, color int) string {
+	if !IsTTY() {
+		return text
+	}
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\\x1b[38;5;%dm\x1b[4:4m%s\x1b[24;39m\x1b]8;;\x1b\\", url, color, text)
+}
+
+// RenderMarkdownLink parses a markdown-style link "[text](url)" and renders it
+// as a clickable terminal hyperlink with the given 256-color index.
+//
+// When stdout is not a TTY, renders as "text (url)" for readability in pipes/logs.
+// If the input isn't a valid markdown link, it's returned as-is.
+func RenderMarkdownLink(s string, color int) string {
+	m := mdLinkPattern.FindStringSubmatch(s)
+	if m == nil {
+		return s
+	}
+	if !IsTTY() {
+		return fmt.Sprintf("%s (%s)", m[1], m[2])
+	}
+	return HyperlinkStyled(m[2], m[1], color)
+}

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"maps"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -781,6 +782,59 @@ func (b *Builder) sendErrorStatus(ctx context.Context, status *stream.SendStream
 	}
 }
 
+// sendLogStatus sends a structured log status update if status is not nil
+func (b *Builder) sendLogStatus(ctx context.Context, status *stream.SendStreamClient[*build_v1alpha.Status], level, text string, fields ...*build_v1alpha.LogField) {
+	if status != nil {
+		so := new(build_v1alpha.Status)
+		entry := &build_v1alpha.LogEntry{}
+		entry.SetLevel(level)
+		entry.SetText(text)
+		if len(fields) > 0 {
+			entry.SetFields(fields)
+		}
+		so.Update().SetLog(entry)
+		if _, err := status.Send(ctx, so); err != nil {
+			b.Log.Warn("error sending log status", "error", err)
+		}
+	}
+}
+
+func logField(key, value string) *build_v1alpha.LogField {
+	f := &build_v1alpha.LogField{}
+	f.SetKey(key)
+	f.SetValue(value)
+	return f
+}
+
+// checkLocalStorageMigration checks whether the app has existing data in
+// local storage but no explicit disk config, and sends a deploy warning.
+func (b *Builder) checkLocalStorageMigration(ctx context.Context, appID entity.Id, configSpec core_v1alpha.ConfigSpec, status *stream.SendStreamClient[*build_v1alpha.Status]) {
+	if b.DataPath == "" {
+		return
+	}
+
+	// Check if any service already has an explicit local disk definition
+	for _, svc := range configSpec.Services {
+		for _, disk := range svc.Disks {
+			if disk.Provider == core_v1alpha.ConfigSpecServicesDisksLOCAL {
+				return
+			}
+		}
+	}
+
+	localPath := filepath.Join(b.DataPath, "data", "local", appID.String())
+	entries, err := os.ReadDir(localPath)
+	if err != nil || len(entries) == 0 {
+		return
+	}
+
+	b.sendLogStatus(ctx, status, "warn", "Local storage data was automatically mounted",
+		logField("detail", "This app has data stored on disk, but your app.toml doesn't declare it yet. "+
+			"Add a disk config so the data continues to be available — this safety net will be removed in a future release."),
+		logField("link", "[Configuring Disks](https://miren.md/disks)"),
+	)
+}
+
 // isSystemEnvVar returns true if the given key is a system-managed env var
 // that should not be injected as a build arg.
 func isSystemEnvVar(key string) bool {
@@ -1409,6 +1463,8 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 	activateSpan.End()
 
 	b.Log.Info("app version updated", "app", name, "version", mrv.Version)
+
+	b.checkLocalStorageMigration(ctx, appRec.ID, configSpec, status)
 
 	// Log the deployment to the app's logs
 	b.logDeployment(ctx, name, mrv.Version, artifactName)

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -813,10 +813,11 @@ func (b *Builder) checkLocalStorageMigration(ctx context.Context, appID entity.I
 		return
 	}
 
-	// Check if any service already has an explicit local disk definition
+	// Check if any service already declares a disk at /miren/data/local
+	// (any provider — local or miren). If so, the user has migrated.
 	for _, svc := range configSpec.Services {
 		for _, disk := range svc.Disks {
-			if disk.Provider == core_v1alpha.ConfigSpecServicesDisksLOCAL {
+			if disk.MountPath == "/miren/data/local" {
 				return
 			}
 		}


### PR DESCRIPTION
PR #700 made local storage opt-in, with a transitional heuristic that auto-mounted if any env var referenced `/miren/data/local`. That turned out to be too narrow — apps that hardcode the path in scripts or configs (uptime-kuma, metrics, victoriametrics, tempo) all broke on their next restart.

This PR replaces the env-var heuristic with a directory check: if the host-side local storage directory has data but the app config doesn't declare a disk, we mount it automatically and tell the user about it during deploy. The check is strictly better — it catches the actual dangerous case (data that would be lost) regardless of how the app references the path. Apps that never wrote data aren't affected.

We're trying to hold the line on being as kind as possible to users when we make breaking changes. This gets about as close to the ideal as we can: the system detects the exact moment you'd be affected, protects your data automatically, and gives you a personalized nudge at deploy time — right when you're paying attention — to go add the config at your own pace. No data loss, no broadcast announcement you might miss, just a gentle warning exactly when it matters.

To surface that warning in `m deploy` output, we added a `log` union variant to the build status stream. It carries a level, a short text summary, and extensible key-value fields for things like detail text and markdown links. The CLI renders warnings under a styled "Warnings:" section with terminal-width-aware wrapping and clickable OSC 8 hyperlinks. The protocol change is backward compatible — old clients silently ignore the new variant.

Along the way we added some shared terminal helpers to `pkg/ui` (terminal width detection, hyperlink rendering with OSC 8 + dotted underline, markdown link parsing) and moved the existing hyperlink function there from app_list.go.

<img width="1578" height="816" alt="2026-04-01 at 17 49 30@2x" src="https://github.com/user-attachments/assets/a6de2c4e-1aa7-4733-a5bd-ff08015077c9" />



Closes MIR-945