### PR TITLE
Authenticate the cluster-local OCI registry

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -528,7 +528,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 			SocketDir:      socketDir,
 			GCKeepStorage:  int64(gcStorage.Bytes()),
 			GCKeepDuration: int64(gcDuration.Seconds()),
-			RegistryHost:   "cluster.local:5000",
+			RegistryHost:   ocireg.Host,
 		}
 
 		err = buildkitComponent.Start(sub, buildkitConfig)
@@ -1015,7 +1015,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		return fmt.Errorf("unrecognized ingress.mode %q (should have been caught by config validation)", mode)
 	}
 
-	registry := ocireg.NewRegistry(cfg.Server.GetDataPath(), ctx.Log, ec)
+	registry := ocireg.NewRegistry(cfg.Server.GetDataPath(), ctx.Log, ec, workloadIssuer)
 
 	if err := registry.Start(ctx, ":5000"); err != nil {
 		ctx.Log.Error("failed to start registry", "error", err)

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1253,6 +1253,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	appClient := appclient.NewClient(c.Log, loopback)
 
 	bs := build.NewBuilder(c.Log, eac, appClient, addonsClient, c.Resolver, c.TempDir, c.LogWriter, c.CloudAuth.DNSHostname, c.BuildKit, c.DataPath)
+	bs.WorkloadIssuer = c.WorkloadIssuer
 
 	var buildHandler build_v1alpha.Builder = bs
 	if labs.Sagas() {

--- a/components/ocireg/auth_test.go
+++ b/components/ocireg/auth_test.go
@@ -1,0 +1,107 @@
+package ocireg
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/workloadidentity"
+)
+
+func registryTestIssuer(t *testing.T) *workloadidentity.Issuer {
+	t.Helper()
+
+	issuer, err := workloadidentity.NewIssuer(workloadidentity.IssuerConfig{
+		DataPath:  t.TempDir(),
+		IssuerURL: "https://cluster.example.com",
+	})
+	require.NoError(t, err)
+	return issuer
+}
+
+func registryToken(
+	t *testing.T,
+	issuer *workloadidentity.Issuer,
+	workload workloadidentity.SystemWorkload,
+	audience string,
+) string {
+	t.Helper()
+
+	token, err := issuer.IssueSystemWorkloadToken(workload, workloadidentity.TokenOptions{
+		Audience: []string{audience},
+	})
+	require.NoError(t, err)
+	return token
+}
+
+func TestAuthorizeRegistry(t *testing.T) {
+	issuer := registryTestIssuer(t)
+	log := testutils.TestLogger(t)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	handler := authorizeRegistry(next, issuer, log)
+
+	sandboxToken := registryToken(t, issuer, workloadidentity.SystemWorkloadSandboxController, Audience)
+	buildKitToken := registryToken(t, issuer, workloadidentity.SystemWorkloadBuildKit, Audience)
+	telemetryToken := registryToken(t, issuer, workloadidentity.SystemWorkloadTelemetryWriter, Audience)
+	wrongAudienceToken := registryToken(t, issuer, workloadidentity.SystemWorkloadBuildKit, "somewhere-else")
+	customerToken, err := issuer.IssueTokenWithOptions("myapp", "sb-123", workloadidentity.TokenOptions{
+		Audience: []string{Audience},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		method     string
+		token      string
+		wantStatus int
+	}{
+		{name: "missing token", method: http.MethodGet, wantStatus: http.StatusUnauthorized},
+		{name: "malformed token", method: http.MethodGet, token: "not-a-jwt", wantStatus: http.StatusUnauthorized},
+		{name: "wrong audience", method: http.MethodGet, token: wrongAudienceToken, wantStatus: http.StatusUnauthorized},
+		{name: "customer sandbox", method: http.MethodGet, token: customerToken, wantStatus: http.StatusForbidden},
+		{name: "telemetry writer", method: http.MethodGet, token: telemetryToken, wantStatus: http.StatusForbidden},
+		{name: "sandbox controller pull", method: http.MethodGet, token: sandboxToken, wantStatus: http.StatusNoContent},
+		{name: "sandbox controller resolve", method: http.MethodHead, token: sandboxToken, wantStatus: http.StatusNoContent},
+		{name: "sandbox controller push", method: http.MethodPost, token: sandboxToken, wantStatus: http.StatusForbidden},
+		{name: "buildkit pull", method: http.MethodGet, token: buildKitToken, wantStatus: http.StatusNoContent},
+		{name: "buildkit push", method: http.MethodPost, token: buildKitToken, wantStatus: http.StatusNoContent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/v2/myapp/manifests/latest", nil)
+			if tt.token != "" {
+				req.Header.Set("Authorization", "Bearer "+tt.token)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+			if tt.wantStatus == http.StatusUnauthorized {
+				assert.Equal(t,
+					`Bearer realm="http://example.com/v2/token",service="miren-registry"`,
+					rec.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
+}
+
+func TestRegistryMuxLeavesHealthCheckUnauthenticated(t *testing.T) {
+	issuer := registryTestIssuer(t)
+	handler := NewRegistryHandler(t.TempDir(), testutils.TestLogger(t), nil)
+	mux := newMux(handler, issuer)
+
+	root := httptest.NewRecorder()
+	mux.ServeHTTP(root, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusOK, root.Code)
+
+	api := httptest.NewRecorder()
+	mux.ServeHTTP(api, httptest.NewRequest(http.MethodGet, "/v2/", nil))
+	assert.Equal(t, http.StatusUnauthorized, api.Code)
+}

--- a/components/ocireg/registry.go
+++ b/components/ocireg/registry.go
@@ -18,6 +18,12 @@ import (
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/workloadidentity"
+)
+
+const (
+	Host     = "cluster.local:5000"
+	Audience = "miren-registry"
 )
 
 // RegistryHandler processes all OCI registry requests
@@ -25,16 +31,18 @@ type Registry struct {
 	RootDir string
 	Log     *slog.Logger
 	EC      *entityserver.Client
+	Issuer  *workloadidentity.Issuer
 
 	server *http.Server
 }
 
 // NewRegistry creates a new Registry.
-func NewRegistry(rootDir string, log *slog.Logger, ec *entityserver.Client) *Registry {
+func NewRegistry(rootDir string, log *slog.Logger, ec *entityserver.Client, issuer *workloadidentity.Issuer) *Registry {
 	return &Registry{
 		RootDir: rootDir,
 		Log:     log,
 		EC:      ec,
+		Issuer:  issuer,
 	}
 }
 
@@ -51,7 +59,7 @@ func (r *Registry) Start(ctx context.Context, addr string) error {
 
 	r.server = &http.Server{
 		Addr:    addr,
-		Handler: newMux(NewRegistryHandler(path, r.Log, r.EC)),
+		Handler: newMux(NewRegistryHandler(path, r.Log, r.EC), r.Issuer),
 		BaseContext: func(net.Listener) context.Context {
 			return ctx
 		},
@@ -61,10 +69,10 @@ func (r *Registry) Start(ctx context.Context, addr string) error {
 }
 
 // newMux wires the registry handler up alongside the health check endpoint.
-func newMux(registry *RegistryHandler) *http.ServeMux {
+func newMux(registry *RegistryHandler, issuer *workloadidentity.Issuer) *http.ServeMux {
 	mux := http.NewServeMux()
 
-	mux.Handle("/v2/", registry)
+	mux.Handle("/v2/", authorizeRegistry(registry, issuer, registry.log))
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
@@ -79,6 +87,59 @@ func newMux(registry *RegistryHandler) *http.ServeMux {
 	})
 
 	return mux
+}
+
+func authorizeRegistry(next http.Handler, issuer *workloadidentity.Issuer, log *slog.Logger) http.Handler {
+	if issuer == nil {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scheme, token, ok := strings.Cut(r.Header.Get("Authorization"), " ")
+		if !ok || !strings.EqualFold(scheme, "Bearer") || token == "" {
+			registryUnauthorized(w, r)
+			return
+		}
+
+		claims, err := issuer.VerifyToken(token, Audience)
+		if err != nil {
+			log.Warn("rejected unauthenticated registry request", "error", err, "remote", r.RemoteAddr)
+			registryUnauthorized(w, r)
+			return
+		}
+
+		switch claims.SystemWorkload {
+		case workloadidentity.SystemWorkloadBuildKit:
+			if claims.IdentityType == workloadidentity.IdentityTypeSystem {
+				next.ServeHTTP(w, r)
+				return
+			}
+		case workloadidentity.SystemWorkloadSandboxController:
+			if claims.IdentityType == workloadidentity.IdentityTypeSystem &&
+				(r.Method == http.MethodGet || r.Method == http.MethodHead) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		case workloadidentity.SystemWorkloadTelemetryWriter:
+		}
+
+		log.Warn("rejected unauthorized registry request",
+			"identity_type", claims.IdentityType,
+			"system_workload", claims.SystemWorkload,
+			"method", r.Method,
+			"remote", r.RemoteAddr)
+		w.WriteHeader(http.StatusForbidden)
+	})
+}
+
+func registryUnauthorized(w http.ResponseWriter, r *http.Request) {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	w.Header().Set("WWW-Authenticate",
+		fmt.Sprintf(`Bearer realm="%s://%s/v2/token",service="%s"`, scheme, r.Host, Audience))
+	w.WriteHeader(http.StatusUnauthorized)
 }
 
 func (r *Registry) Shutdown(ctx context.Context) error {

--- a/components/ocireg/traversal_test.go
+++ b/components/ocireg/traversal_test.go
@@ -39,7 +39,7 @@ func newTestRegistry(t *testing.T) (*httptest.Server, string) {
 
 	handler := NewRegistryHandler(storageRoot, testutils.TestLogger(t), entServer.Client)
 
-	srv := httptest.NewServer(newMux(handler))
+	srv := httptest.NewServer(newMux(handler, nil))
 	t.Cleanup(srv.Close)
 
 	return srv, base

--- a/controllers/sandbox/resolver_test.go
+++ b/controllers/sandbox/resolver_test.go
@@ -1,0 +1,45 @@
+package sandbox
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/components/netresolve"
+	"miren.dev/runtime/components/ocireg"
+	"miren.dev/runtime/pkg/workloadidentity"
+)
+
+func TestLocalRegistryHostUsesSandboxControllerIdentity(t *testing.T) {
+	resolver, mapper := netresolve.NewLocalResolver()
+	require.NoError(t, mapper.SetHost("cluster.local", netip.MustParseAddr("10.42.0.1")))
+
+	issuer, err := workloadidentity.NewIssuer(workloadidentity.IssuerConfig{
+		DataPath:  t.TempDir(),
+		IssuerURL: "https://cluster.example.com",
+	})
+	require.NoError(t, err)
+
+	controller := &SandboxController{
+		Resolver:       resolver,
+		WorkloadIssuer: issuer,
+	}
+	host, err := controller.localRegistryHost()
+	require.NoError(t, err)
+
+	assert.Equal(t, "10.42.0.1:5000", host.Host)
+	assert.Equal(t, docker.HostCapabilityPull|docker.HostCapabilityResolve, host.Capabilities)
+	assert.False(t, host.Capabilities&docker.HostCapabilityPush != 0)
+
+	token := strings.TrimPrefix(host.Header.Get("Authorization"), "Bearer ")
+	require.NotEmpty(t, token)
+	_, err = issuer.VerifySystemWorkloadToken(
+		token,
+		ocireg.Audience,
+		workloadidentity.SystemWorkloadSandboxController,
+	)
+	require.NoError(t, err)
+}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -45,6 +45,7 @@ import (
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/network/network_v1alpha"
 	storage "miren.dev/runtime/api/storage/storage_v1alpha"
+	"miren.dev/runtime/components/ocireg"
 )
 
 const (
@@ -1530,20 +1531,11 @@ func (c *SandboxController) resolver() remotes.Resolver {
 	return docker.NewResolver(docker.ResolverOptions{
 		Hosts: func(host string) ([]docker.RegistryHost, error) {
 			switch host {
-			case "cluster.local", "cluster.local:5000":
-				addr, err := c.Resolver.LookupHost("cluster.local")
+			case "cluster.local", ocireg.Host:
+				config, err := c.localRegistryHost()
 				if err != nil {
-					return nil, fmt.Errorf("failed to resolve cluster.local: %w", err)
+					return nil, err
 				}
-
-				config := docker.RegistryHost{
-					Client:       http.DefaultClient,
-					Host:         addr.String() + ":5000",
-					Scheme:       "http",
-					Path:         "/v2",
-					Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush,
-				}
-
 				return []docker.RegistryHost{config}, nil
 			default:
 				config := containerdx.DefaultRegistryHost(host)
@@ -1551,6 +1543,33 @@ func (c *SandboxController) resolver() remotes.Resolver {
 			}
 		},
 	})
+}
+
+func (c *SandboxController) localRegistryHost() (docker.RegistryHost, error) {
+	addr, err := c.Resolver.LookupHost("cluster.local")
+	if err != nil {
+		return docker.RegistryHost{}, fmt.Errorf("failed to resolve cluster.local: %w", err)
+	}
+
+	config := docker.RegistryHost{
+		Client:       http.DefaultClient,
+		Host:         addr.String() + ":5000",
+		Scheme:       "http",
+		Path:         "/v2",
+		Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve,
+	}
+	if c.WorkloadIssuer != nil {
+		token, err := c.WorkloadIssuer.IssueSystemWorkloadToken(
+			workloadidentity.SystemWorkloadSandboxController,
+			workloadidentity.TokenOptions{Audience: []string{ocireg.Audience}},
+		)
+		if err != nil {
+			return docker.RegistryHost{}, fmt.Errorf("issuing registry token: %w", err)
+		}
+		config.Header = http.Header{"Authorization": []string{"Bearer " + token}}
+	}
+
+	return config, nil
 }
 
 func (c *SandboxController) BuildSpec(

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -36,7 +36,10 @@ func TestSandboxControllerFrozen(t *testing.T) {
 		// constructions became c.NodeId.Id(). This is a mechanical retype that
 		// produces byte-identical entity ids at runtime, and the saga path does no
 		// node-id construction, so there was nothing to mirror there either.
-		"sandbox.go":  "08abc0b3e6c57e4e2c4018d9b252d1de98768e8559e5eda8606fdb0c77347408",
+		//
+		// Registry authentication is shared by both controllers because the saga
+		// controller delegates image pulls to this inner controller.
+		"sandbox.go":  "82a1667dae3227bc67d533b14487187d8a71968c9678f45373996305e2b49897",
 		"volume.go":   "580062fb8a34f3f7f965689467a4b0f2ed403bc63c1ecdeb44949a7ba7e08dff",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/pkg/testserver/server.go
+++ b/pkg/testserver/server.go
@@ -216,7 +216,7 @@ func TestServer(t *testing.T) error {
 	})
 
 	// Create OCI registry
-	ociRegistry := ocireg.NewRegistry(filepath.Join(tempDir, "oci"), log, ec)
+	ociRegistry := ocireg.NewRegistry(filepath.Join(tempDir, "oci"), log, ec, nil)
 
 	// Start the OCI Registry
 	err = ociRegistry.Start(ctx, ":5000")

--- a/pkg/workloadidentity/system_workload.go
+++ b/pkg/workloadidentity/system_workload.go
@@ -13,6 +13,7 @@ type SystemWorkload string
 const (
 	SystemWorkloadSandboxController SystemWorkload = "sandboxcontroller"
 	SystemWorkloadTelemetryWriter   SystemWorkload = "telemetrywriter"
+	SystemWorkloadBuildKit          SystemWorkload = "buildkit"
 )
 
 // ParseSystemWorkload converts the string representation used on the wire into a
@@ -27,7 +28,7 @@ func ParseSystemWorkload(value string) (SystemWorkload, error) {
 
 func (w SystemWorkload) valid() bool {
 	switch w {
-	case SystemWorkloadSandboxController, SystemWorkloadTelemetryWriter:
+	case SystemWorkloadSandboxController, SystemWorkloadTelemetryWriter, SystemWorkloadBuildKit:
 		return true
 	default:
 		return false

--- a/pkg/workloadidentity/system_workload_test.go
+++ b/pkg/workloadidentity/system_workload_test.go
@@ -67,7 +67,11 @@ func TestIssueSystemWorkloadToken_SubjectOmitsUnsetClusterMetadata(t *testing.T)
 }
 
 func TestParseSystemWorkload(t *testing.T) {
-	for _, workload := range []SystemWorkload{SystemWorkloadSandboxController, SystemWorkloadTelemetryWriter} {
+	for _, workload := range []SystemWorkload{
+		SystemWorkloadSandboxController,
+		SystemWorkloadTelemetryWriter,
+		SystemWorkloadBuildKit,
+	} {
 		parsed, err := ParseSystemWorkload(string(workload))
 		require.NoError(t, err)
 		assert.Equal(t, workload, parsed)

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -43,6 +43,7 @@ import (
 	"miren.dev/runtime/pkg/rpc/stream"
 	"miren.dev/runtime/pkg/stackbuild"
 	"miren.dev/runtime/pkg/tarx"
+	"miren.dev/runtime/pkg/workloadidentity"
 )
 
 var buildTracer = otel.Tracer("miren.dev/runtime/build")
@@ -106,6 +107,8 @@ type Builder struct {
 	// BuildKit is the persistent BuildKit component for container image builds.
 	// When set, uses the shared daemon instead of launching ephemeral sandboxes.
 	BuildKit BuildKitProvider
+
+	WorkloadIssuer *workloadidentity.Issuer
 
 	sessions   sync.Map // sessionID → *buildSession
 	cacheLocks *appLocks

--- a/servers/build/build_saga_buildkit.go
+++ b/servers/build/build_saga_buildkit.go
@@ -160,7 +160,7 @@ func (b *Builder) runBuildkitBuild(
 	}
 	b.Log.Debug("buildkitd info", "version", ci.BuildkitVersion.Version, "rev", ci.BuildkitVersion.Revision)
 
-	bk := &Buildkit{Client: bkc, Log: b.Log}
+	bk := &Buildkit{Client: bkc, Log: b.Log, WorkloadIssuer: b.WorkloadIssuer}
 
 	buildEnvVars := computeBuildEnvVars(in.ExistingConfig.Variables, in.AppConfig, in.CLIEnvVars)
 	if len(buildEnvVars) > 0 {

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -3,19 +3,25 @@ package build
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"strings"
 	"sync"
 
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	exptypes "github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/frontend"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/session/auth/authprovider"
+	"miren.dev/runtime/components/ocireg"
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/stackbuild"
+	"miren.dev/runtime/pkg/workloadidentity"
 
 	"github.com/tonistiigi/fsutil"
 )
@@ -23,7 +29,8 @@ import (
 type Buildkit struct {
 	Client *client.Client
 
-	Log *slog.Logger
+	Log            *slog.Logger
+	WorkloadIssuer *workloadidentity.Issuer
 }
 
 type tarOutput struct {
@@ -126,16 +133,11 @@ func (b *Buildkit) Transform(ctx context.Context, dfs fsutil.FS, tos ...Transfor
 		"context":    dfs,
 	}
 
-	r, w, err := os.Pipe()
-	if err != nil {
-		return nil, nil, err
-	}
-
 	output := client.ExportEntry{
 		Type: "image",
 		Attrs: map[string]string{
 			"push": "true",
-			"name": "registry.cluster:5000/",
+			"name": ocireg.Host + "/",
 		},
 	}
 
@@ -147,6 +149,14 @@ func (b *Buildkit) Transform(ctx context.Context, dfs fsutil.FS, tos ...Transfor
 		Frontend:      "dockerfile.v0",
 		FrontendAttrs: opts.frontendAttrs,
 		Ref:           ref,
+	}
+	if err := b.addRegistryAuth(&solveOpt, ocireg.Host); err != nil {
+		return nil, nil, err
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	if opts.cacheDir != "" {
@@ -380,6 +390,10 @@ func (b *Buildkit) BuildImage(
 	}
 
 	solveOpt.Exports = []client.ExportEntry{output}
+	registryHost, _, _ := strings.Cut(imageURL, "/")
+	if err := b.addRegistryAuth(&solveOpt, registryHost); err != nil {
+		return nil, err
+	}
 
 	if opts.cacheDir != "" {
 		solveOpt.CacheImports = []client.CacheOptionsEntry{
@@ -528,4 +542,26 @@ func (b *Buildkit) BuildImage(
 	}
 
 	return &res, err
+}
+
+func (b *Buildkit) addRegistryAuth(solveOpt *client.SolveOpt, registryHost string) error {
+	if b.WorkloadIssuer == nil || registryHost != ocireg.Host {
+		return nil
+	}
+
+	token, err := b.WorkloadIssuer.IssueSystemWorkloadToken(
+		workloadidentity.SystemWorkloadBuildKit,
+		workloadidentity.TokenOptions{Audience: []string{ocireg.Audience}},
+	)
+	if err != nil {
+		return fmt.Errorf("issuing registry token: %w", err)
+	}
+
+	cfg := &configfile.ConfigFile{
+		AuthConfigs: map[string]types.AuthConfig{
+			registryHost: {RegistryToken: token},
+		},
+	}
+	solveOpt.Session = append(solveOpt.Session, authprovider.NewDockerAuthProvider(cfg, nil))
+	return nil
 }

--- a/servers/build/buildkit_test.go
+++ b/servers/build/buildkit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,11 +17,17 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	buildkit "github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/session/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tonistiigi/fsutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
 
+	"miren.dev/runtime/components/ocireg"
 	"miren.dev/runtime/pkg/imagerefs"
+	"miren.dev/runtime/pkg/workloadidentity"
 
 	_ "github.com/moby/buildkit/client/connhelper/dockercontainer"
 )
@@ -35,6 +42,72 @@ const (
 func checkDocker() bool {
 	_, err := os.Stat("/var/run/docker.sock")
 	return err == nil
+}
+
+func TestAddRegistryAuthProvidesBuildKitToken(t *testing.T) {
+	issuer, err := workloadidentity.NewIssuer(workloadidentity.IssuerConfig{
+		DataPath:  t.TempDir(),
+		IssuerURL: "https://cluster.example.com",
+	})
+	require.NoError(t, err)
+
+	bk := &Buildkit{WorkloadIssuer: issuer}
+	var solveOpt buildkit.SolveOpt
+	require.NoError(t, bk.addRegistryAuth(&solveOpt, "cluster.local:5000"))
+	require.Len(t, solveOpt.Session, 1)
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	solveOpt.Session[0].Register(server)
+	go server.Serve(listener)
+	t.Cleanup(func() {
+		server.Stop()
+		listener.Close()
+	})
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	response, err := auth.NewAuthClient(conn).FetchToken(context.Background(), &auth.FetchTokenRequest{
+		Host: "cluster.local:5000",
+	})
+	require.NoError(t, err)
+
+	_, err = issuer.VerifySystemWorkloadToken(
+		response.Token,
+		ocireg.Audience,
+		workloadidentity.SystemWorkloadBuildKit,
+	)
+	require.NoError(t, err)
+}
+
+func TestAddRegistryAuthWithoutIssuer(t *testing.T) {
+	bk := &Buildkit{}
+	var solveOpt buildkit.SolveOpt
+
+	require.NoError(t, bk.addRegistryAuth(&solveOpt, "cluster.local:5000"))
+	assert.Empty(t, solveOpt.Session)
+}
+
+func TestAddRegistryAuthIgnoresExternalRegistry(t *testing.T) {
+	issuer, err := workloadidentity.NewIssuer(workloadidentity.IssuerConfig{
+		DataPath:  t.TempDir(),
+		IssuerURL: "https://cluster.example.com",
+	})
+	require.NoError(t, err)
+
+	bk := &Buildkit{WorkloadIssuer: issuer}
+	var solveOpt buildkit.SolveOpt
+
+	require.NoError(t, bk.addRegistryAuth(&solveOpt, "registry.example.com"))
+	assert.Empty(t, solveOpt.Session)
 }
 
 type testInfra struct {

--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -1027,6 +1027,12 @@ func TestAuthorizeSystemWorkloadRequest(t *testing.T) {
 			workload: workloadidentity.SystemWorkloadSandboxController,
 		},
 		{
+			name:     "registered runner requesting coordinator-only buildkit workload",
+			identity: certIdentity(runnerCertName(runnerID)),
+			workload: workloadidentity.SystemWorkloadBuildKit,
+			wantErr:  true,
+		},
+		{
 			name:     "unknown system workload",
 			identity: certIdentity(runnerCertName(runnerID)),
 			workload: workloadidentity.SystemWorkload("notathing"),


### PR DESCRIPTION
The cluster-local registry had to remain reachable beyond the coordinator once distributed runners arrived, but that also left app images and upload storage open to anything that could reach port 5000.

This stacks on #990’s system workload identities and puts them to work. Coordinator-side BuildKit now gets a short-lived registry token for pushes, while sandbox controllers get a pull-only token. Distributed runners mint that pull token over their existing mTLS channel, so they can fetch images without receiving the cluster signing key or a write-capable credential.

The registry still leaves its health endpoint public, but protects the OCI API whenever workload identity is configured. Clusters without an issuer retain the existing auth-disabled behavior.

Closes MIR-1477

Stacked on #990.