### PR TITLE
Add Pull Request Environments documentation

### DIFF
--- a/docs/docs/ci-deploy.md
+++ b/docs/docs/ci-deploy.md
@@ -25,6 +25,10 @@ This page covers OIDC for **CI/CD deployment authentication** — letting pipeli
 
 No secrets are stored in your CI system. The OIDC token is issued fresh for each job and expires in minutes.
 
+:::tip Per-PR Preview Deploys
+Pairing OIDC with [Pull Request Environments](/pr-environments) lets each PR get its own short-lived preview URL — see that page for the full workflow.
+:::
+
 ## Quick Start with GitHub Actions
 
 ### Step 1: Get Your Cluster Address

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -182,4 +182,5 @@ Miren automatically captures git metadata (commit, branch, author, dirty state) 
 - [App Configuration](/app-configuration) — Configure your app with `.miren/app.toml`
 - [Services](/services) — Define multiple processes in your app
 - [CI/CD Deployment](/ci-deploy) — Deploy from CI pipelines with OIDC authentication
+- [Pull Request Environments](/pr-environments) — Deploy labeled, time-boxed previews per PR
 - [app.toml Reference](/app-toml) — Complete field reference

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -29,6 +29,7 @@ Configuration lives in `.miren/app.toml` in your project. Environment variables,
 
 - [App Configuration](/app-configuration) - `.miren/app.toml` and how to configure your app
 - [Deployment](/deployment) - Deploy workflows, rollbacks, and CI integration
+- [Pull Request Environments](/pr-environments) - Time-boxed preview deploys, one per PR
 - [Services](/services) - Run multiple processes (web, workers, databases) in one app
 - [Scaling](/scaling) - Autoscaling and fixed instance modes
 - [Traffic Routing](/traffic-routing) - Custom domains, TLS, and path-based routing

