### PR TITLE
Proposal: make version retention GC disk-pressure-aware

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1154,9 +1154,10 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		versionGCConfig.RetentionPeriod = c.AppVersionRetentionPeriod
 	}
 	c.versionGC = &versionctrl.GCController{
-		Log:    c.Log.With("module", "version-gc"),
-		EAC:    eac,
-		Config: versionGCConfig,
+		Log:      c.Log.With("module", "version-gc"),
+		EAC:      eac,
+		Config:   versionGCConfig,
+		DataPath: c.DataPath,
 	}
 	c.versionGC.Start(ctx)
 

--- a/controllers/version/gc.go
+++ b/controllers/version/gc.go
@@ -19,6 +19,7 @@ import (
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/appversion"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/sysstats"
 )
 
 // GCConfig holds configuration for app version retention GC.
@@ -31,14 +32,24 @@ type GCConfig struct {
 	// RetentionCount keeps this many most-recent versions per app regardless of
 	// age (default: 10).
 	RetentionCount int
+	// DiskPressureThreshold is the storage-usage percentage at or above which a
+	// sweep drops the RetentionPeriod floor and prunes each app down to its
+	// active version plus RetentionCount most-recent versions. Without this, the
+	// period floor pins every version younger than RetentionPeriod, so on a
+	// busy cluster the downstream image GC has nothing to reclaim and the disk
+	// fills. The active version and RetentionCount are always honored, even
+	// under pressure. Matches the image GC's threshold (default: 80). Zero
+	// disables pressure-aware pruning.
+	DiskPressureThreshold float64
 }
 
 // DefaultGCConfig returns the default GC configuration.
 func DefaultGCConfig() GCConfig {
 	return GCConfig{
-		CheckInterval:   1 * time.Hour,
-		RetentionPeriod: 30 * 24 * time.Hour,
-		RetentionCount:  10,
+		CheckInterval:         1 * time.Hour,
+		RetentionPeriod:       30 * 24 * time.Hour,
+		RetentionCount:        10,
+		DiskPressureThreshold: 80.0,
 	}
 }
 
@@ -64,6 +75,14 @@ type GCController struct {
 	EAC    *entityserver_v1alpha.EntityAccessClient
 	Config GCConfig
 
+	// DataPath is the server data directory sampled for disk usage when
+	// DiskPressureThreshold is set. Empty disables pressure-aware pruning.
+	DataPath string
+
+	// storagePercent samples current storage usage (0-100). Defaults to
+	// sysstats over DataPath when nil; overridden in tests.
+	storagePercent func() float64
+
 	cancel context.CancelFunc
 }
 
@@ -72,7 +91,8 @@ func (c *GCController) Start(ctx context.Context) {
 	c.Log.Info("starting version retention GC controller",
 		"check_interval", c.Config.CheckInterval,
 		"retention_period", c.Config.RetentionPeriod,
-		"retention_count", c.Config.RetentionCount)
+		"retention_count", c.Config.RetentionCount,
+		"disk_pressure_threshold", c.Config.DiskPressureThreshold)
 
 	ctx, c.cancel = context.WithCancel(ctx)
 	go c.run(ctx)
