### PR TITLE
Surface unreachable clusters in miren cluster add instead of silently hiding them

### DIFF
--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -32,6 +32,40 @@ type ClusterResponse struct {
 	OrganizationName  string                 `json:"organization_name"`
 }
 
+// hasReachableAddress reports whether the cloud advertised at least one API
+// address for this cluster. A cluster with none can't be dialed by any client,
+// so it would otherwise be silently hidden from `miren cluster add`. The most
+// common cause is a firewalled inbound port: miren connects over QUIC (UDP
+// 8443), and when the cloud's netcheck can't reach that port it drops the
+// discovered public IP, leaving the cluster advertising nothing. See MIR-1316.
+func (c ClusterResponse) hasReachableAddress() bool {
+	return len(c.APIAddresses) > 0
+}
+
+const (
+	// unreachableAddressNote is the short, inline note shown in listings next to
+	// a cluster that advertised no reachable API address.
+	unreachableAddressNote = "no reachable address"
+
+	// unreachableAddressHelp is the one-line remediation shown alongside that
+	// note. It names UDP 8443 specifically (miren dials over QUIC, so the UDP
+	// port is what's necessary and sufficient, not TCP) and points at the
+	// on-host diagnostic that reproduces the exact decision.
+	unreachableAddressHelp = "open UDP 8443 (QUIC) on the host or set additional_ips, then restart miren; run 'miren debug advertise' on the host to see why"
+)
+
+// printUnreachableClustersHelp prints a warning header, a bulleted list of the
+// given clusters, and the standard remediation guidance. Shared between the
+// cluster-add picker and login's auto-config so the two messages can't drift.
+func printUnreachableClustersHelp(ctx *Context, header string, clusters []ClusterResponse) {
+	ctx.Warn(header)
+	for _, cluster := range clusters {
+		ctx.Info("  • %s (%s)", cluster.Name, cluster.OrganizationName)
+	}
+	ctx.Info("")
+	ctx.Info("To connect: %s", unreachableAddressHelp)
+}
+
 // formatAddressWithGrayPort formats an address with the port portion grayed out
 func formatAddressWithGrayPort(address string) string {
 	host, port, err := net.SplitHostPort(address)
@@ -229,58 +263,37 @@ func fetchAvailableClusters(ctx *Context, config *clientconfig.Config, identity 
 	return response.Clusters, nil
 }
 
-// selectClusterFromList presents an interactive list of clusters for selection and prompts for local name
-// Returns the selected cluster and the local name to use
-func selectClusterFromList(ctx *Context, clusters []ClusterResponse) (*ClusterResponse, string, error) {
-	// Check if we can run interactive mode
-	if !ui.IsInteractive() {
-		// Non-interactive mode - list clusters and exit
-		ctx.Printf("Available clusters:\n\n")
-		clusterNum := 1
-		for _, cluster := range clusters {
-			if len(cluster.APIAddresses) == 0 {
-				continue // Skip clusters without API addresses
-			}
-
-			ctx.Printf("%d. Cluster: %s\n", clusterNum, cluster.Name)
-			ctx.Printf("   Organization: %s\n", cluster.OrganizationName)
-			if cluster.Description != "" {
-				ctx.Printf("   Description: %s\n", cluster.Description)
-			}
-			ctx.Printf("   API Addresses:\n")
-			for _, addr := range cluster.APIAddresses {
-				ctx.Printf("     - %s\n", addr)
-			}
-			if cluster.CACertFingerprint != "" {
-				ctx.Printf("   Certificate Fingerprint: %s\n", cluster.CACertFingerprint)
-			}
-			ctx.Printf("\n")
-			clusterNum++
-		}
-		ctx.Printf("Re-run with --cluster and --address flags to select a specific cluster\n")
-		return nil, "", fmt.Errorf("interactive mode not available")
-	}
-
-	// Create table picker items
-	items := make([]ui.PickerItem, 0, len(clusters))
-	clusterMap := make(map[string]*ClusterResponse)
+// buildClusterPickerItems turns the fetched clusters into picker rows. Every
+// cluster gets a row: reachable ones show their primary address (sorted so a
+// public address wins) and are selectable; unreachable ones (no advertised
+// address) show the reason inline and are marked disabled so the picker greys
+// them out and blocks selection. It returns the rows, a map from row ID back to
+// the source cluster, the set of disabled row IDs, and the count of selectable
+// (reachable) clusters. Kept pure so the classification is unit-testable
+// without standing up a TUI. See MIR-1316.
+func buildClusterPickerItems(clusters []ClusterResponse) (items []ui.PickerItem, clusterMap map[string]*ClusterResponse, disabled map[string]bool, reachableCount int) {
+	items = make([]ui.PickerItem, 0, len(clusters))
+	clusterMap = make(map[string]*ClusterResponse)
+	disabled = make(map[string]bool)
 
 	for i, cluster := range clusters {
-		if len(cluster.APIAddresses) == 0 {
-			continue // Skip clusters without API addresses
-		}
-
-		// Sort addresses to put localhost/0.0.0.0 last
-		addresses := sortAddresses(cluster.APIAddresses)
-
-		// Format primary address with grayed port
-		address := formatAddressWithGrayPort(addresses[0])
-		if len(addresses) > 1 {
-			address = fmt.Sprintf("%s (+%d)", address, len(addresses)-1)
-		}
-
-		// Create table item
 		itemID := fmt.Sprintf("cluster_%d", i)
+
+		var address string
+		if cluster.hasReachableAddress() {
+			reachableCount++
+			// Sort addresses to put localhost/0.0.0.0 last, then format the
+			// primary one with a grayed port.
+			addresses := sortAddresses(cluster.APIAddresses)
+			address = formatAddressWithGrayPort(addresses[0])
+			if len(addresses) > 1 {
+				address = fmt.Sprintf("%s (+%d)", address, len(addresses)-1)
+			}
+		} else {
+			address = unreachableAddressNote
+			disabled[itemID] = true
+		}
+
 		items = append(items, ui.TablePickerItem{
 			Columns: []string{
 				cluster.Name,
@@ -292,10 +305,63 @@ func selectClusterFromList(ctx *Context, clusters []ClusterResponse) (*ClusterRe
 		clusterMap[itemID] = &clusters[i]
 	}
 
+	return items, clusterMap, disabled, reachableCount
+}
+
+// selectClusterFromList presents an interactive list of clusters for selection and prompts for local name
+// Returns the selected cluster and the local name to use
+func selectClusterFromList(ctx *Context, clusters []ClusterResponse) (*ClusterResponse, string, error) {
+	// Check if we can run interactive mode
+	if !ui.IsInteractive() {
+		// Non-interactive mode - list clusters and exit. We list clusters with no
+		// reachable address too (annotated), rather than hiding them: a silently
+		// missing cluster reads as an auth/org problem and sends users chasing
+		// the wrong thing. See MIR-1316.
+		ctx.Printf("Available clusters:\n\n")
+		for clusterNum, cluster := range clusters {
+			ctx.Printf("%d. Cluster: %s\n", clusterNum+1, cluster.Name)
+			ctx.Printf("   Organization: %s\n", cluster.OrganizationName)
+			if cluster.Description != "" {
+				ctx.Printf("   Description: %s\n", cluster.Description)
+			}
+			if cluster.hasReachableAddress() {
+				ctx.Printf("   API Addresses:\n")
+				for _, addr := range cluster.APIAddresses {
+					ctx.Printf("     - %s\n", addr)
+				}
+				if cluster.CACertFingerprint != "" {
+					ctx.Printf("   Certificate Fingerprint: %s\n", cluster.CACertFingerprint)
+				}
+			} else {
+				ctx.Printf("   Status: %s — %s\n", unreachableAddressNote, unreachableAddressHelp)
+			}
+			ctx.Printf("\n")
+		}
+		ctx.Printf("Re-run with --cluster and --address flags to select a specific cluster\n")
+		return nil, "", fmt.Errorf("interactive mode not available")
+	}
+
+	// Build the picker rows. Clusters with no reachable address are listed too,
+	// but disabled (greyed out, not selectable) with the reason inline, rather
+	// than hidden — a silently missing cluster reads as an auth/org problem and
+	// sends users chasing the wrong thing. See MIR-1316.
+	items, clusterMap, disabled, reachableCount := buildClusterPickerItems(clusters)
+
+	// If nothing is selectable, a picker is a dead end. Print the clusters with
+	// their reason and return a clear error instead of trapping the user in a
+	// list where Enter does nothing.
+	if reachableCount == 0 {
+		printUnreachableClustersHelp(ctx, "None of your clusters advertise a reachable address:", clusters)
+		return nil, "", fmt.Errorf("no clusters with a reachable address")
+	}
+
 	// Run the table picker
 	selected, err := ui.RunPicker(items,
 		ui.WithTitle("Select a cluster to bind:"),
 		ui.WithHeaders([]string{"NAME", "ORGANIZATION", "ADDRESS"}),
+		ui.WithDisabledCheck(func(item ui.PickerItem) bool {
+			return disabled[item.ID()]
+		}, unreachableAddressHelp),
 	)
 
 	if err != nil {

--- a/cli/commands/config_bind_helpers_test.go
+++ b/cli/commands/config_bind_helpers_test.go
@@ -1,0 +1,129 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasReachableAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster ClusterResponse
+		want    bool
+	}{
+		{
+			name:    "has an address",
+			cluster: ClusterResponse{APIAddresses: []string{"1.2.3.4:8443"}},
+			want:    true,
+		},
+		{
+			name:    "has multiple addresses",
+			cluster: ClusterResponse{APIAddresses: []string{"1.2.3.4:8443", "[::1]:8443"}},
+			want:    true,
+		},
+		{
+			name:    "empty slice is unreachable",
+			cluster: ClusterResponse{APIAddresses: []string{}},
+			want:    false,
+		},
+		{
+			name:    "nil slice is unreachable",
+			cluster: ClusterResponse{},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cluster.hasReachableAddress())
+		})
+	}
+}
+
+func TestBuildClusterPickerItems(t *testing.T) {
+	t.Run("mixes reachable and unreachable clusters", func(t *testing.T) {
+		clusters := []ClusterResponse{
+			{Name: "club", OrganizationName: "Miren Club", APIAddresses: []string{"34.27.122.56:8443"}},
+			{Name: "oh-data", OrganizationName: "oh-data"}, // no address
+		}
+
+		items, clusterMap, disabled, reachableCount := buildClusterPickerItems(clusters)
+
+		// Every cluster gets a row — the unreachable one is shown, not hidden.
+		require.Len(t, items, 2)
+		assert.Equal(t, 1, reachableCount)
+
+		// The reachable cluster is selectable and shows its address.
+		reachableID := items[0].ID()
+		assert.False(t, disabled[reachableID])
+		assert.Contains(t, strings.Join(items[0].Row(), " "), "34.27.122.56")
+		assert.Same(t, &clusters[0], clusterMap[reachableID])
+
+		// The unreachable cluster is disabled with the reason inline.
+		unreachableID := items[1].ID()
+		assert.True(t, disabled[unreachableID])
+		assert.Contains(t, items[1].Row(), unreachableAddressNote)
+		assert.Same(t, &clusters[1], clusterMap[unreachableID])
+	})
+
+	t.Run("multiple addresses show a count suffix", func(t *testing.T) {
+		clusters := []ClusterResponse{
+			{Name: "multi", APIAddresses: []string{"1.1.1.1:8443", "2.2.2.2:8443"}},
+		}
+
+		items, _, disabled, reachableCount := buildClusterPickerItems(clusters)
+
+		require.Len(t, items, 1)
+		assert.Equal(t, 1, reachableCount)
+		assert.False(t, disabled[items[0].ID()])
+		assert.Contains(t, strings.Join(items[0].Row(), " "), "(+1)")
+	})
+
+	t.Run("all reachable leaves nothing disabled", func(t *testing.T) {
+		clusters := []ClusterResponse{
+			{Name: "a", APIAddresses: []string{"1.1.1.1:8443"}},
+			{Name: "b", APIAddresses: []string{"2.2.2.2:8443"}},
+		}
+
+		items, _, disabled, reachableCount := buildClusterPickerItems(clusters)
+
+		require.Len(t, items, 2)
+		assert.Equal(t, 2, reachableCount)
+		assert.Empty(t, disabled)
+	})
+
+	t.Run("all unreachable reports zero selectable", func(t *testing.T) {
+		clusters := []ClusterResponse{
+			{Name: "a"},
+			{Name: "b"},
+		}
+
+		items, _, disabled, reachableCount := buildClusterPickerItems(clusters)
+
+		require.Len(t, items, 2)
+		assert.Equal(t, 0, reachableCount)
+		assert.Len(t, disabled, 2)
+	})
+
+	t.Run("empty input yields empty rows", func(t *testing.T) {
+		items, clusterMap, disabled, reachableCount := buildClusterPickerItems(nil)
+
+		assert.Empty(t, items)
+		assert.Empty(t, clusterMap)
+		assert.Empty(t, disabled)
+		assert.Equal(t, 0, reachableCount)
+	})
+}
+
+// TestUnreachableRemediationMessaging guards the user-facing guidance against
+// silent drift: the QUIC/UDP-8443 emphasis and the on-host diagnostic pointer
+// are the whole point of MIR-1316, so keep them present.
+func TestUnreachableRemediationMessaging(t *testing.T) {
+	assert.Contains(t, unreachableAddressHelp, "UDP 8443")
+	assert.Contains(t, unreachableAddressHelp, "additional_ips")
+	assert.Contains(t, unreachableAddressHelp, "miren debug advertise")
+	assert.NotEmpty(t, unreachableAddressNote)
+}

--- a/cli/commands/config_bind_render_test.go
+++ b/cli/commands/config_bind_render_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/ui"
+)
+
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;:]*m`)
+
+func stripANSI(s string) string { return ansiRe.ReplaceAllString(s, "") }
+
+// TestClusterPickerRendersUnreachable drives the real ui.PickerModel with the
+// same disabled wiring selectClusterFromList uses, and asserts the rendered
+// view shows the unreachable cluster with its reason (rather than hiding it)
+// and surfaces the remediation when the cursor lands on it. This is the UX
+// MIR-1316 is about, so verify it end-to-end against the actual picker.
+func TestClusterPickerRendersUnreachable(t *testing.T) {
+	clusters := []ClusterResponse{
+		{Name: "club", OrganizationName: "Miren Club", APIAddresses: []string{"34.27.122.56:8443"}},
+		{Name: "oh-data", OrganizationName: "oh-data"}, // firewalled: no address
+	}
+
+	items, _, disabled, reachableCount := buildClusterPickerItems(clusters)
+	require.Equal(t, 1, reachableCount)
+
+	m := ui.NewPicker(items,
+		ui.WithTitle("Select a cluster to bind:"),
+		ui.WithHeaders([]string{"NAME", "ORGANIZATION", "ADDRESS"}),
+		ui.WithDisabledCheck(func(item ui.PickerItem) bool {
+			return disabled[item.ID()]
+		}, unreachableAddressHelp),
+	)
+
+	// Cursor on the reachable row: both clusters visible, no warning shown yet.
+	view := stripANSI(m.View())
+	assert.Contains(t, view, "club")
+	assert.Contains(t, view, "oh-data")
+	assert.Contains(t, view, unreachableAddressNote)
+	assert.NotContains(t, view, unreachableAddressHelp)
+
+	// Move the cursor onto the disabled (unreachable) row: the remediation
+	// message appears.
+	m.SetCursor(1)
+	view = stripANSI(m.View())
+	assert.Contains(t, view, unreachableAddressHelp)
+}

--- a/cli/commands/login.go
+++ b/cli/commands/login.go
@@ -682,16 +682,24 @@ func autoConfigureCluster(ctx *Context, identityName, cloudURL string, keyPair *
 		return fmt.Errorf("failed to fetch available clusters: %w", err)
 	}
 
-	// Filter out clusters without API addresses
+	// Only clusters with a reachable address can be auto-configured.
 	var validClusters []ClusterResponse
 	for _, cluster := range clusters {
-		if len(cluster.APIAddresses) > 0 {
+		if cluster.hasReachableAddress() {
 			validClusters = append(validClusters, cluster)
 		}
 	}
 
 	if len(validClusters) == 0 {
-		ctx.Info("No clusters available for your account")
+		if len(clusters) == 0 {
+			ctx.Info("No clusters available for your account")
+		} else {
+			// Clusters exist but none advertise a reachable address — the common
+			// firewalled-inbound-port case. Say so honestly instead of implying the
+			// account has nothing, which sends users chasing an auth/org red
+			// herring. See MIR-1316.
+			printUnreachableClustersHelp(ctx, fmt.Sprintf("Found %d cluster(s), but none advertise a reachable address:", len(clusters)), clusters)
+		}
 		return ErrNoAutoConfigNeeded
 	}
 


### PR DESCRIPTION
A user spun up a fresh self-hosted cluster and hit a wall. It registered cleanly, showed up green in the miren.cloud dashboard, and heartbeated every five minutes as `active`. But it never appeared in `miren cluster add`, with no error and no explanation. We spent a good chunk of a debugging session ruling out identity, org scoping, and token caching before finding the real cause: the box had a firewalled inbound port.

miren connects over QUIC (UDP 8443). When the cloud's netcheck can't reach that port, the server correctly decides not to advertise an address no client could dial, so it reports zero API addresses. From there the CLI took over the disappearing act: `miren cluster add` filtered out any cluster with no addresses, and `miren login`'s auto-config path reported "No clusters available for your account." Each individual step is defensible, but the sum is a silent black hole that points users squarely at an auth problem that doesn't exist.

This stops the hiding. Zero-address clusters now show up wherever you'd look for them. The interactive picker lists them disabled (greyed out and unselectable) with "no reachable address" inline and the fix in the footer; the non-interactive listing annotates them the same way; and login now tells the difference between "you have no clusters" and "you have clusters but none are reachable right now." The guidance is specific on purpose: it names UDP 8443 (QUIC is both necessary and sufficient, TCP isn't the thing), mentions the `additional_ips` escape hatch, and points at `miren debug advertise`, which reproduces the exact advertise decision on the host.

This is the first, self-contained slice of a larger fix tracked in MIR-1316. The CLI can only say "no reachable address" generically today because the cloud hands it an empty address list with no reason attached. Later tiers teach the cloud and dashboard to report reachability honestly (the dashboard's current "Connected" indicator is wired to a separate liveness signal, so a firewalled box shows green while being un-addable) and to name the exact blocked port and family, so the message can sharpen to "found 203.0.113.10 but couldn't reach UDP 8443" without leaving your laptop.

Part of MIR-1316.