### PR TITLE
Build robust revision-resume abstraction around WatchIndex (MIR-1200)

### DIFF
--- a/api/entityserver/entityserver_v1alpha/constants.go
+++ b/api/entityserver/entityserver_v1alpha/constants.go
@@ -10,6 +10,14 @@ const (
 	EntityOperationUpdate EntityOperation = 2
 	// EntityOperationDelete indicates an entity was deleted
 	EntityOperationDelete EntityOperation = 3
+	// EntityOperationProgress is a watch watermark carrying the latest observed
+	// revision with no entity payload. It lets a client advance its resume cursor
+	// during idle periods (etcd progress notifications).
+	EntityOperationProgress EntityOperation = 4
+	// EntityOperationCompacted signals that the requested watch start revision has
+	// been compacted away. The client must re-list to obtain a fresh snapshot and
+	// resume from the new revision. Revision carries the compaction revision.
+	EntityOperationCompacted EntityOperation = 5
 )
 
 // OperationType returns the typed operation for this EntityOp
@@ -30,4 +38,14 @@ func (v *EntityOp) IsUpdate() bool {
 // IsDelete returns true if this is a delete operation
 func (v *EntityOp) IsDelete() bool {
 	return v.Operation() == int64(EntityOperationDelete)
+}
+
+// IsProgress returns true if this is a watch progress watermark
+func (v *EntityOp) IsProgress() bool {
+	return v.Operation() == int64(EntityOperationProgress)
+}
+
+// IsCompacted returns true if this signals the watch start revision was compacted
+func (v *EntityOp) IsCompacted() bool {
+	return v.Operation() == int64(EntityOperationCompacted)
 }

--- a/api/entityserver/entityserver_v1alpha/rpc.gen.go
+++ b/api/entityserver/entityserver_v1alpha/rpc.gen.go
@@ -311,6 +311,7 @@ type entityOpData struct {
 	Previous  *int64  `cbor:"1,keyasint,omitempty" json:"previous,omitempty"`
 	Operation *int64  `cbor:"2,keyasint,omitempty" json:"operation,omitempty"`
 	EntityId  *string `cbor:"3,keyasint,omitempty" json:"entity_id,omitempty"`
+	Revision  *int64  `cbor:"4,keyasint,omitempty" json:"revision,omitempty"`
 }
 
 type EntityOp struct {
@@ -372,6 +373,21 @@ func (v *EntityOp) EntityId() string {
 
 func (v *EntityOp) SetEntityId(entity_id string) {
 	v.data.EntityId = &entity_id
+}
+
+func (v *EntityOp) HasRevision() bool {
+	return v.data.Revision != nil
+}
+
+func (v *EntityOp) Revision() int64 {
+	if v.data.Revision == nil {
+		return 0
+	}
+	return *v.data.Revision
+}
+
+func (v *EntityOp) SetRevision(revision int64) {
+	v.data.Revision = &revision
 }
 
 func (v *EntityOp) MarshalCBOR() ([]byte, error) {
@@ -1198,8 +1214,9 @@ func (v *EntityAccessDeleteResults) UnmarshalJSON(data []byte) error {
 }
 
 type entityAccessWatchIndexArgsData struct {
-	Index  *entity.Attr    `cbor:"0,keyasint,omitempty" json:"index,omitempty"`
-	Values *rpc.Capability `cbor:"1,keyasint,omitempty" json:"values,omitempty"`
+	Index        *entity.Attr    `cbor:"0,keyasint,omitempty" json:"index,omitempty"`
+	FromRevision *int64          `cbor:"1,keyasint,omitempty" json:"from_revision,omitempty"`
+	Values       *rpc.Capability `cbor:"2,keyasint,omitempty" json:"values,omitempty"`
 }
 
 type EntityAccessWatchIndexArgs struct {
@@ -1213,6 +1230,17 @@ func (v *EntityAccessWatchIndexArgs) HasIndex() bool {
 
 func (v *EntityAccessWatchIndexArgs) Index() entity.Attr {
 	return *v.data.Index
+}
+
+func (v *EntityAccessWatchIndexArgs) HasFromRevision() bool {
+	return v.data.FromRevision != nil
+}
+
+func (v *EntityAccessWatchIndexArgs) FromRevision() int64 {
+	if v.data.FromRevision == nil {
+		return 0
+	}
+	return *v.data.FromRevision
 }
 
 func (v *EntityAccessWatchIndexArgs) HasValues() bool {
@@ -1370,7 +1398,8 @@ func (v *EntityAccessListArgs) UnmarshalJSON(data []byte) error {
 }
 
 type entityAccessListResultsData struct {
-	Values *[]*Entity `cbor:"0,keyasint,omitempty" json:"values,omitempty"`
+	Values   *[]*Entity `cbor:"0,keyasint,omitempty" json:"values,omitempty"`
+	Revision *int64     `cbor:"1,keyasint,omitempty" json:"revision,omitempty"`
 }
 
 type EntityAccessListResults struct {
@@ -1381,6 +1410,10 @@ type EntityAccessListResults struct {
 func (v *EntityAccessListResults) SetValues(values []*Entity) {
 	x := slices.Clone(values)
 	v.data.Values = &x
+}
+
+func (v *EntityAccessListResults) SetRevision(revision int64) {
+	v.data.Revision = &revision
 }
 
 func (v *EntityAccessListResults) MarshalCBOR() ([]byte, error) {
@@ -3152,10 +3185,11 @@ type EntityAccessClientWatchIndexResults struct {
 	data   entityAccessWatchIndexResultsData
 }
 
-func (v EntityAccessClient) WatchIndex(ctx context.Context, index entity.Attr, values stream.SendStream[*EntityOp]) (*EntityAccessClientWatchIndexResults, error) {
+func (v EntityAccessClient) WatchIndex(ctx context.Context, index entity.Attr, from_revision int64, values stream.SendStream[*EntityOp]) (*EntityAccessClientWatchIndexResults, error) {
 	args := EntityAccessWatchIndexArgs{}
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	args.data.Index = &index
+	args.data.FromRevision = &from_revision
 	{
 		ic, oid, c := v.NewInlineCapability(stream.AdaptSendStream[*EntityOp](values), values)
 		args.data.Values = c
@@ -3211,6 +3245,17 @@ func (v *EntityAccessClientListResults) Values() []*Entity {
 		return nil
 	}
 	return *v.data.Values
+}
+
+func (v *EntityAccessClientListResults) HasRevision() bool {
+	return v.data.Revision != nil
+}
+
+func (v *EntityAccessClientListResults) Revision() int64 {
+	if v.data.Revision == nil {
+		return 0
+	}
+	return *v.data.Revision
 }
 
 func (v EntityAccessClient) List(ctx context.Context, index entity.Attr) (*EntityAccessClientListResults, error) {

--- a/api/entityserver/rpc.yml
+++ b/api/entityserver/rpc.yml
@@ -78,6 +78,9 @@ types:
       - name: entity_id
         type: string
         index: 3
+      - name: revision
+        type: int64
+        index: 4
 
   - type: ParsedFile
     fields:
@@ -196,6 +199,8 @@ interfaces:
         parameters:
           - name: index
             type: entity.Attr
+          - name: from_revision
+            type: int64
           - name: values
             type: stream.SendStream[*EntityOp]
 
@@ -214,6 +219,8 @@ interfaces:
           - name: values
             type: list
             element: Entity
+          - name: revision
+            type: int64
 
       - name: makeAttr
         parameters:

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -1156,7 +1156,7 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 
 		a.log.Info("starting sandbox discovery watch")
 
-		_, err := a.eac.WatchIndex(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox), stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
+		_, err := a.eac.WatchIndex(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox), 0, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
 			if op.IsDelete() {
 				// Entity was deleted - clean up from tracking
 				// The ID should still be available in the operation even without the entity
@@ -1924,7 +1924,7 @@ func (a *localActivator) watchPools(ctx context.Context) {
 
 		a.log.Info("starting pool watch")
 
-		_, err := a.eac.WatchIndex(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool), stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
+		_, err := a.eac.WatchIndex(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool), 0, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
 			if op.IsDelete() {
 				// Pool was deleted - clean up all related cache entries
 				if op.HasEntityId() {

--- a/components/ipalloc/ipalloc.go
+++ b/components/ipalloc/ipalloc.go
@@ -16,8 +16,7 @@ import (
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/network/network_v1alpha"
 	"miren.dev/runtime/pkg/entity"
-	"miren.dev/runtime/pkg/multierror"
-	"miren.dev/runtime/pkg/rpc/stream"
+	"miren.dev/runtime/pkg/entity/indexwatch"
 )
 
 type Allocator struct {
@@ -36,32 +35,29 @@ func NewAllocator(log *slog.Logger, subnets []netip.Prefix) *Allocator {
 	}
 }
 
-func (a *Allocator) Refresh(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient) error {
-	res, err := eac.List(ctx, entity.Ref(entity.EntityKind, network_v1alpha.KindService))
-	if err != nil {
-		return err
-	}
-
+// reconcileSnapshot processes a full snapshot of the Service index. It first
+// seeds the allocation table from services that already have IPs (so we never
+// hand out an address that is already in use), then assigns IPs to any service
+// that still lacks them.
+func (a *Allocator) reconcileSnapshot(ctx context.Context, entities []*entity.Entity, eac *entityserver_v1alpha.EntityAccessClient) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	var rerr error
-
-	for _, ent := range res.Values() {
+	for _, ent := range entities {
 		var serv network_v1alpha.Service
-		serv.Decode(ent.Entity())
+		serv.Decode(ent)
 
 		for _, ip := range serv.Ip {
-			addr, err := netip.ParseAddr(ip)
-			if err != nil {
-				rerr = multierror.Append(rerr, err)
-			} else {
-				a.allocations[addr] = ent.Id()
+			if addr, err := netip.ParseAddr(ip); err == nil {
+				a.allocations[addr] = string(ent.Id())
 			}
 		}
 	}
+	a.mu.Unlock()
 
-	return nil
+	for _, ent := range entities {
+		if err := a.assignService(ctx, ent, eac); err != nil {
+			a.log.Error("failed to assign service during sync", "error", err, "service", ent.Id())
+		}
+	}
 }
 
 func (a *Allocator) Allocate(ctx context.Context, id entity.Id) ([]netip.Addr, error) {
@@ -161,26 +157,38 @@ func (a *Allocator) Watch(ctx context.Context, eac *entityserver_v1alpha.EntityA
 
 	index := entity.Ref(entity.EntityKind, network_v1alpha.KindService)
 
-	_, err := eac.WatchIndex(ctx, index, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
-		if op == nil {
-			return nil
-		}
+	// indexwatch.Watcher owns reconnect-with-backoff and resumes the watch from
+	// its revision cursor, so services created or modified while the watch was
+	// down are never missed — replacing the previous one-shot watch that silently
+	// stopped allocating IPs if the watch ever ended.
+	w := indexwatch.New(eac, index, indexwatch.Options{Logger: a.log})
+	if err := w.Start(ctx); err != nil {
+		return err
+	}
+	defer w.Stop()
 
-		switch op.OperationType() {
-		case entityserver_v1alpha.EntityOperationCreate, entityserver_v1alpha.EntityOperationUpdate:
-			// fine
-		default:
-			return nil
-		}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-w.Updates():
+			if !ok {
+				return nil
+			}
 
-		err := a.assignService(ctx, op.Entity().Entity(), eac)
-		if err != nil {
-			a.log.Error("failed to assign sandbox", "error", err, "sandbox", op.Entity().Id())
+			switch ev.Type {
+			case indexwatch.EventSync:
+				a.reconcileSnapshot(ctx, ev.Entities, eac)
+			case indexwatch.EventAdded, indexwatch.EventUpdated:
+				if ev.Entity == nil {
+					continue
+				}
+				if err := a.assignService(ctx, ev.Entity, eac); err != nil {
+					a.log.Error("failed to assign service", "error", err, "service", ev.Id)
+				}
+			}
 		}
-
-		return nil
-	}))
-	return err
+	}
 }
 
 type service struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -159,7 +159,7 @@ func (c *ReconcileController) Start(top context.Context) error {
 				c.Log.Debug("Attempting to establish watch connection", "index", c.index.ID, "value", c.index.Value)
 			}
 
-			_, err := c.esc.WatchIndex(ctx, c.index, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
+			_, err := c.esc.WatchIndex(ctx, c.index, 0, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
 				// Log successful reconnection after retry
 				if retryCount > 0 {
 					c.Log.Info("Watch successfully reconnected", "index", c.index.ID, "value", c.index.Value, "afterAttempts", retryCount)

--- a/pkg/controller/interfaces.go
+++ b/pkg/controller/interfaces.go
@@ -17,6 +17,7 @@ type EntityAccessClient interface {
 	List(ctx context.Context, index entity.Attr) (*entityserver_v1alpha.EntityAccessClientListResults, error)
 
 	// WatchIndex watches for changes to entities matching the given index
-	// and sends updates through the provided sender
-	WatchIndex(ctx context.Context, index entity.Attr, sender stream.SendStream[*entityserver_v1alpha.EntityOp]) error
+	// and sends updates through the provided sender. fromRevision starts the
+	// watch at a specific etcd revision (0 means "from now").
+	WatchIndex(ctx context.Context, index entity.Attr, fromRevision int64, sender stream.SendStream[*entityserver_v1alpha.EntityOp]) error
 }

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -451,7 +451,7 @@ func (s *Server) watchSandboxes(ctx context.Context) {
 		}
 
 		index := entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox)
-		_, err := s.entityClient.WatchIndex(ctx, index, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
+		_, err := s.entityClient.WatchIndex(ctx, index, 0, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
 			if op == nil {
 				return nil
 			}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -14,7 +14,7 @@ import (
 	"github.com/miekg/dns"
 	"miren.dev/runtime/api/compute"
 	"miren.dev/runtime/pkg/entity"
-	"miren.dev/runtime/pkg/rpc/stream"
+	"miren.dev/runtime/pkg/entity/indexwatch"
 
 	compute_v1alpha "miren.dev/runtime/api/compute/compute_v1alpha"
 	core_v1alpha "miren.dev/runtime/api/core/core_v1alpha"
@@ -37,6 +37,7 @@ type Server struct {
 	watchCtx    context.Context
 	watchCancel context.CancelFunc
 	watchWg     sync.WaitGroup
+	watcher     *indexwatch.Watcher
 }
 
 // New creates a new DNS forwarding server
@@ -423,70 +424,89 @@ func (s *Server) handleAppMirenQuery(w dns.ResponseWriter, r *dns.Msg, qname str
 	w.WriteMsg(response)
 }
 
-// Watch starts watching sandbox entities and maintains in-memory DNS mappings
+// Watch starts watching sandbox entities and maintains in-memory DNS mappings.
+// It processes the initial snapshot synchronously so DNS is warm before
+// returning, then consumes live changes in the background.
 func (s *Server) Watch(ctx context.Context) error {
-	// First, recover existing sandboxes to populate initial state
-	if err := s.recoverSandboxes(ctx); err != nil {
-		return fmt.Errorf("failed to recover sandboxes: %w", err)
-	}
-
 	// Create a child context that we can cancel independently
 	s.watchCtx, s.watchCancel = context.WithCancel(ctx)
 
-	// Start watching for sandbox changes
+	index := entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox)
+	s.watcher = indexwatch.New(s.entityClient, index, indexwatch.Options{Logger: s.log})
+	if err := s.watcher.Start(s.watchCtx); err != nil {
+		return err
+	}
+
+	// Process the initial snapshot synchronously (the watcher always delivers an
+	// EventSync first) so DNS mappings are populated before Watch returns.
+	select {
+	case ev, ok := <-s.watcher.Updates():
+		if ok {
+			s.dispatchSandboxEvent(s.watchCtx, ev)
+		}
+	case <-s.watchCtx.Done():
+		return s.watchCtx.Err()
+	}
+
 	s.watchWg.Add(1)
 	go func() {
 		defer s.watchWg.Done()
-		s.watchSandboxes(s.watchCtx)
+		for {
+			select {
+			case <-s.watchCtx.Done():
+				return
+			case ev, ok := <-s.watcher.Updates():
+				if !ok {
+					return
+				}
+				s.dispatchSandboxEvent(s.watchCtx, ev)
+			}
+		}
 	}()
 
 	return nil
 }
 
-func (s *Server) watchSandboxes(ctx context.Context) {
-	for {
-		if ctx.Err() != nil {
-			s.log.Info("sandbox watch stopped due to context cancellation")
+// dispatchSandboxEvent applies a single watcher event to the DNS mappings.
+func (s *Server) dispatchSandboxEvent(ctx context.Context, ev indexwatch.Event) {
+	switch ev.Type {
+	case indexwatch.EventSync:
+		s.reconcileSandboxes(ctx, ev.Entities)
+	case indexwatch.EventAdded, indexwatch.EventUpdated:
+		if ev.Entity == nil {
 			return
 		}
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(ev.Entity)
+		s.handleSandboxUpdate(ctx, &sb, ev.Entity)
+	case indexwatch.EventDeleted:
+		s.handleSandboxDeleteByID(string(ev.Id))
+	}
+}
 
-		index := entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox)
-		_, err := s.entityClient.WatchIndex(ctx, index, 0, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
-			if op == nil {
-				return nil
-			}
+// reconcileSandboxes processes a full snapshot: it applies every sandbox and
+// then removes any tracked sandbox that is no longer present in the index
+// (deleted while the watch was down).
+func (s *Server) reconcileSandboxes(ctx context.Context, entities []*entity.Entity) {
+	present := make(map[string]struct{}, len(entities))
+	for _, en := range entities {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(en)
+		present[sb.ID.String()] = struct{}{}
+		s.handleSandboxUpdate(ctx, &sb, en)
+	}
 
-			switch op.OperationType() {
-			case entityserver_v1alpha.EntityOperationCreate, entityserver_v1alpha.EntityOperationUpdate:
-				if op.Entity() == nil {
-					return nil
-				}
-				en := op.Entity().Entity()
-				var sb compute_v1alpha.Sandbox
-				sb.Decode(en)
-				s.handleSandboxUpdate(ctx, &sb, en)
-
-			case entityserver_v1alpha.EntityOperationDelete:
-				// For DELETE, entity data is nil but we have the ID
-				entityID := op.EntityId()
-				s.handleSandboxDeleteByID(entityID)
-			}
-
-			return nil
-		}))
-
-		if err != nil {
-			if ctx.Err() != nil {
-				s.log.Info("sandbox watch stopped due to context cancellation")
-				return
-			}
-			s.log.Error("sandbox watch ended with error, will restart", "error", err)
-			time.Sleep(5 * time.Second)
-			continue
+	s.mu.RLock()
+	var stale []string
+	for id := range s.entityToIP {
+		if _, ok := present[id]; !ok {
+			stale = append(stale, id)
 		}
+	}
+	s.mu.RUnlock()
 
-		s.log.Warn("sandbox watch ended unexpectedly, restarting")
-		time.Sleep(5 * time.Second)
+	for _, id := range stale {
+		s.handleSandboxDeleteByID(id)
 	}
 }
 
@@ -758,33 +778,6 @@ func (s *Server) handleSandboxDeleteByID(entityID string) {
 	}
 }
 
-func (s *Server) recoverSandboxes(ctx context.Context) error {
-	resp, err := s.entityClient.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
-	if err != nil {
-		return fmt.Errorf("failed to list sandboxes: %w", err)
-	}
-
-	s.log.Info("recovering sandboxes on startup", "total_sandboxes", len(resp.Values()))
-
-	recoveredCount := 0
-	for _, ent := range resp.Values() {
-		var sb compute_v1alpha.Sandbox
-		sb.Decode(ent.Entity())
-
-		// Only recover PENDING and RUNNING sandboxes
-		if !compute.SandboxActive(sb.Status) {
-			continue
-		}
-
-		// Process the sandbox to add to mappings
-		s.handleSandboxUpdate(ctx, &sb, ent.Entity())
-		recoveredCount++
-	}
-
-	s.log.Info("sandbox recovery complete", "recovered_count", recoveredCount)
-	return nil
-}
-
 // ListenAndServe starts the DNS server
 func (s *Server) ListenAndServe() error {
 	return s.Server.ListenAndServe()
@@ -795,6 +788,10 @@ func (s *Server) Shutdown() error {
 	// Cancel the watch context to stop the watcher goroutine
 	if s.watchCancel != nil {
 		s.watchCancel()
+	}
+
+	if s.watcher != nil {
+		s.watcher.Stop()
 	}
 
 	// Wait for the watcher goroutine to finish

--- a/pkg/entity/indexwatch/watcher.go
+++ b/pkg/entity/indexwatch/watcher.go
@@ -296,11 +296,16 @@ func (w *Watcher) run(ctx context.Context) {
 			backoff = w.opts.MinBackoff
 			continue
 		}
+		// A transient error or a clean stream end both drop us here; back off
+		// before resuming either way so an unexpected run of clean ends can't
+		// become a tight reconnect loop.
 		if err != nil {
 			w.log.Error("watch disconnected, will resume", "error", err, "cursor", w.cursor, "backoff", backoff)
-			if !w.sleep(ctx, &backoff) {
-				return
-			}
+		} else {
+			w.log.Info("watch ended cleanly, will resume", "cursor", w.cursor, "backoff", backoff)
+		}
+		if !w.sleep(ctx, &backoff) {
+			return
 		}
 	}
 }

--- a/pkg/entity/indexwatch/watcher.go
+++ b/pkg/entity/indexwatch/watcher.go
@@ -1,0 +1,425 @@
+// Package indexwatch provides a robust, self-healing abstraction around the
+// entity server's WatchIndex API.
+//
+// WatchIndex streams entity changes (create/update/delete) for an attribute
+// based index query, but the underlying watch can stop at any time (etcd
+// errors, RPC disconnects, server restarts). Consumers that use WatchIndex
+// directly must re-establish the watch on failure, and even when they do, any
+// changes that occur while the watch is down are silently lost.
+//
+// A Watcher closes both gaps while keeping only O(1) state — a single etcd
+// revision cursor. It owns one goroutine that:
+//
+//  1. Takes an initial snapshot via List, delivering it as a single EventSync
+//     carrying the complete current set of entities and the revision it was read
+//     at. The cursor is set to that revision.
+//  2. Watches from cursor+1 (etcd WithRev), forwarding live create/update/delete
+//     events and advancing the cursor from each event's revision and from idle
+//     progress watermarks.
+//  3. On a transient disconnect, re-watches from cursor+1 — etcd replays every
+//     put and delete since then, so nothing is missed and no re-list is needed.
+//  4. Only if the cursor has been compacted away does it take a fresh snapshot
+//     (another EventSync) and reset the cursor.
+//
+// Because the watcher holds no per-entity state, deletes that happen during a
+// snapshot gap (initial sync or post-compaction) are not emitted as individual
+// EventDeleted events. Instead an EventSync hands the consumer the full current
+// set, and the consumer reconciles it against its own state in its own business
+// domain (replace its cache; treat any id no longer present as removed) — work
+// these consumers already do today. Live deletes (the common case) arrive as
+// ordinary EventDeleted events.
+package indexwatch
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/rpc/stream"
+)
+
+// EventType describes the kind of change an Event represents.
+type EventType int
+
+const (
+	// EventSync delivers a full snapshot of the index: Entities holds the
+	// complete current set and Rev is the revision it was read at. Emitted on
+	// initial sync and again after a compaction or resync. Consumers reconcile
+	// their own state against Entities (replace their cache; treat any id no
+	// longer present as removed).
+	EventSync EventType = iota
+	// EventAdded indicates a live create.
+	EventAdded
+	// EventUpdated indicates a watched entity changed (live).
+	EventUpdated
+	// EventDeleted indicates an entity left the watched index (live). The Entity
+	// field may be nil; rely on Id.
+	EventDeleted
+)
+
+// String renders the EventType for logging.
+func (t EventType) String() string {
+	switch t {
+	case EventSync:
+		return "sync"
+	case EventAdded:
+		return "added"
+	case EventUpdated:
+		return "updated"
+	case EventDeleted:
+		return "deleted"
+	default:
+		return "unknown"
+	}
+}
+
+// Event is a single change delivered on the Updates channel.
+type Event struct {
+	// Type is the kind of change.
+	Type EventType
+	// Id is the entity's id. Set for Added/Updated/Deleted; empty for EventSync.
+	Id entity.Id
+	// Entity is the full entity for Added/Updated events. It is nil for Deleted
+	// events and for EventSync.
+	Entity *entity.Entity
+	// Entities is the complete current set for EventSync; nil for live events.
+	Entities []*entity.Entity
+	// Rev is the entity's revision for Added/Updated/Deleted, and the snapshot
+	// revision for EventSync.
+	Rev int64
+}
+
+// Options configures a Watcher. The zero value is usable; New applies defaults
+// for any unset field.
+type Options struct {
+	// Logger receives operational logs. Defaults to slog.Default().
+	Logger *slog.Logger
+
+	// ResyncPeriod, when > 0, forces a periodic fresh snapshot even while the
+	// watch is healthy, as belt-and-suspenders drift correction. Defaults to 0
+	// (disabled); revision-resume makes it unnecessary in normal operation.
+	ResyncPeriod time.Duration
+
+	// MinBackoff is the initial delay between reconnect attempts. Defaults to
+	// 1 second.
+	MinBackoff time.Duration
+
+	// MaxBackoff caps the exponential reconnect delay. Defaults to 5 minutes.
+	MaxBackoff time.Duration
+
+	// BufferSize is the capacity of the Updates channel. When the buffer is
+	// full the watch goroutine blocks (applying backpressure to the entity
+	// server) rather than dropping events, so no change is ever lost. Defaults
+	// to 1000.
+	BufferSize int
+}
+
+const (
+	defaultMinBackoff = time.Second
+	defaultMaxBackoff = 5 * time.Minute
+	defaultBufferSize = 1000
+)
+
+func (o *Options) applyDefaults() {
+	if o.Logger == nil {
+		o.Logger = slog.Default()
+	}
+	if o.MinBackoff <= 0 {
+		o.MinBackoff = defaultMinBackoff
+	}
+	if o.MaxBackoff <= 0 {
+		o.MaxBackoff = defaultMaxBackoff
+	}
+	if o.MaxBackoff < o.MinBackoff {
+		o.MaxBackoff = o.MinBackoff
+	}
+	if o.BufferSize <= 0 {
+		o.BufferSize = defaultBufferSize
+	}
+}
+
+// Watcher delivers gap-free change events for a single attribute based index
+// query while holding only a revision cursor. Create one with New, then call
+// Start. Consume events from Updates and optionally wait for the first snapshot
+// via Synced. Call Stop to shut down.
+type Watcher struct {
+	esc   *entityserver_v1alpha.EntityAccessClient
+	index entity.Attr
+	opts  Options
+	log   *slog.Logger
+
+	updates chan Event
+	synced  chan struct{}
+
+	// cursor is the last etcd revision the watcher has fully observed. Owned
+	// exclusively by the watch goroutine; no locking required.
+	cursor int64
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	syncOnce  sync.Once
+}
+
+// New creates a Watcher for the given index query against the entity server.
+// It does not start watching until Start is called.
+func New(esc *entityserver_v1alpha.EntityAccessClient, index entity.Attr, opts Options) *Watcher {
+	opts.applyDefaults()
+
+	return &Watcher{
+		esc:     esc,
+		index:   index,
+		opts:    opts,
+		log:     opts.Logger.With("module", "indexwatch", "index", index.ID),
+		updates: make(chan Event, opts.BufferSize),
+		synced:  make(chan struct{}),
+	}
+}
+
+// Updates returns the channel on which change events are delivered. The channel
+// is closed after Stop completes and the watch goroutine has exited.
+func (w *Watcher) Updates() <-chan Event {
+	return w.updates
+}
+
+// Synced returns a channel that is closed once the first snapshot has been
+// delivered (the first EventSync). Consumers that build an in-memory cache from
+// the stream can wait on it to know when their cache reflects the current state
+// of the index.
+func (w *Watcher) Synced() <-chan struct{} {
+	return w.synced
+}
+
+// Start launches the background watch goroutine. It is safe to call once; later
+// calls are no-ops. The watcher runs until ctx is cancelled or Stop is called.
+func (w *Watcher) Start(ctx context.Context) error {
+	w.startOnce.Do(func() {
+		runCtx, cancel := context.WithCancel(ctx)
+		w.cancel = cancel
+
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			defer close(w.updates)
+			w.run(runCtx)
+		}()
+	})
+
+	return nil
+}
+
+// Stop cancels the watch goroutine and waits for it to exit. It is safe to call
+// multiple times and from multiple goroutines. After Stop returns, the Updates
+// channel is closed.
+func (w *Watcher) Stop() {
+	w.stopOnce.Do(func() {
+		if w.cancel != nil {
+			w.cancel()
+		}
+		w.wg.Wait()
+	})
+}
+
+// markSynced closes the synced channel exactly once.
+func (w *Watcher) markSynced() {
+	w.syncOnce.Do(func() {
+		close(w.synced)
+	})
+}
+
+// decodeEntity converts an entity server wire entity into an entity.Entity,
+// restoring the timestamps and revision.
+func decodeEntity(aen *entityserver_v1alpha.Entity) *entity.Entity {
+	en := entity.New(aen.Attrs())
+	en.SetCreatedAt(time.UnixMilli(aen.CreatedAt()))
+	en.SetUpdatedAt(time.UnixMilli(aen.UpdatedAt()))
+	en.SetRevision(aen.Revision())
+	return en
+}
+
+// send delivers an event on the Updates channel, blocking until there is room
+// (backpressure) or the context is cancelled. It reports whether the event was
+// delivered; a false return means the watcher is shutting down.
+func (w *Watcher) send(ctx context.Context, ev Event) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case w.updates <- ev:
+		return true
+	}
+}
+
+// run is the main loop. It maintains the revision cursor, snapshots when needed
+// (initially and after a compaction or resync), and otherwise resumes the watch
+// from the cursor on every reconnect.
+func (w *Watcher) run(ctx context.Context) {
+	w.log.Info("starting index watch", "value", w.index.Value)
+	defer w.log.Info("index watch stopped")
+
+	backoff := w.opts.MinBackoff
+	needSnapshot := true
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		if needSnapshot {
+			rev, err := w.snapshot(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				w.log.Error("snapshot failed, will retry", "error", err, "backoff", backoff)
+				if !w.sleep(ctx, &backoff) {
+					return
+				}
+				continue
+			}
+			w.cursor = rev
+			needSnapshot = false
+			w.markSynced()
+			backoff = w.opts.MinBackoff
+		}
+
+		resnapshot, err := w.watch(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if resnapshot {
+			// Compaction or periodic resync: take a fresh snapshot, no backoff.
+			needSnapshot = true
+			backoff = w.opts.MinBackoff
+			continue
+		}
+		if err != nil {
+			w.log.Error("watch disconnected, will resume", "error", err, "cursor", w.cursor, "backoff", backoff)
+			if !w.sleep(ctx, &backoff) {
+				return
+			}
+		}
+	}
+}
+
+// snapshot lists the index and delivers it as a single EventSync carrying the
+// complete current set. It returns the revision the snapshot was read at.
+func (w *Watcher) snapshot(ctx context.Context) (int64, error) {
+	resp, err := w.esc.List(ctx, w.index)
+	if err != nil {
+		return 0, err
+	}
+
+	vals := resp.Values()
+	entities := make([]*entity.Entity, 0, len(vals))
+	for _, aen := range vals {
+		entities = append(entities, decodeEntity(aen))
+	}
+
+	rev := resp.Revision()
+	if !w.send(ctx, Event{Type: EventSync, Entities: entities, Rev: rev}) {
+		return 0, ctx.Err()
+	}
+
+	return rev, nil
+}
+
+// watch establishes a single WatchIndex stream resuming from cursor+1 and
+// forwards live events until it ends. It returns resnapshot=true when the caller
+// should take a fresh snapshot (compaction, or the resync timer firing), and an
+// error for a transient failure the caller should resume from after backoff.
+func (w *Watcher) watch(ctx context.Context) (resnapshot bool, err error) {
+	watchCtx := ctx
+	if w.opts.ResyncPeriod > 0 {
+		var cancel context.CancelFunc
+		watchCtx, cancel = context.WithTimeout(ctx, w.opts.ResyncPeriod)
+		defer cancel()
+	}
+
+	var compacted bool
+
+	_, werr := w.esc.WatchIndex(watchCtx, w.index, w.cursor+1, stream.Callback(func(op *entityserver_v1alpha.EntityOp) error {
+		switch op.OperationType() {
+		case entityserver_v1alpha.EntityOperationCompacted:
+			// Cursor too old; end the watch and re-snapshot.
+			compacted = true
+			return nil
+		case entityserver_v1alpha.EntityOperationProgress:
+			if op.Revision() > w.cursor {
+				w.cursor = op.Revision()
+			}
+			return nil
+		}
+
+		ev, ok := w.eventFromOp(op)
+		if !ok {
+			return nil
+		}
+		if !w.send(ctx, ev) {
+			return ctx.Err()
+		}
+		return nil
+	}))
+
+	if compacted {
+		return true, nil
+	}
+
+	// Resync timer fired while the watcher is still running: force a fresh
+	// snapshot rather than a plain resume.
+	if w.opts.ResyncPeriod > 0 && ctx.Err() == nil && watchCtx.Err() != nil {
+		return true, nil
+	}
+
+	return false, werr
+}
+
+// eventFromOp converts a live watch operation into an Event and advances the
+// cursor. It reports whether the op produced a deliverable event (unknown
+// operation types are ignored).
+func (w *Watcher) eventFromOp(op *entityserver_v1alpha.EntityOp) (Event, bool) {
+	var typ EventType
+
+	switch op.OperationType() {
+	case entityserver_v1alpha.EntityOperationCreate:
+		typ = EventAdded
+	case entityserver_v1alpha.EntityOperationUpdate:
+		typ = EventUpdated
+	case entityserver_v1alpha.EntityOperationDelete:
+		typ = EventDeleted
+	default:
+		return Event{}, false
+	}
+
+	rev := op.Revision()
+	if rev > w.cursor {
+		w.cursor = rev
+	}
+
+	var en *entity.Entity
+	if op.HasEntity() {
+		en = decodeEntity(op.Entity())
+	}
+
+	return Event{Type: typ, Id: entity.Id(op.EntityId()), Entity: en, Rev: rev}, true
+}
+
+// sleep waits for the current backoff duration, then doubles it up to MaxBackoff
+// for the next attempt. It returns false if the context was cancelled while
+// waiting.
+func (w *Watcher) sleep(ctx context.Context, backoff *time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(*backoff):
+		next := *backoff * 2
+		if next > w.opts.MaxBackoff {
+			next = w.opts.MaxBackoff
+		}
+		*backoff = next
+		return true
+	}
+}

--- a/pkg/entity/indexwatch/watcher_test.go
+++ b/pkg/entity/indexwatch/watcher_test.go
@@ -1,0 +1,417 @@
+package indexwatch_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/indexwatch"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/servers/entityserver"
+)
+
+var testKind = entity.Id("test/widget")
+
+func testIndex() entity.Attr {
+	return entity.Ref(entity.EntityKind, testKind)
+}
+
+// newTestClient wires an EntityAccessClient to an in-process EntityServer backed
+// by the given mock store, so watcher tests can run without etcd.
+func newTestClient(store *entity.MockStore) *entityserver_v1alpha.EntityAccessClient {
+	server := &entityserver.EntityServer{
+		Log:   slog.Default(),
+		Store: store,
+	}
+	return &entityserver_v1alpha.EntityAccessClient{
+		Client: rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(server)),
+	}
+}
+
+// makeEntity builds an entity with the given id that matches testIndex().
+func makeEntity(id string) *entity.Entity {
+	return entity.New(entity.Ref(entity.DBId, entity.Id(id)), testIndex())
+}
+
+func recv(t *testing.T, ch <-chan indexwatch.Event, d time.Duration) indexwatch.Event {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		return ev
+	case <-time.After(d):
+		t.Fatal("timed out waiting for event")
+		return indexwatch.Event{}
+	}
+}
+
+func fastOpts() indexwatch.Options {
+	return indexwatch.Options{
+		Logger:     slog.Default(),
+		MinBackoff: time.Millisecond,
+		MaxBackoff: 10 * time.Millisecond,
+	}
+}
+
+// idsOf returns the set of ids in a snapshot event.
+func idsOf(ev indexwatch.Event) map[entity.Id]struct{} {
+	ids := make(map[entity.Id]struct{}, len(ev.Entities))
+	for _, en := range ev.Entities {
+		ids[en.Id()] = struct{}{}
+	}
+	return ids
+}
+
+// putEvent builds a raw etcd put event for id at the given revision. create
+// controls whether it reads as a create (CreateRevision == ModRevision) or a
+// modify.
+func putEvent(id string, rev int64, create bool) clientv3.WatchResponse {
+	createRev := rev
+	if !create {
+		createRev = 1 // any value < rev makes IsModify() true
+	}
+	return clientv3.WatchResponse{
+		Events: []*clientv3.Event{{
+			Type: clientv3.EventTypePut,
+			Kv: &mvccpb.KeyValue{
+				Key:            []byte("k/" + id),
+				Value:          []byte(id),
+				CreateRevision: createRev,
+				ModRevision:    rev,
+			},
+		}},
+	}
+}
+
+// deleteEvent builds a raw etcd delete event for id at the given revision.
+func deleteEvent(id string, rev int64) clientv3.WatchResponse {
+	return clientv3.WatchResponse{
+		Events: []*clientv3.Event{{
+			Type: clientv3.EventTypeDelete,
+			Kv: &mvccpb.KeyValue{
+				Key:         []byte("k/" + id),
+				ModRevision: rev,
+			},
+			PrevKv: &mvccpb.KeyValue{
+				Key:         []byte("k/" + id),
+				Value:       []byte(id),
+				ModRevision: rev - 1,
+			},
+		}},
+	}
+}
+
+// gatedWatch installs an OnWatchIndex hook that publishes a fresh controllable
+// channel per watch attempt, so tests can drive raw responses and simulate
+// disconnects.
+func gatedWatch(store *entity.MockStore) chan chan clientv3.WatchResponse {
+	chans := make(chan chan clientv3.WatchResponse, 16)
+	store.OnWatchIndex = func(ctx context.Context, attr entity.Attr) (clientv3.WatchChan, error) {
+		ch := make(chan clientv3.WatchResponse)
+		chans <- ch
+		return ch, nil
+	}
+	return chans
+}
+
+func nextChan(t *testing.T, chans chan chan clientv3.WatchResponse, d time.Duration) chan clientv3.WatchResponse {
+	t.Helper()
+	select {
+	case ch := <-chans:
+		return ch
+	case <-time.After(d):
+		t.Fatal("timed out waiting for watch attempt")
+		return nil
+	}
+}
+
+// TestWatcher_InitialSyncSnapshot verifies the initial snapshot is delivered as a
+// single EventSync carrying the full set, and Synced fires.
+func TestWatcher_InitialSyncSnapshot(t *testing.T) {
+	r := require.New(t)
+
+	store := entity.NewMockStore()
+	for i := 0; i < 3; i++ {
+		_, err := store.CreateEntity(context.Background(), makeEntity(fmt.Sprintf("widget-%d", i)))
+		r.NoError(err)
+	}
+
+	sc := newTestClient(store)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := indexwatch.New(sc, testIndex(), fastOpts())
+	r.NoError(w.Start(ctx))
+	defer w.Stop()
+
+	ev := recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventSync, ev.Type)
+	r.Len(ev.Entities, 3)
+	for _, en := range ev.Entities {
+		r.NotNil(en)
+	}
+
+	select {
+	case <-w.Synced():
+	case <-time.After(5 * time.Second):
+		t.Fatal("Synced did not fire")
+	}
+}
+
+// TestWatcher_LiveEvents verifies live create/update/delete map to
+// Added/Updated/Deleted via the resumed watch stream.
+func TestWatcher_LiveEvents(t *testing.T) {
+	r := require.New(t)
+
+	store := entity.NewMockStore()
+	chans := gatedWatch(store)
+	sc := newTestClient(store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := indexwatch.New(sc, testIndex(), fastOpts())
+	r.NoError(w.Start(ctx))
+	defer w.Stop()
+
+	// Empty initial snapshot.
+	ev := recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventSync, ev.Type)
+	r.Empty(ev.Entities)
+
+	ch := nextChan(t, chans, 5*time.Second)
+
+	// The entity must exist in the store for the server to read it on put events.
+	_, err := store.CreateEntity(ctx, makeEntity("A"))
+	r.NoError(err)
+
+	ch <- putEvent("A", 10, true)
+	ev = recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventAdded, ev.Type)
+	r.Equal(entity.Id("A"), ev.Id)
+	r.Equal(int64(10), ev.Rev)
+
+	ch <- putEvent("A", 11, false)
+	ev = recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventUpdated, ev.Type)
+	r.Equal(entity.Id("A"), ev.Id)
+	r.Equal(int64(11), ev.Rev)
+
+	ch <- deleteEvent("A", 12)
+	ev = recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventDeleted, ev.Type)
+	r.Equal(entity.Id("A"), ev.Id)
+	r.Equal(int64(12), ev.Rev)
+}
+
+// TestWatcher_ResumeFromCursorNoResnapshot verifies a transient disconnect
+// resumes the watch from cursor+1 without taking a fresh snapshot.
+func TestWatcher_ResumeFromCursorNoResnapshot(t *testing.T) {
+	r := require.New(t)
+
+	store := entity.NewMockStore()
+	chans := gatedWatch(store)
+	sc := newTestClient(store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := indexwatch.New(sc, testIndex(), fastOpts())
+	r.NoError(w.Start(ctx))
+	defer w.Stop()
+
+	// Empty initial snapshot at revision 0 → first watch resumes from 1.
+	r.Equal(indexwatch.EventSync, recv(t, w.Updates(), 5*time.Second).Type)
+
+	_, err := store.CreateEntity(ctx, makeEntity("X"))
+	r.NoError(err)
+
+	ch1 := nextChan(t, chans, 5*time.Second)
+	ch1 <- putEvent("X", 5, true) // cursor advances to 5
+	ev := recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventAdded, ev.Type)
+	r.Equal(int64(5), ev.Rev)
+
+	// Transient disconnect.
+	close(ch1)
+
+	// Resume: next watch attempt delivers an update — NOT a fresh EventSync.
+	ch2 := nextChan(t, chans, 5*time.Second)
+	ch2 <- putEvent("X", 7, false)
+	ev = recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventUpdated, ev.Type, "expected resume, not a re-snapshot")
+	r.Equal(int64(7), ev.Rev)
+
+	r.Equal([]int64{1, 6}, store.WatchFromRevsCopy(), "second watch should resume from cursor+1")
+}
+
+// TestWatcher_CompactionResnapshot verifies a compaction signal triggers a fresh
+// snapshot delivered as a new EventSync.
+func TestWatcher_CompactionResnapshot(t *testing.T) {
+	r := require.New(t)
+
+	store := entity.NewMockStore()
+	chans := gatedWatch(store)
+
+	_, err := store.CreateEntity(context.Background(), makeEntity("A"))
+	r.NoError(err)
+
+	sc := newTestClient(store)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := indexwatch.New(sc, testIndex(), fastOpts())
+	r.NoError(w.Start(ctx))
+	defer w.Stop()
+
+	// First snapshot contains A.
+	ev := recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventSync, ev.Type)
+	r.Contains(idsOf(ev), entity.Id("A"))
+
+	ch1 := nextChan(t, chans, 5*time.Second)
+
+	// A new entity appears, then the watch is compacted → forces a re-snapshot.
+	_, err = store.CreateEntity(ctx, makeEntity("B"))
+	r.NoError(err)
+	ch1 <- clientv3.WatchResponse{Canceled: true, CompactRevision: 999}
+
+	// Fresh snapshot now includes A and B.
+	ev = recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventSync, ev.Type)
+	got := idsOf(ev)
+	r.Contains(got, entity.Id("A"))
+	r.Contains(got, entity.Id("B"))
+}
+
+// TestWatcher_ProgressAdvancesCursor verifies a progress watermark advances the
+// resume cursor without emitting an event.
+func TestWatcher_ProgressAdvancesCursor(t *testing.T) {
+	r := require.New(t)
+
+	store := entity.NewMockStore()
+	chans := gatedWatch(store)
+	sc := newTestClient(store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := indexwatch.New(sc, testIndex(), fastOpts())
+	r.NoError(w.Start(ctx))
+	defer w.Stop()
+
+	r.Equal(indexwatch.EventSync, recv(t, w.Updates(), 5*time.Second).Type)
+
+	ch1 := nextChan(t, chans, 5*time.Second)
+	// Progress watermark at revision 50, no events.
+	ch1 <- clientv3.WatchResponse{Header: etcdserverpb.ResponseHeader{Revision: 50}}
+	// Disconnect so the watcher resumes from the advanced cursor.
+	close(ch1)
+
+	// Deliver an event on the resumed watch and confirm no spurious event was
+	// emitted from the progress watermark.
+	ch2 := nextChan(t, chans, 5*time.Second)
+	_, err := store.CreateEntity(ctx, makeEntity("Z"))
+	r.NoError(err)
+	ch2 <- putEvent("Z", 60, true)
+
+	ev := recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventAdded, ev.Type)
+	r.Equal(entity.Id("Z"), ev.Id)
+
+	r.Equal([]int64{1, 51}, store.WatchFromRevsCopy(), "resume should start at progress revision + 1")
+}
+
+// TestWatcher_BlockingBackpressure verifies a slow consumer never loses live
+// events with a buffer of 1: the watcher blocks rather than dropping.
+func TestWatcher_BlockingBackpressure(t *testing.T) {
+	r := require.New(t)
+
+	const n = 30
+	store := entity.NewMockStore()
+	chans := gatedWatch(store)
+	sc := newTestClient(store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := fastOpts()
+	opts.BufferSize = 1
+	w := indexwatch.New(sc, testIndex(), opts)
+	r.NoError(w.Start(ctx))
+	defer w.Stop()
+
+	// Empty initial snapshot.
+	r.Equal(indexwatch.EventSync, recv(t, w.Updates(), 5*time.Second).Type)
+
+	ch := nextChan(t, chans, 5*time.Second)
+
+	// Pre-create the entities so the server can read them on put events.
+	for i := 0; i < n; i++ {
+		_, err := store.CreateEntity(ctx, makeEntity(fmt.Sprintf("widget-%d", i)))
+		r.NoError(err)
+	}
+
+	// Push events faster than they are consumed; the unbuffered channel + buffer
+	// of 1 force backpressure all the way to this goroutine.
+	go func() {
+		for i := 0; i < n; i++ {
+			ch <- putEvent(fmt.Sprintf("widget-%d", i), int64(i+10), true)
+		}
+	}()
+
+	seen := make(map[entity.Id]struct{}, n)
+	deadline := time.After(15 * time.Second)
+	for len(seen) < n {
+		select {
+		case ev := <-w.Updates():
+			r.Equal(indexwatch.EventAdded, ev.Type)
+			seen[ev.Id] = struct{}{}
+			time.Sleep(time.Millisecond) // slow consumer
+		case <-deadline:
+			t.Fatalf("only received %d/%d events", len(seen), n)
+		}
+	}
+	r.Len(seen, n)
+}
+
+// TestWatcher_StopClosesUpdates verifies Stop is idempotent and closes Updates.
+func TestWatcher_StopClosesUpdates(t *testing.T) {
+	r := require.New(t)
+
+	store := entity.NewMockStore()
+	sc := newTestClient(store)
+
+	w := indexwatch.New(sc, testIndex(), fastOpts())
+	r.NoError(w.Start(context.Background()))
+
+	select {
+	case <-w.Synced():
+	case <-time.After(5 * time.Second):
+		t.Fatal("Synced did not fire")
+	}
+
+	w.Stop()
+	w.Stop() // idempotent
+
+	// Drain any buffered snapshot event; the channel must end up closed.
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case _, ok := <-w.Updates():
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("Updates not closed after Stop")
+		}
+	}
+}

--- a/pkg/entity/indexwatch/watcher_test.go
+++ b/pkg/entity/indexwatch/watcher_test.go
@@ -330,6 +330,50 @@ func TestWatcher_ProgressAdvancesCursor(t *testing.T) {
 	r.Equal([]int64{1, 51}, store.WatchFromRevsCopy(), "resume should start at progress revision + 1")
 }
 
+// TestWatcher_CreatedResponseDoesNotAdvanceCursor verifies that etcd's initial
+// Created confirmation (empty events, Created=true) does NOT advance the resume
+// cursor. The Created header carries the current store revision but arrives
+// before the historical backlog replays; advancing the cursor to it and then
+// disconnecting would skip the un-replayed backlog on resume, re-opening the gap
+// the watcher exists to prevent (bug 1b).
+func TestWatcher_CreatedResponseDoesNotAdvanceCursor(t *testing.T) {
+	r := require.New(t)
+
+	store := entity.NewMockStore()
+	chans := gatedWatch(store)
+	sc := newTestClient(store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := indexwatch.New(sc, testIndex(), fastOpts())
+	r.NoError(w.Start(ctx))
+	defer w.Stop()
+
+	// Empty initial snapshot at revision 0 → first watch resumes from 1.
+	r.Equal(indexwatch.EventSync, recv(t, w.Updates(), 5*time.Second).Type)
+
+	ch1 := nextChan(t, chans, 5*time.Second)
+	// The Created confirmation reports the current revision (100) but no backlog.
+	ch1 <- clientv3.WatchResponse{Created: true, Header: etcdserverpb.ResponseHeader{Revision: 100}}
+	// Disconnect before any real event arrives.
+	close(ch1)
+
+	// Resume must start from cursor+1 = 1 (unchanged), NOT 101. If the Created
+	// response had advanced the cursor to 100, events 1..100 would be lost.
+	ch2 := nextChan(t, chans, 5*time.Second)
+	_, err := store.CreateEntity(ctx, makeEntity("Z"))
+	r.NoError(err)
+	ch2 <- putEvent("Z", 60, true)
+
+	ev := recv(t, w.Updates(), 5*time.Second)
+	r.Equal(indexwatch.EventAdded, ev.Type)
+	r.Equal(entity.Id("Z"), ev.Id)
+
+	r.Equal([]int64{1, 1}, store.WatchFromRevsCopy(),
+		"Created response must not advance the cursor; resume should still start at 1")
+}
+
 // TestWatcher_BlockingBackpressure verifies a slow consumer never loses live
 // events with a buffer of 1: the watcher blocks rather than dropping.
 func TestWatcher_BlockingBackpressure(t *testing.T) {

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -28,6 +28,10 @@ type MockStore struct {
 	// Index watchers - maps index key (attr.CAS()) to list of channels to notify
 	indexWatchersMu sync.RWMutex
 	indexWatchers   map[string][]chan clientv3.WatchResponse
+
+	// WatchFromRevs records the fromRev argument of every WatchIndex call, in
+	// order, so tests can assert resume behavior.
+	WatchFromRevs []int64
 }
 
 var _ Store = &MockStore{}
@@ -313,7 +317,19 @@ func (m *MockStore) DeleteEntity(ctx context.Context, id Id) error {
 	return nil
 }
 
-func (m *MockStore) WatchIndex(ctx context.Context, attr Attr) (clientv3.WatchChan, error) {
+// WatchFromRevsCopy returns a snapshot of the fromRev arguments seen by
+// WatchIndex, for tests asserting resume behavior.
+func (m *MockStore) WatchFromRevsCopy() []int64 {
+	m.indexWatchersMu.Lock()
+	defer m.indexWatchersMu.Unlock()
+	return append([]int64(nil), m.WatchFromRevs...)
+}
+
+func (m *MockStore) WatchIndex(ctx context.Context, attr Attr, fromRev int64) (clientv3.WatchChan, error) {
+	m.indexWatchersMu.Lock()
+	m.WatchFromRevs = append(m.WatchFromRevs, fromRev)
+	m.indexWatchersMu.Unlock()
+
 	if m.OnWatchIndex != nil {
 		return m.OnWatchIndex(ctx, attr)
 	}
@@ -495,6 +511,27 @@ func (m *MockStore) ListIndex(ctx context.Context, attr Attr) ([]Id, error) {
 	}
 
 	return ids, nil
+}
+
+// ListIndexRevision returns the matching ids along with a revision. The mock
+// uses the highest entity revision currently in the store as a monotonic proxy
+// for the cluster revision, which is sufficient for resume-cursor tests.
+func (m *MockStore) ListIndexRevision(ctx context.Context, attr Attr) ([]Id, int64, error) {
+	ids, err := m.ListIndex(ctx, attr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	m.mu.RLock()
+	var rev int64
+	for _, e := range m.Entities {
+		if r := e.GetRevision(); r > rev {
+			rev = r
+		}
+	}
+	m.mu.RUnlock()
+
+	return ids, rev, nil
 }
 
 func (m *MockStore) ListCollection(ctx context.Context, collection string) ([]Id, error) {

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -41,8 +41,11 @@ type Store interface {
 	PatchEntity(ctx context.Context, entity *Entity, opts ...EntityOption) (*Entity, error)
 	EnsureEntity(ctx context.Context, entity *Entity, opts ...EntityOption) (*Entity, bool, error)
 	DeleteEntity(ctx context.Context, id Id) error
-	WatchIndex(ctx context.Context, attr Attr) (clientv3.WatchChan, error)
+	WatchIndex(ctx context.Context, attr Attr, fromRev int64) (clientv3.WatchChan, error)
 	ListIndex(ctx context.Context, attr Attr) ([]Id, error)
+	// ListIndexRevision is like ListIndex but also returns the etcd revision the
+	// listing was read at, so a caller can resume a watch from that point.
+	ListIndexRevision(ctx context.Context, attr Attr) ([]Id, int64, error)
 	ListCollection(ctx context.Context, collection string) ([]Id, error)
 
 	CreateSession(ctx context.Context, ttl int64) ([]byte, error)
@@ -1436,35 +1439,43 @@ func (s *EtcdStore) deleteFromCollection(entity *Entity, collection string) erro
 }
 
 func (s *EtcdStore) ListIndex(ctx context.Context, attr Attr) ([]Id, error) {
+	ids, _, err := s.ListIndexRevision(ctx, attr)
+	return ids, err
+}
+
+// ListIndexRevision lists the ids matching attr and returns the etcd revision the
+// listing was read at. The revision lets a caller resume a watch from that point
+// (gap-free) instead of re-reconciling on every reconnect.
+func (s *EtcdStore) ListIndexRevision(ctx context.Context, attr Attr) ([]Id, int64, error) {
 	if attr.ID == DBId {
 		if attr.Value.Kind() != KindId {
-			return nil, cond.ValidationFailure("attribute", "invalid value type for ID")
+			return nil, 0, cond.ValidationFailure("attribute", "invalid value type for ID")
 		}
 
 		id := attr.Value.Id()
 
 		gr, err := s.client.Get(ctx, s.buildKey(id), clientv3.WithCountOnly())
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		if gr.Count == 0 {
-			return nil, nil
+			return nil, gr.Header.Revision, nil
 		}
 
-		return []Id{attr.Value.Id()}, nil
+		return []Id{id}, gr.Header.Revision, nil
 	}
 
 	schema, err := s.GetAttributeSchema(ctx, attr.ID)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if !schema.Index {
-		return nil, fmt.Errorf("attribute %s is not indexed", attr.ID)
+		return nil, 0, fmt.Errorf("attribute %s is not indexed", attr.ID)
 	}
 
-	return s.ListCollection(ctx, attr.CAS())
+	return s.listCollectionRevision(ctx, attr.CAS())
 }
 
 func (s *EtcdStore) IndexPrefix(ctx context.Context, attr Attr) (string, error) {
@@ -1480,7 +1491,7 @@ func (s *EtcdStore) IndexPrefix(ctx context.Context, attr Attr) (string, error) 
 	return s.CollectionPrefix(ctx, attr.CAS())
 }
 
-func (s *EtcdStore) WatchIndex(ctx context.Context, attr Attr) (clientv3.WatchChan, error) {
+func (s *EtcdStore) WatchIndex(ctx context.Context, attr Attr, fromRev int64) (clientv3.WatchChan, error) {
 	if attr.ID == DBId {
 		if attr.Value.Kind() != KindId {
 			return nil, cond.ValidationFailure("attribute", "invalid value type for ID")
@@ -1488,7 +1499,11 @@ func (s *EtcdStore) WatchIndex(ctx context.Context, attr Attr) (clientv3.WatchCh
 
 		id := attr.Value.Id()
 		key := s.buildKey(id)
-		wc := s.client.Watch(ctx, key)
+		var wopts []clientv3.OpOption
+		if fromRev > 0 {
+			wopts = append(wopts, clientv3.WithRev(fromRev))
+		}
+		wc := s.client.Watch(ctx, key, wopts...)
 
 		ret := make(chan clientv3.WatchResponse, 1)
 
@@ -1537,19 +1552,31 @@ func (s *EtcdStore) WatchIndex(ctx context.Context, attr Attr) (clientv3.WatchCh
 		return nil, err
 	}
 
-	return s.client.Watch(ctx, prefix, clientv3.WithPrefix(), clientv3.WithPrevKV()), nil
+	// WithProgressNotify keeps the resume cursor fresh during idle periods;
+	// WithRev resumes the event stream from a prior revision (gap-free) when set.
+	opts := []clientv3.OpOption{clientv3.WithPrefix(), clientv3.WithPrevKV(), clientv3.WithProgressNotify()}
+	if fromRev > 0 {
+		opts = append(opts, clientv3.WithRev(fromRev))
+	}
+
+	return s.client.Watch(ctx, prefix, opts...), nil
 }
 
 var tr = strings.NewReplacer("/", "_", ":", "_")
 
 func (s *EtcdStore) ListCollection(ctx context.Context, collection string) ([]Id, error) {
+	ids, _, err := s.listCollectionRevision(ctx, collection)
+	return ids, err
+}
+
+func (s *EtcdStore) listCollectionRevision(ctx context.Context, collection string) ([]Id, int64, error) {
 	colKey := tr.Replace(collection)
 
 	prefix := fmt.Sprintf("%s/collections/%s/", s.prefix, colKey)
 
 	resp, err := s.client.Get(ctx, prefix, clientv3.WithPrefix())
 	if err != nil {
-		return nil, fmt.Errorf("failed to list entities from etcd: %w", err)
+		return nil, 0, fmt.Errorf("failed to list entities from etcd: %w", err)
 	}
 
 	seen := make(map[Id]struct{})
@@ -1564,7 +1591,7 @@ func (s *EtcdStore) ListCollection(ctx context.Context, collection string) ([]Id
 		entities = append(entities, id)
 	}
 
-	return entities, nil
+	return entities, resp.Header.Revision, nil
 }
 
 func (s *EtcdStore) CollectionPrefix(ctx context.Context, collection string) (string, error) {

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -400,7 +400,7 @@ func TestEtcdStore_UpdateEntity(t *testing.T) {
 
 		r.Equal(addr, sa)
 
-		wc, err := store.WatchIndex(t.Context(), String(Id("test/kind"), "foo"))
+		wc, err := store.WatchIndex(t.Context(), String(Id("test/kind"), "foo"), 0)
 		r.NoError(err)
 
 		r.NoError(store.RevokeSession(t.Context(), sid))
@@ -751,7 +751,7 @@ func TestWatchIndex(t *testing.T) {
 	}
 
 	// Start watching the index before creating any entities
-	watcher, err := store.WatchIndex(ctx, String(attr.Id(), "value1"))
+	watcher, err := store.WatchIndex(ctx, String(attr.Id(), "value1"), 0)
 	if err != nil {
 		t.Fatalf("Failed to create watcher: %v", err)
 	}
@@ -805,7 +805,7 @@ func TestWatchIndex(t *testing.T) {
 	*/
 
 	// Create a new watcher for the new value
-	watcher2, err := store.WatchIndex(ctx, String(attr.Id(), "value2"))
+	watcher2, err := store.WatchIndex(ctx, String(attr.Id(), "value2"), 0)
 	if err != nil {
 		t.Fatalf("Failed to create second watcher: %v", err)
 	}
@@ -839,9 +839,76 @@ func TestWatchIndex(t *testing.T) {
 		t.Fatalf("Failed to create non-indexed schema: %v", err)
 	}
 
-	_, err = store.WatchIndex(ctx, String(nonIndexedSchema.Id(), "value"))
+	_, err = store.WatchIndex(ctx, String(nonIndexedSchema.Id(), "value"), 0)
 	if err == nil {
 		t.Error("Expected error when watching non-indexed attribute")
+	}
+}
+
+func TestListIndexRevision(t *testing.T) {
+	ctx := context.Background()
+	store, _ := setupTestEtcdStore(t)
+
+	attr, err := store.CreateEntity(ctx, New(
+		String(Ident, "test-revindex"),
+		Ref(Type, TypeStr),
+		Bool(Index, true),
+	))
+	require.NoError(t, err)
+
+	_, err = store.CreateEntity(ctx, New(
+		String(attr.Id(), "value1"),
+		String(Ident, "rev-entity-1"),
+	))
+	require.NoError(t, err)
+
+	ids, rev, err := store.ListIndexRevision(ctx, String(attr.Id(), "value1"))
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	require.Greater(t, rev, int64(0), "ListIndexRevision must return the etcd revision")
+}
+
+// TestWatchIndexFromRevision verifies that starting a watch at a prior revision
+// replays changes made after that revision (gap-free resume), and that starting
+// at the current revision does not replay earlier changes.
+func TestWatchIndexFromRevision(t *testing.T) {
+	ctx := context.Background()
+	store, _ := setupTestEtcdStore(t)
+
+	attr, err := store.CreateEntity(ctx, New(
+		String(Ident, "test-resume"),
+		Ref(Type, TypeStr),
+		Bool(Index, true),
+	))
+	require.NoError(t, err)
+
+	idxAttr := String(attr.Id(), "value1")
+
+	// Entity created before the cursor; must NOT be replayed.
+	_, err = store.CreateEntity(ctx, New(idxAttr, String(Ident, "resume-entity-1")))
+	require.NoError(t, err)
+
+	_, rev, err := store.ListIndexRevision(ctx, idxAttr)
+	require.NoError(t, err)
+	require.Greater(t, rev, int64(0))
+
+	// Entity created after the cursor; must be replayed even though it predates
+	// the watch call.
+	entity2, err := store.CreateEntity(ctx, New(idxAttr, String(Ident, "resume-entity-2")))
+	require.NoError(t, err)
+
+	watcher, err := store.WatchIndex(ctx, idxAttr, rev+1)
+	require.NoError(t, err)
+
+	select {
+	case wr := <-watcher:
+		require.NoError(t, wr.Err())
+		require.NotEmpty(t, wr.Events)
+		require.Equal(t, clientv3.EventTypePut, wr.Events[0].Type)
+		require.Equal(t, string(entity2.Id()), string(wr.Events[0].Kv.Value),
+			"resume should replay entity2 (created after the cursor), not entity1")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for replayed event")
 	}
 }
 
@@ -892,7 +959,7 @@ func TestWatchIndex_DBID(t *testing.T) {
 	}
 
 	// Start watching the index before creating any entities
-	watcher, err := store.WatchIndex(ctx, Ref(DBId, "test-entity-1"))
+	watcher, err := store.WatchIndex(ctx, Ref(DBId, "test-entity-1"), 0)
 	if err != nil {
 		t.Fatalf("Failed to create watcher: %v", err)
 	}

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -437,7 +437,7 @@ func (e *EntityServer) WatchIndex(ctx context.Context, req *entityserver_v1alpha
 
 	send := args.Values()
 
-	ch, err := e.Store.WatchIndex(ctx, args.Index())
+	ch, err := e.Store.WatchIndex(ctx, args.Index(), args.FromRevision())
 	if err != nil {
 		return fmt.Errorf("failed to watch index: %w", err)
 	}
@@ -453,10 +453,38 @@ func (e *EntityServer) WatchIndex(ctx context.Context, req *entityserver_v1alpha
 
 			// Check if the watch was canceled or had an error
 			if watchevent.Canceled {
+				// A compacted start revision is recoverable: tell the client to
+				// re-list and resume from a fresh snapshot rather than erroring.
+				if watchevent.CompactRevision > 0 {
+					var op entityserver_v1alpha.EntityOp
+					op.SetOperation(int64(entityserver_v1alpha.EntityOperationCompacted))
+					op.SetRevision(watchevent.CompactRevision)
+					if _, err := send.Send(ctx, &op); err != nil {
+						if !errors.Is(err, context.Canceled) && !errors.Is(err, cond.ErrClosed{}) {
+							e.Log.Error("failed to send compacted signal", "error", err)
+						}
+					}
+					return nil
+				}
 				if err := watchevent.Err(); err != nil {
 					return fmt.Errorf("watch canceled with error: %w", err)
 				}
 				return fmt.Errorf("watch canceled")
+			}
+
+			// Progress notifications carry no events; forward the observed revision
+			// as a watermark so the client can advance its resume cursor while idle.
+			if len(watchevent.Events) == 0 {
+				var op entityserver_v1alpha.EntityOp
+				op.SetOperation(int64(entityserver_v1alpha.EntityOperationProgress))
+				op.SetRevision(watchevent.Header.Revision)
+				if _, err := send.Send(ctx, &op); err != nil {
+					if !errors.Is(err, context.Canceled) && !errors.Is(err, cond.ErrClosed{}) {
+						e.Log.Error("failed to send progress watermark", "error", err)
+					}
+					return nil
+				}
+				continue
 			}
 
 			for _, event := range watchevent.Events {
@@ -480,6 +508,9 @@ func (e *EntityServer) WatchIndex(ctx context.Context, req *entityserver_v1alpha
 
 				var op entityserver_v1alpha.EntityOp
 				op.SetOperation(int64(eventType))
+				// ModRevision is the revision of this change for both puts and
+				// deletes; the client uses it to advance its resume cursor.
+				op.SetRevision(event.Kv.ModRevision)
 
 				if read {
 					op.SetEntityId(string(event.Kv.Value))
@@ -547,8 +578,9 @@ func (e *EntityServer) List(ctx context.Context, req *entityserver_v1alpha.Entit
 	}
 
 	var (
-		ids []entity.Id
-		err error
+		ids     []entity.Id
+		listRev int64
+		err     error
 	)
 
 	index := args.Index()
@@ -563,7 +595,7 @@ func (e *EntityServer) List(ctx context.Context, req *entityserver_v1alpha.Entit
 
 		ids, err = e.Store.ListSessionEntities(ctx, data)
 	} else {
-		ids, err = e.Store.ListIndex(ctx, args.Index())
+		ids, listRev, err = e.Store.ListIndexRevision(ctx, args.Index())
 	}
 
 	if err != nil {
@@ -596,6 +628,7 @@ func (e *EntityServer) List(ctx context.Context, req *entityserver_v1alpha.Entit
 	}
 
 	req.Results().SetValues(ret)
+	req.Results().SetRevision(listRev)
 
 	return nil
 }

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -437,7 +437,14 @@ func (e *EntityServer) WatchIndex(ctx context.Context, req *entityserver_v1alpha
 
 	send := args.Values()
 
-	ch, err := e.Store.WatchIndex(ctx, args.Index(), args.FromRevision())
+	// Progress watermarks and compaction signals are only meaningful to a client
+	// that is resuming from a revision. A from-now client (fromRev==0) predates
+	// these op types and can never fall behind the compaction point, so we never
+	// forward them to it — preserving backward-compatible behavior for callers
+	// that aren't revision-aware (e.g. the legacy activator/controller watches).
+	fromRev := args.FromRevision()
+
+	ch, err := e.Store.WatchIndex(ctx, args.Index(), fromRev)
 	if err != nil {
 		return fmt.Errorf("failed to watch index: %w", err)
 	}
@@ -453,9 +460,11 @@ func (e *EntityServer) WatchIndex(ctx context.Context, req *entityserver_v1alpha
 
 			// Check if the watch was canceled or had an error
 			if watchevent.Canceled {
-				// A compacted start revision is recoverable: tell the client to
-				// re-list and resume from a fresh snapshot rather than erroring.
-				if watchevent.CompactRevision > 0 {
+				// A compacted start revision is recoverable for a resuming client:
+				// tell it to re-list and resume from a fresh snapshot rather than
+				// erroring. A from-now client can never fall behind the compaction
+				// point, so fall through to the legacy error path for it.
+				if watchevent.CompactRevision > 0 && fromRev > 0 {
 					var op entityserver_v1alpha.EntityOp
 					op.SetOperation(int64(entityserver_v1alpha.EntityOperationCompacted))
 					op.SetRevision(watchevent.CompactRevision)
@@ -473,16 +482,22 @@ func (e *EntityServer) WatchIndex(ctx context.Context, req *entityserver_v1alpha
 			}
 
 			// Progress notifications carry no events; forward the observed revision
-			// as a watermark so the client can advance its resume cursor while idle.
-			if len(watchevent.Events) == 0 {
-				var op entityserver_v1alpha.EntityOp
-				op.SetOperation(int64(entityserver_v1alpha.EntityOperationProgress))
-				op.SetRevision(watchevent.Header.Revision)
-				if _, err := send.Send(ctx, &op); err != nil {
-					if !errors.Is(err, context.Canceled) && !errors.Is(err, cond.ErrClosed{}) {
-						e.Log.Error("failed to send progress watermark", "error", err)
+			// as a watermark so a resuming client can advance its cursor while idle.
+			// IsProgressNotify deliberately excludes etcd's initial Created
+			// confirmation: that response reports the current revision but arrives
+			// before the historical backlog replays, so forwarding it would advance
+			// the cursor past events the client hasn't seen yet.
+			if watchevent.IsProgressNotify() {
+				if fromRev > 0 {
+					var op entityserver_v1alpha.EntityOp
+					op.SetOperation(int64(entityserver_v1alpha.EntityOperationProgress))
+					op.SetRevision(watchevent.Header.Revision)
+					if _, err := send.Send(ctx, &op); err != nil {
+						if !errors.Is(err, context.Canceled) && !errors.Is(err, cond.ErrClosed{}) {
+							e.Log.Error("failed to send progress watermark", "error", err)
+						}
+						return nil
 					}
-					return nil
 				}
 				continue
 			}

--- a/servers/entityserver/entityserver_test.go
+++ b/servers/entityserver/entityserver_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	v1alpha "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/entity"
@@ -772,4 +774,154 @@ func TestEntityServer_List_NestedIndexCleanup(t *testing.T) {
 	results = resp.Values()
 	assert.Len(t, results, 1, "Should find only one entity after deletion")
 	assert.Equal(t, entity2.Id().String(), results[0].Id(), "Remaining entity should be entity2")
+}
+
+// watchIndexServer wires an EntityAccessClient to an in-process EntityServer
+// whose store delivers raw watch responses on the returned channel, so tests can
+// drive progress notifications, the initial Created response, and compactions
+// directly.
+func watchIndexServer(t *testing.T) (*entity.MockStore, v1alpha.EntityAccessClient, chan clientv3.WatchResponse) {
+	t.Helper()
+	store := entity.NewMockStore()
+	watchCh := make(chan clientv3.WatchResponse, 8)
+	store.OnWatchIndex = func(ctx context.Context, attr entity.Attr) (clientv3.WatchChan, error) {
+		return watchCh, nil
+	}
+	server := &EntityServer{Log: slog.Default(), Store: store}
+	sc := v1alpha.EntityAccessClient{
+		Client: rpc.LocalClient(v1alpha.AdaptEntityAccess(server)),
+	}
+	return store, sc, watchCh
+}
+
+func putResponse(id string, rev int64) clientv3.WatchResponse {
+	return clientv3.WatchResponse{Events: []*clientv3.Event{{
+		Type: clientv3.EventTypePut,
+		Kv: &mvccpb.KeyValue{
+			Key:            []byte("k/" + id),
+			Value:          []byte(id),
+			CreateRevision: rev,
+			ModRevision:    rev,
+		},
+	}}}
+}
+
+// TestEntityServer_WatchIndex_LegacyClientIgnoresProgress proves a from-now
+// (from_revision==0) client never receives a Progress op, even though the server
+// now sets WithProgressNotify on the underlying watch. Legacy consumers predate
+// the Progress op type and dereference op.Entity() for any non-delete op, so
+// forwarding a watermark to them is a crash (this is bug 1a).
+func TestEntityServer_WatchIndex_LegacyClientIgnoresProgress(t *testing.T) {
+	r := require.New(t)
+
+	store, sc, watchCh := watchIndexServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	index := entity.Keyword(entity.Ident, "test/index")
+
+	// The entity must exist so the server can read it when the put arrives.
+	_, err := store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, "widget-1"), index))
+	r.NoError(err)
+
+	gotOps := make(chan *v1alpha.EntityOp, 16)
+	go func() {
+		_, _ = sc.WatchIndex(ctx, index, 0, stream.Callback(func(op *v1alpha.EntityOp) error {
+			gotOps <- op
+			return nil
+		}))
+	}()
+
+	// An idle progress watermark followed by a real change. The legacy client
+	// must see only the change.
+	watchCh <- clientv3.WatchResponse{Header: etcdserverpb.ResponseHeader{Revision: 50}}
+	watchCh <- putResponse("widget-1", 60)
+
+	select {
+	case op := <-gotOps:
+		r.Equal(int64(v1alpha.EntityOperationCreate), op.Operation(),
+			"legacy client should receive the create, not a progress watermark")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for op")
+	}
+}
+
+// TestEntityServer_WatchIndex_ProgressForwardedWhenResuming documents the
+// intended positive behavior the fix must preserve: a client resuming from a
+// revision (from_revision>0) does receive progress watermarks so it can advance
+// its cursor while idle.
+func TestEntityServer_WatchIndex_ProgressForwardedWhenResuming(t *testing.T) {
+	r := require.New(t)
+
+	_, sc, watchCh := watchIndexServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	index := entity.Keyword(entity.Ident, "test/index")
+
+	gotOps := make(chan *v1alpha.EntityOp, 16)
+	go func() {
+		_, _ = sc.WatchIndex(ctx, index, 5, stream.Callback(func(op *v1alpha.EntityOp) error {
+			gotOps <- op
+			return nil
+		}))
+	}()
+
+	watchCh <- clientv3.WatchResponse{Header: etcdserverpb.ResponseHeader{Revision: 50}}
+
+	select {
+	case op := <-gotOps:
+		r.Equal(int64(v1alpha.EntityOperationProgress), op.Operation(),
+			"resuming client should receive the progress watermark")
+		r.Equal(int64(50), op.Revision())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for op")
+	}
+}
+
+// TestEntityServer_WatchIndex_CreatedResponseNotProgress proves the initial
+// etcd Created response (empty events, Created=true) is NOT forwarded as a
+// progress watermark. Its header revision is the current store revision, but it
+// arrives BEFORE the historical backlog replays — forwarding it would advance a
+// resuming client's cursor past events it has not yet seen, re-opening the very
+// gap this abstraction closes (bug 1b). etcd's own IsProgressNotify() excludes
+// Created for exactly this reason.
+func TestEntityServer_WatchIndex_CreatedResponseNotProgress(t *testing.T) {
+	r := require.New(t)
+
+	store, sc, watchCh := watchIndexServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	index := entity.Keyword(entity.Ident, "test/index")
+
+	_, err := store.CreateEntity(ctx, entity.New(entity.Ref(entity.DBId, "widget-1"), index))
+	r.NoError(err)
+
+	gotOps := make(chan *v1alpha.EntityOp, 16)
+	go func() {
+		// A resuming client (from_revision>0) is the one that would be harmed by a
+		// spurious progress watermark, so assert against it directly.
+		_, _ = sc.WatchIndex(ctx, index, 5, stream.Callback(func(op *v1alpha.EntityOp) error {
+			gotOps <- op
+			return nil
+		}))
+	}()
+
+	// The Created confirmation carries the current revision but no backlog yet.
+	watchCh <- clientv3.WatchResponse{Created: true, Header: etcdserverpb.ResponseHeader{Revision: 100}}
+	// Then the first replayed change.
+	watchCh <- putResponse("widget-1", 6)
+
+	select {
+	case op := <-gotOps:
+		r.Equal(int64(v1alpha.EntityOperationCreate), op.Operation(),
+			"Created response must not be forwarded as a progress watermark")
+		r.Equal(int64(6), op.Revision())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for op")
+	}
 }

--- a/servers/entityserver/entityserver_test.go
+++ b/servers/entityserver/entityserver_test.go
@@ -216,7 +216,7 @@ func TestEntityServer_WatchIndex(t *testing.T) {
 
 	// Start watch in background
 	go func() {
-		_, err := sc.WatchIndex(ctx, index, stream.Callback(func(op *v1alpha.EntityOp) error {
+		_, err := sc.WatchIndex(ctx, index, 0, stream.Callback(func(op *v1alpha.EntityOp) error {
 			r.NotNil(op)
 			r.Equal(int64(v1alpha.EntityOperationCreate), op.Operation())
 			r.True(op.HasEntity())
@@ -364,7 +364,7 @@ func TestEntityServer_WatchIndex_DeleteIncludesEntity(t *testing.T) {
 
 	// Start watch in background
 	go func() {
-		_, err := sc.WatchIndex(ctx, index, stream.Callback(func(op *v1alpha.EntityOp) error {
+		_, err := sc.WatchIndex(ctx, index, 0, stream.Callback(func(op *v1alpha.EntityOp) error {
 			if op.Operation() == int64(v1alpha.EntityOperationDelete) {
 				deleteReceived <- op
 			}
@@ -499,7 +499,7 @@ func TestEntityServer_WatchIndex_DeleteIncludesEntity_Etcd(t *testing.T) {
 	watchDone := make(chan error, 1)
 
 	go func() {
-		_, err := sc.WatchIndex(ctx, index, stream.Callback(func(op *v1alpha.EntityOp) error {
+		_, err := sc.WatchIndex(ctx, index, 0, stream.Callback(func(op *v1alpha.EntityOp) error {
 			if op.Operation() == int64(v1alpha.EntityOperationDelete) {
 				deleteReceived <- op
 			}


### PR DESCRIPTION
## Problem

Many processes use `WatchIndex` to react to entity changes, but the watch starts "from now" and can stop at any time (etcd errors, RPC disconnects, server restarts). Several consumers don't re-watch, and even those that do **silently lose every change that happens while the watch is down** — a class of latent timebombs (`components/ipalloc` was a one-shot with no recovery at all).

## What this adds

A self-healing client-side abstraction, **`pkg/entity/indexwatch`**, that watches correctly *and* reconciles the gap between watch requests — built on etcd's native revision-resume so it holds only **O(1) state** (a revision cursor), not a copy of the index.

```
start / post-compaction:  List → EventSync (full set) + cursor = list.revision
steady state:             watch WithRev(cursor+1) + WithProgressNotify
                            put/delete → Added/Updated/Deleted, cursor = ModRev
                            progress watermark → advance cursor
transient disconnect:     re-watch WithRev(cursor+1)   ← gap-free replay, no re-list
compacted (cursor stale): List again → new EventSync    ← only re-snapshot path
```

The initial sync and any post-compaction re-sync are delivered as a **single `EventSync`** carrying the complete current set; consumers reconcile it in their own domain (replace cache, treat absent ids as removed) — the list-reconcile work these consumers already do. Live changes arrive as `EventAdded`/`EventUpdated`/`EventDeleted`.

### Server/store plumbing
- `rpc.yml`: `EntityOp.revision`, `watch_index.from_revision`, `list.revision` (regenerated)
- `store.WatchIndex(fromRev)` uses `clientv3.WithRev` + `WithProgressNotify`; new `ListIndexRevision` surfaces the snapshot revision
- server emits per-event `ModRevision`, progress watermarks, and a distinct compaction signal (`EntityOperationProgress` / `EntityOperationCompacted`)

### Consumer migration
- **`components/ipalloc`** migrated to the watcher, killing its one-shot watch that silently stopped allocating IPs if the watch ever ended (and fixing a latent gap where pre-existing IP-less services never got addresses).
- **`pkg/dns`** sandbox watch migrated; the initial `EventSync` is processed synchronously so DNS is warm before `Watch` returns, and a snapshot sweep removes sandboxes deleted while the watch was down.
- Other direct `WatchIndex` callers pass `from_revision: 0` ("from now"), so existing behavior is preserved.

## Testing
- 7 `indexwatch` unit tests (initial sync, live events, **resume-without-resnapshot**, compaction, progress watermark, blocking backpressure, stop)
- 2 real-etcd store tests proving `ListIndexRevision` returns a real revision and `WithRev` replays only post-cursor events
- ipalloc + `TestServiceController/handles_service_IP_allocation` (real entity-server integration), dns (9 tests)
- Full `make test` green (4389 tests, 0 failures); `make lint` clean

## Deferred follow-ups (work unchanged today via `from_revision: 0`)
- `activator` watches — highest-risk consumer (routing/scaling hot path); its own focused unit
- `ReconcileController` — test-coupling churn
- indexwatch metrics/observability

Closes MIR-1200.