### PR TITLE
Fix indexwatch `send on closed channel` panic on watch-stream reconnect

### DIFF
--- a/pkg/entity/indexwatch/watcher.go
+++ b/pkg/entity/indexwatch/watcher.go
@@ -158,6 +158,14 @@ type Watcher struct {
 	// exclusively by the watch goroutine; no locking required.
 	cursor int64
 
+	// mu guards the updates channel against the send/close race. Events reach
+	// updates from two unsynchronized senders: the run goroutine (snapshots) and
+	// the RPC dispatch goroutine that invokes our WatchIndex callback. The latter
+	// can still be mid-send when run returns and closes the channel, so both
+	// send and close take mu and consult closed.
+	mu     sync.Mutex
+	closed bool
+
 	startOnce sync.Once
 	stopOnce  sync.Once
 	cancel    context.CancelFunc
@@ -204,7 +212,7 @@ func (w *Watcher) Start(ctx context.Context) error {
 		w.wg.Add(1)
 		go func() {
 			defer w.wg.Done()
-			defer close(w.updates)
+			defer w.closeUpdates()
 			w.run(runCtx)
 		}()
 	})
@@ -244,13 +252,35 @@ func decodeEntity(aen *entityserver_v1alpha.Entity) *entity.Entity {
 // send delivers an event on the Updates channel, blocking until there is room
 // (backpressure) or the context is cancelled. It reports whether the event was
 // delivered; a false return means the watcher is shutting down.
+//
+// It holds mu across the send so a late callback delivery from the RPC dispatch
+// goroutine can never race closeUpdates onto a closed channel. A plain
+// select-with-ctx.Done guard is not enough on its own: once updates is closed,
+// the send case is permanently ready (it panics rather than blocks) and select
+// picks randomly among ready cases, so it would still hit the closed channel
+// roughly half the time even with ctx already cancelled.
 func (w *Watcher) send(ctx context.Context, ev Event) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return false
+	}
 	select {
 	case <-ctx.Done():
 		return false
 	case w.updates <- ev:
 		return true
 	}
+}
+
+// closeUpdates closes the Updates channel exactly once, serialized with send via
+// mu so an in-flight send can never observe the channel mid-close. Called from
+// the run goroutine's deferred teardown after run returns.
+func (w *Watcher) closeUpdates() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
+	close(w.updates)
 }
 
 // run is the main loop. It maintains the revision cursor, snapshots when needed

--- a/pkg/entity/indexwatch/watcher_internal_test.go
+++ b/pkg/entity/indexwatch/watcher_internal_test.go
@@ -1,0 +1,61 @@
+package indexwatch
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"miren.dev/runtime/pkg/entity"
+)
+
+// TestSendAfterCloseIsSafe pins the fix for MIR-1307: a late event delivery
+// (as happens when the RPC dispatch goroutine invokes our WatchIndex callback
+// after run has torn down and closed the Updates channel) must not send on the
+// closed channel. send has to report shutdown, not panic.
+func TestSendAfterCloseIsSafe(t *testing.T) {
+	w := New(nil, entity.Attr{}, Options{BufferSize: 1})
+
+	w.closeUpdates()
+
+	if w.send(context.Background(), Event{Type: EventAdded}) {
+		t.Fatal("send reported delivery on a closed channel")
+	}
+}
+
+// TestConcurrentSendCloseNoPanic hammers the send/close race directly under the
+// race detector: many senders racing a single close must never panic with
+// "send on closed channel" nor deliver after the close. Run with -race for the
+// strongest signal; the closed-flag guard makes it deterministic regardless.
+func TestConcurrentSendCloseNoPanic(t *testing.T) {
+	const senders = 32
+
+	// A cancelled context so every send that loses the race to the close
+	// unblocks promptly via the ctx.Done arm rather than parking on the buffer.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	w := New(nil, entity.Attr{}, Options{BufferSize: 4})
+
+	var wg sync.WaitGroup
+	wg.Add(senders + 1)
+
+	for range senders {
+		go func() {
+			defer wg.Done()
+			// A send may succeed or report shutdown; it must never panic.
+			w.send(ctx, Event{Type: EventAdded})
+		}()
+	}
+
+	go func() {
+		defer wg.Done()
+		w.closeUpdates()
+	}()
+
+	wg.Wait()
+
+	// The channel must end up closed exactly once (a second close would panic).
+	if !w.closed {
+		t.Fatal("closed flag not set after closeUpdates")
+	}
+}


### PR DESCRIPTION
Garden hard-crashed with `panic: send on closed channel` coming out of the indexwatch abstraction during a watch-stream reconnect. With garden restarting repeatedly as PRs deployed, the reconnect/teardown path got hammered and this race surfaced as a whole-process fatal.

The root cause is that the Watcher's `updates` channel has two senders that don't know about each other. The `run` goroutine delivers snapshots on it directly, and the RPC dispatch goroutine delivers live watch events on it by invoking the `WatchIndex` callback we registered. But `run` also owns the close: it does a `defer close(w.updates)` when it tears down. The catch is that the RPC callback's lifetime isn't bounded by the `WatchIndex` call returning (the RPC layer doesn't join in-flight handler goroutines when the call unwinds), so on `Stop` or a reconnect a callback can still be sitting in `send` at the exact moment `run` closes the channel underneath it.

The `send` already had a `select` on `ctx.Done()`, which looks like it should cover this, but it doesn't. Once a channel is closed, its send case becomes permanently ready (a send on a closed channel panics rather than blocks), and Go's `select` picks randomly among ready cases. So even with the context already cancelled, `select` would still choose the closed-channel send about half the time and panic.

The fix serializes `send` and the close behind a mutex plus a `closed` flag, so a check-and-send is atomic with respect to the close and a late callback can never touch a closed channel. We deliberately kept closing the channel on `Stop` rather than taking the "don't close from the producer" route, because both real consumers (dns, ipalloc) and `TestWatcher_StopClosesUpdates` rely on that contract.

There's a new white-box regression test that reproduces the panic (it fails without the guard) plus a `-race` stress test over concurrent send/close.

Closes MIR-1307