### PR TITLE
Add `miren runner install` for one-command runner provisioning

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -686,8 +686,8 @@ miren deploy --analyze
 				Body: "miren runner install",
 			}),
 			WithExample(mflags.Example{
-				Name: "Install with coordinator (for automation)",
-				Body: "miren runner install --coordinator host:8443 --invite-code abc123",
+				Name: "Install with token (for automation)",
+				Body: "miren runner install --token mren_...",
 			}),
 		))
 		d.Dispatch("runner uninstall", Infer("runner uninstall", "Remove systemd service for miren runner", RunnerUninstall,

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -679,6 +679,39 @@ miren deploy --analyze
 				Body: "miren runner remove my-runner --force",
 			}),
 		))
+		d.Dispatch("runner install", Infer("runner install", "Install systemd service for miren runner", RunnerInstall,
+			WithLabsFeature(labs.FeatureDistributedRunners),
+			WithExample(mflags.Example{
+				Name: "Install interactively",
+				Body: "miren runner install",
+			}),
+			WithExample(mflags.Example{
+				Name: "Install with coordinator (for automation)",
+				Body: "miren runner install --coordinator host:8443 --invite-code abc123",
+			}),
+		))
+		d.Dispatch("runner uninstall", Infer("runner uninstall", "Remove systemd service for miren runner", RunnerUninstall,
+			WithLabsFeature(labs.FeatureDistributedRunners),
+			WithExample(mflags.Example{
+				Name: "Uninstall the runner service",
+				Body: "miren runner uninstall",
+			}),
+			WithExample(mflags.Example{
+				Name: "Uninstall and remove all runner data",
+				Body: "miren runner uninstall --remove-data",
+			}),
+		))
+		d.Dispatch("runner service-status", Infer("runner service-status", "Show miren-runner systemd service status", RunnerServiceStatus,
+			WithLabsFeature(labs.FeatureDistributedRunners),
+			WithExample(mflags.Example{
+				Name: "Show service status",
+				Body: "miren runner service-status",
+			}),
+			WithExample(mflags.Example{
+				Name: "Follow service logs",
+				Body: "miren runner service-status --follow",
+			}),
+		))
 	}
 
 	// Server commands

--- a/cli/commands/runner_install.go
+++ b/cli/commands/runner_install.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"golang.org/x/term"
+	"miren.dev/runtime/pkg/enrolltoken"
 	"miren.dev/runtime/pkg/runnerconfig"
 	"miren.dev/runtime/pkg/ui"
 	"miren.dev/runtime/version"
