### PR TITLE
Gate disk reconciliation on the coordinator node

### DIFF
--- a/components/runner/disk_controller_integration_test.go
+++ b/components/runner/disk_controller_integration_test.go
@@ -20,7 +20,7 @@ func TestDiskControllersCanBeCreated(t *testing.T) {
 		log := slog.Default()
 
 		// Create disk controller (entity-only mode)
-		diskController := disk.NewDiskController(log, nil, "test-node", "")
+		diskController := disk.NewDiskController(log, nil, "test-node", "", true)
 		r.NotNil(diskController)
 
 		// Create disk lease controller (entity-only mode)
@@ -40,7 +40,7 @@ func TestDiskControllersCanBeCreated(t *testing.T) {
 		log := slog.Default()
 
 		// Create controllers (entity-only mode)
-		diskController := disk.NewDiskController(log, nil, "test-node", "")
+		diskController := disk.NewDiskController(log, nil, "test-node", "", true)
 		diskLeaseController := disk.NewDiskLeaseController(log, nil, "test-node", "")
 
 		// Verify they can be adapted for the controller manager

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -789,7 +789,7 @@ func (r *Runner) SetupControllers(
 	))
 
 	// Use entity mode controllers
-	diskController := disk.NewDiskController(log, eas, r.Id, r.DiskMode)
+	diskController := disk.NewDiskController(log, eas, r.Id, r.DiskMode, r.deps.IsCoordinator)
 	diskLeaseController := disk.NewDiskLeaseController(log, eas, r.Id, r.DiskMode)
 
 	// Add disk controller to closers list so it gets cleaned up on shutdown

--- a/controllers/disk/disk_controller.go
+++ b/controllers/disk/disk_controller.go
@@ -42,6 +42,14 @@ type DiskController struct {
 	// NodeId is the ID of this node, used for creating volume entities
 	NodeId string
 
+	// isCoordinator is true if this controller runs on the coordinator node.
+	// Today all disks are owned by the coordinator, so only the coordinator
+	// may create, update, or delete disk_volume entities. When cross-node
+	// disk migration lands, shouldManageDisk will gain smarter logic (likely
+	// keyed off a target-node field on the disk entity); every caller
+	// already routes through it.
+	isCoordinator bool
+
 	// Base path for disk mounts (e.g., /var/lib/miren/disks)
 	mountBasePath string
 
@@ -54,15 +62,26 @@ type DiskController struct {
 
 // NewDiskController creates a disk controller that uses disk_volume entities.
 // The diskMode parameter comes from server config (MIREN_DISK_MODE); pass ""
-// for auto-detection.
-func NewDiskController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, nodeId string, diskMode string) *DiskController {
+// for auto-detection. isCoordinator must be true on the primary node and
+// false on distributed runners.
+func NewDiskController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, nodeId string, diskMode string, isCoordinator bool) *DiskController {
 	return &DiskController{
 		Log:            log.With("module", "disk"),
 		EAC:            eac,
 		NodeId:         nodeId,
+		isCoordinator:  isCoordinator,
 		mountBasePath:  "/var/lib/miren/disks",
 		configuredMode: diskMode,
 	}
+}
+
+// shouldManageDisk reports whether this controller is responsible for
+// reconciling the given disk's disk_volume lifecycle. Currently this is
+// coordinator-only; when cross-node migration lands, this will look at
+// the disk's target node.
+func (d *DiskController) shouldManageDisk(disk *storage_v1alpha.Disk) bool {
+	_ = disk
+	return d.isCoordinator
 }
 
 // ForceUniversalMode forces the controller to use disk_volume entities with
@@ -105,6 +124,10 @@ func (d *DiskController) Delete(ctx context.Context, id entity.Id, obj *storage_
 
 // reconcileDisk reconciles the disk state
 func (d *DiskController) reconcileDisk(ctx context.Context, disk *storage_v1alpha.Disk, meta *entity.Meta) error {
+	if !d.shouldManageDisk(disk) {
+		return nil
+	}
+
 	var err error
 
 	switch disk.Status {
@@ -155,18 +178,22 @@ func (d *DiskController) handleProvisioning(ctx context.Context, disk *storage_v
 		return fmt.Errorf("error looking up existing disk_volume for disk %s: %w", disk.ID, err)
 	}
 
-	if existingVolume != nil {
-		// If the volume belongs to a different node, don't touch it
-		myNodeId := entity.Id("node/" + strings.TrimPrefix(d.NodeId, "node/"))
-		if existingVolume.NodeId != "" && existingVolume.NodeId != myNodeId {
-			d.Log.Debug("disk_volume belongs to another node, skipping",
-				"disk", disk.ID,
-				"disk_volume", existingVolume.ID,
-				"volume_node", existingVolume.NodeId,
-				"my_node", myNodeId)
-			return nil
-		}
+	myNodeId := entity.Id("node/" + strings.TrimPrefix(d.NodeId, "node/"))
 
+	if existingVolume != nil && existingVolume.NodeId != "" && existingVolume.NodeId != myNodeId {
+		// Orphan from a runner that created a volume it shouldn't have. Log
+		// and fall through to create our own native volume; the orphan is
+		// harmless here and will be cleaned up via DELETING (or left to the
+		// future migration-aware controller).
+		d.Log.Warn("ignoring foreign disk_volume for coordinator-owned disk",
+			"disk", disk.ID,
+			"disk_volume", existingVolume.ID,
+			"volume_node", existingVolume.NodeId,
+			"my_node", myNodeId)
+		existingVolume = nil
+	}
+
+	if existingVolume != nil {
 		d.Log.Debug("found existing disk_volume for disk",
 			"disk", disk.ID,
 			"disk_volume", existingVolume.ID,
@@ -210,7 +237,7 @@ func (d *DiskController) handleProvisioning(ctx context.Context, disk *storage_v
 		VolumeMode:   diskModeToVolumeMode(d.diskMode),
 		DesiredState: storage_v1alpha.DV_PRESENT,
 		ActualState:  storage_v1alpha.DV_PENDING,
-		NodeId:       entity.Id("node/" + strings.TrimPrefix(d.NodeId, "node/")),
+		NodeId:       myNodeId,
 	}
 
 	// When migrating from LSVD, set MountId to the LSVD volume UUID so the
@@ -365,7 +392,11 @@ func (d *DiskController) findLSVDVolumeId(ctx context.Context, diskId entity.Id)
 	return lsvdVol.VolumeId
 }
 
-// getDiskVolumeForDisk finds the disk_volume entity for a disk
+// getDiskVolumeForDisk finds the disk_volume entity for a disk. When more
+// than one exists (e.g. an orphan left behind by a past violation of the
+// primary-only invariant, or — in the future — a volume belonging to a
+// migration peer), prefer the one owned by this controller's node so the
+// controller reconciles its own volume and ignores foreign ones.
 func (d *DiskController) getDiskVolumeForDisk(ctx context.Context, diskId entity.Id) (*storage_v1alpha.DiskVolume, error) {
 	if d.EAC == nil {
 		return nil, nil
@@ -383,10 +414,24 @@ func (d *DiskController) getDiskVolumeForDisk(ctx context.Context, diskId entity
 		return nil, nil
 	}
 
-	var volume storage_v1alpha.DiskVolume
-	volume.Decode(values[0].Entity())
+	myNodeId := entity.Id("node/" + strings.TrimPrefix(d.NodeId, "node/"))
 
-	return &volume, nil
+	var chosen *storage_v1alpha.DiskVolume
+	for _, v := range values {
+		var volume storage_v1alpha.DiskVolume
+		volume.Decode(v.Entity())
+
+		if volume.NodeId == myNodeId {
+			return &volume, nil
+		}
+
+		if chosen == nil {
+			vol := volume
+			chosen = &vol
+		}
+	}
+
+	return chosen, nil
 }
 
 func diskModeToVolumeMode(mode storage_v1alpha.DiskMode) storage_v1alpha.DiskVolumeVolumeMode {

--- a/controllers/disk/disk_controller.go
+++ b/controllers/disk/disk_controller.go
@@ -84,6 +84,13 @@ func (d *DiskController) shouldManageDisk(disk *storage_v1alpha.Disk) bool {
 	return d.isCoordinator
 }
 
+// myNodeId returns the entity ID used for disk_volumes owned by this
+// controller's node, normalized so the "node/" prefix is always present
+// exactly once regardless of how NodeId was passed in.
+func (d *DiskController) myNodeId() entity.Id {
+	return entity.Id("node/" + strings.TrimPrefix(d.NodeId, "node/"))
+}
+
 // ForceUniversalMode forces the controller to use disk_volume entities with
 // loop devices. This is used by integration tests.
 func (d *DiskController) ForceUniversalMode() {
@@ -178,7 +185,7 @@ func (d *DiskController) handleProvisioning(ctx context.Context, disk *storage_v
 		return fmt.Errorf("error looking up existing disk_volume for disk %s: %w", disk.ID, err)
 	}
 
-	myNodeId := entity.Id("node/" + strings.TrimPrefix(d.NodeId, "node/"))
+	myNodeId := d.myNodeId()
 
 	if existingVolume != nil && existingVolume.NodeId != "" && existingVolume.NodeId != myNodeId {
 		// Orphan from a runner that created a volume it shouldn't have. Log
@@ -414,7 +421,7 @@ func (d *DiskController) getDiskVolumeForDisk(ctx context.Context, diskId entity
 		return nil, nil
 	}
 
-	myNodeId := entity.Id("node/" + strings.TrimPrefix(d.NodeId, "node/"))
+	myNodeId := d.myNodeId()
 
 	var chosen *storage_v1alpha.DiskVolume
 	for _, v := range values {

--- a/controllers/disk/disk_controller_coordinator_test.go
+++ b/controllers/disk/disk_controller_coordinator_test.go
@@ -1,0 +1,190 @@
+package disk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+// TestDiskController_NonCoordinator_NoVolumeCreated is the MIR-1030 repro:
+// a DiskController running on a non-coordinator (distributed runner) node
+// must not create a disk_volume entity when it observes a provisioning
+// disk. Disks are coordinator-only today.
+func TestDiskController_NonCoordinator_NoVolumeCreated(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	dc := NewDiskController(log, es.EAC, "runner-uuid", "", false)
+	dc.ForceUniversalMode()
+
+	disk := &storage_v1alpha.Disk{
+		ID:         "disk/provisioning-disk",
+		Name:       "data",
+		SizeGb:     10,
+		Filesystem: storage_v1alpha.EXT4,
+		Status:     storage_v1alpha.PROVISIONING,
+	}
+
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, disk.ID,
+		disk.Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	meta := &entity.Meta{}
+	err = dc.Create(ctx, disk, meta)
+	require.NoError(t, err)
+
+	volume, err := dc.getDiskVolumeForDisk(ctx, disk.ID)
+	require.NoError(t, err)
+	assert.Nil(t, volume, "non-coordinator runner must not create a disk_volume")
+
+	assert.Equal(t, storage_v1alpha.PROVISIONING, disk.Status, "non-coordinator runner must not mutate disk status")
+}
+
+// TestDiskController_PrefersOwnVolume is the secondary MIR-1030 fix: when
+// an orphaned foreign disk_volume exists alongside the controller's own
+// disk_volume, getDiskVolumeForDisk must return the native one so
+// handleProvisioning can finalize the disk regardless of the orphan.
+func TestDiskController_PrefersOwnVolume(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	dc := NewDiskController(log, es.EAC, "miren", "", true)
+	dc.ForceUniversalMode()
+
+	disk := &storage_v1alpha.Disk{
+		ID:         "disk/with-orphan",
+		Name:       "data",
+		SizeGb:     10,
+		Filesystem: storage_v1alpha.EXT4,
+		Status:     storage_v1alpha.PROVISIONING,
+	}
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, disk.ID,
+		disk.Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	// Orphan volume from a misbehaving runner (the MIR-1030 bug state).
+	foreign := &storage_v1alpha.DiskVolume{
+		Name:         "data",
+		DiskId:       disk.ID,
+		SizeGb:       10,
+		Filesystem:   "ext4",
+		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
+		DesiredState: storage_v1alpha.DV_PRESENT,
+		ActualState:  storage_v1alpha.DV_PENDING,
+		NodeId:       entity.Id("node/runner-uuid"),
+	}
+	_, err = es.EAC.Create(ctx, entity.New(
+		entity.DBId, entity.Id("disk_volume/foreign"),
+		foreign.Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	// Native volume, already ready — should win on selection.
+	native := &storage_v1alpha.DiskVolume{
+		Name:         "data",
+		DiskId:       disk.ID,
+		SizeGb:       10,
+		Filesystem:   "ext4",
+		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
+		DesiredState: storage_v1alpha.DV_PRESENT,
+		ActualState:  storage_v1alpha.DV_READY,
+		VolumeId:     "native-vol-id",
+		NodeId:       entity.Id("node/miren"),
+	}
+	_, err = es.EAC.Create(ctx, entity.New(
+		entity.DBId, entity.Id("disk_volume/native"),
+		native.Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	volume, err := dc.getDiskVolumeForDisk(ctx, disk.ID)
+	require.NoError(t, err)
+	require.NotNil(t, volume)
+	assert.Equal(t, entity.Id("disk_volume/native"), volume.ID, "should prefer the native volume over the orphan")
+
+	meta := &entity.Meta{}
+	err = dc.Create(ctx, disk, meta)
+	require.NoError(t, err)
+
+	assert.Equal(t, storage_v1alpha.PROVISIONED, disk.Status, "disk should reach PROVISIONED via the native volume despite the orphan")
+	assert.Equal(t, "native-vol-id", disk.VolumeId)
+}
+
+// TestDiskController_OnlyOrphan_StillCreatesNative guards against the
+// deadlock described in MIR-1030: if an orphan foreign disk_volume
+// exists without a native one, the coordinator must still create its
+// own native volume rather than skip.
+func TestDiskController_OnlyOrphan_StillCreatesNative(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	dc := NewDiskController(log, es.EAC, "miren", "", true)
+	dc.ForceUniversalMode()
+
+	disk := &storage_v1alpha.Disk{
+		ID:         "disk/orphan-only",
+		Name:       "data",
+		SizeGb:     10,
+		Filesystem: storage_v1alpha.EXT4,
+		Status:     storage_v1alpha.PROVISIONING,
+	}
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, disk.ID,
+		disk.Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	foreign := &storage_v1alpha.DiskVolume{
+		Name:         "data",
+		DiskId:       disk.ID,
+		SizeGb:       10,
+		Filesystem:   "ext4",
+		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
+		DesiredState: storage_v1alpha.DV_PRESENT,
+		ActualState:  storage_v1alpha.DV_READY,
+		NodeId:       entity.Id("node/runner-uuid"),
+	}
+	_, err = es.EAC.Create(ctx, entity.New(
+		entity.DBId, entity.Id("disk_volume/foreign-only"),
+		foreign.Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	meta := &entity.Meta{}
+	err = dc.Create(ctx, disk, meta)
+	require.NoError(t, err)
+
+	// Native volume should now exist, owned by the coordinator.
+	indexAttr := entity.Ref(storage_v1alpha.DiskVolumeDiskIdId, disk.ID)
+	resp, err := es.EAC.List(ctx, indexAttr)
+	require.NoError(t, err)
+	values := resp.Values()
+	require.Len(t, values, 2, "both the orphan and a new native volume should exist")
+
+	var sawNative bool
+	for _, v := range values {
+		var vol storage_v1alpha.DiskVolume
+		vol.Decode(v.Entity())
+		if vol.NodeId == entity.Id("node/miren") {
+			sawNative = true
+		}
+	}
+	assert.True(t, sawNative, "coordinator must have created a native disk_volume alongside the orphan")
+}

--- a/controllers/disk/disk_controller_test.go
+++ b/controllers/disk/disk_controller_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestDiskController_New(t *testing.T) {
 	log := slog.Default()
-	controller := NewDiskController(log, nil, "test-node", "")
+	controller := NewDiskController(log, nil, "test-node", "", true)
 
 	assert.NotNil(t, controller)
 	assert.NotNil(t, controller.Log)

--- a/controllers/disk/integration_test.go
+++ b/controllers/disk/integration_test.go
@@ -96,7 +96,7 @@ func TestDiskControllerUpgradeLSVDToUniversal(t *testing.T) {
 		es, cleanup := testutils.NewInMemEntityServer(t)
 		defer cleanup()
 
-		dc := NewDiskController(log, es.EAC, "test-node-1", "")
+		dc := NewDiskController(log, es.EAC, "test-node-1", "", true)
 		dc.ForceUniversalMode()
 
 		// Create a disk entity that looks like it was provisioned under the old LSVD system:
@@ -145,7 +145,7 @@ func TestDiskControllerUpgradeLSVDToUniversal(t *testing.T) {
 		es, cleanup := testutils.NewInMemEntityServer(t)
 		defer cleanup()
 
-		dc := NewDiskController(log, es.EAC, "test-node-1", "")
+		dc := NewDiskController(log, es.EAC, "test-node-1", "", true)
 		dc.ForceUniversalMode()
 
 		// Disk has a VolumeId (from old system) but no corresponding disk_volume entity
@@ -185,7 +185,7 @@ func TestDiskControllerUpgradeLSVDToUniversal(t *testing.T) {
 		es, cleanup := testutils.NewInMemEntityServer(t)
 		defer cleanup()
 
-		dc := NewDiskController(log, es.EAC, "test-node-1", "")
+		dc := NewDiskController(log, es.EAC, "test-node-1", "", true)
 		dc.ForceUniversalMode()
 
 		disk := &storage_v1alpha.Disk{

--- a/controllers/disk/sandbox_integration_test.go
+++ b/controllers/disk/sandbox_integration_test.go
@@ -96,7 +96,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 		t.Cleanup(cleanup)
 
 		// Create controllers with real EAC and universal mode
-		diskController := NewDiskController(log, es.EAC, "test-node", "")
+		diskController := NewDiskController(log, es.EAC, "test-node", "", true)
 		diskController.ForceUniversalMode()
 		leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
 		leaseController.ForceUniversalMode()
@@ -267,7 +267,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 		es, cleanup := testutils.NewInMemEntityServer(t)
 		t.Cleanup(cleanup)
 
-		diskController := NewDiskController(log, es.EAC, "test-node", "")
+		diskController := NewDiskController(log, es.EAC, "test-node", "", true)
 		diskController.ForceUniversalMode()
 		leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
 		leaseController.ForceUniversalMode()

--- a/controllers/integration/harness.go
+++ b/controllers/integration/harness.go
@@ -76,7 +76,7 @@ func NewTestHarness(t *testing.T) *TestHarness {
 	diskMntCtrl.SetEAC(eac)
 
 	// Create disk controllers using universal mode
-	diskCtrl := disk.NewDiskController(log, eac, testNodeId, "")
+	diskCtrl := disk.NewDiskController(log, eac, testNodeId, "", true)
 	diskCtrl.Init(ctx) //nolint:errcheck
 	diskCtrl.ForceUniversalMode()
 	diskLeaseCtrl := disk.NewDiskLeaseController(log, eac, testNodeId, "")


### PR DESCRIPTION
Observed on `toys` during the rust-chat booth deploy (MIR-1022 work): four consecutive addon sandboxes died at "creating disk lease," the addon never came up, and the app served 500s. Root cause was that a `disk_volume` entity had been created on one of the distributed runner nodes, which violates the invariant that disks live only on the primary today. The parent disk stayed stuck at `provisioning` forever because the primary's reconciler kept seeing the foreign volume, correctly refusing to touch it, and then (less correctly) returning early instead of finalizing its own.

The fix adds a `shouldManageDisk` gate on the `DiskController` that today is just `IsCoordinator`. Wiring it as a helper rather than inlining the check gives us a clear extension point for when cross-node disk migration lands — that logic will likely key off a target-node field on the disk entity, and every caller already routes through one function. Distributed runners now return early from `reconcileDisk` entirely, so they can't accidentally manufacture foreign volumes again.

Took the opportunity to harden the coordinator's own path too: `getDiskVolumeForDisk` now prefers a volume it owns when multiples exist (instead of grabbing `values[0]` and hoping), and `handleProvisioning` treats any lingering orphan as noise rather than a reason to bail, so clusters that already have orphaned volumes from the bug will self-heal on the next reconcile.

Closes MIR-1030