### PR TITLE
Advertise containerized state to cloud for Miren Anywhere (MIR-1164)

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -60,6 +60,7 @@ import (
 	"miren.dev/runtime/pkg/addon/valkey"
 	"miren.dev/runtime/pkg/caauth"
 	"miren.dev/runtime/pkg/cloudauth"
+	"miren.dev/runtime/pkg/containerenv"
 	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/schema"
@@ -1487,6 +1488,7 @@ func (c *Coordinator) ReportStartupStatus(ctx context.Context) error {
 		APIAddresses:      c.apiAddresses(),
 		CACertFingerprint: caFingerprint,
 		Reachability:      c.reachabilityVerdict(),
+		Containerized:     containerenv.InContainer(),
 	}
 
 	return c.authClient.ReportClusterStatus(ctx, status)
@@ -1535,6 +1537,7 @@ func (c *Coordinator) ReportStatus(ctx context.Context) error {
 		ResourceUsage: resourceUsage,
 		APIAddresses:  c.apiAddresses(),
 		Reachability:  c.reachabilityVerdict(),
+		Containerized: containerenv.InContainer(),
 	}
 
 	return c.authClient.ReportClusterStatus(ctx, status)

--- a/pkg/cloudauth/status.go
+++ b/pkg/cloudauth/status.go
@@ -38,6 +38,14 @@ type StatusReport struct {
 	// public source address, so old agents and pre-netcheck reports simply
 	// don't send it and cloud falls back to its generic copy.
 	Reachability *ReachabilityVerdict `json:"reachability,omitempty"`
+
+	// Containerized reports whether the miren server is running inside a
+	// container (Docker, Podman, or a Kubernetes pod). A containerized server is
+	// effectively never reachable directly from the internet, so miren.cloud
+	// uses this to keep Miren Anywhere (POP routing) forced on for the cluster.
+	// Sent unconditionally (no omitempty) so an explicit false keeps cloud in
+	// sync if a cluster ever moves off a container.
+	Containerized bool `json:"containerized"`
 }
 
 // ReachabilityVerdict is a compact, agent-computed explanation of the

--- a/pkg/cloudauth/status_test.go
+++ b/pkg/cloudauth/status_test.go
@@ -103,6 +103,25 @@ func TestReportClusterStatus(t *testing.T) {
 	assert.Equal(t, "Bearer test-jwt-token", authToken)
 }
 
+func TestStatusReport_ContainerizedMarshaling(t *testing.T) {
+	// containerized has no omitempty: cloud relies on it to force Miren Anywhere
+	// on, so both true and an explicit false must always be transmitted.
+	for _, containerized := range []bool{true, false} {
+		body, err := json.Marshal(&StatusReport{
+			ClusterID:     "test-cluster",
+			Containerized: containerized,
+		})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(body, &decoded))
+
+		val, present := decoded["containerized"]
+		require.True(t, present, "containerized key must always be present, got %s", body)
+		assert.Equal(t, containerized, val)
+	}
+}
+
 func TestReportClusterStatus_Validation(t *testing.T) {
 	// Create a test key pair
 	keyPair, err := GenerateKeyPair()

--- a/pkg/containerenv/containerenv.go
+++ b/pkg/containerenv/containerenv.go
@@ -1,0 +1,75 @@
+// Package containerenv detects whether the current process is running inside a
+// container (Docker, Podman, or a Kubernetes pod). The miren server uses this to
+// advertise to miren.cloud that it's containerized, since a containerized server
+// is effectively never reachable directly from the internet and must keep Miren
+// Anywhere (POP routing) on.
+package containerenv
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// dockerEnvPath and podmanEnvPath are the marker files each runtime drops into
+// the container filesystem. Their presence is a definitive signal.
+var (
+	dockerEnvPath = "/.dockerenv"
+	podmanEnvPath = "/run/.containerenv"
+)
+
+// cgroupPaths are read as a fallback when the marker files are absent. Container
+// runtimes leave recognizable tokens in the cgroup hierarchy of PID 1 and the
+// current process.
+var cgroupPaths = []string{"/proc/1/cgroup", "/proc/self/cgroup"}
+
+// cgroupMarkers are substrings that indicate a containerized cgroup hierarchy.
+var cgroupMarkers = []string{"docker", "containerd", "podman", "kubepods", "libpod"}
+
+var (
+	once     sync.Once
+	inCached bool
+)
+
+// InContainer reports whether the process is running inside a container. The
+// result is computed once and cached — it can't change over the process
+// lifetime.
+func InContainer() bool {
+	once.Do(func() {
+		inCached = detect()
+	})
+	return inCached
+}
+
+// detect performs the actual probing. It's separate from InContainer so tests
+// can exercise it directly without the sync.Once cache.
+func detect() bool {
+	if fileExists(dockerEnvPath) || fileExists(podmanEnvPath) {
+		return true
+	}
+	for _, p := range cgroupPaths {
+		if cgroupIndicatesContainer(p) {
+			return true
+		}
+	}
+	return false
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func cgroupIndicatesContainer(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	contents := string(data)
+	for _, marker := range cgroupMarkers {
+		if strings.Contains(contents, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/containerenv/containerenv_test.go
+++ b/pkg/containerenv/containerenv_test.go
@@ -1,0 +1,84 @@
+package containerenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// isolateProbes points all probe paths at a fresh temp dir so a test never sees
+// the real host/container markers, and restores them on cleanup.
+func isolateProbes(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	origDocker, origPodman, origCgroups := dockerEnvPath, podmanEnvPath, cgroupPaths
+	t.Cleanup(func() {
+		dockerEnvPath, podmanEnvPath, cgroupPaths = origDocker, origPodman, origCgroups
+	})
+
+	dockerEnvPath = filepath.Join(dir, "dockerenv")
+	podmanEnvPath = filepath.Join(dir, "containerenv")
+	cgroupPaths = []string{filepath.Join(dir, "self-cgroup"), filepath.Join(dir, "pid1-cgroup")}
+	return dir
+}
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestDetect_NoMarkers(t *testing.T) {
+	isolateProbes(t)
+	if detect() {
+		t.Fatal("detect() = true with no markers present, want false")
+	}
+}
+
+func TestDetect_DockerEnv(t *testing.T) {
+	isolateProbes(t)
+	writeFile(t, dockerEnvPath, "")
+	if !detect() {
+		t.Fatal("detect() = false with /.dockerenv present, want true")
+	}
+}
+
+func TestDetect_PodmanEnv(t *testing.T) {
+	isolateProbes(t)
+	writeFile(t, podmanEnvPath, "")
+	if !detect() {
+		t.Fatal("detect() = false with /run/.containerenv present, want true")
+	}
+}
+
+func TestDetect_CgroupMarker(t *testing.T) {
+	for _, marker := range cgroupMarkers {
+		t.Run(marker, func(t *testing.T) {
+			isolateProbes(t)
+			writeFile(t, cgroupPaths[0], "12:pids:/"+marker+"/abc123\n")
+			if !detect() {
+				t.Fatalf("detect() = false with %q cgroup marker, want true", marker)
+			}
+		})
+	}
+}
+
+func TestDetect_CgroupNoMarker(t *testing.T) {
+	isolateProbes(t)
+	writeFile(t, cgroupPaths[0], "0::/user.slice/session-1.scope\n")
+	writeFile(t, cgroupPaths[1], "0::/init.scope\n")
+	if detect() {
+		t.Fatal("detect() = true for a non-container cgroup, want false")
+	}
+}
+
+func TestInContainer_Caches(t *testing.T) {
+	// InContainer memoizes via sync.Once; the first caller wins. Just assert it
+	// runs and returns a stable value across calls.
+	first := InContainer()
+	if InContainer() != first {
+		t.Fatal("InContainer() returned different values across calls")
+	}
+}


### PR DESCRIPTION
## What

When the miren server starts **inside a container** (Docker Desktop, `miren server container install`, k8s, etc.) it detects that and advertises it to miren.cloud in the cluster status report, so cloud can keep **Miren Anywhere** (POP routing) forced on for the cluster automatically.

## Why

A containerized server is effectively never reachable directly from the internet — its advertised addresses are container-internal and published ports sit behind NAT, so netcheck can't confirm public reachability. Today an operator in that situation has to flip the per-cluster Miren Anywhere toggle (added in MIR-1163) to **Always** by hand. This closes that gap by reporting the fact and letting cloud apply the policy.

## Changes

- **`pkg/containerenv`** (new) — `InContainer() bool` detects a container environment via `/.dockerenv` (Docker), `/run/.containerenv` (Podman), and container/kube markers in `/proc/{1,self}/cgroup`. Memoized with `sync.Once`; probe paths are injectable for tests.
- **`pkg/cloudauth/status.go`** — new `Containerized bool` field on `StatusReport`, sent without `omitempty` so an explicit `false` keeps cloud in sync if a cluster ever moves off a container.
- **`components/coordinate/coordinate.go`** — populate `Containerized` in both the startup (`ReportStartupStatus`) and periodic (`ReportStatus`) status reports.

## Scope

Runtime-only. The cloud-side consumption of the flag (defaulting the Miren Anywhere toggle to Always) lives in a separate repo. **The JSON key `containerized` is a cross-repo contract** — confirm it matches the cloud consumer before that side ships.

## Testing

- `pkg/containerenv` unit tests: docker/podman/cgroup markers + negative cases.
- `pkg/cloudauth` marshal test: `containerized` is always emitted for both `true` and `false`.
- `components/coordinate` package compiles and its tests pass.
- Verified end-to-end that `InContainer()` returns `true` inside the containerized dev/CI environment (via `/.dockerenv`).
- `make lint` clean.