--- a/docs/docs/pr-environments.md
+++ b/docs/docs/pr-environments.md
@@ -1,0 +1,253 @@
+---
+title: Pull Request Environments
+description: Deploy a labeled, time-boxed preview of your app on a subdomain — one per pull request, with automatic cleanup.
+keywords: [pr, preview, ephemeral, github, pull request, environment, review app]
+---
+
+import CliCommand from '@site/src/components/CliCommand';
+
+# Pull Request Environments
+
+A pull request environment is a labeled build of your app — called an **ephemeral version** in Miren — that runs alongside the active version on its own subdomain. It runs separetely from your normal deploys and is deleted automatically when its TTL expires. The typical use is one preview per PR, reachable at something like `pr-123.myapp.example.com`.
+
+## How It Works
+
+When you run `miren deploy --ephemeral <label>`:
+
+1. Miren builds the version but doesn't activate it. The active version keeps serving production traffic.
+2. The new version is reachable at `<label>.<your-app-host>`. A request for any subdomain of an existing route is looked up against ephemeral labels for that route — no separate route entity needed.
+3. After the TTL elapses (default 24 hours), a background controller deletes the version.
+
+Ephemeral deploys don't create deployment history records, don't take the deployment lock, and don't block normal deploys.
+
+## Quick Start
+
+**Step 1: Point DNS at your cluster for the subdomains you'll use.** A wildcard CNAME is the usual choice:
+
+```text
+*.myapp.example.com.   CNAME   cluster-jwomf2l0tn8z.miren.systems.
+```
+
+You don't need to configure a wildcard route on your server. Any existing route for `myapp.example.com` will pick up `pr-123.myapp.example.com` as an ephemeral lookup. See [Custom Domains](/traffic-routing#custom-domains) for the full DNS setup.
+
+**Step 2: Deploy with `--ephemeral` and an optional TTL.**
+
+<CliCommand context="client">
+```miren
+miren deploy --ephemeral pr-123 --ttl 48h
+```
+</CliCommand>
+
+Miren builds the version and prints the access URL:
+
+```text
+Ephemeral version myapp-vXYZ created.
+  Label: pr-123
+  TTL:   48h
+  URL:   https://pr-123.myapp.example.com
+```
+
+Open the URL — your preview is live. TLS provisions on first request.
+
+## What Runs in an Ephemeral Version
+
+**Only the `web` service runs.** Workers, background jobs, scheduled tasks, and any other services defined in `.miren/app.toml` aren't started for ephemeral versions — HTTP traffic to the subdomain is the only thing wired up. If reviewing your PR requires a worker too, use a separate staging app instead.
+
+**Configuration is shared with the active version.** Env vars, secrets, addons, and build config all come from the app's current settings. There's no per-ephemeral override:
+
+- Your preview connects to the same database, queues, and external services as production.
+- You can't change `RAILS_ENV`, feature flags, or service URLs just for the preview.
+- Updates to app config (via `miren config set`, addons, etc.) affect both active and ephemeral versions.
+
+If you need isolation from production data, run ephemeral deploys against a separate staging app.
+
+## Using a Staging App
+
+Because ephemeral versions share config with the active version, a preview deployed against your production app talks to your production database, queues, and external services. That's fine for read-mostly UI changes, but risky as soon as a PR writes data, runs migrations, or fires background jobs.
+
+The recommended pattern is to keep a second app — typically `myapp-staging` — that points at a staging database and any other backing services you want isolated. Run all PR previews against that app instead of production.
+
+**Step 1: Create the staging app.** Deploy your main branch to it with whatever staging-specific config you want:
+
+<CliCommand context="client">
+```miren
+miren deploy -a myapp-staging \
+  -e DATABASE_URL=postgres://staging-db.internal/myapp \
+  -e RAILS_ENV=staging
+```
+</CliCommand>
+
+**Step 2: Add a route for the staging app and wildcard DNS for its subdomains.**
+
+<CliCommand context="client">
+```miren
+miren route set staging.myapp.example.com myapp-staging
+```
+</CliCommand>
+
+```text
+*.staging.myapp.example.com.   CNAME   cluster-jwomf2l0tn8z.miren.systems.
+```
+
+**Step 3: Run PR previews against the staging app.**
+
+<CliCommand context="client">
+```miren
+miren deploy -a myapp-staging --ephemeral pr-123 --ttl 48h
+```
+</CliCommand>
+
+The preview is reachable at `pr-123.staging.myapp.example.com`, isolated from production data. Redeploy the staging app's active version periodically (or on every push to `main`) to keep its baseline fresh — ephemeral previews inherit the staging app's current config and addons, not production's.
+
+In CI, set `MIREN_APP=myapp-staging` (or pass `app: myapp-staging` to the deploy action) so PR workflows always target staging.
+
+#### Using a Staging Cluster
+
+Another pattern is to setup a separate staging cluster that you deploy the PRs to, rather than your production cluster. This lets you isolate the preview even more.
+
+## Labels
+
+Labels are used as DNS subdomains, so they must be DNS-compliant (RFC 1123):
+
+- Lowercase alphanumeric characters and hyphens only
+- Must start and end with an alphanumeric character
+- Max 63 characters
+
+Miren normalizes common separators for you — underscores, slashes, and dots become hyphens, uppercase is lowercased, and other characters are stripped:
+
+| Input | Normalized |
+|-------|------------|
+| `feat/login` | `feat-login` |
+| `My_Branch.v2` | `my-branch-v2` |
+| `PR-123` | `pr-123` |
+
+So a Git branch name usually works as-is:
+
+<CliCommand context="client">
+```miren
+miren deploy --ephemeral "$(git rev-parse --abbrev-ref HEAD)"
+```
+</CliCommand>
+
+**Redeploying with the same label replaces the prior version.** Push a new commit, redeploy with `--ephemeral pr-123`, and the previous `pr-123` version is deleted before the new one becomes reachable. The TTL resets on each deploy.
+
+## TTL and Cleanup
+
+`--ttl` takes a Go duration string (`30m`, `2h`, `48h`) and defaults to `24h`. Expiration is fixed at deploy time.
+
+A background controller sweeps expired versions every five minutes. Requests to an expired label return a 404 once the next sweep runs. There's no extend command — redeploy with the same label to refresh the TTL.
+
+**Per-app limit.** Each app can have at most 10 ephemeral versions at once. Deploying an 11th evicts the version nearest to expiry. Replacing an existing label doesn't count against the limit, since the old version is deleted before the new one is created.
+
+## Listing Ephemeral Versions
+
+Show only ephemeral versions for an app:
+
+<CliCommand context="client">
+```miren
+miren app versions --ephemeral
+```
+</CliCommand>
+
+```text
+VERSION                              LABEL    CREATED   EXPIRES
+myapp-vCVkjR6u7744AsMebwMjGU         pr-123   2m ago    2026-05-28 14:00:00
+myapp-vCVkjJSe4fydvxEHfhsKfA         pr-118   3h ago    2026-05-28 11:30:00
+```
+
+`--format json` is supported for scripting. Drop `--ephemeral` to see all versions, with ephemeral ones marked.
+
+Ephemeral deploys don't appear in `miren app history` — that command shows only tracked deployments of the active version.
+
+## GitHub Actions: Per-PR Previews
+
+To deploy a preview per pull request from GitHub Actions, pair this with [CI/CD Deployment with OIDC](/ci-deploy) so no secrets land in your repo. The example below targets a staging app — see [Using a Staging App](#using-a-staging-app) for why that's the recommended setup.
+
+**Step 1: Allow `pull_request` events on the OIDC binding.**
+
+`miren auth ci --github` permits `push` and `workflow_dispatch` by default. Add `pull_request`:
+
+<CliCommand context="client">
+```miren
+miren auth ci myapp-staging --github acme/web-app \
+  --allowed-events push,workflow_dispatch,pull_request
+```
+</CliCommand>
+
+**Step 2: Add the workflow.**
+
+```yaml
+name: PR Preview
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy preview
+        uses: mirendev/actions/deploy@main
+        with:
+          cluster: ${{ secrets.MIREN_CLUSTER }}
+          app: myapp-staging
+          args: --ephemeral pr-${{ github.event.pull_request.number }} --ttl 48h
+```
+
+Each push replaces the previous preview at the same label. When the PR is merged or closed, the version expires on its own — no teardown step needed.
+
+The preview URL follows the pattern `pr-<number>.staging.<your-host>`, so a follow-up step can post it as a PR comment:
+
+```yaml
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `https://pr-${context.issue.number}.staging.myapp.example.com`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Preview deployed: ${url}`,
+            });
+```
+
+## Limitations
+
+- **`web` service only** — workers and other services from your app config don't start (see [What Runs in an Ephemeral Version](#what-runs-in-an-ephemeral-version)).
+- **Shared configuration** — env vars, secrets, and addons all come from the app. No per-preview overrides.
+- **No deployment history** — `miren app history`, `miren rollback`, and the deployment lock all ignore ephemeral deploys.
+- **10 per app** — older versions are evicted by expiry as new ones arrive.
+- **DNS must cover the subdomains** — without a wildcard CNAME (or per-label records) pointing at your cluster, the URL won't resolve.
+
+## Command Reference
+
+### `miren deploy`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--ephemeral LABEL` | Deploy as an ephemeral preview with this label. Label is normalized to a DNS-safe form. | (off) |
+| `--ttl DURATION` | TTL for the ephemeral version (e.g. `30m`, `48h`). Used only with `--ephemeral`. | `24h` |
+
+### `miren app versions`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--ephemeral` | Show only ephemeral versions for the app. | (off) |
+| `-n, --limit N` | Max versions to show. | `20` |
+| `--format` | Output format (`table`, `json`). | `table` |
+
+See the full [`miren deploy`](/command/deploy) and [`miren app versions`](/command/app-versions) reference pages for all options.
+
+## Next Steps
+
+- [Deployment](/deployment) — How normal deploys work
+- [Traffic Routing](/traffic-routing) — Routes, wildcard DNS, and custom domains
+- [CI/CD Deployment with OIDC](/ci-deploy) — Deploy from GitHub Actions without stored secrets
+- [TLS Certificates](/tls) — How HTTPS works for ephemeral subdomains

