### PR TITLE
Thread short IDs through CLI display

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -506,6 +506,7 @@ func (v *NamedValue) UnmarshalJSON(data []byte) error {
 type versionInfoData struct {
 	Version   *string             `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
 	CreatedAt *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"created_at,omitempty"`
+	ShortId   *string             `cbor:"2,keyasint,omitempty" json:"short_id,omitempty"`
 }
 
 type VersionInfo struct {
@@ -537,6 +538,21 @@ func (v *VersionInfo) CreatedAt() *standard.Timestamp {
 
 func (v *VersionInfo) SetCreatedAt(created_at *standard.Timestamp) {
 	v.data.CreatedAt = created_at
+}
+
+func (v *VersionInfo) HasShortId() bool {
+	return v.data.ShortId != nil
+}
+
+func (v *VersionInfo) ShortId() string {
+	if v.data.ShortId == nil {
+		return ""
+	}
+	return *v.data.ShortId
+}
+
+func (v *VersionInfo) SetShortId(short_id string) {
+	v.data.ShortId = &short_id
 }
 
 func (v *VersionInfo) MarshalCBOR() ([]byte, error) {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -109,6 +109,10 @@ types:
       - name: created_at
         type: standard.Timestamp
         index: 1
+      - name: short_id
+        type: string
+        index: 2
+        doc: Short human-friendly ID for the app version
 
   - type: AppInfo
     fields:

--- a/api/deployment/deployment_v1alpha/rpc.gen.go
+++ b/api/deployment/deployment_v1alpha/rpc.gen.go
@@ -26,6 +26,8 @@ type deploymentInfoData struct {
 	GitInfo             *GitInfo            `cbor:"12,keyasint,omitempty" json:"git_info,omitempty"`
 	DeployedByUserName  *string             `cbor:"21,keyasint,omitempty" json:"deployed_by_user_name,omitempty"`
 	SourceDeploymentId  *string             `cbor:"22,keyasint,omitempty" json:"source_deployment_id,omitempty"`
+	ShortId             *string             `cbor:"23,keyasint,omitempty" json:"short_id,omitempty"`
+	AppVersionShortId   *string             `cbor:"24,keyasint,omitempty" json:"app_version_short_id,omitempty"`
 }
 
 type DeploymentInfo struct {
@@ -248,6 +250,36 @@ func (v *DeploymentInfo) SetSourceDeploymentId(source_deployment_id string) {
 	v.data.SourceDeploymentId = &source_deployment_id
 }
 
+func (v *DeploymentInfo) HasShortId() bool {
+	return v.data.ShortId != nil
+}
+
+func (v *DeploymentInfo) ShortId() string {
+	if v.data.ShortId == nil {
+		return ""
+	}
+	return *v.data.ShortId
+}
+
+func (v *DeploymentInfo) SetShortId(short_id string) {
+	v.data.ShortId = &short_id
+}
+
+func (v *DeploymentInfo) HasAppVersionShortId() bool {
+	return v.data.AppVersionShortId != nil
+}
+
+func (v *DeploymentInfo) AppVersionShortId() string {
+	if v.data.AppVersionShortId == nil {
+		return ""
+	}
+	return *v.data.AppVersionShortId
+}
+
+func (v *DeploymentInfo) SetAppVersionShortId(app_version_short_id string) {
+	v.data.AppVersionShortId = &app_version_short_id
+}
+
 func (v *DeploymentInfo) MarshalCBOR() ([]byte, error) {
 	return cbor.Marshal(v.data)
 }
@@ -445,13 +477,14 @@ func (v *GitInfo) UnmarshalJSON(data []byte) error {
 }
 
 type deploymentLockInfoData struct {
-	AppName              *string             `cbor:"0,keyasint,omitempty" json:"app_name,omitempty"`
-	ClusterId            *string             `cbor:"1,keyasint,omitempty" json:"cluster_id,omitempty"`
-	BlockingDeploymentId *string             `cbor:"2,keyasint,omitempty" json:"blocking_deployment_id,omitempty"`
-	StartedBy            *string             `cbor:"3,keyasint,omitempty" json:"started_by,omitempty"`
-	StartedAt            *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"started_at,omitempty"`
-	CurrentPhase         *string             `cbor:"5,keyasint,omitempty" json:"current_phase,omitempty"`
-	LockExpiresAt        *standard.Timestamp `cbor:"6,keyasint,omitempty" json:"lock_expires_at,omitempty"`
+	AppName                   *string             `cbor:"0,keyasint,omitempty" json:"app_name,omitempty"`
+	ClusterId                 *string             `cbor:"1,keyasint,omitempty" json:"cluster_id,omitempty"`
+	BlockingDeploymentId      *string             `cbor:"2,keyasint,omitempty" json:"blocking_deployment_id,omitempty"`
+	StartedBy                 *string             `cbor:"3,keyasint,omitempty" json:"started_by,omitempty"`
+	StartedAt                 *standard.Timestamp `cbor:"4,keyasint,omitempty" json:"started_at,omitempty"`
+	CurrentPhase              *string             `cbor:"5,keyasint,omitempty" json:"current_phase,omitempty"`
+	LockExpiresAt             *standard.Timestamp `cbor:"6,keyasint,omitempty" json:"lock_expires_at,omitempty"`
+	BlockingDeploymentShortId *string             `cbor:"7,keyasint,omitempty" json:"blocking_deployment_short_id,omitempty"`
 }
 
 type DeploymentLockInfo struct {
@@ -555,6 +588,21 @@ func (v *DeploymentLockInfo) LockExpiresAt() *standard.Timestamp {
 
 func (v *DeploymentLockInfo) SetLockExpiresAt(lock_expires_at *standard.Timestamp) {
 	v.data.LockExpiresAt = lock_expires_at
+}
+
+func (v *DeploymentLockInfo) HasBlockingDeploymentShortId() bool {
+	return v.data.BlockingDeploymentShortId != nil
+}
+
+func (v *DeploymentLockInfo) BlockingDeploymentShortId() string {
+	if v.data.BlockingDeploymentShortId == nil {
+		return ""
+	}
+	return *v.data.BlockingDeploymentShortId
+}
+
+func (v *DeploymentLockInfo) SetBlockingDeploymentShortId(blocking_deployment_short_id string) {
+	v.data.BlockingDeploymentShortId = &blocking_deployment_short_id
 }
 
 func (v *DeploymentLockInfo) MarshalCBOR() ([]byte, error) {

--- a/api/deployment/rpc.yml
+++ b/api/deployment/rpc.yml
@@ -337,6 +337,14 @@ types:
         type: string
         index: 22
         doc: ID of the source deployment (set for rollback/redeploy, empty for fresh builds)
+      - name: short_id
+        type: string
+        index: 23
+        doc: Short human-friendly ID for this deployment
+      - name: app_version_short_id
+        type: string
+        index: 24
+        doc: Short human-friendly ID for the app version
 
   - type: GitInfo
     doc: Git repository information
@@ -413,6 +421,10 @@ types:
         type: standard.Timestamp
         index: 6
         doc: When the lock will expire
+      - name: blocking_deployment_short_id
+        type: string
+        index: 7
+        doc: Short human-friendly ID for the blocking deployment
 
   - type: EnvironmentVariable
     doc: An environment variable to set on the app during deploy

--- a/cli/commands/activation_poller.go
+++ b/cli/commands/activation_poller.go
@@ -21,11 +21,15 @@ type appInfoGetter interface {
 // waitForActivation polls AppInfo to wait for a specific version to become active.
 // This is non-fatal — the deploy/rollback already succeeded server-side, so a
 // timeout just means we can't confirm activation yet.
-func waitForActivation(ctx *Context, getter appInfoGetter, appName, versionID string) {
+func waitForActivation(ctx *Context, getter appInfoGetter, appName, versionID, versionDisplay string) {
 	const (
 		pollInterval = 2 * time.Second
 		timeout      = 60 * time.Second
 	)
+
+	if versionDisplay == "" {
+		versionDisplay = versionID
+	}
 
 	ctx.Printf("Waiting for version to become active...\n")
 
@@ -38,12 +42,12 @@ func waitForActivation(ctx *Context, getter appInfoGetter, appName, versionID st
 		case <-ctx.Done():
 			return
 		case <-deadline:
-			ctx.Printf("⚠ Timed out waiting for version %s to activate. Activation is still in progress.\n", versionID)
+			ctx.Printf("⚠ Timed out waiting for version %s to activate. Activation is still in progress.\n", versionDisplay)
 			return
 		case <-ticker.C:
 			ready, summary := checkVersionActive(ctx, getter, appName, versionID)
 			if ready {
-				ctx.Printf("✓ Version %s is active%s\n", versionID, summary)
+				ctx.Printf("✓ Version %s is active%s\n", versionDisplay, summary)
 				return
 			}
 		}

--- a/cli/commands/app_history.go
+++ b/cli/commands/app_history.go
@@ -274,7 +274,7 @@ func buildDeploymentRow(dep *deployment_v1alpha.DeploymentInfo, opts historyDisp
 
 	row := ui.Row{
 		formatDeploymentStatus(status),
-		formatVersion(dep.AppVersionId(), status),
+		formatVersionWithShortID(dep.AppVersionShortId(), dep.AppVersionId(), status),
 	}
 
 	if opts.hasIdentity {
@@ -285,7 +285,7 @@ func buildDeploymentRow(dep *deployment_v1alpha.DeploymentInfo, opts historyDisp
 
 	if opts.detailed {
 		gitSha, gitBranch, gitMessage := formatGitInfo(dep)
-		row = append(row, ui.CleanEntityID(dep.Id()), formatErrorInfo(dep, status), gitSha, gitBranch, gitMessage)
+		row = append(row, ui.DisplayShortID(dep.ShortId(), dep.Id()), formatErrorInfo(dep, status), gitSha, gitBranch, gitMessage)
 	} else {
 		gitSha, gitBranch, _ := formatGitInfo(dep)
 		row = append(row, gitSha, gitBranch)
@@ -312,6 +312,13 @@ func formatVersion(version, status string) string {
 		return "-"
 	}
 	return version
+}
+
+func formatVersionWithShortID(shortID, version, status string) string {
+	if shortID != "" {
+		return formatVersion(shortID, status)
+	}
+	return formatVersion(ui.DisplayAppVersion(version), status)
 }
 
 func formatDeploymentTime(dep *deployment_v1alpha.DeploymentInfo) string {

--- a/cli/commands/app_list.go
+++ b/cli/commands/app_list.go
@@ -123,7 +123,12 @@ func AppList(ctx *Context, opts struct {
 		routeDisplay := "-"
 
 		if a.HasCurrentVersion() {
-			version = ui.DisplayAppVersion(a.CurrentVersion().Version())
+			cv := a.CurrentVersion()
+			if cv.HasShortId() && cv.ShortId() != "" {
+				version = cv.ShortId()
+			} else {
+				version = ui.DisplayAppVersion(cv.Version())
+			}
 		}
 
 		// Runtime status from server-aggregated pool state

--- a/cli/commands/app_rollback.go
+++ b/cli/commands/app_rollback.go
@@ -117,12 +117,16 @@ func Rollback(ctx *Context, opts struct {
 		return fmt.Errorf("rollback failed")
 	}
 
-	ctx.Printf("✓ Rolled back %s to version %s\n", opts.App, selectedVersion)
+	versionDisplay := selectedVersion
+	if deployResult.HasDeployment() && deployResult.Deployment().HasAppVersionShortId() {
+		versionDisplay = deployResult.Deployment().AppVersionShortId()
+	}
+	ctx.Printf("✓ Rolled back %s to version %s\n", opts.App, versionDisplay)
 
 	appCl, appErr := ctx.RPCClient(rpcAppStatus)
 	if appErr == nil {
 		appStatusClient := app_v1alpha.NewAppStatusClient(appCl)
-		waitForActivation(ctx, appStatusClient, opts.App, selectedVersion)
+		waitForActivation(ctx, appStatusClient, opts.App, selectedVersion, versionDisplay)
 	}
 
 	if deployResult.HasAccessInfo() && deployResult.AccessInfo() != nil {

--- a/cli/commands/app_status.go
+++ b/cli/commands/app_status.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/api/deployment/deployment_v1alpha"
+	"miren.dev/runtime/pkg/ui"
 )
 
 func AppStatus(ctx *Context, opts struct {
@@ -117,7 +118,7 @@ func AppStatus(ctx *Context, opts struct {
 		ctx.Printf("\n%s\n", labelStyle.Render("Active Deployment:"))
 
 		// Deployment ID
-		ctx.Printf("  ID: %s\n", deployment.Id())
+		ctx.Printf("  ID: %s\n", ui.DisplayShortID(deployment.ShortId(), deployment.Id()))
 
 		// Status with color
 		status := deployment.Status()
@@ -245,7 +246,7 @@ func AppStatus(ctx *Context, opts struct {
 				statusIcon = yellowStyle.Render("○")
 			}
 
-			ctx.Printf("  %s %s - %s", statusIcon, timeStr, dep.Id()[:8])
+			ctx.Printf("  %s %s - %s", statusIcon, timeStr, ui.DisplayShortID(dep.ShortId(), dep.Id()))
 
 			if dep.HasGitInfo() && dep.GitInfo() != nil && dep.GitInfo().HasSha() {
 				sha := dep.GitInfo().Sha()

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -152,7 +152,7 @@ func Deploy(ctx *Context, opts struct {
 				ctx.Printf("Another deployment is already in progress for app '%s' on cluster '%s'.\n\n",
 					lockInfo.AppName(), lockInfo.ClusterId())
 				ctx.Printf("Existing deployment details:\n")
-				ctx.Printf("  • Deployment ID: %s\n", lockInfo.BlockingDeploymentId())
+				ctx.Printf("  • Deployment ID: %s\n", ui.DisplayShortID(lockInfo.BlockingDeploymentShortId(), lockInfo.BlockingDeploymentId()))
 				ctx.Printf("  • Started by: %s\n", lockInfo.StartedBy())
 				if lockInfo.HasStartedAt() && lockInfo.StartedAt() != nil {
 					startedAt := time.Unix(lockInfo.StartedAt().Seconds(), 0)
@@ -172,16 +172,18 @@ func Deploy(ctx *Context, opts struct {
 		}
 
 		if result.HasDeployment() && result.Deployment() != nil {
-			deployedVersion := result.Deployment().AppVersionId()
+			dep := result.Deployment()
+			deployedVersion := dep.AppVersionId()
 			if deployedVersion == "" {
 				deployedVersion = opts.Version
 			}
-			ctx.Printf("✓ Deployed version %s to %s\n", deployedVersion, ctx.ClusterName)
+			versionDisplay := ui.DisplayShortID(dep.AppVersionShortId(), deployedVersion)
+			ctx.Printf("✓ Deployed version %s to %s\n", versionDisplay, ctx.ClusterName)
 
 			appCl, appErr := ctx.RPCClient(rpcAppStatus)
 			if appErr == nil {
 				appStatusClient := app_v1alpha.NewAppStatusClient(appCl)
-				waitForActivation(ctx, appStatusClient, name, deployedVersion)
+				waitForActivation(ctx, appStatusClient, name, deployedVersion, versionDisplay)
 			}
 
 			if result.HasAccessInfo() && result.AccessInfo() != nil {
@@ -325,7 +327,7 @@ func Deploy(ctx *Context, opts struct {
 				lockInfo.AppName(), lockInfo.ClusterId())
 
 			ctx.Printf("Existing deployment details:\n")
-			ctx.Printf("  • Deployment ID: %s\n", lockInfo.BlockingDeploymentId())
+			ctx.Printf("  • Deployment ID: %s\n", ui.DisplayShortID(lockInfo.BlockingDeploymentShortId(), lockInfo.BlockingDeploymentId()))
 			ctx.Printf("  • Started by: %s\n", lockInfo.StartedBy())
 
 			if lockInfo.HasStartedAt() && lockInfo.StartedAt() != nil {

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -155,12 +155,13 @@ func EnvSet(ctx *Context, opts struct {
 		return fmt.Errorf("env set failed")
 	}
 
-	ctx.Printf("✓ Set env vars on %s — new version: %s\n", opts.App, res.VersionId())
+	versionDisplay := ui.DisplayShortID(res.Deployment().AppVersionShortId(), res.VersionId())
+	ctx.Printf("✓ Set env vars on %s — new version: %s\n", opts.App, versionDisplay)
 
 	appCl, appErr := ctx.RPCClient(rpcAppStatus)
 	if appErr == nil {
 		appStatusClient := app_v1alpha.NewAppStatusClient(appCl)
-		waitForActivation(ctx, appStatusClient, opts.App, res.VersionId())
+		waitForActivation(ctx, appStatusClient, opts.App, res.VersionId(), versionDisplay)
 	}
 
 	if res.HasAccessInfo() && res.AccessInfo() != nil {
@@ -399,7 +400,8 @@ func EnvDelete(ctx *Context, opts struct {
 		return fmt.Errorf("env delete failed")
 	}
 
-	ctx.Printf("✓ Deleted env vars from %s — new version: %s\n", opts.App, res.VersionId())
+	versionDisplay := ui.DisplayShortID(res.Deployment().AppVersionShortId(), res.VersionId())
+	ctx.Printf("✓ Deleted env vars from %s — new version: %s\n", opts.App, versionDisplay)
 
 	// Warn about config vars that will reappear on next deploy
 	if res.HasDeletedSources() {
@@ -425,7 +427,7 @@ func EnvDelete(ctx *Context, opts struct {
 	appCl, appErr := ctx.RPCClient(rpcAppStatus)
 	if appErr == nil {
 		appStatusClient := app_v1alpha.NewAppStatusClient(appCl)
-		waitForActivation(ctx, appStatusClient, opts.App, res.VersionId())
+		waitForActivation(ctx, appStatusClient, opts.App, res.VersionId(), versionDisplay)
 	}
 
 	if res.HasAccessInfo() && res.AccessInfo() != nil {

--- a/cli/commands/sandbox_pool_list.go
+++ b/cli/commands/sandbox_pool_list.go
@@ -84,7 +84,7 @@ func SandboxPoolList(ctx *Context, opts struct {
 		}
 
 		rows = append(rows, ui.Row{
-			ui.CleanEntityID(pool.ID.String()),
+			ui.BriefId(e.Entity()),
 			ui.DisplayAppVersion(pool.SandboxSpec.Version.String()),
 			pool.Service,
 			mode,

--- a/cli/commands/set.go
+++ b/cli/commands/set.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/pkg/ui"
 )
 
 func Set(ctx *Context, opts struct {
@@ -35,7 +36,7 @@ func Set(ctx *Context, opts struct {
 		return err
 	}
 
-	ctx.Printf("new version id: %s\n", setres.VersionId())
+	ctx.Printf("new version id: %s\n", ui.CleanEntityID(setres.VersionId()))
 
 	return nil
 }

--- a/pkg/ui/entity.go
+++ b/pkg/ui/entity.go
@@ -58,6 +58,14 @@ func entityIdStr(e entity.AttrGetter) string {
 	return ""
 }
 
+// DisplayShortID returns the short ID if available, otherwise falls back to CleanEntityID.
+func DisplayShortID(shortID, fullID string) string {
+	if shortID != "" {
+		return shortID
+	}
+	return CleanEntityID(fullID)
+}
+
 // DisplayAppVersion formats an app version string by removing prefixes and bolding the app name.
 // For example: "app_version/meet-vXYZ123" -> "**meet**-vXYZ123" (where **meet** is bold)
 func DisplayAppVersion(version string) string {

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -14,6 +14,7 @@ import (
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/pkg/cond"
@@ -52,6 +53,18 @@ func NewAppInfo(log *slog.Logger, ec *entityserver.Client, cpu *metrics.CPUUsage
 }
 
 var _ app_v1alpha.Crud = &AppInfo{}
+
+func shortIDFromEntity(ent *entityserver_v1alpha.Entity) string {
+	if ent == nil {
+		return ""
+	}
+	for _, attr := range ent.Attrs() {
+		if entity.Id(attr.ID) == entity.DBShortId {
+			return attr.Value.String()
+		}
+	}
+	return ""
+}
 
 func (r *AppInfo) New(ctx context.Context, state *app_v1alpha.CrudNew) error {
 	name := state.Args().Name()
@@ -101,9 +114,10 @@ func (r *AppInfo) List(ctx context.Context, state *app_v1alpha.CrudList) error {
 
 	// Collect apps and resolve their active versions
 	type appEntry struct {
-		name          string
-		app           core_v1alpha.App
-		activeVersion *core_v1alpha.AppVersion
+		name                string
+		app                 core_v1alpha.App
+		activeVersion       *core_v1alpha.AppVersion
+		activeVersionEntity *entityserver_v1alpha.Entity
 	}
 
 	var apps []appEntry
@@ -118,8 +132,9 @@ func (r *AppInfo) List(ctx context.Context, state *app_v1alpha.CrudList) error {
 
 		if app.ActiveVersion != "" {
 			var appVer core_v1alpha.AppVersion
-			if err := r.EC.GetById(ctx, app.ActiveVersion, &appVer); err == nil {
+			if verEnt, err := r.EC.GetByIdWithEntity(ctx, entity.Id(app.ActiveVersion), &appVer); err == nil {
 				entry.activeVersion = &appVer
+				entry.activeVersionEntity = verEnt
 				if resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer); err == nil {
 					specMap[appVer.ID.String()] = resolvedCfg
 				}
@@ -206,6 +221,9 @@ func (r *AppInfo) List(ctx context.Context, state *app_v1alpha.CrudList) error {
 		if entry.activeVersion != nil {
 			var vi app_v1alpha.VersionInfo
 			vi.SetVersion(entry.activeVersion.Version)
+			if sid := shortIDFromEntity(entry.activeVersionEntity); sid != "" {
+				vi.SetShortId(sid)
+			}
 			a.SetCurrentVersion(&vi)
 		}
 

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -77,7 +77,8 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 
 	if len(existingDeployments) > 0 {
 		// Found an existing in_progress deployment
-		existing := existingDeployments[0]
+		existing := existingDeployments[0].deployment
+		existingEnt := existingDeployments[0].entity
 
 		// Parse the deployment timestamp
 		// Treat malformed/empty timestamps as expired to avoid blocking deployments
@@ -108,6 +109,7 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 			lockInfo.SetAppName(appName)
 			lockInfo.SetClusterId(clusterId)
 			lockInfo.SetBlockingDeploymentId(string(existing.ID))
+			lockInfo.SetBlockingDeploymentShortId(shortIDFromRPCEntity(existingEnt))
 			lockInfo.SetStartedBy(displayEmail)
 			lockInfo.SetStartedAt(standard.ToTimestamp(deploymentTime))
 			lockInfo.SetCurrentPhase(existing.Phase)
@@ -213,6 +215,10 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 
 	// Convert to RPC response
 	deploymentInfo := d.toDeploymentInfo(deployment)
+	if depEnt, err := d.EAC.Get(ctx, putResp.Id()); err == nil {
+		versionShortIDs := d.resolveShortIDs(ctx, []string{deployment.AppVersion})
+		enrichDeploymentShortIDs(deploymentInfo, depEnt.Entity(), versionShortIDs)
+	}
 	results.SetDeployment(deploymentInfo)
 
 	d.Log.Info("Created deployment",
@@ -500,10 +506,19 @@ func (d *DeploymentServer) ListDeployments(ctx context.Context, req *deployment_
 		return err
 	}
 
+	// Batch-resolve app version short IDs
+	versionIDs := make([]string, 0, len(deployments))
+	for _, dwe := range deployments {
+		versionIDs = append(versionIDs, dwe.deployment.AppVersion)
+	}
+	versionShortIDs := d.resolveShortIDs(ctx, versionIDs)
+
 	// Convert to deployment info list
 	deploymentInfos := make([]*deployment_v1alpha.DeploymentInfo, 0, len(deployments))
-	for _, dep := range deployments {
-		deploymentInfos = append(deploymentInfos, d.toDeploymentInfo(dep))
+	for _, dwe := range deployments {
+		info := d.toDeploymentInfo(dwe.deployment)
+		enrichDeploymentShortIDs(info, dwe.entity, versionShortIDs)
+		deploymentInfos = append(deploymentInfos, info)
 	}
 
 	results.SetDeployments(deploymentInfos)
@@ -537,6 +552,8 @@ func (d *DeploymentServer) GetDeploymentById(ctx context.Context, req *deploymen
 	}
 
 	deploymentInfo := d.toDeploymentInfo(&deployment)
+	versionShortIDs := d.resolveShortIDs(ctx, []string{deployment.AppVersion})
+	enrichDeploymentShortIDs(deploymentInfo, deploymentResp.Entity(), versionShortIDs)
 	results.SetDeployment(deploymentInfo)
 
 	return nil
@@ -628,8 +645,10 @@ func (d *DeploymentServer) GetActiveDeployment(ctx context.Context, req *deploym
 		return cond.NotFound("active-deployment", fmt.Sprintf("%s/%s", appName, clusterId))
 	}
 
-	deployment := deployments[0]
-	deploymentInfo := d.toDeploymentInfo(deployment)
+	dwe := deployments[0]
+	deploymentInfo := d.toDeploymentInfo(dwe.deployment)
+	versionShortIDs := d.resolveShortIDs(ctx, []string{dwe.deployment.AppVersion})
+	enrichDeploymentShortIDs(deploymentInfo, dwe.entity, versionShortIDs)
 	results.SetDeployment(deploymentInfo)
 
 	return nil
@@ -764,7 +783,8 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	}
 
 	if len(existingDeployments) > 0 {
-		existing := existingDeployments[0]
+		existing := existingDeployments[0].deployment
+		existingEnt := existingDeployments[0].entity
 
 		deploymentTime, parseErr := time.Parse(time.RFC3339, existing.DeployedBy.Timestamp)
 		if parseErr != nil {
@@ -784,6 +804,7 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 			lockInfo.SetAppName(appName)
 			lockInfo.SetClusterId(clusterId)
 			lockInfo.SetBlockingDeploymentId(string(existing.ID))
+			lockInfo.SetBlockingDeploymentShortId(shortIDFromRPCEntity(existingEnt))
 			lockInfo.SetStartedBy(displayEmail)
 			lockInfo.SetStartedAt(standard.ToTimestamp(deploymentTime))
 			lockInfo.SetCurrentPhase(existing.Phase)
@@ -824,9 +845,9 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	}
 
 	var sourceDeployment *core_v1alpha.Deployment
-	for _, dep := range allDeployments {
-		if dep.AppVersion == sourceVersionId {
-			sourceDeployment = dep
+	for _, dwe := range allDeployments {
+		if dwe.deployment.AppVersion == sourceVersionId {
+			sourceDeployment = dwe.deployment
 			break // listDeploymentsInternal returns newest first
 		}
 	}
@@ -911,6 +932,10 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	}
 
 	deploymentInfo := d.toDeploymentInfo(deployment)
+	if depEnt, getErr := d.EAC.Get(ctx, newDeploymentId); getErr == nil {
+		versionShortIDs := d.resolveShortIDs(ctx, []string{deployment.AppVersion})
+		enrichDeploymentShortIDs(deploymentInfo, depEnt.Entity(), versionShortIDs)
+	}
 	results.SetDeployment(deploymentInfo)
 
 	accessInfo := d.getAccessInfo(ctx, appName)
@@ -1038,7 +1063,8 @@ func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, 
 	}
 
 	if len(existingDeployments) > 0 {
-		existing := existingDeployments[0]
+		existing := existingDeployments[0].deployment
+		existingEnt := existingDeployments[0].entity
 
 		deploymentTime, parseErr := time.Parse(time.RFC3339, existing.DeployedBy.Timestamp)
 		if parseErr != nil {
@@ -1058,6 +1084,7 @@ func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, 
 			lockInfo.SetAppName(appName)
 			lockInfo.SetClusterId(clusterId)
 			lockInfo.SetBlockingDeploymentId(string(existing.ID))
+			lockInfo.SetBlockingDeploymentShortId(shortIDFromRPCEntity(existingEnt))
 			lockInfo.SetStartedBy(displayEmail)
 			lockInfo.SetStartedAt(standard.ToTimestamp(deploymentTime))
 			lockInfo.SetCurrentPhase(existing.Phase)
@@ -1126,6 +1153,10 @@ func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, 
 	}
 
 	deploymentInfo := d.toDeploymentInfo(deployment)
+	if depEnt, getErr := d.EAC.Get(ctx, newDeploymentId); getErr == nil {
+		versionShortIDs := d.resolveShortIDs(ctx, []string{deployment.AppVersion})
+		enrichDeploymentShortIDs(deploymentInfo, depEnt.Entity(), versionShortIDs)
+	}
 	results.SetDeployment(deploymentInfo)
 
 	accessInfo := d.getAccessInfo(ctx, appName)
@@ -1183,7 +1214,7 @@ func (d *DeploymentServer) getAccessInfo(ctx context.Context, appName string) *d
 
 // Internal helper methods
 
-func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName, clusterId, status string, limit int) ([]*core_v1alpha.Deployment, error) {
+func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName, clusterId, status string, limit int) ([]deploymentWithEntity, error) {
 	// List all deployments by type
 	listResp, err := d.EAC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindDeployment))
 	if err != nil {
@@ -1195,7 +1226,7 @@ func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName,
 	entities := listResp.Values()
 
 	// Decode and filter deployments
-	deployments := make([]*core_v1alpha.Deployment, 0)
+	deployments := make([]deploymentWithEntity, 0)
 	for _, e := range entities {
 		// List already returns full entity data with attributes, no need to fetch again
 		var dep core_v1alpha.Deployment
@@ -1212,12 +1243,12 @@ func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName,
 			continue
 		}
 
-		deployments = append(deployments, &dep)
+		deployments = append(deployments, deploymentWithEntity{deployment: &dep, entity: e})
 	}
 
 	// Sort by timestamp (newest first) using efficient sort.Slice
 	sort.Slice(deployments, func(i, j int) bool {
-		return deployments[i].DeployedBy.Timestamp > deployments[j].DeployedBy.Timestamp
+		return deployments[i].deployment.DeployedBy.Timestamp > deployments[j].deployment.DeployedBy.Timestamp
 	})
 
 	// Apply limit after sorting
@@ -1289,6 +1320,58 @@ func (d *DeploymentServer) toDeploymentInfo(deployment *core_v1alpha.Deployment)
 	return info
 }
 
+// shortIDFromRPCEntity extracts the db/short-id attribute from an RPC entity.
+func shortIDFromRPCEntity(ent *entityserver_v1alpha.Entity) string {
+	if ent == nil {
+		return ""
+	}
+	for _, attr := range ent.Attrs() {
+		if entity.Id(attr.ID) == entity.DBShortId {
+			return attr.Value.String()
+		}
+	}
+	return ""
+}
+
+// enrichDeploymentShortIDs populates the short ID fields on a DeploymentInfo
+// from the deployment entity and a version short ID lookup map.
+func enrichDeploymentShortIDs(info *deployment_v1alpha.DeploymentInfo, ent *entityserver_v1alpha.Entity, versionShortIDs map[string]string) {
+	if sid := shortIDFromRPCEntity(ent); sid != "" {
+		info.SetShortId(sid)
+	}
+	if versionShortIDs != nil {
+		if sid, ok := versionShortIDs[info.AppVersionId()]; ok && sid != "" {
+			info.SetAppVersionShortId(sid)
+		}
+	}
+}
+
+// resolveShortIDs batch-resolves short IDs for a set of entity IDs.
+func (d *DeploymentServer) resolveShortIDs(ctx context.Context, ids []string) map[string]string {
+	result := make(map[string]string, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := result[id]; ok {
+			continue // already resolved
+		}
+		resp, err := d.EAC.Get(ctx, id)
+		if err != nil {
+			continue
+		}
+		if sid := shortIDFromRPCEntity(resp.Entity()); sid != "" {
+			result[id] = sid
+		}
+	}
+	return result
+}
+
+type deploymentWithEntity struct {
+	deployment *core_v1alpha.Deployment
+	entity     *entityserver_v1alpha.Entity
+}
+
 // markPreviousActiveAs marks all active deployments for the given app/cluster with the target status,
 // except for the specified currentDeploymentId
 func (d *DeploymentServer) markPreviousActiveAs(ctx context.Context, appName, clusterId, currentDeploymentId, targetStatus string) error {
@@ -1299,7 +1382,8 @@ func (d *DeploymentServer) markPreviousActiveAs(ctx context.Context, appName, cl
 	}
 
 	// Update each active deployment (except the current one) to the target status
-	for _, dep := range deployments {
+	for _, dwe := range deployments {
+		dep := dwe.deployment
 		if string(dep.ID) == currentDeploymentId {
 			continue
 		}


### PR DESCRIPTION
Short IDs (PR #696, RFD-69) have been working great — every entity gets a compact, human-friendly identifier on creation, and `sandbox list` was already showing them. But that was the only place. Everywhere else in the CLI still showed full entity IDs like `deployment-CZdDHFf6Xyy99RrzRkxBg`, and `app status` had a particularly embarrassing bug where it sliced the deployment ID with `[:8]` producing the literal string "deployme" on every line of recent activity.

The core challenge was that most CLI commands get their IDs from RPC responses as plain strings, not as entity objects, so `ui.BriefId()` couldn't be called directly. The fix takes a hybrid approach: enrich the key RPC response types with short ID fields (DeploymentInfo, DeploymentLockInfo, VersionInfo), populate them server-side from entity attributes we already have in hand, and use `BriefId()` directly where entity objects are available (like sandbox-pool list).

The deployment server's `listDeploymentsInternal` was already fetching full entities but throwing them away after decoding — now it preserves them alongside the decoded structs so `toDeploymentInfo` callers can extract short IDs for free. App version short IDs are batch-resolved to avoid N+1 queries in list views.

On the CLI side, everything goes through a new `DisplayShortID(shortID, fullID)` helper that gracefully falls back to `CleanEntityID` when the server hasn't been updated or short IDs aren't available. This means the new CLI works fine against older servers — you just don't get short IDs until the server is deployed too.

Sandbox list POOL/VERSION cross-references (which require batch entity resolution for referenced entities) are deferred for a follow-up.

Resolves MIR-947