### PR TITLE
Bound startup entity maintenance with a timeout so a slow etcd can't block the edge

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -813,8 +813,18 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		return err
 	}
 
+	// Best-effort startup maintenance (format migration, short-id backfill, and
+	// reindex) scans the entity store. Bound it with a timeout so that a large or
+	// not-recently-compacted store fails fast and lets startup continue, rather
+	// than blocking the coordinator — and therefore the edge listener — on an
+	// unbounded read. Each step below already treats failure as non-fatal, so a
+	// timeout simply defers the work to a later startup once compaction catches up.
+	const startupMaintenanceTimeout = 2 * time.Minute
+	maintCtx, cancelMaint := context.WithTimeout(ctx, startupMaintenanceTimeout)
+	defer cancelMaint()
+
 	// Migrate entities from old format to new attribute-based format
-	migrated, skipped, err := entity.MigrateEntityStore(ctx, c.Log, client, entity.MigrateOptions{
+	migrated, skipped, err := entity.MigrateEntityStore(maintCtx, c.Log, client, entity.MigrateOptions{
 		Prefix: c.Prefix,
 		DryRun: false,
 	})
@@ -825,7 +835,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	}
 
 	// Backfill short-ids for entities that don't have one
-	sidMigrated, sidSkipped, sidErr := entity.MigrateShortIds(ctx, c.Log, client, entity.MigrateShortIdOptions{
+	sidMigrated, sidSkipped, sidErr := entity.MigrateShortIds(maintCtx, c.Log, client, entity.MigrateShortIdOptions{
 		Prefix: c.Prefix,
 		DryRun: false,
 	})
@@ -836,7 +846,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	}
 
 	// Check if indexes have changed and reindex if needed
-	if err := c.checkAndReindex(ctx, etcdStore, client); err != nil {
+	if err := c.checkAndReindex(maintCtx, etcdStore, client); err != nil {
 		c.Log.Error("automatic reindex failed (will retry next startup)", "error", err)
 	}
 


### PR DESCRIPTION
## What

The coordinator's startup maintenance phase — entity-format migration (`MigrateEntityStore`), short-id backfill (`MigrateShortIds`), and reindex (`checkAndReindex`) — scans the entire entity store. Each step reads with an unbounded `client.Get(ctx, prefix, clientv3.WithPrefix())`. On a large or not-recently-compacted etcd, that single request can stall, and because it runs before the edge listener is up, the node stays dark until it returns.

This wraps the maintenance phase in a `context.WithTimeout` (2 min). Each step already treats failure as non-fatal (logs a warning and proceeds), so a timeout turns "hang forever" into "fail fast, continue startup, and retry on the next boot once compaction catches up."

## Why

We hit this on a self-hosted single-node cluster (v0.10.0). After a routine restart the coordinator parked in `starting entity migration` and never bound `:80`/`:443` — every app on the box was unreachable for ~7.5 h, while the app containers themselves kept running fine. etcd had accumulated a lot of MVCC history (its scheduled compaction kept getting interrupted by the resulting restart loop), and the unbounded read stalled indefinitely. Small / `--limit` reads stayed instant; only the full prefix read hung. Manually compacting + restarting cleared it, and the migration then completed in ~50 ms.

We may well be missing context on why the read is structured this way, so please treat this as "here's what we saw" rather than a prescription — happy to adjust.

## Notes

- Minimal and behavior-preserving: only adds a bounding context; no logic change.
- `go build`, `go vet`, and `gofmt` are clean. The `pkg/entity` integration tests require the dev etcd environment (`make dev`), so they weren't run locally.
- Companion PR #872 paginates the reads themselves so they complete regardless of store size. The two are independent and complementary — this one is the safety net; that one fixes the read. Either can merge on its own.
