### PR TITLE
Add control-process runtime memory metrics + pprof endpoint

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	_ "net/http/pprof" // registers /debug/pprof handlers on http.DefaultServeMux
 	"net/netip"
 	"os"
 	"os/exec"
@@ -513,6 +514,22 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	ctx.ServerState.CPU = cpu
 	mem := metrics.NewMemoryUsage(ctx.Log, ctx.ServerState.Writer, ctx.ServerState.Reader)
 	ctx.ServerState.Mem = mem
+
+	// Control-process runtime memory metrics. The coordinator process is not
+	// covered by any per-sandbox cgroup, so this is the only visibility into
+	// its own heap/RSS growth. Pushes go_mem_* + process_resident_memory_bytes
+	// (entity="miren/control") through the same writer as the sandbox metrics.
+	runtimeMem := metrics.NewRuntimeMemory(ctx.Log, ctx.ServerState.Writer)
+	go runtimeMem.Monitor(sub)
+
+	// Diagnostic pprof endpoint, bound to localhost only so it is reachable
+	// on-box / via SSH tunnel but never publicly. Lets us pull a heap profile
+	// during a memory balloon to attribute Go-heap growth to an allocation site.
+	go func() {
+		if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
+			ctx.Log.Warn("pprof debug server exited", "err", err)
+		}
+	}()
 
 	// Create log writer and reader
 	logWriter := observability.NewPersistentLogWriter(ctx.ServerState.VictorialogsAddress, ctx.ServerState.VictorialogsTimeout)

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -9,7 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	_ "net/http/pprof" // registers /debug/pprof handlers on http.DefaultServeMux
+	"net/http/pprof"
 	"net/netip"
 	"os"
 	"os/exec"
@@ -55,6 +55,59 @@ import (
 	"miren.dev/runtime/pkg/workloadidentity"
 	"miren.dev/runtime/version"
 )
+
+// pprofAddr is the localhost-only address for the diagnostic pprof endpoint.
+//
+// NOTE: hard-coded, and this assumes a single miren instance per host. If a
+// second instance runs on the same host (e.g. a blue/green deploy) its bind
+// will fail and it will run without pprof, logging an error at startup.
+const pprofAddr = "127.0.0.1:6060"
+
+// startPprofServer starts the diagnostic net/http/pprof endpoint on pprofAddr so
+// a heap profile can be pulled live during a memory balloon without restarting
+// the process.
+//
+// The pprof handlers are registered on a private ServeMux, not the global
+// http.DefaultServeMux, so nothing else in the process can inadvertently expose
+// handlers on this listener. The server shuts down cleanly when ctx is
+// cancelled, matching the rest of the server's lifecycle.
+//
+// pprof is diagnostic-only, so a bind failure is logged as an error (operators
+// need to know it is unavailable) but does not abort server startup.
+func startPprofServer(ctx context.Context, log *slog.Logger) {
+	mux := http.NewServeMux()
+	// Mirror exactly what net/http/pprof's init would register on the default
+	// mux: Index serves the index and the named profiles (heap, goroutine, ...),
+	// the other four are the endpoints Index does not handle.
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	ln, err := net.Listen("tcp", pprofAddr)
+	if err != nil {
+		log.Error("pprof debug server not started", "addr", pprofAddr, "err", err)
+		return
+	}
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("pprof debug server exited", "err", err)
+		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Warn("pprof debug server shutdown", "err", err)
+		}
+	}()
+}
 
 func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	eg, sub := errgroup.WithContext(ctx)
@@ -525,11 +578,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	// Diagnostic pprof endpoint, bound to localhost only so it is reachable
 	// on-box / via SSH tunnel but never publicly. Lets us pull a heap profile
 	// during a memory balloon to attribute Go-heap growth to an allocation site.
-	go func() {
-		if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
-			ctx.Log.Warn("pprof debug server exited", "err", err)
-		}
-	}()
+	startPprofServer(sub, ctx.Log)
 
 	// Create log writer and reader
 	logWriter := observability.NewPersistentLogWriter(ctx.ServerState.VictorialogsAddress, ctx.ServerState.VictorialogsTimeout)

--- a/metrics/runtime_memory.go
+++ b/metrics/runtime_memory.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"context"
 	"log/slog"
-	"runtime"
+	runtimemetrics "runtime/metrics"
 	"time"
 )
 
