### PR TITLE
Fix auto-mounted local storage orphaning duplicate pools, and stop the activator stranding ingress on them

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -2015,6 +2015,49 @@ func (a *localActivator) removePoolFromTracking(poolID entity.Id) {
 	}
 }
 
+// evictStaleVersionBindingsLocked drops version->pool bindings that point at
+// freshPool but whose version freshPool no longer references. When the launcher
+// supersedes a pool it dereferences it (ReferencedByVersions=nil,
+// DesiredInstances=0) without deleting the entity, so the pool still exists and
+// removePoolFromTracking never fires. Without this, a binding established at
+// recovery stays pinned to the drained pool and never re-resolves to the
+// canonical one that still references the version, which is how ingress gets
+// stranded on a superseded pool across a restart (MIR-1293). Evicting the stale
+// entry lets the next AcquireLease re-resolve the key via findPoolInStore, which
+// selects the pool that still references the version.
+//
+// Callers must hold a.mu.
+func (a *localActivator) evictStaleVersionBindingsLocked(freshPool *compute_v1alpha.SandboxPool) {
+	references := func(versionID string) bool {
+		for _, ref := range freshPool.ReferencedByVersions {
+			if ref.String() == versionID {
+				return true
+			}
+		}
+		return false
+	}
+
+	for key, versionRef := range a.versions {
+		if versionRef.poolID == freshPool.ID && !references(key.ver) {
+			delete(a.versions, key)
+			a.log.Info("evicted stale version->pool mapping after pool dereferenced version",
+				"version", key.ver,
+				"service", key.service,
+				"pool", freshPool.ID)
+		}
+	}
+
+	for key, state := range a.pools {
+		if state.pool != nil && state.pool.ID == freshPool.ID && !references(key.ver) {
+			delete(a.pools, key)
+			a.log.Info("evicted stale pool state after pool dereferenced version",
+				"version", key.ver,
+				"service", key.service,
+				"pool", freshPool.ID)
+		}
+	}
+}
+
 // watchPools watches for pool entity changes and keeps the in-memory cache in sync.
 // Handles deletions (cleanup stale entries) and updates (refresh DesiredInstances, etc.).
 func (a *localActivator) watchPools(ctx context.Context) {
@@ -2075,6 +2118,11 @@ func (a *localActivator) watchPools(ctx context.Context) {
 				if ps, ok := a.poolSandboxes[freshPool.ID]; ok {
 					ps.pool = &freshPool
 				}
+
+				// Drop any binding still pinned to this pool for a version it no
+				// longer references (e.g. the launcher just drained a superseded
+				// pool), so the next lease request re-resolves to the canonical pool.
+				a.evictStaleVersionBindingsLocked(&freshPool)
 
 				a.mu.Unlock()
 			}

--- a/components/activator/activator_test.go
+++ b/components/activator/activator_test.go
@@ -2444,6 +2444,180 @@ func TestRemovePoolFromTrackingCleansAllCaches(t *testing.T) {
 	assert.True(t, poolSandboxes2Exists, "pool-2 should still be in poolSandboxes")
 }
 
+// TestEvictStaleVersionBindingsOnDereference verifies that when a pool stops
+// referencing a version but still exists (the launcher drained a superseded
+// pool without deleting the entity), the binding for the dropped version is
+// evicted while bindings for versions the pool still references are retained
+// (MIR-1293).
+func TestEvictStaleVersionBindingsOnDereference(t *testing.T) {
+	log := testutils.TestLogger(t)
+
+	poolID := entity.Id("pool-1")
+	staleKey := verKey{"ver-stale", "web"}
+	keptKey := verKey{"ver-kept", "web"}
+
+	pool := &compute_v1alpha.SandboxPool{ID: poolID, Service: "web"}
+
+	activator := &localActivator{
+		log: log,
+		versions: map[verKey]*versionPoolRef{
+			staleKey: {poolID: poolID, service: "web"},
+			keptKey:  {poolID: poolID, service: "web"},
+		},
+		pools: map[verKey]*poolState{
+			staleKey: {pool: pool, revision: 1},
+			keptKey:  {pool: pool, revision: 1},
+		},
+		poolSandboxes: map[entity.Id]*poolSandboxes{
+			poolID: {pool: pool, sandboxes: []*sandbox{}, service: "web"},
+		},
+	}
+
+	// The launcher drained the pool for ver-stale, but it still serves ver-kept.
+	freshPool := &compute_v1alpha.SandboxPool{
+		ID:                   poolID,
+		Service:              "web",
+		ReferencedByVersions: []entity.Id{entity.Id("ver-kept")},
+	}
+
+	activator.mu.Lock()
+	activator.evictStaleVersionBindingsLocked(freshPool)
+	activator.mu.Unlock()
+
+	activator.mu.RLock()
+	_, staleVerExists := activator.versions[staleKey]
+	_, stalePoolExists := activator.pools[staleKey]
+	_, keptVerExists := activator.versions[keptKey]
+	_, keptPoolExists := activator.pools[keptKey]
+	activator.mu.RUnlock()
+
+	assert.False(t, staleVerExists, "dereferenced version binding should be evicted")
+	assert.False(t, stalePoolExists, "dereferenced version pool state should be evicted")
+	assert.True(t, keptVerExists, "still-referenced version binding should be retained")
+	assert.True(t, keptPoolExists, "still-referenced version pool state should be retained")
+}
+
+// TestWatchPoolsEvictsStaleBindingOnDereference verifies the eviction is wired
+// into the pool watch: when the launcher dereferences a still-existing pool (the
+// EAC.Replace path updatePool uses to drain a superseded pool), the watch drops
+// the now-stale version->pool binding so the next lease request re-resolves to
+// the canonical pool (MIR-1293).
+//
+// This uses the etcd-backed server rather than NewInMemEntityServer because the
+// in-mem index watch classifies every mutation as a Create op and never delivers
+// the Update op this exercises (the same reason TestConcurrentPoolIncrement uses
+// the etcd server for real OCC semantics).
+func TestWatchPoolsEvictsStaleBindingOnDereference(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, cleanup := testutils.NewEtcdEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	testVer := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name:               "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{Mode: "auto", RequestsPerInstance: 10},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", testVer)
+	require.NoError(t, err)
+	testVer.ID = verID
+
+	pool := &compute_v1alpha.SandboxPool{
+		Service:              "web",
+		DesiredInstances:     1,
+		ReferencedByVersions: []entity.Id{testVer.ID},
+		SandboxSpec:          compute_v1alpha.SandboxSpec{Version: testVer.ID},
+	}
+	poolID, err := server.Client.Create(ctx, "test-pool", pool)
+	require.NoError(t, err)
+	pool.ID = poolID
+
+	poolResp, err := server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+
+	log := testutils.TestLogger(t)
+	key := verKey{testVer.ID.String(), "web"}
+
+	activator := &localActivator{
+		log: log,
+		eac: server.EAC,
+		versions: map[verKey]*versionPoolRef{
+			key: {
+				ver:      testVer,
+				poolID:   poolID,
+				service:  "web",
+				strategy: concurrency.NewStrategy(&testVer.Config.Services[0].ServiceConcurrency),
+			},
+		},
+		poolSandboxes: map[entity.Id]*poolSandboxes{
+			poolID: {pool: pool, service: "web"},
+		},
+		pools: map[verKey]*poolState{
+			key: {pool: pool, revision: poolResp.Entity().Revision()},
+		},
+		newSandboxChans: make(map[verKey][]chan struct{}),
+	}
+
+	go activator.watchPools(ctx)
+
+	// Wait until the pool watch is live before issuing the single dereference
+	// below: a late subscription would deliver the pool as part of its initial
+	// snapshot (a Create) rather than as the live Update the eviction keys on. Bump
+	// a harmless field until the watch reflects it in the cache. Each iteration is
+	// a real change so it always produces an op, and the >-threshold check avoids
+	// chasing a moving target across polls.
+	origDesired := pool.DesiredInstances
+	nextDesired := origDesired
+	require.Eventually(t, func() bool {
+		nextDesired++
+		pool.DesiredInstances = nextDesired
+		if err := server.Client.Update(ctx, pool); err != nil {
+			return false
+		}
+		activator.mu.RLock()
+		defer activator.mu.RUnlock()
+		st, ok := activator.pools[key]
+		return ok && st.pool != nil && st.pool.DesiredInstances > origDesired
+	}, 5*time.Second, 50*time.Millisecond, "pool watch should become live")
+
+	// Dereference the pool the way updatePool does: rebuild its attributes
+	// without ReferencedByVersions and Replace, so the pool still exists but no
+	// longer references the version.
+	var finalAttrs []entity.Attr
+	for _, attr := range poolResp.Entity().Attrs() {
+		if attr.ID == compute_v1alpha.SandboxPoolReferencedByVersionsId {
+			continue
+		}
+		finalAttrs = append(finalAttrs, attr)
+	}
+	_, err = server.EAC.Replace(ctx, finalAttrs, 0)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		activator.mu.RLock()
+		defer activator.mu.RUnlock()
+		_, vOk := activator.versions[key]
+		_, pOk := activator.pools[key]
+		return !vOk && !pOk
+	}, 5*time.Second, 50*time.Millisecond,
+		"watch should evict the stale version->pool binding after the pool is dereferenced")
+}
+
 // TestActivatorRefreshesStaleMaxPoolSizeCache verifies that when the in-memory cache
 // shows DesiredInstances >= MaxPoolSize but the entity store has been reset to a lower
 // value, the activator re-reads from the store and continues rather than permanently

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -86,6 +86,7 @@ func (l *Launcher) CreatePoolForVersion(ctx context.Context, ver *core_v1alpha.A
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve config for version %s: %w", ver.Version, err)
 	}
