### PR TITLE
Add Algolia DocSearch and front matter to docs

### DIFF
--- a/docs/docs/addons.md
+++ b/docs/docs/addons.md
@@ -1,3 +1,9 @@
+---
+title: Addons
+description: Managed services like databases that Miren provisions and operates for your app, with automatic credential injection.
+keywords: [addons, managed services, database, postgres, credentials, environment variables]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Addons

--- a/docs/docs/admin-interface.md
+++ b/docs/docs/admin-interface.md
@@ -1,3 +1,9 @@
+---
+title: Admin Interface
+description: Expose custom administrative functions in your app that can be called from the CLI via JSON-RPC.
+keywords: [admin, json-rpc, maintenance, management, cli]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Admin Interface

--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -1,3 +1,9 @@
+---
+title: App Configuration
+description: How Miren detects and configures your app automatically, and when to customize with app.toml.
+keywords: [configuration, app.toml, convention over configuration, environment variables, miren init]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # App Configuration

--- a/docs/docs/app-toml.md
+++ b/docs/docs/app-toml.md
@@ -1,5 +1,8 @@
 ---
+title: app.toml Reference
 sidebar_label: app.toml
+description: Complete reference for .miren/app.toml — services, scaling, disks, environment variables, and build configuration.
+keywords: [app.toml, configuration, reference, services, scaling, environment variables, build]
 ---
 
 # app.toml Reference

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -1,3 +1,9 @@
+---
+title: Changelog
+description: All notable changes to Miren Runtime, organized by release version.
+keywords: [changelog, releases, updates, version history]
+---
+
 # Changelog
 
 All notable changes to Miren Runtime will be documented in this file.

--- a/docs/docs/ci-deploy.md
+++ b/docs/docs/ci-deploy.md
@@ -1,3 +1,9 @@
+---
+title: CI/CD Deployment
+description: Deploy to Miren from CI/CD pipelines using short-lived OIDC tokens instead of stored secrets.
+keywords: [ci, cd, github actions, oidc, deployment, automation, pipeline]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # CI/CD Deployment

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -1,6 +1,7 @@
 ---
 title: "Commands"
 description: "Complete reference for all miren CLI commands"
+keywords: [cli, commands, reference, miren]
 ---
 
 # Commands

--- a/docs/docs/conduct.md
+++ b/docs/docs/conduct.md
@@ -1,6 +1,8 @@
 ---
 slug: /conduct
 title: Code of Conduct
+description: The Miren community code of conduct — guidelines for respectful and inclusive participation.
+keywords: [code of conduct, community, guidelines]
 ---
 
 # Miren Community Code of Conduct

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -1,3 +1,9 @@
+---
+title: Deployment
+description: How miren deploy works — uploading code, building images, and activating new versions.
+keywords: [deploy, build, rollback, versions, container image]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Deployment

--- a/docs/docs/disks.md
+++ b/docs/docs/disks.md
@@ -1,3 +1,9 @@
+---
+title: Persistent Storage
+description: Configure persistent storage for your app using local storage or Miren Disks managed volumes.
+keywords: [disks, storage, persistent, volumes, local storage, backup]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Persistent Storage

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -1,3 +1,9 @@
+---
+title: Firewall Configuration
+description: How Miren configures iptables rules for container networking and how to troubleshoot networking issues.
+keywords: [firewall, iptables, networking, containers, troubleshooting]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Firewall Configuration

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,3 +1,9 @@
+---
+title: Getting Started
+description: Install Miren, set up a server, and deploy your first app in minutes.
+keywords: [getting started, install, setup, quickstart, first deploy]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Getting Started

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,5 +1,8 @@
 ---
 slug: /
+title: Miren
+description: Miren is a container platform for small teams — deploy apps to a Linux server with builds, scaling, routing, TLS, and backups built in.
+keywords: [miren, container platform, deploy, self-hosted, paas]
 ---
 
 # Miren

--- a/docs/docs/labs.md
+++ b/docs/docs/labs.md
@@ -1,3 +1,9 @@
+---
+title: Miren Labs
+description: Experimental features available for early access and feedback before stable release.
+keywords: [labs, experimental, features, opt-in, preview]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Miren Labs

