### PR TITLE
Only expose etcd off-host when mTLS is protecting it

### DIFF
--- a/components/etcd/args_test.go
+++ b/components/etcd/args_test.go
@@ -1,0 +1,133 @@
+package etcd
+
+import (
+	"slices"
+	"testing"
+)
+
+// flagValue returns the value following the named flag, or "" if the flag isn't
+// present or has no value after it.
+func flagValue(args []string, flag string) string {
+	i := slices.Index(args, flag)
+	if i == -1 || i+1 >= len(args) {
+		return ""
+	}
+	return args[i+1]
+}
+
+// TestEtcdArgsListeners pins down which etcd listeners are reachable off-box.
+//
+// Only the gRPC client port may bind to all interfaces, and only when TLS and
+// --client-cert-auth are covering it. The JSON gateway shares the same keyspace
+// but is not covered by --client-cert-auth, so exposing it bypasses the mTLS
+// that distributed runners set up (MIR-1481); the peer port carries plaintext
+// raft. Both stay on loopback.
+func TestEtcdArgsListeners(t *testing.T) {
+	baseConfig := EtcdConfig{
+		Name:           "miren-etcd",
+		DataDir:        etcdDataDir,
+		ClientPort:     defaultEtcdPort,
+		HTTPClientPort: defaultEtcdHTTPPort,
+		PeerPort:       defaultPeerPort,
+		ClusterState:   "new",
+	}
+
+	tests := []struct {
+		name           string
+		tls            *TLSConfig
+		wantClientURL  string
+		wantClientAuth bool
+	}{
+		{
+			name:           "plaintext",
+			tls:            nil,
+			wantClientURL:  "http://127.0.0.1:12379",
+			wantClientAuth: false,
+		},
+		{
+			name:           "mtls",
+			tls:            &TLSConfig{CertsDir: "/var/lib/miren/etcd-certs"},
+			wantClientURL:  "https://0.0.0.0:12379",
+			wantClientAuth: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := baseConfig
+			config.TLS = tt.tls
+
+			args := etcdArgs(config, computeTuning(8*gib, 0))
+
+			if got := flagValue(args, "--listen-client-urls"); got != tt.wantClientURL {
+				t.Errorf("--listen-client-urls = %q, want %q", got, tt.wantClientURL)
+			}
+
+			// These two must never leave the host, in either TLS mode.
+			if got := flagValue(args, "--listen-client-http-urls"); got != "http://127.0.0.1:12381" {
+				t.Errorf("--listen-client-http-urls = %q, want loopback: the JSON gateway serves the same keyspace and --client-cert-auth does not apply to it", got)
+			}
+			if got := flagValue(args, "--listen-peer-urls"); got != "http://127.0.0.1:12380" {
+				t.Errorf("--listen-peer-urls = %q, want loopback: raft peer traffic is plaintext", got)
+			}
+
+			if got := slices.Contains(args, "--client-cert-auth"); got != tt.wantClientAuth {
+				t.Errorf("--client-cert-auth present = %v, want %v", got, tt.wantClientAuth)
+			}
+
+			// Nothing in Miren speaks the JSON API, so it stays off entirely
+			// rather than merely being confined to loopback.
+			if !slices.Contains(args, "--enable-grpc-gateway=false") {
+				t.Error("--enable-grpc-gateway=false missing: the JSON gateway should be disabled, not just loopback-bound")
+			}
+		})
+	}
+}
+
+// TestEtcdArgsTLSFlags checks that TLS material is wired to the paths the certs
+// directory is mounted at in createContainer.
+func TestEtcdArgsTLSFlags(t *testing.T) {
+	config := EtcdConfig{
+		Name:           "miren-etcd",
+		DataDir:        etcdDataDir,
+		ClientPort:     defaultEtcdPort,
+		HTTPClientPort: defaultEtcdHTTPPort,
+		PeerPort:       defaultPeerPort,
+		ClusterState:   "new",
+		TLS:            &TLSConfig{CertsDir: "/var/lib/miren/etcd-certs"},
+	}
+
+	args := etcdArgs(config, computeTuning(8*gib, 0))
+
+	for flag, want := range map[string]string{
+		"--cert-file":       "/certs/server.crt",
+		"--key-file":        "/certs/server.key",
+		"--trusted-ca-file": "/certs/ca.crt",
+	} {
+		if got := flagValue(args, flag); got != want {
+			t.Errorf("%s = %q, want %q", flag, got, want)
+		}
+	}
+}
+
+// TestEtcdArgsInitialToken covers the optional flag so the append order in
+// etcdArgs can't silently drop it.
+func TestEtcdArgsInitialToken(t *testing.T) {
+	config := EtcdConfig{
+		Name:           "miren-etcd",
+		DataDir:        etcdDataDir,
+		ClientPort:     defaultEtcdPort,
+		HTTPClientPort: defaultEtcdHTTPPort,
+		PeerPort:       defaultPeerPort,
+		ClusterState:   "new",
+	}
+
+	if got := flagValue(etcdArgs(config, computeTuning(8*gib, 0)), "--initial-cluster-token"); got != "" {
+		t.Errorf("--initial-cluster-token = %q, want it absent when unset", got)
+	}
+
+	config.InitialToken = "miren-token"
+	if got := flagValue(etcdArgs(config, computeTuning(8*gib, 0)), "--initial-cluster-token"); got != "miren-token" {
+		t.Errorf("--initial-cluster-token = %q, want %q", got, "miren-token")
+	}
+}

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -30,7 +30,17 @@ const (
 	defaultEtcdHTTPPort = 12381             // Non-default port to avoid conflicts
 	defaultPeerPort     = 12380             // Non-default port to avoid conflicts
 	etcdStateFile       = "etcd-state.json" // Tracks container config state
+
+	// Bind addresses for etcd's listeners. Spelled out so that which listeners
+	// are reachable off the host is legible at a glance; see etcdArgs.
+	loopbackHost  = "127.0.0.1"
+	allInterfaces = "0.0.0.0"
 )
