### PR TITLE
Make addon credential-rotation admission atomic

### DIFF
--- a/api/entityserver/client.go
+++ b/api/entityserver/client.go
@@ -77,6 +77,18 @@ func (c *Client) GetByIdWithEntity(ctx context.Context, id entity.Id, sc SchemaE
 	return ret.Entity(), nil
 }
 
+// GetWithEntity is like Get but also returns the raw entity so callers can read
+// its revision for a revision-guarded (optimistic-concurrency) Patch.
+func (c *Client) GetWithEntity(ctx context.Context, name string, sc SchemaEncoder) (*entityserver_v1alpha.Entity, error) {
+	ret, err := c.eac.Get(ctx, sc.ShortKind()+"/"+name)
+	if err != nil {
+		return nil, err
+	}
+
+	sc.Decode(ret.Entity().Entity())
+	return ret.Entity(), nil
+}
+
 type ListResults struct {
 	values []*entity.Entity
 	cur    *entity.Entity

--- a/servers/app/addons.go
+++ b/servers/app/addons.go
@@ -2,14 +2,17 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"miren.dev/runtime/api/addon/addon_v1alpha"
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/idgen"
 )
@@ -246,33 +249,16 @@ func (s *AddonsServer) RotateCredential(ctx context.Context, state *app_v1alpha.
 			return fmt.Errorf("addon %q is not active (status %q); cannot rotate", addonName, assoc.Status)
 		}
 
