### PR TITLE
Add ingress.https_address for HTTPS ingress on a custom address

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -68,6 +68,15 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
+	// Validate ingress.https_address preconditions before any I/O so a bad
+	// config fails fast instead of waiting for component startup to surface
+	// an unrelated-looking error.
+	if cfg.Ingress.GetHTTPSAddress() != "" {
+		if err := validateIngressHTTPSAddressConfig(&cfg.TLS); err != nil {
+			return err
+		}
+	}
+
 	// Initialize Miren Labs feature flags
 	labs.Init(ctx.Log, cfg.Labs)
 
@@ -825,7 +834,22 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		}
 	}()
 
-	if cfg.TLS.GetStandardTLS() {
+	if httpsAddr := cfg.Ingress.GetHTTPSAddress(); httpsAddr != "" {
+		// Cert-source preconditions were already enforced at config-load time.
+		if cfg.TLS.GetSelfSigned() {
+			if err := autotls.ServeTLSSelfSignedOnAddr(sub, ctx.Log, hs, httpsAddr); err != nil {
+				return err
+			}
+		} else {
+			certProvider := co.CertificateProvider()
+			if certProvider == nil {
+				return fmt.Errorf("no certificate provider available")
+			}
+			if err := autotls.ServeTLSWithControllerOnAddr(sub, ctx.Log, certProvider, hs, httpsAddr); err != nil {
+				return err
+			}
+		}
+	} else if cfg.TLS.GetStandardTLS() {
 		if cfg.TLS.GetSelfSigned() {
 			// Use self-signed certificate (for development/testing)
 			if err := autotls.ServeTLSSelfSigned(sub, ctx.Log, hs); err != nil {
@@ -968,6 +992,21 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 
 	co.Stop()
 	return err
+}
+
+// validateIngressHTTPSAddressConfig enforces the cert-source preconditions for
+// binding the HTTPS ingress to a non-default address. Port 80 is not bound in
+// this mode, so HTTP-01 ACME challenges cannot complete; the operator must
+// supply a cert via DNS-01 ACME or self-signed (the latter is appropriate for
+// dev or upstream-of-a-TLS-terminating-proxy deployments).
+func validateIngressHTTPSAddressConfig(tls *serverconfig.TLSConfig) error {
+	if tls.GetSelfSigned() {
+		return nil
+	}
+	if tls.GetAcmeDNSProvider() == "" {
+		return fmt.Errorf("ingress.https_address requires either tls.self_signed or DNS-01 ACME (set tls.acme_dns_provider); HTTP-01 cannot be used because port 80 is not bound in this mode")
+	}
+	return nil
 }
 
 // writeLocalClusterConfig writes a client config file for the local cluster

--- a/cli/commands/server_test.go
+++ b/cli/commands/server_test.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"miren.dev/runtime/pkg/serverconfig"
+)
+
+func TestValidateIngressHTTPSAddressConfig(t *testing.T) {
+	cases := []struct {
+		name         string
+		selfSigned   bool
+		dnsProvider  string
+		wantErr      bool
+		wantContains string
+	}{
+		{name: "valid: dns provider set", dnsProvider: "cloudflare"},
+		{name: "valid: self-signed", selfSigned: true},
+		{name: "valid: self-signed wins when both set", selfSigned: true, dnsProvider: "cloudflare"},
+		{name: "rejects neither cert source", wantErr: true, wantContains: "self_signed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tls := &serverconfig.TLSConfig{}
+			tls.SetSelfSigned(tc.selfSigned)
+			tls.SetAcmeDNSProvider(tc.dnsProvider)
+
+			err := validateIngressHTTPSAddressConfig(tls)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/components/autotls/autotls.go
+++ b/components/autotls/autotls.go
@@ -3,6 +3,7 @@ package autotls
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -112,6 +113,53 @@ func ServeTLSWithController(ctx context.Context, log *slog.Logger, certProvider 
 			log.Error("HTTP server shutdown error", "error", err)
 		}
 		log.Info("HTTPS and HTTP servers shutdown complete")
+	}()
+
+	return nil
+}
+
+// ServeTLSWithControllerOnAddr serves HTTPS on addr without binding port 80.
+// Because port 80 is not bound, ACME HTTP-01 and TLS-ALPN-01 challenges cannot
+// succeed in this mode; certificates must be issued via DNS-01.
+func ServeTLSWithControllerOnAddr(ctx context.Context, log *slog.Logger, certProvider CertificateProvider, h http.Handler, addr string) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
+	return serveTLSOnListener(ctx, log, certProvider, h, ln)
+}
+
+func serveTLSOnListener(ctx context.Context, log *slog.Logger, certProvider CertificateProvider, h http.Handler, ln net.Listener) error {
+	log = log.With("module", "autotls", "mode", "controller", "addr", ln.Addr().String())
+	log.Info("serving TLS with certificate controller")
+
+	tlsConfig := &tls.Config{
+		GetCertificate: certProvider.GetCertificate,
+		MinVersion:     tls.VersionTLS12,
+		NextProtos:     []string{"h2", "http/1.1"},
+	}
+
+	server := &http.Server{
+		Handler:           h,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		err := server.ServeTLS(ln, "", "")
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("error serving HTTPS", "error", err)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		log.Info("shutting down HTTPS server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Error("HTTPS server shutdown error", "error", err)
+		}
 	}()
 
 	return nil

--- a/components/autotls/autotls_test.go
+++ b/components/autotls/autotls_test.go
@@ -1,0 +1,93 @@
+package autotls
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeCertProvider struct {
+	cert *tls.Certificate
+}
+
+func (f *fakeCertProvider) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return f.cert, nil
+}
+
+func TestServeTLSWithControllerOnAddr(t *testing.T) {
+	cert, err := generateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("generate cert: %v", err)
+	}
+	cp := &fakeCertProvider{cert: &cert}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := serveTLSOnListener(ctx, slog.Default(), cp, handler, ln); err != nil {
+		t.Fatalf("serveTLSOnListener: %v", err)
+	}
+
+	addr := ln.Addr().String()
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec // test against in-process self-signed cert
+		Timeout:   2 * time.Second,
+	}
+
+	// The serving goroutine is started but may not yet be accepting; retry briefly.
+	var resp *http.Response
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err = client.Get("https://" + addr + "/")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Fatalf("expected body %q, got %q", "ok", string(body))
+	}
+}
+
+func TestServeTLSWithControllerOnAddrInvalidAddress(t *testing.T) {
+	cert, err := generateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("generate cert: %v", err)
+	}
+	cp := &fakeCertProvider{cert: &cert}
+
+	const malformed = "127.0.0.1:not-a-port"
+	err = ServeTLSWithControllerOnAddr(context.Background(), slog.Default(), cp, http.NotFoundHandler(), malformed)
+	if err == nil {
+		t.Fatal("expected error for malformed address, got nil")
+	}
+	// Verify our wrap (fmt.Errorf "listen %s: %w") rather than just probing stdlib behavior.
+	wantPrefix := "listen " + malformed + ":"
+	if !strings.HasPrefix(err.Error(), wantPrefix) {
+		t.Fatalf("expected error prefix %q, got: %v", wantPrefix, err)
+	}
+}

