### PR TITLE
Upgrade the runtime toolchain to Go 1.26.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
       with:
-        version: v2.6.1
+        version: v2.12.2
 
     - name: Check go.mod tidiness
       run: |

--- a/.iso/Dockerfile
+++ b/.iso/Dockerfile
@@ -1,6 +1,6 @@
 # Miren Runtime Build Environment
 
-FROM golang:1.25
+FROM golang:1.26
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ m app list
 
 ### ISO Environment
 The project uses **iso** for containerized development with all dependencies provided:
-- `.iso/Dockerfile` - Defines the build environment (Go 1.25, containerd, buildkit, etc.)
+- `.iso/Dockerfile` - Defines the build environment (Go 1.26.x, minimum 1.26.5, plus containerd, buildkit, etc.)
 - `.iso/services.yml` - Defines external service containers (MinIO for object storage)
 - All default `make` targets and `hack/` scripts run inside the isolated container
 - Services are automatically started and ready before commands run

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Miren runtime provides a platform for deploying and managing containerized a
 
 ### Prerequisites
 
-- Go 1.25+ (required for building)
+- Go 1.26.5+ (required for building)
 - iso (optional, for containerized development environment)
 
 ### Development Setup

--- a/controllers/sandbox/testdata/heavy-logger/go.mod
+++ b/controllers/sandbox/testdata/heavy-logger/go.mod
@@ -1,3 +1,3 @@
 module heavy-logger
 
-go 1.25
+go 1.26

--- a/discovery/network.go
+++ b/discovery/network.go
@@ -19,7 +19,10 @@ type HTTPEndpoint struct {
 
 func (h *HTTPEndpoint) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var rp httputil.ReverseProxy
-	rp.Director = h.redirect
+	rp.Rewrite = func(req *httputil.ProxyRequest) {
+		h.redirect(req.Out)
+		req.SetXForwarded()
+	}
 	rp.ServeHTTP(w, req)
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762482733,
-        "narHash": "sha256-g/da4FzvckvbiZT075Sb1/YDNDr+tGQgh4N8i5ceYMg=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1ebeec86b771e9d387dd02d82ffdc77ac753abc",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       in {
         devShells.default = pkgs.mkShell {
           packages = [
-            pkgs.go_1_25
+            pkgs.go_1_26
             pkgs.golangci-lint
             pkgs.gotools
             pkgs.bun

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module miren.dev/runtime
 
-go 1.25.1
+go 1.26.5
 
 require (
 	github.com/NimbleMarkets/ntcharts v0.3.1

--- a/hack/build-dist.sh
+++ b/hack/build-dist.sh
@@ -33,7 +33,7 @@ echo "Building portable Linux amd64 binary (version $version)..."
 
 # Create the Dockerfile content
 cat >"$DOCKERFILE" <<EOF
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Accept version as a build argument
 ARG VERSION

--- a/testdata/bad-command/go.mod
+++ b/testdata/bad-command/go.mod
@@ -1,3 +1,3 @@
 module bad-command
 
-go 1.25
+go 1.26

--- a/testdata/build-error/go.mod
+++ b/testdata/build-error/go.mod
@@ -1,3 +1,3 @@
 module build-error
 
-go 1.25
+go 1.26

--- a/testdata/crash-loop/go.mod
+++ b/testdata/crash-loop/go.mod
@@ -1,3 +1,3 @@
 module crash-loop
 
-go 1.25
+go 1.26

--- a/testdata/crash-on-startup/go.mod
+++ b/testdata/crash-on-startup/go.mod
@@ -1,3 +1,3 @@
 module crash-on-startup
 
-go 1.25
+go 1.26

--- a/testdata/db-app/go.mod
+++ b/testdata/db-app/go.mod
@@ -1,5 +1,5 @@
 module db-app
 
-go 1.25
+go 1.26
 
 require github.com/lib/pq v1.10.9

--- a/testdata/go-server/go.mod
+++ b/testdata/go-server/go.mod
@@ -1,3 +1,3 @@
 module go-server
 
-go 1.25
+go 1.26

--- a/testdata/local-disk-app/go.mod
+++ b/testdata/local-disk-app/go.mod
@@ -1,3 +1,3 @@
 module local-disk-app
 
-go 1.25
+go 1.26

--- a/testdata/tcp-echo/go.mod
+++ b/testdata/tcp-echo/go.mod
@@ -1,3 +1,3 @@
 module tcp-echo
 
-go 1.25
+go 1.26

--- a/testdata/websocket-echo/go.mod
+++ b/testdata/websocket-echo/go.mod
@@ -1,5 +1,5 @@
 module websocket-echo
 
-go 1.25
+go 1.26
 
 require golang.org/x/net v0.33.0


### PR DESCRIPTION
The runtime was still on Go 1.25 everywhere it matters: the module directive, build containers, Nix shell, CI linter, and the test apps that deliberately track the current toolchain. Go 1.26 has been stable for a while now, so keeping those pins on the old release was blocking both the linter and the modernization pass we want to stack on top.

This moves the supported toolchain surface to Go 1.26, with 1.26.5 as the compiler baseline, and refreshes nixpkgs so the dev shell supplies that exact compiler and golangci-lint v2.12.2. Older compatibility fixtures stay on 1.21 and 1.23.

The new linter also catches one standard-library deprecation in the discovery proxy. That small path now uses `Rewrite` while preserving its existing routing and `X-Forwarded-For` behavior. The larger ingress proxy migration is deliberately not part of this change.