### PR TITLE
Add `miren runner upgrade` for in-place runner binary updates

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -712,6 +712,28 @@ miren deploy --analyze
 				Body: "miren runner service-status --follow",
 			}),
 		))
+		d.Dispatch("runner upgrade", Infer("runner upgrade", "Upgrade miren runner to the latest or specified version", RunnerUpgrade,
+			WithLabsFeature(labs.FeatureDistributedRunners),
+			WithExample(mflags.Example{
+				Name: "Upgrade to the latest version",
+				Body: "miren runner upgrade",
+			}),
+			WithExample(mflags.Example{
+				Name: "Check for available updates",
+				Body: "miren runner upgrade --check",
+			}),
+			WithExample(mflags.Example{
+				Name: "Upgrade to a specific version",
+				Body: "miren runner upgrade --version v0.2.0",
+			}),
+		))
+		d.Dispatch("runner upgrade rollback", Infer("runner upgrade rollback", "Rollback runner to previous version", RunnerUpgradeRollback,
+			WithLabsFeature(labs.FeatureDistributedRunners),
+			WithExample(mflags.Example{
+				Name: "Rollback to the previous version",
+				Body: "miren runner upgrade rollback",
+			}),
+		))
 	}
 
 	// Server commands

--- a/cli/commands/runner_upgrade.go
+++ b/cli/commands/runner_upgrade.go
@@ -18,7 +18,7 @@ func RunnerUpgrade(ctx *Context, opts struct {
 	Force          bool   `short:"f" long:"force" description:"Force upgrade even if already up to date"`
 	SkipHealth     bool   `long:"skip-health" description:"Skip health check after upgrade"`
 	NoAutoRollback bool   `long:"no-auto-rollback" description:"Disable automatic rollback on failure"`
-	HealthTimeout  int    `long:"health-timeout" description:"Health check timeout in seconds (default: 60)"`
+	HealthTimeout  int    `long:"health-timeout" default:"60" description:"Health check timeout in seconds"`
 }) error {
 	if os.Geteuid() != 0 {
 		return fmt.Errorf("runner upgrade requires root privileges (use sudo)")

--- a/cli/commands/runner_upgrade.go
+++ b/cli/commands/runner_upgrade.go
@@ -1,0 +1,109 @@
+//go:build linux
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"miren.dev/runtime/pkg/release"
+)
+
+// RunnerUpgrade upgrades the miren runner to the latest or specified version
+func RunnerUpgrade(ctx *Context, opts struct {
+	Version        string `short:"V" long:"version" description:"Specific version to upgrade to (e.g., v0.2.0)"`
+	Channel        string `long:"channel" description:"Channel to use: 'latest' (stable releases, default) or 'main' (bleeding edge)"`
+	Check          bool   `short:"c" long:"check" description:"Check for available updates only"`
+	Force          bool   `short:"f" long:"force" description:"Force upgrade even if already up to date"`
+	SkipHealth     bool   `long:"skip-health" description:"Skip health check after upgrade"`
+	NoAutoRollback bool   `long:"no-auto-rollback" description:"Disable automatic rollback on failure"`
+	HealthTimeout  int    `long:"health-timeout" description:"Health check timeout in seconds (default: 60)"`
+}) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("runner upgrade requires root privileges (use sudo)")
+	}
+
+	if !release.IsRunnerRunning() {
+		return fmt.Errorf("miren runner is not running. Use 'miren upgrade' to upgrade the CLI binary instead")
+	}
+
+	version := opts.Version
+	channel := opts.Channel
+
+	if version == "" && channel == "" {
+		channel = "latest"
+	}
+	if channel != "" {
+		version = channel
+	}
+
+	mgrOpts := release.RunnerManagerOptions()
+	mgrOpts.SkipHealthCheck = opts.SkipHealth
+	mgrOpts.AutoRollback = !opts.NoAutoRollback
+	if opts.HealthTimeout > 0 {
+		mgrOpts.HealthTimeout = time.Duration(opts.HealthTimeout) * time.Second
+	}
+
+	if opts.Check {
+		current, latest, err := CheckVersionStatus(ctx, version, &mgrOpts)
+		if err != nil {
+			return err
+		}
+
+		PrintVersionComparison(current, latest)
+
+		if latest.IsNewer(current) {
+			fmt.Println("\nAn update is available! Run 'sudo miren runner upgrade' to install it.")
+		} else {
+			fmt.Println("\nYour runner is already on the latest version.")
+		}
+		return nil
+	}
+
+	needsUpgrade, err := CheckIfUpgradeNeeded(ctx, version, opts.Force, &mgrOpts)
+	if err != nil {
+		ctx.Log.Warn("could not check version status", "error", err)
+	} else if !needsUpgrade {
+		return nil
+	}
+
+	mgr := release.NewManager(mgrOpts)
+
+	current, err := mgr.GetCurrentVersion(ctx)
+	if err != nil {
+		ctx.Log.Warn("could not determine current version", "error", err)
+	}
+
+	artifact := release.NewArtifact(release.ArtifactTypeBase, version)
+
+	fmt.Printf("Upgrading runner to %s version %s...\n", artifact.Type, version)
+	if err := mgr.UpgradeServer(ctx, artifact); err != nil {
+		return err
+	}
+
+	PrintUpgradeSuccess(ctx, current, "Runner", &mgrOpts)
+
+	return nil
+}
+
+// RunnerUpgradeRollback rolls back the runner to the previous version
+func RunnerUpgradeRollback(ctx *Context, opts struct {
+	SkipHealth bool `long:"skip-health" description:"Skip health check after rollback"`
+}) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("runner rollback requires root privileges (use sudo)")
+	}
+
+	mgrOpts := release.RunnerManagerOptions()
+	mgrOpts.SkipHealthCheck = opts.SkipHealth
+	mgr := release.NewManager(mgrOpts)
+
+	fmt.Println("Rolling back runner to previous version...")
+	if err := mgr.Rollback(ctx); err != nil {
+		return err
+	}
+
+	fmt.Println("\nRunner rollback successful!")
+	return nil
+}

