### PR TITLE
Set METRICS_PASSWORD when the blackbox harness boots cloud

### DIFF
--- a/blackbox/harness/cloud.go
+++ b/blackbox/harness/cloud.go
@@ -26,6 +26,7 @@ const (
 	certEncKey           = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	dbURL                = "postgres://cloud:cloud@postgres:5432/cloud?sslmode=disable"
 	valkeyAddr           = "valkey:6379"
+	metricsPassword      = "test-metrics-password"
 )
 
 // CloudEnv manages a cloud+POP test environment for global router blackbox tests.
@@ -276,6 +277,7 @@ func (env *CloudEnv) startCloud(t *testing.T) {
 		"POP_CERT_ENCRYPTION_KEY": certEncKey,
 		"CHALLENGE_SIGNING_KEY":   base64.StdEncoding.EncodeToString(sigKey),
 		"DEV_LOGIN":               "true",
+		"METRICS_PASSWORD":        metricsPassword,
 	}, "/src/bin/bb-cloud", "-mode=all")
 
 	// Wait for cloud to be ready, with process liveness checks


### PR DESCRIPTION
METRICS_PASSWORD being empty broke the blackbox POP tests, and this turned out to be fallout from MIR-1376, which made METRICS_PASSWORD (and VALKEY_ADDRESS) required for cloud to boot so the startup path could stop being conditional.

The blackbox harness spins up a real bb-cloud binary for the POP and global-router tests, and it does so from a hand-rolled env map in startCloud. That map already carried VALKEY_ADDRESS, but nobody taught it about the new METRICS_PASSWORD requirement. So the freshly-built binary hit the new guard, os.Exit(1)'d before serving anything, and the harness's liveness poll dutifully reported "cloud process died."

The fix is a single env var with a dummy test value, matching what cloud's own docker-compose.test.yml uses. Worth noting for later: the harness keeps its own hardcoded copy of cloud's required-vars list, which is exactly the kind of drift MIR-1382 wants to consolidate. When that golden path lands, this harness should source from it instead of maintaining a parallel set.

Closes MIR-1387