### PR TITLE
Fix explicit local disks triggering the legacy auto-mount warning and duplicate mount

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -828,12 +828,14 @@ func (l *Launcher) injectAutoMountLocalDisks(spec *core_v1alpha.ConfigSpec, app 
 	for i := range spec.Services {
 		svc := &spec.Services[i]
 
-		// Skip if the service already declares a disk at the auto-mount path or
-		// under the name we would inject; appending a second disk with the same
-		// name would produce a duplicate volume name in the sandbox spec.
+		// Skip if the service already declares an explicit local-provider disk
+		// (all local volumes share the same per-app host directory, so any local
+		// disk already exposes this data regardless of its mount path), a disk at
+		// the legacy auto-mount path, or a disk under the name we would inject.
+		// The last two also guard against a duplicate volume name in the spec.
 		conflicts := false
 		for _, d := range svc.Disks {
-			if d.MountPath == localDataMountPath || d.Name == localDataDiskName {
+			if d.Provider == core_v1alpha.ConfigSpecServicesDisksLOCAL || d.MountPath == localDataMountPath || d.Name == localDataDiskName {
 				conflicts = true
 				break
 			}

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -2732,6 +2732,79 @@ func TestNoAutoMountWhenExplicitDiskConfig(t *testing.T) {
 	assert.Equal(t, "local", volumes[0].Provider)
 }
 
+// TestNoAutoMountWhenExplicitLocalDiskElsewhere reproduces MIR-1423: an explicit
+// local-provider disk mounted somewhere other than the legacy /miren/data/local
+// path (and not named "local-data") must suppress the transitional auto-mount.
+// All local volumes share the same per-app host directory, so the explicit disk
+// already exposes the data; the path-only check used to miss this and inject a
+// duplicate local-data mount at /miren/data/local pointing at the same bytes.
+func TestNoAutoMountWhenExplicitLocalDiskElsewhere(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "chisigns-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/data",
+						},
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	// The per-app local directory is already populated, which would otherwise
+	// self-trigger the legacy auto-mount for this explicit local disk.
+	dataPath := t.TempDir()
+	localDir := filepath.Join(dataPath, "data", "local", app.ID.String())
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "data.db"), []byte("test"), 0644))
+
+	launcher := newTestLauncher(log, server.EAC)
+	launcher.DataPath = dataPath
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+
+	// Only the declared disk should be present — no injected local-data duplicate.
+	volumes := pools[0].SandboxSpec.Volume
+	require.Len(t, volumes, 1, "explicit local disk should suppress the auto-mount")
+	assert.Equal(t, "chisigns-data", volumes[0].Name)
+	assert.Equal(t, "local", volumes[0].Provider)
+	assert.Equal(t, "/data", volumes[0].MountPath)
+}
+
 // TestNoAutoMountWhenDiskNameTaken verifies the auto-mount is skipped when the
 // service already declares a disk under the "local-data" name, even at a
 // different mount path. Injecting a second disk with that name would produce a

--- a/docs/docs/disks.md
+++ b/docs/docs/disks.md
@@ -49,6 +49,12 @@ mount_path = "/var/lib/postgresql/data"
 - **Host-local**: Data lives on the server's filesystem
 - **Node-pinned**: Apps with local storage are scheduled to the coordinator node
 
+:::warning[Local disks share one per-app store]
+Local storage is keyed per app, not per disk. Every `provider = "local"` disk your app declares — across all its services, regardless of the disk's `name` or `mount_path` — maps to the same directory on the host. Two local disks mounted at `/cache` and `/data` are two windows onto the same files: a write to one shows up in the other.
+
+This is handy for sharing node-local state between an app's services, but if you want isolated areas, use subdirectories under a single local disk (for example `/data/cache` and `/data/uploads`) instead of declaring multiple local disks.
+:::
+
 ### When to Use Local Storage
 
 - SQLite databases

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -836,26 +836,41 @@ func logField(key, value string) *build_v1alpha.LogField {
 	return f
 }
 
