### PR TITLE
Make automatic schema reindex actually converge

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -49,6 +49,7 @@ import (
 	nodehealthctrl "miren.dev/runtime/controllers/nodehealth"
 	"miren.dev/runtime/controllers/sandboxpool"
 	schedulerctrl "miren.dev/runtime/controllers/scheduler"
+	schemareindexctrl "miren.dev/runtime/controllers/schemareindex"
 	versionctrl "miren.dev/runtime/controllers/version"
 	"miren.dev/runtime/metrics"
 	"miren.dev/runtime/observability"
@@ -354,6 +355,7 @@ type Coordinator struct {
 	ephemeralGC   *ephemeralctrl.GCController
 	versionGC     *versionctrl.GCController
 	indexGC       *indexgcctrl.GCController
+	schemaReindex *schemareindexctrl.Controller
 	hs            *httpingress.Server
 
 	authority *caauth.Authority
@@ -423,6 +425,9 @@ func (c *Coordinator) Stop() {
 	}
 	if c.indexGC != nil {
 		c.indexGC.Stop()
+	}
+	if c.schemaReindex != nil {
+		c.schemaReindex.Stop()
 	}
 	if c.debugServer != nil {
 		if err := c.debugServer.Close(); err != nil {
@@ -908,12 +913,17 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		return err
 	}
 
-	// Best-effort startup maintenance (format migration, short-id backfill, and
-	// reindex) scans the entity store. Bound it with a timeout so that a large or
+	// Best-effort startup maintenance (format migration and short-id backfill)
+	// scans the entity store. Bound it with a timeout so that a large or
 	// not-recently-compacted store fails fast and lets startup continue, rather
 	// than blocking the coordinator — and therefore the edge listener — on an
 	// unbounded read. Each step below already treats failure as non-fatal, so a
 	// timeout simply defers the work to a later startup once compaction catches up.
+	//
+	// Schema reindexing used to run here too and was the step most likely to
+	// exhaust this budget. It now runs in the background (see the schema reindex
+	// controller below), where it can checkpoint and resume instead of losing a
+	// partial pass every time the deadline expired.
 	const startupMaintenanceTimeout = 2 * time.Minute
 	maintCtx, cancelMaint := context.WithTimeout(ctx, startupMaintenanceTimeout)
 	defer cancelMaint()
@@ -938,11 +948,6 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		c.Log.Warn("short-id migration completed with errors", "migrated", sidMigrated, "skipped", sidSkipped, "error", sidErr)
 	} else if sidMigrated > 0 {
 		c.Log.Info("short-id migration completed", "migrated", sidMigrated, "skipped", sidSkipped)
-	}
-
-	// Check if indexes have changed and reindex if needed
-	if err := c.checkAndReindex(maintCtx, etcdStore, client); err != nil {
-		c.Log.Error("automatic reindex failed (will retry next startup)", "error", err)
 	}
 
 	ess, err := entityserver.NewEntityServer(c.Log, etcdStore)
@@ -1269,6 +1274,20 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		Config: indexgcctrl.DefaultGCConfig(),
 	}
 	c.indexGC.Start(ctx)
+
+	// Start the schema reindex controller. It backfills index entries after an
+	// index schema change, checkpointing between bounded passes so a store too
+	// large to reindex in one go still converges. This deliberately runs in the
+	// background rather than during startup: under the old startup-time reindex,
+	// a store that exceeded the maintenance deadline restarted the scan from the
+	// first entity every boot and never reached the tail.
+	c.schemaReindex = &schemareindexctrl.Controller{
+		Log:         c.Log.With("module", "schema-reindex"),
+		Store:       etcdStore,
+		CurrentHash: schema.IndexHash,
+		Config:      schemareindexctrl.DefaultConfig(),
+	}
+	c.schemaReindex.Start(ctx)
 
 	ai := app.NewAppInfo(c.Log, ec, c.Cpu, c.Mem, c.HTTP)
 	server.ExposeValue("dev.miren.runtime/app", app_v1alpha.AdaptCrud(ai))
@@ -1697,55 +1716,4 @@ func (c *Coordinator) CertificateProvider() autotls.CertificateProvider {
 // path is used (which doesn't need port 80).
 func (c *Coordinator) AutocertReadySignal() func() {
 	return c.autocertReady
-}
-
-// checkAndReindex compares the current index hash against the stored hash in etcd.
-// If they differ, it runs a reindex to rebuild missing collection entries.
-func (c *Coordinator) checkAndReindex(ctx context.Context, store *entity.EtcdStore, client *clientv3.Client) error {
-	currentHash := schema.IndexHash()
-	hashKey := c.Prefix + "/meta/index-hash"
-
-	resp, err := client.Get(ctx, hashKey)
-	if err != nil {
-		return fmt.Errorf("failed to read index hash: %w", err)
-	}
-
-	var storedHash string
-	if len(resp.Kvs) > 0 {
-		storedHash = string(resp.Kvs[0].Value)
-	}
-
-	if storedHash == currentHash {
-		c.Log.Debug("index hash unchanged, skipping reindex", "hash", currentHash)
-		return nil
-	}
-
-	c.Log.Info("index schema changed, starting automatic reindex",
-		"stored_hash", storedHash,
-		"current_hash", currentHash)
-
-	// Reindex is the heaviest maintenance step and runs last, inside the shared
-	// startup-maintenance deadline that bounds how long the coordinator blocks
-	// the edge listener. That ceiling is the single bound; don't layer a second
-	// timeout here, which would only ever clamp to whatever's left of it. A
-	// reindex that doesn't finish in time is retried on the next startup (it's
-	// gated on the index hash below).
-	stats, err := store.Reindex(ctx, c.Log, entity.ReindexOptions{
-		DryRun:       false,
-		CleanupStale: false,
-	})
-	if err != nil {
-		return fmt.Errorf("reindex failed: %w", err)
-	}
-
-	c.Log.Info("automatic reindex complete",
-		"entities_processed", stats.EntitiesProcessed,
-		"indexes_rebuilt", stats.IndexesRebuilt)
-
-	_, err = client.Put(ctx, hashKey, currentHash)
-	if err != nil {
-		return fmt.Errorf("failed to store index hash: %w", err)
-	}
-
-	return nil
 }

--- a/controllers/schemareindex/reindex.go
+++ b/controllers/schemareindex/reindex.go
@@ -1,0 +1,258 @@
+// Package schemareindex runs the automatic reindex that follows an index
+// schema change, as a paced background job rather than a startup step.
+//
+// Reindexing used to run inline during coordinator startup under the shared
+// maintenance deadline. A store large enough to exceed that deadline could
+// never converge: the new schema hash is only recorded after a complete pass,
+// and each restart began the scan again from the first entity, so the same
+// prefix was reindexed forever and the tail was never reached. Running here
+// instead, with a cursor persisted between bounded passes, means progress
+// accumulates until the scan genuinely finishes — and it converges without
+// needing a restart at all, which a cursor alone would not give us.
+package schemareindex
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"miren.dev/runtime/pkg/entity"
+)
+
+// Config tunes the background reindex. Defaults are gentle: this is
+// convergence insurance running behind a correct write path, not a foreground
+// repair, so it trades wall-clock for staying out of the way.
+type Config struct {
+	// IdleInterval is how long to wait between checks when the store already
+	// matches the current index schema and there is nothing to do.
+	IdleInterval time.Duration
+	// ActiveInterval is how long to wait between passes while a reindex is in
+	// flight. Much shorter than IdleInterval so a pending reindex drains at a
+	// reasonable clip instead of one pass per idle check.
+	ActiveInterval time.Duration
+	// MaxEntitiesPerPass caps how many entities one pass processes before it
+	// checkpoints and yields. Zero means unbounded, which defeats the purpose
+	// here; the controller substitutes the default.
+	MaxEntitiesPerPass int
+	// BatchPause is slept periodically during a pass to rate-limit write
+	// pressure. Zero disables pacing.
+	BatchPause time.Duration
+	// PassTimeout bounds a single pass. A pass cut short still checkpoints its
+	// cursor, so the next one picks up where it stopped.
+	PassTimeout time.Duration
+}
+
+// DefaultConfig returns the default (gentle) configuration.
+func DefaultConfig() Config {
+	return Config{
+		IdleInterval:       1 * time.Hour,
+		ActiveInterval:     10 * time.Second,
+		MaxEntitiesPerPass: 2000,
+		BatchPause:         100 * time.Millisecond,
+		PassTimeout:        5 * time.Minute,
+	}
+}
+
+// Controller reindexes the entity store in the background whenever the running
+// index schema differs from the one the store was last reindexed against. It
+// works directly against the EtcdStore rather than the entity-access client,
+// since it operates below the index it is repairing.
+//
+// The coordinator is a singleton, so there is no second writer racing the
+// cursor or the hash; the state here needs no locking beyond etcd itself.
+type Controller struct {
+	Log   *slog.Logger
+	Store *entity.EtcdStore
+	// CurrentHash returns the index schema hash of the running binary,
+	// injected rather than called directly because the schema registry sits
+	// above the entity package.
+	CurrentHash func() string
+	Config      Config
+
+	cancel context.CancelFunc
+}
+
+// Start begins the background reindex loop.
+func (c *Controller) Start(ctx context.Context) {
+	// Substitute defaults for anything unset. The intervals matter as much as
+	// the batch size: a zero delay makes time.After fire immediately, turning
+	// the loop into a hot spin that reads the index hash from etcd continuously.
+	defaults := DefaultConfig()
+	if c.Config.MaxEntitiesPerPass <= 0 {
+		c.Config.MaxEntitiesPerPass = defaults.MaxEntitiesPerPass
+	}
+	if c.Config.IdleInterval <= 0 {
+		c.Config.IdleInterval = defaults.IdleInterval
+	}
+	if c.Config.ActiveInterval <= 0 {
+		c.Config.ActiveInterval = defaults.ActiveInterval
+	}
+
+	c.Log.Info("starting schema reindex controller",
+		"idle_interval", c.Config.IdleInterval,
+		"active_interval", c.Config.ActiveInterval,
+		"max_entities_per_pass", c.Config.MaxEntitiesPerPass)
+
+	ctx, c.cancel = context.WithCancel(ctx)
+	go c.run(ctx)
+}
+
+// Stop gracefully stops the controller.
+func (c *Controller) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+func (c *Controller) run(ctx context.Context) {
+	// Always wait before a pass, including the first: startup is busy enough
+	// without a full-keyspace scan joining the boot storm, and a schema change
+	// is not urgent to the second. The write path already indexes new entities
+	// correctly; this only backfills the ones that predate the change.
+	delay := c.Config.ActiveInterval
+
+	for {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			c.Log.Info("schema reindex controller stopped")
+			return
+		}
+
+		if c.step(ctx) {
+			delay = c.Config.ActiveInterval
+		} else {
+			delay = c.Config.IdleInterval
+		}
+	}
+}
+
+// step runs at most one bounded pass. It reports whether work remains, so the
+// caller can come back promptly instead of sleeping out a full idle interval.
+// Like the stale-index sweep, it is strictly best-effort: errors are logged,
+// never propagated, and never block a foreground operation.
+func (c *Controller) step(ctx context.Context) bool {
+	currentHash := c.CurrentHash()
+
+	storedHash, err := c.Store.LoadIndexHash(ctx)
+	if err != nil {
+		c.Log.Warn("schema reindex: failed to read index hash", "error", err)
+		return false
+	}
+
+	if storedHash == currentHash {
+		c.Log.Debug("schema reindex: index hash unchanged, nothing to do", "hash", currentHash)
+		return false
+	}
+
+	state, err := c.Store.LoadReindexState(ctx, c.Log)
+	if err != nil {
+		c.Log.Warn("schema reindex: failed to read reindex state", "error", err)
+		return false
+	}
+
+	// A reindex in flight against a different target means the schema changed
+	// again mid-reindex. Finishing the old scan would stamp a hash the store
+	// doesn't actually match, so restart against the new target instead.
+	if state == nil || state.TargetHash != currentHash {
+		if state != nil {
+			c.Log.Info("schema reindex: index schema changed mid-reindex, restarting scan",
+				"previous_target", state.TargetHash,
+				"new_target", currentHash,
+				"discarded_progress", state.EntitiesProcessed)
+		} else {
+			c.Log.Info("schema reindex: index schema changed, starting reindex",
+				"stored_hash", storedHash,
+				"current_hash", currentHash)
+		}
+		state = &entity.ReindexState{TargetHash: currentHash}
+	}
+
+	passCtx := ctx
+	if c.Config.PassTimeout > 0 {
+		var cancel context.CancelFunc
+		passCtx, cancel = context.WithTimeout(ctx, c.Config.PassTimeout)
+		defer cancel()
+	}
+
+	stats, passErr := c.Store.Reindex(passCtx, c.Log, entity.ReindexOptions{
+		StartKey:    state.Cursor,
+		MaxEntities: c.Config.MaxEntitiesPerPass,
+		BatchPause:  c.Config.BatchPause,
+	})
+	if stats == nil {
+		stats = &entity.ReindexStats{}
+	}
+
+	// Checkpoint whatever the pass covered, even when it ended in error: the
+	// cursor it reached is real progress, and dropping it is what made the old
+	// startup path unable to converge. A complete pass reports no cursor, so
+	// this is skipped there and the state is cleared outright below.
+	if stats.NextCursor != "" {
+		state.Cursor = stats.NextCursor
+		state.EntitiesProcessed += stats.EntitiesProcessed
+		if err := c.Store.SaveReindexState(ctx, state); err != nil {
+			c.Log.Warn("schema reindex: failed to checkpoint progress", "error", err)
+		}
+	}
+
+	if passErr != nil {
+		// A pass cut short by a deadline or shutdown is expected and not
+		// alarming; the next one resumes from the checkpoint above. Warn so a
+		// persistent hard error is still visible.
+		c.Log.Warn("schema reindex: pass ended early",
+			"error", passErr,
+			"processed_this_pass", stats.EntitiesProcessed,
+			"processed_total", state.EntitiesProcessed)
+		return true
+	}
+
+	if !stats.Complete {
+		c.Log.Info("schema reindex: pass checkpointed",
+			"processed_this_pass", stats.EntitiesProcessed,
+			"processed_total", state.EntitiesProcessed)
+		return true
+	}
+
+	// Reaching the end of the keyspace is not the same as having indexed
+	// everything. Entities that failed are logged and skipped mid-scan, so a
+	// pass can be Complete with some left un-indexed; stamping the hash there
+	// would declare consistency we never achieved and, because the hash then
+	// matches, nothing would ever retry them.
+	//
+	// The cursor has already advanced past those entities, so keeping the
+	// checkpoint would not retry them either: the next pass would start after
+	// them, finish clean, and stamp. Rewind to the head instead. Reporting no
+	// work pending paces that retry at IdleInterval rather than
+	// ActiveInterval, so an entity that fails permanently costs one rescan an
+	// hour instead of a continuous loop.
+	if stats.EntitiesFailed > 0 {
+		c.Log.Warn("schema reindex: pass reached the end with failures, will rescan",
+			"entities_failed", stats.EntitiesFailed,
+			"processed_this_pass", stats.EntitiesProcessed)
+
+		state.Cursor = ""
+		if err := c.Store.SaveReindexState(ctx, state); err != nil {
+			c.Log.Warn("schema reindex: failed to rewind checkpoint", "error", err)
+		}
+		return false
+	}
+
+	// Record the hash before clearing the cursor. A crash in between costs one
+	// redundant no-op pass; the reverse order would let a partial reindex look
+	// finished.
+	if err := c.Store.SaveIndexHash(ctx, currentHash); err != nil {
+		c.Log.Warn("schema reindex: failed to record index hash", "error", err)
+		return true
+	}
+	if err := c.Store.ClearReindexState(ctx); err != nil {
+		c.Log.Warn("schema reindex: failed to clear reindex state", "error", err)
+	}
+
+	c.Log.Info("schema reindex complete",
+		"hash", currentHash,
+		"entities_processed", state.EntitiesProcessed+stats.EntitiesProcessed,
+		"indexes_rebuilt", stats.IndexesRebuilt)
+
+	return false
+}

