### PR TITLE
Resolve runners by short ID in 'runner remove'

### DIFF
--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -125,10 +125,14 @@ func (m *MockStore) validateSessionAttrs(ctx context.Context, attrs []Attr, opts
 	return nil
 }
 
-// ensureShortId mirrors the real store's auto-allocation of db/short-id on
-// kinded entities that don't already carry one. Without this, tests that
+// ensureShortIdLocked mirrors the real store's auto-allocation of db/short-id
+// on kinded entities that don't already carry one. Without this, tests that
 // resolve entities by their short id would have to inject one by hand.
-func (m *MockStore) ensureShortId(entity *Entity) error {
+//
+// The caller must hold m.mu for writing so that candidate uniqueness and the
+// subsequent insert are serialized; otherwise two concurrent CreateEntity
+// calls could each see a candidate as free and both commit it.
+func (m *MockStore) ensureShortIdLocked(entity *Entity) error {
 	if _, hasKind := entity.Get(EntityKind); !hasKind {
 		return nil
 	}
@@ -136,8 +140,6 @@ func (m *MockStore) ensureShortId(entity *Entity) error {
 		return nil
 	}
 	shortId, err := AllocateShortId(string(entity.Id()), func(candidate string) (bool, error) {
-		m.mu.RLock()
-		defer m.mu.RUnlock()
 		for _, ent := range m.Entities {
 			if attr, ok := ent.Get(DBShortId); ok && attr.Value.String() == candidate {
 				return true, nil
@@ -157,10 +159,6 @@ func (m *MockStore) CreateEntity(ctx context.Context, entity *Entity, opts ...En
 		return nil, err
 	}
 
-	if err := m.ensureShortId(entity); err != nil {
-		return nil, err
-	}
-
 	// Set CreatedAt if not already set (store manages this timestamp)
 	if entity.GetCreatedAt().IsZero() {
 		entity.SetCreatedAt(m.Now())
@@ -169,6 +167,10 @@ func (m *MockStore) CreateEntity(ctx context.Context, entity *Entity, opts ...En
 	entity.SetRevision(1)
 
 	m.mu.Lock()
+	if err := m.ensureShortIdLocked(entity); err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
 	m.Entities[entity.Id()] = entity
 	m.mu.Unlock()
 

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -125,8 +125,39 @@ func (m *MockStore) validateSessionAttrs(ctx context.Context, attrs []Attr, opts
 	return nil
 }
 
+// ensureShortId mirrors the real store's auto-allocation of db/short-id on
+// kinded entities that don't already carry one. Without this, tests that
+// resolve entities by their short id would have to inject one by hand.
+func (m *MockStore) ensureShortId(entity *Entity) error {
+	if _, hasKind := entity.Get(EntityKind); !hasKind {
+		return nil
+	}
+	if _, hasShortId := entity.Get(DBShortId); hasShortId {
+		return nil
+	}
+	shortId, err := AllocateShortId(string(entity.Id()), func(candidate string) (bool, error) {
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+		for _, ent := range m.Entities {
+			if attr, ok := ent.Get(DBShortId); ok && attr.Value.String() == candidate {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to allocate short-id: %w", err)
+	}
+	entity.Set(String(DBShortId, shortId))
+	return nil
+}
+
 func (m *MockStore) CreateEntity(ctx context.Context, entity *Entity, opts ...EntityOption) (*Entity, error) {
 	if err := m.validateSessionAttrs(ctx, entity.attrs, opts); err != nil {
+		return nil, err
+	}
+
+	if err := m.ensureShortId(entity); err != nil {
 		return nil, err
 	}
 

--- a/pkg/model/text_test.go
+++ b/pkg/model/text_test.go
@@ -72,9 +72,12 @@ func TestTextFormatter_Format(t *testing.T) {
 		err := schema.Apply(ctx, store)
 		r.NoError(err)
 
+		// Pre-set short-id so the assertion is deterministic; MockStore would
+		// otherwise allocate a random one for any kinded entity.
 		testEntity, err := store.CreateEntity(context.Background(), entity.New(
 			entity.Ident, types.Keyword("test/myproject"),
 			entity.EntityKind, entity.RefValue("dev.miren.core/kind.project"),
+			entity.DBShortId, "fixed",
 		))
 		r.NoError(err)
 
@@ -94,6 +97,8 @@ attrs:
     value: 2006-01-02T15:04:05Z
   - id: db/id
     value: test/myproject
+  - id: db/short-id
+    value: fixed
   - id: entity/kind
     value: dev.miren.core/kind.project
 `

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -487,9 +487,8 @@ func (s *RegistrationServer) ListRunners(ctx context.Context, req *runner_v1alph
 		}
 		info.SetName(name)
 
-		wrapper := &rpcEntityWrapper{entity: e}
-		if attr, ok := wrapper.Get(entity.DBShortId); ok {
-			info.SetShortId(attr.Value.String())
+		if sid := e.Entity().ShortId(); sid != "" {
+			info.SetShortId(sid)
 		}
 		info.SetStatus(string(node.Status))
 		info.SetVersion(node.Version)
@@ -632,10 +631,11 @@ func (s *RegistrationServer) findNodeByQuery(ctx context.Context, query string) 
 
 		id := entity.Id(e.Id())
 
-		// Exact match by entity ID, runner ID, or name
+		// Exact match by entity ID, runner ID, name, or short ID
 		if string(id) == query ||
 			node.RunnerId == query ||
-			(node.Name != "" && node.Name == query) {
+			(node.Name != "" && node.Name == query) ||
+			e.Entity().ShortId() == query {
 			return &node, id, nil
 		}
 

--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -395,6 +395,45 @@ func TestRemoveRunnerNotFound(t *testing.T) {
 	}
 }
 
+func TestRemoveRunnerByShortId(t *testing.T) {
+	ctx := context.Background()
+	env, cleanup := newTestServer(t)
+	defer cleanup()
+
+	secret := env.createInviteAndDecode(t, ctx)
+
+	joinResult, err := env.client.Join(ctx, secret, "", "10.0.0.3:8443", "v1", nil, "runner-short")
+	if err != nil {
+		t.Fatalf("Join failed: %v", err)
+	}
+	if joinResult.HasError() {
+		t.Fatalf("Join returned error: %s", joinResult.Error())
+	}
+
+	listResult, err := env.client.ListRunners(ctx)
+	if err != nil {
+		t.Fatalf("ListRunners failed: %v", err)
+	}
+	if len(listResult.Runners()) != 1 {
+		t.Fatalf("expected 1 runner, got %d", len(listResult.Runners()))
+	}
+	shortId := listResult.Runners()[0].ShortId()
+	if shortId == "" {
+		t.Fatalf("expected runner to have a short id assigned")
+	}
+
+	removeResult, err := env.client.RemoveRunner(ctx, shortId, false)
+	if err != nil {
+		t.Fatalf("RemoveRunner failed: %v", err)
+	}
+	if removeResult.Error() != "" {
+		t.Fatalf("RemoveRunner returned error: %s", removeResult.Error())
+	}
+	if removeResult.Name() != "runner-short" {
+		t.Errorf("RemoveRunner returned name %q, want %q", removeResult.Name(), "runner-short")
+	}
+}
+
 func TestRemoveRunnerByRunnerId(t *testing.T) {
 	ctx := context.Background()
 	env, cleanup := newTestServer(t)


### PR DESCRIPTION
`miren runner remove` promises "name, ID, or short ID" in its help text but the resolver only ever checked name, runner ID, and entity-ID prefix. Short IDs are stored as a separate `db/short-id` attribute, not as a prefix of the entity ID, so the cute base58 thing printed in `runner list` never actually resolved. Surfaced during the MIR-954 garden bake when `D6P` failed and the operator had to dig out the full UUID instead.

The actual mistake was using the wrong corner of the entity API. `findNodeByQuery` decoded each list result into the typed `compute_v1alpha.Node` struct, which only exposes the fields declared in the Node schema. The short-id is a system attribute, so it was never going to show up there. The clean accessor (`e.Entity().ShortId()`) was sitting right there. The list path next door had previously worked around the gap with a local `rpcEntityWrapper` hack, but findNodeByQuery never got that treatment. New code uses the proper accessor in both places, and the wrapper helper is gone. The whole file would read cleaner end-to-end if it adopted `entityserver.Client` throughout, see MIR-1015 for the broader sweep, but that's a separate cleanup and shouldn't get bundled into a focused bug fix.

Confirmed the new `TestRemoveRunnerByShortId` fails without the resolver change (`runner "6ER" not found`) and passes once it's restored.

The smaller bonus fix is in `pkg/entity/mock.go`. The real store auto-allocates a short-id on every kinded entity at `Put` time, but `MockStore.CreateEntity` had never picked up the equivalent behavior. That drift would have meant any test of short-id-aware code had to poke at the mock's internals to set the attribute by hand. Mirroring the real store's allocation here keeps future tests honest.