### PR TITLE
Speed up the Release workflow from ~21m to ~13m

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     secrets: inherit
 
   package:
-    needs: [init, test]
+    needs: [init]
     strategy:
       matrix:
         include:
@@ -95,7 +95,7 @@ jobs:
         retention-days: 1
 
   build-binaries:
-    needs: [init, test]
+    needs: [init]
     strategy:
       matrix:
         include:
@@ -125,6 +125,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
+        cache: true
 
     - name: Build binary for ${{ matrix.os }}-${{ matrix.arch }}
       run: |
@@ -195,7 +196,7 @@ jobs:
         rm certificate.p12
 
     - name: Build macOS .pkg installer
-      if: matrix.os == 'darwin' && env.INSTALLER_IDENTITY != ''
+      if: matrix.os == 'darwin' && env.INSTALLER_IDENTITY != '' && startsWith(needs.init.outputs.ref, 'v')
       run: |
         mkdir -p pkg-root/usr/local/bin
         cp bin/miren pkg-root/usr/local/bin/miren
@@ -208,49 +209,60 @@ jobs:
           miren-darwin-${{ matrix.arch }}.pkg
         rm -rf pkg-root
 
-    - name: Notarize macOS binary
-      if: matrix.os == 'darwin'
+    - name: Notarize macOS artifacts
+      if: matrix.os == 'darwin' && startsWith(needs.init.outputs.ref, 'v')
       env:
         APPLE_ID: ${{ secrets.APPLE_ID }}
         APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       run: |
-        # Create a zip for notarization of the bare binary
+        # Run bare-binary and .pkg notarization submits in parallel — each
+        # one sits on Apple's notarization service for a couple of minutes,
+        # so doing them concurrently roughly halves the wall time.
+
         zip -j miren-notarize.zip bin/miren
 
-        # Submit bare binary for notarization
         xcrun notarytool submit miren-notarize.zip \
           --apple-id "$APPLE_ID" \
           --password "$APPLE_ID_PASSWORD" \
           --team-id "$APPLE_TEAM_ID" \
-          --wait
+          --wait &
+        BIN_PID=$!
 
-        rm miren-notarize.zip
-
-        # Note: Can't staple bare binaries (only .app/.pkg/.dmg)
-        # The binary is still notarized - Gatekeeper checks online on first run
-
-    - name: Notarize and staple macOS .pkg
-      if: matrix.os == 'darwin' && env.INSTALLER_IDENTITY != ''
-      env:
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      run: |
         PKG_NAME="miren-darwin-${{ matrix.arch }}.pkg"
+        PKG_PID=
+        if [ -f "$PKG_NAME" ]; then
+          xcrun notarytool submit "$PKG_NAME" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait &
+          PKG_PID=$!
+        fi
 
-        # Submit .pkg for notarization (no zip wrapper needed for .pkg)
-        xcrun notarytool submit "$PKG_NAME" \
-          --apple-id "$APPLE_ID" \
-          --password "$APPLE_ID_PASSWORD" \
-          --team-id "$APPLE_TEAM_ID" \
-          --wait
+        wait "$BIN_PID"; BIN_RC=$?
+        PKG_RC=0
+        if [ -n "$PKG_PID" ]; then
+          wait "$PKG_PID"; PKG_RC=$?
+        fi
 
-        # Staple the notarization ticket to the .pkg
-        xcrun stapler staple "$PKG_NAME"
+        rm -f miren-notarize.zip
 
-        # Validate stapling
-        xcrun stapler validate "$PKG_NAME"
+        if [ "$BIN_RC" -ne 0 ]; then
+          echo "Bare-binary notarization failed (exit $BIN_RC)" >&2
+          exit "$BIN_RC"
+        fi
+        if [ "$PKG_RC" -ne 0 ]; then
+          echo ".pkg notarization failed (exit $PKG_RC)" >&2
+          exit "$PKG_RC"
+        fi
+
+        # Bare binaries can't be stapled (only .app/.pkg/.dmg). Gatekeeper
+        # checks the bare binary online on first run.
+        if [ -f "$PKG_NAME" ]; then
+          xcrun stapler staple "$PKG_NAME"
+          xcrun stapler validate "$PKG_NAME"
+        fi
 
     - name: Package binary
       run: |
@@ -268,7 +280,7 @@ jobs:
         retention-days: 1
 
     - name: Upload macOS .pkg artifact
-      if: matrix.os == 'darwin' && env.INSTALLER_IDENTITY != ''
+      if: matrix.os == 'darwin' && env.INSTALLER_IDENTITY != '' && startsWith(needs.init.outputs.ref, 'v')
       uses: actions/upload-artifact@v4
       with:
         name: miren-darwin-${{ matrix.arch }}-pkg
@@ -276,7 +288,7 @@ jobs:
         retention-days: 1
 
   build-and-push-docker:
-    needs: [init, package, upload-to-miren]
+    needs: [init, test, package]
     runs-on: depot-ubuntu-latest
     permissions:
       contents: read
@@ -351,7 +363,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   upload-to-miren:
-    needs: [init, package, build-binaries]
+    needs: [init, test, package, build-binaries]
     runs-on: depot-ubuntu-latest
     concurrency:
       group: upload-to-miren-${{ needs.init.outputs.ref }}


### PR DESCRIPTION
The runtime Release workflow had been sitting at roughly 21 minutes end-to-end on main pushes, and looking at a recent run it was pretty clear most of that time wasn't doing anything load-bearing. The critical path was init → test → build-binaries (darwin/arm64) → upload-to-miren → docker → notify, with several of those dependency edges being incidental rather than necessary.

The biggest win: `package` and `build-binaries` no longer wait for `test`. Today they declare `needs: [init, test]` and sit idle for the full ~10:45 of the test stage before they can even start. Letting them race alongside tests gets us most of the time back. The gate moves down to `upload-to-miren` and `build-and-push-docker`, which now `needs: test` directly, so failing tests still block every artifact from shipping. The trade is that test-failing commits burn CI minutes on builds that won't be used. That's the deliberate cost.

The second-biggest: macOS notarization gets gated to tagged releases only. The two `xcrun notarytool submit --wait` calls (one for the bare binary, one for the `.pkg`) sit waiting on Apple's notarization service for roughly 3 to 4 minutes combined, and main-channel users don't actually consume notarized artifacts. We wrap the `.pkg` build, both notarize calls, the staple/validate, and the `.pkg` upload in `startsWith(needs.init.outputs.ref, 'v')`. Darwin/arm64 drops from ~7m to ~3m on every main push.

For the tagged-release path where we still notarize, the two notarytool submits used to run serially. They now run in parallel, with stapler going after both return. Roughly halves the notarize wall time on the runs where it actually happens.

Three smaller items round it out: `build-and-push-docker` no longer needs `upload-to-miren` (docker only consumes the `package` job's linux artifacts, so that edge was just spurious), `build-binaries`' setup-go now has `cache: true` (mirroring what `package` already does), and the merged notarize step handles missing `.pkg` files gracefully (e.g. when no installer identity is configured).

Predicted main-push critical path: init → test (~10:45) running in parallel with builds → upload (~1:39) → notify, landing inside ~13m.

Closes MIR-1137