### PR TITLE
Fix distributed peer build failing on VCS stamping in CI

### DIFF
--- a/hack/dev-distributed
+++ b/hack/dev-distributed
@@ -29,6 +29,12 @@ bootstrap_peer() {
   echo "    Bootstrapping $peer..."
   # Run the common setup (cgroups, kernel mounts, dirs, host user, etc.)
   peer_exec "$peer" bash -c "source hack/common-setup.sh && setup_cgroups && setup_environment && setup_host_user && setup_kernel_mounts"
+  # The build runs as root in the peer, but /src is owned by the host user,
+  # so git's dubious-ownership check aborts `git status` (exit 128) and Go's
+  # build VCS stamping fails the build. Unlike the standalone dev flow
+  # (hack/dev.sh), which builds as the host user, this path builds as root, so
+  # mark /src safe. Mirrors hack/package-release.sh.
+  peer_exec "$peer" git config --global --add safe.directory /src
   # Build binary
   peer_exec "$peer" make bin/miren
   # Symlinks


### PR DESCRIPTION
The `test-blackbox-distributed` job I just added went green nowhere it mattered: it skips on PRs and only runs on main, so its first real execution was right after merge, where it promptly fell over. The peers bootstrap builds miren on each peer with `make bin/miren`, and iso runs that as root. Since `/src` is owned by the host user, git's dubious-ownership guard kills `git status` with exit 128, and Go's build-time VCS stamping turns that into a hard build failure before any test even runs.

Funny little divergence at the root of it: the standalone dev flow (`hack/dev.sh`) builds as the host user, so ownership lines up and this never bites. The peers path builds as root and never accounted for it. Nothing exercised that combination until this job started running in CI as root.

Fix is the same one `hack/package-release.sh` already uses: mark `/src` a safe directory before building. Both the `git config` and the build run through `peer_exec` as the same user, so the entry lands in exactly the config the build reads.