### PR TITLE
Route runner telemetry through the coordinator

### DIFF
--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -28,6 +28,7 @@ import (
 	"miren.dev/runtime/observability"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/runnerconfig"
+	"miren.dev/runtime/servers/runnertelemetry"
 )
 
 func RunnerStart(ctx *Context, opts struct {
@@ -248,20 +249,50 @@ func RunnerStart(ctx *Context, opts struct {
 		deps.EtcdTLSCAFile = caFile
 	}
 
-	// Initialize observability subsystems. When the coordinator provided
-	// VictoriaMetrics/VictoriaLogs addresses at join time, the runner ships
-	// metrics and logs over flannel to the coordinator's instances. Otherwise
-	// we fall back to debug logging.
+	// Initialize observability subsystems. Telemetry goes to the coordinator's
+	// ingest endpoints rather than to VictoriaMetrics and VictoriaLogs
+	// directly, so neither of those has to listen anywhere this runner can
+	// reach. The addresses the coordinator sends at Join are no longer dialed;
+	// their presence is only the signal that the cluster records telemetry at
+	// all.
+	//
+	// The token source is armed after Start, because a distributed runner mints
+	// through the coordinator and has no issuer until it has connected. Writes
+	// before then fail loudly rather than dropping on the floor; in practice
+	// the first flush is seconds away and the connection is up well before it.
+	tokenSource := runnertelemetry.NewIssuerTokenSource()
+
+	var telemetryClient *runnertelemetry.Client
+	if cfg.VictoriametricsAddress != "" || cfg.VictorialogsAddress != "" {
+		telemetryClient, err = runnertelemetry.NewClient(runnertelemetry.ClientConfig{
+			ClientCertPEM: []byte(cfg.ClientCert),
+			ClientKeyPEM:  []byte(cfg.ClientKey),
+			CACertPEM:     []byte(cfg.CACert),
+			TokenSource:   tokenSource,
+			Timeout:       30 * time.Second,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to build telemetry client: %w", err)
+		}
+		defer func() {
+			if err := telemetryClient.Close(); err != nil {
+				ctx.Log.Error("failed to close telemetry client", "error", err)
+			}
+		}()
+	}
+
 	var metricsWriter *metrics.VictoriaMetricsWriter
-	if cfg.VictoriametricsAddress != "" {
-		metricsWriter = metrics.NewVictoriaMetricsWriter(ctx.Log, cfg.VictoriametricsAddress, 30*time.Second)
+	if telemetryClient != nil && cfg.VictoriametricsAddress != "" {
+		metricsURL := runnertelemetry.MetricsURL(cfg.CoordinatorAddress)
+		metricsWriter = metrics.NewVictoriaMetricsWriter(ctx.Log, metricsURL, 30*time.Second,
+			metrics.WithHTTPClient(telemetryClient.HTTP))
 		metricsWriter.Start()
 		defer func() {
 			if err := metricsWriter.Close(); err != nil {
 				ctx.Log.Error("failed to close metrics writer", "error", err)
 			}
 		}()
-		ctx.Log.Info("metrics writer started", "address", cfg.VictoriametricsAddress)
+		ctx.Log.Info("metrics writer started", "endpoint", metricsURL)
 	} else {
 		ctx.Log.Warn("no VictoriaMetrics address configured, sandbox metrics will not be recorded")
 	}
@@ -272,9 +303,24 @@ func RunnerStart(ctx *Context, opts struct {
 	sbMetrics.MemUsage = metrics.NewMemoryUsage(ctx.Log, metricsWriter, nil)
 	deps.SandboxMetrics = sbMetrics
 
-	if cfg.VictorialogsAddress != "" {
-		deps.LogWriter = observability.NewPersistentLogWriter(cfg.VictorialogsAddress, 30*time.Second)
-		ctx.Log.Info("log writer started", "address", cfg.VictorialogsAddress)
+	if telemetryClient != nil && cfg.VictorialogsAddress != "" {
+		logsURL := runnertelemetry.LogsURL(cfg.CoordinatorAddress)
+		logWriter := observability.NewPersistentLogWriter(logsURL, 30*time.Second,
+			observability.WithHTTPClient(telemetryClient.HTTP))
+
+		// Batch on this path. One HTTP/3 round trip per log line to the
+		// coordinator costs far more than the unbatched POST to a local
+		// VictoriaLogs did, and a failure here is worth hearing about: the
+		// runner's own log goes to the journal, not through this writer, so
+		// reporting it cannot feed back into the buffer it is reporting on.
+		batchWriter := observability.NewBatchLogWriter(logWriter,
+			observability.WithBatchErrorHandler(func(err error, dropped int) {
+				ctx.Log.Error("failed to ship sandbox logs", "error", err, "dropped", dropped)
+			}))
+		defer batchWriter.Close()
+
+		deps.LogWriter = batchWriter
+		ctx.Log.Info("log writer started", "endpoint", logsURL)
 	} else {
 		deps.LogWriter = observability.NewDebugLogWriter(ctx.Log)
 		ctx.Log.Warn("no VictoriaLogs address configured, sandbox logs will only be written to debug output")
@@ -289,6 +335,13 @@ func RunnerStart(ctx *Context, opts struct {
 	// Start runner with errgroup for background network tasks
 	if err := r.Start(egCtx, eg); err != nil {
 		return fmt.Errorf("failed to start runner: %w", err)
+	}
+
+	// Start acquired the coordinator-backed issuer, so telemetry can now mint.
+	if issuer := r.WorkloadIssuer(); issuer != nil {
+		tokenSource.SetIssuer(issuer)
+	} else if telemetryClient != nil {
+		ctx.Log.Error("no workload identity issuer available; telemetry cannot be shipped")
 	}
 
 	ctx.Log.Info("runner started successfully",

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -82,6 +82,7 @@ import (
 	"miren.dev/runtime/servers/logs"
 	oidcbindingsrv "miren.dev/runtime/servers/oidcbinding"
 	runnerserver "miren.dev/runtime/servers/runner"
+	"miren.dev/runtime/servers/runnertelemetry"
 	telemetrysrv "miren.dev/runtime/servers/telemetry"
 	"miren.dev/runtime/version"
 )
@@ -606,6 +607,39 @@ regen:
 	return nil
 }
 
+// runnerTelemetryOptions mounts the ingest endpoints distributed runners ship
+// their metrics and logs to, so VictoriaMetrics and VictoriaLogs never need to
+// listen anywhere a runner can reach.
+//
+// Nothing is mounted without a workload issuer, since the issuer is what
+// verifies the runner's token; a route that could not check its caller would be
+// exactly the unauthenticated opening this replaces. The same goes for a
+// backend whose address we do not know.
+func (c *Coordinator) runnerTelemetryOptions() []rpc.StateOption {
+	if c.WorkloadIssuer == nil {
+		c.Log.Warn("no workload identity issuer; runner telemetry ingest disabled")
+		return nil
+	}
+
+	var opts []rpc.StateOption
+
+	if c.VictoriametricsAddress != "" {
+		opts = append(opts, rpc.WithHTTPHandler(runnertelemetry.MetricsPattern,
+			runnertelemetry.NewMetricsHandler(c.Log, c.WorkloadIssuer, c.VictoriametricsAddress)))
+	} else {
+		c.Log.Warn("no victoriametrics address; runner metrics ingest disabled")
+	}
+
+	if c.VictorialogsAddress != "" {
+		opts = append(opts, rpc.WithHTTPHandler(runnertelemetry.LogsPattern,
+			runnertelemetry.NewLogsHandler(c.Log, c.WorkloadIssuer, c.VictorialogsAddress)))
+	} else {
+		c.Log.Warn("no victorialogs address; runner log ingest disabled")
+	}
+
+	return opts
+}
+
 // buildEtcdTLSConfig creates a tls.Config from the EtcdTLS configuration.
 func (c *Coordinator) buildEtcdTLSConfig() (*tls.Config, error) {
 	if c.EtcdTLS == nil {
@@ -827,6 +861,8 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		rpcOpts = append(rpcOpts, rpc.WithAuthenticator(compositeAuth), rpc.WithAuthorizer(compositeAuthz))
 		c.Log.Info("local-only authentication enabled with OIDC support")
 	}
+
+	rpcOpts = append(rpcOpts, c.runnerTelemetryOptions()...)
 
 	rs, err := rpc.NewState(ctx, rpcOpts...)
 	if err != nil {

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -386,6 +386,17 @@ func (r *Runner) Start(ctx context.Context, eg ...*errgroup.Group) error {
 	return nil
 }
 
+// WorkloadIssuer returns the issuer this runner mints identity tokens through,
+// or nil if none is available.
+//
+// It is only meaningful after Start, which is where a distributed runner
+// acquires its issuer from the coordinator. Callers that build something
+// needing tokens before then should hold a source they can arm afterwards
+// rather than reading this early and caching a nil.
+func (r *Runner) WorkloadIssuer() workloadidentity.TokenIssuer {
+	return r.deps.WorkloadIssuer
+}
+
 // setupRemoteWorkloadIssuer wires a remote workload identity issuer for
 // distributed runners. Runners do not hold the cluster signing key, so they
 // mint tokens by calling the coordinator's RunnerRegistration service. When the

--- a/docs/docs/distributed-runners.md
+++ b/docs/docs/distributed-runners.md
@@ -74,22 +74,20 @@ miren runner join mren_...
 Joining registers the machine as a runner, exchanges the token for a client certificate, and writes a config file to `/var/lib/miren/runner/config.yaml`. Each runner gets a stable identity; if you ever need to re-add a machine, remove the old entry first (see [caveats](#things-to-know) below). Reach for [`runner join`](/command/runner-join) for flags like `--name` and `--labels`.
 
 Joining is only the first connection a runner makes. Once it's running it also
-talks to the coordinator's etcd, metrics, and log endpoints directly, so if
-there's a firewall between your machines it needs to allow rather more than
-8443. These are the defaults:
+talks to the coordinator's etcd endpoint, so if there's a firewall between your
+machines it needs to allow rather more than 8443. These are the defaults:
 
 | Port | Protocol | What it carries | Protection |
 |------|----------|-----------------|------------|
-| 8443 | TCP | Coordinator API, including join | Join token while enrolling, mTLS afterward |
+| 8443 | TCP | Coordinator API, including join and the metrics and logs a runner ships | Join token while enrolling, mTLS afterward |
 | 12379 | TCP | etcd, for Flannel subnet coordination | mTLS |
-| 8428 | TCP | VictoriaMetrics, for metrics the runner reports | none |
-| 9428 | TCP | VictoriaLogs, for logs the runner ships | none |
 | 51820 | UDP | WireGuard overlay | WireGuard encryption |
 
-:::warning[Observability ports are unauthenticated]
-VictoriaMetrics and VictoriaLogs have no authentication of their own. Keep
-them on a private network between your nodes rather than exposing them broadly.
-:::
+Metrics and logs travel over 8443 alongside everything else a runner sends the
+coordinator. VictoriaMetrics and VictoriaLogs themselves stay bound to loopback
+on the coordinator and never need to be reachable from a runner, which is why
+they aren't in that table. A runner authenticates each batch with a short-lived
+identity token scoped to telemetry, on top of the certificate it got at join.
 
 The overlay port needs to be open between runners, not just from each runner
 to the coordinator, since sandboxes on different machines send traffic to each

--- a/metrics/victoriametrics_reader.go
+++ b/metrics/victoriametrics_reader.go
@@ -62,7 +62,7 @@ func (r *VictoriaMetricsReader) InstantQuery(ctx context.Context, query string, 
 		params.Set("time", strconv.FormatInt(ts.Unix(), 10))
 	}
 
-	queryURL := fmt.Sprintf("http://%s/api/v1/query?%s", r.Address, params.Encode())
+	queryURL := fmt.Sprintf("%s/api/v1/query?%s", normalizeBaseURL(r.Address), params.Encode())
 
 	req, err := http.NewRequestWithContext(ctx, "GET", queryURL, nil)
 	if err != nil {
@@ -103,7 +103,7 @@ func (r *VictoriaMetricsReader) RangeQuery(ctx context.Context, query string, st
 		params.Set("step", step)
 	}
 
-	queryURL := fmt.Sprintf("http://%s/api/v1/query_range?%s", r.Address, params.Encode())
+	queryURL := fmt.Sprintf("%s/api/v1/query_range?%s", normalizeBaseURL(r.Address), params.Encode())
 
 	req, err := http.NewRequestWithContext(ctx, "GET", queryURL, nil)
 	if err != nil {

--- a/metrics/victoriametrics_writer.go
+++ b/metrics/victoriametrics_writer.go
@@ -44,8 +44,25 @@ type MetricPoint struct {
 	Timestamp time.Time
 }
 
+// WriterOption customizes a VictoriaMetricsWriter at construction.
+type WriterOption func(*VictoriaMetricsWriter)
+
+// WithHTTPClient replaces the writer's default HTTP client.
+//
+// Callers that cannot reach VictoriaMetrics with a plain client supply their
+// own. A distributed runner ships metrics through the coordinator rather than
+// dialing VictoriaMetrics directly, which means an HTTP/3 transport carrying a
+// credential. Putting that in the client's RoundTripper keeps this writer
+// unaware of how it is authenticated, so the credential has one home rather
+// than being threaded through every send.
+func WithHTTPClient(client *http.Client) WriterOption {
+	return func(w *VictoriaMetricsWriter) {
+		w.client = client
+	}
+}
+
 // NewVictoriaMetricsWriter creates a new VictoriaMetrics writer
-func NewVictoriaMetricsWriter(log *slog.Logger, address string, timeout time.Duration) *VictoriaMetricsWriter {
+func NewVictoriaMetricsWriter(log *slog.Logger, address string, timeout time.Duration, opts ...WriterOption) *VictoriaMetricsWriter {
 	if timeout == 0 {
 		timeout = 30 * time.Second
 	}
@@ -61,7 +78,21 @@ func NewVictoriaMetricsWriter(log *slog.Logger, address string, timeout time.Dur
 		},
 	}
 
+	for _, opt := range opts {
+		opt(w)
+	}
+
 	return w
+}
+
+// normalizeBaseURL ensures the address has a scheme and no trailing slash.
+// A bare host:port keeps its historical meaning of plain HTTP, so existing
+// callers are unaffected, while an address that names https:// is honored.
+func normalizeBaseURL(address string) string {
+	if !strings.HasPrefix(address, "http://") && !strings.HasPrefix(address, "https://") {
+		address = "http://" + address
+	}
+	return strings.TrimRight(address, "/")
 }
 
 // Start begins the background flush routine. It is idempotent and safe to call multiple times.
@@ -182,7 +213,7 @@ func (w *VictoriaMetricsWriter) sendMetrics(points []MetricPoint) error {
 		buf.WriteByte('\n')
 	}
 
-	url := fmt.Sprintf("http://%s/api/v1/import/prometheus", w.Address)
+	url := normalizeBaseURL(w.Address) + "/api/v1/import/prometheus"
 	req, err := http.NewRequestWithContext(context.Background(), "POST", url, &buf)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)

--- a/metrics/victoriametrics_writer_test.go
+++ b/metrics/victoriametrics_writer_test.go
@@ -606,3 +606,71 @@ func TestVictoriaMetricsWriter_PrometheusFormat(t *testing.T) {
 		assert.Contains(t, line, "temperature 23.456789 1000000")
 	})
 }
+
+// recordingTransport captures the request it is handed and answers with a
+// canned status, so transport wiring can be asserted without a live listener.
+type recordingTransport struct {
+	mu     sync.Mutex
+	req    *http.Request
+	status int
+}
+
+func (t *recordingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	t.req = r
+	t.mu.Unlock()
+
+	status := t.status
+	if status == 0 {
+		status = http.StatusNoContent
+	}
+	return &http.Response{StatusCode: status, Body: http.NoBody, Request: r}, nil
+}
+
+func (t *recordingTransport) request() *http.Request {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.req
+}
+
+func TestVictoriaMetricsWriter_Transport(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	flushOnePoint := func(t *testing.T, writer *VictoriaMetricsWriter) {
+		t.Helper()
+		require.NoError(t, writer.WritePoint(context.Background(), MetricPoint{
+			Name:      "test_metric",
+			Value:     1,
+			Timestamp: time.Unix(1234567890, 0),
+		}))
+		writer.flush()
+	}
+
+	t.Run("sends through a supplied HTTP client", func(t *testing.T) {
+		rt := &recordingTransport{}
+		writer := NewVictoriaMetricsWriter(log, "victoriametrics.invalid:8428", 10*time.Second,
+			WithHTTPClient(&http.Client{Transport: rt}))
+
+		flushOnePoint(t, writer)
+
+		req := rt.request()
+		require.NotNil(t, req, "supplied client should have been used")
+		assert.Equal(t, "http://victoriametrics.invalid:8428/api/v1/import/prometheus", req.URL.String())
+	})
+
+	t.Run("honors an address that names its scheme and a base path", func(t *testing.T) {
+		rt := &recordingTransport{}
+		writer := NewVictoriaMetricsWriter(log, "https://coordinator.invalid:8443/_telemetry/metrics", 10*time.Second,
+			WithHTTPClient(&http.Client{Transport: rt}))
+
+		flushOnePoint(t, writer)
+
+		req := rt.request()
+		require.NotNil(t, req)
+		// A runner ships through the coordinator, so the scheme must survive and
+		// the import path must land under the base path rather than replacing it.
+		assert.Equal(t,
+			"https://coordinator.invalid:8443/_telemetry/metrics/api/v1/import/prometheus",
+			req.URL.String())
+	})
+}

--- a/observability/batch_log_writer.go
+++ b/observability/batch_log_writer.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -12,7 +14,47 @@ import (
 const (
 	defaultFlushInterval = 250 * time.Millisecond
 	defaultFlushCount    = 50
+
+	// maxErrorBodyBytes bounds how much of a failed response we quote back.
+	// Enough to carry VictoriaLogs' complaint or an auth rejection, not enough
+	// to turn one bad batch into a wall of output.
+	maxErrorBodyBytes = 512
 )
+
+// BatchErrorHandler reports a batch that never reached VictoriaLogs. dropped is
+// the number of entries lost with it; the buffer is not retried, so they are
+// gone by the time this is called.
+//
+// It runs synchronously on the flush loop, so it must return promptly. A
+// handler that blocks holds up every later flush while WriteEntry keeps
+// accepting entries with no backpressure, so the buffer grows for exactly as
+// long as the block lasts. That is worst at precisely the wrong moment, since
+// whatever is making the handler slow is likely the same outage that made the
+// flush fail. Hand slow work to something else rather than doing it here.
+//
+// Think about where this reports before setting it on a writer that receives
+// the process's own logs. The coordinator tees its slog output into a
+// BatchLogWriter (see cli/commands/server.go), so logging a flush failure
+// through that same logger feeds the failure back into the buffer and
+// re-amplifies it on every flush. Report somewhere that cannot loop back, or
+// leave it unset.
+type BatchErrorHandler func(err error, dropped int)
+
+// BatchLogWriterOption customizes a BatchLogWriter at construction.
+type BatchLogWriterOption func(*BatchLogWriter)
+
+// WithBatchErrorHandler makes flush failures observable.
+//
+// The default is to stay silent, which is what this writer has always done and
+// is survivable while it carries a copy of logs that are also going to stderr.
+// It stops being survivable once a writer is the only path for a runner's logs
+// and the send can fail for a reason nobody would guess, an expired credential
+// being the obvious one. Callers in that position should set this.
+func WithBatchErrorHandler(fn BatchErrorHandler) BatchLogWriterOption {
+	return func(b *BatchLogWriter) {
+		b.onError = fn
+	}
+}
 
 // BatchLogWriter implements LogWriter by buffering entries and flushing them
 // as a single NDJSON HTTP POST to VictoriaLogs. This reduces write pressure
@@ -28,17 +70,24 @@ type BatchLogWriter struct {
 	done      chan struct{}
 	wg        sync.WaitGroup
 	closeOnce sync.Once
+
+	onError BatchErrorHandler
 }
 
 // NewBatchLogWriter wraps a PersistentLogWriter with batching. Entries are
 // buffered and flushed either every 250ms or when 50 entries accumulate,
 // whichever comes first.
-func NewBatchLogWriter(writer *PersistentLogWriter) *BatchLogWriter {
+func NewBatchLogWriter(writer *PersistentLogWriter, opts ...BatchLogWriterOption) *BatchLogWriter {
 	b := &BatchLogWriter{
 		writer:  writer,
 		flushCh: make(chan struct{}, 1),
 		done:    make(chan struct{}),
 	}
+
+	for _, opt := range opts {
+		opt(b)
+	}
+
 	b.wg.Add(1)
 	go b.run()
 	return b
@@ -129,6 +178,7 @@ func (b *BatchLogWriter) flush() {
 	}
 	data := make([]byte, b.buf.Len())
 	copy(data, b.buf.Bytes())
+	dropped := b.count
 	b.buf.Reset()
 	b.count = 0
 	b.mu.Unlock()
@@ -138,8 +188,27 @@ func (b *BatchLogWriter) flush() {
 
 	resp, err := b.writer.Client().Post(insertURL, "application/x-ndjson", bytes.NewReader(data))
 	if err != nil {
+		b.reportError(fmt.Errorf("sending log batch to victorialogs: %w", err), dropped)
 		return
 	}
 	defer resp.Body.Close()
+
+	// A rejected batch answers with a status, not a transport error, so this is
+	// the only place an authentication or quota failure becomes visible at all.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		b.reportError(fmt.Errorf("victorialogs returned status %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(detail))), dropped)
+		return
+	}
+
 	_, _ = io.Copy(io.Discard, resp.Body)
+}
+
+func (b *BatchLogWriter) reportError(err error, dropped int) {
+	if b.onError == nil {
+		return
+	}
+	b.onError(err, dropped)
 }

--- a/observability/batch_log_writer_test.go
+++ b/observability/batch_log_writer_test.go
@@ -359,3 +359,129 @@ func TestBatchLogWriter_InheritsHTTPClient(t *testing.T) {
 		}
 	}
 }
+
+func TestBatchLogWriter_ReportsTransportFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // closed up front so the send fails at the transport
+
+	var mu sync.Mutex
+	var gotErr error
+	gotDropped := -1
+
+	plw := NewPersistentLogWriter(srv.URL, time.Second)
+	bw := NewBatchLogWriter(plw, WithBatchErrorHandler(func(err error, dropped int) {
+		mu.Lock()
+		gotErr, gotDropped = err, dropped
+		mu.Unlock()
+	}))
+	defer bw.Close()
+
+	for i := 0; i < 3; i++ {
+		if err := bw.WriteEntry("test-entity", LogEntry{
+			Timestamp: time.Now(),
+			Stream:    Stdout,
+			Body:      "unreachable",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	waitFor(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return gotErr != nil
+	}, "error handler was never called for a transport failure")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotDropped != 3 {
+		t.Fatalf("reported %d dropped entries, want 3", gotDropped)
+	}
+}
+
+// A rejected batch comes back as a status code, not a transport error. This is
+// the shape an expired or missing credential takes, and before it was checked
+// the entries vanished with no signal whatsoever.
+func TestBatchLogWriter_ReportsRejectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("token expired"))
+	}))
+	defer srv.Close()
+
+	var mu sync.Mutex
+	var gotErr error
+	gotDropped := -1
+
+	plw := NewPersistentLogWriter(srv.URL, time.Second)
+	bw := NewBatchLogWriter(plw, WithBatchErrorHandler(func(err error, dropped int) {
+		mu.Lock()
+		gotErr, gotDropped = err, dropped
+		mu.Unlock()
+	}))
+	defer bw.Close()
+
+	if err := bw.WriteEntry("test-entity", LogEntry{
+		Timestamp: time.Now(),
+		Stream:    Stdout,
+		Body:      "rejected",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return gotErr != nil
+	}, "error handler was never called for a rejected batch")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotDropped != 1 {
+		t.Fatalf("reported %d dropped entries, want 1", gotDropped)
+	}
+	if !strings.Contains(gotErr.Error(), "401") {
+		t.Fatalf("error %q does not mention the status code", gotErr)
+	}
+	if !strings.Contains(gotErr.Error(), "token expired") {
+		t.Fatalf("error %q does not quote the response body", gotErr)
+	}
+}
+
+// A writer with no error handler keeps its historical silence rather than
+// panicking on the nil callback.
+func TestBatchLogWriter_SilentWithoutHandler(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	plw := NewPersistentLogWriter(srv.URL, time.Second)
+	bw := NewBatchLogWriter(plw)
+	defer bw.Close()
+
+	if err := bw.WriteEntry("test-entity", LogEntry{
+		Timestamp: time.Now(),
+		Stream:    Stdout,
+		Body:      "rejected",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(defaultFlushInterval * 3)
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if cond() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal(msg)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/observability/batch_log_writer_test.go
+++ b/observability/batch_log_writer_test.go
@@ -276,3 +276,86 @@ func TestBatchLogWriter_CloseFlushesRemaining(t *testing.T) {
 		t.Fatalf("expected 3 entries flushed on close, got %d", total)
 	}
 }
+
+// recordingTransport captures the request it is handed and answers 200, so
+// transport wiring can be asserted without a live listener.
+type recordingTransport struct {
+	mu   sync.Mutex
+	reqs []*http.Request
+}
+
+func (t *recordingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	t.reqs = append(t.reqs, r)
+	t.mu.Unlock()
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: r}, nil
+}
+
+func (t *recordingTransport) urls() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var out []string
+	for _, r := range t.reqs {
+		out = append(out, r.URL.String())
+	}
+	return out
+}
+
+func TestPersistentLogWriter_WithHTTPClient(t *testing.T) {
+	rt := &recordingTransport{}
+	plw := NewPersistentLogWriter("https://coordinator.invalid:8443/_telemetry/logs", 5*time.Second,
+		WithHTTPClient(&http.Client{Transport: rt}))
+
+	err := plw.WriteEntry("test-entity", LogEntry{
+		Timestamp: time.Now(),
+		Stream:    Stdout,
+		Body:      "direct write",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	urls := rt.urls()
+	if len(urls) != 1 {
+		t.Fatalf("expected the supplied client to be used once, got %d requests", len(urls))
+	}
+	want := "https://coordinator.invalid:8443/_telemetry/logs/insert/jsonline"
+	if urls[0] != want {
+		t.Fatalf("got %q, want %q", urls[0], want)
+	}
+}
+
+// BatchLogWriter borrows the wrapped writer's client, so batching a writer must
+// not quietly drop back to a default transport (which for a runner shipping
+// through the coordinator would mean losing its credential).
+func TestBatchLogWriter_InheritsHTTPClient(t *testing.T) {
+	rt := &recordingTransport{}
+	plw := NewPersistentLogWriter("https://coordinator.invalid:8443/_telemetry/logs", 5*time.Second,
+		WithHTTPClient(&http.Client{Transport: rt}))
+	bw := NewBatchLogWriter(plw)
+	defer bw.Close()
+
+	if err := bw.WriteEntry("test-entity", LogEntry{
+		Timestamp: time.Now(),
+		Stream:    Stdout,
+		Body:      "batched write",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if urls := rt.urls(); len(urls) > 0 {
+			want := "https://coordinator.invalid:8443/_telemetry/logs/insert/jsonline"
+			if urls[0] != want {
+				t.Fatalf("got %q, want %q", urls[0], want)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("batch writer never flushed through the supplied client")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -58,18 +58,41 @@ type PersistentLogWriter struct {
 	client *http.Client
 }
 
+// LogWriterOption customizes a PersistentLogWriter at construction.
+type LogWriterOption func(*PersistentLogWriter)
+
+// WithHTTPClient replaces the writer's default HTTP client.
+//
+// Callers that cannot reach VictoriaLogs with a plain client supply their own.
+// A distributed runner ships logs through the coordinator rather than dialing
+// VictoriaLogs directly, which means an HTTP/3 transport carrying a credential.
+// Putting that in the client's RoundTripper keeps this writer unaware of how it
+// is authenticated. BatchLogWriter borrows this client, so wrapping a writer in
+// batching preserves the transport.
+func WithHTTPClient(client *http.Client) LogWriterOption {
+	return func(l *PersistentLogWriter) {
+		l.client = client
+	}
+}
+
 // NewPersistentLogWriter creates a new PersistentLogWriter.
-func NewPersistentLogWriter(address string, timeout time.Duration) *PersistentLogWriter {
+func NewPersistentLogWriter(address string, timeout time.Duration, opts ...LogWriterOption) *PersistentLogWriter {
 	if timeout == 0 {
 		timeout = 30 * time.Second
 	}
-	return &PersistentLogWriter{
+	l := &PersistentLogWriter{
 		Address: address,
 		Timeout: timeout,
 		client: &http.Client{
 			Timeout: timeout,
 		},
 	}
+
+	for _, opt := range opts {
+		opt(l)
+	}
+
+	return l
 }
 
 func (l *PersistentLogWriter) Client() *http.Client {

--- a/pkg/rpc/http_handler_test.go
+++ b/pkg/rpc/http_handler_test.go
@@ -1,0 +1,127 @@
+package rpc_test
+
+import (
+	"crypto/tls"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/caauth"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+// TestMountedHTTPHandler covers the seam that lets a cluster-internal service
+// ride the RPC listener instead of opening a port of its own. Two properties
+// matter and neither is obvious from the option's signature: a mounted route is
+// reachable over the same QUIC/mTLS listener as RPC, and it inherits the
+// listener's authentication, so a caller without a cluster certificate is
+// refused before the handler runs.
+//
+// The client here is deliberately a bare http3.Transport rather than an RPC
+// client, because that is exactly the shape a caller takes when it ships
+// something that is not an RPC call.
+func TestMountedHTTPHandler(t *testing.T) {
+	ctx := t.Context()
+	r := require.New(t)
+
+	ca, err := caauth.New(caauth.Options{CommonName: "test-ca", Organization: "miren", ValidFor: time.Hour})
+	r.NoError(err)
+	caPEM := ca.GetCACertificate()
+
+	serverCert, err := ca.IssueCertificate(caauth.Options{
+		CommonName:   "test-server",
+		Organization: "miren",
+		ValidFor:     time.Hour,
+		DNSNames:     []string{"localhost"},
+	})
+	r.NoError(err)
+
+	clientCert, err := ca.IssueCertificate(caauth.Options{
+		CommonName:   "test-client",
+		Organization: "miren",
+		ValidFor:     time.Hour,
+	})
+	r.NoError(err)
+
+	var sawRequest bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		sawRequest = true
+		body, _ := io.ReadAll(req.Body)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write(body)
+	})
+
+	ss, err := rpc.NewState(ctx,
+		rpc.WithCertPEMs(serverCert.CertPEM, serverCert.KeyPEM),
+		rpc.WithCertificateVerification(caPEM),
+		rpc.WithAuthenticator(&rpc.LocalOnlyAuthenticator{}),
+		rpc.WithHTTPHandler("POST /_telemetry/probe", handler),
+	)
+	r.NoError(err)
+
+	post := func(t *testing.T, certs []tls.Certificate) (int, string) {
+		t.Helper()
+		tr := &http3.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				Certificates:       certs,
+				NextProtos:         []string{http3.NextProtoH3},
+			},
+		}
+		defer tr.Close()
+
+		client := &http.Client{Transport: tr}
+		resp, err := client.Post("https://"+ss.LoopbackAddr()+"/_telemetry/probe",
+			"text/plain", strings.NewReader("hello"))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return resp.StatusCode, string(body)
+	}
+
+	t.Run("reachable with a cluster certificate", func(t *testing.T) {
+		pair, err := tls.X509KeyPair(clientCert.CertPEM, clientCert.KeyPEM)
+		r.NoError(err)
+
+		status, body := post(t, []tls.Certificate{pair})
+		require.Equal(t, http.StatusAccepted, status)
+		require.Equal(t, "hello", body)
+		require.True(t, sawRequest, "handler should have run")
+	})
+
+	t.Run("refused without a certificate", func(t *testing.T) {
+		// A mounted path is not an RPC path, so the server requires an identity
+		// before dispatch. If this ever starts returning 202 the seam has become
+		// an unauthenticated hole, which is the whole thing it exists to avoid.
+		status, _ := post(t, nil)
+		require.Equal(t, http.StatusUnauthorized, status)
+	})
+}
+
+func TestMountedHTTPHandlerRejectsReservedPattern(t *testing.T) {
+	ctx := t.Context()
+
+	_, err := rpc.NewState(ctx,
+		rpc.WithSkipVerify,
+		rpc.WithHTTPHandler("/_rpc/call/hijack", http.NotFoundHandler()),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reserved for RPC")
+}
+
+func TestMountedHTTPHandlerRejectsNilHandler(t *testing.T) {
+	ctx := t.Context()
+
+	_, err := rpc.NewState(ctx,
+		rpc.WithSkipVerify,
+		rpc.WithHTTPHandler("/_telemetry/probe", nil),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil")
+}

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -308,6 +308,24 @@ func (s *Server) setupMux() {
 	s.mux = mux
 }
 
+// mountHTTPHandlers adds caller-supplied routes to the mux. The RPC prefix is
+// reserved: a handler mounted under it would shadow method dispatch, and the
+// resulting failure (methods quietly answered by the wrong handler) is far
+// harder to diagnose than a refusal at startup.
+func (s *Server) mountHTTPHandlers(mounts []httpHandlerMount) error {
+	for _, m := range mounts {
+		if m.handler == nil {
+			return fmt.Errorf("http handler for %q is nil", m.pattern)
+		}
+		if strings.Contains(m.pattern, rpcPathPrefix) {
+			return fmt.Errorf("http handler pattern %q is reserved for RPC", m.pattern)
+		}
+		s.mux.Handle(m.pattern, m.handler)
+	}
+
+	return nil
+}
+
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -348,9 +366,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mux.ServeHTTP(w, r)
 }
 
+// rpcPathPrefix is the path namespace reserved for RPC dispatch.
+const rpcPathPrefix = "/_rpc/"
+
 // isRPCPath returns true if the path is an RPC endpoint
 func isRPCPath(path string) bool {
-	return len(path) >= 6 && path[:6] == "/_rpc/"
+	return strings.HasPrefix(path, rpcPathPrefix)
 }
 
 type identifyResponse struct {

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -154,6 +154,14 @@ type stateOptions struct {
 	authenticator Authenticator
 	authorizer    Authorizer
 	bearerToken   string // JWT or other bearer token for authentication
+
+	httpHandlers []httpHandlerMount
+}
+
+// httpHandlerMount is an additional handler to mount alongside the RPC surface.
+type httpHandlerMount struct {
+	pattern string
+	handler http.Handler
 }
 
 type StateOption func(*stateOptions)
@@ -234,6 +242,26 @@ func WithAuthenticator(auth Authenticator) StateOption {
 func WithAuthorizer(authz Authorizer) StateOption {
 	return func(o *stateOptions) {
 		o.authorizer = authz
+	}
+}
+
+// WithHTTPHandler mounts an additional handler beside the RPC surface, so a
+// cluster-internal service can be reached over the listener that already
+// authenticates callers instead of opening a port of its own.
+//
+// Pattern uses http.ServeMux syntax. Registration happens before the listener
+// starts serving, so a mounted route is live for the first request.
+//
+// Two things about what a handler mounted here does and does not inherit.
+// It does inherit authentication: a non-RPC path is refused outright unless the
+// authenticator produced an identity, so an anonymous caller never reaches the
+// handler. It does not inherit authorization, because the authorizer runs only
+// on RPC method dispatch. A handler is responsible for deciding what its caller
+// may do, and should not read an identity off the context and assume the
+// answer, since a cluster certificate authenticates as a superuser.
+func WithHTTPHandler(pattern string, handler http.Handler) StateOption {
+	return func(o *stateOptions) {
+		o.httpHandlers = append(o.httpHandlers, httpHandlerMount{pattern: pattern, handler: handler})
 	}
 }
 
@@ -323,6 +351,11 @@ func NewState(ctx context.Context, opts ...StateOption) (*State, error) {
 		authenticator = &NoOpAuthenticator{}
 	}
 
+	server := newServer()
+	if err := server.mountHTTPHandlers(so.httpHandlers); err != nil {
+		return nil, err
+	}
+
 	s := &State{
 		StateCommon: &StateCommon{
 			top:           ctx,
@@ -337,7 +370,7 @@ func NewState(ctx context.Context, opts ...StateOption) (*State, error) {
 		},
 
 		defaultEndpoint: so.endpoint,
-		server:          newServer(),
+		server:          server,
 		transport:       &quic.Transport{Conn: udpConn},
 	}
 

--- a/servers/runnertelemetry/client.go
+++ b/servers/runnertelemetry/client.go
@@ -1,0 +1,213 @@
+package runnertelemetry
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+	"miren.dev/runtime/pkg/workloadidentity"
+)
+
+const (
+	// tokenTTL is requested explicitly rather than taking the issuer's default,
+	// so the runner knows when its own token dies without having to decode it.
+	tokenTTL = time.Hour
+
+	// tokenRefreshLeeway renews this far ahead of expiry, leaving room for a
+	// slow mint and for clock skew against the coordinator.
+	tokenRefreshLeeway = 5 * time.Minute
+)
+
+// ErrIssuerUnavailable means telemetry cannot be shipped because no workload
+// issuer has been wired up yet, or the coordinator has none.
+var ErrIssuerUnavailable = errors.New("workload identity issuer unavailable")
+
+// TokenSource supplies the system workload token a telemetry request carries.
+type TokenSource interface {
+	Token() (string, error)
+}
+
+// MetricsURL and LogsURL are what a runner points its writers at. Each writer
+// appends its own backend-native suffix.
+func MetricsURL(coordinatorAddress string) string {
+	return "https://" + coordinatorAddress + MetricsBasePath
+}
+
+func LogsURL(coordinatorAddress string) string {
+	return "https://" + coordinatorAddress + LogsBasePath
+}
+
+// IssuerTokenSource mints telemetry tokens through a workload issuer, holding
+// each one until shortly before it expires.
+//
+// Its issuer arrives late on purpose. A runner's telemetry writers are built
+// before the runner connects to the coordinator, but the issuer is a remote one
+// that only exists once that connection is up, so the writers are handed this
+// and the issuer is set behind them. Until that happens Token fails rather than
+// returning something unusable, which surfaces as a telemetry send failure
+// instead of a silent gap.
+type IssuerTokenSource struct {
+	mu      sync.Mutex
+	issuer  workloadidentity.TokenIssuer
+	token   string
+	renewAt time.Time
+
+	// now is swappable for tests.
+	now func() time.Time
+}
+
+func NewIssuerTokenSource() *IssuerTokenSource {
+	return &IssuerTokenSource{now: time.Now}
+}
+
+// SetIssuer supplies the issuer once the runner has one. Passing nil leaves the
+// source unarmed, which is the honest state when the coordinator reports it has
+// no issuer configured.
+func (s *IssuerTokenSource) SetIssuer(issuer workloadidentity.TokenIssuer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.issuer = issuer
+	s.token = ""
+	s.renewAt = time.Time{}
+}
+
+func (s *IssuerTokenSource) Token() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.issuer == nil {
+		return "", ErrIssuerUnavailable
+	}
+
+	now := s.now()
+	if s.token != "" && now.Before(s.renewAt) {
+		return s.token, nil
+	}
+
+	token, err := s.issuer.IssueSystemWorkloadToken(
+		workloadidentity.SystemWorkloadTelemetryWriter,
+		workloadidentity.TokenOptions{
+			Audience: []string{Audience},
+			TTL:      tokenTTL,
+		})
+	if err != nil {
+		return "", fmt.Errorf("minting telemetry token: %w", err)
+	}
+
+	s.token = token
+	s.renewAt = now.Add(tokenTTL - tokenRefreshLeeway)
+
+	return token, nil
+}
+
+// tokenRoundTripper attaches the workload token to every telemetry request.
+//
+// Living in the transport rather than at each send is what keeps the writers
+// from having to know they are authenticated at all: they build the same
+// request they always did and the credential is applied underneath.
+type tokenRoundTripper struct {
+	base   http.RoundTripper
+	source TokenSource
+}
+
+func (t *tokenRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	token, err := t.source.Token()
+	if err != nil {
+		return nil, fmt.Errorf("telemetry request has no workload token: %w", err)
+	}
+
+	// A RoundTripper must not modify the request it is given.
+	clone := r.Clone(r.Context())
+	clone.Header.Set(TokenHeader, token)
+
+	return t.base.RoundTrip(clone)
+}
+
+// ClientConfig describes how a runner reaches its coordinator's ingest
+// endpoints.
+type ClientConfig struct {
+	// ClientCertPEM and ClientKeyPEM are the runner's certificate from Join.
+	// The listener requires one, so telemetry rides the same mutual TLS as the
+	// rest of the runner's traffic and the token narrows what that identity may
+	// do rather than replacing it.
+	ClientCertPEM []byte
+	ClientKeyPEM  []byte
+
+	// CACertPEM verifies the coordinator.
+	CACertPEM []byte
+
+	// TokenSource supplies the system workload token.
+	TokenSource TokenSource
+
+	// Timeout bounds a single telemetry request.
+	Timeout time.Duration
+}
+
+// Client is the HTTP client a runner's telemetry writers send through, paired
+// with the QUIC transport underneath it.
+//
+// The transport is held rather than left anonymous so it can be closed. The
+// writers only ever need HTTP, but something has to own the QUIC connections,
+// and without a handle on them they stay open until the process exits.
+type Client struct {
+	// HTTP is what the telemetry writers are constructed with.
+	HTTP *http.Client
+
+	transport *http3.Transport
+}
+
+// Close tears down the underlying QUIC connections.
+func (c *Client) Close() error {
+	if c == nil || c.transport == nil {
+		return nil
+	}
+	return c.transport.Close()
+}
+
+// NewClient builds the client a runner's telemetry writers send through:
+// HTTP/3 to the coordinator, authenticated by the runner's certificate, with a
+// scoped workload token on every request.
+//
+// HTTP/3 is not a preference. The coordinator's authenticated listener is QUIC
+// only, so a plain net/http client cannot reach it at all.
+func NewClient(cfg ClientConfig) (*Client, error) {
+	if cfg.TokenSource == nil {
+		return nil, errors.New("telemetry client requires a token source")
+	}
+
+	cert, err := tls.X509KeyPair(cfg.ClientCertPEM, cfg.ClientKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("loading runner certificate: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(cfg.CACertPEM) {
+		return nil, errors.New("parsing cluster CA certificate")
+	}
+
+	transport := &http3.Transport{
+		TLSClientConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      pool,
+			NextProtos:   []string{http3.NextProtoH3},
+		},
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	return &Client{
+		HTTP: &http.Client{
+			Transport: &tokenRoundTripper{base: transport, source: cfg.TokenSource},
+			Timeout:   timeout,
+		},
+		transport: transport,
+	}, nil
+}

--- a/servers/runnertelemetry/client_test.go
+++ b/servers/runnertelemetry/client_test.go
@@ -1,0 +1,169 @@
+package runnertelemetry_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/pkg/caauth"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/workloadidentity"
+	"miren.dev/runtime/servers/runnertelemetry"
+)
+
+// stubIssuer counts mints so token caching can be observed, and records the
+// options it was asked for.
+type stubIssuer struct {
+	mints    int
+	err      error
+	gotOpts  workloadidentity.TokenOptions
+	gotLoad  workloadidentity.SystemWorkload
+	tokenSeq []string
+}
+
+func (s *stubIssuer) IssueToken(app, sandboxID string) (string, error) { return "", nil }
+
+func (s *stubIssuer) IssueTokenWithOptions(app, sandboxID string, opts workloadidentity.TokenOptions) (string, error) {
+	return "", nil
+}
+
+func (s *stubIssuer) IssuerURL() string { return "https://issuer.invalid" }
+
+func (s *stubIssuer) IssueSystemWorkloadToken(workload workloadidentity.SystemWorkload, opts workloadidentity.TokenOptions) (string, error) {
+	s.gotLoad, s.gotOpts = workload, opts
+	if s.err != nil {
+		return "", s.err
+	}
+	s.mints++
+	if len(s.tokenSeq) >= s.mints {
+		return s.tokenSeq[s.mints-1], nil
+	}
+	return "token", nil
+}
+
+// Until the runner has connected there is no issuer, and the honest answer is a
+// failure. Returning an empty token instead would have the coordinator reject
+// the batch, which looks like a credential problem rather than a startup
+// ordering one.
+func TestTokenSourceFailsBeforeIssuerArrives(t *testing.T) {
+	src := runnertelemetry.NewIssuerTokenSource()
+
+	_, err := src.Token()
+	require.ErrorIs(t, err, runnertelemetry.ErrIssuerUnavailable)
+}
+
+func TestTokenSourceMintsAndCaches(t *testing.T) {
+	iss := &stubIssuer{}
+	src := runnertelemetry.NewIssuerTokenSource()
+	src.SetIssuer(iss)
+
+	first, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "token", first)
+
+	second, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+	require.Equal(t, 1, iss.mints, "a live token should be reused rather than reminted per request")
+
+	// The audience is what keeps this token from being spendable at another
+	// service, and the explicit TTL is what lets the source know when to renew
+	// without decoding the token.
+	require.Equal(t, workloadidentity.SystemWorkloadTelemetryWriter, iss.gotLoad)
+	require.Equal(t, []string{runnertelemetry.Audience}, iss.gotOpts.Audience)
+	require.NotZero(t, iss.gotOpts.TTL)
+}
+
+func TestTokenSourcePropagatesMintFailure(t *testing.T) {
+	iss := &stubIssuer{err: errors.New("coordinator refused")}
+	src := runnertelemetry.NewIssuerTokenSource()
+	src.SetIssuer(iss)
+
+	_, err := src.Token()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "coordinator refused")
+}
+
+// Re-arming drops the cached token. A new issuer means a new connection to the
+// coordinator, and holding a token minted through the old one would keep a
+// stale credential alive past the event that replaced it.
+func TestTokenSourceResetsOnNewIssuer(t *testing.T) {
+	iss := &stubIssuer{tokenSeq: []string{"first", "second"}}
+	src := runnertelemetry.NewIssuerTokenSource()
+
+	src.SetIssuer(iss)
+	first, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "first", first)
+
+	src.SetIssuer(iss)
+	second, err := src.Token()
+	require.NoError(t, err)
+	require.Equal(t, "second", second)
+	require.Equal(t, 2, iss.mints)
+}
+
+func TestClientRequiresTokenSource(t *testing.T) {
+	_, err := runnertelemetry.NewClient(runnertelemetry.ClientConfig{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token source")
+}
+
+func TestURLsComposeWithWriterSuffixes(t *testing.T) {
+	require.Equal(t, "https://coordinator.invalid:8443/_telemetry/metrics",
+		runnertelemetry.MetricsURL("coordinator.invalid:8443"))
+	require.Equal(t, "https://coordinator.invalid:8443/_telemetry/logs",
+		runnertelemetry.LogsURL("coordinator.invalid:8443"))
+}
+
+// The QUIC transport underneath the client has to be reachable for closing.
+// Left anonymous inside NewClient it would hold connections open until the
+// process exited, which is why Client hands back a handle rather than a bare
+// *http.Client.
+func TestClientClosesItsTransport(t *testing.T) {
+	ca, err := caauth.New(caauth.Options{CommonName: "test-ca", Organization: "miren", ValidFor: time.Hour})
+	require.NoError(t, err)
+
+	runnerCert, err := ca.IssueCertificate(caauth.Options{
+		CommonName:   "runner-abc",
+		Organization: "miren",
+		ValidFor:     time.Hour,
+	})
+	require.NoError(t, err)
+
+	src := runnertelemetry.NewIssuerTokenSource()
+	src.SetIssuer(&stubIssuer{})
+
+	client, err := runnertelemetry.NewClient(runnertelemetry.ClientConfig{
+		ClientCertPEM: runnerCert.CertPEM,
+		ClientKeyPEM:  runnerCert.KeyPEM,
+		CACertPEM:     ca.GetCACertificate(),
+		TokenSource:   src,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, client.HTTP)
+
+	require.NoError(t, client.Close())
+
+	// Shutdown paths call this from a defer that may run more than once.
+	require.NoError(t, client.Close())
+}
+
+func TestNilClientCloseIsSafe(t *testing.T) {
+	var c *runnertelemetry.Client
+	require.NoError(t, c.Close())
+}
+
+func TestClientRejectsUnparseableCA(t *testing.T) {
+	src := runnertelemetry.NewIssuerTokenSource()
+	src.SetIssuer(&stubIssuer{})
+
+	_, err := runnertelemetry.NewClient(runnertelemetry.ClientConfig{
+		ClientCertPEM: []byte("not a cert"),
+		ClientKeyPEM:  []byte("not a key"),
+		CACertPEM:     []byte("not a ca"),
+		TokenSource:   src,
+	})
+	require.Error(t, err)
+}

--- a/servers/runnertelemetry/ingest.go
+++ b/servers/runnertelemetry/ingest.go
@@ -1,0 +1,194 @@
+// Package runnertelemetry accepts the metrics and logs a distributed runner
+// ships, and forwards them to the cluster's VictoriaMetrics and VictoriaLogs.
+//
+// It exists so that neither of those ever has to listen anywhere a runner can
+// reach. Open-source VictoriaMetrics and VictoriaLogs have no authentication of
+// their own, so historically the only thing standing between a runner's network
+// and unauthenticated write access to both was a firewall rule. Runners already
+// hold a certificate from Join and already talk to the coordinator over an
+// authenticated listener, so routing telemetry through that listener lets both
+// stay bound to loopback permanently.
+package runnertelemetry
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/pkg/workloadidentity"
+)
+
+const (
+	// Audience scopes a telemetry token to this service. A system workload may
+	// legitimately call several services, so the token it presents here must
+	// name this one; sharing an audience with, say, the registry would make a
+	// token minted for one replayable against the other.
+	Audience = "miren-telemetry"
+
+	// TokenHeader carries the runner's system workload token.
+	//
+	// Deliberately not Authorization. On a cloud-registered cluster the RPC
+	// listener's authenticator tries the cloud JWT validator first whenever an
+	// Authorization header is present, and a validation failure there returns a
+	// hard error rather than falling through to the certificate check below it
+	// (see pkg/cloudauth/rpc_authenticator.go). A cluster-issued workload token
+	// is not a cloud JWT and would fail that validator, so putting it in
+	// Authorization would turn an otherwise-valid mTLS request into a 401. A
+	// header the authenticator ignores keeps the two credentials independent.
+	TokenHeader = "Miren-Workload-Token"
+
+	// MetricsBasePath and LogsBasePath are what a runner points its writers at.
+	// Each writer appends its own backend-native suffix, so the bytes on the
+	// wire are exactly what VictoriaMetrics and VictoriaLogs already accept and
+	// this package never has to understand the payloads.
+	MetricsBasePath = "/_telemetry/metrics"
+	LogsBasePath    = "/_telemetry/logs"
+
+	metricsImportPath = "/api/v1/import/prometheus"
+	logsInsertPath    = "/insert/jsonline"
+
+	// maxIngestBytes bounds a single batch. Comfortably above a full metrics
+	// buffer or log batch, low enough that the coordinator cannot be made to
+	// buffer something enormous on a runner's say-so.
+	maxIngestBytes = 32 << 20
+
+	// forwardTimeout bounds the hop to the local backend. It is loopback, so
+	// anything slower than this is a backend in trouble rather than a slow link.
+	forwardTimeout = 30 * time.Second
+
+	maxErrorBodyBytes = 512
+)
+
+// MetricsPattern and LogsPattern are the ServeMux patterns these handlers mount
+// on.
+//
+// They pin an exact path and method rather than proxying everything beneath a
+// prefix. A prefix would hand a runner the rest of both APIs, including reads
+// and VictoriaMetrics' delete-series admin endpoint, which would make scoping
+// the token pointless: the credential would say "may write telemetry" while the
+// route said "may do anything."
+var (
+	MetricsPattern = http.MethodPost + " " + MetricsBasePath + metricsImportPath
+	LogsPattern    = http.MethodPost + " " + LogsBasePath + logsInsertPath
+)
+
+// Verifier checks that a presented token really identifies the telemetry writer
+// of a runner in this cluster. It is satisfied by *workloadidentity.Issuer,
+// which verifies in-process against the signing keys it already holds.
+type Verifier interface {
+	VerifySystemWorkloadToken(token, audience string, workload workloadidentity.SystemWorkload) (*workloadidentity.WorkloadClaims, error)
+}
+
+type handler struct {
+	log         *slog.Logger
+	verifier    Verifier
+	targetURL   string
+	contentType string
+	client      *http.Client
+	kind        string
+}
+
+// NewMetricsHandler forwards accepted batches to VictoriaMetrics' Prometheus
+// import endpoint. address is the backend's host:port, normally loopback.
+func NewMetricsHandler(log *slog.Logger, verifier Verifier, address string) http.Handler {
+	return newHandler(log, verifier, address, metricsImportPath, "text/plain", "metrics")
+}
+
+// NewLogsHandler forwards accepted batches to VictoriaLogs' JSON-lines insert
+// endpoint. address is the backend's host:port, normally loopback.
+func NewLogsHandler(log *slog.Logger, verifier Verifier, address string) http.Handler {
+	return newHandler(log, verifier, address, logsInsertPath, "application/x-ndjson", "logs")
+}
+
+func newHandler(log *slog.Logger, verifier Verifier, address, path, contentType, kind string) http.Handler {
+	return &handler{
+		log:         log.With("module", "runnertelemetry", "kind", kind),
+		verifier:    verifier,
+		targetURL:   backendURL(address, path),
+		contentType: contentType,
+		client:      &http.Client{Timeout: forwardTimeout},
+		kind:        kind,
+	}
+}
+
+// backendURL renders the forwarding target. A bare host:port means plain HTTP,
+// which is what an embedded backend on loopback is.
+func backendURL(address, path string) string {
+	if !strings.HasPrefix(address, "http://") && !strings.HasPrefix(address, "https://") {
+		address = "http://" + address
+	}
+	return strings.TrimRight(address, "/") + path
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// The token is verified here rather than trusted from the request's ambient
+	// RPC identity, and that is not redundant. Reaching this handler at all
+	// requires a cluster certificate, but a certificate identity bypasses
+	// authorization entirely (pkg/cloudauth/rpc_authenticator.go), so accepting
+	// it would mean any cluster peer could write telemetry. The token is what
+	// narrows that to "the telemetry writer of a registered runner", and it is
+	// short-lived where the certificate is not.
+	token := r.Header.Get(TokenHeader)
+	if token == "" {
+		h.log.Warn("telemetry ingest rejected", "reason", "no workload token")
+		http.Error(w, "missing workload token", http.StatusUnauthorized)
+		return
+	}
+
+	if _, err := h.verifier.VerifySystemWorkloadToken(token, Audience,
+		workloadidentity.SystemWorkloadTelemetryWriter); err != nil {
+		h.log.Warn("telemetry ingest rejected", "reason", "invalid workload token", "error", err)
+		http.Error(w, "invalid workload token", http.StatusUnauthorized)
+		return
+	}
+
+	body := http.MaxBytesReader(w, r.Body, maxIngestBytes)
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, h.targetURL, body)
+	if err != nil {
+		h.log.Error("building forward request", "error", err)
+		http.Error(w, "forwarding telemetry failed", http.StatusInternalServerError)
+		return
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = h.contentType
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		h.log.Error("forwarding telemetry to backend", "error", err, "target", h.targetURL)
+		http.Error(w, "forwarding telemetry failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// The runner decides whether to retry from this status, so a backend
+	// rejection has to reach it rather than being flattened into a success.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+
+		// Quote a bounded prefix, but still drain the rest. Closing a body with
+		// bytes left unread retires the connection, so a backend that rejects
+		// steadily would cost a fresh dial per batch at exactly the moment
+		// things are already going wrong.
+		_, _ = io.Copy(io.Discard, resp.Body)
+
+		h.log.Warn("backend rejected telemetry",
+			"status", resp.StatusCode, "detail", strings.TrimSpace(string(detail)))
+		http.Error(w, fmt.Sprintf("backend returned %d", resp.StatusCode), http.StatusBadGateway)
+		return
+	}
+
+	// Status before the drain. Draining goes to io.Discard rather than to w, so
+	// today the order does not matter, but it would the moment anyone relays
+	// the backend's body to the caller: the first write would commit a 200 and
+	// silently discard whatever the backend actually said.
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(io.Discard, resp.Body)
+}

--- a/servers/runnertelemetry/ingest_test.go
+++ b/servers/runnertelemetry/ingest_test.go
@@ -1,0 +1,160 @@
+package runnertelemetry_test
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/workloadidentity"
+	"miren.dev/runtime/servers/runnertelemetry"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// stubVerifier stands in for the cluster issuer. It records what it was asked
+// so the audience and workload the handler demands can be asserted, which is
+// the part that keeps a token minted for another service from being replayed
+// here.
+type stubVerifier struct {
+	err error
+
+	gotToken    string
+	gotAudience string
+	gotWorkload workloadidentity.SystemWorkload
+}
+
+func (v *stubVerifier) VerifySystemWorkloadToken(token, audience string, workload workloadidentity.SystemWorkload) (*workloadidentity.WorkloadClaims, error) {
+	v.gotToken, v.gotAudience, v.gotWorkload = token, audience, workload
+	if v.err != nil {
+		return nil, v.err
+	}
+	return &workloadidentity.WorkloadClaims{
+		IdentityType:   workloadidentity.IdentityTypeSystem,
+		SystemWorkload: workload,
+	}, nil
+}
+
+type backend struct {
+	srv     *httptest.Server
+	gotBody string
+	gotPath string
+	gotType string
+	status  int
+}
+
+func newBackend(t *testing.T) *backend {
+	t.Helper()
+	b := &backend{status: http.StatusNoContent}
+	b.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		b.gotBody = string(body)
+		b.gotPath = r.URL.Path
+		b.gotType = r.Header.Get("Content-Type")
+		w.WriteHeader(b.status)
+	}))
+	t.Cleanup(b.srv.Close)
+	return b
+}
+
+func (b *backend) address() string {
+	return strings.TrimPrefix(b.srv.URL, "http://")
+}
+
+func post(h http.Handler, token, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, runnertelemetry.MetricsBasePath, strings.NewReader(body))
+	if token != "" {
+		req.Header.Set(runnertelemetry.TokenHeader, token)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestMetricsHandlerForwardsVerifiedBatch(t *testing.T) {
+	be := newBackend(t)
+	v := &stubVerifier{}
+	h := runnertelemetry.NewMetricsHandler(testLogger(), v, be.address())
+
+	rec := post(h, "a-token", "test_metric 1 1234567890000\n")
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, "test_metric 1 1234567890000\n", be.gotBody)
+	require.Equal(t, "/api/v1/import/prometheus", be.gotPath)
+	// The writer sends no Content-Type, so the handler supplies the one the
+	// backend expects rather than forwarding an empty header.
+	require.Equal(t, "text/plain", be.gotType)
+
+	// The audience and workload are what stop a token minted for another
+	// service, or for another system workload, from being spent here.
+	require.Equal(t, "a-token", v.gotToken)
+	require.Equal(t, runnertelemetry.Audience, v.gotAudience)
+	require.Equal(t, workloadidentity.SystemWorkloadTelemetryWriter, v.gotWorkload)
+}
+
+func TestLogsHandlerForwardsVerifiedBatch(t *testing.T) {
+	be := newBackend(t)
+	be.status = http.StatusOK
+	h := runnertelemetry.NewLogsHandler(testLogger(), &stubVerifier{}, be.address())
+
+	rec := post(h, "a-token", `{"_msg":"hello"}`+"\n")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, `{"_msg":"hello"}`+"\n", be.gotBody)
+	require.Equal(t, "/insert/jsonline", be.gotPath)
+	require.Equal(t, "application/x-ndjson", be.gotType)
+}
+
+func TestIngestRejectsMissingToken(t *testing.T) {
+	be := newBackend(t)
+	h := runnertelemetry.NewMetricsHandler(testLogger(), &stubVerifier{}, be.address())
+
+	rec := post(h, "", "test_metric 1 1\n")
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Empty(t, be.gotBody, "nothing should reach the backend without a token")
+}
+
+func TestIngestRejectsInvalidToken(t *testing.T) {
+	be := newBackend(t)
+	h := runnertelemetry.NewMetricsHandler(testLogger(),
+		&stubVerifier{err: io.ErrUnexpectedEOF}, be.address())
+
+	rec := post(h, "a-bad-token", "test_metric 1 1\n")
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Empty(t, be.gotBody, "nothing should reach the backend on a failed verification")
+}
+
+// A backend rejection has to surface rather than being flattened into success,
+// since the runner decides whether to retry from what it gets back.
+func TestIngestSurfacesBackendRejection(t *testing.T) {
+	be := newBackend(t)
+	be.status = http.StatusTooManyRequests
+	h := runnertelemetry.NewMetricsHandler(testLogger(), &stubVerifier{}, be.address())
+
+	rec := post(h, "a-token", "test_metric 1 1\n")
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+// The patterns pin one method and one exact path each. Proxying a whole prefix
+// would expose the rest of both APIs, including reads and delete-series, which
+// would make scoping the token meaningless.
+func TestPatternsArePinnedToIngestPaths(t *testing.T) {
+	require.Equal(t, "POST /_telemetry/metrics/api/v1/import/prometheus", runnertelemetry.MetricsPattern)
+	require.Equal(t, "POST /_telemetry/logs/insert/jsonline", runnertelemetry.LogsPattern)
+
+	// A runner's writer appends its backend-native suffix to the base path, so
+	// the two must compose into exactly the mounted pattern.
+	require.Equal(t, "POST "+runnertelemetry.MetricsBasePath+"/api/v1/import/prometheus",
+		runnertelemetry.MetricsPattern)
+	require.Equal(t, "POST "+runnertelemetry.LogsBasePath+"/insert/jsonline",
+		runnertelemetry.LogsPattern)
+}


### PR DESCRIPTION
Open-source VictoriaMetrics and VictoriaLogs have no authentication, and there's no flag that gives them any. So the only thing standing between a runner network and unauthenticated write access to a cluster's metrics and logs has been a firewall rule. That works fine on the GCP clusters where a default-deny VPC does the job, and it works on eu1 because we pinned both to loopback by hand. It stops working the moment we want a distributed runner somewhere without a cloud firewall in front of it, which is the actual blocker this is clearing.

The issue framed this as a choice between fronting the two with an authenticating proxy or routing telemetry through the coordinator. This takes the second path, and it turned out cheaper than expected: the coordinator's `:8443` is already an `http.ServeMux` behind an auth wrapper, already authenticates every runner by mTLS, and already serves a couple of plain HTTP routes next to the RPC surface. What it lacked was a seam to add more. So rather than a telemetry RPC with schema changes and codegen, this is two handlers on a mux, forwarding bytes VictoriaMetrics and VictoriaLogs already accept. Both backends can now stay on loopback permanently, and two ports leave the runner-reachable set rather than getting secured.

It builds on the system workload identities from #990. A runner mints a token scoped to `telemetrywriter` with its own `miren-telemetry` audience, and the coordinator verifies it in-process against the signing keys it already holds. Verifying is not redundant with the mTLS underneath it, which is the part worth pausing on: reaching the handler at all requires a cluster certificate, but a certificate identity bypasses authorization entirely, so accepting it would mean any cluster peer could write telemetry. The token is what narrows that to the telemetry writer of a still-registered runner, and it expires in an hour where the certificate does not.

A few things fell out of building it that are worth knowing about.

The token deliberately does not travel in `Authorization`. On a cloud-registered cluster the RPC authenticator tries the cloud JWT validator first whenever that header is present, and a validation failure there returns a hard error rather than falling through to the certificate check sitting right below it. A cluster-issued workload token is not a cloud JWT, so putting it in `Authorization` would turn a perfectly valid mTLS request into a 401. It rides its own header instead, which the auth chain ignores and the handler reads.

The routes pin one method and one exact path each rather than proxying everything under a prefix. Proxying a prefix would have handed a runner the rest of both APIs, reads and VictoriaMetrics' delete-series admin endpoint included, and a credential that says "may write telemetry" in front of a route that means "may do anything" isn't really a credential.

`BatchLogWriter` was dropping failed batches without a trace: it checked for a transport error and then discarded the response without looking at the status, so a rejection and a success were indistinguishable. Survivable while those logs were a second copy of something also going to stderr. Not survivable once a writer is the only path off a runner and the send can fail because a token expired. It checks the status now and reports failures with a count of what was lost. Reporting is opt-in rather than logged by default, because the coordinator tees its own log output into one of these writers and a default that logged through the ambient logger would feed each failure back into the buffer it was complaining about.

Logs get batched on the runner path for the first time. One HTTP/3 round trip per log line to the coordinator costs a lot more than an unbatched POST to a VictoriaLogs on the same host did.

**Two things I'd like a second opinion on before this leaves draft.**

There's no fallback. A runner ships through the coordinator or not at all, which means coordinators have to be upgraded before runners. That matches the sequencing we already agreed on (data-tier auth, then firewall, then runners) and it's the only version that actually closes the hole rather than adding a second path beside it. But it is a hard ordering requirement and it's cheap to soften now if you'd rather have a transitional release.

The wire format is untouched on purpose. The coordinator still sends `victoriametrics_address` and `victorialogs_address` at Join; the runner just stops dialing them and reads their presence as "this cluster records telemetry." That kept a schema change out of this PR, but it does leave two fields meaning something other than what they say, which wants a follow-up to replace them with a capability flag.

Worth being explicit about one thing this does not fix: the token proves a request came from the telemetry writer of some registered runner in the cluster, not from which one. Metric labels still come from the payload, so a compromised runner can still write series attributed to another. Fixing that means parsing and rewriting labels at ingest, which is a much larger change and a separate conversation.

Part of MIR-1483. #990 and #991 have landed and this is rebased onto `main`.

**Needs #994 to merge first.** A cluster installed with `--without-cloud` and no `--dns-names` has no workload identity issuer, so on its own this change would take that cohort's runner telemetry from working-but-unauthenticated to not working at all. #994 makes the issuer unconditional and removes that gap. It's a small cohort, but it's the one least able to fall back on a cloud firewall, which is the whole population this issue is about.