--- a/components/autotls/selfsigned.go
+++ b/components/autotls/selfsigned.go
@@ -99,6 +99,55 @@ func ServeTLSSelfSigned(ctx context.Context, log *slog.Logger, h http.Handler) e
 	return nil
 }
 
+// ServeTLSSelfSignedOnAddr serves HTTPS on addr using a self-signed certificate.
+// Unlike ServeTLSSelfSigned, it does not also start a port-80 redirect server,
+// so it can bind to a non-standard address (for example, behind a TLS-terminating
+// proxy that already owns 80/443 on the host).
+func ServeTLSSelfSignedOnAddr(ctx context.Context, log *slog.Logger, h http.Handler, addr string) error {
+	log = log.With("module", "autotls", "mode", "self-signed", "addr", addr)
+	log.Info("serving TLS with self-signed certificate on custom address (dev / behind-proxy mode)")
+
+	cert, err := generateSelfSignedCert()
+	if err != nil {
+		return fmt.Errorf("failed to generate self-signed certificate: %w", err)
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	server := &http.Server{
+		Handler:           h,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		err := server.ServeTLS(ln, "", "")
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("error serving HTTPS", "error", err)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		log.Info("shutting down HTTPS server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Error("HTTPS server shutdown error", "error", err)
+		}
+	}()
+
+	return nil
+}
+
 // generateSelfSignedCert creates an in-memory self-signed certificate
 func generateSelfSignedCert() (tls.Certificate, error) {
 	cert, _, _, err := generateSelfSignedCertWithPEM()

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -97,6 +97,31 @@ Controls TLS certificates for the server and HTTP ingress. See [TLS](/tls) for s
 | `acme_email` | string | — | Email for ACME account registration | `MIREN_TLS_ACME_EMAIL` | `--acme-email` |
 | `self_signed` | bool | `false` | Use self-signed certificates (development only) | `MIREN_TLS_SELF_SIGNED` | `--self-signed-tls` |
 
+## `[ingress]` — HTTP Ingress Settings {#ingress}
+
+Controls where the HTTP ingress listens. Leave empty for the default behavior driven by `[tls]`. Set `https_address` to bind the HTTPS ingress to a non-default `host:port` — useful when another service on the host already owns port 443.
+
+| Field | Type | Default | Description | Env Var | CLI Flag |
+|-------|------|---------|-------------|---------|----------|
+| `https_address` | string | — | `host:port` to bind the HTTPS ingress to instead of `0.0.0.0:443`. When set, port 80 is not bound and `tls.standard_tls` has no effect; cert issuance must use DNS-01 (`tls.acme_dns_provider`) or `tls.self_signed`, since HTTP-01 cannot complete without port 80. | `MIREN_INGRESS_HTTPS_ADDRESS` | `--ingress-https-address` |
+
+```toml
+[ingress]
+https_address = "127.0.0.1:8444"
+
+[tls]
+acme_email = "you@example.com"
+acme_dns_provider = "cloudflare"
+```
+
+When `ingress.https_address` is set:
+
+- Miren binds **only** to that address. Ports 80 and 443 are not bound.
+- `tls.standard_tls` has no effect.
+- ACME HTTP-01 challenges are not possible (they require port 80). Use DNS-01 (`tls.acme_dns_provider`) or `tls.self_signed` as the cert source. Miren refuses to start if neither is configured.
+- Self-signed mode is appropriate for development and for deployments behind a TLS-terminating proxy that uses `proxy_ssl_verify off` (or equivalent), where the upstream certificate identity does not need to be trusted by clients.
+- `tls.additional_ips` and `tls.additional_names` continue to add SAN entries to the issued certificate; they do not bind additional listeners and are unaffected.
+
 ## `[etcd]` — Etcd Settings {#etcd}
 
 Miren uses etcd as its entity store. In standalone mode, an embedded etcd server starts automatically.

--- a/docs/docs/tls.md
+++ b/docs/docs/tls.md
@@ -119,6 +119,8 @@ All TLS settings live under the `[tls]` section of the server config file (typic
 | `acme_dns_provider` | `--acme-dns-provider` | DNS provider name for DNS-01 challenges (e.g., `cloudflare`, `route53`, `dnsimple`) |
 | `standard_tls` | `--serve-tls` | Enable TLS on ports 443/80 (default: `true`) |
 
+To bind the HTTPS ingress to a non-default address, see [`ingress.https_address`](/server-config#ingress).
+
 ## Troubleshooting
 
 ### Certificate Not Provisioning

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -22,6 +22,7 @@ type CLIFlags struct {
 	EtcdConfigPeerPort                   *int     `long:"etcd-peer-port" description:"Etcd peer port"`
 	EtcdConfigPrefix                     *string  `long:"etcd-prefix" short:"p" description:"Etcd prefix"`
 	EtcdConfigStartEmbedded              *bool    `long:"start-etcd" description:"Start embedded etcd server"`
+	IngressConfigHTTPSAddress            *string  `long:"ingress-https-address" description:"host:port to bind the HTTPS ingress to instead of 0.0.0.0:443. When set, port 80 is not bound and standard_tls has no effect; cert issuance must use DNS-01 (set tls.acme_dns_provider) since HTTP-01 challenges require port 80."`
 	ServerConfigAddress                  *string  `long:"address" short:"a" description:"Address to listen on (host:port). For IPv6 use brackets, e.g. \"[::1]:8443\"."`
 	ServerConfigConfigClusterName        *string  `long:"config-cluster-name" short:"C" description:"Name of the cluster in client config"`
 	ServerConfigDataPath                 *string  `long:"data-path" short:"d" description:"Data path"`

--- a/pkg/serverconfig/config.gen.go
+++ b/pkg/serverconfig/config.gen.go
@@ -85,6 +85,7 @@ type Config struct {
 	Buildkit        BuildkitConfig        `toml:"buildkit"`
 	Containerd      ContainerdConfig      `toml:"containerd"`
 	Etcd            EtcdConfig            `toml:"etcd"`
+	Ingress         IngressConfig         `toml:"ingress"`
 	Labs            []string              `toml:"labs" env:"MIREN_LABS"`
 	Mode            *string               `toml:"mode" env:"MIREN_MODE"`
 	Server          ServerConfig          `toml:"server"`
@@ -225,6 +226,24 @@ func (c *EtcdConfig) GetStartEmbedded() bool {
 // SetStartEmbedded sets the value of StartEmbedded
 func (c *EtcdConfig) SetStartEmbedded(v bool) {
 	c.StartEmbedded = &v
+}
+
+// IngressConfig HTTP ingress listener settings. Fields under [ingress] override the default listener selection driven by [tls]; setting any address field here disables the standard 80/443 binding.
+type IngressConfig struct {
+	HTTPSAddress *string `toml:"https_address" env:"MIREN_INGRESS_HTTPS_ADDRESS"`
+}
+
+// GetHTTPSAddress returns the value of HTTPSAddress or its zero value if nil
+func (c *IngressConfig) GetHTTPSAddress() string {
+	if c.HTTPSAddress != nil {
+		return *c.HTTPSAddress
+	}
+	return ""
+}
+
+// SetHTTPSAddress sets the value of HTTPSAddress
+func (c *IngressConfig) SetHTTPSAddress(v string) {
+	c.HTTPSAddress = &v
 }
 
 // ServerConfig Core server settings

--- a/pkg/serverconfig/defaults.gen.go
+++ b/pkg/serverconfig/defaults.gen.go
@@ -13,6 +13,7 @@ func DefaultConfig() *Config {
 		Buildkit:        DefaultBuildkitConfig(),
 		Containerd:      DefaultContainerdConfig(),
 		Etcd:            DefaultEtcdConfig(),
+		Ingress:         DefaultIngressConfig(),
 		Labs:            []string{},
 		Mode:            strPtr("standalone"),
 		Server:          DefaultServerConfig(),
@@ -51,6 +52,13 @@ func DefaultEtcdConfig() EtcdConfig {
 		PeerPort:       intPtr(12380),
 		Prefix:         strPtr("/miren"),
 		StartEmbedded:  nil,
+	}
+}
+
+// DefaultIngressConfig returns default IngressConfig
+func DefaultIngressConfig() IngressConfig {
+	return IngressConfig{
+		HTTPSAddress: strPtr(""),
 	}
 }
 

--- a/pkg/serverconfig/env.gen.go
+++ b/pkg/serverconfig/env.gen.go
@@ -194,6 +194,14 @@ func applyEnvironmentVariables(cfg *Config, log *slog.Logger) error {
 
 	}
 
+	// Apply MIREN_INGRESS_HTTPS_ADDRESS
+	if val := os.Getenv("MIREN_INGRESS_HTTPS_ADDRESS"); val != "" {
+
+		cfg.Ingress.HTTPSAddress = &val
+		log.Debug("applied env var", "key", "MIREN_INGRESS_HTTPS_ADDRESS")
+
+	}
+
 	// Apply MIREN_SERVER_ADDRESS
 	if val := os.Getenv("MIREN_SERVER_ADDRESS"); val != "" {
 

--- a/pkg/serverconfig/loader.gen.go
+++ b/pkg/serverconfig/loader.gen.go
@@ -214,6 +214,10 @@ func applyCLIFlags(cfg *Config, flags *CLIFlags) {
 		cfg.Etcd.StartEmbedded = flags.EtcdConfigStartEmbedded
 	}
 
+	if flags.IngressConfigHTTPSAddress != nil && *flags.IngressConfigHTTPSAddress != "" {
+		cfg.Ingress.HTTPSAddress = flags.IngressConfigHTTPSAddress
+	}
+
 	if flags.ServerConfigAddress != nil && *flags.ServerConfigAddress != "" {
 		cfg.Server.Address = flags.ServerConfigAddress
 	}

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -42,6 +42,11 @@ configs:
         toml: tls
         nested: true
 
+      ingress:
+        type: IngressConfig
+        toml: ingress
+        nested: true
+
       etcd:
         type: EtcdConfig
         toml: etcd
@@ -241,6 +246,20 @@ configs:
           description: Use self-signed certificates for TLS (for development/testing only)
         env: MIREN_TLS_SELF_SIGNED
         toml: self_signed
+
+  IngressConfig:
+    description: "HTTP ingress listener settings. Fields under [ingress] override the default listener selection driven by [tls]; setting any address field here disables the standard 80/443 binding."
+    fields:
+      https_address:
+        type: string
+        default: ""
+        cli:
+          long: ingress-https-address
+          description: "host:port to bind the HTTPS ingress to instead of 0.0.0.0:443. When set, port 80 is not bound and standard_tls has no effect; cert issuance must use DNS-01 (set tls.acme_dns_provider) since HTTP-01 challenges require port 80."
+        env: MIREN_INGRESS_HTTPS_ADDRESS
+        toml: https_address
+        validation:
+          format: host:port
 
   EtcdConfig:
     description: Etcd configuration

--- a/pkg/serverconfig/validation.gen.go
+++ b/pkg/serverconfig/validation.gen.go
@@ -22,6 +22,10 @@ func (c *Config) Validate() error {
 	if err := c.Etcd.Validate(); err != nil {
 		return fmt.Errorf("etcd: %w", err)
 	}
+
+	if err := c.Ingress.Validate(); err != nil {
+		return fmt.Errorf("ingress: %w", err)
+	}
 	// Validate mode
 	if c.Mode != nil {
 		validModes := map[string]bool{
@@ -110,6 +114,21 @@ func (c *EtcdConfig) Validate() error {
 	if c.StartEmbedded != nil && !*c.StartEmbedded && len(c.Endpoints) == 0 {
 		return fmt.Errorf("etcd endpoints must be set when start_embedded=false")
 	}
+
+	return nil
+}
+
+// Validate validates IngressConfig
+func (c *IngressConfig) Validate() error {
+
+	// Validate https_address
+	if c.HTTPSAddress != nil && *c.HTTPSAddress != "" {
+		if _, _, err := net.SplitHostPort(*c.HTTPSAddress); err != nil {
+			return fmt.Errorf("invalid https_address %q: %w", *c.HTTPSAddress, err)
+		}
+	}
+
+	// Check for port conflicts in IngressConfig
 
 	return nil
 }


### PR DESCRIPTION
Companion to #789. Same root motivation — a Miren host already running another application on 80/443 — but for the operator who wants Miren itself to terminate TLS on a non-default port rather than running plain-HTTP behind an external proxy.

This PR adds `ingress.https_address` to the same `[ingress]` section #789 introduces. When set, Miren binds the HTTPS ingress on that address only — no port-80 redirect, no HTTP-01 challenge server, no \`:443\` listener. The cert source must be either DNS-01 ACME (\`tls.acme_dns_provider\`) or \`tls.self_signed\`, since HTTP-01 cannot complete without port 80; \`validateIngressHTTPSAddressConfig\` enforces this at config-load time.

Two new helpers in \`components/autotls/\` carry the actual serving:

- \`ServeTLSWithControllerOnAddr\` parallels the existing \`ServeTLSWithController\` but takes an address and skips the port-80 server.
- \`ServeTLSSelfSignedOnAddr\` does the same for the self-signed path.

Both drop \`acme.ALPNProto\` from \`NextProtos\` since TLS-ALPN-01 also requires port 443.

Validation runs at config-load — right after \`serverconfig.Load(...)\` returns, before any component bootstrap — so a bad cert configuration fails fast with a clear error rather than looking like a containerd or etcd failure thirty seconds later. We learned the hard way that putting validation inside \`Server()\` means containerd dies first on non-root testing boxes.

## Behavior contract

When \`ingress.https_address\` is empty (default), existing \`tls.standard_tls\` paths are unchanged. When it's set, Miren binds HTTPS on that address only; \`tls.standard_tls\` has no effect; cert issuance must use DNS-01 ACME or self-signed.

## Non-goals

- Plain-HTTP-on-custom-port mode — see #789.
- Mutual-exclusion guard for setting \`ingress.http_address\` and \`ingress.https_address\` together — that lands in a third PR alongside the consolidation refactor.

## Schema collision with #789

Both this PR and #789 independently introduce the \`[ingress]\` section with one field each. Whichever lands second will need a small \`pkg/serverconfig/schema.yml\` rebase to merge the field lists; codegen regenerates cleanly from there.

## Testing

- \`TestValidateIngressHTTPSAddressConfig\` table-tests the cert-source validator (DNS-01 path, self-signed path, neither-set rejection, self-signed-wins-over-DNS).
- \`TestServeTLSWithControllerOnAddr\` exercises the parameterized autotls path end-to-end against \`127.0.0.1:0\` with a fake \`CertificateProvider\` and a real TLS handshake.
- Verified end-to-end on Linux in a containerized standalone-mode boot: with \`--self-signed-tls --ingress-https-address=127.0.0.1:18444\`, \`curl -k https://127.0.0.1:18444/\` returns Miren's 404 over a real TLS handshake; \`ss -tln\` confirms no listeners on 80 or 443.