### PR TITLE
Make MockStore reject mistyped db/id the way production does

### DIFF
--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -163,6 +163,12 @@ func (m *MockStore) CreateEntity(ctx context.Context, entity *Entity, opts ...En
 		return nil, err
 	}
 
+	// Mirror EtcdStore.CreateEntity (store.go:171): allocate an ID before
+	// storing. This also makes mock-backed tests fail loudly on a mistyped
+	// db/id, the same way production does, instead of silently keying the
+	// entity under an empty ID.
+	entity.ForceID()
+
 	// Set CreatedAt if not already set (store manages this timestamp)
 	if entity.GetCreatedAt().IsZero() {
 		entity.SetCreatedAt(m.Now())

--- a/pkg/entity/store_conformance_test.go
+++ b/pkg/entity/store_conformance_test.go
@@ -223,6 +223,25 @@ func TestStoreConformance_CreateEntity(t *testing.T) {
 	})
 }
 
+// TestStoreConformance_CreateRejectsMistypedDBId pins the MIR-601 contract: a
+// db/id supplied with the wrong value kind (a bare string, KindString, rather
+// than an entity.Id, KindId) must fail loudly on every backend instead of
+// silently minting a fresh auto-id and discarding the caller's id. This is the
+// mistake that surfaced in MIR-600, where createDiskLease passed a plain string
+// for db/id. Before MIR-601, MockStore.CreateEntity skipped ForceID entirely,
+// so the divergence hid here: production regenerated the id, but mock-backed
+// tests keyed the entity under an empty id without complaint.
+func TestStoreConformance_CreateRejectsMistypedDBId(t *testing.T) {
+	runStoreConformance(t, func(t *testing.T, store Store) {
+		assert.Panics(t, func() {
+			_, _ = store.CreateEntity(t.Context(), New(
+				DBId, "conf-mistyped-id",
+				Any(Doc, "wrong kind"),
+			))
+		}, "a mistyped db/id (KindString) must fail loudly, not silently regenerate the id")
+	})
+}
+
 // TestStoreConformance_EnsureEntity pins the create-if-absent contract that
 // saga storage depends on: the first Ensure creates and reports created=true;
 // a second Ensure with the same id returns the existing entity with


### PR DESCRIPTION
Back on MIR-600 we hit a nasty little bug where `createDiskLease` handed the entity store a plain string for `db/id` instead of an `entity.Id`. A bare string is a `KindString` value, the store didn't recognize it as an id, and it silently minted a fresh auto-generated id and threw the caller's away. MIR-601 came out of that: stop silently replacing IDs.

The dangerous half is already handled. `Entity.ForceID()` now panics when it sees a `db/id` that isn't a `KindId`, so the create path fails loudly instead of quietly substituting a new id. We went with the strict "fail loud" fork on purpose rather than teaching `Entity.Id()` to accept strings, since accepting the wrong type would just bring the silent substitution back under a new name.

What was left was a test/prod gap. `MockStore.CreateEntity` keyed entities straight off `entity.Id()` and never called `ForceID`, so the exact mistake this ticket is about would panic in production but sail through mock-backed tests, storing the entity under an empty id. That's the kind of divergence the store-conformance suite exists to catch (same class as MIR-441), so this closes it: the mock now calls `ForceID` like the real store, and a new conformance scenario pins "a mistyped db/id fails loudly" against both backends.

Closes MIR-601