### PR TITLE
Fix activator double-unlock that crashed miren under activation contention

### DIFF
--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -618,6 +618,11 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 	strategy := concurrency.NewStrategyForVersion(ver, service, &sc)
 	maxInstances := int64(strategy.MaxInstances())
 
+	// poolLoop is labeled so the pool-creation retry path below can break all
+	// the way back out to re-read the cache. The outer loop re-acquires a.mu
+	// from scratch on every iteration (RLock immediately below), so any
+	// `continue poolLoop` MUST leave the lock released.
+poolLoop:
 	for {
 		// Check if pool exists or is being created (read lock)
 		a.mu.RLock()
@@ -838,11 +843,18 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 		if exists {
 			// Another goroutine claimed creation while we waited for lock
 			a.mu.Unlock()
-			continue // Loop back to wait/increment logic
+			continue poolLoop // Loop back to wait/increment logic
 		}
 
 		// Try to find an existing pool in the entity store with retries
-		// DeploymentLauncher may have already created it, but we haven't seen it yet in our cache
+		// DeploymentLauncher may have already created it, but we haven't seen it yet in our cache.
+		//
+		// Lock invariant for this loop: a.mu is held at the top of every
+		// iteration. The attempt>0 backoff below releases it (line ~a.mu.Unlock)
+		// and re-acquires it before the next store query, so any path that exits
+		// an iteration must leave the lock in the state the next iteration (or
+		// the code after the loop) expects: held to stay in this loop, released
+		// to `continue poolLoop`.
 		const maxRetries = 3
 		const baseRetryDelay = 100 * time.Millisecond
 
@@ -870,9 +882,15 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 				a.mu.Lock()
 				_, exists = a.pools[key]
 				if exists {
-					// Another goroutine found or created the pool while we were waiting
+					// Another goroutine found or created the pool while we were
+					// waiting. Break all the way out to the outer loop to pick it
+					// up through the normal wait/increment path. A bare `continue`
+					// here would re-enter *this* attempt loop with the lock
+					// released, and the next iteration's a.mu.Unlock() during
+					// backoff would fatally unlock an already-unlocked mutex
+					// (MIR-1306).
 					a.mu.Unlock()
-					continue // Loop back to main logic
+					continue poolLoop
 				}
 			}
 

