### PR TITLE
Move the Go buildpack to a glibc/bookworm base, with an adaptive runtime stage

### DIFF
--- a/pkg/imagerefs/imagerefs.go
+++ b/pkg/imagerefs/imagerefs.go
@@ -41,6 +41,17 @@ const (
 
 	// Default Busybox image
 	BusyboxDefault = "oci.miren.cloud/busybox:1.37-musl"
+
+	// GoRuntimeStatic is the runtime base for pure-Go (cgo-disabled) builds:
+	// a fully static binary lands here, yielding the canonical tiny Go image.
+	// distroless/static ships ca-certificates, tzdata, and a nonroot user but
+	// no shell or libc (docker.io/... proxied to gcr.io/distroless).
+	GoRuntimeStatic = "oci.miren.cloud/distroless/static-debian12:nonroot"
+
+	// DebianSlim is the runtime base for builds that need glibc at runtime
+	// (cgo) or that carry a runtime filesystem the static image can't hold
+	// (e.g. JS-augmented assets). It has a shell, apt, and glibc.
+	DebianSlim = "oci.miren.cloud/debian:bookworm-slim"
 )
 
 // GetPythonImage returns a Python image reference with the specified version
@@ -53,9 +64,14 @@ func GetRubyImage(version string) string {
 	return "oci.miren.cloud/ruby:" + version + "-slim"
 }
 
-// GetGolangImage returns a Golang image reference with the specified version
+// GetGolangImage returns a Golang builder image reference with the specified
+// version. The Go stack builds on the glibc/bookworm variant (not alpine/musl)
+// so cgo works out of the box: bookworm ships a C toolchain, and glibc is the
+// lingua franca of the prebuilt-binary world (MIR-1248). The build then copies
+// the resulting binary onto a minimal runtime base (see GoRuntimeStatic /
+// DebianSlim) so the heavyweight toolchain never reaches the final image.
 func GetGolangImage(version string) string {
-	return "oci.miren.cloud/golang:" + version + "-alpine"
+	return "oci.miren.cloud/golang:" + version + "-bookworm"
 }
 
 // GetBunImage returns a Bun runtime image reference with the specified version

