### PR TITLE
buildkit: rebind daemon to the current process on miren restart

### DIFF
--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -58,13 +58,14 @@ type Component struct {
 	Namespace string
 	DataPath  string
 
-	mu         sync.Mutex
-	container  containerd.Container
-	running    bool
-	socketPath string
-	socketDir  string
-	hostsPath  string // path to custom /etc/hosts file for the container
-	external   bool   // true if connecting to external daemon (no container management)
+	mu            sync.Mutex
+	container     containerd.Container
+	running       bool
+	socketPath    string
+	socketDir     string
+	hostsPath     string             // path to custom /etc/hosts file for the container
+	external      bool               // true if connecting to external daemon (no container management)
+	monitorCancel context.CancelFunc // cancels the task exit-monitor goroutine on intentional stop
 }
 
 // NewComponent creates a new BuildKit component that manages an embedded daemon.
@@ -175,27 +176,20 @@ func (c *Component) Start(ctx context.Context, config Config) error {
 
 	c.container = container
 
-	// Start container with structured logging
+	// Create the task with structured logging.
 	task, err := container.NewTask(ctx, slogout.WithLogger(c.Log, "buildkit"))
 	if err != nil {
 		container.Delete(ctx, containerd.WithSnapshotCleanup)
+		c.container = nil
 		return fmt.Errorf("failed to create buildkit task: %w", err)
 	}
 
-	if err := task.Start(ctx); err != nil {
-		task.Delete(ctx)
+	if err := c.startTaskAndMonitor(ctx, task); err != nil {
 		container.Delete(ctx, containerd.WithSnapshotCleanup)
-		return fmt.Errorf("failed to start buildkit task: %w", err)
-	}
-
-	// Wait for BuildKit to be ready (socket exists and is connectable)
-	if err := c.waitForReady(ctx); err != nil {
-		task.Delete(ctx)
-		container.Delete(ctx, containerd.WithSnapshotCleanup)
+		c.container = nil
 		return err
 	}
 
-	c.running = true
 	c.Log.Info("buildkit daemon started", "container_id", container.ID(), "socket_path", c.socketPath)
 
 	return nil
@@ -207,18 +201,31 @@ func (c *Component) Stop(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if !c.running {
+	// External mode: no container to manage, just flip the flag idempotently.
+	if c.external {
+		if c.running {
+			c.running = false
+			c.Log.Info("disconnected from external buildkit daemon")
+		}
 		return nil
 	}
 
-	// External mode: nothing to stop
-	if c.external {
-		c.running = false
-		c.Log.Info("disconnected from external buildkit daemon")
+	// Nothing to tear down once the container has been released. Note we can't
+	// gate solely on c.running: after an unexpected daemon death the exit
+	// monitor clears c.running while c.container is still set, and we must still
+	// delete that container and its dead task here.
+	if !c.running && c.container == nil {
 		return nil
 	}
 
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
+
+	// Cancel the exit monitor before tearing down the task so its exit is
+	// treated as an intentional shutdown rather than an unexpected death.
+	if c.monitorCancel != nil {
+		c.monitorCancel()
+		c.monitorCancel = nil
+	}
 
 	if c.container != nil {
 		task, err := c.container.Task(ctx, nil)
@@ -427,48 +434,91 @@ func (c *Component) createContainer(ctx context.Context, image containerd.Image,
 func (c *Component) restartExistingContainer(ctx context.Context, container containerd.Container, dataPath string) error {
 	c.container = container
 
-	task, err := container.Task(ctx, nil)
-	if err == nil {
-		status, err := task.Status(ctx)
-		if err != nil {
-			c.Log.Warn("failed to get task status", "error", err)
-		} else if status.Status == containerd.Running {
-			c.Log.Info("buildkit container is already running")
-			c.running = true
-			return c.waitForReady(ctx)
-		}
-
-		c.Log.Info("starting existing buildkit task")
-		if err := task.Start(ctx); err == nil {
-			c.running = true
-			c.Log.Info("buildkit daemon restarted", "container_id", container.ID())
-			return c.waitForReady(ctx)
-		}
-
-		c.Log.Warn("failed to start existing task, deleting it", "error", err)
-		task.Delete(ctx)
+	// A pre-existing task belongs to a previous miren process. buildkitd's
+	// in-process HTTP/2 session server is bound to the miren process that
+	// launched it, so after a miren restart it can never reconnect — reusing
+	// the task silently expunges all jobs ("NotFound: no such job") and every
+	// build fails. Always evict any existing task and start a fresh one bound
+	// to this process.
+	if task, err := container.Task(ctx, nil); err == nil {
+		c.Log.Info("evicting stale buildkit task before restart")
+		c.stopTask(ctx, task)
 	}
 
-	c.Log.Info("creating new task for existing container")
-	task, err = container.NewTask(ctx, slogout.WithLogger(c.Log, "buildkit"))
+	c.Log.Info("creating new task for existing buildkit container")
+	task, err := container.NewTask(ctx, slogout.WithLogger(c.Log, "buildkit"))
 	if err != nil {
+		c.container = nil
 		return fmt.Errorf("failed to create new task for existing container: %w", err)
+	}
+
+	if err := c.startTaskAndMonitor(ctx, task); err != nil {
+		c.container = nil
+		return err
+	}
+
+	c.Log.Info("buildkit daemon restarted with new task", "container_id", container.ID())
+
+	return nil
+}
+
+// startTaskAndMonitor starts an already-created task, waits for buildkit to
+// become ready, records the running state, and spawns a goroutine that watches
+// for the task exiting unexpectedly. The exit channel is established via
+// task.Wait before task.Start so the exit event can never be missed. On any
+// failure the task is torn down before returning, so the caller only needs to
+// clean up container-level resources. Must be called with c.mu held.
+func (c *Component) startTaskAndMonitor(ctx context.Context, task containerd.Task) error {
+	exitCh, err := task.Wait(ctx)
+	if err != nil {
+		task.Delete(ctx)
+		return fmt.Errorf("failed to wait on buildkit task: %w", err)
 	}
 
 	if err := task.Start(ctx); err != nil {
 		task.Delete(ctx)
-		return fmt.Errorf("failed to start new task for existing container: %w", err)
+		return fmt.Errorf("failed to start buildkit task: %w", err)
 	}
 
 	if err := c.waitForReady(ctx); err != nil {
-		task.Delete(ctx)
+		c.stopTask(ctx, task)
 		return err
 	}
 
+	monitorCtx, cancel := context.WithCancel(context.Background())
+	c.monitorCancel = cancel
 	c.running = true
-	c.Log.Info("buildkit daemon restarted with new task", "container_id", container.ID())
+	go c.monitorTask(monitorCtx, exitCh)
 
 	return nil
+}
+
+// monitorTask watches a running buildkit task for an unexpected exit. An
+// intentional shutdown (Stop or a restart force-stop) cancels monitorCtx first,
+// so this returns quietly. If the task exits on its own, it clears c.running so
+// IsRunning/Client reflect reality and the next build fails fast rather than
+// hanging on a dead daemon.
+func (c *Component) monitorTask(monitorCtx context.Context, exitCh <-chan containerd.ExitStatus) {
+	select {
+	case <-monitorCtx.Done():
+		return
+	case es := <-exitCh:
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		// A stop may have raced in between the exit firing and acquiring the
+		// lock; in that case the stop path owns the state transition.
+		if monitorCtx.Err() != nil || !c.running {
+			return
+		}
+
+		c.running = false
+		if err := es.Error(); err != nil {
+			c.Log.Error("buildkit task exit wait failed, marking daemon not running", "error", err)
+		} else {
+			c.Log.Error("buildkit daemon exited unexpectedly, marking not running", "exit_code", es.ExitCode())
+		}
+	}
 }
 
 func (c *Component) waitForReady(ctx context.Context) error {
@@ -501,13 +551,12 @@ func (c *Component) stopTask(ctx context.Context, task containerd.Task) {
 	shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	// If SIGTERM can't be delivered we still fall through to Delete: a task we
+	// fail to reap here otherwise leaks and blocks the next NewTask on this
+	// container.
 	if err := task.Kill(shutdownCtx, unix.SIGTERM); err != nil {
 		c.Log.Error("failed to send SIGTERM to buildkit task", "error", err)
-		return
-	}
-
-	status, err := task.Wait(shutdownCtx)
-	if err == nil {
+	} else if status, err := task.Wait(shutdownCtx); err == nil {
 		select {
 		case es := <-status:
 			c.Log.Info("buildkit task exited", "code", es.ExitCode())
@@ -527,7 +576,15 @@ func (c *Component) stopTask(ctx context.Context, task containerd.Task) {
 		}
 	}
 
-	deleteCtx, deleteCancel := context.WithTimeout(ctx, 10*time.Second)
+	// Always delete the task, even if the kill path above failed, so the
+	// container is left in a state where a fresh task can be created. Detach
+	// from the parent's cancellation so a cancelled/expired ctx can't skip
+	// cleanup, but carry over the containerd namespace (Delete requires it).
+	deleteBase := context.Background()
+	if ns, ok := namespaces.Namespace(ctx); ok {
+		deleteBase = namespaces.WithNamespace(deleteBase, ns)
+	}
+	deleteCtx, deleteCancel := context.WithTimeout(deleteBase, 10*time.Second)
 	defer deleteCancel()
 
 	if _, err := task.Delete(deleteCtx); err != nil {

--- a/components/buildkit/buildkit_test.go
+++ b/components/buildkit/buildkit_test.go
@@ -10,10 +10,14 @@ import (
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 	"miren.dev/runtime/components/buildkit"
 	"miren.dev/runtime/pkg/containerdx"
 )
+
+const testNamespace = "miren-test"
 
 func TestBuildkitComponent(t *testing.T) {
 	if os.Getenv("SKIP_COMPONENT_TEST") != "" {
@@ -169,5 +173,142 @@ func TestBuildkitComponent(t *testing.T) {
 		defer component.Stop(context.Background())
 
 		r.True(component.IsRunning())
+	})
+}
+
+// buildkitTaskPID loads the miren-buildkit container's task PID directly via
+// containerd, so tests can prove a restart replaced the underlying process.
+func buildkitTaskPID(ctx context.Context, cc *containerd.Client) (uint32, error) {
+	ctx = namespaces.WithNamespace(ctx, testNamespace)
+	container, err := cc.LoadContainer(ctx, "miren-buildkit")
+	if err != nil {
+		return 0, err
+	}
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	return task.Pid(), nil
+}
+
+// TestBuildkitRestart covers the miren-restart scenario (MIR-1303): a fresh
+// Component that finds an already-running buildkit container must evict the
+// stale task and bind a new one, and the exit monitor must reflect an
+// out-of-band daemon death.
+func TestBuildkitRestart(t *testing.T) {
+	if os.Getenv("SKIP_COMPONENT_TEST") != "" {
+		t.Skip("Skipping component test")
+	}
+
+	newClient := func(t *testing.T) *containerd.Client {
+		cc, err := containerd.New(containerdx.DefaultSocket)
+		require.NoError(t, err)
+		t.Cleanup(func() { cc.Close() })
+		return cc
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	t.Run("restart evicts the stale task and recreates a working daemon", func(t *testing.T) {
+		r := require.New(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cc := newClient(t)
+		dataDir := t.TempDir()
+		config := buildkit.Config{SocketDir: t.TempDir(), RegistryHost: "cluster.local:5000"}
+
+		// First "process" launches the daemon.
+		first := buildkit.NewComponent(logger, cc, testNamespace, dataDir)
+		r.NoError(first.Start(ctx, config))
+		r.True(first.IsRunning())
+
+		pidBefore, err := buildkitTaskPID(ctx, cc)
+		r.NoError(err)
+
+		// Second "process" (a miren restart) reuses the existing container but
+		// must force-stop the stale task and start a fresh one bound to itself.
+		second := buildkit.NewComponent(logger, cc, testNamespace, dataDir)
+		r.NoError(second.Start(ctx, config))
+		r.True(second.IsRunning())
+
+		pidAfter, err := buildkitTaskPID(ctx, cc)
+		r.NoError(err)
+		r.NotEqual(pidBefore, pidAfter, "restart must replace the buildkitd process, not reuse it")
+
+		// The freshly bound daemon must actually serve requests.
+		client, err := second.Client(ctx)
+		r.NoError(err)
+		info, err := client.Info(ctx)
+		r.NoError(err)
+		r.NotEmpty(info.BuildkitVersion.Version)
+		client.Close()
+
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer stopCancel()
+		r.NoError(second.Stop(stopCtx))
+		r.False(second.IsRunning())
+	})
+
+	t.Run("exit monitor clears running when the daemon dies", func(t *testing.T) {
+		r := require.New(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cc := newClient(t)
+		config := buildkit.Config{SocketDir: t.TempDir(), RegistryHost: "cluster.local:5000"}
+
+		component := buildkit.NewComponent(logger, cc, testNamespace, t.TempDir())
+		r.NoError(component.Start(ctx, config))
+		r.True(component.IsRunning())
+
+		// Kill buildkitd out from under the component.
+		nsctx := namespaces.WithNamespace(ctx, testNamespace)
+		container, err := cc.LoadContainer(nsctx, "miren-buildkit")
+		r.NoError(err)
+		task, err := container.Task(nsctx, nil)
+		r.NoError(err)
+		r.NoError(task.Kill(nsctx, unix.SIGKILL))
+
+		// The monitor goroutine should observe the exit and flip IsRunning.
+		require.Eventually(t, func() bool { return !component.IsRunning() },
+			30*time.Second, 200*time.Millisecond,
+			"exit monitor should mark the daemon not running after it dies")
+
+		// Even though the daemon already died (IsRunning is false), Stop must
+		// still tear down the leftover container and its dead task rather than
+		// no-op away and leak them.
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer stopCancel()
+		r.NoError(component.Stop(stopCtx))
+
+		_, err = cc.LoadContainer(nsctx, "miren-buildkit")
+		r.Error(err, "Stop should delete the container even after an unexpected death")
+	})
+
+	t.Run("Stop removes the task and container", func(t *testing.T) {
+		r := require.New(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+		defer cancel()
+
+		cc := newClient(t)
+		config := buildkit.Config{SocketDir: t.TempDir(), RegistryHost: "cluster.local:5000"}
+
+		component := buildkit.NewComponent(logger, cc, testNamespace, t.TempDir())
+		r.NoError(component.Start(ctx, config))
+		r.True(component.IsRunning())
+
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer stopCancel()
+		r.NoError(component.Stop(stopCtx))
+		r.False(component.IsRunning())
+
+		// Stop deletes the container outright, so it should no longer load.
+		nsctx := namespaces.WithNamespace(ctx, testNamespace)
+		_, err := cc.LoadContainer(nsctx, "miren-buildkit")
+		r.Error(err)
 	})
 }

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	buildkitclient "github.com/moby/buildkit/client"
 	"github.com/tonistiigi/fsutil"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -78,6 +79,15 @@ type buildSession struct {
 	cancelFunc context.CancelFunc
 }
 
+// BuildKitProvider is the subset of *buildkit.Component the builder depends on.
+// Abstracting it as an interface lets unit tests inject a fake daemon (e.g. one
+// whose Client fails) instead of standing up a real containerd-managed buildkitd.
+type BuildKitProvider interface {
+	Client(ctx context.Context) (*buildkitclient.Client, error)
+	SocketPath() string
+	IsRunning() bool
+}
+
 type Builder struct {
 	Log           *slog.Logger
 	EAS           *entityserver_v1alpha.EntityAccessClient
@@ -95,14 +105,14 @@ type Builder struct {
 
 	// BuildKit is the persistent BuildKit component for container image builds.
 	// When set, uses the shared daemon instead of launching ephemeral sandboxes.
-	BuildKit *buildkit.Component
+	BuildKit BuildKitProvider
 
 	sessions   sync.Map // sessionID → *buildSession
 	cacheLocks *appLocks
 }
 
 func NewBuilder(log *slog.Logger, eas *entityserver_v1alpha.EntityAccessClient, appClient *app.Client, addonsClient *app_v1alpha.AddonsClient, res netresolve.Resolver, tmpdir string, logWriter observability.LogWriter, dnsHostname string, bk *buildkit.Component, dataPath string) *Builder {
-	return &Builder{
+	b := &Builder{
 		Log:           log.With("module", "builder"),
 		EAS:           eas,
 		appClient:     appClient,
@@ -113,10 +123,16 @@ func NewBuilder(log *slog.Logger, eas *entityserver_v1alpha.EntityAccessClient, 
 		ec:            entityserver.NewClient(log, eas),
 		LogWriter:     logWriter,
 		DNSHostname:   dnsHostname,
-		BuildKit:      bk,
 		DataPath:      dataPath,
 		cacheLocks:    newAppLocks(),
 	}
+	// Only assign when non-nil: storing a typed-nil *buildkit.Component into the
+	// BuildKitProvider interface would make the field non-nil and defeat the
+	// `b.BuildKit == nil` guard used to detect an unconfigured daemon.
+	if bk != nil {
+		b.BuildKit = bk
+	}
+	return b
 }
 
 // mergeServiceEnvVars merges per-service environment variables from app.toml into existing service env vars.

--- a/servers/build/build_saga_buildkit.go
+++ b/servers/build/build_saga_buildkit.go
@@ -147,11 +147,18 @@ func (b *Builder) runBuildkitBuild(
 	}
 	defer bkc.Close()
 
-	if ci, err := bkc.Info(ctx); err != nil {
-		b.Log.Error("error getting buildkitd info", "error", err)
-	} else {
-		b.Log.Debug("buildkitd info", "version", ci.BuildkitVersion.Version, "rev", ci.BuildkitVersion.Revision)
+	// Pre-flight health check. A daemon whose socket answers the dial but can't
+	// service requests (e.g. a stale buildkitd left bound to a previous miren
+	// process after a restart) fails here, so the build errors out immediately
+	// instead of proceeding into a confusing "NotFound: no such job" partway
+	// through the solve.
+	ci, err := bkc.Info(ctx)
+	if err != nil {
+		b.Log.Error("buildkit daemon health check failed", "error", err)
+		status.SendError("BuildKit daemon health check failed: %v", err)
+		return nil, "", "", fmt.Errorf("buildkit daemon health check failed: %w", err)
 	}
+	b.Log.Debug("buildkitd info", "version", ci.BuildkitVersion.Version, "rev", ci.BuildkitVersion.Revision)
 
 	bk := &Buildkit{Client: bkc, Log: b.Log}
 

--- a/servers/build/build_saga_buildkit_test.go
+++ b/servers/build/build_saga_buildkit_test.go
@@ -1,0 +1,55 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	buildkitclient "github.com/moby/buildkit/client"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/components/buildkit"
+)
+
+// The real component must satisfy the provider interface the builder depends on.
+var _ BuildKitProvider = (*buildkit.Component)(nil)
+
+// fakeBuildKitProvider is a BuildKitProvider whose Client always fails. It lets
+// the build path be exercised without standing up a real containerd-managed
+// buildkitd daemon.
+type fakeBuildKitProvider struct {
+	clientErr error
+}
+
+func (f fakeBuildKitProvider) Client(context.Context) (*buildkitclient.Client, error) {
+	return nil, f.clientErr
+}
+
+func (f fakeBuildKitProvider) SocketPath() string { return "/nonexistent/buildkitd.sock" }
+
+func (f fakeBuildKitProvider) IsRunning() bool { return true }
+
+// When the daemon can't be reached, runBuildkitBuild must surface the error
+// rather than proceed into the solve. This is the fast-fail behavior that keeps
+// a stale/dead buildkitd from silently breaking builds.
+func TestRunBuildkitBuildClientError(t *testing.T) {
+	r := require.New(t)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	b := &Builder{
+		Log:      log,
+		BuildKit: fakeBuildKitProvider{clientErr: errors.New("dial unix: connection refused")},
+	}
+
+	_, _, _, err := b.runBuildkitBuild(context.Background(), runBuildkitBuildInputs{
+		SourceDir:   t.TempDir(),
+		AppName:     "testapp",
+		VersionName: "v1",
+		ImageURL:    "cluster.local:5000/testapp:v1",
+	}, noopStatusSender{}, &buildLogWriter{log: log})
+
+	r.Error(err)
+	r.Contains(err.Error(), "connection refused")
+}


### PR DESCRIPTION
## Problem (MIR-1303)

buildkitd runs as a containerd-managed container. On a **clean** miren shutdown, the first SIGTERM cancels the server context (`cli/commands/global.go`), which unwinds `Server()` and runs the deferred `buildkitComponent.Stop()` (`cli/commands/server.go`). `Stop()` SIGTERMs buildkitd and deletes the container, so the next boot's `LoadContainer` returns *NotFound* and creates a fresh daemon. That is the normal, working restart path — the one exercised by `systemctl restart`, deploy-driven bounces, and `make dev-server-restart`.

`KillMode=process` in the systemd unit changes this on an **ungraceful** exit. If miren dies without its `Stop()` defer completing — a crash / panic / OOM-kill, a second SIGTERM (which hits `os.Exit(130)` and bypasses defers), or a graceful stop that exceeds `TimeoutStopSec=90s` and gets SIGKILLed — `KillMode=process` kills only miren's own process and leaves buildkitd (in containerd's cgroup) orphaned and still running.

On the next boot, `restartExistingContainer()` finds that still-running task, sets `c.running = true`, and **reuses it** — only dialing the socket to confirm readiness. It never restarts the buildkitd process. But the reused daemon can't serve the new miren process: buildkit builds use a client-side session (the daemon streams local build context back from the client over a hijacked gRPC stream), and that session state was bound to the miren process that exited. The new process's solves fail with `NotFound: no such job <ref>`. This is **silent** — no error, no log — and **every build fails** until buildkitd is manually killed and miren restarted.

It hit the luanchat cluster on 2026-06-30: all builds failed for ~2.5 hours, and buildkitd had been up ~3 days — i.e. it had survived across the restart via the ungraceful path above.

So the failure is **rare but fatal**: it needs an ungraceful exit to orphan a live daemon, which is why it went unnoticed for so long even though miren has been restarted many times — the vast majority of those restarts took the fresh-daemon path. But once it happens, every build fails until manual intervention.

## Fix

Handle the orphaned daemon at the layer that owns buildkit's lifecycle — the containerd component, on start. When `Start()` finds an existing container, reach the same known-good state a fresh boot produces: a buildkitd task freshly bound to the current process.

- **`restartExistingContainer()`** now always force-stops any existing task and starts a fresh one bound to the current process (the primary fix). It no longer reuses a running task. This evicts an orphaned daemon on the next start regardless of how miren exited.
- **`stopTask()`** no longer returns early when SIGTERM fails, so `task.Delete()` always runs and can't leak a task that would block the next `NewTask`. The delete context keeps the containerd namespace while detaching from the parent's cancellation.
- **Exit-monitor goroutine** (via `task.Wait()`, established before `Start()`) clears `c.running` when buildkitd dies unexpectedly, so `IsRunning()`/`Client()` reflect reality. `Stop()` cancels it and now tears down the container even after such a death.
- **`bkc.Info()` pre-flight** is now fatal — a dead/stale daemon fails the build immediately instead of proceeding into a confusing downstream error.
- **`BuildKitProvider` interface** in `servers/build` lets builds be faked in unit tests (with a typed-nil guard preserving the `BuildKit == nil` check).

## Testing

- `hack/it components/buildkit` — 10 tests pass, including new `TestBuildkitRestart` subtests that prove the buildkitd **PID actually changes** across a simulated restart (old task evicted, new one created and serving), that `IsRunning()` flips false on an out-of-band daemon death, and that `Stop()` cleans up the container even after a death.
- `go test ./servers/build/` — new fake-provider unit test for the connect-error fast-fail; full package green.
- `golangci-lint` / `gofmt` / `go vet` clean.