### PR TITLE
Drain old pools before starting new ones for services with disks

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -216,6 +216,20 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	// For each service, ensure a pool exists. Collect IDs of newly created pools.
 	var newPoolIDs []entity.Id
 	for _, svc := range spec.Services {
+		// For services with disks, drain old pools before creating new ones.
+		// Disks require exclusive access (local disks use flock, miren disks
+		// use leases), so the old sandbox must release the disk before the
+		// new one can mount it.
+		if serviceHasDisks(spec, svc.Name) {
+			if err := l.drainStaleDiskPools(ctx, app, &ver, spec, svc.Name); err != nil {
+				l.Log.Error("failed to drain old disk pools, skipping service",
+					"app", app.ID,
+					"service", svc.Name,
+					"error", err)
+				continue
+			}
+		}
+
 		poolID, err := l.ensurePoolForService(ctx, app, &ver, spec, svc.Name)
 		if err != nil {
 			l.Log.Error("failed to ensure pool for service",
@@ -1472,4 +1486,209 @@ func (l *Launcher) cleanupStaleServices(ctx context.Context, app *core_v1alpha.A
 				"error", err)
 		}
 	}
+}
+
+// serviceHasDisks returns true if the named service in the config spec has any
+// disk mounts configured.
+func serviceHasDisks(spec *core_v1alpha.ConfigSpec, serviceName string) bool {
+	for _, svc := range spec.Services {
+		if svc.Name == serviceName {
+			return len(svc.Disks) > 0
+		}
+	}
+	return false
+}
+
+// drainStaleDiskPools finds pools for the given app+service whose spec
+// does not match the current desired spec, scales them to 0, and waits for
+// their sandboxes to stop. This ensures disks are released before a new
+// pool tries to mount them.
+func (l *Launcher) drainStaleDiskPools(
+	ctx context.Context,
+	app *core_v1alpha.App,
+	ver *core_v1alpha.AppVersion,
+	cfgSpec *core_v1alpha.ConfigSpec,
+	serviceName string,
+) error {
+	// Determine which image to use (same logic as ensurePoolForService)
+	image := ver.ImageUrl
+	for _, svc := range cfgSpec.Services {
+		if svc.Name == serviceName && svc.Image != "" {
+			image = containerdx.NormalizeImageReference(svc.Image)
+			break
+		}
+	}
+
+	desiredSpec, err := l.buildSandboxSpec(ctx, app, ver, cfgSpec, serviceName, image)
+	if err != nil {
+		return fmt.Errorf("build sandbox spec: %w", err)
+	}
+
+	stalePools, err := l.findStalePoolsForService(ctx, app.ID, serviceName, desiredSpec)
+	if err != nil {
+		return fmt.Errorf("find stale pools: %w", err)
+	}
+
+	if len(stalePools) == 0 {
+		return nil
+	}
+
+	l.Log.Info("draining stale disk pools before creating new pool",
+		"app", app.ID,
+		"service", serviceName,
+		"stale_pools", len(stalePools))
+
+	for _, pwe := range stalePools {
+		pool := pwe.Pool
+
+		// Remove version references and scale to 0
+		pool.ReferencedByVersions = nil
+		pool.DesiredInstances = 0
+
+		l.Log.Info("scaling down stale disk pool",
+			"pool", pool.ID,
+			"service", pool.Service)
+
+		if err := l.updatePool(ctx, pwe); err != nil {
+			return fmt.Errorf("update pool %s: %w", pool.ID, err)
+		}
+	}
+
+	// Wait for all stale pools to fully drain so disk leases are released.
+	for _, pwe := range stalePools {
+		if err := l.waitForPoolDrained(ctx, pwe.Pool.ID, pwe.Pool.Service, l.PoolReadyTimeout); err != nil {
+			return fmt.Errorf("waiting for pool %s to drain: %w", pwe.Pool.ID, err)
+		}
+	}
+
+	return nil
+}
+
+// findStalePoolsForService returns pools for the given app+service whose spec
+// does NOT match the desired spec. These are old-version pools that should be
+// drained before starting new sandboxes.
+func (l *Launcher) findStalePoolsForService(
+	ctx context.Context,
+	appID entity.Id,
+	serviceName string,
+	desiredSpec *compute_v1alpha.SandboxSpec,
+) ([]*PoolWithEntity, error) {
+	poolsResp, err := l.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool))
+	if err != nil {
+		return nil, fmt.Errorf("list pools: %w", err)
+	}
+
+	var stale []*PoolWithEntity
+	for _, ent := range poolsResp.Values() {
+		var pool compute_v1alpha.SandboxPool
+		pool.Decode(ent.Entity())
+
+		if pool.Service != serviceName {
+			continue
+		}
+
+		var poolMeta core_v1alpha.Metadata
+		poolMeta.Decode(ent.Entity())
+
+		appLabel, _ := poolMeta.Labels.Get("app")
+		if appLabel != appID.String() {
+			continue
+		}
+
+		// Skip pools that already match the desired spec
+		if _, matches := specsMatch(&pool.SandboxSpec, desiredSpec); matches {
+			continue
+		}
+
+		// Skip pools already scaled to 0 with no references AND no active
+		// sandboxes. A previous drain attempt may have set DesiredInstances=0
+		// but timed out before all sandboxes stopped — we still need to wait
+		// for those to finish.
+		if pool.DesiredInstances == 0 && len(pool.ReferencedByVersions) == 0 {
+			hasActive, err := l.hasActiveSandboxForPool(ctx, pool.ID, serviceName)
+			if err != nil {
+				return nil, fmt.Errorf("check active sandboxes for pool %s: %w", pool.ID, err)
+			}
+			if !hasActive {
+				continue
+			}
+		}
+
+		entCopy := *ent.Entity()
+		stale = append(stale, &PoolWithEntity{Pool: &pool, Entity: entCopy})
+	}
+
+	return stale, nil
+}
+
+// waitForPoolDrained polls until a pool has no RUNNING or PENDING sandboxes,
+// indicating that its resources (including disk leases) have been released.
+func (l *Launcher) waitForPoolDrained(ctx context.Context, poolID entity.Id, service string, timeout time.Duration) error {
+	pollInterval := 500 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+
+	for {
+		hasActive, err := l.hasActiveSandboxForPool(ctx, poolID, service)
+		if err != nil {
+			return fmt.Errorf("check sandboxes for pool %s: %w", poolID, err)
+		}
+
+		if !hasActive {
+			l.Log.Info("stale pool fully drained", "pool", poolID)
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("pool %s still has active sandboxes after %s: %w",
+				poolID, timeout, context.DeadlineExceeded)
+		}
+
+		l.Log.Debug("waiting for stale pool to drain",
+			"pool", poolID)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// hasActiveSandboxForPool returns true if there are any RUNNING, PENDING, or
+// NOT_READY sandboxes for the given pool. NOT_READY sandboxes may still hold
+// disk leases, so we must wait for them to fully stop.
+func (l *Launcher) hasActiveSandboxForPool(ctx context.Context, poolID entity.Id, service string) (bool, error) {
+	resp, err := l.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return false, fmt.Errorf("list sandboxes: %w", err)
+	}
+
+	for _, ent := range resp.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(ent.Entity())
+
+		switch sb.Status {
+		case compute_v1alpha.RUNNING, compute_v1alpha.PENDING, compute_v1alpha.NOT_READY:
+			// Active — may still hold disk resources
+		default:
+			continue
+		}
+
+		var md core_v1alpha.Metadata
+		md.Decode(ent.Entity())
+
+		poolLabel, _ := md.Labels.Get("pool")
+		if poolLabel != poolID.String() {
+			continue
+		}
+
+		serviceLabel, _ := md.Labels.Get("service")
+		if serviceLabel != service {
+			continue
+		}
+
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -14,10 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	apiserver "miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/network/network_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
 )
 
 func newTestLauncher(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient) *Launcher {
@@ -2728,4 +2730,428 @@ func TestNoAutoMountWhenExplicitDiskConfig(t *testing.T) {
 	require.Len(t, volumes, 1, "should only have explicit disk config")
 	assert.Equal(t, "my-data", volumes[0].Name)
 	assert.Equal(t, "local", volumes[0].Provider)
+}
+
+// TestDiskPoolDrainedBeforeNewPoolCreated verifies that when deploying a new
+// version of an app with disks, the old pool is scaled to 0 before the new
+// pool is created. This prevents conflicts when both old and new sandboxes try
+// to mount the same disk.
+func TestDiskPoolDrainedBeforeNewPoolCreated(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// Deploy v1 with a local disk (e.g. victoriametrics)
+	v1 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "oci.miren.cloud/victoriametrics:v1",
+		Config: core_v1alpha.Config{
+			Port: 8428,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "victoriametrics",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "vm-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/miren/data/local/victoria-metrics-data",
+						},
+					},
+				},
+			},
+		},
+	}
+	v1ID, err := server.Client.Create(ctx, "test-v1", v1)
+	require.NoError(t, err)
+	v1.ID = v1ID
+
+	app.ActiveVersion = v1.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	poolsV1 := listAllPools(t, ctx, server)
+	require.Len(t, poolsV1, 1, "should create one pool for v1")
+	poolV1ID := poolsV1[0].ID
+
+	// Deploy v2 with same local disk but new image (triggers new pool)
+	v2 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v2",
+		ImageUrl: "oci.miren.cloud/victoriametrics:v2",
+		Config: core_v1alpha.Config{
+			Port: 8428,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "victoriametrics",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "vm-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/miren/data/local/victoria-metrics-data",
+						},
+					},
+				},
+			},
+		},
+	}
+	v2ID, err := server.Client.Create(ctx, "test-v2", v2)
+	require.NoError(t, err)
+	v2.ID = v2ID
+
+	app.ActiveVersion = v2.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// The old pool should have been drained (scaled to 0, no references)
+	// BEFORE the new pool was created.
+	getRes, err := server.EAC.Get(ctx, poolV1ID.String())
+	require.NoError(t, err)
+	var poolV1Refreshed compute_v1alpha.SandboxPool
+	poolV1Refreshed.Decode(getRes.Entity().Entity())
+
+	assert.Equal(t, int64(0), poolV1Refreshed.DesiredInstances,
+		"old disk pool should be scaled to 0")
+	assert.Empty(t, poolV1Refreshed.ReferencedByVersions,
+		"old disk pool should have no version references")
+
+	// New pool should have been created for v2
+	allPools := listAllPools(t, ctx, server)
+	require.Len(t, allPools, 2, "should have old and new pools")
+
+	var poolV2 *compute_v1alpha.SandboxPool
+	for i := range allPools {
+		if allPools[i].ID != poolV1ID {
+			poolV2 = &allPools[i]
+			break
+		}
+	}
+	require.NotNil(t, poolV2, "should find the new pool")
+	assert.Equal(t, "victoriametrics", poolV2.Service)
+	assert.Contains(t, poolV2.ReferencedByVersions, v2.ID)
+
+	// New pool should have the local disk volume
+	require.Len(t, poolV2.SandboxSpec.Volume, 1)
+	assert.Equal(t, "local", poolV2.SandboxSpec.Volume[0].Provider)
+}
+
+// TestDiskDrainBlockedByActiveSandbox verifies that when a RUNNING sandbox
+// exists for the old pool, the drain times out and the new pool is NOT created.
+// This proves drain-before-create ordering: the launcher won't start the new
+// version while the old one still holds the disk.
+func TestDiskDrainBlockedByActiveSandbox(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	v1 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "oci.miren.cloud/victoriametrics:v1",
+		Config: core_v1alpha.Config{
+			Port: 8428,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "victoriametrics",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "vm-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/miren/data/local/victoria-metrics-data",
+						},
+					},
+				},
+			},
+		},
+	}
+	v1ID, err := server.Client.Create(ctx, "test-v1", v1)
+	require.NoError(t, err)
+	v1.ID = v1ID
+
+	app.ActiveVersion = v1.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	poolsV1 := listAllPools(t, ctx, server)
+	require.Len(t, poolsV1, 1)
+	poolV1ID := poolsV1[0].ID
+
+	// Simulate a RUNNING sandbox for the old pool (as the sandbox controller
+	// would create). This holds the disk and blocks draining.
+	sb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+	}
+	_, err = server.Client.Create(ctx, "old-sandbox",
+		sb,
+		apiserver.WithLabels(types.LabelSet(
+			"pool", poolV1ID.String(),
+			"service", "victoriametrics",
+		)),
+	)
+	require.NoError(t, err)
+
+	// Deploy v2
+	v2 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v2",
+		ImageUrl: "oci.miren.cloud/victoriametrics:v2",
+		Config: core_v1alpha.Config{
+			Port: 8428,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "victoriametrics",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "vm-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/miren/data/local/victoria-metrics-data",
+						},
+					},
+				},
+			},
+		},
+	}
+	v2ID, err := server.Client.Create(ctx, "test-v2", v2)
+	require.NoError(t, err)
+	v2.ID = v2ID
+
+	app.ActiveVersion = v2.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	// Reconcile should NOT create a new pool because the old sandbox is
+	// still running (drain times out). The service is skipped.
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Only the original pool should exist — no v2 pool was created
+	allPools := listAllPools(t, ctx, server)
+	require.Len(t, allPools, 1, "should not create new pool while old sandbox is running")
+
+	// The old pool was marked for drain (desired=0, no refs)
+	getRes, err := server.EAC.Get(ctx, poolV1ID.String())
+	require.NoError(t, err)
+	var poolV1 compute_v1alpha.SandboxPool
+	poolV1.Decode(getRes.Entity().Entity())
+	assert.Equal(t, int64(0), poolV1.DesiredInstances,
+		"old pool should be scaled to 0")
+	assert.Empty(t, poolV1.ReferencedByVersions,
+		"old pool should have no version references")
+}
+
+// TestServiceHasDisks verifies the serviceHasDisks helper.
+func TestServiceHasDisks(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     *core_v1alpha.ConfigSpec
+		service  string
+		expected bool
+	}{
+		{
+			name: "service with local disk",
+			spec: &core_v1alpha.ConfigSpec{
+				Services: []core_v1alpha.ConfigSpecServices{
+					{
+						Name: "db",
+						Disks: []core_v1alpha.ConfigSpecServicesDisks{
+							{Name: "data", Provider: core_v1alpha.ConfigSpecServicesDisksLOCAL},
+						},
+					},
+				},
+			},
+			service:  "db",
+			expected: true,
+		},
+		{
+			name: "service with miren disk",
+			spec: &core_v1alpha.ConfigSpec{
+				Services: []core_v1alpha.ConfigSpecServices{
+					{
+						Name: "db",
+						Disks: []core_v1alpha.ConfigSpecServicesDisks{
+							{Name: "data", Provider: core_v1alpha.ConfigSpecServicesDisksMIREN},
+						},
+					},
+				},
+			},
+			service:  "db",
+			expected: true,
+		},
+		{
+			name: "service with no disks",
+			spec: &core_v1alpha.ConfigSpec{
+				Services: []core_v1alpha.ConfigSpecServices{
+					{Name: "web"},
+				},
+			},
+			service:  "web",
+			expected: false,
+		},
+		{
+			name: "different service has disk",
+			spec: &core_v1alpha.ConfigSpec{
+				Services: []core_v1alpha.ConfigSpecServices{
+					{Name: "web"},
+					{
+						Name: "db",
+						Disks: []core_v1alpha.ConfigSpecServicesDisks{
+							{Name: "data", Provider: core_v1alpha.ConfigSpecServicesDisksLOCAL},
+						},
+					},
+				},
+			},
+			service:  "web",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, serviceHasDisks(tt.spec, tt.service))
+		})
+	}
+}
+
+// TestDisklessServiceNotDrained verifies that services without disks still use
+// the normal rolling deploy strategy (new pool created before old pool is
+// cleaned up).
+func TestDisklessServiceNotDrained(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// Deploy v1 — no disks
+	v1 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "oci.miren.cloud/myapp:v1",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	v1ID, err := server.Client.Create(ctx, "test-v1", v1)
+	require.NoError(t, err)
+	v1.ID = v1ID
+
+	app.ActiveVersion = v1.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	launcher := newTestLauncher(log, server.EAC)
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	poolsV1 := listAllPools(t, ctx, server)
+	require.Len(t, poolsV1, 1)
+
+	// Deploy v2 with new image
+	v2 := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v2",
+		ImageUrl: "oci.miren.cloud/myapp:v2",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	v2ID, err := server.Client.Create(ctx, "test-v2", v2)
+	require.NoError(t, err)
+	v2.ID = v2ID
+
+	app.ActiveVersion = v2.ID
+	err = server.Client.Update(ctx, app)
+	require.NoError(t, err)
+
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	// Both pools should exist — rolling deploy creates the new pool before
+	// cleaning up the old one (create-before-drain). Verify one is the active
+	// v2 pool and the other was scaled down by cleanup.
+	allPools := listAllPools(t, ctx, server)
+	require.Len(t, allPools, 2, "rolling deploy should have both pools")
+
+	var newPool, oldPool *compute_v1alpha.SandboxPool
+	for i := range allPools {
+		if len(allPools[i].ReferencedByVersions) > 0 {
+			newPool = &allPools[i]
+		} else {
+			oldPool = &allPools[i]
+		}
+	}
+	require.NotNil(t, newPool, "should have an active pool for v2")
+	require.NotNil(t, oldPool, "should have a decommissioned old pool")
+	assert.Equal(t, int64(1), newPool.DesiredInstances, "new pool should be active")
+	assert.Equal(t, int64(0), oldPool.DesiredInstances, "old pool should be scaled down")
 }


### PR DESCRIPTION
We hit this with victoriametrics on the Garden cluster — deploying a new version would spin up a new sandbox that immediately panicked trying to acquire an flock on a local disk the old sandbox still held. The new sandbox would crash-loop until the old one eventually got cleaned up, at which point it'd finally start. Not great.

The root cause is that `reconcileAppVersion` uses a rolling strategy: create new pool, wait for ready, then clean up old pools. That's the right default for stateless services (avoids 502s during rollover), but for anything with disk mounts it's a non-starter — you can't have two processes holding the same exclusive disk resource.

The fix checks whether a service has disks configured before entering the pool creation loop. If it does, stale pools (ones whose spec doesn't match the new version) get scaled to zero and drained first, so the disk is released before the new sandbox tries to mount it. Services without disks continue using the normal rolling strategy.

This is forward-compatible with the saga-based deployment choreography we're planning (RFD-65) — `drain_old` is just another primitive that'll slot into the step sequence.

Closes MIR-957