### PR TITLE
rpc/stream: opt-in batching for bulk ServeReader callers

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -601,10 +601,10 @@ func Deploy(ctx *Context, opts struct {
 	}
 	buildCall := func(callCtx context.Context, tarReader io.ReadCloser, cb stream.SendStream[*build_v1alpha.Status]) (buildResults, error) {
 		if useOptimized {
-			tarStream := stream.ServeReader(callCtx, tarReader)
+			tarStream := stream.ServeReader(callCtx, tarReader, stream.WithBulkBatching())
 			return bc.BuildFromPrepared(callCtx, sessionID, tarStream, cb, envVars, ephemeralLabel, ephemeralTTL)
 		}
-		return bc.BuildFromTar(callCtx, name, stream.ServeReader(callCtx, tarReader), cb, envVars, ephemeralLabel, ephemeralTTL)
+		return bc.BuildFromTar(callCtx, name, stream.ServeReader(callCtx, tarReader, stream.WithBulkBatching()), cb, envVars, ephemeralLabel, ephemeralTTL)
 	}
 
 	var (
@@ -1314,7 +1314,7 @@ func analyzeApp(ctx *Context, bc *build_v1alpha.BuilderClient, dir string) error
 
 	defer r.Close()
 
-	result, err := bc.AnalyzeApp(ctx, stream.ServeReader(ctx, r))
+	result, err := bc.AnalyzeApp(ctx, stream.ServeReader(ctx, r, stream.WithBulkBatching()))
 	if err != nil {
 		return fmt.Errorf("analysis failed: %w", err)
 	}

--- a/pkg/rpc/stream/stream.go
+++ b/pkg/rpc/stream/stream.go
@@ -47,6 +47,15 @@ func StreamRecv[T any](fn func(T) error) SendStream[T] {
 
 const streamChunkSize = 10 * 1024 * 1024 // 10MB chunks for efficient streaming over high-latency links
 
+// bulkBatchSize is the minimum number of bytes a bulk-mode ServeReader waits
+// to accumulate before responding to a Recv. The Recv↔Read loop is one
+// round-trip per response, so without batching, each gzip flush (often a
+// few hundred bytes) becomes its own RTT, capping a transcontinental deploy
+// at ~2.5 KB/s. 1 MB lifts the ceiling to roughly batch/RTT (~10 MB/s at
+// 100 ms RTT). Opt in via WithBulkBatching; interactive callers like exec
+// stdin must not use this, or they would stall until the buffer fills.
+const bulkBatchSize = 1024 * 1024
+
 type rscReader struct {
 	ctx    context.Context
 	rsc    *RecvStreamClient[[]byte]
@@ -97,7 +106,22 @@ func ToReader(ctx context.Context, x *RecvStreamClient[[]byte]) io.ReadCloser {
 }
 
 type serveReader struct {
-	r io.Reader
+	r        io.Reader
+	minBatch int // 0 means stream as bytes arrive; >0 means batch until ≥minBatch.
+}
+
+// ServeReaderOption configures a ServeReader. The zero-config default is
+// streaming: each underlying Read becomes one Recv response so callers like
+// interactive stdin pipes don't wait for a buffer to fill.
+type ServeReaderOption func(*serveReader)
+
+// WithBulkBatching tells the ServeReader to wait until at least bulkBatchSize
+// bytes are available before responding to a Recv (or until EOF). Use for
+// bulk transfers where the round-trip per chunk is the bottleneck, like
+// shipping a deploy tarball. Must NOT be used for interactive streams —
+// it would stall every key the user types until the buffer fills.
+func WithBulkBatching() ServeReaderOption {
+	return func(s *serveReader) { s.minBatch = bulkBatchSize }
 }
 
 func (s *serveReader) Recv(ctx context.Context, state *RecvStreamRecv[[]byte]) error {
@@ -111,27 +135,54 @@ func (s *serveReader) Recv(ctx context.Context, state *RecvStreamRecv[[]byte]) e
 
 	buf := make([]byte, readSize)
 
-	n, err := s.r.Read(buf)
-	if err != nil {
-		if errors.Is(err, io.EOF) {
-			if c, ok := s.r.(io.Closer); ok {
-				c.Close()
-			}
-			state.Results().SetValue(nil)
-			return nil
+	var (
+		n   int
+		err error
+	)
+	if s.minBatch > 0 {
+		minBatch := s.minBatch
+		if minBatch > readSize {
+			minBatch = readSize
 		}
-		return err
+		n, err = io.ReadAtLeast(s.r, buf, minBatch)
+	} else {
+		// Streaming mode: ship whatever the underlying reader yields right
+		// now, so per-byte interactive sources (tty stdin, etc.) don't stall
+		// waiting to fill a buffer.
+		n, err = s.r.Read(buf)
 	}
 
-	buf = buf[:n]
+	if err != nil {
+		// EOF (no bytes) or short-read EOF (partial final batch in bulk
+		// mode) are both the natural end of stream. Anything else is real.
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			if n == 0 {
+				if c, ok := s.r.(io.Closer); ok {
+					c.Close()
+				}
+				state.Results().SetValue(nil)
+				return nil
+			}
+			// Ship the partial batch without closing s.r — the next Recv
+			// will hit a clean (0, EOF) and close there. Closing now would
+			// turn the next Read into ErrClosedPipe and surface as an RPC
+			// error instead of an orderly end-of-stream.
+		} else {
+			return err
+		}
+	}
 
-	state.Results().SetValue(buf)
+	state.Results().SetValue(buf[:n])
 
 	return nil
 }
 
-func ServeReader(ctx context.Context, r io.Reader) RecvStream[[]byte] {
-	return &serveReader{r: r}
+func ServeReader(ctx context.Context, r io.Reader, opts ...ServeReaderOption) RecvStream[[]byte] {
+	s := &serveReader{r: r}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 type serveWriter struct {

--- a/pkg/rpc/stream/stream_test.go
+++ b/pkg/rpc/stream/stream_test.go
@@ -2,6 +2,8 @@ package stream
 
 import (
 	"context"
+	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -130,5 +132,138 @@ func TestStream(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatal("timed out waiting for output channel to close")
 		}
+	})
+}
+
+// drippyReader returns one byte per Read. Used as a worst-case source for
+// the streaming-vs-batching tests: in streaming mode each drip becomes its
+// own Recv response, in batching mode many drips collapse into one.
+type drippyReader struct {
+	mu     sync.Mutex
+	data   []byte
+	pos    int
+	closed bool
+}
+
+func (d *drippyReader) Read(p []byte) (int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return 0, io.ErrClosedPipe
+	}
+	if d.pos >= len(d.data) {
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = d.data[d.pos]
+	d.pos++
+	return 1, nil
+}
+
+func (d *drippyReader) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.closed = true
+	return nil
+}
+
+// serveAndCount wires a ServeReader-backed RecvStream into a fresh RPC pair
+// and drives the stream by calling Recv directly so we can count how many
+// responses it took to drain the source. Returns the assembled bytes and
+// the chunk count (a chunk being one non-empty Recv response; the final
+// zero-byte EOF response is not counted).
+func serveAndCount(t *testing.T, src io.Reader, opts ...ServeReaderOption) ([]byte, int) {
+	t.Helper()
+	r := require.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ss, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+	ss.Server().ExposeValue("stream", AdaptRecvStream(ServeReader(ctx, src, opts...)))
+
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+	c, err := cs.Connect(ss.ListenAddr(), "stream")
+	r.NoError(err)
+
+	rsc := NewRecvStreamClient[[]byte](c)
+
+	var out []byte
+	var chunks int
+	for {
+		res, err := rsc.Recv(ctx, streamChunkSize)
+		r.NoError(err)
+		v := res.Value()
+		if len(v) == 0 {
+			break
+		}
+		chunks++
+		out = append(out, v...)
+		if chunks > 10_000_000 {
+			t.Fatal("runaway: chunk count exceeded sanity ceiling")
+		}
+	}
+	return out, chunks
+}
+
+func TestServeReader(t *testing.T) {
+	t.Run("WithBulkBatching collapses a drip source into a handful of Recv responses", func(t *testing.T) {
+		r := require.New(t)
+
+		// 4 MB delivered one byte at a time. Bulk mode batches at 1 MB,
+		// so we expect ~4 data chunks plus the final partial chunk; the
+		// assertion ceiling has slack to absorb the partial.
+		const total = 4 * 1024 * 1024
+		src := &drippyReader{data: make([]byte, total)}
+		for i := range src.data {
+			src.data[i] = byte(i)
+		}
+
+		got, chunks := serveAndCount(t, src, WithBulkBatching())
+
+		r.Equal(src.data, got, "all bytes round-trip intact")
+		r.LessOrEqual(chunks, 6, "expected ≤6 chunks under 1 MB batching, got %d", chunks)
+	})
+
+	t.Run("streaming mode (default) emits one chunk per underlying Read", func(t *testing.T) {
+		r := require.New(t)
+
+		// 1024 bytes from the drip source; without batching every byte
+		// should land in its own Recv response, exactly like interactive
+		// stdin would. If this ever ratchets down, it means we
+		// accidentally re-enabled batching for non-bulk callers.
+		const total = 1024
+		src := &drippyReader{data: make([]byte, total)}
+		for i := range src.data {
+			src.data[i] = byte(i)
+		}
+
+		got, chunks := serveAndCount(t, src)
+
+		r.Equal(src.data, got)
+		r.Equal(total, chunks, "streaming mode must emit one chunk per byte from a drip source")
+	})
+
+	t.Run("tiny bulk-batched stream below the floor still terminates cleanly", func(t *testing.T) {
+		r := require.New(t)
+
+		src := &drippyReader{data: []byte("hello world")}
+		got, chunks := serveAndCount(t, src, WithBulkBatching())
+
+		r.Equal([]byte("hello world"), got)
+		r.Equal(1, chunks, "partial-final batch should ship in a single chunk")
+	})
+
+	t.Run("empty stream terminates without error", func(t *testing.T) {
+		r := require.New(t)
+
+		src := &drippyReader{data: nil}
+		got, chunks := serveAndCount(t, src, WithBulkBatching())
+
+		r.Empty(got)
+		r.Equal(0, chunks)
 	})
 }


### PR DESCRIPTION
Today's cloud production deploy crawled at 2.4 KB/s against an 80 MB tarball, which works out to about nine hours just for the upload. Past deploys on the same code path ran 300 to 450 KB/s, which is slow but workable. Something cratered, hard.

The miren CLI streams the deploy tarball over a pull-based RPC: the build server calls `Recv(N)` on the client and the client's `serveReader.Recv` returns whatever a single underlying `s.r.Read(buf)` happens to yield. That's one RPC round trip per underlying Read, regardless of how big the request was. For most of the past year `tarx` used `os.Pipe()`, which has a ~64 KB kernel buffer, so the many small writes that `gzip.Writer` produces piled up in the buffer and `serveReader.Recv`'s single Read pulled them all back at once. The bug was real but the kernel was quietly absorbing the damage.

On 2026-04-29 we switched `tarx` from `os.Pipe` to `io.Pipe` so we could surface walk errors via `CloseWithError`. `io.Pipe` is a strict synchronous handoff with no buffer, so each gzip flush became its own Recv response and the latent single-Read bug went from "annoying" to "deploys take all day". Today was the first production deploy in three weeks, so today is the first one to feel it.

The fix lives in `serveReader.Recv` but it needed a knob, because the same function ships interactive stdin for `sandbox exec` and `app run`. Unconditional batching would wedge those streams (CodeRabbit caught this, thank you CodeRabbit). So we get `WithBulkBatching()`, an opt-in `ServeReaderOption` that flips on a 1 MB `io.ReadAtLeast` floor. Bulk callers (`BuildFromTar`, `BuildFromPrepared`, `AnalyzeApp`) pass it; interactive callers stay bare and keep their per-keystroke responsiveness. Throughput on a bulk stream becomes roughly `batch/RTT`, around 10 MB/s on a 100 ms link, regardless of whether the source is `os.Pipe`, `io.Pipe`, a slow disk, or whatever else the future brings.

The Linear writeup at MIR-1135 has the full history (this is the third time we've tangled with this code path, and each prior round was treating symptoms).

Closes MIR-1135