### PR TITLE
Detect dead sandboxes on failed runners

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -45,6 +45,7 @@ import (
 	artifactctrl "miren.dev/runtime/controllers/artifact"
 	certctrl "miren.dev/runtime/controllers/certificate"
 	deploymentctrl "miren.dev/runtime/controllers/deployment"
+	nodehealthctrl "miren.dev/runtime/controllers/nodehealth"
 	"miren.dev/runtime/controllers/sandboxpool"
 	schedulerctrl "miren.dev/runtime/controllers/scheduler"
 	"miren.dev/runtime/metrics"
@@ -968,6 +969,25 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		1,           // Single worker
 	)
 	c.cm.AddController(schedulerController)
+
+	// Add node health controller (marks sandboxes DEAD when their runner
+	// has been non-READY for longer than the grace period)
+	nodeHealth := nodehealthctrl.NewController(c.Log, eac)
+	if err := nodeHealth.Init(ctx); err != nil {
+		c.Log.Error("failed to initialize node health controller", "error", err)
+		return err
+	}
+
+	nodeHealthRC := controller.NewReconcileController(
+		"nodehealth",
+		c.Log,
+		entity.Ref(entity.EntityKind, compute_v1alpha.KindNode),
+		eac,
+		controller.AdaptReconcileController[compute_v1alpha.Node](nodeHealth),
+		30*time.Second, // Resync to check grace period expiry
+		1,
+	)
+	c.cm.AddController(nodeHealthRC)
 
 	// Add certificate controller — DNS-01 when a DNS provider is configured,
 	// otherwise HTTP-01 via autocert for eager cert provisioning on route set.

--- a/controllers/nodehealth/controller.go
+++ b/controllers/nodehealth/controller.go
@@ -2,6 +2,7 @@ package nodehealth
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -160,6 +161,7 @@ func (c *Controller) markNodeSandboxesDead(ctx context.Context, nodeID entity.Id
 	}
 
 	marked := 0
+	var patchErr error
 	for _, e := range results.Values() {
 		var sb compute_v1alpha.Sandbox
 		sb.Decode(e.Entity())
@@ -181,6 +183,7 @@ func (c *Controller) markNodeSandboxesDead(ctx context.Context, nodeID entity.Id
 		).Attrs(), 0)
 		if err != nil {
 			c.log.Error("failed to mark sandbox dead", "sandbox", sb.ID, "error", err)
+			patchErr = errors.Join(patchErr, err)
 			continue
 		}
 		marked++
@@ -192,5 +195,5 @@ func (c *Controller) markNodeSandboxesDead(ctx context.Context, nodeID entity.Id
 			"count", marked)
 	}
 
-	return nil
+	return patchErr
 }

