### PR TITLE
Stop reporting coordinator as unreachable in runner status

### DIFF
--- a/cli/commands/runner_status.go
+++ b/cli/commands/runner_status.go
@@ -2,11 +2,9 @@ package commands
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"miren.dev/runtime/pkg/runnerconfig"
 )
@@ -24,15 +22,7 @@ func RunnerStatus(ctx *Context, opts struct {
 	}
 
 	ctx.Printf("Runner ID:    %s\n", cfg.RunnerID)
-
-	// Check coordinator reachability
-	conn, err := net.DialTimeout("tcp", cfg.CoordinatorAddress, 3*time.Second)
-	if err != nil {
-		ctx.Printf("Coordinator:  %s (unreachable)\n", cfg.CoordinatorAddress)
-	} else {
-		conn.Close()
-		ctx.Printf("Coordinator:  %s (reachable)\n", cfg.CoordinatorAddress)
-	}
+	ctx.Printf("Coordinator:  %s\n", cfg.CoordinatorAddress)
 
 	// Check containerd
 	socketPath := filepath.Join(opts.DataPath, "containerd", "containerd.sock")


### PR DESCRIPTION
`miren runner status` was telling everyone running a distributed cluster that their coordinator was unreachable. The kicker is that it had nothing to do with their cluster, the probe itself was wrong.

We were doing `net.DialTimeout("tcp", ...)` against the coordinator API, but the API listens over QUIC on UDP (`pkg/rpc/state.go:253` is `net.ListenUDP`, wrapped in `quic.Transport`). There's no TCP server on `:8443` at all. So the probe was never going to succeed, on any cluster, ever. The original bug report's `nc -zv` tests had the same problem and sent us briefly down a localhost-binding rabbit hole that turned out to be unrelated.

For now we're just dropping the probe and printing the configured address as info. A real check would need a QUIC handshake, which is more work than this display bug deserves. If anyone wants live runner health, `m runner list` on the coordinator is the source of truth.

Closes MIR-1130