### PR TITLE
Make WireGuard the only overlay backend

### DIFF
--- a/.iso/peers.yml
+++ b/.iso/peers.yml
@@ -13,12 +13,6 @@ peers:
     environment:
       ROLE: coordinator
       MIREN_LABS: distributedrunners
-      # Dev runs WireGuard ahead of the shipped default (still vxlan) so the
-      # overlay-encryption blackbox test has something to assert against, and
-      # so the backend the clusters are migrating to is the one exercised
-      # every time anyone brings this environment up. Runners inherit it from
-      # the coordinator at join time.
-      MIREN_SERVER_NETWORK_BACKEND: wireguard
     ports:
       - "8443:8443"
 

--- a/api/runner/rpc.yml
+++ b/api/runner/rpc.yml
@@ -91,7 +91,7 @@ interfaces:
             doc: etcd prefix for Flannel network
           - name: network_backend
             type: string
-            doc: Network backend type (vxlan or wireguard)
+            doc: Network backend type, retained for compatibility with older runners
           - name: victoriametrics_address
             type: string
             doc: Address of the VictoriaMetrics instance for metrics ingestion

--- a/blackbox/distributed_runner_test.go
+++ b/blackbox/distributed_runner_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -367,8 +368,8 @@ func stopCapture(t *testing.T, m *harness.Miren, peer, pidFile string) {
 // would all produce a clean underlay capture and a passing test.
 //
 // RFD-51 chose WireGuard precisely so that app-to-database traffic crossing
-// between hosts is not visible to anyone on the network. This test fails if a
-// cluster is running the plaintext VXLAN backend instead.
+// between hosts is not visible to anyone on the network. This also catches a
+// stale VXLAN route that survived an upgrade and kept carrying traffic.
 func TestDistributedOverlayEncryption(t *testing.T) {
 	c := harness.NewCluster(t)
 	skipIfNotDistributed(t, c)
@@ -390,29 +391,40 @@ func TestDistributedOverlayEncryption(t *testing.T) {
 	}
 	// Distinctive and unlikely to collide with anything else on the wire, so a
 	// hit in either capture is unambiguously our probe.
-	marker := "MIRENOVERLAYPROBE" + hex.EncodeToString(nonce[:])
+	suffix := hex.EncodeToString(nonce[:])
+	marker := "MIRENOVERLAYPROBE" + suffix
+
+	// These live on the peers rather than the machine running the test, so
+	// t.TempDir cannot isolate them. Give every run its own names instead:
+	// two test processes may legitimately share a persistent dev cluster.
+	probeInput := fmt.Sprintf("/tmp/overlay-probe-%s-in.txt", suffix)
+	probePID := fmt.Sprintf("/tmp/overlay-probe-%s.pid", suffix)
+	underlayCapture := fmt.Sprintf("/tmp/overlay-cap-underlay-%s.txt", suffix)
+	underlayPID := fmt.Sprintf("/tmp/overlay-cap-underlay-%s.pid", suffix)
+	overlayCapture := fmt.Sprintf("/tmp/overlay-cap-overlay-%s.txt", suffix)
+	overlayPID := fmt.Sprintf("/tmp/overlay-cap-overlay-%s.pid", suffix)
 
 	runnerUnderlay := peerIP(t, m, "runner1", "hostname -I | awk '{print $1}'")
 	runnerOverlay := peerIP(t, m, "runner1", "ip -4 -o addr show flannel-wg | awk '{print $4}' | cut -d/ -f1")
 	t.Logf("runner underlay=%s overlay=%s", runnerUnderlay, runnerOverlay)
 
 	listener := fmt.Sprintf(
-		"nohup nc -l -p %s >/tmp/overlay-probe-in.txt 2>&1 </dev/null & echo $! >/tmp/overlay-probe.pid; disown",
-		probePort)
+		"nohup nc -l -p %s >%s 2>&1 </dev/null & echo $! >%s; disown",
+		probePort, probeInput, probePID)
 	if r := m.PeerExec("runner1", "bash", "-c", listener); !r.Success() {
 		t.Fatalf("failed to start probe listener on runner1: %s", strings.TrimSpace(r.Stderr))
 	}
 	t.Cleanup(func() {
 		m.PeerExec("runner1", "bash", "-c",
-			"kill $(cat /tmp/overlay-probe.pid) 2>/dev/null; rm -f /tmp/overlay-probe.pid /tmp/overlay-probe-in.txt")
+			fmt.Sprintf("kill $(cat %s) 2>/dev/null; rm -f %s %s", probePID, probePID, probeInput))
 	})
 
 	// Scope the underlay capture to the runner's real address so unrelated
 	// chatter on the peers network cannot muddy the result.
 	startCapture(t, m, "coordinator", "eth0", "host "+runnerUnderlay,
-		"/tmp/overlay-cap-underlay.txt", "/tmp/overlay-cap-underlay.pid")
+		underlayCapture, underlayPID)
 	startCapture(t, m, "coordinator", "flannel-wg", "",
-		"/tmp/overlay-cap-overlay.txt", "/tmp/overlay-cap-overlay.pid")
+		overlayCapture, overlayPID)
 
 	send := fmt.Sprintf("echo %s | nc -w 5 %s %s", marker, runnerOverlay, probePort)
 	if r := m.PeerExec("coordinator", "bash", "-c", send); !r.Success() {
@@ -421,7 +433,7 @@ func TestDistributedOverlayEncryption(t *testing.T) {
 
 	harness.Poll(t, "probe arrives on runner1", 30*time.Second, time.Second,
 		func() (bool, string) {
-			r := m.PeerExec("runner1", "grep", "-q", marker, "/tmp/overlay-probe-in.txt")
+			r := m.PeerExec("runner1", "grep", "-q", marker, probeInput)
 			if !r.Success() {
 				return false, "runner has not received the probe yet"
 			}
@@ -429,23 +441,32 @@ func TestDistributedOverlayEncryption(t *testing.T) {
 		},
 	)
 
-	stopCapture(t, m, "coordinator", "/tmp/overlay-cap-overlay.pid")
-	stopCapture(t, m, "coordinator", "/tmp/overlay-cap-underlay.pid")
+	stopCapture(t, m, "coordinator", overlayPID)
+	stopCapture(t, m, "coordinator", underlayPID)
 
 	// The control: the same marker must be readable where it is supposed to be
 	// readable. If this fails the probe never traversed the overlay, and the
 	// underlay assertion below would pass for the wrong reason.
-	if r := m.PeerExec("coordinator", "grep", "-q", marker, "/tmp/overlay-cap-overlay.txt"); !r.Success() {
+	if r := m.PeerExec("coordinator", "grep", "-q", marker, overlayCapture); !r.Success() {
 		t.Fatalf("marker %q never appeared on the overlay device, so this test cannot tell whether the underlay is encrypted", marker)
 	}
 
-	// A capture that saw nothing at all would also report zero matches.
-	size := m.PeerExec("coordinator", "bash", "-c", "wc -c < /tmp/overlay-cap-underlay.txt")
-	if strings.TrimSpace(size.Stdout) == "0" {
-		t.Fatal("underlay capture is empty, so the absence of the marker proves nothing")
+	// A capture that saw no packets would also report zero marker matches. Read
+	// tcpdump's final count rather than the file size, since the listening
+	// banner makes even an empty capture file nonempty.
+	count := m.PeerExec("coordinator", "awk",
+		`/^[0-9]+ packets? captured$/ { captured=$1 } END { if (captured != "") print captured }`,
+		underlayCapture)
+	captured, err := strconv.Atoi(strings.TrimSpace(count.Stdout))
+	if !count.Success() || err != nil {
+		t.Fatalf("could not read tcpdump packet count from underlay capture: stdout=%q stderr=%q",
+			strings.TrimSpace(count.Stdout), strings.TrimSpace(count.Stderr))
+	}
+	if captured == 0 {
+		t.Fatal("underlay capture saw no packets, so the absence of the marker proves nothing")
 	}
 
-	if r := m.PeerExec("coordinator", "grep", "-q", marker, "/tmp/overlay-cap-underlay.txt"); r.Success() {
+	if r := m.PeerExec("coordinator", "grep", "-q", marker, underlayCapture); r.Success() {
 		t.Fatalf("overlay traffic is readable on the underlay: found marker %q in the eth0 capture", marker)
 	}
 }

--- a/cli/commands/runner_join.go
+++ b/cli/commands/runner_join.go
@@ -122,7 +122,6 @@ func performRunnerJoin(ctx *Context, opts runnerJoinOpts) error {
 		Labels:                 labels,
 		EtcdEndpoints:          etcdEndpoints,
 		EtcdPrefix:             res.EtcdPrefix(),
-		NetworkBackend:         res.NetworkBackend(),
 		VictoriametricsAddress: vmAddress,
 		VictorialogsAddress:    vlAddress,
 	}

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -45,8 +45,7 @@ func RunnerStart(ctx *Context, opts struct {
 	ctx.Log.Info("starting distributed runner",
 		"runner_id", cfg.RunnerID,
 		"coordinator", cfg.CoordinatorAddress,
-		"etcd_endpoints", cfg.EtcdEndpoints,
-		"network_backend", cfg.NetworkBackend)
+		"etcd_endpoints", cfg.EtcdEndpoints)
 
 	// Determine listen address. If no explicit address is given, discover the
 	// machine's outbound IP (the one that would route to the coordinator) and
@@ -222,9 +221,8 @@ func RunnerStart(ctx *Context, opts struct {
 		},
 
 		// Flannel network configuration
-		EtcdEndpoints:  cfg.EtcdEndpoints,
-		EtcdPrefix:     cfg.EtcdPrefix,
-		NetworkBackend: cfg.NetworkBackend,
+		EtcdEndpoints: cfg.EtcdEndpoints,
+		EtcdPrefix:    cfg.EtcdPrefix,
 	}
 
 	// Write etcd TLS certs to disk for flannel (which requires file paths)

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -731,7 +731,6 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		Address:                   srvaddr,
 		EtcdEndpoints:             cfg.Etcd.Endpoints,
 		Prefix:                    cfg.Etcd.GetPrefix(),
-		NetworkBackend:            cfg.Server.GetNetworkBackend(),
 		DataPath:                  cfg.Server.GetDataPath(),
 		AdditionalNames:           cfg.TLS.AdditionalNames,
 		IPs:                       ipSet,
@@ -795,7 +794,6 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	grungeOpts := grunge.NetworkOptions{
 		EtcdEndpoints: cfg.Etcd.Endpoints,
 		EtcdPrefix:    cfg.Etcd.GetPrefix() + "/sub/flannel",
-		BackendType:   cfg.Server.GetNetworkBackend(),
 		PrevIPv4:      prevSubnet,
 	}
 

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -97,7 +97,6 @@ type CoordinatorConfig struct {
 	Address         string              `json:"address" yaml:"address"`
 	EtcdEndpoints   []string            `json:"etcd_endpoints" yaml:"etcd_endpoints"`
 	Prefix          string              `json:"prefix" yaml:"prefix"`
-	NetworkBackend  string              `json:"network_backend" yaml:"network_backend"`
 	Resolver        netresolve.Resolver `json:"resolver" yaml:"resolver"`
 	TempDir         string              `json:"temp_dir" yaml:"temp_dir"`
 	DataPath        string              `json:"data_path" yaml:"data_path"`
@@ -1309,7 +1308,6 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		CoordinatorAddr:        c.Address,
 		EtcdEndpoints:          c.EtcdEndpoints,
 		EtcdPrefix:             c.Prefix,
-		NetworkBackend:         c.NetworkBackend,
 		VictoriametricsAddress: c.VictoriametricsAddress,
 		VictorialogsAddress:    c.VictorialogsAddress,
 		WorkloadIssuer:         c.WorkloadIssuer,

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -102,9 +102,8 @@ type RunnerDeps struct {
 
 	// Flannel network configuration (for distributed runners)
 	// If EtcdEndpoints is non-empty, the runner will join the Flannel network
-	EtcdEndpoints  []string
-	EtcdPrefix     string
-	NetworkBackend string
+	EtcdEndpoints []string
+	EtcdPrefix    string
 
 	// TLS configuration for etcd mTLS (for distributed runners, file paths)
 	EtcdTLSCertFile string // Client certificate file path
@@ -450,13 +449,11 @@ func queryWorkloadIssuerInfo(ctx context.Context, regClient *runner_v1alpha.Runn
 func (r *Runner) initializeNetwork(ctx context.Context, eg ...*errgroup.Group) error {
 	r.Log.Info("Initializing distributed runner network",
 		"etcd_endpoints", r.deps.EtcdEndpoints,
-		"etcd_prefix", r.deps.EtcdPrefix,
-		"backend", r.deps.NetworkBackend)
+		"etcd_prefix", r.deps.EtcdPrefix)
 
 	grungeOpts := grunge.NetworkOptions{
 		EtcdEndpoints: r.deps.EtcdEndpoints,
 		EtcdPrefix:    r.deps.EtcdPrefix,
-		BackendType:   r.deps.NetworkBackend,
 		PrevIPv4:      r.deps.IPv4Routable,
 	}
 

--- a/docs/docs/command/server.md
+++ b/docs/docs/command/server.md
@@ -44,7 +44,6 @@ miren server [flags]
 - `--ips` — Additional IPs assigned to the server cert
 - `--labs` — Comma-separated list of Miren Labs features to enable/disable. Prefix with - to disable.
 - `--mode, -m` — Server mode: standalone (default), distributed (experimental)
-- `--network-backend` — Network backend for sandbox connectivity: vxlan (default) or wireguard
 - `--release-path` — Path to release directory containing binaries
 - `--runner-address` — Runner address (host:port). For IPv6 use brackets, e.g. "[::1]:8444".
 - `--runner-id, -r` — Runner ID

--- a/docs/docs/distributed-runners.md
+++ b/docs/docs/distributed-runners.md
@@ -22,7 +22,7 @@ A **runner** is any other machine that has joined the cluster with `miren runner
 
 ### Networking
 
-Sandboxes across every node share a single flat overlay network. A sandbox on one runner can reach a sandbox on another by IP as if they were on the same host, so your services keep talking to each other the same way they did on a single machine. Miren handles the overlay for you; there's nothing to configure per node.
+Sandboxes across every node share a single flat overlay network. A sandbox on one runner can reach a sandbox on another by IP as if they were on the same host, so your services keep talking to each other the same way they did on a single machine. Miren handles the addressing, routes, and WireGuard peers, but your firewall must allow `51820/udp` between every pair of nodes.
 
 :::info[Overlay address ranges]
 Sandbox IPs are allocated from `10.8.0.0/16`, with each node leasing its own `/24` out of that range. Internal service addresses use `10.10.0.0/16`. Keep these ranges clear of your host and datacenter networks to avoid routing conflicts.
@@ -78,25 +78,22 @@ talks to the coordinator's etcd, metrics, and log endpoints directly, so if
 there's a firewall between your machines it needs to allow rather more than
 8443. These are the defaults:
 
-| Port | Protocol | What it carries | Authentication |
-|------|----------|-----------------|----------------|
-| 8443 | TCP | Coordinator API, including join | Join token while enrolling, mTLS after |
+| Port | Protocol | What it carries | Protection |
+|------|----------|-----------------|------------|
+| 8443 | TCP | Coordinator API, including join | Join token while enrolling, mTLS afterward |
 | 12379 | TCP | etcd, for Flannel subnet coordination | mTLS |
 | 8428 | TCP | VictoriaMetrics, for metrics the runner reports | none |
 | 9428 | TCP | VictoriaLogs, for logs the runner ships | none |
-| 8472 | UDP | Flannel overlay, with the default `vxlan` backend | none |
+| 51820 | UDP | WireGuard overlay | WireGuard encryption |
 
 :::warning[Observability ports are unauthenticated]
-VictoriaMetrics and VictoriaLogs have no authentication of their own, and
-neither does the default VXLAN overlay. Keep them on a private network between
-your nodes rather than exposing them broadly.
+VictoriaMetrics and VictoriaLogs have no authentication of their own. Keep
+them on a private network between your nodes rather than exposing them broadly.
 :::
 
-The overlay carries sandbox traffic in the clear today, so treat the network
-between your nodes as part of your trust boundary. Its port also needs to be
-open between runners, not just from each runner to the coordinator, since
-sandboxes on different machines send traffic to each other node-to-node. The
-coordinator's ports are configurable; see the
+The overlay port needs to be open between runners, not just from each runner
+to the coordinator, since sandboxes on different machines send traffic to each
+other node-to-node. The coordinator's ports are configurable; see the
 [server configuration reference](/server-config).
 
 ### 3. Start the runner

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -36,7 +36,6 @@ mode = "standalone"
 [server]
 address = ":8443"
 data_path = "/var/lib/miren"
-network_backend = "vxlan"
 http_request_timeout = 60
 
 [ingress]
@@ -84,8 +83,6 @@ In standalone mode, embedded services start automatically unless explicitly disa
 | `skip_client_config` | bool | `false` | Skip writing client config to `clientconfig.d` | `MIREN_SERVER_SKIP_CLIENT_CONFIG` | `--skip-client-config` |
 | `http_request_timeout` | int | `60` | HTTP request timeout in seconds (minimum: 1) | `MIREN_SERVER_HTTP_REQUEST_TIMEOUT` | `--http-request-timeout` |
 | `stop_sandboxes_on_shutdown` | bool | `false` | Stop all sandboxes when server shuts down (useful in development) | `MIREN_SERVER_STOP_SANDBOXES_ON_SHUTDOWN` | `--stop-sandboxes-on-shutdown` |
-| `network_backend` | string | `vxlan` | Network backend: `vxlan` or `wireguard` | `MIREN_SERVER_NETWORK_BACKEND` | `--network-backend` |
-
 ## `[ingress]` — Ingress Settings {#ingress}
 
 Selects the deployment shape for Miren's HTTP/HTTPS ingress. The mode determines where Miren listens and whether it terminates TLS. See [TLS](/tls) for cert sourcing under each mode.

--- a/go.mod
+++ b/go.mod
@@ -182,7 +182,6 @@ require (
 	github.com/aliyun/credentials-go v1.4.7 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
@@ -203,7 +202,6 @@ require (
 	github.com/baidubce/bce-sdk-go v0.9.250 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
-	github.com/bronze1man/goStrongswanVici v0.0.0-20231128135937-211cef3b0b20 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -386,9 +384,6 @@ require (
 	gopkg.in/ns1/ns1-go.v2 v2.15.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
-	k8s.io/apimachinery v0.31.2 // indirect
-	k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3 // indirect
-	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 	tags.cncf.io/container-device-interface v0.8.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
-github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/aws/aws-sdk-go v1.40.45/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go-v2 v1.9.1/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
@@ -256,8 +254,6 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
-github.com/bronze1man/goStrongswanVici v0.0.0-20231128135937-211cef3b0b20 h1:JMoL5xJSYxo1QVJ3c+4FutWQnks3gZX9DYkgAnvg+5g=
-github.com/bronze1man/goStrongswanVici v0.0.0-20231128135937-211cef3b0b20/go.mod h1:fWUtBEPt2yjrr3WFhOqvajM8JSEU8bEeBcoeSCsKRpc=
 github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
 github.com/casbin/casbin/v2 v2.37.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -1908,12 +1904,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8s.io/apimachinery v0.31.2 h1:i4vUt2hPK56W6mlT7Ry+AO8eEsyxMD1U44NR22CLTYw=
-k8s.io/apimachinery v0.31.2/go.mod h1:rsPdaZJfTfLsNJSQzNHQvYoTmxhoOEofxtOsF3rtsMo=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
-k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3 h1:b2FmK8YH+QEwq/Sy2uAEhmqL5nPfGYbJOcaqjeYYZoA=
-k8s.io/utils v0.0.0-20240902221715-702e33fdd3c3/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 miren.dev/jsonrpc3/go/jsonrpc3 v0.0.0-20260106052505-c98e2702b093 h1:Sd+M5HSUatiCRIyTZIaC89EJu5tiO+qxlz8qoHugjY8=
 miren.dev/jsonrpc3/go/jsonrpc3 v0.0.0-20260106052505-c98e2702b093/go.mod h1:B4A3wSzkcSZQw6Y5opU+rk1+1lEuCWIWkAiN7TkltGE=
 miren.dev/lbd v0.0.0-20260224020427-8914d8db2233 h1:9DxH7Dhnmu7hn1OA2JC5fHpLuVgAqBySws9GLNssLl4=
@@ -1933,8 +1925,6 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
-sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/knftables v0.0.21 h1:mby+JtzhJH1Ucnq++ZJaM+ViQBY5JzIyX4bSCP8K5YQ=
 sigs.k8s.io/knftables v0.0.21/go.mod h1:f/5ZLKYEUPUhVjUCg6l80ACdL7CIIyeL0DxfgojGRTk=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/pkg/grunge/grunge.go
+++ b/pkg/grunge/grunge.go
@@ -26,37 +26,13 @@ import (
 	"go4.org/netipx"
 	"golang.org/x/sync/errgroup"
 
-	_ "github.com/flannel-io/flannel/pkg/backend/alloc"
-	_ "github.com/flannel-io/flannel/pkg/backend/extension"
-	_ "github.com/flannel-io/flannel/pkg/backend/hostgw"
-	_ "github.com/flannel-io/flannel/pkg/backend/ipip"
-	_ "github.com/flannel-io/flannel/pkg/backend/ipsec"
-	_ "github.com/flannel-io/flannel/pkg/backend/udp"
-	_ "github.com/flannel-io/flannel/pkg/backend/vxlan"
 	_ "github.com/flannel-io/flannel/pkg/backend/wireguard"
 )
 
-// errNoBackend is returned rather than silently falling back to a default.
-// The backend decides whether sandbox traffic between hosts is encrypted, so
-// guessing here can hand an operator plaintext VXLAN on a cluster whose config
-// asked for WireGuard, with nothing in the logs to say so. Runners carry the
-// backend in the config written at join time; one that predates the field has
-// to re-join to pick it up.
-var errNoBackend = fmt.Errorf(
-	"no network backend configured: set server.network_backend on the coordinator, " +
-		"and re-join any runner whose config predates the setting")
-
-// staleBackendDevices lists, per backend, the interfaces left behind by the
-// other backends we support. Switching backends does not remove the previous
-// backend's device, and its per-lease routes (one /24 per peer) are more
-// specific than the new backend's route for the whole /16, so the kernel keeps
-// steering remote sandbox traffic into the old device. Leftover VXLAN is the
-// dangerous direction: the node reports WireGuard, logs that it is ignoring
-// non-WireGuard leases, and still ships that peer's traffic in the clear.
-var staleBackendDevices = map[string][]string{
-	"vxlan":     {"flannel-wg", "flannel-wg-v6"},
-	"wireguard": {"flannel.1"},
-}
+const (
+	networkBackend   = "wireguard"
+	staleVXLANDevice = "flannel.1"
+)
 
 type Network struct {
 	NetworkOptions
@@ -71,7 +47,6 @@ type NetworkOptions struct {
 	EtcdEndpoints []string
 	EtcdPrefix    string
 	Interface     string
-	BackendType   string
 
 	PrevIPv4 netip.Prefix
 	PrevIPv6 netip.Prefix
@@ -133,14 +108,10 @@ func buildTLSConfigFromFiles(certFile, keyFile, caFile string) (*tls.Config, err
 }
 
 func (n *Network) SetupConfig(ctx context.Context, v4, v6 netip.Prefix) error {
-	if n.BackendType == "" {
-		return errNoBackend
-	}
-
 	var backend struct {
 		Type string
 	}
-	backend.Type = n.BackendType
+	backend.Type = networkBackend
 
 	var config subnet.Config
 	config.EnableIPv4 = true
@@ -205,23 +176,8 @@ func (n *Network) Lease() *Lease {
 	return &Lease{n.lease}
 }
 
-// removeStaleBackendDevices deletes interfaces belonging to a backend other
-// than the one about to register. Deleting a link takes its routes with it.
-// A device we cannot remove is fatal rather than logged: continuing would mean
-// running as if encrypted while a stale VXLAN path is still winning the route
-// lookup, which is precisely the failure this is here to prevent.
-func (n *Network) removeStaleBackendDevices(backendType string) error {
-	for _, name := range staleBackendDevices[backendType] {
-		if err := n.removeDeviceIfPresent(name, backendType); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // removeDeviceIfPresent deletes one interface, treating absence as success.
-func (n *Network) removeDeviceIfPresent(name, backendType string) error {
+func (n *Network) removeDeviceIfPresent(name string) error {
 	link, err := netlink.LinkByName(name)
 	if err != nil {
 		// Absent is the expected case and the whole point. Any other lookup
@@ -240,7 +196,7 @@ func (n *Network) removeDeviceIfPresent(name, backendType string) error {
 	}
 
 	n.log.Info("removed stale network device from a previous backend",
-		"device", name, "backend", backendType)
+		"device", name, "backend", networkBackend)
 
 	return nil
 }
@@ -293,18 +249,15 @@ func (n *Network) Start(ctx context.Context, eg *errgroup.Group) error {
 
 	bm := backend.NewManager(ctx, sm, extIface)
 
-	if n.BackendType == "" {
-		return errNoBackend
-	}
-	backendType := n.BackendType
-
-	if err := n.removeStaleBackendDevices(backendType); err != nil {
+	// Deleting the old link takes its routes with it. Failure is fatal:
+	// otherwise a stale plaintext route could keep winning after the upgrade.
+	if err := n.removeDeviceIfPresent(staleVXLANDevice); err != nil {
 		return err
 	}
 
-	be, err := bm.GetBackend(backendType)
+	be, err := bm.GetBackend(networkBackend)
 	if err != nil {
-		n.log.Error("Failed to get backend", "backend", backendType, "error", err)
+		n.log.Error("Failed to get backend", "backend", networkBackend, "error", err)
 		return err
 	}
 

--- a/pkg/grunge/grunge_test.go
+++ b/pkg/grunge/grunge_test.go
@@ -1,92 +1,18 @@
 package grunge
 
 import (
-	"context"
 	"log/slog"
-	"net/netip"
-	"slices"
 	"testing"
 )
 
-// An unset backend used to fall through to vxlan. Callers reach SetupConfig
-// with whatever their config produced, so a runner joined before the field
-// existed would quietly publish a plaintext overlay to the whole cluster.
-func TestSetupConfigRejectsEmptyBackend(t *testing.T) {
-	n := &Network{log: slog.Default()}
-
-	err := n.SetupConfig(context.Background(),
-		netip.MustParsePrefix("10.8.0.0/16"),
-		netip.MustParsePrefix("fd47:ace::/64"),
-	)
-	if err == nil {
-		t.Fatal("expected an error for an unconfigured backend, got nil")
-	}
-	if err != errNoBackend {
-		t.Fatalf("expected errNoBackend, got %v", err)
-	}
-}
-
-// Each backend must clean up after the others without listing anything it
-// creates itself. Getting this wrong deletes the device we are about to
-// register on, so it is worth pinning rather than trusting the table by eye.
-func TestStaleBackendDevicesExcludeOwnDevices(t *testing.T) {
-	owned := map[string][]string{
-		"vxlan":     {"flannel.1"},
-		"wireguard": {"flannel-wg", "flannel-wg-v6"},
-	}
-
-	for backend, ours := range owned {
-		stale, ok := staleBackendDevices[backend]
-		if !ok {
-			t.Errorf("backend %q has no stale device list", backend)
-			continue
-		}
-
-		for _, device := range stale {
-			for _, own := range ours {
-				if device == own {
-					t.Errorf("backend %q would delete its own device %q", backend, device)
-				}
-			}
-		}
-	}
-
-	// Every device one backend owns should be cleaned up by the other, or
-	// switching backends leaves a more specific route behind.
-	for backend, ours := range owned {
-		for other, stale := range staleBackendDevices {
-			if other == backend {
-				continue
-			}
-			for _, own := range ours {
-				if !slices.Contains(stale, own) {
-					t.Errorf("backend %q does not clean up %q left by %q", other, own, backend)
-				}
-			}
-		}
-	}
-}
-
-// An unrecognized backend has nothing registered to clean up, and must not be
-// treated as a reason to start deleting interfaces.
-func TestRemoveStaleBackendDevicesIgnoresUnknownBackend(t *testing.T) {
-	n := &Network{log: slog.Default()}
-
-	if err := n.removeStaleBackendDevices("hostgw"); err != nil {
-		t.Fatalf("expected no error for an unknown backend, got %v", err)
-	}
-}
-
 // A device that isn't there is the ordinary case on a node that never ran the
 // other backend, so it has to read as success rather than as a lookup failure.
-// This covers the netlink lookup for real; the unknown-backend case above
-// never reaches it, since that backend has no devices registered to check.
 func TestRemoveDeviceIfPresentTreatsAbsenceAsSuccess(t *testing.T) {
 	n := &Network{log: slog.Default()}
 
 	// Deliberately a name nothing will have, so the test can exercise the
 	// lookup without any chance of deleting a real interface.
-	if err := n.removeDeviceIfPresent("miren-absent-dev0", "wireguard"); err != nil {
+	if err := n.removeDeviceIfPresent("miren-absent-dev0"); err != nil {
 		t.Fatalf("expected absence to be treated as success, got %v", err)
 	}
 }

--- a/pkg/runnerconfig/config.go
+++ b/pkg/runnerconfig/config.go
@@ -19,10 +19,9 @@ type Config struct {
 	ClientKey          string            `yaml:"client_key" json:"client_key"`
 	Labels             map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	// Network configuration for distributed runners
-	EtcdEndpoints  []string `yaml:"etcd_endpoints,omitempty" json:"etcd_endpoints,omitempty"`
-	EtcdPrefix     string   `yaml:"etcd_prefix,omitempty" json:"etcd_prefix,omitempty"`
-	NetworkBackend string   `yaml:"network_backend,omitempty" json:"network_backend,omitempty"`
-	DiskMode       string   `yaml:"disk_mode,omitempty" json:"disk_mode,omitempty"`
+	EtcdEndpoints []string `yaml:"etcd_endpoints,omitempty" json:"etcd_endpoints,omitempty"`
+	EtcdPrefix    string   `yaml:"etcd_prefix,omitempty" json:"etcd_prefix,omitempty"`
+	DiskMode      string   `yaml:"disk_mode,omitempty" json:"disk_mode,omitempty"`
 	// Observability endpoints for metrics and logs
 	VictoriametricsAddress string `yaml:"victoriametrics_address,omitempty" json:"victoriametrics_address,omitempty"`
 	VictorialogsAddress    string `yaml:"victorialogs_address,omitempty" json:"victorialogs_address,omitempty"`

--- a/pkg/runnerconfig/config_test.go
+++ b/pkg/runnerconfig/config_test.go
@@ -1,0 +1,23 @@
+package runnerconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadIgnoresLegacyNetworkBackend(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(configPath, []byte(`
+runner_id: runner-1
+coordinator_address: coordinator.example.com:8443
+network_backend: vxlan
+`), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(configPath); err != nil {
+		t.Fatalf("loading a config with the legacy network_backend field: %v", err)
+	}
+}

--- a/pkg/serverconfig/cli.gen.go
+++ b/pkg/serverconfig/cli.gen.go
@@ -32,7 +32,6 @@ type CLIFlags struct {
 	ServerConfigDataPath                 *string  `long:"data-path" short:"d" description:"Data path" env:"MIREN_SERVER_DATA_PATH"`
 	ServerConfigDiskMode                 *string  `long:"disk-mode" description:"Disk I/O mode: auto (default, detect from hardware), universal (loop devices), or accelerator (lbd devices)" env:"MIREN_DISK_MODE"`
 	ServerConfigHTTPRequestTimeout       *int     `long:"http-request-timeout" description:"HTTP request timeout in seconds" env:"MIREN_SERVER_HTTP_REQUEST_TIMEOUT"`
-	ServerConfigNetworkBackend           *string  `long:"network-backend" description:"Network backend for sandbox connectivity: vxlan (default) or wireguard" env:"MIREN_SERVER_NETWORK_BACKEND"`
 	ServerConfigReleasePath              *string  `long:"release-path" description:"Path to release directory containing binaries" env:"MIREN_SERVER_RELEASE_PATH"`
 	ServerConfigRunnerAddress            *string  `long:"runner-address" description:"Runner address (host:port). For IPv6 use brackets, e.g. \"[::1]:8444\"." env:"MIREN_SERVER_RUNNER_ADDRESS"`
 	ServerConfigRunnerID                 *string  `long:"runner-id" short:"r" description:"Runner ID" env:"MIREN_SERVER_RUNNER_ID"`

--- a/pkg/serverconfig/codegen_test.go
+++ b/pkg/serverconfig/codegen_test.go
@@ -15,7 +15,6 @@ func TestGeneratedCode(t *testing.T) {
 	if cfg.Mode == nil || *cfg.Mode != "standalone" {
 		t.Errorf("expected default mode to be 'standalone', got %v", cfg.Mode)
 	}
-
 	// Test validation
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("default config should be valid, got error: %v", err)

--- a/pkg/serverconfig/config.gen.go
+++ b/pkg/serverconfig/config.gen.go
@@ -314,7 +314,6 @@ type ServerConfig struct {
 	DataPath                *string `toml:"data_path" env:"MIREN_SERVER_DATA_PATH"`
 	DiskMode                *string `toml:"disk_mode" env:"MIREN_DISK_MODE"`
 	HTTPRequestTimeout      *int    `toml:"http_request_timeout" env:"MIREN_SERVER_HTTP_REQUEST_TIMEOUT"`
-	NetworkBackend          *string `toml:"network_backend" env:"MIREN_SERVER_NETWORK_BACKEND"`
 	ReleasePath             *string `toml:"release_path" env:"MIREN_SERVER_RELEASE_PATH"`
 	RunnerAddress           *string `toml:"runner_address" env:"MIREN_SERVER_RUNNER_ADDRESS"`
 	RunnerID                *string `toml:"runner_id" env:"MIREN_SERVER_RUNNER_ID"`
@@ -385,19 +384,6 @@ func (c *ServerConfig) GetHTTPRequestTimeout() int {
 // SetHTTPRequestTimeout sets the value of HTTPRequestTimeout
 func (c *ServerConfig) SetHTTPRequestTimeout(v int) {
 	c.HTTPRequestTimeout = &v
-}
-
-// GetNetworkBackend returns the value of NetworkBackend or its zero value if nil
-func (c *ServerConfig) GetNetworkBackend() string {
-	if c.NetworkBackend != nil {
-		return *c.NetworkBackend
-	}
-	return ""
-}
-
-// SetNetworkBackend sets the value of NetworkBackend
-func (c *ServerConfig) SetNetworkBackend(v string) {
-	c.NetworkBackend = &v
 }
 
 // GetReleasePath returns the value of ReleasePath or its zero value if nil

--- a/pkg/serverconfig/defaults.gen.go
+++ b/pkg/serverconfig/defaults.gen.go
@@ -81,7 +81,6 @@ func DefaultServerConfig() ServerConfig {
 		DataPath:                strPtr("/var/lib/miren"),
 		DiskMode:                strPtr(""),
 		HTTPRequestTimeout:      intPtr(60),
-		NetworkBackend:          strPtr("vxlan"),
 		ReleasePath:             strPtr(""),
 		RunnerAddress:           strPtr("localhost:8444"),
 		RunnerID:                strPtr("miren"),

--- a/pkg/serverconfig/loader.gen.go
+++ b/pkg/serverconfig/loader.gen.go
@@ -258,10 +258,6 @@ func applyCLIFlags(cfg *Config, flags *CLIFlags) {
 		cfg.Server.HTTPRequestTimeout = flags.ServerConfigHTTPRequestTimeout
 	}
 
-	if flags.ServerConfigNetworkBackend != nil && *flags.ServerConfigNetworkBackend != "" {
-		cfg.Server.NetworkBackend = flags.ServerConfigNetworkBackend
-	}
-
 	if flags.ServerConfigReleasePath != nil && *flags.ServerConfigReleasePath != "" {
 		cfg.Server.ReleasePath = flags.ServerConfigReleasePath
 	}

--- a/pkg/serverconfig/schema.yml
+++ b/pkg/serverconfig/schema.yml
@@ -171,17 +171,6 @@ configs:
         env: MIREN_SERVER_STOP_SANDBOXES_ON_SHUTDOWN
         toml: stop_sandboxes_on_shutdown
 
-      network_backend:
-        type: string
-        default: vxlan
-        cli:
-          long: network-backend
-          description: "Network backend for sandbox connectivity: vxlan (default) or wireguard"
-        env: MIREN_SERVER_NETWORK_BACKEND
-        toml: network_backend
-        validation:
-          enum: [vxlan, wireguard]
-
       disk_mode:
         type: string
         default: ""

--- a/pkg/serverconfig/validation.gen.go
+++ b/pkg/serverconfig/validation.gen.go
@@ -183,17 +183,6 @@ func (c *ServerConfig) Validate() error {
 		return fmt.Errorf("http_request_timeout must be at least 1, got %d", *c.HTTPRequestTimeout)
 	}
 
-	// Validate network_backend enum
-	if c.NetworkBackend != nil {
-		validNetworkBackend := map[string]bool{
-			"vxlan":     true,
-			"wireguard": true,
-		}
-		if !validNetworkBackend[*c.NetworkBackend] {
-			return fmt.Errorf("invalid network_backend %q: must be one of [vxlan wireguard]", *c.NetworkBackend)
-		}
-	}
-
 	// Validate runner_address
 	if c.RunnerAddress != nil && *c.RunnerAddress != "" {
 		if _, _, err := net.SplitHostPort(*c.RunnerAddress); err != nil {

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -32,6 +32,7 @@ const (
 	MaxInviteExpiryHours     = 168 // 7 days
 
 	enrollmentCountRetries = 3
+	networkBackend         = "wireguard"
 )
 
 type RegistrationServerConfig struct {
@@ -41,7 +42,6 @@ type RegistrationServerConfig struct {
 	CoordinatorAddr string
 	EtcdEndpoints   []string
 	EtcdPrefix      string
-	NetworkBackend  string
 
 	// Observability endpoints provided to runners at join time
 	VictoriametricsAddress string
@@ -361,9 +361,9 @@ func (s *RegistrationServer) Join(ctx context.Context, req *runner_v1alpha.Runne
 	if s.EtcdPrefix != "" {
 		results.SetEtcdPrefix(s.EtcdPrefix + "/sub/flannel")
 	}
-	if s.NetworkBackend != "" {
-		results.SetNetworkBackend(s.NetworkBackend)
-	}
+	// Keep sending this field for older runner binaries, which persist the
+	// backend selected by the coordinator at join time.
+	results.SetNetworkBackend(networkBackend)
 	if s.VictoriametricsAddress != "" {
 		results.SetVictoriametricsAddress(s.VictoriametricsAddress)
 	}

--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -203,6 +203,10 @@ func TestJoinCreatesNodeEntity(t *testing.T) {
 		t.Errorf("Join returned coordinator addr %q, want %q", joinResult.CoordinatorAddr(), "127.0.0.1:8443")
 	}
 
+	if joinResult.NetworkBackend() != "wireguard" {
+		t.Errorf("Join returned network backend %q, want wireguard", joinResult.NetworkBackend())
+	}
+
 	// Verify the issued certificate includes proper IP SANs
 	block, _ := pem.Decode(joinResult.CertPem())
 	if block == nil {


### PR DESCRIPTION
RFD-51 made encryption part of the distributed runner design, but runtime still exposed the Flannel backend as a choice. That left `vxlan` available as a supported way to send cross-host sandbox traffic in plaintext, even though every supported Miren kernel can run WireGuard.

Distributed runners are still a Labs feature, and we do not know of anyone relying on VXLAN for a real deployment. This is the right point to remove the escape hatch instead of turning it into compatibility baggage.

This removes the choice instead of merely changing its default. Runtime now compiles and selects only WireGuard, ignores the legacy backend field in saved runner configs, and keeps reporting `wireguard` through the join RPC so older runner binaries land on the safe backend too. Startup still removes `flannel.1`, since an old VXLAN device can leave behind more-specific routes that beat the new encrypted path.

The distributed encryption probe remains the backstop for the actual invariant. Its scratch files are now unique per run so concurrent blackbox jobs cannot interfere with each other.

Closes MIR-1482