### PR TITLE
Fix runner CLI commands using unsupported positional arg tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ Running commands:
 
 **Important**: The miren binary must be built **inside** the dev container (not on the host) so it has the correct architecture. Use `./hack/dev-exec make bin/miren` instead of `make bin/miren`.
 
+**Exception**: `go generate` and doc generation (`hack/gen-command-docs`) need host tools like `jq` that aren't in the dev container. For these, build the binary on the host with `make bin/miren` and run `go generate` on the host as well.
+
 **Managing the dev environment:**
 - `make dev-stop` - Stop and remove the persistent dev container
 - `make dev-restart` - Restart the dev environment (stop + start)

--- a/cli/commands/runner_join.go
+++ b/cli/commands/runner_join.go
@@ -24,14 +24,12 @@ func RunnerJoin(ctx *Context, opts struct {
 	ConfigPath  string   `long:"config" description:"Path to save runner config" default:"/var/lib/miren/runner/config.yaml"`
 	RunnerID    string   `long:"runner-id" description:"Specific runner ID to use (for reconnecting)"`
 
-	Args struct {
-		Coordinator string `positional-arg-name:"coordinator" description:"Coordinator address (host:port)"`
-		JoinCode    string `positional-arg-name:"join-code" description:"Join code from 'miren runner invite'"`
-	} `positional-args:"yes"`
+	CoordinatorAddr string `position:"0" usage:"Coordinator address (host:port)"`
+	JoinCode        string `position:"1" usage:"Join code from 'miren runner invite'"`
 }) error {
 	coordinator := opts.Coordinator
 	if coordinator == "" {
-		coordinator = opts.Args.Coordinator
+		coordinator = opts.CoordinatorAddr
 	}
 	if coordinator == "" {
 		return fmt.Errorf("coordinator address is required")
@@ -50,7 +48,7 @@ func RunnerJoin(ctx *Context, opts struct {
 	// Resolve join code: --code flag > positional arg > stdin pipe > TTY prompt
 	code := opts.Code
 	if code == "" {
-		code = opts.Args.JoinCode
+		code = opts.JoinCode
 	}
 	if code == "" {
 		if stat, _ := os.Stdin.Stat(); stat.Mode()&os.ModeCharDevice == 0 {

--- a/cli/commands/runner_remove.go
+++ b/cli/commands/runner_remove.go
@@ -10,11 +10,8 @@ import (
 func RunnerRemove(ctx *Context, opts struct {
 	ConfigCentric
 
-	Force bool `long:"force" short:"f" description:"Force removal even if the runner has active sandboxes"`
-
-	Args struct {
-		Node string `positional-arg-name:"node" description:"Runner to remove (name, ID, or short ID)" required:"true"`
-	} `positional-args:"yes" required:"true"`
+	Force bool   `long:"force" short:"f" description:"Force removal even if the runner has active sandboxes"`
+	Node  string `position:"0" usage:"Runner to remove (name, ID, or short ID)" required:"true"`
 }) error {
 	client, err := ctx.RPCClient(rpc.ServiceRunner)
 	if err != nil {
@@ -24,7 +21,7 @@ func RunnerRemove(ctx *Context, opts struct {
 
 	rc := runner_v1alpha.NewRunnerRegistrationClient(client)
 
-	res, err := rc.RemoveRunner(ctx, opts.Args.Node, opts.Force)
+	res, err := rc.RemoveRunner(ctx, opts.Node, opts.Force)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/runner_revoke.go
+++ b/cli/commands/runner_revoke.go
@@ -10,9 +10,7 @@ import (
 func RunnerRevoke(ctx *Context, opts struct {
 	ConfigCentric
 
-	Args struct {
-		InviteID string `positional-arg-name:"invite-id" description:"ID of the invite to revoke" required:"true"`
-	} `positional-args:"yes" required:"true"`
+	InviteID string `position:"0" usage:"ID of the invite to revoke" required:"true"`
 }) error {
 	client, err := ctx.RPCClient(rpc.ServiceRunner)
 	if err != nil {
@@ -22,7 +20,7 @@ func RunnerRevoke(ctx *Context, opts struct {
 
 	rc := runner_v1alpha.NewRunnerRegistrationClient(client)
 
-	res, err := rc.RevokeInvite(ctx, opts.Args.InviteID)
+	res, err := rc.RevokeInvite(ctx, opts.InviteID)
 	if err != nil {
 		return err
 	}

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,6 @@
+# docs/CLAUDE.md
+
+Files in `docs/docs/command/` and `docs/command-sidebar.json` are generated
+by `hack/gen-command-docs` (triggered via `go generate ./cli/commands/`).
+Do not edit them by hand. Instead, update the command source in
+`cli/commands/` and regenerate.

--- a/docs/docs/command/runner-join.md
+++ b/docs/docs/command/runner-join.md
@@ -15,8 +15,13 @@ This command requires the `distributedrunners` [labs feature](/labs) to be enabl
 ## Usage
 
 ```bash
-miren runner join [flags]
+miren runner join <coordinatoraddr> <joincode> [flags]
 ```
+
+## Arguments
+
+- `coordinatoraddr` — Coordinator address (host:port)
+- `joincode` — Join code from 'miren runner invite'
 
 ## Flags
 

--- a/docs/docs/command/runner-remove.md
+++ b/docs/docs/command/runner-remove.md
@@ -15,8 +15,12 @@ This command requires the `distributedrunners` [labs feature](/labs) to be enabl
 ## Usage
 
 ```bash
-miren runner remove [flags]
+miren runner remove <node> [flags]
 ```
+
+## Arguments
+
+- `node` — Runner to remove (name, ID, or short ID)
 
 ## Flags
 

--- a/docs/docs/command/runner-revoke.md
+++ b/docs/docs/command/runner-revoke.md
@@ -15,8 +15,12 @@ This command requires the `distributedrunners` [labs feature](/labs) to be enabl
 ## Usage
 
 ```bash
-miren runner revoke [flags]
+miren runner revoke <inviteid> [flags]
 ```
+
+## Arguments
+
+- `inviteid` — ID of the invite to revoke
 
 ## Flags
 


### PR DESCRIPTION
The three runner commands (`join`, `revoke`, `remove`) were carrying over a `positional-args:"yes"` struct tag pattern from go-flags that mflags doesn't recognize. Since mflags just silently skips unknown tags, all positional arguments were ignored and users got "unexpected arguments" errors whenever they tried `miren runner join <host> <code>` or `miren runner remove <node>`.

The fix is straightforward: replace the nested `Args` struct with flat fields using mflags' `position:"N"` tags. Regenerated the command docs so the usage lines and argument sections now reflect reality.

Also added a `docs/CLAUDE.md` to prevent future AI-assisted edits from hand-modifying generated command docs, and documented the `go generate` host-tooling exception in the top-level `CLAUDE.md` (the dev container doesn't have `jq`, which the doc generator needs).

Closes MIR-984