### PR TITLE
Consolidate etcd test client creation into pkg/etcdtest

### DIFF
--- a/pkg/entity/migrate_test.go
+++ b/pkg/entity/migrate_test.go
@@ -14,14 +14,14 @@ import (
 func TestMigrateEntityStore(t *testing.T) {
 	r := require.New(t)
 
-	client, _ := setupTestEtcd(t)
+	client, basePrefix := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
-	prefix := "/test-migrate-entities/"
+	prefix := basePrefix + "/migrate-entities/"
 
 	// Create some entities in old format
 	oldEnt1 := OldEntity{
@@ -162,14 +162,14 @@ func TestMigrateEntityStore(t *testing.T) {
 func TestMigrateEntityWithMissingFields(t *testing.T) {
 	r := require.New(t)
 
-	client, _ := setupTestEtcd(t)
+	client, basePrefix := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
-	prefix := "/test-migrate-partial/"
+	prefix := basePrefix + "/migrate-partial/"
 
 	// Create entity with only some old-style fields
 	oldEnt := OldEntity{
@@ -215,14 +215,14 @@ func TestMigrateEntityWithMissingFields(t *testing.T) {
 func TestMigrateEntityPreservesExistingAttributes(t *testing.T) {
 	r := require.New(t)
 
-	client, _ := setupTestEtcd(t)
+	client, basePrefix := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
-	prefix := "/test-migrate-preserve/"
+	prefix := basePrefix + "/migrate-preserve/"
 
 	// Create entity that already has db/id in attributes (shouldn't happen but test it)
 	oldEnt := OldEntity{

--- a/pkg/entity/migrate_test.go
+++ b/pkg/entity/migrate_test.go
@@ -14,7 +14,7 @@ import (
 func TestMigrateEntityStore(t *testing.T) {
 	r := require.New(t)
 
-	client := setupTestEtcd(t)
+	client, _ := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
@@ -162,7 +162,7 @@ func TestMigrateEntityStore(t *testing.T) {
 func TestMigrateEntityWithMissingFields(t *testing.T) {
 	r := require.New(t)
 
-	client := setupTestEtcd(t)
+	client, _ := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
@@ -215,7 +215,7 @@ func TestMigrateEntityWithMissingFields(t *testing.T) {
 func TestMigrateEntityPreservesExistingAttributes(t *testing.T) {
 	r := require.New(t)
 
-	client := setupTestEtcd(t)
+	client, _ := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/pkg/entity/reindex_test.go
+++ b/pkg/entity/reindex_test.go
@@ -1,38 +1,21 @@
 package entity
 
 import (
-	"context"
 	"log/slog"
 	"testing"
-	"time"
 
 	"github.com/mr-tron/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"miren.dev/runtime/pkg/etcdtest"
 )
 
 func setupReindexTestStore(t *testing.T) (*EtcdStore, *clientv3.Client) {
 	t.Helper()
-
-	client, err := clientv3.New(clientv3.Config{
-		Endpoints:       []string{"etcd:2379"},
-		DialTimeout:     2 * time.Second,
-		MaxUnaryRetries: 2,
-	})
+	client, prefix := etcdtest.TestEtcdClient(t)
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
 	require.NoError(t, err)
-
-	ctx := context.Background()
-	_, err = client.Delete(ctx, "/test-reindex/", clientv3.WithPrefix())
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		client.Close()
-	})
-
-	store, err := NewEtcdStore(ctx, slog.Default(), client, "/test-reindex")
-	require.NoError(t, err)
-
 	return store, client
 }
 

--- a/pkg/entity/shortid_migrate_test.go
+++ b/pkg/entity/shortid_migrate_test.go
@@ -13,18 +13,14 @@ import (
 func TestMigrateShortIds(t *testing.T) {
 	r := require.New(t)
 
-	client, _ := setupTestEtcd(t)
+	client, basePrefix := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
-	prefix := "/test-migrate-shortids/"
-
-	// Clean up test data
-	_, err := client.Delete(ctx, prefix, clientv3.WithPrefix())
-	r.NoError(err)
+	prefix := basePrefix + "/migrate-shortids/"
 
 	// Create entity with entity/kind but no short-id (should get one)
 	ent1 := New(
@@ -102,18 +98,14 @@ func TestMigrateShortIds(t *testing.T) {
 func TestMigrateShortIdsDryRun(t *testing.T) {
 	r := require.New(t)
 
-	client, _ := setupTestEtcd(t)
+	client, basePrefix := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
-	prefix := "/test-migrate-shortids-dry/"
-
-	// Clean up test data
-	_, err := client.Delete(ctx, prefix, clientv3.WithPrefix())
-	r.NoError(err)
+	prefix := basePrefix + "/migrate-shortids-dry/"
 
 	// Create entity needing a short-id
 	ent := New(

--- a/pkg/entity/shortid_migrate_test.go
+++ b/pkg/entity/shortid_migrate_test.go
@@ -13,7 +13,7 @@ import (
 func TestMigrateShortIds(t *testing.T) {
 	r := require.New(t)
 
-	client := setupTestEtcd(t)
+	client, _ := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
@@ -102,7 +102,7 @@ func TestMigrateShortIds(t *testing.T) {
 func TestMigrateShortIdsDryRun(t *testing.T) {
 	r := require.New(t)
 
-	client := setupTestEtcd(t)
+	client, _ := setupTestEtcd(t)
 	ctx := context.Background()
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -13,33 +13,24 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"miren.dev/runtime/pkg/etcdtest"
 )
 
-func setupTestEtcd(t *testing.T) *clientv3.Client {
-	client, err := clientv3.New(clientv3.Config{
-		Endpoints:       []string{"etcd:2379"},
-		DialTimeout:     2 * time.Second,
-		MaxUnaryRetries: 2,
-	})
-	require.NoError(t, err)
+func setupTestEtcd(t *testing.T) (*clientv3.Client, string) {
+	return etcdtest.TestEtcdClient(t)
+}
 
-	// Clean up any existing test data
-	ctx := context.Background()
-
-	_, err = client.Delete(ctx, "/test-entities/", clientv3.WithPrefix())
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		client.Close()
-	})
-
-	return client
+// setupTestEtcdStore is a convenience wrapper that returns an EtcdStore
+// backed by a fresh etcd prefix.
+func setupTestEtcdStore(t *testing.T) (*EtcdStore, *clientv3.Client) {
+	client, prefix := setupTestEtcd(t)
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
+	require.New(t).NoError(err)
+	return store, client
 }
 
 func TestEtcdStore_CreateEntity(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	e, err := store.CreateEntity(t.Context(), New(
 		Ident, "test/addresses",
@@ -192,9 +183,7 @@ func TestEtcdStore_CreateEntity(t *testing.T) {
 }
 
 func TestEtcdStore_AttrPred(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	e, err := store.CreateEntity(t.Context(), New(
 		Ident, "test/address",
@@ -263,9 +252,7 @@ func TestEtcdStore_AttrPred(t *testing.T) {
 }
 
 func TestEtcdStore_GetEntity(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create a test entity
 	created, err := store.CreateEntity(t.Context(), New(
@@ -309,9 +296,7 @@ func TestEtcdStore_GetEntity(t *testing.T) {
 }
 
 func TestEtcdStore_UpdateEntity(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create a test entity
 	entity, err := store.CreateEntity(t.Context(), New(
@@ -512,9 +497,7 @@ func TestEtcdStore_UpdateEntity(t *testing.T) {
 }
 
 func TestEtcdStore_GetEntities_Batching(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create test entities - more than maxEntitiesPerBatch to test batching
 	numEntities := 150 // This will require 3 batches (64 + 64 + 22)
@@ -624,9 +607,7 @@ func TestEtcdStore_GetEntities_Batching(t *testing.T) {
 }
 
 func TestEtcdStore_DeleteEntity(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create a test entity
 	entity, err := store.CreateEntity(t.Context(), New(
@@ -670,9 +651,7 @@ func TestEtcdStore_DeleteEntity(t *testing.T) {
 }
 
 func TestEtcdStore_ListIndex(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	k, err := store.CreateEntity(t.Context(), New(
 		Any(Ident, KeywordValue("test/kind")),
@@ -759,9 +738,7 @@ func TestEtcdStore_ListIndex(t *testing.T) {
 
 func TestWatchIndex(t *testing.T) {
 	ctx := context.Background()
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create a attr for an indexed attribute
 	attr, err := store.CreateEntity(ctx, New(
@@ -870,9 +847,7 @@ func TestWatchIndex(t *testing.T) {
 
 func TestWatchEntity_DeleteIncludesEntity(t *testing.T) {
 	ctx := context.Background()
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create an entity
 	created, err := store.CreateEntity(ctx, New(
@@ -905,9 +880,7 @@ func TestWatchEntity_DeleteIncludesEntity(t *testing.T) {
 
 func TestWatchIndex_DBID(t *testing.T) {
 	ctx := context.Background()
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create an entity with the indexed attribute
 	entity1, err := store.CreateEntity(ctx, New(
@@ -949,9 +922,7 @@ func TestWatchIndex_DBID(t *testing.T) {
 }
 
 func TestEtcdStore_UpdateIndexedAttribute_Bug(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create an index attribute that won't change
 	kindAttr, err := store.CreateEntity(t.Context(), New(
@@ -1029,9 +1000,7 @@ func TestEtcdStore_UpdateIndexedAttribute_Bug(t *testing.T) {
 }
 
 func TestEtcdStore_GetEntities(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create multiple test entities
 	entity1, err := store.CreateEntity(t.Context(), New(
@@ -1275,12 +1244,10 @@ func TestEtcdStore_GetEntities(t *testing.T) {
 }
 
 func TestEtcdStore_ReplaceEntity(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create schema for multi-valued attribute
-	_, err = store.CreateEntity(t.Context(), New(
+	_, err := store.CreateEntity(t.Context(), New(
 		Ident, "test/tags",
 		Doc, "Tags for testing",
 		Cardinality, CardinalityMany,
@@ -1414,12 +1381,10 @@ func TestEtcdStore_ReplaceEntity(t *testing.T) {
 }
 
 func TestEtcdStore_PatchEntity(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	// Create schema for multi-valued attribute
-	_, err = store.CreateEntity(t.Context(), New(
+	_, err := store.CreateEntity(t.Context(), New(
 		Ident, "test/labels",
 		Doc, "Labels for testing",
 		Cardinality, CardinalityMany,
@@ -1567,9 +1532,7 @@ func TestEtcdStore_PatchEntity(t *testing.T) {
 }
 
 func TestEtcdStore_EnsureEntity(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	t.Run("ensure creates entity when not exists", func(t *testing.T) {
 		entity, created, err := store.EnsureEntity(t.Context(), New(
@@ -1677,9 +1640,7 @@ func TestEtcdStore_EnsureEntity(t *testing.T) {
 }
 
 func TestEtcdStore_NestedComponentFieldIndexing(t *testing.T) {
-	client := setupTestEtcd(t)
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities")
-	require.NoError(t, err)
+	store, _ := setupTestEtcdStore(t)
 
 	t.Run("top-level indexed fields work", func(t *testing.T) {
 		// Create version entities first
@@ -1905,14 +1866,9 @@ func TestEtcdStore_NestedComponentFieldIndexing(t *testing.T) {
 //   - When the bug exists, this test shows 2 keys remain in etcd after deletion
 //   - When fixed, only 1 key remains (the non-deleted entity)
 func TestEtcdStore_DeleteEntity_IndexCleanup_DirectQuery(t *testing.T) {
-	client := setupTestEtcd(t)
+	client, etcdPrefix := setupTestEtcd(t)
 
-	// Clean up test data from previous runs
-	ctx := context.Background()
-	_, err := client.Delete(ctx, "/test-entities-debug/", clientv3.WithPrefix())
-	require.NoError(t, err)
-
-	store, err := NewEtcdStore(t.Context(), slog.Default(), client, "/test-entities-debug")
+	store, err := NewEtcdStore(t.Context(), slog.Default(), client, etcdPrefix)
 	require.NoError(t, err)
 
 	// Create schema for a component with a nested indexed field
@@ -2153,11 +2109,7 @@ func TestExtractEntityId(t *testing.T) {
 }
 
 func TestCreateEntity_UniqueValueCollisionRetry(t *testing.T) {
-	client := setupTestEtcd(t)
-
-	prefix := "/test-unique-retry"
-	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
-	require.NoError(t, err)
+	client, prefix := setupTestEtcd(t)
 
 	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
 	require.NoError(t, err)
@@ -2205,11 +2157,7 @@ func TestCreateEntity_UniqueValueCollisionRetry(t *testing.T) {
 }
 
 func TestCreateEntity_AllocatesShortId(t *testing.T) {
-	client := setupTestEtcd(t)
-
-	prefix := "/test-shortid-alloc"
-	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
-	require.NoError(t, err)
+	client, prefix := setupTestEtcd(t)
 
 	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
 	require.NoError(t, err)
@@ -2239,11 +2187,7 @@ func TestCreateEntity_AllocatesShortId(t *testing.T) {
 }
 
 func TestCreateEntity_NoShortIdForSystemEntities(t *testing.T) {
-	client := setupTestEtcd(t)
-
-	prefix := "/test-shortid-system"
-	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
-	require.NoError(t, err)
+	client, prefix := setupTestEtcd(t)
 
 	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
 	require.NoError(t, err)
@@ -2258,11 +2202,7 @@ func TestCreateEntity_NoShortIdForSystemEntities(t *testing.T) {
 }
 
 func TestDeleteEntity_CleansUpUniqueKey(t *testing.T) {
-	client := setupTestEtcd(t)
-
-	prefix := "/test-shortid-delete"
-	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
-	require.NoError(t, err)
+	client, prefix := setupTestEtcd(t)
 
 	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
 	require.NoError(t, err)
@@ -2298,11 +2238,7 @@ func TestDeleteEntity_CleansUpUniqueKey(t *testing.T) {
 }
 
 func TestGetOneIndex(t *testing.T) {
-	client := setupTestEtcd(t)
-
-	prefix := "/test-getoneindex"
-	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
-	require.NoError(t, err)
+	client, prefix := setupTestEtcd(t)
 
 	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
 	require.NoError(t, err)
@@ -2337,11 +2273,7 @@ func TestGetOneIndex(t *testing.T) {
 // attributes that sort after "db/entity.updated" (like "db/type") to be pushed
 // past the slice's length on the overwrite path.
 func TestCreateEntity_OverwritePreservesAllAttrs(t *testing.T) {
-	client := setupTestEtcd(t)
-
-	prefix := "/test-overwrite-attrs"
-	_, err := client.Delete(t.Context(), prefix, clientv3.WithPrefix())
-	require.NoError(t, err)
+	client, prefix := setupTestEtcd(t)
 
 	store, err := NewEtcdStore(t.Context(), slog.Default(), client, prefix)
 	require.NoError(t, err)

--- a/pkg/entity/testutils/inmem_server.go
+++ b/pkg/entity/testutils/inmem_server.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	apiserver "miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/schema"
-	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/etcdtest"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/servers/entityserver"
 )
@@ -118,63 +117,36 @@ type EtcdEntityServer struct {
 	etcd   *clientv3.Client
 }
 
-// NewEtcdEntityServer creates a new etcd-backed entity server for testing
-// It connects to etcd:2379 and uses a random prefix for isolation
-// This should be run with ./hack/dev-exec or similar to have etcd available
+// NewEtcdEntityServer creates a new etcd-backed entity server for testing.
+// It connects to etcd:2379 and uses a random prefix for isolation.
+// Fails fast with a clear message if etcd is not reachable (i.e. outside dev env).
 func NewEtcdEntityServer(t *testing.T) (*EtcdEntityServer, func()) {
+	etcdClient, prefix := etcdtest.TestEtcdClient(t)
+
 	ctx := context.Background()
 	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	// Connect to etcd
-	etcdClient, err := clientv3.New(clientv3.Config{
-		Endpoints:   []string{"etcd:2379"},
-		DialTimeout: 5 * time.Second,
-	})
-	if err != nil {
-		t.Fatalf("failed to connect to etcd: %v", err)
-	}
-
-	// Generate random prefix for isolation
-	prefix := "/" + idgen.Gen("test")
-
-	// Create etcd-backed store
 	store, err := entity.NewEtcdStore(ctx, log, etcdClient, prefix)
 	if err != nil {
-		etcdClient.Close()
 		t.Fatalf("failed to create etcd store: %v", err)
 	}
 
-	// Apply schema to the store
 	err = schema.Apply(ctx, store)
 	if err != nil {
-		etcdClient.Close()
 		t.Fatalf("failed to apply schema: %v", err)
 	}
 
-	// Create entity server
 	es, err := entityserver.NewEntityServer(log, store)
 	if err != nil {
-		etcdClient.Close()
 		t.Fatalf("failed to create entity server: %v", err)
 	}
 
-	// Create entity access client with local transport
 	localClient := rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(es))
 	eac := entityserver_v1alpha.NewEntityAccessClient(localClient)
-
-	// Create the high-level entityserver client
 	client := apiserver.NewClient(log, eac)
 
-	cleanup := func() {
-		// Delete all keys with this prefix
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_, err := etcdClient.Delete(ctx, prefix, clientv3.WithPrefix())
-		if err != nil {
-			t.Logf("warning: failed to cleanup etcd prefix %s: %v", prefix, err)
-		}
-		etcdClient.Close()
-	}
+	// TestEtcdClient already registers prefix cleanup and client.Close
+	cleanup := func() {}
 
 	return &EtcdEntityServer{
 		Store:  store,

--- a/pkg/etcdtest/etcd.go
+++ b/pkg/etcdtest/etcd.go
@@ -1,0 +1,54 @@
+package etcdtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"miren.dev/runtime/pkg/idgen"
+)
+
+// TestEtcdClient connects to the shared etcd instance at etcd:2379 and returns
+// a client along with a random prefix for test isolation. It verifies etcd is
+// reachable with a short timeout so tests fail fast with a clear message when
+// run outside the dev environment.
+//
+// Cleanup is registered automatically: all keys under the prefix are deleted
+// and the client is closed when the test finishes.
+func TestEtcdClient(t testing.TB) (*clientv3.Client, string) {
+	t.Helper()
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:       []string{"etcd:2379"},
+		DialTimeout:     2 * time.Second,
+		MaxUnaryRetries: 2,
+	})
+	if err != nil {
+		t.Fatalf("failed to create etcd client: %v", err)
+	}
+
+	// gRPC connections are lazy, so clientv3.New succeeds even when etcd is
+	// unreachable. Do a quick probe to surface that early instead of letting
+	// the test hang on its first real operation.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := client.Get(ctx, "/ping"); err != nil {
+		client.Close()
+		t.Fatalf("cannot reach etcd: %v\nThese tests require the dev environment. Use: make dev, then hack/it or hack/run.", err)
+	}
+
+	prefix := "/" + idgen.Gen("test")
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := client.Delete(ctx, prefix, clientv3.WithPrefix())
+		if err != nil {
+			t.Logf("warning: failed to cleanup etcd prefix %s: %v", prefix, err)
+		}
+		client.Close()
+	})
+
+	return client, prefix
+}

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -5,15 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/etcdtest"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/etcdreg"
 	"miren.dev/runtime/pkg/rpc/example"
@@ -483,21 +482,11 @@ func noTestActor(t *testing.T) {
 		r := require.New(t)
 		ctx := t.Context()
 
-		_, err := net.LookupHost("etcd")
-		if err != nil {
-			t.Skip("etcd not available")
-		}
+		ec, _ := etcdtest.TestEtcdClient(t)
 
 		s := example.AdaptMeter(&exampleMeter{temp: 42})
 
 		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithLogLevel(slog.LevelDebug))
-		r.NoError(err)
-
-		ec, err := clientv3.New(clientv3.Config{
-			Endpoints:       []string{"etcd:2379"},
-			DialTimeout:     2 * time.Second,
-			MaxUnaryRetries: 2,
-		})
 		r.NoError(err)
 
 		log := slog.New(slogfmt.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/servers/entityserver/entityserver_test.go
+++ b/servers/entityserver/entityserver_test.go
@@ -12,34 +12,13 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	v1alpha "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
-	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/etcdtest"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/stream"
 )
 
 func setupTestEtcd(t *testing.T) (*clientv3.Client, string) {
-	client, err := clientv3.New(clientv3.Config{
-		Endpoints:       []string{"etcd:2379"},
-		DialTimeout:     2 * time.Second,
-		MaxUnaryRetries: 2,
-	})
-	require.NoError(t, err)
-
-	// Generate random prefix for isolation
-	prefix := "/" + idgen.Gen("test")
-
-	t.Cleanup(func() {
-		// Delete all keys with this prefix
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_, err := client.Delete(ctx, prefix, clientv3.WithPrefix())
-		if err != nil {
-			t.Logf("warning: failed to cleanup etcd prefix %s: %v", prefix, err)
-		}
-		client.Close()
-	})
-
-	return client, prefix
+	return etcdtest.TestEtcdClient(t)
 }
 
 func TestEntityServer_Get(t *testing.T) {


### PR DESCRIPTION
Tests that need etcd had about seven separate places spinning up their own clients, with three different `setupTestEtcd` functions that were basically the same code copy-pasted with slight return type variations. Worse, when you ran these tests outside the dev environment (easy to do accidentally with `go test ./pkg/entity/...` from the host), they'd hang indefinitely. gRPC connections are lazy, so `clientv3.New` succeeds even when etcd is unreachable, and then the first real RPC just blocks forever with no useful output.

New `pkg/etcdtest.TestEtcdClient(t)` consolidates all of this into one place: it creates the client, does a quick probe with a 5-second timeout to fail fast with a "you need the dev environment" message, generates a random prefix for test isolation, and registers cleanup. The package has minimal dependencies (just the etcd client and idgen) so it doesn't create import cycles with any of the consumers.

All the duplicated setup functions now delegate to it, and the tests that were manually managing their own prefixes and cleanup get that for free. Net result is about 145 fewer lines of test boilerplate.

Closes MIR-975