### PR TITLE
Add an etcdctl debug helper

### DIFF
--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -1014,6 +1014,17 @@ Warning: These commands are intended for advanced users and developers. They may
 	d.Dispatch("debug test load", Infer("debug test load", "Loadtest a URL", TestLoad))
 	d.Dispatch("debug ctr", Infer("debug ctr", "Run ctr with miren defaults", DebugCtr))
 	d.Dispatch("debug ctr nuke", Infer("debug ctr nuke", "Nuke a containerd namespace", CtrNuke))
+	d.Dispatch("debug etcdctl", Infer("debug etcdctl", "Run etcdctl against Miren's embedded etcd", DebugEtcdctl,
+		WithDescription(debugEtcdctlDescription),
+		WithExample(mflags.Example{
+			Name: "Show endpoint status",
+			Body: "miren debug etcdctl endpoint status --write-out=table",
+		}),
+		WithExample(mflags.Example{
+			Name: "List every key",
+			Body: "miren debug etcdctl get / --prefix --keys-only",
+		}),
+	))
 	d.Dispatch("debug colors", Infer("debug colors", "Print some colors", Colors))
 	d.Dispatch("debug bundle", Infer("debug bundle", "Create a support bundle with system debug information", DebugBundle))
 

--- a/cli/commands/debug_ctr.go
+++ b/cli/commands/debug_ctr.go
@@ -13,7 +13,10 @@ func DebugCtr(ctx *Context, opts struct {
 	Socket    string   `long:"socket" description:"path to containerd socket"`
 	Args      []string `rest:"true"`
 }) error {
-	socket := opts.Socket
+	return execCtr(opts.Socket, opts.Namespace, opts.Args)
+}
+
+func execCtr(socket, namespace string, commandArgs []string) error {
 	if socket == "" {
 		socket = defaultContainerdSocket()
 	}
@@ -23,8 +26,8 @@ func DebugCtr(ctx *Context, opts struct {
 		return err
 	}
 
-	args := []string{"ctr", "-a", socket, "-n", opts.Namespace}
-	args = append(args, opts.Args...)
+	args := []string{"ctr", "-a", socket, "-n", namespace}
+	args = append(args, commandArgs...)
 
 	env := os.Environ()
 

--- a/cli/commands/debug_etcdctl.go
+++ b/cli/commands/debug_etcdctl.go
@@ -1,0 +1,198 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/errdefs"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"miren.dev/runtime/components/etcd"
+)
+
+const debugEtcdctlProbeTimeout = 5 * time.Second
+
+const debugEtcdctlDescription = `Place Miren's ` + "`" + `-n` + "`" + `/` + "`" + `--namespace` + "`" + ` and ` + "`" + `--socket` + "`" + ` flags before the etcdctl arguments. Once the etcdctl arguments begin, all remaining flags are passed through to etcdctl unchanged.`
+
+type debugEtcdctlOptions struct {
+	Namespace   string   `short:"n" long:"namespace" description:"containerd namespace" default:"miren"`
+	Socket      string   `long:"socket" description:"path to containerd socket"`
+	Args        []string `rest:"true"`
+	Passthrough []string `unknown:"true"`
+}
+
+func (o debugEtcdctlOptions) etcdctlArgs() []string {
+	args := make([]string, 0, len(o.Args)+len(o.Passthrough))
+	args = append(args, o.Args...)
+	return append(args, o.Passthrough...)
+}
+
+func DebugEtcdctl(ctx *Context, opts debugEtcdctlOptions) error {
+	socket := opts.Socket
+	if socket == "" {
+		socket = defaultContainerdSocket()
+	}
+
+	client, err := containerd.New(socket)
+	if err != nil {
+		return localEtcdUnavailableError(socket, opts.Namespace, err)
+	}
+	defer func() {
+		if client != nil {
+			client.Close()
+		}
+	}()
+
+	containerCtx, cancel := context.WithTimeout(
+		namespaces.WithNamespace(ctx, opts.Namespace),
+		debugEtcdctlProbeTimeout,
+	)
+	defer cancel()
+
+	container, err := client.LoadContainer(containerCtx, etcd.ContainerName)
+	if err != nil {
+		return localEtcdUnavailableError(socket, opts.Namespace, err)
+	}
+	if _, err := container.Task(containerCtx, nil); err != nil {
+		return localEtcdTaskUnavailableError(err)
+	}
+
+	spec, err := container.Spec(containerCtx)
+	if err != nil {
+		return fmt.Errorf("reading etcd container spec: %w", err)
+	}
+
+	args, err := buildEtcdctlExecArgs(spec, opts.etcdctlArgs(), newEtcdctlExecID())
+	if err != nil {
+		return err
+	}
+	cancel()
+
+	_ = client.Close()
+	client = nil
+
+	return execCtr(socket, opts.Namespace, args)
+}
+
+func localEtcdUnavailableError(socket, namespace string, err error) error {
+	if errdefs.IsNotFound(err) {
+		return fmt.Errorf(
+			"embedded etcd container %q was not found in containerd namespace %q; "+
+				"this command must be run on a local Miren coordinator with embedded etcd",
+			etcd.ContainerName, namespace,
+		)
+	}
+
+	if errdefs.IsPermissionDenied(err) || strings.Contains(strings.ToLower(err.Error()), "permission denied") {
+		return fmt.Errorf(
+			"permission denied accessing containerd at %s; run this command with sufficient permissions "+
+				"on a local Miren coordinator",
+			socket,
+		)
+	}
+
+	return fmt.Errorf(
+		"cannot inspect embedded etcd through containerd at %s: %w "+
+			"(this command must be run on a local Miren coordinator with embedded etcd)",
+		socket, err,
+	)
+}
+
+func localEtcdTaskUnavailableError(err error) error {
+	if errdefs.IsNotFound(err) {
+		return fmt.Errorf(
+			"embedded etcd container %q exists but is not running; "+
+				"check the Miren server and coordinator logs",
+			etcd.ContainerName,
+		)
+	}
+
+	return fmt.Errorf("checking embedded etcd task: %w", err)
+}
+
+func buildEtcdctlExecArgs(spec *specs.Spec, etcdctlArgs []string, execID string) ([]string, error) {
+	if spec == nil || spec.Process == nil {
+		return nil, fmt.Errorf("etcd container spec has no process configuration")
+	}
+
+	endpoint, tlsEnabled, err := etcdClientEndpoint(spec.Process.Args)
+	if err != nil {
+		return nil, err
+	}
+
+	connectionArgs := []string{"--endpoints=" + endpoint}
+	if tlsEnabled {
+		if !hasMount(spec.Mounts, "/certs") {
+			return nil, fmt.Errorf("etcd advertises a TLS endpoint but its client certificates are not mounted at /certs")
+		}
+		connectionArgs = append(connectionArgs,
+			"--cacert=/certs/ca.crt",
+			"--cert=/certs/client.crt",
+			"--key=/certs/client.key",
+		)
+	}
+
+	args := []string{
+		"tasks", "exec",
+		"--exec-id", execID,
+		etcd.ContainerName,
+		"/usr/local/bin/etcdctl",
+	}
+	args = append(args, connectionArgs...)
+	args = append(args, etcdctlArgs...)
+	return args, nil
+}
+
+func etcdClientEndpoint(processArgs []string) (string, bool, error) {
+	endpoint := processFlagValue(processArgs, "--advertise-client-urls")
+	if endpoint == "" {
+		endpoint = processFlagValue(processArgs, "--listen-client-urls")
+	}
+	if endpoint == "" {
+		return "", false, fmt.Errorf("etcd container spec has no client endpoint")
+	}
+
+	var scheme string
+	for _, rawEndpoint := range strings.Split(endpoint, ",") {
+		parsed, err := url.Parse(rawEndpoint)
+		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+			return "", false, fmt.Errorf("etcd container spec has invalid client endpoint %q", rawEndpoint)
+		}
+		if scheme != "" && parsed.Scheme != scheme {
+			return "", false, fmt.Errorf("etcd container spec mixes HTTP and HTTPS client endpoints")
+		}
+		scheme = parsed.Scheme
+	}
+
+	return endpoint, scheme == "https", nil
+}
+
+func processFlagValue(args []string, flag string) string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+		if value, ok := strings.CutPrefix(arg, flag+"="); ok {
+			return value
+		}
+	}
+	return ""
+}
+
+func hasMount(mounts []specs.Mount, destination string) bool {
+	for _, mount := range mounts {
+		if mount.Destination == destination {
+			return true
+		}
+	}
+	return false
+}
+
+func newEtcdctlExecID() string {
+	return fmt.Sprintf("miren-etcdctl-%d-%d", os.Getpid(), time.Now().UnixNano())
+}

