### PR TITLE
Add `miren server unregister`

### DIFF
--- a/blackbox/unregister_test.go
+++ b/blackbox/unregister_test.go
@@ -1,0 +1,95 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"strings"
+	"testing"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+// TestServerUnregister exercises `miren server unregister` against a real
+// cloud: the cluster asks to be removed using its own service account key,
+// then clears the registration files it authenticated with.
+//
+// The interesting property is that the cloud side genuinely takes effect.
+// Deleting a cluster only soft-deletes its row and the service account
+// outlives it, so the test stashes the credentials before unregistering and
+// replays them afterwards to confirm they no longer authenticate.
+func TestServerUnregister(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+	harness.NewCloudEnv(t, m)
+
+	const serverDir = "/var/lib/miren/server"
+	const stashDir = "/tmp/bb-unregister-stash"
+
+	// Files that belong to something other than cloud registration. Unregister
+	// must leave every one of them alone: the first four secure CLI-to-cluster
+	// auth, and the last two sign end-user OIDC sessions and the cluster's own
+	// workload identities.
+	bystanders := []string{"ca.crt", "ca.key", "api.crt", "api.key", "oidc-signing.key", "workload-identity.key"}
+	for _, name := range bystanders {
+		m.RunCmdAsRoot("bash", "-c", "test -f "+serverDir+"/"+name+" || touch "+serverDir+"/"+name)
+	}
+
+	// The replay below is only meaningful if the stash actually happened. A
+	// silently failed copy would leave nothing to restore, and the replay would
+	// then "fail" for want of credentials rather than because they were revoked.
+	stash := m.RunCmdAsRoot("bash", "-c", "mkdir -p "+stashDir+" && cp "+serverDir+"/registration.json "+serverDir+"/service-account.key "+stashDir+"/")
+	if !stash.Success() {
+		t.Fatalf("failed to stash registration credentials (exit %d):\n%s\n%s", stash.ExitCode, stash.Stdout, stash.Stderr)
+	}
+	t.Cleanup(func() {
+		m.RunCmdAsRoot("rm", "-rf", stashDir)
+	})
+
+	r := m.RunCmdAsRoot("m", "server", "unregister", "--force")
+	if !r.Success() {
+		t.Fatalf("unregister failed (exit %d):\n%s\n%s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+
+	status := m.RunCmdAsRoot("m", "server", "register", "status")
+	if !strings.Contains(status.Stdout, "No cluster registration found") {
+		t.Errorf("expected no registration after unregister, got:\n%s", status.Stdout)
+	}
+
+	for _, name := range []string{"registration.json", "service-account.key"} {
+		check := m.RunCmdAsRoot("bash", "-c", "test -e "+serverDir+"/"+name+" && echo present || echo gone")
+		if !strings.Contains(check.Stdout, "gone") {
+			t.Errorf("%s should have been removed by unregister", name)
+		}
+	}
+
+	for _, name := range bystanders {
+		check := m.RunCmdAsRoot("bash", "-c", "test -e "+serverDir+"/"+name+" && echo present || echo gone")
+		if !strings.Contains(check.Stdout, "present") {
+			t.Errorf("%s is not cloud registration material and should have survived unregister", name)
+		}
+	}
+
+	// Put the credentials back and try again. The cluster is gone from the
+	// organization and its service account is revoked, so the key that worked a
+	// moment ago must no longer get a token.
+	m.RunCmdAsRoot("bash", "-c", "cp "+stashDir+"/registration.json "+stashDir+"/service-account.key "+serverDir+"/")
+
+	replay := m.RunCmdAsRoot("m", "server", "unregister", "--force")
+	if replay.Success() {
+		t.Errorf("revoked credentials still authenticated to cloud:\n%s", replay.Stdout)
+	}
+
+	// Local state is untouched by the failed attempt, so the operator can still
+	// recover with --local-only.
+	local := m.RunCmdAsRoot("m", "server", "unregister", "--force", "--local-only")
+	if !local.Success() {
+		t.Fatalf("--local-only unregister failed (exit %d):\n%s\n%s", local.ExitCode, local.Stdout, local.Stderr)
+	}
+
+	for _, name := range []string{"registration.json", "service-account.key"} {
+		check := m.RunCmdAsRoot("bash", "-c", "test -e "+serverDir+"/"+name+" && echo present || echo gone")
+		if !strings.Contains(check.Stdout, "gone") {
+			t.Errorf("%s should have been removed by --local-only unregister", name)
+		}
+	}
+}

--- a/cli/commands/commands_linux.go
+++ b/cli/commands/commands_linux.go
@@ -26,6 +26,17 @@ func addCommands(d *mflags.Dispatcher) {
 		}),
 	))
 
