### PR TITLE
Make runner_id uniqueness at Join explicit and tested

### DIFF
--- a/controllers/scheduler/scheduler_test.go
+++ b/controllers/scheduler/scheduler_test.go
@@ -272,10 +272,13 @@ func TestSchedulerMultipleNodes(t *testing.T) {
 	server, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
 
-	// Create multiple ready nodes
+	// Create multiple ready nodes. Each needs a distinct name: Client.Create
+	// derives the entity id from node/<name>, so empty names would collapse all
+	// three onto the same id (and now conflict, since CreateEntity is
+	// put-if-absent on every backend).
 	nodeIDs := make(map[entity.Id]bool)
 	for i := 0; i < 3; i++ {
-		nodeID := createReadyNode(t, ctx, server.Client, "", &compute_v1alpha.Node{
+		nodeID := createReadyNode(t, ctx, server.Client, fmt.Sprintf("node-%d", i), &compute_v1alpha.Node{
 			Status: compute_v1alpha.READY,
 		})
 		nodeIDs[nodeID] = true
@@ -291,7 +294,7 @@ func TestSchedulerMultipleNodes(t *testing.T) {
 		sandbox := &compute_v1alpha.Sandbox{
 			Status: compute_v1alpha.PENDING,
 		}
-		sandboxID, err := server.Client.Create(ctx, "", sandbox)
+		sandboxID, err := server.Client.Create(ctx, fmt.Sprintf("sandbox-%d", i), sandbox)
 		require.NoError(t, err)
 
 		reconcileSandbox(t, ctx, server, scheduler, sandboxID)
@@ -378,10 +381,13 @@ func TestSchedulerStatelessSandboxPrefersRunners(t *testing.T) {
 		Constraints: types.LabelSet("role", "coordinator"),
 	})
 
-	// Create multiple runner nodes
+	// Create multiple runner nodes. Each needs a distinct name: Client.Create
+	// derives the entity id from node/<name>, so empty names would collapse all
+	// three onto the same id (and now conflict, since CreateEntity is
+	// put-if-absent on every backend).
 	runnerIDs := make(map[entity.Id]bool)
 	for i := 0; i < 3; i++ {
-		runnerID := createReadyNode(t, ctx, server.Client, "", &compute_v1alpha.Node{
+		runnerID := createReadyNode(t, ctx, server.Client, fmt.Sprintf("runner-%d", i), &compute_v1alpha.Node{
 			Status:   compute_v1alpha.READY,
 			RunnerId: "550e8400-e29b-41d4-a716-44665544000" + string(rune('0'+i)),
 		})
@@ -403,7 +409,7 @@ func TestSchedulerStatelessSandboxPrefersRunners(t *testing.T) {
 				},
 			},
 		}
-		sandboxID, err := server.Client.Create(ctx, "", sandbox)
+		sandboxID, err := server.Client.Create(ctx, fmt.Sprintf("sandbox-%d", i), sandbox)
 		require.NoError(t, err)
 
 		reconcileSandbox(t, ctx, server, scheduler, sandboxID)

--- a/pkg/entity/mock.go
+++ b/pkg/entity/mock.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -163,6 +164,11 @@ func (m *MockStore) CreateEntity(ctx context.Context, entity *Entity, opts ...En
 		return nil, err
 	}
 
+	var o entityOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	// Mirror EtcdStore.CreateEntity (store.go:171): allocate an ID before
 	// storing. This also makes mock-backed tests fail loudly on a mistyped
 	// db/id, the same way production does, instead of silently keying the
@@ -177,6 +183,21 @@ func (m *MockStore) CreateEntity(ctx context.Context, entity *Entity, opts ...En
 	entity.SetRevision(1)
 
 	m.mu.Lock()
+	// Mirror EtcdStore.CreateEntity (store.go:281-326): create is put-if-absent.
+	// A create against an already-existing id is a conflict, not a silent
+	// overwrite, unless WithOverwrite was passed. An idempotent re-create with
+	// byte-identical attrs returns the existing entity. Without this, mock-backed
+	// tests would diverge from production, which enforces uniqueness via an etcd
+	// CreateRevision==0 transaction, masking bugs (e.g. duplicate runner_id
+	// joins) that production actually rejects.
+	if existing, ok := m.Entities[entity.Id()]; ok && !o.overwrite {
+		if slices.EqualFunc(existing.attrs, entity.attrs, func(a, b Attr) bool { return a.Equal(b) }) {
+			m.mu.Unlock()
+			return existing, nil
+		}
+		m.mu.Unlock()
+		return nil, cond.Conflict("entity", entity.Id())
+	}
 	if err := m.ensureShortIdLocked(entity); err != nil {
 		m.mu.Unlock()
 		return nil, err

--- a/pkg/entity/store_conformance_test.go
+++ b/pkg/entity/store_conformance_test.go
@@ -242,6 +242,44 @@ func TestStoreConformance_CreateRejectsMistypedDBId(t *testing.T) {
 	})
 }
 
+// TestStoreConformance_CreateRejectsDuplicateId pins that CreateEntity is
+// put-if-absent: a second create against an id that already exists (with
+// different attributes) must fail with a conflict rather than silently
+// overwrite the existing entity. Production (EtcdStore) enforces this with an
+// etcd CreateRevision==0 transaction; MockStore must match it so mock-backed
+// tests can't pass while relying on an overwrite that production rejects. This
+// is the store-layer backstop behind runner_id uniqueness at Join (MIR-1225):
+// two joins that resolve the same node/<runner_id> ident cannot clobber each
+// other.
+func TestStoreConformance_CreateRejectsDuplicateId(t *testing.T) {
+	runStoreConformance(t, func(t *testing.T, store Store) {
+		ctx := t.Context()
+		id := Id("conf-create-dup")
+
+		_, err := store.CreateEntity(ctx, New(
+			Ref(DBId, id),
+			Any(Doc, "first"),
+		))
+		require.NoError(t, err)
+
+		_, err = store.CreateEntity(ctx, New(
+			Ref(DBId, id),
+			Any(Doc, "second"),
+		))
+		require.Error(t, err, "create against an existing id must fail")
+		assert.True(t, errors.Is(err, cond.ErrConflict{}),
+			"duplicate create should report a conflict, got: %v", err)
+
+		// The original entity must be untouched by the rejected create.
+		got, err := store.GetEntity(ctx, id)
+		require.NoError(t, err)
+		doc, ok := got.Get(Doc)
+		require.True(t, ok)
+		assert.Equal(t, "first", doc.Value.String(),
+			"rejected create must not overwrite the existing entity")
+	})
+}
+
 // TestStoreConformance_EnsureEntity pins the create-if-absent contract that
 // saga storage depends on: the first Ensure creates and reports created=true;
 // a second Ensure with the same id returns the existing entity with

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -216,6 +216,30 @@ func (s *RegistrationServer) Join(ctx context.Context, req *runner_v1alpha.Runne
 		return nil
 	}
 
+	// Enforce runner_id uniqueness before claiming the invite or minting a
+	// certificate. A runner_id maps directly to the mTLS certificate CommonName
+	// (runner-<id>) that authorizes per-runner actions like minting workload
+	// identity tokens for a sandbox, so a caller who could join as an id that
+	// already backs a live runner would impersonate it. Only a client-supplied
+	// id needs checking; a server-generated UUID is fresh by construction. The
+	// node write below is create-only (its ident collapses to db/id node/<id>,
+	// and CreateEntity is a put-if-absent), which is the atomic backstop against
+	// a concurrent join racing this check. This read makes the rejection
+	// explicit, keeps us from burning a one-time invite or issuing a cert on a
+	// duplicate, and returns a clear, actionable error.
+	if args.RunnerId() != "" {
+		registered, err := s.runnerIDRegistered(ctx, runnerID)
+		if err != nil {
+			s.Log.Error("Failed to check for existing runner", "error", err, "runner_id", runnerID)
+			results.SetError("failed to validate runner id")
+			return nil
+		}
+		if registered {
+			results.SetError(fmt.Sprintf("runner id %s is already registered; remove it first with 'miren runner remove %s'", runnerID, runnerID))
+			return nil
+		}
+	}
+
 	listenAddr := ""
 	if args.HasListenAddr() {
 		listenAddr = args.ListenAddr()
@@ -1103,6 +1127,27 @@ func (s *RegistrationServer) resolveSandboxApp(ctx context.Context, sandboxID st
 	var appMeta core_v1alpha.Metadata
 	appMeta.Decode(appResp.Entity().Entity())
 	return appMeta.Name
+}
+
+// runnerIDRegistered reports whether a node is already registered with the
+// given runner_id. Unlike findNodeByQuery, it matches only the exact RunnerId,
+// never a node name, entity id, or short id. runner_id is the value that maps
+// to the authorizing certificate CommonName (runner-<id>), so it is the
+// property Join must keep unique; a node whose human name happens to equal an
+// incoming UUID must not be mistaken for a duplicate.
+func (s *RegistrationServer) runnerIDRegistered(ctx context.Context, runnerID string) (bool, error) {
+	listResp, err := s.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindNode))
+	if err != nil {
+		return false, err
+	}
+	for _, e := range listResp.Values() {
+		var node compute_v1alpha.Node
+		decodeEntity(e, &node)
+		if node.RunnerId == runnerID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // findNodeByQuery looks up a node entity by name, runner ID, entity ID, or short ID prefix.

--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -325,6 +325,116 @@ func TestReusableInviteMultipleJoins(t *testing.T) {
 	}
 }
 
+// TestJoinRejectsDuplicateRunnerId is the MIR-1225 regression: a caller holding
+// a reusable invite must not be able to join as a runner_id that already backs a
+// live runner. Because runner_id becomes the mTLS cert CommonName that authorizes
+// per-runner actions (minting workload identity tokens for a sandbox), letting a
+// second join reuse a live id would let it impersonate that runner. The second
+// join must be rejected before any certificate is issued.
+func TestJoinRejectsDuplicateRunnerId(t *testing.T) {
+	ctx := context.Background()
+	env, cleanup := newTestServer(t)
+	defer cleanup()
+
+	// A reusable invite is the exposure: it is never consumed on use, so nothing
+	// else gates repeated joins.
+	res, err := env.client.CreateInvite(ctx, nil, 1, "reusable", true, 0, "")
+	if err != nil {
+		t.Fatalf("CreateInvite failed: %v", err)
+	}
+	_, secret, err := enrolltoken.Decode(res.Code())
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+
+	const runnerID = "11111111-1111-1111-1111-111111111111"
+
+	// First join with the chosen id succeeds and mints a cert.
+	first, err := env.client.Join(ctx, secret, runnerID, "10.0.0.1:8443", "v1", nil, "victim")
+	if err != nil {
+		t.Fatalf("first Join RPC failed: %v", err)
+	}
+	if first.HasError() {
+		t.Fatalf("first join returned error: %s", first.Error())
+	}
+	if len(first.CertPem()) == 0 {
+		t.Fatal("first join did not return a certificate")
+	}
+
+	// A second join reusing the same id must be rejected, and must not return a
+	// certificate for the impersonated identity.
+	second, err := env.client.Join(ctx, secret, runnerID, "10.0.0.2:8443", "v1", nil, "impostor")
+	if err != nil {
+		t.Fatalf("second Join RPC failed: %v", err)
+	}
+	if !second.HasError() || second.Error() == "" {
+		t.Fatal("expected second join with a duplicate runner_id to be rejected")
+	}
+	if len(second.CertPem()) != 0 {
+		t.Error("rejected duplicate join must not return a certificate")
+	}
+
+	// The original node entity must be untouched: still exactly one node, with
+	// the victim's identity.
+	list, err := env.client.ListRunners(ctx)
+	if err != nil {
+		t.Fatalf("ListRunners failed: %v", err)
+	}
+	runners := list.Runners()
+	if len(runners) != 1 {
+		t.Fatalf("expected exactly 1 registered runner, got %d", len(runners))
+	}
+	if runners[0].Name() != "victim" {
+		t.Errorf("existing runner should be the original 'victim', got %q", runners[0].Name())
+	}
+}
+
+// TestJoinDuplicateCheckMatchesRunnerIdNotName guards the uniqueness check
+// against false positives: it must key strictly on runner_id, not on a node's
+// human name. A runner may be named with a string that happens to be another
+// runner's UUID; that must not block a legitimate join using that UUID as a
+// runner_id.
+func TestJoinDuplicateCheckMatchesRunnerIdNotName(t *testing.T) {
+	ctx := context.Background()
+	env, cleanup := newTestServer(t)
+	defer cleanup()
+
+	res, err := env.client.CreateInvite(ctx, nil, 1, "reusable", true, 0, "")
+	if err != nil {
+		t.Fatalf("CreateInvite failed: %v", err)
+	}
+	_, secret, err := enrolltoken.Decode(res.Code())
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+
+	// uuidA is used as one runner's *name* and, separately, as another runner's
+	// *id*. Only the id should count for uniqueness.
+	const uuidA = "22222222-2222-2222-2222-222222222222"
+
+	// First runner: a distinct id, but named with uuidA.
+	first, err := env.client.Join(ctx, secret, "33333333-3333-3333-3333-333333333333", "10.0.0.1:8443", "v1", nil, uuidA)
+	if err != nil {
+		t.Fatalf("first Join RPC failed: %v", err)
+	}
+	if first.HasError() {
+		t.Fatalf("first join returned error: %s", first.Error())
+	}
+
+	// Second runner joins using uuidA as its runner_id. No node has that
+	// runner_id (uuidA is only a name), so this must succeed.
+	second, err := env.client.Join(ctx, secret, uuidA, "10.0.0.2:8443", "v1", nil, "second")
+	if err != nil {
+		t.Fatalf("second Join RPC failed: %v", err)
+	}
+	if second.HasError() {
+		t.Fatalf("join using a UUID that is only another runner's name should not be rejected, got: %s", second.Error())
+	}
+	if len(second.CertPem()) == 0 {
+		t.Error("second join should have returned a certificate")
+	}
+}
+
 func TestReusableInviteRevoke(t *testing.T) {
 	ctx := context.Background()
 	env, cleanup := newTestServer(t)


### PR DESCRIPTION
MIR-1225 flagged that a reusable runner invite plus a known `runner_id` could let someone join as an existing runner and mint a certificate impersonating it. That matters because the cert's CommonName is `runner-<runner_id>`, and that name is what authorizes per-runner actions like minting workload identity tokens for a sandbox, which federate out to external systems. Join takes the `runner_id` from the caller, so on paper nothing stops you from picking a live runner's id.

Digging in, production already blocks this, just not on purpose. Join writes the node entity keyed on the ident `node/<runner_id>`, which collapses into the entity's `db/id`, and a `Put` with no explicit wire id falls through to `CreateEntity`, an etcd `CreateRevision==0` put-if-absent. A second Join on a live id conflicts, and since the cert is only returned after that write succeeds, the impersonator never gets one.

The problem was that this protection was accidental and fragile. The certificate is minted before the write that enforces uniqueness, so a future refactor (say, making that opaque "failed to register runner" error friendlier by switching to an upsert) would silently reopen the hole, and nothing documented that the write was load-bearing. Worse, `MockStore.CreateEntity` did an unconditional map overwrite with no put-if-absent, so the guarantee held in etcd but not in the fake most unit tests run against. A mock-backed test would have happily demonstrated the vulnerable behavior.

So this turns an accidental protection into an intentional, tested one. Join now does an explicit `runner_id` uniqueness check up front, before the invite is claimed and before any cert is minted, and returns a clear error that points the operator at `miren runner remove`. The `remove` then `join --runner-id` recovery flow still works, since removing the node frees the id. `MockStore.CreateEntity` now conflicts on a duplicate id exactly like `EtcdStore`, with the etcd CAS still there as the atomic backstop for a concurrent-join race. A store-conformance test pins the put-if-absent behavior on both backends, and a Join regression test covers the duplicate-id rejection.

The heavier option of having the server assign the id and dropping `--runner-id` entirely is noted on the issue as a possible follow-up, but with the vulnerability already blocked it's an attack-surface nice-to-have that would mean rewriting recovery guidance woven through `runner_start.go`.

Closes MIR-1225