### PR TITLE
Add RabbitMQ addon support

### DIFF
--- a/api/addon/addon_v1alpha/schema.gen.go
+++ b/api/addon/addon_v1alpha/schema.gen.go
@@ -889,6 +889,177 @@ func (o *PostgresqlSharedData) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 const (
+	RabbitmqDedicatedDataRabbitmqServerId = entity.Id("dev.miren.addon/rabbitmq_dedicated_data.rabbitmq_server")
+)
+
+type RabbitmqDedicatedData struct {
+	ID             entity.Id `json:"id"`
+	RabbitmqServer entity.Id `cbor:"rabbitmq_server,omitempty" json:"rabbitmq_server,omitempty"`
+}
+
+func (o *RabbitmqDedicatedData) Decode(e entity.AttrGetter) {
+	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(RabbitmqDedicatedDataRabbitmqServerId); ok && a.Value.Kind() == entity.KindId {
+		o.RabbitmqServer = a.Value.Id()
+	}
+}
+
+func (o *RabbitmqDedicatedData) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindRabbitmqDedicatedData)
+}
+
+func (o *RabbitmqDedicatedData) ShortKind() string {
+	return "rabbitmq_dedicated_data"
+}
+
+func (o *RabbitmqDedicatedData) Kind() entity.Id {
+	return KindRabbitmqDedicatedData
+}
+
+func (o *RabbitmqDedicatedData) EntityId() entity.Id {
+	return o.ID
+}
+
+func (o *RabbitmqDedicatedData) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.RabbitmqServer) {
+		attrs = append(attrs, entity.Ref(RabbitmqDedicatedDataRabbitmqServerId, o.RabbitmqServer))
+	}
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindRabbitmqDedicatedData))
+	return
+}
+
+func (o *RabbitmqDedicatedData) Empty() bool {
+	return entity.Empty(o.RabbitmqServer)
+}
+
+func (o *RabbitmqDedicatedData) InitSchema(sb *schema.SchemaBuilder) {
+	sb.Ref("rabbitmq_server", "dev.miren.addon/rabbitmq_dedicated_data.rabbitmq_server")
+}
+
+const (
+	RabbitmqServerAddonNameId        = entity.Id("dev.miren.addon/rabbitmq_server.addon_name")
+	RabbitmqServerAssociationCountId = entity.Id("dev.miren.addon/rabbitmq_server.association_count")
+	RabbitmqServerPasswordId         = entity.Id("dev.miren.addon/rabbitmq_server.password")
+	RabbitmqServerSandboxPoolId      = entity.Id("dev.miren.addon/rabbitmq_server.sandbox_pool")
+	RabbitmqServerServiceId          = entity.Id("dev.miren.addon/rabbitmq_server.service")
+	RabbitmqServerStatusId           = entity.Id("dev.miren.addon/rabbitmq_server.status")
+	RabbitmqServerVariantId          = entity.Id("dev.miren.addon/rabbitmq_server.variant")
+)
+
+type RabbitmqServer struct {
+	ID               entity.Id `json:"id"`
+	AddonName        string    `cbor:"addon_name,omitempty" json:"addon_name,omitempty"`
+	AssociationCount int64     `cbor:"association_count,omitempty" json:"association_count,omitempty"`
+	Password         string    `cbor:"password,omitempty" json:"password,omitempty"`
+	SandboxPool      entity.Id `cbor:"sandbox_pool,omitempty" json:"sandbox_pool,omitempty"`
+	Service          entity.Id `cbor:"service,omitempty" json:"service,omitempty"`
+	Status           string    `cbor:"status,omitempty" json:"status,omitempty"`
+	Variant          string    `cbor:"variant,omitempty" json:"variant,omitempty"`
+}
+
+func (o *RabbitmqServer) Decode(e entity.AttrGetter) {
+	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(RabbitmqServerAddonNameId); ok && a.Value.Kind() == entity.KindString {
+		o.AddonName = a.Value.String()
+	}
+	if a, ok := e.Get(RabbitmqServerAssociationCountId); ok && a.Value.Kind() == entity.KindInt64 {
+		o.AssociationCount = a.Value.Int64()
+	}
+	if a, ok := e.Get(RabbitmqServerPasswordId); ok && a.Value.Kind() == entity.KindString {
+		o.Password = a.Value.String()
+	}
+	if a, ok := e.Get(RabbitmqServerSandboxPoolId); ok && a.Value.Kind() == entity.KindId {
+		o.SandboxPool = a.Value.Id()
+	}
+	if a, ok := e.Get(RabbitmqServerServiceId); ok && a.Value.Kind() == entity.KindId {
+		o.Service = a.Value.Id()
+	}
+	if a, ok := e.Get(RabbitmqServerStatusId); ok && a.Value.Kind() == entity.KindString {
+		o.Status = a.Value.String()
+	}
+	if a, ok := e.Get(RabbitmqServerVariantId); ok && a.Value.Kind() == entity.KindString {
+		o.Variant = a.Value.String()
+	}
+}
+
+func (o *RabbitmqServer) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindRabbitmqServer)
+}
+
+func (o *RabbitmqServer) ShortKind() string {
+	return "rabbitmq_server"
+}
+
+func (o *RabbitmqServer) Kind() entity.Id {
+	return KindRabbitmqServer
+}
+
+func (o *RabbitmqServer) EntityId() entity.Id {
+	return o.ID
+}
+
+func (o *RabbitmqServer) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.AddonName) {
+		attrs = append(attrs, entity.String(RabbitmqServerAddonNameId, o.AddonName))
+	}
+	if !entity.Empty(o.AssociationCount) {
+		attrs = append(attrs, entity.Int64(RabbitmqServerAssociationCountId, o.AssociationCount))
+	}
+	if !entity.Empty(o.Password) {
+		attrs = append(attrs, entity.String(RabbitmqServerPasswordId, o.Password))
+	}
+	if !entity.Empty(o.SandboxPool) {
+		attrs = append(attrs, entity.Ref(RabbitmqServerSandboxPoolId, o.SandboxPool))
+	}
+	if !entity.Empty(o.Service) {
+		attrs = append(attrs, entity.Ref(RabbitmqServerServiceId, o.Service))
+	}
+	if !entity.Empty(o.Status) {
+		attrs = append(attrs, entity.String(RabbitmqServerStatusId, o.Status))
+	}
+	if !entity.Empty(o.Variant) {
+		attrs = append(attrs, entity.String(RabbitmqServerVariantId, o.Variant))
+	}
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindRabbitmqServer))
+	return
+}
+
+func (o *RabbitmqServer) Empty() bool {
+	if !entity.Empty(o.AddonName) {
+		return false
+	}
+	if !entity.Empty(o.AssociationCount) {
+		return false
+	}
+	if !entity.Empty(o.Password) {
+		return false
+	}
+	if !entity.Empty(o.SandboxPool) {
+		return false
+	}
+	if !entity.Empty(o.Service) {
+		return false
+	}
+	if !entity.Empty(o.Status) {
+		return false
+	}
+	if !entity.Empty(o.Variant) {
+		return false
+	}
+	return true
+}
+
+func (o *RabbitmqServer) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("addon_name", "dev.miren.addon/rabbitmq_server.addon_name", schema.Indexed)
+	sb.Int64("association_count", "dev.miren.addon/rabbitmq_server.association_count")
+	sb.String("password", "dev.miren.addon/rabbitmq_server.password")
+	sb.Ref("sandbox_pool", "dev.miren.addon/rabbitmq_server.sandbox_pool")
+	sb.Ref("service", "dev.miren.addon/rabbitmq_server.service")
+	sb.String("status", "dev.miren.addon/rabbitmq_server.status")
+	sb.String("variant", "dev.miren.addon/rabbitmq_server.variant")
+}
+
+const (
 	ValkeyDedicatedDataValkeyServerId = entity.Id("dev.miren.addon/valkey_dedicated_data.valkey_server")
 )
 
