### PR TITLE
docs: add recipes for running Amp and OpenHands agents on Miren

### DIFF
--- a/docs/docs/recipes/amp-runner.md
+++ b/docs/docs/recipes/amp-runner.md
@@ -1,0 +1,321 @@
+---
+title: Run an Amp agent on Miren
+description: A worked example — run the Amp coding agent as a headless runner on Miren that dials out to ampcode.com and shows up as a Machine you drive from the web app.
+keywords: [amp, ampcode, ai agent, runner, machine, headless, remote thread, example, deploy]
+---
+
+import CliCommand from '@site/src/components/CliCommand';
+
+# Run an Amp agent on Miren
+
+Run [Amp](https://ampcode.com), a coding agent, as a headless **runner** on a
+Miren cluster. The container dials *out* to ampcode.com, registers as a Machine, and then
+waits. You create threads from the ampcode.com web app, pick this runner, and the work
+executes on Miren — streaming back to your browser.
+
+The end state: a single portless Miren service running `amp --no-tui`, connected to
+ampcode.com with an API key, with its working directory on a persistent Miren disk. There is
+**no inbound port, no dashboard, and no HTTP ingress** — ampcode.com is the control plane and
+the runner only makes outbound connections.
+
+Along the way it exercises real Miren behavior — custom Dockerfile builds, a **portless
+background service**, `0.0.0.0`-free networking (nothing listens), a writable network disk,
+and single-instance concurrency — so it doubles as a tour of running an outbound-only worker.
+
+:::info[This is an application recipe, not a language guide]
+For getting your own source code onto Miren, start with [Deployment](/deployment) and the
+[Language Guides](/guides). This page is about running a third-party agent as an
+outbound-only service.
+:::
+
+## How it works
+
+1. The Miren service runs `amp --no-tui --runner-id <id>` as a long-lived process.
+2. On start it reads `AMP_API_KEY` and dials ampcode.com, registering as runner `<id>`.
+3. Its `settings.json` has `amp.remoteThreadCreation.enabled: true`, so it accepts threads
+   created remotely.
+4. From the ampcode.com web app you create a thread on that runner. It runs in the runner's
+   working directory (`/workspace` on the disk) and streams output back to ampcode.com — and
+   to `miren logs`.
+
+Because a runner is identified by **host + working directory**, the persistent disk keeps its
+workspace (cloned repos, build caches) stable across redeploys.
+
+## Prerequisites
+
+- `miren` CLI installed and authenticated (`miren whoami`).
+- Access to the target cluster and its org.
+- An **Amp API key** from [ampcode.com/settings](https://ampcode.com/settings).
+- Outbound HTTPS to ampcode.com allowed from the cluster (see [Firewall](/firewall) if you
+  restrict egress).
+
+## Select the target cluster
+
+If the cluster isn't configured locally yet, list what your identity can see and add it
+(this pins the TLS fingerprint):
+
+<CliCommand context="client">
+
+```bash
+# Add a cluster your cloud identity can see (interactive picker; pins the TLS fingerprint)
+miren cluster add -i cloud
+
+miren whoami -C amp
+```
+
+</CliCommand>
+
+The commands below target it explicitly with `-C amp`. Omit `-C` to use your default cluster.
+
+## The Dockerfile
+
+Amp ships as a CLI, not a container image, so build a thin image that installs it with the
+official installer (a standalone binary — no Node required). Include the tools the agent will
+reach for when it runs shell commands (`git`, `ripgrep`, `curl`):
+
+```dockerfile
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates ripgrep curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install the Amp CLI to a fixed location and put it on PATH. AMP_VERSION pins the
+# release for reproducible builds; drop it to track latest, or bump it deliberately.
+ENV AMP_HOME=/opt/amp
+RUN curl -fsSL https://ampcode.com/install.sh | AMP_VERSION=0.0.1784319456-g6a2cfc bash \
+  && ln -s /opt/amp/bin/amp /usr/local/bin/amp
+
+COPY runner.sh /usr/local/bin/runner.sh
+RUN chmod +x /usr/local/bin/runner.sh
+```
+
+:::note[Why the extra symlink]
+The installer drops the binary at `$AMP_HOME/bin/amp` and tries to symlink it into a
+per-user PATH directory (`~/.local/bin`). Building as root, that isn't reliably on `PATH`, so
+the recipe symlinks `/opt/amp/bin/amp` into `/usr/local/bin` explicitly.
+:::
+
+:::note[No ENTRYPOINT or CMD needed]
+Miren runs the service `command` from `app.toml` via `/bin/sh -c "<cmd>"`, so this image
+doesn't need an `ENTRYPOINT` or `CMD` — `runner.sh` is invoked directly (see below).
+:::
+
+## The runner entrypoint
+
+`runner.sh` prepares a writable home and settings on the disk, enables remote thread
+creation, clears any stale runner lock left on the disk by a prior deploy, then hands off to
+the runner with `exec` so signals reach Amp and Miren can stop it cleanly:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKSPACE="${AMP_WORKSPACE:-/workspace}"
+mkdir -p "$HOME" "$WORKSPACE" "$(dirname "$AMP_SETTINGS_FILE")"
+
+# Enable remote thread creation so ampcode.com can dispatch threads to this runner.
+if [ ! -f "$AMP_SETTINGS_FILE" ]; then
+  cat > "$AMP_SETTINGS_FILE" <<'JSON'
+{
+  "amp.remoteThreadCreation.enabled": true,
+  "amp.notifications.enabled": false
+}
+JSON
+fi
+
+# Amp records a per-directory runner lock (a pidfile under its cache). With HOME on a
+# persistent disk that survives redeploys, a stale pidfile makes the new runner refuse to
+# start ("Another Amp process is already serving remote threads"). The Miren disk lease
+# guarantees only one runner container at a time, so any pidfile here at boot is stale.
+rm -f "$HOME/.cache/amp/pids/"*.pid 2>/dev/null || true
+
+# Optional: seed a repo for the agent to work in. Adapt or remove.
+# if [ ! -d "$WORKSPACE/repo/.git" ]; then
+#   git clone https://github.com/you/your-repo "$WORKSPACE/repo"
+# fi
+
+cd "$WORKSPACE"
+exec amp --no-tui --runner-id "$AMP_RUNNER_ID"
+```
+
+## The app.toml
+
+This file lives at `.miren/app.toml` in your project (not the repo root). If you haven't set
+the project up yet, `miren init` creates it for you; otherwise create the `.miren/` directory
+and add the file below. The `Dockerfile` and `runner.sh` stay at the project root.
+
+```toml
+name = "amp-runner"
+
+[build]
+dockerfile = "Dockerfile"
+
+# Portless background service: nothing listens, so no `port`/`port_type`.
+[services.runner]
+command = "runner.sh"
+
+[services.runner.concurrency]
+mode = "fixed"
+num_instances = 1
+
+[[services.runner.disks]]
+name = "workspace"
+provider = "miren"
+mount_path = "/workspace"
+size_gb = 20
+filesystem = "ext4"
+
+[[env]]
+key = "AMP_RUNNER_ID"
+value = "miren-amp"  # a valid hostname; shown as the Machine name on ampcode.com
+[[env]]
+key = "AMP_SETTINGS_FILE"
+value = "/workspace/amp/settings.json"
+[[env]]
+key = "HOME"
+value = "/workspace/home"
+[[env]]
+key = "AMP_LOG_LEVEL"
+value = "info"
+
+[[env]]
+key = "AMP_API_KEY"
+required = true
+sensitive = true
+```
+
+:::warning[Enable remote thread creation or nothing runs]
+A runner with `amp.remoteThreadCreation.enabled` unset connects to ampcode.com but silently
+accepts no threads. `runner.sh` writes it into the settings file pointed at by
+`AMP_SETTINGS_FILE` — keep that in place.
+:::
+
+:::warning[Portless service — name it `runner`, not `web`]
+This service has no `port`/`port_type`, so Miren does no HTTP ingress and no port health
+check. Do **not** name it `web`: Miren's ingress routes an app's hostname to the `web`
+service, and a portless `web` service returns `error acquiring lease: app/amp-runner`
+(HTTP 500) for every request. Any other name (like `runner`) is fine.
+:::
+
+:::warning[Keep the process alive — it self-reconnects]
+`amp --no-tui` is a long-lived daemon (unlike `amp -x`, which runs one prompt and exits).
+Miren restarts the service if the process exits, and the runner re-registers with ampcode.com
+after a bounce. On redeploy it may briefly appear as a new Machine connection before the old
+one drops.
+:::
+
+:::warning[Stable runner id and working directory]
+A runner is identified by host **and** working directory. Set a stable `AMP_RUNNER_ID` (a
+valid hostname) so the Machine is easy to pick in the web app, and keep the working directory
+fixed at `/workspace`. The directory does not have to be a git repo.
+:::
+
+:::danger[Constrain the agent — it runs arbitrary shell]
+A runner executes agent-driven shell commands as the container user with full access to
+`/workspace`. Use a dedicated Amp API key (revocable independently), treat the workspace as
+untrusted, and consider Amp's `amp.commands.allowlist` / `amp.commands.strict` settings to
+limit what it can run unattended.
+:::
+
+:::warning[A Miren disk forces single-instance, churny rollouts]
+A `provider = "miren"` (network) disk holds one exclusive lease, so it requires
+`concurrency mode = "fixed"` with `num_instances = 1`. On redeploy the new instance can't
+mount `/workspace` until the old one releases the lease, so `miren deploy` may print
+`did not become healthy` while the instance actually comes up a few seconds later — re-check
+`miren app status` / `miren sandbox list` before assuming failure. If you'd rather have snappy
+rollouts and don't need node-independent storage, use `provider = "local"` (no lease, no
+fixed-instance requirement; workspace is node-local).
+:::
+
+:::note[Point HOME and settings at the disk]
+Amp reads `~/.config/amp` and may write cache and logs. Setting `HOME=/workspace/home` and
+`AMP_SETTINGS_FILE=/workspace/amp/settings.json` keeps that state on the writable mounted
+disk instead of a read-only image path.
+:::
+
+:::warning[Redeploys leave a stale runner lock on the disk]
+Amp writes a per-directory runner lock — a pidfile under `$HOME/.cache/amp/pids/`. Because
+`HOME` is on the persistent disk, that pidfile survives a redeploy, and the fresh runner
+refuses to start with `Another Amp process is already serving remote threads for /workspace`.
+`runner.sh` deletes stale pidfiles on boot before launching Amp; the disk's single-instance
+lease guarantees no live runner is ever using them.
+:::
+
+Add a `.dockerignore` so local secrets and Miren state stay out of the build context (secrets
+are passed with `miren deploy -s`, never baked into the image):
+
+```text
+.env
+.miren
+```
+
+## Deploy
+
+Non-secret config lives in `app.toml`. Pass the API key with `-s` (masked in output, stored
+server-side); never bake it into the image:
+
+<CliCommand context="client">
+```bash
+miren deploy -a amp-runner -C amp -f \
+  -s "AMP_API_KEY=sgamp_..."
+```
+</CliCommand>
+
+Validate the config without building at any time:
+
+<CliCommand context="client">
+```bash
+miren deploy --analyze -a amp-runner -C amp
+```
+</CliCommand>
+
+## Verify
+
+<CliCommand context="client">
+```bash
+miren app status -a amp-runner -C amp       # Current Version + active
+miren sandbox list -C amp                   # one running sandbox, service "runner"
+miren logs -a amp-runner -C amp --since 5m  # look for the runner connecting to ampcode.com
+```
+</CliCommand>
+
+Then open [ampcode.com](https://ampcode.com): the Machine `miren-amp` should appear as a
+connected runner. Create a thread on it, send a prompt, and confirm the work executes — output
+streams in the ampcode.com web UI and in `miren logs`.
+
+## Using the runner
+
+- **Create work from ampcode.com:** start a thread targeting the `miren-amp` Machine. It runs
+  in `/workspace` on the cluster.
+- **Pre-seed a repo:** clone into the workspace once, and it persists on the disk:
+
+<CliCommand context="client">
+```bash
+miren sandbox list -C amp                   # grab the sandbox id
+miren sandbox exec <sandbox-id> -C amp -- \
+  git clone https://github.com/you/your-repo /workspace/repo
+```
+</CliCommand>
+
+- **Rotate the key:** deploy again with a new `-s "AMP_API_KEY=..."`; the runner reconnects on
+  restart.
+
+## Roadblock checklist
+
+1. Set `amp.remoteThreadCreation.enabled: true` (in `runner.sh`), or the runner accepts no threads.
+2. Portless service: omit `port`/`port_type`, and name it `runner`, not `web` (else `error acquiring lease`).
+3. Run the daemon `amp --no-tui`, not `amp -x` — the service command must not exit.
+4. Give it a stable `AMP_RUNNER_ID` (valid hostname) and a fixed working directory.
+5. A `miren` disk means `fixed` / `num_instances = 1`; expect `did not become healthy` noise on redeploy (verify state before retrying). Use `local` for snappy rollouts.
+6. Point `HOME` and `AMP_SETTINGS_FILE` at the writable disk.
+7. Clear Amp's stale runner pidfile on boot (in `runner.sh`), or redeploys crash-loop with `Another Amp process is already serving remote threads`.
+8. The agent runs arbitrary shell — use a dedicated key and constrain it.
+
+## Next steps
+
+- [App Configuration](/app-configuration) — the full `app.toml` reference in context
+- [Persistent Storage](/disks) — Miren disks vs. local disks
+- [Deployment](/deployment) — deploying your own source to Miren
+- [Firewall](/firewall) — controlling egress if you restrict outbound traffic
+- [Using Dockerfile.miren](/guides#using-dockerfilemiren) — building from your own Dockerfile

--- a/docs/docs/recipes/amp-runner.md
+++ b/docs/docs/recipes/amp-runner.md
@@ -46,8 +46,11 @@ workspace (cloned repos, build caches) stable across redeploys.
 - `miren` CLI installed and authenticated (`miren whoami`).
 - Access to the target cluster and its org.
 - An **Amp API key** from [ampcode.com/settings](https://ampcode.com/settings).
-- Outbound HTTPS to ampcode.com allowed from the cluster (see [Firewall](/firewall) if you
-  restrict egress).
+- Outbound HTTPS from the cluster to Amp's domains (see [Firewall](/firewall) if you restrict
+  egress): `ampcode.com` (service + installer), `auth.ampcode.com` (authentication),
+  `production.ampworkers.com` (the runner's WebSocket connection), and `static.ampcode.com`
+  (binary downloads for install and `amp update`). A narrower allowlist can let the build or
+  runner start while authentication or registration silently fails.
 
 ## Select the target cluster
 
@@ -103,26 +106,29 @@ doesn't need an `ENTRYPOINT` or `CMD` — `runner.sh` is invoked directly (see b
 
 ## The runner entrypoint
 
-`runner.sh` prepares a writable home and settings on the disk, enables remote thread
-creation, clears any stale runner lock left on the disk by a prior deploy, then hands off to
-the runner with `exec` so signals reach Amp and Miren can stop it cleanly:
+`runner.sh` writes Amp's settings on the disk (enabling remote thread creation so ampcode.com
+can dispatch threads to it — without this the runner connects but silently accepts nothing),
+clears any stale runner lock left on the disk by a prior deploy, then hands off to the runner
+with `exec` so signals reach Amp and Miren can stop it cleanly:
 
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Working directory for the runner. Override with AMP_WORKSPACE (in app.toml [[env]]) if you
+# change the disk mount_path.
 WORKSPACE="${AMP_WORKSPACE:-/workspace}"
 mkdir -p "$HOME" "$WORKSPACE" "$(dirname "$AMP_SETTINGS_FILE")"
 
-# Enable remote thread creation so ampcode.com can dispatch threads to this runner.
-if [ ! -f "$AMP_SETTINGS_FILE" ]; then
-  cat > "$AMP_SETTINGS_FILE" <<'JSON'
+# Enable remote thread creation so ampcode.com can dispatch threads to this runner. Rewritten
+# on every boot (not just when absent) so a stale settings file left on the persistent disk
+# can't silently keep the setting off after you change this recipe. Edit the keys to reconfigure.
+cat > "$AMP_SETTINGS_FILE" <<'JSON'
 {
   "amp.remoteThreadCreation.enabled": true,
   "amp.notifications.enabled": false
 }
 JSON
-fi
 
 # Amp records a per-directory runner lock (a pidfile under its cache). With HOME on a
 # persistent disk that survives redeploys, a stale pidfile makes the new runner refuse to
@@ -166,9 +172,13 @@ mount_path = "/workspace"
 size_gb = 20
 filesystem = "ext4"
 
+# A stable, valid hostname, shown as the Machine name on ampcode.com. A runner is identified
+# by host + working directory, so keep this fixed to make it easy to pick in the web app.
 [[env]]
 key = "AMP_RUNNER_ID"
-value = "miren-amp"  # a valid hostname; shown as the Machine name on ampcode.com
+value = "miren-amp"
+# Keep Amp's settings, cache, and logs on the writable disk. Amp otherwise reads/writes
+# ~/.config/amp, which lands on a read-only image path.
 [[env]]
 key = "AMP_SETTINGS_FILE"
 value = "/workspace/amp/settings.json"
@@ -185,30 +195,15 @@ required = true
 sensitive = true
 ```
 
-:::warning[Enable remote thread creation or nothing runs]
-A runner with `amp.remoteThreadCreation.enabled` unset connects to ampcode.com but silently
-accepts no threads. `runner.sh` writes it into the settings file pointed at by
-`AMP_SETTINGS_FILE` — keep that in place.
-:::
+`amp --no-tui` is a long-lived daemon (unlike `amp -x`, which runs one prompt and exits): Miren
+restarts it if it exits, and the runner re-registers with ampcode.com after a bounce (it may
+briefly show as a new Machine connection before the old one drops).
 
 :::warning[Portless service — name it `runner`, not `web`]
 This service has no `port`/`port_type`, so Miren does no HTTP ingress and no port health
 check. Do **not** name it `web`: Miren's ingress routes an app's hostname to the `web`
 service, and a portless `web` service returns `error acquiring lease: app/amp-runner`
 (HTTP 500) for every request. Any other name (like `runner`) is fine.
-:::
-
-:::warning[Keep the process alive — it self-reconnects]
-`amp --no-tui` is a long-lived daemon (unlike `amp -x`, which runs one prompt and exits).
-Miren restarts the service if the process exits, and the runner re-registers with ampcode.com
-after a bounce. On redeploy it may briefly appear as a new Machine connection before the old
-one drops.
-:::
-
-:::warning[Stable runner id and working directory]
-A runner is identified by host **and** working directory. Set a stable `AMP_RUNNER_ID` (a
-valid hostname) so the Machine is easy to pick in the web app, and keep the working directory
-fixed at `/workspace`. The directory does not have to be a git repo.
 :::
 
 :::danger[Constrain the agent — it runs arbitrary shell]
@@ -226,12 +221,6 @@ mount `/workspace` until the old one releases the lease, so `miren deploy` may p
 `miren app status` / `miren sandbox list` before assuming failure. If you'd rather have snappy
 rollouts and don't need node-independent storage, use `provider = "local"` (no lease, no
 fixed-instance requirement; workspace is node-local).
-:::
-
-:::note[Point HOME and settings at the disk]
-Amp reads `~/.config/amp` and may write cache and logs. Setting `HOME=/workspace/home` and
-`AMP_SETTINGS_FILE=/workspace/amp/settings.json` keeps that state on the writable mounted
-disk instead of a read-only image path.
 :::
 
 :::warning[Redeploys leave a stale runner lock on the disk]

--- a/docs/docs/recipes/openhands-agent-server.md
+++ b/docs/docs/recipes/openhands-agent-server.md
@@ -1,0 +1,245 @@
+---
+title: Run an OpenHands agent server
+description: A worked example — run OpenHands' agent server as a self-contained Miren app that executes the coding agent in its own container (no Docker socket) behind an API-key-authenticated HTTP/WebSocket API.
+keywords: [openhands, agent server, ai agent, coding agent, agent canvas, backend, api, example, deploy]
+---
+
+import CliCommand from '@site/src/components/CliCommand';
+
+# Run an OpenHands agent server
+
+[OpenHands](https://docs.openhands.dev) is an AI coding agent. Its
+[Agent Canvas](https://docs.openhands.dev/openhands/usage/agent-canvas/backends) architecture
+splits into a **backend** (an *agent server* that runs the agent in a workspace) and a
+**frontend** (any Agent Canvas client that connects to it). This recipe deploys the
+**agent server** as a self-contained Miren app.
+
+The end state: OpenHands' agent server running as one Miren `web` service on port 8000,
+executing the agent **inside its own container** — no Docker socket, no sibling sandbox
+container — behind an HTTP/WebSocket API protected by a session key, with conversation and
+workspace state on a persistent disk. You point an Agent Canvas client (or the OpenHands SDK)
+at its URL to drive it.
+
+:::info[This is the backend, not the whole UI]
+OpenHands' full local app spawns a **separate sandbox container per conversation via the host
+Docker socket** — which Miren does not expose. The *agent server* is the piece that runs the
+agent in-process in its own container, so it's the part that fits Miren cleanly. Run an
+[Agent Canvas](https://docs.openhands.dev/openhands/usage/agent-canvas) client elsewhere (or in
+the browser) and connect it to this server.
+:::
+
+## How it works
+
+1. The Miren `web` service runs `openhands-agent-server` on `0.0.0.0:8000`.
+2. It authenticates clients with a session key (`X-Session-API-Key` header).
+3. A client (Agent Canvas or the SDK) creates a conversation, passing the LLM model + key and
+   the agent's tools. The agent runs **in this container**, reading/writing its workspace on
+   the mounted disk.
+4. Conversations, the agent workspace, and bash-event history persist under `/data`.
+
+## Prerequisites
+
+- `miren` CLI installed and authenticated (`miren whoami`).
+- Access to the target cluster and its org.
+- An **LLM API key** (e.g. Anthropic) — supplied by the *client* when it starts a
+  conversation, and encrypted at rest by the server's `OH_SECRET_KEY`.
+
+## Select the target cluster
+
+<CliCommand context="client">
+```bash
+# Add a cluster your cloud identity can see (interactive picker; pins the TLS fingerprint)
+miren cluster add -i cloud
+
+miren whoami -C openhands
+```
+</CliCommand>
+
+The commands below target it with `-C openhands`. Omit `-C` to use your default cluster.
+
+## The Dockerfile
+
+The agent server ships as a prebuilt image; wrap it and clear the entrypoint so Miren runs the
+service command from `app.toml`:
+
+```dockerfile
+FROM ghcr.io/openhands/agent-server:main-python
+ENTRYPOINT []
+```
+
+:::tip[Pin a version]
+`main-python` tracks the latest `main` build of the Python agent-server variant. For
+reproducible deploys, pin one of the commit-tagged images (e.g.
+`ghcr.io/openhands/agent-server:<sha>-python`) instead and bump it deliberately.
+:::
+
+## The app.toml
+
+This file lives at `.miren/app.toml`.
+
+```toml
+name = "openhands-agent-server"
+
+[build]
+dockerfile = "Dockerfile"
+
+[services.web]
+command = "exec /usr/local/bin/openhands-agent-server --host 0.0.0.0 --port 8000"
+port = 8000
+port_type = "http"
+port_timeout = "300s"
+
+[services.web.concurrency]
+mode = "fixed"
+num_instances = 1
+
+# Node-local persistence for conversations, the agent workspace, and bash-event history.
+[[services.web.disks]]
+name = "workspace"
+provider = "local"
+mount_path = "/data"
+
+# The server's default state paths are RELATIVE to its working directory and fail to create;
+# point them at absolute paths on the writable disk.
+[[env]]
+key = "OH_CONVERSATIONS_PATH"
+value = "/data/conversations"
+[[env]]
+key = "OH_WORKSPACE_PATH"
+value = "/data/project"
+[[env]]
+key = "OH_BASH_EVENTS_DIR"
+value = "/data/bash_events"
+
+# CORS origin for a browser-based Agent Canvas client (set to your frontend's URL).
+[[env]]
+key = "OH_ALLOW_CORS_ORIGINS_0"
+value = "https://your-agent-canvas-frontend.example.com"
+
+[[env]]
+key = "OH_SESSION_API_KEYS_0"
+required = true
+sensitive = true
+[[env]]
+key = "OH_SECRET_KEY"
+required = true
+sensitive = true
+```
+
+:::warning[Set absolute workspace paths]
+The server's `conversations_path` / `workspace_path` / `bash_events_dir` default to paths
+**relative to the process working directory** (`workspace/…`), which it can't create at
+startup — the server exits with `PermissionError: 'workspace'`. Set `OH_CONVERSATIONS_PATH`,
+`OH_WORKSPACE_PATH`, and `OH_BASH_EVENTS_DIR` to absolute paths on the mounted disk.
+:::
+
+:::warning[Use a `local` disk, and let it run as the image's user]
+Mount the workspace with `provider = "local"`. Don't add a `USER root` to the Dockerfile — the
+image runs as its own `openhands` user, and a writable disk is made writable for the run user
+automatically; forcing root opts out of that.
+:::
+
+:::warning[The agent runs arbitrary shell in this container]
+A client can make the agent execute shell commands as the container user against `/data`. Use
+a dedicated, revocable session key, treat the workspace as untrusted, and keep the server
+reachable only over its authenticated API.
+:::
+
+:::info[The client supplies the LLM]
+Unlike a typical app, the agent server does not take `LLM_API_KEY` itself — the client passes
+the model and key when it creates a conversation. `OH_SECRET_KEY` encrypts those secrets where
+the server persists them.
+:::
+
+Add a `.dockerignore` so local secrets stay out of the build context:
+
+```text
+.env
+.miren
+```
+
+## Deploy
+
+Generate the two secrets once, save them somewhere safe, and pass them with `-s`:
+
+<CliCommand context="client">
+```bash
+SESSION_KEY=$(openssl rand -hex 32)   # clients send this as X-Session-API-Key
+SECRET_KEY=$(openssl rand -hex 32)    # encrypts stored secrets
+
+miren deploy -a openhands-agent-server -C openhands -f \
+  -s "OH_SESSION_API_KEYS_0=$SESSION_KEY" \
+  -s "OH_SECRET_KEY=$SECRET_KEY"
+```
+</CliCommand>
+
+Validate the config without building at any time:
+
+<CliCommand context="client">
+```bash
+miren deploy --analyze -a openhands-agent-server -C openhands
+```
+</CliCommand>
+
+## Add a hostname route
+
+<CliCommand context="client">
+```bash
+miren route set agent.openhands.clusters.miren.run openhands-agent-server -C openhands
+miren route list -C openhands
+```
+</CliCommand>
+
+## Verify
+
+<CliCommand context="client">
+```bash
+miren app status -a openhands-agent-server -C openhands   # Current Version + active
+miren sandbox list -C openhands                           # one running sandbox, service "web"
+
+# Health check is public; the API requires the session key:
+curl -s -o /dev/null -w "%{http_code}\n" https://agent.openhands.clusters.miren.run/alive          # 200
+curl -s -o /dev/null -w "%{http_code}\n" https://agent.openhands.clusters.miren.run/api/conversations   # 401
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -H "X-Session-API-Key: $SESSION_KEY" \
+  https://agent.openhands.clusters.miren.run/api/conversations                                     # 200/422 (auth OK)
+```
+</CliCommand>
+
+## Connect a client
+
+Run an [Agent Canvas](https://docs.openhands.dev/openhands/usage/agent-canvas) frontend
+(locally, or as its own service), open **Manage Backends → Add Backend**, and enter:
+
+- **URL:** `https://agent.openhands.clusters.miren.run`
+- **API key:** the **session key** you generated for `OH_SESSION_API_KEYS_0` at deploy time
+  (the `$SESSION_KEY` from the deploy step). This is the same value clients send as the
+  `X-Session-API-Key` header.
+
+:::warning[Save the session key when you generate it]
+`OH_SESSION_API_KEYS_0` is a `sensitive` env var, so Miren masks it in `miren app status` and
+logs — it can't be read back after deploy. Store the value you generated somewhere safe (a
+password manager); it's what you paste into the frontend. Lost it? Deploy again with a new
+`-s "OH_SESSION_API_KEYS_0=..."` to rotate it, then update the frontend.
+:::
+
+For a browser-based frontend, set `OH_ALLOW_CORS_ORIGINS_0` (above) to that frontend's origin.
+You can also drive the server directly with the OpenHands SDK, which sends the same
+`X-Session-API-Key` header and passes your LLM config per conversation.
+
+## Roadblock checklist
+
+1. The agent server runs on **port 8000**, not 3000 — set `port = 8000`.
+2. Set `OH_CONVERSATIONS_PATH` / `OH_WORKSPACE_PATH` / `OH_BASH_EVENTS_DIR` to absolute paths, or the server exits with `PermissionError: 'workspace'`.
+3. Use a `provider = "local"` disk; don't force `USER root` (it opts out of the disk being made writable for the run user).
+4. Clients authenticate with the `X-Session-API-Key` header; set `OH_SESSION_API_KEYS_0` and `OH_SECRET_KEY`.
+5. For a browser frontend, set `OH_ALLOW_CORS_ORIGINS_0` to its origin.
+6. The client — not the server — supplies the LLM model and key.
+7. Raise `port_timeout`; the image is large and first boot is slow.
+
+## Next steps
+
+- [App Configuration](/app-configuration) — the full `app.toml` reference in context
+- [Persistent Storage](/disks) — local vs. Miren disks
+- [Traffic Routing](/traffic-routing) — how the `web` service and routes fit together
+- [Deploy the Amp agent runner](/recipes/amp-runner) — another headless coding-agent recipe

--- a/docs/docs/recipes/openhands-agent-server.md
+++ b/docs/docs/recipes/openhands-agent-server.md
@@ -145,11 +145,9 @@ a dedicated, revocable session key, treat the workspace as untrusted, and keep t
 reachable only over its authenticated API.
 :::
 
-:::info[The client supplies the LLM]
-Unlike a typical app, the agent server does not take `LLM_API_KEY` itself — the client passes
-the model and key when it creates a conversation. `OH_SECRET_KEY` encrypts those secrets where
+Unlike a typical app, the agent server takes no `LLM_API_KEY` of its own — the client passes the
+model and key when it creates a conversation, and `OH_SECRET_KEY` encrypts those secrets where
 the server persists them.
-:::
 
 Add a `.dockerignore` so local secrets stay out of the build context:
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -87,6 +87,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'recipes/hermes-agent',
         'recipes/amp-runner',
+        'recipes/openhands-agent-server',
       ],
     },
     {

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -86,6 +86,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'recipes/hermes-agent',
+        'recipes/amp-runner',
       ],
     },
     {


### PR DESCRIPTION
Adds two Recipes guides for running headless coding agents on Miren, both validated end-to-end on a live cluster.

## Amp agent runner (`recipes/amp-runner.md`)
Run [Amp](https://ampcode.com) as a headless **runner** that dials out to ampcode.com, registers as a Machine, and executes threads created from the web app. A portless background service — no inbound port, no dashboard. Covers the official installer, `amp --no-tui --runner-id`, enabling remote thread creation, a stable runner id, and clearing Amp's stale per-directory runner lock on redeploy (a persistent-disk gotcha discovered during validation).

## OpenHands agent server (`recipes/openhands-agent-server.md`)
Run OpenHands' **agent server** (the Agent Canvas backend) as a self-contained Miren app that executes the coding agent **in its own container** — no Docker socket, no sibling sandbox — behind a session-key-authenticated HTTP/WebSocket API, with conversation and workspace state on a local disk.

OpenHands' full UI can't run single-container on Miren (it spawns a sandbox container per conversation via the host Docker socket, which Miren doesn't expose). The agent server is the piece that runs the agent in-process, so it fits cleanly and is driven by an Agent Canvas client. The recipe documents the non-obvious bits: absolute `OH_*_PATH` workspace env vars (the relative default crashes with `PermissionError: 'workspace'`), running as the image's non-root user, a `local` disk, session-key auth (`X-Session-API-Key`), CORS for browser clients, and how to get the session key onto the frontend.

## Notes
- Docs-only; `bun run build` (lint + Docusaurus) passes.
- Both recipes were deployed and exercised on a live cluster — Amp registered as a Machine and ran threads; the OpenHands agent server ran a real shell task in-container.