### PR TITLE
Install NodePort DNAT rules on every node

### DIFF
--- a/blackbox/distributed_runner_test.go
+++ b/blackbox/distributed_runner_test.go
@@ -5,6 +5,7 @@ package blackbox
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,4 +117,34 @@ func TestDistributedRunnerLogs(t *testing.T) {
 			return false, "no app startup log yet"
 		},
 	)
+}
+
+// TestDistributedRunnerNodePort guards the MIR-1032 fix: NodePort DNAT rules
+// must install on every node that runs the service controller (coordinator
+// and all runners), not only on the node hosting the sandbox. The tcp-echo
+// testdata app declares node_port = 7000, so after deploy every peer's nft
+// service_nodeports map must contain an entry for tcp/7000.
+func TestDistributedRunnerNodePort(t *testing.T) {
+	c := harness.NewCluster(t)
+	skipIfNotDistributed(t, c)
+	m := harness.NewMiren(t, c)
+
+	harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "tcp-echo",
+	})
+
+	for _, peer := range []string{"coordinator", "runner1"} {
+		harness.Poll(t, fmt.Sprintf("nodeport rule on %s", peer), 60*time.Second, 2*time.Second,
+			func() (bool, string) {
+				r := m.PeerExec(peer, "nft", "list", "map", "inet", "miren", "service_nodeports")
+				if !r.Success() {
+					return false, fmt.Sprintf("nft list map failed (exit %d): %s", r.ExitCode, strings.TrimSpace(r.Stderr))
+				}
+				if !strings.Contains(r.Stdout, "tcp . 7000") {
+					return false, fmt.Sprintf("service_nodeports has no entry for tcp/7000 on %s yet", peer)
+				}
+				return true, ""
+			},
+		)
+	}
 }

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -158,8 +158,11 @@ func (s *ServiceController) endpointChain(ip netip.Addr, port uint16, proto stri
 	return fmt.Sprintf("endpoint_%s", base58.Encode(x[:]))
 }
 
