### PR TITLE
testfmt: replay output from tests that never report a result

### DIFF
--- a/hack/cmd/testfmt/main.go
+++ b/hack/cmd/testfmt/main.go
@@ -27,16 +27,19 @@ type TestState struct {
 	Package string
 	Output  []string
 	Failed  bool
+	Started bool
+	Done    bool
 }
 
 type PackageState struct {
-	Name    string
-	Tests   map[string]*TestState
-	Output  []string
-	Failed  bool
-	Elapsed float64
-	Started bool
-	Done    bool
+	Name      string
+	Tests     map[string]*TestState
+	TestOrder []string
+	Output    []string
+	Failed    bool
+	Elapsed   float64
+	Started   bool
+	Done      bool
 }
 
 type Formatter struct {
@@ -118,6 +121,7 @@ func (f *Formatter) getTest(pkg *PackageState, name string) *TestState {
 			Package: pkg.Name,
 		}
 		pkg.Tests[name] = ts
+		pkg.TestOrder = append(pkg.TestOrder, name)
 	}
 	return ts
 }
@@ -178,23 +182,27 @@ func (f *Formatter) processTestEvent(pkg *PackageState, ev *TestEvent) {
 
 	switch ev.Action {
 	case "run":
+		ts.Started = true
 		if isTopLevel {
 			fmt.Printf("    --- START  %s  %s\n", pkg.Name, ev.Test)
 		}
 	case "output":
 		ts.Output = append(ts.Output, ev.Output)
 	case "pass":
+		ts.Done = true
 		if isTopLevel {
 			fmt.Printf("    --- PASS   %s  %s (%.1fs)\n", pkg.Name, ev.Test, ev.Elapsed)
 		}
 	case "fail":
 		ts.Failed = true
+		ts.Done = true
 		f.HasFailure = true
 		f.FailedTests = append(f.FailedTests, ts)
 		if isTopLevel {
 			fmt.Printf("    --- FAIL   %s  %s (%.1fs)\n", pkg.Name, ev.Test, ev.Elapsed)
 		}
 	case "skip":
+		ts.Done = true
 		if isTopLevel {
 			fmt.Printf("    --- SKIP   %s  %s (%.1fs)\n", pkg.Name, ev.Test, ev.Elapsed)
 		}
@@ -245,6 +253,53 @@ func (f *Formatter) PrintSummary() {
 					fmt.Printf("::error file=%s,line=%s,title=FAIL %s::%s\n", file, line, ts.Name, ts.Package)
 				} else {
 					fmt.Printf("::error title=FAIL %s::%s\n", ts.Name, ts.Package)
+				}
+			}
+		}
+	}
+
+	// Tests that started but never produced a terminal event. That is the
+	// signature of a panic, an os.Exit, or the process being killed: go test
+	// emits no pass/fail for the test, so it never lands in FailedTests and its
+	// buffered output would otherwise be discarded — precisely the case where
+	// that output is the only evidence of what went wrong.
+	var incomplete []*TestState
+	for _, name := range f.PackageOrder {
+		pkg := f.Packages[name]
+		for _, testName := range pkg.TestOrder {
+			if ts := pkg.Tests[testName]; ts.Started && !ts.Done {
+				incomplete = append(incomplete, ts)
+			}
+		}
+	}
+	if len(incomplete) > 0 {
+		fmt.Println()
+		if f.githubActions {
+			fmt.Println("::group::Incomplete test output")
+		}
+		fmt.Println("=== INCOMPLETE TEST OUTPUT (no pass/fail received) ===")
+		for _, ts := range incomplete {
+			fmt.Printf("\n--- INCOMPLETE %s (in %s)\n", ts.Name, ts.Package)
+			for _, line := range ts.Output {
+				fmt.Print("    ", line)
+			}
+		}
+		if f.githubActions {
+			fmt.Println("::endgroup::")
+			// Annotate after the group so these surface as PR annotations. The
+			// package result still owns the exit code; a package that passed
+			// with an incomplete test is odd but not itself a failure.
+			for _, ts := range incomplete {
+				level := "warning"
+				if pkg := f.Packages[ts.Package]; pkg != nil && pkg.Failed {
+					level = "error"
+				}
+				const msg = "test did not report a result (possible panic or crash)"
+				file, line := f.findTestLocation(ts.Package, ts.Output)
+				if file != "" {
+					fmt.Printf("::%s file=%s,line=%s,title=INCOMPLETE %s::%s\n", level, file, line, ts.Name, msg)
+				} else {
+					fmt.Printf("::%s title=INCOMPLETE %s::%s\n", level, ts.Name, msg)
 				}
 			}
 		}

--- a/hack/cmd/testfmt/main_test.go
+++ b/hack/cmd/testfmt/main_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runEvents feeds events through a Formatter and returns everything it printed.
+//
+// opts run against the Formatter the events are actually fed through. Anything
+// a test needs configured has to be set here rather than on a formatter of its
+// own, or the assertion ends up describing a formatter that never saw an event.
+func runEvents(t *testing.T, githubActions bool, events []TestEvent, opts ...func(*Formatter)) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		out, _ := io.ReadAll(r)
+		done <- string(out)
+	}()
+
+	f := &Formatter{
+		Packages:      make(map[string]*PackageState),
+		githubActions: githubActions,
+	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	for _, ev := range events {
+		line, err := json.Marshal(ev)
+		require.NoError(t, err)
+		f.ProcessLine(string(line))
+	}
+	f.PrintSummary()
+
+	require.NoError(t, w.Close())
+	return <-done
+}
+
+// A test that dies without a terminal event — a panic, an os.Exit, or the
+// process being killed — produces no pass/fail action, so it never lands in
+// FailedTests. Its buffered output is the only evidence of what happened and
+// must still be replayed.
+func TestIncompleteTestOutputIsReplayed(t *testing.T) {
+	const pkg = "miren.dev/runtime/pkg/addon/mysql"
+
+	out := runEvents(t, false, []TestEvent{
+		{Action: "run", Package: pkg, Test: "TestMySQL_Integration"},
+		{Action: "output", Package: pkg, Test: "TestMySQL_Integration",
+			Output: "    rotate_integration_test.go:113: provisioning shared\n"},
+		{Action: "output", Package: pkg, Test: "TestMySQL_Integration",
+			Output: "panic: runtime error: invalid memory address\n"},
+		{Action: "output", Package: pkg, Output: "FAIL\t" + pkg + "\t51.462s\n"},
+		{Action: "fail", Package: pkg, Elapsed: 51.462},
+	})
+
+	assert.Contains(t, out, "INCOMPLETE TEST OUTPUT")
+	assert.Contains(t, out, "--- INCOMPLETE TestMySQL_Integration")
+	assert.Contains(t, out, "panic: runtime error: invalid memory address",
+		"the crash output is the whole point; it must survive to the summary")
+	assert.Contains(t, out, "rotate_integration_test.go:113")
+}
+
+// The GitHub annotation should point at the test's source location and be an
+// error (not a warning) when the package itself failed.
+func TestIncompleteTestAnnotation(t *testing.T) {
+	const pkg = "miren.dev/runtime/pkg/addon/mysql"
+
+	// modulePath has to be set on the formatter the events go through. Without
+	// it pkgDir yields "", findTestLocation gives up, and the annotation falls
+	// back to its no-location form, so the file=/line= branch this test exists
+	// to cover would never run.
+	out := runEvents(t, true, []TestEvent{
+		{Action: "run", Package: pkg, Test: "TestMySQL_Integration"},
+		{Action: "output", Package: pkg, Test: "TestMySQL_Integration",
+			Output: "    rotate_integration_test.go:113: boom\n"},
+		{Action: "fail", Package: pkg, Elapsed: 51.462},
+	}, func(f *Formatter) { f.modulePath = "miren.dev/runtime" })
+
+	assert.Contains(t, out, "::group::Incomplete test output")
+	assert.Contains(t, out, "::error file=pkg/addon/mysql/rotate_integration_test.go,line=113,")
+	assert.Contains(t, out, "title=INCOMPLETE TestMySQL_Integration")
+	assert.NotContains(t, out, "::warning", "package failed, so this is an error")
+}
+
+// A package that passes cleanly must not grow a spurious incomplete section.
+func TestNoIncompleteSectionOnCleanRun(t *testing.T) {
+	const pkg = "miren.dev/runtime/pkg/shellwords"
+
+	out := runEvents(t, false, []TestEvent{
+		{Action: "run", Package: pkg, Test: "TestSplitPosix"},
+		{Action: "pass", Package: pkg, Test: "TestSplitPosix", Elapsed: 0.01},
+		{Action: "run", Package: pkg, Test: "TestQuotePosix"},
+		{Action: "skip", Package: pkg, Test: "TestQuotePosix"},
+		{Action: "pass", Package: pkg, Elapsed: 0.02},
+	})
+
+	assert.NotContains(t, out, "INCOMPLETE")
+}
+
+// An ordinary failing test keeps using the existing FailedTests path and is not
+// double-reported as incomplete.
+func TestFailedTestNotReportedAsIncomplete(t *testing.T) {
+	const pkg = "miren.dev/runtime/pkg/tasks"
+
+	out := runEvents(t, false, []TestEvent{
+		{Action: "run", Package: pkg, Test: "TestParseFile"},
+		{Action: "output", Package: pkg, Test: "TestParseFile", Output: "    tasks_test.go:12: mismatch\n"},
+		{Action: "fail", Package: pkg, Test: "TestParseFile", Elapsed: 0.01},
+		{Action: "fail", Package: pkg, Elapsed: 0.02},
+	})
+
+	assert.Contains(t, out, "FAILED TEST OUTPUT")
+	assert.Contains(t, out, "mismatch")
+	assert.NotContains(t, out, "INCOMPLETE")
+}
+
+// Subtests are tracked independently, so a parent that dies mid-subtest surfaces
+// both buffers — the panic text is often attributed to the subtest.
+func TestIncompleteSubtestOutputIsReplayed(t *testing.T) {
+	const pkg = "miren.dev/runtime/pkg/addon/mysql"
+
+	out := runEvents(t, false, []TestEvent{
+		{Action: "run", Package: pkg, Test: "TestMySQL_Integration"},
+		{Action: "run", Package: pkg, Test: "TestMySQL_Integration/RotateSharedRoot"},
+		{Action: "output", Package: pkg, Test: "TestMySQL_Integration/RotateSharedRoot",
+			Output: "panic: send on closed channel\n"},
+		{Action: "fail", Package: pkg, Elapsed: 51.4},
+	})
+
+	assert.Contains(t, out, "--- INCOMPLETE TestMySQL_Integration ")
+	assert.Contains(t, out, "--- INCOMPLETE TestMySQL_Integration/RotateSharedRoot")
+	assert.Contains(t, out, "panic: send on closed channel")
+
+	// Reported in run order: parent before subtest.
+	assert.Less(t,
+		strings.Index(out, "--- INCOMPLETE TestMySQL_Integration "),
+		strings.Index(out, "--- INCOMPLETE TestMySQL_Integration/RotateSharedRoot"))
+}


