### PR TITLE
Collapse Language Guides sidebar category by default

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -33,7 +33,9 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Language Guides',
-      collapsed: false,
+      // Nearly 40 guides; unfurled they dominate the sidebar. The theme still
+      // auto-expands this category when the reader is on a guide page.
+      collapsed: true,
       link: {
         type: 'doc',
         id: 'guides/index',


### PR DESCRIPTION
## Problem

The Language Guides category holds nearly 40 guides and was explicitly set to `collapsed: false`, so it unfurled on every page. It dominated the sidebar and pushed the categories below it (Recipes, Data & Storage, Networking, Reference, Resources) well out of view.

## Change

One line in `docs/sidebars.ts`: `collapsed: false` → `collapsed: true`.

This matches the CLI category, which already does the same thing for the same reason — it's a large generated list.

Readers on a guide page are unaffected. The theme only applies `item.collapsed` to non-active categories:

```js
// @docusaurus/theme-classic/lib/theme/DocSidebarItem/Category/index.js
// (`item.collapsed`) is only used for non-active categories.
return isActive ? false : item.collapsed;
```

So landing on `/guides/elixir` still auto-expands the category with the current page highlighted.

## Verification

Built the site and checked the rendered sidebar markup:

| Page | `aria-expanded` |
|---|---|
| `index` | `false` |
| `getting-started` | `false` |
| `commands` | `false` |
| `guides/elixir` | `true` |
| `guides/rust` | `true` |

Collapsed everywhere except inside the category, where it auto-expands. Build is clean.

## Note

This sets the *initial* state only — the collapse state is sticky per session once a reader toggles it, so it won't re-fold on every navigation.

If sidebar length is a broader concern, the related knob is `themeConfig.docs.sidebar.autoCollapseCategories`, which folds sibling categories when one is opened. That affects all ten categories, so it's deliberately not in this PR.