### PR TITLE
Fix dev-distributed rebuild failing on Text file busy

### DIFF
--- a/hack/dev-distributed
+++ b/hack/dev-distributed
@@ -46,13 +46,28 @@ bootstrap_peer() {
 setup_release_dir() {
   local peer="$1"
   echo "    Setting up release directory on $peer..."
-  peer_exec "$peer" bash -c "mkdir -p /var/lib/miren/release && \
-    cp bin/miren /var/lib/miren/release/ && \
-    cp /usr/local/bin/runc /var/lib/miren/release/ && \
-    cp /usr/local/bin/containerd-shim-runc-v2 /var/lib/miren/release/ && \
-    cp /usr/local/bin/containerd /var/lib/miren/release/ && \
-    cp /usr/local/bin/nerdctl /var/lib/miren/release/ && \
-    cp /usr/local/bin/ctr /var/lib/miren/release/"
+  # Install by rename rather than writing in place. On `rebuild` the peer is
+  # already up: containerd and its shim keep running across a coordinator
+  # restart, and copying onto a live executable fails with ETXTBSY ("Text file
+  # busy"), which used to make rebuild unusable and force a full down/up.
+  # Renaming over the path swaps the directory entry and leaves any running
+  # process on its old inode.
+  peer_exec "$peer" bash -c '
+    set -euo pipefail
+    dest=/var/lib/miren/release
+    mkdir -p "$dest"
+    install_bin() {
+      local src="$1" name
+      name=$(basename "$src")
+      cp -f "$src" "$dest/.$name.tmp"
+      chmod 0755 "$dest/.$name.tmp"
+      mv -f "$dest/.$name.tmp" "$dest/$name"
+    }
+    install_bin bin/miren
+    for b in runc containerd-shim-runc-v2 containerd nerdctl ctr; do
+      install_bin "/usr/local/bin/$b"
+    done
+  '
 }
 
 start_coordinator() {


### PR DESCRIPTION
`hack/dev-distributed rebuild` doesn't work. It dies partway through with `cp: cannot create regular file '/var/lib/miren/release/containerd-shim-runc-v2': Text file busy`, leaving the peers with the coordinator stopped and the new binaries half-installed.

The cause is that `setup_release_dir` copies onto its destinations in place. That's fine on `up`, where the peer was just created and nothing is running, but `rebuild` runs against a live peer, and stopping the coordinator doesn't stop containerd or its shim. `cp` truncates the destination to write it, and truncating a running executable is exactly what ETXTBSY means.

Copying to a temp file in the same directory and renaming over the target avoids it: rename swaps the directory entry and leaves the running process on its old inode. That's the standard way to replace a binary that's in use.

Verified by running `hack/dev-distributed rebuild` against live peers, which previously failed at this step and now completes with both the coordinator and runner coming back ready.

Found while chasing MIR-1469, where the only way to pick up new code in the peers was a full down/up.
