### PR TITLE
Make workload identity subjects unambiguous

### DIFF
--- a/docs/docs/workload-identity.md
+++ b/docs/docs/workload-identity.md
@@ -116,6 +116,12 @@ The `sub` (subject) encodes the workload's identity as a path-like string, omitt
 org:<organization_id>:app:<app>:sandbox:<sandbox_id>
 ```
 
+:::warning[Subject delimiter]
+Each label and value is one colon-delimited segment. Miren refuses to mint a
+token when any segment contains `:`, rather than emit a subject that could be
+decoded as a different identity.
+:::
+
 A decoded token payload looks like:
 
 ```json

--- a/pkg/workloadidentity/issuer.go
+++ b/pkg/workloadidentity/issuer.go
@@ -92,10 +92,10 @@ var _ TokenIssuer = (*Issuer)(nil)
 // IdentityType names the kind of principal a token represents.
 //
 // The value travels as its own claim rather than being inferred from the
-// subject: buildSubject interpolates a user-controlled app name, so
-// prefix-matching a subject string is a forgery vector. Tokens issued before
-// this claim existed carry no identity_type, which reads as "not a system
-// workload" and so fails closed for system-only resources.
+// subject. This lets verifiers authorize an identity class without reparsing
+// the subject grammar. Tokens issued before this claim existed carry no
+// identity_type, which reads as "not a system workload" and so fails closed for
+// system-only resources.
 //
 // It is a defined type so that switches over it are exhaustiveness-checked,
 // the way rpc.AuthMethod already is. Note that this buys nothing at the trust