--- a/controllers/schemareindex/reindex_test.go
+++ b/controllers/schemareindex/reindex_test.go
@@ -1,0 +1,301 @@
+package schemareindex
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/etcdtest"
+)
+
+const testIndexedAttr = "test/kind"
+
+// setupStore builds a store holding entityCount entities carrying an indexed
+// attribute, then drops every collection entry. That is the state a schema
+// change leaves behind: entities that predate the new index and have no entries
+// for it.
+func setupStore(t *testing.T, entityCount int) (*entity.EtcdStore, map[entity.Id]bool, *clientv3.Client) {
+	t.Helper()
+
+	client, prefix := etcdtest.TestEtcdClient(t)
+	store, err := entity.NewEtcdStore(t.Context(), slog.Default(), client, prefix)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	_, err = store.CreateEntity(ctx, entity.New(
+		entity.Ident, testIndexedAttr,
+		entity.Doc, "a kind",
+		entity.Cardinality, entity.CardinalityOne,
+		entity.Type, entity.TypeStr,
+		entity.Index, true,
+	))
+	require.NoError(t, err)
+
+	want := map[entity.Id]bool{}
+	for i := range entityCount {
+		e, err := store.CreateEntity(ctx, entity.New(
+			entity.Ident, entity.Id(fmt.Sprintf("entity-%02d", i)),
+			entity.String(entity.Id(testIndexedAttr), "widget"),
+		))
+		require.NoError(t, err)
+		want[e.Id()] = true
+	}
+
+	_, err = client.Delete(ctx, store.Prefix()+"/collections/", clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	ids, err := store.ListIndex(ctx, entity.String(entity.Id(testIndexedAttr), "widget"))
+	require.NoError(t, err)
+	require.Empty(t, ids, "test setup should leave the index empty")
+
+	return store, want, client
+}
+
+func newController(store *entity.EtcdStore, hash func() string, perPass int) *Controller {
+	return &Controller{
+		Log:         slog.Default(),
+		Store:       store,
+		CurrentHash: hash,
+		Config: Config{
+			MaxEntitiesPerPass: perPass,
+		},
+	}
+}
+
+func indexedIDs(t *testing.T, store *entity.EtcdStore) map[entity.Id]bool {
+	t.Helper()
+
+	ids, err := store.ListIndex(t.Context(), entity.String(entity.Id(testIndexedAttr), "widget"))
+	require.NoError(t, err)
+
+	got := map[entity.Id]bool{}
+	for _, id := range ids {
+		got[id] = true
+	}
+	return got
+}
+
+// TestController_ConvergesAcrossInterruptedPasses is the regression test for
+// MIR-1496. A reindex that cannot finish in a single pass must resume from its
+// checkpoint and eventually index every entity, and must not record the new
+// schema hash until it has — recording it early is what stranded entities
+// un-indexed with nothing left to retry.
+func TestController_ConvergesAcrossInterruptedPasses(t *testing.T) {
+	const entityCount = 12
+	store, want, _ := setupStore(t, entityCount)
+	ctx := t.Context()
+
+	const targetHash = "hash-v2"
+	c := newController(store, func() string { return targetHash }, 3)
+
+	passes := 0
+	for {
+		passes++
+		require.Less(t, passes, 100, "reindex failed to converge")
+
+		more := c.step(ctx)
+		if !more {
+			break
+		}
+
+		// Mid-flight: the hash must still be unrecorded, and the checkpoint
+		// must be present and pointed at this target.
+		storedHash, err := store.LoadIndexHash(ctx)
+		require.NoError(t, err)
+		assert.NotEqual(t, targetHash, storedHash,
+			"schema hash recorded before the reindex finished")
+
+		state, err := store.LoadReindexState(ctx, slog.Default())
+		require.NoError(t, err)
+		require.NotNil(t, state, "an in-flight reindex must leave a checkpoint")
+		assert.Equal(t, targetHash, state.TargetHash)
+		assert.NotEmpty(t, state.Cursor)
+	}
+
+	assert.Greater(t, passes, 1, "test did not exercise resumption")
+
+	storedHash, err := store.LoadIndexHash(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, targetHash, storedHash, "completed reindex must record the hash")
+
+	state, err := store.LoadReindexState(ctx, slog.Default())
+	require.NoError(t, err)
+	assert.Nil(t, state, "completed reindex must clear its checkpoint")
+
+	assert.Equal(t, want, indexedIDs(t, store), "every entity must end up indexed")
+}
+
+// TestController_RestartsWhenSchemaChangesMidReindex covers a second schema
+// change landing while a reindex is still draining. Finishing the in-flight
+// scan would stamp a hash the store doesn't match, so the scan must restart
+// against the new target.
+func TestController_RestartsWhenSchemaChangesMidReindex(t *testing.T) {
+	const entityCount = 12
+	store, want, _ := setupStore(t, entityCount)
+	ctx := t.Context()
+
+	hash := "hash-v2"
+	c := newController(store, func() string { return hash }, 3)
+
+	require.True(t, c.step(ctx), "expected the first pass to leave work behind")
+
+	state, err := store.LoadReindexState(ctx, slog.Default())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, "hash-v2", state.TargetHash)
+	firstCursor := state.Cursor
+	require.NotEmpty(t, firstCursor)
+
+	// Schema changes again before the reindex drains.
+	hash = "hash-v3"
+
+	require.True(t, c.step(ctx), "expected the restarted pass to leave work behind")
+
+	state, err = store.LoadReindexState(ctx, slog.Default())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, "hash-v3", state.TargetHash, "checkpoint must retarget")
+	assert.LessOrEqual(t, state.Cursor, firstCursor,
+		"a retargeted reindex must rescan from the head, not continue the stale cursor")
+
+	for i := 0; c.step(ctx); i++ {
+		require.Less(t, i, 100, "reindex failed to converge after retarget")
+	}
+
+	storedHash, err := store.LoadIndexHash(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "hash-v3", storedHash, "must record the hash it actually reindexed for")
+	assert.Equal(t, want, indexedIDs(t, store))
+}
+
+// TestController_DoesNotRecordHashWhenEntitiesFail is the second half of the
+// convergence guarantee. Reaching the end of the keyspace is not the same as
+// having indexed everything: entities that fail are logged and skipped, so a
+// pass can complete with some left un-indexed. Stamping the hash there would
+// declare a consistency we never reached, and because the stored hash would
+// then match, nothing would ever retry them.
+func TestController_DoesNotRecordHashWhenEntitiesFail(t *testing.T) {
+	store, _, client := setupStore(t, 4)
+	ctx := t.Context()
+
+	// An entity whose key reads fine but whose value cannot be decoded.
+	_, err := client.Put(ctx,
+		store.Prefix()+"/entity/"+base58.Encode([]byte("corrupt-entity")),
+		"this is not a valid encoded entity")
+	require.NoError(t, err)
+
+	const targetHash = "hash-v2"
+	c := newController(store, func() string { return targetHash }, 100)
+
+	// One unbounded-enough pass reaches the end of the keyspace, but hits the
+	// corrupt entity on the way.
+	assert.False(t, c.step(ctx),
+		"a failed pass must report no work pending so the retry paces at IdleInterval")
+
+	storedHash, err := store.LoadIndexHash(ctx)
+	require.NoError(t, err)
+	assert.NotEqual(t, targetHash, storedHash,
+		"hash must not be recorded while entities are still failing")
+
+	state, err := store.LoadReindexState(ctx, slog.Default())
+	require.NoError(t, err)
+	require.NotNil(t, state, "a failed pass must keep its checkpoint so the work is retried")
+	assert.Equal(t, targetHash, state.TargetHash)
+	assert.Empty(t, state.Cursor,
+		"cursor must rewind to the head, since it already advanced past the failures")
+
+	// Once the bad entity is gone, the next pass converges and stamps.
+	_, err = client.Delete(ctx, store.Prefix()+"/entity/"+base58.Encode([]byte("corrupt-entity")))
+	require.NoError(t, err)
+
+	for i := 0; c.step(ctx); i++ {
+		require.Less(t, i, 100, "reindex failed to converge after the failure cleared")
+	}
+
+	storedHash, err = store.LoadIndexHash(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, targetHash, storedHash, "a clean pass must record the hash")
+}
+
+// TestController_StartNormalizesConfig guards the hot-spin failure mode: a
+// partial Config leaves the intervals at zero, and time.After(0) fires
+// immediately, turning the loop into a continuous read of the index hash.
+func TestController_StartNormalizesConfig(t *testing.T) {
+	store, _, _ := setupStore(t, 1)
+
+	c := &Controller{
+		Log:         slog.Default(),
+		Store:       store,
+		CurrentHash: func() string { return "hash-v2" },
+	}
+	c.Start(t.Context())
+	t.Cleanup(c.Stop)
+
+	defaults := DefaultConfig()
+	assert.Equal(t, defaults.IdleInterval, c.Config.IdleInterval)
+	assert.Equal(t, defaults.ActiveInterval, c.Config.ActiveInterval)
+	assert.Equal(t, defaults.MaxEntitiesPerPass, c.Config.MaxEntitiesPerPass)
+}
+
+// TestController_NoopWhenHashMatches keeps the idle path cheap: a store already
+// consistent with the running schema must do no work and report nothing pending.
+func TestController_NoopWhenHashMatches(t *testing.T) {
+	store, _, _ := setupStore(t, 4)
+	ctx := t.Context()
+
+	const targetHash = "hash-v2"
+	require.NoError(t, store.SaveIndexHash(ctx, targetHash))
+
+	c := newController(store, func() string { return targetHash }, 3)
+
+	assert.False(t, c.step(ctx), "matching hash must report no work pending")
+
+	state, err := store.LoadReindexState(ctx, slog.Default())
+	require.NoError(t, err)
+	assert.Nil(t, state, "no-op step must not create a checkpoint")
+
+	// The index stays empty because nothing ran, confirming the short-circuit
+	// happened before any scan rather than after a silent full pass.
+	assert.Empty(t, indexedIDs(t, store))
+}
+
+// TestController_ResumesAfterProcessRestart simulates the coordinator bouncing
+// mid-reindex: a brand-new controller sharing only the persisted state must
+// pick up from the checkpoint rather than starting over.
+func TestController_ResumesAfterProcessRestart(t *testing.T) {
+	const entityCount = 12
+	store, want, _ := setupStore(t, entityCount)
+	ctx := t.Context()
+
+	const targetHash = "hash-v2"
+	hashFn := func() string { return targetHash }
+
+	require.True(t, newController(store, hashFn, 3).step(ctx))
+
+	state, err := store.LoadReindexState(ctx, slog.Default())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	resumeFrom := state.Cursor
+
+	// A fresh controller, as if the process had restarted.
+	c := newController(store, hashFn, 3)
+	require.True(t, c.step(ctx))
+
+	state, err = store.LoadReindexState(ctx, slog.Default())
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Greater(t, state.Cursor, resumeFrom,
+		"a restarted controller must advance the cursor, not restart the scan")
+
+	for i := 0; c.step(ctx); i++ {
+		require.Less(t, i, 100, "reindex failed to converge after restart")
+	}
+
+	assert.Equal(t, want, indexedIDs(t, store))
+}

