### PR TITLE
Guard env-var active_version swings with optimistic concurrency control

### DIFF
--- a/api/app/envvar.go
+++ b/api/app/envvar.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	coreutil "miren.dev/runtime/api/core"
@@ -49,6 +50,13 @@ const envMutateMaxAttempts = 100
 // The read-merge-write is retried under optimistic concurrency control so two
 // parallel env writes (or the addon controller injecting addon vars) cannot
 // silently clobber each other's active-version swing — see createNewVersion.
+//
+// The retry re-reads the app each attempt, so the CAS always lands on the current
+// revision. When baseVersion is nil (every caller today) it also re-resolves the
+// current active config, so the merge composes onto a concurrent winner's version.
+// When a baseVersion is pinned, each attempt re-derives from that fixed version by
+// design — the caller asked to base off it — so the retry re-applies the same base
+// rather than composing onto the winner.
 func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 	baseVersion *core_v1alpha.AppVersion, vars []EnvVarInput, service string) (*MutateResult, error) {
 
@@ -88,6 +96,8 @@ func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 //
 // Like SetEnvVars, the read-merge-write is retried under optimistic concurrency
 // control so a concurrent active-version swing cannot silently clobber the delete.
+// The same baseVersion caveat applies: the retry composes onto a concurrent winner
+// only when baseVersion is nil; a pinned baseVersion is re-applied as-is.
 func DeleteEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 	baseVersion *core_v1alpha.AppVersion, keys []string, service string) (*DeleteResult, error) {
 
@@ -390,10 +400,23 @@ func createNewVersion(ctx context.Context, ec *entityserver.Client, appName stri
 		return nil, err
 	}
 
-	appRec.ActiveVersion = avid
 	if err := ec.Patch(ctx, appRec.ID, appRev,
 		entity.Ref(core_v1alpha.AppActiveVersionId, avid),
 	); err != nil {
+		if errors.Is(err, cond.ErrConflict{}) {
+			// This attempt lost the race, so the version pair we just minted was
+			// never activated. Best-effort delete it (AppVersion first, so it
+			// never dangles past its ConfigVersion) rather than leaving one pair
+			// per retry for the version GC to reap later.
+			if delErr := ec.Delete(ctx, avid); delErr != nil {
+				slog.Warn("failed to delete superseded app version after conflict",
+					"app", appRec.ID, "version", avid, "error", delErr)
+			}
+			if delErr := ec.Delete(ctx, cvid); delErr != nil {
+				slog.Warn("failed to delete superseded config version after conflict",
+					"app", appRec.ID, "config_version", cvid, "error", delErr)
+			}
+		}
 		return nil, err
 	}
 

--- a/api/app/envvar.go
+++ b/api/app/envvar.go
@@ -34,9 +34,21 @@ type DeleteResult struct {
 	DeletedSources []string
 }
 
+// envMutateMaxAttempts is a live-lock backstop for the optimistic-concurrency
+// retry loop shared by SetEnvVars and DeleteEnvVars — it is not an expected
+// limit. Each conflict just means another writer swung the app's active version
+// first; there are only ever a handful of concurrent env/config writers per app,
+// so it is set high enough that genuine contention never spuriously fails a
+// write. On exhaustion the caller gets an error rather than looping forever.
+const envMutateMaxAttempts = 100
+
 // SetEnvVars resolves the config from baseVersion (or current active if nil),
 // merges env vars (with service scope), creates a new ConfigVersion + AppVersion,
 // and activates it. Returns the newly created AppVersion and its version string.
+//
+// The read-merge-write is retried under optimistic concurrency control so two
+// parallel env writes (or the addon controller injecting addon vars) cannot
+// silently clobber each other's active-version swing — see createNewVersion.
 func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 	baseVersion *core_v1alpha.AppVersion, vars []EnvVarInput, service string) (*MutateResult, error) {
 
@@ -46,100 +58,126 @@ func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 		}
 	}
 
