### PR TITLE
Add --summary-json to miren deploy for machine-readable results

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -55,6 +55,7 @@ func Deploy(ctx *Context, opts struct {
 	Sensitive     []string `short:"s" long:"sensitive" description:"Set sensitive environment variable (masked in output)"`
 	Ephemeral     string   `long:"ephemeral" description:"Deploy as ephemeral preview with this label (e.g. feat-login)"`
 	TTL           string   `long:"ttl" description:"TTL for ephemeral version (e.g. 48h)" default:"24h"`
+	SummaryJSON   string   `long:"summary-json" description:"Write a JSON summary of the deploy result (deploy id, version, and route URLs) to this path"`
 }) error {
 	name := opts.App
 	dir := opts.ResolvedDir()
@@ -225,6 +226,13 @@ func Deploy(ctx *Context, opts struct {
 					displayDeployVersionAccessInfo(ctx, name, result.AccessInfo())
 				}
 			}
+
+			// dep.Id() is empty for ephemeral deploys (no deployment record).
+			var summaryURLs []string
+			if result.HasAccessInfo() && result.AccessInfo() != nil {
+				summaryURLs = deployURLs(ctx, result.AccessInfo(), ephemeralLabel)
+			}
+			writeDeploySummary(ctx, opts.SummaryJSON, dep.Id(), deployedVersion, summaryURLs)
 		}
 		return nil
 	}
@@ -994,6 +1002,13 @@ func Deploy(ctx *Context, opts struct {
 	// know the app is actually up.
 	displayAccessInfo(ctx, name, results)
 
+	// deploymentId is empty for ephemeral deploys (no deployment record).
+	var summaryURLs []string
+	if results.HasAccessInfo() && results.AccessInfo() != nil {
+		summaryURLs = deployURLs(ctx, results.AccessInfo(), ephemeralLabel)
+	}
+	writeDeploySummary(ctx, opts.SummaryJSON, deploymentId, appVersionId, summaryURLs)
+
 	return nil
 }
 
@@ -1257,6 +1272,100 @@ func buildStepsSummary(count int) string {
 		return "1 step completed"
 	}
 	return fmt.Sprintf("%d steps completed", count)
+}
+
+// deploySummary is the machine-readable result written by --summary-json. It's
+// a side artifact for CI and tooling (e.g. the mirendev/actions deploy action),
+// giving consumers the values that are otherwise awkward to recover after a
+// deploy without re-parsing human output. deploy_id is empty for ephemeral
+// deploys, which have no deployment record.
+type deploySummary struct {
+	DeployID   string   `json:"deploy_id"`
+	AppVersion string   `json:"app_version"`
+	URLs       []string `json:"urls"`
+}
+
+// accessInfoLike is the subset of the generated AccessInfo types shared by the
+// build and deployment flavors, letting deployURLs serve both deploy paths.
+type accessInfoLike interface {
+	HasHostnames() bool
+	Hostnames() *[]string
+	DefaultRoute() bool
+	ClusterHostname() string
+}
+
+// deployURLs derives the app's reachable https URLs from the server-provided
+// access info, mirroring what the human-readable deploy output prints. It is the
+// authoritative source for route URLs, so tooling doesn't have to scrape the
+// deploy log or reconcile a separate `route list` call.
+func deployURLs(ctx *Context, accessInfo accessInfoLike, ephemeralLabel string) []string {
+	if accessInfo == nil {
+		return nil
+	}
+
+	var urls []string
+	seen := map[string]bool{}
+	add := func(u string) {
+		if u != "" && !seen[u] {
+			seen[u] = true
+			urls = append(urls, u)
+		}
+	}
+
+	if accessInfo.HasHostnames() && accessInfo.Hostnames() != nil {
+		for _, h := range *accessInfo.Hostnames() {
+			if h != "" {
+				add("https://" + h)
+			}
+		}
+	}
+
+	if ephemeralLabel != "" {
+		// Ephemeral previews are additionally reachable at <label>.<cluster-host>.
+		if accessInfo.ClusterHostname() != "" {
+			add("https://" + ephemeralLabel + "." + accessInfo.ClusterHostname())
+		}
+	} else if len(urls) == 0 && accessInfo.DefaultRoute() {
+		// A stable deploy with no explicit route is the default route, reachable
+		// at the cluster hostname.
+		addr := accessInfo.ClusterHostname()
+		if addr == "" && ctx.ClusterConfig != nil {
+			addr = stripPort(ctx.ClusterConfig.Hostname)
+		}
+		if addr != "" {
+			add("https://" + addr)
+		}
+	}
+
+	return urls
+}
+
+// writeDeploySummary writes the deploy summary to path (a no-op if path is
+// empty). It runs after the deploy has already succeeded, so a failure here must
+// never fail the command: it is logged and swallowed.
+func writeDeploySummary(ctx *Context, path, deployID, appVersion string, urls []string) {
+	if path == "" {
+		return
+	}
+	// Keep urls a stable array (never JSON null) so consumers see a fixed schema.
+	if urls == nil {
+		urls = []string{}
+	}
+	summary := deploySummary{
+		DeployID:   deployID,
+		AppVersion: appVersion,
+		URLs:       urls,
+	}
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		ctx.Log.Error("Failed to marshal deploy summary", "error", err)
+		return
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		ctx.Log.Error("Failed to write deploy summary", "path", path, "error", err)
+		return
+	}
+	ctx.Log.Debug("Wrote deploy summary", "path", path, "deploy_id", deployID, "app_version", appVersion, "urls", urls)
 }
 
 // deployAccessInfo provides access to build result access info for display purposes.

