### PR TITLE
Remove the stale VXLAN device when the overlay moves to WireGuard

### DIFF
--- a/.iso/Dockerfile
+++ b/.iso/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     inetutils-ping \
     iproute2 \
     iptables \
+    tcpdump \
     tmux \
     vim \
     netcat-openbsd \

--- a/.iso/peers.yml
+++ b/.iso/peers.yml
@@ -13,6 +13,12 @@ peers:
     environment:
       ROLE: coordinator
       MIREN_LABS: distributedrunners
+      # Dev runs WireGuard ahead of the shipped default (still vxlan) so the
+      # overlay-encryption blackbox test has something to assert against, and
+      # so the backend the clusters are migrating to is the one exercised
+      # every time anyone brings this environment up. Runners inherit it from
+      # the coordinator at join time.
+      MIREN_SERVER_NETWORK_BACKEND: wireguard
     ports:
       - "8443:8443"
 

--- a/blackbox/distributed_runner_test.go
+++ b/blackbox/distributed_runner_test.go
@@ -3,6 +3,8 @@
 package blackbox
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -282,5 +284,168 @@ func TestDistributedRunnerNodePort(t *testing.T) {
 				return true, ""
 			},
 		)
+	}
+}
+
+// peerIP returns a single IP from a peer, failing the test if the lookup
+// produces nothing usable.
+func peerIP(t *testing.T, m *harness.Miren, peer, cmd string) string {
+	t.Helper()
+
+	r := m.PeerExec(peer, "bash", "-c", cmd)
+	if !r.Success() {
+		t.Fatalf("failed to read IP on %s (exit %d): %s", peer, r.ExitCode, strings.TrimSpace(r.Stderr))
+	}
+
+	ip := strings.TrimSpace(r.Stdout)
+	if ip == "" {
+		t.Fatalf("got an empty IP from %s running %q", peer, cmd)
+	}
+	return ip
+}
+
+// startCapture runs tcpdump on an interface and blocks until it has attached,
+// so a probe sent immediately afterwards cannot slip past an unarmed capture.
+func startCapture(t *testing.T, m *harness.Miren, peer, iface, filter, outFile, pidFile string) {
+	t.Helper()
+
+	start := fmt.Sprintf(
+		"nohup tcpdump -i %s -A -s0 %s >%s 2>&1 </dev/null & echo $! >%s; disown",
+		iface, filter, outFile, pidFile)
+
+	r := m.PeerExec(peer, "bash", "-c", start)
+	if !r.Success() {
+		t.Fatalf("failed to start tcpdump on %s/%s: %s", peer, iface, strings.TrimSpace(r.Stderr))
+	}
+
+	t.Cleanup(func() {
+		m.PeerExec(peer, "bash", "-c",
+			fmt.Sprintf("kill $(cat %s) 2>/dev/null; rm -f %s %s", pidFile, pidFile, outFile))
+	})
+
+	harness.Poll(t, fmt.Sprintf("tcpdump listening on %s/%s", peer, iface), 30*time.Second, time.Second,
+		func() (bool, string) {
+			r := m.PeerExec(peer, "grep", "-q", "listening on", outFile)
+			if !r.Success() {
+				return false, "tcpdump has not attached yet"
+			}
+			return true, ""
+		},
+	)
+}
+
+// stopCapture terminates tcpdump and waits for it to exit. tcpdump block-buffers
+// its text output, so a capture file cannot be read meaningfully until the
+// process has flushed on the way out. Stopping first also sidesteps the ordering
+// between the two capture points: a packet reaches the overlay device before its
+// encrypted form leaves the physical one, so reading a live capture could check
+// the underlay before the frames we care about had been written.
+func stopCapture(t *testing.T, m *harness.Miren, peer, pidFile string) {
+	t.Helper()
+
+	m.PeerExec(peer, "bash", "-c", fmt.Sprintf("kill $(cat %s) 2>/dev/null", pidFile))
+
+	harness.Poll(t, fmt.Sprintf("tcpdump on %s exits", peer), 30*time.Second, time.Second,
+		func() (bool, string) {
+			r := m.PeerExec(peer, "bash", "-c",
+				fmt.Sprintf("kill -0 $(cat %s) 2>/dev/null && echo running || echo stopped", pidFile))
+			if strings.TrimSpace(r.Stdout) != "stopped" {
+				return false, "tcpdump is still running"
+			}
+			return true, ""
+		},
+	)
+}
+
+// TestDistributedOverlayEncryption sends a known marker between two nodes over
+// the sandbox overlay and asserts it cannot be read off the underlay.
+//
+// The marker is captured twice: on the overlay device, where it must appear,
+// and on the physical interface, where it must not. Requiring the overlay
+// capture to see it is what keeps this honest. Without that, a probe that
+// never left the host, a mistyped filter, or a capture that failed to attach
+// would all produce a clean underlay capture and a passing test.
+//
+// RFD-51 chose WireGuard precisely so that app-to-database traffic crossing
+// between hosts is not visible to anyone on the network. This test fails if a
+// cluster is running the plaintext VXLAN backend instead.
+func TestDistributedOverlayEncryption(t *testing.T) {
+	c := harness.NewCluster(t)
+	skipIfNotDistributed(t, c)
+	m := harness.NewMiren(t, c)
+
+	// Deliberately a failure rather than a skip. A cluster running the plaintext
+	// backend is the condition this test exists to catch, and a security check
+	// that goes quiet in exactly the case it was written for is worth less than
+	// no check at all.
+	if r := m.PeerExec("coordinator", "ip", "link", "show", "flannel-wg"); !r.Success() {
+		t.Fatal("coordinator has no wireguard device: the overlay is unencrypted")
+	}
+
+	const probePort = "39999"
+
+	var nonce [8]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		t.Fatalf("failed to generate probe marker: %v", err)
+	}
+	// Distinctive and unlikely to collide with anything else on the wire, so a
+	// hit in either capture is unambiguously our probe.
+	marker := "MIRENOVERLAYPROBE" + hex.EncodeToString(nonce[:])
+
+	runnerUnderlay := peerIP(t, m, "runner1", "hostname -I | awk '{print $1}'")
+	runnerOverlay := peerIP(t, m, "runner1", "ip -4 -o addr show flannel-wg | awk '{print $4}' | cut -d/ -f1")
+	t.Logf("runner underlay=%s overlay=%s", runnerUnderlay, runnerOverlay)
+
+	listener := fmt.Sprintf(
+		"nohup nc -l -p %s >/tmp/overlay-probe-in.txt 2>&1 </dev/null & echo $! >/tmp/overlay-probe.pid; disown",
+		probePort)
+	if r := m.PeerExec("runner1", "bash", "-c", listener); !r.Success() {
+		t.Fatalf("failed to start probe listener on runner1: %s", strings.TrimSpace(r.Stderr))
+	}
+	t.Cleanup(func() {
+		m.PeerExec("runner1", "bash", "-c",
+			"kill $(cat /tmp/overlay-probe.pid) 2>/dev/null; rm -f /tmp/overlay-probe.pid /tmp/overlay-probe-in.txt")
+	})
+
+	// Scope the underlay capture to the runner's real address so unrelated
+	// chatter on the peers network cannot muddy the result.
+	startCapture(t, m, "coordinator", "eth0", "host "+runnerUnderlay,
+		"/tmp/overlay-cap-underlay.txt", "/tmp/overlay-cap-underlay.pid")
+	startCapture(t, m, "coordinator", "flannel-wg", "",
+		"/tmp/overlay-cap-overlay.txt", "/tmp/overlay-cap-overlay.pid")
+
+	send := fmt.Sprintf("echo %s | nc -w 5 %s %s", marker, runnerOverlay, probePort)
+	if r := m.PeerExec("coordinator", "bash", "-c", send); !r.Success() {
+		t.Fatalf("failed to send probe across the overlay: %s", strings.TrimSpace(r.Stderr))
+	}
+
+	harness.Poll(t, "probe arrives on runner1", 30*time.Second, time.Second,
+		func() (bool, string) {
+			r := m.PeerExec("runner1", "grep", "-q", marker, "/tmp/overlay-probe-in.txt")
+			if !r.Success() {
+				return false, "runner has not received the probe yet"
+			}
+			return true, ""
+		},
+	)
+
+	stopCapture(t, m, "coordinator", "/tmp/overlay-cap-overlay.pid")
+	stopCapture(t, m, "coordinator", "/tmp/overlay-cap-underlay.pid")
+
+	// The control: the same marker must be readable where it is supposed to be
+	// readable. If this fails the probe never traversed the overlay, and the
+	// underlay assertion below would pass for the wrong reason.
+	if r := m.PeerExec("coordinator", "grep", "-q", marker, "/tmp/overlay-cap-overlay.txt"); !r.Success() {
+		t.Fatalf("marker %q never appeared on the overlay device, so this test cannot tell whether the underlay is encrypted", marker)
+	}
+
+	// A capture that saw nothing at all would also report zero matches.
+	size := m.PeerExec("coordinator", "bash", "-c", "wc -c < /tmp/overlay-cap-underlay.txt")
+	if strings.TrimSpace(size.Stdout) == "0" {
+		t.Fatal("underlay capture is empty, so the absence of the marker proves nothing")
+	}
+
+	if r := m.PeerExec("coordinator", "grep", "-q", marker, "/tmp/overlay-cap-underlay.txt"); r.Success() {
+		t.Fatalf("overlay traffic is readable on the underlay: found marker %q in the eth0 capture", marker)
 	}
 }

