### PR TITLE
Add `runner remove` command to deregister stale nodes

### DIFF
--- a/api/runner/rpc.yml
+++ b/api/runner/rpc.yml
@@ -117,6 +117,30 @@ interfaces:
             element: RunnerInfo
             doc: List of registered runners
 
+      - name: RemoveRunner
+        index: 5
+        doc: Remove a registered runner and clean up associated resources
+        parameters:
+          - name: query
+            type: string
+            doc: Runner to remove (name, ID, or short ID)
+          - name: force
+            type: bool
+            doc: Force removal even if the runner has active sandboxes
+        results:
+          - name: name
+            type: string
+            doc: Name of the removed runner
+          - name: runner_id
+            type: string
+            doc: Runner ID of the removed runner
+          - name: removed_resources
+            type: int32
+            doc: Number of associated resources that were cleaned up
+          - name: error
+            type: string
+            doc: Error message if removal failed
+
 types:
   - type: InviteInfo
     doc: Information about a runner invite
@@ -166,6 +190,10 @@ types:
         type: string
         index: 2
         doc: Node name
+      - name: short_id
+        type: string
+        index: 8
+        doc: Short identifier for display
       - name: status
         type: string
         index: 3

--- a/api/runner/runner_v1alpha/rpc.gen.go
+++ b/api/runner/runner_v1alpha/rpc.gen.go
@@ -146,6 +146,7 @@ type runnerInfoData struct {
 	ApiAddress   *string             `cbor:"5,keyasint,omitempty" json:"api_address,omitempty"`
 	Labels       *[]string           `cbor:"6,keyasint,omitempty" json:"labels,omitempty"`
 	RegisteredAt *standard.Timestamp `cbor:"7,keyasint,omitempty" json:"registered_at,omitempty"`
+	ShortId      *string             `cbor:"8,keyasint,omitempty" json:"short_id,omitempty"`
 }
 
 type RunnerInfo struct {
@@ -268,6 +269,21 @@ func (v *RunnerInfo) RegisteredAt() *standard.Timestamp {
 
 func (v *RunnerInfo) SetRegisteredAt(registered_at *standard.Timestamp) {
 	v.data.RegisteredAt = registered_at
+}
+
+func (v *RunnerInfo) HasShortId() bool {
+	return v.data.ShortId != nil
+}
+
+func (v *RunnerInfo) ShortId() string {
+	if v.data.ShortId == nil {
+		return ""
+	}
+	return *v.data.ShortId
+}
+
+func (v *RunnerInfo) SetShortId(short_id string) {
+	v.data.ShortId = &short_id
 }
 
 func (v *RunnerInfo) MarshalCBOR() ([]byte, error) {
@@ -713,6 +729,98 @@ func (v *RunnerRegistrationListRunnersResults) UnmarshalJSON(data []byte) error 
 	return json.Unmarshal(data, &v.data)
 }
 
+type runnerRegistrationRemoveRunnerArgsData struct {
+	Query *string `cbor:"0,keyasint,omitempty" json:"query,omitempty"`
+	Force *bool   `cbor:"1,keyasint,omitempty" json:"force,omitempty"`
+}
+
+type RunnerRegistrationRemoveRunnerArgs struct {
+	call rpc.Call
+	data runnerRegistrationRemoveRunnerArgsData
+}
+
+func (v *RunnerRegistrationRemoveRunnerArgs) HasQuery() bool {
+	return v.data.Query != nil
+}
+
+func (v *RunnerRegistrationRemoveRunnerArgs) Query() string {
+	if v.data.Query == nil {
+		return ""
+	}
+	return *v.data.Query
+}
+
+func (v *RunnerRegistrationRemoveRunnerArgs) HasForce() bool {
+	return v.data.Force != nil
+}
+
+func (v *RunnerRegistrationRemoveRunnerArgs) Force() bool {
+	if v.data.Force == nil {
+		return false
+	}
+	return *v.data.Force
+}
+
+func (v *RunnerRegistrationRemoveRunnerArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *RunnerRegistrationRemoveRunnerArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *RunnerRegistrationRemoveRunnerArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *RunnerRegistrationRemoveRunnerArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type runnerRegistrationRemoveRunnerResultsData struct {
+	Name             *string `cbor:"0,keyasint,omitempty" json:"name,omitempty"`
+	RunnerId         *string `cbor:"1,keyasint,omitempty" json:"runner_id,omitempty"`
+	RemovedResources *int32  `cbor:"2,keyasint,omitempty" json:"removed_resources,omitempty"`
+	Error            *string `cbor:"3,keyasint,omitempty" json:"error,omitempty"`
+}
+
+type RunnerRegistrationRemoveRunnerResults struct {
+	call rpc.Call
+	data runnerRegistrationRemoveRunnerResultsData
+}
+
+func (v *RunnerRegistrationRemoveRunnerResults) SetName(name string) {
+	v.data.Name = &name
+}
+
+func (v *RunnerRegistrationRemoveRunnerResults) SetRunnerId(runner_id string) {
+	v.data.RunnerId = &runner_id
+}
+
+func (v *RunnerRegistrationRemoveRunnerResults) SetRemovedResources(removed_resources int32) {
+	v.data.RemovedResources = &removed_resources
+}
+
+func (v *RunnerRegistrationRemoveRunnerResults) SetError(error string) {
+	v.data.Error = &error
+}
+
+func (v *RunnerRegistrationRemoveRunnerResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *RunnerRegistrationRemoveRunnerResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *RunnerRegistrationRemoveRunnerResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *RunnerRegistrationRemoveRunnerResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type RunnerRegistrationCreateInvite struct {
 	rpc.Call
 	args    RunnerRegistrationCreateInviteArgs
@@ -843,12 +951,39 @@ func (t *RunnerRegistrationListRunners) Results() *RunnerRegistrationListRunners
 	return results
 }
 
+type RunnerRegistrationRemoveRunner struct {
+	rpc.Call
+	args    RunnerRegistrationRemoveRunnerArgs
+	results RunnerRegistrationRemoveRunnerResults
+}
+
+func (t *RunnerRegistrationRemoveRunner) Args() *RunnerRegistrationRemoveRunnerArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *RunnerRegistrationRemoveRunner) Results() *RunnerRegistrationRemoveRunnerResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type RunnerRegistration interface {
 	CreateInvite(ctx context.Context, state *RunnerRegistrationCreateInvite) error
 	Join(ctx context.Context, state *RunnerRegistrationJoin) error
 	ListInvites(ctx context.Context, state *RunnerRegistrationListInvites) error
 	RevokeInvite(ctx context.Context, state *RunnerRegistrationRevokeInvite) error
 	ListRunners(ctx context.Context, state *RunnerRegistrationListRunners) error
+	RemoveRunner(ctx context.Context, state *RunnerRegistrationRemoveRunner) error
 }
 
 type reexportRunnerRegistration struct {
@@ -872,6 +1007,10 @@ func (reexportRunnerRegistration) RevokeInvite(ctx context.Context, state *Runne
 }
 
 func (reexportRunnerRegistration) ListRunners(ctx context.Context, state *RunnerRegistrationListRunners) error {
+	panic("not implemented")
+}
+
+func (reexportRunnerRegistration) RemoveRunner(ctx context.Context, state *RunnerRegistrationRemoveRunner) error {
 	panic("not implemented")
 }
 
@@ -924,6 +1063,15 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			Public:        false,
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListRunners(ctx, &RunnerRegistrationListRunners{Call: call})
+			},
+		},
+		{
+			Name:          "RemoveRunner",
+			InterfaceName: "RunnerRegistration",
+			Index:         5,
+			Public:        false,
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.RemoveRunner(ctx, &RunnerRegistrationRemoveRunner{Call: call})
 			},
 		},
 	}
