### PR TITLE
Make daemon logging deliberate, and stop the audit trail repeating itself

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,3 +279,37 @@ See `cli/commands/route_list.go` for a reference implementation.
   - Avoid redundant comments that restate what the code does (e.g., `// Start server` above `server.Start()`)
   - Good comments explain complex logic, document assumptions, or clarify non-obvious behavior
   - Function/method comments should explain the purpose and any important side effects, not just restate the name
+
+### Log Levels
+
+Daemons (`miren server`, `miren runner start`) default to **Info**; one-shot CLI
+commands default to **Warn**. `-v` moves one step louder from there, and
+`SIGTTIN`/`SIGTTOU` retune a running process without a restart. Because Info is
+what an operator actually reads on a live cluster, it has to stay worth reading.
+
+- **Error** — the system failed at something it is responsible for. A user's app
+  failing to bind its own declared port is not this; the platform handled that
+  correctly.
+- **Warn** — degraded, unexpected, or handled-but-suspicious. Denials belong
+  here regardless of source.
+- **Info** — the affirmative record of a healthy daemon: lifecycle events, state
+  transitions, decisions taken, and startup confirmations. If a healthy service
+  says nothing at Info, an operator cannot tell "working" from "never
+  attempted."
+- **Debug** — diagnostic detail for when something is already wrong.
+
+Useful tests when picking one:
+
+- **Would this line be identical the next thousand times it fires?** Then it is
+  Debug. Info is for things that happened, not things that are.
+- **Reconcile entry versus reconcile outcome.** "Processing disk update" on
+  every tick is Debug; the handler saying it mounted something is Info.
+- **Would an operator act on it?** If not, it is not Error or Warn. A retry loop
+  that can never converge must not log at full rate forever — it drowns the tier
+  it is in.
+- **Never log a struct at Info.** `%+v` on an entity renders its whole field
+  tree inline. Name the two or three fields that matter.
+- **Audit records are exempt from `-v`** (`pkg/rpc/audit.go` pins an Info
+  floor), so no verbosity default can reduce their volume. Audit volume has to
+  be solved in the audit code — see `certAuthDeduper` for the pattern of
+  collapsing repeats while keeping a count.

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -679,6 +679,7 @@ miren deploy --analyze
 		))
 		d.Dispatch("runner start", Infer("runner start", "Start this machine as a distributed runner", RunnerStart,
 			WithLabsFeature(labs.FeatureDistributedRunners),
+			WithDaemon(),
 			WithExample(mflags.Example{
 				Name: "Start the runner",
 				Body: "miren runner start",
@@ -812,6 +813,7 @@ miren deploy --analyze
 	// Server commands
 	d.Dispatch("server", Infer("server", "Start the miren server", Server,
 		WithGroup(GroupServer),
+		WithDaemon(),
 		WithExample(mflags.Example{
 			Name: "Start in standalone mode",
 			Body: "miren server --mode standalone",

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -76,7 +76,29 @@ func (c *Context) Verbose() bool {
 	return c.verbose > 0
 }
 
-func setup(ctx context.Context, flags *GlobalFlags, opts any, commandName string) *Context {
+// baseLogLevel is where the -v ladder starts before any -v is applied. Each -v
+// moves one step louder from here (slog levels are 4 apart), clamped at Debug.
+//
+// The two answers differ because the two jobs do. A one-shot command like
+// `miren app list` has its result on stdout and should stay quiet on stderr
+// unless something is wrong, so it starts at Warn. A daemon has no result — the
+// log is the only thing it produces — and at Warn a healthy one says nothing
+// about itself at all, so an operator cannot tell "working" from "never
+// attempted". That ambiguity is not hypothetical: during the MIR-1483 telemetry
+// cutover the line confirming the switch was invisible, and verifying it meant
+// pushing a systemd override onto every runner to add -v.
+//
+// Info is the affirmative baseline for a daemon. -v and the SIGTTIN/SIGTTOU
+// handlers below move off it when you actually need Debug, which beats baking a
+// level into a unit file that then outlives the reason for it.
+func baseLogLevel(daemon bool) slog.Level {
+	if daemon {
+		return slog.LevelInfo
+	}
+	return slog.LevelWarn
+}
+
+func setup(ctx context.Context, flags *GlobalFlags, opts any, commandName string, daemon bool) *Context {
 	s := &Context{
 		verbose:     len(flags.Verbose),
 		Stdout:      os.Stdout,
@@ -88,16 +110,8 @@ func setup(ctx context.Context, flags *GlobalFlags, opts any, commandName string
 	// Initialize config from flags
 	s.Config.ServerAddress = flags.ServerAddress
 
-	var level slog.Level
-
-	switch s.verbose {
-	case 0:
-		level = slog.LevelWarn
-	case 1:
-		level = slog.LevelInfo
-	case 2:
-		level = slog.LevelDebug
-	default:
+	level := baseLogLevel(daemon) - slog.Level(4*s.verbose)
+	if level < slog.LevelDebug {
 		level = slog.LevelDebug
 	}
 

--- a/cli/commands/global_test.go
+++ b/cli/commands/global_test.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"miren.dev/mflags"
+	"miren.dev/runtime/pkg/labs"
+)
+
+// TestVerbosityLadder pins the level each -v count resolves to for both kinds of
+// command. The CLI column must not move: it is the historical behaviour and
+// `miren app list` staying quiet on stderr depends on it. The daemon column is
+// the change — a service starts at Info so a healthy one affirms that it came
+// up, instead of being indistinguishable from one that never tried.
+func TestVerbosityLadder(t *testing.T) {
+	cases := []struct {
+		verbose int
+		cli     slog.Level
+		daemon  slog.Level
+	}{
+		{0, slog.LevelWarn, slog.LevelInfo},
+		{1, slog.LevelInfo, slog.LevelDebug},
+		{2, slog.LevelDebug, slog.LevelDebug},
+		// Past Debug there is nowhere louder to go, so extra -v clamps rather
+		// than sliding into levels no handler will ever emit.
+		{3, slog.LevelDebug, slog.LevelDebug},
+		{9, slog.LevelDebug, slog.LevelDebug},
+	}
+
+	for _, tc := range cases {
+		flags := &GlobalFlags{Verbose: make([]bool, tc.verbose)}
+
+		cliCtx := setup(context.Background(), flags, struct{}{}, "test", false)
+		if got := cliCtx.Level(); got != tc.cli {
+			t.Errorf("cli with %d -v: got %v, want %v", tc.verbose, got, tc.cli)
+		}
+		cliCtx.Close()
+
+		daemonCtx := setup(context.Background(), flags, struct{}{}, "test", true)
+		if got := daemonCtx.Level(); got != tc.daemon {
+			t.Errorf("daemon with %d -v: got %v, want %v", tc.verbose, got, tc.daemon)
+		}
+		daemonCtx.Close()
+	}
+}
+
+// TestWithDaemonMarksCommand checks the registration-site option actually
+// reaches setup. It lives at the registration site precisely so the level is
+// correct however the process was launched, so a silent failure to propagate
+// would reintroduce the bug it exists to prevent.
+func TestWithDaemonMarksCommand(t *testing.T) {
+	noop := func(ctx *Context, opts struct{}) error { return nil }
+
+	plain := Infer("plain", "a one-shot command", noop)
+	if plain.daemon {
+		t.Error("a command should not be a daemon unless it says so")
+	}
+
+	service := Infer("service", "a long-running service", noop, WithDaemon())
+	if !service.daemon {
+		t.Error("WithDaemon() did not mark the command")
+	}
+}
+
+// TestDaemonCommandsAreRegisteredAsDaemons is the guard that matters
+// operationally: the two long-running services must carry the marker. Losing it
+// is silent — the process just goes quiet — and the last time a runner ran
+// quieter than intended it took a fleet-wide systemd override to notice.
+func TestDaemonCommandsAreRegisteredAsDaemons(t *testing.T) {
+	// `runner start` only registers with distributed runners enabled, and labs
+	// state is process-wide, so put it back when we're done.
+	labs.Init(slog.New(slog.DiscardHandler), []string{labs.FeatureDistributedRunners})
+	t.Cleanup(func() { labs.Init(slog.New(slog.DiscardHandler), nil) })
+
+	d := mflags.NewDispatcher("miren")
+	RegisterAll(d)
+
+	for _, name := range []string{"server", "runner start"} {
+		cmd, ok := d.GetCommand(name).(*Cmd)
+		if !ok {
+			t.Errorf("command %q is not registered as an inferred command", name)
+			continue
+		}
+		if !cmd.daemon {
+			t.Errorf("command %q must be registered WithDaemon()", name)
+		}
+	}
+}

--- a/cli/commands/infer.go
+++ b/cli/commands/infer.go
@@ -27,6 +27,7 @@ type Cmd struct {
 	labsFeature string
 	description string
 	group       string
+	daemon      bool
 }
 
 type CommandOption func(*Cmd)
@@ -55,6 +56,21 @@ func WithLabsFeature(feature string) CommandOption {
 func WithGroup(group string) CommandOption {
 	return func(c *Cmd) {
 		c.group = group
+	}
+}
+
+// WithDaemon marks a command as a long-running service rather than a one-shot
+// CLI invocation, which starts its -v ladder at Info instead of Warn. See
+// baseLogLevel.
+//
+// This lives at the registration site rather than in the unit file so the level
+// is right however the daemon was launched — systemd, a container entrypoint,
+// or by hand — instead of depending on every launch path remembering to pass a
+// flag. Not remembering is how a coordinator ended up pinned at Debug forever
+// and a runner at Warn, neither deliberately.
+func WithDaemon() CommandOption {
+	return func(c *Cmd) {
+		c.daemon = true
 	}
 }
 
@@ -336,7 +352,7 @@ func (w *Cmd) Invoke(args ...string) error {
 		w.show(w.opts.Elem())
 	}
 
-	ctx := setup(context.Background(), w.global, w.opts.Interface(), w.name)
+	ctx := setup(context.Background(), w.global, w.opts.Interface(), w.name, w.daemon)
 	defer ctx.Close()
 
 	rets := w.f.Call([]reflect.Value{reflect.ValueOf(ctx), w.opts.Elem()})
@@ -376,7 +392,7 @@ func RunCommand(f any, args ...string) (*CommandOutput, error) {
 		return &out, err
 	}
 
-	ctx := setup(context.Background(), cmd.global, cmd.opts.Interface(), cmd.name)
+	ctx := setup(context.Background(), cmd.global, cmd.opts.Interface(), cmd.name, cmd.daemon)
 	defer ctx.Close()
 
 	ctx.Stdout = &out.Stdout

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -305,7 +305,7 @@ func fixSELinuxContext(ctx *Context, binaryPath string) {
 // ServerInstall sets up systemd units to run the miren server
 func ServerInstall(ctx *Context, opts struct {
 	Address         string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
-	Verbosity       string            `long:"verbosity" description:"Verbosity level" default:"-vv"`
+	Verbosity       string            `long:"verbosity" description:"Extra verbosity to bake into the unit (e.g. -v); the server defaults to Info without it"`
 	Branch          string            `short:"b" long:"branch" description:"Branch to download if release not found"`
 	Force           bool              `short:"f" long:"force" description:"Overwrite existing service file"`
 	NoStart         bool              `long:"no-start" description:"Do not start the service after installation"`

--- a/cli/commands/server_install_other.go
+++ b/cli/commands/server_install_other.go
@@ -10,7 +10,7 @@ import (
 // ServerInstall is not supported on non-Linux platforms
 func ServerInstall(ctx *Context, opts struct {
 	Address         string            `short:"a" long:"address" description:"Server address to bind to" default:"0.0.0.0:8443"`
-	Verbosity       string            `long:"verbosity" description:"Verbosity level" default:"-vv"`
+	Verbosity       string            `long:"verbosity" description:"Extra verbosity to bake into the unit (e.g. -v); the server defaults to Info without it"`
 	Branch          string            `short:"b" long:"branch" description:"Branch to download if release not found" default:"main"`
 	Force           bool              `short:"f" long:"force" description:"Overwrite existing service file"`
 	NoStart         bool              `long:"no-start" description:"Do not start the service after installation"`

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -399,7 +399,11 @@ func (l *Launcher) ensurePoolForService(ctx context.Context, app *core_v1alpha.A
 	for _, svc := range spec.Services {
 		if svc.Name == serviceName && svc.Image != "" {
 			image = containerdx.NormalizeImageReference(svc.Image)
-			l.Log.Info("using custom image for service",
+			// Debug rather than Info: this restates configuration on every
+			// deployment reconcile rather than reporting anything happening, and
+			// "original" is usually byte-identical to "image" because
+			// normalization is a no-op for an already-qualified reference.
+			l.Log.Debug("using custom image for service",
 				"service", serviceName,
 				"image", image,
 				"original", svc.Image)

--- a/controllers/disk/disk_controller.go
+++ b/controllers/disk/disk_controller.go
@@ -109,7 +109,11 @@ func (d *DiskController) Create(ctx context.Context, disk *storage_v1alpha.Disk,
 
 // Update handles updates to an existing disk entity
 func (d *DiskController) Update(ctx context.Context, disk *storage_v1alpha.Disk, meta *entity.Meta) error {
-	d.Log.Info("Processing disk update",
+	// Debug rather than Info: this fires on every reconcile of every disk,
+	// including the periodic resync, so a steady-state cluster emits it
+	// constantly while reporting no change. The handlers below log at Info when
+	// they actually do something, which is the part worth seeing.
+	d.Log.Debug("Processing disk update",
 		"disk", disk.ID,
 		"status", disk.Status)
 

--- a/controllers/disk/disk_lease_controller.go
+++ b/controllers/disk/disk_lease_controller.go
@@ -271,7 +271,11 @@ func (d *DiskLeaseController) reconcileLease(ctx context.Context, event string, 
 		return nil
 	}
 
-	d.Log.Info(event,
+	// Debug rather than Info: this fires on entry for every lease on every
+	// reconcile, so a cluster with a handful of steady bound leases repeats it
+	// indefinitely while nothing changes. The handlers below report at Info when
+	// they mount, unmount, or fail something.
+	d.Log.Debug(event,
 		"lease", lease.ID,
 		"disk", lease.DiskId,
 		"status", lease.Status)

--- a/controllers/disk/disk_watch_controller.go
+++ b/controllers/disk/disk_watch_controller.go
@@ -85,7 +85,9 @@ func (d *DiskWatchController) reconcileDependentLeases(ctx context.Context, disk
 	}
 
 	if reconciledCount > 0 {
-		d.Log.Info("Triggered reconciliation of leases due to disk state change",
+		// Enqueuing work is internal plumbing, not an event an operator acts on,
+		// and it repeats for every disk on every resync.
+		d.Log.Debug("Triggered reconciliation of leases due to disk state change",
 			"disk", diskId,
 			"leaseCount", reconciledCount)
 	}

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -361,7 +361,13 @@ func (s *ServiceController) addNodePort(tx *knftables.Transaction, nport int, pr
 }
 
 func (s *ServiceController) Create(ctx context.Context, srv *network_v1alpha.Service, meta *entity.Meta) error {
-	s.Log.Info("Creating service", "service", srv)
+	// Named fields rather than the whole struct: %+v on a Service renders its
+	// address list, match rules and full port table inline, which came to ~300
+	// bytes a line for something that is mostly reporting an identifier.
+	s.Log.Info("Creating service",
+		"service", srv.ID,
+		"addrs", len(srv.Ip),
+		"ports", len(srv.Port))
 
 	lr, err := s.EAC.List(ctx, entity.Ref(network_v1alpha.EndpointsServiceId, srv.ID))
 	if err != nil {

--- a/docs/docs/command/server-install.md
+++ b/docs/docs/command/server-install.md
@@ -23,7 +23,7 @@ miren server install [flags]
 - `--no-start` — Do not start the service after installation
 - `--skip-system-check` — Skip minimum system requirements check
 - `--url, -u` — Cloud URL for registration (default: `https://miren.cloud`)
-- `--verbosity` — Verbosity level (default: `-vv`)
+- `--verbosity` — Extra verbosity to bake into the unit (e.g. -v); the server defaults to Info without it
 - `--without-cloud` — Skip cloud registration setup
 
 ## Global Options

--- a/hack/systemd/entrypoint.sh
+++ b/hack/systemd/entrypoint.sh
@@ -68,7 +68,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 Environment="NO_COLOR=1"
-ExecStart=/var/lib/miren/release/miren server -vv --address=0.0.0.0:8443
+ExecStart=/var/lib/miren/release/miren server --address=0.0.0.0:8443
 Restart=always
 RestartSec=10
 StandardOutput=journal

--- a/pkg/cloudauth/policy_fetcher.go
+++ b/pkg/cloudauth/policy_fetcher.go
@@ -196,7 +196,10 @@ func (pf *PolicyFetcher) fetchPolicy(ctx context.Context) error {
 
 	// Update the stored policy
 	pf.setPolicy(&policy)
-	pf.logger.Info("policy fetched successfully", "rules", len(policy.Rules))
+	// Debug rather than Info: this is a timer-driven refresh that succeeds every
+	// time on a healthy cluster. A failure to refresh is the interesting event,
+	// and that path logs an error.
+	pf.logger.Debug("policy fetched successfully", "rules", len(policy.Rules))
 
 	// Update refresh timestamp and clear evaluator cache
 	pf.mu.Lock()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -417,7 +417,10 @@ func (c *ReconcileController) applyUpdates(ctx context.Context, event Event, upd
 		return
 	}
 
-	c.Log.Info("updating entity with updates produced by controller", "event", event, "updates", len(updates))
+	// Debug rather than Info: every controller write passes through here, so at
+	// Info this and the confirmation below reported each routine reconcile twice
+	// in the operator's stream. Failures still surface at Warn/Error.
+	c.Log.Debug("updating entity with updates produced by controller", "event", event, "updates", len(updates))
 
 	// Add entity ID to attrs for Patch
 	attrs := append([]entity.Attr{entity.Ref(entity.DBId, event.Id)}, updates...)
@@ -432,7 +435,7 @@ func (c *ReconcileController) applyUpdates(ctx context.Context, event Event, upd
 		}
 		c.Log.Error("error updating entity", "entity", event.Id, "error", err)
 	} else {
-		c.Log.Info("updated entity", "entity", event.Id)
+		c.Log.Debug("updated entity", "entity", event.Id)
 		// Record the revision we just wrote so we can skip the watch event
 		if result.HasRevision() {
 			c.RecordWrite(result.Revision())

--- a/pkg/rpc/audit.go
+++ b/pkg/rpc/audit.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
+	"time"
 )
 
 // certFingerprint returns the hex-encoded SHA-256 of a certificate's raw DER,
@@ -30,11 +32,17 @@ func certFingerprint(cert *x509.Certificate) string {
 // sink that re-checks the level in Handle would silently break the floor.
 //
 // The audit trail uses this to hold a fixed Info floor regardless of the
-// process-wide verbosity. Managed servers run at -vv (Debug), so a plain shared
-// logger would never suppress the audit stream's own Debug records (loopback
-// internal traffic); conversely the default is Warn, at which a shared logger
-// would drop audit Info entirely. Pinning the floor at Info decouples the audit
-// trail from the operational -v knob in both directions.
+// process-wide verbosity, which it must do in both directions. Run the process
+// verbosely and a plain shared logger would never suppress the audit stream's
+// own Debug records (loopback internal traffic); run it quietly — a CLI
+// invocation sits at Warn — and a shared logger would drop audit Info entirely.
+// Pinning the floor at Info decouples the audit trail from the operational -v
+// knob either way.
+//
+// The corollary is worth stating because it is easy to forget: the audit stream
+// is immune to -v, so no choice of default verbosity can reduce its volume.
+// Anything about audit volume has to be fixed in the audit code itself, which
+// is what certAuthDeduper does.
 type minLevelHandler struct {
 	slog.Handler
 	min slog.Level
@@ -77,6 +85,143 @@ func isLoopbackAddr(addr string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+// remoteHost strips the port from an *http.Request RemoteAddr. Source ports are
+// ephemeral and carry no attribution value, so the audit trail keys on the host.
+func remoteHost(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	return host
+}
+
+// defaultCertAuthInterval is how often a still-active (cert, peer) pair re-emits
+// its certificate detail. Short enough that the trail keeps useful temporal
+// resolution, long enough that a busy peer costs a dozen records an hour rather
+// than several thousand.
+const defaultCertAuthInterval = 5 * time.Minute
+
+// maxCertAuthTracked bounds the dedup table. Real clusters track a handful of
+// pairs (one per runner, plus operators); the cap exists so that a peer churning
+// through source addresses cannot grow the table without limit.
+const maxCertAuthTracked = 1024
+
+type certAuthKey struct {
+	fingerprint string
+	host        string
+}
+
+type certAuthState struct {
+	last       time.Time
+	suppressed int64
+}
+
+// certAuthDeduper collapses repeated cert-auth records for the same certificate
+// and peer host into one record per interval.
+//
+// The per-request cert-auth record is almost entirely redundant. Every field
+// that distinguishes it (subject, issuer, serial, fingerprint) describes the
+// certificate rather than the request, so a long-lived peer re-emits the same
+// ~330 bytes on every single RPC. Measured on a coordinator with two
+// distributed runners, this was 5,958 records/hour and 47% of everything the
+// process wrote, to convey that the same two certs were still the same two
+// certs.
+//
+// Per-request attribution is not lost, because it never lived here: logAccess
+// records the subject and auth method for every non-public call, and that is
+// the trail the audit design leans on (see logCertAuth). What this preserves is
+// the certificate detail, emitted on first sight of a (cert, peer host) pair
+// and again once per interval, carrying the number of authentications absorbed
+// since the last record. One line saying a cert authenticated 5,958 times is
+// strictly more informative than 5,958 identical lines.
+type certAuthDeduper struct {
+	mu       sync.Mutex
+	interval time.Duration
+	max      int
+	seen     map[certAuthKey]*certAuthState
+
+	// now is overridable so tests can drive the interval without sleeping.
+	now func() time.Time
+}
+
+func newCertAuthDeduper() *certAuthDeduper {
+	return &certAuthDeduper{
+		interval: defaultCertAuthInterval,
+		max:      maxCertAuthTracked,
+		seen:     make(map[certAuthKey]*certAuthState),
+	}
+}
+
+func (d *certAuthDeduper) clock() time.Time {
+	if d.now != nil {
+		return d.now()
+	}
+	return time.Now()
+}
+
+// record reports whether this authentication should be logged and, if so, how
+// many authentications for the same pair went unlogged since the previous
+// record. A nil deduper logs everything, which keeps a hand-constructed
+// StateCommon (as in tests) on the pre-dedup behaviour.
+func (d *certAuthDeduper) record(key certAuthKey) (bool, int64) {
+	if d == nil {
+		return true, 0
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := d.clock()
+
+	if st, ok := d.seen[key]; ok {
+		if now.Sub(st.last) < d.interval {
+			st.suppressed++
+			return false, 0
+		}
+		suppressed := st.suppressed
+		st.last = now
+		st.suppressed = 0
+		return true, suppressed
+	}
+
+	d.evictLocked(now)
+	d.seen[key] = &certAuthState{last: now}
+	return true, 0
+}
+
+// evictLocked keeps the table under its cap, dropping entries that have gone
+// quiet for longer than an interval first and falling back to the
+// least-recently-recorded entry. An evicted entry loses its pending suppressed
+// count, so the peer simply reads as newly seen next time.
+func (d *certAuthDeduper) evictLocked(now time.Time) {
+	if len(d.seen) < d.max {
+		return
+	}
+
+	for k, st := range d.seen {
+		if now.Sub(st.last) >= d.interval {
+			delete(d.seen, k)
+		}
+	}
+	if len(d.seen) < d.max {
+		return
+	}
+
+	var (
+		oldestKey certAuthKey
+		oldest    time.Time
+		found     bool
+	)
+	for k, st := range d.seen {
+		if !found || st.last.Before(oldest) {
+			oldestKey, oldest, found = k, st.last, true
+		}
+	}
+	if found {
+		delete(d.seen, oldestKey)
+	}
+}
+
 // logCertAuth emits a single durable audit record for a successful cert-method
 // authentication.
 //
@@ -92,26 +237,45 @@ func isLoopbackAddr(addr string) bool {
 // Logged at Info for network peers and Debug for loopback (same-host internal
 // component mTLS), so the Info stream isn't drowned by the coordinator's own
 // services authenticating to each other. See isLoopbackAddr.
-func logCertAuth(ctx context.Context, log *slog.Logger, r *http.Request) {
+//
+// Records are deduplicated per (certificate, peer host) so that a long-lived
+// peer costs one record per interval rather than one per RPC; see
+// certAuthDeduper for why that loses no attribution. A record that stands in
+// for suppressed ones carries a "suppressed" count.
+func logCertAuth(ctx context.Context, log *slog.Logger, dedup *certAuthDeduper, r *http.Request) {
 	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
 		return
 	}
 	cert := r.TLS.PeerCertificates[0]
+
+	fingerprint := certFingerprint(cert)
+	shouldLog, suppressed := dedup.record(certAuthKey{
+		fingerprint: fingerprint,
+		host:        remoteHost(r.RemoteAddr),
+	})
+	if !shouldLog {
+		return
+	}
 
 	level := slog.LevelInfo
 	if isLoopbackAddr(r.RemoteAddr) {
 		level = slog.LevelDebug
 	}
 
-	log.Log(ctx, level, "cert auth",
+	attrs := []any{
 		"remote", r.RemoteAddr,
 		"subject", cert.Subject.String(),
 		"issuer", cert.Issuer.String(),
 		"serial", cert.SerialNumber.String(),
-		"fingerprint", certFingerprint(cert),
+		"fingerprint", fingerprint,
 		"verified", len(r.TLS.VerifiedChains) > 0,
 		"chains", len(r.TLS.VerifiedChains),
-	)
+	}
+	if suppressed > 0 {
+		attrs = append(attrs, "suppressed", suppressed)
+	}
+
+	log.Log(ctx, level, "cert auth", attrs...)
 }
 
 // logAccess emits a per-request RPC access record for a non-public method.

--- a/pkg/rpc/audit_test.go
+++ b/pkg/rpc/audit_test.go
@@ -9,10 +9,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"math/big"
 	"net/http"
 	"testing"
+	"time"
 )
 
 // captureLogger returns a slog.Logger writing JSON records into buf, so tests
@@ -75,7 +77,7 @@ func TestLogCertAuth(t *testing.T) {
 		req.RemoteAddr = "203.0.113.7:44321"
 		withVerifiedCert(req)
 
-		logCertAuth(context.Background(), captureLogger(&buf), req)
+		logCertAuth(context.Background(), captureLogger(&buf), nil, req)
 
 		records := decodeRecords(t, &buf)
 		if len(records) != 1 {
@@ -113,7 +115,7 @@ func TestLogCertAuth(t *testing.T) {
 		req.RemoteAddr = "127.0.0.1:8443"
 		withVerifiedCert(req)
 
-		logCertAuth(context.Background(), captureLogger(&buf), req)
+		logCertAuth(context.Background(), captureLogger(&buf), nil, req)
 
 		records := decodeRecords(t, &buf)
 		if len(records) != 1 {
@@ -128,7 +130,7 @@ func TestLogCertAuth(t *testing.T) {
 		var buf bytes.Buffer
 		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
 
-		logCertAuth(context.Background(), captureLogger(&buf), req)
+		logCertAuth(context.Background(), captureLogger(&buf), nil, req)
 
 		if buf.Len() != 0 {
 			t.Errorf("expected no log output, got %q", buf.String())
@@ -140,7 +142,7 @@ func TestLogCertAuth(t *testing.T) {
 		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
 		req.TLS = &tls.ConnectionState{}
 
-		logCertAuth(context.Background(), captureLogger(&buf), req)
+		logCertAuth(context.Background(), captureLogger(&buf), nil, req)
 
 		if buf.Len() != 0 {
 			t.Errorf("expected no log output, got %q", buf.String())
@@ -149,10 +151,10 @@ func TestLogCertAuth(t *testing.T) {
 }
 
 // TestAuditLoggerLevelFloor verifies the audit logger holds an Info floor no
-// matter what level the base logger is at — the managed-server default is -vv
-// (Debug), and without the floor the audit stream's own Debug records (loopback
-// traffic) would never be suppressed. It must also emit Info even when the base
-// is quieter than Info, so the audit trail can't be silenced by lowering -v.
+// matter what level the base logger is at. Without the floor, a verbosely-run
+// process would never suppress the audit stream's own Debug records (loopback
+// traffic). It must also emit Info even when the base is quieter than Info, so
+// the audit trail can't be silenced by lowering -v.
 func TestAuditLoggerLevelFloor(t *testing.T) {
 	levels := map[string]slog.Level{
 		"base at debug (-vv)": slog.LevelDebug,
@@ -328,4 +330,168 @@ func TestLogAccess(t *testing.T) {
 			t.Errorf("expected empty auth_method, got %v", rec["auth_method"])
 		}
 	})
+}
+
+// fakeClockDeduper returns a deduper whose clock the test drives directly, plus
+// a pointer to the current time so the test can advance it.
+func fakeClockDeduper(interval time.Duration) (*certAuthDeduper, *time.Time) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	d := newCertAuthDeduper()
+	d.interval = interval
+	d.now = func() time.Time { return now }
+	return d, &now
+}
+
+// TestCertAuthDeduper covers the collapsing rules for repeated cert-auth
+// records. The volume problem this solves is real: a coordinator with two
+// distributed runners emitted 5,958 identical-except-for-timestamp cert auth
+// lines per hour, 47% of everything it logged.
+func TestCertAuthDeduper(t *testing.T) {
+	key := certAuthKey{fingerprint: "fp-a", host: "10.0.0.1"}
+
+	t.Run("first sight logs, repeats within the interval do not", func(t *testing.T) {
+		d, _ := fakeClockDeduper(5 * time.Minute)
+
+		if logged, suppressed := d.record(key); !logged || suppressed != 0 {
+			t.Fatalf("first record: got (%v, %d), want (true, 0)", logged, suppressed)
+		}
+		for i := 0; i < 100; i++ {
+			if logged, _ := d.record(key); logged {
+				t.Fatalf("repeat %d logged, want suppressed", i)
+			}
+		}
+	})
+
+	t.Run("crossing the interval logs again and reports what it absorbed", func(t *testing.T) {
+		d, now := fakeClockDeduper(5 * time.Minute)
+
+		d.record(key)
+		for i := 0; i < 4999; i++ {
+			d.record(key)
+		}
+
+		*now = now.Add(5 * time.Minute)
+
+		logged, suppressed := d.record(key)
+		if !logged {
+			t.Fatal("expected a record once the interval elapsed")
+		}
+		if suppressed != 4999 {
+			t.Errorf("suppressed count: got %d, want 4999", suppressed)
+		}
+
+		// The counter resets, so the next window reports only its own.
+		if _, s := d.record(key); s != 0 {
+			t.Errorf("counter did not reset: got %d", s)
+		}
+	})
+
+	t.Run("ephemeral source ports collapse into one entry", func(t *testing.T) {
+		d, _ := fakeClockDeduper(5 * time.Minute)
+
+		// remoteHost strips the port, which is what makes dedup effective:
+		// a peer reconnecting from a new source port is the same peer.
+		first := certAuthKey{fingerprint: "fp-a", host: remoteHost("10.0.0.1:8444")}
+		second := certAuthKey{fingerprint: "fp-a", host: remoteHost("10.0.0.1:41857")}
+
+		if logged, _ := d.record(first); !logged {
+			t.Fatal("first port should log")
+		}
+		if logged, _ := d.record(second); logged {
+			t.Error("a different source port should not produce a second record")
+		}
+	})
+
+	t.Run("distinct peers and distinct certs are tracked separately", func(t *testing.T) {
+		d, _ := fakeClockDeduper(5 * time.Minute)
+
+		sameCertOtherHost := certAuthKey{fingerprint: "fp-a", host: "10.0.0.2"}
+		otherCertSameHost := certAuthKey{fingerprint: "fp-b", host: "10.0.0.1"}
+
+		for _, k := range []certAuthKey{key, sameCertOtherHost, otherCertSameHost} {
+			if logged, _ := d.record(k); !logged {
+				t.Errorf("key %+v should log on first sight", k)
+			}
+		}
+	})
+
+	t.Run("a nil deduper logs everything", func(t *testing.T) {
+		var d *certAuthDeduper
+		for i := 0; i < 3; i++ {
+			if logged, suppressed := d.record(key); !logged || suppressed != 0 {
+				t.Fatalf("nil deduper: got (%v, %d), want (true, 0)", logged, suppressed)
+			}
+		}
+	})
+
+	t.Run("the table stays bounded as peers churn", func(t *testing.T) {
+		d, now := fakeClockDeduper(5 * time.Minute)
+		d.max = 16
+
+		for i := 0; i < 500; i++ {
+			d.record(certAuthKey{fingerprint: "fp-a", host: fmt.Sprintf("10.0.%d.%d", i/256, i%256)})
+			// Advance a little so entries age out rather than all looking current.
+			*now = now.Add(time.Second)
+		}
+
+		if len(d.seen) > d.max {
+			t.Errorf("table grew past its cap: %d entries, max %d", len(d.seen), d.max)
+		}
+	})
+}
+
+// TestLogCertAuthDeduplicates checks the emitted records end to end: one line
+// for a burst, and a follow-up line carrying the suppressed count rather than
+// silently dropping the fact that authentication kept happening.
+func TestLogCertAuthDeduplicates(t *testing.T) {
+	cert := &x509.Certificate{
+		Raw:          []byte("cert-der"),
+		Subject:      pkix.Name{CommonName: "runner-1"},
+		Issuer:       pkix.Name{CommonName: "miren-ca"},
+		SerialNumber: big.NewInt(7),
+	}
+
+	newReq := func(addr string) *http.Request {
+		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
+		req.RemoteAddr = addr
+		req.TLS = &tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{cert},
+			VerifiedChains:   [][]*x509.Certificate{{cert}},
+		}
+		return req
+	}
+
+	var buf bytes.Buffer
+	d, now := fakeClockDeduper(5 * time.Minute)
+	log := captureLogger(&buf)
+
+	// A burst from one peer, including a reconnect on a fresh source port.
+	logCertAuth(context.Background(), log, d, newReq("10.0.0.1:8444"))
+	for i := 0; i < 999; i++ {
+		logCertAuth(context.Background(), log, d, newReq("10.0.0.1:41857"))
+	}
+
+	records := decodeRecords(t, &buf)
+	if len(records) != 1 {
+		t.Fatalf("expected the burst to collapse to 1 record, got %d", len(records))
+	}
+	if got := records[0]["subject"]; got != "CN=runner-1" {
+		t.Errorf("subject: got %v, want CN=runner-1", got)
+	}
+	if _, ok := records[0]["suppressed"]; ok {
+		t.Error("the first record should not claim to have suppressed anything")
+	}
+
+	// Once the interval passes, the next authentication reports the backlog.
+	buf.Reset()
+	*now = now.Add(5 * time.Minute)
+	logCertAuth(context.Background(), log, d, newReq("10.0.0.1:8444"))
+
+	records = decodeRecords(t, &buf)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record after the interval, got %d", len(records))
+	}
+	if got := records[0]["suppressed"]; got != float64(999) {
+		t.Errorf("suppressed: got %v, want 999", got)
+	}
 }

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -352,7 +352,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Audit successful cert-method auth. See logCertAuth for why this only
 		// ever records legitimate (internal) mTLS and never an attacker.
 		if identity.Method == AuthMethodCert {
-			logCertAuth(ctx, s.state.audit(), r)
+			logCertAuth(ctx, s.state.audit(), s.state.certAuth, r)
 		}
 	}
 

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -83,6 +83,11 @@ type StateCommon struct {
 	// server's -v verbosity. See newAuditLogger.
 	auditLog *slog.Logger
 
+	// certAuth collapses repeated cert-auth records for a long-lived peer into
+	// one per interval. Nil is valid and means no deduplication. See
+	// certAuthDeduper.
+	certAuth *certAuthDeduper
+
 	opts *stateOptions
 
 	serverTlsCfg *tls.Config
@@ -368,6 +373,7 @@ func NewState(ctx context.Context, opts ...StateOption) (*State, error) {
 			top:           ctx,
 			log:           so.log,
 			auditLog:      newAuditLogger(so.log),
+			certAuth:      newCertAuthDeduper(),
 			opts:          &so,
 			clientTlsCfg:  tlsCfg,
 			privkey:       priv,


### PR DESCRIPTION
`miren server install` defaulted `--verbosity` to `-vv`, so every systemd-installed coordinator ran at Debug indefinitely, while `miren runner install` had no verbosity option at all and inherited the CLI default of Warn. Neither was chosen for the job it was doing.

Before changing anything I measured what a running cluster actually logs, which was worth doing because the fix as filed would not have accomplished much. On a busy coordinator Info already accounts for around 90% of lines, so moving the default from Debug to Info barely registers. The real cost is the audit trail, roughly half of all bytes, and within it a single message. `audit cert auth` fires per-RPC rather than per-connection and re-serializes the full subject DN, issuer DN, serial and fingerprint every time, about 330 bytes a line, thousands of times an hour, to say that the same two runner certs are still the same two runner certs. Because the audit stream is pinned at an Info floor by design it is immune to `-v`, so no choice of default was ever going to reach it.

Hence three revs, in the order the problem revealed itself. Daemons now start their `-v` ladder at Info instead of inheriting the CLI's Warn, with the marker at the command registration site so the level is right however the process was launched rather than depending on every launch path remembering a flag. Cert-auth records are deduplicated per certificate and peer, emitted on first sight and once per interval afterwards carrying a count of what they absorbed. And the Info tier gets a pass over the measured top offenders, driven by emitted volume rather than by reading all 1,315 Info call sites.

Together those cut roughly two thirds of the bytes a coordinator writes.

One deliberate omission. `rpc access` is the largest remaining source, almost entirely `EntityAccess.get/list/put` from runners, and demoting it was the obvious next lever. It is the wrong one: runners hold a general-purpose entity API, so those records are the only visibility into an unconstrained surface, and quieting them would hide exactly the thing worth watching. That is MIR-1520 instead.

The rubric added to CLAUDE.md is the part meant to outlast this. 1,315 Info call sites against 325 Debug says Info is not a considered tier but the level everyone reaches for, and without a written rule it drifts back.

Measuring also surfaced real failures the noise had been hiding, filed as MIR-1518 and MIR-1519.

Closes MIR-1503
