### PR TITLE
Resolve short IDs for sandbox exec, logs, and deploy cancel

### DIFF
--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -666,7 +666,7 @@ func (d *DeploymentServer) CancelDeployment(ctx context.Context, req *deployment
 
 	deploymentId := args.DeploymentId()
 
-	// Get the deployment by ID
+	// Get the deployment by ID (resolves short IDs via the entity server)
 	deploymentResp, err := d.EAC.Get(ctx, deploymentId)
 	if err != nil {
 		if errors.Is(err, cond.ErrNotFound{}) {
@@ -677,6 +677,9 @@ func (d *DeploymentServer) CancelDeployment(ctx context.Context, req *deployment
 		}
 		return nil
 	}
+
+	// Use the resolved entity ID for all subsequent operations
+	deploymentId = deploymentResp.Entity().Id()
 
 	// Decode to Deployment struct
 	var deployment core_v1alpha.Deployment

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -66,6 +66,16 @@ func (e *EntityServer) Get(ctx context.Context, req *entityserver_v1alpha.Entity
 			if resolvedId, idxErr := etcdStore.GetOneIndex(ctx, entity.String(entity.DBShortId, args.Id())); idxErr == nil {
 				ent, err = e.Store.GetEntity(ctx, resolvedId)
 			}
+			// If that didn't work and the ID has a kind prefix (e.g. "sandbox/3sA"),
+			// strip the prefix and try the bare suffix as a short ID.
+			if err != nil {
+				if idx := strings.LastIndex(args.Id(), "/"); idx >= 0 {
+					bare := args.Id()[idx+1:]
+					if resolvedId, idxErr := etcdStore.GetOneIndex(ctx, entity.String(entity.DBShortId, bare)); idxErr == nil {
+						ent, err = e.Store.GetEntity(ctx, resolvedId)
+					}
+				}
+			}
 		}
 		if err != nil {
 			return cond.NotFound("entity", args.Id())

--- a/servers/exec/exec.go
+++ b/servers/exec/exec.go
@@ -48,6 +48,11 @@ func (s *Server) Exec(ctx context.Context, req *exec_v1alpha.SandboxExecExec) er
 
 	id := args.Value()
 
+	// Resolve short IDs to full entity IDs for the containerd label lookup
+	if resolved, err := s.EAC.Get(ctx, id); err == nil {
+		id = resolved.Entity().Id()
+	}
+
 	containers, err := s.CC.Containers(ctx, `labels."runtime.computer/entity-id"==`+id)
 	if err != nil {
 		return err

--- a/servers/logs/logs.go
+++ b/servers/logs/logs.go
@@ -106,9 +106,14 @@ func (s *Server) SandboxLogs(ctx context.Context, state *app_v1alpha.LogsSandbox
 		opts = append(opts, observability.WithFromTime(fromTime))
 	}
 
-	s.Log.Debug("reading logs", "sandbox", args.Sandbox(), "from", args.From())
+	sandboxID, err := s.resolveSandboxID(ctx, args.Sandbox())
+	if err != nil {
+		return err
+	}
 
-	entries, err := s.LogReader.ReadBySandbox(ctx, args.Sandbox(), opts...)
+	s.Log.Debug("reading logs", "sandbox", sandboxID, "from", args.From())
+
+	entries, err := s.LogReader.ReadBySandbox(ctx, sandboxID, opts...)
 	if err != nil {
 		s.Log.Error("failed to read logs", "sandbox", args.Sandbox(), "err", err)
 		return err
@@ -191,6 +196,16 @@ func (s *Server) StreamLogs(ctx context.Context, state *app_v1alpha.LogsStreamLo
 const defaultChunkSize = 100
 const defaultTailLimit = 100
 
+// resolveSandboxID resolves a sandbox identifier (full entity ID, short ID,
+// or sandbox/-prefixed short ID) to the full sandbox entity ID string.
+func (s *Server) resolveSandboxID(ctx context.Context, sandboxID string) (string, error) {
+	ret, err := s.EC.EAC().Get(ctx, sandboxID)
+	if err != nil {
+		return "", fmt.Errorf("sandbox %q not found: %w", sandboxID, err)
+	}
+	return ret.Entity().Id(), nil
+}
+
 // resolveLogTarget converts an RPC LogTarget into an observability.LogTarget,
 // resolving app names to entity IDs as needed.
 func (s *Server) resolveLogTarget(ctx context.Context, target *app_v1alpha.LogTarget) (observability.LogTarget, error) {
@@ -220,7 +235,11 @@ func (s *Server) resolveLogTarget(ctx context.Context, target *app_v1alpha.LogTa
 	}
 
 	if hasSandbox {
-		logTarget.SandboxID = target.Sandbox()
+		resolved, err := s.resolveSandboxID(ctx, target.Sandbox())
+		if err != nil {
+			return logTarget, err
+		}
+		logTarget.SandboxID = resolved
 		return logTarget, nil
 	}
 

--- a/servers/logs/logs.go
+++ b/servers/logs/logs.go
@@ -201,7 +201,7 @@ const defaultTailLimit = 100
 func (s *Server) resolveSandboxID(ctx context.Context, sandboxID string) (string, error) {
 	ret, err := s.EC.EAC().Get(ctx, sandboxID)
 	if err != nil {
-		return "", fmt.Errorf("sandbox %q not found: %w", sandboxID, err)
+		return "", fmt.Errorf("failed to resolve sandbox %q: %w", sandboxID, err)
 	}
 	return ret.Entity().Id(), nil
 }

--- a/servers/logs/logs_test.go
+++ b/servers/logs/logs_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/observability"
@@ -252,8 +253,12 @@ func TestStreamLogChunks_BySandbox(t *testing.T) {
 	}
 
 	mockServer := createMockVictoriaLogs(t, entries, 0)
-	server, _, cleanup := setupTestServer(t, mockServer)
+	server, ec, cleanup := setupTestServer(t, mockServer)
 	defer cleanup()
+
+	// Create the sandbox entity so resolution succeeds
+	_, err := ec.Create(ctx, "test-sandbox-123", &compute_v1alpha.Sandbox{})
+	r.NoError(err)
 
 	client := &app_v1alpha.LogsClient{
 		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
@@ -272,7 +277,7 @@ func TestStreamLogChunks_BySandbox(t *testing.T) {
 	target := &app_v1alpha.LogTarget{}
 	target.SetSandbox("sandbox/test-sandbox-123")
 
-	_, err := client.StreamLogChunks(ctx, target, nil, false, "", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback)
 	r.NoError(err)
 
 	mu.Lock()


### PR DESCRIPTION
Short IDs (those 3-8 char base58 suffixes we show in most output) weren't resolving in a handful of commands, which made them useless for the exact case they're most useful: typing a short ID you just saw in a log or status message. Worst offender was `deploy cancel`, which reported success but silently no-op'd because the write-back used the original unresolved short ID, leaving the deploy lock stuck until its 30-minute timeout.

First commit teaches `EntityServer.Get`'s short ID fallback to handle kind-prefixed input like `sandbox/3sA`. The index stores bare suffixes, but the CLI often normalizes to a `kind/id` form before sending. That single change also fixes `sandbox-pool set-desired` and any other command that flows through the entity server with a prefixed short ID.

Second commit tackles the three commands called out in the issue. `sandbox exec` and `logs sandbox` never resolved IDs at all and needed explicit resolution added. `deploy cancel` was resolving on read but using the original string for the write; fixed by reassigning from the Get response.

Closes MIR-1002