### PR TITLE
Fail builds on app.toml parse errors instead of silently continuing

### DIFF
--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -1246,6 +1246,28 @@ bogus = true
 		assert.Contains(t, err.Error(), "bogus")
 	})
 
+	// A newer CLI may send fields that an older server doesn't recognize.
+	// The server must reject the config rather than silently dropping
+	// services.
+	t.Run("unknown top-level section rejects cleanly (version skew)", func(t *testing.T) {
+		config := `
+name = "test-app"
+
+[services.web]
+command = "bin/server"
+
+[services.valkey]
+image = "oci.miren.cloud/valkey:8"
+
+[future_feature]
+setting = "value"
+`
+		_, err := Parse([]byte(config))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown field")
+		assert.Contains(t, err.Error(), "future_feature")
+	})
+
 	t.Run("valid config still works", func(t *testing.T) {
 		config := `
 name = "test-app"

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -1100,7 +1100,11 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 
 	ac, err := b.loadAppConfig(tr)
 	if err != nil {
-		b.Log.Warn("error loading app config, ignoring", "error", err)
+		setupSpan.RecordError(err)
+		setupSpan.SetStatus(codes.Error, err.Error())
+		setupSpan.End()
+		b.sendErrorStatus(ctx, status, "Invalid app.toml: %v", err)
+		return nil, fmt.Errorf("error loading app config: %w", err)
 	}
 	if ac != nil {
 		b.Log.Info("loaded app config", "name", ac.Name, "envVarCount", len(ac.EnvVars), "serviceCount", len(ac.Services))
@@ -1702,7 +1706,7 @@ func (b *Builder) AnalyzeApp(ctx context.Context, state *build_v1alpha.BuilderAn
 	// Load app config
 	ac, err := b.loadAppConfig(tr)
 	if err != nil {
-		b.Log.Warn("error loading app config, ignoring", "error", err)
+		return fmt.Errorf("error loading app config: %w", err)
 	}
 	if ac != nil {
 		var event build_v1alpha.DetectionEvent


### PR DESCRIPTION
The build server had this pattern in two places where it loaded app.toml:

```go
ac, err := b.loadAppConfig(tr)
if err != nil {
    b.Log.Warn("error loading app config, ignoring", "error", err)
}
```

Any parse error got logged and discarded, and the build continued as if no app.toml existed. Services, env vars, build config, addons -- all silently gone. The user saw a successful deploy with the wrong number of services and no indication that anything went wrong.

This bit us on a deploy where a v0.7.0 CLI sent an `[aliases]` section to a v0.6.1 server. `DisallowUnknownFields` correctly rejected the unknown field, but the error was swallowed. The app deployed with 1 service instead of 3, leading to a ~23 hour degradation and eventual outage when crash cooldown kicked in.

The fix is straightforward: return the error instead of ignoring it. The build path now also sends the parse error to the client via `sendErrorStatus`, so the user gets the full diagnostic (file path, line number, "did you mean?" suggestions) rather than a mysterious "no services defined" error downstream.

The build server code change itself doesn't have direct test coverage. `buildFromDir` is deeply wired into the Builder and hard to unit test in isolation, but we're on the cusp of breaking that whole section into a saga which will make it much more testable. In the meantime we have unit test coverage on the appconfig parsing layer confirming that unknown fields are correctly rejected, including a new version-skew scenario test added here.

Closes MIR-1016