### PR TITLE
Let only the volume's owner mount a disk lease

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on:
   pull_request:
+    # Explicit list because naming `types` replaces the default set. `labeled`
+    # is what lets the ci:distributed opt-in below take effect on an open PR;
+    # the other three are the defaults we'd otherwise lose.
+    types: [opened, synchronize, reopened, labeled]
   merge_group:
   workflow_call:
     # Called by release.yml for main/tag builds
@@ -410,7 +414,14 @@ jobs:
     # workflow_call, where github.event_name is the caller's event ('push'), so
     # excluding 'pull_request' runs it there while skipping PRs. It would also
     # run in a merge queue if one were enabled ('merge_group').
-    if: github.event_name != 'pull_request'
+    #
+    # Label a PR `ci:distributed` to opt into it before merging. Worth doing for
+    # anything touching disks, leases, or the runner: this job is the only place
+    # a second node exists, so a multi-node bug is invisible until it is already
+    # on main and blocking the release (MIR-1469).
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:distributed')
     runs-on: depot-ubuntu-latest
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -471,10 +482,14 @@ jobs:
     - name: Peer logs on failure
       if: failure()
       run: |
+        # The whole suite runs serially against one cluster, so a failure early
+        # on is thousands of lines from the end by the time we get here. A tail
+        # window reliably misses it (MIR-1469 was diagnosed twice from logs that
+        # started five minutes after the failure), so dump the logs whole.
         echo "=== Coordinator server logs ==="
-        iso peers exec coordinator -- tail -200 /tmp/miren-server.log 2>&1 || true
+        iso peers exec coordinator -- cat /tmp/miren-server.log 2>&1 || true
         echo "=== Runner logs ==="
-        iso peers exec runner1 -- tail -200 /tmp/miren-runner.log 2>&1 || true
+        iso peers exec runner1 -- cat /tmp/miren-runner.log 2>&1 || true
 
     - name: Save Docker image to cache
       if: steps.docker-image-cache.outputs.cache-hit != 'true'

