### PR TITLE
Consolidate env-var display behind one masked surface

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -2,11 +2,9 @@ package commands
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -164,8 +162,6 @@ func App(ctx *Context, opts struct {
 	FormatOptions
 	Watch bool `short:"w" long:"watch" description:"Watch the app stats"`
 	Graph bool `short:"g" long:"graph" description:"Graph the app stats"`
-
-	ConfigOnly bool `long:"config-only" description:"Only show the configuration"`
 }) error {
 	crudcl, err := ctx.RPCClient("dev.miren.runtime/app")
 	if err != nil {
@@ -177,16 +173,6 @@ func App(ctx *Context, opts struct {
 	cfgres, err := crud.GetConfiguration(ctx, opts.App)
 	if err != nil {
 		ctx.Printf("unknown application: %s\n", opts.App)
-		return nil
-	}
-
-	if opts.ConfigOnly {
-		data, err := json.MarshalIndent(cfgres.Configuration(), "", "  ")
-		if err != nil {
-			return err
-		}
-
-		ctx.Printf("%s\n", data)
 		return nil
 	}
 
@@ -205,7 +191,7 @@ func App(ctx *Context, opts struct {
 	status := res.Status()
 
 	if opts.IsJSON() {
-		return printAppJSON(status, cfgres.Configuration())
+		return printAppJSON(status)
 	}
 
 	//spew.Dump(status)
@@ -399,20 +385,6 @@ func (m Model) View() string {
 				m.status.ActiveVersion(),
 			))
 	}
-
-	envvars := []string{}
-
-	if m.cfg != nil {
-		for _, v := range m.cfg.EnvVars() {
-			if v.Sensitive() {
-				envvars = append(envvars, fmt.Sprintf("%s=****", v.Key()))
-			} else {
-				envvars = append(envvars, fmt.Sprintf("%s=%s", v.Key(), v.Value()))
-			}
-		}
-	}
-
-	sort.Strings(envvars)
 
 	hdr := fmt.Sprintf("       name: %s\nlast update: %s %s\n",
 		bold.Render(m.status.Name()),
@@ -646,16 +618,11 @@ func (m Model) View() string {
 	return frame
 }
 
-func printAppJSON(status *app_v1alpha.ApplicationStatus, cfg *app_v1alpha.Configuration) error {
+func printAppJSON(status *app_v1alpha.ApplicationStatus) error {
 	type poolJSON struct {
 		Name      string `json:"name"`
 		Instances int    `json:"instances"`
 		Idle      int32  `json:"idle"`
-	}
-
-	type envVarJSON struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
 	}
 
 	type requestStatJSON struct {
@@ -688,7 +655,6 @@ func printAppJSON(status *app_v1alpha.ApplicationStatus, cfg *app_v1alpha.Config
 		LastMinCPU        float64              `json:"last_min_cpu,omitempty"`
 		LastHourCPU       float64              `json:"last_hour_cpu,omitempty"`
 		Pools             []poolJSON           `json:"pools,omitempty"`
-		EnvVars           []envVarJSON         `json:"env_vars,omitempty"`
 		RequestStats      []requestStatJSON    `json:"request_stats,omitempty"`
 		TopPaths          []pathStatJSON       `json:"top_paths,omitempty"`
 		ErrorBreakdown    []errorBreakdownJSON `json:"error_breakdown,omitempty"`
@@ -726,21 +692,6 @@ func printAppJSON(status *app_v1alpha.ApplicationStatus, cfg *app_v1alpha.Config
 			Name:      ps.Name(),
 			Instances: len(ps.Windows()),
 			Idle:      ps.Idle(),
-		})
-	}
-
-	if cfg != nil && cfg.HasEnvVars() {
-		for _, v := range cfg.EnvVars() {
-			value := v.Value()
-			if v.Sensitive() {
-				value = "****"
-			} else if isSensitiveKey(v.Key()) && len(value) > 0 {
-				value = value[:1] + strings.Repeat("*", len(value)-1)
-			}
-			o.EnvVars = append(o.EnvVars, envVarJSON{Key: v.Key(), Value: value})
-		}
-		sort.Slice(o.EnvVars, func(i, j int) bool {
-			return o.EnvVars[i].Key < o.EnvVars[j].Key
 		})
 	}
 

--- a/cli/commands/app_status.go
+++ b/cli/commands/app_status.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -97,20 +98,22 @@ func AppStatus(ctx *Context, opts struct {
 			ctx.Printf("  Concurrency: %d\n", appConfig.Concurrency())
 		}
 
-		// Environment variables
+		// Environment variables: show keys only. Values live behind the one
+		// masked surface, 'miren env'. See MIR-1356.
 		if appConfig.HasEnvVars() && len(appConfig.EnvVars()) > 0 {
-			ctx.Printf("\n%s\n", labelStyle.Render("Environment Variables:"))
+			var keys []string
 			for _, kv := range appConfig.EnvVars() {
-				if kv.HasKey() && kv.HasValue() {
-					// Mask sensitive values
-					value := kv.Value()
-					key := kv.Key()
-					if isSensitiveKey(key) && len(value) > 0 {
-						value = value[:1] + strings.Repeat("*", len(value)-1)
-					}
-					ctx.Printf("  %s=%s\n", key, value)
+				if kv.HasKey() {
+					keys = append(keys, kv.Key())
 				}
 			}
+			sort.Strings(keys)
+
+			ctx.Printf("\n%s (%d)\n", labelStyle.Render("Environment Variables:"), len(keys))
+			for _, key := range keys {
+				ctx.Printf("  %s\n", key)
+			}
+			ctx.Printf("  %s\n", labelStyle.Render(fmt.Sprintf("Run 'miren env list -a %s' to view values", opts.App)))
 		}
 	}
 
@@ -279,10 +282,6 @@ func printAppStatusJSON(
 	recentResult *deployment_v1alpha.DeploymentClientListDeploymentsResults,
 	app, cluster string,
 ) error {
-	type envVar struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
-	}
 	type gitInfo struct {
 		Sha               string `json:"sha,omitempty"`
 		Branch            string `json:"branch,omitempty"`
@@ -294,7 +293,7 @@ func printAppStatusJSON(
 	}
 	type configuration struct {
 		Concurrency int32    `json:"concurrency,omitempty"`
-		EnvVars     []envVar `json:"env_vars,omitempty"`
+		EnvVars     []string `json:"env_vars,omitempty"`
 	}
 	type deploymentJSON struct {
 		ID           string   `json:"id"`
@@ -399,17 +398,11 @@ func printAppStatusJSON(
 		}
 		if appConfig.HasEnvVars() && len(appConfig.EnvVars()) > 0 {
 			for _, kv := range appConfig.EnvVars() {
-				if kv.HasKey() && kv.HasValue() {
-					value := kv.Value()
-					key := kv.Key()
-					if kv.Sensitive() {
-						value = "****"
-					} else if isSensitiveKey(key) && len(value) > 0 {
-						value = value[:1] + strings.Repeat("*", len(value)-1)
-					}
-					cfg.EnvVars = append(cfg.EnvVars, envVar{Key: key, Value: value})
+				if kv.HasKey() {
+					cfg.EnvVars = append(cfg.EnvVars, kv.Key())
 				}
 			}
+			sort.Strings(cfg.EnvVars)
 		}
 		if cfg.Concurrency > 0 || len(cfg.EnvVars) > 0 {
 			output.Configuration = cfg
@@ -428,23 +421,4 @@ func printAppStatusJSON(
 	}
 
 	return PrintJSON(output)
-}
-
-// isSensitiveKey checks if an environment variable key might contain sensitive data
-func isSensitiveKey(key string) bool {
-	lowerKey := strings.ToLower(key)
-	sensitivePatterns := []string{
-		"password", "passwd", "pwd",
-		"secret", "token", "key",
-		"api_key", "apikey",
-		"auth", "credential",
-		"private",
-	}
-
-	for _, pattern := range sensitivePatterns {
-		if strings.Contains(lowerKey, pattern) {
-			return true
-		}
-	}
-	return false
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -212,10 +212,6 @@ miren deploy --analyze
 			Name: "Watch app stats in real time",
 			Body: "miren app --watch",
 		}),
-		WithExample(mflags.Example{
-			Name: "Show only the app configuration",
-			Body: "miren app --config-only",
-		}),
 	))
 	d.Dispatch("app list", Infer("app list", "List all applications", AppList,
 		WithExample(mflags.Example{

--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -1648,7 +1648,7 @@ func analyzeApp(ctx *Context, bc *build_v1alpha.BuilderClient, dir string) error
 			if len(localDetection.Available) > 0 {
 				ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(theme.Success).Render("Available locally:"))
 				for _, ev := range localDetection.Available {
-					valueDisplay := MaskValue(ev.Value, ev.Sensitive)
+					valueDisplay := maskEnvValue(ev.Value, ev.Sensitive, false)
 					if ev.Sensitive {
 						ctx.Printf("    %s %s=%s\n",
 							lipgloss.NewStyle().Foreground(theme.Success).Render("✓"),
@@ -1677,7 +1677,7 @@ func analyzeApp(ctx *Context, bc *build_v1alpha.BuilderClient, dir string) error
 			if len(localDetection.Additional) > 0 {
 				ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(theme.Info).Render("Also found locally (may be relevant):"))
 				for _, ev := range localDetection.Additional {
-					valueDisplay := MaskValue(ev.Value, ev.Sensitive)
+					valueDisplay := maskEnvValue(ev.Value, ev.Sensitive, false)
 					if ev.Sensitive {
 						ctx.Printf("    %s %s=%s\n",
 							lipgloss.NewStyle().Foreground(theme.Info).Render("?"),
@@ -1699,7 +1699,7 @@ func analyzeApp(ctx *Context, bc *build_v1alpha.BuilderClient, dir string) error
 			ctx.Printf("\n%s\n", analyzeTitleStyle.Render("Environment Variables"))
 			ctx.Printf("  %s\n", lipgloss.NewStyle().Foreground(theme.Info).Render("Found locally (may be relevant):"))
 			for _, ev := range localDetection.Additional {
-				valueDisplay := MaskValue(ev.Value, ev.Sensitive)
+				valueDisplay := maskEnvValue(ev.Value, ev.Sensitive, false)
 				if ev.Sensitive {
 					ctx.Printf("    %s %s=%s\n",
 						lipgloss.NewStyle().Foreground(theme.Info).Render("?"),

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -12,6 +13,83 @@ import (
 	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
+
+// envRedacted is the fixed-width placeholder shown for redacted env var values.
+// It deliberately reveals neither the length nor any character of the value.
+const envRedacted = "••••••••••"
+
+// urlUserinfoRe matches the userinfo (user:pass@) component of a URL-shaped
+// value: a scheme, "://", everything up to the first "@", then "@". Requiring a
+// scheme avoids matching bare email addresses in non-URL values.
+var urlUserinfoRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/?#@]+@`)
+
+// maskURLUserinfo redacts embedded credentials in URL-shaped values so secrets
+// like the password in a DATABASE_URL don't leak even when the key name gave no
+// hint and nothing marked the var sensitive. Non-URL values pass through.
+func maskURLUserinfo(value string) string {
+	return urlUserinfoRe.ReplaceAllString(value, "${1}"+envRedacted+"@")
+}
+
+// maskEnvValue is the single source of truth for how an env-var value is
+// displayed anywhere in the CLI (env list/get, deploy analysis, and any future
+// surface). Sensitivity is decided by EVIDENCE, in tiers, and this function
+// honors that evidence — it does not guess:
+//
+//   - Declared: the `sensitive` flag. Set by the user (-s / app.toml) or by the
+//     producer that minted the credential (addons stamp their generated
+//     DATABASE_URL/passwords). This is the authority; when set, we fully redact.
+//   - Structural: even when the flag is unset, URL userinfo (user:pass@) is
+//     redacted, because that is by definition a credential slot — provable
+//     syntax, not a guess. This is the last-line invariant against unmarked
+//     leaks like a hand-set DATABASE_URL.
+//
+// Deliberately absent: key-name matching. A name like "SECRET" is a *guess*,
+// and a guess that silently fails at display time is exactly how DATABASE_URL
+// leaked (MIR-1356). Name heuristics belong only at set-time as a *suggestion*
+// the user can override (see looksLikeSensitive), never here. If a new leak
+// shape appears (e.g. a JDBC "Password=..." string), the fix is to teach the
+// producer to set `sensitive`, NOT to grow this function into a pile of
+// format matchers. Hold this surface small.
+//
+// The unmask toggle (behind an explicit --unmask flag) means "give me the
+// literal bytes" — no masking, no escaping — for copying or scripting.
+// Without it, the value is rendered display-safe: control/ANSI sequences are
+// escaped so a malicious value can't corrupt terminal or CI output.
+func maskEnvValue(value string, sensitive, unmask bool) string {
+	if unmask {
+		return value
+	}
+	if sensitive {
+		return envRedacted
+	}
+	return escapeForDisplay(maskURLUserinfo(value))
+}
+
+// escapeForDisplay replaces ASCII control characters (including ESC used for
+// ANSI sequences, newlines, and carriage returns) with their Go-quoted form so
+// a malicious env value can't break out of a log line or spoof CLI/CI output.
+func escapeForDisplay(s string) string {
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\n':
+			b.WriteString(`\n`)
+		case r == '\r':
+			b.WriteString(`\r`)
+		case r == '\t':
+			b.WriteString(`\t`)
+		case r < 0x20 || r == 0x7f:
+			fmt.Fprintf(&b, `\x%02x`, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
 
 // EnvVarSpec represents a parsed environment variable specification
 type EnvVarSpec struct {
@@ -225,15 +303,7 @@ func EnvGet(ctx *Context, opts struct {
 		}
 	}
 
-	if found.Sensitive() {
-		if opts.Unmask {
-			ctx.Printf("%s\n", found.Value())
-		} else {
-			ctx.Printf("••••••••••\n")
-		}
-	} else {
-		ctx.Printf("%s\n", found.Value())
-	}
+	ctx.Printf("%s\n", maskEnvValue(found.Value(), found.Sensitive(), opts.Unmask))
 	return nil
 }
 
@@ -319,19 +389,15 @@ func EnvList(ctx *Context, opts struct {
 
 		var vars []EnvVar
 		for _, entry := range entries {
-			ev := EnvVar{
+			vars = append(vars, EnvVar{
 				Name:        entry.nv.Key(),
+				Value:       maskEnvValue(entry.nv.Value(), entry.nv.Sensitive(), false),
 				Sensitive:   entry.nv.Sensitive(),
 				Service:     entry.service,
 				Source:      entry.nv.Source(),
 				Required:    entry.nv.Required(),
 				Description: entry.nv.Description(),
-			}
-			// Only include value for non-sensitive variables in JSON
-			if !entry.nv.Sensitive() {
-				ev.Value = entry.nv.Value()
-			}
-			vars = append(vars, ev)
+			})
 		}
 		return PrintJSON(vars)
 	}
@@ -434,20 +500,20 @@ func EnvDelete(ctx *Context, opts struct {
 	return nil
 }
 
-// printEnvTable prints a formatted table of environment variables
+// printEnvTable prints a formatted table of environment variables. Values are
+// always masked; there is deliberately no bulk-reveal flag — revealing a value
+// is a single-secret, explicit operation via `miren env get <key> --unmask`.
 func printEnvTable(ctx *Context, entries []envVarEntry) {
-	// Create a gray style for sensitive values
+	// Create a gray style for masked values
 	grayStyle := lipgloss.NewStyle().Foreground(theme.Muted)
 
 	// Build rows
 	var rows []ui.Row
 	for _, entry := range entries {
-		var value string
-
-		if entry.nv.Sensitive() {
-			value = grayStyle.Render("••••••••••")
-		} else {
-			value = entry.nv.Value()
+		value := maskEnvValue(entry.nv.Value(), entry.nv.Sensitive(), false)
+		// Gray out values we masked so it's clear the redaction is intentional.
+		if value != entry.nv.Value() {
+			value = grayStyle.Render(value)
 		}
 
 		// Get source with backward compatibility

--- a/cli/commands/env_mask_test.go
+++ b/cli/commands/env_mask_test.go
@@ -1,0 +1,187 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"miren.dev/runtime/api/app/app_v1alpha"
+)
+
+func TestMaskURLUserinfo(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "postgres url with user and password",
+			value: "postgres://admin:s3cr3t@db.internal:5432/app",
+			want:  "postgres://" + envRedacted + "@db.internal:5432/app",
+		},
+		{
+			name:  "password only userinfo",
+			value: "redis://:hunter2@cache:6379/0",
+			want:  "redis://" + envRedacted + "@cache:6379/0",
+		},
+		{
+			name:  "bare username userinfo",
+			value: "amqp://guest@broker:5672",
+			want:  "amqp://" + envRedacted + "@broker:5672",
+		},
+		{
+			name:  "plain value passes through",
+			value: "production",
+			want:  "production",
+		},
+		{
+			name:  "url without userinfo passes through",
+			value: "https://api.example.com/v1/webhook",
+			want:  "https://api.example.com/v1/webhook",
+		},
+		{
+			name:  "email-shaped value without scheme passes through",
+			value: "admin@example.com",
+			want:  "admin@example.com",
+		},
+		{
+			name:  "value with equals and query passes through",
+			value: "http://example.com?a=1&b=2",
+			want:  "http://example.com?a=1&b=2",
+		},
+		{
+			name:  "multiple urls both redacted",
+			value: "primary=postgres://u:p@h1/db secondary=postgres://u2:p2@h2/db",
+			want:  "primary=postgres://" + envRedacted + "@h1/db secondary=postgres://" + envRedacted + "@h2/db",
+		},
+		{
+			name:  "empty value",
+			value: "",
+			want:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maskURLUserinfo(tc.value)
+			if got != tc.want {
+				t.Errorf("maskURLUserinfo(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMaskURLUserinfoNoLeak guards the security-critical property: once redacted,
+// no fragment of the original credential should survive in the output.
+func TestMaskURLUserinfoNoLeak(t *testing.T) {
+	value := "postgres://admin:supersecretpassword@db.internal/app"
+	got := maskURLUserinfo(value)
+	for _, leaked := range []string{"admin", "supersecretpassword", "supersecret", "admin:super"} {
+		if strings.Contains(got, leaked) {
+			t.Errorf("redacted value %q leaked credential fragment %q", got, leaked)
+		}
+	}
+}
+
+// TestPrintEnvTableDoesNotLeak drives the real table renderer end-to-end and
+// asserts the DATABASE_URL password never reaches the output unless unmasked.
+// This is the exact surface (name-match-only) that leaked in the reported bug.
+func TestPrintEnvTableDoesNotLeak(t *testing.T) {
+	nv := &app_v1alpha.NamedValue{}
+	nv.SetKey("DATABASE_URL")
+	nv.SetValue("postgres://appuser:s3cr3tpassword@db.internal:5432/app")
+	nv.SetSensitive(false) // deliberately NOT marked sensitive — key name gives no hint
+	entries := []envVarEntry{{nv: nv, service: ""}}
+
+	// The table has no bulk-reveal path: it always masks. Single-secret reveal
+	// is only via `miren env get <key> --unmask`.
+	var buf bytes.Buffer
+	ctx := &Context{Stdout: &buf}
+	printEnvTable(ctx, entries)
+	out := buf.String()
+	if strings.Contains(out, "s3cr3tpassword") {
+		t.Errorf("env table leaked DATABASE_URL password:\n%s", out)
+	}
+	if !strings.Contains(out, "DATABASE_URL") {
+		t.Errorf("env table dropped the key:\n%s", out)
+	}
+}
+
+func TestMaskEnvValue(t *testing.T) {
+	cases := []struct {
+		name      string
+		value     string
+		sensitive bool
+		unmask    bool
+		want      string
+	}{
+		{
+			name:      "sensitive var is fully redacted",
+			value:     "supersecret",
+			sensitive: true,
+			want:      envRedacted,
+		},
+		{
+			name:  "non-sensitive url masks embedded credentials",
+			value: "postgres://admin:s3cr3t@db/app",
+			want:  "postgres://" + envRedacted + "@db/app",
+		},
+		{
+			name:  "non-sensitive plain value shows through",
+			value: "production",
+			want:  "production",
+		},
+		{
+			name:      "unmask reveals sensitive value",
+			value:     "supersecret",
+			sensitive: true,
+			unmask:    true,
+			want:      "supersecret",
+		},
+		{
+			name:   "unmask reveals url credentials",
+			value:  "postgres://admin:s3cr3t@db/app",
+			unmask: true,
+			want:   "postgres://admin:s3cr3t@db/app",
+		},
+		{
+			// Display path escapes control/ANSI sequences so a hostile value
+			// can't corrupt terminal or CI output.
+			name:  "non-sensitive value escapes ansi and control chars",
+			value: "\x1b[31mred\x1b[0m\nsecond",
+			want:  `\x1b[31mred\x1b[0m\nsecond`,
+		},
+		{
+			// unmask is a literal-bytes escape hatch: no masking AND no
+			// escaping, so scripts capture the exact value.
+			name:   "unmask returns literal bytes without escaping",
+			value:  "line1\nline2",
+			unmask: true,
+			want:   "line1\nline2",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maskEnvValue(tc.value, tc.sensitive, tc.unmask)
+			if got != tc.want {
+				t.Errorf("maskEnvValue(%q, sensitive=%v, unmask=%v) = %q, want %q",
+					tc.value, tc.sensitive, tc.unmask, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMaskEnvValueRedactionHidesLengthAndFirstChar guards against the old
+// value[:1]+Repeat("*") and value[:2]+dots behaviors that leaked the first
+// character(s) and/or exact length of a sensitive value.
+func TestMaskEnvValueRedactionHidesLengthAndFirstChar(t *testing.T) {
+	short := maskEnvValue("ab", true, false)
+	long := maskEnvValue("a-very-long-secret-value-here", true, false)
+	if short != long {
+		t.Errorf("redaction width leaks length: short=%q long=%q", short, long)
+	}
+	if strings.HasPrefix(short, "a") {
+		t.Errorf("redaction leaks first character: %q", short)
+	}
+}

--- a/cli/commands/envdetect.go
+++ b/cli/commands/envdetect.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -293,7 +292,13 @@ func looksLikeAppEnvVar(key string) bool {
 	return false
 }
 
-// looksLikeSensitive checks if an env var name suggests it contains sensitive data
+// looksLikeSensitive guesses, from a key NAME alone, whether a var is likely a
+// secret. This is a tier-3 heuristic (a guess), and its only sanctioned use is
+// as a set-time *suggestion* the user can override — e.g. proposing a default
+// `sensitive` flag for locally-detected vars during deploy analysis. It must
+// never be the sole authority for masking at display time: that is what
+// maskEnvValue (flag + structural URL invariant) is for, and it backstops any
+// miss here. See the maskEnvValue doc comment for the full evidence-tier rule.
 func looksLikeSensitive(key string) bool {
 	upperKey := strings.ToUpper(key)
 	for _, pattern := range sensitivePatterns {
@@ -314,48 +319,4 @@ func looksLikeSensitive(key string) bool {
 		}
 	}
 	return false
-}
-
-// MaskValue masks a sensitive value for display, escaping any control or
-// ANSI-escape sequences so they cannot corrupt or spoof terminal/CI output.
-func MaskValue(value string, sensitive bool) string {
-	if !sensitive {
-		return escapeForDisplay(value)
-	}
-	if value == "" {
-		return ""
-	}
-	if len(value) > 8 {
-		// Show a short prefix to help the user identify which value this is
-		// without revealing the full secret. Escape it the same way so a
-		// secret beginning with an ANSI escape can't break the layout.
-		return escapeForDisplay(value[:2]) + "••••••••"
-	}
-	return "••••••••"
-}
-
-// escapeForDisplay replaces ASCII control characters (including ESC used for
-// ANSI sequences, newlines, and carriage returns) with their Go-quoted form
-// so a malicious env value can't break out of a log line.
-func escapeForDisplay(s string) string {
-	if s == "" {
-		return s
-	}
-	var b strings.Builder
-	b.Grow(len(s))
-	for _, r := range s {
-		switch {
-		case r == '\n':
-			b.WriteString(`\n`)
-		case r == '\r':
-			b.WriteString(`\r`)
-		case r == '\t':
-			b.WriteString(`\t`)
-		case r < 0x20 || r == 0x7f:
-			fmt.Fprintf(&b, `\x%02x`, r)
-		default:
-			b.WriteRune(r)
-		}
-	}
-	return b.String()
 }

--- a/cli/commands/envdetect_test.go
+++ b/cli/commands/envdetect_test.go
@@ -99,37 +99,6 @@ func TestLooksLikeSensitive(t *testing.T) {
 	}
 }
 
-func TestMaskValue(t *testing.T) {
-	testCases := []struct {
-		name      string
-		value     string
-		sensitive bool
-		expected  string
-	}{
-		{"long_sensitive_keeps_2_char_prefix", "mysecret123", true, "my••••••••"},
-		{"short_sensitive_fully_masked", "short", true, "••••••••"},
-		{"empty_sensitive", "", true, ""},
-		{"plain_visible", "visible", false, "visible"},
-		{"empty_visible", "", false, ""},
-		{"longer_sensitive", "verylongsecretvalue", true, "ve••••••••"},
-
-		// Control / ANSI escape characters must not pass through verbatim
-		// or they could spoof or corrupt CLI output and CI logs.
-		{"newline_escaped", "line1\nline2", false, `line1\nline2`},
-		{"crlf_escaped", "a\r\nb", false, `a\r\nb`},
-		{"tab_escaped", "a\tb", false, `a\tb`},
-		{"ansi_escape_escaped", "\x1b[31mred\x1b[0m", false, `\x1b[31mred\x1b[0m`},
-		{"sensitive_prefix_escaped", "\x1b[31mxxxxxxxxxx", true, `\x1b[••••••••`},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := MaskValue(tc.value, tc.sensitive)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
-}
-
 // TestDetectLocalEnvVars_DeduplicatesDetectedKeys verifies that a key
 // emitted multiple times by the analyzer (e.g. via both package-based and
 // source-based detection) only produces a single Available/Missing row.

--- a/docs/docs/command/app.md
+++ b/docs/docs/command/app.md
@@ -16,7 +16,6 @@ miren app [flags]
 
 ## Flags
 
-- `--config-only` — Only show the configuration
 - `--format` — Output format (text, json) (default: `text`)
 - `--graph, -g` — Graph the app stats
 - `--json` — Shorthand for --format json
@@ -56,12 +55,6 @@ miren app -a myapp
 
 ```bash
 miren app --watch
-```
-
-**Show only the app configuration:**
-
-```bash
-miren app --config-only
 ```
 
 ## Subcommands


### PR DESCRIPTION
`miren app status` masked `SECRET_KEY_BASE` and `POSTGRES_PASSWORD` but printed `DATABASE_URL` in full, exposing the Postgres password embedded in the URL. The leak was a symptom of a broader pattern: env-var display had been copy-pasted across six CLI surfaces, each with its own masking behavior. The text path in `app status` matched against a hardcoded list of secret-ish key names (`password`, `secret`, `token`, ...), and `DATABASE_URL` matches none of them, so its value printed verbatim. That same path also ignored the explicit `sensitive` flag from app.toml, so a var deliberately marked sensitive still showed in the clear.

The fix has two halves. First, consolidation: env-var *values* now belong to one noun, `miren env`. Values are gone from `app`, `app status`, `app --json`, and the `deploy --analyze` preview. `app status` keeps the key *names* for glanceability and points at `miren env list`. This also let us drop some dead weight: the `--config-only` flag (a pre-`--json` debug dump that emitted raw proto), an env block in the `app` TUI that was built but never rendered, and the `isSensitiveKey` name matcher.

Second, one masking authority. Every surface that shows a value now goes through a single function, and it encodes a clear strategy. Sensitivity is decided by evidence, in tiers: the declared `sensitive` flag is the authority (set by the user, or stamped by the addon that minted the credential), and on top of that a structural invariant redacts `user:pass@` userinfo in URL-shaped values regardless of key name, since that's provable credential syntax rather than a guess. Name matching still exists, but as a set-time suggestion you can override, not a display-time decision. A name-guess that silently fails at display is how `DATABASE_URL` slipped through, so the display path doesn't guess. Redaction is fixed-width (no first-character or length tell), and values are escaped so a hostile env value can't corrupt a terminal or CI log.

There's also no bulk reveal. `env list` and friends always mask; the only way to see a real value is `miren env get <key> --unmask`, one secret at a time. That keeps the friction on revealing proportional to the exposure.

Smoke-tested end to end against a live deploy with an unmarked `DATABASE_URL`: masked in `env list` (table and json), `env get`, `app status`, and `deploy --analyze`, revealed only through `env get --unmask`.

Closes MIR-1356
