### PR TITLE
Add RabbitMQ credential rotation

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1142,6 +1142,29 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	)
 	c.cm.AddController(rotationReconciler)
 
+	eps := execproxy.NewServer(c.Log, eac, rs)
+	server.ExposeValue("dev.miren.runtime/exec", exec_v1alpha.AdaptSandboxExec(eps))
+
+	// Give the addon framework an exec client so providers whose credential lives
+	// inside the container (RabbitMQ) can rotate it via rabbitmqctl. This must be
+	// wired before the controller manager starts, since the rotation controller
+	// can reconcile a pending request (and call fw.Exec) the moment it's running.
+	//
+	// Assumption worth pinning: this loopback binds fw.Exec to whatever THIS
+	// process exposes as the exec service. On the coordinator that's the
+	// node-routing exec proxy (the eps ExposeValue just above), so ExecInPool
+	// reaches an addon sandbox on whatever node holds it. That only holds while
+	// addon reconciliation runs on the coordinator. A runner exposes the
+	// containerd-local exec server under the same name, which sees only its own
+	// node's sandboxes, so if the addon controllers are ever distributed onto
+	// runners this must become a real RPC to a node-router rather than a loopback.
+	execLoopback, err := rs.Connect(rs.LoopbackAddr(), "dev.miren.runtime/exec")
+	if err != nil {
+		c.Log.Error("failed to connect to exec RPC service", "error", err)
+		return err
+	}
+	addonFw.Exec = exec_v1alpha.NewSandboxExecClient(execLoopback)
+
 	// Start the controller manager
 	if err := c.cm.Start(ctx); err != nil {
 		c.Log.Error("failed to start controller manager", "error", err)
@@ -1189,9 +1212,6 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		Config: indexgcctrl.DefaultGCConfig(),
 	}
 	c.indexGC.Start(ctx)
-
-	eps := execproxy.NewServer(c.Log, eac, rs)
-	server.ExposeValue("dev.miren.runtime/exec", exec_v1alpha.AdaptSandboxExec(eps))
 
 	ai := app.NewAppInfo(c.Log, ec, c.Cpu, c.Mem, c.HTTP)
 	server.ExposeValue("dev.miren.runtime/app", app_v1alpha.AdaptCrud(ai))

--- a/pkg/addon/framework.go
+++ b/pkg/addon/framework.go
@@ -1,22 +1,38 @@
 package addon
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/exec/exec_v1alpha"
 	"miren.dev/runtime/api/network/network_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
 	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/rpc/stream"
 	"miren.dev/runtime/pkg/saga"
 )
+
+// execTimeout bounds a single ExecInPool call so a hung exec (unreachable node,
+// stuck command) can't block a reconcile worker indefinitely. Generous: the
+// commands we run (rabbitmqctl) complete in seconds.
+const execTimeout = 2 * time.Minute
+
+// SandboxExecutor runs a command inside a running sandbox and reports its exit
+// code. *exec_v1alpha.SandboxExecClient satisfies it; tests can substitute a
+// stub.
+type SandboxExecutor interface {
+	Exec(ctx context.Context, category string, value string, command string, options *exec_v1alpha.ShellOptions, input stream.RecvStream[[]byte], output stream.SendStream[[]byte], windowUpdates stream.RecvStream[*exec_v1alpha.WindowSize]) (*exec_v1alpha.SandboxExecClientExecResults, error)
+}
 
 // ProviderFramework provides common operations that addon providers need
 // when creating backing infrastructure (pools, services, etc).
@@ -25,6 +41,12 @@ type ProviderFramework struct {
 	EAC     *entityserver_v1alpha.EntityAccessClient
 	Storage saga.Storage
 	Log     *slog.Logger
+
+	// Exec runs commands inside a pool's sandbox. Wired after the exec service
+	// is available (see coordinate.go); nil until then. Only credential rotation
+	// for engines with no network-level password change (RabbitMQ) needs it, and
+	// that runs long after startup.
+	Exec SandboxExecutor
 }
 
 // NewProviderFramework creates a new provider framework.
@@ -200,6 +222,78 @@ func (fw *ProviderFramework) GetServiceAddress(ctx context.Context, serviceID en
 	}
 
 	return svc.Ip[0], nil