--- a/cli/commands/debug_disk_lease.go
+++ b/cli/commands/debug_disk_lease.go
@@ -38,6 +38,14 @@ func DebugDiskLease(ctx *Context, opts struct {
 	// Generate lease ID (format: disk-lease-<base58>)
 	leaseId := idgen.GenNS("disk-lease")
 
+	// Pin the lease to whichever node holds the disk's volume, the way the
+	// sandbox path does. An unpinned lease is reconciled by every node in a
+	// multi-node cluster, and only the volume's owner can actually mount it.
+	nodeId, err := diskVolumeNodeId(ctx, eac, diskId)
+	if err != nil {
+		return err
+	}
+
 	// Create disk lease entity
 	lease := &storage_v1alpha.DiskLease{
 		DiskId: diskId,
@@ -46,6 +54,7 @@ func DebugDiskLease(ctx *Context, opts struct {
 			Path:     opts.Path,
 			ReadOnly: opts.ReadOnly,
 		},
+		NodeId: nodeId,
 	}
 
 	// Set app ID if provided
@@ -71,6 +80,25 @@ func DebugDiskLease(ctx *Context, opts struct {
 	ctx.Info("Read-Only: %v", opts.ReadOnly)
 
 	return nil
+}
+
+// diskVolumeNodeId returns the node holding the disk's volume, or "" when the
+// volume can't be found or isn't stamped with a node.
+func diskVolumeNodeId(ctx context.Context, eac *entityserver_v1alpha.EntityAccessClient, diskId entity.Id) (entity.Id, error) {
+	resp, err := eac.List(ctx, entity.Ref(storage_v1alpha.DiskVolumeDiskIdId, diskId))
+	if err != nil {
+		return "", fmt.Errorf("failed to look up disk_volume for %s: %w", diskId, err)
+	}
+
+	values := resp.Values()
+	if len(values) == 0 {
+		return "", nil
+	}
+
+	var volume storage_v1alpha.DiskVolume
+	volume.Decode(values[0].Entity())
+
+	return volume.NodeId, nil
 }
 
 // DebugDiskLeaseList lists all disk lease entities
@@ -312,11 +340,13 @@ func DebugDiskLeaseStatus(ctx *Context, opts struct {
 		ctx.Info("Node: %s", lease.NodeId)
 	}
 
-	// Check error message if failed
 	if lease.Status == storage_v1alpha.FAILED {
-		// Note: Error message would be in attributes - this would need entity attribute access
 		ctx.Info("")
-		ctx.Info("Status: FAILED - Check entity attributes for error details")
+		if lease.ErrorMessage != "" {
+			ctx.Info("Status: FAILED - %s", lease.ErrorMessage)
+		} else {
+			ctx.Info("Status: FAILED - no error message recorded")
+		}
 	}
 
 	return nil

--- a/controllers/disk/disk_lease_controller.go
+++ b/controllers/disk/disk_lease_controller.go
@@ -187,22 +187,12 @@ func (d *DiskLeaseController) ReconcileOrphanLeases(ctx context.Context, minLeas
 
 // Create handles creation of a new disk lease entity
 func (d *DiskLeaseController) Create(ctx context.Context, lease *storage_v1alpha.DiskLease, meta *entity.Meta) error {
-	d.Log.Info("Processing lease creation",
-		"lease", lease.ID,
-		"disk", lease.DiskId,
-		"status", lease.Status)
-
-	return d.reconcileLease(ctx, lease, meta)
+	return d.reconcileLease(ctx, "Processing lease creation", lease, meta)
 }
 
 // Update handles updates to an existing disk lease entity
 func (d *DiskLeaseController) Update(ctx context.Context, lease *storage_v1alpha.DiskLease, meta *entity.Meta) error {
-	d.Log.Info("Processing lease update",
-		"lease", lease.ID,
-		"disk", lease.DiskId,
-		"status", lease.Status)
-
-	return d.reconcileLease(ctx, lease, meta)
+	return d.reconcileLease(ctx, "Processing lease update", lease, meta)
 }
 
 // Delete handles deletion of a disk lease entity
@@ -233,7 +223,7 @@ func (d *DiskLeaseController) Delete(ctx context.Context, id entity.Id, obj *sto
 }
 
 func (d *DiskLeaseController) cleanupDiskMountForLease(ctx context.Context, leaseId entity.Id, leaseIdStr string) {
-	mount, err := d.getDiskMountForLease(ctx, leaseId)
+	mount, _, err := d.getDiskMountForLease(ctx, leaseId)
 	if err != nil {
 		d.Log.Warn("error looking up disk_mount for deleted lease", "lease", leaseIdStr, "error", err)
 		return
@@ -271,12 +261,20 @@ func (d *DiskLeaseController) cleanupDiskMountForLease(ctx context.Context, leas
 	}
 }
 
-// reconcileLease reconciles the lease state
-func (d *DiskLeaseController) reconcileLease(ctx context.Context, lease *storage_v1alpha.DiskLease, meta *entity.Meta) error {
+// reconcileLease reconciles the lease state. event names the entity change for
+// logging, which happens after the node filter: the controller resyncs every
+// lease every minute on every node, so logging before the filter meant each
+// node narrating leases it was about to drop, once a minute, forever.
+func (d *DiskLeaseController) reconcileLease(ctx context.Context, event string, lease *storage_v1alpha.DiskLease, meta *entity.Meta) error {
 	// Only reconcile leases assigned to this node
 	if lease.NodeId != "" && !d.NodeId.Matches(lease.NodeId) {
 		return nil
 	}
+
+	d.Log.Info(event,
+		"lease", lease.ID,
+		"disk", lease.DiskId,
+		"status", lease.Status)
 
 	var err error
 
@@ -389,8 +387,86 @@ func (d *DiskLeaseController) handlePendingLease(ctx context.Context, lease *sto
 		return nil
 	}
 
+	// Resolve the volume before touching mount state. A lease with no NodeId
+	// (the `debug disk lease` path, and anything created before leases were
+	// pinned) is reconciled by every node, and only the node holding the volume
+	// can mount it. Deciding ownership up front keeps a non-owner from reading
+	// its own stale mount below and driving the shared lease to a terminal
+	// FAILED it can never recover from (MIR-1469).
+	diskVolume, err := d.getDiskVolumeForDisk(ctx, disk.ID)
+	if err != nil {
+		d.Log.Error("Failed to look up disk_volume", "disk", diskId, "error", err)
+		d.cleanupLeaseReservation(diskId)
+
+		lease.Status = storage_v1alpha.FAILED
+		lease.ErrorMessage = fmt.Sprintf("Failed to look up disk_volume: %v", err)
+		return nil
+	}
+
+	if diskVolume == nil {
+		// Recoverable, not terminal: DiskController recreates a missing volume
+		// for a PROVISIONED disk on its next pass, so this is a window to wait
+		// out rather than a reason to burn the lease.
+		d.cleanupLeaseReservation(diskId)
+		d.Log.Info("no disk_volume for disk yet, lease will retry",
+			"disk", diskId,
+			"lease", leaseId)
+		return nil
+	}
+
+	// A volume with no node_id predates the stamp (node_id is required by the
+	// schema but unenforced, same as on the lease). We can't name its owner,
+	// so fall back to the lease's own pin: reaching here means the lease is
+	// either pinned to us or pinned to nobody. Pinned to us, we're the
+	// designated node and proceed. Pinned to nobody either, and there is no
+	// information anywhere about who should mount this, so guessing is how
+	// two nodes end up fighting over it. Wait instead; a resync retries.
+	if diskVolume.NodeId == "" {
+		if lease.NodeId == "" {
+			d.cleanupLeaseReservation(diskId)
+			d.Log.Warn("neither lease nor disk_volume names a node, cannot determine owner",
+				"disk", diskId,
+				"lease", leaseId,
+				"disk_volume", diskVolume.ID)
+			return nil
+		}
+	} else if !d.NodeId.Matches(diskVolume.NodeId) {
+		d.cleanupLeaseReservation(diskId)
+
+		// An unpinned lease reaches every node, and the volume's owner is
+		// among them, so stepping aside is the whole job. Quiet by design:
+		// this is the common, healthy outcome on every non-owner.
+		if lease.NodeId == "" {
+			d.Log.Debug("disk_volume belongs to another node, leaving lease to its owner",
+				"disk", diskId,
+				"lease", leaseId,
+				"disk_volume", diskVolume.ID,
+				"volume_node", diskVolume.NodeId,
+				"my_node", d.NodeId.Id())
+			return nil
+		}
+
+		// Pinned to us, but the volume lives elsewhere. No other node will
+		// pick this up — they all bail at the NodeId filter — so staying quiet
+		// would strand the lease in PENDING forever. Fail it with an error
+		// that names the split, rather than the "volume not found in state"
+		// mount failure this used to surface as.
+		d.Log.Error("lease pinned to this node but its volume lives on another",
+			"disk", diskId,
+			"lease", leaseId,
+			"disk_volume", diskVolume.ID,
+			"volume_node", diskVolume.NodeId,
+			"my_node", d.NodeId.Id())
+
+		lease.Status = storage_v1alpha.FAILED
+		lease.ErrorMessage = fmt.Sprintf(
+			"lease is assigned to node %s but disk_volume %s lives on node %s",
+			d.NodeId.Id(), diskVolume.ID, diskVolume.NodeId)
+		return nil
+	}
+
 	// Check if a disk_mount entity already exists for this lease
-	existingMount, err := d.getDiskMountForLease(ctx, lease.ID)
+	existingMount, _, err := d.getDiskMountForLease(ctx, lease.ID)
 	if err != nil {
 		d.Log.Warn("Error looking up existing disk_mount", "lease", leaseId, "error", err)
 	}
@@ -455,26 +531,6 @@ func (d *DiskLeaseController) handlePendingLease(ctx context.Context, lease *sto
 				"actual_state", existingMount.ActualState)
 			return nil
 		}
-	}
-
-	// Find the disk_volume entity for this disk
-	diskVolume, err := d.getDiskVolumeForDisk(ctx, disk.ID)
-	if err != nil {
-		d.Log.Error("Failed to look up disk_volume", "disk", diskId, "error", err)
-		d.cleanupLeaseReservation(diskId)
-
-		lease.Status = storage_v1alpha.FAILED
-		lease.ErrorMessage = fmt.Sprintf("Failed to look up disk_volume: %v", err)
-		return nil
-	}
-
-	if diskVolume == nil {
-		d.Log.Error("No disk_volume found for disk", "disk", diskId)
-		d.cleanupLeaseReservation(diskId)
-
-		lease.Status = storage_v1alpha.FAILED
-		lease.ErrorMessage = "No disk_volume entity found for disk"
-		return nil
 	}
 
 	if diskVolume.ActualState != storage_v1alpha.DV_READY {
@@ -562,13 +618,23 @@ func (d *DiskLeaseController) handleBoundLease(ctx context.Context, lease *stora
 	}
 	d.mu.Unlock()
 
-	diskMount, err := d.getDiskMountForLease(ctx, lease.ID)
+	diskMount, foreign, err := d.getDiskMountForLease(ctx, lease.ID)
 	if err != nil {
 		d.Log.Warn("Error looking up disk_mount for bound lease", "lease", leaseId, "error", err)
 		return nil
 	}
 
 	if diskMount == nil {
+		// An unpinned lease is reconciled here by every node. If another node
+		// holds the mount, this lease is bound and healthy from its owner's
+		// point of view, and knocking it back to PENDING would just start a
+		// BOUND/PENDING flap between the two nodes.
+		if foreign {
+			d.Log.Debug("Bound lease is mounted by another node, leaving it alone",
+				"lease", leaseId)
+			return nil
+		}
+
 		d.Log.Warn("Bound lease has no disk_mount entity, reverting to pending",
 			"lease", leaseId)
 		lease.Status = storage_v1alpha.PENDING
@@ -620,7 +686,7 @@ func (d *DiskLeaseController) handleReleasedLease(ctx context.Context, lease *st
 		return nil
 	}
 
-	diskMount, err := d.getDiskMountForLease(ctx, lease.ID)
+	diskMount, _, err := d.getDiskMountForLease(ctx, lease.ID)
 	if err != nil {
 		d.Log.Warn("Error looking up disk_mount for released lease", "lease", leaseId, "error", err)
 		return nil
@@ -677,7 +743,7 @@ func (d *DiskLeaseController) handleFailedLease(ctx context.Context, lease *stor
 	}
 	d.mu.Unlock()
 
-	diskMount, err := d.getDiskMountForLease(ctx, lease.ID)
+	diskMount, _, err := d.getDiskMountForLease(ctx, lease.ID)
 	if err != nil {
 		d.Log.Warn("Error looking up disk_mount for failed lease", "lease", leaseId, "error", err)
 		return nil
@@ -731,27 +797,56 @@ func (d *DiskLeaseController) getDiskMountPath(volumeId string) string {
 }
 
 // getDiskMountForLease finds the disk_mount entity for a lease
-func (d *DiskLeaseController) getDiskMountForLease(ctx context.Context, leaseId entity.Id) (*storage_v1alpha.DiskMount, error) {
+func (d *DiskLeaseController) getDiskMountForLease(ctx context.Context, leaseId entity.Id) (*storage_v1alpha.DiskMount, bool, error) {
 	if d.EAC == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	indexAttr := entity.Ref(storage_v1alpha.DiskMountDiskLeaseIdId, leaseId)
 
 	resp, err := d.EAC.List(ctx, indexAttr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list disk_mount entities: %w", err)
+		return nil, false, fmt.Errorf("failed to list disk_mount entities: %w", err)
 	}
 
 	values := resp.Values()
 	if len(values) == 0 {
-		return nil, nil
+		return nil, false, nil
 	}
 
-	var mount storage_v1alpha.DiskMount
-	mount.Decode(values[0].Entity())
+	// A lease can carry more than one disk_mount when several nodes reconciled
+	// it, which is what an unpinned lease invites. Only this node's mount
+	// describes state this controller can act on, so match on NodeId rather
+	// than trusting index order; picking blind was what let another node's
+	// failed mount drive a lease to terminal FAILED (MIR-1469). Mounts
+	// predating the NodeId stamp have none, so fall back to those.
+	//
+	// foreign reports that some other node holds a mount for this lease. A
+	// caller that finds nothing of its own needs that to tell "this lease has
+	// no mount" apart from "its mount isn't mine", since only the former means
+	// the lease has genuinely lost its mount.
+	var (
+		unowned *storage_v1alpha.DiskMount
+		foreign bool
+	)
 
-	return &mount, nil
+	for _, value := range values {
+		var mount storage_v1alpha.DiskMount
+		mount.Decode(value.Entity())
+
+		switch {
+		case d.NodeId.Matches(mount.NodeId):
+			return &mount, false, nil
+		case mount.NodeId == "":
+			if unowned == nil {
+				unowned = &mount
+			}
+		default:
+			foreign = true
+		}
+	}
+
+	return unowned, unowned == nil && foreign, nil
 }
 
 // getDiskVolumeForDisk finds the disk_volume entity for a disk

--- a/controllers/disk/disk_lease_controller_test.go
+++ b/controllers/disk/disk_lease_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
 )
 
 func TestDiskLeaseController_New(t *testing.T) {
@@ -146,4 +147,345 @@ func TestDiskLeaseController_CleanupOldReleasedLeases(t *testing.T) {
 
 	// Should not error even with no EAC
 	assert.NoError(t, err)
+}
+
+// newOwnershipFixture creates a PROVISIONED disk and its disk_volume, stamped
+// with volumeNode (pass "" for a legacy volume that predates the node stamp).
+// The lease ownership tests all need this same pair and differ only in who
+// owns what, so the shape lives here rather than in each of them.
+func newOwnershipFixture(t *testing.T, ctx context.Context, name string, volumeNode entity.Id) (*testutils.InMemEntityServer, entity.Id) {
+	t.Helper()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	diskId := entity.Id("disk/" + name)
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, diskId,
+		(&storage_v1alpha.Disk{
+			ID:       diskId,
+			Name:     name,
+			Status:   storage_v1alpha.PROVISIONED,
+			VolumeId: "vol-" + name,
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	volumeId := entity.Id("disk_volume/vol-" + name)
+	_, err = es.EAC.Create(ctx, entity.New(
+		entity.DBId, volumeId,
+		(&storage_v1alpha.DiskVolume{
+			ID:          volumeId,
+			DiskId:      diskId,
+			VolumeId:    "vol-" + name,
+			ActualState: storage_v1alpha.DV_READY,
+			NodeId:      volumeNode,
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	return es, diskId
+}
+
+// TestDiskLeaseController_SkipsVolumeOwnedByAnotherNode covers a lease with no
+// NodeId, which every node reconciles. Only the node holding the volume may
+// mount it: a non-owner that creates a disk_mount produces one that can never
+// mount, and the lease then binds or fails depending on which mount the index
+// happens to return first (MIR-1469).
+func TestDiskLeaseController_SkipsVolumeOwnedByAnotherNode(t *testing.T) {
+	ctx := context.Background()
+
+	es, diskId := newOwnershipFixture(t, ctx, "shared", compute.NewNodeId("coordinator").Id())
+
+	dlc := NewDiskLeaseController(slog.Default(), es.EAC, compute.NewNodeId("runner1"), "")
+
+	lease := &storage_v1alpha.DiskLease{
+		ID:     entity.Id("disk_lease/unpinned"),
+		DiskId: diskId,
+		Status: storage_v1alpha.PENDING,
+		Mount:  storage_v1alpha.Mount{Path: "/data"},
+	}
+
+	require.NoError(t, dlc.handlePendingLease(ctx, lease))
+
+	assert.Equal(t, storage_v1alpha.PENDING, lease.Status,
+		"non-owner must leave the lease alone, not fail it")
+	assert.Empty(t, lease.ErrorMessage)
+
+	mounts, err := es.EAC.List(ctx, entity.Ref(storage_v1alpha.DiskMountDiskLeaseIdId, lease.ID))
+	require.NoError(t, err)
+	assert.Empty(t, mounts.Values(), "non-owner must not create a disk_mount")
+}
+
+// TestDiskLeaseController_PicksOwnDiskMount covers the lookup side: when a
+// lease already carries mounts from more than one node, the controller must
+// read its own rather than whichever the index returns first.
+func TestDiskLeaseController_PicksOwnDiskMount(t *testing.T) {
+	ctx := context.Background()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	leaseId := entity.Id("disk_lease/two-mounts")
+
+	ownId := entity.Id("disk_mount/from-runner1")
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, ownId,
+		(&storage_v1alpha.DiskMount{
+			ID:          ownId,
+			DiskLeaseId: leaseId,
+			VolumeId:    entity.Id("disk_volume/vol-shared"),
+			ActualState: storage_v1alpha.DM_MOUNTED,
+			NodeId:      compute.NewNodeId("runner1").Id(),
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	foreignId := entity.Id("disk_mount/from-coordinator")
+	_, err = es.EAC.Create(ctx, entity.New(
+		entity.DBId, foreignId,
+		(&storage_v1alpha.DiskMount{
+			ID:          foreignId,
+			DiskLeaseId: leaseId,
+			VolumeId:    entity.Id("disk_volume/vol-shared"),
+			ActualState: storage_v1alpha.DM_ERROR,
+			NodeId:      compute.NewNodeId("coordinator").Id(),
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	dlc := NewDiskLeaseController(slog.Default(), es.EAC, compute.NewNodeId("runner1"), "")
+
+	mount, _, err := dlc.getDiskMountForLease(ctx, leaseId)
+	require.NoError(t, err)
+	require.NotNil(t, mount)
+	assert.Equal(t, ownId, mount.ID)
+	assert.Equal(t, storage_v1alpha.DM_MOUNTED, mount.ActualState)
+
+	// The coordinator, holding no mount of its own for this lease, must not
+	// adopt runner1's. Index order decides nothing here — a node either has a
+	// mount or it doesn't.
+	coordinator := NewDiskLeaseController(slog.Default(), es.EAC, compute.NewNodeId("coordinator"), "")
+
+	own, foreign, err := coordinator.getDiskMountForLease(ctx, entity.Id("disk_lease/runner-only"))
+	require.NoError(t, err)
+	assert.Nil(t, own)
+	assert.False(t, foreign, "no mounts at all is not a foreign mount")
+
+	runnerOnlyId := entity.Id("disk_mount/runner-only-mount")
+	_, err = es.EAC.Create(ctx, entity.New(
+		entity.DBId, runnerOnlyId,
+		(&storage_v1alpha.DiskMount{
+			ID:          runnerOnlyId,
+			DiskLeaseId: entity.Id("disk_lease/runner-only"),
+			VolumeId:    entity.Id("disk_volume/vol-shared"),
+			ActualState: storage_v1alpha.DM_ERROR,
+			NodeId:      compute.NewNodeId("runner1").Id(),
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	own, foreign, err = coordinator.getDiskMountForLease(ctx, entity.Id("disk_lease/runner-only"))
+	require.NoError(t, err)
+	assert.Nil(t, own, "another node's mount is not ours to act on")
+	assert.True(t, foreign, "must report that some other node holds the mount")
+}
+
+// TestDiskLeaseController_NonOwnerIgnoresItsOwnStaleErrorMount covers the state
+// this change has to repair, not just prevent: an unpinned lease that already
+// carries a failed mount from a non-owner. Ownership has to be settled before
+// the existing-mount state machine runs, or the non-owner reads its own
+// DM_ERROR mount and drives the shared lease to a terminal FAILED.
+func TestDiskLeaseController_NonOwnerIgnoresItsOwnStaleErrorMount(t *testing.T) {
+	ctx := context.Background()
+
+	es, diskId := newOwnershipFixture(t, ctx, "legacy", compute.NewNodeId("coordinator").Id())
+	volumeId := entity.Id("disk_volume/vol-legacy")
+
+	leaseId := entity.Id("disk_lease/legacy-unpinned")
+
+	// Left behind by an earlier reconcile on this node, before the guard existed.
+	staleId := entity.Id("disk_mount/stale-runner1")
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, staleId,
+		(&storage_v1alpha.DiskMount{
+			ID:           staleId,
+			DiskLeaseId:  leaseId,
+			VolumeId:     volumeId,
+			ActualState:  storage_v1alpha.DM_ERROR,
+			ErrorMessage: "volume vol-legacy not found in state",
+			NodeId:       compute.NewNodeId("runner1").Id(),
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	dlc := NewDiskLeaseController(slog.Default(), es.EAC, compute.NewNodeId("runner1"), "")
+
+	lease := &storage_v1alpha.DiskLease{
+		ID:     leaseId,
+		DiskId: diskId,
+		Status: storage_v1alpha.PENDING,
+		Mount:  storage_v1alpha.Mount{Path: "/data"},
+	}
+
+	require.NoError(t, dlc.handlePendingLease(ctx, lease))
+
+	assert.Equal(t, storage_v1alpha.PENDING, lease.Status,
+		"a non-owner must not fail a lease from its own stale mount")
+	assert.Empty(t, lease.ErrorMessage)
+}
+
+// TestDiskLeaseController_BoundLeaseSurvivesNonOwnerReconcile covers the other
+// side of an unpinned lease: every node reconciles it in BOUND too. A node that
+// holds no mount of its own must not knock it back to PENDING, or the owner and
+// non-owner flap the lease between BOUND and PENDING forever.
+func TestDiskLeaseController_BoundLeaseSurvivesNonOwnerReconcile(t *testing.T) {
+	ctx := context.Background()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	leaseId := entity.Id("disk_lease/bound-unpinned")
+
+	ownerMountId := entity.Id("disk_mount/owner-mount")
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, ownerMountId,
+		(&storage_v1alpha.DiskMount{
+			ID:          ownerMountId,
+			DiskLeaseId: leaseId,
+			VolumeId:    entity.Id("disk_volume/vol-bound"),
+			ActualState: storage_v1alpha.DM_MOUNTED,
+			NodeId:      compute.NewNodeId("coordinator").Id(),
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	// runner1 holds no mount for this lease.
+	dlc := NewDiskLeaseController(slog.Default(), es.EAC, compute.NewNodeId("runner1"), "")
+
+	lease := &storage_v1alpha.DiskLease{
+		ID:     leaseId,
+		DiskId: entity.Id("disk/bound"),
+		Status: storage_v1alpha.BOUND,
+		Mount:  storage_v1alpha.Mount{Path: "/data"},
+	}
+
+	require.NoError(t, dlc.handleBoundLease(ctx, lease))
+
+	assert.Equal(t, storage_v1alpha.BOUND, lease.Status,
+		"a node without its own mount must leave a bound lease bound")
+}
+
+// TestDiskLeaseController_PinnedLeaseWithForeignVolumeFails covers the case the
+// unpinned guard must not swallow: a lease pinned to this node whose volume
+// lives elsewhere. Every other node bails at the NodeId filter, so if this node
+// also steps aside the lease sits in PENDING forever with nothing explaining
+// why. Fail it, and name the split.
+func TestDiskLeaseController_PinnedLeaseWithForeignVolumeFails(t *testing.T) {
+	ctx := context.Background()
+
+	es, diskId := newOwnershipFixture(t, ctx, "misplaced", compute.NewNodeId("coordinator").Id())
+
+	dlc := NewDiskLeaseController(slog.Default(), es.EAC, compute.NewNodeId("runner1"), "")
+
+	lease := &storage_v1alpha.DiskLease{
+		ID:     entity.Id("disk_lease/pinned-elsewhere"),
+		DiskId: diskId,
+		Status: storage_v1alpha.PENDING,
+		Mount:  storage_v1alpha.Mount{Path: "/data"},
+		NodeId: compute.NewNodeId("runner1").Id(),
+	}
+
+	require.NoError(t, dlc.handlePendingLease(ctx, lease))
+
+	assert.Equal(t, storage_v1alpha.FAILED, lease.Status,
+		"a lease nobody else will pick up must fail loudly, not stall")
+	assert.Contains(t, lease.ErrorMessage, "node/coordinator")
+}
+
+// TestDiskLeaseController_MissingVolumeIsRetryable covers the window where a
+// PROVISIONED disk has no disk_volume yet: DiskController recreates it on its
+// next pass, so the lease must wait rather than burn itself on a state that
+// resolves on its own.
+func TestDiskLeaseController_MissingVolumeIsRetryable(t *testing.T) {
+	ctx := context.Background()
+
+	es, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	diskId := entity.Id("disk/no-volume-yet")
+	_, err := es.EAC.Create(ctx, entity.New(
+		entity.DBId, diskId,
+		(&storage_v1alpha.Disk{
+			ID:       diskId,
+			Name:     "no-volume-yet",
+			Status:   storage_v1alpha.PROVISIONED,
+			VolumeId: "vol-pending",
+		}).Encode,
+	).Attrs())
+	require.NoError(t, err)
+
+	dlc := NewDiskLeaseController(slog.Default(), es.EAC, compute.NewNodeId("miren"), "")
+
+	lease := &storage_v1alpha.DiskLease{
+		ID:     entity.Id("disk_lease/waiting-on-volume"),
+		DiskId: diskId,
+		Status: storage_v1alpha.PENDING,
+		Mount:  storage_v1alpha.Mount{Path: "/data"},
+		NodeId: compute.NewNodeId("miren").Id(),
+	}
+
+	require.NoError(t, dlc.handlePendingLease(ctx, lease))
+
+	assert.Equal(t, storage_v1alpha.PENDING, lease.Status,
+		"a volume that hasn't been created yet is a wait, not a terminal failure")
+	assert.Empty(t, lease.ErrorMessage)
+}
+
+// TestDiskLeaseController_UnstampedVolume covers volumes predating the node_id
+// stamp. With no owner recorded on the volume, the lease's own pin is the only
+// signal left: pinned to us we proceed, pinned to nobody we wait rather than
+// let every node guess and fight over the mount.
+func TestDiskLeaseController_UnstampedVolume(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("lease pinned to us proceeds", func(t *testing.T) {
+		es, diskId := newOwnershipFixture(t, ctx, "unstamped-pinned", "")
+		dlc := NewDiskLeaseController(slog.Default(), es.EAC, compute.NewNodeId("miren"), "")
+
+		lease := &storage_v1alpha.DiskLease{
+			ID:     entity.Id("disk_lease/pinned-to-us"),
+			DiskId: diskId,
+			Status: storage_v1alpha.PENDING,
+			Mount:  storage_v1alpha.Mount{Path: "/data"},
+			NodeId: compute.NewNodeId("miren").Id(),
+		}
+
+		require.NoError(t, dlc.handlePendingLease(ctx, lease))
+
+		mounts, err := es.EAC.List(ctx, entity.Ref(storage_v1alpha.DiskMountDiskLeaseIdId, lease.ID))
+		require.NoError(t, err)
+		assert.Len(t, mounts.Values(), 1,
+			"the designated node should still mount an unstamped volume")
+	})
+
+	t.Run("lease pinned to nobody waits", func(t *testing.T) {
+		es, diskId := newOwnershipFixture(t, ctx, "unstamped-unpinned", "")
+		dlc := NewDiskLeaseController(slog.Default(), es.EAC, compute.NewNodeId("miren"), "")
+
+		lease := &storage_v1alpha.DiskLease{
+			ID:     entity.Id("disk_lease/pinned-to-nobody"),
+			DiskId: diskId,
+			Status: storage_v1alpha.PENDING,
+			Mount:  storage_v1alpha.Mount{Path: "/data"},
+		}
+
+		require.NoError(t, dlc.handlePendingLease(ctx, lease))
+
+		assert.Equal(t, storage_v1alpha.PENDING, lease.Status)
+		mounts, err := es.EAC.List(ctx, entity.Ref(storage_v1alpha.DiskMountDiskLeaseIdId, lease.ID))
+		require.NoError(t, err)
+		assert.Empty(t, mounts.Values(),
+			"with no owner recorded anywhere, no node should claim the mount")
+	})
 }


### PR DESCRIPTION
`TestDiskUndelete` took down the release job on both attempts of run [30291508637](https://github.com/mirendev/runtime/actions/runs/30291508637), an hour after MIR-1469 was closed as fixed. Chasing it turned up something more interesting than a flaky test.

The schema says `disk_lease.node_id` is required, and it means "the node where the disk is mounted." Nothing enforces that on write, and `debug disk lease` never set it. The controller reads a missing `node_id` as "unassigned, everyone have a go", which for a disk lease can't be right: the mount can only happen where the volume physically lives. So both nodes reconciled the same lease and each created its own `disk_mount` pinned to itself, one of which could never work. Then `getDiskMountForLease` took `values[0]` from an unordered index with no node filter, so whether the lease bound or failed terminally came down to which mount the index handed back first. Locally the good one came back first twice; in CI the broken one did, twice. Same commit, opposite outcome.

It needs two nodes, which is why this only ever appeared in `test-blackbox-distributed`, and that job is skipped on `pull_request`. Every PR was green while main was red, which is a rough combination to debug. So this PR also adds a `ci:distributed` label opt-in, and applies it to itself: because `pull_request` runs the workflow from the PR's own head, the fix gets validated by the very job it fixes, before merge rather than after. A path-based auto-trigger for disk and runner changes would be the stronger version, since it doesn't rely on anyone remembering the label, but GitHub has no native per-job path filter and that's more machinery than belongs on a red-main fix.

#970 neither caused this nor was wrong. It fixed a genuine ordering bug in undelete and closed a real data-loss hole, and it changed the test to fail fast on the first `failed` read where the old loop polled for 60s and could still catch a later `bound`. That's why an intermittent flake became a reliable one. The bug was always there; #970 stopped it hiding.

Getting the fix right took two passes. The first version fixed the reported failure but made the pre-existing broken state deterministic instead of 50/50, and would have flapped bound leases between `BOUND` and `PENDING` on non-owner nodes. Both were caught by an external review pass, and both are now regression tests that fail without the fix.

Verified against a local two-node cluster: the full distributed suite passes (45 tests), and the duplicate mount is gone, with only the volume's owner creating one and the other node staying out entirely.

Two follow-ups fall out of this and are not in scope here: `schema.Required` isn't enforced on write, which is why the malformed lease was storable at all, and `disk_lease.node_id` is arguably redundant with the volume's own node and could be derived rather than stored.

Closes MIR-1469
