### PR TITLE
Converge stale entity-store index entries with a background GC

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -45,6 +45,7 @@ import (
 	certctrl "miren.dev/runtime/controllers/certificate"
 	deploymentctrl "miren.dev/runtime/controllers/deployment"
 	ephemeralctrl "miren.dev/runtime/controllers/ephemeral"
+	indexgcctrl "miren.dev/runtime/controllers/indexgc"
 	nodehealthctrl "miren.dev/runtime/controllers/nodehealth"
 	"miren.dev/runtime/controllers/sandboxpool"
 	schedulerctrl "miren.dev/runtime/controllers/scheduler"
@@ -351,6 +352,7 @@ type Coordinator struct {
 	artifactGC    *artifactctrl.GCController
 	ephemeralGC   *ephemeralctrl.GCController
 	versionGC     *versionctrl.GCController
+	indexGC       *indexgcctrl.GCController
 	hs            *httpingress.Server
 
 	authority *caauth.Authority
@@ -417,6 +419,9 @@ func (c *Coordinator) Stop() {
 	}
 	if c.versionGC != nil {
 		c.versionGC.Stop()
+	}
+	if c.indexGC != nil {
+		c.indexGC.Stop()
 	}
 	if c.debugServer != nil {
 		if err := c.debugServer.Close(); err != nil {
@@ -1153,6 +1158,16 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		Config: versionGCConfig,
 	}
 	c.versionGC.Start(ctx)
+
+	// Start the stale index GC controller. It deletes stale index entries in the
+	// background so clusters self-heal; the manual `miren debug reindex` stays
+	// available as the immediate big hammer.
+	c.indexGC = &indexgcctrl.GCController{
+		Log:    c.Log.With("module", "index-gc"),
+		Store:  etcdStore,
+		Config: indexgcctrl.DefaultGCConfig(),
+	}
+	c.indexGC.Start(ctx)
 
 	eps := execproxy.NewServer(c.Log, eac, rs)
 	server.ExposeValue("dev.miren.runtime/exec", exec_v1alpha.AdaptSandboxExec(eps))

--- a/controllers/indexgc/gc.go
+++ b/controllers/indexgc/gc.go
@@ -1,0 +1,144 @@
+// Package indexgc runs a bounded, best-effort background sweep that removes
+// stale entity-store index (collection) entries whose backing entity is gone.
+//
+// The source of these orphans was fixed upstream (atomic deletes, lease-bound
+// session index entries), so this exists to drain any legacy backlog on upgrade
+// and to keep a cluster self-healing if a future leak ever reappears, without
+// anyone having to run `miren debug reindex` by hand. It deliberately does its
+// work off the read path: foreground reads stay pure and never issue deletes.
+package indexgc
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"miren.dev/runtime/pkg/entity"
+)
+
+const (
+	// initialDelay keeps the first sweep clear of the boot storm and any
+	// startup-time additive reindex before it begins deleting.
+	initialDelay = 1 * time.Minute
+)
+
+// GCConfig tunes the background sweep. Defaults are intentionally gentle: this
+// is convergence insurance, not active firefighting, so it drains slowly and
+// stays out of the way.
+type GCConfig struct {
+	// CheckInterval is how often to run a sweep.
+	CheckInterval time.Duration
+	// MaxDeletesPerSweep caps deletions per sweep so a large legacy backlog
+	// drains over several sweeps rather than one thundering pass. Zero means
+	// unbounded.
+	MaxDeletesPerSweep int
+	// BatchPause is slept periodically during deletion to rate-limit write
+	// pressure. Zero disables pacing.
+	BatchPause time.Duration
+	// SweepTimeout bounds a single sweep. A truncated sweep is fine: the next
+	// one resumes the work, since the pass is idempotent.
+	SweepTimeout time.Duration
+}
+
+// DefaultGCConfig returns the default (gentle) configuration.
+func DefaultGCConfig() GCConfig {
+	return GCConfig{
+		CheckInterval:      1 * time.Hour,
+		MaxDeletesPerSweep: 500,
+		BatchPause:         1 * time.Second,
+		SweepTimeout:       10 * time.Minute,
+	}
+}
+
+// GCController periodically removes stale collection entries from the entity
+// store. It operates directly on the EtcdStore's CAS-guarded cleanup rather than
+// going through the entity-access client, since it works below the index it is
+// repairing.
+type GCController struct {
+	Log    *slog.Logger
+	Store  *entity.EtcdStore
+	Config GCConfig
+
+	cancel context.CancelFunc
+}
+
+// Start begins the periodic sweep.
+func (c *GCController) Start(ctx context.Context) {
+	c.Log.Info("starting stale index GC controller",
+		"check_interval", c.Config.CheckInterval,
+		"max_deletes_per_sweep", c.Config.MaxDeletesPerSweep)
+
+	ctx, c.cancel = context.WithCancel(ctx)
+	go c.run(ctx)
+}
+
+// Stop gracefully stops the controller.
+func (c *GCController) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+func (c *GCController) run(ctx context.Context) {
+	// Wait out the initial delay before the first sweep, then start the
+	// periodic ticker. Constructing the ticker after the delay (not before)
+	// keeps the first interval a true CheckInterval and avoids a back-to-back
+	// double-fire if initialDelay is ever tuned longer than CheckInterval.
+	select {
+	case <-time.After(initialDelay):
+		c.sweep(ctx)
+	case <-ctx.Done():
+		c.Log.Info("stale index GC controller stopped")
+		return
+	}
+
+	ticker := time.NewTicker(c.Config.CheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.sweep(ctx)
+		case <-ctx.Done():
+			c.Log.Info("stale index GC controller stopped")
+			return
+		}
+	}
+}
+
+// sweep runs one bounded cleanup pass. It is strictly best-effort: errors are
+// logged, never propagated, and never block a foreground operation.
+func (c *GCController) sweep(ctx context.Context) {
+	sweepCtx := ctx
+	if c.Config.SweepTimeout > 0 {
+		var cancel context.CancelFunc
+		sweepCtx, cancel = context.WithTimeout(ctx, c.Config.SweepTimeout)
+		defer cancel()
+	}
+
+	stats, err := c.Store.CleanupStaleCollectionEntries(sweepCtx, c.Log, entity.CleanupOptions{
+		MaxDeletes: c.Config.MaxDeletesPerSweep,
+		BatchPause: c.Config.BatchPause,
+	})
+	if err != nil {
+		// A truncated scan (deadline/shutdown) is expected and not alarming; the
+		// next sweep resumes. Log at Warn so a persistent hard error is still
+		// visible.
+		c.Log.Warn("stale index GC sweep ended early", "error", err,
+			"scanned", stats.CollectionEntriesScanned,
+			"removed", stats.StaleEntriesRemoved)
+		return
+	}
+
+	if stats.StaleEntriesFound > 0 || stats.StaleEntriesRemoved > 0 {
+		c.Log.Info("stale index GC sweep complete",
+			"scanned", stats.CollectionEntriesScanned,
+			"found", stats.StaleEntriesFound,
+			"removed", stats.StaleEntriesRemoved,
+			"cas_conflicts", stats.CASConflicts,
+			"by_collection", stats.RemovedByCollection)
+	} else {
+		c.Log.Debug("stale index GC sweep complete, nothing stale",
+			"scanned", stats.CollectionEntriesScanned)
+	}
+}

--- a/pkg/entity/cleanup.go
+++ b/pkg/entity/cleanup.go
@@ -1,0 +1,240 @@
+package entity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"miren.dev/runtime/pkg/cond"
+)
+
+// cleanupDeleteBatchSize is how many stale entries we delete between rate-limit
+// pauses. Deletes are issued one CAS'd transaction at a time (see
+// CleanupStaleCollectionEntries); this only governs how often we sleep for
+// BatchPause, not how many keys share a transaction.
+const cleanupDeleteBatchSize = 100
+
+// CleanupOptions bounds a single stale-cleanup pass so it can run continuously
+// in the background without overwhelming the store.
+type CleanupOptions struct {
+	// DryRun scans and counts stale entries but deletes nothing.
+	DryRun bool
+	// MaxDeletes caps how many stale entries a single pass removes. A large
+	// legacy backlog then drains over several passes rather than one thundering
+	// sweep. Zero means unbounded (the manual reindex "big hammer").
+	MaxDeletes int
+	// BatchPause is slept after every cleanupDeleteBatchSize deletes to
+	// rate-limit write pressure. Zero disables pacing.
+	BatchPause time.Duration
+}
+
+// CleanupStats reports what a stale-cleanup pass observed and did. RemovedByCollection
+// breaks removals down by index/collection so a persistent, post-drain leak shows
+// up as a specific collection that keeps re-accumulating orphans rather than
+// hiding in an aggregate count.
+type CleanupStats struct {
+	CollectionEntriesScanned int64
+	StaleEntriesFound        int64
+	StaleEntriesRemoved      int64
+	// CASConflicts counts entries that changed between scan and delete (the slot
+	// was legitimately recreated/re-leased), so the CAS guard skipped them.
+	CASConflicts        int64
+	RemovedByCollection map[string]int64
+}
+
+// CleanupStaleCollectionEntries scans collection (index) entries and removes those
+// whose backing entity is authoritatively absent under a linearizable read.
+//
+// Safety rests on creates being atomic: CreateEntity writes the entity key and its
+// collection entries in one transaction, so a collection entry whose entity is
+// absent is genuinely orphaned, with no create-in-flight race. Each delete is still
+// CAS'd on the entry's mod-revision captured at scan time, so a slot legitimately
+// recreated between scan and delete fails the compare and is left untouched (the
+// ABA guard). The pass is idempotent and bounded, so it is safe to run repeatedly
+// as a background sweep; repetition is what makes it resumable.
+func (s *EtcdStore) CleanupStaleCollectionEntries(ctx context.Context, log *slog.Logger, opts CleanupOptions) (*CleanupStats, error) {
+	stats := &CleanupStats{RemovedByCollection: map[string]int64{}}
+
+	// Build the set of live entity ids so we only pay a per-entry GetEntity for
+	// collection entries that look orphaned. After a store has drained, almost
+	// every entry is in this set and the pass does no point reads at all.
+	allEntityIDs, err := s.ListAllEntityIDs(ctx)
+	if err != nil {
+		return stats, fmt.Errorf("cleanup: failed to list entities: %w", err)
+	}
+	validEntityIDs := make(map[Id]bool, len(allEntityIDs))
+	for _, id := range allEntityIDs {
+		validEntityIDs[id] = true
+	}
+
+	collectionPrefix := s.prefix + "/collections/"
+
+	// pending buffers confirmed-stale entries until we have a batch to delete.
+	// We scan and delete incrementally rather than materializing the whole
+	// keyspace: memory stays bounded by one page + one batch, and if the pass is
+	// cut short (deadline/shutdown) everything deleted before that point sticks.
+	var pending []staleCollectionEntry
+
+	flush := func() error {
+		if len(pending) == 0 {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		s.deleteStaleBatch(ctx, log, pending, stats)
+		pending = pending[:0]
+		if opts.BatchPause > 0 {
+			select {
+			case <-time.After(opts.BatchPause):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	}
+
+	scanErr := scanPagedFunc(ctx, s.client, collectionPrefix, func(kv *mvccpb.KeyValue) error {
+		stats.CollectionEntriesScanned++
+
+		entityID := Id(kv.Value)
+		if validEntityIDs[entityID] {
+			return nil
+		}
+
+		// Not in the snapshot's live set; confirm authoritatively before
+		// treating it as stale. A linearizable not-found is the safe signal;
+		// any other error means we couldn't verify, so we leave it alone.
+		if _, err := s.GetEntity(ctx, entityID); err != nil {
+			if !errors.Is(err, cond.ErrNotFound{}) {
+				log.Warn("cleanup: could not verify entity existence",
+					"entity_id", entityID,
+					"key", string(kv.Key),
+					"error", err)
+				return nil
+			}
+		} else {
+			return nil
+		}
+
+		stats.StaleEntriesFound++
+		if opts.DryRun {
+			return nil
+		}
+
+		pending = append(pending, staleCollectionEntry{
+			key:        string(kv.Key),
+			modRev:     kv.ModRevision,
+			collection: collectionFromKey(string(kv.Key), collectionPrefix),
+		})
+
+		// Flush a full batch, or a short one that would otherwise carry us past
+		// MaxDeletes, so a bounded pass removes at most MaxDeletes and no more.
+		atBudget := opts.MaxDeletes > 0 && int(stats.StaleEntriesRemoved)+len(pending) >= opts.MaxDeletes
+		if len(pending) >= cleanupDeleteBatchSize || atBudget {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+		if opts.MaxDeletes > 0 && stats.StaleEntriesRemoved >= int64(opts.MaxDeletes) {
+			return errStopScan
+		}
+		return nil
+	})
+
+	if scanErr != nil && !errors.Is(scanErr, errStopScan) {
+		// Persist whatever we already confirmed before surfacing the error;
+		// partial progress is the whole point of streaming the sweep.
+		if flushErr := flush(); flushErr != nil {
+			log.Warn("cleanup: failed to flush after scan error", "flush_error", flushErr)
+		}
+		return stats, fmt.Errorf("cleanup: scan failed: %w", scanErr)
+	}
+
+	if err := flush(); err != nil {
+		return stats, err
+	}
+
+	return stats, nil
+}
+
+// errStopScan is a sentinel returned by the scan callback to halt scanning once
+// the per-pass delete budget is reached, without treating it as a real error.
+var errStopScan = errors.New("cleanup: delete budget reached")
+
+// staleCollectionEntry is a collection entry confirmed to point at an absent
+// entity, along with the mod-revision it carried at scan time (the CAS guard).
+type staleCollectionEntry struct {
+	key        string
+	modRev     int64
+	collection string
+}
+
+// deleteStaleBatch removes a batch of confirmed-stale entries, CAS-guarded on the
+// mod-revision each carried at scan time. It first tries one transaction guarded
+// on every entry's mod-revision; if that succeeds (the common case for a static
+// legacy backlog) the whole batch is removed in a single round trip. If any
+// entry changed since the scan the batched compare fails, so it falls back to a
+// per-entry CAS to remove the still-unchanged ones and count the conflicts. It
+// records removals, CAS conflicts, and the per-collection breakdown into stats;
+// per-entry failures are logged, never returned.
+func (s *EtcdStore) deleteStaleBatch(ctx context.Context, log *slog.Logger, batch []staleCollectionEntry, stats *CleanupStats) {
+	if len(batch) == 0 {
+		return
+	}
+
+	cmps := make([]clientv3.Cmp, len(batch))
+	ops := make([]clientv3.Op, len(batch))
+	for i, e := range batch {
+		cmps[i] = clientv3.Compare(clientv3.ModRevision(e.key), "=", e.modRev)
+		ops[i] = clientv3.OpDelete(e.key)
+	}
+
+	resp, err := s.client.Txn(ctx).If(cmps...).Then(ops...).Commit()
+	if err == nil && resp.Succeeded {
+		for _, e := range batch {
+			stats.StaleEntriesRemoved++
+			stats.RemovedByCollection[e.collection]++
+		}
+		return
+	}
+	if err != nil {
+		log.Warn("cleanup: batched delete failed, retrying per entry", "count", len(batch), "error", err)
+	}
+
+	// At least one slot changed (or the batch errored): CAS each entry on its own
+	// so an ABA recreate is skipped rather than dragging down the rest of the batch.
+	for _, e := range batch {
+		r, err := s.client.Txn(ctx).
+			If(clientv3.Compare(clientv3.ModRevision(e.key), "=", e.modRev)).
+			Then(clientv3.OpDelete(e.key)).
+			Commit()
+		if err != nil {
+			log.Warn("cleanup: failed to delete stale entry", "key", e.key, "error", err)
+			continue
+		}
+		if !r.Succeeded {
+			stats.CASConflicts++
+			continue
+		}
+		stats.StaleEntriesRemoved++
+		stats.RemovedByCollection[e.collection]++
+	}
+}
+
+// collectionFromKey extracts the collection segment from a collection entry key.
+// Keys are "{prefix}/collections/{colKey}/{base58(id)}" and colKey has its own
+// slashes replaced (see addToCollectionDirect), so the collection is everything
+// up to the first slash after the prefix.
+func collectionFromKey(key, collectionPrefix string) string {
+	rest := strings.TrimPrefix(key, collectionPrefix)
+	if collection, _, found := strings.Cut(rest, "/"); found {
+		return collection
+	}
+	return rest
+}

--- a/pkg/entity/cleanup_test.go
+++ b/pkg/entity/cleanup_test.go
@@ -1,0 +1,184 @@
+package entity
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// seedStaleEntry writes a collection entry under the given collection segment
+// pointing at an entity id that does not exist, mimicking a leaked index entry.
+func seedStaleEntry(t *testing.T, store *EtcdStore, client *clientv3.Client, collection string, entityID Id) string {
+	t.Helper()
+	key := store.Prefix() + "/collections/" + collection + "/" + base58.Encode([]byte(entityID))
+	_, err := client.Put(t.Context(), key, string(entityID))
+	require.NoError(t, err)
+	return key
+}
+
+func TestCleanup_RemovesStaleKeepsLive(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	live, err := store.CreateEntity(ctx, New(
+		Ident, "entity-1",
+		String(Id("test/kind"), "widget"),
+	))
+	require.NoError(t, err)
+
+	seedStaleEntry(t, store, client, "test_kind_widget", Id("fake/nonexistent"))
+
+	stats, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, stats.StaleEntriesFound)
+	assert.EqualValues(t, 1, stats.StaleEntriesRemoved)
+	assert.EqualValues(t, 0, stats.CASConflicts)
+	// Removal is attributed to the specific collection so a persistent leak is
+	// visible per-collection rather than only in aggregate.
+	assert.Equal(t, int64(1), stats.RemovedByCollection["test_kind_widget"])
+
+	// The live entity's index entry must be untouched.
+	ids, err := store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	assert.Equal(t, live.Id(), ids[0])
+}
+
+func TestCleanup_DryRunRemovesNothing(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	key := seedStaleEntry(t, store, client, "test_kind_widget", Id("fake/nonexistent"))
+
+	stats, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{DryRun: true})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, stats.StaleEntriesFound)
+	assert.EqualValues(t, 0, stats.StaleEntriesRemoved)
+
+	resp, err := client.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Len(t, resp.Kvs, 1, "dry run must not delete")
+}
+
+func TestCleanup_MaxDeletesBoundsAndConverges(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	for _, id := range []Id{"fake/a", "fake/b", "fake/c"} {
+		seedStaleEntry(t, store, client, "test_kind_widget", id)
+	}
+
+	// First bounded sweep removes only MaxDeletes. The streaming sweep stops
+	// scanning once the budget is hit, so it need not have seen every stale entry.
+	first, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{MaxDeletes: 2})
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, first.StaleEntriesRemoved)
+
+	// A subsequent sweep drains the remainder: the pass converges over time.
+	second, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{MaxDeletes: 2})
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, second.StaleEntriesFound)
+	assert.EqualValues(t, 1, second.StaleEntriesRemoved)
+
+	// And once drained, a sweep finds nothing.
+	third, err := store.CleanupStaleCollectionEntries(ctx, slog.Default(), CleanupOptions{MaxDeletes: 2})
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, third.StaleEntriesFound)
+	assert.EqualValues(t, 0, third.StaleEntriesRemoved)
+}
+
+// TestCleanup_CASGuardSkipsRecreatedSlot proves the ABA guard: if a collection
+// slot's mod-revision changes between the scan that captured it and the delete
+// (i.e. it was legitimately recreated/re-leased), the CAS compare fails and the
+// entry is left alone rather than clobbered.
+func TestCleanup_CASGuardSkipsRecreatedSlot(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	key := seedStaleEntry(t, store, client, "test_kind_widget", Id("fake/x"))
+
+	// Capture the mod-revision as a scan would have, then mutate the slot so its
+	// current mod-revision no longer matches.
+	got, err := client.Get(ctx, key)
+	require.NoError(t, err)
+	require.Len(t, got.Kvs, 1)
+	scannedModRev := got.Kvs[0].ModRevision
+
+	_, err = client.Put(ctx, key, "fake/x-recreated")
+	require.NoError(t, err)
+
+	stale := []staleCollectionEntry{{key: key, modRev: scannedModRev, collection: "test_kind_widget"}}
+
+	stats := &CleanupStats{RemovedByCollection: map[string]int64{}}
+	store.deleteStaleBatch(ctx, slog.Default(), stale, stats)
+	assert.EqualValues(t, 0, stats.StaleEntriesRemoved, "stale delete must not clobber a recreated slot")
+	assert.EqualValues(t, 1, stats.CASConflicts)
+
+	resp, err := client.Get(ctx, key)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1, "recreated slot must survive")
+
+	// With the up-to-date mod-revision, the delete goes through.
+	stale[0].modRev = resp.Kvs[0].ModRevision
+	stats2 := &CleanupStats{RemovedByCollection: map[string]int64{}}
+	store.deleteStaleBatch(ctx, slog.Default(), stale, stats2)
+	assert.EqualValues(t, 1, stats2.StaleEntriesRemoved)
+
+	resp, err = client.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Len(t, resp.Kvs, 0)
+}
+
+// TestCleanup_BatchFallbackOnConflict proves that when a single batched delete
+// can't commit because one entry changed, the per-entry fallback still removes
+// the unchanged entries and only the changed one is counted as a conflict.
+func TestCleanup_BatchFallbackOnConflict(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	goodKey := seedStaleEntry(t, store, client, "test_kind_widget", Id("fake/good"))
+	changedKey := seedStaleEntry(t, store, client, "test_kind_widget", Id("fake/changed"))
+
+	get := func(key string) int64 {
+		r, err := client.Get(ctx, key)
+		require.NoError(t, err)
+		require.Len(t, r.Kvs, 1)
+		return r.Kvs[0].ModRevision
+	}
+
+	batch := []staleCollectionEntry{
+		{key: goodKey, modRev: get(goodKey), collection: "test_kind_widget"},
+		{key: changedKey, modRev: get(changedKey), collection: "test_kind_widget"},
+	}
+
+	// Mutate one entry so the batched compare fails and forces the fallback path.
+	_, err := client.Put(ctx, changedKey, "fake/changed-again")
+	require.NoError(t, err)
+
+	stats := &CleanupStats{RemovedByCollection: map[string]int64{}}
+	store.deleteStaleBatch(ctx, slog.Default(), batch, stats)
+	assert.EqualValues(t, 1, stats.StaleEntriesRemoved, "unchanged entry removed via fallback")
+	assert.EqualValues(t, 1, stats.CASConflicts, "changed entry skipped, not clobbered")
+
+	// The good entry is gone; the changed one survives with its new value.
+	r, err := client.Get(ctx, goodKey)
+	require.NoError(t, err)
+	assert.Len(t, r.Kvs, 0)
+	r, err = client.Get(ctx, changedKey)
+	require.NoError(t, err)
+	require.Len(t, r.Kvs, 1)
+	assert.Equal(t, "fake/changed-again", string(r.Kvs[0].Value))
+}