--- a/controllers/nodehealth/controller.go
+++ b/controllers/nodehealth/controller.go
@@ -1,0 +1,146 @@
+package nodehealth
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+const DefaultGracePeriod = 5 * time.Minute
+
+// Controller watches Node entities and marks sandboxes DEAD when their
+// runner has been non-READY for longer than the grace period. This handles
+// the case where a runner dies permanently (node failure, crash without
+// recovery) and its sandboxes need to be cleaned up so the pool controller
+// can create replacements.
+//
+// The grace period exists because containers survive miren process restarts.
+// A runner that's just restarting (upgrade, deploy) will come back and
+// re-adopt its containers via reconcileSandboxesOnBoot(). We only want to
+// intervene when the runner is truly gone.
+//
+// Implements controller.ReconcileControllerI[*compute_v1alpha.Node]
+type Controller struct {
+	log         *slog.Logger
+	eac         *entityserver_v1alpha.EntityAccessClient
+	gracePeriod time.Duration
+
+	mu          sync.Mutex
+	unhealthyAt map[entity.Id]time.Time
+	now         func() time.Time // for testing
+}
+
+func NewController(
+	log *slog.Logger,
+	eac *entityserver_v1alpha.EntityAccessClient,
+) *Controller {
+	return &Controller{
+		log:         log.With("module", "nodehealth"),
+		eac:         eac,
+		gracePeriod: DefaultGracePeriod,
+		unhealthyAt: make(map[entity.Id]time.Time),
+		now:         time.Now,
+	}
+}
+
+func (c *Controller) Init(ctx context.Context) error {
+	c.log.Info("initializing node health controller", "grace_period", c.gracePeriod)
+	return nil
+}
+
+func (c *Controller) Reconcile(ctx context.Context, node *compute_v1alpha.Node, meta *entity.Meta) error {
+	if node.Status == compute_v1alpha.READY {
+		c.clearTracking(node.ID)
+		return nil
+	}
+
+	firstSeen := c.trackUnhealthy(node.ID)
+	elapsed := c.now().Sub(firstSeen)
+
+	if elapsed < c.gracePeriod {
+		c.log.Info("node not ready, within grace period",
+			"node", node.ID,
+			"status", node.Status,
+			"elapsed", elapsed.Round(time.Second),
+			"grace_period", c.gracePeriod)
+		return nil
+	}
+
+	c.log.Warn("node not ready, grace period expired, marking sandboxes dead",
+		"node", node.ID,
+		"status", node.Status,
+		"elapsed", elapsed.Round(time.Second))
+
+	return c.markNodeSandboxesDead(ctx, node.ID)
+}
+
+// clearTracking removes a node from the unhealthy tracker (it recovered).
+func (c *Controller) clearTracking(nodeID entity.Id) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, was := c.unhealthyAt[nodeID]; was {
+		c.log.Info("node recovered, clearing grace period tracking", "node", nodeID)
+		delete(c.unhealthyAt, nodeID)
+	}
+}
+
+// trackUnhealthy records when a node was first seen as non-READY. Returns
+// the timestamp of first observation.
+func (c *Controller) trackUnhealthy(nodeID entity.Id) time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if t, ok := c.unhealthyAt[nodeID]; ok {
+		return t
+	}
+	now := c.now()
+	c.unhealthyAt[nodeID] = now
+	return now
+}
+
+func (c *Controller) markNodeSandboxesDead(ctx context.Context, nodeID entity.Id) error {
+	idx := compute_v1alpha.Index(compute_v1alpha.KindSandbox, nodeID)
+	results, err := c.eac.List(ctx, idx)
+	if err != nil {
+		return err
+	}
+
+	marked := 0
+	for _, e := range results.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(e.Entity())
+
+		if sb.Status == compute_v1alpha.DEAD || sb.Status == compute_v1alpha.STOPPED {
+			continue
+		}
+
+		c.log.Info("marking sandbox dead",
+			"sandbox", sb.ID,
+			"node", nodeID,
+			"previous_status", sb.Status)
+
+		_, err := c.eac.Patch(ctx, entity.New(
+			entity.DBId, sb.ID,
+			(&compute_v1alpha.Sandbox{
+				Status: compute_v1alpha.DEAD,
+			}).Encode,
+		).Attrs(), 0)
+		if err != nil {
+			c.log.Error("failed to mark sandbox dead", "sandbox", sb.ID, "error", err)
+			continue
+		}
+		marked++
+	}
+
+	if marked > 0 {
+		c.log.Warn("marked sandboxes dead for failed node",
+			"node", nodeID,
+			"count", marked)
+	}
+
+	return nil
+}

--- a/controllers/nodehealth/controller.go
+++ b/controllers/nodehealth/controller.go
@@ -24,7 +24,12 @@ const DefaultGracePeriod = 5 * time.Minute
 // re-adopt its containers via reconcileSandboxesOnBoot(). We only want to
 // intervene when the runner is truly gone.
 //
+// Nodes with DISABLED status are intentionally excluded. DISABLED is set
+// by Drain() during graceful shutdown, which handles its own sandbox
+// cleanup. We don't want to race with that.
+//
 // Implements controller.ReconcileControllerI[*compute_v1alpha.Node]
+// Implements controller.DeletingReconcileController
 type Controller struct {
 	log         *slog.Logger
 	eac         *entityserver_v1alpha.EntityAccessClient
@@ -32,6 +37,7 @@ type Controller struct {
 
 	mu          sync.Mutex
 	unhealthyAt map[entity.Id]time.Time
+	handled     map[entity.Id]bool
 	now         func() time.Time // for testing
 }
 
@@ -44,6 +50,7 @@ func NewController(
 		eac:         eac,
 		gracePeriod: DefaultGracePeriod,
 		unhealthyAt: make(map[entity.Id]time.Time),
+		handled:     make(map[entity.Id]bool),
 		now:         time.Now,
 	}
 }
