### PR TITLE
Add shared-password auth for protected routes

### DIFF
--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -364,7 +364,6 @@ func (c *Client) AttachOIDCProvider(ctx context.Context, host string, providerNa
 
 // AttachOIDCProviderToRoute associates an OIDC provider with an already-resolved route
 func (c *Client) AttachOIDCProviderToRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute, providerName string, claimMappings []ingress_v1alpha.ClaimMappings) (*ingress_v1alpha.HttpRoute, error) {
-	// Look up provider
 	provider, err := c.GetOIDCProvider(ctx, providerName)
 	if err != nil {
 		return nil, err
@@ -374,13 +373,11 @@ func (c *Client) AttachOIDCProviderToRoute(ctx context.Context, route *ingress_v
 		return nil, fmt.Errorf("OIDC provider not found: %s", providerName)
 	}
 
-	// Update route with provider reference and claim mappings.
-	// Clear password provider for mutual exclusion.
-	route.OidcProvider = provider.ID
-	route.ClaimMappings = claimMappings
-	route.PasswordProvider = ""
-
-	return route, c.replaceRoute(ctx, route)
+	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
+		r.OidcProvider = provider.ID
+		r.ClaimMappings = claimMappings
+		r.PasswordProvider = ""
+	})
 }
 
 // DetachOIDCProvider removes OIDC provider association from a route
@@ -399,34 +396,39 @@ func (c *Client) DetachOIDCProvider(ctx context.Context, host string) (*ingress_
 
 // DetachOIDCProviderFromRoute removes OIDC provider association from an already-resolved route
 func (c *Client) DetachOIDCProviderFromRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
-	route.OidcProvider = ""
-	route.ClaimMappings = nil
-	route.PasswordProvider = ""
-
-	return route, c.replaceRoute(ctx, route)
+	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
+		r.OidcProvider = ""
+		r.ClaimMappings = nil
+		r.PasswordProvider = ""
+	})
 }
 
-// replaceRoute replaces the full set of route attributes in the entity store.
-// This is used instead of Update when clearing ref fields, because the
-// generated Encode() omits empty fields and the merge-based Update would
-// leave stale refs in place.
-func (c *Client) replaceRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) error {
-	gr, err := c.eac.Get(ctx, string(route.EntityId()))
+// mutateAndReplaceRoute performs a read-modify-write on a route entity.
+// It fetches the latest version from the store, applies the mutate function,
+// and replaces the entity at the current revision. This avoids overwriting
+// concurrent changes that a stale route instance would miss.
+func (c *Client) mutateAndReplaceRoute(ctx context.Context, routeID entity.Id, mutate func(*ingress_v1alpha.HttpRoute)) (*ingress_v1alpha.HttpRoute, error) {
+	gr, err := c.eac.Get(ctx, string(routeID))
 	if err != nil {
-		return fmt.Errorf("failed to get route entity for replace: %w", err)
+		return nil, fmt.Errorf("failed to get route entity for replace: %w", err)
 	}
+
+	var route ingress_v1alpha.HttpRoute
+	route.Decode(gr.Entity().Entity())
+
+	mutate(&route)
 
 	attrs := entity.New(
 		route.Encode,
-		entity.DBId, route.EntityId(),
+		entity.DBId, routeID,
 	).Attrs()
 
 	_, err = c.eac.Replace(ctx, attrs, gr.Entity().Revision())
 	if err != nil {
-		return fmt.Errorf("failed to replace route entity: %w", err)
+		return nil, fmt.Errorf("failed to replace route entity: %w", err)
 	}
 
-	return nil
+	return &route, nil
 }
 
 // CreateOrUpdatePasswordProvider creates or updates a password provider
@@ -510,23 +512,18 @@ func (c *Client) AttachPasswordProviderToRoute(ctx context.Context, route *ingre
 		return nil, fmt.Errorf("password provider not found: %s", providerName)
 	}
 
-	// Set password provider, clear OIDC for mutual exclusion
-	route.PasswordProvider = provider.ID
-	route.OidcProvider = ""
-	route.ClaimMappings = nil
-
-	return route, c.replaceRoute(ctx, route)
+	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
+		r.PasswordProvider = provider.ID
+		r.OidcProvider = ""
+		r.ClaimMappings = nil
+	})
 }
 
 // DetachPasswordProviderFromRoute removes password provider association from a route
 func (c *Client) DetachPasswordProviderFromRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
-	route.PasswordProvider = ""
-
-	if err := c.replaceRoute(ctx, route); err != nil {
-		return nil, fmt.Errorf("failed to detach password provider from route: %w", err)
-	}
-
-	return route, nil
+	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
+		r.PasswordProvider = ""
+	})
 }
 
 func (c *Client) CreateWAFProfile(ctx context.Context, level int) (*ingress_v1alpha.WafProfile, error) {

--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -374,17 +374,13 @@ func (c *Client) AttachOIDCProviderToRoute(ctx context.Context, route *ingress_v
 		return nil, fmt.Errorf("OIDC provider not found: %s", providerName)
 	}
 
-	// Update route with provider reference and claim mappings
+	// Update route with provider reference and claim mappings.
+	// Clear password provider for mutual exclusion.
 	route.OidcProvider = provider.ID
 	route.ClaimMappings = claimMappings
+	route.PasswordProvider = ""
 
-	// Update the route
-	err = c.ec.Update(ctx, route)
-	if err != nil {
-		return nil, fmt.Errorf("failed to attach OIDC provider to route: %w", err)
-	}
-
-	return route, nil
+	return route, c.replaceRoute(ctx, route)
 }
 
 // DetachOIDCProvider removes OIDC provider association from a route
@@ -403,14 +399,131 @@ func (c *Client) DetachOIDCProvider(ctx context.Context, host string) (*ingress_
 
 // DetachOIDCProviderFromRoute removes OIDC provider association from an already-resolved route
 func (c *Client) DetachOIDCProviderFromRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
-	// Clear provider reference and claim mappings
+	route.OidcProvider = ""
+	route.ClaimMappings = nil
+	route.PasswordProvider = ""
+
+	return route, c.replaceRoute(ctx, route)
+}
+
+// replaceRoute replaces the full set of route attributes in the entity store.
+// This is used instead of Update when clearing ref fields, because the
+// generated Encode() omits empty fields and the merge-based Update would
+// leave stale refs in place.
+func (c *Client) replaceRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) error {
+	gr, err := c.eac.Get(ctx, string(route.EntityId()))
+	if err != nil {
+		return fmt.Errorf("failed to get route entity for replace: %w", err)
+	}
+
+	attrs := entity.New(
+		route.Encode,
+		entity.DBId, route.EntityId(),
+	).Attrs()
+
+	_, err = c.eac.Replace(ctx, attrs, gr.Entity().Revision())
+	if err != nil {
+		return fmt.Errorf("failed to replace route entity: %w", err)
+	}
+
+	return nil
+}
+
+// CreateOrUpdatePasswordProvider creates or updates a password provider
+func (c *Client) CreateOrUpdatePasswordProvider(ctx context.Context, provider *ingress_v1alpha.PasswordProvider) (*ingress_v1alpha.PasswordProvider, error) {
+	if provider.Name == "" {
+		return nil, fmt.Errorf("provider name is required")
+	}
+
+	_, err := c.ec.CreateOrUpdate(ctx, provider.Name, provider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create/update password provider: %w", err)
+	}
+
+	return provider, nil
+}
+
+// GetPasswordProvider looks up a password provider by name
+func (c *Client) GetPasswordProvider(ctx context.Context, name string) (*ingress_v1alpha.PasswordProvider, error) {
+	ia := entity.String(ingress_v1alpha.PasswordProviderNameId, name)
+
+	var provider ingress_v1alpha.PasswordProvider
+	err := c.ec.OneAtIndex(ctx, ia, &provider)
+	if err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to lookup password provider %s: %w", name, err)
+	}
+
+	return &provider, nil
+}
+
+// ListPasswordProviders returns all password providers
+func (c *Client) ListPasswordProviders(ctx context.Context) ([]*ingress_v1alpha.PasswordProvider, error) {
+	kindRes, err := c.eac.LookupKind(ctx, "password_provider")
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup password_provider kind: %w", err)
+	}
+
+	res, err := c.eac.List(ctx, kindRes.Attr())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list password providers: %w", err)
+	}
+
+	var providers []*ingress_v1alpha.PasswordProvider
+	for _, e := range res.Values() {
+		var provider ingress_v1alpha.PasswordProvider
+		provider.Decode(e.Entity())
+		providers = append(providers, &provider)
+	}
+
+	return providers, nil
+}
+
+// DeletePasswordProvider deletes a password provider by name
+func (c *Client) DeletePasswordProvider(ctx context.Context, name string) error {
+	provider, err := c.GetPasswordProvider(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	if provider == nil {
+		return fmt.Errorf("password provider not found: %s", name)
+	}
+
+	if err := c.ec.Delete(ctx, provider.ID); err != nil {
+		return fmt.Errorf("failed to delete password provider: %w", err)
+	}
+
+	return nil
+}
+
+// AttachPasswordProviderToRoute associates a password provider with an already-resolved route
+func (c *Client) AttachPasswordProviderToRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute, providerName string) (*ingress_v1alpha.HttpRoute, error) {
+	provider, err := c.GetPasswordProvider(ctx, providerName)
+	if err != nil {
+		return nil, err
+	}
+
+	if provider == nil {
+		return nil, fmt.Errorf("password provider not found: %s", providerName)
+	}
+
+	// Set password provider, clear OIDC for mutual exclusion
+	route.PasswordProvider = provider.ID
 	route.OidcProvider = ""
 	route.ClaimMappings = nil
 
-	// Update the route
-	err := c.ec.Update(ctx, route)
-	if err != nil {
-		return nil, fmt.Errorf("failed to detach OIDC provider from route: %w", err)
+	return route, c.replaceRoute(ctx, route)
+}
+
+// DetachPasswordProviderFromRoute removes password provider association from a route
+func (c *Client) DetachPasswordProviderFromRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
+	route.PasswordProvider = ""
+
+	if err := c.replaceRoute(ctx, route); err != nil {
+		return nil, fmt.Errorf("failed to detach password provider from route: %w", err)
 	}
 
 	return route, nil

--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -348,58 +348,20 @@ func (c *Client) DeleteOIDCProvider(ctx context.Context, name string) error {
 	return nil
 }
 
-// AttachOIDCProvider associates an OIDC provider with a route and sets claim mappings
-func (c *Client) AttachOIDCProvider(ctx context.Context, host string, providerName string, claimMappings []ingress_v1alpha.ClaimMappings) (*ingress_v1alpha.HttpRoute, error) {
-	route, err := c.Lookup(ctx, host)
-	if err != nil {
-		return nil, err
-	}
-
-	if route == nil {
-		return nil, fmt.Errorf("route not found: %s", host)
-	}
-
-	return c.AttachOIDCProviderToRoute(ctx, route, providerName, claimMappings)
-}
-
-// AttachOIDCProviderToRoute associates an OIDC provider with an already-resolved route
-func (c *Client) AttachOIDCProviderToRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute, providerName string, claimMappings []ingress_v1alpha.ClaimMappings) (*ingress_v1alpha.HttpRoute, error) {
-	provider, err := c.GetOIDCProvider(ctx, providerName)
-	if err != nil {
-		return nil, err
-	}
-
-	if provider == nil {
-		return nil, fmt.Errorf("OIDC provider not found: %s", providerName)
-	}
-
+// AttachAuthProviderToRoute associates an auth provider with an already-resolved route.
+// The providerID should be the entity ID of either an OIDC or password provider.
+func (c *Client) AttachAuthProviderToRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute, providerID entity.Id, claimMappings []ingress_v1alpha.ClaimMappings) (*ingress_v1alpha.HttpRoute, error) {
 	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
-		r.OidcProvider = provider.ID
+		r.AuthProvider = providerID
 		r.ClaimMappings = claimMappings
-		r.PasswordProvider = ""
 	})
 }
 
-// DetachOIDCProvider removes OIDC provider association from a route
-func (c *Client) DetachOIDCProvider(ctx context.Context, host string) (*ingress_v1alpha.HttpRoute, error) {
-	route, err := c.Lookup(ctx, host)
-	if err != nil {
-		return nil, err
-	}
-
-	if route == nil {
-		return nil, fmt.Errorf("route not found: %s", host)
-	}
-
-	return c.DetachOIDCProviderFromRoute(ctx, route)
-}
-
-// DetachOIDCProviderFromRoute removes OIDC provider association from an already-resolved route
-func (c *Client) DetachOIDCProviderFromRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
+// DetachAuthProviderFromRoute removes auth provider association from a route
+func (c *Client) DetachAuthProviderFromRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
 	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
-		r.OidcProvider = ""
+		r.AuthProvider = ""
 		r.ClaimMappings = nil
-		r.PasswordProvider = ""
 	})
 }
 
@@ -499,31 +461,6 @@ func (c *Client) DeletePasswordProvider(ctx context.Context, name string) error 
 	}
 
 	return nil
