### PR TITLE
coordinate: stop advertising unverified public DiscoveredIPs

### DIFF
--- a/components/coordinate/api_addresses_test.go
+++ b/components/coordinate/api_addresses_test.go
@@ -27,12 +27,20 @@ func TestApiAddresses(t *testing.T) {
 		wantExcludes   []string
 	}{
 		{
-			name:          "no netcheck with discovered public IPs",
+			// Public discovered IPs are never advertised: an interface IP or
+			// startup-netcheck WAN echo doesn't prove port 8443 is reachable
+			// from outside. Only the coordinator's port-probing netcheck can.
+			name:          "no netcheck: public DiscoveredIPs are not advertised, private flows through",
 			discoveredIPs: []net.IP{publicIPv4, privateIP},
-			wantContains:  append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+			wantContains:  append(localhost, "10.0.0.5:8443"),
+			wantExcludes:  []string{"203.0.113.10:8443"},
 		},
 		{
-			name:          "netcheck ran but found nothing reachable",
+			// MIR-1139 repro: cluster is firewalled (port 8443 closed from outside).
+			// Netcheck ran, got the WAN source, but every probe failed. Today's bug:
+			// apiAddresses() falls back to DiscoveredIPs and advertises the unreachable
+			// WAN IP. After fix: public DiscoveredIPs stay suppressed.
+			name:          "netcheck ran, zero reachable: public DiscoveredIP not advertised (MIR-1139)",
 			discoveredIPs: []net.IP{publicIPv4, privateIP},
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
@@ -42,7 +50,8 @@ func TestApiAddresses(t *testing.T) {
 					},
 				},
 			},
-			wantContains: append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+			wantContains: append(localhost, "10.0.0.5:8443"),
+			wantExcludes: []string{"203.0.113.10:8443"},
 		},
 		{
 			name:          "netcheck ran and found reachable addresses",

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1369,10 +1369,11 @@ func (c *Coordinator) PublicIPs() []net.IP {
 }
 
 // apiAddresses builds the list of API addresses for status reports.
-// User-provided AdditionalIPs are always included. For auto-discovered IPs,
-// netcheck results replace discovered public IPs when reachable addresses
-// are found. If netcheck ran but found nothing reachable, discovered public
-// IPs are kept as a fallback.
+// User-provided AdditionalIPs are always included. Public discovered IPs
+// are never advertised on their own — only the coordinator's port-probing
+// netcheck can confirm a public address is actually reachable, so its
+// results are the sole authority for public addresses. Private, loopback,
+// and link-local DiscoveredIPs flow through for in-LAN clients.
 func (c *Coordinator) apiAddresses() []string {
 	var addrs []string
 
@@ -1389,18 +1390,18 @@ func (c *Coordinator) apiAddresses() []string {
 		addrs = append(addrs, net.JoinHostPort(ip.String(), "8443"))
 	}
 
-	// For discovered IPs, netcheck results replace discovered public IPs
-	// when netcheck found reachable addresses. If netcheck ran but found
-	// nothing reachable (e.g., firewalled), keep discovered public IPs
-	// as a fallback.
-	pubAddrs := c.publicAddresses()
+	// Public DiscoveredIPs are never advertised: an interface IP or the WAN
+	// echo from ipdiscovery's startup netcheck doesn't prove port 8443 is
+	// reachable from outside. publicAddresses() below is the only signal
+	// that does. Private/loopback/link-local IPs still flow through for
+	// in-LAN clients.
 	for _, ip := range c.DiscoveredIPs {
-		if len(pubAddrs) > 0 && !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
+		if !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
 			continue
 		}
 		addrs = append(addrs, net.JoinHostPort(ip.String(), "8443"))
 	}
-	addrs = append(addrs, pubAddrs...)
+	addrs = append(addrs, c.publicAddresses()...)
 
 	c.logAddressesOnce.Do(func() {
 		additional := []string{}


### PR DESCRIPTION
MIR-1117 / #139 fixed one half of a two-path bug: a non-miren listener on 443 could complete a TLS handshake during netcheck, and the cluster would advertise its WAN IP based on that false positive. PR #139 added cert verification so we only trust responses that prove they're from miren-runtime. That closed Path A.

This is Path B. When netcheck legitimately reports zero reachable (e.g. port 443 isn't forwarded at all), `apiAddresses()` was falling back to every IP in `DiscoveredIPs`, which still included the WAN IP echoed by `ipdiscovery`'s startup netcheck. Same bad outcome: cloud writes `cluster-X.miren.systems A <unreachable WAN IP>`, the POP fleet never gets a turn, external clients hit a closed port. I caught this with a fresh home cluster behind NAT.

The realization on the way to the fix was that public DiscoveredIPs were never authoritative on port reachability in the first place. Interface IPs don't know about firewalls. The startup netcheck only echoes the source IP back; nothing about it proves port 8443 is reachable from outside. The coordinator's port-probing netcheck, surfaced via `publicAddresses()`, is the only signal that actually does. So the fallback wasn't just buggy in the firewalled case, it was structurally wrong as a fallback. There was no scenario where a public DiscoveredIP was correct without netcheck also having said yes.

Fix: drop public DiscoveredIPs from `apiAddresses()` entirely. Private, loopback, and link-local DiscoveredIPs still flow through for in-LAN clients. A public IP in the status report now requires explicit netcheck confirmation, full stop. The bug becomes structurally impossible.

A nice side effect: the existing `AdditionalIPs` mechanism (user-configured, unfiltered) becomes the explicit opt-in path. Users with a Tailscale address or some other non-publicly-reachable interface they want resolved via DNS can just set it there. Default-off-with-opt-in falls out for free.

Closes MIR-1139