-		// Mutex: refuse to start a rotation while another is still in flight for
-		// this association, so two rotations can't race the same backing
-		// credential (and its consumer redeploy).
-		reqs, err := s.ec.List(ctx, entity.Ref(addon_v1alpha.RotationRequestAssociationId, assoc.ID))
+		// Admit at most one in-flight rotation per association. The gate is a
+		// single rotation_request entity whose name is derived from the
+		// association, so the store's put-if-absent Create and revision-guarded
+		// Patch are the atomic admission primitives — no list-then-create TOCTOU
+		// where two near-simultaneous rotations both slip through. A terminal
+		// (done/error) request is reclaimed in place for the next rotation rather
+		// than left to block it.
+		id, err := s.admitRotation(ctx, assoc, appName, addonName, credential)
 		if err != nil {
-			return fmt.Errorf("listing rotation requests: %w", err)
-		}
-		for reqs.Next() {
-			var existing addon_v1alpha.RotationRequest
-			if err := reqs.Read(&existing); err != nil {
-				return fmt.Errorf("reading rotation request: %w", err)
-			}
-			if existing.Status == "pending" || existing.Status == "rotating" {
-				return fmt.Errorf("a rotation is already in progress for addon %q on app %q (request %s)", addonName, appName, existing.ID)
-			}
-		}
-
-		req := &addon_v1alpha.RotationRequest{
-			Association: assoc.ID,
-			Addon:       assoc.Addon,
-			Credential:  credential,
-			Status:      "pending",
-		}
-		reqName := fmt.Sprintf("rotate-%s-%s", addonName, idgen.Gen("rr"))
-		id, err := s.ec.Create(ctx, reqName, req)
-		if err != nil {
-			return fmt.Errorf("creating rotation request: %w", err)
+			return err
 		}
 
 		s.log.Info("addon credential rotation requested",
@@ -282,4 +268,70 @@ func (s *AddonsServer) RotateCredential(ctx context.Context, state *app_v1alpha.
 	}
 
 	return fmt.Errorf("addon %q is not attached to app %q", addonName, appName)
+}
+
+// admitRotation atomically admits a single in-flight rotation per association
+// and returns the rotation_request id for the controller to reconcile. The
+// request name is derived from the association, so the store's put-if-absent
+// Create is the admission gate: concurrent callers cannot both create it. A
+// prior terminal (done/error) request is reclaimed in place with a
+// revision-guarded Patch (compare-and-swap on the read revision), so sequential
+// rotations work without a leftover request blocking them and without a
+// delete/recreate race.
+func (s *AddonsServer) admitRotation(ctx context.Context, assoc addon_v1alpha.AddonAssociation, appName, addonName, credential string) (entity.Id, error) {
+	// The association id carries a "kind/" prefix; flatten it so the request
+	// name (and the id derived from it) stays a single clean segment. The
+	// association id alone makes the name unique per association; the addon name
+	// is included only so the request reads clearly in logs and CLI output.
+	reqName := fmt.Sprintf("rotate-%s-%s", addonName, strings.ReplaceAll(string(assoc.ID), "/", "-"))
+
+	var existing addon_v1alpha.RotationRequest
+	existingE, err := s.ec.GetWithEntity(ctx, reqName, &existing)
+	if err != nil {
+		if !errors.Is(err, cond.ErrNotFound{}) {
+			return "", fmt.Errorf("checking for in-flight rotation: %w", err)
+		}
+
+		// No request yet — create one. Create is put-if-absent on the derived
+		// name, so a racing admission fails here and is reported as in-flight
+		// after the re-read below.
+		id, cerr := s.ec.Create(ctx, reqName, &addon_v1alpha.RotationRequest{
+			Association: assoc.ID,
+			Addon:       assoc.Addon,
+			Credential:  credential,
+			Status:      "pending",
+		})
+		if cerr == nil {
+			return id, nil
+		}
+
+		// The create lost a race (or a terminal request already holds the name).
+		// Re-read and fall through to the shared handling below.
+		existingE, err = s.ec.GetWithEntity(ctx, reqName, &existing)
+		if err != nil {
+			return "", fmt.Errorf("creating rotation request: %w", cerr)
+		}
+	}
+
+	if existing.Status == "pending" || existing.Status == "rotating" {
+		return "", fmt.Errorf("a rotation is already in progress for addon %q on app %q (request %s)", addonName, appName, existing.ID)
+	}
+
+	// Terminal request holds the name: reclaim it for this rotation with a
+	// revision-guarded Patch. If another admission reclaimed it first, the CAS
+	// fails with a conflict and we surface the now-in-flight rotation.
+	if err := s.ec.Patch(ctx, existing.ID, existingE.Revision(),
+		entity.String(addon_v1alpha.RotationRequestCredentialId, credential),
+		entity.Ref(addon_v1alpha.RotationRequestAddonId, assoc.Addon),
+		entity.String(addon_v1alpha.RotationRequestStatusId, "pending"),
+		entity.String(addon_v1alpha.RotationRequestNewSecretId, ""),
+		entity.String(addon_v1alpha.RotationRequestErrorMessageId, ""),
+	); err != nil {
+		if errors.Is(err, cond.ErrConflict{}) {
+			return "", fmt.Errorf("a rotation was just started for addon %q on app %q; try again", addonName, appName)
+		}
+		return "", fmt.Errorf("reclaiming rotation request: %w", err)
+	}
+
+	return existing.ID, nil
 }