+	d.Dispatch("server unregister", Infer("server unregister", "Detach this cluster from miren.cloud", Unregister,
+		WithExample(mflags.Example{
+			Name: "Unregister from cloud",
+			Body: "miren server unregister",
+		}),
+		WithExample(mflags.Example{
+			Name: "Clear local registration when the cloud entry is already gone",
+			Body: "miren server unregister --local-only",
+		}),
+	))
+
 	// Server management commands
 	d.Dispatch("server install", Infer("server install", "Install systemd service for miren server", ServerInstall,
 		WithExample(mflags.Example{

--- a/cli/commands/server_register.go
+++ b/cli/commands/server_register.go
@@ -108,7 +108,8 @@ func Register(ctx *Context, opts RegisterOptions) error {
 
 			return nil
 		} else if existing.Status == "approved" {
-			return fmt.Errorf("cluster already registered as %s (ID: %s)", existing.ClusterName, existing.ClusterID)
+			return fmt.Errorf("cluster already registered as %s (ID: %s); run 'miren server unregister' to detach it first",
+				existing.ClusterName, existing.ClusterID)
 		}
 		// If pending but expired, we'll start fresh
 	}

--- a/cli/commands/server_unregister.go
+++ b/cli/commands/server_unregister.go
@@ -1,0 +1,151 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"miren.dev/runtime/pkg/cloudauth"
+	"miren.dev/runtime/pkg/registration"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// UnregisterOptions contains options for detaching a cluster from miren.cloud
+type UnregisterOptions struct {
+	Force     bool   `short:"f" long:"force" description:"Skip the confirmation prompt"`
+	LocalOnly bool   `long:"local-only" description:"Clear local registration without telling miren.cloud"`
+	OutputDir string `short:"o" long:"output" description:"Directory holding the registration" default:"/var/lib/miren/server"`
+}
+
+// Unregister is the inverse of `miren server register`: it detaches the cluster
+// from the miren.cloud organization it registered with and clears the local
+// registration state, so the cluster can be retired or re-registered elsewhere.
+//
+// The cloud half runs first. The service account key is the only credential
+// that can authorize the cloud-side removal, and it lives in the files the
+// local half deletes — clearing those first would strand an unreachable
+// cluster row in the organization with no way to finish from this machine.
+func Unregister(ctx *Context, opts UnregisterOptions) error {
+	reg, err := registration.LoadRegistration(opts.OutputDir)
+	if err != nil {
+		return fmt.Errorf("failed to load registration: %w", err)
+	}
+	if reg == nil {
+		ctx.Info("No cluster registration found in %s; nothing to unregister.", opts.OutputDir)
+		return nil
+	}
+
+	if !opts.Force {
+		confirmed, err := confirmUnregister(ctx, reg, opts.LocalOnly)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			ctx.Info("Unregister cancelled")
+			return nil
+		}
+	}
+
+	if opts.LocalOnly {
+		ctx.Warn("Skipping miren.cloud; the cluster entry in the organization is left in place.")
+	} else if err := unregisterFromCloud(ctx, reg); err != nil {
+		return err
+	}
+
+	if err := registration.ClearRegistration(opts.OutputDir); err != nil {
+		if !opts.LocalOnly {
+			// The cloud side is already done at this point, so the credentials
+			// left on disk are dead. Name the files rather than leaving the
+			// operator to guess which ones are safe to remove.
+			ctx.Warn("The cluster was removed from miren.cloud, but its local registration could not be cleared.")
+			ctx.Warn("Remove these by hand, then restart the server: %s",
+				strings.Join(registrationFilePaths(opts.OutputDir), ", "))
+		}
+		return err
+	}
+
+	ctx.Completed("Cluster unregistered.")
+	restartMirenServiceIfActive(ctx)
+
+	return nil
+}
+
+// unregisterFromCloud removes the cluster from its organization, authenticating
+// as the cluster's own service account.
+func unregisterFromCloud(ctx *Context, reg *registration.StoredRegistration) error {
+	if reg.Status != "approved" {
+		// A pending registration was never approved, so no cluster exists in
+		// the organization to remove. Clearing the local files is the whole job.
+		ctx.Info("Registration was never approved; clearing local state only.")
+		return nil
+	}
+
+	keyPair, err := cloudauth.LoadKeyPairFromPEM(reg.PrivateKey)
+	if err != nil {
+		return fmt.Errorf("failed to load service account key: %w", err)
+	}
+
+	client, err := cloudauth.NewAuthClient(reg.CloudURL, keyPair)
+	if err != nil {
+		return fmt.Errorf("failed to create cloud client: %w", err)
+	}
+
+	ctx.Info("Removing cluster '%s' from %s...", reg.ClusterName, reg.CloudURL)
+
+	if err := client.UnregisterSelf(ctx); err != nil {
+		if errors.Is(err, cloudauth.ErrClusterNotRegistered) {
+			ctx.Info("Cluster was already removed from miren.cloud.")
+			return nil
+		}
+		return fmt.Errorf("failed to unregister from %s: %w (use --local-only to clear local state anyway)",
+			reg.CloudURL, err)
+	}
+
+	ctx.Completed("Removed from miren.cloud.")
+
+	return nil
+}
+
+// confirmUnregister spells out what detaching costs before asking. Workloads
+// keep running throughout — what goes away is everything the cluster gets from
+// being part of an organization.
+func confirmUnregister(ctx *Context, reg *registration.StoredRegistration, localOnly bool) (bool, error) {
+	ctx.Printf("Unregistering cluster '%s' from %s\n", reg.ClusterName, reg.CloudURL)
+	ctx.Printf("\n")
+	ctx.Printf("Apps and sandboxes keep running, but the cluster loses:\n")
+	if reg.DNSHostname != "" {
+		ctx.Printf("  - its cloud DNS records, including %s\n", reg.DNSHostname)
+	} else {
+		ctx.Printf("  - its cloud DNS records\n")
+	}
+	ctx.Printf("  - Miren Anywhere routing, so traffic must reach the cluster directly\n")
+	ctx.Printf("  - cloud RBAC rules, leaving certificate auth as the only way in\n")
+	ctx.Printf("\n")
+	ctx.Printf("If the miren service is running under systemd it restarts at the end,\n")
+	ctx.Printf("so the server stops using the registration.\n")
+	if localOnly {
+		ctx.Printf("\n")
+		ctx.Printf("--local-only: miren.cloud is not contacted, so the cluster entry\n")
+		ctx.Printf("stays in the organization and has to be removed there.\n")
+	}
+	ctx.Printf("\n")
+
+	confirmed, err := ui.Confirm(
+		ui.WithMessage(fmt.Sprintf("Unregister '%s'?", reg.ClusterName)),
+		ui.WithDefault(false),
+	)
+	if err != nil {
+		return false, fmt.Errorf("confirmation failed: %w", err)
+	}
+
+	return confirmed, nil
+}
+
+func registrationFilePaths(dir string) []string {
+	paths := make([]string, 0, len(registration.RegistrationFiles))
+	for _, name := range registration.RegistrationFiles {
+		paths = append(paths, filepath.Join(dir, name))
+	}
+	return paths
+}

--- a/cli/commands/server_unregister_test.go
+++ b/cli/commands/server_unregister_test.go
@@ -1,0 +1,194 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/cloudauth"
+	"miren.dev/runtime/pkg/registration"
+)
+
+// newUnregisterCloud stands up a stub cloud that answers the service account
+// handshake and hands DELETE /api/v1/self/cluster to deleteStatus.
+func newUnregisterCloud(t *testing.T, deleteStatus int, deleted *bool) *httptest.Server {
+	t.Helper()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/service-account/begin":
+			json.NewEncoder(w).Encode(cloudauth.BeginAuthResponse{
+				Envelope:  "test-envelope",
+				Challenge: "dGVzdC1jaGFsbGVuZ2U=",
+			})
+		case "/auth/service-account/complete":
+			json.NewEncoder(w).Encode(cloudauth.CompleteAuthResponse{
+				Token:     "test-jwt-token",
+				ExpiresIn: 3600,
+			})
+		case "/api/v1/self/cluster":
+			if deleted != nil {
+				*deleted = true
+			}
+			w.WriteHeader(deleteStatus)
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+// seedRegistration writes a registration with the given status pointing at
+// cloudURL, and returns the directory holding it.
+func seedRegistration(t *testing.T, cloudURL, status string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	privateKey, _, err := registration.GenerateKeyPair()
+	require.NoError(t, err)
+
+	require.NoError(t, registration.SaveRegistration(dir, &registration.StoredRegistration{
+		ClusterID:   "cluster-123",
+		ClusterName: "prod",
+		PrivateKey:  privateKey,
+		CloudURL:    cloudURL,
+		Status:      status,
+	}))
+
+	return dir
+}
+
+func testUnregisterContext() (*Context, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return &Context{Context: context.Background(), Stdout: &buf}, &buf
+}
+
+func requireRegistrationCleared(t *testing.T, dir string) {
+	t.Helper()
+	for _, name := range registration.RegistrationFiles {
+		require.NoFileExists(t, filepath.Join(dir, name))
+	}
+}
+
+func requireRegistrationIntact(t *testing.T, dir string) {
+	t.Helper()
+	for _, name := range registration.RegistrationFiles {
+		require.FileExists(t, filepath.Join(dir, name))
+	}
+}
+
+func TestUnregisterRemovesCloudEntryThenLocalState(t *testing.T) {
+	var deleted bool
+	ts := newUnregisterCloud(t, http.StatusNoContent, &deleted)
+	dir := seedRegistration(t, ts.URL, "approved")
+
+	ctx, _ := testUnregisterContext()
+	require.NoError(t, Unregister(ctx, UnregisterOptions{Force: true, OutputDir: dir}))
+
+	require.True(t, deleted, "cloud should have been asked to remove the cluster")
+	requireRegistrationCleared(t, dir)
+}
+
+// The service account key is the only credential that can authorize the cloud
+// side, and it lives in the files the local half deletes. If the cloud call
+// fails, the local state has to survive so the operator can retry from this
+// machine instead of stranding an unreachable cluster in the organization.
+func TestUnregisterKeepsLocalStateWhenCloudFails(t *testing.T) {
+	ts := newUnregisterCloud(t, http.StatusInternalServerError, nil)
+	dir := seedRegistration(t, ts.URL, "approved")
+
+	ctx, _ := testUnregisterContext()
+	err := Unregister(ctx, UnregisterOptions{Force: true, OutputDir: dir})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--local-only")
+	requireRegistrationIntact(t, dir)
+}
+
+// A cluster that cloud has already forgotten should still finish its local
+// cleanup, so a retried unregister converges instead of wedging.
+func TestUnregisterCompletesWhenCloudAlreadyForgotCluster(t *testing.T) {
+	ts := newUnregisterCloud(t, http.StatusNotFound, nil)
+	dir := seedRegistration(t, ts.URL, "approved")
+
+	ctx, _ := testUnregisterContext()
+	require.NoError(t, Unregister(ctx, UnregisterOptions{Force: true, OutputDir: dir}))
+
+	requireRegistrationCleared(t, dir)
+}
+
+// --local-only is the orphan recovery path: clear local state without talking
+// to cloud at all, for when the cloud entry is already gone or unreachable.
+func TestUnregisterLocalOnlySkipsCloud(t *testing.T) {
+	// Any request to this server fails the test, which is the assertion.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("--local-only contacted cloud at %s", r.URL.Path)
+	}))
+	defer ts.Close()
+
+	dir := seedRegistration(t, ts.URL, "approved")
+
+	ctx, buf := testUnregisterContext()
+	require.NoError(t, Unregister(ctx, UnregisterOptions{Force: true, LocalOnly: true, OutputDir: dir}))
+
+	requireRegistrationCleared(t, dir)
+	require.Contains(t, buf.String(), "left in place")
+}
+
+// A registration that was never approved has no cluster in the organization to
+// remove, so there is nothing to ask cloud for.
+func TestUnregisterPendingRegistrationSkipsCloud(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("pending registration contacted cloud at %s", r.URL.Path)
+	}))
+	defer ts.Close()
+
+	dir := seedRegistration(t, ts.URL, "pending")
+
+	ctx, _ := testUnregisterContext()
+	require.NoError(t, Unregister(ctx, UnregisterOptions{Force: true, OutputDir: dir}))
+
+	requireRegistrationCleared(t, dir)
+}
+
+func TestUnregisterWithoutRegistrationIsANoOp(t *testing.T) {
+	dir := t.TempDir()
+
+	ctx, buf := testUnregisterContext()
+	require.NoError(t, Unregister(ctx, UnregisterOptions{Force: true, OutputDir: dir}))
+
+	require.Contains(t, buf.String(), "No cluster registration found")
+}
+
+// Unregister must not touch anything in the server directory that is not cloud
+// registration material. The TLS pair secures CLI-to-cluster auth, the OIDC key
+// signs end-user sessions, and the workload identity key anchors the cluster's
+// own service identities — none of them have anything to do with the cloud.
+func TestUnregisterLeavesUnrelatedServerFilesAlone(t *testing.T) {
+	ts := newUnregisterCloud(t, http.StatusNoContent, nil)
+	dir := seedRegistration(t, ts.URL, "approved")
+
+	bystanders := []string{"ca.crt", "ca.key", "api.crt", "api.key", "oidc-signing.key", "workload-identity.key"}
+	for _, name := range bystanders {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("keep me"), 0600))
+	}
+
+	ctx, _ := testUnregisterContext()
+	require.NoError(t, Unregister(ctx, UnregisterOptions{Force: true, OutputDir: dir}))
+
+	requireRegistrationCleared(t, dir)
+	for _, name := range bystanders {
+		require.FileExists(t, filepath.Join(dir, name))
+	}
+}

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -335,6 +335,7 @@
       "command/server-register-status",
       "command/server-status",
       "command/server-uninstall",
