### PR TITLE
Fix app history hiding CI/OIDC deploys (cluster_id name-vs-address mismatch)

### DIFF
--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -70,8 +70,8 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 		return rpc.AppAccessError(ctx, appName)
 	}
 
-	// Check for existing in_progress deployments for this app+cluster
-	existingDeployments, err := d.listDeploymentsInternal(ctx, appName, clusterId, "in_progress", 1)
+	// Check for existing in_progress deployments for this app
+	existingDeployments, err := d.listDeploymentsInternal(ctx, appName, "in_progress", 1)
 	if err != nil {
 		d.Log.Error("Failed to check for existing deployments", "error", err)
 		return cond.Error("failed to check deployment lock")
@@ -482,15 +482,14 @@ func (d *DeploymentServer) ListDeployments(ctx context.Context, req *deployment_
 	args := req.Args()
 	results := req.Results()
 
-	// Extract filters
-	var appName, clusterId, status string
+	// Extract filters. cluster_id is accepted for wire compatibility but no
+	// longer used to filter: this cluster's store only holds its own
+	// deployments (see listDeploymentsInternal / MIR-1465).
+	var appName, status string
 	var limit int32 = 100 // default limit
 
 	if args.HasAppName() {
 		appName = args.AppName()
-	}
-	if args.HasClusterId() {
-		clusterId = args.ClusterId()
 	}
 	if args.HasStatus() {
 		status = args.Status()
@@ -503,7 +502,7 @@ func (d *DeploymentServer) ListDeployments(ctx context.Context, req *deployment_
 		return rpc.AppAccessError(ctx, appName)
 	}
 
-	deployments, err := d.listDeploymentsInternal(ctx, appName, clusterId, status, int(limit))
+	deployments, err := d.listDeploymentsInternal(ctx, appName, status, int(limit))
 	if err != nil {
 		return err
 	}
@@ -638,7 +637,7 @@ func (d *DeploymentServer) GetActiveDeployment(ctx context.Context, req *deploym
 	}
 
 	// Find active deployment
-	deployments, err := d.listDeploymentsInternal(ctx, appName, clusterId, "active", 1)
+	deployments, err := d.listDeploymentsInternal(ctx, appName, "active", 1)
 	if err != nil {
 		return err
 	}
@@ -859,7 +858,7 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	// --- Normal (non-ephemeral) deploy path below ---
 
 	// Check for existing in_progress deployments (deployment lock)
-	existingDeployments, err := d.listDeploymentsInternal(ctx, appName, clusterId, "in_progress", 1)
+	existingDeployments, err := d.listDeploymentsInternal(ctx, appName, "in_progress", 1)
 	if err != nil {
 		d.Log.Error("Failed to check for existing deployments", "error", err)
 		results.SetError("failed to check deployment lock")
@@ -922,7 +921,7 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	}
 
 	// Find the source deployment — the most recent deployment with this app_version_id
-	allDeployments, err := d.listDeploymentsInternal(ctx, appName, clusterId, "", 100)
+	allDeployments, err := d.listDeploymentsInternal(ctx, appName, "", 100)
 	if err != nil {
 		d.Log.Error("Failed to list deployments for source lookup", "error", err)
 		// Continue without source info
@@ -1141,7 +1140,7 @@ func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, 
 	appVersionId := mutResult.VersionID
 
 	// Check for existing in_progress deployments (deployment lock)
-	existingDeployments, err := d.listDeploymentsInternal(ctx, appName, clusterId, "in_progress", 1)
+	existingDeployments, err := d.listDeploymentsInternal(ctx, appName, "in_progress", 1)
 	if err != nil {
 		d.Log.Error("Failed to check for existing deployments", "error", err)
 		results.SetError("failed to check deployment lock")
@@ -1313,7 +1312,14 @@ func (d *DeploymentServer) getAccessInfo(ctx context.Context, appName string, ep
 
 // Internal helper methods
 
-func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName, clusterId, status string, limit int) ([]deploymentWithEntity, error) {
+// listDeploymentsInternal lists deployments from this cluster's entity store,
+// optionally filtered by app name and status. It does not filter by cluster:
+// the store is a loopback into this coordinator's own etcd, so every deployment
+// it holds already belongs to this cluster. The cluster_id stamped on a
+// deployment is client-supplied and inconsistent (a manual deploy sends the
+// cluster name, a CI/OIDC deploy sends the raw address), so filtering on it
+// would hide legitimate deploys — see MIR-1465.
+func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName, status string, limit int) ([]deploymentWithEntity, error) {
 	// List all deployments by type
 	listResp, err := d.EAC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindDeployment))
 	if err != nil {
@@ -1333,9 +1339,6 @@ func (d *DeploymentServer) listDeploymentsInternal(ctx context.Context, appName,
 
 		// Apply filters
 		if appName != "" && dep.AppName != appName {
-			continue
-		}
-		if clusterId != "" && dep.ClusterId != clusterId {
 			continue
 		}
 		if status != "" && dep.Status != status {
@@ -1474,8 +1477,8 @@ type deploymentWithEntity struct {
 // markPreviousActiveAs marks all active deployments for the given app/cluster with the target status,
 // except for the specified currentDeploymentId
 func (d *DeploymentServer) markPreviousActiveAs(ctx context.Context, appName, clusterId, currentDeploymentId, targetStatus string) error {
-	// List all active deployments for this app/cluster
-	deployments, err := d.listDeploymentsInternal(ctx, appName, clusterId, "active", 100)
+	// List all active deployments for this app
+	deployments, err := d.listDeploymentsInternal(ctx, appName, "active", 100)
 	if err != nil {
 		return err
 	}

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -847,7 +847,13 @@ func TestUpdateDeploymentStatusToInProgress(t *testing.T) {
 	}
 }
 
-func TestListDeploymentsClusterFilter(t *testing.T) {
+// TestListDeploymentsIgnoresClusterID pins the MIR-1465 fix: the same physical
+// cluster ends up with deployments filed under two different client-supplied
+// identity strings (a manual deploy stamps the cluster name, a CI/OIDC deploy
+// stamps the raw address), and neither history nor the active-deployment lookup
+// may hide rows based on which string the query is scoped to. The store is
+// per-cluster, so every deployment it holds is ours.
+func TestListDeploymentsIgnoresClusterID(t *testing.T) {
 	ctx := context.Background()
 
 	inmem, cleanup := testutils.NewInMemEntityServer(t)
@@ -863,48 +869,44 @@ func TestListDeploymentsClusterFilter(t *testing.T) {
 		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
 	}
 
-	// Create deployments across different clusters
+	const clusterName = "garden"
+	const clusterAddr = "34.122.229.118:8443"
+
+	// An older manual deploy stamped with the cluster name, then a newer CI
+	// deploy stamped with the raw address. Both target the same cluster.
 	for _, d := range []*core_v1alpha.Deployment{
-		{AppName: "myapp", ClusterId: "cluster-a", AppVersion: "v1", Status: "active"},
-		{AppName: "myapp", ClusterId: "cluster-b", AppVersion: "v2", Status: "active"},
-		{AppName: "myapp", ClusterId: "cluster-a", AppVersion: "v3", Status: "succeeded"},
+		{AppName: "myapp", ClusterId: clusterName, AppVersion: "v1-manual", Status: "succeeded",
+			DeployedBy: core_v1alpha.DeployedBy{Timestamp: time.Now().Add(-1 * time.Hour).Format(time.RFC3339)}},
+		{AppName: "myapp", ClusterId: clusterAddr, AppVersion: "v2-ci", Status: "active",
+			DeployedBy: core_v1alpha.DeployedBy{Timestamp: time.Now().Format(time.RFC3339)}},
 	} {
-		name := d.AppName + "-" + d.ClusterId + "-" + d.AppVersion
+		name := d.AppName + "-" + d.AppVersion
 		if _, err := inmem.Client.Create(ctx, name, d); err != nil {
 			t.Fatalf("Failed to create deployment: %v", err)
 		}
 	}
 
-	// Without cluster filter: should return all 3
-	result, err := client.ListDeployments(ctx, "myapp", "", "", 0)
-	if err != nil {
-		t.Fatalf("ListDeployments failed: %v", err)
-	}
-	if len(result.Deployments()) != 3 {
-		t.Errorf("Expected 3 deployments without cluster filter, got %d", len(result.Deployments()))
-	}
-
-	// With cluster-a filter: should return 2
-	result, err = client.ListDeployments(ctx, "myapp", "cluster-a", "", 0)
-	if err != nil {
-		t.Fatalf("ListDeployments failed: %v", err)
-	}
-	if len(result.Deployments()) != 2 {
-		t.Errorf("Expected 2 deployments for cluster-a, got %d", len(result.Deployments()))
-	}
-	for _, dep := range result.Deployments() {
-		if dep.ClusterId() != "cluster-a" {
-			t.Errorf("Expected cluster-a, got %s", dep.ClusterId())
+	// History returns every deployment for the app regardless of the cluster_id
+	// the caller passes — name, address, or empty.
+	for _, clusterArg := range []string{clusterName, clusterAddr, ""} {
+		result, err := client.ListDeployments(ctx, "myapp", clusterArg, "", 0)
+		if err != nil {
+			t.Fatalf("ListDeployments(cluster_id=%q) failed: %v", clusterArg, err)
+		}
+		if len(result.Deployments()) != 2 {
+			t.Errorf("cluster_id=%q: expected 2 deployments, got %d", clusterArg, len(result.Deployments()))
 		}
 	}
 
-	// With cluster-b filter: should return 1
-	result, err = client.ListDeployments(ctx, "myapp", "cluster-b", "", 0)
+	// The active deployment is the CI (address-stamped) one, and it must be
+	// found even when the caller scopes the query by the cluster *name* — the
+	// exact query that MIR-1465 caused to return the stale manual deploy.
+	active, err := client.GetActiveDeployment(ctx, "myapp", clusterName)
 	if err != nil {
-		t.Fatalf("ListDeployments failed: %v", err)
+		t.Fatalf("GetActiveDeployment(cluster_id=%q) failed: %v", clusterName, err)
 	}
-	if len(result.Deployments()) != 1 {
-		t.Errorf("Expected 1 deployment for cluster-b, got %d", len(result.Deployments()))
+	if got := active.Deployment().AppVersionId(); got != "v2-ci" {
+		t.Errorf("expected active app version %q (CI deploy), got %q", "v2-ci", got)
 	}
 }
 


### PR DESCRIPTION
`miren app history` and `app status` were showing an incomplete picture. Deploys from a laptop showed up fine, but deploys that went through CI were missing, and the "active" deployment was whatever you'd last pushed by hand. The confusing part was that `miren app versions` stayed correct throughout, so the same cluster told two different stories about what was deployed.

The cause was `cluster_id`, a client-supplied string we used as an exact-match filter on reads. A manual `deploy -C garden` stamps `cluster_id: garden`, while a CI deploy authenticates by cluster address and stamps `cluster_id: 34.122.229.118:8443`. Same cluster, two identity strings, so a name-scoped query never matched the address-stamped CI rows.

It turns out that filter wasn't needed at all. Each coordinator's deployment store is a loopback into its own etcd, so it only ever holds its own cluster's deployments. Removing the `cluster_id` comparison in `listDeploymentsInternal` (and its now-unused parameter) fixes the visibility bug without touching the write path or the wire contract, and it also clears up a latent case where a name-stamped and an address-stamped deploy could both stay "active."

This is an interim fix. The longer-term home is MIR-681 (server-owned deployment lifecycle), where the server stamps its own canonical identity instead of trusting the client string.

Fixes MIR-1465.
