### PR TITLE
Detect Ruby version from .ruby-version and the Gemfile

### DIFF
--- a/pkg/imagerefs/imagerefs.go
+++ b/pkg/imagerefs/imagerefs.go
@@ -42,8 +42,15 @@ func GetPythonImage(version string) string {
 	return "oci.miren.cloud/python:" + version + "-slim"
 }
 
-// GetRubyImage returns a Ruby image reference with the specified version
+// GetRubyImage returns a Ruby image reference with the specified version.
+// The version is truncated to major.minor (e.g., "3.3.7" becomes "3.3") since
+// the registry only mirrors major.minor Ruby tags.
 func GetRubyImage(version string) string {
+	// Truncate to major.minor only
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) >= 2 {
+		version = parts[0] + "." + parts[1]
+	}
 	return "oci.miren.cloud/ruby:" + version + "-slim"
 }
 

--- a/pkg/imagerefs/imagerefs_test.go
+++ b/pkg/imagerefs/imagerefs_test.go
@@ -1,0 +1,20 @@
+package imagerefs
+
+import "testing"
+
+func TestGetRubyImage(t *testing.T) {
+	cases := map[string]string{
+		// Patch-level versions (e.g. from .ruby-version) truncate to the
+		// major.minor tag the registry actually mirrors.
+		"3.3.7": "oci.miren.cloud/ruby:3.3-slim",
+		"3.3.0": "oci.miren.cloud/ruby:3.3-slim",
+		// Already major.minor passes through unchanged.
+		"3.4": "oci.miren.cloud/ruby:3.4-slim",
+		"4.0": "oci.miren.cloud/ruby:4.0-slim",
+	}
+	for in, want := range cases {
+		if got := GetRubyImage(in); got != want {
+			t.Errorf("GetRubyImage(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/stackbuild/ruby.go
+++ b/pkg/stackbuild/ruby.go
@@ -98,9 +98,21 @@ type RubyStack struct {
 	hasPumaConfig bool
 	hasRakefile   bool
 
+	// Detected Ruby version (from .ruby-version or the Gemfile ruby directive)
+	rubyVersion string
+
 	// Detected environment variable requirements
 	requiredEnvVars []EnvVarRequirement
 }
+
+// gemfileRubyDirective matches an inline ruby version in the Gemfile, e.g.
+//
+//	ruby "3.3.0"
+//	ruby '3.3'
+//
+// The `ruby file: ".ruby-version"` form is intentionally not matched here; it
+// points back at .ruby-version, which parseRubyVersion reads first.
+var gemfileRubyDirective = regexp.MustCompile(`(?m)^\s*ruby\s+['"]([0-9]+\.[0-9]+(?:\.[0-9]+)?)['"]`)
 
 func (s *RubyStack) BaseDistro() string {
 	return "debian"
@@ -154,6 +166,11 @@ func (s *RubyStack) Init(opts BuildOptions) {
 
 	s.hasRakefile = s.hasFile("Rakefile")
 
+	s.rubyVersion = s.parseRubyVersion()
+	if s.rubyVersion != "" {
+		s.Event("config", "ruby-version", "Ruby version "+s.rubyVersion+" detected")
+	}
+
 	// Detect required environment variables
 	s.requiredEnvVars = s.detectEnvVars()
 	for _, ev := range s.requiredEnvVars {
@@ -189,6 +206,29 @@ func (s *RubyStack) Gemfile() ([]byte, []byte, error) {
 	return gemfileContent, gemfileLockContent, nil
 }
 
+// parseRubyVersion detects the desired Ruby version, preferring an explicit
+// .ruby-version file over an inline `ruby "x.y"` directive in the Gemfile. The
+// Gemfile's `ruby file: ".ruby-version"` form resolves through .ruby-version,
+// so reading that file first covers both. Returns "" when nothing is found.
+func (s *RubyStack) parseRubyVersion() string {
+	if content, err := s.readFile(".ruby-version"); err == nil {
+		if v := strings.TrimSpace(string(content)); v != "" {
+			// .ruby-version may carry a "ruby-" prefix (e.g. "ruby-3.3.0").
+			return strings.TrimPrefix(v, "ruby-")
+		}
+	}
+
+	gemfile, _, err := s.Gemfile()
+	if err != nil {
+		return ""
+	}
+	if m := gemfileRubyDirective.FindSubmatch(gemfile); m != nil {
+		return string(m[1])
+	}
+
+	return ""
+}
+
 func (s *RubyStack) detectGem(gem string) bool {
 	data, lock, err := s.Gemfile()
 	if err != nil {
@@ -213,9 +253,11 @@ func (s *RubyStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 
 	mr := imagemetaresolver.Default()
 
-	version := "3.2"
+	version := "3.4"
 	if opts.Version != "" {
 		version = opts.Version
+	} else if s.rubyVersion != "" {
+		version = s.rubyVersion
 	}
 	base := llb.Image(imagerefs.GetRubyImage(version), llb.WithMetaResolver(mr))
 

--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -308,8 +308,19 @@ func (h *highlevelBuilder) bundleInstall(cur, mnt llb.State) llb.State {
 	// in rather than using h.Access to mount them in read only.
 
 	origin := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)
+	// Stage Gemfile* and .ruby-version (matched via wildcard so a missing file
+	// is not an error). A Gemfile that does `ruby file: ".ruby-version"` reads
+	// the file during bundle install, before copyApp brings in the full context.
 	cur = cur.File(
 		llb.Copy(mnt, "Gemfile*", "/app/", &llb.CopyInfo{
+			CopyDirContentsOnly: true,
+			CreateDestPath:      true,
+			FollowSymlinks:      true,
+			AllowWildcard:       true,
+			AllowEmptyWildcard:  true,
+			CreatedTime:         &origin,
+		})).File(
+		llb.Copy(mnt, ".ruby-version*", "/app/", &llb.CopyInfo{
 			CopyDirContentsOnly: true,
 			CreateDestPath:      true,
 			FollowSymlinks:      true,

--- a/pkg/stackbuild/stackbuild_test.go
+++ b/pkg/stackbuild/stackbuild_test.go
@@ -692,6 +692,77 @@ func TestGoVersionDetection(t *testing.T) {
 	}
 }
 
+func TestRubyVersionDetection(t *testing.T) {
+	// Test parseRubyVersion across its sources: .ruby-version takes precedence
+	// over the Gemfile's inline ruby directive.
+	testCases := []struct {
+		name            string
+		rubyVersion     string // contents of .ruby-version, "" to skip the file
+		gemfileContent  string
+		expectedVersion string
+	}{
+		{
+			name:            "ruby-version file",
+			rubyVersion:     "3.3.0\n",
+			gemfileContent:  "source 'https://rubygems.org'\n",
+			expectedVersion: "3.3.0",
+		},
+		{
+			name:            "ruby-version file with ruby- prefix",
+			rubyVersion:     "ruby-3.4.1\n",
+			gemfileContent:  "source 'https://rubygems.org'\n",
+			expectedVersion: "3.4.1",
+		},
+		{
+			name:            "gemfile inline directive",
+			gemfileContent:  "source 'https://rubygems.org'\nruby \"3.3\"\n",
+			expectedVersion: "3.3",
+		},
+		{
+			name:            "gemfile file directive falls back to ruby-version",
+			rubyVersion:     "3.4.2\n",
+			gemfileContent:  "source 'https://rubygems.org'\nruby file: \".ruby-version\"\n",
+			expectedVersion: "3.4.2",
+		},
+		{
+			name:            "ruby-version wins over gemfile directive",
+			rubyVersion:     "3.4.0\n",
+			gemfileContent:  "source 'https://rubygems.org'\nruby \"3.3\"\n",
+			expectedVersion: "3.4.0",
+		},
+		{
+			name:            "blank ruby-version falls back to gemfile",
+			rubyVersion:     "   \n",
+			gemfileContent:  "source 'https://rubygems.org'\nruby \"3.3\"\n",
+			expectedVersion: "3.3",
+		},
+		{
+			name:            "no version source",
+			gemfileContent:  "source 'https://rubygems.org'\n",
+			expectedVersion: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "Gemfile"), []byte(tc.gemfileContent), 0644))
+			if tc.rubyVersion != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, ".ruby-version"), []byte(tc.rubyVersion), 0644))
+			}
+
+			stack := &RubyStack{
+				MetaStack: MetaStack{
+					dir: dir,
+				},
+			}
+
+			version := stack.parseRubyVersion()
+			require.Equal(t, tc.expectedVersion, version)
+		})
+	}
+}
+
 func TestRust(t *testing.T) {
 	if !checkDocker() {
 		t.Skip("Docker not available")


### PR DESCRIPTION
@solojavier hit this in Discord while upgrading his [hanami-demo](https://github.com/solojavier/hanami-demo) app to hanami 3.0, which needs Ruby >= 3.3. He did the normal thing, set `.ruby-version`, and nothing happened. Then he added `ruby file: ".ruby-version"` to the Gemfile and the build broke entirely. Turns out our Ruby buildpack never read any version source at all. It defaulted to a hardcoded `"3.2"` and only looked at `[build] version` in `.miren/app.toml`. The Go stack already parses `go.mod` for exactly this, so Ruby was just missing the equivalent wiring.

This adds a `parseRubyVersion()` that checks `.ruby-version` first and falls back to an inline `ruby "x.y"` directive in the Gemfile, hooked into the same `opts.Version → detected → default` fallback Go uses. The `ruby file: ".ruby-version"` form resolves through the file, so reading it first covers both ways of pointing at it.

Two smaller things came along for the ride. `.ruby-version` now gets staged into the build layer before `bundle install`, because a Gemfile that does `ruby file: ".ruby-version"` reads that file during install and we weren't copying it until one step later, which is what broke his build. And `GetRubyImage` now truncates to major.minor like `GetGolangImage` already does, so a real-world `.ruby-version` of `3.3.7` resolves to `ruby:3.3-slim` (a tag our registry actually mirrors) instead of a `3.3.7` tag that doesn't exist. The stale `"3.2"` default is bumped to `"3.4"` while we're here.

Net effect: a stock repo with `.ruby-version` plus `ruby file: ".ruby-version"` now builds correctly with zero miren-specific config.

Closes MIR-1242
