### PR TITLE
Harden autocert controller against ACME failure modes

### DIFF
--- a/controllers/certificate/autocert_controller.go
+++ b/controllers/certificate/autocert_controller.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
@@ -20,13 +21,22 @@ import (
 )
 
 const (
-	// How long to suppress ACME retries for a domain after a failure.
-	acmeFailureCooldown = 5 * time.Minute
+	// How long to suppress ACME retries for a domain after a failure. Matches
+	// autocert.Manager's internal createCertRetryAfter so we don't retry before
+	// the Manager has cleaned up its failed state. Server-sent Retry-After
+	// values override this when longer.
+	acmeFailureCooldown = time.Minute
 
 	// Max time to wait for autocert before falling back to the self-signed cert.
 	// The upstream autocert.Manager uses a hardcoded 5-minute timeout internally;
 	// this shorter deadline lets TLS handshakes complete promptly with the fallback.
 	inlineGetCertTimeout = 10 * time.Second
+
+	// Max time to wait for autocert during eager provisioning in Reconcile.
+	// Longer than inlineGetCertTimeout since we're not blocking a TLS handshake,
+	// but much shorter than the Manager's internal 5-minute timeout so we don't
+	// wedge the controller or prevent graceful shutdown.
+	reconcileGetCertTimeout = 30 * time.Second
 )
 
 // AutocertController provisions TLS certificates eagerly using HTTP-01 ACME challenges
@@ -42,7 +52,15 @@ type AutocertController struct {
 	allowedHosts sync.Map      // domain -> struct{}
 	ready        chan struct{} // closed when port-80 ACME challenge server is up
 	publicIPs    func() []net.IP
-	failures     sync.Map // domain -> time.Time of last failure
+	failures     sync.Map // domain -> acmeFailure
+}
+
+// acmeFailure records when an ACME attempt failed and how long to wait before
+// retrying. The cooldown is at least acmeFailureCooldown, but if the ACME
+// server returned a Retry-After header we honor that instead.
+type acmeFailure struct {
+	when     time.Time
+	cooldown time.Duration
 }
 
 type AutocertControllerOpts struct {
@@ -159,6 +177,14 @@ func (c *AutocertController) Reconcile(ctx context.Context, route *ingress_v1alp
 		}
 	}
 
+	// Skip ACME if this domain recently failed, matching the guard in GetCertificate.
+	// Without this, every Reconcile resync would fire a new ACME attempt even while
+	// rate-limited.
+	if c.inCooldown(domain) {
+		log.Debug("skipping eager provisioning: domain in failure cooldown")
+		return nil
+	}
+
 	// Wait for port-80 ACME challenge server to be ready before attempting provisioning
 	select {
 	case <-c.ready:
@@ -166,19 +192,60 @@ func (c *AutocertController) Reconcile(ctx context.Context, route *ingress_v1alp
 		return ctx.Err()
 	}
 
-	// Eagerly provision the certificate with a synthetic ClientHelloInfo
-	hello := &tls.ClientHelloInfo{ServerName: domain}
-	_, err := c.mgr.GetCertificate(hello)
-	if err != nil {
-		c.failures.Store(domain, time.Now())
-		log.Warn("eager cert provisioning failed (will retry on next TLS handshake)", "error", err)
-		// Don't return the error — the controller framework would retry, but autocert
-		// itself will handle this on the next actual TLS handshake or resync.
-		return nil
+	// Build a synthetic ClientHello with realistic parameters so autocert provisions
+	// an ECDSA certificate (what browsers actually prefer), not just RSA.
+	hello := &tls.ClientHelloInfo{
+		ServerName:        domain,
+		SupportedVersions: []uint16{tls.VersionTLS13, tls.VersionTLS12},
+		CipherSuites: []uint16{
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+			tls.TLS_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		},
+		SupportedCurves: []tls.CurveID{tls.X25519, tls.CurveP256, tls.CurveP384},
+		SignatureSchemes: []tls.SignatureScheme{
+			tls.ECDSAWithP256AndSHA256,
+			tls.ECDSAWithP384AndSHA384,
+			tls.PSSWithSHA256,
+			tls.PSSWithSHA384,
+			tls.PKCS1WithSHA256,
+			tls.PKCS1WithSHA384,
+		},
 	}
 
-	c.failures.Delete(domain)
-	log.Info("certificate provisioned successfully")
+	// Run with a timeout so we don't block the controller for the Manager's full
+	// 5-minute internal deadline, which also wedges graceful shutdown.
+	type certResult struct {
+		cert *tls.Certificate
+		err  error
+	}
+	ch := make(chan certResult, 1)
+	go func() {
+		cert, err := c.mgr.GetCertificate(hello)
+		ch <- certResult{cert, err}
+	}()
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			c.recordFailure(domain, res.err)
+			log.Warn("eager cert provisioning failed (will retry on next TLS handshake)", "error", res.err)
+			return nil
+		}
+		c.failures.Delete(domain)
+		log.Info("certificate provisioned successfully")
+	case <-time.After(reconcileGetCertTimeout):
+		c.recordFailure(domain, nil)
+		log.Warn("eager cert provisioning timed out", "timeout", reconcileGetCertTimeout)
+	case <-ctx.Done():
+		c.recordFailure(domain, nil)
+		return ctx.Err()
+	}
+
 	return nil
 }
 