@@ -1068,6 +1239,8 @@ var (
 	KindPostgresServer          = entity.Id("dev.miren.addon/kind.postgres_server")
 	KindPostgresqlDedicatedData = entity.Id("dev.miren.addon/kind.postgresql_dedicated_data")
 	KindPostgresqlSharedData    = entity.Id("dev.miren.addon/kind.postgresql_shared_data")
+	KindRabbitmqDedicatedData   = entity.Id("dev.miren.addon/kind.rabbitmq_dedicated_data")
+	KindRabbitmqServer          = entity.Id("dev.miren.addon/kind.rabbitmq_server")
 	KindValkeyDedicatedData     = entity.Id("dev.miren.addon/kind.valkey_dedicated_data")
 	KindValkeyServer            = entity.Id("dev.miren.addon/kind.valkey_server")
 	Schema                      = entity.Id("dev.miren.addon/schema.v1alpha")
@@ -1083,8 +1256,10 @@ func init() {
 		(&PostgresServer{}).InitSchema(sb)
 		(&PostgresqlDedicatedData{}).InitSchema(sb)
 		(&PostgresqlSharedData{}).InitSchema(sb)
+		(&RabbitmqDedicatedData{}).InitSchema(sb)
+		(&RabbitmqServer{}).InitSchema(sb)
 		(&ValkeyDedicatedData{}).InitSchema(sb)
 		(&ValkeyServer{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.addon", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\xa4\x98[\xae\xdb,\x10\xc7\xd7\xf1ݿޯ\xca\xd1i\xabJ]\x8dE\fqh\xb0\xf1\x01\xecƏm\xa5v!\xbd<t\x7f\xedsepb`\x00㜗\xc8\x191?\x03\xf3\x9fa\xf0Wܠ\x9apL\xfaMM\x05i6\bcސ\x03m\xb0\xfcq\xfcӳ_\x8dv\xf3\xf8];v\xfe\x00\xcb\xfd\xd7\x0e\xf3\x1a\xd1Ƈ\xefv\x940,?}\xd9R||\x10\x04l0١\x8e\xa9\xa2G\x82\xa2F\x9d&\xe9\x1a\xd5В\x9dT\x826\x95f݉\xb1d)h\xab(o4\xe7`\x1b|\xc6\xdd\b\x83ʖ\xa1\xa1\x18\xfd5\x849\x16\x9fr/La\xbcD\x8c\xaa\xa1\xa896\x98\xda5\xf9\x1c\xb0\xff\x86s\x9e\x05\xf6\xdf\xfem\xf4\xfa7\xec5m\x9b\xc45j\x86\x9f\xdau\x7f\xb6\x8d\fZ\xf2\xba\xe5\ri\xd4\xfcd\xc2\f\x90\x1b\x17\x99\x15\xf0\x8fzI\xf7\xfdɝ\x18\xd9q\xd2k\xfc?\x81Q\x882{\x95\xd5ɴ\xb0ȇ\xe9E\x9e\xc8Y\x8b\xfd\xa0\x17\xfb\x97?\xcb\t\xb19\x90A\xbf\xb3\x1c\x1f\xfc\xa8\xff\x13\xf3\xea\x11\xebL̉y\xb4<\xab\x9e\bIyS\xf5\u05c8\xb5{\xc4ZAk$\x86b\x9c\xedi\a\xc2\xf8\xf3\x02\xe3\xbaJ\xd2\xcf*J\x8e\"\xfae0IuI\xa9\ay\xc3\nIDO\xc4\x14\x8d\xbf\xfd\x81\xf6\x98\xac\x18|\xd6\xcb}\x94\xe2\x18Ӝ\xd6o\xad\xff~X6i\x90\x94\xbc\xa4h\x14kQ\xf2n\xaaY7\xd0<bK\xda(\xcd|\x9ad\n\xceU\xd1\")\xdfq\x81M\xbdpM\xfe\x14\x9f$q\x125xˏE\xcb93E̱\x8c\xb0-\xc5\xe1,uAD\xf4\xb44;V\x9d\xfe\xd8\xee\xa0\xfe\xb9\xee\n\xa9Nj\xef\xdd\xf4\xec/$\xfd~\xfbT\xa8\x02\xa7AR\x87\xccF\xc1z\xaf\xe5\xd8#v \x83\xab\xc7@\xdaX\x83V\b\xf2q\x12\xb4F\x91W\v\xa4\x8b$\xe9WA\x0f\xea\xc8q\x1fU\"\x10\xb6KY!E\xd0!x\xa4%-\x06\x0e\x1c\xc7\x7fY\x8c\v3\xb8\x95\x1ak\x87\x05'\xab\xe5\xd8r\xa9*A\xa4+\xc8\xff\xfc\xb1ް\x15\x92\x04\xd1\xf2PkDy\xbdȺH\x96ϗ\xb0+$\x05\x8e\x04\xc0Z\x12\x15H\x12@X\x96ՋEF\xd7\x12\xd1I\"\xdc3@\x04\xec>{q\x85\xb7\x12-\xf7hp;\xe6{Ba\xc5u\x12n\xb8O\xb7\a\xae\xb8@\x80\x95\x02\x98\xb1\x9b\xb6\xc9<&\xcbK\xc0\xbfmM\xb36>ؾ\xa0\xfeB_\"\x04\x17EM\xa4D\xd5\xd4\xf2\xbb&?r\xe0t\x80̴\xb6t{\xfcl\x99\xa2\x83\xbee\xc4\xee\x94\xe9l\\\xe8\x95\xfd\x17\xc0`\xcf/Xq;\b\xf7\xa6#$\xdd2\x83\x86c\xf6\x93\xa4\x91T\xd1\xde\xec>\x9d\xff\x8e\f\xbc\xe5\x9ci\x02\xa8\xa63\xe1\xe2\xb6{\xde\xcepw\x16ٳK\xd3\xf2\x06\xf0\"\x899u@{$\b.0R(\x96\x98`\xe0\x8aP\x82\xe4\x00\xb0\xcd\xf8\xb3E\x92\xcc\aK\xed\x9ar[p\x8biww\xe6\x18p,v\xfaƚo\x8b6V\xd9\xf3\xe4\xf6\xe7\x7f\xd9\x11\x01D(\x02+\"\x98`Z\"\xe5\x06%\xd2\n\xbbc\xb3\xe2\xf2>|>\x87x\x99ۘ\\\xbc\n\x81\xe1\xa6\xdb\rwp\x03b\xed\xd7\xc5;\xf02\v\xe8^\x02\x8c:]S\xce&tA6\xac\xcfN\x9f\x17L\xceh\xcbqq\x86\xbe\xca#\xaeO\xd3י`\xaf\x8d0_\xf9|c\xf2\xc0\x8d\x80o\x99\xb6}\x18\vˏ\x1f\xb5\xa0~A\xc6G\x1dVh\xf8M6t\xd5.'\xb7\xe5\xf8G\xf4%\xbe\xdfA\xee\xb9P\x85\xf9\x8c<}\xf9I|Lv\xef\xe4˟\x88\xbc[S\xc6%\x1e\xb4\xacY7\xad\xec\x13\x15\x8c\vT\xfe̳8\\6\xf3\x8f\x8dH\xc5YQwc\xf2_S\xb4\x12ZY\x9bF\xbf\x01\x00\x00\xff\xff\x01\x00\x00\xff\xff7\xd4l\x1e\xa3\x18\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.addon", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\xa4\x99ٮ\xf34\x10ǟ\x83}\xdfQ?}\x80@<M\xe4\xc6nk\x9a\xc49\xb6\x9bsz\tH\xf0 ,W\xbc\x1e\\\xa3\xd8ic\xcfxMo\x8eґ\xe7\x17\xdb\xf3\x9f\xb1'\xe7O:\x90\x9e\tʦ]\xcf%\x1bv\x84R1\xb03\x1f\xa8\xfa\xe7\xe5M`\x7f5\xdb\xed\xe3\xdf\xc6\xf1\x02\a8\xee\xff\x1d\xa8\xe8\t\x1f \xfcpଣ\xea\xb7?\xf6\x9c\xbe|\x12\x04\xec(;\x90K\xa7\x9b\x89HN\x06}\x9b\xa4o\xd4ב\x1d\x94\x96|8\x1a\xd6\a1\x96j%\x1f5\x17\x83\xe1\x9c]\x03d|\x18ap5v\xe4\xda\xcc\xfe\x06\xd2y\x16H\xf9(L\xe9DK:\xae\xafM/\xa8\xc5\xf4\xbe\tr\xd0\xfe[\xce}\x16\x14\xbe\xfd\xaf\xd9\xebݰײm\x8a\xf6d\xb8\xfek\\Ow\xdb\xcc\xe0\xad\xe8G1\xb0A\xafO6\xcc\b\xb9\xf3\x91E\x01\xff\xd5,\xe9c8\xb9\x1b\xa38Nf\x8d\xef'0\x9a\xf0\xce]\xe5\xf1f\xca,\xf2\xd3\xf4\"o\xe4\xa2\xc5\xfeb\x16\xfb\x16\x9c\xe5\x82؝\xd9ռ\xb3\x9d\x1f`\xd4߉yM\xa4\xbbؘ3\xfb\xe8x\x1e'&\x15\x17\xc3qzM\xba\xf1D\xbaQ\xf2\x9e\xc8k3\xcf\xf6\xb6\x03a\xfc}\x81q]%\xe9w\x15%G1\xf32\x9c\xa4\xa6\xa4\xf4W\xf5\xd45\x8aɉ\xc9%\x1aoÁ\ue622\x18\xfcn\x96\xfbY\x8acMkZ\xff\xe4\xfc\x86a٥AJ\x89\x96\x93Y\xacM+.K\xcdz\xc2\xe6\x19\xdb\xf2A\x1b\xe6\x97I\xa6\x14B7#Q\xeaYHj\xeb\x85o\x82S\xfc\"\x89Sd\xa0{\xf1ҌBt\xb6\x88y\x96\x19\xb6\xe74\x9c\xa5>\x88ɉ\xb7vǎ\xb7\x1f\xae;\xaa\x7f\xbe\xbb&\xfa\xa2\x8c\xf7ay\x86\vI\xbf\xdf=\x15\x8e\x81\xd3 \xa9\xc3\xceE\xe1zo\xe48\x91\xee̮\xbe\x1e\x03i\xe3\f\xaa\x10\xe4\xe7IP\x8d\"_eH\x9b$\t\xab \x80zr<E\x95\x88\x84\xedS*\xa4\x88n\b\x80\x94\xd3b\xe0\xc0\xf1\xfc\xf3b\xcc\xcc\xe0!5\xf6\x1e\vO\xd6\xc8q\x14J\x1f%S\xbe ߃c\xc1\xb0\nI\xa2h\x01T\x8d(_gY\x9bd\xf9u\x0e[!)t$ VNT(I\x10!/\xabo\xb2\x8c\xcb\xc8\xe4E1\xe9\x9f\x012`\x87\xec\xec\n\x1f\x12\xad\x00\xb4\x88l%\xd9\xef\xb9\xee\x9f2\xb2\x05\xc3\x1e\x91-@=$[\xc4\xda$[T\xec!\xb6\xb0\x9e\"\xf9C\xce#\xf2G\xacj\xf9#B^\xfe\xd9Y<&Q@\xc3S^[\xd9Ɖ\xe1\"\xd2p+\xe9\x0e\xac\xe8q\xd1J\x11\xcc\xda\xed\xcd\xde>&O\xc0\x80\xff8\xda~b~p}\xd1\x15\x01\xfb2)\x85lz\xa6\x149.]\xa9o\x82\x91C\x9a\xc6\xcct\xfcM\a\xf7U\x9eb\x82\xbe\xef\x98\xdb\xcc\xf1\u0558i\xe7\xe0\vp\xb0\xd7\x17T4\xb0\xe1\xf6i\x86\xa4\xbb:t'^\xfd\x14\x1b\x14\xd7|\xb2\xbb\xcfן3\x83\xee\x85\xe8\f\x01UΕ\xb0\xb93\\\xb73\xdc@D\xf6lkZ>!^$1\x97K\xfa\x89HF\x1bJ4\x89%&\x1aX\x11J\x94\x1c\b\xb6\x9b\xff\xec\x89b\xeb!\xd2\xfb\xa6\xd2.\xd1a\xba\r\x88-՞\xc5M\xdfX\x7f\xe8\xd0\xe6\x8b\xc0}r\xa7\xfb\xaf\xe2\x88 \"\x16\x81\x13\x11\xca(o\x89\xf6\x83\x12\xe9\xd6\xfc\xb1Eq\xf99|\x16\x87x\x85ۘ\\\xbc\x0e\x81\xf1\xa6\xbb=ap\x03b\x1d\xc2\xe6\x1d\xf8\xb6\b\xe8\xf7\xa9V\x9d\xbe\xa9d\x13.A6\xae\xcf^+\x12L\xce\xe8\xadxs\x86~WF\xacO\xd3\xef\v\xc1\xe0\xa6k?DCc\xf2\xc0\x8d\x80\x1fL\xdb)\x8c\xc5\xf7D\xff&\x1eTo\xfc&\xb6Y\xbf?\x14\"a\x8f`\xf7\x17\x1aKT\xfc\x1cy\x03.\xc8P\xc7\xc1=A50\xeaP\xb1+?\x16C\xabt\x97ܗ\x977\xa2/\x81~gu\x12R7\xf6\x7f?\xcb\xe7\xda\xc4\x7f\x80\xfc\x0fi\xf9\xef\xba\xe0SG\xc1\x97\xb7\xc2>\x13\x8cBW\xff\xa2\xee\xb4\xf8f\x82\xc6\x05N\xd0\xc2;M\xf8\xf8)?~#\x95\xbb\xe2\xfc\x8a\x95\x91\x9a\xe2\x1fͼ\xaaZ\x94\xd0im\n\xff\x0f\x00\x00\xff\xff\x01\x00\x00\xff\xff/X`~\xd4\x1c\x00\x00"))
 }

