### PR TITLE
Release disk leases promptly when a sandbox dies

### DIFF
--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -993,8 +993,15 @@ func (r *Runner) SetupControllers(
 		workers,
 	)
 
-	// Set up periodic cleanup of old released leases (every 5 minutes)
+	// Set up periodic lease maintenance (every 5 minutes): sweep orphan leases
+	// stranded by sandboxes that died without releasing (SIGKILL, boot failure),
+	// then clean up old released leases. The orphan sweep also runs at Init, but
+	// the periodic tick bounds the worst-case wedge to one interval for sandboxes
+	// that die while the controller is already running.
 	diskLeaseRC.SetPeriodic(5*time.Minute, func(ctx context.Context) error {
+		if err := diskLeaseController.ReconcileOrphanLeases(ctx, disk.OrphanSweepGracePeriod); err != nil {
+			log.Warn("periodic orphan lease sweep failed", "error", err)
+		}
 		return diskLeaseController.CleanupOldReleasedLeases(ctx)
 	})
 

--- a/controllers/disk/disk_lease_controller.go
+++ b/controllers/disk/disk_lease_controller.go
@@ -18,6 +18,16 @@ import (
 	"miren.dev/runtime/pkg/idgen"
 )
 
+// OrphanSweepGracePeriod is how old a BOUND/PENDING lease must be before the
+// recurring orphan sweep will reclaim it. It's defense-in-depth: the sweep
+// already only targets leases whose owning sandbox is DEAD or missing, but a
+// young lease may belong to a sandbox that is still booting (its entity not yet
+// settled) or one that just died and whose own in-band ReleaseDiskLeases is
+// still in flight. Skipping young leases lets those in-band paths win the race.
+// The boot-time sweep (Init) bypasses this with a zero grace, since it only ever
+// sees leftovers from a prior, crashed process where nothing is mid-boot.
+const OrphanSweepGracePeriod = 2 * time.Minute
+
 // leaseInfo tracks active lease details
 type leaseInfo struct {
 	leaseId   string
@@ -75,7 +85,9 @@ func (d *DiskLeaseController) Init(ctx context.Context) error {
 	d.diskMode = detectDiskMode(d.configuredMode)
 	d.Log.Info("disk lease controller initialized", "mode", d.diskMode)
 
-	if err := d.reconcileOrphanLeases(ctx); err != nil {
+	// Zero grace at boot: anything we find is a leftover from a prior process,
+	// not a sandbox booting in this one.
+	if err := d.ReconcileOrphanLeases(ctx, 0); err != nil {
 		// Orphan sweep is best-effort — log and continue. Individual
 		// leases may still transition normally via their entity events.
 		d.Log.Warn("orphan lease reconciliation failed", "error", err)
@@ -83,14 +95,21 @@ func (d *DiskLeaseController) Init(ctx context.Context) error {
 	return nil
 }
 
-// reconcileOrphanLeases releases leases whose owning sandbox no longer
+// ReconcileOrphanLeases releases leases whose owning sandbox no longer
 // exists or is already DEAD. On a clean shutdown the sandbox controller
-// releases leases via StopSandbox → ReleaseDiskLeases, but after a
-// SIGKILL the sandbox may be torn down without that path ever running.
-// A BOUND lease left pointing at a dead sandbox then blocks every
-// future sandbox that wants the same disk; clearing those leases at
-// boot turns a latent deadlock into a transient, self-healing one.
-func (d *DiskLeaseController) reconcileOrphanLeases(ctx context.Context) error {
+// releases leases via StopSandbox → ReleaseDiskLeases, but a sandbox can
+// also die without that path running: a SIGKILL, or a boot that fails
+// after binding the lease (the boot-failure defer marks the sandbox DEAD).
+// A BOUND lease left pointing at a dead sandbox then blocks every future
+// sandbox that wants the same disk. This sweep runs both at boot (Init)
+// and periodically, turning a latent deadlock into a transient, self-
+// healing one bounded by the sweep interval.
+//
+// minLeaseAge skips leases younger than the given age. The recurring sweep
+// passes OrphanSweepGracePeriod so it never reclaims a lease that may still
+// belong to a booting sandbox or a death whose in-band release is mid-flight;
+// the boot-time sweep passes 0. See OrphanSweepGracePeriod for the rationale.
+func (d *DiskLeaseController) ReconcileOrphanLeases(ctx context.Context, minLeaseAge time.Duration) error {
 	// Entity-only unit tests instantiate the controller without an EAC
 	// and call Init; skip the sweep cleanly in that case.
 	if d.EAC == nil {
@@ -102,6 +121,7 @@ func (d *DiskLeaseController) reconcileOrphanLeases(ctx context.Context) error {
 		return fmt.Errorf("list disk leases: %w", err)
 	}
 
+	now := time.Now()
 	var released int
 	for _, e := range resp.Values() {
 		var lease storage_v1alpha.DiskLease
@@ -111,6 +131,12 @@ func (d *DiskLeaseController) reconcileOrphanLeases(ctx context.Context) error {
 			continue
 		}
 		if lease.SandboxId == "" {
+			continue
+		}
+
+		// Defense-in-depth: leave young leases alone so the in-band release
+		// paths (and a settling sandbox entity) win any race against the sweep.
+		if minLeaseAge > 0 && now.Sub(e.Entity().GetCreatedAt()) < minLeaseAge {
 			continue
 		}
 

--- a/controllers/disk/orphan_lease_test.go
+++ b/controllers/disk/orphan_lease_test.go
@@ -130,3 +130,117 @@ func TestReconcileOrphanLeasesReleasesLeaseForMissingSandbox(t *testing.T) {
 	assert.Equal(t, storage_v1alpha.RELEASED, lease.Status,
 		"lease for a missing sandbox must be released by the orphan sweep")
 }
+
+// TestReconcileOrphanLeasesRecurring verifies the sweep works as a recurring
+// entry point, not just at Init. A sandbox can die (SIGKILL, boot failure)
+// while the controller is already running; the periodic tick must release the
+// stranded lease, and calling it again must be a harmless no-op.
+func TestReconcileOrphanLeasesRecurring(t *testing.T) {
+	ctx := context.Background()
+	log := slog.Default()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
+	require.NoError(t, leaseController.Init(ctx))
+
+	// After the controller is already up, a sandbox dies holding a BOUND lease.
+	deadSandboxId := entity.Id("sandbox/late-dead")
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, deadSandboxId,
+		(&compute.Sandbox{
+			ID:     deadSandboxId,
+			Status: compute.DEAD,
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	leaseId := entity.Id("disk-lease/late-orphan")
+	_, err = es.EAC.Create(ctx, entity.New(
+		entity.DBId, leaseId,
+		(&storage_v1alpha.DiskLease{
+			ID:         leaseId,
+			DiskId:     entity.Id("disk/late-data"),
+			SandboxId:  deadSandboxId,
+			Status:     storage_v1alpha.BOUND,
+			AcquiredAt: time.Now(),
+			NodeId:     entity.Id("node/test-node"),
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	// The Init sweep already ran before this lease existed; the recurring tick
+	// is what must catch it. Zero grace here to assert the core release logic.
+	require.NoError(t, leaseController.ReconcileOrphanLeases(ctx, 0))
+
+	resp, err := es.EAC.Get(ctx, leaseId.String())
+	require.NoError(t, err)
+	var lease storage_v1alpha.DiskLease
+	lease.Decode(resp.Entity().Entity())
+	assert.Equal(t, storage_v1alpha.RELEASED, lease.Status,
+		"recurring sweep must release a lease whose sandbox died after Init")
+
+	// Running the sweep again is a harmless no-op.
+	require.NoError(t, leaseController.ReconcileOrphanLeases(ctx, 0))
+	resp, err = es.EAC.Get(ctx, leaseId.String())
+	require.NoError(t, err)
+	lease.Decode(resp.Entity().Entity())
+	assert.Equal(t, storage_v1alpha.RELEASED, lease.Status)
+}
+
+// TestReconcileOrphanLeasesGracePeriod verifies the recurring sweep leaves a
+// freshly created lease alone even when its sandbox already reads as DEAD, so a
+// just-booted sandbox or an in-flight teardown isn't raced by the sweep. A zero
+// grace (the boot-time path) still reclaims it immediately.
+func TestReconcileOrphanLeasesGracePeriod(t *testing.T) {
+	ctx := context.Background()
+	log := slog.Default()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	deadSandboxId := entity.Id("sandbox/grace-dead")
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, deadSandboxId,
+		(&compute.Sandbox{
+			ID:     deadSandboxId,
+			Status: compute.DEAD,
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	leaseId := entity.Id("disk-lease/grace-young")
+	_, err = es.EAC.Create(ctx, entity.New(
+		entity.DBId, leaseId,
+		(&storage_v1alpha.DiskLease{
+			ID:         leaseId,
+			DiskId:     entity.Id("disk/grace-data"),
+			SandboxId:  deadSandboxId,
+			Status:     storage_v1alpha.BOUND,
+			AcquiredAt: time.Now(),
+			NodeId:     entity.Id("node/test-node"),
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
+
+	// With a long grace, the just-created lease must be left BOUND even though
+	// its sandbox is DEAD.
+	require.NoError(t, leaseController.ReconcileOrphanLeases(ctx, time.Hour))
+	resp, err := es.EAC.Get(ctx, leaseId.String())
+	require.NoError(t, err)
+	var lease storage_v1alpha.DiskLease
+	lease.Decode(resp.Entity().Entity())
+	assert.Equal(t, storage_v1alpha.BOUND, lease.Status,
+		"grace period must protect a freshly created lease from the recurring sweep")
+
+	// With zero grace (boot-time recovery), the same lease is reclaimed.
+	require.NoError(t, leaseController.ReconcileOrphanLeases(ctx, 0))
+	resp, err = es.EAC.Get(ctx, leaseId.String())
+	require.NoError(t, err)
+	lease.Decode(resp.Entity().Entity())
+	assert.Equal(t, storage_v1alpha.RELEASED, lease.Status,
+		"zero grace must reclaim the orphaned lease")
+}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1021,6 +1021,21 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 			c.Log.Error("sandbox boot failed, marking DEAD", "id", co.ID, "err", err)
 			co.Status = compute.DEAD
 			meta.Update(co.Encode())
+
+			// Boot can fail after we've already bound a disk lease (e.g. a
+			// later port health check fails). Unlike the graceful StopSandbox
+			// path, this defer doesn't tear the sandbox down, so release any
+			// leases here — otherwise the lease stays status.bound pointing at
+			// a dead sandbox and wedges every replacement until it times out.
+			// Use a non-cancelled context: the boot error may itself be a
+			// cancellation, and we still want the lease freed. Bound it with a
+			// timeout so a hung release can't pin the reconcile worker, matching
+			// the cleanup defer below.
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+			defer cancel()
+			if relErr := c.ReleaseDiskLeases(cleanupCtx, co.ID); relErr != nil {
+				c.Log.Error("failed to release disk leases after boot failure", "id", co.ID, "err", relErr)
+			}
 		}
 	}()
 

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "9568271c07785d6b3fd15fe4ac6956a811e9944e7959e8787e35ebe9addcf4db",
+		"sandbox.go":  "6ae7d283706fb956321bdea362a0b439fea17aac598835ae7b1cdac7f412604d",
 		"volume.go":   "b4697764d48a90adc04ce47968ccef11ceba50da8d19c889906c5c3a539065b3",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}


### PR DESCRIPTION
Debugging `jobsv2` on club, a small port misconfiguration turned into a roughly hour-long wait and a pile of DEAD sandboxes. The app has a single-writer persistent disk, and the situation had an unfortunate way of feeding itself: a sandbox would boot far enough to bind the disk lease, not pass its 15s port health check, and get marked DEAD with the lease still `status.bound`. The next replacement would find that lease still held, fail volume config with `disk … has an active lease`, and land in the same place. The lease only freed once it aged out (~66 minutes observed), at which point the replacement would grab it and the cycle would repeat.

The two ways a sandbox shuts down had drifted apart a little. The graceful `StopSandbox` path releases disk leases on its way out, but the imperative `createSandbox` boot-failure path hadn't picked up that step yet, so a lease could outlive the sandbox that held it. The fix is to release leases in that boot-failure defer too. It's correctly sequenced: `createSandbox`'s defers unwind LIFO, so the inner defer tears the container down before this outer one frees the lease.

That handles the reported case right away, but I didn't want to lean on a single code path remembering to clean up. There was already an orphan-lease sweep that releases leases whose owning sandbox is DEAD or gone, it just only ran once at controller startup, so it never got a chance during a live incident. This promotes it to the existing 5-minute periodic, so any path that leaves a lease behind (a SIGKILL, future code) heals within a bounded window instead of an hour. One wrinkle worth noting: a recurring sweep that reclaims "DEAD or missing sandbox" leases could in principle race a sandbox that's still booting, or one whose own teardown is mid-flight. The storage layer already guards against the worst outcome (a second loop attach gets adopted rather than duplicated), but to be safe the recurring sweep skips any lease younger than two minutes and lets the in-band paths go first. The boot-time sweep keeps a zero grace since it only ever sees leftovers from a crashed process.

Verified end to end in dev with a deliberately-wrong-port app on a single-writer disk: on the old binary the lease stayed `bound` and replacements piled up with `active lease` errors; on the fixed binary the lease releases about 2ms after the sandbox is marked DEAD and replacements boot cleanly, no wedge.

The app still crash-loops on the underlying port misconfig, but that's a separate concern (MIR-1246). While I was in here I also filed MIR-1249 for a related unmount-retry gap I noticed during the investigation.

Closes MIR-1245