### PR TITLE
Fix runner upgrade skipping service restart on already-current binary

### DIFF
--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -291,7 +291,7 @@ type logEntryJSON struct {
 
 func printLogEntryJSON(ctx *Context, l *app_v1alpha.LogEntry) {
 	entry := logEntryJSON{
-		Timestamp: standard.FromTimestamp(l.Timestamp()).Format(time.RFC3339Nano),
+		Timestamp: standard.FromTimestamp(l.Timestamp()).UTC().Format(time.RFC3339Nano),
 		Stream:    l.Stream(),
 		Message:   l.Line(),
 	}

--- a/cli/commands/runner_upgrade.go
+++ b/cli/commands/runner_upgrade.go
@@ -56,10 +56,14 @@ func RunnerUpgrade(ctx *Context, opts struct {
 		}
 
 		PrintVersionComparison(current, latest)
+		drift := PrintRunningVersionDrift(mgrOpts.ServiceName, current)
 
-		if latest.IsNewer(current) {
+		switch {
+		case latest.IsNewer(current):
 			fmt.Println("\nAn update is available! Run 'sudo miren runner upgrade' to install it.")
-		} else {
+		case drift:
+			fmt.Println("\nOn-disk binary is current, but the running daemon is stale. Run 'sudo miren runner upgrade' to restart the service.")
+		default:
 			fmt.Println("\nYour runner is already on the latest version.")
 		}
 		return nil
@@ -69,6 +73,10 @@ func RunnerUpgrade(ctx *Context, opts struct {
 	if err != nil {
 		ctx.Log.Warn("could not check version status", "error", err)
 	} else if !needsUpgrade {
+		mgr := release.NewManager(mgrOpts)
+		if _, err := HandleVersionDrift(ctx, mgr, mgrOpts.ServiceName); err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/cli/commands/server_upgrade.go
+++ b/cli/commands/server_upgrade.go
@@ -61,11 +61,14 @@ func ServerUpgrade(ctx *Context, opts struct {
 		}
 
 		PrintVersionComparison(current, latest)
+		drift := PrintRunningVersionDrift(mgrOpts.ServiceName, current)
 
-		// Use proper version comparison with build dates
-		if latest.IsNewer(current) {
+		switch {
+		case latest.IsNewer(current):
 			fmt.Println("\nAn update is available! Run 'sudo miren server upgrade' to install it.")
-		} else {
+		case drift:
+			fmt.Println("\nOn-disk binary is current, but the running daemon is stale. Run 'sudo miren server upgrade' to restart the service.")
+		default:
 			fmt.Println("\nYour server is already on the latest version.")
 		}
 		return nil
@@ -78,7 +81,11 @@ func ServerUpgrade(ctx *Context, opts struct {
 		ctx.Log.Warn("could not check version status", "error", err)
 		// Continue with upgrade if we can't check
 	} else if !needsUpgrade {
-		return nil // Already up to date
+		mgr := release.NewManager(mgrOpts)
+		if _, err := HandleVersionDrift(ctx, mgr, mgrOpts.ServiceName); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	mgr := release.NewManager(mgrOpts)

--- a/cli/commands/upgrade_helpers.go
+++ b/cli/commands/upgrade_helpers.go
@@ -45,16 +45,16 @@ func CheckVersionStatus(ctx context.Context, targetVersion string, mgrOpts *rele
 // PrintVersionComparison prints a formatted comparison of current vs latest versions
 func PrintVersionComparison(current, latest release.VersionInfo) {
 	fmt.Printf("Current version: %s\n", current.Version)
-	if current.Commit != "" && len(current.Commit) > 7 {
-		fmt.Printf("Current commit:  %s\n", current.Commit[:7])
+	if sc := current.ShortCommit(); sc != "" {
+		fmt.Printf("Current commit:  %s\n", sc)
 	}
 	if !current.BuildDate.IsZero() {
 		fmt.Printf("Current build:   %s\n", current.BuildDate.Format("2006-01-02 15:04:05 UTC"))
 	}
 
 	fmt.Printf("\nLatest version:  %s\n", latest.Version)
-	if latest.Commit != "" && len(latest.Commit) > 7 {
-		fmt.Printf("Latest commit:   %s\n", latest.Commit[:7])
+	if sc := latest.ShortCommit(); sc != "" {
+		fmt.Printf("Latest commit:   %s\n", sc)
 	}
 	if !latest.BuildDate.IsZero() {
 		fmt.Printf("Latest build:    %s\n", latest.BuildDate.Format("2006-01-02 15:04:05 UTC"))
@@ -92,6 +92,59 @@ func CheckIfUpgradeNeeded(ctx context.Context, targetVersion string, force bool,
 	return true, nil
 }
 
+// PrintRunningVersionDrift prints an additional line about the running daemon
+// when its version differs from the on-disk binary. Used by --check paths to
+// surface drift without trying to upgrade. Returns true when drift was
+// reported, so callers can adjust their conclusion text.
+func PrintRunningVersionDrift(serviceName string, onDisk release.VersionInfo) bool {
+	runningVer, err := release.GetRunningServiceVersion(serviceName)
+	if err != nil {
+		return false
+	}
+	if runningVer.Equivalent(onDisk) {
+		return false
+	}
+	fmt.Printf("\nRunning daemon:  %s\n", runningVer.Display())
+	return true
+}
+
+// HandleVersionDrift checks whether the running daemon for the given systemd
+// service differs from the binary on disk. If they differ, the service is
+// restarted via mgr (no download, no install) and the function returns true.
+//
+// This exists because `CheckIfUpgradeNeeded` only compares on-disk binary vs
+// target version. If a previous `miren upgrade` already replaced the on-disk
+// binary, the running daemon is stale even though "current == target". Drift
+// detection catches that case and triggers just the restart.
+//
+// If the running version can't be determined (service inaccessible, /proc not
+// readable, etc.), we log a note and return (false, nil) rather than forcing a
+// surprise restart.
+func HandleVersionDrift(ctx context.Context, mgr *release.Manager, serviceName string) (bool, error) {
+	runningVer, err := release.GetRunningServiceVersion(serviceName)
+	if err != nil {
+		fmt.Printf("Note: could not determine running %s version (%v); skipping drift check\n", serviceName, err)
+		return false, nil
+	}
+
+	onDiskVer, err := mgr.GetCurrentVersion(ctx)
+	if err != nil {
+		return false, nil
+	}
+
+	if runningVer.Equivalent(onDiskVer) {
+		return false, nil
+	}
+
+	fmt.Printf("Running %s is at %s; on-disk binary is %s. Restarting to pick up the new binary.\n",
+		serviceName, runningVer.Display(), onDiskVer.Display())
+
+	if err := mgr.RestartAndVerify(ctx); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
 // PrintUpgradeSuccess prints a formatted success message after upgrade
 // If mgrOpts is nil, uses default manager options (for server path)
 func PrintUpgradeSuccess(ctx context.Context, oldVersion release.VersionInfo, commandType string, mgrOpts *release.ManagerOptions) {
@@ -104,22 +157,7 @@ func PrintUpgradeSuccess(ctx context.Context, oldVersion release.VersionInfo, co
 
 	if oldVersion.Version != "" {
 		fmt.Printf("\n%s upgrade successful:\n", commandType)
-		fmt.Printf("  Old: %s", oldVersion.Version)
-		if c := oldVersion.Commit; c != "" && c != "unknown" {
-			end := 8
-			if len(c) < end {
-				end = len(c)
-			}
-			fmt.Printf(" (%s)", c[:end])
-		}
-		fmt.Printf("\n  New: %s", newVersion.Version)
-		if c := newVersion.Commit; c != "" && c != "unknown" {
-			end := 8
-			if len(c) < end {
-				end = len(c)
-			}
-			fmt.Printf(" (%s)", c[:end])
-		}
-		fmt.Printf("\n")
+		fmt.Printf("  Old: %s\n", oldVersion.Display())
+		fmt.Printf("  New: %s\n", newVersion.Display())
 	}
 }

--- a/pkg/release/manager.go
+++ b/pkg/release/manager.go
@@ -156,6 +156,28 @@ func (m *Manager) UpgradeServer(ctx context.Context, artifact Artifact) error {
 	return nil
 }
 
+// RestartAndVerify restarts the systemd service and verifies its health
+// without performing any download or installation. Used by the drift-recovery
+// path when the running daemon is stale relative to the on-disk binary (e.g.,
+// after `miren upgrade` rewrote the release-dir binary but no service restart
+// has happened yet).
+func (m *Manager) RestartAndVerify(ctx context.Context) error {
+	fmt.Printf("Restarting %s service...\n", m.opts.ServiceName)
+	if err := m.restartService(ctx); err != nil {
+		return fmt.Errorf("service restart failed: %w", err)
+	}
+
+	if !m.opts.SkipHealthCheck {
+		fmt.Printf("Verifying service health...\n")
+		if err := m.verifier.VerifyHealth(ctx, m.opts.HealthTimeout); err != nil {
+			return fmt.Errorf("health check failed: %w", err)
+		}
+		fmt.Printf("Service is healthy\n")
+	}
+
+	return nil
+}
+
 // Rollback rolls back to the previous version
 func (m *Manager) Rollback(ctx context.Context) error {
 	// Check if backup exists

--- a/pkg/release/version.go
+++ b/pkg/release/version.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -79,6 +80,82 @@ func parseVersionText(output string) VersionInfo {
 	}
 
 	return info
+}
+
+// ShortCommit returns the 7-char display prefix of v's commit, or "" if the
+// commit is missing or "unknown". 7 chars matches git's default short-sha
+// length and what users see elsewhere.
+func (v VersionInfo) ShortCommit() string {
+	c := v.Commit
+	if c == "" || c == "unknown" {
+		return ""
+	}
+	if len(c) <= 7 {
+		return c
+	}
+	return c[:7]
+}
+
+// Display formats v as "version (commit)" for human-facing output. If the
+// commit is missing, just the version string is returned.
+func (v VersionInfo) Display() string {
+	if sc := v.ShortCommit(); sc != "" {
+		return v.Version + " (" + sc + ")"
+	}
+	return v.Version
+}
+
+// Equivalent returns true if v represents the same build as other.
+// Commits are the strongest signal: if both sides have a known commit, that
+// alone decides. Otherwise we fall back to comparing version string and build
+// date. Used by drift detection to ask "is the running daemon actually a
+// different build than what's on disk?".
+func (v VersionInfo) Equivalent(other VersionInfo) bool {
+	if v.Commit != "" && v.Commit != "unknown" &&
+		other.Commit != "" && other.Commit != "unknown" {
+		return v.Commit == other.Commit
+	}
+	if v.Version != other.Version {
+		return false
+	}
+	if !v.BuildDate.IsZero() && !other.BuildDate.IsZero() {
+		return v.BuildDate.Equal(other.BuildDate)
+	}
+	return true
+}
+
+// GetRunningServiceVersion returns the version info for the binary currently
+// executing for the given systemd service. It looks up the service's MainPID
+// via systemctl and execs /proc/<pid>/exe.
+//
+// On Linux this returns the *actually-running* version regardless of what the
+// on-disk binary at the install path says. The kernel keeps the original inode
+// alive as long as the process holds an exec mapping to it, so /proc/<pid>/exe
+// continues to point at the binary the daemon was started from even after an
+// atomic rename of the install path.
+func GetRunningServiceVersion(serviceName string) (VersionInfo, error) {
+	pid, err := getServiceMainPID(serviceName)
+	if err != nil {
+		return VersionInfo{}, err
+	}
+	if pid == 0 {
+		return VersionInfo{}, fmt.Errorf("service %s is not running", serviceName)
+	}
+	return GetCurrentVersion(fmt.Sprintf("/proc/%d/exe", pid))
+}
+
+func getServiceMainPID(serviceName string) (int, error) {
+	cmd := exec.Command("systemctl", "show", "-p", "MainPID", "--value", serviceName)
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("systemctl show failed for %s: %w", serviceName, err)
+	}
+	pidStr := strings.TrimSpace(string(output))
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return 0, fmt.Errorf("parse MainPID %q for %s: %w", pidStr, serviceName, err)
+	}
+	return pid, nil
 }
 
 // IsNewer returns true if this version is newer than the other

--- a/pkg/release/version_test.go
+++ b/pkg/release/version_test.go
@@ -5,6 +5,126 @@ import (
 	"time"
 )
 
+func TestVersionInfo_Equivalent(t *testing.T) {
+	now := time.Now()
+	later := now.Add(5 * time.Minute)
+
+	tests := []struct {
+		name     string
+		v        VersionInfo
+		other    VersionInfo
+		expected bool
+	}{
+		{
+			name: "matching commits are equivalent regardless of build date",
+			v: VersionInfo{
+				Version:   "main:abc1234",
+				Commit:    "abc1234def567",
+				BuildDate: later,
+			},
+			other: VersionInfo{
+				Version:   "main:abc1234",
+				Commit:    "abc1234def567",
+				BuildDate: now,
+			},
+			expected: true,
+		},
+		{
+			name: "different commits are not equivalent",
+			v: VersionInfo{
+				Version: "main:abc1234",
+				Commit:  "abc1234def567",
+			},
+			other: VersionInfo{
+				Version: "main:def5678",
+				Commit:  "def5678abc123",
+			},
+			expected: false,
+		},
+		{
+			name: "unknown commits fall back to version + build date",
+			v: VersionInfo{
+				Version:   "v0.2.0",
+				Commit:    "unknown",
+				BuildDate: now,
+			},
+			other: VersionInfo{
+				Version:   "v0.2.0",
+				Commit:    "unknown",
+				BuildDate: now,
+			},
+			expected: true,
+		},
+		{
+			name: "unknown commits with different build dates not equivalent",
+			v: VersionInfo{
+				Version:   "v0.2.0",
+				BuildDate: now,
+			},
+			other: VersionInfo{
+				Version:   "v0.2.0",
+				BuildDate: later,
+			},
+			expected: false,
+		},
+		{
+			name: "different versions not equivalent even with no commits",
+			v: VersionInfo{
+				Version: "v0.2.0",
+			},
+			other: VersionInfo{
+				Version: "v0.3.0",
+			},
+			expected: false,
+		},
+		{
+			name: "same version, no commits, no build dates - equivalent",
+			v: VersionInfo{
+				Version: "main:abc1234",
+			},
+			other: VersionInfo{
+				Version: "main:abc1234",
+			},
+			expected: true,
+		},
+		{
+			name: "drift: same version string but different commits",
+			v: VersionInfo{
+				Version: "main",
+				Commit:  "0a13763abcdef",
+			},
+			other: VersionInfo{
+				Version: "main",
+				Commit:  "9876543210fed",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.v.Equivalent(tt.other)
+			if got != tt.expected {
+				t.Errorf("Equivalent() = %v, expected %v", got, tt.expected)
+			}
+			// Equivalence is symmetric
+			rev := tt.other.Equivalent(tt.v)
+			if rev != tt.expected {
+				t.Errorf("Equivalent() not symmetric: forward=%v reverse=%v", got, rev)
+			}
+		})
+	}
+}
+
+func TestGetRunningServiceVersion_NotFound(t *testing.T) {
+	// No real service named this should exist; ensure we get an error
+	// rather than a panic. Mirrors the TestIsServerRunning style.
+	_, err := GetRunningServiceVersion("definitely-not-a-real-miren-service-xyz")
+	if err == nil {
+		t.Error("expected error for non-existent service, got nil")
+	}
+}
+
 func TestVersionInfo_IsNewer(t *testing.T) {
 	now := time.Now()
 	later := now.Add(5 * time.Minute)


### PR DESCRIPTION
The repro from MIR-1036: on a runner host, `miren upgrade` happens to update the release-dir binary at /var/lib/miren/release/miren as a side effect. A subsequent `miren runner upgrade --channel main` reads that same binary, decides "already at the target version", and exits — without restarting the service. The daemon PID keeps executing the previous binary inode, which is exactly what you didn't want. `--force` worked around it, but only because force re-downloads a binary you already had just to trigger a restart.

The version check was answering the wrong question. "Is the on-disk binary at the target version?" is fine for deciding whether to download. But "do we need a restart?" is a separate question, and the right answer comes from comparing the running daemon's version against the on-disk binary. So the fix splits those concerns: when the on-disk binary matches the target, we still check whether the running daemon matches the on-disk binary, and if there's drift we just restart (no download). We get the running daemon's version by exec'ing /proc/<MainPID>/exe — the kernel keeps the original inode alive as long as the process holds an exec mapping to it, so this works even after the install path has been atomically replaced.

Same plumbing applies to `server upgrade` since both share the upgrade helper. The `--check` mode surfaces drift directly now, so you can spot the situation without invoking an upgrade.

Picked up an unrelated bonus along the way: `miren logs --format json` was rendering timestamps in the host's local timezone because `time.Unix()` returns a `time.Time` with `Location: Local`. The test for it pinned the expected output to UTC and only passed on UTC hosts. Adding `.UTC()` before formatting makes both the production code and the test TZ-independent. Human text output is untouched.

Closes MIR-1036