### PR TITLE
Restart miren.service after register instead of warning

### DIFF
--- a/cli/commands/commands_linux.go
+++ b/cli/commands/commands_linux.go
@@ -8,7 +8,7 @@ func addCommands(d *mflags.Dispatcher) {
 	// Server command is now defined in commands.go (renamed from dev)
 
 	// Cloud registration commands
-	d.Dispatch("server register", Infer("server register", "Register this cluster with miren.cloud", Register,
+	d.Dispatch("server register", Infer("server register", "Register this cluster with miren.cloud", RegisterStandalone,
 		WithExample(mflags.Example{
 			Name: "Register with cloud",
 			Body: "miren server register --name my-cluster",

--- a/cli/commands/server_register.go
+++ b/cli/commands/server_register.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -15,6 +16,18 @@ type RegisterOptions struct {
 	CloudURL    string            `short:"u" long:"url" description:"Cloud URL" default:"https://miren.cloud"`
 	Tags        map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
 	OutputDir   string            `short:"o" long:"output" description:"Output directory for registration" default:"/var/lib/miren/server"`
+}
+
+// RegisterStandalone is the CLI entrypoint for `miren server register`. It runs
+// Register and then bounces the local miren.service if one is active, so the
+// user doesn't have to restart manually. The install paths call Register
+// directly because they own the service lifecycle themselves.
+func RegisterStandalone(ctx *Context, opts RegisterOptions) error {
+	if err := Register(ctx, opts); err != nil {
+		return err
+	}
+	restartMirenServiceIfActive(ctx)
+	return nil
 }
 
 // Register handles cluster registration with miren.cloud
@@ -201,9 +214,26 @@ func Register(ctx *Context, opts RegisterOptions) error {
 	}
 	ctx.Info("Configuration saved to: %s", opts.OutputDir)
 
-	ctx.Warn("If you're already running the miren server, you must now restart it to apply the new registration.")
-
 	return nil
+}
+
+// restartMirenServiceIfActive bounces the systemd miren.service so a newly
+// saved registration takes effect, but only when systemd is managing a
+// currently-running server. Other deployment styles (docker, manual, dev) are
+// left alone — install paths run their own lifecycle steps afterward, and
+// nothing the user needs to act on remains.
+func restartMirenServiceIfActive(ctx *Context) {
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return
+	}
+	if err := exec.Command("systemctl", "is-active", "--quiet", "miren.service").Run(); err != nil {
+		return
+	}
+	if err := exec.Command("systemctl", "restart", "miren.service").Run(); err != nil {
+		ctx.Warn("Failed to restart miren.service: %v. Restart manually to apply the new registration.", err)
+		return
+	}
+	ctx.Info("Restarted miren.service to apply the new registration.")
 }
 
 // RegisterStatus displays the current registration status


### PR DESCRIPTION
The warning at the end of `miren server register` ("you must now restart the miren server") was the bug, but the fix had a couple of layers. The warning fires at the end of every Register call, including from inside `miren install`, which then turns around and starts the systemd unit itself a few lines later. So during install it's pure noise. During a standalone re-register against a live cluster it's at least correct, but easy to miss in all the other registration output.

I went down the rabbit hole of "could register just be online and not need a restart at all" first. Short version: the cloud authenticator gets wired into RPC server options at construction time with no swap path, plus the build and deployment servers read DNSHostname by value at startup. So it's a real refactor across the auth chain to make any of it dynamic. Maybe worth it someday, but registration is a once-a-quarter operation and the surface area is large.

What we landed on instead: detect a running systemd `miren.service` and restart it ourselves. Fresh installs (systemd or docker) hit the "unit isn't active yet" branch and stay quiet, since install handles the lifecycle a few lines later anyway. Standalone re-register against a live cluster gets an auto-restart plus a "Restarted miren.service" info line. The one case it still doesn't handle is day-2 re-register on a docker install, but docker is the demo path so it pretty much never happens. Left it.

Closes MIR-1155