### PR TITLE
Default workload identity JWKS to RS256, support multiple live keys

### DIFF
--- a/controllers/sandbox/token_server_test.go
+++ b/controllers/sandbox/token_server_test.go
@@ -71,6 +71,7 @@ func TestTokenServer_DefaultToken(t *testing.T) {
 	require.NotEmpty(t, resp.Value)
 
 	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		assert.Equal(t, "RS256", tok.Method.Alg())
 		return c.WorkloadIssuer.(*workloadidentity.Issuer).PublicKey(), nil
 	})
 	require.NoError(t, err)
@@ -95,6 +96,7 @@ func TestTokenServer_CustomAudience(t *testing.T) {
 	require.NoError(t, err)
 
 	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		assert.Equal(t, "RS256", tok.Method.Alg())
 		return c.WorkloadIssuer.(*workloadidentity.Issuer).PublicKey(), nil
 	}, jwt.WithAudience("sts.amazonaws.com"))
 	require.NoError(t, err)
@@ -116,6 +118,7 @@ func TestTokenServer_CustomTTL(t *testing.T) {
 	require.NoError(t, err)
 
 	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		assert.Equal(t, "RS256", tok.Method.Alg())
 		return c.WorkloadIssuer.(*workloadidentity.Issuer).PublicKey(), nil
 	})
 	require.NoError(t, err)

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -29,7 +29,9 @@ package workloadidentity
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/url"
 	"os"
