### PR TITLE
docs: clarify which commands auto-deploy

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -1082,9 +1082,9 @@ Warning: These commands are intended for advanced users and developers. They may
 	addCommands(d)
 }
 
-// Extended markdown descriptions for commands that create a new app version.
-// These render in the generated command docs (docs/docs/command/*.md) and
-// clarify which operations roll out automatically versus require a rebuild.
+// Extended markdown descriptions for lifecycle commands. These render in the
+// generated command docs (docs/docs/command/*.md) and clarify which operations
+// roll out automatically versus require a rebuild.
 
 const deployDescription = `Deploy uploads your source, builds a new container image on the server, and activates the resulting version — replacing the previously running one. This is the only command that rebuilds your image.
 
@@ -1124,7 +1124,7 @@ Environment variable changes take effect on their own. Running ` + "`" + `miren 
 const envDeleteDescription = `Deleting an environment variable creates a new app version and rolls it out automatically — you do not need to run ` + "`" + `miren deploy` + "`" + ` or ` + "`" + `miren app restart` + "`" + ` afterward. The new version reuses your existing container image (no rebuild), and the command waits for it to become healthy before returning.
 
 :::warning[Deploy app.toml changes first]
-` + "`" + `miren env delete` + "`" + ` builds the new version by copying the *current server-side* spec, not your local ` + "`" + `app.toml` + "`" + `. If you have pending ` + "`" + `app.toml` + "`" + ` changes, deploy them first, then delete the stale variable — otherwise the delete will roll back your unsent changes. Variables declared in ` + "`" + `app.toml` + "`" + ` drop automatically when you remove them from the file and redeploy.
+` + "`" + `miren env delete` + "`" + ` builds the new version by copying the *current server-side* spec, not your local ` + "`" + `app.toml` + "`" + `. If you have pending ` + "`" + `app.toml` + "`" + ` changes, deploy them first, then delete the stale variable — otherwise the delete rolls out the server-side spec and your local edits won't be included. Variables declared in ` + "`" + `app.toml` + "`" + ` drop automatically when you remove them from the file and redeploy.
 :::`
 
 const addonCreateDescription = `Attaching an addon provisions the backing resource and injects its connection details as environment variables into your app. Once provisioning completes, Miren creates a new app version with those variables and rolls it out automatically — you do not need to run ` + "`" + `miren deploy` + "`" + ` or ` + "`" + `miren app restart` + "`" + `. The rollout is deferred until the addon finishes provisioning, so it may not be immediate.`

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -89,6 +89,7 @@ func RegisterAll(d *mflags.Dispatcher) {
 	))
 	d.Dispatch("deploy", Infer("deploy", "Deploy an application", Deploy,
 		WithGroup(GroupGettingStarted),
+		WithDescription(deployDescription),
 		WithExample(mflags.Example{
 			Name: "Basic",
 			Body: "miren deploy",
@@ -122,6 +123,7 @@ miren deploy --analyze
 	))
 	d.Dispatch("rollback", Infer("rollback", "Roll back to a previous version", Rollback,
 		WithGroup(GroupGettingStarted),
+		WithDescription(rollbackDescription),
 		WithExample(mflags.Example{
 			Name: "Rollback the app in the current directory",
 			Body: "miren rollback",
@@ -258,6 +260,7 @@ miren deploy --analyze
 		}),
 	))
 	d.Dispatch("app restart", Infer("app restart", "Restart an application", AppRestart,
+		WithDescription(appRestartDescription),
 		WithExample(mflags.Example{
 			Name: "Restart the current app",
 			Body: "miren app restart",
@@ -362,6 +365,7 @@ miren deploy --analyze
 	// Environment variable commands
 	d.Dispatch("env", Section("env", "Environment variable management commands", "", WithSectionGroup(GroupConfiguring)))
 	d.Dispatch("env set", Infer("env set", "Set environment variables for an application", EnvSet,
+		WithDescription(envSetDescription),
 		WithExample(mflags.Example{
 			Name: "Set an environment variable",
 			Body: "miren env set -e DATABASE_URL=postgres://localhost/mydb",
@@ -400,6 +404,7 @@ miren deploy --analyze
 		}),
 	))
 	d.Dispatch("env delete", Infer("env delete", "Delete environment variables", EnvDelete,
+		WithDescription(envDeleteDescription),
 		WithExample(mflags.Example{
 			Name: "Delete a variable",
 			Body: "miren env delete DATABASE_URL",
@@ -429,6 +434,7 @@ miren deploy --analyze
 		}),
 	))
 	d.Dispatch("addon create", Infer("addon create", "Attach an addon to an application", AddonCreate,
+		WithDescription(addonCreateDescription),
 		WithExample(mflags.Example{
 			Name: "Attach a PostgreSQL addon",
 			Body: "miren addon create miren-postgresql:small",
@@ -445,6 +451,7 @@ miren deploy --analyze
 		}),
 	))
 	d.Dispatch("addon destroy", Infer("addon destroy", "Remove an addon from an application", AddonDestroy,
+		WithDescription(addonDestroyDescription),
 		WithExample(mflags.Example{
 			Name: "Remove an addon",
 			Body: "miren addon destroy miren-postgresql",
@@ -1074,3 +1081,52 @@ Warning: These commands are intended for advanced users and developers. They may
 
 	addCommands(d)
 }
+
+// Extended markdown descriptions for commands that create a new app version.
+// These render in the generated command docs (docs/docs/command/*.md) and
+// clarify which operations roll out automatically versus require a rebuild.
+
+const deployDescription = `Deploy uploads your source, builds a new container image on the server, and activates the resulting version — replacing the previously running one. This is the only command that rebuilds your image.
+
+To activate a previously built version without rebuilding, pass ` + "`" + `--version` + "`" + `:
+` + "```" + `bash
+miren deploy --version myapp-vCVkjR6u7744AsMebwMjGU
+` + "```" + `
+This reuses the existing image and rolls it out immediately — useful for rolling forward to a known-good version without waiting for a build. Find version IDs with ` + "`" + `miren app history` + "`" + `.
+
+:::note[Config changes deploy on their own]
+Changing environment variables (` + "`" + `miren env set` + "`" + ` / ` + "`" + `miren env delete` + "`" + `) or addons (` + "`" + `miren addon create` + "`" + ` / ` + "`" + `miren addon destroy` + "`" + `) already creates and rolls out a new version. You only need ` + "`" + `miren deploy` + "`" + ` when your code or ` + "`" + `app.toml` + "`" + ` has changed.
+:::`
+
+const rollbackDescription = `Rollback re-activates a previous version by reusing its already-built image — no rebuild happens. It presents a picker of recent successful deployments and rolls out the one you choose immediately. The currently active version is excluded since rolling back to it would be a no-op.
+
+Rollback creates a new deployment record; it does not erase history.`
+
+const appRestartDescription = `Restart stops your app's running sandboxes and lets the pool manager re-create them from the *current* active version. It does not create a new version, change any configuration, or rebuild your image — the app comes back on exactly the spec it was already running.
+
+Use restart to:
+- Clear stuck or wedged process state
+- Reset the crash-loop cooldown so a crashing app is retried immediately
+- Pick up data restored out-of-band (for example, after ` + "`" + `miren disk restore` + "`" + `)
+
+:::note[Config and env changes restart on their own]
+You do not need to restart after ` + "`" + `miren env set` + "`" + `, ` + "`" + `miren env delete` + "`" + `, ` + "`" + `miren addon create` + "`" + `, or ` + "`" + `miren addon destroy` + "`" + `. Each of those already creates a new version and rolls out new sandboxes automatically. A manual restart on top only adds a redundant rollout.
+:::`
+
+const envSetDescription = `Setting an environment variable creates a new app version and rolls it out automatically — you do not need to run ` + "`" + `miren deploy` + "`" + ` or ` + "`" + `miren app restart` + "`" + ` afterward. The new version reuses your existing container image (no rebuild); Miren boots new sandboxes with the updated environment and drains the old ones. The command waits for the new version to become healthy before returning.
+
+Use ` + "`" + `-e` + "`" + ` for plain values and ` + "`" + `-s` + "`" + ` for sensitive values (masked in output and logs). A "secret" is simply an env var set with ` + "`" + `-s` + "`" + ` — there is no separate secret command. Pass ` + "`" + `--service` + "`" + ` to scope the change to a single service instead of all services.
+
+:::note[No restart needed]
+Environment variable changes take effect on their own. Running ` + "`" + `miren app restart` + "`" + ` afterward only triggers a redundant second rollout.
+:::`
+
+const envDeleteDescription = `Deleting an environment variable creates a new app version and rolls it out automatically — you do not need to run ` + "`" + `miren deploy` + "`" + ` or ` + "`" + `miren app restart` + "`" + ` afterward. The new version reuses your existing container image (no rebuild), and the command waits for it to become healthy before returning.
+
+:::warning[Deploy app.toml changes first]
+` + "`" + `miren env delete` + "`" + ` builds the new version by copying the *current server-side* spec, not your local ` + "`" + `app.toml` + "`" + `. If you have pending ` + "`" + `app.toml` + "`" + ` changes, deploy them first, then delete the stale variable — otherwise the delete will roll back your unsent changes. Variables declared in ` + "`" + `app.toml` + "`" + ` drop automatically when you remove them from the file and redeploy.
+:::`
+
+const addonCreateDescription = `Attaching an addon provisions the backing resource and injects its connection details as environment variables into your app. Once provisioning completes, Miren creates a new app version with those variables and rolls it out automatically — you do not need to run ` + "`" + `miren deploy` + "`" + ` or ` + "`" + `miren app restart` + "`" + `. The rollout is deferred until the addon finishes provisioning, so it may not be immediate.`
+
+const addonDestroyDescription = `Removing an addon deprovisions the backing resource and strips its injected environment variables from your app. Miren creates a new app version without those variables and rolls it out automatically — you do not need to run ` + "`" + `miren deploy` + "`" + ` or ` + "`" + `miren app restart` + "`" + `.`

--- a/docs/docs/command/addon-create.md
+++ b/docs/docs/command/addon-create.md
@@ -8,6 +8,8 @@ description: "Attach an addon to an application"
 
 Attach an addon to an application
 
+Attaching an addon provisions the backing resource and injects its connection details as environment variables into your app. Once provisioning completes, Miren creates a new app version with those variables and rolls it out automatically — you do not need to run `miren deploy` or `miren app restart`. The rollout is deferred until the addon finishes provisioning, so it may not be immediate.
+
 ## Usage
 
 ```bash

