### PR TITLE
Type the node-id boundary with compute_v1alpha.NodeId

### DIFF
--- a/api/compute/compute_v1alpha/node_id.go
+++ b/api/compute/compute_v1alpha/node_id.go
@@ -1,0 +1,50 @@
+package compute_v1alpha
+
+import (
+	"strings"
+
+	entity "miren.dev/runtime/pkg/entity"
+)
+
+// nodeIdPrefix is the human-id prefix for the compute node kind (KindNode,
+// "dev.miren.compute/kind.node"). This is the one and only place the prefix
+// is written; every node id is built through NewNodeId.
+const nodeIdPrefix = "node/"
+
+// NodeId is the entity ID of a compute node, always in canonical
+// "node/<raw>" form. Construct one only via NewNodeId, which is the single
+// sanctioned way to apply the "node/" prefix; that discipline is what keeps
+// a raw identifier from ever being mistaken for a prefixed one. Convert back
+// to a plain entity.Id with Id() when handing it to the entity store.
+type NodeId entity.Id
+
+// NewNodeId builds a NodeId from a raw node identifier (a UUID, or "miren"
+// for the primary node), normalizing so the "node/" prefix is present
+// exactly once regardless of whether the input already carried it.
+func NewNodeId(raw string) NodeId {
+	// Strip any number of leading "node/" segments so a raw id, an already
+	// prefixed id, and an accidentally double-prefixed one all collapse to
+	// exactly one prefix.
+	for strings.HasPrefix(raw, nodeIdPrefix) {
+		raw = raw[len(nodeIdPrefix):]
+	}
+	return NodeId(nodeIdPrefix + raw)
+}
+
+// Id returns the node id as a plain entity.Id, for use with the entity store
+// and any API that speaks entity.Id.
+func (n NodeId) Id() entity.Id {
+	return entity.Id(n)
+}
+
+// String returns the canonical string form, e.g. "node/abc123".
+func (n NodeId) String() string {
+	return string(n)
+}
+
+// Matches reports whether id refers to this node. Use it to compare a NodeId
+// against a bare entity.Id read from an entity field (e.g. a disk volume's
+// NodeId) without re-prefixing either side.
+func (n NodeId) Matches(id entity.Id) bool {
+	return entity.Id(n) == id
+}

