### PR TITLE
Cut no-op reconcile chatter from miren's journal

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -47,6 +47,11 @@ type Launcher struct {
 	PoolReadyTimeout time.Duration
 
 	appMu sync.Map // per-app mutexes: app ID -> *sync.Mutex
+
+	// warnedNoDisk tracks apps we've already warned about auto-mounting local
+	// storage without a disk config, so the warning fires once per app instead
+	// of on every reconcile tick. Keyed by app ID.
+	warnedNoDisk sync.Map
 }
 
 // PoolWithEntity wraps a SandboxPool with its entity, allowing updates without re-fetching
@@ -131,7 +136,6 @@ func (l *Launcher) Reconcile(ctx context.Context, app *core_v1alpha.App, meta *e
 
 	span.SetAttributes(attribute.String("miren.app.active_version", current.ActiveVersion.String()))
 
-	l.Log.Info("reconciling app", "app", current.ID, "version", current.ActiveVersion)
 	ready, err := l.addonsReady(ctx, current.ID)
 	if err != nil {
 		l.Log.Error("failed to check addon readiness", "app", current.ID, "error", err)
@@ -235,11 +239,6 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 		return fmt.Errorf("failed to resolve config: %w", err)
 	}
 
-	l.Log.Info("reconciling app version",
-		"app", app.ID,
-		"version", ver.Version,
-		"services", len(spec.Services))
-
 	// For each service, ensure a pool exists. Collect IDs of newly created pools.
 	var newPoolIDs []entity.Id
 	for _, svc := range spec.Services {
@@ -319,12 +318,26 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	}
 
 	// Clean up old version pools (pools not referenced by current version)
-	if err := l.cleanupOldVersionPools(ctx, app, ver.ID); err != nil {
+	cleaned, err := l.cleanupOldVersionPools(ctx, app, ver.ID)
+	if err != nil {
 		l.Log.Error("failed to cleanup old version pools",
 			"app", app.ID,
 			"version", ver.ID,
 			"error", err)
 		// Don't fail the entire reconciliation if cleanup fails
+	}
+
+	// Summarize only when this reconcile actually did something. The loop runs
+	// constantly; a steady-state pass that created and cleaned up nothing stays
+	// silent so the journal isn't buried in no-op narration.
+	// pools_started counts pools we booted this pass: both brand-new pools and
+	// drained pools revived for deploy verification (newPoolIDs holds both).
+	if len(newPoolIDs) > 0 || cleaned > 0 {
+		l.Log.Info("reconciled app version",
+			"app", app.ID,
+			"version", ver.Version,
+			"pools_started", len(newPoolIDs),
+			"pools_cleaned_up", cleaned)
 	}
 
 	return nil
@@ -392,12 +405,9 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 	}
 
 	if poolWithEntity != nil {
-		// Reuse existing pool — sandboxes already running, no wait needed
-		l.Log.Info("reusing existing pool",
-			"pool", poolWithEntity.Pool.ID,
-			"service", serviceName,
-			"app", app.ID)
-
+		// Reuse existing pool — sandboxes already running, no wait needed.
+		// Steady-state reuse is a no-op; only log (below) when reuse actually
+		// mutates the pool.
 		needsUpdate := false
 
 		// Update the pool's sandbox spec version to track the current AppVersion
@@ -449,6 +459,10 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 		}
 
 		if needsUpdate {
+			l.Log.Info("reusing existing pool, applying updates",
+				"pool", poolWithEntity.Pool.ID,
+				"service", serviceName,
+				"app", app.ID)
 			if err := l.updatePool(ctx, poolWithEntity); err != nil {
 				return "", fmt.Errorf("failed to update pool: %w", err)
 			}
@@ -779,9 +793,14 @@ func (l *Launcher) buildSandboxSpec(
 			}
 		}
 		if !hasLocalMount && dirHasData(filepath.Join(l.DataPath, "data", "local", app.ID.String())) {
-			l.Log.Warn("auto-mounting local storage for app with existing data but no disk config",
-				"service", serviceName,
-				"app", app.ID)
+			// Warn once per app; this condition holds on every reconcile tick
+			// until the app gets an explicit disk config, so logging each time
+			// just floods the journal.
+			if _, warned := l.warnedNoDisk.LoadOrStore(app.ID, struct{}{}); !warned {
+				l.Log.Warn("auto-mounting local storage for app with existing data but no disk config",
+					"service", serviceName,
+					"app", app.ID)
+			}
 			sbSpec.Volume = append(sbSpec.Volume, compute_v1alpha.SandboxSpecVolume{
 				Name:      "local-data",
 				Provider:  "local",
@@ -1227,21 +1246,16 @@ func (l *Launcher) hasRunningSandboxForPool(ctx context.Context, poolID entity.I
 	return false, nil
 }
 
-// cleanupOldVersionPools removes old version references from pools and scales down unreferenced pools
-func (l *Launcher) cleanupOldVersionPools(ctx context.Context, app *core_v1alpha.App, currentVersionID entity.Id) error {
-	l.Log.Info("cleaning up old version pools",
-		"app", app.ID,
-		"current_version", currentVersionID)
-
+// cleanupOldVersionPools removes old version references from pools and scales
+// down unreferenced pools. It returns the number of pools it actually changed.
+func (l *Launcher) cleanupOldVersionPools(ctx context.Context, app *core_v1alpha.App, currentVersionID entity.Id) (int, error) {
 	// List all pools
 	poolsResp, err := l.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandboxPool))
 	if err != nil {
-		return fmt.Errorf("failed to list pools: %w", err)
+		return 0, fmt.Errorf("failed to list pools: %w", err)
 	}
 
-	poolCount := len(poolsResp.Values())
-	l.Log.Info("found pools to check", "count", poolCount)
-
+	cleaned := 0
 	for _, ent := range poolsResp.Values() {
 		var pool compute_v1alpha.SandboxPool
 		pool.Decode(ent.Entity())
@@ -1256,20 +1270,12 @@ func (l *Launcher) cleanupOldVersionPools(ctx context.Context, app *core_v1alpha
 			continue
 		}
 
-		l.Log.Info("checking pool for cleanup",
-			"pool", pool.ID,
-			"service", pool.Service,
-			"references", pool.ReferencedByVersions)
-
 		// Check if this pool is being used by the current version
 		isUsedByCurrentVersion := containsRef(pool.ReferencedByVersions, currentVersionID)
 
 		if isUsedByCurrentVersion {
-			// Pool is being reused by current version - keep ALL references
-			// Multiple versions may reference the same pool during rolling deployments
-			l.Log.Info("pool is being reused by current version, keeping all references",
-				"pool", pool.ID,
-				"service", pool.Service)
+			// Pool is being reused by current version - keep ALL references.
+			// Multiple versions may reference the same pool during rolling deployments.
 			continue
 		}
 
@@ -1310,9 +1316,10 @@ func (l *Launcher) cleanupOldVersionPools(ctx context.Context, app *core_v1alpha
 			l.Log.Error("failed to update pool", "error", err, "pool", pool.ID)
 			continue
 		}
+		cleaned++
 	}
 
-	return nil
+	return cleaned, nil
 }
 
 // ensureServiceForPorts creates or updates a network Service entity for a service

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -72,8 +72,6 @@ func (s *SagaSandboxController) Init(ctx context.Context) error {
 // Create handles sandbox create/update events. For new sandboxes, it uses
 // the saga-based creation flow.
 func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox, meta *entity.Meta) error {
-	s.log.Info("considering sandbox create or update (saga)", "id", co.ID, "status", co.Status)
-
 	switch co.Status {
 	case compute.DEAD:
 		return nil

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -824,7 +824,6 @@ func (c *SandboxController) checkNetworkHealth(ctx context.Context, sb *compute.
 		}
 	}
 	if !hasTCPPorts {
-		c.Log.Debug("sandbox has no exposed TCP ports, skipping network health check", "sandbox_id", sb.ID)
 		return true
 	}
 
@@ -843,8 +842,6 @@ func (c *SandboxController) checkNetworkHealth(ctx context.Context, sb *compute.
 			}
 			port := int(p.Port)
 			if checkPort(pid, port) {
-				c.Log.Debug("network health check passed",
-					"sandbox_id", sb.ID, "container_name", container.Name, "port", port)
 				return true
 			}
 			c.Log.Debug("network health check found no listener for port",
@@ -859,8 +856,6 @@ func (c *SandboxController) checkNetworkHealth(ctx context.Context, sb *compute.
 	for _, bp := range sb.BoundPort {
 		port := int(bp.Port)
 		if checkPort(pid, port) {
-			c.Log.Debug("network health check passed on observed bound port",
-				"sandbox_id", sb.ID, "port", port)
 			return true
 		}
 		c.Log.Debug("network health check found no listener for observed bound port",
@@ -942,8 +937,6 @@ func (c *SandboxController) reattachLogs(ctx context.Context, sb *compute.Sandbo
 }
 
 func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, meta *entity.Meta) error {
-	c.Log.Info("considering sandbox create or update", "id", co.ID, "status", co.Status)
-
 	switch co.Status {
 	case compute.DEAD:
 		return nil
@@ -2861,12 +2854,6 @@ func (c *SandboxController) Periodic(ctx context.Context, timeHorizon time.Durat
 		// Check if sandbox is DEAD and UpdatedAt is older than time horizon
 		if sb.Status == compute.DEAD {
 			updatedAt := e.Entity().GetUpdatedAt()
-
-			c.Log.Debug("checking sandbox for cleanup",
-				"id", sb.ID,
-				"status", sb.Status,
-				"updated_at", updatedAt.Format(time.RFC3339),
-				"age", now.Sub(updatedAt).String())
 
 			if updatedAt.Before(cutoffTime) {
 				c.Log.Info("deleting old dead sandbox",

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "158b655cbab9fe01fb475b037bb3259c04c26216d743004513310ed70263bd43",
+		"sandbox.go":  "2b69dc3c845199eee68f61fdd0d90df79b72609feacc5af59f3f01f1450c0951",
 		"volume.go":   "b4697764d48a90adc04ce47968ccef11ceba50da8d19c889906c5c3a539065b3",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -152,12 +152,6 @@ func (m *Manager) Reconcile(ctx context.Context, pool *compute_v1alpha.SandboxPo
 		desired = MaxPoolSize
 	}
 
-	m.log.Debug("sandbox counts",
-		"pool", pool.ID,
-		"actual", actual,
-		"ready", ready,
-		"desired", desired)
-
 	// Scale up if needed
 	if actual < desired {
 		toCreate := desired - actual
@@ -513,7 +507,8 @@ func (m *Manager) updatePoolStatus(ctx context.Context, pool *compute_v1alpha.Sa
 		m.log.Debug("updated pool status",
 			"pool", pool.ID,
 			"current", current,
-			"ready", ready)
+			"ready", ready,
+			"desired", min(pool.DesiredInstances, MaxPoolSize))
 	}
 
 	// Propagate all pool changes back to the entity for the framework to diff and persist.


### PR DESCRIPTION
Digging through `journalctl -u miren` on garden, the signal-to-noise ratio was rough: a clean ~1.9h steady-state window held about 80k lines (~700 lines/min, call it 1M lines/day), and roughly 80% of that was reconcile loops heartbeating on every tick even when nothing changed. That's the same theme that bit us in MIR-1279, where garden sat wedged for 14h before a human noticed. A journal that noisy is exactly where a real signal goes to hide.

Three loops drove most of the volume. The sandboxpool `sandbox counts` debug line was the single highest-volume line in the whole journal, firing per-pool every tick even when actual == ready == desired. The deployment launcher narrated its entire reconcile story at INFO on every pass (`reconciling app` → `reconciling app version` → `found pools to check` and onward), seven lines per app per minute regardless of whether anything happened. And the sandbox controller logged `considering sandbox create or update` at the top of every reconcile, plus a handful of debug siblings.

The tempting fix is to just demote everything to debug, but garden already runs at debug, so that buys nothing (the highest-volume line was already debug). So instead of demoting, we took a critical eye to whether these lines earn their place at all and cut the pure heartbeats outright. What's left is gated on actual work: the pool status line already only logs on a count change, so we folded `desired` into it and dropped the redundant counts line. Pool reuse only logs when reuse actually mutates the pool. The deployment loop now emits a single summary line only when it did real work, instead of seven lines of narration. The auto-mount-without-disk-config warning, which was firing for six apps on every tick forever, now warns once per app.

The sandbox `considering` line lives in both the classic and the saga controller, so we removed it from both to keep things quiet regardless of the `labs.Sagas()` flag. That meant touching the frozen legacy `sandbox.go`, which is guarded by a hash test during the saga migration. Per the guard's own instructions I audited the saga path for the parallel change (it was just the twin log line) and bumped the recorded hash.

The two smaller items the issue mentions, the tempo trace-export timeouts and the inbound TLS-handshake scanner noise, are left for separate passes. Those are a different kind of problem than our own loops talking to themselves, and the TLS one in particular wants its own think about `http.Server.ErrorLog` filtering.

Closes MIR-1282