### PR TITLE
Add absolute time-window filtering to `miren logs`

### DIFF
--- a/api/admin/admin_v1alpha/rpc.gen.go
+++ b/api/admin/admin_v1alpha/rpc.gen.go
@@ -593,6 +593,7 @@ func AdaptAdmin(t Admin) *rpc.Interface {
 			InterfaceName: "Admin",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "method", "params"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Invoke(ctx, &AdminInvoke{Call: call})
 			},
@@ -602,6 +603,7 @@ func AdaptAdmin(t Admin) *rpc.Interface {
 			InterfaceName: "Admin",
 			Index:         1,
 			Public:        false,
+			Params:        []string{"app"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListMethods(ctx, &AdminListMethods{Call: call})
 			},
@@ -611,6 +613,7 @@ func AdaptAdmin(t Admin) *rpc.Interface {
 			InterfaceName: "Admin",
 			Index:         2,
 			Public:        false,
+			Params:        []string{"app", "methods"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DescribeMethods(ctx, &AdminDescribeMethods{Call: call})
 			},

--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -3134,6 +3134,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.New(ctx, &CrudNew{Call: call})
 			},
@@ -3143,6 +3144,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "configuration"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetConfiguration(ctx, &CrudSetConfiguration{Call: call})
 			},
@@ -3152,6 +3154,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetConfiguration(ctx, &CrudGetConfiguration{Call: call})
 			},
@@ -3161,6 +3164,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "host"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetHost(ctx, &CrudSetHost{Call: call})
 			},
@@ -3170,6 +3174,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &CrudList{Call: call})
 			},
@@ -3179,6 +3184,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Destroy(ctx, &CrudDestroy{Call: call})
 			},
@@ -3188,6 +3194,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "key", "value", "sensitive", "service"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetEnvVar(ctx, &CrudSetEnvVar{Call: call})
 			},
@@ -3197,6 +3204,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "vars", "service"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetEnvVars(ctx, &CrudSetEnvVars{Call: call})
 			},
@@ -3206,6 +3214,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "vars", "service"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetInitialEnvVars(ctx, &CrudSetInitialEnvVars{Call: call})
 			},
@@ -3215,6 +3224,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "key", "service"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeleteEnvVar(ctx, &CrudDeleteEnvVar{Call: call})
 			},
@@ -3224,6 +3234,7 @@ func AdaptCrud(t Crud) *rpc.Interface {
 			InterfaceName: "Crud",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "service"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Restart(ctx, &CrudRestart{Call: call})
 			},
@@ -3753,6 +3764,7 @@ func AdaptUserQuery(t UserQuery) *rpc.Interface {
 			InterfaceName: "UserQuery",
 			Index:         0,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.WhoAmI(ctx, &UserQueryWhoAmI{Call: call})
 			},
@@ -3914,6 +3926,7 @@ func AdaptAppStatus(t AppStatus) *rpc.Interface {
 			InterfaceName: "AppStatus",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"application"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AppInfo(ctx, &AppStatusAppInfo{Call: call})
 			},
@@ -4231,6 +4244,7 @@ type logsStreamLogChunksArgsData struct {
 	Follow *bool               `cbor:"2,keyasint,omitempty" json:"follow,omitempty"`
 	Filter *string             `cbor:"3,keyasint,omitempty" json:"filter,omitempty"`
 	Chunks *rpc.Capability     `cbor:"4,keyasint,omitempty" json:"chunks,omitempty"`
+	To     *standard.Timestamp `cbor:"5,keyasint,omitempty" json:"to,omitempty"`
 }
 
 type LogsStreamLogChunksArgs struct {
@@ -4285,6 +4299,14 @@ func (v *LogsStreamLogChunksArgs) Chunks() *stream.SendStreamClient[*LogChunk] {
 		return nil
 	}
 	return &stream.SendStreamClient[*LogChunk]{Client: v.call.NewClient(v.data.Chunks)}
+}
+
+func (v *LogsStreamLogChunksArgs) HasTo() bool {
+	return v.data.To != nil
+}
+
+func (v *LogsStreamLogChunksArgs) To() *standard.Timestamp {
+	return v.data.To
 }
 
 func (v *LogsStreamLogChunksArgs) MarshalCBOR() ([]byte, error) {
@@ -4468,6 +4490,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			InterfaceName: "Logs",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"application", "from", "follow"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AppLogs(ctx, &LogsAppLogs{Call: call})
 			},
@@ -4477,6 +4500,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			InterfaceName: "Logs",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"sandbox", "from", "follow"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SandboxLogs(ctx, &LogsSandboxLogs{Call: call})
 			},
@@ -4486,6 +4510,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			InterfaceName: "Logs",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"target", "from", "follow", "logs"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.StreamLogs(ctx, &LogsStreamLogs{Call: call})
 			},
@@ -4495,6 +4520,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			InterfaceName: "Logs",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"target", "from", "follow", "filter", "chunks", "to"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.StreamLogChunks(ctx, &LogsStreamLogChunks{Call: call})
 			},
@@ -4612,7 +4638,7 @@ type LogsClientStreamLogChunksResults struct {
 	data   logsStreamLogChunksResultsData
 }
 
-func (v LogsClient) StreamLogChunks(ctx context.Context, target *LogTarget, from *standard.Timestamp, follow bool, filter string, chunks stream.SendStream[*LogChunk]) (*LogsClientStreamLogChunksResults, error) {
+func (v LogsClient) StreamLogChunks(ctx context.Context, target *LogTarget, from *standard.Timestamp, follow bool, filter string, chunks stream.SendStream[*LogChunk], to *standard.Timestamp) (*LogsClientStreamLogChunksResults, error) {
 	args := LogsStreamLogChunksArgs{}
 	caps := map[rpc.OID]*rpc.InlineCapability{}
 	args.data.Target = target
@@ -4624,6 +4650,7 @@ func (v LogsClient) StreamLogChunks(ctx context.Context, target *LogTarget, from
 		args.data.Chunks = c
 		caps[oid] = ic
 	}
+	args.data.To = to
 
 	var ret logsStreamLogChunksResultsData
 
@@ -5127,6 +5154,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"name", "capacity"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.New(ctx, &DisksNew{Call: call})
 			},
@@ -5136,6 +5164,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetById(ctx, &DisksGetById{Call: call})
 			},
@@ -5145,6 +5174,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetByName(ctx, &DisksGetByName{Call: call})
 			},
@@ -5154,6 +5184,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &DisksList{Call: call})
 			},
@@ -5163,6 +5194,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Delete(ctx, &DisksDelete{Call: call})
 			},
@@ -5678,6 +5710,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			InterfaceName: "Addons",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"name", "addon", "variant", "app", "version"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CreateInstance(ctx, &AddonsCreateInstance{Call: call})
 			},
@@ -5687,6 +5720,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			InterfaceName: "Addons",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListInstances(ctx, &AddonsListInstances{Call: call})
 			},
@@ -5696,6 +5730,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			InterfaceName: "Addons",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeleteInstance(ctx, &AddonsDeleteInstance{Call: call})
 			},

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -567,6 +567,9 @@ interfaces:
             doc: "Optional regex pattern to filter log lines"
           - name: chunks
             type: stream.SendStream[*LogChunk]
+          - name: to
+            type: standard.Timestamp
+            doc: "Optional upper time bound; when unset, reads up to now"
 
   - name: Disks
     methods:

--- a/api/build/build_v1alpha/rpc.gen.go
+++ b/api/build/build_v1alpha/rpc.gen.go
@@ -965,6 +965,7 @@ func AdaptStream(t Stream) *rpc.Interface {
 			InterfaceName: "Stream",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"count"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Recv(ctx, &StreamRecv{Call: call})
 			},
@@ -1570,6 +1571,7 @@ func AdaptBuilder(t Builder) *rpc.Interface {
 			InterfaceName: "Builder",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"application", "tardata", "status", "envVars", "ephemeral_label", "ephemeral_ttl"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.BuildFromTar(ctx, &BuilderBuildFromTar{Call: call})
 			},
@@ -1579,6 +1581,7 @@ func AdaptBuilder(t Builder) *rpc.Interface {
 			InterfaceName: "Builder",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"tardata"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AnalyzeApp(ctx, &BuilderAnalyzeApp{Call: call})
 			},
@@ -1588,6 +1591,7 @@ func AdaptBuilder(t Builder) *rpc.Interface {
 			InterfaceName: "Builder",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"application", "manifest"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.PrepareUpload(ctx, &BuilderPrepareUpload{Call: call})
 			},
@@ -1597,6 +1601,7 @@ func AdaptBuilder(t Builder) *rpc.Interface {
 			InterfaceName: "Builder",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"session_id", "tardata", "status", "envVars", "ephemeral_label", "ephemeral_ttl"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.BuildFromPrepared(ctx, &BuilderBuildFromPrepared{Call: call})
 			},

--- a/api/debug/debug_v1alpha/rpc.gen.go
+++ b/api/debug/debug_v1alpha/rpc.gen.go
@@ -825,6 +825,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			InterfaceName: "NetDB",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"subnet", "reserved_only", "released_only"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListLeases(ctx, &NetDBListLeases{Call: call})
 			},
@@ -834,6 +835,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			InterfaceName: "NetDB",
 			Index:         0,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Status(ctx, &NetDBStatus{Call: call})
 			},
@@ -843,6 +845,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			InterfaceName: "NetDB",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"ip"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ReleaseIP(ctx, &NetDBReleaseIP{Call: call})
 			},