--- a/pkg/entity/reindex.go
+++ b/pkg/entity/reindex.go
@@ -6,10 +6,26 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/mr-tron/base58"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	"miren.dev/runtime/pkg/cond"
 )
+
+const (
+	// reindexBatchSize is how many entities we process between rate-limit
+	// pauses, mirroring cleanupDeleteBatchSize on the cleanup path.
+	reindexBatchSize = 100
+	// reindexProgressInterval is how often a running pass logs progress. A
+	// full reindex on a large store walks tens of thousands of entities, so
+	// this is coarse enough to stay readable in the coordinator log.
+	reindexProgressInterval = 1000
+)
+
+// errReindexBudgetExhausted stops the scan once a bounded pass has processed
+// MaxEntities. It is a control signal, never surfaced to callers.
+var errReindexBudgetExhausted = errors.New("reindex: pass budget exhausted")
 
 // ReindexStats holds statistics about a reindex operation.
 type ReindexStats struct {
@@ -18,76 +34,143 @@ type ReindexStats struct {
 	CollectionEntriesScanned int64
 	StaleEntriesFound        int64
 	StaleEntriesRemoved      int64
+
+	// Complete reports whether the pass reached the end of the entity
+	// keyspace. Only a complete pass has observed every entity, so only a
+	// complete pass may be used to conclude the store matches the current
+	// index schema and stamp the new hash.
+	//
+	// Complete is about coverage, not success: check EntitiesFailed too. A
+	// pass can reach the end of the keyspace while individual entities failed
+	// to index, and treating that as consistent would strand them.
+	Complete bool
+
+	// EntitiesFailed counts entities the pass could not index, either because
+	// the entity could not be read or because a collection write was rejected.
+	// Failures are logged and skipped rather than aborting the scan, so this
+	// is the only signal that a pass which reached the end of the keyspace did
+	// not actually finish the job.
+	EntitiesFailed int64
+
+	// NextCursor is the key to resume at, set whenever the pass stopped early
+	// (budget exhausted, deadline, or shutdown). It is populated even when
+	// Reindex returns an error, so a caller that is interrupted can still
+	// persist the progress it made.
+	NextCursor string
 }
 
 // ReindexOptions controls the behavior of a reindex operation.
 type ReindexOptions struct {
 	DryRun       bool
 	CleanupStale bool
+
+	// StartKey resumes the entity scan at a cursor from an earlier pass's
+	// ReindexStats.NextCursor. Zero scans from the beginning.
+	StartKey string
+
+	// MaxEntities caps how many entities a single pass processes before it
+	// stops and reports a resume cursor, so a large store is reindexed across
+	// several bounded passes rather than one unbounded run. Zero means
+	// unbounded (the manual `miren debug reindex` big hammer).
+	MaxEntities int
+
+	// BatchPause is slept after every reindexBatchSize entities to rate-limit
+	// write pressure. Zero disables pacing.
+	BatchPause time.Duration
 }
 
-// Reindex rebuilds all index (collection) entries for every entity in the store.
-// If opts.CleanupStale is true, it also scans for and removes stale collection entries
-// that point to non-existent entities.
+// Reindex rebuilds index (collection) entries for entities in the store,
+// streaming the entity keyspace in bounded pages rather than materializing
+// every ID up front.
+//
+// A pass may be bounded with opts.MaxEntities and resumed from a later pass via
+// stats.NextCursor, so a store too large to reindex inside one deadline still
+// converges across several passes. Resuming forward-only is safe because the
+// process running the reindex already has the current index schema loaded:
+// anything written while it runs is indexed correctly on the write path, so
+// only pre-existing entities need backfill and their keys don't move. The
+// coordinator is a singleton, so there is no concurrent writer running an older
+// schema that could land un-indexed entities behind the cursor.
+//
+// If opts.CleanupStale is true, a pass that runs to completion also scans for
+// and removes stale collection entries that point to non-existent entities.
 func (s *EtcdStore) Reindex(ctx context.Context, log *slog.Logger, opts ReindexOptions) (*ReindexStats, error) {
 	s.ClearSchemaCache()
 
 	stats := &ReindexStats{}
 
-	// Phase 1: List all entities and rebuild indexes
-	allEntityIDs, err := s.ListAllEntityIDs(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list entities: %w", err)
+	// Phase 1: stream the entity keyspace and rebuild indexes.
+	entityPrefix := fmt.Sprintf("%s/entity/", s.prefix)
+
+	var scanOpts []scanOption
+	if opts.StartKey != "" {
+		scanOpts = append(scanOpts, withStartKey(opts.StartKey))
+		log.Info("reindex: resuming entity scan", "cursor", opts.StartKey)
+	} else {
+		log.Info("reindex: starting entity scan")
 	}
 
-	log.Info("reindex: found entities", "count", len(allEntityIDs))
-
-	log.Info("reindex: rebuilding indexes for current entities")
-	for i, id := range allEntityIDs {
-		select {
-		case <-ctx.Done():
-			return stats, ctx.Err()
-		default:
+	scanErr := scanPagedFunc(ctx, s.client, entityPrefix, func(kv *mvccpb.KeyValue) error {
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 
-		ent, err := s.GetEntity(ctx, id)
-		if err != nil {
-			if errors.Is(err, cond.ErrNotFound{}) {
-				continue
-			}
-			log.Warn("reindex: failed to get entity", "id", id, "error", err)
-			continue
+		key := string(kv.Key)
+		id, ok := entityIDFromKey(log, entityPrefix, key)
+		if !ok {
+			return nil
 		}
 
-		if !opts.DryRun {
-			indexedAttrs := collectIndexedAttributesTolerant(ctx, s, ent.Attrs())
-			for _, attrs := range indexedAttrs {
-				for _, attr := range attrs {
-					err := s.addToCollectionDirect(ctx, ent, attr.CAS())
-					if err != nil {
-						log.Warn("reindex: failed to add to collection", "id", id, "attr", attr.ID, "error", err)
-					} else {
-						stats.IndexesRebuilt++
-					}
-				}
-			}
-		}
+		s.reindexEntity(ctx, log, id, opts, stats)
 
+		// Advance strictly past this key only after the entity is done. Index
+		// writes are idempotent, so a cursor that lags by one entity costs at
+		// most a repeat on resume, never a gap.
+		stats.NextCursor = key + "\x00"
 		stats.EntitiesProcessed++
 
-		if (i+1)%100 == 0 {
+		if stats.EntitiesProcessed%reindexProgressInterval == 0 {
 			log.Info("reindex: progress",
 				"processed", stats.EntitiesProcessed,
-				"total", len(allEntityIDs),
-				"percent", (i+1)*100/len(allEntityIDs))
+				"indexes_rebuilt", stats.IndexesRebuilt)
 		}
+
+		if opts.MaxEntities > 0 && stats.EntitiesProcessed >= int64(opts.MaxEntities) {
+			return errReindexBudgetExhausted
+		}
+
+		if opts.BatchPause > 0 && stats.EntitiesProcessed%reindexBatchSize == 0 {
+			select {
+			case <-time.After(opts.BatchPause):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		return nil
+	}, scanOpts...)
+
+	switch {
+	case scanErr == nil:
+		stats.Complete = true
+		stats.NextCursor = ""
+	case errors.Is(scanErr, errReindexBudgetExhausted):
+		log.Info("reindex: pass budget reached, will resume",
+			"processed", stats.EntitiesProcessed,
+			"cursor", stats.NextCursor)
+	default:
+		// Return the stats alongside the error: the cursor recorded so far is
+		// still valid progress, and an interrupted caller should persist it.
+		return stats, fmt.Errorf("failed to scan entities: %w", scanErr)
 	}
 
 	// Phase 2: Clean up stale index entries (optional). Delegates to the shared,
 	// CAS-guarded cleanup used by the background sweeper so both paths remove
 	// orphans the same safe way. Manual reindex is the "big hammer": unbounded
-	// deletes, no pacing.
-	if opts.CleanupStale {
+	// deletes, no pacing. It is gated on a complete pass because a partial one
+	// hasn't seen every entity and the cleanup's own scan is full-keyspace
+	// regardless, so running it per-pass would be pure waste.
+	if opts.CleanupStale && stats.Complete {
 		log.Info("reindex: cleaning up stale index entries")
 		cleanup, err := s.CleanupStaleCollectionEntries(ctx, log, CleanupOptions{DryRun: opts.DryRun})
 		if err != nil {
@@ -100,14 +183,76 @@ func (s *EtcdStore) Reindex(ctx context.Context, log *slog.Logger, opts ReindexO
 		}
 	}
 
-	log.Info("reindex: complete",
+	log.Info("reindex: pass finished",
+		"complete", stats.Complete,
 		"entities_processed", stats.EntitiesProcessed,
+		"entities_failed", stats.EntitiesFailed,
 		"indexes_rebuilt", stats.IndexesRebuilt,
 		"collection_entries_scanned", stats.CollectionEntriesScanned,
 		"stale_entries_found", stats.StaleEntriesFound,
 		"stale_entries_removed", stats.StaleEntriesRemoved)
 
 	return stats, nil
+}
+
+// entityIDFromKey decodes an entity ID from its store key, reporting false for
+// keys that aren't entities.
+func entityIDFromKey(log *slog.Logger, entityPrefix, key string) (Id, bool) {
+	suffix := strings.TrimPrefix(key, entityPrefix)
+	if suffix == "" {
+		return "", false
+	}
+
+	// Session attributes live under the owning entity's key
+	// (`.../entity/<id>/session/<session>`) and carry nothing to index. Test the
+	// suffix rather than the whole key: a store prefix that happened to contain
+	// "/session/" would otherwise skip every entity in the store, and the pass
+	// would report a clean reindex having indexed nothing.
+	if strings.Contains(suffix, "/session/") {
+		return "", false
+	}
+
+	decoded, err := base58.Decode(suffix)
+	if err != nil {
+		log.Warn("reindex: failed to decode entity ID", "key", suffix, "error", err)
+		return "", false
+	}
+
+	return Id(decoded), true
+}
+
+// reindexEntity rewrites the collection entries for a single entity. Failures
+// are logged rather than aborting the pass, since one unreadable entity must
+// not stop a scan that is otherwise making progress, but they are counted in
+// stats.EntitiesFailed so the caller can tell a genuinely complete pass from
+// one that merely reached the end of the keyspace. An entity that has since
+// been deleted is not a failure; there is simply nothing left to index.
+func (s *EtcdStore) reindexEntity(ctx context.Context, log *slog.Logger, id Id, opts ReindexOptions, stats *ReindexStats) {
+	ent, err := s.GetEntity(ctx, id)
+	if err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			return
+		}
+		log.Warn("reindex: failed to get entity", "id", id, "error", err)
+		stats.EntitiesFailed++
+		return
+	}
+
+	if opts.DryRun {
+		return
+	}
+
+	indexedAttrs := collectIndexedAttributesTolerant(ctx, s, ent.Attrs())
+	for _, attrs := range indexedAttrs {
+		for _, attr := range attrs {
+			if err := s.addToCollectionDirect(ctx, ent, attr.CAS()); err != nil {
+				log.Warn("reindex: failed to add to collection", "id", id, "attr", attr.ID, "error", err)
+				stats.EntitiesFailed++
+				continue
+			}
+			stats.IndexesRebuilt++
+		}
+	}
 }
 
 // collectIndexedAttributesTolerant is like EtcdStore.collectIndexedAttributes but

--- a/pkg/entity/reindex_state.go
+++ b/pkg/entity/reindex_state.go
@@ -1,0 +1,101 @@
+package entity
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+)
+
+// Reindex bookkeeping lives under the store's /meta/ prefix. index-hash records
+// the index schema the store is known to be consistent with; reindex-state
+// records the progress of a reindex working toward a new one. They are written
+// in that order — state cleared only after the hash lands — so a crash between
+// the two re-runs a final no-op pass rather than declaring a partial reindex
+// finished.
+const (
+	indexHashSuffix    = "/meta/index-hash"
+	reindexStateSuffix = "/meta/reindex-state"
+)
+
+// ReindexState is the persisted progress of an in-flight schema reindex, so a
+// reindex too large to finish in one pass resumes where it stopped instead of
+// restarting from the beginning on every coordinator boot.
+type ReindexState struct {
+	// TargetHash is the index schema hash this reindex is working toward. If it
+	// no longer matches the running schema the work in flight is stale, and the
+	// scan must restart from the beginning against the new target.
+	TargetHash string `json:"target_hash"`
+
+	// Cursor is the entity key to resume the scan at.
+	Cursor string `json:"cursor"`
+
+	// EntitiesProcessed counts entities covered across every pass so far. It is
+	// operator visibility only; nothing keys off it.
+	EntitiesProcessed int64 `json:"entities_processed"`
+}
+
+// LoadIndexHash returns the index schema hash the store is recorded as being
+// consistent with. An empty string means no reindex has ever completed.
+func (s *EtcdStore) LoadIndexHash(ctx context.Context) (string, error) {
+	resp, err := s.client.Get(ctx, s.prefix+indexHashSuffix)
+	if err != nil {
+		return "", fmt.Errorf("failed to read index hash: %w", err)
+	}
+	if len(resp.Kvs) == 0 {
+		return "", nil
+	}
+	return string(resp.Kvs[0].Value), nil
+}
+
+// SaveIndexHash records that the store is consistent with hash. Only call this
+// after a reindex pass that ran to completion: it is the gate that stops the
+// work from being retried, so writing it early strands entities un-indexed with
+// nothing left to notice.
+func (s *EtcdStore) SaveIndexHash(ctx context.Context, hash string) error {
+	if _, err := s.client.Put(ctx, s.prefix+indexHashSuffix, hash); err != nil {
+		return fmt.Errorf("failed to store index hash: %w", err)
+	}
+	return nil
+}
+
+// LoadReindexState returns the in-flight reindex progress, or nil if there is
+// none. Unreadable or corrupt state is reported as absent rather than as an
+// error: the safe fallback is a reindex from scratch, which is idempotent.
+func (s *EtcdStore) LoadReindexState(ctx context.Context, log *slog.Logger) (*ReindexState, error) {
+	resp, err := s.client.Get(ctx, s.prefix+reindexStateSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read reindex state: %w", err)
+	}
+	if len(resp.Kvs) == 0 {
+		return nil, nil
+	}
+
+	var state ReindexState
+	if err := json.Unmarshal(resp.Kvs[0].Value, &state); err != nil {
+		log.Warn("reindex: discarding unreadable reindex state, restarting scan", "error", err)
+		return nil, nil
+	}
+
+	return &state, nil
+}
+
+// SaveReindexState persists reindex progress so the next pass resumes from it.
+func (s *EtcdStore) SaveReindexState(ctx context.Context, state *ReindexState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal reindex state: %w", err)
+	}
+	if _, err := s.client.Put(ctx, s.prefix+reindexStateSuffix, string(data)); err != nil {
+		return fmt.Errorf("failed to store reindex state: %w", err)
+	}
+	return nil
+}
+
+// ClearReindexState removes in-flight reindex progress, marking the work done.
+func (s *EtcdStore) ClearReindexState(ctx context.Context) error {
+	if _, err := s.client.Delete(ctx, s.prefix+reindexStateSuffix); err != nil {
+		return fmt.Errorf("failed to clear reindex state: %w", err)
+	}
+	return nil
+}

--- a/pkg/entity/reindex_test.go
+++ b/pkg/entity/reindex_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -121,6 +122,243 @@ func TestReindex_Idempotent(t *testing.T) {
 	ids, err := store.ListIndex(ctx, String(Id("test/kind"), "widget"))
 	require.NoError(t, err)
 	assert.Len(t, ids, 1)
+}
+
+// TestReindex_ResumesAcrossBoundedPasses is the core convergence property: a
+// store too large to reindex in one pass must still reach every entity by
+// resuming from the cursor, and must not report completion until it has.
+func TestReindex_ResumesAcrossBoundedPasses(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	const entityCount = 12
+	want := map[Id]bool{}
+	for i := range entityCount {
+		e, err := store.CreateEntity(ctx, New(
+			Ident, Id(fmt.Sprintf("entity-%02d", i)),
+			String(Id("test/kind"), "widget"),
+		))
+		require.NoError(t, err)
+		want[e.Id()] = true
+	}
+
+	// Drop every collection entry, simulating entities written before the
+	// indexed attribute existed.
+	_, err = client.Delete(ctx, store.Prefix()+"/collections/", clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	ids, err := store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	require.Empty(t, ids)
+
+	const perPass = 3
+	var (
+		cursor   string
+		passes   int
+		complete bool
+	)
+	for !complete {
+		passes++
+		require.Less(t, passes, 100, "reindex failed to converge")
+
+		stats, err := store.Reindex(ctx, slog.Default(), ReindexOptions{
+			StartKey:    cursor,
+			MaxEntities: perPass,
+		})
+		require.NoError(t, err)
+		assert.LessOrEqual(t, stats.EntitiesProcessed, int64(perPass),
+			"pass overran its entity budget")
+
+		if !stats.Complete {
+			require.NotEmpty(t, stats.NextCursor, "incomplete pass must report a cursor")
+			require.Greater(t, stats.NextCursor, cursor, "cursor must move forward")
+		}
+
+		cursor = stats.NextCursor
+		complete = stats.Complete
+	}
+
+	// The store holds schema entities too, so the exact pass count depends on
+	// the base schema; what matters is that it took more than one.
+	assert.Greater(t, passes, 1, "test did not exercise resumption")
+
+	ids, err = store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	assert.Len(t, ids, entityCount)
+
+	got := map[Id]bool{}
+	for _, id := range ids {
+		got[id] = true
+	}
+	assert.Equal(t, want, got, "every entity must be indexed once the passes complete")
+}
+
+// TestReindex_BoundedPassIsIdempotentOnReplay covers the cursor lagging by one
+// entity after a crash: replaying a pass from a stale cursor must not corrupt
+// or duplicate index entries.
+func TestReindex_BoundedPassIsIdempotentOnReplay(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	for i := range 6 {
+		_, err := store.CreateEntity(ctx, New(
+			Ident, Id(fmt.Sprintf("entity-%02d", i)),
+			String(Id("test/kind"), "widget"),
+		))
+		require.NoError(t, err)
+	}
+
+	_, err = client.Delete(ctx, store.Prefix()+"/collections/", clientv3.WithPrefix())
+	require.NoError(t, err)
+
+	first, err := store.Reindex(ctx, slog.Default(), ReindexOptions{MaxEntities: 4})
+	require.NoError(t, err)
+	require.False(t, first.Complete)
+
+	// Replay the same range from the beginning rather than from the cursor,
+	// then continue. Convergence must not depend on each entity being visited
+	// exactly once.
+	_, err = store.Reindex(ctx, slog.Default(), ReindexOptions{MaxEntities: 4})
+	require.NoError(t, err)
+
+	cursor := first.NextCursor
+	for {
+		stats, err := store.Reindex(ctx, slog.Default(), ReindexOptions{
+			StartKey:    cursor,
+			MaxEntities: 4,
+		})
+		require.NoError(t, err)
+		cursor = stats.NextCursor
+		if stats.Complete {
+			break
+		}
+	}
+
+	ids, err := store.ListIndex(ctx, String(Id("test/kind"), "widget"))
+	require.NoError(t, err)
+	assert.Len(t, ids, 6, "replayed passes must not duplicate index entries")
+}
+
+// TestReindex_UnboundedPassCompletesInOne keeps the manual `miren debug
+// reindex` contract intact: no budget means one complete pass, no cursor.
+func TestReindex_UnboundedPassCompletesInOne(t *testing.T) {
+	store, _ := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "entity-1",
+		String(Id("test/kind"), "widget"),
+	))
+	require.NoError(t, err)
+
+	stats, err := store.Reindex(ctx, slog.Default(), ReindexOptions{})
+	require.NoError(t, err)
+	assert.True(t, stats.Complete)
+	assert.Empty(t, stats.NextCursor)
+}
+
+func TestEntityIDFromKey(t *testing.T) {
+	log := slog.Default()
+	id := base58.Encode([]byte("some-entity"))
+
+	t.Run("decodes an entity key", func(t *testing.T) {
+		got, ok := entityIDFromKey(log, "/p/entity/", "/p/entity/"+id)
+		require.True(t, ok)
+		assert.Equal(t, Id("some-entity"), got)
+	})
+
+	t.Run("skips session attribute keys", func(t *testing.T) {
+		_, ok := entityIDFromKey(log, "/p/entity/", "/p/entity/"+id+"/session/"+id)
+		assert.False(t, ok)
+	})
+
+	t.Run("tolerates a store prefix containing /session/", func(t *testing.T) {
+		// Matching on the whole key would skip every entity in a store whose
+		// prefix happens to contain this segment, and the pass would report a
+		// clean reindex having indexed nothing.
+		prefix := "/tenants/session/acme/entity/"
+		got, ok := entityIDFromKey(log, prefix, prefix+id)
+		require.True(t, ok)
+		assert.Equal(t, Id("some-entity"), got)
+	})
+
+	t.Run("skips the bare prefix", func(t *testing.T) {
+		_, ok := entityIDFromKey(log, "/p/entity/", "/p/entity/")
+		assert.False(t, ok)
+	})
+
+	t.Run("skips undecodable keys", func(t *testing.T) {
+		_, ok := entityIDFromKey(log, "/p/entity/", "/p/entity/not!valid!base58")
+		assert.False(t, ok)
+	})
+}
+
+// TestReindex_CountsFailedEntities pins the distinction between a pass that
+// reached the end of the keyspace and one that actually indexed everything.
+// Without the count, an unreadable entity is silently skipped, the pass reports
+// Complete, and the caller stamps a schema hash the store does not match.
+func TestReindex_CountsFailedEntities(t *testing.T) {
+	store, client := setupReindexTestStore(t)
+	ctx := t.Context()
+
+	_, err := store.CreateEntity(ctx, New(
+		Ident, "test/kind",
+		Doc, "a kind",
+		Cardinality, CardinalityOne,
+		Type, TypeStr,
+		Index, true,
+	))
+	require.NoError(t, err)
+
+	_, err = store.CreateEntity(ctx, New(
+		Ident, "entity-1",
+		String(Id("test/kind"), "widget"),
+	))
+	require.NoError(t, err)
+
+	clean, err := store.Reindex(ctx, slog.Default(), ReindexOptions{})
+	require.NoError(t, err)
+	require.True(t, clean.Complete)
+	require.Zero(t, clean.EntitiesFailed, "healthy store must report no failures")
+
+	// Write an entity key whose value can't be decoded, standing in for any
+	// entity the pass can read the key of but not load.
+	_, err = client.Put(ctx,
+		store.Prefix()+"/entity/"+base58.Encode([]byte("corrupt-entity")),
+		"this is not a valid encoded entity")
+	require.NoError(t, err)
+
+	stats, err := store.Reindex(ctx, slog.Default(), ReindexOptions{})
+	require.NoError(t, err)
+	assert.True(t, stats.Complete, "scan still reaches the end of the keyspace")
+	assert.Positive(t, stats.EntitiesFailed, "unreadable entity must be counted as a failure")
 }
 
 func TestReindex_StaleCleanup(t *testing.T) {

--- a/pkg/entity/scan.go
+++ b/pkg/entity/scan.go
@@ -14,6 +14,7 @@ const defaultScanPageSize = 500
 type scanConfig struct {
 	pageSize int64
 	keysOnly bool
+	startKey string
 }
 
 type scanOption func(*scanConfig)
@@ -28,6 +29,21 @@ func withKeysOnly() scanOption {
 // withPageSize overrides the default per-request page size.
 func withPageSize(n int64) scanOption {
 	return func(c *scanConfig) { c.pageSize = n }
+}
+
+// withStartKey begins the scan at key rather than at the head of the prefix,
+// letting a caller resume a scan it stopped partway through. Keys strictly
+// before it are skipped; the range end is still the prefix, so the scan stays
+// bounded to the same keyspace.
+//
+// Resuming this way starts a *fresh* scan at the current revision rather than
+// continuing the original one, since the revision a previous pass pinned to may
+// well be compacted away by now. That means the skipped prefix is only as
+// accurate as the moment it was scanned, so this is for callers whose skipped
+// range is known not to need revisiting. A key at or before the prefix is
+// ignored, so a zero value scans from the head.
+func withStartKey(key string) scanOption {
+	return func(c *scanConfig) { c.startKey = key }
 }
 
 // scanPaged reads every key/value under prefix in ascending key order, fetching
@@ -71,7 +87,9 @@ func scanPagedFunc(ctx context.Context, client *clientv3.Client, prefix string, 
 		getOpts = append(getOpts, clientv3.WithKeysOnly())
 	}
 
-	next := prefix
+	// A start key at or before the prefix would widen the scan; clamp it so the
+	// range stays bounded to the prefix and a zero value means "from the head".
+	next := max(prefix, cfg.startKey)
 	first := true
 	for {
 		resp, err := client.Get(ctx, next, getOpts...)

--- a/pkg/entity/scan_test.go
+++ b/pkg/entity/scan_test.go
@@ -52,6 +52,36 @@ func TestScanPaged(t *testing.T) {
 		}
 	})
 
+	t.Run("start key resumes mid-prefix", func(t *testing.T) {
+		r := require.New(t)
+
+		start := fmt.Sprintf("%skey-%03d", prefix, 10)
+		kvs, err := scanPaged(ctx, client, prefix, withPageSize(4), withStartKey(start))
+		r.NoError(err)
+		r.Len(kvs, total-10)
+		r.Equal(start, string(kvs[0].Key))
+		r.Equal(fmt.Sprintf("%skey-%03d", prefix, total-1), string(kvs[len(kvs)-1].Key))
+	})
+
+	t.Run("start key past the prefix returns nothing", func(t *testing.T) {
+		r := require.New(t)
+
+		kvs, err := scanPaged(ctx, client, prefix, withStartKey(prefix+"key-999"))
+		r.NoError(err)
+		r.Empty(kvs)
+	})
+
+	t.Run("start key before the prefix scans from the head", func(t *testing.T) {
+		r := require.New(t)
+
+		// Clamped rather than honored: an out-of-range cursor must not widen the
+		// scan to sibling keyspaces.
+		kvs, err := scanPaged(ctx, client, prefix, withPageSize(10), withStartKey(basePrefix))
+		r.NoError(err)
+		r.Len(kvs, total)
+		r.Equal(fmt.Sprintf("%skey-%03d", prefix, 0), string(kvs[0].Key))
+	})
+
 	t.Run("empty prefix returns nothing", func(t *testing.T) {
 		r := require.New(t)
 


### PR DESCRIPTION
During the #991 rollout, Club noticed the index schema hash had changed and kicked off the automatic full reindex. It found 87,959 entities, got through about 14,300, then hit the two-minute startup maintenance deadline. The log said it would retry next startup, which sounds reassuring right up until you notice it can't work. The new hash is only written after a complete pass, and each boot restarted the scan from the very first entity. Same prefix, every time, forever. Adding an indexed attribute could leave existing entities missing their new collection entries indefinitely, and the stale-index GC doesn't rescue this since it only removes entries whose backing entity is gone.

The first rev makes the reindex resumable. It had been listing every entity ID up front and walking the slice from index zero, so there was nowhere to put a cursor even if we'd wanted one. It now streams the keyspace through the paged scanner, bounding memory by a page instead of by an 88k-element slice, and a pass can be capped, paced, and resumed from a start key. Stats now come back alongside an error rather than instead of one, because a cursor reached before a deadline expired is still real progress, and discarding it is precisely the bug.

The second rev moves the work off startup into a background controller next to the stale-index GC. We considered just bolting a cursor onto the startup reindex, but that only converges if the cluster keeps restarting, and a long-lived coordinator would sit there unconverged. Resuming forward-only is safe because the coordinator already has the new schema loaded, so anything written while it runs is indexed correctly on the write path; only pre-existing entities need backfill and their keys don't move. It's a singleton, so no older writer can land un-indexed entities behind the cursor. If the schema changes again mid-reindex the cursor resets, since finishing the stale scan would stamp a hash the store doesn't match. The regression test interrupts a reindex partway, resumes it, and asserts the hash stays unrecorded until every entity is indexed.

The `/meta/index-hash` key keeps its name so existing clusters carry over with no migration, and manual `miren debug reindex` is untouched. Worth re-evaluating MIR-981 rather than folding it in here: its value was fitting inside the startup deadline, and this removes that deadline.

Closes MIR-1496
