### PR TITLE
Cut steady-state log noise from miren server

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -1195,10 +1195,6 @@ func (l *Launcher) cleanupOldVersionPools(ctx context.Context, app *core_v1alpha
 		// Check if pool belongs to this app
 		appLabel, _ := poolMeta.Labels.Get("app")
 		if appLabel != app.ID.String() {
-			l.Log.Debug("skipping pool for different app",
-				"pool", pool.ID,
-				"pool_app", appLabel,
-				"our_app", app.ID)
 			continue
 		}
 

--- a/controllers/sandbox/metrics.go
+++ b/controllers/sandbox/metrics.go
@@ -23,7 +23,6 @@ type Cgroups struct {
 
 	attrs       map[string]string
 	lastReading time.Time
-	lastLogTime time.Time
 	prev        map[string]*stats.Metrics
 }
 
@@ -214,11 +213,6 @@ func (m *Metrics) writeStatsToStorage(ctx context.Context) error {
 			m.Log.Error("failed to record memory usage", "err", err)
 		}
 
-		// Only log every 10 seconds
-		if cg.lastLogTime.IsZero() || wallEnd.Sub(cg.lastLogTime) >= 10*time.Second {
-			m.Log.Debug("recorded container stats", "app", name, "sandbox", cg.attrs["sandbox"], "usage", usage, "mem", mem)
-			cg.lastLogTime = wallEnd
-		}
 		cg.lastReading = wallEnd
 	}
 

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -109,7 +109,6 @@ func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox,
 						"id", co.ID, "age", age)
 					return nil
 				}
-				s.log.Debug("sandbox already exists, skipping create")
 				return nil
 			case unhealthy:
 				s.log.Info("sandbox container exists but is unhealthy", "id", co.ID)

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -571,8 +571,6 @@ func PauseContainerID(id entity.Id) string {
 }
 
 func (c *SandboxController) CheckSandbox(ctx context.Context, co *compute.Sandbox, meta *entity.Meta) (int, error) {
-	c.Log.Debug("checking for existing sandbox", "id", co.ID)
-
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
 	_, err := c.CC.LoadContainer(ctx, pauseContainerId(co.ID))
@@ -836,7 +834,6 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 						return nil
 					}
 				}
-				c.Log.Debug("sandbox already exists, skipping create")
 				return nil
 			case unhealthy:
 				c.Log.Info("sandbox container exists but is unhealthy", "id", co.ID)

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "7f47cea78ca245fc430f131f3e15c3d4837b347a6f68b1357a65ec3a019d4081",
+		"sandbox.go":  "d0116681a04feb8dc09a346e185ac3ba8f30436c0835d9e5340986e9c763a495",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -62,11 +62,6 @@ func (m *Manager) Init(ctx context.Context) error {
 // specified in the pool entity.
 // This method is called by the controller framework for both Add and Update events.
 func (m *Manager) Reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPool, meta *entity.Meta) error {
-	m.log.Debug("reconciling pool",
-		"pool", pool.ID,
-		"service", pool.Service,
-		"desired", pool.DesiredInstances)
-
 	// Get all sandboxes for this pool
 	sandboxes, err := m.listSandboxes(ctx, pool)
 	if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -344,8 +344,6 @@ func (c *ReconcileController) runWorker(ctx context.Context) {
 			}
 			c.inFlightMu.Unlock()
 
-			c.Log.Info("Processing event", "entity", event.Id, "worker", WorkerId(ctx), "rev", event.Rev)
-
 			// Process the event
 			updates, err := c.processItem(ctx, event)
 			if err != nil {

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -324,7 +324,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if identity != nil {
 		ctx = ContextWithIdentity(ctx, identity)
 		r = r.WithContext(ctx)
-		s.state.log.Debug("request authenticated", "subject", identity.Subject, "method", identity.Method, "path", r.URL.Path)
 	}
 
 	// For RPC paths, let the method-level check in handleCalls decide based on public flag

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -239,7 +239,6 @@ func (h *Server) expireLeases(ctx context.Context) {
 			// Renew all retained leases — both active (Uses > 0) and idle
 			// but within TTL. This validates with the activator that the
 			// sandbox is still alive, so we never serve a stale route.
-			h.Log.Debug("renewing lease", "app", app, "url", l.Lease.URL, "uses", l.Uses)
 			lease, err := h.aa.RenewLease(ctx, l.Lease)
 			if err != nil {
 				h.Log.Error("error renewing lease", "error", err, "app", app, "url", l.Lease.URL)
@@ -501,7 +500,6 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 		// Use the http route if found
 		targetAppId = route.App
 		routeType = "route"
-		h.Log.Debug("using http route", "host", onlyHost, "app", targetAppId)
 
 		// Check if OIDC authentication is required
 		if !entity.Empty(route.OidcProvider) {


### PR DESCRIPTION
After a v0.7.0 upgrade on one of our prod servers we pulled two hours of `journalctl -u miren` and ran a frequency analysis. The server was producing around 86k lines in that window — roughly 75% DEBUG and 24% INFO — and most of it was content-free steady-state chatter. Every internal RPC logged its own auth success, every proxied HTTP request logged its route match, every sandbox-pool reconcile emitted a three-line trio, every lease got a heartbeat line, every sandbox no-op got a two-line "I checked, nothing to do" pair. Finding anything interesting in the log stream was genuinely hard.

This PR is the straightforward cut: remove the lines that are pure noise and delete the `Processing event` INFO line in the generic controller framework, which was the single loudest prod-visible offender because it fires for every reconcile of every entity. Also took out a redundant container stats log — that data already flows into the customer metrics pipeline under `metrics/`, so the slog copy was just duplication.

The ticket suggested some of these could be downgraded to TRACE instead, but the codebase uses stdlib `slog` with only Debug/Info/Warn/Error. Rather than introduce a custom TRACE level just for this, we deleted outright — `git log -S` will find anything we want back.

A few offenders were actually metrics wearing a trenchcoat. The OTel SDK is already set up in `pkg/rpc/otel.go`, but we don't currently emit any first-party `Counter` / `Histogram` / `UpDownCounter` instruments from the server itself. Ingress request counts, controller reconcile counts, and sandbox pool gauges all belong there rather than in the log stream. That's its own project, tracked as MIR-1026. The `failed to lock file` chatter from embedded etcd's purge routine (240× in 2h) is library-internal and needs its own intervention, tracked as MIR-1025.

Extrapolating from the ticket's volume numbers, this removes roughly 65k of the 86k lines per 2h (~76%).

Closes MIR-1024
Related: MIR-1025, MIR-1026