### PR TITLE
docs: explain how to point a custom domain at a Miren cluster

### DIFF
--- a/docs/docs/miren-cloud/subdomains.md
+++ b/docs/docs/miren-cloud/subdomains.md
@@ -6,7 +6,7 @@ keywords: [subdomains, dns, run.garden, miren.app, custom domain, wildcard]
 
 # Subdomains
 
-You've got a Miren cluster running your stuff — now give it an address people can actually visit. You can always bring your own domain, but if you'd rather skip the DNS busywork, Miren Cloud lets you claim a subdomain like `mycluster.run.garden`, point it at your cluster, and you're live.
+You've got a Miren cluster running your stuff — now give it an address people can actually visit. You can always [bring your own domain](/traffic-routing#custom-domains), but if you'd rather skip the DNS busywork, Miren Cloud lets you claim a subdomain like `mycluster.run.garden`, point it at your cluster, and you're live.
 
 ## Available Base Domains
 

--- a/docs/docs/traffic-routing.md
+++ b/docs/docs/traffic-routing.md
@@ -42,6 +42,45 @@ If an exact route also exists for a specific subdomain, the exact route takes pr
 
 The wildcard `*` must be the first label — patterns like `foo.*.example.com` are not supported. The domain must have at least two labels after the wildcard (e.g., `*.example.com` is valid, `*.com` is not).
 
+### Custom Domains
+
+To put your own domain in front of an app on Miren, point DNS at your cluster and set a route. TLS provisions automatically.
+
+**Find your cluster's hostname.** Clusters registered with Miren Cloud get a hostname under `miren.systems` — something like `cluster-jwomf2l0tn8z.miren.systems`. You'll find yours on the cluster page in [miren.cloud](https://miren.cloud). If you're running standalone without cloud, use your server's public hostname or IP.
+
+**Point DNS at your cluster.** For most setups, point both the apex and a wildcard so you can add or change routes later without touching DNS again:
+
+```text
+yourdomain.com.      ALIAS    cluster-jwomf2l0tn8z.miren.systems.
+*.yourdomain.com.    CNAME    cluster-jwomf2l0tn8z.miren.systems.
+```
+
+Most DNS providers don't allow a CNAME at the apex (`yourdomain.com` with no subdomain). Use an ALIAS or ANAME record where your provider supports it, or an A record pointing at your cluster's IP. The wildcard record can always be a CNAME.
+
+If you only need one hostname on Miren, a single CNAME for that name is fine on its own:
+
+```text
+app.yourdomain.com.  CNAME    cluster-jwomf2l0tn8z.miren.systems.
+```
+
+**Then set a route.** Map any host that resolves to your cluster to an app:
+
+<CliCommand context="client">
+```miren
+miren route set app.yourdomain.com myapp
+```
+</CliCommand>
+
+If you set up wildcard DNS above, you can also send every subdomain to the same app with a [wildcard route](#wildcard-routes):
+
+<CliCommand context="client">
+```miren
+miren route set '*.yourdomain.com' myapp
+```
+</CliCommand>
+
+You don't have to do anything else for HTTPS — Miren provisions Let's Encrypt certificates as requests arrive. See [TLS Certificates](/tls) for the details.
+
 ### Choosing a Port
 
 Miren sets the `PORT` environment variable to tell your app which port to listen on. Your app should bind to `PORT`:


### PR DESCRIPTION
A user in Discord deployed an app on a self-hosted cluster and wanted to point their own domain at it. The `run.garden` / `miren.app` claim flow is already documented and `traffic-routing.md` explains wildcard routes, but neither page connects the dots for "I own example.com, how do I make `*.example.com` resolve to my app?" They worked it out from a one-off answer; that's a problem we should solve once, not every time someone shows up with their own domain.

This adds a "Custom Domains" subsection to `traffic-routing.md` (right after Wildcard Routes, since it builds directly on `miren route set`) that walks through the three pieces of the flow: find your cluster's hostname in the cloud UI, point both the apex and a wildcard at it (the apex-CNAME caveat is called out inline, with ALIAS/ANAME/A as fallbacks), then set a route. The section is structured with bold step-leads so the DNS options and the route options don't read as a flat sequence; the wildcard-route example explicitly references the wildcard-DNS step so the dependency is visible.

The existing "bring your own domain" line in `miren-cloud/subdomains.md` is now a link to the new section, so users who land on the subdomains page first don't walk away thinking `run.garden` and `miren.app` are the only options.

Per-environment previews would be a natural other use case to mention, but those docs are coming in MIR-995, so the section leaves the cross-reference for then.

Closes MIR-1151