### PR TITLE
Fix five flaky CI test patterns

### DIFF
--- a/blackbox/harness/app.go
+++ b/blackbox/harness/app.go
@@ -144,7 +144,7 @@ func WaitForAppReady(t *testing.T, m *Miren, name string, timeout time.Duration)
 				case "healthy":
 					return true, ""
 				case "crashed":
-					t.Fatalf("app %s crashed while waiting for ready", name)
+					return false, fmt.Sprintf("app %s health: crashed (may recover after env injection)", name)
 				default:
 					return false, fmt.Sprintf("app %s health: %s (ready: %d)", name, app.Health, app.ReadyInstances)
 				}

--- a/components/etcd/integration_test.go
+++ b/components/etcd/integration_test.go
@@ -333,18 +333,18 @@ func TestEtcdComponentAutoRestart(t *testing.T) {
 		// Try to connect to etcd
 		client, err := clientv3.New(clientv3.Config{
 			Endpoints:   []string{endpoint},
-			DialTimeout: 1 * time.Second,
+			DialTimeout: 3 * time.Second,
 		})
 		if err != nil {
 			return false
 		}
 		defer client.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 		_, err = client.Get(ctx, "restart-health-check")
 		return err == nil
-	}, 30*time.Second, 1*time.Second, "etcd should auto-restart and become ready")
+	}, 90*time.Second, 1*time.Second, "etcd should auto-restart and become ready")
 
 	t.Log("etcd auto-restarted successfully!")
 

--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -50,7 +50,7 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 	}
 
 	// Create contexts
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	// Start coordinator in background

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -815,9 +815,9 @@ func TestSandbox(t *testing.T) {
 		_, err = sbc.EAC.Put(ctx, &rpcE)
 		r.NoError(err)
 
-		// Run the periodic cleanup with a 2 second time horizon
-		// This tests that sandboxes older than the horizon are cleaned up
-		err = sbc.Periodic(ctx, 0)
+		// Use a negative time horizon so the cutoff is slightly in the future,
+		// avoiding a race where updatedAt ≈ now causes Before(cutoff) to fail.
+		err = sbc.Periodic(ctx, -time.Millisecond)
 		r.NoError(err)
 
 		// Check that the old dead sandbox was deleted

--- a/controllers/sandbox/volume_test.go
+++ b/controllers/sandbox/volume_test.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
@@ -532,8 +533,9 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 		).Attrs())
 		r.NoError(err)
 
-		// Run periodic cleanup with zero time horizon (everything eligible)
-		err = controller.Periodic(ctx, 0)
+		// Use a negative time horizon so the cutoff is slightly in the future,
+		// avoiding a race where updatedAt ≈ now causes Before(cutoff) to fail.
+		err = controller.Periodic(ctx, -time.Millisecond)
 		r.NoError(err)
 
 		// Verify the disk lease was released
@@ -579,7 +581,9 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 		).Attrs())
 		r.NoError(err)
 
-		err = controller.Periodic(ctx, 0)
+		// Use a negative time horizon so the cutoff is slightly in the future,
+		// avoiding a race where updatedAt ≈ now causes Before(cutoff) to fail.
+		err = controller.Periodic(ctx, -time.Millisecond)
 		r.NoError(err)
 
 		resp, err := es.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))

--- a/controllers/sandbox/watchdogtest/container_test.go
+++ b/controllers/sandbox/watchdogtest/container_test.go
@@ -50,6 +50,9 @@ func TestContainerWatchdog(t *testing.T) {
 		nodeE.SetAttrs(entity.New(entity.DBId, nodeId, node.Encode).Attrs())
 		_, err := eac.Put(context.Background(), &nodeE)
 		require.NoError(t, err)
+		// Confirm the node is readable before subtests create sandbox entities that reference it.
+		_, err = eac.Get(context.Background(), nodeId.String())
+		require.NoError(t, err)
 	}
 
 	t.Run("removes orphaned containers", func(t *testing.T) {


### PR DESCRIPTION
We've been seeing about an 8% flake rate in CI over the last couple weeks (7 true flaky failures out of 91 runs). After filtering out branch-specific stuff like frozen hash mismatches and compile errors, there were five distinct patterns, all pretty straightforward to fix.

The biggest offender was `WaitForAppReady` calling `t.Fatalf` the instant it sees a "crashed" health status. During addon provisioning, apps start before their `DATABASE_URL` gets injected, so they crash on first boot and recover once the env var arrives. Now we just treat "crashed" as another transient state and let the overall poll timeout do its job.

The `Periodic` cleanup tests had a cute timestamp precision race: they'd create a DEAD sandbox entity and immediately call `Periodic(ctx, 0)`, but since `updatedAt` was set nanoseconds before `time.Now()` inside Periodic, the `Before(cutoff)` check would sometimes fail. Passing a tiny negative horizon nudges the cutoff into the future so the entity always qualifies.

The watchdog test had a get-after-put race on the node entity, the etcd restart test needed more timeout headroom for slow CI runners, and the runner integration test was missing a context timeout entirely (relying on Go's default 10-minute kill).

Closes MIR-946