### PR TITLE
Fix etcd plain→TLS container recreate wedging after an unclean shutdown

### DIFF
--- a/components/base/base.go
+++ b/components/base/base.go
@@ -14,6 +14,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/errdefs"
 	"golang.org/x/sys/unix"
 )
 
@@ -249,33 +250,38 @@ func (b *BaseComponent) stopTask(ctx context.Context, task containerd.Task) {
 	defer cancel()
 
 	if err := task.Kill(shutdownCtx, unix.SIGTERM); err != nil {
-		b.Log.Error("failed to send SIGTERM to "+b.ComponentName+" task", "error", err)
-		return
-	}
+		// The init process may already be gone — e.g. the previous server died
+		// uncleanly, leaving the task registered but its process dead, so SIGTERM
+		// comes back "not found". Do NOT bail here: we still have to delete the
+		// task record below, otherwise the container (and its snapshot) can't be
+		// removed and the next plain→TLS recreate wedges on "snapshot already
+		// exists". See MIR-1463.
+		b.Log.Warn("failed to send SIGTERM to "+b.ComponentName+" task, proceeding to delete", "error", err)
+	} else {
+		status, err := task.Wait(shutdownCtx)
+		if err == nil {
+			select {
+			case es := <-status:
+				b.Log.Info(b.ComponentName+" task exited", "code", es.ExitCode())
 
-	status, err := task.Wait(shutdownCtx)
-	if err == nil {
-		select {
-		case es := <-status:
-			b.Log.Info(b.ComponentName+" task exited", "code", es.ExitCode())
+			case <-shutdownCtx.Done():
+				b.Log.Warn(b.ComponentName + " task did not exit gracefully, sending SIGKILL")
+				killCtx, killCancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), b.Namespace), 10*time.Second)
+				defer killCancel()
 
-		case <-shutdownCtx.Done():
-			b.Log.Warn(b.ComponentName + " task did not exit gracefully, sending SIGKILL")
-			killCtx, killCancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), b.Namespace), 10*time.Second)
-			defer killCancel()
-
-			if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
-				b.Log.Error("failed to send SIGKILL to "+b.ComponentName+" task", "error", err)
-			} else {
-				statusCh, waitErr := task.Wait(killCtx)
-				if waitErr != nil {
-					b.Log.Error(b.ComponentName+" task wait channel after SIGKILL failed", "error", waitErr)
+				if err := task.Kill(killCtx, unix.SIGKILL); err != nil {
+					b.Log.Error("failed to send SIGKILL to "+b.ComponentName+" task", "error", err)
 				} else {
-					select {
-					case <-statusCh:
-						// Task exited
-					case <-killCtx.Done():
-						b.Log.Warn(b.ComponentName + " task did not exit after SIGKILL within timeout")
+					statusCh, waitErr := task.Wait(killCtx)
+					if waitErr != nil {
+						b.Log.Error(b.ComponentName+" task wait channel after SIGKILL failed", "error", waitErr)
+					} else {
+						select {
+						case <-statusCh:
+							// Task exited
+						case <-killCtx.Done():
+							b.Log.Warn(b.ComponentName + " task did not exit after SIGKILL within timeout")
+						}
 					}
 				}
 			}
@@ -285,7 +291,10 @@ func (b *BaseComponent) stopTask(ctx context.Context, task containerd.Task) {
 	deleteCtx, deleteCancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), b.Namespace), 10*time.Second)
 	defer deleteCancel()
 
-	if _, err := task.Delete(deleteCtx); err != nil {
+	// WithProcessKill force-kills any lingering process before removing the task
+	// record, so a task whose SIGTERM failed above is still cleaned up in one shot.
+	// A not-found task is already gone — treat that as success.
+	if _, err := task.Delete(deleteCtx, containerd.WithProcessKill); err != nil && !errdefs.IsNotFound(err) {
 		b.Log.Error("failed to delete "+b.ComponentName+" task", "error", err)
 	}
 }
@@ -295,25 +304,68 @@ func (b *BaseComponent) StopTask(ctx context.Context, task containerd.Task) {
 	b.stopTask(ctx, task)
 }
 
