### PR TITLE
Enable distributed runners by default

### DIFF
--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -2,7 +2,7 @@ features:
   - name: distributedrunners
     predicate: DistributedRunners
     description: Schedule jobs across multiple runner nodes
-    default: false
+    default: true
 
   - name: sagas
     predicate: Sagas

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -37,7 +37,7 @@ var (
 
 // featureDefaults holds the default state for each feature
 var featureDefaults = map[string]bool{
-	FeatureDistributedRunners: false,
+	FeatureDistributedRunners: true,
 	FeatureSagas:              false,
 }
 

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -18,6 +18,17 @@ func TestDisableFeatureWithPrefix(t *testing.T) {
 	}
 }
 
+func TestDistributedRunnersEnabledByDefault(t *testing.T) {
+	Reset()
+
+	// GA: distributed runners are on by default with no flags set.
+	Init(nil, nil)
+
+	if !DistributedRunners() {
+		t.Error("DistributedRunners should be enabled by default")
+	}
+}
+
 func TestCaseInsensitiveFeatureNames(t *testing.T) {
 	Reset()
 


### PR DESCRIPTION
Distributed runners have been living behind the `--labs distributedrunners` opt-in while they baked. They've held up, so this makes them the default for everyone: one line in `features.yaml` (regenerated into `labs.gen.go`) flipping the `distributedrunners` default to on. Because `IsEnabled` falls back to the feature default whenever a flag isn't explicitly set, that single change lights up all three gates at once: the `runner` command tree registers in the CLI, embedded etcd comes up with the mTLS config remote runners need, and the scheduler takes the distributed path.

The labs flag isn't going anywhere, it's now the escape hatch instead of the opt-in. An operator who sees trouble can force the old behavior back with `MIREN_LABS=-distributedrunners` (the parser already understood the `-` disable prefix, so no new code was needed). Ripping out the flag and gating is deliberately a later step (MIR-1461), so we keep a clean fallback for at least one release.

Worth calling out why this lands now rather than earlier: verifying the flip surfaced two migration hazards the original bake never exercised, and both were fixed first (#964, #965). Enabling the flag flips embedded etcd from plaintext to TLS, and fresh installs needed the CA created before that setup runs, while an existing cluster whose previous shutdown was unclean would wedge on the plain→TLS container recreate. With those in, I verified the full unclean-shutdown migration in a dev cluster: crash a plaintext-etcd server, boot with the flag on, and it now tears down the orphaned container and comes back up on mTLS etcd cleanly instead of dying on "snapshot already exists."

The only other change here is a small test asserting distributed runners are on with no flags set, so a future regeneration can't quietly undo it.

Closes MIR-955