--- a/api/addon/schema.yml
+++ b/api/addon/schema.yml
@@ -134,3 +134,24 @@ kinds:
   valkey_dedicated_data:
     valkey_server:
       type: ref
+
+  rabbitmq_server:
+    addon_name:
+      type: string
+      indexed: true
+    variant:
+      type: string
+    sandbox_pool:
+      type: ref
+    service:
+      type: ref
+    status:
+      type: string
+    association_count:
+      type: int
+    password:
+      type: string
+
+  rabbitmq_dedicated_data:
+    rabbitmq_server:
+      type: ref

--- a/blackbox/addon_rabbitmq_test.go
+++ b/blackbox/addon_rabbitmq_test.go
@@ -1,0 +1,91 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+func TestRabbitmqAddonCreateListDestroy(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+
+	// Create a small (dedicated) RabbitMQ addon on the app
+	m.MustRun("addon", "create", "miren-rabbitmq:small", "-a", name)
+
+	// Wait for addon to appear and provisioning to complete.
+	harness.WaitForAddonReady(t, m, name, "miren-rabbitmq", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "RABBITMQ_URL", 5*time.Minute)
+
+	// Verify RabbitMQ-specific env vars are injected
+	harness.WaitForEnvVar(t, m, name, "RABBITMQ_HOST", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "RABBITMQ_PORT", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "RABBITMQ_USER", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "RABBITMQ_PASSWORD", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "RABBITMQ_VHOST", 30*time.Second)
+
+	// Destroy the addon
+	m.MustRun("addon", "destroy", "miren-rabbitmq", "-a", name, "--force")
+}
+
+func TestRabbitmqAddonDeployWithAppToml(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.UniqueAppName(t, "bun-rabbitmq")
+
+	hostDir := filepath.Join(c.TestdataDir, "bun-rabbitmq")
+	containerDir := m.ContainerPath(hostDir)
+
+	t.Cleanup(func() {
+		t.Logf("cleaning up app %s", name)
+		m.Run("app", "delete", name, "-f")
+	})
+
+	// Deploy without waiting for healthy — the app depends on RABBITMQ_HOST
+	// which is only injected after addon provisioning completes.
+	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
+
+	// Wait for addon provisioning to complete.
+	harness.WaitForAddonReady(t, m, name, "miren-rabbitmq", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "RABBITMQ_HOST", 5*time.Minute)
+
+	// Now wait for the app to become healthy
+	harness.WaitForAppReady(t, m, name, 3*time.Minute)
+
+	// Verify addon is listed
+	r := m.MustRun("addon", "list", "-a", name, "--format", "json")
+	r.RequireContains(t, "miren-rabbitmq")
+
+	// Set a route and verify the app responds with RabbitMQ connectivity
+	host := name + ".test.local"
+	m.MustRun("route", "set", host, name)
+
+	harness.Poll(t, "app responds via route", 30*time.Second, 2*time.Second, func() (bool, string) {
+		code, body, err := harness.HTTPGet(m, host, "/health")
+		if err != nil {
+			return false, err.Error()
+		}
+		if code != 200 {
+			return false, "status " + body
+		}
+		return true, ""
+	})
+
+	// Verify the root endpoint works (exercises RabbitMQ publish/consume)
+	code, body, err := harness.HTTPGet(m, host, "/")
+	if err != nil {
+		t.Fatalf("HTTP GET / failed: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected status 200, got %d: %s", code, body)
+	}
+}

