### PR TITLE
Reconcile service controller parent chain rules on each GC pass

### DIFF
--- a/controllers/service/gc.go
+++ b/controllers/service/gc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -62,9 +63,37 @@ var managedMaps = []string{mapServiceIP4s, mapServiceIP6s, mapServiceNodePort}
 // targetState captures what the kernel should look like, derived from the
 // current Service and Endpoints entities. Chain names plus expected map
 // element keys (canonicalized).
+//
+// serviceSpecs, nodePortSpecs, and endpointSpecs carry enough info for the
+// Periodic reconcile pass to rebuild every live chain's body unconditionally.
+// Knowing the chain name alone (in `chains`) is sufficient for orphan detection
+// but not enough to recompute the chain's rules.
 type targetState struct {
 	chains   set.Set[string]
 	elements map[string]set.Set[string] // mapName -> canonicalKey set
+
+	serviceSpecs  []serviceChainSpec
+	nodePortSpecs []nodePortChainSpec
+	endpointSpecs map[string]endpointChainSpec // chain name -> spec, deduplicated
+}
+
+type serviceChainSpec struct {
+	ip        netip.Addr
+	port      uint16
+	proto     string
+	endpoints []string // endpoint chain names, sorted
+}
+
+type nodePortChainSpec struct {
+	nport     int
+	proto     string
+	endpoints []string // endpoint chain names, sorted
+}
+
+type endpointChainSpec struct {
+	ip    netip.Addr
+	port  uint16
+	proto string
 }
 
 // kernelState captures what the kernel actually has, observed via knftables.
