### PR TITLE
Add workload identity tokens to sandbox containers

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -51,6 +51,7 @@ import (
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/serverconfig"
 	"miren.dev/runtime/pkg/units"
+	"miren.dev/runtime/pkg/workloadidentity"
 	"miren.dev/runtime/version"
 )
 
@@ -573,6 +574,30 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		ctx.Log.Info("no cluster registration found")
 	}
 
+	// Initialize workload identity issuer for sandbox OIDC tokens
+	var workloadIssuer *workloadidentity.Issuer
+	{
+		var issuerURL string
+		if cloudAuthConfig.DNSHostname != "" {
+			issuerURL = "https://" + cloudAuthConfig.DNSHostname
+		} else if len(cfg.TLS.AdditionalNames) > 0 {
+			issuerURL = "https://" + cfg.TLS.AdditionalNames[0]
+		}
+		if issuerURL != "" {
+			workloadIssuer, err = workloadidentity.NewIssuer(workloadidentity.IssuerConfig{
+				DataPath:       cfg.Server.GetDataPath(),
+				IssuerURL:      issuerURL,
+				OrganizationID: cloudAuthConfig.Tags["organization_id"],
+				ClusterID:      cloudAuthConfig.ClusterID,
+			})
+			if err != nil {
+				ctx.Log.Warn("failed to initialize workload identity issuer", "error", err)
+			} else {
+				ctx.Log.Info("workload identity issuer initialized", "issuer", issuerURL)
+			}
+		}
+	}
+
 	// Auto-enable OTel tracing when the standard OTLP endpoint env var is set.
 	// Placed after registration loading so we can identify the cluster in traces.
 	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
@@ -633,6 +658,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		HTTPRequestTimeout:     cfg.Server.HTTPRequestTimeoutDuration(),
 		VictoriametricsAddress: ctx.ServerState.VictoriametricsAddress,
 		VictorialogsAddress:    ctx.ServerState.VictorialogsAddress,
+		WorkloadIssuer:         workloadIssuer,
 	}
 
 	// Pass etcd TLS config when distributed runners is enabled
@@ -801,6 +827,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		Resolver:        res,
 		SandboxMetrics:  ctx.ServerState.SandboxMetrics,
 		IsCoordinator:   true,
+		WorkloadIssuer:  workloadIssuer,
 	}
 
 	rc.DataPath = cfg.Server.GetDataPath()

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -67,6 +67,7 @@ import (
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/saga"
 	"miren.dev/runtime/pkg/sysstats"
+	"miren.dev/runtime/pkg/workloadidentity"
 	"miren.dev/runtime/servers/admin"
 	"miren.dev/runtime/servers/app"
 	"miren.dev/runtime/servers/build"
@@ -129,6 +130,9 @@ type CoordinatorConfig struct {
 
 	// HTTPRequestTimeout is the timeout for HTTP requests to app sandboxes
 	HTTPRequestTimeout time.Duration
+
+	// WorkloadIssuer signs workload identity tokens for sandbox containers
+	WorkloadIssuer *workloadidentity.Issuer
 }
 
 // CloudAuthConfig contains cloud authentication settings
@@ -1133,6 +1137,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	ingressConfig := httpingress.IngressConfig{
 		RequestTimeout: c.HTTPRequestTimeout,
 		DataPath:       c.DataPath,
+		WorkloadIssuer: c.WorkloadIssuer,
 	}
 	c.hs = httpingress.NewServer(ctx, c.Log, ingressConfig, loopback, aa, c.HTTP, c.LogWriter)
 

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -43,6 +43,7 @@ import (
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/saga"
+	"miren.dev/runtime/pkg/workloadidentity"
 	"miren.dev/runtime/servers/exec"
 	"miren.dev/runtime/version"
 )
@@ -107,6 +108,9 @@ type RunnerDeps struct {
 	EtcdTLSCertFile string // Client certificate file path
 	EtcdTLSKeyFile  string // Client private key file path
 	EtcdTLSCAFile   string // CA certificate file path
+
+	// WorkloadIssuer signs workload identity tokens for sandbox containers
+	WorkloadIssuer *workloadidentity.Issuer
 }
 
 const (
@@ -608,6 +612,7 @@ func (r *Runner) SetupControllers(
 		StatusMon:      r.deps.StatusMon,
 		Resolver:       r.deps.Resolver,
 		Metrics:        r.deps.SandboxMetrics,
+		WorkloadIssuer: r.deps.WorkloadIssuer,
 	}
 
 	var sbc sandbox.SandboxLifecycle

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -396,6 +396,15 @@ func (c *SandboxController) reconcileSandboxesOnBoot(ctx context.Context) error 
 					}
 				}
 			}
+
+			// Re-register with token refresher so tokens keep getting renewed
+			if c.tokenRefresher != nil {
+				appName := c.resolveAppName(ctx, &sb)
+				tokenPath := c.sandboxPath(&sb, "identity-token")
+				c.tokenRefresher.register(sb.ID.String(), tokenPath, appName)
+				c.Log.Debug("re-registered sandbox for token refresh",
+					"sandbox_id", sb.ID, "app", appName)
+			}
 		}
 	}
 
@@ -474,6 +483,13 @@ func (c *SandboxController) Init(ctx context.Context) error {
 		return err
 	}
 
+	// Initialize token refresh state before reconcile so surviving sandboxes
+	// can be re-registered during boot reconciliation.
+	if c.WorkloadIssuer != nil {
+		c.tokenRefresher = newTokenRefresher()
+		c.tokenSecrets = newTokenSecretRegistry()
+	}
+
 	// Reconcile sandboxes after containerd restart
 	// This must happen after bridge setup but before starting normal operations
 	err = c.reconcileSandboxesOnBoot(ctx)
@@ -512,9 +528,8 @@ func (c *SandboxController) Init(ctx context.Context) error {
 	c.imageWatchdog.Start(c.topCtx)
 
 	// Start workload identity token refresh loop and token request server
+	// (tokenRefresher and tokenSecrets were created earlier, before reconcile)
 	if c.WorkloadIssuer != nil {
-		c.tokenRefresher = newTokenRefresher()
-		c.tokenSecrets = newTokenSecretRegistry()
 		go c.runTokenRefresh(c.topCtx)
 		go c.startTokenServer(c.topCtx)
 	}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -37,6 +37,7 @@ import (
 	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/netutil"
+	"miren.dev/runtime/pkg/workloadidentity"
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -82,6 +83,7 @@ type SandboxControllerDeps struct {
 	StatusMon      *observability.StatusMonitor
 	Resolver       netresolve.Resolver
 	Metrics        *Metrics
+	WorkloadIssuer *workloadidentity.Issuer
 }
 
 type SandboxController struct {
@@ -106,8 +108,11 @@ type SandboxController struct {
 
 	StatusMon *observability.StatusMonitor
 
-	Resolver netresolve.Resolver
-	Metrics  *Metrics
+	Resolver       netresolve.Resolver
+	Metrics        *Metrics
+	WorkloadIssuer *workloadidentity.Issuer
+
+	tokenRefresher *tokenRefresher
 
 	topCtx context.Context
 	cancel func()
@@ -182,6 +187,7 @@ func NewSandboxController(cfg SandboxControllerDeps) (*SandboxController, error)
 		StatusMon:      cfg.StatusMon,
 		Resolver:       cfg.Resolver,
 		Metrics:        cfg.Metrics,
+		WorkloadIssuer: cfg.WorkloadIssuer,
 	}, nil
 }
 
@@ -503,6 +509,12 @@ func (c *SandboxController) Init(ctx context.Context) error {
 		Config:    DefaultImageGCConfig(),
 	}
 	c.imageWatchdog.Start(c.topCtx)
+
+	// Start workload identity token refresh loop
+	if c.WorkloadIssuer != nil {
+		c.tokenRefresher = newTokenRefresher()
+		go c.runTokenRefresh(c.topCtx)
+	}
 
 	return nil
 }
@@ -2054,6 +2066,30 @@ func (c *SandboxController) buildSubContainerSpec(
 		})
 	}
 
+	// Inject workload identity token
+	if c.WorkloadIssuer != nil {
+		appName := c.resolveAppName(ctx, sb)
+		token, tokenErr := c.WorkloadIssuer.IssueToken(appName, sb.ID.String())
+		if tokenErr != nil {
+			c.Log.Warn("failed to generate workload identity token", "sandbox", sb.ID, "error", tokenErr)
+		} else {
+			tokenPath := c.sandboxPath(sb, "identity-token")
+			if writeErr := os.WriteFile(tokenPath, []byte(token), 0444); writeErr != nil {
+				c.Log.Warn("failed to write workload identity token", "sandbox", sb.ID, "error", writeErr)
+			} else {
+				mounts = append(mounts, specs.Mount{
+					Destination: "/var/run/miren/identity-token",
+					Type:        "bind",
+					Source:      tokenPath,
+					Options:     []string{"rbind", "ro"},
+				})
+				if c.tokenRefresher != nil {
+					c.tokenRefresher.register(sb.ID.String(), tokenPath, appName)
+				}
+			}
+		}
+	}
+
 	// Extract instance number from metadata labels and inject MIREN_INSTANCE_NUM
 	envVars := co.Env
 	var md core_v1alpha.Metadata
