### PR TITLE
Shard the blackbox suite across 3 parallel CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,9 +190,49 @@ jobs:
       if: steps.docker-image-cache.outputs.cache-hit != 'true'
       run: docker save runtime-shell -o /tmp/iso-image.tar
 
+  blackbox-groups:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      with:
+        persist-credentials: false
+        ref: ${{ inputs.ref }}
+
+    - name: Set blackbox shard matrix
+      id: set-matrix
+      run: |
+        # Discover all blackbox test functions by scanning source (no compile,
+        # no cluster) so a newly added test is never silently left unrun.
+        ALL_TESTS=$(grep -rhoE '^func Test[A-Za-z0-9_]+' blackbox --include='*_test.go' \
+          | sed -E 's/^func //' | sort -u)
+
+        # Tests already assigned to a shard in the checked-in manifest.
+        GROUPED=$(jq -r '.groups[].tests[]' hack/blackbox-groups.json | sort -u)
+
+        # TestPOP runs in its own job (test-blackbox-pop); never shard it here.
+        UNGROUPED=$(comm -23 <(echo "$ALL_TESTS") <(echo "$GROUPED") | grep -vx 'TestPOP' || true)
+
+        MATRIX=$(jq -c '.groups' hack/blackbox-groups.json)
+
+        if [ -n "$UNGROUPED" ]; then
+          echo "::warning::Blackbox tests not in blackbox-groups.json (running in extra shard, regenerate with 'make blackbox-groups'): $(echo $UNGROUPED | tr '\n' ' ')"
+          EXTRA=$(echo "$UNGROUPED" | jq -R -s 'split("\n") | map(select(. != ""))')
+          MATRIX=$(echo "$MATRIX" | jq -c --argjson tests "$EXTRA" '. + [{"shard": (length + 1), "estimated_s": 0, "tests": $tests}]')
+        fi
+
+        echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+
   test-blackbox:
+    name: test-blackbox (shard ${{ matrix.group.shard }})
+    needs: blackbox-groups
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: depot-ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ${{ fromJson(needs.blackbox-groups.outputs.matrix) }}
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
@@ -249,10 +289,15 @@ jobs:
     - name: Start miren server
       run: make dev-server-start
 
-    - name: Run blackbox tests
-      # TestPOP runs in its own job (test-blackbox-pop) because its server
-      # restart interferes with subsequent deploys. Skip it here.
-      run: go test -tags blackbox -timeout 15m -v -count=1 -p 1 -skip '^TestPOP$' ./blackbox/...
+    - name: Run blackbox tests (shard ${{ matrix.group.shard }})
+      # Each shard runs only its assigned subset, built into a -run regex from
+      # the matrix. TestPOP runs in its own job (test-blackbox-pop) because its
+      # server restart interferes with subsequent deploys; -skip guards against
+      # it ever slipping into a shard. Per-shard runtime is ~3 min, so 10m
+      # restores fast failure on a genuine hang.
+      run: |
+        RUN=$(echo '${{ toJson(matrix.group.tests) }}' | jq -r 'join("|")')
+        go test -tags blackbox -timeout 10m -v -count=1 -p 1 -run "^(${RUN})$" -skip '^TestPOP$' ./blackbox/...
 
     - name: Server logs on failure
       if: failure()
@@ -360,19 +405,27 @@ jobs:
   # that passes only when every matrix runner and blackbox tests succeed.
   test:
     if: always()
-    needs: [test-runner, test-blackbox, test-blackbox-pop]
+    needs: [test-runner, blackbox-groups, test-blackbox, test-blackbox-pop]
     runs-on: ubuntu-latest
     steps:
     - name: Check results
       run: |
         echo "test-runner result: ${{ needs.test-runner.result }}"
+        echo "blackbox-groups result: ${{ needs.blackbox-groups.result }}"
         echo "test-blackbox result: ${{ needs.test-blackbox.result }}"
         echo "test-blackbox-pop result: ${{ needs.test-blackbox-pop.result }}"
 
         if [[ "${{ needs.test-runner.result }}" != "success" ]]; then
           exit 1
         fi
