### PR TITLE
deps: pin flannel to mirendev fork with subnet-watch compaction fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -430,3 +430,9 @@ require (
 	tags.cncf.io/container-device-interface v0.8.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
+
+// Temporary fork carrying the etcd subnet-watch compaction-recovery fix:
+// upstream hot-loops forever once a watch's start revision is compacted
+// away. Drop this once the fix is merged upstream into flannel-io/flannel
+// and released. Tracking: MIR-1274.
+replace github.com/flannel-io/flannel => github.com/mirendev/flannel v0.26.8-0.20260630195747-affa754a04b8

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,6 @@ github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flannel-io/flannel v0.26.7 h1:fG3xrErZfrCYQGtSAdZcPnp0+uBsZsWZmKAK77zC0ok=
-github.com/flannel-io/flannel v0.26.7/go.mod h1:/oz+EbTC6NGJTxk2VsqBigFAqaIEYBuS7Bf9/MDJ2DI=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7DlmewI=
@@ -917,6 +915,8 @@ github.com/mimuret/golang-iij-dpf v0.9.1 h1:Gj6EhHJkOhr+q2RnvRPJsPMcjuVnWPSccEHy
 github.com/mimuret/golang-iij-dpf v0.9.1/go.mod h1:sl9KyOkESib9+KRD3HaGpgi1xk7eoN2+d96LCLsME2M=
 github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
+github.com/mirendev/flannel v0.26.8-0.20260630195747-affa754a04b8 h1:FYfTsdVBXM9Qxu2lEYOlU3QZ4V5tY6KS1aJmdCO6oHY=
+github.com/mirendev/flannel v0.26.8-0.20260630195747-affa754a04b8/go.mod h1:/oz+EbTC6NGJTxk2VsqBigFAqaIEYBuS7Bf9/MDJ2DI=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/cli v1.1.5 h1:OxRIeJXpAMztws/XHlN2vu6imG5Dpq+j61AzAX5fLng=


### PR DESCRIPTION
Our toys runners kept filling their disks and dropping out of the cluster, and the culprit turned out to be flannel's etcd subnet-watch (MIR-1274). When a flanneld watch reconnects, it re-watches from its original start revision, which it never advances. That's harmless until etcd compacts past that revision, at which point every reconnect fails with "required revision has been compacted" and the watch re-establishes in a tight loop, logging a WARN+INFO pair every few seconds (~7.7 GB/day for us) until the disk fills and the node dies. It's the legacy etcd subnet manager path, so the far more common kube backend is unaffected, which is why it's gone unnoticed upstream. Long-lived standalone nodes like ours are exactly where it bites.

The real fix lives in flannel, so this change just points us at a fork (mirendev/flannel, based on v0.26.7) carrying the patch: on a compacted watch it re-lists at a current revision and resumes from there instead of hot-looping, and it advances the resume revision as events arrive so an ordinary reconnect moves forward rather than replaying from the frozen start rev. We're upstreaming the same patch to flannel-io/flannel and will drop this replace once it merges and ships in a release.

Part of MIR-1274.
