### PR TITLE
Reuse running containerd/buildkitd across test runs instead of starting duplicates

### DIFF
--- a/hack/common-setup.sh
+++ b/hack/common-setup.sh
@@ -62,6 +62,19 @@ start_containerd() {
 
     mkdir -p "$(dirname "$socket_path")"
 
+    # iso run reuses the persistent session container, so a containerd started by
+    # an earlier run is still alive. Reuse it rather than launching a second one
+    # on the same --root/--state, which would conflict on the metadata lock.
+    if ctr --address "$socket_path" version >/dev/null 2>&1; then
+        return
+    fi
+
+    # No healthy daemon answering. Reap any instance wedged mid-startup and clear
+    # its stale socket before starting fresh, mirroring the buildkitd path. -x
+    # matches the daemon exactly so we don't reap its containerd-shim children.
+    pkill -9 -x containerd 2>/dev/null || true
+    rm -f "$socket_path"
+
     if [ "$log_dest" = "/dev/null" ]; then
         containerd --root /data --state /data/state --address "$socket_path" -l trace >/dev/null 2>&1 &
     else
@@ -74,8 +87,20 @@ start_containerd() {
 start_buildkitd() {
     local log_dest="${1:-/dev/null}"
 
-    # Since our buildkit dir is cached across runs, there might be a stale lockfile
-    # sitting around that should be safe to kill
+    # iso run reuses the persistent session container, so a buildkitd started by
+    # an earlier run is still alive and holding the lock on --root. Reuse it when
+    # it's healthy: starting a second buildkitd on the same --root deadlocks on
+    # the buildkit state lock and never becomes ready ("Timeout waiting for
+    # buildkitd").
+    if buildctl debug info >/dev/null 2>&1; then
+        return
+    fi
+
+    # No healthy daemon answering. Reap any instance stuck mid-startup (e.g. one
+    # wedged on the lock from a killed run) and clear its stale lockfile, then
+    # start fresh. -x matches the daemon exactly (no unrelated children exist for
+    # buildkitd today, but keeps it symmetric with the containerd path).
+    pkill -9 -x buildkitd 2>/dev/null || true
     rm -f /data/buildkit/buildkitd.lock
 
     if [ "$log_dest" = "/dev/null" ]; then


### PR DESCRIPTION
Since mirendev/iso#7, `iso run` reuses the persistent session's container instead of spinning up a fresh one per invocation. Great for speed, but it means the containerd and buildkitd daemons that `hack/test.sh` starts now survive from one `hack/run` to the next.

The old `start_buildkitd` didn't account for that. Every run it would `rm -f /data/buildkit/buildkitd.lock` (pulling the lock out from under the still-running daemon) and launch a fresh `buildkitd --root /data/buildkit`. The second daemon then deadlocks on the buildkit state lock the first one holds, never becomes ready, and the run dies with "Timeout waiting for buildkitd." In practice the first `hack/run` in a session works and every one after it hangs until you manually `pkill buildkitd`.

The fix makes daemon startup idempotent for both containerd and buildkitd: if a healthy daemon is already answering (`ctr version` / `buildctl debug info`), reuse it. Only when nothing healthy is answering do we reap any instance wedged mid-startup and start fresh (the reaps use `pkill -x` so we match the daemon exactly and never take out its `containerd-shim` children). containerd had the same latent conflict pattern, so it gets the same treatment; a review pointed out the reap path was initially asymmetric (only buildkitd had it), so both sides now reap wedged instances.

Verified by running `hack/run` twice back to back with no cleanup in between: before, the second run hung on buildkitd; now it reuses the daemon and passes, and the containerd/buildkitd process counts stay at one each instead of climbing.