-        # Blackbox tests are skipped for external (fork) PRs
+        # blackbox-groups builds the shard matrix. If it fails, the sharded
+        # test-blackbox job is skipped, which would otherwise look benign below,
+        # so require it to succeed outright.
+        if [[ "${{ needs.blackbox-groups.result }}" != "success" ]]; then
+          exit 1
+        fi
+        # Blackbox tests are skipped for external (fork) PRs. A matrix job's
+        # aggregate result is success only when every shard passes.
         if [[ "${{ needs.test-blackbox.result }}" != "success" && "${{ needs.test-blackbox.result }}" != "skipped" ]]; then
           exit 1
         fi

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,12 @@ update-test-groups: ## Measure new packages and rebuild hack/test-groups.json
 	bash hack/update-test-times.sh hack/test-times.json
 	python3 hack/calc-test-groups.py hack/test-times.json -n 4 -o hack/test-groups.json
 
+blackbox-groups: ## Rebalance hack/blackbox-groups.json from measured blackbox test times
+	python3 hack/calc-blackbox-groups.py hack/blackbox-test-times.json --env standalone -n 3 -o hack/blackbox-groups.json
+
+measure-blackbox-times: ## Re-measure per-test blackbox times into hack/blackbox-test-times.json (requires `make dev` running)
+	python3 hack/measure-blackbox-times.py -o hack/blackbox-test-times.json
+
 test-blackbox: ## Run blackbox tests (requires `make dev` running)
 	go test -tags blackbox -timeout 15m -v -count=1 -p 1 ./blackbox/...
 
@@ -188,7 +194,7 @@ test-blackbox-pop: ## Run POP blackbox tests (requires `make dev` and cloud repo
 test-blackbox-distributed: ## Run blackbox tests against distributed environment (requires hack/dev-distributed up)
 	BLACKBOX_MODE=peers go test -tags blackbox -timeout 10m -v -count=1 -p 1 ./blackbox/...
 
-.PHONY: test test-shell test-blackbox test-blackbox-pop build-cloud-test test-blackbox-distributed test-coverage test-coverage-ci coverage-report coverage-percent coverage-by-package coverage-pr test-groups update-test-groups
+.PHONY: test test-shell test-blackbox test-blackbox-pop build-cloud-test test-blackbox-distributed test-coverage test-coverage-ci coverage-report coverage-percent coverage-by-package coverage-pr test-groups update-test-groups blackbox-groups measure-blackbox-times
 
 #
 # Building

--- a/hack/blackbox-groups.json
+++ b/hack/blackbox-groups.json
@@ -1,0 +1,64 @@
+{
+  "environment": "standalone",
+  "n_shards": 3,
+  "makespan_s": 178.04,
+  "groups": [
+    {
+      "shard": 1,
+      "estimated_s": 178.04,
+      "tests": [
+        "TestAddonDeployWithVersionInAppToml",
+        "TestZeroDowntimeDeploy",
+        "TestValkeyAddonCreateListDestroy",
+        "TestRabbitmqAddonDeployWithAppToml",
+        "TestMysqlAddonCreateListDestroy",
+        "TestCrashLoop",
+        "TestSandboxExec",
+        "TestDeployGoServer",
+        "TestRouteSetListRemove",
+        "TestSandboxList"
+      ]
+    },
+    {
+      "shard": 2,
+      "estimated_s": 176.09,
+      "tests": [
+        "TestMemcacheAddonCreateListDestroy",
+        "TestEnvSetGetList",
+        "TestLocalDiskPersistence",
+        "TestAddonDeployWithAppToml",
+        "TestAddonCreateListDestroy",
+        "TestEphemeralDeploy",
+        "TestRouteWafEnableDisable",
+        "TestRouteWafInvalidLevel",
+        "TestDeployAndRollback",
+        "TestRouteWafDefaultRoute"
+      ]
+    },
+    {
+      "shard": 3,
+      "estimated_s": 172.16,
+      "tests": [
+        "TestMysqlAddonDeployWithAppToml",
+        "TestRabbitmqAddonCreateListDestroy",
+        "TestBadCommand",
+        "TestValkeyAddonDeployWithAppToml",
+        "TestAddonUnknownAddon",
+        "TestMemcacheAddonDeployWithAppToml",
+        "TestRouteWafJsonOutput",
+        "TestRoutePasswordProtection",
+        "TestRouteWafBlocksMaliciousRequest",
+        "TestDiskUndelete",
+        "TestRoutePasswordProviderLifecycle",
+        "TestAddonVariants",
+        "TestAddonListAvailable",
+        "TestDistributedRunnerCordon",
+        "TestDistributedRunnerDrain",
+        "TestDistributedRunnerList",
+        "TestDistributedRunnerLogs",
+        "TestDistributedRunnerMetrics",
+        "TestDistributedRunnerNodePort"
+      ]
+    }
+  ]
+}

