### PR TITLE
Add a Miren Club docs page

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -61,7 +61,7 @@ sudo miren server install --without-cloud
 
 ### Using Our Demo Cluster
 
-Ask for access to our demo cluster in #miren-club on [Discord](https://miren.dev/discord). Once you have access, log in and add the cluster:
+Ask for access to our demo cluster, [Miren Club](/miren-club), in #miren-club on [Discord](https://miren.dev/discord). Once you have access, log in and add the cluster:
 
 <CliCommand context="client">
 ```miren

--- a/docs/docs/miren-club.md
+++ b/docs/docs/miren-club.md
@@ -1,0 +1,86 @@
+---
+title: Miren Club
+description: Miren Club is our shared cloud cluster for demos and experiments — request access in Discord, connect your CLI, and deploy to *.miren.club.
+keywords: [miren club, demo cluster, shared cluster, hosted, discord, experiment]
+---
+
+import CliCommand from '@site/src/components/CliCommand';
+
+# Miren Club
+
+Miren Club is our shared cloud cluster — a place to experiment with Miren and deploy something to the real internet without setting up a server of your own first. It's the fastest way to go from "I've heard of Miren" to "my app is live," and a great sandbox for demos, hack projects, and kicking the tires.
+
+If you'd rather run Miren on your own machine, that's the [Getting Started](/getting-started) path. Miren Club is for when you just want a cluster to already exist.
+
+## Requesting Access
+
+Access is granted through our [Discord](https://miren.dev/discord). Here's the flow:
+
+1. Sign in to [Miren Cloud](https://miren.cloud) with your GitHub or Google account.
+2. Post in the **#miren-club** channel asking for access, with a sentence about what you'd like to deploy.
+3. One of us will DM you an invite link.
+
+Once you've accepted the invite, you're a member of the Miren Club organization in Miren Cloud and ready to connect.
+
+## Connecting Your CLI
+
+With access sorted, log in from your local machine:
+
+<CliCommand context="client">
+```miren
+miren login
+```
+</CliCommand>
+
+Follow the prompts to authenticate with Miren Cloud. Then bind the club cluster to your local CLI:
+
+<CliCommand context="client">
+```miren
+miren cluster add
+
+Select a cluster to bind:
+   NAME   ORGANIZATION   ADDRESS
+▸  club   Miren Club     34.27.122.56:8443 (+6)
+```
+</CliCommand>
+
+Pick **club** and you're pointed at the shared cluster. Every `miren` command you run now targets Miren Club until you [switch clusters](/command/cluster).
+
+## Deploying and Going Live
+
+Deploying to Miren Club works exactly like deploying anywhere else. From your project directory:
+
+<CliCommand context="client">
+```miren
+miren deploy
+```
+</CliCommand>
+
+The one perk that comes for free: the club owns the `miren.club` domain with wildcard DNS, so you can route your app to any name you like under it. Pick something and set the route:
+
+<CliCommand context="client">
+```miren
+miren route set whateveryoulike.miren.club myapp
+```
+</CliCommand>
+
+That's it — `whateveryoulike.miren.club` is live on the internet, TLS and all. See [Traffic Routing](/traffic-routing) for more on routes.
+
+## Club Rules
+
+Miren Club is a shared resource, so a few ground rules keep it pleasant for everyone:
+
+- **Don't hog the GBs or the MHz.** Other people are sharing this cluster with you. Be a considerate neighbor with memory and CPU.
+- **Watch your step.** Right now there's a single namespace and no per-app permissions, so it's possible to clobber someone else's stuff. Deploy carefully and stay in your lane.
+- **Have fun, but be responsible.** Anything that violates our [Code of Conduct](/conduct) gets removed, and you'll have to turn in your Miren Club membership card.
+
+## Need Help?
+
+- Questions about **Miren Club specifically** (access, the shared cluster, routing to `miren.club`)? Ask in **#miren-club** on [Discord](https://miren.dev/discord).
+- Questions about **using Miren generally**? Ask in **#feedback**, or check [Troubleshooting](/troubleshooting).
+
+## Next Steps
+
+- [Getting Started](/getting-started) — The full deploy walkthrough, which works the same on Miren Club
+- [Traffic Routing](/traffic-routing) — Custom domains, wildcards, and path-based routing
+- [App Configuration](/app-configuration) — Configure your app with `.miren/app.toml`

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -106,6 +106,7 @@ const sidebars: SidebarsConfig = {
       label: 'Resources',
       collapsed: false,
       items: [
+        'miren-club',
         'agent-skills',
         'troubleshooting',
         'terminology',


### PR DESCRIPTION
Brian Cain asked in Discord whether there are public-facing docs for Miren Club, our shared cloud cluster for demos and experiments. There weren't. All we had was the Discord channel itself and a short "Try Demo Cluster" aside on the Getting Started page, so there was nothing durable to hand someone when you wanted to say "yeah, we offer a hosted cluster, here's how to get on it."

This adds a proper page. It explains what Miren Club is, walks through requesting access in `#miren-club`, covers the `miren login` / `miren cluster add` connect flow, shows deploying and routing to `*.miren.club`, and lays out the shared-resource ground rules (don't hog the GBs or the MHz, watch your step in the single namespace, be a good citizen). It lives under Resources in the sidebar, and the Getting Started demo-cluster section now links to it so both point at the same canonical URL.

Closes MIR-1342