--- a/blackbox/addon_test.go
+++ b/blackbox/addon_test.go
@@ -18,6 +18,7 @@ func TestAddonListAvailable(t *testing.T) {
 	r.RequireContains(t, "miren-postgresql")
 	r.RequireContains(t, "miren-mysql")
 	r.RequireContains(t, "miren-valkey")
+	r.RequireContains(t, "miren-rabbitmq")
 }
 
 func TestAddonVariants(t *testing.T) {
@@ -33,6 +34,9 @@ func TestAddonVariants(t *testing.T) {
 	r.RequireContains(t, "shared")
 
 	r = m.MustRun("addon", "variants", "miren-valkey")
+	r.RequireContains(t, "small")
+
+	r = m.MustRun("addon", "variants", "miren-rabbitmq")
 	r.RequireContains(t, "small")
 }
 

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -52,6 +52,7 @@ import (
 	"miren.dev/runtime/pkg/addon"
 	"miren.dev/runtime/pkg/addon/mysql"
 	"miren.dev/runtime/pkg/addon/postgresql"
+	"miren.dev/runtime/pkg/addon/rabbitmq"
 	"miren.dev/runtime/pkg/addon/valkey"
 	"miren.dev/runtime/pkg/caauth"
 	"miren.dev/runtime/pkg/cloudauth"
@@ -868,6 +869,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	addonRegistry.Register(postgresql.AddonName, postgresql.NewProvider(addonFw), postgresql.Definition())
 	addonRegistry.Register(mysql.AddonName, mysql.NewProvider(addonFw), mysql.Definition())
 	addonRegistry.Register(valkey.AddonName, valkey.NewProvider(addonFw), valkey.Definition())
+	addonRegistry.Register(rabbitmq.AddonName, rabbitmq.NewProvider(addonFw), rabbitmq.Definition())
 
 	if err := addonRegistry.EnsureEntities(ctx, ec); err != nil {
 		c.Log.Error("failed to ensure addon entities", "error", err)

--- a/pkg/addon/rabbitmq/dedicated.go
+++ b/pkg/addon/rabbitmq/dedicated.go
@@ -1,0 +1,376 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/dbsaga"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/saga"
+)
+
+const (
+	rabbitmqPort     = 5672
+	defaultUser      = "miren"
+	defaultVhost     = "miren"
+	poolReadyTimeout = 5 * time.Minute
+)
+
+func rabbitmqContainerPorts() []compute_v1alpha.SandboxSpecContainerPort {
+	return []compute_v1alpha.SandboxSpecContainerPort{
+		{
+			Name:     "amqp",
+			Port:     rabbitmqPort,
+			Protocol: compute_v1alpha.SandboxSpecContainerPortTCP,
+		},
+	}
+}
+
+type resultCapture struct {
+	Result *addon.ProvisionResult
+}
+
+// --- Dedicated Provisioning Saga Actions ---
+
+type GenerateCredentialsIn struct {
+	AppName string
+}
+
+type GenerateCredentialsOut struct {
+	Password    string `saga:"password"`
+	Username    string `saga:"username"`
+	Vhost       string `saga:"vhost"`
+	ServiceName string `saga:"servicename"`
+	ServerName  string `saga:"servername"`
+}
+
+func GenerateCredentials(ctx context.Context, in GenerateCredentialsIn) (GenerateCredentialsOut, error) {
+	return GenerateCredentialsOut{
+		Password:    idgen.Gen("pw"),
+		Username:    defaultUser,
+		Vhost:       defaultVhost,
+		ServiceName: fmt.Sprintf("%s-rabbitmq", in.AppName),
+		ServerName:  fmt.Sprintf("rmq-%s-%s", in.AppName, idgen.Gen("s")),
+	}, nil
+}
+
+func UndoGenerateCredentials(ctx context.Context, in GenerateCredentialsIn, out GenerateCredentialsOut) error {
+	return nil
+}
+
+type CreateRabbitmqServerIn struct {
+	ServerName  string `saga:"servername"`
+	VariantName string `saga:"variantname"`
+	Password    string `saga:"password"`
+}
+
+type CreateRabbitmqServerOut struct {
+	ServerID entity.Id `saga:"serverid"`
+}
+
+func CreateRabbitmqServer(ctx context.Context, in CreateRabbitmqServerIn) (CreateRabbitmqServerOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	server := &addon_v1alpha.RabbitmqServer{
+		AddonName:        AddonName,
+		Variant:          in.VariantName,
+		Status:           "provisioning",
+		AssociationCount: 1,
+		Password:         in.Password,
+	}
+
+	serverID, err := fw.EC.Create(ctx, in.ServerName, server)
+	if err != nil {
+		return CreateRabbitmqServerOut{}, fmt.Errorf("creating rabbitmq server entity: %w", err)
+	}
+
+	return CreateRabbitmqServerOut{ServerID: serverID}, nil
+}
+
+func UndoCreateRabbitmqServer(ctx context.Context, in CreateRabbitmqServerIn, out CreateRabbitmqServerOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.EC.Delete(ctx, out.ServerID)
+}
+
+type CreateDedicatedPoolIn struct {
+	ServerName string `saga:"servername"`
+	AppName    string `saga:"appname"`
+	Password   string `saga:"password"`
+	Username   string `saga:"username"`
+	Vhost      string `saga:"vhost"`
+}
+
+type CreateDedicatedPoolOut struct {
+	PoolID entity.Id `saga:"poolid"`
+}
+
+func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateDedicatedPoolOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	labels := types.LabelSet(
+		"addon", AddonName,
+		"app", in.AppName,
+		"server", in.ServerName,
+	)
+
+	poolID, err := fw.CreateSandboxPool(ctx, addon.CreateSandboxPoolSpec{
+		Name:  in.ServerName,
+		Image: DefaultImage,
+		Env: []string{
+			fmt.Sprintf("RABBITMQ_DEFAULT_USER=%s", in.Username),
+			fmt.Sprintf("RABBITMQ_DEFAULT_PASS=%s", in.Password),
+			fmt.Sprintf("RABBITMQ_DEFAULT_VHOST=%s", in.Vhost),
+		},
+		Ports:            rabbitmqContainerPorts(),
+		DesiredInstances: 1,
+		Labels:           labels,
+		SandboxPrefix:    fmt.Sprintf("%s-rmq", in.AppName),
+	})
+	if err != nil {
+		return CreateDedicatedPoolOut{}, fmt.Errorf("creating sandbox pool: %w", err)
+	}
+
+	return CreateDedicatedPoolOut{PoolID: poolID}, nil
+}
+
+func UndoCreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn, out CreateDedicatedPoolOut) error {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.DeleteSandboxPool(ctx, out.PoolID)
+}
+
+type UpdateDedicatedServerIn struct {
+	ServerID    entity.Id `saga:"serverid"`
+	PoolID      entity.Id `saga:"poolid"`
+	ServiceID   entity.Id `saga:"serviceid"`
+	ServiceHost string    `saga:"servicehost"`
+	VariantName string    `saga:"variantname"`
+	Password    string    `saga:"password"`
+}
+
+type UpdateDedicatedServerOut struct {
+	Updated bool
+}
+
+func UpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn) (UpdateDedicatedServerOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	server := &addon_v1alpha.RabbitmqServer{
+		AddonName:        AddonName,
+		Variant:          in.VariantName,
+		Status:           "active",
+		AssociationCount: 1,
+		Password:         in.Password,
+		SandboxPool:      in.PoolID,
+		Service:          in.ServiceID,
+	}
+	server.ID = in.ServerID
+
+	if err := fw.EC.Update(ctx, server); err != nil {
+		return UpdateDedicatedServerOut{}, fmt.Errorf("updating rabbitmq server: %w", err)
+	}
+
+	return UpdateDedicatedServerOut{Updated: true}, nil
+}
+
+func UndoUpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn, out UpdateDedicatedServerOut) error {
+	return nil
+}
+
+type BuildDedicatedResultIn struct {
+	ServiceHost string    `saga:"servicehost"`
+	ServerID    entity.Id `saga:"serverid"`
+	Username    string    `saga:"username"`
+	Password    string    `saga:"password"`
+	Vhost       string    `saga:"vhost"`
+}
+
+type BuildDedicatedResultOut struct {
+	Done bool
+}
+
+func BuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn) (BuildDedicatedResultOut, error) {
+	rc := saga.Get[*resultCapture](ctx)
+
+	envVars := buildEnvVars(in.Username, in.Password, in.ServiceHost, rabbitmqPort, in.Vhost)
+
+	dedicatedData := &addon_v1alpha.RabbitmqDedicatedData{
+		RabbitmqServer: in.ServerID,
+	}
+
+	rc.Result = &addon.ProvisionResult{
+		EnvVars: envVars,
+		Attrs:   dedicatedData.Encode(),
+	}
+
+	return BuildDedicatedResultOut{Done: true}, nil
+}
+
+func UndoBuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn, out BuildDedicatedResultOut) error {
+	return nil
+}
+
+func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+	cfg := &dbsaga.AddonConfig{AddonName: AddonName, Port: rabbitmqPort, ReadyTimeout: poolReadyTimeout}
+	return saga.Define("provision-dedicated-rabbitmq").
+		Using(fw).
+		Using(rc).
+		Using(cfg).
+		Action(GenerateCredentials).Undo(UndoGenerateCredentials).
+		Action(CreateRabbitmqServer).Undo(UndoCreateRabbitmqServer).
+		Action(CreateDedicatedPool).Undo(UndoCreateDedicatedPool).
+		Action(dbsaga.WaitForDedicatedPool).Undo(dbsaga.UndoWaitForDedicatedPool).
+		Action(dbsaga.CreateDedicatedService).Undo(dbsaga.UndoCreateDedicatedService).
+		Action(dbsaga.WaitForDedicatedService).Undo(dbsaga.UndoWaitForDedicatedService).
+		Action(UpdateDedicatedServer).Undo(UndoUpdateDedicatedServer).
+		Action(BuildDedicatedResult).Undo(UndoBuildDedicatedResult).
+		RegisterTo(registry)
+}
+
+// --- Dedicated Deprovisioning Saga Actions ---
+
+type DecodeDedicatedAttrsIn struct {
+	AssocEntity *entity.Entity `saga:"assocentity"`
+}
+
+type DecodeDedicatedAttrsOut struct {
+	DedicatedServerID entity.Id `saga:"dedicatedserverid"`
+}
+
+func DecodeDedicatedAttrs(ctx context.Context, in DecodeDedicatedAttrsIn) (DecodeDedicatedAttrsOut, error) {
+	var data addon_v1alpha.RabbitmqDedicatedData
+	if in.AssocEntity != nil {
+		data.Decode(in.AssocEntity)
+	}
+
+	if data.RabbitmqServer == "" {
+		return DecodeDedicatedAttrsOut{}, fmt.Errorf("no rabbitmq server ref found")
+	}
+
+	return DecodeDedicatedAttrsOut{DedicatedServerID: data.RabbitmqServer}, nil
+}
+
+func UndoDecodeDedicatedAttrs(ctx context.Context, in DecodeDedicatedAttrsIn, out DecodeDedicatedAttrsOut) error {
+	return nil
+}
+
+type LookupDedicatedServerIn struct {
+	DedicatedServerID entity.Id `saga:"dedicatedserverid"`
+}
+
+type LookupDedicatedServerOut struct {
+	DedicatedServiceID entity.Id `saga:"dedicatedserviceid"`
+	DedicatedPoolID    entity.Id `saga:"dedicatedpoolid"`
+}
+
+func LookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn) (LookupDedicatedServerOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.RabbitmqServer
+	if err := fw.EC.GetById(ctx, in.DedicatedServerID, &server); err != nil {
+		return LookupDedicatedServerOut{}, fmt.Errorf("looking up rabbitmq server: %w", err)
+	}
+
+	return LookupDedicatedServerOut{
+		DedicatedServiceID: server.Service,
+		DedicatedPoolID:    server.SandboxPool,
+	}, nil
+}
+
+func UndoLookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn, out LookupDedicatedServerOut) error {
+	return nil
+}
+
+type DeleteDedicatedServerEntityIn struct {
+	DedicatedServerID entity.Id `saga:"dedicatedserverid"`
+
+	PoolCleanedUp saga.Edge `saga:"dedicated_pool_deleted"`
+}
+
+type DeleteDedicatedServerEntityOut struct {
+	ServerDeleted bool
+}
+
+func DeleteDedicatedServerEntity(ctx context.Context, in DeleteDedicatedServerEntityIn) (DeleteDedicatedServerEntityOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	if err := fw.EC.Delete(ctx, in.DedicatedServerID); err != nil {
+		return DeleteDedicatedServerEntityOut{}, fmt.Errorf("deleting rabbitmq server: %w", err)
+	}
+
+	return DeleteDedicatedServerEntityOut{ServerDeleted: true}, nil
+}
+
+func UndoDeleteDedicatedServerEntity(ctx context.Context, in DeleteDedicatedServerEntityIn, out DeleteDedicatedServerEntityOut) error {
+	return nil
+}
+
+func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
+	return saga.Define("deprovision-dedicated-rabbitmq").
+		Using(fw).
+		Action(DecodeDedicatedAttrs).Undo(UndoDecodeDedicatedAttrs).
+		Action(LookupDedicatedServer).Undo(UndoLookupDedicatedServer).
+		Action(dbsaga.DeleteDedicatedService).Undo(dbsaga.UndoDeleteDedicatedService).
+		Action(dbsaga.DeleteDedicatedPool).Undo(dbsaga.UndoDeleteDedicatedPool).
+		Action(DeleteDedicatedServerEntity).Undo(UndoDeleteDedicatedServerEntity).
+		RegisterTo(registry)
+}
+
+func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+	p.Log.Info("provisioning dedicated RabbitMQ",
+		"app", app.Name,
+		"variant", variant.Name)
+
+	rc := &resultCapture{}
+	registry := saga.NewRegistry()
+
+	if err := RegisterDedicatedSaga(registry, p.Fw, rc); err != nil {
+		return nil, fmt.Errorf("registering dedicated saga: %w", err)
+	}
+
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
+
+	err := executor.Start("provision-dedicated-rabbitmq").
+		Input("appname", app.Name).
+		Input("variantname", variant.Name).
+		Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if rc.Result == nil {
+		return nil, fmt.Errorf("saga completed but no result was captured")
+	}
+
+	p.Log.Info("dedicated RabbitMQ provisioned", "app", app.Name)
+	return rc.Result, nil
+}
+
+func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAssociation) error {
+	p.Log.Info("deprovisioning dedicated RabbitMQ", "assoc", assoc.ID)
+
+	registry := saga.NewRegistry()
+
+	if err := RegisterDeprovisionDedicatedSaga(registry, p.Fw); err != nil {
+		return fmt.Errorf("registering deprovision saga: %w", err)
+	}
+
+	storage := p.Fw.Storage
+	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
+
+	err := executor.Start("deprovision-dedicated-rabbitmq").
+		Input("assocentity", assoc.Entity).
+		Execute(ctx)
+	if err != nil {
+		return err
+	}
+
+	p.Log.Info("dedicated RabbitMQ deprovisioned", "assoc", assoc.ID)
+	return nil
+}

