### PR TITLE
Stop shimming local disks onto services that never declared one

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -846,6 +846,21 @@ const (
 	localDataDiskName  = "local-data"
 )
 
+// appDeclaresLocalDisk returns true if any service in the spec declares an
+// explicit local-provider disk. All local volumes share one per-app host
+// directory, so a single explicit declaration anywhere in the app already
+// accounts for whatever that directory holds.
+func appDeclaresLocalDisk(spec *core_v1alpha.ConfigSpec) bool {
+	for _, svc := range spec.Services {
+		for _, d := range svc.Disks {
+			if d.Provider == core_v1alpha.ConfigSpecServicesDisksLOCAL {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // injectAutoMountLocalDisks registers the transitional local-storage auto-mount
 // as a real disk on the resolved config. For any service whose per-app host data
 // directory already holds data but which declares no disk at the auto-mount path,
@@ -859,6 +874,16 @@ const (
 // the disk here does not move any existing data.
 func (l *Launcher) injectAutoMountLocalDisks(spec *core_v1alpha.ConfigSpec, app *core_v1alpha.App) {
 	if l.DataPath == "" {
+		return
+	}
+	// The data check below is app-scoped, but the injection loop is not: without
+	// this guard, one service's explicit local disk makes dirHasData true for the
+	// whole app and shims a disk onto every sibling service. Those siblings then
+	// report serviceHasDisks true and take drainStaleDiskPools, which scales the
+	// old pool to zero *before* creating the new one — a full serving gap on every
+	// deploy for services that never asked for a disk (MIR-1423 suppressed this
+	// per-service; the app-scoped case was missed).
+	if appDeclaresLocalDisk(spec) {
 		return
 	}
 	if !dirHasData(filepath.Join(l.DataPath, "data", "local", app.ID.String())) {

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -2978,6 +2978,117 @@ func TestAutoMountDrainsSupersededPool(t *testing.T) {
 	assert.Equal(t, "/miren/data/local", referencing[0].SandboxSpec.Container[0].Mount[0].Destination)
 }
 
+// TestAutoMountSuppressedWhenSiblingDeclaresLocalDisk reproduces the miren.cloud
+// deploy blip. The auto-mount probe is app-scoped (all local volumes share one
+// per-app host directory), but the injection loop is per-service. An app with a
+// stateful sibling — here valkey, which declares a local disk and fills that
+// directory — therefore had a local disk shimmed onto its stateless services too.
+// Those services then reported serviceHasDisks true and took drainStaleDiskPools,
+// scaling the old pool to zero before creating the new one, so every deploy went
+// through a window with nothing serving. An explicit local disk anywhere in the
+// app already accounts for the data, so the shim must not fire at all.
+func TestAutoMountSuppressedWhenSiblingDeclaresLocalDisk(t *testing.T) {
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	app := &core_v1alpha.App{
+		Project: entity.Id("project-1"),
+	}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	version := &core_v1alpha.AppVersion{
+		App:      app.ID,
+		Version:  "v1",
+		ImageUrl: "test:latest",
+		Config: core_v1alpha.Config{
+			Port: 3000,
+			Services: []core_v1alpha.Services{
+				{
+					Name: "web",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:                "auto",
+						RequestsPerInstance: 10,
+					},
+				},
+				{
+					Name: "valkey",
+					ServiceConcurrency: core_v1alpha.ServiceConcurrency{
+						Mode:         "fixed",
+						NumInstances: 1,
+					},
+					Disks: []core_v1alpha.Disks{
+						{
+							Name:      "valkey-data",
+							Provider:  core_v1alpha.LOCAL,
+							MountPath: "/miren/data/local",
+						},
+					},
+				},
+			},
+		},
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	// valkey has been running and has filled the shared per-app local directory,
+	// so the app-scoped dirHasData probe finds data.
+	dataPath := t.TempDir()
+	localDir := filepath.Join(dataPath, "data", "local", app.ID.String())
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "appendonly.aof"), []byte("test"), 0644))
+
+	launcher := newTestLauncher(log, server.EAC)
+	launcher.DataPath = dataPath
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	poolFor := func(service string) compute_v1alpha.SandboxPool {
+		t.Helper()
+		for _, p := range listAllPools(t, ctx, server) {
+			if p.Service == service {
+				return p
+			}
+		}
+		t.Fatalf("no pool found for service %q", service)
+		return compute_v1alpha.SandboxPool{}
+	}
+
+	// The stateless service must stay diskless: it never declared a disk, and
+	// mounting one is what pushed it onto the drain-before-create path.
+	web := poolFor("web")
+	assert.Empty(t, web.SandboxSpec.Volume,
+		"web must not get an auto-mounted disk just because valkey declares one")
+	require.Len(t, web.SandboxSpec.Container, 1)
+	assert.Empty(t, web.SandboxSpec.Container[0].Mount,
+		"web must not get the /miren/data/local container mount")
+
+	// valkey's own explicit disk is untouched, so it keeps the drain path.
+	valkey := poolFor("valkey")
+	require.Len(t, valkey.SandboxSpec.Volume, 1, "valkey keeps its declared disk")
+	assert.Equal(t, "valkey-data", valkey.SandboxSpec.Volume[0].Name)
+	assert.Equal(t, "local", valkey.SandboxSpec.Volume[0].Provider)
+
+	// The payoff: web is now reachable by the stateless reaper, which runs
+	// create → wait-ready → reap. reapStaleStatelessPools skips services where
+	// serviceHasDisks reports true, so reaping web proves it is off the
+	// drain-before-create path and no longer opens a serving gap on deploy.
+	spec, err := coreutil.ResolveConfig(ctx, server.EAC, version)
+	require.NoError(t, err)
+	version.ImageUrl = "test:v2"
+
+	reaped, err := launcher.reapStaleStatelessPools(ctx, app, version, spec, map[string]bool{"web": true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, reaped, "web should be reaped as a stateless pool, not drained before create")
+}
+
 // TestDiskPoolDrainedBeforeNewPoolCreated verifies that when deploying a new
 // version of an app with disks, the old pool is scaled to 0 before the new
 // pool is created. This prevents conflicts when both old and new sandboxes try


### PR DESCRIPTION
An uptime check fired for miren.cloud during a routine deploy this morning, a timeout that cleared on its own. Chasing it through the cluster logs turned up about four seconds where no web instance was listening at all: both old instances exited, and the replacement didn't bind its port until later. The activator logged three requests parked with "no running sandboxes available" while it waited.

That turned out not to be a fluke of that particular deploy. `injectAutoMountLocalDisks` is the transitional shim that keeps legacy local storage mounted for apps that never declared a disk. It decides whether to fire using an app-scoped probe (`dirHasData` over the shared per-app local directory), but then injects a `local-data` disk into every service in the spec. The cloud app runs a valkey service with a real local disk next to a stateless web service, so valkey's data made the probe true for the whole app and web got a disk it never asked for.

The stray mount would have been harmless on its own. What wasn't: `serviceHasDisks` then reported true for web, which routes it to `drainStaleDiskPools` (scale old to zero, wait for drain, then create new) instead of `reapStaleStatelessPools` (create, wait ready, then reap). The latter exists precisely to avoid a serving gap, and says as much in its own comment. So web and bgtask were taking the stop-the-world path on every single deploy.

The fix is a guard: if any service in the app declares a local-provider disk, that declaration already accounts for whatever the shared directory holds, so the shim shouldn't fire. MIR-1423 applied this same suppression per-service, and since the probe is app-scoped, the suppression needed to be too. Genuinely legacy apps with no explicit disk anywhere are untouched, keeping both the shim and the MIR-1293 drain behavior.

The test builds the production shape, an auto-scaled web service alongside a fixed valkey with a local disk, and asserts the sibling stays diskless while valkey keeps its declared disk. The assertion that actually matters is the last one: `reapStaleStatelessPools` skips anything `serviceHasDisks` claims, so watching it reap web is what proves web is off the drain-before-create path.

Closes MIR-1504