@@ -2062,6 +2098,13 @@ func (c *SandboxController) buildSubContainerSpec(
 	if instanceStr, ok := md.Labels.Get("instance"); ok {
 		envVars = append([]string{fmt.Sprintf("MIREN_INSTANCE_NUM=%s", instanceStr)}, envVars...)
 		c.Log.Debug("injected instance number into container env", "sandbox_id", sb.ID, "container", co.Name, "instance", instanceStr)
+	}
+
+	if c.WorkloadIssuer != nil {
+		envVars = append(envVars,
+			"MIREN_IDENTITY_TOKEN_PATH=/var/run/miren/identity-token",
+			fmt.Sprintf("MIREN_OIDC_ISSUER_URL=%s", c.WorkloadIssuer.IssuerURL()),
+		)
 	}
 
 	specOpts := []oci.SpecOpts{
@@ -2349,6 +2392,9 @@ cleanup:
 
 func (c *SandboxController) Delete(ctx context.Context, id entity.Id, sb *compute.Sandbox) error {
 	c.Log.Debug("delete callback received, cleaning up sandbox", "id", id)
+	if c.tokenRefresher != nil {
+		c.tokenRefresher.unregister(id.String())
+	}
 	if sb != nil {
 		c.UnconfigureFirewall(sb)
 	}
@@ -2627,4 +2673,31 @@ func (c *SandboxController) Periodic(ctx context.Context, timeHorizon time.Durat
 	}
 
 	return nil
+}
+
+func (c *SandboxController) resolveAppName(ctx context.Context, sb *compute.Sandbox) string {
+	if sb.Spec.Version == "" {
+		return ""
+	}
+
+	versionResp, err := c.EAC.Get(ctx, sb.Spec.Version.String())
+	if err != nil {
+		return ""
+	}
+
+	var version core_v1alpha.AppVersion
+	version.Decode(versionResp.Entity().Entity())
+
+	if version.App == "" {
+		return ""
+	}
+
+	appResp, err := c.EAC.Get(ctx, version.App.String())
+	if err != nil {
+		return ""
+	}
+
+	var appMeta core_v1alpha.Metadata
+	appMeta.Decode(appResp.Entity().Entity())
+	return appMeta.Name
 }

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -113,6 +113,7 @@ type SandboxController struct {
 	WorkloadIssuer *workloadidentity.Issuer
 
 	tokenRefresher *tokenRefresher
+	tokenSecrets   *tokenSecretRegistry
 
 	topCtx context.Context
 	cancel func()
@@ -513,6 +514,7 @@ func (c *SandboxController) Init(ctx context.Context) error {
 	// Start workload identity token refresh loop and token request server
 	if c.WorkloadIssuer != nil {
 		c.tokenRefresher = newTokenRefresher()
+		c.tokenSecrets = newTokenSecretRegistry()
 		go c.runTokenRefresh(c.topCtx)
 		go c.startTokenServer(c.topCtx)
 	}
@@ -2107,6 +2109,15 @@ func (c *SandboxController) buildSubContainerSpec(
 			fmt.Sprintf("MIREN_OIDC_ISSUER_URL=%s", c.WorkloadIssuer.IssuerURL()),
 			fmt.Sprintf("MIREN_IDENTITY_TOKEN_URL=http://%s:%d/v1/token", c.Subnet.Router().Addr(), tokenServerPort),
 		)
+		if c.tokenSecrets != nil && len(ep.Addresses) > 0 {
+			secret, secretErr := generateTokenSecret()
+			if secretErr != nil {
+				c.Log.Warn("failed to generate token request secret", "sandbox", sb.ID, "error", secretErr)
+			} else {
+				c.tokenSecrets.register(ep.Addresses[0].Addr().String(), sb.ID.String(), secret)
+				envVars = append(envVars, fmt.Sprintf("MIREN_IDENTITY_TOKEN_SECRET=%s", secret))
+			}
+		}
 	}
 
 	specOpts := []oci.SpecOpts{
@@ -2396,6 +2407,9 @@ func (c *SandboxController) Delete(ctx context.Context, id entity.Id, sb *comput
 	c.Log.Debug("delete callback received, cleaning up sandbox", "id", id)
 	if c.tokenRefresher != nil {
 		c.tokenRefresher.unregister(id.String())
+	}
+	if c.tokenSecrets != nil {
+		c.tokenSecrets.unregister(id.String())
 	}
 	if sb != nil {
 		c.UnconfigureFirewall(sb)

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -510,10 +510,11 @@ func (c *SandboxController) Init(ctx context.Context) error {
 	}
 	c.imageWatchdog.Start(c.topCtx)
 
-	// Start workload identity token refresh loop
+	// Start workload identity token refresh loop and token request server
 	if c.WorkloadIssuer != nil {
 		c.tokenRefresher = newTokenRefresher()
 		go c.runTokenRefresh(c.topCtx)
+		go c.startTokenServer(c.topCtx)
 	}
 
 	return nil
@@ -2074,7 +2075,7 @@ func (c *SandboxController) buildSubContainerSpec(
 			c.Log.Warn("failed to generate workload identity token", "sandbox", sb.ID, "error", tokenErr)
 		} else {
 			tokenPath := c.sandboxPath(sb, "identity-token")
-			if writeErr := os.WriteFile(tokenPath, []byte(token), 0444); writeErr != nil {
+			if writeErr := os.WriteFile(tokenPath, []byte(token), 0644); writeErr != nil {
 				c.Log.Warn("failed to write workload identity token", "sandbox", sb.ID, "error", writeErr)
 			} else {
 				mounts = append(mounts, specs.Mount{
@@ -2104,6 +2105,7 @@ func (c *SandboxController) buildSubContainerSpec(
 		envVars = append(envVars,
 			"MIREN_IDENTITY_TOKEN_PATH=/var/run/miren/identity-token",
 			fmt.Sprintf("MIREN_OIDC_ISSUER_URL=%s", c.WorkloadIssuer.IssuerURL()),
+			fmt.Sprintf("MIREN_IDENTITY_TOKEN_URL=http://%s:%d/v1/token", c.Subnet.Router().Addr(), tokenServerPort),
 		)
 	}
 

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -2075,7 +2075,7 @@ func (c *SandboxController) buildSubContainerSpec(
 			c.Log.Warn("failed to generate workload identity token", "sandbox", sb.ID, "error", tokenErr)
 		} else {
 			tokenPath := c.sandboxPath(sb, "identity-token")
-			if writeErr := os.WriteFile(tokenPath, []byte(token), 0644); writeErr != nil {
+			if writeErr := atomicWriteFile(tokenPath, []byte(token), 0644); writeErr != nil {
 				c.Log.Warn("failed to write workload identity token", "sandbox", sb.ID, "error", writeErr)
 			} else {
 				mounts = append(mounts, specs.Mount{

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "968f9c5174eb931cbea153adddc86ab113dc80d6dcd09de13b21746a65fecb24",
+		"sandbox.go":  "7929dbe09f939b8c982e8d43cfc8c1bc2ede9e39f61c3a708de4cec383584610",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "7929dbe09f939b8c982e8d43cfc8c1bc2ede9e39f61c3a708de4cec383584610",
+		"sandbox.go":  "65e398f232a887de37250abd8da5f27bf66e9ace6625331145d4e788a08f1707",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "b5b6ef50b94fddc50dd583f9df74dde21e81a5b8ff51c77b4d8c42f96ec72c19",
+		"sandbox.go":  "efd1cf0f42f090550e7a1907db080189f58005b7193c42fea724298bdc9a20a5",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "efd1cf0f42f090550e7a1907db080189f58005b7193c42fea724298bdc9a20a5",
+		"sandbox.go":  "5c5e40667148a342d80971553617c1cc3bd2982f7bcb32bcdc0e2894f1da8c58",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "5c5e40667148a342d80971553617c1cc3bd2982f7bcb32bcdc0e2894f1da8c58",
+		"sandbox.go":  "968f9c5174eb931cbea153adddc86ab113dc80d6dcd09de13b21746a65fecb24",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/token_refresh.go
+++ b/controllers/sandbox/token_refresh.go
@@ -1,0 +1,89 @@
+package sandbox
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+)
+
+const tokenRefreshInterval = 45 * time.Minute
+
+type tokenEntry struct {
+	filePath  string
+	appName   string
+	sandboxID string
+}
+
+type tokenRefresher struct {
+	mu      sync.Mutex
+	entries map[string]tokenEntry // keyed by sandbox ID
+}
+
+func newTokenRefresher() *tokenRefresher {
+	return &tokenRefresher{
+		entries: make(map[string]tokenEntry),
+	}
+}
+
+func (tr *tokenRefresher) register(sandboxID, filePath, appName string) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	tr.entries[sandboxID] = tokenEntry{
+		filePath:  filePath,
+		appName:   appName,
+		sandboxID: sandboxID,
+	}
+}
+
+func (tr *tokenRefresher) unregister(sandboxID string) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	delete(tr.entries, sandboxID)
+}
+
+func (tr *tokenRefresher) snapshot() []tokenEntry {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	entries := make([]tokenEntry, 0, len(tr.entries))
+	for _, e := range tr.entries {
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+func (c *SandboxController) runTokenRefresh(ctx context.Context) {
+	ticker := time.NewTicker(tokenRefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.refreshTokens()
+		}
+	}
+}
+
+func (c *SandboxController) refreshTokens() {
+	if c.WorkloadIssuer == nil || c.tokenRefresher == nil {
+		return
+	}
+
+	entries := c.tokenRefresher.snapshot()
+	for _, e := range entries {
+		token, err := c.WorkloadIssuer.IssueToken(e.appName, e.sandboxID)
+		if err != nil {
+			c.Log.Warn("failed to refresh workload identity token", "sandbox", e.sandboxID, "error", err)
+			continue
+		}
+		if err := os.WriteFile(e.filePath, []byte(token), 0444); err != nil {
+			c.Log.Warn("failed to write refreshed workload identity token", "sandbox", e.sandboxID, "error", err)
+		}
+	}
+
+	if len(entries) > 0 {
+		c.Log.Debug("refreshed workload identity tokens", "count", len(entries))
+	}
+}

--- a/controllers/sandbox/token_refresh.go
+++ b/controllers/sandbox/token_refresh.go
@@ -80,7 +80,11 @@ func (c *SandboxController) refreshTokens() {
 			c.Log.Warn("failed to refresh workload identity token", "sandbox", e.sandboxID, "error", err)
 			continue
 		}
-		if err := atomicWriteFile(e.filePath, []byte(token), 0644); err != nil {
+		// Write in-place (not atomic rename) because the file is bind-mounted
+		// into containers. Rename would create a new inode and the container
+		// would keep reading the stale old token. The brief window of partial
+		// content is acceptable for a few-hundred-byte JWT.
+		if err := os.WriteFile(e.filePath, []byte(token), 0644); err != nil {
 			c.Log.Warn("failed to write refreshed workload identity token", "sandbox", e.sandboxID, "error", err)
 		}
 	}

--- a/controllers/sandbox/token_refresh.go
+++ b/controllers/sandbox/token_refresh.go
@@ -78,7 +78,7 @@ func (c *SandboxController) refreshTokens() {
 			c.Log.Warn("failed to refresh workload identity token", "sandbox", e.sandboxID, "error", err)
 			continue
 		}
-		if err := os.WriteFile(e.filePath, []byte(token), 0444); err != nil {
+		if err := os.WriteFile(e.filePath, []byte(token), 0644); err != nil {
 			c.Log.Warn("failed to write refreshed workload identity token", "sandbox", e.sandboxID, "error", err)
 		}
 	}

--- a/controllers/sandbox/token_refresh.go
+++ b/controllers/sandbox/token_refresh.go
@@ -2,7 +2,9 @@ package sandbox
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -78,7 +80,7 @@ func (c *SandboxController) refreshTokens() {
 			c.Log.Warn("failed to refresh workload identity token", "sandbox", e.sandboxID, "error", err)
 			continue
 		}
-		if err := os.WriteFile(e.filePath, []byte(token), 0644); err != nil {
+		if err := atomicWriteFile(e.filePath, []byte(token), 0644); err != nil {
 			c.Log.Warn("failed to write refreshed workload identity token", "sandbox", e.sandboxID, "error", err)
 		}
 	}
@@ -86,4 +88,33 @@ func (c *SandboxController) refreshTokens() {
 	if len(entries) > 0 {
 		c.Log.Debug("refreshed workload identity tokens", "count", len(entries))
 	}
+}
+
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".token-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("setting permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
 }

--- a/controllers/sandbox/token_server.go
+++ b/controllers/sandbox/token_server.go
@@ -2,11 +2,16 @@ package sandbox
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"miren.dev/runtime/pkg/workloadidentity"
@@ -20,6 +25,53 @@ type tokenResponse struct {
 
 type tokenErrorResponse struct {
 	Error string `json:"error"`
+}
+
+type tokenSecretRegistry struct {
+	mu        sync.RWMutex
+	byAddr    map[string]string // IP → secret
+	bySandbox map[string]string // sandboxID → IP (for cleanup)
+}
+
+func newTokenSecretRegistry() *tokenSecretRegistry {
+	return &tokenSecretRegistry{
+		byAddr:    make(map[string]string),
+		bySandbox: make(map[string]string),
+	}
+}
+
+func (r *tokenSecretRegistry) register(ip, sandboxID, secret string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byAddr[ip] = secret
+	r.bySandbox[sandboxID] = ip
+}
+
+func (r *tokenSecretRegistry) unregister(sandboxID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if ip, ok := r.bySandbox[sandboxID]; ok {
+		delete(r.byAddr, ip)
+		delete(r.bySandbox, sandboxID)
+	}
+}
+
+func (r *tokenSecretRegistry) verify(ip, secret string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	expected, ok := r.byAddr[ip]
+	if !ok {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(secret)) == 1
+}
+
+func generateTokenSecret() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }
 
 func (c *SandboxController) startTokenServer(ctx context.Context) {
@@ -63,6 +115,18 @@ func (c *SandboxController) handleTokenRequest(w http.ResponseWriter, r *http.Re
 	remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		writeTokenError(w, http.StatusBadRequest, "invalid remote address")
+		return
+	}
+
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		writeTokenError(w, http.StatusUnauthorized, "missing or invalid Authorization header")
+		return
+	}
+	bearerToken := strings.TrimPrefix(authHeader, "Bearer ")
+
+	if c.tokenSecrets == nil || !c.tokenSecrets.verify(remoteHost, bearerToken) {
+		writeTokenError(w, http.StatusForbidden, "invalid token")
 		return
 	}
 

--- a/controllers/sandbox/token_server.go
+++ b/controllers/sandbox/token_server.go
@@ -1,0 +1,107 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"miren.dev/runtime/pkg/workloadidentity"
+)
+
+const tokenServerPort = 7123
+
+type tokenResponse struct {
+	Value string `json:"value"`
+}
+
+type tokenErrorResponse struct {
+	Error string `json:"error"`
+}
+
+func (c *SandboxController) startTokenServer(ctx context.Context) {
+	listenAddr := fmt.Sprintf("%s:%d", c.Subnet.Router().Addr(), tokenServerPort)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/token", c.handleTokenRequest)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		writeTokenError(w, http.StatusNotFound, "not found")
+	})
+
+	server := &http.Server{
+		Addr:              listenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		server.Shutdown(shutdownCtx)
+	}()
+
+	c.Log.Info("starting workload identity token server", "addr", listenAddr)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		c.Log.Error("token server failed", "error", err)
+	}
+}
+
+func (c *SandboxController) handleTokenRequest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeTokenError(w, http.StatusMethodNotAllowed, "only GET is allowed")
+		return
+	}
+
+	remoteHost, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		writeTokenError(w, http.StatusBadRequest, "invalid remote address")
+		return
+	}
+
+	sandboxID, appName, ok := c.NetServ.LookupSandboxByIP(remoteHost)
+	if !ok {
+		writeTokenError(w, http.StatusForbidden, "unknown source address")
+		return
+	}
+
+	opts := workloadidentity.TokenOptions{}
+
+	if auds := r.URL.Query()["audience"]; len(auds) > 0 {
+		opts.Audience = auds
+	}
+
+	if ttlStr := r.URL.Query().Get("ttl"); ttlStr != "" {
+		ttlSec, err := strconv.Atoi(ttlStr)
+		if err != nil || ttlSec <= 0 {
+			writeTokenError(w, http.StatusBadRequest, "ttl must be a positive integer (seconds)")
+			return
+		}
+		opts.TTL = time.Duration(ttlSec) * time.Second
+	}
+
+	token, err := c.WorkloadIssuer.IssueTokenWithOptions(appName, sandboxID, opts)
+	if err != nil {
+		c.Log.Error("failed to issue token", "sandbox", sandboxID, "error", err)
+		writeTokenError(w, http.StatusInternalServerError, "failed to issue token")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(tokenResponse{
+		Value: token,
+	})
+}
+
+func writeTokenError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(tokenErrorResponse{Error: msg})
+}

--- a/controllers/sandbox/token_server_test.go
+++ b/controllers/sandbox/token_server_test.go
@@ -15,6 +15,10 @@ import (
 	"miren.dev/runtime/pkg/workloadidentity"
 )
 
+const testSandboxIP = "10.0.0.5"
+const testSandboxID = "sandbox/myapp-web-abc123"
+const testSecret = "test-secret-token-value"
+
 func newTestTokenController(t *testing.T) *SandboxController {
 	t.Helper()
 
@@ -29,27 +33,34 @@ func newTestTokenController(t *testing.T) *SandboxController {
 
 	log := slog.Default()
 
-	// Create a ServiceManager with a DNS server that has our test mapping
 	sm := network.NewServiceManager(log, nil)
 	sm.AddTestDNSServer(t, func(s *dns.Server) {
-		s.AddSandboxMapping("sandbox/myapp-web-abc123", "10.0.0.5", "myapp", "web")
+		s.AddSandboxMapping(testSandboxID, testSandboxIP, "myapp", "web")
 	})
+
+	secrets := newTokenSecretRegistry()
+	secrets.register(testSandboxIP, testSandboxID, testSecret)
 
 	return &SandboxController{
 		Log:            log,
 		NetServ:        sm,
 		WorkloadIssuer: issuer,
+		tokenSecrets:   secrets,
 	}
+}
+
+func authedRequest(method, url string) *http.Request {
+	req := httptest.NewRequest(method, url, nil)
+	req.RemoteAddr = testSandboxIP + ":12345"
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	return req
 }
 
 func TestTokenServer_DefaultToken(t *testing.T) {
 	c := newTestTokenController(t)
-
-	req := httptest.NewRequest("GET", "/v1/token", nil)
-	req.RemoteAddr = "10.0.0.5:12345"
 	w := httptest.NewRecorder()
 
-	c.handleTokenRequest(w, req)
+	c.handleTokenRequest(w, authedRequest("GET", "/v1/token"))
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -59,7 +70,6 @@ func TestTokenServer_DefaultToken(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.Value)
 
-	// Parse and verify the token
 	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
 		return c.WorkloadIssuer.PublicKey(), nil
 	})
@@ -67,19 +77,16 @@ func TestTokenServer_DefaultToken(t *testing.T) {
 
 	claims := token.Claims.(*workloadidentity.WorkloadClaims)
 	assert.Equal(t, "myapp", claims.App)
-	assert.Equal(t, "sandbox/myapp-web-abc123", claims.SandboxID)
+	assert.Equal(t, testSandboxID, claims.SandboxID)
 	assert.Equal(t, "org-test", claims.OrganizationID)
 	assert.Equal(t, jwt.ClaimStrings{"miren"}, claims.Audience)
 }
 
 func TestTokenServer_CustomAudience(t *testing.T) {
 	c := newTestTokenController(t)
-
-	req := httptest.NewRequest("GET", "/v1/token?audience=sts.amazonaws.com&audience=myapi.example.com", nil)
-	req.RemoteAddr = "10.0.0.5:12345"
 	w := httptest.NewRecorder()
 
-	c.handleTokenRequest(w, req)
+	c.handleTokenRequest(w, authedRequest("GET", "/v1/token?audience=sts.amazonaws.com&audience=myapi.example.com"))
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -98,12 +105,9 @@ func TestTokenServer_CustomAudience(t *testing.T) {
 
 func TestTokenServer_CustomTTL(t *testing.T) {
 	c := newTestTokenController(t)
-
-	req := httptest.NewRequest("GET", "/v1/token?ttl=300", nil)
-	req.RemoteAddr = "10.0.0.5:12345"
 	w := httptest.NewRecorder()
 
-	c.handleTokenRequest(w, req)
+	c.handleTokenRequest(w, authedRequest("GET", "/v1/token?ttl=300"))
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -121,43 +125,58 @@ func TestTokenServer_CustomTTL(t *testing.T) {
 	assert.Equal(t, 300.0, ttl.Seconds())
 }
 
-func TestTokenServer_UnknownIP(t *testing.T) {
+func TestTokenServer_MissingAuth(t *testing.T) {
 	c := newTestTokenController(t)
 
 	req := httptest.NewRequest("GET", "/v1/token", nil)
-	req.RemoteAddr = "10.0.0.99:12345"
+	req.RemoteAddr = testSandboxIP + ":12345"
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestTokenServer_WrongSecret(t *testing.T) {
+	c := newTestTokenController(t)
+
+	req := httptest.NewRequest("GET", "/v1/token", nil)
+	req.RemoteAddr = testSandboxIP + ":12345"
+	req.Header.Set("Authorization", "Bearer wrong-secret")
 	w := httptest.NewRecorder()
 
 	c.handleTokenRequest(w, req)
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
+}
 
-	var resp tokenErrorResponse
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	require.NoError(t, err)
-	assert.Equal(t, "unknown source address", resp.Error)
+func TestTokenServer_UnknownIP(t *testing.T) {
+	c := newTestTokenController(t)
+
+	req := httptest.NewRequest("GET", "/v1/token", nil)
+	req.RemoteAddr = "10.0.0.99:12345"
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 func TestTokenServer_RejectsPost(t *testing.T) {
 	c := newTestTokenController(t)
-
-	req := httptest.NewRequest("POST", "/v1/token", nil)
-	req.RemoteAddr = "10.0.0.5:12345"
 	w := httptest.NewRecorder()
 
-	c.handleTokenRequest(w, req)
+	c.handleTokenRequest(w, authedRequest("POST", "/v1/token"))
 
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }
 
 func TestTokenServer_InvalidTTL(t *testing.T) {
 	c := newTestTokenController(t)
-
-	req := httptest.NewRequest("GET", "/v1/token?ttl=notanumber", nil)
-	req.RemoteAddr = "10.0.0.5:12345"
 	w := httptest.NewRecorder()
 
-	c.handleTokenRequest(w, req)
+	c.handleTokenRequest(w, authedRequest("GET", "/v1/token?ttl=notanumber"))
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/controllers/sandbox/token_server_test.go
+++ b/controllers/sandbox/token_server_test.go
@@ -1,0 +1,163 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/network"
+	"miren.dev/runtime/pkg/dns"
+	"miren.dev/runtime/pkg/workloadidentity"
+)
+
+func newTestTokenController(t *testing.T) *SandboxController {
+	t.Helper()
+
+	dir := t.TempDir()
+	issuer, err := workloadidentity.NewIssuer(workloadidentity.IssuerConfig{
+		DataPath:       dir,
+		IssuerURL:      "https://test.miren.systems",
+		OrganizationID: "org-test",
+		ClusterID:      "cluster-test",
+	})
+	require.NoError(t, err)
+
+	log := slog.Default()
+
+	// Create a ServiceManager with a DNS server that has our test mapping
+	sm := network.NewServiceManager(log, nil)
+	sm.AddTestDNSServer(t, func(s *dns.Server) {
+		s.AddSandboxMapping("sandbox/myapp-web-abc123", "10.0.0.5", "myapp", "web")
+	})
+
+	return &SandboxController{
+		Log:            log,
+		NetServ:        sm,
+		WorkloadIssuer: issuer,
+	}
+}
+
+func TestTokenServer_DefaultToken(t *testing.T) {
+	c := newTestTokenController(t)
+
+	req := httptest.NewRequest("GET", "/v1/token", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+	var resp tokenResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Value)
+
+	// Parse and verify the token
+	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return c.WorkloadIssuer.PublicKey(), nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(*workloadidentity.WorkloadClaims)
+	assert.Equal(t, "myapp", claims.App)
+	assert.Equal(t, "sandbox/myapp-web-abc123", claims.SandboxID)
+	assert.Equal(t, "org-test", claims.OrganizationID)
+	assert.Equal(t, jwt.ClaimStrings{"miren"}, claims.Audience)
+}
+
+func TestTokenServer_CustomAudience(t *testing.T) {
+	c := newTestTokenController(t)
+
+	req := httptest.NewRequest("GET", "/v1/token?audience=sts.amazonaws.com&audience=myapi.example.com", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp tokenResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return c.WorkloadIssuer.PublicKey(), nil
+	}, jwt.WithAudience("sts.amazonaws.com"))
+	require.NoError(t, err)
+
+	claims := token.Claims.(*workloadidentity.WorkloadClaims)
+	assert.Equal(t, jwt.ClaimStrings{"sts.amazonaws.com", "myapi.example.com"}, claims.Audience)
+}
+
+func TestTokenServer_CustomTTL(t *testing.T) {
+	c := newTestTokenController(t)
+
+	req := httptest.NewRequest("GET", "/v1/token?ttl=300", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp tokenResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return c.WorkloadIssuer.PublicKey(), nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(*workloadidentity.WorkloadClaims)
+	ttl := claims.ExpiresAt.Sub(claims.IssuedAt.Time)
+	assert.Equal(t, 300.0, ttl.Seconds())
+}
+
+func TestTokenServer_UnknownIP(t *testing.T) {
+	c := newTestTokenController(t)
+
+	req := httptest.NewRequest("GET", "/v1/token", nil)
+	req.RemoteAddr = "10.0.0.99:12345"
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var resp tokenErrorResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, "unknown source address", resp.Error)
+}
+
+func TestTokenServer_RejectsPost(t *testing.T) {
+	c := newTestTokenController(t)
+
+	req := httptest.NewRequest("POST", "/v1/token", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestTokenServer_InvalidTTL(t *testing.T) {
+	c := newTestTokenController(t)
+
+	req := httptest.NewRequest("GET", "/v1/token?ttl=notanumber", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/network/services.go
+++ b/network/services.go
@@ -17,7 +17,7 @@ type ServiceManager struct {
 	Log *slog.Logger
 	EAC *entityserver_v1alpha.EntityAccessClient
 
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	bridges map[string]*BridgeServices
 	ctx     context.Context
 }
@@ -131,4 +131,34 @@ func (sm *ServiceManager) ShutdownAll() error {
 	}
 
 	return lastErr
+}
+
+// AddTestDNSServer adds a DNS server to the ServiceManager for testing.
+// The setup function is called with the server to populate test data.
+func (sm *ServiceManager) AddTestDNSServer(t interface{ Helper() }, setup func(*dns.Server)) {
+	t.Helper()
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	s := dns.NewTestServer()
+	setup(s)
+	if sm.bridges["test"] == nil {
+		sm.bridges["test"] = &BridgeServices{}
+	}
+	sm.bridges["test"].dns = append(sm.bridges["test"].dns, s)
+}
+
+// LookupSandboxByIP searches across all bridge DNS servers for a sandbox matching the given IP.
+func (sm *ServiceManager) LookupSandboxByIP(ip string) (sandboxID, appName string, ok bool) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	for _, bs := range sm.bridges {
+		for _, server := range bs.dns {
+			if sandboxID, appName, ok = server.LookupSandboxByIP(ip); ok {
+				return sandboxID, appName, true
+			}
+		}
+	}
+	return "", "", false
 }

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -597,7 +597,22 @@ func NewTestServer() *Server {
 }
 
 // LookupSandboxByIP returns the sandbox entity ID and app name for a given IP.
+// On a cache miss, falls back to an entity store lookup to handle watcher lag.
 func (s *Server) LookupSandboxByIP(ip string) (sandboxID, appName string, ok bool) {
+	s.mu.RLock()
+	sandboxID, ok = s.ipToSandbox[ip]
+	if ok {
+		appName = s.ipToApp[ip]
+		s.mu.RUnlock()
+		return sandboxID, appName, true
+	}
+	s.mu.RUnlock()
+
+	// Cache miss — try resolving via entity store (populates the maps on success)
+	if !s.resolveUnknownIP(ip) {
+		return "", "", false
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	sandboxID, ok = s.ipToSandbox[ip]

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -30,6 +30,7 @@ type Server struct {
 
 	mu              sync.RWMutex
 	ipToApp         map[string]string              // source IP → app name
+	ipToSandbox     map[string]string              // source IP → sandbox entity ID
 	ipToService     map[string]string              // IP → service name (for PTR lookups)
 	appServiceToIPs map[string]map[string][]string // app name → service name → []IPs
 	entityToIP      map[string]string              // entity ID → IP address
@@ -63,6 +64,7 @@ func New(addr string, entityClient *entityserver_v1alpha.EntityAccessClient, log
 		entityClient:    entityClient,
 		log:             log.With("module", "dns"),
 		ipToApp:         make(map[string]string),
+		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
 		appServiceToIPs: make(map[string]map[string][]string),
 		entityToIP:      make(map[string]string),
@@ -579,12 +581,35 @@ func (s *Server) handleSandboxUpdate(ctx context.Context, sb *compute_v1alpha.Sa
 		"app-id", appVer.App.String(),
 	)
 
-	s.addSandboxMapping(sb.ID.String(), ipAddr, appName, service)
+	s.AddSandboxMapping(sb.ID.String(), ipAddr, appName, service)
 }
 
-// addSandboxMapping registers a sandbox's IP address for DNS resolution.
-// This is the core mapping logic, separated for testability.
-func (s *Server) addSandboxMapping(sandboxID, ipAddr, appName, service string) {
+// NewTestServer creates a minimal Server for testing without binding to a port.
+func NewTestServer() *Server {
+	return &Server{
+		log:             slog.Default(),
+		ipToApp:         make(map[string]string),
+		ipToSandbox:     make(map[string]string),
+		ipToService:     make(map[string]string),
+		appServiceToIPs: make(map[string]map[string][]string),
+		entityToIP:      make(map[string]string),
+	}
+}
+
+// LookupSandboxByIP returns the sandbox entity ID and app name for a given IP.
+func (s *Server) LookupSandboxByIP(ip string) (sandboxID, appName string, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sandboxID, ok = s.ipToSandbox[ip]
+	if !ok {
+		return "", "", false
+	}
+	appName = s.ipToApp[ip]
+	return sandboxID, appName, true
+}
+
+// AddSandboxMapping registers a sandbox's IP address for DNS resolution.
+func (s *Server) AddSandboxMapping(sandboxID, ipAddr, appName, service string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.addSandboxMappingLocked(sandboxID, ipAddr, appName, service)
@@ -594,8 +619,9 @@ func (s *Server) addSandboxMappingLocked(sandboxID, ipAddr, appName, service str
 	// Track entity ID -> IP mapping for DELETE operations
 	s.entityToIP[sandboxID] = ipAddr
 
-	// Update ipToApp mapping
+	// Update ipToApp and ipToSandbox mappings
 	s.ipToApp[ipAddr] = appName
+	s.ipToSandbox[ipAddr] = sandboxID
 
 	// Update ipToService mapping for PTR queries
 	s.ipToService[ipAddr] = service
@@ -694,7 +720,7 @@ func (s *Server) resolveUnknownIP(sourceIP string) bool {
 		var appMD core_v1alpha.Metadata
 		appMD.Decode(appResp.Entity().Entity())
 
-		s.addSandboxMapping(sb.ID.String(), ipAddr, appMD.Name, service)
+		s.AddSandboxMapping(sb.ID.String(), ipAddr, appMD.Name, service)
 		s.log.Info("resolved unknown IP to sandbox via entity lookup", "ip", sourceIP, "sandbox", sb.ID, "app", appMD.Name, "service", service)
 		return true
 	}
@@ -747,8 +773,9 @@ func (s *Server) handleSandboxDeleteByID(entityID string) {
 		return // Inconsistent state, but continue
 	}
 
-	// Remove from ipToApp
+	// Remove from ipToApp, ipToSandbox
 	delete(s.ipToApp, ipAddr)
+	delete(s.ipToSandbox, ipAddr)
 
 	// Remove from ipToService
 	delete(s.ipToService, ipAddr)

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -22,6 +22,7 @@ func newTestServer(t *testing.T) *Server {
 	return &Server{
 		log:             log,
 		ipToApp:         make(map[string]string),
+		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
 		appServiceToIPs: make(map[string]map[string][]string),
 		entityToIP:      make(map[string]string),
@@ -47,10 +48,10 @@ func TestIPReuseBetweenSandboxes(t *testing.T) {
 	)
 
 	// Old sandbox (now STOPPED) was registered at IP
-	s.addSandboxMapping(oldSandboxID, sharedIP, appName, serviceName)
+	s.AddSandboxMapping(oldSandboxID, sharedIP, appName, serviceName)
 
 	// New sandbox (RUNNING) gets the same IP after cooldown
-	s.addSandboxMapping(newSandboxID, sharedIP, appName, serviceName)
+	s.AddSandboxMapping(newSandboxID, sharedIP, appName, serviceName)
 
 	// Old sandbox entity is finally deleted (1 hour cleanup delay)
 	s.handleSandboxDeleteByID(oldSandboxID)
@@ -73,7 +74,7 @@ func TestDeleteSandboxCleansUpWhenNoReuse(t *testing.T) {
 		sandboxID = "sandbox/testapp-web-123"
 	)
 
-	s.addSandboxMapping(sandboxID, ip, appName, service)
+	s.AddSandboxMapping(sandboxID, ip, appName, service)
 	assert.Equal(t, appName, s.lookupAppForIP(ip))
 
 	s.handleSandboxDeleteByID(sandboxID)
@@ -96,8 +97,8 @@ func TestDeleteSandboxWithDifferentIPs(t *testing.T) {
 		sandbox2ID = "sandbox/testapp-web-2"
 	)
 
-	s.addSandboxMapping(sandbox1ID, ip1, appName, service)
-	s.addSandboxMapping(sandbox2ID, ip2, appName, service)
+	s.AddSandboxMapping(sandbox1ID, ip1, appName, service)
+	s.AddSandboxMapping(sandbox2ID, ip2, appName, service)
 
 	s.handleSandboxDeleteByID(sandbox1ID)
 
@@ -122,7 +123,7 @@ func TestSandboxStatusTransitionRemovesFromDNS(t *testing.T) {
 	)
 
 	// Simulate a sandbox that was previously RUNNING and tracked
-	s.addSandboxMapping(sandboxID, ip, appName, service)
+	s.AddSandboxMapping(sandboxID, ip, appName, service)
 	assert.Equal(t, appName, s.lookupAppForIP(ip), "sandbox should be tracked initially")
 
 	// Sandbox transitions to STOPPED (e.g., process exited)
@@ -159,7 +160,7 @@ func TestSandboxDeadStatusRemovesFromDNS(t *testing.T) {
 		sandboxID = "sandbox/testapp-api-dead-test"
 	)
 
-	s.addSandboxMapping(sandboxID, ip, appName, service)
+	s.AddSandboxMapping(sandboxID, ip, appName, service)
 	assert.Equal(t, appName, s.lookupAppForIP(ip))
 
 	// Sandbox marked as DEAD (e.g., health check failed)
@@ -234,6 +235,7 @@ func TestResolveUnknownIPFindsAndRegistersSandbox(t *testing.T) {
 		log:             log,
 		entityClient:    inmem.EAC,
 		ipToApp:         make(map[string]string),
+		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
 		appServiceToIPs: make(map[string]map[string][]string),
 		entityToIP:      make(map[string]string),
@@ -286,6 +288,7 @@ func TestResolveUnknownIPNoMatchingIP(t *testing.T) {
 		log:             log,
 		entityClient:    inmem.EAC,
 		ipToApp:         make(map[string]string),
+		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
 		appServiceToIPs: make(map[string]map[string][]string),
 		entityToIP:      make(map[string]string),

--- a/pkg/oidcauth/validator.go
+++ b/pkg/oidcauth/validator.go
@@ -86,6 +86,7 @@ func (v *Validator) validateWithJWKS(ctx context.Context, tokenString, expectedI
 			"RS256", "RS384", "RS512",
 			"ES256", "ES384", "ES512",
 			"PS256", "PS384", "PS512",
+			"EdDSA",
 		}),
 	)
 

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -1,0 +1,170 @@
+package workloadidentity
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+
+	"miren.dev/runtime/pkg/cloudauth"
+)
+
+type IssuerConfig struct {
+	DataPath       string
+	IssuerURL      string
+	OrganizationID string
+	ClusterID      string
+}
+
+type Issuer struct {
+	privateKey     ed25519.PrivateKey
+	publicKey      ed25519.PublicKey
+	kid            string
+	issuerURL      string
+	organizationID string
+	clusterID      string
+}
+
+type WorkloadClaims struct {
+	jwt.RegisteredClaims
+	OrganizationID string `json:"organization_id,omitempty"`
+	ClusterID      string `json:"cluster_id,omitempty"`
+	App            string `json:"app,omitempty"`
+	SandboxID      string `json:"sandbox_id"`
+}
+
+func NewIssuer(cfg IssuerConfig) (*Issuer, error) {
+	keyPath := filepath.Join(cfg.DataPath, "server", "workload-identity.key")
+
+	kp, err := loadOrGenerateKey(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("workload identity key: %w", err)
+	}
+
+	kid := computeKID(kp.PublicKey)
+
+	return &Issuer{
+		privateKey:     kp.PrivateKey,
+		publicKey:      kp.PublicKey,
+		kid:            kid,
+		issuerURL:      cfg.IssuerURL,
+		organizationID: cfg.OrganizationID,
+		clusterID:      cfg.ClusterID,
+	}, nil
+}
+
+func (iss *Issuer) IssuerURL() string {
+	return iss.issuerURL
+}
+
+func (iss *Issuer) IssueToken(app, sandboxID string) (string, error) {
+	now := time.Now()
+
+	sub := buildSubject(iss.organizationID, app, sandboxID)
+
+	claims := WorkloadClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    iss.issuerURL,
+			Subject:   sub,
+			Audience:  jwt.ClaimStrings{"miren"},
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(1 * time.Hour)),
+			ID:        uuid.New().String(),
+		},
+		OrganizationID: iss.organizationID,
+		ClusterID:      iss.clusterID,
+		App:            app,
+		SandboxID:      sandboxID,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	token.Header["kid"] = iss.kid
+
+	return token.SignedString(iss.privateKey)
+}
+
+func (iss *Issuer) DiscoveryDocument() []byte {
+	doc := map[string]any{
+		"issuer":                                iss.issuerURL,
+		"jwks_uri":                              iss.issuerURL + "/.well-known/jwks",
+		"response_types_supported":              []string{"id_token"},
+		"subject_types_supported":               []string{"public"},
+		"id_token_signing_alg_values_supported": []string{"EdDSA"},
+	}
+
+	data, _ := json.Marshal(doc)
+	return data
+}
+
+func (iss *Issuer) JWKSDocument() ([]byte, error) {
+	jwk := jose.JSONWebKey{
+		Key:       iss.publicKey,
+		KeyID:     iss.kid,
+		Algorithm: "EdDSA",
+		Use:       "sig",
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{jwk},
+	}
+
+	return json.Marshal(jwks)
+}
+
+func loadOrGenerateKey(keyPath string) (*cloudauth.KeyPair, error) {
+	data, err := os.ReadFile(keyPath)
+	if err == nil {
+		return cloudauth.LoadKeyPairFromPEM(string(data))
+	}
+
+	if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("reading key file: %w", err)
+	}
+
+	kp, err := cloudauth.GenerateKeyPair()
+	if err != nil {
+		return nil, err
+	}
+
+	pemData, err := kp.PrivateKeyPEM()
+	if err != nil {
+		return nil, fmt.Errorf("encoding private key: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0700); err != nil {
+		return nil, fmt.Errorf("creating key directory: %w", err)
+	}
+
+	if err := os.WriteFile(keyPath, []byte(pemData), 0600); err != nil {
+		return nil, fmt.Errorf("writing key file: %w", err)
+	}
+
+	return kp, nil
+}
+
+func computeKID(pub ed25519.PublicKey) string {
+	hash := sha256.Sum256(pub)
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+func buildSubject(orgID, app, sandboxID string) string {
+	var parts []string
+	if orgID != "" {
+		parts = append(parts, "org:"+orgID)
+	}
+	if app != "" {
+		parts = append(parts, "app:"+app)
+	}
+	parts = append(parts, "sandbox:"+sandboxID)
+	return strings.Join(parts, ":")
+}

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -1,3 +1,27 @@
+// Package workloadidentity implements OIDC workload identity tokens for
+// sandbox containers, following the GitHub Actions OIDC pattern.
+//
+// # Trust Model
+//
+// Each cluster is its own OIDC issuer with an independent Ed25519 signing key
+// and JWKS endpoint. Miren Cloud is not in the trust path — it only contributes
+// organization_id and cluster_id as claim metadata during registration. This
+// per-cluster model means external verifiers (e.g., AWS IAM OIDC) must
+// configure trust per cluster rather than once for all of Miren. A future
+// central issuer could reduce that to one trust config scoped by claims, but
+// would introduce a single point of compromise for all clusters.
+//
+// # Issuer URL (iss claim)
+//
+// The issuer URL is the cluster's cryptographic identity anchor — it's baked
+// into every token and pinned in external trust configurations. For
+// cloud-registered clusters, this is the provisioned DNS hostname
+// (e.g., https://cluster-abc.miren.systems). For bare-metal clusters without
+// registration, it falls back to cfg.TLS.AdditionalNames[0], meaning the
+// identity anchor is determined by config list order. This fallback is
+// intentionally simple for v1; a more deliberate selection mechanism (e.g.,
+// explicit --issuer-url flag) may be warranted if bare-metal OIDC federation
+// sees adoption.
 package workloadidentity
 
 import (

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,6 +71,14 @@ func (iss *Issuer) PublicKey() any {
 	return iss.publicKey
 }
 
+func (iss *Issuer) Hostname() string {
+	u, err := url.Parse(iss.issuerURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
 const (
 	DefaultTTL = 1 * time.Hour
 	MaxTTL     = 24 * time.Hour
@@ -131,7 +140,7 @@ func (iss *Issuer) IssueTokenWithOptions(app, sandboxID string, opts TokenOption
 func (iss *Issuer) DiscoveryDocument() []byte {
 	doc := map[string]any{
 		"issuer":                                iss.issuerURL,
-		"jwks_uri":                              iss.issuerURL + "/.well-known/jwks",
+		"jwks_uri":                              iss.issuerURL + "/.well-known/miren/jwks",
 		"response_types_supported":              []string{"id_token"},
 		"subject_types_supported":               []string{"public"},
 		"id_token_signing_alg_values_supported": []string{"EdDSA"},

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -66,8 +66,43 @@ func (iss *Issuer) IssuerURL() string {
 	return iss.issuerURL
 }
 
+func (iss *Issuer) PublicKey() any {
+	return iss.publicKey
+}
+
+const (
+	DefaultTTL = 1 * time.Hour
+	MaxTTL     = 24 * time.Hour
+	MinTTL     = 60 * time.Second
+)
+
+type TokenOptions struct {
+	Audience []string
+	TTL      time.Duration
+}
+
 func (iss *Issuer) IssueToken(app, sandboxID string) (string, error) {
+	return iss.IssueTokenWithOptions(app, sandboxID, TokenOptions{})
+}
+
+func (iss *Issuer) IssueTokenWithOptions(app, sandboxID string, opts TokenOptions) (string, error) {
 	now := time.Now()
+
+	aud := opts.Audience
+	if len(aud) == 0 {
+		aud = []string{"miren"}
+	}
+
+	ttl := opts.TTL
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	if ttl > MaxTTL {
+		ttl = MaxTTL
+	}
+	if ttl < MinTTL {
+		ttl = MinTTL
+	}
 
 	sub := buildSubject(iss.organizationID, app, sandboxID)
 
@@ -75,10 +110,10 @@ func (iss *Issuer) IssueToken(app, sandboxID string) (string, error) {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    iss.issuerURL,
 			Subject:   sub,
-			Audience:  jwt.ClaimStrings{"miren"},
+			Audience:  jwt.ClaimStrings(aud),
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),
-			ExpiresAt: jwt.NewNumericDate(now.Add(1 * time.Hour)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 			ID:        uuid.New().String(),
 		},
 		OrganizationID: iss.organizationID,

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -33,6 +33,7 @@ type Issuer struct {
 	issuerURL      string
 	organizationID string
 	clusterID      string
+	previousKey    *jose.JSONWebKey
 }
 
 type WorkloadClaims struct {
@@ -53,14 +54,33 @@ func NewIssuer(cfg IssuerConfig) (*Issuer, error) {
 
 	kid := computeKID(kp.PublicKey)
 
-	return &Issuer{
+	iss := &Issuer{
 		privateKey:     kp.PrivateKey,
 		publicKey:      kp.PublicKey,
 		kid:            kid,
 		issuerURL:      cfg.IssuerURL,
 		organizationID: cfg.OrganizationID,
 		clusterID:      cfg.ClusterID,
-	}, nil
+	}
+
+	// Load previous signing key for rotation overlap. During key rotation,
+	// the operator moves workload-identity.key → workload-identity.key.prev
+	// and restarts. Both keys are published in JWKS so tokens signed by the
+	// old key remain verifiable until they expire.
+	prevPath := keyPath + ".prev"
+	if prevData, err := os.ReadFile(prevPath); err == nil {
+		if prevKP, err := cloudauth.LoadKeyPairFromPEM(string(prevData)); err == nil {
+			prevKID := computeKID(prevKP.PublicKey)
+			iss.previousKey = &jose.JSONWebKey{
+				Key:       prevKP.PublicKey,
+				KeyID:     prevKID,
+				Algorithm: "EdDSA",
+				Use:       "sig",
+			}
+		}
+	}
+
+	return iss, nil
 }
 
 func (iss *Issuer) IssuerURL() string {
@@ -158,11 +178,12 @@ func (iss *Issuer) JWKSDocument() ([]byte, error) {
 		Use:       "sig",
 	}
 
-	jwks := jose.JSONWebKeySet{
-		Keys: []jose.JSONWebKey{jwk},
+	keys := []jose.JSONWebKey{jwk}
+	if iss.previousKey != nil {
+		keys = append(keys, *iss.previousKey)
 	}
 
-	return json.Marshal(jwks)
+	return json.Marshal(jose.JSONWebKeySet{Keys: keys})
 }
 
 func loadOrGenerateKey(keyPath string) (*cloudauth.KeyPair, error) {

--- a/pkg/workloadidentity/issuer_test.go
+++ b/pkg/workloadidentity/issuer_test.go
@@ -1,0 +1,200 @@
+package workloadidentity
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIssuer_GeneratesKey(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:       dir,
+		IssuerURL:      "https://example.miren.cloud",
+		OrganizationID: "org-123",
+		ClusterID:      "cluster-456",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, iss)
+
+	assert.Equal(t, "https://example.miren.cloud", iss.IssuerURL())
+	assert.NotEmpty(t, iss.kid)
+
+	// Key file should exist
+	keyPath := filepath.Join(dir, "server", "workload-identity.key")
+	_, err = os.Stat(keyPath)
+	assert.NoError(t, err)
+}
+
+func TestNewIssuer_LoadsExistingKey(t *testing.T) {
+	dir := t.TempDir()
+
+	iss1, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	iss2, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	// Same key should produce same kid
+	assert.Equal(t, iss1.kid, iss2.kid)
+	assert.Equal(t, iss1.publicKey, iss2.publicKey)
+}
+
+func TestIssueToken(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:       dir,
+		IssuerURL:      "https://example.miren.cloud",
+		OrganizationID: "org-123",
+		ClusterID:      "cluster-456",
+	})
+	require.NoError(t, err)
+
+	tokenStr, err := iss.IssueToken("myapp", "sandbox-789")
+	require.NoError(t, err)
+	require.NotEmpty(t, tokenStr)
+
+	// Parse and verify the token
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		assert.Equal(t, jwt.SigningMethodEdDSA, tok.Method)
+		assert.Equal(t, iss.kid, tok.Header["kid"])
+		return iss.publicKey, nil
+	})
+	require.NoError(t, err)
+	require.True(t, token.Valid)
+
+	claims := token.Claims.(*WorkloadClaims)
+	assert.Equal(t, "https://example.miren.cloud", claims.Issuer)
+	assert.Equal(t, "org:org-123:app:myapp:sandbox:sandbox-789", claims.Subject)
+	assert.Equal(t, jwt.ClaimStrings{"miren"}, claims.Audience)
+	assert.Equal(t, "org-123", claims.OrganizationID)
+	assert.Equal(t, "cluster-456", claims.ClusterID)
+	assert.Equal(t, "myapp", claims.App)
+	assert.Equal(t, "sandbox-789", claims.SandboxID)
+	assert.NotNil(t, claims.IssuedAt)
+	assert.NotNil(t, claims.ExpiresAt)
+}
+
+func TestIssueToken_NoOrg(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	tokenStr, err := iss.IssueToken("myapp", "sandbox-789")
+	require.NoError(t, err)
+
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return iss.publicKey, nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(*WorkloadClaims)
+	assert.Equal(t, "app:myapp:sandbox:sandbox-789", claims.Subject)
+	assert.Empty(t, claims.OrganizationID)
+}
+
+func TestIssueToken_NoApp(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:       dir,
+		IssuerURL:      "https://example.miren.cloud",
+		OrganizationID: "org-123",
+	})
+	require.NoError(t, err)
+
+	tokenStr, err := iss.IssueToken("", "sandbox-789")
+	require.NoError(t, err)
+
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return iss.publicKey, nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(*WorkloadClaims)
+	assert.Equal(t, "org:org-123:sandbox:sandbox-789", claims.Subject)
+}
+
+func TestDiscoveryDocument(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	doc := iss.DiscoveryDocument()
+
+	var parsed map[string]any
+	err = json.Unmarshal(doc, &parsed)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://example.miren.cloud", parsed["issuer"])
+	assert.Equal(t, "https://example.miren.cloud/.well-known/jwks", parsed["jwks_uri"])
+	assert.Contains(t, parsed["id_token_signing_alg_values_supported"], "EdDSA")
+}
+
+func TestJWKSDocument(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	data, err := iss.JWKSDocument()
+	require.NoError(t, err)
+
+	var jwks jose.JSONWebKeySet
+	err = json.Unmarshal(data, &jwks)
+	require.NoError(t, err)
+
+	require.Len(t, jwks.Keys, 1)
+	assert.Equal(t, iss.kid, jwks.Keys[0].KeyID)
+	assert.Equal(t, "EdDSA", jwks.Keys[0].Algorithm)
+	assert.Equal(t, "sig", jwks.Keys[0].Use)
+
+	// The key should be usable to verify tokens
+	pubKey, ok := jwks.Keys[0].Key.(ed25519.PublicKey)
+	require.True(t, ok)
+	assert.Equal(t, iss.publicKey, pubKey)
+}
+
+func TestBuildSubject(t *testing.T) {
+	tests := []struct {
+		org, app, sandbox string
+		expected          string
+	}{
+		{"org-1", "app-1", "sb-1", "org:org-1:app:app-1:sandbox:sb-1"},
+		{"", "app-1", "sb-1", "app:app-1:sandbox:sb-1"},
+		{"org-1", "", "sb-1", "org:org-1:sandbox:sb-1"},
+		{"", "", "sb-1", "sandbox:sb-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, buildSubject(tt.org, tt.app, tt.sandbox))
+		})
+	}
+}

--- a/pkg/workloadidentity/issuer_test.go
+++ b/pkg/workloadidentity/issuer_test.go
@@ -182,6 +182,68 @@ func TestJWKSDocument(t *testing.T) {
 	assert.Equal(t, iss.publicKey, pubKey)
 }
 
+func TestJWKSDocument_WithPreviousKey(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create initial issuer (generates key)
+	iss1, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+	oldKID := iss1.kid
+
+	// Simulate key rotation: move current key to .prev
+	keyPath := filepath.Join(dir, "server", "workload-identity.key")
+	err = os.Rename(keyPath, keyPath+".prev")
+	require.NoError(t, err)
+
+	// Create new issuer (generates new key, loads old as previous)
+	iss2, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, oldKID, iss2.kid)
+	require.NotNil(t, iss2.previousKey)
+
+	// JWKS should contain both keys
+	data, err := iss2.JWKSDocument()
+	require.NoError(t, err)
+
+	var jwks jose.JSONWebKeySet
+	err = json.Unmarshal(data, &jwks)
+	require.NoError(t, err)
+
+	require.Len(t, jwks.Keys, 2)
+	assert.Equal(t, iss2.kid, jwks.Keys[0].KeyID)
+	assert.Equal(t, oldKID, jwks.Keys[1].KeyID)
+
+	// Token signed by the new key should be verifiable via JWKS
+	tokenStr, err := iss2.IssueToken("myapp", "sb-1")
+	require.NoError(t, err)
+
+	_, err = jwt.Parse(tokenStr, func(tok *jwt.Token) (interface{}, error) {
+		kid := tok.Header["kid"].(string)
+		keys := jwks.Key(kid)
+		require.NotEmpty(t, keys)
+		return keys[0].Key, nil
+	})
+	require.NoError(t, err)
+
+	// Token signed by the OLD key (simulated via iss1) should also verify via JWKS
+	oldTokenStr, err := iss1.IssueToken("myapp", "sb-2")
+	require.NoError(t, err)
+
+	_, err = jwt.Parse(oldTokenStr, func(tok *jwt.Token) (interface{}, error) {
+		kid := tok.Header["kid"].(string)
+		keys := jwks.Key(kid)
+		require.NotEmpty(t, keys)
+		return keys[0].Key, nil
+	})
+	require.NoError(t, err)
+}
+
 func TestIssueTokenWithOptions_CustomAudience(t *testing.T) {
 	dir := t.TempDir()
 

--- a/pkg/workloadidentity/issuer_test.go
+++ b/pkg/workloadidentity/issuer_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
@@ -179,6 +180,96 @@ func TestJWKSDocument(t *testing.T) {
 	pubKey, ok := jwks.Keys[0].Key.(ed25519.PublicKey)
 	require.True(t, ok)
 	assert.Equal(t, iss.publicKey, pubKey)
+}
+
+func TestIssueTokenWithOptions_CustomAudience(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	tokenStr, err := iss.IssueTokenWithOptions("myapp", "sb-1", TokenOptions{
+		Audience: []string{"sts.amazonaws.com"},
+	})
+	require.NoError(t, err)
+
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return iss.publicKey, nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(*WorkloadClaims)
+	assert.Equal(t, jwt.ClaimStrings{"sts.amazonaws.com"}, claims.Audience)
+}
+
+func TestIssueTokenWithOptions_CustomTTL(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	tokenStr, err := iss.IssueTokenWithOptions("myapp", "sb-1", TokenOptions{
+		TTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return iss.publicKey, nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(*WorkloadClaims)
+	ttl := claims.ExpiresAt.Sub(claims.IssuedAt.Time)
+
+	assert.Equal(t, 5*time.Minute, ttl)
+}
+
+func TestIssueTokenWithOptions_TTLClamping(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	// Max TTL clamped to 24h
+	tokenStr, err := iss.IssueTokenWithOptions("myapp", "sb-1", TokenOptions{
+		TTL: 48 * time.Hour,
+	})
+	require.NoError(t, err)
+
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return iss.publicKey, nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(*WorkloadClaims)
+	ttl := claims.ExpiresAt.Sub(claims.IssuedAt.Time)
+
+	assert.Equal(t, 24*time.Hour, ttl)
+
+	// Min TTL clamped to 60s
+	tokenStr2, err := iss.IssueTokenWithOptions("myapp", "sb-1", TokenOptions{
+		TTL: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	token2, err := jwt.ParseWithClaims(tokenStr2, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return iss.publicKey, nil
+	})
+	require.NoError(t, err)
+
+	claims2 := token2.Claims.(*WorkloadClaims)
+	ttl2 := claims2.ExpiresAt.Sub(claims2.IssuedAt.Time)
+
+	assert.Equal(t, 60*time.Second, ttl2)
 }
 
 func TestBuildSubject(t *testing.T) {

--- a/pkg/workloadidentity/issuer_test.go
+++ b/pkg/workloadidentity/issuer_test.go
@@ -151,7 +151,7 @@ func TestDiscoveryDocument(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://example.miren.cloud", parsed["issuer"])
-	assert.Equal(t, "https://example.miren.cloud/.well-known/jwks", parsed["jwks_uri"])
+	assert.Equal(t, "https://example.miren.cloud/.well-known/miren/jwks", parsed["jwks_uri"])
 	assert.Contains(t, parsed["id_token_signing_alg_values_supported"], "EdDSA")
 }
 

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -39,6 +39,7 @@ import (
 	"miren.dev/runtime/pkg/oidc"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/waf"
+	"miren.dev/runtime/pkg/workloadidentity"
 )
 
 // idleTimeoutConn wraps a net.Conn and sets a read deadline before each
@@ -73,6 +74,7 @@ const (
 type IngressConfig struct {
 	RequestTimeout time.Duration
 	DataPath       string
+	WorkloadIssuer *workloadidentity.Issuer
 }
 
 type Server struct {
@@ -106,6 +108,8 @@ type Server struct {
 
 	connectorMu       sync.RWMutex
 	connectorHandlers map[string]*connectorHandler
+
+	workloadIssuer *workloadidentity.Issuer
 }
 
 type appUsage struct {
@@ -170,6 +174,7 @@ func NewServer(
 		wafProfileCache:    make(map[entity.Id]*wafProfileEntry),
 		passwordHandlers:   make(map[string]*passwordHandler),
 		connectorHandlers:  make(map[string]*connectorHandler),
+		workloadIssuer:     config.WorkloadIssuer,
 	}
 
 	if httpMetrics == nil {
@@ -431,6 +436,16 @@ func (h *Server) handleRequest(w http.ResponseWriter, req *http.Request) {
 		))
 	defer span.End()
 	req = req.WithContext(ctx)
+
+	// Handle OIDC discovery endpoints for workload identity verification
+	if req.URL.Path == "/.well-known/openid-configuration" {
+		h.handleOIDCDiscovery(w, req)
+		return
+	}
+	if req.URL.Path == "/.well-known/jwks" {
+		h.handleJWKS(w, req)
+		return
+	}
 
 	// Handle Miren server health check endpoint before routing
 	// Using .well-known per RFC 8615 to avoid collision with app routes

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -437,13 +437,10 @@ func (h *Server) handleRequest(w http.ResponseWriter, req *http.Request) {
 	defer span.End()
 	req = req.WithContext(ctx)
 
-	// Handle OIDC discovery endpoints for workload identity verification
-	if req.URL.Path == "/.well-known/openid-configuration" {
+	// Handle OIDC discovery — only on the issuer's own hostname to avoid
+	// shadowing apps that serve their own /.well-known/openid-configuration
+	if req.URL.Path == "/.well-known/openid-configuration" && h.isIssuerHost(req.Host) {
 		h.handleOIDCDiscovery(w, req)
-		return
-	}
-	if req.URL.Path == "/.well-known/jwks" {
-		h.handleJWKS(w, req)
 		return
 	}
 
@@ -451,6 +448,10 @@ func (h *Server) handleRequest(w http.ResponseWriter, req *http.Request) {
 	// Using .well-known per RFC 8615 to avoid collision with app routes
 	if req.URL.Path == "/.well-known/miren/health" {
 		h.handleHealth(w, req)
+		return
+	}
+	if req.URL.Path == "/.well-known/miren/jwks" {
+		h.handleJWKS(w, req)
 		return
 	}
 

--- a/servers/httpingress/workload_identity.go
+++ b/servers/httpingress/workload_identity.go
@@ -1,0 +1,28 @@
+package httpingress
+
+import "net/http"
+
+func (h *Server) handleOIDCDiscovery(w http.ResponseWriter, req *http.Request) {
+	if h.workloadIssuer == nil {
+		http.NotFound(w, req)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.Write(h.workloadIssuer.DiscoveryDocument())
+}
+
+func (h *Server) handleJWKS(w http.ResponseWriter, req *http.Request) {
+	if h.workloadIssuer == nil {
+		http.NotFound(w, req)
+		return
+	}
+	data, err := h.workloadIssuer.JWKSDocument()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/jwk-set+json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.Write(data)
+}

--- a/servers/httpingress/workload_identity.go
+++ b/servers/httpingress/workload_identity.go
@@ -1,6 +1,25 @@
 package httpingress
 
-import "net/http"
+import (
+	"net"
+	"net/http"
+)
+
+func (h *Server) isIssuerHost(reqHost string) bool {
+	if h.workloadIssuer == nil {
+		return false
+	}
+	host, _, err := net.SplitHostPort(reqHost)
+	if err != nil {
+		host = reqHost
+	}
+	issuerHost := h.workloadIssuer.Hostname()
+	issuerHostOnly, _, err := net.SplitHostPort(issuerHost)
+	if err != nil {
+		issuerHostOnly = issuerHost
+	}
+	return host == issuerHostOnly
+}
 
 func (h *Server) handleOIDCDiscovery(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodGet {

--- a/servers/httpingress/workload_identity.go
+++ b/servers/httpingress/workload_identity.go
@@ -3,6 +3,10 @@ package httpingress
 import "net/http"
 
 func (h *Server) handleOIDCDiscovery(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 	if h.workloadIssuer == nil {
 		http.NotFound(w, req)
 		return
@@ -13,6 +17,10 @@ func (h *Server) handleOIDCDiscovery(w http.ResponseWriter, req *http.Request) {
 }
 
 func (h *Server) handleJWKS(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 	if h.workloadIssuer == nil {
 		http.NotFound(w, req)
 		return


### PR DESCRIPTION
## Summary

- Implements GitHub Actions-style OIDC workload identity for all sandboxes
- Each sandbox gets a signed Ed25519 JWT at `/var/run/miren/identity-token` with claims for org, cluster, app, and sandbox ID
- Ingress serves standard `/.well-known/openid-configuration` and `/.well-known/jwks` endpoints so external systems can verify tokens
- Tokens have 1-hour expiry with automatic background refresh every 45 minutes
- On-demand token request server on the bridge gateway (`<gateway>:7123/v1/token`) lets sandboxes request tokens with custom audience and TTL
- Feature is gracefully disabled when no issuer URL is available (no registration + no TLS names)

## Design

Follows the GitHub Actions OIDC pattern:
- Cluster generates a dedicated Ed25519 signing keypair (persisted at `${dataPath}/server/workload-identity.key`)
- JWT subject format: `org:<org-id>:app:<app-name>:sandbox:<sandbox-id>`
- Standard claims: `iss`, `sub`, `aud`, `iat`, `nbf`, `exp`, `jti`
- Custom claims: `organization_id`, `cluster_id`, `app`, `sandbox_id`
- External verifiers fetch the public key via JWKS endpoint to validate tokens

### Token request server

An HTTP server bound to the bridge gateway IP on port 7123 provides on-demand tokens:
- `GET /v1/token` — returns a token for the calling sandbox (identified by source IP)
- `GET /v1/token?audience=sts.amazonaws.com` — custom audience (multiple values supported)
- `GET /v1/token?ttl=300` — custom TTL in seconds (min 60s, max 24h, default 1h)
- Response: `{"value": "<jwt>"}` (matches GitHub Actions format)
- IP-to-sandbox lookup reuses the existing DNS server's mapping via `ServiceManager.LookupSandboxByIP`
- Sandboxes discover the endpoint via `MIREN_IDENTITY_TOKEN_URL` env var

### Environment variables injected

- `MIREN_IDENTITY_TOKEN_PATH=/var/run/miren/identity-token` — static token file
- `MIREN_OIDC_ISSUER_URL=https://<cluster>` — OIDC issuer for external verification
- `MIREN_IDENTITY_TOKEN_URL=http://<gateway>:7123/v1/token` — on-demand token endpoint

## Test plan

- [x] Unit tests for key generation, token signing/verification, OIDC discovery, JWKS format
- [x] Unit tests for custom audience and TTL (with clamping)
- [x] Unit tests for token request server (default, custom audience, custom TTL, unknown IP, invalid TTL, method rejection)
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (all packages green)
- [x] Manual: deployed app, exec'd into sandbox, verified token file + env vars
- [x] Manual: verified OIDC discovery and JWKS endpoints on ingress
- [x] Manual: verified token signature using JWKS public key (full end-to-end)