@@ -25,8 +26,8 @@ const (
 // joining a coordinator (interactively or via flags), creating the systemd
 // service, and enabling it.
 func RunnerInstall(ctx *Context, opts struct {
-	Coordinator     string   `short:"c" long:"coordinator" description:"Coordinator address (host:port)"`
-	InviteCode      string   `long:"invite-code" description:"Join code from 'miren runner invite'"`
+	Token           string   `short:"t" long:"token" description:"Enrollment token from 'miren runner token create'"`
+	Coordinator     string   `short:"c" long:"coordinator" description:"Override coordinator address from the token"`
 	Name            string   `long:"name" description:"Human-readable name for this runner (defaults to hostname)"`
 	ListenAddr      string   `short:"l" long:"listen" description:"Address this runner will listen on"`
 	Labels          []string `long:"labels" description:"Runner labels (key=value)"`
@@ -89,7 +90,7 @@ func RunnerInstall(ctx *Context, opts struct {
 	}
 
 	// Join flow: use existing config, flags, interactive prompts, or error
-	if err := resolveRunnerJoin(ctx, opts.Coordinator, opts.InviteCode, opts.Name, opts.ListenAddr, opts.Labels, opts.ConfigPath); err != nil {
+	if err := resolveRunnerJoin(ctx, opts.Token, opts.Coordinator, opts.Name, opts.ListenAddr, opts.Labels, opts.ConfigPath); err != nil {
 		return err
 	}
 
@@ -198,9 +199,9 @@ WantedBy=multi-user.target
 }
 
 // resolveRunnerJoin handles the join step of runner installation. It picks the
-// right strategy based on what's available: existing config on disk, flags
-// passed on the command line, or interactive prompts when there's a TTY.
-func resolveRunnerJoin(ctx *Context, coordinator, inviteCode, name, listenAddr string, labels []string, configPath string) error {
+// right strategy based on what's available: existing config on disk, an
+// enrollment token passed via flag, or interactive prompts when there's a TTY.
+func resolveRunnerJoin(ctx *Context, token, coordinatorOverride, name, listenAddr string, labels []string, configPath string) error {
 	// Case 1: config already exists (previous runner join)
 	if runnerconfig.Exists(configPath) {
 		cfg, err := runnerconfig.Load(configPath)
@@ -211,12 +212,19 @@ func resolveRunnerJoin(ctx *Context, coordinator, inviteCode, name, listenAddr s
 		return nil
 	}
 
-	// Case 2: coordinator and invite code provided via flags
-	if coordinator != "" && inviteCode != "" {
+	// Case 2: token provided via flag
+	if token != "" {
+		coordinator, secret, err := decodeToken(token)
+		if err != nil {
+			return err
+		}
+		if coordinatorOverride != "" {
+			coordinator = coordinatorOverride
+		}
 		ctx.Info("Joining coordinator...")
 		return performRunnerJoin(ctx, runnerJoinOpts{
 			Coordinator: coordinator,
-			Code:        inviteCode,
+			Secret:      secret,
 			Name:        name,
 			ListenAddr:  listenAddr,
 			Labels:      labels,
@@ -224,38 +232,33 @@ func resolveRunnerJoin(ctx *Context, coordinator, inviteCode, name, listenAddr s
 		})
 	}
 
-	// Case 3: interactive TTY, prompt for missing values
+	// Case 3: interactive TTY, prompt for the token
 	if term.IsTerminal(int(os.Stdin.Fd())) {
 		ctx.Info("No runner config found. Let's join a coordinator.")
 		fmt.Println()
 
-		if coordinator == "" {
-			var err error
-			coordinator, err = ui.PromptForInput(
-				ui.WithLabel("Coordinator address (host:port)"),
-				ui.WithPlaceholder("coordinator.example.com:8443"),
-			)
-			if err != nil {
-				return fmt.Errorf("failed to read coordinator address: %w", err)
-			}
+		var err error
+		token, err = ui.PromptForInput(
+			ui.WithLabel("Enter enrollment token"),
+			ui.WithPlaceholder("mren_..."),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to read token: %w", err)
 		}
 
-		if inviteCode == "" {
-			var err error
-			inviteCode, err = ui.PromptForInput(
-				ui.WithLabel("Join code"),
-				ui.WithPlaceholder("word-word-word-abc123"),
-			)
-			if err != nil {
-				return fmt.Errorf("failed to read join code: %w", err)
-			}
+		coordinator, secret, err := decodeToken(token)
+		if err != nil {
+			return err
+		}
+		if coordinatorOverride != "" {
+			coordinator = coordinatorOverride
 		}
 
 		fmt.Println()
 		ctx.Info("Joining coordinator...")
 		return performRunnerJoin(ctx, runnerJoinOpts{
 			Coordinator: coordinator,
-			Code:        inviteCode,
+			Secret:      secret,
 			Name:        name,
 			ListenAddr:  listenAddr,
 			Labels:      labels,
@@ -264,12 +267,25 @@ func resolveRunnerJoin(ctx *Context, coordinator, inviteCode, name, listenAddr s
 	}
 
 	// Case 4: non-interactive, missing required info
-	return fmt.Errorf("no runner config found at %s and no coordinator info provided\n\n"+
-		"  Run interactively, or pass --coordinator and --invite-code:\n"+
-		"    miren runner install --coordinator host:port --invite-code <code>\n\n"+
+	return fmt.Errorf("no runner config found at %s and no token provided\n\n"+
+		"  Run interactively, or pass --token:\n"+
+		"    miren runner install --token <enrollment-token>\n\n"+
 		"  Or join first, then install:\n"+
-		"    miren runner join coordinator:8443 <code>\n"+
+		"    miren runner join <token>\n"+
 		"    miren runner install", configPath)
+}
+
+// decodeToken validates and decodes an enrollment token into a coordinator
+// address and secret.
+func decodeToken(token string) (coordinator, secret string, err error) {
+	if !enrolltoken.IsToken(token) {
+		return "", "", fmt.Errorf("invalid token format (expected mren_ prefix)")
+	}
+	coordinator, secret, err = enrolltoken.Decode(token)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid token: %w", err)
+	}
+	return coordinator, secret, nil
 }
 
 // printRunnerPrerequisiteGuidance prints guidance when prerequisites aren't met.

--- a/cli/commands/runner_install.go
+++ b/cli/commands/runner_install.go
@@ -1,0 +1,391 @@
+//go:build linux
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/term"
+	"miren.dev/runtime/pkg/runnerconfig"
+	"miren.dev/runtime/pkg/ui"
+	"miren.dev/runtime/version"
+)
+
+const (
+	runnerServiceName = "miren-runner.service"
+	runnerServicePath = "/etc/systemd/system/miren-runner.service"
+)
+
+// RunnerInstall sets up a systemd unit to run a miren distributed runner.
+// It handles the full provisioning flow: downloading the release bundle,
+// joining a coordinator (interactively or via flags), creating the systemd
+// service, and enabling it.
+func RunnerInstall(ctx *Context, opts struct {
+	Coordinator     string   `short:"c" long:"coordinator" description:"Coordinator address (host:port)"`
+	InviteCode      string   `long:"invite-code" description:"Join code from 'miren runner invite'"`
+	Name            string   `long:"name" description:"Human-readable name for this runner (defaults to hostname)"`
+	ListenAddr      string   `short:"l" long:"listen" description:"Address this runner will listen on"`
+	Labels          []string `long:"labels" description:"Runner labels (key=value)"`
+	Branch          string   `short:"b" long:"branch" description:"Branch to download"`
+	Force           bool     `short:"f" long:"force" description:"Overwrite existing service file"`
+	NoStart         bool     `long:"no-start" description:"Do not start the service after installation"`
+	SkipSystemCheck bool     `long:"skip-system-check" description:"Skip minimum system requirements check"`
+	ConfigPath      string   `long:"config" description:"Path to runner config" default:"/var/lib/miren/runner/config.yaml"`
+	DataPath        string   `long:"data-path" description:"Path to store runner data" default:"/var/lib/miren/runner"`
+}) error {
+	if opts.Branch == "" {
+		if br := version.Branch(); br != "" {
+			opts.Branch = br
+		} else {
+			opts.Branch = "latest"
+		}
+	}
+
+	// Check prerequisites (root + systemd)
+	prereqs := checkInstallPrerequisites()
+	if !prereqs.hasRoot || !prereqs.hasSystemd {
+		printRunnerPrerequisiteGuidance(ctx, prereqs)
+		if !prereqs.hasRoot {
+			return fmt.Errorf("root privileges required")
+		}
+		return fmt.Errorf("systemd not available")
+	}
+	ctx.Completed("Prerequisites verified (root, systemd)")
+
+	// Check system requirements (memory, disk space)
+	if !opts.SkipSystemCheck {
+		sysReqs := checkSystemRequirements()
+		if printSystemRequirementsGuidance(ctx, sysReqs) {
+			return fmt.Errorf("system does not meet minimum requirements")
+		}
+		ctx.Completed("System requirements verified")
+	} else {
+		ctx.Info("Skipping system requirements check (--skip-system-check specified)")
+	}
+
+	// Download release bundle if not present
+	mirenPath := "/var/lib/miren/release/miren"
+	if _, err := os.Stat(mirenPath); err != nil {
+		ctx.Info("Miren release not found at %s, downloading...", mirenPath)
+
+		if err := PerformDownloadRelease(ctx, DownloadReleaseOptions{
+			Branch: opts.Branch,
+			Global: true,
+			Force:  false,
+			Output: "/var/lib/miren/release",
+		}); err != nil {
+			return fmt.Errorf("failed to download release: %w", err)
+		}
+
+		ctx.Completed("Release downloaded successfully")
+		fixSELinuxContext(ctx, mirenPath)
+	}
+
+	// Join flow: use existing config, flags, interactive prompts, or error
+	if err := resolveRunnerJoin(ctx, opts.Coordinator, opts.InviteCode, opts.Name, opts.ListenAddr, opts.Labels, opts.ConfigPath); err != nil {
+		return err
+	}
+
+	// Create systemd service
+	ctx.Info("Installing miren-runner systemd service...")
+
+	serviceExists := false
+	if _, err := os.Stat(runnerServicePath); err == nil {
+		serviceExists = true
+		if !opts.Force {
+			ctx.Info("Service file already exists at %s (skipping, use --force to overwrite)", runnerServicePath)
+		} else {
+			ctx.Info("Service file exists, overwriting due to --force flag")
+		}
+	}
+
+	if !serviceExists || opts.Force {
+		var execStartParts []string
+		execStartParts = append(execStartParts, mirenPath, "runner", "start")
+
+		if opts.ConfigPath != "/var/lib/miren/runner/config.yaml" {
+			execStartParts = append(execStartParts, fmt.Sprintf("--config=%s", opts.ConfigPath))
+		}
+		if opts.DataPath != "/var/lib/miren/runner" {
+			execStartParts = append(execStartParts, fmt.Sprintf("--data-path=%s", opts.DataPath))
+		}
+
+		execStart := strings.Join(execStartParts, " ")
+
+		// Propagate the current MIREN_LABS value so the spawned binary
+		// also has distributed runners (and any other flags) enabled.
+		labsEnv := os.Getenv("MIREN_LABS")
+
+		serviceContent := fmt.Sprintf(`[Unit]
+Description=Miren Runner Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment="NO_COLOR=1"
+Environment="MIREN_LABS=%s"
+ExecStart=%s
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=miren-runner
+User=root
+WorkingDirectory=/var/lib/miren/release
+KillMode=process
+TimeoutStopSec=90s
+
+[Install]
+WantedBy=multi-user.target
+`, labsEnv, execStart)
+
+		if err := os.WriteFile(runnerServicePath, []byte(serviceContent), 0644); err != nil {
+			return fmt.Errorf("failed to write service file: %w", err)
+		}
+
+		ctx.Completed("Service file created at %s", runnerServicePath)
+
+		ctx.Info("Reloading systemd daemon...")
+		cmd := exec.Command("systemctl", "daemon-reload")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to reload systemd: %w\nOutput: %s", err, output)
+		}
+	}
+
+	// Enable and optionally start
+	if opts.NoStart {
+		ctx.Info("Enabling miren-runner service...")
+		cmd := exec.Command("systemctl", "enable", runnerServiceName)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to enable service: %w\nOutput: %s", err, output)
+		}
+		ctx.Completed("Miren runner service enabled (but not started)")
+	} else {
+		ctx.Info("Enabling and starting miren-runner service...")
+		cmd := exec.Command("systemctl", "enable", "--now", runnerServiceName)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to enable and start service: %w\nOutput: %s", err, output)
+		}
+		ctx.Completed("Miren runner service enabled and started")
+
+		statusCmd := exec.Command("systemctl", "is-active", runnerServiceName)
+		if output, err := statusCmd.CombinedOutput(); err == nil && strings.TrimSpace(string(output)) == "active" {
+			ctx.Completed("Service is running")
+		} else {
+			ctx.Warn("Service may not be running, check status with: systemctl status miren-runner")
+		}
+	}
+
+	// Next steps
+	fmt.Println()
+	ctx.Info("Installation complete!")
+	fmt.Println()
+	ctx.Info("To check service status:")
+	fmt.Println("  systemctl status miren-runner")
+	fmt.Println()
+	ctx.Info("To view logs:")
+	fmt.Println("  journalctl -u miren-runner -f")
+
+	return nil
+}
+
+// resolveRunnerJoin handles the join step of runner installation. It picks the
+// right strategy based on what's available: existing config on disk, flags
+// passed on the command line, or interactive prompts when there's a TTY.
+func resolveRunnerJoin(ctx *Context, coordinator, inviteCode, name, listenAddr string, labels []string, configPath string) error {
+	// Case 1: config already exists (previous runner join)
+	if runnerconfig.Exists(configPath) {
+		cfg, err := runnerconfig.Load(configPath)
+		if err != nil {
+			return fmt.Errorf("runner config exists at %s but couldn't be read: %w", configPath, err)
+		}
+		ctx.Completed("Using existing runner config (runner '%s', coordinator %s)", cfg.Name, cfg.CoordinatorAddress)
+		return nil
+	}
+
+	// Case 2: coordinator and invite code provided via flags
+	if coordinator != "" && inviteCode != "" {
+		ctx.Info("Joining coordinator...")
+		return performRunnerJoin(ctx, runnerJoinOpts{
+			Coordinator: coordinator,
+			Code:        inviteCode,
+			Name:        name,
+			ListenAddr:  listenAddr,
+			Labels:      labels,
+			ConfigPath:  configPath,
+		})
+	}
+
+	// Case 3: interactive TTY, prompt for missing values
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		ctx.Info("No runner config found. Let's join a coordinator.")
+		fmt.Println()
+
+		if coordinator == "" {
+			var err error
+			coordinator, err = ui.PromptForInput(
+				ui.WithLabel("Coordinator address (host:port)"),
+				ui.WithPlaceholder("coordinator.example.com:8443"),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to read coordinator address: %w", err)
+			}
+		}
+
+		if inviteCode == "" {
+			var err error
+			inviteCode, err = ui.PromptForInput(
+				ui.WithLabel("Join code"),
+				ui.WithPlaceholder("word-word-word-abc123"),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to read join code: %w", err)
+			}
+		}
+
+		fmt.Println()
+		ctx.Info("Joining coordinator...")
+		return performRunnerJoin(ctx, runnerJoinOpts{
+			Coordinator: coordinator,
+			Code:        inviteCode,
+			Name:        name,
+			ListenAddr:  listenAddr,
+			Labels:      labels,
+			ConfigPath:  configPath,
+		})
+	}
+
+	// Case 4: non-interactive, missing required info
+	return fmt.Errorf("no runner config found at %s and no coordinator info provided\n\n"+
+		"  Run interactively, or pass --coordinator and --invite-code:\n"+
+		"    miren runner install --coordinator host:port --invite-code <code>\n\n"+
+		"  Or join first, then install:\n"+
+		"    miren runner join coordinator:8443 <code>\n"+
+		"    miren runner install", configPath)
+}
+
+// printRunnerPrerequisiteGuidance prints guidance when prerequisites aren't met.
+func printRunnerPrerequisiteGuidance(ctx *Context, prereqs installPrerequisites) {
+	fmt.Println()
+	ctx.Warn("Cannot proceed with runner installation.")
+	fmt.Println()
+
+	if !prereqs.hasRoot {
+		ctx.Info("Root privileges are required.")
+		fmt.Println("  Run with sudo: sudo miren runner install")
+		fmt.Println()
+	}
+
+	if !prereqs.hasSystemd {
+		ctx.Info("systemd is not available on this system.")
+		fmt.Println()
+		ctx.Info("To run the runner directly (for testing):")
+		fmt.Println("  miren runner start")
+	}
+}
+
+// RunnerUninstall removes the miren-runner systemd service.
+func RunnerUninstall(ctx *Context, opts struct {
+	RemoveData bool   `long:"remove-data" description:"Remove runner data directory"`
+	DataPath   string `long:"data-path" description:"Path to runner data" default:"/var/lib/miren/runner"`
+}) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("runner uninstall requires root privileges (use sudo)")
+	}
+
+	if _, err := os.Stat(runnerServicePath); os.IsNotExist(err) {
+		return fmt.Errorf("service file not found at %s", runnerServicePath)
+	}
+
+	// Stop the service if running
+	isRunningCmd := exec.Command("systemctl", "is-active", runnerServiceName)
+	output, err := isRunningCmd.CombinedOutput()
+	if err == nil && strings.TrimSpace(string(output)) == "active" {
+		ctx.Info("Stopping miren-runner service...")
+		cmd := exec.Command("systemctl", "stop", runnerServiceName)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			ctx.Warn("Failed to stop service: %v\nOutput: %s", err, output)
+		} else {
+			ctx.Completed("Service stopped")
+		}
+	}
+
+	// Disable the service
+	ctx.Info("Disabling miren-runner service...")
+	cmd := exec.Command("systemctl", "disable", runnerServiceName)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		ctx.Warn("Failed to disable service: %v\nOutput: %s", err, output)
+	} else {
+		ctx.Completed("Service disabled")
+	}
+
+	// Remove the service file
+	if err := os.Remove(runnerServicePath); err != nil {
+		return fmt.Errorf("failed to remove service file: %w", err)
+	}
+	ctx.Completed("Service file removed from %s", runnerServicePath)
+
+	// Reload systemd
+	cmd = exec.Command("systemctl", "daemon-reload")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to reload systemd: %w\nOutput: %s", err, output)
+	}
+
+	ctx.Completed("Miren runner service uninstalled")
+
+	if opts.RemoveData {
+		if _, err := os.Stat(opts.DataPath); os.IsNotExist(err) {
+			ctx.Info("Data directory %s does not exist, skipping removal", opts.DataPath)
+		} else {
+			ctx.Info("Removing %s...", opts.DataPath)
+			if err := os.RemoveAll(opts.DataPath); err != nil {
+				return fmt.Errorf("failed to remove data directory: %w", err)
+			}
+			ctx.Completed("Data directory removed")
+		}
+	} else {
+		fmt.Println()
+		ctx.Info("Runner data at %s has not been removed.", opts.DataPath)
+		ctx.Info("To remove it: sudo miren runner uninstall --remove-data")
+	}
+
+	return nil
+}
+
+// RunnerServiceStatus shows the status of the miren-runner systemd service.
+// This is separate from RunnerStatus which shows runner health via RPC.
+func RunnerServiceStatus(ctx *Context, opts struct {
+	Follow bool `short:"f" long:"follow" description:"Follow logs in real-time"`
+}) error {
+	if _, err := os.Stat(runnerServicePath); os.IsNotExist(err) {
+		ctx.Warn("Service file not found at %s", runnerServicePath)
+		ctx.Info("The miren-runner service is not installed. Run 'sudo miren runner install' to set it up.")
+		return nil
+	}
+
+	cmd := exec.Command("systemctl", "status", runnerServiceName, "--no-pager")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		ctx.Log.Debug("systemctl status returned error", "error", err)
+	}
+
+	if opts.Follow {
+		fmt.Println()
+		ctx.Info("Following logs (Ctrl+C to stop)...")
+		fmt.Println()
+
+		cmd = exec.Command("journalctl", "-u", "miren-runner", "-f", "--no-pager")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		return cmd.Run()
+	}
+
+	return nil
+}

--- a/cli/commands/runner_install.go
+++ b/cli/commands/runner_install.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/term"
@@ -69,6 +70,9 @@ func RunnerInstall(ctx *Context, opts struct {
 	// Download release bundle if not present
 	mirenPath := "/var/lib/miren/release/miren"
 	if _, err := os.Stat(mirenPath); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to inspect %s: %w", mirenPath, err)
+		}
 		ctx.Info("Miren release not found at %s, downloading...", mirenPath)
 
 		if err := PerformDownloadRelease(ctx, DownloadReleaseOptions{
@@ -338,11 +342,15 @@ func RunnerUninstall(ctx *Context, opts struct {
 	ctx.Completed("Miren runner service uninstalled")
 
 	if opts.RemoveData {
-		if _, err := os.Stat(opts.DataPath); os.IsNotExist(err) {
-			ctx.Info("Data directory %s does not exist, skipping removal", opts.DataPath)
+		cleanPath := filepath.Clean(opts.DataPath)
+		if cleanPath == "/" || cleanPath == "." || cleanPath == "" {
+			return fmt.Errorf("refusing to remove unsafe data path %q", opts.DataPath)
+		}
+		if _, err := os.Stat(cleanPath); os.IsNotExist(err) {
+			ctx.Info("Data directory %s does not exist, skipping removal", cleanPath)
 		} else {
-			ctx.Info("Removing %s...", opts.DataPath)
-			if err := os.RemoveAll(opts.DataPath); err != nil {
+			ctx.Info("Removing %s...", cleanPath)
+			if err := os.RemoveAll(cleanPath); err != nil {
 				return fmt.Errorf("failed to remove data directory: %w", err)
 			}
 			ctx.Completed("Data directory removed")

--- a/cli/commands/runner_install_other.go
+++ b/cli/commands/runner_install_other.go
@@ -1,0 +1,37 @@
+//go:build !linux
+
+package commands
+
+import "fmt"
+
+// RunnerInstall is not supported on non-Linux platforms
+func RunnerInstall(ctx *Context, opts struct {
+	Token           string   `short:"t" long:"token" description:"Enrollment token from 'miren runner token create'"`
+	Coordinator     string   `short:"c" long:"coordinator" description:"Override coordinator address from the token"`
+	Name            string   `long:"name" description:"Human-readable name for this runner (defaults to hostname)"`
+	ListenAddr      string   `short:"l" long:"listen" description:"Address this runner will listen on"`
+	Labels          []string `long:"labels" description:"Runner labels (key=value)"`
+	Branch          string   `short:"b" long:"branch" description:"Branch to download"`
+	Force           bool     `short:"f" long:"force" description:"Overwrite existing service file"`
+	NoStart         bool     `long:"no-start" description:"Do not start the service after installation"`
+	SkipSystemCheck bool     `long:"skip-system-check" description:"Skip minimum system requirements check"`
+	ConfigPath      string   `long:"config" description:"Path to runner config" default:"/var/lib/miren/runner/config.yaml"`
+	DataPath        string   `long:"data-path" description:"Path to store runner data" default:"/var/lib/miren/runner"`
+}) error {
+	return fmt.Errorf("runner install is only available on Linux")
+}
+
+// RunnerUninstall is not supported on non-Linux platforms
+func RunnerUninstall(ctx *Context, opts struct {
+	RemoveData bool   `long:"remove-data" description:"Remove runner data directory"`
+	DataPath   string `long:"data-path" description:"Path to runner data" default:"/var/lib/miren/runner"`
+}) error {
+	return fmt.Errorf("runner uninstall is only available on Linux")
+}
+
+// RunnerServiceStatus is not supported on non-Linux platforms
+func RunnerServiceStatus(ctx *Context, opts struct {
+	Follow bool `short:"f" long:"follow" description:"Follow logs in real-time"`
+}) error {
+	return fmt.Errorf("runner service-status is only available on Linux")
+}

--- a/cli/commands/runner_join.go
+++ b/cli/commands/runner_join.go
@@ -15,62 +15,28 @@ import (
 	"miren.dev/runtime/version"
 )
 
-func RunnerJoin(ctx *Context, opts struct {
-	Coordinator string   `short:"c" long:"coordinator" description:"Override coordinator address from the token"`
-	Token       string   `long:"token" description:"Enrollment token (or pass as positional arg / via stdin)"`
-	ListenAddr  string   `short:"l" long:"listen" description:"Address this runner will listen on"`
-	Name        string   `long:"name" description:"Human-readable name for this runner (defaults to hostname)"`
-	Labels      []string `long:"labels" description:"Additional labels for the runner (key=value)"`
-	ConfigPath  string   `long:"config" description:"Path to save runner config" default:"/var/lib/miren/runner/config.yaml"`
-	RunnerID    string   `long:"runner-id" description:"Specific runner ID to use (for reconnecting)"`
+// runnerJoinOpts holds the parameters for performing a runner join operation.
+type runnerJoinOpts struct {
+	Coordinator string
+	Secret      string
+	Name        string
+	ListenAddr  string
+	Labels      []string
+	ConfigPath  string
+	RunnerID    string
+}
 
-	TokenArg string `position:"0" usage:"Join token from 'miren runner token create'"`
-}) error {
-	if runnerconfig.Exists(opts.ConfigPath) {
-		return fmt.Errorf("runner config already exists at %s; remove it first to re-register", opts.ConfigPath)
-	}
-
-	// Resolve token: --token flag > positional arg > stdin pipe > TTY prompt
-	token := opts.Token
-	if token == "" {
-		token = opts.TokenArg
-	}
-	if token == "" {
-		if stat, _ := os.Stdin.Stat(); stat.Mode()&os.ModeCharDevice == 0 {
-			scanner := bufio.NewScanner(os.Stdin)
-			if scanner.Scan() {
-				token = strings.TrimSpace(scanner.Text())
-			}
-		}
-	}
-	if token == "" {
-		var err error
-		token, err = ui.PromptForInput(
-			ui.WithLabel("Enter enrollment token"),
-			ui.WithPlaceholder("mren_..."),
-		)
-		if err != nil {
-			return fmt.Errorf("failed to read token: %w", err)
-		}
-	}
-
-	if !enrolltoken.IsToken(token) {
-		return fmt.Errorf("invalid token format (expected mren_ prefix)")
-	}
-
-	addr, secret, err := enrolltoken.Decode(token)
-	if err != nil {
-		return fmt.Errorf("invalid token: %w", err)
-	}
-
-	// Use the address from the token, unless --coordinator overrides it
-	coordinator := addr
-	if opts.Coordinator != "" {
-		coordinator = opts.Coordinator
-	}
-
+// performRunnerJoin executes the core join flow: connects to the coordinator,
+// exchanges the enrollment secret for credentials, and saves the runner config.
+// Both RunnerJoin and RunnerInstall use this.
+func performRunnerJoin(ctx *Context, opts runnerJoinOpts) error {
+	coordinator := opts.Coordinator
 	if _, _, err := net.SplitHostPort(coordinator); err != nil {
 		coordinator = net.JoinHostPort(coordinator, "8443")
+	}
+
+	if runnerconfig.Exists(opts.ConfigPath) {
+		return fmt.Errorf("runner config already exists at %s; remove it first to re-register", opts.ConfigPath)
 	}
 
 	ctx.Printf("Joining coordinator at %s\n", coordinator)
@@ -104,7 +70,7 @@ func RunnerJoin(ctx *Context, opts struct {
 	}
 
 	versionInfo := version.GetInfo()
-	res, err := rc.Join(ctx, secret, opts.RunnerID, listenAddr, versionInfo.Version, opts.Labels, name)
+	res, err := rc.Join(ctx, opts.Secret, opts.RunnerID, listenAddr, versionInfo.Version, opts.Labels, name)
 	if err != nil {
 		return fmt.Errorf("join request failed: %w", err)
 	}
@@ -166,6 +132,74 @@ func RunnerJoin(ctx *Context, opts struct {
 	}
 
 	ctx.Printf("Config saved to %s\n", opts.ConfigPath)
+	return nil
+}
+
+func RunnerJoin(ctx *Context, opts struct {
+	Coordinator string   `short:"c" long:"coordinator" description:"Override coordinator address from the token"`
+	Token       string   `long:"token" description:"Enrollment token (or pass as positional arg / via stdin)"`
+	ListenAddr  string   `short:"l" long:"listen" description:"Address this runner will listen on"`
+	Name        string   `long:"name" description:"Human-readable name for this runner (defaults to hostname)"`
+	Labels      []string `long:"labels" description:"Additional labels for the runner (key=value)"`
+	ConfigPath  string   `long:"config" description:"Path to save runner config" default:"/var/lib/miren/runner/config.yaml"`
+	RunnerID    string   `long:"runner-id" description:"Specific runner ID to use (for reconnecting)"`
+
+	TokenArg string `position:"0" usage:"Join token from 'miren runner token create'"`
+}) error {
+	// Resolve token: --token flag > positional arg > stdin pipe > TTY prompt
+	token := opts.Token
+	if token == "" {
+		token = opts.TokenArg
+	}
+	if token == "" {
+		if stat, err := os.Stdin.Stat(); err == nil && stat.Mode()&os.ModeCharDevice == 0 {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				token = strings.TrimSpace(scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("failed to read token from stdin: %w", err)
+			}
+		}
+	}
+	if token == "" {
+		var err error
+		token, err = ui.PromptForInput(
+			ui.WithLabel("Enter enrollment token"),
+			ui.WithPlaceholder("mren_..."),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to read token: %w", err)
+		}
+	}
+
+	if !enrolltoken.IsToken(token) {
+		return fmt.Errorf("invalid token format (expected mren_ prefix)")
+	}
+
+	addr, secret, err := enrolltoken.Decode(token)
+	if err != nil {
+		return fmt.Errorf("invalid token: %w", err)
+	}
+
+	// Use the address from the token, unless --coordinator overrides it
+	coordinator := addr
+	if opts.Coordinator != "" {
+		coordinator = opts.Coordinator
+	}
+
+	if err := performRunnerJoin(ctx, runnerJoinOpts{
+		Coordinator: coordinator,
+		Secret:      secret,
+		Name:        opts.Name,
+		ListenAddr:  opts.ListenAddr,
+		Labels:      opts.Labels,
+		ConfigPath:  opts.ConfigPath,
+		RunnerID:    opts.RunnerID,
+	}); err != nil {
+		return err
+	}
+
 	ctx.Printf("\nTo start this runner, run:\n")
 	ctx.Printf("  miren runner start\n")
 

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -268,15 +268,18 @@
       "id": "command/runner"
     },
     "items": [
+      "command/runner-install",
       "command/runner-join",
       "command/runner-list",
       "command/runner-remove",
+      "command/runner-service-status",
       "command/runner-start",
       "command/runner-status",
       "command/runner-token",
       "command/runner-token-create",
       "command/runner-token-list",
-      "command/runner-token-revoke"
+      "command/runner-token-revoke",
+      "command/runner-uninstall"
     ]
   },
   {

--- a/docs/docs/command/runner-install.md
+++ b/docs/docs/command/runner-install.md
@@ -1,0 +1,57 @@
+---
+title: "miren runner install"
+sidebar_label: "runner install"
+description: "Install systemd service for miren runner"
+---
+
+# miren runner install
+
+Install systemd service for miren runner
+
+:::note
+This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
+:::
+
+## Usage
+
+```bash
+miren runner install [flags]
+```
+
+## Flags
+
+- `--branch, -b` — Branch to download
+- `--config` — Path to runner config (default: `/var/lib/miren/runner/config.yaml`)
+- `--coordinator, -c` — Override coordinator address from the token
+- `--data-path` — Path to store runner data (default: `/var/lib/miren/runner`)
+- `--force, -f` — Overwrite existing service file
+- `--labels` — Runner labels (key=value)
+- `--listen, -l` — Address this runner will listen on
+- `--name` — Human-readable name for this runner (defaults to hostname)
+- `--no-start` — Do not start the service after installation
+- `--skip-system-check` — Skip minimum system requirements check
+- `--token, -t` — Enrollment token from 'miren runner token create'
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Install interactively:**
+
+```bash
+miren runner install
+```
+
+**Install with token (for automation):**
+
+```bash
+miren runner install --token mren_...
+```
+
+## See also
+
+- [`miren runner`](/command/runner)

--- a/docs/docs/command/runner-service-status.md
+++ b/docs/docs/command/runner-service-status.md
@@ -1,0 +1,47 @@
+---
+title: "miren runner service-status"
+sidebar_label: "runner service-status"
+description: "Show miren-runner systemd service status"
+---
+
+# miren runner service-status
+
+Show miren-runner systemd service status
+
+:::note
+This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
+:::
+
+## Usage
+
+```bash
+miren runner service-status [flags]
+```
+
+## Flags
+
+- `--follow, -f` — Follow logs in real-time
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Show service status:**
+
+```bash
+miren runner service-status
+```
+
+**Follow service logs:**
+
+```bash
+miren runner service-status --follow
+```
+
+## See also
+
+- [`miren runner`](/command/runner)

--- a/docs/docs/command/runner-uninstall.md
+++ b/docs/docs/command/runner-uninstall.md
@@ -1,0 +1,48 @@
+---
+title: "miren runner uninstall"
+sidebar_label: "runner uninstall"
+description: "Remove systemd service for miren runner"
+---
+
+# miren runner uninstall
+
+Remove systemd service for miren runner
+
+:::note
+This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
+:::
+
+## Usage
+
+```bash
+miren runner uninstall [flags]
+```
+
+## Flags
+
+- `--data-path` — Path to runner data (default: `/var/lib/miren/runner`)
+- `--remove-data` — Remove runner data directory
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Uninstall the runner service:**
+
+```bash
+miren runner uninstall
+```
+
+**Uninstall and remove all runner data:**
+
+```bash
+miren runner uninstall --remove-data
+```
+
+## See also
+
+- [`miren runner`](/command/runner)

--- a/docs/docs/command/runner.md
+++ b/docs/docs/command/runner.md
@@ -16,9 +16,12 @@ miren runner [flags]
 
 ## Subcommands
 
+- [`miren runner install`](/command/runner-install) — Install systemd service for miren runner
 - [`miren runner join`](/command/runner-join) — Join this machine to a coordinator as a runner
 - [`miren runner list`](/command/runner-list) — List all registered runners
 - [`miren runner remove`](/command/runner-remove) — Remove a registered runner and clean up resources
+- [`miren runner service-status`](/command/runner-service-status) — Show miren-runner systemd service status
 - [`miren runner start`](/command/runner-start) — Start this machine as a distributed runner
 - [`miren runner status`](/command/runner-status) — Show runner health and configuration
 - [`miren runner token`](/command/runner-token) — Manage join tokens
+- [`miren runner uninstall`](/command/runner-uninstall) — Remove systemd service for miren runner

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -185,15 +185,18 @@ Complete reference for all `miren` CLI commands.
 | Command | Description |
 |---------|-------------|
 | [`miren runner`](/command/runner) | Runner management commands |
+| [`miren runner install`](/command/runner-install) | Install systemd service for miren runner _(`distributedrunners`)_ |
 | [`miren runner join`](/command/runner-join) | Join this machine to a coordinator as a runner _(`distributedrunners`)_ |
 | [`miren runner list`](/command/runner-list) | List all registered runners _(`distributedrunners`)_ |
 | [`miren runner remove`](/command/runner-remove) | Remove a registered runner and clean up resources _(`distributedrunners`)_ |
+| [`miren runner service-status`](/command/runner-service-status) | Show miren-runner systemd service status _(`distributedrunners`)_ |
 | [`miren runner start`](/command/runner-start) | Start this machine as a distributed runner _(`distributedrunners`)_ |
 | [`miren runner status`](/command/runner-status) | Show runner health and configuration _(`distributedrunners`)_ |
 | [`miren runner token`](/command/runner-token) | Manage join tokens |
 | [`miren runner token create`](/command/runner-token-create) | Create a join token for a runner _(`distributedrunners`)_ |
 | [`miren runner token list`](/command/runner-token-list) | List all join tokens _(`distributedrunners`)_ |
 | [`miren runner token revoke`](/command/runner-token-revoke) | Revoke a join token _(`distributedrunners`)_ |
+| [`miren runner uninstall`](/command/runner-uninstall) | Remove systemd service for miren runner _(`distributedrunners`)_ |
 
 ## sandbox
 

--- a/hack/gen-command-docs
+++ b/hack/gen-command-docs
@@ -23,9 +23,9 @@ if [ ! -f "$BINARY" ]; then
   exit 1
 fi
 
-# Get help JSON
+# Get help JSON — enable all labs features so gated commands appear in docs
 echo "Extracting command metadata..."
-MIREN_HELP_JSON=1 "$BINARY" > "$WORK_DIR/help.json"
+MIREN_HELP_JSON=1 MIREN_LABS=all "$BINARY" > "$WORK_DIR/help.json"
 
 # Flatten all commands (recursive) and enrich with subcommand paths
 jq -c '


### PR DESCRIPTION
Provisioning a distributed runner was a multi-step scavenger hunt: install the CLI, manually download the release bundle, hand-write a systemd unit, join the coordinator. `miren server install` does all of this for servers in one shot, but runners had no equivalent. Discovered during MIR-890 when runners would crash on start because only the CLI binary was present (no containerd, runc, or shims).

`miren runner install` handles the full provisioning flow. It checks prerequisites (root, systemd, disk/memory), downloads the release bundle if needed, joins the coordinator, writes a `miren-runner.service` systemd unit, and enables/starts the service. The join step adapts to how you're running it: pass `--coordinator` and `--invite-code` for automation (cloud-init, Terraform), or run it interactively and it'll prompt for both. If someone already ran `miren runner join` beforehand, it detects the existing config and skips straight to service setup.

Also adds `runner uninstall` (stop/disable/remove) and `runner service-status` (systemd status + log following) to match the server install family.

Tested end-to-end on `miren-toys-runner-1`: automated install with flags, re-install with existing config, uninstall, and service-status all verified against the live coordinator. The runner successfully joined, started, and began scheduling sandboxes.

Closes MIR-902