-}
-
-// AttachPasswordProviderToRoute associates a password provider with an already-resolved route
-func (c *Client) AttachPasswordProviderToRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute, providerName string) (*ingress_v1alpha.HttpRoute, error) {
-	provider, err := c.GetPasswordProvider(ctx, providerName)
-	if err != nil {
-		return nil, err
-	}
-
-	if provider == nil {
-		return nil, fmt.Errorf("password provider not found: %s", providerName)
-	}
-
-	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
-		r.PasswordProvider = provider.ID
-		r.OidcProvider = ""
-		r.ClaimMappings = nil
-	})
-}
-
-// DetachPasswordProviderFromRoute removes password provider association from a route
-func (c *Client) DetachPasswordProviderFromRoute(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
-	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
-		r.PasswordProvider = ""
-	})
 }
 
 func (c *Client) CreateWAFProfile(ctx context.Context, level int) (*ingress_v1alpha.WafProfile, error) {

--- a/api/ingress/ingress_v1alpha/schema.gen.go
+++ b/api/ingress/ingress_v1alpha/schema.gen.go
@@ -6,30 +6,31 @@ import (
 )
 
 const (
-	HttpRouteAppId              = entity.Id("dev.miren.ingress/http_route.app")
-	HttpRouteClaimMappingsId    = entity.Id("dev.miren.ingress/http_route.claim_mappings")
-	HttpRouteDefaultId          = entity.Id("dev.miren.ingress/http_route.default")
-	HttpRouteHostId             = entity.Id("dev.miren.ingress/http_route.host")
-	HttpRouteOidcProviderId     = entity.Id("dev.miren.ingress/http_route.oidc_provider")
-	HttpRoutePasswordProviderId = entity.Id("dev.miren.ingress/http_route.password_provider")
-	HttpRouteWafProfileId       = entity.Id("dev.miren.ingress/http_route.waf_profile")
+	HttpRouteAppId           = entity.Id("dev.miren.ingress/http_route.app")
+	HttpRouteAuthProviderId  = entity.Id("dev.miren.ingress/http_route.auth_provider")
+	HttpRouteClaimMappingsId = entity.Id("dev.miren.ingress/http_route.claim_mappings")
+	HttpRouteDefaultId       = entity.Id("dev.miren.ingress/http_route.default")
+	HttpRouteHostId          = entity.Id("dev.miren.ingress/http_route.host")
+	HttpRouteWafProfileId    = entity.Id("dev.miren.ingress/http_route.waf_profile")
 )
 
 type HttpRoute struct {
-	ID               entity.Id       `json:"id"`
-	App              entity.Id       `cbor:"app,omitempty" json:"app,omitempty"`
-	ClaimMappings    []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
-	Default          bool            `cbor:"default,omitempty" json:"default,omitempty"`
-	Host             string          `cbor:"host,omitempty" json:"host,omitempty"`
-	OidcProvider     entity.Id       `cbor:"oidc_provider,omitempty" json:"oidc_provider,omitempty"`
-	PasswordProvider entity.Id       `cbor:"password_provider,omitempty" json:"password_provider,omitempty"`
-	WafProfile       entity.Id       `cbor:"waf_profile,omitempty" json:"waf_profile,omitempty"`
+	ID            entity.Id       `json:"id"`
+	App           entity.Id       `cbor:"app,omitempty" json:"app,omitempty"`
+	AuthProvider  entity.Id       `cbor:"auth_provider,omitempty" json:"auth_provider,omitempty"`
+	ClaimMappings []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
+	Default       bool            `cbor:"default,omitempty" json:"default,omitempty"`
+	Host          string          `cbor:"host,omitempty" json:"host,omitempty"`
+	WafProfile    entity.Id       `cbor:"waf_profile,omitempty" json:"waf_profile,omitempty"`
 }
 
 func (o *HttpRoute) Decode(e entity.AttrGetter) {
 	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
 	if a, ok := e.Get(HttpRouteAppId); ok && a.Value.Kind() == entity.KindId {
 		o.App = a.Value.Id()
+	}
+	if a, ok := e.Get(HttpRouteAuthProviderId); ok && a.Value.Kind() == entity.KindId {
+		o.AuthProvider = a.Value.Id()
 	}
 	for _, a := range e.GetAll(HttpRouteClaimMappingsId) {
 		if a.Value.Kind() == entity.KindComponent {
@@ -43,12 +44,6 @@ func (o *HttpRoute) Decode(e entity.AttrGetter) {
 	}
 	if a, ok := e.Get(HttpRouteHostId); ok && a.Value.Kind() == entity.KindString {
 		o.Host = a.Value.String()
-	}
-	if a, ok := e.Get(HttpRouteOidcProviderId); ok && a.Value.Kind() == entity.KindId {
-		o.OidcProvider = a.Value.Id()
-	}
-	if a, ok := e.Get(HttpRoutePasswordProviderId); ok && a.Value.Kind() == entity.KindId {
-		o.PasswordProvider = a.Value.Id()
 	}
 	if a, ok := e.Get(HttpRouteWafProfileId); ok && a.Value.Kind() == entity.KindId {
 		o.WafProfile = a.Value.Id()
@@ -75,18 +70,15 @@ func (o *HttpRoute) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.App) {
 		attrs = append(attrs, entity.Ref(HttpRouteAppId, o.App))
 	}
+	if !entity.Empty(o.AuthProvider) {
+		attrs = append(attrs, entity.Ref(HttpRouteAuthProviderId, o.AuthProvider))
+	}
 	for _, v := range o.ClaimMappings {
 		attrs = append(attrs, entity.Component(HttpRouteClaimMappingsId, v.Encode()))
 	}
 	attrs = append(attrs, entity.Bool(HttpRouteDefaultId, o.Default))
 	if !entity.Empty(o.Host) {
 		attrs = append(attrs, entity.String(HttpRouteHostId, o.Host))
-	}
-	if !entity.Empty(o.OidcProvider) {
-		attrs = append(attrs, entity.Ref(HttpRouteOidcProviderId, o.OidcProvider))
-	}
-	if !entity.Empty(o.PasswordProvider) {
-		attrs = append(attrs, entity.Ref(HttpRoutePasswordProviderId, o.PasswordProvider))
 	}
 	if !entity.Empty(o.WafProfile) {
 		attrs = append(attrs, entity.Ref(HttpRouteWafProfileId, o.WafProfile))
@@ -99,6 +91,9 @@ func (o *HttpRoute) Empty() bool {
 	if !entity.Empty(o.App) {
 		return false
 	}
+	if !entity.Empty(o.AuthProvider) {
+		return false
+	}
 	if len(o.ClaimMappings) != 0 {
 		return false
 	}
@@ -106,12 +101,6 @@ func (o *HttpRoute) Empty() bool {
 		return false
 	}
 	if !entity.Empty(o.Host) {
-		return false
-	}
-	if !entity.Empty(o.OidcProvider) {
-		return false
-	}
-	if !entity.Empty(o.PasswordProvider) {
 		return false
 	}
 	if !entity.Empty(o.WafProfile) {
@@ -122,12 +111,11 @@ func (o *HttpRoute) Empty() bool {
 
 func (o *HttpRoute) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Ref("app", "dev.miren.ingress/http_route.app", schema.Doc("The application to route to"), schema.Indexed, schema.Tags("dev.miren.app_ref"))
+	sb.Ref("auth_provider", "dev.miren.ingress/http_route.auth_provider", schema.Doc("Reference to an auth provider (OIDC or password) for authentication"), schema.Indexed)
 	sb.Component("claim_mappings", "dev.miren.ingress/http_route.claim_mappings", schema.Doc("Mappings from JWT claims to HTTP headers"), schema.Many)
 	(&ClaimMappings{}).InitSchema(sb.Builder("http_route.claim_mappings"))
 	sb.Bool("default", "dev.miren.ingress/http_route.default", schema.Doc("Whether this is the default route for routing"), schema.Indexed)
 	sb.String("host", "dev.miren.ingress/http_route.host", schema.Doc("The hostname to match on for the application"), schema.Indexed)
-	sb.Ref("oidc_provider", "dev.miren.ingress/http_route.oidc_provider", schema.Doc("Reference to an OIDC provider for authentication"), schema.Indexed)
-	sb.Ref("password_provider", "dev.miren.ingress/http_route.password_provider", schema.Doc("Reference to a password provider for simple authentication"), schema.Indexed)
 	sb.Ref("waf_profile", "dev.miren.ingress/http_route.waf_profile", schema.Doc("Reference to a WAF profile for request filtering"))
 }
 
@@ -400,5 +388,5 @@ func init() {
 		(&PasswordProvider{}).InitSchema(sb)
 		(&WafProfile{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x94\x96ے\xd30\f\x86_\x04\x86\xe3p&\xcc>Qƍ\x95Dԧ\xb5\xddn{\t3\f\x0f\xc2\xc2\x1b\xc25\x139%\xb1\x9du\xcd͎\xa2H\x9f\xf2ے\xb6\xf7\\1\t\xb7\x1c\x8e\x8dD\v\xaaA5Xp\x0e\xf6\xa8\xb8\xbb?=\xcb\xde|\x9a\xde4\xa3\xf7\xa6\xb5\xfa\xe0\xe1\x17\x11N\x8f\xf2\xc0%&\xd0\xfe\xf4\\K\x86*\xaf\xd6\xf7\b\x82\xbb\xef?v\xc8OOK\xa4\x86\x19C\x05\xbb\xc9\xf0g\x03;\xe4?\xa7\xb4\xf7ŴN0\x94\xaddƠ\x1a\x1c\x97L\x9d\x7f\x13G%o&$vZ\x1a\xad@\xf9Śe\xe6U\x9a\a\xabT\xaa\xfeJ\xaa_\xe5\x9f\x1f\xd3\x02\x9c\xbe\x02\x829}j\xef\xbcE5\x10\xe2\xf5U\xc4\b\x8c\x83%F?\xdb+\xc8p\x04\xebP\xab\xe1xÄ\x19\x990\x16%\xb3\xe7v\xd2!\tu!Q\xbd\x97\xc5\x13\xe7г\x83\xf0Tl\xb8<L\xd5\xf8NkA\x80\x8d\xe6Z\x01F\xedB6'+U\xfb\xae\x98\xac\x91w\xad\xb1\xfa\x88\x17\xc12vͭC\xa8\xa6\x882̹;my\x8c\xbb\xcd\xddk\xe4\x9b\"\xf2\x8e\xf5SZ\x8f\x02\b\xb6_;fL\xf16>/\xb0\xd3\xf3\aFtŜ\x9b\xf7q\x1e\xb9\n\xaal\xd7/\xa4\xefC\x11\xd5\x18f\x99\xd2\xc8Z\x01G\x10a\xd0\x12\xdf$\xb3C\xe5\x8b:\xd7\a\xb3\xd5o$4\xba\xd8Y\xea\x93<6\n\xab\x14\xfb\x8dľ\xbd\x02k:\x81\xa0|\x8b\x9c\x8a\xe3\xf2\x986\xed\xc7J\x92\x83\xceB\xe8~\x19\xbbR\xe2ơ\xc4D\x9a\xa0\xe5O\x9a\xbfq\x91q\xfe\xc5h\x0f6\\\xa4\x88<)oc\x8f\xc5<\xd7i\x03.\xec\xa0ٮ\xdeA\x11ikƨ\x1f\xb2ɜ{\xe2E\x1e\x9f\x85\xfe\xd7\xce\xde\xf8\x80\fx\xed\xfcoj\x18\xff<#sc\xe8\x8a\xd8U{\x82\xf9\xd6J\xc3\xf7n\xd4ַ\xe1\xdf\xffz\xcd\\\xff%\x10\rk\xc5VJ\xae\xb3j\xbcs\x01\xf5m\xf0\x17\x00\x00\xff\xff\x01\x00\x00\xff\xff\xf1\x8a٭\xec\b\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x94\x95ے\xd30\f\x86_\x04\x86\xe3p&\xcc>Qƍ\x95Dԧ\xb5\xddl{\t3\xf0\",\xbc!\\3\x91\xd3Ml\xa7\xa9\xf7\xa6\xa3\xca\xf2'K\xfe\xe5\xdcs\xc5$\xdcr\x18*\x89\x16T\x85\xaa\xb3\xe0\x1c\xecQqw\x7f|\x91\xad|\x19W\xaa\xde{S[}\xf0\xf0\x87\b\xc7'y\xe0\x1c\x13h\xffZ\xae%C\x95gk[\x04\xc1\xdd\xcf_;\xe4\xc7\xe7[\xa4\x8a\x19C\t\x9b\xd1\xf0'\x03;\xe4\xb4\xed\xc3\xf6\xb6\x83\xefkc\xf5\x80\x1c,\x01d\xec\x9aP\xbfG\xd4\xc7MT#\x18\xcaZ2cPu\x8eK\xa6N\x7f\x89\xa8\x92\x95\x11\x89\x8d\x96F+P~\xb6\xa6\x8e\xe5Y\xaa\x8bY\n\x1b\xf8\x9d:\xf1&?~L\vp:\x05\x04s<j\xeb\xbcE\xd5\x11\xe2\xedUD\x0f\xec\xdc\xc9v\xb2\x17\x90n\x00\xebP\xabn\xb8a\xc2\xf4L\x18\x8b\x92\xd9S=\xd6!\tu&Q\xbeכ\x1d\xe7в\x83\xf0\x94\xac;\xff\x19\xb3\xf1\x9dւ\x00+:]\x00z\xed\xc2nNVZ\xed\xbb\xcd\xcdw\xac\x1deҢ\x00b엎I6\x9b\xf5~\x9daǗ\x17\xe6i\xc1\x9c\xe4\xf14\x8f\\\x04\x15\n\xe2\x1b\xd5\xf7i\x13U\x19f\x99\xd2\xc8j\x01\x03\x88 \xe5\xc47\x96٠\xf2\x9bu.\x1b\xb3v\xa3T\xa8F\xde<L\xddT\xea\xb3<6\n+,\xf6\a\x15\xfb\xfe\n\xacj\x04\x82\xf25rJ\x8e\xf3\xdfT\x16\x9f\vI\x0e\x1a\vA_2v\xa5ĕ\xa6\xc4D\xd2\xe8\xfc\x93\xee_\xb9\xc8x\xff٨\x0f6\\\xa4\x88<)o奈y\xae\xd1\x06\\\x98\xf2\xc9.\x9e\xf2\x88\xb46c\xa4\aÜ\xbbӖ\xa7\x9ax\x95\xc7g\xa1\x8fz\x15W\x0e\x90\x01\xaf\xf5\xff\xa6\x84\xf1\xe0\xe9\x99\xeb\x83*bWi\ao3v\x1a\xbew\xbd\xb6\xbe\x0e\xdf\xea\xe53s\xfd\xb3\x1d\rk\xc1\xab\x94\\g\xd1x\xe7\x05\x94\xcb\xe0?\x00\x00\x00\xff\xff\x01\x00\x00\xff\xff;\xd8hV\x99\b\x00\x00"))
 }

--- a/api/ingress/ingress_v1alpha/schema.gen.go
+++ b/api/ingress/ingress_v1alpha/schema.gen.go
@@ -6,22 +6,24 @@ import (
 )
 
 const (
-	HttpRouteAppId           = entity.Id("dev.miren.ingress/http_route.app")
-	HttpRouteClaimMappingsId = entity.Id("dev.miren.ingress/http_route.claim_mappings")
-	HttpRouteDefaultId       = entity.Id("dev.miren.ingress/http_route.default")
-	HttpRouteHostId          = entity.Id("dev.miren.ingress/http_route.host")
-	HttpRouteOidcProviderId  = entity.Id("dev.miren.ingress/http_route.oidc_provider")
-	HttpRouteWafProfileId    = entity.Id("dev.miren.ingress/http_route.waf_profile")
+	HttpRouteAppId              = entity.Id("dev.miren.ingress/http_route.app")
+	HttpRouteClaimMappingsId    = entity.Id("dev.miren.ingress/http_route.claim_mappings")
+	HttpRouteDefaultId          = entity.Id("dev.miren.ingress/http_route.default")
+	HttpRouteHostId             = entity.Id("dev.miren.ingress/http_route.host")
+	HttpRouteOidcProviderId     = entity.Id("dev.miren.ingress/http_route.oidc_provider")
+	HttpRoutePasswordProviderId = entity.Id("dev.miren.ingress/http_route.password_provider")
+	HttpRouteWafProfileId       = entity.Id("dev.miren.ingress/http_route.waf_profile")
 )
 
 type HttpRoute struct {
-	ID            entity.Id       `json:"id"`
-	App           entity.Id       `cbor:"app,omitempty" json:"app,omitempty"`
-	ClaimMappings []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
-	Default       bool            `cbor:"default,omitempty" json:"default,omitempty"`
-	Host          string          `cbor:"host,omitempty" json:"host,omitempty"`
-	OidcProvider  entity.Id       `cbor:"oidc_provider,omitempty" json:"oidc_provider,omitempty"`
-	WafProfile    entity.Id       `cbor:"waf_profile,omitempty" json:"waf_profile,omitempty"`
+	ID               entity.Id       `json:"id"`
+	App              entity.Id       `cbor:"app,omitempty" json:"app,omitempty"`
+	ClaimMappings    []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
+	Default          bool            `cbor:"default,omitempty" json:"default,omitempty"`
+	Host             string          `cbor:"host,omitempty" json:"host,omitempty"`
+	OidcProvider     entity.Id       `cbor:"oidc_provider,omitempty" json:"oidc_provider,omitempty"`
+	PasswordProvider entity.Id       `cbor:"password_provider,omitempty" json:"password_provider,omitempty"`
+	WafProfile       entity.Id       `cbor:"waf_profile,omitempty" json:"waf_profile,omitempty"`
 }
 
 func (o *HttpRoute) Decode(e entity.AttrGetter) {
@@ -44,6 +46,9 @@ func (o *HttpRoute) Decode(e entity.AttrGetter) {
 	}
 	if a, ok := e.Get(HttpRouteOidcProviderId); ok && a.Value.Kind() == entity.KindId {
 		o.OidcProvider = a.Value.Id()
+	}
+	if a, ok := e.Get(HttpRoutePasswordProviderId); ok && a.Value.Kind() == entity.KindId {
+		o.PasswordProvider = a.Value.Id()
 	}
 	if a, ok := e.Get(HttpRouteWafProfileId); ok && a.Value.Kind() == entity.KindId {
 		o.WafProfile = a.Value.Id()
@@ -80,6 +85,9 @@ func (o *HttpRoute) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.OidcProvider) {
 		attrs = append(attrs, entity.Ref(HttpRouteOidcProviderId, o.OidcProvider))
 	}
+	if !entity.Empty(o.PasswordProvider) {
+		attrs = append(attrs, entity.Ref(HttpRoutePasswordProviderId, o.PasswordProvider))
+	}
 	if !entity.Empty(o.WafProfile) {
 		attrs = append(attrs, entity.Ref(HttpRouteWafProfileId, o.WafProfile))
 	}
@@ -103,6 +111,9 @@ func (o *HttpRoute) Empty() bool {
 	if !entity.Empty(o.OidcProvider) {
 		return false
 	}
+	if !entity.Empty(o.PasswordProvider) {
+		return false
+	}
 	if !entity.Empty(o.WafProfile) {
 		return false
 	}
@@ -116,6 +127,7 @@ func (o *HttpRoute) InitSchema(sb *schema.SchemaBuilder) {
 	sb.Bool("default", "dev.miren.ingress/http_route.default", schema.Doc("Whether this is the default route for routing"), schema.Indexed)
 	sb.String("host", "dev.miren.ingress/http_route.host", schema.Doc("The hostname to match on for the application"), schema.Indexed)
 	sb.Ref("oidc_provider", "dev.miren.ingress/http_route.oidc_provider", schema.Doc("Reference to an OIDC provider for authentication"), schema.Indexed)
+	sb.Ref("password_provider", "dev.miren.ingress/http_route.password_provider", schema.Doc("Reference to a password provider for simple authentication"), schema.Indexed)
 	sb.Ref("waf_profile", "dev.miren.ingress/http_route.waf_profile", schema.Doc("Reference to a WAF profile for request filtering"))
 }
 
@@ -263,6 +275,69 @@ func (o *OidcProvider) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 const (
+	PasswordProviderNameId         = entity.Id("dev.miren.ingress/password_provider.name")
+	PasswordProviderPasswordHashId = entity.Id("dev.miren.ingress/password_provider.password_hash")
+)
+
+type PasswordProvider struct {
+	ID           entity.Id `json:"id"`
+	Name         string    `cbor:"name,omitempty" json:"name,omitempty"`
+	PasswordHash string    `cbor:"password_hash,omitempty" json:"password_hash,omitempty"`
+}
+
+func (o *PasswordProvider) Decode(e entity.AttrGetter) {
+	o.ID = entity.MustGet(e, entity.DBId).Value.Id()
+	if a, ok := e.Get(PasswordProviderNameId); ok && a.Value.Kind() == entity.KindString {
+		o.Name = a.Value.String()
+	}
+	if a, ok := e.Get(PasswordProviderPasswordHashId); ok && a.Value.Kind() == entity.KindString {
+		o.PasswordHash = a.Value.String()
+	}
+}
+
+func (o *PasswordProvider) Is(e entity.AttrGetter) bool {
+	return entity.Is(e, KindPasswordProvider)
+}
+
+func (o *PasswordProvider) ShortKind() string {
+	return "password_provider"
+}
+
+func (o *PasswordProvider) Kind() entity.Id {
+	return KindPasswordProvider
+}
+
+func (o *PasswordProvider) EntityId() entity.Id {
+	return o.ID
+}
+
+func (o *PasswordProvider) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.Name) {
+		attrs = append(attrs, entity.String(PasswordProviderNameId, o.Name))
+	}
+	if !entity.Empty(o.PasswordHash) {
+		attrs = append(attrs, entity.String(PasswordProviderPasswordHashId, o.PasswordHash))
+	}
+	attrs = append(attrs, entity.Ref(entity.EntityKind, KindPasswordProvider))
+	return
+}
+
+func (o *PasswordProvider) Empty() bool {
+	if !entity.Empty(o.Name) {
+		return false
+	}
+	if !entity.Empty(o.PasswordHash) {
+		return false
+	}
+	return true
+}
+
+func (o *PasswordProvider) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("name", "dev.miren.ingress/password_provider.name", schema.Doc("A unique name for this password provider"), schema.Indexed)
+	sb.String("password_hash", "dev.miren.ingress/password_provider.password_hash", schema.Doc("bcrypt hash of the shared password"))
+}
+
+const (
 	WafProfileParanoiaLevelId = entity.Id("dev.miren.ingress/waf_profile.paranoia_level")
 )
 
@@ -311,17 +386,19 @@ func (o *WafProfile) InitSchema(sb *schema.SchemaBuilder) {
 }
 
 var (
-	KindHttpRoute    = entity.Id("dev.miren.ingress/kind.http_route")
-	KindOidcProvider = entity.Id("dev.miren.ingress/kind.oidc_provider")
-	KindWafProfile   = entity.Id("dev.miren.ingress/kind.waf_profile")
-	Schema           = entity.Id("dev.miren.ingress/schema.v1alpha")
+	KindHttpRoute        = entity.Id("dev.miren.ingress/kind.http_route")
+	KindOidcProvider     = entity.Id("dev.miren.ingress/kind.oidc_provider")
+	KindPasswordProvider = entity.Id("dev.miren.ingress/kind.password_provider")
+	KindWafProfile       = entity.Id("dev.miren.ingress/kind.waf_profile")
+	Schema               = entity.Id("dev.miren.ingress/schema.v1alpha")
 )
 
 func init() {
 	schema.Register("dev.miren.ingress", "v1alpha", func(sb *schema.SchemaBuilder) {
 		(&HttpRoute{}).InitSchema(sb)
 		(&OidcProvider{}).InitSchema(sb)
+		(&PasswordProvider{}).InitSchema(sb)
 		(&WafProfile{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x8c\x95\xdb\xf2\xd3 \x10\xc6_D\xc7\xc38\x9e\x8d\xe3\x13ehX\x92\xb5\x9c\x04\x1a\xdbK\x9d\xd1\x17\xf9\xabo\xa8\xd7\x0eK:\t$\xa5\xb9\xe9la\xf7\xb7|\xf0A~q\xcd\x14|\xe106\n\x1d\xe8\x06u\xef\xc0{8\xa2\xe6\xfe\xe1\xfcl5\xf31\xce4C\b\xb6u\xe6\x14\xe0\x0f\x11Ώ։sN\xa2\xfd\x13\xdc(\x86z\xddM\b\x04\xc9\xfdχ\x03\xf2\xf3\xd3\x1a\xa9a\xd6R\xc3.\x06\xe1b\xe1\x80\xfcw,{W-\xeb$C\xd5*f-\xea\xdes\xc5\xf4\xe5/qt1\x13\x91\xd8\x19e\x8d\x06\x1d\xe6h\x92\xb9\xee\xd2\xdc\xec\xb2S\xf5wR\xfdr\xbd\xfc\x9c\x96\xe0\xb4\nHa\\\xaa\xf0\xc1\xa1\xee\t\xf1\xea.b\x00\xc6\xc1\x11CL\xf1\x02ҏ\xe0<\x1aݏ\x9f\x98\xb4\x03\x93֡b\xee\xd2F\x1d\x8aPW\x12\xf5{Q\xddq\x0e\x82\x9dd\xa0f\xfd\xf5O\xec\xc6\x0f\xc6H\x02l\x98k\x01\x18\x8cO՜\xa2R\xed\xdbj\xb1A\u07b5֙\x11\xaf\x82U>4Y\x87P\xaf\xab\xa8\xafL\xc42\x81\x12\bt\\\x0eL\x98\xea\xd6}\x9ea\xe7\xe77\xeeӂ99\xed\xf1:s\x91\xb4\xd3[\xdfH\xdf\xfb*\xaa\xb1\xcc1m\x90\xb5\x12F\x90\xe9V\x14cQf\x87:Tu.7f\xcb\x1c$4;\x85I\xea\x93un\x96\xb6S\xec\x0f\x12\xfb\xe6\x0e\xac\xe9$\x82\x0e-rj\x8e\xf3\xdf\xd2a\x1fv\x92<t\x0e\x92UU>T\x1276%'\x92\xdd矲~\xe3 \xf3\xfakО\\:H\x99\x8d\x94\xbc\x8dG'\xe7\xf9\xceX\xf0\xe9\xc1\x98\xe2\xdd\x0fFF*S\x8f~0.\xb4\xe9+\xb3\xbc \xf7?8\x99\xcdvܧ|!\xfb\x8c\xf9\x1f\x00\x00\xff\xff\x01\x00\x00\xff\xff\xe5\x12\x94\f\x17\a\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x94\x96ے\xd30\f\x86_\x04\x86\xe3p&\xcc>Qƍ\x95Dԧ\xb5\xddn{\t3\f\x0f\xc2\xc2\x1b\xc25\x139%\xb1\x9du\xcd͎\xa2H\x9f\xf2ے\xb6\xf7\\1\t\xb7\x1c\x8e\x8dD\v\xaaA5Xp\x0e\xf6\xa8\xb8\xbb?=\xcb\xde|\x9a\xde4\xa3\xf7\xa6\xb5\xfa\xe0\xe1\x17\x11N\x8f\xf2\xc0%&\xd0\xfe\xf4\\K\x86*\xaf\xd6\xf7\b\x82\xbb\xef?v\xc8OOK\xa4\x86\x19C\x05\xbb\xc9\xf0g\x03;\xe4?\xa7\xb4\xf7ŴN0\x94\xaddƠ\x1a\x1c\x97L\x9d\x7f\x13G%o&$vZ\x1a\xad@\xf9Śe\xe6U\x9a\a\xabT\xaa\xfeJ\xaa_\xe5\x9f\x1f\xd3\x02\x9c\xbe\x02\x829}j\xef\xbcE5\x10\xe2\xf5U\xc4\b\x8c\x83%F?\xdb+\xc8p\x04\xebP\xab\xe1xÄ\x19\x990\x16%\xb3\xe7v\xd2!\tu!Q\xbd\x97\xc5\x13\xe7г\x83\xf0Tl\xb8<L\xd5\xf8NkA\x80\x8d\xe6Z\x01F\xedB6'+U\xfb\xae\x98\xac\x91w\xad\xb1\xfa\x88\x17\xc12vͭC\xa8\xa6\x882̹;my\x8c\xbb\xcd\xddk\xe4\x9b\"\xf2\x8e\xf5SZ\x8f\x02\b\xb6_;fL\xf16>/\xb0\xd3\xf3\aFtŜ\x9b\xf7q\x1e\xb9\n\xaal\xd7/\xa4\xefC\x11\xd5\x18f\x99\xd2\xc8Z\x01G\x10a\xd0\x12\xdf$\xb3C\xe5\x8b:\xd7\a\xb3\xd5o$4\xba\xd8Y\xea\x93<6\n\xab\x14\xfb\x8dľ\xbd\x02k:\x81\xa0|\x8b\x9c\x8a\xe3\xf2\x986\xed\xc7J\x92\x83\xceB\xe8~\x19\xbbR\xe2ơ\xc4D\x9a\xa0\xe5O\x9a\xbfq\x91q\xfe\xc5h\x0f6\\\xa4\x88<)oc\x8f\xc5<\xd7i\x03.\xec\xa0ٮ\xdeA\x11ikƨ\x1f\xb2ɜ{\xe2E\x1e\x9f\x85\xfe\xd7\xce\xde\xf8\x80\fx\xed\xfcoj\x18\xff<#sc\xe8\x8a\xd8U{\x82\xf9\xd6J\xc3\xf7n\xd4ַ\xe1\xdf\xffz\xcd\\\xff%\x10\rk\xc5VJ\xae\xb3j\xbcs\x01\xf5m\xf0\x17\x00\x00\xff\xff\x01\x00\x00\xff\xff\xf1\x8a٭\xec\b\x00\x00"))
 }

--- a/api/ingress/schema.yml
+++ b/api/ingress/schema.yml
@@ -18,13 +18,9 @@ kinds:
     waf_profile:
       type: ref
       doc: Reference to a WAF profile for request filtering
-    oidc_provider:
+    auth_provider:
       type: ref
-      doc: Reference to an OIDC provider for authentication
-      indexed: true
-    password_provider:
-      type: ref
-      doc: Reference to a password provider for simple authentication
+      doc: Reference to an auth provider (OIDC or password) for authentication
       indexed: true
     claim_mappings:
       type: component

--- a/api/ingress/schema.yml
+++ b/api/ingress/schema.yml
@@ -22,6 +22,10 @@ kinds:
       type: ref
       doc: Reference to an OIDC provider for authentication
       indexed: true
+    password_provider:
+      type: ref
+      doc: Reference to a password provider for simple authentication
+      indexed: true
     claim_mappings:
       type: component
       doc: Mappings from JWT claims to HTTP headers
@@ -33,6 +37,14 @@ kinds:
         header:
           type: string
           doc: The HTTP header name to inject (e.g. X-User-Email)
+  password_provider:
+    name:
+      type: string
+      doc: A unique name for this password provider
+      indexed: true
+    password_hash:
+      type: string
+      doc: bcrypt hash of the shared password
   oidc_provider:
     name:
       type: string

--- a/blackbox/harness/miren.go
+++ b/blackbox/harness/miren.go
@@ -15,12 +15,22 @@ import (
 type Miren struct {
 	t       *testing.T
 	cluster *Cluster
+	envVars map[string]string
 }
 
 // NewMiren creates a CLI runner bound to the given cluster.
 func NewMiren(t *testing.T, cluster *Cluster) *Miren {
 	t.Helper()
 	return &Miren{t: t, cluster: cluster}
+}
+
+// SetEnv sets an environment variable that will be injected into subsequent
+// miren CLI and RunCmd invocations inside the dev container.
+func (m *Miren) SetEnv(key, value string) {
+	if m.envVars == nil {
+		m.envVars = make(map[string]string)
+	}
+	m.envVars[key] = value
 }
 
 // Run executes a miren CLI command and returns the result.
@@ -34,14 +44,17 @@ func (m *Miren) Run(args ...string) *Result {
 	case ModeDev:
 		// hack/dev-exec m <args>
 		devExec := filepath.Join(m.cluster.RepoRoot, "hack", "dev-exec")
-		execArgs := append([]string{"m"}, args...)
+		execArgs := m.prependEnvArgs("m", args...)
 		cmd = exec.Command(devExec, execArgs...)
 		cmd.Dir = m.cluster.RepoRoot
 	case ModeLocal:
 		cmd = exec.Command(m.cluster.MirenBin, args...)
+		for k, v := range m.envVars {
+			cmd.Env = append(cmd.Environ(), k+"="+v)
+		}
 	case ModePeers:
 		// iso peers exec coordinator -- m <args>
-		execArgs := append([]string{"peers", "exec", "coordinator", "--", "m"}, args...)
+		execArgs := append([]string{"peers", "exec", "coordinator", "--"}, m.prependEnvArgs("m", args...)...)
 		cmd = exec.Command("iso", execArgs...)
 		cmd.Dir = m.cluster.RepoRoot
 	default:
@@ -105,12 +118,16 @@ func (m *Miren) RunCmd(args ...string) *Result {
 	switch m.cluster.Mode {
 	case ModeDev:
 		devExec := filepath.Join(m.cluster.RepoRoot, "hack", "dev-exec")
-		cmd = exec.Command(devExec, args...)
+		execArgs := m.prependEnvArgs(args[0], args[1:]...)
+		cmd = exec.Command(devExec, execArgs...)
 		cmd.Dir = m.cluster.RepoRoot
 	case ModeLocal:
 		cmd = exec.Command(args[0], args[1:]...)
+		for k, v := range m.envVars {
+			cmd.Env = append(cmd.Environ(), k+"="+v)
+		}
 	case ModePeers:
-		execArgs := append([]string{"peers", "exec", "coordinator", "--"}, args...)
+		execArgs := append([]string{"peers", "exec", "coordinator", "--"}, m.prependEnvArgs(args[0], args[1:]...)...)
 		cmd = exec.Command("iso", execArgs...)
 		cmd.Dir = m.cluster.RepoRoot
 	default:
@@ -330,6 +347,29 @@ func (m *Miren) RunCmdAsRoot(args ...string) *Result {
 	}
 
 	return r
+}
+
+// prependEnvArgs builds a command arg slice with "env K=V" prefixed when
+// the Miren instance has env vars set. This makes the env vars available
+// inside the dev container since hack/dev-exec constructs a shell command
+// from the provided args.
+func (m *Miren) prependEnvArgs(binary string, args ...string) []string {
+	if len(m.envVars) == 0 {
+		return append([]string{binary}, args...)
+	}
+
+	result := []string{"env"}
+	keys := make([]string, 0, len(m.envVars))
+	for k := range m.envVars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		result = append(result, k+"="+m.envVars[k])
+	}
+	result = append(result, binary)
+	result = append(result, args...)
+	return result
 }
 
 // shellQuote wraps a string in single quotes for safe shell interpolation.

--- a/blackbox/route_password_test.go
+++ b/blackbox/route_password_test.go
@@ -1,0 +1,226 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+func TestRoutePasswordProtection(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	// Deploy a simple app
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+
+	host := name + ".test.local"
+	m.MustRun("route", "set", host, name)
+
+	// Wait for app to be reachable
+	harness.Poll(t, "app responds via route", 30*time.Second, 2*time.Second, func() (bool, string) {
+		code, _, err := harness.HTTPGet(m, host, "/")
+		if err != nil {
+			return false, err.Error()
+		}
+		if code != 200 {
+			return false, fmt.Sprintf("HTTP %d", code)
+		}
+		return true, ""
+	})
+
+	// Create a password provider and protect the route
+	m.MustRun("auth", "provider", "add-password", "test-pw", "--password", "s3cret")
+	t.Cleanup(func() {
+		m.Run("auth", "provider", "remove", "test-pw", "--force")
+	})
+
+	m.MustRun("route", "protect", host, "--provider", "test-pw")
+
+	// Verify route show displays password protection
+	r := m.MustRun("route", "show", host)
+	r.RequireContains(t, "password")
+
+	// Verify unauthenticated request returns the login form (HTTP 200 with HTML)
+	harness.Poll(t, "login form served", 10*time.Second, 1*time.Second, func() (bool, string) {
+		code, body, err := harness.HTTPGet(m, host, "/")
+		if err != nil {
+			return false, err.Error()
+		}
+		if code != 200 {
+			return false, fmt.Sprintf("HTTP %d", code)
+		}
+		if !strings.Contains(body, "Password Required") {
+			return false, "response does not contain login form"
+		}
+		return true, ""
+	})
+
+	// POST the wrong password — should get the form back with error
+	code, body := httpPostPassword(t, m, host, "wrongpassword")
+	if code != 200 {
+		t.Fatalf("expected 200 for wrong password, got %d", code)
+	}
+	if !strings.Contains(body, "Incorrect password") {
+		t.Fatalf("expected error message in form, got: %s", body)
+	}
+
+	// POST the correct password — should get a redirect with a session cookie
+	cookie := httpLoginAndGetCookie(t, m, host, "s3cret")
+	if cookie == "" {
+		t.Fatal("expected session cookie after successful login")
+	}
+
+	// Use the session cookie to access the app
+	code, body = httpGetWithCookie(t, m, host, "/", cookie)
+	if code != 200 {
+		t.Fatalf("expected 200 with valid session cookie, got %d: %s", code, body)
+	}
+	// Should get the actual app response, not the login form
+	if strings.Contains(body, "Password Required") {
+		t.Fatal("expected app content, got login form despite valid cookie")
+	}
+
+	// Unprotect the route
+	m.MustRun("route", "unprotect", host)
+
+	// Verify unauthenticated access works again
+	harness.Poll(t, "route is unprotected", 10*time.Second, 1*time.Second, func() (bool, string) {
+		code, body, err := harness.HTTPGet(m, host, "/")
+		if err != nil {
+			return false, err.Error()
+		}
+		if code != 200 {
+			return false, fmt.Sprintf("HTTP %d", code)
+		}
+		if strings.Contains(body, "Password Required") {
+			return false, "still getting login form"
+		}
+		return true, ""
+	})
+}
+
+func TestRoutePasswordProviderLifecycle(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	// Create a password provider
+	m.MustRun("auth", "provider", "add-password", "lifecycle-pw", "--password", "test123")
+	t.Cleanup(func() {
+		m.Run("auth", "provider", "remove", "lifecycle-pw", "--force")
+	})
+
+	// List should show it with type "password"
+	r := m.MustRun("auth", "provider", "list")
+	r.RequireContains(t, "lifecycle-pw")
+	r.RequireContains(t, "password")
+
+	// Show should display it
+	r = m.MustRun("auth", "provider", "show", "lifecycle-pw")
+	r.RequireContains(t, "lifecycle-pw")
+	r.RequireContains(t, "password")
+
+	// Update the password
+	m.MustRun("auth", "provider", "add-password", "lifecycle-pw", "--password", "newpass", "--update")
+
+	// Remove
+	m.MustRun("auth", "provider", "remove", "lifecycle-pw")
+
+	// Should be gone
+	r = m.MustRun("auth", "provider", "list")
+	if r.OutputContains("lifecycle-pw") {
+		t.Fatal("provider still listed after removal")
+	}
+}
+
+// httpPostPassword POSTs a password to the login endpoint and returns status code and body.
+func httpPostPassword(t *testing.T, m *harness.Miren, hostname, password string) (int, string) {
+	t.Helper()
+
+	r := m.RunCmd("curl", "-sk", "-w", "\n%{http_code}",
+		"-H", fmt.Sprintf("Host: %s", hostname),
+		"-d", fmt.Sprintf("password=%s&return=/", password),
+		"--max-time", "10",
+		// Don't follow redirects so we can inspect the response
+		fmt.Sprintf("https://localhost:443/.well-known/miren/auth/login"))
+
+	if !r.Success() {
+		t.Fatalf("curl POST failed (exit %d): %s", r.ExitCode, r.Stderr)
+	}
+
+	lines := strings.Split(strings.TrimRight(r.Stdout, "\n"), "\n")
+	if len(lines) < 1 {
+		t.Fatalf("unexpected curl output: %q", r.Stdout)
+	}
+
+	statusStr := lines[len(lines)-1]
+	var code int
+	fmt.Sscanf(statusStr, "%d", &code)
+	body := strings.Join(lines[:len(lines)-1], "\n")
+	return code, body
+}
+
+// httpLoginAndGetCookie POSTs the correct password and extracts the session cookie.
+func httpLoginAndGetCookie(t *testing.T, m *harness.Miren, hostname, password string) string {
+	t.Helper()
+
+	r := m.RunCmd("curl", "-sk", "-i",
+		"-H", fmt.Sprintf("Host: %s", hostname),
+		"-d", fmt.Sprintf("password=%s&return=/", password),
+		"--max-time", "10",
+		fmt.Sprintf("https://localhost:443/.well-known/miren/auth/login"))
+
+	if !r.Success() {
+		t.Fatalf("curl POST for login failed (exit %d): %s", r.ExitCode, r.Stderr)
+	}
+
+	for _, line := range strings.Split(r.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(line), "set-cookie:") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				cookieVal := strings.TrimSpace(parts[1])
+				if idx := strings.Index(cookieVal, ";"); idx > 0 {
+					cookieVal = cookieVal[:idx]
+				}
+				if strings.HasPrefix(cookieVal, "miren_pw_session=") {
+					return cookieVal
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// httpGetWithCookie makes an HTTP GET with a cookie header.
+func httpGetWithCookie(t *testing.T, m *harness.Miren, hostname, path, cookie string) (int, string) {
+	t.Helper()
+
+	r := m.RunCmd("curl", "-sk", "-w", "\n%{http_code}",
+		"-H", fmt.Sprintf("Host: %s", hostname),
+		"-b", cookie,
+		"--max-time", "10",
+		fmt.Sprintf("https://localhost:443%s", path))
+
+	if !r.Success() {
+		t.Fatalf("curl GET with cookie failed (exit %d): %s", r.ExitCode, r.Stderr)
+	}
+
+	lines := strings.Split(strings.TrimRight(r.Stdout, "\n"), "\n")
+	if len(lines) < 1 {
+		t.Fatalf("unexpected curl output: %q", r.Stdout)
+	}
+
+	statusStr := lines[len(lines)-1]
+	var code int
+	fmt.Sscanf(statusStr, "%d", &code)
+	body := strings.Join(lines[:len(lines)-1], "\n")
+	return code, body
+}

--- a/cli/commands/auth_provider.go
+++ b/cli/commands/auth_provider.go
@@ -60,6 +60,14 @@ func AuthProviderAdd(ctx *Context, opts struct {
 		return fmt.Errorf("identity provider %q already exists. Pass --update to overwrite (rotates client secret)", opts.Name)
 	}
 
+	pwExisting, err := ic.GetPasswordProvider(ctx, opts.Name)
+	if err != nil {
+		return fmt.Errorf("failed to check for existing password provider: %w", err)
+	}
+	if pwExisting != nil {
+		return fmt.Errorf("a password provider named %q already exists. Provider names must be unique across types", opts.Name)
+	}
+
 	provider := &ingress_v1alpha.OidcProvider{
 		Name:         opts.Name,
 		ProviderUrl:  opts.ProviderURL,

--- a/cli/commands/auth_provider.go
+++ b/cli/commands/auth_provider.go
@@ -96,41 +96,57 @@ func AuthProviderList(ctx *Context, opts struct {
 
 	ic := ingress.NewClient(ctx.Log, client)
 
-	providers, err := ic.ListOIDCProviders(ctx)
+	oidcProviders, err := ic.ListOIDCProviders(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list identity providers: %w", err)
+	}
+
+	pwProviders, err := ic.ListPasswordProviders(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list password providers: %w", err)
 	}
 
 	if opts.IsJSON() {
 		type ProviderJSON struct {
 			Name        string   `json:"name"`
-			ProviderURL string   `json:"provider_url"`
-			ClientID    string   `json:"client_id"`
-			Scopes      []string `json:"scopes"`
+			Type        string   `json:"type"`
+			ProviderURL string   `json:"provider_url,omitempty"`
+			ClientID    string   `json:"client_id,omitempty"`
+			Scopes      []string `json:"scopes,omitempty"`
 		}
 
-		items := make([]ProviderJSON, 0, len(providers))
-		for _, p := range providers {
+		items := make([]ProviderJSON, 0, len(oidcProviders)+len(pwProviders))
+		for _, p := range oidcProviders {
 			items = append(items, ProviderJSON{
 				Name:        p.Name,
+				Type:        "oidc",
 				ProviderURL: p.ProviderUrl,
 				ClientID:    p.ClientId,
 				Scopes:      strings.Fields(p.Scopes),
 			})
 		}
+		for _, p := range pwProviders {
+			items = append(items, ProviderJSON{
+				Name: p.Name,
+				Type: "password",
+			})
+		}
 		return PrintJSON(items)
 	}
 
-	if len(providers) == 0 {
+	if len(oidcProviders) == 0 && len(pwProviders) == 0 {
 		ctx.Printf("No identity providers found\n")
 		return nil
 	}
 
 	var rows []ui.Row
-	headers := []string{"NAME", "PROVIDER URL", "SCOPES"}
+	headers := []string{"NAME", "TYPE", "PROVIDER URL", "SCOPES"}
 
-	for _, p := range providers {
-		rows = append(rows, ui.Row{p.Name, p.ProviderUrl, p.Scopes})
+	for _, p := range oidcProviders {
+		rows = append(rows, ui.Row{p.Name, "oidc", p.ProviderUrl, p.Scopes})
+	}
+	for _, p := range pwProviders {
+		rows = append(rows, ui.Row{p.Name, "password", "", ""})
 	}
 
 	columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0).NoTruncate(1))
@@ -160,40 +176,72 @@ func AuthProviderShow(ctx *Context, opts struct {
 
 	ic := ingress.NewClient(ctx.Log, client)
 
+	// Try OIDC provider first
 	provider, err := ic.GetOIDCProvider(ctx, opts.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get identity provider: %w", err)
 	}
 
-	if provider == nil {
-		return fmt.Errorf("identity provider not found: %s", opts.Name)
-	}
+	if provider != nil {
+		if opts.IsJSON() {
+			type ProviderJSON struct {
+				Name        string   `json:"name"`
+				Type        string   `json:"type"`
+				ProviderURL string   `json:"provider_url"`
+				ClientID    string   `json:"client_id"`
+				Scopes      []string `json:"scopes"`
+			}
 
-	if opts.IsJSON() {
-		type ProviderJSON struct {
-			Name        string   `json:"name"`
-			ProviderURL string   `json:"provider_url"`
-			ClientID    string   `json:"client_id"`
-			Scopes      []string `json:"scopes"`
+			return PrintJSON(ProviderJSON{
+				Name:        provider.Name,
+				Type:        "oidc",
+				ProviderURL: provider.ProviderUrl,
+				ClientID:    provider.ClientId,
+				Scopes:      strings.Fields(provider.Scopes),
+			})
 		}
 
-		return PrintJSON(ProviderJSON{
-			Name:        provider.Name,
-			ProviderURL: provider.ProviderUrl,
-			ClientID:    provider.ClientId,
-			Scopes:      strings.Fields(provider.Scopes),
-		})
+		items := []ui.NamedValue{
+			ui.NewNamedValue("Name", provider.Name),
+			ui.NewNamedValue("Type", "oidc"),
+			ui.NewNamedValue("Provider URL", provider.ProviderUrl),
+			ui.NewNamedValue("Client ID", provider.ClientId),
+			ui.NewNamedValue("Scopes", provider.Scopes),
+		}
+
+		ctx.Printf("%s\n", ui.NewNamedValueList(items).Render())
+		return nil
 	}
 
-	items := []ui.NamedValue{
-		ui.NewNamedValue("Name", provider.Name),
-		ui.NewNamedValue("Provider URL", provider.ProviderUrl),
-		ui.NewNamedValue("Client ID", provider.ClientId),
-		ui.NewNamedValue("Scopes", provider.Scopes),
+	// Try password provider
+	pwProvider, err := ic.GetPasswordProvider(ctx, opts.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get password provider: %w", err)
 	}
 
-	ctx.Printf("%s\n", ui.NewNamedValueList(items).Render())
-	return nil
+	if pwProvider != nil {
+		if opts.IsJSON() {
+			type ProviderJSON struct {
+				Name string `json:"name"`
+				Type string `json:"type"`
+			}
+
+			return PrintJSON(ProviderJSON{
+				Name: pwProvider.Name,
+				Type: "password",
+			})
+		}
+
+		items := []ui.NamedValue{
+			ui.NewNamedValue("Name", pwProvider.Name),
+			ui.NewNamedValue("Type", "password"),
+		}
+
+		ctx.Printf("%s\n", ui.NewNamedValueList(items).Render())
+		return nil
+	}
+
+	return fmt.Errorf("identity provider not found: %s", opts.Name)
 }
 
 func AuthProviderRemove(ctx *Context, opts struct {
@@ -213,37 +261,77 @@ func AuthProviderRemove(ctx *Context, opts struct {
 
 	ic := ingress.NewClient(ctx.Log, client)
 
-	if !opts.Force {
-		provider, err := ic.GetOIDCProvider(ctx, opts.Name)
-		if err != nil {
-			return fmt.Errorf("failed to get identity provider: %w", err)
-		}
-		if provider == nil {
-			return fmt.Errorf("identity provider not found: %s", opts.Name)
-		}
+	// Try OIDC provider first
+	oidcProvider, err := ic.GetOIDCProvider(ctx, opts.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get identity provider: %w", err)
+	}
 
-		routes, err := ic.List(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to list routes: %w", err)
-		}
+	if oidcProvider != nil {
+		if !opts.Force {
+			routes, err := ic.List(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to list routes: %w", err)
+			}
 
-		var inUse []string
-		for _, rm := range routes {
-			if rm.Route.OidcProvider == provider.ID {
-				inUse = append(inUse, rm.Route.Host)
+			var inUse []string
+			for _, rm := range routes {
+				if rm.Route.OidcProvider == oidcProvider.ID {
+					inUse = append(inUse, rm.Route.Host)
+				}
+			}
+
+			if len(inUse) > 0 {
+				return fmt.Errorf("identity provider %q is attached to %d route(s): %s. Detach with `miren route unprotect`, or pass --force to remove anyway", opts.Name, len(inUse), strings.Join(inUse, ", "))
 			}
 		}
 
-		if len(inUse) > 0 {
-			return fmt.Errorf("identity provider %q is attached to %d route(s): %s. Detach with `miren route unprotect`, or pass --force to remove anyway", opts.Name, len(inUse), strings.Join(inUse, ", "))
+		err = ic.DeleteOIDCProvider(ctx, opts.Name)
+		if err != nil {
+			return fmt.Errorf("failed to remove identity provider: %w", err)
 		}
+
+		ctx.Printf("Removed identity provider: %s\n", opts.Name)
+		return nil
 	}
 
-	err = ic.DeleteOIDCProvider(ctx, opts.Name)
+	// Try password provider
+	pwProvider, err := ic.GetPasswordProvider(ctx, opts.Name)
 	if err != nil {
-		return fmt.Errorf("failed to remove identity provider: %w", err)
+		return fmt.Errorf("failed to get password provider: %w", err)
 	}
 
-	ctx.Printf("Removed identity provider: %s\n", opts.Name)
-	return nil
+	if pwProvider != nil {
+		if !opts.Force {
+			routes, err := ic.List(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to list routes: %w", err)
+			}
+
+			var inUse []string
+			for _, rm := range routes {
+				if rm.Route.PasswordProvider == pwProvider.ID {
+					host := rm.Route.Host
+					if rm.Route.Default {
+						host = "(default)"
+					}
+					inUse = append(inUse, host)
+				}
+			}
+
+			if len(inUse) > 0 {
+				return fmt.Errorf("password provider %q is attached to %d route(s): %s. Detach with `miren route unprotect`, or pass --force to remove anyway", opts.Name, len(inUse), strings.Join(inUse, ", "))
+			}
+		}
+
+		err = ic.DeletePasswordProvider(ctx, opts.Name)
+		if err != nil {
+			return fmt.Errorf("failed to remove password provider: %w", err)
+		}
+
+		ctx.Printf("Removed password provider: %s\n", opts.Name)
+		return nil
+	}
+
+	return fmt.Errorf("identity provider not found: %s", opts.Name)
 }

--- a/cli/commands/auth_provider.go
+++ b/cli/commands/auth_provider.go
@@ -284,7 +284,7 @@ func AuthProviderRemove(ctx *Context, opts struct {
 
 			var inUse []string
 			for _, rm := range routes {
-				if rm.Route.OidcProvider == oidcProvider.ID {
+				if rm.Route.AuthProvider == oidcProvider.ID {
 					inUse = append(inUse, rm.Route.Host)
 				}
 			}
@@ -318,7 +318,7 @@ func AuthProviderRemove(ctx *Context, opts struct {
 
 			var inUse []string
 			for _, rm := range routes {
-				if rm.Route.PasswordProvider == pwProvider.ID {
+				if rm.Route.AuthProvider == pwProvider.ID {
 					host := rm.Route.Host
 					if rm.Route.Default {
 						host = "(default)"

--- a/cli/commands/auth_provider_password.go
+++ b/cli/commands/auth_provider_password.go
@@ -39,6 +39,14 @@ func AuthProviderAddPassword(ctx *Context, opts struct {
 		return fmt.Errorf("password provider %q already exists. Pass --update to overwrite (rotates password)", opts.Name)
 	}
 
+	oidcExisting, err := ic.GetOIDCProvider(ctx, opts.Name)
+	if err != nil {
+		return fmt.Errorf("failed to check for existing OIDC provider: %w", err)
+	}
+	if oidcExisting != nil {
+		return fmt.Errorf("an OIDC provider named %q already exists. Provider names must be unique across types", opts.Name)
+	}
+
 	hash, err := bcrypt.GenerateFromPassword([]byte(opts.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("failed to hash password: %w", err)

--- a/cli/commands/auth_provider_password.go
+++ b/cli/commands/auth_provider_password.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -12,7 +14,7 @@ import (
 
 func AuthProviderAddPassword(ctx *Context, opts struct {
 	Name     string `position:"0" usage:"Name for this password provider" required:"true"`
-	Password string `long:"password" description:"Password to protect routes with" required:"true"`
+	Password string `long:"password" description:"Password (omit to prompt interactively, use @file to read from file)"`
 	Update   bool   `long:"update" description:"Overwrite an existing provider with the same name (rotates password)"`
 	ConfigCentric
 }) error {
@@ -20,8 +22,30 @@ func AuthProviderAddPassword(ctx *Context, opts struct {
 		return fmt.Errorf("provider name is required")
 	}
 
-	if opts.Password == "" {
-		return fmt.Errorf("--password is required")
+	password := opts.Password
+
+	switch {
+	case password == "":
+		prompted, err := ui.PromptForInput(
+			ui.WithLabel("Enter password"),
+			ui.WithSensitive(true),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to read password: %w", err)
+		}
+		if prompted == "" {
+			return fmt.Errorf("password cannot be empty")
+		}
+		password = prompted
+	case strings.HasPrefix(password, "@"):
+		data, err := os.ReadFile(password[1:])
+		if err != nil {
+			return fmt.Errorf("failed to read password from file %s: %w", password[1:], err)
+		}
+		password = strings.TrimRight(string(data), "\r\n")
+		if password == "" {
+			return fmt.Errorf("password file is empty")
+		}
 	}
 
 	client, err := ctx.RPCClient("entities")
@@ -47,7 +71,7 @@ func AuthProviderAddPassword(ctx *Context, opts struct {
 		return fmt.Errorf("an OIDC provider named %q already exists. Provider names must be unique across types", opts.Name)
 	}
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(opts.Password), bcrypt.DefaultCost)
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("failed to hash password: %w", err)
 	}

--- a/cli/commands/auth_provider_password.go
+++ b/cli/commands/auth_provider_password.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"fmt"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/ui"
+)
+
+func AuthProviderAddPassword(ctx *Context, opts struct {
+	Name     string `position:"0" usage:"Name for this password provider" required:"true"`
+	Password string `long:"password" description:"Password to protect routes with" required:"true"`
+	Update   bool   `long:"update" description:"Overwrite an existing provider with the same name (rotates password)"`
+	ConfigCentric
+}) error {
+	if opts.Name == "" {
+		return fmt.Errorf("provider name is required")
+	}
+
+	if opts.Password == "" {
+		return fmt.Errorf("--password is required")
+	}
+
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	ic := ingress.NewClient(ctx.Log, client)
+
+	existing, err := ic.GetPasswordProvider(ctx, opts.Name)
+	if err != nil {
+		return fmt.Errorf("failed to check for existing password provider: %w", err)
+	}
+	if existing != nil && !opts.Update {
+		return fmt.Errorf("password provider %q already exists. Pass --update to overwrite (rotates password)", opts.Name)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(opts.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Errorf("failed to hash password: %w", err)
+	}
+
+	provider := &ingress_v1alpha.PasswordProvider{
+		Name:         opts.Name,
+		PasswordHash: string(hash),
+	}
+
+	_, err = ic.CreateOrUpdatePasswordProvider(ctx, provider)
+	if err != nil {
+		return fmt.Errorf("failed to create password provider: %w", err)
+	}
+
+	items := []ui.NamedValue{
+		ui.NewNamedValue("Name", opts.Name),
+		ui.NewNamedValue("Type", "password"),
+	}
+
+	ctx.Printf("%s\n", ui.NewNamedValueList(items).Render())
+	return nil
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -517,8 +517,12 @@ miren deploy --analyze
 
 	d.Dispatch("route protect", Infer("route protect", "Protect an HTTP route with an identity provider", RouteProtect,
 		WithExample(mflags.Example{
-			Name: "Protect a route with an identity provider",
+			Name: "Protect a route with an OIDC provider",
 			Body: "miren route protect example.com --provider my-google-oidc --claim-header email:X-User-Email",
+		}),
+		WithExample(mflags.Example{
+			Name: "Protect a route with a password",
+			Body: "miren route protect example.com --provider my-pw",
 		}),
 		WithExample(mflags.Example{
 			Name: "Protect the default route",
@@ -906,6 +910,12 @@ miren deploy --analyze
   --client-id $CLIENT_ID \
   --client-secret $CLIENT_SECRET \
   --scope email --scope profile`,
+		}),
+	))
+	d.Dispatch("auth provider add-password", Infer("auth provider add-password", "Add a password provider for route protection", AuthProviderAddPassword,
+		WithExample(mflags.Example{
+			Name: "Add a password provider",
+			Body: `miren auth provider add-password my-pw --password hunter2`,
 		}),
 	))
 	d.Dispatch("auth provider list", Infer("auth provider list", "List identity providers", AuthProviderList))

--- a/cli/commands/route_protect.go
+++ b/cli/commands/route_protect.go
@@ -155,6 +155,9 @@ func RouteProtect(ctx *Context, opts struct {
 	}
 
 	if len(opts.ClaimHeader) > 0 {
+		if opts.IsJSON() {
+			return fmt.Errorf("--claim-header is not supported for password providers")
+		}
 		ctx.Printf("Warning: --claim-header is ignored for password providers\n")
 	}
 

--- a/cli/commands/route_protect.go
+++ b/cli/commands/route_protect.go
@@ -59,49 +59,123 @@ func RouteProtect(ctx *Context, opts struct {
 		routeLabel = opts.Host
 	}
 
-	var claimMappings []ingress_v1alpha.ClaimMappings
-	for _, mapping := range opts.ClaimHeader {
-		parts := strings.SplitN(mapping, ":", 2)
-		if len(parts) != 2 {
-			return fmt.Errorf("invalid claim-header mapping format: %s (expected 'claim:header')", mapping)
-		}
-		claim := strings.TrimSpace(parts[0])
-		header := strings.TrimSpace(parts[1])
-		if claim == "" || header == "" {
-			return fmt.Errorf("invalid claim-header mapping format: %q (expected non-empty 'claim:header')", mapping)
-		}
-		claimMappings = append(claimMappings, ingress_v1alpha.ClaimMappings{
-			Claim:  claim,
-			Header: header,
-		})
+	// Auto-detect provider type: try OIDC first, then password
+	oidcProvider, err := ic.GetOIDCProvider(ctx, opts.Provider)
+	if err != nil {
+		return fmt.Errorf("failed to lookup provider: %w", err)
 	}
 
-	_, err = ic.AttachOIDCProviderToRoute(ctx, route, opts.Provider, claimMappings)
+	if oidcProvider != nil {
+		// OIDC provider found — attach with claim mappings
+		var claimMappings []ingress_v1alpha.ClaimMappings
+		for _, mapping := range opts.ClaimHeader {
+			parts := strings.SplitN(mapping, ":", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid claim-header mapping format: %s (expected 'claim:header')", mapping)
+			}
+			claim := strings.TrimSpace(parts[0])
+			header := strings.TrimSpace(parts[1])
+			if claim == "" || header == "" {
+				return fmt.Errorf("invalid claim-header mapping format: %q (expected non-empty 'claim:header')", mapping)
+			}
+			claimMappings = append(claimMappings, ingress_v1alpha.ClaimMappings{
+				Claim:  claim,
+				Header: header,
+			})
+		}
+
+		_, err = ic.AttachOIDCProviderToRoute(ctx, route, opts.Provider, claimMappings)
+		if err != nil {
+			return fmt.Errorf("failed to protect route: %w", err)
+		}
+
+		if opts.IsJSON() {
+			type RouteProtectJSON struct {
+				Route         string              `json:"route"`
+				Protected     bool                `json:"protected"`
+				Provider      string              `json:"provider"`
+				ProviderType  string              `json:"provider_type"`
+				ClaimMappings []map[string]string `json:"claim_mappings,omitempty"`
+			}
+
+			var mappings []map[string]string
+			for _, m := range claimMappings {
+				mappings = append(mappings, map[string]string{
+					"claim":  m.Claim,
+					"header": m.Header,
+				})
+			}
+
+			return PrintJSON(RouteProtectJSON{
+				Route:         routeLabel,
+				Protected:     true,
+				Provider:      opts.Provider,
+				ProviderType:  "oidc",
+				ClaimMappings: mappings,
+			})
+		}
+
+		items := []ui.NamedValue{
+			ui.NewNamedValue("Route", routeLabel),
+			ui.NewNamedValue("Protected", true),
+			ui.NewNamedValue("Provider", opts.Provider),
+			ui.NewNamedValue("Type", "oidc"),
+		}
+
+		ctx.Printf("%s\n", ui.NewNamedValueList(items).Render())
+
+		if len(claimMappings) > 0 {
+			var rows []ui.Row
+			for _, m := range claimMappings {
+				rows = append(rows, ui.Row{m.Claim, m.Header})
+			}
+
+			headers := []string{"CLAIM", "HEADER"}
+			columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0).NoTruncate(1))
+			table := ui.NewTable(
+				ui.WithTableTitle("Claim Mappings"),
+				ui.WithColumns(columns),
+				ui.WithRows(rows),
+			)
+
+			ctx.Printf("\n%s\n", table.Render())
+		}
+
+		return nil
+	}
+
+	// Try password provider
+	pwProvider, err := ic.GetPasswordProvider(ctx, opts.Provider)
+	if err != nil {
+		return fmt.Errorf("failed to lookup provider: %w", err)
+	}
+
+	if pwProvider == nil {
+		return fmt.Errorf("provider not found: %s", opts.Provider)
+	}
+
+	if len(opts.ClaimHeader) > 0 {
+		ctx.Printf("Warning: --claim-header is ignored for password providers\n")
+	}
+
+	_, err = ic.AttachPasswordProviderToRoute(ctx, route, opts.Provider)
 	if err != nil {
 		return fmt.Errorf("failed to protect route: %w", err)
 	}
 
 	if opts.IsJSON() {
 		type RouteProtectJSON struct {
-			Route         string              `json:"route"`
-			Protected     bool                `json:"protected"`
-			Provider      string              `json:"provider"`
-			ClaimMappings []map[string]string `json:"claim_mappings,omitempty"`
-		}
-
-		var mappings []map[string]string
-		for _, m := range claimMappings {
-			mappings = append(mappings, map[string]string{
-				"claim":  m.Claim,
-				"header": m.Header,
-			})
+			Route        string `json:"route"`
+			Protected    bool   `json:"protected"`
+			Provider     string `json:"provider"`
+			ProviderType string `json:"provider_type"`
 		}
 
 		return PrintJSON(RouteProtectJSON{
-			Route:         routeLabel,
-			Protected:     true,
-			Provider:      opts.Provider,
-			ClaimMappings: mappings,
+			Route:        routeLabel,
+			Protected:    true,
+			Provider:     opts.Provider,
+			ProviderType: "password",
 		})
 	}
 
@@ -109,26 +183,9 @@ func RouteProtect(ctx *Context, opts struct {
 		ui.NewNamedValue("Route", routeLabel),
 		ui.NewNamedValue("Protected", true),
 		ui.NewNamedValue("Provider", opts.Provider),
+		ui.NewNamedValue("Type", "password"),
 	}
 
 	ctx.Printf("%s\n", ui.NewNamedValueList(items).Render())
-
-	if len(claimMappings) > 0 {
-		var rows []ui.Row
-		for _, m := range claimMappings {
-			rows = append(rows, ui.Row{m.Claim, m.Header})
-		}
-
-		headers := []string{"CLAIM", "HEADER"}
-		columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0).NoTruncate(1))
-		table := ui.NewTable(
-			ui.WithTableTitle("Claim Mappings"),
-			ui.WithColumns(columns),
-			ui.WithRows(rows),
-		)
-
-		ctx.Printf("\n%s\n", table.Render())
-	}
-
 	return nil
 }

--- a/cli/commands/route_protect.go
+++ b/cli/commands/route_protect.go
@@ -84,7 +84,7 @@ func RouteProtect(ctx *Context, opts struct {
 			})
 		}
 
-		_, err = ic.AttachOIDCProviderToRoute(ctx, route, opts.Provider, claimMappings)
+		_, err = ic.AttachAuthProviderToRoute(ctx, route, oidcProvider.ID, claimMappings)
 		if err != nil {
 			return fmt.Errorf("failed to protect route: %w", err)
 		}
@@ -161,7 +161,7 @@ func RouteProtect(ctx *Context, opts struct {
 		ctx.Printf("Warning: --claim-header is ignored for password providers\n")
 	}
 
-	_, err = ic.AttachPasswordProviderToRoute(ctx, route, opts.Provider)
+	_, err = ic.AttachAuthProviderToRoute(ctx, route, pwProvider.ID, nil)
 	if err != nil {
 		return fmt.Errorf("failed to protect route: %w", err)
 	}

--- a/cli/commands/route_show.go
+++ b/cli/commands/route_show.go
@@ -74,25 +74,21 @@ func RouteShow(ctx *Context, opts struct {
 	protectionType := "none"
 
 	if protected {
-		oidcProvider = &ingress_v1alpha.OidcProvider{}
-		if err := ic.GetEntityStore().GetById(ctx, route.AuthProvider, oidcProvider); err != nil {
+		providerEnt, err := ic.GetEntityStore().GetByIdWithEntity(ctx, route.AuthProvider, &ingress_v1alpha.OidcProvider{})
+		if err != nil {
 			if !errors.Is(err, cond.ErrNotFound{}) {
 				return fmt.Errorf("failed to get auth provider: %w", err)
 			}
-			oidcProvider = nil
-		}
-
-		if oidcProvider != nil {
-			protectionType = "oidc"
 		} else {
-			pwProvider = &ingress_v1alpha.PasswordProvider{}
-			if err := ic.GetEntityStore().GetById(ctx, route.AuthProvider, pwProvider); err != nil {
-				if !errors.Is(err, cond.ErrNotFound{}) {
-					return fmt.Errorf("failed to get auth provider: %w", err)
-				}
-				pwProvider = nil
-			}
-			if pwProvider != nil {
+			raw := providerEnt.Entity()
+			switch {
+			case entity.Is(raw, ingress_v1alpha.KindOidcProvider):
+				oidcProvider = &ingress_v1alpha.OidcProvider{}
+				oidcProvider.Decode(raw)
+				protectionType = "oidc"
+			case entity.Is(raw, ingress_v1alpha.KindPasswordProvider):
+				pwProvider = &ingress_v1alpha.PasswordProvider{}
+				pwProvider.Decode(raw)
 				protectionType = "password"
 			}
 		}

--- a/cli/commands/route_show.go
+++ b/cli/commands/route_show.go
@@ -67,37 +67,35 @@ func RouteShow(ctx *Context, opts struct {
 		}
 	}
 
-	oidcProtected := !entity.Empty(route.OidcProvider)
-	passwordProtected := !entity.Empty(route.PasswordProvider)
-	protected := oidcProtected || passwordProtected
+	protected := !entity.Empty(route.AuthProvider)
 
 	var oidcProvider *ingress_v1alpha.OidcProvider
-	if oidcProtected {
+	var pwProvider *ingress_v1alpha.PasswordProvider
+	protectionType := "none"
+
+	if protected {
 		oidcProvider = &ingress_v1alpha.OidcProvider{}
-		if err := ic.GetEntityStore().GetById(ctx, route.OidcProvider, oidcProvider); err != nil {
+		if err := ic.GetEntityStore().GetById(ctx, route.AuthProvider, oidcProvider); err != nil {
 			if !errors.Is(err, cond.ErrNotFound{}) {
-				return fmt.Errorf("failed to get identity provider: %w", err)
+				return fmt.Errorf("failed to get auth provider: %w", err)
 			}
 			oidcProvider = nil
 		}
-	}
 
-	var pwProvider *ingress_v1alpha.PasswordProvider
-	if passwordProtected {
-		pwProvider = &ingress_v1alpha.PasswordProvider{}
-		if err := ic.GetEntityStore().GetById(ctx, route.PasswordProvider, pwProvider); err != nil {
-			if !errors.Is(err, cond.ErrNotFound{}) {
-				return fmt.Errorf("failed to get password provider: %w", err)
+		if oidcProvider != nil {
+			protectionType = "oidc"
+		} else {
+			pwProvider = &ingress_v1alpha.PasswordProvider{}
+			if err := ic.GetEntityStore().GetById(ctx, route.AuthProvider, pwProvider); err != nil {
+				if !errors.Is(err, cond.ErrNotFound{}) {
+					return fmt.Errorf("failed to get auth provider: %w", err)
+				}
+				pwProvider = nil
 			}
-			pwProvider = nil
+			if pwProvider != nil {
+				protectionType = "password"
+			}
 		}
-	}
-
-	protectionType := "none"
-	if oidcProtected {
-		protectionType = "oidc"
-	} else if passwordProtected {
-		protectionType = "password"
 	}
 
 	if opts.IsJSON() {
@@ -107,8 +105,6 @@ func RouteShow(ctx *Context, opts struct {
 			Default         bool                `json:"default"`
 			Protected       bool                `json:"protected"`
 			ProtectionType  string              `json:"protection_type"`
-			OIDCEnabled     bool                `json:"oidc_enabled"`
-			PasswordEnabled bool                `json:"password_enabled"`
 			ProviderName    string              `json:"provider_name,omitempty"`
 			ProviderURL     string              `json:"provider_url,omitempty"`
 			ProviderMissing bool                `json:"provider_missing,omitempty"`
@@ -122,31 +118,25 @@ func RouteShow(ctx *Context, opts struct {
 		}
 
 		r := RouteJSON{
-			Host:            routeLabel,
-			App:             ui.CleanEntityID(string(route.App)),
-			Default:         route.Default,
-			Protected:       protected,
-			ProtectionType:  protectionType,
-			OIDCEnabled:     oidcProtected,
-			PasswordEnabled: passwordProtected,
-			WafLevel:        wafLevel,
+			Host:           routeLabel,
+			App:            ui.CleanEntityID(string(route.App)),
+			Default:        route.Default,
+			Protected:      protected,
+			ProtectionType: protectionType,
+			WafLevel:       wafLevel,
 		}
 
-		if oidcProtected {
+		if protected {
 			if oidcProvider != nil {
 				r.ProviderName = oidcProvider.Name
 				r.ProviderURL = oidcProvider.ProviderUrl
-			} else {
-				r.ProviderMissing = true
-			}
-			for _, m := range route.ClaimMappings {
-				r.ClaimMappings = append(r.ClaimMappings, map[string]string{
-					"claim":  m.Claim,
-					"header": m.Header,
-				})
-			}
-		} else if passwordProtected {
-			if pwProvider != nil {
+				for _, m := range route.ClaimMappings {
+					r.ClaimMappings = append(r.ClaimMappings, map[string]string{
+						"claim":  m.Claim,
+						"header": m.Header,
+					})
+				}
+			} else if pwProvider != nil {
 				r.ProviderName = pwProvider.Name
 			} else {
 				r.ProviderMissing = true
@@ -164,7 +154,8 @@ func RouteShow(ctx *Context, opts struct {
 		ctx.Printf("  WAF Level: %d\n", wafProfile.ParanoiaLevel)
 	}
 
-	if oidcProtected {
+	switch protectionType {
+	case "oidc":
 		ctx.Printf("  Type:      oidc\n")
 		if oidcProvider != nil {
 			ctx.Printf("  Provider:  %s (%s)\n", oidcProvider.Name, oidcProvider.ProviderUrl)
@@ -188,7 +179,7 @@ func RouteShow(ctx *Context, opts struct {
 
 			ctx.Printf("\n%s\n", table.Render())
 		}
-	} else if passwordProtected {
+	case "password":
 		ctx.Printf("  Type:      password\n")
 		if pwProvider != nil {
 			ctx.Printf("  Provider:  %s\n", pwProvider.Name)

--- a/cli/commands/route_show.go
+++ b/cli/commands/route_show.go
@@ -67,16 +67,37 @@ func RouteShow(ctx *Context, opts struct {
 		}
 	}
 
-	protected := !entity.Empty(route.OidcProvider)
-	var provider *ingress_v1alpha.OidcProvider
-	if protected {
-		provider = &ingress_v1alpha.OidcProvider{}
-		if err := ic.GetEntityStore().GetById(ctx, route.OidcProvider, provider); err != nil {
+	oidcProtected := !entity.Empty(route.OidcProvider)
+	passwordProtected := !entity.Empty(route.PasswordProvider)
+	protected := oidcProtected || passwordProtected
+
+	var oidcProvider *ingress_v1alpha.OidcProvider
+	if oidcProtected {
+		oidcProvider = &ingress_v1alpha.OidcProvider{}
+		if err := ic.GetEntityStore().GetById(ctx, route.OidcProvider, oidcProvider); err != nil {
 			if !errors.Is(err, cond.ErrNotFound{}) {
 				return fmt.Errorf("failed to get identity provider: %w", err)
 			}
-			provider = nil
+			oidcProvider = nil
 		}
+	}
+
+	var pwProvider *ingress_v1alpha.PasswordProvider
+	if passwordProtected {
+		pwProvider = &ingress_v1alpha.PasswordProvider{}
+		if err := ic.GetEntityStore().GetById(ctx, route.PasswordProvider, pwProvider); err != nil {
+			if !errors.Is(err, cond.ErrNotFound{}) {
+				return fmt.Errorf("failed to get password provider: %w", err)
+			}
+			pwProvider = nil
+		}
+	}
+
+	protectionType := "none"
+	if oidcProtected {
+		protectionType = "oidc"
+	} else if passwordProtected {
+		protectionType = "password"
 	}
 
 	if opts.IsJSON() {
@@ -85,7 +106,9 @@ func RouteShow(ctx *Context, opts struct {
 			App             string              `json:"app"`
 			Default         bool                `json:"default"`
 			Protected       bool                `json:"protected"`
+			ProtectionType  string              `json:"protection_type"`
 			OIDCEnabled     bool                `json:"oidc_enabled"`
+			PasswordEnabled bool                `json:"password_enabled"`
 			ProviderName    string              `json:"provider_name,omitempty"`
 			ProviderURL     string              `json:"provider_url,omitempty"`
 			ProviderMissing bool                `json:"provider_missing,omitempty"`
@@ -99,18 +122,20 @@ func RouteShow(ctx *Context, opts struct {
 		}
 
 		r := RouteJSON{
-			Host:        routeLabel,
-			App:         ui.CleanEntityID(string(route.App)),
-			Default:     route.Default,
-			Protected:   protected,
-			OIDCEnabled: protected,
-			WafLevel:    wafLevel,
+			Host:            routeLabel,
+			App:             ui.CleanEntityID(string(route.App)),
+			Default:         route.Default,
+			Protected:       protected,
+			ProtectionType:  protectionType,
+			OIDCEnabled:     oidcProtected,
+			PasswordEnabled: passwordProtected,
+			WafLevel:        wafLevel,
 		}
 
-		if protected {
-			if provider != nil {
-				r.ProviderName = provider.Name
-				r.ProviderURL = provider.ProviderUrl
+		if oidcProtected {
+			if oidcProvider != nil {
+				r.ProviderName = oidcProvider.Name
+				r.ProviderURL = oidcProvider.ProviderUrl
 			} else {
 				r.ProviderMissing = true
 			}
@@ -119,6 +144,12 @@ func RouteShow(ctx *Context, opts struct {
 					"claim":  m.Claim,
 					"header": m.Header,
 				})
+			}
+		} else if passwordProtected {
+			if pwProvider != nil {
+				r.ProviderName = pwProvider.Name
+			} else {
+				r.ProviderMissing = true
 			}
 		}
 
@@ -133,9 +164,10 @@ func RouteShow(ctx *Context, opts struct {
 		ctx.Printf("  WAF Level: %d\n", wafProfile.ParanoiaLevel)
 	}
 
-	if protected {
-		if provider != nil {
-			ctx.Printf("  Provider:  %s (%s)\n", provider.Name, provider.ProviderUrl)
+	if oidcProtected {
+		ctx.Printf("  Type:      oidc\n")
+		if oidcProvider != nil {
+			ctx.Printf("  Provider:  %s (%s)\n", oidcProvider.Name, oidcProvider.ProviderUrl)
 		} else {
 			ctx.Printf("  Provider:  <missing — provider has been deleted>\n")
 		}
@@ -155,6 +187,13 @@ func RouteShow(ctx *Context, opts struct {
 			)
 
 			ctx.Printf("\n%s\n", table.Render())
+		}
+	} else if passwordProtected {
+		ctx.Printf("  Type:      password\n")
+		if pwProvider != nil {
+			ctx.Printf("  Provider:  %s\n", pwProvider.Name)
+		} else {
+			ctx.Printf("  Provider:  <missing — provider has been deleted>\n")
 		}
 	}
 

--- a/cli/commands/route_unprotect.go
+++ b/cli/commands/route_unprotect.go
@@ -51,11 +51,12 @@ func RouteUnprotect(ctx *Context, opts struct {
 		routeLabel = opts.Host
 	}
 
-	if entity.Empty(route.OidcProvider) {
+	if entity.Empty(route.OidcProvider) && entity.Empty(route.PasswordProvider) {
 		ctx.Printf("Route is not protected: %s\n", routeLabel)
 		return nil
 	}
 
+	// DetachOIDCProviderFromRoute clears both OIDC and password provider refs
 	_, err = ic.DetachOIDCProviderFromRoute(ctx, route)
 	if err != nil {
 		return fmt.Errorf("failed to remove route protection: %w", err)

--- a/cli/commands/route_unprotect.go
+++ b/cli/commands/route_unprotect.go
@@ -51,13 +51,12 @@ func RouteUnprotect(ctx *Context, opts struct {
 		routeLabel = opts.Host
 	}
 
-	if entity.Empty(route.OidcProvider) && entity.Empty(route.PasswordProvider) {
+	if entity.Empty(route.AuthProvider) {
 		ctx.Printf("Route is not protected: %s\n", routeLabel)
 		return nil
 	}
 
-	// DetachOIDCProviderFromRoute clears both OIDC and password provider refs
-	_, err = ic.DetachOIDCProviderFromRoute(ctx, route)
+	_, err = ic.DetachAuthProviderFromRoute(ctx, route)
 	if err != nil {
 		return fmt.Errorf("failed to remove route protection: %w", err)
 	}

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -63,6 +63,7 @@
       "command/auth-generate",
       "command/auth-provider",
       "command/auth-provider-add",
+      "command/auth-provider-add-password",
       "command/auth-provider-list",
       "command/auth-provider-remove",
       "command/auth-provider-show"

--- a/docs/docs/command/auth-provider-add-password.md
+++ b/docs/docs/command/auth-provider-add-password.md
@@ -8,10 +8,6 @@ description: "Add a password provider for route protection"
 
 Add a password provider for route protection
 
-:::note
-This command requires the `routeoidc` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/auth-provider-add-password.md
+++ b/docs/docs/command/auth-provider-add-password.md
@@ -22,7 +22,7 @@ miren auth provider add-password <name> [flags]
 
 - `--cluster, -C` — Cluster name
 - `--config` — Path to the config file
-- `--password` — Password to protect routes with
+- `--password` — Password (omit to prompt interactively, use @file to read from file)
 - `--update` — Overwrite an existing provider with the same name (rotates password)
 
 ## Global Options

--- a/docs/docs/command/auth-provider-add-password.md
+++ b/docs/docs/command/auth-provider-add-password.md
@@ -1,0 +1,48 @@
+---
+title: "miren auth provider add-password"
+sidebar_label: "auth provider add-password"
+description: "Add a password provider for route protection"
+---
+
+# miren auth provider add-password
+
+Add a password provider for route protection
+
+:::note
+This command requires the `routeoidc` [labs feature](/labs) to be enabled.
+:::
+
+## Usage
+
+```bash
+miren auth provider add-password <name> [flags]
+```
+
+## Arguments
+
+- `name` — Name for this password provider
+
+## Flags
+
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--password` — Password to protect routes with
+- `--update` — Overwrite an existing provider with the same name (rotates password)
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Add a password provider:**
+
+```bash
+miren auth provider add-password my-pw --password hunter2
+```
+
+## See also
+
+- [`miren auth provider`](/command/auth-provider)

--- a/docs/docs/command/auth-provider.md
+++ b/docs/docs/command/auth-provider.md
@@ -17,6 +17,7 @@ miren auth provider [flags]
 ## Subcommands
 
 - [`miren auth provider add`](/command/auth-provider-add) — Add an identity provider for route protection
+- [`miren auth provider add-password`](/command/auth-provider-add-password) — Add a password provider for route protection
 - [`miren auth provider list`](/command/auth-provider-list) — List identity providers
 - [`miren auth provider remove`](/command/auth-provider-remove) — Remove an identity provider
 - [`miren auth provider show`](/command/auth-provider-show) — Show an identity provider

--- a/docs/docs/command/route-protect.md
+++ b/docs/docs/command/route-protect.md
@@ -36,10 +36,16 @@ miren route protect <host> [flags]
 
 ## Examples
 
-**Protect a route with an identity provider:**
+**Protect a route with an OIDC provider:**
 
 ```bash
 miren route protect example.com --provider my-google-oidc --claim-header email:X-User-Email
+```
+
+**Protect a route with a password:**
+
+```bash
+miren route protect example.com --provider my-pw
 ```
 
 **Protect the default route:**

--- a/docs/docs/command/route-protect.md
+++ b/docs/docs/command/route-protect.md
@@ -36,16 +36,10 @@ miren route protect <host> [flags]
 
 ## Examples
 
-**Protect a route with an OIDC provider:**
+**Protect a route with an identity provider:**
 
 ```bash
 miren route protect example.com --provider my-google-oidc --claim-header email:X-User-Email
-```
-
-**Protect a route with a password:**
-
-```bash
-miren route protect example.com --provider my-pw
 ```
 
 **Protect the default route:**

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -63,6 +63,7 @@ Complete reference for all `miren` CLI commands.
 | [`miren auth generate`](/command/auth-generate) | Generate authentication config file |
 | [`miren auth provider`](/command/auth-provider) | Identity provider management |
 | [`miren auth provider add`](/command/auth-provider-add) | Add an identity provider for route protection |
+| [`miren auth provider add-password`](/command/auth-provider-add-password) | Add a password provider for route protection |
 | [`miren auth provider list`](/command/auth-provider-list) | List identity providers |
 | [`miren auth provider remove`](/command/auth-provider-remove) | Remove an identity provider |
 | [`miren auth provider show`](/command/auth-provider-show) | Show an identity provider |

--- a/pkg/oidc/session.go
+++ b/pkg/oidc/session.go
@@ -290,3 +290,57 @@ func (sm *SessionManager) ClearState(w http.ResponseWriter) {
 		SameSite: http.SameSiteLaxMode,
 	})
 }
+
+// GetNamedCookie reads and decrypts a cookie by name, returning the raw plaintext.
+// Returns nil, nil if the cookie is not present.
+func (sm *SessionManager) GetNamedCookie(r *http.Request, name string) ([]byte, error) {
+	cookie, err := r.Cookie(name)
+	if err != nil {
+		if err == http.ErrNoCookie {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read cookie %s: %w", name, err)
+	}
+
+	data, err := sm.openCookie(cookie.Value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cookie %s: %w", name, err)
+	}
+
+	return data, nil
+}
+
+// SetNamedCookie encrypts data and stores it in a cookie with the given name and expiry.
+func (sm *SessionManager) SetNamedCookie(w http.ResponseWriter, name string, data []byte, expiry time.Time) error {
+	sealed, err := sm.sealCookie(data)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt cookie %s: %w", name, err)
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    sealed,
+		Path:     "/",
+		Domain:   sm.cookieDomain,
+		Expires:  expiry,
+		Secure:   sm.cookieSecure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	return nil
+}
+
+// ClearNamedCookie removes a cookie by name.
+func (sm *SessionManager) ClearNamedCookie(w http.ResponseWriter, name string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     "/",
+		Domain:   sm.cookieDomain,
+		MaxAge:   -1,
+		Secure:   sm.cookieSecure,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -603,9 +603,9 @@ func (h *Server) authMiddleware(route *ingress_v1alpha.HttpRoute, next http.Hand
 
 		switch {
 		case entity.Is(ent, ingress_v1alpha.KindOidcProvider):
-			h.oidcMiddleware(route, next)(w, r)
+			h.oidcMiddleware(route, ent, next)(w, r)
 		case entity.Is(ent, ingress_v1alpha.KindPasswordProvider):
-			h.passwordMiddleware(route, next)(w, r)
+			h.passwordMiddleware(route, ent, next)(w, r)
 		default:
 			h.Log.Error("unknown auth provider kind", "provider", route.AuthProvider)
 			http.Error(w, "Authentication service unavailable", http.StatusServiceUnavailable)

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -552,11 +552,7 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 		h.serveAuthenticatedRequest(w, r, targetAppId, routeType, ephemeralLabel, appName)
 	}
 
-	if !entity.Empty(route.OidcProvider) {
-		handler = h.oidcMiddleware(route, handler)
-	} else if !entity.Empty(route.PasswordProvider) {
-		handler = h.passwordMiddleware(route, handler)
-	}
+	handler = h.authMiddleware(route, handler)
 
 	handler = h.wafMiddleware(route, handler)
 
@@ -588,6 +584,33 @@ func (h *Server) lookupEphemeralRoute(ctx context.Context, host string) (string,
 	}
 
 	return label, route, nil
+}
+
+func (h *Server) authMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
+	if entity.Empty(route.AuthProvider) {
+		return next
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp, err := h.eac.Get(r.Context(), string(route.AuthProvider))
+		if err != nil {
+			h.Log.Error("failed to get auth provider entity", "error", err, "provider", route.AuthProvider)
+			http.Error(w, "Authentication service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		ent := resp.Entity().Entity()
+
+		switch {
+		case entity.Is(ent, ingress_v1alpha.KindOidcProvider):
+			h.oidcMiddleware(route, next)(w, r)
+		case entity.Is(ent, ingress_v1alpha.KindPasswordProvider):
+			h.passwordMiddleware(route, next)(w, r)
+		default:
+			h.Log.Error("unknown auth provider kind", "provider", route.AuthProvider)
+			http.Error(w, "Authentication service unavailable", http.StatusServiceUnavailable)
+		}
+	}
 }
 
 // serveAuthenticatedRequest handles the request after authentication (if any)
@@ -1174,14 +1197,8 @@ func (h *Server) AcquireTunnel(ctx context.Context, hostname, path string) (*Tun
 	if route != nil {
 		targetAppId = route.App
 
-		// Reject tunnels to apps that require authentication.
-		// Auth flows require browser interaction which can't work
-		// over a tunneled WebSocket connection.
-		if !entity.Empty(route.OidcProvider) {
-			return nil, fmt.Errorf("tunneling not supported for OIDC-protected routes (host: %s)", onlyHost)
-		}
-		if !entity.Empty(route.PasswordProvider) {
-			return nil, fmt.Errorf("tunneling not supported for password-protected routes (host: %s)", onlyHost)
+		if !entity.Empty(route.AuthProvider) {
+			return nil, fmt.Errorf("tunneling not supported for auth-protected routes (host: %s)", onlyHost)
 		}
 	} else {
 		defaultRoute, err := h.ingressClient.LookupDefault(ctx)
@@ -1191,11 +1208,8 @@ func (h *Server) AcquireTunnel(ctx context.Context, hostname, path string) (*Tun
 		if defaultRoute == nil {
 			return nil, fmt.Errorf("no route found for %s", onlyHost)
 		}
-		if !entity.Empty(defaultRoute.OidcProvider) {
-			return nil, fmt.Errorf("tunneling not supported for OIDC-protected routes (host: %s)", onlyHost)
-		}
-		if !entity.Empty(defaultRoute.PasswordProvider) {
-			return nil, fmt.Errorf("tunneling not supported for password-protected routes (host: %s)", onlyHost)
+		if !entity.Empty(defaultRoute.AuthProvider) {
+			return nil, fmt.Errorf("tunneling not supported for auth-protected routes (host: %s)", onlyHost)
 		}
 		targetAppId = defaultRoute.App
 	}

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -100,6 +100,9 @@ type Server struct {
 	wafEngine       *waf.Engine
 	wafProfileMu    sync.RWMutex
 	wafProfileCache map[entity.Id]*wafProfileEntry
+
+	passwordMu       sync.RWMutex
+	passwordHandlers map[string]*passwordHandler
 }
 
 type appUsage struct {
@@ -162,6 +165,7 @@ func NewServer(
 		oidcHandlers:       make(map[string]*oidcHandler),
 		wafEngine:          waf.NewEngine(log.With("component", "waf")),
 		wafProfileCache:    make(map[entity.Id]*wafProfileEntry),
+		passwordHandlers:   make(map[string]*passwordHandler),
 	}
 
 	if httpMetrics == nil {
@@ -543,13 +547,15 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 		h.Log.Debug("using default route", "host", onlyHost, "app", targetAppId)
 	}
 
-	// Compose middleware chain: WAF → OIDC → serve
+	// Compose middleware chain: WAF → auth → serve
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		h.serveAuthenticatedRequest(w, r, targetAppId, routeType, ephemeralLabel, appName)
 	}
 
 	if !entity.Empty(route.OidcProvider) {
 		handler = h.oidcMiddleware(route, handler)
+	} else if !entity.Empty(route.PasswordProvider) {
+		handler = h.passwordMiddleware(route, handler)
 	}
 
 	handler = h.wafMiddleware(route, handler)
@@ -1168,11 +1174,14 @@ func (h *Server) AcquireTunnel(ctx context.Context, hostname, path string) (*Tun
 	if route != nil {
 		targetAppId = route.App
 
-		// Reject tunnels to apps that require OIDC authentication.
-		// OIDC auth flows require browser redirects which can't work
+		// Reject tunnels to apps that require authentication.
+		// Auth flows require browser interaction which can't work
 		// over a tunneled WebSocket connection.
 		if !entity.Empty(route.OidcProvider) {
 			return nil, fmt.Errorf("tunneling not supported for OIDC-protected routes (host: %s)", onlyHost)
+		}
+		if !entity.Empty(route.PasswordProvider) {
+			return nil, fmt.Errorf("tunneling not supported for password-protected routes (host: %s)", onlyHost)
 		}
 	} else {
 		defaultRoute, err := h.ingressClient.LookupDefault(ctx)
@@ -1184,6 +1193,9 @@ func (h *Server) AcquireTunnel(ctx context.Context, hostname, path string) (*Tun
 		}
 		if !entity.Empty(defaultRoute.OidcProvider) {
 			return nil, fmt.Errorf("tunneling not supported for OIDC-protected routes (host: %s)", onlyHost)
+		}
+		if !entity.Empty(defaultRoute.PasswordProvider) {
+			return nil, fmt.Errorf("tunneling not supported for password-protected routes (host: %s)", onlyHost)
 		}
 		targetAppId = defaultRoute.App
 	}

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -327,9 +327,8 @@ func oidcProviderMatches(cached *oidcHandler, current *ingress_v1alpha.OidcProvi
 // creating one on first access. The handler (and its oidc.Client) is reused
 // across requests so that discovery and JWKS caches are effective.
 // If the provider config has changed since the handler was cached, the stale
-// handler is replaced with a new one. If the entity store is unreachable but
-// a cached handler exists, the cached handler is returned to avoid failing
-// open (serving requests without authentication).
+// handler is replaced with a new one. If the entity store is unreachable,
+// the cached handler is evicted and an error is returned (fail-closed).
 func (s *Server) getOrCreateOIDCHandler(ctx context.Context, route *ingress_v1alpha.HttpRoute, baseURL string) (*oidcHandler, error) {
 	// Key by route host + baseURL so that handlers with different redirect
 	// URIs (different scheme or host for default routes) are cached separately.
@@ -338,18 +337,11 @@ func (s *Server) getOrCreateOIDCHandler(ctx context.Context, route *ingress_v1al
 		key = "__default__|" + baseURL
 	}
 
-	// Try to resolve the current provider config from the entity store.
 	resp, err := s.eac.Get(ctx, string(route.AuthProvider))
 	if err != nil {
-		// Entity store unavailable — return cached handler if we have one
-		// to avoid failing open (serving without auth).
-		s.oidcMu.RLock()
-		h, ok := s.oidcHandlers[key]
-		s.oidcMu.RUnlock()
-		if ok {
-			s.Log.Warn("entity store unavailable, using cached OIDC handler", "error", err, "host", route.Host)
-			return h, nil
-		}
+		s.oidcMu.Lock()
+		delete(s.oidcHandlers, key)
+		s.oidcMu.Unlock()
 		return nil, fmt.Errorf("failed to get OIDC provider: %w", err)
 	}
 

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -339,7 +339,7 @@ func (s *Server) getOrCreateOIDCHandler(ctx context.Context, route *ingress_v1al
 	}
 
 	// Try to resolve the current provider config from the entity store.
-	resp, err := s.eac.Get(ctx, string(route.OidcProvider))
+	resp, err := s.eac.Get(ctx, string(route.AuthProvider))
 	if err != nil {
 		// Entity store unavailable — return cached handler if we have one
 		// to avoid failing open (serving without auth).
@@ -389,7 +389,7 @@ func (s *Server) getOrCreateOIDCHandler(ctx context.Context, route *ingress_v1al
 
 // oidcMiddleware wraps the request handling with OIDC authentication
 func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
-	if entity.Empty(route.OidcProvider) {
+	if entity.Empty(route.AuthProvider) {
 		return next
 	}
 
@@ -402,7 +402,7 @@ func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.Hand
 		handler, err := s.getOrCreateOIDCHandler(r.Context(), route, baseURL)
 		if err != nil {
 			s.Log.Error("failed to get OIDC handler", "error", err, "host", r.Host)
-			next(w, r)
+			http.Error(w, "Authentication service unavailable", http.StatusServiceUnavailable)
 			return
 		}
 

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -1,7 +1,6 @@
 package httpingress
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -329,24 +328,14 @@ func oidcProviderMatches(cached *oidcHandler, current *ingress_v1alpha.OidcProvi
 // If the provider config has changed since the handler was cached, the stale
 // handler is replaced with a new one. If the entity store is unreachable,
 // the cached handler is evicted and an error is returned (fail-closed).
-func (s *Server) getOrCreateOIDCHandler(ctx context.Context, route *ingress_v1alpha.HttpRoute, baseURL string) (*oidcHandler, error) {
-	// Key by route host + baseURL so that handlers with different redirect
-	// URIs (different scheme or host for default routes) are cached separately.
+func (s *Server) getOrCreateOIDCHandler(route *ingress_v1alpha.HttpRoute, baseURL string, providerEntity entity.AttrGetter) (*oidcHandler, error) {
 	key := route.Host + "|" + baseURL
 	if route.Default {
 		key = "__default__|" + baseURL
 	}
 
-	resp, err := s.eac.Get(ctx, string(route.AuthProvider))
-	if err != nil {
-		s.oidcMu.Lock()
-		delete(s.oidcHandlers, key)
-		s.oidcMu.Unlock()
-		return nil, fmt.Errorf("failed to get OIDC provider: %w", err)
-	}
-
 	var provider ingress_v1alpha.OidcProvider
-	provider.Decode(resp.Entity().Entity())
+	provider.Decode(providerEntity)
 
 	s.oidcMu.RLock()
 	if h, ok := s.oidcHandlers[key]; ok && oidcProviderMatches(h, &provider) {
@@ -379,19 +368,14 @@ func (s *Server) getOrCreateOIDCHandler(ctx context.Context, route *ingress_v1al
 	return handler, nil
 }
 
-// oidcMiddleware wraps the request handling with OIDC authentication
-func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
-	if entity.Empty(route.AuthProvider) {
-		return next
-	}
-
+func (s *Server) oidcMiddleware(route *ingress_v1alpha.HttpRoute, providerEntity entity.AttrGetter, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		scheme := requestScheme(r)
 		baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
 
 		s.oidcSessionManager.SetSecure(scheme == "https")
 
-		handler, err := s.getOrCreateOIDCHandler(r.Context(), route, baseURL)
+		handler, err := s.getOrCreateOIDCHandler(route, baseURL, providerEntity)
 		if err != nil {
 			s.Log.Error("failed to get OIDC handler", "error", err, "host", r.Host)
 			http.Error(w, "Authentication service unavailable", http.StatusServiceUnavailable)

--- a/servers/httpingress/oidc_test.go
+++ b/servers/httpingress/oidc_test.go
@@ -350,7 +350,7 @@ func TestGetOrCreateOIDCHandlerFailClosed(t *testing.T) {
 	}
 
 	// Warm the cache
-	h1, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
+	_, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
 	if err != nil {
 		t.Fatalf("initial getOrCreateOIDCHandler: %v", err)
 	}
@@ -358,22 +358,17 @@ func TestGetOrCreateOIDCHandlerFailClosed(t *testing.T) {
 	// Remove the provider entity to simulate entity store being unavailable
 	store.RemoveEntity(entity.Id(providerIdent))
 
-	// Should return cached handler instead of failing open
-	h2, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
-	if err != nil {
-		t.Fatalf("expected cached handler on entity store failure, got error: %v", err)
-	}
-	if h1 != h2 {
-		t.Error("expected same cached handler instance on entity store failure")
+	// Should fail closed and clear cached handler
+	_, err = srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
+	if err == nil {
+		t.Error("expected error when entity store fails, not cached fallback")
 	}
 
-	// With no cache entry and no entity store, should error (not fail open)
-	routeNew := &ingress_v1alpha.HttpRoute{
-		Host:         "newsite.example.com",
-		AuthProvider: entity.Id(providerIdent),
-	}
-	_, err = srv.getOrCreateOIDCHandler(context.Background(), routeNew, "https://newsite.example.com")
-	if err == nil {
-		t.Error("expected error when entity store fails and no cached handler exists")
+	// Cache entry should have been removed
+	srv.oidcMu.RLock()
+	_, cached := srv.oidcHandlers["socials.example.com|https://socials.example.com"]
+	srv.oidcMu.RUnlock()
+	if cached {
+		t.Error("expected cached handler to be removed after lookup failure")
 	}
 }

--- a/servers/httpingress/oidc_test.go
+++ b/servers/httpingress/oidc_test.go
@@ -283,7 +283,7 @@ func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
 
 	route := &ingress_v1alpha.HttpRoute{
 		Host:         "socials.example.com",
-		OidcProvider: entity.Id(providerIdent),
+		AuthProvider: entity.Id(providerIdent),
 	}
 
 	// First call: creates and caches a handler
@@ -346,7 +346,7 @@ func TestGetOrCreateOIDCHandlerFailClosed(t *testing.T) {
 
 	route := &ingress_v1alpha.HttpRoute{
 		Host:         "socials.example.com",
-		OidcProvider: entity.Id(providerIdent),
+		AuthProvider: entity.Id(providerIdent),
 	}
 
 	// Warm the cache
@@ -370,7 +370,7 @@ func TestGetOrCreateOIDCHandlerFailClosed(t *testing.T) {
 	// With no cache entry and no entity store, should error (not fail open)
 	routeNew := &ingress_v1alpha.HttpRoute{
 		Host:         "newsite.example.com",
-		OidcProvider: entity.Id(providerIdent),
+		AuthProvider: entity.Id(providerIdent),
 	}
 	_, err = srv.getOrCreateOIDCHandler(context.Background(), routeNew, "https://newsite.example.com")
 	if err == nil {

--- a/servers/httpingress/oidc_test.go
+++ b/servers/httpingress/oidc_test.go
@@ -1,17 +1,13 @@
 package httpingress
 
 import (
-	"context"
 	"log/slog"
 	"net/http/httptest"
 	"testing"
 
-	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/oidc"
-	"miren.dev/runtime/pkg/rpc"
-	"miren.dev/runtime/servers/entityserver"
 )
 
 func TestInjectClaims(t *testing.T) {
@@ -246,48 +242,38 @@ func TestOidcProviderMatches(t *testing.T) {
 	})
 }
 
-// storeOIDCProvider adds or replaces an OidcProvider entity in the mock store.
-func storeOIDCProvider(store *entity.MockStore, ident, clientID, clientSecret, providerURL, scopes string) {
-	store.AddEntity(entity.Id(ident), entity.New([]entity.Attr{
-		{ID: entity.Ident, Value: entity.KeywordValue(ident)},
+func makeOIDCProviderEntity(ident, clientID, clientSecret, providerURL, scopes string) *entity.Entity {
+	return entity.New(
+		entity.DBId, entity.Id(ident),
+		entity.Ref(entity.EntityKind, ingress_v1alpha.KindOidcProvider),
 		entity.String(ingress_v1alpha.OidcProviderClientIdId, clientID),
 		entity.String(ingress_v1alpha.OidcProviderClientSecretId, clientSecret),
 		entity.String(ingress_v1alpha.OidcProviderProviderUrlId, providerURL),
 		entity.String(ingress_v1alpha.OidcProviderScopesId, scopes),
-	}))
+	)
 }
 
 func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
-	store := entity.NewMockStore()
-	esrv := &entityserver.EntityServer{
-		Log:   slog.Default(),
-		Store: store,
-	}
-	eac := &entityserver_v1alpha.EntityAccessClient{
-		Client: rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(esrv)),
-	}
-
 	signingKey := make([]byte, 32)
 
 	srv := &Server{
 		Log:                slog.Default(),
-		eac:                eac,
 		oidcSessionManager: oidc.NewSessionManager(false, "", signingKey),
 		oidcHandlers:       make(map[string]*oidcHandler),
 	}
 
 	providerIdent := "test/oidc-provider"
 
-	storeOIDCProvider(store, providerIdent,
-		"client-AAA", "secret-AAA", "https://auth.example.com", "openid email")
-
 	route := &ingress_v1alpha.HttpRoute{
 		Host:         "socials.example.com",
 		AuthProvider: entity.Id(providerIdent),
 	}
 
+	entA := makeOIDCProviderEntity(providerIdent,
+		"client-AAA", "secret-AAA", "https://auth.example.com", "openid email")
+
 	// First call: creates and caches a handler
-	h1, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
+	h1, err := srv.getOrCreateOIDCHandler(route, "https://socials.example.com", entA)
 	if err != nil {
 		t.Fatalf("first getOrCreateOIDCHandler: %v", err)
 	}
@@ -295,8 +281,8 @@ func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
 		t.Fatalf("expected client_id=client-AAA, got %s", h1.provider.ClientId)
 	}
 
-	// Second call with same provider: should return cached handler
-	h2, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
+	// Second call with same entity: should return cached handler
+	h2, err := srv.getOrCreateOIDCHandler(route, "https://socials.example.com", entA)
 	if err != nil {
 		t.Fatalf("second getOrCreateOIDCHandler: %v", err)
 	}
@@ -304,12 +290,11 @@ func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
 		t.Error("expected same handler instance on cache hit")
 	}
 
-	// Update the provider entity with a new client_id
-	storeOIDCProvider(store, providerIdent,
+	// Pass a new entity with updated client_id
+	entB := makeOIDCProviderEntity(providerIdent,
 		"client-BBB", "secret-AAA", "https://auth.example.com", "openid email")
 
-	// Third call: provider changed, should return a new handler
-	h3, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
+	h3, err := srv.getOrCreateOIDCHandler(route, "https://socials.example.com", entB)
 	if err != nil {
 		t.Fatalf("third getOrCreateOIDCHandler: %v", err)
 	}
@@ -318,57 +303,5 @@ func TestGetOrCreateOIDCHandlerCacheInvalidation(t *testing.T) {
 	}
 	if h1 == h3 {
 		t.Error("expected different handler instance after provider change")
-	}
-}
-
-func TestGetOrCreateOIDCHandlerFailClosed(t *testing.T) {
-	store := entity.NewMockStore()
-	esrv := &entityserver.EntityServer{
-		Log:   slog.Default(),
-		Store: store,
-	}
-	eac := &entityserver_v1alpha.EntityAccessClient{
-		Client: rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(esrv)),
-	}
-
-	signingKey := make([]byte, 32)
-
-	srv := &Server{
-		Log:                slog.Default(),
-		eac:                eac,
-		oidcSessionManager: oidc.NewSessionManager(false, "", signingKey),
-		oidcHandlers:       make(map[string]*oidcHandler),
-	}
-
-	providerIdent := "test/oidc-provider"
-	storeOIDCProvider(store, providerIdent,
-		"client-AAA", "secret-AAA", "https://auth.example.com", "openid email")
-
-	route := &ingress_v1alpha.HttpRoute{
-		Host:         "socials.example.com",
-		AuthProvider: entity.Id(providerIdent),
-	}
-
-	// Warm the cache
-	_, err := srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
-	if err != nil {
-		t.Fatalf("initial getOrCreateOIDCHandler: %v", err)
-	}
-
-	// Remove the provider entity to simulate entity store being unavailable
-	store.RemoveEntity(entity.Id(providerIdent))
-
-	// Should fail closed and clear cached handler
-	_, err = srv.getOrCreateOIDCHandler(context.Background(), route, "https://socials.example.com")
-	if err == nil {
-		t.Error("expected error when entity store fails, not cached fallback")
-	}
-
-	// Cache entry should have been removed
-	srv.oidcMu.RLock()
-	_, cached := srv.oidcHandlers["socials.example.com|https://socials.example.com"]
-	srv.oidcMu.RUnlock()
-	if cached {
-		t.Error("expected cached handler to be removed after lookup failure")
 	}
 }

--- a/servers/httpingress/password_auth.go
+++ b/servers/httpingress/password_auth.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"log/slog"
 	"net/http"
+	"path"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -79,6 +82,20 @@ func (h *passwordHandler) clearSession(w http.ResponseWriter) {
 	h.sm.ClearNamedCookie(w, pwSessionCookieName)
 }
 
+func sanitizeReturnPath(raw string) string {
+	if raw == "" {
+		return "/"
+	}
+	if strings.Contains(raw, "://") || strings.HasPrefix(raw, "//") {
+		return "/"
+	}
+	cleaned := path.Clean("/" + raw)
+	if !strings.HasPrefix(cleaned, "/") {
+		return "/"
+	}
+	return cleaned
+}
+
 func (h *passwordHandler) serveLoginForm(w http.ResponseWriter, returnPath string, errorMsg string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
@@ -88,12 +105,12 @@ func (h *passwordHandler) serveLoginForm(w http.ResponseWriter, returnPath strin
 		errorHTML = `<p style="color:#c0392b;margin-bottom:16px">` + errorMsg + `</p>`
 	}
 
-	fmt.Fprintf(w, loginFormHTML, errorHTML, returnPath)
+	fmt.Fprintf(w, loginFormHTML, errorHTML, html.EscapeString(returnPath))
 }
 
 func (h *passwordHandler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		h.serveLoginForm(w, r.URL.Query().Get("return"), "")
+		h.serveLoginForm(w, sanitizeReturnPath(r.URL.Query().Get("return")), "")
 		return
 	}
 
@@ -104,7 +121,7 @@ func (h *passwordHandler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	password := r.FormValue("password")
-	returnPath := r.FormValue("return")
+	returnPath := sanitizeReturnPath(r.FormValue("return"))
 
 	err := bcrypt.CompareHashAndPassword([]byte(h.provider.PasswordHash), []byte(password))
 	if err != nil {
@@ -117,10 +134,6 @@ func (h *passwordHandler) handleLogin(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("failed to set session", "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
-	}
-
-	if returnPath == "" {
-		returnPath = "/"
 	}
 
 	h.logger.Info("password authentication successful", "host", h.route.Host)
@@ -145,13 +158,9 @@ func (s *Server) getOrCreatePasswordHandler(ctx context.Context, route *ingress_
 
 	resp, err := s.eac.Get(ctx, string(route.PasswordProvider))
 	if err != nil {
-		s.passwordMu.RLock()
-		h, ok := s.passwordHandlers[key]
-		s.passwordMu.RUnlock()
-		if ok {
-			s.Log.Warn("entity store unavailable, using cached password handler", "error", err, "host", route.Host)
-			return h, nil
-		}
+		s.passwordMu.Lock()
+		delete(s.passwordHandlers, key)
+		s.passwordMu.Unlock()
 		return nil, fmt.Errorf("failed to get password provider: %w", err)
 	}
 
@@ -197,7 +206,7 @@ func (s *Server) passwordMiddleware(route *ingress_v1alpha.HttpRoute, next http.
 		handler, err := s.getOrCreatePasswordHandler(r.Context(), route, baseURL)
 		if err != nil {
 			s.Log.Error("failed to get password handler", "error", err, "host", r.Host)
-			next(w, r)
+			http.Error(w, "Authentication service unavailable", http.StatusServiceUnavailable)
 			return
 		}
 
@@ -216,7 +225,7 @@ func (s *Server) passwordMiddleware(route *ingress_v1alpha.HttpRoute, next http.
 			return
 		}
 
-		handler.serveLoginForm(w, r.URL.RequestURI(), "")
+		handler.serveLoginForm(w, sanitizeReturnPath(r.URL.RequestURI()), "")
 	}
 }
 

--- a/servers/httpingress/password_auth.go
+++ b/servers/httpingress/password_auth.go
@@ -156,7 +156,7 @@ func (s *Server) getOrCreatePasswordHandler(ctx context.Context, route *ingress_
 		key = "__default__|" + baseURL
 	}
 
-	resp, err := s.eac.Get(ctx, string(route.PasswordProvider))
+	resp, err := s.eac.Get(ctx, string(route.AuthProvider))
 	if err != nil {
 		s.passwordMu.Lock()
 		delete(s.passwordHandlers, key)
@@ -193,7 +193,7 @@ func (s *Server) getOrCreatePasswordHandler(ctx context.Context, route *ingress_
 }
 
 func (s *Server) passwordMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
-	if entity.Empty(route.PasswordProvider) {
+	if entity.Empty(route.AuthProvider) {
 		return next
 	}
 

--- a/servers/httpingress/password_auth.go
+++ b/servers/httpingress/password_auth.go
@@ -1,7 +1,6 @@
 package httpingress
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -150,22 +149,14 @@ func passwordProviderMatches(cached *passwordHandler, current *ingress_v1alpha.P
 	return cp.ID == current.ID && cp.PasswordHash == current.PasswordHash
 }
 
-func (s *Server) getOrCreatePasswordHandler(ctx context.Context, route *ingress_v1alpha.HttpRoute, baseURL string) (*passwordHandler, error) {
+func (s *Server) getOrCreatePasswordHandler(route *ingress_v1alpha.HttpRoute, baseURL string, providerEntity entity.AttrGetter) (*passwordHandler, error) {
 	key := route.Host + "|" + baseURL
 	if route.Default {
 		key = "__default__|" + baseURL
 	}
 
-	resp, err := s.eac.Get(ctx, string(route.AuthProvider))
-	if err != nil {
-		s.passwordMu.Lock()
-		delete(s.passwordHandlers, key)
-		s.passwordMu.Unlock()
-		return nil, fmt.Errorf("failed to get password provider: %w", err)
-	}
-
 	var provider ingress_v1alpha.PasswordProvider
-	provider.Decode(resp.Entity().Entity())
+	provider.Decode(providerEntity)
 
 	s.passwordMu.RLock()
 	if h, ok := s.passwordHandlers[key]; ok && passwordProviderMatches(h, &provider) {
@@ -192,18 +183,14 @@ func (s *Server) getOrCreatePasswordHandler(ctx context.Context, route *ingress_
 	return handler, nil
 }
 
-func (s *Server) passwordMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
-	if entity.Empty(route.AuthProvider) {
-		return next
-	}
-
+func (s *Server) passwordMiddleware(route *ingress_v1alpha.HttpRoute, providerEntity entity.AttrGetter, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		scheme := requestScheme(r)
 		baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
 
 		s.oidcSessionManager.SetSecure(scheme == "https")
 
-		handler, err := s.getOrCreatePasswordHandler(r.Context(), route, baseURL)
+		handler, err := s.getOrCreatePasswordHandler(route, baseURL, providerEntity)
 		if err != nil {
 			s.Log.Error("failed to get password handler", "error", err, "host", r.Host)
 			http.Error(w, "Authentication service unavailable", http.StatusServiceUnavailable)

--- a/servers/httpingress/password_auth.go
+++ b/servers/httpingress/password_auth.go
@@ -1,0 +1,253 @@
+package httpingress
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/oidc"
+)
+
+const (
+	passwordLoginPath       = "/.well-known/miren/auth/login"
+	passwordLogoutPath      = "/.well-known/miren/auth/logout"
+	pwSessionCookieName     = "miren_pw_session"
+	passwordSessionDuration = 24 * time.Hour
+)
+
+type passwordSessionData struct {
+	RouteHost string    `json:"route_host"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type passwordHandler struct {
+	route    *ingress_v1alpha.HttpRoute
+	provider *ingress_v1alpha.PasswordProvider
+	sm       *oidc.SessionManager
+	logger   *slog.Logger
+}
+
+func (h *passwordHandler) checkSession(r *http.Request) bool {
+	data, err := h.sm.GetNamedCookie(r, pwSessionCookieName)
+	if err != nil || data == nil {
+		return false
+	}
+
+	var session passwordSessionData
+	if err := json.Unmarshal(data, &session); err != nil {
+		return false
+	}
+
+	if time.Now().After(session.ExpiresAt) {
+		return false
+	}
+
+	routeHost := h.route.Host
+	if h.route.Default {
+		routeHost = "__default__"
+	}
+	return session.RouteHost == routeHost
+}
+
+func (h *passwordHandler) setSession(w http.ResponseWriter) error {
+	routeHost := h.route.Host
+	if h.route.Default {
+		routeHost = "__default__"
+	}
+
+	session := passwordSessionData{
+		RouteHost: routeHost,
+		ExpiresAt: time.Now().Add(passwordSessionDuration),
+	}
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("failed to marshal session: %w", err)
+	}
+
+	return h.sm.SetNamedCookie(w, pwSessionCookieName, data, session.ExpiresAt)
+}
+
+func (h *passwordHandler) clearSession(w http.ResponseWriter) {
+	h.sm.ClearNamedCookie(w, pwSessionCookieName)
+}
+
+func (h *passwordHandler) serveLoginForm(w http.ResponseWriter, returnPath string, errorMsg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+
+	errorHTML := ""
+	if errorMsg != "" {
+		errorHTML = `<p style="color:#c0392b;margin-bottom:16px">` + errorMsg + `</p>`
+	}
+
+	fmt.Fprintf(w, loginFormHTML, errorHTML, returnPath)
+}
+
+func (h *passwordHandler) handleLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.serveLoginForm(w, r.URL.Query().Get("return"), "")
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		h.logger.Error("failed to parse form", "error", err)
+		h.serveLoginForm(w, "", "Invalid request.")
+		return
+	}
+
+	password := r.FormValue("password")
+	returnPath := r.FormValue("return")
+
+	err := bcrypt.CompareHashAndPassword([]byte(h.provider.PasswordHash), []byte(password))
+	if err != nil {
+		h.logger.Info("password authentication failed", "host", h.route.Host)
+		h.serveLoginForm(w, returnPath, "Incorrect password.")
+		return
+	}
+
+	if err := h.setSession(w); err != nil {
+		h.logger.Error("failed to set session", "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	if returnPath == "" {
+		returnPath = "/"
+	}
+
+	h.logger.Info("password authentication successful", "host", h.route.Host)
+	http.Redirect(w, r, returnPath, http.StatusFound)
+}
+
+func (h *passwordHandler) handleLogout(w http.ResponseWriter, r *http.Request) {
+	h.clearSession(w)
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func passwordProviderMatches(cached *passwordHandler, current *ingress_v1alpha.PasswordProvider) bool {
+	cp := cached.provider
+	return cp.ID == current.ID && cp.PasswordHash == current.PasswordHash
+}
+
+func (s *Server) getOrCreatePasswordHandler(ctx context.Context, route *ingress_v1alpha.HttpRoute, baseURL string) (*passwordHandler, error) {
+	key := route.Host + "|" + baseURL
+	if route.Default {
+		key = "__default__|" + baseURL
+	}
+
+	resp, err := s.eac.Get(ctx, string(route.PasswordProvider))
+	if err != nil {
+		s.passwordMu.RLock()
+		h, ok := s.passwordHandlers[key]
+		s.passwordMu.RUnlock()
+		if ok {
+			s.Log.Warn("entity store unavailable, using cached password handler", "error", err, "host", route.Host)
+			return h, nil
+		}
+		return nil, fmt.Errorf("failed to get password provider: %w", err)
+	}
+
+	var provider ingress_v1alpha.PasswordProvider
+	provider.Decode(resp.Entity().Entity())
+
+	s.passwordMu.RLock()
+	if h, ok := s.passwordHandlers[key]; ok && passwordProviderMatches(h, &provider) {
+		s.passwordMu.RUnlock()
+		return h, nil
+	}
+	s.passwordMu.RUnlock()
+
+	s.passwordMu.Lock()
+	defer s.passwordMu.Unlock()
+
+	if h, ok := s.passwordHandlers[key]; ok && passwordProviderMatches(h, &provider) {
+		return h, nil
+	}
+
+	handler := &passwordHandler{
+		route:    route,
+		provider: &provider,
+		sm:       s.oidcSessionManager,
+		logger:   s.Log.With("module", "password-auth", "host", route.Host, "provider", provider.Name),
+	}
+
+	s.passwordHandlers[key] = handler
+	return handler, nil
+}
+
+func (s *Server) passwordMiddleware(route *ingress_v1alpha.HttpRoute, next http.HandlerFunc) http.HandlerFunc {
+	if entity.Empty(route.PasswordProvider) {
+		return next
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		scheme := requestScheme(r)
+		baseURL := fmt.Sprintf("%s://%s", scheme, r.Host)
+
+		s.oidcSessionManager.SetSecure(scheme == "https")
+
+		handler, err := s.getOrCreatePasswordHandler(r.Context(), route, baseURL)
+		if err != nil {
+			s.Log.Error("failed to get password handler", "error", err, "host", r.Host)
+			next(w, r)
+			return
+		}
+
+		if r.URL.Path == passwordLoginPath {
+			handler.handleLogin(w, r)
+			return
+		}
+
+		if r.URL.Path == passwordLogoutPath {
+			handler.handleLogout(w, r)
+			return
+		}
+
+		if handler.checkSession(r) {
+			next(w, r)
+			return
+		}
+
+		handler.serveLoginForm(w, r.URL.RequestURI(), "")
+	}
+}
+
+// passwordMu and passwordHandlers are added to the Server struct in httpingress.go
+
+var loginFormHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Password Required</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f5; display: flex; justify-content: center; align-items: center; min-height: 100vh; }
+  .card { background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); padding: 32px; width: 100%%; max-width: 380px; }
+  h1 { font-size: 20px; margin-bottom: 24px; text-align: center; color: #333; }
+  input[type=password] { width: 100%%; padding: 10px 12px; border: 1px solid #ddd; border-radius: 4px; font-size: 14px; margin-bottom: 16px; }
+  input[type=password]:focus { outline: none; border-color: #4a90d9; box-shadow: 0 0 0 2px rgba(74,144,217,0.2); }
+  button { width: 100%%; padding: 10px; background: #4a90d9; color: #fff; border: none; border-radius: 4px; font-size: 14px; cursor: pointer; }
+  button:hover { background: #357abd; }
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Password Required</h1>
+  %s
+  <form method="POST" action="` + passwordLoginPath + `">
+    <input type="password" name="password" placeholder="Enter password" autofocus required>
+    <input type="hidden" name="return" value="%s">
+    <button type="submit">Continue</button>
+  </form>
+</div>
+</body>
+</html>`

--- a/servers/httpingress/password_auth_test.go
+++ b/servers/httpingress/password_auth_test.go
@@ -145,7 +145,7 @@ func TestGetOrCreatePasswordHandlerFailClosed(t *testing.T) {
 	}
 
 	// Warm the cache
-	h1, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	_, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
 	if err != nil {
 		t.Fatalf("initial call: %v", err)
 	}
@@ -153,23 +153,18 @@ func TestGetOrCreatePasswordHandlerFailClosed(t *testing.T) {
 	// Remove provider to simulate unavailability
 	store.RemoveEntity(entity.Id(providerIdent))
 
-	// Should return cached handler
-	h2, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
-	if err != nil {
-		t.Fatalf("expected cached handler, got error: %v", err)
-	}
-	if h1 != h2 {
-		t.Error("expected same cached handler on entity store failure")
+	// Should fail closed and clear cached handler
+	_, err = srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	if err == nil {
+		t.Error("expected error when entity store fails, not cached fallback")
 	}
 
-	// No cache + no entity store should error
-	routeNew := &ingress_v1alpha.HttpRoute{
-		Host:             "new.example.com",
-		PasswordProvider: entity.Id(providerIdent),
-	}
-	_, err = srv.getOrCreatePasswordHandler(context.Background(), routeNew, "https://new.example.com")
-	if err == nil {
-		t.Error("expected error when entity store fails and no cached handler exists")
+	// Cache entry should have been removed
+	srv.passwordMu.RLock()
+	_, cached := srv.passwordHandlers["app.example.com|https://app.example.com"]
+	srv.passwordMu.RUnlock()
+	if cached {
+		t.Error("expected cached handler to be removed after lookup failure")
 	}
 }
 
@@ -251,6 +246,58 @@ func TestPasswordSessionRoundtrip(t *testing.T) {
 	})
 }
 
+func TestSanitizeReturnPath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", "/"},
+		{"/", "/"},
+		{"/dashboard", "/dashboard"},
+		{"/a/b/c", "/a/b/c"},
+		{"https://evil.com", "/"},
+		{"//evil.com", "/"},
+		{"http://evil.com/steal", "/"},
+		{"/foo/../bar", "/bar"},
+		{"/../../../etc/passwd", "/etc/passwd"},
+		{"/valid/path", "/valid/path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitizeReturnPath(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeReturnPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoginFormHTMLEscaping(t *testing.T) {
+	signingKey := make([]byte, 32)
+	sm := oidc.NewSessionManager(false, "", signingKey)
+
+	handler := &passwordHandler{
+		route: &ingress_v1alpha.HttpRoute{Host: "app.example.com"},
+		provider: &ingress_v1alpha.PasswordProvider{
+			PasswordHash: "$2a$10$test",
+		},
+		sm:     sm,
+		logger: slog.Default(),
+	}
+
+	w := httptest.NewRecorder()
+	handler.serveLoginForm(w, `"><script>alert(1)</script>`, "")
+
+	body := w.Body.String()
+	if strings.Contains(body, "<script>") {
+		t.Error("XSS payload was not escaped in login form HTML")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Error("expected HTML-escaped script tag in form output")
+	}
+}
+
 func TestPasswordLoginFlow(t *testing.T) {
 	signingKey := make([]byte, 32)
 	sm := oidc.NewSessionManager(false, "", signingKey)
@@ -322,6 +369,23 @@ func TestPasswordLoginFlow(t *testing.T) {
 		}
 		if !foundCookie {
 			t.Error("expected session cookie to be set after successful login")
+		}
+	})
+
+	t.Run("open redirect is blocked", func(t *testing.T) {
+		form := url.Values{"password": {"correctpassword"}, "return": {"https://evil.com/steal"}}
+		req := httptest.NewRequest("POST", passwordLoginPath, strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		handler.handleLogin(w, req)
+
+		if w.Code != http.StatusFound {
+			t.Errorf("expected 302, got %d", w.Code)
+		}
+
+		loc := w.Header().Get("Location")
+		if loc != "/" {
+			t.Errorf("expected redirect to / (sanitized), got %s", loc)
 		}
 	})
 

--- a/servers/httpingress/password_auth_test.go
+++ b/servers/httpingress/password_auth_test.go
@@ -94,8 +94,8 @@ func TestGetOrCreatePasswordHandlerCacheInvalidation(t *testing.T) {
 	storePasswordProvider(store, providerIdent, string(hash1))
 
 	route := &ingress_v1alpha.HttpRoute{
-		Host:             "app.example.com",
-		PasswordProvider: entity.Id(providerIdent),
+		Host:         "app.example.com",
+		AuthProvider: entity.Id(providerIdent),
 	}
 
 	h1, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
@@ -140,8 +140,8 @@ func TestGetOrCreatePasswordHandlerFailClosed(t *testing.T) {
 	storePasswordProvider(store, providerIdent, string(hash))
 
 	route := &ingress_v1alpha.HttpRoute{
-		Host:             "app.example.com",
-		PasswordProvider: entity.Id(providerIdent),
+		Host:         "app.example.com",
+		AuthProvider: entity.Id(providerIdent),
 	}
 
 	// Warm the cache

--- a/servers/httpingress/password_auth_test.go
+++ b/servers/httpingress/password_auth_test.go
@@ -1,7 +1,6 @@
 package httpingress
 
 import (
-	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,35 +10,24 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/oidc"
-	"miren.dev/runtime/pkg/rpc"
-	"miren.dev/runtime/servers/entityserver"
 )
 
-func storePasswordProvider(store *entity.MockStore, ident, hash string) {
-	store.AddEntity(entity.Id(ident), entity.New([]entity.Attr{
-		{ID: entity.Ident, Value: entity.KeywordValue(ident)},
+func makePasswordProviderEntity(ident, hash string) *entity.Entity {
+	return entity.New(
+		entity.DBId, entity.Id(ident),
+		entity.Ref(entity.EntityKind, ingress_v1alpha.KindPasswordProvider),
 		entity.String(ingress_v1alpha.PasswordProviderPasswordHashId, hash),
-	}))
+	)
 }
 
-func newPasswordTestServer(store *entity.MockStore) *Server {
-	esrv := &entityserver.EntityServer{
-		Log:   slog.Default(),
-		Store: store,
-	}
-	eac := &entityserver_v1alpha.EntityAccessClient{
-		Client: rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(esrv)),
-	}
-
+func newPasswordTestServer() *Server {
 	signingKey := make([]byte, 32)
 
 	return &Server{
 		Log:                slog.Default(),
-		eac:                eac,
 		oidcSessionManager: oidc.NewSessionManager(false, "", signingKey),
 		oidcHandlers:       make(map[string]*oidcHandler),
 		passwordHandlers:   make(map[string]*passwordHandler),
@@ -86,19 +74,19 @@ func TestPasswordProviderMatches(t *testing.T) {
 }
 
 func TestGetOrCreatePasswordHandlerCacheInvalidation(t *testing.T) {
-	store := entity.NewMockStore()
-	srv := newPasswordTestServer(store)
+	srv := newPasswordTestServer()
 
 	providerIdent := "test/pw-provider"
 	hash1, _ := bcrypt.GenerateFromPassword([]byte("secret1"), bcrypt.MinCost)
-	storePasswordProvider(store, providerIdent, string(hash1))
 
 	route := &ingress_v1alpha.HttpRoute{
 		Host:         "app.example.com",
 		AuthProvider: entity.Id(providerIdent),
 	}
 
-	h1, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	entA := makePasswordProviderEntity(providerIdent, string(hash1))
+
+	h1, err := srv.getOrCreatePasswordHandler(route, "https://app.example.com", entA)
 	if err != nil {
 		t.Fatalf("first call: %v", err)
 	}
@@ -106,8 +94,8 @@ func TestGetOrCreatePasswordHandlerCacheInvalidation(t *testing.T) {
 		t.Fatalf("expected hash=%s, got %s", string(hash1), h1.provider.PasswordHash)
 	}
 
-	// Same call should return cached handler
-	h2, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	// Same entity should return cached handler
+	h2, err := srv.getOrCreatePasswordHandler(route, "https://app.example.com", entA)
 	if err != nil {
 		t.Fatalf("second call: %v", err)
 	}
@@ -115,11 +103,11 @@ func TestGetOrCreatePasswordHandlerCacheInvalidation(t *testing.T) {
 		t.Error("expected same handler instance on cache hit")
 	}
 
-	// Update the password hash
+	// Pass a new entity with updated hash
 	hash2, _ := bcrypt.GenerateFromPassword([]byte("secret2"), bcrypt.MinCost)
-	storePasswordProvider(store, providerIdent, string(hash2))
+	entB := makePasswordProviderEntity(providerIdent, string(hash2))
 
-	h3, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	h3, err := srv.getOrCreatePasswordHandler(route, "https://app.example.com", entB)
 	if err != nil {
 		t.Fatalf("third call: %v", err)
 	}
@@ -128,43 +116,6 @@ func TestGetOrCreatePasswordHandlerCacheInvalidation(t *testing.T) {
 	}
 	if h1 == h3 {
 		t.Error("expected different handler instance after provider change")
-	}
-}
-
-func TestGetOrCreatePasswordHandlerFailClosed(t *testing.T) {
-	store := entity.NewMockStore()
-	srv := newPasswordTestServer(store)
-
-	providerIdent := "test/pw-provider"
-	hash, _ := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.MinCost)
-	storePasswordProvider(store, providerIdent, string(hash))
-
-	route := &ingress_v1alpha.HttpRoute{
-		Host:         "app.example.com",
-		AuthProvider: entity.Id(providerIdent),
-	}
-
-	// Warm the cache
-	_, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
-	if err != nil {
-		t.Fatalf("initial call: %v", err)
-	}
-
-	// Remove provider to simulate unavailability
-	store.RemoveEntity(entity.Id(providerIdent))
-
-	// Should fail closed and clear cached handler
-	_, err = srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
-	if err == nil {
-		t.Error("expected error when entity store fails, not cached fallback")
-	}
-
-	// Cache entry should have been removed
-	srv.passwordMu.RLock()
-	_, cached := srv.passwordHandlers["app.example.com|https://app.example.com"]
-	srv.passwordMu.RUnlock()
-	if cached {
-		t.Error("expected cached handler to be removed after lookup failure")
 	}
 }
 

--- a/servers/httpingress/password_auth_test.go
+++ b/servers/httpingress/password_auth_test.go
@@ -1,0 +1,349 @@
+package httpingress
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/oidc"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/servers/entityserver"
+)
+
+func storePasswordProvider(store *entity.MockStore, ident, hash string) {
+	store.AddEntity(entity.Id(ident), entity.New([]entity.Attr{
+		{ID: entity.Ident, Value: entity.KeywordValue(ident)},
+		entity.String(ingress_v1alpha.PasswordProviderPasswordHashId, hash),
+	}))
+}
+
+func newPasswordTestServer(store *entity.MockStore) *Server {
+	esrv := &entityserver.EntityServer{
+		Log:   slog.Default(),
+		Store: store,
+	}
+	eac := &entityserver_v1alpha.EntityAccessClient{
+		Client: rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(esrv)),
+	}
+
+	signingKey := make([]byte, 32)
+
+	return &Server{
+		Log:                slog.Default(),
+		eac:                eac,
+		oidcSessionManager: oidc.NewSessionManager(false, "", signingKey),
+		oidcHandlers:       make(map[string]*oidcHandler),
+		passwordHandlers:   make(map[string]*passwordHandler),
+	}
+}
+
+func TestPasswordProviderMatches(t *testing.T) {
+	base := &ingress_v1alpha.PasswordProvider{
+		ID:           "provider-1",
+		PasswordHash: "$2a$10$test",
+	}
+
+	handler := &passwordHandler{provider: base}
+
+	t.Run("identical provider matches", func(t *testing.T) {
+		same := &ingress_v1alpha.PasswordProvider{
+			ID:           "provider-1",
+			PasswordHash: "$2a$10$test",
+		}
+		if !passwordProviderMatches(handler, same) {
+			t.Error("expected match for identical provider")
+		}
+	})
+
+	t.Run("different hash does not match", func(t *testing.T) {
+		different := &ingress_v1alpha.PasswordProvider{
+			ID:           "provider-1",
+			PasswordHash: "$2a$10$other",
+		}
+		if passwordProviderMatches(handler, different) {
+			t.Error("expected mismatch for different hash")
+		}
+	})
+
+	t.Run("different ID does not match", func(t *testing.T) {
+		different := &ingress_v1alpha.PasswordProvider{
+			ID:           "provider-2",
+			PasswordHash: "$2a$10$test",
+		}
+		if passwordProviderMatches(handler, different) {
+			t.Error("expected mismatch for different ID")
+		}
+	})
+}
+
+func TestGetOrCreatePasswordHandlerCacheInvalidation(t *testing.T) {
+	store := entity.NewMockStore()
+	srv := newPasswordTestServer(store)
+
+	providerIdent := "test/pw-provider"
+	hash1, _ := bcrypt.GenerateFromPassword([]byte("secret1"), bcrypt.MinCost)
+	storePasswordProvider(store, providerIdent, string(hash1))
+
+	route := &ingress_v1alpha.HttpRoute{
+		Host:             "app.example.com",
+		PasswordProvider: entity.Id(providerIdent),
+	}
+
+	h1, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if h1.provider.PasswordHash != string(hash1) {
+		t.Fatalf("expected hash=%s, got %s", string(hash1), h1.provider.PasswordHash)
+	}
+
+	// Same call should return cached handler
+	h2, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if h1 != h2 {
+		t.Error("expected same handler instance on cache hit")
+	}
+
+	// Update the password hash
+	hash2, _ := bcrypt.GenerateFromPassword([]byte("secret2"), bcrypt.MinCost)
+	storePasswordProvider(store, providerIdent, string(hash2))
+
+	h3, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	if err != nil {
+		t.Fatalf("third call: %v", err)
+	}
+	if h3.provider.PasswordHash != string(hash2) {
+		t.Fatalf("expected updated hash after provider change")
+	}
+	if h1 == h3 {
+		t.Error("expected different handler instance after provider change")
+	}
+}
+
+func TestGetOrCreatePasswordHandlerFailClosed(t *testing.T) {
+	store := entity.NewMockStore()
+	srv := newPasswordTestServer(store)
+
+	providerIdent := "test/pw-provider"
+	hash, _ := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.MinCost)
+	storePasswordProvider(store, providerIdent, string(hash))
+
+	route := &ingress_v1alpha.HttpRoute{
+		Host:             "app.example.com",
+		PasswordProvider: entity.Id(providerIdent),
+	}
+
+	// Warm the cache
+	h1, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	if err != nil {
+		t.Fatalf("initial call: %v", err)
+	}
+
+	// Remove provider to simulate unavailability
+	store.RemoveEntity(entity.Id(providerIdent))
+
+	// Should return cached handler
+	h2, err := srv.getOrCreatePasswordHandler(context.Background(), route, "https://app.example.com")
+	if err != nil {
+		t.Fatalf("expected cached handler, got error: %v", err)
+	}
+	if h1 != h2 {
+		t.Error("expected same cached handler on entity store failure")
+	}
+
+	// No cache + no entity store should error
+	routeNew := &ingress_v1alpha.HttpRoute{
+		Host:             "new.example.com",
+		PasswordProvider: entity.Id(providerIdent),
+	}
+	_, err = srv.getOrCreatePasswordHandler(context.Background(), routeNew, "https://new.example.com")
+	if err == nil {
+		t.Error("expected error when entity store fails and no cached handler exists")
+	}
+}
+
+func TestPasswordSessionRoundtrip(t *testing.T) {
+	signingKey := make([]byte, 32)
+	sm := oidc.NewSessionManager(false, "", signingKey)
+
+	hash, _ := bcrypt.GenerateFromPassword([]byte("correctpassword"), bcrypt.MinCost)
+	handler := &passwordHandler{
+		route: &ingress_v1alpha.HttpRoute{
+			Host: "app.example.com",
+		},
+		provider: &ingress_v1alpha.PasswordProvider{
+			PasswordHash: string(hash),
+		},
+		sm:     sm,
+		logger: slog.Default(),
+	}
+
+	t.Run("no cookie returns unauthenticated", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		if handler.checkSession(req) {
+			t.Error("expected unauthenticated with no cookie")
+		}
+	})
+
+	t.Run("set and check session", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		if err := handler.setSession(w); err != nil {
+			t.Fatalf("setSession: %v", err)
+		}
+
+		cookies := w.Result().Cookies()
+		var sessionCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == pwSessionCookieName {
+				sessionCookie = c
+				break
+			}
+		}
+		if sessionCookie == nil {
+			t.Fatal("expected session cookie to be set")
+		}
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(sessionCookie)
+		if !handler.checkSession(req) {
+			t.Error("expected authenticated with valid session cookie")
+		}
+	})
+
+	t.Run("wrong route host is rejected", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		if err := handler.setSession(w); err != nil {
+			t.Fatalf("setSession: %v", err)
+		}
+
+		cookies := w.Result().Cookies()
+		var sessionCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == pwSessionCookieName {
+				sessionCookie = c
+				break
+			}
+		}
+
+		otherHandler := &passwordHandler{
+			route: &ingress_v1alpha.HttpRoute{
+				Host: "other.example.com",
+			},
+			sm: sm,
+		}
+
+		req := httptest.NewRequest("GET", "/", nil)
+		req.AddCookie(sessionCookie)
+		if otherHandler.checkSession(req) {
+			t.Error("expected session to be rejected for wrong route host")
+		}
+	})
+}
+
+func TestPasswordLoginFlow(t *testing.T) {
+	signingKey := make([]byte, 32)
+	sm := oidc.NewSessionManager(false, "", signingKey)
+
+	hash, _ := bcrypt.GenerateFromPassword([]byte("correctpassword"), bcrypt.MinCost)
+	handler := &passwordHandler{
+		route: &ingress_v1alpha.HttpRoute{
+			Host: "app.example.com",
+		},
+		provider: &ingress_v1alpha.PasswordProvider{
+			PasswordHash: string(hash),
+		},
+		sm:     sm,
+		logger: slog.Default(),
+	}
+
+	t.Run("GET login shows form", func(t *testing.T) {
+		req := httptest.NewRequest("GET", passwordLoginPath, nil)
+		w := httptest.NewRecorder()
+		handler.handleLogin(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "Password Required") {
+			t.Error("expected login form HTML")
+		}
+	})
+
+	t.Run("wrong password shows error", func(t *testing.T) {
+		form := url.Values{"password": {"wrong"}, "return": {"/"}}
+		req := httptest.NewRequest("POST", passwordLoginPath, strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		handler.handleLogin(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200 (form re-render), got %d", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "Incorrect password") {
+			t.Error("expected error message in form")
+		}
+	})
+
+	t.Run("correct password sets cookie and redirects", func(t *testing.T) {
+		form := url.Values{"password": {"correctpassword"}, "return": {"/dashboard"}}
+		req := httptest.NewRequest("POST", passwordLoginPath, strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+		handler.handleLogin(w, req)
+
+		if w.Code != http.StatusFound {
+			t.Errorf("expected 302, got %d", w.Code)
+		}
+
+		loc := w.Header().Get("Location")
+		if loc != "/dashboard" {
+			t.Errorf("expected redirect to /dashboard, got %s", loc)
+		}
+
+		var foundCookie bool
+		for _, c := range w.Result().Cookies() {
+			if c.Name == pwSessionCookieName {
+				foundCookie = true
+				break
+			}
+		}
+		if !foundCookie {
+			t.Error("expected session cookie to be set after successful login")
+		}
+	})
+
+	t.Run("logout clears cookie and redirects", func(t *testing.T) {
+		req := httptest.NewRequest("GET", passwordLogoutPath, nil)
+		w := httptest.NewRecorder()
+		handler.handleLogout(w, req)
+
+		if w.Code != http.StatusFound {
+			t.Errorf("expected 302, got %d", w.Code)
+		}
+
+		loc := w.Header().Get("Location")
+		if loc != "/" {
+			t.Errorf("expected redirect to /, got %s", loc)
+		}
+
+		for _, c := range w.Result().Cookies() {
+			if c.Name == pwSessionCookieName && c.MaxAge == -1 {
+				return
+			}
+		}
+		t.Error("expected session cookie to be cleared")
+	})
+}


### PR DESCRIPTION
## Summary

- Adds a `password_provider` entity type (parallel to `oidc_provider`) that protects HTTP routes with a shared password and a browser login form
- After entering the correct password, the user receives a 24h encrypted session cookie (XChaCha20-Poly1305, reusing the existing `SessionManager`)
- CLI commands: `auth provider add-password`, unified `list`/`show`/`remove` across both provider types, `route protect --provider` auto-detects type
- Mutual exclusion enforced: attaching one provider type clears the other, using `Replace` instead of merge-based `Update` to correctly remove stale entity refs

## Test plan

- [x] Unit tests for password handler, session roundtrip, login flow, cache invalidation, fail-closed behavior (`servers/httpingress/password_auth_test.go`)
- [x] Blackbox E2E test: deploy app → create password provider → protect route → verify login form → wrong password → correct password + cookie → authenticated access → unprotect → verify open access (`blackbox/route_password_test.go`)
- [x] Blackbox lifecycle test: create → list → show → update → remove password provider
- [x] `make lint` passes (no new issues)
- [x] Existing httpingress and ingress client tests pass

Closes MIR-886