--- a/pkg/entity/reindex.go
+++ b/pkg/entity/reindex.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/mr-tron/base58"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"miren.dev/runtime/pkg/cond"
 )
 
@@ -43,11 +42,6 @@ func (s *EtcdStore) Reindex(ctx context.Context, log *slog.Logger, opts ReindexO
 
 	log.Info("reindex: found entities", "count", len(allEntityIDs))
 
-	validEntityIDs := make(map[Id]bool, len(allEntityIDs))
-	for _, id := range allEntityIDs {
-		validEntityIDs[id] = true
-	}
-
 	log.Info("reindex: rebuilding indexes for current entities")
 	for i, id := range allEntityIDs {
 		select {
@@ -59,7 +53,6 @@ func (s *EtcdStore) Reindex(ctx context.Context, log *slog.Logger, opts ReindexO
 		ent, err := s.GetEntity(ctx, id)
 		if err != nil {
 			if errors.Is(err, cond.ErrNotFound{}) {
-				delete(validEntityIDs, id)
 				continue
 			}
 			log.Warn("reindex: failed to get entity", "id", id, "error", err)
@@ -90,66 +83,20 @@ func (s *EtcdStore) Reindex(ctx context.Context, log *slog.Logger, opts ReindexO
 		}
 	}
 
-	// Phase 2: Clean up stale index entries (optional)
+	// Phase 2: Clean up stale index entries (optional). Delegates to the shared,
+	// CAS-guarded cleanup used by the background sweeper so both paths remove
+	// orphans the same safe way. Manual reindex is the "big hammer": unbounded
+	// deletes, no pacing.
 	if opts.CleanupStale {
 		log.Info("reindex: cleaning up stale index entries")
-		collectionPrefix := s.prefix + "/collections/"
-
-		kvs, err := s.scanPaged(ctx, collectionPrefix)
+		cleanup, err := s.CleanupStaleCollectionEntries(ctx, log, CleanupOptions{DryRun: opts.DryRun})
 		if err != nil {
-			log.Warn("reindex: failed to list collection entries", "error", err)
-		} else {
-			stats.CollectionEntriesScanned = int64(len(kvs))
-
-			var staleKeys []string
-			for _, kv := range kvs {
-				select {
-				case <-ctx.Done():
-					return stats, ctx.Err()
-				default:
-				}
-
-				entityID := Id(kv.Value)
-				if !validEntityIDs[entityID] {
-					if _, err := s.GetEntity(ctx, entityID); err != nil {
-						if errors.Is(err, cond.ErrNotFound{}) {
-							staleKeys = append(staleKeys, string(kv.Key))
-						} else {
-							log.Warn("reindex: could not verify entity existence",
-								"entity_id", entityID,
-								"key", string(kv.Key),
-								"error", err)
-						}
-					}
-				}
-			}
-
-			stats.StaleEntriesFound = int64(len(staleKeys))
-
-			if !opts.DryRun && len(staleKeys) > 0 {
-				log.Info("reindex: removing stale entries", "count", len(staleKeys))
-				for i := 0; i < len(staleKeys); i += 100 {
-					end := i + 100
-					if end > len(staleKeys) {
-						end = len(staleKeys)
-					}
-					batch := staleKeys[i:end]
-
-					var ops []clientv3.Op
-					for _, key := range batch {
-						ops = append(ops, clientv3.OpDelete(key))
-					}
-
-					if len(ops) > 0 {
-						_, err := s.client.Txn(ctx).Then(ops...).Commit()
-						if err != nil {
-							log.Warn("reindex: failed to delete stale entries", "error", err)
-						} else {
-							stats.StaleEntriesRemoved += int64(len(ops))
-						}
-					}
-				}
-			}
+			log.Warn("reindex: stale cleanup failed", "error", err)
+		}
+		if cleanup != nil {
+			stats.CollectionEntriesScanned = cleanup.CollectionEntriesScanned
+			stats.StaleEntriesFound = cleanup.StaleEntriesFound
+			stats.StaleEntriesRemoved = cleanup.StaleEntriesRemoved
 		}
 	}
 

--- a/pkg/entity/scan.go
+++ b/pkg/entity/scan.go
@@ -39,6 +39,24 @@ func withPageSize(n int64) scanOption {
 // bounded and predictable regardless of store size, so every full-keyspace read
 // should route through here instead of open-coding Get(WithPrefix()).
 func scanPaged(ctx context.Context, client *clientv3.Client, prefix string, opts ...scanOption) ([]*mvccpb.KeyValue, error) {
+	var kvs []*mvccpb.KeyValue
+	err := scanPagedFunc(ctx, client, prefix, func(kv *mvccpb.KeyValue) error {
+		kvs = append(kvs, kv)
+		return nil
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return kvs, nil
+}
+
+// scanPagedFunc reads every key/value under prefix in ascending key order,
+// invoking fn once per key/value as pages arrive rather than materializing the
+// whole keyspace. It has the same paging and revision-pinning semantics as
+// scanPaged; prefer it when the caller can process (and discard) entries
+// incrementally, so memory stays bounded by a single page regardless of store
+// size. If fn returns an error the scan stops and returns it.
+func scanPagedFunc(ctx context.Context, client *clientv3.Client, prefix string, fn func(kv *mvccpb.KeyValue) error, opts ...scanOption) error {
 	cfg := scanConfig{pageSize: defaultScanPageSize}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -54,13 +72,11 @@ func scanPaged(ctx context.Context, client *clientv3.Client, prefix string, opts
 	}
 
 	next := prefix
-
-	var kvs []*mvccpb.KeyValue
 	first := true
 	for {
 		resp, err := client.Get(ctx, next, getOpts...)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		// Pin every page after the first to the revision the scan opened at, so
@@ -72,7 +88,11 @@ func scanPaged(ctx context.Context, client *clientv3.Client, prefix string, opts
 			first = false
 		}
 
-		kvs = append(kvs, resp.Kvs...)
+		for _, kv := range resp.Kvs {
+			if err := fn(kv); err != nil {
+				return err
+			}
+		}
 
 		// An empty page can't advance the cursor; stop rather than index
 		// Kvs[-1]. Unreachable while WithLimit > 0, but keeps the loop safe if
@@ -85,7 +105,7 @@ func scanPaged(ctx context.Context, client *clientv3.Client, prefix string, opts
 		next = string(resp.Kvs[len(resp.Kvs)-1].Key) + "\x00"
 	}
 
-	return kvs, nil
+	return nil
 }
 
 // scanPaged reads every key/value under prefix from the store's etcd client in


### PR DESCRIPTION
MIR-1320 fixed the *source* of stale entity-store index entries: deletes became atomic and session-bound index entries now expire with their lease. But nothing removed the entries that had already leaked, and the only cleanup path was a manual `miren debug reindex` that operators had no real reason to know about. The automatic boot reindex isn't a substitute either, since it's gated on the index schema hash and only ever backfills missing entries, never deletes orphans. So a deployed cluster just held onto its bloat indefinitely, and healing was gated behind a maintenance op nobody runs.

This makes clusters self-heal instead. A new background GC controller runs a gentle, bounded sweep that scans collection entries and removes the ones whose backing entity is authoritatively gone under a linearizable read. Because creates are atomic (the entity key and its collection entries land in one transaction), an index entry with no entity is genuinely orphaned rather than a create-in-flight race. Each delete is still CAS-guarded on the entry's mod-revision as an ABA guard, so a slot that gets legitimately recreated between the scan and the delete is left alone.

The sweep is deliberately boring: it runs off the read path so foreground reads stay pure, it's strictly best-effort (errors are logged, never propagated), and its defaults are gentle (hourly, a few hundred deletes per sweep, paced). It streams the keyspace a page at a time and deletes in batches as it goes, so memory stays bounded by a single page and a pass that gets cut short by its deadline still keeps everything it already removed. Removals are reported per-collection, which means that if some future leak ever reappears it shows up as a specific collection that keeps re-accumulating, rather than hiding in an aggregate count. That same streaming, CAS-guarded, batched cleanup core now backs the manual `miren debug reindex` as well, so there's one delete path to reason about and the big-hammer command got safer in the process.

There's no feature flag: we'll let internal soak before release cover the risk, and the gentle bounded defaults are themselves the mitigation since even a worst case drains slowly and visibly. Verified live in a dev cluster by seeding an orphaned collection entry and watching a sweep detect, CAS-delete, and log its removal, alongside unit coverage for the CAS/ABA guard, the batch-conflict fallback, and the bounded-convergence behavior.

Closes MIR-1389