### PR TITLE
Fix `miren runner status` always reporting zero sandboxes

### DIFF
--- a/cli/commands/runner_status.go
+++ b/cli/commands/runner_status.go
@@ -1,12 +1,24 @@
 package commands
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"syscall"
+	"time"
 
+	"miren.dev/runtime/api/compute"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/runnerconfig"
+	"miren.dev/runtime/pkg/ui"
 )
 
 func RunnerStatus(ctx *Context, opts struct {
@@ -16,9 +28,17 @@ func RunnerStatus(ctx *Context, opts struct {
 	// Check if runner is configured
 	cfg, err := runnerconfig.Load(opts.ConfigPath)
 	if err != nil {
-		ctx.Printf("Runner:       not configured\n")
-		ctx.Printf("  (no config at %s)\n", opts.ConfigPath)
-		return fmt.Errorf("runner not configured: %w", err)
+		if errors.Is(err, fs.ErrNotExist) {
+			ctx.Printf("Runner:       not configured\n")
+			ctx.Printf("  (no config at %s)\n", opts.ConfigPath)
+			return fmt.Errorf("runner not configured: %w", err)
+		}
+		// A config we can't read is not the same as a config that isn't there,
+		// and telling an operator "not configured" when the file exists but is
+		// unreadable sends them off to re-run `runner join` for nothing.
+		ctx.Printf("Runner:       unknown\n")
+		ctx.Printf("  (config at %s could not be read)\n", opts.ConfigPath)
+		return fmt.Errorf("reading runner config: %w", err)
 	}
 
 	ctx.Printf("Runner ID:    %s\n", cfg.RunnerID)
@@ -26,12 +46,7 @@ func RunnerStatus(ctx *Context, opts struct {
 
 	// Check containerd
 	socketPath := filepath.Join(opts.DataPath, "containerd", "containerd.sock")
-	if info, err := os.Stat(socketPath); err == nil && info.Mode()&os.ModeSocket != 0 {
-		// Try to find the containerd PID from its pidfile or by checking the socket
-		ctx.Printf("Containerd:   running (socket %s)\n", socketPath)
-	} else {
-		ctx.Printf("Containerd:   not running\n")
-	}
+	ctx.Printf("Containerd:   %s\n", describeContainerd(socketPath))
 
 	// Check etcd connectivity
 	if len(cfg.EtcdEndpoints) > 0 {
@@ -44,36 +59,187 @@ func RunnerStatus(ctx *Context, opts struct {
 		ctx.Printf("Network DB:   %s\n", netdbPath)
 	}
 
-	// Check if the runner process is running by looking for a pidfile
-	pidFile := filepath.Join(opts.DataPath, "runner.pid")
-	if data, err := os.ReadFile(pidFile); err == nil {
-		var pid int
-		if _, err := fmt.Sscanf(string(data), "%d", &pid); err == nil {
-			process, err := os.FindProcess(pid)
-			if err == nil {
-				if err := process.Signal(syscall.Signal(0)); err == nil {
-					ctx.Printf("Status:       running (pid %d)\n", pid)
-				} else {
-					ctx.Printf("Status:       stale pid %d (%s)\n", pid, err)
-				}
-			}
-		}
-	} else {
-		// No pidfile, check if containerd socket exists as a proxy
-		if _, err := os.Stat(socketPath); err == nil {
-			ctx.Printf("Status:       running (no pidfile, socket present)\n")
-		} else {
-			ctx.Printf("Status:       stopped\n")
-		}
-	}
-
-	// Check sandboxes
-	sandboxDir := filepath.Join(opts.DataPath, "containerd", "io.containerd.runtime.v2.task", "miren")
-	if entries, err := os.ReadDir(sandboxDir); err == nil {
-		ctx.Printf("Sandboxes:    %d running\n", len(entries))
-	} else {
-		ctx.Printf("Sandboxes:    0 running\n")
-	}
+	ctx.Printf("Status:       %s\n", describeRunnerProcess(opts.DataPath, socketPath))
+	ctx.Printf("Sandboxes:    %s\n", describeSandboxes(ctx, cfg))
 
 	return nil
+}
+
+// describeContainerd reports on the containerd socket. A missing socket means
+// containerd isn't running; any other stat failure (permissions, most often)
+// means we don't know, and saying "not running" would be a guess.
+func describeContainerd(socketPath string) string {
+	info, err := os.Stat(socketPath)
+	switch {
+	case err == nil && info.Mode()&os.ModeSocket != 0:
+		return fmt.Sprintf("running (socket %s)", socketPath)
+	case err == nil:
+		return fmt.Sprintf("unknown (%s exists but is not a socket)", socketPath)
+	case errors.Is(err, fs.ErrNotExist):
+		return "not running"
+	default:
+		return fmt.Sprintf("unknown (%s)", err)
+	}
+}
+
+// describeRunnerProcess reports whether the runner process is alive, preferring
+// the pidfile and falling back to the containerd socket as a weak proxy.
+func describeRunnerProcess(dataPath, socketPath string) string {
+	pidFile := filepath.Join(dataPath, "runner.pid")
+
+	data, err := os.ReadFile(pidFile)
+	switch {
+	case err == nil:
+		return describePid(pidFile, string(data))
+	case errors.Is(err, fs.ErrNotExist):
+		_, serr := os.Stat(socketPath)
+		switch {
+		case serr == nil:
+			return "running (no pidfile, socket present)"
+		case errors.Is(serr, fs.ErrNotExist):
+			return "stopped"
+		default:
+			return fmt.Sprintf("unknown (no pidfile; %s)", serr)
+		}
+	default:
+		return fmt.Sprintf("unknown (%s: %s)", pidFile, err)
+	}
+}
+
+func describePid(pidFile, contents string) string {
+	var pid int
+	if _, err := fmt.Sscanf(contents, "%d", &pid); err != nil {
+		return fmt.Sprintf("unknown (%s does not contain a pid)", pidFile)
+	}
+
+	// Signal(0) is kill(2), where a non-positive pid addresses a process group
+	// rather than a process: pid 0 asks about our own group, which would answer
+	// yes and report a corrupt pidfile as a live runner.
+	if pid <= 0 {
+		return fmt.Sprintf("unknown (%s contains %d, which is not a pid)", pidFile, pid)
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Sprintf("unknown (pid %d: %s)", pid, err)
+	}
+
+	err = process.Signal(syscall.Signal(0))
+	switch {
+	case err == nil:
+		return fmt.Sprintf("running (pid %d)", pid)
+	case errors.Is(err, syscall.EPERM):
+		// The process is there, we just aren't allowed to signal it. Calling
+		// this stale would declare a healthy runner dead whenever `runner
+		// status` is run as anyone but the user who started it.
+		return fmt.Sprintf("running (pid %d, owned by another user)", pid)
+	default:
+		return fmt.Sprintf("stale pid %d (%s)", pid, err)
+	}
+}
+
+// describeSandboxes asks the coordinator what it has scheduled to this runner.
+// The count deliberately comes from the same node-scoped index that backs
+// `miren sandbox list`, so the two commands agree by construction rather than
+// by two independent guesses at containerd's on-disk layout (MIR-1502).
+func describeSandboxes(ctx *Context, cfg *runnerconfig.Config) string {
+	statuses, err := fetchSandboxStatuses(ctx, cfg)
+	if err != nil {
+		return fmt.Sprintf("unknown (%s)", err)
+	}
+	return formatSandboxCounts(statuses)
+}
+
+// sandboxQueryTimeout bounds the whole coordinator round trip. This is a status
+// command reached for when something already looks wrong, so a coordinator that
+// accepts the connection and then goes quiet should cost a few seconds and an
+// "unknown", not a hang.
+const sandboxQueryTimeout = 15 * time.Second
+
+func fetchSandboxStatuses(ctx *Context, cfg *runnerconfig.Config) ([]compute_v1alpha.SandboxStatus, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, sandboxQueryTimeout)
+	defer cancel()
+
+	clientCfg := clientconfig.NewConfig()
+	clientCfg.SetCluster("coordinator", &clientconfig.ClusterConfig{
+		Hostname:   cfg.CoordinatorAddress,
+		CACert:     cfg.CACert,
+		ClientCert: cfg.ClientCert,
+		ClientKey:  cfg.ClientKey,
+	})
+	if err := clientCfg.SetActiveCluster("coordinator"); err != nil {
+		return nil, err
+	}
+
+	state, err := clientCfg.State(queryCtx, rpc.WithLogger(ctx.Log))
+	if err != nil {
+		return nil, fmt.Errorf("coordinator unreachable: %w", err)
+	}
+
+	client, err := state.Client("entities")
+	if err != nil {
+		return nil, fmt.Errorf("coordinator unreachable: %w", err)
+	}
+	defer client.Close()
+
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+
+	nodeId := compute_v1alpha.NewNodeId(cfg.RunnerID)
+	res, err := eac.List(queryCtx, compute_v1alpha.Index(compute_v1alpha.KindSandbox, nodeId.Id()))
+	if err != nil {
+		return nil, fmt.Errorf("coordinator query failed: %w", err)
+	}
+
+	var statuses []compute_v1alpha.SandboxStatus
+	for _, e := range res.Values() {
+		var sb compute_v1alpha.Sandbox
+		sb.Decode(e.Entity())
+		statuses = append(statuses, sb.Status)
+	}
+
+	return statuses, nil
+}
+
+// formatSandboxCounts renders the sandbox line from the statuses the coordinator
+// reports for this runner. Stopped and dead sandboxes are left out so the number
+// lines up with what `miren sandbox list` shows by default.
+func formatSandboxCounts(statuses []compute_v1alpha.SandboxStatus) string {
+	running := 0
+	others := map[string]int{}
+
+	for _, status := range statuses {
+		if compute.SandboxDead(status) {
+			continue
+		}
+
+		if status == compute_v1alpha.RUNNING {
+			running++
+			continue
+		}
+
+		// An unset status still gets counted, just not as something we can name.
+		name := ui.CleanStatus(string(status))
+		if name == "" {
+			name = "unknown"
+		}
+		others[name]++
+	}
+
+	line := fmt.Sprintf("%d running", running)
+	if len(others) == 0 {
+		return line
+	}
+
+	names := make([]string, 0, len(others))
+	for name := range others {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("%d %s", others[name], name))
+	}
+
+	return fmt.Sprintf("%s (%s)", line, strings.Join(parts, ", "))
 }

--- a/cli/commands/runner_status_test.go
+++ b/cli/commands/runner_status_test.go
@@ -1,0 +1,224 @@
+package commands
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+)
+
+func TestFormatSandboxCounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []compute_v1alpha.SandboxStatus
+		want     string
+	}{
+		{
+			name:     "no sandboxes",
+			statuses: nil,
+			want:     "0 running",
+		},
+		{
+			name: "only running",
+			statuses: []compute_v1alpha.SandboxStatus{
+				compute_v1alpha.RUNNING,
+				compute_v1alpha.RUNNING,
+				compute_v1alpha.RUNNING,
+			},
+			want: "3 running",
+		},
+		{
+			// The bug this command shipped with reported 0 while sandboxes were
+			// plainly running, so a non-zero count with dead entries mixed in is
+			// the case worth pinning down.
+			name: "dead and stopped are excluded",
+			statuses: []compute_v1alpha.SandboxStatus{
+				compute_v1alpha.RUNNING,
+				compute_v1alpha.DEAD,
+				compute_v1alpha.RUNNING,
+				compute_v1alpha.STOPPED,
+				compute_v1alpha.DEAD,
+			},
+			want: "2 running",
+		},
+		{
+			name: "non-running sandboxes are broken out",
+			statuses: []compute_v1alpha.SandboxStatus{
+				compute_v1alpha.RUNNING,
+				compute_v1alpha.PENDING,
+				compute_v1alpha.NOT_READY,
+				compute_v1alpha.PENDING,
+			},
+			want: "1 running (1 not_ready, 2 pending)",
+		},
+		{
+			name:     "empty status is not silently counted as running",
+			statuses: []compute_v1alpha.SandboxStatus{compute_v1alpha.RUNNING, ""},
+			want:     "1 running (1 unknown)",
+		},
+		{
+			name: "everything dead",
+			statuses: []compute_v1alpha.SandboxStatus{
+				compute_v1alpha.DEAD,
+				compute_v1alpha.STOPPED,
+			},
+			want: "0 running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatSandboxCounts(tt.statuses); got != tt.want {
+				t.Errorf("formatSandboxCounts() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatSandboxCountsOrdersBreakdownDeterministically(t *testing.T) {
+	statuses := []compute_v1alpha.SandboxStatus{
+		compute_v1alpha.NOT_READY,
+		compute_v1alpha.PENDING,
+		compute_v1alpha.NOT_READY,
+		compute_v1alpha.PENDING,
+	}
+
+	first := formatSandboxCounts(statuses)
+	for range 20 {
+		if got := formatSandboxCounts(statuses); got != first {
+			t.Fatalf("formatSandboxCounts() is unstable: got %q then %q", first, got)
+		}
+	}
+}
+
+func TestDescribeContainerd(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("missing socket", func(t *testing.T) {
+		got := describeContainerd(filepath.Join(dir, "absent.sock"))
+		if got != "not running" {
+			t.Errorf("got %q, want %q", got, "not running")
+		}
+	})
+
+	t.Run("real socket", func(t *testing.T) {
+		sock := filepath.Join(dir, "containerd.sock")
+		l, err := net.Listen("unix", sock)
+		if err != nil {
+			t.Fatalf("failed to create unix socket: %v", err)
+		}
+		defer l.Close()
+
+		got := describeContainerd(sock)
+		if !strings.HasPrefix(got, "running (socket ") {
+			t.Errorf("got %q, want it to report running", got)
+		}
+	})
+
+	t.Run("path exists but is not a socket", func(t *testing.T) {
+		// A regular file here means something is wrong in a way that "not
+		// running" would paper over.
+		notASocket := filepath.Join(dir, "regular-file")
+		if err := os.WriteFile(notASocket, []byte("hi"), 0600); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+
+		got := describeContainerd(notASocket)
+		if !strings.HasPrefix(got, "unknown (") {
+			t.Errorf("got %q, want an unknown verdict", got)
+		}
+	})
+}
+
+func TestDescribeRunnerProcess(t *testing.T) {
+	t.Run("no pidfile and no socket", func(t *testing.T) {
+		dir := t.TempDir()
+		got := describeRunnerProcess(dir, filepath.Join(dir, "absent.sock"))
+		if got != "stopped" {
+			t.Errorf("got %q, want %q", got, "stopped")
+		}
+	})
+
+	t.Run("no pidfile but socket present", func(t *testing.T) {
+		dir := t.TempDir()
+		sock := filepath.Join(dir, "containerd.sock")
+		l, err := net.Listen("unix", sock)
+		if err != nil {
+			t.Fatalf("failed to create unix socket: %v", err)
+		}
+		defer l.Close()
+
+		got := describeRunnerProcess(dir, sock)
+		if got != "running (no pidfile, socket present)" {
+			t.Errorf("got %q, want the socket-proxy verdict", got)
+		}
+	})
+
+	t.Run("pidfile names this process", func(t *testing.T) {
+		dir := t.TempDir()
+		pid := os.Getpid()
+		writePidFile(t, dir, strconv.Itoa(pid))
+
+		want := "running (pid " + strconv.Itoa(pid) + ")"
+		if got := describeRunnerProcess(dir, filepath.Join(dir, "absent.sock")); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unparseable pidfile reports unknown rather than stopped", func(t *testing.T) {
+		dir := t.TempDir()
+		writePidFile(t, dir, "not-a-pid\n")
+
+		got := describeRunnerProcess(dir, filepath.Join(dir, "absent.sock"))
+		if !strings.HasPrefix(got, "unknown (") {
+			t.Errorf("got %q, want an unknown verdict", got)
+		}
+		if strings.Contains(got, "stopped") || strings.Contains(got, "running") {
+			t.Errorf("got %q, want it to avoid claiming a state it can't determine", got)
+		}
+	})
+
+	t.Run("non-positive pids are rejected before signaling", func(t *testing.T) {
+		// Signal(0) on a non-positive pid addresses a process group, so pid 0
+		// would report our own group as a live runner.
+		for _, contents := range []string{"0", "-1", "-4242"} {
+			dir := t.TempDir()
+			writePidFile(t, dir, contents)
+
+			got := describeRunnerProcess(dir, filepath.Join(dir, "absent.sock"))
+			if !strings.HasPrefix(got, "unknown (") {
+				t.Errorf("pidfile %q: got %q, want an unknown verdict", contents, got)
+			}
+			if strings.Contains(got, "running") {
+				t.Errorf("pidfile %q: got %q, want it to avoid claiming the runner is up", contents, got)
+			}
+		}
+	})
+
+	t.Run("pidfile names a dead process", func(t *testing.T) {
+		dir := t.TempDir()
+
+		cmd := exec.Command("true")
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("failed to run throwaway process: %v", err)
+		}
+		writePidFile(t, dir, strconv.Itoa(cmd.Process.Pid))
+
+		got := describeRunnerProcess(dir, filepath.Join(dir, "absent.sock"))
+		if !strings.HasPrefix(got, "stale pid ") {
+			t.Errorf("got %q, want a stale verdict", got)
+		}
+	})
+}
+
+func writePidFile(t *testing.T, dir, contents string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "runner.pid"), []byte(contents), 0600); err != nil {
+		t.Fatalf("failed to write pidfile: %v", err)
+	}
+}


### PR DESCRIPTION
`miren runner status` has reported "Sandboxes: 0 running" on every runner for as long as we've looked, including runners carrying a full workload. It surfaced during the MIR-1483 rollout: the output said both garden runners were idle, which sent us chasing why nothing was being scheduled onto them, until `miren sandbox list` disagreed and showed a dozen on the same box.

Two problems, and the second hid the first. The count listed a containerd directory whose path was missing a component (the task tree lives under containerd's state dir, not its root), so it never resolved anywhere. And every `ReadDir` failure was swallowed into "0 running", which is indistinguishable from a genuinely idle runner.

Fixing the path alone would have traded a wrong zero for a wrong non-zero, since those entries are containerd tasks and count pause containers and subcontainers too. On a dev cluster running four sandboxes the directory holds eight. So the count now comes from the coordinator's node-scoped sandbox index, the same one `miren sandbox list` renders and the watchdog walks, which means the two commands agree by construction instead of by two independent guesses at containerd's layout. The runner dials with the certs `runner join` persisted, the way `runner reissue` already does. Tradeoff worth naming: this is the coordinator's view of what's scheduled on a runner, not what's physically on the box, so orphaned containers won't show up here. That's the watchdog's beat.

Three more spots in this command had the same swallow-and-guess shape and got the same treatment: an unreadable config no longer claims "not configured", an unparseable pidfile no longer prints no status line at all, and a pid we can't signal is now reported running rather than stale. Anything we can't determine says `unknown` with the reason, never a number we don't have.

Verified on `make dev-distributed` with four sandboxes on runner1: `sandbox list` shows four, `runner status` says four, the containerd state dir holds eight.

Closes MIR-1502
