### PR TITLE
Namespace sandbox-injected env vars under MIREN_RUNTIME_ (MIR-1406)

### DIFF
--- a/api/app/runtimeenv.go
+++ b/api/app/runtimeenv.go
@@ -16,6 +16,11 @@ const (
 // RuntimeEnvNames lists every var Miren injects under MIREN_RUNTIME_. User
 // config must not override these, and none of them may match a var the client
 // reads from its own environment.
+//
+// EnvRuntimeApp and EnvRuntimeVersion are injected into every app sandbox.
+// EnvRuntimeInstanceNum is injected only for instance-backed sandboxes — those
+// carrying an "instance" metadata label; it is set at sandbox-boot time in
+// controllers/sandbox rather than by the deployment launcher.
 var RuntimeEnvNames = []string{
 	EnvRuntimeApp,
 	EnvRuntimeVersion,

--- a/api/app/runtimeenv.go
+++ b/api/app/runtimeenv.go
@@ -1,0 +1,23 @@
+package app
+
+// Environment variables Miren injects into every sandbox, describing the
+// workload to itself.
+//
+// These live under MIREN_RUNTIME_ so they cannot collide with the MIREN_* vars
+// the client reads as input (MIREN_APP, MIREN_CLUSTER, ...). The two directions
+// previously shared the name MIREN_APP, which meant the CLI run inside a sandbox
+// picked up the sandbox's app instead of the one in .miren/app.toml.
+const (
+	EnvRuntimeApp         = "MIREN_RUNTIME_APP"
+	EnvRuntimeVersion     = "MIREN_RUNTIME_VERSION"
+	EnvRuntimeInstanceNum = "MIREN_RUNTIME_INSTANCE_NUM"
+)
+
+// RuntimeEnvNames lists every var Miren injects under MIREN_RUNTIME_. User
+// config must not override these, and none of them may match a var the client
+// reads from its own environment.
+var RuntimeEnvNames = []string{
+	EnvRuntimeApp,
+	EnvRuntimeVersion,
+	EnvRuntimeInstanceNum,
+}

--- a/api/app/runtimeenv.go
+++ b/api/app/runtimeenv.go
@@ -1,5 +1,7 @@
 package app
 
+import "strings"
+
 // Environment variables Miren injects into every sandbox, describing the
 // workload to itself.
 //
@@ -25,4 +27,13 @@ var RuntimeEnvNames = []string{
 	EnvRuntimeApp,
 	EnvRuntimeVersion,
 	EnvRuntimeInstanceNum,
+}
+
+// IsReservedEnvVar reports whether key belongs to the reserved MIREN_ namespace
+// that user config must not set or override. Miren owns the whole prefix so it
+// can inject MIREN_RUNTIME_* (and other MIREN_*) vars without a user's config
+// shadowing them. This is the single source of truth for the prefix check that
+// the env-var guards and system-var filters all apply.
+func IsReservedEnvVar(key string) bool {
+	return strings.HasPrefix(key, "MIREN_")
 }

--- a/api/app/runtimeenv_test.go
+++ b/api/app/runtimeenv_test.go
@@ -1,0 +1,31 @@
+package app
+
+import "testing"
+
+func TestIsReservedEnvVar(t *testing.T) {
+	cases := map[string]bool{
+		EnvRuntimeApp:         true,
+		EnvRuntimeVersion:     true,
+		EnvRuntimeInstanceNum: true,
+		"MIREN_APP":           true,
+		"MIREN_":              true,
+		"MIREN_ANYTHING":      true,
+		"DATABASE_URL":        false,
+		"PORT":                false,
+		"MIRENISH":            false,
+		"":                    false,
+	}
+
+	for key, want := range cases {
+		if got := IsReservedEnvVar(key); got != want {
+			t.Errorf("IsReservedEnvVar(%q) = %v, want %v", key, got, want)
+		}
+	}
+
+	// Every injected name must be reserved, or user config could shadow it.
+	for _, name := range RuntimeEnvNames {
+		if !IsReservedEnvVar(name) {
+			t.Errorf("injected var %q is not reserved", name)
+		}
+	}
+}

--- a/cli/commands/app_test.go
+++ b/cli/commands/app_test.go
@@ -3,10 +3,12 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"miren.dev/mflags"
+	appclient "miren.dev/runtime/api/app"
 )
 
 func writeAppToml(t *testing.T, dir, content string) {
@@ -256,4 +258,57 @@ func TestAppCentric_MIREN_APP_EnvTag(t *testing.T) {
 			t.Errorf("App = %q, want from-cli (CLI should beat env)", a.App)
 		}
 	})