@@ -55,6 +62,13 @@ func (c *Controller) Init(ctx context.Context) error {
 
 func (c *Controller) Reconcile(ctx context.Context, node *compute_v1alpha.Node, meta *entity.Meta) error {
 	if node.Status == compute_v1alpha.READY {
+		c.clearTracking(node.ID)
+		return nil
+	}
+
+	// DISABLED is operator-initiated (Drain). The drain process handles
+	// its own sandbox cleanup, so we stay out of its way.
+	if node.Status == compute_v1alpha.DISABLED {
 		c.clearTracking(node.ID)
 		return nil
 	}
@@ -71,21 +85,45 @@ func (c *Controller) Reconcile(ctx context.Context, node *compute_v1alpha.Node, 
 		return nil
 	}
 
+	if c.isHandled(node.ID) {
+		return nil
+	}
+
 	c.log.Warn("node not ready, grace period expired, marking sandboxes dead",
 		"node", node.ID,
 		"status", node.Status,
 		"elapsed", elapsed.Round(time.Second))
 
-	return c.markNodeSandboxesDead(ctx, node.ID)
+	err := c.markNodeSandboxesDead(ctx, node.ID)
+	if err == nil {
+		c.setHandled(node.ID)
+	}
+	return err
 }
 
-// clearTracking removes a node from the unhealthy tracker (it recovered).
+// Delete cleans up tracking state when a node entity is removed
+// (e.g., via "miren runner remove").
+func (c *Controller) Delete(ctx context.Context, id entity.Id) error {
+	c.clearTracking(id)
+	return nil
+}
+
+// clearTracking removes a node from all tracking maps (it recovered,
+// was removed, or entered a managed state like DISABLED).
 func (c *Controller) clearTracking(nodeID entity.Id) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if _, was := c.unhealthyAt[nodeID]; was {
-		c.log.Info("node recovered, clearing grace period tracking", "node", nodeID)
+	wasTracked := false
+	if _, ok := c.unhealthyAt[nodeID]; ok {
 		delete(c.unhealthyAt, nodeID)
+		wasTracked = true
+	}
+	if c.handled[nodeID] {
+		delete(c.handled, nodeID)
+		wasTracked = true
+	}
+	if wasTracked {
+		c.log.Info("node recovered, clearing grace period tracking", "node", nodeID)
 	}
 }
 
@@ -100,6 +138,18 @@ func (c *Controller) trackUnhealthy(nodeID entity.Id) time.Time {
 	now := c.now()
 	c.unhealthyAt[nodeID] = now
 	return now
+}
+
+func (c *Controller) isHandled(nodeID entity.Id) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.handled[nodeID]
+}
+
+func (c *Controller) setHandled(nodeID entity.Id) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.handled[nodeID] = true
 }
 
 func (c *Controller) markNodeSandboxesDead(ctx context.Context, nodeID entity.Id) error {

--- a/controllers/nodehealth/controller_test.go
+++ b/controllers/nodehealth/controller_test.go
@@ -1,0 +1,273 @@
+package nodehealth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/controller"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+// createReadyNode creates a node entity with session-scoped READY status.
+func createReadyNode(t *testing.T, ctx context.Context, client *entityserver.Client, name string, node *compute_v1alpha.Node) entity.Id {
+	t.Helper()
+
+	status := node.Status
+	node.Status = ""
+	if node.ApiAddress == "" {
+		node.ApiAddress = ":8444"
+	}
+	nodeID, err := client.Create(ctx, name, node)
+	require.NoError(t, err)
+
+	_, sc, err := client.NewSession(ctx, "test node health")
+	require.NoError(t, err)
+
+	err = sc.UpdateAttrs(ctx, nodeID, (&compute_v1alpha.Node{Status: status}).Encode)
+	require.NoError(t, err)
+
+	return nodeID
+}
+
+// createScheduledSandbox creates a sandbox entity and assigns it to a node
+// via a schedule key, mimicking what the scheduler controller does.
+func createScheduledSandbox(t *testing.T, ctx context.Context, server *testutils.InMemEntityServer, name string, nodeID entity.Id, status compute_v1alpha.SandboxStatus) entity.Id {
+	t.Helper()
+
+	sandbox := &compute_v1alpha.Sandbox{
+		Status: status,
+		Spec: compute_v1alpha.SandboxSpec{
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+	sandboxID, err := server.Client.Create(ctx, name, sandbox)
+	require.NoError(t, err)
+
+	// Add schedule key to assign sandbox to the node
+	schedule := compute_v1alpha.Schedule{
+		Key: compute_v1alpha.Key{
+			Kind: compute_v1alpha.KindSandbox,
+			Node: nodeID,
+		},
+	}
+	_, err = server.EAC.Patch(ctx, entity.New(
+		entity.DBId, sandboxID,
+		schedule.Encode,
+	).Attrs(), 0)
+	require.NoError(t, err)
+
+	return sandboxID
+}
+
+// reconcileNode runs the nodehealth controller through the real controller
+// framework for a single node entity.
+func reconcileNode(t *testing.T, ctx context.Context, server *testutils.InMemEntityServer, ctrl *Controller) {
+	t.Helper()
+
+	rc := controller.NewReconcileController(
+		"test-nodehealth",
+		testutils.TestLogger(t),
+		entity.Ref(entity.EntityKind, compute_v1alpha.KindNode),
+		server.EAC,
+		controller.AdaptReconcileController[compute_v1alpha.Node](ctrl),
+		0, 1,
+	)
+
+	resp, err := server.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindNode))
+	require.NoError(t, err)
+
+	for _, e := range resp.Values() {
+		event := controller.Event{
+			Type:   controller.EventUpdated,
+			Id:     e.Entity().Id(),
+			Entity: e.Entity(),
+		}
+		err = rc.ProcessEventForTest(ctx, event)
+		require.NoError(t, err)
+	}
+}
+
+func getSandboxStatus(t *testing.T, ctx context.Context, server *testutils.InMemEntityServer, sandboxID entity.Id) compute_v1alpha.SandboxStatus {
+	t.Helper()
+	resp, err := server.EAC.Get(ctx, sandboxID.String())
+	require.NoError(t, err)
+	var sb compute_v1alpha.Sandbox
+	sb.Decode(resp.Entity().Entity())
+	return sb.Status
+}
+
+func TestReadyNodeNoAction(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	nodeID := createReadyNode(t, ctx, server.Client, "test-node", &compute_v1alpha.Node{
+		Status: compute_v1alpha.READY,
+	})
+
+	sbID := createScheduledSandbox(t, ctx, server, "test-sandbox", nodeID, compute_v1alpha.RUNNING)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	require.NoError(t, ctrl.Init(ctx))
+
+	reconcileNode(t, ctx, server, ctrl)
+
+	assert.Equal(t, compute_v1alpha.RUNNING, getSandboxStatus(t, ctx, server, sbID),
+		"sandbox on READY node should remain RUNNING")
+}
+
+func TestNonReadyNodeWithinGracePeriod(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create a node that is NOT ready (no session-scoped status set)
+	node := &compute_v1alpha.Node{ApiAddress: ":8444"}
+	nodeID, err := server.Client.Create(ctx, "test-node", node)
+	require.NoError(t, err)
+
+	sbID := createScheduledSandbox(t, ctx, server, "test-sandbox", nodeID, compute_v1alpha.RUNNING)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	ctrl.gracePeriod = 5 * time.Minute
+	require.NoError(t, ctrl.Init(ctx))
+
+	reconcileNode(t, ctx, server, ctrl)
+
+	assert.Equal(t, compute_v1alpha.RUNNING, getSandboxStatus(t, ctx, server, sbID),
+		"sandbox should remain RUNNING within grace period")
+}
+
+func TestNonReadyNodeGracePeriodExpired(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	node := &compute_v1alpha.Node{ApiAddress: ":8444"}
+	nodeID, err := server.Client.Create(ctx, "test-node", node)
+	require.NoError(t, err)
+
+	sbRunning := createScheduledSandbox(t, ctx, server, "sb-running", nodeID, compute_v1alpha.RUNNING)
+	sbPending := createScheduledSandbox(t, ctx, server, "sb-pending", nodeID, compute_v1alpha.PENDING)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	ctrl.gracePeriod = 5 * time.Minute
+	require.NoError(t, ctrl.Init(ctx))
+
+	// First reconciliation starts the grace period
+	reconcileNode(t, ctx, server, ctrl)
+
+	// Advance time past grace period
+	ctrl.now = func() time.Time { return time.Now().Add(6 * time.Minute) }
+
+	// Second reconciliation should mark sandboxes DEAD
+	reconcileNode(t, ctx, server, ctrl)
+
+	assert.Equal(t, compute_v1alpha.DEAD, getSandboxStatus(t, ctx, server, sbRunning),
+		"RUNNING sandbox should be marked DEAD after grace period")
+	assert.Equal(t, compute_v1alpha.DEAD, getSandboxStatus(t, ctx, server, sbPending),
+		"PENDING sandbox should be marked DEAD after grace period")
+}
+
+func TestNodeRecoversWithinGracePeriod(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Start with a non-ready node
+	node := &compute_v1alpha.Node{ApiAddress: ":8444"}
+	nodeID, err := server.Client.Create(ctx, "test-node", node)
+	require.NoError(t, err)
+
+	sbID := createScheduledSandbox(t, ctx, server, "test-sandbox", nodeID, compute_v1alpha.RUNNING)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	ctrl.gracePeriod = 5 * time.Minute
+	require.NoError(t, ctrl.Init(ctx))
+
+	// First reconciliation starts the grace period
+	reconcileNode(t, ctx, server, ctrl)
+
+	// Node recovers (set status to READY via session)
+	_, sc, err := server.Client.NewSession(ctx, "recovery")
+	require.NoError(t, err)
+	err = sc.UpdateAttrs(ctx, nodeID, (&compute_v1alpha.Node{Status: compute_v1alpha.READY}).Encode)
+	require.NoError(t, err)
+
+	// Reconcile again - should clear grace period tracking
+	reconcileNode(t, ctx, server, ctrl)
+
+	// Advance time well past the original grace period
+	ctrl.now = func() time.Time { return time.Now().Add(10 * time.Minute) }
+
+	// Reconcile again - should NOT mark sandboxes dead (node is READY)
+	reconcileNode(t, ctx, server, ctrl)
+
+	assert.Equal(t, compute_v1alpha.RUNNING, getSandboxStatus(t, ctx, server, sbID),
+		"sandbox should remain RUNNING after node recovered")
+}
+
+func TestSkipsAlreadyDeadAndStoppedSandboxes(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	node := &compute_v1alpha.Node{ApiAddress: ":8444"}
+	nodeID, err := server.Client.Create(ctx, "test-node", node)
+	require.NoError(t, err)
+
+	sbDead := createScheduledSandbox(t, ctx, server, "sb-dead", nodeID, compute_v1alpha.DEAD)
+	sbStopped := createScheduledSandbox(t, ctx, server, "sb-stopped", nodeID, compute_v1alpha.STOPPED)
+	sbRunning := createScheduledSandbox(t, ctx, server, "sb-running", nodeID, compute_v1alpha.RUNNING)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	ctrl.gracePeriod = 0 // immediate action for this test
+	require.NoError(t, ctrl.Init(ctx))
+
+	reconcileNode(t, ctx, server, ctrl)
+
+	assert.Equal(t, compute_v1alpha.DEAD, getSandboxStatus(t, ctx, server, sbDead),
+		"already DEAD sandbox should stay DEAD")
+	assert.Equal(t, compute_v1alpha.STOPPED, getSandboxStatus(t, ctx, server, sbStopped),
+		"already STOPPED sandbox should stay STOPPED")
+	assert.Equal(t, compute_v1alpha.DEAD, getSandboxStatus(t, ctx, server, sbRunning),
+		"RUNNING sandbox should be marked DEAD")
+}
+
+func TestMultipleNodesIndependent(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Node 1 is healthy
+	node1ID := createReadyNode(t, ctx, server.Client, "healthy-node", &compute_v1alpha.Node{
+		Status: compute_v1alpha.READY,
+	})
+
+	// Node 2 is dead
+	node2 := &compute_v1alpha.Node{ApiAddress: ":8445"}
+	node2ID, err := server.Client.Create(ctx, "dead-node", node2)
+	require.NoError(t, err)
+
+	sb1 := createScheduledSandbox(t, ctx, server, "sb-on-healthy", node1ID, compute_v1alpha.RUNNING)
+	sb2 := createScheduledSandbox(t, ctx, server, "sb-on-dead", node2ID, compute_v1alpha.RUNNING)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	ctrl.gracePeriod = 0 // immediate
+	require.NoError(t, ctrl.Init(ctx))
+
+	reconcileNode(t, ctx, server, ctrl)
+
+	assert.Equal(t, compute_v1alpha.RUNNING, getSandboxStatus(t, ctx, server, sb1),
+		"sandbox on healthy node should remain RUNNING")
+	assert.Equal(t, compute_v1alpha.DEAD, getSandboxStatus(t, ctx, server, sb2),
+		"sandbox on dead node should be marked DEAD")
+}

--- a/controllers/nodehealth/controller_test.go
+++ b/controllers/nodehealth/controller_test.go
@@ -242,6 +242,56 @@ func TestSkipsAlreadyDeadAndStoppedSandboxes(t *testing.T) {
 		"RUNNING sandbox should be marked DEAD")
 }
 