--- a/pkg/imagerefs/imagerefs_test.go
+++ b/pkg/imagerefs/imagerefs_test.go
@@ -20,12 +20,13 @@ func TestGetRubyImage(t *testing.T) {
 
 func TestGetGolangImage(t *testing.T) {
 	cases := map[string]string{
-		// With our pull-through caching registry, patch-level versions
-		// are fully preserved instead of being truncated to major.minor.
-		"1.21.5": "oci.miren.cloud/golang:1.21.5-alpine",
-		"1.21.0": "oci.miren.cloud/golang:1.21.0-alpine",
-		"1.22":   "oci.miren.cloud/golang:1.22-alpine",
-		"1.23":   "oci.miren.cloud/golang:1.23-alpine",
+		// Go builds on the glibc/bookworm variant (MIR-1248), and the
+		// pull-through registry preserves full patch-level versions instead
+		// of truncating to major.minor.
+		"1.21.5": "oci.miren.cloud/golang:1.21.5-bookworm",
+		"1.21.0": "oci.miren.cloud/golang:1.21.0-bookworm",
+		"1.22":   "oci.miren.cloud/golang:1.22-bookworm",
+		"1.23":   "oci.miren.cloud/golang:1.23-bookworm",
 	}
 	for in, want := range cases {
 		if got := GetGolangImage(in); got != want {

--- a/pkg/stackbuild/augment_test.go
+++ b/pkg/stackbuild/augment_test.go
@@ -246,7 +246,7 @@ func TestDetectStack_AttachesAugmentationsToGo(t *testing.T) {
 	stack, err := DetectStack(dir, BuildOptions{Name: "test"})
 	require.NoError(t, err)
 	require.Equal(t, "go", stack.Name())
-	require.Equal(t, "alpine", stack.BaseDistro())
+	require.Equal(t, "debian", stack.BaseDistro())
 
 	ms := stack.metaStack()
 	require.Equal(t, []Augmentation{AugNpm}, ms.Augmentations())
@@ -262,7 +262,7 @@ func TestBaseDistros(t *testing.T) {
 		{&NodeStack{}, "debian"},
 		{&BunStack{}, "debian"},
 		{&RustStack{}, "debian"},
-		{&GoStack{}, "alpine"},
+		{&GoStack{}, "debian"},
 	}
 	for _, c := range cases {
 		require.Equal(t, c.distro, c.stack.BaseDistro(), "%s base distro", c.stack.Name())

--- a/pkg/stackbuild/golang.go
+++ b/pkg/stackbuild/golang.go
@@ -72,12 +72,19 @@ type GoStack struct {
 	// Cached go.mod content for dependency detection
 	goModContent []byte
 
+	// cgoEnabled is the resolved cgo decision: true builds with CGO_ENABLED=1
+	// against glibc and ships on a debian-slim runtime; false builds a static
+	// binary (CGO_ENABLED=0) bound for the distroless runtime. Set in Init().
+	cgoEnabled bool
+
 	// Detected environment variable requirements
 	requiredEnvVars []EnvVarRequirement
 }
 
 func (s *GoStack) BaseDistro() string {
-	return "alpine"
+	// The Go stack builds on golang:<v>-bookworm (glibc/debian), so the
+	// apt-based augmentation machinery applies, same as every other stack.
+	return "debian"
 }
 
 func (s *GoStack) Name() string {
@@ -120,6 +127,17 @@ func (s *GoStack) Init(opts BuildOptions) {
 	s.goModVersion = s.parseGoModVersion()
 	if s.goModVersion != "" {
 		s.Event("config", "go-version", "Go version "+s.goModVersion+" specified in go.mod")
+	}
+
+	// cgo is opt-in via the standard CGO_ENABLED build env var (set under [env]
+	// in app.toml). Off (the default) builds a static binary bound for the
+	// distroless runtime; on links against glibc and ships on debian-slim.
+	// Honoring the canonical Go knob keeps cgo off our app.toml schema, and it
+	// is a clean seam for the planned auto-detection follow-up, which will ask
+	// the toolchain directly and make the env var unnecessary.
+	s.cgoEnabled = opts.EnvVars["CGO_ENABLED"] == "1"
+	if s.cgoEnabled {
+		s.Event("config", "cgo", "Building with cgo enabled (CGO_ENABLED=1)")
 	}
 
 	// Detect required environment variables
@@ -195,16 +213,13 @@ func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
 
 	h := &highlevelBuilder{opts}
 
-	// Install git for private dependencies
-	state := h.apkAdd(base, "git", "ca-certificates")
+	// golang:bookworm already ships git and ca-certificates, and provides the C
+	// toolchain that makes cgo work, so no extra package install is needed on
+	// the builder before fetching private deps or compiling.
+	builder := h.applyAugmentations(base, localCtx, s.BaseDistro(), s.Augmentations(), s.SkipJSInstall())
 
-	// Add app user before copying code so copyApp can set ownership
-	state = s.addAppUser(state)
-
-	state = h.applyAugmentations(state, localCtx, s.BaseDistro(), s.Augmentations(), s.SkipJSInstall())
-
-	// Copy the application code (now owned by app user)
-	appState := h.copyApp(state, localCtx)
+	// Copy the application code (owned by the app user, uid 2010)
+	builder = h.copyApp(builder, localCtx)
 
 	// Use the pre-computed cmdDir from Init()
 	buildDir := s.cmdDir
@@ -217,9 +232,18 @@ func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
 		buildCmd = fmt.Sprintf("sh -c 'go mod download -json && go build -o /bin/app ./%s'", buildDir)
 	}
 
+	// Set CGO_ENABLED explicitly: bookworm ships gcc, so Go would otherwise
+	// default cgo on. Off (the default) keeps the binary static and bound for
+	// the distroless runtime; on links against glibc and ships on debian-slim.
+	cgoEnabled := "0"
+	if s.cgoEnabled {
+		cgoEnabled = "1"
+	}
+
 	// Build with cache
-	state = appState.Dir("/app").Run(
+	builder = builder.Dir("/app").Run(
 		llb.Shlex(buildCmd),
+		llb.AddEnv("CGO_ENABLED", cgoEnabled),
 
 		// This basically is just a scratch mount until we add the ability to
 		// properly export and import the cache dirs.
@@ -227,16 +251,85 @@ func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
 		llb.WithCustomName("[phase] Building Go application"),
 	).Root()
 
-	if opts.AlpineImage == "" {
-		opts.AlpineImage = imagerefs.AlpineDefault
+	// Make the built binary path available to onBuild commands, which run on
+	// the builder where the toolchain and full /app tree still exist.
+	builder = builder.AddEnv("APP", "/bin/app")
+	builder = s.applyOnBuild(builder, opts)
+
+	runtime := s.assembleRuntime(h, mr, builder)
+
+	return &runtime, nil
+}
+
+// assembleRuntime copies the build output onto a minimal runtime base, leaving
+// the heavyweight Go toolchain and module cache behind. The base adapts to the
+// build:
+//
+//   - cgo or JS-augmented apps land on debian-slim: cgo needs glibc at runtime,
+//     and augmented apps carry a built /app tree (compiled frontend assets,
+//     templates) that the binary serves. The full working tree is copied so
+//     that behavior is preserved.
+//   - everything else lands on distroless/static as a binary-only static image
+//     — the canonical tiny Go container. Apps on this path that need runtime
+//     files should embed them (go:embed); a JS augmentation or an explicit
+//     build.cgo = true routes them to the slim base instead.
+//
+// Both paths run as uid 2010 (the app user) for consistency with every other
+// stack: debian-slim creates it with adduser, distroless gets a written
+// /etc/passwd since it has no shell to run adduser.
+func (s *GoStack) assembleRuntime(h *highlevelBuilder, mr llb.ImageMetaResolver, builder llb.State) llb.State {
+	if s.cgoEnabled || len(s.Augmentations()) > 0 {
+		rt := llb.Image(imagerefs.DebianSlim, llb.WithMetaResolver(mr))
+		rt = h.aptInstall(rt, "ca-certificates")
+		rt = s.addAppUser(rt) // sets result.Config.User = "2010"
+		rt = rt.File(llb.Mkdir("/app", 0o755,
+			llb.WithParents(true), llb.WithUIDGID(2010, 2011)))
+		rt = rt.File(llb.Copy(builder, "/bin/app", "/bin/app", &llb.CopyInfo{}))
+		// Carry the built working tree (assets, templates, data files).
+		rt = rt.File(llb.Copy(builder, "/app", "/app", &llb.CopyInfo{
+			CopyDirContentsOnly: true,
+			CreateDestPath:      true,
+			FollowSymlinks:      true,
+			AllowWildcard:       true,
+			AllowEmptyWildcard:  true,
+			ChownOpt:            &appChown,
+		}))
+		return rt
 	}
 
-	state = state.AddEnv("APP", "/bin/app")
+	rt := llb.Image(imagerefs.GoRuntimeStatic, llb.WithMetaResolver(mr))
 
-	state = s.applyOnBuild(state, opts)
+	// distroless ships no shell or coreutils, which breaks two things: the
+	// runner launches the app as `/bin/sh -c <command>` (controllers/sandbox),
+	// and `miren sandbox exec` runs arbitrary commands like `echo`/`ls` in the
+	// container. Drop in a static (musl) busybox and symlink its whole applet
+	// set into /bin, giving /bin/sh plus the common coreutils. busybox is
+	// static so it runs regardless of the base's libc, and the lot adds about a
+	// megabyte.
+	busybox := llb.Image(imagerefs.BusyboxDefault)
+	rt = rt.File(llb.Copy(busybox, "/bin/busybox", "/bin/busybox", &llb.CopyInfo{}))
+	rt = rt.Run(
+		llb.Args([]string{"/bin/busybox", "sh", "-c",
+			"for a in $(/bin/busybox --list); do /bin/busybox ln -s /bin/busybox /bin/$a; done"}),
+		llb.WithCustomName("[phase] Installing busybox shell and coreutils"),
+	).Root()
 
-	return &state, nil
+	rt = rt.File(llb.Mkfile("/etc/passwd", 0o644, goRuntimePasswd))
+	rt = rt.File(llb.Mkfile("/etc/group", 0o644, goRuntimeGroup))
+	rt = rt.File(llb.Mkdir("/app", 0o755,
+		llb.WithParents(true), llb.WithUIDGID(2010, 2011)))
+	rt = rt.File(llb.Copy(builder, "/bin/app", "/bin/app", &llb.CopyInfo{}))
+	s.result.Config.User = "2010"
+	return rt
 }
+
+// goRuntimePasswd/goRuntimeGroup define the app user (uid 2010) on the
+// distroless static runtime, which has no shell to run adduser. A passwd entry
+// also lets pure-Go os/user lookups resolve the running uid.
+var (
+	goRuntimePasswd = []byte("root:x:0:0:root:/root:/sbin/nologin\napp:x:2010:2011:app:/app:/sbin/nologin\n")
+	goRuntimeGroup  = []byte("root:x:0:\napp:x:2011:\n")
+)
 
 func (s *GoStack) WebCommand() string {
 	return "/bin/app"

--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -295,14 +295,6 @@ func (h *highlevelBuilder) aptInstall(cur llb.State, pkgs ...string) llb.State {
 	).State
 }
 
-func (h *highlevelBuilder) apkAdd(cur llb.State, pkgs ...string) llb.State {
-	return cur.Run(
-		llb.Shlexf("apk add --no-cache %s", strings.Join(pkgs, " ")),
-		h.CacheMount("/var/cache/apk"),
-		llb.WithCustomName("[phase] Installing OS packages"),
-	).State
-}
-
 func (h *highlevelBuilder) bundleInstall(cur, mnt llb.State) llb.State {
 	// Because bundle install likes to modify the lock file, we copy the Gemfile and Gemfile.lock
 	// in rather than using h.Access to mount them in read only.

--- a/pkg/stackbuild/stackbuild_test.go
+++ b/pkg/stackbuild/stackbuild_test.go
@@ -1,6 +1,7 @@
 package stackbuild
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"io"
@@ -586,11 +587,84 @@ func TestGo(t *testing.T) {
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state, func(r io.Reader) {
+		// Scan the tar directly rather than via tarx.TarToMap: that helper keeps
+		// only regular files, and the busybox shell/coreutils land as symlinks.
+		names := map[string]bool{}
+		var appData []byte
+		tr := tar.NewReader(r)
+		for {
+			th, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			names[th.Name] = true
+			if th.Name == "bin/app" && th.Typeflag == tar.TypeReg {
+				appData, err = io.ReadAll(tr)
+				require.NoError(t, err)
+			}
+		}
+
+		require.NotEmpty(t, appData, "built binary should be present at bin/app")
+
+		// Pure-Go lands on the distroless static runtime, but it must still carry
+		// a busybox shell and coreutils. /bin/sh because the runner launches the
+		// app via `/bin/sh -c` (a shell-less image crash-loops at boot), and the
+		// likes of /bin/echo so `miren sandbox exec` can run commands in it. The
+		// heavyweight Go toolchain is left behind on the builder.
+		require.True(t, names["bin/sh"], "runtime needs /bin/sh; the runner execs the app via /bin/sh -c")
+		require.True(t, names["bin/echo"], "runtime needs busybox coreutils for `miren sandbox exec`")
+		require.False(t, names["usr/local/go/bin/go"], "runtime image must not carry the Go toolchain")
+		require.True(t, names["etc/passwd"], "distroless runtime should have an app-user passwd entry")
+	})
+}
+
+func TestGoCgo(t *testing.T) {
+	if !checkDocker() {
+		t.Skip("Docker not available")
+	}
+
+	root := t.TempDir()
+	dir := setupTestDir(root, t)
+
+	files := map[string]string{
+		"go.mod":  readFile(t, "go-cgo/go.mod"),
+		"main.go": readFile(t, "go-cgo/main.go"),
+	}
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))
+	}
+
+	// cgo is opt-in via the standard CGO_ENABLED build env var.
+	opts := BuildOptions{Version: "1.23", EnvVars: map[string]string{"CGO_ENABLED": "1"}}
+
+	stack := &GoStack{MetaStack: MetaStack{dir: dir}}
+	stack.Init(opts)
+	require.True(t, stack.cgoEnabled)
+
+	state, err := stack.GenerateLLB(dir, opts)
+	require.NoError(t, err)
+
+	buildLLB(t, dir, state, func(r io.Reader) {
 		m, err := tarx.TarToMap(r)
 		require.NoError(t, err)
-		data, ok := m["bin/app"]
-		require.True(t, ok)
+		// debian-slim has a merged /usr (/bin -> /usr/bin), so the binary
+		// copied to /bin/app lands at usr/bin/app; /bin/app still resolves to
+		// it via the symlink at runtime.
+		data, ok := m["usr/bin/app"]
+		if !ok {
+			data, ok = m["bin/app"]
+		}
+		require.True(t, ok, "cgo binary should be present (bin/app or usr/bin/app)")
 		require.NotEmpty(t, data)
+
+		// cgo lands on debian-slim (etc/debian_version is present there but not
+		// on the distroless static image), with the Go toolchain left behind on
+		// the builder.
+		_, hasDebian := m["etc/debian_version"]
+		require.True(t, hasDebian, "cgo image should ship on debian-slim")
+		_, hasToolchain := m["usr/local/go/bin/go"]
+		require.False(t, hasToolchain, "runtime image must not carry the Go toolchain")
 	})
 }
 
@@ -688,6 +762,34 @@ func TestGoVersionDetection(t *testing.T) {
 
 			version := stack.parseGoModVersion()
 			require.Equal(t, tc.expectedVersion, version)
+		})
+	}
+}
+
+func TestGoCgoEnvVar(t *testing.T) {
+	cgoEnv := func(v string) BuildOptions {
+		return BuildOptions{EnvVars: map[string]string{"CGO_ENABLED": v}}
+	}
+
+	cases := []struct {
+		name string
+		opts BuildOptions
+		want bool
+	}{
+		{"defaults to off (static, distroless)", BuildOptions{}, false},
+		{"CGO_ENABLED=1 enables cgo", cgoEnv("1"), true},
+		{"CGO_ENABLED=0 stays off", cgoEnv("0"), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"),
+				[]byte("module test-app\n\ngo 1.23\n"), 0644))
+
+			stack := &GoStack{MetaStack: MetaStack{dir: dir}}
+			stack.Init(tc.opts)
+			require.Equal(t, tc.want, stack.cgoEnabled)
 		})
 	}
 }