@@ -29,6 +29,25 @@ type RuntimeMemory struct {
 }
 
 const defaultRuntimeMemoryInterval = 10 * time.Second
+
+// runtime/metrics sample names we read. These are the STW-free source for the
+// go_mem_* series below: unlike runtime.ReadMemStats (which stops the world to
+// take a consistent snapshot), runtime/metrics.Read reads live counters. The
+// runtime.MemStats fields the collector historically emitted don't all map to a
+// single sample, so some series are derived — see collect() for the arithmetic,
+// which follows the equivalences documented in the runtime/metrics package.
+const (
+	mHeapObjects  = "/memory/classes/heap/objects:bytes"
+	mHeapUnused   = "/memory/classes/heap/unused:bytes"
+	mHeapReleased = "/memory/classes/heap/released:bytes"
+	mHeapFree     = "/memory/classes/heap/free:bytes"
+	mHeapStacks   = "/memory/classes/heap/stacks:bytes"
+	mTotal        = "/memory/classes/total:bytes"
+	mGCObjects    = "/gc/heap/objects:objects"
+	mGCGoal       = "/gc/heap/goal:bytes"
+	mGCCycles     = "/gc/cycles/total:gc-cycles"
+	mGoroutines   = "/sched/goroutines:goroutines"
+)
 
 // NewRuntimeMemory creates a RuntimeMemory collector. Writer may be nil for
 // environments without metrics collection, in which case Monitor is a no-op.
