### PR TITLE
Spread multi-replica sandboxes across runners

### DIFF
--- a/controllers/scheduler/scheduler.go
+++ b/controllers/scheduler/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 )
@@ -92,18 +93,17 @@ func (c *Controller) Reconcile(ctx context.Context, sandbox *compute_v1alpha.San
 	} else {
 		// Stateless sandboxes prefer runner nodes when available
 		runnerNodes := c.filterRunnerNodes(nodes)
-		if len(runnerNodes) > 0 {
-			assignedNode = runnerNodes[rand.Intn(len(runnerNodes))]
-			c.log.Debug("scheduling stateless sandbox to runner",
-				"sandbox", sandbox.ID,
-				"node", assignedNode.ID)
-		} else {
-			// Fall back to any available node (including coordinator)
-			assignedNode = nodes[rand.Intn(len(nodes))]
-			c.log.Debug("scheduling stateless sandbox to available node (no runners)",
-				"sandbox", sandbox.ID,
-				"node", assignedNode.ID)
+		candidates := runnerNodes
+		fallback := "runner"
+		if len(candidates) == 0 {
+			candidates = nodes
+			fallback = "available node (no runners)"
 		}
+
+		assignedNode = c.pickWithAntiAffinity(ctx, meta, candidates)
+		c.log.Debug("scheduling stateless sandbox to "+fallback,
+			"sandbox", sandbox.ID,
+			"node", assignedNode.ID)
 	}
 
 	c.log.Info("assigning sandbox to node",
@@ -155,6 +155,93 @@ func (c *Controller) filterRunnerNodes(nodes []*compute_v1alpha.Node) []*compute
 		}
 	}
 	return runners
+}
+
+// pickWithAntiAffinity picks a node from candidates that minimizes co-location
+// with other replicas in the same pool. Sandboxes labelled `pool: <id>` (the
+// label is set by the sandbox pool manager) are treated as siblings. Among
+// candidates with the fewest active siblings, one is chosen randomly. Sandboxes
+// without a pool label, or when sibling lookup fails, fall back to a uniform
+// random pick — one-off sandboxes don't carry a spread guarantee.
+//
+// "Active" here means a sibling that is already scheduled and is not in a
+// terminal status (STOPPED, DEAD). Terminal siblings have released their slot
+// on the node and shouldn't influence placement.
+func (c *Controller) pickWithAntiAffinity(ctx context.Context, meta *entity.Meta, candidates []*compute_v1alpha.Node) *compute_v1alpha.Node {
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+
+	var md core_v1alpha.Metadata
+	md.Decode(meta)
+	poolLabel, ok := md.Labels.Get("pool")
+	if !ok || poolLabel == "" {
+		return candidates[rand.Intn(len(candidates))]
+	}
+
+	counts, err := c.countSiblingsPerNode(ctx, poolLabel, meta.Id())
+	if err != nil {
+		c.log.Warn("anti-affinity sibling lookup failed, falling back to random",
+			"pool", poolLabel, "error", err)
+		return candidates[rand.Intn(len(candidates))]
+	}
+
+	minCount := -1
+	var winners []*compute_v1alpha.Node
+	for _, node := range candidates {
+		n := counts[node.ID]
+		if minCount == -1 || n < minCount {
+			minCount = n
+			winners = winners[:0]
+			winners = append(winners, node)
+		} else if n == minCount {
+			winners = append(winners, node)
+		}
+	}
+
+	return winners[rand.Intn(len(winners))]
+}
+
+// countSiblingsPerNode tallies active sandboxes in the same pool by their
+// assigned node. Siblings are sandboxes carrying the same `pool` label, with
+// a Schedule already attached, and not in a terminal status. The sandbox
+// currently being scheduled is excluded from the count.
+func (c *Controller) countSiblingsPerNode(ctx context.Context, poolLabel string, selfID entity.Id) (map[entity.Id]int, error) {
+	results, err := c.eac.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return nil, err
+	}
+
+	counts := make(map[entity.Id]int)
+	for _, ent := range results.Values() {
+		if entity.Id(ent.Id()) == selfID {
+			continue
+		}
+
+		e := ent.Entity()
+
+		var md core_v1alpha.Metadata
+		md.Decode(e)
+		if label, ok := md.Labels.Get("pool"); !ok || label != poolLabel {
+			continue
+		}
+
+		var sibling compute_v1alpha.Sandbox
+		sibling.Decode(e)
+		if sibling.Status == compute_v1alpha.STOPPED || sibling.Status == compute_v1alpha.DEAD {
+			continue
+		}
+
+		var schedule compute_v1alpha.Schedule
+		schedule.Decode(e)
+		if schedule.Key.Node == "" {
+			continue
+		}
+
+		counts[schedule.Key.Node]++
+	}
+
+	return counts, nil
 }
 
 // gatherNodes fetches all node entities from the entity store