--- a/docs/docs/command/addon-destroy.md
+++ b/docs/docs/command/addon-destroy.md
@@ -8,6 +8,8 @@ description: "Remove an addon from an application"
 
 Remove an addon from an application
 
+Removing an addon deprovisions the backing resource and strips its injected environment variables from your app. Miren creates a new app version without those variables and rolls it out automatically — you do not need to run `miren deploy` or `miren app restart`.
+
 ## Usage
 
 ```bash

--- a/docs/docs/command/app-restart.md
+++ b/docs/docs/command/app-restart.md
@@ -8,6 +8,17 @@ description: "Restart an application"
 
 Restart an application
 
+Restart stops your app's running sandboxes and lets the pool manager re-create them from the *current* active version. It does not create a new version, change any configuration, or rebuild your image — the app comes back on exactly the spec it was already running.
+
+Use restart to:
+- Clear stuck or wedged process state
+- Reset the crash-loop cooldown so a crashing app is retried immediately
+- Pick up data restored out-of-band (for example, after `miren disk restore`)
+
+:::note[Config and env changes restart on their own]
+You do not need to restart after `miren env set`, `miren env delete`, `miren addon create`, or `miren addon destroy`. Each of those already creates a new version and rolls out new sandboxes automatically. A manual restart on top only adds a redundant rollout.
+:::
+
 ## Usage
 
 ```bash

