### PR TITLE
Enforce BuildKit's GC byte cap with age-less policy tiers

### DIFF
--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -269,6 +269,38 @@ func (c *Component) Client(ctx context.Context) (*buildkitclient.Client, error) 
 	)
 }
 
+// generateConfig renders the buildkitd.toml the embedded daemon runs with.
+//
+// The GC policy is the part worth reading. BuildKit prunes the build cache
+// after every build, running each worker.oci.gcpolicy tier in order and
+// trimming down to that tier's limit. We tune the tiers for how miren builds:
+// stackbuild turns an uploaded app into an image using persistent package
+// caches, and a small set of base images gets rebuilt constantly.
+//
+// The rule that matters: a byte cap only holds if some tier enforces it with no
+// keepDuration. A keepDuration gate keeps any record used within the window,
+// and it keeps that record's whole ancestry along with it, since we can't drop
+// a base layer while a fresher layer still sits on top. On a busy builder that
+// covers almost the entire cache, so an age-gated cap never binds and the cache
+// grows forever. That's how garden hit 27GB against a 10GB cap and fed the
+// MIR-1279 disk outage. So the last two tiers set no keepDuration.
+//
+// The tiers, in the order BuildKit runs them:
+//
+//  1. Cheap scratch, cleared first. Build inputs and side caches, not built
+//     layers: the uploaded app source (source.local, from stackbuild's
+//     llb.Local context), the persistent package caches (exec.cachemount for
+//     bun/go/pip/bundler, via CacheMountFrom), and git checkouts (rare; we
+//     build from tarballs). Losing these costs a slower next build and nothing
+//     else, so we clear them before touching real layers once they pass 512MB
+//     and 48h. Each filter is its own array element so BuildKit ORs them; a
+//     single comma-joined string gets ANDed, and since a record has one type,
+//     matches nothing.
+//  2. Keep recently-used cache when we can, but stay under the cap.
+//  3. The real ceiling: enforce the cap regardless of age, dropping the
+//     least-recently-used first. This is what breaks the pinning above, since
+//     removing a fresh leaf frees the ancestors under it.
+//  4. Last resort: sweep internal and frontend cache too, to hold the line.
 func (c *Component) generateConfig(gcKeepStorage, gcKeepDuration int64, registryHost string) string {
 	if registryHost == "" {
 		registryHost = "cluster.local:5000"
@@ -297,19 +329,33 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 
 [worker.oci]
   gc = true
-  gckeepstorage = %d
+  gckeepstorage = %[1]d
+
+  # GC policy tuned for miren's build workload; see generateConfig in
+  # components/buildkit/buildkit.go for the rationale.
+  [[worker.oci.gcpolicy]]
+    filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout" ]
+    keepDuration = 172800
+    maxUsedSpace = 512000000
 
   [[worker.oci.gcpolicy]]
-    keepBytes = %d
-    keepDuration = %d
+    keepDuration = %[2]d
+    maxUsedSpace = %[1]d
+
+  [[worker.oci.gcpolicy]]
+    maxUsedSpace = %[1]d
+
+  [[worker.oci.gcpolicy]]
+    all = true
+    maxUsedSpace = %[1]d
 
 [registry."docker.io"]
   http = true
 
-[registry."%s"]
+[registry."%[3]s"]
   insecure = true
   http = true
-`, gcKeepStorage, gcKeepStorage, gcKeepDuration, registryHost)
+`, gcKeepStorage, gcKeepDuration, registryHost)
 }
 
 // writeHostsFile creates or updates the custom /etc/hosts file for the BuildKit container.

