### PR TITLE
Run the distributed CI job when disk or runner code changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,16 @@ on:
     # Explicit list because naming `types` replaces the default set. `labeled`
     # is what lets the ci:distributed opt-in below take effect on an open PR;
     # the other three are the defaults we'd otherwise lose.
+    #
+    # A label change restarts the whole workflow, which looks wasteful enough
+    # to want gating the other jobs on `github.event.action != 'labeled'`.
+    # Don't. The concurrency group above cancels the run in flight, and a
+    # required status check resolves to the newest run of that name. A run
+    # that skipped lint/build/test would therefore replace real results with
+    # skipped ones, and a skipped check is generally treated as satisfying a
+    # required check. That trades one spare CI run for a PR that can merge
+    # without having been tested. Labels land on roughly 1 PR in 60 here, so
+    # the waste is theoretical and the hazard is not.
     types: [opened, synchronize, reopened, labeled]
   merge_group:
   workflow_call:
@@ -90,6 +100,51 @@ jobs:
 
     - name: Check go generate
       run: make generate-check
+
+  # Which parts of the tree a PR touches, for jobs that are too expensive to
+  # run on every PR but too important to leave to someone remembering a label.
+  # Only consulted for pull_request; other events don't gate on it at all.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      distributed: ${{ steps.filter.outputs.distributed }}
+    steps:
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      with:
+        persist-credentials: false
+        ref: ${{ inputs.ref }}
+        # Full history only when we actually diff against a base. Quoted so the
+        # false branch survives: 0 is falsy in a GitHub expression, so an
+        # unquoted `&& 0 ||` would always fall through to the other side.
+        fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+
+    - name: Detect distributed-relevant changes
+      id: filter
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        set -euo pipefail
+
+        # Non-PR events don't consult this output, so don't spend a diff on them.
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "distributed=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        changed=$(git diff --name-only "$BASE_SHA" HEAD)
+        echo "Changed files:"
+        echo "$changed"
+
+        # The code paths that can break the multi-node topology, plus this
+        # workflow itself so a change to the gating is exercised by the PR
+        # that makes it.
+        if echo "$changed" | grep -qE '^(controllers/disk/|components/diskio/|components/runner/|blackbox/|hack/dev-distributed|\.iso/peers\.yml|\.github/workflows/test\.yml)'; then
+          echo "distributed-relevant changes found"
+          echo "distributed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "no distributed-relevant changes"
+          echo "distributed=false" >> "$GITHUB_OUTPUT"
+        fi
 
   test-groups:
     runs-on: ubuntu-latest
@@ -415,13 +470,22 @@ jobs:
     # excluding 'pull_request' runs it there while skipping PRs. It would also
     # run in a merge queue if one were enabled ('merge_group').
     #
-    # Label a PR `ci:distributed` to opt into it before merging. Worth doing for
-    # anything touching disks, leases, or the runner: this job is the only place
-    # a second node exists, so a multi-node bug is invisible until it is already
-    # on main and blocking the release (MIR-1469).
+    # On a PR it runs when the diff touches code that can break the multi-node
+    # topology, or when someone labels the PR `ci:distributed` to ask for it
+    # explicitly. This job is the only place a second node exists, so a bug
+    # there is invisible until it is already on main blocking a release, which
+    # is exactly how MIR-1469 got in.
+    #
+    # `!cancelled()` rather than a plain condition: it keeps the non-PR clause
+    # authoritative even if the `changes` job fails. A failed dependency would
+    # otherwise skip this job on main and tags, quietly dropping the release
+    # coverage this whole gate exists to protect.
+    needs: [changes]
     if: >-
+      !cancelled() && (
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:distributed')
+      needs.changes.outputs.distributed == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:distributed') )
     runs-on: depot-ubuntu-latest
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -503,7 +567,7 @@ jobs:
   # that passes only when every matrix runner and blackbox tests succeed.
   test:
     if: always()
-    needs: [test-runner, blackbox-groups, test-blackbox, test-blackbox-pop, test-blackbox-distributed]
+    needs: [changes, test-runner, blackbox-groups, test-blackbox, test-blackbox-pop, test-blackbox-distributed]
     runs-on: ubuntu-latest
     steps:
     - name: Check results
@@ -513,8 +577,16 @@ jobs:
         echo "test-blackbox result: ${{ needs.test-blackbox.result }}"
         echo "test-blackbox-pop result: ${{ needs.test-blackbox-pop.result }}"
         echo "test-blackbox-distributed result: ${{ needs.test-blackbox-distributed.result }}"
+        echo "changes result: ${{ needs.changes.result }}"
 
         if [[ "${{ needs.test-runner.result }}" != "success" ]]; then
+          exit 1
+        fi
+        # changes decides whether the distributed job runs on a PR. If it
+        # fails, that job skips, and "skipped" is accepted below — so without
+        # this the gate could silently stop covering the very changes it
+        # exists to catch.
+        if [[ "${{ needs.changes.result }}" != "success" ]]; then
           exit 1
         fi
         # blackbox-groups builds the shard matrix. If it fails, the sharded


### PR DESCRIPTION
Follow-on to #983, which added the `ci:distributed` label. This is the other half.

The label works, but it only helps someone who already suspects they need the multi-node job. The person most likely to break that topology is the one who doesn't know the job exists, which is exactly how MIR-1469 reached main: green on every PR, red on main, and three consecutive merges unable to publish because the only job that boots a second node is skipped on `pull_request`.

So: a cheap `changes` job computes whether a PR's diff touches `controllers/disk/`, `components/diskio/`, `components/runner/`, `blackbox/`, the peer harness, or this workflow, and the distributed job runs when it does. The label stays as the manual override for what paths can't see, like a `pkg/` change that alters multi-node behaviour.

Most of the care here went into making sure this can only ever *add* coverage. A path filter can subtract, unlike a label, and "silently didn't run" is the failure mode the whole thing exists to prevent. `!cancelled()` keeps the non-PR clause authoritative even if `changes` fails, so a broken filter can't skip the job on main or tags. And `changes` is in the summary job's `needs`, so its failure fails the required `test` check rather than quietly letting a skip through.

## Why not native path filters

Worth writing down, since it's the obvious first question. GitHub's `paths:` filters are workflow-scoped, not job-scoped, so putting one on `test.yml` would gate the entire suite and a docs-only PR would run no tests at all. The real alternative is splitting the distributed job into its own path-filtered workflow, and that loses two things. `paths` filters the event, while the label is data on the event, so a `labeled` event on a PR that doesn't touch those paths gets filtered out before any condition is evaluated and the override silently stops working. And `release.yml` calls `test.yml` via `workflow_call` and gates the docker push and artifact upload on that whole call, so moving the job out means release has to call the second workflow too, or quietly lose the coverage. Given the bug we just fixed was "a job that didn't run where you assumed it did", a second place to remember seemed like the wrong trade.

## Testing

The filter deliberately includes `.github/workflows/test.yml`, so this PR exercises the job it's gating: `test-blackbox-distributed` should run here. The negative case, that an unrelated PR doesn't trigger it, isn't demonstrable from this PR and wants watching on the next docs-only change.

Closes MIR-1480
