### PR TITLE
sandbox exec: accept sandbox ID as positional argument

### DIFF
--- a/blackbox/sandbox_test.go
+++ b/blackbox/sandbox_test.go
@@ -30,10 +30,15 @@ func TestSandboxExec(t *testing.T) {
 		Testdata: "go-server",
 	})
 
-	// Get sandbox ID from JSON listing
 	sandboxID := harness.GetSandboxID(t, m, name)
 
-	// Exec a simple command in the sandbox
-	r := m.MustRun("sandbox", "exec", "-i", sandboxID, "--", "echo", "hello-from-sandbox")
-	r.RequireContains(t, "hello-from-sandbox")
+	t.Run("positional", func(t *testing.T) {
+		r := m.MustRun("sandbox", "exec", sandboxID, "--", "echo", "hello-from-sandbox")
+		r.RequireContains(t, "hello-from-sandbox")
+	})
+
+	t.Run("id-flag", func(t *testing.T) {
+		r := m.MustRun("sandbox", "exec", "-i", sandboxID, "--", "echo", "hello-from-sandbox")
+		r.RequireContains(t, "hello-from-sandbox")
+	})
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -329,11 +329,11 @@ miren deploy --analyze
 		WithDescription(sandboxExecDescription),
 		WithExample(mflags.Example{
 			Name: "Open a shell in a running sandbox",
-			Body: "miren sandbox exec --id sb_abc123",
+			Body: "miren sandbox exec sb_abc123",
 		}),
 		WithExample(mflags.Example{
 			Name: "Run a command in a sandbox",
-			Body: "miren sandbox exec --id sb_abc123 -- ls -la /app",
+			Body: "miren sandbox exec sb_abc123 -- ls -la /app",
 		}),
 	))
 

--- a/cli/commands/sandbox_exec.go
+++ b/cli/commands/sandbox_exec.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/signal"
@@ -14,10 +15,19 @@ import (
 
 func SandboxExec(ctx *Context, opts struct {
 	ConfigCentric
-	Id string `short:"i" long:"id" description:"Sandbox ID" default:"miren-sandbox"`
+	Id string `short:"i" long:"id" description:"Sandbox ID"`
 
 	Args []string `rest:"true"`
 }) error {
+	id := opts.Id
+	args := opts.Args
+	if id == "" {
+		if len(args) == 0 {
+			return fmt.Errorf("sandbox ID is required (pass as first positional arg or via --id)")
+		}
+		id, args = args[0], args[1:]
+	}
+
 	cl, err := ctx.RPCClient("dev.miren.runtime/exec")
 	if err != nil {
 		return err
@@ -35,7 +45,7 @@ func SandboxExec(ctx *Context, opts struct {
 		out io.Writer
 	)
 
-	opt.SetCommand(opts.Args)
+	opt.SetCommand(args)
 
 	// Set up interactive console if available, otherwise use standard streams
 	if con, err := console.ConsoleFromFile(os.Stdin); err == nil {
@@ -86,8 +96,8 @@ func SandboxExec(ctx *Context, opts struct {
 
 	res, err := sec.Exec(
 		ctx,
-		"id", opts.Id,
-		strings.Join(opts.Args, " "),
+		"id", id,
+		strings.Join(args, " "),
 		opt,
 		input, output,
 		winUS,

--- a/docs/docs/command/sandbox-exec.md
+++ b/docs/docs/command/sandbox-exec.md
@@ -39,7 +39,7 @@ miren sandbox exec [args...] [flags]
 
 - `--cluster, -C` — Cluster name
 - `--config` — Path to the config file
-- `--id, -i` — Sandbox ID (default: `miren-sandbox`)
+- `--id, -i` — Sandbox ID
 
 ## Global Options
 
@@ -52,13 +52,13 @@ miren sandbox exec [args...] [flags]
 **Open a shell in a running sandbox:**
 
 ```bash
-miren sandbox exec --id sb_abc123
+miren sandbox exec sb_abc123
 ```
 
 **Run a command in a sandbox:**
 
 ```bash
-miren sandbox exec --id sb_abc123 -- ls -la /app
+miren sandbox exec sb_abc123 -- ls -la /app
 ```
 
 ## See also


### PR DESCRIPTION
When I copy a sandbox ID out of `sandbox list` and run `miren sandbox exec yKm -- hostname`, I expect that to work. Instead I got `ERROR: failed to get entity sandbox/miren-sandbox: not found`, which sent me on a brief detour wondering where "miren-sandbox" was coming from. It was coming from the sentinel default on the `--id` flag, and my positional was happily sliding into the rest-args bucket.

Dropped the default, and now if `--id` isn't set we peel the first positional off as the sandbox ID, matching what docker and kubectl do. If neither is given, you get a clear "sandbox ID is required" error instead of the bogus lookup. Tests cover both call shapes.

Refs MIR-1131