### PR TITLE
Switch tarx to go-git's gitignore matcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/flannel-io/flannel v0.26.7
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/go-acme/lego/v4 v4.28.1
+	github.com/go-git/go-git/v5 v5.18.0
 	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-logr/logr v1.4.3
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
@@ -83,7 +84,6 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/quic-go/quic-go v0.57.1
 	github.com/quic-go/webtransport-go v0.9.0
-	github.com/shibumi/go-pathspec v1.3.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.11.1
@@ -132,6 +132,11 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
+	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
+	github.com/go-git/go-billy/v5 v5.8.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/shibumi/go-pathspec v1.3.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
 require (
@@ -247,7 +252,7 @@ require (
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,12 @@ github.com/go-acme/tencentedgdeone v1.1.48/go.mod h1:mu6tA+bPhlSd+CKUfzRikE0mfxm
 github.com/go-cmd/cmd v1.0.5/go.mod h1:y8q8qlK5wQibcw63djSl/ntiHUHXHGdCkPk0j4QeW4s=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
+github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
+github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDzZG0=
+github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
+github.com/go-git/go-git/v5 v5.18.0 h1:O831KI+0PR51hM2kep6T8k+w0/LIAD490gvqMCvL5hM=
+github.com/go-git/go-git/v5 v5.18.0/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -535,8 +541,9 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
@@ -733,6 +740,8 @@ github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFr
 github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
 github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
@@ -1903,6 +1912,7 @@ gopkg.in/ns1/ns1-go.v2 v2.15.1/go.mod h1:pfaU0vECVP7DIOr453z03HXS6dFJpXdNRwOyRzw
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -26,12 +26,17 @@ type FileManifest struct {
 }
 
 // parseGitignoreFile reads a .gitignore file and returns its parsed patterns
-// scoped to the given domain (path components from the walk root). Returns
-// nil if the file doesn't exist or is empty.
-func parseGitignoreFile(path string, domain []string) []gitignore.Pattern {
+// scoped to the given domain (path components from the walk root). A missing
+// file is not an error and returns (nil, nil); other read failures (e.g.
+// permission denied) propagate up so we don't silently treat them as "no
+// patterns" and ship a tar that should have been filtered.
+func parseGitignoreFile(path string, domain []string) ([]gitignore.Pattern, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 	var patterns []gitignore.Pattern
 	for line := range strings.SplitSeq(string(data), "\n") {
@@ -41,7 +46,7 @@ func parseGitignoreFile(path string, domain []string) []gitignore.Pattern {
 		}
 		patterns = append(patterns, gitignore.ParsePattern(line, domain))
 	}
-	return patterns
+	return patterns, nil
 }
 
 // parseStringPatterns parses a list of raw gitignore-style pattern strings
@@ -119,13 +124,16 @@ func TarToMap(r io.Reader) (map[string][]byte, error) {
 // ComputeManifest walks a directory using the same gitignore/include logic as MakeTar
 // and returns a manifest of all regular files with their SHA-256 hashes.
 func ComputeManifest(dir string, includePatterns []string) ([]FileManifest, error) {
-	ignorePatterns := parseGitignoreFile(filepath.Join(dir, ".gitignore"), nil)
+	ignorePatterns, err := parseGitignoreFile(filepath.Join(dir, ".gitignore"), nil)
+	if err != nil {
+		return nil, err
+	}
 	ignorePatterns = append(ignorePatterns, gitignore.ParsePattern(".git", nil))
 	includes := parseStringPatterns(includePatterns)
 
 	var manifest []FileManifest
 
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -155,7 +163,11 @@ func ComputeManifest(dir string, includePatterns []string) ([]FileManifest, erro
 
 		if info.IsDir() {
 			nestedGitignore := filepath.Join(path, ".gitignore")
-			if more := parseGitignoreFile(nestedGitignore, segs); more != nil {
+			more, err := parseGitignoreFile(nestedGitignore, segs)
+			if err != nil {
+				return err
+			}
+			if more != nil {
 				ignorePatterns = append(ignorePatterns, more...)
 			}
 			return nil
@@ -230,7 +242,11 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 	gzw := gzip.NewWriter(w)
 	tw := tar.NewWriter(gzw)
 
-	ignorePatterns := parseGitignoreFile(filepath.Join(dir, ".gitignore"), nil)
+	ignorePatterns, err := parseGitignoreFile(filepath.Join(dir, ".gitignore"), nil)
+	if err != nil {
+		w.Close()
+		return nil, err
+	}
 	ignorePatterns = append(ignorePatterns, gitignore.ParsePattern(".git", nil))
 	includes := parseStringPatterns(includePatterns)
 
@@ -271,7 +287,11 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 
 			if info.IsDir() {
 				nestedGitignore := filepath.Join(path, ".gitignore")
-				if more := parseGitignoreFile(nestedGitignore, segs); more != nil {
+				more, err := parseGitignoreFile(nestedGitignore, segs)
+				if err != nil {
+					return err
+				}
+				if more != nil {
 					ignorePatterns = append(ignorePatterns, more...)
 				}
 				return nil

--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/shibumi/go-pathspec"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/tonistiigi/fsutil"
 )
 
@@ -25,66 +25,56 @@ type FileManifest struct {
 	Mode int32
 }
 
-// parseGitignore reads a .gitignore file and returns its patterns.
-// Returns nil if the file doesn't exist or can't be read.
-func parseGitignore(path string) []string {
+// parseGitignoreFile reads a .gitignore file and returns its parsed patterns
+// scoped to the given domain (path components from the walk root). Returns
+// nil if the file doesn't exist or is empty.
+func parseGitignoreFile(path string, domain []string) []gitignore.Pattern {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
 	}
-	var patterns []string
-	for _, line := range strings.Split(string(data), "\n") {
+	var patterns []gitignore.Pattern
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
-		if line != "" && !strings.HasPrefix(line, "#") {
-			patterns = append(patterns, line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
 		}
+		patterns = append(patterns, gitignore.ParsePattern(line, domain))
 	}
 	return patterns
 }
 
-// isGitignored checks whether a relative path is matched by any applicable
-// gitignore in the map. The map is keyed by directory relative path ("." for
-// root). Only gitignores whose directory is a parent of rp are consulted.
-func isGitignored(rp string, isDir bool, gitignoreMap map[string][]string) (bool, error) {
-	for dir, patterns := range gitignoreMap {
-		if len(patterns) == 0 {
-			continue
-		}
-		// Check that rp is within this gitignore's subtree
-		if dir != "." {
-			if !strings.HasPrefix(rp, dir+"/") {
-				continue
-			}
-		}
-		// Compute the path relative to the gitignore's directory
-		relPath := rp
-		if dir != "." {
-			relPath = strings.TrimPrefix(rp, dir+"/")
-		}
-		paths := []string{relPath}
-		if isDir {
-			paths = append(paths, relPath+"/")
-		}
-		for _, checkPath := range paths {
-			ignore, err := pathspec.GitIgnore(patterns, checkPath)
-			if err != nil {
-				return false, fmt.Errorf("invalid gitignore pattern: %w", err)
-			}
-			if ignore {
-				return true, nil
-			}
-		}
+// parseStringPatterns parses a list of raw gitignore-style pattern strings
+// (e.g. user-supplied --include patterns) into gitignore.Patterns rooted at
+// the walk root.
+func parseStringPatterns(rawPatterns []string) []gitignore.Pattern {
+	if len(rawPatterns) == 0 {
+		return nil
 	}
-	return false, nil
+	patterns := make([]gitignore.Pattern, 0, len(rawPatterns))
+	for _, p := range rawPatterns {
+		patterns = append(patterns, gitignore.ParsePattern(p, nil))
+	}
+	return patterns
 }
 
-// ValidatePattern checks if a pattern is valid for use with pathspec.GitIgnore
-func ValidatePattern(pattern string) error {
-	// Test the pattern with a dummy path to ensure it's valid
-	_, err := pathspec.GitIgnore([]string{pattern}, "test")
-	if err != nil {
-		return fmt.Errorf("invalid pattern syntax: %w", err)
+// pathSegments converts an OS-relative path into the []string component form
+// that gitignore.Matcher expects.
+func pathSegments(rp string) []string {
+	rp = filepath.ToSlash(rp)
+	if rp == "" || rp == "." {
+		return nil
 	}
+	return strings.Split(rp, "/")
+}
+
+// ValidatePattern checks that a user-supplied gitignore-style pattern parses
+// successfully.
+func ValidatePattern(pattern string) error {
+	if strings.TrimSpace(pattern) == "" {
+		return fmt.Errorf("invalid pattern syntax: empty pattern")
+	}
+	gitignore.ParsePattern(pattern, nil)
 	return nil
 }
 
@@ -129,10 +119,9 @@ func TarToMap(r io.Reader) (map[string][]byte, error) {
 // ComputeManifest walks a directory using the same gitignore/include logic as MakeTar
 // and returns a manifest of all regular files with their SHA-256 hashes.
 func ComputeManifest(dir string, includePatterns []string) ([]FileManifest, error) {
-	gitignoreMap := make(map[string][]string)
-	rootPatterns := parseGitignore(filepath.Join(dir, ".gitignore"))
-	rootPatterns = append(rootPatterns, ".git")
-	gitignoreMap["."] = rootPatterns
+	ignorePatterns := parseGitignoreFile(filepath.Join(dir, ".gitignore"), nil)
+	ignorePatterns = append(ignorePatterns, gitignore.ParsePattern(".git", nil))
+	includes := parseStringPatterns(includePatterns)
 
 	var manifest []FileManifest
 
@@ -151,30 +140,12 @@ func ComputeManifest(dir string, includePatterns []string) ([]FileManifest, erro
 			return nil
 		}
 
-		isIncluded := false
-		if len(includePatterns) > 0 {
-			paths := []string{rp}
-			if info.IsDir() {
-				paths = append(paths, rp+"/")
-			}
-			for _, checkPath := range paths {
-				match, matchErr := pathspec.GitIgnore(includePatterns, checkPath)
-				if matchErr != nil {
-					return fmt.Errorf("invalid include pattern: %w", matchErr)
-				}
-				if match {
-					isIncluded = true
-					break
-				}
-			}
-		}
+		segs := pathSegments(rp)
+
+		isIncluded := len(includes) > 0 && gitignore.NewMatcher(includes).Match(segs, info.IsDir())
 
 		if !isIncluded {
-			ignored, ignoreErr := isGitignored(rp, info.IsDir(), gitignoreMap)
-			if ignoreErr != nil {
-				return ignoreErr
-			}
-			if ignored {
+			if gitignore.NewMatcher(ignorePatterns).Match(segs, info.IsDir()) {
 				if info.IsDir() {
 					return filepath.SkipDir
 				}
@@ -184,8 +155,8 @@ func ComputeManifest(dir string, includePatterns []string) ([]FileManifest, erro
 
 		if info.IsDir() {
 			nestedGitignore := filepath.Join(path, ".gitignore")
-			if patterns := parseGitignore(nestedGitignore); patterns != nil {
-				gitignoreMap[rp] = patterns
+			if more := parseGitignoreFile(nestedGitignore, segs); more != nil {
+				ignorePatterns = append(ignorePatterns, more...)
 			}
 			return nil
 		}
@@ -259,10 +230,9 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 	gzw := gzip.NewWriter(w)
 	tw := tar.NewWriter(gzw)
 
-	gitignoreMap := make(map[string][]string)
-	rootPatterns := parseGitignore(filepath.Join(dir, ".gitignore"))
-	rootPatterns = append(rootPatterns, ".git")
-	gitignoreMap["."] = rootPatterns
+	ignorePatterns := parseGitignoreFile(filepath.Join(dir, ".gitignore"), nil)
+	ignorePatterns = append(ignorePatterns, gitignore.ParsePattern(".git", nil))
+	includes := parseStringPatterns(includePatterns)
 
 	go func() {
 		defer w.Close()
@@ -286,30 +256,12 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 				return nil
 			}
 
-			isIncluded := false
-			if len(includePatterns) > 0 {
-				paths := []string{rp}
-				if info.IsDir() {
-					paths = append(paths, rp+"/")
-				}
-				for _, checkPath := range paths {
-					match, matchErr := pathspec.GitIgnore(includePatterns, checkPath)
-					if matchErr != nil {
-						return fmt.Errorf("invalid include pattern: %w", matchErr)
-					}
-					if match {
-						isIncluded = true
-						break
-					}
-				}
-			}
+			segs := pathSegments(rp)
+
+			isIncluded := len(includes) > 0 && gitignore.NewMatcher(includes).Match(segs, info.IsDir())
 
 			if !isIncluded {
-				ignored, ignoreErr := isGitignored(rp, info.IsDir(), gitignoreMap)
-				if ignoreErr != nil {
-					return ignoreErr
-				}
-				if ignored {
+				if gitignore.NewMatcher(ignorePatterns).Match(segs, info.IsDir()) {
 					if info.IsDir() {
 						return filepath.SkipDir
 					}
@@ -319,8 +271,8 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 
 			if info.IsDir() {
 				nestedGitignore := filepath.Join(path, ".gitignore")
-				if patterns := parseGitignore(nestedGitignore); patterns != nil {
-					gitignoreMap[rp] = patterns
+				if more := parseGitignoreFile(nestedGitignore, segs); more != nil {
+					ignorePatterns = append(ignorePatterns, more...)
 				}
 				return nil
 			}

--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -131,6 +131,9 @@ func ComputeManifest(dir string, includePatterns []string) ([]FileManifest, erro
 	ignorePatterns = append(ignorePatterns, gitignore.ParsePattern(".git", nil))
 	includes := parseStringPatterns(includePatterns)
 
+	includesMatcher := gitignore.NewMatcher(includes)
+	ignoreMatcher := gitignore.NewMatcher(ignorePatterns)
+
 	var manifest []FileManifest
 
 	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -150,10 +153,10 @@ func ComputeManifest(dir string, includePatterns []string) ([]FileManifest, erro
 
 		segs := pathSegments(rp)
 
-		isIncluded := len(includes) > 0 && gitignore.NewMatcher(includes).Match(segs, info.IsDir())
+		isIncluded := len(includes) > 0 && includesMatcher.Match(segs, info.IsDir())
 
 		if !isIncluded {
-			if gitignore.NewMatcher(ignorePatterns).Match(segs, info.IsDir()) {
+			if ignoreMatcher.Match(segs, info.IsDir()) {
 				if info.IsDir() {
 					return filepath.SkipDir
 				}
@@ -169,6 +172,7 @@ func ComputeManifest(dir string, includePatterns []string) ([]FileManifest, erro
 			}
 			if more != nil {
 				ignorePatterns = append(ignorePatterns, more...)
+				ignoreMatcher = gitignore.NewMatcher(ignorePatterns)
 			}
 			return nil
 		}
@@ -241,6 +245,9 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 	ignorePatterns = append(ignorePatterns, gitignore.ParsePattern(".git", nil))
 	includes := parseStringPatterns(includePatterns)
 
+	includesMatcher := gitignore.NewMatcher(includes)
+	ignoreMatcher := gitignore.NewMatcher(ignorePatterns)
+
 	// io.Pipe (rather than os.Pipe) lets us surface walk errors to the
 	// reader via CloseWithError instead of silently EOF-ing.
 	r, w := io.Pipe()
@@ -267,10 +274,10 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 
 			segs := pathSegments(rp)
 
-			isIncluded := len(includes) > 0 && gitignore.NewMatcher(includes).Match(segs, info.IsDir())
+			isIncluded := len(includes) > 0 && includesMatcher.Match(segs, info.IsDir())
 
 			if !isIncluded {
-				if gitignore.NewMatcher(ignorePatterns).Match(segs, info.IsDir()) {
+				if ignoreMatcher.Match(segs, info.IsDir()) {
 					if info.IsDir() {
 						return filepath.SkipDir
 					}
@@ -286,6 +293,7 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 				}
 				if more != nil {
 					ignorePatterns = append(ignorePatterns, more...)
+					ignoreMatcher = gitignore.NewMatcher(ignorePatterns)
 				}
 				return nil
 			}

--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -234,30 +234,23 @@ func MakeFilteredTar(dir string, includePatterns []string, onlyPaths map[string]
 // and only including regular files for which accept returns true. Directory entries
 // are emitted lazily as needed to contain accepted files.
 func makeTarWithFilter(dir string, includePatterns []string, accept func(string) bool, uncompressedBytes *atomic.Int64) (io.ReadCloser, error) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		return nil, err
-	}
-
-	gzw := gzip.NewWriter(w)
-	tw := tar.NewWriter(gzw)
-
 	ignorePatterns, err := parseGitignoreFile(filepath.Join(dir, ".gitignore"), nil)
 	if err != nil {
-		w.Close()
 		return nil, err
 	}
 	ignorePatterns = append(ignorePatterns, gitignore.ParsePattern(".git", nil))
 	includes := parseStringPatterns(includePatterns)
 
-	go func() {
-		defer w.Close()
-		defer tw.Close()
-		defer gzw.Close()
+	// io.Pipe (rather than os.Pipe) lets us surface walk errors to the
+	// reader via CloseWithError instead of silently EOF-ing.
+	r, w := io.Pipe()
+	gzw := gzip.NewWriter(w)
+	tw := tar.NewWriter(gzw)
 
+	go func() {
 		emittedDirs := make(map[string]bool)
 
-		filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		walkErr := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
@@ -350,6 +343,22 @@ func makeTarWithFilter(dir string, includePatterns []string, accept func(string)
 
 			return nil
 		})
+
+		// Close the tar/gzip writers before the pipe so their trailers
+		// flush. Order matters: tw must close before gzw, gzw before w.
+		// On walk error, propagate it through the pipe so the reader
+		// gets the actual failure instead of a silent EOF.
+		if cerr := tw.Close(); cerr != nil && walkErr == nil {
+			walkErr = cerr
+		}
+		if cerr := gzw.Close(); cerr != nil && walkErr == nil {
+			walkErr = cerr
+		}
+		if walkErr != nil {
+			w.CloseWithError(walkErr)
+			return
+		}
+		w.Close()
 	}()
 
 	return r, nil

--- a/pkg/tarx/tarx_test.go
+++ b/pkg/tarx/tarx_test.go
@@ -328,6 +328,43 @@ func TestMakeTarGitignoreNegation(t *testing.T) {
 	require.ElementsMatch(t, expected, entries)
 }
 
+// TestMakeTarBridgetownTmpPids mirrors the on-disk shape of a vanilla
+// `bridgetown new` checkout: only tmp/pids/.keep exists (no tmp/.keep), with
+// the gitignore using `/tmp/*` plus a `!/tmp/pids/` negation to keep the
+// pidfile directory tracked. Without the kept .keep file surviving the
+// walker, lazy directory emission drops tmp/ from the tar entirely and
+// Puma fails to write tmp/pids/server.pid at runtime.
+func TestMakeTarBridgetownTmpPids(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tarx-test-bridgetown-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	files := map[string]string{
+		"Gemfile":         "source 'https://rubygems.org'\n",
+		"config/puma.rb":  "pidfile 'tmp/pids/server.pid'\n",
+		"tmp/pids/.keep":  "",
+		"tmp/cache/x.txt": "should be ignored",
+	}
+	for filename, content := range files {
+		fullPath := filepath.Join(tmpDir, filename)
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0755))
+		require.NoError(t, os.WriteFile(fullPath, []byte(content), 0644))
+	}
+
+	gitignore := "/tmp/*\n!/tmp/.keep\n/tmp/pids/*\n!/tmp/pids/\n!/tmp/pids/.keep\n"
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(gitignore), 0644))
+
+	reader, err := MakeTar(tmpDir, nil, nil)
+	require.NoError(t, err)
+
+	entries := extractTarEntries(t, reader)
+	require.Contains(t, entries, "tmp/pids/.keep",
+		"tmp/pids/.keep must be in the tar so Puma can write tmp/pids/server.pid at runtime")
+	require.Contains(t, entries, "tmp",
+		"tmp/ directory header must be in the tar so /app/tmp/ exists in the runtime image")
+	require.NotContains(t, entries, "tmp/cache/x.txt")
+}
+
 func TestComputeManifest(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "tarx-manifest-")
 	require.NoError(t, err)

--- a/pkg/tarx/tarx_test.go
+++ b/pkg/tarx/tarx_test.go
@@ -365,6 +365,41 @@ func TestMakeTarBridgetownTmpPids(t *testing.T) {
 	require.NotContains(t, entries, "tmp/cache/x.txt")
 }
 
+// TestMakeTarSiblingGitignoresDoNotCrossPollute verifies that when a nested
+// .gitignore is encountered, its patterns do not leak to sibling directories.
+// We accumulate patterns into a single slice as we walk, so this test pins
+// down that go-git's per-pattern `domain` actually scopes matches to the
+// gitignore's directory subtree.
+func TestMakeTarSiblingGitignoresDoNotCrossPollute(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tarx-sibling-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	files := map[string]string{
+		"subdirA/.gitignore": "keep.txt\n",
+		"subdirA/keep.txt":   "should be ignored in subdirA",
+		"subdirA/other.txt":  "kept",
+		"subdirB/keep.txt":   "should NOT be ignored in subdirB",
+		"subdirB/other.txt":  "kept",
+	}
+	for filename, content := range files {
+		fullPath := filepath.Join(tmpDir, filename)
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0755))
+		require.NoError(t, os.WriteFile(fullPath, []byte(content), 0644))
+	}
+
+	reader, err := MakeTar(tmpDir, nil, nil)
+	require.NoError(t, err)
+
+	entries := extractTarEntries(t, reader)
+	require.NotContains(t, entries, "subdirA/keep.txt",
+		"subdirA/.gitignore must hide keep.txt in subdirA")
+	require.Contains(t, entries, "subdirB/keep.txt",
+		"subdirA/.gitignore must NOT affect subdirB")
+	require.Contains(t, entries, "subdirA/other.txt")
+	require.Contains(t, entries, "subdirB/other.txt")
+}
+
 func TestComputeManifest(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "tarx-manifest-")
 	require.NoError(t, err)


### PR DESCRIPTION
A user report came in about a vanilla `bridgetown new` app failing to boot after deploy with `Errno::ENOENT - tmp/pids/server.pid`. Bridgetown ships with `tmp/pids/.keep` plus a `.gitignore` that uses `/tmp/*` and `!/tmp/pids/` to keep the pidfile directory tracked. When miren bundles source for deploy, the gitignore walker drops `tmp/` from the tar entirely, so `tmp/pids/` never makes it into the image, and Puma has nowhere to write its pidfile.

The walker was using `shibumi/go-pathspec`, a generic glob library whose `GitIgnore` function takes a single string path with no way to indicate it's a directory. Our `isGitignored` worked around that by checking both `relPath` and `relPath + "/"` and OR-ing the result, but the dual-form check breaks negations: the no-slash form matches `/tmp/*` and short-circuits before the trailing-slash negation `!/tmp/pids/` ever gets a chance. Once the walker `SkipDir`s `tmp/pids/`, lazy directory emission drops `tmp/` from the tar. Pathspec is a generic glob library, not a real gitignore implementation, and we'd been bending it into the wrong shape.

Swapping to `go-git/v5/plumbing/format/gitignore`, the parser go-git itself uses, gets us a proper `Match(path []string, isDir bool) bool` API. All 19 existing tarx tests pass unchanged, which is a strong signal the swap is behavior-preserving for everything except the bug we were after. `TestMakeTarBridgetownTmpPids` is the new regression guard. Binary delta is +20KB after dead-code elimination.

Closes [MIR-1075](https://linear.app/miren/issue/MIR-1075).