### PR TITLE
Bump blackbox suite timeout to 15m to stop CI variance flakes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,7 +252,7 @@ jobs:
     - name: Run blackbox tests
       # TestPOP runs in its own job (test-blackbox-pop) because its server
       # restart interferes with subsequent deploys. Skip it here.
-      run: go test -tags blackbox -timeout 10m -v -count=1 -p 1 -skip '^TestPOP$' ./blackbox/...
+      run: go test -tags blackbox -timeout 15m -v -count=1 -p 1 -skip '^TestPOP$' ./blackbox/...
 
     - name: Server logs on failure
       if: failure()

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ update-test-groups: ## Measure new packages and rebuild hack/test-groups.json
 	python3 hack/calc-test-groups.py hack/test-times.json -n 4 -o hack/test-groups.json
 
 test-blackbox: ## Run blackbox tests (requires `make dev` running)
-	go test -tags blackbox -timeout 10m -v -count=1 -p 1 ./blackbox/...
+	go test -tags blackbox -timeout 15m -v -count=1 -p 1 ./blackbox/...
 
 build-cloud-test: ## Build cloud and POP binaries for POP blackbox tests
 	@CLOUD_REPO=$${BLACKBOX_CLOUD_REPO:-$$(cd .. && pwd)/cloud}; \


### PR DESCRIPTION
The blackbox suite has been running with almost no headroom against its wall-clock timeout. It takes around 9.7 minutes of a 10 minute budget, and because it runs serially (`-p 1` is forced by the shared containerd/buildkit instance), there's no slack to absorb a slow runner or a noisy neighbor. When ordinary variance tips a run past 10:00, the Release pipeline goes red and the timeout panic blames whichever test happened to be holding the baton at that moment, which makes it look like a hang in an innocent test rather than the aggregate-runtime problem it actually is.

This is the stopgap: bump the ceiling to 15 minutes on both the CI command and the local `make test-blackbox` target so they don't drift. The POP blackbox job already runs at 15m, so we're matching precedent rather than inventing a number. The tradeoff is that a genuine hang now burns 15 minutes before failing instead of 10, which is acceptable for a suite that isn't known to hang.

This buys runway, not a cure. The suite is ~583s and growing, so the durable fix is to shard it across parallel jobs the way the unit tests already split into runners. That's tracked as the next piece of work under MIR-1431, which is why this refs the issue but doesn't close it.

Refs MIR-1431