### PR TITLE
Page entity-store scans in startup migrations instead of one unbounded read

### DIFF
--- a/pkg/entity/migrate.go
+++ b/pkg/entity/migrate.go
@@ -129,16 +129,16 @@ func MigrateEntityStore(ctx context.Context, log *slog.Logger, client *clientv3.
 	log.Info("starting entity migration", "prefix", opts.Prefix, "dry_run", opts.DryRun)
 
 	// List all entities
-	resp, err := client.Get(ctx, opts.Prefix, clientv3.WithPrefix())
+	kvs, err := listEntitiesPaged(ctx, client, opts.Prefix)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to list entities: %w", err)
 	}
 
-	log.Info("found entities to scan", "count", len(resp.Kvs))
+	log.Info("found entities to scan", "count", len(kvs))
 
 	var errors int
 
-	for _, kv := range resp.Kvs {
+	for _, kv := range kvs {
 		key := string(kv.Key)
 
 		if strings.Contains(key, "/session/") {
@@ -316,7 +316,7 @@ func MigrateEntityStore(ctx context.Context, log *slog.Logger, client *clientv3.
 
 	if errors > 0 {
 		log.Warn("migration completed with errors",
-			"total", len(resp.Kvs),
+			"total", len(kvs),
 			"migrated", migrated,
 			"skipped", skipped,
 			"errors", errors)
@@ -324,7 +324,7 @@ func MigrateEntityStore(ctx context.Context, log *slog.Logger, client *clientv3.
 	}
 
 	log.Info("migration completed successfully",
-		"total", len(resp.Kvs),
+		"total", len(kvs),
 		"migrated", migrated,
 		"skipped", skipped)
 

--- a/pkg/entity/scan.go
+++ b/pkg/entity/scan.go
@@ -1,0 +1,47 @@
+package entity
+
+import (
+	"context"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// defaultScanPageSize bounds how many entities are fetched per etcd request
+// when scanning the entity keyspace.
+const defaultScanPageSize = 500
+
+// listEntitiesPaged reads every key/value under prefix in ascending key order,
+// fetching them in bounded pages rather than a single Get(WithPrefix()).
+//
+// A single unbounded prefix read loads the entire keyspace (keys and values) in
+// one RPC. On a large or not-recently-compacted store that request can stall,
+// which is a problem when it runs early in coordinator startup. Paging keeps
+// each request bounded and predictable regardless of store size.
+func listEntitiesPaged(ctx context.Context, client *clientv3.Client, prefix string) ([]*mvccpb.KeyValue, error) {
+	rangeEnd := clientv3.GetPrefixRangeEnd(prefix)
+	next := prefix
+
+	var kvs []*mvccpb.KeyValue
+	for {
+		resp, err := client.Get(ctx, next,
+			clientv3.WithRange(rangeEnd),
+			clientv3.WithLimit(defaultScanPageSize),
+			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		kvs = append(kvs, resp.Kvs...)
+
+		if !resp.More {
+			break
+		}
+
+		// Resume strictly after the last key returned in this page.
+		next = string(resp.Kvs[len(resp.Kvs)-1].Key) + "\x00"
+	}
+
+	return kvs, nil
+}

--- a/pkg/entity/shortid_migrate.go
+++ b/pkg/entity/shortid_migrate.go
@@ -24,12 +24,12 @@ func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Cli
 
 	log.Info("starting short-id migration", "prefix", prefix, "dry_run", opts.DryRun)
 
-	resp, err := client.Get(ctx, prefix, clientv3.WithPrefix())
+	kvs, err := listEntitiesPaged(ctx, client, prefix)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to list entities: %w", err)
 	}
 
-	log.Info("found entities to scan for short-id migration", "count", len(resp.Kvs))
+	log.Info("found entities to scan for short-id migration", "count", len(kvs))
 
 	// Build a set of existing unique keys for collision checking.
 	// We use the full unique key (attrCAS-based) to avoid collisions
@@ -46,7 +46,7 @@ func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Cli
 
 	var errorCount int
 
-	for _, kv := range resp.Kvs {
+	for _, kv := range kvs {
 		key := string(kv.Key)
 
 		// Skip session keys


### PR DESCRIPTION
## What

`MigrateEntityStore` and `MigrateShortIds` each read the entire entity keyspace with a single `client.Get(ctx, prefix, clientv3.WithPrefix())`. This adds a small `listEntitiesPaged` helper that reads the prefix in bounded pages (`WithLimit` + a key cursor, ascending key order) and uses it in both migrations. Per-entity processing is unchanged — only the read is paged.

## Why

A single unbounded prefix read loads the whole keyspace (keys **and** values) in one RPC. On a large or not-recently-compacted store that request can stall, and because these migrations run early in coordinator startup, a stall blocks the edge listener from coming up. We hit exactly this on a self-hosted node — the migration's full read hung for hours after a restart, leaving every app unreachable (more detail in the companion PR #871). Paging keeps each request bounded and predictable regardless of store size.

As with #871, we may be missing context here, so this is offered as "what worked for us" rather than a prescription.

## Notes

- `go build`, `go vet`, and `gofmt` are clean. The `pkg/entity` integration tests need the dev etcd environment (`make dev`) and weren't run locally.
- The unique-key read in `MigrateShortIds` is keys-only (bounded payload), so it's left as-is — glad to page it too if you'd prefer consistency.
- Companion PR #871 adds a startup-phase timeout as defense-in-depth. The two are independent and complementary; either can merge on its own. If you'd rather take just one, this is the root-cause fix and #871 is the belt-and-suspenders.