--- a/pkg/addon/rabbitmq/dedicated.go
+++ b/pkg/addon/rabbitmq/dedicated.go
@@ -7,6 +7,7 @@ import (
 
 	"miren.dev/runtime/api/addon/addon_v1alpha"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/pkg/addon"
 	"miren.dev/runtime/pkg/addon/dbsaga"
 	"miren.dev/runtime/pkg/entity"
@@ -99,11 +100,12 @@ func UndoCreateRabbitmqServer(ctx context.Context, in CreateRabbitmqServerIn, ou
 }
 
 type CreateDedicatedPoolIn struct {
-	ServerName string `saga:"servername"`
-	AppName    string `saga:"appname"`
-	Password   string `saga:"password"`
-	Username   string `saga:"username"`
-	Vhost      string `saga:"vhost"`
+	ServerName    string            `saga:"servername"`
+	AppName       string            `saga:"appname"`
+	Password      string            `saga:"password"`
+	Username      string            `saga:"username"`
+	Vhost         string            `saga:"vhost"`
+	VariantConfig map[string]string `saga:"variantconfig"`
 }
 
 type CreateDedicatedPoolOut struct {
@@ -119,6 +121,10 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 		"server", in.ServerName,
 	)
 
+	sizeGb := addon.ParseStorageGb(in.VariantConfig[ConfigStorage])
+	diskName := fmt.Sprintf("rmq-%s-data", in.ServerName)
+	mountPath := "/var/lib/rabbitmq"
+
 	poolID, err := fw.CreateSandboxPool(ctx, addon.CreateSandboxPoolSpec{
 		Name:  in.ServerName,
 		Image: DefaultImage,
@@ -131,6 +137,20 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 		DesiredInstances: 1,
 		Labels:           labels,
 		SandboxPrefix:    fmt.Sprintf("%s-rmq", in.AppName),
+		Mounts: []compute_v1alpha.SandboxSpecContainerMount{
+			{Source: "rmqdata", Destination: mountPath},
+		},
+		Volumes: []compute_v1alpha.SandboxSpecVolume{
+			{
+				Name:         "rmqdata",
+				Provider:     "miren",
+				DiskName:     diskName,
+				MountPath:    mountPath,
+				SizeGb:       sizeGb,
+				Filesystem:   "ext4",
+				LeaseTimeout: "5m",
+			},
+		},
 	})
 	if err != nil {
 		return CreateDedicatedPoolOut{}, fmt.Errorf("creating sandbox pool: %w", err)
@@ -141,7 +161,11 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 
 func UndoCreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn, out CreateDedicatedPoolOut) error {
 	fw := saga.Get[*addon.ProviderFramework](ctx)
-	return fw.DeleteSandboxPool(ctx, out.PoolID)
+	if err := fw.DeleteSandboxPool(ctx, out.PoolID); err != nil {
+		return err
+	}
+	diskName := fmt.Sprintf("rmq-%s-data", in.ServerName)
+	return fw.DeleteDiskByName(ctx, diskName)
 }
 
 type UpdateDedicatedServerIn struct {
@@ -264,8 +288,9 @@ type LookupDedicatedServerIn struct {
 }
 
 type LookupDedicatedServerOut struct {
-	DedicatedServiceID entity.Id `saga:"dedicatedserviceid"`
-	DedicatedPoolID    entity.Id `saga:"dedicatedpoolid"`
+	DedicatedServiceID  entity.Id `saga:"dedicatedserviceid"`
+	DedicatedPoolID     entity.Id `saga:"dedicatedpoolid"`
+	DedicatedServerName string    `saga:"dedicatedservername"`
 }
 
 func LookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn) (LookupDedicatedServerOut, error) {
@@ -276,9 +301,15 @@ func LookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn) (Loo
 		return LookupDedicatedServerOut{}, fmt.Errorf("looking up rabbitmq server: %w", err)
 	}
 
+	var meta core_v1alpha.Metadata
+	if err := fw.EC.GetById(ctx, in.DedicatedServerID, &meta); err != nil {
+		return LookupDedicatedServerOut{}, fmt.Errorf("looking up server metadata: %w", err)
+	}
+
 	return LookupDedicatedServerOut{
-		DedicatedServiceID: server.Service,
-		DedicatedPoolID:    server.SandboxPool,
+		DedicatedServiceID:  server.Service,
+		DedicatedPoolID:     server.SandboxPool,
+		DedicatedServerName: meta.Name,
 	}, nil
 }
 
