### PR TITLE
Report a reachability verdict to cloud

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1426,6 +1426,18 @@ func (c *Coordinator) apiAddresses() []string {
 	return final
 }
 
+// reachabilityVerdict synthesizes the agent's inbound-reachability verdict from
+// the cached netcheck result, for reporting to cloud. Returns nil when netcheck
+// has produced no usable public source address, so the field is simply omitted
+// from the report and cloud falls back to its generic copy.
+func (c *Coordinator) reachabilityVerdict() *cloudauth.ReachabilityVerdict {
+	c.netcheckMu.RLock()
+	netcheck := c.netcheckResult
+	c.netcheckMu.RUnlock()
+
+	return netcheck.ReachabilityVerdict()
+}
+
 // ReportStatus reports the current cluster status to miren.cloud
 func (c *Coordinator) ReportStartupStatus(ctx context.Context) error {
 	if c.authClient == nil {
@@ -1459,6 +1471,7 @@ func (c *Coordinator) ReportStartupStatus(ctx context.Context) error {
 		ClusterID:         c.CloudAuth.ClusterID,
 		APIAddresses:      c.apiAddresses(),
 		CACertFingerprint: caFingerprint,
+		Reachability:      c.reachabilityVerdict(),
 	}
 
 	return c.authClient.ReportClusterStatus(ctx, status)
@@ -1506,6 +1519,7 @@ func (c *Coordinator) ReportStatus(ctx context.Context) error {
 		WorkloadCount: workloadCount,
 		ResourceUsage: resourceUsage,
 		APIAddresses:  c.apiAddresses(),
+		Reachability:  c.reachabilityVerdict(),
 	}
 
 	return c.authClient.ReportClusterStatus(ctx, status)

--- a/docs/docs/miren-cloud/connectivity.md
+++ b/docs/docs/miren-cloud/connectivity.md
@@ -1,0 +1,78 @@
+---
+title: Cluster Connectivity
+description: How to read the Connectivity panel — whether your cluster is online, whether Miren can deploy to it, and whether users can reach your apps.
+keywords: [connectivity, reachability, control plane, netcheck, quic, firewall, miren anywhere, unreachable]
+---
+
+# Cluster Connectivity
+
+The **Connectivity** panel on a cluster's page answers three separate questions. They're easy to lump together, but they fail independently and they have different fixes, so Miren keeps them apart:
+
+1. [Is the cluster online?](#is-the-cluster-online) — is it alive and checking in with Miren Cloud at all?
+2. [Can Miren deploy to this cluster?](#can-miren-deploy-to-this-cluster) — can the CLI and the deploy path reach it over the internet?
+3. [Can users reach your apps?](#can-users-reach-your-apps) — can visitors load the applications running on it?
+
+A cluster can be online but not deployable, or undeployable over the internet yet still serving apps through the Miren POP network. Reading the three checks separately tells you exactly which layer is having trouble.
+
+:::info[What this page covers]
+This page explains what each check means and how to fix a "not reachable" verdict. For the exact ports and provider-specific firewall setup, see [Firewall Configuration](/firewall).
+:::
+
+## Is the cluster online?
+
+This check is about liveness, not ports. Your Miren server checks in with Miren Cloud on a short interval; if Cloud has heard from it recently, the cluster reads as **Online**, and if there's also a live control link it reads as **Connected**. If check-ins stop, it goes **Offline**.
+
+A cluster being online only means it's running and can talk *out* to Miren Cloud. It says nothing about whether anything can reach it from the outside — that's the next two checks.
+
+:::note[Online but nothing else works?]
+Outbound connectivity (the cluster reaching Cloud) and inbound connectivity (clients reaching the cluster) are different paths. A firewall commonly allows the first while blocking the second, which is exactly the case the next check catches.
+:::
+
+## Can Miren deploy to this cluster?
+
+This is the **control plane**: the Miren API that the CLI and the deploy path use, served over QUIC on UDP port 8443. For `miren deploy`, `miren logs`, and everything else the CLI does to reach your cluster over the internet, this port has to be reachable.
+
+When Miren can't reach it, the panel doesn't just say "Not reachable" — it names the culprit:
+
+```text
+Miren Cloud found this cluster at 203.0.113.10, but couldn't open a connection to it on UDP 8443 (QUIC).
+```
+
+That verdict comes from a reachability check Miren Cloud runs against the address your cluster reports (see [How Miren checks reachability](#how-miren-checks-reachability)). Cloud can see your public address but can't open a connection back to it on the port the control plane needs. Something in the inbound path is dropping UDP 8443 — most often a host firewall, a cloud-provider security group, or a NAT with no port forward for it.
+
+To fix it, make sure inbound **UDP 8443** reaches your server end to end — through the host firewall, any cloud security group, and any NAT in front of it. The cluster becomes reachable the moment the port opens; the server's QUIC listener is already running, so nothing needs restarting. The dashboard catches up on its next reachability check (see the note below), or right away if you restart to force one:
+
+```bash
+sudo miren server restart
+```
+
+If your cluster's public address isn't the one Miren discovered — for example it sits behind a load balancer or a static NAT — set the reachable address explicitly with `additional_ips` in your [server configuration](/server-config) instead of relying on discovery.
+
+:::tip[Reachable, but no public address]
+A cluster on a private network (home lab, VPC with no public IP) will read "Not reachable" here and that's expected — you deploy to it from the same LAN. Miren Anywhere carries app traffic, not the control plane, and so **won't** change this check.
+:::
+
+## Can users reach your apps?
+
+This check is about **application traffic** — the HTTP/HTTPS your visitors load, served on ports 80 and 443, entirely separate from the control-plane port above.
+
+There are two ways users can reach your apps:
+
+- **Directly**, when the cluster has a public address. The apps are served straight from your server.
+- **Via Miren Anywhere**, when it doesn't. Miren routes app traffic through the Miren POP network, so your apps stay reachable even from behind NAT with no public address of their own.
+
+This is why a cluster can show "Not reachable" for the control plane and still show apps as available: Miren Anywhere solves the app-traffic problem without solving the deploy problem. See [Custom subdomains](/miren-cloud/subdomains) for how app hostnames are provisioned.
+
+## How Miren checks reachability
+
+Your Miren server reports the addresses it believes it's reachable at, and Miren Cloud runs a **netcheck**: from the outside, it looks at the public address the connection actually came from and probes the ports your server advertised. The result is what the Control plane check reports.
+
+Three outcomes are possible:
+
+- **Reachable** — Cloud connected to at least one advertised port. The address is confirmed and handed to clients.
+- **Not reachable, address known** — Cloud saw a public address but couldn't connect to any port. Something in the inbound path (a firewall, a cloud security group, or a NAT) is dropping the traffic, and this is the verdict that names the specific port.
+- **No public address** — Cloud only ever saw a private or carrier-NAT source, so there's nothing to hand out. Common for home labs and locked-down VPCs; expected, not an error.
+
+:::note[The panel reflects the last check]
+Reachability is re-checked periodically (roughly hourly) and at startup, not on every status report — so after you open a port the panel can lag even though the cluster is already reachable. Restart the server to force a fresh check, or wait for the next one.
+:::

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -74,6 +74,7 @@ const sidebars: SidebarsConfig = {
           label: 'Overview',
         },
         'miren-cloud/subdomains',
+        'miren-cloud/connectivity',
         {
           type: 'doc',
           id: 'miren-cloud/cloud-updates',

--- a/pkg/cloudauth/netcheck.go
+++ b/pkg/cloudauth/netcheck.go
@@ -45,6 +45,75 @@ type NetcheckDualStackResult struct {
 	IPv6 *NetcheckResponse
 }
 
+// transportForProtocol maps a netcheck protocol to the transport the dashboard
+// should name. QUIC (http3) rides on UDP; plain http/https are TCP.
+func transportForProtocol(protocol string) string {
+	if protocol == "http3" {
+		return "UDP"
+	}
+	return "TCP"
+}
+
+// ReachabilityVerdict synthesizes a compact reachability verdict from a
+// netcheck result, for reporting to cloud. It returns nil when netcheck
+// produced no usable public source address for either family (nil result,
+// missing responses, or a private/invalid source) — in that case there is
+// nothing proven to report and cloud should fall back to its generic copy.
+//
+// When a public source address is present, the verdict names it. If any port
+// on that source was reachable, Reachable is true and no ports are listed;
+// otherwise Reachable is false and every failed port is listed with its
+// transport so the dashboard can say "UDP 8443 (QUIC) unreachable".
+func (r *NetcheckDualStackResult) ReachabilityVerdict() *ReachabilityVerdict {
+	if r == nil {
+		return nil
+	}
+
+	// A reachable port on either family means the cluster is reachable, so we
+	// scan both families before concluding otherwise. If none is reachable, the
+	// first family with a usable public source becomes the not-reachable verdict.
+	var notReachable *ReachabilityVerdict
+	for _, resp := range []*NetcheckResponse{r.IPv4, r.IPv6} {
+		if resp == nil {
+			continue
+		}
+		src := net.ParseIP(resp.SourceAddress)
+		if src == nil || !src.IsGlobalUnicast() || src.IsPrivate() {
+			continue
+		}
+
+		var unreachable []UnreachablePort
+		reachable := false
+		for _, res := range resp.Results {
+			if res.Reachable {
+				reachable = true
+				continue
+			}
+			unreachable = append(unreachable, UnreachablePort{
+				Port:      res.Port,
+				Protocol:  res.Protocol,
+				Transport: transportForProtocol(res.Protocol),
+			})
+		}
+
+		if reachable {
+			return &ReachabilityVerdict{
+				Reachable:     true,
+				PublicAddress: resp.SourceAddress,
+			}
+		}
+		if notReachable == nil {
+			notReachable = &ReachabilityVerdict{
+				Reachable:        false,
+				PublicAddress:    resp.SourceAddress,
+				UnreachablePorts: unreachable,
+			}
+		}
+	}
+
+	return notReachable
+}
+
 // ErrPrivateAddress is returned when the cloud rejects the request
 // because the cluster's IP is private/loopback/link-local.
 var ErrPrivateAddress = errors.New("client IP is not a public address")

--- a/pkg/cloudauth/netcheck_test.go
+++ b/pkg/cloudauth/netcheck_test.go
@@ -5,8 +5,135 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
+
+func TestReachabilityVerdict(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *NetcheckDualStackResult
+		want   *ReachabilityVerdict
+	}{
+		{
+			name:   "nil result reports nothing",
+			result: nil,
+			want:   nil,
+		},
+		{
+			name:   "no families reports nothing",
+			result: &NetcheckDualStackResult{},
+			want:   nil,
+		},
+		{
+			name: "private source is not a usable verdict",
+			result: &NetcheckDualStackResult{
+				IPv4: &NetcheckResponse{
+					SourceAddress: "192.168.1.10",
+					Results:       []NetcheckResult{{Port: 8443, Protocol: "http3", Reachable: false}},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "reachable port names the public address, no ports listed",
+			result: &NetcheckDualStackResult{
+				IPv4: &NetcheckResponse{
+					SourceAddress: "159.195.16.123",
+					Results: []NetcheckResult{
+						{Port: 8443, Protocol: "https", Reachable: true},
+						{Port: 8443, Protocol: "http3", Reachable: false},
+					},
+				},
+			},
+			want: &ReachabilityVerdict{
+				Reachable:     true,
+				PublicAddress: "159.195.16.123",
+			},
+		},
+		{
+			name: "firewalled QUIC names the culprit with UDP transport",
+			result: &NetcheckDualStackResult{
+				IPv4: &NetcheckResponse{
+					SourceAddress: "159.195.16.123",
+					Results: []NetcheckResult{
+						{Port: 8443, Protocol: "http3", Reachable: false, Error: "timeout"},
+					},
+				},
+			},
+			want: &ReachabilityVerdict{
+				Reachable:     false,
+				PublicAddress: "159.195.16.123",
+				UnreachablePorts: []UnreachablePort{
+					{Port: 8443, Protocol: "http3", Transport: "UDP"},
+				},
+			},
+		},
+		{
+			name: "all-unreachable lists every failed port with transport",
+			result: &NetcheckDualStackResult{
+				IPv4: &NetcheckResponse{
+					SourceAddress: "159.195.16.123",
+					Results: []NetcheckResult{
+						{Port: 8443, Protocol: "https", Reachable: false},
+						{Port: 8443, Protocol: "http3", Reachable: false},
+					},
+				},
+			},
+			want: &ReachabilityVerdict{
+				Reachable:     false,
+				PublicAddress: "159.195.16.123",
+				UnreachablePorts: []UnreachablePort{
+					{Port: 8443, Protocol: "https", Transport: "TCP"},
+					{Port: 8443, Protocol: "http3", Transport: "UDP"},
+				},
+			},
+		},
+		{
+			name: "falls through invalid ipv4 source to reachable ipv6",
+			result: &NetcheckDualStackResult{
+				IPv4: &NetcheckResponse{
+					SourceAddress: "10.0.0.1",
+					Results:       []NetcheckResult{{Port: 8443, Protocol: "http3", Reachable: false}},
+				},
+				IPv6: &NetcheckResponse{
+					SourceAddress: "2606:4700:4700::1111",
+					Results:       []NetcheckResult{{Port: 8443, Protocol: "https", Reachable: true}},
+				},
+			},
+			want: &ReachabilityVerdict{
+				Reachable:     true,
+				PublicAddress: "2606:4700:4700::1111",
+			},
+		},
+		{
+			name: "a firewalled public ipv4 does not mask a reachable ipv6",
+			result: &NetcheckDualStackResult{
+				IPv4: &NetcheckResponse{
+					SourceAddress: "159.195.16.123",
+					Results:       []NetcheckResult{{Port: 8443, Protocol: "http3", Reachable: false}},
+				},
+				IPv6: &NetcheckResponse{
+					SourceAddress: "2606:4700:4700::1111",
+					Results:       []NetcheckResult{{Port: 8443, Protocol: "http3", Reachable: true}},
+				},
+			},
+			want: &ReachabilityVerdict{
+				Reachable:     true,
+				PublicAddress: "2606:4700:4700::1111",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.result.ReachabilityVerdict()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReachabilityVerdict() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestNetcheck(t *testing.T) {
 	t.Run("success with reachable ports", func(t *testing.T) {

--- a/pkg/cloudauth/status.go
+++ b/pkg/cloudauth/status.go
@@ -32,6 +32,38 @@ type StatusReport struct {
 	LastRBACSync      *time.Time        `json:"last_rbac_sync,omitempty"`
 	APIAddresses      []string          `json:"api_addresses,omitempty"`
 	CACertFingerprint string            `json:"ca_cert_fingerprint,omitempty"`
+	// Reachability, when non-nil, carries the agent's verdict on whether the
+	// cluster's public address is reachable from the internet and, if not,
+	// which ports failed. Omitted (nil) when netcheck never produced a usable
+	// public source address, so old agents and pre-netcheck reports simply
+	// don't send it and cloud falls back to its generic copy.
+	Reachability *ReachabilityVerdict `json:"reachability,omitempty"`
+}
+
+// ReachabilityVerdict is a compact, agent-computed explanation of the
+// cluster's inbound reachability, synthesized from the netcheck trace at
+// report time. It exists so the dashboard can name the culprit ("found
+// 159.195.16.123 but UDP 8443 (QUIC) unreachable") instead of showing a
+// generic "Not reachable" with static guess-at-the-fix copy.
+type ReachabilityVerdict struct {
+	// Reachable is true when netcheck confirmed at least one reachable port
+	// on a public source address. Deliberately no omitempty: a false value is
+	// the interesting case and must travel on the wire.
+	Reachable bool `json:"reachable"`
+	// PublicAddress is the public source address netcheck observed (the IP the
+	// cluster appears as from the internet), e.g. "159.195.16.123".
+	PublicAddress string `json:"public_address,omitempty"`
+	// UnreachablePorts lists the ports that failed the check, present only
+	// when Reachable is false.
+	UnreachablePorts []UnreachablePort `json:"unreachable_ports,omitempty"`
+}
+
+// UnreachablePort names a single port/protocol that netcheck could not reach,
+// with its transport spelled out so the dashboard can say "UDP 8443 (QUIC)".
+type UnreachablePort struct {
+	Port      int    `json:"port"`
+	Protocol  string `json:"protocol"`  // "http3", "https", "http"
+	Transport string `json:"transport"` // "UDP" (QUIC/http3) or "TCP"
 }
 
 // ReportClusterStatus sends a status report for the specified cluster


### PR DESCRIPTION
When a self-hosted cluster is unreachable because inbound QUIC is firewalled, we could *tell* it was unreachable but not say *why*. The dashboard just showed a generic "Not reachable." The annoying part: both ends already did the work and threw it away. `ComputeAdvertise` builds a full per-candidate trace with reasons (including the exact "address family proven unreachable by netcheck" case), and `miren debug advertise` already renders it, but `apiAddresses()` kept only the final `[]string` and dropped the trace on the floor.

This is the runtime half of MIR-1377. It synthesizes a compact `ReachabilityVerdict` from the cached netcheck result: the public address netcheck actually saw, plus which ports failed and their transport (so cloud can say "UDP 8443 (QUIC)"). That per-port detail has to come from the raw `NetcheckResponse.Results`, since the candidate reason is only family-level. The verdict rides along on `StatusReport` as an optional pointer field, populated in both report builders, and degrades gracefully: old agents and reports from before netcheck has run just omit it, and cloud falls back to today's generic copy.

There's also a new Cluster Connectivity docs page explaining the three connectivity checks and how to read a not-reachable verdict, since the dashboard now links into it.

Pairs with the cloud PR that stores and renders the verdict. Part of MIR-1377.
