### PR TITLE
Remove the addons labs flag from runtime

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -418,53 +418,46 @@ miren deploy --analyze
 		}),
 	))
 
-	// Addon commands (gated behind labs flag)
-	if labs.Addons() {
-		d.Dispatch("addon", Section("addon", "Addon management commands", "", WithSectionGroup(GroupConfiguring)))
-		d.Dispatch("addon list-available", Infer("addon list-available", "List available addons", AddonListAvailable,
-			WithLabsFeature(labs.FeatureAddons),
-			WithExample(mflags.Example{
-				Name: "List available addons",
-				Body: "miren addon list-available",
-			}),
-		))
-		d.Dispatch("addon variants", Infer("addon variants", "Show variants for an addon", AddonVariants,
-			WithLabsFeature(labs.FeatureAddons),
-			WithExample(mflags.Example{
-				Name: "Show variants for PostgreSQL",
-				Body: "miren addon variants miren-postgresql",
-			}),
-		))
-		d.Dispatch("addon create", Infer("addon create", "Attach an addon to an application", AddonCreate,
-			WithLabsFeature(labs.FeatureAddons),
-			WithExample(mflags.Example{
-				Name: "Attach a PostgreSQL addon",
-				Body: "miren addon create miren-postgresql:small",
-			}),
-			WithExample(mflags.Example{
-				Name: "Attach a PostgreSQL addon with a specific version",
-				Body: "miren addon create miren-postgresql:small --version 16",
-			}),
-		))
-		d.Dispatch("addon list", Infer("addon list", "List addons attached to an application", AddonList,
-			WithLabsFeature(labs.FeatureAddons),
-			WithExample(mflags.Example{
-				Name: "List addons for the current app",
-				Body: "miren addon list",
-			}),
-		))
-		d.Dispatch("addon destroy", Infer("addon destroy", "Remove an addon from an application", AddonDestroy,
-			WithLabsFeature(labs.FeatureAddons),
-			WithExample(mflags.Example{
-				Name: "Remove an addon",
-				Body: "miren addon destroy miren-postgresql",
-			}),
-			WithExample(mflags.Example{
-				Name: "Remove without confirmation",
-				Body: "miren addon destroy miren-postgresql --force",
-			}),
-		))
-	}
+	// Addon commands
+	d.Dispatch("addon", Section("addon", "Addon management commands", "", WithSectionGroup(GroupConfiguring)))
+	d.Dispatch("addon list-available", Infer("addon list-available", "List available addons", AddonListAvailable,
+		WithExample(mflags.Example{
+			Name: "List available addons",
+			Body: "miren addon list-available",
+		}),
+	))
+	d.Dispatch("addon variants", Infer("addon variants", "Show variants for an addon", AddonVariants,
+		WithExample(mflags.Example{
+			Name: "Show variants for PostgreSQL",
+			Body: "miren addon variants miren-postgresql",
+		}),
+	))
+	d.Dispatch("addon create", Infer("addon create", "Attach an addon to an application", AddonCreate,
+		WithExample(mflags.Example{
+			Name: "Attach a PostgreSQL addon",
+			Body: "miren addon create miren-postgresql:small",
+		}),
+		WithExample(mflags.Example{
+			Name: "Attach a PostgreSQL addon with a specific version",
+			Body: "miren addon create miren-postgresql:small --version 16",
+		}),
+	))
+	d.Dispatch("addon list", Infer("addon list", "List addons attached to an application", AddonList,
+		WithExample(mflags.Example{
+			Name: "List addons for the current app",
+			Body: "miren addon list",
+		}),
+	))
+	d.Dispatch("addon destroy", Infer("addon destroy", "Remove an addon from an application", AddonDestroy,
+		WithExample(mflags.Example{
+			Name: "Remove an addon",
+			Body: "miren addon destroy miren-postgresql",
+		}),
+		WithExample(mflags.Example{
+			Name: "Remove without confirmation",
+			Body: "miren addon destroy miren-postgresql --force",
+		}),
+	))
 
 	// Route commands
 	d.Dispatch("route", Infer("route", "List all HTTP routes", Route,

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -933,19 +933,17 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	)
 	c.cm.AddController(launcherController)
 
-	if labs.Addons() {
-		// Watch AddonAssociation changes to re-trigger launcher when addons become ready
-		addonLauncherController := controller.NewReconcileController(
-			"deploymentlauncher-addons",
-			c.Log,
-			entity.Ref(entity.EntityKind, addon_v1alpha.KindAddonAssociation),
-			eac,
-			launcher.AddonAssociationHandler(),
-			0, // No resync — driven entirely by watch events
-			1,
-		)
-		c.cm.AddController(addonLauncherController)
-	}
+	// Watch AddonAssociation changes to re-trigger launcher when addons become ready
+	addonLauncherController := controller.NewReconcileController(
+		"deploymentlauncher-addons",
+		c.Log,
+		entity.Ref(entity.EntityKind, addon_v1alpha.KindAddonAssociation),
+		eac,
+		launcher.AddonAssociationHandler(),
+		0, // No resync — driven entirely by watch events
+		1,
+	)
+	c.cm.AddController(addonLauncherController)
 
 	// Add sandbox pool controller (reconciles pool desired_instances to actual sandboxes)
 	poolController := controller.NewReconcileController(
@@ -1045,28 +1043,26 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		c.cm.AddController(certRC)
 	}
 
-	if labs.Addons() {
-		// Add addon controller (reconciles addon associations for provisioning/deprovisioning)
-		addonController := addonctrl.NewController(c.Log, ec, eac, addonRegistry)
-		if err := addonController.Init(ctx); err != nil {
-			c.Log.Error("failed to initialize addon controller", "error", err)
-			return err
-		}
-
-		addonReconciler := controller.NewReconcileController(
-			"addon",
-			c.Log,
-			entity.Ref(entity.EntityKind, addon_v1alpha.KindAddonAssociation),
-			eac,
-			controller.AdaptReconcileController[addon_v1alpha.AddonAssociation](addonController),
-			time.Minute,
-			// Multiple workers so a long-running provisioning saga for one
-			// association does not block reconciliation of others. Same-entity
-			// concurrency is already prevented by ReconcileController.inFlight.
-			4,
-		)
-		c.cm.AddController(addonReconciler)
+	// Add addon controller (reconciles addon associations for provisioning/deprovisioning)
+	addonController := addonctrl.NewController(c.Log, ec, eac, addonRegistry)
+	if err := addonController.Init(ctx); err != nil {
+		c.Log.Error("failed to initialize addon controller", "error", err)
+		return err
 	}
+
+	addonReconciler := controller.NewReconcileController(
+		"addon",
+		c.Log,
+		entity.Ref(entity.EntityKind, addon_v1alpha.KindAddonAssociation),
+		eac,
+		controller.AdaptReconcileController[addon_v1alpha.AddonAssociation](addonController),
+		time.Minute,
+		// Multiple workers so a long-running provisioning saga for one
+		// association does not block reconciliation of others. Same-entity
+		// concurrency is already prevented by ReconcileController.inFlight.
+		4,
+	)
+	c.cm.AddController(addonReconciler)
 
 	// Start the controller manager
 	if err := c.cm.Start(ctx); err != nil {
@@ -1097,18 +1093,15 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	server.ExposeValue("dev.miren.runtime/app", app_v1alpha.AdaptCrud(ai))
 	server.ExposeValue("dev.miren.runtime/app-status", app_v1alpha.AdaptAppStatus(ai))
 
-	var addonsClient *app_v1alpha.AddonsClient
-	if labs.Addons() {
-		addonsServer := app.NewAddonsServer(c.Log, ec, addonRegistry, addon.NewRegistryImageChecker())
-		server.ExposeValue("dev.miren.runtime/addons", app_v1alpha.AdaptAddons(addonsServer))
+	addonsServer := app.NewAddonsServer(c.Log, ec, addonRegistry, addon.NewRegistryImageChecker())
+	server.ExposeValue("dev.miren.runtime/addons", app_v1alpha.AdaptAddons(addonsServer))
 
-		addonsLoopback, err := rs.Connect(rs.LoopbackAddr(), "dev.miren.runtime/addons")
-		if err != nil {
-			c.Log.Error("failed to connect to addons RPC service", "error", err)
-			return err
-		}
-		addonsClient = app_v1alpha.NewAddonsClient(addonsLoopback)
+	addonsLoopback, err := rs.Connect(rs.LoopbackAddr(), "dev.miren.runtime/addons")
+	if err != nil {
+		c.Log.Error("failed to connect to addons RPC service", "error", err)
+		return err
 	}
+	addonsClient := app_v1alpha.NewAddonsClient(addonsLoopback)
 
 	// Create app client for the builder
 	appClient := appclient.NewClient(c.Log, loopback)

--- a/docs/docs/command/addon-create.md
+++ b/docs/docs/command/addon-create.md
@@ -8,10 +8,6 @@ description: "Attach an addon to an application"
 
 Attach an addon to an application
 
-:::note
-This command requires the `addons` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/addon-destroy.md
+++ b/docs/docs/command/addon-destroy.md
@@ -8,10 +8,6 @@ description: "Remove an addon from an application"
 
 Remove an addon from an application
 
-:::note
-This command requires the `addons` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/addon-list-available.md
+++ b/docs/docs/command/addon-list-available.md
@@ -8,10 +8,6 @@ description: "List available addons"
 
 List available addons
 
-:::note
-This command requires the `addons` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/addon-list.md
+++ b/docs/docs/command/addon-list.md
@@ -8,10 +8,6 @@ description: "List addons attached to an application"
 
 List addons attached to an application
 
-:::note
-This command requires the `addons` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/addon-variants.md
+++ b/docs/docs/command/addon-variants.md
@@ -8,10 +8,6 @@ description: "Show variants for an addon"
 
 Show variants for an addon
 
-:::note
-This command requires the `addons` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -13,11 +13,11 @@ Complete reference for all `miren` CLI commands.
 | Command | Description |
 |---------|-------------|
 | [`miren addon`](/command/addon) | Addon management commands |
-| [`miren addon create`](/command/addon-create) | Attach an addon to an application _(`addons`)_ |
-| [`miren addon destroy`](/command/addon-destroy) | Remove an addon from an application _(`addons`)_ |
-| [`miren addon list`](/command/addon-list) | List addons attached to an application _(`addons`)_ |
-| [`miren addon list-available`](/command/addon-list-available) | List available addons _(`addons`)_ |
-| [`miren addon variants`](/command/addon-variants) | Show variants for an addon _(`addons`)_ |
+| [`miren addon create`](/command/addon-create) | Attach an addon to an application |
+| [`miren addon destroy`](/command/addon-destroy) | Remove an addon from an application |
+| [`miren addon list`](/command/addon-list) | List addons attached to an application |
+| [`miren addon list-available`](/command/addon-list-available) | List available addons |
+| [`miren addon variants`](/command/addon-variants) | Show variants for an addon |
 
 ## admin
 

--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -14,11 +14,6 @@ features:
     description: Enable the admin API for application management functions
     default: false
 
-  - name: addons
-    predicate: Addons
-    description: Enable the addon system for managed backing services
-    default: true
-
   - name: sagas
     predicate: Sagas
     description: Use saga-based crash-recoverable workflows for sandbox lifecycle

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -13,7 +13,6 @@ const (
 	FeatureGlobalRouter       = "globalrouter"
 	FeatureDistributedRunners = "distributedrunners"
 	FeatureAdminAPI           = "adminapi"
-	FeatureAddons             = "addons"
 	FeatureSagas              = "sagas"
 )
 
@@ -23,7 +22,6 @@ func AllFeatures() []string {
 		FeatureGlobalRouter,
 		FeatureDistributedRunners,
 		FeatureAdminAPI,
-		FeatureAddons,
 		FeatureSagas,
 	}
 }
@@ -34,7 +32,6 @@ func FeatureDescriptions() map[string]string {
 		FeatureGlobalRouter:       "Use global NAT traversal router for connectivity",
 		FeatureDistributedRunners: "Schedule jobs across multiple runner nodes",
 		FeatureAdminAPI:           "Enable the admin API for application management functions",
-		FeatureAddons:             "Enable the addon system for managed backing services",
 		FeatureSagas:              "Use saga-based crash-recoverable workflows for sandbox lifecycle",
 	}
 }
@@ -49,7 +46,6 @@ var featureDefaults = map[string]bool{
 	FeatureGlobalRouter:       false,
 	FeatureDistributedRunners: false,
 	FeatureAdminAPI:           false,
-	FeatureAddons:             true,
 	FeatureSagas:              false,
 }
 
@@ -154,12 +150,6 @@ func DistributedRunners() bool {
 // Enable the admin API for application management functions
 func AdminAPI() bool {
 	return IsEnabled(FeatureAdminAPI)
-}
-
-// Addons returns whether the addons feature is enabled.
-// Enable the addon system for managed backing services
-func Addons() bool {
-	return IsEnabled(FeatureAddons)
 }
 
 // Sagas returns whether the sagas feature is enabled.

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -73,16 +73,16 @@ func TestAllKeywordEnablesAllFeatures(t *testing.T) {
 func TestAllKeywordWithExclusion(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"all", "-addons"})
+	Init(nil, []string{"all", "-adminapi"})
 
 	for _, name := range AllFeatures() {
-		if name == FeatureAddons {
+		if name == FeatureAdminAPI {
 			if IsEnabled(name) {
-				t.Error("Addons should be disabled after 'all,-addons'")
+				t.Error("AdminAPI should be disabled after 'all,-adminapi'")
 			}
 		} else {
 			if !IsEnabled(name) {
-				t.Errorf("Feature %q should be enabled after 'all,-addons'", name)
+				t.Errorf("Feature %q should be enabled after 'all,-adminapi'", name)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

The addon system already defaulted to **enabled** (`addons: true` in the labs config), so the `addons` labs feature flag was dead ceremony rather than a real gate. This PR graduates addons out of labs entirely, making the addon controllers, RPC server, and CLI commands unconditionally available. There is no production behavior change — just removal of the now-meaningless gating.

## Changes

- **`pkg/labs/features.yaml`** — deleted the `addons` feature entry
- **`pkg/labs/labs.gen.go`** — regenerated; drops `FeatureAddons`, the `Addons()` predicate, the default-map entry, and the description
- **`pkg/labs/labs_test.go`** — retargeted `TestAllKeywordWithExclusion` to `-adminapi`/`FeatureAdminAPI`
- **`components/coordinate/coordinate.go`** — inlined three `if labs.Addons()` guards (deploymentlauncher-addons watcher, addon controller/reconciler, addons RPC server+client); flattened the `var addonsClient` declaration into a direct `:=` since it's consumed unconditionally by the builder
- **`cli/commands/commands.go`** — removed the labs guard and the five `WithLabsFeature(labs.FeatureAddons)` markers from the addon commands
- **`docs/docs/command/addon-*.md` + `commands.md`** — regenerated to drop the "requires the \`addons\` labs feature" notes and index markers

The `labs` import is retained in both Go files since other features (`DistributedRunners`, `AdminAPI`, `GlobalRouter`) still use it.

## Verification

- `go build ./...` — success
- `go test ./pkg/labs/...` — passes
- `grep -rn 'FeatureAddons\|labs.Addons\b'` — no residual references
- `make lint` — 0 issues (docs lint + golangci-lint clean)

Fixes [MIR-1183](https://linear.app/miren/issue/MIR-1183/remove-addons-flag-from-runtime).