### PR TITLE
Report where every labs feature landed, and document turning one off

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -23,9 +24,11 @@ func Run(args []string) int {
 		labs.EnableAll()
 	}
 
-	// Initialize labs feature flags from environment before registering commands
+	// Initialize labs feature flags from environment before registering commands.
+	// Discard the log: this only decides which commands get registered, and the
+	// server logs the same thing properly when it starts.
 	if labsEnv := os.Getenv("MIREN_LABS"); labsEnv != "" {
-		labs.Init(nil, strings.Split(labsEnv, ","))
+		labs.Init(slog.New(slog.DiscardHandler), strings.Split(labsEnv, ","))
 	}
 
 	d := mflags.NewDispatcher("miren")

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -11,6 +11,9 @@ All notable changes to Miren Runtime will be documented in this file.
 ## Unreleased
 *main*
 
+**Improvements**
+- **Labs features say where they landed, and how to turn one off** - A labs feature that defaults to on used to say nothing at boot, which is exactly the state an operator most wants confirmed, and the docs only covered switching features on. Every boot now logs a `labs features` line reporting where each feature ended up whether or not you named it, and [Miren Labs](/labs) documents the `-` prefix (`--labs -distributedrunners`, `MIREN_LABS=-distributedrunners`) that turns a feature back off. ([#1012](https://github.com/mirendev/runtime/pull/1012))
+
 ---
 
 ## v0.12.1

--- a/docs/docs/labs.md
+++ b/docs/docs/labs.md
@@ -15,9 +15,12 @@ Miren Labs is where we ship experimental features that aren't quite ready for pr
 Labs features are:
 
 - **Experimental** — APIs and behavior may change based on feedback
-- **Opt-in** — Disabled by default, you choose when to try them
+- **Opt-in** — Off by default, you choose when to try them
+- **Reversible** — Anything you turn on you can turn back off
 - **Supported** — We want to hear about bugs and rough edges
 - **On a path** — Most labs features are headed toward stable release
+
+When a feature graduates to stable it flips on by default and stops being opt-in, but we leave its flag in place for a release so you can turn it back off if the new behavior causes trouble. After that release the flag and the old behavior both go away.
 
 ## Enabling Labs Features
 
@@ -38,6 +41,25 @@ MIREN_LABS=distributedrunners miren server
 MIREN_LABS=distributedrunners,sagas miren server
 ```
 </CliCommand>
+
+## Turning a Feature Off
+
+Prefix a feature name with `-` to disable it. This is how you back out of a feature that's on by default, and it takes the same flag and environment variable as enabling.
+
+<CliCommand context="server">
+```miren
+# Turn off a feature that is on by default
+miren server --labs -distributedrunners
+
+# Via environment variable
+MIREN_LABS=-distributedrunners miren server
+
+# Mix and match: sagas on, distributed runners off
+MIREN_LABS=sagas,-distributedrunners miren server
+```
+</CliCommand>
+
+Check the server log to confirm the setting landed. Every boot logs a `labs features` line listing where each feature ended up, whether or not you named it.
 
 ## Giving Feedback
 

--- a/pkg/labs/cmd/labsgen/main.go
+++ b/pkg/labs/cmd/labsgen/main.go
@@ -89,6 +89,7 @@ package labs
 
 import (
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -134,6 +135,8 @@ var featureDefaults = map[string]bool{
 // Each flag can be a feature name to enable it, or prefixed with "-" to disable it.
 // Unknown feature names are logged as warnings but do not cause an error.
 // This function should be called once at startup.
+//
+// log is required; pass slog.New(slog.DiscardHandler) to silence it.
 func Init(log *slog.Logger, flags []string) {
 	mu.Lock()
 	defer mu.Unlock()
@@ -164,25 +167,31 @@ func Init(log *slog.Logger, flags []string) {
 			for featureName := range featureDefaults {
 				enabledFeatures[featureName] = !disable
 			}
-			if log != nil {
-				log.Info("labs feature configured", "feature", "all", "enabled", !disable)
-			}
 			continue
 		}
 
 		// Check if it's a known feature
 		if _, known := featureDefaults[name]; !known {
-			if log != nil {
-				log.Warn("unknown labs feature flag", "flag", flag)
-			}
+			log.Warn("unknown labs feature flag", "flag", flag)
 			continue
 		}
 
 		enabledFeatures[name] = !disable
-		if log != nil {
-			log.Info("labs feature configured", "feature", name, "enabled", !disable)
-		}
 	}
+
+	// Report where every feature landed, not just the ones that were named.
+	// Features that default to on say nothing on their own, so without this
+	// the boot log is silent about the state an operator most wants to see.
+	names := AllFeatures()
+	sort.Strings(names)
+
+	attrs := make([]any, 0, len(names)*2)
+	for _, name := range names {
+		// Read the map directly: IsEnabled takes the read lock we already hold.
+		attrs = append(attrs, name, enabledFeatures[name])
+	}
+
+	log.Info("labs features", attrs...)
 }
 
 // Reset resets the feature flags to their default state.

--- a/pkg/labs/labs.gen.go
+++ b/pkg/labs/labs.gen.go
@@ -4,6 +4,7 @@ package labs
 
 import (
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -45,6 +46,8 @@ var featureDefaults = map[string]bool{
 // Each flag can be a feature name to enable it, or prefixed with "-" to disable it.
 // Unknown feature names are logged as warnings but do not cause an error.
 // This function should be called once at startup.
+//
+// log is required; pass slog.New(slog.DiscardHandler) to silence it.
 func Init(log *slog.Logger, flags []string) {
 	mu.Lock()
 	defer mu.Unlock()
@@ -75,25 +78,31 @@ func Init(log *slog.Logger, flags []string) {
 			for featureName := range featureDefaults {
 				enabledFeatures[featureName] = !disable
 			}
-			if log != nil {
-				log.Info("labs feature configured", "feature", "all", "enabled", !disable)
-			}
 			continue
 		}
 
 		// Check if it's a known feature
 		if _, known := featureDefaults[name]; !known {
-			if log != nil {
-				log.Warn("unknown labs feature flag", "flag", flag)
-			}
+			log.Warn("unknown labs feature flag", "flag", flag)
 			continue
 		}
 
 		enabledFeatures[name] = !disable
-		if log != nil {
-			log.Info("labs feature configured", "feature", name, "enabled", !disable)
-		}
 	}
+
+	// Report where every feature landed, not just the ones that were named.
+	// Features that default to on say nothing on their own, so without this
+	// the boot log is silent about the state an operator most wants to see.
+	names := AllFeatures()
+	sort.Strings(names)
+
+	attrs := make([]any, 0, len(names)*2)
+	for _, name := range names {
+		// Read the map directly: IsEnabled takes the read lock we already hold.
+		attrs = append(attrs, name, enabledFeatures[name])
+	}
+
+	log.Info("labs features", attrs...)
 }
 
 // Reset resets the feature flags to their default state.

--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -7,11 +7,16 @@ import (
 	"testing"
 )
 
+// quiet is for the tests that assert on feature state rather than on log output.
+func quiet() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
 func TestDisableFeatureWithPrefix(t *testing.T) {
 	Reset()
 
 	// Enable first, then disable
-	Init(nil, []string{"sagas", "-sagas"})
+	Init(quiet(), []string{"sagas", "-sagas"})
 
 	if Sagas() {
 		t.Error("Sagas should be disabled after '-sagas'")
@@ -21,7 +26,7 @@ func TestDisableFeatureWithPrefix(t *testing.T) {
 func TestCaseInsensitiveFeatureNames(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"Sagas", "DISTRIBUTEDRUNNERS"})
+	Init(quiet(), []string{"Sagas", "DISTRIBUTEDRUNNERS"})
 
 	if !Sagas() {
 		t.Error("Sagas should be enabled (case-insensitive)")
@@ -51,7 +56,7 @@ func TestUnknownFeatureLogsWarning(t *testing.T) {
 func TestEmptyAndWhitespaceFlags(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"", "  ", "sagas", "  ", ""})
+	Init(quiet(), []string{"", "  ", "sagas", "  ", ""})
 
 	if !Sagas() {
 		t.Error("Sagas should be enabled despite empty/whitespace flags")
@@ -61,7 +66,7 @@ func TestEmptyAndWhitespaceFlags(t *testing.T) {
 func TestAllKeywordEnablesAllFeatures(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"all"})
+	Init(quiet(), []string{"all"})
 
 	for _, name := range AllFeatures() {
 		if !IsEnabled(name) {
@@ -73,7 +78,7 @@ func TestAllKeywordEnablesAllFeatures(t *testing.T) {
 func TestAllKeywordWithExclusion(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"all", "-distributedrunners"})
+	Init(quiet(), []string{"all", "-distributedrunners"})
 
 	for _, name := range AllFeatures() {
 		if name == FeatureDistributedRunners {
@@ -91,7 +96,7 @@ func TestAllKeywordWithExclusion(t *testing.T) {
 func TestNegativeAllDisablesAll(t *testing.T) {
 	Reset()
 
-	Init(nil, []string{"sagas", "distributedrunners", "-all"})
+	Init(quiet(), []string{"sagas", "distributedrunners", "-all"})
 
 	for _, name := range AllFeatures() {
 		if IsEnabled(name) {


### PR DESCRIPTION
#971 graduates distributed runners to on-by-default, which makes `MIREN_LABS=-distributedrunners` the escape hatch for anyone the new default bites. Nothing in the docs mentions that lever exists. `labs.md` still opens by telling you labs features are "Disabled by default," which stops being true the moment that flip ships. So this covers the graduation path on its own, ahead of any particular feature taking it, and it wants to be in the same release as #971.

`labs.md` gains the `-` prefix with worked examples, a note that a graduated feature keeps its flag for one release before both it and the old behavior go away, and "Reversible" alongside the other expectations.

`Init` grew a matching gap. The per-feature "labs feature configured" lines only fired for features you named explicitly, so a feature defaulting to on said nothing at all, which is exactly the state an operator wants confirmed after an upgrade changed it. `Init` now reports where every feature ended up, named or not, on one line at boot. That lands where the rubric added in #1009 puts it: a startup confirmation, once per process, not something that repeats identically forever.

`Init` also requires a logger now instead of treating nil as "be quiet". The one caller that wanted silence says so with `slog.DiscardHandler`.

Split out of #972, which is now just the saga default flip and is being held for a later release so distributed runners get one of their own.
