### PR TITLE
Coalesce repeated log lines in `logs -f` into a live summary

### DIFF
--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -12,6 +12,7 @@ import (
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/standard"
 	"miren.dev/runtime/pkg/rpc/stream"
+	"miren.dev/runtime/pkg/ui"
 )
 
 // normalizeSandboxID ensures the sandbox ID has the "sandbox/" prefix
@@ -171,7 +172,8 @@ func LogsSystem(ctx *Context, opts struct {
 	}
 	// When no --last and no --follow, ts is nil → server returns last 100 lines
 
-	printer := logPrinter(ctx, opts.IsJSON())
+	printer, flush := logPrinter(ctx, opts.IsJSON(), opts.Follow)
+	defer flush()
 
 	ac := app_v1alpha.LogsClient{Client: cl}
 	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
@@ -200,10 +202,12 @@ type logDispatchArgs struct {
 // dispatchLogs handles protocol negotiation and dispatches to the appropriate
 // log streaming method based on server capabilities.
 func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, args logDispatchArgs) error {
-	printer := logPrinter(ctx, args.json)
+	printer, flush := logPrinter(ctx, args.json, args.follow)
+	defer flush()
 
 	// For app queries, wrap the printer to skip system logs that may have
-	// leaked into app log storage due to entity field collisions.
+	// leaked into app log storage due to entity field collisions. The wrapper
+	// sits in front of the coalescer so filtered-out lines aren't counted.
 	if args.app != "" {
 		inner := printer
 		printer = func(l *app_v1alpha.LogEntry) {
@@ -268,16 +272,27 @@ var streamTypePrefixes = map[string]string{
 	"user-oob": "U",
 }
 
-// logPrinter returns a function that prints a log entry in either text or JSON format.
-func logPrinter(ctx *Context, jsonOutput bool) func(*app_v1alpha.LogEntry) {
+// logPrinter returns a function that prints a log entry (text or JSON) and a
+// flush function to call once the stream ends. For interactive text follow on a
+// TTY it collapses runs of repeated lines into a live-updated counter line; in
+// every other mode it prints each entry verbatim and flush is a no-op.
+func logPrinter(ctx *Context, jsonOutput, follow bool) (func(*app_v1alpha.LogEntry), func()) {
+	noop := func() {}
+
 	if jsonOutput {
 		return func(l *app_v1alpha.LogEntry) {
 			printLogEntryJSON(ctx, l)
-		}
+		}, noop
 	}
+
+	if follow && ui.IsTTY() {
+		c := newLogCoalescer(ctx)
+		return c.print, c.flush
+	}
+
 	return func(l *app_v1alpha.LogEntry) {
 		printLogEntry(ctx, l)
-	}
+	}, noop
 }
 
 // logEntryJSON is the JSON representation of a log entry.
@@ -311,7 +326,10 @@ func printLogEntryJSON(ctx *Context, l *app_v1alpha.LogEntry) {
 	ctx.Printf("%s\n", data)
 }
 
-func printLogEntry(ctx *Context, l *app_v1alpha.LogEntry) {
+// renderLogEntry returns the full display line (without a trailing newline) and
+// a signature that is identical for entries that differ only by their timestamp.
+// The signature lets callers collapse runs of repeated lines (see logCoalescer).
+func renderLogEntry(l *app_v1alpha.LogEntry) (display, signature string) {
 	prefix := ""
 	if l.HasAttributes() {
 		if shortID, ok := l.Attributes()["miren.short_id"]; ok && shortID != "" {
@@ -330,12 +348,109 @@ func printLogEntry(ctx *Context, l *app_v1alpha.LogEntry) {
 	if l.HasAttributes() {
 		attrs = formatAttributes(l.Attributes())
 	}
-	ctx.Printf("%s %s: %s%s%s\n",
-		streamTypePrefixes[l.Stream()],
+
+	stream := streamTypePrefixes[l.Stream()]
+	display = fmt.Sprintf("%s %s: %s%s%s",
+		stream,
 		standard.FromTimestamp(l.Timestamp()).Format("2006-01-02 15:04:05"),
 		prefix,
 		l.Line(),
 		attrs)
+	// Everything except the timestamp. The NUL separator keeps field boundaries
+	// unambiguous so distinct entries can't collide on a shared signature.
+	signature = stream + "\x00" + prefix + l.Line() + attrs
+	return display, signature
+}
+
+func printLogEntry(ctx *Context, l *app_v1alpha.LogEntry) {
+	display, _ := renderLogEntry(l)
+	ctx.Printf("%s\n", display)
+}
+
+// logCoalescer collapses consecutive log lines that differ only by their
+// timestamp. The first occurrence of a line is printed in full and committed;
+// subsequent identical lines are summarized by a single live-updated line
+// printed beneath it ("[ Repeated Nx over <span> ]") instead of scrolling the
+// terminal.
+//
+// It is only used for interactive --follow on a TTY; piped, JSON, and non-follow
+// output never coalesce so machine consumers see every line verbatim.
+type logCoalescer struct {
+	ctx     *Context
+	sig     string    // signature of the current run
+	count   int       // number of lines seen in the current run
+	firstTS time.Time // timestamp of the first line in the current run
+	live    bool      // a summary line is currently on screen with no trailing newline
+}
+
+func newLogCoalescer(ctx *Context) *logCoalescer {
+	return &logCoalescer{ctx: ctx}
+}
+
+func (c *logCoalescer) print(l *app_v1alpha.LogEntry) {
+	display, signature := renderLogEntry(l)
+	ts := standard.FromTimestamp(l.Timestamp())
+
+	if c.count > 0 && signature == c.sig {
+		c.count++
+		// Redraw the summary line in place beneath the repeated log line.
+		c.ctx.Printf("\r\033[K[ Repeated %dx%s ]", c.count, runSpanSuffix(c.firstTS, ts))
+		c.live = true
+		return
+	}
+
+	// Distinct line: commit any in-progress summary, then print in full.
+	if c.live {
+		c.ctx.Printf("\n")
+	}
+	c.ctx.Printf("%s\n", display)
+	c.sig = signature
+	c.count = 1
+	c.firstTS = ts
+	c.live = false
+}
+
+// runSpanSuffix returns " over <dur>" describing how long a collapsed run has
+// been repeating, or "" when the span is under a second. Timestamps are
+// truncated to the second first so the span matches the difference between the
+// second-resolution timestamps the user actually sees; bursts within one
+// displayed second show no span, keeping the summary clean.
+func runSpanSuffix(first, last time.Time) string {
+	span := last.Truncate(time.Second).Sub(first.Truncate(time.Second))
+	if span < time.Second {
+		return ""
+	}
+	return " over " + formatRunSpan(span)
+}
+
+// formatRunSpan renders a whole-second duration compactly (e.g. "14s", "1m15s",
+// "2h5m"). Input is expected to be pre-rounded to a second.
+func formatRunSpan(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		m := int(d.Minutes())
+		if s := int(d.Seconds()) % 60; s > 0 {
+			return fmt.Sprintf("%dm%ds", m, s)
+		}
+		return fmt.Sprintf("%dm", m)
+	default:
+		h := int(d.Hours())
+		if m := int(d.Minutes()) % 60; m > 0 {
+			return fmt.Sprintf("%dh%dm", h, m)
+		}
+		return fmt.Sprintf("%dh", h)
+	}
+}
+
+// flush commits a dangling summary line with a newline so the final run isn't
+// left without one. Safe to call when nothing is pending.
+func (c *logCoalescer) flush() {
+	if c.live {
+		c.ctx.Printf("\n")
+		c.live = false
+	}
 }
 
 var hiddenAttributes = map[string]bool{

--- a/cli/commands/logs_test.go
+++ b/cli/commands/logs_test.go
@@ -308,6 +308,191 @@ func TestPrintLogEntry(t *testing.T) {
 	})
 }
 
+func TestRenderLogEntry(t *testing.T) {
+	mk := func(tsec int, line string) *app_v1alpha.LogEntry {
+		e := &app_v1alpha.LogEntry{}
+		e.SetTimestamp(standard.ToTimestamp(time.Date(2026, 3, 13, 16, 30, tsec, 0, time.UTC)))
+		e.SetStream("stdout")
+		e.SetLine(line)
+		return e
+	}
+
+	t.Run("same content different timestamp shares signature", func(t *testing.T) {
+		_, sig1 := renderLogEntry(mk(11, "ping"))
+		d2, sig2 := renderLogEntry(mk(12, "ping"))
+		d1, _ := renderLogEntry(mk(11, "ping"))
+
+		if sig1 != sig2 {
+			t.Errorf("signatures should match for lines differing only by timestamp: %q vs %q", sig1, sig2)
+		}
+		if d1 == d2 {
+			t.Errorf("displays should differ when timestamps differ, both = %q", d1)
+		}
+	})
+
+	t.Run("different content produces different signature", func(t *testing.T) {
+		_, sig1 := renderLogEntry(mk(11, "ping"))
+		_, sig2 := renderLogEntry(mk(11, "pong"))
+		if sig1 == sig2 {
+			t.Errorf("signatures should differ for different content, both = %q", sig1)
+		}
+	})
+}
+
+func TestLogCoalescer(t *testing.T) {
+	mk := func(tsec int, line string) *app_v1alpha.LogEntry {
+		e := &app_v1alpha.LogEntry{}
+		e.SetTimestamp(standard.ToTimestamp(time.Date(2026, 3, 13, 16, 30, tsec, 0, time.UTC)))
+		e.SetStream("stdout")
+		e.SetLine(line)
+		return e
+	}
+
+	// Construct the coalescer directly with a buffer-backed Context, bypassing
+	// the TTY gate so the collapse logic itself is exercised.
+	newCoalescer := func(buf *bytes.Buffer) *logCoalescer {
+		ctx := &Context{Context: context.Background(), Stdout: buf}
+		return &logCoalescer{ctx: ctx}
+	}
+
+	t.Run("repeated lines collapse to one live counter", func(t *testing.T) {
+		var buf bytes.Buffer
+		c := newCoalescer(&buf)
+		for i := 0; i < 4; i++ {
+			c.print(mk(11+i, "ping"))
+		}
+		c.flush()
+
+		out := buf.String()
+		// timestamps 11..14 → final count 4, span 3s
+		if !strings.Contains(out, "[ Repeated 4x over 3s ]") {
+			t.Errorf("expected summary [ Repeated 4x over 3s ], got: %q", out)
+		}
+		if !strings.Contains(out, "\r") {
+			t.Errorf("expected at least one \\r redraw, got: %q", out)
+		}
+		// First occurrence committed once, then the summary redraws — exactly one
+		// full "ping" line is followed by summary redraws, never four full lines.
+		if strings.Count(out, "\n") != 2 {
+			t.Errorf("expected 2 newlines (first line + flushed summary), got %d: %q", strings.Count(out, "\n"), out)
+		}
+	})
+
+	t.Run("distinct line commits the counter and prints in full", func(t *testing.T) {
+		var buf bytes.Buffer
+		c := newCoalescer(&buf)
+		c.print(mk(11, "ping"))
+		c.print(mk(12, "ping"))
+		c.print(mk(13, "different"))
+		c.flush()
+
+		out := buf.String()
+		if !strings.Contains(out, "[ Repeated 2x over 1s ]") {
+			t.Errorf("expected [ Repeated 2x over 1s ] for the ping run, got: %q", out)
+		}
+		if !strings.Contains(out, "different") {
+			t.Errorf("expected the distinct line printed, got: %q", out)
+		}
+	})
+
+	t.Run("same-second repeats omit the span", func(t *testing.T) {
+		var buf bytes.Buffer
+		c := newCoalescer(&buf)
+		c.print(mk(11, "ping"))
+		c.print(mk(11, "ping"))
+		c.flush()
+
+		out := buf.String()
+		if !strings.Contains(out, "[ Repeated 2x ]") {
+			t.Errorf("expected bare [ Repeated 2x ] with no span, got: %q", out)
+		}
+		if strings.Contains(out, "over") {
+			t.Errorf("did not expect a span for a sub-second run, got: %q", out)
+		}
+	})
+
+	t.Run("single non-repeated line has no summary", func(t *testing.T) {
+		var buf bytes.Buffer
+		c := newCoalescer(&buf)
+		c.print(mk(11, "solo"))
+		c.flush()
+
+		out := buf.String()
+		if strings.Contains(out, "Repeated") {
+			t.Errorf("did not expect a summary for a single line, got: %q", out)
+		}
+		if strings.Contains(out, "\r") {
+			t.Errorf("did not expect a \\r redraw for a single line, got: %q", out)
+		}
+		if !strings.Contains(out, "solo") {
+			t.Errorf("expected the line content, got: %q", out)
+		}
+	})
+}
+
+func TestFormatRunSpan(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{1 * time.Second, "1s"},
+		{14 * time.Second, "14s"},
+		{59 * time.Second, "59s"},
+		{60 * time.Second, "1m"},
+		{75 * time.Second, "1m15s"},
+		{2 * time.Hour, "2h"},
+		{2*time.Hour + 5*time.Minute, "2h5m"},
+	}
+	for _, tt := range tests {
+		if got := formatRunSpan(tt.d); got != tt.want {
+			t.Errorf("formatRunSpan(%s) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestRunSpanSuffix(t *testing.T) {
+	base := time.Date(2026, 3, 13, 16, 30, 0, 0, time.UTC)
+
+	if got := runSpanSuffix(base, base); got != "" {
+		t.Errorf("zero span should produce no suffix, got %q", got)
+	}
+	if got := runSpanSuffix(base, base.Add(900*time.Millisecond)); got != "" {
+		t.Errorf("sub-second span should produce no suffix, got %q", got)
+	}
+	if got := runSpanSuffix(base, base.Add(14*time.Second)); got != " over 14s" {
+		t.Errorf("expected \" over 14s\", got %q", got)
+	}
+}
+
+func TestLogPrinterNonTTYNeverCoalesces(t *testing.T) {
+	// A bytes.Buffer Stdout is not a TTY, so even with follow=true the plain
+	// printer must be returned — guaranteeing piped output keeps every line.
+	var buf bytes.Buffer
+	ctx := &Context{Context: context.Background(), Stdout: &buf}
+	printer, flush := logPrinter(ctx, false, true)
+
+	ts := time.Date(2026, 3, 13, 16, 30, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		e := &app_v1alpha.LogEntry{}
+		e.SetTimestamp(standard.ToTimestamp(ts))
+		e.SetStream("stdout")
+		e.SetLine("ping")
+		printer(e)
+	}
+	flush()
+
+	out := buf.String()
+	if strings.Contains(out, "\r") {
+		t.Errorf("non-TTY output must not use \\r redraws, got: %q", out)
+	}
+	if strings.Contains(out, "Repeated") {
+		t.Errorf("non-TTY output must not collapse lines, got: %q", out)
+	}
+	if n := strings.Count(out, "ping"); n != 3 {
+		t.Errorf("expected 3 verbatim ping lines, got %d: %q", n, out)
+	}
+}
+
 func TestFormatAttributes(t *testing.T) {
 	t.Run("filters hidden attributes", func(t *testing.T) {
 		m := map[string]string{


### PR DESCRIPTION
## Summary

When following logs with `m logs -f` on an app that emits a steady stream of near-identical lines (e.g. a 1-second health/DNS ping), the terminal fills with lines that differ **only by their timestamp**, burying genuinely new output:

```
U 2026-06-04 16:58:11: [router] method=POST path="/dns-query" host=clusters.miren.garden ... duration_ms=0 ...
U 2026-06-04 16:58:12: [router] method=POST path="/dns-query" host=clusters.miren.garden ... duration_ms=0 ...
U 2026-06-04 16:58:13: [router] method=POST path="/dns-query" host=clusters.miren.garden ... duration_ms=0 ...
```

Now consecutive lines that are identical except for the timestamp collapse: the first occurrence prints in full, and a single **live-updated** line beneath it summarizes the run, redrawn in place as it continues:

```
U 2026-06-04 16:58:11: [router] method=POST path="/dns-query" host=clusters.miren.garden ... duration_ms=0 ...
[ Repeated 14x over 14s ]
```

## Details

- `renderLogEntry` splits a log entry into its full display string and a timestamp-independent **signature**; consecutive entries with the same signature are treated as a run.
- `logCoalescer` prints the first occurrence in full, then redraws `[ Repeated Nx over <span> ]` in place (`\r\033[K`) for each repeat. A distinct line commits the summary with a newline and prints below it.
- The span is computed from second-truncated timestamps so it matches what the user sees; sub-second bursts (multiple lines in one displayed second) show a bare `[ Repeated Nx ]`.
- **Coalescing engages only for text + `--follow` + TTY.** JSON (`--format json`), piped, and non-follow output emit every line verbatim, so machine consumers and `grep` are unaffected. Wired in via the `logPrinter` factory, which now also returns a `flush` to commit a dangling summary when the stream ends.

## Testing

- New unit tests: `TestRenderLogEntry`, `TestLogCoalescer` (collapse / distinct-line commit / single line / same-second), `TestFormatRunSpan`, `TestRunSpanSuffix`, and `TestLogPrinterNonTTYNeverCoalesces` (guards the machine-output contract).
- Full `cli/commands` package: **234 tests pass**.
- `make lint`: 0 issues.

Closes MIR-1221.


https://github.com/user-attachments/assets/51525b1b-004b-4516-8321-3b71fc431505

