### PR TITLE
Fetch the container spec through the sandbox ops adapter

### DIFF
--- a/controllers/sandbox/create_saga.go
+++ b/controllers/sandbox/create_saga.go
@@ -253,7 +253,7 @@ func bootTask(ctx context.Context, in bootTaskIn) (bootTaskOut, error) {
 		return bootTaskOut{}, fmt.Errorf("booting task: %w", err)
 	}
 
-	rootSpec, err := container.Spec(ctx)
+	rootSpec, err := deps.runtime.ContainerSpec(ctx, container)
 	if err != nil {
 		return bootTaskOut{}, fmt.Errorf("getting container spec: %w", err)
 	}

--- a/controllers/sandbox/create_saga_test.go
+++ b/controllers/sandbox/create_saga_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	apitypes "github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/namespaces"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/cio"
@@ -184,6 +185,12 @@ func (m *mockContainerRuntime) CreateContainer(ctx context.Context, id string, o
 	return id, nil
 }
 
+// ContainerSpec mirrors sandboxOps: the namespace is the adapter's job to
+// supply, not the saga action's.
+func (m *mockContainerRuntime) ContainerSpec(ctx context.Context, cont containerd.Container) (*oci.Spec, error) {
+	return cont.Spec(namespaces.WithNamespace(ctx, "miren-test"))
+}
+
 func (m *mockContainerRuntime) LoadContainer(ctx context.Context, id string) (containerd.Container, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -331,6 +338,10 @@ type sagaMockContainer struct {
 	id     string
 	spec   *oci.Spec
 	taskFn func(context.Context, cio.Attach) (containerd.Task, error)
+
+	// specNamespace records the containerd namespace the last Spec call
+	// arrived with, so tests can assert the caller supplied one.
+	specNamespace string
 }
 
 func (c *sagaMockContainer) ID() string { return c.id }
@@ -341,7 +352,16 @@ func (c *sagaMockContainer) Delete(context.Context, ...containerd.DeleteOpts) er
 func (c *sagaMockContainer) NewTask(context.Context, cio.Creator, ...containerd.NewTaskOpts) (containerd.Task, error) {
 	return nil, nil
 }
+
+// Spec refuses an un-namespaced context the way containerd does, so a caller
+// that goes around sandboxOps fails here instead of silently passing on a
+// client that happens to have a default namespace configured.
 func (c *sagaMockContainer) Spec(ctx context.Context) (*oci.Spec, error) {
+	ns, ok := namespaces.Namespace(ctx)
+	if !ok {
+		return nil, fmt.Errorf("namespace is required: %w", errdefs.ErrFailedPrecondition)
+	}
+	c.specNamespace = ns
 	return c.spec, nil
 }
 func (c *sagaMockContainer) Task(ctx context.Context, attach cio.Attach) (containerd.Task, error) {

--- a/controllers/sandbox/interface.go
+++ b/controllers/sandbox/interface.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/oci"
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/network"
@@ -45,6 +46,11 @@ type SandboxContainerRuntime interface {
 	BuildSpec(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, meta *entity.Meta) ([]containerd.NewContainerOpts, error)
 	CreateContainer(ctx context.Context, id string, opts ...containerd.NewContainerOpts) (string, error)
 	LoadContainer(ctx context.Context, id string) (containerd.Container, error)
+	// ContainerSpec fetches a loaded container's OCI spec. Callers must go
+	// through here rather than calling cont.Spec directly: containerd resolves
+	// the container out of the namespace on the context, and only this
+	// implementation knows which namespace that is.
+	ContainerSpec(ctx context.Context, cont containerd.Container) (*oci.Spec, error)
 	CleanupContainer(ctx context.Context, cont containerd.Container)
 	BootInitialTask(ctx context.Context, sb *compute.Sandbox, ep *network.EndpointConfig, container containerd.Container, shortID string) (containerd.Task, error)
 	ConfigureVolumes(ctx context.Context, sb *compute.Sandbox, meta *entity.Meta) (map[string]string, error)

--- a/controllers/sandbox/sandbox_ops.go
+++ b/controllers/sandbox/sandbox_ops.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/containerd/containerd/namespaces"
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
@@ -105,6 +106,11 @@ func (o *sandboxOps) CreateContainer(ctx context.Context, id string, opts ...con
 func (o *sandboxOps) LoadContainer(ctx context.Context, id string) (containerd.Container, error) {
 	ctx = namespaces.WithNamespace(ctx, o.ctrl.Namespace)
 	return o.ctrl.CC.LoadContainer(ctx, id)
+}
+
+func (o *sandboxOps) ContainerSpec(ctx context.Context, cont containerd.Container) (*oci.Spec, error) {
+	ctx = namespaces.WithNamespace(ctx, o.ctrl.Namespace)
+	return cont.Spec(ctx)
 }
 
 func (o *sandboxOps) CleanupContainer(ctx context.Context, cont containerd.Container) {

--- a/controllers/sandbox/sandbox_ops_test.go
+++ b/controllers/sandbox/sandbox_ops_test.go
@@ -1,0 +1,35 @@
+package sandbox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The saga actions hold a context that nobody has namespaced, so every
+// containerd call has to pick up the namespace on its way through sandboxOps.
+// ContainerSpec used to be missing from that adapter and the saga called
+// cont.Spec directly, which only worked because the server happens to build
+// its containerd client with a default namespace. Anyone constructing a client
+// without one (the test harness, for instance) got "namespace is required"
+// instead.
+func TestSandboxOpsContainerSpecCarriesNamespace(t *testing.T) {
+	cont := &sagaMockContainer{
+		id: "test-sandbox-1",
+		spec: &oci.Spec{
+			Linux: &specs.Linux{CgroupsPath: "/sys/fs/cgroup/sandbox/test-sandbox-1"},
+		},
+	}
+
+	ops := &sandboxOps{ctrl: &SandboxController{Namespace: "miren-test"}}
+
+	spec, err := ops.ContainerSpec(context.Background(), cont)
+	require.NoError(t, err)
+	assert.Equal(t, "/sys/fs/cgroup/sandbox/test-sandbox-1", spec.Linux.CgroupsPath)
+	assert.Equal(t, "miren-test", cont.specNamespace,
+		"ContainerSpec must namespace the context before handing it to containerd")
+}


### PR DESCRIPTION
The saga's boot-task action called `container.Spec` on the raw action context. Every other containerd call in that path goes through `sandboxOps`, which wraps the context with the controller's namespace on the way past, so this one call was the only one running without a namespace.

It worked anyway, because the server builds its containerd client with `WithDefaultNamespace` and the gRPC interceptor backfills the namespace when the context doesn't carry one. Build a client without that default (`pkg/testutils` does) and the same call fails with "namespace is required".

`ContainerSpec` joins the runtime interface next to its siblings, and the saga mock now refuses an un-namespaced context the way containerd does, so going around the adapter fails in a unit test instead of waiting for someone's client to lack a default.

Split out of #972. This is a fix on the saga path, which is still off by default, so it carries no risk for a stock cluster and no reason to wait for the flag decision.
