### PR TITLE
Remove globalrouter labs flag

### DIFF
--- a/blackbox/harness/cloud.go
+++ b/blackbox/harness/cloud.go
@@ -53,8 +53,8 @@ type CloudEnv struct {
 
 // NewCloudEnv builds a full cloud+POP environment for testing the global router.
 // It builds cloud/POP binaries, starts cloud, registers a POP and cluster,
-// starts POP, and restarts the miren server with --labs globalrouter.
-// The environment is torn down via t.Cleanup.
+// starts POP, and restarts the miren server so it picks up the new
+// registration.json. The environment is torn down via t.Cleanup.
 func NewCloudEnv(t *testing.T, m *Miren) *CloudEnv {
 	t.Helper()
 
@@ -99,8 +99,8 @@ func NewCloudEnv(t *testing.T, m *Miren) *CloudEnv {
 	// Start POP
 	env.startPOP(t)
 
-	// Restart miren server with globalrouter enabled
-	env.restartServerWithGlobalRouter(t)
+	// Restart miren server so it picks up the registration
+	env.restartServerWithRegistration(t)
 
 	// Wait for global router to connect
 	env.waitForConnection(t)
@@ -451,9 +451,9 @@ func (env *CloudEnv) startPOP(t *testing.T) {
 	t.Log("POP server ready")
 }
 
-func (env *CloudEnv) restartServerWithGlobalRouter(t *testing.T) {
+func (env *CloudEnv) restartServerWithRegistration(t *testing.T) {
 	t.Helper()
-	t.Log("restarting miren server with --labs globalrouter...")
+	t.Log("restarting miren server to pick up registration...")
 
 	// Stop current server
 	env.m.RunCmdAsRoot("bash", "-c", "hack/dev-server stop")
@@ -462,13 +462,12 @@ func (env *CloudEnv) restartServerWithGlobalRouter(t *testing.T) {
 	// old "Miren server started" line from the previous startup.
 	env.m.RunCmdAsRoot("bash", "-c", ": > /tmp/miren-server.log")
 
-	// Start with globalrouter lab flag
-	env.m.RunCmdAsRoot("bash", "-c", "DEV_SERVER_FLAGS='--labs globalrouter' hack/dev-server start")
+	env.m.RunCmdAsRoot("bash", "-c", "hack/dev-server start")
 
 	// Wait for server to be ready
 	r := env.m.RunCmdAsRoot("hack/dev-server", "wait-ready", "60")
 	if !r.Success() {
-		t.Fatalf("server failed to start with globalrouter: %s", r.Stderr)
+		t.Fatalf("server failed to start: %s", r.Stderr)
 	}
 
 	// Also wait for buildkit's hosts file to be updated with the registry IP,
@@ -483,14 +482,14 @@ func (env *CloudEnv) restartServerWithGlobalRouter(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		// Restart server without globalrouter to restore original state
+		// Restart server after registration files are removed to restore original state
 		env.m.RunCmdAsRoot("bash", "-c", "hack/dev-server stop")
 		env.m.RunCmdAsRoot("bash", "-c", ": > /tmp/miren-server.log")
 		env.m.RunCmdAsRoot("bash", "-c", "hack/dev-server start")
 		env.m.RunCmdAsRoot("hack/dev-server", "wait-ready", "30")
 	})
 
-	t.Log("miren server restarted with globalrouter enabled")
+	t.Log("miren server restarted with registration loaded")
 }
 
 func (env *CloudEnv) waitForConnection(t *testing.T) {

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1269,8 +1269,8 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		go c.reportStatusPeriodically(ctx)
 	}
 
-	// Start global router for NAT traversal when enabled
-	if labs.GlobalRouter() && c.CloudAuth.Enabled && c.authClient != nil {
+	// Start global router for NAT traversal when cloud auth is configured
+	if c.CloudAuth.Enabled && c.authClient != nil {
 		cloudURL := c.CloudAuth.CloudURL
 		if cloudURL == "" {
 			cloudURL = DefaultCloudURL

--- a/docs/docs/miren-cloud/global-router.md
+++ b/docs/docs/miren-cloud/global-router.md
@@ -1,0 +1,60 @@
+
+# Global Router
+
+The global router is the connection between your cluster and Miren Cloud. It's how requests for your [subdomain](/miren-cloud/subdomains) reach your cluster, even when the cluster is behind NAT or a firewall.
+
+## How It Works
+
+When your cluster is registered with Miren Cloud, the miren server opens a long-lived connection to miren.cloud itself. When a request arrives at a Miren Cloud Point of Presence (POP), the POP determines which cluster the request is for and asks miren.cloud to have that cluster's server connect directly to the POP. Subsequent requests for your hostnames terminate at the POP, which forwards them to your cluster over the new connection.
+
+The result: you don't need a public IP, port forwarding, or DNS gymnastics on your cluster — Miren Cloud handles ingress and uses the global router as the path back to you.
+
+## When It Runs
+
+The global router starts automatically whenever the miren server has cloud auth configured — i.e. after you've run `miren server install` (without `--without-cloud`) or `miren server register`. There's no flag to enable, no separate process to run.
+
+If you run a fully standalone cluster (`miren server install --without-cloud`), the global router doesn't start; your cluster reaches the network however you've wired it.
+
+## How Requests Use the Global Router
+
+To use the global router, requests need to arrive at the Miren Cloud POP network. There are two ways that can happen:
+
+_These examples use `cluster-xyz` as a stand-in for cluster IDs. You can find cluster IDs in miren.cloud._
+
+1. **A request to `cluster-xyz.global.miren.systems`.** `*.global.miren.systems` points at `pop-global.miren.cloud`, so any request to that hostname is routed explicitly to the cluster named in the hostname.
+2. **A cluster whose port 443 is not publicly reachable.** When a cluster connects to miren.cloud it checks whether its own port 443 is publicly accessible. If it isn't, miren.cloud automatically points the cluster's default DNS record (`cluster-xyz.miren.systems`) at `pop-global.miren.cloud` so traffic flows through the POP network instead.
+
+### Miren Cloud Subdomains
+
+A subdomain assigned by miren.cloud automatically routes traffic via the global router when the cluster has no publicly reachable port. It does this by pointing the subdomain at the cluster's auto-assigned DNS record — which, as described above, already points at `pop-global.miren.cloud`.
+
+### User-Provided Domains
+
+In the future, we'll allow users to bring their own domain names and route them through the global router. Today, you can point any DNS record at a cluster's public IP, which works fine for clusters that are publicly reachable.
+
+## Verifying the Connection
+
+Once the server is running, look for the global router connecting to cloud in the server logs:
+
+```
+component=globalrouter ... connected to cloud
+```
+
+You can also confirm from the cluster side:
+
+```bash
+miren cluster list
+```
+
+A registered cluster that has connected through the global router will show up here.
+
+## Troubleshooting
+
+**Cluster won't connect.** The global router requires outbound connectivity to miren.cloud (TLS over TCP on port 443) and to every host under `pop-global.miren.cloud` (HTTP/3 over UDP on port 8443). If your network blocks outbound traffic, check that the POP host (visible in server logs under `component=globalrouter`) is reachable.
+
+**Hostnames return cloud errors.** If a request to `mycluster.run.garden` lands at the POP but fails to forward, the global router connection may be down. Restart the miren server and watch the logs for the `connected to cloud` marker.
+
+## Next Steps
+
+- [Subdomains](/miren-cloud/subdomains) — Claim a hostname that uses the global router
+- [Miren Cloud Overview](/miren-cloud/overview) — Cluster registration and login

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -134,6 +134,11 @@ const sidebars: SidebarsConfig = {
         'miren-cloud/connectivity',
         {
           type: 'doc',
+          id: 'miren-cloud/global-router',
+          label: 'Global Router',
+        },
+        {
+          type: 'doc',
           id: 'miren-cloud/cloud-updates',
           label: 'Updates',
         },

--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -1,9 +1,4 @@
 features:
-  - name: globalrouter
-    predicate: GlobalRouter
-    description: Use global NAT traversal router for connectivity
-    default: false
-
   - name: distributedrunners
     predicate: DistributedRunners
     description: Schedule jobs across multiple runner nodes

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -10,7 +10,6 @@ import (
 
 // Feature name constants
 const (
-	FeatureGlobalRouter       = "globalrouter"
 	FeatureDistributedRunners = "distributedrunners"
 	FeatureSagas              = "sagas"
 )
@@ -18,7 +17,6 @@ const (
 // AllFeatures returns a list of all known feature names
 func AllFeatures() []string {
 	return []string{
-		FeatureGlobalRouter,
 		FeatureDistributedRunners,
 		FeatureSagas,
 	}
@@ -27,7 +25,6 @@ func AllFeatures() []string {
 // FeatureDescriptions returns a map of feature names to their descriptions
 func FeatureDescriptions() map[string]string {
 	return map[string]string{
-		FeatureGlobalRouter:       "Use global NAT traversal router for connectivity",
 		FeatureDistributedRunners: "Schedule jobs across multiple runner nodes",
 		FeatureSagas:              "Use saga-based crash-recoverable workflows",
 	}
@@ -40,7 +37,6 @@ var (
 
 // featureDefaults holds the default state for each feature
 var featureDefaults = map[string]bool{
-	FeatureGlobalRouter:       false,
 	FeatureDistributedRunners: false,
 	FeatureSagas:              false,
 }
@@ -129,12 +125,6 @@ func IsEnabled(name string) bool {
 }
 
 // Feature predicate functions
-
-// GlobalRouter returns whether the globalrouter feature is enabled.
-// Use global NAT traversal router for connectivity
-func GlobalRouter() bool {
-	return IsEnabled(FeatureGlobalRouter)
-}
 
 // DistributedRunners returns whether the distributedrunners feature is enabled.
 // Schedule jobs across multiple runner nodes

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -11,20 +11,20 @@ func TestDisableFeatureWithPrefix(t *testing.T) {
 	Reset()
 
 	// Enable first, then disable
-	Init(nil, []string{"globalrouter", "-globalrouter"})
+	Init(nil, []string{"sagas", "-sagas"})
 
-	if GlobalRouter() {
-		t.Error("GlobalRouter should be disabled after '-globalrouter'")
+	if Sagas() {
+		t.Error("Sagas should be disabled after '-sagas'")
 	}
 }
 
 func TestCaseInsensitiveFeatureNames(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"GlobalRouter", "DISTRIBUTEDRUNNERS"})
+	Init(nil, []string{"Sagas", "DISTRIBUTEDRUNNERS"})
 
-	if !GlobalRouter() {
-		t.Error("GlobalRouter should be enabled (case-insensitive)")
+	if !Sagas() {
+		t.Error("Sagas should be enabled (case-insensitive)")
 	}
 	if !DistributedRunners() {
 		t.Error("DistributedRunners should be enabled (case-insensitive)")
@@ -51,10 +51,10 @@ func TestUnknownFeatureLogsWarning(t *testing.T) {
 func TestEmptyAndWhitespaceFlags(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"", "  ", "globalrouter", "  ", ""})
+	Init(nil, []string{"", "  ", "sagas", "  ", ""})
 
-	if !GlobalRouter() {
-		t.Error("GlobalRouter should be enabled despite empty/whitespace flags")
+	if !Sagas() {
+		t.Error("Sagas should be enabled despite empty/whitespace flags")
 	}
 }
 
@@ -91,7 +91,7 @@ func TestAllKeywordWithExclusion(t *testing.T) {
 func TestNegativeAllDisablesAll(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"globalrouter", "distributedrunners", "-all"})
+	Init(nil, []string{"sagas", "distributedrunners", "-all"})
 
 	for _, name := range AllFeatures() {
 		if IsEnabled(name) {


### PR DESCRIPTION
## Summary
- Graduates the global router from a labs feature to default behavior — it now starts automatically whenever the miren server has cloud auth configured.
- Drops `globalrouter` from `pkg/labs/features.yaml` (regenerates `labs.gen.go`), removes the `labs.GlobalRouter()` gate in `components/coordinate`, and updates `pkg/labs/labs_test.go` to use `routeoidc` as the representative flag for the enable/disable/case/all-keyword tests.
- Cleans up the blackbox cloud harness: renames `restartServerWithGlobalRouter` → `restartServerWithRegistration` (the restart still has to happen to load `registration.json`) and drops `DEV_SERVER_FLAGS='--labs globalrouter'`.
- Adds `docs/docs/miren-cloud/global-router.md` describing how the feature works, when it runs, how it interacts with subdomains, and basic troubleshooting; links it from the Miren Cloud sidebar.

## Notes for Reviewers
- Any cluster currently starting with `MIREN_LABS=globalrouter` (or `--labs globalrouter`) will get a benign "unknown labs feature flag" warning at startup. No behavior change.
- `make lint` passes; `pkg/labs` and `pkg/globalrouter` tests pass on the host. `components/coordinate` integration tests need the dev container's etcd/containerd and were not run locally.

Refs MIR-1079

## Test plan
- [ ] CI green (lint + unit tests)
- [ ] Blackbox cloud test (`make test-blackbox` against the cloud harness) verifies the global router still connects without the labs flag
- [ ] Manually start a registered cluster and confirm `connected to cloud` appears in logs