### PR TITLE
Add audit logging for cert auth and per-request RPC access

### DIFF
--- a/pkg/rpc/audit.go
+++ b/pkg/rpc/audit.go
@@ -1,0 +1,172 @@
+package rpc
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"log/slog"
+	"net"
+	"net/http"
+)
+
+// certFingerprint returns the hex-encoded SHA-256 of a certificate's raw DER,
+// the standard stable identifier for a cert in an audit trail.
+func certFingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// minLevelHandler wraps a slog.Handler and enforces its own minimum level,
+// independent of the wrapped handler's configured level. Records below min are
+// dropped even if the wrapped handler would emit them; records at or above min
+// are passed straight to the wrapped handler's Handle, which does the
+// formatting and writing without re-checking the level.
+//
+// The Info floor is therefore only as reliable as that last assumption: it
+// relies on the wrapped sink not re-gating in Handle. That is the slog.Handler
+// contract (the standard library handlers gate only in Enabled, which the
+// Logger checks before calling Handle), so any well-behaved sink is fine, but a
+// sink that re-checks the level in Handle would silently break the floor.
+//
+// The audit trail uses this to hold a fixed Info floor regardless of the
+// process-wide verbosity. Managed servers run at -vv (Debug), so a plain shared
+// logger would never suppress the audit stream's own Debug records (loopback
+// internal traffic); conversely the default is Warn, at which a shared logger
+// would drop audit Info entirely. Pinning the floor at Info decouples the audit
+// trail from the operational -v knob in both directions.
+type minLevelHandler struct {
+	slog.Handler
+	min slog.Level
+}
+
+func (h minLevelHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.min
+}
+
+func (h minLevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return minLevelHandler{Handler: h.Handler.WithAttrs(attrs), min: h.min}
+}
+
+func (h minLevelHandler) WithGroup(name string) slog.Handler {
+	return minLevelHandler{Handler: h.Handler.WithGroup(name), min: h.min}
+}
+
+// newAuditLogger derives the security audit logger from the server's base
+// logger. It shares the base's sink (so audit records flow to the same log
+// collection) but pins the level floor at Info via minLevelHandler and tags the
+// stream module=audit so it can be filtered and routed downstream.
+func newAuditLogger(base *slog.Logger) *slog.Logger {
+	return slog.New(minLevelHandler{Handler: base.Handler(), min: slog.LevelInfo}).
+		With("module", "audit")
+}
+
+// isLoopbackAddr reports whether addr (an *http.Request RemoteAddr in "host:port"
+// form) is a loopback address — i.e. a same-host internal component rather than
+// a network peer. Loopback traffic is the coordinator's own services talking to
+// each other (e.g. the API server polling its own entity store) and dominates
+// the log; audit records for it are demoted to Debug so the Info stream stays
+// the network attack surface. An unparseable address is treated as non-loopback
+// so we err toward recording at the higher level.
+func isLoopbackAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// logCertAuth emits a single durable audit record for a successful cert-method
+// authentication.
+//
+// Note on scope: the listener uses tls.VerifyClientCertIfGiven, so any client
+// cert reaching this point has already chained to the cluster CA and a forged
+// cert is rejected during the TLS handshake, before any authenticator runs.
+// This record therefore only ever captures legitimate cert auth (in practice,
+// internal component mTLS) — it can never see an attacker. It exists so that
+// legitimate cert use is attributable after the fact, not as a tripwire; the
+// per-request access log (logAccess) is the auth-method-agnostic audit trail
+// that survives a bypass on any path. Kept deliberately to one line.
+//
+// Logged at Info for network peers and Debug for loopback (same-host internal
+// component mTLS), so the Info stream isn't drowned by the coordinator's own
+// services authenticating to each other. See isLoopbackAddr.
+func logCertAuth(ctx context.Context, log *slog.Logger, r *http.Request) {
+	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return
+	}
+	cert := r.TLS.PeerCertificates[0]
+
+	level := slog.LevelInfo
+	if isLoopbackAddr(r.RemoteAddr) {
+		level = slog.LevelDebug
+	}
+
+	log.Log(ctx, level, "cert auth",
+		"remote", r.RemoteAddr,
+		"subject", cert.Subject.String(),
+		"issuer", cert.Issuer.String(),
+		"serial", cert.SerialNumber.String(),
+		"fingerprint", certFingerprint(cert),
+		"verified", len(r.TLS.VerifiedChains) > 0,
+		"chains", len(r.TLS.VerifiedChains),
+	)
+}
+
+// logAccess emits a per-request RPC access record for a non-public method.
+// It is intentionally auth-method-agnostic: every line carries the source IP,
+// the authenticated subject, and the auth method, so the trail stays useful no
+// matter which auth path a caller (or a future bypass) came in on. outcome is
+// "ok" for an authorized dispatch, or "unauthorized"/"forbidden" for a rejected
+// one; non-ok outcomes log at Warn so denials surface without a level filter.
+//
+// Callers invoke this only for non-public methods. Public methods (e.g. health
+// checks and runner Join, which are public precisely because they carry no
+// caller identity) are intentionally left out of the audit trail rather than
+// logging identity-less lines for them.
+func logAccess(ctx context.Context, log *slog.Logger, r *http.Request, mm Method, outcome string, extra ...any) {
+	var subject, method string
+	if id := IdentityFromContext(ctx); id != nil {
+		subject = id.Subject
+		method = string(id.Method)
+	}
+
+	// Denials are security-relevant wherever they come from, so they always
+	// surface at Warn. A successful call from a network peer is the audit
+	// signal we care about (the MIR-1323 exfil was a remote read) and logs at
+	// Info; the same call over loopback is trusted same-host component chatter
+	// and drops to Debug. See isLoopbackAddr.
+	level := slog.LevelInfo
+	switch {
+	case outcome != "ok":
+		level = slog.LevelWarn
+	case isLoopbackAddr(r.RemoteAddr):
+		level = slog.LevelDebug
+	}
+
+	attrs := []any{
+		"remote", r.RemoteAddr,
+		"rpc", mm.InterfaceName + "." + mm.Name,
+		"subject", subject,
+		"auth_method", method,
+		"outcome", outcome,
+	}
+	attrs = append(attrs, extra...)
+
+	log.Log(ctx, level, "rpc access", attrs...)
+}
+
+// logAuthReject records a rejected capability-signature request (a bad, expired,
+// or forged rpc-signature on the ed25519 capability path in authRequest). These
+// rejections happen before any Identity is established, so they don't flow
+// through logAccess, but a forged or replayed capability is exactly the kind of
+// event the audit trail exists to capture, so it must not be confined to the
+// general log. Always Warn, since every one of these is a failed auth attempt.
+func logAuthReject(log *slog.Logger, r *http.Request, oid OID, reason string) {
+	log.Warn("auth rejected",
+		"remote", r.RemoteAddr,
+		"oid", string(oid),
+		"reason", reason,
+	)
+}