+	l.injectAutoMountLocalDisks(spec, &app)
 
 	poolID, err := l.ensurePoolForService(ctx, &app, ver, spec, service)
 	if err != nil {
@@ -238,6 +239,7 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	if err != nil {
 		return fmt.Errorf("failed to resolve config: %w", err)
 	}
+	l.injectAutoMountLocalDisks(spec, app)
 
 	// For each service, ensure a pool exists. Collect IDs of newly created pools.
 	var newPoolIDs []entity.Id
@@ -781,38 +783,6 @@ func (l *Launcher) buildSandboxSpec(
 		}
 	}
 
-	// Transitional: auto-mount local storage if the host directory has existing
-	// data but no explicit disk config. This prevents data loss for apps that
-	// relied on the old implicit mount behavior. Will be removed in a future release.
-	if l.DataPath != "" {
-		hasLocalMount := false
-		for _, m := range appCont.Mount {
-			if m.Destination == "/miren/data/local" {
-				hasLocalMount = true
-				break
-			}
-		}
-		if !hasLocalMount && dirHasData(filepath.Join(l.DataPath, "data", "local", app.ID.String())) {
-			// Warn once per app; this condition holds on every reconcile tick
-			// until the app gets an explicit disk config, so logging each time
-			// just floods the journal.
-			if _, warned := l.warnedNoDisk.LoadOrStore(app.ID, struct{}{}); !warned {
-				l.Log.Warn("auto-mounting local storage for app with existing data but no disk config",
-					"service", serviceName,
-					"app", app.ID)
-			}
-			sbSpec.Volume = append(sbSpec.Volume, compute_v1alpha.SandboxSpecVolume{
-				Name:      "local-data",
-				Provider:  "local",
-				MountPath: "/miren/data/local",
-			})
-			appCont.Mount = append(appCont.Mount, compute_v1alpha.SandboxSpecContainerMount{
-				Source:      "local-data",
-				Destination: "/miren/data/local",
-			})
-		}
-	}
-
 	if shutdownTimeout != "" {
 		appCont.ShutdownTimeout = shutdownTimeout
 	}
