### PR TITLE
labs: graduate admin API to GA, remove adminapi flag

### DIFF
--- a/cli/commands/server_install_docker.go
+++ b/cli/commands/server_install_docker.go
@@ -29,7 +29,7 @@ func ServerInstallDocker(ctx *Context, opts struct {
 	ClusterName  string            `long:"cluster-name" description:"Cluster name for cloud registration"`
 	CloudURL     string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
 	Tags         map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
-	Labs         []string          `short:"l" long:"labs" description:"Miren Labs features to enable (e.g. adminapi). Prefix with - to disable."`
+	Labs         []string          `short:"l" long:"labs" description:"Miren Labs features to enable (e.g. distributedrunners). Prefix with - to disable."`
 }) error {
 	if opts.ClusterName == "" {
 		opts.ClusterName = opts.Name

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1149,9 +1149,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	c.hs = httpingress.NewServer(ctx, c.Log, ingressConfig, loopback, aa, c.HTTP, c.LogWriter)
 
 	adminServer := admin.NewServer(c.Log, ec, c.hs, c.LogWriter)
-	if labs.AdminAPI() {
-		server.ExposeValue("dev.miren.runtime/admin", admin_v1alpha.AdaptAdmin(adminServer))
-	}
+	server.ExposeValue("dev.miren.runtime/admin", admin_v1alpha.AdaptAdmin(adminServer))
 
 	runnerReg := runnerserver.NewRegistrationServer(runnerserver.RegistrationServerConfig{
 		Log:                    c.Log,

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -29,7 +29,6 @@ import (
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
 	"miren.dev/runtime/pkg/idgen"
-	"miren.dev/runtime/pkg/labs"
 )
 
 var launcherTracer = otel.Tracer("miren.dev/runtime/deployment/launcher")
@@ -672,7 +671,7 @@ func (l *Launcher) buildSandboxSpec(
 	if portEnvValue > 0 {
 		appCont.Env = append(appCont.Env, fmt.Sprintf("PORT=%d", portEnvValue))
 	}
-	if labs.AdminAPI() && ver.AdminToken != "" {
+	if ver.AdminToken != "" {
 		appCont.Env = append(appCont.Env, "ADMIN_TOKEN="+ver.AdminToken)
 	}
 

--- a/docs/docs/command/server-docker-install.md
+++ b/docs/docs/command/server-docker-install.md
@@ -21,7 +21,7 @@ miren server docker install [flags]
 - `--host-network` — Use host networking (ignores port mappings)
 - `--http-port` — HTTP port mapping (default: `80`)
 - `--image, -i` — Docker image to use (default: `oci.miren.cloud/miren:latest`)
-- `--labs, -l` — Miren Labs features to enable (e.g. adminapi). Prefix with - to disable.
+- `--labs, -l` — Miren Labs features to enable (e.g. distributedrunners). Prefix with - to disable.
 - `--name, -n` — Container name
 - `--url, -u` — Cloud URL for registration (default: `https://miren.cloud`)
 - `--without-cloud` — Skip cloud registration setup

--- a/docs/docs/labs.md
+++ b/docs/docs/labs.md
@@ -26,16 +26,16 @@ Labs features are controlled via the `--labs` flag or `MIREN_LABS` environment v
 <CliCommand context="server">
 ```miren
 # Enable a single labs feature
-miren server --labs adminapi
+miren server --labs distributedrunners
 
 # Enable multiple features
-miren server --labs adminapi --labs distributedrunners
+miren server --labs distributedrunners --labs globalrouter
 
 # Via environment variable
-MIREN_LABS=adminapi miren server
+MIREN_LABS=distributedrunners miren server
 
 # Multiple features via environment variable (comma-separated)
-MIREN_LABS=adminapi,distributedrunners miren server
+MIREN_LABS=distributedrunners,globalrouter miren server
 ```
 </CliCommand>
 

--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -9,11 +9,6 @@ features:
     description: Schedule jobs across multiple runner nodes
     default: false
 
-  - name: adminapi
-    predicate: AdminAPI
-    description: Enable the admin API for application management functions
-    default: false
-
   - name: sagas
     predicate: Sagas
     description: Use saga-based crash-recoverable workflows for sandbox lifecycle

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -12,7 +12,6 @@ import (
 const (
 	FeatureGlobalRouter       = "globalrouter"
 	FeatureDistributedRunners = "distributedrunners"
-	FeatureAdminAPI           = "adminapi"
 	FeatureSagas              = "sagas"
 )
 
@@ -21,7 +20,6 @@ func AllFeatures() []string {
 	return []string{
 		FeatureGlobalRouter,
 		FeatureDistributedRunners,
-		FeatureAdminAPI,
 		FeatureSagas,
 	}
 }
@@ -31,7 +29,6 @@ func FeatureDescriptions() map[string]string {
 	return map[string]string{
 		FeatureGlobalRouter:       "Use global NAT traversal router for connectivity",
 		FeatureDistributedRunners: "Schedule jobs across multiple runner nodes",
-		FeatureAdminAPI:           "Enable the admin API for application management functions",
 		FeatureSagas:              "Use saga-based crash-recoverable workflows for sandbox lifecycle",
 	}
 }
@@ -45,7 +42,6 @@ var (
 var featureDefaults = map[string]bool{
 	FeatureGlobalRouter:       false,
 	FeatureDistributedRunners: false,
-	FeatureAdminAPI:           false,
 	FeatureSagas:              false,
 }
 
@@ -144,12 +140,6 @@ func GlobalRouter() bool {
 // Schedule jobs across multiple runner nodes
 func DistributedRunners() bool {
 	return IsEnabled(FeatureDistributedRunners)
-}
-
-// AdminAPI returns whether the adminapi feature is enabled.
-// Enable the admin API for application management functions
-func AdminAPI() bool {
-	return IsEnabled(FeatureAdminAPI)
 }
 
 // Sagas returns whether the sagas feature is enabled.

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -21,13 +21,13 @@ func TestDisableFeatureWithPrefix(t *testing.T) {
 func TestCaseInsensitiveFeatureNames(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"GlobalRouter", "ADMINAPI"})
+	Init(nil, []string{"GlobalRouter", "DISTRIBUTEDRUNNERS"})
 
 	if !GlobalRouter() {
 		t.Error("GlobalRouter should be enabled (case-insensitive)")
 	}
-	if !AdminAPI() {
-		t.Error("AdminAPI should be enabled (case-insensitive)")
+	if !DistributedRunners() {
+		t.Error("DistributedRunners should be enabled (case-insensitive)")
 	}
 }
 
@@ -73,16 +73,16 @@ func TestAllKeywordEnablesAllFeatures(t *testing.T) {
 func TestAllKeywordWithExclusion(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"all", "-adminapi"})
+	Init(nil, []string{"all", "-distributedrunners"})
 
 	for _, name := range AllFeatures() {
-		if name == FeatureAdminAPI {
+		if name == FeatureDistributedRunners {
 			if IsEnabled(name) {
-				t.Error("AdminAPI should be disabled after 'all,-adminapi'")
+				t.Error("DistributedRunners should be disabled after 'all,-distributedrunners'")
 			}
 		} else {
 			if !IsEnabled(name) {
-				t.Errorf("Feature %q should be enabled after 'all,-adminapi'", name)
+				t.Errorf("Feature %q should be enabled after 'all,-distributedrunners'", name)
 			}
 		}
 	}
@@ -91,7 +91,7 @@ func TestAllKeywordWithExclusion(t *testing.T) {
 func TestNegativeAllDisablesAll(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"globalrouter", "adminapi", "-all"})
+	Init(nil, []string{"globalrouter", "distributedrunners", "-all"})
 
 	for _, name := range AllFeatures() {
 		if IsEnabled(name) {


### PR DESCRIPTION
## Summary

Graduates the Admin API from a Miren Labs feature to GA by removing the `adminapi` flag and making the admin API always-on.

The `adminapi` flag only gated two things; the admin token is already generated unconditionally for every app version (`servers/build/build.go`), and the `miren admin` CLI was never flag-gated — so GA-ing the feature is just dropping the two guards plus cleanup.

## Changes

- **`pkg/labs/features.yaml`** — remove the `adminapi` feature; regenerate `pkg/labs/labs.gen.go` (drops `FeatureAdminAPI` and the `AdminAPI()` predicate).
- **`components/coordinate/coordinate.go`** — always expose the admin RPC server (removed `if labs.AdminAPI()`).
- **`controllers/deployment/launcher.go`** — inject `ADMIN_TOKEN` whenever a version has a token; removed the now-unused `labs` import.
- **`pkg/labs/labs_test.go`** — swap the two `adminapi` test references for `distributedrunners`.
- **`cli/commands/server_install_docker.go`** + regenerated **`docs/docs/command/server-docker-install.md`** — `--labs` help example no longer references `adminapi`.
- **`docs/docs/labs.md`** — replace `adminapi` examples.

## Compatibility

Existing deployments passing `--labs adminapi` will log a `"unknown labs feature flag"` warning but otherwise work fine — the admin API is now always on. No compat shim added; the warning serves as a soft deprecation signal.

## Testing

- `go test ./pkg/labs/...` — pass
- `go vet` across coordinate / deployment / admin / cli — clean
- `make lint` — 0 issues, docs lint passed
- Full host binary build — compiles

Closes MIR-1175