--- a/pkg/stackbuild/testdata/go-cgo/go.mod
+++ b/pkg/stackbuild/testdata/go-cgo/go.mod
@@ -1,0 +1,3 @@
+module test-cgo-app
+
+go 1.23

--- a/pkg/stackbuild/testdata/go-cgo/main.go
+++ b/pkg/stackbuild/testdata/go-cgo/main.go
@@ -1,0 +1,18 @@
+package main
+
+// A minimal cgo program: the `import "C"` plus a C snippet forces the build
+// onto the cgo path (CGO_ENABLED=1, glibc runtime) without pulling any external
+// module, keeping the build hermetic. Uses only the C stdlib.
+
+/*
+#include <stdio.h>
+
+static void greet(void) {
+	printf("hello from cgo\n");
+}
+*/
+import "C"
+
+func main() {
+	C.greet()
+}


### PR DESCRIPTION
Go was the odd one out. Every other language stack (Python, Ruby, Node, Bun, Rust) had already moved to debian/glibc, but the Go buildpack was still building on `golang:<v>-alpine`. musl is where a whole class of prebuilt-binary compatibility problems live, and cgo was the most visible symptom: source-compiled cgo fell back to `CGO_ENABLED=0` because the alpine builder ships no C toolchain, and prebuilt-glibc cgo like duckdb's vendored static archive couldn't link against musl at all.