-	appVer, spec, appRec, err := resolveBaseVersion(ctx, ec, appName, baseVersion)
-	if err != nil {
-		return nil, err
+	for attempt := 0; attempt < envMutateMaxAttempts; attempt++ {
+		appVer, spec, appRec, appRev, err := resolveBaseVersion(ctx, ec, appName, baseVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := mergeIntoSpec(spec, vars, service); err != nil {
+			return nil, err
+		}
+
+		result, err := createNewVersion(ctx, ec, appName, appVer, spec, appRec, appRev)
+		if err == nil {
+			return result, nil
+		}
+		if !errors.Is(err, cond.ErrConflict{}) {
+			return nil, err
+		}
+		// Lost the CAS race with a concurrent active-version swing; re-resolve
+		// against the winner's version and retry so neither change is dropped.
 	}
 
-	if err := mergeIntoSpec(spec, vars, service); err != nil {
-		return nil, err
-	}
-
-	return createNewVersion(ctx, ec, appName, appVer, spec, appRec)
+	return nil, fmt.Errorf("failed to set env vars on app %q after %d attempts due to concurrent writes", appName, envMutateMaxAttempts)
 }
 
 // DeleteEnvVars resolves the config from baseVersion (or current active if nil),
 // removes the specified keys, creates a new ConfigVersion + AppVersion, and
 // activates it. Returns the new version plus the source of each deleted var.
+//
+// Like SetEnvVars, the read-merge-write is retried under optimistic concurrency
+// control so a concurrent active-version swing cannot silently clobber the delete.
 func DeleteEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 	baseVersion *core_v1alpha.AppVersion, keys []string, service string) (*DeleteResult, error) {
 
-	appVer, spec, appRec, err := resolveBaseVersion(ctx, ec, appName, baseVersion)
-	if err != nil {
-		return nil, err
-	}
+	for attempt := 0; attempt < envMutateMaxAttempts; attempt++ {
+		appVer, spec, appRec, appRev, err := resolveBaseVersion(ctx, ec, appName, baseVersion)
+		if err != nil {
+			return nil, err
+		}
 
-	if appRec.ActiveVersion == "" {
-		return nil, fmt.Errorf("app has no active version")
-	}
+		if appRec.ActiveVersion == "" {
+			return nil, fmt.Errorf("app has no active version")
+		}
 
-	var deletedSources []string
+		var deletedSources []string
 
-	for _, key := range keys {
-		if service == "" {
-			found := false
-			newVars := make([]core_v1alpha.ConfigSpecVariables, 0, len(spec.Variables))
-			for _, v := range spec.Variables {
-				if v.Key == key {
-					found = true
-					deletedSources = append(deletedSources, v.Source)
-					continue
+		for _, key := range keys {
+			if service == "" {
+				found := false
+				newVars := make([]core_v1alpha.ConfigSpecVariables, 0, len(spec.Variables))
+				for _, v := range spec.Variables {
+					if v.Key == key {
+						found = true
+						deletedSources = append(deletedSources, v.Source)
+						continue
+					}
+					newVars = append(newVars, v)
 				}
-				newVars = append(newVars, v)
-			}
-			if !found {
-				return nil, fmt.Errorf("environment variable %q not found", key)
-			}
-			spec.Variables = newVars
-		} else {
-			svcFound := false
-			for i := range spec.Services {
-				if spec.Services[i].Name == service {
-					svcFound = true
-					envFound := false
-					newEnvs := make([]core_v1alpha.ConfigSpecServicesEnv, 0, len(spec.Services[i].Env))
-					for _, e := range spec.Services[i].Env {
-						if e.Key == key {
-							envFound = true
-							deletedSources = append(deletedSources, e.Source)
-							continue
+				if !found {
+					return nil, fmt.Errorf("environment variable %q not found", key)
+				}
+				spec.Variables = newVars
+			} else {
+				svcFound := false
+				for i := range spec.Services {
+					if spec.Services[i].Name == service {
+						svcFound = true
+						envFound := false
+						newEnvs := make([]core_v1alpha.ConfigSpecServicesEnv, 0, len(spec.Services[i].Env))
+						for _, e := range spec.Services[i].Env {
+							if e.Key == key {
+								envFound = true
+								deletedSources = append(deletedSources, e.Source)
+								continue
+							}
+							newEnvs = append(newEnvs, e)
 						}
-						newEnvs = append(newEnvs, e)
+						if !envFound {
+							return nil, fmt.Errorf("environment variable %q not found in service %q", key, service)
+						}
+						spec.Services[i].Env = newEnvs
+						break
 					}
-					if !envFound {
-						return nil, fmt.Errorf("environment variable %q not found in service %q", key, service)
-					}
-					spec.Services[i].Env = newEnvs
-					break
 				}
-			}
-			if !svcFound {
-				return nil, fmt.Errorf("service %q not found", service)
+				if !svcFound {
+					return nil, fmt.Errorf("service %q not found", service)
+				}
 			}
 		}
+
+		result, err := createNewVersion(ctx, ec, appName, appVer, spec, appRec, appRev)
+		if err == nil {
+			return &DeleteResult{
+				MutateResult:   *result,
+				DeletedSources: deletedSources,
+			}, nil
+		}
+		if !errors.Is(err, cond.ErrConflict{}) {
+			return nil, err
+		}
+		// Lost the CAS race; re-resolve and retry.
 	}
 
-	result, err := createNewVersion(ctx, ec, appName, appVer, spec, appRec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DeleteResult{
-		MutateResult:   *result,
-		DeletedSources: deletedSources,
-	}, nil
+	return nil, fmt.Errorf("failed to delete env vars on app %q after %d attempts due to concurrent writes", appName, envMutateMaxAttempts)
 }
 
 // resolveBaseVersion loads the app, resolves the base version and config spec.
-// If baseVersion is nil, the current active version is used.
+// If baseVersion is nil, the current active version is used. It also returns the
+// app entity's revision at read time, so the caller can swing active_version
+// under optimistic concurrency control (see createNewVersion).
 func resolveBaseVersion(ctx context.Context, ec *entityserver.Client, appName string,
-	baseVersion *core_v1alpha.AppVersion) (*core_v1alpha.AppVersion, *core_v1alpha.ConfigSpec, *core_v1alpha.App, error) {
+	baseVersion *core_v1alpha.AppVersion) (*core_v1alpha.AppVersion, *core_v1alpha.ConfigSpec, *core_v1alpha.App, int64, error) {
+
+	appEnt, err := ec.EAC().Get(ctx, "app/"+appName)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
 
 	var appRec core_v1alpha.App
-	err := ec.Get(ctx, appName, &appRec)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	appRec.Decode(appEnt.Entity().Entity())
+	appRev := appEnt.Entity().Revision()
 
 	var appVer core_v1alpha.AppVersion
 	var spec core_v1alpha.ConfigSpec
@@ -148,24 +186,24 @@ func resolveBaseVersion(ctx context.Context, ec *entityserver.Client, appName st
 		appVer = *baseVersion
 		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVer)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to resolve config: %w", err)
+			return nil, nil, nil, 0, fmt.Errorf("failed to resolve config: %w", err)
 		}
 		spec = *resolvedCfg
 	} else if appRec.ActiveVersion != "" {
 		err = ec.GetById(ctx, appRec.ActiveVersion, &appVer)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, 0, err
 		}
 		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVer)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to resolve config: %w", err)
+			return nil, nil, nil, 0, fmt.Errorf("failed to resolve config: %w", err)
 		}
 		spec = *resolvedCfg
 	} else {
 		appVer.App = appRec.ID
 	}
 
-	return &appVer, &spec, &appRec, nil
+	return &appVer, &spec, &appRec, appRev, nil
 }
 
 // SetInitialEnvVars stages env vars on an app's initial ConfigVersion,
@@ -323,9 +361,15 @@ func mergeIntoSpec(spec *core_v1alpha.ConfigSpec, vars []EnvVarInput, service st
 	return nil
 }
 
-// createNewVersion creates a ConfigVersion + AppVersion from the mutated spec and activates it.
+// createNewVersion creates a ConfigVersion + AppVersion from the mutated spec and
+// activates it. The active_version pointer is swung with a CAS on appRev (the app
+// revision captured when the base config was resolved), so a concurrent writer
+// that swings active_version first — another env mutation, or the addon
+// controller injecting addon vars — is detected and the caller retries against
+// the winner's version instead of silently clobbering it. Returns cond.ErrConflict
+// on a lost race.
 func createNewVersion(ctx context.Context, ec *entityserver.Client, appName string,
-	appVer *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec, appRec *core_v1alpha.App) (*MutateResult, error) {
+	appVer *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec, appRec *core_v1alpha.App, appRev int64) (*MutateResult, error) {
 
 	appVer.Version = appName + "-" + idgen.Gen("v")
 
@@ -347,9 +391,10 @@ func createNewVersion(ctx context.Context, ec *entityserver.Client, appName stri
 	}
 
 	appRec.ActiveVersion = avid
-	err = ec.Update(ctx, appRec)
-	if err != nil {
-		return nil, fmt.Errorf("error updating app entity: %w", err)
+	if err := ec.Patch(ctx, appRec.ID, appRev,
+		entity.Ref(core_v1alpha.AppActiveVersionId, avid),
+	); err != nil {
+		return nil, err
 	}
 
 	return &MutateResult{

--- a/api/app/envvar.go
+++ b/api/app/envvar.go
@@ -43,6 +43,13 @@ type DeleteResult struct {
 // write. On exhaustion the caller gets an error rather than looping forever.
 const envMutateMaxAttempts = 100
 
+// testHookAfterResolve, when non-nil, runs inside the SetEnvVars/DeleteEnvVars
+// retry loop after the base version is resolved (so the app revision is already
+// captured) but before the version is minted and the CAS runs. Tests use it to
+// deterministically inject a competing active-version swing and exercise the
+// retry-and-recover path. Always nil in production.
+var testHookAfterResolve func()
+
 // SetEnvVars resolves the config from baseVersion (or current active if nil),
 // merges env vars (with service scope), creates a new ConfigVersion + AppVersion,
 // and activates it. Returns the newly created AppVersion and its version string.
@@ -74,6 +81,10 @@ func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 
 		if err := mergeIntoSpec(spec, vars, service); err != nil {
 			return nil, err
+		}
+
+		if testHookAfterResolve != nil {
+			testHookAfterResolve()
 		}
 
 		result, err := createNewVersion(ctx, ec, appName, appVer, spec, appRec, appRev)
@@ -405,14 +416,14 @@ func createNewVersion(ctx context.Context, ec *entityserver.Client, appName stri
 	); err != nil {
 		if errors.Is(err, cond.ErrConflict{}) {
 			// This attempt lost the race, so the version pair we just minted was
-			// never activated. Best-effort delete it (AppVersion first, so it
-			// never dangles past its ConfigVersion) rather than leaving one pair
-			// per retry for the version GC to reap later.
+			// never activated. Best-effort delete it, AppVersion first: only drop
+			// the ConfigVersion once its AppVersion is gone, so a failed delete
+			// leaves a coherent pair for the version GC to reap rather than an
+			// AppVersion dangling at a missing ConfigVersion.
 			if delErr := ec.Delete(ctx, avid); delErr != nil {
 				slog.Warn("failed to delete superseded app version after conflict",
 					"app", appRec.ID, "version", avid, "error", delErr)
-			}
-			if delErr := ec.Delete(ctx, cvid); delErr != nil {
+			} else if delErr := ec.Delete(ctx, cvid); delErr != nil {
 				slog.Warn("failed to delete superseded config version after conflict",
 					"app", appRec.ID, "config_version", cvid, "error", delErr)
 			}

--- a/api/app/envvar_test.go
+++ b/api/app/envvar_test.go
@@ -3,7 +3,10 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -98,6 +101,42 @@ func TestSetEnvVarsComposesSequentially(t *testing.T) {
 	require.Equal(t, "1", vars["BASE"])
 	require.Equal(t, "a", vars["FOO"])
 	require.Equal(t, "b", vars["BAR"])
+}
+
+// TestSetEnvVarsConcurrentComposeAll drives the retry loop through real mid-flight
+// conflicts: several writers set distinct keys on the same app at once. With the
+// OCC retry each loser re-reads the winner's active version and composes onto it,
+// so every key must survive. Without the CAS+retry (the old unconditional Put),
+// concurrent writers each start from the base version and the last write wins,
+// dropping the rest.
+func TestSetEnvVarsConcurrentComposeAll(t *testing.T) {
+	ctx, ec := newEnvTestClient(t)
+	createEnvTestApp(t, ctx, ec, "myapp", []core_v1alpha.Variable{{Key: "BASE", Value: "1", Source: "config"}})
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = SetEnvVars(ctx, ec, "myapp", nil,
+				[]EnvVarInput{{Key: fmt.Sprintf("K%d", i), Value: strconv.Itoa(i)}}, "")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "concurrent SetEnvVars %d failed", i)
+	}
+
+	vars := activeEnvVars(t, ctx, ec, "myapp")
+	require.Equal(t, "1", vars["BASE"], "base config var must survive")
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("K%d", i)
+		require.Equal(t, strconv.Itoa(i), vars[key],
+			"concurrent writer %d's var must be present (would be clobbered without OCC retry)", i)
+	}
 }
 
 // TestDeleteEnvVarsComposesSequentially confirms the DeleteEnvVars retry-loop

--- a/api/app/envvar_test.go
+++ b/api/app/envvar_test.go
@@ -1,0 +1,119 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	coreutil "miren.dev/runtime/api/core"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+func newEnvTestClient(t *testing.T) (context.Context, *entityserver.Client) {
+	t.Helper()
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	return ctx, entityserver.NewClient(slog.Default(), inmem.EAC)
+}
+
+// createEnvTestApp creates an app with an active AppVersion whose inline config
+// carries the given variables.
+func createEnvTestApp(t *testing.T, ctx context.Context, ec *entityserver.Client, name string, vars []core_v1alpha.Variable) {
+	t.Helper()
+	verID, err := ec.Create(ctx, name+"-v0", &core_v1alpha.AppVersion{
+		Version: name + "-v0",
+		Config:  core_v1alpha.Config{Variable: append([]core_v1alpha.Variable(nil), vars...)},
+	})
+	require.NoError(t, err)
+	_, err = ec.Create(ctx, name, &core_v1alpha.App{ActiveVersion: verID})
+	require.NoError(t, err)
+}
+
+// activeEnvVars resolves the variables on an app's current active version.
+func activeEnvVars(t *testing.T, ctx context.Context, ec *entityserver.Client, name string) map[string]string {
+	t.Helper()
+	var app core_v1alpha.App
+	require.NoError(t, ec.Get(ctx, name, &app))
+	var ver core_v1alpha.AppVersion
+	require.NoError(t, ec.GetById(ctx, app.ActiveVersion, &ver))
+	spec, err := coreutil.ResolveConfig(ctx, ec.EAC(), &ver)
+	require.NoError(t, err)
+	out := make(map[string]string, len(spec.Variables))
+	for _, v := range spec.Variables {
+		out[v.Key] = v.Value
+	}
+	return out
+}
+
+// TestCreateNewVersionCASGuardsActiveVersion is the regression test for the
+// active-version clobber (the same class as MIR-1458). An env mutation resolves
+// the base config at one revision, then a competing writer swings active_version
+// before the mutation's write lands. Without a CAS the mutation's unconditional
+// Put would overwrite active_version and silently drop the competitor's version;
+// the CAS on the app revision must reject the stale write instead.
+func TestCreateNewVersionCASGuardsActiveVersion(t *testing.T) {
+	ctx, ec := newEnvTestClient(t)
+	createEnvTestApp(t, ctx, ec, "myapp", []core_v1alpha.Variable{{Key: "BASE", Value: "1", Source: "config"}})
+
+	// Resolve the base config at the current app revision, as SetEnvVars does.
+	appVer, spec, appRec, appRev, err := resolveBaseVersion(ctx, ec, "myapp", nil)
+	require.NoError(t, err)
+
+	// A competing writer swings active_version in the meantime (e.g. a parallel
+	// env set, or the addon controller injecting DATABASE_URL).
+	_, err = SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "COMPETITOR", Value: "c"}}, "")
+	require.NoError(t, err)
+
+	// Our write, built from the now-stale revision, must be rejected.
+	require.NoError(t, mergeIntoSpec(spec, []EnvVarInput{{Key: "MINE", Value: "m"}}, ""))
+	_, err = createNewVersion(ctx, ec, "myapp", appVer, spec, appRec, appRev)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, cond.ErrConflict{}), "stale write must conflict, got %v", err)
+
+	// The competitor's var survives; the clobbering write did not land.
+	vars := activeEnvVars(t, ctx, ec, "myapp")
+	require.Equal(t, "c", vars["COMPETITOR"], "competing writer's var must survive")
+	require.NotContains(t, vars, "MINE", "clobbering write must not have activated")
+}
+
+// TestSetEnvVarsComposesSequentially confirms the retry-loop refactor preserves
+// the normal accumulate-across-calls behavior.
+func TestSetEnvVarsComposesSequentially(t *testing.T) {
+	ctx, ec := newEnvTestClient(t)
+	createEnvTestApp(t, ctx, ec, "myapp", []core_v1alpha.Variable{{Key: "BASE", Value: "1", Source: "config"}})
+
+	_, err := SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "FOO", Value: "a"}}, "")
+	require.NoError(t, err)
+	_, err = SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "BAR", Value: "b"}}, "")
+	require.NoError(t, err)
+
+	vars := activeEnvVars(t, ctx, ec, "myapp")
+	require.Equal(t, "1", vars["BASE"])
+	require.Equal(t, "a", vars["FOO"])
+	require.Equal(t, "b", vars["BAR"])
+}
+
+// TestDeleteEnvVarsComposesSequentially confirms the DeleteEnvVars retry-loop
+// refactor still removes the requested key and preserves the rest.
+func TestDeleteEnvVarsComposesSequentially(t *testing.T) {
+	ctx, ec := newEnvTestClient(t)
+	createEnvTestApp(t, ctx, ec, "myapp", []core_v1alpha.Variable{{Key: "BASE", Value: "1", Source: "config"}})
+
+	_, err := SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "FOO", Value: "a"}}, "")
+	require.NoError(t, err)
+
+	res, err := DeleteEnvVars(ctx, ec, "myapp", nil, []string{"FOO"}, "")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	vars := activeEnvVars(t, ctx, ec, "myapp")
+	require.Equal(t, "1", vars["BASE"])
+	require.NotContains(t, vars, "FOO")
+}