+}
+
+// runningSandboxForPool finds a running sandbox belonging to the given pool.
+// Sandboxes carry a "pool" label set to their pool's ID (see the sandbox pool
+// controller); labels aren't indexed, so we list by kind and filter in memory.
+func (fw *ProviderFramework) runningSandboxForPool(ctx context.Context, poolID entity.Id) (entity.Id, error) {
+	resp, err := fw.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return "", fmt.Errorf("listing sandboxes: %w", err)
+	}
+	for _, ent := range resp.Values() {
+		var md core_v1alpha.Metadata
+		md.Decode(ent.Entity())
+		if pl, _ := md.Labels.Get("pool"); pl != poolID.String() {
+			continue
+		}
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(ent.Entity())
+		if sb.Status != compute_v1alpha.RUNNING {
+			continue
+		}
+		return entity.Id(ent.Entity().Id()), nil
+	}
+	return "", fmt.Errorf("no running sandbox found for pool %s", poolID)
+}
+
+// ExecInPool runs a command inside a running sandbox of the given pool and
+// returns an error if the command cannot be run or exits non-zero. Output is
+// captured only to enrich error messages. It targets any running instance;
+// callers should use it for node-local operations (e.g. rabbitmqctl) that are
+// safe to run against a single instance.
+func (fw *ProviderFramework) ExecInPool(ctx context.Context, poolID entity.Id, args ...string) error {
+	if fw.Exec == nil {
+		return fmt.Errorf("exec capability not configured")
+	}
+	if len(args) == 0 {
+		return fmt.Errorf("no command given")
+	}
+
+	sandboxID, err := fw.runningSandboxForPool(ctx, poolID)
+	if err != nil {
+		return err
+	}
+
+	// Bound the call so a hung exec can't wedge the reconcile worker.
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	opts := new(exec_v1alpha.ShellOptions)
+	opts.SetCommand(args)
+
+	var out bytes.Buffer
+	winCh := make(chan *exec_v1alpha.WindowSize)
+	close(winCh) // non-interactive: no terminal resize events
+
+	// Report only the command name in errors: args may carry a secret (e.g. a
+	// rotated password), and this error flows into logs and, on failure, durable
+	// saga state.
+	cmd := args[0]
+
+	res, err := fw.Exec.Exec(ctx, "id", sandboxID.String(), cmd, opts,
+		stream.ServeReader(ctx, bytes.NewReader(nil)),
+		stream.ServeWriter(ctx, &out),
+		stream.ChanReader(winCh),
+	)
+	if err != nil {
+		return fmt.Errorf("exec %s in sandbox %s: %w", cmd, sandboxID, err)
+	}
+	if code := res.Code(); code != 0 {
+		return fmt.Errorf("command %s exited %d in sandbox %s: %s", cmd, code, sandboxID, strings.TrimSpace(out.String()))
+	}
+	return nil
 }
 
 // WaitForServiceAddress watches a Service entity until it has an IP address

