### PR TITLE
Clean up app log output

### DIFF
--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -339,8 +339,7 @@ func printLogEntry(ctx *Context, l *app_v1alpha.LogEntry) {
 }
 
 var hiddenAttributes = map[string]bool{
-	"source":        true,
-	"user.orig_msg": true,
+	"source": true,
 }
 
 func formatAttributes(m map[string]string) string {

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -29,7 +29,7 @@ func buildFilterWithService(userFilter, service string) string {
 	if service == "" {
 		return userFilter
 	}
-	serviceFilter := fmt.Sprintf("service:%q", service)
+	serviceFilter := fmt.Sprintf("(service:%q OR miren.service:%q)", service, service)
 	if userFilter == "" {
 		return serviceFilter
 	}
@@ -313,13 +313,19 @@ func printLogEntryJSON(ctx *Context, l *app_v1alpha.LogEntry) {
 
 func printLogEntry(ctx *Context, l *app_v1alpha.LogEntry) {
 	prefix := ""
-	if l.HasSource() && l.Source() != "" {
+	if l.HasAttributes() {
+		if shortID, ok := l.Attributes()["miren.short_id"]; ok && shortID != "" {
+			prefix = "[" + shortID + "] "
+		}
+	}
+	if prefix == "" && l.HasSource() && l.Source() != "" {
 		source := l.Source()
 		if len(source) > 12 {
 			source = source[:3] + "…" + source[len(source)-8:]
 		}
 		prefix = "[" + source + "] "
 	}
+
 	attrs := ""
 	if l.HasAttributes() {
 		attrs = formatAttributes(l.Attributes())
@@ -332,13 +338,24 @@ func printLogEntry(ctx *Context, l *app_v1alpha.LogEntry) {
 		attrs)
 }
 
+var hiddenAttributes = map[string]bool{
+	"source":        true,
+	"user.orig_msg": true,
+}
+
 func formatAttributes(m map[string]string) string {
 	if len(m) == 0 {
 		return ""
 	}
 	keys := make([]string, 0, len(m))
 	for k := range m {
+		if hiddenAttributes[k] || strings.HasPrefix(k, "miren.") {
+			continue
+		}
 		keys = append(keys, k)
+	}
+	if len(keys) == 0 {
+		return ""
 	}
 	slices.Sort(keys)
 

--- a/cli/commands/logs_test.go
+++ b/cli/commands/logs_test.go
@@ -29,7 +29,7 @@ func TestBuildFilterWithService(t *testing.T) {
 			name:       "service only",
 			userFilter: "",
 			service:    "web",
-			want:       `service:"web"`,
+			want:       `(service:"web" OR miren.service:"web")`,
 		},
 		{
 			name:       "filter only",
@@ -41,19 +41,19 @@ func TestBuildFilterWithService(t *testing.T) {
 			name:       "service and filter",
 			userFilter: "error",
 			service:    "web",
-			want:       `service:"web" error`,
+			want:       `(service:"web" OR miren.service:"web") error`,
 		},
 		{
 			name:       "service with complex filter",
 			userFilter: `error -debug /timeout/`,
 			service:    "worker",
-			want:       `service:"worker" error -debug /timeout/`,
+			want:       `(service:"worker" OR miren.service:"worker") error -debug /timeout/`,
 		},
 		{
 			name:       "service with spaces needs quoting",
 			userFilter: "",
 			service:    "my service",
-			want:       `service:"my service"`,
+			want:       `(service:"my service" OR miren.service:"my service")`,
 		},
 	}
 
@@ -214,6 +214,129 @@ func TestPrintLogEntryJSON(t *testing.T) {
 			if err := json.Unmarshal([]byte(line), &obj); err != nil {
 				t.Errorf("line %d is not valid JSON: %v", i, err)
 			}
+		}
+	})
+}
+
+func TestPrintLogEntry(t *testing.T) {
+	ts := time.Date(2026, 3, 13, 16, 30, 0, 0, time.UTC)
+
+	t.Run("uses short_id for bracket display", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx := &Context{Context: context.Background(), Stdout: &buf}
+
+		entry := &app_v1alpha.LogEntry{}
+		entry.SetTimestamp(standard.ToTimestamp(ts))
+		entry.SetStream("stdout")
+		entry.SetSource("clusteragent-web-CbZwTC2ATZnrWjt1uPwog")
+		entry.SetLine("hello world")
+		entry.SetAttributes(map[string]string{"miren.short_id": "wog"})
+
+		printLogEntry(ctx, entry)
+
+		got := buf.String()
+		if !strings.Contains(got, "[wog]") {
+			t.Errorf("expected [wog] in output, got: %s", got)
+		}
+		if strings.Contains(got, "miren.short_id=") {
+			t.Errorf("miren.short_id should be hidden from attributes, got: %s", got)
+		}
+	})
+
+	t.Run("falls back to abbreviated source without short_id", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx := &Context{Context: context.Background(), Stdout: &buf}
+
+		entry := &app_v1alpha.LogEntry{}
+		entry.SetTimestamp(standard.ToTimestamp(ts))
+		entry.SetStream("stdout")
+		entry.SetSource("clusteragent-web-CbZwTC2ATZnrWjt1uPwog")
+		entry.SetLine("hello world")
+
+		printLogEntry(ctx, entry)
+
+		got := buf.String()
+		if !strings.Contains(got, "[clu…jt1uPwog]") {
+			t.Errorf("expected abbreviated source in output, got: %s", got)
+		}
+	})
+
+	t.Run("filters noise attributes", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx := &Context{Context: context.Background(), Stdout: &buf}
+
+		entry := &app_v1alpha.LogEntry{}
+		entry.SetTimestamp(standard.ToTimestamp(ts))
+		entry.SetStream("stdout")
+		entry.SetLine("hello")
+		entry.SetAttributes(map[string]string{
+			"miren.container": "app",
+			"miren.sandbox":   "sandbox/test-abc123",
+			"miren.service":   "web",
+			"miren.stage":     "app-run",
+			"miren.version":   "app_version/test-v1",
+			"miren.short_id":  "abc",
+			"component":       "scheduler",
+		})
+
+		printLogEntry(ctx, entry)
+
+		got := buf.String()
+		if !strings.Contains(got, "component=scheduler") {
+			t.Errorf("expected component=scheduler in output, got: %s", got)
+		}
+		if strings.Contains(got, "miren.") {
+			t.Errorf("miren.* attributes should be hidden, got: %s", got)
+		}
+	})
+
+	t.Run("plain text lines displayed as-is", func(t *testing.T) {
+		var buf bytes.Buffer
+		ctx := &Context{Context: context.Background(), Stdout: &buf}
+
+		entry := &app_v1alpha.LogEntry{}
+		entry.SetTimestamp(standard.ToTimestamp(ts))
+		entry.SetStream("stdout")
+		entry.SetLine("plain text log message")
+
+		printLogEntry(ctx, entry)
+
+		got := buf.String()
+		if !strings.Contains(got, "plain text log message") {
+			t.Errorf("expected plain text preserved, got: %s", got)
+		}
+	})
+}
+
+func TestFormatAttributes(t *testing.T) {
+	t.Run("filters hidden attributes", func(t *testing.T) {
+		m := map[string]string{
+			"miren.container": "app",
+			"miren.sandbox":   "sandbox/test",
+			"miren.service":   "web",
+			"miren.stage":     "app-run",
+			"miren.version":   "v1",
+			"miren.short_id":  "abc",
+			"source":          "test-id",
+			"component":       "scheduler",
+		}
+		got := formatAttributes(m)
+		if !strings.Contains(got, "component=scheduler") {
+			t.Errorf("expected component=scheduler, got: %q", got)
+		}
+		if strings.Contains(got, "miren.") {
+			t.Errorf("hidden attrs should not appear, got: %q", got)
+		}
+	})
+
+	t.Run("returns empty when all attributes are hidden", func(t *testing.T) {
+		m := map[string]string{
+			"miren.container": "app",
+			"miren.sandbox":   "sandbox/test",
+		}
+		got := formatAttributes(m)
+		if got != "" {
+			t.Errorf("expected empty, got: %q", got)
 		}
 	})
 }

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -887,10 +887,6 @@ func specsMatch(spec1, spec2 *compute_v1alpha.SandboxSpec) (string, bool) {
 		return fmt.Sprintf("port wait timeout mismatch: %s vs %s", spec1.PortWaitTimeout, spec2.PortWaitTimeout), false
 	}
 
