### PR TITLE
Prune old app versions and reclaim their image blobs

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -635,30 +635,41 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		}
 	}
 
+	// A malformed retention period parses to 0, which the coordinator treats as
+	// "use the default" rather than "retain nothing". Warn so the operator knows
+	// their configured value was ignored.
+	appVersionRetentionPeriod, err := units.ParseDuration(cfg.AppVersion.GetRetentionPeriod())
+	if err != nil {
+		ctx.Log.Warn("invalid app_version.retention_period, falling back to default",
+			"value", cfg.AppVersion.GetRetentionPeriod(), "error", err)
+	}
+
 	// Build coordinator config
 	coordConfig := coordinate.CoordinatorConfig{
-		Address:                srvaddr,
-		EtcdEndpoints:          cfg.Etcd.Endpoints,
-		Prefix:                 cfg.Etcd.GetPrefix(),
-		NetworkBackend:         cfg.Server.GetNetworkBackend(),
-		DataPath:               cfg.Server.GetDataPath(),
-		AdditionalNames:        cfg.TLS.AdditionalNames,
-		IPs:                    ipSet,
-		AcmeEmail:              cfg.TLS.GetAcmeEmail(),
-		AcmeDNSProvider:        cfg.TLS.GetAcmeDNSProvider(),
-		Resolver:               res,
-		TempDir:                os.TempDir(),
-		CloudAuth:              cloudAuthConfig,
-		Mem:                    mem,
-		Cpu:                    cpu,
-		HTTP:                   httpMetrics,
-		Logs:                   logs,
-		LogWriter:              logWriter,
-		BuildKit:               buildkitComponent,
-		HTTPRequestTimeout:     cfg.Server.HTTPRequestTimeoutDuration(),
-		VictoriametricsAddress: ctx.ServerState.VictoriametricsAddress,
-		VictorialogsAddress:    ctx.ServerState.VictorialogsAddress,
-		WorkloadIssuer:         workloadIssuer,
+		Address:                   srvaddr,
+		EtcdEndpoints:             cfg.Etcd.Endpoints,
+		Prefix:                    cfg.Etcd.GetPrefix(),
+		NetworkBackend:            cfg.Server.GetNetworkBackend(),
+		DataPath:                  cfg.Server.GetDataPath(),
+		AdditionalNames:           cfg.TLS.AdditionalNames,
+		IPs:                       ipSet,
+		AcmeEmail:                 cfg.TLS.GetAcmeEmail(),
+		AcmeDNSProvider:           cfg.TLS.GetAcmeDNSProvider(),
+		Resolver:                  res,
+		TempDir:                   os.TempDir(),
+		CloudAuth:                 cloudAuthConfig,
+		Mem:                       mem,
+		Cpu:                       cpu,
+		HTTP:                      httpMetrics,
+		Logs:                      logs,
+		LogWriter:                 logWriter,
+		BuildKit:                  buildkitComponent,
+		HTTPRequestTimeout:        cfg.Server.HTTPRequestTimeoutDuration(),
+		VictoriametricsAddress:    ctx.ServerState.VictoriametricsAddress,
+		VictorialogsAddress:       ctx.ServerState.VictorialogsAddress,
+		WorkloadIssuer:            workloadIssuer,
+		AppVersionRetentionCount:  cfg.AppVersion.GetRetentionCount(),
+		AppVersionRetentionPeriod: appVersionRetentionPeriod,
 	}
 
 	// Pass etcd TLS config when distributed runners is enabled

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -48,6 +48,7 @@ import (
 	nodehealthctrl "miren.dev/runtime/controllers/nodehealth"
 	"miren.dev/runtime/controllers/sandboxpool"
 	schedulerctrl "miren.dev/runtime/controllers/scheduler"
+	versionctrl "miren.dev/runtime/controllers/version"
 	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/addon"
@@ -130,6 +131,11 @@ type CoordinatorConfig struct {
 
 	// HTTPRequestTimeout is the timeout for HTTP requests to app sandboxes
 	HTTPRequestTimeout time.Duration
+
+	// AppVersionRetentionCount and AppVersionRetentionPeriod tune the version
+	// retention GC. Values <= 0 fall back to the controller defaults.
+	AppVersionRetentionCount  int
+	AppVersionRetentionPeriod time.Duration
 
 	// WorkloadIssuer signs workload identity tokens for sandbox containers
 	WorkloadIssuer *workloadidentity.Issuer
@@ -344,6 +350,7 @@ type Coordinator struct {
 	autocertReady func() // nil when DNS-01 path is used
 	artifactGC    *artifactctrl.GCController
 	ephemeralGC   *ephemeralctrl.GCController
+	versionGC     *versionctrl.GCController
 	hs            *httpingress.Server
 
 	authority *caauth.Authority
@@ -385,6 +392,9 @@ func (c *Coordinator) Stop() {
 	}
 	if c.ephemeralGC != nil {
 		c.ephemeralGC.Stop()
+	}
+	if c.versionGC != nil {
+		c.versionGC.Stop()
 	}
 	if c.debugServer != nil {
 		if err := c.debugServer.Close(); err != nil {
@@ -1106,6 +1116,21 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		Config: ephemeralctrl.DefaultGCConfig(),
 	}
 	c.ephemeralGC.Start(ctx)
+
+	// Start the version retention GC controller
+	versionGCConfig := versionctrl.DefaultGCConfig()
+	if c.AppVersionRetentionCount > 0 {
+		versionGCConfig.RetentionCount = c.AppVersionRetentionCount
+	}
+	if c.AppVersionRetentionPeriod > 0 {
+		versionGCConfig.RetentionPeriod = c.AppVersionRetentionPeriod
+	}
+	c.versionGC = &versionctrl.GCController{
+		Log:    c.Log.With("module", "version-gc"),
+		EAC:    eac,
+		Config: versionGCConfig,
+	}
+	c.versionGC.Start(ctx)
 
 	eps := execproxy.NewServer(c.Log, eac, rs)
 	server.ExposeValue("dev.miren.runtime/exec", exec_v1alpha.AdaptSandboxExec(eps))

--- a/controllers/artifact/gc.go
+++ b/controllers/artifact/gc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
 	"time"
 
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -16,18 +15,12 @@ import (
 type GCConfig struct {
 	// CheckInterval is how often to run the GC sweep (default: 1h)
 	CheckInterval time.Duration
-	// RetentionDays is how many days to keep artifacts regardless of count (default: 30)
-	RetentionDays int
-	// RetentionCount is how many recent artifacts per app to keep regardless of age (default: 20)
-	RetentionCount int
 }
 
 // DefaultGCConfig returns the default GC configuration.
 func DefaultGCConfig() GCConfig {
 	return GCConfig{
-		CheckInterval:  1 * time.Hour,
-		RetentionDays:  30,
-		RetentionCount: 20,
+		CheckInterval: 1 * time.Hour,
 	}
 }
 
@@ -37,14 +30,22 @@ type GCResult struct {
 	ArchivedArtifacts []entity.Id
 	// FailedArtifacts contains IDs and errors for artifacts that failed to update
 	FailedArtifacts map[entity.Id]error
-	// TotalArtifacts is the total number of artifacts evaluated
+	// TotalArtifacts is the total number of active artifacts evaluated
 	TotalArtifacts int
 	// RetainedArtifacts is the number of artifacts kept active
 	RetainedArtifacts int
 }
 
-// GCController periodically applies retention policies to artifacts,
-// transitioning old artifacts to "archived" status.
+// GCController periodically archives artifacts that are no longer referenced by
+// any AppVersion. Archiving (Status=ARCHIVED) is the signal the downstream
+// image GC and blob GC key off to reclaim the image and its registry blobs.
+//
+// Retention is reference-driven rather than age- or count-based: an artifact is
+// kept exactly as long as some AppVersion still points at it. Because artifacts
+// are deduplicated by manifest digest (many versions can share one artifact),
+// an artifact survives until its last referencing version is pruned. The
+// version retention GC (controllers/version) is what removes those references
+// over time; this controller reacts to the result.
 type GCController struct {
 	Log    *slog.Logger
 	EAC    *entityserver_v1alpha.EntityAccessClient
@@ -56,9 +57,7 @@ type GCController struct {
 // Start begins the periodic GC process.
 func (c *GCController) Start(ctx context.Context) {
 	c.Log.Info("starting artifact GC controller",
-		"check_interval", c.Config.CheckInterval,
-		"retention_days", c.Config.RetentionDays,
-		"retention_count", c.Config.RetentionCount)
+		"check_interval", c.Config.CheckInterval)
 
 	ctx, c.cancel = context.WithCancel(ctx)
 	go c.run(ctx)
@@ -124,7 +123,7 @@ func (c *GCController) runGCWithLogging(ctx context.Context) {
 	}
 }
 
-// RunGC applies the retention policy to all artifacts.
+// RunGC archives every active artifact that no AppVersion references.
 func (c *GCController) RunGC(ctx context.Context) (*GCResult, error) {
 	result := &GCResult{
 		ArchivedArtifacts: []entity.Id{},
@@ -134,94 +133,58 @@ func (c *GCController) RunGC(ctx context.Context) (*GCResult, error) {
 	gcCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	// List only active artifacts - archived and empty-status artifacts are skipped
+	// Build the set of artifacts still referenced by a version. This spans ALL
+	// AppVersions — ephemeral ones included — since an ephemeral version's image
+	// must stay available for as long as the version exists.
+	referenced, err := c.referencedArtifacts(gcCtx)
+	if err != nil {
+		return result, err
+	}
+
+	// Only active artifacts can be archived; already-archived ones are skipped.
 	resp, err := c.EAC.List(gcCtx, entity.Ref(core_v1alpha.ArtifactStatusId, core_v1alpha.ArtifactStatusActiveId))
 	if err != nil {
 		return result, fmt.Errorf("failed to list active artifacts: %w", err)
 	}
 
-	now := time.Now()
-	retentionCutoff := now.Add(-time.Duration(c.Config.RetentionDays) * 24 * time.Hour)
-
-	// Group artifacts by app
-	type artifactInfo struct {
-		artifact  core_v1alpha.Artifact
-		revision  int64
-		createdAt time.Time
-	}
-
-	artifactsByApp := make(map[entity.Id][]artifactInfo)
-	var orphanedArtifacts []artifactInfo
+	result.TotalArtifacts = len(resp.Values())
 
 	for _, e := range resp.Values() {
 		var art core_v1alpha.Artifact
 		art.Decode(e.Entity())
 
-		info := artifactInfo{
-			artifact:  art,
-			revision:  e.Revision(),
-			createdAt: time.UnixMilli(e.CreatedAt()),
-		}
-
-		if art.App == "" {
-			// Orphaned artifact (no app reference)
-			orphanedArtifacts = append(orphanedArtifacts, info)
-		} else {
-			artifactsByApp[art.App] = append(artifactsByApp[art.App], info)
-		}
-	}
-
-	result.TotalArtifacts = len(resp.Values())
-
-	// Process artifacts per app
-	for _, artifacts := range artifactsByApp {
-		// Sort by creation time, newest first
-		sort.Slice(artifacts, func(i, j int) bool {
-			return artifacts[i].createdAt.After(artifacts[j].createdAt)
-		})
-
-		for i, info := range artifacts {
-			shouldRetain := false
-
-			// Keep if within retention days
-			if info.createdAt.After(retentionCutoff) {
-				shouldRetain = true
-			}
-
-			// Keep if within retention count (first N in sorted list)
-			if i < c.Config.RetentionCount {
-				shouldRetain = true
-			}
-
-			if shouldRetain {
-				result.RetainedArtifacts++
-			} else {
-				// Archive this artifact
-				err := c.archiveArtifact(gcCtx, info.artifact, info.revision)
-				if err != nil {
-					result.FailedArtifacts[info.artifact.ID] = err
-				} else {
-					result.ArchivedArtifacts = append(result.ArchivedArtifacts, info.artifact.ID)
-				}
-			}
-		}
-	}
-
-	// Handle orphaned artifacts - archive if older than retention days
-	for _, info := range orphanedArtifacts {
-		if info.createdAt.After(retentionCutoff) {
+		if referenced[art.ID] {
 			result.RetainedArtifacts++
+			continue
+		}
+
+		if err := c.archiveArtifact(gcCtx, art, e.Revision()); err != nil {
+			result.FailedArtifacts[art.ID] = err
 		} else {
-			err := c.archiveArtifact(gcCtx, info.artifact, info.revision)
-			if err != nil {
-				result.FailedArtifacts[info.artifact.ID] = err
-			} else {
-				result.ArchivedArtifacts = append(result.ArchivedArtifacts, info.artifact.ID)
-			}
+			result.ArchivedArtifacts = append(result.ArchivedArtifacts, art.ID)
 		}
 	}
 
 	return result, nil
+}
+
+// referencedArtifacts returns the set of artifact IDs referenced by any
+// AppVersion.
+func (c *GCController) referencedArtifacts(ctx context.Context) (map[entity.Id]bool, error) {
+	resp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list app versions: %w", err)
+	}
+
+	referenced := make(map[entity.Id]bool)
+	for _, e := range resp.Values() {
+		var av core_v1alpha.AppVersion
+		av.Decode(e.Entity())
+		if av.Artifact != "" {
+			referenced[av.Artifact] = true
+		}
+	}
+	return referenced, nil
 }
 
 // archiveArtifact updates an artifact's status to archived.

--- a/controllers/artifact/gc_test.go
+++ b/controllers/artifact/gc_test.go
@@ -1,0 +1,126 @@
+package artifact
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	testutils "miren.dev/runtime/pkg/entity/testutils"
+)
+
+func artifactStatus(t *testing.T, eac *entityserver_v1alpha.EntityAccessClient, id entity.Id) core_v1alpha.ArtifactStatus {
+	t.Helper()
+	res, err := eac.Get(context.Background(), id.String())
+	require.NoError(t, err)
+	require.True(t, res.HasEntity())
+	var art core_v1alpha.Artifact
+	art.Decode(res.Entity().Entity())
+	return art.Status
+}
+
+func TestGCController_ArchivesUnreferenced(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "gcapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	// An active artifact that no version references.
+	artID, err := inmem.Client.Create(ctx, "orphan", &core_v1alpha.Artifact{App: appID, Status: core_v1alpha.ACTIVE})
+	require.NoError(t, err)
+
+	gc := &GCController{Log: log, EAC: inmem.EAC, Config: GCConfig{CheckInterval: time.Hour}}
+
+	result, err := gc.RunGC(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(result.ArchivedArtifacts))
+	require.Equal(t, 0, result.RetainedArtifacts)
+	require.Equal(t, core_v1alpha.ARCHIVED, artifactStatus(t, inmem.EAC, artID))
+}
+
+func TestGCController_RetainsReferenced(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "gcapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	artID, err := inmem.Client.Create(ctx, "live", &core_v1alpha.Artifact{App: appID, Status: core_v1alpha.ACTIVE})
+	require.NoError(t, err)
+
+	// A version references the artifact, so it must stay active.
+	_, err = inmem.Client.Create(ctx, "v1", &core_v1alpha.AppVersion{App: appID, Version: "v1", Artifact: artID})
+	require.NoError(t, err)
+
+	gc := &GCController{Log: log, EAC: inmem.EAC, Config: GCConfig{CheckInterval: time.Hour}}
+
+	result, err := gc.RunGC(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(result.ArchivedArtifacts))
+	require.Equal(t, 1, result.RetainedArtifacts)
+	require.Equal(t, core_v1alpha.ACTIVE, artifactStatus(t, inmem.EAC, artID))
+}
+
+func TestGCController_RetainsEphemeralReferenced(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "gcapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	artID, err := inmem.Client.Create(ctx, "eph-art", &core_v1alpha.Artifact{App: appID, Status: core_v1alpha.ACTIVE})
+	require.NoError(t, err)
+
+	// Only an ephemeral version references it — its image is still needed.
+	_, err = inmem.Client.Create(ctx, "eph", &core_v1alpha.AppVersion{
+		App:                appID,
+		Version:            "eph",
+		Artifact:           artID,
+		EphemeralLabel:     "pr-1",
+		EphemeralExpiresAt: time.Now().Add(48 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	gc := &GCController{Log: log, EAC: inmem.EAC, Config: GCConfig{CheckInterval: time.Hour}}
+
+	result, err := gc.RunGC(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, len(result.ArchivedArtifacts))
+	require.Equal(t, core_v1alpha.ACTIVE, artifactStatus(t, inmem.EAC, artID),
+		"artifact referenced by an ephemeral version must stay active")
+}
+
+func TestGCController_SkipsArchived(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "gcapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	// Already archived: the active-status index should not surface it at all.
+	_, err = inmem.Client.Create(ctx, "done", &core_v1alpha.Artifact{App: appID, Status: core_v1alpha.ARCHIVED})
+	require.NoError(t, err)
+
+	gc := &GCController{Log: log, EAC: inmem.EAC, Config: GCConfig{CheckInterval: time.Hour}}
+
+	result, err := gc.RunGC(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, result.TotalArtifacts, "archived artifacts are not evaluated")
+	require.Equal(t, 0, len(result.ArchivedArtifacts))
+}

--- a/controllers/ephemeral/gc.go
+++ b/controllers/ephemeral/gc.go
@@ -8,6 +8,7 @@ import (
 
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/appversion"
 	"miren.dev/runtime/pkg/entity"
 	ephemeralx "miren.dev/runtime/pkg/ephemeral"
 )
@@ -100,10 +101,15 @@ func (c *GCController) RunGC(ctx context.Context) (*GCResult, error) {
 	gcCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	// List all app versions — filter for ephemeral ones
-	// We use the app_version app index to get all versions across all apps
-	// A more efficient approach would use the ephemeral_expires_at index,
-	// but that requires range queries. For now, scan all versions.
+	// Scan every AppVersion and filter to the ephemeral ones. This set is
+	// bounded: non-ephemeral versions are capped by the retention GC
+	// (controllers/version) and ephemeral ones by DefaultMaxEphemeral per app,
+	// so the scan does not grow with total deploy history. The store's index
+	// lookups are equality-only, so there is no range query over
+	// ephemeral_expires_at to target expired versions directly. If this scan
+	// ever costs too much (roughly thousands of apps, given the 5-minute
+	// cadence), the fix is an equality-indexed "ephemeral" marker attr so we can
+	// List(ephemeral=true) instead of scanning-and-filtering every version.
 	resp, err := c.EAC.List(gcCtx, entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion))
 	if err != nil {
 		// Fall back to scanning by iterating through known apps
@@ -130,7 +136,7 @@ func (c *GCController) RunGC(ctx context.Context) (*GCResult, error) {
 			"label", av.EphemeralLabel,
 			"expired_at", av.EphemeralExpiresAt)
 
-		if err := ephemeralx.DeleteVersion(gcCtx, c.EAC, av.ID, c.Log); err != nil {
+		if err := appversion.DeleteWithPools(gcCtx, c.EAC, &av, c.Log); err != nil {
 			c.Log.Error("failed to delete expired ephemeral version",
 				"version_id", av.ID, "error", err)
 			result.FailedVersions++

--- a/controllers/version/gc.go
+++ b/controllers/version/gc.go
@@ -1,0 +1,318 @@
+// Package version implements retention garbage collection for AppVersions.
+//
+// Every deploy mints a new AppVersion that otherwise lives forever, bloating
+// the entity store and making the ephemeral GC's full-version scan grow without
+// bound. This controller hard-deletes old non-active, non-ephemeral versions so
+// that growth stays bounded. Ephemeral versions are skipped — they have their
+// own TTL-based GC (controllers/ephemeral).
+package version
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/appversion"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// GCConfig holds configuration for app version retention GC.
+type GCConfig struct {
+	// CheckInterval is how often to run the GC sweep (default: 1h).
+	CheckInterval time.Duration
+	// RetentionPeriod keeps versions newer than this regardless of count
+	// (default: 30 days).
+	RetentionPeriod time.Duration
+	// RetentionCount keeps this many most-recent versions per app regardless of
+	// age (default: 10).
+	RetentionCount int
+}
+
+// DefaultGCConfig returns the default GC configuration.
+func DefaultGCConfig() GCConfig {
+	return GCConfig{
+		CheckInterval:   1 * time.Hour,
+		RetentionPeriod: 30 * 24 * time.Hour,
+		RetentionCount:  10,
+	}
+}
+
+// GCResult contains information about versions processed during a GC sweep.
+type GCResult struct {
+	// DeletedVersions is the number of versions hard-deleted.
+	DeletedVersions int
+	// FailedVersions is the number of versions that failed to delete.
+	FailedVersions int
+	// RetainedVersions is the number of versions kept by retention policy.
+	RetainedVersions int
+	// SkippedLive is the number of prune candidates retained because a live
+	// sandbox still references them.
+	SkippedLive int
+	// TotalScanned is the number of non-ephemeral versions evaluated.
+	TotalScanned int
+}
+
+// GCController periodically applies retention policy to AppVersions,
+// hard-deleting old non-active, non-ephemeral versions.
+type GCController struct {
+	Log    *slog.Logger
+	EAC    *entityserver_v1alpha.EntityAccessClient
+	Config GCConfig
+
+	cancel context.CancelFunc
+}
+
+// Start begins the periodic GC process.
+func (c *GCController) Start(ctx context.Context) {
+	c.Log.Info("starting version retention GC controller",
+		"check_interval", c.Config.CheckInterval,
+		"retention_period", c.Config.RetentionPeriod,
+		"retention_count", c.Config.RetentionCount)
+
+	ctx, c.cancel = context.WithCancel(ctx)
+	go c.run(ctx)
+}
+
+// Stop gracefully stops the controller.
+func (c *GCController) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+func (c *GCController) run(ctx context.Context) {
+	ticker := time.NewTicker(c.Config.CheckInterval)
+	defer ticker.Stop()
+
+	// Run an initial GC on startup after a short delay.
+	select {
+	case <-time.After(30 * time.Second):
+		c.runGCWithLogging(ctx)
+	case <-ctx.Done():
+		c.Log.Info("version retention GC controller stopped")
+		return
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			c.runGCWithLogging(ctx)
+		case <-ctx.Done():
+			c.Log.Info("version retention GC controller stopped")
+			return
+		}
+	}
+}
+
+func (c *GCController) runGCWithLogging(ctx context.Context) {
+	result, err := c.RunGC(ctx)
+	if err != nil {
+		c.Log.Error("version retention GC failed", "error", err)
+		return
+	}
+
+	if result.DeletedVersions > 0 || result.FailedVersions > 0 {
+		c.Log.Info("version retention GC complete",
+			"deleted", result.DeletedVersions,
+			"failed", result.FailedVersions,
+			"skipped_live", result.SkippedLive,
+			"retained", result.RetainedVersions,
+			"total", result.TotalScanned)
+	} else {
+		c.Log.Debug("version retention GC complete, nothing pruned",
+			"skipped_live", result.SkippedLive,
+			"retained", result.RetainedVersions,
+			"total", result.TotalScanned)
+	}
+}
+
+type versionInfo struct {
+	version   core_v1alpha.AppVersion
+	createdAt time.Time
+}
+
+// RunGC applies the retention policy to all non-ephemeral AppVersions.
+func (c *GCController) RunGC(ctx context.Context) (*GCResult, error) {
+	result := &GCResult{}
+
+	gcCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	activeVersions, err := c.activeVersions(gcCtx)
+	if err != nil {
+		return result, err
+	}
+
+	liveVersions, err := c.versionsWithLiveSandboxes(gcCtx)
+	if err != nil {
+		return result, err
+	}
+
+	resp, err := c.EAC.List(gcCtx, entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion))
+	if err != nil {
+		return result, fmt.Errorf("failed to list app versions: %w", err)
+	}
+
+	// Group non-ephemeral versions by app.
+	versionsByApp := make(map[entity.Id][]versionInfo)
+	for _, e := range resp.Values() {
+		var av core_v1alpha.AppVersion
+		av.Decode(e.Entity())
+
+		// Ephemeral versions have their own TTL-based GC.
+		if av.EphemeralLabel != "" {
+			continue
+		}
+
+		result.TotalScanned++
+		versionsByApp[av.App] = append(versionsByApp[av.App], versionInfo{
+			version:   av,
+			createdAt: time.UnixMilli(e.CreatedAt()),
+		})
+	}
+
+	now := time.Now()
+	retentionCutoff := now.Add(-c.Config.RetentionPeriod)
+
+	for appID, versions := range versionsByApp {
+		// Sort by creation time, newest first.
+		sort.Slice(versions, func(i, j int) bool {
+			return versions[i].createdAt.After(versions[j].createdAt)
+		})
+
+		activeVersion := activeVersions[appID]
+
+		for i, info := range versions {
+			// Always keep the active version, the most-recent N, and anything
+			// younger than the retention window.
+			if info.version.ID == activeVersion ||
+				i < c.Config.RetentionCount ||
+				info.createdAt.After(retentionCutoff) {
+				result.RetainedVersions++
+				continue
+			}
+
+			// Never delete a version a live sandbox still references; retain it
+			// for a future sweep once the sandbox is gone.
+			if liveVersions[info.version.ID] {
+				c.Log.Debug("retaining prune candidate with live sandbox",
+					"version_id", info.version.ID, "app", appID)
+				result.SkippedLive++
+				continue
+			}
+
+			v := info.version
+
+			// The active/live sets were snapshotted at the top of the sweep,
+			// which can be up to a full pass stale. Re-verify the pin state
+			// immediately before deleting so a rollback that makes this version
+			// active, or a sandbox that starts referencing it mid-sweep, isn't
+			// deleted out from under the running system.
+			pinned, err := c.pinnedNow(gcCtx, v.ID, appID)
+			if err != nil {
+				c.Log.Warn("failed to re-check version before delete; retaining",
+					"version_id", v.ID, "error", err)
+				result.FailedVersions++
+				continue
+			}
+			if pinned {
+				c.Log.Debug("retaining prune candidate pinned during sweep",
+					"version_id", v.ID, "app", appID)
+				result.SkippedLive++
+				continue
+			}
+
+			if err := appversion.Delete(gcCtx, c.EAC, &v, c.Log); err != nil {
+				c.Log.Warn("failed to delete app version", "version_id", v.ID, "error", err)
+				result.FailedVersions++
+			} else {
+				result.DeletedVersions++
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// activeVersions returns a map of app ID to its active version ID.
+func (c *GCController) activeVersions(ctx context.Context) (map[entity.Id]entity.Id, error) {
+	resp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindApp))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list apps: %w", err)
+	}
+
+	active := make(map[entity.Id]entity.Id)
+	for _, e := range resp.Values() {
+		var app core_v1alpha.App
+		app.Decode(e.Entity())
+		if app.ActiveVersion != "" {
+			active[app.ID] = app.ActiveVersion
+		}
+	}
+	return active, nil
+}
+
+// versionsWithLiveSandboxes returns the set of version IDs that a pending,
+// not-ready, or running sandbox currently references.
+func (c *GCController) versionsWithLiveSandboxes(ctx context.Context) (map[entity.Id]bool, error) {
+	resp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sandboxes: %w", err)
+	}
+
+	live := make(map[entity.Id]bool)
+	for _, e := range resp.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(e.Entity())
+
+		switch sb.Status {
+		case compute_v1alpha.PENDING, compute_v1alpha.NOT_READY, compute_v1alpha.RUNNING:
+			if sb.Spec.Version != "" {
+				live[sb.Spec.Version] = true
+			}
+		case compute_v1alpha.STOPPED, compute_v1alpha.DEAD:
+			// Terminal sandboxes no longer pin their version.
+		}
+	}
+	return live, nil
+}
+
+// pinnedNow re-checks, immediately before deletion, whether a prune candidate
+// has become its app's active version or picked up a live sandbox since the
+// pre-sweep snapshots were taken. Both lookups are cheap point queries (a
+// single Get and an indexed list) and only run for versions that already
+// cleared retention, so this stays inexpensive.
+func (c *GCController) pinnedNow(ctx context.Context, versionID, appID entity.Id) (bool, error) {
+	appResp, err := c.EAC.Get(ctx, appID.String())
+	if err != nil {
+		return false, fmt.Errorf("failed to re-check app %s: %w", appID, err)
+	}
+	if appResp.HasEntity() {
+		var app core_v1alpha.App
+		app.Decode(appResp.Entity().Entity())
+		if app.ActiveVersion == versionID {
+			return true, nil
+		}
+	}
+
+	sbResp, err := c.EAC.List(ctx, entity.Ref(compute_v1alpha.SandboxSpecVersionId, versionID))
+	if err != nil {
+		return false, fmt.Errorf("failed to re-check sandboxes for version %s: %w", versionID, err)
+	}
+	for _, e := range sbResp.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(e.Entity())
+		switch sb.Status {
+		case compute_v1alpha.PENDING, compute_v1alpha.NOT_READY, compute_v1alpha.RUNNING:
+			return true, nil
+		case compute_v1alpha.STOPPED, compute_v1alpha.DEAD:
+			// Terminal sandboxes no longer pin their version.
+		}
+	}
+	return false, nil
+}

--- a/controllers/version/gc_test.go
+++ b/controllers/version/gc_test.go
@@ -1,0 +1,273 @@
+package version
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	compute_v1alpha "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	testutils "miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
+)
+
+// createVersion creates an AppVersion with an explicit creation time. The
+// entity store honors a pre-set CreatedAt, which lets these tests assert
+// recency-based retention deterministically.
+func createVersion(t *testing.T, eac *entityserver_v1alpha.EntityAccessClient, name string, av *core_v1alpha.AppVersion, createdAt time.Time) entity.Id {
+	t.Helper()
+	ent := entity.New(
+		(&core_v1alpha.Metadata{Name: name}).Encode,
+		av.Encode,
+		entity.Ident, types.Keyword(av.ShortKind()+"/"+name),
+	)
+	ent.SetCreatedAt(createdAt)
+
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetAttrs(ent.Attrs())
+	pr, err := eac.Put(context.Background(), &rpcE)
+	require.NoError(t, err)
+	return entity.Id(pr.Id())
+}
+
+func setActiveVersion(t *testing.T, eac *entityserver_v1alpha.EntityAccessClient, appID, versionID entity.Id) {
+	t.Helper()
+	res, err := eac.Get(context.Background(), appID.String())
+	require.NoError(t, err)
+	patch := entity.New(
+		entity.Ref(entity.DBId, appID),
+		(&core_v1alpha.App{ActiveVersion: versionID}).Encode,
+	)
+	_, err = eac.Patch(context.Background(), patch.Attrs(), res.Entity().Revision())
+	require.NoError(t, err)
+}
+
+func versionExists(t *testing.T, eac *entityserver_v1alpha.EntityAccessClient, id entity.Id) bool {
+	t.Helper()
+	// A hard-deleted entity surfaces as a not-found error rather than an empty
+	// result, so treat any lookup failure as "gone".
+	res, err := eac.Get(context.Background(), id.String())
+	if err != nil {
+		return false
+	}
+	return res.HasEntity()
+}
+
+func TestGCController_RetentionCountAndActive(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "gcapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	now := time.Now()
+	// Five versions, v1 oldest .. v5 newest, all dated in the past so a zero
+	// RetentionPeriod cutoff (now) leaves age-based retention out of it.
+	ids := make([]entity.Id, 5)
+	for i := range 5 {
+		name := "v" + string(rune('1'+i))
+		ids[i] = createVersion(t, inmem.EAC, name,
+			&core_v1alpha.AppVersion{App: appID, Version: name},
+			now.Add(time.Duration(i-5)*time.Hour))
+	}
+
+	// Make an old version (v2) the active one; it must be kept even though it
+	// falls outside the most-recent count.
+	setActiveVersion(t, inmem.EAC, appID, ids[1])
+
+	gc := &GCController{
+		Log: log,
+		EAC: inmem.EAC,
+		Config: GCConfig{
+			CheckInterval:   time.Hour,
+			RetentionCount:  2, // keep v5, v4
+			RetentionPeriod: 0, // disable age-based retention
+		},
+	}
+
+	result, err := gc.RunGC(ctx)
+	require.NoError(t, err)
+
+	// Kept: v5, v4 (count) + v2 (active). Pruned: v3, v1.
+	require.Equal(t, 2, result.DeletedVersions)
+	require.Equal(t, 3, result.RetainedVersions)
+	require.Equal(t, 5, result.TotalScanned)
+
+	require.True(t, versionExists(t, inmem.EAC, ids[4]), "newest kept by count")
+	require.True(t, versionExists(t, inmem.EAC, ids[3]), "second-newest kept by count")
+	require.True(t, versionExists(t, inmem.EAC, ids[1]), "active version kept")
+	require.False(t, versionExists(t, inmem.EAC, ids[2]), "v3 pruned")
+	require.False(t, versionExists(t, inmem.EAC, ids[0]), "v1 pruned")
+}
+
+func TestGCController_RetentionPeriod(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "daysapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	now := time.Now()
+	recent := createVersion(t, inmem.EAC, "recent",
+		&core_v1alpha.AppVersion{App: appID, Version: "recent"}, now.Add(-5*24*time.Hour))
+	old := createVersion(t, inmem.EAC, "old",
+		&core_v1alpha.AppVersion{App: appID, Version: "old"}, now.Add(-40*24*time.Hour))
+
+	gc := &GCController{
+		Log: log,
+		EAC: inmem.EAC,
+		Config: GCConfig{
+			CheckInterval:   time.Hour,
+			RetentionCount:  0,                   // disable count-based retention
+			RetentionPeriod: 30 * 24 * time.Hour, // keep anything younger than 30 days
+		},
+	}
+
+	result, err := gc.RunGC(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, result.DeletedVersions)
+	require.True(t, versionExists(t, inmem.EAC, recent), "version within retention window kept")
+	require.False(t, versionExists(t, inmem.EAC, old), "version older than retention window pruned")
+}
+
+func TestGCController_SkipsEphemeral(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "ephapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	now := time.Now()
+	// An old ephemeral version that would be pruned if it were normal.
+	eph := createVersion(t, inmem.EAC, "eph",
+		&core_v1alpha.AppVersion{
+			App:                appID,
+			Version:            "eph",
+			EphemeralLabel:     "pr-1",
+			EphemeralExpiresAt: now.Add(48 * time.Hour),
+		}, now.Add(-90*24*time.Hour))
+
+	gc := &GCController{
+		Log:    log,
+		EAC:    inmem.EAC,
+		Config: GCConfig{CheckInterval: time.Hour, RetentionCount: 0, RetentionPeriod: 0},
+	}
+
+	result, err := gc.RunGC(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, result.TotalScanned, "ephemeral versions are not scanned")
+	require.Equal(t, 0, result.DeletedVersions)
+	require.True(t, versionExists(t, inmem.EAC, eph), "ephemeral version untouched by retention GC")
+}
+
+func TestGCController_SkipsLiveSandbox(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "liveapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	now := time.Now()
+	// Two prunable old versions.
+	withSandbox := createVersion(t, inmem.EAC, "with-sb",
+		&core_v1alpha.AppVersion{App: appID, Version: "with-sb"}, now.Add(-90*24*time.Hour))
+	noSandbox := createVersion(t, inmem.EAC, "no-sb",
+		&core_v1alpha.AppVersion{App: appID, Version: "no-sb"}, now.Add(-91*24*time.Hour))
+
+	// A running sandbox pins withSandbox.
+	sb := &compute_v1alpha.Sandbox{Status: compute_v1alpha.RUNNING}
+	sb.Spec.Version = withSandbox
+	_, err = inmem.Client.Create(ctx, "sb1", sb)
+	require.NoError(t, err)
+
+	gc := &GCController{
+		Log:    log,
+		EAC:    inmem.EAC,
+		Config: GCConfig{CheckInterval: time.Hour, RetentionCount: 0, RetentionPeriod: 0},
+	}
+
+	result, err := gc.RunGC(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, result.DeletedVersions)
+	require.Equal(t, 1, result.SkippedLive)
+	require.True(t, versionExists(t, inmem.EAC, withSandbox), "version with live sandbox retained")
+	require.False(t, versionExists(t, inmem.EAC, noSandbox), "version without sandbox pruned")
+}
+
+func TestGCController_PinnedNow(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	gc := &GCController{Log: testutils.TestLogger(t), EAC: inmem.EAC, Config: DefaultGCConfig()}
+
+	appID, err := inmem.Client.Create(ctx, "pinapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	now := time.Now()
+	vActive := createVersion(t, inmem.EAC, "v-active", &core_v1alpha.AppVersion{App: appID, Version: "v-active"}, now)
+	vLive := createVersion(t, inmem.EAC, "v-live", &core_v1alpha.AppVersion{App: appID, Version: "v-live"}, now)
+	vFree := createVersion(t, inmem.EAC, "v-free", &core_v1alpha.AppVersion{App: appID, Version: "v-free"}, now)
+
+	setActiveVersion(t, inmem.EAC, appID, vActive)
+
+	sb := &compute_v1alpha.Sandbox{Status: compute_v1alpha.RUNNING}
+	sb.Spec.Version = vLive
+	_, err = inmem.Client.Create(ctx, "sb-live", sb)
+	require.NoError(t, err)
+
+	pinned, err := gc.pinnedNow(ctx, vActive, appID)
+	require.NoError(t, err)
+	require.True(t, pinned, "active version is pinned")
+
+	pinned, err = gc.pinnedNow(ctx, vLive, appID)
+	require.NoError(t, err)
+	require.True(t, pinned, "version with a live sandbox is pinned")
+
+	pinned, err = gc.pinnedNow(ctx, vFree, appID)
+	require.NoError(t, err)
+	require.False(t, pinned, "unreferenced version is not pinned")
+}
+
+func TestGCController_DeletesConfigVersion(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "cfgapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	cvID, err := inmem.Client.Create(ctx, "old-cfg", &core_v1alpha.ConfigVersion{})
+	require.NoError(t, err)
+
+	old := createVersion(t, inmem.EAC, "old",
+		&core_v1alpha.AppVersion{App: appID, Version: "old", ConfigVersion: cvID},
+		time.Now().Add(-90*24*time.Hour))
+
+	gc := &GCController{
+		Log:    log,
+		EAC:    inmem.EAC,
+		Config: GCConfig{CheckInterval: time.Hour, RetentionCount: 0, RetentionPeriod: 0},
+	}
+
+	result, err := gc.RunGC(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, result.DeletedVersions)
+	require.False(t, versionExists(t, inmem.EAC, old), "version pruned")
+	require.False(t, versionExists(t, inmem.EAC, cvID), "config version cascade-deleted")
+}

--- a/docs/docs/command/server.md
+++ b/docs/docs/command/server.md
@@ -19,6 +19,8 @@ miren server [flags]
 - `--acme-dns-provider` — DNS provider for ACME DNS-01 challenges (e.g., cloudflare, route53, exec). When set, uses DNS challenge instead of HTTP challenge. See https://go-acme.github.io/lego/dns/ for available providers.
 - `--acme-email` — Email address for ACME account registration (recommended for account recovery and notifications)
 - `--address, -a` — Address to listen on (host:port). For IPv6 use brackets, e.g. "[::1]:8443".
+- `--app-version-retention-count` — Number of most-recent versions to retain per app regardless of age
+- `--app-version-retention-period` — Retain versions newer than this duration regardless of count (e.g. 30d, 2w)
 - `--buildkit-gc-duration` — How long to keep BuildKit cache entries (e.g., 7d, 24h)
 - `--buildkit-gc-storage` — Maximum BuildKit layer cache size (e.g., 10GB, 50GB)
 - `--buildkit-socket` — Path to external BuildKit Unix socket (for distributed mode)

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -183,3 +183,14 @@ Controls the embedded VictoriaMetrics instance used for application metrics.
 | `address` | string | `victoriametrics:8428` | Address when not using embedded | `MIREN_VICTORIAMETRICS_ADDRESS` | `--victoriametrics-addr` |
 
 \* Defaults to `true` in standalone mode only.
+
+## `[app_version]` — Version Retention {#app-version}
+
+Every deploy creates a new version of an app, and Miren keeps a bounded history of them rather than retaining every version forever. Pruning old versions frees the disk space their container images take up and keeps the server's per-app state from growing with every deploy.
+
+A version is retained if it is among the most recent `retention_count` **or** newer than `retention_period` — whichever rule keeps it. The two settings are a floor, not a budget: raising either one keeps more versions. The currently active version is always retained regardless of these limits, and ephemeral (preview) versions are managed separately by their own TTL.
+
+| Field | Type | Default | Description | Env Var | CLI Flag |
+|-------|------|---------|-------------|---------|----------|
+| `retention_count` | int | `10` | Most-recent versions to keep per app, regardless of age | `MIREN_APP_VERSION_RETENTION_COUNT` | `--app-version-retention-count` |
+| `retention_period` | string | `30d` | Keep versions newer than this, regardless of count (e.g. `30d`, `2w`) | `MIREN_APP_VERSION_RETENTION_PERIOD` | `--app-version-retention-period` |

--- a/pkg/appversion/delete.go
+++ b/pkg/appversion/delete.go
@@ -1,0 +1,124 @@
+// Package appversion holds shared helpers for managing AppVersion entities and
+// the resources that hang off them. It is consumed by both the ephemeral GC
+// (TTL expiry) and the version retention GC (count/age pruning) so the deletion
+// cascade lives in exactly one place.
+package appversion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// Delete hard-deletes an AppVersion and its 1:1 ConfigVersion.
+//
+// It deliberately does NOT touch sandbox pools. The sandbox pool Manager owns
+// pool lifecycle: on deploy the launcher de-refs and scales superseded pools to
+// zero, and the Manager's sweep reaps drained pools that no current version
+// references (see controllers/sandboxpool). By the time a version is old enough
+// to prune, its pools are already gone. Callers that need immediate pool
+// teardown rather than waiting for that sweep should use DeleteWithPools.
+//
+// ConfigVersion cleanup is best-effort: an orphaned ConfigVersion holds no
+// blobs, so a failure there is logged but does not block deleting the version.
+func Delete(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, version *core_v1alpha.AppVersion, log *slog.Logger) error {
+	// Delete the version first. If we cleaned up the ConfigVersion first and
+	// then the version delete failed, the surviving version would point at a
+	// missing config; ordering it this way means the best-effort cleanup only
+	// runs once the parent is actually gone.
+	if _, err := eac.Delete(ctx, version.ID.String()); err != nil {
+		return fmt.Errorf("failed to delete app version %s: %w", version.ID, err)
+	}
+
+	if version.ConfigVersion != "" {
+		if _, err := eac.Delete(ctx, version.ConfigVersion.String()); err != nil {
+			log.Warn("failed to delete config version for app version",
+				"version_id", version.ID, "config_version", version.ConfigVersion, "error", err)
+		}
+	}
+
+	log.Info("deleted app version", "version_id", version.ID)
+	return nil
+}
+
+// DeleteWithPools tears down the version's sandbox pools before deleting the
+// version, for callers (e.g. ephemeral TTL expiry) that want prompt teardown
+// instead of waiting for the pool Manager's idle sweep. Pools referenced only
+// by this version are deleted; pools shared with other versions keep their
+// remaining references.
+//
+// Pool cleanup runs first. If it fails, the AppVersion is retained so a future
+// pass can retry — otherwise we would leak pools that can no longer be traced
+// back to any version.
+func DeleteWithPools(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, version *core_v1alpha.AppVersion, log *slog.Logger) error {
+	if err := cleanupSandboxPools(ctx, eac, version.ID, log); err != nil {
+		return err
+	}
+	return Delete(ctx, eac, version, log)
+}
+
+// cleanupSandboxPools removes the sandbox pools that reference the given
+// version. Pools owned exclusively by this version are deleted; pools shared
+// across versions have just this version's reference removed. Any failure is
+// returned so the caller can retain the version for a later retry.
+func cleanupSandboxPools(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, versionID entity.Id, log *slog.Logger) error {
+	poolResp, err := eac.List(ctx, entity.Ref(
+		compute_v1alpha.SandboxPoolReferencedByVersionsId,
+		versionID,
+	))
+	if err != nil {
+		return fmt.Errorf("failed to list pools for app version %s: %w", versionID, err)
+	}
+
+	var poolErrs []error
+	for _, p := range poolResp.Values() {
+		poolID := p.Id()
+
+		var pool compute_v1alpha.SandboxPool
+		pool.Decode(p.Entity())
+
+		if len(pool.ReferencedByVersions) > 1 {
+			// Shared pool — remove our reference instead of deleting.
+			var remaining []entity.Id
+			for _, ref := range pool.ReferencedByVersions {
+				if ref != versionID {
+					remaining = append(remaining, ref)
+				}
+			}
+			pool.ReferencedByVersions = remaining
+
+			updateEntity := &entityserver_v1alpha.Entity{}
+			updateEntity.SetId(poolID)
+			updateEntity.SetAttrs(pool.Encode())
+			updateEntity.SetRevision(p.Revision())
+			if _, err := eac.Put(ctx, updateEntity); err != nil {
+				log.Warn("failed to remove version reference from shared pool", "pool_id", poolID, "error", err)
+				poolErrs = append(poolErrs, fmt.Errorf("pool %s: %w", poolID, err))
+			} else {
+				log.Debug("removed version reference from shared pool", "pool_id", poolID)
+			}
+			continue
+		}
+
+		// Exclusively owned — delete the pool.
+		if _, err := eac.Delete(ctx, poolID); err != nil {
+			log.Warn("failed to delete sandbox pool", "pool_id", poolID, "error", err)
+			poolErrs = append(poolErrs, fmt.Errorf("pool %s: %w", poolID, err))
+		} else {
+			log.Debug("deleted sandbox pool for app version", "pool_id", poolID)
+		}
+	}
+
+	if len(poolErrs) > 0 {
+		return fmt.Errorf("failed to delete %d sandbox pool(s) for app version %s; retaining version for retry: %w",
+			len(poolErrs), versionID, errors.Join(poolErrs...))
+	}
+
+	return nil
+}

--- a/pkg/ephemeral/manage.go
+++ b/pkg/ephemeral/manage.go
@@ -2,15 +2,14 @@ package ephemeral
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
 	"time"
 
-	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/appversion"
 	"miren.dev/runtime/pkg/entity"
 )
 
@@ -30,7 +29,7 @@ func ReplaceExisting(ctx context.Context, eac *entityserver_v1alpha.EntityAccess
 		if v.version.EphemeralLabel == label {
 			log.Info("replacing existing ephemeral version",
 				"label", label, "version_id", v.version.ID)
-			if err := deleteEphemeralVersion(ctx, eac, v.version.ID, log); err != nil {
+			if err := appversion.DeleteWithPools(ctx, eac, v.version, log); err != nil {
 				return fmt.Errorf("failed to delete existing ephemeral version %s: %w", v.version.ID, err)
 			}
 		}
@@ -64,7 +63,7 @@ func EnforceLimit(ctx context.Context, eac *entityserver_v1alpha.EntityAccessCli
 			"label", v.version.EphemeralLabel,
 			"version_id", v.version.ID,
 			"expires_at", v.version.EphemeralExpiresAt)
-		if err := deleteEphemeralVersion(ctx, eac, v.version.ID, log); err != nil {
+		if err := appversion.DeleteWithPools(ctx, eac, v.version, log); err != nil {
 			return fmt.Errorf("failed to evict ephemeral version %s: %w", v.version.ID, err)
 		}
 	}
@@ -87,7 +86,7 @@ func DeleteExpired(ctx context.Context, eac *entityserver_v1alpha.EntityAccessCl
 				"label", v.version.EphemeralLabel,
 				"version_id", v.version.ID,
 				"expired_at", v.version.EphemeralExpiresAt)
-			if err := deleteEphemeralVersion(ctx, eac, v.version.ID, log); err != nil {
+			if err := appversion.DeleteWithPools(ctx, eac, v.version, log); err != nil {
 				log.Error("failed to delete expired ephemeral version",
 					"version_id", v.version.ID, "error", err)
 				continue
@@ -120,81 +119,6 @@ func listEphemeralVersions(ctx context.Context, eac *entityserver_v1alpha.Entity
 		}
 	}
 	return result, nil
-}
-
-// DeleteVersion deletes an ephemeral AppVersion and its associated
-// sandbox pools.
-func DeleteVersion(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, versionID entity.Id, log *slog.Logger) error {
-	return deleteEphemeralVersion(ctx, eac, versionID, log)
-}
-
-func deleteEphemeralVersion(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, versionID entity.Id, log *slog.Logger) error {
-	// Delete sandbox pools that reference this version. If pool cleanup fails,
-	// abort deletion of the AppVersion entity — the version must remain so a
-	// future GC pass can retry pool cleanup. Otherwise we'd permanently leak
-	// sandbox pools that can no longer be traced back to any version.
-	poolResp, err := eac.List(ctx, entity.Ref(
-		compute_v1alpha.SandboxPoolReferencedByVersionsId,
-		versionID,
-	))
-	if err != nil {
-		return fmt.Errorf("failed to list pools for ephemeral version %s: %w", versionID, err)
-	}
-
-	var poolErrs []error
-	for _, p := range poolResp.Values() {
-		poolID := p.Id()
-
-		// Pools can be shared across versions (ReferencedByVersions is plural).
-		// Only delete pools exclusively owned by this version. For shared pools,
-		// remove just this version's reference.
-		var pool compute_v1alpha.SandboxPool
-		pool.Decode(p.Entity())
-
-		if len(pool.ReferencedByVersions) > 1 {
-			// Shared pool — remove our reference instead of deleting
-			var remaining []entity.Id
-			for _, ref := range pool.ReferencedByVersions {
-				if ref != versionID {
-					remaining = append(remaining, ref)
-				}
-			}
-			pool.ReferencedByVersions = remaining
-
-			updateEntity := &entityserver_v1alpha.Entity{}
-			updateEntity.SetId(poolID)
-			updateEntity.SetAttrs(pool.Encode())
-			updateEntity.SetRevision(p.Revision())
-			if _, err := eac.Put(ctx, updateEntity); err != nil {
-				log.Warn("failed to remove version reference from shared pool", "pool_id", poolID, "error", err)
-				poolErrs = append(poolErrs, fmt.Errorf("pool %s: %w", poolID, err))
-			} else {
-				log.Debug("removed version reference from shared pool", "pool_id", poolID)
-			}
-			continue
-		}
-
-		// Exclusively owned — delete the pool
-		if _, err := eac.Delete(ctx, poolID); err != nil {
-			log.Warn("failed to delete sandbox pool", "pool_id", poolID, "error", err)
-			poolErrs = append(poolErrs, fmt.Errorf("pool %s: %w", poolID, err))
-		} else {
-			log.Debug("deleted sandbox pool for ephemeral version", "pool_id", poolID)
-		}
-	}
-
-	if len(poolErrs) > 0 {
-		return fmt.Errorf("failed to delete %d sandbox pool(s) for ephemeral version %s; retaining version for retry: %w",
-			len(poolErrs), versionID, errors.Join(poolErrs...))
-	}
-
-	// Delete the AppVersion entity itself
-	if _, err := eac.Delete(ctx, string(versionID)); err != nil {
-		return fmt.Errorf("failed to delete app version %s: %w", versionID, err)
-	}
-
-	log.Info("Deleted ephemeral version", "version_id", versionID)
-	return nil
 }
 
 // LookupByLabel finds an ephemeral AppVersion for the given app and label.

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -5,6 +5,8 @@ package serverconfig
 // CLIFlags represents command-line flags for server configuration
 // All fields are pointers to distinguish between set and unset values
 type CLIFlags struct {
+	AppVersionConfigRetentionCount       *int     `long:"app-version-retention-count" description:"Number of most-recent versions to retain per app regardless of age" env:"MIREN_APP_VERSION_RETENTION_COUNT"`
+	AppVersionConfigRetentionPeriod      *string  `long:"app-version-retention-period" description:"Retain versions newer than this duration regardless of count (e.g. 30d, 2w)" env:"MIREN_APP_VERSION_RETENTION_PERIOD"`
 	BuildkitConfigGcKeepDuration         *string  `long:"buildkit-gc-duration" description:"How long to keep BuildKit cache entries (e.g., 7d, 24h)" env:"MIREN_BUILDKIT_GC_KEEP_DURATION"`
 	BuildkitConfigGcKeepStorage          *string  `long:"buildkit-gc-storage" description:"Maximum BuildKit layer cache size (e.g., 10GB, 50GB)" env:"MIREN_BUILDKIT_GC_KEEP_STORAGE"`
 	BuildkitConfigSocketDir              *string  `long:"buildkit-socket-dir" description:"Directory for embedded BuildKit Unix socket (defaults to data_path/buildkit/socket)" env:"MIREN_BUILDKIT_SOCKET_DIR"`

--- a/pkg/serverconfig/config.gen.go
+++ b/pkg/serverconfig/config.gen.go
@@ -6,6 +6,38 @@ import (
 	"time"
 )
 
+// AppVersionConfig App version retention garbage collection
+type AppVersionConfig struct {
+	RetentionCount  *int    `toml:"retention_count" env:"MIREN_APP_VERSION_RETENTION_COUNT"`
+	RetentionPeriod *string `toml:"retention_period" env:"MIREN_APP_VERSION_RETENTION_PERIOD"`
+}
+
+// GetRetentionCount returns the value of RetentionCount or its zero value if nil
+func (c *AppVersionConfig) GetRetentionCount() int {
+	if c.RetentionCount != nil {
+		return *c.RetentionCount
+	}
+	return 0
+}
+
+// SetRetentionCount sets the value of RetentionCount
+func (c *AppVersionConfig) SetRetentionCount(v int) {
+	c.RetentionCount = &v
+}
+
+// GetRetentionPeriod returns the value of RetentionPeriod or its zero value if nil
+func (c *AppVersionConfig) GetRetentionPeriod() string {
+	if c.RetentionPeriod != nil {
+		return *c.RetentionPeriod
+	}
+	return ""
+}
+
+// SetRetentionPeriod sets the value of RetentionPeriod
+func (c *AppVersionConfig) SetRetentionPeriod(v string) {
+	c.RetentionPeriod = &v
+}
+
 // BuildkitConfig BuildKit daemon configuration
 type BuildkitConfig struct {
 	GcKeepDuration *string `toml:"gc_keep_duration" env:"MIREN_BUILDKIT_GC_KEEP_DURATION"`
@@ -82,6 +114,7 @@ func (c *BuildkitConfig) SetStartEmbedded(v bool) {
 
 // Config Complete server configuration from all sources
 type Config struct {
+	AppVersion      AppVersionConfig      `toml:"app_version"`
 	Buildkit        BuildkitConfig        `toml:"buildkit"`
 	Containerd      ContainerdConfig      `toml:"containerd"`
 	Etcd            EtcdConfig            `toml:"etcd"`

--- a/pkg/serverconfig/defaults.gen.go
+++ b/pkg/serverconfig/defaults.gen.go
@@ -10,6 +10,7 @@ func strPtr(s string) *string { return &s }
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
 	return &Config{
+		AppVersion:      DefaultAppVersionConfig(),
 		Buildkit:        DefaultBuildkitConfig(),
 		Containerd:      DefaultContainerdConfig(),
 		Etcd:            DefaultEtcdConfig(),
@@ -20,6 +21,14 @@ func DefaultConfig() *Config {
 		TLS:             DefaultTLSConfig(),
 		Victorialogs:    DefaultVictoriaLogsConfig(),
 		Victoriametrics: DefaultVictoriaMetricsConfig(),
+	}
+}
+
+// DefaultAppVersionConfig returns default AppVersionConfig
+func DefaultAppVersionConfig() AppVersionConfig {
+	return AppVersionConfig{
+		RetentionCount:  intPtr(10),
+		RetentionPeriod: strPtr("30d"),
 	}
 }
 

--- a/pkg/serverconfig/loader.gen.go
+++ b/pkg/serverconfig/loader.gen.go
@@ -154,6 +154,14 @@ func loadConfigFile(path string, cfg *Config) error {
 
 func applyCLIFlags(cfg *Config, flags *CLIFlags) {
 
+	if flags.AppVersionConfigRetentionCount != nil {
+		cfg.AppVersion.RetentionCount = flags.AppVersionConfigRetentionCount
+	}
+
+	if flags.AppVersionConfigRetentionPeriod != nil && *flags.AppVersionConfigRetentionPeriod != "" {
+		cfg.AppVersion.RetentionPeriod = flags.AppVersionConfigRetentionPeriod
+	}
+
 	if flags.BuildkitConfigGcKeepDuration != nil && *flags.BuildkitConfigGcKeepDuration != "" {
 		cfg.Buildkit.GcKeepDuration = flags.BuildkitConfigGcKeepDuration
 	}

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -72,6 +72,11 @@ configs:
         toml: buildkit
         nested: true
 
+      app_version:
+        type: AppVersionConfig
+        toml: app_version
+        nested: true
+
   ServerConfig:
     description: Core server settings
     fields:
@@ -507,3 +512,24 @@ configs:
           description: How long to keep BuildKit cache entries (e.g., 7d, 24h)
         env: MIREN_BUILDKIT_GC_KEEP_DURATION
         toml: gc_keep_duration
+
+  AppVersionConfig:
+    description: App version retention garbage collection
+    fields:
+      retention_count:
+        type: int
+        default: 10
+        cli:
+          long: app-version-retention-count
+          description: Number of most-recent versions to retain per app regardless of age
+        env: MIREN_APP_VERSION_RETENTION_COUNT
+        toml: retention_count
+
+      retention_period:
+        type: string
+        default: "30d"
+        cli:
+          long: app-version-retention-period
+          description: Retain versions newer than this duration regardless of count (e.g. 30d, 2w)
+        env: MIREN_APP_VERSION_RETENTION_PERIOD
+        toml: retention_period

--- a/pkg/serverconfig/validation.gen.go
+++ b/pkg/serverconfig/validation.gen.go
@@ -11,6 +11,10 @@ import (
 // Validate validates the configuration
 func (c *Config) Validate() error {
 
+	if err := c.AppVersion.Validate(); err != nil {
+		return fmt.Errorf("app_version: %w", err)
+	}
+
 	if err := c.Buildkit.Validate(); err != nil {
 		return fmt.Errorf("buildkit: %w", err)
 	}
@@ -52,6 +56,14 @@ func (c *Config) Validate() error {
 	if err := c.Victoriametrics.Validate(); err != nil {
 		return fmt.Errorf("victoriametrics: %w", err)
 	}
+	return nil
+}
+
+// Validate validates AppVersionConfig
+func (c *AppVersionConfig) Validate() error {
+
+	// Check for port conflicts in AppVersionConfig
+
 	return nil
 }
 


### PR DESCRIPTION
App version retention is something we always figured we'd need eventually, and this is us building it. Every deploy mints a new AppVersion, and until now they lived forever. That unbounded growth had two costs: it bloated the entity store (and made the ephemeral GC's every-5-minute all-versions scan grow with the cluster's whole deploy history), and it kept disk pinned. Each version references an Artifact, and Artifacts reference registry blobs, so as long as old versions stuck around the image and blob GC could never reclaim old images.

So this adds a periodic version retention GC, modeled on the existing artifact GC and wired in beside it. Per app it keeps the most recent `retention_count` versions or anything newer than `retention_period`, whichever rule keeps it, always keeps the active version, and skips anything a running or pending sandbox still references. Everything else is hard-deleted along with its 1:1 ConfigVersion.

The interesting part is the disk half. Artifacts are shared many-versions-to-one (they're deduped by manifest digest), so you can't just archive a deleted version's artifact, since another live version might share the same image and would start 404ing. Instead, artifact archiving becomes reference-driven: the artifact GC's old blind age/count retention is replaced with "archive any active artifact that zero surviving versions reference," computed across all versions. That gives the existing image and blob GC chain something to actually reclaim, and a shared artifact naturally survives until its last referencing version is pruned.

While in here, the sandbox-pool cleanup that used to live in the ephemeral delete path got pulled into a shared helper. It turned out the version GC doesn't need it at all: the pool manager already reaps drained, unreferenced pools on its own, and the deploy launcher de-refs superseded pools. So there's now a plain `appversion.Delete` (a version plus its ConfigVersion) that the version GC uses, and a `DeleteWithPools` wrapper that only the ephemeral path calls, where prompt teardown actually matters.

Retention is configurable through `app_version.retention_count` and `app_version.retention_period` (defaults 10 and 30d), following the duration-string style of the existing victorialogs/buildkit knobs, and documented in the server config reference.

Closes MIR-329