### PR TITLE
MIR-1198: track ephemeral versions on lease and re-sync activator on watch reconnect

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -292,22 +292,10 @@ func (a *localActivator) AcquireLease(ctx context.Context, ver *core_v1alpha.App
 		return a.waitForSandbox(ctx, ver, service, false)
 	}
 
-	// Ephemeral pools must never scale beyond 1 instance — preview deploys
-	// are short-lived and are meant for inspection, not traffic. If the cached
-	// pool is ephemeral, wait for the existing sandbox instead of incrementing.
-	a.mu.RLock()
-	state, statePresent := a.pools[key]
-	isEphemeral := statePresent && !state.inProgress && state.pool != nil && state.pool.Ephemeral
-	a.mu.RUnlock()
-	if isEphemeral {
-		a.log.Info("ephemeral pool — not scaling, waiting for capacity",
-			"app", ver.App,
-			"version", ver.Version,
-			"service", service)
-		return a.waitForSandbox(ctx, ver, service, false)
-	}
-
-	// No RUNNING or PENDING sandboxes - need to scale up via pool
+	// No RUNNING or PENDING sandboxes - need to scale up via pool.
+	// Ephemeral preview deploys are capped at one instance by EphemeralStrategy
+	// (MaxInstances=1), so requestPoolCapacity won't scale them past their single
+	// sandbox — it returns the at-cap pool and the caller waits for it.
 	a.log.Info("no available sandboxes, requesting capacity from pool",
 		"app", ver.App,
 		"version", ver.Version,
@@ -553,6 +541,46 @@ func (a *localActivator) waitForSandbox(ctx context.Context, ver *core_v1alpha.A
 	}
 }
 
+// registerVersionPoolLocked records the version->pool mapping and ensures an
+// (initially empty) poolSandboxes entry exists for the pool. The caller must
+// hold a.mu for writing.
+//
+// It is idempotent: existing entries are left untouched, since the watcher and
+// recovery own the contents of poolSandboxes[*].sandboxes. It deliberately does
+// not touch a.pools — each caller sets that with its own entity revision.
+//
+// This consolidates the bookkeeping that requestPoolCapacity must do whenever it
+// resolves a pool for a version. Without it, the on-demand creation path (used by
+// ephemeral versions, which the DeploymentLauncher never pre-creates a pool for)
+// would seed a.pools but not a.versions, leaving the version untracked until the
+// watcher happened to discover a sandbox — so AcquireLease would report
+// "tracked: false" and never hand out a lease (MIR-1198).
+func (a *localActivator) registerVersionPoolLocked(
+	key verKey,
+	ver *core_v1alpha.AppVersion,
+	pool *compute_v1alpha.SandboxPool,
+	service string,
+	strategy concurrency.ConcurrencyStrategy,
+) {
+	if _, exists := a.versions[key]; !exists {
+		a.versions[key] = &versionPoolRef{
+			ver:      ver,
+			poolID:   pool.ID,
+			service:  service,
+			strategy: strategy,
+		}
+	}
+
+	if _, ok := a.poolSandboxes[pool.ID]; !ok {
+		a.poolSandboxes[pool.ID] = &poolSandboxes{
+			pool:      pool,
+			sandboxes: []*sandbox{},
+			service:   service,
+			strategy:  strategy,
+		}
+	}
+}
+
 // requestPoolCapacity finds the SandboxPool created by DeploymentLauncher and increments DesiredInstances.
 // It uses retry logic with exponential backoff to handle the race where Activator receives
 // a request before DeploymentLauncher has finished creating the pool.
@@ -602,23 +630,22 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 				continue
 			}
 
