### PR TITLE
Thread short IDs through remaining CLI display gaps

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -1986,7 +1986,8 @@ func (v *CrudSetConfigurationArgs) UnmarshalJSON(data []byte) error {
 }
 
 type crudSetConfigurationResultsData struct {
-	VersionId *string `cbor:"0,keyasint,omitempty" json:"versionId,omitempty"`
+	VersionId      *string `cbor:"0,keyasint,omitempty" json:"versionId,omitempty"`
+	VersionShortId *string `cbor:"1,keyasint,omitempty" json:"versionShortId,omitempty"`
 }
 
 type CrudSetConfigurationResults struct {
@@ -1996,6 +1997,10 @@ type CrudSetConfigurationResults struct {
 
 func (v *CrudSetConfigurationResults) SetVersionId(versionId string) {
 	v.data.VersionId = &versionId
+}
+
+func (v *CrudSetConfigurationResults) SetVersionShortId(versionShortId string) {
+	v.data.VersionShortId = &versionShortId
 }
 
 func (v *CrudSetConfigurationResults) MarshalCBOR() ([]byte, error) {
@@ -2051,8 +2056,9 @@ func (v *CrudGetConfigurationArgs) UnmarshalJSON(data []byte) error {
 }
 
 type crudGetConfigurationResultsData struct {
-	Configuration *Configuration `cbor:"0,keyasint,omitempty" json:"configuration,omitempty"`
-	VersionId     *string        `cbor:"1,keyasint,omitempty" json:"versionId,omitempty"`
+	Configuration  *Configuration `cbor:"0,keyasint,omitempty" json:"configuration,omitempty"`
+	VersionId      *string        `cbor:"1,keyasint,omitempty" json:"versionId,omitempty"`
+	VersionShortId *string        `cbor:"2,keyasint,omitempty" json:"versionShortId,omitempty"`
 }
 
 type CrudGetConfigurationResults struct {
@@ -2066,6 +2072,10 @@ func (v *CrudGetConfigurationResults) SetConfiguration(configuration *Configurat
 
 func (v *CrudGetConfigurationResults) SetVersionId(versionId string) {
 	v.data.VersionId = &versionId
+}
+
+func (v *CrudGetConfigurationResults) SetVersionShortId(versionShortId string) {
+	v.data.VersionShortId = &versionShortId
 }
 
 func (v *CrudGetConfigurationResults) MarshalCBOR() ([]byte, error) {
@@ -2352,7 +2362,8 @@ func (v *CrudSetEnvVarArgs) UnmarshalJSON(data []byte) error {
 }
 
 type crudSetEnvVarResultsData struct {
-	VersionId *string `cbor:"0,keyasint,omitempty" json:"versionId,omitempty"`
+	VersionId      *string `cbor:"0,keyasint,omitempty" json:"versionId,omitempty"`
+	VersionShortId *string `cbor:"1,keyasint,omitempty" json:"versionShortId,omitempty"`
 }
 
 type CrudSetEnvVarResults struct {
@@ -2362,6 +2373,10 @@ type CrudSetEnvVarResults struct {
 
 func (v *CrudSetEnvVarResults) SetVersionId(versionId string) {
 	v.data.VersionId = &versionId
+}
+
+func (v *CrudSetEnvVarResults) SetVersionShortId(versionShortId string) {
+	v.data.VersionShortId = &versionShortId
 }
 
 func (v *CrudSetEnvVarResults) MarshalCBOR() ([]byte, error) {
@@ -2441,7 +2456,8 @@ func (v *CrudSetEnvVarsArgs) UnmarshalJSON(data []byte) error {
 }
 
 type crudSetEnvVarsResultsData struct {
-	VersionId *string `cbor:"0,keyasint,omitempty" json:"versionId,omitempty"`
+	VersionId      *string `cbor:"0,keyasint,omitempty" json:"versionId,omitempty"`
+	VersionShortId *string `cbor:"1,keyasint,omitempty" json:"versionShortId,omitempty"`
 }
 
 type CrudSetEnvVarsResults struct {
@@ -2451,6 +2467,10 @@ type CrudSetEnvVarsResults struct {
 
 func (v *CrudSetEnvVarsResults) SetVersionId(versionId string) {
 	v.data.VersionId = &versionId
+}
+
+func (v *CrudSetEnvVarsResults) SetVersionShortId(versionShortId string) {
+	v.data.VersionShortId = &versionShortId
 }
 
 func (v *CrudSetEnvVarsResults) MarshalCBOR() ([]byte, error) {
@@ -2530,8 +2550,9 @@ func (v *CrudDeleteEnvVarArgs) UnmarshalJSON(data []byte) error {
 }
 
 type crudDeleteEnvVarResultsData struct {
-	VersionId     *string `cbor:"0,keyasint,omitempty" json:"versionId,omitempty"`
-	DeletedSource *string `cbor:"1,keyasint,omitempty" json:"deletedSource,omitempty"`
+	VersionId      *string `cbor:"0,keyasint,omitempty" json:"versionId,omitempty"`
+	VersionShortId *string `cbor:"1,keyasint,omitempty" json:"versionShortId,omitempty"`
+	DeletedSource  *string `cbor:"2,keyasint,omitempty" json:"deletedSource,omitempty"`
 }
 
 type CrudDeleteEnvVarResults struct {
@@ -2541,6 +2562,10 @@ type CrudDeleteEnvVarResults struct {
 
 func (v *CrudDeleteEnvVarResults) SetVersionId(versionId string) {
 	v.data.VersionId = &versionId
+}
+
+func (v *CrudDeleteEnvVarResults) SetVersionShortId(versionShortId string) {
+	v.data.VersionShortId = &versionShortId
 }
 
 func (v *CrudDeleteEnvVarResults) SetDeletedSource(deletedSource string) {
@@ -3121,6 +3146,17 @@ func (v *CrudClientSetConfigurationResults) VersionId() string {
 	return *v.data.VersionId
 }
 
+func (v *CrudClientSetConfigurationResults) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *CrudClientSetConfigurationResults) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
+}
+
 func (v CrudClient) SetConfiguration(ctx context.Context, app string, configuration *Configuration) (*CrudClientSetConfigurationResults, error) {
 	args := CrudSetConfigurationArgs{}
 	args.data.App = &app
@@ -3158,6 +3194,17 @@ func (v *CrudClientGetConfigurationResults) VersionId() string {
 		return ""
 	}
 	return *v.data.VersionId
+}
+
+func (v *CrudClientGetConfigurationResults) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *CrudClientGetConfigurationResults) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
 }
 
 func (v CrudClient) GetConfiguration(ctx context.Context, app string) (*CrudClientGetConfigurationResults, error) {
@@ -3258,6 +3305,17 @@ func (v *CrudClientSetEnvVarResults) VersionId() string {
 	return *v.data.VersionId
 }
 
+func (v *CrudClientSetEnvVarResults) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *CrudClientSetEnvVarResults) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
+}
+
 func (v CrudClient) SetEnvVar(ctx context.Context, app string, key string, value string, sensitive bool, service string) (*CrudClientSetEnvVarResults, error) {
 	args := CrudSetEnvVarArgs{}
 	args.data.App = &app
@@ -3292,6 +3350,17 @@ func (v *CrudClientSetEnvVarsResults) VersionId() string {
 	return *v.data.VersionId
 }
 
+func (v *CrudClientSetEnvVarsResults) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *CrudClientSetEnvVarsResults) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
+}
+
 func (v CrudClient) SetEnvVars(ctx context.Context, app string, vars []*NamedValue, service string) (*CrudClientSetEnvVarsResults, error) {
 	args := CrudSetEnvVarsArgs{}
 	args.data.App = &app
@@ -3323,6 +3392,17 @@ func (v *CrudClientDeleteEnvVarResults) VersionId() string {
 		return ""
 	}
 	return *v.data.VersionId
+}
+
+func (v *CrudClientDeleteEnvVarResults) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *CrudClientDeleteEnvVarResults) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
 }
 
 func (v *CrudClientDeleteEnvVarResults) HasDeletedSource() bool {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -388,6 +388,8 @@ interfaces:
         results:
           - name: versionId
             type: string
+          - name: versionShortId
+            type: string
       - name: getConfiguration
         parameters:
           - name: app
@@ -396,6 +398,8 @@ interfaces:
           - name: configuration
             type: Configuration
           - name: versionId
+            type: string
+          - name: versionShortId
             type: string
       - name: setHost
         parameters:
@@ -428,6 +432,8 @@ interfaces:
         results:
           - name: versionId
             type: string
+          - name: versionShortId
+            type: string
       - name: setEnvVars
         parameters:
           - name: app
@@ -441,6 +447,8 @@ interfaces:
         results:
           - name: versionId
             type: string
+          - name: versionShortId
+            type: string
       - name: deleteEnvVar
         parameters:
           - name: app
@@ -452,6 +460,8 @@ interfaces:
             doc: "Optional service name for per-service env vars. Empty means global."
         results:
           - name: versionId
+            type: string
+          - name: versionShortId
             type: string
           - name: deletedSource
             type: string

--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -1089,8 +1089,9 @@ func (v *BuilderBuildFromTarArgs) UnmarshalJSON(data []byte) error {
 }
 
 type builderBuildFromTarResultsData struct {
-	Version    *string      `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
-	AccessInfo **AccessInfo `cbor:"1,keyasint,omitempty" json:"access_info,omitempty"`
+	Version        *string      `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
+	VersionShortId *string      `cbor:"1,keyasint,omitempty" json:"version_short_id,omitempty"`
+	AccessInfo     **AccessInfo `cbor:"2,keyasint,omitempty" json:"access_info,omitempty"`
 }
 
 type BuilderBuildFromTarResults struct {
@@ -1100,6 +1101,10 @@ type BuilderBuildFromTarResults struct {
 
 func (v *BuilderBuildFromTarResults) SetVersion(version string) {
 	v.data.Version = &version
+}
+
+func (v *BuilderBuildFromTarResults) SetVersionShortId(version_short_id string) {
+	v.data.VersionShortId = &version_short_id
 }
 
 func (v *BuilderBuildFromTarResults) SetAccessInfo(access_info **AccessInfo) {
@@ -1337,8 +1342,9 @@ func (v *BuilderBuildFromPreparedArgs) UnmarshalJSON(data []byte) error {
 }
 
 type builderBuildFromPreparedResultsData struct {
-	Version    *string      `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
-	AccessInfo **AccessInfo `cbor:"1,keyasint,omitempty" json:"access_info,omitempty"`
+	Version        *string      `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
+	VersionShortId *string      `cbor:"1,keyasint,omitempty" json:"version_short_id,omitempty"`
+	AccessInfo     **AccessInfo `cbor:"2,keyasint,omitempty" json:"access_info,omitempty"`
 }
 
 type BuilderBuildFromPreparedResults struct {
@@ -1348,6 +1354,10 @@ type BuilderBuildFromPreparedResults struct {
 
 func (v *BuilderBuildFromPreparedResults) SetVersion(version string) {
 	v.data.Version = &version
+}
+
+func (v *BuilderBuildFromPreparedResults) SetVersionShortId(version_short_id string) {
+	v.data.VersionShortId = &version_short_id
 }
 
 func (v *BuilderBuildFromPreparedResults) SetAccessInfo(access_info **AccessInfo) {
@@ -1576,6 +1586,17 @@ func (v *BuilderClientBuildFromTarResults) Version() string {
 	return *v.data.Version
 }
 
+func (v *BuilderClientBuildFromTarResults) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *BuilderClientBuildFromTarResults) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
+}
+
 func (v *BuilderClientBuildFromTarResults) HasAccessInfo() bool {
 	return v.data.AccessInfo != nil
 }
@@ -1693,6 +1714,17 @@ func (v *BuilderClientBuildFromPreparedResults) Version() string {
 		return ""
 	}
 	return *v.data.Version
+}
+
+func (v *BuilderClientBuildFromPreparedResults) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *BuilderClientBuildFromPreparedResults) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
 }
 
 func (v *BuilderClientBuildFromPreparedResults) HasAccessInfo() bool {

--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -1090,8 +1090,8 @@ func (v *BuilderBuildFromTarArgs) UnmarshalJSON(data []byte) error {
 
 type builderBuildFromTarResultsData struct {
 	Version        *string      `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
-	VersionShortId *string      `cbor:"1,keyasint,omitempty" json:"version_short_id,omitempty"`
-	AccessInfo     **AccessInfo `cbor:"2,keyasint,omitempty" json:"access_info,omitempty"`
+	AccessInfo     **AccessInfo `cbor:"1,keyasint,omitempty" json:"access_info,omitempty"`
+	VersionShortId *string      `cbor:"2,keyasint,omitempty" json:"version_short_id,omitempty"`
 }
 
 type BuilderBuildFromTarResults struct {
@@ -1103,12 +1103,12 @@ func (v *BuilderBuildFromTarResults) SetVersion(version string) {
 	v.data.Version = &version
 }
 
-func (v *BuilderBuildFromTarResults) SetVersionShortId(version_short_id string) {
-	v.data.VersionShortId = &version_short_id
-}
-
 func (v *BuilderBuildFromTarResults) SetAccessInfo(access_info **AccessInfo) {
 	v.data.AccessInfo = access_info
+}
+
+func (v *BuilderBuildFromTarResults) SetVersionShortId(version_short_id string) {
+	v.data.VersionShortId = &version_short_id
 }
 
 func (v *BuilderBuildFromTarResults) MarshalCBOR() ([]byte, error) {
@@ -1343,8 +1343,8 @@ func (v *BuilderBuildFromPreparedArgs) UnmarshalJSON(data []byte) error {
 
 type builderBuildFromPreparedResultsData struct {
 	Version        *string      `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
-	VersionShortId *string      `cbor:"1,keyasint,omitempty" json:"version_short_id,omitempty"`
-	AccessInfo     **AccessInfo `cbor:"2,keyasint,omitempty" json:"access_info,omitempty"`
+	AccessInfo     **AccessInfo `cbor:"1,keyasint,omitempty" json:"access_info,omitempty"`
+	VersionShortId *string      `cbor:"2,keyasint,omitempty" json:"version_short_id,omitempty"`
 }
 
 type BuilderBuildFromPreparedResults struct {
@@ -1356,12 +1356,12 @@ func (v *BuilderBuildFromPreparedResults) SetVersion(version string) {
 	v.data.Version = &version
 }
 
-func (v *BuilderBuildFromPreparedResults) SetVersionShortId(version_short_id string) {
-	v.data.VersionShortId = &version_short_id
-}
-
 func (v *BuilderBuildFromPreparedResults) SetAccessInfo(access_info **AccessInfo) {
 	v.data.AccessInfo = access_info
+}
+
+func (v *BuilderBuildFromPreparedResults) SetVersionShortId(version_short_id string) {
+	v.data.VersionShortId = &version_short_id
 }
 
 func (v *BuilderBuildFromPreparedResults) MarshalCBOR() ([]byte, error) {
@@ -1586,17 +1586,6 @@ func (v *BuilderClientBuildFromTarResults) Version() string {
 	return *v.data.Version
 }
 
-func (v *BuilderClientBuildFromTarResults) HasVersionShortId() bool {
-	return v.data.VersionShortId != nil
-}
-
-func (v *BuilderClientBuildFromTarResults) VersionShortId() string {
-	if v.data.VersionShortId == nil {
-		return ""
-	}
-	return *v.data.VersionShortId
-}
-
 func (v *BuilderClientBuildFromTarResults) HasAccessInfo() bool {
 	return v.data.AccessInfo != nil
 }
@@ -1606,6 +1595,17 @@ func (v *BuilderClientBuildFromTarResults) AccessInfo() *AccessInfo {
 		return nil
 	}
 	return *v.data.AccessInfo
+}
+
+func (v *BuilderClientBuildFromTarResults) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *BuilderClientBuildFromTarResults) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
 }
 
 func (v BuilderClient) BuildFromTar(ctx context.Context, application string, tardata stream.RecvStream[[]byte], status stream.SendStream[*Status], envVars []*EnvironmentVariable) (*BuilderClientBuildFromTarResults, error) {
@@ -1716,17 +1716,6 @@ func (v *BuilderClientBuildFromPreparedResults) Version() string {
 	return *v.data.Version
 }
 
-func (v *BuilderClientBuildFromPreparedResults) HasVersionShortId() bool {
-	return v.data.VersionShortId != nil
-}
-
-func (v *BuilderClientBuildFromPreparedResults) VersionShortId() string {
-	if v.data.VersionShortId == nil {
-		return ""
-	}
-	return *v.data.VersionShortId
-}
-
 func (v *BuilderClientBuildFromPreparedResults) HasAccessInfo() bool {
 	return v.data.AccessInfo != nil
 }
@@ -1736,6 +1725,17 @@ func (v *BuilderClientBuildFromPreparedResults) AccessInfo() *AccessInfo {
 		return nil
 	}
 	return *v.data.AccessInfo
+}
+
+func (v *BuilderClientBuildFromPreparedResults) HasVersionShortId() bool {
+	return v.data.VersionShortId != nil
+}
+
+func (v *BuilderClientBuildFromPreparedResults) VersionShortId() string {
+	if v.data.VersionShortId == nil {
+		return ""
+	}
+	return *v.data.VersionShortId
 }
 
 func (v BuilderClient) BuildFromPrepared(ctx context.Context, session_id string, tardata stream.RecvStream[[]byte], status stream.SendStream[*Status], envVars []*EnvironmentVariable) (*BuilderClientBuildFromPreparedResults, error) {

--- a/api/build/rpc.yml
+++ b/api/build/rpc.yml
@@ -218,11 +218,11 @@ interfaces:
         results:
           - name: version
             type: string
-          - name: version_short_id
-            type: string
           - name: access_info
             type: '*AccessInfo'
             doc: Information about how to access the deployed app
+          - name: version_short_id
+            type: string
 
       - name: analyzeApp
         doc: Analyze an app without building it, returning detected stack, services, and configuration
@@ -259,9 +259,9 @@ interfaces:
         results:
           - name: version
             type: string
-          - name: version_short_id
-            type: string
           - name: access_info
             type: '*AccessInfo'
             doc: Information about how to access the deployed app
+          - name: version_short_id
+            type: string
 

--- a/api/build/rpc.yml
+++ b/api/build/rpc.yml
@@ -218,6 +218,8 @@ interfaces:
         results:
           - name: version
             type: string
+          - name: version_short_id
+            type: string
           - name: access_info
             type: '*AccessInfo'
             doc: Information about how to access the deployed app
@@ -256,6 +258,8 @@ interfaces:
             doc: Environment variables to set on the app (optional, applied with source=manual)
         results:
           - name: version
+            type: string
+          - name: version_short_id
             type: string
           - name: access_info
             type: '*AccessInfo'

--- a/blackbox/sandbox_test.go
+++ b/blackbox/sandbox_test.go
@@ -16,8 +16,9 @@ func TestSandboxList(t *testing.T) {
 		Testdata: "go-server",
 	})
 
-	// List sandboxes — our app's sandbox should appear in the output
-	r := m.MustRun("sandbox", "list")
+	// List sandboxes — our app's sandbox should appear in the output.
+	// Use JSON format since the table view shows short IDs, not app names.
+	r := m.MustRun("sandbox", "list", "--format", "json")
 	r.RequireContains(t, name)
 }
 

--- a/cli/commands/app_rollback.go
+++ b/cli/commands/app_rollback.go
@@ -68,7 +68,7 @@ func Rollback(ctx *Context, opts struct {
 		items[i] = ui.TablePickerItem{
 			ItemID: dep.AppVersionId(),
 			Columns: []string{
-				dep.AppVersionId(),
+				ui.DisplayShortID(dep.AppVersionShortId(), dep.AppVersionId()),
 				dep.Status(),
 				formatDeploymentTime(dep),
 				gitSha,

--- a/cli/commands/app_status.go
+++ b/cli/commands/app_status.go
@@ -83,7 +83,8 @@ func AppStatus(ctx *Context, opts struct {
 
 	// Version info
 	if appResult.HasVersionId() && appResult.VersionId() != "" {
-		ctx.Printf("%s %s\n", labelStyle.Render("Current Version:"), appResult.VersionId())
+		versionDisplay := ui.DisplayShortID(appResult.VersionShortId(), appResult.VersionId())
+		ctx.Printf("%s %s\n", labelStyle.Render("Current Version:"), versionDisplay)
 	} else {
 		ctx.Printf("%s %s\n", labelStyle.Render("Current Version:"), yellowStyle.Render("No version deployed"))
 	}

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -553,6 +553,8 @@ func Deploy(ctx *Context, opts struct {
 	// buildCall wraps either BuildFromTar or BuildFromPrepared
 	type buildResults interface {
 		Version() string
+		HasVersionShortId() bool
+		VersionShortId() string
 		HasAccessInfo() bool
 		AccessInfo() *build_v1alpha.AccessInfo
 	}
@@ -813,9 +815,6 @@ func Deploy(ctx *Context, opts struct {
 
 	ctx.Log.Debug("Build completed", "version", results.Version())
 
-	// For now, use the version string as the app version identifier
-	// The build service creates app_version entities but we can't easily look them up yet
-	// TODO: Implement proper app version entity lookup when entity service access is available in CLI
 	appVersionId := results.Version()
 	if appVersionId == "" {
 		updateDeploymentOnError("Build did not return a version")
@@ -848,7 +847,8 @@ func Deploy(ctx *Context, opts struct {
 	}
 	finalizeSpan.End()
 
-	ctx.Printf("\n\nUpdated version %s deployed. All traffic moved to new version.\n", results.Version())
+	versionDisplay := ui.DisplayShortID(results.VersionShortId(), results.Version())
+	ctx.Printf("\n\nUpdated version %s deployed. All traffic moved to new version.\n", versionDisplay)
 
 	if len(deployWarnings) > 0 {
 		warnHeaderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("208")).Bold(true)

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -57,20 +57,16 @@ func SandboxList(ctx *Context, opts struct {
 		poolShortIdMap[pool.ID.String()] = ui.BriefId(e.Entity())
 	}
 
-	// Build a map of version ID -> short ID
-	versionKindRes, err := eac.LookupKind(ctx, "app_version")
-	if err != nil {
-		return err
-	}
-	versionsRes, err := eac.List(ctx, versionKindRes.Attr())
-	if err != nil {
-		return err
-	}
+	// Build a map of version ID -> short ID (best-effort for display)
 	versionShortIdMap := make(map[string]string)
-	for _, e := range versionsRes.Values() {
-		var v core_v1alpha.AppVersion
-		v.Decode(e.Entity())
-		versionShortIdMap[v.ID.String()] = ui.BriefId(e.Entity())
+	if versionKindRes, err := eac.LookupKind(ctx, "app_version"); err == nil {
+		if versionsRes, err := eac.List(ctx, versionKindRes.Attr()); err == nil {
+			for _, e := range versionsRes.Values() {
+				var v core_v1alpha.AppVersion
+				v.Decode(e.Entity())
+				versionShortIdMap[v.ID.String()] = ui.BriefId(e.Entity())
+			}
+		}
 	}
 
 	// Build a map of node entity ID -> human-readable name

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -54,7 +54,9 @@ func SandboxList(ctx *Context, opts struct {
 		var pool compute_v1alpha.SandboxPool
 		pool.Decode(e.Entity())
 		poolServiceMap[pool.ID.String()] = pool.Service
-		poolShortIdMap[pool.ID.String()] = ui.BriefId(e.Entity())
+		if sid := e.Entity().ShortId(); sid != "" {
+			poolShortIdMap[pool.ID.String()] = sid
+		}
 	}
 
 	// Build a map of version ID -> short ID (best-effort for display)
@@ -64,7 +66,9 @@ func SandboxList(ctx *Context, opts struct {
 			for _, e := range versionsRes.Values() {
 				var v core_v1alpha.AppVersion
 				v.Decode(e.Entity())
-				versionShortIdMap[v.ID.String()] = ui.BriefId(e.Entity())
+				if sid := e.Entity().ShortId(); sid != "" {
+					versionShortIdMap[v.ID.String()] = sid
+				}
 			}
 		}
 	}

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -47,12 +47,30 @@ func SandboxList(ctx *Context, opts struct {
 		return err
 	}
 
-	// Create a map of pool ID -> service
+	// Create maps of pool ID -> service and pool ID -> short ID
 	poolServiceMap := make(map[string]string)
+	poolShortIdMap := make(map[string]string)
 	for _, e := range poolsRes.Values() {
 		var pool compute_v1alpha.SandboxPool
 		pool.Decode(e.Entity())
 		poolServiceMap[pool.ID.String()] = pool.Service
+		poolShortIdMap[pool.ID.String()] = ui.BriefId(e.Entity())
+	}
+
+	// Build a map of version ID -> short ID
+	versionKindRes, err := eac.LookupKind(ctx, "app_version")
+	if err != nil {
+		return err
+	}
+	versionsRes, err := eac.List(ctx, versionKindRes.Attr())
+	if err != nil {
+		return err
+	}
+	versionShortIdMap := make(map[string]string)
+	for _, e := range versionsRes.Values() {
+		var v core_v1alpha.AppVersion
+		v.Decode(e.Entity())
+		versionShortIdMap[v.ID.String()] = ui.BriefId(e.Entity())
 	}
 
 	// Build a map of node entity ID -> human-readable name
@@ -221,9 +239,20 @@ func SandboxList(ctx *Context, opts struct {
 			sandboxId = ui.BriefId(e.Entity())
 		}
 
+		// Resolve version display: prefer short ID
+		versionDisplay := ui.DisplayAppVersion(sandbox.Spec.Version.String())
+		if shortId, ok := versionShortIdMap[sandbox.Spec.Version.String()]; ok {
+			versionDisplay = shortId
+		}
+
+		// Resolve pool display: prefer short ID
+		if shortId, ok := poolShortIdMap[poolLabel]; ok {
+			poolLabelDisplay = shortId
+		}
+
 		rows = append(rows, ui.Row{
 			sandboxId,
-			ui.DisplayAppVersion(sandbox.Spec.Version.String()),
+			versionDisplay,
 			service,
 			poolLabelDisplay,
 			address,

--- a/cli/commands/sandbox_pool_list.go
+++ b/cli/commands/sandbox_pool_list.go
@@ -43,11 +43,13 @@ func SandboxPoolList(ctx *Context, opts struct {
 		return err
 	}
 
-	// Build resolved config spec map for lookup
+	// Build resolved config spec map and version short ID map for lookup
 	specMap := make(map[string]*core_v1alpha.ConfigSpec)
+	versionShortIdMap := make(map[string]string)
 	for _, e := range versionsRes.Values() {
 		v := new(core_v1alpha.AppVersion)
 		v.Decode(e.Entity())
+		versionShortIdMap[v.ID.String()] = ui.BriefId(e.Entity())
 		if resolvedCfg, err := coreutil.ResolveConfig(ctx, eac, v); err == nil {
 			specMap[v.ID.String()] = resolvedCfg
 		}
@@ -83,9 +85,14 @@ func SandboxPoolList(ctx *Context, opts struct {
 			}
 		}
 
+		versionDisplay := ui.DisplayAppVersion(pool.SandboxSpec.Version.String())
+		if shortId, ok := versionShortIdMap[pool.SandboxSpec.Version.String()]; ok {
+			versionDisplay = shortId
+		}
+
 		rows = append(rows, ui.Row{
 			ui.BriefId(e.Entity()),
-			ui.DisplayAppVersion(pool.SandboxSpec.Version.String()),
+			versionDisplay,
 			pool.Service,
 			mode,
 			fmt.Sprintf("%d", pool.DesiredInstances),

--- a/cli/commands/sandbox_pool_list.go
+++ b/cli/commands/sandbox_pool_list.go
@@ -49,7 +49,9 @@ func SandboxPoolList(ctx *Context, opts struct {
 	for _, e := range versionsRes.Values() {
 		v := new(core_v1alpha.AppVersion)
 		v.Decode(e.Entity())
-		versionShortIdMap[v.ID.String()] = ui.BriefId(e.Entity())
+		if sid := e.Entity().ShortId(); sid != "" {
+			versionShortIdMap[v.ID.String()] = sid
+		}
 		if resolvedCfg, err := coreutil.ResolveConfig(ctx, eac, v); err == nil {
 			specMap[v.ID.String()] = resolvedCfg
 		}

--- a/cli/commands/sandbox_pool_set_desired.go
+++ b/cli/commands/sandbox_pool_set_desired.go
@@ -8,6 +8,7 @@ import (
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/ui"
 )
 
 func SandboxPoolSetDesired(ctx *Context, opts struct {
@@ -68,7 +69,7 @@ func SandboxPoolSetDesired(ctx *Context, opts struct {
 	// Check if there's actually a change
 	if newDesired == pool.DesiredInstances {
 		ctx.Printf("Pool %s (service=%s) already has desired_instances=%d\n",
-			pool.ID.String(), pool.Service, pool.DesiredInstances)
+			ui.BriefId(getRes.Entity().Entity()), pool.Service, pool.DesiredInstances)
 		return nil
 	}
 
@@ -91,7 +92,7 @@ func SandboxPoolSetDesired(ctx *Context, opts struct {
 	}
 
 	ctx.Printf("Successfully updated sandbox pool:\n")
-	ctx.Printf("  Pool ID: %s\n", pool.ID.String())
+	ctx.Printf("  Pool ID: %s\n", ui.BriefId(getRes.Entity().Entity()))
 	ctx.Printf("  Service: %s\n", pool.Service)
 	ctx.Printf("  Previous desired_instances: %d\n", pool.DesiredInstances)
 	ctx.Printf("  New desired_instances: %d\n", newDesired)

--- a/cli/commands/set.go
+++ b/cli/commands/set.go
@@ -36,7 +36,7 @@ func Set(ctx *Context, opts struct {
 		return err
 	}
 
-	ctx.Printf("new version id: %s\n", ui.CleanEntityID(setres.VersionId()))
+	ctx.Printf("new version id: %s\n", ui.DisplayShortID(setres.VersionShortId(), setres.VersionId()))
 
 	return nil
 }

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -54,6 +54,16 @@ func NewAppInfo(log *slog.Logger, ec *entityserver.Client, cpu *metrics.CPUUsage
 
 var _ app_v1alpha.Crud = &AppInfo{}
 
+// versionShortId looks up the short ID for a version entity by its full ID.
+func (r *AppInfo) versionShortId(ctx context.Context, versionId string) string {
+	var v core_v1alpha.AppVersion
+	ent, err := r.EC.GetByIdWithEntity(ctx, entity.Id(versionId), &v)
+	if err != nil {
+		return ""
+	}
+	return shortIDFromEntity(ent)
+}
+
 func shortIDFromEntity(ent *entityserver_v1alpha.Entity) string {
 	if ent == nil {
 		return ""
@@ -427,6 +437,9 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 	}
 
 	state.Results().SetVersionId(appVer.Version)
+	if sid := r.versionShortId(ctx, string(avid)); sid != "" {
+		state.Results().SetVersionShortId(sid)
+	}
 
 	return nil
 }
@@ -525,6 +538,10 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 	cfg.SetEntrypoint(spec.Entrypoint)
 
 	state.Results().SetConfiguration(&cfg)
+	state.Results().SetVersionId(appVer.Version)
+	if sid := r.versionShortId(ctx, string(appRec.ActiveVersion)); sid != "" {
+		state.Results().SetVersionShortId(sid)
+	}
 
 	return nil
 }
@@ -576,6 +593,9 @@ func (r *AppInfo) SetEnvVar(ctx context.Context, state *app_v1alpha.CrudSetEnvVa
 	}
 
 	state.Results().SetVersionId(versionId)
+	if sid := r.versionShortId(ctx, versionId); sid != "" {
+		state.Results().SetVersionShortId(sid)
+	}
 	return nil
 }
 
@@ -598,6 +618,9 @@ func (r *AppInfo) SetEnvVars(ctx context.Context, state *app_v1alpha.CrudSetEnvV
 	}
 
 	state.Results().SetVersionId(versionId)
+	if sid := r.versionShortId(ctx, versionId); sid != "" {
+		state.Results().SetVersionShortId(sid)
+	}
 	return nil
 }
 
@@ -610,6 +633,9 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 	}
 
 	state.Results().SetVersionId(result.VersionID)
+	if sid := r.versionShortId(ctx, result.VersionID); sid != "" {
+		state.Results().SetVersionShortId(sid)
+	}
 	if len(result.DeletedSources) > 0 {
 		state.Results().SetDeletedSource(result.DeletedSources[0])
 	}

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -930,6 +930,9 @@ func (b *Builder) BuildFromTar(ctx context.Context, state *build_v1alpha.Builder
 	}
 
 	state.Results().SetVersion(result.version)
+	if result.versionShortId != "" {
+		state.Results().SetVersionShortId(result.versionShortId)
+	}
 	state.Results().SetAccessInfo(&result.accessInfo)
 
 	return nil
@@ -1064,14 +1067,18 @@ func (b *Builder) BuildFromPrepared(ctx context.Context, state *build_v1alpha.Bu
 	}
 
 	state.Results().SetVersion(result.version)
+	if result.versionShortId != "" {
+		state.Results().SetVersionShortId(result.versionShortId)
+	}
 	state.Results().SetAccessInfo(&result.accessInfo)
 
 	return nil
 }
 
 type buildResult struct {
-	version    string
-	accessInfo *build_v1alpha.AccessInfo
+	version        string
+	versionShortId string
+	accessInfo     *build_v1alpha.AccessInfo
 }
 
 func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
@@ -1472,9 +1479,21 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 
 	accessInfo := b.getAccessInfo(ctx, name)
 
+	// Look up the short ID for the newly created version entity
+	var versionShortId string
+	if ent, err := b.ec.GetByIdWithEntity(ctx, id, mrv); err == nil {
+		for _, attr := range ent.Attrs() {
+			if entity.Id(attr.ID) == entity.DBShortId {
+				versionShortId = attr.Value.String()
+				break
+			}
+		}
+	}
+
 	return &buildResult{
-		version:    mrv.Version,
-		accessInfo: accessInfo,
+		version:        mrv.Version,
+		versionShortId: versionShortId,
+		accessInfo:     accessInfo,
 	}, nil
 }
 


### PR DESCRIPTION
The first short ID sweep (PR #721) caught the big ones, but a handful of commands were still showing full entity IDs. Two flavors of problem here.

Some commands already had the entity data in hand but weren't extracting short IDs from it. `sandbox list` VERSION and POOL columns, `sandbox pool list` VERSION, `sandbox pool set-desired` output, and `app rollback`'s version picker all fell into this bucket. Straightforward fix: build a lookup map from the entities we're already fetching.

The harder ones were commands where the short ID simply wasn't available. `app status`, `set` (concurrency), and `deploy` all get their version ID from RPC responses that only carried the full string. For these, added `versionShortId` fields to the app and build RPC schemas, wired up the server side to look up the short ID after entity creation, and updated the CLI to prefer the short form when present. All additive optional fields, so fully back compat with older servers.

Closes MIR-947