--- a/docs/docs/pr-environments.md
+++ b/docs/docs/pr-environments.md
@@ -65,7 +65,7 @@ If you need isolation from production data, run ephemeral deploys against a sepa
 
 Because ephemeral versions share config with the active version, a preview deployed against your production app talks to your production database, queues, and external services. That's fine for read-mostly UI changes, but risky as soon as a PR writes data, runs migrations, or fires background jobs.
 
-The recommended pattern is to keep a second app — typically `myapp-staging` — that points at a staging database and any other backing services you want isolated. Run all PR previews against that app instead of production.
+Set up a second app — typically `myapp-staging` — that points at a staging database and any other backing services you want isolated, then run all PR previews against that app instead of production.
 
 **Step 1: Create the staging app.** Deploy your main branch to it with whatever staging-specific config you want:
 
@@ -135,7 +135,7 @@ miren deploy --ephemeral "$(git rev-parse --abbrev-ref HEAD)"
 
 `--ttl` takes a Go duration string (`30m`, `2h`, `48h`) and defaults to `24h`. Expiration is fixed at deploy time.
 
-A background controller sweeps expired versions every five minutes. Requests to an expired label return a 404 once the next sweep runs. There's no extend command — redeploy with the same label to refresh the TTL.
+Requests to an expired label return 404 immediately — the ephemeral lookup filters expired versions itself, so the cutoff is enforced as soon as the timestamp passes. A background controller sweeps the actual entities every five minutes to free their resources. There's no extend command — redeploy with the same label to refresh the TTL.
 
 **Per-app limit.** Each app can have at most 10 ephemeral versions at once. Deploying an 11th evicts the version nearest to expiry. Replacing an existing label doesn't count against the limit, since the old version is deleted before the new one is created.
 