So this moves the Go stack onto `golang:<v>-bookworm`, which ships a C toolchain so cgo works, and flips `BaseDistro()` to `"debian"` so the existing apt-vs-apk augmentation machinery applies. It mostly deletes an inconsistency rather than adding surface area. bookworm specifically, not trixie: it's the one debian codename Docker publishes for every Go version an app might pin (trixie images don't exist for Go ≤ 1.23), and keeping builder and runtime on the same codename avoids glibc skew.

The catch is image size. The Go stack ships the whole builder image as the final image today (it always has, same as Rust), so there was never a tiny-image story to protect, but a bookworm-with-toolchain builder would make that even chunkier. So the build is now genuinely multi-stage: it compiles on the heavyweight builder, then copies just the result onto a minimal runtime base. By default the binary is built `CGO_ENABLED=0` and ships on `distroless/static`, the tiny static Go image people expect. cgo apps ship on `debian-slim`, where glibc and a real runtime filesystem are available (that's also where JS-augmented apps land, since they carry built assets in `/app`). Both paths run as the app user, uid 2010, for consistency with every other stack. One wrinkle the blackbox suite caught: miren's runtime expects a shell and coreutils in the image. The runner launches every app as `/bin/sh -c <command>` (a shell-less image crash-loops at boot), and `miren sandbox exec` runs commands like `echo`/`ls` in the container. distroless ships neither, so it gets a static musl busybox with its applet symlinks, about a megabyte; debian-slim already has them. The same extract pattern sets up Rust to shed its builder image too, tracked in MIR-1259.

On turning cgo on: rather than add a Go-specific `cgo` field to the shared app.toml build schema, the buildpack honors the standard `CGO_ENABLED` env var. It's the canonical Go knob, so `CGO_ENABLED=1` doing a glibc build is the least surprising thing for a Go developer, and it keeps stack-specific concepts out of the schema. It's the explicit opt-in for now; a planned follow-up (MIR-1258) adds automatic detection (building the app to find out whether cgo is what makes it compile, the way #862 auto-detects the real port), at which point this same env var becomes the fast path that skips the extra detection pass.

Stacked on #864 (the imagerefs pull-through cleanup), since both touch `GetGolangImage`. The two runtime bases (`debian:bookworm-slim`, `distroless/static-debian12`) needed adding to the registry proxy allowlist, already applied to prod via mirendev/infra#77.

Closes MIR-1248
