### PR TITLE
Add ingress.http_address for plain-HTTP ingress on a custom address

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -825,7 +825,35 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		}
 	}()
 
-	if cfg.TLS.GetStandardTLS() {
+	if ingressAddr := cfg.Ingress.GetHTTPAddress(); ingressAddr != "" {
+		warnIngressTLSOverride(ctx.Log, &cfg.TLS)
+		// Bind synchronously so a port conflict surfaces as a startup error
+		// instead of an orphaned goroutine after the supervisor thinks we're up.
+		ln, err := net.Listen("tcp", ingressAddr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %w", ingressAddr, err)
+		}
+		ctx.Log.Info("serving plain HTTP ingress", "addr", ln.Addr().String())
+		ingressServer := &http.Server{
+			Handler:           hs,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		eg.Go(func() error {
+			if err := ingressServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+				return fmt.Errorf("HTTP ingress on %s: %w", ingressAddr, err)
+			}
+			return nil
+		})
+		eg.Go(func() error {
+			<-sub.Done()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := ingressServer.Shutdown(shutdownCtx); err != nil {
+				return fmt.Errorf("HTTP ingress shutdown on %s: %w", ingressAddr, err)
+			}
+			return nil
+		})
+	} else if cfg.TLS.GetStandardTLS() {
 		if cfg.TLS.GetSelfSigned() {
 			// Use self-signed certificate (for development/testing)
 			if err := autotls.ServeTLSSelfSigned(sub, ctx.Log, hs); err != nil {
@@ -968,6 +996,29 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 
 	co.Stop()
 	return err
+}
+
+// warnIngressTLSOverride logs a warning for each tls.* setting that is
+// non-default but has no effect because ingress.http_address is set.
+// standard_tls is intentionally skipped: it defaults to true, so an
+// unmodified config would always trigger a misleading warning.
+func warnIngressTLSOverride(log *slog.Logger, tls *serverconfig.TLSConfig) {
+	const suffix = "ignored because ingress.http_address is set; the ingress serves plain HTTP"
+	if tls.GetSelfSigned() {
+		log.Warn("tls.self_signed " + suffix)
+	}
+	if tls.GetAcmeEmail() != "" {
+		log.Warn("tls.acme_email " + suffix)
+	}
+	if tls.GetAcmeDNSProvider() != "" {
+		log.Warn("tls.acme_dns_provider " + suffix)
+	}
+	if len(tls.AdditionalIPs) > 0 {
+		log.Warn("tls.additional_ips " + suffix + "; no certificate is issued")
+	}
+	if len(tls.AdditionalNames) > 0 {
+		log.Warn("tls.additional_names " + suffix + "; no certificate is issued")
+	}
 }
 
 // writeLocalClusterConfig writes a client config file for the local cluster

--- a/cli/commands/server_test.go
+++ b/cli/commands/server_test.go
@@ -1,0 +1,108 @@
+//go:build linux
+
+package commands
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"miren.dev/runtime/pkg/serverconfig"
+)
+
+func TestWarnIngressTLSOverride(t *testing.T) {
+	cases := []struct {
+		name           string
+		standardTLS    bool
+		selfSigned     bool
+		acmeEmail      string
+		acmeProvider   string
+		additionalIPs  []string
+		additionalDNS  []string
+		wantContains   []string
+		notWantContain []string
+	}{
+		{
+			name:           "default tls config: silent",
+			notWantContain: []string{"ignored"},
+		},
+		{
+			// standard_tls defaults to true, so any naïve "warn when set"
+			// implementation would cry wolf on every default config. Pin the
+			// exclusion so it doesn't silently regress.
+			name:           "standard_tls true: silent (excluded by design)",
+			standardTLS:    true,
+			notWantContain: []string{"standard_tls", "ignored"},
+		},
+		{
+			name:           "self_signed warns",
+			selfSigned:     true,
+			wantContains:   []string{"tls.self_signed"},
+			notWantContain: []string{"acme", "additional"},
+		},
+		{
+			name:           "acme_email warns by name",
+			acmeEmail:      "ops@example.com",
+			wantContains:   []string{"tls.acme_email"},
+			notWantContain: []string{"acme_dns_provider", "self_signed"},
+		},
+		{
+			name:           "acme_dns_provider warns by name",
+			acmeProvider:   "cloudflare",
+			wantContains:   []string{"tls.acme_dns_provider"},
+			notWantContain: []string{"acme_email", "self_signed"},
+		},
+		{
+			name:           "additional_ips warns",
+			additionalIPs:  []string{"10.0.0.1"},
+			wantContains:   []string{"tls.additional_ips"},
+			notWantContain: []string{"additional_names"},
+		},
+		{
+			name: "all warn together, each named individually",
+			selfSigned:    true,
+			acmeEmail:     "ops@example.com",
+			acmeProvider:  "cloudflare",
+			additionalIPs: []string{"10.0.0.1"},
+			additionalDNS: []string{"alt.example.com"},
+			wantContains: []string{
+				"tls.self_signed",
+				"tls.acme_email",
+				"tls.acme_dns_provider",
+				"tls.additional_ips",
+				"tls.additional_names",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tls := &serverconfig.TLSConfig{
+				AdditionalIPs:   tc.additionalIPs,
+				AdditionalNames: tc.additionalDNS,
+			}
+			tls.SetStandardTLS(tc.standardTLS)
+			tls.SetSelfSigned(tc.selfSigned)
+			tls.SetAcmeEmail(tc.acmeEmail)
+			tls.SetAcmeDNSProvider(tc.acmeProvider)
+
+			var buf bytes.Buffer
+			log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+			warnIngressTLSOverride(log, tls)
+
+			out := buf.String()
+			for _, want := range tc.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected log output to contain %q, got: %s", want, out)
+				}
+			}
+			for _, bad := range tc.notWantContain {
+				if strings.Contains(out, bad) {
+					t.Errorf("expected log output NOT to contain %q, got: %s", bad, out)
+				}
+			}
+		})
+	}
+}

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -97,6 +97,29 @@ Controls TLS certificates for the server and HTTP ingress. See [TLS](/tls) for s
 | `acme_email` | string | — | Email for ACME account registration | `MIREN_TLS_ACME_EMAIL` | `--acme-email` |
 | `self_signed` | bool | `false` | Use self-signed certificates (development only) | `MIREN_TLS_SELF_SIGNED` | `--self-signed-tls` |
 
