### PR TITLE
Detect and install npm/bun automatically (MIR-1132)

### DIFF
--- a/pkg/stackbuild/augment.go
+++ b/pkg/stackbuild/augment.go
@@ -16,8 +16,9 @@ import (
 type Augmentation string
 
 const (
-	AugNpm Augmentation = "npm"
-	AugBun Augmentation = "bun"
+	AugNpm  Augmentation = "npm"
+	AugYarn Augmentation = "yarn"
+	AugBun  Augmentation = "bun"
 )
 
 // DetectAugmentations returns the set of augmentations needed for the app
@@ -42,15 +43,23 @@ func DetectAugmentations(dir, primaryStack string) (augs []Augmentation, skipIns
 	}
 
 	if hasRegularFile(dir, "package.json") {
-		augs = append(augs, AugNpm)
 		switch {
+		case hasRegularFile(dir, "yarn.lock"):
+			augs = append(augs, AugYarn)
+			events = append(events, DetectionEvent{
+				Kind:    "augmentation",
+				Name:    "yarn",
+				Message: "Found yarn.lock — installing yarn via corepack",
+			})
 		case hasRegularFile(dir, "package-lock.json"):
+			augs = append(augs, AugNpm)
 			events = append(events, DetectionEvent{
 				Kind:    "augmentation",
 				Name:    "npm",
 				Message: "Found package-lock.json — installing npm",
 			})
 		default:
+			augs = append(augs, AugNpm)
 			events = append(events, DetectionEvent{
 				Kind:    "augmentation",
 				Name:    "npm",
@@ -138,6 +147,11 @@ func (h *highlevelBuilder) applyAugmentations(cur, localCtx llb.State, distro st
 			if !skipInstall {
 				cur = h.runNpmInstall(cur, localCtx)
 			}
+		case AugYarn:
+			cur = h.installYarn(cur, distro)
+			if !skipInstall {
+				cur = h.runYarnInstall(cur, localCtx)
+			}
 		case AugBun:
 			cur = h.installBun(cur)
 			if !skipInstall {
@@ -146,6 +160,17 @@ func (h *highlevelBuilder) applyAugmentations(cur, localCtx llb.State, distro st
 		}
 	}
 	return cur
+}
+
+// installYarn layers nodejs+npm and enables corepack so the yarn shim is on
+// PATH. Yarn itself is provisioned lazily by corepack from package.json's
+// "packageManager" field (or falls back to classic yarn 1).
+func (h *highlevelBuilder) installYarn(cur llb.State, distro string) llb.State {
+	cur = h.installNpm(cur, distro)
+	return cur.Run(
+		llb.Shlex("corepack enable"),
+		llb.WithCustomName("[phase] Enabling corepack for yarn"),
+	).State
 }
 
 // ensureAppDir creates /app owned by the app user so the install can run
@@ -169,7 +194,7 @@ func (h *highlevelBuilder) runNpmInstall(cur, mnt llb.State) llb.State {
 	cur = h.ensureAppDir(cur)
 
 	cur = cur.File(llb.Copy(mnt, "/", "/app", &llb.CopyInfo{
-		IncludePatterns:    []string{"package.json", "package-lock.json", "yarn.lock"},
+		IncludePatterns:    []string{"package.json", "package-lock.json"},
 		CreateDestPath:     true,
 		AllowWildcard:      true,
 		AllowEmptyWildcard: true,
@@ -181,6 +206,29 @@ func (h *highlevelBuilder) runNpmInstall(cur, mnt llb.State) llb.State {
 		llb.AddEnv("HOME", "/home/app"),
 		llb.User("app"),
 		llb.WithCustomName("[phase] Installing JS deps with npm augmentation"),
+	).State
+}
+
+// runYarnInstall copies yarn package files into /app and runs yarn install as
+// the app user. COREPACK_ENABLE_DOWNLOAD_PROMPT silences the interactive
+// download prompt newer corepack versions emit when fetching a yarn release.
+func (h *highlevelBuilder) runYarnInstall(cur, mnt llb.State) llb.State {
+	cur = h.ensureAppDir(cur)
+
+	cur = cur.File(llb.Copy(mnt, "/", "/app", &llb.CopyInfo{
+		IncludePatterns:    []string{"package.json", "yarn.lock", ".yarnrc", ".yarnrc.yml"},
+		CreateDestPath:     true,
+		AllowWildcard:      true,
+		AllowEmptyWildcard: true,
+		ChownOpt:           &appChown,
+	}), llb.WithCustomName("copy yarn package files"))
+
+	return cur.Dir("/app").Run(
+		llb.Shlex("yarn install"),
+		llb.AddEnv("HOME", "/home/app"),
+		llb.AddEnv("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0"),
+		llb.User("app"),
+		llb.WithCustomName("[phase] Installing JS deps with yarn augmentation"),
 	).State
 }
 

--- a/pkg/stackbuild/augment.go
+++ b/pkg/stackbuild/augment.go
@@ -42,8 +42,13 @@ func DetectAugmentations(dir, primaryStack string) (augs []Augmentation, skipIns
 		return nil, false, nil
 	}
 
+	hasBunLock := hasRegularFile(dir, "bun.lock") || hasRegularFile(dir, "bun.lockb")
+
 	if hasRegularFile(dir, "package.json") {
 		switch {
+		case hasBunLock:
+			// Bun owns the install path below; don't also run npm install on
+			// a bun-managed manifest.
 		case hasRegularFile(dir, "yarn.lock"):
 			augs = append(augs, AugYarn)
 			events = append(events, DetectionEvent{
@@ -68,7 +73,7 @@ func DetectAugmentations(dir, primaryStack string) (augs []Augmentation, skipIns
 		}
 	}
 
-	if hasRegularFile(dir, "bun.lock") || hasRegularFile(dir, "bun.lockb") {
+	if hasBunLock {
 		augs = append(augs, AugBun)
 		events = append(events, DetectionEvent{
 			Kind:    "augmentation",
@@ -215,8 +220,16 @@ func (h *highlevelBuilder) runNpmInstall(cur, mnt llb.State) llb.State {
 func (h *highlevelBuilder) runYarnInstall(cur, mnt llb.State) llb.State {
 	cur = h.ensureAppDir(cur)
 
+	// Yarn Berry projects pin a yarn release via `yarnPath` in .yarnrc.yml,
+	// and yarnPath takes precedence over corepack. Include .yarn/releases,
+	// plugins, and patches so pinned binaries / plugins / patches are
+	// present during install.
 	cur = cur.File(llb.Copy(mnt, "/", "/app", &llb.CopyInfo{
-		IncludePatterns:    []string{"package.json", "yarn.lock", ".yarnrc", ".yarnrc.yml"},
+		IncludePatterns: []string{
+			"package.json", "yarn.lock",
+			".yarnrc", ".yarnrc.yml",
+			".yarn/releases/**", ".yarn/plugins/**", ".yarn/patches/**",
+		},
 		CreateDestPath:     true,
 		AllowWildcard:      true,
 		AllowEmptyWildcard: true,

--- a/pkg/stackbuild/augment.go
+++ b/pkg/stackbuild/augment.go
@@ -1,0 +1,206 @@
+package stackbuild
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/moby/buildkit/client/llb"
+	"miren.dev/runtime/pkg/imagerefs"
+)
+
+// Augmentation represents a secondary toolchain layered onto the primary stack's
+// base image. Augmentations are detected from lockfiles in the app directory
+// (e.g. package-lock.json -> npm) and let apps written in one language pull in
+// auxiliary build tooling — most commonly JS package managers used to build
+// frontend assets for a Rails/Django/Go web app.
+type Augmentation string
+
+const (
+	AugNpm Augmentation = "npm"
+	AugBun Augmentation = "bun"
+)
+
+// DetectAugmentations returns the set of augmentations needed for the app
+// located at dir, given the primary stack that was already selected.
+//
+// It returns nil (no augmentations) when the primary stack is "node" or "bun",
+// since those stacks already ship npm or bun in their base image. The returned
+// events describe what was detected so they can be surfaced alongside primary
+// stack detection events in the build output.
+//
+// npm is triggered by the presence of package.json (not just package-lock.json),
+// to preserve compatibility with apps — most notably Rails — that ship a
+// package.json for asset pipelines without committing a lockfile.
+//
+// skipInstall is true when the app already ships a node_modules directory — in
+// that case the JS tooling (npm/bun) is still installed so onBuild commands
+// can use it, but the package install step is skipped because the user's
+// vendored node_modules will be brought in by copyApp.
+func DetectAugmentations(dir, primaryStack string) (augs []Augmentation, skipInstall bool, events []DetectionEvent) {
+	if primaryStack == "node" || primaryStack == "bun" {
+		return nil, false, nil
+	}
+
+	if hasRegularFile(dir, "package.json") {
+		augs = append(augs, AugNpm)
+		switch {
+		case hasRegularFile(dir, "package-lock.json"):
+			events = append(events, DetectionEvent{
+				Kind:    "augmentation",
+				Name:    "npm",
+				Message: "Found package-lock.json — installing npm",
+			})
+		default:
+			events = append(events, DetectionEvent{
+				Kind:    "augmentation",
+				Name:    "npm",
+				Message: "Found package.json — installing npm",
+			})
+		}
+	}
+
+	if hasRegularFile(dir, "bun.lock") || hasRegularFile(dir, "bun.lockb") {
+		augs = append(augs, AugBun)
+		events = append(events, DetectionEvent{
+			Kind:    "augmentation",
+			Name:    "bun",
+			Message: "Found bun lockfile — installing bun",
+		})
+	}
+
+	if len(augs) > 0 && hasDir(dir, "node_modules") {
+		skipInstall = true
+		events = append(events, DetectionEvent{
+			Kind:    "augmentation",
+			Name:    "node_modules",
+			Message: "Vendored node_modules detected — skipping JS install",
+		})
+	}
+
+	return augs, skipInstall, events
+}
+
+func hasRegularFile(dir, name string) bool {
+	st, err := os.Stat(filepath.Join(dir, name))
+	return err == nil && st.Mode().IsRegular()
+}
+
+func hasDir(dir, name string) bool {
+	st, err := os.Stat(filepath.Join(dir, name))
+	return err == nil && st.IsDir()
+}
+
+// installNpm layers nodejs+npm onto cur using the package manager appropriate
+// for the given base distro.
+func (h *highlevelBuilder) installNpm(cur llb.State, distro string) llb.State {
+	switch distro {
+	case "alpine":
+		return cur.Run(
+			llb.Shlex("apk add --no-cache nodejs npm"),
+			h.CacheMount("/var/cache/apk"),
+			llb.WithCustomName("[phase] Installing npm augmentation"),
+		).State
+	default:
+		return cur.Run(
+			llb.Shlex("sh -c 'apt-get update && apt-get install -y nodejs npm'"),
+			h.CacheMount("/var/lib/apt/lists"),
+			h.CacheMount("/var/cache/apt/archives"),
+			llb.WithCustomName("[phase] Installing npm augmentation"),
+		).State
+	}
+}
+
+// installBun copies the bun binary from the official bun image. Distro-agnostic
+// because bun ships as a single static binary.
+func (h *highlevelBuilder) installBun(cur llb.State) llb.State {
+	bunImg := llb.Image(imagerefs.GetBunImage("1"))
+	return cur.File(
+		llb.Copy(bunImg, "/usr/local/bin/bun", "/usr/local/bin/bun", &llb.CopyInfo{
+			FollowSymlinks: true,
+		}),
+		llb.WithCustomName("[phase] Installing bun augmentation"),
+	)
+}
+
+// applyAugmentations layers all requested augmentations onto cur in order:
+// install the tool, and (unless skipInstall is true) run its package install
+// against the lockfiles from localCtx so JS deps are available during
+// subsequent build phases (asset precompile, onBuild, etc).
+//
+// When skipInstall is true the user already ships a node_modules directory;
+// we install the tool (so onBuild can shell out to npm/bun) but leave the
+// vendored node_modules to flow in via copyApp.
+func (h *highlevelBuilder) applyAugmentations(cur, localCtx llb.State, distro string, augs []Augmentation, skipInstall bool) llb.State {
+	for _, aug := range augs {
+		switch aug {
+		case AugNpm:
+			cur = h.installNpm(cur, distro)
+			if !skipInstall {
+				cur = h.runNpmInstall(cur, localCtx)
+			}
+		case AugBun:
+			cur = h.installBun(cur)
+			if !skipInstall {
+				cur = h.runBunInstall(cur, localCtx)
+			}
+		}
+	}
+	return cur
+}
+
+// ensureAppDir creates /app owned by the app user so the install can run
+// unprivileged.
+func (h *highlevelBuilder) ensureAppDir(cur llb.State) llb.State {
+	return cur.File(llb.Mkdir("/app", 0755,
+		llb.WithParents(true),
+		llb.WithUIDGID(2010, 2011),
+	))
+}
+
+// runNpmInstall copies JS package files into /app and runs npm install as the
+// app user.
+//
+// No persistent cache mount: BuildKit's cache mount root is root-owned
+// (it comes from the scratch state's root, not a subdir we create), so an
+// unprivileged npm install can't write to it. The pragmatic fix is to skip
+// the cache — the per-layer cache still avoids re-running this step when
+// package files don't change.
+func (h *highlevelBuilder) runNpmInstall(cur, mnt llb.State) llb.State {
+	cur = h.ensureAppDir(cur)
+
+	cur = cur.File(llb.Copy(mnt, "/", "/app", &llb.CopyInfo{
+		IncludePatterns:    []string{"package.json", "package-lock.json", "yarn.lock"},
+		CreateDestPath:     true,
+		AllowWildcard:      true,
+		AllowEmptyWildcard: true,
+		ChownOpt:           &appChown,
+	}), llb.WithCustomName("copy npm package files"))
+
+	return cur.Dir("/app").Run(
+		llb.Shlex("npm install"),
+		llb.AddEnv("HOME", "/home/app"),
+		llb.User("app"),
+		llb.WithCustomName("[phase] Installing JS deps with npm augmentation"),
+	).State
+}
+
+// runBunInstall copies bun package files into /app and runs bun install as the
+// app user. See runNpmInstall for the cache-mount rationale.
+func (h *highlevelBuilder) runBunInstall(cur, mnt llb.State) llb.State {
+	cur = h.ensureAppDir(cur)
+
+	cur = cur.File(llb.Copy(mnt, "/", "/app", &llb.CopyInfo{
+		IncludePatterns:    []string{"package.json", "bun.lock", "bun.lockb"},
+		CreateDestPath:     true,
+		AllowWildcard:      true,
+		AllowEmptyWildcard: true,
+		ChownOpt:           &appChown,
+	}), llb.WithCustomName("copy bun package files"))
+
+	return cur.Dir("/app").Run(
+		llb.Shlex("bun install"),
+		llb.AddEnv("HOME", "/home/app"),
+		llb.User("app"),
+		llb.WithCustomName("[phase] Installing JS deps with bun augmentation"),
+	).State
+}

--- a/pkg/stackbuild/augment_test.go
+++ b/pkg/stackbuild/augment_test.go
@@ -46,6 +46,33 @@ func TestDetectAugmentations_NpmFromPackageJsonOnly(t *testing.T) {
 	require.Contains(t, events[0].Message, "package.json")
 }
 
+func TestDetectAugmentations_YarnFromLock(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json": `{"name":"frontend"}`,
+		"yarn.lock":    ``,
+	})
+
+	augs, skipInstall, events := DetectAugmentations(dir, "ruby")
+	require.False(t, skipInstall)
+	require.Equal(t, []Augmentation{AugYarn}, augs)
+	require.Len(t, events, 1)
+	require.Equal(t, "yarn", events[0].Name)
+	require.Contains(t, events[0].Message, "yarn.lock")
+}
+
+func TestDetectAugmentations_YarnWinsOverPackageLock(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json":      `{"name":"frontend"}`,
+		"yarn.lock":         ``,
+		"package-lock.json": `{}`,
+	})
+
+	augs, _, _ := DetectAugmentations(dir, "ruby")
+	require.Equal(t, []Augmentation{AugYarn}, augs, "yarn.lock should win when both lockfiles exist")
+}
+
 func TestDetectAugmentations_BunFromLock(t *testing.T) {
 	dir := t.TempDir()
 	writeFiles(t, dir, map[string]string{
@@ -152,8 +179,7 @@ func TestDetectStack_AttachesAugmentationsToPython(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "python", stack.Name())
 
-	ms, ok := metaStackOf(stack)
-	require.True(t, ok)
+	ms := stack.metaStack()
 	require.Equal(t, []Augmentation{AugNpm}, ms.Augmentations())
 
 	hasAugmentationEvent := false
@@ -177,8 +203,7 @@ func TestDetectStack_NoAugmentationForNode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "node", stack.Name())
 
-	ms, ok := metaStackOf(stack)
-	require.True(t, ok)
+	ms := stack.metaStack()
 	require.Nil(t, ms.Augmentations())
 }
 
@@ -194,8 +219,7 @@ func TestDetectStack_SkipInstallWhenNodeModulesPresent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "python", stack.Name())
 
-	ms, ok := metaStackOf(stack)
-	require.True(t, ok)
+	ms := stack.metaStack()
 	require.Equal(t, []Augmentation{AugNpm}, ms.Augmentations())
 	require.True(t, ms.SkipJSInstall())
 }
@@ -212,8 +236,7 @@ func TestDetectStack_AttachesAugmentationsToGo(t *testing.T) {
 	require.Equal(t, "go", stack.Name())
 	require.Equal(t, "alpine", stack.BaseDistro())
 
-	ms, ok := metaStackOf(stack)
-	require.True(t, ok)
+	ms := stack.metaStack()
 	require.Equal(t, []Augmentation{AugNpm}, ms.Augmentations())
 }
 

--- a/pkg/stackbuild/augment_test.go
+++ b/pkg/stackbuild/augment_test.go
@@ -81,7 +81,19 @@ func TestDetectAugmentations_BunFromLock(t *testing.T) {
 	})
 
 	augs, _, _ := DetectAugmentations(dir, "ruby")
-	require.Equal(t, []Augmentation{AugNpm, AugBun}, augs)
+	require.Equal(t, []Augmentation{AugBun}, augs, "bun owns install when bun.lock is present; npm should not also run")
+}
+
+func TestDetectAugmentations_BunWinsOverPackageLock(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json":      `{"name":"frontend"}`,
+		"package-lock.json": `{}`,
+		"bun.lockb":         ``,
+	})
+
+	augs, _, _ := DetectAugmentations(dir, "ruby")
+	require.Equal(t, []Augmentation{AugBun}, augs, "bun should win even when package-lock.json is present")
 }
 
 func TestDetectAugmentations_BunFromLockb(t *testing.T) {

--- a/pkg/stackbuild/augment_test.go
+++ b/pkg/stackbuild/augment_test.go
@@ -1,0 +1,235 @@
+package stackbuild
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	}
+}
+
+func TestDetectAugmentations_NpmFromPackageLock(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json":      `{"name":"frontend"}`,
+		"package-lock.json": `{}`,
+	})
+
+	augs, skipInstall, events := DetectAugmentations(dir, "python")
+	require.False(t, skipInstall)
+	require.Equal(t, []Augmentation{AugNpm}, augs)
+	require.Len(t, events, 1)
+	require.Equal(t, "augmentation", events[0].Kind)
+	require.Equal(t, "npm", events[0].Name)
+	require.Contains(t, events[0].Message, "package-lock.json")
+}
+
+func TestDetectAugmentations_NpmFromPackageJsonOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json": `{"name":"frontend"}`,
+	})
+
+	augs, skipInstall, events := DetectAugmentations(dir, "ruby")
+	require.False(t, skipInstall)
+	require.Equal(t, []Augmentation{AugNpm}, augs)
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].Message, "package.json")
+}
+
+func TestDetectAugmentations_BunFromLock(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json": `{"name":"frontend"}`,
+		"bun.lock":     ``,
+	})
+
+	augs, _, _ := DetectAugmentations(dir, "ruby")
+	require.Equal(t, []Augmentation{AugNpm, AugBun}, augs)
+}
+
+func TestDetectAugmentations_BunFromLockb(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"bun.lockb": ``,
+	})
+
+	augs, skipInstall, events := DetectAugmentations(dir, "go")
+	require.False(t, skipInstall)
+	require.Equal(t, []Augmentation{AugBun}, augs)
+	require.Len(t, events, 1)
+	require.Equal(t, "bun", events[0].Name)
+}
+
+func TestDetectAugmentations_SkipForNode(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json":      `{"name":"app"}`,
+		"package-lock.json": `{}`,
+		"bun.lock":          ``,
+	})
+
+	augs, skipInstall, events := DetectAugmentations(dir, "node")
+	require.Nil(t, augs)
+	require.False(t, skipInstall)
+	require.Nil(t, events)
+}
+
+func TestDetectAugmentations_SkipForBun(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json": `{"name":"app"}`,
+		"bun.lock":     ``,
+	})
+
+	augs, _, events := DetectAugmentations(dir, "bun")
+	require.Nil(t, augs)
+	require.Nil(t, events)
+}
+
+func TestDetectAugmentations_NoneWithoutLockfiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"go.mod": `module example.com/app`,
+	})
+
+	augs, _, _ := DetectAugmentations(dir, "go")
+	require.Nil(t, augs)
+}
+
+func TestDetectAugmentations_SkipInstallWhenNodeModulesPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json":              `{"name":"frontend"}`,
+		"package-lock.json":         `{}`,
+		"node_modules/.keep":        ``,
+		"node_modules/foo/index.js": ``,
+	})
+
+	augs, skipInstall, events := DetectAugmentations(dir, "ruby")
+	require.Equal(t, []Augmentation{AugNpm}, augs, "tool should still be installed")
+	require.True(t, skipInstall, "JS install should be skipped when node_modules is present")
+
+	var sawSkipEvent bool
+	for _, e := range events {
+		if e.Name == "node_modules" {
+			sawSkipEvent = true
+		}
+	}
+	require.True(t, sawSkipEvent, "expected node_modules skip event")
+}
+
+func TestDetectAugmentations_NoSkipWhenNoLockfiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"go.mod":             `module example.com/app`,
+		"node_modules/.keep": ``,
+	})
+
+	augs, skipInstall, _ := DetectAugmentations(dir, "go")
+	require.Nil(t, augs)
+	require.False(t, skipInstall, "skipInstall is only relevant when there's something to skip")
+}
+
+func TestDetectStack_AttachesAugmentationsToPython(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"requirements.txt":  `flask==2.0`,
+		"package.json":      `{"name":"frontend"}`,
+		"package-lock.json": `{}`,
+	})
+
+	stack, err := DetectStack(dir, BuildOptions{Name: "test"})
+	require.NoError(t, err)
+	require.Equal(t, "python", stack.Name())
+
+	ms, ok := metaStackOf(stack)
+	require.True(t, ok)
+	require.Equal(t, []Augmentation{AugNpm}, ms.Augmentations())
+
+	hasAugmentationEvent := false
+	for _, e := range stack.Events() {
+		if e.Kind == "augmentation" && e.Name == "npm" {
+			hasAugmentationEvent = true
+			break
+		}
+	}
+	require.True(t, hasAugmentationEvent, "expected augmentation event in stack Events()")
+}
+
+func TestDetectStack_NoAugmentationForNode(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json":      `{"name":"app"}`,
+		"package-lock.json": `{}`,
+	})
+
+	stack, err := DetectStack(dir, BuildOptions{Name: "test"})
+	require.NoError(t, err)
+	require.Equal(t, "node", stack.Name())
+
+	ms, ok := metaStackOf(stack)
+	require.True(t, ok)
+	require.Nil(t, ms.Augmentations())
+}
+
+func TestDetectStack_SkipInstallWhenNodeModulesPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"requirements.txt":   `flask==2.0`,
+		"package.json":       `{"name":"frontend"}`,
+		"node_modules/.keep": ``,
+	})
+
+	stack, err := DetectStack(dir, BuildOptions{Name: "test"})
+	require.NoError(t, err)
+	require.Equal(t, "python", stack.Name())
+
+	ms, ok := metaStackOf(stack)
+	require.True(t, ok)
+	require.Equal(t, []Augmentation{AugNpm}, ms.Augmentations())
+	require.True(t, ms.SkipJSInstall())
+}
+
+func TestDetectStack_AttachesAugmentationsToGo(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"go.mod":       "module example.com/app\n\ngo 1.23\n",
+		"package.json": `{"name":"frontend"}`,
+	})
+
+	stack, err := DetectStack(dir, BuildOptions{Name: "test"})
+	require.NoError(t, err)
+	require.Equal(t, "go", stack.Name())
+	require.Equal(t, "alpine", stack.BaseDistro())
+
+	ms, ok := metaStackOf(stack)
+	require.True(t, ok)
+	require.Equal(t, []Augmentation{AugNpm}, ms.Augmentations())
+}
+
+func TestBaseDistros(t *testing.T) {
+	cases := []struct {
+		stack  Stack
+		distro string
+	}{
+		{&RubyStack{}, "debian"},
+		{&PythonStack{}, "debian"},
+		{&NodeStack{}, "debian"},
+		{&BunStack{}, "debian"},
+		{&RustStack{}, "debian"},
+		{&GoStack{}, "alpine"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.distro, c.stack.BaseDistro(), "%s base distro", c.stack.Name())
+	}
+}

