### PR TITLE
Harden embedded etcd against freelist bloat

### DIFF
--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -187,6 +187,7 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 			e.Log.Info("found existing etcd container, attempting restart", "container_id", existingContainer.ID())
 			err = e.restartExistingContainer(ctx, existingContainer, config)
 			if err == nil {
+				e.StartMaintenanceLoop(ctx)
 				return nil
 			}
 			// If restart failed (e.g., port mismatch), try deleting the container and creating fresh

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -37,8 +37,13 @@ var (
 // etcdState tracks the configuration state of the etcd container.
 // This is persisted to detect when configuration changes require container recreation.
 type etcdState struct {
-	TLSEnabled bool `json:"tls_enabled"`
+	TLSEnabled    bool `json:"tls_enabled"`
+	ConfigVersion int  `json:"config_version"`
 }
+
+// currentConfigVersion should be bumped whenever the container spec changes
+// (new env vars, different args, etc.) so that upgrades recreate the container.
+const currentConfigVersion = 1
 
 // TLSConfig holds TLS certificate paths for etcd mTLS.
 // When configured, etcd will require client certificate authentication.
@@ -148,35 +153,35 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 		return fmt.Errorf("failed to create data directory: %w", err)
 	}
 
-	// Check if TLS configuration has changed since the container was created.
-	// If so, we must recreate the container since TLS settings are baked into the args.
+	// Check if the container config has changed since last start. If so, we
+	// must recreate the container since env vars and args are baked into the spec.
 	requestedTLSEnabled := config.TLS != nil
 	prevState := e.loadState()
 