--- a/cli/commands/debug_etcdctl_test.go
+++ b/cli/commands/debug_etcdctl_test.go
@@ -1,0 +1,198 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEtcdctlExecArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		processArgs []string
+		mounts      []specs.Mount
+		userArgs    []string
+		want        []string
+	}{
+		{
+			name: "plaintext endpoint",
+			processArgs: []string{
+				"/usr/local/bin/etcd",
+				"--advertise-client-urls", "http://localhost:12379",
+			},
+			userArgs: []string{"get", "/", "--prefix"},
+			want: []string{
+				"tasks", "exec", "--exec-id", "test-exec",
+				"miren-etcd", "/usr/local/bin/etcdctl",
+				"--endpoints=http://localhost:12379",
+				"get", "/", "--prefix",
+			},
+		},
+		{
+			name: "TLS endpoint",
+			processArgs: []string{
+				"/usr/local/bin/etcd",
+				"--advertise-client-urls=https://localhost:22379",
+			},
+			mounts:   []specs.Mount{{Destination: "/certs"}},
+			userArgs: []string{"endpoint", "status", "--write-out=table"},
+			want: []string{
+				"tasks", "exec", "--exec-id", "test-exec",
+				"miren-etcd", "/usr/local/bin/etcdctl",
+				"--endpoints=https://localhost:22379",
+				"--cacert=/certs/ca.crt",
+				"--cert=/certs/client.crt",
+				"--key=/certs/client.key",
+				"endpoint", "status", "--write-out=table",
+			},
+		},
+		{
+			name: "listen URL fallback",
+			processArgs: []string{
+				"/usr/local/bin/etcd",
+				"--listen-client-urls", "http://127.0.0.1:32379",
+			},
+			want: []string{
+				"tasks", "exec", "--exec-id", "test-exec",
+				"miren-etcd", "/usr/local/bin/etcdctl",
+				"--endpoints=http://127.0.0.1:32379",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &specs.Spec{
+				Process: &specs.Process{Args: tt.processArgs},
+				Mounts:  tt.mounts,
+			}
+			got, err := buildEtcdctlExecArgs(spec, tt.userArgs, "test-exec")
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildEtcdctlExecArgsErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *specs.Spec
+		want string
+	}{
+		{
+			name: "missing process",
+			spec: &specs.Spec{},
+			want: "no process configuration",
+		},
+		{
+			name: "missing endpoint",
+			spec: &specs.Spec{Process: &specs.Process{Args: []string{"etcd"}}},
+			want: "no client endpoint",
+		},
+		{
+			name: "invalid endpoint",
+			spec: &specs.Spec{Process: &specs.Process{Args: []string{
+				"etcd", "--advertise-client-urls", "localhost:12379",
+			}}},
+			want: "invalid client endpoint",
+		},
+		{
+			name: "TLS certificates not mounted",
+			spec: &specs.Spec{Process: &specs.Process{Args: []string{
+				"etcd", "--advertise-client-urls", "https://localhost:12379",
+			}}},
+			want: "client certificates are not mounted",
+		},
+		{
+			name: "mixed endpoint schemes",
+			spec: &specs.Spec{Process: &specs.Process{Args: []string{
+				"etcd", "--advertise-client-urls", "http://etcd-1:2379,https://etcd-2:2379",
+			}}},
+			want: "mixes HTTP and HTTPS client endpoints",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buildEtcdctlExecArgs(tt.spec, nil, "test-exec")
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestEtcdClientEndpointSupportsMultipleURLs(t *testing.T) {
+	got, tlsEnabled, err := etcdClientEndpoint([]string{
+		"etcd",
+		"--advertise-client-urls",
+		"https://etcd-1:2379,https://etcd-2:2379",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://etcd-1:2379,https://etcd-2:2379", got)
+	require.True(t, tlsEnabled)
+}
+
+func TestDebugEtcdctlOptionsPreservePassthroughOrder(t *testing.T) {
+	cmd := Infer("debug etcdctl", "test", DebugEtcdctl)
+	require.NoError(t, cmd.fs.Parse([]string{
+		"get", "--prefix", "/", "--keys-only",
+	}))
+
+	opts := cmd.opts.Elem().Interface().(debugEtcdctlOptions)
+	require.Equal(t, []string{
+		"get", "--prefix", "/", "--keys-only",
+	}, opts.etcdctlArgs())
+}
+
+func TestDebugEtcdctlMirenFlagsMustComeFirst(t *testing.T) {
+	cmd := Infer("debug etcdctl", "test", DebugEtcdctl)
+	require.NoError(t, cmd.fs.Parse([]string{
+		"--socket", "/custom.sock", "get", "/", "--prefix", "--namespace", "custom",
+	}))
+
+	opts := cmd.opts.Elem().Interface().(debugEtcdctlOptions)
+	require.Equal(t, "/custom.sock", opts.Socket)
+	require.Equal(t, "miren", opts.Namespace)
+	require.Equal(t, []string{
+		"get", "/", "--prefix", "--namespace", "custom",
+	}, opts.etcdctlArgs())
+}
+
+func TestLocalEtcdUnavailableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "container not found",
+			err:  errdefs.ErrNotFound,
+			want: `embedded etcd container "miren-etcd" was not found in containerd namespace "miren"`,
+		},
+		{
+			name: "permission denied",
+			err:  errors.New("dial unix /run/containerd.sock: connect: permission denied"),
+			want: "permission denied accessing containerd at /run/containerd.sock",
+		},
+		{
+			name: "connection failure",
+			err:  errors.New("connection refused"),
+			want: "this command must be run on a local Miren coordinator with embedded etcd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := localEtcdUnavailableError("/run/containerd.sock", "miren", tt.err)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestLocalEtcdTaskUnavailableError(t *testing.T) {
+	err := localEtcdTaskUnavailableError(errdefs.ErrNotFound)
+	require.ErrorContains(t, err, `embedded etcd container "miren-etcd" exists but is not running`)
+	require.ErrorContains(t, err, "check the Miren server and coordinator logs")
+}

--- a/components/etcd/etcd.go
+++ b/components/etcd/etcd.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	etcdContainerName   = "miren-etcd"
+	// ContainerName is the containerd identity of Miren's embedded etcd.
+	ContainerName       = "miren-etcd"
 	etcdDataDir         = "/etcd-data"
 	defaultEtcdPort     = 12379             // Non-default port to avoid conflicts
 	defaultEtcdHTTPPort = 12381             // Non-default port to avoid conflicts
@@ -231,7 +232,7 @@ func (e *EtcdComponent) Start(ctx context.Context, config EtcdConfig) error {
 	}
 
 	// Check if container already exists
-	existingContainer, err := e.CC.LoadContainer(ctx, etcdContainerName)
+	existingContainer, err := e.CC.LoadContainer(ctx, ContainerName)
 	if err == nil {
 		if configChanged {
 			e.Log.Info("etcd container config changed, recreating container",
@@ -555,9 +556,9 @@ func (e *EtcdComponent) createContainer(ctx context.Context, image containerd.Im
 	// Create container
 	container, err := e.CC.NewContainer(
 		ctx,
-		etcdContainerName,
+		ContainerName,
 		containerd.WithImage(image),
-		containerd.WithNewSnapshot(etcdContainerName+"-snapshot", image),
+		containerd.WithNewSnapshot(ContainerName+"-snapshot", image),
 		containerd.WithNewSpec(opts...),
 	)
 	if err != nil {

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -137,6 +137,7 @@
       "command/debug-entity-patch",
       "command/debug-entity-put",
       "command/debug-entity-replace",
+      "command/debug-etcdctl",
       "command/debug-netdb",
       "command/debug-netdb-gc",
       "command/debug-netdb-list",

--- a/docs/docs/command/debug-etcdctl.md
+++ b/docs/docs/command/debug-etcdctl.md
@@ -1,0 +1,46 @@
+---
+title: "miren debug etcdctl"
+sidebar_label: "debug etcdctl"
+description: "Run etcdctl against Miren's embedded etcd"
+---
+
+# miren debug etcdctl
+
+Run etcdctl against Miren's embedded etcd
+
+Place Miren's `-n`/`--namespace` and `--socket` flags before the etcdctl arguments. Once the etcdctl arguments begin, all remaining flags are passed through to etcdctl unchanged.
+
+## Usage
+
+```bash
+miren debug etcdctl [args...] [flags]
+```
+
+## Flags
+
+- `--namespace, -n` — containerd namespace (default: `miren`)
+- `--socket` — path to containerd socket
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Show endpoint status:**
+
+```bash
+miren debug etcdctl endpoint status --write-out=table
+```
+
+**List every key:**
+
+```bash
+miren debug etcdctl get / --prefix --keys-only
+```
+
+## See also
+
+- [`miren debug`](/command/debug)

--- a/docs/docs/command/debug.md
+++ b/docs/docs/command/debug.md
@@ -23,6 +23,7 @@ miren debug [flags]
 - [`miren debug ctr`](/command/debug-ctr) — Run ctr with miren defaults
 - [`miren debug disk`](/command/debug-disk) — Disk entity debug commands
 - [`miren debug entity`](/command/debug-entity) — Entity store debug commands
+- [`miren debug etcdctl`](/command/debug-etcdctl) — Run etcdctl against Miren's embedded etcd
 - [`miren debug netdb`](/command/debug-netdb) — Network database debug commands
 - [`miren debug rbac`](/command/debug-rbac) — Fetch and display RBAC rules from miren.cloud
 - [`miren debug reindex`](/command/debug-reindex) — Rebuild all entity indexes from scratch

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -306,6 +306,7 @@ These commands are intended for advanced debugging and troubleshooting. They may
 | [`miren debug entity patch`](/command/debug-entity-patch) | Patch an existing entity |
 | [`miren debug entity put`](/command/debug-entity-put) | Put an entity |
 | [`miren debug entity replace`](/command/debug-entity-replace) | Replace an existing entity |
+| [`miren debug etcdctl`](/command/debug-etcdctl) | Run etcdctl against Miren's embedded etcd |
 | [`miren debug netdb`](/command/debug-netdb) | Network database debug commands |
 | [`miren debug netdb gc`](/command/debug-netdb-gc) | Find and release orphaned IP leases |
 | [`miren debug netdb list`](/command/debug-netdb-list) | List all IP leases from netdb |


### PR DESCRIPTION
Getting at embedded etcd currently means either dropping down to `miren debug ctr`, remembering the container and task incantation, then reconstructing the active endpoint and mTLS flags, or installing `etcdctl` separately and wiring up those same connection details by hand. Both work, but both are fiddly little rituals for a common debugging job.

This adds `miren debug etcdctl ...` as the direct path. The command reads the live etcd container spec, supplies the advertised endpoint and mounted client credentials when TLS is enabled, and passes the remaining arguments through unchanged. It still delegates the actual exec to `ctr`, so its I/O, signal, and exit behavior stays familiar.

The command is deliberately local to coordinators running embedded etcd. Missing containers, inaccessible sockets, and connection failures now explain that requirement rather than leaking an opaque containerd error.

The `make dev` smoke test exercised the mTLS path against etcd 3.5.15: endpoint status and health succeeded, a limited prefix query returned live Miren keys, and etcdctl flags worked both before and after the subcommand. The CLI package tests pass and lint is clean.