### PR TITLE
Stop leaking containerd FIFO dirs on sandbox teardown

### DIFF
--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -266,7 +266,7 @@ func undoBootTask(ctx context.Context, in bootTaskIn, _ bootTaskOut) error {
 		return nil
 	}
 
-	task, err := container.Task(ctx, nil)
+	task, err := container.Task(ctx, cleanupAttach())
 	if err != nil {
 		log.Debug("saga undo: task not found", "id", in.ContainerID)
 		return nil

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -52,6 +52,14 @@ const (
 
 var sandboxImage = imagerefs.Pause
 
+// cleanupAttach is the cio.Attach to pass to container.Task when we're
+// retrieving a task purely to delete it. The non-nil attach makes containerd
+// populate t.io with a FIFO closer that removes /run/containerd/fifo/<n>;
+// passing nil leaves t.io nil and task.Delete silently leaks the directory.
+func cleanupAttach() cio.Attach {
+	return cio.NewAttach()
+}
+
 type containerPorts struct {
 	Ports []observability.BoundPort
 }
@@ -1643,8 +1651,7 @@ func (c *SandboxController) CleanupContainer(ctx context.Context, cont container
 		c.portMonitor.StopMonitoring(containerID)
 	}
 
-	// Try to kill and delete any task first
-	task, err := cont.Task(ctx, nil)
+	task, err := cont.Task(ctx, cleanupAttach())
 	if err == nil && task != nil {
 		task.Kill(ctx, unix.SIGKILL)
 		_, err = task.Delete(ctx, containerd.WithProcessKill)
@@ -2211,7 +2218,7 @@ func (c *SandboxController) DestroySubContainers(ctx context.Context, id entity.
 
 	for i := range containers {
 		info := &containers[i]
-		task, err := info.container.Task(ctx, nil)
+		task, err := info.container.Task(ctx, cleanupAttach())
 		if err != nil {
 			c.Log.Debug("no task found for container", "id", info.id)
 			continue
@@ -2431,7 +2438,7 @@ func (c *SandboxController) StopSandbox(ctx context.Context, id entity.Id) error
 	// Delete pause container
 	c.Log.Debug("deleting pause container", "id", id)
 	if container != nil {
-		task, err := container.Task(ctx, nil)
+		task, err := container.Task(ctx, cleanupAttach())
 		if err != nil {
 			if !errdefs.IsNotFound(err) {
 				c.Log.Error("failed to get pause task", "id", id, "err", err)

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "de8f9ab0c48de3440a3b0d05c7875cbaf12600547287ba3ad857efc3e63a1725",
+		"sandbox.go":  "018bfd335f21e5785601cee6c8d93de0cc00f1e2317bb8af5d0a55dc01c0fccb",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}

--- a/controllers/sandbox/watchdog.go
+++ b/controllers/sandbox/watchdog.go
@@ -284,7 +284,7 @@ func (w *ContainerWatchdog) removeContainer(ctx context.Context, container conta
 	containerID := container.ID()
 
 	// Try to delete any task first
-	task, err := container.Task(ctx, nil)
+	task, err := container.Task(ctx, cleanupAttach())
 	if err == nil && task != nil {
 		// Try to delete the task (it should already be dead from SIGQUIT/SIGKILL)
 		_, delErr := task.Delete(ctx, containerd.WithProcessKill)


### PR DESCRIPTION
On May 8th, `club` ate itself. About 22 apps started flapping, runc kept failing with ENOSPC creating `/run/containerd/runc/miren/<id>_pause`, but the disk was 17% full. The actual constraint was inodes: `/run` had 819,199 of 819,200 used, and `/run/containerd/fifo` had 272,484 directories against 40 live shims. The leak had been accumulating for weeks.

Root cause turned out to be a thin gap in our task teardown. Every place we tear a task down (`destroySubContainers`, `CleanupContainer`, the saga undo, the watchdog, the pause-container delete) fetches the task back from containerd via `container.Task(ctx, nil)`. With a nil attach, containerd hands back a task struct with `t.io == nil`. `task.Delete` then kills the shim, RPCs `TaskService.Delete`, and only invokes the FIFO-removing closer if `t.io != nil`. That closer is what does the `os.RemoveAll` on the random-integer `/run/containerd/fifo/<n>` dir, so without it the directory and its two named pipes just sit there forever.

Fix is to pass `cio.NewAttach()` instead of `nil`. With a non-nil attach, containerd's `loadFifos` builds a FIFOSet from the server-stored FIFO paths, hangs a directory-removing closer on it, wraps it as IO, and stores it on `t.io`. `Delete` then cleans up correctly. I wrapped the call in a small `cleanupAttach()` helper so the doc-comment lives in one place and the five teardown call sites read as `Task(ctx, cleanupAttach())`.

Built a small reproducer that ran 50 create/destroy cycles against the embedded containerd: the old nil-attach pattern leaked exactly 50 dirs (1 per cycle), swapping to `cio.NewAttach()` leaked zero. Same 1:1 ratio matches what `club` was doing in production (~4 dirs/min on ~2 sandbox replacements/min). The reproducer was disposable so it didn't get committed; the unit tests cover the call sites.

This is the root-cause fix for the outage. The other follow-up threads from MIR-1109 (tmpfs `nr_inodes` bump plus alerting, pool crash-cooldown ratcheting, default-route entity log spam) are separate concerns I'll file as their own issues.

Closes MIR-1109