### PR TITLE
Make the sandbox IP ownership map authoritative

### DIFF
--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -116,6 +116,7 @@ type SandboxController struct {
 
 	tokenRefresher *tokenRefresher
 	tokenSecrets   *tokenSecretRegistry
+	lookupRefresh  refreshLimiter
 
 	topCtx context.Context
 	cancel func()
@@ -2053,6 +2054,8 @@ func (c *SandboxController) BootContainers(
 		}
 	}()
 
+	c.registerSandboxDNS(ctx, sb, ep, meta)
+
 	for _, container := range sb.Spec.Container {
 		opts, err := c.buildSubContainerSpec(ctx, sb, &container, ep, sbPid, meta, volumeMounts)
 		if err != nil {
@@ -2736,6 +2739,11 @@ cleanup:
 
 func (c *SandboxController) Delete(ctx context.Context, id entity.Id, sb *compute.Sandbox) error {
 	c.Log.Debug("delete callback received, cleaning up sandbox", "id", id)
+	if c.NetServ != nil {
+		// Drop the address claim here rather than leaving it to the watcher's delete
+		// event, so a recycled address is free the moment the sandbox holding it goes.
+		c.NetServ.RemoveSandboxMapping(id.String())
+	}
 	if c.tokenRefresher != nil {
 		c.tokenRefresher.unregister(id.String())
 	}
@@ -3021,6 +3029,41 @@ func (c *SandboxController) Periodic(ctx context.Context, timeHorizon time.Durat
 	}
 
 	return nil
+}
+
+// registerSandboxDNS publishes the sandbox's address to the DNS servers from the side
+// that actually knows it: this controller allocated the address, so it can register the
+// mapping before the container starts instead of waiting for the entity watcher to
+// notice. The watcher still reconciles, but it is no longer the only writer.
+//
+// This matters beyond DNS. The workload identity token server resolves a caller's
+// identity by looking its source address up in the same map, so a recycled address that
+// still named its previous owner meant the new sandbox could never present a secret that
+// matched — a permanent 403 for anything deployed onto that address (MIR-1511).
+func (c *SandboxController) registerSandboxDNS(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, meta *entity.Meta) {
+	if c.NetServ == nil || ep == nil || len(ep.Addresses) == 0 || meta == nil {
+		return
+	}
+
+	var md core_v1alpha.Metadata
+	md.Decode(meta)
+
+	// DNS entries are keyed by app+service; a sandbox without a service label has no
+	// name to answer to, which matches what the watcher does with one.
+	service, _ := md.Labels.Get("service")
+	if service == "" {
+		return
+	}
+
+	appName := c.resolveAppName(ctx, sb)
+	if appName == "" {
+		c.Log.Warn("could not resolve app name for sandbox DNS mapping", "sandbox", sb.ID)
+		return
+	}
+
+	ip := ep.Addresses[0].Addr().String()
+	c.NetServ.AddSandboxMapping(sb.ID.String(), ip, appName, service)
+	c.Log.Debug("registered sandbox DNS mapping", "sandbox", sb.ID, "ip", ip, "app", appName, "service", service)
 }
 
 func (c *SandboxController) resolveAppName(ctx context.Context, sb *compute.Sandbox) string {

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -24,7 +24,7 @@ import (
 //	sha256sum controllers/sandbox/sandbox.go controllers/sandbox/volume.go controllers/sandbox/firewall.go
 func TestSandboxControllerFrozen(t *testing.T) {
 	frozen := map[string]string{
-		"sandbox.go":  "4734a18ab35e3f8b39edcfa0943fec640560a2426ce5682561480c662a075cf0",
+		"sandbox.go":  "637c44467c9524b8e8f15f695149c584898d32ceb66989f0cda8aafbc5ae2978",
 		"volume.go":   "580062fb8a34f3f7f965689467a4b0f2ed403bc63c1ecdeb44949a7ba7e08dff",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/controllers/sandbox/token_server.go
+++ b/controllers/sandbox/token_server.go
@@ -36,7 +36,13 @@ type tokenErrorResponse struct {
 // tokenSecretRegistry maps a sandbox's identity to its token-request secret. Keying by
 // sandbox identity (rather than raw source IP) means a recycled pod IP can never match a
 // stale secret left behind by a previous sandbox: the caller's identity is resolved from
-// the IP via the authoritative netdb lookup, and the secret is checked against that.
+// its source address, and the secret is checked against that sandbox.
+//
+// The address lookup is therefore load-bearing for identity, not just for DNS. It is what
+// decides which app the issued token claims to be. That lookup used to be able to name a
+// sandbox that no longer held the address, which this registry was the only thing
+// standing between and an identity-confusion bug (MIR-1511) — so treat a verification
+// failure as evidence the mapping may be wrong, not only that the caller may be.
 type tokenSecretRegistry struct {
 	mu        sync.RWMutex
 	bySandbox map[string]string // sandboxID → secret
@@ -68,6 +74,45 @@ func (r *tokenSecretRegistry) verify(sandboxID, secret string) bool {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(expected), []byte(secret)) == 1
+}
+
+// refreshCooldown bounds how often one source address can force the token server to
+// re-derive its mapping from the entity store.
+const refreshCooldown = 10 * time.Second
+
+// refreshLimiterSweepAt is the size past which allow drops expired entries. Source
+// addresses come from a bridge subnet, so the map stays far below this in practice; the
+// sweep is here so a long-lived runner churning through addresses cannot grow it without
+// bound.
+const refreshLimiterSweepAt = 256
+
+// refreshLimiter rate-limits mapping re-resolution per source address. Its zero value is
+// ready to use and allows the first attempt for any address.
+type refreshLimiter struct {
+	mu   sync.Mutex
+	last map[string]time.Time
+}
+
+func (l *refreshLimiter) allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	if at, seen := l.last[key]; seen && now.Sub(at) < refreshCooldown {
+		return false
+	}
+	if l.last == nil {
+		l.last = make(map[string]time.Time)
+	}
+	if len(l.last) >= refreshLimiterSweepAt {
+		for addr, at := range l.last {
+			if now.Sub(at) >= refreshCooldown {
+				delete(l.last, addr)
+			}
+		}
+	}
+	l.last[key] = now
+	return true
 }
 
 func generateTokenSecret() (string, error) {
@@ -134,6 +179,20 @@ func (c *SandboxController) startTokenServer(ctx context.Context) {
 	}
 }
 
+func (c *SandboxController) verifyTokenSecret(sandboxID, secret string) bool {
+	return c.tokenSecrets != nil && c.tokenSecrets.verify(sandboxID, secret)
+}
+
+// refreshSandboxByIP re-derives an address's owner from the entity store, subject to the
+// per-address cooldown: a container retrying a bad token request in a loop must not turn
+// every failure into an entity-store scan.
+func (c *SandboxController) refreshSandboxByIP(ip string) (sandboxID, appName string, ok bool) {
+	if c.NetServ == nil || !c.lookupRefresh.allow(ip) {
+		return "", "", false
+	}
+	return c.NetServ.RefreshSandboxByIP(ip)
+}
+
 func (c *SandboxController) handleTokenRequest(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeTokenError(w, http.StatusMethodNotAllowed, "only GET is allowed")
@@ -159,9 +218,26 @@ func (c *SandboxController) handleTokenRequest(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if c.tokenSecrets == nil || !c.tokenSecrets.verify(sandboxID, bearerToken) {
-		writeTokenError(w, http.StatusForbidden, "invalid token")
-		return
+	if !c.verifyTokenSecret(sandboxID, bearerToken) {
+		// The caller holds a secret the sandbox we resolved does not own. Either it is
+		// an impostor, or the address mapping is stale and named the sandbox that used
+		// to hold this address — which a sandbox on a recycled IP could never recover
+		// from, because nothing else would ever correct the mapping (MIR-1511). Re-derive
+		// the owner from the entity store and try once more, so a mapping that has gone
+		// wrong costs one rejected request instead of the life of the sandbox.
+		corrected, correctedApp, refreshed := c.refreshSandboxByIP(remoteHost)
+		if !refreshed || corrected == sandboxID || !c.verifyTokenSecret(corrected, bearerToken) {
+			c.Log.Warn("workload token request failed verification",
+				"source_ip", remoteHost, "resolved_sandbox", sandboxID, "resolved_app", appName)
+			writeTokenError(w, http.StatusForbidden, "invalid token")
+			return
+		}
+
+		c.Log.Warn("corrected stale sandbox address mapping during token request",
+			"source_ip", remoteHost,
+			"stale_sandbox", sandboxID, "stale_app", appName,
+			"sandbox", corrected, "app", correctedApp)
+		sandboxID, appName = corrected, correctedApp
 	}
 
 	opts := workloadidentity.TokenOptions{}

--- a/controllers/sandbox/token_server_test.go
+++ b/controllers/sandbox/token_server_test.go
@@ -2,12 +2,14 @@ package sandbox
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
@@ -198,6 +200,109 @@ func TestTokenSecretRegistry_KeyedBySandboxIdentity(t *testing.T) {
 
 	r.unregister("sandbox/old")
 	assert.False(t, r.verify("sandbox/old", "secret-old"))
+}
+
+// TestTokenServer_RecycledIPResolvesToCurrentSandbox reproduces MIR-1511: a sandbox that
+// lands on a recently-recycled address gets 403 "invalid token" forever, because the
+// address still resolves to the sandbox that held it before and the presented secret is
+// checked against that one. The identity the server would have issued is the *previous*
+// sandbox's app, which is why this is a security bug and not only an availability one.
+func TestTokenServer_RecycledIPResolvesToCurrentSandbox(t *testing.T) {
+	const (
+		recycledIP = "10.8.64.17"
+		newSandbox = "sandbox/reviewagent-web-NEW"
+		oldSandbox = "sandbox/db-app-web-OLD"
+		newSecret  = "the-new-sandbox-secret"
+	)
+
+	c := newTestTokenController(t)
+
+	sm := network.NewServiceManager(slog.Default(), nil)
+	sm.AddTestDNSServer(t, func(s *dns.Server) {
+		// The new sandbox takes the address, then a late event for the outgoing one
+		// re-registers it — the ordering that left the mapping naming the old sandbox.
+		s.AddSandboxMapping(newSandbox, recycledIP, "reviewagent", "web")
+		s.AddSandboxMapping(oldSandbox, recycledIP, "db-app", "web")
+		s.RemoveSandboxMapping(oldSandbox)
+	})
+	c.NetServ = sm
+	c.tokenSecrets.register(newSandbox, newSecret)
+
+	req := httptest.NewRequest("GET", "/v1/token", nil)
+	req.RemoteAddr = recycledIP + ":12345"
+	req.Header.Set("Authorization", "Bearer "+newSecret)
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "the sandbox currently holding the address should get a token")
+
+	var resp tokenResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+		return c.WorkloadIssuer.(*workloadidentity.Issuer).PublicKey(), nil
+	})
+	require.NoError(t, err)
+
+	claims := token.Claims.(*workloadidentity.WorkloadClaims)
+	assert.Equal(t, newSandbox, claims.SandboxID)
+	assert.Equal(t, "reviewagent", claims.App,
+		"the token must carry the current occupant's identity, never the previous one's")
+}
+
+// TestTokenServer_CorrectedMappingUnblocksSandbox covers the recovery path from the
+// handler's side: a sandbox locked out by a stale mapping starts working the moment the
+// mapping is fixed, with no restart. Re-deriving the mapping needs an entity store, so
+// the re-resolution itself is covered in pkg/dns; here the correction is applied directly.
+func TestTokenServer_CorrectedMappingUnblocksSandbox(t *testing.T) {
+	const (
+		liveSandbox = "sandbox/reviewagent-web-LIVE"
+		liveSecret  = "the-live-sandbox-secret"
+	)
+
+	c := newTestTokenController(t)
+	c.tokenSecrets.register(liveSandbox, liveSecret)
+
+	// The address resolves to a sandbox that no longer holds it, so the live sandbox's
+	// secret cannot verify against the identity the lookup returns.
+	req := httptest.NewRequest("GET", "/v1/token", nil)
+	req.RemoteAddr = testSandboxIP + ":12345"
+	req.Header.Set("Authorization", "Bearer "+liveSecret)
+	w := httptest.NewRecorder()
+
+	c.handleTokenRequest(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code,
+		"with no entity store to re-derive from, a stale mapping still rejects")
+
+	// Once the mapping is corrected — by the watcher, by the controller registering the
+	// sandbox, or by a re-resolution — the same request succeeds without the sandbox
+	// having restarted.
+	c.NetServ.AddSandboxMapping(liveSandbox, testSandboxIP, "reviewagent", "web")
+
+	w = httptest.NewRecorder()
+	c.handleTokenRequest(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRefreshLimiter_BoundsRescansPerAddress(t *testing.T) {
+	var l refreshLimiter
+
+	assert.True(t, l.allow("10.8.64.17"), "the first attempt for an address is allowed")
+	assert.False(t, l.allow("10.8.64.17"), "a retry within the cooldown is not")
+	assert.True(t, l.allow("10.8.64.18"), "the cooldown is per address")
+}
+
+func TestRefreshLimiter_SweepsExpiredEntries(t *testing.T) {
+	l := refreshLimiter{last: make(map[string]time.Time)}
+
+	// Fill past the sweep threshold with entries old enough to be expired.
+	stale := time.Now().Add(-2 * refreshCooldown)
+	for i := range refreshLimiterSweepAt {
+		l.last[fmt.Sprintf("10.8.%d.%d", i/256, i%256)] = stale
+	}
+
+	require.True(t, l.allow("10.8.64.17"))
+	assert.Equal(t, 1, len(l.last), "expired entries should be dropped, leaving only the new one")
 }
 
 func TestWriteLoadTokenSecret_RoundTrip(t *testing.T) {

--- a/network/services.go
+++ b/network/services.go
@@ -148,6 +148,37 @@ func (sm *ServiceManager) AddTestDNSServer(t interface{ Helper() }, setup func(*
 	sm.bridges["test"].dns = append(sm.bridges["test"].dns, s)
 }
 
+// AddSandboxMapping registers a sandbox's address with every DNS server, so the mapping
+// is in place before the sandbox's container starts rather than whenever the entity
+// watcher gets to it. Every server watches the whole sandbox index and LookupSandboxByIP
+// searches all of them, so the mappings are cluster-wide on each server either way.
+//
+// The caller here is the controller that allocated the address, which makes it the
+// authority on who owns it — the watcher-derived view remains as reconciliation.
+func (sm *ServiceManager) AddSandboxMapping(sandboxID, ip, appName, service string) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	for _, bs := range sm.bridges {
+		for _, server := range bs.dns {
+			server.AddSandboxMapping(sandboxID, ip, appName, service)
+		}
+	}
+}
+
+// RemoveSandboxMapping withdraws a sandbox's address claim from every DNS server. If
+// another sandbox has already taken the address (a recycled IP), that sandbox keeps it.
+func (sm *ServiceManager) RemoveSandboxMapping(sandboxID string) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	for _, bs := range sm.bridges {
+		for _, server := range bs.dns {
+			server.RemoveSandboxMapping(sandboxID)
+		}
+	}
+}
+
 // LookupSandboxByIP searches across all bridge DNS servers for a sandbox matching the given IP.
 func (sm *ServiceManager) LookupSandboxByIP(ip string) (sandboxID, appName string, ok bool) {
 	sm.mu.RLock()
@@ -161,4 +192,23 @@ func (sm *ServiceManager) LookupSandboxByIP(ip string) (sandboxID, appName strin
 		}
 	}
 	return "", "", false
+}
+
+// RefreshSandboxByIP re-derives an address's owner from the entity store on every DNS
+// server, ignoring what they have cached, and returns the corrected answer. Every server
+// is refreshed rather than stopping at the first hit, so a mapping that has gone stale
+// cannot survive on one of them.
+func (sm *ServiceManager) RefreshSandboxByIP(ip string) (sandboxID, appName string, ok bool) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	for _, bs := range sm.bridges {
+		for _, server := range bs.dns {
+			id, app, found := server.RefreshSandboxByIP(ip)
+			if found && !ok {
+				sandboxID, appName, ok = id, app, true
+			}
+		}
+	}
+	return sandboxID, appName, ok
 }

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -21,6 +22,24 @@ import (
 	entityserver_v1alpha "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 )
 
+// sandboxMapping is one sandbox's claim on an address: the IP it holds and what that
+// address answers as. The IP-keyed maps are a projection of these claims — every write
+// to them goes through addSandboxMappingLocked or releaseIPLocked so an address always
+// names a sandbox that still claims it.
+//
+// Recycled IPs mean two sandboxes can hold a claim on the same address at once (the
+// outgoing one's entity outlives its container by up to an hour). seq breaks that tie:
+// it increments on every registration, so the most recent claimant owns the address and
+// a delete can hand it back to whoever is left. Ownership is security-relevant — the
+// workload identity token server resolves a caller's identity from ipToSandbox — so the
+// tie-break is deterministic rather than dependent on map iteration order (MIR-1511).
+type sandboxMapping struct {
+	ip      string
+	app     string
+	service string
+	seq     uint64
+}
+
 type Server struct {
 	*dns.Server
 	client       *dns.Client
@@ -33,7 +52,8 @@ type Server struct {
 	ipToSandbox     map[string]string              // source IP → sandbox entity ID
 	ipToService     map[string]string              // IP → service name (for PTR lookups)
 	appServiceToIPs map[string]map[string][]string // app name → service name → []IPs
-	entityToIP      map[string]string              // entity ID → IP address
+	sandboxes       map[string]sandboxMapping      // sandbox entity ID → what it claims
+	seq             uint64                         // registration counter; see sandboxMapping.seq
 
 	watchCtx    context.Context
 	watchCancel context.CancelFunc
@@ -67,7 +87,7 @@ func New(addr string, entityClient *entityserver_v1alpha.EntityAccessClient, log
 		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
 		appServiceToIPs: make(map[string]map[string][]string),
-		entityToIP:      make(map[string]string),
+		sandboxes:       make(map[string]sandboxMapping),
 	}
 
 	s.Handler = dns.HandlerFunc(s.handleRequest)
@@ -500,7 +520,7 @@ func (s *Server) reconcileSandboxes(ctx context.Context, entities []*entity.Enti
 
 	s.mu.RLock()
 	var stale []string
-	for id := range s.entityToIP {
+	for id := range s.sandboxes {
 		if _, ok := present[id]; !ok {
 			stale = append(stale, id)
 		}
@@ -522,16 +542,9 @@ func (s *Server) handleSandboxUpdate(ctx context.Context, sb *compute_v1alpha.Sa
 		return
 	}
 
-	s.mu.Lock()
-	_, tracked := s.entityToIP[sb.ID.String()]
-	s.mu.Unlock()
-
-	if tracked {
-		// Already tracked, skip
-		return
-	}
-
-	// Get sandbox IP
+	// A sandbox with no address yet is in its pre-assignment state, not one giving
+	// an address up: leave any existing claim alone and wait for the patch that
+	// fills Network in, which arrives as another update.
 	if len(sb.Network) == 0 {
 		return
 	}
@@ -540,6 +553,21 @@ func (s *Server) handleSandboxUpdate(ctx context.Context, sb *compute_v1alpha.Sa
 	ipAddr := sb.Network[0].Address
 	if strings.Contains(ipAddr, "/") {
 		ipAddr = strings.Split(ipAddr, "/")[0]
+	}
+
+	// Re-derive the mapping unless this sandbox is already the recorded owner of this
+	// exact address. Checking ownership rather than mere presence is the point: a
+	// sandbox that is tracked but whose address now names someone else has to be able
+	// to reclaim it, otherwise a stale entry survives until the process restarts
+	// (MIR-1511). The common case — an unrelated update for a sandbox that already
+	// owns its address — still returns before the two entity lookups below.
+	s.mu.RLock()
+	prev, tracked := s.sandboxes[sb.ID.String()]
+	owner := s.ipToSandbox[ipAddr]
+	s.mu.RUnlock()
+
+	if tracked && prev.ip == ipAddr && owner == sb.ID.String() {
+		return
 	}
 
 	// Get service label from metadata
@@ -592,7 +620,7 @@ func NewTestServer() *Server {
 		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
 		appServiceToIPs: make(map[string]map[string][]string),
-		entityToIP:      make(map[string]string),
+		sandboxes:       make(map[string]sandboxMapping),
 	}
 }
 
@@ -631,42 +659,133 @@ func (s *Server) AddSandboxMapping(sandboxID, ipAddr, appName, service string) {
 }
 
 func (s *Server) addSandboxMappingLocked(sandboxID, ipAddr, appName, service string) {
-	// Track entity ID -> IP mapping for DELETE operations
-	s.entityToIP[sandboxID] = ipAddr
+	prev, tracked := s.sandboxes[sandboxID]
 
-	// Update ipToApp and ipToSandbox mappings
+	// The sandbox moved: give up its previous address before claiming this one, so
+	// the address it left behind stops resolving to it.
+	if tracked && prev.ip != ipAddr {
+		s.releaseIPLocked(prev.ip, sandboxID)
+	}
+
+	owner, owned := s.ipToSandbox[ipAddr]
+	if tracked && prev.ip == ipAddr && prev.app == appName && prev.service == service && owner == sandboxID {
+		return // already recorded exactly this way
+	}
+
+	if owned && owner != sandboxID {
+		// Two sandboxes claiming one address is either a recycled IP whose previous
+		// owner has not been cleaned up yet or a genuine duplicate assignment
+		// (MIR-1238). The newest claim wins; log it either way, because before
+		// MIR-1511 this transition was silent and left us unable to tell which of
+		// the two a stale mapping had come from.
+		s.log.Warn("sandbox IP mapping reassigned",
+			"ip", ipAddr,
+			"previous_sandbox", owner, "previous_app", s.ipToApp[ipAddr],
+			"sandbox", sandboxID, "app", appName)
+	}
+
+	// Withdraw whatever this address currently advertises as before re-advertising
+	// it: when an IP moves between apps the old app must stop handing it out.
+	s.withdrawServiceRecordLocked(ipAddr)
+
+	s.seq++
+	s.sandboxes[sandboxID] = sandboxMapping{ip: ipAddr, app: appName, service: service, seq: s.seq}
+	s.pointIPLocked(ipAddr, sandboxID, appName, service)
+
+	s.log.Info("added sandbox to DNS mapping", "sandbox", sandboxID, "app", appName, "service", service, "ip", ipAddr)
+}
+
+// pointIPLocked makes ipAddr resolve to the given sandbox and advertises it under
+// app+service. Callers are responsible for withdrawing any previous advertisement.
+func (s *Server) pointIPLocked(ipAddr, sandboxID, appName, service string) {
 	s.ipToApp[ipAddr] = appName
 	s.ipToSandbox[ipAddr] = sandboxID
-
-	// Update ipToService mapping for PTR queries
 	s.ipToService[ipAddr] = service
 
-	// Update appServiceToIPs mapping
 	if s.appServiceToIPs[appName] == nil {
 		s.appServiceToIPs[appName] = make(map[string][]string)
 	}
+	if !slices.Contains(s.appServiceToIPs[appName][service], ipAddr) {
+		s.appServiceToIPs[appName][service] = append(s.appServiceToIPs[appName][service], ipAddr)
+	}
+}
 
-	// Check if IP already exists in the list for this app+service
-	existingIPs := s.appServiceToIPs[appName][service]
-	found := false
-	for _, existingIP := range existingIPs {
-		if existingIP == ipAddr {
-			found = true
-			break
+// releaseIPLocked gives up ignoreID's claim on ipAddr. If another sandbox still claims
+// the address — the usual case for a recycled IP, where the outgoing sandbox's entity
+// is deleted well after the new sandbox has taken the address — the maps are re-pointed
+// at the newest remaining claimant instead of being left naming the sandbox that just
+// went away. Only when nothing claims the address any more is it withdrawn.
+//
+// ignoreID must be excluded rather than assumed absent: addSandboxMappingLocked calls
+// this for a sandbox that has moved, and that sandbox is still in s.sandboxes under its
+// old address at the time. handleSandboxDeleteByID has already removed it, so there the
+// exclusion is redundant.
+func (s *Server) releaseIPLocked(ipAddr, ignoreID string) {
+	var (
+		heirID string
+		heir   sandboxMapping
+	)
+	for id, m := range s.sandboxes {
+		if id == ignoreID || m.ip != ipAddr {
+			continue
+		}
+		if heirID == "" || m.seq > heir.seq {
+			heirID, heir = id, m
 		}
 	}
 
-	if !found {
-		s.appServiceToIPs[appName][service] = append(existingIPs, ipAddr)
-		s.log.Info("added sandbox to DNS mapping", "sandbox", sandboxID, "app", appName, "service", service, "ip", ipAddr)
+	if heirID == "" {
+		s.withdrawServiceRecordLocked(ipAddr)
+		delete(s.ipToApp, ipAddr)
+		delete(s.ipToSandbox, ipAddr)
+		delete(s.ipToService, ipAddr)
+		s.log.Info("removed sandbox from DNS mapping", "entity_id", ignoreID, "ip", ipAddr)
+		return
+	}
+
+	if s.ipToSandbox[ipAddr] == heirID {
+		return // the heir already owns it; nothing to re-point
+	}
+
+	s.withdrawServiceRecordLocked(ipAddr)
+	s.pointIPLocked(ipAddr, heirID, heir.app, heir.service)
+	s.log.Info("re-pointed IP to surviving sandbox",
+		"ip", ipAddr, "entity_id", ignoreID, "sandbox", heirID, "app", heir.app, "service", heir.service)
+}
+
+// withdrawServiceRecordLocked stops every app+service advertising ipAddr. It sweeps the
+// whole table rather than trusting ipToApp, so an address that ended up advertised under
+// more than one app can only be listed by its current owner afterwards.
+func (s *Server) withdrawServiceRecordLocked(ipAddr string) {
+	for appName, serviceMap := range s.appServiceToIPs {
+		for service, ips := range serviceMap {
+			filtered := slices.DeleteFunc(slices.Clone(ips), func(ip string) bool { return ip == ipAddr })
+			if len(filtered) == len(ips) {
+				continue
+			}
+			if len(filtered) == 0 {
+				delete(serviceMap, service)
+				continue
+			}
+			serviceMap[service] = filtered
+		}
+		if len(serviceMap) == 0 {
+			delete(s.appServiceToIPs, appName)
+		}
 	}
 }
 
 // resolveUnknownIP searches the entity store for a sandbox with the given IP address
 // and registers it for DNS resolution if found. This handles the race where a sandbox
 // container starts making DNS queries before the entity watcher processes the RUNNING
-// status update. The lookup registers sandboxes regardless of status since the container
-// is clearly running if it's making DNS queries.
+// status update — PENDING sandboxes count, since the container is clearly running if it
+// is making DNS queries.
+//
+// It considers only active sandboxes, and among several picks the most recently created.
+// A sandbox that has stopped can keep its entity — address and all — for up to an hour
+// after its container is gone, and taking the first address match regardless of status
+// meant a dead sandbox could be installed as the owner of an address a live one was
+// already using, which the token server then reads as the caller's identity (MIR-1511).
 func (s *Server) resolveUnknownIP(sourceIP string) bool {
 	if s.entityClient == nil {
 		return false
@@ -683,6 +802,39 @@ func (s *Server) resolveUnknownIP(sourceIP string) bool {
 		return true
 	}
 
+	return s.resolveIPFromStore(sourceIP)
+}
+
+// RefreshSandboxByIP re-derives an address's owner from the entity store and returns the
+// result, ignoring what is cached. Callers use it when they have evidence the cached
+// answer is wrong — the token server, for instance, when a caller presents a secret the
+// resolved sandbox does not own.
+//
+// It is deliberately non-destructive: if the store cannot answer, the existing mapping is
+// left in place rather than dropped, so a transient entity-store failure during a request
+// that was already going to be rejected cannot also blank out an address's DNS.
+func (s *Server) RefreshSandboxByIP(ip string) (sandboxID, appName string, ok bool) {
+	if !s.resolveIPFromStore(ip) {
+		return "", "", false
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sandboxID, ok = s.ipToSandbox[ip]
+	if !ok {
+		return "", "", false
+	}
+	return sandboxID, s.ipToApp[ip], true
+}
+
+// resolveIPFromStore scans the sandbox index for the address's rightful owner and
+// registers it, replacing whatever was mapped before. Among several claimants it takes
+// the most recently created active one; see resolveUnknownIP for why.
+func (s *Server) resolveIPFromStore(sourceIP string) bool {
+	if s.entityClient == nil {
+		return false
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -692,11 +844,17 @@ func (s *Server) resolveUnknownIP(sourceIP string) bool {
 		return false
 	}
 
+	var (
+		best      *compute_v1alpha.Sandbox
+		bestEnt   *entity.Entity
+		bestBirth int64
+	)
+
 	for _, ent := range resp.Values() {
 		var sb compute_v1alpha.Sandbox
 		sb.Decode(ent.Entity())
 
-		if len(sb.Network) == 0 {
+		if len(sb.Network) == 0 || !compute.SandboxActive(sb.Status) {
 			continue
 		}
 
@@ -709,38 +867,45 @@ func (s *Server) resolveUnknownIP(sourceIP string) bool {
 			continue
 		}
 
-		var md core_v1alpha.Metadata
-		md.Decode(ent.Entity())
-
-		service, _ := md.Labels.Get("service")
-		if service == "" {
-			return false
+		if best == nil || ent.CreatedAt() > bestBirth {
+			candidate := sb
+			best, bestEnt, bestBirth = &candidate, ent.Entity(), ent.CreatedAt()
 		}
-
-		verResp, err := s.entityClient.Get(ctx, sb.Spec.Version.String())
-		if err != nil {
-			s.log.Debug("failed to get version for unknown IP sandbox", "ip", sourceIP, "error", err)
-			return false
-		}
-
-		var appVer core_v1alpha.AppVersion
-		appVer.Decode(verResp.Entity().Entity())
-
-		appResp, err := s.entityClient.Get(ctx, appVer.App.String())
-		if err != nil {
-			s.log.Debug("failed to get app for unknown IP sandbox", "ip", sourceIP, "error", err)
-			return false
-		}
-
-		var appMD core_v1alpha.Metadata
-		appMD.Decode(appResp.Entity().Entity())
-
-		s.AddSandboxMapping(sb.ID.String(), ipAddr, appMD.Name, service)
-		s.log.Info("resolved unknown IP to sandbox via entity lookup", "ip", sourceIP, "sandbox", sb.ID, "app", appMD.Name, "service", service)
-		return true
 	}
 
-	return false
+	if best == nil {
+		return false
+	}
+
+	var md core_v1alpha.Metadata
+	md.Decode(bestEnt)
+
+	service, _ := md.Labels.Get("service")
+	if service == "" {
+		return false
+	}
+
+	verResp, err := s.entityClient.Get(ctx, best.Spec.Version.String())
+	if err != nil {
+		s.log.Debug("failed to get version for unknown IP sandbox", "ip", sourceIP, "error", err)
+		return false
+	}
+
+	var appVer core_v1alpha.AppVersion
+	appVer.Decode(verResp.Entity().Entity())
+
+	appResp, err := s.entityClient.Get(ctx, appVer.App.String())
+	if err != nil {
+		s.log.Debug("failed to get app for unknown IP sandbox", "ip", sourceIP, "error", err)
+		return false
+	}
+
+	var appMD core_v1alpha.Metadata
+	appMD.Decode(appResp.Entity().Entity())
+
+	s.AddSandboxMapping(best.ID.String(), sourceIP, appMD.Name, service)
+	s.log.Info("resolved unknown IP to sandbox via entity lookup", "ip", sourceIP, "sandbox", best.ID, "app", appMD.Name, "service", service)
+	return true
 }
 
 // lookupAppForIP returns the app name associated with the given IP address.
@@ -755,69 +920,21 @@ func (s *Server) handleSandboxDeleteByID(entityID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Look up the IP address from entity ID
-	ipAddr, found := s.entityToIP[entityID]
+	m, found := s.sandboxes[entityID]
 	if !found {
 		// Not tracked, nothing to do
 		return
 	}
 
-	// Remove from entityToIP map
-	delete(s.entityToIP, entityID)
+	delete(s.sandboxes, entityID)
+	s.releaseIPLocked(m.ip, entityID)
+}
 
-	// Check if any other entity is still using this IP address.
-	// This can happen when IPs are reused: a new sandbox gets the same IP
-	// before the old sandbox's entity is cleaned up.
-	ipStillInUse := false
-	for _, ip := range s.entityToIP {
-		if ip == ipAddr {
-			ipStillInUse = true
-			break
-		}
-	}
-
-	if ipStillInUse {
-		s.log.Debug("IP still in use by another entity, keeping DNS mappings",
-			"entity_id", entityID, "ip", ipAddr)
-		return
-	}
-
-	// Get app name from ipToApp mapping
-	appName, found := s.ipToApp[ipAddr]
-	if !found {
-		return // Inconsistent state, but continue
-	}
-
-	// Remove from ipToApp, ipToSandbox
-	delete(s.ipToApp, ipAddr)
-	delete(s.ipToSandbox, ipAddr)
-
-	// Remove from ipToService
-	delete(s.ipToService, ipAddr)
-
-	// Remove from appServiceToIPs - need to find and remove IP from all services
-	if serviceMap, ok := s.appServiceToIPs[appName]; ok {
-		for service, ips := range serviceMap {
-			for i, ip := range ips {
-				if ip == ipAddr {
-					// Remove this IP from the slice
-					s.appServiceToIPs[appName][service] = append(ips[:i], ips[i+1:]...)
-					s.log.Info("removed sandbox from DNS mapping", "entity_id", entityID, "app", appName, "service", service, "ip", ipAddr)
-					break
-				}
-			}
-
-			// Clean up empty service entries
-			if len(s.appServiceToIPs[appName][service]) == 0 {
-				delete(s.appServiceToIPs[appName], service)
-			}
-		}
-
-		// Clean up empty app entries
-		if len(s.appServiceToIPs[appName]) == 0 {
-			delete(s.appServiceToIPs, appName)
-		}
-	}
+// RemoveSandboxMapping withdraws a sandbox's claim on its address. It is called by the
+// sandbox controller when a sandbox is torn down, so a local teardown takes effect
+// immediately rather than waiting on the entity watcher.
+func (s *Server) RemoveSandboxMapping(sandboxID string) {
+	s.handleSandboxDeleteByID(sandboxID)
 }
 
 // ListenAndServe starts the DNS server

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -25,7 +25,7 @@ func newTestServer(t *testing.T) *Server {
 		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
 		appServiceToIPs: make(map[string]map[string][]string),
-		entityToIP:      make(map[string]string),
+		sandboxes:       make(map[string]sandboxMapping),
 	}
 }
 
@@ -139,11 +139,11 @@ func TestSandboxStatusTransitionRemovesFromDNS(t *testing.T) {
 
 	// Verify all mappings are cleaned up
 	s.mu.RLock()
-	_, hasEntityMapping := s.entityToIP[sandboxID]
+	_, hasEntityMapping := s.sandboxes[sandboxID]
 	_, hasServiceMapping := s.ipToService[ip]
 	s.mu.RUnlock()
 
-	assert.False(t, hasEntityMapping, "entityToIP mapping should be removed")
+	assert.False(t, hasEntityMapping, "the sandbox's claim should be removed")
 	assert.False(t, hasServiceMapping, "ipToService mapping should be removed")
 }
 
@@ -238,7 +238,7 @@ func TestResolveUnknownIPFindsAndRegistersSandbox(t *testing.T) {
 		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
 		appServiceToIPs: make(map[string]map[string][]string),
-		entityToIP:      make(map[string]string),
+		sandboxes:       make(map[string]sandboxMapping),
 	}
 
 	// IP should not be registered yet
@@ -291,7 +291,7 @@ func TestResolveUnknownIPNoMatchingIP(t *testing.T) {
 		ipToSandbox:     make(map[string]string),
 		ipToService:     make(map[string]string),
 		appServiceToIPs: make(map[string]map[string][]string),
-		entityToIP:      make(map[string]string),
+		sandboxes:       make(map[string]sandboxMapping),
 	}
 
 	assert.False(t, s.resolveUnknownIP("10.8.24.100"),

--- a/pkg/dns/ip_ownership_test.go
+++ b/pkg/dns/ip_ownership_test.go
@@ -1,0 +1,330 @@
+package dns
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compute_v1alpha "miren.dev/runtime/api/compute/compute_v1alpha"
+	core_v1alpha "miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/slogfmt"
+)
+
+// These tests cover MIR-1511: a sandbox that lands on a recently-recycled IP could
+// never obtain a workload identity token, because ipToSandbox kept naming the IP's
+// previous owner and nothing in this package ever re-pointed it. The token server
+// resolves a caller's identity from that map, so a wrong entry is not just a stale
+// DNS answer — it is an identity the caller can never satisfy.
+//
+// Each test drives the map through one ordering that produced the stale entry.
+
+// ownerOf is the question the token server asks: who owns this IP right now?
+func ownerOf(t *testing.T, s *Server, ip string) (sandboxID, appName string) {
+	t.Helper()
+	sandboxID, appName, ok := s.LookupSandboxByIP(ip)
+	require.True(t, ok, "IP %s should resolve to a sandbox", ip)
+	return sandboxID, appName
+}
+
+// TestDeleteRepointsIPToSurvivingSandbox covers the delete path: when a sandbox is
+// deleted but another entity still claims its IP, the mapping must be re-pointed at
+// the survivor. Previously handleSandboxDeleteByID returned early in that branch
+// without touching ipToSandbox, so the map kept naming the deleted sandbox forever.
+func TestDeleteRepointsIPToSurvivingSandbox(t *testing.T) {
+	s := newTestServer(t)
+
+	const (
+		ip     = "10.8.64.17"
+		liveID = "sandbox/reviewagent-web-LIVE"
+		goneID = "sandbox/db-app-web-GONE"
+	)
+
+	// The new sandbox claims the recycled IP, then a late event for the outgoing
+	// sandbox re-registers it on the same IP — leaving the map naming the old one.
+	s.AddSandboxMapping(liveID, ip, "reviewagent", "web")
+	s.AddSandboxMapping(goneID, ip, "db-app", "web")
+
+	s.handleSandboxDeleteByID(goneID)
+
+	sandboxID, appName := ownerOf(t, s, ip)
+	assert.Equal(t, liveID, sandboxID,
+		"IP should be re-pointed at the surviving sandbox, not left naming the deleted one")
+	assert.Equal(t, "reviewagent", appName,
+		"app name must follow the surviving sandbox — it becomes the issued token's identity")
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	assert.Equal(t, "web", s.ipToService[ip], "service mapping should follow the survivor")
+	assert.Contains(t, s.appServiceToIPs["reviewagent"]["web"], ip,
+		"survivor's app should still advertise the IP")
+	assert.NotContains(t, s.appServiceToIPs["db-app"]["web"], ip,
+		"deleted sandbox's app should no longer advertise the IP")
+}
+
+// TestReassignedIPDropsPreviousOwnersServiceRecord covers the add path's other half:
+// when an IP moves to a different app, the previous owner's service record has to be
+// withdrawn. Otherwise db-app's web.app.miren keeps answering with an address that now
+// belongs to reviewagent.
+func TestReassignedIPDropsPreviousOwnersServiceRecord(t *testing.T) {
+	s := newTestServer(t)
+
+	const ip = "10.8.64.17"
+
+	s.AddSandboxMapping("sandbox/db-app-web-OLD", ip, "db-app", "web")
+	s.AddSandboxMapping("sandbox/reviewagent-web-NEW", ip, "reviewagent", "web")
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	assert.Contains(t, s.appServiceToIPs["reviewagent"]["web"], ip)
+	assert.NotContains(t, s.appServiceToIPs["db-app"]["web"], ip,
+		"an IP that moved to another app must stop being advertised by the previous app")
+}
+
+// TestTrackedSandboxReassertsStolenIP covers the `tracked` early return. A live
+// sandbox that is already tracked never re-asserted ownership of its own IP, so once
+// another registration overwrote ipToSandbox there was no writer left that could fix
+// it — the map stayed wrong until the runner restarted.
+func TestTrackedSandboxReassertsStolenIP(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	const ip = "10.8.64.17"
+
+	s := newEntityBackedServer(t, inmem)
+	sb, en := createSandbox(t, inmem, sandboxFixture{
+		app:     "reviewagent",
+		version: "reviewagent-v1",
+		name:    "reviewagent-web-live",
+		service: "web",
+		ip:      ip,
+		status:  compute_v1alpha.RUNNING,
+	})
+
+	// The live sandbox is registered and tracked.
+	s.handleSandboxUpdate(ctx, sb, en)
+	sandboxID, _ := ownerOf(t, s, ip)
+	require.Equal(t, sb.ID.String(), sandboxID, "live sandbox should own its IP to begin with")
+
+	// A stale registration for the IP's previous owner steals the mapping.
+	s.AddSandboxMapping("sandbox/db-app-web-STALE", ip, "db-app", "web")
+
+	// Any subsequent event for the live sandbox must reclaim it.
+	s.handleSandboxUpdate(ctx, sb, en)
+
+	sandboxID, appName := ownerOf(t, s, ip)
+	assert.Equal(t, sb.ID.String(), sandboxID,
+		"a live sandbox must reclaim its own IP even though it is already tracked")
+	assert.Equal(t, "reviewagent", appName)
+}
+
+// TestTrackedSandboxFollowsIPChange pins the coherence between the per-sandbox record
+// and the IP-keyed maps: if a tracked sandbox's address changes, the old IP must stop
+// resolving to it.
+func TestTrackedSandboxFollowsIPChange(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	const (
+		oldIP = "10.8.64.17"
+		newIP = "10.8.64.18"
+	)
+
+	s := newEntityBackedServer(t, inmem)
+	sb, en := createSandbox(t, inmem, sandboxFixture{
+		app:     "reviewagent",
+		version: "reviewagent-v1",
+		name:    "reviewagent-web-moving",
+		service: "web",
+		ip:      newIP,
+		status:  compute_v1alpha.RUNNING,
+	})
+
+	// The sandbox was tracked at its previous address.
+	s.AddSandboxMapping(sb.ID.String(), oldIP, "reviewagent", "web")
+
+	s.handleSandboxUpdate(ctx, sb, en)
+
+	sandboxID, _ := ownerOf(t, s, newIP)
+	assert.Equal(t, sb.ID.String(), sandboxID, "sandbox should be reachable at its current address")
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	assert.NotContains(t, s.ipToSandbox, oldIP, "the sandbox's previous address should be released")
+	assert.Equal(t, newIP, s.sandboxes[sb.ID.String()].ip)
+}
+
+// TestResolveUnknownIPPrefersLiveSandbox covers the lazy fallback. It scanned every
+// sandbox entity and took the first address match regardless of status, so a dead
+// sandbox whose entity had not been garbage collected yet could be installed as the
+// owner of an IP a live sandbox was already using.
+func TestResolveUnknownIPPrefersLiveSandbox(t *testing.T) {
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	const ip = "10.8.64.17"
+
+	// Both entities exist at once, which is the normal state for a recycled IP: the
+	// outgoing sandbox keeps its entity, address and all, well after its container is
+	// gone. Which one a List hands back first is not defined, so before the fix the
+	// answer here depended on map iteration order — the point is that it no longer can.
+	createSandbox(t, inmem, sandboxFixture{
+		app:     "db-app",
+		version: "db-app-v1",
+		name:    "db-app-web-dead",
+		service: "web",
+		ip:      ip,
+		status:  compute_v1alpha.DEAD,
+	})
+	live, _ := createSandbox(t, inmem, sandboxFixture{
+		app:     "reviewagent",
+		version: "reviewagent-v1",
+		name:    "reviewagent-web-live",
+		service: "web",
+		ip:      ip,
+		status:  compute_v1alpha.RUNNING,
+	})
+
+	s := newEntityBackedServer(t, inmem)
+
+	require.True(t, s.resolveUnknownIP(ip))
+
+	sandboxID, appName := ownerOf(t, s, ip)
+	assert.Equal(t, live.ID.String(), sandboxID,
+		"a dead sandbox must never outrank a live one for the same IP")
+	assert.Equal(t, "reviewagent", appName)
+}
+
+// TestRefreshSandboxByIPCorrectsStaleMapping covers the escape hatch the token server
+// uses when a caller's secret contradicts the identity an address resolved to: the
+// mapping is re-derived from the entity store and replaced.
+func TestRefreshSandboxByIPCorrectsStaleMapping(t *testing.T) {
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	const ip = "10.8.64.17"
+
+	live, _ := createSandbox(t, inmem, sandboxFixture{
+		app:     "reviewagent",
+		version: "reviewagent-v1",
+		name:    "reviewagent-web-live",
+		service: "web",
+		ip:      ip,
+		status:  compute_v1alpha.RUNNING,
+	})
+
+	s := newEntityBackedServer(t, inmem)
+	s.AddSandboxMapping("sandbox/db-app-web-STALE", ip, "db-app", "web")
+
+	sandboxID, appName, ok := s.RefreshSandboxByIP(ip)
+	require.True(t, ok)
+	assert.Equal(t, live.ID.String(), sandboxID, "refresh should return the address's real owner")
+	assert.Equal(t, "reviewagent", appName)
+
+	cached, _ := ownerOf(t, s, ip)
+	assert.Equal(t, live.ID.String(), cached, "and should leave the corrected mapping behind")
+}
+
+// TestRefreshSandboxByIPKeepsMappingWhenStoreCannotAnswer pins the non-destructive half:
+// a refresh that finds nothing must leave the existing mapping alone rather than blanking
+// out an address because one request failed to authenticate.
+func TestRefreshSandboxByIPKeepsMappingWhenStoreCannotAnswer(t *testing.T) {
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	const ip = "10.8.64.17"
+
+	s := newEntityBackedServer(t, inmem)
+	s.AddSandboxMapping("sandbox/reviewagent-web-LIVE", ip, "reviewagent", "web")
+
+	_, _, ok := s.RefreshSandboxByIP(ip)
+	assert.False(t, ok, "the store has no sandbox at this address")
+
+	sandboxID, _ := ownerOf(t, s, ip)
+	assert.Equal(t, "sandbox/reviewagent-web-LIVE", sandboxID, "the existing mapping should survive")
+}
+
+// TestResolveUnknownIPSkipsDeadSandbox is the same rule with no live claimant: an
+// address that only a dead sandbox holds should not resolve at all. Registering it
+// would hand the next sandbox on that IP an identity it can never authenticate as.
+func TestResolveUnknownIPSkipsDeadSandbox(t *testing.T) {
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	const ip = "10.8.64.17"
+
+	createSandbox(t, inmem, sandboxFixture{
+		app:     "db-app",
+		version: "db-app-v1",
+		name:    "db-app-web-dead",
+		service: "web",
+		ip:      ip,
+		status:  compute_v1alpha.DEAD,
+	})
+
+	s := newEntityBackedServer(t, inmem)
+
+	assert.False(t, s.resolveUnknownIP(ip),
+		"an IP held only by a dead sandbox should not be registered")
+}
+
+// --- fixtures ---
+
+type sandboxFixture struct {
+	app     string
+	version string
+	name    string
+	service string
+	ip      string
+	status  compute_v1alpha.SandboxStatus
+}
+
+func newEntityBackedServer(t *testing.T, inmem *testutils.InMemEntityServer) *Server {
+	t.Helper()
+	s := newTestServer(t)
+	s.log = slog.New(slogfmt.NewTestHandler(t, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	s.entityClient = inmem.EAC
+	return s
+}
+
+// createSandbox builds the app → version → sandbox chain handleSandboxUpdate walks to
+// derive an app name, and returns the decoded sandbox plus its entity.
+func createSandbox(t *testing.T, inmem *testutils.InMemEntityServer, f sandboxFixture) (*compute_v1alpha.Sandbox, *entity.Entity) {
+	t.Helper()
+	ctx := context.Background()
+
+	versionID := entity.Id("app_version/" + f.version)
+	if _, err := inmem.EAC.Get(ctx, versionID.String()); err != nil {
+		appID, err := inmem.Client.Create(ctx, f.app, &core_v1alpha.App{})
+		require.NoError(t, err)
+		_, err = inmem.Client.Create(ctx, f.version, &core_v1alpha.AppVersion{App: appID})
+		require.NoError(t, err)
+	}
+
+	id, err := inmem.Client.Create(ctx, f.name, &compute_v1alpha.Sandbox{
+		Status:  f.status,
+		Network: []compute_v1alpha.Network{{Address: f.ip + "/24"}},
+		Spec:    compute_v1alpha.SandboxSpec{Version: versionID},
+	}, entityserver.WithLabels(types.Labels{
+		{Key: "service", Value: f.service},
+	}))
+	require.NoError(t, err)
+
+	resp, err := inmem.EAC.Get(ctx, id.String())
+	require.NoError(t, err)
+	en := resp.Entity().Entity()
+
+	var sb compute_v1alpha.Sandbox
+	sb.Decode(en)
+	return &sb, en
+}


### PR DESCRIPTION
A sandbox that landed on a recently-recycled pod IP could never get a workload identity token: `403 {"error":"invalid token"}` forever, and restarting the app didn't help. It took biscuit down for ~7 hours on Aug 3, and stayed invisible because it only bites newly created sandboxes. Everything already running holds a valid token and keeps working, so the cluster looks healthy right up until something deploys.

The token server identifies a caller by looking its source address up in the DNS server's map, so that map decides which app an issued token claims to be. Nothing ever fixed a wrong answer: deletes bailed when another entity still claimed the address without re-pointing at the survivor, a tracked live sandbox never re-asserted its own address, and the fallback took the first match regardless of status (so a stopped sandbox, whose entity lingers for up to an hour with its address, could outrank the live one). Ownership is now derived from per-sandbox claims, and the controller registers the mapping itself in BootContainers rather than waiting on the watcher.

There's also a recovery path: a failed secret verification is the signature of a poisoned mapping, so the token server re-derives the owner once and retries. A stale entry costs one rejected request instead of the sandbox's whole life.

Five of the eleven new tests fail against the old code. `miren debug dns` from the issue's remediation notes isn't here: that table is per-runner in-memory state, and reaching it needs a runner-side RPC plus coordinator node routing, which deserves its own change.

Closes MIR-1511
