### PR TITLE
Fix build saga crash recovery so resumed builds complete after a restart

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -943,6 +943,15 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		}
 	}
 
+	// The registry is now listening and cluster.local resolves to it, so
+	// it's safe to resume any build sagas interrupted by a previous crash.
+	// Recovery runs here, not inside co.Start, because a resumed image push
+	// needs these dependencies that Start does not yet have (MIR-1285). It
+	// runs in the background on sub (the errgroup/shutdown context) so a
+	// recovered build, which re-runs to completion and can take minutes,
+	// doesn't block boot but is still cancelled on server shutdown.
+	go co.RecoverBuildSagas(sub)
+
 	cert, err := co.IssueCertificate("miren-server")
 	if err != nil {
 		ctx.Log.Error("failed to issue server certificate", "error", err)

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -361,6 +361,12 @@ type Coordinator struct {
 	logAddressesOnce sync.Once
 
 	debugServer *debugsrv.Server
+
+	// sagaBuilder is retained so build saga recovery can be driven from
+	// the boot sequence (RecoverBuildSagas) after the build's runtime
+	// dependencies — the registry and the cluster.local mapping — are
+	// ready. nil when sagas are disabled. See MIR-1285.
+	sagaBuilder *build.SagaBuilder
 }
 
 func (c *Coordinator) Activator() activator.AppActivator {
@@ -373,6 +379,22 @@ func (c *Coordinator) SandboxPoolManager() *sandboxpool.Manager {
 
 func (c *Coordinator) HttpIngress() *httpingress.Server {
 	return c.hs
+}
+
+// RecoverBuildSagas resumes in-flight build sagas left by a previous
+// process. It must be called from the boot sequence AFTER the runtime
+// dependencies a resumed build needs — the cluster registry and the
+// cluster.local name mapping — are ready. Recovery is deliberately not
+// run during Start, where it would resume an image push before those
+// exist (MIR-1285). No-op when sagas are disabled; recovery errors are
+// logged, not fatal.
+func (c *Coordinator) RecoverBuildSagas(ctx context.Context) {
+	if c.sagaBuilder == nil {
+		return
+	}
+	if err := c.sagaBuilder.Recover(ctx); err != nil {
+		c.Log.Error("build saga recovery completed with errors", "error", err)
+	}
 }
 
 // Stop stops the coordinator and all managed controllers
@@ -1133,10 +1155,15 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	if labs.Sagas() {
 		sagaStorage := saga.NewEntityStorage(etcdStore, c.Log)
 		sagaBuilder := build.NewSagaBuilder(bs, sagaStorage, c.Log)
-		if err := sagaBuilder.Init(ctx); err != nil {
+		if err := sagaBuilder.Init(); err != nil {
 			c.Log.Error("failed to initialize saga builder", "error", err)
 			return err
 		}
+		// Retain for RecoverBuildSagas, driven from the boot sequence
+		// after the registry and cluster.local mapping are ready. Running
+		// recovery here would resume an image push before they exist
+		// (MIR-1285).
+		c.sagaBuilder = sagaBuilder
 		buildHandler = sagaBuilder
 	}
 	server.ExposeValue("dev.miren.runtime/build", build_v1alpha.AdaptBuilder(buildHandler))

--- a/pkg/saga/eac_storage.go
+++ b/pkg/saga/eac_storage.go
@@ -103,6 +103,7 @@ func (s *EACStorage) Get(ctx context.Context, id string) (*Execution, error) {
 func (s *EACStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
 	// Query for each incomplete status
 	var allEntities []*es.Entity
+	seen := make(map[string]struct{})
 
 	for _, statusRef := range []entity.Id{
 		saga_v1alpha.SagaStatusPendingId,
@@ -116,7 +117,17 @@ func (s *EACStorage) ListIncomplete(ctx context.Context) ([]*Execution, error) {
 		if err != nil {
 			return nil, fmt.Errorf("listing sagas with status %s: %w", statusRef, err)
 		}
-		allEntities = append(allEntities, resp.Values()...)
+		// Deduplicate by ID: a saga can appear under more than one status
+		// index (e.g. a stale pending entry after transitioning to running),
+		// and recovering the same execution twice causes double execution.
+		for _, v := range resp.Values() {
+			id := v.Id()
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			allEntities = append(allEntities, v)
+		}
 	}
 
 	if len(allEntities) == 0 {

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -130,9 +130,22 @@ func (s *EntityStorage) ListIncomplete(ctx context.Context) ([]*Execution, error
 		return nil, fmt.Errorf("listing undoing sagas: %w", err)
 	}
 
-	// Combine IDs
-	allIds := append(pendingIds, runningIds...)
-	allIds = append(allIds, undoingIds...)
+	// Combine IDs, deduplicating by ID. A saga can transiently appear under
+	// more than one status index (e.g. a stale pending entry lingering after
+	// the transition to running). Recovering the same execution twice causes
+	// double execution: the second pass re-runs already-completed actions and
+	// collides on entities the first pass created.
+	seen := make(map[entity.Id]struct{})
+	var allIds []entity.Id
+	for _, ids := range [][]entity.Id{pendingIds, runningIds, undoingIds} {
+		for _, id := range ids {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			allIds = append(allIds, id)
+		}
+	}
 	if len(allIds) == 0 {
 		return nil, nil
 	}

--- a/servers/build/saga_builder.go
+++ b/servers/build/saga_builder.go
@@ -77,19 +77,30 @@ func NewSagaBuilder(inner *Builder, sagaStorage saga.Storage, log *slog.Logger) 
 	}
 }
 
-// Init registers the build-from-tar saga definition with the executor
-// and recovers any incomplete sagas left over from a previous process.
-// Should be called once at server startup before serving RPC requests.
-func (s *SagaBuilder) Init(ctx context.Context) error {
+// Init registers the build-from-tar saga definition with the executor.
+// It must be called once at startup, before serving RPC requests, so new
+// builds can run. It deliberately does not recover in-flight sagas:
+// recovery resumes a build's image push, which needs the cluster
+// registry and the cluster.local name mapping, and those are established
+// late in boot (after the coordinator's own startup). Recovery is split
+// into Recover and driven from the boot sequence once those dependencies
+// exist. See MIR-1285.
+func (s *SagaBuilder) Init() error {
 	if err := registerBuildSaga(s.registry, s.inner, s.streams, s.statuses, s.log); err != nil {
 		return fmt.Errorf("registering build-from-tar saga: %w", err)
 	}
-	if err := s.executor.Recover(ctx); err != nil {
-		// Recovery failures don't block startup — they're already
-		// logged inside Recover. New requests can still come in.
-		s.log.Error("saga recovery completed with errors", "error", err)
-	}
 	return nil
+}
+
+// Recover resumes any incomplete sagas left over from a previous
+// process. It must run only after a resumed build's runtime dependencies
+// (the registry listener and the cluster.local name mapping) are ready;
+// running it mid-boot resumes the image push before those exist, so the
+// build fails and rolls back (MIR-1285). The error is returned for the
+// caller to log; recovery failures are not fatal, since new build
+// requests can still be served.
+func (s *SagaBuilder) Recover(ctx context.Context) error {
+	return s.executor.Recover(ctx)
 }
 
 // BuildFromTar is the saga-backed implementation of the RPC method.


### PR DESCRIPTION
Saga crash recovery for builds worked in the narrow sense that the executor faithfully recovered an in-flight `build-from-tar` saga from etcd on restart and resumed the `build-image` action. What it couldn't do was finish. The recovered build would try to push its image to `cluster.local:5000` and fail with `dial tcp: lookup cluster.local ... no such host`, burn through buildkit's fast internal retries in about a second, and roll the whole thing back. A fresh deploy minutes later worked fine, which was the tell that this was an ordering problem, not a broken registry.

Mapping the boot sequence made the cause clear, and it's more of a structural inversion than a race. Build saga recovery ran synchronously inside `co.Start()`, but the things a push depends on (the flannel-derived router address, the `cluster.local` host mapping, `SetRegistryIP`, and the registry listener itself) are all established later in the server boot path, after `co.Start()` returns. So on every restart with an in-flight build, recovery resumed the push into a world where the push target didn't resolve yet.

The fix is to run recovery from the boot sequence after those dependencies exist, rather than in the middle of coordinator startup. Recovery is split out of `SagaBuilder.Init` (which now just registers the saga definition) into a `Recover` method the coordinator drives via `RecoverBuildSagas`, called once the registry and name mapping are up.

Verifying it end to end (deploy with an `onbuild = ["sleep 180"]` window, SIGKILL the coordinator mid-build, restart) turned up two more things, which is why the diff is a little bigger than a pure reorder.

First, once recovery actually succeeds it re-runs the whole build to completion, which takes minutes, and doing that synchronously wedged boot: the server never signaled ready and health checks would time out. The old code got away with synchronous recovery only because it always failed in about a second. So recovery now runs in the background, and boot completes promptly while the recovered build finishes on its own.

Second, with recovery finally getting past the push, it started colliding on `create-config-version`. It turned out `saga.ListIncomplete` combined the pending, running, and undoing status-index IDs without deduplicating, so a saga that lingered in more than one index got recovered twice, and the second pass re-ran already-completed actions and conflicted on an entity the first pass had created. This bug predates the change; it was just invisible while recovery always died at the push. Fixed by deduplicating in both saga storage backends.

After all three, the repro is clean: the coordinator boots in a few seconds, recovery runs exactly once, and the resumed build completes and activates the new version, with zero DNS errors and zero conflicts.

The stale deployment lock a crashed deploy leaves behind (the other symptom in the original issue) is intentionally out of scope here and stays with MIR-681, where server-owned deployment lifecycle is the right home for it. The broader "boot ordering is implicit and fragile" problem this exposed is written up separately as an RFD (Boot Dependency Graph).

Closes MIR-1285