-	// Determine if we need to recreate the container due to TLS config mismatch.
-	// If there's no state file but there IS an existing container, we must also
-	// recreate because we can't verify the container's TLS config matches.
-	var tlsConfigMismatch bool
+	var configChanged bool
 	if prevState == nil {
-		// No state file - if TLS is requested, we must recreate to ensure TLS is enabled
-		tlsConfigMismatch = requestedTLSEnabled
+		// No state file. If TLS is requested we must recreate to be sure it's
+		// enabled; if not, the existing container is probably fine.
+		configChanged = requestedTLSEnabled
 	} else {
-		// Have state file - check if TLS setting changed
-		tlsConfigMismatch = prevState.TLSEnabled != requestedTLSEnabled
+		configChanged = prevState.TLSEnabled != requestedTLSEnabled ||
+			prevState.ConfigVersion != currentConfigVersion
 	}
 
 	// Check if container already exists
 	existingContainer, err := e.CC.LoadContainer(ctx, etcdContainerName)
 	if err == nil {
-		if tlsConfigMismatch {
-			previousTLS := false
-			if prevState != nil {
-				previousTLS = prevState.TLSEnabled
-			}
-			e.Log.Info("etcd TLS configuration changed, recreating container",
-				"previous_tls", previousTLS,
+		if configChanged {
+			e.Log.Info("etcd container config changed, recreating container",
+				"previous_tls", prevState != nil && prevState.TLSEnabled,
 				"requested_tls", requestedTLSEnabled,
-				"had_state_file", prevState != nil)
+				"previous_config_version", func() int {
+					if prevState != nil {
+						return prevState.ConfigVersion
+					}
+					return 0
+				}(),
+				"current_config_version", currentConfigVersion)
 			e.CleanupExistingContainer(ctx, existingContainer)
 		} else {
 			e.Log.Info("found existing etcd container, attempting restart", "container_id", existingContainer.ID())
@@ -255,7 +260,7 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	e.StartMaintenanceLoop(ctx)
 
 	// Persist the TLS state so we can detect config changes on restart
-	if err := e.saveState(&etcdState{TLSEnabled: e.tlsEnabled}); err != nil {
+	if err := e.saveState(&etcdState{TLSEnabled: e.tlsEnabled, ConfigVersion: currentConfigVersion}); err != nil {
 		e.Log.Warn("failed to save etcd state", "error", err)
 	}
 

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -251,6 +251,9 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	// Start monitoring for unexpected exits
 	e.StartExitMonitor(ctx)
 
+	// Start periodic maintenance (health logging + auto-defrag)
+	e.StartMaintenanceLoop(ctx)
+
 	// Persist the TLS state so we can detect config changes on restart
 	if err := e.saveState(&etcdState{TLSEnabled: e.tlsEnabled}); err != nil {
 		e.Log.Warn("failed to save etcd state", "error", err)
@@ -417,6 +420,7 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 		oci.WithEnv([]string{
 			"ETCD_AUTO_COMPACTION_MODE=periodic",
 			"ETCD_AUTO_COMPACTION_RETENTION=1h",
+			"ETCD_EXPERIMENTAL_BACKEND_BBOLT_FREELIST_TYPE=map",
 		}),
 		oci.WithMounts(mounts),
 	}

--- a/components/etcd/maintenance.go
+++ b/components/etcd/maintenance.go
@@ -115,7 +115,7 @@ func (e *EtcdComponent) runMaintenanceCheck(ctx context.Context, client *clientv
 	attrs := []any{
 		"db_size_bytes", dbSize,
 		"db_size_in_use_bytes", dbSizeInUse,
-		"bloat_ratio", fmt.Sprintf("%.2f", bloatRatio),
+		"bloat_ratio", bloatRatio,
 	}
 
 	switch {

--- a/components/etcd/maintenance.go
+++ b/components/etcd/maintenance.go
@@ -1,0 +1,156 @@
+package etcd
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+const (
+	maintenanceInterval = 5 * time.Minute
+	defragBloatRatio    = 2.0
+	warnBloatRatio      = 1.5
+	errorBloatRatio     = 3.0
+)
+
+// StartMaintenanceLoop runs a background goroutine that periodically checks
+// etcd database health and triggers defragmentation when the BoltDB file has
+// grown significantly larger than its live data. Compaction (already configured
+// as periodic/1h) marks old revisions as deleted, but BoltDB never releases
+// pages without an explicit defrag.
+func (e *EtcdComponent) StartMaintenanceLoop(ctx context.Context) {
+	go e.maintenanceLoop(ctx)
+}
+
+func (e *EtcdComponent) maintenanceLoop(ctx context.Context) {
+	endpoint := e.ClientEndpoint()
+	if endpoint == "" {
+		e.Log.Warn("etcd maintenance loop: no endpoint available, skipping")
+		return
+	}
+
+	client, err := e.newMaintenanceClient(endpoint)
+	if err != nil {
+		e.Log.Error("etcd maintenance loop: failed to create client", "error", err)
+		return
+	}
+	defer client.Close()
+
+	ticker := time.NewTicker(maintenanceInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			e.runMaintenanceCheck(ctx, client, endpoint)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (e *EtcdComponent) newMaintenanceClient(endpoint string) (*clientv3.Client, error) {
+	cfg := clientv3.Config{
+		Endpoints:   []string{endpoint},
+		DialTimeout: 5 * time.Second,
+	}
+
+	if e.config.TLS != nil {
+		tlsCfg, err := buildMaintenanceTLSConfig(e.config.TLS.CertsDir)
+		if err != nil {
+			return nil, fmt.Errorf("building TLS config: %w", err)
+		}
+		cfg.TLS = tlsCfg
+	}
+
+	return clientv3.New(cfg)
+}
+
+func buildMaintenanceTLSConfig(certsDir string) (*tls.Config, error) {
+	certFile := filepath.Join(certsDir, "server.crt")
+	keyFile := filepath.Join(certsDir, "server.key")
+	caFile := filepath.Join(certsDir, "ca.crt")
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading key pair: %w", err)
+	}
+
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading CA cert: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA certificate")
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+	}, nil
+}
+
+func (e *EtcdComponent) runMaintenanceCheck(ctx context.Context, client *clientv3.Client, endpoint string) {
+	resp, err := client.Status(ctx, endpoint)
+	if err != nil {
+		e.Log.Warn("etcd maintenance: failed to get status", "error", err)
+		return
+	}
+
+	dbSize := resp.DbSize
+	dbSizeInUse := resp.DbSizeInUse
+	var bloatRatio float64
+	if dbSizeInUse > 0 {
+		bloatRatio = float64(dbSize) / float64(dbSizeInUse)
+	}
+
+	attrs := []any{
+		"db_size_bytes", dbSize,
+		"db_size_in_use_bytes", dbSizeInUse,
+		"bloat_ratio", fmt.Sprintf("%.2f", bloatRatio),
+	}
+
+	switch {
+	case bloatRatio >= errorBloatRatio:
+		e.Log.Error("etcd database bloat is critically high", attrs...)
+	case bloatRatio >= warnBloatRatio:
+		e.Log.Warn("etcd database bloat is elevated", attrs...)
+	default:
+		e.Log.Info("etcd database status", attrs...)
+	}
+
+	if dbSizeInUse > 0 && dbSize > int64(defragBloatRatio*float64(dbSizeInUse)) {
+		e.defragment(ctx, client, endpoint, dbSize)
+	}
+}
+
+func (e *EtcdComponent) defragment(ctx context.Context, client *clientv3.Client, endpoint string, dbSizeBefore int64) {
+	e.Log.Info("etcd defrag starting", "db_size_before_bytes", dbSizeBefore)
+
+	_, err := client.Defragment(ctx, endpoint)
+	if err != nil {
+		e.Log.Error("etcd defrag failed", "error", err)
+		return
+	}
+
+	resp, err := client.Status(ctx, endpoint)
+	if err != nil {
+		e.Log.Warn("etcd defrag completed but failed to get post-defrag status", "error", err)
+		return
+	}
+
+	reclaimed := dbSizeBefore - resp.DbSize
+	e.Log.Info("etcd defrag completed",
+		"db_size_before_bytes", dbSizeBefore,
+		"db_size_after_bytes", resp.DbSize,
+		"reclaimed_bytes", reclaimed,
+	)
+}


### PR DESCRIPTION
We hit a production outage where etcd's BoltDB file ballooned to 627 MB with only 53 MB of live data. Hourly compaction was already configured, but compaction only marks old revisions as deleted. BoltDB never releases those pages back without an explicit defrag call, so the freelist just kept growing until write operations stalled and took down the cluster.

This does two things to prevent a recurrence. First, it switches the BoltDB freelist type from `array` to `map`. The array freelist does O(n) page allocation, which is exactly the thing that wedged under pressure. The map freelist uses a hashmap for O(1) lookups. Despite the `experimental-` prefix on the flag, this has been stable since etcd 3.4.9 and is widely used in production.

Second, it adds a maintenance loop that ticks every 5 minutes, calls the etcd maintenance API to check `DbSize` vs `DbSizeInUse`, and triggers defrag when the bloat ratio exceeds 2x. The same loop logs structured health metrics (db size, live data size, bloat ratio) at INFO/WARN/ERROR depending on how bloated things are, so we'll have early visibility into any future growth trends. Defrag briefly pauses the etcd server, but for our single-node embedded setup that's a sub-second blip.

**Config versioning for upgrades**

Container specs (env vars, args) are baked in at creation time and survive across restarts. Without intervention, the freelist type change would never take effect on existing installs because `Start()` reuses the existing container. This PR adds a `ConfigVersion` field to the persisted etcd state file. When the version doesn't match, the container is torn down and recreated with the current spec (data is preserved via bind mount). Existing installs will go from version 0 to 1 on their first restart after this upgrade.

This is a pattern worth adopting for the other container-managed components (buildkit, victoriametrics, victorialogs). See RFD-70 for the broader discussion.

Closes MIR-968