### PR TITLE
Reject conflicting ingress addresses and consolidate mode selection

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -825,7 +825,35 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		}
 	}()
 
-	if cfg.TLS.GetStandardTLS() {
+	if ingressAddr := cfg.Ingress.GetHTTPAddress(); ingressAddr != "" {
+		warnIngressTLSOverride(ctx.Log, &cfg.TLS)
+		// Bind synchronously so a port conflict surfaces as a startup error
+		// instead of an orphaned goroutine after the supervisor thinks we're up.
+		ln, err := net.Listen("tcp", ingressAddr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %w", ingressAddr, err)
+		}
+		ctx.Log.Info("serving plain HTTP ingress", "addr", ln.Addr().String())
+		ingressServer := &http.Server{
+			Handler:           hs,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		eg.Go(func() error {
+			if err := ingressServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+				return fmt.Errorf("HTTP ingress on %s: %w", ingressAddr, err)
+			}
+			return nil
+		})
+		eg.Go(func() error {
+			<-sub.Done()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := ingressServer.Shutdown(shutdownCtx); err != nil {
+				return fmt.Errorf("HTTP ingress shutdown on %s: %w", ingressAddr, err)
+			}
+			return nil
+		})
+	} else if cfg.TLS.GetStandardTLS() {
 		if cfg.TLS.GetSelfSigned() {
 			// Use self-signed certificate (for development/testing)
 			if err := autotls.ServeTLSSelfSigned(sub, ctx.Log, hs); err != nil {
@@ -968,6 +996,29 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 
 	co.Stop()
 	return err
+}
+
+// warnIngressTLSOverride logs a warning for each tls.* setting that is
+// non-default but has no effect because ingress.http_address is set.
+// standard_tls is intentionally skipped: it defaults to true, so an
+// unmodified config would always trigger a misleading warning.
+func warnIngressTLSOverride(log *slog.Logger, tls *serverconfig.TLSConfig) {
+	const suffix = "ignored because ingress.http_address is set; the ingress serves plain HTTP"
+	if tls.GetSelfSigned() {
+		log.Warn("tls.self_signed " + suffix)
+	}
+	if tls.GetAcmeEmail() != "" {
+		log.Warn("tls.acme_email " + suffix)
+	}
+	if tls.GetAcmeDNSProvider() != "" {
+		log.Warn("tls.acme_dns_provider " + suffix)
+	}
+	if len(tls.AdditionalIPs) > 0 {
+		log.Warn("tls.additional_ips " + suffix + "; no certificate is issued")
+	}
+	if len(tls.AdditionalNames) > 0 {
+		log.Warn("tls.additional_names " + suffix + "; no certificate is issued")
+	}
 }
 
 // writeLocalClusterConfig writes a client config file for the local cluster

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -1029,6 +1029,9 @@ func selectIngressMode(cfg *serverconfig.Config) (ingressMode, string, error) {
 	httpAddr := cfg.Ingress.GetHTTPAddress()
 	httpsAddr := cfg.Ingress.GetHTTPSAddress()
 
+	if httpAddr != "" && httpsAddr != "" {
+		return 0, "", fmt.Errorf("ingress.http_address and ingress.https_address are mutually exclusive; set at most one")
+	}
 	if httpAddr != "" {
 		return ingressModeCustomHTTP, httpAddr, nil
 	}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -68,13 +68,12 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Validate ingress.https_address preconditions before any I/O so a bad
-	// config fails fast instead of waiting for component startup to surface
-	// an unrelated-looking error.
-	if cfg.Ingress.GetHTTPSAddress() != "" {
-		if err := validateIngressHTTPSAddressConfig(&cfg.TLS); err != nil {
-			return err
-		}
+	// Resolve the ingress mode at config-load time so config-only errors
+	// (mutual exclusion, missing cert source) fail fast instead of waiting
+	// for component startup to surface unrelated-looking failures.
+	mode, ingressAddr, err := selectIngressMode(cfg)
+	if err != nil {
+		return err
 	}
 
 	// Initialize Miren Labs feature flags
@@ -834,15 +833,15 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		}
 	}()
 
-	if ingressAddr := cfg.Ingress.GetHTTPAddress(); ingressAddr != "" {
+	switch mode {
+	case ingressModeCustomHTTP:
 		warnIngressTLSOverride(ctx.Log, &cfg.TLS)
 		if err := serveCustomHTTPIngress(sub, eg, ctx.Log, hs, ingressAddr); err != nil {
 			return err
 		}
-	} else if httpsAddr := cfg.Ingress.GetHTTPSAddress(); httpsAddr != "" {
-		// Cert-source preconditions were already enforced at config-load time.
+	case ingressModeCustomHTTPS:
 		if cfg.TLS.GetSelfSigned() {
-			if err := autotls.ServeTLSSelfSignedOnAddr(sub, ctx.Log, hs, httpsAddr); err != nil {
+			if err := autotls.ServeTLSSelfSignedOnAddr(sub, ctx.Log, hs, ingressAddr); err != nil {
 				return err
 			}
 		} else {
@@ -850,11 +849,11 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 			if certProvider == nil {
 				return fmt.Errorf("no certificate provider available")
 			}
-			if err := autotls.ServeTLSWithControllerOnAddr(sub, ctx.Log, certProvider, hs, httpsAddr); err != nil {
+			if err := autotls.ServeTLSWithControllerOnAddr(sub, ctx.Log, certProvider, hs, ingressAddr); err != nil {
 				return err
 			}
 		}
-	} else if cfg.TLS.GetStandardTLS() {
+	case ingressModeStandardTLS:
 		if cfg.TLS.GetSelfSigned() {
 			// Use self-signed certificate (for development/testing)
 			if err := autotls.ServeTLSSelfSigned(sub, ctx.Log, hs); err != nil {
@@ -874,7 +873,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 				readyFn()
 			}
 		}
-	} else {
+	case ingressModeStandardHTTP:
 		go func() {
 			err := http.ListenAndServe(":80", hs)
 			if err != nil {
@@ -997,6 +996,52 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 
 	co.Stop()
 	return err
+}
+
+// ingressMode names the four ways Miren can expose its HTTP ingress. The
+// selection order is encoded in selectIngressMode; see Server() for how each
+// mode is wired up.
+type ingressMode int
+
+const (
+	// ingressModeStandardTLS — bind 0.0.0.0:443 with TLS plus 0.0.0.0:80 for
+	// HTTP-01 ACME challenges and HTTPS redirects. The default.
+	ingressModeStandardTLS ingressMode = iota
+
+	// ingressModeStandardHTTP — bind 0.0.0.0:80 plain HTTP, no TLS. The
+	// legacy fallback when standard_tls is explicitly disabled and no
+	// [ingress] address is set.
+	ingressModeStandardHTTP
+
+	// ingressModeCustomHTTP — bind plain HTTP on ingress.http_address,
+	// typically behind a TLS-terminating proxy.
+	ingressModeCustomHTTP
+
+	// ingressModeCustomHTTPS — bind HTTPS on ingress.https_address,
+	// typically when another service on the host owns 443.
+	ingressModeCustomHTTPS
+)
+
+// selectIngressMode resolves the operator's configuration into a single
+// ingress mode + bind address, applying the precedence rules and rejecting
+// configurations that conflict.
+func selectIngressMode(cfg *serverconfig.Config) (ingressMode, string, error) {
+	httpAddr := cfg.Ingress.GetHTTPAddress()
+	httpsAddr := cfg.Ingress.GetHTTPSAddress()
+
+	if httpAddr != "" {
+		return ingressModeCustomHTTP, httpAddr, nil
+	}
+	if httpsAddr != "" {
+		if err := validateIngressHTTPSAddressConfig(&cfg.TLS); err != nil {
+			return 0, "", err
+		}
+		return ingressModeCustomHTTPS, httpsAddr, nil
+	}
+	if cfg.TLS.GetStandardTLS() {
+		return ingressModeStandardTLS, "", nil
+	}
+	return ingressModeStandardHTTP, "", nil
 }
 
 // serveCustomHTTPIngress binds plain HTTP on addr without TLS, intended for

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -836,32 +836,9 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 
 	if ingressAddr := cfg.Ingress.GetHTTPAddress(); ingressAddr != "" {
 		warnIngressTLSOverride(ctx.Log, &cfg.TLS)
-		// Bind synchronously so a port conflict surfaces as a startup error
-		// instead of an orphaned goroutine after the supervisor thinks we're up.
-		ln, err := net.Listen("tcp", ingressAddr)
-		if err != nil {
-			return fmt.Errorf("listen %s: %w", ingressAddr, err)
+		if err := serveCustomHTTPIngress(sub, eg, ctx.Log, hs, ingressAddr); err != nil {
+			return err
 		}
-		ctx.Log.Info("serving plain HTTP ingress", "addr", ln.Addr().String())
-		ingressServer := &http.Server{
-			Handler:           hs,
-			ReadHeaderTimeout: 5 * time.Second,
-		}
-		eg.Go(func() error {
-			if err := ingressServer.Serve(ln); err != nil && err != http.ErrServerClosed {
-				return fmt.Errorf("HTTP ingress on %s: %w", ingressAddr, err)
-			}
-			return nil
-		})
-		eg.Go(func() error {
-			<-sub.Done()
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			if err := ingressServer.Shutdown(shutdownCtx); err != nil {
-				return fmt.Errorf("HTTP ingress shutdown on %s: %w", ingressAddr, err)
-			}
-			return nil
-		})
 	} else if httpsAddr := cfg.Ingress.GetHTTPSAddress(); httpsAddr != "" {
 		// Cert-source preconditions were already enforced at config-load time.
 		if cfg.TLS.GetSelfSigned() {
@@ -1022,7 +999,39 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	return err
 }
 
-<<<<<<< HEAD
+// serveCustomHTTPIngress binds plain HTTP on addr without TLS, intended for
+// deployments where Miren runs behind a TLS-terminating proxy. Listens
+// synchronously so a port conflict surfaces as a startup error rather than
+// an orphaned goroutine; the accept loop and graceful shutdown run in
+// errgroup-managed goroutines so a fatal Serve error terminates the process.
+func serveCustomHTTPIngress(ctx context.Context, eg *errgroup.Group, log *slog.Logger, h http.Handler, addr string) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
+	log.Info("serving plain HTTP ingress", "addr", ln.Addr().String())
+	server := &http.Server{
+		Handler:           h,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	eg.Go(func() error {
+		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("HTTP ingress on %s: %w", addr, err)
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("HTTP ingress shutdown on %s: %w", addr, err)
+		}
+		return nil
+	})
+	return nil
+}
+
 // warnIngressTLSOverride logs a warning for each tls.* setting that is
 // non-default but has no effect because ingress.http_address is set.
 // standard_tls is intentionally skipped: it defaults to true, so an
@@ -1044,7 +1053,8 @@ func warnIngressTLSOverride(log *slog.Logger, tls *serverconfig.TLSConfig) {
 	if len(tls.AdditionalNames) > 0 {
 		log.Warn("tls.additional_names " + suffix + "; no certificate is issued")
 	}
-=======
+}
+
 // validateIngressHTTPSAddressConfig enforces the cert-source preconditions for
 // binding the HTTPS ingress to a non-default address. Port 80 is not bound in
 // this mode, so HTTP-01 ACME challenges cannot complete; the operator must
@@ -1058,7 +1068,6 @@ func validateIngressHTTPSAddressConfig(tls *serverconfig.TLSConfig) error {
 		return fmt.Errorf("ingress.https_address requires either tls.self_signed or DNS-01 ACME (set tls.acme_dns_provider); HTTP-01 cannot be used because port 80 is not bound in this mode")
 	}
 	return nil
->>>>>>> 68cd0e19 (Bind HTTPS to ingress.https_address when configured)
 }
 
 // writeLocalClusterConfig writes a client config file for the local cluster

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -68,6 +68,15 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
+	// Validate ingress.https_address preconditions before any I/O so a bad
+	// config fails fast instead of waiting for component startup to surface
+	// an unrelated-looking error.
+	if cfg.Ingress.GetHTTPSAddress() != "" {
+		if err := validateIngressHTTPSAddressConfig(&cfg.TLS); err != nil {
+			return err
+		}
+	}
+
 	// Initialize Miren Labs feature flags
 	labs.Init(ctx.Log, cfg.Labs)
 
@@ -853,6 +862,21 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 			}
 			return nil
 		})
+	} else if httpsAddr := cfg.Ingress.GetHTTPSAddress(); httpsAddr != "" {
+		// Cert-source preconditions were already enforced at config-load time.
+		if cfg.TLS.GetSelfSigned() {
+			if err := autotls.ServeTLSSelfSignedOnAddr(sub, ctx.Log, hs, httpsAddr); err != nil {
+				return err
+			}
+		} else {
+			certProvider := co.CertificateProvider()
+			if certProvider == nil {
+				return fmt.Errorf("no certificate provider available")
+			}
+			if err := autotls.ServeTLSWithControllerOnAddr(sub, ctx.Log, certProvider, hs, httpsAddr); err != nil {
+				return err
+			}
+		}
 	} else if cfg.TLS.GetStandardTLS() {
 		if cfg.TLS.GetSelfSigned() {
 			// Use self-signed certificate (for development/testing)
@@ -998,6 +1022,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	return err
 }
 
+<<<<<<< HEAD
 // warnIngressTLSOverride logs a warning for each tls.* setting that is
 // non-default but has no effect because ingress.http_address is set.
 // standard_tls is intentionally skipped: it defaults to true, so an
@@ -1019,6 +1044,21 @@ func warnIngressTLSOverride(log *slog.Logger, tls *serverconfig.TLSConfig) {
 	if len(tls.AdditionalNames) > 0 {
 		log.Warn("tls.additional_names " + suffix + "; no certificate is issued")
 	}
+=======
+// validateIngressHTTPSAddressConfig enforces the cert-source preconditions for
+// binding the HTTPS ingress to a non-default address. Port 80 is not bound in
+// this mode, so HTTP-01 ACME challenges cannot complete; the operator must
+// supply a cert via DNS-01 ACME or self-signed (the latter is appropriate for
+// dev or upstream-of-a-TLS-terminating-proxy deployments).
+func validateIngressHTTPSAddressConfig(tls *serverconfig.TLSConfig) error {
+	if tls.GetSelfSigned() {
+		return nil
+	}
+	if tls.GetAcmeDNSProvider() == "" {
+		return fmt.Errorf("ingress.https_address requires either tls.self_signed or DNS-01 ACME (set tls.acme_dns_provider); HTTP-01 cannot be used because port 80 is not bound in this mode")
+	}
+	return nil
+>>>>>>> 68cd0e19 (Bind HTTPS to ingress.https_address when configured)
 }
 
 // writeLocalClusterConfig writes a client config file for the local cluster

--- a/cli/commands/server_test.go
+++ b/cli/commands/server_test.go
@@ -1,0 +1,108 @@
+//go:build linux
+
+package commands
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"miren.dev/runtime/pkg/serverconfig"
+)
+
+func TestWarnIngressTLSOverride(t *testing.T) {
+	cases := []struct {
+		name           string
+		standardTLS    bool
+		selfSigned     bool
+		acmeEmail      string
+		acmeProvider   string
+		additionalIPs  []string
+		additionalDNS  []string
+		wantContains   []string
+		notWantContain []string
+	}{
+		{
+			name:           "default tls config: silent",
+			notWantContain: []string{"ignored"},
+		},
+		{
+			// standard_tls defaults to true, so any naïve "warn when set"
+			// implementation would cry wolf on every default config. Pin the
+			// exclusion so it doesn't silently regress.
+			name:           "standard_tls true: silent (excluded by design)",
+			standardTLS:    true,
+			notWantContain: []string{"standard_tls", "ignored"},
+		},
+		{
+			name:           "self_signed warns",
+			selfSigned:     true,
+			wantContains:   []string{"tls.self_signed"},
+			notWantContain: []string{"acme", "additional"},
+		},
+		{
+			name:           "acme_email warns by name",
+			acmeEmail:      "ops@example.com",
+			wantContains:   []string{"tls.acme_email"},
+			notWantContain: []string{"acme_dns_provider", "self_signed"},
+		},
+		{
+			name:           "acme_dns_provider warns by name",
+			acmeProvider:   "cloudflare",
+			wantContains:   []string{"tls.acme_dns_provider"},
+			notWantContain: []string{"acme_email", "self_signed"},
+		},
+		{
+			name:           "additional_ips warns",
+			additionalIPs:  []string{"10.0.0.1"},
+			wantContains:   []string{"tls.additional_ips"},
+			notWantContain: []string{"additional_names"},
+		},
+		{
+			name: "all warn together, each named individually",
+			selfSigned:    true,
+			acmeEmail:     "ops@example.com",
+			acmeProvider:  "cloudflare",
+			additionalIPs: []string{"10.0.0.1"},
+			additionalDNS: []string{"alt.example.com"},
+			wantContains: []string{
+				"tls.self_signed",
+				"tls.acme_email",
+				"tls.acme_dns_provider",
+				"tls.additional_ips",
+				"tls.additional_names",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tls := &serverconfig.TLSConfig{
+				AdditionalIPs:   tc.additionalIPs,
+				AdditionalNames: tc.additionalDNS,
+			}
+			tls.SetStandardTLS(tc.standardTLS)
+			tls.SetSelfSigned(tc.selfSigned)
+			tls.SetAcmeEmail(tc.acmeEmail)
+			tls.SetAcmeDNSProvider(tc.acmeProvider)
+
+			var buf bytes.Buffer
+			log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+			warnIngressTLSOverride(log, tls)
+
+			out := buf.String()
+			for _, want := range tc.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected log output to contain %q, got: %s", want, out)
+				}
+			}
+			for _, bad := range tc.notWantContain {
+				if strings.Contains(out, bad) {
+					t.Errorf("expected log output NOT to contain %q, got: %s", bad, out)
+				}
+			}
+		})
+	}
+}

--- a/cli/commands/server_test.go
+++ b/cli/commands/server_test.go
@@ -107,6 +107,102 @@ func TestWarnIngressTLSOverride(t *testing.T) {
 	}
 }
 
+func TestSelectIngressMode(t *testing.T) {
+	cases := []struct {
+		name         string
+		httpAddr     string
+		httpsAddr    string
+		standardTLS  bool
+		selfSigned   bool
+		dnsProvider  string
+		wantMode     ingressMode
+		wantAddr     string
+		wantErr      bool
+		wantContains string
+	}{
+		{
+			name:        "default config picks standard TLS",
+			standardTLS: true,
+			wantMode:    ingressModeStandardTLS,
+		},
+		{
+			name:     "standard_tls=false with no ingress falls back to plain :80",
+			wantMode: ingressModeStandardHTTP,
+		},
+		{
+			name:     "ingress.http_address picks custom HTTP",
+			httpAddr: "127.0.0.1:8080",
+			wantMode: ingressModeCustomHTTP,
+			wantAddr: "127.0.0.1:8080",
+		},
+		{
+			name:        "ingress.https_address with dns provider picks custom HTTPS",
+			httpsAddr:   "127.0.0.1:8444",
+			dnsProvider: "cloudflare",
+			wantMode:    ingressModeCustomHTTPS,
+			wantAddr:    "127.0.0.1:8444",
+		},
+		{
+			name:       "ingress.https_address with self_signed picks custom HTTPS",
+			httpsAddr:  "127.0.0.1:8444",
+			selfSigned: true,
+			wantMode:   ingressModeCustomHTTPS,
+			wantAddr:   "127.0.0.1:8444",
+		},
+		{
+			name:         "both ingress addresses set is rejected",
+			httpAddr:     "127.0.0.1:8080",
+			httpsAddr:    "127.0.0.1:8444",
+			wantErr:      true,
+			wantContains: "mutually exclusive",
+		},
+		{
+			name:         "ingress.https_address without cert source is rejected",
+			httpsAddr:    "127.0.0.1:8444",
+			wantErr:      true,
+			wantContains: "self_signed",
+		},
+		{
+			name:        "ingress.http_address wins over standard_tls",
+			httpAddr:    "127.0.0.1:8080",
+			standardTLS: true,
+			wantMode:    ingressModeCustomHTTP,
+			wantAddr:    "127.0.0.1:8080",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &serverconfig.Config{}
+			cfg.Ingress.SetHTTPAddress(tc.httpAddr)
+			cfg.Ingress.SetHTTPSAddress(tc.httpsAddr)
+			cfg.TLS.SetStandardTLS(tc.standardTLS)
+			cfg.TLS.SetSelfSigned(tc.selfSigned)
+			cfg.TLS.SetAcmeDNSProvider(tc.dnsProvider)
+
+			mode, addr, err := selectIngressMode(cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if mode != tc.wantMode {
+				t.Errorf("mode: got %d, want %d", mode, tc.wantMode)
+			}
+			if addr != tc.wantAddr {
+				t.Errorf("addr: got %q, want %q", addr, tc.wantAddr)
+			}
+		})
+	}
+}
+
 func TestValidateIngressHTTPSAddressConfig(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/cli/commands/server_test.go
+++ b/cli/commands/server_test.go
@@ -60,7 +60,7 @@ func TestWarnIngressTLSOverride(t *testing.T) {
 			notWantContain: []string{"additional_names"},
 		},
 		{
-			name: "all warn together, each named individually",
+			name:          "all warn together, each named individually",
 			selfSigned:    true,
 			acmeEmail:     "ops@example.com",
 			acmeProvider:  "cloudflare",
@@ -102,6 +102,43 @@ func TestWarnIngressTLSOverride(t *testing.T) {
 				if strings.Contains(out, bad) {
 					t.Errorf("expected log output NOT to contain %q, got: %s", bad, out)
 				}
+			}
+		})
+	}
+}
+
+func TestValidateIngressHTTPSAddressConfig(t *testing.T) {
+	cases := []struct {
+		name         string
+		selfSigned   bool
+		dnsProvider  string
+		wantErr      bool
+		wantContains string
+	}{
+		{name: "valid: dns provider set", dnsProvider: "cloudflare"},
+		{name: "valid: self-signed", selfSigned: true},
+		{name: "valid: self-signed wins when both set", selfSigned: true, dnsProvider: "cloudflare"},
+		{name: "rejects neither cert source", wantErr: true, wantContains: "self_signed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tls := &serverconfig.TLSConfig{}
+			tls.SetSelfSigned(tc.selfSigned)
+			tls.SetAcmeDNSProvider(tc.dnsProvider)
+
+			err := validateIngressHTTPSAddressConfig(tls)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/components/autotls/autotls.go
+++ b/components/autotls/autotls.go
@@ -3,6 +3,7 @@ package autotls
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -112,6 +113,53 @@ func ServeTLSWithController(ctx context.Context, log *slog.Logger, certProvider 
 			log.Error("HTTP server shutdown error", "error", err)
 		}
 		log.Info("HTTPS and HTTP servers shutdown complete")
+	}()
+
+	return nil
+}
+
+// ServeTLSWithControllerOnAddr serves HTTPS on addr without binding port 80.
+// Because port 80 is not bound, ACME HTTP-01 and TLS-ALPN-01 challenges cannot
+// succeed in this mode; certificates must be issued via DNS-01.
+func ServeTLSWithControllerOnAddr(ctx context.Context, log *slog.Logger, certProvider CertificateProvider, h http.Handler, addr string) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
+	return serveTLSOnListener(ctx, log, certProvider, h, ln)
+}
+
+func serveTLSOnListener(ctx context.Context, log *slog.Logger, certProvider CertificateProvider, h http.Handler, ln net.Listener) error {
+	log = log.With("module", "autotls", "mode", "controller", "addr", ln.Addr().String())
+	log.Info("serving TLS with certificate controller")
+
+	tlsConfig := &tls.Config{
+		GetCertificate: certProvider.GetCertificate,
+		MinVersion:     tls.VersionTLS12,
+		NextProtos:     []string{"h2", "http/1.1"},
+	}
+
+	server := &http.Server{
+		Handler:           h,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		err := server.ServeTLS(ln, "", "")
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("error serving HTTPS", "error", err)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		log.Info("shutting down HTTPS server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Error("HTTPS server shutdown error", "error", err)
+		}
 	}()
 
 	return nil

--- a/components/autotls/autotls_test.go
+++ b/components/autotls/autotls_test.go
@@ -1,0 +1,93 @@
+package autotls
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeCertProvider struct {
+	cert *tls.Certificate
+}
+
+func (f *fakeCertProvider) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return f.cert, nil
+}
+
+func TestServeTLSWithControllerOnAddr(t *testing.T) {
+	cert, err := generateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("generate cert: %v", err)
+	}
+	cp := &fakeCertProvider{cert: &cert}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := serveTLSOnListener(ctx, slog.Default(), cp, handler, ln); err != nil {
+		t.Fatalf("serveTLSOnListener: %v", err)
+	}
+
+	addr := ln.Addr().String()
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec // test against in-process self-signed cert
+		Timeout:   2 * time.Second,
+	}
+
+	// The serving goroutine is started but may not yet be accepting; retry briefly.
+	var resp *http.Response
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err = client.Get("https://" + addr + "/")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok" {
+		t.Fatalf("expected body %q, got %q", "ok", string(body))
+	}
+}
+
+func TestServeTLSWithControllerOnAddrInvalidAddress(t *testing.T) {
+	cert, err := generateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("generate cert: %v", err)
+	}
+	cp := &fakeCertProvider{cert: &cert}
+
+	const malformed = "127.0.0.1:not-a-port"
+	err = ServeTLSWithControllerOnAddr(context.Background(), slog.Default(), cp, http.NotFoundHandler(), malformed)
+	if err == nil {
+		t.Fatal("expected error for malformed address, got nil")
+	}
+	// Verify our wrap (fmt.Errorf "listen %s: %w") rather than just probing stdlib behavior.
+	wantPrefix := "listen " + malformed + ":"
+	if !strings.HasPrefix(err.Error(), wantPrefix) {
+		t.Fatalf("expected error prefix %q, got: %v", wantPrefix, err)
+	}
+}

