### PR TITLE
deploy: stop suggesting an unroutable subdomain hostname

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -1419,53 +1419,20 @@ func displayAccessInfo(ctx *Context, appName string, results deployAccessInfo) {
 		} else {
 			ctx.Printf("\nYour app is the default route and will receive all unmatched traffic.\n")
 		}
-		suggestRoute(ctx, appName, accessInfo.ClusterHostname())
+		suggestRoute(ctx, appName)
 	} else {
 		ctx.Printf("\nNo routes configured for this app.\n")
-		suggestRoute(ctx, appName, accessInfo.ClusterHostname())
+		suggestRoute(ctx, appName)
 		ctx.Printf("To make it the default route: miren route set-default %s\n", appName)
 	}
 }
 
-// suggestRoute suggests a route command, using the cloud DNS hostname if available
-func suggestRoute(ctx *Context, appName string, clusterHostname string) {
-	if clusterHostname != "" {
-		// Suggest a specific subdomain using the app name
-		subdomain := sanitizeForSubdomain(appName)
-		suggestedHost := subdomain + "." + clusterHostname
-		ctx.Printf("To set a hostname, try: miren route set %s %s\n", suggestedHost, appName)
-	} else {
-		ctx.Printf("To set a hostname, try: miren route set <hostname> %s\n", appName)
-	}
-}
-
-// sanitizeForSubdomain converts an app name to a valid subdomain label
-func sanitizeForSubdomain(name string) string {
-	// Convert to lowercase
-	result := strings.ToLower(name)
-	// Replace underscores with hyphens
-	result = strings.ReplaceAll(result, "_", "-")
-	// Replace any other non-alphanumeric chars with hyphens
-	var sanitized strings.Builder
-	for _, r := range result {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
-			sanitized.WriteRune(r)
-		} else {
-			sanitized.WriteRune('-')
-		}
-	}
-	result = sanitized.String()
-	// Remove leading/trailing hyphens
-	result = strings.Trim(result, "-")
-	// Collapse multiple hyphens
-	for strings.Contains(result, "--") {
-		result = strings.ReplaceAll(result, "--", "-")
-	}
-	// Ensure it's not empty
-	if result == "" {
-		result = "app"
-	}
-	return result
+// suggestRoute prints a hint for giving the app a hostname. It intentionally
+// does not synthesize a subdomain of the cluster's own hostname (e.g.
+// app.cluster-x.miren.systems): Miren Anywhere serves the cluster apex but not
+// subdomains beneath it, so such a hostname would not route today. See MIR-1450.
+func suggestRoute(ctx *Context, appName string) {
+	ctx.Printf("To set a hostname, try: miren route set <hostname> %s\n", appName)
 }
 
 // stripPort removes any port suffix from a host string

--- a/cli/commands/deploy_display.go
+++ b/cli/commands/deploy_display.go
@@ -53,10 +53,10 @@ func displayDeployVersionAccessInfo(ctx *Context, appName string, accessInfo *de
 		} else {
 			ctx.Printf("\nYour app is the default route and will receive all unmatched traffic.\n")
 		}
-		suggestRoute(ctx, appName, clusterAddr)
+		suggestRoute(ctx, appName)
 	} else {
 		ctx.Printf("\nNo routes configured for this app.\n")
-		suggestRoute(ctx, appName, clusterAddr)
+		suggestRoute(ctx, appName)
 		ctx.Printf("To make it the default route: miren route set-default %s\n", appName)
 	}
 }


### PR DESCRIPTION
At the end of a deploy, when an app had no custom hostname yet, we'd try to be helpful and print a ready-to-run `miren route set myapp.cluster-x.miren.systems myapp`. Turns out that's a hostname that resolves but can't actually serve traffic under Miren Anywhere: the POP terminates TLS with only the top-level wildcard cert (`*.miren.systems`), and a wildcard matches exactly one label, so it covers the cluster apex but not a subdomain a level deeper. The name comes up in DNS, the request reaches the POP, and then the TLS handshake dies. Not a great first impression for someone following our own suggestion.

The CLI is the wrong place to be clever about this. At deploy time it doesn't know whether the cluster routes direct (where those subdomains genuinely work) or through the POP (where they don't), so guessing a specific hostname is exactly what gets us into trouble. This drops the synthesized subdomain and falls back to the generic `miren route set <hostname>` guidance, which the user fills in with a name they control. The "make it the default route" line right below it is still the always-works path, and the apex-availability messaging elsewhere is untouched, so nothing useful is lost. The `sanitizeForSubdomain` helper had no other callers and goes with it.

The companion cloud-side fix (making the Connectivity panel's subdomain guidance conditional on routing mode) is a separate PR. Part of MIR-1450.