### PR TITLE
Cap SandboxLogs per-line buffer to bound control-process memory

### DIFF
--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -39,27 +39,58 @@ func NewSandboxLogs(
 	}
 }
 
+// maxLineBytes caps a single newline-terminated log line. A sandbox that emits
+// a huge, newline-poor blob to stdout (e.g. a verbose scraper dumping a raw
+// payload) would otherwise grow s.buf — and the control process's Go heap —
+// without bound, since a line is only flushed on '\n'. containerd streams in
+// small chunks, so the unbounded growth happens by accumulation across many
+// Write calls into s.buf; capping the buffer bounds memory to roughly
+// maxLineBytes per concurrent sandbox regardless of what an app spews. Bytes
+// past the cap are dropped until the next newline flushes the truncated line.
+const maxLineBytes = 1 << 20 // 1 MiB
+
 func (s *SandboxLogs) Write(p []byte) (n int, err error) {
 	n = len(p)
-
-	if s.buf.Len() > 0 {
-		s.buf.Write(p)
-		p = s.buf.Bytes()
-	}
 
 	for len(p) > 0 {
 		nl := bytes.IndexByte(p, '\n')
 		if nl == -1 {
-			s.buf.Write(p)
+			// No newline yet: stash the remainder for the next Write, capped.
+			s.bufferCapped(p)
 			break
 		}
 
-		s.processLine(string(p[:nl]))
+		if s.buf.Len() > 0 {
+			// Complete a line started in a previous Write.
+			s.bufferCapped(p[:nl])
+			s.processLine(s.buf.String())
+			s.buf.Reset()
+		} else {
+			line := p[:nl]
+			if len(line) > maxLineBytes {
+				line = line[:maxLineBytes]
+			}
+			s.processLine(string(line))
+		}
 
 		p = p[nl+1:]
 	}
 
 	return
+}
+
+// bufferCapped appends p to the partial-line buffer but never lets it exceed
+// maxLineBytes, so an unterminated firehose can't grow the buffer (and the
+// heap) without bound.
+func (s *SandboxLogs) bufferCapped(p []byte) {
+	room := maxLineBytes - s.buf.Len()
+	if room <= 0 {
+		return
+	}
+	if len(p) > room {
+		p = p[:room]
+	}
+	s.buf.Write(p)
 }
 
 var jsonLevelToStream = map[string]observability.LogStream{

--- a/controllers/sandbox/log_test.go
+++ b/controllers/sandbox/log_test.go
@@ -83,6 +83,35 @@ func TestSandboxLogs(t *testing.T) {
 		r.Equal("partial line", mock.entries[0].log.Body)
 	})
 
+	t.Run("caps an unterminated firehose line", func(t *testing.T) {
+		r := require.New(t)
+
+		mock := &mockLogWriter{}
+		entityID := identity.NewID()
+
+		logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+		sl := NewSandboxLogs(logger, entityID, map[string]string{}, mock)
+
+		// Stream ~12.5 MiB with no newline, in 64 KiB chunks the way containerd
+		// pumps a blob — far more than the 1 MiB cap.
+		chunk := bytes.Repeat([]byte("x"), 64*1024)
+		for i := 0; i < 200; i++ {
+			n, err := sl.Write(chunk)
+			r.NoError(err)
+			r.Equal(len(chunk), n) // all bytes are always "consumed"
+		}
+
+		// Nothing flushed yet (no newline), and the buffer never exceeded the cap.
+		r.Len(mock.entries, 0)
+		r.LessOrEqual(sl.buf.Len(), maxLineBytes)
+
+		// A newline flushes the line, truncated to the cap rather than ~12 MiB.
+		_, err := sl.Write([]byte("\n"))
+		r.NoError(err)
+		r.Len(mock.entries, 1)
+		r.Equal(maxLineBytes, len(mock.entries[0].log.Body))
+	})
+
 	t.Run("handles USER prefix", func(t *testing.T) {
 		r := require.New(t)
 


### PR DESCRIPTION
## Problem

A sandbox that emits a large, newline-poor blob to stdout grows
`(*SandboxLogs).buf` without bound. A log line is only flushed on `\n`, so
containerd streaming a multi-GB payload across many `Write` calls accumulates
the whole thing in one `bytes.Buffer`, which is then `gjson`-parsed and
JSON-marshaled into a single log entry.

On our self-hosted cluster this manifested as a recurring control-process memory
balloon (~every 4h) that tripped the host OOM and took down every app in the
shared `miren.service` cgroup. A live heap profile of the control process during
a balloon attributed **97.8% of a 68 GB heap** to this path:

```
containerd cio.copyIO  →  (*SandboxLogs).Write
  bytes.growSlice            20.6 GB   (one unbounded bytes.Buffer)
  encoding/json.Marshal      18.4 GB   (marshaling the giant line)
HeapInuse 53.7 GB, 54M objects
```

The trigger was an app's 4-hourly job occasionally logging a huge raw payload.

## Fix

Cap the partial-line buffer at 1 MiB (`maxLineBytes`): bytes past the cap are
dropped until the next newline flushes the truncated line, bounding memory to
roughly `maxLineBytes` per concurrent sandbox regardless of what an app emits.

Also fixes a latent bug where `buf` was never `Reset` after completing a
buffered line, so a partial line could be re-appended to itself.

Existing `TestSandboxLogs` cases (line handling, partial-line buffering, USER/
ERROR prefixes) are unchanged; a new case asserts a ~12 MiB newline-poor stream
is capped to `maxLineBytes` and flushes truncated on the next newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