--- a/docs/docs/command/deploy.md
+++ b/docs/docs/command/deploy.md
@@ -8,6 +8,18 @@ description: "Deploy an application"
 
 Deploy an application
 
+Deploy uploads your source, builds a new container image on the server, and activates the resulting version — replacing the previously running one. This is the only command that rebuilds your image.
+
+To activate a previously built version without rebuilding, pass `--version`:
+```bash
+miren deploy --version myapp-vCVkjR6u7744AsMebwMjGU
+```
+This reuses the existing image and rolls it out immediately — useful for rolling forward to a known-good version without waiting for a build. Find version IDs with `miren app history`.
+
+:::note[Config changes deploy on their own]
+Changing environment variables (`miren env set` / `miren env delete`) or addons (`miren addon create` / `miren addon destroy`) already creates and rolls out a new version. You only need `miren deploy` when your code or `app.toml` has changed.
+:::
+
 ## Usage
 
 ```bash

--- a/docs/docs/command/env-delete.md
+++ b/docs/docs/command/env-delete.md
@@ -8,6 +8,12 @@ description: "Delete environment variables"
 
 Delete environment variables
 
+Deleting an environment variable creates a new app version and rolls it out automatically — you do not need to run `miren deploy` or `miren app restart` afterward. The new version reuses your existing container image (no rebuild), and the command waits for it to become healthy before returning.
+
+:::warning[Deploy app.toml changes first]
+`miren env delete` builds the new version by copying the *current server-side* spec, not your local `app.toml`. If you have pending `app.toml` changes, deploy them first, then delete the stale variable — otherwise the delete will roll back your unsent changes. Variables declared in `app.toml` drop automatically when you remove them from the file and redeploy.
+:::
+
 ## Usage
 
 ```bash

