### PR TITLE
Force Rust crate rebuild to prevent shipping stale binaries

### DIFF
--- a/pkg/stackbuild/rust.go
+++ b/pkg/stackbuild/rust.go
@@ -124,16 +124,9 @@ func (s *RustStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 		cpCmd = fmt.Sprintf("cp target/release/%s /bin/app", binaryName)
 	}
 
-	// Force-rebuild our crate: buildkit normalizes source mtimes, so cargo's
-	// fingerprint check can skip a real source change and ship a stale binary.
-	buildCmd := "cargo build --release"
-	if s.packageName != "" {
-		buildCmd = fmt.Sprintf("cargo clean --release -p %s && cargo build --release", s.packageName)
-	}
-
 	state = state.Dir("/app").Run(
 		llb.Args([]string{"/bin/sh", "-c",
-			fmt.Sprintf("%s && %s", buildCmd, cpCmd)}),
+			fmt.Sprintf("%s && %s", s.buildCommand(), cpCmd)}),
 		h.CacheMount("/usr/local/cargo/registry"),
 		h.CacheMount("/app/target"),
 		llb.WithCustomName("[phase] Building Rust application"),
@@ -144,6 +137,14 @@ func (s *RustStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 	state = s.applyOnBuild(state, opts)
 
 	return &state, nil
+}
+
+// buildCommand force-rebuilds the workspace crate to dodge the buildkit-mtime / cargo-fingerprint staleness bug (MIR-1027).
+func (s *RustStack) buildCommand() string {
+	if s.packageName != "" {
+		return fmt.Sprintf("cargo clean --release -p %s && cargo build --release", s.packageName)
+	}
+	return "cargo build --release"
 }
 
 func (s *RustStack) WebCommand() string {

--- a/pkg/stackbuild/rust.go
+++ b/pkg/stackbuild/rust.go
@@ -124,9 +124,16 @@ func (s *RustStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 		cpCmd = fmt.Sprintf("cp target/release/%s /bin/app", binaryName)
 	}
 
+	// Force-rebuild our crate: buildkit normalizes source mtimes, so cargo's
+	// fingerprint check can skip a real source change and ship a stale binary.
+	buildCmd := "cargo build --release"
+	if s.packageName != "" {
+		buildCmd = fmt.Sprintf("cargo clean --release -p %s && cargo build --release", s.packageName)
+	}
+
 	state = state.Dir("/app").Run(
 		llb.Args([]string{"/bin/sh", "-c",
-			fmt.Sprintf("cargo build --release && %s", cpCmd)}),
+			fmt.Sprintf("%s && %s", buildCmd, cpCmd)}),
 		h.CacheMount("/usr/local/cargo/registry"),
 		h.CacheMount("/app/target"),
 		llb.WithCustomName("[phase] Building Rust application"),

--- a/pkg/stackbuild/stackbuild_test.go
+++ b/pkg/stackbuild/stackbuild_test.go
@@ -718,6 +718,8 @@ func TestRust(t *testing.T) {
 			dir: dir,
 		},
 	}
+	require.True(t, stack.Detect())
+	stack.Init(BuildOptions{Version: "1"})
 	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "1"})
 	require.NoError(t, err)
 

--- a/pkg/stackbuild/stackbuild_test.go
+++ b/pkg/stackbuild/stackbuild_test.go
@@ -1107,3 +1107,28 @@ func TestRustWebCommand(t *testing.T) {
 
 	require.Equal(t, "/bin/app", stack.WebCommand())
 }
+
+func TestRustBuildCommand(t *testing.T) {
+	t.Run("with package name force-rebuilds workspace crate", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte("[package]\nname = \"my-app\"\nversion = \"0.1.0\"\n"), 0644))
+
+		stack := &RustStack{MetaStack: MetaStack{dir: dir}}
+		require.True(t, stack.Detect())
+		stack.Init(BuildOptions{})
+
+		require.Equal(t, "cargo clean --release -p my-app && cargo build --release", stack.buildCommand())
+	})
+
+	t.Run("virtual workspace falls back to bare cargo build", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte("[workspace]\nmembers = [\"member-a\"]\n"), 0644))
+
+		stack := &RustStack{MetaStack: MetaStack{dir: dir}}
+		require.True(t, stack.Detect())
+		stack.Init(BuildOptions{})
+
+		require.Empty(t, stack.packageName)
+		require.Equal(t, "cargo build --release", stack.buildCommand())
+	})
+}


### PR DESCRIPTION
Source-only changes to a Rust app could silently fail to reach the sandbox. `miren deploy` would succeed, a fresh image would build and push, a new sandbox would start — but the binary inside was whatever got built last time. The tell was a build log line like `Finished release profile in 0.10s` where actual compilation should have been.

Root cause: buildkit normalizes mtimes on the source files it copies into `/app`. Cargo's freshness check for the workspace crate is mtime-based, comparing source mtimes against fingerprints stored in the `/app/target` cache mount (which persists across builds). When a normalized-mtime source file looks "older" than its cached build artifact, cargo happily declares the crate fresh and the `cp` that follows pulls the stale binary out of the cache.

The fix uses cargo's own primitive for exactly this: `cargo clean --release -p <pkg>` forgets the workspace crate's fingerprint and artifacts while leaving the dependency compilation cache untouched. That gives us "always rebuild our crate, keep the cached deps," which is the right tradeoff for a deploy tool — a slightly slower deploy beats a silently stale one.

We also noticed the existing `TestRust` was skipping `Init()` before `GenerateLLB()`, so the test wasn't exercising the path with `packageName` set. Added the missing `Init()` call so CI actually covers the new code path.

Two follow-ons came out of the investigation and are worth flagging: MIR-1028 for virtual workspaces (no top-level `[package]`) which don't work at all in the Rust stack today (pre-existing, unrelated to this fix), and MIR-1029 for an exploratory spike on whether we should migrate the Rust stack to the community-standard cargo-chef pattern, which wouldn't need this workaround at all.

Closes MIR-1027