+      "command/server-unregister",
       "command/server-upgrade",
       "command/server-upgrade-rollback"
     ]

--- a/docs/docs/command/server-unregister.md
+++ b/docs/docs/command/server-unregister.md
@@ -1,0 +1,45 @@
+---
+title: "miren server unregister"
+sidebar_label: "server unregister"
+description: "Detach this cluster from miren.cloud"
+---
+
+# miren server unregister
+
+Detach this cluster from miren.cloud
+
+## Usage
+
+```bash
+miren server unregister [flags]
+```
+
+## Flags
+
+- `--force, -f` — Skip the confirmation prompt
+- `--local-only` — Clear local registration without telling miren.cloud
+- `--output, -o` — Directory holding the registration (default: `/var/lib/miren/server`)
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Unregister from cloud:**
+
+```bash
+miren server unregister
+```
+
+**Clear local registration when the cloud entry is already gone:**
+
+```bash
+miren server unregister --local-only
+```
+
+## See also
+
+- [`miren server`](/command/server)

--- a/docs/docs/command/server.md
+++ b/docs/docs/command/server.md
@@ -85,4 +85,5 @@ miren server --mode standalone
 - [`miren server register`](/command/server-register) — Register this cluster with miren.cloud
 - [`miren server status`](/command/server-status) — Show miren service status
 - [`miren server uninstall`](/command/server-uninstall) — Remove systemd service for miren server
