### PR TITLE
Remove post_import from the docs (it never actually runs)

### DIFF
--- a/docs/docs/app-toml.md
+++ b/docs/docs/app-toml.md
@@ -15,7 +15,6 @@ For a guide-style introduction, see [App Configuration](/app-configuration).
 
 ```toml
 name = "myapp"
-post_import = "make db-migrate"
 include = ["configs/"]
 
 # Global environment variables
@@ -71,7 +70,6 @@ tail = "logs app -f"
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
 | `name` | string | Application name | Inferred from directory name |
-| `post_import` | string | Command to run after importing a new version (e.g. database migrations) | — |
 | `include` | string[] | Extra files or directories to include in the build context | — |
 | `concurrency` | int | **Legacy.** Global concurrency target. Use `[services.<name>.concurrency]` instead. | — |
 

--- a/docs/docs/terminology.md
+++ b/docs/docs/terminology.md
@@ -96,10 +96,6 @@ A configuration that links an [app](#app) to an [identity provider](#identity-pr
 
 Commands defined in the `[build]` section of [app.toml](#apptoml) that run inside the build container after the main build steps. Used for tasks like asset compilation (`npm run build`) or pruning dev dependencies. Equivalent to Dockerfile `ONBUILD` instructions but configured declaratively.
 
-## Post-Import
-
-A command defined in [app.toml](#apptoml) (`post_import = "..."`) that runs after a new [version](#version) is imported but before it receives traffic. Commonly used for database migrations (e.g., `post_import = "make db-migrate"`).
-
 ## Procfile
 
 A simple file format for defining [services](#service) in your app. Each line maps a service name to a command (e.g., `web: node server.js`). For more advanced configuration (scaling, disks, images), use [app.toml](#apptoml) instead.


### PR DESCRIPTION
`post_import` looks like a real feature from the docs: it's a documented `app.toml` key with precise semantics ("runs after a new version is imported but before it receives traffic, commonly used for database migrations"), and it's parsed and validated on the way in. The catch is that nothing in the runtime ever reads it. The Go field is referenced exactly once in the whole repo, at its own declaration. So a deploy with `post_import = "…/rake db:migrate"` reports success while the migration never runs, and you find out later when a worker crash-loops on a missing table.

That's the worst kind of trap because the docs actively lead you into it. This pulls `post_import` out of the app.toml reference and the terminology glossary so it stops advertising a step that doesn't happen. Purely docs here, no behavior change.

The bigger "wire it or retire it" decision has landed on retire, but the code-level piece (warning on the key instead of silently accepting it) and folding the escape-hatch capability into MIR-853's one-shot service work comes in a follow-up. This is just the urgent de-trapping.

Part of MIR-1289.