### PR TITLE
Emit etcd health metrics promptly on startup instead of up to 5 minutes late

### DIFF
--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -87,12 +87,29 @@ type EtcdComponent struct {
 	// via SetMetricsWriter after the metrics subsystem comes up (which happens after etcd
 	// and its maintenance loop have already started), so access is atomic. Nil-safe.
 	writer atomic.Pointer[metrics.VictoriaMetricsWriter]
+
+	// metricsKick nudges the maintenance loop to run a check the moment the metrics
+	// writer is attached. The writer only exists after the embedded VictoriaMetrics
+	// address is known, which is well after the loop's immediate startup check — so
+	// without this the first health sample would be up to maintenanceInterval late
+	// (and, on a cluster that restarts more often than that, effectively never). It is
+	// buffered so SetMetricsWriter never blocks even if the loop is still connecting.
+	metricsKick chan struct{}
 }
 
 // SetMetricsWriter configures the metrics sink for the maintenance loop's health gauges.
 // Safe to call with nil or at any time (the maintenance loop reads it atomically each tick).
 func (e *EtcdComponent) SetMetricsWriter(w *metrics.VictoriaMetricsWriter) {
 	e.writer.Store(w)
+	if w == nil {
+		return
+	}
+	// Land a fresh sample now instead of waiting for the next periodic tick. Coalesces:
+	// if a kick is already pending the loop will pick up the latest writer anyway.
+	select {
+	case e.metricsKick <- struct{}{}:
+	default:
+	}
 }
 
 func NewEtcdComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPath string) *EtcdComponent {
@@ -105,6 +122,7 @@ func NewEtcdComponent(log *slog.Logger, cc *containerd.Client, namespace, dataPa
 
 	e := &EtcdComponent{
 		BaseComponent: bc,
+		metricsKick:   make(chan struct{}, 1),
 	}
 
 	// Set up callbacks for the base component

--- a/components/etcd/maintenance.go
+++ b/components/etcd/maintenance.go
@@ -100,6 +100,11 @@ func (e *EtcdComponent) maintenanceLoop(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			e.runMaintenanceCheck(ctx, client, endpoint)
+		case <-e.metricsKick:
+			// The metrics writer was just attached (see SetMetricsWriter); run a check
+			// now so the first health sample lands promptly rather than up to a full
+			// interval later. The immediate check above ran before the writer existed.
+			e.runMaintenanceCheck(ctx, client, endpoint)
 		case <-ctx.Done():
 			return
 		}

--- a/components/etcd/metrics_kick_test.go
+++ b/components/etcd/metrics_kick_test.go
@@ -1,0 +1,47 @@
+package etcd
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/metrics"
+)
+
+// TestSetMetricsWriterKicksMaintenanceLoop verifies that attaching a metrics writer
+// enqueues a single, non-blocking nudge for the maintenance loop. The loop consumes
+// this to emit a health sample promptly instead of waiting for the next periodic tick
+// (the writer is attached well after the loop's immediate startup check).
+func TestSetMetricsWriterKicksMaintenanceLoop(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	e := NewEtcdComponent(log, nil, "test", t.TempDir())
+
+	// A nil writer clears the sink but must not enqueue a kick — there is nothing to
+	// emit to, so waking the loop would just log a status line into the void.
+	e.SetMetricsWriter(nil)
+	select {
+	case <-e.metricsKick:
+		t.Fatal("nil writer should not enqueue a maintenance kick")
+	default:
+	}
+
+	// Attaching a real writer enqueues a kick, and repeated attaches coalesce onto the
+	// single buffered slot rather than blocking (the loop will read the latest writer
+	// anyway via the atomic pointer).
+	w := metrics.NewVictoriaMetricsWriter(log, "localhost:8428", time.Second)
+	e.SetMetricsWriter(w)
+	e.SetMetricsWriter(w)
+	e.SetMetricsWriter(w)
+
+	select {
+	case <-e.metricsKick:
+	default:
+		t.Fatal("attaching a metrics writer should enqueue a maintenance kick")
+	}
+	select {
+	case <-e.metricsKick:
+		t.Fatal("kicks should coalesce to a single pending signal")
+	default:
+	}
+}


### PR DESCRIPTION
While running the etcd reliability changes from #900 through a live cluster (MIR-1398), the smoke test turned up a gap in the new health metrics. The etcd gauges (db size, in-use, quota headroom, bloat ratio, NOSPACE alarm) are emitted from the maintenance loop, which reads the metrics writer atomically on each tick. The catch is *when* that writer shows up: it cannot be constructed until the embedded VictoriaMetrics address is known, and by the boot ordering in `server.go` that happens well after etcd has started and its maintenance loop has already run its immediate startup check. So the writer is nil for the check that matters most.

The practical fallout is that the first health sample was up to a full maintenance interval (five minutes) late. On a cluster that restarts more often than that, the ticker resets every boot and the gauges effectively never emit. The sharp edge is a startup NOSPACE self-recovery: the maintenance loop's immediate check will compact, defrag, and disarm a wedged etcd within seconds of boot, which is exactly the incident this hardening was built for, and it does all of that while emitting zero metrics. The self-heal works, but it is invisible to monitoring precisely when you would want the signal.

Rather than fight the boot order (moving VictoriaMetrics ahead of etcd is its own readiness-graph question, tracked in MIR-1290), this just closes the loop the moment the writer does arrive. `SetMetricsWriter` now drops a non-blocking signal on a small buffered channel, and the maintenance loop's select wakes on it to run a check right away. A fresh sample lands within seconds of boot instead of waiting for the first tick.

Verified live on a dev cluster: with a distinctive 37 MB state loaded, a restart onto the patched binary emitted a fresh sample during startup (~5 seconds before full readiness), where the old code left the series stale for the usual five minutes.

This is a partial fix by design. It makes the gauges emit promptly, but a startup remediation still is not observable as a discrete *event* (by the time the writer attaches, etcd is already recovered and the gauges read healthy). Capturing that wants a persisted recovery counter, which belongs with the operational-metrics forwarding work in MIR-1390.

Refs MIR-1398, #900. Related: MIR-1290, MIR-1390.