### PR TITLE
Pin QUIC InitialPacketSize at every client dial site

### DIFF
--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/quic-go/quic-go"
 	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/ui"
 )
 
@@ -307,6 +308,7 @@ func extractTLSCertificate(ctx context.Context, address string) (string, string,
 
 	// Create QUIC config
 	quicConfig := &quic.Config{
+		InitialPacketSize:    rpc.InitialPacketSize,
 		HandshakeIdleTimeout: 5 * time.Second,
 		MaxIdleTimeout:       10 * time.Second,
 	}

--- a/cli/commands/doctor_probe.go
+++ b/cli/commands/doctor_probe.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
+
+	"miren.dev/runtime/pkg/rpc"
 )
 
 // probeOutcome is what a reachability probe learned. The distinction that
@@ -126,6 +128,7 @@ func probeQUIC(addr string) probe {
 		NextProtos: []string{http3.NextProtoH3},
 		MinVersion: tls.VersionTLS13,
 	}, &quic.Config{
+		InitialPacketSize:    rpc.InitialPacketSize,
 		HandshakeIdleTimeout: probeTimeout,
 		MaxIdleTimeout:       probeTimeout,
 	})

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -375,6 +375,7 @@ func probeAddress(ctx context.Context, address string) error {
 	}
 
 	quicConfig := &quic.Config{
+		InitialPacketSize:    rpc.InitialPacketSize,
 		HandshakeIdleTimeout: 2 * time.Second,
 		MaxIdleTimeout:       3 * time.Second,
 	}

--- a/pkg/anywhere/pop.go
+++ b/pkg/anywhere/pop.go
@@ -18,6 +18,7 @@ import (
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/http3"
 
+	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/servers/httpingress"
 )
 
@@ -153,7 +154,9 @@ func (m *POPManager) servePOP(ctx context.Context, pc *popConnection, cr Connect
 		ServerName:         host,
 	}
 