+- [`miren server unregister`](/command/server-unregister) — Detach this cluster from miren.cloud
 - [`miren server upgrade`](/command/server-upgrade) — Upgrade miren server

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -248,6 +248,7 @@ Complete reference for all `miren` CLI commands.
 | [`miren server register status`](/command/server-register-status) | Show cluster registration status |
 | [`miren server status`](/command/server-status) | Show miren service status |
 | [`miren server uninstall`](/command/server-uninstall) | Remove systemd service for miren server |
+| [`miren server unregister`](/command/server-unregister) | Detach this cluster from miren.cloud |
 | [`miren server upgrade`](/command/server-upgrade) | Upgrade miren server |
 | [`miren server upgrade rollback`](/command/server-upgrade-rollback) | Rollback server to previous version |
 

--- a/docs/docs/miren-cloud/overview.md
+++ b/docs/docs/miren-cloud/overview.md
@@ -44,6 +44,24 @@ miren login
 
 The [Getting Started](/getting-started) guide covers the full install-and-first-deploy flow. For everything the CLI can do with clusters, see the [`miren cluster`](/command/cluster) reference.
 
+## Disconnecting
+
+Connecting is reversible. [`miren server unregister`](/command/server-unregister) is the inverse of registering: it removes the cluster from your organization in Miren Cloud, revokes the credentials it was using, and clears its registration locally.
+
+```bash
+sudo miren server unregister
+```
+
+Your apps and sandboxes keep running throughout. What goes away is everything the cluster got from being part of an organization: its cloud DNS records, Miren Anywhere routing, and cloud-managed access rules, which leaves certificate authentication as the way in. The cluster carries on as a standalone one, exactly as if you had installed it with `--without-cloud`.
+
+This is also how you move a cluster between organizations. Unregister it, `miren login` against the organization you want, then register again. The cluster comes back as a new entry with a fresh identity rather than carrying its old one across, since a cluster record belongs to the organization it was created in.
+
+:::warning[Apps served through Miren Cloud lose their address]
+If your apps are reachable at a [subdomain](/miren-cloud/subdomains) or through [Miren Anywhere](/miren-cloud/miren-anywhere), that traffic stops once the cluster is unregistered. The apps are still running, but nothing routes to them until you give the cluster an address of its own.
+:::
+
+If the cluster entry in Miren Cloud is already gone, or the cluster can't reach the internet to say goodbye, `sudo miren server unregister --local-only` clears the local registration without contacting the cloud.
+
 ## Explore
 
 - [Subdomains](/miren-cloud/subdomains) — Claim a hostname like `mycluster.run.garden` for your apps

