### PR TITLE
Decouple POP test's cloud build from runtime's Go toolchain

### DIFF
--- a/blackbox/harness/cloud.go
+++ b/blackbox/harness/cloud.go
@@ -184,11 +184,18 @@ func (env *CloudEnv) buildBinaries(t *testing.T, cloudRepo string) {
 
 	binDir := filepath.Join(env.m.cluster.RepoRoot, "bin")
 
+	// GOTOOLCHAIN=auto lets these builds fetch whatever toolchain the cloud
+	// repo's go.mod requires, decoupling it from runtime's Go version. CI's
+	// setup-go exports GOTOOLCHAIN=local job-wide, which would otherwise pin
+	// the cloud build to runtime's toolchain and fail whenever cloud requires
+	// a newer Go. Appended last so it wins over the inherited value.
+	buildEnv := append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux", "GOTOOLCHAIN=auto")
+
 	// Build cloud binary
 	t.Log("building cloud binary...")
 	cmd := exec.Command("go", "build", "-o", filepath.Join(binDir, "bb-cloud"), "./cmd/cloud")
 	cmd.Dir = cloudRepo
-	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux")
+	cmd.Env = buildEnv
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("failed to build cloud binary: %v\n%s", err, out)
 	}
@@ -197,7 +204,7 @@ func (env *CloudEnv) buildBinaries(t *testing.T, cloudRepo string) {
 	t.Log("building POP binary...")
 	cmd = exec.Command("go", "build", "-o", filepath.Join(binDir, "bb-pop"), "./cmd/pop")
 	cmd.Dir = cloudRepo
-	cmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux")
+	cmd.Env = buildEnv
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("failed to build POP binary: %v\n%s", err, out)
 	}


### PR DESCRIPTION
The `test-blackbox-pop` job on main went red with:

```
go: go.mod requires go >= 1.25.8 (running go 1.25.1; GOTOOLCHAIN=local)
--- FAIL: TestPOP
```

Nothing in runtime changed to cause this. The POP test builds the cloud repo's binaries from source on the host runner, and CI's `setup-go` exports `GOTOOLCHAIN=local` job-wide so runtime never surprise-downloads a toolchain. The side effect is that the cloud build was pinned to *runtime's* Go version. When cloud bumped its `go.mod` to require go >= 1.25.8 while runtime was still on 1.25.1, the cloud build couldn't fetch a newer toolchain and failed, taking main's CI down with it.

The quick fix would be to bump runtime's `go.mod` to 1.25.8, but that just papers over a bad coupling: cloud can unilaterally break runtime's CI, and we'd be chasing their Go version forever. Instead, this scopes the toolchain decision to the exact spot where we build the foreign repo. Setting `GOTOOLCHAIN=auto` on the cloud/pop build commands lets each fetch whatever toolchain cloud's own `go.mod` declares.

Now the two repos are decoupled: runtime keeps its own Go version, and cloud bumping ahead can no longer break us. It also matches what already happens when you run the POP test locally, where `GOTOOLCHAIN` defaults to `auto` anyway. The env var is appended last so it wins over the inherited `local`.