### PR TITLE
Fix disk_mount reconcile hot-loop on orphaned mount (MIR-1345)

### DIFF
--- a/components/diskio/disk_mount_controller.go
+++ b/components/diskio/disk_mount_controller.go
@@ -2,6 +2,7 @@ package diskio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -10,8 +11,23 @@ import (
 
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 )
+
+// OrphanMountSweepGracePeriod is how old a disk_mount must be before the orphan
+// sweeper will delete it for a missing backing volume. It guards against a race
+// where a mount has just been created but its volume entity hasn't been
+// observed yet.
+const OrphanMountSweepGracePeriod = 2 * time.Minute
+
+// writeTracker records revisions written directly by this controller so the
+// owning ReconcileController's watch can skip its own events. It is satisfied
+// by *controller.ReconcileController; declared locally to keep diskio decoupled
+// from pkg/controller.
+type writeTracker interface {
+	RecordWrite(revision int64)
+}
 
 // DiskMountController watches disk_mount entities and manages loop-device mounts.
 type DiskMountController struct {
@@ -24,6 +40,11 @@ type DiskMountController struct {
 
 	// Cloud client for lease management and segment replay (nil when cloud not configured)
 	cloudClient CloudDiskClient
+
+	// writeTracker records revisions this controller writes directly via eac,
+	// so the reconcile watch skips the resulting self-generated events instead
+	// of re-triggering reconcile in a tight loop. nil in unit tests.
+	writeTracker writeTracker
 
 	// keepMounts, when true, causes Shutdown to skip unmounting.
 	// Set during reload so the new process can pick up existing mounts.
@@ -47,6 +68,13 @@ func (c *DiskMountController) SetEAC(eac *entityserver_v1alpha.EntityAccessClien
 // SetCloudClient sets the cloud client for lease management and segment replay.
 func (c *DiskMountController) SetCloudClient(client CloudDiskClient) {
 	c.cloudClient = client
+}
+
+// SetWriteTracker wires the reconcile controller's write tracker so that entity
+// writes this controller makes directly (via updateMountState) are recorded and
+// their watch events are skipped, preventing a self-retriggering reconcile loop.
+func (c *DiskMountController) SetWriteTracker(wt writeTracker) {
+	c.writeTracker = wt
 }
 
 // SetKeepMounts tells the controller to skip unmounting during Shutdown.
@@ -655,8 +683,20 @@ func (c *DiskMountController) updateMountState(ctx context.Context, id entity.Id
 		attrs = append(attrs, entity.String(storage_v1alpha.DiskMountErrorMessageId, *errorMsg))
 	}
 
-	_, err := c.eac.Patch(ctx, attrs, 0)
-	return err
+	result, err := c.eac.Patch(ctx, attrs, 0)
+	if err != nil {
+		return err
+	}
+
+	// Record the revision we just wrote so the reconcile watch skips this
+	// self-generated event rather than re-enqueuing the same entity — the
+	// mechanism that stops a stuck mount from self-retriggering at full
+	// throughput (MIR-1345).
+	if c.writeTracker != nil && result != nil && result.HasRevision() {
+		c.writeTracker.RecordWrite(result.Revision())
+	}
+
+	return nil
 }
 
 func (c *DiskMountController) setMountError(ctx context.Context, id entity.Id, errorMsg string) {
@@ -713,39 +753,7 @@ func (c *DiskMountController) ReconcileWithEntities(ctx context.Context) error {
 		}
 
 		c.log.Info("cleaning up orphaned disk mount", "entity_id", mountState.EntityId)
-
-		// For alwaysMount volumes, skip actual unmount/detach — volume controller owns those
-		if alwaysMount(mountState.Mode) {
-			c.state.DeleteMount(mountState.EntityId)
-			orphanCleaned = true
-			continue
-		}
-
-		if mountState.Mounted && mountState.MountPath != "" {
-			if err := c.ops.Unmount(mountState.MountPath); err != nil {
-				c.log.Warn("failed to unmount orphaned mount", "entity_id", mountState.EntityId, "error", err)
-			}
-		}
-
-		if mountState.DevicePath != "" {
-			if mountState.Mode == storage_v1alpha.VM_ACCELERATOR {
-				if err := c.ops.LbdDetach(ctx, mountState.DevicePath); err != nil {
-					c.log.Warn("failed to detach lbd for orphaned mount", "entity_id", mountState.EntityId, "error", err)
-				}
-			} else {
-				if err := c.ops.LoopDetach(mountState.DevicePath); err != nil {
-					c.log.Warn("failed to detach loop for orphaned mount", "entity_id", mountState.EntityId, "error", err)
-				}
-			}
-		}
-
-		if mountState.LeaseNonce != "" && c.cloudClient != nil {
-			if err := c.cloudClient.ReleaseLease(ctx, mountState.VolumeId, mountState.LeaseNonce); err != nil {
-				c.log.Warn("failed to release lease for orphaned mount", "entity_id", mountState.EntityId, "error", err)
-			}
-		}
-
-		c.state.DeleteMount(mountState.EntityId)
+		c.teardownLocalMount(ctx, mountState)
 		orphanCleaned = true
 	}
 
@@ -753,6 +761,123 @@ func (c *DiskMountController) ReconcileWithEntities(ctx context.Context) error {
 		if err := c.state.Save(); err != nil {
 			c.log.Warn("failed to save state after orphan cleanup", "error", err)
 		}
+	}
+
+	return nil
+}
+
+// teardownLocalMount unmounts, detaches, and releases the lease for a locally
+// tracked mount, then removes it from local state. It does not touch the entity
+// or persist state (callers batch the Save). alwaysMount volumes are owned by
+// the volume controller, so their mount/detach is skipped.
+func (c *DiskMountController) teardownLocalMount(ctx context.Context, mountState *MountState) {
+	if alwaysMount(mountState.Mode) {
+		c.state.DeleteMount(mountState.EntityId)
+		return
+	}
+
+	if mountState.Mounted && mountState.MountPath != "" {
+		if err := c.ops.Unmount(mountState.MountPath); err != nil {
+			c.log.Warn("failed to unmount orphaned mount", "entity_id", mountState.EntityId, "error", err)
+		}
+	}
+
+	if mountState.DevicePath != "" {
+		if mountState.Mode == storage_v1alpha.VM_ACCELERATOR {
+			if err := c.ops.LbdDetach(ctx, mountState.DevicePath); err != nil {
+				c.log.Warn("failed to detach lbd for orphaned mount", "entity_id", mountState.EntityId, "error", err)
+			}
+		} else {
+			if err := c.ops.LoopDetach(mountState.DevicePath); err != nil {
+				c.log.Warn("failed to detach loop for orphaned mount", "entity_id", mountState.EntityId, "error", err)
+			}
+		}
+	}
+
+	if mountState.LeaseNonce != "" && c.cloudClient != nil {
+		if err := c.cloudClient.ReleaseLease(ctx, mountState.VolumeId, mountState.LeaseNonce); err != nil {
+			c.log.Warn("failed to release lease for orphaned mount", "entity_id", mountState.EntityId, "error", err)
+		}
+	}
+
+	c.state.DeleteMount(mountState.EntityId)
+}
+
+// ReconcileOrphanMounts deletes disk_mount entities on this node whose backing
+// disk_volume no longer exists. Such a mount can never reach its desired state
+// and, before writes are deduped, self-retriggers reconcile indefinitely
+// (MIR-1345). Deleting the entity via the entity server also removes its
+// secondary-index keys, which a raw etcd delete would leave dangling.
+//
+// minMountAge guards against deleting a just-created mount whose volume entity
+// hasn't been observed yet; pass OrphanMountSweepGracePeriod in production.
+func (c *DiskMountController) ReconcileOrphanMounts(ctx context.Context, minMountAge time.Duration) error {
+	if c.eac == nil {
+		return fmt.Errorf("entity access client not set; call SetEAC before reconciling")
+	}
+
+	resp, err := c.eac.List(ctx, c.Index())
+	if err != nil {
+		return fmt.Errorf("list disk_mount entities: %w", err)
+	}
+
+	now := time.Now()
+	var deleted, localCleaned int
+	for _, e := range resp.Values() {
+		var mount storage_v1alpha.DiskMount
+		mount.Decode(e.Entity())
+
+		if mount.VolumeId == "" {
+			continue
+		}
+
+		// Leave young mounts alone so a mount created before its volume was
+		// observed doesn't get swept in a race.
+		if minMountAge > 0 && now.Sub(e.Entity().GetCreatedAt()) < minMountAge {
+			continue
+		}
+
+		// Is the backing volume gone? Only a definitive not-found counts as
+		// orphaned; transient errors are skipped so we fail safe.
+		_, verr := c.eac.Get(ctx, string(mount.VolumeId))
+		if verr == nil {
+			continue
+		}
+		if !errors.Is(verr, cond.ErrNotFound{}) {
+			c.log.Warn("orphan mount sweep: failed to load backing volume",
+				"entity_id", mount.ID, "volume_id", mount.VolumeId, "error", verr)
+			continue
+		}
+
+		c.log.Info("orphan mount sweep: deleting mount with missing backing volume",
+			"entity_id", mount.ID,
+			"volume_id", mount.VolumeId,
+			"disk_lease_id", mount.DiskLeaseId,
+			"actual_state", mount.ActualState,
+		)
+
+		// Best-effort local teardown before removing the entity.
+		if mountState := c.state.GetMount(string(mount.ID)); mountState != nil {
+			c.teardownLocalMount(ctx, mountState)
+			localCleaned++
+		}
+
+		if _, derr := c.eac.Delete(ctx, string(mount.ID)); derr != nil {
+			c.log.Warn("orphan mount sweep: failed to delete mount entity",
+				"entity_id", mount.ID, "error", derr)
+			continue
+		}
+		deleted++
+	}
+
+	if localCleaned > 0 {
+		if err := c.state.Save(); err != nil {
+			c.log.Warn("failed to save state after orphan mount sweep", "error", err)
+		}
+	}
+
+	if deleted > 0 {
+		c.log.Info("orphan mount sweep complete", "deleted", deleted)
 	}
 
 	return nil

--- a/components/diskio/disk_mount_orphan_sweep_test.go
+++ b/components/diskio/disk_mount_orphan_sweep_test.go
@@ -1,0 +1,208 @@
+package diskio
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+// fakeWriteTracker records the revisions handed to it so tests can assert the
+// disk mount controller reports its direct entity writes.
+type fakeWriteTracker struct {
+	revs []int64
+}
+
+func (f *fakeWriteTracker) RecordWrite(rev int64) {
+	f.revs = append(f.revs, rev)
+}
+
+// TestDiskMountControllerRecordsSelfWrites verifies that when a write tracker is
+// wired, updateMountState reports the revision it wrote so the reconcile watch
+// can skip its own events instead of self-retriggering (MIR-1345).
+func TestDiskMountControllerRecordsSelfWrites(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	dataPath := t.TempDir()
+	nodeId := "test-node-1"
+	state := NewState()
+	ops := newMockDiskMountOps()
+
+	mc := newTestDiskMountController(log, dataPath, nodeId, es.EAC, state, ops)
+	tracker := &fakeWriteTracker{}
+	mc.SetWriteTracker(tracker)
+
+	// A mount whose backing volume is missing drives updateMountState (via the
+	// error path), which is exactly the write we need to record.
+	mount := &storage_v1alpha.DiskMount{
+		ID:           "disk_mount/mnt-selfwrite",
+		NodeId:       entity.Id("node/" + nodeId),
+		VolumeId:     "disk_volume/vol-missing",
+		MountPath:    "/mnt/selfwrite",
+		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
+		ActualState:  storage_v1alpha.DM_PENDING,
+	}
+	createDiskMountEntity(ctx, t, es, mount)
+
+	require.NoError(t, mc.ReconcileWithEntities(ctx))
+
+	require.NotEmpty(t, tracker.revs, "controller should record the revisions it writes")
+	for _, rev := range tracker.revs {
+		assert.Greater(t, rev, int64(0), "recorded revisions should be positive")
+	}
+}
+
+// TestDiskMountControllerSelfWritesNilTrackerSafe verifies that without a write
+// tracker (as in most unit tests and any un-wired path) updateMountState is a
+// no-op with respect to tracking and does not panic.
+func TestDiskMountControllerSelfWritesNilTrackerSafe(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	state := NewState()
+	mc := newTestDiskMountController(log, t.TempDir(), "test-node-1", es.EAC, state, newMockDiskMountOps())
+
+	mount := &storage_v1alpha.DiskMount{
+		ID:           "disk_mount/mnt-nil-tracker",
+		NodeId:       entity.Id("node/test-node-1"),
+		VolumeId:     "disk_volume/vol-missing",
+		MountPath:    "/mnt/nil",
+		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
+		ActualState:  storage_v1alpha.DM_PENDING,
+	}
+	createDiskMountEntity(ctx, t, es, mount)
+
+	require.NotPanics(t, func() {
+		require.NoError(t, mc.ReconcileWithEntities(ctx))
+	})
+}
+
+// TestReconcileOrphanMountsDeletesMissingVolume verifies the sweeper deletes a
+// disk_mount whose backing volume no longer exists and tears down its local
+// state — the doubly-orphaned case from the MIR-1345 incident.
+func TestReconcileOrphanMountsDeletesMissingVolume(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	dataPath := t.TempDir()
+	nodeId := "test-node-1"
+	state := NewState()
+	ops := newMockDiskMountOps()
+
+	mount := &storage_v1alpha.DiskMount{
+		ID:           "disk_mount/mnt-orphan",
+		NodeId:       entity.Id("node/" + nodeId),
+		VolumeId:     "disk_volume/vol-gone",
+		MountPath:    "/mnt/orphan",
+		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
+		ActualState:  storage_v1alpha.DM_ERROR,
+	}
+	createDiskMountEntity(ctx, t, es, mount)
+
+	// Local mount state that should be torn down before the entity is deleted.
+	state.SetMount("disk_mount/mnt-orphan", &MountState{
+		EntityId:   "disk_mount/mnt-orphan",
+		VolumeId:   "disk_volume/vol-gone",
+		DevicePath: "/dev/loop5",
+		MountPath:  "/mnt/orphan",
+		Mounted:    true,
+	})
+	ops.mountedPaths["/mnt/orphan"] = true
+
+	mc := newTestDiskMountController(log, dataPath, nodeId, es.EAC, state, ops)
+
+	require.NoError(t, mc.ReconcileOrphanMounts(ctx, 0))
+
+	// Entity is gone.
+	_, err := es.EAC.Get(ctx, "disk_mount/mnt-orphan")
+	require.Error(t, err)
+
+	// Local state was torn down.
+	assert.Nil(t, state.GetMount("disk_mount/mnt-orphan"))
+	assert.Contains(t, ops.unmounts, "/mnt/orphan")
+	assert.Contains(t, ops.detachedLoops, "/dev/loop5")
+}
+
+// TestReconcileOrphanMountsKeepsMountWithExistingVolume verifies the sweeper
+// leaves a mount alone while its backing volume still exists.
+func TestReconcileOrphanMountsKeepsMountWithExistingVolume(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	nodeId := "test-node-1"
+	state := NewState()
+
+	createDiskVolumeEntity(ctx, t, es, &storage_v1alpha.DiskVolume{
+		ID:     "disk_volume/vol-live",
+		NodeId: entity.Id("node/" + nodeId),
+		DiskId: "disk/disk-live",
+		SizeGb: 10,
+	})
+
+	mount := &storage_v1alpha.DiskMount{
+		ID:           "disk_mount/mnt-live",
+		NodeId:       entity.Id("node/" + nodeId),
+		VolumeId:     "disk_volume/vol-live",
+		MountPath:    "/mnt/live",
+		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
+		ActualState:  storage_v1alpha.DM_MOUNTED,
+	}
+	createDiskMountEntity(ctx, t, es, mount)
+
+	mc := newTestDiskMountController(log, t.TempDir(), nodeId, es.EAC, state, newMockDiskMountOps())
+
+	require.NoError(t, mc.ReconcileOrphanMounts(ctx, 0))
+
+	// Entity still present.
+	_, err := es.EAC.Get(ctx, "disk_mount/mnt-live")
+	require.NoError(t, err)
+}
+
+// TestReconcileOrphanMountsRespectsGracePeriod verifies a freshly created mount
+// is not swept even when its backing volume is missing, so a mount created just
+// before its volume is observed doesn't get deleted in a race.
+func TestReconcileOrphanMountsRespectsGracePeriod(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	nodeId := "test-node-1"
+	state := NewState()
+
+	mount := &storage_v1alpha.DiskMount{
+		ID:           "disk_mount/mnt-young",
+		NodeId:       entity.Id("node/" + nodeId),
+		VolumeId:     "disk_volume/vol-gone",
+		MountPath:    "/mnt/young",
+		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
+		ActualState:  storage_v1alpha.DM_ERROR,
+	}
+	createDiskMountEntity(ctx, t, es, mount)
+
+	mc := newTestDiskMountController(log, t.TempDir(), nodeId, es.EAC, state, newMockDiskMountOps())
+
+	// Just-created mount is younger than the grace period → left alone.
+	require.NoError(t, mc.ReconcileOrphanMounts(ctx, time.Hour))
+
+	_, err := es.EAC.Get(ctx, "disk_mount/mnt-young")
+	require.NoError(t, err)
+}

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -848,9 +848,22 @@ func (r *Runner) SetupControllers(
 	))
 
 	mntHandler := controller.AdaptReconcileController[storage_v1alpha.DiskMount](r.dmc)
-	cm.AddController(controller.NewReconcileController(
+	mntController := controller.NewReconcileController(
 		"disk-mount", log, r.dmc.Index(), eas, mntHandler, 5*time.Minute, workers,
-	))
+	)
+	// Record the mount controller's direct entity writes so the watch skips its
+	// own events instead of self-retriggering reconcile in a tight loop (MIR-1345).
+	r.dmc.SetWriteTracker(mntController.WriteTracker())
+	// Periodically delete mounts whose backing volume is gone. Such a mount can
+	// never reach its desired state; sweeping bounds how long an orphan lingers
+	// and re-attempts a failing reconcile (MIR-1345).
+	mntController.SetPeriodic(5*time.Minute, func(ctx context.Context) error {
+		if err := r.dmc.ReconcileOrphanMounts(ctx, diskio.OrphanMountSweepGracePeriod); err != nil {
+			log.Warn("periodic orphan mount sweep failed", "error", err)
+		}
+		return nil
+	})
+	cm.AddController(mntController)
 
 	// Use entity mode controllers
 	diskController := disk.NewDiskController(log, eas, r.Id, r.DiskMode, r.deps.IsCoordinator)


### PR DESCRIPTION
## Summary

Fixes the MIR-1345 incident where an orphaned `disk_mount` entity spun in a tight, backoff-free reconcile loop, ballooning etcd from ~0.7 GB → the 2 GiB backend quota in ~90 min, arming a persisted `NOSPACE` alarm and wedging the runtime on boot.

This PR covers the **primary root-cause fix only**. The etcd defense-in-depth items from the ticket (explicit `--quota-backend-bytes`, NOSPACE self-recovery, absolute-size defrag triggers/metrics) are intentionally deferred to a separate follow-up.

## Why it looped

The disk-mount `ReconcileController` runs a **watch** (every etcd change to a matching entity is enqueued) and a **worker** (pulls events, calls `reconcileMount`). The framework has a `recentWrites` ring (`pkg/controller/controller.go:207`) whose job is to skip watch events for revisions the controller *itself* wrote — "if I caused this change, I don't need to react to it." It's populated by `RecordWrite`, called from `applyUpdates` (the path where a controller *returns* attrs for the framework to write).

`DiskMountController` doesn't use that path. It writes state **directly** via `c.eac.Patch` inside `updateMountState`, and discarded the result. So its revisions never entered `recentWrites`, and its own writes were never filtered from the watch:

1. Worker reconciles the mount: `DM_ERROR` + `DM_WANT_MOUNTED` → `attachAndMount` → volume missing → `setMountError` → `eac.Patch` writes rev `N`.
2. That write is a change to the entity → the watch delivers an event for rev `N`.
3. The callback enqueues it (it's not in `recentWrites`) → worker reconciles again → writes rev `N+1`.
4. Back to step 2.

**The controller's own write was the input that woke it up again.** Each iteration wrote `DM_ATTACHING` then `DM_ERROR` (two writes, ×7 keys via secondary indexes), with no external driver — self-sustaining churn at ~1000 writes/s.

For the incident mount, both the backing `disk_volume` and the parent `disk_lease` were already gone from etcd (doubly orphaned), so every attempt failed identically and re-fired immediately. #898 (which made previously-failing patches over stale references succeed) didn't cause the loop — it *unmasked* it, converting a silently-failing loop into one that wrote durably at full throughput.

## Fix 1 — Record the controller's direct writes

Capture the revision returned by `eac.Patch` in `updateMountState` and report it through a `WriteTracker`, exactly as the framework intends for "controllers that make manual entity writes outside the reconciliation framework." Now:

- Worker writes rev `N` → `RecordWrite(N)` adds it to the ring.
- The watch event for `N` hits `recentWrites.Contains(N)` → **true** → dropped, never enqueued.
- No self-generated work → worker goes idle. Loop broken.

The mount is still stuck in `DM_ERROR`, but it now sits quietly and is only re-examined on a genuinely external trigger (the 5-min periodic resync, or a real entity change) instead of at full throughput. This is a general fix for any direct-write oscillation in this controller, not just the orphan case.

A minimal one-method `writeTracker` interface is declared locally in `diskio` to avoid a new package dependency on `pkg/controller` (the coupling already lives at the `runner` layer). It's nil-safe, so existing unit tests without a tracker are unaffected.

## Fix 2 — Sweep doubly-orphaned mounts

Fix 1 stops the etcd churn, but a mount whose backing volume is permanently gone would still retry forever on every resync and never settle. `ReconcileOrphanMounts` (mirroring the existing `DiskLeaseController.ReconcileOrphanLeases`) deletes such mounts:

- Lists node-scoped `disk_mount` entities, resolves each `VolumeId` via `eac.Get`.
- Only a definitive `cond.ErrNotFound` counts as orphaned; transient errors are logged and skipped (fail-safe — a blip can't cause mass deletion).
- Best-effort local teardown (unmount/detach/release), then `eac.Delete` on the entity. Deleting through the entity server cleans up the secondary-index keys — a raw etcd `del` of only the `/entity/` key would leave the exact dangling-index state #898 was about.
- Guarded by `OrphanMountSweepGracePeriod` (2m) against a mount created just before its volume is observed.

Wired as a periodic callback on the disk-mount controller (runs once at startup + every 5 min).

## Testing

- 5 new tests in `disk_mount_orphan_sweep_test.go`: self-write recording, nil-tracker safety, sweeper deletes missing-volume mount + tears down local state, sweeper keeps mounts with a live volume, sweeper respects the grace period.
- Full `components/diskio` package (123 tests) passes; `go build ./...` and `golangci-lint` clean.

## Deferred (separate follow-up)

etcd defense-in-depth so a future runaway degrades instead of wedging boot: explicit configurable `--quota-backend-bytes`, NOSPACE self-recovery in the maintenance loop (`AlarmList` → compact → defrag → `AlarmDisarm`), and an absolute-size defrag trigger + DB-size/alarm metrics.
