### PR TITLE
validate: allow tls.additional_names / tls.additional_ips in behind-proxy-http

### DIFF
--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -109,7 +109,7 @@ The `behind-proxy-*` modes default to localhost to keep accidental misconfigurat
 
 ## `[tls]` — TLS Settings {#tls}
 
-Controls cert sourcing for ingress modes that terminate TLS (`tls-autoprovision` and `behind-proxy-https`). Ignored under `behind-proxy-http`; populating these fields under that mode is an error. See [TLS](/tls) for setup guides.
+Settings under `[tls]` cover two kinds of certs. `acme_email`, `acme_dns_provider`, and `self_signed` configure the ingress cert and only apply when Miren terminates TLS (`tls-autoprovision` or `behind-proxy-https`); they're rejected at startup under `behind-proxy-http`. `additional_names` and `additional_ips` are different: they extend the SANs on the API server and etcd certs, which exist regardless of ingress mode, so they're valid under any mode. See [TLS](/tls) for setup guides.
 
 | Field | Type | Default | Description | Env Var | CLI Flag |
 |-------|------|---------|-------------|---------|----------|

--- a/docs/docs/tls.md
+++ b/docs/docs/tls.md
@@ -118,20 +118,27 @@ Two other modes are available for deployments where Miren sits behind a TLS-term
 | Mode | What Miren does | Cert source |
 |------|-----------------|-------------|
 | `tls-autoprovision` (default) | Binds `:443` for TLS and `:80` for redirect / HTTP-01 ACME | `[tls]` (ACME or self-signed) |
