### PR TITLE
Stop telling readers to enable a labs feature that ships on

### DIFF
--- a/cli/commands/server_install_container.go
+++ b/cli/commands/server_install_container.go
@@ -36,7 +36,7 @@ func ServerInstallContainer(ctx *Context, opts struct {
 	ClusterName   string            `long:"cluster-name" description:"Cluster name for cloud registration"`
 	CloudURL      string            `short:"u" long:"url" description:"Cloud URL for registration" default:"https://miren.cloud"`
 	Tags          map[string]string `short:"t" long:"tag" description:"Tags for the cluster (key:value)"`
-	Labs          []string          `short:"l" long:"labs" description:"Miren Labs features to enable (e.g. distributedrunners). Prefix with - to disable."`
+	Labs          []string          `short:"l" long:"labs" description:"Miren Labs features to enable (e.g. sagas). Prefix with - to disable."`
 }) error {
 	if opts.ClusterName == "" {
 		opts.ClusterName = opts.Name

--- a/docs/docs/command/runner-cordon.md
+++ b/docs/docs/command/runner-cordon.md
@@ -8,10 +8,6 @@ description: "Mark a runner unschedulable without stopping its sandboxes"
 
 Mark a runner unschedulable without stopping its sandboxes
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-drain.md
+++ b/docs/docs/command/runner-drain.md
@@ -8,10 +8,6 @@ description: "Cordon a runner and evict its sandboxes onto other nodes"
 
 Cordon a runner and evict its sandboxes onto other nodes
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-install.md
+++ b/docs/docs/command/runner-install.md
@@ -8,10 +8,6 @@ description: "Install systemd service for miren runner"
 
 Install systemd service for miren runner
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-join.md
+++ b/docs/docs/command/runner-join.md
@@ -8,10 +8,6 @@ description: "Join this machine to a coordinator as a runner"
 
 Join this machine to a coordinator as a runner
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-list.md
+++ b/docs/docs/command/runner-list.md
@@ -8,10 +8,6 @@ description: "List all registered runners"
 
 List all registered runners
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-reissue.md
+++ b/docs/docs/command/runner-reissue.md
@@ -8,10 +8,6 @@ description: "Rotate this runner's certificate in place (requires a still-valid 
 
 Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-remove.md
+++ b/docs/docs/command/runner-remove.md
@@ -8,10 +8,6 @@ description: "Remove a registered runner and clean up resources"
 
 Remove a registered runner and clean up resources
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-service-status.md
+++ b/docs/docs/command/runner-service-status.md
@@ -8,10 +8,6 @@ description: "Show miren-runner systemd service status"
 
 Show miren-runner systemd service status
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-start.md
+++ b/docs/docs/command/runner-start.md
@@ -8,10 +8,6 @@ description: "Start this machine as a distributed runner"
 
 Start this machine as a distributed runner
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-status.md
+++ b/docs/docs/command/runner-status.md
@@ -8,10 +8,6 @@ description: "Show runner health and configuration"
 
 Show runner health and configuration
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-token-create.md
+++ b/docs/docs/command/runner-token-create.md
@@ -8,10 +8,6 @@ description: "Create a join token for a runner"
 
 Create a join token for a runner
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-token-list.md
+++ b/docs/docs/command/runner-token-list.md
@@ -8,10 +8,6 @@ description: "List all join tokens"
 
 List all join tokens
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-token-revoke.md
+++ b/docs/docs/command/runner-token-revoke.md
@@ -8,10 +8,6 @@ description: "Revoke a join token"
 
 Revoke a join token
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-uncordon.md
+++ b/docs/docs/command/runner-uncordon.md
@@ -8,10 +8,6 @@ description: "Make a cordoned runner eligible for scheduling again"
 
 Make a cordoned runner eligible for scheduling again
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-uninstall.md
+++ b/docs/docs/command/runner-uninstall.md
@@ -8,10 +8,6 @@ description: "Remove systemd service for miren runner"
 
 Remove systemd service for miren runner
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-upgrade-rollback.md
+++ b/docs/docs/command/runner-upgrade-rollback.md
@@ -8,10 +8,6 @@ description: "Rollback runner to previous version"
 
 Rollback runner to previous version
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/runner-upgrade.md
+++ b/docs/docs/command/runner-upgrade.md
@@ -8,10 +8,6 @@ description: "Upgrade miren runner to the latest or specified version"
 
 Upgrade miren runner to the latest or specified version
 
-:::note
-This command requires the `distributedrunners` [labs feature](/labs) to be enabled.
-:::
-
 ## Usage
 
 ```bash

--- a/docs/docs/command/server-container-install.md
+++ b/docs/docs/command/server-container-install.md
@@ -23,7 +23,7 @@ miren server container install [flags]
 - `--http-port` — HTTP port mapping (default: `80`)
 - `--image, -i` — Container image to use (default: `oci.miren.cloud/miren:latest`)
 - `--ingress-mode` — Ingress mode: tls-autoprovision (default), behind-proxy-http (Miren serves plain HTTP behind a TLS-terminating proxy like tailscale serve / nginx), or behind-proxy-https (Miren terminates TLS on :443 behind a TCP-passthrough proxy)
-- `--labs, -l` — Miren Labs features to enable (e.g. distributedrunners). Prefix with - to disable.
+- `--labs, -l` — Miren Labs features to enable (e.g. sagas). Prefix with - to disable.
 - `--name, -n` — Container name
 - `--runtime` — Container runtime to use: docker or podman (auto-detected by default, preferring docker)
 - `--url, -u` — Cloud URL for registration (default: `https://miren.cloud`)

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -194,24 +194,24 @@ Complete reference for all `miren` CLI commands.
 | Command | Description |
 |---------|-------------|
 | [`miren runner`](/command/runner) | Runner management commands |
-| [`miren runner cordon`](/command/runner-cordon) | Mark a runner unschedulable without stopping its sandboxes _(`distributedrunners`)_ |
-| [`miren runner drain`](/command/runner-drain) | Cordon a runner and evict its sandboxes onto other nodes _(`distributedrunners`)_ |
-| [`miren runner install`](/command/runner-install) | Install systemd service for miren runner _(`distributedrunners`)_ |
-| [`miren runner join`](/command/runner-join) | Join this machine to a coordinator as a runner _(`distributedrunners`)_ |
-| [`miren runner list`](/command/runner-list) | List all registered runners _(`distributedrunners`)_ |
-| [`miren runner reissue`](/command/runner-reissue) | Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity _(`distributedrunners`)_ |
-| [`miren runner remove`](/command/runner-remove) | Remove a registered runner and clean up resources _(`distributedrunners`)_ |
-| [`miren runner service-status`](/command/runner-service-status) | Show miren-runner systemd service status _(`distributedrunners`)_ |
-| [`miren runner start`](/command/runner-start) | Start this machine as a distributed runner _(`distributedrunners`)_ |
-| [`miren runner status`](/command/runner-status) | Show runner health and configuration _(`distributedrunners`)_ |
+| [`miren runner cordon`](/command/runner-cordon) | Mark a runner unschedulable without stopping its sandboxes |
+| [`miren runner drain`](/command/runner-drain) | Cordon a runner and evict its sandboxes onto other nodes |
+| [`miren runner install`](/command/runner-install) | Install systemd service for miren runner |
+| [`miren runner join`](/command/runner-join) | Join this machine to a coordinator as a runner |
+| [`miren runner list`](/command/runner-list) | List all registered runners |
+| [`miren runner reissue`](/command/runner-reissue) | Rotate this runner's certificate in place (requires a still-valid cert), keeping its identity |
+| [`miren runner remove`](/command/runner-remove) | Remove a registered runner and clean up resources |
+| [`miren runner service-status`](/command/runner-service-status) | Show miren-runner systemd service status |
+| [`miren runner start`](/command/runner-start) | Start this machine as a distributed runner |
+| [`miren runner status`](/command/runner-status) | Show runner health and configuration |
 | [`miren runner token`](/command/runner-token) | Manage join tokens |
-| [`miren runner token create`](/command/runner-token-create) | Create a join token for a runner _(`distributedrunners`)_ |
-| [`miren runner token list`](/command/runner-token-list) | List all join tokens _(`distributedrunners`)_ |
-| [`miren runner token revoke`](/command/runner-token-revoke) | Revoke a join token _(`distributedrunners`)_ |
-| [`miren runner uncordon`](/command/runner-uncordon) | Make a cordoned runner eligible for scheduling again _(`distributedrunners`)_ |
-| [`miren runner uninstall`](/command/runner-uninstall) | Remove systemd service for miren runner _(`distributedrunners`)_ |
-| [`miren runner upgrade`](/command/runner-upgrade) | Upgrade miren runner to the latest or specified version _(`distributedrunners`)_ |
-| [`miren runner upgrade rollback`](/command/runner-upgrade-rollback) | Rollback runner to previous version _(`distributedrunners`)_ |
+| [`miren runner token create`](/command/runner-token-create) | Create a join token for a runner |
+| [`miren runner token list`](/command/runner-token-list) | List all join tokens |
+| [`miren runner token revoke`](/command/runner-token-revoke) | Revoke a join token |
+| [`miren runner uncordon`](/command/runner-uncordon) | Make a cordoned runner eligible for scheduling again |
+| [`miren runner uninstall`](/command/runner-uninstall) | Remove systemd service for miren runner |
+| [`miren runner upgrade`](/command/runner-upgrade) | Upgrade miren runner to the latest or specified version |
+| [`miren runner upgrade rollback`](/command/runner-upgrade-rollback) | Rollback runner to previous version |
 
 ## sandbox
 

--- a/hack/gen-command-docs
+++ b/hack/gen-command-docs
@@ -7,7 +7,7 @@
 #
 # Usage: ./hack/gen-command-docs
 #
-# Requires bin/miren to be built first (make bin/miren).
+# Requires bin/miren to be built first (make bin/miren), plus jq and yq.
 
 set -euo pipefail
 
@@ -35,6 +35,17 @@ jq -c '
     ((.subcommands // [])[] | flatten_with_subs);
   [.commands[] | flatten_with_subs]
 ' "$WORK_DIR/help.json" > "$WORK_DIR/all_commands.json"
+
+# A feature keeps its gating after it ships enabled, so operators retain an
+# escape hatch (`--labs -<name>`). That means the help JSON still reports a
+# requiredFeature for commands nobody has to opt into anymore. What decides
+# whether a reader has anything to do is the default in features.yaml, not the
+# presence of the gate, so that default drives the note and the index badge.
+DEFAULT_ON_FEATURES=$(yq -o=json -I=0 '[.features[] | select(.default) | .name]' "$ROOT_DIR/pkg/labs/features.yaml")
+
+is_default_on() {
+  jq -e --arg f "$1" 'index($f) != null' <<< "$DEFAULT_ON_FEATURES" > /dev/null
+}
 
 # Prepare output directory
 rm -rf "$OUT_DIR"
@@ -150,9 +161,9 @@ generate_command_doc() {
     # --- Required feature flag ---
     local required_feature
     required_feature=$(echo "$cmd_json" | jq -r '.requiredFeature // ""')
-    if [ -n "$required_feature" ]; then
+    if [ -n "$required_feature" ] && ! is_default_on "$required_feature"; then
       echo ""
-      echo ":::note"
+      echo ":::note[Labs feature]"
       echo "This command requires the \`$required_feature\` [labs feature](/labs) to be enabled."
       echo ":::"
     fi
@@ -316,7 +327,7 @@ generate_commands_index() {
   local outfile="$ROOT_DIR/docs/docs/commands.md"
 
   # Build main command sections (excluding internal and debug)
-  jq -r '
+  jq -r --argjson on "$DEFAULT_ON_FEATURES" '
     [.[] | select(
       (.path | startswith("internal") | not) and
       (.path | startswith("debug") | not) and
@@ -330,20 +341,22 @@ generate_commands_index() {
     "| Command | Description |\n|---------|-------------|\n" +
     ([.[] |
       (.path | gsub(" "; "-")) as $filename |
-      (if (.requiredFeature // "") != "" then " _(`\(.requiredFeature)`)_" else "" end) as $badge |
+      (.requiredFeature // "") as $feat |
+      (if $feat != "" and ($on | index($feat)) == null then " _(`\($feat)`)_" else "" end) as $badge |
       "| [`miren \(.path)`](/command/\($filename)) | \(.usage)\($badge) |"
     ] | join("\n")) +
     "\n"
   ' "$WORK_DIR/all_commands.json" > "$WORK_DIR/command_sections.md"
 
   # Build debug command section
-  jq -r '
+  jq -r --argjson on "$DEFAULT_ON_FEATURES" '
     [.[] | select(.path | startswith("debug"))] |
     if length > 0 then
       "| Command | Description |\n|---------|-------------|\n" +
       ([.[] |
         (.path | gsub(" "; "-")) as $filename |
-        (if (.requiredFeature // "") != "" then " _(`\(.requiredFeature)`)_" else "" end) as $badge |
+        (.requiredFeature // "") as $feat |
+        (if $feat != "" and ($on | index($feat)) == null then " _(`\($feat)`)_" else "" end) as $badge |
         "| [`miren \(.path)`](/command/\($filename)) | \(.usage)\($badge) |"
       ] | join("\n")) +
       "\n"


### PR DESCRIPTION
#971 flipped distributed runners on by default while deliberately keeping the labs gate as an escape hatch. That leaves the docs saying something that isn't true anymore: every `miren runner *` page opens by telling you to enable `distributedrunners` first, and the commands index tags all seventeen with a `_(distributedrunners)_` badge.

The generator was keying off the wrong signal. `hack/gen-command-docs` emitted the note whenever a command carried a `requiredFeature` at all, and a graduated feature keeps that gate on purpose, so the help JSON still reports one for commands nobody has to opt into anymore. What actually decides whether a reader has anything to do is the feature's default, so the script now reads that from `pkg/labs/features.yaml` and skips both the note and the badge for anything shipping enabled. It needs `yq` alongside `jq` now, and the header says so. A feature that's still opt-in is unaffected: I flipped the default back to `false` locally and confirmed all seventeen notes and badges come back.

Two smaller things came along. The remaining note gained a bracketed title (`:::note[Labs feature]`), since `docs/CLAUDE.md` requires titles on admonitions and asks this generator to follow the same rules, and the docs lint excludes generated pages so it had been drifting quietly. And `server install container`'s `--labs` flag used `distributedrunners` as its example of a feature to enable, which is now a no-op, so it points at `sagas` instead.

`labs.md` is untouched here on purpose. #1012 covers the graduation story and the `-` escape hatch in that file.

Verified with `make docs-lint` and a clean regeneration against current main.