--- a/components/activator/activator_test.go
+++ b/components/activator/activator_test.go
@@ -2,6 +2,7 @@ package activator
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -3673,6 +3674,117 @@ func TestResyncWakesParkedWaiter(t *testing.T) {
 		assert.Less(t, time.Since(start), 10*time.Second, "waiter was woken by the wake, not the fallback ticker")
 	case <-time.After(15 * time.Second):
 		t.Fatal("parked waiter was never woken after re-sync")
+	}
+}
+
+// TestRequestPoolCapacityRetryRaceNoDoubleUnlock reproduces MIR-1306.
+//
+// Under activation contention, a goroutine sitting in requestPoolCapacity's
+// pool-lookup backoff would notice another goroutine had populated the cache
+// and take a bare `continue`, re-entering the attempt loop with a.mu released.
+// The next backoff iteration then called a.mu.Unlock() on an already-unlocked
+// RWMutex — a fatal, unrecoverable runtime throw that took down the whole
+// process (embedded etcd and every app on the node). The trigger is a pool that
+// becomes visible in the store *while* concurrent callers are mid-retry, so some
+// find it and populate a.pools[key] while others are still backing off and about
+// to re-check the cache.
+//
+// There are no ordinary assertions here: the failure mode is a fatal
+// double-unlock that crashes the test binary outright, so simply reaching the
+// end of the rounds without the process dying is the pass condition. Requires an
+// etcd-backed entity store, so run it inside the dev container:
+//
+//	./hack/dev-exec go test -run TestRequestPoolCapacityRetryRaceNoDoubleUnlock ./components/activator
+//
+// Deliberately without -race: the increment path has a separate, pre-existing
+// data race (MIR-1308) that the detector trips on and that would drown out this
+// test's signal. The double-unlock is a fatal throw, so it surfaces without the
+// detector anyway.
+func TestRequestPoolCapacityRetryRaceNoDoubleUnlock(t *testing.T) {
+	ctx := context.Background()
+
+	server, cleanup := testutils.NewEtcdEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{}
+	appID, err := server.Client.Create(ctx, "test-app-race", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	// The bug is timing-dependent, so we run several rounds. Pre-fix, the very
+	// first round reliably crashes; post-fix, every round drains cleanly.
+	const rounds = 10
+	const numGoroutines = 40
+
+	for round := 0; round < rounds; round++ {
+		// A fresh version each round means a fresh cache key and a store with no
+		// pool for it yet, forcing every caller through the store-lookup retry
+		// loop from an empty cache.
+		testVer := &core_v1alpha.AppVersion{
+			App:      app.ID,
+			Version:  fmt.Sprintf("v%d", round),
+			ImageUrl: "test:latest",
+			Config: core_v1alpha.Config{
+				Services: []core_v1alpha.Services{
+					{
+						Name: "web",
+						ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+							Mode:                "auto",
+							RequestsPerInstance: 10,
+						},
+					},
+				},
+			},
+		}
+		verID, err := server.Client.Create(ctx, fmt.Sprintf("test-ver-race-%d", round), testVer)
+		require.NoError(t, err)
+		testVer.ID = verID
+
+		activator := &localActivator{
+			log:             testutils.TestLogger(t),
+			eac:             server.EAC,
+			versions:        make(map[verKey]*versionPoolRef),
+			poolSandboxes:   make(map[entity.Id]*poolSandboxes),
+			pools:           make(map[verKey]*poolState),
+			newSandboxChans: make(map[verKey][]chan struct{}),
+		}
+
+		// Launch callers that all miss the cache and enter the store-lookup retry
+		// loop. The pool does not exist yet, so their first lookups return nil and
+		// they begin backing off.
+		done := make(chan error, numGoroutines)
+		barrier := make(chan struct{})
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				<-barrier
+				_, err := activator.requestPoolCapacity(ctx, testVer, "web")
+				done <- err
+			}()
+		}
+		close(barrier)
+
+		// Let the callers reach their first backoff (100ms), then make the pool
+		// visible in the store, mimicking DeploymentLauncher creating it
+		// mid-activation. Now retry lookups start finding it: whoever finds it
+		// first populates a.pools[key] while others are still mid-backoff and
+		// about to re-check the cache — the exact MIR-1306 race window.
+		time.Sleep(120 * time.Millisecond)
+		racePool := &compute_v1alpha.SandboxPool{
+			Service:              "web",
+			SandboxSpec:          compute_v1alpha.SandboxSpec{Version: testVer.ID},
+			ReferencedByVersions: []entity.Id{testVer.ID},
+			DesiredInstances:     0,
+			CurrentInstances:     0,
+		}
+		_, err = server.Client.Create(ctx, fmt.Sprintf("test-pool-race-%d", round), racePool)
+		require.NoError(t, err)
+
+		// Drain every caller. We don't require success — depending on scheduling a
+		// caller may hit a benign OCC conflict or the not-found terminal path. We
+		// only require the process to survive: no fatal double-unlock.
+		for i := 0; i < numGoroutines; i++ {
+			<-done
+		}
 	}
 }
 


### PR DESCRIPTION
Garden hard-crashed with `fatal error: sync: Unlock of unlocked RWMutex`, which on a single-node miren means the whole process goes down: embedded etcd, every app, everything. A `systemctl restart` brought it back, but it's the kind of bug that bites again the moment traffic spikes.

The culprit lives in the activator's `requestPoolCapacity`. When no pool is cached yet, it runs a small retry loop that polls the entity store for a pool the DeploymentLauncher might be creating concurrently. That inner loop has an invariant: `a.mu` is held at the top of every iteration, because the backoff between attempts unlocks the mutex during the sleep and re-locks before the next store query. One branch broke it. When a goroutine noticed another goroutine had already populated the cache, it unlocked and did a bare `continue`, meaning to loop back to the outer wait/increment logic. But `continue` only targets the nearest enclosing loop, so it re-entered the *inner* loop with the lock released. The next iteration's backoff-unlock then fired on an already-unlocked mutex, and Go turns that into a fatal throw you can't recover from.

It's a narrow race: it only triggers when a concurrent goroutine wins the pool-creation race specifically on a retry attempt, so you need real activation contention (lots of apps waking at once) to hit it. That's why it stayed hidden since October and only showed up now. #883's pool-eviction work increased pool churn and pushed enough traffic through this path to finally surface it.

The fix labels the outer loop and makes that branch `continue poolLoop`, so it breaks all the way out and picks the pool up through the normal cached path with the lock in the state the outer loop expects (released). While in here I audited the rest of the retry loop's lock discipline; this was the only actual defect, but I gave the sibling branch just above it the same explicit label (it was already correct by accident of nesting) and wrote the invariant down in a comment so the next person doesn't have to re-derive it. There's a new stress test that reconstructs the race by making a pool appear in the store while a crowd of callers is mid-backoff.

One thing worth flagging separately: running that stress test under `-race` also turns up a pre-existing data race on the increment path (concurrent access to the shared cached pool state), unrelated to this crash and untouched by this change. The normal suite doesn't run `-race`, so it's not blocking, but it's real and I'll file a follow-up.

Closes MIR-1306