--- a/api/app/envvar_test.go
+++ b/api/app/envvar_test.go
@@ -3,10 +3,7 @@ package app
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
-	"strconv"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,6 +12,7 @@ import (
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 )
 
@@ -103,40 +101,50 @@ func TestSetEnvVarsComposesSequentially(t *testing.T) {
 	require.Equal(t, "b", vars["BAR"])
 }
 
-// TestSetEnvVarsConcurrentComposeAll drives the retry loop through real mid-flight
-// conflicts: several writers set distinct keys on the same app at once. With the
-// OCC retry each loser re-reads the winner's active version and composes onto it,
-// so every key must survive. Without the CAS+retry (the old unconditional Put),
-// concurrent writers each start from the base version and the last write wins,
-// dropping the rest.
-func TestSetEnvVarsConcurrentComposeAll(t *testing.T) {
+// TestSetEnvVarsRetriesAndRecoversOnConflict deterministically drives the retry
+// loop through a mid-flight conflict: a competing writer swings active_version
+// after our base version is resolved but before our CAS, via the test hook. The
+// first Patch must lose, the loop must re-resolve the winner's version and compose
+// onto it, and both vars must survive. Without the CAS+retry the competing swing
+// would be silently clobbered.
+func TestSetEnvVarsRetriesAndRecoversOnConflict(t *testing.T) {
 	ctx, ec := newEnvTestClient(t)
 	createEnvTestApp(t, ctx, ec, "myapp", []core_v1alpha.Variable{{Key: "BASE", Value: "1", Source: "config"}})
 
-	const n = 8
-	var wg sync.WaitGroup
-	errs := make([]error, n)
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			_, errs[i] = SetEnvVars(ctx, ec, "myapp", nil,
-				[]EnvVarInput{{Key: fmt.Sprintf("K%d", i), Value: strconv.Itoa(i)}}, "")
-		}(i)
+	testHookAfterResolve = func() {
+		// Fire exactly once: clear the hook first so the competing write below
+		// doesn't re-enter it, and so our own retry doesn't re-trigger it.
+		testHookAfterResolve = nil
+		// Competing writer wins the active-version swing while we are mid-flight,
+		// bumping the app revision under us so our Patch conflicts.
+		_, err := SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "COMPETITOR", Value: "c"}}, "")
+		require.NoError(t, err)
 	}
