### PR TITLE
Add system workload identities

### DIFF
--- a/api/runner/rpc.yml
+++ b/api/runner/rpc.yml
@@ -303,6 +303,33 @@ interfaces:
             type: string
             doc: Error message if the drain failed
 
+      - name: IssueSystemWorkloadToken
+        index: 12
+        doc: |
+          Mint an identity token for a Miren system workload running on a
+          distributed runner, which does not hold the cluster signing key. The
+          caller is an mTLS-authenticated runner, and the coordinator restricts
+          which system workloads a runner may request; a runner cannot obtain an
+          identity for a workload it does not run.
+        parameters:
+          - name: system_workload
+            type: string
+            doc: System workload identity to mint (e.g. sandboxcontroller)
+          - name: audience
+            type: list
+            element: string
+            doc: Optional token audiences (defaults to "miren" when empty)
+          - name: ttl_seconds
+            type: int64
+            doc: Optional token TTL in seconds (0 uses the issuer default)
+        results:
+          - name: token
+            type: string
+            doc: The signed system workload identity token (JWT)
+          - name: error
+            type: string
+            doc: Error message if issuance failed
+
 types:
   - type: InviteInfo
     doc: Information about a runner invite

--- a/api/runner/runner_v1alpha/rpc.gen.go
+++ b/api/runner/runner_v1alpha/rpc.gen.go
@@ -1448,6 +1448,100 @@ func (v *RunnerRegistrationDrainRunnerResults) UnmarshalJSON(data []byte) error 
 	return json.Unmarshal(data, &v.data)
 }
 
+type runnerRegistrationIssueSystemWorkloadTokenArgsData struct {
+	SystemWorkload *string   `cbor:"0,keyasint,omitempty" json:"system_workload,omitempty"`
+	Audience       *[]string `cbor:"1,keyasint,omitempty" json:"audience,omitempty"`
+	TtlSeconds     *int64    `cbor:"2,keyasint,omitempty" json:"ttl_seconds,omitempty"`
+}
+
+type RunnerRegistrationIssueSystemWorkloadTokenArgs struct {
+	call rpc.Call
+	data runnerRegistrationIssueSystemWorkloadTokenArgsData
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) HasSystemWorkload() bool {
+	return v.data.SystemWorkload != nil
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) SystemWorkload() string {
+	if v.data.SystemWorkload == nil {
+		return ""
+	}
+	return *v.data.SystemWorkload
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) HasAudience() bool {
+	return v.data.Audience != nil
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) Audience() []string {
+	if v.data.Audience == nil {
+		return nil
+	}
+	return *v.data.Audience
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) HasTtlSeconds() bool {
+	return v.data.TtlSeconds != nil
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) TtlSeconds() int64 {
+	if v.data.TtlSeconds == nil {
+		return 0
+	}
+	return *v.data.TtlSeconds
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type runnerRegistrationIssueSystemWorkloadTokenResultsData struct {
+	Token *string `cbor:"0,keyasint,omitempty" json:"token,omitempty"`
+	Error *string `cbor:"1,keyasint,omitempty" json:"error,omitempty"`
+}
+
+type RunnerRegistrationIssueSystemWorkloadTokenResults struct {
+	call rpc.Call
+	data runnerRegistrationIssueSystemWorkloadTokenResultsData
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenResults) SetToken(token string) {
+	v.data.Token = &token
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenResults) SetError(error string) {
+	v.data.Error = &error
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *RunnerRegistrationIssueSystemWorkloadTokenResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type RunnerRegistrationCreateInvite struct {
 	rpc.Call
 	args    RunnerRegistrationCreateInviteArgs
@@ -1760,6 +1854,32 @@ func (t *RunnerRegistrationDrainRunner) Results() *RunnerRegistrationDrainRunner
 	return results
 }
 
+type RunnerRegistrationIssueSystemWorkloadToken struct {
+	rpc.Call
+	args    RunnerRegistrationIssueSystemWorkloadTokenArgs
+	results RunnerRegistrationIssueSystemWorkloadTokenResults
+}
+
+func (t *RunnerRegistrationIssueSystemWorkloadToken) Args() *RunnerRegistrationIssueSystemWorkloadTokenArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *RunnerRegistrationIssueSystemWorkloadToken) Results() *RunnerRegistrationIssueSystemWorkloadTokenResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type RunnerRegistration interface {
 	CreateInvite(ctx context.Context, state *RunnerRegistrationCreateInvite) error
 	Join(ctx context.Context, state *RunnerRegistrationJoin) error
@@ -1773,6 +1893,7 @@ type RunnerRegistration interface {
 	CordonRunner(ctx context.Context, state *RunnerRegistrationCordonRunner) error
 	UncordonRunner(ctx context.Context, state *RunnerRegistrationUncordonRunner) error
 	DrainRunner(ctx context.Context, state *RunnerRegistrationDrainRunner) error
+	IssueSystemWorkloadToken(ctx context.Context, state *RunnerRegistrationIssueSystemWorkloadToken) error
 }
 
 type reexportRunnerRegistration struct {
@@ -1824,6 +1945,10 @@ func (reexportRunnerRegistration) UncordonRunner(ctx context.Context, state *Run
 }
 
 func (reexportRunnerRegistration) DrainRunner(ctx context.Context, state *RunnerRegistrationDrainRunner) error {
+	panic("not implemented")
+}
+
+func (reexportRunnerRegistration) IssueSystemWorkloadToken(ctx context.Context, state *RunnerRegistrationIssueSystemWorkloadToken) error {
 	panic("not implemented")
 }
 
@@ -1951,6 +2076,16 @@ func AdaptRunnerRegistration(t RunnerRegistration) *rpc.Interface {
 			Params:        []string{"query", "reason", "timeout_seconds"},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.DrainRunner(ctx, &RunnerRegistrationDrainRunner{Call: call})
+			},
+		},
+		{
+			Name:          "IssueSystemWorkloadToken",
+			InterfaceName: "RunnerRegistration",
+			Index:         12,
+			Public:        false,
+			Params:        []string{"system_workload", "audience", "ttl_seconds"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.IssueSystemWorkloadToken(ctx, &RunnerRegistrationIssueSystemWorkloadToken{Call: call})
 			},
 		},
 	}
@@ -2649,4 +2784,48 @@ func (v RunnerRegistrationClient) DrainRunner(ctx context.Context, query string,
 	}
 
 	return &RunnerRegistrationClientDrainRunnerResults{client: v.Client, data: ret}, nil
+}
+
+type RunnerRegistrationClientIssueSystemWorkloadTokenResults struct {
+	client rpc.Client
+	data   runnerRegistrationIssueSystemWorkloadTokenResultsData
+}
+
+func (v *RunnerRegistrationClientIssueSystemWorkloadTokenResults) HasToken() bool {
+	return v.data.Token != nil
+}
+
+func (v *RunnerRegistrationClientIssueSystemWorkloadTokenResults) Token() string {
+	if v.data.Token == nil {
+		return ""
+	}
+	return *v.data.Token
+}
+
+func (v *RunnerRegistrationClientIssueSystemWorkloadTokenResults) HasError() bool {
+	return v.data.Error != nil
+}
+
+func (v *RunnerRegistrationClientIssueSystemWorkloadTokenResults) Error() string {
+	if v.data.Error == nil {
+		return ""
+	}
+	return *v.data.Error
+}
+
+func (v RunnerRegistrationClient) IssueSystemWorkloadToken(ctx context.Context, system_workload string, audience []string, ttl_seconds int64) (*RunnerRegistrationClientIssueSystemWorkloadTokenResults, error) {
+	args := RunnerRegistrationIssueSystemWorkloadTokenArgs{}
+	args.data.SystemWorkload = &system_workload
+	x := slices.Clone(audience)
+	args.data.Audience = &x
+	args.data.TtlSeconds = &ttl_seconds
+
+	var ret runnerRegistrationIssueSystemWorkloadTokenResultsData
+
+	err := v.Call(ctx, "IssueSystemWorkloadToken", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunnerRegistrationClientIssueSystemWorkloadTokenResults{client: v.Client, data: ret}, nil
 }

--- a/components/runner/remote_issuer.go
+++ b/components/runner/remote_issuer.go
@@ -67,3 +67,24 @@ func (r *remoteIssuer) IssueTokenWithOptions(_, sandboxID string, opts workloadi
 	}
 	return res.Token(), nil
 }
