### PR TITLE
Docs a11y cleanup

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -139,6 +139,7 @@ const config: Config = {
           href: 'https://github.com/mirendev/runtime',
           label: 'GitHub',
           position: 'right',
+          'aria-label': 'GitHub repository (opens in new tab)',
         },
       ],
     },

--- a/docs/src/components/CliCommand.tsx
+++ b/docs/src/components/CliCommand.tsx
@@ -20,11 +20,14 @@ export default function CliCommand({
   context: Context;
   children: React.ReactNode;
 }) {
+  const labels = badges[context];
+  const description = `Runs on: ${labels.join(" and ").toLowerCase()}`;
+
   return (
-    <div className="cli-command">
+    <div className="cli-command" role="group" aria-label={description}>
       <div className="cli-command__body">{children}</div>
-      <div className="cli-command__footer">
-        {badges[context].map((label) => (
+      <div className="cli-command__footer" aria-hidden="true">
+        {labels.map((label) => (
           <span key={label} className={`cli-command__badge ${badgeClass[label]}`}>
             {label}
           </span>

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -742,6 +742,7 @@ a:hover {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 
@@ -750,4 +751,37 @@ a:hover {
   outline: 2px solid var(--ifm-color-primary);
   outline-offset: 2px;
   border-radius: 0.25rem;
+}
+
+[data-theme='dark'] *:focus-visible {
+  outline-color: var(--miren-topaz-300);
+}
+
+/* Skip-to-content link */
+.skipToContent_node_modules-\@docusaurus-theme-classic-lib-theme-SkipToContent-styles-module,
+[class*="skipToContent"] {
+  background: var(--ifm-color-primary);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  font-weight: var(--ifm-font-weight-semibold);
+  border-radius: 0 0 0.375rem 0;
+  z-index: 1000;
+}
+
+/* Windows High Contrast Mode support */
+@media (forced-colors: active) {
+  .gradient-text {
+    background: none;
+    -webkit-background-clip: unset;
+    background-clip: unset;
+    -webkit-text-fill-color: LinkText;
+  }
+
+  .cli-command__badge {
+    border: 1px solid ButtonText;
+  }
+
+  *:focus-visible {
+    outline: 2px solid Highlight;
+  }
 }


### PR DESCRIPTION
found some mini a11y issues when i was working on search

## Summary
- Add `aria-label` to GitHub navbar link for screen readers
- Add `role="group"` and accessible descriptions to CLI command context badges, with decorative badges hidden from assistive tech
- Improve focus-visible styles for dark mode and high contrast mode (Windows)
- Style the skip-to-content link and add `scroll-behavior: auto` for reduced-motion users

Fixes MIR-1095