### PR TITLE
Include IP SANs in runner API certificate

### DIFF
--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"strings"
 	"time"
 
@@ -183,16 +184,37 @@ func (s *RegistrationServer) Join(ctx context.Context, req *runner_v1alpha.Runne
 		return nil
 	}
 
-	// Now that invite is claimed, issue the certificate
+	// Now that invite is claimed, issue the certificate with proper SANs
+	// so the coordinator can connect to the runner's API by IP.
 	runnerIDPrefix := runnerID
 	if len(runnerIDPrefix) > 8 {
 		runnerIDPrefix = runnerIDPrefix[:8]
 	}
 	certName := fmt.Sprintf("runner-%s", runnerIDPrefix)
+
+	ips := []net.IP{
+		net.ParseIP("127.0.0.1"),
+		net.ParseIP("::1"),
+	}
+	dnsNames := []string{"localhost"}
+
+	if listenAddr != "" {
+		host, _, err := net.SplitHostPort(listenAddr)
+		if err == nil && host != "" {
+			if ip := net.ParseIP(host); ip != nil {
+				ips = append(ips, ip)
+			} else if host != "localhost" {
+				dnsNames = append(dnsNames, host)
+			}
+		}
+	}
+
 	cc, err := s.Authority.IssueCertificate(caauth.Options{
 		CommonName:   certName,
 		Organization: "miren",
 		ValidFor:     365 * 24 * time.Hour,
+		IPs:          ips,
+		DNSNames:     dnsNames,
 	})
 	if err != nil {
 		s.Log.Error("Failed to issue certificate", "error", err, "runner_id", runnerID)

--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -2,6 +2,9 @@ package runner
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
 	"testing"
 
 	"miren.dev/runtime/api/runner/runner_v1alpha"
@@ -88,5 +91,45 @@ func TestJoinCreatesNodeEntity(t *testing.T) {
 
 	if joinResult.CoordinatorAddr() != "127.0.0.1:8443" {
 		t.Errorf("Join returned coordinator addr %q, want %q", joinResult.CoordinatorAddr(), "127.0.0.1:8443")
+	}
+
+	// Verify the issued certificate includes proper IP SANs so the
+	// coordinator can connect to the runner by IP without TLS errors.
+	block, _ := pem.Decode(joinResult.CertPem())
+	if block == nil {
+		t.Fatal("failed to decode cert PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	wantIPs := []net.IP{
+		net.ParseIP("127.0.0.1"),
+		net.ParseIP("::1"),
+		net.ParseIP("10.0.0.1"),
+	}
+	for _, wantIP := range wantIPs {
+		found := false
+		for _, gotIP := range cert.IPAddresses {
+			if gotIP.Equal(wantIP) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("certificate missing IP SAN %s, got %v", wantIP, cert.IPAddresses)
+		}
+	}
+
+	foundLocalhost := false
+	for _, name := range cert.DNSNames {
+		if name == "localhost" {
+			foundLocalhost = true
+			break
+		}
+	}
+	if !foundLocalhost {
+		t.Errorf("certificate missing DNS SAN 'localhost', got %v", cert.DNSNames)
 	}
 }


### PR DESCRIPTION
When a runner joins the cluster, the coordinator issues it a TLS certificate for its API server. That cert was being created with just a CommonName and no SANs at all. Later, when the coordinator tried to proxy `run` or `exec` to the runner by IP address, Go's TLS verification rightfully rejected the connection: "cannot validate certificate for 10.128.0.39 because it doesn't contain any IP SANs."

The fix is the same pattern we already use in `Coordinator.RunnerConfig()` for the co-located runner case: parse the runner's advertised listen address, and include it (plus the usual localhost defaults) in the certificate's IP and DNS SANs. The listen address is already available in the `Join` handler, it just wasn't being used for cert generation.

Fixes MIR-920