### PR TITLE
Fix session index-entry leak and patch validation over stale references

### DIFF
--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -219,7 +219,7 @@ func (s *EtcdStore) CreateEntity(
 	var coltxopt []clientv3.Op
 	for _, attrs := range indexedAttrs {
 		for _, attr := range attrs {
-			coltxopt = append(coltxopt, s.addToCollectionOp(entity, attr.CAS()))
+			coltxopt = append(coltxopt, s.addToCollectionOp(entity, attr.CAS(), plainIndexLease(o.bind, sid)))
 
 			if sessPart != "" {
 				coltxopt = append(coltxopt, s.addToCollectionSessionOp(entity, attr.CAS(), sessPart, sid))
@@ -356,7 +356,7 @@ func (s *EtcdStore) CreateEntity(
 		coltxopt = coltxopt[:0]
 		for _, attrs := range indexedAttrs {
 			for _, attr := range attrs {
-				coltxopt = append(coltxopt, s.addToCollectionOp(entity, attr.CAS()))
+				coltxopt = append(coltxopt, s.addToCollectionOp(entity, attr.CAS(), plainIndexLease(o.bind, sid)))
 				if sessPart != "" {
 					coltxopt = append(coltxopt, s.addToCollectionSessionOp(entity, attr.CAS(), sessPart, sid))
 				}
@@ -708,7 +708,11 @@ func (s *EtcdStore) UpdateEntity(
 	// Revision is a store-maintained attr, so we remove it from the changes.
 	entity.Remove(Revision)
 
-	err = s.validator.ValidateAttributes(ctx, entity.attrs)
+	// An update only owns the attributes it sets. Exempt unchanged references
+	// from the existence check so a pre-existing reference whose target was
+	// deleted out from under the entity can't block an unrelated change. See
+	// MIR-1320.
+	err = s.validator.ValidateUpdate(ctx, entity.attrs, originalEntity.attrs)
 	if err != nil {
 		return nil, err
 	}
@@ -723,38 +727,15 @@ func (s *EtcdStore) UpdateEntity(
 		sessPart = base58.Encode(o.session)
 	}
 
-	var coltxopt []clientv3.Op
-
 	// Separate attributes into primary and session, and collect indexed attributes (including nested ones)
 	primary, session, newIndexedAttrs, err := s.separateSessionAttributes(ctx, entity.attrs)
 	if err != nil {
 		return nil, err
 	}
 
-	// Compare old and new indexed attributes and only update collections when values change
-	for attrID, oldAttrs := range originalIndexedAttrs {
-		newAttrs := newIndexedAttrs[attrID]
-
-		// Remove old attributes that are no longer present or have changed values
-		for _, oldAttr := range oldAttrs {
-			found := slices.ContainsFunc(newAttrs, oldAttr.Equal)
-			if !found {
-				coltxopt = append(coltxopt, s.deleteFromCollectionOp(entity, oldAttr.CAS()))
-			}
-		}
-	}
-
-	// All new indexed attributes should update their respective indexes so any watchers will get notified
-	for _, newAttrs := range newIndexedAttrs {
-		for _, newAttr := range newAttrs {
-			coltxopt = append(coltxopt, s.addToCollectionOp(entity, newAttr.CAS()))
-			// And if this is a session-bound update, add a subordinate index entry
-			// so that watchers will be updated when the lease expires
-			if sessPart != "" {
-				coltxopt = append(coltxopt, s.addToCollectionSessionOp(entity, newAttr.CAS(), sessPart, sid))
-			}
-		}
-	}
+	// Reindex changed attributes via the shared helper so the lease and watcher
+	// semantics stay in one place (also used by ReplaceEntity/PatchEntity).
+	coltxopt := s.buildCollectionOps(entity, originalIndexedAttrs, newIndexedAttrs, sessPart, sid, o.bind)
 
 	// Build unique-value update operations (release old, claim new)
 	uniqueOps, uniqueConditions, err := s.buildUniqueUpdateOps(ctx, entity.Id(), originalEntity, entity)
@@ -904,7 +885,7 @@ func (s *EtcdStore) separateSessionAttributes(ctx context.Context, attrs []Attr)
 }
 
 // buildCollectionOps builds etcd operations for updating indexed attribute collections
-func (s *EtcdStore) buildCollectionOps(entity *Entity, originalIndexedAttrs, newIndexedAttrs map[Id][]Attr, sessPart string, sid int64) []clientv3.Op {
+func (s *EtcdStore) buildCollectionOps(entity *Entity, originalIndexedAttrs, newIndexedAttrs map[Id][]Attr, sessPart string, sid int64, bind bool) []clientv3.Op {
 	var ops []clientv3.Op
 
 	// Remove old indexed attributes that are no longer present or have changed
@@ -921,7 +902,7 @@ func (s *EtcdStore) buildCollectionOps(entity *Entity, originalIndexedAttrs, new
 	// Add all new indexed attributes
 	for _, newAttrs := range newIndexedAttrs {
 		for _, newAttr := range newAttrs {
-			ops = append(ops, s.addToCollectionOp(entity, newAttr.CAS()))
+			ops = append(ops, s.addToCollectionOp(entity, newAttr.CAS(), plainIndexLease(bind, sid)))
 			if sessPart != "" {
 				ops = append(ops, s.addToCollectionSessionOp(entity, newAttr.CAS(), sessPart, sid))
 			}
@@ -1068,8 +1049,10 @@ func (s *EtcdStore) ReplaceEntity(
 	// Revision is a store-maintained attr, so we remove it from the replacement.
 	repl.Remove(Revision)
 
-	// Validate replacement attributes
-	if err := s.validator.ValidateAttributes(ctx, repl.attrs); err != nil {
+	// Validate replacement attributes. A replace only owns the references it
+	// sets: a reference carried over unchanged from the existing entity must not
+	// fail the existence check just because its target was deleted. See MIR-1320.
+	if err := s.validator.ValidateUpdate(ctx, repl.attrs, originalEntity.attrs); err != nil {
 		return nil, err
 	}
 
@@ -1086,7 +1069,7 @@ func (s *EtcdStore) ReplaceEntity(
 		sid, _ = binary.Varint(o.session)
 		sessPart = base58.Encode(o.session)
 	}
-	coltxopt := s.buildCollectionOps(repl, originalIndexedAttrs, newIndexedAttrs, sessPart, sid)
+	coltxopt := s.buildCollectionOps(repl, originalIndexedAttrs, newIndexedAttrs, sessPart, sid, o.bind)
 
 	// Build unique-value update operations (release old, claim new)
 	uniqueOps, uniqueConditions, err := s.buildUniqueUpdateOps(ctx, repl.Id(), originalEntity, repl)
@@ -1205,7 +1188,11 @@ func (s *EtcdStore) PatchEntity(
 	// Revision is a store-maintained attr, so we remove it from the changes.
 	entity.Remove(Revision)
 
-	err = s.validator.ValidateAttributes(ctx, entity.attrs)
+	// A patch only owns the attributes it sets. Exempt unchanged references from
+	// the existence check so a pre-existing reference whose target was deleted
+	// out from under the entity can't block an unrelated change (e.g. a
+	// status-only patch). See MIR-1320.
+	err = s.validator.ValidateUpdate(ctx, entity.attrs, originalEntity.attrs)
 	if err != nil {
 		return nil, err
 	}
@@ -1239,7 +1226,7 @@ func (s *EtcdStore) PatchEntity(
 		sid, _ = binary.Varint(o.session)
 		sessPart = base58.Encode(o.session)
 	}
-	coltxopt := s.buildCollectionOps(entity, originalIndexedAttrs, newIndexedAttrs, sessPart, sid)
+	coltxopt := s.buildCollectionOps(entity, originalIndexedAttrs, newIndexedAttrs, sessPart, sid, o.bind)
 
 	// Build unique-value update operations (release old, claim new)
 	uniqueOps, uniqueConditions, err := s.buildUniqueUpdateOps(ctx, entity.Id(), originalEntity, entity)
@@ -1442,12 +1429,30 @@ func (s *EtcdStore) addToCollectionSessionOp(entity *Entity, collection, suffix 
 	return clientv3.OpPut(key, entity.Id().String(), clientv3.WithLease(clientv3.LeaseID(sid)))
 }
 
-func (s *EtcdStore) addToCollectionOp(entity *Entity, collection string) clientv3.Op {
+// plainIndexLease returns the lease that an entity's plain (durable) index
+// entries should carry. When the entity key itself is leased to a session
+// (BondToSession sets bind), its index entries must share that lease so etcd
+// garbage-collects them atomically with the entity. Otherwise the unleased
+// index entry outlives the entity when the session lease expires, leaving a
+// stale "phantom" index entry pointing at a deleted entity. For unbound
+// (durable) entities this returns NoLease so the index entry stays durable and
+// is cleaned up by DeleteEntity. See MIR-1320.
+func plainIndexLease(bind bool, sid int64) clientv3.LeaseID {
+	if bind {
+		return clientv3.LeaseID(sid)
+	}
+	return clientv3.NoLease
+}
+
+func (s *EtcdStore) addToCollectionOp(entity *Entity, collection string, lease clientv3.LeaseID) clientv3.Op {
 	key := base58.Encode([]byte(entity.Id()))
 	colKey := tr.Replace(collection)
 
 	key = fmt.Sprintf("%s/collections/%s/%s", s.prefix, colKey, key)
 
+	if lease != clientv3.NoLease {
+		return clientv3.OpPut(key, entity.Id().String(), clientv3.WithLease(lease))
+	}
 	return clientv3.OpPut(key, entity.Id().String())
 }
 

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -2490,3 +2490,217 @@ func TestEtcdStore_PingSessionAfterLeaseGone(t *testing.T) {
 	r.Contains(err.Error(), "lease not found",
 		"error wording is load-bearing: entityserver.isLeaseGone matches this substring")
 }
+
+// collectionKVsForEntity returns every /collections/ entry whose value points at
+// the given entity id, exposing each KV's attached etcd Lease. Used to assert
+// whether an entity's index entries share its session lease (MIR-1320).
+func collectionKVsForEntity(t *testing.T, client *clientv3.Client, prefix string, id Id) []*mvccpb.KeyValue {
+	t.Helper()
+	resp, err := client.Get(context.Background(), prefix+"/collections/", clientv3.WithPrefix())
+	require.NoError(t, err)
+	var out []*mvccpb.KeyValue
+	for _, kv := range resp.Kvs {
+		if string(kv.Value) == id.String() {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+// TestEtcdStore_BoundEntityIndexEntriesShareSessionLease is the MIR-1320
+// regression at the store layer. A session-bound entity (BondToSession leases
+// the entity key itself) must have its plain index entries leased to the same
+// session, so etcd garbage-collects them atomically with the entity when the
+// lease is revoked or expires. Before the fix the plain index entry was written
+// unleased and outlived the entity, leaving a stale index entry pointing at a
+// deleted entity — which on one production cluster accumulated to the point
+// where 88% of "pool" and 98% of "session" index entries were phantoms.
+func TestEtcdStore_BoundEntityIndexEntriesShareSessionLease(t *testing.T) {
+	store, client := setupTestEtcdStore(t)
+	ctx := t.Context()
+	r := require.New(t)
+
+	// An indexed attribute so entities produce collection (index) entries.
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	r.NoError(err)
+
+	// A durable (unbound) entity: its index entry must stay UNLEASED so it
+	// remains durable and is removed only by an explicit delete.
+	durable, err := store.CreateEntity(ctx, New(
+		Ident, "durable-1",
+		String(Id("test/kind"), "widget"),
+	))
+	r.NoError(err)
+	durableKVs := collectionKVsForEntity(t, client, store.Prefix(), durable.Id())
+	r.NotEmpty(durableKVs, "durable entity must have an index entry")
+	for _, kv := range durableKVs {
+		r.Zero(kv.Lease, "durable entity's index entry %q must not be leased", kv.Key)
+	}
+
+	// A session-bound entity: BondToSession leases the entity key, so its
+	// index entries must carry a lease too.
+	sid, err := store.CreateSession(ctx, 30)
+	r.NoError(err)
+
+	bound, err := store.CreateEntity(ctx, New(
+		Ident, "bound-1",
+		String(Id("test/kind"), "widget"),
+	), BondToSession(sid))
+	r.NoError(err)
+
+	boundKVs := collectionKVsForEntity(t, client, store.Prefix(), bound.Id())
+	r.NotEmpty(boundKVs, "bound entity must have index entries")
+	for _, kv := range boundKVs {
+		r.NotZero(kv.Lease,
+			"bound entity's index entry %q must share the session lease (MIR-1320)", kv.Key)
+	}
+
+	// Both entities are indexed while the session is alive.
+	ids, err := store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	r.NoError(err)
+	r.Contains(ids, durable.Id())
+	r.Contains(ids, bound.Id())
+
+	// End the session: etcd revokes the lease and drops every attached key,
+	// including the bound entity and — with the fix — its index entries.
+	r.NoError(store.RevokeSession(ctx, sid))
+
+	// The bound entity is gone...
+	_, err = store.GetEntity(ctx, bound.Id())
+	r.Error(err, "bound entity must be removed when its session lease is revoked")
+
+	// ...and no stale index entry outlives it.
+	r.Empty(collectionKVsForEntity(t, client, store.Prefix(), bound.Id()),
+		"no index entry may outlive a bound entity's session lease (MIR-1320)")
+
+	// The durable entity and its index entry are untouched.
+	_, err = store.GetEntity(ctx, durable.Id())
+	r.NoError(err)
+	ids, err = store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	r.NoError(err)
+	r.Equal([]Id{durable.Id()}, ids)
+}
+
+// TestEtcdStore_PatchStatusToleratesDanglingRef is the MIR-1320 general-invariant
+// test: a patch owns only the attributes it sets. When an entity holds a
+// reference to something later deleted out from under it, an unrelated change
+// (like a status patch) must still succeed. A brand-new dangling reference must
+// still be rejected. Before the fix, PatchEntity re-validated the whole merged
+// entity, so any dangling reference made every patch fail and any controller
+// reconciling the entity looped forever (the disk-lease orphan sweeper).
+func TestEtcdStore_PatchStatusToleratesDanglingRef(t *testing.T) {
+	store, _ := setupTestEtcdStore(t)
+	ctx := t.Context()
+	r := require.New(t)
+
+	// A reference attribute (like disk_lease.disk_id) and a plain status.
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/target-ref",
+		Doc, "a reference to another entity",
+		Cardinality, CardinalityOne,
+		Type, TypeRef,
+	))
+	r.NoError(err)
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "test/status",
+		Doc, "a status",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+	))
+	r.NoError(err)
+
+	// The referenced entity, and an entity referencing it with a status.
+	target, err := store.CreateEntity(ctx, New(Any(Ident, KeywordValue("target/thing"))))
+	r.NoError(err)
+	holder, err := store.CreateEntity(ctx, New(
+		Any(Ident, KeywordValue("holder/thing")),
+		Ref(Id("test/target-ref"), target.Id()),
+		String(Id("test/status"), "bound"),
+	))
+	r.NoError(err)
+
+	// The target is deleted out from under the holder.
+	r.NoError(store.DeleteEntity(ctx, target.Id()))
+
+	// A status-only patch must still succeed even though test/target-ref now
+	// dangles. Before the fix this failed with "references a non-existent entity".
+	_, err = store.PatchEntity(ctx, New(
+		DBId, holder.Id(),
+		String(Id("test/status"), "released"),
+	))
+	r.NoError(err, "status patch must tolerate a pre-existing dangling reference (MIR-1320)")
+
+	got, err := store.GetEntity(ctx, holder.Id())
+	r.NoError(err)
+	statusAttr, ok := got.Get(Id("test/status"))
+	r.True(ok)
+	r.Equal("released", statusAttr.Value.Any())
+
+	// But setting a brand-new reference to a non-existent entity is still rejected.
+	_, err = store.PatchEntity(ctx, New(
+		DBId, holder.Id(),
+		Ref(Id("test/target-ref"), Id("target/does-not-exist")),
+	))
+	r.Error(err, "setting a new dangling reference must still be rejected")
+}
+
+// TestEtcdStore_PatchToleratesDanglingRefInComponent covers the component-nested
+// case of the MIR-1320 exemption: a reference living inside an unchanged
+// component attribute must also be exempt from re-validation on a patch, or a
+// status change would fail once the component's nested target is deleted.
+func TestEtcdStore_PatchToleratesDanglingRefInComponent(t *testing.T) {
+	store, _ := setupTestEtcdStore(t)
+	ctx := t.Context()
+	r := require.New(t)
+
+	// A component type with a nested reference field, plus a plain status.
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/spec",
+		Doc, "a component type",
+		Cardinality, CardinalityOne,
+		Type, TypeComponent,
+	))
+	r.NoError(err)
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "test/spec.target",
+		Doc, "a nested reference field",
+		Cardinality, CardinalityOne,
+		Type, TypeRef,
+	))
+	r.NoError(err)
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "test/status",
+		Doc, "a status",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+	))
+	r.NoError(err)
+
+	target, err := store.CreateEntity(ctx, New(Any(Ident, KeywordValue("target/comp"))))
+	r.NoError(err)
+	holder, err := store.CreateEntity(ctx, New([]Attr{
+		Keyword(Ident, "holder-comp"),
+		Component(Id("test/spec"), []Attr{
+			Ref(Id("test/spec.target"), target.Id()),
+		}),
+		String(Id("test/status"), "bound"),
+	}))
+	r.NoError(err)
+
+	// Delete the entity referenced from inside the component.
+	r.NoError(store.DeleteEntity(ctx, target.Id()))
+
+	// A status patch must still succeed even though the unchanged component now
+	// holds a dangling nested reference the patch never touches (MIR-1320).
+	_, err = store.PatchEntity(ctx, New(
+		DBId, holder.Id(),
+		String(Id("test/status"), "released"),
+	))
+	r.NoError(err, "status patch must tolerate a dangling ref nested in an unchanged component")
+}

--- a/pkg/entity/validation.go
+++ b/pkg/entity/validation.go
@@ -148,12 +148,51 @@ func (v *Validator) ValidateEntity(ctx context.Context, entity *Entity) error {
 }
 
 func (v *Validator) ValidateAttributes(ctx context.Context, attrs []Attr) error {
+	return v.validateAttributes(ctx, attrs, nil)
+}
+
+// ValidateUpdate validates the merged attributes of an update or patch. It
+// behaves like ValidateAttributes but skips the reference-existence check for
+// any reference attribute whose value is unchanged from the original entity.
+//
+// A patch is only responsible for the references it sets. A reference that was
+// already present and valid, whose target has since been deleted out from under
+// the entity, must not block an unrelated change such as a status-only patch.
+// Otherwise an entity holding a now-dangling reference becomes impossible to
+// patch at all, and any controller reconciling it spins forever. See MIR-1320.
+func (v *Validator) ValidateUpdate(ctx context.Context, newAttrs, originalAttrs []Attr) error {
+	return v.validateAttributes(ctx, newAttrs, exemptUnchangedRefs(originalAttrs))
+}
+
+// refExemptFn reports whether the reference-existence check for a given
+// attribute should be skipped. A nil predicate checks every reference, which is
+// the correct behavior for creates.
+type refExemptFn func(attr Attr) bool
+
+// exemptUnchangedRefs returns a predicate that exempts reference attributes
+// appearing unchanged (same id and value) in the original attribute set.
+func exemptUnchangedRefs(original []Attr) refExemptFn {
+	byID := make(map[Id][]Attr, len(original))
+	for _, a := range original {
+		byID[a.ID] = append(byID[a.ID], a)
+	}
+	return func(attr Attr) bool {
+		for _, o := range byID[attr.ID] {
+			if o.Equal(attr) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func (v *Validator) validateAttributes(ctx context.Context, attrs []Attr, exempt refExemptFn) error {
 	// Check them one-off...
 
 	count := make(map[Id]int)
 	for i, attr := range attrs {
 		count[attr.ID]++
-		if err := v.ValidateAttribute(ctx, &attr); err != nil {
+		if err := v.validateAttribute(ctx, &attr, exempt); err != nil {
 			return err
 		}
 
@@ -178,6 +217,10 @@ func (v *Validator) ValidateAttributes(ctx context.Context, attrs []Attr) error 
 
 // ValidateAttribute validates a single attribute against its schema
 func (v *Validator) ValidateAttribute(ctx context.Context, attr *Attr) error {
+	return v.validateAttribute(ctx, attr, nil)
+}
+
+func (v *Validator) validateAttribute(ctx context.Context, attr *Attr, exempt refExemptFn) error {
 	name := attr.ID
 
 	if name == DBId {
@@ -248,7 +291,7 @@ func (v *Validator) ValidateAttribute(ctx context.Context, attr *Attr) error {
 		if !ok {
 			return fmt.Errorf("attribute %s must be a string representing an entity ID", name)
 		}
-		if str != "" {
+		if str != "" && (exempt == nil || !exempt(*attr)) {
 			if _, err := v.store.GetEntity(ctx, str); err != nil {
 				return fmt.Errorf("attribute %s references a non-existent entity: %w", name, err)
 			}
@@ -284,8 +327,11 @@ func (v *Validator) ValidateAttribute(ctx context.Context, attr *Attr) error {
 			return fmt.Errorf("attribute %s must be an array", name)
 		}
 
+		// If the whole array attribute is unchanged, don't re-check the
+		// existence of the references it contains (see ValidateUpdate).
+		skipRefCheck := exempt != nil && exempt(*attr)
 		for i, elem := range tuple {
-			if err := v.validateToType(ctx, elem, schema.ElemType); err != nil {
+			if err := v.validateToType(ctx, elem, schema.ElemType, skipRefCheck); err != nil {
 				return fmt.Errorf("attribute %s[%d]: %w", name, i, err)
 			}
 		}
@@ -300,7 +346,15 @@ func (v *Validator) ValidateAttribute(ctx context.Context, attr *Attr) error {
 		}
 
 		comp := attr.Value.Component()
-		err := v.ValidateAttributes(ctx, comp.attrs)
+		// If the whole component attribute is unchanged, don't re-check the
+		// existence of the references nested inside it. The top-level exempt
+		// predicate is keyed on top-level attributes and never matches nested
+		// ones, so mirror the TypeArray handling and exempt the whole component.
+		compExempt := exempt
+		if exempt != nil && exempt(*attr) {
+			compExempt = func(Attr) bool { return true }
+		}
+		err := v.validateAttributes(ctx, comp.attrs, compExempt)
 		if err != nil {
 			return fmt.Errorf("attribute %s must be a valid component: %w", name, err)
 		}
@@ -355,8 +409,10 @@ func (v *Validator) ValidateAttribute(ctx context.Context, attr *Attr) error {
 	return nil
 }
 
-// ValidateAttribute validates a single attribute against its schema
-func (v *Validator) validateToType(ctx context.Context, val any, typ Id) error {
+// validateToType validates a single value against a type. skipRefCheck omits
+// the reference-existence check, used when the containing attribute is unchanged
+// on an update (see ValidateUpdate).
+func (v *Validator) validateToType(ctx context.Context, val any, typ Id, skipRefCheck bool) error {
 	// Validate value based on type
 	switch typ {
 	case TypeKeyword, TypeStr:
@@ -387,7 +443,7 @@ func (v *Validator) validateToType(ctx context.Context, val any, typ Id) error {
 		if !ok {
 			return fmt.Errorf("value must be a string representing an entity ID")
 		}
-		if str != "" {
+		if str != "" && !skipRefCheck {
 			if _, err := v.store.GetEntity(ctx, str); err != nil {
 				return fmt.Errorf("value references a non-existent entity: %w", err)
 			}

--- a/pkg/entity/validation_test.go
+++ b/pkg/entity/validation_test.go
@@ -286,7 +286,7 @@ func TestValidateToType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validator.validateToType(t.Context(), tt.value, tt.typ)
+			err := validator.validateToType(t.Context(), tt.value, tt.typ, false)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
Baking sagas on garden turned up a persistent error loop that traced back to two independent entity-store bugs, both about the correctness of the index and patch paths. This fixes both. (The larger `pool`-kind index leak from the same investigation is a separate concurrency bug in `DeleteEntity` and gets its own follow-up; this PR is the session-leak and sweeper-loop half.)

**Session-bound entities were leaking index entries.** When an entity's key is leased to a session (`BondToSession`), etcd drops the key when the lease expires. But the plain kind-index entry we write alongside it carried no lease, so it outlived the entity it pointed at. With sessions cycling roughly every 60 seconds, these orphaned entries accumulated fast: on garden, 98% of `session` index entries pointed at entities that no longer existed. The fix leases the plain index entry with the same session lease whenever the entity key itself is leased, so etcd garbage-collects them together. Durable (unleased) entities are untouched and still cleaned up by `DeleteEntity`.

**Patches were choking on pre-existing dangling references.** `PatchEntity` (and `UpdateEntity`/`ReplaceEntity`) re-validated the whole merged entity, including a reference-existence check on attributes the change never touched. So once an entity held a reference to something later deleted out from under it, *every* patch failed, and any controller reconciling that entity looped forever. The disk-lease orphan sweeper is where this surfaced: it couldn't patch an orphaned lease to `RELEASED` because the lease's disk had been deleted, so it retried every five minutes for days. The general fix is that a mutation only owns the attributes it sets, so unchanged references are exempt from the existence check. Creates, and any new or changed reference, are still fully validated. With this in place the sweeper's ordinary release path just works, so no sweeper-specific change is needed.

Both fixes are covered by etcd-backed tests that fail without the change: one asserts a bound entity's index entries share its session lease and vanish when the lease is revoked, the other that a status patch tolerates a pre-existing dangling reference while a brand-new one is still rejected.

Relates to MIR-1320.