@@ -102,8 +131,9 @@ func (s *ServiceController) Periodic(ctx context.Context) error {
 
 func (s *ServiceController) computeTargetState(ctx context.Context) (*targetState, error) {
 	target := &targetState{
-		chains:   set.New[string](),
-		elements: make(map[string]set.Set[string]),
+		chains:        set.New[string](),
+		elements:      make(map[string]set.Set[string]),
+		endpointSpecs: make(map[string]endpointChainSpec),
 	}
 	for _, m := range managedMaps {
 		target.elements[m] = set.New[string]()
@@ -133,6 +163,31 @@ func (s *ServiceController) computeTargetState(ctx context.Context) (*targetStat
 
 		for _, tp := range srv.Port {
 			proto := nftProto(tp.Protocol)
+			targetPort := tp.TargetPort
+			if targetPort == 0 {
+				targetPort = tp.Port
+			}
+
+			// Resolve endpoint chain names once per (port, proto). Service-IP
+			// and NodePort dispatchers share the same backend set, so each
+			// (ip, port, proto) tuple maps to a single endpoint chain by hash.
+			var epChains []string
+			for _, ep := range endpointsByService[srv.ID] {
+				for _, e := range ep.Endpoint {
+					ip, err := netip.ParseAddr(e.Ip)
+					if err != nil {
+						return nil, fmt.Errorf("parse endpoint IP %q: %w", e.Ip, err)
+					}
+					epChain := s.endpointChain(ip, uint16(targetPort), proto)
+					target.chains.Add(epChain)
+					epChains = append(epChains, epChain)
+					target.endpointSpecs[epChain] = endpointChainSpec{
+						ip: ip, port: uint16(targetPort), proto: proto,
+					}
+				}
+			}
+			slices.Sort(epChains)
+			epChains = slices.Compact(epChains)
 
 			for _, sip := range srv.Ip {
 				ip, err := netip.ParseAddr(sip)
@@ -143,6 +198,10 @@ func (s *ServiceController) computeTargetState(ctx context.Context) (*targetStat
 				target.elements[mapForServiceIP(ip)].Add(canonicalKey(
 					[]string{ip.String(), proto, strconv.FormatInt(tp.Port, 10)},
 				))
+				target.serviceSpecs = append(target.serviceSpecs, serviceChainSpec{
+					ip: ip, port: uint16(tp.Port), proto: proto,
+					endpoints: epChains,
+				})
 			}
 
 			if tp.NodePort != 0 {
@@ -150,20 +209,10 @@ func (s *ServiceController) computeTargetState(ctx context.Context) (*targetStat
 				target.elements[mapServiceNodePort].Add(canonicalKey(
 					[]string{proto, strconv.FormatInt(tp.NodePort, 10)},
 				))
-			}
-
-			targetPort := tp.TargetPort
-			if targetPort == 0 {
-				targetPort = tp.Port
-			}
-			for _, ep := range endpointsByService[srv.ID] {
-				for _, e := range ep.Endpoint {
-					ip, err := netip.ParseAddr(e.Ip)
-					if err != nil {
-						return nil, fmt.Errorf("parse endpoint IP %q: %w", e.Ip, err)
-					}
-					target.chains.Add(s.endpointChain(ip, uint16(targetPort), proto))
-				}
+				target.nodePortSpecs = append(target.nodePortSpecs, nodePortChainSpec{
+					nport: int(tp.NodePort), proto: proto,
+					endpoints: epChains,
+				})
 			}
 		}
 	}
@@ -207,6 +256,10 @@ func (s *ServiceController) snapshotKernelState(ctx context.Context) (*kernelSta
 func (s *ServiceController) applyGC(ctx context.Context, target *targetState, actual *kernelState) error {
 	tx := s.nft.NewTransaction()
 
+	// Drop stale dispatcher map elements first so that the reconcile-add path
+	// below doesn't trip "File exists" when a live key needs a fresh value
+	// (e.g. across a chain-hash-function bump: same proto+port, but the goto
+	// target chain name shifted).
 	staleElements := 0
 	for mapName, expected := range target.elements {
 		for canonKey, el := range actual.elements[mapName] {
@@ -226,17 +279,30 @@ func (s *ServiceController) applyGC(ctx context.Context, target *targetState, ac
 		}
 	}
 
-	// Orphan chains in two phases. Service and nodeport chains contain
-	// `goto endpoint_*` rules; deleting an endpoint chain while one of
-	// those rules still references it triggers EBUSY even inside an
-	// atomic batch (commands process sequentially). So drop parents
-	// first, leaves last.
-	var orphanParents, orphanLeaves []string
+	// Reconcile live chain bodies. Periodic runs even when no entity changed,
+	// so this is the self-heal path: if a live parent chain ended up with a
+	// stale vmap (UpdateEndpoints event missed, setEndpoints called with an
+	// empty list pre-fix, pre-#795 stacked rules, etc.), flush+rebuild here
+	// corrects it, and the orphan endpoint chains it was pinning become
+	// deletable in the same tx.
+	s.reconcileLiveChains(tx, target)
+
+	// Orphan chains in three phases. nft processes batch deletes sequentially
+	// even inside an atomic transaction, so we have to delete in reverse-
+	// dependency order to avoid EBUSY on chains that still have referrers:
+	//   nodeport_* may contain `goto service_*` (pre-#795 shape) → delete first
+	//   service_*  contains `goto endpoint_*` via vmap                → next
+	//   endpoint_* are leaves                                          → last
+	var orphanNodePorts, orphanServices, orphanLeaves []string
 	for chain, kind := range actual.chains {
 		switch kind {
-		case chainKindService, chainKindNodePort:
+		case chainKindNodePort:
 			if !target.chains.Contains(chain) {
-				orphanParents = append(orphanParents, chain)
+				orphanNodePorts = append(orphanNodePorts, chain)
+			}
+		case chainKindService:
+			if !target.chains.Contains(chain) {
+				orphanServices = append(orphanServices, chain)
 			}
 		case chainKindEndpoint:
 			if !target.chains.Contains(chain) {
@@ -245,8 +311,12 @@ func (s *ServiceController) applyGC(ctx context.Context, target *targetState, ac
 		}
 		// chainKindStatic and chainKindUnknown: leave alone.
 	}
+	orphanParentCount := len(orphanNodePorts) + len(orphanServices)
 
-	for _, chain := range orphanParents {
+	for _, chain := range orphanNodePorts {
+		tx.Delete(&knftables.Chain{Name: chain})
+	}
+	for _, chain := range orphanServices {
 		tx.Delete(&knftables.Chain{Name: chain})
 	}
 	for _, chain := range orphanLeaves {
@@ -257,17 +327,44 @@ func (s *ServiceController) applyGC(ctx context.Context, target *targetState, ac
 		return nil
 	}
 
-	s.Log.Info("GC pass pruning stale nft state",
+	s.Log.Info("GC pass reconciling nft state",
+		"reconciled_chains", len(target.serviceSpecs)+len(target.nodePortSpecs)+len(target.endpointSpecs),
 		"stale_elements", staleElements,
-		"orphan_chains", len(orphanParents)+len(orphanLeaves),
+		"orphan_chains", orphanParentCount+len(orphanLeaves),
 	)
 
 	if err := s.nft.Run(ctx, tx); err != nil {
 		return fmt.Errorf("apply GC batch: %w", err)
 	}
 
-	s.invalidateCacheAfterGC(append(orphanParents, orphanLeaves...))
+	deleted := append(append(orphanNodePorts, orphanServices...), orphanLeaves...)
+	s.syncCachesAfterGC(target, deleted)
 	return nil
+}
+
+// reconcileLiveChains emits Add+Flush+rules for every endpoint chain, service
+// chain, and nodeport chain that the entity store currently claims. It does
+// not consult the chainEndpoints cache; that's the whole point — Periodic
+// runs as a backstop, so whatever the kernel currently looks like, this
+// rebuilds it to match the entity store.
+func (s *ServiceController) reconcileLiveChains(tx *knftables.Transaction, target *targetState) {
+	for _, ep := range target.endpointSpecs {
+		s.addEndpointChain(tx, ep.ip, ep.port, ep.proto)
+	}
+	for _, sp := range target.serviceSpecs {
+		s.addServiceChain(tx, sp.ip, int(sp.port), sp.proto)
+		s.writeChainBody(tx, s.serviceChain(sp.ip, sp.port, sp.proto), "services", sp.endpoints)
+	}
+	for _, sp := range target.nodePortSpecs {
+		chain := s.nodeportChain(sp.nport, sp.proto)
+		tx.Add(&knftables.Chain{Name: chain})
+		tx.Add(&knftables.Element{
+			Map:   mapServiceNodePort,
+			Key:   []string{sp.proto, strconv.Itoa(sp.nport)},
+			Value: []string{"goto " + chain},
+		})
+		s.writeChainBody(tx, chain, "nodeports", sp.endpoints)
+	}
 }
 
 // gotoTarget extracts the target chain from a verdict-map element's value.
@@ -282,13 +379,22 @@ func gotoTarget(el *knftables.Element) string {
 	return el.Value[0][len(prefix):]
 }
 
-// invalidateCacheAfterGC keeps the chainEndpoints cache in sync after deletes.
-// If we delete a chain but leave its name in the cache, the next Create()
-// would skip the rebuild thinking nothing changed, leaving the chain absent
-// while the dispatcher's map element points at it.
-func (s *ServiceController) invalidateCacheAfterGC(deletedChains []string) {
+// syncCachesAfterGC keeps the chainEndpoints cache aligned with what we just
+// wrote to the kernel. Reconciled chains get their current endpoint set
+// recorded (so the next event-driven setEndpoints can no-op when truly
+// unchanged); deleted chains are dropped from the cache (so a future Create
+// doesn't skip the rebuild thinking nothing changed).
+func (s *ServiceController) syncCachesAfterGC(target *targetState, deletedChains []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	for _, sp := range target.serviceSpecs {
+		chain := s.serviceChain(sp.ip, sp.port, sp.proto)
+		s.chainEndpoints[chain] = append([]string(nil), sp.endpoints...)
+	}
+	for _, sp := range target.nodePortSpecs {
+		chain := s.nodeportChain(sp.nport, sp.proto)
+		s.chainEndpoints[chain] = append([]string(nil), sp.endpoints...)
+	}
 	for _, c := range deletedChains {
 		delete(s.chainEndpoints, c)
 	}

--- a/controllers/service/gc_test.go
+++ b/controllers/service/gc_test.go
@@ -29,6 +29,23 @@ func nftChains(t *testing.T, ctx context.Context, sc *ServiceController) set.Set
 	return out
 }
 
+func nftRuleCount(t *testing.T, ctx context.Context, sc *ServiceController, chain string) int {
+	t.Helper()
+	rules, err := sc.nft.ListRules(ctx, chain)
+	require.NoError(t, err)
+	return len(rules)
+}
+
+func putEndpoints(t *testing.T, ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, eps *network_v1alpha.Endpoints) {
+	t.Helper()
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetAttrs(entity.New(
+		entity.Keyword(entity.Ident, eps.ID.String()),
+		eps.Encode).Attrs())
+	_, err := eac.Put(ctx, &rpcE)
+	require.NoError(t, err)
+}
+
 func nftMapElementKeys(t *testing.T, ctx context.Context, sc *ServiceController, mapName string) set.Set[string] {
 	t.Helper()
 	els, err := sc.nft.ListElements(ctx, "map", mapName)
@@ -217,6 +234,175 @@ func TestServicePeriodic(t *testing.T) {
 		r.NoError(sc.Periodic(ctx))
 
 		r.True(nftChains(t, ctx, sc).Contains(epChain), "endpoint chain still in use by svcB should not be pruned")
+	})
+
+	t.Run("rebuilds parent chain body to drop traffic when endpoints drop to empty", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		testDeps, cleanup := testutils.NewTestDeps()
+		defer cleanup()
+
+		sc, err := newServiceController(testDeps)
+		r.NoError(err)
+		r.NoError(sc.Init(ctx))
+
+		const sandboxIP = "10.8.123.7"
+		const svcIP = "10.99.123.1"
+		const port = 6669
+
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID:   svcID,
+			Ip:   []string{svcIP},
+			Port: []network_v1alpha.Port{{Name: "irc", Port: port}},
+		}
+		putService(t, ctx, testDeps.EAC, svc)
+
+		epsID := entity.Id("endpoints-" + svcID.String())
+		eps := &network_v1alpha.Endpoints{
+			ID:       epsID,
+			Service:  svcID,
+			Endpoint: []network_v1alpha.Endpoint{{Ip: sandboxIP, Port: port}},
+		}
+		putEndpoints(t, ctx, testDeps.EAC, eps)
+
+		r.NoError(sc.Create(ctx, svc, &entity.Meta{Entity: entity.New(svc.Encode), Revision: 1}))
+
+		parentChain := sc.serviceChain(netip.MustParseAddr(svcIP), port, "tcp")
+		epChain := sc.endpointChain(netip.MustParseAddr(sandboxIP), port, "tcp")
+
+		r.True(nftChains(t, ctx, sc).Contains(parentChain))
+		r.True(nftChains(t, ctx, sc).Contains(epChain))
+
+		// Drop the Endpoints entity. Pre-fix, setEndpoints({}) would early-return
+		// here on the next event, leaving the parent's vmap pointing at the
+		// now-orphan endpoint chain and the GC pass aborting with EBUSY every
+		// 5 minutes. We never fire that event in the test — we go straight to
+		// Periodic, which exercises the self-heal path.
+		_, err = testDeps.EAC.Delete(ctx, epsID.String())
+		r.NoError(err)
+
+		r.NoError(sc.Periodic(ctx))
+
+		r.True(nftChains(t, ctx, sc).Contains(parentChain), "parent chain should still exist")
+		r.False(nftChains(t, ctx, sc).Contains(epChain), "orphan endpoint chain should be deleted now that the parent no longer pins it")
+
+		// Parent body when empty: counter + drop = 2 rules.
+		r.Equal(2, nftRuleCount(t, ctx, sc, parentChain), "empty-endpoint parent should be counter + drop")
+	})
+
+	t.Run("rebuilds parent chain vmap when endpoint IP rotates", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		testDeps, cleanup := testutils.NewTestDeps()
+		defer cleanup()
+
+		sc, err := newServiceController(testDeps)
+		r.NoError(err)
+		r.NoError(sc.Init(ctx))
+
+		const oldIP = "10.8.54.24"
+		const newIP = "10.8.29.42"
+		const svcIP = "10.99.124.1"
+		const port = 6669
+
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID:   svcID,
+			Ip:   []string{svcIP},
+			Port: []network_v1alpha.Port{{Name: "irc", Port: port}},
+		}
+		putService(t, ctx, testDeps.EAC, svc)
+
+		oldEpsID := entity.Id("endpoints-old-" + svcID.String())
+		putEndpoints(t, ctx, testDeps.EAC, &network_v1alpha.Endpoints{
+			ID:       oldEpsID,
+			Service:  svcID,
+			Endpoint: []network_v1alpha.Endpoint{{Ip: oldIP, Port: port}},
+		})
+
+		r.NoError(sc.Create(ctx, svc, &entity.Meta{Entity: entity.New(svc.Encode), Revision: 1}))
+
+		parentChain := sc.serviceChain(netip.MustParseAddr(svcIP), port, "tcp")
+		oldEpChain := sc.endpointChain(netip.MustParseAddr(oldIP), port, "tcp")
+		newEpChain := sc.endpointChain(netip.MustParseAddr(newIP), port, "tcp")
+
+		r.True(nftChains(t, ctx, sc).Contains(oldEpChain))
+		r.False(nftChains(t, ctx, sc).Contains(newEpChain))
+
+		// Rotate the endpoint IP without firing UpdateEndpoints. Old Endpoints
+		// entity is gone (its sandbox died), new Endpoints entity took its
+		// place. Periodic should rebuild the parent vmap to the new chain and
+		// drop the orphan.
+		_, err = testDeps.EAC.Delete(ctx, oldEpsID.String())
+		r.NoError(err)
+		putEndpoints(t, ctx, testDeps.EAC, &network_v1alpha.Endpoints{
+			ID:       entity.Id("endpoints-new-" + svcID.String()),
+			Service:  svcID,
+			Endpoint: []network_v1alpha.Endpoint{{Ip: newIP, Port: port}},
+		})
+
+		r.NoError(sc.Periodic(ctx))
+
+		r.True(nftChains(t, ctx, sc).Contains(parentChain), "parent chain still exists")
+		r.True(nftChains(t, ctx, sc).Contains(newEpChain), "new endpoint chain created")
+		r.False(nftChains(t, ctx, sc).Contains(oldEpChain), "stale endpoint chain pruned")
+
+		// Non-empty parent: counter + one masq jump per routablePrefix + vmap.
+		// TestDeps installs 3 routable prefixes (subnet, 10.10.0.0/16, fd47:.../64).
+		r.Equal(5, nftRuleCount(t, ctx, sc, parentChain), "parent chain should be rebuilt to current shape")
+	})
+
+	t.Run("rebuilds parent chain when extra rules have accumulated", func(t *testing.T) {
+		r := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		testDeps, cleanup := testutils.NewTestDeps()
+		defer cleanup()
+
+		sc, err := newServiceController(testDeps)
+		r.NoError(err)
+		r.NoError(sc.Init(ctx))
+
+		const sandboxIP = "10.8.125.7"
+		const svcIP = "10.99.125.1"
+		const port = 6669
+
+		svcID := entity.Id(svcName())
+		svc := &network_v1alpha.Service{
+			ID:   svcID,
+			Ip:   []string{svcIP},
+			Port: []network_v1alpha.Port{{Name: "irc", Port: port}},
+		}
+		putService(t, ctx, testDeps.EAC, svc)
+		putEndpoints(t, ctx, testDeps.EAC, &network_v1alpha.Endpoints{
+			ID:       entity.Id("endpoints-" + svcID.String()),
+			Service:  svcID,
+			Endpoint: []network_v1alpha.Endpoint{{Ip: sandboxIP, Port: port}},
+		})
+
+		r.NoError(sc.Create(ctx, svc, &entity.Meta{Entity: entity.New(svc.Encode), Revision: 1}))
+
+		parentChain := sc.serviceChain(netip.MustParseAddr(svcIP), port, "tcp")
+		r.Equal(5, nftRuleCount(t, ctx, sc, parentChain), "fresh parent should have 5 rules")
+
+		// Inject the kind of stacked-duplicate state that the pre-#795
+		// append-without-flush code would leave behind across redeploys.
+		injectTx := sc.nft.NewTransaction()
+		injectTx.Add(&knftables.Rule{Chain: parentChain, Rule: `counter name "services"`})
+		injectTx.Add(&knftables.Rule{Chain: parentChain, Rule: "ip saddr 10.123.0.0/16 jump mark-for-masq"})
+		injectTx.Add(&knftables.Rule{Chain: parentChain, Rule: "ip saddr 10.124.0.0/16 jump mark-for-masq"})
+		r.NoError(sc.nft.Run(ctx, injectTx))
+		r.Greater(nftRuleCount(t, ctx, sc, parentChain), 5, "injection should have added rules")
+
+		r.NoError(sc.Periodic(ctx))
+
+		r.Equal(5, nftRuleCount(t, ctx, sc, parentChain), "Periodic should flush and rebuild to the canonical 5-rule shape")
 	})
 
 	t.Run("does not touch chains outside managed prefixes", func(t *testing.T) {

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -286,29 +286,45 @@ func (s *ServiceController) addServiceChain(tx *knftables.Transaction, ip netip.
 	})
 }
 
-// setEndpoints fills in the body of a service-IP or nodeport chain: counter,
-// per-prefix mark-for-masq jumps, and a numgen-random vmap that load-balances
-// across the endpoint chains. Skips the flush+rebuild when the endpoint set
-// hasn't changed from the cache, which avoids resetting the named counter and
-// reduces unnecessary kernel transactions on the periodic resync.
+// setEndpoints fills in the body of a service-IP or nodeport chain. Skips the
+// flush+rebuild when the endpoint set hasn't changed from the cache to avoid
+// resetting the named counter on each event-driven reconcile. For the
+// unconditional-rebuild path used by Periodic, see writeChainBody.
 func (s *ServiceController) setEndpoints(tx *knftables.Transaction, chain, counterName string, endpoints []string) {
-	if len(endpoints) == 0 {
-		return
-	}
-
-	slices.Sort(endpoints)
+	sorted := append([]string(nil), endpoints...)
+	slices.Sort(sorted)
 
 	s.mu.Lock()
 	cur, ok := s.chainEndpoints[chain]
-	if ok && slices.Equal(cur, endpoints) {
+	if ok && slices.Equal(cur, sorted) {
 		s.mu.Unlock()
 		return
 	}
-	s.chainEndpoints[chain] = endpoints
+	s.chainEndpoints[chain] = sorted
 	s.mu.Unlock()
 
+	s.writeChainBody(tx, chain, counterName, sorted)
+}
+
+// writeChainBody flushes a service-IP or nodeport chain and re-emits its full
+// rule set: counter, per-prefix mark-for-masq jumps, and a numgen-random vmap
+// across endpoint chains. When endpoints is empty the chain is rebuilt with
+// just `counter + drop` so traffic to a service with no backends is dropped
+// rather than DNAT'd to a stale address. Bypasses the chainEndpoints cache;
+// callers that want the cached fast path should go through setEndpoints.
+func (s *ServiceController) writeChainBody(tx *knftables.Transaction, chain, counterName string, endpoints []string) {
 	tx.Flush(&knftables.Chain{Name: chain})
 	tx.Add(&knftables.Rule{Chain: chain, Rule: knftables.Concat("counter name", `"`+counterName+`"`)})
+
+	if len(endpoints) == 0 {
+		// `drop` rather than `reject` because the calling path includes
+		// nat-prerouting, where `reject` isn't permitted. Result is a connect
+		// timeout instead of ECONNREFUSED, but still preferable to forwarding
+		// traffic to a stale endpoint address.
+		tx.Add(&knftables.Rule{Chain: chain, Rule: "drop"})
+		return
+	}
+
 	for _, rp := range s.routablePrefixes {
 		if rp.Addr().Is4() {
 			tx.Add(&knftables.Rule{Chain: chain, Rule: knftables.Concat("ip saddr !=", rp, "counter jump", chainMarkForMasq)})
@@ -331,11 +347,9 @@ func (s *ServiceController) setEndpoints(tx *knftables.Transaction, chain, count
 // this node's NodePort to one of the service's endpoint sandbox IPs, picked
 // at random. Mirrors addServiceChain + setEndpoints but stands alone so that
 // NodePort works on every node regardless of whether the service has an
-// allocated cluster IP yet.
+// allocated cluster IP yet. When endpoints is empty, setEndpoints writes a
+// `drop` body so the NodePort gets the same fail-shut treatment as cluster IPs.
 func (s *ServiceController) addNodePort(tx *knftables.Transaction, nport int, proto string, endpoints []string) {
-	if len(endpoints) == 0 {
-		return
-	}
 	chain := s.nodeportChain(nport, proto)
 	tx.Add(&knftables.Chain{Name: chain})
 	tx.Add(&knftables.Element{


### PR DESCRIPTION
The service controller's periodic GC loop on toys-runner-2 was failing every five minutes with "Device or resource busy" trying to delete an endpoint chain that a live parent chain was still pointing at. Pre-#795 this was silent. After #795 it became an `[ERROR]` log every cycle.

Tracing back: `setEndpoints` early-returned on empty endpoint sets. When an Endpoints entity transitioned from "one endpoint" to "no endpoints" (exactly what happens when a sandbox dies and its backing rotates), the parent's `numgen ... vmap { 0 : goto endpoint_<old> }` stuck around forever. The old endpoint chain was orphan from the entity store's perspective, so GC tried to delete it, but the live parent's stale reference made the kernel refuse, and the reconcile loop kept retrying the same doomed delete.

The fix has two layers. `setEndpoints` now flushes the parent and writes a `counter + drop` body when there are no endpoints, so future zero-endpoint transitions don't leak a stale vmap. `Periodic` also flushes and rebuilds every live service and nodeport chain body before the orphan-delete pass. This is the self-heal path: it catches the existing damage on Toys today plus any future drift class we haven't enumerated, and it means the orphan endpoint chain has no inbound references when the delete fires in the same transaction.

Two ordering subtleties surfaced while deploying to toys-runner-2. First, pre-#795 nodeport chains have bodies containing `goto service_*` rules (the old code never flushed, so rule sets accumulated across redeploys). If both the orphan nodeport and orphan service are queued for deletion in one transaction, the service can't be dropped while the nodeport still references it. So orphan-parent deletes are split into nodeports-first, then services. Second, the chain-hash function bumped at some point (exactly the scenario #795 mentioned), so the entity store wants dispatcher map entries pointing at new-hash chain names while the kernel still has old-hash names. The reconcile path tried to `add element` with the new value, but nft refuses to overwrite an existing key. Reordering so stale dispatcher elements drop before reconcile re-adds takes care of it.

A note on the empty-endpoint choice: `drop` rather than `reject` because the parent chain is reachable from nat-prerouting, where `reject` isn't permitted. Result is a connect timeout instead of `ECONNREFUSED`. Fast-fail would require splitting into a separate filter base chain (kube-proxy-style), which is a bigger refactor than this bug needs.

Verified on toys-runner-2: the stuck `endpoint_DqRxf9quDgDkr2C1RUM5wdhmBNS41LM6gUb5j4i2Bnqp` chain is gone, `service_GAGhE...` rebuilt to `counter + drop`, ~30 orphan endpoint chains in the dead 10.8.54.x subnet cleaned up, no `runner.reconcile.service` errors since the rev2 binary started.

Closes MIR-1129