### PR TITLE
Auto-tune etcd config to system RAM

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -341,18 +341,23 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	// etcdTLSSetup holds etcd TLS configuration when distributed runners is enabled
 	var etcdTLSSetup *coordinate.EtcdTLSSetupResult
 
+	// etcdComponent is hoisted so the metrics writer can be attached later, once the
+	// metrics subsystem is initialized (which happens after etcd has started).
+	var etcdComponent *etcd.EtcdComponent
+
 	// Start embedded etcd server if requested
 	if cfg.Etcd.GetStartEmbedded() {
 		ctx.Log.Info("starting embedded etcd server", "client-port", cfg.Etcd.GetClientPort(), "peer-port", cfg.Etcd.GetPeerPort())
 
-		etcdComponent := etcd.NewEtcdComponent(ctx.Log, ctx.ServerState.CC, ctx.ServerState.Namespace, cfg.Server.GetDataPath())
+		etcdComponent = etcd.NewEtcdComponent(ctx.Log, ctx.ServerState.CC, ctx.ServerState.Namespace, cfg.Server.GetDataPath())
 
 		etcdConfig := etcd.EtcdConfig{
-			Name:           "miren-etcd",
-			ClientPort:     cfg.Etcd.GetClientPort(),
-			HTTPClientPort: cfg.Etcd.GetHTTPClientPort(),
-			PeerPort:       cfg.Etcd.GetPeerPort(),
-			ClusterState:   "new",
+			Name:              "miren-etcd",
+			ClientPort:        cfg.Etcd.GetClientPort(),
+			HTTPClientPort:    cfg.Etcd.GetHTTPClientPort(),
+			PeerPort:          cfg.Etcd.GetPeerPort(),
+			ClusterState:      "new",
+			QuotaBackendBytes: int64(cfg.Etcd.GetQuotaBackendBytes()),
 		}
 
 		// Set up etcd TLS when distributed runners feature is enabled
@@ -554,6 +559,13 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	// Initialize metrics components via ServerState
 	ctx.ServerState.InitMetricsWriter(ctx.Log)
 	ctx.ServerState.InitMetricsReader(ctx.Log)
+
+	// The metrics writer only exists now (it needs the VictoriaMetrics address), after
+	// etcd and its maintenance loop have already started; attach it so the loop can emit
+	// etcd health gauges. The loop reads the writer atomically each tick.
+	if etcdComponent != nil {
+		etcdComponent.SetMetricsWriter(ctx.ServerState.Writer)
+	}
 
 	// Create CPU and memory usage monitors
 	cpu := metrics.NewCPUUsage(ctx.Log, ctx.ServerState.Writer, ctx.ServerState.Reader)

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -43,7 +43,9 @@ type etcdState struct {
 
 // currentConfigVersion should be bumped whenever the container spec changes
 // (new env vars, different args, etc.) so that upgrades recreate the container.
-const currentConfigVersion = 1
+//
+// v2: memory auto-tuning — etcd flags/env are now scaled to system RAM.
+const currentConfigVersion = 2
 
 // TLSConfig holds TLS certificate paths for etcd mTLS.
 // When configured, etcd will require client certificate authentication.
@@ -369,6 +371,21 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 		scheme = "https"
 	}
 
+	// Scale etcd's memory-related config to the size of the node it runs on so it
+	// behaves as a ~10%-of-RAM co-tenant rather than growing to fill the node.
+	tuning := computeTuning(detectSystemRAMBytes())
+	e.Log.Info("etcd memory auto-tuning",
+		"system_ram_bytes", tuning.SystemRAMBytes,
+		"budget_bytes", tuning.BudgetBytes,
+		"quota_backend_bytes", tuning.QuotaBackendBytes,
+		"gomemlimit_bytes", tuning.GoMemLimitBytes,
+		"gogc", tuning.GOGC,
+		"auto_compaction_retention", tuning.AutoCompactionReten,
+		"snapshot_count", tuning.SnapshotCount,
+		"snapshot_catchup_entries", tuning.SnapshotCatchupEntries,
+		"max_concurrent_streams", tuning.MaxConcurrentStreams,
+		"compaction_batch_limit", tuning.CompactionBatchLimit)
+
 	args := []string{
 		"/usr/local/bin/etcd",
 		"--name", config.Name,
@@ -381,6 +398,8 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 		"--initial-cluster", fmt.Sprintf("%s=http://localhost:%d", config.Name, config.PeerPort),
 		"--initial-cluster-state", config.ClusterState,
 	}
+
+	args = append(args, tuning.args()...)
 
 	if config.InitialToken != "" {
 		args = append(args, "--initial-cluster-token", config.InitialToken)
@@ -423,11 +442,7 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 		oci.WithHostHostsFile,
 		oci.WithHostResolvconf,
 		oci.WithProcessArgs(args...),
-		oci.WithEnv([]string{
-			"ETCD_AUTO_COMPACTION_MODE=periodic",
-			"ETCD_AUTO_COMPACTION_RETENTION=1h",
-			"ETCD_EXPERIMENTAL_BACKEND_BBOLT_FREELIST_TYPE=map",
-		}),
+		oci.WithEnv(tuning.envVars()),
 		oci.WithMounts(mounts),
 	}
 

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -37,8 +37,9 @@ var (
 // etcdState tracks the configuration state of the etcd container.
 // This is persisted to detect when configuration changes require container recreation.
 type etcdState struct {
-	TLSEnabled    bool `json:"tls_enabled"`
-	ConfigVersion int  `json:"config_version"`
+	TLSEnabled      bool   `json:"tls_enabled"`
+	ConfigVersion   int    `json:"config_version"`
+	TuningSignature string `json:"tuning_signature,omitempty"`
 }
 
 // currentConfigVersion should be bumped whenever the container spec changes
@@ -155,6 +156,11 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 		return fmt.Errorf("failed to create data directory: %w", err)
 	}
 
+	// Scale etcd's memory-related config to the size of the node it runs on so it
+	// behaves as a ~10%-of-RAM co-tenant rather than growing to fill the node.
+	tuning := computeTuning(detectSystemRAMBytes())
+	tuningSignature := tuning.signature()
+
 	// Check if the container config has changed since last start. If so, we
 	// must recreate the container since env vars and args are baked into the spec.
 	requestedTLSEnabled := config.TLS != nil
@@ -167,7 +173,8 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 		configChanged = requestedTLSEnabled
 	} else {
 		configChanged = prevState.TLSEnabled != requestedTLSEnabled ||
-			prevState.ConfigVersion != currentConfigVersion
+			prevState.ConfigVersion != currentConfigVersion ||
+			prevState.TuningSignature != tuningSignature
 	}
 
 	// Check if container already exists
@@ -183,7 +190,8 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 					}
 					return 0
 				}(),
-				"current_config_version", currentConfigVersion)
+				"current_config_version", currentConfigVersion,
+				"tuning_changed", prevState != nil && prevState.TuningSignature != tuningSignature)
 			e.CleanupExistingContainer(ctx, existingContainer)
 		} else {
 			e.Log.Info("found existing etcd container, attempting restart", "container_id", existingContainer.ID())
@@ -227,7 +235,7 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	e.Log.Info("starting etcd with host networking", "client_port", config.ClientPort, "peer_port", config.PeerPort, "tls", e.tlsEnabled)
 
 	// Create container
-	container, err := e.createContainer(ctx, image, config)
+	container, err := e.createContainer(ctx, image, config, tuning)
 	if err != nil {
 		return fmt.Errorf("failed to create etcd container: %w", err)
 	}
@@ -262,8 +270,13 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	// Start periodic maintenance (health logging + auto-defrag)
 	e.StartMaintenanceLoop(ctx)
 
-	// Persist the TLS state so we can detect config changes on restart
-	if err := e.saveState(&etcdState{TLSEnabled: e.tlsEnabled, ConfigVersion: currentConfigVersion}); err != nil {
+	// Persist the TLS state and tuning signature so we can detect config changes
+	// (including a node RAM change that alters tuning) on restart.
+	if err := e.saveState(&etcdState{
+		TLSEnabled:      e.tlsEnabled,
+		ConfigVersion:   currentConfigVersion,
+		TuningSignature: tuningSignature,
+	}); err != nil {
 		e.Log.Warn("failed to save etcd state", "error", err)
 	}
 
@@ -362,7 +375,7 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 	return nil
 }
 
-func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Image, config EtcdConfig) (containerd.Container, error) {
+func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Image, config EtcdConfig, tuning etcdTuning) (containerd.Container, error) {
 	dataPath := filepath.Join(e.DataPath, "etcd")
 
 	// Determine URL scheme based on TLS config
@@ -371,9 +384,6 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 		scheme = "https"
 	}
 
-	// Scale etcd's memory-related config to the size of the node it runs on so it
-	// behaves as a ~10%-of-RAM co-tenant rather than growing to fill the node.
-	tuning := computeTuning(detectSystemRAMBytes())
 	e.Log.Info("etcd memory auto-tuning",
 		"system_ram_bytes", tuning.SystemRAMBytes,
 		"budget_bytes", tuning.BudgetBytes,

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -17,6 +18,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"miren.dev/runtime/components/base"
+	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/slogout"
 )