--- a/pkg/addon/rabbitmq/rotate.go
+++ b/pkg/addon/rabbitmq/rotate.go
@@ -1,0 +1,200 @@
+package rabbitmq
+
+import (
+	"context"
+	"fmt"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/saga"
+)
+
+var _ addon.CredentialRotator = (*Provider)(nil)
+
+// rotateCapture carries the RotationResult out of the rotation saga.
+type rotateCapture struct {
+	Result *addon.RotationResult
+}
+
+// RotateCredential implements addon.CredentialRotator for RabbitMQ. A dedicated
+// server has a single credential: the `miren` user's password, which the app
+// connects with.
+//
+// RabbitMQ is the outlier. Its password lives inside the node's mnesia database
+// (seeded once at first boot from RABBITMQ_DEFAULT_PASS), AMQP has no
+// password-change operation, and only the AMQP port is exposed, so there is no
+// way to rotate it over the network like the SQL engines. Instead we run
+// `rabbitmqctl change_password` inside the running container, record the new
+// value on the server entity, and hand the app fresh connection vars to redeploy
+// on. rabbitmqctl authenticates to the node via the Erlang cookie, not the user
+// password, so a crashed retry converges no matter which password the node
+// currently holds (no try-both dance needed).
+func (p *Provider) RotateCredential(ctx context.Context, assoc addon.AddonAssociation, credential, newSecret string) (*addon.RotationResult, error) {
+	switch credential {
+	case "", "user":
+		return p.rotateDedicated(ctx, assoc, newSecret)
+	default:
+		return nil, fmt.Errorf("unknown rabbitmq credential %q (valid: \"user\")", credential)
+	}
+}
+
+type LoadRotationStateIn struct {
+	DedicatedServerID entity.Id `saga:"dedicatedserverid"`
+}
+
+type LoadRotationStateOut struct {
+	RotatePoolID      entity.Id `saga:"rotatepoolid"`
+	RotateOldPassword string    `saga:"rotateoldpassword"`
+	RotateServiceHost string    `saga:"rotateservicehost"`
+}
+
+func LoadRotationState(ctx context.Context, in LoadRotationStateIn) (LoadRotationStateOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+
+	var server addon_v1alpha.RabbitmqServer
+	if err := fw.EC.GetById(ctx, in.DedicatedServerID, &server); err != nil {
+		return LoadRotationStateOut{}, fmt.Errorf("looking up rabbitmq server: %w", err)
+	}
+	if server.SandboxPool == "" {
+		return LoadRotationStateOut{}, fmt.Errorf("rabbitmq server %s has no sandbox pool", in.DedicatedServerID)
+	}
+
+	serviceHost, err := fw.GetServiceAddress(ctx, server.Service)
+	if err != nil {
+		return LoadRotationStateOut{}, fmt.Errorf("resolving rabbitmq service address: %w", err)
+	}
+
+	return LoadRotationStateOut{
+		RotatePoolID:      server.SandboxPool,
+		RotateOldPassword: server.Password,
+		RotateServiceHost: serviceHost,
+	}, nil
+}
+
+func UndoLoadRotationState(ctx context.Context, in LoadRotationStateIn, out LoadRotationStateOut) error {
+	return nil
+}
+
+type ChangePasswordIn struct {
+	RotatePoolID      entity.Id `saga:"rotatepoolid"`
+	RotateNewPassword string    `saga:"rotatenewpassword"`
+	RotateOldPassword string    `saga:"rotateoldpassword"`
+}
+
+type ChangePasswordOut struct {
+	// Gates the entity update on the engine actually changing; passed as data
+	// (not a bare edge) so the consumer could verify it if it wanted to.
+	PasswordChanged bool `saga:"rmq_password_changed"`
+}
+
+func ChangePassword(ctx context.Context, in ChangePasswordIn) (ChangePasswordOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	// The password rides as a rabbitmqctl argv, so it's briefly visible in the
+	// container's /proc/<pid>/cmdline. That's inherent to `rabbitmqctl
+	// change_password` (which takes no stdin form), and the dedicated broker
+	// container is single-tenant, so the exposure is confined to the broker's
+	// own process namespace. Accepted rather than worked around.
+	if err := fw.ExecInPool(ctx, in.RotatePoolID, "rabbitmqctl", "change_password", defaultUser, in.RotateNewPassword); err != nil {
+		return ChangePasswordOut{}, fmt.Errorf("changing rabbitmq password: %w", err)
+	}
+	return ChangePasswordOut{PasswordChanged: true}, nil
+}
+
+func UndoChangePassword(ctx context.Context, in ChangePasswordIn, out ChangePasswordOut) error {
+	// An empty RotateOldPassword means there's no prior password to restore
+	// (nothing was recorded), so skipping the rollback ALTER is intentional.
+	if !out.PasswordChanged || in.RotateOldPassword == "" {
+		return nil
+	}
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.ExecInPool(ctx, in.RotatePoolID, "rabbitmqctl", "change_password", defaultUser, in.RotateOldPassword)
+}
+
+type UpdateServerPasswordIn struct {
+	DedicatedServerID entity.Id `saga:"dedicatedserverid"`
+	RotateNewPassword string    `saga:"rotatenewpassword"`
+	RotateOldPassword string    `saga:"rotateoldpassword"`
+
+	PasswordChanged bool `saga:"rmq_password_changed"`
+}
+
+type UpdateServerPasswordOut struct {
+	Recorded bool
+}
+
+func UpdateServerPassword(ctx context.Context, in UpdateServerPasswordIn) (UpdateServerPasswordOut, error) {
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	if err := fw.EC.Patch(ctx, in.DedicatedServerID, 0,
+		entity.String(addon_v1alpha.RabbitmqServerPasswordId, in.RotateNewPassword),
+	); err != nil {
+		return UpdateServerPasswordOut{}, fmt.Errorf("recording new rabbitmq password: %w", err)
+	}
+	return UpdateServerPasswordOut{Recorded: true}, nil
+}
+
+func UndoUpdateServerPassword(ctx context.Context, in UpdateServerPasswordIn, out UpdateServerPasswordOut) error {
+	if !out.Recorded {
+		return nil
+	}
+	fw := saga.Get[*addon.ProviderFramework](ctx)
+	return fw.EC.Patch(ctx, in.DedicatedServerID, 0,
+		entity.String(addon_v1alpha.RabbitmqServerPasswordId, in.RotateOldPassword),
+	)
+}
+
+type BuildRotationResultIn struct {
+	RotateServiceHost string `saga:"rotateservicehost"`
+	RotateNewPassword string `saga:"rotatenewpassword"`
+}
+
+type BuildRotationResultOut struct {
+	Done bool
+}
+
+func BuildRotationResult(ctx context.Context, in BuildRotationResultIn) (BuildRotationResultOut, error) {
+	rc := saga.Get[*rotateCapture](ctx)
+	rc.Result = &addon.RotationResult{
+		EnvVars: buildEnvVars(defaultUser, in.RotateNewPassword, in.RotateServiceHost, rabbitmqPort, defaultVhost),
+	}
+	return BuildRotationResultOut{Done: true}, nil
+}
+
+func UndoBuildRotationResult(ctx context.Context, in BuildRotationResultIn, out BuildRotationResultOut) error {
+	return nil
+}
+
+// RegisterRotateDedicatedSaga registers the dedicated RabbitMQ rotation saga.
+func RegisterRotateDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *rotateCapture) error {
+	return saga.Define("rotate-dedicated-rabbitmq").
+		Using(fw).
+		Using(rc).
+		Action(DecodeDedicatedAttrs).Undo(UndoDecodeDedicatedAttrs).
+		Action(LoadRotationState).Undo(UndoLoadRotationState).
+		Action(ChangePassword).Undo(UndoChangePassword).
+		Action(UpdateServerPassword).Undo(UndoUpdateServerPassword).
+		Action(BuildRotationResult).Undo(UndoBuildRotationResult).
+		RegisterTo(registry)
+}
+
+func (p *Provider) rotateDedicated(ctx context.Context, assoc addon.AddonAssociation, newSecret string) (*addon.RotationResult, error) {
+	p.Log.Info("rotating dedicated RabbitMQ credential", "assoc", assoc.ID)
+
+	rc := &rotateCapture{}
+	registry := saga.NewRegistry()
+	if err := RegisterRotateDedicatedSaga(registry, p.Fw, rc); err != nil {
+		return nil, fmt.Errorf("registering rotate saga: %w", err)
+	}
+
+	executor := saga.NewExecutor(p.Fw.Storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
+	if err := executor.Start("rotate-dedicated-rabbitmq").
+		Input("assocentity", assoc.Entity).
+		Input("rotatenewpassword", newSecret).
+		Execute(ctx); err != nil {
+		return nil, err
+	}
+	if rc.Result == nil {
+		return nil, fmt.Errorf("rotation saga completed but no result was captured")
+	}
+	return rc.Result, nil
+}

--- a/pkg/addon/rabbitmq/rotate_integration_test.go
+++ b/pkg/addon/rabbitmq/rotate_integration_test.go
@@ -1,0 +1,126 @@
+package rabbitmq_test
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/exec/exec_v1alpha"
+	"miren.dev/runtime/components/diskio"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/addon/rabbitmq"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/saga"
+	"miren.dev/runtime/pkg/testserver"
+)
+
+// TestRabbitMQ_Rotation_Integration provisions a real RabbitMQ, rotates the
+// `miren` user's password via rabbitmqctl inside the container, and proves the
+// rotation at the auth layer: rabbitmqctl authenticate_user accepts the new
+// password and rejects the old one, and the new value is recorded on the server
+// entity. RabbitMQ has no AMQP-level password change and no client library here,
+// so this exercises the exec-based path end to end.
+func TestRabbitMQ_Rotation_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if err := diskio.EnsureLoopDevices(slog.Default()); err != nil {
+		t.Skip("skipping integration test: loop devices not available:", err)
+	}
+
+	require.NoError(t, testserver.TestServer(t))
+	time.Sleep(5 * time.Second)
+
+	ctx := t.Context()
+	log := testutils.TestDebugLogger(t)
+
+	rs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	require.NoError(t, err)
+
+	client, err := rs.Connect("localhost:8443", "entities")
+	require.NoError(t, err)
+
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+	ec := entityserver.NewClient(log, eac)
+	fw := addon.NewProviderFramework(log, ec, eac, saga.NewMemoryStorage())
+
+	// RabbitMQ rotation runs rabbitmqctl inside the container, so the framework
+	// needs an exec client (the coordinator wires this at startup; here we do it
+	// by hand against the same exec service).
+	execConn, err := rs.Connect("localhost:8443", "dev.miren.runtime/exec")
+	require.NoError(t, err)
+	fw.Exec = exec_v1alpha.NewSandboxExecClient(execConn)
+
+	provider := rabbitmq.NewProvider(fw)
+
+	prov, err := provider.Provision(ctx, addon.App{Name: "rmqrot-app"}, addon.Variant{Name: "small"})
+	require.NoError(t, err)
+	require.NotNil(t, prov)
+
+	provEnv := make(map[string]string)
+	for _, v := range prov.EnvVars {
+		provEnv[v.Key] = v.Value
+	}
+	oldPassword := provEnv["RABBITMQ_PASSWORD"]
+	require.NotEmpty(t, oldPassword)
+
+	assocID, err := ec.Create(ctx, idgen.GenNS("addon-assoc"), &addon_v1alpha.AddonAssociation{
+		Variant: "small",
+		Status:  "active",
+	})
+	require.NoError(t, err)
+	require.NoError(t, ec.Patch(ctx, assocID, 0, prov.Attrs...))
+	resp, err := eac.Get(ctx, assocID.String())
+	require.NoError(t, err)
+	rawAssoc := resp.Entity().Entity()
+
+	var data addon_v1alpha.RabbitmqDedicatedData
+	data.Decode(rawAssoc)
+	require.NotEmpty(t, data.RabbitmqServer)
+
+	var serverBefore addon_v1alpha.RabbitmqServer
+	require.NoError(t, ec.GetById(ctx, data.RabbitmqServer, &serverBefore))
+	require.Equal(t, oldPassword, serverBefore.Password)
+	poolID := serverBefore.SandboxPool
+	require.NotEmpty(t, poolID)
+
+	// authOK reports whether the miren user authenticates with the given password
+	// (rabbitmqctl authenticate_user exits non-zero on a bad password).
+	authOK := func(password string) bool {
+		return fw.ExecInPool(ctx, poolID, "rabbitmqctl", "authenticate_user", "miren", password) == nil
+	}
+
+	// Wait until the Erlang node is up and accepts the provisioned credential;
+	// rabbitmqctl becomes usable a little after the AMQP port binds.
+	require.Eventually(t, func() bool {
+		return authOK(oldPassword)
+	}, 120*time.Second, 5*time.Second, "rabbitmq should accept the provisioned credential")
+
+	const newSecret = "rotated-rmq-secret"
+	res, err := provider.RotateCredential(ctx,
+		addon.AddonAssociation{ID: assocID, Variant: "small", Entity: rawAssoc}, "user", newSecret)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	rotEnv := make(map[string]string)
+	for _, v := range res.EnvVars {
+		rotEnv[v.Key] = v.Value
+	}
+	assert.Equal(t, newSecret, rotEnv["RABBITMQ_PASSWORD"], "result should carry the new password")
+
+	var serverAfter addon_v1alpha.RabbitmqServer
+	require.NoError(t, ec.GetById(ctx, data.RabbitmqServer, &serverAfter))
+	assert.Equal(t, newSecret, serverAfter.Password, "entity should record the new password")
+
+	// Auth-layer proof: the new password works, the old one is rejected.
+	assert.True(t, authOK(newSecret), "new password should authenticate")
+	assert.False(t, authOK(oldPassword), "old password should be rejected")
+}