@@ -215,11 +282,8 @@ func (c *AutocertController) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Ce
 
 	// Skip ACME if this domain recently failed — prevents rapid-fire attempts
 	// from every incoming TLS handshake while rate-limited.
-	if lastFail, ok := c.failures.Load(host); ok {
-		if time.Since(lastFail.(time.Time)) < acmeFailureCooldown {
-			return &c.fallbackCert, nil
-		}
-		c.failures.Delete(host)
+	if c.inCooldown(host) {
+		return &c.fallbackCert, nil
 	}
 
 	// Run autocert with a deadline so handshakes fall back to the self-signed
@@ -239,9 +303,10 @@ func (c *AutocertController) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Ce
 		if res.err == nil {
 			return res.cert, nil
 		}
-		c.failures.Store(host, time.Now())
+		c.recordFailure(host, res.err)
 		c.log.Debug("autocert failed, using fallback", "host", host, "error", res.err)
 	case <-time.After(inlineGetCertTimeout):
+		c.recordFailure(host, nil)
 		c.log.Warn("autocert timed out, using fallback", "host", host, "timeout", inlineGetCertTimeout)
 	}
 
@@ -298,6 +363,33 @@ func (c *AutocertController) isAllowedHost(host string) bool {
 			return true
 		}
 	}
+	return false
+}
+
+// recordFailure stores a cooldown entry for a domain. If the error is an ACME
+// rate-limit with a Retry-After duration, we honor that instead of our default.
+func (c *AutocertController) recordFailure(domain string, err error) {
+	cooldown := acmeFailureCooldown
+	if err != nil {
+		if ra, ok := acme.RateLimit(err); ok && ra > cooldown {
+			cooldown = ra
+		}
+	}
+	c.failures.Store(domain, acmeFailure{when: time.Now(), cooldown: cooldown})
+}
+
+// inCooldown reports whether a domain is in the failure cooldown window.
+// Returns true if retries should be suppressed. Cleans up expired entries.
+func (c *AutocertController) inCooldown(domain string) bool {
+	v, ok := c.failures.Load(domain)
+	if !ok {
+		return false
+	}
+	f := v.(acmeFailure)
+	if time.Since(f.when) < f.cooldown {
+		return true
+	}
+	c.failures.Delete(domain)
 	return false
 }
 

