### PR TITLE
release: inherit secrets when calling reusable test workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       ref: ${{ needs.init.outputs.ref }}
+    secrets: inherit
 
   package:
     needs: [init, test]


### PR DESCRIPTION
## Summary

The Release workflow calls \`.github/workflows/test.yml\` via \`workflow_call\` but didn't pass any secrets. After the new \`test-blackbox-pop\` job was added (mirendev/runtime#746) which requires \`CLOUD_REPO_TOKEN\` to check out the cloud repo, the reusable workflow fails on main with:

\`\`\`
##[error]Input required and not supplied: token
\`\`\`

Fix: add \`secrets: inherit\` so the reusable workflow sees all repo secrets.

## Test plan

- [ ] Release workflow passes on this branch