### PR TITLE
Fix Entity.Update to handle multi-valued attrs correctly

### DIFF
--- a/blackbox/addon_memcache_test.go
+++ b/blackbox/addon_memcache_test.go
@@ -29,12 +29,10 @@ func TestMemcacheAddonCreateListDestroy(t *testing.T) {
 	harness.WaitForEnvVar(t, m, name, "MEMCACHE_HOST", 30*time.Second)
 	harness.WaitForEnvVar(t, m, name, "MEMCACHE_PORT", 30*time.Second)
 
-	// Destroy the addon and verify the association is removed.
-	// NOTE: WaitForEnvVarRemoved is blocked by MIR-974 (Entity.Set
-	// overwrites many:true component attrs, so deprovision only removes
-	// 1 of N env vars). Add it back once that's fixed.
+	// Destroy the addon and verify full async cleanup completes.
 	m.MustRun("addon", "destroy", "miren-memcache", "-a", name, "--force")
 	harness.WaitForAddonRemoved(t, m, name, "miren-memcache", 5*time.Minute)
+	harness.WaitForEnvVarRemoved(t, m, name, "MEMCACHE_URL", 5*time.Minute)
 }
 
 func TestMemcacheAddonDeployWithAppToml(t *testing.T) {

--- a/blackbox/addon_rabbitmq_test.go
+++ b/blackbox/addon_rabbitmq_test.go
@@ -32,10 +32,10 @@ func TestRabbitmqAddonCreateListDestroy(t *testing.T) {
 	harness.WaitForEnvVar(t, m, name, "RABBITMQ_PASSWORD", 30*time.Second)
 	harness.WaitForEnvVar(t, m, name, "RABBITMQ_VHOST", 30*time.Second)
 
-	// Destroy the addon and verify the association is removed.
-	// NOTE: WaitForEnvVarRemoved blocked by MIR-974.
+	// Destroy the addon and verify full async cleanup completes.
 	m.MustRun("addon", "destroy", "miren-rabbitmq", "-a", name, "--force")
 	harness.WaitForAddonRemoved(t, m, name, "miren-rabbitmq", 5*time.Minute)
+	harness.WaitForEnvVarRemoved(t, m, name, "RABBITMQ_URL", 5*time.Minute)
 }
 
 func TestRabbitmqAddonDeployWithAppToml(t *testing.T) {

--- a/blackbox/addon_test.go
+++ b/blackbox/addon_test.go
@@ -62,10 +62,10 @@ func TestAddonCreateListDestroy(t *testing.T) {
 	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 30*time.Second)
 	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
 
-	// Destroy the addon and verify the association is removed.
-	// NOTE: WaitForEnvVarRemoved blocked by MIR-974.
+	// Destroy the addon and verify full async cleanup completes.
 	m.MustRun("addon", "destroy", "miren-postgresql", "-a", name, "--force")
 	harness.WaitForAddonRemoved(t, m, name, "miren-postgresql", 5*time.Minute)
+	harness.WaitForEnvVarRemoved(t, m, name, "DATABASE_URL", 5*time.Minute)
 }
 
 func TestAddonDeployWithAppToml(t *testing.T) {
@@ -200,10 +200,10 @@ func TestMysqlAddonCreateListDestroy(t *testing.T) {
 	harness.WaitForEnvVar(t, m, name, "MYSQL_HOST", 30*time.Second)
 	harness.WaitForEnvVar(t, m, name, "MYSQL_DATABASE", 30*time.Second)
 
-	// Destroy the addon and verify the association is removed.
-	// NOTE: WaitForEnvVarRemoved blocked by MIR-974.
+	// Destroy the addon and verify full async cleanup completes.
 	m.MustRun("addon", "destroy", "miren-mysql", "-a", name, "--force")
 	harness.WaitForAddonRemoved(t, m, name, "miren-mysql", 5*time.Minute)
+	harness.WaitForEnvVarRemoved(t, m, name, "DATABASE_URL", 5*time.Minute)
 }
 
 func TestValkeyAddonCreateListDestroy(t *testing.T) {
@@ -228,10 +228,10 @@ func TestValkeyAddonCreateListDestroy(t *testing.T) {
 	// Verify REDIS_* aliases are also injected
 	harness.WaitForEnvVar(t, m, name, "REDIS_URL", 30*time.Second)
 
-	// Destroy the addon and verify the association is removed.
-	// NOTE: WaitForEnvVarRemoved blocked by MIR-974.
+	// Destroy the addon and verify full async cleanup completes.
 	m.MustRun("addon", "destroy", "miren-valkey", "-a", name, "--force")
 	harness.WaitForAddonRemoved(t, m, name, "miren-valkey", 5*time.Minute)
+	harness.WaitForEnvVarRemoved(t, m, name, "VALKEY_URL", 5*time.Minute)
 }
 
 func TestAddonUnknownAddon(t *testing.T) {

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -1011,16 +1011,6 @@ func (l *Launcher) updatePool(ctx context.Context, poolWithEntity *PoolWithEntit
 	// Build new attributes from the pool
 	newAttrs := pool.Encode()
 
-	// Filter out ReferencedByVersions from encoded attrs - we'll add them separately
-	// (pool.Encode() includes them, but we need explicit control to handle empty arrays)
-	filteredAttrs := make([]entity.Attr, 0, len(newAttrs))
-	for _, attr := range newAttrs {
-		if attr.ID != compute_v1alpha.SandboxPoolReferencedByVersionsId {
-			filteredAttrs = append(filteredAttrs, attr)
-		}
-	}
-	newAttrs = filteredAttrs
-
 	// Add critical fields that Encode() filters out
 	// (Encode() uses entity.Empty() which filters out zero/empty values)
 
@@ -1053,12 +1043,13 @@ func (l *Launcher) updatePool(ctx context.Context, poolWithEntity *PoolWithEntit
 	// Build the final attribute list: metadata from existing + new pool attrs
 	finalAttrs := make([]entity.Attr, 0, len(ent.Attrs())+len(newAttrs))
 
-	// Collect IDs we're replacing (including multi-valued attrs we'll handle separately)
+	// Collect IDs we're replacing
 	replacingIDs := make(map[entity.Id]bool)
 	for _, attr := range newAttrs {
 		replacingIDs[attr.ID] = true
 	}
-	// Always replace ReferencedByVersions (even if empty) since we're explicitly setting them
+	// Always replace ReferencedByVersions (even if empty) since we're explicitly setting them.
+	// Encode() won't emit attrs for an empty slice, but we still need to clear old refs.
 	replacingIDs[compute_v1alpha.SandboxPoolReferencedByVersionsId] = true
 
 	// Add existing attrs except those we're replacing
@@ -1068,16 +1059,8 @@ func (l *Launcher) updatePool(ctx context.Context, poolWithEntity *PoolWithEntit
 		}
 	}
 
-	// Add all new attrs
+	// Add all new attrs (including multi-valued ReferencedByVersions from Encode())
 	finalAttrs = append(finalAttrs, newAttrs...)
-
-	// Now add ALL the references from the pool (multi-valued attribute)
-	// NOTE: We can't use entity.Update() for multi-valued attributes because
-	// entity.Set() replaces the first matching attribute instead of adding a new one.
-	// This is why we manually append each reference.
-	for _, ref := range pool.ReferencedByVersions {
-		finalAttrs = append(finalAttrs, entity.Ref(compute_v1alpha.SandboxPoolReferencedByVersionsId, ref))
-	}
 
 	// Use Replace with the combined attributes (preserves metadata)
 	_, err := l.EAC.Replace(ctx, finalAttrs, 0)

--- a/pkg/entity/entity.go
+++ b/pkg/entity/entity.go
@@ -292,9 +292,18 @@ func (e *Entity) Merge(other *Entity) error {
 }
 
 func (e *Entity) Update(attrs []Attr) error {
+	// Collect the set of attr IDs being updated, then remove all existing
+	// attrs for those IDs. This ensures multi-valued (many:true) component
+	// attrs are fully replaced rather than having only the first overwritten.
+	seen := make(map[Id]bool, len(attrs))
 	for _, attr := range attrs {
-		e.Set(attr)
+		if !seen[attr.ID] {
+			seen[attr.ID] = true
+			e.Remove(attr.ID)
+		}
 	}
+
+	e.attrs = append(e.attrs, attrs...)
 	return e.Fixup()
 }
 

--- a/pkg/entity/entity_test.go
+++ b/pkg/entity/entity_test.go
@@ -516,3 +516,46 @@ func TestEntity_Update_MultipleTimesDoesNotDuplicate(t *testing.T) {
 	// Verify final revision value is correct
 	r.Equal(int64(5), ent.GetRevision())
 }
+
+func TestEntity_Update_MultiValuedAttrs(t *testing.T) {
+	r := require.New(t)
+
+	multiID := Id("test/multi")
+	singleID := Id("test/single")
+
+	// Start with an entity that has two attrs sharing the same ID (simulating many:true)
+	// plus a single-valued attr.
+	ent := New(
+		Ref(DBId, "test/entity"),
+		String(multiID, "old-a"),
+		String(multiID, "old-b"),
+		String(singleID, "original"),
+	)
+
+	// Sanity check: both multi-valued attrs are present
+	r.Len(ent.GetAll(multiID), 2)
+
+	// Update with three new multi-valued attrs and a new single-valued attr
+	err := ent.Update([]Attr{
+		String(multiID, "new-x"),
+		String(multiID, "new-y"),
+		String(multiID, "new-z"),
+		String(singleID, "updated"),
+	})
+	r.NoError(err)
+
+	// Multi-valued: should have exactly the 3 new values, not the 2 old ones
+	multiAttrs := ent.GetAll(multiID)
+	r.Len(multiAttrs, 3, "expected all new multi-valued attrs, got %d", len(multiAttrs))
+
+	vals := make([]string, len(multiAttrs))
+	for i, a := range multiAttrs {
+		vals[i] = a.Value.String()
+	}
+	r.ElementsMatch([]string{"new-x", "new-y", "new-z"}, vals)
+
+	// Single-valued: should be replaced as before
+	single, ok := ent.Get(singleID)
+	r.True(ok)
+	r.Equal("updated", single.Value.String())
+}


### PR DESCRIPTION
`Entity.Update` was implemented as a loop over `Entity.Set`, which has "upsert exactly one" semantics. That's fine for single-valued attrs, but `many:true` component fields (like `addon_association.variables`) produce multiple attrs with the same ID from `Encode()`. Each call to `Set` just overwrote the first matching slot, so only the last value survived.

The concrete impact was on addon provisioning: an addon with 8 env vars would only persist the last one in its `variables` field. That meant `removeEnvVars` during deprovision would only clean up 1 of N, leaving stale addon env vars on the app permanently.

The fix changes `Update` to "replace-all-for-key": remove all existing attrs for each incoming ID, then append the new set. This is the same semantic the store-level `UpdateEntity` already implements (via remove + merge), just applied at the in-memory entity layer where controllers operate via `meta.Update()`.

The deployment launcher had a workaround for exactly this bug (with a comment explaining it), so that's unwound here. And the blackbox addon tests get their `WaitForEnvVarRemoved` assertions back (removed in the memcache PR pending this fix).

Closes MIR-974