### PR TITLE
Bind GitHub CI auth to the repository claims

### DIFF
--- a/cli/commands/auth_ci.go
+++ b/cli/commands/auth_ci.go
@@ -11,7 +11,7 @@ import (
 const gitHubActionsIssuer = "https://token.actions.githubusercontent.com"
 
 func AuthCIAdd(ctx *Context, opts struct {
-	GitHub        string `long:"github" description:"GitHub owner/repo shorthand (sets issuer, subject, provider)"`
+	GitHub        string `long:"github" description:"GitHub owner/repo shorthand (sets issuer, provider, and repository claim conditions)"`
 	Issuer        string `long:"issuer" description:"OIDC issuer URL"`
 	Subject       string `long:"subject" description:"Glob pattern for the token subject"`
 	AllowedEvents string `long:"allowed-events" description:"Comma-separated event names to allow (default: push,workflow_dispatch)"`
@@ -30,25 +30,13 @@ func AuthCIAdd(ctx *Context, opts struct {
 	var claimConditions []*oidcbinding_v1alpha.ClaimCondition
 
 	if opts.GitHub != "" {
-		if !strings.Contains(opts.GitHub, "/") {
-			return fmt.Errorf("--github must be in owner/repo format (e.g. acme/web-app)")
+		conditions, err := gitHubClaimConditions(opts.GitHub, opts.AllowedEvents, opts.AllowedRefs)
+		if err != nil {
+			return err
 		}
 		provider = "github"
 		issuer = gitHubActionsIssuer
-		if subject == "" {
-			subject = "repo:" + opts.GitHub + ":*"
-		}
-
-		// Default allowed events
-		events := "push,workflow_dispatch"
-		if opts.AllowedEvents != "" {
-			events = opts.AllowedEvents
-		}
-		claimConditions = append(claimConditions, newClaimCondition("event_name", events))
-
-		if opts.AllowedRefs != "" {
-			claimConditions = append(claimConditions, newClaimCondition("ref", opts.AllowedRefs))
-		}
+		claimConditions = conditions
 	} else {
 		// Generic OIDC provider
 		if opts.AllowedEvents != "" {
@@ -189,6 +177,39 @@ func AuthCIRemove(ctx *Context, opts struct {
 
 	ctx.Printf("Removed CI authentication binding %s\n", opts.ID)
 	return nil
+}
+
+// gitHubClaimConditions builds the claim conditions for a GitHub Actions
+// binding from the owner/repo shorthand.
+//
+// These deliberately carry the repo's identity instead of a subject pattern. As
+// of GitHub's immutable subject claims change (July 15, 2026), the sub claim
+// embeds numeric IDs (repo:OWNER@1234/REPO@5678:ref:refs/heads/main) for any
+// repo created, renamed, or transferred after the cutover, so a pattern built by
+// concatenating owner/repo names silently never matches. The repository and
+// repository_owner claims were left alone by that change and identify the caller
+// under either subject format.
+func gitHubClaimConditions(githubRepo, allowedEvents, allowedRefs string) ([]*oidcbinding_v1alpha.ClaimCondition, error) {
+	owner, repo, found := strings.Cut(githubRepo, "/")
+	if !found || owner == "" || repo == "" || strings.Contains(repo, "/") {
+		return nil, fmt.Errorf("--github must be in owner/repo format (e.g. acme/web-app)")
+	}
+
+	events := "push,workflow_dispatch"
+	if allowedEvents != "" {
+		events = allowedEvents
+	}
+
+	conditions := []*oidcbinding_v1alpha.ClaimCondition{
+		newClaimCondition("repository", githubRepo),
+		newClaimCondition("repository_owner", owner),
+		newClaimCondition("event_name", events),
+	}
+	if allowedRefs != "" {
+		conditions = append(conditions, newClaimCondition("ref", allowedRefs))
+	}
+
+	return conditions, nil
 }
 
 func newClaimCondition(key, pattern string) *oidcbinding_v1alpha.ClaimCondition {

--- a/cli/commands/auth_ci_test.go
+++ b/cli/commands/auth_ci_test.go
@@ -1,0 +1,74 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestGitHubClaimConditions(t *testing.T) {
+	conditions, err := gitHubClaimConditions("acme/web-app", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, cc := range conditions {
+		got[cc.Key()] = cc.Pattern()
+	}
+
+	want := map[string]string{
+		"repository":       "acme/web-app",
+		"repository_owner": "acme",
+		"event_name":       "push,workflow_dispatch",
+	}
+	for key, pattern := range want {
+		if got[key] != pattern {
+			t.Errorf("%s = %q, want %q", key, got[key], pattern)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d conditions, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// The subject claim is off limits for GitHub bindings: it's the thing that
+// changed formats, and anything derived from owner/repo names can't match a
+// post-cutover repo.
+func TestGitHubClaimConditions_NoSubjectDerivedCondition(t *testing.T) {
+	conditions, err := gitHubClaimConditions("acme/web-app", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, cc := range conditions {
+		if cc.Key() == "sub" {
+			t.Errorf("binding should not constrain the sub claim, got pattern %q", cc.Pattern())
+		}
+	}
+}
+
+func TestGitHubClaimConditions_Overrides(t *testing.T) {
+	conditions, err := gitHubClaimConditions("acme/web-app", "workflow_dispatch", "refs/heads/main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, cc := range conditions {
+		got[cc.Key()] = cc.Pattern()
+	}
+
+	if got["event_name"] != "workflow_dispatch" {
+		t.Errorf("event_name = %q, want workflow_dispatch", got["event_name"])
+	}
+	if got["ref"] != "refs/heads/main" {
+		t.Errorf("ref = %q, want refs/heads/main", got["ref"])
+	}
+}
+
+func TestGitHubClaimConditions_RejectsMalformedShorthand(t *testing.T) {
+	for _, input := range []string{"acme", "", "/web-app", "acme/", "acme/web-app/extra"} {
+		if _, err := gitHubClaimConditions(input, "", ""); err == nil {
+			t.Errorf("expected %q to be rejected as owner/repo shorthand", input)
+		}
+	}
+}

--- a/cli/commands/rpc_errors.go
+++ b/cli/commands/rpc_errors.go
@@ -203,6 +203,30 @@ func (c *Context) diagnoseResolve(re *rpc.ResolveError) *ui.Diagnostic {
 		}
 
 	case rpc.ResolveStatusError:
+		// A CI token that verified but matched no binding is not an expired
+		// session. Sending someone to 'miren login' when their credentials are
+		// fine is the single most expensive wrong turn this error can cause,
+		// which is why the server goes out of its way to name this case.
+		if re.StatusCode == 401 && re.Code == rpc.AuthErrorOIDCBindingMismatch {
+			return &ui.Diagnostic{
+				Summary: fmt.Sprintf("no CI binding on %s accepts this token", cluster),
+				Detail: "The token is valid and correctly signed, it just doesn't match any " +
+					"binding configured on this cluster. Signing in again won't help, " +
+					"because the credentials aren't the problem.",
+				Facts: []ui.Fact{{Label: "Cluster reported", Value: re.Detail}},
+				Causes: []string{
+					"the binding names a different repository",
+					"the repository was created, renamed, or transferred after 2026-07-15, and the binding still matches on the old subject format",
+					"the workflow's event or ref isn't allowed by the binding",
+				},
+				Actions: []ui.Action{
+					{Command: "miren auth ci list -a <app>", Note: "see the configured bindings"},
+					{Command: "miren auth ci add --github OWNER/REPO -a <app>", Note: "replace a stale one"},
+				},
+				Cause: fmt.Errorf("%w: %w", ErrAccessDenied, re),
+			}
+		}
+
 		if re.StatusCode == 401 {
 			return &ui.Diagnostic{
 				Summary: fmt.Sprintf("access denied on %s", cluster),

--- a/cli/commands/rpc_errors_catalog_test.go
+++ b/cli/commands/rpc_errors_catalog_test.go
@@ -51,6 +51,12 @@ func TestRPCErrorMessageCatalog(t *testing.T) {
 			err:      rpc.NewResolveStatusError("entities", "localhost:8443", 401),
 		},
 		{
+			scenario: "CI token verified but matched no binding",
+			err: rpc.NewResolveStatusErrorWithReason("entities", "localhost:8443", 401,
+				rpc.AuthErrorOIDCBindingMismatch,
+				"OIDC token did not match any CI binding (issuer=https://token.actions.githubusercontent.com subject=repo:acme@1234567/web-app@7654321:ref:refs/heads/main repository=acme/web-app)"),
+		},
+		{
 			scenario: "unexpected HTTP status",
 			err:      rpc.NewResolveStatusError("entities", "localhost:8443", 404),
 		},

--- a/cli/commands/testdata/rpc_error_messages.txt
+++ b/cli/commands/testdata/rpc_error_messages.txt
@@ -72,6 +72,26 @@ ERROR: access denied on cluster "local"
     miren login     sign in again
     miren whoami    check your current identity
 
+# CI token verified but matched no binding
+
+ERROR: no CI binding on cluster "local" accepts this token
+
+  The token is valid and correctly signed, it just doesn't match any binding
+  configured on this cluster. Signing in again won't help, because the
+  credentials aren't the problem.
+
+  Cluster reported  OIDC token did not match any CI binding (issuer=https://token.actions.githubusercontent.com subject=repo:acme@1234567/web-app@7654321:ref:refs/heads/main repository=acme/web-app)
+
+  Possible causes
+    • the binding names a different repository
+    • the repository was created, renamed, or transferred after 2026-07-15, and
+      the binding still matches on the old subject format
+    • the workflow's event or ref isn't allowed by the binding
+
+  Try
+    miren auth ci list -a <app>                       see the configured bindings
+    miren auth ci add --github OWNER/REPO -a <app>    replace a stale one
+
 # unexpected HTTP status
 
 ERROR: cluster "local" returned an unexpected response (HTTP 404)

--- a/docs/docs/ci-deploy.md
+++ b/docs/docs/ci-deploy.md
@@ -18,7 +18,7 @@ This page covers OIDC for **CI/CD deployment authentication** — letting pipeli
 
 ## How It Works
 
-1. **Create an OIDC binding** on your Miren cluster that links an app to an identity provider and subject pattern.
+1. **Create an OIDC binding** on your Miren cluster that links an app to an identity provider and the claims that identify your repository.
 2. **Your CI job runs** and the Miren CLI auto-detects the CI environment (e.g., GitHub Actions sets `ACTIONS_ID_TOKEN_REQUEST_URL`).
 3. **The CLI requests a short-lived token** from the CI provider's OIDC endpoint, with the cluster hostname as the audience.
 4. **Miren validates the token** by fetching the provider's OIDC discovery document and JWKS keys, then checks that the token's subject and claims match a configured binding.
@@ -61,7 +61,7 @@ miren auth ci myapp --github acme/web-app
 
 This creates a binding with:
 - **Issuer:** `https://token.actions.githubusercontent.com`
-- **Subject pattern:** `repo:acme/web-app:*` (matches all branches and events)
+- **Repository:** `acme/web-app`, owned by `acme` (matches all branches and events)
 - **Allowed events:** `push,workflow_dispatch` (by default)
 
 You can restrict further — see [Restricting Access](#restricting-access) below.
@@ -114,20 +114,30 @@ Commit this to your repository (e.g., as `.miren/clientconfig.yaml`) and set `MI
 
 The `--github` shorthand provides sensible defaults, but you can tighten access further.
 
-### Subject Patterns
+### Restricting to a Branch
 
-The subject pattern controls which GitHub Actions runs can authenticate. GitHub sets the token subject to a string like `repo:acme/web-app:ref:refs/heads/main`.
-
-The default pattern `repo:acme/web-app:*` matches all refs and event types. To restrict to a specific branch:
+The `--github` shorthand accepts any branch or event from the repository. To narrow it to a single branch, use `--allowed-refs`:
 
 <CliCommand context="client">
 ```miren
 miren auth ci myapp --github acme/web-app \
-  --subject "repo:acme/web-app:ref:refs/heads/main"
+  --allowed-refs "refs/heads/main"
 ```
 </CliCommand>
 
 Glob patterns are supported. `*` matches any characters **including** `/`, unlike standard path matching. `?` matches a single character.
+
+### A Note on Subject Patterns
+
+Bindings created with `--github` match on the token's `repository` and `repository_owner` claims rather than on its subject. This is deliberate. As of [GitHub's immutable subject claims change](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/), any repository created, renamed, or transferred after July 15, 2026 sends a subject with numeric IDs embedded in it:
+
+```
+repo:acme@277133432/web-app@1316584243:ref:refs/heads/main
+```
+
+A pattern written against the older `repo:acme/web-app:*` format can never match that, and GitHub recommends binding policies to repository metadata instead of parsing the subject. The `repository` claims are unaffected by the change and work under either format.
+
+You can still set `--subject` explicitly for a provider that needs it, and it will be used as-is. If you have a binding created before this change that stopped working, re-run `miren auth ci add --github OWNER/REPO` to replace it.
 
 ### Allowed Events
 
@@ -237,7 +247,7 @@ Example output:
 
 ```
 ID         PROVIDER   ISSUER                                        SUBJECT                   CONDITIONS
-abc123     github     https://token.actions.githubusercontent.com   repo:acme/web-app:*       event_name=push,workflow_dispatch
+abc123     github     https://token.actions.githubusercontent.com                             repository=acme/web-app; repository_owner=acme; event_name=push,workflow_dispatch
 def456     generic    https://gitlab.com                            project_path:acme/web-*
 ```
 
@@ -258,7 +268,7 @@ Create an OIDC binding for an application.
 | Flag | Description |
 |------|-------------|
 | `-a, --app` | Application name (required) |
-| `--github OWNER/REPO` | GitHub shorthand — sets issuer, subject pattern, and provider automatically |
+| `--github OWNER/REPO` | GitHub shorthand — sets issuer, provider, and repository claim conditions automatically |
 | `--issuer URL` | OIDC issuer URL (required if `--github` is not used) |
 | `--subject PATTERN` | Glob pattern for the token subject claim |
 | `--allowed-events EVENTS` | Comma-separated event names to allow (default with `--github`: `push,workflow_dispatch`) |
@@ -323,10 +333,12 @@ permissions:
 
 ### "OIDC access denied" or token not matching any binding
 
-Check that:
-- The subject pattern on the binding matches the token's subject. Use `miren auth ci list` to see the configured pattern.
-- GitHub's token subject format is `repo:OWNER/REPO:ref:refs/heads/BRANCH` for push events and `repo:OWNER/REPO:environment:ENVIRONMENT` for environment-triggered runs. Make sure your pattern accounts for this.
+The CLI reports the rejected token's subject and repository as part of the error, so start by comparing those against `miren auth ci list -a myapp`. Then check that:
+
+- The binding's `repository` condition names the repo the workflow is running in. A binding created for a different repo, or one left over from before a rename, won't match.
+- If the binding has a subject pattern rather than repository conditions, it predates [GitHub's immutable subject claims change](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/) and will not match a repo created, renamed, or transferred after July 15, 2026. Re-run `miren auth ci add --github OWNER/REPO` to replace it.
 - The allowed events include the event type that triggered the workflow (e.g., `push`, `pull_request`).
+- The allowed refs, if set, cover the branch or tag being deployed.
 
 ### CLI not using OIDC (falling back to other auth)
 

--- a/docs/docs/ci-deploy.md
+++ b/docs/docs/ci-deploy.md
@@ -339,7 +339,7 @@ permissions:
 
 ### "OIDC access denied" or token not matching any binding
 
-The CLI reports the rejected token's subject and repository as part of the error, so start by comparing those against `miren auth ci list -a myapp`. Then check that:
+When a token is rejected because it didn't match a binding, the CLI reports the subject and repository it saw, so start by comparing those against `miren auth ci list -a myapp`. Other authentication failures stay generic. Then check that:
 
 - The binding's `repository` condition names the repo the workflow is running in. A binding created for a different repo, or one left over from before a rename, won't match.
 - If the binding has a subject pattern instead of repository conditions, check that the pattern matches the subject in the error. A name-based pattern like `repo:OWNER/REPO:*` can't match a repo created, renamed, or transferred after July 15, 2026, since those send numeric IDs in the subject (see [GitHub's immutable subject claims change](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)). Re-run `miren auth ci add --github OWNER/REPO` to replace it with one that doesn't depend on the subject format.

--- a/docs/docs/ci-deploy.md
+++ b/docs/docs/ci-deploy.md
@@ -61,7 +61,7 @@ miren auth ci myapp --github acme/web-app
 
 This creates a binding with:
 - **Issuer:** `https://token.actions.githubusercontent.com`
-- **Repository:** `acme/web-app`, owned by `acme` (matches all branches and events)
+- **Repository:** `acme/web-app`, owned by `acme` (matches all branches)
 - **Allowed events:** `push,workflow_dispatch` (by default)
 
 You can restrict further — see [Restricting Access](#restricting-access) below.
@@ -116,7 +116,7 @@ The `--github` shorthand provides sensible defaults, but you can tighten access 
 
 ### Restricting to a Branch
 
-The `--github` shorthand accepts any branch or event from the repository. To narrow it to a single branch, use `--allowed-refs`:
+The `--github` shorthand accepts any ref from the repository, for the allowed events. To narrow it to a single branch, use `--allowed-refs`:
 
 <CliCommand context="client">
 ```miren
@@ -125,19 +125,25 @@ miren auth ci myapp --github acme/web-app \
 ```
 </CliCommand>
 
-Glob patterns are supported. `*` matches any characters **including** `/`, unlike standard path matching. `?` matches a single character.
+:::warning[Globs match across slashes]
+`*` matches any characters including `/`, unlike standard path matching. `?` matches a single character.
+:::
 
 ### A Note on Subject Patterns
 
 Bindings created with `--github` match on the token's `repository` and `repository_owner` claims rather than on its subject. This is deliberate. As of [GitHub's immutable subject claims change](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/), any repository created, renamed, or transferred after July 15, 2026 sends a subject with numeric IDs embedded in it:
 
-```
-repo:acme@277133432/web-app@1316584243:ref:refs/heads/main
+```text
+repo:acme@1234567/web-app@7654321:ref:refs/heads/main
 ```
 
 A pattern written against the older `repo:acme/web-app:*` format can never match that, and GitHub recommends binding policies to repository metadata instead of parsing the subject. The `repository` claims are unaffected by the change and work under either format.
 
 You can still set `--subject` explicitly for a provider that needs it, and it will be used as-is. If you have a binding created before this change that stopped working, re-run `miren auth ci add --github OWNER/REPO` to replace it.
+
+:::warning[Upgrade the server first]
+Older servers require a subject pattern and will reject a binding created by a newer CLI. Upgrade the server before creating or replacing a GitHub binding. Existing bindings keep working either way.
+:::
 
 ### Allowed Events
 

--- a/docs/docs/ci-deploy.md
+++ b/docs/docs/ci-deploy.md
@@ -342,7 +342,7 @@ permissions:
 The CLI reports the rejected token's subject and repository as part of the error, so start by comparing those against `miren auth ci list -a myapp`. Then check that:
 
 - The binding's `repository` condition names the repo the workflow is running in. A binding created for a different repo, or one left over from before a rename, won't match.
-- If the binding has a subject pattern rather than repository conditions, it predates [GitHub's immutable subject claims change](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/) and will not match a repo created, renamed, or transferred after July 15, 2026. Re-run `miren auth ci add --github OWNER/REPO` to replace it.
+- If the binding has a subject pattern instead of repository conditions, check that the pattern matches the subject in the error. A name-based pattern like `repo:OWNER/REPO:*` can't match a repo created, renamed, or transferred after July 15, 2026, since those send numeric IDs in the subject (see [GitHub's immutable subject claims change](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)). Re-run `miren auth ci add --github OWNER/REPO` to replace it with one that doesn't depend on the subject format.
 - The allowed events include the event type that triggered the workflow (e.g., `push`, `pull_request`).
 - The allowed refs, if set, cover the branch or tag being deployed.
 

--- a/docs/docs/command/auth-ci-add.md
+++ b/docs/docs/command/auth-ci-add.md
@@ -19,7 +19,7 @@ miren auth ci add [flags]
 - `--allowed-events` — Comma-separated event names to allow (default: push,workflow_dispatch)
 - `--allowed-refs` — Glob pattern for allowed git refs
 - `--description` — Human-readable description of this binding
-- `--github` — GitHub owner/repo shorthand (sets issuer, subject, provider)
+- `--github` — GitHub owner/repo shorthand (sets issuer, provider, and repository claim conditions)
 - `--issuer` — OIDC issuer URL
 - `--subject` — Glob pattern for the token subject
 

--- a/pkg/oidcauth/authenticator.go
+++ b/pkg/oidcauth/authenticator.go
@@ -124,11 +124,46 @@ func (a *OIDCAuthenticator) Authenticate(ctx context.Context, r *http.Request) (
 		}, nil
 	}
 
-	a.logger.Debug("OIDC token did not match any binding",
+	repository, _ := claims.getClaimString("repository")
+
+	a.logger.Info("OIDC token did not match any binding",
 		"issuer", issuer,
 		"subject", claims.Subject,
+		"repository", repository,
 	)
-	return nil, nil
+	return nil, &BindingMismatchError{
+		Issuer:     issuer,
+		Subject:    claims.Subject,
+		Repository: repository,
+	}
+}
+
+// BindingMismatchError reports a token that verified against a configured issuer
+// but matched none of that issuer's bindings. It carries claims from the token
+// the caller presented, so echoing it back tells them nothing they didn't
+// already hold. It deliberately says nothing about the bindings themselves.
+// Those are cluster configuration, and this error is rendered for a caller who
+// is by definition unauthenticated.
+type BindingMismatchError struct {
+	Issuer     string
+	Subject    string
+	Repository string
+}
+
+var _ rpc.DisclosableAuthError = (*BindingMismatchError)(nil)
+
+// AuthErrorCode implements rpc.DisclosableAuthError, opting this error into
+// being returned to the caller rather than collapsing into a bare 401.
+func (e *BindingMismatchError) AuthErrorCode() string {
+	return rpc.AuthErrorOIDCBindingMismatch
+}
+
+func (e *BindingMismatchError) Error() string {
+	msg := fmt.Sprintf("OIDC token did not match any CI binding (issuer=%s subject=%s", e.Issuer, e.Subject)
+	if e.Repository != "" {
+		msg += " repository=" + e.Repository
+	}
+	return msg + ")"
 }
 
 // peekIssuer extracts the issuer claim from a JWT without verifying the signature.

--- a/pkg/oidcauth/authenticator_test.go
+++ b/pkg/oidcauth/authenticator_test.go
@@ -3,7 +3,9 @@ package oidcauth
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -260,6 +262,156 @@ func TestOIDCAuthenticator_MatchingBinding(t *testing.T) {
 	}
 }
 
+// GitHub's immutable subject claims (July 15, 2026) embed numeric IDs in sub,
+// so a binding built from owner/repo names can no longer rely on it. Bindings
+// created by `miren auth ci add --github` match on the repository claims, which
+// that change left alone. These have to accept both subject formats, since a
+// cluster will be serving repos on either side of the cutover for a long time.
+func TestOIDCAuthenticator_RepositoryClaimBinding(t *testing.T) {
+	subjects := map[string]string{
+		"legacy subject":    "repo:acme/app:ref:refs/heads/main",
+		"immutable subject": "repo:acme@277133432/app@1316584243:ref:refs/heads/main",
+	}
+
+	for name, subject := range subjects {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			inmem, cleanup := testutils.NewInMemEntityServer(t)
+			defer cleanup()
+
+			ts := newTestOIDCServer(t)
+			defer ts.Close()
+
+			app := &core_v1alpha.App{}
+			if _, err := inmem.Client.Create(ctx, "my-app", app); err != nil {
+				t.Fatalf("failed to create app: %v", err)
+			}
+
+			var appRec core_v1alpha.App
+			if err := inmem.Client.Get(ctx, "my-app", &appRec); err != nil {
+				t.Fatalf("failed to get app: %v", err)
+			}
+
+			binding := &core_v1alpha.OidcBinding{
+				App:      appRec.EntityId(),
+				Provider: "github",
+				Issuer:   ts.URL(),
+				ClaimConditions: []core_v1alpha.ClaimConditions{
+					{Key: "repository", Pattern: "acme/app"},
+					{Key: "repository_owner", Pattern: "acme"},
+					{Key: "event_name", Pattern: "push,workflow_dispatch"},
+				},
+			}
+			if _, err := inmem.Client.Create(ctx, "oidcb-repo-claim", binding); err != nil {
+				t.Fatalf("failed to create OIDC binding: %v", err)
+			}
+
+			auth := NewOIDCAuthenticator(testutils.TestLogger(t))
+			auth.SetEAC(inmem.EAC)
+
+			token := ts.SignToken(jwt.MapClaims{
+				"iss":              ts.URL(),
+				"sub":              subject,
+				"aud":              "test-host",
+				"exp":              time.Now().Add(10 * time.Minute).Unix(),
+				"iat":              time.Now().Unix(),
+				"event_name":       "push",
+				"repository":       "acme/app",
+				"repository_owner": "acme",
+			})
+
+			req := httptest.NewRequest("GET", "https://test-host/", nil)
+			req.Host = "test-host"
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			identity, err := auth.Authenticate(ctx, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if identity == nil {
+				t.Fatal("expected identity, got nil")
+			}
+			if identity.Subject != subject {
+				t.Errorf("subject = %q, want %q", identity.Subject, subject)
+			}
+		})
+	}
+}
+
+// The bug this all exists to fix: a binding whose subject pattern was built by
+// concatenating owner/repo never matches a token from a repo created, renamed,
+// or transferred after the cutover.
+func TestOIDCAuthenticator_LegacySubjectPatternRejectsImmutableSubject(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ts := newTestOIDCServer(t)
+	defer ts.Close()
+
+	app := &core_v1alpha.App{}
+	if _, err := inmem.Client.Create(ctx, "my-app", app); err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+
+	var appRec core_v1alpha.App
+	if err := inmem.Client.Get(ctx, "my-app", &appRec); err != nil {
+		t.Fatalf("failed to get app: %v", err)
+	}
+
+	binding := &core_v1alpha.OidcBinding{
+		App:            appRec.EntityId(),
+		Provider:       "github",
+		Issuer:         ts.URL(),
+		SubjectPattern: "repo:acme/app:*",
+	}
+	if _, err := inmem.Client.Create(ctx, "oidcb-legacy", binding); err != nil {
+		t.Fatalf("failed to create OIDC binding: %v", err)
+	}
+
+	auth := NewOIDCAuthenticator(testutils.TestLogger(t))
+	auth.SetEAC(inmem.EAC)
+
+	subject := "repo:acme@277133432/app@1316584243:ref:refs/heads/main"
+	token := ts.SignToken(jwt.MapClaims{
+		"iss":        ts.URL(),
+		"sub":        subject,
+		"aud":        "test-host",
+		"exp":        time.Now().Add(10 * time.Minute).Unix(),
+		"iat":        time.Now().Unix(),
+		"event_name": "push",
+		"repository": "acme/app",
+	})
+
+	req := httptest.NewRequest("GET", "https://test-host/", nil)
+	req.Host = "test-host"
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	identity, err := auth.Authenticate(ctx, req)
+	if identity != nil {
+		t.Error("expected the immutable-format subject not to match a name-based pattern")
+	}
+
+	// The rejection has to explain itself: the received subject and repository
+	// are what turn this from a log-spelunking session into an obvious fix.
+	var mismatch *BindingMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("expected a BindingMismatchError, got %v", err)
+	}
+	if mismatch.Subject != subject {
+		t.Errorf("Subject = %q, want %q", mismatch.Subject, subject)
+	}
+	if mismatch.Repository != "acme/app" {
+		t.Errorf("Repository = %q, want acme/app", mismatch.Repository)
+	}
+	if mismatch.AuthErrorCode() != rpc.AuthErrorOIDCBindingMismatch {
+		t.Errorf("AuthErrorCode = %q, want %q", mismatch.AuthErrorCode(), rpc.AuthErrorOIDCBindingMismatch)
+	}
+	if !strings.Contains(mismatch.Error(), subject) {
+		t.Errorf("error message should name the rejected subject, got %q", mismatch.Error())
+	}
+}
+
 func TestOIDCAuthenticator_SubjectMismatch(t *testing.T) {
 	ctx := context.Background()
 	inmem, cleanup := testutils.NewInMemEntityServer(t)
@@ -306,11 +458,16 @@ func TestOIDCAuthenticator_SubjectMismatch(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	identity, err := auth.Authenticate(ctx, req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 	if identity != nil {
 		t.Error("expected nil identity when subject doesn't match binding pattern")
+	}
+
+	var mismatch *BindingMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("expected a BindingMismatchError, got %v", err)
+	}
+	if mismatch.Subject != "repo:acme/app:ref:refs/heads/main" {
+		t.Errorf("expected the rejected subject in the error, got %q", mismatch.Subject)
 	}
 }
 
@@ -365,11 +522,13 @@ func TestOIDCAuthenticator_ClaimConditionMismatch(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	identity, err := auth.Authenticate(ctx, req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 	if identity != nil {
 		t.Error("expected nil identity when claim condition doesn't match")
+	}
+
+	var mismatch *BindingMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("expected a BindingMismatchError, got %v", err)
 	}
 }
 

--- a/pkg/oidcauth/composite.go
+++ b/pkg/oidcauth/composite.go
@@ -2,6 +2,7 @@ package oidcauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -74,8 +75,16 @@ func (c *CompositeAuthenticator) Authenticate(ctx context.Context, r *http.Reque
 		}
 	}
 
-	// Neither succeeded. Return the primary error if there was one,
-	// otherwise the OIDC error.
+	// Neither succeeded. A binding mismatch wins over the primary's error: it
+	// means OIDC got far enough to verify the token's signature and audience, so
+	// it knows exactly why the caller was rejected. The primary, by contrast,
+	// only failed to parse a token that was never meant for it.
+	var mismatch *BindingMismatchError
+	if errors.As(oidcErr, &mismatch) {
+		return nil, oidcErr
+	}
+
+	// Otherwise prefer the primary error if there was one.
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oidcauth/composite_test.go
+++ b/pkg/oidcauth/composite_test.go
@@ -2,6 +2,7 @@ package oidcauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -66,6 +67,38 @@ func TestCompositeAuthenticator_PrimaryErrorOIDCNil(t *testing.T) {
 	_, err := comp.Authenticate(context.Background(), req)
 	if err == nil {
 		t.Fatal("expected error to propagate from primary")
+	}
+}
+
+func TestCompositeAuthenticator_BindingMismatchBeatsPrimaryError(t *testing.T) {
+	// A CI token makes the primary fail with something unhelpful, since the
+	// token was never meant for it. OIDC verified the token and knows exactly
+	// why it was rejected, so that's the error the caller should get.
+	primary := &mockAuthenticator{
+		err: fmt.Errorf("key with ID xyz not found"),
+	}
+	oidcStub := &mockAuthenticator{
+		err: &BindingMismatchError{
+			Issuer:     "https://token.actions.githubusercontent.com",
+			Subject:    "repo:acme@277133432/app@1316584243:ref:refs/heads/main",
+			Repository: "acme/app",
+		},
+	}
+
+	comp := &CompositeAuthenticator{primary: primary, oidc: oidcStub}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	identity, err := comp.Authenticate(context.Background(), req)
+	if identity != nil {
+		t.Error("expected nil identity when neither authenticator succeeds")
+	}
+
+	var mismatch *BindingMismatchError
+	if !errors.As(err, &mismatch) {
+		t.Fatalf("expected the binding mismatch to win, got %v", err)
+	}
+	if mismatch.Repository != "acme/app" {
+		t.Errorf("Repository = %q, want acme/app", mismatch.Repository)
 	}
 }
 

--- a/pkg/rpc/auth_failure_test.go
+++ b/pkg/rpc/auth_failure_test.go
@@ -1,0 +1,64 @@
+package rpc
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type disclosableTestError struct{ msg string }
+
+func (e *disclosableTestError) Error() string         { return e.msg }
+func (e *disclosableTestError) AuthErrorCode() string { return AuthErrorOIDCBindingMismatch }
+
+func TestWriteAuthFailure_DisclosesOptedInReason(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeAuthFailure(w, &disclosableTestError{msg: "OIDC token did not match any CI binding (subject=repo:acme/app)"})
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if got := w.Header().Get("rpc-status"); got != AuthErrorOIDCBindingMismatch {
+		t.Errorf("rpc-status = %q, want %q", got, AuthErrorOIDCBindingMismatch)
+	}
+	if got := w.Header().Get("rpc-error"); got == "" {
+		t.Error("rpc-error should carry the reason the caller was rejected")
+	}
+}
+
+// Anything that didn't opt in stays a bare 401. An authenticator has to say
+// explicitly that its failure is safe to hand back.
+func TestWriteAuthFailure_OrdinaryErrorStaysOpaque(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeAuthFailure(w, fmt.Errorf("signing key 4f2a not found in keyring"))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	if got := w.Header().Get("rpc-status"); got != "" {
+		t.Errorf("rpc-status = %q, want empty", got)
+	}
+	if got := w.Header().Get("rpc-error"); got != "" {
+		t.Errorf("rpc-error = %q, want empty; internal auth detail must not leak", got)
+	}
+}
+
+func TestNewResolveStatusError_CarriesServerDetail(t *testing.T) {
+	err := NewResolveStatusErrorWithReason("entities", "localhost:8443", 401, AuthErrorOIDCBindingMismatch, "OIDC token did not match any CI binding")
+
+	var resolveErr *ResolveError
+	if !errors.As(err, &resolveErr) {
+		t.Fatalf("expected a *ResolveError, got %T", err)
+	}
+	if resolveErr.Code != AuthErrorOIDCBindingMismatch {
+		t.Errorf("Code = %q, want %q", resolveErr.Code, AuthErrorOIDCBindingMismatch)
+	}
+	if resolveErr.Detail != "OIDC token did not match any CI binding" {
+		t.Errorf("Detail = %q", resolveErr.Detail)
+	}
+	if resolveErr.StatusCode != 401 {
+		t.Errorf("StatusCode = %d, want 401", resolveErr.StatusCode)
+	}
+}

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -336,7 +336,8 @@ func (c *NetworkClient) resolveCapability(name string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return NewResolveStatusError(name, c.remote, resp.StatusCode)
+		return NewResolveStatusErrorWithReason(name, c.remote, resp.StatusCode,
+			resp.Header.Get("rpc-status"), resp.Header.Get("rpc-error"))
 	}
 
 	var lr lookupResponse

--- a/pkg/rpc/error.go
+++ b/pkg/rpc/error.go
@@ -5,6 +5,22 @@ import (
 	"time"
 )
 
+// DisclosableAuthError is an authentication failure whose reason is safe to
+// hand back to the caller that triggered it. Authenticators opt in by
+// implementing it; anything else surfaces as a bare 401, because auth failures
+// otherwise make a convenient oracle for probing a cluster's configuration.
+type DisclosableAuthError interface {
+	error
+
+	// AuthErrorCode returns a short machine-readable code, sent as rpc-status
+	// so clients can recognize the failure without parsing the message.
+	AuthErrorCode() string
+}
+
+// AuthErrorOIDCBindingMismatch marks a CI token that verified against a
+// configured issuer but matched none of that issuer's bindings.
+const AuthErrorOIDCBindingMismatch = "oidc-binding-mismatch"
+
 type ErrorCategory interface {
 	ErrorCategory() string
 }
@@ -82,6 +98,13 @@ type ResolveError struct {
 	Msg        string
 	StatusCode int // HTTP status code for ResolveStatusError
 
+	// Code is the server's rpc-status header, when it sent one. It names the
+	// failure so the CLI can recognize it without parsing prose.
+	Code string
+	// Detail is the server's rpc-error header: an explanation the server judged
+	// safe to return to this caller. Empty for most failures.
+	Detail string
+
 	// Name is the capability being resolved, e.g. "entities".
 	Name string
 	// Remote is the address we were talking to, e.g. "localhost:8443".
@@ -145,12 +168,31 @@ func NewResolveHTTPError(err error, format string, args ...interface{}) error {
 
 // NewResolveStatusError creates a status code error
 func NewResolveStatusError(name, remote string, statusCode int) error {
+	return newResolveStatusError(name, remote, statusCode, "", "")
+}
+
+// NewResolveStatusErrorWithReason creates a status code error carrying the
+// server's rpc-status and rpc-error headers: a rejection the server chose to
+// name and explain rather than leave opaque. Both may be empty, which is the
+// normal case, since most failures disclose nothing to an unauthenticated
+// caller.
+func NewResolveStatusErrorWithReason(name, remote string, statusCode int, code, detail string) error {
+	return newResolveStatusError(name, remote, statusCode, code, detail)
+}
+
+func newResolveStatusError(name, remote string, statusCode int, code, detail string) error {
+	msg := fmt.Sprintf("unexpected status code %d from %s while looking up %q", statusCode, remote, name)
+	if detail != "" {
+		msg += ": " + detail
+	}
 	return &ResolveError{
 		Kind:       ResolveStatusError,
 		StatusCode: statusCode,
 		Name:       name,
 		Remote:     remote,
-		Msg:        fmt.Sprintf("unexpected status code %d from %s while looking up %q", statusCode, remote, name),
+		Code:       code,
+		Detail:     detail,
+		Msg:        msg,
 	}
 }
 

--- a/pkg/rpc/oidc_denial_test.go
+++ b/pkg/rpc/oidc_denial_test.go
@@ -1,0 +1,97 @@
+package rpc_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/oidcauth"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/example"
+)
+
+// stubAuthenticator fails every request with a fixed error.
+type stubAuthenticator struct{ err error }
+
+func (s *stubAuthenticator) Authenticate(ctx context.Context, r *http.Request) (*rpc.Identity, error) {
+	return nil, s.err
+}
+
+// TestOIDCBindingMismatchReachesTheClient is the end-to-end check for the half
+// of MIR-1491 that was about diagnosis rather than matching. A CI deploy that
+// presents a valid token matching no binding used to surface as a bare 401,
+// which the CLI rendered as "your session may have expired, run 'miren login'" —
+// advice that is wrong in a way that costs hours, since the credentials are
+// fine.
+//
+// The unit tests cover the pieces (the authenticator builds the error, the 401
+// handler sets the headers, the client parses them). This one runs a real
+// QUIC/HTTP3 listener and a real client so the reason has to survive the actual
+// transport: headers set on an error response, carried over the wire, and
+// plumbed back into the ResolveError the CLI inspects.
+func TestOIDCBindingMismatchReachesTheClient(t *testing.T) {
+	ctx := t.Context()
+	r := require.New(t)
+
+	subject := "repo:acme@277133432/app@1316584243:ref:refs/heads/main"
+
+	ss, err := rpc.NewState(ctx,
+		rpc.WithSkipVerify,
+		rpc.WithAuthenticator(&stubAuthenticator{err: &oidcauth.BindingMismatchError{
+			Issuer:     "https://token.actions.githubusercontent.com",
+			Subject:    subject,
+			Repository: "acme/app",
+		}}),
+	)
+	r.NoError(err)
+	ss.Server().ExposeValue("meter", example.AdaptEmitTemps(&exampleEmit{}))
+
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+
+	_, err = cs.Connect(ss.ListenAddr(), "meter")
+	r.Error(err, "expected the connection to be denied")
+
+	var resolveErr *rpc.ResolveError
+	r.True(errors.As(err, &resolveErr), "expected a *rpc.ResolveError, got %T: %v", err, err)
+	r.Equal(401, resolveErr.StatusCode)
+
+	// Code is what lets the CLI suppress the 'miren login' hint.
+	r.Equal(rpc.AuthErrorOIDCBindingMismatch, resolveErr.Code)
+
+	// Detail is what turns a log-spelunking session into an obvious fix.
+	r.Contains(resolveErr.Detail, subject)
+	r.Contains(resolveErr.Detail, "acme/app")
+}
+
+// An authenticator that didn't opt into disclosure must not leak its reason
+// across the wire, even though it travels the same path.
+func TestOrdinaryAuthFailureDisclosesNothingToTheClient(t *testing.T) {
+	ctx := t.Context()
+	r := require.New(t)
+
+	ss, err := rpc.NewState(ctx,
+		rpc.WithSkipVerify,
+		rpc.WithAuthenticator(&stubAuthenticator{
+			err: fmt.Errorf("signing key 4f2a not found in keyring"),
+		}),
+	)
+	r.NoError(err)
+	ss.Server().ExposeValue("meter", example.AdaptEmitTemps(&exampleEmit{}))
+
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+
+	_, err = cs.Connect(ss.ListenAddr(), "meter")
+	r.Error(err)
+
+	var resolveErr *rpc.ResolveError
+	r.True(errors.As(err, &resolveErr), "expected a *rpc.ResolveError, got %T: %v", err, err)
+	r.Equal(401, resolveErr.StatusCode)
+	r.Empty(resolveErr.Code)
+	r.Empty(resolveErr.Detail)
+	r.NotContains(err.Error(), "keyring")
+}

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -339,7 +340,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	identity, err := s.state.authenticator.Authenticate(ctx, r)
 	if err != nil {
 		s.state.log.Warn("authentication failed", "error", err, "path", r.URL.Path)
-		http.Error(w, "authentication failed", http.StatusUnauthorized)
+		writeAuthFailure(w, err)
 		return
 	}
 
@@ -368,6 +369,19 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // rpcPathPrefix is the path namespace reserved for RPC dispatch.
 const rpcPathPrefix = "/_rpc/"
+
+// writeAuthFailure responds 401 to a failed authentication, explaining why only
+// when the authenticator opted in by implementing DisclosableAuthError. Every
+// other failure stays a bare 401: the caller is unauthenticated, and a chatty
+// rejection is a fine oracle for probing how a cluster is configured.
+func writeAuthFailure(w http.ResponseWriter, err error) {
+	var disclosable DisclosableAuthError
+	if errors.As(err, &disclosable) {
+		w.Header().Add("rpc-status", disclosable.AuthErrorCode())
+		w.Header().Add("rpc-error", disclosable.Error())
+	}
+	http.Error(w, "authentication failed", http.StatusUnauthorized)
+}
 
 // isRPCPath returns true if the path is an RPC endpoint
 func isRPCPath(path string) bool {

--- a/servers/oidcbinding/server.go
+++ b/servers/oidcbinding/server.go
@@ -76,10 +76,6 @@ func (s *Server) Add(ctx context.Context, state *oidcbinding_v1alpha.OidcBinding
 
 	provider := args.Provider()
 	subjectPattern := args.SubjectPattern()
-	if subjectPattern == "" {
-		results.SetError("subject_pattern is required")
-		return nil
-	}
 	description := args.Description()
 
 	// Build claim conditions
@@ -99,6 +95,11 @@ func (s *Server) Add(ctx context.Context, state *oidcbinding_v1alpha.OidcBinding
 			Key:     "event_name",
 			Pattern: "push,workflow_dispatch",
 		})
+	}
+
+	if !identifiesCaller(subjectPattern, claimConditions) {
+		results.SetError("binding must identify the caller: set a subject pattern or a claim condition (e.g. repository) that is not a bare wildcard")
+		return nil
 	}
 
 	binding := &core_v1alpha.OidcBinding{
@@ -209,6 +210,32 @@ func (s *Server) Remove(ctx context.Context, state *oidcbinding_v1alpha.OidcBind
 	s.Log.Info("removed OIDC binding", "id", id)
 	results.SetSuccess(true)
 	return nil
+}
+
+// identifiesCaller reports whether a binding narrows the tokens it accepts down
+// to a particular caller. Without this, a binding constrained only by event_name
+// (or by nothing at all) would accept a token from any repository the issuer
+// serves, which for GitHub Actions means every repository on github.com.
+func identifiesCaller(subjectPattern string, conditions []core_v1alpha.ClaimConditions) bool {
+	if !isWildcardPattern(subjectPattern) {
+		return true
+	}
+	for _, cc := range conditions {
+		// event_name says what triggered the workflow, never who ran it.
+		if cc.Key == "event_name" {
+			continue
+		}
+		if !isWildcardPattern(cc.Pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// isWildcardPattern reports whether a pattern constrains nothing: either empty
+// or made up entirely of '*', both of which match any value.
+func isWildcardPattern(pattern string) bool {
+	return strings.Trim(pattern, "*") == ""
 }
 
 func toBindingInfo(id, appName string, b *core_v1alpha.OidcBinding) *oidcbinding_v1alpha.BindingInfo {

--- a/servers/oidcbinding/server.go
+++ b/servers/oidcbinding/server.go
@@ -212,17 +212,29 @@ func (s *Server) Remove(ctx context.Context, state *oidcbinding_v1alpha.OidcBind
 	return nil
 }
 
+// runScopedClaims describe the circumstances of a workflow run rather than who
+// is running it. Any repository on github.com can push to a branch called main,
+// so none of these narrows a binding to a particular caller no matter how
+// specific the pattern looks.
+var runScopedClaims = map[string]bool{
+	"event_name":            true,
+	"ref":                   true,
+	"ref_type":              true,
+	"ref_protected":         true,
+	"runner_environment":    true,
+	"repository_visibility": true,
+}
+
 // identifiesCaller reports whether a binding narrows the tokens it accepts down
-// to a particular caller. Without this, a binding constrained only by event_name
-// (or by nothing at all) would accept a token from any repository the issuer
-// serves, which for GitHub Actions means every repository on github.com.
+// to a particular caller. Without this, a binding constrained only by run-scoped
+// claims (or by nothing at all) would accept a token from any repository the
+// issuer serves, which for GitHub Actions means every repository on github.com.
 func identifiesCaller(subjectPattern string, conditions []core_v1alpha.ClaimConditions) bool {
 	if !isWildcardPattern(subjectPattern) {
 		return true
 	}
 	for _, cc := range conditions {
-		// event_name says what triggered the workflow, never who ran it.
-		if cc.Key == "event_name" {
+		if runScopedClaims[cc.Key] {
 			continue
 		}
 		if !isWildcardPattern(cc.Pattern) {

--- a/servers/oidcbinding/server_test.go
+++ b/servers/oidcbinding/server_test.go
@@ -1,0 +1,76 @@
+package oidcbinding
+
+import (
+	"testing"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+)
+
+func TestIdentifiesCaller(t *testing.T) {
+	tests := []struct {
+		name       string
+		subject    string
+		conditions []core_v1alpha.ClaimConditions
+		want       bool
+	}{
+		{
+			name:    "subject pattern alone",
+			subject: "repo:acme/app:*",
+			want:    true,
+		},
+		{
+			name: "repository claim alone",
+			conditions: []core_v1alpha.ClaimConditions{
+				{Key: "repository", Pattern: "acme/app"},
+				{Key: "event_name", Pattern: "push,workflow_dispatch"},
+			},
+			want: true,
+		},
+		{
+			name:       "nothing at all",
+			conditions: nil,
+			want:       false,
+		},
+		{
+			// event_name says what triggered the workflow, not who ran it. A
+			// binding constrained only by it accepts a push from any repo on
+			// github.com.
+			name: "event_name alone",
+			conditions: []core_v1alpha.ClaimConditions{
+				{Key: "event_name", Pattern: "push"},
+			},
+			want: false,
+		},
+		{
+			name:    "bare wildcard subject",
+			subject: "*",
+			conditions: []core_v1alpha.ClaimConditions{
+				{Key: "event_name", Pattern: "push"},
+			},
+			want: false,
+		},
+		{
+			name:    "wildcard subject rescued by a repository claim",
+			subject: "*",
+			conditions: []core_v1alpha.ClaimConditions{
+				{Key: "repository", Pattern: "acme/app"},
+			},
+			want: true,
+		},
+		{
+			name: "wildcard repository claim constrains nothing",
+			conditions: []core_v1alpha.ClaimConditions{
+				{Key: "repository", Pattern: "*"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := identifiesCaller(tt.subject, tt.conditions); got != tt.want {
+				t.Errorf("identifiesCaller(%q, %v) = %v, want %v", tt.subject, tt.conditions, got, tt.want)
+			}
+		})
+	}
+}

--- a/servers/oidcbinding/server_test.go
+++ b/servers/oidcbinding/server_test.go
@@ -42,6 +42,36 @@ func TestIdentifiesCaller(t *testing.T) {
 			want: false,
 		},
 		{
+			// Reachable from the CLI's generic path with just --issuer and
+			// --allowed-refs. A branch name says nothing about which repo the
+			// push came from, so this would accept any repo on github.com.
+			name: "ref alone",
+			conditions: []core_v1alpha.ClaimConditions{
+				{Key: "ref", Pattern: "refs/heads/main"},
+			},
+			want: false,
+		},
+		{
+			name: "run-scoped claims however specific",
+			conditions: []core_v1alpha.ClaimConditions{
+				{Key: "event_name", Pattern: "push"},
+				{Key: "ref", Pattern: "refs/heads/main"},
+				{Key: "ref_type", Pattern: "branch"},
+				{Key: "ref_protected", Pattern: "true"},
+				{Key: "runner_environment", Pattern: "github-hosted"},
+				{Key: "repository_visibility", Pattern: "private"},
+			},
+			want: false,
+		},
+		{
+			name: "one identifying claim among run-scoped ones is enough",
+			conditions: []core_v1alpha.ClaimConditions{
+				{Key: "ref", Pattern: "refs/heads/main"},
+				{Key: "repository", Pattern: "acme/app"},
+			},
+			want: true,
+		},
+		{
 			name:    "bare wildcard subject",
 			subject: "*",
 			conditions: []core_v1alpha.ClaimConditions{


### PR DESCRIPTION
Setting up autodeploy on a freshly created repo, the binding was accepted without complaint and then every token bounced. The CI side said `access denied` and suggested running `miren login`, which was the wrong lead entirely: the credentials were fine.

The cause is GitHub's [immutable subject claims change](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/). Any repo created, renamed, or transferred after July 15 2026 sends a subject with numeric IDs baked in, and `miren auth ci add --github` built its pattern by string-concatenating owner and repo, so the binding was inert from the moment it was created. It isn't only a new-repo problem: the first rename of a long-working repo breaks it the same way, with no setup context to explain why deploys stopped.

So bind on the `repository` and `repository_owner` claims instead, which GitHub recommends over parsing the subject and which this change left alone. I confirmed that against a real token from a post-cutover repo rather than trusting the changelog (values below anonymized):

```
"sub":              "repo:acme@1234567/web-app@7654321:ref:refs/heads/main"
"repository":       "acme/web-app"
"repository_owner": "acme"
```

Names come through intact. `repository_id` is present too, and binding on that would survive renames, but it costs an API call at creation time and makes bindings unreadable, so this takes the cheaper option. `--immutable` is an easy follow-up if renames ever bite.

Dropping the generated subject meant the server could no longer require a subject pattern, so that check is replaced with one that earns its keep: a binding must be narrowed by something identifying the caller. Nothing previously stopped you creating one constrained only by `event_name`, which accepts a push from any repo on github.com.

The other half is diagnosis. The real reason was logged at Debug and reachable only through `miren logs system auth`, which you have to already suspect to go looking for. Authenticators can now opt a failure into being explained (`rpc.DisclosableAuthError`), and the OIDC one does, returning the rejected subject and repository in the `rpc-error` header so the CLI prints them and drops the login hint. Those come from the caller's own verified token, so nothing leaks that they didn't already hold, and binding config is never included. Everything else stays a bare 401.

Rollout note: a new CLI against an un-upgraded server fails binding creation with `subject_pattern is required`, so servers want upgrading first.

Fixes MIR-1491
