### PR TITLE
Add app name column to sandbox list

### DIFF
--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -59,8 +59,9 @@ func SandboxList(ctx *Context, opts struct {
 		}
 	}
 
-	// Build a map of version ID -> short ID (best-effort for display)
+	// Build maps of version ID -> short ID and version ID -> app name (best-effort for display)
 	versionShortIdMap := make(map[string]string)
+	versionAppMap := make(map[string]string)
 	if versionKindRes, err := eac.LookupKind(ctx, "app_version"); err == nil {
 		if versionsRes, err := eac.List(ctx, versionKindRes.Attr()); err == nil {
 			for _, e := range versionsRes.Values() {
@@ -68,6 +69,9 @@ func SandboxList(ctx *Context, opts struct {
 				v.Decode(e.Entity())
 				if sid := e.Entity().ShortId(); sid != "" {
 					versionShortIdMap[v.ID.String()] = sid
+				}
+				if !entity.Empty(v.App) {
+					versionAppMap[v.ID.String()] = ui.CleanEntityID(v.App.String())
 				}
 			}
 		}
@@ -107,6 +111,7 @@ func SandboxList(ctx *Context, opts struct {
 	if opts.IsJSON() {
 		var sandboxes []struct {
 			compute_v1alpha.Sandbox
+			App     string `json:"app,omitempty"`
 			Pool    string `json:"pool,omitempty"`
 			Service string `json:"service,omitempty"`
 			Address string `json:"address,omitempty"`
@@ -152,14 +157,22 @@ func SandboxList(ctx *Context, opts struct {
 				runner = nodeNameMap[sch.Key.Node]
 			}
 
+			// Resolve app name from version
+			appName := ""
+			if name, ok := versionAppMap[sandbox.Spec.Version.String()]; ok {
+				appName = name
+			}
+
 			entry := struct {
 				compute_v1alpha.Sandbox
+				App     string `json:"app,omitempty"`
 				Pool    string `json:"pool,omitempty"`
 				Service string `json:"service,omitempty"`
 				Address string `json:"address,omitempty"`
 				Runner  string `json:"runner,omitempty"`
 			}{
 				Sandbox: sandbox,
+				App:     appName,
 				Pool:    poolLabel,
 				Service: service,
 				Address: address,
@@ -174,7 +187,7 @@ func SandboxList(ctx *Context, opts struct {
 	// Table output - all the UI formatting logic
 	var rows []ui.Row
 	var deadCount int
-	headers := []string{"ID", "VERSION", "SERVICE", "POOL", "ADDRESS", "RUNNER", "STATUS", "CREATED", "UPDATED"}
+	headers := []string{"ID", "APP", "VERSION", "SERVICE", "POOL", "ADDRESS", "RUNNER", "STATUS", "CREATED", "UPDATED"}
 
 	for _, e := range res.Values() {
 		// Decode the sandbox entity
@@ -250,8 +263,15 @@ func SandboxList(ctx *Context, opts struct {
 			poolLabelDisplay = shortId
 		}
 
+		// Resolve app name from version
+		appName := "-"
+		if name, ok := versionAppMap[sandbox.Spec.Version.String()]; ok {
+			appName = name
+		}
+
 		rows = append(rows, ui.Row{
 			sandboxId,
+			appName,
 			versionDisplay,
 			service,
 			poolLabelDisplay,

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -71,7 +71,7 @@ func SandboxList(ctx *Context, opts struct {
 					versionShortIdMap[v.ID.String()] = sid
 				}
 				if !entity.Empty(v.App) {
-					versionAppMap[v.ID.String()] = ui.CleanEntityID(v.App.String())
+					versionAppMap[v.ID.String()] = v.App.String()
 				}
 			}
 		}
@@ -266,7 +266,7 @@ func SandboxList(ctx *Context, opts struct {
 		// Resolve app name from version
 		appName := "-"
 		if name, ok := versionAppMap[sandbox.Spec.Version.String()]; ok {
-			appName = name
+			appName = ui.CleanEntityID(name)
 		}
 
 		rows = append(rows, ui.Row{


### PR DESCRIPTION
With the switch to short IDs, `sandbox list` lost the app name that used to piggyback on the version column (the old version IDs were prefixed with the app name). Now that those IDs are just three-character hashes, you can't tell which app a sandbox belongs to without cross-referencing.

Added an explicit APP column right after ID. It pulls the app name from the `AppVersion.App` field we were already fetching, so no extra RPC calls. Both table and JSON output get the new field.

Closes MIR-1007