--- a/hack/blackbox-test-times.json
+++ b/hack/blackbox-test-times.json
@@ -1,0 +1,207 @@
+{
+  "summary": {
+    "total_test_time_s": 526.23,
+    "test_count": 33,
+    "source": "CI run 29856793428 job 88723011745 (green merge of PR #946)"
+  },
+  "tests": [
+    {
+      "name": "TestAddonDeployWithVersionInAppToml",
+      "environment": "standalone",
+      "elapsed_s": 38.4,
+      "status": "pass"
+    },
+    {
+      "name": "TestMemcacheAddonCreateListDestroy",
+      "environment": "standalone",
+      "elapsed_s": 36.15,
+      "status": "pass"
+    },
+    {
+      "name": "TestMysqlAddonDeployWithAppToml",
+      "environment": "standalone",
+      "elapsed_s": 32.31,
+      "status": "pass"
+    },
+    {
+      "name": "TestRabbitmqAddonCreateListDestroy",
+      "environment": "standalone",
+      "elapsed_s": 30.95,
+      "status": "pass"
+    },
+    {
+      "name": "TestEnvSetGetList",
+      "environment": "standalone",
+      "elapsed_s": 29.08,
+      "status": "pass"
+    },
+    {
+      "name": "TestZeroDowntimeDeploy",
+      "environment": "standalone",
+      "elapsed_s": 22.45,
+      "status": "pass"
+    },
+    {
+      "name": "TestValkeyAddonCreateListDestroy",
+      "environment": "standalone",
+      "elapsed_s": 21.95,
+      "status": "pass"
+    },
+    {
+      "name": "TestBadCommand",
+      "environment": "standalone",
+      "elapsed_s": 20.97,
+      "status": "pass"
+    },
+    {
+      "name": "TestLocalDiskPersistence",
+      "environment": "standalone",
+      "elapsed_s": 20.55,
+      "status": "pass"
+    },
+    {
+      "name": "TestRabbitmqAddonDeployWithAppToml",
+      "environment": "standalone",
+      "elapsed_s": 19.97,
+      "status": "pass"
+    },
+    {
+      "name": "TestValkeyAddonDeployWithAppToml",
+      "environment": "standalone",
+      "elapsed_s": 19.92,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonDeployWithAppToml",
+      "environment": "standalone",
+      "elapsed_s": 19.89,
+      "status": "pass"
+    },
+    {
+      "name": "TestMysqlAddonCreateListDestroy",
+      "environment": "standalone",
+      "elapsed_s": 18.82,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonUnknownAddon",
+      "environment": "standalone",
+      "elapsed_s": 18.66,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonCreateListDestroy",
+      "environment": "standalone",
+      "elapsed_s": 18.6,
+      "status": "pass"
+    },
+    {
+      "name": "TestCrashLoop",
+      "environment": "standalone",
+      "elapsed_s": 17.31,
+      "status": "pass"
+    },
+    {
+      "name": "TestMemcacheAddonDeployWithAppToml",
+      "environment": "standalone",
+      "elapsed_s": 17.05,
+      "status": "pass"
+    },
+    {
+      "name": "TestEphemeralDeploy",
+      "environment": "standalone",
+      "elapsed_s": 11.64,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafEnableDisable",
+      "environment": "standalone",
+      "elapsed_s": 11.07,
+      "status": "pass"
+    },
+    {
+      "name": "TestSandboxExec",
+      "environment": "standalone",
+      "elapsed_s": 10.85,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafJsonOutput",
+      "environment": "standalone",
+      "elapsed_s": 10.82,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafInvalidLevel",
+      "environment": "standalone",
+      "elapsed_s": 10.8,
+      "status": "pass"
+    },
+    {
+      "name": "TestDeployGoServer",
+      "environment": "standalone",
+      "elapsed_s": 10.74,
+      "status": "pass"
+    },
+    {
+      "name": "TestRoutePasswordProtection",
+      "environment": "standalone",
+      "elapsed_s": 9.59,
+      "status": "pass"
+    },
+    {
+      "name": "TestDeployAndRollback",
+      "environment": "standalone",
+      "elapsed_s": 9.47,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafBlocksMaliciousRequest",
+      "environment": "standalone",
+      "elapsed_s": 9.21,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteSetListRemove",
+      "environment": "standalone",
+      "elapsed_s": 8.94,
+      "status": "pass"
+    },
+    {
+      "name": "TestRouteWafDefaultRoute",
+      "environment": "standalone",
+      "elapsed_s": 8.84,
+      "status": "pass"
+    },
+    {
+      "name": "TestSandboxList",
+      "environment": "standalone",
+      "elapsed_s": 8.61,
+      "status": "pass"
+    },
+    {
+      "name": "TestDiskUndelete",
+      "environment": "standalone",
+      "elapsed_s": 1.49,
+      "status": "pass"
+    },
+    {
+      "name": "TestRoutePasswordProviderLifecycle",
+      "environment": "standalone",
+      "elapsed_s": 0.66,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonVariants",
+      "environment": "standalone",
+      "elapsed_s": 0.38,
+      "status": "pass"
+    },
+    {
+      "name": "TestAddonListAvailable",
+      "environment": "standalone",
+      "elapsed_s": 0.09,
+      "status": "pass"
+    }
+  ]
+}

