### PR TITLE
Enforce schema.Choices on ref-typed attribute writes

### DIFF
--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -642,7 +642,7 @@ func TestManagerZeroValuePersistence(t *testing.T) {
 	for _, ent := range results.Values() {
 		_, err := server.EAC.Patch(ctx, []entity.Attr{
 			entity.Ref(entity.DBId, ent.Entity().Id()),
-			entity.String(compute_v1alpha.SandboxStatusId, string(compute_v1alpha.DEAD)),
+			entity.Ref(compute_v1alpha.SandboxStatusId, compute_v1alpha.SandboxStatusDeadId),
 		}, 0)
 		require.NoError(t, err)
 	}

--- a/guardrails/refenum_test.go
+++ b/guardrails/refenum_test.go
@@ -1,0 +1,274 @@
+// Package guardrails holds structural tests that scan the source tree for
+// anti-patterns the type system and unit tests can't catch on their own.
+package guardrails
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// allowedEnumWraps lists "file:line" sites that are permitted to wrap a
+// screaming-case constant in entity.Id(). It should stay empty; add an entry
+// only with a comment explaining why the value really is a full id, not an
+// enum value.
+var allowedEnumWraps = map[string]bool{}
+
+// TestNoEnumValueWrappedInEntityId guards MIR-1425/MIR-1288 at the source level,
+// and answers Evan's "we should probably audit uses of entity.Id" on #927.
+//
+// Ref-typed status attributes take a fully-qualified choice id (e.g.
+// SandboxStatusStoppedId = "dev.miren.compute/status.stopped"). The recurring
+// bug is wrapping the *short* enum value constant instead —
+// entity.Ref(SandboxStatusId, entity.Id(compute_v1alpha.STOPPED)) — which
+// yields "status.stopped", a value no schema.Choices set contains. The runtime
+// validator now rejects that on any write it exercises; this scan catches the
+// shape everywhere at CI time, including non-write contexts (comparisons) the
+// validator never sees.
+//
+// Two rules, tuned so real enum values trip it and ordinary field accesses
+// don't:
+//   - A BARE screaming-case ident wrapped in entity.Id() (entity.Id(STOPPED))
+//     is an enum value in any context, so it's flagged wherever it appears.
+//   - A package-qualified screaming const (entity.Id(compute_v1alpha.STOPPED))
+//     is flagged only as the value of an entity.Ref / entity.RefValue. That
+//     keeps the common, legitimate entity.Id(x.ID) field conversion (also
+//     upper-case) from tripping it outside of a ref.
+//
+// The correct fully-qualified *Id constants are MixedCase, so they never match.
+func TestNoEnumValueWrappedInEntityId(t *testing.T) {
+	root := repoRoot(t)
+
+	var violations []string
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", "testdata", "node_modules", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			// A file we can't parse isn't this test's problem; the compiler
+			// will surface it. Skip rather than fail on unrelated breakage.
+			return nil
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if inner, ok := findEnumWrap(call); ok {
+				pos := fset.Position(call.Pos())
+				rel, _ := filepath.Rel(root, pos.Filename)
+				site := rel + ":" + itoa(pos.Line)
+				if !allowedEnumWraps[site] {
+					violations = append(violations, site+"  ->  "+inner)
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking source tree: %v", err)
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("wrapping a short enum value in entity.Id() writes an unresolvable "+
+			"id (MIR-1288); use the fully-qualified <Kind><Value>Id constant or the "+
+			"generated .Encode() instead:\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+// TestEnumWrapMatcherDetects proves the scan actually fires on the bug shapes
+// and stays quiet on the legitimate forms, so a green
+// TestNoEnumValueWrappedInEntityId means "clean", not "matcher broken".
+func TestEnumWrapMatcherDetects(t *testing.T) {
+	const src = `package p
+
+func f() {
+	entity.Ref(SandboxStatusId, entity.Id(compute_v1alpha.STOPPED)) // BAD: pkg enum value in ref
+	entity.Ref(SandboxStatusId, entity.Id(DEAD))                    // BAD: bare enum value in ref
+	entity.RefValue(entity.Id(RUNNING))                             // BAD: bare enum value via RefValue
+	_ = status == entity.Id(PENDING)                                // BAD: bare enum value in a comparison
+
+	entity.Ref(SandboxStatusId, compute_v1alpha.SandboxStatusStoppedId) // ok: full *Id const
+	entity.Ref(SandboxStatusId, entity.Id(fullID))                      // ok: dynamic lower-case id
+	entity.Ref(SandboxStatusId, "")                                     // ok: clearing
+	_ = entity.Id(compute_v1alpha.STOPPED)                              // ok: pkg-qualified outside a ref
+	_ = entity.Id(attr.ID)                                              // ok: field access, never flagged
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "snippet.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	var hits []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok {
+			if inner, ok := findEnumWrap(call); ok {
+				hits = append(hits, inner)
+			}
+		}
+		return true
+	})
+
+	want := []string{
+		"entity.Id(compute_v1alpha.STOPPED)",
+		"entity.Id(DEAD)",
+		"entity.Id(RUNNING)",
+		"entity.Id(PENDING)",
+	}
+	if len(hits) != len(want) {
+		t.Fatalf("expected %v, got %v", want, hits)
+	}
+	for i := range want {
+		if hits[i] != want[i] {
+			t.Fatalf("hit %d: expected %q, got %q (all: %v)", i, want[i], hits[i], hits)
+		}
+	}
+}
+
+// findEnumWrap reports an enum-value-in-entity.Id() misuse for a single call
+// expression, if any, returning a printable form of the offending expression.
+func findEnumWrap(call *ast.CallExpr) (string, bool) {
+	// Rule 1: a bare screaming-case ident wrapped in entity.Id(), anywhere.
+	if name, ok := entitySelector(call.Fun); ok && name == "Id" && len(call.Args) == 1 {
+		if id, ok := call.Args[0].(*ast.Ident); ok && isScreamingCase(id.Name) {
+			return "entity.Id(" + id.Name + ")", true
+		}
+	}
+	// Rule 2: entity.Id(pkg.SCREAMING) as the value of a ref.
+	if refArg, ok := refValueArg(call); ok {
+		if inner, ok := enumWrapSelector(refArg); ok {
+			return "entity.Id(" + inner + ")", true
+		}
+	}
+	return "", false
+}
+
+// refValueArg returns the argument that supplies the ref *value* for an
+// entity.Ref(id, value) or entity.RefValue(value) call, if this call is one.
+func refValueArg(call *ast.CallExpr) (ast.Expr, bool) {
+	name, ok := entitySelector(call.Fun)
+	if !ok {
+		return nil, false
+	}
+	switch name {
+	case "Ref":
+		if len(call.Args) == 2 {
+			return call.Args[1], true
+		}
+	case "RefValue":
+		if len(call.Args) == 1 {
+			return call.Args[0], true
+		}
+	}
+	return nil, false
+}
+
+// enumWrapSelector reports whether expr is entity.Id(pkg.SCREAMING), returning
+// a printable form of the selector. The bare-ident case is handled globally by
+// findEnumWrap's Rule 1, so this only matches package-qualified selectors.
+func enumWrapSelector(expr ast.Expr) (string, bool) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return "", false
+	}
+	if name, ok := entitySelector(call.Fun); !ok || name != "Id" || len(call.Args) != 1 {
+		return "", false
+	}
+	sel, ok := call.Args[0].(*ast.SelectorExpr)
+	if !ok || !isScreamingCase(sel.Sel.Name) {
+		return "", false
+	}
+	if x, ok := sel.X.(*ast.Ident); ok {
+		return x.Name + "." + sel.Sel.Name, true
+	}
+	return sel.Sel.Name, true
+}
+
+// entitySelector returns the method name for an `entity.<Name>` selector.
+func entitySelector(fun ast.Expr) (string, bool) {
+	sel, ok := fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	x, ok := sel.X.(*ast.Ident)
+	if !ok || x.Name != "entity" {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
+// isScreamingCase reports whether s looks like an enum value constant:
+// upper-case letters, digits and underscores only, with at least one letter and
+// length > 1 (so "A" or "42" don't trip it).
+func isScreamingCase(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	hasLetter := false
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			hasLetter = true
+		case r >= '0' && r <= '9', r == '_':
+		default:
+			return false
+		}
+	}
+	return hasLetter
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+
+// repoRoot walks up from the test's working directory to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.mod above %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/pkg/entity/schema/schema.go
+++ b/pkg/entity/schema/schema.go
@@ -144,7 +144,7 @@ type attrBuilder struct {
 	session  bool
 	tags     []string
 
-	choises []entity.Id
+	choices []entity.Id
 
 	extra []entity.Attr
 }
@@ -181,7 +181,7 @@ func Tags(tags ...string) AttrOption {
 
 func Choices(choices ...entity.Id) AttrOption {
 	return func(b *attrBuilder) {
-		b.choises = append(b.choises, choices...)
+		b.choices = append(b.choices, choices...)
 	}
 }
 
@@ -222,6 +222,25 @@ func (s *SchemaBuilder) Attr(name, id string, typ entity.Id, opts ...AttrOption)
 
 	for _, tag := range ab.tags {
 		attrs = append(attrs, entity.Tag, tag)
+	}
+
+	// Choices declare the set of valid values for the attribute. Surface them
+	// as EnumValues so convertEntityToSchema lands them on AttributeSchema and
+	// the validator can enforce membership (see MIR-1425). This is the same
+	// attribute the Enum builder injects, so ref-typed choices and true enums
+	// share one enforcement path.
+	if len(ab.choices) > 0 {
+		choices := make([]any, len(ab.choices))
+		for i, c := range ab.choices {
+			choices[i] = c
+		}
+		attrs = append(attrs, entity.EnumValues, entity.ArrayValue(choices...))
+	}
+
+	// AdditionalAttrs carries pre-built attrs (e.g. the Enum builder's
+	// EnumValues) that would otherwise be dropped on the floor.
+	for _, extra := range ab.extra {
+		attrs = append(attrs, extra)
 	}
 
 	ent := entity.New(attrs...)

--- a/pkg/entity/schema/schema_test.go
+++ b/pkg/entity/schema/schema_test.go
@@ -66,6 +66,33 @@ func TestIndexedAttributeIDs(t *testing.T) {
 	assert.False(t, seen["test-index-hash/doc"], "test-index-hash/doc should not be indexed")
 }
 
+// TestRefChoicesEmitsEnumValues guards MIR-1425: declaring schema.Choices on a
+// ref attribute must surface those choices as an EnumValues attribute on the
+// built schema entity, which is where the validator reads them from.
+func TestRefChoicesEmitsEnumValues(t *testing.T) {
+	sb := &SchemaBuilder{
+		domain: "test-choices",
+		attrs:  make(map[entity.Id]*entity.Entity),
+	}
+
+	id := sb.Ref("status", "test-choices/status",
+		Doc("The status"),
+		Choices(entity.Id("test-choices/status.a"), entity.Id("test-choices/status.b")),
+	)
+
+	ent := sb.attrs[id]
+	require.NotNil(t, ent)
+
+	attr, ok := ent.Get(entity.EnumValues)
+	require.True(t, ok, "Choices should surface as an EnumValues attribute")
+
+	vals, ok := attr.Value.Any().([]entity.Value)
+	require.True(t, ok, "EnumValues should be a []Value")
+	require.Len(t, vals, 2)
+	assert.Equal(t, entity.Id("test-choices/status.a"), vals[0].Any())
+	assert.Equal(t, entity.Id("test-choices/status.b"), vals[1].Any())
+}
+
 func TestIndexHash_Deterministic(t *testing.T) {
 	hash1 := IndexHash()
 	hash2 := IndexHash()

--- a/pkg/entity/system.go
+++ b/pkg/entity/system.go
@@ -122,12 +122,19 @@ func InitSystemEntities(save func(*Entity) error) error {
 		Type, TypeRef,
 	)
 
+	// EnumValues holds a heterogeneous []Value bag of allowed choices, built
+	// with ArrayValue (which yields a KindArray of []Value). The TypeArray
+	// validator asserts []any and would reject that representation, so this is
+	// declared TypeAny — the ElemType was already TypeAny, i.e. never
+	// element-type-checked. This matters because domain schemas that declare
+	// schema.Choices now surface an EnumValues attr and install through the
+	// validating CreateEntity path (see MIR-1425); the base system entities
+	// bypass validation via basicSave, so they were never affected.
 	enumValues := New(
 		Ident, types.Keyword(EnumValues),
 		Doc, "Enum values",
 		Cardinality, CardinalityMany,
-		Type, TypeArray,
-		EntityElemType, TypeAny,
+		Type, TypeAny,
 	)
 
 	enumType := New(

--- a/pkg/entity/validation.go
+++ b/pkg/entity/validation.go
@@ -68,6 +68,25 @@ func asEntityId(val any) (Id, error) {
 	}
 }
 
+// matchesChoice reports whether val equals one of the declared choice values.
+// It backs both the enum check and the ref-typed schema.Choices enforcement.
+func matchesChoice(choices []Value, val Value) bool {
+	return slices.IndexFunc(choices, func(e Value) bool {
+		return e.Equal(val)
+	}) != -1
+}
+
+// choiceValues renders a choice set for error messages, unwrapping each Value
+// to its underlying Go value (e.g. the ref Id) so the message reads as a plain
+// list rather than Kind-prefixed Value strings.
+func choiceValues(choices []Value) []any {
+	out := make([]any, len(choices))
+	for i, c := range choices {
+		out[i] = c.Any()
+	}
+	return out
+}
+
 // ValidateEntity validates all attributes in an entity against their schemas
 func (v *Validator) ValidateEntity(ctx context.Context, entity *Entity) error {
 	require := map[Id]struct{}{}
@@ -292,6 +311,13 @@ func (v *Validator) validateAttribute(ctx context.Context, attr *Attr, exempt re
 			return fmt.Errorf("attribute %s must be a string representing an entity ID", name)
 		}
 		if str != "" && (exempt == nil || !exempt(*attr)) {
+			// When the attribute declares a choice set (schema.Choices),
+			// enforce membership before the existence check: it's cheaper and
+			// gives a more precise error than "references a non-existent
+			// entity" for the common status-ref case (see MIR-1425).
+			if len(schema.EnumValues) > 0 && !matchesChoice(schema.EnumValues, attr.Value) {
+				return fmt.Errorf("attribute %s must be one of %v (was %v)", name, choiceValues(schema.EnumValues), str)
+			}
 			if _, err := v.store.GetEntity(ctx, str); err != nil {
 				return fmt.Errorf("attribute %s references a non-existent entity: %w", name, err)
 			}
@@ -315,11 +341,8 @@ func (v *Validator) validateAttribute(ctx context.Context, attr *Attr, exempt re
 			return fmt.Errorf("attribute %s must be a timestamp (int64 or RFC3339 string), got %T", name, v)
 		}
 	case TypeEnum:
-		idx := slices.IndexFunc(schema.EnumValues, func(e Value) bool {
-			return e.Equal(attr.Value)
-		})
-		if idx == -1 {
-			return fmt.Errorf("attribute %s must be one of %v (was %v)", name, schema.EnumValues, attr.Value)
+		if !matchesChoice(schema.EnumValues, attr.Value) {
+			return fmt.Errorf("attribute %s must be one of %v (was %v)", name, choiceValues(schema.EnumValues), attr.Value)
 		}
 	case TypeArray:
 		tuple, ok := attr.Value.Any().([]any)

--- a/pkg/entity/validation_test.go
+++ b/pkg/entity/validation_test.go
@@ -296,6 +296,102 @@ func TestValidateToType(t *testing.T) {
 	}
 }
 
+// TestValidateRefChoices guards MIR-1425: a ref-typed attribute that declares a
+// choice set (schema.Choices, surfaced as EnumValues) must reject any value
+// outside that set, even a value that points at a real entity — the case bare
+// existence checking can't catch.
+func TestValidateRefChoices(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := require.New(t)
+	ctx := t.Context()
+
+	// A ref attribute that declares a choice set, mirroring what the schema
+	// builder now emits for schema.Choices(...).
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/status",
+		Doc, "status",
+		Cardinality, CardinalityOne,
+		Type, TypeRef,
+		EnumValues, ArrayValue(Id("test/status.a"), Id("test/status.b")),
+	))
+	r.NoError(err)
+
+	// A plain ref attribute with no choices, to prove behavior is unchanged.
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "test/target",
+		Doc, "target",
+		Cardinality, CardinalityOne,
+		Type, TypeRef,
+	))
+	r.NoError(err)
+
+	// All three referents exist in the store. status.c exists but is NOT a
+	// declared choice — the nastier case existence alone can't reject.
+	for _, id := range []string{"test/status.a", "test/status.b", "test/status.c"} {
+		_, err := store.CreateEntity(ctx, New(Ident, id))
+		r.NoError(err)
+	}
+
+	validator := NewValidator(store)
+
+	// A declared choice passes.
+	a := Ref("test/status", "test/status.a")
+	r.NoError(validator.ValidateAttribute(ctx, &a))
+
+	// An existing-but-unlisted value is rejected on membership, not existence.
+	c := Ref("test/status", "test/status.c")
+	err = validator.ValidateAttribute(ctx, &c)
+	r.Error(err)
+	r.Contains(err.Error(), "must be one of")
+
+	// Clearing to empty stays allowed.
+	empty := Ref("test/status", "")
+	r.NoError(validator.ValidateAttribute(ctx, &empty))
+
+	// A choices-less ref still only checks existence: existing ok, missing not.
+	ok := Ref("test/target", "test/status.a")
+	r.NoError(validator.ValidateAttribute(ctx, &ok))
+
+	missing := Ref("test/target", "test/does_not_exist")
+	err = validator.ValidateAttribute(ctx, &missing)
+	r.Error(err)
+	r.Contains(err.Error(), "non-existent")
+}
+
+// TestValidateUpdateRefChoicesExempt guards that an unchanged choice ref is not
+// re-validated on an unrelated patch (the MIR-1320 concern): a value that
+// predates enforcement must not block a status-only update elsewhere.
+func TestValidateUpdateRefChoicesExempt(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	r := require.New(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/status",
+		Doc, "status",
+		Cardinality, CardinalityOne,
+		Type, TypeRef,
+		EnumValues, ArrayValue(Id("test/status.a"), Id("test/status.b")),
+	))
+	r.NoError(err)
+	_, err = store.CreateEntity(ctx, New(Ident, "test/status.legacy"))
+	r.NoError(err)
+
+	validator := NewValidator(store)
+
+	// A pre-existing out-of-set value carried unchanged through an update is
+	// exempt and does not block the write.
+	legacy := Ref("test/status", "test/status.legacy")
+	r.NoError(validator.ValidateUpdate(ctx, []Attr{legacy}, []Attr{legacy}))
+
+	// But changing that attribute to a still-invalid value is rejected.
+	r.Error(validator.ValidateUpdate(ctx, []Attr{legacy}, nil))
+}
+
 func TestValidate_EntityAttrs(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()


### PR DESCRIPTION
The MIR-1288 bug was `app restart` writing a sandbox status ref as the short `entity.Id(STOPPED)` instead of the full `SandboxStatusStoppedId`, so the ref resolved to nothing and the stop was a silent no-op. #927 fixed that one line; this is the class-wide guard so the shape can't recur.

Chasing how the validator was *supposed* to catch it turned up the real story: the entire `schema.Choices` / enum enforcement path was dead code. The `Attr` builder wrote `ab.choices` into its struct but never read it back, so no schema entity ever carried an `EnumValues` attr, the validator's `TypeEnum` branch was unreachable, and `sb.Enum` is called nowhere. Every "enum" is really a ref with `schema.Choices(...)`, and refs were only existence-checked, never membership-checked. A wrong ref that pointed at a real entity would have sailed straight through.

The fix wires it up end to end: the builder surfaces choices as an `EnumValues` attr, and the `TypeRef` validator enforces membership (reusing the enum branch's check). It stays behind the existing guard that exempts clearing-to-empty and unchanged refs on an update, so only newly written out-of-set values get rejected, keeping the MIR-1320 behavior intact.

One trap worth flagging: `db/enumValues` was declared `TypeArray`, but `ArrayValue` yields `[]Value` while the array validator asserts `[]any`. System schemas dodge it via un-validated writes, but domain schemas install through validation, so every real choices schema would've failed to install with "must be an array." Its `ElemType` was already `TypeAny`, so declaring the attribute itself `TypeAny` is the honest fix and leaves the hot array path alone. This is safe on upgrade because we're loosening validation, not tightening it, and the bootstrap blind-overwrites the core entity before `schema.Apply` runs.

Also lands a `guardrails/` package: a static scan banning a short enum value wrapped in `entity.Id()` (bare anywhere, or package-qualified inside a ref), catching the shape at CI time even on paths the validator never runs. This answers Evan's "audit uses of entity.Id" from #927; the tree came back clean.

Verified in iso across `pkg/entity` (etcd and file store paths), schema, sandboxpool, and the coordinator-boot test that installs every real schema on etcd. Closes MIR-1425.
