### PR TITLE
Unify entity-store full scans behind a bounded paged primitive

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1543,10 +1543,13 @@ func (c *Coordinator) checkAndReindex(ctx context.Context, store *entity.EtcdSto
 		"stored_hash", storedHash,
 		"current_hash", currentHash)
 
-	reindexCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-
-	stats, err := store.Reindex(reindexCtx, c.Log, entity.ReindexOptions{
+	// Reindex is the heaviest maintenance step and runs last, inside the shared
+	// startup-maintenance deadline that bounds how long the coordinator blocks
+	// the edge listener. That ceiling is the single bound; don't layer a second
+	// timeout here, which would only ever clamp to whatever's left of it. A
+	// reindex that doesn't finish in time is retried on the next startup (it's
+	// gated on the index hash below).
+	stats, err := store.Reindex(ctx, c.Log, entity.ReindexOptions{
 		DryRun:       false,
 		CleanupStale: false,
 	})

--- a/pkg/entity/migrate.go
+++ b/pkg/entity/migrate.go
@@ -129,7 +129,7 @@ func MigrateEntityStore(ctx context.Context, log *slog.Logger, client *clientv3.
 	log.Info("starting entity migration", "prefix", opts.Prefix, "dry_run", opts.DryRun)
 
 	// List all entities
-	kvs, err := listEntitiesPaged(ctx, client, opts.Prefix)
+	kvs, err := scanPaged(ctx, client, opts.Prefix)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to list entities: %w", err)
 	}

--- a/pkg/entity/reindex.go
+++ b/pkg/entity/reindex.go
@@ -95,14 +95,14 @@ func (s *EtcdStore) Reindex(ctx context.Context, log *slog.Logger, opts ReindexO
 		log.Info("reindex: cleaning up stale index entries")
 		collectionPrefix := s.prefix + "/collections/"
 
-		resp, err := s.client.Get(ctx, collectionPrefix, clientv3.WithPrefix())
+		kvs, err := s.scanPaged(ctx, collectionPrefix)
 		if err != nil {
 			log.Warn("reindex: failed to list collection entries", "error", err)
 		} else {
-			stats.CollectionEntriesScanned = int64(len(resp.Kvs))
+			stats.CollectionEntriesScanned = int64(len(kvs))
 
 			var staleKeys []string
-			for _, kv := range resp.Kvs {
+			for _, kv := range kvs {
 				select {
 				case <-ctx.Done():
 					return stats, ctx.Err()

--- a/pkg/entity/scan.go
+++ b/pkg/entity/scan.go
@@ -7,35 +7,77 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-// defaultScanPageSize bounds how many entities are fetched per etcd request
-// when scanning the entity keyspace.
+// defaultScanPageSize bounds how many keys are fetched per etcd request when
+// scanning a keyspace.
 const defaultScanPageSize = 500
 
-// listEntitiesPaged reads every key/value under prefix in ascending key order,
-// fetching them in bounded pages rather than a single Get(WithPrefix()).
+type scanConfig struct {
+	pageSize int64
+	keysOnly bool
+}
+
+type scanOption func(*scanConfig)
+
+// withKeysOnly fetches keys without their values. Use it when the caller only
+// needs the key set (e.g. listing IDs or checking for collisions), so etcd
+// doesn't ship values it won't read.
+func withKeysOnly() scanOption {
+	return func(c *scanConfig) { c.keysOnly = true }
+}
+
+// withPageSize overrides the default per-request page size.
+func withPageSize(n int64) scanOption {
+	return func(c *scanConfig) { c.pageSize = n }
+}
+
+// scanPaged reads every key/value under prefix in ascending key order, fetching
+// them in bounded pages rather than a single Get(WithPrefix()).
 //
-// A single unbounded prefix read loads the entire keyspace (keys and values) in
-// one RPC. On a large or not-recently-compacted store that request can stall,
-// which is a problem when it runs early in coordinator startup. Paging keeps
-// each request bounded and predictable regardless of store size.
-func listEntitiesPaged(ctx context.Context, client *clientv3.Client, prefix string) ([]*mvccpb.KeyValue, error) {
-	rangeEnd := clientv3.GetPrefixRangeEnd(prefix)
+// A single unbounded prefix read loads the entire keyspace in one RPC. On a
+// large or not-recently-compacted store that request can stall, which is a
+// problem when it runs early in coordinator startup. Paging keeps each request
+// bounded and predictable regardless of store size, so every full-keyspace read
+// should route through here instead of open-coding Get(WithPrefix()).
+func scanPaged(ctx context.Context, client *clientv3.Client, prefix string, opts ...scanOption) ([]*mvccpb.KeyValue, error) {
+	cfg := scanConfig{pageSize: defaultScanPageSize}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	getOpts := []clientv3.OpOption{
+		clientv3.WithRange(clientv3.GetPrefixRangeEnd(prefix)),
+		clientv3.WithLimit(cfg.pageSize),
+		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
+	}
+	if cfg.keysOnly {
+		getOpts = append(getOpts, clientv3.WithKeysOnly())
+	}
+
 	next := prefix
 
 	var kvs []*mvccpb.KeyValue
+	first := true
 	for {
-		resp, err := client.Get(ctx, next,
-			clientv3.WithRange(rangeEnd),
-			clientv3.WithLimit(defaultScanPageSize),
-			clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),
-		)
+		resp, err := client.Get(ctx, next, getOpts...)
 		if err != nil {
 			return nil, err
 		}
 
+		// Pin every page after the first to the revision the scan opened at, so
+		// concurrent writes can't make us miss or duplicate keys partway
+		// through. A scan that outruns the compaction window will then fail
+		// loudly (ErrCompacted) rather than return a torn result.
+		if first {
+			getOpts = append(getOpts, clientv3.WithRev(resp.Header.Revision))
+			first = false
+		}
+
 		kvs = append(kvs, resp.Kvs...)
 
-		if !resp.More {
+		// An empty page can't advance the cursor; stop rather than index
+		// Kvs[-1]. Unreachable while WithLimit > 0, but keeps the loop safe if
+		// that ever changes.
+		if !resp.More || len(resp.Kvs) == 0 {
 			break
 		}
 
@@ -44,4 +86,10 @@ func listEntitiesPaged(ctx context.Context, client *clientv3.Client, prefix stri
 	}
 
 	return kvs, nil
+}
+
+// scanPaged reads every key/value under prefix from the store's etcd client in
+// bounded pages. See the package-level scanPaged for why.
+func (s *EtcdStore) scanPaged(ctx context.Context, prefix string, opts ...scanOption) ([]*mvccpb.KeyValue, error) {
+	return scanPaged(ctx, s.client, prefix, opts...)
 }

--- a/pkg/entity/scan_test.go
+++ b/pkg/entity/scan_test.go
@@ -1,0 +1,62 @@
+package entity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanPaged(t *testing.T) {
+	r := require.New(t)
+
+	client, basePrefix := setupTestEtcd(t)
+	ctx := context.Background()
+
+	prefix := basePrefix + "/scan/"
+
+	// Write more keys than a single page so we exercise the paging loop with a
+	// tiny page size, plus a key just outside the prefix that must not show up.
+	const total = 25
+	for i := range total {
+		_, err := client.Put(ctx, fmt.Sprintf("%skey-%03d", prefix, i), fmt.Sprintf("value-%03d", i))
+		r.NoError(err)
+	}
+	_, err := client.Put(ctx, basePrefix+"/other/key", "nope")
+	r.NoError(err)
+
+	t.Run("pages through every key in order", func(t *testing.T) {
+		r := require.New(t)
+
+		kvs, err := scanPaged(ctx, client, prefix, withPageSize(10))
+		r.NoError(err)
+		r.Len(kvs, total)
+
+		for i, kv := range kvs {
+			r.Equal(fmt.Sprintf("%skey-%03d", prefix, i), string(kv.Key))
+			r.Equal(fmt.Sprintf("value-%03d", i), string(kv.Value))
+		}
+	})
+
+	t.Run("keys-only omits values", func(t *testing.T) {
+		r := require.New(t)
+
+		kvs, err := scanPaged(ctx, client, prefix, withPageSize(10), withKeysOnly())
+		r.NoError(err)
+		r.Len(kvs, total)
+
+		for i, kv := range kvs {
+			r.Equal(fmt.Sprintf("%skey-%03d", prefix, i), string(kv.Key))
+			r.Empty(kv.Value)
+		}
+	})
+
+	t.Run("empty prefix returns nothing", func(t *testing.T) {
+		r := require.New(t)
+
+		kvs, err := scanPaged(ctx, client, basePrefix+"/empty/")
+		r.NoError(err)
+		r.Empty(kvs)
+	})
+}

--- a/pkg/entity/shortid_migrate.go
+++ b/pkg/entity/shortid_migrate.go
@@ -24,7 +24,7 @@ func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Cli
 
 	log.Info("starting short-id migration", "prefix", prefix, "dry_run", opts.DryRun)
 
-	kvs, err := listEntitiesPaged(ctx, client, prefix)
+	kvs, err := scanPaged(ctx, client, prefix)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to list entities: %w", err)
 	}
@@ -34,13 +34,13 @@ func MigrateShortIds(ctx context.Context, log *slog.Logger, client *clientv3.Cli
 	// Build a set of existing unique keys for collision checking.
 	// We use the full unique key (attrCAS-based) to avoid collisions
 	// between different unique attributes.
-	uniqueResp, err := client.Get(ctx, uniquePrefix, clientv3.WithPrefix(), clientv3.WithKeysOnly())
+	uniqueKvs, err := scanPaged(ctx, client, uniquePrefix, withKeysOnly())
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to list existing unique keys: %w", err)
 	}
 
 	existingUnique := make(map[string]struct{})
-	for _, kv := range uniqueResp.Kvs {
+	for _, kv := range uniqueKvs {
 		existingUnique[string(kv.Key)] = struct{}{}
 	}
 

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -1787,15 +1787,13 @@ func enumerateAllAttrs(attrs []Attr) []Attr {
 // ListAllEntityIDs returns all entity IDs in the store
 func (s *EtcdStore) ListAllEntityIDs(ctx context.Context) ([]Id, error) {
 	prefix := fmt.Sprintf("%s/entity/", s.prefix)
-	resp, err := s.client.Get(ctx, prefix,
-		clientv3.WithPrefix(),
-		clientv3.WithKeysOnly())
+	kvs, err := s.scanPaged(ctx, prefix, withKeysOnly())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list entities: %w", err)
 	}
 
 	var ids []Id
-	for _, kv := range resp.Kvs {
+	for _, kv := range kvs {
 		key := string(kv.Key)
 		// Skip session keys (they have /session/ in the path)
 		if strings.Contains(key, "/session/") {


### PR DESCRIPTION
Follow-on cleanup to #871 and #872, which fixed a coordinator parking in `starting entity migration` for ~7.5h after a restart. The startup maintenance phase reads the whole entity keyspace before the edge listener binds, and on a bloated etcd that unbounded read stalled indefinitely. #871 added a 2-minute timeout (the net) and #872 paginated two of the reads (the fix).

The catch is that #872's paging helper only covered two of the five full-keyspace reads in the startup path; the other three (the short-id unique-key set, `ListAllEntityIDs`, and reindex's stale-cleanup scan) still open-coded their own `Get(WithPrefix())`. So instead of leaving bounding as something each call site has to remember, we promote the helper to one primitive every read shares. `listEntitiesPaged` becomes `scanPaged` with keys-only and page-size options plus a thin `EtcdStore` method, and all five scans now route through a single paging loop.

While in here, we also untangled the timeout nesting. Reindex had its own inner 5-minute deadline, but it was derived from #871's outer 2-minute ceiling, so it could only ever clamp down to whatever was left of the 2 minutes. It never granted reindex anything. We dropped it and let reindex share the single 2-minute bound, which is the real guarantee anyway; an unfinished reindex is hash-gated to retry on the next boot.

Closes MIR-1272