+}
+
+// TestCLIEnvTagsDoNotReadInjectedVars closes the MIR-1406 collision from the CLI
+// side. It derives the MIREN_* vars the CLI reads from the actual mflags `env:`
+// struct tags on AppCentric (which embeds ConfigCentric) — no hand-maintained
+// list to drift out of sync — and asserts none of them names a var Miren injects
+// into sandboxes. The deployment side guarantees the other half: every injected
+// var stays under the reserved MIREN_RUNTIME_ prefix (see
+// TestRuntimeEnvNamesDoNotCollideWithClientEnv).
+//
+// These are the app/cluster targeting flags whose env tags caused MIR-1406. Vars
+// the CLI reads via os.Getenv elsewhere aren't reflected here, but they're safe
+// as long as none of them lives under MIREN_RUNTIME_, which is reserved.
+func TestCLIEnvTagsDoNotReadInjectedVars(t *testing.T) {
+	injected := make(map[string]bool, len(appclient.RuntimeEnvNames))
+	for _, n := range appclient.RuntimeEnvNames {
+		injected[n] = true
+	}
+
+	tags := collectEnvTags(reflect.TypeOf(AppCentric{}))
+	if len(tags) == 0 {
+		t.Fatal("no env tags found — the reflection walk is not seeing the CLI flags")
+	}
+
+	for _, env := range tags {
+		if injected[env] {
+			t.Errorf("CLI flag reads env %q, which Miren injects into sandboxes — "+
+				"running the CLI inside a sandbox would target the wrong app (MIR-1406)", env)
+		}
+	}
+}
+
+// collectEnvTags returns the `env:` struct tags on t and, recursively, on its
+// embedded (anonymous) structs — mirroring how mflags composes flags.
+func collectEnvTags(t reflect.Type) []string {
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	var out []string
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if env := f.Tag.Get("env"); env != "" {
+			out = append(out, env)
+		}
+		if f.Anonymous {
+			out = append(out, collectEnvTags(f.Type)...)
+		}
+	}
+	return out
 }

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"miren.dev/runtime/api/addon/addon_v1alpha"
+	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -570,8 +572,8 @@ func (l *Launcher) buildSandboxSpec(
 		Name:  "app",
 		Image: image,
 		Env: []string{
-			"MIREN_APP=" + appMD.Name,
-			"MIREN_VERSION=" + ver.Version,
+			appclient.EnvRuntimeApp + "=" + appMD.Name,
+			appclient.EnvRuntimeVersion + "=" + ver.Version,
 		},
 		Directory: startDir,
 	}
@@ -1017,7 +1019,7 @@ func mountsEqual(mounts1, mounts2 []compute_v1alpha.SandboxSpecContainerMount) b
 }
 
 // envVarsEqual compares two env var slices in an order-independent way,