--- a/servers/app/addons_integration_test.go
+++ b/servers/app/addons_integration_test.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/api/app/app_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+// setupAddonsTestEtcd wires the AddonsServer over a real etcd-backed entity
+// store, which (unlike the mock) enforces ident-unique Create and
+// revision-guarded Patch — the two primitives the admission gate relies on.
+// Requires the dev environment's etcd; skip in -short.
+func setupAddonsTestEtcd(t *testing.T) (context.Context, *app_v1alpha.AddonsClient, *entityserver.Client) {
+	t.Helper()
+
+	ctx := context.Background()
+	etcd, cleanup := testutils.NewEtcdEntityServer(t)
+	t.Cleanup(cleanup)
+
+	ec := entityserver.NewClient(slog.Default(), etcd.EAC)
+	return ctx, newAddonsClient(t, ctx, ec), ec
+}
+
+// TestRotateCredentialConcurrentAdmissionEtcd is the real-store proof that the
+// admission gate is atomic. Many RotateCredential calls firing at once on one
+// association must yield exactly one rotation_request; the rest are rejected.
+// This is the race the old list-then-create check let slip through, and the
+// mock store can't verify it (it enforces neither ident-unique Create nor the
+// revision guard), so it runs against real etcd.
+func TestRotateCredentialConcurrentAdmissionEtcd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, client, ec := setupAddonsTestEtcd(t)
+
+	_, err := ec.Create(ctx, "myapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+	assocID := createActiveAddon(t, ctx, client, ec, "myapp")
+
+	const n = 8
+	var wg sync.WaitGroup
+	ids := make([]string, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release all goroutines together to maximize contention
+			res, err := client.RotateCredential(ctx, "myapp", "miren-postgresql", "app")
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			ids[i] = res.Id()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	var admitted, rejected int
+	var admittedID string
+	for i := 0; i < n; i++ {
+		if errs[i] == nil {
+			admitted++
+			admittedID = ids[i]
+		} else {
+			rejected++
+			assert.Contains(t, errs[i].Error(), "rotation", "rejection should mention the rotation")
+		}
+	}
+
+	assert.Equal(t, 1, admitted, "exactly one rotation should be admitted")
+	assert.Equal(t, n-1, rejected, "every other caller should be rejected")
+	assert.NotEmpty(t, admittedID)
+	assert.Equal(t, 1, countRotationRequests(t, ctx, ec, assocID), "only one rotation_request should exist")
+}
+
+// TestRotateCredentialReclaimAfterDoneEtcd verifies the terminal->pending
+// reclaim against real optimistic concurrency: the handler reads the request's
+// revision and Patches at it, so a wrong or stale revision would be rejected by
+// etcd. The mock can't catch that (it ignores the revision guard), so this
+// confirms the CAS path passes the correct revision on a real store.
+func TestRotateCredentialReclaimAfterDoneEtcd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx, client, ec := setupAddonsTestEtcd(t)
+
+	_, err := ec.Create(ctx, "myapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+	assocID := createActiveAddon(t, ctx, client, ec, "myapp")
+
+	res1, err := client.RotateCredential(ctx, "myapp", "miren-postgresql", "app")
+	require.NoError(t, err)
+	reqID := entity.Id(res1.Id())
+
+	// Simulate the controller finishing, with a leftover secret to prove reclaim
+	// clears it.
+	require.NoError(t, ec.Patch(ctx, reqID, 0,
+		entity.String(addon_v1alpha.RotationRequestStatusId, "done"),
+		entity.String(addon_v1alpha.RotationRequestNewSecretId, "leftover")))
+
+	res2, err := client.RotateCredential(ctx, "myapp", "miren-postgresql", "root")
+	require.NoError(t, err)
+	assert.Equal(t, reqID, entity.Id(res2.Id()), "terminal request should be reclaimed in place")
+
+	var req addon_v1alpha.RotationRequest
+	require.NoError(t, ec.GetById(ctx, reqID, &req))
+	assert.Equal(t, "pending", req.Status)
+	assert.Equal(t, "root", req.Credential)
+	assert.Empty(t, req.NewSecret)
+	assert.Equal(t, 1, countRotationRequests(t, ctx, ec, assocID))
+}

--- a/servers/app/addons_test.go
+++ b/servers/app/addons_test.go
@@ -46,6 +46,15 @@ func setupAddonsTest(t *testing.T) (context.Context, *app_v1alpha.AddonsClient, 
 
 	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
 
+	return ctx, newAddonsClient(t, ctx, ec), ec
+}
+
+// newAddonsClient wires an AddonsServer (with a single registered mock provider)
+// over the given entity client. Shared by the mock-backed unit tests and the
+// etcd-backed concurrency test so both exercise the same handler.
+func newAddonsClient(t *testing.T, ctx context.Context, ec *entityserver.Client) *app_v1alpha.AddonsClient {
+	t.Helper()
+
 	registry := addon.NewRegistry()
 	registry.Register("miren-postgresql", &mockProvider{}, addon.AddonDefinition{
 		Name:           "miren-postgresql",
@@ -62,11 +71,9 @@ func setupAddonsTest(t *testing.T) (context.Context, *app_v1alpha.AddonsClient, 
 
 	server := NewAddonsServer(slog.Default(), ec, registry, nil)
 
-	client := &app_v1alpha.AddonsClient{
+	return &app_v1alpha.AddonsClient{
 		Client: rpc.LocalClient(app_v1alpha.AdaptAddons(server)),
 	}
-
-	return ctx, client, ec
 }
 
 func TestAddonsCreateInstance(t *testing.T) {
@@ -184,4 +191,136 @@ func TestAddonsDeleteInstanceNotFound(t *testing.T) {
 	_, err = client.DeleteInstance(ctx, "myapp", "miren-postgresql")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not attached")
+}
+
+// createActiveAddon attaches an addon and promotes the association to "active"
+// so RotateCredential will admit it. The provisioning controller that would
+// normally flip the status isn't running in these unit tests.
+func createActiveAddon(t *testing.T, ctx context.Context, client *app_v1alpha.AddonsClient, ec *entityserver.Client, appName string) entity.Id {
+	t.Helper()
+
+	res, err := client.CreateInstance(ctx, "test", "miren-postgresql", "small", appName, "")
+	require.NoError(t, err)
+
+	assocID := entity.Id(res.Id())
+	require.NoError(t, ec.Patch(ctx, assocID, 0,
+		entity.String(addon_v1alpha.AddonAssociationStatusId, "active")))
+	return assocID
+}
+
+// countRotationRequests returns how many rotation_request entities exist for the
+// association — the singleton gate should keep this at exactly one.
+func countRotationRequests(t *testing.T, ctx context.Context, ec *entityserver.Client, assocID entity.Id) int {
+	t.Helper()
+
+	reqs, err := ec.List(ctx, entity.Ref(addon_v1alpha.RotationRequestAssociationId, assocID))
+	require.NoError(t, err)
+
+	count := 0
+	for reqs.Next() {
+		count++
+	}
+	return count
+}
+
+func TestRotateCredentialAdmitsFirstRotation(t *testing.T) {
+	ctx, client, ec := setupAddonsTest(t)
+
+	_, err := ec.Create(ctx, "myapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+	assocID := createActiveAddon(t, ctx, client, ec, "myapp")
+
+	res, err := client.RotateCredential(ctx, "myapp", "miren-postgresql", "app")
+	require.NoError(t, err)
+	require.NotEmpty(t, res.Id())
+
+	var req addon_v1alpha.RotationRequest
+	require.NoError(t, ec.GetById(ctx, entity.Id(res.Id()), &req))
+	assert.Equal(t, "pending", req.Status)
+	assert.Equal(t, "app", req.Credential)
+	assert.Equal(t, assocID, req.Association)
+	assert.Equal(t, 1, countRotationRequests(t, ctx, ec, assocID))
+}
+
+func TestRotateCredentialRejectsWhileInFlight(t *testing.T) {
+	ctx, client, ec := setupAddonsTest(t)
+
+	_, err := ec.Create(ctx, "myapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+	assocID := createActiveAddon(t, ctx, client, ec, "myapp")
+
+	res, err := client.RotateCredential(ctx, "myapp", "miren-postgresql", "app")
+	require.NoError(t, err)
+	reqID := entity.Id(res.Id())
+
+	// A "pending" request already holds the association's slot.
+	_, err = client.RotateCredential(ctx, "myapp", "miren-postgresql", "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already in progress")
+
+	// The controller moves it to "rotating" mid-flight; still no new admission.
+	require.NoError(t, ec.Patch(ctx, reqID, 0,
+		entity.String(addon_v1alpha.RotationRequestStatusId, "rotating")))
+	_, err = client.RotateCredential(ctx, "myapp", "miren-postgresql", "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already in progress")
+
+	assert.Equal(t, 1, countRotationRequests(t, ctx, ec, assocID))
+}
+
+func TestRotateCredentialReclaimsAfterDone(t *testing.T) {
+	ctx, client, ec := setupAddonsTest(t)
+
+	_, err := ec.Create(ctx, "myapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+	assocID := createActiveAddon(t, ctx, client, ec, "myapp")
+
+	res1, err := client.RotateCredential(ctx, "myapp", "miren-postgresql", "app")
+	require.NoError(t, err)
+	reqID := entity.Id(res1.Id())
+
+	// Simulate the controller finishing, leaving a stale secret behind to prove
+	// reclaim clears it.
+	require.NoError(t, ec.Patch(ctx, reqID, 0,
+		entity.String(addon_v1alpha.RotationRequestStatusId, "done"),
+		entity.String(addon_v1alpha.RotationRequestNewSecretId, "leftover")))
+
+	res2, err := client.RotateCredential(ctx, "myapp", "miren-postgresql", "root")
+	require.NoError(t, err)
+	// Singleton per association: the terminal request is reclaimed in place.
+	assert.Equal(t, reqID, entity.Id(res2.Id()))
+
+	var req addon_v1alpha.RotationRequest
+	require.NoError(t, ec.GetById(ctx, reqID, &req))
+	assert.Equal(t, "pending", req.Status)
+	assert.Equal(t, "root", req.Credential)
+	assert.Empty(t, req.NewSecret)
+	assert.Equal(t, 1, countRotationRequests(t, ctx, ec, assocID))
+}
+
+func TestRotateCredentialReclaimsAfterError(t *testing.T) {
+	ctx, client, ec := setupAddonsTest(t)
+
+	_, err := ec.Create(ctx, "myapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+	assocID := createActiveAddon(t, ctx, client, ec, "myapp")
+
+	res1, err := client.RotateCredential(ctx, "myapp", "miren-postgresql", "app")
+	require.NoError(t, err)
+	reqID := entity.Id(res1.Id())
+
+	// A prior rotation failed terminally with a recorded message.
+	require.NoError(t, ec.Patch(ctx, reqID, 0,
+		entity.String(addon_v1alpha.RotationRequestStatusId, "error"),
+		entity.String(addon_v1alpha.RotationRequestErrorMessageId, "boom")))
+
+	res2, err := client.RotateCredential(ctx, "myapp", "miren-postgresql", "app")
+	require.NoError(t, err)
+	assert.Equal(t, reqID, entity.Id(res2.Id()))
+
+	var req addon_v1alpha.RotationRequest
+	require.NoError(t, ec.GetById(ctx, reqID, &req))
+	assert.Equal(t, "pending", req.Status)
+	assert.Empty(t, req.ErrorMessage)
+	assert.Equal(t, 1, countRotationRequests(t, ctx, ec, assocID))
 }


### PR DESCRIPTION
The `miren addon rotate` admission gate had a time-of-check/time-of-use hole. To enforce "one rotation in flight per association," the `RotateCredential` handler listed the association's existing rotation_requests, bailed if any was pending, then created a new one. Two rotations firing in the same window both see an empty list and both create, so they end up racing the same backing credential and each other's consumer redeploy. CodeRabbit flagged this on #948.

This swaps the list-then-create check for an atomic gate. Each association gets a single rotation_request whose name is derived from the association id, so the entity store's put-if-absent Create *is* the admission primitive: when two callers race, the unique-ident transaction picks exactly one winner. A prior terminal (done/error) request is reclaimed in place with a revision-guarded Patch rather than deleted and recreated, so sequential rotations keep working without a leftover request blocking them, and without a delete/create race to reason about. It's the same put-if-absent + CAS shape the runner registration path already uses.

The mock store can't prove atomicity (it enforces neither ident-unique Create nor the revision guard), so beyond the mock-based state-machine tests there's a real-etcd integration test that fires eight concurrent rotations at one association and asserts exactly one is admitted, plus a reclaim-after-done test that confirms the CAS passes the correct revision against real optimistic concurrency.

Part of MIR-1355.