@@ -1204,4 +1352,68 @@ func (v RunnerRegistrationClient) ListRunners(ctx context.Context) (*RunnerRegis
 	}
 
 	return &RunnerRegistrationClientListRunnersResults{client: v.Client, data: ret}, nil
+}
+
+type RunnerRegistrationClientRemoveRunnerResults struct {
+	client rpc.Client
+	data   runnerRegistrationRemoveRunnerResultsData
+}
+
+func (v *RunnerRegistrationClientRemoveRunnerResults) HasName() bool {
+	return v.data.Name != nil
+}
+
+func (v *RunnerRegistrationClientRemoveRunnerResults) Name() string {
+	if v.data.Name == nil {
+		return ""
+	}
+	return *v.data.Name
+}
+
+func (v *RunnerRegistrationClientRemoveRunnerResults) HasRunnerId() bool {
+	return v.data.RunnerId != nil
+}
+
+func (v *RunnerRegistrationClientRemoveRunnerResults) RunnerId() string {
+	if v.data.RunnerId == nil {
+		return ""
+	}
+	return *v.data.RunnerId
+}
+
+func (v *RunnerRegistrationClientRemoveRunnerResults) HasRemovedResources() bool {
+	return v.data.RemovedResources != nil
+}
+
+func (v *RunnerRegistrationClientRemoveRunnerResults) RemovedResources() int32 {
+	if v.data.RemovedResources == nil {
+		return 0
+	}
+	return *v.data.RemovedResources
+}
+
+func (v *RunnerRegistrationClientRemoveRunnerResults) HasError() bool {
+	return v.data.Error != nil
+}
+
+func (v *RunnerRegistrationClientRemoveRunnerResults) Error() string {
+	if v.data.Error == nil {
+		return ""
+	}
+	return *v.data.Error
+}
+
+func (v RunnerRegistrationClient) RemoveRunner(ctx context.Context, query string, force bool) (*RunnerRegistrationClientRemoveRunnerResults, error) {
+	args := RunnerRegistrationRemoveRunnerArgs{}
+	args.data.Query = &query
+	args.data.Force = &force
+
+	var ret runnerRegistrationRemoveRunnerResultsData
+
+	err := v.Call(ctx, "RemoveRunner", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunnerRegistrationClientRemoveRunnerResults{client: v.Client, data: ret}, nil
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -655,6 +655,17 @@ miren deploy --analyze
 				Body: "miren runner invite list",
 			}),
 		))
