### PR TITLE
dev-exec: respect ISO_SESSION override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@
 # Disable telemetry
 export DO_NOT_TRACK=1
 
-# Generate a unique session name based on the project directory
+# Generate a unique session name based on the project directory.
+# Exported so recipes that shell out to hack/dev-exec target the same
+# session, including when ISO_SESSION is overridden from the environment.
 ISO_SESSION ?= dev-$(shell basename "$$(pwd)")
+export ISO_SESSION
 
 # Extract git info on the host for passing to container builds
 # These handle both regular repos and worktrees

--- a/hack/dev-exec
+++ b/hack/dev-exec
@@ -8,8 +8,9 @@
 #   ./hack/dev-exec --root bash hack/dev-server start  # Run as root
 #
 # This script executes commands in the persistent dev container created by
-# `make dev`. The session name is automatically derived from the current
-# directory, ensuring each worktree has its own isolated dev environment.
+# `make dev`. The session name comes from ISO_SESSION when set (matching the
+# Makefile's `ISO_SESSION ?=` override), falling back to one derived from the
+# current directory, so each worktree gets its own isolated dev environment.
 
 set -e
 
@@ -30,8 +31,11 @@ if [ ! -d ".iso" ]; then
   exit 1
 fi
 
-# Generate session name based on current directory
-SESSION="dev-$(basename "$(pwd)")"
+# Respect an ISO_SESSION override, falling back to the directory-derived name.
+# Without this, `ISO_SESSION=... make dev` and dev-exec disagree about which
+# container to target — and basename collisions (e.g. two checkouts both named
+# "runtime") silently cross-wire dev environments anyway.
+SESSION="${ISO_SESSION:-dev-$(basename "$(pwd)")}"
 
 # Check if the dev environment is running by checking iso status output
 STATUS_OUTPUT=$(ISO_SESSION="$SESSION" iso status --session "$SESSION" 2>&1)


### PR DESCRIPTION
Found this while untangling why a dev environment was showing stale code. The Makefile has always let you override `ISO_SESSION` (it's declared with `?=`), but `hack/dev-exec` computed its own session name from the directory basename, full stop. So with an override in play, `make dev` starts a container under your name while every dev-exec-based target quietly targets `dev-<basename>` instead. And since iso reported that container as running (it belonged to my main checkout), dev-exec happily execed into it: wrong tree, wrong binaries, no error.

The same basename derivation also means two checkouts whose directories share a name silently cross-wire even without an override, which is how I actually hit this: a workspace checkout and my main checkout were both named `runtime`, and the workspace's `make dev` attached me to the main checkout's two-week-old container.

Two small changes: dev-exec now respects `ISO_SESSION` when set, falling back to the same directory-derived default as before, and the Makefile exports the variable so recipes that shell out to dev-exec stay on the same session as the rest of the Makefile. Nothing changes for anyone who doesn't set the variable.