--- a/hack/calc-blackbox-groups.py
+++ b/hack/calc-blackbox-groups.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Calculate balanced blackbox test groupings for parallel CI shards.
+
+The blackbox suite is a single Go package, so it can't be split across
+runners by package the way unit tests are (see hack/calc-test-groups.py).
+Instead we split by *test name*: each shard runs a subset via
+`go test -run '^(TestA|TestB|...)$'`.
+
+Tests are partitioned first by the environment they need (standalone, pop,
+peers, ...) and then LPT-bin-packed within each environment, since a single
+shard boots exactly one environment. Today only the standalone pool is large
+enough to shard and wired into CI; the environment dimension keeps the tooling
+ready to shard the others by config if they ever grow.
+
+Discovers the current test set via `go test -list` so newly added tests are
+included even before they have timing data. Untimed tests are assigned to the
+lightest shard so they always run somewhere.
+
+Usage:
+  ./hack/calc-blackbox-groups.py hack/blackbox-test-times.json \
+      --env standalone -n 3 -o hack/blackbox-groups.json
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+# Tests that never participate in the sharded standalone job. TestPOP runs in
+# its own CI job (different environment: cloud repo + secret + server restart).
+ALWAYS_SKIP = {"TestPOP"}
+
+
+def load_times(path):
+    with open(path) as f:
+        data = json.load(f)
+    return data["tests"]
+
+
+def discover_tests():
+    """Run `go test -list` to find all blackbox test functions.
+
+    Compiles the test binary (needs the blackbox build tag) but does not run
+    any test, so it needs no cluster.
+    """
+    result = subprocess.run(
+        ["go", "test", "-tags", "blackbox", "-list", ".*", "./blackbox/..."],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"Warning: go test -list failed: {result.stderr}", file=sys.stderr)
+        return []
+    names = []
+    for line in result.stdout.strip().splitlines():
+        line = line.strip()
+        if line.startswith("Test"):
+            names.append(line)
+    return sorted(names)
+
+
+def pack_lpt(tests, n_shards, new_tests=None):
+    """Longest Processing Time first bin-packing.
+
+    Sort tests by descending time, assign each to the currently lightest
+    shard. Untimed (new) tests are appended to the lightest shard as we go.
+    """
+    tests = sorted(tests, key=lambda t: t["elapsed_s"], reverse=True)
+
+    shards = [[] for _ in range(n_shards)]
+    shard_times = [0.0] * n_shards
+
+    for t in tests:
+        i = shard_times.index(min(shard_times))
+        shards[i].append(t)
+        shard_times[i] += t["elapsed_s"]
+
+    for name in (new_tests or []):
+        i = shard_times.index(min(shard_times))
+        shards[i].append({"name": name, "elapsed_s": 0.0})
+        # a fresh test's real cost is unknown; nudge so they spread out
+        shard_times[i] += 0.01
+
+    return shards, shard_times
+
+
+def build_output(shards, shard_times, environment):
+    groups = []
+    for i, (tests, total) in enumerate(zip(shards, shard_times)):
+        groups.append({
+            "shard": i + 1,
+            "estimated_s": round(total, 2),
+            "tests": [t["name"] for t in
+                      sorted(tests, key=lambda t: -t["elapsed_s"])],
+        })
+    return {
+        "environment": environment,
+        "n_shards": len(shards),
+        "makespan_s": round(max(shard_times), 2),
+        "groups": groups,
+    }
+
+
+def print_groups(output):
+    print(f"\n{'='*66}")
+    print(f"  {output['environment']}: {output['n_shards']} shards | "
+          f"makespan (test time only): {output['makespan_s']:.1f}s")
+    print(f"{'='*66}")
+    for g in output["groups"]:
+        print(f"\n  Shard {g['shard']}: {g['estimated_s']:.1f}s "
+              f"({len(g['tests'])} tests)")
+        for name in g["tests"]:
+            print(f"    {name}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calculate blackbox shard groupings")
+    parser.add_argument("input", help="blackbox-test-times.json")
+    parser.add_argument("--env", default="standalone",
+                        help="Environment pool to shard (default: standalone)")
+    parser.add_argument("-n", "--shards", type=int, default=3,
+                        help="Number of parallel shards (default: 3)")
+    parser.add_argument("-o", "--output", help="Write groups JSON to file")
+    parser.add_argument("--no-discover", action="store_true",
+                        help="Skip go test -list discovery (use only timing data)")
+    args = parser.parse_args()
+
+    all_tests = load_times(args.input)
+    tests = [t for t in all_tests
+             if t.get("environment", "standalone") == args.env
+             and t["name"] not in ALWAYS_SKIP]
+
+    new_tests = []
+    if not args.no_discover:
+        known = {t["name"] for t in all_tests} | ALWAYS_SKIP
+        discovered = discover_tests()
+        new = [n for n in discovered if n not in known]
+        if new:
+            print(f"Discovered {len(new)} test(s) with no timing data "
+                  f"(assigned to lightest shard):")
+            for n in new:
+                print(f"  {n}")
+            new_tests = new
+
+        # Warn about timed tests that no longer exist.
+        discovered_set = set(discovered)
+        if discovered_set:
+            stale = [t["name"] for t in tests if t["name"] not in discovered_set]
+            if stale:
+                print(f"\nWarning: {len(stale)} timed test(s) no longer exist:")
+                for n in stale:
+                    print(f"  {n}")
+                tests = [t for t in tests if t["name"] in discovered_set]
+
+    shards, shard_times = pack_lpt(tests, args.shards, new_tests=new_tests)
+    output = build_output(shards, shard_times, args.env)
+    print_groups(output)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(output, f, indent=2)
+            f.write("\n")
+        print(f"\nGroups written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/measure-blackbox-times.py
+++ b/hack/measure-blackbox-times.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Measure per-test execution time for the blackbox suite.
+
+The blackbox suite is a single Go package, so unlike unit tests we time
+individual test functions rather than packages. This runs the full suite once
+with -v and parses the `--- PASS/FAIL/SKIP: TestName (N.NNs)` lines that
+`go test` emits, writing hack/blackbox-test-times.json for the shard bin-packer
+(hack/calc-blackbox-groups.py) to consume.
+
+Requires a running dev environment (make dev) since the tests exercise a real
+cluster. TestPOP and the distributed-runner tests are excluded: they run in
+different environments and self-skip here.
+
+You can also parse an existing `go test -v` log instead of running the suite,
+which is handy for seeding from a CI run:
+
+  ./hack/measure-blackbox-times.py --from-log blackbox.log
+  ./hack/measure-blackbox-times.py                 # runs the suite itself
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+RESULT_RE = re.compile(r'^\s*--- (PASS|FAIL|SKIP): (Test\w+) \(([\d.]+)s\)')
+
+# Excluded from the standalone timing set: TestPOP runs in its own job, and the
+# distributed-runner tests self-skip outside the peers topology.
+EXCLUDE_PREFIXES = ("TestPOP", "TestDistributedRunner")
+
+
+def parse_log(lines):
+    tests = {}
+    for line in lines:
+        m = RESULT_RE.match(line)
+        if not m:
+            continue
+        status, name, elapsed = m.group(1), m.group(2), float(m.group(3))
+        if name.startswith(EXCLUDE_PREFIXES):
+            continue
+        # Keep the last observation if a name somehow repeats.
+        tests[name] = {
+            "name": name,
+            "environment": "standalone",
+            "elapsed_s": elapsed,
+            "status": status.lower(),
+        }
+    return sorted(tests.values(), key=lambda t: -t["elapsed_s"])
+
+
+def run_suite():
+    """Run the full blackbox suite with -v and stream its output back."""
+    cmd = ["go", "test", "-tags", "blackbox", "-timeout", "15m", "-v",
+           "-count=1", "-p", "1", "-skip", "^TestPOP$", "./blackbox/..."]
+    print(f"Running: {' '.join(cmd)}\n", file=sys.stderr)
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    sys.stderr.write(proc.stderr)
+    if proc.returncode != 0:
+        print(f"\nWarning: suite exited {proc.returncode}; timing data may be "
+              f"incomplete for failed tests.", file=sys.stderr)
+    return proc.stdout.splitlines()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Measure blackbox per-test times")
+    parser.add_argument("-o", "--output", default="hack/blackbox-test-times.json",
+                        help="Output file (default: hack/blackbox-test-times.json)")
+    parser.add_argument("--from-log", metavar="FILE",
+                        help="Parse an existing `go test -v` log instead of running")
+    parser.add_argument("--source", default=None,
+                        help="Provenance note recorded in the output summary")
+    args = parser.parse_args()
+
+    if args.from_log:
+        with open(args.from_log) as f:
+            lines = f.read().splitlines()
+        source = args.source or f"parsed from {args.from_log}"
+    else:
+        lines = run_suite()
+        source = args.source or "local `go test -tags blackbox -v` run"
+
+    tests = parse_log(lines)
+    if not tests:
+        print("Error: no test timings found in output.", file=sys.stderr)
+        sys.exit(1)
+
+    out = {
+        "summary": {
+            "total_test_time_s": round(sum(t["elapsed_s"] for t in tests), 2),
+            "test_count": len(tests),
+            "source": source,
+        },
+        "tests": tests,
+    }
+    with open(args.output, "w") as f:
+        json.dump(out, f, indent=2)
+        f.write("\n")
+
+    print(f"Wrote {len(tests)} test timings "
+          f"({out['summary']['total_test_time_s']:.1f}s total) to {args.output}",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The last PR (#946) bumped the blackbox timeout from 10m to 15m to stop the bleeding, and it earned its keep immediately: that very merge run took 11m17s, past the old 10m wall. But a bigger timeout only buys runway. The suite is ~9 minutes of serial work and growing, so the durable fix is to stop running it as one long serial job.

The wrinkle is that blackbox is a single Go package, so the existing unit-test sharding (which bin-packs by package across `test (runner 1..5)`) does not apply. We shard by test name instead. A checked-in manifest (`hack/blackbox-groups.json`) assigns each test to one of three shards, and each shard boots its own dev environment and runs its subset via a `-run` regex. Splitting the suite this way is safe because the harness was already built for it: app names come from `sha256(t.Name() + runID)` with a per-process run ID, whose own doc comment says it exists so names do not collide across concurrent runs against the same cluster. No test depends on another, and each cleans up after itself.

The manifest is balanced with LPT bin-packing (`hack/calc-blackbox-groups.py`) over real per-test timings measured from a green run, which lands the three shards at roughly 178/176/172 seconds of test time. To keep it honest as tests come and go, a small setup job scans the source for every test function and runs anything missing from the manifest in an extra shard, so a newly added test can never be silently left unrun. Regenerating the manifest is a `make blackbox-groups` away, and `make measure-blackbox-times` refreshes the timings.

One deliberate bit of generality: each test in the timings file is tagged with the environment it needs (`standalone` today), and the packer shards within an environment. Only the standalone pool is big enough to shard right now, but if the POP or distributed pools ever grow, sharding them becomes a config change against the same machinery rather than a new pile of code.

Expected effect is the blackbox stage dropping from ~9.5 min to around 5, at the cost of running three runners instead of one, the same tradeoff the five unit-test runners already make. The individual shard names change, but the `test` summary job stays the single branch-protection gate and only goes green when every shard passes.

Closes MIR-1431