### PR TITLE
Fix local disks not mounting for web service sandboxes

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -633,7 +633,8 @@ func (l *Launcher) buildSandboxSpec(
 	// Add disk volumes and mounts for this service
 	for _, svc := range cfgSpec.Services {
 		if svc.Name == serviceName {
-			// Check concurrency constraints for miren disk volumes
+			// Pre-compute concurrency mode for miren disk eligibility check
+			var skipMirenDisks bool
 			hasMirenDisks := false
 			for _, disk := range svc.Disks {
 				if disk.Provider == "" || disk.Provider == core_v1alpha.ConfigSpecServicesDisksMIREN {
@@ -648,10 +649,10 @@ func (l *Launcher) buildSandboxSpec(
 				}
 
 				if svcConcurrency.Mode != "fixed" {
-					l.Log.Warn("skipping disk attachment for non-fixed service",
+					l.Log.Warn("skipping miren disk attachment for non-fixed service",
 						"service", serviceName,
 						"mode", svcConcurrency.Mode)
-					break
+					skipMirenDisks = true
 				}
 			}
 
@@ -664,6 +665,10 @@ func (l *Launcher) buildSandboxSpec(
 					provider = "miren"
 				default:
 					provider = "miren"
+				}
+
+				if skipMirenDisks && provider != "local" {
+					continue
 				}
 
 				sbSpec.Volume = append(sbSpec.Volume, compute_v1alpha.SandboxSpecVolume{

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -2403,3 +2403,142 @@ func TestDiskProviderDefaultsToMiren(t *testing.T) {
 	require.Len(t, volumes, 1)
 	assert.Equal(t, "miren", volumes[0].Provider, "empty provider should default to miren")
 }
+
+// TestLocalDisksAttachedForAutoScalingWebService verifies that local disks are
+// mounted on web services with auto concurrency mode. This is a regression test
+// for MIR-950 where the miren disk concurrency guard broke out of the entire
+// disk loop, preventing local disks from being attached.
+func TestLocalDisksAttachedForAutoScalingWebService(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/miren/data/local",
+						},
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1, "should create one pool")
+
+	volumes := pools[0].SandboxSpec.Volume
+	require.Len(t, volumes, 1, "local disk should be attached even with auto concurrency")
+	assert.Equal(t, "local", volumes[0].Provider)
+	assert.Equal(t, "data", volumes[0].Name)
+	assert.Equal(t, "/miren/data/local", volumes[0].MountPath)
+
+	// Verify the container mount was also added
+	containers := pools[0].SandboxSpec.Container
+	require.NotEmpty(t, containers)
+	require.Len(t, containers[0].Mount, 1, "container should have disk mount")
+	assert.Equal(t, "data", containers[0].Mount[0].Source)
+	assert.Equal(t, "/miren/data/local", containers[0].Mount[0].Destination)
+}
+
+// TestMirenDisksSkippedForAutoScalingWebService verifies that miren disks are
+// still correctly skipped for non-fixed concurrency services, while local disks
+// in the same config are still attached.
+func TestMirenDisksSkippedForAutoScalingWebService(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "local-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/data",
+						},
+						{
+							Name:      "miren-data",
+							Provider:  core_v1alpha.MIREN,
+							MountPath: "/miren-data",
+							SizeGb:    1,
+						},
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1, "should create one pool")
+
+	volumes := pools[0].SandboxSpec.Volume
+	require.Len(t, volumes, 1, "only local disk should be attached, miren disk should be skipped")
+	assert.Equal(t, "local", volumes[0].Provider)
+	assert.Equal(t, "local-data", volumes[0].Name)
+}


### PR DESCRIPTION
Apps like uptime-kuma that define `[[services.web.disks]]` with `provider = "local"` were crashing because their disk mounts never showed up in the sandbox. The sandbox was also getting scheduled as stateless since it had no volumes.

The root cause was in `buildSandboxSpec` — there's a guard that skips miren disk attachment when the service isn't using fixed concurrency mode (since miren disks need instance affinity). The problem was that guard used `break` to exit the *entire* disk loop, which meant local disks got thrown out with the bathwater. Web services default to auto concurrency, so any web service with local disks hit this path every time.

The fix scopes the guard to only skip miren disks via a flag + `continue`, letting local disks through regardless of concurrency mode. Two new tests cover the exact MIR-950 scenario (local disks on an auto-scaling web service) and confirm miren disks are still correctly skipped when they should be.

Closes MIR-950