### PR DESCRIPTION
The main release build failed on `pkg/addon/mysql` and the log was useless. `=== FAIL` after 51 seconds, `TestMySQL_Integration` printed its `--- START` line and then nothing, and the "Failed package output" group contained exactly one line: the FAIL summary. No panic, no assertion, no hint about what went wrong.

Turns out that's structural rather than bad luck. testfmt buffers each test's output and only replays it for tests that landed in `FailedTests`, which is populated solely on a `fail` action. When a test dies without a terminal event (a panic, an `os.Exit`, the process getting killed) `go test -json` never emits that action, so the buffer gets dropped on the floor. The `CRASHED PACKAGES` check doesn't catch it either, since that only fires when the *package* never reported, and here the package did report a perfectly clean `fail`. So the failure mode where buffered output is the only evidence is precisely the one guaranteed to discard it.

The fix is to track whether each test reached a terminal action and replay the buffers of the ones that didn't, under a new `INCOMPLETE TEST OUTPUT` section. Stable ordering needed a small addition too, since the per-package `Tests` map had no defined iteration order.

One deliberate choice: incomplete tests don't set `HasFailure`. The package's own result still owns the exit code, so this is purely additive and can't turn a green run red on its own. The GitHub annotation is an error when the package failed and a warning when it didn't, the latter being a case that shouldn't happen (go test passing a package containing a crashed test) but isn't ours to fail on.

The package had no tests, so there are some now. The one that matters pins the invariant: output from a started-but-unfinished test has to survive to the summary.

This doesn't fix the mysql failure itself, which is still red and now looks deterministic rather than flaky (two attempts on the same commit, both dying at ~51.4s). That's being chased separately. This just means the next occurrence explains itself instead of costing an hour of log archaeology.
