### PR TITLE
Reap orphaned stateless pools when a spec change forces replacement

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -74,6 +74,16 @@ func NewLauncher(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient)
 // on demand. This implements activator.PoolCreator for ephemeral versions that
 // bypass the normal DeploymentLauncher reconciliation loop.
 func (l *Launcher) CreatePoolForVersion(ctx context.Context, ver *core_v1alpha.AppVersion, service string) (entity.Id, error) {
+	// Serialize against Reconcile (and other on-demand creates) for the same app.
+	// Both paths do a findMatchingPool → create window; without a shared lock the
+	// activator and the reconciler can each miss the other's in-flight pool and
+	// both create one, duplicating every sandbox (MIR-1432, the tempo two-web-pools
+	// finding). Keyed on app ID, identical to Reconcile.
+	val, _ := l.appMu.LoadOrStore(ver.App, &sync.Mutex{})
+	mu := val.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+
 	// Resolve the app entity
 	var app core_v1alpha.App
 	appResp, err := l.EAC.Get(ctx, ver.App.String())
@@ -244,7 +254,12 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	l.injectAutoMountLocalDisks(spec, app)
 
 	// For each service, ensure a pool exists. Collect IDs of newly created pools.
+	// ensuredServices tracks services whose replacement pool was successfully
+	// ensured this pass; only those are eligible for stale-pool reaping below, so
+	// we never scale down a service's only running pool when its replacement
+	// failed to create.
 	var newPoolIDs []entity.Id
+	ensuredServices := make(map[string]bool)
 	for _, svc := range spec.Services {
 		// For services with disks, drain old pools before creating new ones.
 		// Disks require exclusive access (local disks use flock, miren disks
@@ -269,6 +284,7 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 			// Continue with other services even if one fails
 			continue
 		}
+		ensuredServices[svc.Name] = true
 		if poolID != "" {
 			newPoolIDs = append(newPoolIDs, poolID)
 		}
@@ -321,6 +337,25 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 		}
 	}
 
+	// Reap stateless pools whose baked spec no longer matches the desired spec.
+	// cleanupOldVersionPools below keys on version references, so it never reaps
+	// a superseded pool that still references the current version — which is
+	// exactly what happens when a binary change (not a new AppVersion) alters the
+	// baked spec, e.g. a runtime-injected env var rename. Those husks kept running
+	// alongside their replacements indefinitely (MIR-1432). Disk services already
+	// get spec-based reaping via drainStaleDiskPools before create; this covers
+	// the stateless services after their replacements are ready. Only reap for
+	// services whose replacement was successfully ensured, so a failed create
+	// never leaves a service with its old pool scaled down and no replacement.
+	reaped, err := l.reapStaleStatelessPools(ctx, app, &ver, spec, ensuredServices)
+	if err != nil {
+		l.Log.Error("failed to reap stale stateless pools",
+			"app", app.ID,
+			"version", ver.ID,
+			"error", err)
+		// Don't fail the entire reconciliation if reaping fails
+	}
+
 	// Clean up old version pools (pools not referenced by current version)
 	cleaned, err := l.cleanupOldVersionPools(ctx, app, ver.ID)
 	if err != nil {
@@ -330,6 +365,8 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 			"error", err)
 		// Don't fail the entire reconciliation if cleanup fails
 	}
+
+	cleaned += reaped
 
 	// Summarize only when this reconcile actually did something. The loop runs
 	// constantly; a steady-state pass that created and cleaned up nothing stays
@@ -1646,6 +1683,81 @@ func (l *Launcher) drainStaleDiskPools(
 	}
 
 	return nil