--- a/controllers/scheduler/scheduler_test.go
+++ b/controllers/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -489,4 +490,199 @@ func TestIsStatefulDetection(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// createPreScheduledSandbox creates a sandbox already assigned to a node, used
+// to seed sibling state for spread tests.
+func createPreScheduledSandbox(t *testing.T, ctx context.Context, server *testutils.InMemEntityServer, name, poolID string, nodeID entity.Id, status compute_v1alpha.SandboxStatus) entity.Id {
+	t.Helper()
+
+	sb := &compute_v1alpha.Sandbox{
+		Status: status,
+		Spec: compute_v1alpha.SandboxSpec{
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+	sbID, err := server.Client.Create(ctx, name, sb,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID)))
+	require.NoError(t, err)
+
+	// Patch in the schedule via the entity server so cardinality-aware merge
+	// keeps the sandbox's existing entity/kind alongside the new schedule kind.
+	schedule := compute_v1alpha.Schedule{
+		Key: compute_v1alpha.Key{
+			Kind: compute_v1alpha.KindSandbox,
+			Node: nodeID,
+		},
+	}
+	err = server.Client.Patch(ctx, sbID, 0, schedule.Encode()...)
+	require.NoError(t, err)
+
+	return sbID
+}
+
+// TestSchedulerSpreadsReplicasAcrossRunners is the MIR-1143 regression: with
+// two runners and two siblings in the same pool, both replicas must not pile
+// onto the same node. Repeats enough times to catch the random-collision case
+// that surfaced the bug.
+func TestSchedulerSpreadsReplicasAcrossRunners(t *testing.T) {
+	for trial := 0; trial < 20; trial++ {
+		t.Run(fmt.Sprintf("trial-%d", trial), func(t *testing.T) {
+			ctx := context.Background()
+			log := testutils.TestLogger(t)
+
+			server, cleanup := testutils.NewInMemEntityServer(t)
+			defer cleanup()
+
+			runner1 := createReadyNode(t, ctx, server.Client, "runner-1", &compute_v1alpha.Node{
+				Status:   compute_v1alpha.READY,
+				RunnerId: "550e8400-e29b-41d4-a716-446655440001",
+			})
+			runner2 := createReadyNode(t, ctx, server.Client, "runner-2", &compute_v1alpha.Node{
+				Status:   compute_v1alpha.READY,
+				RunnerId: "550e8400-e29b-41d4-a716-446655440002",
+			})
+
+			scheduler := NewController(log, server.EAC)
+			require.NoError(t, scheduler.Init(ctx))
+
+			poolID := "pool-spread-test"
+
+			placements := make(map[entity.Id]int)
+			for i := 0; i < 2; i++ {
+				sb := &compute_v1alpha.Sandbox{
+					Status: compute_v1alpha.PENDING,
+					Spec: compute_v1alpha.SandboxSpec{
+						Container: []compute_v1alpha.SandboxSpecContainer{
+							{Image: "test:latest"},
+						},
+					},
+				}
+				sbID, err := server.Client.Create(ctx, fmt.Sprintf("sb-%d", i), sb,
+					entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID)))
+				require.NoError(t, err)
+
+				reconcileSandbox(t, ctx, server, scheduler, sbID)
+
+				resp, err := server.EAC.Get(ctx, sbID.String())
+				require.NoError(t, err)
+				var schedule compute_v1alpha.Schedule
+				schedule.Decode(resp.Entity().Entity())
+				placements[schedule.Key.Node]++
+			}
+
+			assert.Equal(t, 1, placements[runner1], "runner-1 should host exactly one replica")
+			assert.Equal(t, 1, placements[runner2], "runner-2 should host exactly one replica")
+		})
+	}
+}
+
+// TestSchedulerPacksWhenReplicasExceedRunners verifies the soft fallback: with
+// more replicas than runners we don't refuse to schedule, we just pack.
+func TestSchedulerPacksWhenReplicasExceedRunners(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	runner1 := createReadyNode(t, ctx, server.Client, "runner-1", &compute_v1alpha.Node{
+		Status:   compute_v1alpha.READY,
+		RunnerId: "550e8400-e29b-41d4-a716-446655440001",
+	})
+	runner2 := createReadyNode(t, ctx, server.Client, "runner-2", &compute_v1alpha.Node{
+		Status:   compute_v1alpha.READY,
+		RunnerId: "550e8400-e29b-41d4-a716-446655440002",
+	})
+
+	scheduler := NewController(log, server.EAC)
+	require.NoError(t, scheduler.Init(ctx))
+
+	poolID := "pool-pack-test"
+
+	placements := make(map[entity.Id]int)
+	for i := 0; i < 5; i++ {
+		sb := &compute_v1alpha.Sandbox{
+			Status: compute_v1alpha.PENDING,
+			Spec: compute_v1alpha.SandboxSpec{
+				Container: []compute_v1alpha.SandboxSpecContainer{
+					{Image: "test:latest"},
+				},
+			},
+		}
+		sbID, err := server.Client.Create(ctx, fmt.Sprintf("sb-%d", i), sb,
+			entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID)))
+		require.NoError(t, err)
+
+		reconcileSandbox(t, ctx, server, scheduler, sbID)
+
+		resp, err := server.EAC.Get(ctx, sbID.String())
+		require.NoError(t, err)
+		var schedule compute_v1alpha.Schedule
+		schedule.Decode(resp.Entity().Entity())
+		placements[schedule.Key.Node]++
+	}
+
+	assert.Equal(t, 5, placements[runner1]+placements[runner2], "all replicas should be scheduled")
+	// With 5 replicas over 2 runners the soft-spread keeps each node within 1
+	// of perfect balance (i.e. 3/2 or 2/3 — no 5/0 or 4/1).
+	diff := placements[runner1] - placements[runner2]
+	if diff < 0 {
+		diff = -diff
+	}
+	assert.LessOrEqual(t, diff, 1, "soft spread should balance within 1: got %d/%d",
+		placements[runner1], placements[runner2])
+}
+
+// TestSchedulerSpreadIgnoresTerminalSiblings ensures STOPPED and DEAD siblings
+// don't influence placement — they're not actually consuming the node.
+func TestSchedulerSpreadIgnoresTerminalSiblings(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	runner1 := createReadyNode(t, ctx, server.Client, "runner-1", &compute_v1alpha.Node{
+		Status:   compute_v1alpha.READY,
+		RunnerId: "550e8400-e29b-41d4-a716-446655440001",
+	})
+	runner2 := createReadyNode(t, ctx, server.Client, "runner-2", &compute_v1alpha.Node{
+		Status:   compute_v1alpha.READY,
+		RunnerId: "550e8400-e29b-41d4-a716-446655440002",
+	})
+
+	poolID := "pool-terminal-test"
+
+	// runner-1 has a STOPPED sibling (should be ignored).
+	// runner-2 has a RUNNING sibling (should count).
+	// A fresh replica should land on runner-1 because it has 0 active siblings.
+	createPreScheduledSandbox(t, ctx, server, "stopped-sb", poolID, runner1, compute_v1alpha.STOPPED)
+	createPreScheduledSandbox(t, ctx, server, "running-sb", poolID, runner2, compute_v1alpha.RUNNING)
+
+	scheduler := NewController(log, server.EAC)
+	require.NoError(t, scheduler.Init(ctx))
+
+	sb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.PENDING,
+		Spec: compute_v1alpha.SandboxSpec{
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Image: "test:latest"},
+			},
+		},
+	}
+	sbID, err := server.Client.Create(ctx, "fresh-sb", sb,
+		entityserver.WithLabels(types.LabelSet("service", "web", "pool", poolID)))
+	require.NoError(t, err)
+
+	reconcileSandbox(t, ctx, server, scheduler, sbID)
+
+	resp, err := server.EAC.Get(ctx, sbID.String())
+	require.NoError(t, err)
+	var schedule compute_v1alpha.Schedule
+	schedule.Decode(resp.Entity().Entity())
+	assert.Equal(t, runner1, schedule.Key.Node,
+		"fresh replica should prefer runner-1 (0 active siblings) over runner-2 (1 active sibling)")
 }

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -185,6 +185,21 @@ func (m *MockStore) UpdateEntity(ctx context.Context, id Id, entity *Entity, opt
 		return nil, err
 	}
 
