### PR TITLE
coordinate: trust negative netcheck per family, filter CGNAT

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -881,6 +881,7 @@ Warning: These commands are intended for advanced users and developers. They may
 
 `))
 	d.Dispatch("debug connection", Infer("debug connection", "Test connectivity and authentication with a server", DebugConnection))
+	d.Dispatch("debug advertise", Infer("debug advertise", "Show which addresses the server would advertise and why", DebugAdvertise))
 	d.Dispatch("debug reindex", Infer("debug reindex", "Rebuild all entity indexes from scratch", DebugReindex))
 	d.Dispatch("debug test", Section("debug test", "Debug test commands", ""))
 	d.Dispatch("debug test load", Infer("debug test load", "Loadtest a URL", TestLoad))

--- a/cli/commands/debug_advertise.go
+++ b/cli/commands/debug_advertise.go
@@ -48,7 +48,7 @@ func DebugAdvertise(ctx *Context, opts struct {
 		return err
 	}
 
-	var discoveredIPs []net.IP
+	ipSet := coordinate.NewIPSet()
 	for _, a := range discovery.Addresses {
 		ip := net.ParseIP(a.IP)
 		if ip == nil {
@@ -60,20 +60,20 @@ func DebugAdvertise(ctx *Context, opts struct {
 			ctx.Info("  %-15s %-40s [skipped: link-local]", a.Interface, a.IP)
 			continue
 		}
-		ctx.Info("  %-15s %-40s", a.Interface, a.IP)
-		discoveredIPs = append(discoveredIPs, ip)
+		ctx.Info("  %-15s %-40s (discovered)", a.Interface, a.IP)
+		ipSet.AddDiscovered(ip)
 	}
-	ctx.Info("")
 
-	var additionalIPs []net.IP
 	for _, s := range opts.AdditionalIPs {
 		ip := net.ParseIP(s)
 		if ip == nil {
 			ctx.Warn("--additional-ip %q is not a valid IP, skipping", s)
 			continue
 		}
-		additionalIPs = append(additionalIPs, ip)
+		ctx.Info("  %-15s %-40s (explicit)", "user", ip.String())
+		ipSet.AddExplicit(ip)
 	}
+	ctx.Info("")
 
 	ctx.Info("Step 2: dual-stack netcheck")
 	var netcheckResult *cloudauth.NetcheckDualStackResult
@@ -96,10 +96,9 @@ func DebugAdvertise(ctx *Context, opts struct {
 	ctx.Info("")
 
 	candidates, final := coordinate.ComputeAdvertise(coordinate.AdvertiseInput{
-		ListenAddr:    listenAddr,
-		AdditionalIPs: additionalIPs,
-		DiscoveredIPs: discoveredIPs,
-		Netcheck:      netcheckResult,
+		ListenAddr: listenAddr,
+		IPs:        ipSet.All(),
+		Netcheck:   netcheckResult,
 	})
 
 	ctx.Info("Step 3: per-candidate classification and inclusion decision")

--- a/cli/commands/debug_advertise.go
+++ b/cli/commands/debug_advertise.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"sort"
-	"strconv"
 	"time"
 
 	"miren.dev/runtime/components/coordinate"
@@ -12,17 +11,10 @@ import (
 	"miren.dev/runtime/pkg/ipdiscovery"
 )
 
-// DebugAdvertise reproduces the server's public-IP advertisement logic and
-// prints per-candidate classification + the final advertised list, so we can
-// debug cases where the server advertises addresses that aren't actually
-// reachable from clients.
-//
-// This mirrors the behavior of:
-//   - cli/commands/server.go (ipdiscovery.DiscoverWithTimeout + link-local filter)
-//   - components/coordinate/coordinate.go (runNetcheck, publicAddresses, apiAddresses)
-//
-// It deliberately duplicates that logic so it can run without a live
-// coordinator. If the logic in either place changes, update this command too.
+// DebugAdvertise runs the same advertise-address computation the server uses
+// (coordinate.ComputeAdvertise) and prints a per-candidate explanation plus
+// the final advertised list, so we can debug cases where the server
+// advertises addresses that aren't actually reachable from clients.
 func DebugAdvertise(ctx *Context, opts struct {
 	CloudURL      string   `long:"cloud-url" description:"Cloud URL to use for netcheck (default: https://api.miren.cloud)"`
 	SkipNetcheck  bool     `long:"skip-netcheck" description:"Skip the netcheck call and only report interface scan"`
@@ -49,7 +41,7 @@ func DebugAdvertise(ctx *Context, opts struct {
 		discoveryOpts.NetcheckURL = cloudURL
 	}
 
-	ctx.Info("Step 1: interface scan (+ optional netcheck IP discovery)")
+	ctx.Info("Step 1: interface scan")
 	discovery, err := ipdiscovery.DiscoverWithTimeout(15*time.Second, ctx.Log, discoveryOpts)
 	if err != nil {
 		ctx.Warn("ipdiscovery.Discover failed: %v", err)
@@ -103,121 +95,33 @@ func DebugAdvertise(ctx *Context, opts struct {
 	}
 	ctx.Info("")
 
-	// Apply the same source-address validation runNetcheck does: drop any
-	// source IP that isn't a public global unicast address. A rejected
-	// source family is treated as if that family's netcheck never ran.
-	if netcheckResult != nil {
-		if netcheckResult.IPv4 != nil {
-			src := net.ParseIP(netcheckResult.IPv4.SourceAddress)
-			if src == nil || !src.IsGlobalUnicast() || src.IsPrivate() {
-				ctx.Info("  IPv4 source %s rejected (not public global unicast)", netcheckResult.IPv4.SourceAddress)
-				netcheckResult.IPv4 = nil
-			}
-		}
-		if netcheckResult.IPv6 != nil {
-			src := net.ParseIP(netcheckResult.IPv6.SourceAddress)
-			if src == nil || !src.IsGlobalUnicast() || src.IsPrivate() {
-				ctx.Info("  IPv6 source %s rejected (not public global unicast)", netcheckResult.IPv6.SourceAddress)
-				netcheckResult.IPv6 = nil
-			}
-		}
-		if netcheckResult.IPv4 == nil && netcheckResult.IPv6 == nil {
-			netcheckResult = nil
-		}
-	}
-
-	pubAddrs := publicAddressesFromNetcheck(netcheckResult)
+	candidates, final := coordinate.ComputeAdvertise(coordinate.AdvertiseInput{
+		ListenAddr:    listenAddr,
+		AdditionalIPs: additionalIPs,
+		DiscoveredIPs: discoveredIPs,
+		Netcheck:      netcheckResult,
+	})
 
 	ctx.Info("Step 3: per-candidate classification and inclusion decision")
-	ctx.Info("  (mirrors components/coordinate/coordinate.go apiAddresses)")
 	ctx.Info("")
-	ctx.Info("  %-18s %-40s %-18s %s", "SOURCE", "IP:PORT", "CLASSIFICATION", "DECISION")
-	ctx.Info("  %s", "------------------------------------------------------------------------------------------------")
-
-	var finalAddrs []string
-
-	// Listen address — only included if it has a valid IP host.
-	if host, _, err := net.SplitHostPort(listenAddr); err == nil && net.ParseIP(host) != nil {
-		finalAddrs = append(finalAddrs, listenAddr)
-		ctx.Info("  %-18s %-40s %-18s ADVERTISED", "listen", listenAddr, classifyHostPort(listenAddr))
-	} else {
-		ctx.Info("  %-18s %-40s %-18s SKIPPED (not a literal IP host)", "listen", listenAddr, "-")
-	}
-
-	// Localhost — always added.
-	for _, lh := range []string{"127.0.0.1:8443", "[::1]:8443"} {
-		finalAddrs = append(finalAddrs, lh)
-		ctx.Info("  %-18s %-40s %-18s ADVERTISED (always)", "localhost", lh, "loopback")
-	}
-
-	// Configured AdditionalIPs — always added.
-	for _, ip := range additionalIPs {
-		hp := net.JoinHostPort(ip.String(), "8443")
-		finalAddrs = append(finalAddrs, hp)
-		ctx.Info("  %-18s %-40s %-18s ADVERTISED (configured)", "additional", hp, classify(ip))
-	}
-
-	// Discovered IPs — filtered against netcheck's public addresses per
-	// the current apiAddresses rule.
-	for _, ip := range discoveredIPs {
-		hp := net.JoinHostPort(ip.String(), "8443")
-		class := classify(ip)
-		isPublicCandidate := !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast()
-		if len(pubAddrs) > 0 && isPublicCandidate {
-			ctx.Info("  %-18s %-40s %-18s SKIPPED (replaced by netcheck public)", "discovered", hp, class)
-			continue
+	ctx.Info("  %-12s %-40s %-16s %-10s %s", "SOURCE", "IP:PORT", "CLASS", "DECISION", "REASON")
+	ctx.Info("  %s", "-------------------------------------------------------------------------------------------------------------")
+	for _, c := range candidates {
+		decision := "SKIPPED"
+		if c.Included {
+			decision = "ADVERTISED"
 		}
-		reason := "fallback (no netcheck public addrs)"
-		if !isPublicCandidate {
-			reason = "private/loopback, included unconditionally"
-		}
-		finalAddrs = append(finalAddrs, hp)
-		ctx.Info("  %-18s %-40s %-18s ADVERTISED (%s)", "discovered", hp, class, reason)
-	}
-
-	// Netcheck-reachable public addresses.
-	for _, hp := range pubAddrs {
-		finalAddrs = append(finalAddrs, hp)
-		ctx.Info("  %-18s %-40s %-18s ADVERTISED (netcheck reachable)", "netcheck", hp, classifyHostPort(hp))
+		ctx.Info("  %-12s %-40s %-16s %-10s %s",
+			c.Source, c.HostPort, c.Classification, decision, c.Reason)
 	}
 
 	ctx.Info("")
-	ctx.Info("Final advertised list (%d entries):", len(finalAddrs))
-	for _, a := range finalAddrs {
+	ctx.Info("Final advertised list (%d entries):", len(final))
+	for _, a := range final {
 		ctx.Info("  %s", a)
 	}
 
-	reachabilitySummary(ctx, netcheckResult, discoveredIPs, additionalIPs, pubAddrs)
-
 	return nil
-}
-
-func publicAddressesFromNetcheck(result *cloudauth.NetcheckDualStackResult) []string {
-	if result == nil {
-		return nil
-	}
-	seen := make(map[string]struct{})
-	var addrs []string
-	for _, resp := range []*cloudauth.NetcheckResponse{result.IPv4, result.IPv6} {
-		if resp == nil || resp.SourceAddress == "" {
-			continue
-		}
-		if net.ParseIP(resp.SourceAddress) == nil {
-			continue
-		}
-		for _, r := range resp.Results {
-			if !r.Reachable {
-				continue
-			}
-			hp := net.JoinHostPort(resp.SourceAddress, strconv.Itoa(r.Port))
-			if _, ok := seen[hp]; ok {
-				continue
-			}
-			seen[hp] = struct{}{}
-			addrs = append(addrs, hp)
-		}
-	}
-	return addrs
 }
 
 func printNetcheckResponse(ctx *Context, family string, resp *cloudauth.NetcheckResponse) {
@@ -241,111 +145,9 @@ func printNetcheckResponse(ctx *Context, family string, resp *cloudauth.Netcheck
 		family, resp.SourceAddress, reachable, unreachable, resp.DurationMs)
 }
 
-func classify(ip net.IP) string {
-	switch {
-	case ip.IsLoopback():
-		return "loopback"
-	case ip.IsLinkLocalUnicast():
-		return "link-local"
-	case ip.IsPrivate():
-		return "private"
-	case ip.IsGlobalUnicast():
-		return "global-unicast"
-	default:
-		return "other"
-	}
-}
-
-func classifyHostPort(hp string) string {
-	host, _, err := net.SplitHostPort(hp)
-	if err != nil {
-		return "-"
-	}
-	ip := net.ParseIP(host)
-	if ip == nil {
-		return "-"
-	}
-	return classify(ip)
-}
-
 func boolWord(b bool, yes, no string) string {
 	if b {
 		return yes
 	}
 	return no
-}
-
-// reachabilitySummary highlights the specific failure modes behind MIR-1018:
-// netcheck source IPs that were proven unreachable but still get advertised,
-// and tailscale/bridge/ULA interfaces that sneak through the private filter.
-func reachabilitySummary(ctx *Context, result *cloudauth.NetcheckDualStackResult, discovered, additional []net.IP, pubAddrs []string) {
-	ctx.Info("")
-	ctx.Info("Reachability notes:")
-
-	noted := false
-
-	// Case 1: netcheck returned a source IP but *zero* reachable ports.
-	if result != nil {
-		for _, entry := range []struct {
-			family string
-			resp   *cloudauth.NetcheckResponse
-		}{
-			{"IPv4", result.IPv4},
-			{"IPv6", result.IPv6},
-		} {
-			if entry.resp == nil || entry.resp.SourceAddress == "" {
-				continue
-			}
-			anyReachable := false
-			for _, r := range entry.resp.Results {
-				if r.Reachable {
-					anyReachable = true
-					break
-				}
-			}
-			if !anyReachable {
-				noted = true
-				ctx.Warn("  netcheck %s source %s is PROVEN UNREACHABLE but still advertised via the discovered-IP fallback (MIR-1018 bug #1)",
-					entry.family, entry.resp.SourceAddress)
-			}
-		}
-	}
-
-	// Case 2: suspicious private-range interfaces that are almost never
-	// reachable from a generic client (tailscale CGNAT, docker, libvirt, ULA).
-	for _, ip := range discovered {
-		if reason := suspiciousPrivate(ip); reason != "" {
-			noted = true
-			ctx.Warn("  discovered IP %s advertised (%s) — almost certainly not reachable from an arbitrary client (MIR-1018 bug #2)",
-				ip, reason)
-		}
-	}
-
-	if !noted {
-		ctx.Info("  none")
-	}
-	_ = pubAddrs
-	_ = additional
-}
-
-func suspiciousPrivate(ip net.IP) string {
-	if ip == nil {
-		return ""
-	}
-	if ip4 := ip.To4(); ip4 != nil {
-		switch {
-		case ip4[0] == 100 && ip4[1]&0xc0 == 64:
-			return "tailscale CGNAT 100.64.0.0/10"
-		case ip4[0] == 172 && ip4[1] == 17:
-			return "docker bridge 172.17.0.0/16"
-		case ip4[0] == 192 && ip4[1] == 168 && ip4[2] == 122:
-			return "libvirt default bridge 192.168.122.0/24"
-		}
-		return ""
-	}
-	// IPv6 ULA fc00::/7
-	if len(ip) == net.IPv6len && (ip[0]&0xfe) == 0xfc {
-		return "IPv6 ULA fc00::/7 (e.g. tailscale)"
-	}
-	return ""
 }

--- a/cli/commands/debug_advertise.go
+++ b/cli/commands/debug_advertise.go
@@ -1,0 +1,351 @@
+package commands
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"time"
+
+	"miren.dev/runtime/components/coordinate"
+	"miren.dev/runtime/pkg/cloudauth"
+	"miren.dev/runtime/pkg/ipdiscovery"
+)
+
+// DebugAdvertise reproduces the server's public-IP advertisement logic and
+// prints per-candidate classification + the final advertised list, so we can
+// debug cases where the server advertises addresses that aren't actually
+// reachable from clients.
+//
+// This mirrors the behavior of:
+//   - cli/commands/server.go (ipdiscovery.DiscoverWithTimeout + link-local filter)
+//   - components/coordinate/coordinate.go (runNetcheck, publicAddresses, apiAddresses)
+//
+// It deliberately duplicates that logic so it can run without a live
+// coordinator. If the logic in either place changes, update this command too.
+func DebugAdvertise(ctx *Context, opts struct {
+	CloudURL      string   `long:"cloud-url" description:"Cloud URL to use for netcheck (default: https://api.miren.cloud)"`
+	SkipNetcheck  bool     `long:"skip-netcheck" description:"Skip the netcheck call and only report interface scan"`
+	AdditionalIPs []string `long:"additional-ip" description:"Simulate a server-configured AdditionalIP (repeatable)"`
+	ListenAddr    string   `long:"listen" description:"Simulate the server's listen address (default: 0.0.0.0:8443)"`
+}) error {
+	cloudURL := opts.CloudURL
+	if cloudURL == "" {
+		cloudURL = coordinate.DefaultCloudURL
+	}
+	listenAddr := opts.ListenAddr
+	if listenAddr == "" {
+		listenAddr = "0.0.0.0:8443"
+	}
+
+	ctx.Info("debug advertise — reproducing server advertisement logic")
+	ctx.Info("  cloud URL:    %s", cloudURL)
+	ctx.Info("  listen:       %s", listenAddr)
+	ctx.Info("  netcheck:     %s", boolWord(!opts.SkipNetcheck, "enabled", "skipped"))
+	ctx.Info("")
+
+	discoveryOpts := ipdiscovery.Options{}
+	if !opts.SkipNetcheck {
+		discoveryOpts.NetcheckURL = cloudURL
+	}
+
+	ctx.Info("Step 1: interface scan (+ optional netcheck IP discovery)")
+	discovery, err := ipdiscovery.DiscoverWithTimeout(15*time.Second, ctx.Log, discoveryOpts)
+	if err != nil {
+		ctx.Warn("ipdiscovery.Discover failed: %v", err)
+		return err
+	}
+
+	var discoveredIPs []net.IP
+	for _, a := range discovery.Addresses {
+		ip := net.ParseIP(a.IP)
+		if ip == nil {
+			continue
+		}
+		// server.go drops link-local addresses before handing the list
+		// to the coordinator — mirror that here.
+		if ip.IsLinkLocalUnicast() {
+			ctx.Info("  %-15s %-40s [skipped: link-local]", a.Interface, a.IP)
+			continue
+		}
+		ctx.Info("  %-15s %-40s", a.Interface, a.IP)
+		discoveredIPs = append(discoveredIPs, ip)
+	}
+	ctx.Info("")
+
+	var additionalIPs []net.IP
+	for _, s := range opts.AdditionalIPs {
+		ip := net.ParseIP(s)
+		if ip == nil {
+			ctx.Warn("--additional-ip %q is not a valid IP, skipping", s)
+			continue
+		}
+		additionalIPs = append(additionalIPs, ip)
+	}
+
+	ctx.Info("Step 2: dual-stack netcheck")
+	var netcheckResult *cloudauth.NetcheckDualStackResult
+	if opts.SkipNetcheck {
+		ctx.Info("  skipped (--skip-netcheck)")
+	} else {
+		ports := []cloudauth.NetcheckPort{
+			{Port: 8443, Protocol: "https"},
+			{Port: 8443, Protocol: "http3"},
+		}
+		netcheckResult, err = cloudauth.NetcheckDualStack(ctx, cloudURL, ports)
+		if err != nil {
+			ctx.Warn("netcheck failed: %v", err)
+			netcheckResult = nil
+		} else {
+			printNetcheckResponse(ctx, "IPv4", netcheckResult.IPv4)
+			printNetcheckResponse(ctx, "IPv6", netcheckResult.IPv6)
+		}
+	}
+	ctx.Info("")
+
+	// Apply the same source-address validation runNetcheck does: drop any
+	// source IP that isn't a public global unicast address. A rejected
+	// source family is treated as if that family's netcheck never ran.
+	if netcheckResult != nil {
+		if netcheckResult.IPv4 != nil {
+			src := net.ParseIP(netcheckResult.IPv4.SourceAddress)
+			if src == nil || !src.IsGlobalUnicast() || src.IsPrivate() {
+				ctx.Info("  IPv4 source %s rejected (not public global unicast)", netcheckResult.IPv4.SourceAddress)
+				netcheckResult.IPv4 = nil
+			}
+		}
+		if netcheckResult.IPv6 != nil {
+			src := net.ParseIP(netcheckResult.IPv6.SourceAddress)
+			if src == nil || !src.IsGlobalUnicast() || src.IsPrivate() {
+				ctx.Info("  IPv6 source %s rejected (not public global unicast)", netcheckResult.IPv6.SourceAddress)
+				netcheckResult.IPv6 = nil
+			}
+		}
+		if netcheckResult.IPv4 == nil && netcheckResult.IPv6 == nil {
+			netcheckResult = nil
+		}
+	}
+
+	pubAddrs := publicAddressesFromNetcheck(netcheckResult)
+
+	ctx.Info("Step 3: per-candidate classification and inclusion decision")
+	ctx.Info("  (mirrors components/coordinate/coordinate.go apiAddresses)")
+	ctx.Info("")
+	ctx.Info("  %-18s %-40s %-18s %s", "SOURCE", "IP:PORT", "CLASSIFICATION", "DECISION")
+	ctx.Info("  %s", "------------------------------------------------------------------------------------------------")
+
+	var finalAddrs []string
+
+	// Listen address — only included if it has a valid IP host.
+	if host, _, err := net.SplitHostPort(listenAddr); err == nil && net.ParseIP(host) != nil {
+		finalAddrs = append(finalAddrs, listenAddr)
+		ctx.Info("  %-18s %-40s %-18s ADVERTISED", "listen", listenAddr, classifyHostPort(listenAddr))
+	} else {
+		ctx.Info("  %-18s %-40s %-18s SKIPPED (not a literal IP host)", "listen", listenAddr, "-")
+	}
+
+	// Localhost — always added.
+	for _, lh := range []string{"127.0.0.1:8443", "[::1]:8443"} {
+		finalAddrs = append(finalAddrs, lh)
+		ctx.Info("  %-18s %-40s %-18s ADVERTISED (always)", "localhost", lh, "loopback")
+	}
+
+	// Configured AdditionalIPs — always added.
+	for _, ip := range additionalIPs {
+		hp := net.JoinHostPort(ip.String(), "8443")
+		finalAddrs = append(finalAddrs, hp)
+		ctx.Info("  %-18s %-40s %-18s ADVERTISED (configured)", "additional", hp, classify(ip))
+	}
+
+	// Discovered IPs — filtered against netcheck's public addresses per
+	// the current apiAddresses rule.
+	for _, ip := range discoveredIPs {
+		hp := net.JoinHostPort(ip.String(), "8443")
+		class := classify(ip)
+		isPublicCandidate := !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast()
+		if len(pubAddrs) > 0 && isPublicCandidate {
+			ctx.Info("  %-18s %-40s %-18s SKIPPED (replaced by netcheck public)", "discovered", hp, class)
+			continue
+		}
+		reason := "fallback (no netcheck public addrs)"
+		if !isPublicCandidate {
+			reason = "private/loopback, included unconditionally"
+		}
+		finalAddrs = append(finalAddrs, hp)
+		ctx.Info("  %-18s %-40s %-18s ADVERTISED (%s)", "discovered", hp, class, reason)
+	}
+
+	// Netcheck-reachable public addresses.
+	for _, hp := range pubAddrs {
+		finalAddrs = append(finalAddrs, hp)
+		ctx.Info("  %-18s %-40s %-18s ADVERTISED (netcheck reachable)", "netcheck", hp, classifyHostPort(hp))
+	}
+
+	ctx.Info("")
+	ctx.Info("Final advertised list (%d entries):", len(finalAddrs))
+	for _, a := range finalAddrs {
+		ctx.Info("  %s", a)
+	}
+
+	reachabilitySummary(ctx, netcheckResult, discoveredIPs, additionalIPs, pubAddrs)
+
+	return nil
+}
+
+func publicAddressesFromNetcheck(result *cloudauth.NetcheckDualStackResult) []string {
+	if result == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var addrs []string
+	for _, resp := range []*cloudauth.NetcheckResponse{result.IPv4, result.IPv6} {
+		if resp == nil || resp.SourceAddress == "" {
+			continue
+		}
+		if net.ParseIP(resp.SourceAddress) == nil {
+			continue
+		}
+		for _, r := range resp.Results {
+			if !r.Reachable {
+				continue
+			}
+			hp := net.JoinHostPort(resp.SourceAddress, strconv.Itoa(r.Port))
+			if _, ok := seen[hp]; ok {
+				continue
+			}
+			seen[hp] = struct{}{}
+			addrs = append(addrs, hp)
+		}
+	}
+	return addrs
+}
+
+func printNetcheckResponse(ctx *Context, family string, resp *cloudauth.NetcheckResponse) {
+	if resp == nil {
+		ctx.Info("  %s: no response", family)
+		return
+	}
+	var reachable []string
+	var unreachable []string
+	for _, r := range resp.Results {
+		entry := fmt.Sprintf("%s/%d", r.Protocol, r.Port)
+		if r.Reachable {
+			reachable = append(reachable, entry)
+		} else {
+			unreachable = append(unreachable, entry)
+		}
+	}
+	sort.Strings(reachable)
+	sort.Strings(unreachable)
+	ctx.Info("  %s source=%s reachable=%v unreachable=%v duration=%dms",
+		family, resp.SourceAddress, reachable, unreachable, resp.DurationMs)
+}
+
+func classify(ip net.IP) string {
+	switch {
+	case ip.IsLoopback():
+		return "loopback"
+	case ip.IsLinkLocalUnicast():
+		return "link-local"
+	case ip.IsPrivate():
+		return "private"
+	case ip.IsGlobalUnicast():
+		return "global-unicast"
+	default:
+		return "other"
+	}
+}
+
+func classifyHostPort(hp string) string {
+	host, _, err := net.SplitHostPort(hp)
+	if err != nil {
+		return "-"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return "-"
+	}
+	return classify(ip)
+}
+
+func boolWord(b bool, yes, no string) string {
+	if b {
+		return yes
+	}
+	return no
+}
+
+// reachabilitySummary highlights the specific failure modes behind MIR-1018:
+// netcheck source IPs that were proven unreachable but still get advertised,
+// and tailscale/bridge/ULA interfaces that sneak through the private filter.
+func reachabilitySummary(ctx *Context, result *cloudauth.NetcheckDualStackResult, discovered, additional []net.IP, pubAddrs []string) {
+	ctx.Info("")
+	ctx.Info("Reachability notes:")
+
+	noted := false
+
+	// Case 1: netcheck returned a source IP but *zero* reachable ports.
+	if result != nil {
+		for _, entry := range []struct {
+			family string
+			resp   *cloudauth.NetcheckResponse
+		}{
+			{"IPv4", result.IPv4},
+			{"IPv6", result.IPv6},
+		} {
+			if entry.resp == nil || entry.resp.SourceAddress == "" {
+				continue
+			}
+			anyReachable := false
+			for _, r := range entry.resp.Results {
+				if r.Reachable {
+					anyReachable = true
+					break
+				}
+			}
+			if !anyReachable {
+				noted = true
+				ctx.Warn("  netcheck %s source %s is PROVEN UNREACHABLE but still advertised via the discovered-IP fallback (MIR-1018 bug #1)",
+					entry.family, entry.resp.SourceAddress)
+			}
+		}
+	}
+
+	// Case 2: suspicious private-range interfaces that are almost never
+	// reachable from a generic client (tailscale CGNAT, docker, libvirt, ULA).
+	for _, ip := range discovered {
+		if reason := suspiciousPrivate(ip); reason != "" {
+			noted = true
+			ctx.Warn("  discovered IP %s advertised (%s) — almost certainly not reachable from an arbitrary client (MIR-1018 bug #2)",
+				ip, reason)
+		}
+	}
+
+	if !noted {
+		ctx.Info("  none")
+	}
+	_ = pubAddrs
+	_ = additional
+}
+
+func suspiciousPrivate(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		switch {
+		case ip4[0] == 100 && ip4[1]&0xc0 == 64:
+			return "tailscale CGNAT 100.64.0.0/10"
+		case ip4[0] == 172 && ip4[1] == 17:
+			return "docker bridge 172.17.0.0/16"
+		case ip4[0] == 192 && ip4[1] == 168 && ip4[2] == 122:
+			return "libvirt default bridge 192.168.122.0/24"
+		}
+		return ""
+	}
+	// IPv6 ULA fc00::/7
+	if len(ip) == net.IPv6len && (ip[0]&0xfe) == 0xfc {
+		return "IPv6 ULA fc00::/7 (e.g. tailscale)"
+	}
+	return ""
+}

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -75,10 +75,10 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	ctx.UILog.Info("starting miren server", "version", versionInfo.Version, "commit", versionInfo.Commit)
 
 	// Discover local and public IPs early so they're available for TLS cert SANs.
-	// We track discovered IPs separately from user-configured IPs so the
-	// coordinator can treat them differently (netcheck can replace discovered
-	// public IPs but user-configured IPs always pass through).
-	var discoveredIps []net.IP
+	// IPs are tagged with whether they are user-configured (explicit) or
+	// auto-discovered from interfaces. The coordinator uses this to decide
+	// which IPs to prune (discovered) vs always include (explicit).
+	ipSet := coordinate.NewIPSet()
 	discovery, err := ipdiscovery.DiscoverWithTimeout(10*time.Second, ctx.Log, ipdiscovery.Options{
 		NetcheckURL: coordinate.DefaultCloudURL,
 	})
@@ -88,7 +88,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		for _, addr := range discovery.Addresses {
 			ip := net.ParseIP(addr.IP)
 			if ip != nil && !ip.IsLinkLocalUnicast() {
-				discoveredIps = append(discoveredIps, ip)
+				ipSet.AddDiscovered(ip)
 			}
 		}
 		ctx.Log.Info("discovered IPs", "addresses", len(discovery.Addresses))
@@ -296,7 +296,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 			ctx.Log.Info("setting up etcd mTLS for distributed runners")
 
 			var err error
-			etcdTLSSetup, err = coordinate.SetupEtcdTLS(ctx.Log, cfg.Server.GetDataPath(), cfg.TLS.AdditionalNames, discoveredIps)
+			etcdTLSSetup, err = coordinate.SetupEtcdTLS(ctx.Log, cfg.Server.GetDataPath(), cfg.TLS.AdditionalNames, ipSet.RawIPs())
 			if err != nil {
 				ctx.Log.Error("failed to set up etcd TLS", "error", err)
 				return err
@@ -516,20 +516,13 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	systemHandler := observability.NewSystemLogHandler(ctx.Log.Handler(), batchWriter)
 	ctx.Log = slog.New(systemHandler)
 
-	var additionalIps []net.IP
-	seen := make(map[string]struct{})
 	for _, ip := range cfg.TLS.AdditionalIPs {
 		addr := net.ParseIP(ip)
 		if addr == nil {
 			ctx.Log.Error("failed to parse additional IP", "ip", ip)
 			return fmt.Errorf("failed to parse additional IP %s", ip)
 		}
-		key := addr.String()
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		additionalIps = append(additionalIps, addr)
+		ipSet.AddExplicit(addr)
 	}
 
 	// Create HTTP metrics
@@ -618,8 +611,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		NetworkBackend:         cfg.Server.GetNetworkBackend(),
 		DataPath:               cfg.Server.GetDataPath(),
 		AdditionalNames:        cfg.TLS.AdditionalNames,
-		AdditionalIPs:          additionalIps,
-		DiscoveredIPs:          discoveredIps,
+		IPs:                    ipSet,
 		AcmeEmail:              cfg.TLS.GetAcmeEmail(),
 		AcmeDNSProvider:        cfg.TLS.GetAcmeDNSProvider(),
 		Resolver:               res,

--- a/components/coordinate/advertise.go
+++ b/components/coordinate/advertise.go
@@ -7,18 +7,104 @@ import (
 	"miren.dev/runtime/pkg/cloudauth"
 )
 
+// SourcedIP is an IP address tagged with how it was obtained. Explicit IPs
+// (user-configured via AdditionalIPs or the server config) always pass
+// through to the advertised list. Discovered IPs (auto-scanned from local
+// interfaces) are subject to netcheck pruning, CGNAT filtering, etc.
+type SourcedIP struct {
+	IP       net.IP
+	Explicit bool // true = user-configured, false = auto-discovered
+}
+
+// IPSet is an ordered, de-duplicated collection of SourcedIP entries.
+// When a duplicate IP is added, the Explicit flag is sticky: adding an
+// IP as explicit promotes a previously-discovered entry, but adding it
+// as discovered never demotes an explicit one. Iteration order matches
+// first-insertion order.
+type IPSet struct {
+	entries []SourcedIP
+	index   map[string]int // IP string → index into entries
+}
+
+// NewIPSet creates an empty IPSet.
+func NewIPSet() *IPSet {
+	return &IPSet{index: make(map[string]int)}
+}
+
+// Add inserts an IP. If the IP already exists and the new entry is
+// explicit, it promotes the existing entry. Discovered duplicates are
+// silently ignored.
+func (s *IPSet) Add(sip SourcedIP) {
+	if sip.IP == nil {
+		return
+	}
+	key := sip.IP.String()
+	if i, ok := s.index[key]; ok {
+		if sip.Explicit && !s.entries[i].Explicit {
+			s.entries[i].Explicit = true
+		}
+		return
+	}
+	s.index[key] = len(s.entries)
+	s.entries = append(s.entries, sip)
+}
+
+// AddDiscovered is a convenience for Add(SourcedIP{IP: ip, Explicit: false}).
+func (s *IPSet) AddDiscovered(ip net.IP) {
+	s.Add(SourcedIP{IP: ip, Explicit: false})
+}
+
+// AddExplicit is a convenience for Add(SourcedIP{IP: ip, Explicit: true}).
+func (s *IPSet) AddExplicit(ip net.IP) {
+	s.Add(SourcedIP{IP: ip, Explicit: true})
+}
+
+// All returns the entries in insertion order. The returned slice is a
+// copy — callers may not modify it. Safe to call on a nil receiver.
+func (s *IPSet) All() []SourcedIP {
+	if s == nil {
+		return nil
+	}
+	out := make([]SourcedIP, len(s.entries))
+	copy(out, s.entries)
+	return out
+}
+
+// RawIPs extracts just the net.IP values in insertion order.
+// Safe to call on a nil receiver.
+func (s *IPSet) RawIPs() []net.IP {
+	if s == nil {
+		return nil
+	}
+	out := make([]net.IP, 0, len(s.entries))
+	for _, e := range s.entries {
+		out = append(out, e.IP)
+	}
+	return out
+}
+
+// Len returns the number of unique IPs in the set.
+// Safe to call on a nil receiver.
+func (s *IPSet) Len() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.entries)
+}
+
 // AdvertiseInput is the raw input for computing the set of API addresses
 // the server should advertise to clients and to miren.cloud.
 type AdvertiseInput struct {
 	// ListenAddr is the server's own listen address (e.g. "0.0.0.0:8443").
-	// Included in the advertised list only if it has a literal IP host.
+	// Included in the advertised list only if it has a literal,
+	// non-loopback, non-unspecified IP.
 	ListenAddr string
 
-	// AdditionalIPs are user-configured IPs that must always be advertised.
-	AdditionalIPs []net.IP
-
-	// DiscoveredIPs are interface-scanned IPs from the local host.
-	DiscoveredIPs []net.IP
+	// IPs is the unified list of all candidate IP addresses, each
+	// tagged as explicit (user-configured) or discovered (interface scan).
+	// Explicit IPs bypass all filtering except loopback / unspecified.
+	// Discovered IPs are subject to CGNAT, netcheck, and other pruning.
+	IPs []SourcedIP
 
 	// Netcheck is the result of the dual-stack netcheck, if one has run.
 	// A nil pointer means netcheck never ran / failed entirely.
@@ -33,7 +119,7 @@ type AdvertiseInput struct {
 // both production (building the final list) and debug tooling (explaining
 // the decision for every IP).
 type AdvertiseCandidate struct {
-	Source         string // "listen", "localhost", "additional", "discovered", "netcheck"
+	Source         string // "listen", "explicit", "discovered", "netcheck"
 	HostPort       string
 	IP             net.IP
 	Classification string // loopback / link-local / private / global-unicast / other
@@ -57,23 +143,18 @@ type AdvertiseCandidate struct {
 //
 //  1. Listen address: included if it parses as host:port with a literal,
 //     non-loopback, non-unspecified IP.
-//  2. AdditionalIPs: always included (user-curated), except loopback
+//
+//  2. Explicit IPs (user-configured): always included, except loopback
 //     and unspecified which are dropped with a reason.
-//  3. DiscoveredIPs:
-//     a. CGNAT addresses (100.64.0.0/10) are dropped. This range is used
-//     by tailscale tailnets and carrier-grade NAT; advertising them to
-//     a generic client is misleading. Users who want a CGNAT address
-//     advertised can pass it via AdditionalIPs.
-//     b. Other private / loopback / link-local IPs are always included —
-//     they may serve clients on the same LAN and we can't tell from
-//     here which private ranges are reachable.
+//
+//  3. Discovered IPs (auto-scanned from interfaces):
+//     a. Loopback and unspecified are dropped.
+//     b. CGNAT addresses (100.64.0.0/10) are dropped.
 //     c. Public (global-unicast, non-private) IPs are dropped if netcheck
 //     ran for that address family and proved the family unreachable
-//     (valid public source IP, zero reachable ports), or if netcheck
-//     found reachable addresses (in which case the confirmed netcheck
-//     source is advertised instead).
-//     d. Otherwise (netcheck didn't run or source was invalid) they are
-//     kept as a fallback.
+//     or found reachable addresses (replaced by netcheck-confirmed ones).
+//     d. Otherwise kept as a fallback.
+//
 //  4. Netcheck public addresses: included when reachable on at least one port.
 func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
 	port := in.Port
@@ -140,47 +221,53 @@ func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
 		}
 	}
 
-	// 2. AdditionalIPs.
-	for _, ip := range in.AdditionalIPs {
-		if ip == nil {
-			continue
-		}
-		cand := AdvertiseCandidate{
-			Source:         "additional",
-			HostPort:       net.JoinHostPort(ip.String(), portStr),
-			IP:             ip,
-			Classification: classify(ip),
-		}
-		switch {
-		case ip.IsUnspecified():
-			cand.Included = false
-			cand.Reason = "unspecified address (0.0.0.0 / ::) is not routable"
-		case ip.IsLoopback():
-			cand.Included = false
-			cand.Reason = "loopback is not reachable from remote clients"
-		default:
-			cand.Included = true
-			cand.Reason = "user-configured"
-		}
-		add(cand)
-	}
-
 	// Compute per-family netcheck state.
 	v4State := netcheckFamilyState(familyIPv4, in.Netcheck)
 	v6State := netcheckFamilyState(familyIPv6, in.Netcheck)
 
-	// 3. DiscoveredIPs.
-	for _, ip := range in.DiscoveredIPs {
+	// 2 & 3. IPs — explicit pass through, discovered are filtered.
+	for _, sip := range in.IPs {
+		ip := sip.IP
 		if ip == nil {
 			continue
 		}
 		hp := net.JoinHostPort(ip.String(), portStr)
+
+		source := "discovered"
+		if sip.Explicit {
+			source = "explicit"
+		}
+
 		cand := AdvertiseCandidate{
-			Source:         "discovered",
+			Source:         source,
 			HostPort:       hp,
 			IP:             ip,
 			Classification: classify(ip),
 		}
+
+		// Loopback / unspecified always rejected regardless of source.
+		if ip.IsUnspecified() {
+			cand.Included = false
+			cand.Reason = "unspecified address is not routable"
+			add(cand)
+			continue
+		}
+		if ip.IsLoopback() {
+			cand.Included = false
+			cand.Reason = "loopback is not reachable from remote clients"
+			add(cand)
+			continue
+		}
+
+		// Explicit IPs pass through with no further filtering.
+		if sip.Explicit {
+			cand.Included = true
+			cand.Reason = "user-configured"
+			add(cand)
+			continue
+		}
+
+		// --- Discovered IP filtering below ---
 
 		if isCGNAT(ip) {
 			cand.Included = false
@@ -192,7 +279,7 @@ func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
 		isPublicCandidate := !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast()
 		if !isPublicCandidate {
 			cand.Included = true
-			cand.Reason = "private/loopback/link-local, kept for LAN clients"
+			cand.Reason = "private/link-local, kept for LAN clients"
 			add(cand)
 			continue
 		}
@@ -279,8 +366,7 @@ func netcheckFamilyState(fam netcheckFamily, result *cloudauth.NetcheckDualStack
 }
 
 // publicAddressesFromNetcheck returns netcheck-confirmed reachable host:port
-// strings. Mirrors the old (*Coordinator).publicAddresses() but as a pure
-// function so it can be shared with debug tooling.
+// strings.
 func publicAddressesFromNetcheck(result *cloudauth.NetcheckDualStackResult) []string {
 	if result == nil {
 		return nil

--- a/components/coordinate/advertise.go
+++ b/components/coordinate/advertise.go
@@ -1,0 +1,322 @@
+package coordinate
+
+import (
+	"net"
+	"strconv"
+
+	"miren.dev/runtime/pkg/cloudauth"
+)
+
+// AdvertiseInput is the raw input for computing the set of API addresses
+// the server should advertise to clients and to miren.cloud.
+type AdvertiseInput struct {
+	// ListenAddr is the server's own listen address (e.g. "0.0.0.0:8443").
+	// Included in the advertised list only if it has a literal IP host.
+	ListenAddr string
+
+	// AdditionalIPs are user-configured IPs that must always be advertised.
+	AdditionalIPs []net.IP
+
+	// DiscoveredIPs are interface-scanned IPs from the local host.
+	DiscoveredIPs []net.IP
+
+	// Netcheck is the result of the dual-stack netcheck, if one has run.
+	// A nil pointer means netcheck never ran / failed entirely.
+	Netcheck *cloudauth.NetcheckDualStackResult
+
+	// Port is the port to append to bare IPs (defaults to 8443).
+	Port int
+}
+
+// AdvertiseCandidate describes one candidate address the advertise logic
+// considered, and whether it ended up in the final advertised set. Used by
+// both production (building the final list) and debug tooling (explaining
+// the decision for every IP).
+type AdvertiseCandidate struct {
+	Source         string // "listen", "localhost", "additional", "discovered", "netcheck"
+	HostPort       string
+	IP             net.IP
+	Classification string // loopback / link-local / private / global-unicast / other
+	Included       bool
+	Reason         string
+}
+
+// ComputeAdvertise is the single source of truth for computing the addresses
+// the server advertises. It returns the ordered list of candidates (including
+// rejected ones, so callers can explain why) and the final list of advertised
+// host:port strings.
+//
+// Filtering rules:
+//
+//  1. Listen address: included if it parses as host:port with a literal IP.
+//  2. Localhost (127.0.0.1, ::1): always included.
+//  3. AdditionalIPs: always included (user-curated).
+//  4. DiscoveredIPs:
+//     a. CGNAT addresses (100.64.0.0/10) are dropped. This range is used
+//     by tailscale tailnets and carrier-grade NAT; advertising them to
+//     a generic client is misleading. Users who want a CGNAT address
+//     advertised can pass it via AdditionalIPs.
+//     b. Other private / loopback / link-local IPs are always included —
+//     they may serve clients on the same LAN and we can't tell from
+//     here which private ranges are reachable.
+//     c. Public (global-unicast, non-private) IPs are dropped if netcheck
+//     ran for that address family and proved the family unreachable
+//     (valid public source IP, zero reachable ports), or if netcheck
+//     found reachable addresses (in which case the confirmed netcheck
+//     source is advertised instead).
+//     d. Otherwise (netcheck didn't run or source was invalid) they are
+//     kept as a fallback.
+//  5. Netcheck public addresses: included when reachable on at least one port.
+func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
+	port := in.Port
+	if port == 0 {
+		port = 8443
+	}
+	portStr := strconv.Itoa(port)
+
+	var cands []AdvertiseCandidate
+	var final []string
+	seen := make(map[string]struct{})
+
+	add := func(c AdvertiseCandidate) {
+		cands = append(cands, c)
+		if !c.Included {
+			return
+		}
+		if _, ok := seen[c.HostPort]; ok {
+			return
+		}
+		seen[c.HostPort] = struct{}{}
+		final = append(final, c.HostPort)
+	}
+
+	// 1. Listen address.
+	if in.ListenAddr != "" {
+		host, _, err := net.SplitHostPort(in.ListenAddr)
+		if err == nil && net.ParseIP(host) != nil {
+			ip := net.ParseIP(host)
+			add(AdvertiseCandidate{
+				Source:         "listen",
+				HostPort:       in.ListenAddr,
+				IP:             ip,
+				Classification: classify(ip),
+				Included:       true,
+				Reason:         "server listen address",
+			})
+		} else {
+			add(AdvertiseCandidate{
+				Source:   "listen",
+				HostPort: in.ListenAddr,
+				Included: false,
+				Reason:   "not a literal IP host",
+			})
+		}
+	}
+
+	// 2. Localhost.
+	for _, lh := range []string{
+		net.JoinHostPort("127.0.0.1", portStr),
+		net.JoinHostPort("::1", portStr),
+	} {
+		host, _, _ := net.SplitHostPort(lh)
+		add(AdvertiseCandidate{
+			Source:         "localhost",
+			HostPort:       lh,
+			IP:             net.ParseIP(host),
+			Classification: "loopback",
+			Included:       true,
+			Reason:         "always advertised",
+		})
+	}
+
+	// 3. AdditionalIPs.
+	for _, ip := range in.AdditionalIPs {
+		if ip == nil {
+			continue
+		}
+		add(AdvertiseCandidate{
+			Source:         "additional",
+			HostPort:       net.JoinHostPort(ip.String(), portStr),
+			IP:             ip,
+			Classification: classify(ip),
+			Included:       true,
+			Reason:         "user-configured",
+		})
+	}
+
+	// Compute per-family netcheck state.
+	v4State := netcheckFamilyState(familyIPv4, in.Netcheck)
+	v6State := netcheckFamilyState(familyIPv6, in.Netcheck)
+
+	// 4. DiscoveredIPs.
+	for _, ip := range in.DiscoveredIPs {
+		if ip == nil {
+			continue
+		}
+		hp := net.JoinHostPort(ip.String(), portStr)
+		cand := AdvertiseCandidate{
+			Source:         "discovered",
+			HostPort:       hp,
+			IP:             ip,
+			Classification: classify(ip),
+		}
+
+		if isCGNAT(ip) {
+			cand.Included = false
+			cand.Reason = "CGNAT 100.64.0.0/10 (e.g. tailscale)"
+			add(cand)
+			continue
+		}
+
+		isPublicCandidate := !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast()
+		if !isPublicCandidate {
+			cand.Included = true
+			cand.Reason = "private/loopback/link-local, kept for LAN clients"
+			add(cand)
+			continue
+		}
+
+		state := v4State
+		if ip.To4() == nil {
+			state = v6State
+		}
+		switch state {
+		case netcheckReachable:
+			cand.Included = false
+			cand.Reason = "replaced by netcheck-confirmed public address"
+		case netcheckUnreachable:
+			cand.Included = false
+			cand.Reason = "address family proven unreachable by netcheck"
+		default:
+			cand.Included = true
+			cand.Reason = "no netcheck override"
+		}
+		add(cand)
+	}
+
+	// 5. Netcheck public addresses.
+	for _, hp := range publicAddressesFromNetcheck(in.Netcheck) {
+		host, _, _ := net.SplitHostPort(hp)
+		ip := net.ParseIP(host)
+		add(AdvertiseCandidate{
+			Source:         "netcheck",
+			HostPort:       hp,
+			IP:             ip,
+			Classification: classify(ip),
+			Included:       true,
+			Reason:         "netcheck confirmed reachable",
+		})
+	}
+
+	return cands, final
+}
+
+type netcheckFamily int
+
+const (
+	familyIPv4 netcheckFamily = iota
+	familyIPv6
+)
+
+type netcheckStatus int
+
+const (
+	netcheckNotRun netcheckStatus = iota
+	netcheckUnreachable
+	netcheckReachable
+)
+
+// netcheckFamilyState returns what we know about reachability for one address
+// family. A nil NetcheckDualStackResult or a nil family response means "not
+// run". A response with a non-public/invalid source address is also treated
+// as not run (same rule runNetcheck applies). A response with a valid source
+// but zero reachable ports is "proven unreachable".
+func netcheckFamilyState(fam netcheckFamily, result *cloudauth.NetcheckDualStackResult) netcheckStatus {
+	if result == nil {
+		return netcheckNotRun
+	}
+	var resp *cloudauth.NetcheckResponse
+	switch fam {
+	case familyIPv4:
+		resp = result.IPv4
+	case familyIPv6:
+		resp = result.IPv6
+	}
+	if resp == nil {
+		return netcheckNotRun
+	}
+	src := net.ParseIP(resp.SourceAddress)
+	if src == nil || !src.IsGlobalUnicast() || src.IsPrivate() {
+		return netcheckNotRun
+	}
+	for _, r := range resp.Results {
+		if r.Reachable {
+			return netcheckReachable
+		}
+	}
+	return netcheckUnreachable
+}
+
+// publicAddressesFromNetcheck returns netcheck-confirmed reachable host:port
+// strings. Mirrors the old (*Coordinator).publicAddresses() but as a pure
+// function so it can be shared with debug tooling.
+func publicAddressesFromNetcheck(result *cloudauth.NetcheckDualStackResult) []string {
+	if result == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var addrs []string
+	for _, resp := range []*cloudauth.NetcheckResponse{result.IPv4, result.IPv6} {
+		if resp == nil || resp.SourceAddress == "" {
+			continue
+		}
+		src := net.ParseIP(resp.SourceAddress)
+		if src == nil || !src.IsGlobalUnicast() || src.IsPrivate() {
+			continue
+		}
+		for _, r := range resp.Results {
+			if !r.Reachable {
+				continue
+			}
+			hp := net.JoinHostPort(resp.SourceAddress, strconv.Itoa(r.Port))
+			if _, ok := seen[hp]; ok {
+				continue
+			}
+			seen[hp] = struct{}{}
+			addrs = append(addrs, hp)
+		}
+	}
+	return addrs
+}
+
+// isCGNAT reports whether ip falls in the 100.64.0.0/10 Carrier-Grade NAT
+// range (RFC 6598). Tailscale tailnet addresses also live in this range,
+// so filtering CGNAT out of discovered-IP lists keeps them from being
+// advertised to clients who aren't on the tailnet.
+func isCGNAT(ip net.IP) bool {
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return false
+	}
+	return ip4[0] == 100 && ip4[1]&0xc0 == 0x40
+}
+
+// classify returns a short string describing the kind of address, for
+// diagnostic output.
+func classify(ip net.IP) string {
+	if ip == nil {
+		return "unknown"
+	}
+	switch {
+	case ip.IsLoopback():
+		return "loopback"
+	case ip.IsLinkLocalUnicast():
+		return "link-local"
+	case ip.IsPrivate():
+		return "private"
+	case ip.IsGlobalUnicast():
+		return "global-unicast"
+	default:
+		return "other"
+	}
+}

--- a/components/coordinate/advertise.go
+++ b/components/coordinate/advertise.go
@@ -46,12 +46,20 @@ type AdvertiseCandidate struct {
 // rejected ones, so callers can explain why) and the final list of advertised
 // host:port strings.
 //
+// The returned list is intended for StatusReport.APIAddresses, i.e. the
+// addresses miren.cloud hands out to clients that want to reach this
+// cluster. Loopback and unspecified (0.0.0.0, ::) addresses are never
+// included — a client coming in through miren.cloud is by definition not
+// running on the same host, so those entries would only produce failed
+// connection attempts.
+//
 // Filtering rules:
 //
-//  1. Listen address: included if it parses as host:port with a literal IP.
-//  2. Localhost (127.0.0.1, ::1): always included.
-//  3. AdditionalIPs: always included (user-curated).
-//  4. DiscoveredIPs:
+//  1. Listen address: included if it parses as host:port with a literal,
+//     non-loopback, non-unspecified IP.
+//  2. AdditionalIPs: always included (user-curated), except loopback
+//     and unspecified which are dropped with a reason.
+//  3. DiscoveredIPs:
 //     a. CGNAT addresses (100.64.0.0/10) are dropped. This range is used
 //     by tailscale tailnets and carrier-grade NAT; advertising them to
 //     a generic client is misleading. Users who want a CGNAT address
@@ -66,7 +74,7 @@ type AdvertiseCandidate struct {
 //     source is advertised instead).
 //     d. Otherwise (netcheck didn't run or source was invalid) they are
 //     kept as a fallback.
-//  5. Netcheck public addresses: included when reachable on at least one port.
+//  4. Netcheck public addresses: included when reachable on at least one port.
 func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
 	port := in.Port
 	if port == 0 {
@@ -93,8 +101,34 @@ func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
 	// 1. Listen address.
 	if in.ListenAddr != "" {
 		host, _, err := net.SplitHostPort(in.ListenAddr)
-		if err == nil && net.ParseIP(host) != nil {
-			ip := net.ParseIP(host)
+		ip := net.ParseIP(host)
+		switch {
+		case err != nil || ip == nil:
+			add(AdvertiseCandidate{
+				Source:   "listen",
+				HostPort: in.ListenAddr,
+				Included: false,
+				Reason:   "not a literal IP host",
+			})
+		case ip.IsUnspecified():
+			add(AdvertiseCandidate{
+				Source:         "listen",
+				HostPort:       in.ListenAddr,
+				IP:             ip,
+				Classification: "unspecified",
+				Included:       false,
+				Reason:         "unspecified address (0.0.0.0 / ::) is not routable",
+			})
+		case ip.IsLoopback():
+			add(AdvertiseCandidate{
+				Source:         "listen",
+				HostPort:       in.ListenAddr,
+				IP:             ip,
+				Classification: "loopback",
+				Included:       false,
+				Reason:         "loopback is not reachable from remote clients",
+			})
+		default:
 			add(AdvertiseCandidate{
 				Source:         "listen",
 				HostPort:       in.ListenAddr,
@@ -103,52 +137,39 @@ func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
 				Included:       true,
 				Reason:         "server listen address",
 			})
-		} else {
-			add(AdvertiseCandidate{
-				Source:   "listen",
-				HostPort: in.ListenAddr,
-				Included: false,
-				Reason:   "not a literal IP host",
-			})
 		}
 	}
 
-	// 2. Localhost.
-	for _, lh := range []string{
-		net.JoinHostPort("127.0.0.1", portStr),
-		net.JoinHostPort("::1", portStr),
-	} {
-		host, _, _ := net.SplitHostPort(lh)
-		add(AdvertiseCandidate{
-			Source:         "localhost",
-			HostPort:       lh,
-			IP:             net.ParseIP(host),
-			Classification: "loopback",
-			Included:       true,
-			Reason:         "always advertised",
-		})
-	}
-
-	// 3. AdditionalIPs.
+	// 2. AdditionalIPs.
 	for _, ip := range in.AdditionalIPs {
 		if ip == nil {
 			continue
 		}
-		add(AdvertiseCandidate{
+		cand := AdvertiseCandidate{
 			Source:         "additional",
 			HostPort:       net.JoinHostPort(ip.String(), portStr),
 			IP:             ip,
 			Classification: classify(ip),
-			Included:       true,
-			Reason:         "user-configured",
-		})
+		}
+		switch {
+		case ip.IsUnspecified():
+			cand.Included = false
+			cand.Reason = "unspecified address (0.0.0.0 / ::) is not routable"
+		case ip.IsLoopback():
+			cand.Included = false
+			cand.Reason = "loopback is not reachable from remote clients"
+		default:
+			cand.Included = true
+			cand.Reason = "user-configured"
+		}
+		add(cand)
 	}
 
 	// Compute per-family netcheck state.
 	v4State := netcheckFamilyState(familyIPv4, in.Netcheck)
 	v6State := netcheckFamilyState(familyIPv6, in.Netcheck)
 
-	// 4. DiscoveredIPs.
+	// 3. DiscoveredIPs.
 	for _, ip := range in.DiscoveredIPs {
 		if ip == nil {
 			continue
@@ -194,7 +215,7 @@ func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
 		add(cand)
 	}
 
-	// 5. Netcheck public addresses.
+	// 4. Netcheck public addresses.
 	for _, hp := range publicAddressesFromNetcheck(in.Netcheck) {
 		host, _, _ := net.SplitHostPort(hp)
 		ip := net.ParseIP(host)

--- a/components/coordinate/api_addresses_test.go
+++ b/components/coordinate/api_addresses_test.go
@@ -9,16 +9,22 @@ import (
 	"miren.dev/runtime/pkg/cloudauth"
 )
 
+func explicit(ip string) SourcedIP  { return SourcedIP{IP: net.ParseIP(ip), Explicit: true} }
+func discovered(ip string) SourcedIP { return SourcedIP{IP: net.ParseIP(ip), Explicit: false} }
+
+func makeIPSet(entries ...SourcedIP) *IPSet {
+	s := NewIPSet()
+	for _, e := range entries {
+		s.Add(e)
+	}
+	return s
+}
+
 func TestApiAddresses(t *testing.T) {
-	// Default listen is the wildcard 0.0.0.0:8443. This is what most
-	// servers actually run with, and it must never end up in the
-	// advertised list that gets shipped to miren.cloud. A client reached
-	// via cloud can't connect to 0.0.0.0 or to loopback.
 	const wildcardListen = "0.0.0.0:8443"
 
 	// Addresses that must never appear in the advertised list for any
-	// case below, since a remote client reached via miren.cloud can't
-	// use them.
+	// case, since a remote client reached via miren.cloud can't use them.
 	nonRoutable := []string{
 		"0.0.0.0:8443",
 		"[::]:8443",
@@ -26,31 +32,22 @@ func TestApiAddresses(t *testing.T) {
 		"[::1]:8443",
 	}
 
-	publicIPv4 := net.ParseIP("203.0.113.10")
-	publicIPv6 := net.ParseIP("2001:db8::10")
-	privateIP := net.ParseIP("10.0.0.5")
-
 	tests := []struct {
 		name           string
 		listenAddr     string
-		additionalIPs  []net.IP
-		discoveredIPs  []net.IP
+		ips            *IPSet
 		netcheckResult *cloudauth.NetcheckDualStackResult
 		wantContains   []string
 		wantExcludes   []string
 	}{
 		{
-			name:          "no netcheck with discovered public IPs",
-			discoveredIPs: []net.IP{publicIPv4, privateIP},
-			wantContains:  []string{"203.0.113.10:8443", "10.0.0.5:8443"},
+			name:         "no netcheck with discovered public IPs",
+			ips:          makeIPSet(discovered("203.0.113.10"), discovered("10.0.0.5")),
+			wantContains: []string{"203.0.113.10:8443", "10.0.0.5:8443"},
 		},
 		{
-			// MIR-1018: when netcheck ran with a valid public source IP
-			// but every probed port failed, we now trust the negative
-			// result and drop global-unicast discovered IPs in that
-			// family. Private LAN IPs are still kept.
-			name:          "netcheck proved IPv4 unreachable drops public discovered IP",
-			discoveredIPs: []net.IP{publicIPv4, privateIP},
+			name: "netcheck proved IPv4 unreachable drops discovered public IP",
+			ips:  makeIPSet(discovered("203.0.113.10"), discovered("10.0.0.5")),
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "203.0.113.10",
@@ -63,31 +60,41 @@ func TestApiAddresses(t *testing.T) {
 			wantExcludes: []string{"203.0.113.10:8443"},
 		},
 		{
-			// Netcheck failing entirely (e.g. no cloud connectivity) still
-			// lets discovered public IPs pass through as a fallback.
+			// Explicit IPs are never pruned by netcheck — the user asked
+			// for them specifically, even if netcheck says unreachable.
+			name: "explicit IP survives negative netcheck",
+			ips:  makeIPSet(explicit("203.0.113.10"), discovered("10.0.0.5")),
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "203.0.113.10",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "tcp", Reachable: false},
+					},
+				},
+			},
+			wantContains: []string{"203.0.113.10:8443", "10.0.0.5:8443"},
+		},
+		{
 			name:           "netcheck not run keeps discovered public IPs",
-			discoveredIPs:  []net.IP{publicIPv4, privateIP},
+			ips:            makeIPSet(discovered("203.0.113.10"), discovered("10.0.0.5")),
 			netcheckResult: nil,
 			wantContains:   []string{"203.0.113.10:8443", "10.0.0.5:8443"},
 		},
 		{
-			// MIR-1018: CGNAT addresses (tailscale tailnet / ISP CGNAT)
-			// are filtered out of the discovered list by default.
-			name:          "CGNAT discovered IP is filtered",
-			discoveredIPs: []net.IP{net.ParseIP("100.107.209.9"), privateIP},
-			wantContains:  []string{"10.0.0.5:8443"},
-			wantExcludes:  []string{"100.107.209.9:8443"},
+			name:         "CGNAT discovered IP is filtered",
+			ips:          makeIPSet(discovered("100.107.209.9"), discovered("10.0.0.5")),
+			wantContains: []string{"10.0.0.5:8443"},
+			wantExcludes: []string{"100.107.209.9:8443"},
 		},
 		{
-			// Users who explicitly want a CGNAT address advertised can
-			// still set it as an AdditionalIP.
-			name:          "CGNAT AdditionalIP is kept",
-			additionalIPs: []net.IP{net.ParseIP("100.107.209.9")},
-			wantContains:  []string{"100.107.209.9:8443"},
+			// Explicit CGNAT is kept — the user asked for it.
+			name:         "CGNAT explicit IP is kept",
+			ips:          makeIPSet(explicit("100.107.209.9")),
+			wantContains: []string{"100.107.209.9:8443"},
 		},
 		{
-			name:          "netcheck ran and found reachable addresses",
-			discoveredIPs: []net.IP{publicIPv4, privateIP},
+			name: "netcheck ran and found reachable addresses",
+			ips:  makeIPSet(discovered("203.0.113.10"), discovered("10.0.0.5")),
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "203.0.113.10",
@@ -99,15 +106,13 @@ func TestApiAddresses(t *testing.T) {
 			wantContains: []string{"10.0.0.5:8443", "203.0.113.10:8443"},
 		},
 		{
-			// Nothing to advertise. Should produce an empty list, not
-			// a list of nonsense loopback / wildcard entries.
 			name:         "no IPs and no netcheck yields empty list",
 			wantContains: nil,
 			wantExcludes: nonRoutable,
 		},
 		{
-			name:          "netcheck replaces discovered public IP with different source",
-			discoveredIPs: []net.IP{publicIPv4, privateIP},
+			name: "netcheck replaces discovered public IP with different source",
+			ips:  makeIPSet(discovered("203.0.113.10"), discovered("10.0.0.5")),
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "198.51.100.1",
@@ -120,8 +125,8 @@ func TestApiAddresses(t *testing.T) {
 			wantExcludes: []string{"203.0.113.10:8443"},
 		},
 		{
-			name:          "dual-stack netcheck with both families reachable",
-			discoveredIPs: []net.IP{publicIPv4, privateIP},
+			name: "dual-stack netcheck with both families reachable",
+			ips:  makeIPSet(discovered("203.0.113.10"), discovered("10.0.0.5")),
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "203.0.113.10",
@@ -139,8 +144,8 @@ func TestApiAddresses(t *testing.T) {
 			wantContains: []string{"203.0.113.10:8443", "[2001:db8::1]:8443", "10.0.0.5:8443"},
 		},
 		{
-			name:          "dual-stack netcheck with only IPv4 reachable",
-			discoveredIPs: []net.IP{publicIPv4, privateIP},
+			name: "dual-stack netcheck with only IPv4 reachable",
+			ips:  makeIPSet(discovered("203.0.113.10"), discovered("10.0.0.5")),
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "203.0.113.10",
@@ -153,9 +158,8 @@ func TestApiAddresses(t *testing.T) {
 			wantContains: []string{"203.0.113.10:8443", "10.0.0.5:8443"},
 		},
 		{
-			name:          "user-provided AdditionalIPs always included even with netcheck",
-			additionalIPs: []net.IP{publicIPv4},
-			discoveredIPs: []net.IP{privateIP},
+			name: "explicit IPs always included even with netcheck",
+			ips:  makeIPSet(explicit("203.0.113.10"), discovered("10.0.0.5")),
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "198.51.100.1",
@@ -167,8 +171,8 @@ func TestApiAddresses(t *testing.T) {
 			wantContains: []string{"203.0.113.10:8443", "198.51.100.1:8443", "10.0.0.5:8443"},
 		},
 		{
-			name:          "mixed-family: IPv4 reachable, discovered IPv6 preserved",
-			discoveredIPs: []net.IP{publicIPv4, publicIPv6, privateIP},
+			name: "mixed-family: IPv4 reachable, discovered IPv6 preserved",
+			ips:  makeIPSet(discovered("203.0.113.10"), discovered("2001:db8::10"), discovered("10.0.0.5")),
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
 					SourceAddress: "203.0.113.10",
@@ -181,18 +185,39 @@ func TestApiAddresses(t *testing.T) {
 			wantContains: []string{"203.0.113.10:8443", "[2001:db8::10]:8443", "10.0.0.5:8443"},
 		},
 		{
-			// A non-wildcard, non-loopback listen address IS advertised,
-			// because it's a real routable bind.
 			name:         "explicit non-wildcard listen address is advertised",
 			listenAddr:   "198.51.100.7:8443",
 			wantContains: []string{"198.51.100.7:8443"},
 		},
 		{
-			// AdditionalIPs that are loopback/unspecified get rejected.
-			name:          "loopback AdditionalIP is dropped",
-			additionalIPs: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1"), net.ParseIP("0.0.0.0"), publicIPv4},
-			wantContains:  []string{"203.0.113.10:8443"},
-			wantExcludes:  nonRoutable,
+			name:         "loopback explicit IP is dropped",
+			ips:          makeIPSet(explicit("127.0.0.1"), explicit("::1"), explicit("0.0.0.0"), explicit("203.0.113.10")),
+			wantContains: []string{"203.0.113.10:8443"},
+			wantExcludes: nonRoutable,
+		},
+		{
+			// IPSet dedup: when an IP is discovered first and then added
+			// again as explicit, it promotes to explicit and bypasses
+			// netcheck filtering.
+			name: "discovered IP promoted to explicit by IPSet dedup",
+			ips: func() *IPSet {
+				s := NewIPSet()
+				s.AddDiscovered(net.ParseIP("203.0.113.10"))
+				s.AddExplicit(net.ParseIP("203.0.113.10"))
+				s.AddDiscovered(net.ParseIP("10.0.0.5"))
+				return s
+			}(),
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "203.0.113.10",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "tcp", Reachable: false},
+					},
+				},
+			},
+			// 203.0.113.10 was promoted from discovered → explicit, so
+			// it survives the negative netcheck.
+			wantContains: []string{"203.0.113.10:8443", "10.0.0.5:8443"},
 		},
 	}
 
@@ -204,9 +229,8 @@ func TestApiAddresses(t *testing.T) {
 			}
 			c := &Coordinator{
 				CoordinatorConfig: CoordinatorConfig{
-					Address:       listen,
-					AdditionalIPs: tt.additionalIPs,
-					DiscoveredIPs: tt.discoveredIPs,
+					Address: listen,
+					IPs:     tt.ips,
 				},
 				Log:            slog.Default(),
 				netcheckResult: tt.netcheckResult,
@@ -214,13 +238,9 @@ func TestApiAddresses(t *testing.T) {
 
 			got := c.apiAddresses()
 
-			// Non-routable addresses are NEVER advertised — assert
-			// this for every case, in addition to the per-case
-			// excludes.
 			for _, nr := range nonRoutable {
 				assert.NotContains(t, got, nr, "non-routable address %q must never be advertised", nr)
 			}
-
 			for _, want := range tt.wantContains {
 				assert.Contains(t, got, want, "expected %q in result", want)
 			}

--- a/components/coordinate/api_addresses_test.go
+++ b/components/coordinate/api_addresses_test.go
@@ -9,7 +9,7 @@ import (
 	"miren.dev/runtime/pkg/cloudauth"
 )
 
-func explicit(ip string) SourcedIP  { return SourcedIP{IP: net.ParseIP(ip), Explicit: true} }
+func explicit(ip string) SourcedIP   { return SourcedIP{IP: net.ParseIP(ip), Explicit: true} }
 func discovered(ip string) SourcedIP { return SourcedIP{IP: net.ParseIP(ip), Explicit: false} }
 
 func makeIPSet(entries ...SourcedIP) *IPSet {

--- a/components/coordinate/api_addresses_test.go
+++ b/components/coordinate/api_addresses_test.go
@@ -10,9 +10,21 @@ import (
 )
 
 func TestApiAddresses(t *testing.T) {
-	const listenAddr = "0.0.0.0:8443"
+	// Default listen is the wildcard 0.0.0.0:8443. This is what most
+	// servers actually run with, and it must never end up in the
+	// advertised list that gets shipped to miren.cloud. A client reached
+	// via cloud can't connect to 0.0.0.0 or to loopback.
+	const wildcardListen = "0.0.0.0:8443"
 
-	localhost := []string{"0.0.0.0:8443", "127.0.0.1:8443", "[::1]:8443"}
+	// Addresses that must never appear in the advertised list for any
+	// case below, since a remote client reached via miren.cloud can't
+	// use them.
+	nonRoutable := []string{
+		"0.0.0.0:8443",
+		"[::]:8443",
+		"127.0.0.1:8443",
+		"[::1]:8443",
+	}
 
 	publicIPv4 := net.ParseIP("203.0.113.10")
 	publicIPv6 := net.ParseIP("2001:db8::10")
@@ -20,6 +32,7 @@ func TestApiAddresses(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		listenAddr     string
 		additionalIPs  []net.IP
 		discoveredIPs  []net.IP
 		netcheckResult *cloudauth.NetcheckDualStackResult
@@ -29,7 +42,7 @@ func TestApiAddresses(t *testing.T) {
 		{
 			name:          "no netcheck with discovered public IPs",
 			discoveredIPs: []net.IP{publicIPv4, privateIP},
-			wantContains:  append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+			wantContains:  []string{"203.0.113.10:8443", "10.0.0.5:8443"},
 		},
 		{
 			// MIR-1018: when netcheck ran with a valid public source IP
@@ -46,7 +59,7 @@ func TestApiAddresses(t *testing.T) {
 					},
 				},
 			},
-			wantContains: append(localhost, "10.0.0.5:8443"),
+			wantContains: []string{"10.0.0.5:8443"},
 			wantExcludes: []string{"203.0.113.10:8443"},
 		},
 		{
@@ -55,14 +68,14 @@ func TestApiAddresses(t *testing.T) {
 			name:           "netcheck not run keeps discovered public IPs",
 			discoveredIPs:  []net.IP{publicIPv4, privateIP},
 			netcheckResult: nil,
-			wantContains:   append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+			wantContains:   []string{"203.0.113.10:8443", "10.0.0.5:8443"},
 		},
 		{
 			// MIR-1018: CGNAT addresses (tailscale tailnet / ISP CGNAT)
 			// are filtered out of the discovered list by default.
 			name:          "CGNAT discovered IP is filtered",
 			discoveredIPs: []net.IP{net.ParseIP("100.107.209.9"), privateIP},
-			wantContains:  append(localhost, "10.0.0.5:8443"),
+			wantContains:  []string{"10.0.0.5:8443"},
 			wantExcludes:  []string{"100.107.209.9:8443"},
 		},
 		{
@@ -70,7 +83,7 @@ func TestApiAddresses(t *testing.T) {
 			// still set it as an AdditionalIP.
 			name:          "CGNAT AdditionalIP is kept",
 			additionalIPs: []net.IP{net.ParseIP("100.107.209.9")},
-			wantContains:  append(localhost, "100.107.209.9:8443"),
+			wantContains:  []string{"100.107.209.9:8443"},
 		},
 		{
 			name:          "netcheck ran and found reachable addresses",
@@ -83,11 +96,14 @@ func TestApiAddresses(t *testing.T) {
 					},
 				},
 			},
-			wantContains: append(localhost, "10.0.0.5:8443", "203.0.113.10:8443"),
+			wantContains: []string{"10.0.0.5:8443", "203.0.113.10:8443"},
 		},
 		{
-			name:         "no IPs and no netcheck",
-			wantContains: localhost,
+			// Nothing to advertise. Should produce an empty list, not
+			// a list of nonsense loopback / wildcard entries.
+			name:         "no IPs and no netcheck yields empty list",
+			wantContains: nil,
+			wantExcludes: nonRoutable,
 		},
 		{
 			name:          "netcheck replaces discovered public IP with different source",
@@ -100,7 +116,7 @@ func TestApiAddresses(t *testing.T) {
 					},
 				},
 			},
-			wantContains: append(localhost, "198.51.100.1:8443", "10.0.0.5:8443"),
+			wantContains: []string{"198.51.100.1:8443", "10.0.0.5:8443"},
 			wantExcludes: []string{"203.0.113.10:8443"},
 		},
 		{
@@ -120,7 +136,7 @@ func TestApiAddresses(t *testing.T) {
 					},
 				},
 			},
-			wantContains: append(localhost, "203.0.113.10:8443", "[2001:db8::1]:8443", "10.0.0.5:8443"),
+			wantContains: []string{"203.0.113.10:8443", "[2001:db8::1]:8443", "10.0.0.5:8443"},
 		},
 		{
 			name:          "dual-stack netcheck with only IPv4 reachable",
@@ -134,7 +150,7 @@ func TestApiAddresses(t *testing.T) {
 				},
 				IPv6: nil,
 			},
-			wantContains: append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+			wantContains: []string{"203.0.113.10:8443", "10.0.0.5:8443"},
 		},
 		{
 			name:          "user-provided AdditionalIPs always included even with netcheck",
@@ -148,8 +164,7 @@ func TestApiAddresses(t *testing.T) {
 					},
 				},
 			},
-			// User-provided public IP is always kept, netcheck address is also added
-			wantContains: append(localhost, "203.0.113.10:8443", "198.51.100.1:8443", "10.0.0.5:8443"),
+			wantContains: []string{"203.0.113.10:8443", "198.51.100.1:8443", "10.0.0.5:8443"},
 		},
 		{
 			name:          "mixed-family: IPv4 reachable, discovered IPv6 preserved",
@@ -163,20 +178,33 @@ func TestApiAddresses(t *testing.T) {
 				},
 				IPv6: nil,
 			},
-			// IPv4 discovered public IP is replaced by the netcheck-confirmed
-			// one. IPv6 netcheck didn't run, so we don't know whether the
-			// discovered IPv6 is reachable — keep it as a fallback on a
-			// per-family basis, same as we would if IPv4 netcheck had failed.
-			wantContains: append(localhost, "203.0.113.10:8443", "[2001:db8::10]:8443", "10.0.0.5:8443"),
-			wantExcludes: []string{},
+			wantContains: []string{"203.0.113.10:8443", "[2001:db8::10]:8443", "10.0.0.5:8443"},
+		},
+		{
+			// A non-wildcard, non-loopback listen address IS advertised,
+			// because it's a real routable bind.
+			name:         "explicit non-wildcard listen address is advertised",
+			listenAddr:   "198.51.100.7:8443",
+			wantContains: []string{"198.51.100.7:8443"},
+		},
+		{
+			// AdditionalIPs that are loopback/unspecified get rejected.
+			name:          "loopback AdditionalIP is dropped",
+			additionalIPs: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1"), net.ParseIP("0.0.0.0"), publicIPv4},
+			wantContains:  []string{"203.0.113.10:8443"},
+			wantExcludes:  nonRoutable,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			listen := tt.listenAddr
+			if listen == "" {
+				listen = wildcardListen
+			}
 			c := &Coordinator{
 				CoordinatorConfig: CoordinatorConfig{
-					Address:       listenAddr,
+					Address:       listen,
 					AdditionalIPs: tt.additionalIPs,
 					DiscoveredIPs: tt.discoveredIPs,
 				},
@@ -185,6 +213,13 @@ func TestApiAddresses(t *testing.T) {
 			}
 
 			got := c.apiAddresses()
+
+			// Non-routable addresses are NEVER advertised — assert
+			// this for every case, in addition to the per-case
+			// excludes.
+			for _, nr := range nonRoutable {
+				assert.NotContains(t, got, nr, "non-routable address %q must never be advertised", nr)
+			}
 
 			for _, want := range tt.wantContains {
 				assert.Contains(t, got, want, "expected %q in result", want)

--- a/components/coordinate/api_addresses_test.go
+++ b/components/coordinate/api_addresses_test.go
@@ -32,7 +32,11 @@ func TestApiAddresses(t *testing.T) {
 			wantContains:  append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
 		},
 		{
-			name:          "netcheck ran but found nothing reachable",
+			// MIR-1018: when netcheck ran with a valid public source IP
+			// but every probed port failed, we now trust the negative
+			// result and drop global-unicast discovered IPs in that
+			// family. Private LAN IPs are still kept.
+			name:          "netcheck proved IPv4 unreachable drops public discovered IP",
 			discoveredIPs: []net.IP{publicIPv4, privateIP},
 			netcheckResult: &cloudauth.NetcheckDualStackResult{
 				IPv4: &cloudauth.NetcheckResponse{
@@ -42,7 +46,31 @@ func TestApiAddresses(t *testing.T) {
 					},
 				},
 			},
-			wantContains: append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+			wantContains: append(localhost, "10.0.0.5:8443"),
+			wantExcludes: []string{"203.0.113.10:8443"},
+		},
+		{
+			// Netcheck failing entirely (e.g. no cloud connectivity) still
+			// lets discovered public IPs pass through as a fallback.
+			name:           "netcheck not run keeps discovered public IPs",
+			discoveredIPs:  []net.IP{publicIPv4, privateIP},
+			netcheckResult: nil,
+			wantContains:   append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
+		},
+		{
+			// MIR-1018: CGNAT addresses (tailscale tailnet / ISP CGNAT)
+			// are filtered out of the discovered list by default.
+			name:          "CGNAT discovered IP is filtered",
+			discoveredIPs: []net.IP{net.ParseIP("100.107.209.9"), privateIP},
+			wantContains:  append(localhost, "10.0.0.5:8443"),
+			wantExcludes:  []string{"100.107.209.9:8443"},
+		},
+		{
+			// Users who explicitly want a CGNAT address advertised can
+			// still set it as an AdditionalIP.
+			name:          "CGNAT AdditionalIP is kept",
+			additionalIPs: []net.IP{net.ParseIP("100.107.209.9")},
+			wantContains:  append(localhost, "100.107.209.9:8443"),
 		},
 		{
 			name:          "netcheck ran and found reachable addresses",
@@ -135,11 +163,12 @@ func TestApiAddresses(t *testing.T) {
 				},
 				IPv6: nil,
 			},
-			// IPv4 is replaced by netcheck, but discovered IPv6 is still public
-			// and gets dropped because netcheck had reachable results. This is
-			// acceptable: the IPv6 wasn't verified reachable, so we don't report it.
-			wantContains: append(localhost, "203.0.113.10:8443", "10.0.0.5:8443"),
-			wantExcludes: []string{"[2001:db8::10]:8443"},
+			// IPv4 discovered public IP is replaced by the netcheck-confirmed
+			// one. IPv6 netcheck didn't run, so we don't know whether the
+			// discovered IPv6 is reachable — keep it as a fallback on a
+			// per-family basis, same as we would if IPv4 netcheck had failed.
+			wantContains: append(localhost, "203.0.113.10:8443", "[2001:db8::10]:8443", "10.0.0.5:8443"),
+			wantExcludes: []string{},
 		},
 	}
 

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -97,8 +97,7 @@ type CoordinatorConfig struct {
 	TempDir         string              `json:"temp_dir" yaml:"temp_dir"`
 	DataPath        string              `json:"data_path" yaml:"data_path"`
 	AdditionalNames []string            `json:"additional_names" yaml:"additional_names"`
-	AdditionalIPs   []net.IP            `json:"additional_ips" yaml:"additional_ips"`
-	DiscoveredIPs   []net.IP            `json:"discovered_ips" yaml:"discovered_ips"`
+	IPs             *IPSet              `json:"ips" yaml:"ips"`
 
 	// ACME certificate configuration
 	AcmeEmail       string `json:"acme_email" yaml:"acme_email"`
@@ -477,8 +476,7 @@ func (c *Coordinator) LoadAPICert(ctx context.Context) error {
 		net.ParseIP("::1"),
 	}
 
-	ips = append(ips, c.AdditionalIPs...)
-	ips = append(ips, c.DiscoveredIPs...)
+	ips = append(ips, c.IPs.RawIPs()...)
 
 	cert := filepath.Join(c.DataPath, "server", "api.crt")
 	keyPath := filepath.Join(c.DataPath, "server", "api.key")
@@ -1297,7 +1295,8 @@ func (c *Coordinator) PublicIPs() []net.IP {
 	}
 
 	if len(ips) == 0 {
-		for _, ip := range append(c.AdditionalIPs, c.DiscoveredIPs...) {
+		for _, sip := range c.IPs.All() {
+			ip := sip.IP
 			if ip == nil || !ip.IsGlobalUnicast() || ip.IsPrivate() {
 				continue
 			}
@@ -1321,22 +1320,21 @@ func (c *Coordinator) apiAddresses() []string {
 	c.netcheckMu.RUnlock()
 
 	_, final := ComputeAdvertise(AdvertiseInput{
-		ListenAddr:    c.Address,
-		AdditionalIPs: c.AdditionalIPs,
-		DiscoveredIPs: c.DiscoveredIPs,
-		Netcheck:      netcheck,
+		ListenAddr: c.Address,
+		IPs:        c.IPs.All(),
+		Netcheck:   netcheck,
 	})
 
 	c.logAddressesOnce.Do(func() {
-		additional := []string{}
-		for _, ip := range c.AdditionalIPs {
-			additional = append(additional, ip.String())
+		var explicit, discovered []string
+		for _, sip := range c.IPs.All() {
+			if sip.Explicit {
+				explicit = append(explicit, sip.IP.String())
+			} else {
+				discovered = append(discovered, sip.IP.String())
+			}
 		}
-		discovered := []string{}
-		for _, ip := range c.DiscoveredIPs {
-			discovered = append(discovered, ip.String())
-		}
-		c.Log.Info("reporting API addresses", "listen", c.Address, "configured", additional, "discovered", discovered, "result", final)
+		c.Log.Info("reporting API addresses", "listen", c.Address, "configured", explicit, "discovered", discovered, "result", final)
 	})
 
 	return final

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1270,43 +1269,6 @@ func (c *Coordinator) runNetcheck(ctx context.Context) {
 	}
 }
 
-// publicAddresses returns addresses derived from the cached dual-stack netcheck result.
-// Returns nil if no netcheck has been done or the cluster isn't publicly reachable.
-func (c *Coordinator) publicAddresses() []string {
-	c.netcheckMu.RLock()
-	result := c.netcheckResult
-	c.netcheckMu.RUnlock()
-
-	if result == nil {
-		return nil
-	}
-
-	seen := make(map[string]struct{})
-	var addrs []string
-
-	for _, resp := range []*cloudauth.NetcheckResponse{result.IPv4, result.IPv6} {
-		if resp == nil || resp.SourceAddress == "" {
-			continue
-		}
-		if net.ParseIP(resp.SourceAddress) == nil {
-			continue
-		}
-		for _, r := range resp.Results {
-			if !r.Reachable {
-				continue
-			}
-			hp := net.JoinHostPort(resp.SourceAddress, strconv.Itoa(r.Port))
-			if _, ok := seen[hp]; ok {
-				continue
-			}
-			seen[hp] = struct{}{}
-			addrs = append(addrs, hp)
-		}
-	}
-
-	return addrs
-}
-
 // PublicIPs returns the cluster's known public IP addresses from netcheck,
 // falling back to user-provided AdditionalIPs and auto-discovered IPs
 // (filtered to global unicast, non-private) if netcheck hasn't run yet.
@@ -1350,39 +1312,20 @@ func (c *Coordinator) PublicIPs() []net.IP {
 	return ips
 }
 
-// apiAddresses builds the list of API addresses for status reports.
-// User-provided AdditionalIPs are always included. For auto-discovered IPs,
-// netcheck results replace discovered public IPs when reachable addresses
-// are found. If netcheck ran but found nothing reachable, discovered public
-// IPs are kept as a fallback.
+// apiAddresses builds the list of API addresses the server should advertise.
+// The heavy lifting lives in ComputeAdvertise so the same rules can be
+// exercised by the 'miren debug advertise' command.
 func (c *Coordinator) apiAddresses() []string {
-	var addrs []string
+	c.netcheckMu.RLock()
+	netcheck := c.netcheckResult
+	c.netcheckMu.RUnlock()
 
-	// Only include c.Address if it contains a valid IP host.
-	if host, _, err := net.SplitHostPort(c.Address); err == nil && net.ParseIP(host) != nil {
-		addrs = append(addrs, c.Address)
-	}
-
-	// Add localhost addresses
-	addrs = append(addrs, "127.0.0.1:8443", "[::1]:8443")
-
-	// User-provided IPs are always included.
-	for _, ip := range c.AdditionalIPs {
-		addrs = append(addrs, net.JoinHostPort(ip.String(), "8443"))
-	}
-
-	// For discovered IPs, netcheck results replace discovered public IPs
-	// when netcheck found reachable addresses. If netcheck ran but found
-	// nothing reachable (e.g., firewalled), keep discovered public IPs
-	// as a fallback.
-	pubAddrs := c.publicAddresses()
-	for _, ip := range c.DiscoveredIPs {
-		if len(pubAddrs) > 0 && !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
-			continue
-		}
-		addrs = append(addrs, net.JoinHostPort(ip.String(), "8443"))
-	}
-	addrs = append(addrs, pubAddrs...)
+	_, final := ComputeAdvertise(AdvertiseInput{
+		ListenAddr:    c.Address,
+		AdditionalIPs: c.AdditionalIPs,
+		DiscoveredIPs: c.DiscoveredIPs,
+		Netcheck:      netcheck,
+	})
 
 	c.logAddressesOnce.Do(func() {
 		additional := []string{}
@@ -1393,10 +1336,10 @@ func (c *Coordinator) apiAddresses() []string {
 		for _, ip := range c.DiscoveredIPs {
 			discovered = append(discovered, ip.String())
 		}
-		c.Log.Info("reporting API addresses", "listen", c.Address, "configured", additional, "discovered", discovered, "result", addrs)
+		c.Log.Info("reporting API addresses", "listen", c.Address, "configured", additional, "discovered", discovered, "result", final)
 	})
 
-	return addrs
+	return final
 }
 
 // ReportStatus reports the current cluster status to miren.cloud

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -101,6 +101,7 @@
       "id": "command/debug"
     },
     "items": [
+      "command/debug-advertise",
       "command/debug-bundle",
       "command/debug-colors",
       "command/debug-connection",

--- a/docs/docs/command/debug-advertise.md
+++ b/docs/docs/command/debug-advertise.md
@@ -1,0 +1,32 @@
+---
+title: "miren debug advertise"
+sidebar_label: "debug advertise"
+description: "Show which addresses the server would advertise and why"
+---
+
+# miren debug advertise
+
+Show which addresses the server would advertise and why
+
+## Usage
+
+```bash
+miren debug advertise [flags]
+```
+
+## Flags
+
+- `--additional-ip` — Simulate a server-configured AdditionalIP (repeatable)
+- `--cloud-url` — Cloud URL to use for netcheck (default: https://api.miren.cloud)
+- `--listen` — Simulate the server's listen address (default: 0.0.0.0:8443)
+- `--skip-netcheck` — Skip the netcheck call and only report interface scan
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## See also
+
+- [`miren debug`](/command/debug)

--- a/docs/docs/command/debug.md
+++ b/docs/docs/command/debug.md
@@ -16,6 +16,7 @@ miren debug [flags]
 
 ## Subcommands
 
+- [`miren debug advertise`](/command/debug-advertise) — Show which addresses the server would advertise and why
 - [`miren debug bundle`](/command/debug-bundle) — Create a support bundle with system debug information
 - [`miren debug colors`](/command/debug-colors) — Print some colors
 - [`miren debug connection`](/command/debug-connection) — Test connectivity and authentication with a server

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -267,6 +267,7 @@ These commands are intended for advanced debugging and troubleshooting. They may
 | Command | Description |
 |---------|-------------|
 | [`miren debug`](/command/debug) | Debug and troubleshooting commands |
+| [`miren debug advertise`](/command/debug-advertise) | Show which addresses the server would advertise and why |
 | [`miren debug bundle`](/command/debug-bundle) | Create a support bundle with system debug information |
 | [`miren debug colors`](/command/debug-colors) | Print some colors |
 | [`miren debug connection`](/command/debug-connection) | Test connectivity and authentication with a server |


### PR DESCRIPTION
Opening this on Evan's behalf since the branch has been sitting since April 15. Original commits are his (`dd03230d` "Fix MIR-1018" and `8eb63ab` "Add 'debug advertise' command"); I'm just turning the crank after rediscovering the same bug as MIR-1139.

Two problems addressed.

The advertise-address logic in `coordinate.apiAddresses` was treating "netcheck ran but found zero reachable" as identical to "netcheck didn't run at all" and falling back to discovered IPs in both cases. That fallback would push the WAN IP of a firewalled cluster (or a tailnet address from `tailscale0`) into the status report, and cloud would happily write A records to those unreachable IPs instead of routing through POP. Per-family state fixes this: an IPv4 success no longer silently drops discovered IPv6 public addresses, and a per-family "ran and found nothing" verdict is now trusted rather than papered over.

Addresses in 100.64.0.0/10 (RFC 6598) are also filtered out of the discovered list by default. This range is used by Tailscale and by ISP CGNAT, neither of which is reachable from a generic external client. Users who genuinely want a CGNAT address advertised can set it explicitly via `AdditionalIPs`, which passes through unfiltered.

The logic itself was factored into a pure `ComputeAdvertise` function so the production path and the `debug advertise` command share the same decision tree. That makes the debug command actually useful for diagnosing "why is my cluster advertising X" without needing to start a full coordinator.

Closes MIR-1018
Closes MIR-1139 (duplicate)