### PR TITLE
docs: strip addon-name parentheticals from addons side nav

### DIFF
--- a/docs/docs/addons.md
+++ b/docs/docs/addons.md
@@ -107,7 +107,7 @@ When the version value contains `:`, Miren uses it as the complete image referen
 
 When an addon is provisioned, Miren injects connection credentials as environment variables into your app. These are available to all services in the app. Variables marked sensitive are redacted in `miren env list` output.
 
-### PostgreSQL (`miren-postgresql`)
+### PostgreSQL
 
 | Variable | Description | Example |
 |----------|-------------|---------|
@@ -120,7 +120,7 @@ When an addon is provisioned, Miren injects connection credentials as environmen
 
 Most frameworks and ORMs connect automatically using `DATABASE_URL`.
 
-### MySQL (`miren-mysql`)
+### MySQL
 
 | Variable | Description | Example |
 |----------|-------------|---------|
@@ -131,7 +131,7 @@ Most frameworks and ORMs connect automatically using `DATABASE_URL`.
 | `MYSQL_PASSWORD` | Database password (sensitive) | — |
 | `MYSQL_DATABASE` | Database name | `myapp` |
 
-### Valkey (`miren-valkey`)
+### Valkey
 
 Valkey is wire-compatible with Redis, so Miren injects both `VALKEY_*` and `REDIS_*` variables pointing at the same server. Use whichever your client library expects.
 
@@ -142,7 +142,7 @@ Valkey is wire-compatible with Redis, so Miren injects both `VALKEY_*` and `REDI
 | `VALKEY_PORT` / `REDIS_PORT` | Server port | `6379` |
 | `VALKEY_PASSWORD` / `REDIS_PASSWORD` | Password (sensitive) | — |
 
-### RabbitMQ (`miren-rabbitmq`)
+### RabbitMQ
 
 | Variable | Description | Example |
 |----------|-------------|---------|
@@ -153,7 +153,7 @@ Valkey is wire-compatible with Redis, so Miren injects both `VALKEY_*` and `REDI
 | `RABBITMQ_PASSWORD` | Broker password (sensitive) | — |
 | `RABBITMQ_VHOST` | Virtual host | `/` |
 
-### Memcached (`miren-memcache`)
+### Memcached
 
 | Variable | Description | Example |
 |----------|-------------|---------|


### PR DESCRIPTION
## Summary

The right-side table of contents on https://miren.md/addons is generated from heading text, so the addon-name parentheticals in the Environment Variables subsection headings cluttered the nav (e.g. "PostgreSQL (miren-postgresql)").

This drops the parentheticals from the five subsection headings:

- PostgreSQL (`miren-postgresql`) → PostgreSQL
- MySQL (`miren-mysql`) → MySQL
- Valkey (`miren-valkey`) → Valkey
- RabbitMQ (`miren-rabbitmq`) → RabbitMQ
- Memcached (`miren-memcache`) → Memcached

The addon names remain documented in the "Available Addons" table at the top of the page.

Closes MIR-1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)