--- a/pkg/cloudauth/unregister.go
+++ b/pkg/cloudauth/unregister.go
@@ -1,0 +1,55 @@
+package cloudauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// ErrClusterNotRegistered reports that miren.cloud has no cluster for this
+// service account. Unregistering is meant to be safe to retry, so callers
+// treat this as "the cloud side is already done" rather than a failure.
+var ErrClusterNotRegistered = errors.New("cluster not registered with cloud")
+
+// UnregisterSelf asks miren.cloud to remove the cluster this client
+// authenticates as, revoking its service account along the way. It is the
+// cloud half of `miren server unregister` — the cluster identifies itself with
+// the service account key from its registration, so no user login is involved.
+func (a *AuthClient) UnregisterSelf(ctx context.Context) error {
+	token, err := a.GetToken(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get authentication token: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/self/cluster", a.serverURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send unregister request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		return ErrClusterNotRegistered
+	}
+
+	var errResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err == nil {
+		if errMsg, ok := errResp["error"].(string); ok {
+			return fmt.Errorf("unregister failed: %s", errMsg)
+		}
+	}
+
+	return fmt.Errorf("unregister failed with status code: %d", resp.StatusCode)
+}

--- a/pkg/cloudauth/unregister_test.go
+++ b/pkg/cloudauth/unregister_test.go
@@ -1,0 +1,101 @@
+package cloudauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newUnregisterTestServer stands up a cloud stub that answers the service
+// account handshake and hands the unregister request to unregisterHandler.
+func newUnregisterTestServer(t *testing.T, unregisterHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/auth/service-account/begin":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(BeginAuthResponse{
+				Envelope:  "test-envelope",
+				Challenge: "dGVzdC1jaGFsbGVuZ2U=",
+			})
+
+		case "/auth/service-account/complete":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(CompleteAuthResponse{
+				Token:     "test-jwt-token",
+				ExpiresIn: 3600,
+			})
+
+		case "/api/v1/self/cluster":
+			unregisterHandler(w, r)
+
+		default:
+			t.Errorf("Unexpected request to %s", r.URL.Path)
+		}
+	}))
+}
+
+func TestUnregisterSelf(t *testing.T) {
+	var method, authToken string
+
+	ts := newUnregisterTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		authToken = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer ts.Close()
+
+	keyPair, err := GenerateKeyPair()
+	require.NoError(t, err)
+
+	authClient, err := NewAuthClient(ts.URL, keyPair)
+	require.NoError(t, err)
+
+	require.NoError(t, authClient.UnregisterSelf(context.Background()))
+
+	assert.Equal(t, http.MethodDelete, method)
+	assert.Equal(t, "Bearer test-jwt-token", authToken)
+}
+
+// A cluster that was already removed reports a distinct error, so unregister
+// can finish clearing local state instead of failing a retry.
+func TestUnregisterSelf_AlreadyGone(t *testing.T) {
+	ts := newUnregisterTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer ts.Close()
+
+	keyPair, err := GenerateKeyPair()
+	require.NoError(t, err)
+
+	authClient, err := NewAuthClient(ts.URL, keyPair)
+	require.NoError(t, err)
+
+	err = authClient.UnregisterSelf(context.Background())
+	assert.ErrorIs(t, err, ErrClusterNotRegistered)
+}
+
+func TestUnregisterSelf_ServerError(t *testing.T) {
+	ts := newUnregisterTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "database unavailable"})
+	})
+	defer ts.Close()
+
+	keyPair, err := GenerateKeyPair()
+	require.NoError(t, err)
+
+	authClient, err := NewAuthClient(ts.URL, keyPair)
+	require.NoError(t, err)
+
+	err = authClient.UnregisterSelf(context.Background())
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrClusterNotRegistered)
+	assert.Contains(t, err.Error(), "database unavailable")
+}

