### PR TITLE
rpc: pin QUIC InitialPacketSize at 1200 for 1280-MTU tunnels

### DIFF
--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -40,6 +40,14 @@ func init() {
 	}
 
 	DefaultQUICConfig = quic.Config{
+		// Pin the QUIC Initial at the 1200-byte spec minimum so the handshake
+		// fits a 1280-MTU path (Tailscale/WireGuard tunnels, the IPv6 minimum).
+		// quic-go's default of 1280 yields a 1308-byte IPv4 datagram with DF
+		// set, which such tunnels silently drop, hanging the handshake in both
+		// directions. PMTUD raises the packet size again after the handshake
+		// completes, so 1500-MTU paths are unaffected. See quic-go#5573,
+		// quic-go#5634, tailscale#2633.
+		InitialPacketSize:              1200,
 		EnableDatagrams:                true,
 		MaxIncomingStreams:             1000,
 		MaxIncomingUniStreams:          1000,


### PR DESCRIPTION
## What's going on

Remote `miren` calls to any cluster you reach over Tailscale hang on the first real RPC with `timeout: no recent network activity`, while on-box calls and calls to public-IP cloud clusters work fine. The culprit turned out to be packet size, not anything in our RPC layer.

quic-go bumped its default `InitialPacketSize` to 1280 bytes a few releases back (we're on v0.57.1, where it's a hardcoded `const InitialPacketSize = 1280`). As a UDP payload that's a 1308-byte IP packet, and QUIC sets the don't-fragment bit. Tailscale's `tailscale0` has a 1280 MTU (the IPv6 minimum, standard for WireGuard-based tunnels), so the handshake's opening packet is too big to send: the kernel rejects it with EMSGSIZE and it never hits the wire. A packet capture on the server during a failing call showed zero inbound packets.

It's symmetric: even once the client's Initial is small enough to get through, the server's handshake flight carries the TLS cert, gets capped at the same 1280, and drops on its own egress, so the handshake stalls there instead. Both ends need the smaller initial. This also explains why it never looked fleet-wide — every cloud cluster is addressed over a public 1500-MTU path where 1308 fits fine. Only Tailscale-addressed clusters hit the 1280 wall.

## Since when

Not a recent regression. quic-go unified its initial size to 1280 at v0.44.0 (before that it used 1252 for IPv4, which just fit a 1280-MTU tunnel). miren has carried a quic-go past that line since the QUIC/cbor RPC stack first landed (v0.48.2, Dec 2024), so every tagged release has shipped this. The recent v0.49.0 to v0.57.1 bump is unrelated; both carry the 1280 default.

## The fix

Pin `InitialPacketSize` to 1200, the RFC 9000 minimum (§14.1: an Initial datagram may only exceed 1200 bytes "if the sender believes that the network path and peer both support" it, which we can't assume across arbitrary tunnels). That's a 1228-byte IPv4 datagram and 1248-byte IPv6, both comfortably under a 1280 MTU. Path MTU discovery still ramps packets back up after the handshake, so nothing changes for normal 1500-MTU paths.

This is a known quic-go-over-Tailscale gotcha ([tailscale#2633](https://github.com/tailscale/tailscale/issues/2633), open since 2021; [quic-go#5573](https://github.com/quic-go/quic-go/issues/5573) is our exact symptom). quic-go declined to lower their own default ([quic-go#5634](https://github.com/quic-go/quic-go/issues/5634), closed not-planned), so the right place to fix it is our application config.

## How it was verified

Built a patched client and server and ran against a homelab cluster reached over Tailscale. Before: `app list` times out, zero packets at the server. Client-only patch: the Initial reaches the server and the handshake starts (error changes to "handshake did not complete in time"). Both ends patched: `app list` completes and returns the app table, with every datagram staying at or under the 1280 MTU.

Fixes MIR-1270.