-func (s *ServiceController) nodeportChain(ip netip.Addr, port uint16, proto string) string {
-	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%s:%d", ip.String(), proto, port)))
+// nodeportChain names the per-NodePort chain. NodePort dispatch is a property
+// of the cluster-facing port, so the key is (proto, nport) — independent of
+// any service IP, which a service may not yet have when this chain installs.
+func (s *ServiceController) nodeportChain(nport int, proto string) string {
+	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%d", proto, nport)))
 	return fmt.Sprintf("nodeport_%s", base58.Encode(x[:]))
 }
 
@@ -217,30 +220,52 @@ func (s *ServiceController) updateServiceEndpoints(cmd *nftCommands, sip netip.A
 	return nil
 }
 
-func (s *ServiceController) setupNodePort(cmd *nftCommands, nport int, sip netip.Addr, sport int, proto string) error {
-	chain := s.nodeportChain(sip, uint16(sport), proto)
-
-	if cmd.knownChains.Contains(chain) {
+// setupNodePort installs a per-NodePort chain that DNATs traffic landing on
+// this node's NodePort to one of the service's endpoint sandbox IPs, picked at
+// random. It mirrors the shape of the service-IP chain (counter, masq for
+// non-routable sources, random-vmap dispatch to endpoint chains) but stands
+// alone so that NodePort works on every node regardless of whether the service
+// has an allocated cluster IP yet.
+func (s *ServiceController) setupNodePort(cmd *nftCommands, nport int, proto string, endpoints []string) error {
+	if len(endpoints) == 0 {
 		return nil
 	}
 
-	cmd.knownChains.Add(chain)
+	chain := s.nodeportChain(nport, proto)
 
-	cmd.append("add chain inet %s %s", s.table, chain)
+	slices.Sort(endpoints)
 
-	cmd.append("add element inet %s service_nodeports { %s . %d : goto %s }", s.table, proto, nport, chain)
+	s.mu.Lock()
+	if cur, ok := s.chainEndpoints[chain]; ok && slices.Equal(cur, endpoints) {
+		s.mu.Unlock()
+		return nil
+	}
+	s.chainEndpoints[chain] = endpoints
+	s.mu.Unlock()
+
+	if cmd.knownChains.Contains(chain) {
+		cmd.append("flush chain inet %s %s", s.table, chain)
+	} else {
+		cmd.knownChains.Add(chain)
+		cmd.append("add chain inet %s %s", s.table, chain)
+		cmd.append("add element inet %s service_nodeports { %s . %d : goto %s }", s.table, proto, nport, chain)
+	}
 
 	cmd.append("add rule inet %s %s counter name \"nodeports\"", s.table, chain)
 	for _, rp := range s.routablePrefixes {
 		if rp.Addr().Is4() {
-			cmd.append("add rule inet %s %s ip saddr == %s goto %s", s.table, chain, rp.String(), s.serviceChain(sip, uint16(sport), proto))
+			cmd.append("add rule inet %s %s ip saddr != %s counter jump mark-for-masq", s.table, chain, rp.String())
 		} else {
-			cmd.append("add rule inet %s %s ip6 saddr == %s goto %s", s.table, chain, rp.String(), s.serviceChain(sip, uint16(sport), proto))
+			cmd.append("add rule inet %s %s ip6 saddr != %s counter jump mark-for-masq", s.table, chain, rp.String())
 		}
 	}
 
-	cmd.append("add rule inet %s %s fib saddr type local counter jump mark-for-masq", s.table, chain)
-	cmd.append("add rule inet %s %s fib saddr type local counter goto %s", s.table, chain, s.serviceChain(sip, uint16(sport), proto))
+	vmap := make([]string, len(endpoints))
+	for i, ep := range endpoints {
+		vmap[i] = fmt.Sprintf("%d : goto %s", i, ep)
+	}
+	cmd.append("add rule inet %s %s numgen random mod %d vmap { %s }", s.table, chain, len(endpoints), strings.Join(vmap, ", "))
+
 	return nil
 }
 
@@ -455,10 +480,6 @@ func (s *ServiceController) apply(ctx context.Context, cmd *nftCommands) error {
 func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Service, meta *entity.Meta) error {
 	s.Log.Info("Creating service", "service", srv)
 
-	if len(srv.Ip) == 0 {
-		return nil
-	}
-
 	lr, err := s.EAC.List(ctx, entity.Ref(network_v1alpha.EndpointsServiceId, srv.ID))
 	if err != nil {
 		return fmt.Errorf("failed to list endpoints: %w", err)
@@ -466,61 +487,79 @@ func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Ser
 
 	cmd := s.cmd.Clone()
 
-	var firstIp netip.Addr
+	// Build endpoint chains once, keyed by the public-facing port. Both the
+	// service-IP path and the NodePort path consume the same set so that a
+	// service with a NodePort but no allocated cluster IP still gets DNAT
+	// installed on every node.
+	type portKey struct {
+		Port  int64
+		Proto string
+	}
+	epChainsByPort := make(map[portKey][]string, len(srv.Port))
+	for _, tp := range srv.Port {
+		target := tp.TargetPort
+		if target == 0 {
+			target = tp.Port
+		}
+		proto := nftProto(tp.Protocol)
+		key := portKey{Port: tp.Port, Proto: proto}
 
+		for _, ent := range lr.Values() {
+			var eps network_v1alpha.Endpoints
+			eps.Decode(ent.Entity())
+
+			for _, ep := range eps.Endpoint {
+				destIP, err := netip.ParseAddr(ep.Ip)
+				if err != nil {
+					return fmt.Errorf("failed to parse endpoint IP address: %v", err)
+				}
+
+				chain, err := s.setupEndpointChain(cmd, destIP, uint16(target), proto)
+				if err != nil {
+					return fmt.Errorf("failed to setup endpoint chain: %w", err)
+				}
+
+				epChainsByPort[key] = append(epChainsByPort[key], chain)
+			}
+		}
+	}
+
+	// Service-IP path: for cluster-internal traffic to <serviceIP>:<port>.
+	// Skipped when the service has no allocated IP.
 	for _, sip := range srv.Ip {
 		ip, err := netip.ParseAddr(sip)
 		if err != nil {
 			return fmt.Errorf("failed to parse service IP address: %w", err)
 		}
 
-		if !firstIp.IsValid() {
-			firstIp = ip
-		}
-
 		for _, tp := range srv.Port {
-			target := tp.TargetPort
-			if target == 0 {
-				target = tp.Port
-			}
 			proto := nftProto(tp.Protocol)
-
-			var epChains []string
-			for _, ent := range lr.Values() {
-				var eps network_v1alpha.Endpoints
-				eps.Decode(ent.Entity())
-
-				for _, ep := range eps.Endpoint {
-					destIP, err := netip.ParseAddr(ep.Ip)
-					if err != nil {
-						return fmt.Errorf("failed to parse endpoint IP address: %v", err)
-					}
-
-					chain, err := s.setupEndpointChain(cmd, destIP, uint16(target), proto)
-					if err != nil {
-						return fmt.Errorf("failed to setup endpoint chain: %w", err)
-					}
-
-					epChains = append(epChains, chain)
-				}
-			}
+			key := portKey{Port: tp.Port, Proto: proto}
 
 			if err := s.createServiceChain(cmd, ip, int(tp.Port), proto); err != nil {
 				return fmt.Errorf("failed to create service chain: %w", err)
 			}
 
-			if err := s.updateServiceEndpoints(cmd, ip, int(tp.Port), proto, epChains); err != nil {
+			if err := s.updateServiceEndpoints(cmd, ip, int(tp.Port), proto, epChainsByPort[key]); err != nil {
 				return fmt.Errorf("failed to update service endpoints: %w", err)
 			}
 		}
 	}
 
+	// NodePort path: every node that runs the controller installs this rule,
+	// independent of where the service's sandboxes live, so external traffic
+	// to <any-node>:<nport> reaches the service. Same model as Kubernetes
+	// kube-proxy: any node answers, cluster routing carries the DNAT'd packet
+	// to the right sandbox.
 	for _, tp := range srv.Port {
-		if tp.NodePort != 0 {
-			proto := nftProto(tp.Protocol)
-			if err := s.setupNodePort(cmd, int(tp.NodePort), firstIp, int(tp.Port), proto); err != nil {
-				return fmt.Errorf("failed to setup node port: %w", err)
-			}
+		if tp.NodePort == 0 {
+			continue
+		}
+		proto := nftProto(tp.Protocol)
+		key := portKey{Port: tp.Port, Proto: proto}
+
+		if err := s.setupNodePort(cmd, int(tp.NodePort), proto, epChainsByPort[key]); err != nil {
+			return fmt.Errorf("failed to setup node port: %w", err)
 		}
 	}
 

--- a/controllers/service/service_test.go
+++ b/controllers/service/service_test.go
@@ -893,6 +893,169 @@ func TestServiceController(t *testing.T) {
 		r.NoError(err)
 	})
 
+	t.Run("installs nodeport chain without service IP", func(t *testing.T) {
+		// MIR-1032: a service with a NodePort must install the NodePort DNAT
+		// chain on every node, including nodes that don't host the sandbox and
+		// even when the service has no allocated cluster IP yet. Before the
+		// fix, Create() returned early when srv.Ip was empty so the NodePort
+		// rule was never installed on the coordinator.
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		testDeps, cleanup := testutils.NewTestDeps()
+		defer cleanup()
+
+		eac := testDeps.EAC
+
+		sc, err := newServiceController(testDeps)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "rust-chat"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name:     "console",
+					Port:     6669,
+					NodePort: 30669,
+				},
+			},
+		}
+
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetAttrs(entity.New(
+			entity.Keyword(entity.Ident, svcID.String()),
+			svc.Encode).Attrs())
+		_, err = eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		epID := entity.Id("endpoints-" + svcID.String())
+		eps := &network_v1alpha.Endpoints{
+			ID:      epID,
+			Service: svcID,
+			Endpoint: []network_v1alpha.Endpoint{
+				{Ip: "10.8.103.56", Port: 6669},
+			},
+		}
+
+		var epRPC entityserver_v1alpha.Entity
+		epRPC.SetAttrs(entity.New(
+			entity.Keyword(entity.Ident, epID.String()),
+			eps.Encode).Attrs())
+		_, err = eac.Put(ctx, &epRPC)
+		r.NoError(err)
+
+		svcEntity := entity.New(svc.Encode)
+		meta := &entity.Meta{Entity: svcEntity, Revision: 1}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		npChain := sc.nodeportChain(30669, "tcp")
+		epIP := netip.MustParseAddr("10.8.103.56")
+		expectedEpChain := sc.endpointChain(epIP, 6669, "tcp")
+
+		sc.mu.Lock()
+		got, ok := sc.chainEndpoints[npChain]
+		sc.mu.Unlock()
+
+		r.True(ok, "NodePort chain should be tracked even without a service IP")
+		r.Equal([]string{expectedEpChain}, got, "NodePort chain should DNAT to the endpoint chain")
+	})
+
+	t.Run("rebuilds nodeport vmap when endpoints change", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		testDeps, cleanup := testutils.NewTestDeps()
+		defer cleanup()
+
+		eac := testDeps.EAC
+
+		sc, err := newServiceController(testDeps)
+		r.NoError(err)
+
+		err = sc.Init(ctx)
+		r.NoError(err)
+
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID: svcID,
+			Match: types.Labels{
+				types.Label{Key: "app", Value: "rust-chat"},
+			},
+			Port: []network_v1alpha.Port{
+				{
+					Name:     "console",
+					Port:     6669,
+					NodePort: 30669,
+				},
+			},
+		}
+
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetAttrs(entity.New(
+			entity.Keyword(entity.Ident, svcID.String()),
+			svc.Encode).Attrs())
+		_, err = eac.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		epID := entity.Id("endpoints-" + svcID.String())
+		eps := &network_v1alpha.Endpoints{
+			ID:      epID,
+			Service: svcID,
+			Endpoint: []network_v1alpha.Endpoint{
+				{Ip: "10.8.103.56", Port: 6669},
+			},
+		}
+
+		var epRPC entityserver_v1alpha.Entity
+		epRPC.SetAttrs(entity.New(
+			entity.Keyword(entity.Ident, epID.String()),
+			eps.Encode).Attrs())
+		putRes, err := eac.Put(ctx, &epRPC)
+		r.NoError(err)
+		epRevision := putRes.Revision()
+
+		svcEntity := entity.New(svc.Encode)
+		meta := &entity.Meta{Entity: svcEntity, Revision: 1}
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		npChain := sc.nodeportChain(30669, "tcp")
+
+		sc.mu.Lock()
+		first := append([]string{}, sc.chainEndpoints[npChain]...)
+		sc.mu.Unlock()
+		r.Len(first, 1, "expected one endpoint chain after first reconcile")
+
+		eps.Endpoint = append(eps.Endpoint, network_v1alpha.Endpoint{Ip: "10.8.104.42", Port: 6669})
+		updated := entity.New(
+			entity.Keyword(entity.Ident, epID.String()),
+			eps.Encode)
+		_, err = eac.Replace(ctx, updated.Attrs(), epRevision)
+		r.NoError(err)
+
+		err = sc.Create(ctx, svc, meta)
+		r.NoError(err)
+
+		sc.mu.Lock()
+		second := append([]string{}, sc.chainEndpoints[npChain]...)
+		sc.mu.Unlock()
+
+		r.Len(second, 2, "expected NodePort chain to track both endpoint chains after rebuild")
+		r.NotEqual(first, second, "NodePort chain endpoint set should change when endpoints change")
+	})
+
 	t.Run("creates per-port endpoint chains for multi-port services", func(t *testing.T) {
 		r := require.New(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
NodePort services were unreachable whenever the sandbox landed on a distributed runner, and `nc -z chat.miren.toys 30669` would refuse the connection while the rule sat correctly installed on the runner hosting the sandbox. Felt like a clear "every-node-should-have-this-rule" gap, but the picture got more interesting once we dug in.

ServiceController already runs on every node (the coordinator runs a runner-style component with `IsCoordinator: true`) and watches every Service entity by Kind, not by node. So the cluster-wide install model was already wired. Why wasn't it working?

Two things, layered. The per-NodePort nft chain was keyed on `(serviceIP, servicePort, proto)`, and `setupNodePort` had an "already created this chain, skipping" shortcut. When a service redeployed with a new NodePort but kept the same service IP and port, the chain name didn't change, so the shortcut fired and the new `service_nodeports { tcp . NPORT : goto … }` map element was never added. The April 21 logs on toys captured exactly this: rust-chat went from `node_port = 6669` to `node_port = 30669`, the coordinator's `Creating service` fired with the new NodePort, but the map element stayed pointing at the old one.

The fix for that part is small: rekey on `(proto, NodePort)`. The map already looks up on those two; the chain name should follow.

While we were in there, we also lifted the early-return-on-empty-Ip in `Create()` (which would otherwise skip NodePort install during the first-reconcile race before the IP allocator runs) and decoupled NodePort from the service chain entirely. The two install paths now share a (port, proto)-keyed endpoint-chain map and run independently. NodePort no longer `goto`s into a service chain; it stands alone with its own counter/masq/vmap. Bonus: it now rebuilds when endpoints change, which the old code silently dropped.

Test coverage at three levels: unit tests for the no-IP and endpoint-rebuild cases, plus a focused `TestDistributedRunnerNodePort` blackbox that deploys tcp-echo (which declares `node_port = 7000`) and verifies the `service_nodeports` map element shows up on both the coordinator and runner1.

Tagging the terraform `node-port` firewall tag work for the runner module as a separate followup against the infra repo. Runners in `miren-development` have no external IP today, so it doesn't block this fix.

Closes MIR-1032