### PR TITLE
Fix `miren app restart` reporting 0 sandboxes and stopping nothing

### DIFF
--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -732,10 +732,13 @@ func (r *AppInfo) Restart(ctx context.Context, state *app_v1alpha.CrudRestart) e
 			}
 
 			if err := r.EC.Patch(ctx, sb.ID, 0,
-				entity.Ref(compute_v1alpha.SandboxStatusId, entity.Id(compute_v1alpha.STOPPED)),
+				entity.Ref(compute_v1alpha.SandboxStatusId, compute_v1alpha.SandboxStatusStoppedId),
 			); err != nil {
-				r.Log.Warn("failed to stop sandbox", "sandbox", sb.ID, "error", err)
-				continue
+				// Surface stop failures loudly instead of swallowing them.
+				// The original bug reported "0 sandboxes" success while
+				// silently failing to stop anything; a restart that can't
+				// stop a sandbox it found must not look like it worked.
+				return fmt.Errorf("stopping sandbox %s: %w", sb.ID, err)
 			}
 			stoppedSandboxes++
 		}

--- a/servers/app/restart_test.go
+++ b/servers/app/restart_test.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+// TestAppRestart_StopsRunningSandboxes guards MIR-1288/MIR-1410: restart used to
+// patch sandbox status with the short-form enum ref entity.Id(STOPPED)
+// ("status.stopped") instead of the fully-qualified SandboxStatusStoppedId. The
+// ref never resolved, so the sandbox never actually stopped and the command
+// reported "0 sandboxes" while doing nothing.
+func TestAppRestart_StopsRunningSandboxes(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+
+	appInfo := &AppInfo{
+		Log:  slog.Default(),
+		EC:   ec,
+		CPU:  &metrics.CPUUsage{},
+		Mem:  &metrics.MemoryUsage{},
+		HTTP: &metrics.HTTPMetrics{},
+	}
+
+	client := &app_v1alpha.CrudClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptCrud(appInfo)),
+	}
+
+	// App with a single web pool holding one RUNNING sandbox.
+	appName := "restart-app"
+	appID, err := ec.Create(ctx, appName, &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	pool := &compute_v1alpha.SandboxPool{App: appID, Service: "web"}
+	poolID, err := ec.Create(ctx, "restart-app-pool", pool)
+	require.NoError(t, err)
+
+	sb := &compute_v1alpha.Sandbox{Status: compute_v1alpha.RUNNING}
+	sbID, err := ec.Create(ctx, "restart-app-sb", sb,
+		entityserver.WithLabels(types.LabelSet("pool", poolID.String())))
+	require.NoError(t, err)
+
+	result, err := client.Restart(ctx, appName, "")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), result.RestartedPools(), "should restart the one pool")
+	require.Equal(t, int32(1), result.StoppedSandboxes(), "should count the stopped sandbox")
+
+	// The real regression guard: the sandbox must actually decode back to
+	// STOPPED. With the pre-fix short-form ref it decoded to "" (silent no-op).
+	var stopped compute_v1alpha.Sandbox
+	require.NoError(t, ec.GetById(ctx, sbID, &stopped))
+	require.Equal(t, compute_v1alpha.STOPPED, stopped.Status,
+		"sandbox should be STOPPED after restart, not left in a stale/empty status")
+}


### PR DESCRIPTION
`miren app restart` had been quietly broken: it always printed "stopped 0 sandboxes" and, worse, didn't actually stop anything. This came in as MIR-1410, but digging in turned up that the root cause was already filed as MIR-1288, so this closes that one and folds in the duplicate reports.

The restart handler stops each running sandbox by patching its status to STOPPED. The bug was in how it built the reference: `entity.Id(compute_v1alpha.STOPPED)` produces `"status.stopped"`, the enum's display string, when the actual entity id is the fully-qualified `SandboxStatusStoppedId` (`"dev.miren.compute/status.stopped"`). That ref pointed at an entity that doesn't exist, so the validator rejected every write, and the loop swallowed the rejection with a warn-and-continue. The counter never incremented (hence "0"), and no sandbox ever moved.

The fix itself is one line: use `SandboxStatusStoppedId`. I went with the single-ref form rather than encoding a whole `Sandbox{Status: STOPPED}`, because create_saga.go already documents that the encoder form emits defaults like `hostNetwork=false` and clobbers real values on a patch.

While in there, I stopped the loop from swallowing the stop error. That warn-and-continue is exactly what turned a caught validator rejection into a silent success. A restart that finds a sandbox and can't stop it should fail loudly, not tell you it worked.

There was no server-level test for AppRestart, which is how this shipped, so this adds one. It fails on the old ref (the sandbox status decodes back to empty) and passes on the fix. I also smoke-tested it in the standalone dev env: deployed a two-pool app, ran `m app restart`, and watched it report "stopped 2 sandboxes across 2 pools" while the old sandboxes went dead and fresh ones came up.

Two follow-ups came out of this that are intentionally not here: MIR-1424 (restart should escalate to a hard kill for wedged processes and block until the restart is confirmed) and MIR-1425 (teach the entity validator to enforce schema.Choices on ref writes, so this whole class of bad-enum-ref mistake gets caught centrally).

Closes MIR-1288