### PR TITLE
Fix valkey sandbox starting without --requirepass

### DIFF
--- a/blackbox/addon_valkey_test.go
+++ b/blackbox/addon_valkey_test.go
@@ -1,0 +1,65 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+func TestValkeyAddonDeployWithAppToml(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.UniqueAppName(t, "bun-valkey")
+
+	hostDir := filepath.Join(c.TestdataDir, "bun-valkey")
+	containerDir := m.ContainerPath(hostDir)
+
+	t.Cleanup(func() {
+		t.Logf("cleaning up app %s", name)
+		m.Run("app", "delete", name, "-f")
+	})
+
+	// Deploy without waiting for healthy — the app depends on VALKEY_URL
+	// which is only injected after addon provisioning completes.
+	m.MustRun("deploy", "-a", name, "-d", containerDir, "-f")
+
+	// Wait for addon provisioning to complete.
+	harness.WaitForAddonReady(t, m, name, "miren-valkey", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "VALKEY_URL", 5*time.Minute)
+
+	// Now wait for the app to become healthy
+	harness.WaitForAppReady(t, m, name, 3*time.Minute)
+
+	// Verify addon is listed
+	r := m.MustRun("addon", "list", "-a", name, "--format", "json")
+	r.RequireContains(t, "miren-valkey")
+
+	// Set a route and verify the app responds with valkey connectivity
+	host := name + ".test.local"
+	m.MustRun("route", "set", host, name)
+
+	harness.Poll(t, "app responds via route", 30*time.Second, 2*time.Second, func() (bool, string) {
+		code, body, err := harness.HTTPGet(m, host, "/health")
+		if err != nil {
+			return false, err.Error()
+		}
+		if code != 200 {
+			return false, "status " + body
+		}
+		return true, ""
+	})
+
+	// Verify the root endpoint works (exercises valkey AUTH + INCR)
+	code, body, err := harness.HTTPGet(m, host, "/")
+	if err != nil {
+		t.Fatalf("HTTP GET / failed: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected status 200, got %d: %s", code, body)
+	}
+}

