### PR TITLE
Adapt CLI colors to the terminal background (light/dark)

### DIFF
--- a/cli/commands/admin.go
+++ b/cli/commands/admin.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"miren.dev/runtime/api/admin/admin_v1alpha"
+	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -529,7 +530,7 @@ func methodDefinition(m *admin_v1alpha.AdminMethod) ui.Definition {
 // did not advertise its parameters". Returns the empty string when params are
 // listed (the tree already speaks for itself).
 func paramShapeNote(m *admin_v1alpha.AdminMethod) string {
-	faint := lipgloss.NewStyle().Faint(true)
+	faint := lipgloss.NewStyle().Foreground(theme.Muted)
 	switch {
 	case !m.HasParams():
 		return faint.Render("  (parameters not advertised by this method)")
@@ -618,17 +619,17 @@ func adminMethodHelp(ctx *Context, adminClient *admin_v1alpha.AdminClient, appNa
 
 // JSON syntax highlighting styles (similar to jq)
 var (
-	jsonKeyStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("12")) // Blue for keys
-	jsonStringStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // Green for strings
-	jsonNumberStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("14")) // Cyan for numbers
-	jsonBoolStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("11")) // Yellow for booleans
-	jsonNullStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))  // Gray for null
-	jsonBracket     = lipgloss.NewStyle().Foreground(lipgloss.Color("15")) // White for brackets
+	jsonKeyStyle    = lipgloss.NewStyle().Foreground(theme.Info)    // Blue for keys
+	jsonStringStyle = lipgloss.NewStyle().Foreground(theme.Success) // Green for strings
+	jsonNumberStyle = lipgloss.NewStyle().Foreground(theme.Info)    // Blue for numbers
+	jsonBoolStyle   = lipgloss.NewStyle().Foreground(theme.Warning) // Yellow for booleans
+	jsonNullStyle   = lipgloss.NewStyle().Foreground(theme.Muted)   // Gray for null
+	jsonBracket     = lipgloss.NewStyle().Foreground(theme.Muted)   // Muted for brackets
 )
 
 // Pretty rendering styles
 var (
-	tableTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))
+	tableTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(theme.Info)
 )
 
 // highlightJSON recursively renders a JSON value with syntax highlighting

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -19,6 +19,7 @@ import (
 	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/rpc/standard"
+	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 	"miren.dev/runtime/pkg/units"
 )
@@ -269,7 +270,7 @@ var defaultStyle = lipgloss.NewStyle().
 	PaddingLeft(1).PaddingRight(1)
 
 var titleStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("3")) // yellow
+	Foreground(theme.Header) // yellow
 
 func (m Model) Init() tea.Cmd {
 	return nil
@@ -378,7 +379,7 @@ const (
 
 var (
 	bold  = lipgloss.NewStyle().Bold(true)
-	faint = lipgloss.NewStyle().Faint(true)
+	faint = lipgloss.NewStyle().Foreground(theme.Muted)
 )
 
 func (m Model) View() string {
@@ -632,7 +633,7 @@ func (m Model) View() string {
 			bottomRow,
 		)
 		footer =
-			lipgloss.NewStyle().Width(m.width - 3).Align(lipgloss.Right).Faint(true).Render(
+			faint.Width(m.width - 3).Align(lipgloss.Right).Render(
 				fmt.Sprintf("Updated: %s", time.Now().Format(Stamp)),
 			)
 	}

--- a/cli/commands/app_history.go
+++ b/cli/commands/app_history.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/api/deployment/deployment_v1alpha"
+	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -114,12 +115,12 @@ var statusStyles = map[string]struct {
 	icon  string
 	style lipgloss.Style
 }{
-	"active":      {"✓", lipgloss.NewStyle().Foreground(lipgloss.Color("10"))}, // Green
-	"succeeded":   {"✓", lipgloss.NewStyle().Foreground(lipgloss.Color("12"))}, // Blue
-	"failed":      {"✗", lipgloss.NewStyle().Foreground(lipgloss.Color("9"))},  // Red
-	"rolled_back": {"↩", lipgloss.NewStyle().Foreground(lipgloss.Color("11"))}, // Yellow
-	"in_progress": {"⟳", lipgloss.NewStyle().Foreground(lipgloss.Color("14"))}, // Cyan
-	"cancelled":   {"⊘", lipgloss.NewStyle().Foreground(lipgloss.Color("11"))}, // Yellow
+	"active":      {"✓", lipgloss.NewStyle().Foreground(theme.Success)}, // Green
+	"succeeded":   {"✓", lipgloss.NewStyle().Foreground(theme.Info)},    // Blue
+	"failed":      {"✗", lipgloss.NewStyle().Foreground(theme.Error)},   // Red
+	"rolled_back": {"↩", lipgloss.NewStyle().Foreground(theme.Warning)}, // Yellow
+	"in_progress": {"⟳", lipgloss.NewStyle().Foreground(theme.Info)},    // Blue
+	"cancelled":   {"⊘", lipgloss.NewStyle().Foreground(theme.Warning)}, // Yellow
 }
 
 type historyDisplayOpts struct {
@@ -176,7 +177,7 @@ func AppHistory(ctx *Context, opts struct {
 	}
 
 	// Print header
-	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Info)
 	ctx.Printf("%s\n", headerStyle.Render(fmt.Sprintf("Deployment History for %s", opts.App)))
 	ctx.Printf("Cluster: %s\n", ctx.ClusterName)
 	ctx.Printf("\n")

--- a/cli/commands/app_status.go
+++ b/cli/commands/app_status.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/api/deployment/deployment_v1alpha"
+	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -67,12 +68,12 @@ func AppStatus(ctx *Context, opts struct {
 	}
 
 	// Define styles
-	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))
-	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("8"))
-	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
-	blueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
-	yellowStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-	redStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Info)
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Muted)
+	greenStyle := lipgloss.NewStyle().Foreground(theme.Success)
+	blueStyle := lipgloss.NewStyle().Foreground(theme.Info)
+	yellowStyle := lipgloss.NewStyle().Foreground(theme.Warning)
+	redStyle := lipgloss.NewStyle().Foreground(theme.Error)
 
 	// Print header
 	ctx.Printf("%s\n\n", headerStyle.Render(fmt.Sprintf("Status for %s", opts.App)))