+
+// etcdURL formats one of etcd's listen or advertise URLs.
+func etcdURL(scheme, host string, port int) string {
+	return fmt.Sprintf("%s://%s:%d", scheme, host, port)
+}
 
 var (
 	etcdImage = imagerefs.Etcd
@@ -48,7 +58,9 @@ type etcdState struct {
 // (new env vars, different args, etc.) so that upgrades recreate the container.
 //
 // v2: memory auto-tuning — etcd flags/env are now scaled to system RAM.
-const currentConfigVersion = 2
+// v3: the JSON gateway and raft peer listeners moved to loopback. Without this
+// bump an upgraded cluster keeps its old container and stays bound to 0.0.0.0.
+const currentConfigVersion = 3
 
 // TLSConfig holds TLS certificate paths for etcd mTLS.
 // When configured, etcd will require client certificate authentication.
@@ -416,38 +428,61 @@ func (e *EtcdComponent) restartExistingContainer(ctx context.Context, container 
 	return nil
 }
 
-func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Image, config EtcdConfig, tuning etcdTuning) (containerd.Container, error) {
-	dataPath := filepath.Join(e.DataPath, "etcd")
-
-	// Determine URL scheme based on TLS config
-	scheme := "http"
+// etcdArgs builds the etcd command line. It's split out from createContainer so
+// the listener bindings can be asserted in a test without standing up a container.
+//
+// The rule is that nothing off the host may talk to etcd unless mTLS is
+// covering the conversation, which in practice means the gRPC client port
+// with distributed runners enabled. Everything else binds loopback:
+//
+//   - The gRPC client port opens up only when TLS is configured, since that's
+//     when runners dial it over the network and when --client-cert-auth is
+//     there to police it. Without TLS the server itself is the only caller
+//     and it connects to 127.0.0.1, so there's nothing to expose.
+//   - The HTTP client port. --client-cert-auth does not apply to it, so
+//     binding it off-box would hand out unauthenticated access to the whole
+//     keyspace, bypassing the mTLS set up for distributed runners. The flag
+//     is still set, because setting it is what makes --listen-client-urls
+//     serve gRPC alone and avoids the single-port multiplexing etcd warns
+//     about; it just isn't reachable off the host anymore.
+//   - The peer port carries plaintext raft. etcd's own default for it is
+//     loopback, we advertise localhost, and there is exactly one member. If
+//     etcd ever grows to multiple members this needs peer TLS (peer certs,
+//     which SetupEtcdTLS does not currently mint), not a wider bind.
+//
+// The JSON gateway is disabled outright on top of that. Nothing in Miren
+// speaks it, every internal caller goes through the etcd client on the gRPC
+// port, and etcdctl inside the etcd container covers ad hoc debugging. Health
+// and metrics are registered separately and are unaffected.
+func etcdArgs(config EtcdConfig, tuning etcdTuning) []string {
+	// Client traffic is TLS and reachable off-host only when mTLS is set up;
+	// everything else is plaintext and stays on loopback.
+	clientScheme, clientBind := "http", loopbackHost
 	if config.TLS != nil {
-		scheme = "https"
+		clientScheme, clientBind = "https", allInterfaces
 	}
 
-	e.Log.Info("etcd memory auto-tuning",
-		"system_ram_bytes", tuning.SystemRAMBytes,
-		"budget_bytes", tuning.BudgetBytes,
-		"quota_backend_bytes", tuning.QuotaBackendBytes,
-		"gomemlimit_bytes", tuning.GoMemLimitBytes,
-		"gogc", tuning.GOGC,
-		"auto_compaction_retention", tuning.AutoCompactionReten,
-		"snapshot_count", tuning.SnapshotCount,
-		"snapshot_catchup_entries", tuning.SnapshotCatchupEntries,
-		"max_concurrent_streams", tuning.MaxConcurrentStreams,
-		"compaction_batch_limit", tuning.CompactionBatchLimit)
+	clientURL := etcdURL(clientScheme, clientBind, config.ClientPort)
+	gatewayURL := etcdURL("http", loopbackHost, config.HTTPClientPort)
+	peerURL := etcdURL("http", loopbackHost, config.PeerPort)
+
+	// Advertised URLs name how to reach this member rather than what to bind,
+	// so they use localhost regardless of the bind address above.
+	advertiseClientURL := etcdURL(clientScheme, "localhost", config.ClientPort)
+	advertisePeerURL := etcdURL("http", "localhost", config.PeerPort)
 
 	args := []string{
 		"/usr/local/bin/etcd",
 		"--name", config.Name,
 		"--data-dir", config.DataDir,
-		"--listen-client-urls", fmt.Sprintf("%s://0.0.0.0:%d", scheme, config.ClientPort),
-		"--listen-client-http-urls", fmt.Sprintf("http://0.0.0.0:%d", config.HTTPClientPort),
-		"--advertise-client-urls", fmt.Sprintf("%s://localhost:%d", scheme, config.ClientPort),
-		"--listen-peer-urls", fmt.Sprintf("http://0.0.0.0:%d", config.PeerPort),
-		"--initial-advertise-peer-urls", fmt.Sprintf("http://localhost:%d", config.PeerPort),
-		"--initial-cluster", fmt.Sprintf("%s=http://localhost:%d", config.Name, config.PeerPort),
+		"--listen-client-urls", clientURL,
+		"--listen-client-http-urls", gatewayURL,
+		"--advertise-client-urls", advertiseClientURL,
+		"--listen-peer-urls", peerURL,
+		"--initial-advertise-peer-urls", advertisePeerURL,
+		"--initial-cluster", config.Name + "=" + advertisePeerURL,
 		"--initial-cluster-state", config.ClusterState,
+		"--enable-grpc-gateway=false",
 	}
 
 	args = append(args, tuning.args()...)
@@ -465,6 +500,26 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 			"--trusted-ca-file", "/certs/ca.crt",
 		)
 	}
+
+	return args
+}
+
+func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Image, config EtcdConfig, tuning etcdTuning) (containerd.Container, error) {
+	dataPath := filepath.Join(e.DataPath, "etcd")
+
+	e.Log.Info("etcd memory auto-tuning",
+		"system_ram_bytes", tuning.SystemRAMBytes,
+		"budget_bytes", tuning.BudgetBytes,
+		"quota_backend_bytes", tuning.QuotaBackendBytes,
+		"gomemlimit_bytes", tuning.GoMemLimitBytes,
+		"gogc", tuning.GOGC,
+		"auto_compaction_retention", tuning.AutoCompactionReten,
+		"snapshot_count", tuning.SnapshotCount,
+		"snapshot_catchup_entries", tuning.SnapshotCatchupEntries,
+		"max_concurrent_streams", tuning.MaxConcurrentStreams,
+		"compaction_batch_limit", tuning.CompactionBatchLimit)
+
+	args := etcdArgs(config, tuning)
 
 	// Build mounts list
 	mounts := []specs.Mount{

--- a/docs/docs/distributed-runners.md
+++ b/docs/docs/distributed-runners.md
@@ -73,6 +73,32 @@ miren runner join mren_...
 
 Joining registers the machine as a runner, exchanges the token for a client certificate, and writes a config file to `/var/lib/miren/runner/config.yaml`. Each runner gets a stable identity; if you ever need to re-add a machine, remove the old entry first (see [caveats](#things-to-know) below). Reach for [`runner join`](/command/runner-join) for flags like `--name` and `--labels`.
 
+Joining is only the first connection a runner makes. Once it's running it also
+talks to the coordinator's etcd, metrics, and log endpoints directly, so if
+there's a firewall between your machines it needs to allow rather more than
+8443. These are the defaults:
+
+| Port | Protocol | What it carries | Authentication |
+|------|----------|-----------------|----------------|
+| 8443 | TCP | Coordinator API, including join | Join token while enrolling, mTLS after |
+| 12379 | TCP | etcd, for Flannel subnet coordination | mTLS |
+| 8428 | TCP | VictoriaMetrics, for metrics the runner reports | none |
+| 9428 | TCP | VictoriaLogs, for logs the runner ships | none |
+| 8472 | UDP | Flannel overlay, with the default `vxlan` backend | none |
+
+:::warning[Observability ports are unauthenticated]
+VictoriaMetrics and VictoriaLogs have no authentication of their own, and
+neither does the default VXLAN overlay. Keep them on a private network between
+your nodes rather than exposing them broadly.
+:::
+
+The overlay carries sandbox traffic in the clear today, so treat the network
+between your nodes as part of your trust boundary. Its port also needs to be
+open between runners, not just from each runner to the coordinator, since
+sandboxes on different machines send traffic to each other node-to-node. The
+coordinator's ports are configurable; see the
+[server configuration reference](/server-config).
+
 ### 3. Start the runner
 
 For a quick trial, start the runner in the foreground:

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -132,9 +132,17 @@ Miren uses etcd as its entity store. In standalone mode, an embedded etcd server
 | `start_embedded` | bool | `true`\* | Start embedded etcd server | `MIREN_ETCD_START_EMBEDDED` | `--start-etcd` |
 | `client_port` | int | `12379` | Embedded etcd client port | `MIREN_ETCD_CLIENT_PORT` | `--etcd-client-port` |
 | `peer_port` | int | `12380` | Embedded etcd peer port | `MIREN_ETCD_PEER_PORT` | `--etcd-peer-port` |
-| `http_client_port` | int | `12381` | Embedded etcd HTTP client port | `MIREN_ETCD_HTTP_CLIENT_PORT` | `--etcd-http-client-port` |
+| `http_client_port` | int | `12381` | Embedded etcd HTTP client port (bound to loopback) | `MIREN_ETCD_HTTP_CLIENT_PORT` | `--etcd-http-client-port` |
 
 \* Defaults to `true` in standalone mode only.
+
+:::info[Embedded etcd is loopback-bound unless mTLS is on]
+`client_port` binds to all interfaces only when etcd mTLS is configured, which
+today means when distributed runners are enabled. Otherwise it binds
+`127.0.0.1`, as do `peer_port` and `http_client_port` in either case. etcd's
+JSON gateway is disabled outright; its health and metrics endpoints are
+unaffected.
+:::
 
 ## `[containerd]` — Containerd Settings {#containerd}
 


### PR DESCRIPTION
Turning on `distributedrunners` sets up mTLS for etcd, but that only ever covered the gRPC client port. `--listen-client-http-urls` was hardcoded to `0.0.0.0`, etcd doesn't apply `--client-cert-auth` to that listener, and both ports serve the same keyspace. The mTLS was real but bypassable by anyone who could reach the box.

The rule now is that nothing off the host talks to etcd unless mTLS is covering the conversation. The gRPC client port opens up only when TLS is configured; without it the server itself is the only caller and it already connects to `127.0.0.1`. The peer port binds loopback either way, since it carries plaintext raft and there's exactly one member. The JSON gateway is off entirely rather than merely confined, because nothing in Miren speaks it and `miren debug ctr -- tasks exec ... etcdctl` covers the debugging it was good for. Health and metrics live on separate handlers and are unaffected.

The `currentConfigVersion` bump is worth a second look. Container args are baked into the OCI spec, and for a cluster already on `distributedrunners` the TLS state doesn't change across an upgrade, so the version is the only thing that forces recreation. Without it every existing cluster keeps its old container and stays on `0.0.0.0` while looking like it got the fix.

Second commit is a docs gap found on the way through: the distributed runners guide says to make sure the runner can reach the coordinator on 8443 and stops there, but a runner also dials etcd, VictoriaMetrics and VictoriaLogs directly and carries sandbox traffic over VXLAN. Five ports, one of them UDP, and that guide is what a self-hosted operator uses to decide what to open.

Not here: any TLS story for the non-`distributedrunners` population. That's a shrinking group once the flag flips, and the cheap answer covers them anyway, since nobody off the host gets to talk to their etcd either.

Closes MIR-1481