--- a/pkg/stackbuild/bun.go
+++ b/pkg/stackbuild/bun.go
@@ -46,6 +46,10 @@ type BunStack struct {
 	requiredEnvVars []EnvVarRequirement
 }
 
+func (s *BunStack) BaseDistro() string {
+	return "debian"
+}
+
 func (s *BunStack) Name() string {
 	return "bun"
 }

--- a/pkg/stackbuild/golang.go
+++ b/pkg/stackbuild/golang.go
@@ -76,6 +76,10 @@ type GoStack struct {
 	requiredEnvVars []EnvVarRequirement
 }
 
+func (s *GoStack) BaseDistro() string {
+	return "alpine"
+}
+
 func (s *GoStack) Name() string {
 	return "go"
 }
@@ -196,6 +200,8 @@ func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
 
 	// Add app user before copying code so copyApp can set ownership
 	state = s.addAppUser(state)
+
+	state = h.applyAugmentations(state, localCtx, s.BaseDistro(), s.Augmentations(), s.SkipJSInstall())
 
 	// Copy the application code (now owned by app user)
 	appState := h.copyApp(state, localCtx)

--- a/pkg/stackbuild/node.go
+++ b/pkg/stackbuild/node.go
@@ -84,6 +84,10 @@ type NodeStack struct {
 	requiredEnvVars []EnvVarRequirement
 }
 
