### PR TITLE
Bind VictoriaMetrics and VictoriaLogs to loopback

### DIFF
--- a/components/victorialogs/victorialogs.go
+++ b/components/victorialogs/victorialogs.go
@@ -135,7 +135,7 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 	}
 
 	// Wait for VictoriaLogs to be ready
-	if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+	if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
 		task.Delete(ctx)
 		container.Delete(ctx, containerd.WithSnapshotCleanup)
 		return err
@@ -152,7 +152,10 @@ func (c *VictoriaLogsComponent) Start(ctx context.Context, config VictoriaLogsCo
 
 func (c *VictoriaLogsComponent) HTTPEndpoint() string {
 	return c.IfRunning(func() string {
-		return fmt.Sprintf("localhost:%d", c.httpPort)
+		// Names the bind address literally rather than "localhost", which on a
+		// dual-stack host resolves to ::1 first and would spend a failed dial
+		// on every new connection to a v4-only listener.
+		return fmt.Sprintf("127.0.0.1:%d", c.httpPort)
 	})
 }
 
@@ -169,7 +172,7 @@ func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, co
 		} else if status.Status == containerd.Running {
 			c.Log.Info("victorialogs container is already running")
 			c.SetTask(task)
-			if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+			if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
 				return err
 			}
 			c.StartExitMonitor(ctx)
@@ -181,7 +184,7 @@ func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, co
 		if err == nil {
 			c.SetTask(task)
 			c.Log.Info("victorialogs server restarted", "container_id", container.ID(), "http_port", config.HTTPPort)
-			if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+			if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
 				return err
 			}
 			c.StartExitMonitor(ctx)
@@ -204,7 +207,7 @@ func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, co
 		return fmt.Errorf("failed to start new task for existing container: %w", err)
 	}
 
-	if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+	if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
 		task.Delete(ctx)
 		return err
 	}