+}
+
+// reapStaleStatelessPools scales to 0 any pool for a stateless service whose
+// baked spec no longer matches the desired spec. It is the stateless twin of
+// drainStaleDiskPools, but runs *after* the new pool is ready rather than before
+// create: stateless pools hold no exclusive lease, so we want create → wait →
+// reap to avoid a serving gap, and there's no drain to block on.
+//
+// Disk services are skipped here — they already went through drainStaleDiskPools
+// before create. Only services present in ensuredServices are reaped: if a
+// service's replacement pool failed to be ensured this pass, we leave its old
+// pool running rather than scale down the only instance with no replacement.
+// Returns the number of pools it scaled down.
+func (l *Launcher) reapStaleStatelessPools(
+	ctx context.Context,
+	app *core_v1alpha.App,
+	ver *core_v1alpha.AppVersion,
+	cfgSpec *core_v1alpha.ConfigSpec,
+	ensuredServices map[string]bool,
+) (int, error) {
+	reaped := 0
+	for _, svc := range cfgSpec.Services {
+		if serviceHasDisks(cfgSpec, svc.Name) {
+			continue
+		}
+		if !ensuredServices[svc.Name] {
+			continue
+		}
+
+		// Determine which image to use (same logic as ensurePoolForService)
+		image := ver.ImageUrl
+		if svc.Image != "" {
+			image = containerdx.NormalizeImageReference(svc.Image)
+		}
+
+		desiredSpec, err := l.buildSandboxSpec(ctx, app, ver, cfgSpec, svc.Name, image)
+		if err != nil {
+			return reaped, fmt.Errorf("build sandbox spec for service %s: %w", svc.Name, err)
+		}
+
+		stalePools, err := l.findStalePoolsForService(ctx, app.ID, svc.Name, desiredSpec)
+		if err != nil {
+			return reaped, fmt.Errorf("find stale pools for service %s: %w", svc.Name, err)
+		}
+
+		for _, pwe := range stalePools {
+			pool := pwe.Pool
+
+			// findStalePoolsForService keeps returning a pool while its sandboxes
+			// drain (the disk path re-waits on it). We don't wait, so a pool that's
+			// already at the target state needs no further action — skipping it
+			// avoids re-logging and re-writing the same husk every tick until its
+			// sandboxes finish stopping.
+			if pool.DesiredInstances == 0 && len(pool.ReferencedByVersions) == 0 {
+				continue
+			}
+
+			// Remove version references and scale to 0. Clearing refs also keeps
+			// cleanupOldVersionPools from redundantly touching the same pool.
+			pool.ReferencedByVersions = nil
+			pool.DesiredInstances = 0
+
+			l.Log.Info("reaping stale stateless pool",
+				"pool", pool.ID,
+				"service", pool.Service,
+				"app", app.ID)
+
+			if err := l.updatePool(ctx, pwe); err != nil {
+				return reaped, fmt.Errorf("update pool %s: %w", pool.ID, err)
+			}
+			reaped++
+		}
+	}
+
+	return reaped, nil
 }
 
 // findStalePoolsForService returns pools for the given app+service whose spec

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appclient "miren.dev/runtime/api/app"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	apiserver "miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -3779,4 +3781,374 @@ func TestEphemeralVersionDoesNotReuseExistingPool(t *testing.T) {
 	}
 	require.NotNil(t, ephPool, "ephemeral version should have its own pool")
 	require.NotNil(t, normalPool, "normal version's pool should remain unshared")
