### PR TITLE
Check archive entry names with filepath.IsLocal

### DIFF
--- a/pkg/release/downloader.go
+++ b/pkg/release/downloader.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"miren.dev/runtime/pkg/tarx"
 )
 
 // Downloader handles artifact downloads from the asset service
@@ -301,26 +303,14 @@ func (d *assetDownloader) extractTarGz(tarPath, targetDir string) (string, error
 			return "", err
 		}
 
-		// Sanitize and validate the path to prevent path traversal attacks
-		cleanName := filepath.Clean(header.Name)
-
-		// Skip entries with problematic names
-		if cleanName == "" || cleanName == "." || cleanName == ".." {
+		// Entries naming the extraction root itself carry nothing to write.
+		if header.Name == "" || filepath.Clean(filepath.FromSlash(header.Name)) == "." {
 			continue
 		}
 
-		// Reject absolute paths
-		if filepath.IsAbs(cleanName) {
-			return "", fmt.Errorf("tar contains absolute path: %s", header.Name)
-		}
-
-		// Compute destination path
-		targetPath := filepath.Join(extractDir, cleanName)
-
-		// Verify the target path is within extractDir
-		relPath, err := filepath.Rel(extractDir, targetPath)
-		if err != nil || strings.HasPrefix(relPath, "..") || filepath.IsAbs(relPath) {
-			return "", fmt.Errorf("tar contains path traversal: %s", header.Name)
+		targetPath, err := tarx.SafeWritePath(extractDir, header.Name)
+		if err != nil {
+			return "", fmt.Errorf("invalid tar entry %q: %w", header.Name, err)
 		}
 
 		switch header.Typeflag {

--- a/pkg/release/downloader_test.go
+++ b/pkg/release/downloader_test.go
@@ -1,0 +1,114 @@
+package release
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type downloadTarEntry struct {
+	header  tar.Header
+	content []byte
+}
+
+func writeDownloadTar(t *testing.T, entries []downloadTarEntry) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+
+	gw := gzip.NewWriter(file)
+	tw := tar.NewWriter(gw)
+	for _, entry := range entries {
+		header := entry.header
+		header.Size = int64(len(entry.content))
+		require.NoError(t, tw.WriteHeader(&header))
+		if len(entry.content) > 0 {
+			_, err := tw.Write(entry.content)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	require.NoError(t, file.Close())
+
+	return path
+}
+
+func TestExtractTarGzRejectsEscapingEntries(t *testing.T) {
+	tests := []struct {
+		name       string
+		headerName func(parent string) string
+	}{
+		{
+			name:       "parent traversal",
+			headerName: func(string) string { return "../outside" },
+		},
+		{
+			name:       "embedded traversal",
+			headerName: func(string) string { return "nested/../../outside" },
+		},
+		{
+			name: "absolute path",
+			headerName: func(parent string) string {
+				return filepath.Join(parent, "outside")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := t.TempDir()
+			target := filepath.Join(parent, "target")
+			require.NoError(t, os.Mkdir(target, 0755))
+
+			archive := writeDownloadTar(t, []downloadTarEntry{
+				{
+					header: tar.Header{
+						Name:     tt.headerName(parent),
+						Typeflag: tar.TypeReg,
+						Mode:     0644,
+					},
+					content: []byte("escaped"),
+				},
+			})
+
+			d := &assetDownloader{}
+			_, err := d.extractTarGz(archive, target)
+			require.ErrorContains(t, err, "invalid tar entry")
+
+			// The traversal targets sit one level above the extraction temp dir,
+			// so check both the target dir and its parent.
+			_, err = os.Stat(filepath.Join(parent, "outside"))
+			require.ErrorIs(t, err, os.ErrNotExist)
+			_, err = os.Stat(filepath.Join(target, "outside"))
+			require.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestExtractTarGzFindsBinary(t *testing.T) {
+	target := t.TempDir()
+	archive := writeDownloadTar(t, []downloadTarEntry{
+		{header: tar.Header{Name: "./", Typeflag: tar.TypeDir, Mode: 0755}},
+		{header: tar.Header{Name: "bin", Typeflag: tar.TypeDir, Mode: 0755}},
+		{
+			header:  tar.Header{Name: "miren", Typeflag: tar.TypeReg, Mode: 0755},
+			content: []byte("binary"),
+		},
+	})
+
+	d := &assetDownloader{}
+	path, err := d.extractTarGz(archive, target)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(target, "miren.new"), path)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, []byte("binary"), content)
+}

--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -388,21 +388,19 @@ func (cr *countingReader) Read(p []byte) (int, error) {
 
 // SafePath joins an untrusted archive path to root after verifying that the
 // result remains within root.
+//
+// The containment check runs on the entry name rather than on the joined
+// result. filepath.IsLocal rejects absolute paths and anything that climbs out
+// via "..", and checking the name up front is the one shape CodeQL's zip-slip
+// sanitizer model recognizes, so callers that extract through this helper stop
+// tripping go/zipslip.
 func SafePath(root, name string) (string, error) {
-	if filepath.IsAbs(name) {
-		return "", fmt.Errorf("archive path is absolute: %q", name)
-	}
-
-	target := filepath.Join(root, filepath.FromSlash(name))
-	rel, err := filepath.Rel(root, target)
-	if err != nil {
-		return "", fmt.Errorf("resolving archive path %q: %w", name, err)
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+	clean := filepath.FromSlash(name)
+	if !filepath.IsLocal(clean) {
 		return "", fmt.Errorf("archive path escapes destination directory: %q", name)
 	}
 
-	return target, nil
+	return filepath.Join(root, clean), nil
 }
 
 // SafeWritePath validates an archive path and rejects existing symlinks in the


### PR DESCRIPTION
#988 made tar extraction safe but CodeQL never agreed. The scan that closed
the old zip-slip alert opened three new ones in the same second, because the
containment guard is written in a shape the query cannot read.

CodeQL's zip-slip model recognizes exactly four sanitizer guards, and the
relevant one is strings.HasPrefix on the true branch: it assumes HasPrefix
means "confined to a known-good root". We use HasPrefix inverted, to reject,
so the analyzer marks the error return as the clean path and lets taint flow
straight through to the extraction. The release downloader has the same
inversion, which #988 never touched.

filepath.IsLocal says the same thing in the polarity the query expects, and
says it about the entry name rather than the joined result, so the guard
lands before anything derives from it. It also subsumes the absolute-path
check and the Rel comparison, which is why both come out.

The downloader now routes through tarx.SafeWritePath instead of carrying its
own copy of the logic. That copy was slightly weaker anyway (its HasPrefix
lacked the separator, so a sibling named "..foo" was falsely rejected) and it
had no protection against writing through an existing symlink. One behavior
change rides along: a ".." entry now errors instead of being silently
skipped, matching what the CLI extractor already did. Empty entry names error
too, rather than resolving to the extraction root.
