### PR TITLE
certificate: allow ephemeral subdomains of normal routes

### DIFF
--- a/controllers/certificate/autocert_controller.go
+++ b/controllers/certificate/autocert_controller.go
@@ -349,19 +349,28 @@ func (c *AutocertController) dnsPointsToUs(domain string) bool {
 }
 
 // isAllowedHost checks whether host is covered by the allowed set, including
-// wildcard entries. For example, if "*.example.com" is in the set,
-// "foo.example.com" is allowed but "example.com" is not — the wildcard
-// matches exactly one DNS label.
+// wildcard entries and ephemeral subdomains. For example, if "*.example.com"
+// is in the set, "foo.example.com" is allowed but "example.com" is not — the
+// wildcard matches exactly one DNS label. Additionally, if "example.com" is
+// in the set as a normal (non-wildcard) route, "label.example.com" is allowed
+// to support ephemeral deploys, which prepend a label to the route's hostname
+// (see httpingress.lookupEphemeralRoute for the matching request-routing logic).
 func (c *AutocertController) isAllowedHost(host string) bool {
 	if _, ok := c.allowedHosts.Load(host); ok {
 		return true
 	}
-	// Check if a wildcard covers this subdomain: foo.example.com → *.example.com
-	if idx := strings.IndexByte(host, '.'); idx >= 0 {
-		wildcard := "*" + host[idx:]
-		if _, ok := c.allowedHosts.Load(wildcard); ok {
-			return true
-		}
+	idx := strings.IndexByte(host, '.')
+	if idx <= 0 {
+		return false
+	}
+	parent := host[idx+1:]
+	// Wildcard route covers this subdomain: foo.example.com → *.example.com
+	if _, ok := c.allowedHosts.Load("*." + parent); ok {
+		return true
+	}
+	// Ephemeral subdomain of a normal route: pr-33.app.example.com → app.example.com
+	if _, ok := c.allowedHosts.Load(parent); ok {
+		return true
 	}
 	return false
 }

--- a/controllers/certificate/autocert_controller_test.go
+++ b/controllers/certificate/autocert_controller_test.go
@@ -189,6 +189,46 @@ func TestAutocertController_HostPolicy_WildcardMatching(t *testing.T) {
 	}
 }
 
+// TestAutocertController_IsAllowedHost_EphemeralSubdomain verifies that an
+// ephemeral subdomain of a normal (non-wildcard) route is allowed, matching
+// the request-routing behavior in httpingress.lookupEphemeralRoute. Without
+// this, ephemeral deploy URLs like pr-33.app.example.com would serve the
+// fallback self-signed cert instead of provisioning via autocert.
+func TestAutocertController_IsAllowedHost_EphemeralSubdomain(t *testing.T) {
+	c := newTestAutocertController(t)
+	c.allowedHosts.Store("app.example.com", struct{}{})
+
+	tests := []struct {
+		host    string
+		allowed bool
+	}{
+		{"app.example.com", true},        // exact match (the registered route)
+		{"pr-33.app.example.com", true},  // ephemeral subdomain of the route
+		{"feat-x.app.example.com", true}, // another ephemeral label
+		{"app.example.org", false},       // unrelated TLD
+		{"example.com", false},           // parent of the route, not a subdomain
+		{"other.com", false},             // unrelated domain
+	}
+
+	for _, tt := range tests {
+		got := c.isAllowedHost(tt.host)
+		if got != tt.allowed {
+			t.Errorf("isAllowedHost(%q) = %v, want %v", tt.host, got, tt.allowed)
+		}
+	}
+}
+
+func TestAutocertController_HostPolicy_EphemeralSubdomain(t *testing.T) {
+	c := newTestAutocertController(t)
+	c.allowedHosts.Store("app.example.com", struct{}{})
+
+	// Ephemeral subdomain of a normal route should be accepted by HostPolicy
+	// so autocert will attempt ACME provisioning instead of falling back.
+	if err := c.mgr.HostPolicy(context.Background(), "pr-33.app.example.com"); err != nil {
+		t.Errorf("expected host policy to accept ephemeral subdomain, got: %v", err)
+	}
+}
+
 func TestAutocertController_Init_PrePopulatesAllowedHosts(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

- Fixes MIR-1141: ephemeral deploys served the cluster's self-signed fallback cert instead of a real TLS certificate.
- The autocert controller's `isAllowedHost` only matched exact hosts and one-level wildcards (`*.example.com`). The request-routing layer (`httpingress.lookupEphemeralRoute`) was already stripping the first DNS label of incoming hosts and matching the parent against the route set, so a request to `pr-33.app.example.com` would route correctly to the app on `app.example.com` — but the TLS handshake's SNI lookup happened earlier in `GetCertificate`, missed the allow-list, and short-circuited to the self-signed fallback before autocert could provision anything.
- Mirror the strip-and-match logic in `isAllowedHost` so the cert layer agrees with the routing layer on which hostnames belong to an app. Autocert will now attempt HTTP-01 provisioning inline on the first handshake for `<label>.<route-host>`.

## Test plan

- [x] `go test ./controllers/certificate/...` — 19 passing, including two new cases covering the ephemeral-subdomain-of-normal-route path (`TestAutocertController_IsAllowedHost_EphemeralSubdomain`, `TestAutocertController_HostPolicy_EphemeralSubdomain`).
- [x] `golangci-lint run ./controllers/certificate/...` — clean.
- [ ] Manual: deploy with `--ephemeral pr-33`, confirm the URL returned by the API serves a Let's Encrypt cert rather than the self-signed fallback.

## Caveats

- For the inline ACME provisioning to succeed, the user still needs DNS that resolves `<label>.<route-host>` to the cluster (e.g. a wildcard A record covering the route's domain). When DNS is missing, the handshake will still fall back to the self-signed cert, but that is now an external misconfiguration rather than a bug on our side.
- Each new ephemeral label triggers a new Let's Encrypt order. The existing per-domain failure cooldown handles rate-limit backoff, but heavy churn on distinct labels could press up against LE order limits.