--- a/controllers/certificate/autocert_controller_test.go
+++ b/controllers/certificate/autocert_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/pkg/entity"
@@ -231,6 +232,88 @@ func TestAutocertController_Init_PrePopulatesAllowedHosts(t *testing.T) {
 	// Verify unknown hosts are NOT in allowedHosts
 	if _, ok := c.allowedHosts.Load("unknown.com"); ok {
 		t.Error("unexpected host in allowed hosts")
+	}
+}
+
+func TestAutocertController_Reconcile_SkipsDuringFailureCooldown(t *testing.T) {
+	c := newTestAutocertController(t)
+	c.SetReady()
+
+	// Simulate a recent failure for this domain
+	c.failures.Store("cooldown.example.com", acmeFailure{when: time.Now(), cooldown: acmeFailureCooldown})
+
+	route, meta := testRouteMeta("cooldown-route", "cooldown.example.com")
+	if err := c.Reconcile(context.Background(), route, meta); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Domain should still be in allowedHosts (Reconcile always adds it)
+	if _, ok := c.allowedHosts.Load("cooldown.example.com"); !ok {
+		t.Error("expected domain to be in allowed hosts")
+	}
+
+	// Failure entry should still be present (not cleared by a successful provision)
+	if _, ok := c.failures.Load("cooldown.example.com"); !ok {
+		t.Error("expected failure entry to remain during cooldown")
+	}
+}
+
+func TestAutocertController_Reconcile_ClearsExpiredCooldown(t *testing.T) {
+	c := newTestAutocertController(t)
+	c.SetReady()
+
+	// Simulate an old failure (well past cooldown)
+	c.failures.Store("expired.example.com", acmeFailure{when: time.Now().Add(-10 * time.Minute), cooldown: acmeFailureCooldown})
+
+	route, meta := testRouteMeta("expired-route", "expired.example.com")
+	// This will attempt ACME (and fail since there's no real ACME server),
+	// but the important thing is it doesn't skip due to cooldown.
+	_ = c.Reconcile(context.Background(), route, meta)
+
+	// The old failure entry should have been deleted before the attempt.
+	// A new one may have been stored if the ACME attempt itself failed,
+	// but the original stale timestamp should be gone.
+	if v, ok := c.failures.Load("expired.example.com"); ok {
+		f := v.(acmeFailure)
+		if time.Since(f.when) > time.Minute {
+			t.Error("expected stale failure entry to be replaced, but old timestamp remains")
+		}
+	}
+}
+
+func TestAutocertController_GetCertificate_RecordsFailureOnTimeout(t *testing.T) {
+	c := newTestAutocertController(t)
+	c.allowedHosts.Store("timeout.example.com", struct{}{})
+
+	// GetCertificate will attempt autocert, which will fail/timeout since
+	// there's no real ACME server. It should record a failure.
+	hello := &tls.ClientHelloInfo{ServerName: "timeout.example.com"}
+	cert, err := c.GetCertificate(hello)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected fallback cert, got nil")
+	}
+
+	// After the call completes (via timeout or error), the domain should be in failures
+	if _, ok := c.failures.Load("timeout.example.com"); !ok {
+		t.Error("expected failure to be recorded after GetCertificate timeout/error")
+	}
+}
+
+func TestAutocertController_GetCertificate_SkipsDuringCooldown(t *testing.T) {
+	c := newTestAutocertController(t)
+	c.allowedHosts.Store("cooldown.example.com", struct{}{})
+	c.failures.Store("cooldown.example.com", acmeFailure{when: time.Now(), cooldown: acmeFailureCooldown})
+
+	hello := &tls.ClientHelloInfo{ServerName: "cooldown.example.com"}
+	cert, err := c.GetCertificate(hello)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected fallback cert, got nil")
 	}
 }
 


### PR DESCRIPTION
I exercised the new failure handling during a move of my blog across domains, where I added the route for the new domain before DNS had fully propagated. That's how I discovered all these issues. Glad to be improving this stuff because "DNS not quite right yet" is going to be a really common setup scenario.

The initial HTTP-01 challenge failed (as expected, DNS wasn't ready), but then every subsequent TLS handshake spawned a new ACME attempt because the timeout codepath in GetCertificate never recorded a failure, so the cooldown mechanism never activated. Let's Encrypt's 5-failed-authorizations-per-hour limit was exhausted in about 9 minutes. Reconcile compounded things by having no timeout (blocking for autocert.Manager's full 5-minute internal deadline, which also prevented graceful shutdown) and no cooldown check of its own.

There was also a subtler issue where the synthetic ClientHello used for eager provisioning had nil cipher suite fields. autocert.Manager's `supportsECDSA` check treats that as "no ECDSA support" and provisions an RSA-only cert. Browsers connect with full ECDSA-capable hellos, find no matching cert in cache, and fall through to inline ACME provisioning. So even after eager provisioning reported success, the site would still show a self-signed fallback.

The core changes: Reconcile checks the failure cooldown before attempting ACME and wraps the call in a 30-second timeout. GetCertificate now records a failure on timeout (not just on error), so the cooldown actually kicks in. The synthetic ClientHello includes realistic TLS parameters with ECDSA support. And failure tracking now honors server-sent Retry-After headers via `acme.RateLimit()`, with the default cooldown dropped from 5 minutes to 1 minute (matching autocert's internal `createCertRetryAfter`) so users who fix the underlying problem get faster feedback.

We also investigated the goroutine leak from timed-out calls into `autocert.Manager`. The Manager's `GetCertificate` API doesn't accept a context, so orphaned goroutines can't be cancelled. But with the cooldown fix, the leak rate is bounded to at most one goroutine per domain per cooldown period, which is acceptable.

Closes MIR-971