@@ -852,6 +855,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			InterfaceName: "NetDB",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"subnet"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ReleaseSubnet(ctx, &NetDBReleaseSubnet{Call: call})
 			},
@@ -861,6 +865,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			InterfaceName: "NetDB",
 			Index:         0,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ReleaseAll(ctx, &NetDBReleaseAll{Call: call})
 			},
@@ -870,6 +875,7 @@ func AdaptNetDB(t NetDB) *rpc.Interface {
 			InterfaceName: "NetDB",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"subnet", "dry_run"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Gc(ctx, &NetDBGc{Call: call})
 			},

--- a/api/deployment/deployment_v1alpha/rpc.gen.go
+++ b/api/deployment/deployment_v1alpha/rpc.gen.go
@@ -2315,6 +2315,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app_name", "cluster_id", "app_version_id", "git_info"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CreateDeployment(ctx, &DeploymentCreateDeployment{Call: call})
 			},
@@ -2324,6 +2325,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         1,
 			Public:        false,
+			Params:        []string{"deployment_id", "status", "error_message"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.UpdateDeploymentStatus(ctx, &DeploymentUpdateDeploymentStatus{Call: call})
 			},
@@ -2333,6 +2335,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         2,
 			Public:        false,
+			Params:        []string{"deployment_id", "phase"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.UpdateDeploymentPhase(ctx, &DeploymentUpdateDeploymentPhase{Call: call})
 			},
@@ -2342,6 +2345,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         3,
 			Public:        false,
+			Params:        []string{"deployment_id", "error_message", "build_logs"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.UpdateFailedDeployment(ctx, &DeploymentUpdateFailedDeployment{Call: call})
 			},
@@ -2351,6 +2355,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         4,
 			Public:        false,
+			Params:        []string{"deployment_id", "app_version_id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.UpdateDeploymentAppVersion(ctx, &DeploymentUpdateDeploymentAppVersion{Call: call})
 			},
@@ -2360,6 +2365,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         5,
 			Public:        false,
+			Params:        []string{"app_name", "cluster_id", "status", "limit"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListDeployments(ctx, &DeploymentListDeployments{Call: call})
 			},
@@ -2369,6 +2375,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         6,
 			Public:        false,
+			Params:        []string{"deployment_id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetDeploymentById(ctx, &DeploymentGetDeploymentById{Call: call})
 			},
@@ -2378,6 +2385,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         7,
 			Public:        false,
+			Params:        []string{"app_name", "cluster_id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetActiveDeployment(ctx, &DeploymentGetActiveDeployment{Call: call})
 			},
@@ -2387,6 +2395,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         8,
 			Public:        false,
+			Params:        []string{"deployment_id", "caller_user_id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CancelDeployment(ctx, &DeploymentCancelDeployment{Call: call})
 			},
@@ -2396,6 +2405,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         9,
 			Public:        false,
+			Params:        []string{"app_name", "cluster_id", "app_version_id", "is_rollback", "env_vars", "ephemeral_label", "ephemeral_ttl"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeployVersion(ctx, &DeploymentDeployVersion{Call: call})
 			},
@@ -2405,6 +2415,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         10,
 			Public:        false,
+			Params:        []string{"app_name", "cluster_id", "vars", "service"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetEnvVars(ctx, &DeploymentSetEnvVars{Call: call})
 			},
@@ -2414,6 +2425,7 @@ func AdaptDeployment(t Deployment) *rpc.Interface {
 			InterfaceName: "Deployment",
 			Index:         11,
 			Public:        false,
+			Params:        []string{"app_name", "cluster_id", "keys", "service"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeleteEnvVars(ctx, &DeploymentDeleteEnvVars{Call: call})
 			},

--- a/api/entityserver/entityserver_v1alpha/rpc.gen.go
+++ b/api/entityserver/entityserver_v1alpha/rpc.gen.go
@@ -577,6 +577,7 @@ func AdaptStream(t Stream) *rpc.Interface {
 			InterfaceName: "Stream",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"count"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Recv(ctx, &StreamRecv{Call: call})
 			},
@@ -2667,6 +2668,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Get(ctx, &EntityAccessGet{Call: call})
 			},
@@ -2676,6 +2678,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"entity"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Put(ctx, &EntityAccessPut{Call: call})
 			},
@@ -2685,6 +2688,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"attrs"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Create(ctx, &EntityAccessCreate{Call: call})
 			},
@@ -2694,6 +2698,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"attrs", "revision"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Replace(ctx, &EntityAccessReplace{Call: call})
 			},
@@ -2703,6 +2708,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"attrs", "revision"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Patch(ctx, &EntityAccessPatch{Call: call})
 			},
@@ -2712,6 +2718,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"attrs"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Ensure(ctx, &EntityAccessEnsure{Call: call})
 			},
@@ -2721,6 +2728,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"entity", "session"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.PutSession(ctx, &EntityAccessPutSession{Call: call})
 			},
@@ -2730,6 +2738,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Delete(ctx, &EntityAccessDelete{Call: call})
 			},
@@ -2739,6 +2748,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"index", "from_revision", "values"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.WatchIndex(ctx, &EntityAccessWatchIndex{Call: call})
 			},
@@ -2748,6 +2758,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id", "updates"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.WatchEntity(ctx, &EntityAccessWatchEntity{Call: call})
 			},
@@ -2757,6 +2768,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"index"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &EntityAccessList{Call: call})
 			},
@@ -2766,6 +2778,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id", "value"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.MakeAttr(ctx, &EntityAccessMakeAttr{Call: call})
 			},
@@ -2775,6 +2788,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"kind"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.LookupKind(ctx, &EntityAccessLookupKind{Call: call})
 			},
@@ -2784,6 +2798,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"data"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Parse(ctx, &EntityAccessParse{Call: call})
 			},
@@ -2793,6 +2808,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"entity"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Format(ctx, &EntityAccessFormat{Call: call})
 			},
@@ -2802,6 +2818,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"ttl", "usage"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CreateSession(ctx, &EntityAccessCreateSession{Call: call})
 			},
@@ -2811,6 +2828,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.RevokeSession(ctx, &EntityAccessRevokeSession{Call: call})
 			},
@@ -2820,6 +2838,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.PingSession(ctx, &EntityAccessPingSession{Call: call})
 			},
@@ -2829,6 +2848,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"dry_run"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Reindex(ctx, &EntityAccessReindex{Call: call})
 			},
@@ -2838,6 +2858,7 @@ func AdaptEntityAccess(t EntityAccess) *rpc.Interface {
 			InterfaceName: "EntityAccess",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"tag"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetAttributesByTag(ctx, &EntityAccessGetAttributesByTag{Call: call})
 			},

--- a/api/exec/exec_v1alpha/rpc.gen.go
+++ b/api/exec/exec_v1alpha/rpc.gen.go
@@ -350,6 +350,7 @@ func AdaptSandboxExec(t SandboxExec) *rpc.Interface {
 			InterfaceName: "SandboxExec",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"category", "value", "command", "options", "input", "output", "window_updates"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Exec(ctx, &SandboxExecExec{Call: call})
 			},

--- a/api/httpingress/httpingress_v1alpha/rpc.gen.go
+++ b/api/httpingress/httpingress_v1alpha/rpc.gen.go
@@ -393,6 +393,7 @@ func AdaptInternalHttp(t InternalHttp) *rpc.Interface {
 			InterfaceName: "InternalHttp",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"request"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DoRequest(ctx, &InternalHttpDoRequest{Call: call})
 			},

--- a/api/metric/metric_v1alpha/rpc.gen.go
+++ b/api/metric/metric_v1alpha/rpc.gen.go
@@ -314,6 +314,7 @@ func AdaptSandboxMetrics(t SandboxMetrics) *rpc.Interface {
 			InterfaceName: "SandboxMetrics",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"sandbox"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Snapshot(ctx, &SandboxMetricsSnapshot{Call: call})
 			},

--- a/api/oidcbinding/oidcbinding_v1alpha/rpc.gen.go
+++ b/api/oidcbinding/oidcbinding_v1alpha/rpc.gen.go
@@ -577,6 +577,7 @@ func AdaptOidcBindings(t OidcBindings) *rpc.Interface {
 			InterfaceName: "OidcBindings",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "provider", "issuer", "subject_pattern", "claim_conditions", "description"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Add(ctx, &OidcBindingsAdd{Call: call})
 			},
@@ -586,6 +587,7 @@ func AdaptOidcBindings(t OidcBindings) *rpc.Interface {
 			InterfaceName: "OidcBindings",
 			Index:         1,
 			Public:        false,
+			Params:        []string{"app"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &OidcBindingsList{Call: call})
 			},