+}
+
+// TestStaleStatelessPoolReapedOnSameVersionSpecChange reproduces MIR-1432: a
+// binary change (not a new AppVersion) alters the baked sandbox spec, so the old
+// pool fails specsMatch and a replacement is created — but the old pool still
+// references the *current* version, so cleanupOldVersionPools (which keys on
+// version references) never reaps it. On garden this stranded a running duplicate
+// of every stateless app for ~15 hours. reapStaleStatelessPools must scale the
+// husk to zero.
+//
+// We simulate the binary-driven spec change by mutating the active version's
+// image in place (a scalar field, so the store Put replaces it cleanly) and
+// re-reconciling the same version. What matters is the invariant the incident
+// exercised: spec mismatch while the pool still references the current version.
+func TestStaleStatelessPoolReapedOnSameVersionSpecChange(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{Project: entity.Id("project-1")}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	ver := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "oci.miren.cloud/web:1",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-v1", ver)
+	require.NoError(t, err)
+	ver.ID = verID
+
+	app.ActiveVersion = ver.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	launcher := newTestLauncher(log, server.EAC)
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1, "one pool for the initial deploy")
+	oldPoolID := pools[0].ID
+	require.Contains(t, pools[0].ReferencedByVersions, ver.ID)
+
+	// Binary-driven spec change on the SAME version: the baked image differs, so
+	// the existing pool no longer matches, but the version ID is unchanged.
+	ver.ImageUrl = "oci.miren.cloud/web:2"
+	require.NoError(t, server.Client.Update(ctx, ver))
+
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	pools = listAllPools(t, ctx, server)
+	require.Len(t, pools, 2, "replacement pool created alongside the old one")
+
+	var oldPool, newPool *compute_v1alpha.SandboxPool
+	for i := range pools {
+		if pools[i].ID == oldPoolID {
+			oldPool = &pools[i]
+		} else {
+			newPool = &pools[i]
+		}
+	}
+	require.NotNil(t, oldPool, "old pool should still exist")
+	require.NotNil(t, newPool, "new pool should have been created")
+
+	// The core assertion: the stranded husk is reaped, not left running.
+	assert.Equal(t, int64(0), oldPool.DesiredInstances,
+		"stale same-version pool must be scaled to 0 (MIR-1432)")
+	assert.Empty(t, oldPool.ReferencedByVersions,
+		"reaped pool should have its version references cleared")
+
+	// And the replacement is the live one.
+	assert.Equal(t, "oci.miren.cloud/web:2", newPool.SandboxSpec.Container[0].Image)
+	assert.GreaterOrEqual(t, newPool.DesiredInstances, int64(1),
+		"replacement pool should be running")
+	assert.Contains(t, newPool.ReferencedByVersions, ver.ID)
+}
+
+// TestSteadyStateReconcileDoesNotReap guards against the reap firing on a no-op
+// pass: when nothing has changed, the single matching pool must be left exactly
+// as-is (no scale-to-zero, no churn — the reconciler runs every minute).
+func TestSteadyStateReconcileDoesNotReap(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{Project: entity.Id("project-1")}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	ver := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "oci.miren.cloud/web:1",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-v1", ver)
+	require.NoError(t, err)
+	ver.ID = verID
+
+	app.ActiveVersion = ver.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	launcher := newTestLauncher(log, server.EAC)
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	before := listAllPools(t, ctx, server)
+	require.Len(t, before, 1)
+
+	// Reconcile again with nothing changed.
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	after := listAllPools(t, ctx, server)
+	require.Len(t, after, 1, "steady-state reconcile must not create or drop pools")
+	assert.Equal(t, before[0].ID, after[0].ID, "same pool reused")
+	assert.Equal(t, int64(1), after[0].DesiredInstances,
+		"steady-state reconcile must not scale the live pool down")
+	assert.Contains(t, after[0].ReferencedByVersions, ver.ID)
+}
+
+// TestCreatePoolForVersionSerializesWithReconcile proves Fix B: the activator's
+// on-demand CreatePoolForVersion contends on the same per-app mutex Reconcile
+// holds. Without the shared lock, an activator-create racing a reconciler-create
+// can each miss the other's in-flight pool and both create one, duplicating every
+// sandbox (the tempo two-web-pools finding). We hold the app mutex and assert
+// CreatePoolForVersion blocks until it's released.
+func TestCreatePoolForVersionSerializesWithReconcile(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{Project: entity.Id("project-1")}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	ver := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "oci.miren.cloud/web:1",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{Name: "web"},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-v1", ver)
+	require.NoError(t, err)
+	ver.ID = verID
+
+	launcher := newTestLauncher(log, server.EAC)
+
+	// Take the per-app mutex Reconcile would hold, keyed exactly as both paths key
+	// it (on the app ID). CreatePoolForVersion keys on ver.App, which is app.ID.
+	val, _ := launcher.appMu.LoadOrStore(app.ID, &sync.Mutex{})
+	mu := val.(*sync.Mutex)
+	mu.Lock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, cErr := launcher.CreatePoolForVersion(ctx, ver, "web")
+		done <- cErr
+	}()
+
+	// While we hold the mutex, CreatePoolForVersion must not make progress.
+	select {
+	case <-done:
+		mu.Unlock()
+		t.Fatal("CreatePoolForVersion did not block on the per-app mutex — Fix B regressed")
+	case <-time.After(100 * time.Millisecond):
+		// Still blocked, as expected.
+	}
+
+	// Release the mutex; CreatePoolForVersion should now complete.
+	mu.Unlock()
+	select {
+	case cErr := <-done:
+		require.NoError(t, cErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("CreatePoolForVersion did not complete after mutex release")
+	}
+
+	// Exactly one pool — no duplicate creation.
+	pools := listAllPools(t, ctx, server)
+	assert.Len(t, pools, 1, "should create exactly one pool")
+}
+
+// TestReapSkipsServicesWithoutEnsuredReplacement guards the gate that keeps
+// reaping from scaling down a service's only pool when this pass failed to
+// ensure a replacement for it. A stale pool must survive when its service is
+// absent from ensuredServices, and only get reaped once the service is present.
+func TestReapSkipsServicesWithoutEnsuredReplacement(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{Project: entity.Id("project-1")}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	ver := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "oci.miren.cloud/web:1",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-v1", ver)
+	require.NoError(t, err)
+	ver.ID = verID
+
+	app.ActiveVersion = ver.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	launcher := newTestLauncher(log, server.EAC)
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+	poolID := pools[0].ID
+	require.Equal(t, int64(1), pools[0].DesiredInstances)
+
+	// Resolve the same spec reconcile used, then make the live pool stale purely
+	// via an image change on the version we pass to the reaper.
+	spec, err := coreutil.ResolveConfig(ctx, server.EAC, ver)
+	require.NoError(t, err)
+	ver.ImageUrl = "oci.miren.cloud/web:2"
+
+	// Replacement NOT ensured this pass: the stale pool must be left alone.
+	reaped, err := launcher.reapStaleStatelessPools(ctx, app, ver, spec, map[string]bool{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, reaped, "no reaping when the service's replacement wasn't ensured")
+
+	got, err := server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+	var pool compute_v1alpha.SandboxPool
+	pool.Decode(got.Entity().Entity())
+	assert.Equal(t, int64(1), pool.DesiredInstances,
+		"stale pool must survive while its replacement is missing")
+
+	// Replacement ensured: now the stale pool is reaped.
+	reaped, err = launcher.reapStaleStatelessPools(ctx, app, ver, spec, map[string]bool{"web": true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped, "stale pool reaped once its replacement is ensured")
+
+	got, err = server.EAC.Get(ctx, poolID.String())
+	require.NoError(t, err)
+	pool.Decode(got.Entity().Entity())
+	assert.Equal(t, int64(0), pool.DesiredInstances, "stale pool scaled to 0")
+}
+
+// TestConcurrentCreateAndReconcileNoDeadlock fires both lock-taking entry points
+// at the same app concurrently and asserts they both return (no deadlock under
+// contention) and converge on a single pool. The shared appMu is a single,
+// non-nested lock class, so a cycle isn't structurally possible; this is the
+// runtime backstop for that reasoning. Run under -race to catch data races too.
+func TestConcurrentCreateAndReconcileNoDeadlock(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{Project: entity.Id("project-1")}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	ver := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "oci.miren.cloud/web:1",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-v1", ver)
+	require.NoError(t, err)
+	ver.ID = verID
+
+	app.ActiveVersion = ver.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	launcher := newTestLauncher(log, server.EAC)
+
+	var wg sync.WaitGroup
+	var createErr, reconcileErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, createErr = launcher.CreatePoolForVersion(ctx, ver, "web")
+	}()
+	go func() {
+		defer wg.Done()
+		reconcileErr = launcher.Reconcile(ctx, app, nil)
+	}()
+
+	waited := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(waited)
+	}()
+
+	select {
+	case <-waited:
+		// Both returned — no deadlock.
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent CreatePoolForVersion + Reconcile deadlocked")
+	}
+
+	require.NoError(t, createErr, "CreatePoolForVersion should not error under contention")
+	require.NoError(t, reconcileErr, "Reconcile should not error under contention")
+
+	// Whichever ran the findMatchingPool scan second reuses the first pool, so
+	// contention converges on exactly one pool rather than duplicating it.
+	pools := listAllPools(t, ctx, server)
+	assert.Len(t, pools, 1, "concurrent create + reconcile must converge on one pool")
 }