-// checkLocalStorageMigration checks whether the app has existing data in
-// local storage but no explicit disk config, and sends a deploy warning.
-func (b *Builder) checkLocalStorageMigration(ctx context.Context, appID entity.Id, configSpec core_v1alpha.ConfigSpec, status *stream.SendStreamClient[*build_v1alpha.Status]) {
-	if b.DataPath == "" {
-		return
-	}
-
-	// Check if any service already declares a disk at /miren/data/local
-	// (any provider — local or miren). If so, the user has migrated.
+// configDeclaresLocalStorage reports whether the config already declares a disk
+// that satisfies the local-storage migration. That's true when any service
+// declares an explicit local-provider disk (regardless of its container mount
+// path — all local volumes share the same per-app host directory keyed on app
+// ID), or a disk of any provider at the legacy /miren/data/local mount path.
+func configDeclaresLocalStorage(configSpec core_v1alpha.ConfigSpec) bool {
 	for _, svc := range configSpec.Services {
 		for _, disk := range svc.Disks {
-			if disk.MountPath == "/miren/data/local" {
-				return
+			if disk.Provider == core_v1alpha.ConfigSpecServicesDisksLOCAL || disk.MountPath == "/miren/data/local" {
+				return true
 			}
 		}
 	}
+	return false
+}
 
-	localPath := filepath.Join(b.DataPath, "data", "local", appID.String())
+// shouldWarnLocalStorageMigration reports whether a deploy should warn that the
+// app has existing data in local storage but no explicit disk config.
+func shouldWarnLocalStorageMigration(dataPath string, appID entity.Id, configSpec core_v1alpha.ConfigSpec) bool {
+	if dataPath == "" {
+		return false
+	}
+	if configDeclaresLocalStorage(configSpec) {
+		return false
+	}
+
+	localPath := filepath.Join(dataPath, "data", "local", appID.String())
 	entries, err := os.ReadDir(localPath)
-	if err != nil || len(entries) == 0 {
+	return err == nil && len(entries) > 0
+}
+
+// checkLocalStorageMigration checks whether the app has existing data in
+// local storage but no explicit disk config, and sends a deploy warning.
+func (b *Builder) checkLocalStorageMigration(ctx context.Context, appID entity.Id, configSpec core_v1alpha.ConfigSpec, status *stream.SendStreamClient[*build_v1alpha.Status]) {
+	if !shouldWarnLocalStorageMigration(b.DataPath, appID, configSpec) {
 		return
 	}
 

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -3,6 +3,8 @@ package build
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
@@ -2455,6 +2457,91 @@ func TestValidateDiskConfigsLocalDiskSkipsCheck(t *testing.T) {
 
 	err := validateDiskConfigs(ctx, server.EAC, spec)
 	assert.NoError(t, err)
+}
+
+// TestShouldWarnLocalStorageMigration covers the migration-warning decision,
+// including MIR-1423: an explicit local-provider disk mounted somewhere other
+// than the legacy /miren/data/local path must suppress the warning. All local
+// volumes share the same per-app host directory keyed on app ID, so the explicit
+// disk already exposes the data — the old path-only check missed this and warned
+// (and injected a duplicate mount) once the shared directory held data.
+func TestShouldWarnLocalStorageMigration(t *testing.T) {
+	const appID = entity.Id("app/test")
+
+	localDiskAt := func(mountPath string) core_v1alpha.ConfigSpec {
+		return core_v1alpha.ConfigSpec{
+			Services: []core_v1alpha.ConfigSpecServices{{
+				Name: "web",
+				Disks: []core_v1alpha.ConfigSpecServicesDisks{{
+					Name:      "chisigns-data",
+					MountPath: mountPath,
+					Provider:  core_v1alpha.ConfigSpecServicesDisksLOCAL,
+				}},
+			}},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		spec      core_v1alpha.ConfigSpec
+		writeData bool
+		want      bool
+	}{
+		{
+			name:      "existing data, no disk declared",
+			spec:      core_v1alpha.ConfigSpec{Services: []core_v1alpha.ConfigSpecServices{{Name: "web"}}},
+			writeData: true,
+			want:      true,
+		},
+		{
+			name:      "explicit local disk at /data suppresses warning",
+			spec:      localDiskAt("/data"),
+			writeData: true,
+			want:      false,
+		},
+		{
+			name:      "explicit local disk at legacy path suppresses warning",
+			spec:      localDiskAt("/miren/data/local"),
+			writeData: true,
+			want:      false,
+		},
+		{
+			name: "miren-provider disk at legacy path suppresses warning",
+			spec: core_v1alpha.ConfigSpec{Services: []core_v1alpha.ConfigSpecServices{{
+				Name: "web",
+				Disks: []core_v1alpha.ConfigSpecServicesDisks{{
+					Name:      "legacy",
+					MountPath: "/miren/data/local",
+					Provider:  core_v1alpha.ConfigSpecServicesDisksMIREN,
+				}},
+			}}},
+			writeData: true,
+			want:      false,
+		},
+		{
+			name:      "no existing data, no disk declared",
+			spec:      core_v1alpha.ConfigSpec{Services: []core_v1alpha.ConfigSpecServices{{Name: "web"}}},
+			writeData: false,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataPath := t.TempDir()
+			if tt.writeData {
+				localDir := filepath.Join(dataPath, "data", "local", appID.String())
+				require.NoError(t, os.MkdirAll(localDir, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(localDir, "data.db"), []byte("x"), 0644))
+			}
+			got := shouldWarnLocalStorageMigration(dataPath, appID, tt.spec)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("empty data path never warns", func(t *testing.T) {
+		assert.False(t, shouldWarnLocalStorageMigration("", appID, core_v1alpha.ConfigSpec{}))
+	})
 }
 
 func TestValidateDiskConfigsAutoCreate(t *testing.T) {


### PR DESCRIPTION
Declare a local disk the normal way, `provider = "local"` mounted at some path like `/data`, and the deploy would still warn that `app.toml` had no disk declaration. Worse, the resolved sandbox pool ended up with two mounts: the declared disk at its path, plus an injected `local-data` at `/miren/data/local`.

The transitional auto-mount was self-triggering. Both the builder's migration warning and the launcher's auto-mount injection decided "this app hasn't migrated" by looking for a disk mounted at exactly `/miren/data/local`. A local disk mounted anywhere else didn't count. And because all local volumes for an app resolve to the same per-app host directory (keyed on app ID, not disk name or mount path), once the explicit disk had data, that shared directory was non-empty, so every subsequent deploy saw "legacy data with no disk config" and both warned and injected the duplicate.

The fix broadens both checks: any explicit `provider = "local"` disk now satisfies the migration check regardless of its mount path, while the legacy `/miren/data/local` path check stays for disks intentionally placed there. The auto-mount machinery itself is untouched, since registering it as a real disk is deliberate (MIR-1293). Regression coverage lands for the reproducing case, a populated per-app directory with an explicit local disk mounted elsewhere, asserting only the declared disk is present and no warning fires.

Chasing this turned up something worth writing down: local storage is really one shared per-app store, and every local disk an app declares is just another window onto it, even across services. That's a coherent model but it's completely invisible in the config, so I added a docs note spelling it out and filed MIR-1427 to make it more legible rather than risk a migration.

Closes MIR-1423