@@ -219,7 +222,18 @@ func (c *VictoriaLogsComponent) restartExistingContainer(ctx context.Context, co
 }
 
 func (c *VictoriaLogsComponent) createContainer(ctx context.Context, image containerd.Image, dataPath string, config VictoriaLogsConfig) (containerd.Container, error) {
-	listenAddr := fmt.Sprintf(":%d", config.HTTPPort)
+	// Loopback only. VictoriaLogs authenticates nobody, so whatever can reach
+	// this port can read and write the cluster's logs, which include anything
+	// an app prints. Nothing off-host needs to reach it: the coordinator's own
+	// reads and writes are local, and distributed runners ship through the
+	// coordinator's authenticated listener rather than dialing here
+	// (MIR-1483). Binding the wildcard would leave a firewall rule as the only
+	// thing standing in front of it, which is a control that can be flushed,
+	// reordered, or simply absent on a host nobody configured.
+	//
+	// -enableTCP6 below does not reopen this. It governs whether IPv6 may be
+	// used at all; the listener is whatever this address names.
+	listenAddr := fmt.Sprintf("127.0.0.1:%d", config.HTTPPort)
 
 	opts := []oci.SpecOpts{
 		oci.WithImageConfig(image),

--- a/components/victorialogs/victorialogs_test.go
+++ b/components/victorialogs/victorialogs_test.go
@@ -53,7 +53,7 @@ func TestVictoriaLogsComponent(t *testing.T) {
 		r.NoError(err)
 
 		r.True(component.IsRunning())
-		r.Equal("localhost:9428", component.HTTPEndpoint())
+		r.Equal("127.0.0.1:9428", component.HTTPEndpoint())
 
 		// Give it a moment to fully start
 		time.Sleep(2 * time.Second)
@@ -141,7 +141,7 @@ func TestVictoriaLogsComponent(t *testing.T) {
 		r.NoError(err)
 		defer component.Stop(ctx)
 
-		r.Equal("localhost:9430", component.HTTPEndpoint())
+		r.Equal("127.0.0.1:9430", component.HTTPEndpoint())
 	})
 
 	t.Run("uses custom retention period", func(t *testing.T) {
@@ -221,7 +221,7 @@ func TestVictoriaLogsComponentAutoRestart(t *testing.T) {
 	r.NoError(err)
 	r.True(component.IsRunning())
 
-	endpoint := fmt.Sprintf("http://localhost:%d", httpPort)
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d", httpPort)
 
 	// Wait for victorialogs to be fully ready
 	r.Eventually(func() bool {

--- a/components/victoriametrics/integration_test.go
+++ b/components/victoriametrics/integration_test.go
@@ -86,7 +86,7 @@ func TestVictoriaMetricsComponentIntegration(t *testing.T) {
 	httpEndpoint := component.HTTPEndpoint()
 	assert.NotEmpty(t, httpEndpoint, "HTTP endpoint should not be empty")
 
-	expectedHTTPEndpoint := fmt.Sprintf("localhost:%d", httpPort)
+	expectedHTTPEndpoint := fmt.Sprintf("127.0.0.1:%d", httpPort)
 	assert.Equal(t, expectedHTTPEndpoint, httpEndpoint, "HTTP endpoint should match expected")
 
 	// Wait for VictoriaMetrics to be fully ready by polling health endpoint
@@ -272,7 +272,7 @@ func TestVictoriaMetricsComponent_GracefulShutdown(t *testing.T) {
 	// Wait for VictoriaMetrics to be fully ready by polling
 	client := &http.Client{Timeout: 5 * time.Second}
 	require.Eventually(t, func() bool {
-		resp, err := client.Get(fmt.Sprintf("http://localhost:%d/health", config.HTTPPort))
+		resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/health", config.HTTPPort))
 		if err != nil {
 			return false
 		}
@@ -329,7 +329,7 @@ func TestVictoriaMetricsComponent_MultipleStarts(t *testing.T) {
 
 		// Wait for VictoriaMetrics to be ready by polling
 		require.Eventually(t, func() bool {
-			resp, err := client.Get(fmt.Sprintf("http://localhost:%d/health", config.HTTPPort))
+			resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/health", config.HTTPPort))
 			if err != nil {
 				return false
 			}

--- a/components/victoriametrics/victoriametrics.go
+++ b/components/victoriametrics/victoriametrics.go
@@ -135,7 +135,7 @@ func (c *VictoriaMetricsComponent) Start(ctx context.Context, config VictoriaMet
 	}
 
 	// Wait for VictoriaMetrics to be ready
-	if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+	if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
 		task.Delete(ctx)
 		container.Delete(ctx, containerd.WithSnapshotCleanup)
 		return err
@@ -152,7 +152,10 @@ func (c *VictoriaMetricsComponent) Start(ctx context.Context, config VictoriaMet
 
 func (c *VictoriaMetricsComponent) HTTPEndpoint() string {
 	return c.IfRunning(func() string {
-		return fmt.Sprintf("localhost:%d", c.httpPort)
+		// Names the bind address literally rather than "localhost", which on a
+		// dual-stack host resolves to ::1 first and would spend a failed dial
+		// on every new connection to a v4-only listener.
+		return fmt.Sprintf("127.0.0.1:%d", c.httpPort)
 	})
 }
 
@@ -169,7 +172,7 @@ func (c *VictoriaMetricsComponent) restartExistingContainer(ctx context.Context,
 		} else if status.Status == containerd.Running {
 			c.Log.Info("victoriametrics container is already running")
 			c.SetTask(task)
-			if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+			if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
 				return err
 			}
 			c.StartExitMonitor(ctx)
@@ -181,7 +184,7 @@ func (c *VictoriaMetricsComponent) restartExistingContainer(ctx context.Context,
 		if err == nil {
 			c.SetTask(task)
 			c.Log.Info("victoriametrics server restarted", "container_id", container.ID(), "http_port", config.HTTPPort)
-			if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+			if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
 				return err
 			}
 			c.StartExitMonitor(ctx)
@@ -204,7 +207,7 @@ func (c *VictoriaMetricsComponent) restartExistingContainer(ctx context.Context,
 		return fmt.Errorf("failed to start new task for existing container: %w", err)
 	}
 
-	if err := c.WaitForReady(ctx, "localhost", config.HTTPPort); err != nil {
+	if err := c.WaitForReady(ctx, "127.0.0.1", config.HTTPPort); err != nil {
 		task.Delete(ctx)
 		return err
 	}
@@ -219,7 +222,18 @@ func (c *VictoriaMetricsComponent) restartExistingContainer(ctx context.Context,
 }
 
 func (c *VictoriaMetricsComponent) createContainer(ctx context.Context, image containerd.Image, dataPath string, config VictoriaMetricsConfig) (containerd.Container, error) {
-	listenAddr := fmt.Sprintf(":%d", config.HTTPPort)
+	// Loopback only. VictoriaMetrics authenticates nobody, so whatever can
+	// reach this port can read and write the cluster's metrics, including its
+	// delete-series endpoint. Nothing off-host needs to reach it: the
+	// coordinator's own reads and writes are local, and distributed runners
+	// ship through the coordinator's authenticated listener rather than dialing
+	// here (MIR-1483). Binding the wildcard would leave a firewall rule as the
+	// only thing standing in front of it, which is a control that can be
+	// flushed, reordered, or simply absent on a host nobody configured.
+	//
+	// -enableTCP6 below does not reopen this. It governs whether IPv6 may be
+	// used at all; the listener is whatever this address names.
+	listenAddr := fmt.Sprintf("127.0.0.1:%d", config.HTTPPort)
 
 	opts := []oci.SpecOpts{
 		oci.WithImageConfig(image),


### PR DESCRIPTION
#992 routed distributed runner telemetry through the coordinator's authenticated listener, and its whole premise was that VictoriaMetrics and VictoriaLogs could then stop listening anywhere a runner can reach. The premise was right but unimplemented: both components still bound the wildcard, exactly as MIR-1483 describes them doing, so those ports were as open after that PR as before it. What stood in front of them remained a firewall rule, and on the GCP dev clusters that rule turns out to be the auto-created `default-allow-internal`, which permits all TCP and UDP across `10.128.0.0/9` and isn't managed in our infra repo at all.

Neither service authenticates anybody, so reachability is the entire access control. A firewall is a reasonable second layer and a poor only layer, since it can be flushed, reordered, or never applied on a host nobody configured. Binding `127.0.0.1` removes the exposure rather than guarding it, and then there's no rule left to maintain.

This is safe now in a way it wasn't before. The coordinator's own reads and writes go over loopback, and runners ship to `:8443` instead of dialing these directly. The only population that could be stranded is a cluster running distributed runners on a build predating #992, and since distributed runners sit behind `MIREN_LABS`, that's a small and known set. I rolled #992 out to garden, toys and club this morning and confirmed both metrics and logs arriving through the coordinator's ingest before writing this.

Moving the endpoint and readiness probe from `localhost` to the literal address is deliberate rather than cosmetic. On a dual-stack host `localhost` resolves to `::1` first, and against a v4-only listener that spends a failed dial on every new connection, which the readiness probe would pay during startup.

Two things this deliberately doesn't do. It doesn't add authentication to either backend: once they're on loopback the reachable set is host-level access, which already grants the etcd keyspace, the workload identity signing key, and the data files themselves, so a credential on the metrics port defends nothing that isn't already gone. And it leaves the external-instance path alone, where `--victoriametrics-addr` points at something an operator runs and secures themselves.

One residual worth naming: a sandbox with `Spec.HostNetwork` set shares the host netns and can still reach loopback. That needs rights to write a sandbox entity, a much higher bar than "any host on the VPC", but it's why I'd rather see a regression test pinning the bind address than call this airtight.

Closes MIR-1483