-	controlConn, err := quicTransport.Dial(ctx, udpAddr, controlTLS, &quic.Config{})
+	controlConn, err := quicTransport.Dial(ctx, udpAddr, controlTLS, &quic.Config{
+		InitialPacketSize: rpc.InitialPacketSize,
+	})
 	if err != nil {
 		m.log.Error("failed to dial POP control plane",
 			"pop_xid", pc.popXID, "address", addr, "error", err)
@@ -225,7 +228,8 @@ func (m *POPManager) servePOP(ctx context.Context, pc *popConnection, cr Connect
 	}
 
 	dataConn, err := quicTransport.Dial(ctx, udpAddr, dataTLS, &quic.Config{
-		KeepAlivePeriod: 15 * time.Second,
+		InitialPacketSize: rpc.InitialPacketSize,
+		KeepAlivePeriod:   15 * time.Second,
 	})
 	if err != nil {
 		controlConn.CloseWithError(0, "data plane dial failed")

--- a/pkg/rpc/initial_packet_size_test.go
+++ b/pkg/rpc/initial_packet_size_test.go
@@ -1,0 +1,100 @@
+package rpc
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestQUICConfigsPinInitialPacketSize walks the tree and fails on any
+// quic.Config literal that omits InitialPacketSize.
+//
+// This is guarding a bug we have now shipped twice. Omitting the field costs
+// nothing on a 1500-MTU path and silently breaks every handshake over a
+// 1280-MTU tunnel (Tailscale, WireGuard), because quic-go swallows the
+// resulting EMSGSIZE without shrinking the Initial. The first fix pinned it in
+// DefaultQUICConfig and missed four call sites that build their own config; one
+// of those was `miren cluster add`, which left a user unable to reach a
+// tailnet-only cluster while every server-side diagnostic looked healthy.
+//
+// A grep would do, but nothing runs a grep. If this test becomes an obstacle,
+// deleting it is fine; just make sure the thing it is protecting still holds.
+func TestQUICConfigsPinInitialPacketSize(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var offenders []string
+
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// Vendored and generated trees are not ours to police.
+			switch d.Name() {
+			case ".git", ".jj", "vendor", "node_modules", "testdata":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			// A file we cannot parse is not this test's problem; the build
+			// catches it far more legibly.
+			return nil
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			sel, ok := lit.Type.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Config" {
+				return true
+			}
+			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "quic" {
+				return true
+			}
+
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				if key, ok := kv.Key.(*ast.Ident); ok && key.Name == "InitialPacketSize" {
+					return true
+				}
+			}
+
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				rel = path
+			}
+			offenders = append(offenders, rel+":"+strconv.Itoa(fset.Position(lit.Pos()).Line))
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo: %v", err)
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("quic.Config literals missing InitialPacketSize (set it to rpc.InitialPacketSize):\n  %s\n\n"+
+			"Handshakes over 1280-MTU tunnels (Tailscale, WireGuard) fail silently without it.",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -25,6 +25,20 @@ import (
 	"miren.dev/runtime/pkg/slogfmt"
 )
 
+// InitialPacketSize pins the QUIC Initial at the 1200-byte spec minimum so the
+// handshake fits a 1280-MTU path (Tailscale/WireGuard tunnels, the IPv6
+// minimum). quic-go's default of 1280 yields a 1308-byte IPv4 datagram with DF
+// set, which such tunnels silently drop, hanging the handshake in both
+// directions. PMTUD raises the packet size again after the handshake completes,
+// so 1500-MTU paths are unaffected. See quic-go#5573, quic-go#5634,
+// tailscale#2633.
+//
+// Every quic.Config we hand to a Dial or Listen must set this. quic-go swallows
+// the resulting EMSGSIZE without shrinking the Initial (see sendQueue.Run), so
+// forgetting it costs a silent timeout on tunnelled paths and nothing at all on
+// ordinary ones.
+const InitialPacketSize = 1200
+
 var (
 	DefaultQUICConfig quic.Config
 
@@ -33,14 +47,7 @@ var (
 
 func init() {
 	DefaultQUICConfig = quic.Config{
-		// Pin the QUIC Initial at the 1200-byte spec minimum so the handshake
-		// fits a 1280-MTU path (Tailscale/WireGuard tunnels, the IPv6 minimum).
-		// quic-go's default of 1280 yields a 1308-byte IPv4 datagram with DF
-		// set, which such tunnels silently drop, hanging the handshake in both
-		// directions. PMTUD raises the packet size again after the handshake
-		// completes, so 1500-MTU paths are unaffected. See quic-go#5573,
-		// quic-go#5634, tailscale#2633.
-		InitialPacketSize:              1200,
+		InitialPacketSize:              InitialPacketSize,
 		EnableDatagrams:                true,
 		MaxIncomingStreams:             1000,
 		MaxIncomingUniStreams:          1000,


### PR DESCRIPTION
A user reported they couldn't reach a Miren node on a Tailscale-only VPS. `miren cluster add` timed out on every address, including the manual `--address` form that bypasses Cloud entirely. The server was healthy the whole time: dual-stack wildcard bind on UDP 8443, Cloud check-ins landing fine.

The problem was client-side. We pinned QUIC's Initial packet at the 1200-byte spec minimum in `DefaultQUICConfig` back in June so handshakes would survive 1280-MTU tunnels, but that only covered `pkg/rpc`. Four call sites build their own `quic.Config` and never got it: `cluster add`'s cert extraction, the clientconfig connectivity probe, doctor's reachability probe, and both anywhere POP dials.

Without the pin, quic-go uses a 1280-byte Initial, which is 1308 bytes on the wire over IPv4 or 1328 over IPv6, both with DF set. `tailscale0` is a 1280-MTU interface, so `sendto` returns `EMSGSIZE` and `sendQueue.Run` swallows it without shrinking the Initial. The client never emits a handshake packet at all, so what you see is `timeout: no recent network activity` and nothing whatsoever on the wire, indistinguishable from a firewall or an ACL. Confirmed against a healthy production cluster: dialing it over the tailnet fails, while that same cluster over a LAN address has always been fine.

Exported the constant as `rpc.InitialPacketSize` and added a test that fails on any `quic.Config` literal missing it. Omitting the field costs nothing on an ordinary network and breaks every handshake on a tunnelled one, which is exactly the kind of convention that rots silently, and we've now shipped that bug twice.

Worth flagging that this is verified by construction rather than end to end. Build and lint are clean and the guard test does bite when the pin is removed, but a patched binary hasn't crossed a real 1280-MTU path yet.

Only clients are affected. Servers are fine.

Closes MIR-1510