--- a/cli/commands/runner_upgrade.go
+++ b/cli/commands/runner_upgrade.go
@@ -31,6 +31,10 @@ func RunnerUpgrade(ctx *Context, opts struct {
 	version := opts.Version
 	channel := opts.Channel
 
+	if version != "" && channel != "" {
+		return fmt.Errorf("--version and --channel are mutually exclusive")
+	}
+
 	if version == "" && channel == "" {
 		channel = "latest"
 	}

--- a/cli/commands/runner_upgrade_other.go
+++ b/cli/commands/runner_upgrade_other.go
@@ -12,7 +12,7 @@ func RunnerUpgrade(ctx *Context, opts struct {
 	Force          bool   `short:"f" long:"force" description:"Force upgrade even if already up to date"`
 	SkipHealth     bool   `long:"skip-health" description:"Skip health check after upgrade"`
 	NoAutoRollback bool   `long:"no-auto-rollback" description:"Disable automatic rollback on failure"`
-	HealthTimeout  int    `long:"health-timeout" description:"Health check timeout in seconds (default: 60)"`
+	HealthTimeout  int    `long:"health-timeout" default:"60" description:"Health check timeout in seconds"`
 }) error {
 	return fmt.Errorf("runner upgrade is only available on Linux")
 }

--- a/cli/commands/runner_upgrade_other.go
+++ b/cli/commands/runner_upgrade_other.go
@@ -1,0 +1,25 @@
+//go:build !linux
+
+package commands
+
+import "fmt"
+
+// RunnerUpgrade is not supported on non-Linux platforms
+func RunnerUpgrade(ctx *Context, opts struct {
+	Version        string `short:"V" long:"version" description:"Specific version to upgrade to (e.g., v0.2.0)"`
+	Channel        string `long:"channel" description:"Channel to use: 'latest' (stable releases, default) or 'main' (bleeding edge)"`
+	Check          bool   `short:"c" long:"check" description:"Check for available updates only"`
+	Force          bool   `short:"f" long:"force" description:"Force upgrade even if already up to date"`
+	SkipHealth     bool   `long:"skip-health" description:"Skip health check after upgrade"`
+	NoAutoRollback bool   `long:"no-auto-rollback" description:"Disable automatic rollback on failure"`
+	HealthTimeout  int    `long:"health-timeout" description:"Health check timeout in seconds (default: 60)"`
+}) error {
+	return fmt.Errorf("runner upgrade is only available on Linux")
+}
+
+// RunnerUpgradeRollback is not supported on non-Linux platforms
+func RunnerUpgradeRollback(ctx *Context, opts struct {
+	SkipHealth bool `long:"skip-health" description:"Skip health check after rollback"`
+}) error {
+	return fmt.Errorf("runner upgrade rollback is only available on Linux")
+}

--- a/cli/commands/server_upgrade.go
+++ b/cli/commands/server_upgrade.go
@@ -17,7 +17,7 @@ func ServerUpgrade(ctx *Context, opts struct {
 	Release        bool   `short:"r" long:"release" description:"Upgrade full release package (not just base)"`
 	SkipHealth     bool   `long:"skip-health" description:"Skip health check after upgrade"`
 	NoAutoRollback bool   `long:"no-auto-rollback" description:"Disable automatic rollback on failure"`
-	HealthTimeout  int    `long:"health-timeout" description:"Health check timeout in seconds (default: 60)"`
+	HealthTimeout  int    `long:"health-timeout" default:"60" description:"Health check timeout in seconds"`
 }) error {
 	// Check if running with sufficient privileges
 	if os.Geteuid() != 0 {

--- a/cli/commands/server_upgrade.go
+++ b/cli/commands/server_upgrade.go
@@ -33,12 +33,13 @@ func ServerUpgrade(ctx *Context, opts struct {
 	version := opts.Version
 	channel := opts.Channel
 
-	// If neither specified, default to latest channel
+	if version != "" && channel != "" {
+		return fmt.Errorf("--version and --channel are mutually exclusive")
+	}
+
 	if version == "" && channel == "" {
 		channel = "latest"
 	}
-
-	// If channel specified, use it as version
 	if channel != "" {
 		version = channel
 	}

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -279,7 +279,9 @@
       "command/runner-token-create",
       "command/runner-token-list",
       "command/runner-token-revoke",
-      "command/runner-uninstall"
+      "command/runner-uninstall",
+      "command/runner-upgrade",
+      "command/runner-upgrade-rollback"
     ]
   },
   {

--- a/docs/docs/command/runner-upgrade-rollback.md
+++ b/docs/docs/command/runner-upgrade-rollback.md
@@ -1,0 +1,41 @@
+---
+title: "miren runner upgrade rollback"
+sidebar_label: "runner upgrade rollback"
+description: "Rollback runner to previous version"
+---
+
+# miren runner upgrade rollback
+
+Rollback runner to previous version
+
+:::note
+This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
+:::
+
+## Usage
+
+```bash
+miren runner upgrade rollback [flags]
+```
+
+## Flags
+
+- `--skip-health` — Skip health check after rollback
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Rollback to the previous version:**
+
+```bash
+miren runner upgrade rollback
+```
+
+## See also
+
+- [`miren runner upgrade`](/command/runner-upgrade)

--- a/docs/docs/command/runner-upgrade.md
+++ b/docs/docs/command/runner-upgrade.md
@@ -1,0 +1,63 @@
+---
+title: "miren runner upgrade"
+sidebar_label: "runner upgrade"
+description: "Upgrade miren runner to the latest or specified version"
+---
+
+# miren runner upgrade
+
+Upgrade miren runner to the latest or specified version
+
+:::note
+This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
+:::
+
+## Usage
+
+```bash
+miren runner upgrade [flags]
+```
+
+## Flags
+
+- `--channel` — Channel to use: 'latest' (stable releases, default) or 'main' (bleeding edge)
+- `--check, -c` — Check for available updates only
+- `--force, -f` — Force upgrade even if already up to date
+- `--health-timeout` — Health check timeout in seconds (default: 60) (default: `0`)
+- `--no-auto-rollback` — Disable automatic rollback on failure
+- `--skip-health` — Skip health check after upgrade
+- `--version, -V` — Specific version to upgrade to (e.g., v0.2.0)
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Upgrade to the latest version:**
+
+```bash
+miren runner upgrade
+```
+
+**Check for available updates:**
+
+```bash
+miren runner upgrade --check
+```
+
+**Upgrade to a specific version:**
+
+```bash
+miren runner upgrade --version v0.2.0
+```
+
+## Subcommands
+
+- [`miren runner upgrade rollback`](/command/runner-upgrade-rollback) — Rollback runner to previous version
+
+## See also
+
+- [`miren runner`](/command/runner)

--- a/docs/docs/command/runner-upgrade.md
+++ b/docs/docs/command/runner-upgrade.md
@@ -23,7 +23,7 @@ miren runner upgrade [flags]
 - `--channel` — Channel to use: 'latest' (stable releases, default) or 'main' (bleeding edge)
 - `--check, -c` — Check for available updates only
 - `--force, -f` — Force upgrade even if already up to date
-- `--health-timeout` — Health check timeout in seconds (default: 60) (default: `0`)
+- `--health-timeout` — Health check timeout in seconds (default: `60`)
 - `--no-auto-rollback` — Disable automatic rollback on failure
 - `--skip-health` — Skip health check after upgrade
 - `--version, -V` — Specific version to upgrade to (e.g., v0.2.0)

--- a/docs/docs/command/runner.md
+++ b/docs/docs/command/runner.md
@@ -25,3 +25,4 @@ miren runner [flags]
 - [`miren runner status`](/command/runner-status) — Show runner health and configuration
 - [`miren runner token`](/command/runner-token) — Manage join tokens
 - [`miren runner uninstall`](/command/runner-uninstall) — Remove systemd service for miren runner
+- [`miren runner upgrade`](/command/runner-upgrade) — Upgrade miren runner to the latest or specified version

--- a/docs/docs/command/server-upgrade.md
+++ b/docs/docs/command/server-upgrade.md
@@ -19,7 +19,7 @@ miren server upgrade [flags]
 - `--channel` — Channel to use: 'latest' (stable releases, default) or 'main' (bleeding edge)
 - `--check, -c` — Check for available updates only
 - `--force, -f` — Force upgrade even if already up to date
-- `--health-timeout` — Health check timeout in seconds (default: 60) (default: `0`)
+- `--health-timeout` — Health check timeout in seconds (default: `60`)
 - `--no-auto-rollback` — Disable automatic rollback on failure
 - `--release, -r` — Upgrade full release package (not just base)
 - `--skip-health` — Skip health check after upgrade

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -197,6 +197,8 @@ Complete reference for all `miren` CLI commands.
 | [`miren runner token list`](/command/runner-token-list) | List all join tokens _(`distributedrunners`)_ |
 | [`miren runner token revoke`](/command/runner-token-revoke) | Revoke a join token _(`distributedrunners`)_ |
 | [`miren runner uninstall`](/command/runner-uninstall) | Remove systemd service for miren runner _(`distributedrunners`)_ |
+| [`miren runner upgrade`](/command/runner-upgrade) | Upgrade miren runner to the latest or specified version _(`distributedrunners`)_ |
+| [`miren runner upgrade rollback`](/command/runner-upgrade-rollback) | Rollback runner to previous version _(`distributedrunners`)_ |
 
 ## sandbox
 

--- a/pkg/release/health.go
+++ b/pkg/release/health.go
@@ -171,12 +171,20 @@ func (n *NoOpHealthVerifier) VerifyHealth(ctx context.Context, timeout time.Dura
 
 // IsServerRunning checks if the miren server is currently running as a systemd service
 func IsServerRunning() bool {
-	// Require root for systemd service checks
+	return isSystemdServiceActive("miren")
+}
+
+// IsRunnerRunning checks if the miren runner is currently running as a systemd service
+func IsRunnerRunning() bool {
+	return isSystemdServiceActive("miren-runner")
+}
+
+func isSystemdServiceActive(unit string) bool {
 	if os.Geteuid() != 0 {
 		return false
 	}
 
-	cmd := exec.Command("systemctl", "is-active", "miren")
+	cmd := exec.Command("systemctl", "is-active", unit)
 	output, err := cmd.Output()
 	if err != nil {
 		return false

--- a/pkg/release/manager.go
+++ b/pkg/release/manager.go
@@ -45,6 +45,15 @@ func DefaultManagerOptions() ManagerOptions {
 	}
 }
 
+// RunnerManagerOptions returns manager options configured for the runner service.
+// The install path is the same as the server (shared binary), but the service
+// name targets the miren-runner systemd unit.
+func RunnerManagerOptions() ManagerOptions {
+	opts := DefaultManagerOptions()
+	opts.ServiceName = "miren-runner"
+	return opts
+}
+
 // NewManager creates a new upgrade manager
 func NewManager(opts ManagerOptions) *Manager {
 	installOpts := InstallOptions{


### PR DESCRIPTION
`miren server upgrade` handles the full download/swap/restart cycle for coordinators, but runners had no equivalent. The only way to update a runner binary was SSH in and manually scp it, or nuke and reprovision the whole VM. We hit this during MIR-965 validation when we needed to update a runner and had to do it by hand.

Turns out the `release.Manager` was already parameterized on `ServiceName`, so most of the work here is wiring. Added a `RunnerManagerOptions()` factory that targets the `miren-runner` systemd unit, then built `runner upgrade` and `runner upgrade rollback` commands that mirror the server equivalents. Also did a small refactor extracting `isSystemdServiceActive()` so both `IsServerRunning()` and `IsRunnerRunning()` go through the same path.

The runner upgrade drops the `--release` flag since runners only need the base artifact (no full release package).

Closes MIR-1003