### PR TITLE
Fix flaky RabbitMQ addon test broken by an upstream broker tag float

### DIFF
--- a/testdata/bun-rabbitmq/index.ts
+++ b/testdata/bun-rabbitmq/index.ts
@@ -5,41 +5,60 @@ const testQueue = "bun-test-queue";
 
 async function publishAndConsume(): Promise<string> {
   const conn = await amqp.connect(url);
+  // Connection-level errors (e.g. the broker closing the connection) surface
+  // as async 'error' events, not as rejections of the awaited calls below.
+  // Without a handler they become uncaught exceptions and crash the process.
+  conn.on("error", () => {});
   const ch = await conn.createChannel();
+  ch.on("error", () => {});
 
-  await ch.assertQueue(testQueue, { durable: false });
+  try {
+    // RabbitMQ 4.3+ denies transient non-exclusive queues by default (the
+    // transient_nonexcl_queues deprecated feature went denied_by_default in
+    // 4.3.0), so this queue must be durable.
+    await ch.assertQueue(testQueue, { durable: true });
 
-  const message = `hello-${Date.now()}`;
-  ch.sendToQueue(testQueue, Buffer.from(message));
+    const message = `hello-${Date.now()}`;
+    ch.sendToQueue(testQueue, Buffer.from(message));
 
-  // Consume the message we just published.
-  const result = await new Promise<string>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("consume timeout")), 5000);
-    ch.consume(
-      testQueue,
-      (msg) => {
-        if (msg) {
-          clearTimeout(timeout);
-          ch.ack(msg);
-          resolve(msg.content.toString());
-        }
-      },
-      { noAck: false }
-    );
-  });
-
-  await ch.close();
-  await conn.close();
-  return result;
+    // Consume the message we just published.
+    return await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("consume timeout")), 5000);
+      ch.consume(
+        testQueue,
+        (msg) => {
+          if (msg) {
+            clearTimeout(timeout);
+            ch.ack(msg);
+            resolve(msg.content.toString());
+          }
+        },
+        { noAck: false }
+      );
+    });
+  } finally {
+    // Always release the channel/connection, even on the error or timeout
+    // paths, so repeated failures can't leak connections against broker limits.
+    await ch.close().catch(() => {});
+    await conn.close().catch(() => {});
+  }
 }
 
 async function healthCheck(): Promise<boolean> {
   const conn = await amqp.connect(url);
+  conn.on("error", () => {});
   const ch = await conn.createChannel();
-  await ch.assertQueue("health-check", { durable: false });
-  await ch.deleteQueue("health-check");
-  await ch.close();
-  await conn.close();
+  ch.on("error", () => {});
+  try {
+    // Exclusive queues are connection-scoped and auto-delete on close, so they
+    // sidestep the transient_nonexcl_queues restriction without needing
+    // durability or an explicit delete. Use a server-generated name (empty
+    // string) so concurrent health checks can't collide on a locked name.
+    await ch.assertQueue("", { exclusive: true });
+  } finally {
+    await ch.close().catch(() => {});
+    await conn.close().catch(() => {});
+  }
   return true;
 }
 


### PR DESCRIPTION
`TestRabbitmqAddonDeployWithAppToml` went flaky, and the trail was a fun one. The symptom was the bun web app crash-looping right after boot until the 30s route check gave up, with the ingress reporting "failed to boot." It looked environment-sensitive (passed in standalone CI and on the prior release, failed in the heavier Release pipeline and locally), which smelled like resource contention. It wasn't.

The bun fixture declares its queues as transient and non-exclusive (`durable: false`). Our RabbitMQ addon points the broker at the floating `rabbitmq:4` tag, which has drifted forward to 4.3.2, and the `transient_nonexcl_queues` deprecated feature went `denied_by_default` in RabbitMQ 4.3.0 (it was merely deprecated but still permitted through 4.2.x). So the broker now answers `assertQueue` with a 541 connection-close. amqplib raises that as an async `error` event on the connection, which lands outside the per-request `try/catch`, becomes an uncaught exception, and kills the bun process. Repeat until crash cooldown.

The key thing is that nothing in our repo changed. The addon has used the floating `:4` tag since it landed back in April, and this fixture has been byte-for-byte the same since it was added, working fine for ~2.5 months. The trigger was purely upstream drift behind the tag. That also explains the "environment-sensitive" behavior: the runs that passed almost certainly had a pre-4.3 broker image, while fresh pulls picked up 4.3.x and started failing.

The fix lives in the fixture: the round-trip queue becomes durable and the health-check queue becomes exclusive (both exempt from the restriction), and we attach connection error handlers so a broker-side close degrades into a clean 503 instead of crashing the process. Verified by running the real blackbox test four times back to back, all green.

The broader question this raises, that a floating major tag lets an upstream default-flip break addon users with no change on their end, is deliberately out of scope here. It belongs with the in-flight pull-through upstream image mirror work, where we'll sort out what reproducible image references mean for addons. Delightful coincidence that the tag float bit us the very week that work is happening.

Closes MIR-1250