--- a/components/buildkit/config_test.go
+++ b/components/buildkit/config_test.go
@@ -11,29 +11,69 @@ func TestGenerateConfig(t *testing.T) {
 	c := &Component{}
 	config := c.generateConfig(10*1024*1024*1024, 86400, "registry.example.com:5000")
 
-	t.Run("has single catch-all gcpolicy", func(t *testing.T) {
+	// gcPolicyBlocks splits the config into its individual gcpolicy bodies
+	// (text from one "[[worker.oci.gcpolicy]]" header to the next section).
+	gcPolicyBlocks := func(cfg string) []string {
+		var blocks []string
+		const hdr = "[[worker.oci.gcpolicy]]"
+		rest := cfg
+		for {
+			i := strings.Index(rest, hdr)
+			if i < 0 {
+				break
+			}
+			rest = rest[i+len(hdr):]
+			end := len(rest)
+			if n := strings.Index(rest, "[["); n >= 0 {
+				end = n
+			}
+			if n := strings.Index(rest, "\n[registry"); n >= 0 && n < end {
+				end = n
+			}
+			blocks = append(blocks, rest[:end])
+		}
+		return blocks
+	}
+
+	t.Run("enforces the byte cap with an age-less tier", func(t *testing.T) {
 		r := require.New(t)
 
-		count := strings.Count(config, "[[worker.oci.gcpolicy]]")
-		r.Equal(1, count, "should have exactly one gcpolicy block")
+		blocks := gcPolicyBlocks(config)
+		r.GreaterOrEqual(len(blocks), 2, "should have multiple graduated gcpolicy tiers")
+
+		// MIR-1280: a keepDuration-only policy can never enforce the cap because
+		// it pins recently-used records and their whole ancestry. At least one
+		// tier must carry maxUsedSpace WITHOUT keepDuration so the ceiling binds
+		// regardless of entry age.
+		ageless := 0
+		for _, b := range blocks {
+			if strings.Contains(b, "maxUsedSpace") && !strings.Contains(b, "keepDuration") {
+				ageless++
+			}
+		}
+		r.GreaterOrEqual(ageless, 1, "at least one tier must enforce maxUsedSpace with no keepDuration")
+
+		// The last-resort tier must be the age-less all=true ceiling, or
+		// internal/frontend cache stays outside the enforced cap.
+		last := blocks[len(blocks)-1]
+		r.Contains(last, "all = true", "final tier should cover all cache types")
+		r.Contains(last, "maxUsedSpace", "final tier should enforce the byte cap")
+		r.NotContains(last, "keepDuration", "final tier must not be age-gated")
 	})
 
-	t.Run("policy has no filters (catch-all)", func(t *testing.T) {
+	t.Run("uses maxUsedSpace as the cap, not deprecated keepBytes", func(t *testing.T) {
 		r := require.New(t)
+		r.Contains(config, "maxUsedSpace")
+		r.NotContains(config, "keepBytes")
+	})
 
-		idx := strings.Index(config, "[[worker.oci.gcpolicy]]")
-		r.GreaterOrEqual(idx, 0, "gcpolicy block should be present in config")
-
-		block := config[idx:]
-		// Extract just the policy block (up to next section)
-		nextSection := strings.Index(block, "\n[registry")
-		if nextSection > 0 {
-			block = block[:nextSection]
-		}
-
-		r.NotContains(block, "filters")
-		r.Contains(block, "keepBytes")
-		r.Contains(block, "keepDuration")
+	t.Run("source filters use OR (array) form, not comma-joined AND", func(t *testing.T) {
+		r := require.New(t)
+		// A single comma-joined filter string is AND'd and matches no record.
+		r.NotContains(config, "type==source.local,type==exec.cachemount")
+		r.Contains(config, `"type==source.local"`)
+		r.Contains(config, `"type==exec.cachemount"`)
+		r.Contains(config, `"type==source.git.checkout"`)
 	})
 
 	t.Run("uses provided registry host", func(t *testing.T) {


### PR DESCRIPTION
BuildKit's build cache on miren-garden grew to 27GB against a configured 10GB cap and became a primary contributor to the MIR-1279 disk-pressure outage. The frustrating part: when we pruned it by hand it dropped right back under the limit, so the cache was always collectable. Automatic GC just never did it.

Digging in on the box turned up two compounding faults in the `buildkitd.toml` we generate. First, no ceiling field was ever actually set. We configured `keepBytes`, which BuildKit v0.19 deprecates and quietly migrates to `reservedSpace`, and that's a floor ("never prune below this"), not a cap. The real ceiling field, `maxUsedSpace`, was left at zero. `buildctl debug workers` on garden confirmed it: `{reservedSpace:10GB, maxUsedSpace:0, keepDuration:7d}`.

Second, and this is the subtle one, `keepDuration` protects far more than it looks. It shields any record used within the window, but because a parent layer can't be deleted while a child still references it, it transitively pins the entire ancestry of anything touched recently. On a builder that constantly rebuilds the same family of base images, that's nearly the whole cache. We measured it on garden: 73 of 73 records older than 7 days were pinned by a younger descendant, zero were freely deletable. So GC ran faithfully after every build and only ever reclaimed the thin tail that had just aged out, while the cap never bound and the pile climbed.

We proved the mechanism live with a controlled prune: same 2GB target, `--keep-duration 168h` freed 0 bytes while dropping the age gate freed 7.74GB. And we confirmed this isn't something a version bump fixes: the prune logic is byte-identical from v0.19 (what we run) through v0.31.

The fix replaces the single age-gated policy with a graduated set that mirrors BuildKit's own default shape: a 48h/512MB tier for the cheapest-to-rebuild sources, a soft `keepDuration` tier, and then two age-less `maxUsedSpace` tiers that enforce the ceiling regardless of age (the age-less pass drops fresh leaves so their pinned ancestors can finally go). Source filters use the array (OR) form, since a single comma-joined string ANDs the types and matches nothing.

Follow-ups filed while we were in here: MIR-1286 (the `miren-oci` registry has no retention and has ballooned to 236GB) and MIR-1287 (get BuildKit off the release candidate and align the daemon/client/test versions).

Closes MIR-1280