--- a/api/compute/compute_v1alpha/node_id_test.go
+++ b/api/compute/compute_v1alpha/node_id_test.go
@@ -1,0 +1,42 @@
+package compute_v1alpha
+
+import (
+	"testing"
+
+	entity "miren.dev/runtime/pkg/entity"
+)
+
+func TestNewNodeId(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want NodeId
+	}{
+		{"raw uuid", "abc123", "node/abc123"},
+		{"primary", "miren", "node/miren"},
+		{"already prefixed", "node/abc123", "node/abc123"},
+		{"double prefixed", "node/node/abc123", "node/abc123"},
+		{"triple prefixed", "node/node/node/abc123", "node/abc123"},
+		{"empty", "", "node/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NewNodeId(tc.raw); got != tc.want {
+				t.Fatalf("NewNodeId(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNodeIdMatches(t *testing.T) {
+	n := NewNodeId("abc123")
+	if !n.Matches(entity.Id("node/abc123")) {
+		t.Fatalf("expected %q to match node/abc123", n)
+	}
+	if n.Matches(entity.Id("node/other")) {
+		t.Fatalf("did not expect %q to match node/other", n)
+	}
+	if n.Matches(entity.Id("abc123")) {
+		t.Fatalf("unprefixed raw id should not match a canonical NodeId")
+	}
+}

--- a/cli/commands/disk_undelete.go
+++ b/cli/commands/disk_undelete.go
@@ -143,7 +143,7 @@ func DiskUndelete(ctx *Context, opts struct {
 	nodeId, err := resolver.findNodeId(context.Background())
 	if err != nil {
 		ctx.Warn("Failed to find node ID, using stored value: %v", err)
-		nodeId = entity.Id(meta.NodeID)
+		nodeId = meta.NodeID.Id()
 	}
 
 	imagePath := filepath.Join(destPath, "disk.img")

--- a/components/diskio/cloud_integration_test.go
+++ b/components/diskio/cloud_integration_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/lbd"
@@ -475,7 +477,7 @@ func TestCloudIntegrationFullRoundTrip(t *testing.T) {
 	// Replay using the real cloudDiskClient → mock server
 	cloudClient := NewCloudDiskClient(slog.Default(), mock.URL(), authClient)
 	state := NewState()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloudClient)
 
 	err = mc.replayMissingSegments(context.Background(), &VolumeState{
@@ -641,7 +643,7 @@ func TestCloudIntegrationIncrementalReplay(t *testing.T) {
 	// Replay
 	cloudClient := NewCloudDiskClient(slog.Default(), mock.URL(), authClient)
 	state := NewState()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloudClient)
 
 	err = mc.replayMissingSegments(context.Background(), &VolumeState{
@@ -709,7 +711,7 @@ func TestCloudIntegrationOverwriteSemantics(t *testing.T) {
 
 	cloudClient := NewCloudDiskClient(slog.Default(), mock.URL(), authClient)
 	state := NewState()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloudClient)
 
 	err = mc.replayMissingSegments(context.Background(), &VolumeState{

--- a/components/diskio/deleted_volume.go
+++ b/components/diskio/deleted_volume.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 )
 
 const (
@@ -17,15 +19,15 @@ const (
 // DeletedVolumeMetadata stores information about a soft-deleted disk volume
 // so it can be restored via the undelete command.
 type DeletedVolumeMetadata struct {
-	DiskID     string    `json:"disk_id"`
-	DiskName   string    `json:"disk_name"`
-	SizeGb     int64     `json:"size_gb"`
-	Filesystem string    `json:"filesystem"`
-	VolumeID   string    `json:"volume_id"`
-	VolumeMode string    `json:"volume_mode"`
-	CreatedBy  string    `json:"created_by,omitempty"`
-	NodeID     string    `json:"node_id"`
-	DeletedAt  time.Time `json:"deleted_at"`
+	DiskID     string         `json:"disk_id"`
+	DiskName   string         `json:"disk_name"`
+	SizeGb     int64          `json:"size_gb"`
+	Filesystem string         `json:"filesystem"`
+	VolumeID   string         `json:"volume_id"`
+	VolumeMode string         `json:"volume_mode"`
+	CreatedBy  string         `json:"created_by,omitempty"`
+	NodeID     compute.NodeId `json:"node_id"`
+	DeletedAt  time.Time      `json:"deleted_at"`
 }
 
 // DeletedVolumesPath returns the path to the deleted-volumes directory.

--- a/components/diskio/deleted_volume_test.go
+++ b/components/diskio/deleted_volume_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +23,7 @@ func TestSaveAndLoadDeletedVolumeMetadata(t *testing.T) {
 		VolumeID:   "disk-vol-xyz",
 		VolumeMode: "volume_mode.vm_universal",
 		CreatedBy:  "user/user-1",
-		NodeID:     "node/node-1",
+		NodeID:     compute.NewNodeId("node-1"),
 		DeletedAt:  time.Now().Truncate(time.Millisecond),
 	}
 

--- a/components/diskio/disk_mount_controller.go
+++ b/components/diskio/disk_mount_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/cond"
@@ -33,7 +34,7 @@ type writeTracker interface {
 type DiskMountController struct {
 	log      *slog.Logger
 	dataPath string
-	nodeId   string
+	nodeId   compute.NodeId
 	eac      *entityserver_v1alpha.EntityAccessClient
 	state    *State
 	ops      DiskMountOps
@@ -51,7 +52,7 @@ type DiskMountController struct {
 	keepMounts bool
 }
 
-func NewDiskMountController(log *slog.Logger, dataPath, nodeId string, state *State, ops DiskMountOps) *DiskMountController {
+func NewDiskMountController(log *slog.Logger, dataPath string, nodeId compute.NodeId, state *State, ops DiskMountOps) *DiskMountController {
 	return &DiskMountController{
 		log:      log.With("module", "disk-mount"),
 		dataPath: dataPath,
@@ -92,8 +93,7 @@ func (c *DiskMountController) Reconcile(ctx context.Context, mount *storage_v1al
 }
 
 func (c *DiskMountController) Index() entity.Attr {
-	fullNodeId := "node/" + c.nodeId
-	return entity.Ref(storage_v1alpha.DiskMountNodeIdId, entity.Id(fullNodeId))
+	return entity.Ref(storage_v1alpha.DiskMountNodeIdId, c.nodeId.Id())
 }
 
 // Shutdown releases cloud leases. Mount/detach cleanup is handled by
@@ -711,8 +711,7 @@ func (c *DiskMountController) ReconcileWithEntities(ctx context.Context) error {
 		return fmt.Errorf("entity access client not set; call SetEAC before reconciling")
 	}
 
-	fullNodeId := "node/" + c.nodeId
-	nodeIdRef := entity.Id(fullNodeId)
+	nodeIdRef := c.nodeId.Id()
 	indexAttr := entity.Ref(storage_v1alpha.DiskMountNodeIdId, nodeIdRef)
 
 	resp, err := c.eac.List(ctx, indexAttr)
@@ -728,7 +727,7 @@ func (c *DiskMountController) ReconcileWithEntities(ctx context.Context) error {
 		var mount storage_v1alpha.DiskMount
 		mount.Decode(entResp.Entity())
 
-		if string(mount.NodeId) != fullNodeId {
+		if !c.nodeId.Matches(mount.NodeId) {
 			continue
 		}
 

--- a/components/diskio/disk_mount_controller_test.go
+++ b/components/diskio/disk_mount_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"testing"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -14,7 +16,7 @@ import (
 )
 
 func newTestDiskMountController(log *slog.Logger, dataPath, nodeId string, eac *entityserver_v1alpha.EntityAccessClient, state *State, ops DiskMountOps) *DiskMountController {
-	mc := NewDiskMountController(log, dataPath, nodeId, state, ops)
+	mc := NewDiskMountController(log, dataPath, compute.NewNodeId(nodeId), state, ops)
 	mc.SetEAC(eac)
 	return mc
 }
@@ -52,7 +54,7 @@ func TestDiskMountControllerReconcileMountMounted(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-123",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-123",
 		MountPath:    "/mnt/data",
 		ReadOnly:     false,
@@ -137,7 +139,7 @@ func TestDiskMountControllerAdoptsExistingLoopDevice(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-972",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-972",
 		MountPath:    "/mnt/data",
 		ReadOnly:     false,
@@ -198,7 +200,7 @@ func TestDiskMountControllerReconcileMountUnmounted(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-456",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-456",
 		MountPath:    "/mnt/data",
 		DesiredState: storage_v1alpha.DM_WANT_UNMOUNTED,
@@ -244,7 +246,7 @@ func TestDiskMountControllerReconcileSkipsOtherNodes(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-other",
-		NodeId:       entity.Id("node/other-node"),
+		NodeId:       compute.NewNodeId("other-node").Id(),
 		VolumeId:     "disk_volume/vol-other",
 		MountPath:    "/mnt/other",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -285,7 +287,7 @@ func TestDiskMountControllerReconcileMountAlreadyMounted(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-ready",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-ready",
 		MountPath:    "/mnt/ready",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -318,7 +320,7 @@ func TestDiskMountControllerReconcileVolumeNotFound(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-missing",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-missing",
 		MountPath:    "/mnt/missing",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -365,7 +367,7 @@ func TestDiskMountControllerReconcileMountReadOnly(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-ro",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-ro",
 		MountPath:    "/mnt/readonly",
 		ReadOnly:     true,
@@ -407,7 +409,7 @@ func TestDiskMountControllerReconcileAlreadyDetached(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-detached",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-detached",
 		MountPath:    "/mnt/detached",
 		DesiredState: storage_v1alpha.DM_WANT_UNMOUNTED,
@@ -446,7 +448,7 @@ func TestDiskMountControllerReconcileErrorRecovery(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-err",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-err",
 		MountPath:    "/mnt/recover",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -490,7 +492,7 @@ func TestDiskMountControllerMultipleMounts(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		mount := &storage_v1alpha.DiskMount{
 			ID:           entity.Id("disk_mount/mnt-" + string(rune('0'+i))),
-			NodeId:       entity.Id("node/" + nodeId),
+			NodeId:       compute.NewNodeId(nodeId).Id(),
 			VolumeId:     entity.Id("disk_volume/vol-" + string(rune('0'+i))),
 			MountPath:    "/mnt/data" + string(rune('0'+i)),
 			DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -583,7 +585,7 @@ func TestDiskMountControllerReconcileKeepsNonOrphanedMounts(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-keep",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-keep",
 		MountPath:    "/mnt/keep",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -608,7 +610,7 @@ func TestDiskMountControllerShutdown(t *testing.T) {
 	state := NewState()
 	ops := newMockDiskMountOps()
 
-	mc := NewDiskMountController(log, dataPath, nodeId, state, ops)
+	mc := NewDiskMountController(log, dataPath, compute.NewNodeId(nodeId), state, ops)
 
 	// Mount state with no cloud client — Shutdown should be a no-op for unmount/detach
 	// (DiskVolumeController handles that now)
@@ -643,7 +645,7 @@ func TestDiskMountControllerUnmountNotInState(t *testing.T) {
 	// Mount not in local state but entity requests unmount
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-gone",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-gone",
 		MountPath:    "/mnt/gone",
 		DesiredState: storage_v1alpha.DM_WANT_UNMOUNTED,
@@ -691,7 +693,7 @@ func TestDiskMountControllerUniversalSkipsMountOnAttach(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-uni",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-uni",
 		MountPath:    "/mnt/vol-uni",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -750,7 +752,7 @@ func TestDiskMountControllerUniversalSkipsUnmountOnDetach(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-uni-off",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-uni",
 		MountPath:    "/mnt/vol-uni",
 		DesiredState: storage_v1alpha.DM_WANT_UNMOUNTED,
@@ -784,7 +786,7 @@ func TestDiskMountControllerUniversalShutdownSkips(t *testing.T) {
 	state := NewState()
 	ops := newMockDiskMountOps()
 
-	mc := NewDiskMountController(log, dataPath, nodeId, state, ops)
+	mc := NewDiskMountController(log, dataPath, compute.NewNodeId(nodeId), state, ops)
 
 	ops.mountedPaths["/mnt/uni"] = true
 	ops.mountedPaths["/mnt/acc"] = true

--- a/components/diskio/disk_mount_orphan_sweep_test.go
+++ b/components/diskio/disk_mount_orphan_sweep_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 	"time"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
-	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 )
 
@@ -44,7 +45,7 @@ func TestDiskMountControllerRecordsSelfWrites(t *testing.T) {
 	// error path), which is exactly the write we need to record.
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-selfwrite",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-missing",
 		MountPath:    "/mnt/selfwrite",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -75,7 +76,7 @@ func TestDiskMountControllerSelfWritesNilTrackerSafe(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-nil-tracker",
-		NodeId:       entity.Id("node/test-node-1"),
+		NodeId:       compute.NewNodeId("test-node-1").Id(),
 		VolumeId:     "disk_volume/vol-missing",
 		MountPath:    "/mnt/nil",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -105,7 +106,7 @@ func TestReconcileOrphanMountsDeletesMissingVolume(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-orphan",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-gone",
 		MountPath:    "/mnt/orphan",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -151,14 +152,14 @@ func TestReconcileOrphanMountsKeepsMountWithExistingVolume(t *testing.T) {
 
 	createDiskVolumeEntity(ctx, t, es, &storage_v1alpha.DiskVolume{
 		ID:     "disk_volume/vol-live",
-		NodeId: entity.Id("node/" + nodeId),
+		NodeId: compute.NewNodeId(nodeId).Id(),
 		DiskId: "disk/disk-live",
 		SizeGb: 10,
 	})
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-live",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-live",
 		MountPath:    "/mnt/live",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
@@ -190,7 +191,7 @@ func TestReconcileOrphanMountsRespectsGracePeriod(t *testing.T) {
 
 	mount := &storage_v1alpha.DiskMount{
 		ID:           "disk_mount/mnt-young",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		VolumeId:     "disk_volume/vol-gone",
 		MountPath:    "/mnt/young",
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,

--- a/components/diskio/disk_volume_controller.go
+++ b/components/diskio/disk_volume_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/entity"
@@ -26,7 +27,7 @@ func alwaysMount(mode storage_v1alpha.DiskVolumeVolumeMode) bool {
 type DiskVolumeController struct {
 	log      *slog.Logger
 	dataPath string
-	nodeId   string
+	nodeId   compute.NodeId
 	eac      *entityserver_v1alpha.EntityAccessClient
 	state    *State
 	ops      DiskVolumeOps
@@ -41,7 +42,7 @@ type DiskVolumeController struct {
 	orphanSweepDone bool
 }
 
-func NewDiskVolumeController(log *slog.Logger, dataPath, nodeId string, state *State, ops DiskVolumeOps, mntOps DiskMountOps) *DiskVolumeController {
+func NewDiskVolumeController(log *slog.Logger, dataPath string, nodeId compute.NodeId, state *State, ops DiskVolumeOps, mntOps DiskMountOps) *DiskVolumeController {
 	return &DiskVolumeController{
 		log:      log.With("module", "disk-volume"),
 		dataPath: dataPath,
@@ -71,8 +72,7 @@ func (c *DiskVolumeController) Reconcile(ctx context.Context, volume *storage_v1
 }
 
 func (c *DiskVolumeController) Index() entity.Attr {
-	fullNodeId := "node/" + c.nodeId
-	return entity.Ref(storage_v1alpha.DiskVolumeNodeIdId, entity.Id(fullNodeId))
+	return entity.Ref(storage_v1alpha.DiskVolumeNodeIdId, c.nodeId.Id())
 }
 
 func (c *DiskVolumeController) reconcileVolume(ctx context.Context, volume *storage_v1alpha.DiskVolume) error {
@@ -385,7 +385,7 @@ func (c *DiskVolumeController) softDeleteVolume(ctx context.Context, volume *sto
 		Filesystem: volume.Filesystem,
 		VolumeID:   volState.VolumeId,
 		VolumeMode: string(volume.VolumeMode),
-		NodeID:     string(volume.NodeId),
+		NodeID:     compute.NewNodeId(string(volume.NodeId)),
 		DeletedAt:  time.Now(),
 	}
 
@@ -787,8 +787,7 @@ func (c *DiskVolumeController) ReconcileWithEntities(ctx context.Context) error 
 		return fmt.Errorf("entity access client not set; call SetEAC before reconciling")
 	}
 
-	fullNodeId := "node/" + c.nodeId
-	nodeIdRef := entity.Id(fullNodeId)
+	nodeIdRef := c.nodeId.Id()
 	indexAttr := entity.Ref(storage_v1alpha.DiskVolumeNodeIdId, nodeIdRef)
 
 	resp, err := c.eac.List(ctx, indexAttr)
@@ -806,7 +805,7 @@ func (c *DiskVolumeController) ReconcileWithEntities(ctx context.Context) error 
 
 		entityIds[string(volume.ID)] = struct{}{}
 
-		if string(volume.NodeId) != fullNodeId {
+		if !c.nodeId.Matches(volume.NodeId) {
 			continue
 		}
 

--- a/components/diskio/disk_volume_controller_test.go
+++ b/components/diskio/disk_volume_controller_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -18,7 +20,7 @@ import (
 
 func newTestDiskVolumeController(log *slog.Logger, dataPath, nodeId string, eac *entityserver_v1alpha.EntityAccessClient, state *State, ops DiskVolumeOps) *DiskVolumeController {
 	mntOps := newMockDiskMountOps()
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, ops, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, ops, mntOps)
 	vc.SetEAC(eac)
 	return vc
 }
@@ -47,7 +49,7 @@ func TestDiskVolumeControllerReconcileVolumePresent(t *testing.T) {
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-123",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		DesiredState: storage_v1alpha.DV_PRESENT,
@@ -116,7 +118,7 @@ func TestDiskVolumeControllerReconcileVolumeAbsent(t *testing.T) {
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-456",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       5,
 		Filesystem:   "xfs",
 		DesiredState: storage_v1alpha.DV_ABSENT,
@@ -159,7 +161,7 @@ func TestDiskVolumeControllerReconcileSkipsOtherNodes(t *testing.T) {
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-other",
-		NodeId:       entity.Id("node/other-node"),
+		NodeId:       compute.NewNodeId("other-node").Id(),
 		SizeGb:       10,
 		DesiredState: storage_v1alpha.DV_PRESENT,
 		ActualState:  storage_v1alpha.DV_PENDING,
@@ -199,7 +201,7 @@ func TestDiskVolumeControllerReconcileVolumeAlreadyReady(t *testing.T) {
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-ready",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		DesiredState: storage_v1alpha.DV_PRESENT,
@@ -241,7 +243,7 @@ func TestDiskVolumeControllerReconcileVolumeReadyButMissing(t *testing.T) {
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-missing",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		DesiredState: storage_v1alpha.DV_PRESENT,
@@ -279,7 +281,7 @@ func TestDiskVolumeControllerReconcileVolumeErrorRetry(t *testing.T) {
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-err",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		DesiredState: storage_v1alpha.DV_PRESENT,
@@ -365,7 +367,7 @@ func TestDiskVolumeControllerReconcileKeepsNonOrphanedVolumes(t *testing.T) {
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-keep",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		DesiredState: storage_v1alpha.DV_PRESENT,
@@ -400,7 +402,7 @@ func TestDiskVolumeControllerMultipleVolumes(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		vol := &storage_v1alpha.DiskVolume{
 			ID:           entity.Id("disk_volume/vol-" + string(rune('0'+i))),
-			NodeId:       entity.Id("node/" + nodeId),
+			NodeId:       compute.NewNodeId(nodeId).Id(),
 			SizeGb:       int64(i * 10),
 			Filesystem:   "ext4",
 			DesiredState: storage_v1alpha.DV_PRESENT,
@@ -445,7 +447,7 @@ func TestDiskVolumeControllerReconcilePersistedVolumeOnDisk(t *testing.T) {
 	// Entity is in PENDING state but local state has the volume on disk
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-persist",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		DesiredState: storage_v1alpha.DV_PRESENT,
@@ -485,7 +487,7 @@ func TestDiskVolumeControllerDeleteNotInState(t *testing.T) {
 	// Volume not in local state but entity requests deletion
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-gone",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		DesiredState: storage_v1alpha.DV_ABSENT,
 		ActualState:  storage_v1alpha.DV_READY,
@@ -516,12 +518,12 @@ func TestDiskVolumeControllerUniversalMountAtCreation(t *testing.T) {
 	volOps := newMockDiskVolumeOps()
 	mntOps := newMockDiskMountOps()
 
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, volOps, mntOps)
 	vc.SetEAC(es.EAC)
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-uni",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
@@ -585,12 +587,12 @@ func TestDiskVolumeControllerUniversalRemountOnReconcile(t *testing.T) {
 	})
 	volOps.existingPaths[volPath] = true
 
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, volOps, mntOps)
 	vc.SetEAC(es.EAC)
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-remount",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
@@ -657,12 +659,12 @@ func TestDiskVolumeControllerUniversalAdoptsExistingLoopDevice(t *testing.T) {
 	mntOps.loopBacking = map[string]string{imagePath: staleLoopDev}
 	mntOps.formattedDevs[staleLoopDev] = "ext4"
 
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, volOps, mntOps)
 	vc.SetEAC(es.EAC)
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-972",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
@@ -727,12 +729,12 @@ func TestDiskVolumeControllerUniversalFailsClosedWhenFindLoopErrors(t *testing.T
 	// Simulate sysfs being unreadable.
 	mntOps.findLoopErr = errors.New("sysfs read error")
 
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, volOps, mntOps)
 	vc.SetEAC(es.EAC)
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-fcl",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
@@ -786,7 +788,7 @@ func TestDiskVolumeControllerOrphanLoopSweep(t *testing.T) {
 	foreignImage := "/some/other/place/disk.img"
 	mntOps.loopBacking[foreignImage] = foreignLoopDev
 
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, volOps, mntOps)
 	vc.SetEAC(es.EAC)
 
 	err := vc.ReconcileWithEntities(ctx)
@@ -833,7 +835,7 @@ func TestDiskVolumeControllerOrphanSweepUnmountsBeforeDetach(t *testing.T) {
 	mntOps.mountedPaths[orphanMountPath] = true
 	mntOps.mountDevices[orphanMountPath] = orphanLoopDev
 
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, volOps, mntOps)
 	vc.SetEAC(es.EAC)
 
 	err := vc.ReconcileWithEntities(ctx)
@@ -892,12 +894,12 @@ func TestDiskVolumeControllerUniversalUnmountOnDelete(t *testing.T) {
 	volOps.existingPaths[volDir] = true
 	mntOps.mountedPaths[mountPath] = true
 
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, volOps, mntOps)
 	vc.SetEAC(es.EAC)
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-del",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
@@ -960,7 +962,7 @@ func TestDiskVolumeControllerShutdown(t *testing.T) {
 	mntOps.mountedPaths[accMountPath] = true
 	mntOps.mountDevices[accMountPath] = "/dev/lbd0"
 
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, volOps, mntOps)
 
 	vc.Shutdown()
 
@@ -996,12 +998,12 @@ func TestDiskVolumeControllerAcceleratorNoMountAtCreation(t *testing.T) {
 	volOps := newMockDiskVolumeOps()
 	mntOps := newMockDiskMountOps()
 
-	vc := NewDiskVolumeController(log, dataPath, nodeId, state, volOps, mntOps)
+	vc := NewDiskVolumeController(log, dataPath, compute.NewNodeId(nodeId), state, volOps, mntOps)
 	vc.SetEAC(es.EAC)
 
 	vol := &storage_v1alpha.DiskVolume{
 		ID:           "disk_volume/vol-acc",
-		NodeId:       entity.Id("node/" + nodeId),
+		NodeId:       compute.NewNodeId(nodeId).Id(),
 		SizeGb:       10,
 		Filesystem:   "ext4",
 		VolumeMode:   storage_v1alpha.VM_ACCELERATOR,

--- a/components/diskio/segment_replay_test.go
+++ b/components/diskio/segment_replay_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/lbd"
@@ -104,7 +106,7 @@ func TestReplayOneSegmentWriteEntries(t *testing.T) {
 		downloadData: map[string][]byte{"seg-1": segData},
 	}
 
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", NewState(), newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), NewState(), newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	img, err := openDiskImage(diskPath)
@@ -163,7 +165,7 @@ func TestReplayMissingSegmentsFiltersbyHorizon(t *testing.T) {
 		DiskPath: volDir,
 	})
 
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	volState := state.GetVolume("disk_volume/vol1")
@@ -191,7 +193,7 @@ func TestReplayMissingSegmentsNoRemoteSegments(t *testing.T) {
 	}
 
 	state := NewState()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	err := mc.replayMissingSegments(context.Background(), &VolumeState{
@@ -217,7 +219,7 @@ func TestReplayMissingSegmentsAllAlreadyApplied(t *testing.T) {
 	}
 
 	state := NewState()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	err := mc.replayMissingSegments(context.Background(), &VolumeState{
@@ -268,7 +270,7 @@ func TestReplayMissingSegmentsMultiple(t *testing.T) {
 	}
 
 	state := NewState()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	err = mc.replayMissingSegments(context.Background(), &VolumeState{
@@ -306,7 +308,7 @@ func TestReplayMissingSegmentsDownloadError(t *testing.T) {
 	}
 
 	state := NewState()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	err = mc.replayMissingSegments(context.Background(), &VolumeState{
@@ -456,7 +458,7 @@ func TestReplayToQCow2Image(t *testing.T) {
 	}
 
 	state := NewState()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	err = mc.replayMissingSegments(context.Background(), &VolumeState{
@@ -501,7 +503,7 @@ func TestLeaseAcquiredBeforeReplay(t *testing.T) {
 	})
 
 	ops := newMockDiskMountOps()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, ops)
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, ops)
 	mc.SetCloudClient(cloud)
 
 	// The lease is acquired in attachAndMount, which requires an EAC.
@@ -523,7 +525,7 @@ func TestLeaseReleasedOnUnmount(t *testing.T) {
 		LeaseNonce: "nonce-abc",
 	})
 
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	// Shutdown should release leases
@@ -545,7 +547,7 @@ func TestLeaseNotReleasedWithoutNonce(t *testing.T) {
 		LeaseNonce: "", // no lease
 	})
 
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	mc.Shutdown()
@@ -562,7 +564,7 @@ func TestLeaseNotReleasedWithoutCloudClient(t *testing.T) {
 		LeaseNonce: "some-nonce",
 	})
 
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	// No cloud client set
 
 	// Should not panic
@@ -607,7 +609,7 @@ func TestReplayOverwriteAtSameBlock(t *testing.T) {
 	}
 
 	state := NewState()
-	mc := NewDiskMountController(slog.Default(), tmpDir, "node-1", state, newMockDiskMountOps())
+	mc := NewDiskMountController(slog.Default(), tmpDir, compute.NewNodeId("node-1"), state, newMockDiskMountOps())
 	mc.SetCloudClient(cloud)
 
 	err = mc.replayMissingSegments(context.Background(), &VolumeState{

--- a/components/runner/disk_controller_integration_test.go
+++ b/components/runner/disk_controller_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/controllers/disk"
@@ -20,11 +22,11 @@ func TestDiskControllersCanBeCreated(t *testing.T) {
 		log := slog.Default()
 
 		// Create disk controller (entity-only mode)
-		diskController := disk.NewDiskController(log, nil, "test-node", "", true)
+		diskController := disk.NewDiskController(log, nil, compute.NewNodeId("test-node"), "", true)
 		r.NotNil(diskController)
 
 		// Create disk lease controller (entity-only mode)
-		diskLeaseController := disk.NewDiskLeaseController(log, nil, "test-node", "")
+		diskLeaseController := disk.NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 		r.NotNil(diskLeaseController)
 
 		// Verify controllers can be initialized
@@ -40,8 +42,8 @@ func TestDiskControllersCanBeCreated(t *testing.T) {
 		log := slog.Default()
 
 		// Create controllers (entity-only mode)
-		diskController := disk.NewDiskController(log, nil, "test-node", "", true)
-		diskLeaseController := disk.NewDiskLeaseController(log, nil, "test-node", "")
+		diskController := disk.NewDiskController(log, nil, compute.NewNodeId("test-node"), "", true)
+		diskLeaseController := disk.NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 		// Verify they can be adapted for the controller manager
 		diskAdapter := controller.AdaptController(diskController)

--- a/components/runner/integration_test.go
+++ b/components/runner/integration_test.go
@@ -120,7 +120,7 @@ func TestRunnerCoordinatorIntegration(t *testing.T) {
 	eac := entityserver_v1alpha.EntityAccessClient{Client: client}
 
 	// Check the node entity for the runner
-	nodeId := "node/" + runnerCfg.Id
+	nodeId := compute.NewNodeId(runnerCfg.Id).String()
 
 	// Poll for the node entity to be ready (wait for runner startup to complete)
 	var nodeRes *entityserver_v1alpha.EntityAccessClientGetResults

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -217,6 +217,14 @@ func (r *Runner) entityClient() *entityserver.Client {
 	return r.ec
 }
 
+// nodeId returns this runner's own node identity in canonical node/<raw>
+// form. r.Id is the raw runner id from config; everything that references this
+// node in the entity store goes through here so the node-id prefix is applied
+// consistently in exactly one place (see compute_v1alpha.NewNodeId).
+func (r *Runner) nodeId() compute_v1alpha.NodeId {
+	return compute_v1alpha.NewNodeId(r.Id)
+}
+
 // Drain sets the runner's node status to disabled and stops all running sandboxes
 func (r *Runner) Drain(ctx context.Context) error {
 	ec := r.entityClient()
@@ -228,7 +236,7 @@ func (r *Runner) Drain(ctx context.Context) error {
 
 	// Set node status to disabled
 	r.Log.Info("setting node status to disabled", "id", r.Id)
-	err := ec.UpdateAttrs(ctx, entity.Id(r.Id), (&compute_v1alpha.Node{
+	err := ec.UpdateAttrs(ctx, r.nodeId().Id(), (&compute_v1alpha.Node{
 		Status: compute_v1alpha.DISABLED,
 	}).Encode)
 	if err != nil {
@@ -238,7 +246,7 @@ func (r *Runner) Drain(ctx context.Context) error {
 	r.Log.Info("node status set to disabled", "id", r.Id)
 
 	// List all sandboxes scheduled to this node
-	idx := compute_v1alpha.Index(compute_v1alpha.KindSandbox, entity.Id("node/"+r.Id))
+	idx := compute_v1alpha.Index(compute_v1alpha.KindSandbox, r.nodeId().Id())
 	results, err := ec.List(ctx, idx)
 	if err != nil {
 		return fmt.Errorf("failed to query sandboxes on node: %w", err)
@@ -670,7 +678,7 @@ func (r *Runner) SetupControllers(
 		CC:             r.deps.CC,
 		EAC:            eas,
 		Namespace:      r.deps.Namespace,
-		NodeId:         r.Id,
+		NodeId:         r.nodeId(),
 		NetServ:        r.deps.NetServ,
 		Bridge:         r.deps.Bridge,
 		Subnet:         r.deps.Subnet,
@@ -757,7 +765,7 @@ func (r *Runner) SetupControllers(
 	volOps := diskio.NewRealDiskVolumeOps(log)
 	mntOps := diskio.NewRealDiskMountOps(log)
 
-	r.dvc = diskio.NewDiskVolumeController(log, dataPath, r.Id, diskioState, volOps, mntOps)
+	r.dvc = diskio.NewDiskVolumeController(log, dataPath, r.nodeId(), diskioState, volOps, mntOps)
 	r.dvc.SetEAC(eas)
 
 	if err := r.dvc.Init(ctx); err != nil {
@@ -770,7 +778,7 @@ func (r *Runner) SetupControllers(
 		log.Warn("failed to reconcile disk volumes on startup", "error", err)
 	}
 
-	r.dmc = diskio.NewDiskMountController(log, dataPath, r.Id, diskioState, mntOps)
+	r.dmc = diskio.NewDiskMountController(log, dataPath, r.nodeId(), diskioState, mntOps)
 	r.dmc.SetEAC(eas)
 
 	// Reconcile mounts with entity server on startup to re-mount any
@@ -866,8 +874,8 @@ func (r *Runner) SetupControllers(
 	cm.AddController(mntController)
 
 	// Use entity mode controllers
-	diskController := disk.NewDiskController(log, eas, r.Id, r.DiskMode, r.deps.IsCoordinator)
-	diskLeaseController := disk.NewDiskLeaseController(log, eas, r.Id, r.DiskMode)
+	diskController := disk.NewDiskController(log, eas, r.nodeId(), r.DiskMode, r.deps.IsCoordinator)
+	diskLeaseController := disk.NewDiskLeaseController(log, eas, r.nodeId(), r.DiskMode)
 
 	// Add disk controller to closers list so it gets cleaned up on shutdown
 	r.closers = append(r.closers, diskController)
@@ -903,7 +911,7 @@ func (r *Runner) SetupControllers(
 	sbController := controller.NewReconcileController(
 		"sandbox",
 		log,
-		compute_v1alpha.Index(compute_v1alpha.KindSandbox, entity.Id("node/"+r.Id)),
+		compute_v1alpha.Index(compute_v1alpha.KindSandbox, r.nodeId().Id()),
 		eas,
 		sbcHandler,
 		time.Minute,
@@ -1020,7 +1028,7 @@ func (r *Runner) SetupControllers(
 
 	// Add disk_volume watch controller to trigger disk re-reconciliation when
 	// disk_volume entities change (e.g. volume becomes DV_READY after provisioning)
-	diskVolumeWatchController := disk.NewDiskVolumeWatchController(log, eas, diskRC, r.Id)
+	diskVolumeWatchController := disk.NewDiskVolumeWatchController(log, eas, diskRC, r.nodeId())
 	cm.AddController(
 		controller.NewReconcileController(
 			"disk-volume-watch",
@@ -1035,7 +1043,7 @@ func (r *Runner) SetupControllers(
 
 	// Add disk_mount watch controller to trigger disk lease re-reconciliation when
 	// disk_mount entities change (e.g. mount becomes DM_MOUNTED after mounting)
-	diskMountWatchController := disk.NewDiskMountWatchController(log, eas, diskLeaseRC, r.Id)
+	diskMountWatchController := disk.NewDiskMountWatchController(log, eas, diskLeaseRC, r.nodeId())
 	cm.AddController(
 		controller.NewReconcileController(
 			"disk-mount-watch",

--- a/controllers/disk/disk_controller.go
+++ b/controllers/disk/disk_controller.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/controller"
@@ -40,7 +41,7 @@ type DiskController struct {
 	EAC *entityserver_v1alpha.EntityAccessClient
 
 	// NodeId is the ID of this node, used for creating volume entities
-	NodeId string
+	NodeId compute.NodeId
 
 	// isCoordinator is true if this controller runs on the coordinator node.
 	// Today all disks are owned by the coordinator, so only the coordinator
@@ -64,7 +65,7 @@ type DiskController struct {
 // The diskMode parameter comes from server config (MIREN_DISK_MODE); pass ""
 // for auto-detection. isCoordinator must be true on the primary node and
 // false on distributed runners.
-func NewDiskController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, nodeId string, diskMode string, isCoordinator bool) *DiskController {
+func NewDiskController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, nodeId compute.NodeId, diskMode string, isCoordinator bool) *DiskController {
 	return &DiskController{
 		Log:            log.With("module", "disk"),
 		EAC:            eac,
@@ -82,13 +83,6 @@ func NewDiskController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessC
 func (d *DiskController) shouldManageDisk(disk *storage_v1alpha.Disk) bool {
 	_ = disk
 	return d.isCoordinator
-}
-
-// myNodeId returns the entity ID used for disk_volumes owned by this
-// controller's node, normalized so the "node/" prefix is always present
-// exactly once regardless of how NodeId was passed in.
-func (d *DiskController) myNodeId() entity.Id {
-	return entity.Id("node/" + strings.TrimPrefix(d.NodeId, "node/"))
 }
 
 // ForceUniversalMode forces the controller to use disk_volume entities with
@@ -185,9 +179,9 @@ func (d *DiskController) handleProvisioning(ctx context.Context, disk *storage_v
 		return fmt.Errorf("error looking up existing disk_volume for disk %s: %w", disk.ID, err)
 	}
 
-	myNodeId := d.myNodeId()
+	myNodeId := d.NodeId.Id()
 
-	if existingVolume != nil && existingVolume.NodeId != "" && existingVolume.NodeId != myNodeId {
+	if existingVolume != nil && existingVolume.NodeId != "" && !d.NodeId.Matches(existingVolume.NodeId) {
 		// Orphan from a runner that created a volume it shouldn't have. Log
 		// and fall through to create our own native volume; the orphan is
 		// harmless here and will be cleaned up via DELETING (or left to the
@@ -393,14 +387,12 @@ func (d *DiskController) getDiskVolumeForDisk(ctx context.Context, diskId entity
 		return nil, nil
 	}
 
-	myNodeId := d.myNodeId()
-
 	var chosen *storage_v1alpha.DiskVolume
 	for _, v := range values {
 		var volume storage_v1alpha.DiskVolume
 		volume.Decode(v.Entity())
 
-		if volume.NodeId == myNodeId {
+		if d.NodeId.Matches(volume.NodeId) {
 			return &volume, nil
 		}
 

--- a/controllers/disk/disk_controller_coordinator_test.go
+++ b/controllers/disk/disk_controller_coordinator_test.go
@@ -3,6 +3,8 @@ package disk
 import (
 	"testing"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
@@ -21,7 +23,7 @@ func TestDiskController_NonCoordinator_NoVolumeCreated(t *testing.T) {
 	es, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
 
-	dc := NewDiskController(log, es.EAC, "runner-uuid", "", false)
+	dc := NewDiskController(log, es.EAC, compute.NewNodeId("runner-uuid"), "", false)
 	dc.ForceUniversalMode()
 
 	disk := &storage_v1alpha.Disk{
@@ -60,7 +62,7 @@ func TestDiskController_PrefersOwnVolume(t *testing.T) {
 	es, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
 
-	dc := NewDiskController(log, es.EAC, "miren", "", true)
+	dc := NewDiskController(log, es.EAC, compute.NewNodeId("miren"), "", true)
 	dc.ForceUniversalMode()
 
 	disk := &storage_v1alpha.Disk{
@@ -85,7 +87,7 @@ func TestDiskController_PrefersOwnVolume(t *testing.T) {
 		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
 		DesiredState: storage_v1alpha.DV_PRESENT,
 		ActualState:  storage_v1alpha.DV_PENDING,
-		NodeId:       entity.Id("node/runner-uuid"),
+		NodeId:       compute.NewNodeId("runner-uuid").Id(),
 	}
 	_, err = es.EAC.Create(ctx, entity.New(
 		entity.DBId, entity.Id("disk_volume/foreign"),
@@ -103,7 +105,7 @@ func TestDiskController_PrefersOwnVolume(t *testing.T) {
 		DesiredState: storage_v1alpha.DV_PRESENT,
 		ActualState:  storage_v1alpha.DV_READY,
 		VolumeId:     "native-vol-id",
-		NodeId:       entity.Id("node/miren"),
+		NodeId:       compute.NewNodeId("miren").Id(),
 	}
 	_, err = es.EAC.Create(ctx, entity.New(
 		entity.DBId, entity.Id("disk_volume/native"),
@@ -135,7 +137,7 @@ func TestDiskController_OnlyOrphan_StillCreatesNative(t *testing.T) {
 	es, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()
 
-	dc := NewDiskController(log, es.EAC, "miren", "", true)
+	dc := NewDiskController(log, es.EAC, compute.NewNodeId("miren"), "", true)
 	dc.ForceUniversalMode()
 
 	disk := &storage_v1alpha.Disk{
@@ -159,7 +161,7 @@ func TestDiskController_OnlyOrphan_StillCreatesNative(t *testing.T) {
 		VolumeMode:   storage_v1alpha.VM_UNIVERSAL,
 		DesiredState: storage_v1alpha.DV_PRESENT,
 		ActualState:  storage_v1alpha.DV_READY,
-		NodeId:       entity.Id("node/runner-uuid"),
+		NodeId:       compute.NewNodeId("runner-uuid").Id(),
 	}
 	_, err = es.EAC.Create(ctx, entity.New(
 		entity.DBId, entity.Id("disk_volume/foreign-only"),
@@ -182,7 +184,7 @@ func TestDiskController_OnlyOrphan_StillCreatesNative(t *testing.T) {
 	for _, v := range values {
 		var vol storage_v1alpha.DiskVolume
 		vol.Decode(v.Entity())
-		if vol.NodeId == entity.Id("node/miren") {
+		if vol.NodeId == compute.NewNodeId("miren").Id() {
 			sawNative = true
 		}
 	}

--- a/controllers/disk/disk_controller_test.go
+++ b/controllers/disk/disk_controller_test.go
@@ -4,15 +4,17 @@ import (
 	"log/slog"
 	"testing"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDiskController_New(t *testing.T) {
 	log := slog.Default()
-	controller := NewDiskController(log, nil, "test-node", "", true)
+	controller := NewDiskController(log, nil, compute.NewNodeId("test-node"), "", true)
 
 	assert.NotNil(t, controller)
 	assert.NotNil(t, controller.Log)
 	assert.Equal(t, "/var/lib/miren/disks", controller.mountBasePath)
-	assert.Equal(t, "test-node", controller.NodeId)
+	assert.Equal(t, compute.NewNodeId("test-node"), controller.NodeId)
 }

--- a/controllers/disk/disk_lease_controller.go
+++ b/controllers/disk/disk_lease_controller.go
@@ -43,7 +43,7 @@ type DiskLeaseController struct {
 	EAC *entityserver_v1alpha.EntityAccessClient
 
 	// NodeId is the ID of this node, used for creating disk_mount entities
-	NodeId string
+	NodeId compute.NodeId
 
 	// Base path for disk mounts (e.g., /var/lib/miren/disks)
 	mountBasePath string
@@ -62,7 +62,7 @@ type DiskLeaseController struct {
 
 // NewDiskLeaseController creates a disk lease controller that uses disk_mount entities.
 // The diskMode parameter comes from server config (MIREN_DISK_MODE); pass "" for auto-detection.
-func NewDiskLeaseController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, nodeId string, diskMode string) *DiskLeaseController {
+func NewDiskLeaseController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, nodeId compute.NodeId, diskMode string) *DiskLeaseController {
 	return &DiskLeaseController{
 		Log:            log.With("module", "disk-lease"),
 		EAC:            eac,
@@ -274,8 +274,7 @@ func (d *DiskLeaseController) cleanupDiskMountForLease(ctx context.Context, leas
 // reconcileLease reconciles the lease state
 func (d *DiskLeaseController) reconcileLease(ctx context.Context, lease *storage_v1alpha.DiskLease, meta *entity.Meta) error {
 	// Only reconcile leases assigned to this node
-	myNodeId := entity.Id("node/" + d.NodeId)
-	if lease.NodeId != "" && lease.NodeId != myNodeId {
+	if lease.NodeId != "" && !d.NodeId.Matches(lease.NodeId) {
 		return nil
 	}
 
@@ -497,7 +496,7 @@ func (d *DiskLeaseController) handlePendingLease(ctx context.Context, lease *sto
 		ReadOnly:     lease.Mount.ReadOnly,
 		DesiredState: storage_v1alpha.DM_WANT_MOUNTED,
 		ActualState:  storage_v1alpha.DM_PENDING,
-		NodeId:       entity.Id("node/" + d.NodeId),
+		NodeId:       d.NodeId.Id(),
 	}
 
 	d.Log.Info("Creating disk_mount entity",

--- a/controllers/disk/disk_lease_controller_test.go
+++ b/controllers/disk/disk_lease_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"testing"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
@@ -13,17 +15,17 @@ import (
 
 func TestDiskLeaseController_New(t *testing.T) {
 	log := slog.Default()
-	controller := NewDiskLeaseController(log, nil, "test-node", "")
+	controller := NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 	assert.NotNil(t, controller)
 	assert.NotNil(t, controller.Log)
 	assert.Equal(t, "/var/lib/miren/disks", controller.mountBasePath)
-	assert.Equal(t, "test-node", controller.NodeId)
+	assert.Equal(t, compute.NewNodeId("test-node"), controller.NodeId)
 }
 
 func TestDiskLeaseController_LeaseConflict(t *testing.T) {
 	log := slog.Default()
-	dlc := NewDiskLeaseController(log, nil, "test-node", "")
+	dlc := NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 	// Simulate existing lease for the disk
 	dlc.activeLeases["disk/test-disk"] = "disk-lease/existing-lease"
@@ -50,7 +52,7 @@ func TestDiskLeaseController_LeaseConflict(t *testing.T) {
 
 func TestDiskLeaseController_Delete(t *testing.T) {
 	log := slog.Default()
-	dlc := NewDiskLeaseController(log, nil, "test-node", "")
+	dlc := NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 	// Setup active lease and lease details
 	dlc.activeLeases["disk/test-disk"] = "disk-lease/test-lease"
@@ -75,7 +77,7 @@ func TestDiskLeaseController_Delete(t *testing.T) {
 
 func TestDiskLeaseController_Release(t *testing.T) {
 	log := slog.Default()
-	dlc := NewDiskLeaseController(log, nil, "test-node", "")
+	dlc := NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 	// Setup active lease
 	dlc.activeLeases["disk/test-disk"] = "disk-lease/test-lease"
@@ -108,7 +110,7 @@ func TestDiskLeaseController_Release(t *testing.T) {
 
 func TestDiskLeaseController_ReleaseIdempotent(t *testing.T) {
 	log := slog.Default()
-	dlc := NewDiskLeaseController(log, nil, "test-node", "")
+	dlc := NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 	// Setup: No active lease (already released)
 	releasedLease := &storage_v1alpha.DiskLease{
@@ -135,7 +137,7 @@ func TestDiskLeaseController_ReleaseIdempotent(t *testing.T) {
 
 func TestDiskLeaseController_CleanupOldReleasedLeases(t *testing.T) {
 	log := slog.Default()
-	dlc := NewDiskLeaseController(log, nil, "test-node", "")
+	dlc := NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 	// Since we don't have a real EAC, we test the logic in isolation
 	// The controller should skip cleanup when EAC is nil (test mode)

--- a/controllers/disk/disk_mount_watch_controller.go
+++ b/controllers/disk/disk_mount_watch_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/controller"
@@ -17,13 +18,13 @@ import (
 type DiskMountWatchController struct {
 	Log    *slog.Logger
 	EAC    *entityserver_v1alpha.EntityAccessClient
-	NodeId string
+	NodeId compute.NodeId
 
 	LeaseController *controller.ReconcileController
 }
 
 // NewDiskMountWatchController creates a new disk mount watch controller.
-func NewDiskMountWatchController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, leaseController *controller.ReconcileController, nodeId string) *DiskMountWatchController {
+func NewDiskMountWatchController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, leaseController *controller.ReconcileController, nodeId compute.NodeId) *DiskMountWatchController {
 	return &DiskMountWatchController{
 		Log:             log.With("module", "disk-mount-watch"),
 		EAC:             eac,
@@ -42,7 +43,7 @@ func (m *DiskMountWatchController) Create(ctx context.Context, mount *storage_v1
 
 func (m *DiskMountWatchController) Update(ctx context.Context, mount *storage_v1alpha.DiskMount, meta *entity.Meta) error {
 	// Only process mounts assigned to this node
-	if mount.NodeId != "" && mount.NodeId != entity.Id("node/"+m.NodeId) {
+	if mount.NodeId != "" && !m.NodeId.Matches(mount.NodeId) {
 		return nil
 	}
 	if mount.DiskLeaseId == "" {

--- a/controllers/disk/disk_volume_watch_controller.go
+++ b/controllers/disk/disk_volume_watch_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/controller"
@@ -17,13 +18,13 @@ import (
 type DiskVolumeWatchController struct {
 	Log    *slog.Logger
 	EAC    *entityserver_v1alpha.EntityAccessClient
-	NodeId string
+	NodeId compute.NodeId
 
 	DiskController *controller.ReconcileController
 }
 
 // NewDiskVolumeWatchController creates a new disk volume watch controller.
-func NewDiskVolumeWatchController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, diskController *controller.ReconcileController, nodeId string) *DiskVolumeWatchController {
+func NewDiskVolumeWatchController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, diskController *controller.ReconcileController, nodeId compute.NodeId) *DiskVolumeWatchController {
 	return &DiskVolumeWatchController{
 		Log:            log.With("module", "disk-volume-watch"),
 		EAC:            eac,
@@ -41,7 +42,7 @@ func (v *DiskVolumeWatchController) Create(ctx context.Context, vol *storage_v1a
 }
 
 func (v *DiskVolumeWatchController) Update(ctx context.Context, vol *storage_v1alpha.DiskVolume, meta *entity.Meta) error {
-	if vol.NodeId != "" && vol.NodeId != entity.Id("node/"+v.NodeId) {
+	if vol.NodeId != "" && !v.NodeId.Matches(vol.NodeId) {
 		return nil
 	}
 	if vol.DiskId == "" {

--- a/controllers/disk/integration_test.go
+++ b/controllers/disk/integration_test.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"testing"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
@@ -15,7 +17,7 @@ import (
 func TestDiskAndLeaseIntegration(t *testing.T) {
 	t.Run("lease conflict detection", func(t *testing.T) {
 		log := slog.Default()
-		leaseController := NewDiskLeaseController(log, nil, "test-node", "")
+		leaseController := NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 		// Manually track an active lease
 		leaseController.activeLeases["disk/integration-disk"] = "disk-lease/existing-lease"
@@ -46,7 +48,7 @@ func TestDiskAndLeaseIntegration(t *testing.T) {
 
 	t.Run("lease release flow", func(t *testing.T) {
 		log := slog.Default()
-		leaseController := NewDiskLeaseController(log, nil, "test-node", "")
+		leaseController := NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 		// Setup active lease
 		diskId := "disk/release-test-disk"
@@ -80,7 +82,7 @@ func TestDiskAndLeaseIntegration(t *testing.T) {
 
 	t.Run("cleanup old released leases", func(t *testing.T) {
 		log := slog.Default()
-		leaseController := NewDiskLeaseController(log, nil, "test-node", "")
+		leaseController := NewDiskLeaseController(log, nil, compute.NewNodeId("test-node"), "")
 
 		// Test that cleanup doesn't fail in test mode (no EAC)
 		err := leaseController.CleanupOldReleasedLeases(context.Background())
@@ -96,7 +98,7 @@ func TestDiskControllerUpgradeProvisionedToUniversal(t *testing.T) {
 		es, cleanup := testutils.NewInMemEntityServer(t)
 		defer cleanup()
 
-		dc := NewDiskController(log, es.EAC, "test-node-1", "", true)
+		dc := NewDiskController(log, es.EAC, compute.NewNodeId("test-node-1"), "", true)
 		dc.ForceUniversalMode()
 
 		// Create a disk entity that was provisioned under an older system:
@@ -144,7 +146,7 @@ func TestDiskControllerUpgradeProvisionedToUniversal(t *testing.T) {
 		es, cleanup := testutils.NewInMemEntityServer(t)
 		defer cleanup()
 
-		dc := NewDiskController(log, es.EAC, "test-node-1", "", true)
+		dc := NewDiskController(log, es.EAC, compute.NewNodeId("test-node-1"), "", true)
 		dc.ForceUniversalMode()
 
 		// Disk has a VolumeId (from old system) but no corresponding disk_volume entity
@@ -184,7 +186,7 @@ func TestDiskControllerUpgradeProvisionedToUniversal(t *testing.T) {
 		es, cleanup := testutils.NewInMemEntityServer(t)
 		defer cleanup()
 
-		dc := NewDiskController(log, es.EAC, "test-node-1", "", true)
+		dc := NewDiskController(log, es.EAC, compute.NewNodeId("test-node-1"), "", true)
 		dc.ForceUniversalMode()
 
 		disk := &storage_v1alpha.Disk{
@@ -213,7 +215,7 @@ func TestDiskControllerUpgradeProvisionedToUniversal(t *testing.T) {
 			VolumeId:     "vol-ready-123",
 			DesiredState: storage_v1alpha.DV_PRESENT,
 			ActualState:  storage_v1alpha.DV_READY,
-			NodeId:       entity.Id("node/test-node-1"),
+			NodeId:       compute.NewNodeId("test-node-1").Id(),
 		}
 
 		_, err = es.EAC.Create(ctx, entity.New(

--- a/controllers/disk/orphan_lease_test.go
+++ b/controllers/disk/orphan_lease_test.go
@@ -46,7 +46,7 @@ func TestReconcileOrphanLeasesReleasesDeadSandboxLease(t *testing.T) {
 			SandboxId:  deadSandboxId,
 			Status:     storage_v1alpha.BOUND,
 			AcquiredAt: time.Now(),
-			NodeId:     entity.Id("node/test-node"),
+			NodeId:     compute.NewNodeId("test-node").Id(),
 		}).Encode,
 	).Attrs())
 	require.NoError(t, err)
@@ -71,12 +71,12 @@ func TestReconcileOrphanLeasesReleasesDeadSandboxLease(t *testing.T) {
 			SandboxId:  liveSandboxId,
 			Status:     storage_v1alpha.BOUND,
 			AcquiredAt: time.Now(),
-			NodeId:     entity.Id("node/test-node"),
+			NodeId:     compute.NewNodeId("test-node").Id(),
 		}).Encode,
 	).Attrs())
 	require.NoError(t, err)
 
-	leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
+	leaseController := NewDiskLeaseController(log, es.EAC, compute.NewNodeId("test-node"), "")
 	require.NoError(t, leaseController.Init(ctx))
 
 	// Orphan lease should now be RELEASED.
@@ -115,12 +115,12 @@ func TestReconcileOrphanLeasesReleasesLeaseForMissingSandbox(t *testing.T) {
 			SandboxId:  entity.Id("sandbox/does-not-exist"),
 			Status:     storage_v1alpha.BOUND,
 			AcquiredAt: time.Now(),
-			NodeId:     entity.Id("node/test-node"),
+			NodeId:     compute.NewNodeId("test-node").Id(),
 		}).Encode,
 	).Attrs())
 	require.NoError(t, err)
 
-	leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
+	leaseController := NewDiskLeaseController(log, es.EAC, compute.NewNodeId("test-node"), "")
 	require.NoError(t, leaseController.Init(ctx))
 
 	resp, err := es.EAC.Get(ctx, leaseId.String())
@@ -142,7 +142,7 @@ func TestReconcileOrphanLeasesRecurring(t *testing.T) {
 	es, cleanup := testutils.NewInMemEntityServer(t)
 	t.Cleanup(cleanup)
 
-	leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
+	leaseController := NewDiskLeaseController(log, es.EAC, compute.NewNodeId("test-node"), "")
 	require.NoError(t, leaseController.Init(ctx))
 
 	// After the controller is already up, a sandbox dies holding a BOUND lease.
@@ -165,7 +165,7 @@ func TestReconcileOrphanLeasesRecurring(t *testing.T) {
 			SandboxId:  deadSandboxId,
 			Status:     storage_v1alpha.BOUND,
 			AcquiredAt: time.Now(),
-			NodeId:     entity.Id("node/test-node"),
+			NodeId:     compute.NewNodeId("test-node").Id(),
 		}).Encode,
 	).Attrs())
 	require.NoError(t, err)
@@ -219,12 +219,12 @@ func TestReconcileOrphanLeasesGracePeriod(t *testing.T) {
 			SandboxId:  deadSandboxId,
 			Status:     storage_v1alpha.BOUND,
 			AcquiredAt: time.Now(),
-			NodeId:     entity.Id("node/test-node"),
+			NodeId:     compute.NewNodeId("test-node").Id(),
 		}).Encode,
 	).Attrs())
 	require.NoError(t, err)
 
-	leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
+	leaseController := NewDiskLeaseController(log, es.EAC, compute.NewNodeId("test-node"), "")
 
 	// With a long grace, the just-created lease must be left BOUND even though
 	// its sandbox is DEAD.

--- a/controllers/disk/sandbox_integration_test.go
+++ b/controllers/disk/sandbox_integration_test.go
@@ -96,9 +96,9 @@ func TestSandboxDiskIntegration(t *testing.T) {
 		t.Cleanup(cleanup)
 
 		// Create controllers with real EAC and universal mode
-		diskController := NewDiskController(log, es.EAC, "test-node", "", true)
+		diskController := NewDiskController(log, es.EAC, compute.NewNodeId("test-node"), "", true)
 		diskController.ForceUniversalMode()
-		leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
+		leaseController := NewDiskLeaseController(log, es.EAC, compute.NewNodeId("test-node"), "")
 		leaseController.ForceUniversalMode()
 
 		// Step 1: Create and provision a disk
@@ -167,7 +167,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 				ReadOnly: false,
 			},
 			AcquiredAt: now,
-			NodeId:     entity.Id("node/test-node"),
+			NodeId:     compute.NewNodeId("test-node").Id(),
 		}
 
 		// Process lease binding - creates disk_mount entity, stays PENDING
@@ -205,7 +205,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 				Path: "/mnt/data",
 			},
 			AcquiredAt: now,
-			NodeId:     entity.Id("node/test-node"),
+			NodeId:     compute.NewNodeId("test-node").Id(),
 		}
 
 		conflictMeta := &entity.Meta{}
@@ -232,7 +232,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 				Path: "/mnt/data",
 			},
 			AcquiredAt: time.Now(),
-			NodeId:     entity.Id("node/test-node"),
+			NodeId:     compute.NewNodeId("test-node").Id(),
 		}
 
 		newMeta := &entity.Meta{}
@@ -267,9 +267,9 @@ func TestSandboxDiskIntegration(t *testing.T) {
 		es, cleanup := testutils.NewInMemEntityServer(t)
 		t.Cleanup(cleanup)
 
-		diskController := NewDiskController(log, es.EAC, "test-node", "", true)
+		diskController := NewDiskController(log, es.EAC, compute.NewNodeId("test-node"), "", true)
 		diskController.ForceUniversalMode()
-		leaseController := NewDiskLeaseController(log, es.EAC, "test-node", "")
+		leaseController := NewDiskLeaseController(log, es.EAC, compute.NewNodeId("test-node"), "")
 		leaseController.ForceUniversalMode()
 
 		// Create multiple disks
@@ -370,7 +370,7 @@ func TestSandboxDiskIntegration(t *testing.T) {
 					ReadOnly: false,
 				},
 				AcquiredAt: now,
-				NodeId:     entity.Id("node/test-node"),
+				NodeId:     compute.NewNodeId("test-node").Id(),
 			}
 
 			meta := &entity.Meta{}

--- a/controllers/integration/chaos_test.go
+++ b/controllers/integration/chaos_test.go
@@ -400,7 +400,7 @@ func faultDuplicateLease(t *testing.T, ctx context.Context, h *TestHarness, rng 
 			Path:    "/data",
 			Options: "rw",
 		},
-		NodeId: entity.Id("node/" + testNodeId),
+		NodeId: compute.NewNodeId(testNodeId).Id(),
 	}
 
 	conflictLeaseID := entity.Id("disk-lease/" + idgen.GenNS("disk-lease"))
@@ -418,7 +418,7 @@ func faultDuplicateLease(t *testing.T, ctx context.Context, h *TestHarness, rng 
 
 // chaosReconcileRound runs each controller 1-3 times in random order.
 func chaosReconcileRound(ctx context.Context, h *TestHarness, rng *rand.Rand) {
-	nodeId := entity.Id("node/" + testNodeId)
+	nodeId := compute.NewNodeId(testNodeId).Id()
 
 	type ctrlDef struct {
 		index entity.Attr

--- a/controllers/integration/fake_sandbox.go
+++ b/controllers/integration/fake_sandbox.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	storage "miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/entity"
@@ -18,11 +19,11 @@ import (
 type FakeSandboxController struct {
 	Log    *slog.Logger
 	EAC    *entityserver_v1alpha.EntityAccessClient
-	NodeId string
+	NodeId compute.NodeId
 }
 
 // NewFakeSandboxController creates a new fake sandbox controller.
-func NewFakeSandboxController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, nodeId string) *FakeSandboxController {
+func NewFakeSandboxController(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, nodeId compute.NodeId) *FakeSandboxController {
 	return &FakeSandboxController{
 		Log:    log.With("module", "fake-sandbox"),
 		EAC:    eac,
@@ -91,13 +92,13 @@ func (f *FakeSandboxController) AcquireDiskLease(ctx context.Context, diskID, sa
 		return "", fmt.Errorf("failed to list disk leases: %w", err)
 	}
 
-	nodeID := entity.Id("node/" + f.NodeId)
+	nodeID := f.NodeId.Id()
 
 	for _, e := range listResp.Values() {
 		var lease storage.DiskLease
 		lease.Decode(e.Entity())
 
-		if lease.DiskId == diskID && lease.NodeId == nodeID {
+		if lease.DiskId == diskID && f.NodeId.Matches(lease.NodeId) {
 			if lease.SandboxId == sandboxID {
 				f.Log.Info("found existing lease", "lease", lease.ID)
 				return lease.ID, nil

--- a/controllers/integration/harness.go
+++ b/controllers/integration/harness.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/components/diskio"
@@ -61,6 +62,8 @@ func NewTestHarness(t *testing.T) *TestHarness {
 
 	eac := es.EAC
 
+	nodeId := compute.NewNodeId(testNodeId)
+
 	// Create diskio state backed by a temp file so Save() succeeds
 	dataPath := t.TempDir()
 	diskioState := diskio.NewState()
@@ -69,17 +72,17 @@ func NewTestHarness(t *testing.T) *TestHarness {
 	// Create mock ops
 	volOps := newMockDiskVolumeOps()
 	mntOps := newMockDiskMountOps()
-	diskVolCtrl := diskio.NewDiskVolumeController(log, dataPath, testNodeId, diskioState, volOps, mntOps)
+	diskVolCtrl := diskio.NewDiskVolumeController(log, dataPath, nodeId, diskioState, volOps, mntOps)
 	diskVolCtrl.SetEAC(eac)
 
-	diskMntCtrl := diskio.NewDiskMountController(log, dataPath, testNodeId, diskioState, mntOps)
+	diskMntCtrl := diskio.NewDiskMountController(log, dataPath, nodeId, diskioState, mntOps)
 	diskMntCtrl.SetEAC(eac)
 
 	// Create disk controllers using universal mode
-	diskCtrl := disk.NewDiskController(log, eac, testNodeId, "", true)
+	diskCtrl := disk.NewDiskController(log, eac, nodeId, "", true)
 	diskCtrl.Init(ctx) //nolint:errcheck
 	diskCtrl.ForceUniversalMode()
-	diskLeaseCtrl := disk.NewDiskLeaseController(log, eac, testNodeId, "")
+	diskLeaseCtrl := disk.NewDiskLeaseController(log, eac, nodeId, "")
 	diskLeaseCtrl.Init(ctx) //nolint:errcheck
 
 	// Create ReconcileControllers for each.
@@ -122,7 +125,7 @@ func NewTestHarness(t *testing.T) *TestHarness {
 	)
 
 	// Create fake sandbox controller
-	fakeSandbox := NewFakeSandboxController(log, eac, testNodeId)
+	fakeSandbox := NewFakeSandboxController(log, eac, nodeId)
 
 	return &TestHarness{
 		T:              t,
@@ -193,7 +196,7 @@ func (h *TestHarness) ReconcileAll(ctx context.Context, maxIterations int) {
 		maxIterations = 20
 	}
 
-	nodeId := entity.Id("node/" + testNodeId)
+	nodeId := compute.NewNodeId(testNodeId).Id()
 
 	indexes := []struct {
 		index entity.Attr

--- a/controllers/integration/lifecycle_test.go
+++ b/controllers/integration/lifecycle_test.go
@@ -699,7 +699,7 @@ func TestDiskDeletionLifecycle(t *testing.T) {
 	assert.Equal(t, storage.DV_ABSENT, vols[0].DesiredState, "volume desired_state should be DV_ABSENT")
 
 	// Reconcile disk-volume — volume controller processes deletion
-	nodeId := entity.Id("node/" + testNodeId)
+	nodeId := compute.NewNodeId(testNodeId).Id()
 	h.reconcileByIndex(ctx, entity.Ref(storage.DiskVolumeNodeIdId, nodeId), h.DiskVolRC)
 
 	// Volume should now be VOL_DELETED
@@ -774,7 +774,7 @@ func TestLeaseConflictDetection(t *testing.T) {
 			Path:    "/data",
 			Options: "rw",
 		},
-		NodeId: entity.Id("node/" + testNodeId),
+		NodeId: compute.NewNodeId(testNodeId).Id(),
 	}
 
 	conflictLeaseID := entity.Id("disk-lease/" + idgen.GenNS("disk-lease"))

--- a/controllers/integration/overlapping_test.go
+++ b/controllers/integration/overlapping_test.go
@@ -144,7 +144,7 @@ func TestStopDuringMountCreation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Drive disk to PROVISIONED without processing the mount
-	nodeId := entity.Id("node/" + testNodeId)
+	nodeId := compute.NewNodeId(testNodeId).Id()
 	for i := 0; i < 5; i++ {
 		h.reconcileKind(ctx, storage.KindDisk, h.DiskRC)
 		h.reconcileByIndex(ctx, entity.Ref(storage.DiskVolumeNodeIdId, nodeId), h.DiskVolRC)

--- a/controllers/integration/redeploy_test.go
+++ b/controllers/integration/redeploy_test.go
@@ -69,7 +69,7 @@ func concurrentReconcileEntities(ctx context.Context, h *TestHarness, index enti
 // concurrentReconcileRound runs all four disk-lifecycle controller types concurrently,
 // each with multiple worker goroutines processing their entities.
 func concurrentReconcileRound(ctx context.Context, h *TestHarness, workers int) {
-	nodeId := entity.Id("node/" + testNodeId)
+	nodeId := compute.NewNodeId(testNodeId).Id()
 
 	type ctrlDef struct {
 		index entity.Attr

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -72,7 +72,7 @@ type SandboxControllerDeps struct {
 	CC        *containerd.Client
 	EAC       *entityserver_v1alpha.EntityAccessClient
 	Namespace string
-	NodeId    string
+	NodeId    compute.NodeId
 	NetServ   *network.ServiceManager
 	Bridge    string
 	Subnet    *netdb.Subnet
@@ -94,7 +94,7 @@ type SandboxController struct {
 	EAC *entityserver_v1alpha.EntityAccessClient
 
 	Namespace string
-	NodeId    string
+	NodeId    compute.NodeId
 
 	NetServ *network.ServiceManager
 
@@ -313,7 +313,7 @@ func (c *SandboxController) reconcileSandboxesOnBoot(ctx context.Context) error 
 	// index as the controller watch (see runner.go) ensures we don't
 	// accidentally mark sandboxes on other nodes as unhealthy because their
 	// containers don't exist in our local containerd.
-	resp, err := c.EAC.List(ctx, compute.Index(compute.KindSandbox, entity.Id("node/"+c.NodeId)))
+	resp, err := c.EAC.List(ctx, compute.Index(compute.KindSandbox, c.NodeId.Id()))
 	if err != nil {
 		return fmt.Errorf("failed to list sandboxes: %w", err)
 	}
@@ -2861,7 +2861,7 @@ func (c *SandboxController) Periodic(ctx context.Context, timeHorizon time.Durat
 
 	// List sandboxes scheduled to this node only so we don't delete
 	// sandbox entities that belong to other runners.
-	resp, err := c.EAC.List(ctx, compute.Index(compute.KindSandbox, entity.Id("node/"+c.NodeId)))
+	resp, err := c.EAC.List(ctx, compute.Index(compute.KindSandbox, c.NodeId.Id()))
 	if err != nil {
 		return fmt.Errorf("failed to list sandboxes: %w", err)
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -30,8 +30,14 @@ func TestSandboxControllerFrozen(t *testing.T) {
 		// the saga path also reaches via deps.runtime.BootContainers, so both
 		// controllers already share the new behavior and there was nothing to
 		// mirror in create_saga.go.
-		"sandbox.go":  "16e150f5ecae1f26ae4d3ac07a10b281a55c7fd220e8a9f58a6774e3e73cbcde",
-		"volume.go":   "b4697764d48a90adc04ce47968ccef11ceba50da8d19c889906c5c3a539065b3",
+		//
+		// Also updated for MIR-1072 (typed node-id boundary): the NodeId fields
+		// became compute_v1alpha.NodeId and the inline entity.Id("node/"+c.NodeId)
+		// constructions became c.NodeId.Id(). This is a mechanical retype that
+		// produces byte-identical entity ids at runtime, and the saga path does no
+		// node-id construction, so there was nothing to mirror there either.
+		"sandbox.go":  "08abc0b3e6c57e4e2c4018d9b252d1de98768e8559e5eda8606fdb0c77347408",
+		"volume.go":   "580062fb8a34f3f7f965689467a4b0f2ed403bc63c1ecdeb44949a7ba7e08dff",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}
 

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -44,7 +44,7 @@ func newSandboxController(d *testutils.TestDeps) (*SandboxController, error) {
 		CC:             d.CC,
 		EAC:            d.EAC,
 		Namespace:      d.Namespace,
-		NodeId:         "test-node",
+		NodeId:         compute.NewNodeId("test-node"),
 		NetServ:        d.NetServ,
 		Bridge:         d.Bridge,
 		Subnet:         d.Subnet,
@@ -99,7 +99,7 @@ func TestSandbox(t *testing.T) {
 	// The test sandbox controller uses NodeId "test-node".
 	// Only set the kind — Status is a session attribute and can't be set via Put.
 	{
-		nodeId := entity.Id("node/test-node")
+		nodeId := compute.NewNodeId("test-node").Id()
 		node := &compute.Node{}
 		var nodeE entityserver_v1alpha.Entity
 		nodeE.SetId(nodeId.String())
@@ -724,7 +724,7 @@ func TestSandbox(t *testing.T) {
 		schedule := compute.Schedule{
 			Key: compute.Key{
 				Kind: compute.KindSandbox,
-				Node: entity.Id("node/test-node"),
+				Node: compute.NewNodeId("test-node").Id(),
 			},
 		}
 

--- a/controllers/sandbox/volume.go
+++ b/controllers/sandbox/volume.go
@@ -200,7 +200,7 @@ func (c *SandboxController) configureMirenVolume(ctx context.Context, sb *comput
 	}
 
 	// Acquire a lease for this disk on this node (creates new or takes over existing)
-	nodeID := entity.Id("node/" + c.NodeId)
+	nodeID := c.NodeId.Id()
 	leaseID, err := c.acquireDiskLease(ctx, diskID, nodeID, sb.ID, appID, volume.MountPath, readOnly)
 	if err != nil {
 		return "", fmt.Errorf("failed to get or create disk lease: %w", err)
@@ -349,7 +349,7 @@ func (c *SandboxController) createDiskLease(ctx context.Context, diskID entity.I
 		"mount_path", mountPath,
 		"node_id", c.NodeId)
 
-	nodeID := entity.Id("node/" + c.NodeId)
+	nodeID := c.NodeId.Id()
 
 	lease := &storage.DiskLease{
 		DiskId:    diskID,

--- a/controllers/sandbox/volume_test.go
+++ b/controllers/sandbox/volume_test.go
@@ -25,7 +25,7 @@ func TestAcquireDiskLease(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node",
+			NodeId: compute.NewNodeId("test-node"),
 		}
 
 		// Setup: Create a disk entity
@@ -45,7 +45,7 @@ func TestAcquireDiskLease(t *testing.T) {
 
 		// Act: Request a lease when none exists
 		sandboxID := entity.Id("sandbox/new-sandbox")
-		nodeID := entity.Id("node/test-node")
+		nodeID := compute.NewNodeId("test-node").Id()
 		appID := entity.Id("app/test-app")
 
 		leaseID, err := controller.acquireDiskLease(ctx, diskID, nodeID, sandboxID, appID, "/data", false)
@@ -80,7 +80,7 @@ func TestAcquireDiskLease(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node",
+			NodeId: compute.NewNodeId("test-node"),
 		}
 
 		// Setup: Create a disk entity
@@ -100,7 +100,7 @@ func TestAcquireDiskLease(t *testing.T) {
 
 		// Setup: Create an existing lease owned by our sandbox
 		sandboxID := entity.Id("sandbox/my-sandbox")
-		nodeID := entity.Id("node/test-node")
+		nodeID := compute.NewNodeId("test-node").Id()
 		existingLeaseID := entity.Id("disk-lease/existing-lease")
 
 		existingLease := &storage.DiskLease{
@@ -143,7 +143,7 @@ func TestAcquireDiskLease(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node",
+			NodeId: compute.NewNodeId("test-node"),
 		}
 
 		// Setup: Create a disk entity
@@ -161,7 +161,7 @@ func TestAcquireDiskLease(t *testing.T) {
 		).Attrs())
 		r.NoError(err)
 
-		nodeID := entity.Id("node/test-node")
+		nodeID := compute.NewNodeId("test-node").Id()
 		otherSandboxID := entity.Id("sandbox/other-sandbox")
 		mySandboxID := entity.Id("sandbox/my-sandbox")
 		appID := entity.Id("app/test-app")
@@ -213,7 +213,7 @@ func TestAcquireDiskLease(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node",
+			NodeId: compute.NewNodeId("test-node"),
 		}
 
 		// Setup: Create a disk entity
@@ -233,7 +233,7 @@ func TestAcquireDiskLease(t *testing.T) {
 
 		// Setup: Create an existing RELEASED lease (from a dead sandbox)
 		oldSandboxID := entity.Id("sandbox/old-sandbox")
-		nodeID := entity.Id("node/test-node")
+		nodeID := compute.NewNodeId("test-node").Id()
 		releasedLeaseID := entity.Id("disk-lease/released-lease")
 
 		releasedLease := &storage.DiskLease{
@@ -284,7 +284,7 @@ func TestAcquireDiskLease(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node-2",
+			NodeId: compute.NewNodeId("test-node-2"),
 		}
 
 		// Setup: Create a disk entity
@@ -304,7 +304,7 @@ func TestAcquireDiskLease(t *testing.T) {
 
 		// Setup: Create an existing lease on a DIFFERENT node
 		sandbox1ID := entity.Id("sandbox/sandbox-on-node1")
-		node1ID := entity.Id("node/test-node-1")
+		node1ID := compute.NewNodeId("test-node-1").Id()
 		existingLeaseID := entity.Id("disk-lease/node1-lease")
 
 		existingLease := &storage.DiskLease{
@@ -327,7 +327,7 @@ func TestAcquireDiskLease(t *testing.T) {
 
 		// Act: Request a lease on node2 (controller.NodeId = "test-node-2")
 		sandbox2ID := entity.Id("sandbox/sandbox-on-node2")
-		node2ID := entity.Id("node/test-node-2")
+		node2ID := compute.NewNodeId("test-node-2").Id()
 		appID := entity.Id("app/test-app")
 
 		newLeaseID, err := controller.acquireDiskLease(ctx, diskID, node2ID, sandbox2ID, appID, "/data", false)
@@ -361,12 +361,12 @@ func TestReleaseDiskLeases(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node",
+			NodeId: compute.NewNodeId("test-node"),
 		}
 
 		// Setup: Create a sandbox and its disk lease
 		sandboxID := entity.Id("sandbox/dying-sandbox")
-		nodeID := entity.Id("node/test-node")
+		nodeID := compute.NewNodeId("test-node").Id()
 		diskID := entity.Id("disk/test-disk")
 		leaseID := entity.Id("disk-lease/to-be-released")
 
@@ -420,13 +420,13 @@ func TestReleaseDiskLeases(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node",
+			NodeId: compute.NewNodeId("test-node"),
 		}
 
 		// Setup: Create two sandboxes with their own leases
 		sandbox1ID := entity.Id("sandbox/sandbox-1")
 		sandbox2ID := entity.Id("sandbox/sandbox-2")
-		nodeID := entity.Id("node/test-node")
+		nodeID := compute.NewNodeId("test-node").Id()
 
 		lease1ID := entity.Id("disk-lease/lease-1")
 		lease1 := &storage.DiskLease{
@@ -483,7 +483,7 @@ func testSchedule() compute.Schedule {
 	return compute.Schedule{
 		Key: compute.Key{
 			Kind: compute.KindSandbox,
-			Node: entity.Id("node/test-node"),
+			Node: compute.NewNodeId("test-node").Id(),
 		},
 	}
 }
@@ -501,7 +501,7 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node",
+			NodeId: compute.NewNodeId("test-node"),
 		}
 
 		sandboxID := entity.Id("sandbox/dead-with-lease")
@@ -527,7 +527,7 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 				ID:        leaseID,
 				DiskId:    diskID,
 				SandboxId: sandboxID,
-				NodeId:    entity.Id("node/test-node"),
+				NodeId:    compute.NewNodeId("test-node").Id(),
 				Status:    storage.BOUND,
 			}).Encode,
 		).Attrs())
@@ -564,7 +564,7 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node",
+			NodeId: compute.NewNodeId("test-node"),
 		}
 
 		sandboxID := entity.Id("sandbox/dead-no-lease")
@@ -603,7 +603,7 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 		controller := &SandboxController{
 			Log:    log,
 			EAC:    es.EAC,
-			NodeId: "test-node",
+			NodeId: compute.NewNodeId("test-node"),
 		}
 
 		sandboxID := entity.Id("sandbox/running-with-lease")
@@ -629,7 +629,7 @@ func TestPeriodicReleasesDiskLeases(t *testing.T) {
 				ID:        leaseID,
 				DiskId:    diskID,
 				SandboxId: sandboxID,
-				NodeId:    entity.Id("node/test-node"),
+				NodeId:    compute.NewNodeId("test-node").Id(),
 				Status:    storage.BOUND,
 			}).Encode,
 		).Attrs())

--- a/controllers/sandbox/watchdog.go
+++ b/controllers/sandbox/watchdog.go
@@ -16,7 +16,6 @@ import (
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/cond"
-	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/netdb"
 )
 
@@ -39,7 +38,7 @@ type ContainerWatchdog struct {
 	Namespace string
 	// NodeId scopes sandbox lookups to this node so we only consider
 	// sandboxes that are scheduled here when building the valid set.
-	NodeId string
+	NodeId compute.NodeId
 	// CheckInterval is how often to check for orphaned containers
 	CheckInterval time.Duration
 	// GraceWindow is how long to wait before removing containers from non-running sandboxes
@@ -137,7 +136,7 @@ func (w *ContainerWatchdog) CleanupOrphanedContainers(ctx context.Context) (*Cle
 	validContainers := make(map[string]bool)
 	indexedSandboxes := make(map[string]bool)
 
-	resp, err := w.EAC.List(cleanupCtx, compute.Index(compute.KindSandbox, entity.Id("node/"+w.NodeId)))
+	resp, err := w.EAC.List(cleanupCtx, compute.Index(compute.KindSandbox, w.NodeId.Id()))
 	if err != nil {
 		return result, fmt.Errorf("failed to list sandboxes: %w", err)
 	}

--- a/controllers/sandbox/watchdogtest/container_test.go
+++ b/controllers/sandbox/watchdogtest/container_test.go
@@ -43,7 +43,7 @@ func TestContainerWatchdog(t *testing.T) {
 	// Create the node entity so sandbox ScheduleKeys can reference it.
 	// Only set the kind — Status is a session attribute and can't be set via Put.
 	{
-		nodeId := entity.Id("node/" + testNodeId)
+		nodeId := compute.NewNodeId(testNodeId).Id()
 		node := &compute.Node{}
 		var nodeE entityserver_v1alpha.Entity
 		nodeE.SetId(nodeId.String())
@@ -73,7 +73,7 @@ func TestContainerWatchdog(t *testing.T) {
 		schedule := compute.Schedule{
 			Key: compute.Key{
 				Kind: compute.KindSandbox,
-				Node: entity.Id("node/" + testNodeId),
+				Node: compute.NewNodeId(testNodeId).Id(),
 			},
 		}
 
@@ -113,7 +113,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:            cc,
 			EAC:           eac,
 			Namespace:     ns,
-			NodeId:        testNodeId,
+			NodeId:        compute.NewNodeId(testNodeId),
 			CheckInterval: 100 * time.Millisecond,
 		}
 
@@ -157,7 +157,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:        cc,
 			EAC:       eac,
 			Namespace: ns,
-			NodeId:    testNodeId,
+			NodeId:    compute.NewNodeId(testNodeId),
 		}
 
 		// Run cleanup
@@ -190,7 +190,7 @@ func TestContainerWatchdog(t *testing.T) {
 		schedule := compute.Schedule{
 			Key: compute.Key{
 				Kind: compute.KindSandbox,
-				Node: entity.Id("node/" + testNodeId),
+				Node: compute.NewNodeId(testNodeId).Id(),
 			},
 		}
 
@@ -226,7 +226,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:          cc,
 			EAC:         eac,
 			Namespace:   ns,
-			NodeId:      testNodeId,
+			NodeId:      compute.NewNodeId(testNodeId),
 			GraceWindow: 10 * time.Millisecond,
 		}
 
@@ -261,7 +261,7 @@ func TestContainerWatchdog(t *testing.T) {
 		schedule := compute.Schedule{
 			Key: compute.Key{
 				Kind: compute.KindSandbox,
-				Node: entity.Id("node/" + testNodeId),
+				Node: compute.NewNodeId(testNodeId).Id(),
 			},
 		}
 
@@ -295,7 +295,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:          cc,
 			EAC:         eac,
 			Namespace:   ns,
-			NodeId:      testNodeId,
+			NodeId:      compute.NewNodeId(testNodeId),
 			GraceWindow: 10 * time.Second,
 		}
 
@@ -346,7 +346,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:        cc,
 			EAC:       eac,
 			Namespace: ns,
-			NodeId:    testNodeId,
+			NodeId:    compute.NewNodeId(testNodeId),
 		}
 
 		result, err := watchdog.CleanupOrphanedContainers(ctx)
@@ -367,7 +367,7 @@ func TestContainerWatchdog(t *testing.T) {
 			CC:            cc,
 			EAC:           eac,
 			Namespace:     ns,
-			NodeId:        testNodeId,
+			NodeId:        compute.NewNodeId(testNodeId),
 			CheckInterval: 100 * time.Millisecond,
 		}
 

--- a/controllers/service/service_test.go
+++ b/controllers/service/service_test.go
@@ -45,7 +45,7 @@ func newSandboxController(d *testutils.TestDeps) (*sandbox.SandboxController, er
 		CC:             d.CC,
 		EAC:            d.EAC,
 		Namespace:      d.Namespace,
-		NodeId:         "test-node",
+		NodeId:         compute.NewNodeId("test-node"),
 		NetServ:        d.NetServ,
 		Bridge:         d.Bridge,
 		Subnet:         d.Subnet,

--- a/pkg/entity/testutils/mock_sandbox_controller.go
+++ b/pkg/entity/testutils/mock_sandbox_controller.go
@@ -45,7 +45,7 @@ type MockSandboxController struct {
 	AssignNetwork bool
 
 	// NodeID is the mock node ID to assign to sandboxes.
-	// Defaults to "node/mock-node".
+	// Defaults to node/mock-node.
 	NodeID entity.Id
 
 	mu        sync.Mutex
@@ -63,7 +63,7 @@ func NewMockSandboxController(log *slog.Logger, eac *entityserver_v1alpha.Entity
 		EAC:           eac,
 		PollInterval:  50 * time.Millisecond,
 		AssignNetwork: true,
-		NodeID:        entity.Id("node/mock-node"),
+		NodeID:        compute_v1alpha.NewNodeId("mock-node").Id(),
 		FailSandboxes: make(map[entity.Id]bool),
 		processed:     make(map[entity.Id]bool),
 	}

--- a/servers/runner/registration_authz_test.go
+++ b/servers/runner/registration_authz_test.go
@@ -36,7 +36,7 @@ func newOwnershipTestServer(t *testing.T) (*RegistrationServer, func()) {
 	})
 
 	ctx := context.Background()
-	nodeID := entity.Id("node/" + authzRunnerID)
+	nodeID := compute_v1alpha.NewNodeId(authzRunnerID).Id()
 
 	_, err = es.EAC.Create(ctx, entity.New(
 		entity.DBId, nodeID,


### PR DESCRIPTION
Back during the MIR-1030 review, Evan flagged the little `myNodeId` helper we added in #770 as a bandage over a much bigger pattern. A node id in this codebase comes in two shapes, a raw identifier (a UUID, or `"miren"` for the primary) and the prefixed entity id `node/<raw>`, and we had no type discipline about which one any given variable held. Controllers stored `nodeId string` and hand-stitched the `"node/"` prefix on at every point of use, sometimes with a defensive `TrimPrefix` and usually without. Both forms wore the same `string`/`entity.Id` type, so the compiler could never tell anyone they'd mixed them up. That's exactly the fuzziness that let MIR-1030 happen, a runner writing a disk volume with the wrong `NodeId`.

Before touching anything we surveyed the whole tree to see how big the pattern really was: 40-odd non-test construction sites across 13 entity kinds, and for node specifically, exactly one of sixteen sites defended against double-prefixing. So this is the node-shaped first slice of a larger cleanup.

The fix is a real type. `NodeId` is now a defined type with a single constructor, `NewNodeId`, that applies and normalizes the `"node/"` prefix once. After this the literal `"node/"` appears in exactly one place in the runtime. Controller fields and constructors take a `NodeId`, it gets built once at the boundary where the raw id enters (the runner wiring, the test harness), and it converts back to a plain `entity.Id` only at the store edge via `.Id()`, with `.Matches()` for comparisons against untyped entity fields.

One notable placement decision: the type lives in `compute_v1alpha`, right next to where the node kind is actually schema'd, rather than in the generic `entity` package. Baking a node-specific prefix into the domain-agnostic entity framework would have inverted the layering, teaching the generic store about one specific kind.

The typing also shook out a latent bug. `Runner.Drain` was writing node status to the raw `r.Id` instead of the prefixed `node/<id>` the node is actually stored under (the register path a few lines away got it right), so the disable-on-drain was silently hitting a nonexistent id. It's now routed through the typed id like everything else.

The broader cleanup is captured as follow-ups: MIR-1447 to extend the same discipline to the other twelve kinds, and MIR-1448 to teach the schema generator to emit typed ids so the boundary conversions eventually disappear.

Closes MIR-1072