--- a/cli/commands/cluster.go
+++ b/cli/commands/cluster.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -85,7 +86,7 @@ func ClusterList(ctx *Context, opts struct {
 			// Format address - color port portion gray for table display
 			address := ccfg.Hostname
 			if host, port, err := net.SplitHostPort(address); err == nil {
-				grayPort := lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render(":" + port)
+				grayPort := lipgloss.NewStyle().Foreground(theme.Muted).Render(":" + port)
 				address = host + grayPort
 			}
 

--- a/cli/commands/color.go
+++ b/cli/commands/color.go
@@ -2,21 +2,51 @@ package commands
 
 import (
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
 	"miren.dev/runtime/pkg/color"
+	"miren.dev/runtime/pkg/theme"
 )
 
+// Colors prints the resolved CLI color theme and a swatch of each semantic role.
+// It's a support aid: users on a misdetected terminal can run `miren colors` and
+// paste the output so we can see what was detected and how to override it.
 func Colors(ctx *Context, opts struct {
 }) error {
+	ctx.Printf("Resolved theme: %s\n", theme.Current())
 
-	sample := func(str string, color string) string {
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render(str)
+	// Query the live terminal background regardless of how the theme was resolved
+	// (an override may have skipped auto-detection during startup).
+	if bg := color.Background(); bg != "" {
+		swatch := lipgloss.NewStyle().Foreground(lipgloss.Color(bg)).Render("████")
+		ctx.Printf("Terminal background: %s %s\n", bg, swatch)
+	} else {
+		ctx.Printf("Terminal background: (terminal did not report)\n")
 	}
-	bg := color.Background()
-	lf := color.LiveFaint()
 
-	ctx.Printf("Background: %s %s\n", bg, sample("background", bg))
-	ctx.Printf("LiveFaint: %s %s\n", lf, sample("faint background", lf))
-	ctx.Printf("ANSIFaint: %s\n",
-		lipgloss.NewStyle().Faint(true).Render("ansi faint"))
+	ctx.Printf("Color profile: %s\n", profileName(lipgloss.ColorProfile()))
+	ctx.Printf("Override with MIREN_THEME=auto|light|dark|no, the `theme` config field, or NO_COLOR/FORCE_COLOR.\n")
+
+	ctx.Printf("\nSemantic roles:\n")
+	for _, r := range theme.Roles() {
+		swatch := lipgloss.NewStyle().Foreground(r.Color).Render("████")
+		ctx.Printf("  %s  %s\n", swatch, r.Name)
+	}
+
 	return nil
+}
+
+func profileName(p termenv.Profile) string {
+	switch p {
+	case termenv.TrueColor:
+		return "truecolor"
+	case termenv.ANSI256:
+		return "ansi256"
+	case termenv.ANSI:
+		return "ansi"
+	case termenv.Ascii:
+		return "ascii (no color)"
+	default:
+		return "unknown"
+	}
 }

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/cloudauth"
+	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -40,7 +41,7 @@ func formatAddressWithGrayPort(address string) string {
 	}
 
 	// Gray out the port portion
-	grayStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	grayStyle := lipgloss.NewStyle().Foreground(theme.Muted)
 
 	// Check if host needs brackets (IPv6)
 	if strings.Contains(host, ":") {
@@ -434,7 +435,12 @@ func (m localNameModel) View() string {
 	return modalStyle.Render(modalContent.String())
 }
 
-// Define consistent styles for both list and modal
+// Define consistent styles for both list and modal.
+//
+// These are intentionally NOT drawn from pkg/theme: the modal paints its own dark
+// background (bgColor) and layers light text on top, so it reads correctly on any
+// terminal. Swapping in adaptive foregrounds would flip them to dark tones on a
+// light terminal while the box stayed dark, making the modal unreadable.
 var (
 	// Shared colors
 	primaryColor   = lipgloss.Color("229") // Bright yellow-white for titles

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -37,6 +37,7 @@ import (
 	"miren.dev/runtime/pkg/rpc/standard"
 	"miren.dev/runtime/pkg/rpc/stream"
 	"miren.dev/runtime/pkg/tarx"
+	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -282,8 +283,8 @@ func Deploy(ctx *Context, opts struct {
 		}
 	}
 
-	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
-	faintStyle := lipgloss.NewStyle().Faint(true)
+	greenStyle := lipgloss.NewStyle().Foreground(theme.Success)
+	faintStyle := lipgloss.NewStyle().Foreground(theme.Muted)
 	ctx.Printf("  ✓ %s: %s %s %s\n", greenStyle.Render("Deploying"), name, faintStyle.Render("→"), ctx.ClusterName)
 
 	cl, err := ctx.RPCClient("dev.miren.runtime/build")
@@ -663,7 +664,6 @@ func Deploy(ctx *Context, opts struct {
 
 	if useExplainMode {
 		if useOptimized && cachedFiles > 0 {
-			faintStyle := lipgloss.NewStyle().Faint(true)
 			ctx.Printf("  %s\n", faintStyle.Render(fmt.Sprintf("Reused %d/%d files from previous deploy, uploading %d", cachedFiles, totalFiles, len(neededPaths))))
 		}
 
@@ -951,7 +951,7 @@ func Deploy(ctx *Context, opts struct {
 		if len(warns) == 0 {
 			return
 		}
-		warnHeaderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("208")).Bold(true)
+		warnHeaderStyle := lipgloss.NewStyle().Foreground(theme.Warning).Bold(true)
 		ctx.Printf("\n%s\n", warnHeaderStyle.Render("Warnings:"))
 		for _, entry := range warns {
 			renderDeployWarning(ctx, entry)
@@ -1219,9 +1219,8 @@ func createBuildStatusCallback(
 }
 
 func renderDeployWarning(ctx *Context, entry *build_v1alpha.LogEntry) {
-	orange := lipgloss.Color("208")
-	headerStyle := lipgloss.NewStyle().Foreground(orange).Bold(true)
-	linkStyle := lipgloss.NewStyle().Foreground(orange).Faint(true)
+	headerStyle := lipgloss.NewStyle().Foreground(theme.Warning).Bold(true)
+	linkStyle := lipgloss.NewStyle().Foreground(theme.Warning)
 
 	// Compute wrap width: terminal width minus indent (4 chars), capped at 76
 	const indent = 4
@@ -1232,7 +1231,7 @@ func renderDeployWarning(ctx *Context, entry *build_v1alpha.LogEntry) {
 			detailWidth = min(available, maxWidth)
 		}
 	}
-	detailStyle := lipgloss.NewStyle().Foreground(orange).Width(detailWidth).PaddingLeft(indent)
+	detailStyle := lipgloss.NewStyle().Foreground(theme.Warning).Width(detailWidth).PaddingLeft(indent)
 
 	ctx.Printf("  %s\n", headerStyle.Render("⚠ "+entry.Text()))
 
@@ -1246,7 +1245,7 @@ func renderDeployWarning(ctx *Context, entry *build_v1alpha.LogEntry) {
 		ctx.Printf("%s\n", detailStyle.Render(detail))
 	}
 	if link, ok := fields["link"]; ok {
-		ctx.Printf("    %s%s\n", linkStyle.Render("See: "), ui.RenderMarkdownLink(link, 208))
+		ctx.Printf("    %s%s\n", linkStyle.Render("See: "), ui.RenderMarkdownLink(link, theme.Warning))
 	}
 }
 
@@ -1372,10 +1371,10 @@ func stripPort(host string) string {
 var (
 	analyzeTitleStyle = lipgloss.NewStyle().
 				Bold(true).
-				Foreground(lipgloss.Color("3")) // yellow
+				Foreground(theme.Header) // yellow
 
 	analyzeLabelStyle = lipgloss.NewStyle().
-				Faint(true).
+				Foreground(theme.Muted).
 				Width(12).
 				Align(lipgloss.Right)
 
@@ -1384,23 +1383,27 @@ var (
 
 	// Badge styles for different event kinds
 	badgeFile = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("12")). // blue
+			Foreground(theme.Info).
 			Bold(true)
 	badgePackage = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("10")). // green
+			Foreground(theme.Success).
 			Bold(true)
 	badgeFramework = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("13")). // magenta
+			Foreground(theme.Highlight).
 			Bold(true)
 	badgeConfig = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("11")). // yellow
+			Foreground(theme.Warning).
 			Bold(true)
+	// dir shares Info with file, and script shares Warning with config; italic
+	// keeps each pair visually distinct now that the palette is role-based.
 	badgeDir = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("14")). // cyan
-			Bold(true)
+			Foreground(theme.Info).
+			Bold(true).
+			Italic(true)
 	badgeScript = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("208")). // orange
-			Bold(true)
+			Foreground(theme.Warning).
+			Bold(true).
+			Italic(true)
 )
 
 func eventKindBadge(kind string) string {
@@ -1419,7 +1422,7 @@ func eventKindBadge(kind string) string {
 	case "script":
 		return badgeScript.Render(badge)
 	default:
-		return lipgloss.NewStyle().Faint(true).Render(badge)
+		return lipgloss.NewStyle().Foreground(theme.Muted).Render(badge)
 	}
 }
 
@@ -1506,13 +1509,13 @@ func analyzeApp(ctx *Context, bc *build_v1alpha.BuilderClient, dir string) error
 			for _, svc := range services {
 				sourceInfo := ""
 				if svc.Source() != "" {
-					sourceInfo = lipgloss.NewStyle().Faint(true).Render(fmt.Sprintf(" (%s)", svc.Source()))
+					sourceInfo = lipgloss.NewStyle().Foreground(theme.Muted).Render(fmt.Sprintf(" (%s)", svc.Source()))
 				}
 
 				command := svc.Command()
 				if command == "" {
 					// Service uses Dockerfile CMD (image default)
-					command = lipgloss.NewStyle().Faint(true).Italic(true).Render("image default")
+					command = lipgloss.NewStyle().Foreground(theme.Muted).Italic(true).Render("image default")
 				}
 
 				ctx.Printf("  %s: %s%s\n",
@@ -1534,17 +1537,17 @@ func analyzeApp(ctx *Context, bc *build_v1alpha.BuilderClient, dir string) error
 
 			// Show available (detected + found locally)
 			if len(localDetection.Available) > 0 {
-				ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Render("Available locally:"))
+				ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(theme.Success).Render("Available locally:"))
 				for _, ev := range localDetection.Available {
 					valueDisplay := MaskValue(ev.Value, ev.Sensitive)
 					if ev.Sensitive {
 						ctx.Printf("    %s %s=%s\n",
-							lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Render("✓"),
+							lipgloss.NewStyle().Foreground(theme.Success).Render("✓"),
 							ev.Key,
-							lipgloss.NewStyle().Faint(true).Render(valueDisplay))
+							lipgloss.NewStyle().Foreground(theme.Muted).Render(valueDisplay))
 					} else {
 						ctx.Printf("    %s %s=%s\n",
-							lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Render("✓"),
+							lipgloss.NewStyle().Foreground(theme.Success).Render("✓"),
 							ev.Key,
 							valueDisplay)
 					}
@@ -1553,27 +1556,27 @@ func analyzeApp(ctx *Context, bc *build_v1alpha.BuilderClient, dir string) error
 
 			// Show missing (detected but not found locally)
 			if len(localDetection.Missing) > 0 {
-				ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render("Not set locally:"))
+				ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(theme.Warning).Render("Not set locally:"))
 				for _, ev := range localDetection.Missing {
 					ctx.Printf("    %s %s\n",
-						lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render("○"),
+						lipgloss.NewStyle().Foreground(theme.Warning).Render("○"),
 						ev.Key)
 				}
 			}
 
 			// Show additional app-related env vars found locally
 			if len(localDetection.Additional) > 0 {
-				ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render("Also found locally (may be relevant):"))
+				ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(theme.Info).Render("Also found locally (may be relevant):"))
 				for _, ev := range localDetection.Additional {
 					valueDisplay := MaskValue(ev.Value, ev.Sensitive)
 					if ev.Sensitive {
 						ctx.Printf("    %s %s=%s\n",
-							lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render("?"),
+							lipgloss.NewStyle().Foreground(theme.Info).Render("?"),
 							ev.Key,
-							lipgloss.NewStyle().Faint(true).Render(valueDisplay))
+							lipgloss.NewStyle().Foreground(theme.Muted).Render(valueDisplay))
 					} else {
 						ctx.Printf("    %s %s=%s\n",
-							lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render("?"),
+							lipgloss.NewStyle().Foreground(theme.Info).Render("?"),
 							ev.Key,
 							valueDisplay)
 					}
@@ -1585,17 +1588,17 @@ func analyzeApp(ctx *Context, bc *build_v1alpha.BuilderClient, dir string) error
 		localDetection := DetectLocalEnvVars(nil)
 		if len(localDetection.Additional) > 0 {
 			ctx.Printf("\n%s\n", analyzeTitleStyle.Render("Environment Variables"))
-			ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render("Found locally (may be relevant):"))
+			ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(theme.Info).Render("Found locally (may be relevant):"))
 			for _, ev := range localDetection.Additional {
 				valueDisplay := MaskValue(ev.Value, ev.Sensitive)
 				if ev.Sensitive {
 					ctx.Printf("    %s %s=%s\n",
-						lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render("?"),
+						lipgloss.NewStyle().Foreground(theme.Info).Render("?"),
 						ev.Key,
-						lipgloss.NewStyle().Faint(true).Render(valueDisplay))
+						lipgloss.NewStyle().Foreground(theme.Muted).Render(valueDisplay))
 				} else {
 					ctx.Printf("    %s %s=%s\n",
-						lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render("?"),
+						lipgloss.NewStyle().Foreground(theme.Info).Render("?"),
 						ev.Key,
 						valueDisplay)
 				}

--- a/cli/commands/deploy_ui.go
+++ b/cli/commands/deploy_ui.go
@@ -10,29 +10,20 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"miren.dev/runtime/pkg/color"
 	"miren.dev/runtime/pkg/colortheory"
 	"miren.dev/runtime/pkg/progress/progressui"
 	"miren.dev/runtime/pkg/progress/upload"
+	"miren.dev/runtime/pkg/theme"
 )
 
 // UI Styles
 var (
-	liveFaint         lipgloss.Style
-	deployPrefixStyle = lipgloss.NewStyle().Faint(true)
-	phaseSummaryStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // Green for completed phases
-	phaseTimeStyle    = lipgloss.NewStyle().Faint(true)
-	phaseFailStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("9")) // Red for failed phases
+	liveFaint         = lipgloss.NewStyle().Foreground(theme.Muted)
+	deployPrefixStyle = lipgloss.NewStyle().Foreground(theme.Muted)
+	phaseSummaryStyle = lipgloss.NewStyle().Foreground(theme.Success) // Green for completed phases
+	phaseTimeStyle    = lipgloss.NewStyle().Foreground(theme.Muted)
+	phaseFailStyle    = lipgloss.NewStyle().Foreground(theme.Error) // Red for failed phases
 )
-
-func init() {
-	lf := color.LiveFaint()
-	if lf == "" {
-		liveFaint = lipgloss.NewStyle().Faint(true)
-	} else {
-		liveFaint = lipgloss.NewStyle().Foreground(lipgloss.Color(lf))
-	}
-}
 
 // Custom spinner styles
 var (

--- a/cli/commands/doctor.go
+++ b/cli/commands/doctor.go
@@ -14,14 +14,15 @@ import (
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/pkg/auth"
 	"miren.dev/runtime/pkg/cloudauth"
+	"miren.dev/runtime/pkg/theme"
 )
 
 var (
-	infoGreen  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
-	infoRed    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
-	infoYellow = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
-	infoGray   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	infoLabel  = lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
+	infoGreen  = lipgloss.NewStyle().Foreground(theme.Success)
+	infoRed    = lipgloss.NewStyle().Foreground(theme.Error)
+	infoYellow = lipgloss.NewStyle().Foreground(theme.Warning)
+	infoGray   = lipgloss.NewStyle().Foreground(theme.Muted)
+	infoLabel  = lipgloss.NewStyle().Foreground(theme.Info)
 	infoBold   = lipgloss.NewStyle().Bold(true)
 )
 

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/api/deployment/deployment_v1alpha"
+	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -436,7 +437,7 @@ func EnvDelete(ctx *Context, opts struct {
 // printEnvTable prints a formatted table of environment variables
 func printEnvTable(ctx *Context, entries []envVarEntry) {
 	// Create a gray style for sensitive values
-	grayStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	grayStyle := lipgloss.NewStyle().Foreground(theme.Muted)
 
 	// Build rows
 	var rows []ui.Row

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -17,6 +17,7 @@ import (
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/slogfmt"
 	"miren.dev/runtime/pkg/slogrus"
+	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -112,6 +113,15 @@ func setup(ctx context.Context, flags *GlobalFlags, opts any) *Context {
 			s.Log.Warn("Failed to load client config", "error", err)
 		}
 	}
+
+	// Resolve the CLI color palette once, adapting to the terminal background and
+	// honoring NO_COLOR/FORCE_COLOR plus the `theme` config field. Safe to call
+	// per-command: it's guarded by a sync.Once internally.
+	var configuredTheme string
+	if s.ClientConfig != nil {
+		configuredTheme = s.ClientConfig.Theme()
+	}
+	theme.Init(configuredTheme)
 
 	if lc, ok := opts.(interface {
 		LoadCluster() (*clientconfig.ClusterConfig, string, error)
@@ -326,7 +336,7 @@ func (c *Context) DisplayTable(headers []string, rows [][]string) {
 	// Define styles
 	headerStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("12")). // Blue
+		Foreground(theme.Info). // Blue
 		PaddingRight(2)
 
 	cellStyle := lipgloss.NewStyle().
@@ -364,7 +374,7 @@ func (c *Context) DisplayTable(headers []string, rows [][]string) {
 		sep += strings.Repeat("─", width+2)
 	}
 	fmt.Fprintln(c.Stdout, lipgloss.NewStyle().
-		Foreground(lipgloss.Color("8")). // Gray
+		Foreground(theme.Muted). // Gray
 		Render(sep))
 
 	// Render data rows

--- a/cli/commands/help_render.go
+++ b/cli/commands/help_render.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/mflags"
+	"miren.dev/runtime/pkg/theme"
 )
 
 // RenderTopLevelHelp renders grouped help output for the top-level command list.
@@ -31,7 +32,7 @@ func RenderTopLevelHelp(d *mflags.Dispatcher) {
 		}
 	}
 
-	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("220"))
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(theme.Header)
 
 	fmt.Printf("Usage: %s <command> [arguments]\n", d.Name())
 
@@ -55,7 +56,7 @@ func RenderTopLevelHelp(d *mflags.Dispatcher) {
 func formatHelpLine(d *mflags.Dispatcher, child mflags.ChildEntry, maxLen int) string {
 	grandchildren := d.GetDirectChildren(child.Path)
 
-	faint := lipgloss.NewStyle().Faint(true)
+	faint := lipgloss.NewStyle().Foreground(theme.Muted)
 
 	suffix := ""
 	if len(grandchildren) > 0 {

--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -13,6 +13,7 @@ import (
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/pkg/stackbuild"
+	"miren.dev/runtime/pkg/theme"
 )
 
 // inferAppName derives a sanitized app name from a directory path.
@@ -161,7 +162,7 @@ func Init(ctx *Context, opts struct {
 
 		if len(requiredVars) > 0 {
 			ctx.Printf("\n")
-			ctx.Printf("%s\n", lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("1")).Render("Required Environment Variables"))
+			ctx.Printf("%s\n", lipgloss.NewStyle().Bold(true).Foreground(theme.Error).Render("Required Environment Variables"))
 
 			for _, ev := range requiredVars {
 				if ev.DefaultValue != "" {
@@ -208,12 +209,12 @@ func Init(ctx *Context, opts struct {
 
 		if len(recommendedVars) > 0 {
 			ctx.Printf("\n")
-			ctx.Printf("%s\n", lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("3")).Render("Recommended Environment Variables"))
+			ctx.Printf("%s\n", lipgloss.NewStyle().Bold(true).Foreground(theme.Warning).Render("Recommended Environment Variables"))
 			ctx.Printf("You may also want to configure:\n\n")
 
 			for _, ev := range recommendedVars {
 				ctx.Printf("  %s\n", lipgloss.NewStyle().Bold(true).Render(ev.Name))
-				ctx.Printf("    %s\n", lipgloss.NewStyle().Faint(true).Render(ev.Reason))
+				ctx.Printf("    %s\n", lipgloss.NewStyle().Foreground(theme.Muted).Render(ev.Reason))
 			}
 		}
 	}
@@ -230,7 +231,7 @@ func Init(ctx *Context, opts struct {
 		cl, err := ctx.RPCClient("dev.miren.runtime/app")
 		if err != nil {
 			ctx.Printf("\n%s Could not connect to server: %v\n",
-				lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render("Warning:"), err)
+				lipgloss.NewStyle().Foreground(theme.Warning).Render("Warning:"), err)
 			ctx.Printf("Secrets not stored. Run 'miren config set' to configure manually after logging in.\n")
 		} else {
 			ac := app_v1alpha.NewCrudClient(cl)
@@ -238,7 +239,7 @@ func Init(ctx *Context, opts struct {
 			_, err = ac.New(ctx, appConfig.Name)
 			if err != nil {
 				ctx.Printf("\n%s Could not create app on server: %v\n",
-					lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render("Warning:"), err)
+					lipgloss.NewStyle().Foreground(theme.Warning).Render("Warning:"), err)
 				ctx.Printf("Secrets not stored. Run 'miren config set' to configure manually.\n")
 			} else {
 				// Stage the secrets on the app's initial ConfigVersion via a
@@ -257,7 +258,7 @@ func Init(ctx *Context, opts struct {
 				_, err := ac.SetInitialEnvVars(ctx, appConfig.Name, rpcVars, "")
 				if err != nil {
 					ctx.Printf("\n%s Failed to stage secrets on server: %v\n",
-						lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render("Warning:"), err)
+						lipgloss.NewStyle().Foreground(theme.Warning).Render("Warning:"), err)
 					ctx.Printf("Secrets not stored. Run 'miren config set' to configure manually.\n")
 				} else {
 					serverConfigured = append(serverConfigured, secretsToStore...)
@@ -272,12 +273,12 @@ func Init(ctx *Context, opts struct {
 			ctx.Printf("  %s=%s %s\n",
 				lipgloss.NewStyle().Bold(true).Render(defVar.Key),
 				defVar.Value,
-				lipgloss.NewStyle().Faint(true).Foreground(lipgloss.Color("2")).Render("✓ default (in app.toml)"))
+				lipgloss.NewStyle().Foreground(theme.Success).Render("✓ default (in app.toml)"))
 		}
 		for _, secret := range serverConfigured {
 			ctx.Printf("  %s %s\n",
 				lipgloss.NewStyle().Bold(true).Render(secret.Key),
-				lipgloss.NewStyle().Faint(true).Foreground(lipgloss.Color("2")).Render("✓ "+secret.Source+" (stored on server)"))
+				lipgloss.NewStyle().Foreground(theme.Success).Render("✓ "+secret.Source+" (stored on server)"))
 		}
 	}
 
@@ -285,7 +286,7 @@ func Init(ctx *Context, opts struct {
 		ctx.Printf("\nMust be configured manually:\n")
 		for _, ev := range needsManualConfig {
 			ctx.Printf("  %s\n", lipgloss.NewStyle().Bold(true).Render(ev.Name))
-			ctx.Printf("    %s\n", lipgloss.NewStyle().Faint(true).Render(ev.Reason))
+			ctx.Printf("    %s\n", lipgloss.NewStyle().Foreground(theme.Muted).Render(ev.Reason))
 		}
 		ctx.Printf("\nSet their values with:\n")
 		ctx.Printf("  miren config set <KEY>=<value>\n")

--- a/cli/commands/tea_utils.go
+++ b/cli/commands/tea_utils.go
@@ -6,6 +6,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"miren.dev/runtime/pkg/theme"
 )
 
 // SelectionModel is a generic model for selecting from a list of items
@@ -81,10 +83,10 @@ func (m *SelectionModel) View() string {
 		if m.cursor == i {
 			// Override with selection color unless item already has custom styling
 			if m.ItemStyle == nil {
-				style = style.Foreground(lipgloss.Color("170"))
+				style = style.Foreground(theme.Highlight)
 			} else {
 				// If there's custom styling, just make it bold
-				style = style.Bold(true).Foreground(lipgloss.Color("170"))
+				style = style.Bold(true).Foreground(theme.Highlight)
 			}
 		}
 
@@ -124,7 +126,7 @@ func SelectCluster(ctx *Context, title string, clusters []string, activeCluster 
 	if dimActive {
 		model.ItemStyle = func(item string) lipgloss.Style {
 			if item == activeCluster {
-				return lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+				return lipgloss.NewStyle().Foreground(theme.Muted)
 			}
 			return lipgloss.NewStyle()
 		}

--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -55,6 +55,7 @@ type ClusterConfig struct {
 // Config represents the complete client configuration
 type Config struct {
 	active     string
+	theme      string
 	clusters   map[string]*ClusterConfig
 	identities map[string]*IdentityConfig
 	keys       map[string]*KeyConfig
@@ -77,6 +78,7 @@ type Config struct {
 // ConfigData is used for YAML unmarshaling to handle private fields
 type ConfigData struct {
 	Active     string                     `yaml:"active_cluster,omitempty"`
+	Theme      string                     `yaml:"theme,omitempty"` // CLI color theme: auto | light | dark | no
 	Clusters   map[string]*ClusterConfig  `yaml:"clusters,omitempty"`
 	Identities map[string]*IdentityConfig `yaml:"identities,omitempty"`
 	Keys       map[string]*KeyConfig      `yaml:"keys,omitempty"`
@@ -90,6 +92,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	c.active = temp.Active
+	c.theme = temp.Theme
 	c.clusters = temp.Clusters
 	c.identities = temp.Identities
 	c.keys = temp.Keys
@@ -101,6 +104,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (c *Config) MarshalYAML() (interface{}, error) {
 	return &ConfigData{
 		Active:     c.active,
+		Theme:      c.theme,
 		Clusters:   c.clusters,
 		Identities: c.identities,
 		Keys:       c.keys,
@@ -171,6 +175,17 @@ func (c *Config) Validate() error {
 // ActiveCluster returns the name of the active cluster
 func (c *Config) ActiveCluster() string {
 	return c.active
+}
+
+// Theme returns the configured CLI color theme preference (auto | light | dark |
+// no), or "" if unset. An empty value means auto-detect.
+func (c *Config) Theme() string {
+	return c.theme
+}
+
+// SetTheme sets the CLI color theme preference.
+func (c *Config) SetTheme(theme string) {
+	c.theme = theme
 }
 
 // GetActiveCluster returns the active cluster configuration
@@ -434,6 +449,7 @@ func LoadConfig() (*Config, error) {
 	}
 
 	config.active = cdata.Active
+	config.theme = cdata.Theme
 	config.clusters = cdata.Clusters
 	config.identities = cdata.Identities
 	config.keys = cdata.Keys
@@ -548,6 +564,7 @@ func (c *Config) SaveTo(path string) error {
 	var cdata ConfigData
 
 	cdata.Active = c.active
+	cdata.Theme = c.theme
 	cdata.Clusters = c.clusters
 	cdata.Identities = c.identities
 	cdata.Keys = c.keys

--- a/pkg/progress/progressui/display.go
+++ b/pkg/progress/progressui/display.go
@@ -24,6 +24,8 @@ import (
 	"github.com/tonistiigi/units"
 	"github.com/tonistiigi/vt100"
 	"golang.org/x/time/rate"
+
+	"miren.dev/runtime/pkg/theme"
 )
 
 type displayOpts struct {
@@ -1030,7 +1032,7 @@ func setupTerminals(jobs []*job, height int, all bool) []*job {
 	return jobs
 }
 
-var cachedColor = lipgloss.NewStyle().Foreground(lipgloss.Color("#E2CC8E"))
+var cachedColor = lipgloss.NewStyle().Foreground(theme.Warning)
 
 func (disp *ttyDisplay) print(d displayInfo, width, height int, all bool) {
 	// this output is inspired by Buck

--- a/pkg/theme/theme.go
+++ b/pkg/theme/theme.go
@@ -1,0 +1,288 @@
+// Package theme centralizes the miren CLI's color palette and adapts it to the
+// terminal it's running in.
+//
+// Historically colors were hard-coded as bright 256-color ANSI indices tuned for
+// dark terminals, which washed out (or dropped below readable contrast) on light
+// backgrounds. This package instead exposes a small set of semantic roles
+// (Header, Success, Warning, ...) as lipgloss.AdaptiveColor values whose light and
+// dark variants are hand-tuned for contrast on their respective backgrounds.
+//
+// Init decides, once per process, which variant to use. It honors the de-facto
+// terminal color conventions (NO_COLOR, FORCE_COLOR/CLICOLOR) and a manual
+// override (MIREN_THEME env var or the `theme` client-config field), falling back
+// to background auto-detection (COLORFGBG hint, then an OSC 11 query) and finally
+// to dark, the safe historical default.
+package theme
+
+import (
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/lucasb-eyer/go-colorful"
+	"github.com/muesli/termenv"
+	"golang.org/x/term"
+
+	"miren.dev/runtime/pkg/color"
+)
+
+// Variant is the resolved palette variant.
+type Variant int
+
+const (
+	// VariantDark is the palette for dark-background terminals (the default).
+	VariantDark Variant = iota
+	// VariantLight is the palette for light-background terminals.
+	VariantLight
+	// VariantNoColor disables color entirely (NO_COLOR / `theme: no`).
+	VariantNoColor
+)
+
+func (v Variant) String() string {
+	switch v {
+	case VariantLight:
+		return "light"
+	case VariantNoColor:
+		return "no-color"
+	case VariantDark:
+		return "dark"
+	default:
+		return "dark"
+	}
+}
+
+// Semantic color roles. Each is a lipgloss.CompleteAdaptiveColor, which carries
+// exact values for the truecolor, ANSI256, and ANSI profiles, split by light and
+// dark background. lipgloss selects the Light/Dark side from the background
+// darkness we set via SetHasDarkBackground in Init, then reads the field matching
+// the terminal's color profile with NO automatic degradation. This lets us serve
+// designed jewel tones on truecolor terminals while pinning 256-color terminals
+// to xterm anchor indices (so distinct roles never quantize into the same muddy
+// bucket) and still degrade sanely to the basic 16 colors.
+//
+// Dark values stay close to the previous bright palette. Light values are darker,
+// saturated tones tuned for contrast on white; the warm hues (gold/orange) run a
+// little lower on contrast but are used bold or as status glyphs where that reads
+// fine.
+var (
+	// Header styles section headings and table column headers (was bright "220").
+	// On light backgrounds gold reads muddy, so headers borrow the Info blue there
+	// (bold + underline still distinguish them from plain Info text); dark keeps
+	// the gold.
+	Header = lipgloss.CompleteAdaptiveColor{
+		Dark:  lipgloss.CompleteColor{TrueColor: "#FFD75F", ANSI256: "221", ANSI: "11"},
+		Light: lipgloss.CompleteColor{TrueColor: "#2563EB", ANSI256: "26", ANSI: "4"},
+	}
+	// Success marks healthy/OK/added state (was bright green "10"/"2").
+	Success = lipgloss.CompleteAdaptiveColor{
+		Dark:  lipgloss.CompleteColor{TrueColor: "#4EC94E", ANSI256: "77", ANSI: "10"},
+		Light: lipgloss.CompleteColor{TrueColor: "#15803D", ANSI256: "28", ANSI: "2"},
+	}
+	// Warning marks degraded/pending/attention state (was yellow "11"/"3"/"208").
+	Warning = lipgloss.CompleteAdaptiveColor{
+		Dark:  lipgloss.CompleteColor{TrueColor: "#E0B000", ANSI256: "178", ANSI: "11"},
+		Light: lipgloss.CompleteColor{TrueColor: "#C2410C", ANSI256: "166", ANSI: "3"},
+	}
+	// Error marks failed/error state (was red "9"/"196").
+	Error = lipgloss.CompleteAdaptiveColor{
+		Dark:  lipgloss.CompleteColor{TrueColor: "#FF6B6B", ANSI256: "203", ANSI: "9"},
+		Light: lipgloss.CompleteColor{TrueColor: "#DC2626", ANSI256: "160", ANSI: "1"},
+	}
+	// Info marks informational accents and links (was blue "12"/"62").
+	Info = lipgloss.CompleteAdaptiveColor{
+		Dark:  lipgloss.CompleteColor{TrueColor: "#5FAFFF", ANSI256: "75", ANSI: "12"},
+		Light: lipgloss.CompleteColor{TrueColor: "#2563EB", ANSI256: "26", ANSI: "4"},
+	}
+	// Muted is low-emphasis secondary text. It replaces the pervasive Faint(true)
+	// usage, which relied on the terminal's dim attribute and vanished on light
+	// backgrounds (was gray "8"/"240"/"244"/"245").
+	Muted = lipgloss.CompleteAdaptiveColor{
+		Dark:  lipgloss.CompleteColor{TrueColor: "#9A9A9A", ANSI256: "246", ANSI: "8"},
+		Light: lipgloss.CompleteColor{TrueColor: "#6B7280", ANSI256: "243", ANSI: "8"},
+	}
+	// Highlight marks the selected/active item in interactive pickers.
+	Highlight = lipgloss.CompleteAdaptiveColor{
+		Dark:  lipgloss.CompleteColor{TrueColor: "#D7AFFF", ANSI256: "183", ANSI: "13"},
+		Light: lipgloss.CompleteColor{TrueColor: "#7C3AED", ANSI256: "91", ANSI: "5"},
+	}
+)
+
+// Role pairs a human name with its color, for the `miren colors` debug command.
+type Role struct {
+	Name  string
+	Color lipgloss.CompleteAdaptiveColor
+}
+
+// Roles returns the semantic roles in display order.
+func Roles() []Role {
+	return []Role{
+		{"Header", Header},
+		{"Success", Success},
+		{"Warning", Warning},
+		{"Error", Error},
+		{"Info", Info},
+		{"Muted", Muted},
+		{"Highlight", Highlight},
+	}
+}
+
+var (
+	once       sync.Once
+	current    Variant
+	detectedBG string
+)
+
+// Current returns the resolved palette variant. It is only meaningful after Init.
+func Current() Variant { return current }
+
+// DetectedBackground returns the terminal background hex observed during
+// detection, or "" if detection didn't run (override set, not a TTY, or the
+// terminal didn't answer). Used by the `miren colors` debug command.
+func DetectedBackground() string { return detectedBG }
+
+// Init resolves the palette variant once per process and applies it to lipgloss's
+// default renderer. configured is the `theme` value from client config (may be
+// empty). It is safe to call multiple times; only the first call takes effect.
+func Init(configured string) {
+	once.Do(func() {
+		v, force := resolve(os.LookupEnv, configured, detectBackground, isTTY())
+		current = v
+
+		switch {
+		case v == VariantNoColor:
+			lipgloss.SetColorProfile(termenv.Ascii)
+		case force:
+			// Emit color even when stdout isn't a TTY (piped, CI). Floor at
+			// ANSI256 so forcing never degrades to no color, but honor COLORTERM
+			// so a truecolor environment still gets truecolor.
+			lipgloss.SetColorProfile(forcedProfile(os.LookupEnv))
+		default:
+			// Color is on and this is (or should be) an interactive terminal.
+			// Some modern terminals report a TERM that older termenv builds don't
+			// recognize (e.g. TERM=xterm-ghostty forwarded over SSH, with no
+			// COLORTERM to fall back on), which makes lipgloss degrade all the way
+			// to Ascii — monochrome output on a perfectly capable terminal. Floor
+			// to ANSI256 so we always render at least the anchor palette. Truecolor
+			// still requires the terminal to advertise it (COLORTERM or a TERM
+			// termenv knows); this only rescues the "would've been monochrome" case.
+			if isTTY() && lipgloss.ColorProfile() == termenv.Ascii && colorCapableTerm(os.LookupEnv) {
+				lipgloss.SetColorProfile(termenv.ANSI256)
+			}
+		}
+
+		lipgloss.SetHasDarkBackground(v != VariantLight)
+	})
+}
+
+// detectBackground runs the active OSC 11 query and records the result for the
+// debug command. Kept as a named function so resolve stays pure and testable.
+func detectBackground() string {
+	detectedBG = color.Background()
+	return detectedBG
+}
+
+// resolve is the pure decision function: given the environment, the configured
+// override, a background probe, and whether stdout is a TTY, it returns the
+// variant and whether color output should be forced on. It performs no I/O beyond
+// calling detectBG (only when it actually needs the background).
+func resolve(lookup func(string) (string, bool), configured string, detectBG func() string, isTTY bool) (Variant, bool) {
+	override := configured
+	if v, ok := lookup("MIREN_THEME"); ok && v != "" {
+		override = v
+	}
+	override = strings.ToLower(strings.TrimSpace(override))
+
+	force := truthyEnv(lookup, "FORCE_COLOR") || truthyEnv(lookup, "CLICOLOR_FORCE")
+
+	switch override {
+	case "no", "none", "off", "never":
+		return VariantNoColor, false
+	case "light":
+		return VariantLight, force
+	case "dark":
+		return VariantDark, force
+	}
+
+	// NO_COLOR (present and non-empty) or CLICOLOR=0 disables color unless the
+	// user explicitly forces it back on.
+	if !force {
+		if v, ok := lookup("NO_COLOR"); ok && v != "" {
+			return VariantNoColor, false
+		}
+		if v, ok := lookup("CLICOLOR"); ok && v == "0" {
+			return VariantNoColor, false
+		}
+	}
+
+	// Auto-detect the background. Prefer the passive COLORFGBG hint (no terminal
+	// round-trip); fall back to the active OSC 11 probe only on a TTY; default to
+	// dark, matching the historical palette.
+	if hint, ok := lookup("COLORFGBG"); ok {
+		if v, matched := variantFromColorFGBG(hint); matched {
+			return v, force
+		}
+	}
+	if isTTY {
+		if isLightHex(detectBG()) {
+			return VariantLight, force
+		}
+	}
+	return VariantDark, force
+}
+
+func truthyEnv(lookup func(string) (string, bool), key string) bool {
+	v, ok := lookup(key)
+	return ok && v != "" && v != "0"
+}
+
+// forcedProfile picks the color profile to use when color is forced on (piped,
+// CI). It floors at ANSI256 so forcing never yields no color, and upgrades to
+// truecolor when the environment advertises it via COLORTERM.
+func forcedProfile(lookup func(string) (string, bool)) termenv.Profile {
+	if ct, _ := lookup("COLORTERM"); ct == "truecolor" || ct == "24bit" {
+		return termenv.TrueColor
+	}
+	return termenv.ANSI256
+}
+
+// colorCapableTerm reports whether TERM names a real terminal that can render
+// color, as opposed to a genuine no-color signal ("dumb" or an unset TERM). It's
+// used to decide whether an Ascii profile on a TTY is a real "no color" request
+// or just termenv failing to recognize a modern terminal's name.
+func colorCapableTerm(lookup func(string) (string, bool)) bool {
+	t, ok := lookup("TERM")
+	return ok && t != "" && t != "dumb"
+}
+
+// variantFromColorFGBG interprets a COLORFGBG value like "15;0" (fg;bg) or
+// "15;default;0". The background is the last field; ANSI 7 and 9-15 are light.
+func variantFromColorFGBG(v string) (Variant, bool) {
+	fields := strings.Split(v, ";")
+	if len(fields) == 0 {
+		return VariantDark, false
+	}
+	bg := strings.TrimSpace(fields[len(fields)-1])
+	switch bg {
+	case "7", "9", "10", "11", "12", "13", "14", "15":
+		return VariantLight, true
+	case "0", "1", "2", "3", "4", "5", "6", "8":
+		return VariantDark, true
+	}
+	return VariantDark, false
+}
+
+// isLightHex reports whether a "#rrggbb" background color is light. Empty or
+// unparseable input is treated as dark (the safe default).
+func isLightHex(hex string) bool {
+	c, err := colorful.Hex(hex)
+	if err != nil {
+		return false
+	}
+	_, _, l := c.Hsl()
+	return l > 0.5
+}
+
+func isTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/pkg/theme/theme_test.go
+++ b/pkg/theme/theme_test.go
@@ -1,0 +1,233 @@
+package theme
+
+import (
+	"testing"
+
+	"github.com/muesli/termenv"
+)
+
+func lookupFrom(env map[string]string) func(string) (string, bool) {
+	return func(k string) (string, bool) {
+		v, ok := env[k]
+		return v, ok
+	}
+}
+
+func TestResolve(t *testing.T) {
+	const lightBG = "#ffffff"
+	const darkBG = "#000000"
+
+	tests := []struct {
+		name       string
+		env        map[string]string
+		configured string
+		bg         string // background the probe returns
+		isTTY      bool
+		want       Variant
+		wantForce  bool
+	}{
+		{
+			name: "NO_COLOR disables color",
+			env:  map[string]string{"NO_COLOR": "1"},
+			want: VariantNoColor,
+		},
+		{
+			name:  "empty NO_COLOR is ignored",
+			env:   map[string]string{"NO_COLOR": ""},
+			bg:    darkBG,
+			isTTY: true,
+			want:  VariantDark,
+		},
+		{
+			name:      "FORCE_COLOR overrides NO_COLOR and forces color",
+			env:       map[string]string{"NO_COLOR": "1", "FORCE_COLOR": "1"},
+			isTTY:     false,
+			want:      VariantDark,
+			wantForce: true,
+		},
+		{
+			name: "MIREN_THEME=light wins",
+			env:  map[string]string{"MIREN_THEME": "light"},
+			want: VariantLight,
+		},
+		{
+			name: "MIREN_THEME=dark wins",
+			env:  map[string]string{"MIREN_THEME": "dark"},
+			bg:   lightBG, // ignored because override is explicit
+			want: VariantDark,
+		},
+		{
+			name: "MIREN_THEME=no disables color",
+			env:  map[string]string{"MIREN_THEME": "no"},
+			want: VariantNoColor,
+		},
+		{
+			name:       "config theme is honored when no env override",
+			configured: "light",
+			want:       VariantLight,
+		},
+		{
+			name:       "MIREN_THEME env overrides config",
+			env:        map[string]string{"MIREN_THEME": "dark"},
+			configured: "light",
+			want:       VariantDark,
+		},
+		{
+			name: "CLICOLOR=0 disables color",
+			env:  map[string]string{"CLICOLOR": "0"},
+			want: VariantNoColor,
+		},
+		{
+			name:      "CLICOLOR_FORCE re-enables color",
+			env:       map[string]string{"CLICOLOR": "0", "CLICOLOR_FORCE": "1"},
+			want:      VariantDark,
+			wantForce: true,
+		},
+		{
+			name: "COLORFGBG dark background",
+			env:  map[string]string{"COLORFGBG": "15;0"},
+			want: VariantDark,
+		},
+		{
+			name: "COLORFGBG light background",
+			env:  map[string]string{"COLORFGBG": "0;15"},
+			want: VariantLight,
+		},
+		{
+			name:  "COLORFGBG preferred over probe",
+			env:   map[string]string{"COLORFGBG": "0;15"},
+			bg:    darkBG,
+			isTTY: true,
+			want:  VariantLight,
+		},
+		{
+			name:  "OSC probe reports light background",
+			bg:    lightBG,
+			isTTY: true,
+			want:  VariantLight,
+		},
+		{
+			name:  "OSC probe reports dark background",
+			bg:    darkBG,
+			isTTY: true,
+			want:  VariantDark,
+		},
+		{
+			name:  "no TTY defaults to dark",
+			bg:    lightBG, // would be light, but probe shouldn't run
+			isTTY: false,
+			want:  VariantDark,
+		},
+		{
+			name: "FORCE_COLOR=0 does not force",
+			env:  map[string]string{"FORCE_COLOR": "0"},
+			want: VariantDark,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probed := false
+			detectBG := func() string {
+				probed = true
+				return tt.bg
+			}
+
+			got, force := resolve(lookupFrom(tt.env), tt.configured, detectBG, tt.isTTY)
+			if got != tt.want {
+				t.Errorf("variant = %v, want %v", got, tt.want)
+			}
+			if force != tt.wantForce {
+				t.Errorf("force = %v, want %v", force, tt.wantForce)
+			}
+
+			// The active probe must never run when stdout isn't a TTY: it reads
+			// from the terminal and would hang or corrupt piped/test output.
+			if probed && !tt.isTTY {
+				t.Errorf("background probe ran without a TTY")
+			}
+		})
+	}
+}
+
+func TestIsLightHex(t *testing.T) {
+	tests := []struct {
+		hex  string
+		want bool
+	}{
+		{"#ffffff", true},
+		{"#fdf6e3", true}, // solarized light
+		{"#000000", false},
+		{"#1e1e1e", false}, // typical dark theme
+		{"#4d4d4d", false}, // dark gray resolves dark
+		{"", false},        // unparseable -> dark
+		{"not-a-color", false},
+	}
+	for _, tt := range tests {
+		if got := isLightHex(tt.hex); got != tt.want {
+			t.Errorf("isLightHex(%q) = %v, want %v", tt.hex, got, tt.want)
+		}
+	}
+}
+
+func TestForcedProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want termenv.Profile
+	}{
+		{"no COLORTERM floors at ANSI256", nil, termenv.ANSI256},
+		{"COLORTERM=truecolor -> truecolor", map[string]string{"COLORTERM": "truecolor"}, termenv.TrueColor},
+		{"COLORTERM=24bit -> truecolor", map[string]string{"COLORTERM": "24bit"}, termenv.TrueColor},
+		{"COLORTERM=yes stays ANSI256", map[string]string{"COLORTERM": "yes"}, termenv.ANSI256},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := forcedProfile(lookupFrom(tt.env)); got != tt.want {
+				t.Errorf("forcedProfile = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestColorCapableTerm(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"xterm-ghostty is capable", map[string]string{"TERM": "xterm-ghostty"}, true},
+		{"xterm-256color is capable", map[string]string{"TERM": "xterm-256color"}, true},
+		{"dumb is not", map[string]string{"TERM": "dumb"}, false},
+		{"empty TERM is not", map[string]string{"TERM": ""}, false},
+		{"unset TERM is not", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := colorCapableTerm(lookupFrom(tt.env)); got != tt.want {
+				t.Errorf("colorCapableTerm = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVariantFromColorFGBG(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    Variant
+		matched bool
+	}{
+		{"15;0", VariantDark, true},
+		{"0;15", VariantLight, true},
+		{"15;8", VariantDark, true},        // 8 is dark (bright black)
+		{"0;7", VariantLight, true},        // 7 is light (white)
+		{"15;default", VariantDark, false}, // unknown -> no match
+		{"", VariantDark, false},
+	}
+	for _, tt := range tests {
+		got, matched := variantFromColorFGBG(tt.in)
+		if got != tt.want || matched != tt.matched {
+			t.Errorf("variantFromColorFGBG(%q) = (%v, %v), want (%v, %v)", tt.in, got, matched, tt.want, tt.matched)
+		}
+	}
+}

--- a/pkg/ui/definition_list.go
+++ b/pkg/ui/definition_list.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"miren.dev/runtime/pkg/theme"
 )
 
 // Definition represents a single definition entry with a term, description, and optional details
@@ -41,13 +43,13 @@ type DefinitionListStyles struct {
 // DefaultDefinitionListStyles returns the default styling
 func DefaultDefinitionListStyles() DefinitionListStyles {
 	return DefinitionListStyles{
-		Title:       lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")),
-		Term:        lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10")),
+		Title:       lipgloss.NewStyle().Bold(true).Foreground(theme.Info),
+		Term:        lipgloss.NewStyle().Bold(true).Foreground(theme.Success),
 		Description: lipgloss.NewStyle().Italic(true),
-		DetailName:  lipgloss.NewStyle().Foreground(lipgloss.Color("14")),
-		DetailType:  lipgloss.NewStyle().Foreground(lipgloss.Color("13")),
-		Required:    lipgloss.NewStyle().Foreground(lipgloss.Color("9")),
-		TreeLine:    lipgloss.NewStyle().Faint(true),
+		DetailName:  lipgloss.NewStyle().Foreground(theme.Info),
+		DetailType:  lipgloss.NewStyle().Foreground(theme.Highlight),
+		Required:    lipgloss.NewStyle().Foreground(theme.Error),
+		TreeLine:    lipgloss.NewStyle().Foreground(theme.Muted),
 	}
 }
 

--- a/pkg/ui/hint.go
+++ b/pkg/ui/hint.go
@@ -1,6 +1,10 @@
 package ui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
+
+	"miren.dev/runtime/pkg/theme"
+)
 
 // Hint renders a dimmed hint/tip message
 type Hint struct {
@@ -12,7 +16,7 @@ type Hint struct {
 func NewHint(text string) *Hint {
 	return &Hint{
 		text:  text,
-		style: lipgloss.NewStyle().Faint(true),
+		style: lipgloss.NewStyle().Foreground(theme.Muted),
 	}
 }
 

--- a/pkg/ui/named_value.go
+++ b/pkg/ui/named_value.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"miren.dev/runtime/pkg/theme"
 )
 
 // ValueType represents the type of a value for styling purposes
@@ -91,10 +93,10 @@ func DefaultNamedValueStyles() NamedValueStyles {
 	return NamedValueStyles{
 		Label:       lipgloss.NewStyle(),
 		Separator:   ": ",
-		StringValue: lipgloss.NewStyle().Foreground(lipgloss.Color("10")), // Green
-		NumberValue: lipgloss.NewStyle().Foreground(lipgloss.Color("14")), // Cyan
-		BoolValue:   lipgloss.NewStyle().Foreground(lipgloss.Color("11")), // Yellow
-		NullValue:   lipgloss.NewStyle().Foreground(lipgloss.Color("8")),  // Gray
+		StringValue: lipgloss.NewStyle().Foreground(theme.Success), // Green
+		NumberValue: lipgloss.NewStyle().Foreground(theme.Info),    // Blue
+		BoolValue:   lipgloss.NewStyle().Foreground(theme.Warning), // Yellow
+		NullValue:   lipgloss.NewStyle().Foreground(theme.Muted),   // De-emphasized
 		OtherValue:  lipgloss.NewStyle(),
 	}
 }

--- a/pkg/ui/picker.go
+++ b/pkg/ui/picker.go
@@ -7,6 +7,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"miren.dev/runtime/pkg/theme"
 )
 
 // PickerItem represents an item that can be selected in the picker
@@ -113,7 +115,7 @@ func (m *PickerModel) View() string {
 	if m.Title != "" {
 		titleStyle := lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("229"))
+			Foreground(theme.Header)
 		b.WriteString(titleStyle.Render(m.Title))
 		b.WriteString("\n\n")
 	}
@@ -153,12 +155,12 @@ func (m *PickerModel) View() string {
 
 	// Style for selected row
 	selectedStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("39")).
+		Foreground(theme.Highlight).
 		Bold(true)
 
 	// Style for disabled rows
 	disabledStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("240"))
+		Foreground(theme.Muted)
 
 	// Render the table with custom row styling
 	var tableLines []string
@@ -200,7 +202,7 @@ func (m *PickerModel) View() string {
 					Bold(true).
 					Underline(true).
 					UnderlineSpaces(true).
-					Foreground(lipgloss.Color("220"))
+					Foreground(theme.Header)
 
 				headerCells = append(headerCells, headerStyle.Render(renderedCell))
 			}
@@ -250,7 +252,7 @@ func (m *PickerModel) View() string {
 
 	// Help text
 	helpStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("241")).
+		Foreground(theme.Muted).
 		MarginTop(1)
 
 	helpText := "\n(Use ↑/↓ or j/k to navigate, Enter to select, Esc to cancel)"
@@ -258,7 +260,7 @@ func (m *PickerModel) View() string {
 
 	if m.Footer != "" {
 		footerStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("244"))
+			Foreground(theme.Muted)
 		b.WriteString("\n")
 		b.WriteString(footerStyle.Render(m.Footer))
 	}
@@ -269,7 +271,7 @@ func (m *PickerModel) View() string {
 		if m.cursor < len(m.Items) && m.IsDisabled(m.Items[m.cursor]) {
 			// Show the warning message
 			msgStyle := lipgloss.NewStyle().
-				Foreground(lipgloss.Color("196"))
+				Foreground(theme.Error)
 			b.WriteString(msgStyle.Render("⚠ " + m.DisabledMessage))
 		} else {
 			// Keep the space reserved but empty

--- a/pkg/ui/prompt.go
+++ b/pkg/ui/prompt.go
@@ -7,6 +7,8 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"miren.dev/runtime/pkg/theme"
 )
 
 // PromptOption configures a text input prompt
@@ -146,7 +148,7 @@ func (m textInputModel) View() string {
 		return ""
 	}
 
-	promptStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	promptStyle := lipgloss.NewStyle().Foreground(theme.Muted)
 
 	return fmt.Sprintf(
 		"%s\n\n%s\n\n%s",

--- a/pkg/ui/status.go
+++ b/pkg/ui/status.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"miren.dev/runtime/pkg/theme"
 )
 
 // DisplayStatus returns a colored version of the status string based on common status values.
@@ -15,15 +17,15 @@ func DisplayStatus(status string) string {
 	// Apply color based on status value
 	switch status {
 	case "dead", "failed", "error":
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render(status) // gray
+		return lipgloss.NewStyle().Foreground(theme.Muted).Render(status) // de-emphasized
 	case "running", "active", "healthy", "ready":
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Render(status) // green
+		return lipgloss.NewStyle().Foreground(theme.Success).Render(status) // green
 	case "stopped", "inactive", "unhealthy", "not_ready":
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(status) // red
+		return lipgloss.NewStyle().Foreground(theme.Error).Render(status) // red
 	case "pending", "starting", "waiting", "creating":
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Render(status) // blue
+		return lipgloss.NewStyle().Foreground(theme.Info).Render(status) // blue
 	case "paused", "suspended":
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render(status) // yellow
+		return lipgloss.NewStyle().Foreground(theme.Warning).Render(status) // yellow
 	default:
 		return status // no color for unknown/other statuses
 	}

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -9,6 +9,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
 	"golang.org/x/term"
+
+	"miren.dev/runtime/pkg/theme"
 )
 
 // oscPattern matches OSC 8 hyperlink sequences: ESC ] 8 ; ; URL ST TEXT ESC ] 8 ; ; ST
@@ -111,7 +113,7 @@ func DefaultTableStyles() TableStyles {
 			Bold(true).
 			Underline(true).
 			UnderlineSpaces(true).
-			Foreground(lipgloss.Color("220")),
+			Foreground(theme.Header),
 		Cell:  lipgloss.NewStyle(),
 		Title: lipgloss.NewStyle().Bold(true),
 	}

--- a/pkg/ui/terminal.go
+++ b/pkg/ui/terminal.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 
+	"github.com/charmbracelet/lipgloss"
 	"golang.org/x/term"
 )
 
@@ -27,33 +28,51 @@ func TerminalWidth() int {
 }
 
 // Hyperlink creates a clickable terminal hyperlink using the OSC 8 escape sequence
-// with dotted underline styling. Raw SGR sequences are used so the result can be
-// safely combined with lipgloss-rendered text without interference.
+// with underline styling. Raw SGR sequences are used so the result can be safely
+// combined with lipgloss-rendered text without interference.
+//
+// We use a plain underline (\x1b[4m) rather than the colon-style dotted underline
+// (\x1b[4:4m): Terminal.app and other terminals don't understand colon SGR
+// subparameters and misrender them as a stray background that bleeds across the
+// line.
 //
 // When stdout is not a TTY, returns just the text with no escape sequences.
 func Hyperlink(url, text string) string {
 	if !IsTTY() {
 		return text
 	}
-	return fmt.Sprintf("\x1b]8;;%s\x1b\\\x1b[4:4m%s\x1b[24m\x1b]8;;\x1b\\", url, text)
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\\x1b[4m%s\x1b[24m\x1b]8;;\x1b\\", url, text)
 }
 
-// HyperlinkStyled is like Hyperlink but also applies a foreground color (256-color index).
+// HyperlinkStyled is like Hyperlink but also applies a foreground color, which
+// adapts to the terminal's profile and background via the theme's color roles.
 //
 // When stdout is not a TTY, returns just the text with no escape sequences.
-func HyperlinkStyled(url, text string, color int) string {
+func HyperlinkStyled(url, text string, color lipgloss.TerminalColor) string {
 	if !IsTTY() {
 		return text
 	}
-	return fmt.Sprintf("\x1b]8;;%s\x1b\\\x1b[38;5;%dm\x1b[4:4m%s\x1b[24;39m\x1b]8;;\x1b\\", url, color, text)
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b[4m%s\x1b[24;39m\x1b]8;;\x1b\\", url, foregroundSeq(color), text)
+}
+
+// foregroundSeq returns the SGR escape that sets the foreground to color for the
+// active color profile (e.g. "\x1b[38;2;194;65;12m"), or "" when color is off.
+// Raw OSC 8 hyperlinks can't be rendered through a lipgloss style without
+// disturbing the hyperlink sequences, so we emit the color escape by hand.
+func foregroundSeq(color lipgloss.TerminalColor) string {
+	seq := lipgloss.ColorProfile().FromColor(color).Sequence(false)
+	if seq == "" {
+		return ""
+	}
+	return "\x1b[" + seq + "m"
 }
 
 // RenderMarkdownLink parses a markdown-style link "[text](url)" and renders it
-// as a clickable terminal hyperlink with the given 256-color index.
+// as a clickable terminal hyperlink in the given theme color.
 //
 // When stdout is not a TTY, renders as "text (url)" for readability in pipes/logs.
 // If the input isn't a valid markdown link, it's returned as-is.
-func RenderMarkdownLink(s string, color int) string {
+func RenderMarkdownLink(s string, color lipgloss.TerminalColor) string {
 	m := mdLinkPattern.FindStringSubmatch(s)
 	if m == nil {
 		return s


### PR DESCRIPTION
A community member on a light-background terminal reported the `miren` CLI was hard to read. The palette was tuned for dark terminals and hard-coded as bright 256-color ANSI indices spread across about twenty files, so on white the yellow section headers and table headings washed out and the `Faint(true)` secondary text dropped below readable contrast. There was no central theme, and nothing ever told lipgloss the background color, so even the lone `AdaptiveColor` already in the tree silently always picked its dark variant.

This adds a `pkg/theme` package that owns the palette. It exposes semantic roles (Header, Success, Warning, Error, Info, Muted, Highlight) instead of raw indices, and resolves the right variant once at startup. Detection follows the usual conventions: `NO_COLOR`/`CLICOLOR=0` turn color off, `FORCE_COLOR`/`CLICOLOR_FORCE` turn it on, a `MIREN_THEME` env var or a `theme` field in `clientconfig.yaml` overrides everything, and otherwise it auto-detects from the terminal background (a `COLORFGBG` hint, then an OSC 11 query, then dark as the default). All the scattered call sites move onto the semantic roles, and `Faint(true)` becomes a real muted foreground, which is the biggest readability win on light backgrounds.

The roles are `CompleteAdaptiveColor`, so each carries explicit values per color profile: truecolor terminals get saturated jewel tones, and 256-color terminals get values pinned to xterm anchor indices so two distinct roles never quantize into the same bucket. Interactive terminals whose `TERM` this termenv build doesn't recognize (Ghostty over SSH, for one) floor to ANSI256 rather than rendering monochrome.

There's also a `miren debug colors` command that prints the resolved theme, detected background, active profile, and a swatch of every role, so a misdetection report comes with paste-able diagnostics.

Closes MIR-1312