### PR TITLE
fix: remove shadowed duplicate route protect/unprotect registrations

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -544,23 +544,6 @@ miren deploy --analyze
 		}),
 	))
 
-	d.Dispatch("route protect", Infer("route protect", "Protect an HTTP route with an identity provider", RouteProtect,
-		WithExample(mflags.Example{
-			Name: "Protect a route with an identity provider",
-			Body: "miren route protect example.com --provider my-google-oidc --claim-header email:X-User-Email",
-		}),
-		WithExample(mflags.Example{
-			Name: "Protect the default route",
-			Body: "miren route protect --default --provider my-google-oidc",
-		}),
-	))
-	d.Dispatch("route unprotect", Infer("route unprotect", "Remove identity-provider protection from an HTTP route", RouteUnprotect,
-		WithExample(mflags.Example{
-			Name: "Remove protection from a route",
-			Body: "miren route unprotect example.com",
-		}),
-	))
-
 	// Config commands
 	d.Dispatch("config", Section("config", "Configuration file management", "", WithSectionGroup(GroupClient)))
 	d.Dispatch("config info", Infer("config info", "Show configuration file locations and format", ConfigInfo,

--- a/docs/docs/command/route-protect.md
+++ b/docs/docs/command/route-protect.md
@@ -36,10 +36,16 @@ miren route protect <host> [flags]
 
 ## Examples
 
-**Protect a route with an identity provider:**
+**Protect a route with an OIDC provider:**
 
 ```bash
 miren route protect example.com --provider my-google-oidc --claim-header email:X-User-Email
+```
+
+**Protect a route with a password:**
+
+```bash
+miren route protect example.com --provider my-pw
 ```
 
 **Protect the default route:**


### PR DESCRIPTION
## Problem

`route protect` and `route unprotect` are each dispatched twice in `cli/commands/commands.go` — once at ~507-534 and again at ~547-562.

`mflags.Dispatcher.Dispatch` is a plain map assignment:

```go
d.commands[normalizedPath] = &CommandEntry{...}   // dispatcher.go:222
```

So the later registration **silently replaces** the earlier one — no warning, no panic.

For `route protect` the second registration is the *sparser* of the two, so it shadows the richer first one and drops the **password-provider example** (`miren route protect example.com --provider my-pw`) — the only example demonstrating `--provider` with a password provider. It was missing from both `--help` and the shipped docs.

The `route unprotect` duplicate is byte-identical, so it was harmless.

## Fix

Remove the redundant second block, keeping the richer registration.

The regenerated `route-protect.md` is the proof: the password example is back, and the first example is now correctly labeled "Protect a route with an OIDC provider" instead of the generic "identity provider".

Only `route-protect.md` changed on regeneration — confirming the `unprotect` duplicate really was a no-op.

## Verification

- `miren route protect --help` and `miren route unprotect --help` both still dispatch
- `go generate ./cli/commands/` touched only `route-protect.md`
- `make lint` → 0 issues

## Notes

Found while reviewing #928 — pre-existing on `main` and unrelated to that PR's content, so it's split out here to land on its own merits.