### PR TITLE
Run the image's entrypoint in exec form when no command is set

### DIFF
--- a/blackbox/entrypoint_image_test.go
+++ b/blackbox/entrypoint_image_test.go
@@ -1,0 +1,39 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"testing"
+	"time"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+// TestDeployImageEntrypointNoCommand verifies that when a service sets no
+// command, Miren runs the image's own ENTRYPOINT+CMD in exec form (argv, no
+// /bin/sh -c). The fixture image declares no service command, so its ENTRYPOINT
+// must run directly. Its CMD carries a $-literal arg; exec form delivers it
+// verbatim, whereas a shell-wrapped command would let /bin/sh expand it to
+// empty (the var is unset). See MIR-1444.
+func TestDeployImageEntrypointNoCommand(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "entrypoint-image",
+	})
+
+	// The app only becomes healthy if the image's ENTRYPOINT ran and bound the
+	// port, so reaching this point already proves the no-command exec path
+	// launches. Now assert argv fidelity from the entrypoint's own logs.
+	harness.Poll(t, "entrypoint argv logged", 30*time.Second, 2*time.Second,
+		func() (bool, string) {
+			r := m.Run("logs", "-a", name)
+			// Verbatim, unexpanded: proves exec form, not /bin/sh -c.
+			if r.OutputContains("arg[1]=<--note=$ENTRYPOINT_IMAGE_SHOULD_NOT_EXPAND>") {
+				return true, ""
+			}
+			return false, "entrypoint argv not yet in logs"
+		},
+	)
+}

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -360,7 +360,11 @@ func mapDiskProvider(provider string) core_v1alpha.ConfigSpecServicesDisksProvid
 // resolves defaults, and returns the final service configurations.
 // This is the core logic for determining which services exist in an app_version
 // and what their concurrency settings should be.