--- a/cli/commands/deploy_summary_test.go
+++ b/cli/commands/deploy_summary_test.go
@@ -1,0 +1,184 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"miren.dev/runtime/clientconfig"
+)
+
+// fakeAccessInfo implements accessInfoLike so deployURLs can be exercised
+// without constructing generated proto messages.
+type fakeAccessInfo struct {
+	hasHostnames    bool
+	hostnames       []string
+	defaultRoute    bool
+	clusterHostname string
+}
+
+func (f fakeAccessInfo) HasHostnames() bool      { return f.hasHostnames }
+func (f fakeAccessInfo) Hostnames() *[]string    { return &f.hostnames }
+func (f fakeAccessInfo) DefaultRoute() bool      { return f.defaultRoute }
+func (f fakeAccessInfo) ClusterHostname() string { return f.clusterHostname }
+
+func summaryTestCtx() *Context {
+	return &Context{
+		Context: context.Background(),
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestDeployURLs(t *testing.T) {
+	tests := []struct {
+		name           string
+		accessInfo     accessInfoLike
+		ephemeralLabel string
+		clusterConfig  *clientconfig.ClusterConfig
+		want           []string
+	}{
+		{
+			name:       "nil access info",
+			accessInfo: nil,
+			want:       nil,
+		},
+		{
+			name:       "stable with hostnames dedups",
+			accessInfo: fakeAccessInfo{hasHostnames: true, hostnames: []string{"a.example.com", "b.example.com", "a.example.com"}},
+			want:       []string{"https://a.example.com", "https://b.example.com"},
+		},
+		{
+			name:       "stable default route uses cluster hostname",
+			accessInfo: fakeAccessInfo{defaultRoute: true, clusterHostname: "c.org.miren.systems"},
+			want:       []string{"https://c.org.miren.systems"},
+		},
+		{
+			name:          "stable default route falls back to cluster config, stripping port",
+			accessInfo:    fakeAccessInfo{defaultRoute: true},
+			clusterConfig: &clientconfig.ClusterConfig{Hostname: "cluster.example.com:8443"},
+			want:          []string{"https://cluster.example.com"},
+		},
+		{
+			name:       "stable no hostnames and no default route yields nothing",
+			accessInfo: fakeAccessInfo{},
+			want:       nil,
+		},
+		{
+			name:           "ephemeral adds label subdomain alongside hostnames",
+			accessInfo:     fakeAccessInfo{hasHostnames: true, hostnames: []string{"x.example.com"}, clusterHostname: "cl.miren.systems"},
+			ephemeralLabel: "pr-1",
+			want:           []string{"https://x.example.com", "https://pr-1.cl.miren.systems"},
+		},
+		{
+			name:           "ephemeral without cluster hostname keeps only hostnames",
+			accessInfo:     fakeAccessInfo{hasHostnames: true, hostnames: []string{"x.example.com"}},
+			ephemeralLabel: "pr-1",
+			want:           []string{"https://x.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := summaryTestCtx()
+			ctx.ClusterConfig = tt.clusterConfig
+			got := deployURLs(ctx, tt.accessInfo, tt.ephemeralLabel)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("deployURLs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteDeploySummary(t *testing.T) {
+	t.Run("stable deploy writes all fields", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "summary.json")
+		writeDeploySummary(summaryTestCtx(), path, "dpl_abc", "ver_123", []string{"https://a.example.com", "https://b.example.com"})
+
+		var got deploySummary
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading summary: %v", err)
+		}
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshaling summary: %v", err)
+		}
+		want := deploySummary{
+			DeployID:   "dpl_abc",
+			AppVersion: "ver_123",
+			URLs:       []string{"https://a.example.com", "https://b.example.com"},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("summary = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("no urls still emits a stable schema", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "summary.json")
+		writeDeploySummary(summaryTestCtx(), path, "dpl_x", "ver_x", nil)
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading summary: %v", err)
+		}
+		// urls must serialize as [] (never null), and there is no url field.
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("unmarshaling summary: %v", err)
+		}
+		if _, ok := raw["url"]; ok {
+			t.Fatalf("did not expect a url field, got: %s", data)
+		}
+		if string(raw["urls"]) != "[]" {
+			t.Fatalf("expected urls to be [], got: %s", raw["urls"])
+		}
+	})
+
+	t.Run("ephemeral deploy leaves deploy_id empty", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "summary.json")
+		writeDeploySummary(summaryTestCtx(), path, "", "ver_eph", []string{"https://pr-1.cl.miren.systems"})
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading summary: %v", err)
+		}
+		// deploy_id must be present-but-empty (a stable schema for consumers),
+		// not omitted.
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("unmarshaling summary: %v", err)
+		}
+		if _, ok := raw["deploy_id"]; !ok {
+			t.Fatalf("expected deploy_id key to be present, got: %s", data)
+		}
+		var got deploySummary
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshaling summary: %v", err)
+		}
+		if got.DeployID != "" {
+			t.Fatalf("expected empty deploy_id, got %q", got.DeployID)
+		}
+		if got.AppVersion != "ver_eph" {
+			t.Fatalf("expected app_version ver_eph, got %q", got.AppVersion)
+		}
+	})
+
+	t.Run("empty path is a silent no-op", func(t *testing.T) {
+		// A capturing logger lets us observe that the empty-path early return
+		// neither writes nor logs (a successful write emits a Debug line).
+		var logs bytes.Buffer
+		ctx := &Context{
+			Context: context.Background(),
+			Log:     slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		}
+		writeDeploySummary(ctx, "", "dpl_x", "ver_x", []string{"https://x.example.com"})
+		if logs.Len() != 0 {
+			t.Fatalf("expected no log output for empty path, got: %s", logs.String())
+		}
+	})
+}