@@ -228,22 +228,7 @@ The preview URL follows the pattern `pr-<number>.staging.<your-host>`, so a foll
 
 ## Command Reference
 
-### `miren deploy`
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--ephemeral LABEL` | Deploy as an ephemeral preview with this label. Label is normalized to a DNS-safe form. | (off) |
-| `--ttl DURATION` | TTL for the ephemeral version (e.g. `30m`, `48h`). Used only with `--ephemeral`. | `24h` |
-
-### `miren app versions`
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--ephemeral` | Show only ephemeral versions for the app. | (off) |
-| `-n, --limit N` | Max versions to show. | `20` |
-| `--format` | Output format (`table`, `json`). | `table` |
-
-See the full [`miren deploy`](/command/deploy) and [`miren app versions`](/command/app-versions) reference pages for all options.
+The flags introduced on this page are `--ephemeral` and `--ttl` on [`miren deploy`](/command/deploy), and `--ephemeral` on [`miren app versions`](/command/app-versions). Those reference pages have the full flag listings.
 
 ## Next Steps
 

--- a/docs/docs/pr-environments.md
+++ b/docs/docs/pr-environments.md
@@ -8,7 +8,7 @@ import CliCommand from '@site/src/components/CliCommand';
 
 # Pull Request Environments
 
-A pull request environment is a labeled build of your app — called an **ephemeral version** in Miren — that runs alongside the active version on its own subdomain. It runs separetely from your normal deploys and is deleted automatically when its TTL expires. The typical use is one preview per PR, reachable at something like `pr-123.myapp.example.com`.
+A pull request environment is a labeled build of your app — called an **ephemeral version** in Miren — that runs alongside the active version on its own subdomain. It runs separately from your normal deploys and is deleted automatically when its TTL expires. The typical use is one preview per PR, reachable at something like `pr-123.myapp.example.com`.
 
 ## How It Works
 