+func (s *NodeStack) BaseDistro() string {
+	return "debian"
+}
+
 func (s *NodeStack) Name() string {
 	return "node"
 }

--- a/pkg/stackbuild/python.go
+++ b/pkg/stackbuild/python.go
@@ -99,6 +99,10 @@ type PythonStack struct {
 	requiredEnvVars []EnvVarRequirement
 }
 
+func (s *PythonStack) BaseDistro() string {
+	return "debian"
+}
+
 func (s *PythonStack) Name() string {
 	return "python"
 }
@@ -250,6 +254,9 @@ func (s *PythonStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, er
 
 	base = s.addAppUser(base)
 
+	h := &highlevelBuilder{opts}
+	base = h.applyAugmentations(base, localCtx, s.BaseDistro(), s.Augmentations(), s.SkipJSInstall())
+
 	// Create pip cache mount
 	pipCache := llb.Scratch().File(
 		llb.Mkdir("/pip-cache", 0777, llb.WithParents(true)),
@@ -343,8 +350,6 @@ func (s *PythonStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, er
 			llb.WithCustomName("[phase] Installing Python dependencies with uv"),
 		).Root()
 	}
-
-	h := &highlevelBuilder{opts}
 
 	// Copy the rest of the application code
 	state = h.copyApp(state, localCtx)

--- a/pkg/stackbuild/ruby.go
+++ b/pkg/stackbuild/ruby.go
@@ -223,7 +223,9 @@ func (s *RubyStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 
 	h := &highlevelBuilder{opts}
 
-	// My kingdom for a pipe operator.
+	// nodejs is load-bearing here even with the npm augmentation: some rubygems
+	// shell out to `node` directly during install/runtime without a package.json,
+	// so it must be present on every Ruby build regardless of augmentation state.
 	base = h.aptInstall(base, "build-essential", "libpq-dev", "nodejs", "libyaml-dev", "postgresql-client", "git", "curl", "ssh")
 
 	base = h.applyAugmentations(base, localCtx, s.BaseDistro(), s.Augmentations(), s.SkipJSInstall())

--- a/pkg/stackbuild/ruby.go
+++ b/pkg/stackbuild/ruby.go
@@ -102,6 +102,10 @@ type RubyStack struct {
 	requiredEnvVars []EnvVarRequirement
 }
 
+func (s *RubyStack) BaseDistro() string {
+	return "debian"
+}
+
 func (s *RubyStack) Name() string {
 	return "ruby"
 }
@@ -221,6 +225,8 @@ func (s *RubyStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 
 	// My kingdom for a pipe operator.
 	base = h.aptInstall(base, "build-essential", "libpq-dev", "nodejs", "libyaml-dev", "postgresql-client", "git", "curl", "ssh")
+
+	base = h.applyAugmentations(base, localCtx, s.BaseDistro(), s.Augmentations(), s.SkipJSInstall())
 
 	base = base.
 		AddEnv("SECRET_KEY_BASE_DUMMY", "1").

--- a/pkg/stackbuild/rust.go
+++ b/pkg/stackbuild/rust.go
@@ -75,6 +75,10 @@ type RustStack struct {
 	requiredEnvVars []EnvVarRequirement
 }
 
+func (s *RustStack) BaseDistro() string {
+	return "debian"
+}
+
 func (s *RustStack) Name() string {
 	return "rust"
 }
@@ -164,6 +168,8 @@ func (s *RustStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 	base = s.addAppUser(base)
 
 	h := &highlevelBuilder{opts}
+
+	base = h.applyAugmentations(base, localCtx, s.BaseDistro(), s.Augmentations(), s.SkipJSInstall())
 
 	// Copy the application code
 	state := h.copyApp(base, localCtx)

--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -73,6 +73,12 @@ type Stack interface {
 	// BaseDistro returns the package manager family of the stack's base image
 	// ("debian" or "alpine"). Used to dispatch apt vs apk for augmentations.
 	BaseDistro() string
+
+	// metaStack returns the embedded *MetaStack. Unexported so only stacks in
+	// this package can satisfy Stack — and since every concrete stack embeds
+	// MetaStack, the method is auto-fulfilled, making it impossible to add a
+	// new stack without also wiring up augmentation/events plumbing.
+	metaStack() *MetaStack
 }
 
 // DetectStack identifies the programming stack in the given directory
@@ -103,32 +109,10 @@ func DetectStack(dir string, opts BuildOptions) (Stack, error) {
 // stack so that Events() reports them and GenerateLLB() can apply them.
 func attachAugmentations(stack Stack, dir string) {
 	augs, skipInstall, events := DetectAugmentations(dir, stack.Name())
-	if ms, ok := metaStackOf(stack); ok {
-		ms.augmentations = augs
-		ms.skipJSInstall = skipInstall
-		ms.events = append(ms.events, events...)
-	}
-}
-
-// metaStackOf returns the embedded *MetaStack from a Stack implementation.
-// All concrete stacks in this package embed MetaStack, so this should always
-// succeed for stacks created by DetectStack.
-func metaStackOf(stack Stack) (*MetaStack, bool) {
-	switch s := stack.(type) {
-	case *RubyStack:
-		return &s.MetaStack, true
-	case *PythonStack:
-		return &s.MetaStack, true
-	case *NodeStack:
-		return &s.MetaStack, true
-	case *BunStack:
-		return &s.MetaStack, true
-	case *GoStack:
-		return &s.MetaStack, true
-	case *RustStack:
-		return &s.MetaStack, true
-	}
-	return nil, false
+	ms := stack.metaStack()
+	ms.augmentations = augs
+	ms.skipJSInstall = skipInstall
+	ms.events = append(ms.events, events...)
 }
 
 // MetaStack provides shared functionality for all stack implementations
@@ -138,6 +122,12 @@ type MetaStack struct {
 	events        []DetectionEvent
 	augmentations []Augmentation
 	skipJSInstall bool
+}
+
+// metaStack returns s itself, fulfilling the unexported Stack interface
+// requirement automatically for every concrete stack that embeds MetaStack.
+func (s *MetaStack) metaStack() *MetaStack {
+	return s
 }
 
 // Augmentations returns the secondary tooling layers (npm, bun, ...) attached

--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -69,6 +69,10 @@ type Stack interface {
 
 	// RequiredEnvVars returns environment variables detected as required/recommended
 	RequiredEnvVars() []EnvVarRequirement
+
+	// BaseDistro returns the package manager family of the stack's base image
+	// ("debian" or "alpine"). Used to dispatch apt vs apk for augmentations.
+	BaseDistro() string
 }
 
 // DetectStack identifies the programming stack in the given directory
@@ -87,6 +91,7 @@ func DetectStack(dir string, opts BuildOptions) (Stack, error) {
 	for _, stack := range stacks {
 		if stack.Detect() {
 			stack.Init(opts)
+			attachAugmentations(stack, dir)
 			return stack, nil
 		}
 	}
@@ -94,11 +99,58 @@ func DetectStack(dir string, opts BuildOptions) (Stack, error) {
 	return nil, fmt.Errorf("no supported stack detected in %s", dir)
 }
 
+// attachAugmentations detects and records augmentations for the given primary
+// stack so that Events() reports them and GenerateLLB() can apply them.
+func attachAugmentations(stack Stack, dir string) {
+	augs, skipInstall, events := DetectAugmentations(dir, stack.Name())
+	if ms, ok := metaStackOf(stack); ok {
+		ms.augmentations = augs
+		ms.skipJSInstall = skipInstall
+		ms.events = append(ms.events, events...)
+	}
+}
+
+// metaStackOf returns the embedded *MetaStack from a Stack implementation.
+// All concrete stacks in this package embed MetaStack, so this should always
+// succeed for stacks created by DetectStack.
+func metaStackOf(stack Stack) (*MetaStack, bool) {
+	switch s := stack.(type) {
+	case *RubyStack:
+		return &s.MetaStack, true
+	case *PythonStack:
+		return &s.MetaStack, true
+	case *NodeStack:
+		return &s.MetaStack, true
+	case *BunStack:
+		return &s.MetaStack, true
+	case *GoStack:
+		return &s.MetaStack, true
+	case *RustStack:
+		return &s.MetaStack, true
+	}
+	return nil, false
+}
+
 // MetaStack provides shared functionality for all stack implementations
 type MetaStack struct {
-	dir    string
-	result ocispecs.Image
-	events []DetectionEvent
+	dir           string
+	result        ocispecs.Image
+	events        []DetectionEvent
+	augmentations []Augmentation
+	skipJSInstall bool
+}
+
+// Augmentations returns the secondary tooling layers (npm, bun, ...) attached
+// to this stack by DetectStack.
+func (s *MetaStack) Augmentations() []Augmentation {
+	return s.augmentations
+}
+
+// SkipJSInstall reports whether the app already ships a node_modules directory,
+// in which case the JS package install (npm install / bun install) should be
+// skipped — the tool itself is still installed so onBuild commands can use it.
+func (s *MetaStack) SkipJSInstall() bool {
+	return s.skipJSInstall
 }
 
 func (s *MetaStack) Init(opts BuildOptions) {


### PR DESCRIPTION
## Summary

- Adds a stack-augmentation system in `pkg/stackbuild/` that detects when a non-Node/Bun primary stack ships a `package.json` and layers npm (and/or bun) onto its base image — so Rails/Django/Go/Rust apps with JS-driven frontends Just Work without per-app config.
- Each augmentation installs the tool (`apt` for Debian images, `apk` for Alpine/Go) and then runs `npm install` / `bun install` as the unprivileged `app` user (uid 2010) so the resulting `node_modules` is writable at runtime.
- If the app already ships `node_modules`, the tool is still installed (so onBuild commands can shell out) but the install step is skipped — the vendored modules flow through via `copyApp`.

## Implementation notes

- New `Augmentation` type + `DetectAugmentations` in `pkg/stackbuild/augment.go`.
- `Stack` interface gains `BaseDistro()` (`debian` / `alpine`) so the augmentation helpers can dispatch the right package manager.
- `MetaStack` gains `augmentations` + `skipJSInstall` fields populated by `attachAugmentations` after primary stack detection; detection events surface alongside primary events.
- bun augmentation copies the bun binary from the official bun image via multi-stage `llb.Copy`.
- npm install runs without a persistent cache mount (the scratch root is root-owned, which conflicts with running as `app`); per-layer caching still avoids re-runs when package files don't change. A future PR can add a properly-owned cache via `llb.SourcePath`.

## Test plan

- [x] Unit tests in `pkg/stackbuild/augment_test.go` cover: npm-from-package-lock, npm-from-package-json, bun-from-lock/lockb, skip-for-node, skip-for-bun, node_modules skip path, attachment via `DetectStack`, base distros for all six stacks (14 tests, all passing).
- [x] `go build ./pkg/stackbuild/` ✓
- [x] `make lint` ✓
- [ ] End-to-end: build a Rails app with `package.json` + `dartsass-rails` and verify `assets:precompile` succeeds.
- [ ] End-to-end: build a Python app with a vendored `node_modules` and verify the skip path works.