### PR TITLE
Refresh runner node version on each startup

### DIFF
--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -101,7 +101,10 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 		runnerDone <- runner.Start(ctx)
 	}()
 
-	defer runner.Close()
+	defer func() {
+		cancel()
+		runner.Close()
+	}()
 
 	cfg, err := coord.LocalConfig()
 	r.NoError(err)

--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -19,6 +19,7 @@ import (
 	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/testutils"
+	"miren.dev/runtime/version"
 )
 
 func TestRunnerCoordinatorIntegration(t *testing.T) {
@@ -165,6 +166,10 @@ nodeReady:
 	r.True(ok)
 
 	r.Equal(compute.NodeStatusReadyId, status.Value.Id())
+
+	nodeVersion, ok := node.Get(compute.NodeVersionId)
+	r.True(ok, "node entity should have version attr after startup")
+	r.Equal(version.GetInfo().Version, nodeVersion.Value.String())
 
 	// Create and start the scheduler controller
 	scheduler := schedulerctrl.NewController(testDeps.Log, &eac)

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -44,6 +44,7 @@ import (
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/saga"
 	"miren.dev/runtime/servers/exec"
+	"miren.dev/runtime/version"
 )
 
 type RunnerConfig struct {
@@ -553,6 +554,7 @@ func (r *Runner) setupEntity(ctx context.Context, ec *entityserver.Client) error
 		Name:        r.Name,
 		Constraints: types.LabelSet("compute", "generic", "role", role),
 		ApiAddress:  r.ListenAddress,
+		Version:     version.GetInfo().Version,
 	}
 
 	r.Log.Info("Registering node entity", "role", role, "address", r.ListenAddress)


### PR DESCRIPTION
The bug from MIR-918 was small but satisfying. `setupEntity` runs every time a runner starts, but the `compute.Node` struct it built left `Version` unset. The field got seeded once during the initial Join RPC and was never touched again, so after upgrading binaries and restarting, `miren runner list` kept reporting the old version. One field added to the struct closes that loop.

While writing the regression test I noticed the existing integration test took 124 seconds to fail when the assertion didn't hold. Turned out to be a defer ordering quirk where the test context cancel ran after runner cleanup, leaving testDeps stuck waiting for the `runner.Start` goroutine to exit on its own context timeout. Combined cancel + close into one defer at the right point, and failures now surface in about 8 seconds. Split it out as the first commit so it stands on its own.

Closes MIR-918