### PR TITLE
Fix release-tag.sh changelog check failing under pipefail

### DIFF
--- a/hack/release-tag.sh
+++ b/hack/release-tag.sh
@@ -91,7 +91,12 @@ if [ "$JJ_MODE" = true ]; then
   if [ "$FORCE" = true ]; then
     echo "Warning: Skipping changelog check (--force); fetch and origin/main targeting still run"
   else
-    if ! git show "$TARGET":docs/docs/changelog.md 2>/dev/null | grep -q "^## $VERSION"; then
+    # Read the changelog into a variable rather than piping it. `grep -q` exits
+    # on its first match, which SIGPIPEs `git show` into exit 141, and pipefail
+    # turns that into a failed check even when the version is present.
+    REMOTE_CHANGELOG=$(git show "$TARGET":docs/docs/changelog.md 2>/dev/null || true)
+
+    if ! grep -q "^## $VERSION" <<<"$REMOTE_CHANGELOG"; then
       echo "Error: origin/main changelog does not contain '## $VERSION'"
       echo "Has the release PR been merged?"
       echo "Or use --force to skip this check"


### PR DESCRIPTION
Tagging v0.12.1 tonight hit this: `release-tag.sh` insisted origin/main's changelog didn't contain `## v0.12.1` when it very much did, right there at line 16.

It's a SIGPIPE-under-pipefail bug. `grep -q` exits the moment it matches, `git show` gets a SIGPIPE and exits 141, and `set -o pipefail` faithfully reports the pipeline as failed. The check is inverted into an error precisely when it should pass, which means it fails *harder* the earlier the version heading appears in the file.

Fix is to read the changelog into a variable and grep that. A `git show` failure still leaves it empty and fails the check, so a genuinely missing changelog is caught the same as before.

This only affects the jj-workspace branch. The plain-git path greps the file on disk with no pipe involved. That branch landed in #950 on the 22nd, one day after v0.12.0 was tagged, so v0.12.1 was its first real outing and `--force` was the only way through.

Verified against the live repo: `v0.12.1` and `v0.12.0` both pass, `v9.9.9` correctly fails, and a nonexistent path correctly fails. I didn't re-run the full script end to end for a passing case, because every version in the changelog now has a tag and the tag-exists guard short-circuits first.