+
+// IssueSystemWorkloadToken mints an identity for a system workload running on
+// this runner. The coordinator constrains which workloads a runner may ask for.
+func (r *remoteIssuer) IssueSystemWorkloadToken(workload workloadidentity.SystemWorkload, opts workloadidentity.TokenOptions) (string, error) {
+	ctx, cancel := context.WithTimeout(r.ctx, remoteTokenTimeout)
+	defer cancel()
+
+	var ttlSeconds int64
+	if opts.TTL > 0 {
+		ttlSeconds = int64(opts.TTL / time.Second)
+	}
+
+	res, err := r.client.IssueSystemWorkloadToken(ctx, string(workload), opts.Audience, ttlSeconds)
+	if err != nil {
+		return "", fmt.Errorf("requesting system workload token from coordinator: %w", err)
+	}
+	if res.Error() != "" {
+		return "", fmt.Errorf("coordinator refused system workload token: %s", res.Error())
+	}
+	return res.Token(), nil
+}

--- a/docs/docs/workload-identity.md
+++ b/docs/docs/workload-identity.md
@@ -108,6 +108,7 @@ Each token is a JWT carrying the standard registered claims plus a few Miren-spe
 | `cluster_id` | The cluster that issued the token |
 | `app` | The application name |
 | `sandbox_id` | The sandbox instance |
+| `identity_type` | The kind of principal the token represents (always `sandbox` for the tokens your app receives) |
 
 The `sub` (subject) encodes the workload's identity as a path-like string, omitting any empty parts:
 
@@ -129,9 +130,17 @@ A decoded token payload looks like:
   "organization_id": "org-demo-xyz",
   "cluster_id": "cluster-aabbcc",
   "app": "demo",
