### PR TITLE
Fix the coordinator API port and cover runners in the surrounding docs

### DIFF
--- a/docs/docs/distributed-runners.md
+++ b/docs/docs/distributed-runners.md
@@ -79,9 +79,13 @@ machines it needs to allow rather more than 8443. These are the defaults:
 
 | Port | Protocol | What it carries | Protection |
 |------|----------|-----------------|------------|
-| 8443 | TCP | Coordinator API, including join and the metrics and logs a runner ships | Join token while enrolling, mTLS afterward |
+| 8443 | UDP | Coordinator API, including join and the metrics and logs a runner ships | Join token while enrolling, mTLS afterward |
 | 12379 | TCP | etcd, for Flannel subnet coordination | mTLS |
 | 51820 | UDP | WireGuard overlay | WireGuard encryption |
+
+The coordinator API is QUIC, so 8443 is UDP rather than TCP. Opening the TCP
+port instead is a common way to end up with a runner that can't join. The same
+ports are listed in the [firewall reference](/firewall#between-nodes-distributed-runners).
 
 Metrics and logs travel over 8443 alongside everything else a runner sends the
 coordinator. VictoriaMetrics and VictoriaLogs themselves stay bound to loopback

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -61,6 +61,20 @@ If you're running Miren on a cloud provider, you'll need to configure security g
 
 **NodePorts:** If your app exposes non-HTTP services with `node_port` in the port configuration, those ports must also be open. For example, an IRC server with `node_port = 6667` requires TCP port 6667 to be reachable.
 
+### Between Nodes (Distributed Runners)
+
+If you've grown the cluster with [distributed runners](/distributed-runners), the nodes also talk to each other. These are separate from the inbound ports above, and they only matter when there's a firewall between your machines.
+
+| Port | Protocol | Direction | Purpose |
+|------|----------|-----------|---------|
+| 8443 | UDP | Runner to coordinator | Coordinator API: join, scheduling, and the metrics and logs a runner ships |
+| 12379 | TCP | Runner to coordinator | etcd, for overlay subnet coordination |
+| 51820 | UDP | Every node to every other node | WireGuard overlay carrying sandbox-to-sandbox traffic |
+
+**The overlay port is the one people miss.** Sandboxes on different machines send traffic directly to each other, so 51820/udp has to be open between every pair of nodes, not just from each runner back to the coordinator.
+
+**Telemetry doesn't need its own ports.** VictoriaMetrics and VictoriaLogs stay bound to loopback on the coordinator and are never reachable from a runner. A runner ships its metrics and logs over the coordinator API on 8443 like everything else it sends.
+
 ### Outbound Connectivity
 
 Miren requires outbound internet access for several operations. Most cloud providers allow all outbound traffic by default, but if you have restrictive egress rules, ensure the following destinations are reachable:

--- a/docs/docs/scaling.md
+++ b/docs/docs/scaling.md
@@ -10,6 +10,10 @@ import CliCommand from '@site/src/components/CliCommand';
 
 Miren automatically scales your application instances based on traffic. This page explains how scaling works and how to configure it for your needs.
 
+:::info[Scaling out across machines]
+This page is about how many instances of your app run. When the machine itself runs out of room, you add more machines to the cluster instead: see [Distributed Runners](/distributed-runners).
+:::
+
 ## How Autoscaling Works
 
 By default, Miren uses **autoscaling** for web services. As traffic to your application increases, Miren automatically launches additional instances to handle the load. When traffic decreases, instances are scaled back down.
@@ -231,4 +235,5 @@ miren sandbox list
 
 - [app.toml Reference — Concurrency](/app-toml#concurrency) — Complete field reference for concurrency settings
 - [Services](/services) — Define multiple processes in your app
+- [Distributed Runners](/distributed-runners) — Add machines when one server isn't enough
 - [Getting Started](/getting-started) — Deploy your first app

--- a/docs/docs/system-requirements.md
+++ b/docs/docs/system-requirements.md
@@ -1,7 +1,7 @@
 ---
 title: System Requirements
-description: Minimum and recommended hardware for running a Miren server — OS, architecture, memory, and storage.
-keywords: [system requirements, hardware, linux, memory, disk space, arm64, x86]
+description: Minimum and recommended hardware for running a Miren server or runner — OS, architecture, memory, and storage.
+keywords: [system requirements, hardware, linux, memory, disk space, arm64, x86, runner]
 ---
 
 import CliCommand from '@site/src/components/CliCommand';
@@ -31,9 +31,15 @@ Container images and build caches add up quickly. Base images for languages like
 
 Starting with 50 GB gives you enough room to get going. With 100 GB you'll have space to grow without worrying about "no space left on device" errors during builds.
 
+## Runner nodes
+
+The same numbers apply to every machine you add as a [distributed runner](/distributed-runners). `miren runner install` runs the same check against the same minimums.
+
+The reasoning shifts a little, though. A runner doesn't build your apps or hold cluster state, so it never runs buildkit or etcd, and it won't see the build-time memory spikes that set the server's floor. What it does run is containerd and every sandbox the scheduler places on it, and it pulls and stores the images those sandboxes need. So on a runner, plan memory around how many sandboxes you expect to land there, and storage around the images they pull rather than the build cache.
+
 ## What happens if my system is too small?
 
-The `miren server install` command checks your system against these requirements before installing. If your machine doesn't meet the minimums, the installer will let you know what's short and point you here.
+The `miren server install` and `miren runner install` commands check your system against these requirements before installing. If your machine doesn't meet the minimums, the installer will let you know what's short and point you here.
 
 If you're below the recommended thresholds but above the minimums, you'll see a heads-up but installation will proceed normally.
 
@@ -46,6 +52,8 @@ sudo miren server install --skip-system-check
 ```
 
 </CliCommand>
+
+`miren runner install` takes the same flag, which is worth knowing if you're enrolling runners from a provisioning script that can't answer a prompt.
 
 ## We'd love to hear from you
 


### PR DESCRIPTION
Auditing the docs story ahead of the distributed runners release turned up one thing that's actively wrong and three places where a reader falls off a cliff.

The wrong one: the ports table in `distributed-runners.md` listed the coordinator API as TCP 8443. It's QUIC, so it's UDP. `pkg/rpc/state.go:306` opens the socket with `net.ListenUDP`, wraps it in a `quic.Transport`, and serves through `http3.Server`, and the telemetry ingest from MIR-1483 mounts onto that same listener via `WithHTTPHandler` rather than a TCP side channel. Anyone writing firewall rules from that table opens the wrong port and gets a runner that can't join. `firewall.md` already had it right, which is how the disagreement surfaced.

The three gaps are all variations on "the runner story only exists on one page."

`firewall.md` is where you go when you're configuring a security group, and it only described a single-machine cluster. It now has a node-to-node section with all three ports, including the one people actually miss: 51820/udp has to be open between every pair of runners, not just from each runner back to the coordinator, because sandboxes on different machines talk directly. It also records that telemetry needs no ports of its own, since VictoriaMetrics and VictoriaLogs stay bound to loopback.

`scaling.md` never mentioned runners, nodes, or machines at all. It's the most natural page to land on once you've run out of capacity, and it only discussed scaling instances. It now says up front that adding machines is the other axis, and links to the guide.

`system-requirements.md` read as server-only, but `runner install` calls the same `checkSystemRequirements()` and enforces the same 4 GB / 50 GB floors. That's stated now, along with why the reasoning differs on a runner (no buildkit and no etcd, so memory is about how many sandboxes land there rather than build headroom) and that `--skip-system-check` exists there too, which matters for the provisioning-script flow the runners guide recommends.

Verified with `make docs-lint` and a full `bun run build`. The site is configured `onBrokenLinks: 'throw'` and built clean, so the new cross-page anchor resolves.