@@ -287,9 +318,11 @@ func UndoLookupDedicatedServer(ctx context.Context, in LookupDedicatedServerIn, 
 }
 
 type DeleteDedicatedServerEntityIn struct {
-	DedicatedServerID entity.Id `saga:"dedicatedserverid"`
+	DedicatedServerID   entity.Id `saga:"dedicatedserverid"`
+	DedicatedServerName string    `saga:"dedicatedservername"`
 
-	PoolCleanedUp saga.Edge `saga:"dedicated_pool_deleted"`
+	ServiceCleanedUp saga.Edge `saga:"dedicated_service_deleted"`
+	PoolCleanedUp    saga.Edge `saga:"dedicated_pool_deleted"`
 }
 
 type DeleteDedicatedServerEntityOut struct {
@@ -298,6 +331,13 @@ type DeleteDedicatedServerEntityOut struct {
 
 func DeleteDedicatedServerEntity(ctx context.Context, in DeleteDedicatedServerEntityIn) (DeleteDedicatedServerEntityOut, error) {
 	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	if in.DedicatedServerName != "" {
+		diskName := fmt.Sprintf("rmq-%s-data", in.DedicatedServerName)
+		if err := fw.DeleteDiskByName(ctx, diskName); err != nil {
+			return DeleteDedicatedServerEntityOut{}, fmt.Errorf("deleting dedicated data disk %s: %w", diskName, err)
+		}
+	}
 
 	if err := fw.EC.Delete(ctx, in.DedicatedServerID); err != nil {
 		return DeleteDedicatedServerEntityOut{}, fmt.Errorf("deleting rabbitmq server: %w", err)
@@ -339,6 +379,7 @@ func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, varian
 	err := executor.Start("provision-dedicated-rabbitmq").
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
+		Input("variantconfig", variant.Config).
 		Execute(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/addon/rabbitmq/dedicated_test.go
+++ b/pkg/addon/rabbitmq/dedicated_test.go
@@ -1,0 +1,98 @@
+package rabbitmq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/saga"
+)
+
+func TestRegisterDedicatedSaga(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+	rc := &resultCapture{}
+
+	err := RegisterDedicatedSaga(registry, fw, rc)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("provision-dedicated-rabbitmq")
+	require.True(t, ok)
+	assert.Equal(t, "provision-dedicated-rabbitmq", def.Name)
+	assert.Len(t, def.Actions, 8)
+}
+
+func TestRegisterDeprovisionDedicatedSaga(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+
+	err := RegisterDeprovisionDedicatedSaga(registry, fw)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("deprovision-dedicated-rabbitmq")
+	require.True(t, ok)
+	assert.Equal(t, "deprovision-dedicated-rabbitmq", def.Name)
+	assert.Len(t, def.Actions, 5)
+}
+
+func TestDeprovisionDedicatedSagaOrder(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+
+	err := RegisterDeprovisionDedicatedSaga(registry, fw)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("deprovision-dedicated-rabbitmq")
+	require.True(t, ok)
+
+	order := def.ExecutionOrder()
+
+	indexOf := func(name string) int {
+		for i, n := range order {
+			if n == name {
+				return i
+			}
+		}
+		t.Fatalf("action %q not found in order %v", name, order)
+		return -1
+	}
+
+	assert.Less(t, indexOf("decode-dedicated-attrs"), indexOf("lookup-dedicated-server"),
+		"decode-dedicated-attrs must come before lookup-dedicated-server")
+	assert.Less(t, indexOf("lookup-dedicated-server"), indexOf("delete-dedicated-service"),
+		"lookup-dedicated-server must come before delete-dedicated-service")
+	assert.Less(t, indexOf("lookup-dedicated-server"), indexOf("delete-dedicated-pool"),
+		"lookup-dedicated-server must come before delete-dedicated-pool")
+	assert.Less(t, indexOf("delete-dedicated-pool"), indexOf("delete-dedicated-server-entity"),
+		"delete-dedicated-pool must come before delete-dedicated-server-entity")
+}
+
+func TestDedicatedSagaActionOrder(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+	rc := &resultCapture{}
+
+	err := RegisterDedicatedSaga(registry, fw, rc)
+	require.NoError(t, err)
+
+	def, ok := registry.Get("provision-dedicated-rabbitmq")
+	require.True(t, ok)
+
+	expectedActions := []string{
+		"generate-credentials",
+		"create-rabbitmq-server",
+		"create-dedicated-pool",
+		"wait-for-dedicated-pool",
+		"create-dedicated-service",
+		"wait-for-dedicated-service",
+		"update-dedicated-server",
+		"build-dedicated-result",
+	}
+
+	for _, name := range expectedActions {
+		_, exists := def.Actions[name]
+		assert.True(t, exists, "expected action %q to exist", name)
+	}
+}

--- a/pkg/addon/rabbitmq/dedicated_test.go
+++ b/pkg/addon/rabbitmq/dedicated_test.go
@@ -67,6 +67,8 @@ func TestDeprovisionDedicatedSagaOrder(t *testing.T) {
 		"lookup-dedicated-server must come before delete-dedicated-pool")
 	assert.Less(t, indexOf("delete-dedicated-pool"), indexOf("delete-dedicated-server-entity"),
 		"delete-dedicated-pool must come before delete-dedicated-server-entity")
+	assert.Less(t, indexOf("delete-dedicated-service"), indexOf("delete-dedicated-server-entity"),
+		"delete-dedicated-service must come before delete-dedicated-server-entity")
 }
 
 func TestDedicatedSagaActionOrder(t *testing.T) {

--- a/pkg/addon/rabbitmq/plans.go
+++ b/pkg/addon/rabbitmq/plans.go
@@ -9,6 +9,10 @@ const (
 	DefaultImage = "docker.io/library/rabbitmq:4"
 )
 
+const (
+	ConfigStorage = "storage"
+)
+
 func Definition() addon.AddonDefinition {
 	return addon.AddonDefinition{
 		Name:           AddonName,
@@ -19,6 +23,12 @@ func Definition() addon.AddonDefinition {
 			{
 				Name:        "small",
 				Description: "Dedicated RabbitMQ server",
+				Details: map[string]string{
+					"Storage": "1 GB",
+				},
+				Config: map[string]string{
+					ConfigStorage: "1Gi",
+				},
 			},
 		},
 	}

--- a/pkg/addon/rabbitmq/plans.go
+++ b/pkg/addon/rabbitmq/plans.go
@@ -1,0 +1,25 @@
+package rabbitmq
+
+import (
+	"miren.dev/runtime/pkg/addon"
+)
+
+const (
+	AddonName    = "miren-rabbitmq"
+	DefaultImage = "docker.io/library/rabbitmq:4"
+)
+
+func Definition() addon.AddonDefinition {
+	return addon.AddonDefinition{
+		Name:           AddonName,
+		DisplayName:    "Miren RabbitMQ",
+		Description:    "Managed RabbitMQ message broker",
+		DefaultVariant: "small",
+		Variants: []addon.VariantDefinition{
+			{
+				Name:        "small",
+				Description: "Dedicated RabbitMQ server",
+			},
+		},
+	}
+}

--- a/pkg/addon/rabbitmq/plans_test.go
+++ b/pkg/addon/rabbitmq/plans_test.go
@@ -14,6 +14,7 @@ func TestDefinitionHasAllVariants(t *testing.T) {
 	assert.Equal(t, "small", def.DefaultVariant)
 	assert.Len(t, def.Variants, 1)
 	assert.Equal(t, "small", def.Variants[0].Name)
+	assert.Equal(t, "1Gi", def.Variants[0].Config[ConfigStorage])
 }
 
 func TestBuildEnvVars(t *testing.T) {
@@ -43,6 +44,18 @@ func TestBuildEnvVars(t *testing.T) {
 }
 
 func TestBuildRabbitmqURL(t *testing.T) {
-	url := buildRabbitmqURL("user", "pass", "host.example.com", 5672, "myapp")
-	assert.Equal(t, "amqp://user:pass@host.example.com:5672/myapp", url)
+	t.Run("simple vhost", func(t *testing.T) {
+		u := buildRabbitmqURL("user", "pass", "host.example.com", 5672, "myapp")
+		assert.Equal(t, "amqp://user:pass@host.example.com:5672/myapp", u)
+	})
+
+	t.Run("root vhost is percent-encoded", func(t *testing.T) {
+		u := buildRabbitmqURL("user", "pass", "host.example.com", 5672, "/")
+		assert.Equal(t, "amqp://user:pass@host.example.com:5672/%2F", u)
+	})
+
+	t.Run("vhost with slash", func(t *testing.T) {
+		u := buildRabbitmqURL("user", "pass", "host.example.com", 5672, "my/app")
+		assert.Equal(t, "amqp://user:pass@host.example.com:5672/my%2Fapp", u)
+	})
 }

--- a/pkg/addon/rabbitmq/plans_test.go
+++ b/pkg/addon/rabbitmq/plans_test.go
@@ -1,0 +1,48 @@
+package rabbitmq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefinitionHasAllVariants(t *testing.T) {
+	def := Definition()
+
+	assert.Equal(t, AddonName, def.Name)
+	assert.Equal(t, "Miren RabbitMQ", def.DisplayName)
+	assert.Equal(t, "small", def.DefaultVariant)
+	assert.Len(t, def.Variants, 1)
+	assert.Equal(t, "small", def.Variants[0].Name)
+}
+
+func TestBuildEnvVars(t *testing.T) {
+	vars := buildEnvVars("miren", "secret", "myhost", 5672, "miren")
+
+	assert.Len(t, vars, 6)
+
+	varMap := make(map[string]string)
+	sensitiveMap := make(map[string]bool)
+	for _, v := range vars {
+		varMap[v.Key] = v.Value
+		sensitiveMap[v.Key] = v.Sensitive
+	}
+
+	assert.Equal(t, "amqp://miren:secret@myhost:5672/miren", varMap["RABBITMQ_URL"])
+	assert.True(t, sensitiveMap["RABBITMQ_URL"])
+	assert.Equal(t, "myhost", varMap["RABBITMQ_HOST"])
+	assert.False(t, sensitiveMap["RABBITMQ_HOST"])
+	assert.Equal(t, "5672", varMap["RABBITMQ_PORT"])
+	assert.False(t, sensitiveMap["RABBITMQ_PORT"])
+	assert.Equal(t, "miren", varMap["RABBITMQ_USER"])
+	assert.False(t, sensitiveMap["RABBITMQ_USER"])
+	assert.Equal(t, "secret", varMap["RABBITMQ_PASSWORD"])
+	assert.True(t, sensitiveMap["RABBITMQ_PASSWORD"])
+	assert.Equal(t, "miren", varMap["RABBITMQ_VHOST"])
+	assert.False(t, sensitiveMap["RABBITMQ_VHOST"])
+}
+
+func TestBuildRabbitmqURL(t *testing.T) {
+	url := buildRabbitmqURL("user", "pass", "host.example.com", 5672, "myapp")
+	assert.Equal(t, "amqp://user:pass@host.example.com:5672/myapp", url)
+}

--- a/pkg/addon/rabbitmq/provider.go
+++ b/pkg/addon/rabbitmq/provider.go
@@ -32,13 +32,16 @@ func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation
 }
 
 func buildRabbitmqURL(user, password, host string, port int, vhost string) string {
+	// Build the authority portion using url.URL for proper escaping of
+	// user/password, then append the vhost path manually. Per the AMQP URI
+	// spec, the vhost is a single path segment so slashes must be
+	// percent-encoded (e.g. the default vhost "/" becomes "/%2F").
 	u := url.URL{
 		Scheme: "amqp",
 		User:   url.UserPassword(user, password),
 		Host:   net.JoinHostPort(host, fmt.Sprintf("%d", port)),
-		Path:   "/" + vhost,
 	}
-	return u.String()
+	return u.String() + "/" + url.PathEscape(vhost)
 }
 
 func buildEnvVars(user, password, host string, port int, vhost string) []addon.Variable {

--- a/pkg/addon/rabbitmq/provider.go
+++ b/pkg/addon/rabbitmq/provider.go
@@ -1,0 +1,55 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/dbsaga"
+)
+
+type Provider struct {
+	dbsaga.BaseProvider
+}
+
+func NewProvider(fw *addon.ProviderFramework) *Provider {
+	return &Provider{
+		BaseProvider: dbsaga.BaseProvider{
+			Fw:  fw,
+			Log: fw.Log.With("addon", AddonName),
+		},
+	}
+}
+
+func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+	return p.provisionDedicated(ctx, app, variant)
+}
+
+func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation) error {
+	return p.deprovisionDedicated(ctx, assoc)
+}
+
+func buildRabbitmqURL(user, password, host string, port int, vhost string) string {
+	u := url.URL{
+		Scheme: "amqp",
+		User:   url.UserPassword(user, password),
+		Host:   net.JoinHostPort(host, fmt.Sprintf("%d", port)),
+		Path:   "/" + vhost,
+	}
+	return u.String()
+}
+
+func buildEnvVars(user, password, host string, port int, vhost string) []addon.Variable {
+	portStr := fmt.Sprintf("%d", port)
+
+	return []addon.Variable{
+		{Key: "RABBITMQ_URL", Value: buildRabbitmqURL(user, password, host, port, vhost), Sensitive: true},
+		{Key: "RABBITMQ_HOST", Value: host},
+		{Key: "RABBITMQ_PORT", Value: portStr},
+		{Key: "RABBITMQ_USER", Value: user},
+		{Key: "RABBITMQ_PASSWORD", Value: password, Sensitive: true},
+		{Key: "RABBITMQ_VHOST", Value: vhost},
+	}
+}

--- a/testdata/bun-rabbitmq/.miren/app.toml
+++ b/testdata/bun-rabbitmq/.miren/app.toml
@@ -1,0 +1,7 @@
+name = "bun-rabbitmq"
+
+[services.web]
+command = "bun run index.ts"
+
+[addons.miren-rabbitmq]
+variant = "small"

--- a/testdata/bun-rabbitmq/index.ts
+++ b/testdata/bun-rabbitmq/index.ts
@@ -1,0 +1,74 @@
+import * as amqp from "amqplib";
+
+const url = process.env.RABBITMQ_URL!;
+const testQueue = "bun-test-queue";
+
+async function publishAndConsume(): Promise<string> {
+  const conn = await amqp.connect(url);
+  const ch = await conn.createChannel();
+
+  await ch.assertQueue(testQueue, { durable: false });
+
+  const message = `hello-${Date.now()}`;
+  ch.sendToQueue(testQueue, Buffer.from(message));
+
+  // Consume the message we just published.
+  const result = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("consume timeout")), 5000);
+    ch.consume(
+      testQueue,
+      (msg) => {
+        if (msg) {
+          clearTimeout(timeout);
+          ch.ack(msg);
+          resolve(msg.content.toString());
+        }
+      },
+      { noAck: false }
+    );
+  });
+
+  await ch.close();
+  await conn.close();
+  return result;
+}
+
+async function healthCheck(): Promise<boolean> {
+  const conn = await amqp.connect(url);
+  const ch = await conn.createChannel();
+  await ch.assertQueue("health-check", { durable: false });
+  await ch.deleteQueue("health-check");
+  await ch.close();
+  await conn.close();
+  return true;
+}
+
+const server = Bun.serve({
+  port: process.env.PORT || 3000,
+
+  async fetch(req) {
+    const u = new URL(req.url);
+
+    if (u.pathname === "/") {
+      try {
+        const msg = await publishAndConsume();
+        return new Response(`RabbitMQ round-trip OK: ${msg}\n`);
+      } catch (e) {
+        return new Response(`RabbitMQ error: ${e}\n`, { status: 503 });
+      }
+    }
+
+    if (u.pathname === "/health") {
+      try {
+        await healthCheck();
+        return new Response("ok\n");
+      } catch (e) {
+        return new Response(`rabbitmq unavailable: ${e}\n`, { status: 503 });
+      }
+    }
+
+    return new Response("not found\n", { status: 404 });
+  },
+});
+
+console.log(`Listening on http://localhost:${server.port}`);