-  "sandbox_id": "sandbox/demo-web-xxyyzz"
+  "sandbox_id": "sandbox/demo-web-xxyyzz",
+  "identity_type": "sandbox"
 }
 ```
+
+:::note[System workload tokens]
+Tokens issued to your sandboxes always carry `identity_type: "sandbox"`. Miren
+issues tokens to its own system workloads as well, with a different value and a
+different subject shape, but those are never handed to an app and aren't
+something you request.
+:::
 
 External systems use these claims to decide what a token is allowed to do — for example, an AWS role trust policy can require a specific `sub` or `aud` before handing back credentials.
 

--- a/pkg/oidcauth/composite.go
+++ b/pkg/oidcauth/composite.go
@@ -102,6 +102,22 @@ func (c *CompositeAuthorizer) Authorize(ctx context.Context, identity *rpc.Ident
 		// OIDC callers are restricted to the oidc-deploy role
 		return authorizeOIDC(resource, action)
 
+	case rpc.AuthMethodSystem:
+		// System workload identities exist to reach specific cluster-internal
+		// services (the registry, telemetry), each of which verifies the token
+		// itself against its own audience. They carry no RPC privileges at all:
+		// falling through to the default would hand blanket access to any
+		// caller holding one, which is the opposite of why the identity is
+		// scoped.
+		//
+		// Deny-by-default is a starting point, not the intended end state.
+		// System workload tokens carry a real subject
+		// (org:X:cluster:Y:system:name), so once authorization is driven by
+		// policy rather than by the identity method, a workload that needs a
+		// particular method should be granted it by rule like any other
+		// subject, and this arm should go away rather than grow a list.
+		return fmt.Errorf("access denied: system workload identities may not call RPC methods")
+
 	case rpc.AuthMethodJWT, rpc.AuthMethodAnonymous, rpc.AuthMethodToken:
 		// Delegate to primary (cloud RBAC).
 		fallthrough

--- a/pkg/rpc/authenticator.go
+++ b/pkg/rpc/authenticator.go
@@ -37,6 +37,7 @@ const (
 	AuthMethodAnonymous AuthMethod = "anonymous" // No authentication (public methods)
 	AuthMethodToken     AuthMethod = "token"     // Bearer token (e.g., outboard)
 	AuthMethodOIDC      AuthMethod = "oidc"      // External OIDC token (e.g., GitHub Actions)
+	AuthMethodSystem    AuthMethod = "system"    // Cluster-issued system workload identity
 )
 
 // Identity represents an authenticated caller

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -75,17 +75,44 @@ type Issuer struct {
 type TokenIssuer interface {
 	IssueToken(app, sandboxID string) (string, error)
 	IssueTokenWithOptions(app, sandboxID string, opts TokenOptions) (string, error)
+	IssueSystemWorkloadToken(workload SystemWorkload, opts TokenOptions) (string, error)
 	IssuerURL() string
 }
 
 var _ TokenIssuer = (*Issuer)(nil)
+
+// IdentityType names the kind of principal a token represents.
+//
+// The value travels as its own claim rather than being inferred from the
+// subject: buildSubject interpolates a user-controlled app name, so
+// prefix-matching a subject string is a forgery vector. Tokens issued before
+// this claim existed carry no identity_type, which reads as "not a system
+// workload" and so fails closed for system-only resources.
+//
+// It is a defined type so that switches over it are exhaustiveness-checked,
+// the way rpc.AuthMethod already is. Note that this buys nothing at the trust
+// boundary itself: a token arriving from a caller decodes into whatever string
+// it contained, so verification still has to compare the value rather than
+// assume it is one of the constants below.
+type IdentityType string
+
+const (
+	IdentityTypeSandbox IdentityType = "sandbox"
+	IdentityTypeSystem  IdentityType = "system"
+)
 
 type WorkloadClaims struct {
 	jwt.RegisteredClaims
 	OrganizationID string `json:"organization_id,omitempty"`
 	ClusterID      string `json:"cluster_id,omitempty"`
 	App            string `json:"app,omitempty"`
-	SandboxID      string `json:"sandbox_id"`
+	// SandboxID deliberately keeps its unconditional encoding: it predates
+	// system workload tokens and external verifiers may already federate on its
+	// presence. System workload tokens therefore carry an empty sandbox_id
+	// rather than omitting it.
+	SandboxID      string         `json:"sandbox_id"`
+	IdentityType   IdentityType   `json:"identity_type,omitempty"`
+	SystemWorkload SystemWorkload `json:"system_workload,omitempty"`
 }
 
 func NewIssuer(cfg IssuerConfig) (*Issuer, error) {
@@ -191,6 +218,12 @@ const (
 	DefaultTTL = 1 * time.Hour
 	MaxTTL     = 24 * time.Hour
 	MinTTL     = 60 * time.Second
+
+	// DefaultAudience is the audience stamped on a token whose caller did not
+	// ask for a specific one. Callers guarding a particular service should
+	// always request their own audience and verify it, so that a token minted
+	// for one service cannot be replayed against another.
+	DefaultAudience = "miren"
 )
 
 type TokenOptions struct {
@@ -203,11 +236,23 @@ func (iss *Issuer) IssueToken(app, sandboxID string) (string, error) {
 }
 
 func (iss *Issuer) IssueTokenWithOptions(app, sandboxID string, opts TokenOptions) (string, error) {
+	claims := iss.baseClaims(buildSubject(iss.organizationID, app, sandboxID), opts)
+	claims.App = app
+	claims.SandboxID = sandboxID
+	claims.IdentityType = IdentityTypeSandbox
+
+	return iss.sign(claims)
+}
+
+// baseClaims fills in everything common to every token the cluster issues:
+// registered claims, the cluster metadata external verifiers federate on, and
+// the normalized audience and lifetime.
+func (iss *Issuer) baseClaims(subject string, opts TokenOptions) WorkloadClaims {
 	now := time.Now()
 
 	aud := opts.Audience
 	if len(aud) == 0 {
-		aud = []string{"miren"}
+		aud = []string{DefaultAudience}
 	}
 
 	ttl := opts.TTL
@@ -221,12 +266,10 @@ func (iss *Issuer) IssueTokenWithOptions(app, sandboxID string, opts TokenOption
 		ttl = MinTTL
 	}
 
-	sub := buildSubject(iss.organizationID, app, sandboxID)
-
-	claims := WorkloadClaims{
+	return WorkloadClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    iss.issuerURL,
-			Subject:   sub,
+			Subject:   subject,
 			Audience:  jwt.ClaimStrings(aud),
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),
@@ -235,10 +278,12 @@ func (iss *Issuer) IssueTokenWithOptions(app, sandboxID string, opts TokenOption
 		},
 		OrganizationID: iss.organizationID,
 		ClusterID:      iss.clusterID,
-		App:            app,
-		SandboxID:      sandboxID,
 	}
+}
 
+// sign signs claims with the primary key, stamping its kid so verifiers can
+// select the right key during rotation.
+func (iss *Issuer) sign(claims WorkloadClaims) (string, error) {
 	token := jwt.NewWithClaims(iss.primary.method, claims)
 	token.Header["kid"] = iss.primary.kid
 

--- a/pkg/workloadidentity/system_workload.go
+++ b/pkg/workloadidentity/system_workload.go
@@ -1,0 +1,76 @@
+package workloadidentity
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SystemWorkload names a Miren-owned workload that may receive an identity.
+// System workloads are a closed set: adding one is a code change, not a
+// runtime configuration operation.
+type SystemWorkload string
+
+const (
+	SystemWorkloadSandboxController SystemWorkload = "sandboxcontroller"
+	SystemWorkloadTelemetryWriter   SystemWorkload = "telemetrywriter"
+)
+
+// ParseSystemWorkload converts the string representation used on the wire into a
+// known system workload.
+func ParseSystemWorkload(value string) (SystemWorkload, error) {
+	workload := SystemWorkload(value)
+	if !workload.valid() {
+		return "", fmt.Errorf("unknown system workload %q", value)
+	}
+	return workload, nil
+}
+
+func (w SystemWorkload) valid() bool {
+	switch w {
+	case SystemWorkloadSandboxController, SystemWorkloadTelemetryWriter:
+		return true
+	default:
+		return false
+	}
+}
+
+// IssueSystemWorkloadToken mints a token identifying a Miren-owned workload
+// (the sandbox controller, a telemetry writer) rather than a customer workload.
+//
+// System workload tokens let Miren's own code authenticate to cluster-internal
+// services without a second credential system: they are minted by the same
+// issuer, verified the same way, and inherit the short lifetimes that make
+// revocation tractable. They are deliberately distinguishable from sandbox
+// tokens by the identity_type claim, because the services they open are
+// precisely the ones a sandbox must not reach.
+//
+// Callers choose an audience scoped to the service they intend to reach, since
+// one workload may call several services. The receiving service verifies that
+// audience and the expected workload together so a token minted for one
+// workload or service cannot be replayed against another.
+func (iss *Issuer) IssueSystemWorkloadToken(workload SystemWorkload, opts TokenOptions) (string, error) {
+	if !workload.valid() {
+		return "", fmt.Errorf("unknown system workload %q", workload)
+	}
+
+	claims := iss.baseClaims(buildSystemWorkloadSubject(iss.organizationID, iss.clusterID, workload), opts)
+	claims.SystemWorkload = workload
+	claims.IdentityType = IdentityTypeSystem
+
+	return iss.sign(claims)
+}
+
+// buildSystemWorkloadSubject renders a system workload's subject as
+// org:<org>:cluster:<cluster>:system:<name>, omitting the org and cluster
+// segments when the cluster has no registration to supply them.
+func buildSystemWorkloadSubject(orgID, clusterID string, workload SystemWorkload) string {
+	var parts []string
+	if orgID != "" {
+		parts = append(parts, "org:"+orgID)
+	}
+	if clusterID != "" {
+		parts = append(parts, "cluster:"+clusterID)
+	}
+	parts = append(parts, "system:"+string(workload))
+	return strings.Join(parts, ":")
+}

--- a/pkg/workloadidentity/system_workload_test.go
+++ b/pkg/workloadidentity/system_workload_test.go
@@ -1,0 +1,288 @@
+package workloadidentity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testIssuer(t *testing.T) *Issuer {
+	t.Helper()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:       t.TempDir(),
+		IssuerURL:      "https://example.miren.cloud",
+		OrganizationID: "org-123",
+		ClusterID:      "cluster-456",
+	})
+	require.NoError(t, err)
+	return iss
+}
+
+func TestIssueSystemWorkloadToken_Claims(t *testing.T) {
+	iss := testIssuer(t)
+
+	token, err := iss.IssueSystemWorkloadToken(SystemWorkloadSandboxController, TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	require.NoError(t, err)
+
+	claims, err := iss.VerifyToken(token, "miren-registry")
+	require.NoError(t, err)
+
+	assert.Equal(t, IdentityTypeSystem, claims.IdentityType)
+	assert.Equal(t, SystemWorkloadSandboxController, claims.SystemWorkload)
+	assert.Equal(t, "org:org-123:cluster:cluster-456:system:sandboxcontroller", claims.Subject)
+	assert.Equal(t, "org-123", claims.OrganizationID)
+	assert.Equal(t, "cluster-456", claims.ClusterID)
+
+	// A system workload identity is not scoped to any app or sandbox.
+	assert.Empty(t, claims.App)
+	assert.Empty(t, claims.SandboxID)
+}
+
+func TestIssueSystemWorkloadToken_SubjectOmitsUnsetClusterMetadata(t *testing.T) {
+	// A bare-metal cluster with no registration has neither an org nor a
+	// cluster id, and the subject should degrade to just the workload rather
+	// than emitting empty segments.
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  t.TempDir(),
+		IssuerURL: "https://baremetal.example.com",
+	})
+	require.NoError(t, err)
+
+	token, err := iss.IssueSystemWorkloadToken(SystemWorkloadSandboxController, TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	require.NoError(t, err)
+
+	claims, err := iss.VerifyToken(token, "miren-registry")
+	require.NoError(t, err)
+	assert.Equal(t, "system:sandboxcontroller", claims.Subject)
+}
+
+func TestParseSystemWorkload(t *testing.T) {
+	for _, workload := range []SystemWorkload{SystemWorkloadSandboxController, SystemWorkloadTelemetryWriter} {
+		parsed, err := ParseSystemWorkload(string(workload))
+		require.NoError(t, err)
+		assert.Equal(t, workload, parsed)
+	}
+
+	_, err := ParseSystemWorkload("notathing")
+	require.Error(t, err)
+}
+
+func TestIssueSystemWorkloadToken_RejectsUnknownWorkload(t *testing.T) {
+	_, err := testIssuer(t).IssueSystemWorkloadToken(SystemWorkload("notathing"), TokenOptions{})
+	require.Error(t, err)
+}
+
+// TestVerifySystemWorkloadToken_RejectsSandboxToken is the check the whole scheme
+// rests on. Sandboxes can reach cluster-internal services on the bridge, and
+// their tokens are signed by the same key as a system workload's, so the
+// identity_type claim is the only thing keeping them out.
+func TestVerifySystemWorkloadToken_RejectsSandboxToken(t *testing.T) {
+	iss := testIssuer(t)
+
+	token, err := iss.IssueTokenWithOptions("myapp", "sb-123", TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	require.NoError(t, err)
+
+	// The token itself is perfectly valid...
+	claims, err := iss.VerifyToken(token, "miren-registry")
+	require.NoError(t, err)
+	assert.Equal(t, IdentityTypeSandbox, claims.IdentityType)
+
+	// ...but it is not a system workload identity.
+	_, err = iss.VerifySystemWorkloadToken(token, "miren-registry", SystemWorkloadSandboxController)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a system workload identity")
+}
+
+func TestVerifySystemWorkloadToken_AcceptsSystemWorkloadToken(t *testing.T) {
+	iss := testIssuer(t)
+
+	token, err := iss.IssueSystemWorkloadToken(SystemWorkloadSandboxController, TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	require.NoError(t, err)
+
+	claims, err := iss.VerifySystemWorkloadToken(token, "miren-registry", SystemWorkloadSandboxController)
+	require.NoError(t, err)
+	assert.Equal(t, SystemWorkloadSandboxController, claims.SystemWorkload)
+}
+
+func TestVerifySystemWorkloadToken_RejectsDifferentSystemWorkload(t *testing.T) {
+	iss := testIssuer(t)
+
+	token, err := iss.IssueSystemWorkloadToken(SystemWorkloadTelemetryWriter, TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	require.NoError(t, err)
+
+	_, err = iss.VerifySystemWorkloadToken(token, "miren-registry", SystemWorkloadSandboxController)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `system workload "telemetrywriter", expected "sandboxcontroller"`)
+}
+
+func TestVerifySystemWorkloadToken_RejectsUnknownExpectedWorkload(t *testing.T) {
+	iss := testIssuer(t)
+
+	token, err := iss.IssueSystemWorkloadToken(SystemWorkloadSandboxController, TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	require.NoError(t, err)
+
+	_, err = iss.VerifySystemWorkloadToken(token, "miren-registry", SystemWorkload("notathing"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown expected system workload "notathing"`)
+}
+
+// TestVerifyToken_RejectsWrongAudience covers replay across services: a token
+// minted so a system workload can reach one service must not open another.
+func TestVerifyToken_RejectsWrongAudience(t *testing.T) {
+	iss := testIssuer(t)
+
+	token, err := iss.IssueSystemWorkloadToken(SystemWorkloadSandboxController, TokenOptions{
+		Audience: []string{"miren-metrics"},
+	})
+	require.NoError(t, err)
+
+	_, err = iss.VerifyToken(token, "miren-registry")
+	require.Error(t, err)
+
+	// Same token, at the service it was actually minted for.
+	_, err = iss.VerifyToken(token, "miren-metrics")
+	assert.NoError(t, err)
+}
+
+func TestVerifyToken_RequiresExpectedAudience(t *testing.T) {
+	iss := testIssuer(t)
+
+	token, err := iss.IssueSystemWorkloadToken(SystemWorkloadSandboxController, TokenOptions{})
+	require.NoError(t, err)
+
+	// Verifying without naming an audience would silently accept a token minted
+	// for anything, so it is refused outright.
+	_, err = iss.VerifyToken(token, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "audience is required")
+}
+
+func TestVerifyToken_RejectsExpiredToken(t *testing.T) {
+	iss := testIssuer(t)
+
+	// Build an already-expired token directly; IssueSystemWorkloadToken clamps TTL
+	// to MinTTL, so it cannot produce one.
+	claims := iss.baseClaims("system:sandboxcontroller", TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	claims.IdentityType = IdentityTypeSystem
+	claims.SystemWorkload = SystemWorkloadSandboxController
+	claims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-time.Minute))
+
+	token, err := iss.sign(claims)
+	require.NoError(t, err)
+
+	_, err = iss.VerifyToken(token, "miren-registry")
+	assert.Error(t, err)
+}
+
+func TestVerifyToken_RejectsTokenFromAnotherCluster(t *testing.T) {
+	// Each cluster is its own issuer with its own key, so a neighbouring
+	// cluster's token must not verify here even though it is well-formed and
+	// names the same audience.
+	other := testIssuer(t)
+	iss := testIssuer(t)
+
+	token, err := other.IssueSystemWorkloadToken(SystemWorkloadSandboxController, TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	require.NoError(t, err)
+
+	_, err = iss.VerifyToken(token, "miren-registry")
+	assert.Error(t, err)
+}
+
+// TestVerifyToken_RejectsUnsignedToken covers the classic JWT confusion attack:
+// a caller nominating "none" as the algorithm to skip signature verification.
+func TestVerifyToken_RejectsUnsignedToken(t *testing.T) {
+	iss := testIssuer(t)
+
+	claims := iss.baseClaims("system:sandboxcontroller", TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	claims.IdentityType = IdentityTypeSystem
+	claims.SystemWorkload = SystemWorkloadSandboxController
+
+	unsigned := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	unsigned.Header["kid"] = iss.primary.kid
+	token, err := unsigned.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+
+	_, err = iss.VerifyToken(token, "miren-registry")
+	assert.Error(t, err)
+}
+
+func TestVerifyToken_RejectsTokenWithoutKID(t *testing.T) {
+	iss := testIssuer(t)
+
+	claims := iss.baseClaims("system:sandboxcontroller", TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	claims.IdentityType = IdentityTypeSystem
+	claims.SystemWorkload = SystemWorkloadSandboxController
+
+	// Sign with the real key but omit the kid header.
+	token := jwt.NewWithClaims(iss.primary.method, claims)
+	signed, err := token.SignedString(iss.primary.private)
+	require.NoError(t, err)
+
+	_, err = iss.VerifyToken(signed, "miren-registry")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kid")
+}
+
+// TestVerifyToken_AcceptsTokenFromRotatedKey confirms verification follows the
+// rotation overlap the issuer already supports: a token signed before a
+// rotation stays verifiable while the old key is still advertised.
+func TestVerifyToken_AcceptsTokenFromRotatedKey(t *testing.T) {
+	dir := t.TempDir()
+
+	before, err := NewIssuer(IssuerConfig{
+		DataPath:       dir,
+		IssuerURL:      "https://example.miren.cloud",
+		OrganizationID: "org-123",
+		ClusterID:      "cluster-456",
+	})
+	require.NoError(t, err)
+
+	token, err := before.IssueSystemWorkloadToken(SystemWorkloadSandboxController, TokenOptions{
+		Audience: []string{"miren-registry"},
+	})
+	require.NoError(t, err)
+
+	// Rotate: the operator moves the current key aside and restarts, which
+	// generates a fresh primary and advertises the old one for verification.
+	keyPath := filepath.Join(dir, "server", "workload-identity.key")
+	require.NoError(t, os.Rename(keyPath, keyPath+".prev"))
+
+	after, err := NewIssuer(IssuerConfig{
+		DataPath:       dir,
+		IssuerURL:      "https://example.miren.cloud",
+		OrganizationID: "org-123",
+		ClusterID:      "cluster-456",
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, before.primary.kid, after.primary.kid)
+
+	claims, err := after.VerifySystemWorkloadToken(token, "miren-registry", SystemWorkloadSandboxController)
+	require.NoError(t, err)
+	assert.Equal(t, SystemWorkloadSandboxController, claims.SystemWorkload)
+}

--- a/pkg/workloadidentity/verify.go
+++ b/pkg/workloadidentity/verify.go
@@ -1,0 +1,107 @@
+package workloadidentity
+
+import (
+	"crypto"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// VerifyToken checks a token minted by this issuer and returns its claims.
+//
+// This is the in-process verification path, for callers that live in the same
+// process as the signing key (the coordinator). It reads the public keys
+// directly and performs no network I/O, so it neither depends on nor races the
+// JWKS endpoint. Verifiers in other processes should fetch JWKS over the
+// issuer's discovery document instead — see pkg/oidcauth's Validator.
+//
+// expectedAudience is required. A token is only accepted if it names that
+// audience, which is what stops a token minted for one service being replayed
+// against another.
+func (iss *Issuer) VerifyToken(tokenString, expectedAudience string) (*WorkloadClaims, error) {
+	if expectedAudience == "" {
+		return nil, fmt.Errorf("an expected audience is required to verify a token")
+	}
+
+	parser := jwt.NewParser(
+		// Pin the accepted algorithms to the ones this issuer actually signs
+		// with. Without this a token could nominate its own algorithm, which is
+		// the classic JWT confusion attack.
+		jwt.WithValidMethods(iss.supportedAlgs()),
+		jwt.WithIssuer(iss.issuerURL),
+		jwt.WithAudience(expectedAudience),
+		jwt.WithExpirationRequired(),
+	)
+
+	claims := &WorkloadClaims{}
+	if _, err := parser.ParseWithClaims(tokenString, claims, iss.keyForToken); err != nil {
+		return nil, fmt.Errorf("verifying token: %w", err)
+	}
+
+	return claims, nil
+}
+
+// VerifySystemWorkloadToken verifies a token and additionally requires that it
+// identifies the expected Miren-owned system workload rather than a customer
+// workload or a different system workload.
+//
+// Services that only system workloads may reach should call this rather than
+// VerifyToken, so neither the identity type nor workload authorization can be
+// forgotten at a call site. Sandbox tokens are signed by the same key and will
+// verify cleanly; these claims are the only thing separating them.
+func (iss *Issuer) VerifySystemWorkloadToken(tokenString, expectedAudience string, expectedWorkload SystemWorkload) (*WorkloadClaims, error) {
+	if !expectedWorkload.valid() {
+		return nil, fmt.Errorf("unknown expected system workload %q", expectedWorkload)
+	}
+
+	claims, err := iss.VerifyToken(tokenString, expectedAudience)
+	if err != nil {
+		return nil, err
+	}
+
+	if claims.IdentityType != IdentityTypeSystem {
+		return nil, fmt.Errorf("token is not a system workload identity (identity_type %q)", claims.IdentityType)
+	}
+	if !claims.SystemWorkload.valid() {
+		return nil, fmt.Errorf("system workload token carries unknown workload %q", claims.SystemWorkload)
+	}
+	if claims.SystemWorkload != expectedWorkload {
+		return nil, fmt.Errorf("token identifies system workload %q, expected %q", claims.SystemWorkload, expectedWorkload)
+	}
+
+	return claims, nil
+}
+
+// keyForToken resolves the public key a token was signed with by matching its
+// kid header against the issuer's live and advertised keys. A token without a
+// kid is refused: this issuer stamps one on everything it signs, so a missing
+// kid means the token did not come from here.
+func (iss *Issuer) keyForToken(token *jwt.Token) (any, error) {
+	kid, _ := token.Header["kid"].(string)
+	if kid == "" {
+		return nil, fmt.Errorf("token has no kid header")
+	}
+
+	if pub := iss.publicKeyByID(kid); pub != nil {
+		return pub, nil
+	}
+
+	return nil, fmt.Errorf("no known signing key for kid %q", kid)
+}
+
+// publicKeyByID returns the public key with the given key ID, or nil. Live
+// signing keys are searched before advertised (verify-only) ones, though key
+// IDs are content-derived so the two sets cannot disagree about a key.
+func (iss *Issuer) publicKeyByID(kid string) crypto.PublicKey {
+	for _, k := range iss.keys {
+		if k.kid == kid {
+			return k.public
+		}
+	}
+	for _, jwk := range iss.advertised {
+		if jwk.KeyID == kid {
+			return jwk.Key
+		}
+	}
+	return nil
+}

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -1029,6 +1029,111 @@ func (s *RegistrationServer) IssueWorkloadToken(ctx context.Context, req *runner
 	return nil
 }
 
+// runnerSystemWorkloads are the identities a distributed runner is allowed to
+// request. A runner cannot mint an identity for a workload it does not run,
+// notably one belonging only to the coordinator, whose identity opens strictly
+// more than a runner's does.
+//
+// Adding an entry is the intended way to onboard a new runner-side workload.
+var runnerSystemWorkloads = []workloadidentity.SystemWorkload{
+	// The sandbox controller pulls images from the cluster-local registry.
+	workloadidentity.SystemWorkloadSandboxController,
+
+	// The telemetry writers ship metrics and logs off the runner. Metrics and
+	// logs share one identity deliberately: both writers are constructed by the
+	// same process from the same certificate at the same moment, so splitting
+	// them would add an allowlist entry without adding a boundary.
+	workloadidentity.SystemWorkloadTelemetryWriter,
+}
+
+// IssueSystemWorkloadToken mints a system workload identity token on behalf of a
+// distributed runner, which does not hold the cluster signing key. The caller is
+// an mTLS-authenticated runner, and the workload it may request is
+// constrained by runnerSystemWorkloads.
+func (s *RegistrationServer) IssueSystemWorkloadToken(ctx context.Context, req *runner_v1alpha.RunnerRegistrationIssueSystemWorkloadToken) error {
+	args := req.Args()
+	results := req.Results()
+
+	if s.WorkloadIssuer == nil {
+		results.SetError("workload identity issuer is not configured")
+		return nil
+	}
+
+	if !args.HasSystemWorkload() || args.SystemWorkload() == "" {
+		results.SetError("system workload is required")
+		return nil
+	}
+	workload, err := workloadidentity.ParseSystemWorkload(args.SystemWorkload())
+	if err != nil {
+		s.Log.Warn("system workload token request denied", "system_workload", args.SystemWorkload(), "error", err)
+		results.SetError("not authorized to issue a token for this system workload")
+		return nil
+	}
+
+	if err := s.authorizeSystemWorkloadRequest(ctx, workload); err != nil {
+		s.Log.Warn("system workload token request denied", "system_workload", workload, "error", err)
+		results.SetError("not authorized to issue a token for this system workload")
+		return nil
+	}
+
+	// The audience names the service this workload intends to call, so it is
+	// caller-selected rather than coupled to the workload here. The receiving
+	// service verifies both the audience and expected workload before granting
+	// access.
+	opts := workloadidentity.TokenOptions{}
+	if args.HasAudience() {
+		opts.Audience = args.Audience()
+	}
+	if args.HasTtlSeconds() && args.TtlSeconds() > 0 {
+		opts.TTL = time.Duration(args.TtlSeconds()) * time.Second
+	}
+
+	token, err := s.WorkloadIssuer.IssueSystemWorkloadToken(workload, opts)
+	if err != nil {
+		s.Log.Error("failed to issue system workload identity token",
+			"system_workload", workload, "error", err)
+		results.SetError("failed to issue token")
+		return nil
+	}
+
+	results.SetToken(token)
+	return nil
+}
+
+// authorizeSystemWorkloadRequest verifies that the named workload is available
+// on runners and that the caller presents a certificate for a runner that is
+// still registered. The registration check bounds a decommissioned runner's
+// access, since caauth has no revocation and its certificate stays valid until
+// it expires.
+func (s *RegistrationServer) authorizeSystemWorkloadRequest(ctx context.Context, workload workloadidentity.SystemWorkload) error {
+	if !slices.Contains(runnerSystemWorkloads, workload) {
+		return fmt.Errorf("system workload %q is not one a runner may request", workload)
+	}
+
+	identity, err := requireRunnerCertIdentity(ctx)
+	if err != nil {
+		return err
+	}
+	if identity == nil {
+		return nil
+	}
+
+	runnerID, ok := strings.CutPrefix(identity.Subject, "runner-")
+	if !ok || runnerID == "" {
+		return fmt.Errorf("caller %q is not a runner certificate", identity.Subject)
+	}
+
+	registered, err := s.runnerIDRegistered(ctx, runnerID)
+	if err != nil {
+		return fmt.Errorf("verifying registration of runner %s: %w", runnerID, err)
+	}
+	if !registered {
+		return fmt.Errorf("runner %s is not registered", runnerID)
+	}
+
+	return nil
+}
+
 // runnerCertName is the client-certificate CommonName issued to a runner during
 // Join. It embeds the full runner ID so the coordinator can attribute an mTLS
 // connection back to a specific runner and authorize per-runner actions.
@@ -1048,17 +1153,12 @@ func runnerCertName(runnerID string) string {
 // runnerCertName. When authentication is disabled (anonymous), there is nothing
 // to verify against and the check is skipped.
 func (s *RegistrationServer) authorizeSandboxOwnership(ctx context.Context, sandboxID string) error {
-	identity := rpc.IdentityFromContext(ctx)
+	identity, err := requireRunnerCertIdentity(ctx)
+	if err != nil {
+		return err
+	}
 	if identity == nil {
-		return fmt.Errorf("no caller identity")
-	}
-	if identity.Method == rpc.AuthMethodAnonymous {
-		// Authentication is disabled on this coordinator; ownership cannot be
-		// established, so don't block issuance.
 		return nil
-	}
-	if identity.Method != rpc.AuthMethodCert {
-		return fmt.Errorf("caller must authenticate with a runner certificate, got %q", identity.Method)
 	}
 
 	sbResp, err := s.EAC.Get(ctx, sandboxID)
@@ -1089,6 +1189,25 @@ func (s *RegistrationServer) authorizeSandboxOwnership(ctx context.Context, sand
 	}
 
 	return nil
+}
+
+// requireRunnerCertIdentity validates the common authentication boundary for
+// runner token issuance. An anonymous identity means authentication is disabled
+// on this coordinator, so there is no certificate identity to authorize against.
+// NoAuth is only used by in-process test helpers and is not configurable in a
+// real deployment.
+func requireRunnerCertIdentity(ctx context.Context) (*rpc.Identity, error) {
+	identity := rpc.IdentityFromContext(ctx)
+	if identity == nil {
+		return nil, fmt.Errorf("no caller identity")
+	}
+	if identity.Method == rpc.AuthMethodAnonymous {
+		return nil, nil
+	}
+	if identity.Method != rpc.AuthMethodCert {
+		return nil, fmt.Errorf("caller must authenticate with a runner certificate, got %q", identity.Method)
+	}
+	return identity, nil
 }
 
 // resolveSandboxApp derives the application name for a sandbox from the entity

--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -16,6 +16,7 @@ import (
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/workloadidentity"
 )
 
 type testEnv struct {
@@ -990,4 +991,112 @@ func containsStr(ss []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// TestAuthorizeSystemWorkloadRequest covers the authorization guarding system
+// workload identity minting. The caller must be a runner that is still
+// registered, and it may only ask for a workload it actually runs.
+func TestAuthorizeSystemWorkloadRequest(t *testing.T) {
+	ctx := context.Background()
+	env, cleanup := newTestServer(t)
+	defer cleanup()
+
+	secret := env.createInviteAndDecode(t, ctx)
+	joinResult, err := env.client.Join(ctx, secret, "", "10.0.0.1:8443", "test-version", nil, "test-runner")
+	if err != nil {
+		t.Fatalf("Join RPC failed: %v", err)
+	}
+	if joinResult.HasError() {
+		t.Fatalf("Join returned error: %s", joinResult.Error())
+	}
+	runnerID := joinResult.RunnerId()
+
+	certIdentity := func(cn string) *rpc.Identity {
+		return &rpc.Identity{Subject: cn, Method: rpc.AuthMethodCert}
+	}
+
+	tests := []struct {
+		name     string
+		identity *rpc.Identity
+		workload workloadidentity.SystemWorkload
+		wantErr  bool
+	}{
+		{
+			name:     "registered runner requesting an allowed system workload",
+			identity: certIdentity(runnerCertName(runnerID)),
+			workload: workloadidentity.SystemWorkloadSandboxController,
+		},
+		{
+			name:     "unknown system workload",
+			identity: certIdentity(runnerCertName(runnerID)),
+			workload: workloadidentity.SystemWorkload("notathing"),
+			wantErr:  true,
+		},
+		{
+			// caauth has no revocation, so a removed runner keeps a valid
+			// certificate. The registration check is what cuts its access.
+			name:     "certificate for a runner that is not registered",
+			identity: certIdentity(runnerCertName("00000000-0000-0000-0000-000000000000")),
+			workload: workloadidentity.SystemWorkloadSandboxController,
+			wantErr:  true,
+		},
+		{
+			name:     "certificate that is not a runner certificate",
+			identity: certIdentity("miren-server"),
+			workload: workloadidentity.SystemWorkloadSandboxController,
+			wantErr:  true,
+		},
+		{
+			name:     "non-certificate authentication",
+			identity: &rpc.Identity{Subject: "user@example.com", Method: rpc.AuthMethodJWT},
+			workload: workloadidentity.SystemWorkloadSandboxController,
+			wantErr:  true,
+		},
+		{
+			name:     "no caller identity",
+			identity: nil,
+			workload: workloadidentity.SystemWorkloadSandboxController,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callCtx := ctx
+			if tt.identity != nil {
+				callCtx = rpc.ContextWithIdentity(ctx, tt.identity)
+			}
+
+			err := env.server.authorizeSystemWorkloadRequest(callCtx, tt.workload)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected authorization to fail, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expected authorization to succeed, got %v", err)
+			}
+		})
+	}
+}
+
+// TestAuthorizeSystemWorkloadRequestAnonymousKeepsAllowlist pins the shape of the
+// no-authentication path. Issuance is allowed because there is no identity to
+// check against (NoAuth is test-only), but the allowlist still applies, so even
+// an unauthenticated coordinator cannot mint an arbitrary system identity.
+func TestAuthorizeSystemWorkloadRequestAnonymousKeepsAllowlist(t *testing.T) {
+	ctx := context.Background()
+	env, cleanup := newTestServer(t)
+	defer cleanup()
+
+	anon := rpc.ContextWithIdentity(ctx, &rpc.Identity{
+		Subject: "anonymous",
+		Method:  rpc.AuthMethodAnonymous,
+	})
+
+	if err := env.server.authorizeSystemWorkloadRequest(anon, workloadidentity.SystemWorkloadSandboxController); err != nil {
+		t.Errorf("expected allowlisted system workload to be permitted, got %v", err)
+	}
+
+	if err := env.server.authorizeSystemWorkloadRequest(anon, workloadidentity.SystemWorkload("coordinator")); err == nil {
+		t.Error("expected a system workload off the allowlist to be refused")
+	}
 }


### PR DESCRIPTION
Miren already has workload identity for customer sandboxes, but the next internal services we need to protect are reached by Miren’s own code. The sandbox controller pulls from the cluster-local registry, and the telemetry writers ship metrics and logs from distributed runners. Neither fits the sandbox identity model.

Rather than introduce another credential system, this extends the existing issuer with system workload identities. They use the same signing keys and short lifetimes, but carry an explicit `identity_type: system`, a closed system-workload name, and subjects such as `org:X:cluster:Y:system:sandboxcontroller`. Audience verification keeps tokens scoped to the service they were minted for.

Distributed runners still do not receive the signing key. They request tokens from the coordinator over the mTLS channel established during Join, where the coordinator checks that the runner remains registered and restricts which workloads it may request. That gives us a useful revocation boundary even though the underlying runner certificates remain valid until they expire.

The initial workloads are `sandboxcontroller` for MIR-1477 and `telemetrywriter` for MIR-1483. System workload identities deliberately receive no RPC privileges by default. Each internal service must verify the token against its own audience instead of inheriting the RPC authorizer’s permissive fallback.

This PR stops at the shared identity primitives so the registry and telemetry work can proceed independently on top of them.

Part of MIR-1477 and MIR-1483.