+	// Determine which incoming attr IDs should replace existing values
+	// (cardinality=one) vs accumulate alongside them (cardinality=many).
+	// Mirrors EtcdStore.UpdateEntity (store.go:687) so mock-backed tests
+	// observe the same merge semantics production does.
+	replaceIds := make(map[Id]bool)
+	for _, attr := range entity.attrs {
+		schema, err := m.GetAttributeSchema(ctx, attr.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get attribute schema: %w", err)
+		}
+		if !schema.AllowMany {
+			replaceIds[attr.ID] = true
+		}
+	}
+
 	m.mu.Lock()
 	e, ok := m.Entities[id]
 	if !ok {
@@ -192,22 +207,16 @@ func (m *MockStore) UpdateEntity(ctx context.Context, id Id, entity *Entity, opt
 		return nil, cond.NotFound("entity", id)
 	}
 
-	// Build combined attribute list
-	combinedAttrs := make([]Attr, 0, len(e.attrs))
-
-	// First, copy over existing attributes that aren't being updated
-	attrMap := make(map[Id]Attr)
-	for _, attr := range entity.attrs {
-		attrMap[attr.ID] = attr
-	}
-
+	// Keep existing attrs except those being replaced (cardinality=one IDs
+	// present in the incoming change). Cardinality=many attrs are preserved
+	// so the new incoming values append to the existing set.
+	combinedAttrs := make([]Attr, 0, len(e.attrs)+len(entity.attrs))
 	for _, existing := range e.attrs {
-		if _, isUpdated := attrMap[existing.ID]; !isUpdated {
+		if !replaceIds[existing.ID] {
 			combinedAttrs = append(combinedAttrs, existing)
 		}
 	}
 
-	// Then add the new/updated attributes
 	combinedAttrs = append(combinedAttrs, entity.attrs...)
 
 	// Create a copy to avoid modifying the original

--- a/pkg/entity/testutils/inmem_server.go
+++ b/pkg/entity/testutils/inmem_server.go
@@ -34,8 +34,21 @@ func NewInMemEntityServer(t *testing.T) (*InMemEntityServer, func()) {
 	// Create mock store
 	mockStore := entity.NewMockStore()
 
+	// Seed system schema entities (entity/kind cardinality, etc) so the mock
+	// reports the same AttributeSchema that EtcdStore does. Without this,
+	// MockStore.UpdateEntity treats every attr as cardinality-one and
+	// silently drops existing values on cardinality-many attrs like
+	// entity/kind during patch.
+	err := entity.InitSystemEntities(func(e *entity.Entity) error {
+		mockStore.AddEntity(e.Id(), e)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to init system entities: %v", err)
+	}
+
 	// Apply schema to the store
-	err := schema.Apply(ctx, mockStore)
+	err = schema.Apply(ctx, mockStore)
 	if err != nil {
 		t.Fatalf("failed to apply schema: %v", err)
 	}


### PR DESCRIPTION
During the [MIR-954](https://linear.app/miren/issue/MIR-954) garden bake we noticed mirendev had both of its replicas sharing `runner-2`. If that node had blipped, the live-replica count would have dropped to zero instead of degrading to one. Tracing it down, the scheduler was calling `rand.Intn(len(runnerNodes))` independently for each sandbox with no awareness of where the app's other replicas already lived. Two coin-flips on two nodes hit 50/50 collision; same risk applies to any multi-replica app on a multi-runner cluster.

The fix is the soft anti-affinity flavor that the issue called out as option 1. When a stateless sandbox carries a `pool` label (the sandbox pool manager already stamps these), the scheduler reads its siblings out of the entity store, counts how many active ones live on each candidate runner, and picks the one with the fewest. Ties get random tiebreak. Sandboxes without a pool label, like one-offs or debug exec sandboxes, fall through to today's uniform random pick because they don't carry a spread guarantee. When you have more replicas than runners we pack instead of refusing, which keeps `num_instances >= n_runners` deploys working.

Perf wise, this lists all sandboxes once per scheduling event. Reasonable for now: bursty during deploys, zero in steady state, and it mirrors the pattern `sandboxpool.Manager.listSandboxes` already uses. If it ever shows up in a flame graph, the natural next step is the scheduler maintaining a `pool → []scheduledNode` map fed by its existing sandbox watch, not a separate cache layer.

Getting the tests to pass dragged a hidden mockstore bug into the light. `MockStore.UpdateEntity` was treating every incoming attr as cardinality-one and dropping the existing values on patch. EtcdStore honors `AllowMany`: cardinality-many attrs like `entity/kind` accumulate, so when the scheduler patches in `Schedule.Encode()` you end up with `[kind.sandbox, kind.schedule, kind.metadata]`, which is the intended trait declaration (the entity has schedule attrs set, so it has the schedule trait). Mock was collapsing that to just `kind.schedule`, which both hid the trait semantics and broke my anti-affinity tests because scheduled sandboxes were falling out of the by-kind index. Mock now mirrors etcd's behavior, and `NewInMemEntityServer` seeds system entities so `GetAttributeSchema` actually has the schema entity to consult for `entity/kind`'s cardinality.

Closes MIR-1143