### PR TITLE
Fix nil-logger panic in the labs default-on test

### DIFF
--- a/pkg/labs/labs_test.go
+++ b/pkg/labs/labs_test.go
@@ -27,7 +27,7 @@ func TestDistributedRunnersEnabledByDefault(t *testing.T) {
 	Reset()
 
 	// GA: distributed runners are on by default with no flags set.
-	Init(nil, nil)
+	Init(quiet(), nil)
 
 	if !DistributedRunners() {
 		t.Error("DistributedRunners should be enabled by default")


### PR DESCRIPTION
`TestDistributedRunnersEnabledByDefault` panics on every run at HEAD, taking all of `pkg/labs` down with it. The retry harness flagged it as a flake, but it's fully deterministic. Main has been red since #971 merged.

Nobody actually wrote a bug here. #1012 tightened `labs.Init` so the logger is required, dropping the `if log != nil` guards and adding an unconditional `log.Info("labs features", ...)` at the end, and it dutifully updated all six test call sites that existed at the time. #971 was already in flight with a brand new test calling `Init(nil, nil)`, which was perfectly fine on the code that branch was cut from, since an empty flag list meant `Init` never reached the logger at all. Both PRs were green on their own branches, the two changes touch different regions of `labs_test.go` so git merged them without a murmur, and main segfaulted the instant the second one landed.

So this is the one line #1012 would have written had that test existed yet. I swept the rest of the tree while I was in here, and every other `labs.Init` call site already passes a real logger.

The instance is trivial, but the class is worth a thought. `nil` is a perfectly valid `*slog.Logger`, so neither the compiler nor per-branch CI can catch this. Requiring branches to be up to date with main before merge is the thing that actually prevents it.