@@ -67,24 +86,65 @@ func (r *RuntimeMemory) Monitor(ctx context.Context) {
 }
 
 func (r *RuntimeMemory) collect(ctx context.Context) error {
-	var ms runtime.MemStats
-	runtime.ReadMemStats(&ms)
+	samples := []runtimemetrics.Sample{
+		{Name: mHeapObjects}, {Name: mHeapUnused}, {Name: mHeapReleased},
+		{Name: mHeapFree}, {Name: mHeapStacks}, {Name: mTotal},
+		{Name: mGCObjects}, {Name: mGCGoal}, {Name: mGCCycles}, {Name: mGoroutines},
+	}
+	runtimemetrics.Read(samples)
+
+	// Index the readable (KindUint64) samples by name. A sample the runtime
+	// doesn't recognize comes back as KindBad; we simply skip any series that
+	// depends on it rather than emit a bogus zero.
+	vals := make(map[string]uint64, len(samples))
+	for _, s := range samples {
+		if s.Value.Kind() == runtimemetrics.KindUint64 {
+			vals[s.Name] = s.Value.Uint64()
+		}
+	}
 
 	ts := time.Now()
 	labels := map[string]string{"entity": r.Entity}
 
-	points := []MetricPoint{
-		{Name: "go_mem_heap_alloc_bytes", Labels: labels, Value: float64(ms.HeapAlloc), Timestamp: ts},
-		{Name: "go_mem_heap_inuse_bytes", Labels: labels, Value: float64(ms.HeapInuse), Timestamp: ts},
-		{Name: "go_mem_heap_sys_bytes", Labels: labels, Value: float64(ms.HeapSys), Timestamp: ts},
-		{Name: "go_mem_heap_idle_bytes", Labels: labels, Value: float64(ms.HeapIdle), Timestamp: ts},
-		{Name: "go_mem_heap_released_bytes", Labels: labels, Value: float64(ms.HeapReleased), Timestamp: ts},
-		{Name: "go_mem_heap_objects", Labels: labels, Value: float64(ms.HeapObjects), Timestamp: ts},
-		{Name: "go_mem_stack_inuse_bytes", Labels: labels, Value: float64(ms.StackInuse), Timestamp: ts},
-		{Name: "go_mem_sys_bytes", Labels: labels, Value: float64(ms.Sys), Timestamp: ts},
-		{Name: "go_mem_next_gc_bytes", Labels: labels, Value: float64(ms.NextGC), Timestamp: ts},
-		{Name: "go_gc_count_total", Labels: labels, Value: float64(ms.NumGC), Timestamp: ts},
-		{Name: "go_goroutines", Labels: labels, Value: float64(runtime.NumGoroutine()), Timestamp: ts},
+	points := make([]MetricPoint, 0, 12)
+
+	// emit appends one series whose value is the sum of the named samples, but
+	// only if every one of them was present — a missing constituent skips the
+	// series rather than emitting a bogus partial value.
+	emit := func(name string, names ...string) {
+		var total uint64
+		for _, n := range names {
+			v, ok := vals[n]
+			if !ok {
+				return
+			}
+			total += v
+		}
+		points = append(points, MetricPoint{Name: name, Labels: labels, Value: float64(total), Timestamp: ts})
+	}
+
+	// Emitted names are preserved from the previous runtime.MemStats-based
+	// implementation so existing dashboards/PromQL keep working. The
+	// runtime.MemStats -> runtime/metrics equivalences below are the ones
+	// documented in the runtime/metrics package.
+	emit("go_mem_heap_alloc_bytes", mHeapObjects)                                      // MemStats.HeapAlloc
+	emit("go_mem_heap_inuse_bytes", mHeapObjects, mHeapUnused)                         // MemStats.HeapInuse
+	emit("go_mem_heap_sys_bytes", mHeapObjects, mHeapUnused, mHeapReleased, mHeapFree) // MemStats.HeapSys
+	emit("go_mem_heap_idle_bytes", mHeapReleased, mHeapFree)                           // MemStats.HeapIdle
+	emit("go_mem_heap_released_bytes", mHeapReleased)                                  // MemStats.HeapReleased
+	emit("go_mem_heap_objects", mGCObjects)                                            // MemStats.HeapObjects
+	emit("go_mem_stack_inuse_bytes", mHeapStacks)                                      // MemStats.StackInuse
+	emit("go_mem_next_gc_bytes", mGCGoal)                                              // MemStats.NextGC
+	emit("go_gc_count_total", mGCCycles)                                               // MemStats.NumGC
+	emit("go_goroutines", mGoroutines)                                                 // runtime.NumGoroutine()
+
+	// MemStats.Sys = /memory/classes/total:bytes - /memory/classes/heap/released:bytes
+	// (memory obtained from the OS that has not been released back to it). This
+	// one is a difference, not a sum, so it can't go through emit.
+	if total, ok := vals[mTotal]; ok {
+		if released, ok := vals[mHeapReleased]; ok {
+			points = append(points, MetricPoint{Name: "go_mem_sys_bytes", Labels: labels, Value: float64(total - released), Timestamp: ts})
+		}
 	}
 
 	// Process RSS includes off-heap memory the Go runtime stats can't see

--- a/metrics/runtime_memory.go
+++ b/metrics/runtime_memory.go
@@ -1,0 +1,103 @@
+package metrics
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"time"
+)
+
+// RuntimeMemory collects Go runtime memory stats for the miren control process
+// itself and pushes them to VictoriaMetrics in the same push-only style as the
+// per-sandbox collectors (MemoryUsage/CPUUsage). The control process is not
+// covered by any per-sandbox cgroup, so today there is no visibility into the
+// coordinator's own heap/RSS growth — these series are that visibility.
+//
+// All series carry entity="miren/control" so they sit alongside the per-app
+// memory_usage_bytes{entity="app/..."} series and can be compared directly.
+// The key diagnostic is the gap between process_resident_memory_bytes (the
+// whole control process, including off-heap: cgo, mmap'd bbolt/etcd, the
+// buildkit content store) and go_mem_heap_inuse_bytes (Go-managed heap only):
+//   - both balloon together  -> Go heap; a pprof heap profile names the site.
+//   - RSS balloons, heap flat -> off-heap; pprof can't see it, look at bbolt/buildkit.
+type RuntimeMemory struct {
+	Log    *slog.Logger
+	Writer *VictoriaMetricsWriter
+
+	// Entity is the value of the "entity" label on every emitted series.
+	Entity string
+}
+
+const defaultRuntimeMemoryInterval = 10 * time.Second
+
+// NewRuntimeMemory creates a RuntimeMemory collector. Writer may be nil for
+// environments without metrics collection, in which case Monitor is a no-op.
+func NewRuntimeMemory(log *slog.Logger, writer *VictoriaMetricsWriter) *RuntimeMemory {
+	return &RuntimeMemory{
+		Log:    log,
+		Writer: writer,
+		Entity: "miren/control",
+	}
+}
+
+// Monitor samples runtime memory every defaultRuntimeMemoryInterval and pushes
+// one batch of points per tick until ctx is cancelled. Mirrors the cadence and
+// lifecycle of (*sandbox.Metrics).Monitor.
+func (r *RuntimeMemory) Monitor(ctx context.Context) {
+	if r.Writer == nil {
+		return
+	}
+
+	r.Log.Info("control-process runtime memory metrics started",
+		"entity", r.Entity, "interval", defaultRuntimeMemoryInterval)
+
+	ticker := time.NewTicker(defaultRuntimeMemoryInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := r.collect(ctx); err != nil {
+				r.Log.Error("failed to record control-process runtime memory", "err", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (r *RuntimeMemory) collect(ctx context.Context) error {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	ts := time.Now()
+	labels := map[string]string{"entity": r.Entity}
+
+	points := []MetricPoint{
+		{Name: "go_mem_heap_alloc_bytes", Labels: labels, Value: float64(ms.HeapAlloc), Timestamp: ts},
+		{Name: "go_mem_heap_inuse_bytes", Labels: labels, Value: float64(ms.HeapInuse), Timestamp: ts},
+		{Name: "go_mem_heap_sys_bytes", Labels: labels, Value: float64(ms.HeapSys), Timestamp: ts},
+		{Name: "go_mem_heap_idle_bytes", Labels: labels, Value: float64(ms.HeapIdle), Timestamp: ts},
+		{Name: "go_mem_heap_released_bytes", Labels: labels, Value: float64(ms.HeapReleased), Timestamp: ts},
+		{Name: "go_mem_heap_objects", Labels: labels, Value: float64(ms.HeapObjects), Timestamp: ts},
+		{Name: "go_mem_stack_inuse_bytes", Labels: labels, Value: float64(ms.StackInuse), Timestamp: ts},
+		{Name: "go_mem_sys_bytes", Labels: labels, Value: float64(ms.Sys), Timestamp: ts},
+		{Name: "go_mem_next_gc_bytes", Labels: labels, Value: float64(ms.NextGC), Timestamp: ts},
+		{Name: "go_gc_count_total", Labels: labels, Value: float64(ms.NumGC), Timestamp: ts},
+		{Name: "go_goroutines", Labels: labels, Value: float64(runtime.NumGoroutine()), Timestamp: ts},
+	}
+
+	// Process RSS includes off-heap memory the Go runtime stats can't see
+	// (mmap'd bbolt/etcd, buildkit content store, cgo). The gap against
+	// go_mem_heap_inuse_bytes is what tells us which kind of memory balloons.
+	if rss, ok := processResidentBytes(); ok {
+		points = append(points, MetricPoint{
+			Name:      "process_resident_memory_bytes",
+			Labels:    labels,
+			Value:     float64(rss),
+			Timestamp: ts,
+		})
+	}
+
+	return r.Writer.WritePoints(ctx, points)
+}

--- a/metrics/runtime_memory_linux.go
+++ b/metrics/runtime_memory_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package metrics
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// processResidentBytes returns the resident set size of the *control process*
+// itself (the miren binary), read from /proc/self/statm.
+//
+// Deliberately the process RSS, not the miren.service cgroup's memory.current:
+// in cgroup v2 the service total is recursive and includes every app-sandbox
+// and addon-DB child cgroup, which would conflate the coordinator's own growth
+// with normal app memory. The balloon we are chasing lives in the coordinator
+// process (the cgroup hits ~50G while all sandboxes sum to ~2.5G), so the
+// process RSS is exactly the signal we want.
+func processResidentBytes() (uint64, bool) {
+	// /proc/self/statm fields (in pages): size resident shared text lib data dt
+	data, err := os.ReadFile("/proc/self/statm")
+	if err != nil {
+		return 0, false
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 2 {
+		return 0, false
+	}
+	pages, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return pages * uint64(os.Getpagesize()), true
+}

--- a/metrics/runtime_memory_other.go
+++ b/metrics/runtime_memory_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package metrics
+
+// processResidentBytes has no portable implementation off Linux; the control
+// process only runs on Linux in production. On other platforms (e.g. darwin
+// dev builds) RSS is simply omitted from the emitted series.
+func processResidentBytes() (uint64, bool) {
+	return 0, false
+}

--- a/metrics/runtime_memory_test.go
+++ b/metrics/runtime_memory_test.go
@@ -1,0 +1,84 @@
+package metrics
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestRuntimeMemory_Collect(t *testing.T) {
+	var receivedData string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedData = string(body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	writer := NewVictoriaMetricsWriter(testLogger(), strings.TrimPrefix(server.URL, "http://"), 10*time.Second)
+	rm := NewRuntimeMemory(testLogger(), writer)
+
+	require.NoError(t, rm.collect(context.Background()))
+	writer.flush()
+
+	// These series must always be emitted regardless of the underlying
+	// runtime/metrics availability — they map to core, always-present samples.
+	expected := []string{
+		"go_mem_heap_alloc_bytes",
+		"go_mem_heap_inuse_bytes",
+		"go_mem_heap_sys_bytes",
+		"go_mem_heap_idle_bytes",
+		"go_mem_heap_released_bytes",
+		"go_mem_heap_objects",
+		"go_mem_stack_inuse_bytes",
+		"go_mem_sys_bytes",
+		"go_mem_next_gc_bytes",
+		"go_gc_count_total",
+		"go_goroutines",
+	}
+	for _, name := range expected {
+		assert.Contains(t, receivedData, name+"{", "expected series %q", name)
+	}
+
+	// Every series carries the control-process entity label.
+	for _, line := range strings.Split(strings.TrimSpace(receivedData), "\n") {
+		if line == "" {
+			continue
+		}
+		assert.Contains(t, line, `entity="miren/control"`, "line missing entity label: %s", line)
+	}
+}
+
+func TestRuntimeMemory_MonitorNilWriterIsNoop(t *testing.T) {
+	rm := NewRuntimeMemory(testLogger(), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// With a nil Writer, Monitor must return immediately rather than block on
+	// its ticker, so this completes well within the timeout.
+	done := make(chan struct{})
+	go func() {
+		rm.Monitor(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Monitor did not return immediately with a nil Writer")
+	}
+}


### PR DESCRIPTION
Supersedes #876. Brings in @jcasimir's control-process instrumentation (his commit is preserved with full attribution) and applies the review feedback from that PR.

## Problem

The bundled VictoriaMetrics only receives per-app-sandbox metrics (`memory_usage_bytes{entity="app/..."}`); there is no series for the control process itself, and it exposes no `/metrics` or pprof endpoint. So when the coordinator's own Go heap grows (e.g. a memory balloon), it is invisible to the very metrics stack miren ships, and unattributable without rebuilding.

## Change

A `RuntimeMemory` collector in the same push-only style as the existing sandbox collectors: a goroutine samples runtime memory every 10s and pushes `go_mem_*`, `go_goroutines`, and `process_resident_memory_bytes` (`entity="miren/control"`) through the existing `VictoriaMetricsWriter`. The gap between process RSS and `go_mem_heap_inuse_bytes` distinguishes a Go-heap balloon (a heap profile can name the site) from off-heap growth (mmap'd bbolt/etcd, the buildkit content store).

Also registers `net/http/pprof` on a localhost-only `:6060` listener so a heap profile can be pulled live during an incident without crashing the process.

Purely additive; no schema/entity changes.

## Review feedback addressed (from #876)

- **STW pause (evanphx):** the collector uses `runtime/metrics.Read` (live counters, no stop-the-world) instead of `runtime.ReadMemStats`. Emitted series names are preserved; the `runtime.MemStats`-derived series (HeapInuse/HeapSys/HeapIdle/Sys) are computed from the equivalences documented in the `runtime/metrics` package, and any absent sample is skipped rather than emitted as a zero.
- **DefaultServeMux hole (evanphx):** pprof handlers are registered on a private `http.ServeMux` rather than blank-imported into `http.DefaultServeMux`, so nothing else in the process can inadvertently be exposed on this listener.
- **Goroutine lifecycle / bind errors (miren-code-agent):** the pprof endpoint is an `http.Server` that binds via `net.Listen` up front (a bind failure is a startup `Error`, not a silent `Warn`) and shuts down cleanly on context cancellation instead of leaking. The hard-coded-port / one-instance-per-host assumption is documented.
- **Test coverage (miren-code-agent):** added unit coverage for `RuntimeMemory.collect()` (metric names, entity label) and the nil-`Writer` no-op path.

## Verification

- `go test ./metrics/` (incl. new collect + nil-writer tests) passes; `go vet` and `golangci-lint` clean.
- Confirmed emitted values are internally consistent (e.g. `go_mem_heap_sys_bytes` = inuse + released + free, `go_mem_sys_bytes` = total − released).
- Verified the pprof endpoint standalone: `/debug/pprof/`, `/debug/pprof/heap`, and `/debug/pprof/cmdline` all serve on the private mux, and the server becomes unreachable after context cancellation (graceful shutdown honoured).