### PR TITLE
Keep tar extraction inside its destination

### DIFF
--- a/cli/commands/download_release.go
+++ b/cli/commands/download_release.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"miren.dev/runtime/pkg/tarx"
 	"miren.dev/runtime/version"
 )
 
@@ -243,12 +244,9 @@ func extractTarGz(src, dest string) error {
 			return err
 		}
 
-		// Construct the file path
-		target := filepath.Join(dest, header.Name)
-
-		// Check for directory traversal
-		if !strings.HasPrefix(filepath.Clean(target), filepath.Clean(dest)) {
-			return fmt.Errorf("tar entry %s tries to escape destination directory", header.Name)
+		target, err := tarx.SafeWritePath(dest, header.Name)
+		if err != nil {
+			return fmt.Errorf("invalid tar entry %q: %w", header.Name, err)
 		}
 
 		switch header.Typeflag {
@@ -275,11 +273,8 @@ func extractTarGz(src, dest string) error {
 				return err
 			}
 			outFile.Close()
-		case tar.TypeSymlink:
-			// Create symlink
-			if err := os.Symlink(header.Linkname, target); err != nil {
-				return err
-			}
+		case tar.TypeSymlink, tar.TypeLink:
+			return fmt.Errorf("tar entry %q uses an unsupported link type", header.Name)
 		}
 	}
 

--- a/cli/commands/download_release.go
+++ b/cli/commands/download_release.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -68,13 +69,17 @@ func PerformDownloadRelease(ctx *Context, opts DownloadReleaseOptions) error {
 	}
 
 	// Check if release directory exists