--- a/pkg/grunge/grunge.go
+++ b/pkg/grunge/grunge.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
@@ -12,7 +13,6 @@ import (
 	"path"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/flannel-io/flannel/pkg/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
@@ -21,8 +21,7 @@ import (
 	"github.com/flannel-io/flannel/pkg/subnet"
 	fetcd "github.com/flannel-io/flannel/pkg/subnet/etcd"
 	"github.com/flannel-io/flannel/pkg/trafficmngr/nftables"
-	mvccpb "go.etcd.io/etcd/api/v3/mvccpb"
-	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	"github.com/vishvananda/netlink"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go4.org/netipx"
 	"golang.org/x/sync/errgroup"
@@ -36,6 +35,28 @@ import (
 	_ "github.com/flannel-io/flannel/pkg/backend/vxlan"
 	_ "github.com/flannel-io/flannel/pkg/backend/wireguard"
 )
+
+// errNoBackend is returned rather than silently falling back to a default.
+// The backend decides whether sandbox traffic between hosts is encrypted, so
+// guessing here can hand an operator plaintext VXLAN on a cluster whose config
+// asked for WireGuard, with nothing in the logs to say so. Runners carry the
+// backend in the config written at join time; one that predates the field has
+// to re-join to pick it up.
+var errNoBackend = fmt.Errorf(
+	"no network backend configured: set server.network_backend on the coordinator, " +
+		"and re-join any runner whose config predates the setting")
+
+// staleBackendDevices lists, per backend, the interfaces left behind by the
+// other backends we support. Switching backends does not remove the previous
+// backend's device, and its per-lease routes (one /24 per peer) are more
+// specific than the new backend's route for the whole /16, so the kernel keeps
+// steering remote sandbox traffic into the old device. Leftover VXLAN is the
+// dangerous direction: the node reports WireGuard, logs that it is ignoring
+// non-WireGuard leases, and still ships that peer's traffic in the clear.
+var staleBackendDevices = map[string][]string{
+	"vxlan":     {"flannel-wg", "flannel-wg-v6"},
+	"wireguard": {"flannel.1"},
+}
 
 type Network struct {
 	NetworkOptions
@@ -112,16 +133,14 @@ func buildTLSConfigFromFiles(certFile, keyFile, caFile string) (*tls.Config, err
 }
 
 func (n *Network) SetupConfig(ctx context.Context, v4, v6 netip.Prefix) error {
+	if n.BackendType == "" {
+		return errNoBackend
+	}
+
 	var backend struct {
 		Type string
 	}
-
-	// Use configured backend type, defaulting to vxlan for backward compatibility
-	backendType := n.BackendType
-	if backendType == "" {
-		backendType = "vxlan"
-	}
-	backend.Type = backendType
+	backend.Type = n.BackendType
 
 	var config subnet.Config
 	config.EnableIPv4 = true
@@ -186,63 +205,44 @@ func (n *Network) Lease() *Lease {
 	return &Lease{n.lease}
 }
 
-func kvToIPLease(kv *mvccpb.KeyValue, ttl int64) (*lease.Lease, error) {
-	sn, tsn6 := subnet.ParseSubnetKey(string(kv.Key))
-	if sn == nil {
-		return nil, fmt.Errorf("failed to parse subnet key %s", kv.Key)
+// removeStaleBackendDevices deletes interfaces belonging to a backend other
+// than the one about to register. Deleting a link takes its routes with it.
+// A device we cannot remove is fatal rather than logged: continuing would mean
+// running as if encrypted while a stale VXLAN path is still winning the route
+// lookup, which is precisely the failure this is here to prevent.
+func (n *Network) removeStaleBackendDevices(backendType string) error {
+	for _, name := range staleBackendDevices[backendType] {
+		if err := n.removeDeviceIfPresent(name, backendType); err != nil {
+			return err
+		}
 	}
 
-	var sn6 ip.IP6Net
-	if tsn6 != nil {
-		sn6 = *tsn6
-	}
-
-	attrs := &lease.LeaseAttrs{}
-	if err := json.Unmarshal([]byte(kv.Value), attrs); err != nil {
-		return nil, err
-	}
-
-	exp := time.Now().Add(time.Duration(ttl) * time.Second)
-
-	lease := lease.Lease{
-		EnableIPv4: true,
-		EnableIPv6: !sn6.Empty(),
-		Subnet:     *sn,
-		IPv6Subnet: sn6,
-		Attrs:      *attrs,
-		Expiration: exp,
-		Asof:       kv.ModRevision,
-	}
-
-	return &lease, nil
+	return nil
 }
 
-func (n *Network) AllLeases(ctx context.Context) ([]lease.Lease, error) {
-	key := path.Join(n.EtcdPrefix, "subnets")
-	resp, err := n.ec.Get(ctx, key, clientv3.WithPrefix())
+// removeDeviceIfPresent deletes one interface, treating absence as success.
+func (n *Network) removeDeviceIfPresent(name, backendType string) error {
+	link, err := netlink.LinkByName(name)
 	if err != nil {
-		if err == rpctypes.ErrGRPCKeyNotFound {
-			// key not found: treat it as empty set
-			return []lease.Lease{}, nil
+		// Absent is the expected case and the whole point. Any other lookup
+		// failure means we cannot tell whether a stale device is there, which
+		// is not a question to answer optimistically.
+		var notFound netlink.LinkNotFoundError
+		if errors.As(err, &notFound) {
+			return nil
 		}
-		return nil, err
+
+		return fmt.Errorf("failed to look up %s while cleaning up after a previous backend: %w", name, err)
 	}
 
-	leases := []lease.Lease{}
-	for _, kv := range resp.Kvs {
-		ttlresp, err := n.ec.TimeToLive(ctx, clientv3.LeaseID(kv.Lease))
-		if err != nil {
-			continue
-		}
-		l, err := kvToIPLease(kv, ttlresp.TTL)
-		if err != nil {
-			continue
-		}
-
-		leases = append(leases, *l)
+	if err := netlink.LinkDel(link); err != nil {
+		return fmt.Errorf("failed to remove stale %s device left by a previous backend: %w", name, err)
 	}
 
-	return leases, nil
+	n.log.Info("removed stale network device from a previous backend",
+		"device", name, "backend", backendType)
+
+	return nil
 }
 
 func (n *Network) Start(ctx context.Context, eg *errgroup.Group) error {
@@ -293,10 +293,13 @@ func (n *Network) Start(ctx context.Context, eg *errgroup.Group) error {
 
 	bm := backend.NewManager(ctx, sm, extIface)
 
-	// Use configured backend type, defaulting to vxlan for backward compatibility
+	if n.BackendType == "" {
+		return errNoBackend
+	}
 	backendType := n.BackendType
-	if backendType == "" {
-		backendType = "vxlan"
+
+	if err := n.removeStaleBackendDevices(backendType); err != nil {
+		return err
 	}
 
 	be, err := bm.GetBackend(backendType)

--- a/pkg/grunge/grunge_test.go
+++ b/pkg/grunge/grunge_test.go
@@ -1,0 +1,92 @@
+package grunge
+
+import (
+	"context"
+	"log/slog"
+	"net/netip"
+	"slices"
+	"testing"
+)
+
+// An unset backend used to fall through to vxlan. Callers reach SetupConfig
+// with whatever their config produced, so a runner joined before the field
+// existed would quietly publish a plaintext overlay to the whole cluster.
+func TestSetupConfigRejectsEmptyBackend(t *testing.T) {
+	n := &Network{log: slog.Default()}
+
+	err := n.SetupConfig(context.Background(),
+		netip.MustParsePrefix("10.8.0.0/16"),
+		netip.MustParsePrefix("fd47:ace::/64"),
+	)
+	if err == nil {
+		t.Fatal("expected an error for an unconfigured backend, got nil")
+	}
+	if err != errNoBackend {
+		t.Fatalf("expected errNoBackend, got %v", err)
+	}
+}
+
+// Each backend must clean up after the others without listing anything it
+// creates itself. Getting this wrong deletes the device we are about to
+// register on, so it is worth pinning rather than trusting the table by eye.
+func TestStaleBackendDevicesExcludeOwnDevices(t *testing.T) {
+	owned := map[string][]string{
+		"vxlan":     {"flannel.1"},
+		"wireguard": {"flannel-wg", "flannel-wg-v6"},
+	}
+
+	for backend, ours := range owned {
+		stale, ok := staleBackendDevices[backend]
+		if !ok {
+			t.Errorf("backend %q has no stale device list", backend)
+			continue
+		}
+
+		for _, device := range stale {
+			for _, own := range ours {
+				if device == own {
+					t.Errorf("backend %q would delete its own device %q", backend, device)
+				}
+			}
+		}
+	}
+
+	// Every device one backend owns should be cleaned up by the other, or
+	// switching backends leaves a more specific route behind.
+	for backend, ours := range owned {
+		for other, stale := range staleBackendDevices {
+			if other == backend {
+				continue
+			}
+			for _, own := range ours {
+				if !slices.Contains(stale, own) {
+					t.Errorf("backend %q does not clean up %q left by %q", other, own, backend)
+				}
+			}
+		}
+	}
+}
+
+// An unrecognized backend has nothing registered to clean up, and must not be
+// treated as a reason to start deleting interfaces.
+func TestRemoveStaleBackendDevicesIgnoresUnknownBackend(t *testing.T) {
+	n := &Network{log: slog.Default()}
+
+	if err := n.removeStaleBackendDevices("hostgw"); err != nil {
+		t.Fatalf("expected no error for an unknown backend, got %v", err)
+	}
+}
+
+// A device that isn't there is the ordinary case on a node that never ran the
+// other backend, so it has to read as success rather than as a lookup failure.
+// This covers the netlink lookup for real; the unknown-backend case above
+// never reaches it, since that backend has no devices registered to check.
+func TestRemoveDeviceIfPresentTreatsAbsenceAsSuccess(t *testing.T) {
+	n := &Network{log: slog.Default()}
+
+	// Deliberately a name nothing will have, so the test can exercise the
+	// lookup without any chance of deleting a real interface.
+	if err := n.removeDeviceIfPresent("miren-absent-dev0", "wireguard"); err != nil {
+		t.Fatalf("expected absence to be treated as success, got %v", err)
+	}
+}


### PR DESCRIPTION
Miren's distributed runners share a flat overlay for sandbox traffic. RFD-51 specified WireGuard for it and rejected VXLAN by name, since that traffic includes app-to-database calls whenever a workload runs off the coordinator. The overlay currently defaults to VXLAN, which is unencrypted.

**The default is still VXLAN here, and WireGuard is where this is heading.** Moving it is deliberately a separate step, because existing clusters need the WireGuard port opened and their backend pinned explicitly before the default shifts under them. Nodes pick up new releases on independent schedules, and a cluster split across two backends partitions rather than degrading, since each side ignores the other's flannel leases. So the order is pin, migrate, then change the default. This PR is the groundwork for that: the bug that would have made the migration silently unsafe, and a test that can tell whether an overlay is actually encrypted.

**The bug.** Rehearsing the migration in `dev-distributed` turned up something I didn't expect. Flannel's VXLAN backend creates `flannel.1`, its WireGuard backend creates `flannel-wg`, and switching between them doesn't remove the old device. Flannel's per-peer /24 routes are more specific than the new backend's /16, so the kernel keeps picking the stale one: `ip route get` on a remote sandbox address chose `flannel.1`, with the VXLAN FDB still pointing at the other node. The node comes up reporting WireGuard, logs that it's ignoring non-WireGuard leases, and ships that peer's sandbox traffic in the clear. An ordinary service restart is enough to cause it. So the old backend's device is now removed before the new one registers, and failing to remove it is fatal rather than logged.

**The test.** A random marker goes between two nodes and is captured twice: it has to be readable on `flannel-wg` and absent from the physical interface. The overlay capture is the control, without which a probe that never left the host would produce a clean underlay capture and a green test. It fails rather than skips when there's no WireGuard device, which I checked by cycling the dev environment to VXLAN and watching it fail. Dev peers now run WireGuard so it has something to assert against.

Smaller cleanups: grunge's two silent fallbacks to `vxlan` are gone, so a setting that decides whether traffic is encrypted can't be guessed at (a runner config predating the field now errors instead, and needs a re-join). `AllLeases()` is deleted. RFD-51 flagged it as the thing still needing wiring up, but flannel programs its own peers and routes, so it never had a caller.

Refs MIR-1482