### PR DESCRIPTION
The night #925 shipped the `MIREN_APP` → `MIREN_RUNTIME_APP` env var rename, garden woke up running two of every app. The autoupdate changed the binary that bakes each sandbox spec, so on restart every existing pool failed `specsMatch` on its now-stale env vars, and the launcher dutifully created a replacement pool for each one. The trouble is the replacements were created but the originals were never reaped, so for about 15 hours every stateless app had a duplicate sandbox running alongside it, and the reconciler hot-looped the mismatch log every minute without ever converging. The visible symptom was biscuit posting 4× duplicate reviews.

The root cause isn't the env rename, it's that the reconciler used two different definitions of pool identity. The create path asks "does the baked spec match?" while the stateless cleanup path asks "is this pool still referenced by the current version?". Those agree until something changes the spec without cutting a new AppVersion, which is exactly what a binary change does. Both the husk and its replacement referenced the same current version, so the version-keyed cleanup treated the husk as still-current and skipped it forever. Disk services dodged the whole thing because they already reap on spec mismatch via `drainStaleDiskPools`, just gated behind `serviceHasDisks`.

So the fix is to give stateless services that same spec-based reaping. The one wrinkle is ordering: disk pools drain before the new pool is created because they hold an exclusive lease, but stateless pools have no such constraint, so we create the replacement, wait for it to come up, and only then scale the stale husk to zero. That avoids any serving gap. It reuses the existing `findStalePoolsForService` and skips husks already at the target state so a pool draining its sandboxes doesn't re-churn the logs.

While in here I also closed a related race the same incident turned up: tempo got two web pools created at once. The activator's on-demand `CreatePoolForVersion` was ensuring pools without taking the per-app mutex that `Reconcile` holds, so an activator-create racing a reconciler-create could each miss the other's in-flight pool and both create one. It now takes the same lock. The reaping and the lock are a single, non-nested lock class, so there's no deadlock surface, and there's a test that fires both entry points concurrently to keep it that way.

The bigger architectural questions this raised (unifying the two identity notions, keeping runtime-injected vars out of the comparison surface entirely, a golden spec test) are captured as follow-up notes on MIR-1432, sequenced around Evan's MIR-1435 env-rename backcompat work.

Closes MIR-1432