### PR TITLE
docs: send Algolia click & conversion events from search

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -181,6 +181,10 @@ const config: Config = {
       indexName: 'Miren Docs',
       contextualSearch: true,
       searchPagePath: 'search',
+      // Send click & conversion events to Algolia so we can see which search
+      // results people actually open (Click Analytics in the Algolia
+      // dashboard). DocSearch handles the queryID/userToken plumbing.
+      insights: true,
     },
     prism: {
       theme: prismThemes.github,


### PR DESCRIPTION
Enable DocSearch's `insights: true` option so the docs search box sends **click** and **conversion** events to Algolia.

## Why
Search-query analytics already flow automatically (DocSearch runs searches through the Algolia API), so we can already see *what* people search. The gap was **click events** — which result people actually open for a given query. Enabling insights lights up **Click Analytics** (CTR, click position) on the *Miren Docs* index.

## What changed
- `docs/docusaurus.config.ts`: added `insights: true` to the `algolia` themeConfig. On `@docsearch/react` v4, DocSearch handles the `queryID`/`userToken` plumbing automatically.

## Notes
- Algolia's dashboard "automatic event collection" toggle is a separate no-code path that requires InstantSearch/Autocomplete on the page; DocSearch isn't detected by it (expected warning). Our events are sent programmatically, so that toggle should stay off.
- After deploy, verify via **Data sources → Events → Debugger** in the Algolia dashboard (search + click a result → `clicked` event appears).

Linear: MIR-1247
