### PR TITLE
Close a Valkey rotation pool leak on mid-swap crash

### DIFF
--- a/pkg/addon/framework.go
+++ b/pkg/addon/framework.go
@@ -57,7 +57,13 @@ type CreateSandboxPoolSpec struct {
 
 // CreateSandboxPool creates a fixed-mode SandboxPool entity.
 func (fw *ProviderFramework) CreateSandboxPool(ctx context.Context, spec CreateSandboxPoolSpec) (entity.Id, error) {
-	name := idgen.GenNS("pool")
+	// A caller-supplied Name gives the pool a deterministic identity (so a retry
+	// can rediscover a pool a prior attempt created); otherwise generate a random
+	// one. The id derives from the name either way.
+	name := spec.Name
+	if name == "" {
+		name = idgen.GenNS("pool")
+	}
 	poolID := entity.Id("pool/" + name)
 
 	pool := &compute_v1alpha.SandboxPool{

--- a/pkg/addon/valkey/rotate.go
+++ b/pkg/addon/valkey/rotate.go
@@ -2,11 +2,15 @@ package valkey
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"miren.dev/runtime/api/addon/addon_v1alpha"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/saga"
 )
@@ -183,18 +187,96 @@ func rebuildPoolSpec(pool *compute_v1alpha.SandboxPool, command string) addon.Cr
 	return spec
 }
 
-func SwapValkeyPool(ctx context.Context, in SwapValkeyPoolIn) (SwapValkeyPoolOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
+// rotationPoolName derives the new pool's name deterministically from the server
+// and the pool being replaced. Because it is stable across retries, a re-run of
+// the swap rediscovers the pool a prior (possibly crashed) attempt created
+// instead of leaking it and standing up a duplicate. It is intentionally keyed
+// on non-secret ids, not the new password: the password lives in the pool's
+// launch command, and a rotation toward a different secret is told apart by
+// comparing that command when deciding whether to adopt.
+func rotationPoolName(serverID, oldPoolID entity.Id) string {
+	sum := sha256.Sum256([]byte(string(serverID) + "\x00" + string(oldPoolID)))
+	return "valkey-rot-" + hex.EncodeToString(sum[:8])
+}
 
+// poolLaunchCommand returns a pool's container launch command, or "" if it has
+// no container.
+func poolLaunchCommand(pool *compute_v1alpha.SandboxPool) string {
+	if len(pool.SandboxSpec.Container) == 0 {
+		return ""
+	}
+	return pool.SandboxSpec.Container[0].Command
+}
+
+// createRotationPool stands up the new pool at the deterministic id, cloning the
+// old pool's spec but launching with the rotated password's command. The create
+// and the preceding lookup are not atomic, so a concurrent attempt could win the
+// create; because the id is deterministic per (server, old pool) and a rotation
+// reruns with the same secret, the winner targets the same command, so a
+// conflict is treated as a successful adoption (verified defensively).
+func createRotationPool(ctx context.Context, fw *addon.ProviderFramework, oldPool *compute_v1alpha.SandboxPool, poolID entity.Id, name, command string) error {
+	spec := rebuildPoolSpec(oldPool, command)
+	spec.Name = name
+	switch _, err := fw.CreateSandboxPool(ctx, spec); {
+	case err == nil:
+		return nil
+	case errors.Is(err, cond.ErrConflict{}):
+		var raced compute_v1alpha.SandboxPool
+		if gerr := fw.EC.GetById(ctx, poolID, &raced); gerr != nil {
+			return fmt.Errorf("re-reading rotation pool after create conflict: %w", gerr)
+		}
+		if poolLaunchCommand(&raced) != command {
+			return fmt.Errorf("rotation pool %s already exists with a different launch command", poolID)
+		}
+		fw.Log.Info("adopting concurrently-created valkey pool", "pool", poolID)
+		return nil
+	default:
+		return fmt.Errorf("creating new valkey pool: %w", err)
+	}
+}
+
+func SwapValkeyPool(ctx context.Context, in SwapValkeyPoolIn) (SwapValkeyPoolOut, error) {
+	return swapValkeyPool(ctx, saga.Get[*addon.ProviderFramework](ctx), in)
+}
+
+// swapValkeyPool holds the swap logic with the framework passed explicitly, so it
+// can be driven directly in tests without a full saga executor.
+func swapValkeyPool(ctx context.Context, fw *addon.ProviderFramework, in SwapValkeyPoolIn) (SwapValkeyPoolOut, error) {
 	var oldPool compute_v1alpha.SandboxPool
 	if err := fw.EC.GetById(ctx, in.RotateOldPoolID, &oldPool); err != nil {
 		return SwapValkeyPoolOut{}, fmt.Errorf("reading old valkey pool: %w", err)
 	}
 
-	spec := rebuildPoolSpec(&oldPool, valkeyCommand(in.RotateNewPassword))
-	newPoolID, err := fw.CreateSandboxPool(ctx, spec)
-	if err != nil {
-		return SwapValkeyPoolOut{}, fmt.Errorf("creating new valkey pool: %w", err)
+	// The new pool has a deterministic id, so a swap that reruns (e.g. a crash
+	// landed between the create and the repoint) can rediscover it instead of
+	// leaking it and creating a duplicate.
+	poolName := rotationPoolName(in.RotateServerID, in.RotateOldPoolID)
+	newPoolID := entity.Id("pool/" + poolName)
+	target := valkeyCommand(in.RotateNewPassword)
+
+	var existing compute_v1alpha.SandboxPool
+	switch err := fw.EC.GetById(ctx, newPoolID, &existing); {
+	case err == nil && poolLaunchCommand(&existing) == target:
+		// A prior attempt for this same rotation already stood the pool up; adopt
+		// it rather than leaking it and creating a duplicate.
+		fw.Log.Info("adopting new valkey pool from a prior rotation attempt", "pool", newPoolID)
+	case err == nil:
+		// A pool sits at this slot but launches with a different password: an
+		// orphan from an earlier rotation that crashed and was abandoned. Tear it
+		// down and rebuild the slot for the current secret.
+		fw.Log.Info("replacing stale valkey rotation pool", "pool", newPoolID)
+		if derr := fw.DeleteSandboxPool(ctx, newPoolID); derr != nil {
+			return SwapValkeyPoolOut{}, fmt.Errorf("removing stale rotation pool: %w", derr)
+		}
+		if err := createRotationPool(ctx, fw, &oldPool, newPoolID, poolName, target); err != nil {
+			return SwapValkeyPoolOut{}, err
+		}
+	case errors.Is(err, cond.ErrNotFound{}):
+		if err := createRotationPool(ctx, fw, &oldPool, newPoolID, poolName, target); err != nil {
+			return SwapValkeyPoolOut{}, err
+		}
+	default:
+		return SwapValkeyPoolOut{}, fmt.Errorf("checking for existing rotation pool: %w", err)
 	}
 
 	// Point the server at the new pool. Consumers reach valkey through the

--- a/pkg/addon/valkey/rotate_test.go
+++ b/pkg/addon/valkey/rotate_test.go
@@ -1,12 +1,19 @@
 package valkey
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/saga"
 )
 
@@ -60,4 +67,169 @@ func TestRotateDedicatedSagaOrder(t *testing.T) {
 		"must create the new pool before waiting on it")
 	assert.Less(t, indexOf("wait-valkey-pool-ready"), indexOf("delete-old-valkey-pool"),
 		"must confirm the new pool is ready before deleting the old one")
+}
+
+func newRotateTestFramework(t *testing.T) (context.Context, *addon.ProviderFramework) {
+	t.Helper()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	fw := &addon.ProviderFramework{
+		EC:  entityserver.NewClient(slog.Default(), inmem.EAC),
+		EAC: inmem.EAC,
+		Log: slog.Default(),
+	}
+	return context.Background(), fw
+}
+
+func serverPoolRef(t *testing.T, ctx context.Context, fw *addon.ProviderFramework, serverID entity.Id) entity.Id {
+	t.Helper()
+	var server addon_v1alpha.ValkeyServer
+	require.NoError(t, fw.EC.GetById(ctx, serverID, &server))
+	return server.SandboxPool
+}
+
+func poolCommand(t *testing.T, ctx context.Context, fw *addon.ProviderFramework, poolID entity.Id) string {
+	t.Helper()
+	var pool compute_v1alpha.SandboxPool
+	require.NoError(t, fw.EC.GetById(ctx, poolID, &pool))
+	require.NotEmpty(t, pool.SandboxSpec.Container)
+	return pool.SandboxSpec.Container[0].Command
+}
+
+// TestSwapValkeyPoolCreatesThenAdopts is the pool-leak regression: the first
+// swap stands up the new pool with a deterministic id, and a re-run (as would
+// happen when a crash lands between the create and the repoint) adopts that same
+// pool instead of leaking it and creating a second one.
+func TestSwapValkeyPoolCreatesThenAdopts(t *testing.T) {
+	ctx, fw := newRotateTestFramework(t)
+
+	oldPoolID, err := fw.CreateSandboxPool(ctx, addon.CreateSandboxPoolSpec{
+		DesiredInstances: 1,
+		Image:            "valkey",
+		Command:          valkeyCommand("oldpw"),
+	})
+	require.NoError(t, err)
+
+	serverID, err := fw.EC.Create(ctx, "vk", &addon_v1alpha.ValkeyServer{
+		Password:    "oldpw",
+		SandboxPool: oldPoolID,
+	})
+	require.NoError(t, err)
+
+	in := SwapValkeyPoolIn{
+		RotateServerID:    serverID,
+		RotateOldPoolID:   oldPoolID,
+		RotateNewPassword: "newpw",
+	}
+
+	// First swap: creates the new pool at its deterministic id and repoints.
+	out1, err := swapValkeyPool(ctx, fw, in)
+	require.NoError(t, err)
+	newPoolID := out1.RotateNewPoolID
+	require.NotEmpty(t, newPoolID)
+	assert.NotEqual(t, oldPoolID, newPoolID)
+	assert.Equal(t, entity.Id("pool/"+rotationPoolName(serverID, oldPoolID)), newPoolID)
+	assert.Equal(t, newPoolID, serverPoolRef(t, ctx, fw, serverID), "server should point at the new pool")
+	assert.Equal(t, valkeyCommand("newpw"), poolCommand(t, ctx, fw, newPoolID))
+
+	// Simulate a crash between create and repoint: the repoint is undone, so the
+	// server points back at the old pool while the new pool lingers.
+	require.NoError(t, fw.EC.Patch(ctx, serverID, 0,
+		entity.Ref(addon_v1alpha.ValkeyServerSandboxPoolId, oldPoolID)))
+
+	// Second swap: must adopt the lingering pool. If adoption were broken it would
+	// try to create at the same deterministic id and fail with a conflict, so a
+	// clean success returning the same id proves adoption (no duplicate leaked).
+	out2, err := swapValkeyPool(ctx, fw, in)
+	require.NoError(t, err)
+	assert.Equal(t, newPoolID, out2.RotateNewPoolID, "should adopt the existing pool, not leak a duplicate")
+	assert.Equal(t, newPoolID, serverPoolRef(t, ctx, fw, serverID), "server should be repointed at the adopted pool")
+}
+
+// TestSwapValkeyPoolReplacesStalePool covers the orphan left by an earlier
+// rotation that crashed and was abandoned: a pool sits at the deterministic slot
+// but launches with a different (older) password. A fresh rotation toward a new
+// secret must not adopt it; it tears the stale pool down and rebuilds the slot.
+func TestSwapValkeyPoolReplacesStalePool(t *testing.T) {
+	ctx, fw := newRotateTestFramework(t)
+
+	oldPoolID, err := fw.CreateSandboxPool(ctx, addon.CreateSandboxPoolSpec{
+		DesiredInstances: 1,
+		Image:            "valkey",
+		Command:          valkeyCommand("oldpw"),
+	})
+	require.NoError(t, err)
+
+	serverID, err := fw.EC.Create(ctx, "vk", &addon_v1alpha.ValkeyServer{
+		Password:    "oldpw",
+		SandboxPool: oldPoolID,
+	})
+	require.NoError(t, err)
+
+	// A prior rotation toward "stalepw" stood up the slot pool and then was
+	// abandoned, leaving it behind.
+	_, err = swapValkeyPool(ctx, fw, SwapValkeyPoolIn{
+		RotateServerID:    serverID,
+		RotateOldPoolID:   oldPoolID,
+		RotateNewPassword: "stalepw",
+	})
+	require.NoError(t, err)
+	require.NoError(t, fw.EC.Patch(ctx, serverID, 0,
+		entity.Ref(addon_v1alpha.ValkeyServerSandboxPoolId, oldPoolID)))
+
+	// A fresh rotation toward "freshpw" finds the stale pool at the same slot
+	// (same server + old pool), must reject it on the command mismatch, and
+	// rebuild the slot for the new secret.
+	out, err := swapValkeyPool(ctx, fw, SwapValkeyPoolIn{
+		RotateServerID:    serverID,
+		RotateOldPoolID:   oldPoolID,
+		RotateNewPassword: "freshpw",
+	})
+	require.NoError(t, err)
+
+	slotID := entity.Id("pool/" + rotationPoolName(serverID, oldPoolID))
+	assert.Equal(t, slotID, out.RotateNewPoolID, "should reuse the deterministic slot")
+	assert.Equal(t, valkeyCommand("freshpw"), poolCommand(t, ctx, fw, out.RotateNewPoolID),
+		"slot pool should launch with the fresh password, not the stale one")
+	assert.Equal(t, out.RotateNewPoolID, serverPoolRef(t, ctx, fw, serverID))
+}
+
+// TestCreateRotationPoolAdoptsOnConflict covers the create losing a race: if a
+// concurrent attempt already created the pool at the deterministic id, a
+// conflict is adopted when the launch command matches and refused when it does
+// not.
+func TestCreateRotationPoolAdoptsOnConflict(t *testing.T) {
+	ctx, fw := newRotateTestFramework(t)
+
+	basePoolID, err := fw.CreateSandboxPool(ctx, addon.CreateSandboxPoolSpec{
+		DesiredInstances: 1,
+		Image:            "valkey",
+		Command:          valkeyCommand("oldpw"),
+	})
+	require.NoError(t, err)
+	var basePool compute_v1alpha.SandboxPool
+	require.NoError(t, fw.EC.GetById(ctx, basePoolID, &basePool))
+
+	name := "valkey-rot-conflict"
+	poolID := entity.Id("pool/" + name)
+
+	// A concurrent attempt already stood the pool up at the deterministic id,
+	// targeting the same secret.
+	_, err = fw.CreateSandboxPool(ctx, addon.CreateSandboxPoolSpec{
+		Name:             name,
+		DesiredInstances: 1,
+		Image:            "valkey",
+		Command:          valkeyCommand("newpw"),
+	})
+	require.NoError(t, err)
+
+	// Matching command: the conflict is adopted.
+	require.NoError(t, createRotationPool(ctx, fw, &basePool, poolID, name, valkeyCommand("newpw")))
+
+	// Different command at the same id: refuse to adopt.
+	err = createRotationPool(ctx, fw, &basePool, poolID, name, valkeyCommand("different"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different launch command")
 }


### PR DESCRIPTION
Dedicated Valkey rotation re-launches the pool, because the password is baked into the launch command: scale the old pool to zero, stand up a new pool with the new password on the same single-attach disk, repoint the server at it, then delete the old pool. `SwapValkeyPool` creates the new pool and then repoints. The repoint-returns-error path already tears the new pool down inline, but a process crash landing between the create and the repoint leaves no compensation to run (a failed action's own Undo doesn't fire). The old pool stays scaled to zero, the new pool is orphaned, and a retry called `CreateSandboxPool` again, standing up a second pool and leaking the first. Narrow window on a cache addon, but a real leak.

The fix gives the new pool a deterministic identity so a retry can rediscover it. `CreateSandboxPool` now honors a caller-supplied `Name` (it was an unused field; it still generates a random name when empty), and `SwapValkeyPool` derives the new pool's name from the server and the pool it replaces, both non-secret ids (the password lives in the pool's launch command, not the name). On a rerun it adopts a pool already sitting at that slot when the launch command matches the target, and replaces it when the command differs, which also reaps an orphan left by an earlier rotation that crashed and was abandoned.

Store-backed tests drive the swap twice: once standing in for the crash-before-repoint retry, asserting it adopts the same pool rather than leaking a duplicate, and once with a stale-secret pool already at the slot, asserting it rebuilds rather than adopts.

Part of MIR-1355.