@@ -106,12 +108,22 @@ func NewIssuer(cfg IssuerConfig) (*Issuer, error) {
 	// the operator moves workload-identity.key → workload-identity.key.prev
 	// and restarts. The EdDSA→RS256 migration in loadOrGenerateKey uses the same
 	// .prev slot. The old key is published (verify-only) in JWKS so tokens signed
-	// by it remain verifiable until they expire.
+	// by it remain verifiable until they expire. A present-but-broken .prev is a
+	// startup failure: silently dropping it would break verification overlap for
+	// already-issued tokens with no operator signal.
 	prevPath := keyPath + ".prev"
-	if prevData, err := os.ReadFile(prevPath); err == nil {
-		if prevKP, err := loadSigningKeyFromPEM(string(prevData)); err == nil {
-			iss.advertised = append(iss.advertised, jwkForPublic(prevKP.public, prevKP.kid))
+	prevData, err := os.ReadFile(prevPath)
+	switch {
+	case err == nil:
+		prevKP, err := loadSigningKeyFromPEM(string(prevData))
+		if err != nil {
+			return nil, fmt.Errorf("loading previous signing key %s: %w", prevPath, err)
 		}
+		iss.advertised = append(iss.advertised, jwkForPublic(prevKP.public, prevKP.kid))
+	case errors.Is(err, fs.ErrNotExist):
+		// No previous key; nothing to advertise.
+	default:
+		return nil, fmt.Errorf("reading previous signing key %s: %w", prevPath, err)
 	}
 
 	// Load additional live keys from the workload-identity.d directory (a sibling
@@ -132,7 +144,7 @@ func NewIssuer(cfg IssuerConfig) (*Issuer, error) {
 func loadLiveKeysDir(dir string) []*signingKey {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			slog.Warn("reading workload identity keys directory", "dir", dir, "error", err)
 		}
 		return nil
@@ -303,7 +315,18 @@ func loadOrGenerateKey(keyPath string) (*signingKey, error) {
 		// advertised in JWKS for verification. Demote it into the .prev slot
 		// (picked up by the rotation-overlap loading in NewIssuer) and generate a
 		// fresh RS256 key as the active signing key.
-		if err := os.Rename(keyPath, keyPath+".prev"); err != nil {
+		//
+		// Refuse to overwrite an existing .prev: os.Rename clobbers silently on
+		// most filesystems, which would discard a key still needed to verify
+		// in-flight tokens (e.g. from a prior manual rotation). Require the
+		// operator to clear it first.
+		prevPath := keyPath + ".prev"
+		if _, statErr := os.Stat(prevPath); statErr == nil {
+			return nil, fmt.Errorf("demoting legacy EdDSA key: %s already exists; remove it manually before migrating", prevPath)
+		} else if !errors.Is(statErr, fs.ErrNotExist) {
+			return nil, fmt.Errorf("checking for existing previous key %s: %w", prevPath, statErr)
+		}
+		if err := os.Rename(keyPath, prevPath); err != nil {
 			return nil, fmt.Errorf("demoting legacy EdDSA key: %w", err)
 		}
 		slog.Info("migrated workload identity signing key from EdDSA to RS256; old key retained in JWKS for verification",
@@ -311,7 +334,7 @@ func loadOrGenerateKey(keyPath string) (*signingKey, error) {
 		return generateAndWriteKey(keyPath)
 	}
 
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, fs.ErrNotExist) {
 		return nil, fmt.Errorf("reading key file: %w", err)
 	}
 

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -3,8 +3,11 @@
 //
 // # Trust Model
 //
-// Each cluster is its own OIDC issuer with an independent Ed25519 signing key
-// and JWKS endpoint. Miren Cloud is not in the trust path — it only contributes
+// Each cluster is its own OIDC issuer with an independent signing key and JWKS
+// endpoint. New clusters sign with RS256 (RSA), the universally supported
+// default; clusters provisioned before that default keep their EdDSA key
+// advertised in JWKS for verification while new tokens are signed with a freshly
+// generated RS256 key. Miren Cloud is not in the trust path — it only contributes
 // organization_id and cluster_id as claim metadata during registration. This
 // per-cluster model means external verifiers (e.g., AWS IAM OIDC) must
 // configure trust per cluster rather than once for all of Miren. A future
@@ -25,11 +28,9 @@
 package workloadidentity
 
 import (
-	"crypto/ed25519"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -39,8 +40,6 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
-
-	"miren.dev/runtime/pkg/cloudauth"
 )
 
 type IssuerConfig struct {
@@ -51,13 +50,20 @@ type IssuerConfig struct {
 }
 
 type Issuer struct {
-	privateKey     ed25519.PrivateKey
-	publicKey      ed25519.PublicKey
-	kid            string
+	// primary is the default signing key. All issued tokens are signed with it.
+	primary *signingKey
+	// keys are the live signing keys: primary first, then any keys loaded from
+	// the workload-identity.d directory. All are published in JWKS. Holding
+	// several supports key rotation (stage and publish a new key before cutting
+	// over) and multiple key types live at once.
+	keys []*signingKey
+	// advertised holds additional public keys published in JWKS for
+	// verification only (e.g. a rotated-out previous key, or a legacy EdDSA key
+	// retained after migrating signing to RS256).
+	advertised     []jose.JSONWebKey
 	issuerURL      string
 	organizationID string
 	clusterID      string
-	previousKey    *jose.JSONWebKey
 }
 
 // TokenIssuer is the minting surface the sandbox controller depends on. The
@@ -83,17 +89,14 @@ type WorkloadClaims struct {
 func NewIssuer(cfg IssuerConfig) (*Issuer, error) {
 	keyPath := filepath.Join(cfg.DataPath, "server", "workload-identity.key")
 
-	kp, err := loadOrGenerateKey(keyPath)
+	primary, err := loadOrGenerateKey(keyPath)
 	if err != nil {
 		return nil, fmt.Errorf("workload identity key: %w", err)
 	}
 
-	kid := computeKID(kp.PublicKey)
-
 	iss := &Issuer{
-		privateKey:     kp.PrivateKey,
-		publicKey:      kp.PublicKey,
-		kid:            kid,
+		primary:        primary,
+		keys:           []*signingKey{primary},
 		issuerURL:      cfg.IssuerURL,
 		organizationID: cfg.OrganizationID,
 		clusterID:      cfg.ClusterID,
@@ -101,22 +104,59 @@ func NewIssuer(cfg IssuerConfig) (*Issuer, error) {
 
 	// Load previous signing key for rotation overlap. During key rotation,
 	// the operator moves workload-identity.key → workload-identity.key.prev
-	// and restarts. Both keys are published in JWKS so tokens signed by the
-	// old key remain verifiable until they expire.
+	// and restarts. The EdDSA→RS256 migration in loadOrGenerateKey uses the same
+	// .prev slot. The old key is published (verify-only) in JWKS so tokens signed
+	// by it remain verifiable until they expire.
 	prevPath := keyPath + ".prev"
 	if prevData, err := os.ReadFile(prevPath); err == nil {
-		if prevKP, err := cloudauth.LoadKeyPairFromPEM(string(prevData)); err == nil {
-			prevKID := computeKID(prevKP.PublicKey)
-			iss.previousKey = &jose.JSONWebKey{
-				Key:       prevKP.PublicKey,
-				KeyID:     prevKID,
-				Algorithm: "EdDSA",
-				Use:       "sig",
-			}
+		if prevKP, err := loadSigningKeyFromPEM(string(prevData)); err == nil {
+			iss.advertised = append(iss.advertised, jwkForPublic(prevKP.public, prevKP.kid))
 		}
 	}
 
+	// Load additional live keys from the workload-identity.d directory (a sibling
+	// of the primary key file). Each key there is sign-capable and published in
+	// JWKS, enabling key rotation and multiple key types to coexist. A missing
+	// directory is normal; a malformed key is logged and skipped rather than
+	// failing startup.
+	keysDir := filepath.Join(filepath.Dir(keyPath), "workload-identity.d")
+	iss.keys = append(iss.keys, loadLiveKeysDir(keysDir)...)
+
 	return iss, nil
+}
+
+// loadLiveKeysDir loads every key file in dir as a live signing key. Directory
+// entries are returned by os.ReadDir sorted by name (deterministic). Directories
+// and dotfiles are skipped; unreadable or unparseable files are logged and
+// skipped.
+func loadLiveKeysDir(dir string) []*signingKey {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("reading workload identity keys directory", "dir", dir, "error", err)
+		}
+		return nil
+	}
+
+	var keys []*signingKey
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			slog.Warn("reading workload identity key", "path", path, "error", err)
+			continue
+		}
+		kp, err := loadSigningKeyFromPEM(string(data))
+		if err != nil {
+			slog.Warn("parsing workload identity key", "path", path, "error", err)
+			continue
+		}
+		keys = append(keys, kp)
+	}
+	return keys
 }
 
 func (iss *Issuer) IssuerURL() string {
@@ -124,7 +164,7 @@ func (iss *Issuer) IssuerURL() string {
 }
 
 func (iss *Issuer) PublicKey() any {
-	return iss.publicKey
+	return iss.primary.public
 }
 
 func (iss *Issuer) Hostname() string {
@@ -187,10 +227,10 @@ func (iss *Issuer) IssueTokenWithOptions(app, sandboxID string, opts TokenOption
 		SandboxID:      sandboxID,
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
-	token.Header["kid"] = iss.kid
+	token := jwt.NewWithClaims(iss.primary.method, claims)
+	token.Header["kid"] = iss.primary.kid
 
-	return token.SignedString(iss.privateKey)
+	return token.SignedString(iss.primary.private)
 }
 
 func (iss *Issuer) DiscoveryDocument() []byte {
@@ -199,45 +239,93 @@ func (iss *Issuer) DiscoveryDocument() []byte {
 		"jwks_uri":                              iss.issuerURL + "/.well-known/miren/jwks",
 		"response_types_supported":              []string{"id_token"},
 		"subject_types_supported":               []string{"public"},
-		"id_token_signing_alg_values_supported": []string{"EdDSA"},
+		"id_token_signing_alg_values_supported": iss.supportedAlgs(),
 	}
 
 	data, _ := json.Marshal(doc)
 	return data
 }
 
-func (iss *Issuer) JWKSDocument() ([]byte, error) {
-	jwk := jose.JSONWebKey{
-		Key:       iss.publicKey,
-		KeyID:     iss.kid,
-		Algorithm: "EdDSA",
-		Use:       "sig",
+// supportedAlgs returns the distinct JWA algorithms across the live signing keys
+// and any advertised keys, preserving primary-first order.
+func (iss *Issuer) supportedAlgs() []string {
+	seen := map[string]bool{}
+	var algs []string
+	add := func(alg string) {
+		if alg != "" && !seen[alg] {
+			seen[alg] = true
+			algs = append(algs, alg)
+		}
 	}
 
-	keys := []jose.JSONWebKey{jwk}
-	if iss.previousKey != nil {
-		keys = append(keys, *iss.previousKey)
+	for _, k := range iss.keys {
+		add(k.alg)
+	}
+	for _, jwk := range iss.advertised {
+		add(jwk.Algorithm)
+	}
+	return algs
+}
+
+func (iss *Issuer) JWKSDocument() ([]byte, error) {
+	seen := map[string]bool{}
+	var keys []jose.JSONWebKey
+	add := func(jwk jose.JSONWebKey) {
+		if jwk.KeyID == "" || seen[jwk.KeyID] {
+			return
+		}
+		seen[jwk.KeyID] = true
+		keys = append(keys, jwk)
+	}
+
+	for _, k := range iss.keys {
+		add(jwkForPublic(k.public, k.kid))
+	}
+	for _, jwk := range iss.advertised {
+		add(jwk)
 	}
 
 	return json.Marshal(jose.JSONWebKeySet{Keys: keys})
 }
 
-func loadOrGenerateKey(keyPath string) (*cloudauth.KeyPair, error) {
+func loadOrGenerateKey(keyPath string) (*signingKey, error) {
 	data, err := os.ReadFile(keyPath)
 	if err == nil {
-		return cloudauth.LoadKeyPairFromPEM(string(data))
+		kp, err := loadSigningKeyFromPEM(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("loading key file: %w", err)
+		}
+		if kp.alg != "EdDSA" {
+			return kp, nil
+		}
+
+		// Legacy EdDSA key: migrate signing to RS256 while keeping the EdDSA key
+		// advertised in JWKS for verification. Demote it into the .prev slot
+		// (picked up by the rotation-overlap loading in NewIssuer) and generate a
+		// fresh RS256 key as the active signing key.
+		if err := os.Rename(keyPath, keyPath+".prev"); err != nil {
+			return nil, fmt.Errorf("demoting legacy EdDSA key: %w", err)
+		}
+		slog.Info("migrated workload identity signing key from EdDSA to RS256; old key retained in JWKS for verification",
+			"key", keyPath)
+		return generateAndWriteKey(keyPath)
 	}
 
 	if !os.IsNotExist(err) {
 		return nil, fmt.Errorf("reading key file: %w", err)
 	}
 
-	kp, err := cloudauth.GenerateKeyPair()
+	return generateAndWriteKey(keyPath)
+}
+
+// generateAndWriteKey creates a new RS256 signing key and persists it to keyPath.
+func generateAndWriteKey(keyPath string) (*signingKey, error) {
+	kp, err := generateSigningKey()
 	if err != nil {
 		return nil, err
 	}
 
-	pemData, err := kp.PrivateKeyPEM()
+	pemData, err := kp.privateKeyPEM()
 	if err != nil {
 		return nil, fmt.Errorf("encoding private key: %w", err)
 	}
@@ -251,11 +339,6 @@ func loadOrGenerateKey(keyPath string) (*cloudauth.KeyPair, error) {
 	}
 
 	return kp, nil
-}
-
-func computeKID(pub ed25519.PublicKey) string {
-	hash := sha256.Sum256(pub)
-	return base64.RawURLEncoding.EncodeToString(hash[:])
 }
 
 func buildSubject(orgID, app, sandboxID string) string {

--- a/pkg/workloadidentity/issuer_test.go
+++ b/pkg/workloadidentity/issuer_test.go
@@ -534,3 +534,40 @@ func TestNewIssuer_SkipsUnparseableDirectoryKey(t *testing.T) {
 	require.NotEmpty(t, jwks.Key(iss.primary.kid))
 	require.NotEmpty(t, jwks.Key(goodKID))
 }
+
+func TestNewIssuer_MigrationRefusesToClobberPrev(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "server", "workload-identity.key")
+	writeLegacyEdDSAKey(t, keyPath)
+	// A pre-existing .prev (e.g. from a prior manual rotation) must not be
+	// silently overwritten by the EdDSA→RS256 migration.
+	require.NoError(t, os.WriteFile(keyPath+".prev", []byte("existing prev key"), 0600))
+
+	_, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+
+	// The legacy primary and the existing .prev are left untouched.
+	assert.FileExists(t, keyPath)
+	prevData, readErr := os.ReadFile(keyPath + ".prev")
+	require.NoError(t, readErr)
+	assert.Equal(t, "existing prev key", string(prevData))
+}
+
+func TestNewIssuer_FailsOnBrokenPrev(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "server", "workload-identity.key")
+	require.NoError(t, os.MkdirAll(filepath.Dir(keyPath), 0700))
+	// A present-but-unparseable .prev must fail startup, not be silently dropped.
+	require.NoError(t, os.WriteFile(keyPath+".prev", []byte("not a pem key"), 0600))
+
+	_, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "previous signing key")
+}

--- a/pkg/workloadidentity/issuer_test.go
+++ b/pkg/workloadidentity/issuer_test.go
@@ -1,8 +1,13 @@
 package workloadidentity
 
 import (
+	"crypto"
 	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +32,7 @@ func TestNewIssuer_GeneratesKey(t *testing.T) {
 	require.NotNil(t, iss)
 
 	assert.Equal(t, "https://example.miren.cloud", iss.IssuerURL())
-	assert.NotEmpty(t, iss.kid)
+	assert.NotEmpty(t, iss.primary.kid)
 
 	// Key file should exist
 	keyPath := filepath.Join(dir, "server", "workload-identity.key")
@@ -51,8 +56,8 @@ func TestNewIssuer_LoadsExistingKey(t *testing.T) {
 	require.NoError(t, err)
 
 	// Same key should produce same kid
-	assert.Equal(t, iss1.kid, iss2.kid)
-	assert.Equal(t, iss1.publicKey, iss2.publicKey)
+	assert.Equal(t, iss1.primary.kid, iss2.primary.kid)
+	assert.Equal(t, iss1.primary.public, iss2.primary.public)
 }
 
 func TestIssueToken(t *testing.T) {
@@ -72,9 +77,9 @@ func TestIssueToken(t *testing.T) {
 
 	// Parse and verify the token
 	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
-		assert.Equal(t, jwt.SigningMethodEdDSA, tok.Method)
-		assert.Equal(t, iss.kid, tok.Header["kid"])
-		return iss.publicKey, nil
+		assert.Equal(t, jwt.SigningMethodRS256, tok.Method)
+		assert.Equal(t, iss.primary.kid, tok.Header["kid"])
+		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
 	require.True(t, token.Valid)
@@ -104,7 +109,7 @@ func TestIssueToken_NoOrg(t *testing.T) {
 	require.NoError(t, err)
 
 	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
-		return iss.publicKey, nil
+		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
 
@@ -127,7 +132,7 @@ func TestIssueToken_NoApp(t *testing.T) {
 	require.NoError(t, err)
 
 	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
-		return iss.publicKey, nil
+		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
 
@@ -152,7 +157,7 @@ func TestDiscoveryDocument(t *testing.T) {
 
 	assert.Equal(t, "https://example.miren.cloud", parsed["issuer"])
 	assert.Equal(t, "https://example.miren.cloud/.well-known/miren/jwks", parsed["jwks_uri"])
-	assert.Contains(t, parsed["id_token_signing_alg_values_supported"], "EdDSA")
+	assert.Contains(t, parsed["id_token_signing_alg_values_supported"], "RS256")
 }
 
 func TestJWKSDocument(t *testing.T) {
@@ -172,14 +177,14 @@ func TestJWKSDocument(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, jwks.Keys, 1)
-	assert.Equal(t, iss.kid, jwks.Keys[0].KeyID)
-	assert.Equal(t, "EdDSA", jwks.Keys[0].Algorithm)
+	assert.Equal(t, iss.primary.kid, jwks.Keys[0].KeyID)
+	assert.Equal(t, "RS256", jwks.Keys[0].Algorithm)
 	assert.Equal(t, "sig", jwks.Keys[0].Use)
 
 	// The key should be usable to verify tokens
-	pubKey, ok := jwks.Keys[0].Key.(ed25519.PublicKey)
+	pubKey, ok := jwks.Keys[0].Key.(*rsa.PublicKey)
 	require.True(t, ok)
-	assert.Equal(t, iss.publicKey, pubKey)
+	assert.Equal(t, iss.primary.public, pubKey)
 }
 
 func TestJWKSDocument_WithPreviousKey(t *testing.T) {
@@ -191,7 +196,7 @@ func TestJWKSDocument_WithPreviousKey(t *testing.T) {
 		IssuerURL: "https://example.miren.cloud",
 	})
 	require.NoError(t, err)
-	oldKID := iss1.kid
+	oldKID := iss1.primary.kid
 
 	// Simulate key rotation: move current key to .prev
 	keyPath := filepath.Join(dir, "server", "workload-identity.key")
@@ -204,8 +209,8 @@ func TestJWKSDocument_WithPreviousKey(t *testing.T) {
 		IssuerURL: "https://example.miren.cloud",
 	})
 	require.NoError(t, err)
-	assert.NotEqual(t, oldKID, iss2.kid)
-	require.NotNil(t, iss2.previousKey)
+	assert.NotEqual(t, oldKID, iss2.primary.kid)
+	require.NotEmpty(t, iss2.advertised)
 
 	// JWKS should contain both keys
 	data, err := iss2.JWKSDocument()
@@ -216,7 +221,7 @@ func TestJWKSDocument_WithPreviousKey(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, jwks.Keys, 2)
-	assert.Equal(t, iss2.kid, jwks.Keys[0].KeyID)
+	assert.Equal(t, iss2.primary.kid, jwks.Keys[0].KeyID)
 	assert.Equal(t, oldKID, jwks.Keys[1].KeyID)
 
 	// Token signed by the new key should be verifiable via JWKS
@@ -259,7 +264,7 @@ func TestIssueTokenWithOptions_CustomAudience(t *testing.T) {
 	require.NoError(t, err)
 
 	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
-		return iss.publicKey, nil
+		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
 
@@ -282,7 +287,7 @@ func TestIssueTokenWithOptions_CustomTTL(t *testing.T) {
 	require.NoError(t, err)
 
 	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
-		return iss.publicKey, nil
+		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
 
@@ -308,7 +313,7 @@ func TestIssueTokenWithOptions_TTLClamping(t *testing.T) {
 	require.NoError(t, err)
 
 	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
-		return iss.publicKey, nil
+		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
 
@@ -324,7 +329,7 @@ func TestIssueTokenWithOptions_TTLClamping(t *testing.T) {
 	require.NoError(t, err)
 
 	token2, err := jwt.ParseWithClaims(tokenStr2, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
-		return iss.publicKey, nil
+		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
 
@@ -350,4 +355,182 @@ func TestBuildSubject(t *testing.T) {
 			assert.Equal(t, tt.expected, buildSubject(tt.org, tt.app, tt.sandbox))
 		})
 	}
+}
+
+// writeLegacyEdDSAKey writes a PKCS#8 PEM Ed25519 private key to keyPath,
+// emulating a cluster provisioned before the RS256 default. Returns the public
+// key for assertions.
+func writeLegacyEdDSAKey(t *testing.T, keyPath string) ed25519.PublicKey {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	pemData := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(keyPath), 0700))
+	require.NoError(t, os.WriteFile(keyPath, pemData, 0600))
+
+	return pub
+}
+
+func TestNewIssuer_MigratesLegacyEdDSAKey(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "server", "workload-identity.key")
+	edPub := writeLegacyEdDSAKey(t, keyPath)
+	edKID := computeKID(edPub)
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	// Active signing key is now RS256, not the legacy EdDSA key.
+	assert.Equal(t, "RS256", iss.primary.alg)
+	_, ok := iss.primary.public.(*rsa.PublicKey)
+	require.True(t, ok)
+	assert.NotEqual(t, edKID, iss.primary.kid)
+
+	// The legacy EdDSA key was demoted to the .prev slot.
+	_, err = os.Stat(keyPath + ".prev")
+	require.NoError(t, err)
+
+	// Newly minted tokens are signed with RS256.
+	tokenStr, err := iss.IssueToken("myapp", "sandbox-1")
+	require.NoError(t, err)
+	parsed, _, err := jwt.NewParser().ParseUnverified(tokenStr, &WorkloadClaims{})
+	require.NoError(t, err)
+	assert.Equal(t, "RS256", parsed.Header["alg"])
+	assert.Equal(t, iss.primary.kid, parsed.Header["kid"])
+
+	// JWKS advertises both the active RS256 key and the legacy EdDSA key, the
+	// latter keeping its original kid so already-issued tokens still verify.
+	data, err := iss.JWKSDocument()
+	require.NoError(t, err)
+	var jwks jose.JSONWebKeySet
+	require.NoError(t, json.Unmarshal(data, &jwks))
+	require.Len(t, jwks.Keys, 2)
+
+	assert.Equal(t, iss.primary.kid, jwks.Keys[0].KeyID)
+	assert.Equal(t, "RS256", jwks.Keys[0].Algorithm)
+
+	assert.Equal(t, edKID, jwks.Keys[1].KeyID)
+	assert.Equal(t, "EdDSA", jwks.Keys[1].Algorithm)
+	advPub, ok := jwks.Keys[1].Key.(ed25519.PublicKey)
+	require.True(t, ok)
+	assert.Equal(t, edPub, advPub)
+
+	// Discovery advertises both algorithms, RS256 first.
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(iss.DiscoveryDocument(), &doc))
+	assert.Equal(t, []any{"RS256", "EdDSA"}, doc["id_token_signing_alg_values_supported"])
+
+	// The freshly minted token verifies under the active RS256 JWK.
+	_, err = jwt.Parse(tokenStr, func(tok *jwt.Token) (interface{}, error) {
+		return jwks.Key(tok.Header["kid"].(string))[0].Key, nil
+	})
+	require.NoError(t, err)
+}
+
+// writeKeyFile generates a signing key of the given algorithm ("RS256" or
+// "EdDSA"), writes it as PKCS#8 PEM to path, and returns its kid.
+func writeKeyFile(t *testing.T, path, alg string) string {
+	t.Helper()
+
+	var priv crypto.Signer
+	switch alg {
+	case "RS256":
+		k, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		priv = k
+	case "EdDSA":
+		_, k, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		priv = k
+	default:
+		t.Fatalf("unsupported alg %q", alg)
+	}
+
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	pemData := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0700))
+	require.NoError(t, os.WriteFile(path, pemData, 0600))
+
+	return computeKID(priv.Public())
+}
+
+func TestNewIssuer_LoadsDirectoryKeys(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "server", "workload-identity.d")
+	edKID := writeKeyFile(t, filepath.Join(keysDir, "extra-eddsa.key"), "EdDSA")
+	rsaKID := writeKeyFile(t, filepath.Join(keysDir, "extra-rsa.key"), "RS256")
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	// Primary was auto-generated as RS256; the two directory keys are live.
+	assert.Equal(t, "RS256", iss.primary.alg)
+	require.Len(t, iss.keys, 3)
+
+	// JWKS publishes all three live keys, keyed by kid.
+	data, err := iss.JWKSDocument()
+	require.NoError(t, err)
+	var jwks jose.JSONWebKeySet
+	require.NoError(t, json.Unmarshal(data, &jwks))
+	require.Len(t, jwks.Keys, 3)
+	require.NotEmpty(t, jwks.Key(iss.primary.kid))
+	require.NotEmpty(t, jwks.Key(edKID))
+	require.NotEmpty(t, jwks.Key(rsaKID))
+
+	// Discovery lists both algorithms.
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(iss.DiscoveryDocument(), &doc))
+	assert.ElementsMatch(t, []any{"RS256", "EdDSA"}, doc["id_token_signing_alg_values_supported"])
+
+	// Signing still uses the primary key only.
+	tokenStr, err := iss.IssueToken("myapp", "sb-1")
+	require.NoError(t, err)
+	parsed, _, err := jwt.NewParser().ParseUnverified(tokenStr, &WorkloadClaims{})
+	require.NoError(t, err)
+	assert.Equal(t, "RS256", parsed.Header["alg"])
+	assert.Equal(t, iss.primary.kid, parsed.Header["kid"])
+
+	// The token verifies under the primary JWK from JWKS.
+	_, err = jwt.Parse(tokenStr, func(tok *jwt.Token) (interface{}, error) {
+		return jwks.Key(tok.Header["kid"].(string))[0].Key, nil
+	})
+	require.NoError(t, err)
+}
+
+func TestNewIssuer_SkipsUnparseableDirectoryKey(t *testing.T) {
+	dir := t.TempDir()
+	keysDir := filepath.Join(dir, "server", "workload-identity.d")
+	require.NoError(t, os.MkdirAll(keysDir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(keysDir, "garbage.key"), []byte("not a pem key"), 0600))
+	goodKID := writeKeyFile(t, filepath.Join(keysDir, "good.key"), "EdDSA")
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://example.miren.cloud",
+	})
+	require.NoError(t, err)
+
+	// Primary + the one good directory key; the garbage file is skipped.
+	require.Len(t, iss.keys, 2)
+
+	data, err := iss.JWKSDocument()
+	require.NoError(t, err)
+	var jwks jose.JSONWebKeySet
+	require.NoError(t, json.Unmarshal(data, &jwks))
+	require.Len(t, jwks.Keys, 2)
+	require.NotEmpty(t, jwks.Key(iss.primary.kid))
+	require.NotEmpty(t, jwks.Key(goodKID))
 }

--- a/pkg/workloadidentity/key.go
+++ b/pkg/workloadidentity/key.go
@@ -53,7 +53,11 @@ func loadSigningKeyFromPEM(data string) (*signingKey, error) {
 	priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
 	if err != nil {
 		// Fall back to a raw Ed25519 seed for parity with legacy keys written
-		// by cloudauth.LoadKeyPairFromPEM.
+		// by cloudauth.LoadKeyPairFromPEM. Those keys store the 32-byte raw
+		// Ed25519 seed directly (not DER-encoded), so a block this exact length
+		// only occurs for that legacy format — the length check is an
+		// unambiguous discriminant here and won't misfire on PKCS#8 keys (which
+		// fail to parse only on genuinely malformed input).
 		if len(block.Bytes) == ed25519.SeedSize {
 			priv = ed25519.NewKeyFromSeed(block.Bytes)
 		} else {
@@ -84,6 +88,11 @@ func newSigningKey(priv crypto.Signer) (*signingKey, error) {
 		method = jwt.SigningMethodRS256
 	case "EdDSA":
 		method = jwt.SigningMethodEdDSA
+	default:
+		// Unreachable today (algName only returns RS256/EdDSA/""), but guards
+		// against a future algName value leaving method nil, which would panic
+		// in token.SignedString.
+		return nil, fmt.Errorf("no JWT signing method for alg %q", alg)
 	}
 
 	return &signingKey{

--- a/pkg/workloadidentity/key.go
+++ b/pkg/workloadidentity/key.go
@@ -1,0 +1,150 @@
+package workloadidentity
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// rsaKeyBits is the size of freshly generated RSA signing keys. 2048 is the
+// standard OIDC default and is accepted by essentially every external verifier.
+const rsaKeyBits = 2048
+
+// signingKey is the issuer's active signing key. It is algorithm-agnostic: the
+// concrete key is either an *rsa.PrivateKey (RS256, the default for new keys) or
+// an ed25519.PrivateKey (EdDSA, retained for clusters provisioned before the
+// RS256 default). alg and method are derived from the key type so the rest of
+// the issuer never has to switch on it.
+type signingKey struct {
+	private crypto.Signer
+	public  crypto.PublicKey
+	alg     string
+	method  jwt.SigningMethod
+	kid     string
+}
+
+// generateSigningKey creates a new RSA signing key. RS256 is the default for all
+// newly provisioned clusters.
+func generateSigningKey() (*signingKey, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	if err != nil {
+		return nil, fmt.Errorf("generating RSA key: %w", err)
+	}
+	return newSigningKey(priv)
+}
+
+// loadSigningKeyFromPEM parses a PEM-encoded private key into a signingKey,
+// supporting both RSA and Ed25519 keys.
+func loadSigningKeyFromPEM(data string) (*signingKey, error) {
+	block, _ := pem.Decode([]byte(data))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		// Fall back to a raw Ed25519 seed for parity with legacy keys written
+		// by cloudauth.LoadKeyPairFromPEM.
+		if len(block.Bytes) == ed25519.SeedSize {
+			priv = ed25519.NewKeyFromSeed(block.Bytes)
+		} else {
+			return nil, fmt.Errorf("parsing private key: %w", err)
+		}
+	}
+
+	signer, ok := priv.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("private key of type %T does not implement crypto.Signer", priv)
+	}
+
+	return newSigningKey(signer)
+}
+
+// newSigningKey wraps a crypto.Signer, deriving the JWA algorithm and JWT
+// signing method from the concrete key type.
+func newSigningKey(priv crypto.Signer) (*signingKey, error) {
+	pub := priv.Public()
+	alg := algName(pub)
+	if alg == "" {
+		return nil, fmt.Errorf("unsupported signing key type: %T", priv)
+	}
+
+	var method jwt.SigningMethod
+	switch alg {
+	case "RS256":
+		method = jwt.SigningMethodRS256
+	case "EdDSA":
+		method = jwt.SigningMethodEdDSA
+	}
+
+	return &signingKey{
+		private: priv,
+		public:  pub,
+		alg:     alg,
+		method:  method,
+		kid:     computeKID(pub),
+	}, nil
+}
+
+// computeKID derives a stable key ID from a public key. Ed25519 keys hash their
+// raw bytes (preserving the IDs of tokens issued before the RS256 migration);
+// other key types hash their PKIX DER encoding.
+func computeKID(pub crypto.PublicKey) string {
+	var raw []byte
+	switch k := pub.(type) {
+	case ed25519.PublicKey:
+		raw = k
+	default:
+		der, err := x509.MarshalPKIXPublicKey(pub)
+		if err != nil {
+			return ""
+		}
+		raw = der
+	}
+	hash := sha256.Sum256(raw)
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// privateKeyPEM encodes the private key as PKCS#8 PEM. Works for both RSA and
+// Ed25519 keys.
+func (k *signingKey) privateKeyPEM() (string, error) {
+	der, err := x509.MarshalPKCS8PrivateKey(k.private)
+	if err != nil {
+		return "", fmt.Errorf("marshaling private key: %w", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})), nil
+}
+
+// algName returns the JWA algorithm identifier for a public key, or "" if the
+// key type is not supported.
+func algName(pub crypto.PublicKey) string {
+	switch pub.(type) {
+	case *rsa.PublicKey:
+		return "RS256"
+	case ed25519.PublicKey:
+		return "EdDSA"
+	default:
+		return ""
+	}
+}
+
+// jwkForPublic builds a signing JWK for a public key, deriving the algorithm
+// from the key type. go-jose marshals the correct JWK parameters per key type
+// (RSA -> {kty:RSA,n,e}, Ed25519 -> {kty:OKP,crv:Ed25519,x}).
+func jwkForPublic(pub crypto.PublicKey, kid string) jose.JSONWebKey {
+	return jose.JSONWebKey{
+		Key:       pub,
+		KeyID:     kid,
+		Algorithm: algName(pub),
+		Use:       "sig",
+	}
+}


### PR DESCRIPTION
## Summary

The cluster's workload-identity OIDC issuer (`pkg/workloadidentity`) signed sandbox tokens with **EdDSA**. EdDSA is exotic and rejected by many OIDC federation verifiers (e.g. AWS STS), so this defaults to **RS256**, which is universally supported — and extends the issuer to hold **multiple live keys** for rotation and mixed key types.

### Phase 1 — RS256 default
- New `pkg/workloadidentity/key.go`: an algorithm-agnostic `signingKey` (RSA or Ed25519 via `crypto.Signer`), **decoupled from `cloudauth`** (which must stay Ed25519 — it backs cluster auth via `Sign`/`VerifySignature`).
- New clusters generate **RSA-2048 / RS256**.
- Clusters with a legacy EdDSA key **auto-migrate**: the EdDSA key is demoted to the `.prev` slot and kept **advertised in JWKS** (so in-flight ≤24h tokens still verify), while new tokens sign with a fresh RS256 key. Ed25519 `kid` computation is preserved so already-issued tokens still match.

### Phase 2 — multiple live keys
- The issuer now holds a `primary` signer plus `keys []*signingKey` — the primary plus any keys dropped into **`server/workload-identity.d/`**. All live keys are **published in JWKS** (deduped by `kid`) alongside verify-only `advertised` keys; the discovery doc lists every algorithm present.
- Supports **key rotation** (publish a new key before cutting over) and **multiple key types** coexisting.
- **Signing remains primary-only** for now — per-request key/type selection (and the runner→coordinator RPC) is intentionally deferred, so `TokenOptions` is unchanged.

## Scope / not changed
- `pkg/cloudauth` (cluster auth — stays Ed25519), `pkg/auth/jwt.go` (Miren Cloud's tokens — separate repo), `pkg/oidcauth/validator.go` (already accepts RS256).

## Notes
- One-time auto-rotation on upgrade for EdDSA clusters; the issuer URL (external trust anchor) is unchanged, so federation configs need no update. The migration renames `key → key.prev`, clobbering any pre-existing `.prev` (an older, almost-certainly-expired EdDSA key).

## Testing
- `go test ./pkg/workloadidentity/` — 19 passed (incl. legacy-migration + directory-key tests)
- `go test ./controllers/sandbox/ -run Token` — 8 passed (token_server end-to-end with RS256)
- `make lint` — 0 issues