--- a/pkg/addon/valkey/dedicated.go
+++ b/pkg/addon/valkey/dedicated.go
@@ -125,8 +125,7 @@ func CreateDedicatedPool(ctx context.Context, in CreateDedicatedPoolIn) (CreateD
 	poolID, err := fw.CreateSandboxPool(ctx, addon.CreateSandboxPoolSpec{
 		Name:             in.ServerName,
 		Image:            image,
-		Command:          "valkey-server --save 60 1",
-		Env:              []string{fmt.Sprintf("VALKEY_EXTRA_FLAGS=--requirepass %s", in.Password)},
+		Command:          fmt.Sprintf("valkey-server --save 60 1 --requirepass %s", in.Password),
 		Ports:            valkeyContainerPorts(),
 		DesiredInstances: 1,
 		Labels:           labels,

--- a/testdata/bun-valkey/.miren/app.toml
+++ b/testdata/bun-valkey/.miren/app.toml
@@ -1,0 +1,7 @@
+name = "bun-valkey"
+
+[services.web]
+command = "bun run index.ts"
+
+[addons.miren-valkey]
+variant = "small"

--- a/testdata/bun-valkey/index.ts
+++ b/testdata/bun-valkey/index.ts
@@ -1,0 +1,132 @@
+import { connect, Socket } from "net";
+
+const url = new URL(process.env.VALKEY_URL!);
+const host = url.hostname;
+const port = Number(url.port || 6379);
+const password = decodeURIComponent(url.password || "");
+
+function encodeCommand(args: string[]): string {
+  let out = `*${args.length}\r\n`;
+  for (const a of args) {
+    out += `$${Buffer.byteLength(a)}\r\n${a}\r\n`;
+  }
+  return out;
+}
+
+// Parse a single RESP reply starting at offset `i` in `buf`.
+// Returns [value, newOffset] or throws if more data is needed or on protocol error.
+// Value types: string (simple or bulk), number (integer), null (nil bulk), Error (error reply).
+function parseReply(buf: string, i: number): [string | number | null | Error, number] {
+  if (i >= buf.length) throw new Error("incomplete");
+  const type = buf[i];
+  const lineEnd = buf.indexOf("\r\n", i + 1);
+  if (lineEnd < 0) throw new Error("incomplete");
+  const head = buf.slice(i + 1, lineEnd);
+  if (type === "+") return [head, lineEnd + 2];
+  if (type === "-") return [new Error(head), lineEnd + 2];
+  if (type === ":") return [Number(head), lineEnd + 2];
+  if (type === "$") {
+    const len = Number(head);
+    if (len === -1) return [null, lineEnd + 2];
+    const dataEnd = lineEnd + 2 + len;
+    if (buf.length < dataEnd + 2) throw new Error("incomplete");
+    return [buf.slice(lineEnd + 2, dataEnd), dataEnd + 2];
+  }
+  throw new Error(`unsupported reply type: ${type}`);
+}
+
+class ValkeyClient {
+  private sock: Socket;
+  private buf = "";
+  private pending: Array<(v: string | number | null | Error) => void> = [];
+
+  constructor(sock: Socket) {
+    this.sock = sock;
+    sock.on("data", (chunk) => {
+      this.buf += chunk.toString("binary");
+      this.drain();
+    });
+  }
+
+  private drain() {
+    while (this.pending.length > 0) {
+      try {
+        const [value, next] = parseReply(this.buf, 0);
+        this.buf = this.buf.slice(next);
+        this.pending.shift()!(value);
+      } catch {
+        return; // wait for more bytes
+      }
+    }
+  }
+
+  send(args: string[]): Promise<string | number | null> {
+    return new Promise((resolve, reject) => {
+      this.pending.push((v) => (v instanceof Error ? reject(v) : resolve(v)));
+      this.sock.write(encodeCommand(args));
+    });
+  }
+
+  close() {
+    this.sock.end();
+  }
+}
+
+function dial(): Promise<ValkeyClient> {
+  return new Promise((resolve, reject) => {
+    const sock = connect(port, host);
+    sock.setTimeout(5000, () => {
+      sock.destroy();
+      reject(new Error("valkey connect timeout"));
+    });
+    sock.once("error", reject);
+    sock.once("connect", async () => {
+      const client = new ValkeyClient(sock);
+      try {
+        if (password) await client.send(["AUTH", password]);
+        resolve(client);
+      } catch (e) {
+        sock.destroy();
+        reject(e);
+      }
+    });
+  });
+}
+
+const server = Bun.serve({
+  port: process.env.PORT || 3000,
+
+  async fetch(req) {
+    const u = new URL(req.url);
+
+    if (u.pathname === "/") {
+      const client = await dial();
+      try {
+        const count = await client.send(["INCR", "visits"]);
+        return new Response(`Hello! Visit count: ${count}\n`);
+      } finally {
+        client.close();
+      }
+    }
+
+    if (u.pathname === "/health") {
+      try {
+        const client = await dial();
+        try {
+          await client.send(["SET", "healthcheck", "ok"]);
+          const val = await client.send(["GET", "healthcheck"]);
+          if (val === "ok") return new Response("ok\n");
+          return new Response(`valkey read mismatch: ${val}\n`, { status: 503 });
+        } finally {
+          client.close();
+        }
+      } catch (e) {
+        return new Response(`valkey unavailable: ${e}\n`, { status: 503 });
+      }
+    }
+
+    return new Response("not found\n", { status: 404 });
+  },
+});
+
+console.log(`Listening on http://localhost:${server.port}`);

--- a/testdata/bun-valkey/package.json
+++ b/testdata/bun-valkey/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bun-valkey-example",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "bun run index.ts"
+  }
+}


### PR DESCRIPTION
The Valkey addon looked fine on paper: apps got `REDIS_URL=redis://:pwXYZ@host:6379`, `VALKEY_PASSWORD`, and friends injected into their environment. Meanwhile the valkey sandbox got `VALKEY_EXTRA_FLAGS=--requirepass pwXYZ` in its env and `valkey-server --save 60 1` as its command. What nobody noticed: nothing ever expanded the env var into argv. Sandbox `Command` bypasses the image's entrypoint, and there's no shell in between. So valkey-server started with no password configured, while every app client faithfully tried to AUTH using the password in its URL and got `ERR AUTH <password> called without any password configured`. No valkey addon user could actually connect.

The fix is a two-line change: interpolate the password directly into the command at provision time and drop the dead env var. This follows the pattern memcache already uses for runtime secrets in argv.

The more interesting half of this PR is the test that would have caught this. The old blackbox suite had a valkey test, but it only asserted that `VALKEY_URL`, `VALKEY_HOST`, etc. got injected into the app environment — "did we plumb the strings through," not "does the datastore actually work." Compare against the postgres/memcache/rabbitmq addon tests, which all deploy a small app that round-trips through the service via an HTTP route. Valkey never got that treatment, which is how this bug shipped.

So alongside the fix, this adds `testdata/bun-valkey/` with a tiny inline RESP client (no npm deps, matches the bun-memcache minimalism) and `TestValkeyAddonDeployWithAppToml` that deploys it, sets a route, and hits `/health` (AUTHed SET+GET round-trip) and `/` (AUTH then INCR). The test fails against the old code with the exact error from the Linear issue, and passes against the fix in about 26 seconds.

Closes MIR-1035