### PR TITLE
docs: keep admonitions from stacking into walls

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -37,6 +37,13 @@ Rules:
 2. One concept per admonition; keep the body concise — the type tag already
    carries the "importance" signal. Don't nest admonitions.
 3. Always close with `:::` on its own line.
+4. Don't stack them. More than two or three admonitions in a row and the
+   "this is important" signal collapses into wallpaper — the reader (and the
+   retrieval agent) can no longer tell the load-bearing gotcha from the aside.
+   Reserve callouts for what actually breaks, surprises, or bites; explanatory
+   "here's why this value" context belongs in prose or a code comment, not a
+   box. When a section genuinely has many gotchas, one scannable summary (a
+   roadblock checklist, a table) beats a column of boxes.
 
 `hack/gen-command-docs` also emits admonitions; keep it consistent with the
 above. The docs lint (`bun run lint`) enforces these rules.

--- a/docs/docs/recipes/hermes-agent.md
+++ b/docs/docs/recipes/hermes-agent.md
@@ -133,17 +133,12 @@ only via a messaging platform or `miren sandbox exec`), name the service somethi
 and omit `port`/`port_type` — then Miren does no HTTP ingress and no port health check.
 :::
 
-:::warning[Bind 0.0.0.0, not localhost]
-Miren health-checks and routes to the port from *outside* the container. Hermes components
-default to `127.0.0.1`. Set `HERMES_DASHBOARD_HOST=0.0.0.0` (and `API_SERVER_HOST=0.0.0.0`
-if you ever enable the API server) or the health check reports
-`nothing is listening on :<port>`.
-:::
-
-:::warning[First boot is slow — raise port_timeout]
-s6 init, first-boot seeding, and a config-schema migration all run before the port binds.
-Set `port_timeout = "180s"` so the health check doesn't give up at the 15-second default.
-:::
+Two details in that config bite if you skip them. Miren health-checks and routes to the
+port from *outside* the container, but Hermes components default to `127.0.0.1` — set
+`HERMES_DASHBOARD_HOST=0.0.0.0` (and `API_SERVER_HOST=0.0.0.0` if you ever enable the API
+server) or the health check reports `nothing is listening on :<port>`. And first boot is
+slow: s6 init, first-boot seeding, and a config-schema migration all run before the port
+binds, so `port_timeout = "180s"` keeps the check from giving up at the 15-second default.
 
 :::warning[A Miren disk forces single-instance, churny rollouts]
 A `provider = "miren"` (network) disk holds one exclusive lease, so it requires


### PR DESCRIPTION
PR #907 unified our callouts on Docusaurus admonitions with the right intent: surface genuine gotchas so they do not get flattened to plain text on retrieval. But it never said anything about *density*, and the way you make a gotcha stand out is by it actually standing out. Once a section stacks eight near-identical yellow boxes, that signal is gone. The reader cannot tell the load-bearing warning from the explanatory aside, and neither can a retrieval agent.

This adds a fourth rule to `docs/CLAUDE.md`: do not stack more than two or three admonitions in a row, and keep "here is why this value" context in prose or a code comment. Reserve the callout treatment for what actually breaks, surprises, or bites.

It applies the rule to the Hermes recipe as the first cleanup, folding the `bind 0.0.0.0` and `port_timeout` warnings into a sentence between the two callouts that genuinely bite (the `web`-name lease error and the disk-churn rollout). The roadblock checklist still carries the scannable summary, so no content is lost.

This is groundwork for reviewing #938, whose two new agent recipes have the same wall-of-callouts shape. That review will point here and ask them to align.

`bun run lint` passes. The density rule is guidance, not lint-enforced: Check 4 still only polices type, title, and inline-bold.