### PR TITLE
imagerefs: move base and infrastructure images to the pull-through world

### DIFF
--- a/pkg/imagerefs/imagerefs.go
+++ b/pkg/imagerefs/imagerefs.go
@@ -2,25 +2,33 @@
 // This provides a single source of truth for image versions and makes updates easier.
 package imagerefs
 
-// Infrastructure images
+// Infrastructure images. These reference exact upstream version tags served
+// through the oci.miren.cloud pull-through cache (RFD-87): the proxy aliases
+// each name to its real upstream registry (gcr.io, registry.k8s.io, ghcr.io,
+// quay.io, Docker Hub). They were previously pinned to opaque "v1" tags from
+// the hand-maintained mirror; that mirror is retired, though the old v1 tags
+// stay frozen in the registry so already-deployed clusters keep resolving them
+// through the proxy's legacy-tag bypass.
 const (
-	// etcd distributed key-value store
-	Etcd = "oci.miren.cloud/etcd:v1"
+	// etcd distributed key-value store (gcr.io/etcd-development/etcd)
+	Etcd = "oci.miren.cloud/etcd:v3.5.15"
 
-	// Kubernetes pause container for sandboxes
-	Pause = "oci.miren.cloud/pause:v1"
+	// Kubernetes pause container for sandboxes (registry.k8s.io/pause)
+	Pause = "oci.miren.cloud/pause:3.8"
 
-	// BuildKit daemon for building containers
-	BuildKit = "oci.miren.cloud/buildkit:v1"
+	// BuildKit daemon for building containers (ghcr.io/mirendev/buildkit). Our
+	// fork only publishes a rolling "latest", so we pin its digest for
+	// reproducible builds; bump this when rolling out a new BuildKit.
+	BuildKit = "oci.miren.cloud/buildkit@sha256:1263587b78162302359fec3485c153d44872114b8e944ef94be053cc2218679f"
 
-	// Minio object storage server
-	Minio = "oci.miren.cloud/minio:v1"
+	// Minio object storage server (quay.io/minio/minio)
+	Minio = "oci.miren.cloud/minio:RELEASE.2025-04-03T14-56-28Z"
 
-	// VictoriaLogs log storage server
-	VictoriaLogs = "oci.miren.cloud/victoria-logs:v1"
+	// VictoriaLogs log storage server (docker.io/victoriametrics/victoria-logs)
+	VictoriaLogs = "oci.miren.cloud/victoria-logs:v1.0.0-victorialogs"
 
-	// VictoriaMetrics metrics storage server
-	VictoriaMetrics = "oci.miren.cloud/victoria-metrics:v1"
+	// VictoriaMetrics metrics storage server (docker.io/victoriametrics/victoria-metrics)
+	VictoriaMetrics = "oci.miren.cloud/victoria-metrics:v1.106.1"
 
 	// Miren runtime server
 	Miren = "oci.miren.cloud/miren:latest"

--- a/pkg/imagerefs/imagerefs.go
+++ b/pkg/imagerefs/imagerefs.go
@@ -2,8 +2,6 @@
 // This provides a single source of truth for image versions and makes updates easier.
 package imagerefs
 
-import "strings"
-
 // Infrastructure images
 const (
 	// etcd distributed key-value store
@@ -42,26 +40,13 @@ func GetPythonImage(version string) string {
 	return "oci.miren.cloud/python:" + version + "-slim"
 }
 
-// GetRubyImage returns a Ruby image reference with the specified version.
-// The version is truncated to major.minor (e.g., "3.3.7" becomes "3.3") since
-// the registry only mirrors major.minor Ruby tags.
+// GetRubyImage returns a Ruby image reference with the specified version
 func GetRubyImage(version string) string {
-	// Truncate to major.minor only
-	parts := strings.SplitN(version, ".", 3)
-	if len(parts) >= 2 {
-		version = parts[0] + "." + parts[1]
-	}
 	return "oci.miren.cloud/ruby:" + version + "-slim"
 }
 
-// GetGolangImage returns a Golang image reference with the specified version.
-// The version is truncated to major.minor (e.g., "1.21.5" becomes "1.21").
+// GetGolangImage returns a Golang image reference with the specified version
 func GetGolangImage(version string) string {
-	// Truncate to major.minor only
-	parts := strings.SplitN(version, ".", 3)
-	if len(parts) >= 2 {
-		version = parts[0] + "." + parts[1]
-	}
 	return "oci.miren.cloud/golang:" + version + "-alpine"
 }
 

--- a/pkg/imagerefs/imagerefs_test.go
+++ b/pkg/imagerefs/imagerefs_test.go
@@ -4,17 +4,32 @@ import "testing"
 
 func TestGetRubyImage(t *testing.T) {
 	cases := map[string]string{
-		// Patch-level versions (e.g. from .ruby-version) truncate to the
-		// major.minor tag the registry actually mirrors.
-		"3.3.7": "oci.miren.cloud/ruby:3.3-slim",
-		"3.3.0": "oci.miren.cloud/ruby:3.3-slim",
-		// Already major.minor passes through unchanged.
-		"3.4": "oci.miren.cloud/ruby:3.4-slim",
-		"4.0": "oci.miren.cloud/ruby:4.0-slim",
+		// With our pull-through caching registry, patch-level versions
+		// are fully preserved instead of being truncated to major.minor.
+		"3.3.7": "oci.miren.cloud/ruby:3.3.7-slim",
+		"3.3.0": "oci.miren.cloud/ruby:3.3.0-slim",
+		"3.4":   "oci.miren.cloud/ruby:3.4-slim",
+		"4.0":   "oci.miren.cloud/ruby:4.0-slim",
 	}
 	for in, want := range cases {
 		if got := GetRubyImage(in); got != want {
 			t.Errorf("GetRubyImage(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGetGolangImage(t *testing.T) {
+	cases := map[string]string{
+		// With our pull-through caching registry, patch-level versions
+		// are fully preserved instead of being truncated to major.minor.
+		"1.21.5": "oci.miren.cloud/golang:1.21.5-alpine",
+		"1.21.0": "oci.miren.cloud/golang:1.21.0-alpine",
+		"1.22":   "oci.miren.cloud/golang:1.22-alpine",
+		"1.23":   "oci.miren.cloud/golang:1.23-alpine",
+	}
+	for in, want := range cases {
+		if got := GetGolangImage(in); got != want {
+			t.Errorf("GetGolangImage(%q) = %q, want %q", in, got, want)
 		}
 	}
 }


### PR DESCRIPTION
Now that RFD-87's pull-through cache is live the runtime can stop working around the old hand-maintained mirror and just ask for real upstream versions.

For the language stacks, `GetRubyImage` and `GetGolangImage` no longer truncate the requested version to `MAJOR.MINOR`. The mirror used to hold only `MAJOR.MINOR` tags so we trimmed to match; the cache serves any tag, so a `.ruby-version` of `3.3.7` now resolves to `ruby:3.3.7-slim` instead of silently building on `3.3`. Python and the other stacks already passed the full version through, so this brings Ruby and Go in line.

For the infrastructure images, the opaque `v1` tags give way to exact upstream versions served on demand: `etcd:v3.5.15`, `pause:3.8`, `victoria-logs:v1.0.0-victorialogs`, `victoria-metrics:v1.106.1`, and `minio:RELEASE.2025-04-03T14-56-28Z`. The proxy aliases each name to its real registry, so they resolve through the same front door. BuildKit is the exception: it's our own ghcr fork that only publishes a rolling `latest`, so it's pinned by digest (identical bytes to the old `buildkit:v1`). I verified every one of these resolves through `oci.miren.cloud` before flipping it.

Deployed clusters keep working throughout: the old `v1` images stay frozen behind the proxy's legacy-tag bypass, so anything still asking for `:v1` is served as before while new builds move to the real tags.

Part of MIR-1243.
