### PR TITLE
doctor: add QUIC reachability check for the API port

### DIFF
--- a/cli/commands/doctor_server.go
+++ b/cli/commands/doctor_server.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -9,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/ui"
 )
@@ -75,6 +78,12 @@ func DoctorServer(ctx *Context, opts struct {
 	// Check HTTP (port 80)
 	httpStatus, httpDetail := checkHTTP(host)
 	printEndpointStatus(ctx, "HTTP", httpStatus, httpDetail)
+
+	// Check QUIC (the API port — UDP). The HTTPS/HTTP probes above only
+	// cover TCP; a host firewall that allows TCP but not UDP will pass
+	// those checks while silently dropping every API request.
+	quicStatus, quicDetail := checkQUIC(cluster.Hostname)
+	printEndpointStatus(ctx, "QUIC", quicStatus, quicDetail)
 
 	// Show suggestions when not connected
 	if !connected {
@@ -210,6 +219,52 @@ func describeHTTPError(err error) string {
 		return opErr.Err.Error()
 	}
 	return err.Error()
+}
+
+// checkQUIC verifies that the cluster's API port (UDP/QUIC) is reachable.
+// Failure here when HTTPS/HTTP succeed almost always means a host firewall
+// allowing TCP but not UDP on the same port (a common UFW/firewalld pitfall).
+func checkQUIC(addr string) (bool, string) {
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		addr = net.JoinHostPort(addr, "8443")
+	}
+	_, port, _ := net.SplitHostPort(addr)
+
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return false, fmt.Sprintf("resolve failed: %s", err)
+	}
+
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv6zero, Port: 0})
+	if err != nil {
+		udpConn, err = net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+		if err != nil {
+			return false, fmt.Sprintf("local udp socket: %s", err)
+		}
+	}
+	defer udpConn.Close()
+
+	transport := &quic.Transport{Conn: udpConn}
+	defer transport.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := transport.Dial(ctx, udpAddr, &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{http3.NextProtoH3},
+	}, &quic.Config{
+		HandshakeIdleTimeout: 5 * time.Second,
+		MaxIdleTimeout:       10 * time.Second,
+	})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "no recent network activity") {
+			return false, fmt.Sprintf("no response on udp/%s (host firewall may be blocking inbound UDP)", port)
+		}
+		return false, err.Error()
+	}
+	_ = conn.CloseWithError(0, "doctor")
+	return true, "handshake ok"
 }
 
 // checkHTTP verifies HTTP connectivity (typically redirects to HTTPS)


### PR DESCRIPTION
## Summary

Adds a `[✓|✗] QUIC` endpoint check to `miren doctor server`, alongside the existing HTTPS/HTTP checks.

The existing endpoint probes only cover TCP. If a host firewall (UFW, firewalld, cloud security group) allows TCP on the API port but not UDP — a common configuration when operators add `8443/tcp` rules out of habit — every external `miren deploy` and `miren cluster export-address` silently fails with the client-side timeout `error performing http request: timeout: no recent network activity`. The server side shows zero observable signal: no errors, no warnings, no requests visible in `miren logs system`, because packets are dropped at netfilter INPUT before reaching the socket.

This is documented in `docs/docs/firewall.md` but is easy to miss, and the existing `miren doctor server` shows all green for HTTPS/HTTP while the actual API port is unreachable.

## What it does

Adds `checkQUIC(addr string) (bool, string)` modeled on `checkHTTPS` / `checkHTTP`:

- Dials QUIC with `http3.NextProtoH3` (the same ALPN the real RPC server advertises in `pkg/rpc/state.go`), so a successful handshake also exercises the TLS path.
- 5s handshake timeout; on `context.DeadlineExceeded` or the QUIC idle-timeout error, the detail message points directly at the most likely cause:
  ```
  [✗] QUIC   no response on udp/8443 (host firewall may be blocking inbound UDP)
  ```
- On success:
  ```
  [✓] QUIC   handshake ok
  ```
- IPv6-first, fallback to IPv4 for the local UDP socket — same pattern as `cli/commands/cluster_add.go`.

## Usage

No CLI change. Just run as before:

```
miren doctor server
```

Output now includes the QUIC line in the Endpoints block.

## Test plan

- [x] `go build ./cmd/miren` — compiles
- [x] `go vet ./cli/commands/` — clean
- [x] `golangci-lint run --timeout=10m ./cli/commands/...` — 0 issues
- [x] Manual: run against a healthy local cluster → `[✓] QUIC   handshake ok`
- [x] Manual: run against a cluster where UFW drops UDP 8443 → `[✗] QUIC   no response on udp/8443 (host firewall may be blocking inbound UDP)`
- [ ] Manual: run against a stopped miren (connection refused) — confirms the fallthrough error message is reasonable

No new tests in `doctor_server_test.go` — the existing `checkHTTPS` / `checkHTTP` helpers also have no tests and I didn't want to grow this PR's scope. Happy to add a table-driven test in a follow-up if maintainers want one.

## Followups (out of scope here)

Things I considered and deliberately left out to keep the patch focused:

- A startup banner on `miren server` start that mentions UDP is the API port, surfaced in journalctl.
- Updates to `showFixConnectivityHelp` to specify `lsof -i UDP:8443` (currently only suggests `:443` TCP).
- An optional UFW-rule check at `miren server install` time.

Happy to PR any of these separately if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