+## `[ingress]` — HTTP Ingress Settings {#ingress}
+
+Controls where the HTTP ingress listens. Leave empty for the default behavior driven by `[tls]`. Set `http_address` to run a plain-HTTP ingress behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.).
+
+| Field | Type | Default | Description | Env Var | CLI Flag |
+|-------|------|---------|-------------|---------|----------|
+| `http_address` | string | — | `host:port` to bind a plain-HTTP ingress on instead of starting TLS. When set, no TLS is performed and ports 80 and 443 are not bound; `tls.*` settings have no effect. | `MIREN_INGRESS_HTTP_ADDRESS` | `--ingress-http-address` |
+
+```toml
+[ingress]
+http_address = "127.0.0.1:8080"
+```
+
+The upstream proxy is responsible for TLS termination, certificate management, and any HTTP→HTTPS redirects. Miren only sees plain HTTP from that proxy.
+
+### Ingress precedence
+
+Miren picks at most one ingress mode at startup, in this order:
+
+1. `ingress.http_address` set → bind plain HTTP on that address; no TLS, no port-80 fallback, `tls.*` ignored (with warnings for non-default fields).
+2. else `tls.standard_tls = true` (the default) → bind HTTPS on `:443` and an HTTP→HTTPS redirect on `:80`.
+3. else (`tls.standard_tls = false` and no `ingress.http_address`) → bind plain HTTP on `:80`. This is the legacy fallback; new deployments behind a proxy should prefer `ingress.http_address`.
+
 ## `[etcd]` — Etcd Settings {#etcd}
 
 Miren uses etcd as its entity store. In standalone mode, an embedded etcd server starts automatically.

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -22,6 +22,7 @@ type CLIFlags struct {
 	EtcdConfigPeerPort                   *int     `long:"etcd-peer-port" description:"Etcd peer port"`
 	EtcdConfigPrefix                     *string  `long:"etcd-prefix" short:"p" description:"Etcd prefix"`
 	EtcdConfigStartEmbedded              *bool    `long:"start-etcd" description:"Start embedded etcd server"`
+	IngressConfigHTTPAddress             *string  `long:"ingress-http-address" description:"host:port to bind a plain-HTTP ingress on instead of starting TLS. Intended for deployments behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.). When set, no TLS is performed and ports 80 and 443 are not bound; tls.* settings have no effect."`
 	ServerConfigAddress                  *string  `long:"address" short:"a" description:"Address to listen on (host:port). For IPv6 use brackets, e.g. \"[::1]:8443\"."`
 	ServerConfigConfigClusterName        *string  `long:"config-cluster-name" short:"C" description:"Name of the cluster in client config"`
 	ServerConfigDataPath                 *string  `long:"data-path" short:"d" description:"Data path"`

--- a/pkg/serverconfig/config.gen.go
+++ b/pkg/serverconfig/config.gen.go
@@ -85,6 +85,7 @@ type Config struct {
 	Buildkit        BuildkitConfig        `toml:"buildkit"`
 	Containerd      ContainerdConfig      `toml:"containerd"`
 	Etcd            EtcdConfig            `toml:"etcd"`
+	Ingress         IngressConfig         `toml:"ingress"`
 	Labs            []string              `toml:"labs" env:"MIREN_LABS"`
 	Mode            *string               `toml:"mode" env:"MIREN_MODE"`
 	Server          ServerConfig          `toml:"server"`
@@ -225,6 +226,24 @@ func (c *EtcdConfig) GetStartEmbedded() bool {
 // SetStartEmbedded sets the value of StartEmbedded
 func (c *EtcdConfig) SetStartEmbedded(v bool) {
 	c.StartEmbedded = &v
+}
+
+// IngressConfig HTTP ingress listener settings. Fields under [ingress] override the default listener selection driven by [tls]; setting any address field here disables the standard 80/443 binding.
+type IngressConfig struct {
+	HTTPAddress *string `toml:"http_address" env:"MIREN_INGRESS_HTTP_ADDRESS"`
+}
+
+// GetHTTPAddress returns the value of HTTPAddress or its zero value if nil
+func (c *IngressConfig) GetHTTPAddress() string {
+	if c.HTTPAddress != nil {
+		return *c.HTTPAddress
+	}
+	return ""
+}
+
+// SetHTTPAddress sets the value of HTTPAddress
+func (c *IngressConfig) SetHTTPAddress(v string) {
+	c.HTTPAddress = &v
 }
 
 // ServerConfig Core server settings

--- a/pkg/serverconfig/defaults.gen.go
+++ b/pkg/serverconfig/defaults.gen.go
@@ -13,6 +13,7 @@ func DefaultConfig() *Config {
 		Buildkit:        DefaultBuildkitConfig(),
 		Containerd:      DefaultContainerdConfig(),
 		Etcd:            DefaultEtcdConfig(),
+		Ingress:         DefaultIngressConfig(),
 		Labs:            []string{},
 		Mode:            strPtr("standalone"),
 		Server:          DefaultServerConfig(),
@@ -51,6 +52,13 @@ func DefaultEtcdConfig() EtcdConfig {
 		PeerPort:       intPtr(12380),
 		Prefix:         strPtr("/miren"),
 		StartEmbedded:  nil,
+	}
+}
+
+// DefaultIngressConfig returns default IngressConfig
+func DefaultIngressConfig() IngressConfig {
+	return IngressConfig{
+		HTTPAddress: strPtr(""),
 	}
 }
 

--- a/pkg/serverconfig/env.gen.go
+++ b/pkg/serverconfig/env.gen.go
@@ -194,6 +194,14 @@ func applyEnvironmentVariables(cfg *Config, log *slog.Logger) error {
 
 	}
 
+	// Apply MIREN_INGRESS_HTTP_ADDRESS
+	if val := os.Getenv("MIREN_INGRESS_HTTP_ADDRESS"); val != "" {
+
+		cfg.Ingress.HTTPAddress = &val
+		log.Debug("applied env var", "key", "MIREN_INGRESS_HTTP_ADDRESS")
+
+	}
+
 	// Apply MIREN_SERVER_ADDRESS
 	if val := os.Getenv("MIREN_SERVER_ADDRESS"); val != "" {
 

--- a/pkg/serverconfig/loader.gen.go
+++ b/pkg/serverconfig/loader.gen.go
@@ -214,6 +214,10 @@ func applyCLIFlags(cfg *Config, flags *CLIFlags) {
 		cfg.Etcd.StartEmbedded = flags.EtcdConfigStartEmbedded
 	}
 
+	if flags.IngressConfigHTTPAddress != nil && *flags.IngressConfigHTTPAddress != "" {
+		cfg.Ingress.HTTPAddress = flags.IngressConfigHTTPAddress
+	}
+
 	if flags.ServerConfigAddress != nil && *flags.ServerConfigAddress != "" {
 		cfg.Server.Address = flags.ServerConfigAddress
 	}

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -42,6 +42,11 @@ configs:
         toml: tls
         nested: true
 
+      ingress:
+        type: IngressConfig
+        toml: ingress
+        nested: true
+
       etcd:
         type: EtcdConfig
         toml: etcd
@@ -241,6 +246,20 @@ configs:
           description: Use self-signed certificates for TLS (for development/testing only)
         env: MIREN_TLS_SELF_SIGNED
         toml: self_signed
+
+  IngressConfig:
+    description: "HTTP ingress listener settings. Fields under [ingress] override the default listener selection driven by [tls]; setting any address field here disables the standard 80/443 binding."
+    fields:
+      http_address:
+        type: string
+        default: ""
+        cli:
+          long: ingress-http-address
+          description: "host:port to bind a plain-HTTP ingress on instead of starting TLS. Intended for deployments behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.). When set, no TLS is performed and ports 80 and 443 are not bound; tls.* settings have no effect."
+        env: MIREN_INGRESS_HTTP_ADDRESS
+        toml: http_address
+        validation:
+          format: host:port
 
   EtcdConfig:
     description: Etcd configuration

--- a/pkg/serverconfig/validation.gen.go
+++ b/pkg/serverconfig/validation.gen.go
@@ -22,6 +22,10 @@ func (c *Config) Validate() error {
 	if err := c.Etcd.Validate(); err != nil {
 		return fmt.Errorf("etcd: %w", err)
 	}
+
+	if err := c.Ingress.Validate(); err != nil {
+		return fmt.Errorf("ingress: %w", err)
+	}
 	// Validate mode
 	if c.Mode != nil {
 		validModes := map[string]bool{
@@ -110,6 +114,21 @@ func (c *EtcdConfig) Validate() error {
 	if c.StartEmbedded != nil && !*c.StartEmbedded && len(c.Endpoints) == 0 {
 		return fmt.Errorf("etcd endpoints must be set when start_embedded=false")
 	}
+
+	return nil
+}
+
+// Validate validates IngressConfig
+func (c *IngressConfig) Validate() error {
+
+	// Validate http_address
+	if c.HTTPAddress != nil && *c.HTTPAddress != "" {
+		if _, _, err := net.SplitHostPort(*c.HTTPAddress); err != nil {
+			return fmt.Errorf("invalid http_address %q: %w", *c.HTTPAddress, err)
+		}
+	}
+
+	// Check for port conflicts in IngressConfig
 
 	return nil
 }


### PR DESCRIPTION
Standing up a Miren server on a host that already serves another application on 80/443 currently leaves no way to put the Miren ingress somewhere else. Setting `--serve-tls=false` falls back to a hard-coded `:80`, which still collides. The intended deployment shape is the standard one — TLS-terminating proxy out front, plain HTTP to Miren on a loopback port inward — but Miren can't bind anywhere except 0.0.0.0.

This PR introduces a new `[ingress]` config section with one field, `http_address`. When set, Miren binds plain HTTP on that address and skips the standard 80/443 binding entirely. `tls.*` settings have no effect in this mode; a `warnIngressTLSOverride` helper logs one warning per non-default `tls.*` field, naming each so operators can grep and clean up. `tls.standard_tls` is intentionally not in the warn list — it defaults to `true`, so warning whenever it's "set" would fire on every default config.

The listener binds synchronously so a port conflict surfaces as a startup error instead of an orphaned goroutine after the supervisor thinks we're up. The accept loop and graceful shutdown run in background goroutines wired to the parent context.

When `ingress.http_address` is empty (default), all existing paths are unchanged.

## Non-goals

HTTPS on a custom port is a related but distinct change — a follow-up PR adds `ingress.https_address`. A third PR introduces a `selectIngressMode` resolver that rejects setting both ingress addresses simultaneously, once there are two fields to be exclusive with.

## Testing

- `TestWarnIngressTLSOverride` in `cli/commands/server_test.go` table-tests each warn-trigger field, including the silent-on-default `standard_tls` case.
- Verified end-to-end on Linux in a containerized standalone-mode boot: `curl http://127.0.0.1:18080/` against the custom address returns Miren's 404; `ss -tln` confirms no listeners on 80 or 443; the warn line fires as expected when `--self-signed-tls` is set alongside.