### PR TITLE
Self-heal the distributed runner's etcd session after a coordinator restart

### DIFF
--- a/api/entityserver/client.go
+++ b/api/entityserver/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -411,9 +412,68 @@ type Session struct {
 	mu sync.Mutex
 
 	cancel context.CancelFunc
+
+	// dead is closed once the keepalive loop concludes the lease is
+	// unrecoverable (e.g. the coordinator/etcd that granted it restarted).
+	// The owner selects on Dead() to re-establish a fresh session.
+	dead     chan struct{}
+	deadOnce sync.Once
 }
 
 const defaultTTL = 60
+
+// Dead returns a channel that is closed when the session's lease has been lost
+// and cannot be pinged back to life. Callers should re-establish a new session
+// (via NewSession) rather than continuing to use this one.
+func (l *Session) Dead() <-chan struct{} {
+	return l.dead
+}
+
+func (l *Session) markDead() {
+	l.deadOnce.Do(func() { close(l.dead) })
+}
+
+// isLeaseGone reports whether err indicates the etcd lease backing the session
+// no longer exists, meaning the session is unrecoverable and must be rebuilt.
+// The error crosses an RPC boundary and arrives as a flattened string, so we
+// match on the underlying etcd message ("requested lease not found") rather
+// than a typed sentinel.
+func isLeaseGone(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "lease not found")
+}
+
+type pingAction int
+
+const (
+	pingOK    pingAction = iota // lease renewed; session healthy
+	pingRetry                   // transient failure; keep trying
+	pingDead                    // lease unrecoverable; rebuild the session
+)
+
+// evalPing classifies the result of one keepalive ping. firstFailure is the
+// time of the first failure in the current run of consecutive failures (zero
+// if the previous ping succeeded); it returns the updated firstFailure to carry
+// forward. A definitive "lease not found" is fatal immediately; other errors
+// are treated as transient until they persist longer than the lease TTL, past
+// which the lease has certainly expired regardless of what the error says.
+func evalPing(err error, firstFailure, now time.Time, ttl time.Duration) (pingAction, time.Time) {
+	if err == nil {
+		return pingOK, time.Time{}
+	}
+	if isLeaseGone(err) {
+		return pingDead, firstFailure
+	}
+	if firstFailure.IsZero() {
+		firstFailure = now
+	}
+	if now.Sub(firstFailure) > ttl {
+		return pingDead, firstFailure
+	}
+	return pingRetry, firstFailure
+}
 
 // Grant creates a new lease with the given TTL
 func (c *Client) NewSession(ctx context.Context, usage string) (*Session, *Client, error) {
@@ -435,6 +495,8 @@ func (c *Client) NewSession(ctx context.Context, usage string) (*Session, *Clien
 		id: ret.Id(),
 
 		cancel: cancel,
+
+		dead: make(chan struct{}),
 	}
 
 	go func() {
@@ -446,14 +508,39 @@ func (c *Client) NewSession(ctx context.Context, usage string) (*Session, *Clien
 			session.Revoke(ctx)
 		}()
 
-		ticker := time.NewTicker((time.Duration(ttl) * time.Second) / 2)
+		leaseTTL := time.Duration(ttl) * time.Second
+		ticker := time.NewTicker(leaseTTL / 2)
 		defer ticker.Stop()
+
+		// firstFailure is the time of the first ping failure in the current
+		// run of consecutive failures; zero when the last ping succeeded.
+		var firstFailure time.Time
 
 		for {
 			select {
 			case <-ticker.C:
-				if err := session.Ping(ctx); err != nil {
+				// Bound each ping so a hung request can't stall the ticker and
+				// freeze dead-detection; a stuck ping simply times out and is
+				// treated as a failure by evalPing.
+				pingCtx, pingCancel := context.WithTimeout(ctx, leaseTTL/2)
+				err := session.Ping(pingCtx)
+				pingCancel()
+
+				var action pingAction
+				action, firstFailure = evalPing(err, firstFailure, time.Now(), leaseTTL)
+
+				switch action {
+				case pingDead:
+					c.log.Warn("session lease lost, signaling for re-establish",
+						"id", session.id, "error", err)
+					session.markDead()
+					// Release the session's context; this goroutine owns it and
+					// is exiting, and nothing re-pings a dead session.
+					cancel()
+					return
+				case pingRetry:
 					c.log.Error("failed to ping session", "error", err)
+				case pingOK:
 				}
 			case <-ctx.Done():
 				return

--- a/api/entityserver/session_test.go
+++ b/api/entityserver/session_test.go
@@ -1,0 +1,84 @@
+package entityserver
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestIsLeaseGone(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("connection refused"), false},
+		// The message as it arrives after crossing the RPC boundary from the
+		// coordinator's PingSession -> etcd KeepAliveOnce.
+		{"wrapped etcd", errors.New("remote error: generic unknown: failed to assert lease: etcdserver: requested lease not found"), true},
+		{"bare etcd", errors.New("etcdserver: requested lease not found"), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isLeaseGone(tc.err); got != tc.want {
+				t.Fatalf("isLeaseGone(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvalPing(t *testing.T) {
+	const ttl = 60 * time.Second
+	base := time.Unix(1_700_000_000, 0)
+	leaseGone := errors.New("etcdserver: requested lease not found")
+	transient := errors.New("connection refused")
+
+	t.Run("success resets failure clock", func(t *testing.T) {
+		action, first := evalPing(nil, base.Add(-90*time.Second), base, ttl)
+		if action != pingOK {
+			t.Fatalf("action = %v, want pingOK", action)
+		}
+		if !first.IsZero() {
+			t.Fatalf("firstFailure = %v, want zero", first)
+		}
+	})
+
+	t.Run("lease gone is immediately fatal", func(t *testing.T) {
+		// Fatal even on the very first failure, before any TTL window elapses.
+		action, _ := evalPing(leaseGone, time.Time{}, base, ttl)
+		if action != pingDead {
+			t.Fatalf("action = %v, want pingDead", action)
+		}
+	})
+
+	t.Run("first transient failure retries and stamps the clock", func(t *testing.T) {
+		action, first := evalPing(transient, time.Time{}, base, ttl)
+		if action != pingRetry {
+			t.Fatalf("action = %v, want pingRetry", action)
+		}
+		if !first.Equal(base) {
+			t.Fatalf("firstFailure = %v, want %v", first, base)
+		}
+	})
+
+	t.Run("transient within TTL keeps retrying", func(t *testing.T) {
+		firstFailure := base
+		action, first := evalPing(transient, firstFailure, base.Add(ttl), ttl)
+		if action != pingRetry {
+			t.Fatalf("action = %v, want pingRetry", action)
+		}
+		if !first.Equal(firstFailure) {
+			t.Fatalf("firstFailure = %v, want carried-forward %v", first, firstFailure)
+		}
+	})
+
+	t.Run("transient past TTL is treated as lost lease", func(t *testing.T) {
+		firstFailure := base
+		action, _ := evalPing(transient, firstFailure, base.Add(ttl+time.Second), ttl)
+		if action != pingDead {
+			t.Fatalf("action = %v, want pingDead", action)
+		}
+	})
+}

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -166,8 +168,11 @@ type Runner struct {
 
 	cc *containerd.Client
 
-	ec *entityserver.Client
-	se *entityserver.Session
+	// sessMu guards ec/se, which are swapped when the health session is
+	// re-established after a lost lease (see superviseSession).
+	sessMu sync.Mutex
+	ec     *entityserver.Client
+	se     *entityserver.Session
 
 	closers []io.Closer
 
@@ -205,9 +210,18 @@ func (r *Runner) SetRestartMode(v bool) {
 	}
 }
 
+// entityClient returns the current session-scoped entity client, which may be
+// swapped out when the health session is re-established (see superviseSession).
+func (r *Runner) entityClient() *entityserver.Client {
+	r.sessMu.Lock()
+	defer r.sessMu.Unlock()
+	return r.ec
+}
+
 // Drain sets the runner's node status to disabled and stops all running sandboxes
 func (r *Runner) Drain(ctx context.Context) error {
-	if r.ec == nil || r.Id == "" {
+	ec := r.entityClient()
+	if ec == nil || r.Id == "" {
 		return fmt.Errorf("runner not initialized with entity client")
 	}
 
@@ -215,7 +229,7 @@ func (r *Runner) Drain(ctx context.Context) error {
 
 	// Set node status to disabled
 	r.Log.Info("setting node status to disabled", "id", r.Id)
-	err := r.ec.UpdateAttrs(ctx, entity.Id(r.Id), (&compute_v1alpha.Node{
+	err := ec.UpdateAttrs(ctx, entity.Id(r.Id), (&compute_v1alpha.Node{
 		Status: compute_v1alpha.DISABLED,
 	}).Encode)
 	if err != nil {
@@ -226,7 +240,7 @@ func (r *Runner) Drain(ctx context.Context) error {
 
 	// List all sandboxes scheduled to this node
 	idx := compute_v1alpha.Index(compute_v1alpha.KindSandbox, entity.Id("node/"+r.Id))
-	results, err := r.ec.List(ctx, idx)
+	results, err := ec.List(ctx, idx)
 	if err != nil {
 		return fmt.Errorf("failed to query sandboxes on node: %w", err)
 	}
@@ -606,20 +620,51 @@ func (r *Runner) initializeNetwork(ctx context.Context, eg ...*errgroup.Group) e
 	return nil
 }
 
-func (r *Runner) setupEntity(ctx context.Context, ec *entityserver.Client) error {
+// setupEntity establishes the runner's coordinator health session and node
+// registration, then supervises the session so a lost lease (e.g. from a
+// coordinator restart) is transparently re-established. base is the plain,
+// non-session entity client; each session is minted from it.
+func (r *Runner) setupEntity(ctx context.Context, base *entityserver.Client) error {
 	if r.Id == "" {
 		return nil
 	}
 
+	if err := r.establishSession(ctx, base); err != nil {
+		return err
+	}
+
+	go r.superviseSession(ctx, base)
+
+	return nil
+}
+
+// establishSession mints a fresh health session from base, registers the node
+// entity, and marks it READY. The node's READY status is session-scoped: it
+// lives under the etcd lease and vanishes when the lease dies, so this must be
+// re-run to bring the runner back after a lost session. base is the plain
+// (non-session) client; the session-scoped client it returns is stored on r.ec.
+func (r *Runner) establishSession(ctx context.Context, base *entityserver.Client) error {
 	r.Log.Info("Creating health session")
 
-	sess, ec, err := ec.NewSession(ctx, "runner health")
+	sess, ec, err := base.NewSession(ctx, "runner health")
 	if err != nil {
 		return err
 	}
 
-	r.ec = ec
-	r.se = sess
+	// If registration below fails we abandon this session, so revoke its
+	// lease rather than leaking a keepalive goroutine and orphaned lease.
+	// The retry path can otherwise pile these up on a flaky coordinator.
+	published := false
+	defer func() {
+		if published {
+			return
+		}
+		revokeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if rerr := sess.Revoke(revokeCtx); rerr != nil {
+			r.Log.Warn("failed to revoke unregistered health session", "error", rerr)
+		}
+	}()
 
 	role := "runner"
 	if r.deps.IsCoordinator {
@@ -648,9 +693,70 @@ func (r *Runner) setupEntity(ctx context.Context, ec *entityserver.Client) error
 		return err
 	}
 
+	r.sessMu.Lock()
+	r.ec = ec
+	r.se = sess
+	published = true
+	r.sessMu.Unlock()
+
 	r.Log.Info("Runner registered and ready", "id", res, "status", "ready")
 
 	return nil
+}
+
+// superviseSession watches the current health session and re-establishes it
+// when its lease is lost. Without this, a coordinator restart orphans the
+// runner's lease, the session-scoped READY status is dropped, and the runner
+// stays not-ready until manually restarted (MIR-1305). Re-establishing well
+// within nodehealth's grace period keeps the runner's sandboxes from being
+// evacuated.
+func (r *Runner) superviseSession(ctx context.Context, base *entityserver.Client) {
+	for {
+		r.sessMu.Lock()
+		se := r.se
+		r.sessMu.Unlock()
+		if se == nil {
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-se.Dead():
+		}
+
+		// No explicit Close on the old session: by the time Dead() fires its
+		// keepalive goroutine has already stopped and revoked what it could,
+		// so establishSession can simply overwrite r.se with a fresh one.
+		r.Log.Warn("runner health session lease lost, re-establishing", "id", r.Id)
+
+		backoff := time.Second
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+
+			if err := r.establishSession(ctx, base); err == nil {
+				r.Log.Info("runner health session re-established", "id", r.Id)
+				break
+			} else {
+				r.Log.Error("failed to re-establish runner health session, retrying",
+					"error", err, "backoff", backoff)
+			}
+
+			// Jitter the wait so a fleet of runners knocked offline by the
+			// same coordinator restart doesn't reconnect in lockstep. Sleep a
+			// random 50-100% of the current backoff.
+			wait := backoff/2 + time.Duration(rand.Int64N(int64(backoff/2)+1))
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(wait):
+			}
+
+			backoff = min(backoff*2, 30*time.Second)
+		}
+	}
 }
 
 func (r *Runner) SetupControllers(

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -2464,3 +2464,29 @@ func TestEtcdStore_PatchPreservesReadInSessionAttributes(t *testing.T) {
 	))
 	r.Error(err, "patching a session attribute without a session must still fail")
 }
+
+// TestEtcdStore_PingSessionAfterLeaseGone locks in the error contract that the
+// runner's session keepalive relies on to detect a lost lease and re-establish
+// (MIR-1305): once the lease backing a session is gone, PingSession must return
+// an error whose message contains "lease not found". The client-side classifier
+// (entityserver.isLeaseGone) matches on exactly that substring, so if etcd ever
+// changes this wording, this test fails before the runner silently regresses to
+// pinging a dead lease forever.
+func TestEtcdStore_PingSessionAfterLeaseGone(t *testing.T) {
+	r := require.New(t)
+	store, _ := setupTestEtcdStore(t)
+
+	sid, err := store.CreateSession(t.Context(), 30)
+	r.NoError(err)
+
+	// A healthy session pings clean.
+	r.NoError(store.PingSession(t.Context(), sid))
+
+	// Revoking the lease simulates the coordinator/etcd restart that orphans it.
+	r.NoError(store.RevokeSession(t.Context(), sid))
+
+	err = store.PingSession(t.Context(), sid)
+	r.Error(err, "pinging a session whose lease is gone must error")
+	r.Contains(err.Error(), "lease not found",
+		"error wording is load-bearing: entityserver.isLeaseGone matches this substring")
+}


### PR DESCRIPTION
A distributed runner talks to the coordinator's etcd through a session backed by a lease, and it registers its node as READY under that lease. That's a deliberate design: the READY status is session-scoped, so if the runner process dies, the lease lapses and the coordinator notices the node is gone. The problem is that the *coordinator* restarting bounces that same etcd, and if it's down longer than the lease TTL (a real autoupdate swapping the binary easily is), the lease gets orphaned. The runner's keepalive loop would notice its pings failing, log `failed to ping session`, and then do nothing about it: it kept asserting the same dead lease every 30 seconds forever. Meanwhile the coordinator saw the node drop out of READY, stopped scheduling to it, and evacuated its sandboxes onto other nodes. On garden, where the coordinator autoupdates every hour, this quietly knocked every runner not-ready after each update until someone SSH'd in and restarted `miren-runner` by hand.

The fix teaches the session how to die. It now exposes a `Dead()` channel that closes when a ping definitively fails, either because the coordinator answers `requested lease not found`, or, as a backstop against etcd rewording that error, because pings have been failing continuously for longer than the lease TTL (past which the lease is certainly gone regardless of what came back). The runner supervises that signal and, when it fires, rebuilds the session from the ground up with capped backoff: fresh lease, re-registered node, READY written again. Since the whole dance finishes comfortably inside nodehealth's five-minute grace window, a normal coordinator restart no longer costs the runner its sandboxes, it just blips out of ready and back.

Worth noting from the live testing: the coordinator's embedded etcd actually persists its lease across a *fast* restart, so a quick bounce is already self-healing and never trips any of this. The failure only shows up when downtime exceeds the TTL, which is exactly the backstop's job, and that's the path I exercised end to end in the distributed dev environment (coordinator held down past the TTL, runner detected the wedge, backed off while it was gone, then re-established and re-registered on its own the moment it returned).

Closes MIR-1305