+func TestDisabledNodeSkipsGracePeriod(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	// Create a DISABLED node (simulating Drain in progress)
+	nodeID := createReadyNode(t, ctx, server.Client, "draining-node", &compute_v1alpha.Node{
+		Status: compute_v1alpha.DISABLED,
+	})
+
+	sbID := createScheduledSandbox(t, ctx, server, "test-sandbox", nodeID, compute_v1alpha.RUNNING)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	ctrl.gracePeriod = 0 // would fire immediately if not skipped
+	require.NoError(t, ctrl.Init(ctx))
+
+	reconcileNode(t, ctx, server, ctrl)
+
+	assert.Equal(t, compute_v1alpha.RUNNING, getSandboxStatus(t, ctx, server, sbID),
+		"sandbox on DISABLED node should remain RUNNING (drain handles cleanup)")
+}
+
+func TestHandledNodeNotRescanned(t *testing.T) {
+	ctx := context.Background()
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	node := &compute_v1alpha.Node{ApiAddress: ":8444"}
+	nodeID, err := server.Client.Create(ctx, "test-node", node)
+	require.NoError(t, err)
+
+	sbID := createScheduledSandbox(t, ctx, server, "test-sandbox", nodeID, compute_v1alpha.RUNNING)
+
+	ctrl := NewController(testutils.TestLogger(t), server.EAC)
+	ctrl.gracePeriod = 0
+	require.NoError(t, ctrl.Init(ctx))
+
+	// First reconcile marks sandbox DEAD
+	reconcileNode(t, ctx, server, ctrl)
+	assert.Equal(t, compute_v1alpha.DEAD, getSandboxStatus(t, ctx, server, sbID))
+
+	// Create a new sandbox on the same dead node (simulating external creation)
+	sbNew := createScheduledSandbox(t, ctx, server, "new-sandbox", nodeID, compute_v1alpha.RUNNING)
+
+	// Second reconcile should skip (node already handled)
+	reconcileNode(t, ctx, server, ctrl)
+	assert.Equal(t, compute_v1alpha.RUNNING, getSandboxStatus(t, ctx, server, sbNew),
+		"new sandbox should not be marked DEAD because node was already handled")
+}
+
 func TestMultipleNodesIndependent(t *testing.T) {
 	ctx := context.Background()
 	server, cleanup := testutils.NewInMemEntityServer(t)


### PR DESCRIPTION
When a distributed runner dies (process crash, node failure), its session-scoped `READY` status on the Node entity clears after the ~60s session TTL. The scheduler already uses this to avoid placing *new* sandboxes on dead nodes, but nothing was watching for *existing* sandboxes that were already running there. They'd stay in `RUNNING` status forever, and the coordinator would keep routing traffic to their IPs, causing request timeouts for as long as the node was down.

The fix is a new `nodehealth` controller on the coordinator that watches Node entities. When a node loses READY, the controller starts a 5-minute grace period. If the node doesn't recover within that window, it lists all sandboxes scheduled to the node and marks them DEAD. The activator's existing watch pipeline picks up the status change and immediately invalidates cached leases, so traffic stops routing to the dead IPs. The pool controller then sees the reduced capacity and spins up replacements on healthy nodes.

The grace period is the interesting design choice here. Containers survive miren process restarts (containerd keeps running), and `reconcileSandboxesOnBoot()` re-adopts them when the runner comes back. We verified on Garden that all 13 sandboxes survived today's restart with zero downtime. Marking sandboxes DEAD immediately would break this recovery path and cause unnecessary churn on every upgrade or restart. Five minutes is generous for any normal restart (typically 15-30 seconds) while still bounding the impact of a real failure.

We also discovered during investigation that `reconcileSandboxesOnBoot()` reattaches logs and re-reserves IPs for surviving sandboxes, but doesn't re-register cgroup metrics monitoring. That's tracked separately in MIR-1013.

Validated on Toys with a coordinator + distributed runner topology. Killed the runner process and watched the coordinator detect the node going not-ready after session TTL, tick through the grace period for 5 minutes, then mark 3 sandboxes dead. The pool controller replaced them on surviving nodes within seconds. Also verified the restart path: bounced the runner, it recovered in under a second, grace period cleared, no sandbox disruption.

Closes MIR-1009