### PR TITLE
Auto-discover listen address during runner join

### DIFF
--- a/cli/commands/discover_ip.go
+++ b/cli/commands/discover_ip.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+)
+
+// discoverOutboundIP finds the local IP that would be used to reach the given
+// remote address. This gives us the machine's IP on the right interface without
+// actually connecting.
+func discoverOutboundIP(remoteAddr string) (netip.Addr, error) {
+	conn, err := net.Dial("udp4", remoteAddr)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	defer conn.Close()
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return netip.Addr{}, fmt.Errorf("unexpected local address type")
+	}
+	ip4 := addr.IP.To4()
+	if ip4 == nil {
+		return netip.Addr{}, fmt.Errorf("discovered non-IPv4 address: %s", addr.IP)
+	}
+	return netip.AddrFrom4([4]byte(ip4)), nil
+}

--- a/cli/commands/runner_join.go
+++ b/cli/commands/runner_join.go
@@ -92,8 +92,18 @@ func RunnerJoin(ctx *Context, opts struct {
 
 	rc := runner_v1alpha.NewRunnerRegistrationClient(client)
 
+	listenAddr := opts.ListenAddr
+	if listenAddr == "" {
+		ip, err := discoverOutboundIP(coordinator)
+		if err != nil {
+			return fmt.Errorf("could not discover outbound IP for listen address (use --listen to set manually): %w", err)
+		}
+		listenAddr = net.JoinHostPort(ip.String(), "8444")
+		ctx.Log.Info("discovered listen address", "addr", listenAddr)
+	}
+
 	versionInfo := version.GetInfo()
-	res, err := rc.Join(ctx, code, opts.RunnerID, opts.ListenAddr, versionInfo.Version, opts.Labels, name)
+	res, err := rc.Join(ctx, code, opts.RunnerID, listenAddr, versionInfo.Version, opts.Labels, name)
 	if err != nil {
 		return fmt.Errorf("join request failed: %w", err)
 	}

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -300,4 +300,3 @@ func RunnerStart(ctx *Context, opts struct {
 	ctx.Log.Info("runner stopped")
 	return nil
 }
-

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -301,22 +301,3 @@ func RunnerStart(ctx *Context, opts struct {
 	return nil
 }
 
-// discoverOutboundIP finds the local IP that would be used to reach the given
-// remote address. This gives us the machine's IP on the right interface without
-// actually connecting.
-func discoverOutboundIP(remoteAddr string) (netip.Addr, error) {
-	conn, err := net.Dial("udp4", remoteAddr)
-	if err != nil {
-		return netip.Addr{}, err
-	}
-	defer conn.Close()
-	addr, ok := conn.LocalAddr().(*net.UDPAddr)
-	if !ok {
-		return netip.Addr{}, fmt.Errorf("unexpected local address type")
-	}
-	ip4 := addr.IP.To4()
-	if ip4 == nil {
-		return netip.Addr{}, fmt.Errorf("discovered non-IPv4 address: %s", addr.IP)
-	}
-	return netip.AddrFrom4([4]byte(ip4)), nil
-}


### PR DESCRIPTION
`runner start` already had the nice behavior of discovering the machine's outbound IP when no `--listen` flag is provided, but `runner join` was just passing an empty string through to the coordinator. Since certs are issued at join time, this meant the runner's real IP never made it into the certificate's SAN list. You'd join fine, start fine, and then get `x509: certificate is valid for 127.0.0.1, ::1, not 10.128.0.40` the moment the coordinator tried to proxy to the runner.

The fix is the obvious one: call `discoverOutboundIP` in `runner join` the same way `runner start` does, so the cert gets the right IP SAN from the start. `--listen` still works as a manual override.

Closes MIR-999