### PR TITLE
Enable sagas by default, keeping the flag as an escape hatch

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -14,6 +14,9 @@ All notable changes to Miren Runtime will be documented in this file.
 **Features**
 - **Maintenance mode for routes** - `miren route down app.example.com --reason "Upgrading the database"` takes a hostname out of service and shows visitors a holding page; `miren route up` puts it back. Visitors get a 503, which is what crawlers and uptime monitors expect from planned downtime, rather than the 500s or platform error pages the old workarounds produced, plus a `Retry-After` when you give an expected return time with `--back-at`. Your app keeps running throughout, so `miren app run` and one-shot migrations work during the window. See the [maintenance mode guide](/maintenance-mode).
 
+**Improvements**
+- **Builds and sandbox startup survive a restart** - Both are now driven by the saga engine, which journals each step as it goes, so a control-plane restart in the middle of one resumes it (or unwinds it cleanly) instead of stranding a half-built image or a sandbox that never finishes coming up. This ran behind the `sagas` labs flag on our own clusters for the last few releases and is now the default everywhere. The flag stays for one release as an escape hatch: start the server with `--labs -sagas` (or `MIREN_LABS=-sagas`) to go back to the old path, and please tell us if you need to, because the old path goes away in the release after this one. See [Miren Labs](/labs). ([#972](https://github.com/mirendev/runtime/pull/972))
+
 ---
 
 ## v0.13.0

--- a/pkg/labs/features.yaml
+++ b/pkg/labs/features.yaml
@@ -4,7 +4,9 @@ features:
     description: Schedule jobs across multiple runner nodes
     default: true
 
+  # Sagas are GA (MIR-953). The flag survives only as an escape hatch (-sagas)
+  # for one release; MIR-1460 removes it and the pre-saga code path with it.
   - name: sagas
     predicate: Sagas
     description: Use saga-based crash-recoverable workflows
-    default: false
+    default: true

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -39,7 +39,7 @@ var (
 // featureDefaults holds the default state for each feature
 var featureDefaults = map[string]bool{
 	FeatureDistributedRunners: true,
-	FeatureSagas:              false,
+	FeatureSagas:              true,
 }
 
 // Init initializes the labs feature flags from the provided flag strings.

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -12,6 +12,33 @@ func quiet() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
+// Sagas graduated to on-by-default in MIR-953, keeping the flag purely as an
+// escape hatch. Both halves of that contract are pinned here: nothing has to be
+// passed to get sagas, and "-sagas" on its own is enough to get the old path
+// back. MIR-1460 deletes this test along with the flag.
+func TestSagasEnabledByDefault(t *testing.T) {
+	Reset()
+
+	if !Sagas() {
+		t.Error("Sagas should be enabled by default")
+	}
+
+	Init(quiet(), nil)
+	if !Sagas() {
+		t.Error("Sagas should be enabled after Init with no flags")
+	}
+
+	Init(quiet(), []string{"distributedrunners"})
+	if !Sagas() {
+		t.Error("Sagas should stay enabled when an unrelated feature is named")
+	}
+
+	Init(quiet(), []string{"-sagas"})
+	if Sagas() {
+		t.Error("Sagas should be disabled by '-sagas' alone")
+	}
+}
+
 func TestDisableFeatureWithPrefix(t *testing.T) {
 	Reset()
 


### PR DESCRIPTION
Sagas have carried sandbox creation and builds on garden since early July and on club since mid-July. Nothing came out of either soak that argues for keeping this opt-in.

This flips the default while leaving the flag behind. `MIREN_LABS=-sagas` (or `--labs -sagas`) puts a cluster back on the pre-saga path, and that lever survives one release so anyone who hits badness has somewhere to go. MIR-1460 removes the flag and old path later.

The saga-retention gap that held this PR is addressed by #1022. The containerd namespace fix and labs logging and escape-hatch docs were split into #1011 and #1012. What remains here is the default change, its generated counterpart, a test pinning both halves of the contract, and the changelog entry.

Closes MIR-953