### PR TITLE
Fix sandbox hostname resolution for sub-containers

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -551,6 +551,13 @@ func containerPrefix(id entity.Id) string {
 	return "sandbox." + cid
 }
 
+// sandboxHostname returns a valid hostname for a sandbox container.
+// This is used both for the UTS hostname and the /etc/hosts entry so that
+// processes like EPMD that resolve their own hostname can find themselves.
+func sandboxHostname(id entity.Id) string {
+	return strings.TrimPrefix(id.String(), "sandbox/")
+}
+
 func pauseContainerId(id entity.Id) string {
 	return PauseContainerID(id)
 }
@@ -1385,7 +1392,7 @@ func (c *SandboxController) BuildSpec(
 		return nil, err
 	}
 
-	err = c.setupHosts(sb, sb.ID.String())
+	err = c.setupHosts(sb, sandboxHostname(sb.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -1426,6 +1433,7 @@ func (c *SandboxController) BuildSpec(
 		oci.WithoutMounts("/sys"),
 		oci.WithMounts(mounts),
 		oci.WithProcessCwd("/"),
+		oci.WithHostname(sandboxHostname(sb.ID)),
 		oci.WithAnnotations(map[string]string{
 			"io.kubernetes.cri.container-type": "sandbox",
 		}),
@@ -1969,6 +1977,10 @@ func (c *SandboxController) buildSubContainerSpec(
 		oci.WithLinuxNamespace(specs.LinuxNamespace{
 			Type: specs.IPCNamespace,
 			Path: fmt.Sprintf("/proc/%d/ns/ipc", sbPid),
+		}),
+		oci.WithLinuxNamespace(specs.LinuxNamespace{
+			Type: specs.UTSNamespace,
+			Path: fmt.Sprintf("/proc/%d/ns/uts", sbPid),
 		}),
 		oci.WithLinuxNamespace(specs.LinuxNamespace{
 			Type: specs.TimeNamespace,

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "e558dc99c430fb12cc93bc11021f6141c389874e0b028cec0f94cc5ba6c4021f",
+		"sandbox.go":  "25d02624b3ff335dfb433edfc79f48db8bc1febac799f1e44b1526f9d0d52e30",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}


### PR DESCRIPTION
Sub-containers in a sandbox were getting auto-generated hostnames from containerd that didn't match anything in `/etc/hosts` or DNS. This went unnoticed because none of the existing addon processes (valkey, postgres, mysql) resolve their own hostname at startup. Erlang's EPMD does, and it dies immediately if it can't, which surfaced this during RabbitMQ addon work.

The sandbox architecture already shares network, IPC, and time namespaces between the pause container and sub-containers, but UTS (the namespace that holds the hostname) was missing. This meant each sub-container got a random containerd-generated hostname like `250a27c3c755` while `/etc/hosts` mapped a different name to `127.0.0.1`.

The fix aligns with how Kubernetes pods handle this: set an explicit hostname on the pause container, share the UTS namespace to sub-containers, and make sure `/etc/hosts` agrees.

## Test plan
- Blackbox test suite covers the general sandbox launch path (app sandboxes, addon sandboxes)
- Manually verified RabbitMQ addon sandbox starts successfully (previously crashed with `epmd_error` after ~6 seconds)