@@ -179,6 +199,12 @@ func (c *GCController) RunGC(ctx context.Context) (*GCResult, error) {
 	now := time.Now()
 	retentionCutoff := now.Add(-c.Config.RetentionPeriod)
 
+	// Under disk pressure, drop the age-based floor so retention collapses to
+	// the active version plus RetentionCount. The period floor otherwise pins
+	// every recent version's image, leaving the downstream image GC nothing to
+	// reclaim while the disk fills.
+	underPressure := c.underDiskPressure()
+
 	for appID, versions := range versionsByApp {
 		// Sort by creation time, newest first.
 		sort.Slice(versions, func(i, j int) bool {
@@ -188,11 +214,12 @@ func (c *GCController) RunGC(ctx context.Context) (*GCResult, error) {
 		activeVersion := activeVersions[appID]
 
 		for i, info := range versions {
-			// Always keep the active version, the most-recent N, and anything
-			// younger than the retention window.
+			// Always keep the active version and the most-recent N. Also keep
+			// anything younger than the retention window, unless we're under
+			// disk pressure and shedding the age-based floor.
 			if info.version.ID == activeVersion ||
 				i < c.Config.RetentionCount ||
-				info.createdAt.After(retentionCutoff) {
+				(!underPressure && info.createdAt.After(retentionCutoff)) {
 				result.RetainedVersions++
 				continue
 			}
@@ -237,6 +264,37 @@ func (c *GCController) RunGC(ctx context.Context) (*GCResult, error) {
 	}
 
 	return result, nil
+}
+
+// underDiskPressure reports whether current storage usage is at or above the
+// configured threshold, in which case the sweep drops the RetentionPeriod floor
+// and prunes each app to its active version plus RetentionCount. Returns false
+// when pressure-aware pruning is disabled (threshold <= 0) or no usage source is
+// available.
+func (c *GCController) underDiskPressure() bool {
+	if c.Config.DiskPressureThreshold <= 0 {
+		return false
+	}
+
+	sample := c.storagePercent
+	if sample == nil {
+		if c.DataPath == "" {
+			return false
+		}
+		sample = func() float64 {
+			return sysstats.CollectSystemStats(c.DataPath).StoragePercent
+		}
+	}
+
+	pct := sample()
+	if pct >= c.Config.DiskPressureThreshold {
+		c.Log.Info("disk pressure at or above threshold; dropping retention period floor for this sweep",
+			"storage_percent", pct,
+			"threshold", c.Config.DiskPressureThreshold,
+			"retention_count", c.Config.RetentionCount)
+		return true
+	}
+	return false
 }
 
 // activeVersions returns a map of app ID to its active version ID.

--- a/controllers/version/gc_test.go
+++ b/controllers/version/gc_test.go
@@ -138,6 +138,56 @@ func TestGCController_RetentionPeriod(t *testing.T) {
 	require.False(t, versionExists(t, inmem.EAC, old), "version older than retention window pruned")
 }
 
+func TestGCController_DiskPressureDropsPeriodFloor(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+	log := testutils.TestLogger(t)
+
+	appID, err := inmem.Client.Create(ctx, "pressureapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	now := time.Now()
+	// Four versions, all well within the retention period, so the age floor
+	// alone would retain every one of them.
+	ids := make([]entity.Id, 4)
+	for i := range 4 {
+		name := "v" + string(rune('1'+i))
+		ids[i] = createVersion(t, inmem.EAC, name,
+			&core_v1alpha.AppVersion{App: appID, Version: name},
+			now.Add(time.Duration(i-4)*time.Hour))
+	}
+
+	newController := func(storagePercent float64) *GCController {
+		return &GCController{
+			Log: log,
+			EAC: inmem.EAC,
+			Config: GCConfig{
+				CheckInterval:         time.Hour,
+				RetentionCount:        1,
+				RetentionPeriod:       30 * 24 * time.Hour,
+				DiskPressureThreshold: 80,
+			},
+			storagePercent: func() float64 { return storagePercent },
+		}
+	}
+
+	// Below threshold: the period floor keeps all four despite RetentionCount=1.
+	result, err := newController(50).RunGC(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, result.DeletedVersions, "no pruning below disk pressure threshold")
+	require.Equal(t, 4, result.RetainedVersions)
+
+	// At/above threshold: the period floor is dropped, collapsing retention to
+	// the single most-recent version (RetentionCount=1).
+	result, err = newController(85).RunGC(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 3, result.DeletedVersions, "period floor dropped under pressure")
+	require.Equal(t, 1, result.RetainedVersions)
+	require.True(t, versionExists(t, inmem.EAC, ids[3]), "most-recent version kept by count under pressure")
+	require.False(t, versionExists(t, inmem.EAC, ids[0]), "older recent version pruned under pressure")
+}
+
 func TestGCController_SkipsEphemeral(t *testing.T) {
 	ctx := context.Background()
 	inmem, cleanup := testutils.NewInMemEntityServer(t)

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -192,6 +192,8 @@ Every deploy creates a new version of an app, and Miren keeps a bounded history 
 
 A version is retained if it is among the most recent `retention_count` **or** newer than `retention_period` — whichever rule keeps it. The two settings are a floor, not a budget: raising either one keeps more versions. The currently active version is always retained regardless of these limits, and ephemeral (preview) versions are managed separately by their own TTL.
 
+Because `retention_period` keeps every version younger than the window regardless of count, a frequently-deployed app accumulates roughly `deploys-per-day × retention_period` versions — and each pins a container image, snapshot, and registry blob. To keep that from filling the disk, the version GC becomes disk-pressure-aware: once storage usage reaches the image GC's threshold (80%), a sweep drops the `retention_period` floor and prunes each app down to its active version plus `retention_count`, so the downstream image GC can reclaim space. The active version and `retention_count` are always honored. On high-deploy clusters, set a small `retention_period` (or rely on `retention_count`) rather than waiting for pressure.
+
 | Field | Type | Default | Description | Env Var | CLI Flag |
 |-------|------|---------|-------------|---------|----------|
 | `retention_count` | int | `10` | Most-recent versions to keep per app, regardless of age | `MIREN_APP_VERSION_RETENTION_COUNT` | `--app-version-retention-count` |


### PR DESCRIPTION
## What this is

We run a self-hosted single-node cluster and ran into steady disk-space growth from accumulated app-version images (background in mirendev/runtime#933). This is a **proposed addition** — an implementation we believe would address that — rather than a bug fix. The current retention behavior is intentional and documented, so treat this as a feature concept for discussion; we're very open to a different direction.

## Idea

Today a version is retained if it's among the most recent `retention_count` **or** newer than `retention_period`. On a cluster that deploys frequently, the period clause keeps a lot of recent versions, and since each one pins a container image, an overlayfs snapshot, and a registry blob, disk usage can climb faster than the window ages things out. The image GC runs under disk pressure, but it can only remove images whose version has already been pruned — so it doesn't reclaim much while those versions are still retained.

This adds a disk-pressure signal to the version GC: when storage usage reaches the image GC's threshold (80%), a sweep drops the `retention_period` floor and prunes each app down to its active version plus `retention_count`. Below the threshold, nothing changes.

## Implementation notes

- The active version and `retention_count` are **always** honored — only the age-based surplus is shed, and only while under pressure.
- Live-sandbox and mid-sweep pin re-checks are unchanged, so nothing in use is removed.
- Disk sampling is injected (`storagePercent`) so the behavior is unit-tested without touching real storage; production wires `DataPath` through the coordinator and samples via `sysstats`.

## Validation

- `go build` / `go vet` / `go test ./controllers/version/` pass, including a new test covering below- and above-threshold sweeps. (Full `iso`/`make test` suite should run in CI.)
- On our cluster, applying the equivalent policy by hand reclaimed ~330 GB (86% → 47% disk) — which is what prompted this. The idea here is to make that reclamation happen automatically under pressure instead of needing a manual retention change.

## Open questions — would love your take

- **Default-on vs opt-in:** it's currently on by default at 80% so a stock install benefits, but happy to gate it behind a config flag (default off) if you'd rather.
- **Threshold:** hardcoded to match the image GC's 80%; could be shared config for a single source of truth.
- If this isn't a direction you'd want, no worries at all — the concept (making retention disk-aware) matters more to us than this specific implementation.