-// ignoring version-specific system env vars (MIREN_VERSION, MIREN_APP)
+// ignoring the system env vars Miren injects per version — see filterSystemEnvVars.
 func envVarsEqual(env1, env2 []string) bool {
 	// Filter out system env vars
 	filtered1 := filterSystemEnvVars(env1)
@@ -1043,33 +1045,28 @@ func envVarsEqual(env1, env2 []string) bool {
 }
 
 // isSystemEnvVar returns true if the given key is a system-managed env var
-// that user config must not override.
+// that user config must not override. The whole MIREN_ namespace is reserved,
+// so only the unprefixed names need naming here.
 func isSystemEnvVar(key string) bool {
 	switch key {
-	case "MIREN_VERSION", "MIREN_APP", "MIREN_INSTANCE_NUM", "PORT", "ADMIN_TOKEN":
+	case "PORT", "ADMIN_TOKEN":
 		return true
 	}
 	return strings.HasPrefix(key, "MIREN_")
 }
 
-// filterSystemEnvVars filters out system-managed env vars that shouldn't affect pool reuse
+// filterSystemEnvVars filters out system-managed env vars that shouldn't affect pool reuse.
+// Unlike isSystemEnvVar this matches exact names rather than the MIREN_ prefix: a user's
+// own MIREN_-prefixed var could never be set anyway, but a pool must still be reused across
+// versions that differ only in the values Miren injects.
 func filterSystemEnvVars(envVars []string) []string {
+	skip := append([]string{"PORT", "ADMIN_TOKEN"}, appclient.RuntimeEnvNames...)
+
 	filtered := []string{}
 	for _, e := range envVars {
-		// Skip MIREN_VERSION, MIREN_APP, MIREN_INSTANCE_NUM, PORT, and ADMIN_TOKEN - these are set automatically
-		if strings.HasPrefix(e, "MIREN_VERSION=") {
-			continue
-		}
-		if strings.HasPrefix(e, "MIREN_APP=") {
-			continue
-		}
-		if strings.HasPrefix(e, "MIREN_INSTANCE_NUM=") {
-			continue
-		}
-		if strings.HasPrefix(e, "PORT=") {
-			continue
-		}
-		if strings.HasPrefix(e, "ADMIN_TOKEN=") {
+		if slices.ContainsFunc(skip, func(name string) bool {
+			return strings.HasPrefix(e, name+"=")
+		}) {
 			continue
 		}
 		filtered = append(filtered, e)

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -1045,8 +1045,9 @@ func envVarsEqual(env1, env2 []string) bool {
 }
 
 // isSystemEnvVar returns true if the given key is a system-managed env var
-// that user config must not override. The whole MIREN_ namespace is reserved,
-// so only the unprefixed names need naming here.
+// that user config must not override. The whole MIREN_ namespace is reserved
+// (the injected MIREN_RUNTIME_* vars are enumerated in api/app/runtimeenv.go),
+// so only the unprefixed names need explicit cases here.
 func isSystemEnvVar(key string) bool {
 	switch key {
 	case "PORT", "ADMIN_TOKEN":

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -1053,7 +1053,7 @@ func isSystemEnvVar(key string) bool {
 	case "PORT", "ADMIN_TOKEN":
 		return true
 	}
-	return strings.HasPrefix(key, "MIREN_")
+	return appclient.IsReservedEnvVar(key)
 }
 
 // filterSystemEnvVars filters out system-managed env vars that shouldn't affect pool reuse.

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -3420,24 +3420,41 @@ func TestRuntimeEnvVarsInjectedIntoSandboxSpec(t *testing.T) {
 // nothing Miren injects into a sandbox may share a name with a var the client reads
 // from its own environment, or the CLI misbehaves when run inside a sandbox.
 func TestRuntimeEnvNamesDoNotCollideWithClientEnv(t *testing.T) {
-	// Vars the client reads as input. Keep in sync with the env:"..." struct tags in
-	// cli/commands (app.go, config.go) and the os.Getenv calls in cli/ and clientconfig/.
-	clientEnv := []string{
-		"MIREN_APP",
-		"MIREN_CLUSTER",
-		"MIREN_CONFIG",
-		"MIREN_THEME",
-		"MIREN_LABS",
-		"MIREN_CONTAINER_RUNTIME",
-		"MIREN_DISK_MODE",
-		"MIREN_HELP_JSON",
-		"MIREN_DIAL_PROGRAM",
-	}
+	// The structural guarantee: injected vars live under the reserved MIREN_RUNTIME_
+	// sub-namespace, and the CLI reads no var under that prefix. This is what makes
+	// collisions impossible for *future* CLI vars too — a new MIREN_FOO the CLI adds
+	// cannot match a MIREN_RUNTIME_* injected name. The allowlist below can't catch
+	// that on its own, since it only knows today's CLI vars.
+	t.Run("all injected names use the reserved prefix", func(t *testing.T) {
+		for _, injected := range appclient.RuntimeEnvNames {
+			assert.True(t, strings.HasPrefix(injected, "MIREN_RUNTIME_"),
+				"%s is injected but not under MIREN_RUNTIME_ — it could collide with a CLI var", injected)
+		}
+	})
 
-	for _, injected := range appclient.RuntimeEnvNames {
-		assert.NotContains(t, clientEnv, injected,
-			"%s is injected into sandboxes AND read by the client — that is the MIR-1406 collision", injected)
-	}
+	// A concrete regression check for the specific MIR-1406 collision. This list is
+	// hand-maintained; keep it in sync with the env:"..." struct tags in cli/commands
+	// (app.go, config.go) and the os.Getenv calls in cli/ and clientconfig/. It's a
+	// backstop for the prefix rule above, not the primary guarantee — a CLI var added
+	// without updating this list is still covered as long as it isn't MIREN_RUNTIME_*.
+	t.Run("no injected name matches a known CLI var", func(t *testing.T) {
+		clientEnv := []string{
+			"MIREN_APP",
+			"MIREN_CLUSTER",
+			"MIREN_CONFIG",
+			"MIREN_THEME",
+			"MIREN_LABS",
+			"MIREN_CONTAINER_RUNTIME",
+			"MIREN_DISK_MODE",
+			"MIREN_HELP_JSON",
+			"MIREN_DIAL_PROGRAM",
+		}
+
+		for _, injected := range appclient.RuntimeEnvNames {
+			assert.NotContains(t, clientEnv, injected,
+				"%s is injected into sandboxes AND read by the client — that is the MIR-1406 collision", injected)
+		}
+	})
 }
 
 // TestCreatePoolForVersionEphemeral verifies that the web pool of an ephemeral

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	apiserver "miren.dev/runtime/api/entityserver"
@@ -3366,6 +3367,77 @@ func TestPortTimeoutPropagatesToSandboxSpec(t *testing.T) {
 	workerSpec, err := l.buildSandboxSpec(ctx, app, ver, cfgSpec, "worker", "test:latest")
 	require.NoError(t, err)
 	assert.Empty(t, workerSpec.PortWaitTimeout, "worker without timeout stays empty so default applies in resolvePortWaitTimeout")
+}
+
+// TestRuntimeEnvVarsInjectedIntoSandboxSpec pins the names Miren injects into
+// every app container. The old names (MIREN_APP, MIREN_VERSION) collided with the
+// vars the CLI reads from its own environment, so `miren` run inside a sandbox
+// targeted the sandbox's app instead of the one in .miren/app.toml (MIR-1406).
+func TestRuntimeEnvVarsInjectedIntoSandboxSpec(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{Project: entity.Id("project-1")}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	ver := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", ver)
+	require.NoError(t, err)
+	ver.ID = verID
+
+	cfgSpec := &core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{Name: "web", Port: 4000}},
+	}
+
+	l := newTestLauncher(log, server.EAC)
+
+	spec, err := l.buildSandboxSpec(ctx, app, ver, cfgSpec, "web", "test:latest")
+	require.NoError(t, err)
+	require.NotEmpty(t, spec.Container)
+
+	env := spec.Container[0].Env
+	assert.Contains(t, env, appclient.EnvRuntimeApp+"=test-app")
+	assert.Contains(t, env, appclient.EnvRuntimeVersion+"=v1")
+
+	for _, e := range env {
+		assert.False(t, strings.HasPrefix(e, "MIREN_APP="),
+			"MIREN_APP must not be injected — the CLI reads it as its target app (MIR-1406)")
+		assert.False(t, strings.HasPrefix(e, "MIREN_VERSION="),
+			"MIREN_VERSION was renamed to %s", appclient.EnvRuntimeVersion)
+	}
+}
+
+// TestRuntimeEnvNamesDoNotCollideWithClientEnv is the regression guard for MIR-1406:
+// nothing Miren injects into a sandbox may share a name with a var the client reads
+// from its own environment, or the CLI misbehaves when run inside a sandbox.
+func TestRuntimeEnvNamesDoNotCollideWithClientEnv(t *testing.T) {
+	// Vars the client reads as input. Keep in sync with the env:"..." struct tags in
+	// cli/commands (app.go, config.go) and the os.Getenv calls in cli/ and clientconfig/.
+	clientEnv := []string{
+		"MIREN_APP",
+		"MIREN_CLUSTER",
+		"MIREN_CONFIG",
+		"MIREN_THEME",
+		"MIREN_LABS",
+		"MIREN_CONTAINER_RUNTIME",
+		"MIREN_DISK_MODE",
+		"MIREN_HELP_JSON",
+		"MIREN_DIAL_PROGRAM",
+	}
+
+	for _, injected := range appclient.RuntimeEnvNames {
+		assert.NotContains(t, clientEnv, injected,
+			"%s is injected into sandboxes AND read by the client — that is the MIR-1406 collision", injected)
+	}
 }
 
 // TestCreatePoolForVersionEphemeral verifies that the web pool of an ephemeral

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -3416,45 +3416,18 @@ func TestRuntimeEnvVarsInjectedIntoSandboxSpec(t *testing.T) {
 	}
 }
 
-// TestRuntimeEnvNamesDoNotCollideWithClientEnv is the regression guard for MIR-1406:
-// nothing Miren injects into a sandbox may share a name with a var the client reads
-// from its own environment, or the CLI misbehaves when run inside a sandbox.
+// TestRuntimeEnvNamesDoNotCollideWithClientEnv is the deployment half of the
+// MIR-1406 regression guard: every var Miren injects into a sandbox must live
+// under the reserved MIREN_RUNTIME_ sub-namespace. That is what makes collisions
+// impossible for any CLI var, present or future — the CLI reads no var under that
+// prefix. The CLI half, which derives the CLI's env-tag names by reflection and
+// asserts none reads an injected var, lives in cli/commands
+// (TestCLIEnvTagsDoNotReadInjectedVars) so it stays next to the flags it checks.
 func TestRuntimeEnvNamesDoNotCollideWithClientEnv(t *testing.T) {
-	// The structural guarantee: injected vars live under the reserved MIREN_RUNTIME_
-	// sub-namespace, and the CLI reads no var under that prefix. This is what makes
-	// collisions impossible for *future* CLI vars too — a new MIREN_FOO the CLI adds
-	// cannot match a MIREN_RUNTIME_* injected name. The allowlist below can't catch
-	// that on its own, since it only knows today's CLI vars.
-	t.Run("all injected names use the reserved prefix", func(t *testing.T) {
-		for _, injected := range appclient.RuntimeEnvNames {
-			assert.True(t, strings.HasPrefix(injected, "MIREN_RUNTIME_"),
-				"%s is injected but not under MIREN_RUNTIME_ — it could collide with a CLI var", injected)
-		}
-	})
-
-	// A concrete regression check for the specific MIR-1406 collision. This list is
-	// hand-maintained; keep it in sync with the env:"..." struct tags in cli/commands
-	// (app.go, config.go) and the os.Getenv calls in cli/ and clientconfig/. It's a
-	// backstop for the prefix rule above, not the primary guarantee — a CLI var added
-	// without updating this list is still covered as long as it isn't MIREN_RUNTIME_*.
-	t.Run("no injected name matches a known CLI var", func(t *testing.T) {
-		clientEnv := []string{
-			"MIREN_APP",
-			"MIREN_CLUSTER",
-			"MIREN_CONFIG",
-			"MIREN_THEME",
-			"MIREN_LABS",
-			"MIREN_CONTAINER_RUNTIME",
-			"MIREN_DISK_MODE",
-			"MIREN_HELP_JSON",
-			"MIREN_DIAL_PROGRAM",
-		}
-
-		for _, injected := range appclient.RuntimeEnvNames {
-			assert.NotContains(t, clientEnv, injected,
-				"%s is injected into sandboxes AND read by the client — that is the MIR-1406 collision", injected)
-		}
-	})
+	for _, injected := range appclient.RuntimeEnvNames {
+		assert.True(t, strings.HasPrefix(injected, "MIREN_RUNTIME_"),
+			"%s is injected but not under MIREN_RUNTIME_ — it could collide with a CLI var", injected)
+	}
 }
 
 // TestCreatePoolForVersionEphemeral verifies that the web pool of an ephemeral

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/sys/unix"
+	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/components/netresolve"
 	"miren.dev/runtime/network"
 	"miren.dev/runtime/observability"
@@ -2276,13 +2277,13 @@ func (c *SandboxController) buildSubContainerSpec(
 		}
 	}
 
-	// Extract instance number from metadata labels and inject MIREN_INSTANCE_NUM
+	// Extract instance number from metadata labels and inject the instance env var
 	envVars := co.Env
 	var md core_v1alpha.Metadata
 	md.Decode(meta)
 
 	if instanceStr, ok := md.Labels.Get("instance"); ok {
-		envVars = append([]string{fmt.Sprintf("MIREN_INSTANCE_NUM=%s", instanceStr)}, envVars...)
+		envVars = append([]string{fmt.Sprintf("%s=%s", appclient.EnvRuntimeInstanceNum, instanceStr)}, envVars...)
 		c.Log.Debug("injected instance number into container env", "sandbox_id", sb.ID, "container", co.Name, "instance", instanceStr)
 	}
 

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,10 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "2b69dc3c845199eee68f61fdd0d90df79b72609feacc5af59f3f01f1450c0951",
+		// Updated for MIR-1406 (MIREN_INSTANCE_NUM -> MIREN_RUNTIME_INSTANCE_NUM).
+		// The saga path builds no container env of its own, so there was no
+		// equivalent change to mirror in create_saga.go.
+		"sandbox.go":  "3ef46aaf0e5a62f3396389f95256d7abce9c84a49b3d1e445926cf579c94836b",
 		"volume.go":   "b4697764d48a90adc04ce47968ccef11ceba50da8d19c889906c5c3a539065b3",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -172,18 +172,18 @@ The `required` flag is useful for variables whose values differ per environment�
 
 #### Variables Miren Injects
 
-Every sandbox receives these automatically. You don't declare them, and your app can read them to find out what it is:
+Miren injects these automatically. You don't declare them, and your app can read them to find out what it is:
 
-| Variable | Value |
-|----------|-------|
-| `MIREN_RUNTIME_APP` | The app name |
-| `MIREN_RUNTIME_VERSION` | The deployed version, e.g. `v1` |
-| `MIREN_RUNTIME_INSTANCE_NUM` | This instance's number, starting at `0`. See [Scaling](/scaling). |
+| Variable | Value | Injected |
+|----------|-------|----------|
+| `MIREN_RUNTIME_APP` | The app name | Every sandbox |
+| `MIREN_RUNTIME_VERSION` | The deployed version, e.g. `v1` | Every sandbox |
+| `MIREN_RUNTIME_INSTANCE_NUM` | This instance's number, starting at `0`. See [Scaling](/scaling). | Instance-backed sandboxes only |
 
 Sandboxes also get `PORT` (the port your web service should listen on) and the [workload identity](/workload-identity) variables.
 
 :::info[Injected vs. CLI variables]
-`MIREN_RUNTIME_*` is the namespace Miren injects **into** your app. Every other `MIREN_*` variable — `MIREN_APP`, `MIREN_CLUSTER`, `MIREN_CONFIG` — is input **to** the `miren` CLI, used to pick what a command acts on (see [CI/CD Deployment](/ci-deploy)). Keeping them separate means running `miren` inside a sandbox still resolves the app from your `.miren/app.toml`.
+`MIREN_RUNTIME_*` is the namespace Miren injects **into** your app; the `MIREN_IDENTITY_*` [workload identity](/workload-identity) variables are injected too. The other `MIREN_*` variables — such as `MIREN_APP`, `MIREN_CLUSTER`, and `MIREN_CONFIG` — are input **to** the `miren` CLI, used to pick what a command acts on (see [CI/CD Deployment](/ci-deploy)). Keeping the injected and input variables separate means running `miren` inside a sandbox still resolves the app from your `.miren/app.toml`.
 :::
 
 :::warning[The MIREN_ prefix is reserved]

--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -170,6 +170,26 @@ description = "Third-party API key for payment processing"
 
 The `required` flag is useful for variables whose values differ per environment—declare them in `app.toml` with an empty value and `required = true`, then set the actual value with `miren env set` before deploying. The `sensitive` flag ensures secrets aren't accidentally exposed in terminal output.
 
+#### Variables Miren Injects
+
+Every sandbox receives these automatically. You don't declare them, and your app can read them to find out what it is:
+
+| Variable | Value |
+|----------|-------|
+| `MIREN_RUNTIME_APP` | The app name |
+| `MIREN_RUNTIME_VERSION` | The deployed version, e.g. `v1` |
+| `MIREN_RUNTIME_INSTANCE_NUM` | This instance's number, starting at `0`. See [Scaling](/scaling). |
+
+Sandboxes also get `PORT` (the port your web service should listen on) and the [workload identity](/workload-identity) variables.
+
+:::info[Injected vs. CLI variables]
+`MIREN_RUNTIME_*` is the namespace Miren injects **into** your app. Every other `MIREN_*` variable — `MIREN_APP`, `MIREN_CLUSTER`, `MIREN_CONFIG` — is input **to** the `miren` CLI, used to pick what a command acts on (see [CI/CD Deployment](/ci-deploy)). Keeping them separate means running `miren` inside a sandbox still resolves the app from your `.miren/app.toml`.
+:::
+
+:::warning[The MIREN_ prefix is reserved]
+You can't set your own variables under `MIREN_` — `miren env set MIREN_FOO=bar` fails with `cannot set MIREN_ environment variables`. Miren owns the whole namespace so it can add injected variables without colliding with yours. Name your own `APP_*` or anything else.
+:::
+
 ### Traffic Routing
 
 For HTTP services, Miren handles routing automatically. For non-HTTP services (TCP/UDP), you can expose ports directly using the `ports` array:

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -12,6 +12,7 @@ All notable changes to Miren Runtime will be documented in this file.
 *main*
 
 **Breaking Changes**
+- **Env vars injected into sandboxes moved to a `MIREN_RUNTIME_` prefix** - `MIREN_APP` meant two different things: the app name injected into your running sandbox, and the CLI's target app read from your own environment. Running `miren` inside a sandbox therefore picked up the sandbox's app and silently ignored the `.miren/app.toml` in front of it. The injected variables are now namespaced and no longer collide: `MIREN_APP` → `MIREN_RUNTIME_APP`, `MIREN_VERSION` → `MIREN_RUNTIME_VERSION`, `MIREN_INSTANCE_NUM` → `MIREN_RUNTIME_INSTANCE_NUM`. If your app reads any of the old names, update it before deploying — the old names are gone, not deprecated. `MIREN_APP` as a CLI input is unchanged, so CI pipelines that set it keep working, as do the `MIREN_IDENTITY_*` workload identity variables. See [App Configuration](/app-configuration#variables-miren-injects).
 - **LSVD disk volumes are no longer supported** - The legacy LSVD/NBD disk backend has been removed entirely, along with the one-time migration that converted LSVD volumes to the Universal (loop-device) format. That automatic migration shipped in **v0.6.0** and has run on first boot of every release since. If a node still holds un-migrated LSVD volume data when it reaches this release, that data can no longer be converted and the volume will not come back. Before upgrading to this version, upgrade to **at least v0.6.0** and boot it once so every LSVD volume is migrated first.
 
 ---

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -875,7 +875,7 @@ func isSystemEnvVar(key string) bool {
 	case "PORT", "ADMIN_TOKEN":
 		return true
 	}
-	return strings.HasPrefix(key, "MIREN_")
+	return app.IsReservedEnvVar(key)
 }
 
 // computeBuildEnvVars computes the merged set of environment variables to inject

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -867,10 +867,11 @@ func (b *Builder) checkLocalStorageMigration(ctx context.Context, appID entity.I
 }
 
 // isSystemEnvVar returns true if the given key is a system-managed env var
-// that should not be injected as a build arg.
+// that should not be injected as a build arg. The whole MIREN_ namespace is
+// reserved, so only the unprefixed names need naming here.
 func isSystemEnvVar(key string) bool {
 	switch key {
-	case "MIREN_VERSION", "MIREN_APP", "MIREN_INSTANCE_NUM", "PORT", "ADMIN_TOKEN":
+	case "PORT", "ADMIN_TOKEN":
 		return true
 	}
 	return strings.HasPrefix(key, "MIREN_")

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -868,7 +868,8 @@ func (b *Builder) checkLocalStorageMigration(ctx context.Context, appID entity.I
 
 // isSystemEnvVar returns true if the given key is a system-managed env var
 // that should not be injected as a build arg. The whole MIREN_ namespace is
-// reserved, so only the unprefixed names need naming here.
+// reserved (the injected MIREN_RUNTIME_* vars are enumerated in
+// api/app/runtimeenv.go), so only the unprefixed names need explicit cases here.
 func isSystemEnvVar(key string) bool {
 	switch key {
 	case "PORT", "ADMIN_TOKEN":

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -1700,10 +1701,13 @@ func TestIsSystemEnvVar(t *testing.T) {
 		key      string
 		isSystem bool
 	}{
-		{"MIREN_VERSION", true},
-		{"MIREN_APP", true},
-		{"MIREN_INSTANCE_NUM", true},
+		// The entire MIREN_ namespace is reserved, whoever set it.
+		{appclient.EnvRuntimeApp, true},
+		{appclient.EnvRuntimeVersion, true},
+		{appclient.EnvRuntimeInstanceNum, true},
 		{"MIREN_CUSTOM", true},
+		{"MIREN_", true},
+		// Unprefixed system vars, named explicitly.
 		{"PORT", true},
 		{"ADMIN_TOKEN", true},
 		{"DATABASE_URL", false},
@@ -1712,6 +1716,7 @@ func TestIsSystemEnvVar(t *testing.T) {
 		{"SECRET_KEY_BASE", false},
 		{"MY_PORT", false},
 		{"PORTNAME", false},
+		{"MIRENISH", false},
 	}
 
 	for _, tt := range tests {
@@ -1784,8 +1789,8 @@ func TestComputeBuildEnvVars(t *testing.T) {
 			name: "system vars are filtered out",
 			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "DATABASE_URL", Value: "postgres://localhost/db", Source: "manual"},
-				{Key: "MIREN_VERSION", Value: "v1", Source: "config"},
-				{Key: "MIREN_APP", Value: "myapp", Source: "config"},
+				{Key: appclient.EnvRuntimeVersion, Value: "v1", Source: "config"},
+				{Key: appclient.EnvRuntimeApp, Value: "myapp", Source: "config"},
 				{Key: "PORT", Value: "8080", Source: "manual"},
 				{Key: "ADMIN_TOKEN", Value: "token123", Source: "manual"},
 				{Key: "MIREN_CUSTOM", Value: "custom", Source: "config"},

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -355,9 +355,14 @@ func (s *Server) buildSandboxSpec(
 		Directory: startDir,
 	}
 
-	// Add global config env vars
+	// Add global config env vars, stripping any reserved MIREN_ keys so user
+	// config can't shadow the injected sandbox metadata above (mirrors the
+	// filter in controllers/deployment/launcher.go).
 	envMap := make(map[string]string)
 	for _, x := range cfgSpec.Variables {
+		if appclient.IsReservedEnvVar(x.Key) {
+			continue
+		}
 		envMap[x.Key] = x.Value
 	}
 

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -345,8 +346,8 @@ func (s *Server) buildSandboxSpec(
 		Name:  "app",
 		Image: image,
 		Env: []string{
-			"MIREN_APP=" + appMD.Name,
-			"MIREN_VERSION=" + ver.Version,
+			appclient.EnvRuntimeApp + "=" + appMD.Name,
+			appclient.EnvRuntimeVersion + "=" + ver.Version,
 		},
 		Directory: startDir,
 	}

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -346,6 +346,9 @@ func (s *Server) buildSandboxSpec(
 		Name:  "app",
 		Image: image,
 		Env: []string{
+			// EnvRuntimeInstanceNum is deliberately omitted here: the sandbox
+			// controller injects it at boot from the instance metadata label
+			// (see controllers/sandbox), and exec sandboxes aren't instance-backed.
 			appclient.EnvRuntimeApp + "=" + appMD.Name,
 			appclient.EnvRuntimeVersion + "=" + ver.Version,
 		},


### PR DESCRIPTION
## Problem

`MIREN_APP` meant two contradictory things:

- **Injected into every sandbox** as the running app's name (`controllers/deployment/launcher.go`, `servers/exec_proxy/exec_proxy.go`).
- **Read by the CLI** as the user's target app (`cli/commands/app.go`, via an mflags `env:` tag).

Because mflags applies `env:` as the flag *default*, and a set default outranks the `.miren/app.toml` fallback, running `miren` inside a sandbox silently targeted the sandbox's app and ignored the app config in front of it. That's the ticket's "causes issues with using the CLI inside a sandbox."

## Fix

Move the injected vars to a `MIREN_RUNTIME_` namespace the CLI never reads:

| Old | New |
|-----|-----|
| `MIREN_APP` | `MIREN_RUNTIME_APP` |
| `MIREN_VERSION` | `MIREN_RUNTIME_VERSION` |
| `MIREN_INSTANCE_NUM` | `MIREN_RUNTIME_INSTANCE_NUM` |

The rule is now: **`MIREN_RUNTIME_*` is injected into your app; every other `MIREN_*` is CLI input.** Clean break — no legacy names. The CLI's `MIREN_APP` input (documented for CI) and the `MIREN_IDENTITY_*` workload identity vars are unchanged.

## Notes for reviewers

- **Breaking change, by design.** Apps reading `MIREN_APP`/`MIREN_VERSION` break on next deploy. Documented in the changelog with the old→new mapping. Dual-injecting would leave `MIREN_APP` in the sandbox and therefore leave the bug unfixed.
- **Names defined once** in the new `api/app/runtimeenv.go` instead of the literal being retyped across five files.
- **Dead-code cleanup:** both copies of `isSystemEnvVar` already fell through to a `MIREN_` prefix check, so the explicit `MIREN_*` switch cases did nothing — dropped, leaving `PORT`/`ADMIN_TOKEN` + the prefix.
- **Frozen-file hash updated:** `sandbox.go` is guarded by `sandbox_frozen_test.go` pending the saga cutover. Per its instructions I audited the saga path — `create_saga.go` builds no container env, so there was nothing to mirror.
- **New coverage** for the gap that let this ship: a launcher test asserting the runtime vars land in the sandbox spec (and the old names don't), plus a regression test asserting no injected name collides with a var the CLI reads. Both were mutation-tested — they fail against the old behavior and pass after.

## Verification

- `make lint` (Go + docs) clean; affected package tests pass.
- Verified end-to-end on a deployed app: a real sandbox shows `MIREN_RUNTIME_APP` / `MIREN_RUNTIME_VERSION` / `MIREN_RUNTIME_INSTANCE_NUM=0` with `PORT` intact and no bare `MIREN_APP`. Running the CLI from a dir with no `app.toml` and the old `MIREN_APP` set reproduces the hijack; with `MIREN_RUNTIME_APP` set it correctly errors asking for an app.

## Follow-up (not in this PR)

`MIREN_VERSION` still carries two other unrelated meanings — the image build arg and which miren release CI downloads. Tracked separately.