-	wg.Wait()
+	t.Cleanup(func() { testHookAfterResolve = nil })
 
-	for i, err := range errs {
-		require.NoError(t, err, "concurrent SetEnvVars %d failed", i)
-	}
+	_, err := SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "MINE", Value: "m"}}, "")
+	require.NoError(t, err)
 
 	vars := activeEnvVars(t, ctx, ec, "myapp")
 	require.Equal(t, "1", vars["BASE"], "base config var must survive")
-	for i := 0; i < n; i++ {
-		key := fmt.Sprintf("K%d", i)
-		require.Equal(t, strconv.Itoa(i), vars[key],
-			"concurrent writer %d's var must be present (would be clobbered without OCC retry)", i)
+	require.Equal(t, "c", vars["COMPETITOR"], "competing writer's var must survive the retry")
+	require.Equal(t, "m", vars["MINE"], "our var must be present after the retry")
+
+	// The version pair minted on the losing first attempt must have been cleaned
+	// up, not left to accumulate: base + competitor + final = 3 AppVersions.
+	require.Equal(t, 3, countAppVersions(t, ctx, ec), "the superseded version from the lost CAS race must be cleaned up")
+}
+
+// countAppVersions returns the number of AppVersion entities in the store.
+func countAppVersions(t *testing.T, ctx context.Context, ec *entityserver.Client) int {
+	t.Helper()
+	res, err := ec.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion))
+	require.NoError(t, err)
+	n := 0
+	for res.Next() {
+		n++
 	}
