### PR TITLE
Read image config from the buildkit gateway, not the unresolvable cluster.local registry

### DIFF
--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -3,17 +3,15 @@ package build
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
+	exptypes "github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	"miren.dev/runtime/pkg/idgen"
@@ -26,11 +24,6 @@ type Buildkit struct {
 	Client *client.Client
 
 	Log *slog.Logger
-
-	// RegistryURLOverride is used for fetching image configs when the push URL
-	// is not accessible from the current host (e.g., in tests where push goes to
-	// a docker network address but fetch needs localhost:port)
-	RegistryURLOverride string
 }
 
 type tarOutput struct {
@@ -294,68 +287,6 @@ type BuildResult struct {
 	DetectionEvents []stackbuild.DetectionEvent
 }
 
-// fetchImageConfigFromRegistry fetches the image config JSON from a registry using the config digest.
-// imageURL is like "registry:5000/repo:tag" and configDigest is like "sha256:abc123..."
-// If insecure is true, falls back to HTTP if HTTPS fails (for local/test registries).
-func fetchImageConfigFromRegistry(ctx context.Context, imageURL, configDigest string, insecure bool) ([]byte, error) {
-	// Parse the image URL to extract registry and repository
-	// Format: [registry/]repository[:tag]
-	parts := strings.SplitN(imageURL, "/", 2)
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("invalid image URL format: %s", imageURL)
-	}
-
-	registry := parts[0]
-	repoWithTag := parts[1]
-
-	// Remove tag from repository
-	repo := strings.Split(repoWithTag, ":")[0]
-
-	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-
-	// Try HTTPS first
-	url := fmt.Sprintf("https://%s/v2/%s/blobs/%s", registry, repo, configDigest)
-	body, err := doRegistryFetch(ctx, httpClient, url)
-	if err == nil {
-		return body, nil
-	}
-
-	// Fall back to HTTP only if insecure flag is explicitly set
-	if insecure {
-		url = fmt.Sprintf("http://%s/v2/%s/blobs/%s", registry, repo, configDigest)
-		body, err = doRegistryFetch(ctx, httpClient, url)
-		if err == nil {
-			return body, nil
-		}
-	}
-
-	return nil, fmt.Errorf("failed to fetch config from registry: %w", err)
-}
-
-// doRegistryFetch performs an HTTP GET request with the given context and client.
-func doRegistryFetch(ctx context.Context, client *http.Client, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("registry returned status %d", resp.StatusCode)
-	}
-
-	return io.ReadAll(resp.Body)
-}
-
 func (b *Buildkit) BuildImage(
 	ctx context.Context,
 	dfs fsutil.FS,
@@ -538,6 +469,13 @@ func (b *Buildkit) BuildImage(
 		return &res, err
 	}
 
+	// inlineImageConfig captures the built image's config JSON straight from the
+	// gateway result metadata, where the frontend deposits it under
+	// exptypes.ExporterImageConfigKey. Reading it here keeps config extraction in
+	// the coordinator's own context, so we never round-trip to the registry by its
+	// in-cluster name (cluster.local), which the coordinator can't resolve.
+	var inlineImageConfig []byte
+
 	buildResp, err := b.Client.Build(ctx, solveOpt, "runtime", func(ctx context.Context, c gateway.Client) (*gateway.Result, error) {
 		if opts.phaseUpdates != nil {
 			opts.phaseUpdates("solving")
@@ -556,6 +494,10 @@ func (b *Buildkit) BuildImage(
 
 		b.Log.Info("solved", "ref", ref)
 
+		// Single-platform builds emit the config under the plain key; ParseKey
+		// with a nil platform reads exactly that.
+		inlineImageConfig = exptypes.ParseKey(res.Metadata, exptypes.ExporterImageConfigKey, nil)
+
 		return res, nil
 	}, ssProgress)
 
@@ -564,40 +506,16 @@ func (b *Buildkit) BuildImage(
 			res.ManifestDigest = digest
 		}
 
-		// Extract working directory from image config for Dockerfile builds
-		var configJSON string
-		if cfg, ok := buildResp.ExporterResponse["containerimage.config"]; ok {
-			// Config is directly available in response
-			configJSON = cfg
-		} else if configDigest, ok := buildResp.ExporterResponse["containerimage.config.digest"]; ok {
-			// Config needs to be fetched from registry
-			fetchURL := imageURL
-			if b.RegistryURLOverride != "" {
-				// Use override URL for fetching (e.g., localhost:port in tests)
-				// Extract the repository path from imageURL and combine with override registry
-				parts := strings.SplitN(imageURL, "/", 2)
-				if len(parts) == 2 {
-					fetchURL = b.RegistryURLOverride + "/" + parts[1]
-				}
-			}
-			b.Log.Debug("fetching config from registry", "digest", configDigest, "fetchURL", fetchURL)
-			// Use insecure (HTTP fallback) when RegistryURLOverride is set (test/local registries)
-			insecure := b.RegistryURLOverride != ""
-			configBytes, fetchErr := fetchImageConfigFromRegistry(ctx, fetchURL, configDigest, insecure)
-			if fetchErr != nil {
-				b.Log.Warn("failed to fetch config from registry", "error", fetchErr)
-			} else {
-				configJSON = string(configBytes)
-			}
-		}
-
-		if configJSON != "" {
+		// Extract working directory, entrypoint, and command from the image config
+		// for Dockerfile builds. The config comes from the gateway result metadata
+		// captured during the solve above.
+		if len(inlineImageConfig) > 0 {
 			var imgConfig struct {
 				Config struct {
 					WorkingDir string `json:"WorkingDir"`
 				} `json:"config"`
 			}
-			if err := json.Unmarshal([]byte(configJSON), &imgConfig); err == nil {
+			if err := json.Unmarshal(inlineImageConfig, &imgConfig); err == nil {
 				res.WorkingDir = imgConfig.Config.WorkingDir
 			} else {
 				b.Log.Warn("failed to parse image config", "error", err)

--- a/servers/build/buildkit_test.go
+++ b/servers/build/buildkit_test.go
@@ -253,11 +253,9 @@ RUN echo "test" > /custom/workdir/test.txt
 	dfs, err := fsutil.NewFS(testDir)
 	require.NoError(t, err)
 
-	// Create Buildkit instance with registry override for config fetching
 	bk := &Buildkit{
-		Client:              bkc,
-		Log:                 slog.Default(),
-		RegistryURLOverride: registry.host, // Use localhost:port for fetching config
+		Client: bkc,
+		Log:    slog.Default(),
 	}
 
 	// Build the image
@@ -301,9 +299,8 @@ WORKDIR /
 	require.NoError(t, err)
 
 	bk := &Buildkit{
-		Client:              bkc,
-		Log:                 slog.Default(),
-		RegistryURLOverride: registry.host,
+		Client: bkc,
+		Log:    slog.Default(),
 	}
 
 	bs := BuildStack{
@@ -344,9 +341,8 @@ RUN echo "no workdir"
 	require.NoError(t, err)
 
 	bk := &Buildkit{
-		Client:              bkc,
-		Log:                 slog.Default(),
-		RegistryURLOverride: registry.host,
+		Client: bkc,
+		Log:    slog.Default(),
 	}
 
 	bs := BuildStack{
@@ -392,9 +388,8 @@ CMD ["server.js"]
 	require.NoError(t, err)
 
 	bk := &Buildkit{
-		Client:              bkc,
-		Log:                 slog.Default(),
-		RegistryURLOverride: registry.host,
+		Client: bkc,
+		Log:    slog.Default(),
 	}
 
 	bs := BuildStack{
@@ -408,10 +403,12 @@ CMD ["server.js"]
 	res, err := bk.BuildImage(ctx, dfs, bs, "test-app", imageURL)
 	require.NoError(t, err)
 
-	// Verify entrypoint and cmd were extracted
-	assert.Equal(t, "node", res.Entrypoint, "Entrypoint should match ENTRYPOINT in Dockerfile")
-	assert.Equal(t, "server.js", res.Command, "Command should match CMD in Dockerfile")
+	// The image's ENTRYPOINT/CMD are intentionally not flattened into
+	// BuildResult; they run in exec form at launch via oci.WithImageConfig
+	// (MIR-1444). BuildImage only extracts WorkingDir here.
 	assert.Equal(t, "/app", res.WorkingDir, "WorkingDir should match WORKDIR in Dockerfile")
+	assert.Equal(t, "", res.Entrypoint, "Entrypoint runs in exec form at launch, not surfaced in BuildResult")
+	assert.Equal(t, "", res.Command, "Command runs in exec form at launch, not surfaced in BuildResult")
 }
 
 func TestBuildImageCmdOnly(t *testing.T) {
@@ -438,9 +435,8 @@ CMD ["npm", "start"]
 	require.NoError(t, err)
 
 	bk := &Buildkit{
-		Client:              bkc,
-		Log:                 slog.Default(),
-		RegistryURLOverride: registry.host,
+		Client: bkc,
+		Log:    slog.Default(),
 	}
 
 	bs := BuildStack{
@@ -454,8 +450,9 @@ CMD ["npm", "start"]
 	res, err := bk.BuildImage(ctx, dfs, bs, "test-app", imageURL)
 	require.NoError(t, err)
 
-	// Verify cmd was extracted (entrypoint should be empty for alpine)
-	assert.Equal(t, "npm start", res.Command, "Command should match CMD in Dockerfile")
+	// CMD runs in exec form at launch (MIR-1444), so BuildImage does not
+	// surface it as a flattened command string in BuildResult.
+	assert.Equal(t, "", res.Command, "Command runs in exec form at launch, not surfaced in BuildResult")
 	assert.Equal(t, "", res.Entrypoint, "Entrypoint should be empty when not set")
 }
 
@@ -483,9 +480,8 @@ WORKDIR /var/www/html/app/current
 	require.NoError(t, err)
 
 	bk := &Buildkit{
-		Client:              bkc,
-		Log:                 slog.Default(),
-		RegistryURLOverride: registry.host,
+		Client: bkc,
+		Log:    slog.Default(),
 	}
 
 	bs := BuildStack{


### PR DESCRIPTION
When a Dockerfile build finishes, the coordinator wants the built image's `WorkingDir`, `Entrypoint`, and `Cmd` so it can fold them into the deploy. The way it got them was to take the config blob's digest and re-fetch the blob from the registry using the image's push URL. That URL is `cluster.local:5000`, an in-cluster name that's meaningful from the workload/buildkit network but meaningless from the coordinator's host. So the fetch died with `dial tcp: lookup cluster.local ... no such host`, and the error got swallowed as a WARN. Nothing surfaced to the user, and `WorkingDir` silently fell back to `/app`.

The code read like it had a fast path and a fallback: prefer an inline `containerimage.config` from the build response, and only re-fetch from the registry if it's missing. But the inline branch was dead. buildkit's image exporter never echoes `containerimage.config` back in its response (it's only ever an input attr), so every Dockerfile build fell through to the fetch, and every fetch died on `cluster.local`. The only reason CI never caught it was `RegistryURLOverride`, a test-only knob that rewrote the fetch to a reachable `localhost:port`. In dev and prod it's unset, so image-config extraction was silently broken for 100% of Dockerfile builds.

The config was never far away, though. The author even reached for the right key name, just in the wrong bag: `containerimage.config` does carry the full config JSON, but the dockerfile frontend deposits it in the buildkit gateway result metadata, not the exporter response. That's readable right inside the `Build` callback, in the coordinator's own process. So we grab it there and feed it to the same unmarshal we already had, and the whole by-name registry path goes away: the dead inline branch, `fetchImageConfigFromRegistry`, its HTTP helper, the `RegistryURLOverride` field, and the test wiring that set it. The image-config integration tests now pass with the override removed, which is the real proof the coordinator gets the config without ever reaching the registry.

One thing fell out of the rebase worth calling out. MIR-1444 stopped folding the image's ENTRYPOINT/CMD into `BuildResult` (they now run in exec form at launch via `oci.WithImageConfig`), but left `TestBuildImageEntrypointAndCmd` and `TestBuildImageCmdOnly` asserting the old flattened values. Those tests skip in CI when there's no Docker socket, so the drift rode along unnoticed until this PR touched the same tests. I updated them to assert the exec-form reality: a Dockerfile build surfaces only `WorkingDir` through `BuildResult`.

Found while spiking MIR-1444, and this unblocks MIR-1445 (default the service port to the image's `EXPOSE`), which reads the same config through the same path.

Closes MIR-1453
