### PR TITLE
docs: sandboxes run under runc, not gvisor

### DIFF
--- a/docs/docs/terminology.md
+++ b/docs/docs/terminology.md
@@ -118,7 +118,7 @@ Authentication at the routing layer using an [identity provider](#identity-provi
 
 ## Sandbox
 
-An isolated execution environment where your app runs. Sandboxes use gvisor for security isolation and have their own network namespace.
+An isolated execution environment where your app runs. Sandboxes are Linux containers managed by containerd, isolated using kernel namespaces and cgroups, and each has its own network namespace by default.
 
 ## Sandbox Pool
 


### PR DESCRIPTION
The glossary entry for Sandbox said sandboxes use gvisor for security isolation. They don't, and haven't for a while: both container specs pass `io.containerd.runc.v2`, and there's no reference to runsc anywhere in the tree. What you actually get is an ordinary runc container isolated by kernel namespaces and cgroups, with its own network namespace unless host networking is on.

Layering in gvisor, or another execution engine, is something we may well want later. Until one actually ships, though, the docs should describe what runs today. Isolation strength is the kind of claim people make deployment decisions on, so overstating it costs more than saying less.