--- a/pkg/rpc/audit_test.go
+++ b/pkg/rpc/audit_test.go
@@ -1,0 +1,331 @@
+package rpc
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"testing"
+)
+
+// captureLogger returns a slog.Logger writing JSON records into buf, so tests
+// can assert on the exact fields an audit line carries.
+func captureLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+// decodeRecords parses each JSON log line in buf into a map.
+func decodeRecords(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var records []map[string]any
+	dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	for dec.More() {
+		var rec map[string]any
+		if err := dec.Decode(&rec); err != nil {
+			t.Fatalf("decoding log record: %v", err)
+		}
+		records = append(records, rec)
+	}
+	return records
+}
+
+func TestIsLoopbackAddr(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1:8443":     true,
+		"[::1]:8443":         true, // IPv6 loopback (dual-stack / v6-only hosts)
+		"192.168.144.7:8444": false,
+		"203.0.113.7:44321":  false,
+		"[2001:db8::1]:443":  false, // routable IPv6
+		"garbage":            false, // unparseable -> treated as non-loopback
+		"":                   false,
+	}
+	for addr, want := range cases {
+		if got := isLoopbackAddr(addr); got != want {
+			t.Errorf("isLoopbackAddr(%q) = %v, want %v", addr, got, want)
+		}
+	}
+}
+
+func TestLogCertAuth(t *testing.T) {
+	rawDER := []byte("some-der-certificate-bytes")
+	cert := &x509.Certificate{
+		Raw:          rawDER,
+		Subject:      pkix.Name{CommonName: "miren-server"},
+		Issuer:       pkix.Name{CommonName: "miren-ca"},
+		SerialNumber: big.NewInt(0x0abc),
+	}
+
+	withVerifiedCert := func(req *http.Request) {
+		req.TLS = &tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{cert},
+			VerifiedChains:   [][]*x509.Certificate{{cert}},
+		}
+	}
+
+	t.Run("verified cert from a network peer emits a full audit line at info", func(t *testing.T) {
+		var buf bytes.Buffer
+		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+		req.RemoteAddr = "203.0.113.7:44321"
+		withVerifiedCert(req)
+
+		logCertAuth(context.Background(), captureLogger(&buf), req)
+
+		records := decodeRecords(t, &buf)
+		if len(records) != 1 {
+			t.Fatalf("expected 1 record, got %d", len(records))
+		}
+		rec := records[0]
+
+		sum := sha256.Sum256(rawDER)
+		wantFP := hex.EncodeToString(sum[:])
+
+		checks := map[string]any{
+			"msg":         "cert auth",
+			"level":       "INFO",
+			"remote":      "203.0.113.7:44321",
+			"subject":     "CN=miren-server",
+			"issuer":      "CN=miren-ca",
+			"serial":      "2748", // 0x0abc in decimal
+			"fingerprint": wantFP,
+			"verified":    true,
+		}
+		for k, want := range checks {
+			if got := rec[k]; got != want {
+				t.Errorf("field %q: got %v, want %v", k, got, want)
+			}
+		}
+		// chains is a JSON number; it decodes to float64(1).
+		if got := rec["chains"]; got != float64(1) {
+			t.Errorf("field chains: got %v, want 1", got)
+		}
+	})
+
+	t.Run("verified cert over loopback drops to debug", func(t *testing.T) {
+		var buf bytes.Buffer
+		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+		req.RemoteAddr = "127.0.0.1:8443"
+		withVerifiedCert(req)
+
+		logCertAuth(context.Background(), captureLogger(&buf), req)
+
+		records := decodeRecords(t, &buf)
+		if len(records) != 1 {
+			t.Fatalf("expected 1 record, got %d", len(records))
+		}
+		if got := records[0]["level"]; got != "DEBUG" {
+			t.Errorf("expected DEBUG level for loopback, got %v", got)
+		}
+	})
+
+	t.Run("no TLS emits nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+
+		logCertAuth(context.Background(), captureLogger(&buf), req)
+
+		if buf.Len() != 0 {
+			t.Errorf("expected no log output, got %q", buf.String())
+		}
+	})
+
+	t.Run("TLS without peer certs emits nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+		req.TLS = &tls.ConnectionState{}
+
+		logCertAuth(context.Background(), captureLogger(&buf), req)
+
+		if buf.Len() != 0 {
+			t.Errorf("expected no log output, got %q", buf.String())
+		}
+	})
+}
+
+// TestAuditLoggerLevelFloor verifies the audit logger holds an Info floor no
+// matter what level the base logger is at — the managed-server default is -vv
+// (Debug), and without the floor the audit stream's own Debug records (loopback
+// traffic) would never be suppressed. It must also emit Info even when the base
+// is quieter than Info, so the audit trail can't be silenced by lowering -v.
+func TestAuditLoggerLevelFloor(t *testing.T) {
+	levels := map[string]slog.Level{
+		"base at debug (-vv)": slog.LevelDebug,
+		"base at info":        slog.LevelInfo,
+		"base at warn":        slog.LevelWarn,
+	}
+
+	for name, baseLevel := range levels {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			base := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: baseLevel}))
+			audit := newAuditLogger(base)
+
+			audit.Debug("loopback line")
+			audit.Info("remote line")
+			audit.Warn("denial line")
+
+			var msgs []string
+			for _, rec := range decodeRecords(t, &buf) {
+				msgs = append(msgs, rec["msg"].(string))
+			}
+
+			// Debug is always dropped (floor is Info); Info and Warn always emit,
+			// even when the base handler is at Warn.
+			want := []string{"remote line", "denial line"}
+			if len(msgs) != len(want) {
+				t.Fatalf("got messages %v, want %v", msgs, want)
+			}
+			for i := range want {
+				if msgs[i] != want[i] {
+					t.Errorf("message %d: got %q, want %q", i, msgs[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLogAuthReject(t *testing.T) {
+	var buf bytes.Buffer
+	req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+	req.RemoteAddr = "203.0.113.9:5555"
+
+	logAuthReject(captureLogger(&buf), req, OID("cap-123"), "signature verification failed")
+
+	records := decodeRecords(t, &buf)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	rec := records[0]
+
+	want := map[string]any{
+		"msg":    "auth rejected",
+		"level":  "WARN",
+		"remote": "203.0.113.9:5555",
+		"oid":    "cap-123",
+		"reason": "signature verification failed",
+	}
+	for k, v := range want {
+		if got := rec[k]; got != v {
+			t.Errorf("field %q: got %v, want %v", k, got, v)
+		}
+	}
+}
+
+func TestLogAccess(t *testing.T) {
+	mm := Method{Name: "List", InterfaceName: "AppServer"}
+
+	newReq := func() *http.Request {
+		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+		req.RemoteAddr = "198.51.100.4:5555"
+		return req
+	}
+
+	ctxWithIdentity := ContextWithIdentity(context.Background(), &Identity{
+		Subject: "user-42",
+		Method:  AuthMethodJWT,
+	})
+
+	t.Run("ok outcome logs at info with identity fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		logAccess(ctxWithIdentity, captureLogger(&buf), newReq(), mm, "ok")
+
+		records := decodeRecords(t, &buf)
+		if len(records) != 1 {
+			t.Fatalf("expected 1 record, got %d", len(records))
+		}
+		rec := records[0]
+
+		want := map[string]any{
+			"msg":         "rpc access",
+			"level":       "INFO",
+			"remote":      "198.51.100.4:5555",
+			"rpc":         "AppServer.List",
+			"subject":     "user-42",
+			"auth_method": "jwt",
+			"outcome":     "ok",
+		}
+		for k, v := range want {
+			if got := rec[k]; got != v {
+				t.Errorf("field %q: got %v, want %v", k, got, v)
+			}
+		}
+	})
+
+	t.Run("ok outcome over loopback drops to debug", func(t *testing.T) {
+		var buf bytes.Buffer
+		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+		req.RemoteAddr = "127.0.0.1:8443"
+		logAccess(ctxWithIdentity, captureLogger(&buf), req, mm, "ok")
+
+		records := decodeRecords(t, &buf)
+		if len(records) != 1 {
+			t.Fatalf("expected 1 record, got %d", len(records))
+		}
+		if got := records[0]["level"]; got != "DEBUG" {
+			t.Errorf("expected DEBUG level for loopback ok, got %v", got)
+		}
+	})
+
+	t.Run("denial over loopback still logs at warn", func(t *testing.T) {
+		var buf bytes.Buffer
+		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+		req.RemoteAddr = "127.0.0.1:8443"
+		logAccess(ctxWithIdentity, captureLogger(&buf), req, mm, "forbidden", "error", "denied")
+
+		records := decodeRecords(t, &buf)
+		if len(records) != 1 {
+			t.Fatalf("expected 1 record, got %d", len(records))
+		}
+		if got := records[0]["level"]; got != "WARN" {
+			t.Errorf("expected WARN level for loopback denial, got %v", got)
+		}
+	})
+
+	t.Run("forbidden outcome logs at warn and carries extra fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		logAccess(ctxWithIdentity, captureLogger(&buf), newReq(), mm, "forbidden", "error", "access denied by RBAC policy")
+
+		records := decodeRecords(t, &buf)
+		if len(records) != 1 {
+			t.Fatalf("expected 1 record, got %d", len(records))
+		}
+		rec := records[0]
+
+		if rec["level"] != "WARN" {
+			t.Errorf("expected WARN level, got %v", rec["level"])
+		}
+		if rec["outcome"] != "forbidden" {
+			t.Errorf("expected outcome=forbidden, got %v", rec["outcome"])
+		}
+		if rec["error"] != "access denied by RBAC policy" {
+			t.Errorf("expected error field passed through, got %v", rec["error"])
+		}
+	})
+
+	t.Run("unauthorized outcome without identity logs empty subject", func(t *testing.T) {
+		var buf bytes.Buffer
+		logAccess(context.Background(), captureLogger(&buf), newReq(), mm, "unauthorized")
+
+		records := decodeRecords(t, &buf)
+		if len(records) != 1 {
+			t.Fatalf("expected 1 record, got %d", len(records))
+		}
+		rec := records[0]
+
+		if rec["level"] != "WARN" {
+			t.Errorf("expected WARN level, got %v", rec["level"])
+		}
+		if rec["subject"] != "" {
+			t.Errorf("expected empty subject, got %v", rec["subject"])
+		}
+		if rec["auth_method"] != "" {
+			t.Errorf("expected empty auth_method, got %v", rec["auth_method"])
+		}
+	})
+}

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -329,6 +329,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if identity != nil {
 		ctx = ContextWithIdentity(ctx, identity)
 		r = r.WithContext(ctx)
+
+		// Audit successful cert-method auth. See logCertAuth for why this only
+		// ever records legitimate (internal) mTLS and never an attacker.
+		if identity.Method == AuthMethodCert {
+			logCertAuth(ctx, s.state.audit(), r)
+		}
 	}
 
 	// For RPC paths, let the method-level check in handleCalls decide based on public flag
@@ -784,27 +790,27 @@ func (s *Server) authRequest(r *http.Request, w http.ResponseWriter, oid OID) (e
 	ts := r.Header.Get("rpc-timestamp")
 
 	if ts == "" {
-		s.state.log.Warn("No timestamp provided for authentication")
+		logAuthReject(s.state.audit(), r, oid, "no timestamp provided")
 		http.Error(w, "no timestamp provided", http.StatusForbidden)
 		return nil, false
 	}
 
 	t, err := time.Parse(time.RFC3339Nano, ts)
 	if err != nil {
-		s.state.log.Warn("Failed to parse timestamp", "error", err)
+		logAuthReject(s.state.audit(), r, oid, "malformed timestamp")
 		http.Error(w, "failed to parse timestamp", http.StatusForbidden)
 		return nil, false
 	}
 
 	if time.Since(t) > 10*time.Minute {
-		s.state.log.Warn("Timestamp too old", "timestamp", t)
+		logAuthReject(s.state.audit(), r, oid, "timestamp too old")
 		http.Error(w, "timestamp too old", http.StatusForbidden)
 		return nil, false
 	}
 
 	sign := r.Header.Get("rpc-signature")
 	if sign == "" {
-		s.state.log.Warn("No signature provided")
+		logAuthReject(s.state.audit(), r, oid, "no signature provided")
 		http.Error(w, "no signature provided", http.StatusForbidden)
 		return nil, false
 	}
@@ -826,19 +832,19 @@ func (s *Server) authRequest(r *http.Request, w http.ResponseWriter, oid OID) (e
 
 	bsign, err := base58.Decode(sign)
 	if err != nil {
-		s.state.log.Warn("Failed to decode signature", "error", err)
+		logAuthReject(s.state.audit(), r, oid, "malformed signature")
 		http.Error(w, "failed to decode signature", http.StatusForbidden)
 		return nil, false
 	}
 
 	if len(capa.pub) != ed25519.PublicKeySize {
-		s.state.log.Warn("Invalid public key size", "size", len(capa.pub))
+		logAuthReject(s.state.audit(), r, oid, "invalid capability public key")
 		http.Error(w, "invalid public key size", http.StatusForbidden)
 		return nil, false
 	}
 
 	if !ed25519.Verify(capa.pub, buf.Bytes(), bsign) {
-		s.state.log.Warn("Failed to verify signature")
+		logAuthReject(s.state.audit(), r, oid, "signature verification failed")
 		http.Error(w, "failed to verify signature", http.StatusForbidden)
 		return nil, false
 	}
@@ -917,8 +923,7 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 	if !mm.Public {
 		identity := IdentityFromContext(ctx)
 		if identity == nil {
-			s.state.log.Warn("authentication required for non-public method",
-				"method", method, "interface", mm.InterfaceName)
+			logAccess(ctx, s.state.audit(), r, mm, "unauthorized")
 			w.Header().Add("rpc-status", "unauthorized")
 			w.Header().Add("rpc-error", "authentication required")
 			w.WriteHeader(http.StatusUnauthorized)
@@ -930,14 +935,15 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 			resource := strings.ToLower(mm.InterfaceName)
 			action := strings.ToLower(mm.Name)
 			if err := s.state.authorizer.Authorize(ctx, identity, resource, action); err != nil {
-				s.state.log.Warn("authorization denied",
-					"resource", resource, "action", action, "subject", identity.Subject, "error", err)
+				logAccess(ctx, s.state.audit(), r, mm, "forbidden", "error", err)
 				w.Header().Add("rpc-status", "forbidden")
 				w.Header().Add("rpc-error", err.Error())
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}
 		}
+
+		logAccess(ctx, s.state.audit(), r, mm, "ok")
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -1076,8 +1082,7 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 		if !mm.Public {
 			identity := IdentityFromContext(ctx)
 			if identity == nil {
-				s.state.log.Warn("authentication required for non-public method",
-					"method", method, "interface", mm.InterfaceName)
+				logAccess(ctx, s.state.audit(), r, mm, "unauthorized")
 				w.Header().Add("rpc-status", "unauthorized")
 				w.Header().Add("rpc-error", "authentication required")
 				w.WriteHeader(http.StatusUnauthorized)
@@ -1089,14 +1094,15 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 				resource := strings.ToLower(mm.InterfaceName)
 				action := strings.ToLower(mm.Name)
 				if err := s.state.authorizer.Authorize(ctx, identity, resource, action); err != nil {
-					s.state.log.Warn("authorization denied",
-						"resource", resource, "action", action, "subject", identity.Subject, "error", err)
+					logAccess(ctx, s.state.audit(), r, mm, "forbidden", "error", err)
 					w.Header().Add("rpc-status", "forbidden")
 					w.Header().Add("rpc-error", err.Error())
 					w.WriteHeader(http.StatusForbidden)
 					return
 				}
 			}
+
+			logAccess(ctx, s.state.audit(), r, mm, "ok")
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -80,6 +80,11 @@ type StateCommon struct {
 	top context.Context
 	log *slog.Logger
 
+	// auditLog is the security audit trail, pinned at an Info floor and tagged
+	// module=audit so it stays legible and volume-bounded regardless of the
+	// server's -v verbosity. See newAuditLogger.
+	auditLog *slog.Logger
+
 	opts *stateOptions
 
 	serverTlsCfg *tls.Config
@@ -93,6 +98,15 @@ type StateCommon struct {
 	pubkey  ed25519.PublicKey
 
 	qc quic.Config
+}
+
+// audit returns the security audit logger, falling back to the general logger
+// if one was not wired up (e.g. a hand-constructed StateCommon in a test).
+func (s *StateCommon) audit() *slog.Logger {
+	if s.auditLog != nil {
+		return s.auditLog
+	}
+	return s.log
 }
 
 type State struct {
@@ -322,6 +336,7 @@ func NewState(ctx context.Context, opts ...StateOption) (*State, error) {
 		StateCommon: &StateCommon{
 			top:           ctx,
 			log:           so.log,
+			auditLog:      newAuditLogger(so.log),
 			opts:          &so,
 			clientTlsCfg:  tlsCfg,
 			privkey:       priv,


### PR DESCRIPTION
When we dug into the MIR-1323 auth bypass, one of the nastiest parts was that a successful exploit left no trace. Successful cert authentication logged nothing (only failures did), and there was no per-request RPC access log, so a forged cert reading every entity in the store was forensically invisible. This adds both.

The two trails aren't equal in value. The cert-auth log writes one line per successful cert authentication (source IP, subject, issuer, serial, SHA-256 fingerprint, verify result) from the single `ServeHTTP` chokepoint, covering all three authenticator wirings at once. It's the low-value half by construction though: the MIR-1323 fix switched the listener to `VerifyClientCertIfGiven`, so a forged cert now dies in the TLS handshake before any authenticator runs, and this line only ever records legitimate, mostly-internal mTLS.

The per-request access log is the one that earns its keep. It's auth-method-agnostic: one line per non-public dispatch with remote addr, subject, auth method, `interface.method`, and outcome. Keying off the authenticated identity rather than the cert means it still delivers if the next bypass lands on the JWT or socket path. Rejections on the ed25519 capability-signature path (`authRequest`) get pulled into the trail too, as `auth rejected` lines. Those happen before any identity is established so they don't go through the access log, but a bad, expired, or forged `rpc-signature` is exactly the kind of thing the trail should catch.

Both hooks split by origin: remote at Info, loopback (same-host internal component mTLS) at Debug, denials always at Warn. That keeps the whole network attack surface at Info, including remote reads (the MIR-1323 exfil signature), while the trusted internal chatter that dominates a busy cluster stays out of the way. Since managed servers run at `-vv` (Debug), the trail uses its own logger pinned at an Info floor independent of the global `-v` knob, tagged `module=audit` for easy filtering.

This pairs with MIR-1325 (actor attribution on entity mutations), which threads the same `IdentityFromContext(ctx)` down into the entity write handlers. To keep the two correlatable, MIR-1325 should stamp `identity.Subject` as the actor: that's exactly what this access log emits as `subject`, making it the join key between "who wrote this entity" and "what calls that subject made."

One follow-up worth noting: the cert-auth hook fires per HTTP request, so a valid-cert client stuck in a retry loop can generate unbounded Info lines. A per-source rate cap or dedup on the audit path would be sensible hardening later.

Closes MIR-1324