@@ -595,6 +597,7 @@ func AdaptOidcBindings(t OidcBindings) *rpc.Interface {
 			InterfaceName: "OidcBindings",
 			Index:         2,
 			Public:        false,
+			Params:        []string{"id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Remove(ctx, &OidcBindingsRemove{Call: call})
 			},

--- a/api/outboard/outboard_v1alpha/rpc.gen.go
+++ b/api/outboard/outboard_v1alpha/rpc.gen.go
@@ -358,6 +358,7 @@ func AdaptOutboardControl(t OutboardControl) *rpc.Interface {
 			InterfaceName: "OutboardControl",
 			Index:         0,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Health(ctx, &OutboardControlHealth{Call: call})
 			},
@@ -367,6 +368,7 @@ func AdaptOutboardControl(t OutboardControl) *rpc.Interface {
 			InterfaceName: "OutboardControl",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"expected_version"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CheckVersion(ctx, &OutboardControlCheckVersion{Call: call})
 			},

--- a/api/rpc.gen.go
+++ b/api/rpc.gen.go
@@ -839,6 +839,7 @@ func AdaptUserQuery(t UserQuery) *rpc.Interface {
 			InterfaceName: "UserQuery",
 			Index:         0,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.WhoAmI(ctx, &UserQueryWhoAmI{Call: call})
 			},
@@ -1000,6 +1001,7 @@ func AdaptAppInfo(t AppInfo) *rpc.Interface {
 			InterfaceName: "AppInfo",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"application"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AppInfo(ctx, &AppInfoAppInfo{Call: call})
 			},
@@ -1184,6 +1186,7 @@ func AdaptLogs(t Logs) *rpc.Interface {
 			InterfaceName: "Logs",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"application", "from", "follow"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.AppLogs(ctx, &LogsAppLogs{Call: call})
 			},
@@ -1729,6 +1732,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"name", "capacity"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.New(ctx, &DisksNew{Call: call})
 			},
@@ -1738,6 +1742,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetById(ctx, &DisksGetById{Call: call})
 			},
@@ -1747,6 +1752,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetByName(ctx, &DisksGetByName{Call: call})
 			},
@@ -1756,6 +1762,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.List(ctx, &DisksList{Call: call})
 			},
@@ -1765,6 +1772,7 @@ func AdaptDisks(t Disks) *rpc.Interface {
 			InterfaceName: "Disks",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Delete(ctx, &DisksDelete{Call: call})
 			},
@@ -2280,6 +2288,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			InterfaceName: "Addons",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"name", "addon", "variant", "app", "version"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CreateInstance(ctx, &AddonsCreateInstance{Call: call})
 			},
@@ -2289,6 +2298,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			InterfaceName: "Addons",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListInstances(ctx, &AddonsListInstances{Call: call})
 			},
@@ -2298,6 +2308,7 @@ func AdaptAddons(t Addons) *rpc.Interface {
 			InterfaceName: "Addons",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"app", "name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DeleteInstance(ctx, &AddonsDeleteInstance{Call: call})
 			},

--- a/api/runner/runner_v1alpha/rpc.gen.go
+++ b/api/runner/runner_v1alpha/rpc.gen.go
@@ -1458,6 +1458,7 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			InterfaceName: "RunnerRegistration",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"labels", "expires_in_hours", "name", "reusable", "ttl_seconds", "coordinator_addr"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.CreateInvite(ctx, &RunnerRegistrationCreateInvite{Call: call})
 			},
@@ -1467,6 +1468,7 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			InterfaceName: "RunnerRegistration",
 			Index:         1,
 			Public:        true,
+			Params:        []string{"code", "runner_id", "listen_addr", "version", "labels", "name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Join(ctx, &RunnerRegistrationJoin{Call: call})
 			},
@@ -1476,6 +1478,7 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			InterfaceName: "RunnerRegistration",
 			Index:         2,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListInvites(ctx, &RunnerRegistrationListInvites{Call: call})
 			},
@@ -1485,6 +1488,7 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			InterfaceName: "RunnerRegistration",
 			Index:         3,
 			Public:        false,
+			Params:        []string{"invite_id"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.RevokeInvite(ctx, &RunnerRegistrationRevokeInvite{Call: call})
 			},
@@ -1494,6 +1498,7 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			InterfaceName: "RunnerRegistration",
 			Index:         4,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ListRunners(ctx, &RunnerRegistrationListRunners{Call: call})
 			},
@@ -1503,6 +1508,7 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			InterfaceName: "RunnerRegistration",
 			Index:         5,
 			Public:        false,
+			Params:        []string{"query", "force"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.RemoveRunner(ctx, &RunnerRegistrationRemoveRunner{Call: call})
 			},
@@ -1512,6 +1518,7 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			InterfaceName: "RunnerRegistration",
 			Index:         6,
 			Public:        false,
+			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.WorkloadIssuerInfo(ctx, &RunnerRegistrationWorkloadIssuerInfo{Call: call})
 			},
@@ -1521,6 +1528,7 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			InterfaceName: "RunnerRegistration",
 			Index:         7,
 			Public:        false,
+			Params:        []string{"sandbox_id", "audience", "ttl_seconds"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.IssueWorkloadToken(ctx, &RunnerRegistrationIssueWorkloadToken{Call: call})
 			},
@@ -1530,6 +1538,7 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			InterfaceName: "RunnerRegistration",
 			Index:         8,
 			Public:        true,
+			Params:        []string{"listen_addr"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.RefreshCertificate(ctx, &RunnerRegistrationRefreshCertificate{Call: call})
 			},

--- a/api/telemetry/telemetry_v1alpha/rpc.gen.go
+++ b/api/telemetry/telemetry_v1alpha/rpc.gen.go
@@ -116,6 +116,7 @@ func AdaptTelemetry(t Telemetry) *rpc.Interface {
 			InterfaceName: "Telemetry",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"span_data"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ReportSpans(ctx, &TelemetryReportSpans{Call: call})
 			},

--- a/cli/commands/logs.go
+++ b/cli/commands/logs.go
@@ -63,12 +63,95 @@ func buildSystemFilter(component, userFilter string) string {
 	return filter
 }
 