--- a/docs/docs/command/deploy.md
+++ b/docs/docs/command/deploy.md
@@ -23,6 +23,7 @@ miren deploy [flags]
 - `--explain-format` — Explain format (default: `auto`) (choices: `auto`, `plain`, `tty`, `rawjson`)
 - `--force, -f` — Skip confirmation prompt
 - `--sensitive, -s` — Set sensitive environment variable (masked in output)
+- `--summary-json` — Write a JSON summary of the deploy result (deploy id, version, and route URLs) to this path
 - `--ttl` — TTL for ephemeral version (e.g. 48h) (default: `24h`)
 - `--version, -V` — Deploy an existing version (skip build)
 


### PR DESCRIPTION
`miren deploy` has only ever spoken to humans. There's a nice TUI while it builds and activates, ending in a "here's where your app lives" message, but nothing structured comes out the other end. So anything downstream that wants the deploy id, the version miren assigned, or the route URLs is stuck either scraping that human output or making a separate `route list` call and reconciling it. Both are fragile: they break the moment we reword a log line.

The thing is, the command already has all of this in hand right at the success point. It knows the deployment record id, it knows the app version it just built, and the server hands it the access info with the route hostnames. It just wasn't handing any of it back.

This adds a `--summary-json <path>` flag that writes a small JSON object with `deploy_id`, `app_version`, `url`, and `urls`. `deploy_id` is empty for ephemeral previews, which deliberately have no deployment record. The URL derivation mirrors exactly what the human output prints (including the ephemeral `<label>.<cluster-host>` form and the default-route fallback), so the summary is authoritative rather than a second guess that might drift.

Writing happens after the deploy has already succeeded, so a failure to write the summary is logged and swallowed. It never turns a good deploy into a failed command.

This is the runtime half of MIR-780; the mirendev/actions deploy action is the first consumer.

Part of MIR-780