-| `behind-proxy-http` | Plain HTTP at the configured address (default `127.0.0.1:80`); TLS lives at the proxy | n/a — `[tls]` is unused |
+| `behind-proxy-http` | Plain HTTP at the configured address (default `127.0.0.1:80`); TLS lives at the proxy | n/a (proxy terminates TLS) |
 | `behind-proxy-https` | TLS terminated at the configured address (default `127.0.0.1:443`); no `:80` listener, so no HTTP-01 ACME | `[tls]` self-signed or DNS-01 ACME only |
 
 See [Server Configuration Reference → `[ingress]`](/server-config#ingress) for the full schema. The HTTP-01 ACME flow described above only applies under `tls-autoprovision`; under `behind-proxy-https`, certs must come from DNS-01 ACME or be self-signed because Miren doesn't bind `:80` in that mode (and the public DNS for the hostname points at the proxy anyway, not at Miren).
 
 ## TLS Settings Reference
 
-All TLS settings live under the `[tls]` section of the server config file (typically `/var/lib/miren/server/config.toml`). Consulted only under TLS-terminating ingress modes:
+All TLS settings live under the `[tls]` section of the server config file (typically `/var/lib/miren/server/config.toml`). The three ingress-cert settings below are consulted only under TLS-terminating ingress modes:
 
 | Setting | CLI Flag | Description |
 |---------|----------|-------------|
 | `acme_email` | `--acme-email` | Email for Let's Encrypt account registration and expiry notifications |
 | `acme_dns_provider` | `--acme-dns-provider` | DNS provider name for DNS-01 challenges (e.g., `cloudflare`, `route53`, `dnsimple`) |
 | `self_signed` | `--self-signed-tls` | Use a self-signed cert instead of ACME (development, or behind a non-verifying TLS proxy) |
+
+Two additional `[tls]` settings apply to the API server and etcd certs rather than ingress, so they're valid under any ingress mode:
+
+| Setting | CLI Flag | Description |
+|---------|----------|-------------|
+| `additional_names` | `--dns-names` | Extra DNS names appended to the API server and etcd cert SANs |
+| `additional_ips` | `--ips` | Extra IPs appended to the API server and etcd cert SANs |
 
 ## Troubleshooting
 

--- a/pkg/serverconfig/validate.go
+++ b/pkg/serverconfig/validate.go
@@ -46,12 +46,11 @@ func (c *Config) ValidateIngressCoherence() error {
 		if c.TLS.GetAcmeDNSProvider() != "" {
 			populated = append(populated, "tls.acme_dns_provider")
 		}
-		if len(c.TLS.AdditionalIPs) > 0 {
-			populated = append(populated, "tls.additional_ips")
-		}
-		if len(c.TLS.AdditionalNames) > 0 {
-			populated = append(populated, "tls.additional_names")
-		}
+		// tls.additional_names / tls.additional_ips are intentionally NOT
+		// gated here: they're applied to the API server cert (always-on
+		// TLS on the API port) and the etcd cert. Both exist regardless
+		// of ingress.mode. The fields gated above (self_signed,
+		// acme_email, acme_dns_provider) really are ingress-cert-only.
 		if len(populated) > 0 {
 			return fmt.Errorf("ingress.mode = %q does not terminate TLS, but the following [tls] fields are set and would be ignored: %s. Either remove them or pick a TLS-terminating mode (tls-autoprovision, behind-proxy-https)", mode, strings.Join(populated, ", "))
 		}

--- a/pkg/serverconfig/validate_test.go
+++ b/pkg/serverconfig/validate_test.go
@@ -75,6 +75,32 @@ func TestValidateIngressCoherence(t *testing.T) {
 			wantContains: "tls.acme_email, tls.acme_dns_provider",
 		},
 		{
+			// tls.additional_names / tls.additional_ips also feed the API
+			// server cert (and the etcd cert), which exist regardless of
+			// ingress.mode. So they must be allowed in behind-proxy-http.
+			name: "behind-proxy-http accepts tls.additional_names",
+			setup: func(c *Config) {
+				c.Ingress.SetMode(IngressModeBehindProxyHTTP)
+				c.TLS.AdditionalNames = []string{"miren.example.com"}
+			},
+		},
+		{
+			name: "behind-proxy-http accepts tls.additional_ips",
+			setup: func(c *Config) {
+				c.Ingress.SetMode(IngressModeBehindProxyHTTP)
+				c.TLS.AdditionalIPs = []string{"203.0.113.5"}
+			},
+		},
+		{
+			name: "behind-proxy-http rejects ingress-only fields even when additional_* are also set",
+			setup: func(c *Config) {
+				c.Ingress.SetMode(IngressModeBehindProxyHTTP)
+				c.TLS.SetAcmeEmail("ops@example.com")
+				c.TLS.AdditionalNames = []string{"miren.example.com"}
+			},
+			wantContains: "tls.acme_email",
+		},
+		{
 			name: "rejects unix: address with clear message",
 			setup: func(c *Config) {
 				c.Ingress.SetMode(IngressModeBehindProxyHTTP)


### PR DESCRIPTION
## Summary

`pkg/serverconfig/validate.go` rejects `tls.additional_names` and `tls.additional_ips` when `ingress.mode = behind-proxy-http`, on the grounds that "ingress doesn't terminate TLS, so these fields would be ignored". That premise is correct for `tls.self_signed`, `tls.acme_email`, and `tls.acme_dns_provider` — those only affect ingress cert provisioning. But `tls.additional_names` / `tls.additional_ips` also feed:

- **the API server cert** (`components/coordinate/coordinate.go::LoadAPICert` appends `c.AdditionalNames` and `c.IPs.RawIPs()` to the cert SANs before `authority.IssueCertificate`)
- **the etcd cert** (`coordinate.SetupEtcdTLS` is invoked with `cfg.TLS.AdditionalNames` and `ipSet.RawIPs()` from `cli/commands/server.go:315`)

Both of those certs exist regardless of ingress mode. So under `behind-proxy-http`, operators legitimately need to set these fields to make the API/etcd certs cover the cluster's public hostname / IP — but the validation refuses.

In our setup that surfaced as: external `miren deploy` from CI fails Go's TLS hostname check (`leaf cert SAN doesn't match miren.blueyard.app`) because removing `--dns-names=...` from ExecStart — necessary to satisfy this validator — also stripped the SAN from the API cert. No alternative knob exists to set just the API cert SANs.

## Change

Just remove the two over-broad checks. The downstream wiring already handles these fields correctly in every ingress mode.

```diff
 		if c.TLS.GetAcmeDNSProvider() != "" {
 			populated = append(populated, "tls.acme_dns_provider")
 		}
-		if len(c.TLS.AdditionalIPs) > 0 {
-			populated = append(populated, "tls.additional_ips")
-		}
-		if len(c.TLS.AdditionalNames) > 0 {
-			populated = append(populated, "tls.additional_names")
-		}
+		// tls.additional_names / tls.additional_ips are intentionally NOT
+		// gated here: they're applied to the API server cert (always-on
+		// TLS on the API port) and the etcd cert. Both exist regardless
+		// of ingress.mode. The fields gated above (self_signed,
+		// acme_email, acme_dns_provider) really are ingress-cert-only.
 		if len(populated) > 0 {
```

Tests added in `validate_test.go`:
- `behind-proxy-http accepts tls.additional_names`
- `behind-proxy-http accepts tls.additional_ips`
- `behind-proxy-http rejects ingress-only fields even when additional_* are also set`

Verifies the relaxation lands without weakening the ingress-only field check.

## Test plan

- [x] `go test ./pkg/serverconfig/` — passes (including the three new cases)
- [x] `golangci-lint run ./pkg/serverconfig/` — 0 issues
- [x] Manual: built locally, installed on a `behind-proxy-http` cluster with `--dns-names=miren.blueyard.app --ips=160.202.129.155` in ExecStart. miren came up cleanly, regenerated the API cert with the new SANs, and external `miren deploy` from off-box now succeeds where it previously failed Go's hostname check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
