### PR TITLE
Add /etc/hosts entry mapping sandbox IP to hostname

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1252,6 +1252,10 @@ func (c *SandboxController) AllocateNetwork(
 }
 
 func (c *SandboxController) setupHosts(sb *compute.Sandbox, name string, ep *network.EndpointConfig) error {
+	if ep == nil || len(ep.Addresses) == 0 {
+		return fmt.Errorf("no addresses allocated for sandbox %s", sb.ID)
+	}
+
 	var lines []string
 
 	lines = append(lines, "# The following lines are managed by runtime.computer")

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1251,12 +1251,16 @@ func (c *SandboxController) AllocateNetwork(
 	return ep, nil
 }
 
-func (c *SandboxController) setupHosts(sb *compute.Sandbox, name string) error {
+func (c *SandboxController) setupHosts(sb *compute.Sandbox, name string, ep *network.EndpointConfig) error {
 	var lines []string
 
 	lines = append(lines, "# The following lines are managed by runtime.computer")
-	lines = append(lines, fmt.Sprintf("127.0.0.1\tlocalhost localhost.localdomain %s", name))
-	lines = append(lines, fmt.Sprintf("::1\tlocalhost localhost.localdomain %s", name))
+	lines = append(lines, "127.0.0.1\tlocalhost localhost.localdomain")
+	lines = append(lines, "::1\tlocalhost localhost.localdomain")
+
+	for _, prefix := range ep.Addresses {
+		lines = append(lines, fmt.Sprintf("%s\t%s", prefix.Addr(), name))
+	}
 
 	for _, addr := range sb.Spec.StaticHost {
 		lines = append(lines, fmt.Sprintf("%s\t%s", addr.Ip, addr.Host))
@@ -1376,7 +1380,7 @@ func (c *SandboxController) BuildSpec(
 		return nil, err
 	}
 
-	err = c.setupHosts(sb, sandboxHostname(sb.ID))
+	err = c.setupHosts(sb, sandboxHostname(sb.ID), ep)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "134aede57e930f58ae82bdc867de9a03d20eef2d110191ea5b696b15f74da592",
+		"sandbox.go":  "db857972e4383cb4d5de0ec8428e74726fb803c314663898fa5338e04f898266",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "d0116681a04feb8dc09a346e185ac3ba8f30436c0835d9e5340986e9c763a495",
+		"sandbox.go":  "134aede57e930f58ae82bdc867de9a03d20eef2d110191ea5b696b15f74da592",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}


### PR DESCRIPTION
## Summary
- Map each sandbox's allocated IP address(es) to its hostname in `/etc/hosts`, so processes that resolve their own hostname (e.g., EPMD) get the real sandbox IP instead of loopback
- Move hostname off the `127.0.0.1`/`::1` localhost lines to dedicated IP→hostname entries
- Update frozen hash for `sandbox.go` (saga path shares `BuildSpec` → `setupHosts`, so both controllers are covered)

Closes MIR-1100

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (including frozen file hash check)
- [ ] Manual: start a sandbox, exec in, verify `cat /etc/hosts` shows `<sandbox-ip> <hostname>` instead of hostname on the localhost line