### PR TITLE
Re-register sandbox metrics for containers that survive a restart

### DIFF
--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -398,18 +398,7 @@ func addMetrics(ctx context.Context, in addMetricsIn) (addMetricsOut, error) {
 		return addMetricsOut{}, fmt.Errorf("fetching sandbox: %w", err)
 	}
 
-	le := sb.Spec.LogEntity
-	if le == "" {
-		le = sb.ID.String()
-	}
-
-	attrs := map[string]string{"miren.sandbox": sb.ID.String()}
-	if sb.Spec.Version != "" {
-		attrs["miren.version"] = sb.Spec.Version.String()
-	}
-	for _, lbl := range sb.Spec.LogAttribute {
-		attrs[lbl.Key] = lbl.Value
-	}
+	le, attrs := sandboxMetricsIdentity(sb)
 
 	if err := deps.obs.AddMetrics(le, in.AllCgroups, attrs); err != nil {
 		return addMetricsOut{}, fmt.Errorf("adding metrics: %w", err)

--- a/controllers/sandbox/metrics.go
+++ b/controllers/sandbox/metrics.go
@@ -60,6 +60,30 @@ func (m *Metrics) Add(name string, pathes map[string]string, attributes map[stri
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.add(name, pathes, attributes)
+}
+
+// AddIfAbsent registers cgroups for name only when it isn't already monitored,
+// reporting whether it did. The check and the insert happen under one lock, so
+// two callers racing to re-register the same sandbox can't both win and reset
+// the CPU counters Add would otherwise discard.
+func (m *Metrics) AddIfAbsent(name string, pathes map[string]string, attributes map[string]string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.namedEntries[name]; ok {
+		return false, nil
+	}
+
+	if err := m.add(name, pathes, attributes); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// add does the work of Add. Callers hold m.mu.
+func (m *Metrics) add(name string, pathes map[string]string, attributes map[string]string) error {
 	if m.namedEntries == nil {
 		m.namedEntries = make(map[string]*Cgroups)
 	}
@@ -81,6 +105,18 @@ func (m *Metrics) Add(name string, pathes map[string]string, attributes map[stri
 	m.namedEntries[name] = &cg
 
 	return nil
+}
+
+// Has reports whether a log entity is already being monitored. Re-registration
+// paths that run on every reconcile check this before doing the work of
+// collecting cgroup paths; AddIfAbsent is what actually makes the registration
+// safe against a concurrent one.
+func (m *Metrics) Has(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, ok := m.namedEntries[name]
+	return ok
 }
 
 func (m *Metrics) Remove(name string) error {

--- a/controllers/sandbox/metrics_darwin.go
+++ b/controllers/sandbox/metrics_darwin.go
@@ -34,6 +34,18 @@ func (m *Metrics) Add(name string, pathes map[string]string, attributes map[stri
 	return nil
 }
 
+func (m *Metrics) AddIfAbsent(name string, pathes map[string]string, attributes map[string]string) (bool, error) {
+	return true, nil
+}
+
+func (m *Metrics) Has(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, ok := m.namedEntries[name]
+	return ok
+}
+
 func (m *Metrics) Remove(name string) error {
 	return nil
 }

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -85,6 +85,14 @@ func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox,
 		} else {
 			switch searchRes {
 			case same:
+				// Same adoption gap as the non-saga controller: healthy
+				// containers this process didn't boot need their metrics
+				// re-registered here (MIR-1013).
+				if err := s.inner.ensureMetrics(ctx, co); err != nil {
+					s.log.Warn("failed to ensure metrics for existing sandbox",
+						"id", co.ID, "error", err)
+				}
+
 				if co.Status == compute.PENDING {
 					createdAt := meta.GetCreatedAt()
 					age := time.Since(createdAt)

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -447,6 +447,17 @@ func (c *SandboxController) reconcileSandboxesOnBoot(ctx context.Context) error 
 						"sandbox_id", sb.ID)
 				}
 			}
+
+			// Re-register cgroup metrics. Logs are reattached above, so a
+			// surviving sandbox that skips this looks entirely healthy while
+			// its CPU and memory series stop dead at the restart and never
+			// resume (MIR-1013). Failing here must not cost us the sandbox:
+			// unhealthySandboxes gets deleted, and a metrics gap is a far
+			// better outcome than killing a running workload.
+			if err := c.ensureMetrics(ctx, &sb); err != nil {
+				c.Log.Warn("failed to re-register metrics during boot reconciliation",
+					"sandbox_id", sb.ID, "error", err)
+			}
 		}
 	}
 
@@ -894,6 +905,98 @@ func (c *SandboxController) pauseContainerPID(ctx context.Context, pauseID strin
 	return int(task.Pid()), nil
 }
 
+// sandboxMetricsIdentity returns the log entity a sandbox's cgroup metrics are
+// keyed by, plus the attributes those metrics carry. Every registration site
+// shares this so the key always matches the one StopSandbox removes, and so
+// new attributes reach all of them at once.
+func sandboxMetricsIdentity(sb *compute.Sandbox) (string, map[string]string) {
+	le := sb.Spec.LogEntity
+	if le == "" {
+		le = sb.ID.String()
+	}
+
+	attrs := map[string]string{
+		"miren.sandbox": sb.ID.String(),
+	}
+
+	if sb.Spec.Version != "" {
+		attrs["miren.version"] = sb.Spec.Version.String()
+	}
+
+	for _, lbl := range sb.Spec.LogAttribute {
+		attrs[lbl.Key] = lbl.Value
+	}
+
+	return le, attrs
+}
+
+// sandboxCgroups reads the cgroup path of each of a sandbox's live containers
+// from containerd, keyed the way createSandbox keys them: "" for the pause
+// container, the container name for each subcontainer.
+func (c *SandboxController) sandboxCgroups(ctx context.Context, sb *compute.Sandbox) (map[string]string, error) {
+	ctx = namespaces.WithNamespace(ctx, c.Namespace)
+
+	ids := map[string]string{"": pauseContainerId(sb.ID)}
+	for _, container := range sb.Spec.Container {
+		ids[container.Name] = fmt.Sprintf("%s-%s", containerPrefix(sb.ID), container.Name)
+	}
+
+	cgroups := make(map[string]string, len(ids))
+
+	for name, id := range ids {
+		container, err := c.CC.LoadContainer(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("loading container %s: %w", id, err)
+		}
+
+		spec, err := container.Spec(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("getting spec for container %s: %w", id, err)
+		}
+
+		if spec.Linux == nil {
+			return nil, fmt.Errorf("container %s has no linux spec", id)
+		}
+
+		cgroups[name] = spec.Linux.CgroupsPath
+	}
+
+	return cgroups, nil
+}
+
+// ensureMetrics registers cgroup metrics for a sandbox this process did not
+// boot itself, so CPU and memory keep flowing for containers that outlived a
+// restart. Sandboxes already being monitored are left alone: this runs on
+// every reconcile for adopted sandboxes, and re-adding would reset the CPU
+// delta baseline each time (MIR-1013).
+func (c *SandboxController) ensureMetrics(ctx context.Context, sb *compute.Sandbox) error {
+	le, attrs := sandboxMetricsIdentity(sb)
+
+	// Cheap bail-out so the common case doesn't ask containerd for a spec per
+	// container on every reconcile. AddIfAbsent below is what actually keeps
+	// two concurrent callers from both registering.
+	if c.Metrics.Has(le) {
+		return nil
+	}
+
+	cgroups, err := c.sandboxCgroups(ctx, sb)
+	if err != nil {
+		return err
+	}
+
+	added, err := c.Metrics.AddIfAbsent(le, cgroups, attrs)
+	if err != nil {
+		return err
+	}
+
+	if added {
+		c.Log.Debug("registered metrics for surviving sandbox",
+			"sandbox_id", sb.ID, "log_entity", le)
+	}
+
+	return nil
+}
+
 // reattachLogs reattaches log consumers to a container's task after controller restart.
 // This is critical to prevent stdout/stderr buffers from filling up and blocking the process.
 // containerName should be empty string for the pause container, or the subcontainer name otherwise.
@@ -952,6 +1055,16 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 		} else {
 			switch searchRes {
 			case same:
+				// The containers are healthy but this process may not have
+				// booted them: a sandbox still PENDING at restart is skipped by
+				// boot reconciliation, so this is the only place its metrics get
+				// re-registered (MIR-1013). ensureMetrics is a no-op once the
+				// sandbox is monitored, so running it every reconcile is safe.
+				if err := c.ensureMetrics(ctx, co); err != nil {
+					c.Log.Warn("failed to ensure metrics for existing sandbox",
+						"id", co.ID, "error", err)
+				}
+
 				// If sandbox exists and is healthy but status is PENDING,
 				// update it to RUNNING. This is a fallback to recover from failed
 				// status updates (e.g. due to OCC conflicts during creation).
@@ -1154,22 +1267,7 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 		return err
 	}
 
-	le := co.Spec.LogEntity
-	if le == "" {
-		le = co.ID.String()
-	}
-
-	attrs := map[string]string{
-		"miren.sandbox": co.ID.String(),
-	}
-
-	if co.Spec.Version != "" {
-		attrs["miren.version"] = co.Spec.Version.String()
-	}
-
-	for _, lbl := range co.Spec.LogAttribute {
-		attrs[lbl.Key] = lbl.Value
-	}
+	le, attrs := sandboxMetricsIdentity(co)
 
 	err = c.Metrics.Add(le, cgroups, attrs)
 	if err != nil {

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,22 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		// Updated for MIR-1428 (mounted disks writable by the run user) and
-		// MIR-1435 (inject MIREN_INSTANCE_NUM alongside MIREN_RUNTIME_INSTANCE_NUM
-		// as a deprecated alias). Both changes live in buildSubContainerSpec, which
-		// the saga path also reaches via deps.runtime.BootContainers, so both
-		// controllers already share the new behavior and there was nothing to
-		// mirror in create_saga.go.
-		//
-		// Also updated for MIR-1072 (typed node-id boundary): the NodeId fields
-		// became compute_v1alpha.NodeId and the inline entity.Id("node/"+c.NodeId)
-		// constructions became c.NodeId.Id(). This is a mechanical retype that
-		// produces byte-identical entity ids at runtime, and the saga path does no
-		// node-id construction, so there was nothing to mirror there either.
-		//
-		// Registry authentication is shared by both controllers because the saga
-		// controller delegates image pulls to this inner controller.
-		"sandbox.go":  "82a1667dae3227bc67d533b14487187d8a71968c9678f45373996305e2b49897",
+		"sandbox.go":  "4734a18ab35e3f8b39edcfa0943fec640560a2426ce5682561480c662a075cf0",
 		"volume.go":   "580062fb8a34f3f7f965689467a4b0f2ed403bc63c1ecdeb44949a7ba7e08dff",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -374,6 +374,125 @@ func TestSandbox(t *testing.T) {
 		t.Logf("total CPU seconds recorded: %f", cpuSeconds)
 	})
 
+	// A sandbox that outlives the process which booted it has to get its cgroup
+	// metrics re-registered during boot reconciliation. Logs reattach either
+	// way, so a sandbox that misses this looks perfectly healthy while its CPU
+	// and memory series stop dead at the restart (MIR-1013).
+	t.Run("re-registers metrics for sandboxes that survive a restart", func(t *testing.T) {
+		r := require.New(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		ctx = namespaces.WithNamespace(ctx, ns)
+
+		co, err := newSandboxController(testDeps)
+		r.NoError(err)
+
+		defer co.Close()
+		r.NoError(co.Init(ctx))
+
+		id := entity.Id(sbName())
+
+		var sb compute.Sandbox
+
+		sb.ID = id
+
+		sb.Labels = append(sb.Labels, "runtime.computer/app=mn-sort")
+
+		sb.Spec.Container = append(sb.Spec.Container, compute.SandboxSpecContainer{
+			Name:  "sort",
+			Image: "mn-sort:latest",
+		})
+
+		// Boot reconciliation only considers sandboxes scheduled to this node,
+		// so the entity needs the schedule key the scheduler would have set.
+		schedule := compute.Schedule{
+			Key: compute.Key{
+				Kind: compute.KindSandbox,
+				Node: compute.NewNodeId("test-node").Id(),
+			},
+		}
+
+		var rpcE entityserver_v1alpha.Entity
+		rpcE.SetId(id.String())
+		rpcE.SetAttrs(entity.New(
+			entity.DBId, id,
+			sb.Encode,
+			schedule.Encode).Attrs())
+		_, err = co.EAC.Put(ctx, &rpcE)
+		r.NoError(err)
+
+		result, err := co.EAC.Get(ctx, id.String())
+		r.NoError(err)
+
+		meta := &entity.Meta{
+			Entity:   result.Entity().Entity(),
+			Revision: result.Entity().Revision(),
+		}
+
+		var tco compute.Sandbox
+		tco.Decode(entity.New(
+			entity.DBId, id,
+			sb.Encode))
+
+		err = co.Create(ctx, &tco, meta)
+		r.NoError(err)
+
+		defer func() {
+			r.NoError(co.StopSandbox(context.WithoutCancel(ctx), id))
+		}()
+
+		// Create only updates its in-memory copy of the entity; by the time a
+		// real restart happens the store holds the sandbox as RUNNING.
+		tco.Status = compute.RUNNING
+
+		var runningE entityserver_v1alpha.Entity
+		runningE.SetId(id.String())
+		runningE.SetAttrs(entity.New(
+			entity.DBId, id,
+			tco.Encode,
+			schedule.Encode).Attrs())
+		_, err = co.EAC.Put(ctx, &runningE)
+		r.NoError(err)
+
+		le, _ := sandboxMetricsIdentity(&tco)
+
+		// The process that booted the sandbox is gone, and its cgroup
+		// monitoring went with it. The containers keep running.
+		r.NoError(co.Metrics.Remove(le))
+
+		co2, err := newSandboxController(testDeps)
+		r.NoError(err)
+
+		defer co2.Close()
+
+		r.False(co2.Metrics.Has(le), "a fresh controller starts with nothing registered")
+
+		// Init is what runs boot reconciliation in production.
+		r.NoError(co2.Init(ctx))
+
+		r.True(co2.Metrics.Has(le), "boot reconciliation should re-register metrics")
+
+		// Gather reads the cgroups we registered, so it fails loudly if the
+		// recovered paths are wrong rather than just silently reporting zeros.
+		snapshots, err := co2.Metrics.Gather(le)
+		r.NoError(err)
+		r.Len(snapshots, 2, "expected the pause container and the sort container")
+
+		usage := map[string]int64{}
+		for _, cs := range snapshots {
+			usage[cs.Name()] = cs.Metrics().MemoryUsage()
+		}
+
+		r.Contains(usage, "", "pause container cgroup should be monitored")
+		r.Contains(usage, "sort", "sort container cgroup should be monitored")
+
+		for name, mem := range usage {
+			r.Positive(mem, "container %q should report memory usage", name)
+		}
+	})
+
 	t.Run("configures networking", func(t *testing.T) {
 		r := require.New(t)
 


### PR DESCRIPTION
When miren restarts, `reconcileSandboxesOnBoot` adopts the containers that outlived the process. It reattaches log consumers, re-reserves IPs, and re-registers workload identity tokens. It never re-registered cgroup metrics, so CPU and memory for every recovered sandbox stopped at the restart and never came back. Logs kept flowing the whole time, which is what made this expensive to notice: a recovered sandbox looks completely healthy right up until you go looking for its metrics. Every runner and coordinator restart re-triggered it, so the fleet lost metrics for surviving sandboxes on each upgrade.

There's a second way to lose metrics that the boot path can't cover. Boot reconciliation only considers sandboxes the store already has as RUNNING, so one that was still PENDING at restart gets adopted later, when `CheckSandbox` returns `same`. Registering there is trickier than it looks, because that branch runs on every reconcile tick and `Metrics.Add` replaces the entry wholesale, discarding the previous CPU counters. Re-adding on each tick would reset the delta baseline forever and produce no CPU data at all. Hence `Metrics.Has`, and an `ensureMetrics` that does nothing when the sandbox is already monitored.

The log entity and attribute derivation was already copy-pasted between `createSandbox` and the saga's `addMetrics`. A third copy is exactly the kind of drift that let this hide, so all of it now goes through one `sandboxMetricsIdentity` helper.

On the frozen-hash bump for `sandbox.go`: the boot fix is shared between both controllers, since `SagaSandboxController.Init` delegates to the inner controller's `Init`. The adoption half needed mirroring and got it in `saga_controller.go`'s own `same` branch, and `create_saga.go` picks up the shared identity helper.

The test builds a real sandbox, discards the controller that booted it, and `Init`s a fresh one, which is the shape an actual restart takes. I confirmed it fails against the old code.

Closes MIR-1013