-	if !labelsEqual(spec1.LogAttribute, spec2.LogAttribute) {
-		return "log attribute mismatch", false
-	}
-
 	// All fields match (excluding version)
 	return "", true
 }

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -524,7 +524,7 @@ func (l *Launcher) buildSandboxSpec(
 	sbSpec := &compute_v1alpha.SandboxSpec{
 		Version:      ver.ID,
 		LogEntity:    app.ID.String(),
-		LogAttribute: types.LabelSet("stage", "app-run", "service", serviceName),
+		LogAttribute: types.LabelSet("miren.stage", "app-run", "miren.service", serviceName),
 	}
 
 	startDir := cfgSpec.StartDirectory

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -887,6 +887,10 @@ func specsMatch(spec1, spec2 *compute_v1alpha.SandboxSpec) (string, bool) {
 		return fmt.Sprintf("port wait timeout mismatch: %s vs %s", spec1.PortWaitTimeout, spec2.PortWaitTimeout), false
 	}
 
+	if !labelsEqual(spec1.LogAttribute, spec2.LogAttribute) {
+		return "log attribute mismatch", false
+	}
+
 	// All fields match (excluding version)
 	return "", true
 }

--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -221,7 +221,7 @@ func bootTask(ctx context.Context, in bootTaskIn) (bootTaskOut, error) {
 	deps := saga.Get[*createSandboxDeps](ctx)
 	log := saga.Get[*slog.Logger](ctx)
 
-	sb, _, err := deps.entities.GetSandbox(ctx, in.SandboxID)
+	sb, meta, err := deps.entities.GetSandbox(ctx, in.SandboxID)
 	if err != nil {
 		return bootTaskOut{}, fmt.Errorf("fetching sandbox: %w", err)
 	}
@@ -236,7 +236,7 @@ func bootTask(ctx context.Context, in bootTaskIn) (bootTaskOut, error) {
 		return bootTaskOut{}, fmt.Errorf("loading container: %w", err)
 	}
 
-	task, err := deps.runtime.BootInitialTask(ctx, sb, ep, container)
+	task, err := deps.runtime.BootInitialTask(ctx, sb, ep, container, meta.ShortId())
 	if err != nil {
 		return bootTaskOut{}, fmt.Errorf("booting task: %w", err)
 	}
@@ -326,7 +326,7 @@ func bootContainers(ctx context.Context, in bootContainersIn) (bootContainersOut
 		// failures happen before any container produces output, so the
 		// log stream would otherwise be empty and the reason would only
 		// be visible in journalctl on the node.
-		deps.obs.LogSandboxEvent(sb,
+		deps.obs.LogSandboxEvent(sb, meta.ShortId(),
 			fmt.Sprintf("volume configuration failed: %v", err))
 		return bootContainersOut{}, fmt.Errorf("configuring volumes: %w", err)
 	}
@@ -391,9 +391,9 @@ func addMetrics(ctx context.Context, in addMetricsIn) (addMetricsOut, error) {
 		le = sb.ID.String()
 	}
 
-	attrs := map[string]string{"sandbox": sb.ID.String()}
+	attrs := map[string]string{"miren.sandbox": sb.ID.String()}
 	if sb.Spec.Version != "" {
-		attrs["version"] = sb.Spec.Version.String()
+		attrs["miren.version"] = sb.Spec.Version.String()
 	}
 	for _, lbl := range sb.Spec.LogAttribute {
 		attrs[lbl.Key] = lbl.Value

--- a/controllers/sandbox/create_saga_test.go
+++ b/controllers/sandbox/create_saga_test.go
@@ -200,7 +200,7 @@ func (m *mockContainerRuntime) CleanupContainer(ctx context.Context, cont contai
 	m.cleanupContainerCalls++
 }
 
-func (m *mockContainerRuntime) BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container) (containerd.Task, error) {
+func (m *mockContainerRuntime) BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container, shortID string) (containerd.Task, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.bootInitialTaskCalls++
@@ -299,7 +299,7 @@ func (m *mockObservability) UpdateServices(ctx context.Context, co *compute.Sand
 	return m.updateSvcsErr
 }
 
-func (m *mockObservability) LogSandboxEvent(sb *compute.Sandbox, line string) {
+func (m *mockObservability) LogSandboxEvent(sb *compute.Sandbox, shortID, line string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.loggedEvents = append(m.loggedEvents, line)
@@ -772,8 +772,8 @@ func TestCreateSandboxSaga_MetricsAttributes(t *testing.T) {
 
 	assert.Equal(t, 1, h.obs.addMetricsCalls)
 	assert.Equal(t, "my-app", h.obs.lastLogEntity)
-	assert.Equal(t, h.sandboxID, h.obs.lastAttrs["sandbox"])
-	assert.Equal(t, "v42", h.obs.lastAttrs["version"])
+	assert.Equal(t, h.sandboxID, h.obs.lastAttrs["miren.sandbox"])
+	assert.Equal(t, "v42", h.obs.lastAttrs["miren.version"])
 	assert.Equal(t, "production", h.obs.lastAttrs["env"])
 	assert.Equal(t, "us-east", h.obs.lastAttrs["region"])
 

--- a/controllers/sandbox/interface.go
+++ b/controllers/sandbox/interface.go
@@ -46,7 +46,7 @@ type SandboxContainerRuntime interface {
 	CreateContainer(ctx context.Context, id string, opts ...containerd.NewContainerOpts) (string, error)
 	LoadContainer(ctx context.Context, id string) (containerd.Container, error)
 	CleanupContainer(ctx context.Context, cont containerd.Container)
-	BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container) (containerd.Task, error)
+	BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container, shortID string) (containerd.Task, error)
 	ConfigureVolumes(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) (map[string]string, error)
 	BootContainers(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, sbPid int, cgroups map[string]string, meta *entity.Meta, volumeMounts map[string]string) ([]WaitPort, error)
 	DestroySubContainers(ctx context.Context, id entity.Id) error
@@ -65,5 +65,5 @@ type SandboxObservability interface {
 	// surfaces it alongside container output. Intended for startup
 	// or teardown events where a container never produced logs of
 	// its own (e.g. volume mount failures).
-	LogSandboxEvent(sb *compute.Sandbox, line string)
+	LogSandboxEvent(sb *compute.Sandbox, shortID, line string)
 }

--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -3,9 +3,9 @@ package sandbox
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +18,7 @@ type SandboxLogs struct {
 	log    *slog.Logger
 	entity string
 	attrs  map[string]string
+	extra  map[string]string
 	buf    bytes.Buffer
 	stream observability.LogStream
 	lw     observability.LogWriter
@@ -33,6 +34,7 @@ func NewSandboxLogs(
 		log:    log,
 		entity: entity,
 		attrs:  attrs,
+		extra:  make(map[string]string),
 		stream: observability.Stdout,
 		lw:     lw,
 	}
@@ -59,13 +61,6 @@ func (s *SandboxLogs) Write(p []byte) (n int, err error) {
 	}
 
 	return
-}
-
-var jsonLogSkipFields = map[string]bool{
-	"time":    true,
-	"level":   true,
-	"msg":     true,
-	"message": true,
 }
 
 var jsonLevelToStream = map[string]observability.LogStream{
@@ -95,20 +90,14 @@ func (s *SandboxLogs) processLine(line string) {
 		traceId = matches[1]
 	}
 
-	attrs := s.attrs
-	if body, extra, lvlStream, ok := parseStructuredJSON(line); ok {
-		extra["user.orig_msg"] = line
+	var extra map[string]string
+	if body, lvlStream, ok := s.scanJSON(line); ok {
+		s.extra["user.orig_msg"] = line
 		line = body
 		if lvlStream != "" {
 			stream = lvlStream
 		}
-		attrs = make(map[string]string)
-		for k, v := range s.attrs {
-			attrs[k] = v
-		}
-		for k, v := range extra {
-			attrs[k] = v
-		}
+		extra = s.extra
 	}
 
 	err := s.lw.WriteEntry(s.entity, observability.LogEntry{
@@ -116,57 +105,114 @@ func (s *SandboxLogs) processLine(line string) {
 		Stream:     stream,
 		Body:       line,
 		TraceID:    traceId,
-		Attributes: attrs,
+		Attributes: s.attrs,
+		Extra:      extra,
 	})
 	if err != nil {
 		s.log.Error("failed to write log entry", "error", err, "line", line)
 	}
 }
 
-// parseStructuredJSON detects structured JSON log lines and extracts fields.
-// Returns the message body, extra attributes, an optional stream override, and whether parsing succeeded.
-func parseStructuredJSON(line string) (string, map[string]string, observability.LogStream, bool) {
+// scanJSON uses the json tokenizer to extract structured fields from a JSON log
+// line directly into s.extra, avoiding a full unmarshal. Returns the message,
+// an optional stream override, and whether parsing succeeded.
+func (s *SandboxLogs) scanJSON(line string) (string, observability.LogStream, bool) {
 	if len(line) == 0 || line[0] != '{' {
-		return "", nil, "", false
+		return "", "", false
 	}
 
-	var fields map[string]any
-	if err := json.Unmarshal([]byte(line), &fields); err != nil {
-		return "", nil, "", false
+	dec := json.NewDecoder(strings.NewReader(line))
+
+	// Expect opening brace
+	t, err := dec.Token()
+	if err != nil || t != json.Delim('{') {
+		return "", "", false
 	}
 
-	msg, _ := fields["msg"].(string)
-	if msg == "" {
-		msg, _ = fields["message"].(string)
-	}
-	if msg == "" {
-		return "", nil, "", false
-	}
+	clear(s.extra)
 
+	var msg string
 	var stream observability.LogStream
-	if level, ok := fields["level"].(string); ok {
-		stream = jsonLevelToStream[level]
-	}
 
-	extra := make(map[string]string, len(fields))
-	for k, v := range fields {
-		if jsonLogSkipFields[k] {
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return "", "", false
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return "", "", false
+		}
+
+		valTok, err := dec.Token()
+		if err != nil {
+			return "", "", false
+		}
+
+		// If value is a nested object or array, skip it
+		if delim, ok := valTok.(json.Delim); ok {
+			if !skipNestedJSON(dec, delim) {
+				return "", "", false
+			}
 			continue
 		}
-		switch val := v.(type) {
-		case string:
-			extra[k] = val
+
+		switch key {
+		case "msg", "message":
+			if v, ok := valTok.(string); ok {
+				msg = v
+			}
+		case "level":
+			if v, ok := valTok.(string); ok {
+				stream = jsonLevelToStream[v]
+			}
+		case "time":
+			// skip
 		default:
-			extra[k] = fmt.Sprintf("%v", v)
+			switch v := valTok.(type) {
+			case string:
+				s.extra[key] = v
+			case float64:
+				s.extra[key] = strconv.FormatFloat(v, 'f', -1, 64)
+			case bool:
+				s.extra[key] = strconv.FormatBool(v)
+			case nil:
+				// skip nulls
+			}
 		}
 	}
 
-	return msg, extra, stream, true
+	if msg == "" {
+		return "", "", false
+	}
+
+	return msg, stream, true
+}
+
+// skipNestedJSON consumes a balanced JSON object or array from the decoder.
+func skipNestedJSON(dec *json.Decoder, open json.Delim) bool {
+	depth := 1
+	for depth > 0 {
+		t, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		if d, ok := t.(json.Delim); ok {
+			switch d {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+	return true
 }
 
 func (s *SandboxLogs) Stderr() *SandboxLogs {
 	x := *s
 	x.stream = observability.Stderr
+	x.extra = make(map[string]string)
 
 	return &x
 }

--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -170,6 +170,9 @@ func (s *SandboxLogs) scanJSON(line string) (string, observability.LogStream, bo
 		case "time":
 			// skip
 		default:
+			if strings.HasPrefix(key, "miren.") {
+				key = "-" + key
+			}
 			switch v := valTok.(type) {
 			case string:
 				s.extra[key] = v

--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -151,10 +151,11 @@ func (s *SandboxLogs) scanJSON(line string) (string, observability.LogStream, bo
 		case "time":
 			// skip
 		default:
-			// Escape user fields that would collide with internal miren.*
-			// attribution so app logs can't shadow it.
+			// Escape user fields that would collide with internal attribution
+			// so app logs can't shadow it: the miren.* namespace and the lone
+			// un-namespaced "source" key both get a leading dash.
 			k := key.Str
-			if strings.HasPrefix(k, "miren.") {
+			if strings.HasPrefix(k, "miren.") || k == "source" {
 				k = "-" + k
 			}
 			switch value.Type {

--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -122,6 +122,7 @@ func (s *SandboxLogs) scanJSON(line string) (string, observability.LogStream, bo
 	}
 
 	dec := json.NewDecoder(strings.NewReader(line))
+	dec.UseNumber()
 
 	// Expect opening brace
 	t, err := dec.Token()
@@ -172,14 +173,28 @@ func (s *SandboxLogs) scanJSON(line string) (string, observability.LogStream, bo
 			switch v := valTok.(type) {
 			case string:
 				s.extra[key] = v
-			case float64:
-				s.extra[key] = strconv.FormatFloat(v, 'f', -1, 64)
+			case json.Number:
+				s.extra[key] = v.String()
 			case bool:
 				s.extra[key] = strconv.FormatBool(v)
 			case nil:
 				// skip nulls
 			}
 		}
+	}
+
+	// Consume closing brace
+	closeTok, err := dec.Token()
+	if err != nil || closeTok != json.Delim('}') {
+		return "", "", false
+	}
+
+	// Reject if there's trailing content after the JSON object
+	if dec.More() {
+		return "", "", false
+	}
+	if _, err := dec.Token(); err == nil {
+		return "", "", false
 	}
 
 	if msg == "" {

--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -2,6 +2,8 @@ package sandbox
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -59,6 +61,20 @@ func (s *SandboxLogs) Write(p []byte) (n int, err error) {
 	return
 }
 
+var jsonLogSkipFields = map[string]bool{
+	"time":    true,
+	"level":   true,
+	"msg":     true,
+	"message": true,
+}
+
+var jsonLevelToStream = map[string]observability.LogStream{
+	"ERROR": observability.Stderr,
+	"error": observability.Stderr,
+	"WARN":  observability.Stderr,
+	"warn":  observability.Stderr,
+}
+
 func (s *SandboxLogs) processLine(line string) {
 	ts := time.Now()
 
@@ -79,16 +95,73 @@ func (s *SandboxLogs) processLine(line string) {
 		traceId = matches[1]
 	}
 
+	attrs := s.attrs
+	if body, extra, lvlStream, ok := parseStructuredJSON(line); ok {
+		extra["user.orig_msg"] = line
+		line = body
+		if lvlStream != "" {
+			stream = lvlStream
+		}
+		attrs = make(map[string]string, len(s.attrs)+len(extra))
+		for k, v := range s.attrs {
+			attrs[k] = v
+		}
+		for k, v := range extra {
+			attrs[k] = v
+		}
+	}
+
 	err := s.lw.WriteEntry(s.entity, observability.LogEntry{
 		Timestamp:  ts,
 		Stream:     stream,
 		Body:       line,
 		TraceID:    traceId,
-		Attributes: s.attrs,
+		Attributes: attrs,
 	})
 	if err != nil {
 		s.log.Error("failed to write log entry", "error", err, "line", line)
 	}
+}
+
+// parseStructuredJSON detects structured JSON log lines and extracts fields.
+// Returns the message body, extra attributes, an optional stream override, and whether parsing succeeded.
+func parseStructuredJSON(line string) (string, map[string]string, observability.LogStream, bool) {
+	if len(line) == 0 || line[0] != '{' {
+		return "", nil, "", false
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(line), &fields); err != nil {
+		return "", nil, "", false
+	}
+
+	msg, _ := fields["msg"].(string)
+	if msg == "" {
+		msg, _ = fields["message"].(string)
+	}
+	if msg == "" {
+		return "", nil, "", false
+	}
+
+	var stream observability.LogStream
+	if level, ok := fields["level"].(string); ok {
+		stream = jsonLevelToStream[level]
+	}
+
+	extra := make(map[string]string, len(fields))
+	for k, v := range fields {
+		if jsonLogSkipFields[k] {
+			continue
+		}
+		switch val := v.(type) {
+		case string:
+			extra[k] = val
+		default:
+			extra[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	return msg, extra, stream, true
 }
 
 func (s *SandboxLogs) Stderr() *SandboxLogs {

--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -102,7 +102,7 @@ func (s *SandboxLogs) processLine(line string) {
 		if lvlStream != "" {
 			stream = lvlStream
 		}
-		attrs = make(map[string]string, len(s.attrs)+len(extra))
+		attrs = make(map[string]string)
 		for k, v := range s.attrs {
 			attrs[k] = v
 		}

--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -91,7 +91,6 @@ func (s *SandboxLogs) processLine(line string) {
 
 	var extra map[string]string
 	if body, lvlStream, ok := s.scanJSON(line); ok {
-		s.extra["user.orig_msg"] = line
 		line = body
 		if lvlStream != "" {
 			stream = lvlStream

--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -2,13 +2,12 @@ package sandbox
 
 import (
 	"bytes"
-	"encoding/json"
 	"log/slog"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
+	"github.com/tidwall/gjson"
 	"miren.dev/runtime/observability"
 )
 
@@ -113,20 +112,24 @@ func (s *SandboxLogs) processLine(line string) {
 	}
 }
 
-// scanJSON uses the json tokenizer to extract structured fields from a JSON log
-// line directly into s.extra, avoiding a full unmarshal. Returns the message,
-// an optional stream override, and whether parsing succeeded.
+// scanJSON extracts structured fields from a JSON log line into s.extra,
+// promoting scalar fields and skipping nested objects/arrays. Returns the
+// message, an optional stream override derived from the level, and whether
+// parsing succeeded. Lines that aren't a JSON object, carry no string msg, or
+// have trailing content fall through to be logged verbatim.
 func (s *SandboxLogs) scanJSON(line string) (string, observability.LogStream, bool) {
 	if len(line) == 0 || line[0] != '{' {
 		return "", "", false
 	}
 
-	dec := json.NewDecoder(strings.NewReader(line))
-	dec.UseNumber()
+	// gjson.Parse ignores trailing content, so validate the whole line first
+	// to keep logging malformed or trailing-junk lines verbatim.
+	if !gjson.Valid(line) {
+		return "", "", false
+	}
 
-	// Expect opening brace
-	t, err := dec.Token()
-	if err != nil || t != json.Delim('{') {
+	root := gjson.Parse(line)
+	if !root.IsObject() {
 		return "", "", false
 	}
 
@@ -135,96 +138,43 @@ func (s *SandboxLogs) scanJSON(line string) (string, observability.LogStream, bo
 	var msg string
 	var stream observability.LogStream
 
-	for dec.More() {
-		keyTok, err := dec.Token()
-		if err != nil {
-			return "", "", false
-		}
-		key, ok := keyTok.(string)
-		if !ok {
-			return "", "", false
-		}
-
-		valTok, err := dec.Token()
-		if err != nil {
-			return "", "", false
-		}
-
-		// If value is a nested object or array, skip it
-		if delim, ok := valTok.(json.Delim); ok {
-			if !skipNestedJSON(dec, delim) {
-				return "", "", false
-			}
-			continue
-		}
-
-		switch key {
+	root.ForEach(func(key, value gjson.Result) bool {
+		switch key.Str {
 		case "msg", "message":
-			if v, ok := valTok.(string); ok {
-				msg = v
+			if value.Type == gjson.String {
+				msg = value.Str
 			}
 		case "level":
-			if v, ok := valTok.(string); ok {
-				stream = jsonLevelToStream[v]
+			if value.Type == gjson.String {
+				stream = jsonLevelToStream[value.Str]
 			}
 		case "time":
 			// skip
 		default:
-			if strings.HasPrefix(key, "miren.") {
-				key = "-" + key
+			// Escape user fields that would collide with internal miren.*
+			// attribution so app logs can't shadow it.
+			k := key.Str
+			if strings.HasPrefix(k, "miren.") {
+				k = "-" + k
 			}
-			switch v := valTok.(type) {
-			case string:
-				s.extra[key] = v
-			case json.Number:
-				s.extra[key] = v.String()
-			case bool:
-				s.extra[key] = strconv.FormatBool(v)
-			case nil:
-				// skip nulls
+			switch value.Type {
+			case gjson.String:
+				s.extra[k] = value.Str
+			case gjson.Number, gjson.True, gjson.False:
+				// Raw preserves the original numeric literal (large integers
+				// included) and renders bools as "true"/"false".
+				s.extra[k] = value.Raw
 			}
+			// gjson.Null and nested objects/arrays (gjson.JSON) are skipped.
 		}
-	}
-
-	// Consume closing brace
-	closeTok, err := dec.Token()
-	if err != nil || closeTok != json.Delim('}') {
-		return "", "", false
-	}
-
-	// Reject if there's trailing content after the JSON object
-	if dec.More() {
-		return "", "", false
-	}
-	if _, err := dec.Token(); err == nil {
-		return "", "", false
-	}
+		return true
+	})
 
 	if msg == "" {
 		return "", "", false
 	}
 
 	return msg, stream, true
-}
-
-// skipNestedJSON consumes a balanced JSON object or array from the decoder.
-func skipNestedJSON(dec *json.Decoder, open json.Delim) bool {
-	depth := 1
-	for depth > 0 {
-		t, err := dec.Token()
-		if err != nil {
-			return false
-		}
-		if d, ok := t.(json.Delim); ok {
-			switch d {
-			case '{', '[':
-				depth++
-			case '}', ']':
-				depth--
-			}
-		}
-	}
-	return true
 }
 
 func (s *SandboxLogs) Stderr() *SandboxLogs {

--- a/controllers/sandbox/log_test.go
+++ b/controllers/sandbox/log_test.go
@@ -452,6 +452,22 @@ func TestScanJSON(t *testing.T) {
 		}
 	})
 
+	t.Run("un-namespaced source key is escaped", func(t *testing.T) {
+		// source is the one internal attribute that isn't under the miren.*
+		// namespace, so it gets the same dash-escape treatment.
+		sl := newScanner()
+		_, _, ok := sl.scanJSON(`{"msg":"hi","source":"evil"}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if _, exists := sl.extra["source"]; exists {
+			t.Error("source should be escaped, not stored directly")
+		}
+		if sl.extra["-source"] != "evil" {
+			t.Errorf("extra[-source] = %q, want %q", sl.extra["-source"], "evil")
+		}
+	})
+
 	t.Run("rejects trailing content after JSON object", func(t *testing.T) {
 		sl := newScanner()
 		_, _, ok := sl.scanJSON(`{"msg":"ok"} trailing`)

--- a/controllers/sandbox/log_test.go
+++ b/controllers/sandbox/log_test.go
@@ -249,20 +249,28 @@ func BenchmarkSandboxLogs(b *testing.B) {
 	}
 }
 
-func TestParseStructuredJSON(t *testing.T) {
+func TestScanJSON(t *testing.T) {
+	newScanner := func() *SandboxLogs {
+		return NewSandboxLogs(
+			slog.New(slog.NewTextHandler(os.Stderr, nil)),
+			"test", map[string]string{}, &mockLogWriter{},
+		)
+	}
+
 	t.Run("valid JSON with msg", func(t *testing.T) {
-		body, extra, stream, ok := parseStructuredJSON(`{"time":"2026-01-01T00:00:00Z","level":"INFO","msg":"hello","key":"val"}`)
+		sl := newScanner()
+		body, stream, ok := sl.scanJSON(`{"time":"2026-01-01T00:00:00Z","level":"INFO","msg":"hello","key":"val"}`)
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
 		if body != "hello" {
 			t.Errorf("body = %q, want %q", body, "hello")
 		}
-		if extra["key"] != "val" {
-			t.Errorf("extra[key] = %q, want %q", extra["key"], "val")
+		if sl.extra["key"] != "val" {
+			t.Errorf("extra[key] = %q, want %q", sl.extra["key"], "val")
 		}
 		for _, skip := range []string{"time", "level", "msg"} {
-			if _, exists := extra[skip]; exists {
+			if _, exists := sl.extra[skip]; exists {
 				t.Errorf("field %q should be stripped", skip)
 			}
 		}
@@ -272,7 +280,8 @@ func TestParseStructuredJSON(t *testing.T) {
 	})
 
 	t.Run("valid JSON with message field", func(t *testing.T) {
-		body, _, _, ok := parseStructuredJSON(`{"time":"2026-01-01T00:00:00Z","level":"INFO","message":"hello"}`)
+		sl := newScanner()
+		body, _, ok := sl.scanJSON(`{"time":"2026-01-01T00:00:00Z","level":"INFO","message":"hello"}`)
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
@@ -282,7 +291,8 @@ func TestParseStructuredJSON(t *testing.T) {
 	})
 
 	t.Run("ERROR level sets stderr stream", func(t *testing.T) {
-		_, _, stream, ok := parseStructuredJSON(`{"level":"ERROR","msg":"fail"}`)
+		sl := newScanner()
+		_, stream, ok := sl.scanJSON(`{"level":"ERROR","msg":"fail"}`)
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
@@ -292,7 +302,8 @@ func TestParseStructuredJSON(t *testing.T) {
 	})
 
 	t.Run("WARN level sets stderr stream", func(t *testing.T) {
-		_, _, stream, ok := parseStructuredJSON(`{"level":"WARN","msg":"warning"}`)
+		sl := newScanner()
+		_, stream, ok := sl.scanJSON(`{"level":"WARN","msg":"warning"}`)
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
@@ -302,29 +313,61 @@ func TestParseStructuredJSON(t *testing.T) {
 	})
 
 	t.Run("non-JSON returns false", func(t *testing.T) {
-		_, _, _, ok := parseStructuredJSON("plain text")
+		sl := newScanner()
+		_, _, ok := sl.scanJSON("plain text")
 		if ok {
 			t.Error("expected ok=false for plain text")
 		}
 	})
 
 	t.Run("JSON without msg field returns false", func(t *testing.T) {
-		_, _, _, ok := parseStructuredJSON(`{"key":"value","other":"data"}`)
+		sl := newScanner()
+		_, _, ok := sl.scanJSON(`{"key":"value","other":"data"}`)
 		if ok {
 			t.Error("expected ok=false for JSON without msg")
 		}
 	})
 
 	t.Run("non-string values are formatted", func(t *testing.T) {
-		_, extra, _, ok := parseStructuredJSON(`{"msg":"hi","count":42,"flag":true}`)
+		sl := newScanner()
+		_, _, ok := sl.scanJSON(`{"msg":"hi","count":42,"flag":true}`)
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
-		if extra["count"] != "42" {
-			t.Errorf("extra[count] = %q, want %q", extra["count"], "42")
+		if sl.extra["count"] != "42" {
+			t.Errorf("extra[count] = %q, want %q", sl.extra["count"], "42")
 		}
-		if extra["flag"] != "true" {
-			t.Errorf("extra[flag] = %q, want %q", extra["flag"], "true")
+		if sl.extra["flag"] != "true" {
+			t.Errorf("extra[flag] = %q, want %q", sl.extra["flag"], "true")
+		}
+	})
+
+	t.Run("nested objects are skipped", func(t *testing.T) {
+		sl := newScanner()
+		body, _, ok := sl.scanJSON(`{"msg":"hi","nested":{"a":1},"after":"yes"}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if body != "hi" {
+			t.Errorf("body = %q, want %q", body, "hi")
+		}
+		if _, exists := sl.extra["nested"]; exists {
+			t.Error("nested objects should be skipped")
+		}
+		if sl.extra["after"] != "yes" {
+			t.Errorf("extra[after] = %q, want %q", sl.extra["after"], "yes")
+		}
+	})
+
+	t.Run("reuses extra map across calls", func(t *testing.T) {
+		sl := newScanner()
+		sl.scanJSON(`{"msg":"first","aaa":"1"}`)
+		sl.scanJSON(`{"msg":"second","bbb":"2"}`)
+		if _, exists := sl.extra["aaa"]; exists {
+			t.Error("extra from first call should be cleared")
+		}
+		if sl.extra["bbb"] != "2" {
+			t.Errorf("extra[bbb] = %q, want %q", sl.extra["bbb"], "2")
 		}
 	})
 }
@@ -346,17 +389,17 @@ func TestProcessLineJSON(t *testing.T) {
 	if entry.Body != "processing step" {
 		t.Errorf("body = %q, want %q", entry.Body, "processing step")
 	}
-	if entry.Attributes["component"] != "provisioner" {
-		t.Errorf("attrs[component] = %q, want %q", entry.Attributes["component"], "provisioner")
+	if entry.Extra["component"] != "provisioner" {
+		t.Errorf("extra[component] = %q, want %q", entry.Extra["component"], "provisioner")
 	}
-	if entry.Attributes["cluster_id"] != "ZA8" {
-		t.Errorf("attrs[cluster_id] = %q, want %q", entry.Attributes["cluster_id"], "ZA8")
+	if entry.Extra["cluster_id"] != "ZA8" {
+		t.Errorf("extra[cluster_id] = %q, want %q", entry.Extra["cluster_id"], "ZA8")
 	}
 	if entry.Attributes["miren.sandbox"] != "sandbox/test-abc" {
 		t.Errorf("base attrs should be preserved: attrs[miren.sandbox] = %q", entry.Attributes["miren.sandbox"])
 	}
-	if _, hasTime := entry.Attributes["time"]; hasTime {
-		t.Error("time field should be stripped from attributes")
+	if _, hasTime := entry.Extra["time"]; hasTime {
+		t.Error("time field should be stripped from extra")
 	}
 }
 

--- a/controllers/sandbox/log_test.go
+++ b/controllers/sandbox/log_test.go
@@ -342,6 +342,20 @@ func TestScanJSON(t *testing.T) {
 		}
 	})
 
+	t.Run("large numbers preserve original literal", func(t *testing.T) {
+		sl := newScanner()
+		_, _, ok := sl.scanJSON(`{"msg":"hi","big":1000000,"id":9007199254740993}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if sl.extra["big"] != "1000000" {
+			t.Errorf("extra[big] = %q, want %q", sl.extra["big"], "1000000")
+		}
+		if sl.extra["id"] != "9007199254740993" {
+			t.Errorf("extra[id] = %q, want %q", sl.extra["id"], "9007199254740993")
+		}
+	})
+
 	t.Run("nested objects are skipped", func(t *testing.T) {
 		sl := newScanner()
 		body, _, ok := sl.scanJSON(`{"msg":"hi","nested":{"a":1},"after":"yes"}`)
@@ -356,6 +370,14 @@ func TestScanJSON(t *testing.T) {
 		}
 		if sl.extra["after"] != "yes" {
 			t.Errorf("extra[after] = %q, want %q", sl.extra["after"], "yes")
+		}
+	})
+
+	t.Run("rejects trailing content after JSON object", func(t *testing.T) {
+		sl := newScanner()
+		_, _, ok := sl.scanJSON(`{"msg":"ok"} trailing`)
+		if ok {
+			t.Error("expected ok=false for JSON with trailing content")
 		}
 	})
 

--- a/controllers/sandbox/log_test.go
+++ b/controllers/sandbox/log_test.go
@@ -373,6 +373,23 @@ func TestScanJSON(t *testing.T) {
 		}
 	})
 
+	t.Run("miren. prefixed keys are escaped", func(t *testing.T) {
+		sl := newScanner()
+		_, _, ok := sl.scanJSON(`{"msg":"hi","miren.sandbox":"evil","safe":"ok"}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if _, exists := sl.extra["miren.sandbox"]; exists {
+			t.Error("miren.sandbox should be escaped, not stored directly")
+		}
+		if sl.extra["-miren.sandbox"] != "evil" {
+			t.Errorf("extra[-miren.sandbox] = %q, want %q", sl.extra["-miren.sandbox"], "evil")
+		}
+		if sl.extra["safe"] != "ok" {
+			t.Errorf("extra[safe] = %q, want %q", sl.extra["safe"], "ok")
+		}
+	})
+
 	t.Run("rejects trailing content after JSON object", func(t *testing.T) {
 		sl := newScanner()
 		_, _, ok := sl.scanJSON(`{"msg":"ok"} trailing`)

--- a/controllers/sandbox/log_test.go
+++ b/controllers/sandbox/log_test.go
@@ -146,9 +146,9 @@ func TestSandboxLogs(t *testing.T) {
 		entityID := identity.NewID()
 
 		attrs := map[string]string{
-			"sandbox":   "test-sandbox",
-			"container": "test-container",
-			"version":   "v1.0.0",
+			"miren.sandbox":   "test-sandbox",
+			"miren.container": "test-container",
+			"miren.version":   "v1.0.0",
 		}
 
 		logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
@@ -246,6 +246,117 @@ func BenchmarkSandboxLogs(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		sl.Write(input)
+	}
+}
+
+func TestParseStructuredJSON(t *testing.T) {
+	t.Run("valid JSON with msg", func(t *testing.T) {
+		body, extra, stream, ok := parseStructuredJSON(`{"time":"2026-01-01T00:00:00Z","level":"INFO","msg":"hello","key":"val"}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if body != "hello" {
+			t.Errorf("body = %q, want %q", body, "hello")
+		}
+		if extra["key"] != "val" {
+			t.Errorf("extra[key] = %q, want %q", extra["key"], "val")
+		}
+		for _, skip := range []string{"time", "level", "msg"} {
+			if _, exists := extra[skip]; exists {
+				t.Errorf("field %q should be stripped", skip)
+			}
+		}
+		if stream != "" {
+			t.Errorf("stream = %q, want empty for INFO", stream)
+		}
+	})
+
+	t.Run("valid JSON with message field", func(t *testing.T) {
+		body, _, _, ok := parseStructuredJSON(`{"time":"2026-01-01T00:00:00Z","level":"INFO","message":"hello"}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if body != "hello" {
+			t.Errorf("body = %q, want %q", body, "hello")
+		}
+	})
+
+	t.Run("ERROR level sets stderr stream", func(t *testing.T) {
+		_, _, stream, ok := parseStructuredJSON(`{"level":"ERROR","msg":"fail"}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if stream != observability.Stderr {
+			t.Errorf("stream = %q, want stderr", stream)
+		}
+	})
+
+	t.Run("WARN level sets stderr stream", func(t *testing.T) {
+		_, _, stream, ok := parseStructuredJSON(`{"level":"WARN","msg":"warning"}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if stream != observability.Stderr {
+			t.Errorf("stream = %q, want stderr", stream)
+		}
+	})
+
+	t.Run("non-JSON returns false", func(t *testing.T) {
+		_, _, _, ok := parseStructuredJSON("plain text")
+		if ok {
+			t.Error("expected ok=false for plain text")
+		}
+	})
+
+	t.Run("JSON without msg field returns false", func(t *testing.T) {
+		_, _, _, ok := parseStructuredJSON(`{"key":"value","other":"data"}`)
+		if ok {
+			t.Error("expected ok=false for JSON without msg")
+		}
+	})
+
+	t.Run("non-string values are formatted", func(t *testing.T) {
+		_, extra, _, ok := parseStructuredJSON(`{"msg":"hi","count":42,"flag":true}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if extra["count"] != "42" {
+			t.Errorf("extra[count] = %q, want %q", extra["count"], "42")
+		}
+		if extra["flag"] != "true" {
+			t.Errorf("extra[flag] = %q, want %q", extra["flag"], "true")
+		}
+	})
+}
+
+func TestProcessLineJSON(t *testing.T) {
+	mock := &mockLogWriter{}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	entityID := "test-entity"
+	baseAttrs := map[string]string{"miren.sandbox": "sandbox/test-abc"}
+
+	sl := NewSandboxLogs(logger, entityID, baseAttrs, mock)
+	sl.Write([]byte(`{"time":"2026-01-01T00:00:00Z","level":"INFO","msg":"processing step","component":"provisioner","cluster_id":"ZA8"}` + "\n"))
+
+	if len(mock.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(mock.entries))
+	}
+
+	entry := mock.entries[0].log
+	if entry.Body != "processing step" {
+		t.Errorf("body = %q, want %q", entry.Body, "processing step")
+	}
+	if entry.Attributes["component"] != "provisioner" {
+		t.Errorf("attrs[component] = %q, want %q", entry.Attributes["component"], "provisioner")
+	}
+	if entry.Attributes["cluster_id"] != "ZA8" {
+		t.Errorf("attrs[cluster_id] = %q, want %q", entry.Attributes["cluster_id"], "ZA8")
+	}
+	if entry.Attributes["miren.sandbox"] != "sandbox/test-abc" {
+		t.Errorf("base attrs should be preserved: attrs[miren.sandbox] = %q", entry.Attributes["miren.sandbox"])
+	}
+	if _, hasTime := entry.Attributes["time"]; hasTime {
+		t.Error("time field should be stripped from attributes")
 	}
 }
 

--- a/controllers/sandbox/log_test.go
+++ b/controllers/sandbox/log_test.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"bytes"
+	"io"
 	"log/slog"
 	"os"
 	"testing"
@@ -246,6 +247,67 @@ func BenchmarkSandboxLogs(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		sl.Write(input)
+	}
+}
+
+// nopLogWriter discards entries so benchmarks measure the ingest/parse path
+// without the allocation noise of mockLogWriter's growing slice.
+type nopLogWriter struct{}
+
+func (nopLogWriter) WriteEntry(string, observability.LogEntry) error { return nil }
+
+// BenchmarkSandboxLogsByLineKind isolates the cost of the JSON ingest path
+// added for structured-log parsing. The plain case hits the early scanJSON
+// bail; the JSON cases exercise the json.Decoder tokenizer, which allocates a
+// decoder plus per-token strings on the hottest path in the system. Run with
+// -benchmem to see allocs/op.
+//
+// The JSON shapes are modeled on a real sample of garden/club app logs: Go
+// slog lines (string time/level) carry 1-2 fields in the common case and ~5
+// for HTTP access logs, while pino/Node lines (numeric time/level) wrap nested
+// req/res objects that exercise skipNestedJSON. In that sample only ~0.5% of
+// total volume was JSON at all, so the plain fast-path dominates in aggregate;
+// these cases measure the per-line cost an app pays when it does log structured.
+func BenchmarkSandboxLogsByLineKind(b *testing.B) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	entityID := identity.NewID()
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"plain", "a plain unstructured log line\n"},
+		// Go slog, msg+level+time plus 1-2 fields — the ~93% common case.
+		{
+			"slog_narrow",
+			`{"time":"2026-06-04T16:05:55Z","level":"INFO","msg":"Inactive player cleanup completed",` +
+				`"totalPlayers":0,"cleanedPlayers":0}` + "\n",
+		},
+		// Go slog HTTP access log — the realistic flat "wide" case (~5 fields).
+		{
+			"slog_request",
+			`{"time":"2026-06-04T14:11:05Z","level":"INFO","msg":"request","method":"GET",` +
+				`"path":"/.well-known/openid-configuration","status":200,"duration_ms":0,"remote_addr":"10.0.0.1:41436"}` + "\n",
+		},
+		// pino/Node, numeric level/time plus a nested req object — exercises skipNestedJSON.
+		{
+			"pino_nested",
+			`{"level":30,"time":1780585649689,"pid":1,"hostname":"node-1","name":"app",` +
+				`"req":{"id":27550,"method":"GET","url":"/wp-admin/install.php","query":{"step":"1"},` +
+				`"headers":{"host":"example.com","user-agent":"curl/8.0"}},"msg":"incoming request"}` + "\n",
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			sl := NewSandboxLogs(logger, entityID, map[string]string{}, nopLogWriter{})
+			input := []byte(tc.line)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				sl.Write(input)
+			}
+		})
 	}
 }
 

--- a/controllers/sandbox/log_test.go
+++ b/controllers/sandbox/log_test.go
@@ -471,6 +471,36 @@ func TestScanJSON(t *testing.T) {
 			t.Errorf("extra[bbb] = %q, want %q", sl.extra["bbb"], "2")
 		}
 	})
+
+	t.Run("unescapes string escapes and unicode", func(t *testing.T) {
+		sl := newScanner()
+		body, _, ok := sl.scanJSON(`{"msg":"line1\nline2\t\"q\"","path":"a\/b","emoji":"☃"}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if body != "line1\nline2\t\"q\"" {
+			t.Errorf("body = %q, want escapes decoded", body)
+		}
+		// \/ is a valid JSON escape that Go's strconv.Unquote rejects; gjson
+		// handles it, which is part of why we don't hand-roll unescaping.
+		if sl.extra["path"] != "a/b" {
+			t.Errorf("extra[path] = %q, want %q", sl.extra["path"], "a/b")
+		}
+		if sl.extra["emoji"] != "☃" {
+			t.Errorf("extra[emoji] = %q, want snowman (multibyte UTF-8 passthrough)", sl.extra["emoji"])
+		}
+	})
+
+	t.Run("float literal preserved", func(t *testing.T) {
+		sl := newScanner()
+		_, _, ok := sl.scanJSON(`{"msg":"hi","responseTime":0.6435079574584961}`)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if sl.extra["responseTime"] != "0.6435079574584961" {
+			t.Errorf("extra[responseTime] = %q, want exact float literal", sl.extra["responseTime"])
+		}
+	})
 }
 
 func TestProcessLineJSON(t *testing.T) {

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -310,9 +310,11 @@ func (c *SandboxController) reconcileSandboxesOnBoot(ctx context.Context) error 
 		}
 		runningCount++
 
+		shortID := entityShortID(e.Entity())
+
 		// Reattach logs to pause container
 		pauseID := pauseContainerId(sb.ID)
-		if err := c.reattachLogs(ctx, &sb, pauseID, ""); err != nil {
+		if err := c.reattachLogs(ctx, &sb, pauseID, "", shortID); err != nil {
 			c.Log.Warn("failed to reattach logs to pause container",
 				"sandbox_id", sb.ID,
 				"pause_container_id", pauseID,
@@ -336,7 +338,7 @@ func (c *SandboxController) reconcileSandboxesOnBoot(ctx context.Context) error 
 			containerID := fmt.Sprintf("%s-%s", containerPrefix(sb.ID), container.Name)
 
 			// Reattach logs for this subcontainer
-			if err := c.reattachLogs(ctx, &sb, containerID, container.Name); err != nil {
+			if err := c.reattachLogs(ctx, &sb, containerID, container.Name, shortID); err != nil {
 				c.Log.Warn("failed to reattach logs to subcontainer",
 					"sandbox_id", sb.ID,
 					"container_name", container.Name,
@@ -791,7 +793,7 @@ func (c *SandboxController) pauseContainerPID(ctx context.Context, pauseID strin
 // reattachLogs reattaches log consumers to a container's task after controller restart.
 // This is critical to prevent stdout/stderr buffers from filling up and blocking the process.
 // containerName should be empty string for the pause container, or the subcontainer name otherwise.
-func (c *SandboxController) reattachLogs(ctx context.Context, sb *compute.Sandbox, containerID string, containerName string) error {
+func (c *SandboxController) reattachLogs(ctx context.Context, sb *compute.Sandbox, containerID, containerName, shortID string) error {
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
 	container, err := c.CC.LoadContainer(ctx, containerID)
@@ -800,7 +802,7 @@ func (c *SandboxController) reattachLogs(ctx context.Context, sb *compute.Sandbo
 	}
 
 	// Create log consumer for this container
-	sl := c.logConsumer(sb, containerName)
+	sl := c.logConsumer(sb, containerName, shortID)
 
 	// Reattach to the existing task with our log consumer
 	// This drains stdout/stderr and prevents the process from blocking on writes
@@ -1013,7 +1015,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 		}
 	}()
 
-	task, err := c.BootInitialTask(ctx, co, ep, container)
+	task, err := c.BootInitialTask(ctx, co, ep, container, meta.ShortId())
 	if err != nil {
 		return err
 	}
@@ -1038,11 +1040,11 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 	}
 
 	attrs := map[string]string{
-		"sandbox": co.ID.String(),
+		"miren.sandbox": co.ID.String(),
 	}
 
 	if co.Spec.Version != "" {
-		attrs["version"] = co.Spec.Version.String()
+		attrs["miren.version"] = co.Spec.Version.String()
 	}
 
 	for _, lbl := range co.Spec.LogAttribute {
@@ -1530,23 +1532,34 @@ func (c *SandboxController) writeResolve(path string, ep *network.EndpointConfig
 // streaming (via logConsumer) and runtime lifecycle events (via
 // EmitSandboxEvent) share this so the two sources appear with the
 // same identity and metadata in the log stream.
-func sandboxLogMeta(sb *compute.Sandbox, container string) (string, map[string]string) {
+func entityShortID(e entity.AttrGetter) string {
+	if attr, ok := e.Get(entity.DBShortId); ok {
+		return attr.Value.String()
+	}
+	return ""
+}
+
+func sandboxLogMeta(sb *compute.Sandbox, container, shortID string) (string, map[string]string) {
 	le := sb.Spec.LogEntity
 	if le == "" {
 		le = sb.ID.String()
 	}
 
 	attrs := map[string]string{
-		"sandbox": sb.ID.String(),
-		"source":  strings.TrimPrefix(sb.ID.String(), "sandbox/"),
+		"miren.sandbox": sb.ID.String(),
+		"source":        strings.TrimPrefix(sb.ID.String(), "sandbox/"),
+	}
+
+	if shortID != "" {
+		attrs["miren.short_id"] = shortID
 	}
 
 	if container != "" {
-		attrs["container"] = container
+		attrs["miren.container"] = container
 	}
 
 	if sb.Spec.Version != "" {
-		attrs["version"] = sb.Spec.Version.String()
+		attrs["miren.version"] = sb.Spec.Version.String()
 	}
 
 	for _, lbl := range sb.Spec.LogAttribute {
@@ -1556,8 +1569,8 @@ func sandboxLogMeta(sb *compute.Sandbox, container string) (string, map[string]s
 	return le, attrs
 }
 
-func (c *SandboxController) logConsumer(sb *compute.Sandbox, container string) *SandboxLogs {
-	le, attrs := sandboxLogMeta(sb, container)
+func (c *SandboxController) logConsumer(sb *compute.Sandbox, container, shortID string) *SandboxLogs {
+	le, attrs := sandboxLogMeta(sb, container, shortID)
 	return NewSandboxLogs(c.Log, le, attrs, c.LogWriter)
 }
 
@@ -1566,8 +1579,8 @@ func (c *SandboxController) logConsumer(sb *compute.Sandbox, container string) *
 // stdio pipeline uses. Events go on the Stderr stream so operators see
 // them in `miren logs sandbox <id>` and can distinguish them from
 // application output via the [miren] prefix.
-func (c *SandboxController) EmitSandboxEvent(sb *compute.Sandbox, line string) {
-	le, attrs := sandboxLogMeta(sb, "")
+func (c *SandboxController) EmitSandboxEvent(sb *compute.Sandbox, shortID, line string) {
+	le, attrs := sandboxLogMeta(sb, "", shortID)
 	err := c.LogWriter.WriteEntry(le, observability.LogEntry{
 		Timestamp:  time.Now(),
 		Stream:     observability.Stderr,
@@ -1585,10 +1598,11 @@ func (c *SandboxController) BootInitialTask(
 	sb *compute.Sandbox,
 	ep *network.EndpointConfig,
 	container containerd.Container,
+	shortID string,
 ) (containerd.Task, error) {
 	c.Log.Info("booting sandbox task")
 
-	sl := c.logConsumer(sb, "")
+	sl := c.logConsumer(sb, "", shortID)
 
 	task, err := container.NewTask(ctx, cio.NewCreator(
 		cio.WithStreams(nil, sl, sl.Stderr())))
@@ -1758,7 +1772,7 @@ func (c *SandboxController) BootContainers(
 
 		cgroups[container.Name] = spec.Linux.CgroupsPath
 
-		sl := c.logConsumer(sb, container.Name)
+		sl := c.logConsumer(sb, container.Name, meta.ShortId())
 
 		// Build cio options based on container spec
 		var cioOpts []cio.Opt

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "018bfd335f21e5785601cee6c8d93de0cc00f1e2317bb8af5d0a55dc01c0fccb",
+		"sandbox.go":  "b5b6ef50b94fddc50dd583f9df74dde21e81a5b8ff51c77b4d8c42f96ec72c19",
 		"volume.go":   "292dbc050cd94901ab704a23605f5537c944787c9e06077a3fc004f40e9c0b6c",
 		"firewall.go": "802cb47113ab3c3710451ded4c203922d750d3ab42124d92d31f7c62acc2e73c",
 	}

--- a/controllers/sandbox/sandbox_ops.go
+++ b/controllers/sandbox/sandbox_ops.go
@@ -112,9 +112,9 @@ func (o *sandboxOps) CleanupContainer(ctx context.Context, cont containerd.Conta
 	o.ctrl.CleanupContainer(ctx, cont)
 }
 
-func (o *sandboxOps) BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container) (containerd.Task, error) {
+func (o *sandboxOps) BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container, shortID string) (containerd.Task, error) {
 	ctx = namespaces.WithNamespace(ctx, o.ctrl.Namespace)
-	return o.ctrl.BootInitialTask(ctx, sb, ep, container)
+	return o.ctrl.BootInitialTask(ctx, sb, ep, container, shortID)
 }
 
 func (o *sandboxOps) ConfigureVolumes(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) (map[string]string, error) {
@@ -156,6 +156,6 @@ func (o *sandboxOps) UpdateServices(ctx context.Context, co *compute.Sandbox, me
 	return o.ctrl.UpdateServices(ctx, co, meta, ep)
 }
 
-func (o *sandboxOps) LogSandboxEvent(sb *compute.Sandbox, line string) {
-	o.ctrl.EmitSandboxEvent(sb, line)
+func (o *sandboxOps) LogSandboxEvent(sb *compute.Sandbox, shortID, line string) {
+	o.ctrl.EmitSandboxEvent(sb, shortID, line)
 }

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -1225,7 +1225,7 @@ func TestSandbox(t *testing.T) {
 
 		// Now test the reattach function directly by calling it
 		// This simulates what happens during controller restart
-		err = co1.reattachLogs(ctx, &tco, containerID, "logger")
+		err = co1.reattachLogs(ctx, &tco, containerID, "logger", "")
 		r.NoError(err, "should be able to reattach logs to running container")
 
 		// Verify task stays running after reattach and logs are collected.

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/gjson v1.18.0
 	github.com/tonistiigi/fsutil v0.0.0-20250113203817-b14e27f4135a
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240710180619-ddb21b71c0b4
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
@@ -150,7 +151,6 @@ require (
 	github.com/magefile/mage v1.17.0 // indirect
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20250424160509-463d218d4745 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/valllabh/ocsf-schema-golang v1.0.3 // indirect

--- a/observability/batch_log_writer.go
+++ b/observability/batch_log_writer.go
@@ -65,6 +65,12 @@ func (b *BatchLogWriter) WriteEntry(entity string, le LogEntry) error {
 		}
 		logData[k] = v
 	}
+	for k, v := range le.Extra {
+		if isReservedLogField(k) {
+			continue
+		}
+		logData[k] = v
+	}
 
 	jsonData, err := json.Marshal(logData)
 	if err != nil {

--- a/observability/integration_test.go
+++ b/observability/integration_test.go
@@ -83,24 +83,24 @@ func TestVictoriaLogsIntegration(t *testing.T) {
 				body:   "Application started",
 				stream: observability.Stdout,
 				attributes: map[string]string{
-					"sandbox": sandboxID,
-					"phase":   "startup",
+					"miren.sandbox": sandboxID,
+					"phase":         "startup",
 				},
 			},
 			{
 				body:   "Warning: deprecated API used",
 				stream: observability.Stderr,
 				attributes: map[string]string{
-					"sandbox": sandboxID,
-					"phase":   "runtime",
+					"miren.sandbox": sandboxID,
+					"phase":         "runtime",
 				},
 			},
 			{
 				body:   "User action: button clicked",
 				stream: observability.UserOOB,
 				attributes: map[string]string{
-					"sandbox": sandboxID,
-					"user_id": "test-user",
+					"miren.sandbox": sandboxID,
+					"user_id":       "test-user",
 				},
 			},
 		}
@@ -141,7 +141,7 @@ func TestVictoriaLogsIntegration(t *testing.T) {
 		r.Len(sandboxEntries, 3, "should have 3 logs for sandbox")
 
 		for _, entry := range sandboxEntries {
-			r.Equal(sandboxID, entry.Attributes["sandbox"], "should have correct sandbox ID")
+			r.Equal(sandboxID, entry.Attributes["miren.sandbox"], "should have correct sandbox ID")
 		}
 	})
 

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -47,6 +47,7 @@ type LogEntry struct {
 	Stream     LogStream
 	TraceID    string
 	Attributes map[string]string
+	Extra      map[string]string
 	Body       string
 }
 
@@ -100,6 +101,12 @@ func (l *PersistentLogWriter) WriteEntry(entity string, le LogEntry) error {
 	// Add attributes as top-level fields, but never overwrite reserved fields
 	// that control log routing and identity.
 	for k, v := range le.Attributes {
+		if isReservedLogField(k) {
+			continue
+		}
+		logData[k] = v
+	}
+	for k, v := range le.Extra {
 		if isReservedLogField(k) {
 			continue
 		}

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -280,8 +280,10 @@ func (l *LogReader) ReadBySandbox(ctx context.Context, sandboxID string, opts ..
 		limit = DefaultLogReadLimit
 	}
 
-	// Build LogsQL query filtering by sandbox attribute
-	query := `sandbox:` + logsQLQuote(sandboxID)
+	// Build LogsQL query filtering by sandbox attribute.
+	// Query both old and new field names for backwards compatibility.
+	quoted := logsQLQuote(sandboxID)
+	query := `(sandbox:` + quoted + ` OR miren.sandbox:` + quoted + `)`
 
 	// Victoria Logs often requires a time range
 	startTime := o.From
@@ -303,7 +305,8 @@ type LogTarget struct {
 func (t LogTarget) Query() string {
 	var base string
 	if t.SandboxID != "" {
-		base = `sandbox:` + logsQLQuote(t.SandboxID)
+		quoted := logsQLQuote(t.SandboxID)
+		base = `(sandbox:` + quoted + ` OR miren.sandbox:` + quoted + `)`
 	} else {
 		base = `entity:` + logsQLQuote(t.EntityID)
 	}

--- a/servers/logs/logs_test.go
+++ b/servers/logs/logs_test.go
@@ -728,12 +728,15 @@ func TestLogTarget_QueryWithoutFilter(t *testing.T) {
 	query := target.Query()
 	require.Contains(t, query, "sandbox:")
 
-	// With a filter, the query should be longer
+	// With a filter, the query should include both sandbox selector and filter
 	targetWithFilter := observability.LogTarget{
 		SandboxID: "sandbox/test",
 		Filter:    "error",
 	}
-	require.Contains(t, targetWithFilter.Query(), "error")
+	filteredQuery := targetWithFilter.Query()
+	require.Contains(t, filteredQuery, "sandbox:")
+	require.Contains(t, filteredQuery, "sandbox/test")
+	require.Contains(t, filteredQuery, "error")
 }
 
 func TestStreamLogChunks_InvalidFilterRegex(t *testing.T) {

--- a/servers/logs/logs_test.go
+++ b/servers/logs/logs_test.go
@@ -727,7 +727,13 @@ func TestLogTarget_QueryWithoutFilter(t *testing.T) {
 
 	query := target.Query()
 	require.Contains(t, query, "sandbox:")
-	require.NotContains(t, query, " ") // No filter appended
+
+	// With a filter, the query should be longer
+	targetWithFilter := observability.LogTarget{
+		SandboxID: "sandbox/test",
+		Filter:    "error",
+	}
+	require.Contains(t, targetWithFilter.Query(), "error")
 }
 
 func TestStreamLogChunks_InvalidFilterRegex(t *testing.T) {


### PR DESCRIPTION
## Summary
- Parse structured JSON log lines at sandbox log ingress: extract `msg` as body, strip `time`/`level`, promote remaining fields to first-class log attributes, preserve original as `user.orig_msg`
- Namespace internal log attributes under `miren.*` prefix (`miren.sandbox`, `miren.service`, `miren.stage`, `miren.container`, `miren.version`, `miren.short_id`)
- Display the real entity short ID in log brackets (e.g. `[CBZ]` instead of `[clu…jt1uPwog]`)
- Hide `miren.*` attributes from CLI text output — only user/app attributes are shown
- Backwards-compatible queries: sandbox and service filters match both old and new field names

Before:
```
S 2026-05-30 20:36:20: [clu…jt1uPwog] {"time":"...","level":"INFO","msg":"processing step","component":"provisioner"} container=app sandbox=sandbox/... service=web stage=app-run version=...
```

After:
```
S 2026-05-30 20:36:20: [CBZ] processing step component=provisioner cluster_id=ZA8 saga=cluster_teardown
```

Closes MIR-1189

## Test plan
- [x] Unit tests for JSON log parsing at ingress (`TestParseStructuredJSON`, `TestProcessLineJSON`)
- [x] Unit tests for CLI display formatting (`TestPrintLogEntry`, `TestFormatAttributes`)
- [x] Unit tests for backwards-compatible filter construction (`TestBuildFilterWithService`)
- [ ] Manual test with `miren logs` against a running app to verify output format
- [ ] Verify `miren logs sandbox <id>` works for both old and new log entries
- [ ] Verify `miren logs --service <name>` works for both old and new log entries