@@ -264,7 +264,12 @@ func (iss *Issuer) IssueToken(app, sandboxID string) (string, error) {
 }
 
 func (iss *Issuer) IssueTokenWithOptions(app, sandboxID string, opts TokenOptions) (string, error) {
-	claims := iss.baseClaims(buildSubject(iss.organizationID, app, sandboxID), opts)
+	subject, err := newSandboxSubject(iss.organizationID, app, sandboxID)
+	if err != nil {
+		return "", fmt.Errorf("building sandbox workload subject: %w", err)
+	}
+
+	claims := iss.baseClaims(subject, opts)
 	claims.App = app
 	claims.SandboxID = sandboxID
 	claims.IdentityType = IdentityTypeSandbox
@@ -275,7 +280,7 @@ func (iss *Issuer) IssueTokenWithOptions(app, sandboxID string, opts TokenOption
 // baseClaims fills in everything common to every token the cluster issues:
 // registered claims, the cluster metadata external verifiers federate on, and
 // the normalized audience and lifetime.
-func (iss *Issuer) baseClaims(subject string, opts TokenOptions) WorkloadClaims {
+func (iss *Issuer) baseClaims(subject Subject, opts TokenOptions) WorkloadClaims {
 	now := time.Now()
 
 	aud := opts.Audience
@@ -297,7 +302,7 @@ func (iss *Issuer) baseClaims(subject string, opts TokenOptions) WorkloadClaims 
 	return WorkloadClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    iss.issuerURL,
-			Subject:   subject,
+			Subject:   subject.String(),
 			Audience:  jwt.ClaimStrings(aud),
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),
@@ -435,16 +440,4 @@ func generateAndWriteKey(keyPath string) (*signingKey, error) {
 	}
 
 	return kp, nil
-}
-
-func buildSubject(orgID, app, sandboxID string) string {
-	var parts []string
-	if orgID != "" {
-		parts = append(parts, "org:"+orgID)
-	}
-	if app != "" {
-		parts = append(parts, "app:"+app)
-	}
-	parts = append(parts, "sandbox:"+sandboxID)
-	return strings.Join(parts, ":")
 }

--- a/pkg/workloadidentity/issuer_test.go
+++ b/pkg/workloadidentity/issuer_test.go
@@ -96,6 +96,19 @@ func TestIssueToken(t *testing.T) {
 	assert.NotNil(t, claims.ExpiresAt)
 }
 
+func TestIssueToken_RejectsAmbiguousSubject(t *testing.T) {
+	iss, err := NewIssuer(IssuerConfig{
+		DataPath:       t.TempDir(),
+		IssuerURL:      "https://example.miren.cloud",
+		OrganizationID: "org-123",
+	})
+	require.NoError(t, err)
+
+	_, err = iss.IssueToken("prod-api:sandbox:x", "sandbox/attacker")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `subject app value "prod-api:sandbox:x" contains reserved delimiter ":"`)
+}
+
 func TestIssueToken_NoOrg(t *testing.T) {
 	dir := t.TempDir()
 
@@ -337,24 +350,6 @@ func TestIssueTokenWithOptions_TTLClamping(t *testing.T) {
 	ttl2 := claims2.ExpiresAt.Sub(claims2.IssuedAt.Time)
 
 	assert.Equal(t, 60*time.Second, ttl2)
-}
-
-func TestBuildSubject(t *testing.T) {
-	tests := []struct {
-		org, app, sandbox string
-		expected          string
-	}{
-		{"org-1", "app-1", "sb-1", "org:org-1:app:app-1:sandbox:sb-1"},
-		{"", "app-1", "sb-1", "app:app-1:sandbox:sb-1"},
-		{"org-1", "", "sb-1", "org:org-1:sandbox:sb-1"},
-		{"", "", "sb-1", "sandbox:sb-1"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.expected, func(t *testing.T) {
-			assert.Equal(t, tt.expected, buildSubject(tt.org, tt.app, tt.sandbox))
-		})
-	}
 }
 
 // writeLegacyEdDSAKey writes a PKCS#8 PEM Ed25519 private key to keyPath,

--- a/pkg/workloadidentity/subject.go
+++ b/pkg/workloadidentity/subject.go
@@ -1,0 +1,84 @@
+package workloadidentity
+
+import (
+	"fmt"
+	"strings"
+)
+
+const subjectDelimiter = ":"
+
+// Subject is the structured identity rendered into a workload token's sub
+// claim. Its segments are private so every subject the issuer accepts has
+// passed through the delimiter validation in newSubject.
+type Subject struct {
+	segments []subjectSegment
+}
+
+type subjectSegment struct {
+	label string
+	value string
+}
+
+func newSubject(segments ...subjectSegment) (Subject, error) {
+	for _, segment := range segments {
+		if segment.label == "" {
+			return Subject{}, fmt.Errorf("subject segment label cannot be empty")
+		}
+		if strings.Contains(segment.label, subjectDelimiter) {
+			return Subject{}, fmt.Errorf("subject segment label %q contains reserved delimiter %q", segment.label, subjectDelimiter)
+		}
+		if strings.Contains(segment.value, subjectDelimiter) {
+			return Subject{}, fmt.Errorf("subject %s value %q contains reserved delimiter %q", segment.label, segment.value, subjectDelimiter)
+		}
+	}
+
+	return Subject{segments: append([]subjectSegment(nil), segments...)}, nil
+}
+
+func newSandboxSubject(orgID, app, sandboxID string) (Subject, error) {
+	var segments []subjectSegment
+	if orgID != "" {
+		segments = append(segments, subjectSegment{label: "org", value: orgID})
+	}
+	if app != "" {
+		segments = append(segments, subjectSegment{label: "app", value: app})
+	}
+	segments = append(segments, subjectSegment{label: "sandbox", value: sandboxID})
+	return newSubject(segments...)
+}
+
+func newSystemWorkloadSubject(orgID, clusterID string, workload SystemWorkload) (Subject, error) {
+	var segments []subjectSegment
+	if orgID != "" {
+		segments = append(segments, subjectSegment{label: "org", value: orgID})
+	}
+	if clusterID != "" {
+		segments = append(segments, subjectSegment{label: "cluster", value: clusterID})
+	}
+	segments = append(segments, subjectSegment{label: "system", value: string(workload)})
+	return newSubject(segments...)
+}
+
+// String renders the subject as alternating colon-delimited labels and values.
+func (s Subject) String() string {
+	parts := make([]string, 0, len(s.segments)*2)
+	for _, segment := range s.segments {
+		parts = append(parts, segment.label, segment.value)
+	}
+	return strings.Join(parts, subjectDelimiter)
+}
+
+// parseSubject exists to pin the grammar's governing property in tests: every
+// subject we emit must decode to exactly the segments that went in.
+func parseSubject(encoded string) (Subject, error) {
+	parts := strings.Split(encoded, subjectDelimiter)
+	if len(parts)%2 != 0 {
+		return Subject{}, fmt.Errorf("subject has an incomplete label/value pair")
+	}
+
+	segments := make([]subjectSegment, 0, len(parts)/2)
+	for i := 0; i < len(parts); i += 2 {
+		segments = append(segments, subjectSegment{label: parts[i], value: parts[i+1]})
+	}
+	return newSubject(segments...)
+}

--- a/pkg/workloadidentity/subject_test.go
+++ b/pkg/workloadidentity/subject_test.go
@@ -1,0 +1,153 @@
+package workloadidentity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubjectRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    func() (Subject, error)
+		expected string
+	}{
+		{
+			name: "sandbox with all metadata",
+			build: func() (Subject, error) {
+				return newSandboxSubject("org-1", "app-1", "sandbox/sb-1")
+			},
+			expected: "org:org-1:app:app-1:sandbox:sandbox/sb-1",
+		},
+		{
+			name: "sandbox without organization",
+			build: func() (Subject, error) {
+				return newSandboxSubject("", "app-1", "sandbox/sb-1")
+			},
+			expected: "app:app-1:sandbox:sandbox/sb-1",
+		},
+		{
+			name: "sandbox without app",
+			build: func() (Subject, error) {
+				return newSandboxSubject("org-1", "", "sandbox/sb-1")
+			},
+			expected: "org:org-1:sandbox:sandbox/sb-1",
+		},
+		{
+			name: "sandbox without optional metadata",
+			build: func() (Subject, error) {
+				return newSandboxSubject("", "", "sandbox/sb-1")
+			},
+			expected: "sandbox:sandbox/sb-1",
+		},
+		{
+			name: "system workload with all metadata",
+			build: func() (Subject, error) {
+				return newSystemWorkloadSubject("org-1", "cluster-1", SystemWorkloadSandboxController)
+			},
+			expected: "org:org-1:cluster:cluster-1:system:sandboxcontroller",
+		},
+		{
+			name: "system workload without organization",
+			build: func() (Subject, error) {
+				return newSystemWorkloadSubject("", "cluster-1", SystemWorkloadSandboxController)
+			},
+			expected: "cluster:cluster-1:system:sandboxcontroller",
+		},
+		{
+			name: "system workload without cluster",
+			build: func() (Subject, error) {
+				return newSystemWorkloadSubject("org-1", "", SystemWorkloadSandboxController)
+			},
+			expected: "org:org-1:system:sandboxcontroller",
+		},
+		{
+			name: "system workload without optional metadata",
+			build: func() (Subject, error) {
+				return newSystemWorkloadSubject("", "", SystemWorkloadSandboxController)
+			},
+			expected: "system:sandboxcontroller",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subject, err := tt.build()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, subject.String())
+
+			parsed, err := parseSubject(subject.String())
+			require.NoError(t, err)
+			assert.Equal(t, subject, parsed)
+		})
+	}
+}
+
+func TestSubjectRejectsReservedDelimiter(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func() (Subject, error)
+		field string
+	}{
+		{
+			name:  "sandbox organization",
+			build: func() (Subject, error) { return newSandboxSubject("org:1", "app-1", "sandbox/sb-1") },
+			field: "org",
+		},
+		{
+			name: "sandbox app",
+			build: func() (Subject, error) {
+				return newSandboxSubject("org-1", "evil:sandbox:sb-victim", "sandbox/sb-mine")
+			},
+			field: "app",
+		},
+		{
+			name:  "sandbox id",
+			build: func() (Subject, error) { return newSandboxSubject("org-1", "evil", "sb-victim:sandbox:sb-mine") },
+			field: "sandbox",
+		},
+		{
+			name: "system organization",
+			build: func() (Subject, error) {
+				return newSystemWorkloadSubject("org:1", "cluster-1", SystemWorkloadSandboxController)
+			},
+			field: "org",
+		},
+		{
+			name: "system cluster",
+			build: func() (Subject, error) {
+				return newSystemWorkloadSubject("org-1", "cluster:1", SystemWorkloadSandboxController)
+			},
+			field: "cluster",
+		},
+		{
+			name: "system workload",
+			build: func() (Subject, error) {
+				return newSystemWorkloadSubject("org-1", "cluster-1", SystemWorkload("bad:name"))
+			},
+			field: "system",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.build()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "subject "+tt.field+" value")
+		})
+	}
+}
+
+func TestParseSubjectRejectsMalformedEncoding(t *testing.T) {
+	for _, encoded := range []string{
+		"",
+		"org:org-1:app",
+		":value",
+	} {
+		t.Run(encoded, func(t *testing.T) {
+			_, err := parseSubject(encoded)
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/workloadidentity/system_workload.go
+++ b/pkg/workloadidentity/system_workload.go
@@ -2,7 +2,6 @@ package workloadidentity
 
 import (
 	"fmt"
-	"strings"
 )
 
 // SystemWorkload names a Miren-owned workload that may receive an identity.
@@ -54,24 +53,14 @@ func (iss *Issuer) IssueSystemWorkloadToken(workload SystemWorkload, opts TokenO
 		return "", fmt.Errorf("unknown system workload %q", workload)
 	}
 
-	claims := iss.baseClaims(buildSystemWorkloadSubject(iss.organizationID, iss.clusterID, workload), opts)
+	subject, err := newSystemWorkloadSubject(iss.organizationID, iss.clusterID, workload)
+	if err != nil {
+		return "", fmt.Errorf("building system workload subject: %w", err)
+	}
+
+	claims := iss.baseClaims(subject, opts)
 	claims.SystemWorkload = workload
 	claims.IdentityType = IdentityTypeSystem
 
 	return iss.sign(claims)
-}
-
-// buildSystemWorkloadSubject renders a system workload's subject as
-// org:<org>:cluster:<cluster>:system:<name>, omitting the org and cluster
-// segments when the cluster has no registration to supply them.
-func buildSystemWorkloadSubject(orgID, clusterID string, workload SystemWorkload) string {
-	var parts []string
-	if orgID != "" {
-		parts = append(parts, "org:"+orgID)
-	}
-	if clusterID != "" {
-		parts = append(parts, "cluster:"+clusterID)
-	}
-	parts = append(parts, "system:"+string(workload))
-	return strings.Join(parts, ":")
 }

--- a/pkg/workloadidentity/system_workload_test.go
+++ b/pkg/workloadidentity/system_workload_test.go
@@ -24,6 +24,14 @@ func testIssuer(t *testing.T) *Issuer {
 	return iss
 }
 
+func testSystemWorkloadSubject(t *testing.T) Subject {
+	t.Helper()
+
+	subject, err := newSystemWorkloadSubject("", "", SystemWorkloadSandboxController)
+	require.NoError(t, err)
+	return subject
+}
+
 func TestIssueSystemWorkloadToken_Claims(t *testing.T) {
 	iss := testIssuer(t)
 
@@ -184,7 +192,7 @@ func TestVerifyToken_RejectsExpiredToken(t *testing.T) {
 
 	// Build an already-expired token directly; IssueSystemWorkloadToken clamps TTL
 	// to MinTTL, so it cannot produce one.
-	claims := iss.baseClaims("system:sandboxcontroller", TokenOptions{
+	claims := iss.baseClaims(testSystemWorkloadSubject(t), TokenOptions{
 		Audience: []string{"miren-registry"},
 	})
 	claims.IdentityType = IdentityTypeSystem
@@ -219,7 +227,7 @@ func TestVerifyToken_RejectsTokenFromAnotherCluster(t *testing.T) {
 func TestVerifyToken_RejectsUnsignedToken(t *testing.T) {
 	iss := testIssuer(t)
 
-	claims := iss.baseClaims("system:sandboxcontroller", TokenOptions{
+	claims := iss.baseClaims(testSystemWorkloadSubject(t), TokenOptions{
 		Audience: []string{"miren-registry"},
 	})
 	claims.IdentityType = IdentityTypeSystem
@@ -237,7 +245,7 @@ func TestVerifyToken_RejectsUnsignedToken(t *testing.T) {
 func TestVerifyToken_RejectsTokenWithoutKID(t *testing.T) {
 	iss := testIssuer(t)
 
-	claims := iss.baseClaims("system:sandboxcontroller", TokenOptions{
+	claims := iss.baseClaims(testSystemWorkloadSubject(t), TokenOptions{
 		Audience: []string{"miren-registry"},
 	})
 	claims.IdentityType = IdentityTypeSystem


### PR DESCRIPTION
We were assembling workload identity `sub` claims by joining labels and values with `:`, but the delimiter was still allowed inside those values. That let distinct workloads collapse to the same federation identity. The OCI registry happened to block the dangerous app name from running today, which meant the identity boundary was leaning on an unrelated subsystem.

This gives the grammar an owner. Both sandbox and system workload issuers now build a validated `Subject`, and the shared claim builder no longer accepts raw strings. An unexported parser and round-trip tests pin the governing property: everything we emit decodes to exactly the segments that went in. Valid subjects stay byte-for-byte identical, while ambiguous values fail minting.

I also checked the deployed app inventories on garden, toys, and eu1. None has a colon-bearing name, so this tightening does not need a migration path.

Closes MIR-1486