### PR TITLE
Make DeleteEntity atomic to stop the pool index leak (MIR-1334)

### DIFF
--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -1322,61 +1322,97 @@ func (s *EtcdStore) EnsureEntity(
 	return entity, true, nil
 }
 
-// DeleteEntity implements Store interface
+// deleteEntityRaceHook is a test seam. When non-nil, DeleteEntity invokes it
+// after reading the entity but before committing the guarded delete transaction,
+// letting a white-box test deterministically interleave a concurrent write into
+// the revision-guard window. It is always nil in production.
+var deleteEntityRaceHook func()
+
+// DeleteEntity implements Store interface.
+//
+// The delete is atomic: the entity key, its index (collection) entries, and its
+// unique-value keys are all removed in a single revision-guarded transaction. If
+// they were removed separately (as they once were, with the index deletes issued
+// as immediate unconditional Deletes before the entity-key txn), a concurrent
+// no-OCC patch could slip into the gap and re-add index entries after the entity
+// was gone, leaking a stale index entry (MIR-1334).
+//
+// Because the txn is guarded on the entity's ModRevision, a concurrent write that
+// bumps the revision between our read and the txn makes it fail. Pools are patched
+// on every reconcile tick via the no-OCC path, so a single-shot delete could lose
+// that race repeatedly; we re-read and retry a bounded number of times so the
+// delete wins against a busy reconcile loop instead of spuriously reporting the
+// entity as already gone.
 func (s *EtcdStore) DeleteEntity(ctx context.Context, id Id) error {
-	entity, err := s.GetEntity(ctx, id)
-	if err != nil {
-		if errors.Is(err, cond.ErrNotFound{}) {
-			return nil
+	const maxDeleteRetries = 3
+	for attempt := 0; ; attempt++ {
+		entity, err := s.GetEntity(ctx, id)
+		if err != nil {
+			if errors.Is(err, cond.ErrNotFound{}) {
+				return nil
+			}
+			return err
 		}
-		return err
-	}
 
-	// Collect all indexed attributes including nested ones within components
-	indexedAttrs, err := s.collectIndexedAttributes(ctx, entity.attrs)
-	if err != nil {
-		return err
-	}
+		// Collect all indexed attributes including nested ones within components
+		indexedAttrs, err := s.collectIndexedAttributes(ctx, entity.attrs)
+		if err != nil {
+			return err
+		}
 
-	// Delete all index entries for this entity
-	for _, attrs := range indexedAttrs {
-		for _, attr := range attrs {
-			// TODO: Batch this as an op into the below txn
-			err := s.deleteFromCollection(entity, attr.CAS())
-			if err != nil {
-				return fmt.Errorf("failed to delete entity from collection: %w", err)
+		// Test seam: exercise the read-before-txn window deterministically. This
+		// is the exact gap a concurrent no-OCC patch could slip into (MIR-1334),
+		// so a test can inject one here to prove the delete stays atomic. Always
+		// nil in production.
+		if deleteEntityRaceHook != nil {
+			deleteEntityRaceHook()
+		}
+
+		key := s.buildKey(id)
+
+		// Build all delete operations: entity key + index entries + unique-value
+		// keys, so the whole delete commits (or fails) as one guarded txn.
+		ops := []clientv3.Op{clientv3.OpDelete(key)}
+
+		for _, attrs := range indexedAttrs {
+			for _, attr := range attrs {
+				ops = append(ops, s.deleteFromCollectionOp(entity, attr.CAS()))
 			}
 		}
+
+		uniqueAttrs, err := s.collectUniqueAttrs(ctx, entity)
+		if err != nil {
+			return err
+		}
+		for _, attr := range uniqueAttrs {
+			ops = append(ops, s.deleteUniqueOp(attr))
+		}
+
+		// Guard on the entity's ModRevision so the delete is all-or-nothing and
+		// can't interleave with a concurrent patch.
+		txnResp, err := s.client.Txn(ctx).
+			If(clientv3.Compare(clientv3.ModRevision(key), "=", entity.GetRevision())).
+			Then(ops...).
+			Commit()
+
+		if err != nil {
+			return fmt.Errorf("failed to delete entity from etcd: %w", err)
+		}
+
+		if txnResp.Succeeded {
+			return nil
+		}
+
+		// The guard failed: either the entity was concurrently deleted, or a
+		// concurrent write bumped its revision. Re-read and retry; GetEntity
+		// returning NotFound on the next pass resolves the former.
+		if attempt >= maxDeleteRetries {
+			s.log.Error("delete lost revision race after retries", "id", id)
+			return cond.Conflict("entity", id)
+		}
+		s.log.Info("delete revision race, re-reading and retrying",
+			"id", id, "attempt", attempt+1)
 	}
-
-	key := s.buildKey(id)
-
-	// Build delete operations: entity key + unique-value keys
-	ops := []clientv3.Op{clientv3.OpDelete(key)}
-
-	uniqueAttrs, err := s.collectUniqueAttrs(ctx, entity)
-	if err != nil {
-		return err
-	}
-	for _, attr := range uniqueAttrs {
-		ops = append(ops, s.deleteUniqueOp(attr))
-	}
-
-	// Use Txn to check that the key exists before deleting
-	txnResp, err := s.client.Txn(ctx).
-		If(clientv3.Compare(clientv3.ModRevision(key), "=", entity.GetRevision())).
-		Then(ops...).
-		Commit()
-
-	if err != nil {
-		return fmt.Errorf("failed to delete entity from etcd: %w", err)
-	}
-
-	if !txnResp.Succeeded {
-		return cond.NotFound("entity", id)
-	}
-
-	return nil
 }
 
 // ClearSchemaCache clears the in-memory schema cache, forcing subsequent
@@ -1463,17 +1499,6 @@ func (s *EtcdStore) deleteFromCollectionOp(entity *Entity, collection string) cl
 	key = fmt.Sprintf("%s/collections/%s/%s", s.prefix, colKey, key)
 
 	return clientv3.OpDelete(key)
-}
-
-func (s *EtcdStore) deleteFromCollection(entity *Entity, collection string) error {
-	key := base58.Encode([]byte(entity.Id()))
-	colKey := tr.Replace(collection)
-
-	ctx := context.Background()
-	key = fmt.Sprintf("%s/collections/%s/%s", s.prefix, colKey, key)
-
-	_, err := s.client.Delete(ctx, key)
-	return err
 }
 
 func (s *EtcdStore) ListIndex(ctx context.Context, attr Attr) ([]Id, error) {

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2703,4 +2704,279 @@ func TestEtcdStore_PatchToleratesDanglingRefInComponent(t *testing.T) {
 		String(Id("test/status"), "released"),
 	))
 	r.NoError(err, "status patch must tolerate a dangling ref nested in an unchanged component")
+}
+
+// expectedIndexKey rebuilds the etcd collection key that addToCollectionOp would
+// write for the given entity id + indexed attribute, so a test can check whether
+// that specific index entry survives a delete.
+func expectedIndexKey(prefix string, id Id, attr Attr) string {
+	return fmt.Sprintf("%s/collections/%s/%s", prefix, tr.Replace(attr.CAS()), base58.Encode([]byte(id)))
+}
+
+// TestEtcdStore_DeleteRemovesAllIndexEntries reproduces the MIR-1320 "pool"
+// leak. A durable (unleased) kinded entity must have EVERY index entry removed
+// by DeleteEntity, including the system-managed entity/kind and db/short-id
+// indexes. On garden, deleted pool entities deterministically leaked exactly
+// those two index entries — 63% of the cluster's stale index.
+func TestEtcdStore_DeleteRemovesAllIndexEntries(t *testing.T) {
+	store, client := setupTestEtcdStore(t)
+	ctx := t.Context()
+	r := require.New(t)
+
+	// A kind entity to reference (entity/kind is a validated ref).
+	k, err := store.CreateEntity(ctx, New(Any(Ident, KeywordValue("test/pool-kind"))))
+	r.NoError(err)
+
+	// A domain indexed attribute, for contrast with the system indexes.
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "test/region",
+		Doc, "a region",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	r.NoError(err)
+
+	// A durable, kinded entity like a pool: entity/kind (indexed) triggers a
+	// db/short-id allocation (also indexed), plus a domain indexed attr.
+	pool, err := store.CreateEntity(ctx, New(
+		Any(Ident, KeywordValue("pool/thing-1")),
+		Ref(EntityKind, k.Id()),
+		String(Id("test/region"), "us-central1"),
+	))
+	r.NoError(err)
+
+	// Read the stored form to recover the system attrs (short-id is allocated
+	// by the store) and compute their expected index keys.
+	stored, err := store.GetEntity(ctx, pool.Id())
+	r.NoError(err)
+	kindAttrs := stored.GetAll(EntityKind)
+	r.NotEmpty(kindAttrs, "stored entity must carry entity/kind")
+	shortIDAttr, ok := stored.Get(DBShortId)
+	r.True(ok, "kinded entity must have a db/short-id")
+
+	kindKey := expectedIndexKey(store.Prefix(), pool.Id(), kindAttrs[0])
+	shortIDKey := expectedIndexKey(store.Prefix(), pool.Id(), shortIDAttr)
+
+	before := collectionKVsForEntity(t, client, store.Prefix(), pool.Id())
+	r.NotEmpty(before, "kinded entity must have index entries")
+	t.Logf("index entries before delete: %d", len(before))
+
+	r.NoError(store.DeleteEntity(ctx, pool.Id()))
+
+	after := collectionKVsForEntity(t, client, store.Prefix(), pool.Id())
+	var leakedKind, leakedShortID bool
+	for _, kv := range after {
+		key := string(kv.Key)
+		label := "domain"
+		switch key {
+		case kindKey:
+			label = "entity/kind"
+			leakedKind = true
+		case shortIDKey:
+			label = "db/short-id"
+			leakedShortID = true
+		}
+		t.Logf("LEAKED after delete [%s]: %s", label, key)
+	}
+	t.Logf("leaked entity/kind index: %v   leaked db/short-id index: %v", leakedKind, leakedShortID)
+
+	r.Empty(after, "DeleteEntity must remove every index entry (MIR-1320 pool leak)")
+}
+
+// TestEtcdStore_PatchThenDeleteRemovesAllIndexEntries checks the realistic pool
+// lifecycle: a kinded entity is patched (no-OCC, like a reconcile status write,
+// including an indexed-value change) and then deleted. Every index entry — the
+// old and new value of the changed attr, plus the system indexes — must be gone.
+// If a sequential patch-then-delete leaks, the pool bug is an update-path gap;
+// if it's clean, the garden leak must be the concurrent delete-vs-patch race.
+func TestEtcdStore_PatchThenDeleteRemovesAllIndexEntries(t *testing.T) {
+	store, client := setupTestEtcdStore(t)
+	ctx := t.Context()
+	r := require.New(t)
+
+	k, err := store.CreateEntity(ctx, New(Any(Ident, KeywordValue("test/pool-kind"))))
+	r.NoError(err)
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "test/region",
+		Doc, "a region",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	r.NoError(err)
+
+	pool, err := store.CreateEntity(ctx, New(
+		Any(Ident, KeywordValue("pool/thing-2")),
+		Ref(EntityKind, k.Id()),
+		String(Id("test/region"), "us-central1"),
+	))
+	r.NoError(err)
+
+	// No-OCC patch that changes the indexed region value (exercises old-value
+	// index cleanup) — mimics a reconcile tick rewriting the entity.
+	_, err = store.PatchEntity(ctx, New(
+		DBId, pool.Id(),
+		String(Id("test/region"), "us-east1"),
+	))
+	r.NoError(err)
+
+	// The old region value must no longer be indexed.
+	oldIdx, err := store.ListIndex(ctx, String(Id("test/region"), "us-central1"))
+	r.NoError(err)
+	r.NotContains(oldIdx, pool.Id(), "old indexed value must be removed by patch")
+
+	r.NoError(store.DeleteEntity(ctx, pool.Id()))
+
+	after := collectionKVsForEntity(t, client, store.Prefix(), pool.Id())
+	for _, kv := range after {
+		t.Logf("LEAKED after patch+delete: %s", kv.Key)
+	}
+	r.Empty(after, "patch-then-delete must leave no index entry (MIR-1320 pool leak)")
+}
+
+// TestEtcdStore_ConcurrentDeleteVsPatchNoStaleIndex is a stress smoke test for
+// the MIR-1334 scenario: it hammers no-OCC patches (the reconcile status-write
+// path) against a concurrent DeleteEntity on a high-churn, pool-like entity and
+// asserts the store never settles into an index/entity desync.
+//
+// The invariant every store mutation preserves is index ⟺ entity: an index
+// (collection) entry exists iff the entity it points at exists. This test drives
+// the real concurrent path (and guards against panics/deadlocks/gross breakage
+// under it), but it is NOT a reliable regression guard for the atomicity bug on
+// its own: the race window is narrow and concurrent patches tend to re-add the
+// index before the quiescence check, so the old non-atomic delete can pass here.
+// TestEtcdStore_DeleteIsAtomicUnderConcurrentPatch pins the atomicity guarantee
+// deterministically via a test seam; this one exercises it at volume.
+func TestEtcdStore_ConcurrentDeleteVsPatchNoStaleIndex(t *testing.T) {
+	store, client := setupTestEtcdStore(t)
+	ctx := t.Context()
+	r := require.New(t)
+
+	k, err := store.CreateEntity(ctx, New(Any(Ident, KeywordValue("test/pool-kind"))))
+	r.NoError(err)
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "test/region",
+		Doc, "a region",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	r.NoError(err)
+
+	const iterations = 40
+	const patchesPerIter = 15
+
+	for i := range iterations {
+		pool, err := store.CreateEntity(ctx, New(
+			Any(Ident, KeywordValue(fmt.Sprintf("pool/churn-%d", i))),
+			Ref(EntityKind, k.Id()),
+			String(Id("test/region"), "us-central1"),
+		))
+		r.NoError(err)
+		id := pool.Id()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Patcher: hammer no-OCC status patches (cas=0), rotating an indexed
+		// value so old-value index cleanup runs too. Errors are expected once
+		// the deleter wins (the entity is gone), so they're ignored.
+		go func() {
+			defer wg.Done()
+			for j := range patchesPerIter {
+				_, _ = store.PatchEntity(ctx, New(
+					DBId, id,
+					String(Id("test/region"), fmt.Sprintf("region-%d", j)),
+				))
+			}
+		}()
+
+		// Deleter: race a single delete against the patch storm.
+		go func() {
+			defer wg.Done()
+			_ = store.DeleteEntity(ctx, id)
+		}()
+
+		wg.Wait()
+
+		// At quiescence, index and entity must agree.
+		_, getErr := store.GetEntity(ctx, id)
+		kvs := collectionKVsForEntity(t, client, store.Prefix(), id)
+		if getErr != nil {
+			r.Empty(kvs, "iter %d: entity is gone but index entries survive (stale index, MIR-1334)", i)
+		} else {
+			r.NotEmpty(kvs, "iter %d: entity exists but its index entries are missing (index desync)", i)
+		}
+
+		// Ensure the entity is actually removed before the next iteration so a
+		// lingering (resurrected) entity doesn't mask a later leak.
+		r.NoError(store.DeleteEntity(ctx, id))
+		r.Empty(collectionKVsForEntity(t, client, store.Prefix(), id),
+			"iter %d: cleanup delete must leave no index entry", i)
+	}
+}
+
+// TestEtcdStore_DeleteIsAtomicUnderConcurrentPatch is the deterministic MIR-1334
+// regression test. It uses the deleteEntityRaceHook seam to inject exactly one
+// no-OCC patch into DeleteEntity's read-before-txn window — the precise gap a
+// reconcile status write could land in — and asserts the delete still leaves the
+// index and entity in agreement.
+//
+// With the atomic delete, the injected patch bumps the revision, the guarded txn
+// fails, and the bounded retry re-reads at the new revision and removes the
+// entity and every index entry together. With the old non-atomic delete (index
+// removed by unconditional Deletes before the txn), the injected patch re-adds
+// the index, the unconditional delete wipes it, and the entity txn then fails on
+// the now-stale revision — leaving the entity alive with its index gone. This
+// test forbids that disagreement, so it fails against the old delete and passes
+// against the fix.
+func TestEtcdStore_DeleteIsAtomicUnderConcurrentPatch(t *testing.T) {
+	store, client := setupTestEtcdStore(t)
+	ctx := t.Context()
+	r := require.New(t)
+
+	k, err := store.CreateEntity(ctx, New(Any(Ident, KeywordValue("test/pool-kind"))))
+	r.NoError(err)
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "test/region",
+		Doc, "a region",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	r.NoError(err)
+
+	pool, err := store.CreateEntity(ctx, New(
+		Any(Ident, KeywordValue("pool/race-1")),
+		Ref(EntityKind, k.Id()),
+		String(Id("test/region"), "us-central1"),
+	))
+	r.NoError(err)
+
+	// Fire one no-OCC patch inside the delete's read-before-txn window. sync.Once
+	// keeps it to a single injection so the atomic delete's retry can re-read past
+	// the revision bump and win; firing on every attempt would just be an infinite
+	// patch storm that no delete could beat.
+	var once sync.Once
+	deleteEntityRaceHook = func() {
+		once.Do(func() {
+			_, perr := store.PatchEntity(ctx, New(
+				DBId, pool.Id(),
+				String(Id("test/region"), "us-east1"),
+			))
+			r.NoError(perr, "injected concurrent patch must succeed")
+		})
+	}
+	t.Cleanup(func() { deleteEntityRaceHook = nil })
+
+	// The atomic delete loses the guard on the first attempt (revision bumped by
+	// the injected patch) and wins on the retry.
+	r.NoError(store.DeleteEntity(ctx, pool.Id()))
+
+	// Entity and index must agree: both gone.
+	_, getErr := store.GetEntity(ctx, pool.Id())
+	r.Error(getErr, "entity must be deleted after DeleteEntity returns")
+	r.Empty(collectionKVsForEntity(t, client, store.Prefix(), pool.Id()),
+		"no index entry may survive a delete that raced a patch (MIR-1334)")
 }

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -552,12 +552,16 @@ func (e *EntityServer) WatchIndex(ctx context.Context, req *entityserver_v1alpha
 					op.SetEntityId(string(entityId))
 					op.SetPrevious(event.PrevKv.ModRevision)
 
-					// Try to fetch the entity data for the delete event.
-					// Index entries are deleted before the entity key, so the entity
-					// may still exist. Fall back to a revision-based read if not.
+					// Try to fetch the entity data for the delete event. When only
+					// an index entry is dropped (e.g. a session lease expiring) the
+					// entity itself may still exist, so try a current read first.
+					// When the entity was deleted via DeleteEntity, the index entry
+					// and the entity key are removed together in one atomic txn, so
+					// the entity is already gone at this event's revision; read it at
+					// the prior revision to recover what was deleted.
 					en, err := e.Store.GetEntity(ctx, entityId)
 					if err != nil {
-						en, err = e.Store.GetEntityAtRevision(ctx, entityId, event.Kv.ModRevision)
+						en, err = e.Store.GetEntityAtRevision(ctx, entityId, event.Kv.ModRevision-1)
 					}
 					if err != nil {
 						e.Log.Error("failed to get entity for delete event", "error", err, "id", entityId)


### PR DESCRIPTION
This is the second half of the garden index-leak cleanup. #898 fixed the `session`-kind leak and the disk-lease sweeper loop; this one goes after the bigger remaining chunk, the `pool` kind, which accounted for about 63% of garden's stale index. On garden, 88% of `pool` index entries pointed at entities that no longer existed.

The root cause is that `DeleteEntity` wasn't atomic. It removed an entity's index and unique-key entries up front with immediate, unconditional `client.Delete` calls, then removed the entity key in a separate revision-guarded transaction (there was even a standing `// TODO: Batch this as an op into the below txn` at the index-delete site). Pools are the highest-churn entity, created and destroyed on every deploy and autoscale, and they get status-patched every reconcile tick through the no-OCC (`cas=0`) path. So a patch could slip into the gap between those two steps and re-add index entries after the entity was already gone, leaving the index and the entity out of sync. It concentrated in `pool` because that's the only high-churn kind under constant no-OCC patching.

The fix folds the index and unique-key deletes into the same revision-guarded transaction as the entity-key delete, so a delete is all-or-nothing and can't interleave with a concurrent patch. One consequence: because the transaction is guarded on the entity's ModRevision, a no-OCC patch that bumps the revision between our read and the commit now makes the delete fail cleanly instead of half-completing. Since pools are patched constantly, a single-shot guarded delete could lose that race over and over and report the entity as already gone while it's still alive, so the delete is wrapped in a bounded retry loop that re-reads and rebuilds its ops before trying again. It wins against a busy reconcile loop rather than giving up.

Making the delete atomic also surfaced a dependency in the entity server's `WatchIndex` delete-event enrichment. It recovered the deleted entity's data by reading at the index entry's delete revision, which only worked because the old ordering left the entity key alive one revision longer than its index entry. Now that they're removed together in one txn, it reads at the prior revision instead. (`TestEntityServer_WatchIndex_DeleteIncludesEntity_Etcd` caught this in CI, which is a nice bit of coverage.)

On testing: the two sequential baselines (from the MIR-1320 investigation) prove the non-concurrent delete and patch-then-delete paths already remove every index entry, including the system `entity/kind` and `db/short-id` indexes, so the leak really does require concurrency. Reproducing that concurrency turned out to be the interesting part. A plain "hammer patches while you delete" stress test doesn't reliably fail on the old code, because concurrent patches re-add the index before you can observe the desync (300 iterations, zero catches). So there are two concurrency tests: the stress smoke test that exercises the real path at volume, and a deterministic regression test that uses a tiny nil-in-production seam to inject exactly one patch into the delete's read-before-txn window. That one fails against the old non-atomic delete and passes against this fix, which is what makes it an actual regression guard.

Closes MIR-1334
