### PR TITLE
Fix cluster not reconnecting to recreated POP VMs

### DIFF
--- a/pkg/globalrouter/pop.go
+++ b/pkg/globalrouter/pop.go
@@ -94,6 +94,7 @@ func (m *POPManager) HandleConnectionRequest(ctx context.Context, req Connection
 //  3. Serve incoming HTTP/3 requests on connection 2
 func (m *POPManager) servePOP(ctx context.Context, pc *popConnection, cr ConnectionRequest) {
 	defer func() {
+		pc.cancel()
 		m.mu.Lock()
 		if m.conns[pc.popXID] == pc {
 			delete(m.conns, pc.popXID)

--- a/pkg/globalrouter/pop.go
+++ b/pkg/globalrouter/pop.go
@@ -58,11 +58,12 @@ func NewPOPManager(clusterXID string, ingress *httpingress.Server, log *slog.Log
 // exist.
 func (m *POPManager) HandleConnectionRequest(ctx context.Context, req ConnectionRequest) error {
 	m.mu.Lock()
-	_, exists := m.conns[req.POPXID]
-	if exists {
-		m.mu.Unlock()
-		m.log.Debug("POP connection already exists", "pop_xid", req.POPXID)
-		return nil
+	existing, replacing := m.conns[req.POPXID]
+	if replacing {
+		// Cloud sent a new connection request for a POPXID we already
+		// have. The POP was likely recreated (new VM, same hostname).
+		// Cancel the old connection so servePOP exits, then replace it.
+		existing.cancel()
 	}
 
 	connCtx, cancel := context.WithCancel(context.Background())
@@ -72,6 +73,10 @@ func (m *POPManager) HandleConnectionRequest(ctx context.Context, req Connection
 	}
 	m.conns[req.POPXID] = pc
 	m.mu.Unlock()
+
+	if replacing {
+		m.log.Info("replacing stale POP connection", "pop_xid", req.POPXID)
+	}
 
 	m.log.Info("establishing connection to POP",
 		"pop_xid", req.POPXID,
@@ -90,7 +95,9 @@ func (m *POPManager) HandleConnectionRequest(ctx context.Context, req Connection
 func (m *POPManager) servePOP(ctx context.Context, pc *popConnection, cr ConnectionRequest) {
 	defer func() {
 		m.mu.Lock()
-		delete(m.conns, pc.popXID)
+		if m.conns[pc.popXID] == pc {
+			delete(m.conns, pc.popXID)
+		}
 		m.mu.Unlock()
 		m.log.Info("POP connection closed", "pop_xid", pc.popXID)
 	}()

--- a/pkg/globalrouter/pop.go
+++ b/pkg/globalrouter/pop.go
@@ -274,6 +274,15 @@ func (m *POPManager) servePOP(ctx context.Context, pc *popConnection, cr Connect
 		}),
 	}
 
+	// Close the data-plane connection when our context is cancelled
+	// (e.g., this POP entry is replaced by a new connection request).
+	// Without this, ServeQUICConn blocks until the peer drops the
+	// connection, leaking the old goroutine.
+	go func() {
+		<-ctx.Done()
+		dataConn.CloseWithError(0, "connection replaced")
+	}()
+
 	if err := h3srv.ServeQUICConn(dataConn); err != nil && ctx.Err() == nil {
 		m.log.Error("POP data plane server error",
 			"pop_xid", pc.popXID, "error", err)

--- a/pkg/globalrouter/pop_test.go
+++ b/pkg/globalrouter/pop_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"testing"
+	"time"
 )
 
 func TestPOPManagerHandleConnectionRequest(t *testing.T) {
@@ -27,7 +28,7 @@ func TestPOPManagerHandleConnectionRequest(t *testing.T) {
 		t.Errorf("expected [pop-1], got %v", pops)
 	}
 
-	// Duplicate request should be a no-op
+	// Duplicate request replaces the existing connection
 	if err := pm.HandleConnectionRequest(t.Context(), req); err != nil {
 		t.Fatalf("duplicate HandleConnectionRequest: %v", err)
 	}
@@ -79,6 +80,62 @@ func TestPOPManagerClose(t *testing.T) {
 	pops := pm.ConnectedPOPs()
 	if len(pops) != 0 {
 		t.Errorf("expected 0 POPs after Close, got %d", len(pops))
+	}
+}
+
+func TestPOPManagerReplaceStaleConnection(t *testing.T) {
+	pm := NewPOPManager("test-cluster", nil, slog.Default())
+	defer pm.Close()
+
+	req1 := ConnectionRequest{
+		POPXID:     "pop-1",
+		POPAddress: "https://pop1.example.com:443",
+		Hostname:   "myapp.example.com",
+		RequestID:  "req-1",
+	}
+
+	if err := pm.HandleConnectionRequest(t.Context(), req1); err != nil {
+		t.Fatalf("first HandleConnectionRequest: %v", err)
+	}
+
+	pops := pm.ConnectedPOPs()
+	if len(pops) != 1 || pops[0] != "pop-1" {
+		t.Fatalf("expected [pop-1], got %v", pops)
+	}
+
+	// Send a second connection request for the same POPXID (simulates
+	// a POP VM recreate). The old entry should be replaced, not ignored.
+	req2 := ConnectionRequest{
+		POPXID:       "pop-1",
+		POPAddress:   "https://pop1.example.com:443",
+		Hostname:     "myapp.example.com",
+		RequestID:    "req-2",
+		ConnectToken: "new-token",
+	}
+
+	if err := pm.HandleConnectionRequest(t.Context(), req2); err != nil {
+		t.Fatalf("replacement HandleConnectionRequest: %v", err)
+	}
+
+	// Immediately after replacement, should still have exactly one entry.
+	pops = pm.ConnectedPOPs()
+	if len(pops) != 1 || pops[0] != "pop-1" {
+		t.Errorf("expected [pop-1] after replacement, got %v", pops)
+	}
+
+	// Wait for both servePOP goroutines to finish (they fail on DNS
+	// resolution of the fake address). The guarded defer in the old
+	// goroutine must not delete the replacement entry — only the new
+	// goroutine's defer should clean up its own entry.
+	time.Sleep(200 * time.Millisecond)
+
+	// Both goroutines exited: old one was cancelled, new one failed DNS.
+	// Map should be empty since the new goroutine legitimately cleaned
+	// up after itself. The key invariant is that we never see 2 entries
+	// and the replacement was served (not short-circuited).
+	pops = pm.ConnectedPOPs()
+	if len(pops) > 1 {
+		t.Errorf("expected at most 1 POP after goroutine cleanup, got %v", pops)
 	}
 }
 

--- a/pkg/globalrouter/pop_test.go
+++ b/pkg/globalrouter/pop_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"log/slog"
 	"testing"
-	"time"
 )
 
 func TestPOPManagerHandleConnectionRequest(t *testing.T) {
@@ -87,55 +86,72 @@ func TestPOPManagerReplaceStaleConnection(t *testing.T) {
 	pm := NewPOPManager("test-cluster", nil, slog.Default())
 	defer pm.Close()
 
-	req1 := ConnectionRequest{
+	req := ConnectionRequest{
 		POPXID:     "pop-1",
 		POPAddress: "https://pop1.example.com:443",
 		Hostname:   "myapp.example.com",
 		RequestID:  "req-1",
 	}
 
-	if err := pm.HandleConnectionRequest(t.Context(), req1); err != nil {
-		t.Fatalf("first HandleConnectionRequest: %v", err)
+	pm.HandleConnectionRequest(t.Context(), req)
+
+	pm.mu.Lock()
+	firstPC := pm.conns["pop-1"]
+	pm.mu.Unlock()
+
+	if firstPC == nil {
+		t.Fatal("first connection not created")
+	}
+
+	// Second request for the same POPXID (simulates POP VM recreate).
+	req.RequestID = "req-2"
+	req.ConnectToken = "new-token"
+	pm.HandleConnectionRequest(t.Context(), req)
+
+	pm.mu.Lock()
+	secondPC := pm.conns["pop-1"]
+	pm.mu.Unlock()
+
+	if secondPC == nil {
+		t.Fatal("replacement connection not created")
+	}
+	if firstPC == secondPC {
+		t.Fatal("HandleConnectionRequest did not replace the existing connection")
 	}
 
 	pops := pm.ConnectedPOPs()
 	if len(pops) != 1 || pops[0] != "pop-1" {
-		t.Fatalf("expected [pop-1], got %v", pops)
+		t.Errorf("expected [pop-1], got %v", pops)
 	}
+}
 
-	// Send a second connection request for the same POPXID (simulates
-	// a POP VM recreate). The old entry should be replaced, not ignored.
-	req2 := ConnectionRequest{
-		POPXID:       "pop-1",
-		POPAddress:   "https://pop1.example.com:443",
-		Hostname:     "myapp.example.com",
-		RequestID:    "req-2",
-		ConnectToken: "new-token",
+// Verify that a replaced servePOP goroutine's deferred cleanup does not
+// delete the replacement entry from the map.
+func TestServePOPCleanupSkipsReplacedEntry(t *testing.T) {
+	pm := NewPOPManager("test-cluster", nil, slog.Default())
+	defer pm.Close()
+
+	oldPC := &popConnection{popXID: "pop-1", cancel: func() {}}
+	newPC := &popConnection{popXID: "pop-1", cancel: func() {}}
+
+	pm.mu.Lock()
+	pm.conns["pop-1"] = newPC
+	pm.mu.Unlock()
+
+	// Simulate the old servePOP goroutine's deferred cleanup — this is
+	// the same guard that runs in servePOP's defer block.
+	pm.mu.Lock()
+	if pm.conns[oldPC.popXID] == oldPC {
+		delete(pm.conns, oldPC.popXID)
 	}
+	pm.mu.Unlock()
 
-	if err := pm.HandleConnectionRequest(t.Context(), req2); err != nil {
-		t.Fatalf("replacement HandleConnectionRequest: %v", err)
-	}
+	pm.mu.Lock()
+	survivor := pm.conns["pop-1"]
+	pm.mu.Unlock()
 
-	// Immediately after replacement, should still have exactly one entry.
-	pops = pm.ConnectedPOPs()
-	if len(pops) != 1 || pops[0] != "pop-1" {
-		t.Errorf("expected [pop-1] after replacement, got %v", pops)
-	}
-
-	// Wait for both servePOP goroutines to finish (they fail on DNS
-	// resolution of the fake address). The guarded defer in the old
-	// goroutine must not delete the replacement entry — only the new
-	// goroutine's defer should clean up its own entry.
-	time.Sleep(200 * time.Millisecond)
-
-	// Both goroutines exited: old one was cancelled, new one failed DNS.
-	// Map should be empty since the new goroutine legitimately cleaned
-	// up after itself. The key invariant is that we never see 2 entries
-	// and the replacement was served (not short-circuited).
-	pops = pm.ConnectedPOPs()
-	if len(pops) > 1 {
-		t.Errorf("expected at most 1 POP after goroutine cleanup, got %v", pops)
+	if survivor != newPC {
+		t.Fatal("old goroutine's cleanup deleted the replacement entry")
 	}
 }
 


### PR DESCRIPTION
## Summary

- When a POP VM is recreated (same POPXID, new instance), `HandleConnectionRequest` was short-circuiting on the stale map entry without verifying liveness — the cluster sat on the dead QUIC connection for minutes, ignoring all `connection.request` messages from cloud
- Now, a duplicate connection request cancels the old entry and establishes a fresh connection. The `servePOP` defer is guarded (`m.conns[pc.popXID] == pc`) so a replaced goroutine can't delete the new entry

Fixes MIR-1133

## Test plan

- [x] `TestPOPManagerReplaceStaleConnection` — verifies a second request for the same POPXID replaces the entry rather than being ignored
- [x] Existing tests pass (11/11), lint clean
- [ ] Deploy to staging and recreate a POP VM (`terraform taint` + `apply`) to confirm cluster reconnects immediately