@@ -826,6 +796,67 @@ func (l *Launcher) buildSandboxSpec(
 func dirHasData(path string) bool {
 	entries, err := os.ReadDir(path)
 	return err == nil && len(entries) > 0
+}
+
+// localDataMountPath is where the transitional local-storage auto-mount is
+// exposed inside the container, and localDataDiskName is the disk/volume name
+// it is registered under.
+const (
+	localDataMountPath = "/miren/data/local"
+	localDataDiskName  = "local-data"
+)
+
+// injectAutoMountLocalDisks registers the transitional local-storage auto-mount
+// as a real disk on the resolved config. For any service whose per-app host data
+// directory already holds data but which declares no disk at the auto-mount path,
+// it appends a "local" disk to the config. Doing this at config-resolution time
+// (rather than patching the sandbox spec at build time) puts the app on the
+// disk-aware deploy path: serviceHasDisks reports true, so drainStaleDiskPools
+// reaps superseded pools instead of leaving a duplicate orphaned pool behind that
+// keeps a live version reference and can strand ingress on a restart (MIR-1293).
+//
+// configureLocalVolume keys the on-disk location purely on the app ID, so naming
+// the disk here does not move any existing data.
+func (l *Launcher) injectAutoMountLocalDisks(spec *core_v1alpha.ConfigSpec, app *core_v1alpha.App) {
+	if l.DataPath == "" {
+		return
+	}
+	if !dirHasData(filepath.Join(l.DataPath, "data", "local", app.ID.String())) {
+		return
+	}
+
+	for i := range spec.Services {
+		svc := &spec.Services[i]
+
+		// Skip if the service already declares a disk at the auto-mount path or
+		// under the name we would inject; appending a second disk with the same
+		// name would produce a duplicate volume name in the sandbox spec.
+		conflicts := false
+		for _, d := range svc.Disks {
+			if d.MountPath == localDataMountPath || d.Name == localDataDiskName {
+				conflicts = true
+				break
+			}
+		}
+		if conflicts {
+			continue
+		}
+
+		// Warn once per app; this condition holds on every reconcile tick until
+		// the app gets an explicit disk config, so logging each time would just
+		// flood the journal.
+		if _, warned := l.warnedNoDisk.LoadOrStore(app.ID, struct{}{}); !warned {
+			l.Log.Warn("auto-mounting local storage for app with existing data but no disk config",
+				"service", svc.Name,
+				"app", app.ID)
+		}
+
+		svc.Disks = append(svc.Disks, core_v1alpha.ConfigSpecServicesDisks{
+			Name:      localDataDiskName,
+			Provider:  core_v1alpha.ConfigSpecServicesDisksLOCAL,
+			MountPath: localDataMountPath,
+		})
+	}
 }
 
 // findMatchingPool searches for an existing pool with matching spec.

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -2732,6 +2732,176 @@ func TestNoAutoMountWhenExplicitDiskConfig(t *testing.T) {
 	assert.Equal(t, "local", volumes[0].Provider)
 }
 
+// TestNoAutoMountWhenDiskNameTaken verifies the auto-mount is skipped when the
+// service already declares a disk under the "local-data" name, even at a
+// different mount path. Injecting a second disk with that name would produce a
+// duplicate volume name in the sandbox spec.
+func TestNoAutoMountWhenDiskNameTaken(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "local-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/somewhere/else",
+						},
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	// Existing data would otherwise trigger the auto-mount.
+	dataPath := t.TempDir()
+	localDir := filepath.Join(dataPath, "data", "local", app.ID.String())
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "data.db"), []byte("test"), 0644))
+
+	launcher := newTestLauncher(log, server.EAC)
+	launcher.DataPath = dataPath
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	// Only the explicitly-named disk should be present; no injected duplicate.
+	volumes := pools[0].SandboxSpec.Volume
+	require.Len(t, volumes, 1, "should not inject a duplicate local-data disk")
+	assert.Equal(t, "local-data", volumes[0].Name)
+	assert.Equal(t, "/somewhere/else", volumes[0].MountPath)
+}
+
+// TestAutoMountDrainsSupersededPool reproduces MIR-1293: an app using
+// auto-mounted local storage (existing data, no explicit disk config) must not
+// accumulate a second pool for the same version when the auto-mount first drifts
+// the pool spec. Before the fix the auto-mount was patched into the sandbox spec
+// at build time only, so serviceHasDisks stayed false, the stale-pool drain never
+// ran, and the superseded diskless pool lingered as a duplicate that still
+// referenced the current version. Registering the auto-mount as a real disk in
+// the resolved config puts the app on the disk-aware path, so the superseded pool
+// is drained and dereferenced.
+func TestAutoMountDrainsSupersededPool(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	dataPath := t.TempDir()
+	launcher := newTestLauncher(log, server.EAC)
+	launcher.DataPath = dataPath
+
+	// First reconcile: no local data yet, so a single diskless pool is created.
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+	require.Empty(t, pools[0].SandboxSpec.Volume, "first pool should be diskless")
+	disklessPoolID := pools[0].ID
+
+	// The app writes to its local storage between reconciles, so the auto-mount
+	// probe now finds existing data.
+	localDir := filepath.Join(dataPath, "data", "local", app.ID.String())
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "data.db"), []byte("test"), 0644))
+
+	// Second reconcile: the auto-mount now drifts the spec. The superseded
+	// diskless pool must be drained and dereferenced, not left as a duplicate
+	// orphan that still references the current version (MIR-1293).
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	getRes, err := server.EAC.Get(ctx, disklessPoolID.String())
+	require.NoError(t, err)
+	var oldPool compute_v1alpha.SandboxPool
+	oldPool.Decode(getRes.Entity().Entity())
+	assert.Equal(t, int64(0), oldPool.DesiredInstances,
+		"superseded diskless pool should be scaled to 0")
+	assert.Empty(t, oldPool.ReferencedByVersions,
+		"superseded diskless pool should be dereferenced")
+
+	// Exactly one pool should still reference the current version, and it should
+	// carry the auto-mounted local disk.
+	pools = listAllPools(t, ctx, server)
+	var referencing []compute_v1alpha.SandboxPool
+	for i := range pools {
+		if containsRef(pools[i].ReferencedByVersions, version.ID) {
+			referencing = append(referencing, pools[i])
+		}
+	}
+	require.Len(t, referencing, 1, "exactly one pool should reference the current version")
+	require.Len(t, referencing[0].SandboxSpec.Volume, 1)
+	assert.Equal(t, "local-data", referencing[0].SandboxSpec.Volume[0].Name)
+	assert.Equal(t, "local", referencing[0].SandboxSpec.Volume[0].Provider)
+	assert.Equal(t, "/miren/data/local", referencing[0].SandboxSpec.Volume[0].MountPath)
+
+	// The container mount is the user-visible half of the auto-mount, so verify
+	// it too, not just the volume declaration.
+	require.Len(t, referencing[0].SandboxSpec.Container, 1)
+	require.Len(t, referencing[0].SandboxSpec.Container[0].Mount, 1)
+	assert.Equal(t, "local-data", referencing[0].SandboxSpec.Container[0].Mount[0].Source)
+	assert.Equal(t, "/miren/data/local", referencing[0].SandboxSpec.Container[0].Mount[0].Destination)
+}
+
 // TestDiskPoolDrainedBeforeNewPoolCreated verifies that when deploying a new
 // version of an app with disks, the old pool is scaled to 0 before the new
 // pool is created. This prevents conflicts when both old and new sandboxes try


### PR DESCRIPTION
This came out of a real outage: an unattended reboot took an app with auto-mounted local storage fully offline for ~90 minutes while a healthy sandbox sat idle in a sibling pool. Two separate problems, one the cause and one the amplifier, so this is two revs.

The cause is that auto-mounted storage was patched into the sandbox spec at build time instead of the resolved config. That drifts the pool spec enough to spawn a replacement pool, but leaves `serviceHasDisks` false, which is the gate on the stale-pool drain. So the superseded pool never gets dereferenced and lingers as an immortal duplicate. The first rev registers the auto-mount as a real disk on the resolved config, so the existing drain reaps it like any other disk app.

The amplifier is that the activator binds each `(version,service)` to the first pool it sees at startup and never re-points that binding, so it can get stuck serving from a drained or crash-looping pool while a healthy one sits idle. The second rev makes `watchPools` drop a binding once its pool stops referencing the version, so the next request re-resolves to the pool that actually serves it. It keys off the launcher's own reference, so it guards against a stale binding from any cause, which also makes it safe to roll out alongside the first fix.

Closes MIR-1293