--- a/docs/docs/command/env-delete.md
+++ b/docs/docs/command/env-delete.md
@@ -11,7 +11,7 @@ Delete environment variables
 Deleting an environment variable creates a new app version and rolls it out automatically — you do not need to run `miren deploy` or `miren app restart` afterward. The new version reuses your existing container image (no rebuild), and the command waits for it to become healthy before returning.
 
 :::warning[Deploy app.toml changes first]
-`miren env delete` builds the new version by copying the *current server-side* spec, not your local `app.toml`. If you have pending `app.toml` changes, deploy them first, then delete the stale variable — otherwise the delete will roll back your unsent changes. Variables declared in `app.toml` drop automatically when you remove them from the file and redeploy.
+`miren env delete` builds the new version by copying the *current server-side* spec, not your local `app.toml`. If you have pending `app.toml` changes, deploy them first, then delete the stale variable — otherwise the delete rolls out the server-side spec and your local edits won't be included. Variables declared in `app.toml` drop automatically when you remove them from the file and redeploy.
 :::
 
 ## Usage

--- a/docs/docs/command/env-set.md
+++ b/docs/docs/command/env-set.md
@@ -8,6 +8,14 @@ description: "Set environment variables for an application"
 
 Set environment variables for an application
 
+Setting an environment variable creates a new app version and rolls it out automatically — you do not need to run `miren deploy` or `miren app restart` afterward. The new version reuses your existing container image (no rebuild); Miren boots new sandboxes with the updated environment and drains the old ones. The command waits for the new version to become healthy before returning.
+
+Use `-e` for plain values and `-s` for sensitive values (masked in output and logs). A "secret" is simply an env var set with `-s` — there is no separate secret command. Pass `--service` to scope the change to a single service instead of all services.
+
+:::note[No restart needed]
+Environment variable changes take effect on their own. Running `miren app restart` afterward only triggers a redundant second rollout.
+:::
+
 ## Usage
 
 ```bash

--- a/docs/docs/command/rollback.md
+++ b/docs/docs/command/rollback.md
@@ -8,6 +8,10 @@ description: "Roll back to a previous version"
 
 Roll back to a previous version
 
+Rollback re-activates a previous version by reusing its already-built image — no rebuild happens. It presents a picker of recent successful deployments and rolls out the one you choose immediately. The currently active version is excluded since rolling back to it would be a no-op.
+
+Rollback creates a new deployment record; it does not erase history.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Problem

Agents reading the docs tell users to restart their app after changing env vars. That advice is wrong — `miren env set` and `miren env delete` already create a new app version and roll it out automatically. A follow-up `miren app restart` is just a redundant second rollout.

The docs never said this. The behavior was recorded **only** in `docs/docs/changelog.md` — not in `deployment.md`, not in `app-configuration.md`, not in any language guide, and not in the generated `command/env-set.md`. The one page describing env-change redeploy semantics was buried in a recipe (`recipes/hermes-agent.md`). A reader — human or agent — had no way to learn the truth.

## Approach

State the deploy behavior in the docs for **each individual command that causes a deploy**, so it's impossible to read the command's docs and miss it.

`docs/docs/command/*` is generated, so the prose lives in the CLI source via the existing `WithDescription` hook (`cli/commands/infer.go`), which `hack/gen-command-docs` emits directly below the command synopsis.

| Command | Now documents |
|---|---|
| `deploy` | The only command that rebuilds; `--version` activates an existing image with no build |
| `rollback` | Re-activates a previous image, no rebuild |
| `env set` | New version, no rebuild, no restart needed, waits for healthy |
| `env delete` | Same, plus: copies the **current server-side spec**, not local `app.toml` — deploy `app.toml` changes first |
| `addon create` / `addon destroy` | New version rolls out automatically, deferred until provisioning completes |
| `app restart` | Creates **no** new version, and is **not** needed after any of the above |

`app restart` is the direct antidote to the reported bug.

## Verification

- `MIREN_HELP_JSON=1 bin/miren` confirms the descriptions reach the generator
- `go generate ./cli/commands/` touched only the 7 intended pages — no unrelated churn
- `bun run lint` ✓ · `bun run build` ✓ (admonitions parse) · `make lint` → 0 issues

## Notes

Behavior was verified against the code, not assumed. Everything pivots on `App.ActiveVersion` — writing it triggers a rollout (`controllers/deployment/launcher.go`), and config-only changes reuse the existing image rather than rebuilding.

Claims are scoped deliberately: `app restart` is still legitimately needed after `miren disk restore`, so the docs say restart isn't needed after *config/env/addon* changes rather than promising "never".

Out of scope, but found while reading: `api/app/envvar.go:349` activates the new version *before* the deploy-lock check in `servers/deployment/server.go`, so a user can see "env set failed: deployment in progress" while the change is already live. That's a code bug rather than a docs one — worth its own issue.

Fixes MIR-1409.