@@ -63,6 +65,10 @@ type EtcdConfig struct {
 	InitialToken   string
 	ClusterState   string
 	TLS            *TLSConfig // If set, enables mTLS for client connections
+
+	// QuotaBackendBytes, when > 0, sets --quota-backend-bytes explicitly. When 0 the
+	// value is auto-derived from system RAM (see computeTuning).
+	QuotaBackendBytes int64
 }
 
 type EtcdComponent struct {
@@ -72,6 +78,21 @@ type EtcdComponent struct {
 	peerPort   int
 	tlsEnabled bool
 	config     EtcdConfig
+
+	// quotaBackendBytes is the effective backend quota the container was started with;
+	// the maintenance loop uses it for the near-quota reclaim trigger.
+	quotaBackendBytes int64
+
+	// writer, when set, receives etcd health gauges from the maintenance loop. It is set
+	// via SetMetricsWriter after the metrics subsystem comes up (which happens after etcd
+	// and its maintenance loop have already started), so access is atomic. Nil-safe.
+	writer atomic.Pointer[metrics.VictoriaMetricsWriter]
+}
+
+// SetMetricsWriter configures the metrics sink for the maintenance loop's health gauges.
+// Safe to call with nil or at any time (the maintenance loop reads it atomically each tick).
+func (e *EtcdComponent) SetMetricsWriter(w *metrics.VictoriaMetricsWriter) {
+	e.writer.Store(w)
 }
 
 func NewEtcdComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *EtcdComponent {
@@ -157,9 +178,11 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	}
 
 	// Scale etcd's memory-related config to the size of the node it runs on so it
-	// behaves as a ~10%-of-RAM co-tenant rather than growing to fill the node.
-	tuning := computeTuning(detectSystemRAMBytes())
+	// behaves as a ~10%-of-RAM co-tenant rather than growing to fill the node. The
+	// backend quota honors an explicit config override when set.
+	tuning := computeTuning(detectSystemRAMBytes(), config.QuotaBackendBytes)
 	tuningSignature := tuning.signature()
+	e.quotaBackendBytes = tuning.QuotaBackendBytes
 
 	// Check if the container config has changed since last start. If so, we
 	// must recreate the container since env vars and args are baked into the spec.

--- a/components/etcd/maintenance.go
+++ b/components/etcd/maintenance.go
@@ -9,7 +9,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"miren.dev/runtime/metrics"
 )
 
 const (
@@ -17,7 +19,46 @@ const (
 	defragBloatRatio    = 2.0
 	warnBloatRatio      = 1.5
 	errorBloatRatio     = 3.0
+
+	// quotaHighWaterFraction triggers a proactive compact+defrag once the physical
+	// backend size passes this fraction of the quota — before it reaches the hard
+	// limit and arms a NOSPACE alarm. Keyed off physical DbSize (what the quota is
+	// enforced against), so it is immune to the pending-page distortion in DbSizeInUse.
+	quotaHighWaterFraction = 0.80
+
+	// clientRetryInterval is how long the maintenance loop waits before retrying to
+	// build its etcd client, so a transient failure at startup does not permanently
+	// disable maintenance (the loop used to return and never run again).
+	clientRetryInterval = 10 * time.Second
 )
+
+// maintenanceAction is the remediation the maintenance loop should take for the
+// observed backend state. Determined by the pure decideMaintenance function so the
+// trigger thresholds are unit-testable without a live etcd.
+type maintenanceAction int
+
+const (
+	actionNone    maintenanceAction = iota // healthy: nothing to do
+	actionDefrag                           // bloated (ratio): defrag to return free pages to the OS
+	actionReclaim                          // near quota: compact-to-head + defrag to shrink the file
+	actionRecover                          // NOSPACE armed: reclaim + disarm the alarm
+)
+
+// decideMaintenance picks the remediation for the observed backend state. NOSPACE
+// recovery takes precedence, then the absolute near-quota trigger (physical dbSize vs
+// quota), then the bloat-ratio backstop.
+func decideMaintenance(dbSize, dbSizeInUse, quota int64, noSpace bool) maintenanceAction {
+	switch {
+	case noSpace:
+		return actionRecover
+	case quota > 0 && float64(dbSize) > quotaHighWaterFraction*float64(quota):
+		return actionReclaim
+	case dbSizeInUse > 0 && dbSize > int64(defragBloatRatio*float64(dbSizeInUse)):
+		return actionDefrag
+	default:
+		return actionNone
+	}
+}
 
 // StartMaintenanceLoop runs a background goroutine that periodically checks
 // etcd database health and triggers defragmentation when the BoltDB file has
@@ -29,18 +70,17 @@ func (e *EtcdComponent) StartMaintenanceLoop(ctx context.Context) {
 }
 
 func (e *EtcdComponent) maintenanceLoop(ctx context.Context) {
-	endpoint := e.ClientEndpoint()
-	if endpoint == "" {
-		e.Log.Warn("etcd maintenance loop: no endpoint available, skipping")
-		return
-	}
-
-	client, err := e.newMaintenanceClient(endpoint)
-	if err != nil {
-		e.Log.Error("etcd maintenance loop: failed to create client", "error", err)
-		return
+	// Build the client with retry: a transient failure (endpoint not ready yet, dial
+	// error) must not permanently disable maintenance for the process lifetime.
+	client, endpoint := e.connectMaintenanceClient(ctx)
+	if client == nil {
+		return // ctx cancelled before we could connect
 	}
 	defer client.Close()
+
+	// Run a check immediately so a wedged (NOSPACE) or near-full etcd is remediated
+	// within seconds of startup rather than waiting for the first ticker interval.
+	e.runMaintenanceCheck(ctx, client, endpoint)
 
 	ticker := time.NewTicker(maintenanceInterval)
 	defer ticker.Stop()
@@ -51,6 +91,28 @@ func (e *EtcdComponent) maintenanceLoop(ctx context.Context) {
 			e.runMaintenanceCheck(ctx, client, endpoint)
 		case <-ctx.Done():
 			return
+		}
+	}
+}
+
+// connectMaintenanceClient builds the etcd client, retrying until it succeeds or the
+// context is cancelled. Returns (nil, "") only if ctx is cancelled first.
+func (e *EtcdComponent) connectMaintenanceClient(ctx context.Context) (*clientv3.Client, string) {
+	for {
+		if endpoint := e.ClientEndpoint(); endpoint != "" {
+			client, err := e.newMaintenanceClient(endpoint)
+			if err == nil {
+				return client, endpoint
+			}
+			e.Log.Error("etcd maintenance loop: failed to create client, will retry", "error", err)
+		} else {
+			e.Log.Warn("etcd maintenance loop: no endpoint available yet, will retry")
+		}
+
+		select {
+		case <-time.After(clientRetryInterval):
+		case <-ctx.Done():
+			return nil, ""
 		}
 	}
 }
@@ -112,13 +174,19 @@ func (e *EtcdComponent) runMaintenanceCheck(ctx context.Context, client *clientv
 		bloatRatio = float64(dbSize) / float64(dbSizeInUse)
 	}
 
+	noSpace, alarmedMembers := e.checkNoSpace(ctx, client)
+
 	attrs := []any{
 		"db_size_bytes", dbSize,
 		"db_size_in_use_bytes", dbSizeInUse,
 		"bloat_ratio", bloatRatio,
+		"quota_bytes", e.quotaBackendBytes,
+		"nospace_alarm", noSpace,
 	}
 
 	switch {
+	case noSpace:
+		e.Log.Error("etcd NOSPACE alarm is active", attrs...)
 	case bloatRatio >= errorBloatRatio:
 		e.Log.Error("etcd database bloat is critically high", attrs...)
 	case bloatRatio >= warnBloatRatio:
@@ -127,8 +195,111 @@ func (e *EtcdComponent) runMaintenanceCheck(ctx context.Context, client *clientv
 		e.Log.Info("etcd database status", attrs...)
 	}
 
-	if dbSizeInUse > 0 && dbSize > int64(defragBloatRatio*float64(dbSizeInUse)) {
+	e.emitMetrics(ctx, dbSize, dbSizeInUse, bloatRatio, noSpace)
+
+	switch decideMaintenance(dbSize, dbSizeInUse, e.quotaBackendBytes, noSpace) {
+	case actionRecover:
+		e.recoverFromNoSpace(ctx, client, endpoint, resp.Header.Revision, dbSize, alarmedMembers)
+	case actionReclaim:
+		e.Log.Warn("etcd backend near quota, reclaiming space",
+			"db_size_bytes", dbSize, "quota_bytes", e.quotaBackendBytes)
+		e.reclaimSpace(ctx, client, endpoint, resp.Header.Revision, dbSize)
+	case actionDefrag:
 		e.defragment(ctx, client, endpoint, dbSize)
+	case actionNone:
+	}
+}
+
+// checkNoSpace lists active alarms and reports whether any NOSPACE alarm is armed,
+// returning the member IDs that raised it (for disarming).
+func (e *EtcdComponent) checkNoSpace(ctx context.Context, client *clientv3.Client) (bool, []uint64) {
+	resp, err := client.AlarmList(ctx)
+	if err != nil {
+		e.Log.Warn("etcd maintenance: failed to list alarms", "error", err)
+		return false, nil
+	}
+
+	var members []uint64
+	for _, a := range resp.Alarms {
+		if a.Alarm == etcdserverpb.AlarmType_NOSPACE {
+			members = append(members, a.MemberID)
+		}
+	}
+	return len(members) > 0, members
+}
+
+// reclaimSpace compacts to the given revision (physically) and defragments, which is
+// the only way to shrink the on-disk file. Used both proactively near the quota and
+// during NOSPACE recovery. Compaction discards MVCC history to head; acceptable since
+// this only fires near-quota or when already wedged (uptime > history).
+func (e *EtcdComponent) reclaimSpace(ctx context.Context, client *clientv3.Client, endpoint string, rev, dbSizeBefore int64) {
+	if rev > 0 {
+		e.Log.Info("etcd compaction starting", "revision", rev)
+		if _, err := client.Compact(ctx, rev, clientv3.WithCompactPhysical()); err != nil {
+			e.Log.Error("etcd compaction failed", "error", err)
+			// Fall through to defrag anyway — it still reclaims freelist bloat.
+		} else {
+			e.Log.Info("etcd compaction completed", "revision", rev)
+		}
+	}
+	e.defragment(ctx, client, endpoint, dbSizeBefore)
+}
+
+// recoverFromNoSpace self-heals a read-only etcd: reclaim space, then disarm the
+// NOSPACE alarm(s) so writes are accepted again, turning a hard outage that requires
+// manual operator intervention into a self-healing event.
+func (e *EtcdComponent) recoverFromNoSpace(ctx context.Context, client *clientv3.Client, endpoint string, rev, dbSize int64, members []uint64) {
+	e.Log.Error("etcd NOSPACE alarm armed, attempting self-recovery (compact+defrag+disarm)",
+		"db_size_bytes", dbSize, "quota_bytes", e.quotaBackendBytes)
+
+	e.reclaimSpace(ctx, client, endpoint, rev, dbSize)
+
+	for _, id := range members {
+		_, err := client.AlarmDisarm(ctx, &clientv3.AlarmMember{
+			MemberID: id,
+			Alarm:    etcdserverpb.AlarmType_NOSPACE,
+		})
+		if err != nil {
+			e.Log.Error("etcd NOSPACE alarm disarm failed", "member_id", id, "error", err)
+			continue
+		}
+		e.Log.Warn("etcd NOSPACE alarm disarmed", "member_id", id)
+	}
+
+	if stillNoSpace, _ := e.checkNoSpace(ctx, client); stillNoSpace {
+		e.Log.Error("etcd still NOSPACE after recovery attempt; manual intervention may be required")
+	} else {
+		e.Log.Warn("etcd NOSPACE recovery succeeded, backend is writable again")
+	}
+}
+
+// emitMetrics publishes etcd backend health gauges. No-op if no writer is configured.
+func (e *EtcdComponent) emitMetrics(ctx context.Context, dbSize, dbSizeInUse int64, bloatRatio float64, noSpace bool) {
+	writer := e.writer.Load()
+	if writer == nil {
+		return
+	}
+
+	now := time.Now()
+	var headroom int64
+	if e.quotaBackendBytes > 0 {
+		headroom = e.quotaBackendBytes - dbSize // quota is enforced against physical DbSize
+	}
+	alarm := 0.0
+	if noSpace {
+		alarm = 1.0
+	}
+
+	points := []metrics.MetricPoint{
+		{Name: "etcd_db_size_bytes", Value: float64(dbSize), Timestamp: now},
+		{Name: "etcd_db_size_in_use_bytes", Value: float64(dbSizeInUse), Timestamp: now},
+		{Name: "etcd_backend_quota_bytes", Value: float64(e.quotaBackendBytes), Timestamp: now},
+		{Name: "etcd_quota_headroom_bytes", Value: float64(headroom), Timestamp: now},
+		{Name: "etcd_bloat_ratio", Value: bloatRatio, Timestamp: now},
+		{Name: "etcd_nospace_alarm", Value: alarm, Timestamp: now},
+	}
+	if err := writer.WritePoints(ctx, points); err != nil {
+		e.Log.Warn("etcd maintenance: failed to write metrics", "error", err)
 	}
 }
 

--- a/components/etcd/maintenance.go
+++ b/components/etcd/maintenance.go
@@ -38,21 +38,32 @@ const (
 type maintenanceAction int
 
 const (
-	actionNone    maintenanceAction = iota // healthy: nothing to do
-	actionDefrag                           // bloated (ratio): defrag to return free pages to the OS
-	actionReclaim                          // near quota: compact-to-head + defrag to shrink the file
-	actionRecover                          // NOSPACE armed: reclaim + disarm the alarm
+	actionNone     maintenanceAction = iota // healthy: nothing to do
+	actionDefrag                            // bloated (ratio): defrag to return free pages to the OS
+	actionReclaim                           // near quota with reclaimable bloat: compact-to-head + defrag
+	actionWarnFull                          // near quota but mostly live data: defrag can't help — warn
+	actionRecover                           // NOSPACE armed: reclaim + disarm the alarm
 )
 
 // decideMaintenance picks the remediation for the observed backend state. NOSPACE
 // recovery takes precedence, then the absolute near-quota trigger (physical dbSize vs
 // quota), then the bloat-ratio backstop.
+//
+// The near-quota branch only reclaims when compact+defrag can actually pull the physical
+// file back under the high-water — i.e. the live data (dbSizeInUse) is itself below the
+// high-water, so the excess is reclaimable bloat. If the live data is already over the
+// high-water, defrag cannot shrink it and re-running compact+defrag every tick would
+// thrash without progress; we surface a "raise the quota / shed keyspace" warning instead.
 func decideMaintenance(dbSize, dbSizeInUse, quota int64, noSpace bool) maintenanceAction {
+	highWater := quotaHighWaterFraction * float64(quota)
 	switch {
 	case noSpace:
 		return actionRecover
-	case quota > 0 && float64(dbSize) > quotaHighWaterFraction*float64(quota):
-		return actionReclaim
+	case quota > 0 && float64(dbSize) > highWater:
+		if float64(dbSizeInUse) < highWater {
+			return actionReclaim
+		}
+		return actionWarnFull
 	case dbSizeInUse > 0 && dbSize > int64(defragBloatRatio*float64(dbSizeInUse)):
 		return actionDefrag
 	default:
@@ -202,8 +213,11 @@ func (e *EtcdComponent) runMaintenanceCheck(ctx context.Context, client *clientv
 		e.recoverFromNoSpace(ctx, client, endpoint, resp.Header.Revision, dbSize, alarmedMembers)
 	case actionReclaim:
 		e.Log.Warn("etcd backend near quota, reclaiming space",
-			"db_size_bytes", dbSize, "quota_bytes", e.quotaBackendBytes)
+			"db_size_bytes", dbSize, "db_size_in_use_bytes", dbSizeInUse, "quota_bytes", e.quotaBackendBytes)
 		e.reclaimSpace(ctx, client, endpoint, resp.Header.Revision, dbSize)
+	case actionWarnFull:
+		e.Log.Error("etcd backend near quota and mostly live data; compaction/defrag cannot reclaim enough space — raise --quota-backend-bytes or reduce the keyspace",
+			"db_size_bytes", dbSize, "db_size_in_use_bytes", dbSizeInUse, "quota_bytes", e.quotaBackendBytes)
 	case actionDefrag:
 		e.defragment(ctx, client, endpoint, dbSize)
 	case actionNone:

--- a/components/etcd/maintenance_test.go
+++ b/components/etcd/maintenance_test.go
@@ -1,0 +1,82 @@
+package etcd
+
+import "testing"
+
+func TestDecideMaintenance(t *testing.T) {
+	const quota = 8 * gib // high-water at 0.80 → 6.4 GiB
+
+	tests := []struct {
+		name                       string
+		dbSize, dbSizeInUse, quota int64
+		noSpace                    bool
+		want                       maintenanceAction
+	}{
+		{
+			name:   "healthy: low bloat, well under quota",
+			dbSize: 1 * gib, dbSizeInUse: 900 * mib, quota: quota,
+			want: actionNone,
+		},
+		{
+			name:   "bloated: ratio over 2x, under high-water",
+			dbSize: 1 * gib, dbSizeInUse: 400 * mib, quota: quota,
+			want: actionDefrag,
+		},
+		{
+			name:   "near quota: above 80% high-water, low bloat",
+			dbSize: 7 * gib, dbSizeInUse: 6900 * mib, quota: quota,
+			want: actionReclaim,
+		},
+		{
+			name:   "near quota takes precedence over bloat ratio",
+			dbSize: 7 * gib, dbSizeInUse: 1 * gib, quota: quota,
+			want: actionReclaim,
+		},
+		{
+			name:   "NOSPACE takes precedence over everything",
+			dbSize: 7 * gib, dbSizeInUse: 1 * gib, quota: quota, noSpace: true,
+			want: actionRecover,
+		},
+		{
+			name:   "NOSPACE with an otherwise-healthy-looking size still recovers",
+			dbSize: 1 * gib, dbSizeInUse: 1 * gib, quota: quota, noSpace: true,
+			want: actionRecover,
+		},
+		{
+			name:   "no quota known: falls back to bloat ratio only (near-quota disabled)",
+			dbSize: 7 * gib, dbSizeInUse: 6900 * mib, quota: 0,
+			want: actionNone,
+		},
+		{
+			name:   "no quota known but bloated: defrags",
+			dbSize: 7 * gib, dbSizeInUse: 1 * gib, quota: 0,
+			want: actionDefrag,
+		},
+		{
+			name:   "zero dbSizeInUse never divides / never defrags on ratio",
+			dbSize: 1 * gib, dbSizeInUse: 0, quota: quota,
+			want: actionNone,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideMaintenance(tc.dbSize, tc.dbSizeInUse, tc.quota, tc.noSpace)
+			if got != tc.want {
+				t.Errorf("decideMaintenance(%d,%d,%d,%v) = %d, want %d",
+					tc.dbSize, tc.dbSizeInUse, tc.quota, tc.noSpace, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecideMaintenanceHighWaterBoundary(t *testing.T) {
+	const quota = 10 * gib // 80% = 8 GiB exactly
+
+	// Strictly above the high-water reclaims; at/below does not (assuming low bloat).
+	if got := decideMaintenance(8*gib+1, 8*gib, quota, false); got != actionReclaim {
+		t.Errorf("just above high-water: got %d, want actionReclaim", got)
+	}
+	if got := decideMaintenance(8*gib, 7*gib+900*mib, quota, false); got == actionReclaim {
+		t.Errorf("exactly at high-water should not reclaim, got actionReclaim")
+	}
+}

--- a/components/etcd/maintenance_test.go
+++ b/components/etcd/maintenance_test.go
@@ -22,9 +22,14 @@ func TestDecideMaintenance(t *testing.T) {
 			want: actionDefrag,
 		},
 		{
-			name:   "near quota: above 80% high-water, low bloat",
-			dbSize: 7 * gib, dbSizeInUse: 6900 * mib, quota: quota,
+			name:   "near quota with reclaimable bloat: live data under high-water",
+			dbSize: 7 * gib, dbSizeInUse: 5 * gib, quota: quota, // high-water 6.4 GiB
 			want: actionReclaim,
+		},
+		{
+			name:   "near quota but mostly live data: defrag cannot help, warn",
+			dbSize: 7 * gib, dbSizeInUse: 6900 * mib, quota: quota, // in-use 6.7 GiB > 6.4 GiB high-water
+			want: actionWarnFull,
 		},
 		{
 			name:   "near quota takes precedence over bloat ratio",
@@ -70,13 +75,18 @@ func TestDecideMaintenance(t *testing.T) {
 }
 
 func TestDecideMaintenanceHighWaterBoundary(t *testing.T) {
-	const quota = 10 * gib // 80% = 8 GiB exactly
+	const quota = 10 * gib // 80% high-water = 8 GiB exactly
 
-	// Strictly above the high-water reclaims; at/below does not (assuming low bloat).
-	if got := decideMaintenance(8*gib+1, 8*gib, quota, false); got != actionReclaim {
-		t.Errorf("just above high-water: got %d, want actionReclaim", got)
+	// Strictly above the high-water, with live data under it, reclaims.
+	if got := decideMaintenance(8*gib+1, 4*gib, quota, false); got != actionReclaim {
+		t.Errorf("just above high-water with reclaimable bloat: got %d, want actionReclaim", got)
 	}
-	if got := decideMaintenance(8*gib, 7*gib+900*mib, quota, false); got == actionReclaim {
-		t.Errorf("exactly at high-water should not reclaim, got actionReclaim")
+	// Exactly at the high-water (not strictly above) does not trigger the near-quota path.
+	if got := decideMaintenance(8*gib, 4*gib, quota, false); got == actionReclaim || got == actionWarnFull {
+		t.Errorf("exactly at high-water should not trigger near-quota path, got %d", got)
+	}
+	// Above the high-water but live data also above it warns instead of thrashing.
+	if got := decideMaintenance(9*gib, 8*gib+1, quota, false); got != actionWarnFull {
+		t.Errorf("near quota, live data over high-water: got %d, want actionWarnFull", got)
 	}
 }

--- a/components/etcd/tuning.go
+++ b/components/etcd/tuning.go
@@ -151,6 +151,13 @@ func (t etcdTuning) envVars() []string {
 	}
 }
 
+// signature is a stable fingerprint of the tuning-derived spec (env + args). It is
+// persisted in etcdState so a restart on a node whose RAM has changed regenerates the
+// container instead of reusing a spec built for the old budget.
+func (t etcdTuning) signature() string {
+	return strings.Join(append(t.envVars(), t.args()...), " ")
+}
+
 // args renders the etcd command-line flags for the tuning. Flag names target etcd v3.5,
 // where snapshot-catchup-entries and compaction-batch-limit are experimental-prefixed
 // (both graduated to stable names in 3.6).

--- a/components/etcd/tuning.go
+++ b/components/etcd/tuning.go
@@ -19,9 +19,9 @@ import (
 // GC harder as it approaches the budget.
 //
 // The one exception is --quota-backend-bytes, a hard knob whose breach takes etcd
-// read-only cluster-wide. It is NOT scaled down by RAM: it is floored at etcd's 2 GiB
-// default (see quotaFloorBytes) so the tuning only ever adds backend headroom on large
-// nodes, never removes it on small ones.
+// read-only cluster-wide. It is NOT scaled down by RAM: it is floored well above realistic
+// keyspaces (see quotaFloorBytes) so the tuning only ever adds backend headroom on large
+// nodes, never removes it on small ones. Operators can override it explicitly.
 const (
 	kib = 1024
 	mib = 1024 * 1024
@@ -31,13 +31,14 @@ const (
 	// hold a working keyspace, so the budget never drops under this even on tiny nodes.
 	memoryFloorBytes = 100 * mib
 
-	// quotaFloorBytes is etcd's built-in default backend quota (2 GiB). We never set a
-	// quota below it: --quota-backend-bytes is the one hard knob whose breach raises a
-	// cluster-wide NOSPACE alarm (etcd goes read-only until a manual compact/defrag/
-	// disarm), and keyspace tracks workload rather than the RAM of the node etcd
-	// co-tenants on. Flooring here keeps the tuning purely additive headroom on large
-	// nodes and never a write-outage regression on small ones.
-	quotaFloorBytes = 2 * gib
+	// quotaFloorBytes is the minimum backend quota we ever set. --quota-backend-bytes is the
+	// one hard knob whose breach raises a cluster-wide NOSPACE alarm (etcd goes read-only
+	// until a manual compact/defrag/disarm), and keyspace tracks workload rather than the RAM
+	// of the node etcd co-tenants on. etcd's built-in default (2 GiB) proved too small in
+	// production — a ~711 MB live keyspace bloated to 2.1 GB and hit the quota — so we floor
+	// at 4 GiB (~5.6x that live size, ~2x the bloated file). Flooring keeps the tuning purely
+	// additive headroom on large nodes and never a write-outage regression on small ones.
+	quotaFloorBytes = 4 * gib
 
 	// quotaCapBytes caps the backend quota regardless of how large the node is. This is
 	// etcd's own maximum supported backend size.
@@ -93,19 +94,24 @@ func detectSystemRAMBytes() int64 {
 }
 
 // computeTuning derives etcd config from the node's RAM. A systemRAMBytes of 0 (unknown)
-// yields the smallest tier via the budget floor.
-func computeTuning(systemRAMBytes int64) etcdTuning {
+// yields the smallest tier via the budget floor. quotaOverride, when > 0, sets
+// --quota-backend-bytes explicitly (operator-configured); otherwise the quota is the
+// RAM-scaled value clamped to [quotaFloorBytes, quotaCapBytes].
+func computeTuning(systemRAMBytes int64, quotaOverride int64) etcdTuning {
 	budget := systemRAMBytes / 10
 	if budget < memoryFloorBytes {
 		budget = memoryFloorBytes
 	}
 
-	quota := budget * 30 / 100
-	if quota < quotaFloorBytes {
-		quota = quotaFloorBytes
-	}
-	if quota > quotaCapBytes {
-		quota = quotaCapBytes
+	quota := quotaOverride
+	if quota <= 0 {
+		quota = budget * 30 / 100
+		if quota < quotaFloorBytes {
+			quota = quotaFloorBytes
+		}
+		if quota > quotaCapBytes {
+			quota = quotaCapBytes
+		}
 	}
 
 	streams := budget / (2 * mib)

--- a/components/etcd/tuning.go
+++ b/components/etcd/tuning.go
@@ -13,10 +13,15 @@ import (
 //
 //	B = max(0.10 * system_RAM, 100 MiB)
 //
-// and scale etcd's advisory config (Go GC pressure via GOMEMLIMIT/GOGC, backend quota,
-// compaction/snapshot cadence, concurrent streams) off it. These are advisory only:
-// no cgroup limit is imposed, so etcd is never OOM-killed by us; GOMEMLIMIT simply
-// drives the Go runtime to GC harder as it approaches the budget.
+// and scale etcd's soft config (Go GC pressure via GOMEMLIMIT/GOGC, compaction/snapshot
+// cadence, concurrent streams) off it. These are advisory only: no cgroup limit is
+// imposed, so etcd is never OOM-killed by us; GOMEMLIMIT simply drives the Go runtime to
+// GC harder as it approaches the budget.
+//
+// The one exception is --quota-backend-bytes, a hard knob whose breach takes etcd
+// read-only cluster-wide. It is NOT scaled down by RAM: it is floored at etcd's 2 GiB
+// default (see quotaFloorBytes) so the tuning only ever adds backend headroom on large
+// nodes, never removes it on small ones.
 const (
 	kib = 1024
 	mib = 1024 * 1024
@@ -26,7 +31,16 @@ const (
 	// hold a working keyspace, so the budget never drops under this even on tiny nodes.
 	memoryFloorBytes = 100 * mib
 
-	// quotaCapBytes caps the backend quota regardless of how large the node is.
+	// quotaFloorBytes is etcd's built-in default backend quota (2 GiB). We never set a
+	// quota below it: --quota-backend-bytes is the one hard knob whose breach raises a
+	// cluster-wide NOSPACE alarm (etcd goes read-only until a manual compact/defrag/
+	// disarm), and keyspace tracks workload rather than the RAM of the node etcd
+	// co-tenants on. Flooring here keeps the tuning purely additive headroom on large
+	// nodes and never a write-outage regression on small ones.
+	quotaFloorBytes = 2 * gib
+
+	// quotaCapBytes caps the backend quota regardless of how large the node is. This is
+	// etcd's own maximum supported backend size.
 	quotaCapBytes = 8 * gib
 
 	// Tier boundaries, expressed against the budget B. They line up with the standard
@@ -87,6 +101,9 @@ func computeTuning(systemRAMBytes int64) etcdTuning {
 	}
 
 	quota := budget * 30 / 100
+	if quota < quotaFloorBytes {
+		quota = quotaFloorBytes
+	}
 	if quota > quotaCapBytes {
 		quota = quotaCapBytes
 	}

--- a/components/etcd/tuning.go
+++ b/components/etcd/tuning.go
@@ -1,0 +1,165 @@
+package etcd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// etcd memory tuning derives etcd's runtime configuration from the amount of RAM
+// on the node it runs on. etcd is a small co-tenant here: it should hold to roughly
+// 10% of system RAM rather than grow to fill the node. We compute a per-node budget
+//
+//	B = max(0.10 * system_RAM, 100 MiB)
+//
+// and scale etcd's advisory config (Go GC pressure via GOMEMLIMIT/GOGC, backend quota,
+// compaction/snapshot cadence, concurrent streams) off it. These are advisory only:
+// no cgroup limit is imposed, so etcd is never OOM-killed by us; GOMEMLIMIT simply
+// drives the Go runtime to GC harder as it approaches the budget.
+const (
+	kib = 1024
+	mib = 1024 * 1024
+	gib = 1024 * 1024 * 1024
+
+	// memoryFloorBytes is etcd's practical resident floor: below ~100 MiB it cannot
+	// hold a working keyspace, so the budget never drops under this even on tiny nodes.
+	memoryFloorBytes = 100 * mib
+
+	// quotaCapBytes caps the backend quota regardless of how large the node is.
+	quotaCapBytes = 8 * gib
+
+	// Tier boundaries, expressed against the budget B. They line up with the standard
+	// node sizes: nodes up to ~2 GB, ~8 GB, and ~16 GB of RAM respectively (B = RAM/10
+	// above the floor), so a 2 GB node lands in the smallest tier, an 8 GB node in the
+	// next, and so on.
+	tierSmallMaxBytes  = 2 * gib / 10  // ~204.8 MiB
+	tierMediumMaxBytes = 8 * gib / 10  // ~819.2 MiB
+	tierLargeMaxBytes  = 16 * gib / 10 // ~1638.4 MiB
+)
+
+// etcdTuning is the set of etcd config values computed for a given node size.
+type etcdTuning struct {
+	SystemRAMBytes int64
+	BudgetBytes    int64
+
+	QuotaBackendBytes      int64
+	GoMemLimitBytes        int64
+	GOGC                   int
+	AutoCompactionMode     string
+	AutoCompactionReten    string
+	SnapshotCount          int
+	SnapshotCatchupEntries int
+	MaxConcurrentStreams   int
+	CompactionBatchLimit   int
+}
+
+// detectSystemRAMBytes reads total system memory from /proc/meminfo. It returns 0 when
+// the value cannot be determined so callers fall back to the memory floor.
+func detectSystemRAMBytes() int64 {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "MemTotal:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return 0
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			return 0
+		}
+		return kb * kib // /proc/meminfo reports kB
+	}
+	return 0
+}
+
+// computeTuning derives etcd config from the node's RAM. A systemRAMBytes of 0 (unknown)
+// yields the smallest tier via the budget floor.
+func computeTuning(systemRAMBytes int64) etcdTuning {
+	budget := systemRAMBytes / 10
+	if budget < memoryFloorBytes {
+		budget = memoryFloorBytes
+	}
+
+	quota := budget * 30 / 100
+	if quota > quotaCapBytes {
+		quota = quotaCapBytes
+	}
+
+	streams := budget / (2 * mib)
+	switch {
+	case streams < 50:
+		streams = 50
+	case streams > 8000:
+		streams = 8000
+	}
+
+	t := etcdTuning{
+		SystemRAMBytes:       systemRAMBytes,
+		BudgetBytes:          budget,
+		QuotaBackendBytes:    quota,
+		GoMemLimitBytes:      budget * 65 / 100,
+		AutoCompactionMode:   "periodic",
+		MaxConcurrentStreams: int(streams),
+	}
+
+	switch {
+	case budget <= tierSmallMaxBytes:
+		t.GOGC = 25
+		t.AutoCompactionReten = "30m"
+		t.SnapshotCount = 1000
+		t.SnapshotCatchupEntries = 500
+		t.CompactionBatchLimit = 100
+	case budget <= tierMediumMaxBytes:
+		t.GOGC = 50
+		t.AutoCompactionReten = "1h"
+		t.SnapshotCount = 5000
+		t.SnapshotCatchupEntries = 2500
+		t.CompactionBatchLimit = 500
+	case budget <= tierLargeMaxBytes:
+		t.GOGC = 75
+		t.AutoCompactionReten = "2h"
+		t.SnapshotCount = 10000
+		t.SnapshotCatchupEntries = 5000
+		t.CompactionBatchLimit = 1000
+	default:
+		t.GOGC = 100
+		t.AutoCompactionReten = "3h"
+		t.SnapshotCount = 10000
+		t.SnapshotCatchupEntries = 5000
+		t.CompactionBatchLimit = 1000
+	}
+
+	return t
+}
+
+// envVars renders the Go-runtime and etcd env for the container. GOMEMLIMIT/GOGC steer the
+// Go runtime; the ETCD_* vars configure compaction. The bbolt freelist type is kept from the
+// prior fixed config.
+func (t etcdTuning) envVars() []string {
+	return []string{
+		fmt.Sprintf("GOMEMLIMIT=%dB", t.GoMemLimitBytes),
+		fmt.Sprintf("GOGC=%d", t.GOGC),
+		fmt.Sprintf("ETCD_AUTO_COMPACTION_MODE=%s", t.AutoCompactionMode),
+		fmt.Sprintf("ETCD_AUTO_COMPACTION_RETENTION=%s", t.AutoCompactionReten),
+		"ETCD_EXPERIMENTAL_BACKEND_BBOLT_FREELIST_TYPE=map",
+	}
+}
+
+// args renders the etcd command-line flags for the tuning. Flag names target etcd v3.5,
+// where snapshot-catchup-entries and compaction-batch-limit are experimental-prefixed
+// (both graduated to stable names in 3.6).
+func (t etcdTuning) args() []string {
+	return []string{
+		"--quota-backend-bytes", strconv.FormatInt(t.QuotaBackendBytes, 10),
+		"--snapshot-count", strconv.Itoa(t.SnapshotCount),
+		"--experimental-snapshot-catchup-entries", strconv.Itoa(t.SnapshotCatchupEntries),
+		"--max-concurrent-streams", strconv.Itoa(t.MaxConcurrentStreams),
+		"--experimental-compaction-batch-limit", strconv.Itoa(t.CompactionBatchLimit),
+	}
+}

--- a/components/etcd/tuning_test.go
+++ b/components/etcd/tuning_test.go
@@ -137,6 +137,30 @@ func TestTuningEnvVars(t *testing.T) {
 	}
 }
 
+func TestTuningSignature(t *testing.T) {
+	// Same RAM yields a stable, non-empty signature.
+	sig := computeTuning(8 * gib).signature()
+	if sig == "" {
+		t.Fatal("signature is empty")
+	}
+	if again := computeTuning(8 * gib).signature(); again != sig {
+		t.Errorf("signature not stable for equal RAM: %q != %q", sig, again)
+	}
+
+	// A RAM change that moves the node to a different tier changes the signature,
+	// which is what forces the container to be recreated on restart.
+	if other := computeTuning(32 * gib).signature(); other == sig {
+		t.Errorf("signature did not change across tiers: %q", sig)
+	}
+
+	// A RAM change that stays within the same tier (5 GiB and 8 GiB are both the
+	// medium tier) but alters the continuous formulas (quota/GOMEMLIMIT/streams)
+	// also changes the signature.
+	if other := computeTuning(5 * gib).signature(); other == sig {
+		t.Errorf("signature did not change for a within-tier RAM change: %q", sig)
+	}
+}
+
 func TestTuningArgs(t *testing.T) {
 	args := computeTuning(8 * gib).args()
 

--- a/components/etcd/tuning_test.go
+++ b/components/etcd/tuning_test.go
@@ -113,9 +113,11 @@ func TestQuotaFloorAndCap(t *testing.T) {
 	}
 
 	// A very large node (3% of RAM above the 4 GiB floor) gets the RAM-scaled quota.
-	// 200 GiB → budget 20 GiB → 30% = 6 GiB, between floor and cap.
-	if got := computeTuning(200*gib, 0).QuotaBackendBytes; got != 200*gib/10*30/100 {
-		t.Errorf("200 GiB: quota = %d, want RAM-scaled %d", got, 200*gib/10*30/100)
+	// 200 GiB → budget 20 GiB → 30% = 6 GiB, between floor and cap. Hardcoded golden
+	// value rather than restating computeTuning's formula.
+	const wantScaledQuota = 6442450944 // 6 GiB = 3% of 200 GiB
+	if got := computeTuning(200*gib, 0).QuotaBackendBytes; got != wantScaledQuota {
+		t.Errorf("200 GiB: quota = %d, want RAM-scaled %d", got, int64(wantScaledQuota))
 	}
 
 	// An enormous node is capped at etcd's 8 GiB maximum.

--- a/components/etcd/tuning_test.go
+++ b/components/etcd/tuning_test.go
@@ -1,0 +1,153 @@
+package etcd
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestComputeTuning(t *testing.T) {
+	tests := []struct {
+		name    string
+		ramGiB  float64
+		want    etcdTuning
+		wantRAM int64
+	}{
+		{
+			name:   "1GB",
+			ramGiB: 1,
+			want: etcdTuning{
+				BudgetBytes: 107374182, QuotaBackendBytes: 32212254, GoMemLimitBytes: 69793218,
+				GOGC: 25, AutoCompactionReten: "30m", SnapshotCount: 1000,
+				SnapshotCatchupEntries: 500, MaxConcurrentStreams: 51, CompactionBatchLimit: 100,
+			},
+		},
+		{
+			name:   "2GB",
+			ramGiB: 2,
+			want: etcdTuning{
+				BudgetBytes: 214748364, QuotaBackendBytes: 64424509, GoMemLimitBytes: 139586436,
+				GOGC: 25, AutoCompactionReten: "30m", SnapshotCount: 1000,
+				SnapshotCatchupEntries: 500, MaxConcurrentStreams: 102, CompactionBatchLimit: 100,
+			},
+		},
+		{
+			name:   "4GB",
+			ramGiB: 4,
+			want: etcdTuning{
+				BudgetBytes: 429496729, QuotaBackendBytes: 128849018, GoMemLimitBytes: 279172873,
+				GOGC: 50, AutoCompactionReten: "1h", SnapshotCount: 5000,
+				SnapshotCatchupEntries: 2500, MaxConcurrentStreams: 204, CompactionBatchLimit: 500,
+			},
+		},
+		{
+			name:   "8GB",
+			ramGiB: 8,
+			want: etcdTuning{
+				BudgetBytes: 858993459, QuotaBackendBytes: 257698037, GoMemLimitBytes: 558345748,
+				GOGC: 50, AutoCompactionReten: "1h", SnapshotCount: 5000,
+				SnapshotCatchupEntries: 2500, MaxConcurrentStreams: 409, CompactionBatchLimit: 500,
+			},
+		},
+		{
+			name:   "16GB",
+			ramGiB: 16,
+			want: etcdTuning{
+				BudgetBytes: 1717986918, QuotaBackendBytes: 515396075, GoMemLimitBytes: 1116691496,
+				GOGC: 75, AutoCompactionReten: "2h", SnapshotCount: 10000,
+				SnapshotCatchupEntries: 5000, MaxConcurrentStreams: 819, CompactionBatchLimit: 1000,
+			},
+		},
+		{
+			name:   "32GB",
+			ramGiB: 32,
+			want: etcdTuning{
+				BudgetBytes: 3435973836, QuotaBackendBytes: 1030792150, GoMemLimitBytes: 2233382993,
+				GOGC: 100, AutoCompactionReten: "3h", SnapshotCount: 10000,
+				SnapshotCatchupEntries: 5000, MaxConcurrentStreams: 1638, CompactionBatchLimit: 1000,
+			},
+		},
+		{
+			name:   "64GB",
+			ramGiB: 64,
+			want: etcdTuning{
+				BudgetBytes: 6871947673, QuotaBackendBytes: 2061584301, GoMemLimitBytes: 4466765987,
+				GOGC: 100, AutoCompactionReten: "3h", SnapshotCount: 10000,
+				SnapshotCatchupEntries: 5000, MaxConcurrentStreams: 3276, CompactionBatchLimit: 1000,
+			},
+		},
+		{
+			name:   "sub-1GB floors to 100MiB",
+			ramGiB: 0.5,
+			want: etcdTuning{
+				BudgetBytes: 104857600, QuotaBackendBytes: 31457280, GoMemLimitBytes: 68157440,
+				GOGC: 25, AutoCompactionReten: "30m", SnapshotCount: 1000,
+				SnapshotCatchupEntries: 500, MaxConcurrentStreams: 50, CompactionBatchLimit: 100,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ram := int64(tc.ramGiB * gib)
+			got := computeTuning(ram)
+
+			tc.want.SystemRAMBytes = ram
+			tc.want.AutoCompactionMode = "periodic"
+
+			if got != tc.want {
+				t.Errorf("computeTuning(%d):\n got  %+v\n want %+v", ram, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeTuningZeroRAMUsesFloor(t *testing.T) {
+	got := computeTuning(0)
+	if got.BudgetBytes != memoryFloorBytes {
+		t.Errorf("budget = %d, want floor %d", got.BudgetBytes, memoryFloorBytes)
+	}
+	if got.GOGC != 25 || got.SnapshotCount != 1000 || got.MaxConcurrentStreams != 50 {
+		t.Errorf("zero RAM should yield smallest tier, got %+v", got)
+	}
+}
+
+func TestBudgetIsMonotonicInRAM(t *testing.T) {
+	var prev int64
+	for gigs := 1; gigs <= 128; gigs++ {
+		b := computeTuning(int64(gigs) * gib).BudgetBytes
+		if b < prev {
+			t.Fatalf("budget decreased at %d GiB: %d < %d", gigs, b, prev)
+		}
+		prev = b
+	}
+}
+
+func TestTuningEnvVars(t *testing.T) {
+	env := computeTuning(8 * gib).envVars()
+
+	want := []string{
+		"GOMEMLIMIT=558345748B",
+		"GOGC=50",
+		"ETCD_AUTO_COMPACTION_MODE=periodic",
+		"ETCD_AUTO_COMPACTION_RETENTION=1h",
+		"ETCD_EXPERIMENTAL_BACKEND_BBOLT_FREELIST_TYPE=map",
+	}
+	if !slices.Equal(env, want) {
+		t.Errorf("envVars() = %v, want %v", env, want)
+	}
+}
+
+func TestTuningArgs(t *testing.T) {
+	args := computeTuning(8 * gib).args()
+
+	want := []string{
+		"--quota-backend-bytes", "257698037",
+		"--snapshot-count", "5000",
+		"--experimental-snapshot-catchup-entries", "2500",
+		"--max-concurrent-streams", "409",
+		"--experimental-compaction-batch-limit", "500",
+	}
+	if !slices.Equal(args, want) {
+		t.Errorf("args() = %v, want %v", args, want)
+	}
+}

--- a/components/etcd/tuning_test.go
+++ b/components/etcd/tuning_test.go
@@ -16,7 +16,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "1GB",
 			ramGiB: 1,
 			want: etcdTuning{
-				BudgetBytes: 107374182, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 69793218,
+				BudgetBytes: 107374182, QuotaBackendBytes: 4294967296, GoMemLimitBytes: 69793218,
 				GOGC: 25, AutoCompactionReten: "30m", SnapshotCount: 1000,
 				SnapshotCatchupEntries: 500, MaxConcurrentStreams: 51, CompactionBatchLimit: 100,
 			},
@@ -25,7 +25,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "2GB",
 			ramGiB: 2,
 			want: etcdTuning{
-				BudgetBytes: 214748364, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 139586436,
+				BudgetBytes: 214748364, QuotaBackendBytes: 4294967296, GoMemLimitBytes: 139586436,
 				GOGC: 25, AutoCompactionReten: "30m", SnapshotCount: 1000,
 				SnapshotCatchupEntries: 500, MaxConcurrentStreams: 102, CompactionBatchLimit: 100,
 			},
@@ -34,7 +34,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "4GB",
 			ramGiB: 4,
 			want: etcdTuning{
-				BudgetBytes: 429496729, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 279172873,
+				BudgetBytes: 429496729, QuotaBackendBytes: 4294967296, GoMemLimitBytes: 279172873,
 				GOGC: 50, AutoCompactionReten: "1h", SnapshotCount: 5000,
 				SnapshotCatchupEntries: 2500, MaxConcurrentStreams: 204, CompactionBatchLimit: 500,
 			},
@@ -43,7 +43,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "8GB",
 			ramGiB: 8,
 			want: etcdTuning{
-				BudgetBytes: 858993459, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 558345748,
+				BudgetBytes: 858993459, QuotaBackendBytes: 4294967296, GoMemLimitBytes: 558345748,
 				GOGC: 50, AutoCompactionReten: "1h", SnapshotCount: 5000,
 				SnapshotCatchupEntries: 2500, MaxConcurrentStreams: 409, CompactionBatchLimit: 500,
 			},
@@ -52,7 +52,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "16GB",
 			ramGiB: 16,
 			want: etcdTuning{
-				BudgetBytes: 1717986918, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 1116691496,
+				BudgetBytes: 1717986918, QuotaBackendBytes: 4294967296, GoMemLimitBytes: 1116691496,
 				GOGC: 75, AutoCompactionReten: "2h", SnapshotCount: 10000,
 				SnapshotCatchupEntries: 5000, MaxConcurrentStreams: 819, CompactionBatchLimit: 1000,
 			},
@@ -61,7 +61,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "32GB",
 			ramGiB: 32,
 			want: etcdTuning{
-				BudgetBytes: 3435973836, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 2233382993,
+				BudgetBytes: 3435973836, QuotaBackendBytes: 4294967296, GoMemLimitBytes: 2233382993,
 				GOGC: 100, AutoCompactionReten: "3h", SnapshotCount: 10000,
 				SnapshotCatchupEntries: 5000, MaxConcurrentStreams: 1638, CompactionBatchLimit: 1000,
 			},
@@ -70,7 +70,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "64GB",
 			ramGiB: 64,
 			want: etcdTuning{
-				BudgetBytes: 6871947673, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 4466765987,
+				BudgetBytes: 6871947673, QuotaBackendBytes: 4294967296, GoMemLimitBytes: 4466765987,
 				GOGC: 100, AutoCompactionReten: "3h", SnapshotCount: 10000,
 				SnapshotCatchupEntries: 5000, MaxConcurrentStreams: 3276, CompactionBatchLimit: 1000,
 			},
@@ -79,7 +79,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "sub-1GB floors to 100MiB",
 			ramGiB: 0.5,
 			want: etcdTuning{
-				BudgetBytes: 104857600, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 68157440,
+				BudgetBytes: 104857600, QuotaBackendBytes: 4294967296, GoMemLimitBytes: 68157440,
 				GOGC: 25, AutoCompactionReten: "30m", SnapshotCount: 1000,
 				SnapshotCatchupEntries: 500, MaxConcurrentStreams: 50, CompactionBatchLimit: 100,
 			},
@@ -89,7 +89,7 @@ func TestComputeTuning(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ram := int64(tc.ramGiB * gib)
-			got := computeTuning(ram)
+			got := computeTuning(ram, 0)
 
 			tc.want.SystemRAMBytes = ram
 			tc.want.AutoCompactionMode = "periodic"
@@ -102,29 +102,38 @@ func TestComputeTuning(t *testing.T) {
 }
 
 func TestQuotaFloorAndCap(t *testing.T) {
-	// quota-backend-bytes is never set below etcd's 2 GiB default, so the tuning is
-	// purely additive backend headroom and never a NOSPACE write-outage regression.
-	// For every node up to 64 GB, 3% of RAM is under 2 GiB, so the floor applies.
+	// quota-backend-bytes is never set below the 4 GiB floor, so the tuning is purely
+	// additive backend headroom and never a NOSPACE write-outage regression. For every
+	// node up to 64 GB, 3% of RAM is under 4 GiB, so the floor applies.
 	for _, ramGiB := range []int64{1, 2, 4, 8, 16, 32, 64} {
-		got := computeTuning(ramGiB * gib).QuotaBackendBytes
+		got := computeTuning(ramGiB*gib, 0).QuotaBackendBytes
 		if got != quotaFloorBytes {
 			t.Errorf("%d GiB: quota = %d, want floor %d", ramGiB, got, quotaFloorBytes)
 		}
 	}
 
-	// A very large node (3% of RAM above 2 GiB) gets the RAM-scaled quota.
-	if got := computeTuning(100 * gib).QuotaBackendBytes; got != 100*gib/10*30/100 {
-		t.Errorf("100 GiB: quota = %d, want RAM-scaled %d", got, 100*gib/10*30/100)
+	// A very large node (3% of RAM above the 4 GiB floor) gets the RAM-scaled quota.
+	// 200 GiB → budget 20 GiB → 30% = 6 GiB, between floor and cap.
+	if got := computeTuning(200*gib, 0).QuotaBackendBytes; got != 200*gib/10*30/100 {
+		t.Errorf("200 GiB: quota = %d, want RAM-scaled %d", got, 200*gib/10*30/100)
 	}
 
 	// An enormous node is capped at etcd's 8 GiB maximum.
-	if got := computeTuning(300 * gib).QuotaBackendBytes; got != quotaCapBytes {
+	if got := computeTuning(300*gib, 0).QuotaBackendBytes; got != quotaCapBytes {
 		t.Errorf("300 GiB: quota = %d, want cap %d", got, quotaCapBytes)
+	}
+
+	// An explicit override wins over the RAM-scaled value (even below the floor).
+	if got := computeTuning(64*gib, 6*gib).QuotaBackendBytes; got != 6*gib {
+		t.Errorf("override: quota = %d, want %d", got, int64(6*gib))
+	}
+	if got := computeTuning(64*gib, 1*gib).QuotaBackendBytes; got != 1*gib {
+		t.Errorf("override below floor: quota = %d, want %d", got, int64(1*gib))
 	}
 }
 
 func TestComputeTuningZeroRAMUsesFloor(t *testing.T) {
-	got := computeTuning(0)
+	got := computeTuning(0, 0)
 	if got.BudgetBytes != memoryFloorBytes {
 		t.Errorf("budget = %d, want floor %d", got.BudgetBytes, memoryFloorBytes)
 	}
@@ -136,7 +145,7 @@ func TestComputeTuningZeroRAMUsesFloor(t *testing.T) {
 func TestBudgetIsMonotonicInRAM(t *testing.T) {
 	var prev int64
 	for gigs := 1; gigs <= 128; gigs++ {
-		b := computeTuning(int64(gigs) * gib).BudgetBytes
+		b := computeTuning(int64(gigs)*gib, 0).BudgetBytes
 		if b < prev {
 			t.Fatalf("budget decreased at %d GiB: %d < %d", gigs, b, prev)
 		}
@@ -145,7 +154,7 @@ func TestBudgetIsMonotonicInRAM(t *testing.T) {
 }
 
 func TestTuningEnvVars(t *testing.T) {
-	env := computeTuning(8 * gib).envVars()
+	env := computeTuning(8*gib, 0).envVars()
 
 	want := []string{
 		"GOMEMLIMIT=558345748B",
@@ -161,33 +170,39 @@ func TestTuningEnvVars(t *testing.T) {
 
 func TestTuningSignature(t *testing.T) {
 	// Same RAM yields a stable, non-empty signature.
-	sig := computeTuning(8 * gib).signature()
+	sig := computeTuning(8*gib, 0).signature()
 	if sig == "" {
 		t.Fatal("signature is empty")
 	}
-	if again := computeTuning(8 * gib).signature(); again != sig {
+	if again := computeTuning(8*gib, 0).signature(); again != sig {
 		t.Errorf("signature not stable for equal RAM: %q != %q", sig, again)
 	}
 
 	// A RAM change that moves the node to a different tier changes the signature,
 	// which is what forces the container to be recreated on restart.
-	if other := computeTuning(32 * gib).signature(); other == sig {
+	if other := computeTuning(32*gib, 0).signature(); other == sig {
 		t.Errorf("signature did not change across tiers: %q", sig)
 	}
 
 	// A RAM change that stays within the same tier (5 GiB and 8 GiB are both the
 	// medium tier) but alters the continuous soft knobs (GOMEMLIMIT/streams) also
 	// changes the signature.
-	if other := computeTuning(5 * gib).signature(); other == sig {
+	if other := computeTuning(5*gib, 0).signature(); other == sig {
 		t.Errorf("signature did not change for a within-tier RAM change: %q", sig)
+	}
+
+	// An explicit quota override changes the signature (so a config change recreates
+	// the container on restart).
+	if other := computeTuning(8*gib, 6*gib).signature(); other == sig {
+		t.Errorf("signature did not change for a quota override: %q", sig)
 	}
 }
 
 func TestTuningArgs(t *testing.T) {
-	args := computeTuning(8 * gib).args()
+	args := computeTuning(8*gib, 0).args()
 
 	want := []string{
-		"--quota-backend-bytes", "2147483648",
+		"--quota-backend-bytes", "4294967296",
 		"--snapshot-count", "5000",
 		"--experimental-snapshot-catchup-entries", "2500",
 		"--max-concurrent-streams", "409",

--- a/components/etcd/tuning_test.go
+++ b/components/etcd/tuning_test.go
@@ -16,7 +16,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "1GB",
 			ramGiB: 1,
 			want: etcdTuning{
-				BudgetBytes: 107374182, QuotaBackendBytes: 32212254, GoMemLimitBytes: 69793218,
+				BudgetBytes: 107374182, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 69793218,
 				GOGC: 25, AutoCompactionReten: "30m", SnapshotCount: 1000,
 				SnapshotCatchupEntries: 500, MaxConcurrentStreams: 51, CompactionBatchLimit: 100,
 			},
@@ -25,7 +25,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "2GB",
 			ramGiB: 2,
 			want: etcdTuning{
-				BudgetBytes: 214748364, QuotaBackendBytes: 64424509, GoMemLimitBytes: 139586436,
+				BudgetBytes: 214748364, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 139586436,
 				GOGC: 25, AutoCompactionReten: "30m", SnapshotCount: 1000,
 				SnapshotCatchupEntries: 500, MaxConcurrentStreams: 102, CompactionBatchLimit: 100,
 			},
@@ -34,7 +34,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "4GB",
 			ramGiB: 4,
 			want: etcdTuning{
-				BudgetBytes: 429496729, QuotaBackendBytes: 128849018, GoMemLimitBytes: 279172873,
+				BudgetBytes: 429496729, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 279172873,
 				GOGC: 50, AutoCompactionReten: "1h", SnapshotCount: 5000,
 				SnapshotCatchupEntries: 2500, MaxConcurrentStreams: 204, CompactionBatchLimit: 500,
 			},
@@ -43,7 +43,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "8GB",
 			ramGiB: 8,
 			want: etcdTuning{
-				BudgetBytes: 858993459, QuotaBackendBytes: 257698037, GoMemLimitBytes: 558345748,
+				BudgetBytes: 858993459, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 558345748,
 				GOGC: 50, AutoCompactionReten: "1h", SnapshotCount: 5000,
 				SnapshotCatchupEntries: 2500, MaxConcurrentStreams: 409, CompactionBatchLimit: 500,
 			},
@@ -52,7 +52,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "16GB",
 			ramGiB: 16,
 			want: etcdTuning{
-				BudgetBytes: 1717986918, QuotaBackendBytes: 515396075, GoMemLimitBytes: 1116691496,
+				BudgetBytes: 1717986918, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 1116691496,
 				GOGC: 75, AutoCompactionReten: "2h", SnapshotCount: 10000,
 				SnapshotCatchupEntries: 5000, MaxConcurrentStreams: 819, CompactionBatchLimit: 1000,
 			},
@@ -61,7 +61,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "32GB",
 			ramGiB: 32,
 			want: etcdTuning{
-				BudgetBytes: 3435973836, QuotaBackendBytes: 1030792150, GoMemLimitBytes: 2233382993,
+				BudgetBytes: 3435973836, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 2233382993,
 				GOGC: 100, AutoCompactionReten: "3h", SnapshotCount: 10000,
 				SnapshotCatchupEntries: 5000, MaxConcurrentStreams: 1638, CompactionBatchLimit: 1000,
 			},
@@ -70,7 +70,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "64GB",
 			ramGiB: 64,
 			want: etcdTuning{
-				BudgetBytes: 6871947673, QuotaBackendBytes: 2061584301, GoMemLimitBytes: 4466765987,
+				BudgetBytes: 6871947673, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 4466765987,
 				GOGC: 100, AutoCompactionReten: "3h", SnapshotCount: 10000,
 				SnapshotCatchupEntries: 5000, MaxConcurrentStreams: 3276, CompactionBatchLimit: 1000,
 			},
@@ -79,7 +79,7 @@ func TestComputeTuning(t *testing.T) {
 			name:   "sub-1GB floors to 100MiB",
 			ramGiB: 0.5,
 			want: etcdTuning{
-				BudgetBytes: 104857600, QuotaBackendBytes: 31457280, GoMemLimitBytes: 68157440,
+				BudgetBytes: 104857600, QuotaBackendBytes: 2147483648, GoMemLimitBytes: 68157440,
 				GOGC: 25, AutoCompactionReten: "30m", SnapshotCount: 1000,
 				SnapshotCatchupEntries: 500, MaxConcurrentStreams: 50, CompactionBatchLimit: 100,
 			},
@@ -98,6 +98,28 @@ func TestComputeTuning(t *testing.T) {
 				t.Errorf("computeTuning(%d):\n got  %+v\n want %+v", ram, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestQuotaFloorAndCap(t *testing.T) {
+	// quota-backend-bytes is never set below etcd's 2 GiB default, so the tuning is
+	// purely additive backend headroom and never a NOSPACE write-outage regression.
+	// For every node up to 64 GB, 3% of RAM is under 2 GiB, so the floor applies.
+	for _, ramGiB := range []int64{1, 2, 4, 8, 16, 32, 64} {
+		got := computeTuning(ramGiB * gib).QuotaBackendBytes
+		if got != quotaFloorBytes {
+			t.Errorf("%d GiB: quota = %d, want floor %d", ramGiB, got, quotaFloorBytes)
+		}
+	}
+
+	// A very large node (3% of RAM above 2 GiB) gets the RAM-scaled quota.
+	if got := computeTuning(100 * gib).QuotaBackendBytes; got != 100*gib/10*30/100 {
+		t.Errorf("100 GiB: quota = %d, want RAM-scaled %d", got, 100*gib/10*30/100)
+	}
+
+	// An enormous node is capped at etcd's 8 GiB maximum.
+	if got := computeTuning(300 * gib).QuotaBackendBytes; got != quotaCapBytes {
+		t.Errorf("300 GiB: quota = %d, want cap %d", got, quotaCapBytes)
 	}
 }
 
@@ -154,8 +176,8 @@ func TestTuningSignature(t *testing.T) {
 	}
 
 	// A RAM change that stays within the same tier (5 GiB and 8 GiB are both the
-	// medium tier) but alters the continuous formulas (quota/GOMEMLIMIT/streams)
-	// also changes the signature.
+	// medium tier) but alters the continuous soft knobs (GOMEMLIMIT/streams) also
+	// changes the signature.
 	if other := computeTuning(5 * gib).signature(); other == sig {
 		t.Errorf("signature did not change for a within-tier RAM change: %q", sig)
 	}
@@ -165,7 +187,7 @@ func TestTuningArgs(t *testing.T) {
 	args := computeTuning(8 * gib).args()
 
 	want := []string{
-		"--quota-backend-bytes", "257698037",
+		"--quota-backend-bytes", "2147483648",
 		"--snapshot-count", "5000",
 		"--experimental-snapshot-catchup-entries", "2500",
 		"--max-concurrent-streams", "409",

--- a/docs/docs/command/server.md
+++ b/docs/docs/command/server.md
@@ -37,6 +37,7 @@ miren server [flags]
 - `--etcd-http-client-port` — Etcd HTTP client port
 - `--etcd-peer-port` — Etcd peer port
 - `--etcd-prefix, -p` — Etcd prefix
+- `--etcd-quota-backend-bytes` — Etcd backend quota in bytes (0 = auto-size from system RAM)
 - `--http-request-timeout` — HTTP request timeout in seconds
 - `--ingress-address` — Optional bind override. Replaces the mode's default bind entirely (interface and port). Rejected by validation in tls-autoprovision (where :443 + :80 is structural). Reserved unix:/path prefix is not yet supported.
 - `--ingress-mode` — Ingress mode: tls-autoprovision (default, :443 + :80 with ACME or self-signed), behind-proxy-http (plain HTTP for use behind a TLS-terminating proxy), behind-proxy-https (TLS terminated by Miren; certs come from self-signed or DNS-01 ACME, since :80 isn't bound for HTTP-01)

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -23,6 +23,7 @@ type CLIFlags struct {
 	EtcdConfigHTTPClientPort             *int     `long:"etcd-http-client-port" description:"Etcd HTTP client port" env:"MIREN_ETCD_HTTP_CLIENT_PORT"`
 	EtcdConfigPeerPort                   *int     `long:"etcd-peer-port" description:"Etcd peer port" env:"MIREN_ETCD_PEER_PORT"`
 	EtcdConfigPrefix                     *string  `long:"etcd-prefix" short:"p" description:"Etcd prefix" env:"MIREN_ETCD_PREFIX"`
+	EtcdConfigQuotaBackendBytes          *int     `long:"etcd-quota-backend-bytes" description:"Etcd backend quota in bytes (0 = auto-size from system RAM)" env:"MIREN_ETCD_QUOTA_BACKEND_BYTES"`
 	EtcdConfigStartEmbedded              *bool    `long:"start-etcd" description:"Start embedded etcd server" env:"MIREN_ETCD_START_EMBEDDED"`
 	IngressConfigAddress                 *string  `long:"ingress-address" description:"Optional bind override. Replaces the mode's default bind entirely (interface and port). Rejected by validation in tls-autoprovision (where :443 + :80 is structural). Reserved unix:/path prefix is not yet supported." env:"MIREN_INGRESS_ADDRESS"`
 	IngressConfigMode                    *string  `long:"ingress-mode" description:"Ingress mode: tls-autoprovision (default, :443 + :80 with ACME or self-signed), behind-proxy-http (plain HTTP for use behind a TLS-terminating proxy), behind-proxy-https (TLS terminated by Miren; certs come from self-signed or DNS-01 ACME, since :80 isn't bound for HTTP-01)" env:"MIREN_INGRESS_MODE"`

--- a/pkg/serverconfig/config.gen.go
+++ b/pkg/serverconfig/config.gen.go
@@ -188,12 +188,13 @@ func (c *ContainerdConfig) SetStartEmbedded(v bool) {
 
 // EtcdConfig Etcd configuration
 type EtcdConfig struct {
-	ClientPort     *int     `toml:"client_port" env:"MIREN_ETCD_CLIENT_PORT"`
-	Endpoints      []string `toml:"endpoints" env:"MIREN_ETCD_ENDPOINTS"`
-	HTTPClientPort *int     `toml:"http_client_port" env:"MIREN_ETCD_HTTP_CLIENT_PORT"`
-	PeerPort       *int     `toml:"peer_port" env:"MIREN_ETCD_PEER_PORT"`
-	Prefix         *string  `toml:"prefix" env:"MIREN_ETCD_PREFIX"`
-	StartEmbedded  *bool    `toml:"start_embedded" env:"MIREN_ETCD_START_EMBEDDED"`
+	ClientPort        *int     `toml:"client_port" env:"MIREN_ETCD_CLIENT_PORT"`
+	Endpoints         []string `toml:"endpoints" env:"MIREN_ETCD_ENDPOINTS"`
+	HTTPClientPort    *int     `toml:"http_client_port" env:"MIREN_ETCD_HTTP_CLIENT_PORT"`
+	PeerPort          *int     `toml:"peer_port" env:"MIREN_ETCD_PEER_PORT"`
+	Prefix            *string  `toml:"prefix" env:"MIREN_ETCD_PREFIX"`
+	QuotaBackendBytes *int     `toml:"quota_backend_bytes" env:"MIREN_ETCD_QUOTA_BACKEND_BYTES"`
+	StartEmbedded     *bool    `toml:"start_embedded" env:"MIREN_ETCD_START_EMBEDDED"`
 }
 
 // GetClientPort returns the value of ClientPort or its zero value if nil
@@ -246,6 +247,19 @@ func (c *EtcdConfig) GetPrefix() string {
 // SetPrefix sets the value of Prefix
 func (c *EtcdConfig) SetPrefix(v string) {
 	c.Prefix = &v
+}
+
+// GetQuotaBackendBytes returns the value of QuotaBackendBytes or its zero value if nil
+func (c *EtcdConfig) GetQuotaBackendBytes() int {
+	if c.QuotaBackendBytes != nil {
+		return *c.QuotaBackendBytes
+	}
+	return 0
+}
+
+// SetQuotaBackendBytes sets the value of QuotaBackendBytes
+func (c *EtcdConfig) SetQuotaBackendBytes(v int) {
+	c.QuotaBackendBytes = &v
 }
 
 // GetStartEmbedded returns the value of StartEmbedded or its zero value if nil

--- a/pkg/serverconfig/defaults.gen.go
+++ b/pkg/serverconfig/defaults.gen.go
@@ -55,12 +55,13 @@ func DefaultContainerdConfig() ContainerdConfig {
 // DefaultEtcdConfig returns default EtcdConfig
 func DefaultEtcdConfig() EtcdConfig {
 	return EtcdConfig{
-		ClientPort:     intPtr(12379),
-		Endpoints:      []string{},
-		HTTPClientPort: intPtr(12381),
-		PeerPort:       intPtr(12380),
-		Prefix:         strPtr("/miren"),
-		StartEmbedded:  nil,
+		ClientPort:        intPtr(12379),
+		Endpoints:         []string{},
+		HTTPClientPort:    intPtr(12381),
+		PeerPort:          intPtr(12380),
+		Prefix:            strPtr("/miren"),
+		QuotaBackendBytes: intPtr(0),
+		StartEmbedded:     nil,
 	}
 }
 

--- a/pkg/serverconfig/loader.gen.go
+++ b/pkg/serverconfig/loader.gen.go
@@ -222,6 +222,10 @@ func applyCLIFlags(cfg *Config, flags *CLIFlags) {
 		cfg.Etcd.Prefix = flags.EtcdConfigPrefix
 	}
 
+	if flags.EtcdConfigQuotaBackendBytes != nil {
+		cfg.Etcd.QuotaBackendBytes = flags.EtcdConfigQuotaBackendBytes
+	}
+
 	if flags.EtcdConfigStartEmbedded != nil {
 		cfg.Etcd.StartEmbedded = flags.EtcdConfigStartEmbedded
 	}

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -342,6 +342,9 @@ configs:
           port: true
 
       quota_backend_bytes:
+        # int is 64-bit on the amd64/arm64 targets miren builds for, so byte counts up
+        # to the 8 GiB cap fit; the config generator has no int64 type. Negatives are
+        # rejected so a bad value fails early rather than silently auto-sizing.
         type: int
         default: 0
         cli:
@@ -349,6 +352,8 @@ configs:
           description: Etcd backend quota in bytes (0 = auto-size from system RAM)
         env: MIREN_ETCD_QUOTA_BACKEND_BYTES
         toml: quota_backend_bytes
+        validation:
+          min: 0
 
   VictoriaLogsConfig:
     description: VictoriaLogs configuration

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -341,6 +341,15 @@ configs:
         validation:
           port: true
 
+      quota_backend_bytes:
+        type: int
+        default: 0
+        cli:
+          long: etcd-quota-backend-bytes
+          description: Etcd backend quota in bytes (0 = auto-size from system RAM)
+        env: MIREN_ETCD_QUOTA_BACKEND_BYTES
+        toml: quota_backend_bytes
+
   VictoriaLogsConfig:
     description: VictoriaLogs configuration
     fields:

--- a/pkg/serverconfig/validation.gen.go
+++ b/pkg/serverconfig/validation.gen.go
@@ -101,6 +101,11 @@ func (c *EtcdConfig) Validate() error {
 		return fmt.Errorf("peer_port must be between 1 and 65535, got %d", *c.PeerPort)
 	}
 
+	// Validate quota_backend_bytes minimum
+	if c.QuotaBackendBytes != nil && *c.QuotaBackendBytes < 0 {
+		return fmt.Errorf("quota_backend_bytes must be at least 0, got %d", *c.QuotaBackendBytes)
+	}
+
 	// Check for port conflicts in EtcdConfig
 	seen := make(map[int]bool)
 	if c.ClientPort != nil {


### PR DESCRIPTION
## Motivation

As we're working towards further stability, it's important to look at each of our sub-components configuration, this is the first.

## Summary

etcd runs as a small co-tenant inside customer clusters (nodes from ~1 GB to 64 GB RAM) and should hold to roughly **10% of system RAM** rather than grow to fill the node. Until now it launched with a fixed set of options regardless of node size.

This implements the **config-options portion** of the memory-tier tuning analysis: compute a per-node budget and scale etcd's memory-related config off it, auto-detected at startup.

## What it does

Computes a per-node budget `B = max(0.10 × system_RAM, 100 MiB)` from `/proc/meminfo` and derives:

- **`GOMEMLIMIT`** (65% of B) and **`GOGC`** — Go GC pressure toward the budget
- **`--quota-backend-bytes`** (30% of B, capped at 8 GiB) — the actual ceiling on keyspace growth
- Tier-keyed (≤200 MiB / ≤800 MiB / ≤1.6 GiB / else): **auto-compaction retention**, **`--snapshot-count`**, **`--experimental-snapshot-catchup-entries`**, **`--max-concurrent-streams`**, **`--experimental-compaction-batch-limit`**

The computed values are logged at startup (`etcd memory auto-tuning`).

## Design notes

- **Advisory only, no cgroup enforcement.** No `memory.max` is imposed on the container, so miren never OOM-kills etcd. `GOMEMLIMIT` drives the runtime to GC harder as it approaches the budget (soft limit — it will exceed rather than crash if the live set is genuinely too large); `--quota-backend-bytes` is the enforced bound that stops keyspace growth (`NOSPACE`).
- **Auto-detect only** — no new config knobs; operators can still override any value via `ETCD_*` env.
- **etcd v3.5 flag names.** The image is `v3.5.15`, where `snapshot-catchup-entries` and `compaction-batch-limit` are experimental-prefixed (they graduate to stable names in 3.6). Verified against the etcd 3.5 source.
- Bumps `currentConfigVersion` (1→2) so existing containers recreate on upgrade to pick up the new spec.

Out of scope: the fork-level code changes (C.x) and the cgroup enforcement layer from the analysis.

## Testing

- `go test ./components/etcd/` — 13 pass (tier table over 1/2/4/8/16/32/64 GB + sub-1 GB floor + zero-RAM fallback + monotonicity + env/args rendering)
- `go vet`, `make lint` — clean
- `go build ./components/etcd/... ./cli/...` — succeeds

End-to-end verification against a running dev cluster has not been run yet.