### PR TITLE
Give every cluster a workload identity issuer

### DIFF
--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -656,27 +656,42 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		ctx.Log.Info("no cluster registration found")
 	}
 
-	// Initialize workload identity issuer for sandbox OIDC tokens
+	// Initialize the workload identity issuer.
+	//
+	// Every cluster gets one. It used to be conditional on having a hostname to
+	// anchor it to, which quietly made internal authentication depend on
+	// external addressability: a cluster installed with --without-cloud and no
+	// --dns-names got no issuer, so its own services had no way to authenticate
+	// to each other and fell back to trusting the network. But the services that
+	// consume these tokens (the cluster-local registry, runner telemetry) all
+	// verify in-process against the signing keys, which needs no DNS and no
+	// publicly trusted certificate. Only federating to an outside party needs
+	// those, and a cluster with no hostname simply has an anchor nobody outside
+	// can resolve.
 	var workloadIssuer *workloadidentity.Issuer
 	{
-		var issuerURL string
-		if cloudAuthConfig.DNSHostname != "" {
+		issuerURL := workloadidentity.LocalIssuerURL
+		switch {
+		case cloudAuthConfig.DNSHostname != "":
 			issuerURL = "https://" + cloudAuthConfig.DNSHostname
-		} else if len(cfg.TLS.AdditionalNames) > 0 {
+		case len(cfg.TLS.AdditionalNames) > 0:
 			issuerURL = "https://" + cfg.TLS.AdditionalNames[0]
 		}
-		if issuerURL != "" {
-			workloadIssuer, err = workloadidentity.NewIssuer(workloadidentity.IssuerConfig{
-				DataPath:       cfg.Server.GetDataPath(),
-				IssuerURL:      issuerURL,
-				OrganizationID: cloudAuthConfig.Tags["organization_id"],
-				ClusterID:      cloudAuthConfig.ClusterID,
-			})
-			if err != nil {
-				ctx.Log.Warn("failed to initialize workload identity issuer", "error", err)
-			} else {
-				ctx.Log.Info("workload identity issuer initialized", "issuer", issuerURL)
-			}
+
+		workloadIssuer, err = workloadidentity.NewIssuer(workloadidentity.IssuerConfig{
+			DataPath:       cfg.Server.GetDataPath(),
+			IssuerURL:      issuerURL,
+			OrganizationID: cloudAuthConfig.Tags["organization_id"],
+			ClusterID:      cloudAuthConfig.ClusterID,
+		})
+		if err != nil {
+			ctx.Log.Warn("failed to initialize workload identity issuer", "error", err)
+		} else if issuerURL == workloadidentity.LocalIssuerURL {
+			ctx.Log.Info("workload identity issuer initialized with a cluster-local anchor; "+
+				"internal authentication is active, external federation needs a hostname",
+				"issuer", issuerURL)
+		} else {
+			ctx.Log.Info("workload identity issuer initialized", "issuer", issuerURL)
 		}
 	}
 

--- a/docs/docs/workload-identity.md
+++ b/docs/docs/workload-identity.md
@@ -210,9 +210,15 @@ The issuer URL is your cluster's public hostname. For clusters registered with M
 
 ## Sharp Edges & Limitations
 
-### Workload identity requires an issuer URL
+### Federation needs a hostname; identity itself doesn't
 
-Workload identity turns on automatically — there's no per-app setting to enable it — **but only when the cluster has an issuer URL**. That means a Miren Cloud registration or a configured TLS name. A bare cluster with neither won't issue tokens, and the `MIREN_IDENTITY_*` environment variables won't be present in your sandboxes. If your code reads them, guard for their absence.
+Workload identity turns on automatically — there's no per-app setting to enable it — and every cluster issues tokens, including one installed with `--without-cloud` and no TLS name. Your sandboxes always get the `MIREN_IDENTITY_*` variables.
+
+What such a cluster lacks is a hostname an outside party can resolve. It anchors its tokens at `https://cluster.local`, which nothing outside the cluster can fetch a discovery document from, so **external federation won't work**: AWS, GCP, and Azure all need to reach your issuer URL to fetch its keys. Give the cluster a real name (register it with Miren Cloud, or pass `--dns-names`) and its tokens become federatable, with no other change.
+
+:::note[Why tokens exist either way]
+Miren's own services authenticate to each other with these tokens — the cluster-local registry and the telemetry that distributed runners ship both verify them against the signing key in-process, which needs no DNS and no publicly trusted certificate. Tying identity to being externally addressable would leave those services with nothing but the network to trust.
+:::
 
 ### The file refreshes on a fixed loop — read it fresh
 
@@ -227,7 +233,7 @@ The token file is refreshed roughly every 45 minutes, in place. This interval is
 In a cluster with [distributed runners](/distributed-runners), only the coordinator holds the signing key. On a distributed runner, token issuance is proxied back to the coordinator over RPC. Two consequences worth knowing:
 
 - There's a small amount of extra latency, and issuance depends on the coordinator being reachable.
-- If the coordinator itself has no issuer configured, runners **silently disable** token issuance — sandboxes on those runners simply won't get the `MIREN_IDENTITY_*` variables.
+- A runner that can't reach the coordinator's issuer at startup disables token issuance for its sandboxes, so they won't get the `MIREN_IDENTITY_*` variables. The coordinator always has an issuer, so in practice this means a connectivity problem rather than a configuration one.
 
 ### Restarts and the token-server secret
 

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -25,6 +25,14 @@
 // intentionally simple for v1; a more deliberate selection mechanism (e.g.,
 // explicit --issuer-url flag) may be warranted if bare-metal OIDC federation
 // sees adoption.
+//
+// A cluster with no hostname at all still gets an issuer, anchored at
+// LocalIssuerURL. Identity is not conditional on being externally addressable:
+// the cluster's own services authenticate to each other with these tokens and
+// verify them in-process against the signing keys, which needs no DNS, no
+// reachability, and no publicly trusted certificate. Only federation to an
+// outside party needs those, and that is a property of the anchor rather than
+// a mode the cluster is in.
 package workloadidentity
 
 import (
@@ -115,6 +123,21 @@ type WorkloadClaims struct {
 	SystemWorkload SystemWorkload `json:"system_workload,omitempty"`
 }
 
+// LocalIssuerURL anchors a cluster that has no hostname to advertise.
+//
+// It is deliberately a name the cluster already owns rather than a synthetic
+// placeholder: cluster.local is how the cluster refers to itself internally,
+// resolved to whatever is locally appropriate (the registry router on the
+// coordinator, the coordinator's address on a runner). Nothing outside can
+// resolve it at all, which is the honest signal that such a cluster cannot
+// federate to an external party until it is given a real hostname.
+//
+// Note that this is an identity anchor, not an endpoint. It is compared as a
+// string when verifying, never fetched, so it does not matter that the
+// resolution it names is set up later in startup or means different things in
+// different processes.
+const LocalIssuerURL = "https://cluster.local"
+
 func NewIssuer(cfg IssuerConfig) (*Issuer, error) {
 	keyPath := filepath.Join(cfg.DataPath, "server", "workload-identity.key")
 
@@ -123,10 +146,15 @@ func NewIssuer(cfg IssuerConfig) (*Issuer, error) {
 		return nil, fmt.Errorf("workload identity key: %w", err)
 	}
 
+	issuerURL := cfg.IssuerURL
+	if issuerURL == "" {
+		issuerURL = LocalIssuerURL
+	}
+
 	iss := &Issuer{
 		primary:        primary,
 		keys:           []*signingKey{primary},
-		issuerURL:      cfg.IssuerURL,
+		issuerURL:      issuerURL,
 		organizationID: cfg.OrganizationID,
 		clusterID:      cfg.ClusterID,
 	}

--- a/pkg/workloadidentity/issuer_test.go
+++ b/pkg/workloadidentity/issuer_test.go
@@ -571,3 +571,57 @@ func TestNewIssuer_FailsOnBrokenPrev(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "previous signing key")
 }
+
+// A cluster with no hostname to advertise still gets a working issuer. This is
+// the --without-cloud install with no --dns-names: it has no way to be
+// federated against from outside, but its own services still have to
+// authenticate to each other, and they verify in-process against these keys.
+func TestNewIssuer_AnchorsLocallyWithoutAHostname(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		ClusterID: "cluster-456",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, LocalIssuerURL, iss.IssuerURL())
+	assert.Equal(t, "cluster.local", iss.Hostname())
+}
+
+// The whole point of issuing on a hostname-less cluster is that the tokens are
+// usable, so mint and verify a real one end to end.
+func TestLocalAnchoredIssuerRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		ClusterID: "cluster-456",
+	})
+	require.NoError(t, err)
+
+	token, err := iss.IssueSystemWorkloadToken(
+		SystemWorkloadTelemetryWriter,
+		TokenOptions{Audience: []string{"miren-telemetry"}},
+	)
+	require.NoError(t, err)
+
+	claims, err := iss.VerifySystemWorkloadToken(token, "miren-telemetry", SystemWorkloadTelemetryWriter)
+	require.NoError(t, err)
+	assert.Equal(t, LocalIssuerURL, claims.Issuer)
+	assert.Equal(t, IdentityTypeSystem, claims.IdentityType)
+	assert.Equal(t, "cluster:cluster-456:system:telemetrywriter", claims.Subject)
+}
+
+// An explicit hostname still wins; the local anchor is only a floor.
+func TestNewIssuer_PrefersAnExplicitHostname(t *testing.T) {
+	dir := t.TempDir()
+
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:  dir,
+		IssuerURL: "https://cluster-abc.miren.systems",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://cluster-abc.miren.systems", iss.IssuerURL())
+}