-func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[string]string) []core_v1alpha.ConfigSpecServices {
+// ensureWeb, when true, guarantees a web service exists: if neither app.toml
+// nor the Procfile supplied a web command, webDefault becomes its command. That
+// default may be empty, which is the image/Dockerfile case where the image's
+// own ENTRYPOINT+CMD run in exec form at launch (MIR-1444).
+func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[string]string, ensureWeb bool, webDefault string) []core_v1alpha.ConfigSpecServices {
 	// Build command map from app config
 	srvMap := map[string]string{}
 	if appConfig != nil {
@@ -375,6 +379,15 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 	for k, v := range procfileServices {
 		if _, ok := srvMap[k]; !ok {
 			srvMap[k] = v
+		}
+	}
+
+	// Default a web command when nothing above supplied one. srvMap["web"]
+	// existing here is exactly "app.toml or Procfile defined a web command", so
+	// this owns the whole "is there a web command yet?" decision in one place.
+	if ensureWeb {
+		if _, ok := srvMap["web"]; !ok {
+			srvMap["web"] = webDefault
 		}
 	}
 
@@ -547,27 +560,20 @@ func buildVersionConfig(inputs ConfigInputs) core_v1alpha.ConfigSpec {
 		spec.StartDirectory = "/app"
 	}
 
-	// If no web service defined in app config or Procfile, but we have a command or entrypoint,
-	// create a synthetic Procfile entry for web service
-	hasWebInAppConfig := ac != nil && ac.Services["web"] != nil && ac.Services["web"].Command != ""
-	hasWebInProcfile := procfileServices != nil && procfileServices["web"] != ""
-	if !hasWebInAppConfig && !hasWebInProcfile && res != nil {
-		// Use Command if available, otherwise fall back to Entrypoint
-		webCmd := res.Command
-		if webCmd == "" {
-			webCmd = res.Entrypoint
-		}
-		if webCmd != "" {
-			if procfileServices == nil {
-				procfileServices = make(map[string]string)
-			}
-			procfileServices["web"] = webCmd
+	// A build produces a runnable artifact, so it needs a routable web service.
+	// If nothing (app.toml or Procfile) defined a web command, fall back to the
+	// build's default: a stack build supplies one, while an image/Dockerfile
+	// build leaves it empty so the image's own ENTRYPOINT+CMD run in exec form
+	// at launch (MIR-1444). buildServicesConfig owns that defaulting, so we
+	// don't stage synthetic entries into the caller-owned Procfile map.
+	webDefault := ""
+	if res != nil {
+		webDefault = res.Command
+		if webDefault == "" {
+			webDefault = res.Entrypoint
 		}
 	}
-
-	// Build service configurations with concurrency settings from app.toml/Procfile
-	// Commands are set directly on each service (svc.Command) by buildServicesConfig
-	spec.Services = buildServicesConfig(ac, procfileServices)
+	spec.Services = buildServicesConfig(ac, procfileServices, res != nil, webDefault)
 
 	// Merge env vars: preserve manual vars from existing services
 	for i := range spec.Services {
@@ -1552,39 +1558,6 @@ func (b *Builder) logDeployment(ctx context.Context, appName, version, artifact 
 	if err != nil {
 		b.Log.Error("failed to write deployment log entry", "error", err, "app", appName)
 	}
-}
-
-// buildImageCommand combines the OCI image entrypoint and cmd into a single shell command string.
-// This is used when no Procfile or app config command is specified for a service.
-func buildImageCommand(entrypoint, cmd []string) string {
-	// Combine entrypoint and cmd
-	var parts []string
-	parts = append(parts, entrypoint...)
-	parts = append(parts, cmd...)
-
-	if len(parts) == 0 {
-		return ""
-	}
-
-	// If there's only one part and it looks like a shell command, return it directly
-	if len(parts) == 1 {
-		return parts[0]
-	}
-
-	// For multiple parts, we need to properly quote them for shell execution
-	// This handles cases like: ENTRYPOINT ["node"] CMD ["server.js"]
-	// Which should become: node server.js
-	var quotedParts []string
-	for _, p := range parts {
-		// If the part contains spaces or special characters, quote it
-		if strings.ContainsAny(p, " \t\n\"'$`\\") {
-			quotedParts = append(quotedParts, fmt.Sprintf("%q", p))
-		} else {
-			quotedParts = append(quotedParts, p)
-		}
-	}
-
-	return strings.Join(quotedParts, " ")
 }
 
 func (b *Builder) readProcFile(dfs fsutil.FS) (map[string]string, error) {

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -89,6 +89,8 @@ func TestBuildServicesConfig(t *testing.T) {
 		name             string
 		appConfig        *appconfig.AppConfig
 		procfileServices map[string]string
+		ensureWeb        bool
+		webDefault       string
 		validateServices func(t *testing.T, services []core_v1alpha.ConfigSpecServices)
 	}{
 		{
@@ -708,6 +710,30 @@ func TestBuildServicesConfig(t *testing.T) {
 			},
 		},
 		{
+			name:             "ensureWeb defaults web when nothing supplies a command",
+			appConfig:        nil,
+			procfileServices: nil,
+			ensureWeb:        true,
+			webDefault:       "",
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
+				require.Len(t, services, 1)
+				assert.Equal(t, "web", services[0].Name)
+				assert.Empty(t, services[0].Command, "empty default is the image exec-form case")
+			},
+		},
+		{
+			name:             "ensureWeb does not override a web command from the Procfile",
+			appConfig:        nil,
+			procfileServices: map[string]string{"web": "npm start"},
+			ensureWeb:        true,
+			webDefault:       "should-not-win",
+			validateServices: func(t *testing.T, services []core_v1alpha.ConfigSpecServices) {
+				require.Len(t, services, 1)
+				assert.Equal(t, "web", services[0].Name)
+				assert.Equal(t, "npm start", services[0].Command)
+			},
+		},
+		{
 			name: "service with port_timeout copies through to ConfigSpec",
 			appConfig: &appconfig.AppConfig{
 				Services: map[string]*appconfig.ServiceConfig{
@@ -738,7 +764,7 @@ func TestBuildServicesConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			services := buildServicesConfig(tt.appConfig, tt.procfileServices)
+			services := buildServicesConfig(tt.appConfig, tt.procfileServices, tt.ensureWeb, tt.webDefault)
 			tt.validateServices(t, services)
 		})
 	}
@@ -1189,77 +1215,6 @@ func TestMergeServiceEnvVars(t *testing.T) {
 	}
 }
 
-func TestBuildImageCommand(t *testing.T) {
-	tests := []struct {
-		name       string
-		entrypoint []string
-		cmd        []string
-		want       string
-	}{
-		{
-			name:       "nil entrypoint and cmd",
-			entrypoint: nil,
-			cmd:        nil,
-			want:       "",
-		},
-		{
-			name:       "empty entrypoint and cmd",
-			entrypoint: []string{},
-			cmd:        []string{},
-			want:       "",
-		},
-		{
-			name:       "entrypoint only",
-			entrypoint: []string{"node", "server.js"},
-			cmd:        nil,
-			want:       "node server.js",
-		},
-		{
-			name:       "cmd only",
-			entrypoint: nil,
-			cmd:        []string{"npm", "start"},
-			want:       "npm start",
-		},
-		{
-			name:       "entrypoint and cmd combined",
-			entrypoint: []string{"node"},
-			cmd:        []string{"server.js"},
-			want:       "node server.js",
-		},
-		{
-			name:       "shell form entrypoint",
-			entrypoint: []string{"/bin/sh", "-c", "exec node server.js"},
-			cmd:        nil,
-			want:       "/bin/sh -c \"exec node server.js\"",
-		},
-		{
-			name:       "single element shell command",
-			entrypoint: []string{"npm start"},
-			cmd:        nil,
-			want:       "npm start",
-		},
-		{
-			name:       "arguments with spaces",
-			entrypoint: []string{"python"},
-			cmd:        []string{"-c", "print('hello world')"},
-			want:       "python -c \"print('hello world')\"",
-		},
-		{
-			name:       "complex command",
-			entrypoint: []string{"./start.sh"},
-			cmd:        []string{"--config", "/etc/myapp/config.yaml"},
-			want:       "./start.sh --config /etc/myapp/config.yaml",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := buildImageCommand(tt.entrypoint, tt.cmd)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestBuildVersionConfig(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1267,7 +1222,7 @@ func TestBuildVersionConfig(t *testing.T) {
 		validate func(t *testing.T, spec core_v1alpha.ConfigSpec)
 	}{
 		{
-			name: "image entrypoint creates web service when no services configured",
+			name: "build result entrypoint creates web service when no services configured",
 			inputs: ConfigInputs{
 				BuildResult: &BuildResult{
 					Entrypoint: "node server.js",
@@ -1285,7 +1240,7 @@ func TestBuildVersionConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "image entrypoint creates web service when only worker in procfile",
+			name: "build result entrypoint creates web service when only worker in procfile",
 			inputs: ConfigInputs{
 				BuildResult: &BuildResult{
 					Entrypoint: "npm start",
@@ -1315,7 +1270,7 @@ func TestBuildVersionConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "procfile web takes precedence over image entrypoint",
+			name: "procfile web takes precedence over build result entrypoint",
 			inputs: ConfigInputs{
 				BuildResult: &BuildResult{
 					Entrypoint: "node default.js",
@@ -1334,7 +1289,7 @@ func TestBuildVersionConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "app config web command takes precedence over image entrypoint",
+			name: "app config web command takes precedence over build result entrypoint",
 			inputs: ConfigInputs{
 				BuildResult: &BuildResult{
 					Entrypoint: "node default.js",
@@ -1356,7 +1311,11 @@ func TestBuildVersionConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "no image entrypoint means no web service when no config",
+			// A build that produced an image but carries no command is the
+			// image/Dockerfile case: we still materialize a web service, with an
+			// empty command, so the image's own ENTRYPOINT+CMD run in exec form
+			// at launch (MIR-1444) instead of the app silently having no service.
+			name: "image build with no command still yields an empty-command web service",
 			inputs: ConfigInputs{
 				BuildResult: &BuildResult{
 					WorkingDir: "/app",
@@ -1366,7 +1325,9 @@ func TestBuildVersionConfig(t *testing.T) {
 				ExistingConfig:   core_v1alpha.ConfigSpec{},
 			},
 			validate: func(t *testing.T, spec core_v1alpha.ConfigSpec) {
-				assert.Len(t, spec.Services, 0, "should have no services")
+				require.Len(t, spec.Services, 1, "web service should materialize so the image entrypoint runs")
+				assert.Equal(t, "web", spec.Services[0].Name)
+				assert.Empty(t, spec.Services[0].Command, "command stays empty so the image's ENTRYPOINT+CMD run in exec form")
 				assert.Equal(t, "/app", spec.StartDirectory)
 			},
 		},

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -594,23 +594,18 @@ func (b *Buildkit) BuildImage(
 		if configJSON != "" {
 			var imgConfig struct {
 				Config struct {
-					WorkingDir string   `json:"WorkingDir"`
-					Entrypoint []string `json:"Entrypoint"`
-					Cmd        []string `json:"Cmd"`
+					WorkingDir string `json:"WorkingDir"`
 				} `json:"config"`
 			}
 			if err := json.Unmarshal([]byte(configJSON), &imgConfig); err == nil {
 				res.WorkingDir = imgConfig.Config.WorkingDir
-				if res.Entrypoint == "" {
-					res.Entrypoint = buildImageCommand(imgConfig.Config.Entrypoint, nil)
-				}
-
-				if res.Command == "" {
-					res.Command = buildImageCommand(imgConfig.Config.Cmd, nil)
-				}
 			} else {
 				b.Log.Warn("failed to parse image config", "error", err)
 			}
+			// We intentionally do not flatten the image's ENTRYPOINT/CMD into a
+			// command string here. When a service has no command, the image's
+			// own ENTRYPOINT+CMD run in exec form via oci.WithImageConfig at
+			// launch (MIR-1444), preserving argv boundaries, PID 1, and signals.
 		}
 	}
 

--- a/testdata/entrypoint-image/.miren/app.toml
+++ b/testdata/entrypoint-image/.miren/app.toml
@@ -1,0 +1,1 @@
+name = "entrypoint-image"

--- a/testdata/entrypoint-image/Dockerfile.miren
+++ b/testdata/entrypoint-image/Dockerfile.miren
@@ -1,0 +1,12 @@
+FROM alpine:3.20
+RUN apk add --no-cache python3
+COPY entrypoint.sh /entrypoint.sh
+COPY www /www
+RUN chmod +x /entrypoint.sh
+EXPOSE 3000
+# Exec-form entrypoint: with no service command, Miren must run this argv
+# directly (no /bin/sh -c), preserving arg boundaries, PID 1, and signals.
+ENTRYPOINT ["/entrypoint.sh"]
+# The $-literal arg is the tell: exec form passes it verbatim, while a
+# shell-wrapped command would let /bin/sh expand it (to empty, since unset).
+CMD ["serve", "--note=$ENTRYPOINT_IMAGE_SHOULD_NOT_EXPAND"]

--- a/testdata/entrypoint-image/entrypoint.sh
+++ b/testdata/entrypoint-image/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Fixture for MIR-1444: log argv verbatim so the blackbox test can assert the
+# service launched in exec form. When run as the image's own ENTRYPOINT+CMD
+# (no /bin/sh -c), the $-literal CMD arg arrives unexpanded and this is PID 1.
+echo "entrypoint-image: pid=$$ argc=$#"
+i=0
+for a in "$@"; do
+	echo "entrypoint-image: arg[$i]=<$a>"
+	i=$((i + 1))
+done
+exec python3 -m http.server "${PORT:-3000}" --directory /www

--- a/testdata/entrypoint-image/www/index.html
+++ b/testdata/entrypoint-image/www/index.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>entrypoint-image</title>
+<h1>entrypoint-image is up</h1>


### PR DESCRIPTION
Part of RFD-91's [bring-your-own-image](https://linear.app/miren/issue/MIR-1430) effort, where the goal is to carve out the reasons you need a hand-written `Dockerfile.miren` shim to run an upstream image. One of those reasons is that Miren throws away the image's `ENTRYPOINT`: every service launches as `/bin/sh -c "COMMAND"`, and for a Dockerfile build with no service command we'd synthesize that COMMAND ourselves by flattening the image's `ENTRYPOINT` + `CMD` back into a shell string.

That flatten (`buildImageCommand`) is lossy in a couple of ways worth spelling out. It quotes argv with Go's `%q`, which is *Go* double-quote syntax rather than shell-safe quoting, so an arg like `--flag=$VAR` comes back wrapped in shell double-quotes and then gets expanded by `/bin/sh -c` (a latent injection footgun, not just a cosmetic bug). And wrapping everything in a shell wedges a process between the runtime and the image's real entrypoint, which is where PID 1 and signal forwarding go subtly wrong.

The nice surprise once I dug in: the sandbox seam already does the right thing. `oci.WithImageConfig` loads the image's exec-form argv into the spec, and the `/bin/sh -c` override only fires when a command is actually present. So the whole fix lives upstream. Stop synthesizing a command from the image (drop `buildImageCommand` and its two call sites), and let the image's own `ENTRYPOINT` + `CMD` stand as the process argv in exec form, the way `docker run IMAGE` behaves. The one gap to close alongside it: with nothing synthesizing a web command anymore, a no-command image build needs to still materialize a `web` service (now with an empty command) so that exec path is actually reachable.

Giving a `command` is completely unchanged. You still get `/bin/sh -c "COMMAND"` with `$PORT`, pipes, redirects, and `exec` all intact, which is the full-control escape hatch. Stack (buildpack) builds are unaffected too: their web command still comes from the stack, and their entrypoint still flows through the existing `cfgSpec.Entrypoint` path.

RFD-91 flagged PID 1 and signal forwarding as the load-bearing bet, so I spiked it in the dev environment before writing the change. A no-command image runs its entrypoint as PID 1, receives a `$`-literal `CMD` arg verbatim (proving exec form, since a shell would have expanded it), and catches `SIGTERM` for graceful shutdown. The new blackbox test (`entrypoint-image`) locks that argv fidelity so it can't quietly regress.

The spike also turned up two things worth tracking separately, both filed: [MIR-1452](https://linear.app/miren/issue/MIR-1452) (make `image = "..."` a first-class build source, the step that deletes the shim entirely rather than just shrinking it) and [MIR-1453](https://linear.app/miren/issue/MIR-1453), a pre-existing bug where the coordinator reads the built image's config back through the in-cluster `cluster.local` registry name it can't resolve. This change doesn't depend on that fetch (it reads the image config from the local content store at launch), but the EXPOSE-port sibling will, so it's linked as a blocker there.

Closes MIR-1444.