-// deleteContainerWithRetry deletes the container with retry logic.
+// deleteContainerAndSnapshot deletes the container and makes sure its snapshot is
+// gone. It reads the snapshotter + snapshot key first, deletes the container with
+// WithSnapshotCleanup, then explicitly removes the snapshot as a fallback so a failed
+// or partial container delete can't strand it — a stranded snapshot wedges the next
+// recreate on "snapshot already exists" (MIR-1463). A not-found container or snapshot
+// is treated as success.
+//
+// It runs on a detached, namespaced context with its own deadline (like stopTask's
+// final delete) so a cancelled caller — e.g. a shutdown — can't abort the delete or
+// the snapshot removal partway and leak the very snapshot this path exists to reclaim.
+func (b *BaseComponent) deleteContainerAndSnapshot(container containerd.Container) error {
+	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), b.Namespace), 30*time.Second)
+	defer cancel()
+
+	var snapshotterName, snapshotKey string
+	if info, err := container.Info(ctx); err == nil {
+		snapshotterName = info.Snapshotter
+		snapshotKey = info.SnapshotKey
+	}
+
+	delErr := container.Delete(ctx, containerd.WithSnapshotCleanup)
+	if errdefs.IsNotFound(delErr) {
+		delErr = nil
+	}
+
+	// Fallback: ensure the snapshot is gone regardless of how the container delete
+	// fared. Harmless if WithSnapshotCleanup already removed it (Remove tolerates a
+	// missing key), and it's the backstop that keeps a failed delete from leaking.
+	if snapshotterName != "" && snapshotKey != "" {
+		if snapshotter := b.CC.SnapshotService(snapshotterName); snapshotter != nil {
+			if err := snapshotter.Remove(ctx, snapshotKey); err != nil && !errdefs.IsNotFound(err) {
+				b.Log.Warn("failed to explicitly remove "+b.ComponentName+" snapshot", "error", err, "snapshot_key", snapshotKey)
+			}
+		}
+	}
+
+	return delErr
+}
+
+// deleteContainerWithRetry deletes the container (and its snapshot) with retry logic.
 func (b *BaseComponent) deleteContainerWithRetry(ctx context.Context, container containerd.Container) {
 	const maxRetries = 3
 	const retryDelay = 2 * time.Second
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		err := container.Delete(deleteCtx, containerd.WithSnapshotCleanup)
-		cancel()
-
+		// The delete itself runs on a detached context so it always finishes; ctx
+		// only governs whether we keep retrying, so a shutdown stops the backoff
+		// loop promptly instead of blocking on it.
+		err := b.deleteContainerAndSnapshot(container)
 		if err == nil {
 			b.Log.Info(b.ComponentName + " container deleted successfully")
 			return
 		}
-
 		b.Log.Error("failed to delete "+b.ComponentName+" container", "error", err, "attempt", attempt, "max_retries", maxRetries)
 
 		if attempt < maxRetries {
-			time.Sleep(retryDelay)
+			select {
+			case <-time.After(retryDelay):
+			case <-ctx.Done():
+				b.Log.Warn(b.ComponentName+" container delete retries cancelled", "error", ctx.Err())
+				return
+			}
 		}
 	}
 
@@ -331,17 +383,16 @@ func (b *BaseComponent) DeleteContainerWithRetry(ctx context.Context) {
 }
 
 // CleanupExistingContainer stops the task and deletes a container during restart scenarios.
+// It shares the same task-delete and snapshot-cleanup path as the graceful Stop flow, so
+// a task left registered by an unclean shutdown still gets force-deleted and its snapshot
+// removed rather than stranding both and wedging the recreate (MIR-1463).
 func (b *BaseComponent) CleanupExistingContainer(ctx context.Context, container containerd.Container) {
 	task, err := container.Task(ctx, nil)
 	if err == nil {
 		b.stopTask(ctx, task)
 	}
 
-	deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	if err := container.Delete(deleteCtx, containerd.WithSnapshotCleanup); err != nil {
-		b.Log.Warn("failed to delete existing container during cleanup", "error", err)
-	}
+	b.deleteContainerWithRetry(ctx, container)
 }
 
 // WaitForReady waits until the component is ready by checking TCP connectivity.

--- a/components/etcd/integration_test.go
+++ b/components/etcd/integration_test.go
@@ -5,17 +5,21 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"golang.org/x/sys/unix"
 	"miren.dev/runtime/components/etcd"
+	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/testutils"
 )
 