--- a/pkg/addon/rabbitmq/rotate_test.go
+++ b/pkg/addon/rabbitmq/rotate_test.go
@@ -1,0 +1,45 @@
+package rabbitmq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// TestRotateDedicatedSagaOrder pins the rotation ordering: resolve the pool and
+// connection details, change the password inside the container, then record it
+// on the entity only once the engine has taken it (gated by an edge on the
+// change).
+func TestRotateDedicatedSagaOrder(t *testing.T) {
+	registry := saga.NewRegistry()
+	fw := &addon.ProviderFramework{}
+	rc := &rotateCapture{}
+
+	require.NoError(t, RegisterRotateDedicatedSaga(registry, fw, rc))
+
+	def, ok := registry.Get("rotate-dedicated-rabbitmq")
+	require.True(t, ok)
+	assert.Len(t, def.Actions, 5)
+
+	order := def.ExecutionOrder()
+	indexOf := func(name string) int {
+		for i, n := range order {
+			if n == name {
+				return i
+			}
+		}
+		t.Fatalf("action %q not found in order %v", name, order)
+		return -1
+	}
+
+	assert.Less(t, indexOf("decode-dedicated-attrs"), indexOf("load-rotation-state"),
+		"must decode the server ref before looking it up")
+	assert.Less(t, indexOf("load-rotation-state"), indexOf("change-password"),
+		"must resolve the pool before changing the password")
+	assert.Less(t, indexOf("change-password"), indexOf("update-server-password"),
+		"entity must record the new password only after the engine takes it")
+}