+			// state.pool is now a real (non-sentinel) cached pool. Ensure the
+			// version->pool mapping exists before we increment and return: a pool
+			// created on-demand seeds a.pools but not a.versions, so without this
+			// a cached ephemeral pool would stay untracked and AcquireLease would
+			// never resolve its sandbox (MIR-1198). Seeding here also self-heals
+			// pools created before this fix shipped, on the next lease request.
+			a.mu.Lock()
+			a.registerVersionPoolLocked(key, ver, state.pool, service, strategy)
+			a.mu.Unlock()
+
 			// Check if pool is in crash cooldown before attempting to increment
 			if !state.pool.CooldownUntil.IsZero() && time.Now().Before(state.pool.CooldownUntil) {
 				return state.pool, fmt.Errorf("%w: application in crash cooldown until %s (consecutive crashes: %d)",
 					ErrSandboxDiedEarly,
 					state.pool.CooldownUntil.Format(time.RFC3339),
 					state.pool.ConsecutiveCrashCount)
-			}
-
-			// Ephemeral pools never scale beyond 1 instance. AcquireLease should
-			// already short-circuit this path, but guard here as well so any
-			// future caller can't accidentally scale a preview deploy.
-			if state.pool.Ephemeral && state.pool.DesiredInstances >= 1 {
-				a.log.Debug("ephemeral pool — refusing to increment capacity",
-					"pool", state.pool.ID,
-					"service", service,
-					"desired_instances", state.pool.DesiredInstances)
-				return state.pool, nil
 			}
 
 			// Update existing pool - increment DesiredInstances with optimistic concurrency control
@@ -871,21 +898,7 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 				inProgress: false,
 			}
 
-			a.versions[key] = &versionPoolRef{
-				ver:      ver,
-				poolID:   poolID,
-				service:  service,
-				strategy: strategy,
-			}
-
-			if _, ok := a.poolSandboxes[poolID]; !ok {
-				a.poolSandboxes[poolID] = &poolSandboxes{
-					pool:      foundPool,
-					sandboxes: []*sandbox{},
-					service:   service,
-					strategy:  strategy,
-				}
-			}
+			a.registerVersionPoolLocked(key, ver, foundPool, service, strategy)
 
 			// If the pool is already at its strategy's cap, there's nothing
 			// to patch (e.g. ephemeral pools seed at DesiredInstances=1 with
@@ -1008,6 +1021,7 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 					pool:     foundPool.pool,
 					revision: foundPool.revision,
 				}
+				a.registerVersionPoolLocked(key, ver, foundPool.pool, service, strategy)
 			}
 			a.mu.Unlock()
 			close(sentinel.done)
@@ -1142,10 +1156,30 @@ func (a *localActivator) Invalidations() <-chan SandboxInvalidation {
 	return a.invalidationCh
 }
 
