### PR TITLE
Honor --channel on `miren upgrade --check`

### DIFF
--- a/cli/commands/runner_upgrade.go
+++ b/cli/commands/runner_upgrade.go
@@ -28,18 +28,9 @@ func RunnerUpgrade(ctx *Context, opts struct {
 		return fmt.Errorf("miren runner is not running. Use 'miren upgrade' to upgrade the CLI binary instead")
 	}
 
-	version := opts.Version
-	channel := opts.Channel
-
-	if version != "" && channel != "" {
-		return fmt.Errorf("--version and --channel are mutually exclusive")
-	}
-
-	if version == "" && channel == "" {
-		channel = "latest"
-	}
-	if channel != "" {
-		version = channel
+	version, err := resolveVersionChannel(opts.Version, opts.Channel)
+	if err != nil {
+		return err
 	}
 
 	mgrOpts := release.RunnerManagerOptions()

--- a/cli/commands/server_upgrade.go
+++ b/cli/commands/server_upgrade.go
@@ -29,19 +29,9 @@ func ServerUpgrade(ctx *Context, opts struct {
 		return fmt.Errorf("miren server is not running. Use 'miren upgrade' to upgrade the CLI binary instead")
 	}
 
-	// Determine version/channel
-	version := opts.Version
-	channel := opts.Channel
-
-	if version != "" && channel != "" {
-		return fmt.Errorf("--version and --channel are mutually exclusive")
-	}
-
-	if version == "" && channel == "" {
-		channel = "latest"
-	}
-	if channel != "" {
-		version = channel
+	version, err := resolveVersionChannel(opts.Version, opts.Channel)
+	if err != nil {
+		return err
 	}
 
 	// Create manager with server configuration

--- a/cli/commands/upgrade.go
+++ b/cli/commands/upgrade.go
@@ -32,9 +32,14 @@ func Upgrade(ctx *Context, opts struct {
 	mgrOpts.InstallPath = exe
 	mgrOpts.SkipHealthCheck = true // CLI doesn't need health check
 
+	version, err := resolveVersionChannel(opts.Version, opts.Channel)
+	if err != nil {
+		return err
+	}
+
 	// Check mode - just report if update is available
 	if opts.Check {
-		current, latest, err := CheckVersionStatus(ctx, opts.Version, &mgrOpts)
+		current, latest, err := CheckVersionStatus(ctx, version, &mgrOpts)
 		if err != nil {
 			return err
 		}
@@ -129,20 +134,6 @@ func Upgrade(ctx *Context, opts struct {
 	// Update manager with final install path
 	mgrOpts.InstallPath = installPath
 	mgr := release.NewManager(mgrOpts)
-
-	// Determine version/channel
-	version := opts.Version
-	channel := opts.Channel
-
-	// If neither specified, default to latest channel
-	if version == "" && channel == "" {
-		channel = "latest"
-	}
-
-	// If channel specified, use it as version
-	if channel != "" {
-		version = channel
-	}
 
 	needsUpgrade, err := CheckIfUpgradeNeeded(ctx, version, opts.Force, &mgrOpts)
 	if err != nil {

--- a/cli/commands/upgrade_helpers.go
+++ b/cli/commands/upgrade_helpers.go
@@ -7,6 +7,22 @@ import (
 	"miren.dev/runtime/pkg/release"
 )
 
+// resolveVersionChannel collapses the --version and --channel flags into a
+// single target version string. The two flags are mutually exclusive; when
+// neither is set the target defaults to the "latest" channel.
+func resolveVersionChannel(version, channel string) (string, error) {
+	if version != "" && channel != "" {
+		return "", fmt.Errorf("--version and --channel are mutually exclusive")
+	}
+	if version == "" && channel == "" {
+		return "latest", nil
+	}
+	if channel != "" {
+		return channel, nil
+	}
+	return version, nil
+}
+
 // CheckVersionStatus checks if an update is available for the given target version
 // Returns the current and latest version info
 // If mgrOpts is nil, uses default manager options (for server path)

--- a/cli/commands/upgrade_helpers_test.go
+++ b/cli/commands/upgrade_helpers_test.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveVersionChannel(t *testing.T) {
+	testCases := []struct {
+		name    string
+		version string
+		channel string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "neither set defaults to latest",
+			want: "latest",
+		},
+		{
+			name:    "channel main resolves to main",
+			channel: "main",
+			want:    "main",
+		},
+		{
+			name:    "channel latest resolves to latest",
+			channel: "latest",
+			want:    "latest",
+		},
+		{
+			name:    "version only is passed through",
+			version: "v0.2.0",
+			want:    "v0.2.0",
+		},
+		{
+			name:    "both version and channel is an error",
+			version: "v0.2.0",
+			channel: "main",
+			wantErr: true,
+		},
+		{
+			name:    "version with channel=latest is still an error",
+			version: "v0.2.0",
+			channel: "latest",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveVersionChannel(tc.version, tc.channel)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
`miren upgrade --check --channel main` was silently reporting against the `latest` channel. The version/channel translation in `upgrade.go` lived below the `--check` early return, so the check path only ever saw the raw `--version` flag, which `CheckVersionStatus` defaults to `"latest"` when empty. The same code path was also missing the `--version`/`--channel` mutex check that the server and runner upgrade commands enforce.

The fix is a one-line reorder: resolve version and channel before the `if opts.Check` branch. But while looking at it, all three upgrade commands (`miren upgrade`, `miren server upgrade`, `miren runner upgrade`) had near-identical copies of the same translation block, and the `upgrade.go` copy was the one that had drifted out of sync. That's basically the source of the bug.

Pulled the resolution into a `resolveVersionChannel` helper in `upgrade_helpers.go` and routed all three commands through it. The helper is pure, so it gets clean unit test coverage, including a regression test for the `--check --channel main` case. The three commands can't drift apart again.

Closes MIR-1114