### PR TITLE
Add runner reissue to rotate runner credentials in place

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -673,6 +673,13 @@ miren deploy --analyze
 				Body: "miren runner join mren_... --coordinator 10.0.0.5:8443",
 			}),
 		))
+		d.Dispatch("runner reissue", Infer("runner reissue", "Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity", RunnerReissue,
+			WithLabsFeature(labs.FeatureDistributedRunners),
+			WithExample(mflags.Example{
+				Name: "Rotate this runner's certificate",
+				Body: "miren runner reissue",
+			}),
+		))
 		d.Dispatch("runner start", Infer("runner start", "Start this machine as a distributed runner", RunnerStart,
 			WithLabsFeature(labs.FeatureDistributedRunners),
 			WithExample(mflags.Example{

--- a/cli/commands/runner_reissue.go
+++ b/cli/commands/runner_reissue.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"fmt"
+	"net"
+
+	"miren.dev/runtime/api/runner/runner_v1alpha"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/runnerconfig"
+)
+
+// RunnerReissue rotates the runner's client certificate in place. It authenticates
+// to the coordinator with the runner's existing certificate and asks for a fresh
+// one (new key, same identity and CommonName), then writes only the credential
+// material back to the config. Use it to rotate credentials on demand, for hygiene
+// or in response to a suspected key compromise, without a full re-join: the runner
+// keeps its identity and its sandbox schedules stay bound to the same node.
+//
+// The on-disk certificate must still be valid, because it is the authentication.
+// A runner whose certificate has expired or is otherwise unusable can't be rotated
+// this way and should be re-provisioned with `runner remove` followed by
+// `runner join --runner-id <id>`, which re-establishes the same identity from a
+// fresh join token.
+func RunnerReissue(ctx *Context, opts struct {
+	Coordinator string `short:"c" long:"coordinator" description:"Override coordinator address (defaults to the runner config)"`
+	ListenAddr  string `short:"l" long:"listen" description:"Address this runner listens on (covered by the new cert; auto-discovered if unset)"`
+	ConfigPath  string `long:"config" description:"Path to the runner config" default:"/var/lib/miren/runner/config.yaml"`
+}) error {
+	if !runnerconfig.Exists(opts.ConfigPath) {
+		return fmt.Errorf("no runner config at %s; run 'miren runner join' first", opts.ConfigPath)
+	}
+
+	cfg, err := runnerconfig.Load(opts.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load runner config: %w", err)
+	}
+	if cfg.ClientCert == "" || cfg.ClientKey == "" || cfg.CACert == "" {
+		return fmt.Errorf("runner config at %s has no complete certificate material to rotate; re-provision with 'runner remove' + 'runner join'", opts.ConfigPath)
+	}
+
+	coordinator := cfg.CoordinatorAddress
+	if opts.Coordinator != "" {
+		coordinator = opts.Coordinator
+	}
+	if coordinator == "" {
+		return fmt.Errorf("no coordinator address in config; pass --coordinator")
+	}
+
+	listenAddr := opts.ListenAddr
+	if listenAddr == "" {
+		ip, err := discoverOutboundIP(coordinator)
+		if err != nil {
+			return fmt.Errorf("could not discover listen address (use --listen to set manually): %w", err)
+		}
+		listenAddr = net.JoinHostPort(ip.String(), "8444")
+	}
+
+	ctx.Printf("Rotating certificate for runner '%s' (%s) via %s\n", cfg.Name, cfg.RunnerID, coordinator)
+
+	// Authenticate with the runner's existing certificate. This is what proves we
+	// are this runner, so the coordinator will only ever re-issue for the identity
+	// the presented certificate already carries.
+	cs, err := rpc.NewState(ctx,
+		rpc.WithLogger(ctx.Log),
+		rpc.WithBindAddr("[::]:0"),
+		rpc.WithCertPEMs([]byte(cfg.ClientCert), []byte(cfg.ClientKey)),
+		rpc.WithCertificateVerification([]byte(cfg.CACert)),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create RPC state: %w", err)
+	}
+	defer cs.Close()
+
+	client, err := cs.Connect(coordinator, rpc.ServiceRunner)
+	if err != nil {
+		return fmt.Errorf("failed to connect to coordinator: %w", err)
+	}
+	defer client.Close()
+
+	rc := runner_v1alpha.NewRunnerRegistrationClient(client)
+	res, err := rc.RefreshCertificate(ctx, listenAddr)
+	if err != nil {
+		return fmt.Errorf("reissue request failed: %w", err)
+	}
+	if res.Error() != "" {
+		return fmt.Errorf("reissue rejected by coordinator: %s", res.Error())
+	}
+	if len(res.CertPem()) == 0 || len(res.KeyPem()) == 0 || len(res.CaPem()) == 0 {
+		return fmt.Errorf("coordinator returned incomplete certificate material; leaving config unchanged")
+	}
+
+	// Update only the credential material; every other field (labels, disk_mode,
+	// endpoints, name) is preserved as-is.
+	cfg.ClientCert = string(res.CertPem())
+	cfg.ClientKey = string(res.KeyPem())
+	cfg.CACert = string(res.CaPem())
+
+	if err := cfg.Save(opts.ConfigPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	ctx.Printf("Certificate rotated; config updated at %s\n", opts.ConfigPath)
+	ctx.Printf("\nRestart the runner to load the new certificate:\n")
+	ctx.Printf("  systemctl restart miren-runner\n")
+
+	return nil
+}

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -63,12 +63,12 @@ func RunnerStart(ctx *Context, opts struct {
 	}
 
 	// The runner's certificate is persisted in the config (often on a disk that
-	// outlives the VM). If the listen address has changed since the cert was
-	// issued, the persisted cert no longer covers our IP and clients (e.g.
-	// sandbox exec) will fail TLS verification. Re-issue the cert before we use
-	// it to serve. Refreshing is fatal when the address isn't covered: serving a
-	// stale cert would leave the runner silently unreachable.
-	if err := ensureRunnerCertificate(ctx, cfg, opts.ConfigPath, listenAddr); err != nil {
+	// outlives the VM). Before serving, reconcile it: refresh it if the listen
+	// address isn't covered (fatal — a stale cert leaves the runner unreachable),
+	// proactively rotate it if it's past its renewal threshold, and warn if its
+	// CommonName has drifted from the runner_id. Rotation takes effect on this
+	// start; the cert baked into the serving stack below is the reconciled one.
+	if err := reconcileRunnerCertificate(ctx, cfg, opts.ConfigPath, listenAddr); err != nil {
 		return err
 	}
 
@@ -315,28 +315,78 @@ func RunnerStart(ctx *Context, opts struct {
 	return nil
 }
 
-// ensureRunnerCertificate re-issues the runner's server certificate when the
-// current listen address is not covered by the persisted certificate's SANs.
-// This happens when a VM is recreated with a new IP but a persistent disk keeps
-// the old config (cert + runner ID). The refreshed cert is written back to the
-// config so it survives subsequent restarts. A required-but-failed refresh is
-// fatal: serving a stale cert would leave the runner silently unreachable.
-func ensureRunnerCertificate(ctx *Context, cfg *runnerconfig.Config, configPath, listenAddr string) error {
+// certRenewalFraction is the fraction of a certificate's total validity after
+// which the runner proactively rotates it. Rotating at two-thirds of the lifetime
+// leaves roughly a third of the validity as runway to authenticate the renewal
+// (which uses the still-valid current cert), keeping the runner clear of the hard
+// expiry cliff where it can no longer refresh itself.
+const certRenewalFraction = 2.0 / 3.0
+
+// reconcileRunnerCertificate inspects the persisted runner certificate at startup
+// and brings it into a good state before the runner serves. It handles three
+// conditions: a listen address the cert's SANs don't cover (refresh, fatal on
+// failure because a stale cert leaves the runner unreachable), a cert past its
+// renewal threshold (proactive rotation, best-effort since a still-valid cert
+// isn't worth failing startup over), and a CommonName that has drifted from the
+// runner_id (warn — workload tokens will be denied until the runner is
+// re-provisioned).
+//
+// An already-expired certificate is fatal: it can't be refreshed (the expired
+// cert is what would authenticate the refresh), so the runner can't recover in
+// place and must be re-provisioned. Rotation and refresh use RefreshCertificate,
+// which preserves the cert's CommonName, so a drifted CommonName can't be repaired
+// here either and is surfaced as a warning.
+func reconcileRunnerCertificate(ctx *Context, cfg *runnerconfig.Config, configPath, listenAddr string) error {
 	if cfg.ClientCert == "" {
 		return nil
+	}
+
+	warnIfCertCommonNameDrifted(ctx, cfg)
+
+	expired, err := certExpired(cfg.ClientCert)
+	if err != nil {
+		return fmt.Errorf("failed to inspect runner certificate: %w", err)
+	}
+	if expired {
+		return fmt.Errorf("runner certificate has expired and cannot be rotated in place; "+
+			"re-provision with 'miren runner remove' then 'miren runner join --runner-id %s'", cfg.RunnerID)
 	}
 
 	covered, err := certCoversListenAddr(cfg.ClientCert, listenAddr)
 	if err != nil {
 		return fmt.Errorf("failed to inspect runner certificate: %w", err)
 	}
-	if covered {
-		return nil
+
+	if !covered {
+		ctx.Log.Info("runner certificate does not cover listen address; refreshing",
+			"listen_addr", listenAddr)
+		// Fatal on failure: serving a cert that doesn't cover our address leaves
+		// the runner silently unreachable.
+		return refreshRunnerCertificate(ctx, cfg, configPath, listenAddr)
 	}
 
-	ctx.Log.Info("runner certificate does not cover listen address; refreshing",
-		"listen_addr", listenAddr)
+	needsRotation, err := certPastRenewalThreshold(cfg.ClientCert)
+	if err != nil {
+		ctx.Log.Warn("could not evaluate runner certificate expiry; skipping rotation", "error", err)
+		return nil
+	}
+	if needsRotation {
+		ctx.Log.Info("runner certificate is past its renewal threshold; rotating",
+			"listen_addr", listenAddr)
+		// Best-effort: the cert is still valid, so a momentarily unavailable
+		// coordinator shouldn't block startup. We'll try again on the next start.
+		if err := refreshRunnerCertificate(ctx, cfg, configPath, listenAddr); err != nil {
+			ctx.Log.Warn("proactive certificate rotation failed; will retry on next start", "error", err)
+		}
+	}
 
+	return nil
+}
+
+// refreshRunnerCertificate asks the coordinator to re-issue the runner's
+// certificate (preserving its CommonName) with SANs for listenAddr, then writes
+// the new material back to the config so it survives restarts.
+func refreshRunnerCertificate(ctx *Context, cfg *runnerconfig.Config, configPath, listenAddr string) error {
 	cs, err := rpc.NewState(ctx,
 		rpc.WithLogger(ctx.Log),
 		rpc.WithBindAddr("[::]:0"),
@@ -380,6 +430,82 @@ func ensureRunnerCertificate(ctx *Context, cfg *runnerconfig.Config, configPath,
 	return nil
 }
 
+// parseLeafCertificate decodes the first PEM block in certPEM and returns the
+// parsed leaf certificate.
+func parseLeafCertificate(certPEM string) (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing certificate: %w", err)
+	}
+	return cert, nil
+}
+
+// certExpired reports whether the leaf certificate in certPEM is past its
+// NotAfter. An expired cert can't authenticate a refresh, so the runner can't
+// recover it in place.
+func certExpired(certPEM string) (bool, error) {
+	cert, err := parseLeafCertificate(certPEM)
+	if err != nil {
+		return false, err
+	}
+	return time.Now().After(cert.NotAfter), nil
+}
+
+// certPastRenewalThreshold reports whether the leaf certificate in certPEM is past
+// certRenewalFraction of its total validity and should be proactively rotated.
+func certPastRenewalThreshold(certPEM string) (bool, error) {
+	cert, err := parseLeafCertificate(certPEM)
+	if err != nil {
+		return false, err
+	}
+
+	lifetime := cert.NotAfter.Sub(cert.NotBefore)
+	if lifetime <= 0 {
+		return false, nil
+	}
+	renewAfter := cert.NotBefore.Add(time.Duration(float64(lifetime) * certRenewalFraction))
+	return time.Now().After(renewAfter), nil
+}
+
+// warnIfCertCommonNameDrifted logs a loud warning when the persisted certificate's
+// CommonName no longer matches runner-<runner_id>. This is the state that silently
+// broke workload identity on older runners (MIR-1228): the coordinator authorizes
+// workload-token requests by the cert CommonName, so a drifted name is denied.
+// In-place rotation preserves the CommonName and so can't repair a drifted one, so
+// we direct the operator to re-provision the runner, which mints a fresh cert with
+// the current naming scheme while keeping the same runner_id.
+func warnIfCertCommonNameDrifted(ctx *Context, cfg *runnerconfig.Config) {
+	if cfg.RunnerID == "" {
+		return
+	}
+	cn, err := certCommonName(cfg.ClientCert)
+	if err != nil {
+		return
+	}
+
+	// Mirrors the coordinator's runnerCertName scheme (runner-<full runner_id>).
+	want := "runner-" + cfg.RunnerID
+	if cn != want {
+		ctx.Log.Warn("runner certificate CommonName does not match runner_id; workload identity tokens will be denied. Re-provision this runner ('miren runner remove' then 'miren runner join' reusing its runner_id) to mint a cert with the current naming scheme.",
+			"cert_common_name", cn,
+			"expected_common_name", want,
+			"runner_id", cfg.RunnerID)
+	}
+}
+
+// certCommonName returns the CommonName of the leaf certificate in certPEM.
+func certCommonName(certPEM string) (string, error) {
+	cert, err := parseLeafCertificate(certPEM)
+	if err != nil {
+		return "", err
+	}
+	return cert.Subject.CommonName, nil
+}
+
 // certCoversListenAddr reports whether the leaf certificate in certPEM carries a
 // SAN matching the host of listenAddr: an IP SAN for an IP host, or a DNS SAN
 // for a hostname. This mirrors how the coordinator builds the certificate's SANs
@@ -393,13 +519,9 @@ func certCoversListenAddr(certPEM, listenAddr string) (bool, error) {
 		return true, nil
 	}
 
-	block, _ := pem.Decode([]byte(certPEM))
-	if block == nil {
-		return false, fmt.Errorf("no PEM block found in certificate")
-	}
-	cert, err := x509.ParseCertificate(block.Bytes)
+	cert, err := parseLeafCertificate(certPEM)
 	if err != nil {
-		return false, fmt.Errorf("parsing certificate: %w", err)
+		return false, err
 	}
 
 	if ip := net.ParseIP(host); ip != nil {

--- a/cli/commands/runner_start_cert_test.go
+++ b/cli/commands/runner_start_cert_test.go
@@ -1,0 +1,146 @@
+//go:build linux
+
+package commands
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// makeTestCertPEM mints a self-signed leaf certificate with the given CommonName
+// and validity window, returning its PEM encoding. It lets the expiry/CN checks be
+// tested against precise NotBefore/NotAfter values (caauth issues relative to now).
+func makeTestCertPEM(t *testing.T, commonName string, notBefore, notAfter time.Time) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func TestCertPastRenewalThreshold(t *testing.T) {
+	now := time.Now()
+	year := 365 * 24 * time.Hour
+
+	tests := []struct {
+		name      string
+		notBefore time.Time
+		notAfter  time.Time
+		want      bool
+	}{
+		{
+			// Freshly issued: ~0% of lifetime elapsed.
+			name:      "fresh cert not due",
+			notBefore: now,
+			notAfter:  now.Add(year),
+			want:      false,
+		},
+		{
+			// Just under two-thirds (200 of 365 days elapsed).
+			name:      "past half but under threshold",
+			notBefore: now.Add(-200 * 24 * time.Hour),
+			notAfter:  now.Add(165 * 24 * time.Hour),
+			want:      false,
+		},
+		{
+			// Past two-thirds (300 of 365 days elapsed).
+			name:      "past renewal threshold",
+			notBefore: now.Add(-300 * 24 * time.Hour),
+			notAfter:  now.Add(65 * 24 * time.Hour),
+			want:      true,
+		},
+		{
+			// Already expired is well past the threshold.
+			name:      "expired",
+			notBefore: now.Add(-2 * year),
+			notAfter:  now.Add(-year),
+			want:      true,
+		},
+		{
+			// Degenerate zero-length validity is treated as not-due.
+			name:      "zero lifetime",
+			notBefore: now,
+			notAfter:  now,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			certPEM := makeTestCertPEM(t, "runner-abc", tt.notBefore, tt.notAfter)
+			got, err := certPastRenewalThreshold(certPEM)
+			if err != nil {
+				t.Fatalf("certPastRenewalThreshold returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("certPastRenewalThreshold = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCertPastRenewalThresholdInvalidPEM(t *testing.T) {
+	if _, err := certPastRenewalThreshold("not a pem"); err == nil {
+		t.Fatal("expected error for invalid PEM input")
+	}
+}
+
+func TestCertExpired(t *testing.T) {
+	now := time.Now()
+	hour := time.Hour
+
+	valid := makeTestCertPEM(t, "runner-abc", now.Add(-hour), now.Add(hour))
+	if got, err := certExpired(valid); err != nil || got {
+		t.Errorf("certExpired(valid) = %v (err %v), want false", got, err)
+	}
+
+	expired := makeTestCertPEM(t, "runner-abc", now.Add(-2*hour), now.Add(-hour))
+	if got, err := certExpired(expired); err != nil || !got {
+		t.Errorf("certExpired(expired) = %v (err %v), want true", got, err)
+	}
+
+	if _, err := certExpired("not a pem"); err == nil {
+		t.Fatal("expected error for invalid PEM input")
+	}
+}
+
+func TestCertCommonName(t *testing.T) {
+	now := time.Now()
+	certPEM := makeTestCertPEM(t, "runner-abcd1234-5678-90ab-cdef-1234567890ab", now, now.Add(time.Hour))
+
+	cn, err := certCommonName(certPEM)
+	if err != nil {
+		t.Fatalf("certCommonName returned error: %v", err)
+	}
+	if want := "runner-abcd1234-5678-90ab-cdef-1234567890ab"; cn != want {
+		t.Errorf("certCommonName = %q, want %q", cn, want)
+	}
+}
+
+func TestCertCommonNameInvalidPEM(t *testing.T) {
+	if _, err := certCommonName("not a pem"); err == nil {
+		t.Fatal("expected error for invalid PEM input")
+	}
+}

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -270,6 +270,7 @@
       "command/runner-install",
       "command/runner-join",
       "command/runner-list",
+      "command/runner-reissue",
       "command/runner-remove",
       "command/runner-service-status",
       "command/runner-start",

--- a/docs/docs/command/runner-reissue.md
+++ b/docs/docs/command/runner-reissue.md
@@ -1,0 +1,43 @@
+---
+title: "miren runner reissue"
+sidebar_label: "runner reissue"
+description: "Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity"
+---
+
+# miren runner reissue
+
+Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity
+
+:::note
+This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
+:::
+
+## Usage
+
+```bash
+miren runner reissue [flags]
+```
+
+## Flags
+
+- `--config` — Path to the runner config (default: `/var/lib/miren/runner/config.yaml`)
+- `--coordinator, -c` — Override coordinator address (defaults to the runner config)
+- `--listen, -l` — Address this runner listens on (covered by the new cert; auto-discovered if unset)
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Rotate this runner's certificate:**
+
+```bash
+miren runner reissue
+```
+
+## See also
+
+- [`miren runner`](/command/runner)

--- a/docs/docs/command/runner.md
+++ b/docs/docs/command/runner.md
@@ -21,6 +21,7 @@ miren runner [flags]
 - [`miren runner install`](/command/runner-install) — Install systemd service for miren runner
 - [`miren runner join`](/command/runner-join) — Join this machine to a coordinator as a runner
 - [`miren runner list`](/command/runner-list) — List all registered runners
+- [`miren runner reissue`](/command/runner-reissue) — Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity
 - [`miren runner remove`](/command/runner-remove) — Remove a registered runner and clean up resources
 - [`miren runner service-status`](/command/runner-service-status) — Show miren-runner systemd service status
 - [`miren runner start`](/command/runner-start) — Start this machine as a distributed runner

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -198,6 +198,7 @@ Complete reference for all `miren` CLI commands.
 | [`miren runner install`](/command/runner-install) | Install systemd service for miren runner _(`distributedrunners`)_ |
 | [`miren runner join`](/command/runner-join) | Join this machine to a coordinator as a runner _(`distributedrunners`)_ |
 | [`miren runner list`](/command/runner-list) | List all registered runners _(`distributedrunners`)_ |
+| [`miren runner reissue`](/command/runner-reissue) | Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity _(`distributedrunners`)_ |
 | [`miren runner remove`](/command/runner-remove) | Remove a registered runner and clean up resources _(`distributedrunners`)_ |
 | [`miren runner service-status`](/command/runner-service-status) | Show miren-runner systemd service status _(`distributedrunners`)_ |
 | [`miren runner start`](/command/runner-start) | Start this machine as a distributed runner _(`distributedrunners`)_ |


### PR DESCRIPTION
A distributed runner gets its mTLS client certificate once, at `runner join`, and it lives for a year. Until now there was no supported way to rotate it short of a full manual re-join, which drops the runner's schedules and is fiddly enough that we resorted to surgical entity edits by hand when we hit it in production. "You can mint a runner credential but never rotate it" is also a plain table-stakes gap for running distributed runners for real.

`miren runner reissue` closes it. Run it on the runner host and it authenticates with the runner's existing certificate, asks the coordinator for a fresh one (new key, same identity and CommonName), and writes only the credential material back to the config. The runner keeps its identity and its sandbox schedules stay bound to the same node. It's deliberately built on the coordinator's existing `RefreshCertificate` path rather than a new RPC: because the existing certificate is the authentication, a runner can only ever rotate its own credential, so there's no new authorization surface and no way to mint a cert for another runner's identity.

Alongside the manual command, the runner now reconciles its certificate at startup: it proactively rotates once the cert is past two-thirds of its lifetime, so a continuously-deployed fleet renews itself well before expiry, and it warns loudly if the CommonName has drifted from the runner_id, so that class of workload-identity breakage shows up in the logs instead of silently denying tokens.

Two cases are intentionally out of scope, because both need an anchor the existing certificate can't provide: a cert that has already expired (mTLS won't handshake), and a cert whose CommonName predates a naming-scheme change. Both are handled by re-provisioning, `runner remove` then `runner join --runner-id <id>`, which re-establishes the same identity from a fresh join token without the old hand-surgery. A runner with an expired cert is already fully offline with no live work, so that's a fine line to draw.

Closes MIR-1228