### PR DESCRIPTION
Whether a cluster got a workload identity issuer depended on whether it had a hostname to anchor one to, either a Miren Cloud registration or a `--dns-names` value. A cluster installed with `--without-cloud` and neither got no issuer at all.

That made internal authentication conditional on external addressability, and those two things aren't actually related. Everything consuming these tokens today is the cluster talking to itself: the cluster-local registry (#991) and the telemetry a distributed runner ships (#992). Both verify in-process against the signing key, which needs no DNS, no reachability, and no publicly trusted certificate. Only federating to an outside party needs any of that.

The cost landed in the wrong place. A `--without-cloud` cluster is precisely the one that can't lean on a cloud VPC firewall, and it's the one we gave the weakest story: `authorizeRegistry` passes requests straight through when there's no issuer, so those clusters run an open registry, and runner telemetry has nothing to authenticate with either. The clusters with the least network protection got the least authentication.

So every cluster gets an issuer. One with no hostname anchors at `https://cluster.local` — a name it already owns internally, rather than a synthetic placeholder. Nothing outside can resolve it, which is the honest signal that such a cluster can't federate until it's given a real name, and is exactly why it costs nothing internally. Give it a hostname later and its tokens become federatable with no other change.

Worth being explicit about the two behavior changes, since neither is invisible.

**Registry auth starts being enforced on clusters that previously had none.** That's the point, but it means a pull or push that fails to present a token turns into a broken deploy rather than a quiet passthrough. Both minting sites (`localRegistryHost` and the buildkit push path) already key off the issuer being present, so they'll now mint, and the blackbox suites exercise that path on a server started without `--dns-names`.

**Sandboxes on hostname-less clusters now receive identity tokens where they previously received none.** They're real and verifiable inside the cluster, and they won't federate to AWS or GCP — which is no worse than the nothing they replace. The docs claimed a bare cluster issues no tokens and that the `MIREN_IDENTITY_*` variables are absent, so they're corrected to separate federation from identity rather than conflating them.

One thing I deliberately didn't do: auto-detect a public IP and use that as the anchor. A publicly routable cluster *could* in principle federate on an IP — our discovery handler keys off `url.Parse(issuerURL).Host` and would serve it fine — but `autocert` can't obtain a publicly trusted certificate for a bare IP, and relying parties vary on whether they'll accept one. Anyone who wants to try can already pass `--dns-names 203.0.113.5`, which is used verbatim. Guessing on their behalf would mean an unstable anchor that changes when the IP does.

Prerequisite for #992, which otherwise regresses telemetry on exactly this cohort.
