### PR TITLE
MIR-970: Unblock addon deprovisioning when provisioning saga is in-flight

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1033,7 +1033,10 @@ func (c *Coordinator) Start(ctx context.Context) error {
 			eac,
 			controller.AdaptReconcileController[addon_v1alpha.AddonAssociation](addonController),
 			time.Minute,
-			1,
+			// Multiple workers so a long-running provisioning saga for one
+			// association does not block reconciliation of others. Same-entity
+			// concurrency is already prevented by ReconcileController.inFlight.
+			4,
 		)
 		c.cm.AddController(addonReconciler)
 	}

--- a/controllers/addon/controller.go
+++ b/controllers/addon/controller.go
@@ -64,6 +64,20 @@ func (c *Controller) Reconcile(ctx context.Context, assoc *addon_v1alpha.AddonAs
 func (c *Controller) provision(ctx context.Context, assoc *addon_v1alpha.AddonAssociation, meta *entity.Meta) error {
 	c.log.Info("provisioning addon", "association", assoc.ID, "addon", assoc.Addon, "variant", assoc.Variant)
 
+	// Re-read the association to guard against stale events (e.g. on startup
+	// resync, the reconcile event may carry an older revision than what's
+	// now in the store). If the user has already marked this association for
+	// deprovisioning, skip; the subsequent deprovisioning event will handle it.
+	var current addon_v1alpha.AddonAssociation
+	if err := c.ec.GetById(ctx, assoc.ID, &current); err != nil {
+		return fmt.Errorf("re-reading association: %w", err)
+	}
+	if current.Status != "pending" {
+		c.log.Info("association no longer pending, skipping provision",
+			"association", assoc.ID, "status", current.Status)
+		return nil
+	}
+
 	// Step 1: Set status to provisioning
 	if err := meta.Update((&addon_v1alpha.AddonAssociation{Status: "provisioning"}).Encode()); err != nil {
 		return fmt.Errorf("setting status to provisioning: %w", err)

--- a/controllers/addon/controller_test.go
+++ b/controllers/addon/controller_test.go
@@ -246,6 +246,53 @@ func TestProvisionCompensatesOnPostProvisionFailure(t *testing.T) {
 	assert.True(t, provider.deprovisionCalled, "Deprovision should have been called as compensation after post-provision failure")
 }
 
+// TestProvisionSkipsWhenAssociationNoLongerPending verifies the pre-flight
+// re-read: if a stale Reconcile event routes through provision() but the
+// association has since moved to "deprovisioning" (e.g. on startup resync
+// after the user ran `addon destroy`), provision() must be a no-op so the
+// subsequent deprovisioning event can run.
+func TestProvisionSkipsWhenAssociationNoLongerPending(t *testing.T) {
+	ctx, ctrl, ec, provider := setupControllerTest(t)
+
+	appID, err := ec.Create(ctx, "myapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	addonID, err := ec.Create(ctx, "miren-postgresql", &addon_v1alpha.Addon{
+		Name: "miren-postgresql",
+	})
+	require.NoError(t, err)
+
+	assocID, err := ec.Create(ctx, "test-assoc", &addon_v1alpha.AddonAssociation{
+		App:     appID,
+		Addon:   addonID,
+		Variant: "small",
+		Status:  "pending",
+	})
+	require.NoError(t, err)
+
+	// Capture a stale "pending" view of the association.
+	var stale addon_v1alpha.AddonAssociation
+	meta, err := getMeta(ctx, ec, assocID, &stale)
+	require.NoError(t, err)
+
+	// In the meantime, the user destroys the addon and the status flips.
+	require.NoError(t, ec.Patch(ctx, assocID, 0,
+		(&addon_v1alpha.AddonAssociation{Status: "deprovisioning"}).Encode()...,
+	))
+
+	// Now reconcile the stale event. provision() should re-read, see the
+	// association is no longer "pending", and skip without calling the provider.
+	require.NoError(t, ctrl.Reconcile(ctx, &stale, meta))
+
+	assert.False(t, provider.provisionCalled, "Provision should NOT be called when association is no longer pending")
+
+	// The on-disk status should remain "deprovisioning" — provision() must not
+	// have overwritten it.
+	var current addon_v1alpha.AddonAssociation
+	require.NoError(t, ec.GetById(ctx, assocID, &current))
+	assert.Equal(t, "deprovisioning", current.Status)
+}
+
 func TestDeprovisionCompletesWhenAppDeleted(t *testing.T) {
 	ctx, ctrl, ec, provider := setupControllerTest(t)
 


### PR DESCRIPTION
## Summary
- Bump addon reconciler worker count from 1 → 4 so a long-running provisioning saga (e.g. valkey waiting on sandbox pool readiness) no longer blocks every other addon event. Same-entity serialization is still guaranteed by `ReconcileController.inFlight`.
- Add a pre-flight re-read at the top of `provision()`: if the association is no longer `pending` (e.g. user ran `addon destroy` during the crash/resync window) skip instead of re-starting a saga that would conflict with leftover resources.

## Why
Observed sequence:
1. Reconciler starts provisioning rabbitmq and valkey.
2. Valkey saga blocks waiting on sandbox pool readiness — occupies the sole worker.
3. User runs `addon destroy`; status flips to `deprovisioning`.
4. Deprovisioning event sits in the work queue forever.

On restart, the resync re-enqueues stale `pending` events and re-triggers provisioning on associations the user had already destroyed, creating conflicting resources.

## Test plan
- [x] `go test ./controllers/addon/` — new `TestProvisionSkipsWhenAssociationNoLongerPending` covers the stale-event path.
- [x] `go vet ./controllers/addon/... ./components/coordinate/...`
- [ ] Smoke in `make dev`: install valkey + rabbitmq, confirm rabbitmq finishes while valkey is still waiting on its sandbox pool.

## Out of scope
Coordinating saga `Recover()` with a concurrent reconciler-driven re-provision is tracked as a follow-up — the fixes here narrow the window significantly but do not fully close it.