### PR TITLE
Remove dead usersubdomains labs flag and trim low-value tests

### DIFF
--- a/docs/docs/labs.md
+++ b/docs/docs/labs.md
@@ -23,13 +23,13 @@ Labs features are controlled via the `--labs` flag or `MIREN_LABS` environment v
 miren server --labs adminapi
 
 # Enable multiple features
-miren server --labs adminapi --labs usersubdomains
+miren server --labs adminapi --labs routeoidc
 
 # Via environment variable
 MIREN_LABS=adminapi miren server
 
 # Multiple features via environment variable (comma-separated)
-MIREN_LABS=adminapi,usersubdomains miren server
+MIREN_LABS=adminapi,routeoidc miren server
 ```
 </CliCommand>
 

--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -9,11 +9,6 @@ features:
     description: Schedule jobs across multiple runner nodes
     default: false
 
-  - name: usersubdomains
-    predicate: UserSubdomains
-    description: Allow claiming custom subdomains
-    default: false
-
   - name: adminapi
     predicate: AdminAPI
     description: Enable the admin API for application management functions

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -12,7 +12,6 @@ import (
 const (
 	FeatureGlobalRouter       = "globalrouter"
 	FeatureDistributedRunners = "distributedrunners"
-	FeatureUserSubdomains     = "usersubdomains"
 	FeatureAdminAPI           = "adminapi"
 	FeatureRouteOIDC          = "routeoidc"
 	FeatureAddons             = "addons"
@@ -24,7 +23,6 @@ func AllFeatures() []string {
 	return []string{
 		FeatureGlobalRouter,
 		FeatureDistributedRunners,
-		FeatureUserSubdomains,
 		FeatureAdminAPI,
 		FeatureRouteOIDC,
 		FeatureAddons,
@@ -37,7 +35,6 @@ func FeatureDescriptions() map[string]string {
 	return map[string]string{
 		FeatureGlobalRouter:       "Use global NAT traversal router for connectivity",
 		FeatureDistributedRunners: "Schedule jobs across multiple runner nodes",
-		FeatureUserSubdomains:     "Allow claiming custom subdomains",
 		FeatureAdminAPI:           "Enable the admin API for application management functions",
 		FeatureRouteOIDC:          "Enable OIDC authentication for HTTP routes",
 		FeatureAddons:             "Enable the addon system for managed backing services",
@@ -54,7 +51,6 @@ var (
 var featureDefaults = map[string]bool{
 	FeatureGlobalRouter:       false,
 	FeatureDistributedRunners: false,
-	FeatureUserSubdomains:     false,
 	FeatureAdminAPI:           false,
 	FeatureRouteOIDC:          false,
 	FeatureAddons:             true,
@@ -156,12 +152,6 @@ func GlobalRouter() bool {
 // Schedule jobs across multiple runner nodes
 func DistributedRunners() bool {
 	return IsEnabled(FeatureDistributedRunners)
-}
-
-// UserSubdomains returns whether the usersubdomains feature is enabled.
-// Allow claiming custom subdomains
-func UserSubdomains() bool {
-	return IsEnabled(FeatureUserSubdomains)
 }
 
 // AdminAPI returns whether the adminapi feature is enabled.

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -7,59 +7,6 @@ import (
 	"testing"
 )
 
-func TestDefaultFeatureValues(t *testing.T) {
-	Reset()
-
-	// All features should be disabled by default
-	if GlobalRouter() {
-		t.Error("GlobalRouter should be false by default")
-	}
-	if DistributedRunners() {
-		t.Error("DistributedRunners should be false by default")
-	}
-	if UserSubdomains() {
-		t.Error("UserSubdomains should be false by default")
-	}
-	if AdminAPI() {
-		t.Error("AdminAPI should be false by default")
-	}
-	if RouteOIDC() {
-		t.Error("RouteOIDC should be false by default")
-	}
-}
-
-func TestEnableFeatureViaInit(t *testing.T) {
-	Reset()
-
-	Init(nil, []string{"globalrouter"})
-
-	if !GlobalRouter() {
-		t.Error("GlobalRouter should be enabled after Init with 'globalrouter'")
-	}
-	if DistributedRunners() {
-		t.Error("DistributedRunners should still be false")
-	}
-	if UserSubdomains() {
-		t.Error("UserSubdomains should still be false")
-	}
-}
-
-func TestEnableMultipleFeatures(t *testing.T) {
-	Reset()
-
-	Init(nil, []string{"globalrouter", "usersubdomains"})
-
-	if !GlobalRouter() {
-		t.Error("GlobalRouter should be enabled")
-	}
-	if DistributedRunners() {
-		t.Error("DistributedRunners should still be false")
-	}
-	if !UserSubdomains() {
-		t.Error("UserSubdomains should be enabled")
-	}
-}
-
 func TestDisableFeatureWithPrefix(t *testing.T) {
 	Reset()
 
@@ -74,13 +21,13 @@ func TestDisableFeatureWithPrefix(t *testing.T) {
 func TestCaseInsensitiveFeatureNames(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"GlobalRouter", "USERSUBDOMAINS"})
+	Init(nil, []string{"GlobalRouter", "ADMINAPI"})
 
 	if !GlobalRouter() {
 		t.Error("GlobalRouter should be enabled (case-insensitive)")
 	}
-	if !UserSubdomains() {
-		t.Error("UserSubdomains should be enabled (case-insensitive)")
+	if !AdminAPI() {
+		t.Error("AdminAPI should be enabled (case-insensitive)")
 	}
 }
 
@@ -98,91 +45,6 @@ func TestUnknownFeatureLogsWarning(t *testing.T) {
 	}
 	if !strings.Contains(logOutput, "unknownfeature") {
 		t.Errorf("Expected warning to contain the unknown feature name, got: %s", logOutput)
-	}
-}
-
-func TestIsEnabledFunction(t *testing.T) {
-	Reset()
-
-	Init(nil, []string{"globalrouter"})
-
-	if !IsEnabled("globalrouter") {
-		t.Error("IsEnabled('globalrouter') should return true")
-	}
-	if !IsEnabled("GlobalRouter") {
-		t.Error("IsEnabled('GlobalRouter') should return true (case-insensitive)")
-	}
-	if IsEnabled("distributedrunners") {
-		t.Error("IsEnabled('distributedrunners') should return false")
-	}
-	if IsEnabled("unknownfeature") {
-		t.Error("IsEnabled('unknownfeature') should return false")
-	}
-}
-
-func TestAllFeatures(t *testing.T) {
-	features := AllFeatures()
-
-	if len(features) != 7 {
-		t.Errorf("Expected 7 features, got %d", len(features))
-	}
-
-	expected := []string{"globalrouter", "distributedrunners", "usersubdomains", "adminapi", "routeoidc", "addons", "sagas"}
-	for _, name := range expected {
-		found := false
-		for _, f := range features {
-			if f == name {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Expected feature %q not found in AllFeatures()", name)
-		}
-	}
-}
-
-func TestFeatureDescriptions(t *testing.T) {
-	descriptions := FeatureDescriptions()
-
-	if len(descriptions) != 7 {
-		t.Errorf("Expected 7 descriptions, got %d", len(descriptions))
-	}
-
-	if descriptions[FeatureGlobalRouter] == "" {
-		t.Error("GlobalRouter description should not be empty")
-	}
-	if descriptions[FeatureDistributedRunners] == "" {
-		t.Error("DistributedRunners description should not be empty")
-	}
-	if descriptions[FeatureUserSubdomains] == "" {
-		t.Error("UserSubdomains description should not be empty")
-	}
-	if descriptions[FeatureAdminAPI] == "" {
-		t.Error("AdminAPI description should not be empty")
-	}
-	if descriptions[FeatureRouteOIDC] == "" {
-		t.Error("RouteOIDC description should not be empty")
-	}
-	if descriptions[FeatureAddons] == "" {
-		t.Error("Addons description should not be empty")
-	}
-	if descriptions[FeatureSagas] == "" {
-		t.Error("Sagas description should not be empty")
-	}
-}
-
-func TestResetFunction(t *testing.T) {
-	Init(nil, []string{"globalrouter", "distributedrunners", "usersubdomains", "adminapi", "routeoidc"})
-
-	if !GlobalRouter() || !DistributedRunners() || !UserSubdomains() || !AdminAPI() || !RouteOIDC() {
-		t.Error("All features should be enabled before reset")
-	}
-
-	Reset()
-
-	if GlobalRouter() || DistributedRunners() || UserSubdomains() || AdminAPI() || RouteOIDC() {
-		t.Error("All features should be back to defaults (false) after reset")
 	}
 }
 
@@ -229,40 +91,11 @@ func TestAllKeywordWithExclusion(t *testing.T) {
 func TestNegativeAllDisablesAll(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"globalrouter", "usersubdomains", "-all"})
+	Init(nil, []string{"globalrouter", "adminapi", "-all"})
 
 	for _, name := range AllFeatures() {
 		if IsEnabled(name) {
 			t.Errorf("Feature %q should be disabled after '-all'", name)
 		}
-	}
-}
-
-func TestAllKeywordCaseInsensitive(t *testing.T) {
-	Reset()
-
-	Init(nil, []string{"ALL"})
-
-	for _, name := range AllFeatures() {
-		if !IsEnabled(name) {
-			t.Errorf("Feature %q should be enabled after Init with 'ALL'", name)
-		}
-	}
-}
-
-func TestInitLogsEnabledFeatures(t *testing.T) {
-	Reset()
-
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-
-	Init(logger, []string{"globalrouter"})
-
-	logOutput := buf.String()
-	if !strings.Contains(logOutput, "labs feature configured") {
-		t.Errorf("Expected info log about configured feature, got: %s", logOutput)
-	}
-	if !strings.Contains(logOutput, "globalrouter") {
-		t.Errorf("Expected log to contain feature name, got: %s", logOutput)
 	}
 }


### PR DESCRIPTION
The `usersubdomains` flag was one of the original three stubs created when the labs system was born, but nothing in the runtime ever checked it. Git history confirms no code outside `pkg/labs` and `docs` ever referenced it. The feature lives entirely in cloud, so this is just a dead definition collecting dust (and test maintenance churn).

While poking at the tests to remove `UserSubdomains` references, it became clear most of them were testing generated code rather than interesting behavior. Kept the seven tests that exercise real `Init` parsing logic (negation, case folding, unknown flags, whitespace, the `all`/`-all` keywords) and dropped the rest. Net result is -188 lines and a test suite that won't need touching every time a feature flag is added or removed.