--- a/servers/exec/exec.go
+++ b/servers/exec/exec.go
@@ -8,6 +8,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	coreutil "miren.dev/runtime/api/core"
@@ -40,6 +41,13 @@ func NewServer(log *slog.Logger, cc *containerd.Client, eac *entityserver_v1alph
 var _ exec_v1alpha.SandboxExec = (*Server)(nil)
 
 func (s *Server) Exec(ctx context.Context, req *exec_v1alpha.SandboxExecExec) error {
+	// The container lives in this runner's containerd namespace, so scope the
+	// operations below to it directly rather than depending on the caller's
+	// context or the containerd client's default namespace. The CLI path only
+	// worked by accident of that default; programmatic callers (e.g. addon
+	// credential rotation) reach us with a bare context.
+	ctx = namespaces.WithNamespace(ctx, s.Namespace)
+
 	args := req.Args()
 
 	if args.Category() != "id" {


### PR DESCRIPTION
RabbitMQ was the last addon without credential rotation, and it's the awkward one. Every other engine can change a password over the network: Postgres and MySQL take an ALTER, Valkey relaunches its pool with the new requirepass. RabbitMQ can't. Its password lives inside the node's internal mnesia database, seeded exactly once at first boot from `RABBITMQ_DEFAULT_PASS`, and AMQP has no password-change operation. The only lever is `rabbitmqctl`, run inside the container.

So the first commit gives the addon framework a way to reach inside a running pool. There's already an exec RPC (the one behind `miren sandbox exec`), it just wasn't wired to the addon layer. `ExecInPool` resolves a pool's running sandbox and runs a command in it non-interactively, turning a non-zero exit into an error. Wiring that up surfaced a latent quirk: the exec server was relying on the caller's context to carry the containerd namespace, which the CLI only supplied by accident of the containerd client's default namespace. A programmatic caller shows up with a bare context and gets "namespace is required." The server knows its own namespace, so it now scopes to that directly. No behavior change in production (same `"miren"` namespace), just an honest contract instead of trusting whatever the caller happened to set.

The second commit is the rotation itself: `rabbitmqctl change_password` for the miren user, record it on the server entity, redeploy the app onto the new connection string. It's idempotent without any effort because rabbitmqctl authenticates to the node through the Erlang cookie rather than the user's password, so a crashed retry converges regardless of which password the node currently holds. No connect-with-both-passwords dance like the SQL root rotations needed.

Verified the usual three ways: saga-ordering unit test, an integration test that stands up a real broker and proves the rotation at the auth layer (`rabbitmqctl authenticate_user` accepts the new password and rejects the old), and a live smoke through the full CLI stack including the app redeploy and a clean deprovision. `m sandbox exec` still works too, so the namespace change is good for the interactive path.

With this and the MySQL rotation (#953, in review), `miren addon rotate` covers every addon: Valkey, shared and dedicated Postgres, shared and dedicated MySQL, and RabbitMQ.

Part of MIR-1355.
