### PR TITLE
Release sandbox token state at teardown, not entity delete

### DIFF
--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -373,6 +373,11 @@ func undoBootContainers(ctx context.Context, in bootContainersIn, _ bootContaine
 	}
 	log.Debug("saga undo: destroyed subcontainers", "sandbox", in.SandboxID)
 
+	// Booting the subcontainers is what registers the sandbox for token refresh
+	// (see buildSubContainerSpec), so undoing it has to release that state. A
+	// failed saga marks the sandbox DEAD without ever reaching StopSandbox.
+	deps.runtime.ReleaseTokenState(entity.Id(in.SandboxID))
+
 	if err := deps.runtime.ReleaseDiskLeases(ctx, entity.Id(in.SandboxID)); err != nil {
 		return fmt.Errorf("saga undo: releasing disk leases for %s: %w", in.SandboxID, err)
 	}

--- a/controllers/sandbox/create_saga_test.go
+++ b/controllers/sandbox/create_saga_test.go
@@ -138,6 +138,7 @@ type mockContainerRuntime struct {
 	bootContainersCalls      int
 	destroySubCtrsCalls      int
 	releaseDiskLeasesCalls   int
+	releaseTokenStateCalls   int
 	unconfigureFirewallCalls int
 	waitForPortCalls         int
 	lastWaitForPortTimeout   time.Duration
@@ -246,6 +247,12 @@ func (m *mockContainerRuntime) ReleaseDiskLeases(ctx context.Context, sandboxID 
 	defer m.mu.Unlock()
 	m.releaseDiskLeasesCalls++
 	return m.releaseDiskLeasesErr
+}
+
+func (m *mockContainerRuntime) ReleaseTokenState(id entity.Id) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releaseTokenStateCalls++
 }
 
 func (m *mockContainerRuntime) UnconfigureFirewall(sb *compute.Sandbox) {
@@ -662,6 +669,8 @@ func TestCreateSandboxSaga_WaitPortsFails(t *testing.T) {
 	assert.Equal(t, 1, h.obs.removeMetricsCalls)
 	assert.Equal(t, 1, h.runtime.destroySubCtrsCalls)
 	assert.Equal(t, 1, h.runtime.releaseDiskLeasesCalls)
+	assert.Equal(t, 1, h.runtime.releaseTokenStateCalls,
+		"undoing boot-containers must release the token state it registered")
 	assert.Equal(t, 1, h.runtime.unconfigureFirewallCalls)
 	assert.Equal(t, 1, h.runtime.cleanupContainerCalls)
 	assert.Equal(t, 1, h.networking.releaseCalls)

--- a/controllers/sandbox/interface.go
+++ b/controllers/sandbox/interface.go
@@ -51,6 +51,7 @@ type SandboxContainerRuntime interface {
 	BootContainers(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, sbPid int, cgroups map[string]string, meta *entity.Meta, volumeMounts map[string]string) ([]WaitPort, error)
 	DestroySubContainers(ctx context.Context, id entity.Id) error
 	ReleaseDiskLeases(ctx context.Context, sandboxID entity.Id) error
+	ReleaseTokenState(id entity.Id)
 	UnconfigureFirewall(sb *compute.Sandbox)
 	WaitForPort(ctx context.Context, id string, port int, timeout time.Duration) error
 	// DiagnoseListening reports which ports a container is actually listening

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -77,7 +77,7 @@ func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox,
 		return nil
 	case compute.STOPPED:
 		s.log.Debug("sandbox is stopped, verifying it is no longer running")
-		return s.inner.StopSandbox(ctx, co.ID)
+		return s.inner.StopSandbox(ctx, co.ID, co)
 	case "", compute.PENDING, compute.RUNNING:
 		searchRes, err := s.inner.CheckSandbox(ctx, co, meta)
 		if err != nil {
@@ -131,7 +131,7 @@ func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox,
 					}
 				}
 
-				if err := s.inner.StopSandbox(ctx, co.ID); err != nil {
+				if err := s.inner.StopSandbox(ctx, co.ID, co); err != nil {
 					return fmt.Errorf("failed to cleanup unhealthy sandbox: %w", err)
 				}
 				return nil

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -2748,6 +2748,38 @@ func (c *SandboxController) Delete(ctx context.Context, id entity.Id, sb *comput
 	return c.StopSandbox(ctx, id, sb)
 }
 
+// entityFallbackIPs returns the addresses recorded on a sandbox entity, for use
+// when the pause container's labels couldn't supply them.
+//
+// A DEAD sandbox yields nothing. DEAD is only reached by way of a teardown that
+// already released the sandbox's addresses, and nothing ever clears Network on
+// the entity, so those addresses are stale by construction. Releasing them again
+// would be a no-op at best; once the netdb cooldown has passed and another
+// sandbox has reserved one of them, ReleaseAddr updates the row by IP with no
+// ownership check and hands a live address back to the pool.
+//
+// The delete callback is the path that makes this reachable, since it carries
+// the prior entity and fires from the periodic sweep an hour after teardown.
+func entityFallbackIPs(sb *compute.Sandbox) map[string]bool {
+	ips := make(map[string]bool)
+	if sb.Status == compute.DEAD {
+		return ips
+	}
+
+	for _, net := range sb.Network {
+		addr := net.Address
+		if strings.Contains(addr, "/") {
+			if prefix, err := netip.ParsePrefix(addr); err == nil {
+				addr = prefix.Addr().String()
+			}
+		}
+		if addr != "" {
+			ips[addr] = true
+		}
+	}
+	return ips
+}
+
 // StopSandbox tears down a sandbox and releases every resource it holds. sb is
 // optional: callers that already have the entity pass it so cleanup still works
 // once the entity has been deleted from the store, and it is fetched here
@@ -2829,19 +2861,7 @@ func (c *SandboxController) StopSandbox(ctx context.Context, id entity.Id, sb *c
 
 		// Use the entity's IPs as fallback if container labels didn't have them
 		if len(sandboxIPs) == 0 {
-			sandboxIPs = make(map[string]bool)
-			for _, net := range sb.Network {
-				addr := net.Address
-				if strings.Contains(addr, "/") {
-					if prefix, err := netip.ParsePrefix(addr); err == nil {
-						addr = prefix.Addr().String()
-					}
-				}
-				if addr != "" {
-					sandboxIPs[addr] = true
-				}
-			}
-
+			sandboxIPs = entityFallbackIPs(sb)
 			if len(sandboxIPs) > 0 {
 				c.Log.Debug("retrieved IPs from entity for cleanup", "id", id, "ips", sandboxIPs)
 			}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -1048,7 +1048,7 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 		return nil
 	case compute.STOPPED:
 		c.Log.Debug("sandbox is stopped, verifying it is no longer running")
-		return c.StopSandbox(ctx, co.ID)
+		return c.StopSandbox(ctx, co.ID, co)
 	case "", compute.PENDING, compute.RUNNING:
 		searchRes, err := c.CheckSandbox(ctx, co, meta)
 		if err != nil {
@@ -1126,7 +1126,7 @@ func (c *SandboxController) Create(ctx context.Context, co *compute.Sandbox, met
 				}
 
 				// Clean up the unhealthy sandbox
-				err := c.StopSandbox(ctx, co.ID)
+				err := c.StopSandbox(ctx, co.ID, co)
 				if err != nil {
 					c.Log.Error("failed to cleanup unhealthy sandbox", "id", co.ID, "err", err)
 					return fmt.Errorf("failed to cleanup unhealthy sandbox: %w", err)
@@ -1241,6 +1241,12 @@ func (c *SandboxController) createSandbox(ctx context.Context, co *compute.Sandb
 
 			// Clean up the pause container using the common cleanup function
 			c.CleanupContainer(ctx, container)
+
+			// Boot may have gotten far enough to register the sandbox for token
+			// refresh (see buildSubContainerSpec). This path marks the sandbox DEAD
+			// without going through StopSandbox, so release that state here or it
+			// lingers until the entity is swept.
+			c.ReleaseTokenState(co.ID)
 
 			// Update sandbox status to DEAD in entity store
 			co.Status = compute.DEAD
@@ -2739,34 +2745,37 @@ cleanup:
 
 func (c *SandboxController) Delete(ctx context.Context, id entity.Id, sb *compute.Sandbox) error {
 	c.Log.Debug("delete callback received, cleaning up sandbox", "id", id)
-	if c.NetServ != nil {
-		// Drop the address claim here rather than leaving it to the watcher's delete
-		// event, so a recycled address is free the moment the sandbox holding it goes.
-		c.NetServ.RemoveSandboxMapping(id.String())
-	}
-	if c.tokenRefresher != nil {
-		c.tokenRefresher.unregister(id.String())
-	}
-	if c.tokenSecrets != nil {
-		c.tokenSecrets.unregister(id.String())
-		// Best-effort removal of the persisted secret. StopSandbox also wipes the whole
-		// sandbox dir, but removing the sensitive secret here ensures it doesn't linger
-		// if StopSandbox errors out before reaching its dir cleanup.
-		secretPath := filepath.Join(c.Tempdir, "containerd", id.PathSafe(), tokenSecretFilename)
-		if err := os.Remove(secretPath); err != nil && !os.IsNotExist(err) {
-			c.Log.Warn("failed to remove persisted token secret", "sandbox", id, "error", err)
-		}
-	}
-	if sb != nil {
-		c.UnconfigureFirewall(sb)
-	}
-	return c.StopSandbox(ctx, id)
+	return c.StopSandbox(ctx, id, sb)
 }
 
-func (c *SandboxController) StopSandbox(ctx context.Context, id entity.Id) error {
+// StopSandbox tears down a sandbox and releases every resource it holds. sb is
+// optional: callers that already have the entity pass it so cleanup still works
+// once the entity has been deleted from the store, and it is fetched here
+// otherwise.
+func (c *SandboxController) StopSandbox(ctx context.Context, id entity.Id, sb *compute.Sandbox) error {
 	ctx = namespaces.WithNamespace(ctx, c.Namespace)
 
 	c.Log.Debug("stopping sandbox", "id", id)
+
+	// Release in-memory token state first. Container teardown below can be slow or
+	// fail partway, and a sandbox left registered keeps getting fresh tokens minted
+	// for a file that is about to disappear.
+	c.ReleaseTokenState(id)
+
+	if c.NetServ != nil {
+		// Drop the address claim here rather than leaving it to the watcher's delete
+		// event, so a recycled address is free the moment the sandbox holding it goes.
+		// Teardown is that moment, and it runs well ahead of the entity delete.
+		c.NetServ.RemoveSandboxMapping(id.String())
+	}
+
+	// Best-effort removal of the persisted secret. The whole sandbox dir is wiped
+	// further down, but removing the sensitive secret up front ensures it doesn't
+	// linger if teardown errors out before reaching that cleanup.
+	secretPath := filepath.Join(c.Tempdir, "containerd", id.PathSafe(), tokenSecretFilename)
+	if err := os.Remove(secretPath); err != nil && !os.IsNotExist(err) {
+		c.Log.Warn("failed to remove persisted token secret", "sandbox", id, "error", err)
+	}
 
 	// Get LogEntity from pause container labels for metrics cleanup
 	var le string
@@ -2797,16 +2806,28 @@ func (c *SandboxController) StopSandbox(ctx context.Context, id entity.Id) error
 		c.Log.Warn("failed to load pause container", "id", id, "err", err)
 	}
 
-	// Fetch sandbox entity for firewall cleanup and as IP fallback
-	resp, entityErr := c.EAC.Get(ctx, id.String())
-	if entityErr == nil {
-		var sb compute.Sandbox
-		sb.Decode(resp.Entity().Entity())
+	// Fetch the sandbox entity for firewall cleanup and as IP fallback, unless the
+	// caller already handed us one. Delete callbacks fire after the entity is gone,
+	// so their copy is the only one we will ever see.
+	if sb == nil {
+		resp, entityErr := c.EAC.Get(ctx, id.String())
+		switch {
+		case entityErr == nil:
+			var fetched compute.Sandbox
+			fetched.Decode(resp.Entity().Entity())
+			sb = &fetched
+		case !errors.Is(entityErr, cond.ErrNotFound{}):
+			c.Log.Warn("failed to get sandbox entity for cleanup", "id", id, "err", entityErr)
+		default:
+			c.Log.Debug("sandbox entity already deleted and no sandbox supplied, skipping firewall cleanup", "id", id)
+		}
+	}
 
+	if sb != nil {
 		// Clean up iptables DNAT rules before destroying containers
-		c.UnconfigureFirewall(&sb)
+		c.UnconfigureFirewall(sb)
 
-		// Use entity store IPs as fallback if container labels didn't have them
+		// Use the entity's IPs as fallback if container labels didn't have them
 		if len(sandboxIPs) == 0 {
 			sandboxIPs = make(map[string]bool)
 			for _, net := range sb.Network {
@@ -2822,13 +2843,9 @@ func (c *SandboxController) StopSandbox(ctx context.Context, id entity.Id) error
 			}
 
 			if len(sandboxIPs) > 0 {
-				c.Log.Debug("retrieved IPs from entity store for cleanup", "id", id, "ips", sandboxIPs)
+				c.Log.Debug("retrieved IPs from entity for cleanup", "id", id, "ips", sandboxIPs)
 			}
 		}
-	} else if !errors.Is(entityErr, cond.ErrNotFound{}) {
-		c.Log.Warn("failed to get sandbox entity for cleanup", "id", id, "err", entityErr)
-	} else {
-		c.Log.Debug("sandbox entity already deleted, firewall cleanup handled by DeleteEntity if available", "id", id)
 	}
 
 	// Fallback if we couldn't get LogEntity from labels

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "b2dec423842e4ec391ddb10fc6e4edc6770ab308dd2504d693e058a803fc4652",
+		"sandbox.go":  "ec5ba5e106c28047a646217a6b8afb4125d55a1e97f6fd9fe183611115cf1dae",
 		"volume.go":   "580062fb8a34f3f7f965689467a4b0f2ed403bc63c1ecdeb44949a7ba7e08dff",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "637c44467c9524b8e8f15f695149c584898d32ceb66989f0cda8aafbc5ae2978",
+		"sandbox.go":  "b2dec423842e4ec391ddb10fc6e4edc6770ab308dd2504d693e058a803fc4652",
 		"volume.go":   "580062fb8a34f3f7f965689467a4b0f2ed403bc63c1ecdeb44949a7ba7e08dff",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/sandbox_ops.go
+++ b/controllers/sandbox/sandbox_ops.go
@@ -134,6 +134,10 @@ func (o *sandboxOps) ReleaseDiskLeases(ctx context.Context, sandboxID entity.Id)
 	return o.ctrl.ReleaseDiskLeases(ctx, sandboxID)
 }
 
+func (o *sandboxOps) ReleaseTokenState(id entity.Id) {
+	o.ctrl.ReleaseTokenState(id)
+}
+
 func (o *sandboxOps) UnconfigureFirewall(sb *compute.Sandbox) {
 	o.ctrl.UnconfigureFirewall(sb)
 }

--- a/controllers/sandbox/sandbox_test.go
+++ b/controllers/sandbox/sandbox_test.go
@@ -440,7 +440,7 @@ func TestSandbox(t *testing.T) {
 		r.NoError(err)
 
 		defer func() {
-			r.NoError(co.StopSandbox(context.WithoutCancel(ctx), id))
+			r.NoError(co.StopSandbox(context.WithoutCancel(ctx), id, nil))
 		}()
 
 		// Create only updates its in-memory copy of the entity; by the time a

--- a/controllers/sandbox/stop_sandbox_ips_test.go
+++ b/controllers/sandbox/stop_sandbox_ips_test.go
@@ -1,0 +1,67 @@
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// The entity's recorded addresses are only a safe cleanup source while the
+// sandbox still owns them. Once it reaches DEAD a teardown has already released
+// them, and nothing clears Network, so a later delete callback would be handing
+// back an address that may since have been reserved by someone else.
+func TestEntityFallbackIPs(t *testing.T) {
+	network := []compute.Network{
+		{Address: "10.8.0.5/32"},
+		{Address: "10.8.0.6"},
+	}
+
+	tests := []struct {
+		name   string
+		status compute.SandboxStatus
+		want   map[string]bool
+	}{
+		{
+			name:   "running sandbox still owns its addresses",
+			status: compute.RUNNING,
+			want:   map[string]bool{"10.8.0.5": true, "10.8.0.6": true},
+		},
+		{
+			name:   "stopped sandbox has not released them yet",
+			status: compute.STOPPED,
+			want:   map[string]bool{"10.8.0.5": true, "10.8.0.6": true},
+		},
+		{
+			name:   "dead sandbox already released them",
+			status: compute.DEAD,
+			want:   map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := &compute.Sandbox{
+				ID:      entity.Id("sandbox/test"),
+				Status:  tt.status,
+				Network: network,
+			}
+
+			assert.Equal(t, tt.want, entityFallbackIPs(sb))
+		})
+	}
+}
+
+func TestEntityFallbackIPs_SkipsEmptyAddresses(t *testing.T) {
+	sb := &compute.Sandbox{
+		ID:     entity.Id("sandbox/test"),
+		Status: compute.RUNNING,
+		Network: []compute.Network{
+			{Address: ""},
+			{Address: "10.8.0.7/32"},
+		},
+	}
+
+	assert.Equal(t, map[string]bool{"10.8.0.7": true}, entityFallbackIPs(sb))
+}

--- a/controllers/sandbox/token_refresh.go
+++ b/controllers/sandbox/token_refresh.go
@@ -109,17 +109,19 @@ func (c *SandboxController) refreshTokens() {
 		case errors.Is(err, fs.ErrNotExist):
 			// The sandbox directory is gone, so the sandbox is gone. Teardown
 			// normally unregisters the entry (see ReleaseTokenState); this keeps a
-			// path that skipped it from refreshing a dead sandbox forever.
+			// path that skipped it from refreshing a dead sandbox forever. Release
+			// through the same call teardown uses, so the backstop also clears the
+			// token secret instead of leaving it authorized.
 			c.Log.Debug("dropping token refresh entry for departed sandbox", "sandbox", e.sandboxID)
-			c.tokenRefresher.unregister(e.sandboxID)
+			c.ReleaseTokenState(entity.Id(e.sandboxID))
 			dropped++
 		default:
 			c.Log.Warn("failed to write refreshed workload identity token", "sandbox", e.sandboxID, "error", err)
 		}
 	}
 
-	if len(entries) > 0 {
-		c.Log.Debug("refreshed workload identity tokens", "count", len(entries)-dropped)
+	if refreshed := len(entries) - dropped; refreshed > 0 {
+		c.Log.Debug("refreshed workload identity tokens", "count", refreshed)
 	}
 
 	// A non-zero count means some teardown path skipped ReleaseTokenState — the

--- a/controllers/sandbox/token_refresh.go
+++ b/controllers/sandbox/token_refresh.go
@@ -2,11 +2,15 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"miren.dev/runtime/pkg/entity"
 )
 
 const tokenRefreshInterval = 45 * time.Minute
@@ -54,6 +58,20 @@ func (tr *tokenRefresher) snapshot() []tokenEntry {
 	return entries
 }
 
+// ReleaseTokenState drops every in-memory workload identity record for a sandbox.
+// Called from StopSandbox so the state goes away with the sandbox itself rather
+// than with the entity, which outlives it by up to the periodic cleanup horizon,
+// and from the boot-failure cleanup paths, which never reach StopSandbox.
+func (c *SandboxController) ReleaseTokenState(id entity.Id) {
+	sandboxID := id.String()
+	if c.tokenRefresher != nil {
+		c.tokenRefresher.unregister(sandboxID)
+	}
+	if c.tokenSecrets != nil {
+		c.tokenSecrets.unregister(sandboxID)
+	}
+}
+
 func (c *SandboxController) runTokenRefresh(ctx context.Context) {
 	ticker := time.NewTicker(tokenRefreshInterval)
 	defer ticker.Stop()
@@ -74,6 +92,7 @@ func (c *SandboxController) refreshTokens() {
 	}
 
 	entries := c.tokenRefresher.snapshot()
+	var dropped int
 	for _, e := range entries {
 		token, err := c.WorkloadIssuer.IssueToken(e.appName, e.sandboxID)
 		if err != nil {
@@ -84,13 +103,29 @@ func (c *SandboxController) refreshTokens() {
 		// into containers. Rename would create a new inode and the container
 		// would keep reading the stale old token. The brief window of partial
 		// content is acceptable for a few-hundred-byte JWT.
-		if err := os.WriteFile(e.filePath, []byte(token), 0644); err != nil {
+		err = os.WriteFile(e.filePath, []byte(token), 0644)
+		switch {
+		case err == nil:
+		case errors.Is(err, fs.ErrNotExist):
+			// The sandbox directory is gone, so the sandbox is gone. Teardown
+			// normally unregisters the entry (see ReleaseTokenState); this keeps a
+			// path that skipped it from refreshing a dead sandbox forever.
+			c.Log.Debug("dropping token refresh entry for departed sandbox", "sandbox", e.sandboxID)
+			c.tokenRefresher.unregister(e.sandboxID)
+			dropped++
+		default:
 			c.Log.Warn("failed to write refreshed workload identity token", "sandbox", e.sandboxID, "error", err)
 		}
 	}
 
 	if len(entries) > 0 {
-		c.Log.Debug("refreshed workload identity tokens", "count", len(entries))
+		c.Log.Debug("refreshed workload identity tokens", "count", len(entries)-dropped)
+	}
+
+	// A non-zero count means some teardown path skipped ReleaseTokenState — the
+	// self-heal covered for it, but the gap is worth seeing without debug logging.
+	if dropped > 0 {
+		c.Log.Info("dropped stale token refresh entries", "count", dropped)
 	}
 }
 

--- a/controllers/sandbox/token_refresh_test.go
+++ b/controllers/sandbox/token_refresh_test.go
@@ -1,0 +1,118 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/entity"
+)
+
+func sandboxIDs(entries []tokenEntry) []string {
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		ids = append(ids, e.sandboxID)
+	}
+	return ids
+}
+
+func TestTokenRefresher_RegisterUnregister(t *testing.T) {
+	tr := newTokenRefresher()
+
+	assert.Empty(t, tr.snapshot())
+
+	tr.register("sandbox/one", "/tmp/one/identity-token", "myapp")
+	tr.register("sandbox/two", "/tmp/two/identity-token", "otherapp")
+
+	entries := tr.snapshot()
+	require.Len(t, entries, 2)
+	assert.ElementsMatch(t, []string{"sandbox/one", "sandbox/two"}, sandboxIDs(entries))
+
+	tr.unregister("sandbox/one")
+
+	entries = tr.snapshot()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "sandbox/two", entries[0].sandboxID)
+	assert.Equal(t, "/tmp/two/identity-token", entries[0].filePath)
+	assert.Equal(t, "otherapp", entries[0].appName)
+
+	// Unregistering an unknown sandbox is a no-op.
+	tr.unregister("sandbox/never-seen")
+	assert.Len(t, tr.snapshot(), 1)
+}
+
+// releaseTokenState is what teardown calls, so it has to clear both registries —
+// leaving the secret behind would keep a dead sandbox's token requests authorized.
+func TestReleaseTokenState_ClearsBothRegistries(t *testing.T) {
+	c := newTestTokenController(t)
+	c.tokenRefresher = newTokenRefresher()
+
+	id := entity.Id(testSandboxID)
+	c.tokenRefresher.register(testSandboxID, "/tmp/identity-token", "myapp")
+	require.Len(t, c.tokenRefresher.snapshot(), 1)
+	require.True(t, c.tokenSecrets.verify(testSandboxID, testSecret))
+
+	c.ReleaseTokenState(id)
+
+	assert.Empty(t, c.tokenRefresher.snapshot())
+	assert.False(t, c.tokenSecrets.verify(testSandboxID, testSecret))
+}
+
+func TestReleaseTokenState_NilRegistries(t *testing.T) {
+	c := newTestTokenController(t)
+	c.tokenRefresher = nil
+	c.tokenSecrets = nil
+
+	assert.NotPanics(t, func() {
+		c.ReleaseTokenState(entity.Id(testSandboxID))
+	})
+}
+
+func TestRefreshTokens_RewritesLiveTokens(t *testing.T) {
+	c := newTestTokenController(t)
+	c.tokenRefresher = newTokenRefresher()
+
+	tokenPath := filepath.Join(t.TempDir(), "identity-token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("stale"), 0644))
+
+	c.tokenRefresher.register(testSandboxID, tokenPath, "myapp")
+	c.refreshTokens()
+
+	data, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, "stale", string(data))
+	assert.NotEmpty(t, data)
+
+	// A live sandbox stays registered for the next tick.
+	assert.Len(t, c.tokenRefresher.snapshot(), 1)
+}
+
+// A sandbox whose directory has been torn down must drop out of the refresh set
+// instead of failing to write a fresh token on every tick, forever.
+func TestRefreshTokens_DropsDepartedSandboxes(t *testing.T) {
+	c := newTestTokenController(t)
+	c.tokenRefresher = newTokenRefresher()
+
+	liveDir := t.TempDir()
+	livePath := filepath.Join(liveDir, "identity-token")
+	require.NoError(t, os.WriteFile(livePath, []byte("stale"), 0644))
+
+	// Same shape as a sandbox whose dir StopSandbox already removed.
+	goneDir := filepath.Join(t.TempDir(), "removed-sandbox")
+	gonePath := filepath.Join(goneDir, "identity-token")
+
+	c.tokenRefresher.register("sandbox/live", livePath, "myapp")
+	c.tokenRefresher.register("sandbox/gone", gonePath, "deadapp")
+
+	c.refreshTokens()
+
+	entries := c.tokenRefresher.snapshot()
+	require.Len(t, entries, 1)
+	assert.Equal(t, "sandbox/live", entries[0].sandboxID)
+
+	data, err := os.ReadFile(livePath)
+	require.NoError(t, err)
+	assert.NotEqual(t, "stale", string(data))
+}

--- a/controllers/sandbox/token_refresh_test.go
+++ b/controllers/sandbox/token_refresh_test.go
@@ -106,11 +106,21 @@ func TestRefreshTokens_DropsDepartedSandboxes(t *testing.T) {
 	c.tokenRefresher.register("sandbox/live", livePath, "myapp")
 	c.tokenRefresher.register("sandbox/gone", gonePath, "deadapp")
 
+	// Both sandboxes still hold a token-request secret. The departed one's has to
+	// go with it, or the backstop leaves a dead sandbox authorized.
+	c.tokenSecrets.register("sandbox/live", "live-secret")
+	c.tokenSecrets.register("sandbox/gone", "gone-secret")
+
 	c.refreshTokens()
 
 	entries := c.tokenRefresher.snapshot()
 	require.Len(t, entries, 1)
 	assert.Equal(t, "sandbox/live", entries[0].sandboxID)
+
+	assert.False(t, c.tokenSecrets.verify("sandbox/gone", "gone-secret"),
+		"the departed sandbox's token secret should be released with its refresh entry")
+	assert.True(t, c.tokenSecrets.verify("sandbox/live", "live-secret"),
+		"the live sandbox's token secret must survive")
 
 	data, err := os.ReadFile(livePath)
 	require.NoError(t, err)


### PR DESCRIPTION
The token refresher was handing back entries for sandboxes that had exited long ago. Every 45 minutes it would mint a fresh JWT for each one and try to write it to a file teardown had already deleted, which is a lot of warn-level noise for no benefit.

The unregister lived in `Delete`, which is the entity-delete callback, and the normal exit path never gets there. A container exits, `monitorTaskExit` flips the sandbox to STOPPED, and reconcile calls `StopSandbox` directly. `StopSandbox` removes the whole sandbox directory but never touched any of the token state, and the entity itself hangs around until `Periodic` sweeps DEAD sandboxes an hour later. So an entry was stale for an hour minimum, and if that delete never landed (delete error, sandbox rescheduled to another node, lease release failing) it leaked for the life of the process. The stale token secret is the part I liked least, since it keeps a dead sandbox's token requests authorized against the token server.

`StopSandbox` is the choke point every teardown path funnels through, so the cleanup moved there, and it now runs up front rather than behind container work that can hang or fail partway. It takes the sandbox as an optional argument, which is the bit that made this awkward before: `Delete` fires after the entity is gone, so the copy it was handed is the only one anyone will ever see, and that's why it had grown a duplicate of the firewall teardown. `Delete` is a two-line wrapper now.

The interesting part was the frozen-file guard on `sandbox.go`, which asks you to audit the saga controller before touching the hash. Doing that turned up the same leak in both boot-failure paths, the non-saga defer in `createSandbox` and `undoBootContainers` in the saga. Both tear down containers and mark the sandbox DEAD without ever reaching `StopSandbox`, and the token file is still sitting on disk at that point, so the self-heal below would never have covered for them either.

Speaking of which, the refresh loop now drops an entry when the write comes back ENOENT, since a missing sandbox directory means a missing sandbox. Teardown should have unregistered it already, so a non-zero drop count logs at info as a hint that some path skipped the cleanup.

Closes MIR-1512