--- a/pkg/registration/registration.go
+++ b/pkg/registration/registration.go
@@ -257,6 +257,34 @@ func SaveRegistration(dir string, reg *StoredRegistration) error {
 	return nil
 }
 
+// RegistrationFiles are the files SaveRegistration writes, and the complete
+// set that has to go for a cluster to stop considering itself registered.
+//
+// Nothing else in the server directory belongs to cloud registration, which is
+// easy to get wrong by eye: ca.crt/ca.key and api.crt/api.key secure
+// CLI-to-cluster authentication, oidc-signing.key signs end-user session
+// cookies for OIDC-protected routes, and workload-identity.key anchors the
+// cluster's own service identities. Removing any of those breaks something
+// unrelated to the cloud.
+var RegistrationFiles = []string{
+	"registration.json",
+	"service-account.key",
+}
+
+// ClearRegistration removes the registration data from the specified
+// directory, leaving the rest of the server directory alone. Missing files are
+// not an error, so a partially cleared directory can be finished off by
+// running again.
+func ClearRegistration(dir string) error {
+	for _, name := range RegistrationFiles {
+		if err := os.Remove(filepath.Join(dir, name)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
 // LoadRegistration loads the registration data from the specified directory
 func LoadRegistration(dir string) (*StoredRegistration, error) {
 	path := filepath.Join(dir, "registration.json")

--- a/pkg/registration/registration_test.go
+++ b/pkg/registration/registration_test.go
@@ -1,0 +1,64 @@
+package registration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClearRegistration(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, SaveRegistration(dir, &StoredRegistration{
+		ClusterID:   "cluster-123",
+		ClusterName: "prod",
+		PrivateKey:  "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
+		Status:      "approved",
+	}))
+
+	// Everything else in the server directory belongs to something other than
+	// cloud registration and has to survive: these secure CLI-to-cluster auth,
+	// end-user OIDC sessions, and the cluster's own workload identities.
+	bystanders := []string{"ca.crt", "ca.key", "api.crt", "api.key", "oidc-signing.key", "workload-identity.key"}
+	for _, name := range bystanders {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("keep me"), 0600))
+	}
+
+	require.NoError(t, ClearRegistration(dir))
+
+	reg, err := LoadRegistration(dir)
+	require.NoError(t, err)
+	assert.Nil(t, reg)
+
+	for _, name := range RegistrationFiles {
+		assert.NoFileExists(t, filepath.Join(dir, name))
+	}
+	for _, name := range bystanders {
+		assert.FileExists(t, filepath.Join(dir, name))
+	}
+}
+
+// Clearing a directory that was already cleared should succeed, so an
+// interrupted unregister can be finished by running it again.
+func TestClearRegistrationIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, ClearRegistration(dir))
+	require.NoError(t, ClearRegistration(dir))
+}
+
+// A partially cleared directory — registration.json gone but the key left
+// behind — should finish cleanly rather than stopping at the missing file.
+func TestClearRegistrationPartial(t *testing.T) {
+	dir := t.TempDir()
+
+	keyPath := filepath.Join(dir, "service-account.key")
+	require.NoError(t, os.WriteFile(keyPath, []byte("key"), 0600))
+
+	require.NoError(t, ClearRegistration(dir))
+
+	assert.NoFileExists(t, keyPath)
+}