+// resyncFromStore re-reads pools and sandboxes from the entity store and adopts
+// any that the in-memory caches are missing. WatchIndex only streams new ops from
+// the current revision — it does not replay existing entities on (re)connect — so a
+// watch reconnect (compaction, leader change, network blip) silently drops every
+// event during the gap. Without a re-sync those changes are lost until the process
+// restarts, which is how an ephemeral version ends up permanently untracked even
+// though a healthy sandbox exists for it (MIR-1198). recoverPools and
+// recoverSandboxes are additive (create-only / dedupe by sandbox ID) and lock per
+// item, so this is safe to run repeatedly against live state and from either watch.
+func (a *localActivator) resyncFromStore(ctx context.Context) {
+	a.log.Info("re-syncing activator state from store after watch reconnect")
+	if err := a.recoverPools(ctx); err != nil {
+		a.log.Error("failed to re-sync pools after watch reconnect", "error", err)
+	}
+	if err := a.recoverSandboxes(ctx); err != nil {
+		a.log.Error("failed to re-sync sandboxes after watch reconnect", "error", err)
+	}
+}
+
 func (a *localActivator) watchSandboxes(ctx context.Context) {
 	// Watch for sandbox changes: update status AND discover new RUNNING sandboxes
 	// This is the single source of sandbox discovery for the activator
 	// Retry loop to handle transient failures
+	firstWatch := true
 	for {
 		select {
 		case <-ctx.Done():
@@ -1153,6 +1187,13 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 			return
 		default:
 		}
+
+		// NewLocalActivator already ran the initial recovery, so only re-sync on
+		// reconnects (see resyncFromStore for why this is necessary).
+		if !firstWatch {
+			a.resyncFromStore(ctx)
+		}
+		firstWatch = false
 
 		a.log.Info("starting sandbox discovery watch")
 
@@ -1636,12 +1677,19 @@ func (a *localActivator) recoverPools(ctx context.Context) error {
 
 		a.mu.Lock()
 
-		// Cache pool state (for sentinel pattern in requestPoolCapacity)
+		// Cache pool state (for sentinel pattern in requestPoolCapacity).
+		// Create-only: at startup the map is empty so this seeds every pool, but
+		// when recoverPools runs again as a live re-sync (watch reconnect) we must
+		// not clobber an in-progress creation sentinel or a freshly-patched
+		// revision held by a concurrent requestPoolCapacity. watchPools keeps
+		// existing entries' DesiredInstances fresh; here we only fill gaps.
 		key := verKey{versionID.String(), pool.Service}
-		a.pools[key] = &poolState{
-			pool:       &pool,
-			revision:   ent.Revision(),
-			inProgress: false,
+		if _, ok := a.pools[key]; !ok {
+			a.pools[key] = &poolState{
+				pool:       &pool,
+				revision:   ent.Revision(),
+				inProgress: false,
+			}
 		}
 
 		// Initialize empty poolSandboxes entry (sandboxes will be added by recoverSandboxes)
@@ -1914,6 +1962,7 @@ func (a *localActivator) removePoolFromTracking(poolID entity.Id) {
 // watchPools watches for pool entity changes and keeps the in-memory cache in sync.
 // Handles deletions (cleanup stale entries) and updates (refresh DesiredInstances, etc.).
 func (a *localActivator) watchPools(ctx context.Context) {
+	firstWatch := true
 	for {
 		select {
 		case <-ctx.Done():
@@ -1921,6 +1970,14 @@ func (a *localActivator) watchPools(ctx context.Context) {
 			return
 		default:
 		}
+
+		// Like watchSandboxes, the pool watch streams only new ops from the current
+		// revision, so re-sync from the store on reconnect to recover pool/version
+		// mappings missed while the watch was down (see resyncFromStore).
+		if !firstWatch {
+			a.resyncFromStore(ctx)
+		}
+		firstWatch = false
 
 		a.log.Info("starting pool watch")
 

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -1165,6 +1165,12 @@ func (a *localActivator) Invalidations() <-chan SandboxInvalidation {
 // though a healthy sandbox exists for it (MIR-1198). recoverPools and
 // recoverSandboxes are additive (create-only / dedupe by sandbox ID) and lock per
 // item, so this is safe to run repeatedly against live state and from either watch.
+//
+// Both watchSandboxes and watchPools call this on their own reconnect, so a single
+// etcd blip (which usually trips both watches at once) runs the reconcile twice,
+// roughly concurrently. That's intentional: the redundant pass is idempotent and
+// bounded, and accepting it is cheaper than adding cross-goroutine debounce state
+// to coordinate the two watchers.
 func (a *localActivator) resyncFromStore(ctx context.Context) {
 	a.log.Info("re-syncing activator state from store after watch reconnect")
 	if err := a.recoverPools(ctx); err != nil {
@@ -1172,6 +1178,32 @@ func (a *localActivator) resyncFromStore(ctx context.Context) {
 	}
 	if err := a.recoverSandboxes(ctx); err != nil {
 		a.log.Error("failed to re-sync sandboxes after watch reconnect", "error", err)
+	}
+
+	// Recovery adopts sandboxes by appending to poolSandboxes directly, bypassing
+	// the per-sandbox notify the watcher does, so wake parked waiters to re-check
+	// rather than making them wait out the 60s fallback ticker.
+	a.wakeAllWaiters()
+}
+
+// wakeAllWaiters signals every parked waitForSandbox goroutine to re-check its
+// pool. resyncFromStore calls this after a reconnect reconcile: recoverSandboxes
+// adopts sandboxes by appending to poolSandboxes directly, bypassing the
+// per-sandbox notify the watcher does (see watchSandboxes), so without this an
+// already-parked waiter wouldn't see an adopted sandbox until the 60s fallback
+// ticker — and would log a misleading "channel notification may have failed" when
+// it finally woke. A spurious wake is harmless: the waiter re-scans and re-parks
+// if its sandbox still isn't there.
+func (a *localActivator) wakeAllWaiters() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, chans := range a.newSandboxChans {
+		for _, ch := range chans {
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
+		}
 	}
 }
 
@@ -1683,6 +1715,14 @@ func (a *localActivator) recoverPools(ctx context.Context) error {
 		// not clobber an in-progress creation sentinel or a freshly-patched
 		// revision held by a concurrent requestPoolCapacity. watchPools keeps
 		// existing entries' DesiredInstances fresh; here we only fill gaps.
+		//
+		// Deliberately we do NOT refresh an already-cached entry here, even though
+		// the missed-event window is exactly when its DesiredInstances/revision
+		// could have gone stale. A refresh is unsafe: this re-sync's store read can
+		// itself be older than an in-memory revision a concurrent requestPoolCapacity
+		// just patched, so overwriting could move the cache backward. The stale case
+		// self-heals instead — the next increment hits a revision conflict on Patch,
+		// clears the entry, and re-reads (see the ErrConflict path above).
 		key := verKey{versionID.String(), pool.Service}
 		if _, ok := a.pools[key]; !ok {
 			a.pools[key] = &poolState{

--- a/components/activator/activator_test.go
+++ b/components/activator/activator_test.go
@@ -3365,3 +3365,139 @@ func TestReSyncRecoversUntrackedEphemeralSandbox(t *testing.T) {
 	require.NotNil(t, lease)
 	assert.Equal(t, "http://10.0.0.7:3000", lease.URL)
 }
+
+// TestWakeAllWaitersNonBlocking verifies wakeAllWaiters signals an empty
+// notification channel and does not block on one that is already full (the
+// buffered channel a parked waiter registers). This is the mechanism
+// resyncFromStore relies on to nudge parked waiters after a reconnect reconcile.
+func TestWakeAllWaitersNonBlocking(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	activator := &localActivator{
+		log:             log,
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	empty := make(chan struct{}, 1)
+	full := make(chan struct{}, 1)
+	full <- struct{}{} // pre-fill so a second send would block without the default
+
+	activator.newSandboxChans[verKey{"ver-a", "web"}] = []chan struct{}{empty}
+	activator.newSandboxChans[verKey{"ver-b", "web"}] = []chan struct{}{full}
+
+	done := make(chan struct{})
+	go func() {
+		activator.wakeAllWaiters()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("wakeAllWaiters blocked on a full channel")
+	}
+
+	select {
+	case <-empty:
+	default:
+		t.Fatal("wakeAllWaiters did not signal the empty channel")
+	}
+}
+
+// TestResyncWakesParkedWaiter is the regression test for the parked-waiter gap:
+// recoverSandboxes adopts sandboxes by appending to poolSandboxes directly,
+// bypassing the per-sandbox notify the watcher does. A request already parked in
+// waitForSandbox when a reconnect happens would therefore not see its adopted
+// sandbox until the 60s fallback ticker. resyncFromStore now calls wakeAllWaiters
+// to nudge it immediately; this test parks a real waiter, then drives the re-sync
+// and asserts the lease is delivered far faster than the ticker would allow.
+func TestResyncWakesParkedWaiter(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	testVer := newEphemeralVersion(t, server, ctx)
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:              "web",
+		SandboxSpec:          compute_v1alpha.SandboxSpec{Version: testVer.ID},
+		ReferencedByVersions: []entity.Id{testVer.ID},
+		DesiredInstances:     1,
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+
+	activator := &localActivator{
+		log:             log,
+		eac:             server.EAC,
+		versions:        make(map[verKey]*versionPoolRef),
+		poolSandboxes:   make(map[entity.Id]*poolSandboxes),
+		pools:           make(map[verKey]*poolState),
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	key := verKey{testVer.ID.String(), "web"}
+
+	// Park a real waiter. The pool exists at cap (desired=1, MaxInstances=1) but no
+	// sandbox does yet, so AcquireLease resolves the pool, tracks the version, finds
+	// no sandbox, and parks in waitForSandbox.
+	type result struct {
+		lease *Lease
+		err   error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		lease, err := activator.AcquireLease(ctx, testVer, "web")
+		resCh <- result{lease, err}
+	}()
+
+	// Wait until the waiter has registered its notification channel (i.e. it has
+	// parked). The channel is buffered, so a wake delivered after this point lands
+	// even if the waiter hasn't reached its select yet.
+	require.Eventually(t, func() bool {
+		activator.mu.RLock()
+		defer activator.mu.RUnlock()
+		return len(activator.newSandboxChans[key]) > 0
+	}, 2*time.Second, 5*time.Millisecond, "waiter never parked")
+
+	// Now a RUNNING sandbox appears in the store, as it would after the pool scaled
+	// up during a watch gap.
+	sb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+		Spec: compute_v1alpha.SandboxSpec{
+			Version: testVer.ID,
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Port: []compute_v1alpha.SandboxSpecContainerPort{{Port: 3000, Name: "http", Type: "http"}}},
+			},
+		},
+		Network: []compute_v1alpha.Network{{Address: "10.0.0.7"}},
+	}
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetAttrs(entity.New(
+		(&core_v1alpha.Metadata{
+			Name:   "eph-sandbox",
+			Labels: types.LabelSet("service", "web", "pool", poolID.String()),
+		}).Encode,
+		entity.Ident, entity.MustKeyword("sandbox/eph-sb"),
+		sb.Encode,
+	).Attrs())
+	_, err = server.EAC.Put(ctx, &rpcE)
+	require.NoError(t, err)
+
+	// The reconnect re-sync adopts the sandbox and wakes the parked waiter.
+	start := time.Now()
+	activator.resyncFromStore(ctx)
+
+	select {
+	case res := <-resCh:
+		require.NoError(t, res.err)
+		require.NotNil(t, res.lease)
+		assert.Equal(t, "http://10.0.0.7:3000", res.lease.URL)
+		// The fallback ticker is 60s; the wake must deliver far sooner.
+		assert.Less(t, time.Since(start), 10*time.Second, "waiter was woken by the wake, not the fallback ticker")
+	case <-time.After(15 * time.Second):
+		t.Fatal("parked waiter was never woken after re-sync")
+	}
+}

--- a/components/activator/activator_test.go
+++ b/components/activator/activator_test.go
@@ -3011,3 +3011,357 @@ func TestAcquireLeaseSucceedsAfterURLArrives(t *testing.T) {
 	assert.Greater(t, elapsed, 50*time.Millisecond, "should have waited for the URL to arrive")
 	assert.Less(t, elapsed, 2*time.Second, "should not have timed out")
 }
+
+// fakePoolCreator is a test PoolCreator that delegates to a closure, letting a
+// test control when and how the on-demand pool is created.
+type fakePoolCreator struct {
+	create func(ctx context.Context, ver *core_v1alpha.AppVersion, service string) (entity.Id, error)
+}
+
+func (f *fakePoolCreator) CreatePoolForVersion(ctx context.Context, ver *core_v1alpha.AppVersion, service string) (entity.Id, error) {
+	return f.create(ctx, ver, service)
+}
+
+func newEphemeralVersion(t *testing.T, server *testutils.InMemEntityServer, ctx context.Context) *core_v1alpha.AppVersion {
+	t.Helper()
+
+	app := &core_v1alpha.App{}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+
+	ver := &core_v1alpha.AppVersion{
+		App:            appID,
+		Version:        "v1",
+		ImageUrl:       "test:latest",
+		EphemeralLabel: "feat-x",
+		Config: core_v1alpha.Config{
+			Services: []core_v1alpha.Services{
+				{Name: "web"},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", ver)
+	require.NoError(t, err)
+	ver.ID = verID
+	return ver
+}
+
+// TestRequestPoolCapacityOnDemandSeedsVersionMapping is the direct MIR-1198
+// regression test. Ephemeral versions have no pool pre-created by the launcher,
+// so requestPoolCapacity creates one on demand via the PoolCreator. That branch
+// used to seed only a.pools, leaving a.versions empty — so AcquireLease reported
+// "tracked: false" and never handed out a lease even though the pool (and later a
+// sandbox) existed. It must now seed a.versions and a.poolSandboxes too.
+func TestRequestPoolCapacityOnDemandSeedsVersionMapping(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	testVer := newEphemeralVersion(t, server, ctx)
+
+	activator := &localActivator{
+		log:             log,
+		eac:             server.EAC,
+		versions:        make(map[verKey]*versionPoolRef),
+		poolSandboxes:   make(map[entity.Id]*poolSandboxes),
+		pools:           make(map[verKey]*poolState),
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	var createdPoolID entity.Id
+	activator.poolCreator = &fakePoolCreator{
+		create: func(ctx context.Context, ver *core_v1alpha.AppVersion, service string) (entity.Id, error) {
+			pool := &compute_v1alpha.SandboxPool{
+				Service:              service,
+				SandboxSpec:          compute_v1alpha.SandboxSpec{Version: ver.ID},
+				ReferencedByVersions: []entity.Id{ver.ID},
+				DesiredInstances:     1,
+			}
+			id, err := server.Client.Create(ctx, "ondemand-pool", pool)
+			if err != nil {
+				return "", err
+			}
+			createdPoolID = id
+			return id, nil
+		},
+	}
+
+	resultPool, err := activator.requestPoolCapacity(ctx, testVer, "web")
+	require.NoError(t, err)
+	require.NotNil(t, resultPool)
+
+	key := verKey{testVer.ID.String(), "web"}
+
+	activator.mu.RLock()
+	defer activator.mu.RUnlock()
+
+	versionRef, ok := activator.versions[key]
+	require.True(t, ok, "on-demand pool creation must seed a.versions for the ephemeral version (MIR-1198)")
+	assert.Equal(t, createdPoolID, versionRef.poolID)
+
+	_, ok = activator.poolSandboxes[createdPoolID]
+	require.True(t, ok, "on-demand pool creation must seed an a.poolSandboxes entry")
+}
+
+// TestRequestPoolCapacityCachedSeedsVersionMapping covers the self-heal path: a
+// pool created on-demand before this fix shipped (or one whose watcher mapping was
+// lost) leaves a.pools cached but a.versions empty. Every subsequent call hits the
+// cached-pool branch, which must now seed a.versions so the version becomes
+// resolvable without requiring a process restart.
+func TestRequestPoolCapacityCachedSeedsVersionMapping(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	testVer := newEphemeralVersion(t, server, ctx)
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:              "web",
+		SandboxSpec:          compute_v1alpha.SandboxSpec{Version: testVer.ID},
+		ReferencedByVersions: []entity.Id{testVer.ID},
+		DesiredInstances:     1,
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	getRes, err := server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+
+	activator := &localActivator{
+		log:             log,
+		eac:             server.EAC,
+		versions:        make(map[verKey]*versionPoolRef),
+		poolSandboxes:   make(map[entity.Id]*poolSandboxes),
+		pools:           make(map[verKey]*poolState),
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	key := verKey{testVer.ID.String(), "web"}
+	// Mimic a pool created on-demand before the fix: a.pools is cached but
+	// a.versions was never seeded.
+	activator.pools[key] = &poolState{
+		pool:       pool,
+		revision:   getRes.Entity().Revision(),
+		inProgress: false,
+	}
+
+	_, err = activator.requestPoolCapacity(ctx, testVer, "web")
+	require.NoError(t, err)
+
+	activator.mu.RLock()
+	defer activator.mu.RUnlock()
+
+	versionRef, ok := activator.versions[key]
+	require.True(t, ok, "cached-pool path must self-heal by seeding a.versions (MIR-1198)")
+	assert.Equal(t, poolID, versionRef.poolID)
+}
+
+// TestAcquireLeaseEphemeralOnDemand exercises the full lease path for an ephemeral
+// version end-to-end: AcquireLease -> waitForSandbox -> requestPoolCapacity creates
+// the pool on demand (seeding a.versions), then the watcher (simulated here) injects
+// the booted sandbox. Before the fix the version stayed untracked, so AcquireLease
+// would hang until the 120s cap; this test bounds the wait to 2s so a regression
+// fails fast.
+func TestAcquireLeaseEphemeralOnDemand(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	testVer := newEphemeralVersion(t, server, ctx)
+	strategy := concurrency.NewStrategyForVersion(testVer, "web", &testVer.Config.Services[0].ServiceConcurrency)
+
+	activator := &localActivator{
+		log:             log,
+		eac:             server.EAC,
+		versions:        make(map[verKey]*versionPoolRef),
+		poolSandboxes:   make(map[entity.Id]*poolSandboxes),
+		pools:           make(map[verKey]*poolState),
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	activator.poolCreator = &fakePoolCreator{
+		create: func(ctx context.Context, ver *core_v1alpha.AppVersion, service string) (entity.Id, error) {
+			pool := &compute_v1alpha.SandboxPool{
+				Service:              service,
+				SandboxSpec:          compute_v1alpha.SandboxSpec{Version: ver.ID},
+				ReferencedByVersions: []entity.Id{ver.ID},
+				DesiredInstances:     1,
+			}
+			return server.Client.Create(ctx, "ondemand-pool", pool)
+		},
+	}
+
+	key := verKey{testVer.ID.String(), "web"}
+
+	// Simulate the watcher discovering the booted sandbox shortly after the pool
+	// is created on-demand: poll until the version becomes tracked, then inject a
+	// RUNNING sandbox with a URL and notify waiters.
+	go func() {
+		for {
+			activator.mu.RLock()
+			versionRef, ok := activator.versions[key]
+			activator.mu.RUnlock()
+			if ok {
+				activator.mu.Lock()
+				ps := activator.poolSandboxes[versionRef.poolID]
+				ent := entity.Blank()
+				ent.SetID("eph-sandbox")
+				ps.sandboxes = append(ps.sandboxes, &sandbox{
+					sandbox: &compute_v1alpha.Sandbox{
+						ID:     entity.Id("eph-sandbox"),
+						Status: compute_v1alpha.RUNNING,
+						Spec:   compute_v1alpha.SandboxSpec{Version: testVer.ID},
+					},
+					ent:         ent,
+					lastRenewal: time.Now(),
+					url:         "http://10.0.0.7:3000",
+					tracker:     strategy.InitializeTracker(),
+				})
+				if chans, ok := activator.newSandboxChans[key]; ok {
+					for _, ch := range chans {
+						select {
+						case ch <- struct{}{}:
+						default:
+						}
+					}
+				}
+				activator.mu.Unlock()
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	acqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	lease, err := activator.AcquireLease(acqCtx, testVer, "web")
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.Equal(t, "http://10.0.0.7:3000", lease.URL)
+}
+
+// TestRecoverPoolsPreservesInProgressSentinel verifies recoverPools is safe to run
+// as a live re-sync (on watch reconnect): it must not clobber an in-progress
+// creation sentinel held by a concurrent requestPoolCapacity, which would strand
+// the sentinel's waiters on the abandoned done channel.
+func TestRecoverPoolsPreservesInProgressSentinel(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	testVer := newEphemeralVersion(t, server, ctx)
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:              "web",
+		SandboxSpec:          compute_v1alpha.SandboxSpec{Version: testVer.ID},
+		ReferencedByVersions: []entity.Id{testVer.ID},
+		DesiredInstances:     1,
+	}
+	_, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+
+	activator := &localActivator{
+		log:             log,
+		eac:             server.EAC,
+		versions:        make(map[verKey]*versionPoolRef),
+		poolSandboxes:   make(map[entity.Id]*poolSandboxes),
+		pools:           make(map[verKey]*poolState),
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	key := verKey{testVer.ID.String(), "web"}
+	sentinel := &poolState{inProgress: true, done: make(chan struct{})}
+	activator.pools[key] = sentinel
+
+	require.NoError(t, activator.recoverPools(ctx))
+
+	activator.mu.RLock()
+	got := activator.pools[key]
+	activator.mu.RUnlock()
+	assert.Same(t, sentinel, got, "recoverPools must not replace an in-progress creation sentinel")
+	assert.True(t, got.inProgress, "sentinel must remain in-progress")
+}
+
+// TestReSyncRecoversUntrackedEphemeralSandbox reproduces the steady state the
+// activator lands in after a watch reconnect drops events (MIR-1198): a pool and a
+// RUNNING sandbox exist in the store for an ephemeral version, but the activator
+// tracks nothing (WatchIndex never replayed them). The re-sync that watchSandboxes
+// now runs on reconnect — recoverPools + recoverSandboxes — must adopt the sandbox
+// and seed a.versions so AcquireLease can hand out a lease instead of hanging.
+func TestReSyncRecoversUntrackedEphemeralSandbox(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	testVer := newEphemeralVersion(t, server, ctx)
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:              "web",
+		SandboxSpec:          compute_v1alpha.SandboxSpec{Version: testVer.ID},
+		ReferencedByVersions: []entity.Id{testVer.ID},
+		DesiredInstances:     1,
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+
+	sb := &compute_v1alpha.Sandbox{
+		Status: compute_v1alpha.RUNNING,
+		Spec: compute_v1alpha.SandboxSpec{
+			Version: testVer.ID,
+			Container: []compute_v1alpha.SandboxSpecContainer{
+				{Port: []compute_v1alpha.SandboxSpecContainerPort{{Port: 3000, Name: "http", Type: "http"}}},
+			},
+		},
+		Network: []compute_v1alpha.Network{{Address: "10.0.0.7"}},
+	}
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetAttrs(entity.New(
+		(&core_v1alpha.Metadata{
+			Name:   "eph-sandbox",
+			Labels: types.LabelSet("service", "web", "pool", poolID.String()),
+		}).Encode,
+		entity.Ident, entity.MustKeyword("sandbox/eph-sb"),
+		sb.Encode,
+	).Attrs())
+	_, err = server.EAC.Put(ctx, &rpcE)
+	require.NoError(t, err)
+
+	activator := &localActivator{
+		log:             log,
+		eac:             server.EAC,
+		versions:        make(map[verKey]*versionPoolRef),
+		poolSandboxes:   make(map[entity.Id]*poolSandboxes),
+		pools:           make(map[verKey]*poolState),
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	key := verKey{testVer.ID.String(), "web"}
+	activator.mu.RLock()
+	_, tracked := activator.versions[key]
+	activator.mu.RUnlock()
+	require.False(t, tracked, "precondition: version must start untracked (as after a dropped watch event)")
+
+	// The re-sync watchSandboxes performs on reconnect.
+	require.NoError(t, activator.recoverPools(ctx))
+	require.NoError(t, activator.recoverSandboxes(ctx))
+
+	acqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	lease, err := activator.AcquireLease(acqCtx, testVer, "web")
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	assert.Equal(t, "http://10.0.0.7:3000", lease.URL)
+}


### PR DESCRIPTION
## Problem

Ephemeral preview deploys intermittently fail at the ingress with `error acquiring lease` and **never recover** — the activator logs `tracked: false` / `fallback ticker fired` for a version even though its pool and a healthy RUNNING sandbox both exist. The signature is "works for a while, then stops" (existing ephemeral blackbox tests pass).

## Root cause

`a.versions[key]` (the version→pool mapping every lease lookup keys off) is populated by only three places, and ephemeral versions hit none of the synchronous ones reliably:

1. **On-demand pool creation didn't seed it.** Ephemeral versions skip activation at deploy, so the DeploymentLauncher never pre-creates their pool — they go through `requestPoolCapacity`'s on-demand branch, which set only `a.pools`, not `a.versions`/`a.poolSandboxes`. Only the launcher-found branch (normal deploys) seeded all three. So an ephemeral version was untracked until the async watcher happened to discover its sandbox.

2. **The watcher is the only continuous populator, and it loses events on reconnect.** `WatchIndex` (`pkg/entity/store.go:1538`) is a raw etcd watch from the current revision — no snapshot/replay on (re)connect — and the watch retry loop just re-calls it after a 5s sleep. The only full store reconcile (`recoverPools` + `recoverSandboxes`) runs **once**, at startup. So a watch reset (compaction, leader change, network blip) silently drops events; a sandbox that booted in that window (including after ephemeral scale-to-zero or a re-deploy with a new version ID) is never re-seen, and the version is stranded until a process restart. That's the "works, then stops."

## Fix

- **`registerVersionPoolLocked`** — seed `a.versions` + `a.poolSandboxes` from `requestPoolCapacity`'s on-demand, cached, and launcher-found branches, so the mapping is established when the pool is resolved rather than depending on the watcher.
- **`resyncFromStore`** (`recoverPools` + `recoverSandboxes`) — run on every reconnect in both `watchSandboxes` and `watchPools`, repairing both the version mapping and the sandbox objects after a missed-event window. `recoverPools`' `a.pools` write is now create-only so a live re-sync can't clobber an in-progress creation sentinel (startup behavior unchanged).
- Remove dead `state.pool.Ephemeral` reads (field never set true; ephemeral scaling is enforced by `EphemeralStrategy.MaxInstances()` since MIR-1159).

## Tests

6 new tests in `components/activator/activator_test.go`, including:
- `TestRequestPoolCapacityOnDemandSeedsVersionMapping` / `...Cached...` — direct regression (fail without the fix, proven by revert).
- `TestAcquireLeaseEphemeralOnDemand` — end-to-end lease via the on-demand path, bounded to 2s so a regression fails fast instead of hanging out the 120s cap.
- `TestRecoverPoolsPreservesInProgressSentinel` — live re-sync doesn't clobber a sentinel.
- `TestReSyncRecoversUntrackedEphemeralSandbox` — reproduces the bug-report steady state (pool + RUNNING sandbox in store, activator tracking nothing) and proves the reconnect re-sync recovers it.

42/42 activator tests pass in iso; `make lint` clean.

## Notes / follow-ups

- A residual sub-ms gap remains between the re-sync list and the new watch establishing (vs. the multi-second outage it replaces); a fully gap-free revision-resume watch would be a larger, separate change.