@@ -371,6 +375,157 @@ func TestEtcdComponentAutoRestart(t *testing.T) {
 	assert.Equal(t, "post-restart-value", string(resp.Kvs[0].Value), "value should match")
 
 	t.Log("Auto-restart test completed successfully!")
+}
+
+// TestEtcdRecreateAfterUncleanShutdown is the regression test for MIR-1463.
+//
+// Enabling distributed runners flips embedded etcd from plaintext to TLS, which makes
+// the component recreate its container on the next boot. If the *previous* server died
+// uncleanly, the etcd containerd task is left registered but its init process is gone.
+// The old cleanup path sent SIGTERM, got "not found", and bailed without deleting the
+// task — so the container couldn't be deleted, its snapshot leaked, and creating the new
+// container failed with "snapshot already exists", wedging the node.
+//
+// We reproduce the wedge condition directly: a leftover "miren-etcd" container that owns
+// the "miren-etcd-snapshot" snapshot, with a registered-but-dead task, plus a state file
+// from the prior boot. We force the recreate with an old config_version rather than a real
+// TLS flip — it's the same CleanupExistingContainer path (the actual site of the bug) and
+// keeps the test hermetic (no CA seeding or mTLS client needed). The assertion is that the
+// recreate succeeds and etcd comes back up serving reads and writes.
+func TestEtcdRecreateAfterUncleanShutdown(t *testing.T) {
+	testDeps, cleanup := testutils.NewTestDeps()
+	defer cleanup()
+
+	cc := testDeps.CC
+
+	tmpDir, err := os.MkdirTemp("", "etcd-recreate-test")
+	require.NoError(t, err, "failed to create temp dir")
+	defer os.RemoveAll(tmpDir)
+
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	testNamespace := fmt.Sprintf("miren-etcd-recreate-test-%d", time.Now().UnixNano())
+	ctx := namespaces.WithNamespace(context.Background(), testNamespace)
+
+	// Backstop cleanup for both the seeded and recreated containers.
+	defer cleanupContainer(t, cc, testNamespace)
+
+	// Seed the leftover container + snapshot exactly as a real plaintext boot would.
+	t.Log("Seeding leftover etcd container from a prior boot...")
+	image, err := cc.Pull(ctx, imagerefs.Etcd, containerd.WithPullUnpack)
+	if err != nil {
+		if strings.Contains(err.Error(), "permission denied") {
+			t.Skip("permission denied error, skipping test")
+		}
+		require.NoError(t, err, "failed to pull etcd image")
+	}
+
+	container, err := cc.NewContainer(ctx, "miren-etcd",
+		containerd.WithImage(image),
+		containerd.WithNewSnapshot("miren-etcd-snapshot", image),
+		containerd.WithNewSpec(
+			oci.WithImageConfig(image),
+			oci.WithProcessArgs("/usr/local/bin/etcd", "--version"),
+		),
+	)
+	require.NoError(t, err, "failed to seed leftover etcd container")
+
+	// Start a task and let it exit on its own, but deliberately never delete it. This
+	// mimics an unclean shutdown: the containerd task record survives while its init
+	// process is gone, so a later SIGTERM comes back "not found".
+	task, err := container.NewTask(ctx, cio.NullIO)
+	require.NoError(t, err, "failed to create seed task")
+	exitCh, err := task.Wait(ctx)
+	require.NoError(t, err, "failed to wait on seed task")
+	require.NoError(t, task.Start(ctx), "failed to start seed task")
+	select {
+	case <-exitCh:
+	case <-time.After(30 * time.Second):
+		t.Fatal("seed task did not exit in time")
+	}
+
+	// Confirm we actually reproduced the wedge precondition: the task is still
+	// registered, but its process is gone so it can't be signalled.
+	leftover, err := container.Task(ctx, nil)
+	require.NoError(t, err, "leftover task should still be registered after an unclean shutdown")
+	require.Error(t, leftover.Kill(ctx, unix.SIGTERM), "leftover task process should already be gone")
+
+	// Write the state file from the prior boot so Start takes the recreate path.
+	etcdDir := filepath.Join(tmpDir, "etcd")
+	require.NoError(t, os.MkdirAll(etcdDir, 0700), "failed to create etcd data dir")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(etcdDir, "etcd-state.json"),
+		[]byte(`{"tls_enabled":false,"config_version":1}`),
+		0600,
+	), "failed to write seed state file")
+
+	// Now perform the recreate that used to wedge on the leaked snapshot.
+	t.Log("Starting etcd component (should recreate cleanly, not wedge)...")
+	component := etcd.NewEtcdComponent(log, cc, testNamespace, tmpDir)
+
+	clientPort := testutils.GetFreePort(t)
+	peerPort := testutils.GetFreePort(t)
+	httpClientPort := testutils.GetFreePort(t)
+
+	config := etcd.EtcdConfig{
+		Name:           "test-etcd-recreate",
+		ClientPort:     clientPort,
+		HTTPClientPort: httpClientPort,
+		PeerPort:       peerPort,
+		InitialToken:   "recreate-test-cluster",
+		ClusterState:   "new",
+	}
+
+	defer func() {
+		if component.IsRunning() {
+			if err := component.Stop(context.Background()); err != nil {
+				t.Logf("failed to stop component: %v", err)
+			}
+		}
+	}()
+
+	err = component.Start(context.Background(), config)
+	if err != nil && strings.Contains(err.Error(), "permission denied") {
+		t.Skip("permission denied error, skipping test")
+	}
+	require.NoError(t, err, "recreate after an unclean shutdown must not wedge on a leaked snapshot")
+	require.True(t, component.IsRunning(), "component should be running after a clean recreate")
+
+	// Verify etcd actually serves after the recreate.
+	endpoint := component.ClientEndpoint()
+	var etcdClient *clientv3.Client
+	require.Eventually(t, func() bool {
+		etcdClient, err = clientv3.New(clientv3.Config{
+			Endpoints:   []string{endpoint},
+			DialTimeout: 1 * time.Second,
+		})
+		if err != nil {
+			return false
+		}
+		checkCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		_, err = etcdClient.Get(checkCtx, "health-check")
+		if err != nil {
+			etcdClient.Close()
+			etcdClient = nil
+			return false
+		}
+		return true
+	}, 30*time.Second, 500*time.Millisecond, "recreated etcd failed to become ready")
+	defer etcdClient.Close()
+
+	opCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err = etcdClient.Put(opCtx, "recreate-key", "recreate-value")
+	require.NoError(t, err, "should be able to write after recreate")
+	resp, err := etcdClient.Get(opCtx, "recreate-key")
+	require.NoError(t, err, "should be able to read after recreate")
+	require.Len(t, resp.Kvs, 1, "expected one key after recreate")
+	assert.Equal(t, "recreate-value", string(resp.Kvs[0].Value), "value should round-trip after recreate")
+
+	t.Log("Recreate after unclean shutdown succeeded!")
 }
 
 func cleanupContainer(t *testing.T, cc *containerd.Client, namespace string) {


### PR DESCRIPTION
Turning on distributed runners flips embedded etcd from plaintext to TLS, which makes the etcd component recreate its containerd container on the next boot. That recreate got delicate if things went wrong: if the *previous* server had died uncleanly, the new one would wedge on startup and the node would stay down until someone manually cleared a leaked snapshot. A clean transition is fine, and we've done it before (a normal upgrade with a graceful etcd reboot tears everything down in order). The problem is a fleet-wide default-on flip, where unclean shutdowns (crashes, OOMs, host reboots) are exactly what we have to survive.

The etcd task is its own containerd task, independent of the miren process, so it outlives a crash. On recreate we'd SIGTERM the leftover task, but an unclean shutdown leaves the task registered with its init process already dead, so the SIGTERM came back "not found" and `stopTask` bailed without deleting the task. Then it cascaded: the still-registered task blocked the container delete, so the snapshot cleanup never ran, `miren-etcd-snapshot` leaked, and creating the fresh container failed with "already exists".

The fix is in the shared base component, so etcd, victoriametrics, and victorialogs all get it. `stopTask` now falls through on a failed Kill and force-deletes the task with `WithProcessKill`, and container deletion goes through one `deleteContainerAndSnapshot` helper that removes the snapshot as a fallback so a failed delete can't strand it. The graceful Stop path and the recreate path share that helper now.

The same teardown dance is duplicated across base, buildkit, and the sandbox controller. Converging them is real cleanup but too wide a blast radius for a GA-blocking fix, so that's filed as MIR-1466.

Regression test seeds the exact wedge (a leftover container and snapshot with a dead-but-registered task) and asserts the recreate comes back up serving. Fails without the fix, passes with it.

Closes MIR-1463