### PR TITLE
Let .miren/app.toml outrank MIREN_APP when resolving the app name

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -25,9 +25,15 @@ import (
 type AppCentric struct {
 	ConfigCentric `group:"Config Options"`
 
-	_   struct{} `group:"App Options"`
-	App string   `short:"a" long:"app" env:"MIREN_APP" description:"Application name"`
-	Dir string   `short:"d" long:"dir" description:"Directory to run from" default:"."`
+	_ struct{} `group:"App Options"`
+
+	// App carries only the -a/--app flag. MIREN_APP is deliberately not an
+	// env tag here: mflags applies env tags in FromStruct, before Validate
+	// runs, which would leave Validate unable to tell an explicit flag from
+	// the environment. Validate reads MIREN_APP itself instead, below the
+	// config file. See Validate for the resolution order.
+	App string `short:"a" long:"app" description:"Application name (defaults to .miren/app.toml, then $MIREN_APP)"`
+	Dir string `short:"d" long:"dir" description:"Directory to run from" default:"."`
 
 	config        *appconfig.AppConfig
 	resolvedDir   string // absolute path to the directory containing .miren/app.toml
@@ -44,6 +50,18 @@ func (a *AppCentric) ResolvedDir() string {
 	return a.Dir
 }
 
+// Validate loads .miren/app.toml and resolves the target app name. Resolution
+// priority:
+//  1. -a/--app flag (explicit override)
+//  2. name in .miren/app.toml
+//  3. MIREN_APP env var
+//  4. inferred from the directory name, via a 'miren init' prompt
+//
+// The config file outranks MIREN_APP because every app sandbox exports
+// MIREN_APP=<its own app>; without this ordering, deploying from inside a
+// sandbox would silently target the sandbox's app rather than the app.toml in
+// the working directory. Note this differs from LoadCluster below, where
+// MIREN_CLUSTER still outranks stored per-app state.
 func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 	a.config = nil
 	a.resolvedDir = ""
@@ -76,8 +94,10 @@ func (a *AppCentric) Validate(glbl *GlobalFlags) error {
 	if a.App == "" {
 		if a.config != nil && a.config.Name != "" {
 			a.App = a.config.Name
+		} else if envApp := os.Getenv("MIREN_APP"); envApp != "" {
+			a.App = envApp
 		} else {
-			// No app name from flag or config — try to help the user.
+			// No app name from flag, config, or env — try to help the user.
 			workDir := a.Dir
 			if workDir == "." || workDir == "" {
 				wd, err := os.Getwd()

--- a/cli/commands/app_test.go
+++ b/cli/commands/app_test.go
@@ -220,13 +220,100 @@ command = ["foo", "bar"]
 	})
 }
 
-// TestAppCentric_MIREN_APP_EnvTag confirms that env:"MIREN_APP" on AppCentric.App
-// actually flows through mflags' FromStruct path (which silently ignored the tag
-// before the env-tag support landed in mflags MIR-986). It also verifies the
-// CLI-beats-env precedence the rest of the system relies on.
-func TestAppCentric_MIREN_APP_EnvTag(t *testing.T) {
-	t.Run("env populates App when CLI flag absent", func(t *testing.T) {
+// TestAppCentric_NoEnvTagOnApp pins that AppCentric.App carries no env:"MIREN_APP"
+// tag. mflags applies env tags in FromStruct, before Validate runs, so a tag here
+// would make MIREN_APP indistinguishable from an explicit -a and silently outrank
+// .miren/app.toml again (MIR-1402). MIREN_APP is read in Validate instead; see
+// TestAppCentric_AppNamePrecedence.
+func TestAppCentric_NoEnvTagOnApp(t *testing.T) {
+	t.Setenv("MIREN_APP", "from-env")
+
+	var a AppCentric
+	fs := mflags.NewFlagSet("app")
+	if err := fs.FromStruct(&a); err != nil {
+		t.Fatalf("FromStruct: %v", err)
+	}
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if a.App != "" {
+		t.Errorf("App = %q after parsing, want empty — MIREN_APP must not be wired up as an env tag; resolve it in Validate below the config file", a.App)
+	}
+}
+
+// TestAppCentric_AppNamePrecedence covers the resolution order Validate implements:
+// -a flag > .miren/app.toml > MIREN_APP.
+func TestAppCentric_AppNamePrecedence(t *testing.T) {
+	t.Run("env populates App when no app.toml", func(t *testing.T) {
 		t.Setenv("MIREN_APP", "from-env")
+		dir := t.TempDir()
+
+		a := AppCentric{Dir: dir}
+		if err := a.Validate(&GlobalFlags{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.App != "from-env" {
+			t.Errorf("App = %q, want from-env (env is the fallback when no config exists)", a.App)
+		}
+	})
+
+	t.Run("app.toml beats env", func(t *testing.T) {
+		t.Setenv("MIREN_APP", "from-env")
+		dir := t.TempDir()
+		writeAppToml(t, dir, `name = "myapp"`)
+
+		a := AppCentric{Dir: dir}
+		if err := a.Validate(&GlobalFlags{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.App != "myapp" {
+			t.Errorf("App = %q, want myapp (config file must outrank MIREN_APP)", a.App)
+		}
+	})
+
+	t.Run("app flag beats both app.toml and env", func(t *testing.T) {
+		t.Setenv("MIREN_APP", "from-env")
+		dir := t.TempDir()
+		writeAppToml(t, dir, `name = "myapp"`)
+
+		a := AppCentric{Dir: dir, App: "from-cli"}
+		if err := a.Validate(&GlobalFlags{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.App != "from-cli" {
+			t.Errorf("App = %q, want from-cli (explicit flag wins)", a.App)
+		}
+	})
+
+	t.Run("app.toml found in parent beats env", func(t *testing.T) {
+		t.Setenv("MIREN_APP", "from-env")
+		parent := t.TempDir()
+		writeAppToml(t, parent, `name = "myapp"`)
+
+		sub := filepath.Join(parent, "scripts")
+		if err := os.MkdirAll(sub, 0755); err != nil {
+			t.Fatalf("failed to create subdirectory: %v", err)
+		}
+		chdir(t, sub)
+
+		a := AppCentric{Dir: "."}
+		if err := a.Validate(&GlobalFlags{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.App != "myapp" {
+			t.Errorf("App = %q, want myapp (parent-walk config must outrank MIREN_APP)", a.App)
+		}
+	})
+
+	// The MIR-1402 repro, through the real command lifecycle: mflags parsing
+	// followed by Validate, with MIREN_APP set the way an app sandbox sets it.
+	// The direct-construction subtests above cannot catch a re-added env tag,
+	// since they never run FromStruct.
+	t.Run("full mflags lifecycle: app.toml beats sandbox MIREN_APP", func(t *testing.T) {
+		t.Setenv("MIREN_APP", "sandbox-app")
+		dir := t.TempDir()
+		writeAppToml(t, dir, `name = "checkout-app"`)
+		chdir(t, dir)
 
 		var a AppCentric
 		fs := mflags.NewFlagSet("app")
@@ -236,24 +323,25 @@ func TestAppCentric_MIREN_APP_EnvTag(t *testing.T) {
 		if err := fs.Parse(nil); err != nil {
 			t.Fatalf("Parse: %v", err)
 		}
-		if a.App != "from-env" {
-			t.Errorf("App = %q, want %q (env tag should have fired)", a.App, "from-env")
+		if err := a.Validate(&GlobalFlags{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if a.App != "checkout-app" {
+			t.Errorf("App = %q, want checkout-app — deploying from inside a sandbox must honor the app.toml in the working directory", a.App)
 		}
 	})
 
-	t.Run("CLI flag beats env", func(t *testing.T) {
-		t.Setenv("MIREN_APP", "from-env")
+	t.Run("empty env is ignored", func(t *testing.T) {
+		t.Setenv("MIREN_APP", "")
+		dir := t.TempDir()
 
-		var a AppCentric
-		fs := mflags.NewFlagSet("app")
-		if err := fs.FromStruct(&a); err != nil {
-			t.Fatalf("FromStruct: %v", err)
+		a := AppCentric{Dir: dir}
+		err := a.Validate(&GlobalFlags{})
+		if err == nil {
+			t.Fatal("expected error when no app name is resolvable")
 		}
-		if err := fs.Parse([]string{"--app=from-cli"}); err != nil {
-			t.Fatalf("Parse: %v", err)
-		}
-		if a.App != "from-cli" {
-			t.Errorf("App = %q, want from-cli (CLI should beat env)", a.App)
+		if !strings.Contains(err.Error(), "miren init") {
+			t.Errorf("expected error to mention 'miren init', got: %v", err)
 		}
 	})
 }

--- a/docs/docs/ci-deploy.md
+++ b/docs/docs/ci-deploy.md
@@ -187,7 +187,8 @@ set -euo pipefail
 
 # --- Configuration (set these in your CI environment) ---
 # MIREN_CLUSTER: cluster address with TLS fingerprint (from `miren cluster export-address`)
-# MIREN_APP:     application name to deploy
+# MIREN_APP:     application name to deploy, when the checkout has no .miren/app.toml
+#                (a checked-in app.toml wins — pass `-a <name>` to override it)
 
 : "${MIREN_CLUSTER:?MIREN_CLUSTER must be set}"
 : "${MIREN_APP:?MIREN_APP must be set}"
@@ -214,6 +215,7 @@ miren version
 
 # 2. Deploy
 # MIREN_CLUSTER and MIREN_APP are read from the environment automatically.
+# MIREN_APP applies only if the checkout has no .miren/app.toml; that file wins.
 # In GitHub Actions, the CLI auto-detects the OIDC token. For other CI systems,
 # you'll need to acquire an OIDC token from your provider and set
 # ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN, or
@@ -306,8 +308,16 @@ Output format: `address:port;sha1:fingerprint`
 | Variable | Description |
 |----------|-------------|
 | `MIREN_CLUSTER` | Cluster address with optional TLS fingerprint (`address:port;sha1:fingerprint`). The CLI connects directly — no config file needed. Can also be a cluster name from an existing config. |
-| `MIREN_APP` | Target application name. Equivalent to `-a myapp` on commands. |
+| `MIREN_APP` | Target application name, used when the working directory has no `.miren/app.toml`. A config file takes precedence — use `-a myapp` to override one. |
 | `MIREN_CONFIG` | Path to a `clientconfig.yaml` file. Alternative to `MIREN_CLUSTER` when you need a config file. |
+
+The app name resolves in this order: the `-a`/`--app` flag, then `name` in `.miren/app.toml`, then `MIREN_APP`.
+
+:::warning[MIREN_APP does not override a checked-in app.toml]
+If your repository has a `.miren/app.toml`, its `name` wins over `MIREN_APP`. To target a different app from CI — a staging app, for instance — pass `-a <name>` explicitly rather than setting the environment variable.
+
+The config file takes precedence because every app sandbox exports `MIREN_APP` naming its own app. Without this ordering, running `miren deploy` from inside a sandbox would silently target the sandbox's app instead of the checkout you are standing in.
+:::
 
 ## Troubleshooting
 

--- a/docs/docs/command/addon-create.md
+++ b/docs/docs/command/addon-create.md
@@ -29,7 +29,7 @@ miren addon create <spec> [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/addon-destroy.md
+++ b/docs/docs/command/addon-destroy.md
@@ -29,7 +29,7 @@ miren addon destroy <name> [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/addon-list.md
+++ b/docs/docs/command/addon-list.md
@@ -26,7 +26,7 @@ miren addon list [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/admin.md
+++ b/docs/docs/command/admin.md
@@ -111,7 +111,7 @@ miren admin <method> [args...] [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/app-history.md
+++ b/docs/docs/command/app-history.md
@@ -31,7 +31,7 @@ miren app history [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/app-restart.md
+++ b/docs/docs/command/app-restart.md
@@ -25,7 +25,7 @@ miren app restart [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/app-run.md
+++ b/docs/docs/command/app-run.md
@@ -45,7 +45,7 @@ miren app run [args...] [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/app-status.md
+++ b/docs/docs/command/app-status.md
@@ -26,7 +26,7 @@ miren app status [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/app-versions.md
+++ b/docs/docs/command/app-versions.md
@@ -28,7 +28,7 @@ miren app versions [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/app.md
+++ b/docs/docs/command/app.md
@@ -28,7 +28,7 @@ miren app [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/auth-ci-add.md
+++ b/docs/docs/command/auth-ci-add.md
@@ -30,7 +30,7 @@ miren auth ci add [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/auth-ci-list.md
+++ b/docs/docs/command/auth-ci-list.md
@@ -21,7 +21,7 @@ miren auth ci list [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/cluster-current.md
+++ b/docs/docs/command/cluster-current.md
@@ -21,7 +21,7 @@ miren cluster current [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/deploy.md
+++ b/docs/docs/command/deploy.md
@@ -34,7 +34,7 @@ miren deploy [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/env-delete.md
+++ b/docs/docs/command/env-delete.md
@@ -26,7 +26,7 @@ miren env delete [args...] [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/env-get.md
+++ b/docs/docs/command/env-get.md
@@ -30,7 +30,7 @@ miren env get <key> [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/env-list.md
+++ b/docs/docs/command/env-list.md
@@ -26,7 +26,7 @@ miren env list [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/env-set.md
+++ b/docs/docs/command/env-set.md
@@ -27,7 +27,7 @@ miren env set [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/logs-app.md
+++ b/docs/docs/command/logs-app.md
@@ -131,7 +131,7 @@ miren logs app [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/logs-build.md
+++ b/docs/docs/command/logs-build.md
@@ -35,7 +35,7 @@ miren logs build <version> [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/logs.md
+++ b/docs/docs/command/logs.md
@@ -131,7 +131,7 @@ miren logs [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/command/rollback.md
+++ b/docs/docs/command/rollback.md
@@ -21,7 +21,7 @@ miren rollback [flags]
 
 ## App Options
 
-- `--app, -a` — Application name
+- `--app, -a` — Application name (defaults to .miren/app.toml, then $MIREN_APP)
 - `--dir, -d` — Directory to run from (default: `.`)
 
 ## Global Options

--- a/docs/docs/pr-environments.md
+++ b/docs/docs/pr-environments.md
@@ -103,7 +103,11 @@ miren deploy -a myapp-staging --ephemeral pr-123 --ttl 48h
 
 The preview is reachable at `pr-123.staging.myapp.example.com`, isolated from production data. Redeploy the staging app's active version periodically (or on every push to `main`) to keep its baseline fresh — ephemeral previews inherit the staging app's current config and addons, not production's.
 
-In CI, set `MIREN_APP=myapp-staging` (or pass `app: myapp-staging` to the deploy action) so PR workflows always target staging.
+In CI, pass `-a myapp-staging` (or `app: myapp-staging` to the deploy action) so PR workflows always target staging.
+
+:::warning[Use -a, not MIREN_APP, to target staging]
+Setting `MIREN_APP=myapp-staging` will not redirect a deploy if your repository has a `.miren/app.toml` — the config file's `name` takes precedence, and previews would go to the app it names. Pass `-a` explicitly instead.
+:::
 
 ### Using a Staging Cluster
 


### PR DESCRIPTION
Fixes MIR-1402.

## The bug

Every app sandbox exports `MIREN_APP` naming its own app (`controllers/deployment/launcher.go:573`, `servers/exec_proxy/exec_proxy.go:348`), and the CLI read a variable of that same name to pick its target (`cli/commands/app.go`). Deploying from inside a sandbox therefore picked up the sandbox's app and silently overrode the `.miren/app.toml` in the working directory — the config file was read, parsed, and then ignored.

Repro: `m app shell` into a sandbox for `foo`, `cd` to a checkout whose `app.toml` declares `bar`, run `m deploy` → deploys to `foo`, no error, no warning. Same-app deploys are harmless, which is what kept this hidden until someone did cross-app work from inside a sandbox.

## The fix

Resolution order is now:

    -a/--app flag  >  .miren/app.toml  >  MIREN_APP  >  miren init prompt

The `env:"MIREN_APP"` tag had to come off `AppCentric.App` to make this possible. mflags applies env tags in `FromStruct`, at command registration — before `Parse`, long before `Validate` — and exposes no provenance (`Flag.HasValue` is documented as "set by env var **or** CLI arg"). So while the tag was present, `Validate` had no way to distinguish an explicit `--app` from the environment. `Validate` now reads `MIREN_APP` itself, positioned below the config check.

`MIREN_APP` still works for its documented CI use — deploying from a checkout with no `app.toml`. It just no longer wins against a config file that is present.

## Breaking change worth a look

`docs/docs/pr-environments.md` told readers to set `MIREN_APP=myapp-staging` in CI so PR previews target staging. A repo with a checked-in `app.toml` will now deploy to the app that file names instead. This was a deliberate call: the override is dropped silently, matching the chosen precedence rather than warning or erroring on disagreement. Docs now steer that case to an explicit `-a myapp-staging`, with warning admonitions there and in `ci-deploy.md`.

Docs are the only mitigation — there is no runtime signal for someone who doesn't read them. A one-line stderr warning on env/config disagreement would be easy to add later if this bites anyone.

## Out of scope

The sandbox injection sites and reserved-var skip lists (`launcher.go:1049`, `build.go:873`) are untouched. Renaming the in-container variable would break anything reading it, and the precedence change resolves the bug without it. One residual: deploying from inside a sandbox in a directory with *no* `app.toml` still resolves to the sandbox's own app — that's the documented env fallback working as designed.

## Testing

`TestAppCentric_AppNamePrecedence` covers the ladder, including a subtest driving the full `FromStruct` → `Parse` → `Validate` lifecycle — the path the bug actually lived on. The direct-construction subtests alone would have passed before the fix, since they never run `FromStruct`. `TestAppCentric_NoEnvTagOnApp` pins that the env tag stays off. Both were confirmed to fail with the tag restored.

Verified end-to-end with the built binary:

| Scenario | Resolves to |
|---|---|
| `app.toml` = checkout-app, `MIREN_APP`=sandbox-app | `checkout-app` |
| same, plus `-a flag-app` | `flag-app` |
| no `app.toml`, `MIREN_APP`=ci-app | `ci-app` |
| no `app.toml`, no env, non-TTY | `miren init` error |

`make lint` clean, docs lint passes. Generated command docs regenerated for the flag description change.