--- a/docs/docs/languages.md
+++ b/docs/docs/languages.md
@@ -1,3 +1,8 @@
+---
+title: Supported Languages
+description: Languages and frameworks Miren detects automatically, including build and runtime configuration.
+keywords: [languages, ruby, node, python, go, rust, bun, framework, build]
+---
 
 # Supported Languages
 

--- a/docs/docs/logs.md
+++ b/docs/docs/logs.md
@@ -1,3 +1,9 @@
+---
+title: Logs
+description: View and query application, build, sandbox, and system logs with the miren logs command.
+keywords: [logs, logging, victoria logs, debugging, output, build logs]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Logs

--- a/docs/docs/miren-cloud/cloud-updates.md
+++ b/docs/docs/miren-cloud/cloud-updates.md
@@ -1,3 +1,9 @@
+---
+title: Cloud Updates
+description: What's new in Miren Cloud — feature releases, fixes, and improvements.
+keywords: [updates, changelog, miren cloud, releases]
+---
+
 # Updates
 
 What's new in Miren Cloud.

--- a/docs/docs/miren-cloud/overview.md
+++ b/docs/docs/miren-cloud/overview.md
@@ -1,3 +1,8 @@
+---
+title: Miren Cloud
+description: Central control plane for managing Miren clusters — team access, backups, multi-environment workflows, and custom subdomains.
+keywords: [miren cloud, control plane, teams, rbac, backup, multi-environment, organization]
+---
 
 # Miren Cloud
 

--- a/docs/docs/miren-cloud/subdomains.md
+++ b/docs/docs/miren-cloud/subdomains.md
@@ -1,3 +1,8 @@
+---
+title: Subdomains
+description: Claim a custom subdomain like mycluster.run.garden for your Miren cluster with automatic DNS and wildcard routing.
+keywords: [subdomains, dns, run.garden, miren.app, custom domain, wildcard]
+---
 
 # Subdomains
 

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -1,3 +1,8 @@
+---
+title: Observability
+description: OpenTelemetry distributed tracing for the request lifecycle, including routing, sandbox management, and container operations.
+keywords: [observability, tracing, opentelemetry, spans, latency, cold start]
+---
 
 # Observability
 

--- a/docs/docs/route-protect.md
+++ b/docs/docs/route-protect.md
@@ -1,3 +1,9 @@
+---
+title: Protecting Routes
+description: Add single sign-on to your app's HTTP routes using OIDC, with identity passed as headers.
+keywords: [route protection, oidc, sso, authentication, single sign-on, identity provider]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Protecting Routes

--- a/docs/docs/scaling.md
+++ b/docs/docs/scaling.md
@@ -1,3 +1,9 @@
+---
+title: Application Scaling
+description: How Miren autoscales your app based on traffic, and how to configure scaling behavior.
+keywords: [scaling, autoscaling, concurrency, instances, traffic, scale to zero]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Application Scaling

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -1,5 +1,8 @@
 ---
+title: Server Configuration Reference
 sidebar_label: server.toml
+description: Complete reference for Miren server configuration — config file, environment variables, and CLI flags.
+keywords: [server.toml, server configuration, environment variables, flags, settings]
 ---
 
 import CliCommand from '@site/src/components/CliCommand';

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -1,3 +1,9 @@
+---
+title: Services
+description: Run multiple processes in a single app — web servers, workers, databases — each with independent scaling.
+keywords: [services, processes, worker, web, background jobs, multi-process]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Services
@@ -303,7 +309,7 @@ For detailed scaling configuration, see [Application Scaling](/scaling).
 
 ## Persistent Storage
 
