### PR TITLE
Reconcile bridge state on flannel lease rotation

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/netip"
 	"os"
@@ -438,6 +437,16 @@ func (c *SandboxController) Init(ctx context.Context) error {
 		return err
 	}
 
+	// Drop any bridge addresses, NAT rules, or POSTROUTING jumps left over
+	// from a previous flannel lease era. Without this, a runner whose lease
+	// rotated (typically after >24h offline) ends up with two pod subnets
+	// pinned to the same bridge and a NAT chain whose ACCEPT rules end up
+	// after the catch-all MASQUERADE (MIR-1108).
+	err = network.ReconcileBridgeAddresses(c.Log, link, bc.Addresses)
+	if err != nil {
+		return err
+	}
+
 	err = network.MasqueradeEndpoint(ep)
 	if err != nil {
 		return err
@@ -679,28 +688,41 @@ func (c *SandboxController) isContainerHealthy(ctx context.Context, containerID 
 	}
 }
 
-// checkNetworkHealth verifies that a sandbox is reachable on its network address
-// Returns true if the sandbox has no ports (background workers) or if at least one port is reachable
-// Returns false if the sandbox has ports but none are reachable
+// checkNetworkHealth verifies that a sandbox's app is still listening on at
+// least one declared port. Returns true for sandboxes with no exposed ports
+// (background workers) or no allocated network. Returns false if ports are
+// declared but none are in LISTEN state inside the pause container's
+// network namespace.
+//
+// The check reads /proc/<pause-pid>/net/tcp{,6} rather than dialing the pod
+// IP from the host. Host-to-pod TCP dials traverse the bridge's POSTROUTING
+// chain and can be intercepted by MASQUERADE, breaking connection tracking
+// on the dialing host. PortMonitor switched away from dials for the same
+// reason (commit 63661df3); MIR-1108 is the same class of bug here.
 func (c *SandboxController) checkNetworkHealth(ctx context.Context, sb *compute.Sandbox) bool {
-	// Skip if sandbox has no network allocated
 	if len(sb.Network) == 0 {
 		c.Log.Debug("sandbox has no network, skipping network health check", "sandbox_id", sb.ID)
 		return true
 	}
 
-	// Parse network address to get IP
-	addr := sb.Network[0].Address
-	ip, err := netutil.ParseNetworkAddress(addr)
-	if err != nil {
-		c.Log.Debug("failed to parse sandbox address", "sandbox_id", sb.ID, "address", addr, "error", err)
-		return false
+	hasPorts := false
+	for _, container := range sb.Spec.Container {
+		if len(container.Port) > 0 {
+			hasPorts = true
+			break
+		}
+	}
+	if !hasPorts {
+		c.Log.Debug("sandbox has no exposed ports, skipping network health check", "sandbox_id", sb.ID)
+		return true
 	}
 
-	// Iterate over containers, trying each container's first port until one succeeds
-	checkedCount := 0
-	dialer := &net.Dialer{
-		Timeout: 2 * time.Second,
+	pauseID := pauseContainerId(sb.ID)
+	pid, err := c.pauseContainerPID(ctx, pauseID)
+	if err != nil {
+		c.Log.Debug("failed to resolve pause container PID for health check",
+			"sandbox_id", sb.ID, "pause_id", pauseID, "error", err)
+		return false
 	}
 
 	for _, container := range sb.Spec.Container {
@@ -708,35 +730,38 @@ func (c *SandboxController) checkNetworkHealth(ctx context.Context, sb *compute.
 			continue
 		}
 
-		// Check first port for this container
-		port := container.Port[0].Port
-		address := net.JoinHostPort(ip, fmt.Sprintf("%d", port))
-		checkedCount++
-
-		conn, err := dialer.DialContext(ctx, "tcp", address)
-		if err != nil {
-			c.Log.Debug("network health check failed for port",
-				"sandbox_id", sb.ID,
-				"container_name", container.Name,
-				"address", address,
-				"error", err)
-			continue
+		port := int(container.Port[0].Port)
+		if checkPort(pid, port) {
+			c.Log.Debug("network health check passed",
+				"sandbox_id", sb.ID, "container_name", container.Name, "port", port)
+			return true
 		}
-		conn.Close()
 
-		// At least one port is reachable, network is healthy
-		c.Log.Debug("network health check passed", "sandbox_id", sb.ID, "address", address)
-		return true
+		c.Log.Debug("network health check found no listener for port",
+			"sandbox_id", sb.ID, "container_name", container.Name, "port", port)
 	}
 
-	// If no ports were checked (background worker), consider it healthy
-	if checkedCount == 0 {
-		c.Log.Debug("sandbox has no exposed ports, skipping network health check", "sandbox_id", sb.ID)
-		return true
-	}
-
-	// All checked ports failed
 	return false
+}
+
+// pauseContainerPID returns the PID of the pause container's task. The
+// pause container shares its network namespace with all sub-containers,
+// so its /proc/<pid>/net/tcp{,6} reflects the listening sockets of the
+// app processes inside the sandbox.
+func (c *SandboxController) pauseContainerPID(ctx context.Context, pauseID string) (int, error) {
+	ctx = namespaces.WithNamespace(ctx, c.Namespace)
+
+	container, err := c.CC.LoadContainer(ctx, pauseID)
+	if err != nil {
+		return 0, fmt.Errorf("loading pause container: %w", err)
+	}
+
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("getting pause task: %w", err)
+	}
+
+	return int(task.Pid()), nil
 }
 
 // reattachLogs reattaches log consumers to a container's task after controller restart.

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -689,31 +689,40 @@ func (c *SandboxController) isContainerHealthy(ctx context.Context, containerID 
 }
 
 // checkNetworkHealth verifies that a sandbox's app is still listening on at
-// least one declared port. Returns true for sandboxes with no exposed ports
-// (background workers) or no allocated network. Returns false if ports are
-// declared but none are in LISTEN state inside the pause container's
-// network namespace.
+// least one declared TCP port. Returns true for sandboxes with no exposed
+// TCP ports (background workers, UDP-only) or no allocated network. Returns
+// false if TCP ports are declared but none are in LISTEN state inside the
+// pause container's network namespace.
 //
 // The check reads /proc/<pause-pid>/net/tcp{,6} rather than dialing the pod
 // IP from the host. Host-to-pod TCP dials traverse the bridge's POSTROUTING
 // chain and can be intercepted by MASQUERADE, breaking connection tracking
 // on the dialing host. PortMonitor switched away from dials for the same
 // reason (commit 63661df3); MIR-1108 is the same class of bug here.
+//
+// Only TCP ports are probed because /proc/net/tcp does not expose UDP
+// listeners; a UDP-only sandbox would be wrongly killed if we treated UDP
+// ports as health-relevant.
 func (c *SandboxController) checkNetworkHealth(ctx context.Context, sb *compute.Sandbox) bool {
 	if len(sb.Network) == 0 {
 		c.Log.Debug("sandbox has no network, skipping network health check", "sandbox_id", sb.ID)
 		return true
 	}
 
-	hasPorts := false
+	hasTCPPorts := false
 	for _, container := range sb.Spec.Container {
-		if len(container.Port) > 0 {
-			hasPorts = true
+		for _, p := range container.Port {
+			if portIsTCP(p) {
+				hasTCPPorts = true
+				break
+			}
+		}
+		if hasTCPPorts {
 			break
 		}
 	}
-	if !hasPorts {
-		c.Log.Debug("sandbox has no exposed ports, skipping network health check", "sandbox_id", sb.ID)
+	if !hasTCPPorts {
+		c.Log.Debug("sandbox has no exposed TCP ports, skipping network health check", "sandbox_id", sb.ID)
 		return true
 	}
 
@@ -726,22 +735,29 @@ func (c *SandboxController) checkNetworkHealth(ctx context.Context, sb *compute.
 	}
 
 	for _, container := range sb.Spec.Container {
-		if len(container.Port) == 0 {
-			continue
-		}
-
-		port := int(container.Port[0].Port)
-		if checkPort(pid, port) {
-			c.Log.Debug("network health check passed",
+		for _, p := range container.Port {
+			if !portIsTCP(p) {
+				continue
+			}
+			port := int(p.Port)
+			if checkPort(pid, port) {
+				c.Log.Debug("network health check passed",
+					"sandbox_id", sb.ID, "container_name", container.Name, "port", port)
+				return true
+			}
+			c.Log.Debug("network health check found no listener for port",
 				"sandbox_id", sb.ID, "container_name", container.Name, "port", port)
-			return true
 		}
-
-		c.Log.Debug("network health check found no listener for port",
-			"sandbox_id", sb.ID, "container_name", container.Name, "port", port)
 	}
 
 	return false
+}
+
+// portIsTCP returns true for ports declared as TCP. Empty Protocol defaults
+// to TCP (matches mapLegacyProtocol), so ports without a protocol set are
+// treated as TCP as well.
+func portIsTCP(p compute.SandboxSpecContainerPort) bool {
+	return p.Protocol == "" || p.Protocol == compute.SandboxSpecContainerPortTCP
 }
 
 // pauseContainerPID returns the PID of the pause container's task. The

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "93f5fd43c35998a7dbcbfb8b4988e33a2cae102a4a97ad86f49add0698b47007",
+		"sandbox.go":  "de8f9ab0c48de3440a3b0d05c7875cbaf12600547287ba3ad857efc3e63a1725",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "db857972e4383cb4d5de0ec8428e74726fb803c314663898fa5338e04f898266",
+		"sandbox.go":  "93f5fd43c35998a7dbcbfb8b4988e33a2cae102a4a97ad86f49add0698b47007",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -1334,36 +1334,10 @@ func TestSandbox(t *testing.T) {
 		r.True(healthy, "sandbox without network should be considered healthy")
 	})
 
-	t.Run("checkNetworkHealth returns false for unreachable ports", func(t *testing.T) {
-		r := require.New(t)
-
-		c := &SandboxController{
-			Log: slog.Default(),
-		}
-
-		ctx := context.Background()
-
-		// Sandbox with network and ports, but ports are unreachable
-		sb := &compute.Sandbox{
-			ID: entity.Id("test-sb"),
-			Network: []compute.Network{
-				{Address: "192.0.2.1/32"}, // TEST-NET-1, should be unreachable
-			},
-			Spec: compute.SandboxSpec{
-				Container: []compute.SandboxSpecContainer{
-					{
-						Name: "app",
-						Port: []compute.SandboxSpecContainerPort{
-							{Port: 9999}, // Unreachable port
-						},
-					},
-				},
-			},
-		}
-
-		healthy := c.checkNetworkHealth(ctx, sb)
-		r.False(healthy, "sandbox with unreachable ports should be considered unhealthy")
-	})
+	// The "unreachable ports" check that used to live here verified the old
+	// TCP-dial behavior, which checkNetworkHealth no longer does (MIR-1108).
+	// The current implementation reads /proc/<pause-pid>/net/tcp via
+	// checkPort; that path is exercised end-to-end by portmonitor_test.go.
 
 	t.Run("PENDING sandbox with running containers should transition to RUNNING", func(t *testing.T) {
 		r := require.New(t)

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -455,13 +455,15 @@ func CheckBridgeStatus(name string) error {
 	return nil
 }
 
-// ReconcileBridgeAddresses removes bridge addresses, NAT chain rules, and
-// POSTROUTING jumps that belong to subnets no longer in `desired`. Drift
-// happens when a runner's flannel lease rotates (typically after the runner
-// is offline long enough for its etcd lease to expire) and a fresh subnet
-// is allocated. Without this reconcile the host bridge accumulates stale
-// addresses across lease eras, and the per-bridge MIREN-* chain accumulates
-// rules that interfere with traffic on the new subnet (MIR-1108).
+// ReconcileBridgeAddresses owns the per-bridge NAT chain shape and removes
+// bridge addresses + POSTROUTING jumps that belong to subnets no longer in
+// `desired`. It runs at sandbox controller init so the chain is in the
+// right shape before any sandbox is created. Drift happens when a runner's
+// flannel lease rotates (typically after the runner is offline long enough
+// for its etcd lease to expire) and a fresh subnet is allocated; without
+// this reconcile the host bridge accumulates stale addresses across lease
+// eras, and the per-bridge MIREN-* chain accumulates rules that interfere
+// with traffic on the new subnet (MIR-1108).
 func ReconcileBridgeAddresses(log *slog.Logger, br netlink.Link, desired []netip.Prefix) error {
 	bridgeName := br.Attrs().Name
 	chain := formatChain(bridgeName)
@@ -488,33 +490,31 @@ func ReconcileBridgeAddresses(log *slog.Logger, br netlink.Link, desired []netip
 		}
 	}
 
-	if len(stale) == 0 {
-		return nil
-	}
-
-	log.Warn("removing stale bridge state",
-		"bridge", bridgeName, "stale", stale, "desired", desired)
-
 	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 	if err != nil {
 		return fmt.Errorf("locating iptables: %w", err)
 	}
 
-	for _, s := range stale {
-		ipn := netipx.PrefixIPNet(s)
-		if err := deleteAddr(br, ipn); err != nil {
-			return fmt.Errorf("removing stale bridge address %s: %w", s, err)
-		}
-		log.Info("removed stale bridge address", "bridge", bridgeName, "address", s)
+	if len(stale) > 0 {
+		log.Warn("removing stale bridge state",
+			"bridge", bridgeName, "stale", stale, "desired", desired)
 
-		if err := removeStalePostroutingJumps(log, ipt, chain, comment, s); err != nil {
-			log.Warn("failed to clean POSTROUTING jumps",
-				"bridge", bridgeName, "subnet", s, "error", err)
+		for _, s := range stale {
+			ipn := netipx.PrefixIPNet(s)
+			if err := deleteAddr(br, ipn); err != nil {
+				return fmt.Errorf("removing stale bridge address %s: %w", s, err)
+			}
+			log.Info("removed stale bridge address", "bridge", bridgeName, "address", s)
+
+			if err := removeStalePostroutingJumps(log, ipt, chain, comment, s); err != nil {
+				log.Warn("failed to clean POSTROUTING jumps",
+					"bridge", bridgeName, "subnet", s, "error", err)
+			}
 		}
 	}
 
 	if err := reconcileMasqChain(ipt, chain, comment, desired); err != nil {
-		return fmt.Errorf("reconciling chain after removing stale addresses: %w", err)
+		return fmt.Errorf("reconciling chain on %s: %w", bridgeName, err)
 	}
 
 	return nil
@@ -554,6 +554,12 @@ func removeStalePostroutingJumps(log *slog.Logger, ipt *iptables.IPTables, chain
 	return nil
 }
 
+// MasqueradeEndpoint adds a POSTROUTING jump for each address in `ec` to
+// the per-bridge MIREN-* chain, so packets with that source pod IP get
+// masqueraded on egress to non-pod-subnet destinations. The bridge-scope
+// chain content (per-subnet ACCEPTs followed by the MASQUERADE catch-all)
+// is owned by ReconcileBridgeAddresses, which runs at controller init
+// before any sandbox is created.
 func MasqueradeEndpoint(ec *EndpointConfig) error {
 	if len(ec.Addresses) == 0 {
 		return nil
@@ -565,10 +571,6 @@ func MasqueradeEndpoint(ec *EndpointConfig) error {
 	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 	if err != nil {
 		return fmt.Errorf("locating iptables: %w", err)
-	}
-
-	if err := reconcileMasqChain(ipt, chain, comment, ec.Addresses); err != nil {
-		return err
 	}
 
 	for _, ac := range ec.Addresses {

--- a/network/bridge.go
+++ b/network/bridge.go
@@ -9,6 +9,9 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"regexp"
+	"slices"
+	"strings"
 	"syscall"
 	"time"
 
@@ -452,15 +455,211 @@ func CheckBridgeStatus(name string) error {
 	return nil
 }
 
+// ReconcileBridgeAddresses removes bridge addresses, NAT chain rules, and
+// POSTROUTING jumps that belong to subnets no longer in `desired`. Drift
+// happens when a runner's flannel lease rotates (typically after the runner
+// is offline long enough for its etcd lease to expire) and a fresh subnet
+// is allocated. Without this reconcile the host bridge accumulates stale
+// addresses across lease eras, and the per-bridge MIREN-* chain accumulates
+// rules that interfere with traffic on the new subnet (MIR-1108).
+func ReconcileBridgeAddresses(log *slog.Logger, br netlink.Link, desired []netip.Prefix) error {
+	bridgeName := br.Attrs().Name
+	chain := formatChain(bridgeName)
+	comment := fmt.Sprintf("id: %q", bridgeName)
+
+	desiredSet := make(map[string]bool, len(desired))
+	for _, p := range desired {
+		desiredSet[p.String()] = true
+	}
+
+	addrs, err := netlink.AddrList(br, netlink.FAMILY_V4)
+	if err != nil {
+		return fmt.Errorf("listing addresses on %s: %w", bridgeName, err)
+	}
+
+	var stale []netip.Prefix
+	for _, addr := range addrs {
+		prefix, ok := netipx.FromStdIPNet(addr.IPNet)
+		if !ok {
+			continue
+		}
+		if !desiredSet[prefix.String()] {
+			stale = append(stale, prefix)
+		}
+	}
+
+	if len(stale) == 0 {
+		return nil
+	}
+
+	log.Warn("removing stale bridge state",
+		"bridge", bridgeName, "stale", stale, "desired", desired)
+
+	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+	if err != nil {
+		return fmt.Errorf("locating iptables: %w", err)
+	}
+
+	for _, s := range stale {
+		ipn := netipx.PrefixIPNet(s)
+		if err := deleteAddr(br, ipn); err != nil {
+			return fmt.Errorf("removing stale bridge address %s: %w", s, err)
+		}
+		log.Info("removed stale bridge address", "bridge", bridgeName, "address", s)
+
+		if err := removeStalePostroutingJumps(log, ipt, chain, comment, s); err != nil {
+			log.Warn("failed to clean POSTROUTING jumps",
+				"bridge", bridgeName, "subnet", s, "error", err)
+		}
+	}
+
+	if err := reconcileMasqChain(ipt, chain, comment, desired); err != nil {
+		return fmt.Errorf("reconciling chain after removing stale addresses: %w", err)
+	}
+
+	return nil
+}
+
+// postroutingSourceIP extracts the source IP from a `-A POSTROUTING -s X ...` rule line.
+var postroutingSourceIP = regexp.MustCompile(`-s\s+(\d+\.\d+\.\d+\.\d+)`)
+
+func removeStalePostroutingJumps(log *slog.Logger, ipt *iptables.IPTables, chain, comment string, stale netip.Prefix) error {
+	rules, err := ipt.List("nat", "POSTROUTING")
+	if err != nil {
+		return fmt.Errorf("listing POSTROUTING: %w", err)
+	}
+
+	target := "-j " + chain
+	for _, rule := range rules {
+		if !strings.Contains(rule, target) {
+			continue
+		}
+		m := postroutingSourceIP.FindStringSubmatch(rule)
+		if m == nil {
+			continue
+		}
+		src, err := netip.ParseAddr(m[1])
+		if err != nil || !stale.Contains(src) {
+			continue
+		}
+		if err := ipt.DeleteIfExists("nat", "POSTROUTING",
+			"-s", src.String(),
+			"-m", "comment", "--comment", comment,
+			"-j", chain,
+		); err != nil {
+			log.Warn("failed to delete stale POSTROUTING jump",
+				"src", src, "chain", chain, "error", err)
+		}
+	}
+	return nil
+}
+
 func MasqueradeEndpoint(ec *EndpointConfig) error {
+	if len(ec.Addresses) == 0 {
+		return nil
+	}
+
 	chain := formatChain(ec.Bridge.Name)
 	comment := fmt.Sprintf("id: %q", ec.Bridge.Name)
 
+	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+	if err != nil {
+		return fmt.Errorf("locating iptables: %w", err)
+	}
+
+	if err := reconcileMasqChain(ipt, chain, comment, ec.Addresses); err != nil {
+		return err
+	}
+
 	for _, ac := range ec.Addresses {
-		if err := ip.SetupIPMasq(netipx.PrefixIPNet(ac), chain, comment); err != nil {
-			return err
+		ipn := netipx.PrefixIPNet(ac)
+		if err := ipt.AppendUnique("nat", "POSTROUTING",
+			"-s", ipn.IP.String(),
+			"-m", "comment", "--comment", comment,
+			"-j", chain,
+		); err != nil {
+			return fmt.Errorf("adding POSTROUTING jump for %s: %w", ipn.IP, err)
 		}
 	}
 
 	return nil
+}
+
+// reconcileMasqChain converges the per-bridge NAT chain to the desired shape:
+// one ACCEPT per pod subnet followed by a single MASQUERADE catch-all. Order
+// matters because MASQUERADE is terminal, so any ACCEPT after it would be
+// unreachable. The previous implementation appended ACCEPT then MASQUERADE
+// per call, which left later subnets' ACCEPTs stranded after the
+// already-present MASQUERADE (MIR-1108).
+//
+// To stay idempotent under concurrent calls and on already-correct chains,
+// the chain is only flushed and rebuilt when its current content does not
+// already match the desired shape.
+func reconcileMasqChain(ipt *iptables.IPTables, chain, comment string, addresses []netip.Prefix) error {
+	chains, err := ipt.ListChains("nat")
+	if err != nil {
+		return fmt.Errorf("listing nat chains: %w", err)
+	}
+	if !slices.Contains(chains, chain) {
+		if err := ipt.NewChain("nat", chain); err != nil {
+			return fmt.Errorf("creating chain %s: %w", chain, err)
+		}
+	}
+
+	desired := desiredMasqRules(comment, addresses)
+
+	matches, err := chainMatchesDesired(ipt, chain, desired)
+	if err != nil {
+		return fmt.Errorf("inspecting chain %s: %w", chain, err)
+	}
+	if matches {
+		return nil
+	}
+
+	if err := ipt.ClearChain("nat", chain); err != nil {
+		return fmt.Errorf("clearing chain %s: %w", chain, err)
+	}
+	for _, rule := range desired {
+		if err := ipt.Append("nat", chain, rule...); err != nil {
+			return fmt.Errorf("appending rule to %s: %w", chain, err)
+		}
+	}
+	return nil
+}
+
+// desiredMasqRules builds the chain content in the order it should appear:
+// per-subnet ACCEPTs first, then the catch-all MASQUERADE last.
+func desiredMasqRules(comment string, addresses []netip.Prefix) [][]string {
+	rules := make([][]string, 0, len(addresses)+1)
+	for _, ac := range addresses {
+		ipn := netipx.PrefixIPNet(ac).String()
+		rules = append(rules, []string{"-d", ipn, "-m", "comment", "--comment", comment, "-j", "ACCEPT"})
+	}
+	rules = append(rules, []string{"!", "-d", "224.0.0.0/4", "-m", "comment", "--comment", comment, "-j", "MASQUERADE"})
+	return rules
+}
+
+// chainMatchesDesired returns true when the chain's existing rules already
+// represent the desired shape: every desired rule exists, no extra rules
+// exist, and the last rule is MASQUERADE (so all ACCEPTs precede it).
+func chainMatchesDesired(ipt *iptables.IPTables, chain string, desired [][]string) (bool, error) {
+	for _, rule := range desired {
+		ok, err := ipt.Exists("nat", chain, rule...)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+
+	rules, err := ipt.List("nat", chain)
+	if err != nil {
+		return false, err
+	}
+	// rules[0] is the "-N <chain>" header; remaining entries are "-A ..." rules.
+	if len(rules)-1 != len(desired) {
+		return false, nil
+	}
+	return strings.Contains(rules[len(rules)-1], "-j MASQUERADE"), nil
 }

--- a/network/noop_darwin.go
+++ b/network/noop_darwin.go
@@ -5,6 +5,7 @@ package network
 import (
 	"fmt"
 	"log/slog"
+	"net/netip"
 
 	"github.com/vishvananda/netlink"
 )
@@ -27,4 +28,8 @@ func ConfigureGW(br netlink.Link, ec *EndpointConfig) error {
 
 func MasqueradeEndpoint(ec *EndpointConfig) error {
 	return fmt.Errorf("network masquerade not supported on this platform")
+}
+
+func ReconcileBridgeAddresses(log *slog.Logger, br netlink.Link, desired []netip.Prefix) error {
+	return fmt.Errorf("bridge reconciliation not supported on this platform")
 }


### PR DESCRIPTION
The toys runner had a sandbox killer that turned out to be subtler than the original issue framed it. The Linear comment thread on MIR-1108 has the full forensic walkthrough; this PR ships the fixes.

A runner's flannel lease in etcd has a ~23h TTL. If the runner is offline long enough for the lease to expire (toys-runner-1 had a 15-day gap after an OOM-and-stop), flannel allocates a fresh subnet on next start. The runner's bridge then accumulates the new subnet's gateway address alongside the old one, and the per-bridge MIREN-* chain accumulates rules across both lease eras. The new subnet's ACCEPT rule lands after the catch-all MASQUERADE, where it's unreachable. Reply packets from new-subnet sandboxes get masqueraded back to the bridge IP, the host's TCP state on the dial doesn't match, the dial times out, and `checkNetworkHealth` (running on the runner itself) kills the sandbox within seconds of it reaching RUNNING. The original issue framed this as a coordinator-side probe, but reconciliation is node-scoped and the runner is its own killer.

The fix has three layers. The first reconciles bridge state at controller init: if the bridge has addresses outside the desired set, the stale addresses get stripped along with their POSTROUTING jumps, and the per-bridge NAT chain is rebuilt from scratch. The second refactors `MasqueradeEndpoint` to converge to the right shape via flush-and-rebuild-when-needed, so per-call drift from any source gets cleaned up rather than accumulating. The third switches `checkNetworkHealth` from TCP-dial to `/proc/<pause-pid>/net/tcp` inspection, mirroring what `PortMonitor` did in `63661df3` and sidestepping host-to-pod network fragility entirely.

Closes MIR-1108