+// timeFlagLayouts are the absolute timestamp formats accepted by --since/--until,
+// tried in order. Naive (zoneless) layouts are interpreted in the local timezone,
+// matching docker and journalctl.
+var timeFlagLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02 15:04:05",
+	"2006-01-02 15:04",
+	"2006-01-02",
+	"15:04:05",
+	"15:04",
+}
+
+// parseTimeFlag resolves a --since/--until value to an absolute time. It accepts
+// RFC3339 timestamps, a handful of common naive layouts (interpreted in local
+// time, with time-only forms anchored to today), and Go durations like "2h" or
+// "90m", which are treated as that long ago relative to now.
+func parseTimeFlag(s string, now time.Time) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, fmt.Errorf("empty time value")
+	}
+
+	for _, layout := range timeFlagLayouts {
+		t, err := time.ParseInLocation(layout, s, time.Local)
+		if err != nil {
+			continue
+		}
+		// Time-only layouts parse with a zero (year 0) date; anchor them to today.
+		if t.Year() == 0 {
+			t = time.Date(now.Year(), now.Month(), now.Day(),
+				t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.Local)
+		}
+		return t, nil
+	}
+
+	if d, err := time.ParseDuration(s); err == nil {
+		return now.Add(-d), nil
+	}
+
+	return time.Time{}, fmt.Errorf(
+		"not a recognized timestamp or duration (try RFC3339, '2006-01-02 15:04', or a duration like '2h')")
+}
+
+// resolveLogWindow computes the from/until bounds for a log query from the
+// --last/--since/--until flags, enforcing the flag-combination rules. A nil
+// return means that bound is open (read from the start of retention / up to now).
+func resolveLogWindow(last *time.Duration, since, until string, follow bool, now time.Time) (from, to *standard.Timestamp, err error) {
+	if since != "" && last != nil {
+		return nil, nil, fmt.Errorf("--since and --last both set the start of the window; use one or the other")
+	}
+	if until != "" && follow {
+		return nil, nil, fmt.Errorf("--until cannot be combined with --follow (a live tail has no end)")
+	}
+
+	switch {
+	case since != "":
+		t, perr := parseTimeFlag(since, now)
+		if perr != nil {
+			return nil, nil, fmt.Errorf("invalid --since value %q: %w", since, perr)
+		}
+		from = standard.ToTimestamp(t)
+	case last != nil:
+		from = standard.ToTimestamp(now.Add(-*last))
+	}
+
+	if until != "" {
+		t, perr := parseTimeFlag(until, now)
+		if perr != nil {
+			return nil, nil, fmt.Errorf("invalid --until value %q: %w", until, perr)
+		}
+		to = standard.ToTimestamp(t)
+	}
+
+	if from != nil && to != nil && standard.FromTimestamp(to).Before(standard.FromTimestamp(from)) {
+		return nil, nil, fmt.Errorf("the window is empty: --until is before --since")
+	}
+
+	return from, to, nil
+}
+
 // LogsApp shows application logs. This is the default subcommand for `miren logs`.
 func LogsApp(ctx *Context, opts struct {
 	AppCentric
 	FormatOptions
 
 	Last    *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
+	Since   string         `long:"since" description:"Show logs since a time (RFC3339, '2006-01-02 15:04', or a duration like '2h' ago)"`
+	Until   string         `long:"until" description:"Show logs until a time (RFC3339, '2006-01-02 15:04', or a duration like '30m' ago); not valid with --follow"`
 	Follow  bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
 	Filter  string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
 	Service string         `long:"service" description:"Filter logs by service name (e.g., 'web', 'worker')"`
@@ -78,10 +161,16 @@ func LogsApp(ctx *Context, opts struct {
 		return err
 	}
 
+	from, until, err := resolveLogWindow(opts.Last, opts.Since, opts.Until, opts.Follow, time.Now())
+	if err != nil {
+		return err
+	}
+
 	combinedFilter := buildFilterWithService(opts.Filter, opts.Service)
 	return dispatchLogs(ctx, cl, logDispatchArgs{
 		app:            opts.App,
-		last:           opts.Last,
+		from:           from,
+		until:          until,
 		follow:         opts.Follow,
 		rawFilter:      opts.Filter,
 		combinedFilter: combinedFilter,
@@ -96,6 +185,8 @@ func LogsSandbox(ctx *Context, opts struct {
 
 	SandboxID string         `position:"0" usage:"Sandbox ID" required:"true"`
 	Last      *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
+	Since     string         `long:"since" description:"Show logs since a time (RFC3339, '2006-01-02 15:04', or a duration like '2h' ago)"`
+	Until     string         `long:"until" description:"Show logs until a time (RFC3339, '2006-01-02 15:04', or a duration like '30m' ago); not valid with --follow"`
 	Follow    bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
 	Filter    string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
 }) error {
@@ -106,9 +197,15 @@ func LogsSandbox(ctx *Context, opts struct {
 		return err
 	}
 
+	from, until, err := resolveLogWindow(opts.Last, opts.Since, opts.Until, opts.Follow, time.Now())
+	if err != nil {
+		return err
+	}
+
 	return dispatchLogs(ctx, cl, logDispatchArgs{
 		sandbox:        sandbox,
-		last:           opts.Last,
+		from:           from,
+		until:          until,
 		follow:         opts.Follow,
 		rawFilter:      opts.Filter,
 		combinedFilter: opts.Filter,
@@ -123,6 +220,8 @@ func LogsBuild(ctx *Context, opts struct {
 
 	Version string         `position:"0" usage:"Build version (e.g., v3)" required:"true"`
 	Last    *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
+	Since   string         `long:"since" description:"Show logs since a time (RFC3339, '2006-01-02 15:04', or a duration like '2h' ago)"`
+	Until   string         `long:"until" description:"Show logs until a time (RFC3339, '2006-01-02 15:04', or a duration like '30m' ago); not valid with --follow"`
 	Follow  bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
 	Filter  string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
 }) error {
@@ -131,10 +230,16 @@ func LogsBuild(ctx *Context, opts struct {
 		return err
 	}
 
+	from, until, err := resolveLogWindow(opts.Last, opts.Since, opts.Until, opts.Follow, time.Now())
+	if err != nil {
+		return err
+	}
+
 	combinedFilter := buildBuildFilter(opts.Version, opts.Filter)
 	return dispatchLogs(ctx, cl, logDispatchArgs{
 		app:            opts.App,
-		last:           opts.Last,
+		from:           from,
+		until:          until,
 		follow:         opts.Follow,
 		rawFilter:      opts.Filter,
 		combinedFilter: combinedFilter,
@@ -149,6 +254,8 @@ func LogsSystem(ctx *Context, opts struct {
 
 	Component string         `position:"0" usage:"System component to filter by (e.g., 'etcd', 'scheduler')"`
 	Last      *time.Duration `short:"l" long:"last" description:"Show logs from the last duration"`
+	Since     string         `long:"since" description:"Show logs since a time (RFC3339, '2006-01-02 15:04', or a duration like '2h' ago)"`
+	Until     string         `long:"until" description:"Show logs until a time (RFC3339, '2006-01-02 15:04', or a duration like '30m' ago); not valid with --follow"`
 	Follow    bool           `short:"f" long:"follow" description:"Follow log output (live tail)"`
 	Filter    string         `short:"g" long:"grep" description:"Filter logs (e.g., 'error', '\"exact phrase\"', 'error -debug', '/regex/')"`
 }) error {
@@ -161,16 +268,20 @@ func LogsSystem(ctx *Context, opts struct {
 		return fmt.Errorf("system logs require a newer server version")
 	}
 
+	from, until, err := resolveLogWindow(opts.Last, opts.Since, opts.Until, opts.Follow, time.Now())
+	if err != nil {
+		return err
+	}
+	// When no time bounds and no --follow, from is nil → server returns last 100 lines
+
+	if until != nil && !cl.HasMethodParam(ctx, "streamLogChunks", "to") {
+		return fmt.Errorf("--until requires a newer server version")
+	}
+
 	target := &app_v1alpha.LogTarget{}
 	target.SetSystem(true)
 
 	combinedFilter := buildSystemFilter(opts.Component, opts.Filter)
-
-	var ts *standard.Timestamp
-	if opts.Last != nil {
-		ts = standard.ToTimestamp(time.Now().Add(-*opts.Last))
-	}
-	// When no --last and no --follow, ts is nil → server returns last 100 lines
 
 	printer, flush := logPrinter(ctx, opts.IsJSON(), opts.Follow)
 	defer flush()
@@ -183,7 +294,7 @@ func LogsSystem(ctx *Context, opts struct {
 		return nil
 	})
 
-	_, err = ac.StreamLogChunks(ctx, target, ts, opts.Follow, combinedFilter, callback)
+	_, err = ac.StreamLogChunks(ctx, target, from, opts.Follow, combinedFilter, callback, until)
 	return err
 }
 
@@ -192,7 +303,8 @@ func LogsSystem(ctx *Context, opts struct {
 type logDispatchArgs struct {
 	app            string
 	sandbox        string
-	last           *time.Duration
+	from           *standard.Timestamp
+	until          *standard.Timestamp
 	follow         bool
 	rawFilter      string
 	combinedFilter string
@@ -220,6 +332,14 @@ func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, args logDispatchArgs) err
 
 	// Check if server supports streaming (prefer chunked for efficiency)
 	if cl.HasMethod(ctx, "streamLogChunks") {
+		// The `to` bound (from --until) is a parameter added to streamLogChunks
+		// after it first shipped. A server with the method but not the parameter
+		// would silently ignore the bound, so detect that and error instead of
+		// quietly returning a wider window than asked for.
+		if args.until != nil && !cl.HasMethodParam(ctx, "streamLogChunks", "to") {
+			return fmt.Errorf("--until requires a newer server version")
+		}
+
 		// Append system exclusion for server-side filtering on app queries
 		filter := args.combinedFilter
 		if args.app != "" {
@@ -229,7 +349,12 @@ func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, args logDispatchArgs) err
 				filter = systemExclusion + " " + filter
 			}
 		}
-		return streamLogChunks(ctx, cl, args.app, args.sandbox, args.last, args.follow, filter, printer)
+		return streamLogChunks(ctx, cl, args.app, args.sandbox, args.from, args.until, args.follow, filter, printer)
+	}
+
+	// Servers without streamLogChunks can't honor an upper bound at all.
+	if args.until != nil {
+		return fmt.Errorf("--until requires a newer server version")
 	}
 
 	// Older server - warn about upgrade and limited functionality
@@ -253,7 +378,7 @@ func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, args logDispatchArgs) err
 	}
 
 	if cl.HasMethod(ctx, "streamLogs") {
-		return streamLogs(ctx, cl, args.app, args.sandbox, args.last, args.follow, filter, printer)
+		return streamLogs(ctx, cl, args.app, args.sandbox, args.from, args.follow, filter, printer)
 	}
 
 	// Warn if --follow requested but not supported
@@ -262,7 +387,7 @@ func dispatchLogs(ctx *Context, cl *rpc.NetworkClient, args logDispatchArgs) err
 	}
 
 	// Fall back to legacy pagination
-	return legacyLogs(ctx, cl, args.app, args.sandbox, args.last, filter, printer)
+	return legacyLogs(ctx, cl, args.app, args.sandbox, args.from, filter, printer)
 }
 
 var streamTypePrefixes = map[string]string{
@@ -488,7 +613,7 @@ func formatAttributes(m map[string]string) string {
 	return b.String()
 }
 
-func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *time.Duration, follow bool, filter *logfilter.Filter, printer func(*app_v1alpha.LogEntry)) error {
+func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, from *standard.Timestamp, follow bool, filter *logfilter.Filter, printer func(*app_v1alpha.LogEntry)) error {
 	ac := app_v1alpha.LogsClient{Client: cl}
 
 	// Build target
@@ -499,14 +624,9 @@ func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *
 		target.SetApp(app)
 	}
 
-	// Determine start time
-	var ts *standard.Timestamp
-	if last != nil {
-		ts = standard.ToTimestamp(time.Now().Add(-*last))
-	}
-	// When no --last: ts is nil
-	// - follow mode: start from now
-	// - non-follow: server returns last 100 lines
+	// from is resolved by the caller from --last/--since. When nil: follow
+	// starts from now, non-follow returns the last 100 lines. This protocol has
+	// no end bound, so --until is rejected before reaching here.
 
 	// Create callback to print logs as they arrive
 	callback := stream.Callback(func(l *app_v1alpha.LogEntry) error {
@@ -519,11 +639,11 @@ func streamLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *
 		return nil
 	})
 
-	_, err := ac.StreamLogs(ctx, target, ts, follow, callback)
+	_, err := ac.StreamLogs(ctx, target, from, follow, callback)
 	return err
 }
 
-func streamLogChunks(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *time.Duration, follow bool, filter string, printer func(*app_v1alpha.LogEntry)) error {
+func streamLogChunks(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, from, until *standard.Timestamp, follow bool, filter string, printer func(*app_v1alpha.LogEntry)) error {
 	ac := app_v1alpha.LogsClient{Client: cl}
 
 	// Build target
@@ -534,14 +654,9 @@ func streamLogChunks(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, l
 		target.SetApp(app)
 	}
 
-	// Determine start time
-	var ts *standard.Timestamp
-	if last != nil {
-		ts = standard.ToTimestamp(time.Now().Add(-*last))
-	}
-	// When no --last: ts is nil
-	// - follow mode: start from now
-	// - non-follow: server returns last 100 lines
+	// from/until are resolved by the caller from --last/--since/--until. When
+	// from is nil: follow starts from now, non-follow returns the last 100 lines.
+	// When until is nil, the server reads up to now.
 
 	// Create callback to print logs as they arrive in chunks
 	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error {
@@ -551,18 +666,15 @@ func streamLogChunks(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, l
 		return nil
 	})
 
-	_, err := ac.StreamLogChunks(ctx, target, ts, follow, filter, callback)
+	_, err := ac.StreamLogChunks(ctx, target, from, follow, filter, callback, until)
 	return err
 }
 
-func legacyLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, last *time.Duration, filter *logfilter.Filter, printer func(*app_v1alpha.LogEntry)) error {
+func legacyLogs(ctx *Context, cl *rpc.NetworkClient, app, sandbox string, from *standard.Timestamp, filter *logfilter.Filter, printer func(*app_v1alpha.LogEntry)) error {
 	ac := app_v1alpha.LogsClient{Client: cl}
 
-	var ts *standard.Timestamp
-
-	if last != nil {
-		ts = standard.ToTimestamp(time.Now().Add(-*last))
-	} else {
+	ts := from
+	if ts == nil {
 		// Legacy protocol can't do server-side limit=100, so default to
 		// last 1 hour as a reasonable bounded window of recent logs.
 		ts = standard.ToTimestamp(time.Now().Add(-1 * time.Hour))

--- a/cli/commands/logs_doc.go
+++ b/cli/commands/logs_doc.go
@@ -15,17 +15,28 @@ Running ` + "`" + `miren logs` + "`" + ` without a subcommand shows app logs (ba
 
 ## Time Range
 
-By default, logs show the last 100 lines. Use ` + "`" + `--last` + "`" + ` to specify a time range:
+By default, logs show the last 100 lines. Use ` + "`" + `--since` + "`" + ` and ` + "`" + `--until` + "`" + ` to bound the window. Each accepts an RFC3339 timestamp, a friendlier ` + "`" + `2006-01-02 15:04` + "`" + ` style time (interpreted in your local timezone), or a duration that's read as "ago":
 
 ` + "```" + `bash
-# Show logs from the last 5 minutes
-miren logs --last 5m
+# Last 5 minutes (a duration is read as "ago")
+miren logs --since 5m
 
-# Show logs from the last hour
+# A bounded historical window, e.g. chasing an incident
+miren logs --since "2026-06-25 14:00" --until "2026-06-25 14:30"
+
+# From an absolute start up to now
+miren logs --since 2026-06-25T14:00:00Z
+
+# Everything up to a point in the past (start of retention through --until)
+miren logs --until "2026-06-25 14:30"
+` + "```" + `
+
+` + "`" + `--since` + "`" + ` and ` + "`" + `--until` + "`" + ` compose with ` + "`" + `--grep` + "`" + ` and ` + "`" + `--service` + "`" + `. ` + "`" + `--until` + "`" + ` can't be combined with ` + "`" + `--follow` + "`" + ` (a live tail has no end). The older ` + "`" + `--last` + "`" + ` flag still works and is equivalent to ` + "`" + `--since` + "`" + ` with a duration:
+
+` + "```" + `bash
+# These two are equivalent
 miren logs --last 1h
-
-# Show logs from the last 24 hours
-miren logs --last 24h
+miren logs --since 1h
 ` + "```" + `
 
 ## Following Logs

--- a/cli/commands/logs_test.go
+++ b/cli/commands/logs_test.go
@@ -526,6 +526,152 @@ func TestFormatAttributes(t *testing.T) {
 	})
 }
 
+func TestParseTimeFlag(t *testing.T) {
+	now := time.Date(2026, 6, 26, 15, 30, 0, 0, time.Local)
+
+	t.Run("RFC3339 with zone", func(t *testing.T) {
+		got, err := parseTimeFlag("2026-06-25T14:00:00Z", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := time.Date(2026, 6, 25, 14, 0, 0, 0, time.UTC); !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("naive datetime parsed as local", func(t *testing.T) {
+		got, err := parseTimeFlag("2026-06-25 14:00", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := time.Date(2026, 6, 25, 14, 0, 0, 0, time.Local); !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("date only is midnight local", func(t *testing.T) {
+		got, err := parseTimeFlag("2026-06-25", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := time.Date(2026, 6, 25, 0, 0, 0, 0, time.Local); !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("time only anchors to today", func(t *testing.T) {
+		got, err := parseTimeFlag("14:30", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := time.Date(2026, 6, 26, 14, 30, 0, 0, time.Local); !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("duration is treated as ago", func(t *testing.T) {
+		got, err := parseTimeFlag("2h", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := now.Add(-2 * time.Hour); !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("surrounding whitespace tolerated", func(t *testing.T) {
+		got, err := parseTimeFlag("  90m  ", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := now.Add(-90 * time.Minute); !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	for _, in := range []string{"", "not-a-time", "2026/06/25", "yesterday"} {
+		t.Run("rejects "+in, func(t *testing.T) {
+			if _, err := parseTimeFlag(in, now); err == nil {
+				t.Errorf("parseTimeFlag(%q) = nil error, want error", in)
+			}
+		})
+	}
+}
+
+func TestResolveLogWindow(t *testing.T) {
+	now := time.Date(2026, 6, 26, 15, 30, 0, 0, time.Local)
+	dur := 2 * time.Hour
+
+	at := func(ts *standard.Timestamp) time.Time { return standard.FromTimestamp(ts) }
+
+	t.Run("--since and --last conflict", func(t *testing.T) {
+		if _, _, err := resolveLogWindow(&dur, "1h", "", false, now); err == nil {
+			t.Error("expected error when both --since and --last set")
+		}
+	})
+
+	t.Run("--until with --follow conflict", func(t *testing.T) {
+		if _, _, err := resolveLogWindow(nil, "", "1h", true, now); err == nil {
+			t.Error("expected error when --until combined with --follow")
+		}
+	})
+
+	t.Run("--last sets from, until open", func(t *testing.T) {
+		from, to, err := resolveLogWindow(&dur, "", "", false, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if to != nil {
+			t.Errorf("expected nil until, got %v", at(to))
+		}
+		if want := now.Add(-dur); !at(from).Equal(want) {
+			t.Errorf("from = %v, want %v", at(from), want)
+		}
+	})
+
+	t.Run("--since and --until set both bounds", func(t *testing.T) {
+		from, to, err := resolveLogWindow(nil, "2026-06-25T14:00:00Z", "2026-06-25T15:00:00Z", false, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := time.Date(2026, 6, 25, 14, 0, 0, 0, time.UTC); !at(from).Equal(want) {
+			t.Errorf("from = %v, want %v", at(from), want)
+		}
+		if want := time.Date(2026, 6, 25, 15, 0, 0, 0, time.UTC); !at(to).Equal(want) {
+			t.Errorf("until = %v, want %v", at(to), want)
+		}
+	})
+
+	t.Run("no flags leaves both open", func(t *testing.T) {
+		from, to, err := resolveLogWindow(nil, "", "", false, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if from != nil || to != nil {
+			t.Errorf("expected both nil, got from=%v to=%v", from, to)
+		}
+	})
+
+	t.Run("invalid --since surfaces error", func(t *testing.T) {
+		if _, _, err := resolveLogWindow(nil, "bogus", "", false, now); err == nil {
+			t.Error("expected error for invalid --since")
+		}
+	})
+
+	t.Run("invalid --until surfaces error", func(t *testing.T) {
+		if _, _, err := resolveLogWindow(nil, "", "bogus", false, now); err == nil {
+			t.Error("expected error for invalid --until")
+		}
+	})
+
+	t.Run("inverted window is rejected", func(t *testing.T) {
+		// --since 1h, --until 2h → start (1h ago) is after end (2h ago).
+		if _, _, err := resolveLogWindow(nil, "1h", "2h", false, now); err == nil {
+			t.Error("expected error when --until is before --since")
+		}
+	})
+}
+
 func TestBuildSystemFilter(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/docs/docs/command/logs-app.md
+++ b/docs/docs/command/logs-app.md
@@ -23,17 +23,28 @@ Running `miren logs` without a subcommand shows app logs (backward compatible).
 
 ## Time Range
 
-By default, logs show the last 100 lines. Use `--last` to specify a time range:
+By default, logs show the last 100 lines. Use `--since` and `--until` to bound the window. Each accepts an RFC3339 timestamp, a friendlier `2006-01-02 15:04` style time (interpreted in your local timezone), or a duration that's read as "ago":
 
 ```bash
-# Show logs from the last 5 minutes
-miren logs --last 5m
+# Last 5 minutes (a duration is read as "ago")
+miren logs --since 5m
 
-# Show logs from the last hour
+# A bounded historical window, e.g. chasing an incident
+miren logs --since "2026-06-25 14:00" --until "2026-06-25 14:30"
+
+# From an absolute start up to now
+miren logs --since 2026-06-25T14:00:00Z
+
+# Everything up to a point in the past (start of retention through --until)
+miren logs --until "2026-06-25 14:30"
+```
+
+`--since` and `--until` compose with `--grep` and `--service`. `--until` can't be combined with `--follow` (a live tail has no end). The older `--last` flag still works and is equivalent to `--since` with a duration:
+
+```bash
+# These two are equivalent
 miren logs --last 1h
-
-# Show logs from the last 24 hours
-miren logs --last 24h
+miren logs --since 1h
 ```
 
 ## Following Logs
@@ -110,6 +121,8 @@ miren logs app [flags]
 - `--json` — Shorthand for --format json
 - `--last, -l` — Show logs from the last duration
 - `--service` — Filter logs by service name (e.g., 'web', 'worker')
+- `--since` — Show logs since a time (RFC3339, '2006-01-02 15:04', or a duration like '2h' ago)
+- `--until` — Show logs until a time (RFC3339, '2006-01-02 15:04', or a duration like '30m' ago); not valid with --follow
 
 ## Config Options
 

--- a/docs/docs/command/logs-build.md
+++ b/docs/docs/command/logs-build.md
@@ -25,6 +25,8 @@ miren logs build <version> [flags]
 - `--grep, -g` — Filter logs (e.g., 'error', '"exact phrase"', 'error -debug', '/regex/')
 - `--json` — Shorthand for --format json
 - `--last, -l` — Show logs from the last duration
+- `--since` — Show logs since a time (RFC3339, '2006-01-02 15:04', or a duration like '2h' ago)
+- `--until` — Show logs until a time (RFC3339, '2006-01-02 15:04', or a duration like '30m' ago); not valid with --follow
 
 ## Config Options
 

--- a/docs/docs/command/logs-sandbox.md
+++ b/docs/docs/command/logs-sandbox.md
@@ -27,6 +27,8 @@ miren logs sandbox <sandboxid> [flags]
 - `--grep, -g` — Filter logs (e.g., 'error', '"exact phrase"', 'error -debug', '/regex/')
 - `--json` — Shorthand for --format json
 - `--last, -l` — Show logs from the last duration
+- `--since` — Show logs since a time (RFC3339, '2006-01-02 15:04', or a duration like '2h' ago)
+- `--until` — Show logs until a time (RFC3339, '2006-01-02 15:04', or a duration like '30m' ago); not valid with --follow
 
 ## Global Options
 

--- a/docs/docs/command/logs-system.md
+++ b/docs/docs/command/logs-system.md
@@ -27,6 +27,8 @@ miren logs system <component> [flags]
 - `--grep, -g` — Filter logs (e.g., 'error', '"exact phrase"', 'error -debug', '/regex/')
 - `--json` — Shorthand for --format json
 - `--last, -l` — Show logs from the last duration
+- `--since` — Show logs since a time (RFC3339, '2006-01-02 15:04', or a duration like '2h' ago)
+- `--until` — Show logs until a time (RFC3339, '2006-01-02 15:04', or a duration like '30m' ago); not valid with --follow
 
 ## Global Options
 

--- a/docs/docs/command/logs.md
+++ b/docs/docs/command/logs.md
@@ -23,17 +23,28 @@ Running `miren logs` without a subcommand shows app logs (backward compatible).
 
 ## Time Range
 
-By default, logs show the last 100 lines. Use `--last` to specify a time range:
+By default, logs show the last 100 lines. Use `--since` and `--until` to bound the window. Each accepts an RFC3339 timestamp, a friendlier `2006-01-02 15:04` style time (interpreted in your local timezone), or a duration that's read as "ago":
 
 ```bash
-# Show logs from the last 5 minutes
-miren logs --last 5m
+# Last 5 minutes (a duration is read as "ago")
+miren logs --since 5m
 
-# Show logs from the last hour
+# A bounded historical window, e.g. chasing an incident
+miren logs --since "2026-06-25 14:00" --until "2026-06-25 14:30"
+
+# From an absolute start up to now
+miren logs --since 2026-06-25T14:00:00Z
+
+# Everything up to a point in the past (start of retention through --until)
+miren logs --until "2026-06-25 14:30"
+```
+
+`--since` and `--until` compose with `--grep` and `--service`. `--until` can't be combined with `--follow` (a live tail has no end). The older `--last` flag still works and is equivalent to `--since` with a duration:
+
+```bash
+# These two are equivalent
 miren logs --last 1h
-
-# Show logs from the last 24 hours
-miren logs --last 24h
+miren logs --since 1h
 ```
 
 ## Following Logs
@@ -110,6 +121,8 @@ miren logs [flags]
 - `--json` — Shorthand for --format json
 - `--last, -l` — Show logs from the last duration
 - `--service` — Filter logs by service name (e.g., 'web', 'worker')
+- `--since` — Show logs since a time (RFC3339, '2006-01-02 15:04', or a duration like '2h' ago)
+- `--until` — Show logs until a time (RFC3339, '2006-01-02 15:04', or a duration like '30m' ago); not valid with --follow
 
 ## Config Options
 

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -225,6 +225,7 @@ func NewLogReader(address string, timeout time.Duration) *LogReader {
 
 type logReadOpts struct {
 	From  time.Time
+	Until time.Time
 	Limit int
 }
 
@@ -233,6 +234,14 @@ type LogReaderOption func(*logReadOpts)
 func WithFromTime(t time.Time) LogReaderOption {
 	return func(o *logReadOpts) {
 		o.From = t
+	}
+}
+
+// WithUntilTime bounds the query to entries at or before t. When unset, queries
+// read up to the present.
+func WithUntilTime(t time.Time) LogReaderOption {
+	return func(o *logReadOpts) {
+		o.Until = t
 	}
 }
 
@@ -363,8 +372,12 @@ func (l *LogReader) executeStreamQuery(ctx context.Context, query string, logCh 
 	if startTime.IsZero() {
 		startTime = time.Now().Add(-24 * time.Hour)
 	}
+	endTime := o.Until
+	if endTime.IsZero() {
+		endTime = time.Now()
+	}
 	params.Set("start", startTime.Format(time.RFC3339Nano))
-	params.Set("end", time.Now().Format(time.RFC3339Nano))
+	params.Set("end", endTime.Format(time.RFC3339Nano))
 
 	fullURL := fmt.Sprintf("%s?%s", queryURL, params.Encode())
 

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -305,36 +305,50 @@ func (c *NetworkClient) reresolveCapability(rs *InterfaceState) error {
 	return nil
 }
 
-// ListMethods returns the list of methods available on this capability.
-// Returns an error if the server doesn't support method introspection (old servers).
-func (c *NetworkClient) ListMethods(ctx context.Context) ([]string, error) {
+// fetchMethods queries the server's method-introspection endpoint. Returns an
+// error if the server doesn't support introspection (old servers).
+func (c *NetworkClient) fetchMethods(ctx context.Context) (methodsResponse, error) {
+	if c.localClient != nil {
+		return c.localClient.listMethods(), nil
+	}
+
 	url := "https://" + c.remote + "/_rpc/methods/" + string(c.oid)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, err
+		return methodsResponse{}, err
 	}
 
 	c.addBearerToken(req)
 
 	resp, err := c.roundTrip(req)
 	if err != nil {
-		return nil, err
+		return methodsResponse{}, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return methodsResponse{}, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
 	var result methodsResponse
 	if err := cbor.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, err
+		return methodsResponse{}, err
 	}
 
 	if result.Error != "" {
-		return nil, errors.New(result.Error)
+		return methodsResponse{}, errors.New(result.Error)
 	}
 
+	return result, nil
+}
+
+// ListMethods returns the list of methods available on this capability.
+// Returns an error if the server doesn't support method introspection (old servers).
+func (c *NetworkClient) ListMethods(ctx context.Context) ([]string, error) {
+	result, err := c.fetchMethods(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return result.Methods, nil
 }
 
@@ -347,6 +361,24 @@ func (c *NetworkClient) HasMethod(ctx context.Context, method string) bool {
 	}
 	for _, m := range methods {
 		if m == method {
+			return true
+		}
+	}
+	return false
+}
+
+// HasMethodParam reports whether the remote interface's method accepts a given
+// parameter. This distinguishes servers that have a method from servers that
+// have a newer revision of it with an added parameter. Returns false if the
+// method or parameter is absent, or if the server is too old to report
+// parameters at all (introspection predates this, or the method itself).
+func (c *NetworkClient) HasMethodParam(ctx context.Context, method, param string) bool {
+	result, err := c.fetchMethods(ctx)
+	if err != nil {
+		return false
+	}
+	for _, p := range result.Params[method] {
+		if p == param {
 			return true
 		}
 	}

--- a/pkg/rpc/example/rpc.go
+++ b/pkg/rpc/example/rpc.go
@@ -365,6 +365,7 @@ func AdaptMeter(t Meter) *rpc.Interface {
 			InterfaceName: "Meter",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.ReadTemperature(ctx, &MeterReadTemperature{Call: call})
 			},
@@ -374,6 +375,7 @@ func AdaptMeter(t Meter) *rpc.Interface {
 			InterfaceName: "Meter",
 			Index:         1,
 			Public:        false,
+			Params:        []string{"name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetSetter(ctx, &MeterGetSetter{Call: call})
 			},
@@ -561,6 +563,7 @@ func AdaptSetTemp(t SetTemp) *rpc.Interface {
 			InterfaceName: "SetTemp",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"temp"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetTemp(ctx, &SetTempSetTemp{Call: call})
 			},
@@ -717,6 +720,7 @@ func AdaptUpdateReceiver(t UpdateReceiver) *rpc.Interface {
 			InterfaceName: "UpdateReceiver",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"reading"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Update(ctx, &UpdateReceiverUpdate{Call: call})
 			},
@@ -865,6 +869,7 @@ func AdaptMeterUpdates(t MeterUpdates) *rpc.Interface {
 			InterfaceName: "MeterUpdates",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"recv"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.RegisterUpdates(ctx, &MeterUpdatesRegisterUpdates{Call: call})
 			},
@@ -1018,6 +1023,7 @@ func AdaptAdjustTemp(t AdjustTemp) *rpc.Interface {
 			InterfaceName: "AdjustTemp",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"setter"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Adjust(ctx, &AdjustTempAdjust{Call: call})
 			},
@@ -1171,6 +1177,7 @@ func AdaptSetTempG[T any](t SetTempG[T]) *rpc.Interface {
 			InterfaceName: "SetTempG",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"temp"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.SetTemp(ctx, &SetTempGSetTemp[T]{Call: call})
 			},
@@ -1319,6 +1326,7 @@ func AdaptEmitTemps(t EmitTemps) *rpc.Interface {
 			InterfaceName: "EmitTemps",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"emitter"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Emit(ctx, &EmitTempsEmit{Call: call})
 			},

--- a/pkg/rpc/generator.go
+++ b/pkg/rpc/generator.go
@@ -2013,6 +2013,11 @@ func (g *Generator) generateInterfaces(f *j.File) error {
 						g.Line().Id("InterfaceName").Op(":").Lit(i.Name)
 						g.Line().Id("Index").Op(":").Lit(m.Index)
 						g.Line().Id("Public").Op(":").Lit(m.Public)
+						g.Line().Id("Params").Op(":").Index().String().ValuesFunc(func(g *j.Group) {
+							for _, p := range m.Parameters {
+								g.Lit(p.Name)
+							}
+						})
 						g.Line().Id("Handler").Op(":").Func().Params(
 							j.Id("ctx").Qual("context", "Context"),
 							j.Id("call").Qual(rpc, "Call"),

--- a/pkg/rpc/introspect_test.go
+++ b/pkg/rpc/introspect_test.go
@@ -1,0 +1,51 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+)
+
+// TestHasMethodParam covers parameter-level capability detection: a client can
+// tell a server that has a method from one that has a newer revision of it with
+// an added parameter. This is what lets callers gate a flag like --until on
+// actual `to` support instead of mere method presence.
+func TestHasMethodParam(t *testing.T) {
+	noop := func(ctx context.Context, call Call) error { return nil }
+	iface := NewInterface([]Method{
+		{
+			Name:          "streamLogChunks",
+			InterfaceName: "Logs",
+			Params:        []string{"target", "from", "follow", "filter", "chunks", "to"},
+			Handler:       noop,
+		},
+		{
+			// Stands in for an older revision: method exists, no `to` param.
+			Name:          "appLogs",
+			InterfaceName: "Logs",
+			Params:        []string{"application", "from", "follow"},
+			Handler:       noop,
+		},
+	}, struct{}{})
+
+	c := LocalClient(iface)
+	ctx := context.Background()
+
+	if !c.HasMethod(ctx, "streamLogChunks") {
+		t.Fatal("expected streamLogChunks to be present")
+	}
+	if c.HasMethod(ctx, "missingMethod") {
+		t.Error("unknown method must report absent")
+	}
+	if !c.HasMethodParam(ctx, "streamLogChunks", "to") {
+		t.Error("expected streamLogChunks to advertise the 'to' param")
+	}
+	if c.HasMethodParam(ctx, "streamLogChunks", "bogus") {
+		t.Error("a parameter the method does not declare must report false")
+	}
+	if c.HasMethodParam(ctx, "appLogs", "to") {
+		t.Error("appLogs has no 'to' param; this is the old-server case the gate guards")
+	}
+	if c.HasMethodParam(ctx, "missingMethod", "to") {
+		t.Error("unknown method must report false, not panic")
+	}
+}

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -117,6 +117,11 @@ type Method struct {
 	// Public marks this method as accessible without TLS client certificate authentication.
 	// The RPC layer will reject unauthenticated calls to non-public methods automatically.
 	Public bool
+	// Params lists the method's parameter names in schema order. It powers
+	// parameter-level capability detection: a client can ask whether a server
+	// understands a specific parameter (e.g. one added after the method first
+	// shipped) instead of only whether the method exists. See HasMethodParam.
+	Params []string
 }
 
 type HasRestoreState interface {
@@ -534,6 +539,26 @@ type lookupResponse struct {
 type methodsResponse struct {
 	Methods []string `json:"methods,omitempty" cbor:"methods,omitempty"`
 	Error   string   `json:"error,omitempty" cbor:"error,omitempty"`
+	// Params maps each method name to its parameter names. Added after Methods,
+	// so older servers simply omit it and newer clients read a nil map as "this
+	// server can't report parameters" rather than "no parameters."
+	Params map[string][]string `json:"params,omitempty" cbor:"params,omitempty"`
+}
+
+// newMethodsResponse builds an introspection response from an interface's method
+// set. Shared by the network discovery endpoint and the in-process transport so
+// the two can't report different things.
+func newMethodsResponse(m map[string]Method) methodsResponse {
+	methods := make([]string, 0, len(m))
+	params := make(map[string][]string, len(m))
+	for name, mm := range m {
+		methods = append(methods, name)
+		if len(mm.Params) > 0 {
+			params[name] = mm.Params
+		}
+	}
+	sort.Strings(methods)
+	return methodsResponse{Methods: methods, Params: params}
 }
 
 func (s *Server) listMethods(w http.ResponseWriter, r *http.Request) {
@@ -553,13 +578,7 @@ func (s *Server) listMethods(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	methods := make([]string, 0, len(hc.methods))
-	for name := range hc.methods {
-		methods = append(methods, name)
-	}
-	sort.Strings(methods)
-
-	cbor.NewEncoder(w).Encode(methodsResponse{Methods: methods})
+	cbor.NewEncoder(w).Encode(newMethodsResponse(hc.methods))
 }
 
 func (s *Server) lookup(w http.ResponseWriter, r *http.Request) {

--- a/pkg/rpc/stream/stream.gen.go
+++ b/pkg/rpc/stream/stream.gen.go
@@ -122,6 +122,7 @@ func AdaptSendStream[T any](t SendStream[T]) *rpc.Interface {
 			InterfaceName: "SendStream",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"value"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Send(ctx, &SendStreamSend[T]{Call: call})
 			},
@@ -287,6 +288,7 @@ func AdaptRecvStream[T any](t RecvStream[T]) *rpc.Interface {
 			InterfaceName: "RecvStream",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"count"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Recv(ctx, &RecvStreamRecv[T]{Call: call})
 			},

--- a/pkg/rpc/test_helpers.go
+++ b/pkg/rpc/test_helpers.go
@@ -74,6 +74,10 @@ type localClient struct {
 	iface *Interface
 }
 
+func (l *localClient) listMethods() methodsResponse {
+	return newMethodsResponse(l.iface.methods)
+}
+
 func (l *localClient) Call(ctx context.Context, name string, arg, ret any) error {
 	m, ok := l.iface.methods[name]
 	if !ok {

--- a/pkg/rpc/testdata/generic.go
+++ b/pkg/rpc/testdata/generic.go
@@ -165,6 +165,7 @@ func AdaptReader[T any](t Reader[T]) *rpc.Interface {
 			InterfaceName: "Reader",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"value"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.Read(ctx, &ReaderRead[T]{Call: call})
 			},

--- a/pkg/rpc/testdata/rpc.go
+++ b/pkg/rpc/testdata/rpc.go
@@ -278,6 +278,7 @@ func AdaptTown(t Town) *rpc.Interface {
 			InterfaceName: "Town",
 			Index:         0,
 			Public:        true,
+			Params:        []string{"name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.GetHero(ctx, &TownGetHero{Call: call})
 			},
@@ -287,6 +288,7 @@ func AdaptTown(t Town) *rpc.Interface {
 			InterfaceName: "Town",
 			Index:         1,
 			Public:        false,
+			Params:        []string{"name"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.HireHero(ctx, &TownHireHero{Call: call})
 			},
@@ -485,6 +487,7 @@ func AdaptEmpower(t Empower) *rpc.Interface {
 			InterfaceName: "Empower",
 			Index:         0,
 			Public:        false,
+			Params:        []string{"power"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.IncreasePower(ctx, &EmpowerIncreasePower{Call: call})
 			},

--- a/servers/logs/logs.go
+++ b/servers/logs/logs.go
@@ -273,6 +273,10 @@ func (s *Server) StreamLogChunks(ctx context.Context, state *app_v1alpha.LogsStr
 	} else if !args.Follow() {
 		opts = append(opts, observability.WithLimit(defaultTailLimit))
 	}
+	if args.HasTo() {
+		toTime := standard.FromTimestamp(args.To())
+		opts = append(opts, observability.WithUntilTime(toTime))
+	}
 
 	logTarget, err := s.resolveLogTarget(ctx, target)
 	if err != nil {

--- a/servers/logs/logs_test.go
+++ b/servers/logs/logs_test.go
@@ -152,7 +152,7 @@ func TestStreamLogChunks_Basic(t *testing.T) {
 	target := &app_v1alpha.LogTarget{}
 	target.SetApp("test-app")
 
-	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback, nil)
 	r.NoError(err)
 
 	mu.Lock()
@@ -217,7 +217,7 @@ func TestStreamLogChunks_Chunking(t *testing.T) {
 	target := &app_v1alpha.LogTarget{}
 	target.SetApp("test-app")
 
-	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback, nil)
 	r.NoError(err)
 
 	mu.Lock()
@@ -277,7 +277,7 @@ func TestStreamLogChunks_BySandbox(t *testing.T) {
 	target := &app_v1alpha.LogTarget{}
 	target.SetSandbox("sandbox/test-sandbox-123")
 
-	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback, nil)
 	r.NoError(err)
 
 	mu.Lock()
@@ -325,13 +325,61 @@ func TestStreamLogChunks_WithFromTime(t *testing.T) {
 
 	fromTime := standard.ToTimestamp(now.Add(-1 * time.Hour))
 
-	_, err = client.StreamLogChunks(ctx, target, fromTime, false, "", callback)
+	_, err = client.StreamLogChunks(ctx, target, fromTime, false, "", callback, nil)
 	r.NoError(err)
 
 	mu.Lock()
 	defer mu.Unlock()
 
 	r.NotEmpty(receivedChunks)
+}
+
+// TestStreamLogChunks_WithUntilTime verifies the `to` bound is threaded all the
+// way to the VictoriaLogs query as the `end` parameter, rather than the server
+// hardcoding end=now.
+func TestStreamLogChunks_WithUntilTime(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	r := require.New(t)
+
+	until := time.Now().Add(-30 * time.Minute)
+
+	var mu sync.Mutex
+	var gotEnd string
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		gotEnd = req.URL.Query().Get("end")
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	server, ec, cleanup := setupTestServer(t, mockServer)
+	defer cleanup()
+
+	app := &core_v1alpha.App{}
+	_, err := ec.Create(ctx, "test-app", app)
+	r.NoError(err)
+
+	client := &app_v1alpha.LogsClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptLogs(server)),
+	}
+
+	callback := stream.Callback(func(chunk *app_v1alpha.LogChunk) error { return nil })
+
+	target := &app_v1alpha.LogTarget{}
+	target.SetApp("test-app")
+
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback, standard.ToTimestamp(until))
+	r.NoError(err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	r.NotEmpty(gotEnd, "expected the server to forward an end bound to victorialogs")
+	parsed, err := time.Parse(time.RFC3339Nano, gotEnd)
+	r.NoError(err)
+	r.WithinDuration(until, parsed, time.Second)
 }
 
 func TestStreamLogChunks_FollowModePeriodicFlush(t *testing.T) {
@@ -393,7 +441,7 @@ func TestStreamLogChunks_FollowModePeriodicFlush(t *testing.T) {
 	target := &app_v1alpha.LogTarget{}
 	target.SetApp("test-app")
 
-	_, err = client.StreamLogChunks(ctx, target, nil, true, "", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, true, "", callback, nil)
 	r.NoError(err)
 
 	mu.Lock()
@@ -431,7 +479,7 @@ func TestStreamLogChunks_ErrorNoTarget(t *testing.T) {
 	// Empty target - should error
 	target := &app_v1alpha.LogTarget{}
 
-	_, err := client.StreamLogChunks(ctx, target, nil, false, "", callback)
+	_, err := client.StreamLogChunks(ctx, target, nil, false, "", callback, nil)
 	r.Error(err)
 	r.Contains(err.Error(), "target must specify exactly one of app, sandbox, or system")
 }
@@ -457,7 +505,7 @@ func TestStreamLogChunks_AppNotFound(t *testing.T) {
 	target := &app_v1alpha.LogTarget{}
 	target.SetApp("nonexistent-app")
 
-	_, err := client.StreamLogChunks(ctx, target, nil, false, "", callback)
+	_, err := client.StreamLogChunks(ctx, target, nil, false, "", callback, nil)
 	r.Error(err)
 }
 
@@ -504,7 +552,7 @@ func TestStreamLogChunks_LogEntryFields(t *testing.T) {
 	target := &app_v1alpha.LogTarget{}
 	target.SetApp("test-app")
 
-	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "", callback, nil)
 	r.NoError(err)
 
 	mu.Lock()
@@ -558,7 +606,7 @@ func TestStreamLogChunks_FilterPassedToVictoriaLogs(t *testing.T) {
 	target.SetApp("test-app")
 
 	// Filter for ERROR logs - this should be passed to VictoriaLogs
-	_, err = client.StreamLogChunks(ctx, target, nil, false, "ERROR", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "ERROR", callback, nil)
 	r.NoError(err)
 
 	mu.Lock()
@@ -608,7 +656,7 @@ func TestStreamLogChunks_FilterNoMatches(t *testing.T) {
 	target.SetApp("test-app")
 
 	// Filter for something that doesn't exist
-	_, err = client.StreamLogChunks(ctx, target, nil, false, "CRITICAL", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "CRITICAL", callback, nil)
 	r.NoError(err)
 
 	mu.Lock()
@@ -696,7 +744,7 @@ func TestStreamLogChunks_FilterWithFollow(t *testing.T) {
 	target.SetApp("test-app")
 
 	// Filter for ERROR in follow mode
-	_, err = client.StreamLogChunks(ctx, target, nil, true, "ERROR", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, true, "ERROR", callback, nil)
 	r.NoError(err)
 
 	mu.Lock()
@@ -765,7 +813,7 @@ func TestStreamLogChunks_InvalidFilterRegex(t *testing.T) {
 	target.SetApp("test-app")
 
 	// Invalid regex should return error
-	_, err = client.StreamLogChunks(ctx, target, nil, false, "/[invalid/", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "/[invalid/", callback, nil)
 	r.Error(err)
 	r.Contains(err.Error(), "invalid filter")
 }
@@ -819,7 +867,7 @@ func TestStreamLogChunks_FilterWithRegex(t *testing.T) {
 	target.SetApp("test-app")
 
 	// Use regex filter syntax /pattern/
-	_, err = client.StreamLogChunks(ctx, target, nil, false, "/ERR(OR)?/", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "/ERR(OR)?/", callback, nil)
 	r.NoError(err)
 
 	// Verify the query contains the compiled LogsQL regex format
@@ -872,7 +920,7 @@ func TestStreamLogChunks_FilterWithNegation(t *testing.T) {
 	target.SetApp("test-app")
 
 	// Use negation filter syntax: show errors but not debug
-	_, err = client.StreamLogChunks(ctx, target, nil, false, "error -debug", callback)
+	_, err = client.StreamLogChunks(ctx, target, nil, false, "error -debug", callback, nil)
 	r.NoError(err)
 
 	// Verify the query contains negation
@@ -941,7 +989,7 @@ func TestStreamLogChunks_QueryContract(t *testing.T) {
 		target.SetApp("test-app")
 
 		// No from time, no follow → server applies default limit
-		_, err := client.StreamLogChunks(ctx, target, nil, false, "", noop)
+		_, err := client.StreamLogChunks(ctx, target, nil, false, "", noop, nil)
 		r.NoError(err)
 
 		mu.Lock()
@@ -962,7 +1010,7 @@ func TestStreamLogChunks_QueryContract(t *testing.T) {
 		target.SetApp("test-app")
 
 		fromTime := standard.ToTimestamp(now.Add(-5 * time.Minute))
-		_, err := client.StreamLogChunks(ctx, target, fromTime, false, "", noop)
+		_, err := client.StreamLogChunks(ctx, target, fromTime, false, "", noop, nil)
 		r.NoError(err)
 
 		mu.Lock()


### PR DESCRIPTION
`miren logs` could only ever look backward from now. The one time control was `--last <duration>`, which set the start to `now - duration` and always pinned the end to the present. That's fine for "what just happened," but useless when you're chasing an incident with a known window and don't want to scroll through everything since 2pm to see what happened between 2:00 and 2:30.

So this adds a `--since`/`--until` pair to all four log subcommands (`app`, `sandbox`, `build`, `system`). Rather than invent our own vocabulary, we leaned into what people already have in their fingers from docker, journalctl, and git: `--since`/`--until`, each overloaded to take either a timestamp or a duration. You can write a full RFC3339 timestamp for a precise boundary, a friendlier naive form like `"2026-06-25 14:00"` (interpreted in your local timezone), or just a duration like `2h` that's read as "that long ago." `--since 2h --until 30m` gives you the window from two hours ago to thirty minutes ago. The old `--last` flag still works, it's just shorthand for `--since` with a duration now, so nobody has to relearn anything.

Most of the backend was already in shape for this. The query layer always called into VictoriaLogs with both a start and an end, but the end was hardcoded to `time.Now()` and there was no way to pass anything else through. The real work was threading an upper bound the rest of the way: `streamLogChunks` gained a `to` parameter, `logReadOpts` grew an `Until` field, and `executeStreamQuery` now honors it. `--since` was almost free since it just produces a `from` timestamp that every protocol version already accepts. A couple of guardrails fall out naturally too: `--until` with `--follow` is rejected (a live tail has no end), `--since` alongside `--last` is rejected (they'd fight over the start), and an inverted window (`--until` before `--since`) is caught up front.

While wiring this up, the obvious gate had a hole: `--until` would be allowed whenever the server had `streamLogChunks`, but that method predates the `to` parameter, so a server in that in-between range would silently ignore the bound. Since the whole fleet released to date is in exactly that range, that's not a rare edge. So the RPC discovery layer now reports parameter names alongside method names, and `--until` checks for real `to` support before sending it. Older servers get a clean "newer server required" error instead of a silently-dropped bound, and the same fix covers the latent `--service`/`--build` case for free. That capability work is the first commit; the logs feature that consumes it is the second.

Closes MIR-1226
