### PR TITLE
Fix section subcommand help when a global flag precedes the section (MIR-1309)

### DIFF
--- a/cli/commands/help.go
+++ b/cli/commands/help.go
@@ -44,11 +44,17 @@ func Section(name, desc, help string, opts ...SectionOption) mflags.Command {
 		desc = help
 	}
 
+	fs := mflags.NewFlagSet(name)
+	// Sections declare no flags of their own, but users routinely place global
+	// flags (e.g. -C/--cluster) before a section name. Tolerate unknown flags so
+	// the section still renders its sub-command help instead of failing to parse.
+	fs.AllowUnknownFlags(true)
+
 	s := &section{
 		name: name,
 		desc: desc,
 		help: help,
-		fs:   mflags.NewFlagSet(name),
+		fs:   fs,
 	}
 
 	for _, o := range opts {

--- a/cli/commands/section_help_test.go
+++ b/cli/commands/section_help_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"miren.dev/mflags"
+	"miren.dev/runtime/pkg/labs"
+)
+
+// TestSectionHelpWithGlobalFlag guards against MIR-1309: a value-taking global
+// flag (e.g. -C/--cluster) placed before a section name must still render the
+// section's sub-commands rather than falling back to top-level help or a flag
+// parse error.
+func TestSectionHelpWithGlobalFlag(t *testing.T) {
+	labs.EnableAll()
+
+	cases := [][]string{
+		{"auth"},
+		{"auth", "help"},
+		{"help", "auth"},
+		{"-C", "prod", "auth"},
+		{"-C", "prod", "auth", "help"},
+		{"-C", "prod", "auth", "--help"},
+	}
+
+	for _, args := range cases {
+		t.Run(argsName(args), func(t *testing.T) {
+			out := captureDispatch(t, args)
+
+			// The auth section's sub-commands must appear; top-level help would
+			// instead list unrelated commands like "app".
+			for _, want := range []string{"generate", "provider", "ci"} {
+				if !bytes.Contains([]byte(out), []byte(want)) {
+					t.Errorf("expected auth sub-command %q in output for %v, got:\n%s", want, args, out)
+				}
+			}
+		})
+	}
+}
+
+func argsName(args []string) string {
+	name := ""
+	for i, a := range args {
+		if i > 0 {
+			name += "_"
+		}
+		name += a
+	}
+	return name
+}
+
+// captureDispatch builds the full dispatcher and runs Execute with the given
+// args, returning everything written to stdout.
+func captureDispatch(t *testing.T, args []string) string {
+	t.Helper()
+
+	d := mflags.NewDispatcher("miren")
+	RegisterAll(d)
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := d.Execute(args)
+
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("Execute(%v) returned error: %v", args, err)
+	}
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	miren.dev/jsonrpc3/go/jsonrpc3 v0.0.0-20260106052505-c98e2702b093
 	miren.dev/lbd v0.0.0-20260224020427-8914d8db2233
-	miren.dev/mflags v0.0.0-20260518222642-0ca7adc28461
+	miren.dev/mflags v0.0.0-20260709231109-a397dcbc98df
 	sigs.k8s.io/knftables v0.0.21
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1989,8 +1989,8 @@ miren.dev/jsonrpc3/go/jsonrpc3 v0.0.0-20260106052505-c98e2702b093 h1:Sd+M5HSUati
 miren.dev/jsonrpc3/go/jsonrpc3 v0.0.0-20260106052505-c98e2702b093/go.mod h1:B4A3wSzkcSZQw6Y5opU+rk1+1lEuCWIWkAiN7TkltGE=
 miren.dev/lbd v0.0.0-20260224020427-8914d8db2233 h1:9DxH7Dhnmu7hn1OA2JC5fHpLuVgAqBySws9GLNssLl4=
 miren.dev/lbd v0.0.0-20260224020427-8914d8db2233/go.mod h1:+x9fy2p45csBnGUJdqxCUmzlUTCipoVDbv6zIapTgDA=
-miren.dev/mflags v0.0.0-20260518222642-0ca7adc28461 h1:ETSN/0nBy1Dqpu43INesvPWoipOaC5+pfKzRjngkeO0=
-miren.dev/mflags v0.0.0-20260518222642-0ca7adc28461/go.mod h1:G1eQ/upWVdO6BGT6dlh5Yqjt+9ncH5RUAKX6UKi1F9Q=
+miren.dev/mflags v0.0.0-20260709231109-a397dcbc98df h1:4fo71OveODliBgU9sv2M/uepiRNAwQPJ7YTPuNffQNc=
+miren.dev/mflags v0.0.0-20260709231109-a397dcbc98df/go.mod h1:G1eQ/upWVdO6BGT6dlh5Yqjt+9ncH5RUAKX6UKi1F9Q=
 modernc.org/libc v1.67.6 h1:eVOQvpModVLKOdT+LvBPjdQqfrZq+pC39BygcT+E7OI=
 modernc.org/libc v1.67.6/go.mod h1:JAhxUVlolfYDErnwiqaLvUqc8nfb2r6S6slAgZOnaiE=
 modernc.org/mathutil v1.7.1 h1:GCZVGXdaN8gTqB1Mf/usp1Y/hSqgI2vAGGP4jZMCxOU=


### PR DESCRIPTION
## Problem

MIR-1309 was filed as "`miren help auth` refuses to show the subcommands," but
that form works. The real defect: a **value-taking global flag before a section
name** breaks subcommand help.

```
miren -C prod auth help   → printed TOP-LEVEL help instead of auth's subcommands
miren -C prod auth        → same class of failure
```

`auth` (and `env`, `sandbox`, `config`, …) is a `Section` with an empty
flagset. The mflags interspersed-flag resolver correctly guessed `-C` consumed
`prod`, matched the `auth` section, then rejected the match because `-C` isn't
declared in the section's flagset — falling back to top-level help.

## Fix

Two parts:

1. **mflags** (already merged: mirendev/mflags#15) — the resolver no longer
   rejects a matched command path just because a pre-command flag is unknown to
   it. This PR bumps the pin to that commit.
2. **runtime** (here) — section flagsets now `AllowUnknownFlags(true)`, so the
   no-help form (`miren -C prod auth`) parses the leftover global flag and
   renders subcommands via `ErrShowHelp` instead of erroring.

## Tests

- `cli/commands/section_help_test.go` — new regression test built via
  `RegisterAll`, covering `miren [-C prod] auth [help|--help]`.
- Verified end-to-end against a real build: every section form lists its
  subcommands; `-C prod app list` still receives the cluster and
  `-C prod auth generate` still runs the real command.

Fixes MIR-1309.