### PR TITLE
Stop racing ourselves on the docker release artifacts

### DIFF
--- a/docker/Dockerfile.miren
+++ b/docker/Dockerfile.miren
@@ -29,11 +29,10 @@ RUN chmod +x /entrypoint.sh
 # Create necessary directories
 RUN mkdir -p /var/lib/miren
 
-# Download the components to run the server
-# TODO this should be given the specific version to download
-# Right now we're not using the miren binary in the release, just
-# the components like containerd, so it's less of a big deal.
-RUN miren download release -g
+# Install release components for the server runtime (containerd, etc.).
+# Same artifacts as /usr/local/bin above; copying locally avoids racing
+# the upload-to-miren job that publishes these to api.miren.cloud.
+COPY docker/artifacts/${TARGETARCH}/ /var/lib/miren/release/
 
 # Declare volume for data persistence
 VOLUME /var/lib/miren


### PR DESCRIPTION
The release pipeline had this weird self-own where the docker build job would race against the upload-to-miren job that was, at that exact moment, publishing the artifacts the docker build was trying to download. Both jobs gate on `[init, test, package]` and run in parallel, and the upload pushes a .tar.gz and its .sha256 sidecar through a parallel worker pool. The small .sha256 finishes first, so for a 30-60 second window api.miren.cloud is serving the new hash next to the still-old tarball. The docker build's `miren download release -g` would predictably pull both and blow up on a checksum mismatch. Failure was at https://github.com/mirendev/runtime/actions/runs/26537880941.

The fun part: the docker job already has the tarball locally. The workflow extracts `release-base-linux-${arch}.tar.gz` into `docker/artifacts/${TARGETARCH}/` before invoking buildx, and that's the exact same content the Dockerfile was turning around and re-downloading from miren.cloud. Pre-existing TODO in the Dockerfile even acknowledged the redundancy. So this just swaps the `RUN miren download release -g` for a `COPY docker/artifacts/${TARGETARCH}/ /var/lib/miren/release/` and calls it a day.

Worth being honest about what this doesn't fix: the api.miren.cloud inconsistency is still real for end users running `miren download release -g` against mutable channels (`main`, `latest`) while a release is mid-publish. The window is narrow and a retry clears it, but the bug exists. Filed as MIR-1170 with a proposal for an OCI-style content-addressed asset layout that would close it for all consumers.