### PR TITLE
Delete unused rpc.DefaultTransport and reject out-of-range integer attrs

### DIFF
--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -26,19 +26,12 @@ import (
 )
 
 var (
-	DefaultTransport  http3.Transport
 	DefaultQUICConfig quic.Config
 
 	DefaultLogLevel = slog.LevelInfo
 )
 
 func init() {
-	DefaultTransport.EnableDatagrams = true
-	DefaultTransport.Logger = slog.Default()
-	DefaultTransport.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: true,
-	}
-
 	DefaultQUICConfig = quic.Config{
 		// Pin the QUIC Initial at the 1200-byte spec minimum so the handshake
 		// fits a 1280-MTU path (Tailscale/WireGuard tunnels, the IPv6 minimum).
@@ -60,8 +53,6 @@ func init() {
 		InitialConnectionReceiveWindow: 10 * 1024 * 1024, // 10MB total
 		MaxConnectionReceiveWindow:     20 * 1024 * 1024, // 20MB total max
 	}
-
-	DefaultTransport.QUICConfig = &DefaultQUICConfig
 }
 
 // closedPacketConn is a stub net.PacketConn that returns net.ErrClosed on all operations.

--- a/servers/entityserver/entityserver.go
+++ b/servers/entityserver/entityserver.go
@@ -677,12 +677,14 @@ func (e *EntityServer) MakeAttr(ctx context.Context, req *entityserver_v1alpha.E
 		value = entity.StringValue(args.Value())
 
 	case entity.TypeInt:
-		i, err := strconv.ParseInt(args.Value(), 10, 64)
+		// Atoi parses at the platform's int width, so out-of-range values are
+		// rejected rather than silently truncated on 32-bit builds.
+		i, err := strconv.Atoi(args.Value())
 		if err != nil {
 			return fmt.Errorf("invalid integer value: %w", err)
 		}
 
-		value = entity.IntValue(int(i))
+		value = entity.IntValue(i)
 
 	case entity.TypeFloat:
 		f, err := strconv.ParseFloat(args.Value(), 64)


### PR DESCRIPTION
`rpc.DefaultTransport` was an exported package var carrying `InsecureSkipVerify: true`, which is the sort of thing worth a second look. It turns out nothing referenced it outside its own `init()`. Real client connections build their TLS config from `State.clientTlsCfg` and pin the peer certificate through `VerifyPeerCertificate`, so this transport was never in any code path. Deleting it is both the fix and the explanation. `DefaultQUICConfig` sitting next to it is genuinely used and stays.

`MakeAttr` parsed integer attribute values with `ParseInt(..., 64)` and then converted to `int`, which silently truncates on a 32-bit build. Since the value arrives over the wire, an oversized input would have been stored as some unrelated number rather than refused. `Atoi` parses at the platform's int width and returns `ErrRange`, so the error path that was already there now catches it.

Two revs since the changes are unrelated.