### PR TITLE
Make tailnet-only clusters reachable

### DIFF
--- a/cli/commands/debug_advertise.go
+++ b/cli/commands/debug_advertise.go
@@ -74,7 +74,7 @@ func DebugAdvertise(ctx *Context, opts struct {
 			continue
 		}
 		humanInfo("  %-15s %-40s (discovered)", a.Interface, a.IP)
-		ipSet.AddDiscovered(ip)
+		ipSet.AddDiscoveredFrom(ip, a.Interface)
 	}
 
 	for _, s := range opts.AdditionalIPs {
@@ -119,6 +119,7 @@ func DebugAdvertise(ctx *Context, opts struct {
 			Source         string `json:"source"`
 			HostPort       string `json:"host_port"`
 			IP             string `json:"ip,omitempty"`
+			Interface      string `json:"interface,omitempty"`
 			Classification string `json:"classification,omitempty"`
 			Included       bool   `json:"included"`
 			Reason         string `json:"reason"`
@@ -135,6 +136,7 @@ func DebugAdvertise(ctx *Context, opts struct {
 			out.Candidates[i] = candidateJSON{
 				Source:         c.Source,
 				HostPort:       c.HostPort,
+				Interface:      c.Interface,
 				Classification: c.Classification,
 				Included:       c.Included,
 				Reason:         c.Reason,
@@ -148,15 +150,19 @@ func DebugAdvertise(ctx *Context, opts struct {
 
 	ctx.Info("Step 3: per-candidate classification and inclusion decision")
 	ctx.Info("")
-	ctx.Info("  %-12s %-40s %-16s %-10s %s", "SOURCE", "IP:PORT", "CLASS", "DECISION", "REASON")
-	ctx.Info("  %s", "-------------------------------------------------------------------------------------------------------------")
+	ctx.Info("  %-12s %-40s %-12s %-16s %-10s %s", "SOURCE", "IP:PORT", "IFACE", "CLASS", "DECISION", "REASON")
+	ctx.Info("  %s", "-------------------------------------------------------------------------------------------------------------------------")
 	for _, c := range candidates {
 		decision := "SKIPPED"
 		if c.Included {
 			decision = "ADVERTISED"
 		}
-		ctx.Info("  %-12s %-40s %-16s %-10s %s",
-			c.Source, c.HostPort, c.Classification, decision, c.Reason)
+		iface := c.Interface
+		if iface == "" {
+			iface = "-"
+		}
+		ctx.Info("  %-12s %-40s %-12s %-16s %-10s %s",
+			c.Source, c.HostPort, iface, c.Classification, decision, c.Reason)
 	}
 
 	ctx.Info("")

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -146,7 +146,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		for _, addr := range discovery.Addresses {
 			ip := net.ParseIP(addr.IP)
 			if ip != nil && !ip.IsLinkLocalUnicast() {
-				ipSet.AddDiscovered(ip)
+				ipSet.AddDiscoveredFrom(ip, addr.Interface)
 			}
 		}
 		ctx.Log.Info("discovered IPs", "addresses", len(discovery.Addresses))

--- a/components/coordinate/advertise.go
+++ b/components/coordinate/advertise.go
@@ -1,8 +1,10 @@
 package coordinate
 
 import (
+	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"miren.dev/runtime/pkg/cloudauth"
 )
@@ -10,10 +12,16 @@ import (
 // SourcedIP is an IP address tagged with how it was obtained. Explicit IPs
 // (user-configured via AdditionalIPs or the server config) always pass
 // through to the advertised list. Discovered IPs (auto-scanned from local
-// interfaces) are subject to netcheck pruning, CGNAT filtering, etc.
+// interfaces) are subject to netcheck pruning, bridge filtering, etc.
 type SourcedIP struct {
 	IP       net.IP
 	Explicit bool // true = user-configured, false = auto-discovered
+
+	// Interface is the name of the link the IP was discovered on, when
+	// known. Empty for explicit IPs and for callers that don't track it.
+	// Used to tell a host's real NICs apart from the container bridges
+	// Miren and Docker create, which are never reachable from a client.
+	Interface string
 }
 
 // IPSet is an ordered, de-duplicated collection of SourcedIP entries.
@@ -43,6 +51,12 @@ func (s *IPSet) Add(sip SourcedIP) {
 		if sip.Explicit && !s.entries[i].Explicit {
 			s.entries[i].Explicit = true
 		}
+		// Keep whichever entry actually knows the interface: an explicit
+		// IP that duplicates a discovered one carries no interface of its
+		// own, and losing the name would hide it from bridge filtering.
+		if s.entries[i].Interface == "" && sip.Interface != "" {
+			s.entries[i].Interface = sip.Interface
+		}
 		return
 	}
 	s.index[key] = len(s.entries)
@@ -52,6 +66,12 @@ func (s *IPSet) Add(sip SourcedIP) {
 // AddDiscovered is a convenience for Add(SourcedIP{IP: ip, Explicit: false}).
 func (s *IPSet) AddDiscovered(ip net.IP) {
 	s.Add(SourcedIP{IP: ip, Explicit: false})
+}
+
+// AddDiscoveredFrom records a discovered IP along with the interface it was
+// found on, so bridge filtering can tell a real NIC from a container bridge.
+func (s *IPSet) AddDiscoveredFrom(ip net.IP, iface string) {
+	s.Add(SourcedIP{IP: ip, Explicit: false, Interface: iface})
 }
 
 // AddExplicit is a convenience for Add(SourcedIP{IP: ip, Explicit: true}).
@@ -103,7 +123,8 @@ type AdvertiseInput struct {
 	// IPs is the unified list of all candidate IP addresses, each
 	// tagged as explicit (user-configured) or discovered (interface scan).
 	// Explicit IPs bypass all filtering except loopback / unspecified.
-	// Discovered IPs are subject to CGNAT, netcheck, and other pruning.
+	// Discovered IPs are subject to container-bridge filtering, netcheck,
+	// and other pruning.
 	IPs []SourcedIP
 
 	// Netcheck is the result of the dual-stack netcheck, if one has run.
@@ -122,7 +143,8 @@ type AdvertiseCandidate struct {
 	Source         string // "listen", "explicit", "discovered", "netcheck"
 	HostPort       string
 	IP             net.IP
-	Classification string // loopback / link-local / private / global-unicast / other
+	Interface      string // discovering interface, when known
+	Classification string // tailnet / container-bridge / loopback / link-local / private / global-unicast / other
 	Included       bool
 	Reason         string
 }
@@ -149,11 +171,15 @@ type AdvertiseCandidate struct {
 //
 //  3. Discovered IPs (auto-scanned from interfaces):
 //     a. Loopback and unspecified are dropped.
-//     b. CGNAT addresses (100.64.0.0/10) are dropped.
-//     c. Public (global-unicast, non-private) IPs are dropped if netcheck
-//     ran for that address family and proved the family unreachable
-//     or found reachable addresses (replaced by netcheck-confirmed ones).
-//     d. Otherwise kept as a fallback.
+//     b. Addresses on a container bridge (docker0, flannel.1, rt0, …) are
+//     dropped — they exist only for workloads on this host.
+//     c. Addresses the internet can't route to (LAN, CGNAT, ULA, and so any
+//     overlay network) are kept, since they may be how this client
+//     reaches us.
+//     d. Internet-routable IPs are dropped if netcheck ran for that address
+//     family and proved the family unreachable or found reachable
+//     addresses (replaced by netcheck-confirmed ones).
+//     e. Otherwise kept as a fallback.
 //
 //  4. Netcheck public addresses: included when reachable on at least one port.
 func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
@@ -242,7 +268,8 @@ func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
 			Source:         source,
 			HostPort:       hp,
 			IP:             ip,
-			Classification: classify(ip),
+			Interface:      sip.Interface,
+			Classification: classifyOn(ip, sip.Interface),
 		}
 
 		// Loopback / unspecified always rejected regardless of source.
@@ -269,17 +296,29 @@ func ComputeAdvertise(in AdvertiseInput) ([]AdvertiseCandidate, []string) {
 
 		// --- Discovered IP filtering below ---
 
-		if isCGNAT(ip) {
+		// Container bridges (Miren's own rt0/flannel, plus docker0 and
+		// friends) carry addresses that only ever route to workloads on
+		// this host, so advertising them just buys clients a timeout.
+		if isContainerBridge(sip.Interface) {
 			cand.Included = false
-			cand.Reason = "CGNAT 100.64.0.0/10 (e.g. tailscale)"
+			cand.Reason = fmt.Sprintf("container bridge %q is local to this host", sip.Interface)
 			add(cand)
 			continue
 		}
 
-		isPublicCandidate := !ip.IsLoopback() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast()
-		if !isPublicCandidate {
+		// Anything the internet can't route to is kept as a candidate. It
+		// may be exactly how this client reaches us — over the LAN, or
+		// over an overlay like Tailscale — and the client probes every
+		// advertised address in parallel and takes the first that answers,
+		// so a candidate it can't use costs it nothing.
+		//
+		// This is the one rule, applied to both families. Singling out
+		// IPv4 CGNAT while the matching IPv6 ULA sailed through as
+		// "private" is what left tailnet-only clusters advertising the
+		// half that rarely works and dropping the half that does.
+		if !isPubliclyRoutable(ip) {
 			cand.Included = true
-			cand.Reason = "private/link-local, kept for LAN clients"
+			cand.Reason = "not internet-routable, kept for LAN and overlay clients"
 			add(cand)
 			continue
 		}
@@ -400,15 +439,89 @@ func publicAddressesFromNetcheck(result *cloudauth.NetcheckDualStackResult) []st
 }
 
 // isCGNAT reports whether ip falls in the 100.64.0.0/10 Carrier-Grade NAT
-// range (RFC 6598). Tailscale tailnet addresses also live in this range,
-// so filtering CGNAT out of discovered-IP lists keeps them from being
-// advertised to clients who aren't on the tailnet.
+// range (RFC 6598).
 func isCGNAT(ip net.IP) bool {
 	ip4 := ip.To4()
 	if ip4 == nil {
 		return false
 	}
 	return ip4[0] == 100 && ip4[1]&0xc0 == 0x40
+}
+
+// isPubliclyRoutable reports whether the public internet can reach ip. It is
+// the runtime-side twin of the cloud's netaddr.IsPubliclyRoutable, and the
+// only classification the advertise rules need: overlay networks have to live
+// in non-routable space to be overlays, so Tailscale, iroh, Nebula and the
+// rest are all covered without naming any of them.
+func isPubliclyRoutable(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() || ip.IsMulticast() ||
+		ip.IsPrivate() {
+		return false
+	}
+	return !isCGNAT(ip)
+}
+
+// looksLikeTailnet is a display-only hint for `miren debug advertise`, so an
+// operator reading the table sees why two addresses on different families got
+// the same treatment. It never gates a decision, so a guess that ages badly
+// costs nothing but a label. fd7a:115c:a1e0::/48 is Tailscale's ULA prefix.
+func looksLikeTailnet(ip net.IP, iface string) bool {
+	if strings.HasPrefix(iface, "tailscale") {
+		return true
+	}
+	if isCGNAT(ip) {
+		return true
+	}
+	b := ip.To16()
+	return ip.To4() == nil && b != nil &&
+		b[0] == 0xfd && b[1] == 0x7a && b[2] == 0x11 &&
+		b[3] == 0x5c && b[4] == 0xa1 && b[5] == 0xe0
+}
+
+// containerBridgeNames are interfaces whose addresses serve workloads on this
+// host and nothing else. rt0 and flannel.* are Miren's own; the rest come
+// from other container runtimes that may share the box.
+var containerBridgeNames = []string{
+	"rt0",      // Miren sandbox bridge
+	"flannel.", // flannel VXLAN (flannel.1)
+	"flannel-", // flannel wireguard backend
+	"cni",      // cni0, cni-podman0
+	"cbr0",
+	"docker",  // docker0, docker1
+	"br-",     // docker user-defined bridges
+	"virbr",   // libvirt
+	"podman",  // podman0
+	"kube-br", // kubelet bridge
+}
+
+// isContainerBridge reports whether an interface name is a container bridge.
+// An unknown (empty) name is never treated as one — better to advertise a
+// useless address than to silently drop the only address that works.
+func isContainerBridge(iface string) bool {
+	if iface == "" {
+		return false
+	}
+	for _, prefix := range containerBridgeNames {
+		if strings.HasPrefix(iface, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyOn is classify with the discovering interface in hand, which lets
+// it name the two cases the plain address can't reveal: an overlay address
+// (indistinguishable from CGNAT or a ULA) and a container bridge.
+func classifyOn(ip net.IP, iface string) string {
+	if looksLikeTailnet(ip, iface) {
+		return "tailnet"
+	}
+	if isContainerBridge(iface) {
+		return "container-bridge"
+	}
+	return classify(ip)
 }
 
 // classify returns a short string describing the kind of address, for

--- a/components/coordinate/advertise_test.go
+++ b/components/coordinate/advertise_test.go
@@ -1,0 +1,86 @@
+package coordinate
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPubliclyRoutable(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{"203.0.113.10", true},
+		{"2001:db8::10", true},
+
+		// CGNAT (RFC 6598) is global-unicast and not private as far as Go
+		// is concerned, so it needs naming explicitly. The /10 boundaries
+		// are worth pinning: the mask is easy to write as a /8 by mistake.
+		{"100.64.0.0", false},
+		{"100.107.209.9", false},
+		{"100.127.255.255", false},
+		{"100.63.255.255", true},
+		{"100.128.0.0", true},
+
+		{"fd7a:115c:a1e0::2801:9641", false}, // tailscale ULA
+		{"fd00::1", false},                   // any other ULA
+		{"10.0.0.5", false},
+		{"172.17.0.1", false},
+		{"192.168.1.1", false},
+		{"127.0.0.1", false},
+		{"::1", false},
+		{"0.0.0.0", false},
+		{"169.254.1.1", false},
+		{"fe80::1", false},
+		{"224.0.0.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPubliclyRoutable(net.ParseIP(tt.addr)))
+		})
+	}
+}
+
+func TestIsContainerBridge(t *testing.T) {
+	for _, iface := range []string{
+		"rt0", "flannel.1", "flannel-wg", "docker0", "docker1",
+		"br-9f2a1c", "cni0", "cni-podman0", "cbr0", "virbr0", "podman0",
+	} {
+		assert.True(t, isContainerBridge(iface), "expected %q to be a container bridge", iface)
+	}
+
+	for _, iface := range []string{"eth0", "eno1", "wlan0", "tailscale0", "ens18", "lo"} {
+		assert.False(t, isContainerBridge(iface), "expected %q not to be a container bridge", iface)
+	}
+
+	// An unknown interface must never be filtered: dropping the only
+	// address that works is far worse than advertising a dead one.
+	assert.False(t, isContainerBridge(""))
+}
+
+func TestIPSetKeepsInterfaceOnPromotion(t *testing.T) {
+	// An explicit IP carries no interface of its own. When it duplicates a
+	// discovered entry the name has to survive, or bridge filtering would
+	// stop being able to see it.
+	s := NewIPSet()
+	s.AddDiscoveredFrom(net.ParseIP("10.8.45.1"), "rt0")
+	s.AddExplicit(net.ParseIP("10.8.45.1"))
+
+	entries := s.All()
+	assert.Len(t, entries, 1)
+	assert.True(t, entries[0].Explicit)
+	assert.Equal(t, "rt0", entries[0].Interface)
+}
+
+func TestClassifyOnNamesOverlayAndBridge(t *testing.T) {
+	// Display-only labels, but they're what an operator reads out of
+	// `miren debug advertise` when two addresses got the same treatment.
+	assert.Equal(t, "tailnet", classifyOn(net.ParseIP("100.107.209.9"), "tailscale0"))
+	assert.Equal(t, "tailnet", classifyOn(net.ParseIP("fd7a:115c:a1e0::1"), ""))
+	assert.Equal(t, "container-bridge", classifyOn(net.ParseIP("172.17.0.1"), "docker0"))
+	assert.Equal(t, "private", classifyOn(net.ParseIP("10.50.1.170"), "eth0"))
+	assert.Equal(t, "global-unicast", classifyOn(net.ParseIP("203.0.113.10"), "eth0"))
+}

--- a/components/coordinate/api_addresses_test.go
+++ b/components/coordinate/api_addresses_test.go
@@ -12,6 +12,12 @@ import (
 func explicit(ip string) SourcedIP   { return SourcedIP{IP: net.ParseIP(ip), Explicit: true} }
 func discovered(ip string) SourcedIP { return SourcedIP{IP: net.ParseIP(ip), Explicit: false} }
 
+// onIface is discovered() with the interface the address was found on, which
+// is what bridge filtering keys off.
+func onIface(ip, iface string) SourcedIP {
+	return SourcedIP{IP: net.ParseIP(ip), Interface: iface}
+}
+
 func makeIPSet(entries ...SourcedIP) *IPSet {
 	s := NewIPSet()
 	for _, e := range entries {
@@ -81,16 +87,74 @@ func TestApiAddresses(t *testing.T) {
 			wantContains:   []string{"203.0.113.10:8443", "10.0.0.5:8443"},
 		},
 		{
-			name:         "CGNAT discovered IP is filtered",
+			// MIR-1509: CGNAT used to be dropped here, which left a
+			// tailnet-only cluster with nothing usable to advertise. The
+			// internet can't route to it, so it's kept for clients that
+			// share the overlay.
+			name:         "CGNAT discovered IP is kept for overlay clients",
 			ips:          makeIPSet(discovered("100.107.209.9"), discovered("10.0.0.5")),
-			wantContains: []string{"10.0.0.5:8443"},
-			wantExcludes: []string{"100.107.209.9:8443"},
+			wantContains: []string{"100.107.209.9:8443", "10.0.0.5:8443"},
+		},
+		{
+			// The IPv6 half of a tailnet has to get the same answer as the
+			// IPv4 half; disagreeing is what made this fail in the field.
+			name:         "tailscale ULA and CGNAT are treated alike",
+			ips:          makeIPSet(discovered("100.107.209.9"), discovered("fd7a:115c:a1e0::2801:9641")),
+			wantContains: []string{"100.107.209.9:8443", "[fd7a:115c:a1e0::2801:9641]:8443"},
+		},
+		{
+			// A negative netcheck says nothing about overlay reachability,
+			// so it must not prune the tailnet address with the public one.
+			name: "netcheck failure does not drop CGNAT",
+			ips:  makeIPSet(discovered("203.0.113.10"), discovered("100.107.209.9")),
+			netcheckResult: &cloudauth.NetcheckDualStackResult{
+				IPv4: &cloudauth.NetcheckResponse{
+					SourceAddress: "203.0.113.10",
+					Results: []cloudauth.NetcheckResult{
+						{Port: 8443, Protocol: "tcp", Reachable: false},
+					},
+				},
+			},
+			wantContains: []string{"100.107.209.9:8443"},
+			wantExcludes: []string{"203.0.113.10:8443"},
 		},
 		{
 			// Explicit CGNAT is kept — the user asked for it.
 			name:         "CGNAT explicit IP is kept",
 			ips:          makeIPSet(explicit("100.107.209.9")),
 			wantContains: []string{"100.107.209.9:8443"},
+		},
+		{
+			// Container bridges only ever route to workloads on this host,
+			// so they're noise in every cluster's advertised list.
+			name: "container bridge addresses are dropped",
+			ips: makeIPSet(
+				onIface("172.17.0.1", "docker0"),
+				onIface("10.8.45.1", "rt0"),
+				onIface("10.8.45.0", "flannel.1"),
+				onIface("10.50.1.170", "eth0"),
+			),
+			wantContains: []string{"10.50.1.170:8443"},
+			wantExcludes: []string{"172.17.0.1:8443", "10.8.45.1:8443", "10.8.45.0:8443"},
+		},
+		{
+			// An explicit IP is user intent and outranks bridge filtering.
+			name:         "explicit IP on a bridge interface is still kept",
+			ips:          makeIPSet(SourcedIP{IP: net.ParseIP("172.17.0.1"), Explicit: true, Interface: "docker0"}),
+			wantContains: []string{"172.17.0.1:8443"},
+		},
+		{
+			// Ani's cluster: the only reachable address is the tailnet one,
+			// and everything else on the box is a bridge or unroutable.
+			name: "tailnet-only host advertises its tailnet addresses",
+			ips: makeIPSet(
+				onIface("100.107.209.9", "tailscale0"),
+				onIface("fd7a:115c:a1e0::2801:9641", "tailscale0"),
+				onIface("172.17.0.1", "docker0"),
+				onIface("172.18.0.1", "br-9f2a"),
+			),
+			wantContains: []string{"100.107.209.9:8443", "[fd7a:115c:a1e0::2801:9641]:8443"},
+			wantExcludes: []string{"172.17.0.1:8443", "172.18.0.1:8443"},
 		},
 		{
 			name: "netcheck ran and found reachable addresses",

--- a/docs/docs/miren-cloud/connectivity.md
+++ b/docs/docs/miren-cloud/connectivity.md
@@ -49,7 +49,7 @@ sudo miren server restart
 If your cluster's public address isn't the one Miren discovered — for example it sits behind a load balancer or a static NAT — set the reachable address explicitly with `additional_ips` in your [server configuration](/server-config) instead of relying on discovery.
 
 :::tip[Reachable, but no public address]
-A cluster on a private network (home lab, VPC with no public IP) will read "Not reachable" here and that's expected — you deploy to it from the same LAN. Miren Anywhere carries app traffic, not the control plane, and so **won't** change this check.
+A cluster on a private network (home lab, VPC with no public IP, or a host that only answers on a tailnet) will read "Not reachable" here and that's expected — you deploy to it from the same LAN or overlay. Miren Anywhere carries app traffic, not the control plane, and so **won't** change this check. For the tailnet case end to end, see [Running Miren on a Tailnet](/tailscale).
 :::
 
 ## Can users reach your apps?
@@ -71,7 +71,9 @@ Three outcomes are possible:
 
 - **Reachable** — Cloud connected to at least one advertised port. The address is confirmed and handed to clients.
 - **Not reachable, address known** — Cloud saw a public address but couldn't connect to any port. Something in the inbound path (a firewall, a cloud security group, or a NAT) is dropping the traffic, and this is the verdict that names the specific port.
-- **No public address** — Cloud only ever saw a private or carrier-NAT source, so there's nothing to hand out. Common for home labs and locked-down VPCs; expected, not an error.
+- **No public address** — Cloud only ever saw a private or carrier-NAT source, so there's nothing to hand out. Common for home labs, locked-down VPCs, and tailnet-only hosts; expected, not an error.
+
+To see which addresses your cluster settled on and why each one was kept or dropped, run `miren debug advertise` on the host. It reproduces the server's own logic and prints a reason per candidate, which is usually faster than inferring the answer from the dashboard.
 
 :::note[The panel reflects the last check]
 Reachability is re-checked periodically (roughly hourly) and at startup, not on every status report — so after you open a port the panel can lag even though the cluster is already reachable. Restart the server to force a fresh check, or wait for the next one.

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -110,10 +110,12 @@ The `behind-proxy-*` modes default to localhost to keep accidental misconfigurat
 
 Settings under `[tls]` cover two kinds of certs. `acme_email`, `acme_dns_provider`, and `self_signed` configure the ingress cert and only apply when Miren terminates TLS (`tls-autoprovision` or `behind-proxy-https`); they're rejected at startup under `behind-proxy-http`. `additional_names` and `additional_ips` are different: they extend the SANs on the API server and etcd certs, which exist regardless of ingress mode, so they're valid under any mode. See [TLS](/tls) for setup guides.
 
+`additional_ips` does more than its name suggests. Alongside adding SANs, every address listed there is passed straight through to the addresses the server advertises to Miren Cloud, skipping the filtering that discovered addresses go through. That makes it the way to pin an address discovery gets wrong — a host behind a static NAT, or one where you want a specific interface used. See [Running Miren on a Tailnet](/tailscale) for a worked example, and run `miren debug advertise` on the host to see what discovery decided and why.
+
 | Field | Type | Default | Description | Env Var | CLI Flag |
 |-------|------|---------|-------------|---------|----------|
 | `additional_names` | string[] | `[]` | Extra DNS names for the server certificate | `MIREN_TLS_ADDITIONAL_NAMES` | `--dns-names` |
-| `additional_ips` | string[] | `[]` | Extra IPs for the server certificate | `MIREN_TLS_ADDITIONAL_IPS` | `--ips` |
+| `additional_ips` | string[] | `[]` | Extra IPs for the server certificate, and forced into the advertised address list | `MIREN_TLS_ADDITIONAL_IPS` | `--ips` |
 | `acme_dns_provider` | string | — | DNS provider for ACME DNS-01 challenges (e.g. `cloudflare`, `route53`). Required under `behind-proxy-https` if not using `self_signed`. | `MIREN_TLS_ACME_DNS_PROVIDER` | `--acme-dns-provider` |
 | `acme_email` | string | — | Email for ACME account registration | `MIREN_TLS_ACME_EMAIL` | `--acme-email` |
 | `self_signed` | bool | `false` | Use self-signed certificates (development only, or behind a TLS-terminating proxy that doesn't verify) | `MIREN_TLS_SELF_SIGNED` | `--self-signed-tls` |

--- a/docs/docs/tailscale.md
+++ b/docs/docs/tailscale.md
@@ -1,0 +1,126 @@
+---
+title: Running Miren on a Tailnet
+description: How to run a Miren cluster on a host with no public address, using Tailscale or another overlay network.
+keywords: [tailscale, tailnet, vpn, wireguard, private network, overlay, headscale, dns-01, private cluster]
+---
+
+# Running Miren on a Tailnet
+
+Your cluster doesn't need a public IP. A box on your home network, a VPS with
+every inbound port closed, or a machine that only answers on
+[Tailscale](https://tailscale.com/) all make perfectly good clusters. Most of
+it just works, but two things change when nothing on the internet can reach
+you: how your apps get certificates, and how visitors reach them.
+
+This page covers both, plus what to expect from the dashboard.
+
+:::info[Applies to any overlay]
+Tailscale is the common case, but nothing here is specific to it. Headscale,
+Nebula, ZeroTier, and plain WireGuard all behave the same way.
+:::
+
+## Setting up
+
+Install Miren and register the cluster the way you normally would. There's no
+special configuration for this part.
+
+At startup your server looks at its network interfaces and reports the
+addresses a client might reach it on, tailnet addresses included. When you run
+`miren cluster add` from another machine on the tailnet, the CLI tries every
+address it got back, in parallel, and keeps whichever answers first. Your
+tailnet address is in there, so it connects.
+
+Certificates for the API are handled for you. Miren signs them with the
+cluster's own CA and includes every address it found, so connecting over the
+tailnet verifies without any extra setup.
+
+## Certificates for your apps
+
+This is the part that needs a decision from you.
+
+Miren gets certificates for your apps from Let's Encrypt, and the default
+challenge type asks Let's Encrypt to connect to your host on port 80. On a
+tailnet-only box that connection can't happen, so the certificate never
+arrives.
+
+Use a DNS-01 challenge instead. It proves you own the domain by writing a DNS
+record, so nothing ever needs to reach your host:
+
+```toml
+[tls]
+acme_email = 'you@example.com'
+acme_dns_provider = 'dnsimple'
+```
+
+Put your provider's API credentials in the server environment file at
+`/var/lib/miren/server/env`, then restart. [TLS](/tls) has the full list of
+supported providers and the variables each one expects.
+
+:::warning[HTTP-01 can't work here]
+This isn't a preference, it's the only option. An HTTP-01 challenge needs Let's
+Encrypt to reach port 80 on your host from the public internet, so on a
+tailnet-only cluster it fails every time with a validation timeout.
+:::
+
+## Getting traffic to your apps
+
+Who needs to reach your apps decides this one.
+
+**Just you and your tailnet?** Point DNS at your tailnet address. A `100.x`
+address in public DNS is fine and fairly common: it resolves for everyone but
+only routes for people on your tailnet. Tailscale's
+[MagicDNS](https://tailscale.com/kb/1081/magicdns/) works too if you'd rather
+not publish anything at all.
+
+**The whole internet?** Use [Miren Anywhere](/miren-cloud/miren-anywhere). It
+carries app traffic through the Miren POP network and reaches your cluster over
+the connection your cluster already makes outbound, so you don't need a public
+address or any open ports. On a cluster with no public address, it turns on by
+default.
+
+:::note[Deploys still go direct]
+Miren Anywhere carries app traffic only. Deploys, logs, and everything else the
+CLI does talk straight to your cluster on UDP 8443, so you deploy from a machine
+on the tailnet.
+:::
+
+## What the dashboard shows
+
+A tailnet-only cluster reads **Online**, with the control plane **not
+reachable** and apps reachable through Miren Anywhere. Only the middle one looks
+alarming, and it isn't: it means Miren Cloud can't open a connection from the
+public internet, which is exactly what you set up. See
+[Cluster Connectivity](/miren-cloud/connectivity) for what each of the three
+checks actually measures.
+
+## Troubleshooting
+
+**Start with `miren debug advertise`.** Run it on the host and it prints every
+address your server found, along with why it kept or dropped each one. That's
+usually faster than guessing:
+
+```bash
+sudo miren debug advertise
+```
+
+Addresses on container bridges like `docker0` and Miren's own `rt0` get dropped
+on purpose, since they only ever route to workloads on the same host.
+
+**Pin an address by hand** when discovery gets it wrong, like a host behind a
+static NAT. Anything in `additional_ips` skips discovery entirely and is always
+advertised:
+
+```toml
+[tls]
+additional_ips = ["100.91.121.48"]
+```
+
+Advertisement is worked out at startup, so restart the server after changing
+it.
+
+**If connections time out,** first make sure you're on a current release.
+Miren v0.12.1 and earlier couldn't complete a QUIC handshake through a tunnel
+at all, which made tailnets unusable. After that, check the server is actually
+listening with `sudo ss -lunp | grep 8443`, and remember that Tailscale ACLs
+are enforced by `tailscaled` itself, so a permissive host firewall won't help
+if an ACL is blocking the port.

--- a/docs/docs/tls.md
+++ b/docs/docs/tls.md
@@ -140,7 +140,14 @@ Two additional `[tls]` settings apply to the API server and etcd certs rather th
 | Setting | CLI Flag | Description |
 |---------|----------|-------------|
 | `additional_names` | `--dns-names` | Extra DNS names appended to the API server and etcd cert SANs |
-| `additional_ips` | `--ips` | Extra IPs appended to the API server and etcd cert SANs |
+| `additional_ips` | `--ips` | Extra IPs appended to the API server and etcd cert SANs, and forced into the advertised address list |
+
+:::tip[`additional_ips` also controls advertisement]
+Addresses in `additional_ips` bypass the filtering applied to auto-discovered
+addresses and are always advertised to Miren Cloud, which makes this the lever
+for a cluster behind a static NAT or on a private network. See
+[Running Miren on a Tailnet](/tailscale).
+:::
 
 ## Troubleshooting
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -47,6 +47,7 @@ const sidebars: SidebarsConfig = {
         'traffic-routing',
         'tls',
         'firewall',
+        'tailscale',
         'waf',
         'route-protect',
         'workload-identity',


### PR DESCRIPTION
Running Miren on a box reachable only over Tailscale didn't really work, and two separate bugs were hiding each other. This fixes the discovery half.

We filtered CGNAT out of advertised addresses deliberately, back when the concern was leaking tailnet addresses to clients who aren't on the tailnet. But Tailscale's IPv6 ULA reads as `IsPrivate()` and went through untouched, so the net effect was advertising the address family that often doesn't work while dropping the one that usually does. Meanwhile `docker0` and our own `rt0` and `flannel.1` were being advertised to everyone, despite only ever routing to workloads on the same host. One cluster I checked advertised five addresses, not one of which a remote client could use.

The original rationale doesn't hold up either. Clients probe every advertised address in parallel and cancel the rest on first success, so a candidate you can't route to costs a goroutine and nothing else. And "don't advertise things that might not work" wasn't a principle we were actually upholding while shipping container bridge addresses to the world.

So the rule is now uniform: keep anything the internet can't route to, drop container bridges, and let netcheck prune the genuinely public ones as before. That's deliberately RFC-based rather than Tailscale-aware, since an overlay network has to live in non-routable space to be an overlay. iroh and Nebula get the same treatment for free. The one place a vendor name survives is the `tailnet` label in `miren debug advertise`, which is display-only and gates nothing.

On the box that reproduced this, the advertised list went from five addresses a remote client couldn't use to four that it can, including the tailnet IPv4 address that was the whole point.

The second rev adds a guide for running on a tailnet, covering setup, the DNS-01 requirement for app certificates, and how app traffic gets to you. It also documents `additional_ips` as an advertisement control, which it has always been, even though both config pages described it purely as a certificate setting.

Needs the cloud side merged first (mirendev/cloud#191). Without it, cloud treats a tailnet address as public and would publish these as A records.

Closes MIR-1509