-For stateful services like databases, use [Local Shared Storage](/disks#local-shared-storage)—persistent storage automatically available at `/miren/data/local`. Configure your database to store data there:
+For stateful services like databases, use [Local Storage](/disks#local-storage)—persistent storage automatically available at `/miren/data/local`. Configure your database to store data there:
 
 ```toml
 [services.postgres]

--- a/docs/docs/system-requirements.md
+++ b/docs/docs/system-requirements.md
@@ -1,3 +1,9 @@
+---
+title: System Requirements
+description: Minimum and recommended hardware for running a Miren server — OS, architecture, memory, and storage.
+keywords: [system requirements, hardware, linux, memory, disk space, arm64, x86]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # System Requirements

--- a/docs/docs/terminology.md
+++ b/docs/docs/terminology.md
@@ -1,3 +1,8 @@
+---
+title: Terminology
+description: Definitions of common terms used in Miren — apps, clusters, sandboxes, services, and more.
+keywords: [terminology, glossary, definitions, concepts]
+---
 
 # Terminology
 

--- a/docs/docs/tls.md
+++ b/docs/docs/tls.md
@@ -1,3 +1,9 @@
+---
+title: TLS Certificates
+description: Automatic TLS certificate provisioning via Let's Encrypt, including DNS challenges and custom certificates.
+keywords: [tls, ssl, certificates, https, lets encrypt, acme, dns challenge]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # TLS Certificates

--- a/docs/docs/traffic-routing.md
+++ b/docs/docs/traffic-routing.md
@@ -1,3 +1,9 @@
+---
+title: Traffic Routing
+description: Route HTTP traffic to apps via hostnames, and configure non-HTTP ports for TCP/UDP services.
+keywords: [routing, routes, hostname, dns, ports, tcp, udp, load balancing, wildcard]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Traffic Routing

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1,3 +1,9 @@
+---
+title: Troubleshooting
+description: Step-by-step guide to diagnosing issues with Miren applications, builds, networking, and server health.
+keywords: [troubleshooting, debugging, errors, miren doctor, health check]
+---
+
 import CliCommand from '@site/src/components/CliCommand';
 
 # Troubleshooting

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -124,17 +124,16 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
+      title: '',
       logo: {
-        alt: 'Miren Logo',
+        alt: 'Miren Docs',
         src: 'img/logo-light.svg',
         srcDark: 'img/logo.svg',
       },
       items: [
-        {
-          type: 'docSidebar',
-          sidebarId: 'tutorialSidebar',
-          position: 'left',
-          label: 'Docs',
+{
+          type: 'search',
+          position: 'right',
         },
         {
           href: 'https://github.com/mirendev/runtime',
@@ -174,6 +173,13 @@ const config: Config = {
         },
       ],
       copyright: `© ${new Date().getFullYear()} From your friends at <a href="https://miren.dev" target="_blank" rel="noopener noreferrer">Miren</a>`,
+    },
+    algolia: {
+      appId: 'UMQ0GOVXIG',
+      apiKey: '9ac12cfcf7f3cdb2ccd3fe48548cc1ed',
+      indexName: 'Miren Docs',
+      contextualSearch: true,
+      searchPagePath: 'search',
     },
     prism: {
       theme: prismThemes.github,

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -704,6 +704,34 @@ a:hover {
 }
 
 /* ========================================
+ * Algolia DocSearch Overrides
+ * ======================================== */
+
+.DocSearch-Button {
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+.DocSearch-Button:hover {
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+.DocSearch-Form {
+  outline: none !important;
+  outline-offset: 0 !important;
+}
+
+.DocSearch-Input:focus-visible {
+  outline: none;
+  outline-offset: 0;
+}
+
+.DocSearch-Modal a:hover {
+  text-decoration: none;
+}
+
+/* ========================================
  * Accessibility & Motion
  * ======================================== */
 

--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://miren.md/sitemap.xml
+
+# Algolia-Crawler-Verif: 5D76B29A07238A67

--- a/hack/gen-command-docs
+++ b/hack/gen-command-docs
@@ -351,6 +351,7 @@ generate_commands_index() {
     echo "---"
     echo "title: \"Commands\""
     echo "description: \"Complete reference for all miren CLI commands\""
+    echo "keywords: [cli, commands, reference, miren]"
     echo "---"
     echo ""
     echo "# Commands"


### PR DESCRIPTION
## Summary
- Add Algolia DocSearch integration with crawler verification in robots.txt
- Add description and keywords front matter to all doc pages for better search indexing
- Clean up navbar ordering (search before GitHub link) and hide title text next to logo
- Fix broken anchor link in services.md

Resolves MIR-1041
Resolves MIR-1087

<img width="1004" height="689" alt="Screenshot 2026-05-05 at 11 09 33 AM" src="https://github.com/user-attachments/assets/a5fca978-bc5d-4178-a2e4-200949680510" />