### PR DESCRIPTION
`miren server register` never had an inverse, which made connecting to Miren Cloud a one-way door. Getting back out meant stopping the server, guessing which files under `/var/lib/miren/server` were registration state, and moving them aside, with `sudo miren server register -n new-name` refusing to help until you got the guess right. #793 has the full account of doing this by hand.

`miren server unregister` closes that. It tells the cloud to remove the cluster (which revokes its credentials), clears the local registration, and bounces the server through the same helper `register` already uses.

The ordering is the interesting design bit. Cloud goes first, because the service account key is the only credential that can authorize the cloud-side removal and it lives in the very files the local half deletes. Wipe local first and a failed cloud call leaves you with an unreachable cluster row in the org and nothing on the box that can finish the job. So a cloud failure aborts with local state untouched and points at `--local-only`, which is also the escape hatch for when the cloud entry is already gone.

Worth recording: only `registration.json` and `service-account.key` are registration material. The others in that directory are easy to mistake for it and all mean something else. `ca.*` and `api.*` secure CLI-to-cluster certificate auth, `oidc-signing.key` signs end-user sessions on OIDC-protected routes (removing it logs every user out of every protected route), and `workload-identity.key` anchors the cluster's own service identities. The workaround in #793 took out `oidc-signing.key` unnecessarily, so the file list now lives in code with a comment naming the bystanders.

Docs get a "Disconnecting" section on the Miren Cloud overview page, next to the "Getting connected" section it inverts. That page's whole argument is that connecting is additive rather than lock-in, and a documented way out is the strongest form of that claim.

The cloud-side endpoint this calls ships separately and needs to be deployed before this is useful.

Closes MIR-1107
Closes #793