--- a/testdata/bun-rabbitmq/package.json
+++ b/testdata/bun-rabbitmq/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bun-rabbitmq-example",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "bun run index.ts"
+  },
+  "dependencies": {
+    "amqplib": "^0.10.5"
+  }
+}


### PR DESCRIPTION
This adds RabbitMQ as a managed messaging addon, giving apps access to a durable message queue via `miren addon create miren-rabbitmq:small`. It rounds out the initial addon set with a third category (messaging) alongside relational DBs and caching/KV.

The implementation follows the pattern established by the recent Memcache and Valkey addons — dedicated-only, saga-based provisioning, no shared variant to start. RabbitMQ's official Docker image conveniently supports `RABBITMQ_DEFAULT_USER`, `RABBITMQ_DEFAULT_PASS`, and `RABBITMQ_DEFAULT_VHOST` env vars, so the container boots with the right credentials and vhost already configured without needing a post-boot `rabbitmqctl` step.

Apps get the standard set of connection env vars: `RABBITMQ_URL` (amqp://...), `RABBITMQ_HOST`, `RABBITMQ_PORT`, `RABBITMQ_USER`, `RABBITMQ_PASSWORD`, and `RABBITMQ_VHOST`. The URL and password are marked sensitive.

The testdata app (`bun-rabbitmq`) uses `amqplib` to do an AMQP publish/consume round-trip on `/` and a queue assert/delete health check on `/health`. Blackbox tests cover both the CLI addon lifecycle (create/list/destroy) and app.toml-driven deployment with connectivity verification.

Closes MIR-963