-	if _, err := os.Stat(releaseDir); err == nil && !opts.Force {
-		return fmt.Errorf("release directory already exists at %s (use -f to force)", releaseDir)
+	if _, err := os.Lstat(releaseDir); err == nil {
+		if !opts.Force {
+			return fmt.Errorf("release directory already exists at %s (use -f to force)", releaseDir)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to inspect release directory: %w", err)
 	}
 
-	// Create release directory
-	if err := os.MkdirAll(releaseDir, 0755); err != nil {
-		return fmt.Errorf("failed to create release directory: %w", err)
+	releaseParent := filepath.Dir(filepath.Clean(releaseDir))
+	if err := os.MkdirAll(releaseParent, 0755); err != nil {
+		return fmt.Errorf("failed to create release parent directory: %w", err)
 	}
 
 	ctx.Log.Info("downloading release", "branch", opts.Branch, "arch", arch, "url", baseURL)
@@ -90,14 +95,12 @@ func PerformDownloadRelease(ctx *Context, opts DownloadReleaseOptions) error {
 	ctx.Log.Info("downloading checksum", "url", shaURL)
 	shaPath := filepath.Join(tempDir, "release.tar.gz.sha256")
 	if err := downloadFile(shaPath, shaURL); err != nil {
-		os.RemoveAll(releaseDir)
 		return fmt.Errorf("failed to download checksum from %s: %w", shaURL, err)
 	}
 
 	// Read expected checksum
 	shaData, err := os.ReadFile(shaPath)
 	if err != nil {
-		os.RemoveAll(releaseDir)
 		return fmt.Errorf("failed to read checksum file: %w", err)
 	}
 	expectedSum := strings.TrimSpace(strings.Split(string(shaData), " ")[0])
@@ -107,7 +110,6 @@ func PerformDownloadRelease(ctx *Context, opts DownloadReleaseOptions) error {
 	tarPath := filepath.Join(tempDir, "release.tar.gz")
 	fmt.Printf("Downloading from %s\n", baseURL)
 	if err := downloadFile(tarPath, baseURL); err != nil {
-		os.RemoveAll(releaseDir)
 		return fmt.Errorf("failed to download release: %w", err)
 	}
 
@@ -115,32 +117,94 @@ func PerformDownloadRelease(ctx *Context, opts DownloadReleaseOptions) error {
 	ctx.Log.Info("verifying checksum")
 	actualSum, err := calculateSHA256(tarPath)
 	if err != nil {
-		os.RemoveAll(releaseDir)
 		return fmt.Errorf("failed to calculate checksum: %w", err)
 	}
 
 	if actualSum != expectedSum {
-		os.RemoveAll(releaseDir)
 		return fmt.Errorf("checksum mismatch: expected %s, got %s", expectedSum, actualSum)
 	}
 
-	// Extract tarball
-	ctx.Log.Info("extracting release", "destination", releaseDir)
-	if err := extractTarGz(tarPath, releaseDir); err != nil {
-		os.RemoveAll(releaseDir)
+	stagingDir, err := os.MkdirTemp(releaseParent, "."+filepath.Base(releaseDir)+"-staging-*")
+	if err != nil {
+		return fmt.Errorf("failed to create release staging directory: %w", err)
+	}
+	defer os.RemoveAll(stagingDir)
+	if err := os.Chmod(stagingDir, 0755); err != nil {
+		return fmt.Errorf("failed to set release staging permissions: %w", err)
+	}
+
+	ctx.Log.Info("extracting release", "destination", stagingDir)
+	if err := extractTarGz(tarPath, stagingDir); err != nil {
 		return fmt.Errorf("failed to extract release: %w", err)
 	}
 
-	cmd := exec.Command(filepath.Join(releaseDir, "miren"), "version")
-	out, err := cmd.Output()
+	versionCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	out, err := releaseBinaryVersion(versionCtx, stagingDir)
+	cancel()
 	if err != nil {
-		return fmt.Errorf("failed to run release binary: %w", err)
+		return err
+	}
+
+	backupDir, err := promoteReleaseDir(stagingDir, releaseDir, opts.Force)
+	if err != nil {
+		if backupDir != "" {
+			return fmt.Errorf("failed to install release; previous release preserved at %s: %w", backupDir, err)
+		}
+		return fmt.Errorf("failed to install release: %w", err)
+	}
+	if backupDir != "" {
+		if err := os.RemoveAll(backupDir); err != nil {
+			ctx.Log.Warn("failed to remove previous release backup", "path", backupDir, "error", err)
+		}
 	}
 
 	ctx.Log.Info("release binary version", "version", strings.TrimSpace(string(out)))
 
 	ctx.Log.Info("release downloaded successfully", "path", releaseDir)
 	return nil
+}
+
+func releaseBinaryVersion(ctx context.Context, releaseDir string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, filepath.Join(releaseDir, "miren"), "version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("failed to run release binary: %w (output: %s)", ctxErr, strings.TrimSpace(string(out)))
+		}
+		return nil, fmt.Errorf("failed to run release binary: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+func promoteReleaseDir(stagingDir, releaseDir string, replaceExisting bool) (string, error) {
+	if _, err := os.Lstat(releaseDir); os.IsNotExist(err) {
+		return "", os.Rename(stagingDir, releaseDir)
+	} else if err != nil {
+		return "", err
+	}
+	if !replaceExisting {
+		return "", fmt.Errorf("release directory already exists at %s", releaseDir)
+	}
+
+	backupDir, err := os.MkdirTemp(filepath.Dir(filepath.Clean(releaseDir)), "."+filepath.Base(releaseDir)+"-previous-*")
+	if err != nil {
+		return "", err
+	}
+	if err := os.Remove(backupDir); err != nil {
+		return "", err
+	}
+
+	if err := os.Rename(releaseDir, backupDir); err != nil {
+		return "", err
+	}
+	if err := os.Rename(stagingDir, releaseDir); err != nil {
+		if rollbackErr := os.Rename(backupDir, releaseDir); rollbackErr != nil {
+			return backupDir, fmt.Errorf("promoting staged release: %v (rollback failed: %w)", err, rollbackErr)
+		}
+		return "", fmt.Errorf("promoting staged release: %w", err)
+	}
+
+	return backupDir, nil
 }
 
 // DownloadRelease is the CLI command handler for downloading a release

--- a/cli/commands/download_release_test.go
+++ b/cli/commands/download_release_test.go
@@ -1,0 +1,154 @@
+package commands
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type releaseTarEntry struct {
+	header  tar.Header
+	content []byte
+}
+
+func writeReleaseTar(t *testing.T, entries []releaseTarEntry) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "release.tar.gz")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+
+	gw := gzip.NewWriter(file)
+	tw := tar.NewWriter(gw)
+	for _, entry := range entries {
+		header := entry.header
+		header.Size = int64(len(entry.content))
+		require.NoError(t, tw.WriteHeader(&header))
+		if len(entry.content) > 0 {
+			_, err := tw.Write(entry.content)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	require.NoError(t, file.Close())
+
+	return path
+}
+
+func TestExtractTarGzRejectsLinks(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeflag byte
+		linkname string
+	}{
+		{
+			name:     "escaping symlink",
+			typeflag: tar.TypeSymlink,
+			linkname: "..",
+		},
+		{
+			name:     "internal symlink",
+			typeflag: tar.TypeSymlink,
+			linkname: "versions/v1",
+		},
+		{
+			name:     "hard link",
+			typeflag: tar.TypeLink,
+			linkname: "miren",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			archive := writeReleaseTar(t, []releaseTarEntry{
+				{
+					header: tar.Header{
+						Name:     "link",
+						Typeflag: tt.typeflag,
+						Mode:     0777,
+						Linkname: tt.linkname,
+					},
+				},
+			})
+
+			err := extractTarGz(archive, t.TempDir())
+			require.ErrorContains(t, err, "unsupported link type")
+		})
+	}
+}
+
+func TestExtractTarGzRejectsPreExistingSymlinkTraversal(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "dest")
+	outside := filepath.Join(parent, "outside")
+	require.NoError(t, os.Mkdir(dest, 0755))
+	require.NoError(t, os.Mkdir(outside, 0755))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dest, "escape")))
+
+	archive := writeReleaseTar(t, []releaseTarEntry{
+		{
+			header: tar.Header{
+				Name:     "escape/file",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+			content: []byte("escaped"),
+		},
+	})
+
+	err := extractTarGz(archive, dest)
+	require.ErrorContains(t, err, "traverses symlink")
+	_, err = os.Stat(filepath.Join(outside, "file"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestExtractTarGzRejectsSymlinkRoot(t *testing.T) {
+	parent := t.TempDir()
+	outside := filepath.Join(parent, "outside")
+	dest := filepath.Join(parent, "dest")
+	require.NoError(t, os.Mkdir(outside, 0755))
+	require.NoError(t, os.Symlink(outside, dest))
+
+	archive := writeReleaseTar(t, []releaseTarEntry{
+		{
+			header: tar.Header{
+				Name:     "file",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+			content: []byte("escaped"),
+		},
+	})
+
+	err := extractTarGz(archive, dest)
+	require.ErrorContains(t, err, "archive root is a symlink")
+	_, err = os.Stat(filepath.Join(outside, "file"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestExtractTarGzRejectsSiblingPrefixTraversal(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "dest")
+	require.NoError(t, os.Mkdir(dest, 0755))
+
+	archive := writeReleaseTar(t, []releaseTarEntry{
+		{
+			header: tar.Header{
+				Name:     "../dest-evil/outside",
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+			},
+			content: []byte("escaped"),
+		},
+	})
+
+	err := extractTarGz(archive, dest)
+	require.ErrorContains(t, err, "invalid tar entry")
+	_, err = os.Stat(filepath.Join(parent, "dest-evil", "outside"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/cli/commands/download_release_test.go
+++ b/cli/commands/download_release_test.go
@@ -3,9 +3,11 @@ package commands
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -151,4 +153,106 @@ func TestExtractTarGzRejectsSiblingPrefixTraversal(t *testing.T) {
 	require.ErrorContains(t, err, "invalid tar entry")
 	_, err = os.Stat(filepath.Join(parent, "dest-evil", "outside"))
 	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestReleaseBinaryVersion(t *testing.T) {
+	writeBinary := func(t *testing.T, content string) string {
+		t.Helper()
+
+		releaseDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(releaseDir, "miren"), []byte(content), 0755))
+		return releaseDir
+	}
+
+	t.Run("returns version output", func(t *testing.T) {
+		releaseDir := writeBinary(t, "#!/bin/sh\necho v1.2.3\n")
+
+		out, err := releaseBinaryVersion(context.Background(), releaseDir)
+		require.NoError(t, err)
+		require.Equal(t, "v1.2.3\n", string(out))
+	})
+
+	t.Run("includes stderr on failure", func(t *testing.T) {
+		releaseDir := writeBinary(t, "#!/bin/sh\necho broken release >&2\nexit 1\n")
+
+		_, err := releaseBinaryVersion(context.Background(), releaseDir)
+		require.ErrorContains(t, err, "broken release")
+	})
+
+	t.Run("honors context deadline", func(t *testing.T) {
+		releaseDir := writeBinary(t, "#!/bin/sh\nexec sleep 5\n")
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		_, err := releaseBinaryVersion(ctx, releaseDir)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+}
+
+func TestPromoteReleaseDir(t *testing.T) {
+	writeMarker := func(t *testing.T, dir, content string) {
+		t.Helper()
+		require.NoError(t, os.Mkdir(dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "marker"), []byte(content), 0644))
+	}
+
+	t.Run("installs a new release", func(t *testing.T) {
+		parent := t.TempDir()
+		staging := filepath.Join(parent, "staging")
+		release := filepath.Join(parent, "release")
+		writeMarker(t, staging, "new")
+
+		backup, err := promoteReleaseDir(staging, release, false)
+		require.NoError(t, err)
+		require.Empty(t, backup)
+		content, err := os.ReadFile(filepath.Join(release, "marker"))
+		require.NoError(t, err)
+		require.Equal(t, []byte("new"), content)
+	})
+
+	t.Run("replaces an existing release and keeps a backup", func(t *testing.T) {
+		parent := t.TempDir()
+		staging := filepath.Join(parent, "staging")
+		release := filepath.Join(parent, "release")
+		writeMarker(t, staging, "new")
+		writeMarker(t, release, "old")
+
+		backup, err := promoteReleaseDir(staging, release, true)
+		require.NoError(t, err)
+		require.NotEmpty(t, backup)
+		content, err := os.ReadFile(filepath.Join(release, "marker"))
+		require.NoError(t, err)
+		require.Equal(t, []byte("new"), content)
+		content, err = os.ReadFile(filepath.Join(backup, "marker"))
+		require.NoError(t, err)
+		require.Equal(t, []byte("old"), content)
+	})
+
+	t.Run("does not replace without force", func(t *testing.T) {
+		parent := t.TempDir()
+		staging := filepath.Join(parent, "staging")
+		release := filepath.Join(parent, "release")
+		writeMarker(t, staging, "new")
+		writeMarker(t, release, "old")
+
+		_, err := promoteReleaseDir(staging, release, false)
+		require.ErrorContains(t, err, "already exists")
+		content, err := os.ReadFile(filepath.Join(release, "marker"))
+		require.NoError(t, err)
+		require.Equal(t, []byte("old"), content)
+	})
+
+	t.Run("restores the previous release when promotion fails", func(t *testing.T) {
+		parent := t.TempDir()
+		staging := filepath.Join(parent, "missing-staging")
+		release := filepath.Join(parent, "release")
+		writeMarker(t, release, "old")
+
+		backup, err := promoteReleaseDir(staging, release, true)
+		require.ErrorContains(t, err, "promoting staged release")
+		require.Empty(t, backup)
+		content, err := os.ReadFile(filepath.Join(release, "marker"))
+		require.NoError(t, err)
+		require.Equal(t, []byte("old"), content)
+	})
 }

--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -386,6 +386,67 @@ func (cr *countingReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
+// SafePath joins an untrusted archive path to root after verifying that the
+// result remains within root.
+func SafePath(root, name string) (string, error) {
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("archive path is absolute: %q", name)
+	}
+
+	target := filepath.Join(root, filepath.FromSlash(name))
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", fmt.Errorf("resolving archive path %q: %w", name, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("archive path escapes destination directory: %q", name)
+	}
+
+	return target, nil
+}
+
+// SafeWritePath validates an archive path and rejects existing symlinks in the
+// destination path so extraction cannot write through them.
+func SafeWritePath(root, name string) (string, error) {
+	rootInfo, err := os.Lstat(filepath.Clean(root))
+	if err != nil {
+		return "", fmt.Errorf("inspecting archive root: %w", err)
+	}
+	if rootInfo.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("archive root is a symlink: %q", root)
+	}
+
+	target, err := SafePath(root, name)
+	if err != nil {
+		return "", err
+	}
+
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", fmt.Errorf("resolving archive path %q: %w", name, err)
+	}
+
+	current := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "." || part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("inspecting archive path %q: %w", name, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("archive path traverses symlink: %q", name)
+		}
+	}
+
+	return target, nil
+}
+
 func TarFS(r io.Reader, dir string) (fsutil.FS, error) {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
@@ -403,7 +464,10 @@ func TarFS(r io.Reader, dir string) (fsutil.FS, error) {
 			return nil, err
 		}
 
-		path := filepath.Join(dir, th.Name)
+		path, err := SafeWritePath(dir, th.Name)
+		if err != nil {
+			return nil, err
+		}
 		if th.Typeflag == tar.TypeDir {
 			if err := os.Mkdir(path, 0755); err != nil && !os.IsExist(err) {
 				return nil, err

--- a/pkg/tarx/tarx_test.go
+++ b/pkg/tarx/tarx_test.go
@@ -617,6 +617,108 @@ func TestTarFS_PreExistingDirectory(t *testing.T) {
 	require.Equal(t, string(content), string(got))
 }
 
+func TestTarFSRejectsEscapingPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerName  func(parent string) string
+		outsidePath func(parent string) string
+	}{
+		{
+			name: "parent traversal",
+			headerName: func(string) string {
+				return "../outside"
+			},
+			outsidePath: func(parent string) string {
+				return filepath.Join(parent, "outside")
+			},
+		},
+		{
+			name: "embedded traversal",
+			headerName: func(string) string {
+				return "nested/../../outside"
+			},
+			outsidePath: func(parent string) string {
+				return filepath.Join(parent, "outside")
+			},
+		},
+		{
+			name: "sibling prefix",
+			headerName: func(string) string {
+				return "../dest-evil/outside"
+			},
+			outsidePath: func(parent string) string {
+				return filepath.Join(parent, "dest-evil", "outside")
+			},
+		},
+		{
+			name: "absolute path",
+			headerName: func(parent string) string {
+				return filepath.Join(parent, "outside")
+			},
+			outsidePath: func(parent string) string {
+				return filepath.Join(parent, "outside")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := t.TempDir()
+			dest := filepath.Join(parent, "dest")
+			require.NoError(t, os.Mkdir(dest, 0755))
+
+			content := []byte("escaped")
+			var buf bytes.Buffer
+			gw := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gw)
+			require.NoError(t, tw.WriteHeader(&tar.Header{
+				Name:     tt.headerName(parent),
+				Typeflag: tar.TypeReg,
+				Mode:     0644,
+				Size:     int64(len(content)),
+			}))
+			_, err := tw.Write(content)
+			require.NoError(t, err)
+			require.NoError(t, tw.Close())
+			require.NoError(t, gw.Close())
+
+			_, err = TarFS(&buf, dest)
+			require.ErrorContains(t, err, "archive path")
+			_, err = os.Stat(tt.outsidePath(parent))
+			require.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestTarFSRejectsPreExistingSymlinkTraversal(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "dest")
+	outside := filepath.Join(parent, "outside")
+	require.NoError(t, os.Mkdir(dest, 0755))
+	require.NoError(t, os.Mkdir(outside, 0755))
+	require.NoError(t, os.Symlink(outside, filepath.Join(dest, "escape")))
+
+	content := []byte("escaped")
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "escape/file",
+		Typeflag: tar.TypeReg,
+		Mode:     0644,
+		Size:     int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	_, err = TarFS(&buf, dest)
+	require.ErrorContains(t, err, "traverses symlink")
+	_, err = os.Stat(filepath.Join(outside, "file"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestMakeTarWithIncludePatterns(t *testing.T) {
 	// Create temporary directory
 	tmpDir, err := os.MkdirTemp("", "tarx-test-include-")


### PR DESCRIPTION
Build contexts reach `TarFS` before BuildKit gets a chance to isolate them, but the extractor trusted every archive entry name. The release downloader did check entry paths, though its prefix comparison had boundary gaps and archive symlinks could still point outside the release directory.

Both extraction paths now share component-aware containment checks and refuse to write through existing symlink components, including a symlinked extraction root. Release artifacts are assembled from copied binaries and do not need links, so the downloader rejects symlink and hard-link entries outright instead of attempting to reproduce attacker-controlled link graphs.

`--force` now builds the replacement in a sibling staging directory and verifies its binary before touching the current release. Installation moves the old directory aside, promotes staging, and rolls back if promotion fails, so a bad download does not destroy the last working release.

Closes MIR-1475