--- a/components/autotls/selfsigned.go
+++ b/components/autotls/selfsigned.go
@@ -99,6 +99,55 @@ func ServeTLSSelfSigned(ctx context.Context, log *slog.Logger, h http.Handler) e
 	return nil
 }
 
+// ServeTLSSelfSignedOnAddr serves HTTPS on addr using a self-signed certificate.
+// Unlike ServeTLSSelfSigned, it does not also start a port-80 redirect server,
+// so it can bind to a non-standard address (for example, behind a TLS-terminating
+// proxy that already owns 80/443 on the host).
+func ServeTLSSelfSignedOnAddr(ctx context.Context, log *slog.Logger, h http.Handler, addr string) error {
+	log = log.With("module", "autotls", "mode", "self-signed", "addr", addr)
+	log.Info("serving TLS with self-signed certificate on custom address (dev / behind-proxy mode)")
+
+	cert, err := generateSelfSignedCert()
+	if err != nil {
+		return fmt.Errorf("failed to generate self-signed certificate: %w", err)
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	server := &http.Server{
+		Handler:           h,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		err := server.ServeTLS(ln, "", "")
+		if err != nil && err != http.ErrServerClosed {
+			log.Error("error serving HTTPS", "error", err)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		log.Info("shutting down HTTPS server")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			log.Error("HTTPS server shutdown error", "error", err)
+		}
+	}()
+
+	return nil
+}
+
 // generateSelfSignedCert creates an in-memory self-signed certificate
 func generateSelfSignedCert() (tls.Certificate, error) {
 	cert, _, _, err := generateSelfSignedCertWithPEM()

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -99,11 +99,25 @@ Controls TLS certificates for the server and HTTP ingress. See [TLS](/tls) for s
 
 ## `[ingress]` — HTTP Ingress Settings {#ingress}
 
-Controls where the HTTP ingress listens. Leave empty for the default behavior driven by `[tls]`. Set `http_address` to run a plain-HTTP ingress behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.).
+Controls where the HTTP ingress listens. Leave empty for the default behavior driven by `[tls]`. The `[ingress]` fields are **mutually exclusive** — set at most one.
 
 | Field | Type | Default | Description | Env Var | CLI Flag |
 |-------|------|---------|-------------|---------|----------|
 | `http_address` | string | — | `host:port` to bind a plain-HTTP ingress on instead of starting TLS. When set, no TLS is performed and ports 80 and 443 are not bound; `tls.*` settings have no effect. | `MIREN_INGRESS_HTTP_ADDRESS` | `--ingress-http-address` |
+| `https_address` | string | — | `host:port` to bind the HTTPS ingress on instead of `0.0.0.0:443`. When set, port 80 is not bound and `tls.standard_tls` has no effect; cert issuance must use DNS-01 (`tls.acme_dns_provider`) or `tls.self_signed`, since HTTP-01 cannot complete without port 80. | `MIREN_INGRESS_HTTPS_ADDRESS` | `--ingress-https-address` |
+
+### Ingress precedence
+
+Miren picks at most one ingress mode at startup, in this order:
+
+1. `ingress.http_address` set → bind plain HTTP on that address; no TLS, no port-80 fallback, `tls.*` ignored (with warnings for non-default fields).
+2. else `ingress.https_address` set → bind HTTPS on that address; no port-80 fallback, cert sourced from DNS-01 ACME or `tls.self_signed`.
+3. else `tls.standard_tls = true` (the default) → bind HTTPS on `:443` and an HTTP→HTTPS redirect on `:80`.
+4. else (`tls.standard_tls = false` and no `ingress.*` set) → bind plain HTTP on `:80`. This is the legacy fallback; new deployments behind a proxy should prefer `ingress.http_address`.
+
+Setting both `ingress.http_address` and `ingress.https_address` is rejected at config load.
+
+### Plain HTTP behind a TLS-terminating proxy
 
 ```toml
 [ingress]
@@ -112,13 +126,24 @@ http_address = "127.0.0.1:8080"
 
 The upstream proxy is responsible for TLS termination, certificate management, and any HTTP→HTTPS redirects. Miren only sees plain HTTP from that proxy.
 
-### Ingress precedence
+### HTTPS on a non-default address
 
-Miren picks at most one ingress mode at startup, in this order:
+```toml
+[ingress]
+https_address = "127.0.0.1:8444"
 
-1. `ingress.http_address` set → bind plain HTTP on that address; no TLS, no port-80 fallback, `tls.*` ignored (with warnings for non-default fields).
-2. else `tls.standard_tls = true` (the default) → bind HTTPS on `:443` and an HTTP→HTTPS redirect on `:80`.
-3. else (`tls.standard_tls = false` and no `ingress.http_address`) → bind plain HTTP on `:80`. This is the legacy fallback; new deployments behind a proxy should prefer `ingress.http_address`.
+[tls]
+acme_email = "you@example.com"
+acme_dns_provider = "cloudflare"
+```
+
+When `ingress.https_address` is set:
+
+- Miren binds **only** to that address. Ports 80 and 443 are not bound.
+- `tls.standard_tls` has no effect.
+- ACME HTTP-01 challenges are not possible (they require port 80). Use DNS-01 (`tls.acme_dns_provider`) or `tls.self_signed` as the cert source. Miren refuses to start if neither is configured.
+- Self-signed mode is appropriate for development and for deployments behind a TLS-terminating proxy that uses `proxy_ssl_verify off` (or equivalent), where the upstream certificate identity does not need to be trusted by clients.
+- `tls.additional_ips` and `tls.additional_names` continue to add SAN entries to the issued certificate; they do not bind additional listeners and are unaffected.
 
 ## `[etcd]` — Etcd Settings {#etcd}
 

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -97,6 +97,29 @@ Controls TLS certificates for the server and HTTP ingress. See [TLS](/tls) for s
 | `acme_email` | string | — | Email for ACME account registration | `MIREN_TLS_ACME_EMAIL` | `--acme-email` |
 | `self_signed` | bool | `false` | Use self-signed certificates (development only) | `MIREN_TLS_SELF_SIGNED` | `--self-signed-tls` |
 
+## `[ingress]` — HTTP Ingress Settings {#ingress}
+
+Controls where the HTTP ingress listens. Leave empty for the default behavior driven by `[tls]`. Set `http_address` to run a plain-HTTP ingress behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.).
+
+| Field | Type | Default | Description | Env Var | CLI Flag |
+|-------|------|---------|-------------|---------|----------|
+| `http_address` | string | — | `host:port` to bind a plain-HTTP ingress on instead of starting TLS. When set, no TLS is performed and ports 80 and 443 are not bound; `tls.*` settings have no effect. | `MIREN_INGRESS_HTTP_ADDRESS` | `--ingress-http-address` |
+
+```toml
+[ingress]
+http_address = "127.0.0.1:8080"
+```
+
+The upstream proxy is responsible for TLS termination, certificate management, and any HTTP→HTTPS redirects. Miren only sees plain HTTP from that proxy.
+
+### Ingress precedence
+
+Miren picks at most one ingress mode at startup, in this order:
+
+1. `ingress.http_address` set → bind plain HTTP on that address; no TLS, no port-80 fallback, `tls.*` ignored (with warnings for non-default fields).
+2. else `tls.standard_tls = true` (the default) → bind HTTPS on `:443` and an HTTP→HTTPS redirect on `:80`.
+3. else (`tls.standard_tls = false` and no `ingress.http_address`) → bind plain HTTP on `:80`. This is the legacy fallback; new deployments behind a proxy should prefer `ingress.http_address`.
+
 ## `[etcd]` — Etcd Settings {#etcd}
 
 Miren uses etcd as its entity store. In standalone mode, an embedded etcd server starts automatically.

--- a/docs/docs/tls.md
+++ b/docs/docs/tls.md
@@ -119,6 +119,8 @@ All TLS settings live under the `[tls]` section of the server config file (typic
 | `acme_dns_provider` | `--acme-dns-provider` | DNS provider name for DNS-01 challenges (e.g., `cloudflare`, `route53`, `dnsimple`) |
 | `standard_tls` | `--serve-tls` | Enable TLS on ports 443/80 (default: `true`) |
 
+To bind the HTTPS ingress to a non-default address, see [`ingress.https_address`](/server-config#ingress).
+
 ## Troubleshooting
 
 ### Certificate Not Provisioning

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -22,7 +22,8 @@ type CLIFlags struct {
 	EtcdConfigPeerPort                   *int     `long:"etcd-peer-port" description:"Etcd peer port"`
 	EtcdConfigPrefix                     *string  `long:"etcd-prefix" short:"p" description:"Etcd prefix"`
 	EtcdConfigStartEmbedded              *bool    `long:"start-etcd" description:"Start embedded etcd server"`
-	IngressConfigHTTPAddress             *string  `long:"ingress-http-address" description:"host:port to bind a plain-HTTP ingress on instead of starting TLS. Intended for deployments behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.). When set, no TLS is performed and ports 80 and 443 are not bound; tls.* settings have no effect."`
+	IngressConfigHTTPAddress             *string  `long:"ingress-http-address" description:"host:port to bind a plain-HTTP ingress on instead of starting TLS. Intended for deployments behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.). When set, no TLS is performed and ports 80 and 443 are not bound; tls.* settings have no effect. Mutually exclusive with https_address."`
+	IngressConfigHTTPSAddress            *string  `long:"ingress-https-address" description:"host:port to bind the HTTPS ingress to instead of 0.0.0.0:443. When set, port 80 is not bound and standard_tls has no effect; cert issuance must use DNS-01 (set tls.acme_dns_provider) or tls.self_signed since HTTP-01 challenges require port 80. Mutually exclusive with http_address."`
 	ServerConfigAddress                  *string  `long:"address" short:"a" description:"Address to listen on (host:port). For IPv6 use brackets, e.g. \"[::1]:8443\"."`
 	ServerConfigConfigClusterName        *string  `long:"config-cluster-name" short:"C" description:"Name of the cluster in client config"`
 	ServerConfigDataPath                 *string  `long:"data-path" short:"d" description:"Data path"`

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -22,6 +22,7 @@ type CLIFlags struct {
 	EtcdConfigPeerPort                   *int     `long:"etcd-peer-port" description:"Etcd peer port"`
 	EtcdConfigPrefix                     *string  `long:"etcd-prefix" short:"p" description:"Etcd prefix"`
 	EtcdConfigStartEmbedded              *bool    `long:"start-etcd" description:"Start embedded etcd server"`
+	IngressConfigHTTPAddress             *string  `long:"ingress-http-address" description:"host:port to bind a plain-HTTP ingress on instead of starting TLS. Intended for deployments behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.). When set, no TLS is performed and ports 80 and 443 are not bound; tls.* settings have no effect."`
 	ServerConfigAddress                  *string  `long:"address" short:"a" description:"Address to listen on (host:port). For IPv6 use brackets, e.g. \"[::1]:8443\"."`
 	ServerConfigConfigClusterName        *string  `long:"config-cluster-name" short:"C" description:"Name of the cluster in client config"`
 	ServerConfigDataPath                 *string  `long:"data-path" short:"d" description:"Data path"`

--- a/pkg/serverconfig/config.gen.go
+++ b/pkg/serverconfig/config.gen.go
@@ -85,6 +85,7 @@ type Config struct {
 	Buildkit        BuildkitConfig        `toml:"buildkit"`
 	Containerd      ContainerdConfig      `toml:"containerd"`
 	Etcd            EtcdConfig            `toml:"etcd"`
+	Ingress         IngressConfig         `toml:"ingress"`
 	Labs            []string              `toml:"labs" env:"MIREN_LABS"`
 	Mode            *string               `toml:"mode" env:"MIREN_MODE"`
 	Server          ServerConfig          `toml:"server"`
@@ -225,6 +226,24 @@ func (c *EtcdConfig) GetStartEmbedded() bool {
 // SetStartEmbedded sets the value of StartEmbedded
 func (c *EtcdConfig) SetStartEmbedded(v bool) {
 	c.StartEmbedded = &v
+}
+
+// IngressConfig HTTP ingress listener settings. Fields under [ingress] override the default listener selection driven by [tls]; setting any address field here disables the standard 80/443 binding.
+type IngressConfig struct {
+	HTTPAddress *string `toml:"http_address" env:"MIREN_INGRESS_HTTP_ADDRESS"`
+}
+
+// GetHTTPAddress returns the value of HTTPAddress or its zero value if nil
+func (c *IngressConfig) GetHTTPAddress() string {
+	if c.HTTPAddress != nil {
+		return *c.HTTPAddress
+	}
+	return ""
+}
+
+// SetHTTPAddress sets the value of HTTPAddress
+func (c *IngressConfig) SetHTTPAddress(v string) {
+	c.HTTPAddress = &v
 }
 
 // ServerConfig Core server settings

--- a/pkg/serverconfig/config.gen.go
+++ b/pkg/serverconfig/config.gen.go
@@ -230,7 +230,8 @@ func (c *EtcdConfig) SetStartEmbedded(v bool) {
 
 // IngressConfig HTTP ingress listener settings. Fields under [ingress] override the default listener selection driven by [tls]; setting any address field here disables the standard 80/443 binding.
 type IngressConfig struct {
-	HTTPAddress *string `toml:"http_address" env:"MIREN_INGRESS_HTTP_ADDRESS"`
+	HTTPAddress  *string `toml:"http_address" env:"MIREN_INGRESS_HTTP_ADDRESS"`
+	HTTPSAddress *string `toml:"https_address" env:"MIREN_INGRESS_HTTPS_ADDRESS"`
 }
 
 // GetHTTPAddress returns the value of HTTPAddress or its zero value if nil
@@ -244,6 +245,19 @@ func (c *IngressConfig) GetHTTPAddress() string {
 // SetHTTPAddress sets the value of HTTPAddress
 func (c *IngressConfig) SetHTTPAddress(v string) {
 	c.HTTPAddress = &v
+}
+
+// GetHTTPSAddress returns the value of HTTPSAddress or its zero value if nil
+func (c *IngressConfig) GetHTTPSAddress() string {
+	if c.HTTPSAddress != nil {
+		return *c.HTTPSAddress
+	}
+	return ""
+}
+
+// SetHTTPSAddress sets the value of HTTPSAddress
+func (c *IngressConfig) SetHTTPSAddress(v string) {
+	c.HTTPSAddress = &v
 }
 
 // ServerConfig Core server settings

--- a/pkg/serverconfig/defaults.gen.go
+++ b/pkg/serverconfig/defaults.gen.go
@@ -58,7 +58,8 @@ func DefaultEtcdConfig() EtcdConfig {
 // DefaultIngressConfig returns default IngressConfig
 func DefaultIngressConfig() IngressConfig {
 	return IngressConfig{
-		HTTPAddress: strPtr(""),
+		HTTPAddress:  strPtr(""),
+		HTTPSAddress: strPtr(""),
 	}
 }
 

--- a/pkg/serverconfig/defaults.gen.go
+++ b/pkg/serverconfig/defaults.gen.go
@@ -13,6 +13,7 @@ func DefaultConfig() *Config {
 		Buildkit:        DefaultBuildkitConfig(),
 		Containerd:      DefaultContainerdConfig(),
 		Etcd:            DefaultEtcdConfig(),
+		Ingress:         DefaultIngressConfig(),
 		Labs:            []string{},
 		Mode:            strPtr("standalone"),
 		Server:          DefaultServerConfig(),
@@ -51,6 +52,13 @@ func DefaultEtcdConfig() EtcdConfig {
 		PeerPort:       intPtr(12380),
 		Prefix:         strPtr("/miren"),
 		StartEmbedded:  nil,
+	}
+}
+
+// DefaultIngressConfig returns default IngressConfig
+func DefaultIngressConfig() IngressConfig {
+	return IngressConfig{
+		HTTPAddress: strPtr(""),
 	}
 }
 

--- a/pkg/serverconfig/env.gen.go
+++ b/pkg/serverconfig/env.gen.go
@@ -202,6 +202,14 @@ func applyEnvironmentVariables(cfg *Config, log *slog.Logger) error {
 
 	}
 
+	// Apply MIREN_INGRESS_HTTPS_ADDRESS
+	if val := os.Getenv("MIREN_INGRESS_HTTPS_ADDRESS"); val != "" {
+
+		cfg.Ingress.HTTPSAddress = &val
+		log.Debug("applied env var", "key", "MIREN_INGRESS_HTTPS_ADDRESS")
+
+	}
+
 	// Apply MIREN_SERVER_ADDRESS
 	if val := os.Getenv("MIREN_SERVER_ADDRESS"); val != "" {
 

--- a/pkg/serverconfig/env.gen.go
+++ b/pkg/serverconfig/env.gen.go
@@ -194,6 +194,14 @@ func applyEnvironmentVariables(cfg *Config, log *slog.Logger) error {
 
 	}
 
+	// Apply MIREN_INGRESS_HTTP_ADDRESS
+	if val := os.Getenv("MIREN_INGRESS_HTTP_ADDRESS"); val != "" {
+
+		cfg.Ingress.HTTPAddress = &val
+		log.Debug("applied env var", "key", "MIREN_INGRESS_HTTP_ADDRESS")
+
+	}
+
 	// Apply MIREN_SERVER_ADDRESS
 	if val := os.Getenv("MIREN_SERVER_ADDRESS"); val != "" {
 

--- a/pkg/serverconfig/loader.gen.go
+++ b/pkg/serverconfig/loader.gen.go
@@ -218,6 +218,10 @@ func applyCLIFlags(cfg *Config, flags *CLIFlags) {
 		cfg.Ingress.HTTPAddress = flags.IngressConfigHTTPAddress
 	}
 
+	if flags.IngressConfigHTTPSAddress != nil && *flags.IngressConfigHTTPSAddress != "" {
+		cfg.Ingress.HTTPSAddress = flags.IngressConfigHTTPSAddress
+	}
+
 	if flags.ServerConfigAddress != nil && *flags.ServerConfigAddress != "" {
 		cfg.Server.Address = flags.ServerConfigAddress
 	}

--- a/pkg/serverconfig/loader.gen.go
+++ b/pkg/serverconfig/loader.gen.go
@@ -214,6 +214,10 @@ func applyCLIFlags(cfg *Config, flags *CLIFlags) {
 		cfg.Etcd.StartEmbedded = flags.EtcdConfigStartEmbedded
 	}
 
+	if flags.IngressConfigHTTPAddress != nil && *flags.IngressConfigHTTPAddress != "" {
+		cfg.Ingress.HTTPAddress = flags.IngressConfigHTTPAddress
+	}
+
 	if flags.ServerConfigAddress != nil && *flags.ServerConfigAddress != "" {
 		cfg.Server.Address = flags.ServerConfigAddress
 	}

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -255,9 +255,20 @@ configs:
         default: ""
         cli:
           long: ingress-http-address
-          description: "host:port to bind a plain-HTTP ingress on instead of starting TLS. Intended for deployments behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.). When set, no TLS is performed and ports 80 and 443 are not bound; tls.* settings have no effect."
+          description: "host:port to bind a plain-HTTP ingress on instead of starting TLS. Intended for deployments behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.). When set, no TLS is performed and ports 80 and 443 are not bound; tls.* settings have no effect. Mutually exclusive with https_address."
         env: MIREN_INGRESS_HTTP_ADDRESS
         toml: http_address
+        validation:
+          format: host:port
+
+      https_address:
+        type: string
+        default: ""
+        cli:
+          long: ingress-https-address
+          description: "host:port to bind the HTTPS ingress to instead of 0.0.0.0:443. When set, port 80 is not bound and standard_tls has no effect; cert issuance must use DNS-01 (set tls.acme_dns_provider) or tls.self_signed since HTTP-01 challenges require port 80. Mutually exclusive with http_address."
+        env: MIREN_INGRESS_HTTPS_ADDRESS
+        toml: https_address
         validation:
           format: host:port
 

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -42,6 +42,11 @@ configs:
         toml: tls
         nested: true
 
+      ingress:
+        type: IngressConfig
+        toml: ingress
+        nested: true
+
       etcd:
         type: EtcdConfig
         toml: etcd
@@ -241,6 +246,20 @@ configs:
           description: Use self-signed certificates for TLS (for development/testing only)
         env: MIREN_TLS_SELF_SIGNED
         toml: self_signed
+
+  IngressConfig:
+    description: "HTTP ingress listener settings. Fields under [ingress] override the default listener selection driven by [tls]; setting any address field here disables the standard 80/443 binding."
+    fields:
+      http_address:
+        type: string
+        default: ""
+        cli:
+          long: ingress-http-address
+          description: "host:port to bind a plain-HTTP ingress on instead of starting TLS. Intended for deployments behind a TLS-terminating proxy (nginx, Caddy, an ALB, etc.). When set, no TLS is performed and ports 80 and 443 are not bound; tls.* settings have no effect."
+        env: MIREN_INGRESS_HTTP_ADDRESS
+        toml: http_address
+        validation:
+          format: host:port
 
   EtcdConfig:
     description: Etcd configuration

--- a/pkg/serverconfig/validation.gen.go
+++ b/pkg/serverconfig/validation.gen.go
@@ -22,6 +22,10 @@ func (c *Config) Validate() error {
 	if err := c.Etcd.Validate(); err != nil {
 		return fmt.Errorf("etcd: %w", err)
 	}
+
+	if err := c.Ingress.Validate(); err != nil {
+		return fmt.Errorf("ingress: %w", err)
+	}
 	// Validate mode
 	if c.Mode != nil {
 		validModes := map[string]bool{
@@ -110,6 +114,21 @@ func (c *EtcdConfig) Validate() error {
 	if c.StartEmbedded != nil && !*c.StartEmbedded && len(c.Endpoints) == 0 {
 		return fmt.Errorf("etcd endpoints must be set when start_embedded=false")
 	}
+
+	return nil
+}
+
+// Validate validates IngressConfig
+func (c *IngressConfig) Validate() error {
+
+	// Validate http_address
+	if c.HTTPAddress != nil && *c.HTTPAddress != "" {
+		if _, _, err := net.SplitHostPort(*c.HTTPAddress); err != nil {
+			return fmt.Errorf("invalid http_address %q: %w", *c.HTTPAddress, err)
+		}
+	}
+
+	// Check for port conflicts in IngressConfig
 
 	return nil
 }

--- a/pkg/serverconfig/validation.gen.go
+++ b/pkg/serverconfig/validation.gen.go
@@ -128,6 +128,13 @@ func (c *IngressConfig) Validate() error {
 		}
 	}
 
+	// Validate https_address
+	if c.HTTPSAddress != nil && *c.HTTPSAddress != "" {
+		if _, _, err := net.SplitHostPort(*c.HTTPSAddress); err != nil {
+			return fmt.Errorf("invalid https_address %q: %w", *c.HTTPSAddress, err)
+		}
+	}
+
 	// Check for port conflicts in IngressConfig
 
 	return nil


### PR DESCRIPTION
Stacked on #789 and #790. Once those land, this PR's diff against \`main\` shrinks to just the consolidation work — three commits at the tip of the branch.

#789 and #790 each introduce a new \`[ingress]\` field and add their own arm to the \`if/else if\` ladder in \`Server()\` that picks an ingress mode. Naively merged, the two arms compose by source-line ordering — a contract that's never been a deliberate decision, and one nothing prevents an operator from breaking by setting both \`ingress.http_address\` and \`ingress.https_address\` together.

This PR fixes that in three steps:

1. **\`Extract serveCustomHTTPIngress helper\`** — pure refactor of the plain-HTTP wiring out of \`Server()\` into a self-contained helper, in preparation for the switch.

2. **\`Replace ingress if-ladder with selectIngressMode switch\`** — introduces a typed \`ingressMode\` enum (standard TLS, standard HTTP fallback, custom HTTP, custom HTTPS) and a \`selectIngressMode(cfg) (mode, addr, error)\` resolver that owns the precedence rules. The call site in \`Server()\` becomes a flat switch on the resolved mode. \`selectIngressMode\` is invoked at config-load time, right after \`serverconfig.Load(...)\` returns — so any rejection condition (mutual exclusion below; cert-source from #790) fails fast before component bootstrap. Pure refactor — no new behavior.

3. **\`Reject ingress.http_address and ingress.https_address being set together\`** — adds the mutual-exclusion guard inside \`selectIngressMode\`. Operators get \`ingress.http_address and ingress.https_address are mutually exclusive; set at most one\` at startup rather than a silent winner picked by source order.

## Why a third PR rather than one larger PR per side

Each preceding PR ships a narrowly-scoped feature (\"add this knob\") with clean operator UX in isolation. Adding the consolidation to either #789 or #790 alone would either preempt the other PR's design space or grow that PR's diff with refactor work that's only justified when both fields exist. Keeping it separate gives reviewers the option to merge the building blocks on their own timeline without holding back the consolidation.

## Testing

- \`TestSelectIngressMode\` is a new table test in \`cli/commands/server_test.go\` covering the full mode-selection matrix: each mode resolves to the correct \`(mode, addr)\` pair, the cert-source preconditions for custom HTTPS are enforced, and the new mutual-exclusion rule produces the expected error.
- The existing \`TestWarnIngressTLSOverride\` (from #789) and \`TestValidateIngressHTTPSAddressConfig\` (from #790) carry forward unchanged.
- Verified end-to-end on Linux in a containerized standalone-mode boot: setting both \`--ingress-http-address\` and \`--ingress-https-address\` produces the mutual-exclusion error in <200ms with no component startup attempted; running each mode individually binds correctly on its custom address; the cross-PR warn helper from #789 fires by exact field name when \`tls.self_signed\` is left set alongside \`ingress.http_address\`.