@@ -101,7 +101,7 @@ The preview is reachable at `pr-123.staging.myapp.example.com`, isolated from pr
 
 In CI, set `MIREN_APP=myapp-staging` (or pass `app: myapp-staging` to the deploy action) so PR workflows always target staging.
 
-#### Using a Staging Cluster
+### Using a Staging Cluster
 
 Another pattern is to setup a separate staging cluster that you deploy the PRs to, rather than your production cluster. This lets you isolate the preview even more.
 

--- a/docs/docs/pr-environments.md
+++ b/docs/docs/pr-environments.md
@@ -193,23 +193,25 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Deploy preview
+        id: deploy
         uses: mirendev/actions/deploy@main
         with:
           cluster: ${{ secrets.MIREN_CLUSTER }}
           app: myapp-staging
-          args: --ephemeral pr-${{ github.event.pull_request.number }} --ttl 48h
+          ephemeral: pr-${{ github.event.pull_request.number }}
+          ttl: 48h
 ```
 
 Each push replaces the previous preview at the same label. When the PR is merged or closed, the version expires on its own — no teardown step needed.
 
-The preview URL follows the pattern `pr-<number>.staging.<your-host>`, so a follow-up step can post it as a PR comment:
+The deploy action exposes the preview URL as a step output, so a follow-up step can post it as a PR comment:
 
 ```yaml
       - name: Comment preview URL
         uses: actions/github-script@v7
         with:
           script: |
-            const url = `https://pr-${context.issue.number}.staging.myapp.example.com`;
+            const url = '${{ steps.deploy.outputs.url }}';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/docs/docs/traffic-routing.md
+++ b/docs/docs/traffic-routing.md
@@ -42,6 +42,8 @@ If an exact route also exists for a specific subdomain, the exact route takes pr
 
 The wildcard `*` must be the first label — patterns like `foo.*.example.com` are not supported. The domain must have at least two labels after the wildcard (e.g., `*.example.com` is valid, `*.com` is not).
 
+For [Pull Request Environments](/pr-environments), you don't need a wildcard route — any subdomain of an existing route automatically resolves to its ephemeral label. You only need wildcard *DNS* pointing at your cluster.
+
 ### Custom Domains
 
 To put your own domain in front of an app on Miren, point DNS at your cluster and set a route. TLS provisions automatically.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -35,6 +35,7 @@ const sidebars: SidebarsConfig = {
         'waf',
         'route-protect',
         'ci-deploy',
+        'pr-environments',
         'admin-interface',
         'observability',
         'logs',


### PR DESCRIPTION
## Summary

Closes MIR-995. Adds a dedicated docs page for ephemeral deploys (a.k.a. PR environments), since today the feature is only documented in a one-line changelog entry and the auto-generated `--ephemeral` flag descriptions.

- New `docs/docs/pr-environments.md` covering:
  - How ephemeral deploys work (build + don't activate, subdomain lookup, TTL cleanup)
  - Quick start (DNS-only — no wildcard route needed)
  - **What runs**: `web` service only, configuration is shared with the active version
  - **Using a staging app**: the recommended pattern for keeping previews off production data, with a staging-cluster alternative
  - Label rules (RFC 1123 normalization)
  - TTL & cleanup (default 24h, sweeps every 5 min, 10-version per-app cap)
  - GitHub Actions per-PR preview workflow targeting the staging app, with OIDC + PR-comment posting
  - Limitations and command-flag reference
- Wires the page into the Features sidebar.
- Cross-links from `deployment.md`, `traffic-routing.md`, `ci-deploy.md`, and `intro.md`.

## Test plan

- [x] `bun run build` passes (lint + Docusaurus build, no broken links)
- [ ] `bun run start` and click through every cross-link in the new doc
- [ ] Eyeball the rendered page on https://miren.md/ once merged