### PR TITLE
pin workflow actions to secure commit SHAs 📌

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,15 +26,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
@@ -48,7 +50,7 @@ jobs:
 
       - name: Upload build artifacts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs/build
 
@@ -68,7 +70,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
 
       - name: Format Slack success message
         id: slack-message
@@ -121,7 +123,7 @@ jobs:
           echo "SLACK_EOF" >> $GITHUB_OUTPUT
 
       - name: Send Slack success notification
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -172,7 +174,7 @@ jobs:
 
       - name: Send Slack failure notification
         if: failure()
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,9 @@ jobs:
       ref: ${{ steps.set-ref.outputs.ref }}
       sha: ${{ steps.set-ref.outputs.sha }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           ref: ${{ inputs.ref || github.ref_name }}
       - id: set-ref
         run: |
@@ -62,12 +63,13 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
+        persist-credentials: false
         ref: ${{ needs.init.outputs.ref }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -88,7 +90,7 @@ jobs:
         mv release.tar.gz release-base-linux-${{ matrix.arch }}.tar.gz
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: miren-base-linux-${{ matrix.arch }}
         path: release-base-linux-${{ matrix.arch }}.tar.gz
@@ -117,12 +119,13 @@ jobs:
       attestations: write
       contents: read
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
+        persist-credentials: false
         ref: ${{ needs.init.outputs.ref }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -271,7 +274,7 @@ jobs:
         zip -j miren-${{ matrix.os }}-${{ matrix.arch }}.zip bin/miren
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: miren-${{ matrix.os }}-${{ matrix.arch }}
         path: |
@@ -281,7 +284,7 @@ jobs:
 
     - name: Upload macOS .pkg artifact
       if: matrix.os == 'darwin' && env.INSTALLER_IDENTITY != '' && startsWith(needs.init.outputs.ref, 'v')
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: miren-darwin-${{ matrix.arch }}-pkg
         path: miren-darwin-${{ matrix.arch }}.pkg
@@ -295,18 +298,19 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.init.outputs.ref }}
 
       - name: Download amd64 package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: miren-base-linux-amd64
           path: artifacts/amd64
 
       - name: Download arm64 package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: miren-base-linux-arm64
           path: artifacts/arm64
@@ -318,13 +322,13 @@ jobs:
           tar -xzf artifacts/arm64/release-base-linux-arm64.tar.gz -C docker/artifacts/arm64
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-central1-docker.pkg.dev
@@ -352,7 +356,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Build and push miren Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: ./docker/Dockerfile.miren
@@ -373,17 +377,18 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           ref: ${{ needs.init.outputs.ref }}
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 
       - name: Get OIDC token
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         id: get-oidc-token
         with:
           script: |
@@ -616,7 +621,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}
           private-key: ${{ secrets.HOMEBREW_TAP_APP_KEY }}
@@ -643,7 +648,7 @@ jobs:
     steps:
       - name: Send Slack notification on failure
         if: contains(needs.*.result, 'failure')
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -627,6 +627,7 @@ jobs:
           private-key: ${{ secrets.HOMEBREW_TAP_APP_KEY }}
           owner: mirendev
           repositories: homebrew-tap
+          permission-actions: write
 
       - name: Trigger homebrew-tap update
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,18 +27,19 @@ jobs:
   lint:
     runs-on: depot-ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
+        persist-credentials: false
         ref: ${{ inputs.ref }}
 
     - name: Set up Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
     - name: Docs lint
       run: bun run lint
       working-directory: docs
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -53,7 +54,7 @@ jobs:
 
     - name: Cache Go tools
       id: cache-go-tools
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/go/bin
         key: ${{ runner.os }}-go-tools-${{ hashFiles('go.mod') }}
@@ -67,7 +68,7 @@ jobs:
         go install go.uber.org/mock/mockgen@latest
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
       with:
         version: v2.6.1
 
@@ -91,8 +92,9 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
+        persist-credentials: false
         ref: ${{ inputs.ref }}
 
     - name: Set test matrix
@@ -130,12 +132,13 @@ jobs:
       matrix:
         group: ${{ fromJson(needs.test-groups.outputs.matrix) }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
+        persist-credentials: false
         ref: ${{ inputs.ref }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -148,7 +151,7 @@ jobs:
 
     - name: Cache iso binary
       id: iso-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/go/bin/iso
         key: iso-binary-${{ steps.iso-version.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -161,7 +164,7 @@ jobs:
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Restore iso cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /tmp/iso-cache
         key: iso-cache-${{ hashFiles('go.sum') }}
@@ -169,7 +172,7 @@ jobs:
 
     - name: Restore Docker image cache
       id: docker-image-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /tmp/iso-image.tar
         key: iso-image-${{ hashFiles('.iso/Dockerfile', '.iso/.bashrc', 'hack/containerd-config.toml') }}
@@ -191,12 +194,13 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: depot-ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
+        persist-credentials: false
         ref: ${{ inputs.ref }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -209,7 +213,7 @@ jobs:
 
     - name: Cache iso binary
       id: iso-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/go/bin/iso
         key: iso-binary-${{ steps.iso-version.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -222,7 +226,7 @@ jobs:
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Restore iso cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /tmp/iso-cache
         key: iso-cache-blackbox-${{ hashFiles('go.sum') }}
@@ -230,7 +234,7 @@ jobs:
 
     - name: Restore Docker image cache
       id: docker-image-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /tmp/iso-image.tar
         key: iso-image-${{ hashFiles('.iso/Dockerfile', '.iso/.bashrc', 'hack/containerd-config.toml') }}
@@ -268,12 +272,13 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: depot-ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
+        persist-credentials: false
         ref: ${{ inputs.ref }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -286,7 +291,7 @@ jobs:
 
     - name: Cache iso binary
       id: iso-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/go/bin/iso
         key: iso-binary-${{ steps.iso-version.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -299,7 +304,7 @@ jobs:
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Restore iso cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /tmp/iso-cache
         key: iso-cache-blackbox-pop-${{ hashFiles('go.sum') }}
@@ -307,7 +312,7 @@ jobs:
 
     - name: Restore Docker image cache
       id: docker-image-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: /tmp/iso-image.tar
         key: iso-image-${{ hashFiles('.iso/Dockerfile', '.iso/.bashrc', 'hack/containerd-config.toml') }}
@@ -319,8 +324,9 @@ jobs:
     # POP tests need the cloud repo to build cloud and pop binaries from source.
     # Requires CLOUD_REPO_TOKEN secret — a PAT with read access to mirendev/cloud.
     - name: Checkout cloud repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
+        persist-credentials: false
         repository: mirendev/cloud
         path: cloud
         token: ${{ secrets.CLOUD_REPO_TOKEN }}
@@ -379,12 +385,13 @@ jobs:
     if: github.event_name != 'workflow_call'
     runs-on: depot-ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
+        persist-credentials: false
         ref: ${{ inputs.ref }}
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: 'go.mod'
         cache: true


### PR DESCRIPTION
Just some supply chain hygiene. Using immutable commit SHAs instead of mutable tags is generally the way to go for GitHub Actions, so I pinned everything across the test, release, and docs workflows.

I also bumped a few of the older actions to their latest versions and disabled credential persistence on the checkout steps to keep things locked down.