+	return n
 }
 
 // TestDeleteEnvVarsComposesSequentially confirms the DeleteEnvVars retry-loop

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -271,167 +271,189 @@ func (r *AppInfo) List(ctx context.Context, state *app_v1alpha.CrudList) error {
 func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudSetConfiguration) error {
 	name := state.Args().App()
 
-	var appRec core_v1alpha.App
-
-	err := r.EC.Get(ctx, name, &appRec)
-	if err != nil {
-		if errors.Is(err, cond.ErrNotFound{}) {
-			// No app, no problem.
-			return nil
-		}
-
-		return err
-	}
-
-	var appVer core_v1alpha.AppVersion
-	var spec core_v1alpha.ConfigSpec
-
-	if appRec.ActiveVersion != "" {
-		err = r.EC.GetById(ctx, appRec.ActiveVersion, &appVer)
+	// The read-merge-write below is retried under optimistic concurrency
+	// control: the active_version swing is guarded by a CAS on the app revision,
+	// so a concurrent writer (another SetConfiguration, an env mutation, or the
+	// addon controller injecting addon vars) that swings active_version first is
+	// detected and re-merged instead of silently clobbered.
+	//
+	// maxAttempts is a live-lock backstop, not an expected limit: there are only
+	// ever a handful of concurrent config writers per app, so it is set high
+	// enough that genuine contention never spuriously fails, while still
+	// guaranteeing termination rather than looping forever.
+	const maxAttempts = 100
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		appEnt, err := r.EC.EAC().Get(ctx, "app/"+name)
 		if err != nil {
+			if errors.Is(err, cond.ErrNotFound{}) {
+				// No app, no problem.
+				return nil
+			}
+
 			return err
 		}
-		resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
-		if err != nil {
-			return fmt.Errorf("failed to resolve config: %w", err)
-		}
-		spec = *resolvedCfg
-	} else {
-		appVer.App = appRec.ID
-	}
 
-	cfg := state.Args().Configuration()
+		var appRec core_v1alpha.App
+		appRec.Decode(appEnt.Entity().Entity())
+		appRev := appEnt.Entity().Revision()
 
-	if cfg.HasEnvVars() {
-		for _, nv := range cfg.EnvVars() {
-			if strings.HasPrefix(nv.Key(), "MIREN_") {
-				return fmt.Errorf("cannot set MIREN_ environment variables")
+		var appVer core_v1alpha.AppVersion
+		var spec core_v1alpha.ConfigSpec
+
+		if appRec.ActiveVersion != "" {
+			if err := r.EC.GetById(ctx, appRec.ActiveVersion, &appVer); err != nil {
+				return err
 			}
-		}
-	}
-
-	// Set commands directly on services
-	for _, s := range cfg.Commands() {
-		found := false
-		for i := range spec.Services {
-			if spec.Services[i].Name == s.Service() {
-				spec.Services[i].Command = s.Command()
-				found = true
-				break
+			resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
+			if err != nil {
+				return fmt.Errorf("failed to resolve config: %w", err)
 			}
+			spec = *resolvedCfg
+		} else {
+			appVer.App = appRec.ID
 		}
-		if !found {
-			spec.Services = append(spec.Services, core_v1alpha.ConfigSpecServices{
-				Name:    s.Service(),
-				Command: s.Command(),
-			})
-		}
-	}
 
-	// Replace the entire env var list with the new one from the client
-	// The client is responsible for sending the complete desired state
-	if cfg.HasEnvVars() {
-		spec.Variables = nil
-		for _, ev := range cfg.EnvVars() {
-			source := ev.Source()
-			nv := core_v1alpha.ConfigSpecVariables{
-				Key:         ev.Key(),
-				Value:       ev.Value(),
-				Sensitive:   ev.Sensitive(),
-				Source:      source,
-				Required:    ev.Required(),
-				Description: ev.Description(),
-			}
-			spec.Variables = append(spec.Variables, nv)
-		}
-	}
+		cfg := state.Args().Configuration()
 
-	// Handle per-service env vars
-	if cfg.HasServices() {
-		for _, svcCfg := range cfg.Services() {
-			// Validate per-service env vars
-			if svcCfg.HasServiceEnv() {
-				for _, nv := range svcCfg.ServiceEnv() {
-					if strings.HasPrefix(nv.Key(), "MIREN_") {
-						return fmt.Errorf("cannot set MIREN_ environment variables")
-					}
+		if cfg.HasEnvVars() {
+			for _, nv := range cfg.EnvVars() {
+				if strings.HasPrefix(nv.Key(), "MIREN_") {
+					return fmt.Errorf("cannot set MIREN_ environment variables")
 				}
 			}
+		}
 
-			// Find or create the service in spec.Services
-			var found bool
+		// Set commands directly on services
+		for _, s := range cfg.Commands() {
+			found := false
 			for i := range spec.Services {
-				if spec.Services[i].Name == svcCfg.Service() {
-					spec.Services[i].Env = nil
-					if svcCfg.HasServiceEnv() {
-						for _, ev := range svcCfg.ServiceEnv() {
-							source := ev.Source()
-							nv := core_v1alpha.ConfigSpecServicesEnv{
-								Key:         ev.Key(),
-								Value:       ev.Value(),
-								Sensitive:   ev.Sensitive(),
-								Source:      source,
-								Required:    ev.Required(),
-								Description: ev.Description(),
-							}
-							spec.Services[i].Env = append(spec.Services[i].Env, nv)
-						}
-					}
+				if spec.Services[i].Name == s.Service() {
+					spec.Services[i].Command = s.Command()
 					found = true
 					break
 				}
 			}
-
-			if !found && svcCfg.HasServiceEnv() {
-				svc := core_v1alpha.ConfigSpecServices{
-					Name: svcCfg.Service(),
-				}
-				for _, ev := range svcCfg.ServiceEnv() {
-					source := ev.Source()
-					nv := core_v1alpha.ConfigSpecServicesEnv{
-						Key:         ev.Key(),
-						Value:       ev.Value(),
-						Sensitive:   ev.Sensitive(),
-						Source:      source,
-						Required:    ev.Required(),
-						Description: ev.Description(),
-					}
-					svc.Env = append(svc.Env, nv)
-				}
-				spec.Services = append(spec.Services, svc)
+			if !found {
+				spec.Services = append(spec.Services, core_v1alpha.ConfigSpecServices{
+					Name:    s.Service(),
+					Command: s.Command(),
+				})
 			}
 		}
+
+		// Replace the entire env var list with the new one from the client
+		// The client is responsible for sending the complete desired state
+		if cfg.HasEnvVars() {
+			spec.Variables = nil
+			for _, ev := range cfg.EnvVars() {
+				source := ev.Source()
+				nv := core_v1alpha.ConfigSpecVariables{
+					Key:         ev.Key(),
+					Value:       ev.Value(),
+					Sensitive:   ev.Sensitive(),
+					Source:      source,
+					Required:    ev.Required(),
+					Description: ev.Description(),
+				}
+				spec.Variables = append(spec.Variables, nv)
+			}
+		}
+
+		// Handle per-service env vars
+		if cfg.HasServices() {
+			for _, svcCfg := range cfg.Services() {
+				// Validate per-service env vars
+				if svcCfg.HasServiceEnv() {
+					for _, nv := range svcCfg.ServiceEnv() {
+						if strings.HasPrefix(nv.Key(), "MIREN_") {
+							return fmt.Errorf("cannot set MIREN_ environment variables")
+						}
+					}
+				}
+
+				// Find or create the service in spec.Services
+				var found bool
+				for i := range spec.Services {
+					if spec.Services[i].Name == svcCfg.Service() {
+						spec.Services[i].Env = nil
+						if svcCfg.HasServiceEnv() {
+							for _, ev := range svcCfg.ServiceEnv() {
+								source := ev.Source()
+								nv := core_v1alpha.ConfigSpecServicesEnv{
+									Key:         ev.Key(),
+									Value:       ev.Value(),
+									Sensitive:   ev.Sensitive(),
+									Source:      source,
+									Required:    ev.Required(),
+									Description: ev.Description(),
+								}
+								spec.Services[i].Env = append(spec.Services[i].Env, nv)
+							}
+						}
+						found = true
+						break
+					}
+				}
+
+				if !found && svcCfg.HasServiceEnv() {
+					svc := core_v1alpha.ConfigSpecServices{
+						Name: svcCfg.Service(),
+					}
+					for _, ev := range svcCfg.ServiceEnv() {
+						source := ev.Source()
+						nv := core_v1alpha.ConfigSpecServicesEnv{
+							Key:         ev.Key(),
+							Value:       ev.Value(),
+							Sensitive:   ev.Sensitive(),
+							Source:      source,
+							Required:    ev.Required(),
+							Description: ev.Description(),
+						}
+						svc.Env = append(svc.Env, nv)
+					}
+					spec.Services = append(spec.Services, svc)
+				}
+			}
+		}
+
+		spec.Entrypoint = cfg.Entrypoint()
+
+		appVer.Version = name + "-" + idgen.Gen("v")
+
+		// Create ConfigVersion as the sole config store
+		cvid, err := r.createConfigVersion(ctx, &spec, appVer.App, appVer.Version)
+		if err != nil {
+			return fmt.Errorf("error creating config version: %w", err)
+		}
+		appVer.ConfigVersion = cvid
+		appVer.Config = core_v1alpha.Config{}
+
+		avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
+		if err != nil {
+			return err
+		}
+
+		// Swing active_version under OCC. A conflict means another writer got
+		// there first, so re-read and re-merge on the next iteration.
+		err = r.EC.Patch(ctx, appRec.ID, appRev,
+			entity.Ref(core_v1alpha.AppActiveVersionId, avid),
+		)
+		if err != nil {
+			if errors.Is(err, cond.ErrConflict{}) {
+				continue
+			}
+			return fmt.Errorf("error updating app entity: %w", err)
+		}
+
+		state.Results().SetVersionId(appVer.Version)
+		if sid := r.versionShortId(ctx, string(avid)); sid != "" {
+			state.Results().SetVersionShortId(sid)
+		}
+
+		return nil
 	}
 
-	spec.Entrypoint = cfg.Entrypoint()
-
-	appVer.Version = name + "-" + idgen.Gen("v")
-
-	// Create ConfigVersion as the sole config store
-	cvid, err := r.createConfigVersion(ctx, &spec, appVer.App, appVer.Version)
-	if err != nil {
-		return fmt.Errorf("error creating config version: %w", err)
-	}
-	appVer.ConfigVersion = cvid
-	appVer.Config = core_v1alpha.Config{}
-
-	avid, err := r.EC.Create(ctx, appVer.Version, &appVer)
-	if err != nil {
-		return err
-	}
-
-	appRec.ActiveVersion = avid
-	err = r.EC.Update(ctx, &appRec)
-	if err != nil {
-		return fmt.Errorf("error updating app entity: %w", err)
-	}
-
-	state.Results().SetVersionId(appVer.Version)
-	if sid := r.versionShortId(ctx, string(avid)); sid != "" {
-		state.Results().SetVersionShortId(sid)
-	}
-
-	return nil
+	return fmt.Errorf("failed to set configuration on app %q after %d attempts due to concurrent writes", name, maxAttempts)
 }
 
 func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudGetConfiguration) error {

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -441,14 +441,14 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 		if err != nil {
 			if errors.Is(err, cond.ErrConflict{}) {
 				// This attempt lost the race, so the version pair we just minted
-				// was never activated. Best-effort delete it (AppVersion first,
-				// so it never dangles past its ConfigVersion) rather than leaving
-				// one pair per retry for the version GC to reap later.
+				// was never activated. Best-effort delete it, AppVersion first:
+				// only drop the ConfigVersion once its AppVersion is gone, so a
+				// failed delete leaves a coherent pair for the version GC to reap
+				// rather than an AppVersion dangling at a missing ConfigVersion.
 				if delErr := r.EC.Delete(ctx, avid); delErr != nil {
 					r.Log.Warn("failed to delete superseded app version after conflict",
 						"app", appRec.ID, "version", avid, "error", delErr)
-				}
-				if delErr := r.EC.Delete(ctx, cvid); delErr != nil {
+				} else if delErr := r.EC.Delete(ctx, cvid); delErr != nil {
 					r.Log.Warn("failed to delete superseded config version after conflict",
 						"app", appRec.ID, "config_version", cvid, "error", delErr)
 				}

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -440,6 +440,18 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 		)
 		if err != nil {
 			if errors.Is(err, cond.ErrConflict{}) {
+				// This attempt lost the race, so the version pair we just minted
+				// was never activated. Best-effort delete it (AppVersion first,
+				// so it never dangles past its ConfigVersion) rather than leaving
+				// one pair per retry for the version GC to reap later.
+				if delErr := r.EC.Delete(ctx, avid); delErr != nil {
+					r.Log.Warn("failed to delete superseded app version after conflict",
+						"app", appRec.ID, "version", avid, "error", delErr)
+				}
+				if delErr := r.EC.Delete(ctx, cvid); delErr != nil {
+					r.Log.Warn("failed to delete superseded config version after conflict",
+						"app", appRec.ID, "config_version", cvid, "error", delErr)
+				}
 				continue
 			}
 			return fmt.Errorf("error updating app entity: %w", err)


### PR DESCRIPTION
The addon controller wasn't the only place swinging an app's `active_version` with an unguarded read-modify-write. While hunting for siblings of the MIR-1458 clobber, two more turned up with the exact same shape: the env-var mutation paths `SetEnvVars`/`DeleteEnvVars` (`api/app/envvar.go`) and `SetConfiguration` (`servers/app/app.go`). Each reads the app plus its active config, merges the change into a freshly minted version, then writes the app record back with an unconditional `Put`. Two writers that started from the same active version, whether two parallel env writes or one env write racing the addon controller injecting `DATABASE_URL`, each mint a version and the second `Put` clobbers the first, silently dropping a whole version.

The fix is the same one we applied to the addon controller, and it was already sitting right next door: `SetInitialEnvVars` in the same file guards its app write with `Replace`+revision+retry and a comment describing this precise race. The active-version path just never got the treatment. Now we capture the app revision when the base config is resolved and swing `active_version` with a CAS `Patch` guarded on that revision, retrying the whole read-merge-write on conflict so the retry composes onto the winner's version instead of overwriting it.

A deterministic regression test (`TestCreateNewVersionCASGuardsActiveVersion`) reproduces the clobber: it resolves a base version, lets a competing writer swing `active_version`, then asserts the stale write is rejected with a conflict and the competitor's var survives. It's verified to fail against the pre-fix unconditional `Put`.

This is stacked on #954 and depends on the `MockStore` OCC-parity change from it, which is what lets the conflict surface in the mock-backed test. The retry cap is a high live-lock backstop (100), not a real limit, matching the addon fix.

The sweep also turned up a few lower-severity spots (the deployment launcher's `Replace(..., 0)` calls, the sandboxpool crash counter) that were ruled out because they recompute deterministically or hold only self-healing telemetry, so no genuine data is lost there.