+		d.Dispatch("runner remove", Infer("runner remove", "Remove a registered runner and clean up resources", RunnerRemove,
+			WithLabsFeature(labs.FeatureDistributedRunners),
+			WithExample(mflags.Example{
+				Name: "Remove a runner by name",
+				Body: "miren runner remove my-runner",
+			}),
+			WithExample(mflags.Example{
+				Name: "Force remove a runner with active sandboxes",
+				Body: "miren runner remove my-runner --force",
+			}),
+		))
 	}
 
 	// Server commands

--- a/cli/commands/runner_list.go
+++ b/cli/commands/runner_list.go
@@ -33,6 +33,7 @@ func RunnerList(ctx *Context, opts struct {
 	if opts.IsJSON() {
 		type RunnerJSON struct {
 			ID           string   `json:"id"`
+			ShortID      string   `json:"short_id,omitempty"`
 			RunnerID     string   `json:"runner_id"`
 			Name         string   `json:"name"`
 			Status       string   `json:"status"`
@@ -46,6 +47,7 @@ func RunnerList(ctx *Context, opts struct {
 		for _, r := range runners {
 			rj := RunnerJSON{
 				ID:         r.Id(),
+				ShortID:    r.ShortId(),
 				RunnerID:   r.RunnerId(),
 				Name:       r.Name(),
 				Status:     r.Status(),
@@ -67,10 +69,12 @@ func RunnerList(ctx *Context, opts struct {
 		return nil
 	}
 
-	headers := []string{"NAME", "STATUS", "VERSION", "ADDRESS", "REGISTERED"}
+	headers := []string{"ID", "NAME", "STATUS", "VERSION", "ADDRESS", "REGISTERED"}
 	var rows []ui.Row
 
 	for _, r := range runners {
+		id := ui.DisplayShortID(r.ShortId(), r.Id())
+
 		name := r.Name()
 		if name == "" {
 			name = r.RunnerId()
@@ -106,7 +110,7 @@ func RunnerList(ctx *Context, opts struct {
 			registered = formatDuration(time.Since(standard.FromTimestamp(r.RegisteredAt()))) + " ago"
 		}
 
-		rows = append(rows, ui.Row{name, status, version, addr, registered})
+		rows = append(rows, ui.Row{id, name, status, version, addr, registered})
 	}
 
 	sort.Slice(rows, func(i, j int) bool {

--- a/cli/commands/runner_remove.go
+++ b/cli/commands/runner_remove.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/api/runner/runner_v1alpha"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+func RunnerRemove(ctx *Context, opts struct {
+	ConfigCentric
+
+	Force bool `long:"force" short:"f" description:"Force removal even if the runner has active sandboxes"`
+
+	Args struct {
+		Node string `positional-arg-name:"node" description:"Runner to remove (name, ID, or short ID)" required:"true"`
+	} `positional-args:"yes" required:"true"`
+}) error {
+	client, err := ctx.RPCClient(rpc.ServiceRunner)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	rc := runner_v1alpha.NewRunnerRegistrationClient(client)
+
+	res, err := rc.RemoveRunner(ctx, opts.Args.Node, opts.Force)
+	if err != nil {
+		return err
+	}
+
+	if res.Error() != "" {
+		return fmt.Errorf("%s", res.Error())
+	}
+
+	ctx.Printf("Removed runner %q", res.Name())
+	if res.RemovedResources() > 0 {
+		ctx.Printf(" (%d associated resources cleaned up)", res.RemovedResources())
+	}
+	ctx.Printf("\n")
+
+	return nil
+}

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -272,6 +272,7 @@
       "command/runner-invite-list",
       "command/runner-join",
       "command/runner-list",
+      "command/runner-remove",
       "command/runner-revoke",
       "command/runner-start",
       "command/runner-status"

--- a/docs/docs/command/runner-remove.md
+++ b/docs/docs/command/runner-remove.md
@@ -1,0 +1,49 @@
+---
+title: "miren runner remove"
+sidebar_label: "runner remove"
+description: "Remove a registered runner and clean up resources"
+---
+
+# miren runner remove
+
+Remove a registered runner and clean up resources
+
+:::note
+This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
+:::
+
+## Usage
+
+```bash
+miren runner remove [flags]
+```
+
+## Flags
+
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--force, -f` — Force removal even if the runner has active sandboxes
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Remove a runner by name:**
+
+```bash
+miren runner remove my-runner
+```
+
+**Force remove a runner with active sandboxes:**
+
+```bash
+miren runner remove my-runner --force
+```
+
+## See also
+
+- [`miren runner`](/command/runner)

--- a/docs/docs/command/runner.md
+++ b/docs/docs/command/runner.md
@@ -19,6 +19,7 @@ miren runner [flags]
 - [`miren runner invite`](/command/runner-invite) — Create a join code for a new runner
 - [`miren runner join`](/command/runner-join) — Join this machine to a coordinator as a runner
 - [`miren runner list`](/command/runner-list) — List all registered runners
+- [`miren runner remove`](/command/runner-remove) — Remove a registered runner and clean up resources
 - [`miren runner revoke`](/command/runner-revoke) — Revoke a runner invitation
 - [`miren runner start`](/command/runner-start) — Start this machine as a distributed runner
 - [`miren runner status`](/command/runner-status) — Show runner health and configuration

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -189,6 +189,7 @@ Complete reference for all `miren` CLI commands.
 | [`miren runner invite list`](/command/runner-invite-list) | List all runner invitations _(`distributedrunners`)_ |
 | [`miren runner join`](/command/runner-join) | Join this machine to a coordinator as a runner _(`distributedrunners`)_ |
 | [`miren runner list`](/command/runner-list) | List all registered runners _(`distributedrunners`)_ |
+| [`miren runner remove`](/command/runner-remove) | Remove a registered runner and clean up resources _(`distributedrunners`)_ |
 | [`miren runner revoke`](/command/runner-revoke) | Revoke a runner invitation _(`distributedrunners`)_ |
 | [`miren runner start`](/command/runner-start) | Start this machine as a distributed runner _(`distributedrunners`)_ |
 | [`miren runner status`](/command/runner-status) | Show runner health and configuration _(`distributedrunners`)_ |

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -13,6 +13,7 @@ import (
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/runner/runner_v1alpha"
+	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/caauth"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
@@ -409,6 +410,11 @@ func (s *RegistrationServer) ListRunners(ctx context.Context, req *runner_v1alph
 			name = string(node.ID)
 		}
 		info.SetName(name)
+
+		wrapper := &rpcEntityWrapper{entity: e}
+		if attr, ok := wrapper.Get(entity.DBShortId); ok {
+			info.SetShortId(attr.Value.String())
+		}
 		info.SetStatus(string(node.Status))
 		info.SetVersion(node.Version)
 		info.SetApiAddress(node.ApiAddress)
@@ -428,6 +434,168 @@ func (s *RegistrationServer) ListRunners(ctx context.Context, req *runner_v1alph
 
 	results.SetRunners(runners)
 	return nil
+}
+
+func (s *RegistrationServer) RemoveRunner(ctx context.Context, req *runner_v1alpha.RunnerRegistrationRemoveRunner) error {
+	args := req.Args()
+	results := req.Results()
+
+	if !args.HasQuery() || args.Query() == "" {
+		results.SetError("runner name or ID is required")
+		return nil
+	}
+
+	query := args.Query()
+	force := args.HasForce() && args.Force()
+
+	// Find the node entity matching the query
+	node, nodeID, err := s.findNodeByQuery(ctx, query)
+	if err != nil {
+		s.Log.Error("Failed to find runner", "query", query, "error", err)
+		results.SetError("failed to find runner")
+		return nil
+	}
+	if node == nil {
+		results.SetError(fmt.Sprintf("runner %q not found", query))
+		return nil
+	}
+
+	// Check for active schedules (sandboxes assigned to this node)
+	scheduleCount, err := s.countNodeSchedules(ctx, nodeID)
+	if err != nil {
+		s.Log.Error("Failed to check schedules", "node_id", nodeID, "error", err)
+		results.SetError("failed to check for active sandboxes")
+		return nil
+	}
+
+	if scheduleCount > 0 && !force {
+		results.SetError(fmt.Sprintf("runner has %d active sandbox schedule(s); use --force to remove anyway", scheduleCount))
+		return nil
+	}
+
+	// Clean up associated resources
+	removedResources := int32(0)
+
+	// Delete schedules for this node
+	if scheduleCount > 0 {
+		deleted, err := s.deleteNodeSchedules(ctx, nodeID)
+		if err != nil {
+			s.Log.Error("Failed to delete schedules", "node_id", nodeID, "error", err)
+			results.SetError("failed to clean up schedules")
+			return nil
+		}
+		removedResources += int32(deleted)
+	}
+
+	// Delete disk mounts, volumes, and leases for this node
+	for _, ref := range []entity.Attr{
+		entity.Ref(storage_v1alpha.DiskMountNodeIdId, nodeID),
+		entity.Ref(storage_v1alpha.DiskVolumeNodeIdId, nodeID),
+		entity.Ref(storage_v1alpha.DiskLeaseNodeIdId, nodeID),
+	} {
+		deleted, err := s.deleteEntitiesByIndex(ctx, ref)
+		if err != nil {
+			s.Log.Warn("Failed to clean up some resources", "index", ref.ID, "error", err)
+		}
+		removedResources += int32(deleted)
+	}
+
+	// Delete the node entity
+	_, err = s.EAC.Delete(ctx, string(nodeID))
+	if err != nil {
+		s.Log.Error("Failed to delete node entity", "node_id", nodeID, "error", err)
+		results.SetError("failed to delete runner")
+		return nil
+	}
+
+	name := node.Name
+	if name == "" {
+		name = string(nodeID)
+	}
+
+	s.Log.Info("Removed runner",
+		"name", name,
+		"runner_id", node.RunnerId,
+		"node_id", nodeID,
+		"removed_resources", removedResources)
+
+	results.SetName(name)
+	results.SetRunnerId(node.RunnerId)
+	results.SetRemovedResources(removedResources)
+	return nil
+}
+
+// findNodeByQuery looks up a node entity by name, runner ID, entity ID, or short ID prefix.
+func (s *RegistrationServer) findNodeByQuery(ctx context.Context, query string) (*compute_v1alpha.Node, entity.Id, error) {
+	listResp, err := s.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindNode))
+	if err != nil {
+		return nil, "", err
+	}
+
+	query = strings.TrimSpace(query)
+
+	for _, e := range listResp.Values() {
+		var node compute_v1alpha.Node
+		decodeEntity(e, &node)
+
+		if node.RunnerId == "" {
+			continue
+		}
+
+		id := entity.Id(e.Id())
+
+		// Match by entity ID, runner ID, name, or short ID prefix
+		if string(id) == query ||
+			node.RunnerId == query ||
+			(node.Name != "" && node.Name == query) ||
+			strings.HasPrefix(string(id), query) {
+			return &node, id, nil
+		}
+	}
+
+	return nil, "", nil
+}
+
+func (s *RegistrationServer) countNodeSchedules(ctx context.Context, nodeID entity.Id) (int, error) {
+	listResp, err := s.EAC.List(ctx, entity.Ref(compute_v1alpha.KeyNodeId, nodeID))
+	if err != nil {
+		return 0, err
+	}
+	return len(listResp.Values()), nil
+}
+
+func (s *RegistrationServer) deleteNodeSchedules(ctx context.Context, nodeID entity.Id) (int, error) {
+	listResp, err := s.EAC.List(ctx, entity.Ref(compute_v1alpha.KeyNodeId, nodeID))
+	if err != nil {
+		return 0, err
+	}
+
+	deleted := 0
+	for _, e := range listResp.Values() {
+		if _, err := s.EAC.Delete(ctx, e.Id()); err != nil {
+			s.Log.Warn("Failed to delete schedule", "id", e.Id(), "error", err)
+			continue
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+func (s *RegistrationServer) deleteEntitiesByIndex(ctx context.Context, ref entity.Attr) (int, error) {
+	listResp, err := s.EAC.List(ctx, ref)
+	if err != nil {
+		return 0, err
+	}
+
+	deleted := 0
+	for _, e := range listResp.Values() {
+		if _, err := s.EAC.Delete(ctx, e.Id()); err != nil {
+			s.Log.Warn("Failed to delete entity", "id", e.Id(), "error", err)
+			continue
+		}
+		deleted++
+	}
+	return deleted, nil
 }
 
 func (s *RegistrationServer) findInviteByHash(ctx context.Context, codeHash string) (*runner_v1alpha.RunnerInvite, int64, error) {

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -452,7 +452,7 @@ func (s *RegistrationServer) RemoveRunner(ctx context.Context, req *runner_v1alp
 	node, nodeID, err := s.findNodeByQuery(ctx, query)
 	if err != nil {
 		s.Log.Error("Failed to find runner", "query", query, "error", err)
-		results.SetError("failed to find runner")
+		results.SetError(err.Error())
 		return nil
 	}
 	if node == nil {
@@ -526,6 +526,8 @@ func (s *RegistrationServer) RemoveRunner(ctx context.Context, req *runner_v1alp
 }
 
 // findNodeByQuery looks up a node entity by name, runner ID, entity ID, or short ID prefix.
+// Exact matches (name, runner ID, entity ID) are returned immediately. Prefix
+// matches are collected and only returned when unambiguous.
 func (s *RegistrationServer) findNodeByQuery(ctx context.Context, query string) (*compute_v1alpha.Node, entity.Id, error) {
 	listResp, err := s.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindNode))
 	if err != nil {
@@ -533,6 +535,12 @@ func (s *RegistrationServer) findNodeByQuery(ctx context.Context, query string) 
 	}
 
 	query = strings.TrimSpace(query)
+
+	type candidate struct {
+		node compute_v1alpha.Node
+		id   entity.Id
+	}
+	var prefixMatches []candidate
 
 	for _, e := range listResp.Values() {
 		var node compute_v1alpha.Node
@@ -544,16 +552,27 @@ func (s *RegistrationServer) findNodeByQuery(ctx context.Context, query string) 
 
 		id := entity.Id(e.Id())
 
-		// Match by entity ID, runner ID, name, or short ID prefix
+		// Exact match by entity ID, runner ID, or name
 		if string(id) == query ||
 			node.RunnerId == query ||
-			(node.Name != "" && node.Name == query) ||
-			strings.HasPrefix(string(id), query) {
+			(node.Name != "" && node.Name == query) {
 			return &node, id, nil
+		}
+
+		// Prefix match by entity ID
+		if strings.HasPrefix(string(id), query) {
+			prefixMatches = append(prefixMatches, candidate{node, id})
 		}
 	}
 
-	return nil, "", nil
+	switch len(prefixMatches) {
+	case 0:
+		return nil, "", nil
+	case 1:
+		return &prefixMatches[0].node, prefixMatches[0].id, nil
+	default:
+		return nil, "", fmt.Errorf("ambiguous query %q matches %d runners", query, len(prefixMatches))
+	}
 }
 
 func (s *RegistrationServer) countNodeSchedules(ctx context.Context, nodeID entity.Id) (int, error) {

--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -133,3 +133,171 @@ func TestJoinCreatesNodeEntity(t *testing.T) {
 		t.Errorf("certificate missing DNS SAN 'localhost', got %v", cert.DNSNames)
 	}
 }
+
+func TestRemoveRunner(t *testing.T) {
+	ctx := context.Background()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ca, err := caauth.New(caauth.Options{
+		CommonName:   "test-ca",
+		Organization: "test",
+	})
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	regServer := NewRegistrationServer(
+		testutils.TestLogger(t),
+		ca,
+		es.EAC,
+		"127.0.0.1:8443",
+		nil, "", "",
+	)
+
+	localClient := rpc.LocalClient(runner_v1alpha.AdaptRunnerRegistration(regServer))
+	client := runner_v1alpha.NewRunnerRegistrationClient(localClient)
+
+	// Create and join a runner
+	inviteResult, err := client.CreateInvite(ctx, nil, 1)
+	if err != nil {
+		t.Fatalf("CreateInvite failed: %v", err)
+	}
+
+	joinResult, err := client.Join(ctx, inviteResult.Code(), "", "10.0.0.1:8443", "test-version", nil, "test-runner")
+	if err != nil {
+		t.Fatalf("Join failed: %v", err)
+	}
+	if joinResult.HasError() {
+		t.Fatalf("Join returned error: %s", joinResult.Error())
+	}
+
+	// Verify the runner shows up in the list
+	listResult, err := client.ListRunners(ctx)
+	if err != nil {
+		t.Fatalf("ListRunners failed: %v", err)
+	}
+	if len(listResult.Runners()) != 1 {
+		t.Fatalf("expected 1 runner, got %d", len(listResult.Runners()))
+	}
+
+	// Remove the runner by name
+	removeResult, err := client.RemoveRunner(ctx, "test-runner", false)
+	if err != nil {
+		t.Fatalf("RemoveRunner failed: %v", err)
+	}
+	if removeResult.Error() != "" {
+		t.Fatalf("RemoveRunner returned error: %s", removeResult.Error())
+	}
+	if removeResult.Name() != "test-runner" {
+		t.Errorf("RemoveRunner returned name %q, want %q", removeResult.Name(), "test-runner")
+	}
+	if removeResult.RunnerId() != joinResult.RunnerId() {
+		t.Errorf("RemoveRunner returned runner_id %q, want %q", removeResult.RunnerId(), joinResult.RunnerId())
+	}
+
+	// Verify the runner is gone
+	listResult, err = client.ListRunners(ctx)
+	if err != nil {
+		t.Fatalf("ListRunners after remove failed: %v", err)
+	}
+	if len(listResult.Runners()) != 0 {
+		t.Errorf("expected 0 runners after remove, got %d", len(listResult.Runners()))
+	}
+}
+
+func TestRemoveRunnerNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ca, err := caauth.New(caauth.Options{
+		CommonName:   "test-ca",
+		Organization: "test",
+	})
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	regServer := NewRegistrationServer(
+		testutils.TestLogger(t),
+		ca,
+		es.EAC,
+		"127.0.0.1:8443",
+		nil, "", "",
+	)
+
+	localClient := rpc.LocalClient(runner_v1alpha.AdaptRunnerRegistration(regServer))
+	client := runner_v1alpha.NewRunnerRegistrationClient(localClient)
+
+	removeResult, err := client.RemoveRunner(ctx, "nonexistent", false)
+	if err != nil {
+		t.Fatalf("RemoveRunner failed: %v", err)
+	}
+	if removeResult.Error() == "" {
+		t.Error("expected error for nonexistent runner, got none")
+	}
+}
+
+func TestRemoveRunnerByRunnerId(t *testing.T) {
+	ctx := context.Background()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ca, err := caauth.New(caauth.Options{
+		CommonName:   "test-ca",
+		Organization: "test",
+	})
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	regServer := NewRegistrationServer(
+		testutils.TestLogger(t),
+		ca,
+		es.EAC,
+		"127.0.0.1:8443",
+		nil, "", "",
+	)
+
+	localClient := rpc.LocalClient(runner_v1alpha.AdaptRunnerRegistration(regServer))
+	client := runner_v1alpha.NewRunnerRegistrationClient(localClient)
+
+	// Create and join a runner
+	inviteResult, err := client.CreateInvite(ctx, nil, 1)
+	if err != nil {
+		t.Fatalf("CreateInvite failed: %v", err)
+	}
+
+	joinResult, err := client.Join(ctx, inviteResult.Code(), "", "10.0.0.2:8443", "v1", nil, "runner-two")
+	if err != nil {
+		t.Fatalf("Join failed: %v", err)
+	}
+	if joinResult.HasError() {
+		t.Fatalf("Join returned error: %s", joinResult.Error())
+	}
+
+	// Remove by runner ID
+	removeResult, err := client.RemoveRunner(ctx, joinResult.RunnerId(), false)
+	if err != nil {
+		t.Fatalf("RemoveRunner failed: %v", err)
+	}
+	if removeResult.Error() != "" {
+		t.Fatalf("RemoveRunner returned error: %s", removeResult.Error())
+	}
+	if removeResult.Name() != "runner-two" {
+		t.Errorf("RemoveRunner returned name %q, want %q", removeResult.Name(), "runner-two")
+	}
+
+	// Verify gone
+	listResult, err := client.ListRunners(ctx)
+	if err != nil {
+		t.Fatalf("ListRunners failed: %v", err)
+	}
+	if len(listResult.Runners()) != 0 {
+		t.Errorf("expected 0 runners, got %d", len(listResult.Runners()))
+	}
+}


### PR DESCRIPTION
After repeated join attempts (or nodes that get decommissioned), the runner list accumulates stale entries that will never come back. `runner revoke` handles invite codes but there was no way to clean up actual registered nodes from etcd.

This adds `miren runner remove <node>` which accepts a node name, runner ID, or short ID prefix. It resolves the node, checks for active sandbox schedules (refusing unless `--force` is passed), cleans up any associated disk resources (mounts, volumes, leases), and deletes the node entity.

While wiring this up, noticed that `runner list` was missed in the short ID sweep (#721), so this also threads short IDs through the runner list output. Users need to be able to discover the identifier to pass to `remove`, after all.

Flannel subnet leases are intentionally skipped here. They have a 24-hour etcd TTL and we're not close to exhausting subnet space, so natural expiry is fine for now.

Closes MIR-917