### PR TITLE
Fix staticcheck SA5011 nil pointer warnings in registration_test.go

### DIFF
--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -74,6 +74,7 @@ func issueLeafCert(t *testing.T, ca *caauth.Authority, commonName, org string, i
 	block, _ := pem.Decode(cc.CertPEM)
 	if block == nil {
 		t.Fatal("failed to decode issued cert PEM")
+		return nil
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
@@ -562,6 +563,7 @@ func (e *testEnv) joinRunner(t *testing.T, ctx context.Context, listenAddr, name
 	block, _ := pem.Decode(res.CertPem())
 	if block == nil {
 		t.Fatal("failed to decode join cert PEM")
+		return nil, ""
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
@@ -591,6 +593,7 @@ func TestReissueRunnerCertificate(t *testing.T) {
 		block, _ := pem.Decode(cc.CertPEM)
 		if block == nil {
 			t.Fatal("failed to decode re-issued cert PEM")
+			return
 		}
 		newCert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {


### PR DESCRIPTION
## Summary

`servers/runner/registration_test.go` had three `SA5011` (possible nil pointer dereference) staticcheck warnings on `main` that fail the lint job on every PR (spotted while CI ran on #850).

Three blocks followed the pattern `if block == nil { t.Fatal(...) }` and then dereferenced `block.Bytes`. Staticcheck doesn't treat the `t.Fatal` path as terminating, so it flagged a possible nil dereference. The already-correct block at lines 203–207 proves the fix: it has an explicit `return` after `t.Fatal`, which is why it was never flagged.

## Changes

All in `servers/runner/registration_test.go`, matching the existing pattern:

- `issueLeafCert` (returns `*x509.Certificate`) → `return nil`
- `joinRunner` (returns `(*x509.Certificate, string)`) → `return nil, ""`
- `TestReissueRunnerCertificate` subtest closure (no return value) → bare `return`

The new `return`s are unreachable (they sit after `t.Fatal`, which never returns), so test behavior is unchanged — this is pure lint hygiene.

## Verification

- `make lint` → **0 issues** (down from 3 SA5011 warnings)

Fixes MIR-1233.