### PR TITLE
Simplify loops with modern Go syntax

### DIFF
--- a/api/app/envvar.go
+++ b/api/app/envvar.go
@@ -73,7 +73,7 @@ func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 		}
 	}
 
-	for attempt := 0; attempt < envMutateMaxAttempts; attempt++ {
+	for range envMutateMaxAttempts {
 		appVer, spec, appRec, appRev, err := resolveBaseVersion(ctx, ec, appName, baseVersion)
 		if err != nil {
 			return nil, err
@@ -112,7 +112,7 @@ func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 func DeleteEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 	baseVersion *core_v1alpha.AppVersion, keys []string, service string) (*DeleteResult, error) {
 
-	for attempt := 0; attempt < envMutateMaxAttempts; attempt++ {
+	for range envMutateMaxAttempts {
 		appVer, spec, appRec, appRev, err := resolveBaseVersion(ctx, ec, appName, baseVersion)
 		if err != nil {
 			return nil, err
@@ -249,7 +249,7 @@ func SetInitialEnvVars(ctx context.Context, ec *entityserver.Client, appName str
 	}
 
 	const maxAttempts = 5
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for range maxAttempts {
 		appEnt, err := ec.EAC().Get(ctx, "app/"+appName)
 		if err != nil {
 			return "", err

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -99,7 +99,7 @@ func sortAddresses(addresses []string) []string {
 	copy(sorted, addresses)
 
 	// Sort with custom logic
-	for i := 0; i < len(sorted); i++ {
+	for i := range sorted {
 		for j := i + 1; j < len(sorted); j++ {
 			// Check if addresses should be swapped
 			if shouldSwapAddresses(sorted[i], sorted[j]) {

--- a/cli/commands/logs_test.go
+++ b/cli/commands/logs_test.go
@@ -197,7 +197,7 @@ func TestPrintLogEntryJSON(t *testing.T) {
 		var buf bytes.Buffer
 		ctx := &Context{Context: context.Background(), Stdout: &buf}
 
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			entry := &app_v1alpha.LogEntry{}
 			entry.SetTimestamp(standard.ToTimestamp(ts))
 			entry.SetStream("stdout")
@@ -463,7 +463,7 @@ func TestLogCoalescer(t *testing.T) {
 	t.Run("repeated lines collapse to one live counter", func(t *testing.T) {
 		var buf bytes.Buffer
 		c := newCoalescer(&buf)
-		for i := 0; i < 4; i++ {
+		for i := range 4 {
 			c.print(mk(11+i, "ping"))
 		}
 		c.flush()
@@ -577,7 +577,7 @@ func TestLogPrinterNonTTYNeverCoalesces(t *testing.T) {
 	printer, flush := logPrinter(ctx, false, true)
 
 	ts := time.Date(2026, 3, 13, 16, 30, 0, 0, time.UTC)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		e := &app_v1alpha.LogEntry{}
 		e.SetTimestamp(standard.ToTimestamp(ts))
 		e.SetStream("stdout")

--- a/cli/commands/safe_status_ch_test.go
+++ b/cli/commands/safe_status_ch_test.go
@@ -34,10 +34,10 @@ func TestSafeStatusChNoPanicOnConcurrentClose(t *testing.T) {
 
 	var senderWG sync.WaitGroup
 	senderWG.Add(senders)
-	for i := 0; i < senders; i++ {
+	for range senders {
 		go func() {
 			defer senderWG.Done()
-			for j := 0; j < sendsPerGoroutine; j++ {
+			for j := range sendsPerGoroutine {
 				if err := s.Send(ctx, &client.SolveStatus{}); err != nil {
 					t.Errorf("Send returned error: %v", err)
 					return
@@ -81,7 +81,7 @@ func TestSafeStatusChCloseUnblocksParkedSend(t *testing.T) {
 
 	<-parked
 	// Give the Send a moment to enter the select.
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		_ = i
 	}
 

--- a/clientconfig/leafwrite_test.go
+++ b/clientconfig/leafwrite_test.go
@@ -49,7 +49,7 @@ func TestAtomicWriteFileNoTornRead(t *testing.T) {
 	big, err := yaml.Marshal(&ConfigData{
 		Identities: func() map[string]*IdentityConfig {
 			m := make(map[string]*IdentityConfig)
-			for i := 0; i < 200; i++ {
+			for i := range 200 {
 				m[string(rune('a'+i%26))+string(rune('0'+i%10))+"-"+itoa(i)] = &IdentityConfig{
 					Type:         "token",
 					Token:        "eyJhbGciOiJFZERTQSJ9." + itoa(i),
@@ -84,7 +84,7 @@ func TestAtomicWriteFileNoTornRead(t *testing.T) {
 	}()
 
 	// Writer: alternate payloads so length changes each time.
-	for i := 0; i < 300; i++ {
+	for i := range 300 {
 		payload := big
 		if i%2 == 0 {
 			payload = small

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -422,7 +422,7 @@ func findWorkingAddress(ctx context.Context, addresses []string) (string, error)
 
 	// Wait for the first successful probe or all failures
 	var errors []string
-	for i := 0; i < len(addresses); i++ {
+	for range addresses {
 		select {
 		case res := <-resultChan:
 			if res.err == nil {

--- a/clientconfig/token_refresh_concurrency_test.go
+++ b/clientconfig/token_refresh_concurrency_test.go
@@ -114,7 +114,7 @@ func TestTokenForIdentityConcurrentRefresh(t *testing.T) {
 
 	// In-process goroutines, each with its own freshly-loaded Config (mirrors
 	// separate `m` invocations that share the on-disk config).
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -138,7 +138,7 @@ func TestTokenForIdentityConcurrentRefresh(t *testing.T) {
 	}
 
 	// Subprocesses: prove the lock is cross-process, not just cross-goroutine.
-	for i := 0; i < subprocesses; i++ {
+	for range subprocesses {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -676,7 +676,7 @@ poolLoop:
 
 			const maxRetries = 3
 			poolDeleted := false
-			for attempt := 0; attempt < maxRetries; attempt++ {
+			for attempt := range maxRetries {
 				a.mu.Lock()
 				if state.pool.DesiredInstances >= maxInstances {
 					poolIDForMaxCheck := state.pool.ID
@@ -859,7 +859,7 @@ poolLoop:
 		const baseRetryDelay = 100 * time.Millisecond
 
 		var foundPoolWithRev *poolWithRevision
-		for attempt := 0; attempt < maxRetries; attempt++ {
+		for attempt := range maxRetries {
 			if attempt > 0 {
 				// Release lock during retry delay
 				a.mu.Unlock()

--- a/components/activator/activator_fixed_mode_test.go
+++ b/components/activator/activator_fixed_mode_test.go
@@ -134,7 +134,7 @@ func TestActivatorFixedModeRoundRobin(t *testing.T) {
 	sandboxURLs := make(map[string]int)
 
 	// Acquire multiple leases - should round-robin
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		lease, err := activator.AcquireLease(ctx, appVer, "web")
 		require.NoError(t, err)
 		require.NotNil(t, lease)
@@ -259,7 +259,7 @@ func TestActivatorFixedModeNoSlotExhaustion(t *testing.T) {
 	// Acquire many leases simultaneously (without releasing)
 	// For auto mode this would exhaust slots, but fixed mode should handle it fine
 	leases := make([]*Lease, 0)
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		lease, err := activator.AcquireLease(ctx, appVer, "web")
 		require.NoError(t, err)
 		require.NotNil(t, lease)

--- a/components/activator/activator_test.go
+++ b/components/activator/activator_test.go
@@ -121,7 +121,7 @@ func TestActivatorConcurrentSafety(t *testing.T) {
 
 	// Goroutine 1: Add versions
 	go func() {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			activator.mu.Lock()
 			activator.versions[verKey{ver: "ver-1", service: "web"}] = &versionPoolRef{
 				poolID:  poolID,
@@ -134,7 +134,7 @@ func TestActivatorConcurrentSafety(t *testing.T) {
 
 	// Goroutine 2: Read versions
 	go func() {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			activator.mu.Lock()
 			_ = activator.versions[verKey{ver: "ver-1", service: "web"}]
 			activator.mu.Unlock()
@@ -144,7 +144,7 @@ func TestActivatorConcurrentSafety(t *testing.T) {
 
 	// Goroutine 3: Delete versions
 	go func() {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			activator.mu.Lock()
 			delete(activator.versions, verKey{ver: "ver-1", service: "web"})
 			activator.mu.Unlock()
@@ -153,7 +153,7 @@ func TestActivatorConcurrentSafety(t *testing.T) {
 	}()
 
 	// Wait for all goroutines
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		<-done
 	}
 
@@ -330,7 +330,7 @@ func TestActivatorRecoveryIntegration(t *testing.T) {
 	pool.ID = poolID
 
 	// Create multiple running sandboxes
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		sb := compute_v1alpha.Sandbox{
 			Status: compute_v1alpha.RUNNING,
 			Spec: compute_v1alpha.SandboxSpec{
@@ -1675,7 +1675,7 @@ func TestConcurrentPoolIncrement(t *testing.T) {
 	errors := make(chan error, numGoroutines)
 	barrier := make(chan struct{})
 
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		go func(id int) {
 			// Wait for all goroutines to be ready
 			<-barrier
@@ -1694,7 +1694,7 @@ func TestConcurrentPoolIncrement(t *testing.T) {
 
 	// Collect all results
 	var returnedPools []*compute_v1alpha.SandboxPool
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		select {
 		case pool := <-results:
 			returnedPools = append(returnedPools, pool)
@@ -2277,7 +2277,7 @@ func TestActivatorDoesNotFailFastWhenPoolIsReusedByNewVersion(t *testing.T) {
 
 	// 9 DEAD sandboxes in the shared pool, all tagged as v1's.
 	var deadSandboxes []*sandbox
-	for i := 0; i < 9; i++ {
+	for i := range 9 {
 		id := entity.Id("dead-v1-" + string(rune('0'+i)))
 		ent := entity.Blank()
 		ent.SetID(id)
@@ -2971,7 +2971,7 @@ func TestRequestPoolCapacityAtMaxReturnsExistingPool(t *testing.T) {
 		inProgress: false,
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		resultPool, err := activator.requestPoolCapacity(ctx, testVer, "web")
 		require.NoError(t, err, "iteration %d: at-cap pool must not error", i)
 		require.NotNil(t, resultPool)
@@ -3716,7 +3716,7 @@ func TestRequestPoolCapacityRetryRaceNoDoubleUnlock(t *testing.T) {
 	const rounds = 10
 	const numGoroutines = 40
 
-	for round := 0; round < rounds; round++ {
+	for round := range rounds {
 		// A fresh version each round means a fresh cache key and a store with no
 		// pool for it yet, forcing every caller through the store-lookup retry
 		// loop from an empty cache.
@@ -3754,7 +3754,7 @@ func TestRequestPoolCapacityRetryRaceNoDoubleUnlock(t *testing.T) {
 		// they begin backing off.
 		done := make(chan error, numGoroutines)
 		barrier := make(chan struct{})
-		for i := 0; i < numGoroutines; i++ {
+		for range numGoroutines {
 			go func() {
 				<-barrier
 				_, err := activator.requestPoolCapacity(ctx, testVer, "web")
@@ -3782,7 +3782,7 @@ func TestRequestPoolCapacityRetryRaceNoDoubleUnlock(t *testing.T) {
 		// Drain every caller. We don't require success — depending on scheduling a
 		// caller may hit a benign OCC conflict or the not-found terminal path. We
 		// only require the process to survive: no fatal double-unlock.
-		for i := 0; i < numGoroutines; i++ {
+		for range numGoroutines {
 			<-done
 		}
 	}

--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -569,7 +569,7 @@ func (c *Component) monitorTask(monitorCtx context.Context, exitCh <-chan contai
 
 func (c *Component) waitForReady(ctx context.Context) error {
 	// Wait for the Unix socket to be created and connectable
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		// Check if socket file exists
 		if _, err := os.Stat(c.socketPath); err == nil {
 			// Try to connect to it

--- a/components/diskio/state_test.go
+++ b/components/diskio/state_test.go
@@ -210,9 +210,9 @@ func TestStateConcurrentAccess(t *testing.T) {
 	// Simulate concurrent access
 	done := make(chan bool, 10)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		go func(idx int) {
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				state.SetVolume("vol-1", &VolumeState{EntityId: "vol-1"})
 				_ = state.GetVolume("vol-1")
 			}
@@ -220,9 +220,9 @@ func TestStateConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		go func(idx int) {
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				state.SetMount("mount-1", &MountState{EntityId: "mount-1"})
 				_ = state.GetMount("mount-1")
 			}
@@ -231,7 +231,7 @@ func TestStateConcurrentAccess(t *testing.T) {
 	}
 
 	// Wait for all goroutines
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 

--- a/components/ipalloc/ipalloc.go
+++ b/components/ipalloc/ipalloc.go
@@ -139,7 +139,7 @@ func generateRandomIPInSubnet(r *mrand.Rand, prefix netip.Prefix) (netip.Addr, e
 	copy(paddedOffset[len(paddedOffset)-len(offsetBytes):], offsetBytes)
 
 	// Apply the offset
-	for i := 0; i < len(ipBytes); i++ {
+	for i := range ipBytes {
 		ipBytes[i] += paddedOffset[i]
 	}
 

--- a/components/victoriametrics/integration_test.go
+++ b/components/victoriametrics/integration_test.go
@@ -315,7 +315,7 @@ func TestVictoriaMetricsComponent_MultipleStarts(t *testing.T) {
 
 	// Start, stop, start, stop multiple times
 	client := &http.Client{Timeout: 5 * time.Second}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		t.Logf("Cycle %d: Starting...", i+1)
 		err = component.Start(ctx, config)
 		if err != nil {

--- a/controllers/integration/chaos_test.go
+++ b/controllers/integration/chaos_test.go
@@ -438,7 +438,7 @@ func chaosReconcileRound(ctx context.Context, h *TestHarness, rng *rand.Rand) {
 
 	for _, c := range controllers {
 		passes := rng.Intn(3) + 1
-		for i := 0; i < passes; i++ {
+		for range passes {
 			h.reconcileByIndex(ctx, c.index, c.rc)
 		}
 	}
@@ -469,7 +469,7 @@ func TestChaosConvergence(t *testing.T) {
 
 	// Phase 1: Boot N sandboxes with individual disks
 	const numSandboxes = 3
-	for i := 0; i < numSandboxes; i++ {
+	for i := range numSandboxes {
 		sbID := entity.Id(fmt.Sprintf("sandbox/chaos-%d", i))
 		diskName := fmt.Sprintf("chaos-disk-%d", i)
 		diskID, leaseID := bootSandboxWithDisk(t, ctx, h, sbID, diskName, 10)
@@ -497,7 +497,7 @@ func TestChaosConvergence(t *testing.T) {
 		report.recordAttempt(fault.name, ok)
 
 		rounds := rng.Intn(5) + 1
-		for r := 0; r < rounds; r++ {
+		for range rounds {
 			chaosReconcileRound(ctx, h, rng)
 		}
 

--- a/controllers/integration/lifecycle_test.go
+++ b/controllers/integration/lifecycle_test.go
@@ -521,7 +521,7 @@ func TestPoolScaleDownReleasesDisks(t *testing.T) {
 	}
 
 	var sandboxes []sbInfo
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		sbID := entity.Id(entity.Id("sandbox/scale-" + string(rune('a'+i))))
 		diskName := "scale-disk-" + string(rune('a'+i))
 		diskID, leaseID := bootSandboxWithDisk(t, ctx, h, sbID, diskName, 10)

--- a/controllers/integration/overlapping_test.go
+++ b/controllers/integration/overlapping_test.go
@@ -145,7 +145,7 @@ func TestStopDuringMountCreation(t *testing.T) {
 
 	// Drive disk to PROVISIONED without processing the mount
 	nodeId := compute.NewNodeId(testNodeId).Id()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		h.reconcileKind(ctx, storage.KindDisk, h.DiskRC)
 		h.reconcileByIndex(ctx, entity.Ref(storage.DiskVolumeNodeIdId, nodeId), h.DiskVolRC)
 	}
@@ -157,7 +157,7 @@ func TestStopDuringMountCreation(t *testing.T) {
 	mount := getMountForLease(t, ctx, h, leaseID)
 	// If mount wasn't created (disk still provisioning), drive more reconciliation
 	if mount == nil {
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			h.reconcileKind(ctx, storage.KindDisk, h.DiskRC)
 			h.reconcileByIndex(ctx, entity.Ref(storage.DiskVolumeNodeIdId, nodeId), h.DiskVolRC)
 			h.reconcileKind(ctx, storage.KindDiskLease, h.DiskLeaseRC)
@@ -255,7 +255,7 @@ func TestReplacementMountPathCollision(t *testing.T) {
 
 	// KEY INTERLEAVING: Process mount-B first (attach+mount), then mount-A (unmount).
 	// This is the worst case ordering that exposes the path collision bug.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		err = h.ReconcileEntity(ctx, mountBID)
 		require.NoError(t, err, "ReconcileEntity for mount-B should not fail")
 		bState := getMountByID(t, ctx, h, mountBID)

--- a/controllers/integration/redeploy_test.go
+++ b/controllers/integration/redeploy_test.go
@@ -52,7 +52,7 @@ func concurrentReconcileEntities(ctx context.Context, h *TestHarness, index enti
 	close(ch)
 
 	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
+	for range workers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -428,7 +428,7 @@ func TestRapidRedeployWithDisk(t *testing.T) {
 		// Run 0-2 concurrent disk controller reconciliation rounds per iteration
 		// to create varying interleaving patterns
 		reconcileRounds := v % 3
-		for r := 0; r < reconcileRounds; r++ {
+		for range reconcileRounds {
 			concurrentReconcileRound(ctx, h, concWorkers)
 		}
 
@@ -445,7 +445,7 @@ func TestRapidRedeployWithDisk(t *testing.T) {
 	finalizeStoppedSandboxes(t, ctx, h)
 
 	// Concurrent disk controller rounds
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		concurrentReconcileRound(ctx, h, concWorkers)
 	}
 	h.ReconcileAll(ctx, 30)

--- a/controllers/sandbox/log_test.go
+++ b/controllers/sandbox/log_test.go
@@ -95,7 +95,7 @@ func TestSandboxLogs(t *testing.T) {
 		// Stream ~12.5 MiB with no newline, in 64 KiB chunks the way containerd
 		// pumps a blob — far more than the 1 MiB cap.
 		chunk := bytes.Repeat([]byte("x"), 64*1024)
-		for i := 0; i < 200; i++ {
+		for range 200 {
 			n, err := sl.Write(chunk)
 			r.NoError(err)
 			r.Equal(len(chunk), n) // all bytes are always "consumed"
@@ -586,7 +586,7 @@ func BenchmarkSandboxLogsLargeBuffer(b *testing.B) {
 
 	// Create a large buffer with many lines
 	var buf bytes.Buffer
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		buf.WriteString("log line ")
 		buf.WriteString(string('0' + rune(i%10)))
 		buf.WriteByte('\n')

--- a/controllers/sandboxpool/manager_test.go
+++ b/controllers/sandboxpool/manager_test.go
@@ -102,7 +102,7 @@ func TestManagerScaleUpPartial(t *testing.T) {
 	pool.ID = poolID
 
 	// Create 2 existing sandboxes for this pool
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		sb := &compute_v1alpha.Sandbox{
 			Status: compute_v1alpha.RUNNING,
 			Spec:   pool.SandboxSpec,
@@ -235,7 +235,7 @@ func TestManagerVersionFiltering(t *testing.T) {
 
 	// Create 2 sandboxes with old version but correct pool label.
 	// These should be counted as pool members (pool label is authoritative).
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		sb := &compute_v1alpha.Sandbox{
 			Status: compute_v1alpha.RUNNING,
 			Spec: compute_v1alpha.SandboxSpec{
@@ -533,7 +533,7 @@ func TestManagerScaleDownFixedModeProactive(t *testing.T) {
 
 	// Create 3 RUNNING sandboxes, all with no activity yet (LastActivity.IsZero())
 	// This simulates a deployment where sandboxes just started
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		sb := &compute_v1alpha.Sandbox{
 			Status: compute_v1alpha.RUNNING,
 			// LastActivity is zero (not set) - simulates fresh sandboxes
@@ -617,7 +617,7 @@ func TestManagerZeroValuePersistence(t *testing.T) {
 	// Test 1: Update DesiredInstances to 0 via checkPoolForScaleDown
 	// Create 5 idle sandboxes so checkPoolForScaleDown will decrement DesiredInstances to 0
 	now := time.Now()
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		sb := &compute_v1alpha.Sandbox{
 			Status:       compute_v1alpha.RUNNING,
 			LastActivity: now.Add(-10 * time.Minute),
@@ -1426,7 +1426,7 @@ func TestManagerCrashResetDoesNotRecount(t *testing.T) {
 	// Create 3 DEAD sandboxes that crashed quickly (lifetime < 60s).
 	// These represent sandboxes from a previous version that crash-looped.
 	crashTime := time.Now().Add(-5 * time.Minute)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		createdAt := crashTime.Add(time.Duration(i) * 30 * time.Second)
 		server.Store.NowFunc = func() time.Time { return createdAt }
 

--- a/controllers/scheduler/scheduler_test.go
+++ b/controllers/scheduler/scheduler_test.go
@@ -277,7 +277,7 @@ func TestSchedulerMultipleNodes(t *testing.T) {
 	// three onto the same id (and now conflict, since CreateEntity is
 	// put-if-absent on every backend).
 	nodeIDs := make(map[entity.Id]bool)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		nodeID := createReadyNode(t, ctx, server.Client, fmt.Sprintf("node-%d", i), &compute_v1alpha.Node{
 			Status: compute_v1alpha.READY,
 		})
@@ -290,7 +290,7 @@ func TestSchedulerMultipleNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create and schedule multiple sandboxes
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		sandbox := &compute_v1alpha.Sandbox{
 			Status: compute_v1alpha.PENDING,
 		}
@@ -386,7 +386,7 @@ func TestSchedulerStatelessSandboxPrefersRunners(t *testing.T) {
 	// three onto the same id (and now conflict, since CreateEntity is
 	// put-if-absent on every backend).
 	runnerIDs := make(map[entity.Id]bool)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		runnerID := createReadyNode(t, ctx, server.Client, fmt.Sprintf("runner-%d", i), &compute_v1alpha.Node{
 			Status:   compute_v1alpha.READY,
 			RunnerId: "550e8400-e29b-41d4-a716-44665544000" + string(rune('0'+i)),
@@ -400,7 +400,7 @@ func TestSchedulerStatelessSandboxPrefersRunners(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create and schedule multiple stateless sandboxes
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		sandbox := &compute_v1alpha.Sandbox{
 			Status: compute_v1alpha.PENDING,
 			Spec: compute_v1alpha.SandboxSpec{
@@ -579,7 +579,7 @@ func createPreScheduledSandbox(t *testing.T, ctx context.Context, server *testut
 // onto the same node. Repeats enough times to catch the random-collision case
 // that surfaced the bug.
 func TestSchedulerSpreadsReplicasAcrossRunners(t *testing.T) {
-	for trial := 0; trial < 20; trial++ {
+	for trial := range 20 {
 		t.Run(fmt.Sprintf("trial-%d", trial), func(t *testing.T) {
 			ctx := context.Background()
 			log := testutils.TestLogger(t)
@@ -602,7 +602,7 @@ func TestSchedulerSpreadsReplicasAcrossRunners(t *testing.T) {
 			poolID := "pool-spread-test"
 
 			placements := make(map[entity.Id]int)
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				sb := &compute_v1alpha.Sandbox{
 					Status: compute_v1alpha.PENDING,
 					Spec: compute_v1alpha.SandboxSpec{
@@ -654,7 +654,7 @@ func TestSchedulerPacksWhenReplicasExceedRunners(t *testing.T) {
 	poolID := "pool-pack-test"
 
 	placements := make(map[entity.Id]int)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		sb := &compute_v1alpha.Sandbox{
 			Status: compute_v1alpha.PENDING,
 			Spec: compute_v1alpha.SandboxSpec{

--- a/metrics/victoriametrics_writer_test.go
+++ b/metrics/victoriametrics_writer_test.go
@@ -58,7 +58,7 @@ func TestVictoriaMetricsWriter_WritePoint(t *testing.T) {
 		writer := NewVictoriaMetricsWriter(log, "localhost:8428", 10*time.Second)
 
 		// Fill buffer to maxMetricBufferSize
-		for i := 0; i < maxMetricBufferSize; i++ {
+		for i := range maxMetricBufferSize {
 			err := writer.WritePoint(context.Background(), MetricPoint{
 				Name:      "test_metric",
 				Value:     float64(i),
@@ -122,7 +122,7 @@ func TestVictoriaMetricsWriter_WritePoints(t *testing.T) {
 		writer := NewVictoriaMetricsWriter(log, "localhost:8428", 10*time.Second)
 
 		// Fill buffer to near capacity
-		for i := 0; i < maxMetricBufferSize-100; i++ {
+		for i := range maxMetricBufferSize - 100 {
 			err := writer.WritePoint(context.Background(), MetricPoint{
 				Name:      "test",
 				Value:     float64(i),
@@ -251,7 +251,7 @@ func TestVictoriaMetricsWriter_FlushBehavior(t *testing.T) {
 		defer writer.Close()
 
 		// Write exactly 1000 points
-		for i := 0; i < 1000; i++ {
+		for i := range 1000 {
 			err := writer.WritePoint(context.Background(), MetricPoint{
 				Name:      "test",
 				Value:     float64(i),
@@ -283,7 +283,7 @@ func TestVictoriaMetricsWriter_FlushBehavior(t *testing.T) {
 		defer writer.Close()
 
 		// Write a few points
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			err := writer.WritePoint(context.Background(), MetricPoint{
 				Name:      "test",
 				Value:     float64(i),
@@ -314,7 +314,7 @@ func TestVictoriaMetricsWriter_FlushBehavior(t *testing.T) {
 		writer := NewVictoriaMetricsWriter(log, strings.TrimPrefix(server.URL, "http://"), 10*time.Second)
 
 		// Write a few points
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			err := writer.WritePoint(context.Background(), MetricPoint{
 				Name:      "test",
 				Value:     float64(i),
@@ -362,7 +362,7 @@ func TestVictoriaMetricsWriter_Close(t *testing.T) {
 		writer.Start()
 
 		// Write some points
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			err := writer.WritePoint(context.Background(), MetricPoint{
 				Name:      "test",
 				Value:     float64(i),
@@ -443,11 +443,11 @@ func TestVictoriaMetricsWriter_ConcurrentWrites(t *testing.T) {
 		numGoroutines := 10
 		pointsPerGoroutine := 50
 
-		for i := 0; i < numGoroutines; i++ {
+		for i := range numGoroutines {
 			wg.Add(1)
 			go func(id int) {
 				defer wg.Done()
-				for j := 0; j < pointsPerGoroutine; j++ {
+				for j := range pointsPerGoroutine {
 					err := writer.WritePoint(context.Background(), MetricPoint{
 						Name:      "concurrent_test",
 						Labels:    map[string]string{"goroutine": string(rune(id + '0'))},

--- a/network/config_test.go
+++ b/network/config_test.go
@@ -58,7 +58,7 @@ func TestReserveConflictFree(t *testing.T) {
 		// so every reservation the loop makes collides and it gives up.
 		live := make(map[netip.Addr]bool)
 		addr := netip.MustParseAddr("10.8.64.2")
-		for i := 0; i < allocBridgeMaxAttempts; i++ {
+		for range allocBridgeMaxAttempts {
 			live[addr] = true
 			addr = addr.Next()
 		}

--- a/observability/batch_log_writer_test.go
+++ b/observability/batch_log_writer_test.go
@@ -376,7 +376,7 @@ func TestBatchLogWriter_ReportsTransportFailure(t *testing.T) {
 	}))
 	defer bw.Close()
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		if err := bw.WriteEntry("test-entity", LogEntry{
 			Timestamp: time.Now(),
 			Stream:    Stdout,

--- a/observability/integration_test.go
+++ b/observability/integration_test.go
@@ -184,7 +184,7 @@ func TestVictoriaLogsIntegration(t *testing.T) {
 
 		// Write logs with specific timestamps
 		baseTime := time.Now()
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			err := writer.WriteEntry(entityID, observability.LogEntry{
 				Timestamp: baseTime.Add(time.Duration(i) * time.Second),
 				Stream:    observability.Stdout,
@@ -249,7 +249,7 @@ func TestVictoriaLogsIntegration(t *testing.T) {
 
 		// Write 100 logs
 		logCount := 100
-		for i := 0; i < logCount; i++ {
+		for i := range logCount {
 			err := writer.WriteEntry(entityID, observability.LogEntry{
 				Timestamp: time.Now(),
 				Stream:    observability.Stdout,

--- a/pkg/cel/escaping_test.go
+++ b/pkg/cel/escaping_test.go
@@ -143,7 +143,7 @@ func TestUnescapeMalformed(t *testing.T) {
 
 func TestEscapingFuzz(t *testing.T) {
 	fuzzer := fuzz.New()
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		var unescaped string
 		fuzzer.Fuzz(&unescaped)
 		t.Run(fmt.Sprintf("%d - '%s'", i, unescaped), func(t *testing.T) {

--- a/pkg/cel/library/lists.go
+++ b/pkg/cel/library/lists.go
@@ -281,7 +281,7 @@ func indexOf(list ref.Val, item ref.Val) ref.Val {
 		return types.MaybeNoSuchOverloadErr(list)
 	}
 	sz := lister.Size().(types.Int)
-	for i := types.Int(0); i < sz; i++ {
+	for i := range sz {
 		if lister.Get(types.Int(i)).Equal(item) == types.True {
 			return types.Int(i)
 		}

--- a/pkg/cel/value.go
+++ b/pkg/cel/value.go
@@ -548,10 +548,10 @@ func (lv *ListValue) Add(other ref.Val) ref.Val {
 	szLeft := int(oArr.Size().(types.Int))
 	sz := szRight + szLeft
 	combo := make([]ref.Val, sz)
-	for i := 0; i < szRight; i++ {
+	for i := range szRight {
 		combo[i] = lv.Entries[i].ExprValue()
 	}
-	for i := 0; i < szLeft; i++ {
+	for i := range szLeft {
 		combo[i+szRight] = oArr.Get(types.Int(i))
 	}
 	return types.DefaultTypeAdapter.NativeToValue(combo)
@@ -583,7 +583,7 @@ func (lv *ListValue) Contains(val ref.Val) ref.Val {
 	}
 	var err ref.Val
 	sz := len(lv.Entries)
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		elem := lv.Entries[i]
 		cmp := elem.Equal(val)
 		b, ok := cmp.(types.Bool)
@@ -621,7 +621,7 @@ func (lv *ListValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error)
 	// Allow the element ConvertToNative() function to determine whether conversion is possible.
 	sz := len(lv.Entries)
 	nativeList := reflect.MakeSlice(typeDesc, int(sz), int(sz))
-	for i := 0; i < sz; i++ {
+	for i := range sz {
 		elem := lv.Entries[i]
 		nativeElemVal, err := elem.ConvertToNative(otherElem)
 		if err != nil {
@@ -654,7 +654,7 @@ func (lv *ListValue) Equal(other ref.Val) ref.Val {
 	if sz != oArr.Size() {
 		return types.False
 	}
-	for i := types.Int(0); i < sz; i++ {
+	for i := range sz {
 		cmp := lv.Get(i).Equal(oArr.Get(i))
 		if cmp != types.True {
 			return cmp

--- a/pkg/concurrency/strategy_test.go
+++ b/pkg/concurrency/strategy_test.go
@@ -181,7 +181,7 @@ func TestAutoStrategy_CapacityBoundary(t *testing.T) {
 	// Lease size is 2 (20% of 10)
 	// Max is 10
 	// Acquire 4 leases to get to 8 used
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		tracker.AcquireLease()
 	}
 	assert.Equal(t, 8, tracker.Used())
@@ -272,7 +272,7 @@ func TestEphemeralStrategy_AlwaysHasCapacity(t *testing.T) {
 	eph := &EphemeralStrategy{scaleDownDelay: 5 * time.Minute}
 	tracker := eph.InitializeTracker()
 
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		assert.True(t, tracker.HasCapacity(), "iteration %d should still have capacity", i)
 		tracker.AcquireLease()
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -854,7 +854,7 @@ func TestReconcileController_InFlightQueueing(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for all 5 events to be sent
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		select {
 		case <-eventsSent:
 		case <-time.After(1 * time.Second):
@@ -868,7 +868,7 @@ func TestReconcileController_InFlightQueueing(t *testing.T) {
 	// Now unblock the handler one at a time
 	// Since all events are for the same entity, they should be processed sequentially
 	// by the same worker, not concurrently
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		blockChan <- struct{}{}
 		time.Sleep(10 * time.Millisecond) // Small delay between unblocks
 	}
@@ -1061,7 +1061,7 @@ func TestReconcileController_InFlightWithMultipleEntities(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for all 6 events to be sent (3 per entity)
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		select {
 		case <-eventsSent:
 		case <-time.After(1 * time.Second):
@@ -1073,7 +1073,7 @@ func TestReconcileController_InFlightWithMultipleEntities(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Unblock all handlers
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		blockChan <- struct{}{}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/pkg/controller/ringset_test.go
+++ b/pkg/controller/ringset_test.go
@@ -66,22 +66,22 @@ func TestRingSet_Concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Spawn multiple goroutines adding values
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(start int) {
 			defer wg.Done()
-			for j := 0; j < 50; j++ {
+			for j := range 50 {
 				rs.Add(int64(start*50 + j))
 			}
 		}(i)
 	}
 
 	// Spawn multiple goroutines checking values
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(start int) {
 			defer wg.Done()
-			for j := 0; j < 50; j++ {
+			for j := range 50 {
 				_ = rs.Contains(int64(start*50 + j))
 			}
 		}(i)

--- a/pkg/deploylifecycle/lock.go
+++ b/pkg/deploylifecycle/lock.go
@@ -184,7 +184,7 @@ func (l *Locks) Acquire(ctx context.Context, appName, deploymentID string) (*Hol
 
 	id := LockID(appName)
 
-	for attempt := 0; attempt < lockAcquireLimit; attempt++ {
+	for attempt := range lockAcquireLimit {
 		mine := l.holderFor(appName, deploymentID)
 
 		res, err := l.eac.Ensure(ctx, l.encode(id, mine))

--- a/pkg/deploylifecycle/lock_test.go
+++ b/pkg/deploylifecycle/lock_test.go
@@ -357,7 +357,7 @@ func TestConcurrentAcquireYieldsExactlyOneWinner(t *testing.T) {
 	)
 
 	start := make(chan struct{})
-	for i := 0; i < contenders; i++ {
+	for i := range contenders {
 		id := "dep-" + string(rune('a'+i))
 		wg.Add(1)
 		go func() {

--- a/pkg/deploylifecycle/tracker.go
+++ b/pkg/deploylifecycle/tracker.go
@@ -322,7 +322,7 @@ func (t *Tracker) update(ctx context.Context, deploymentID string, mutate func(*
 		return cond.ValidationFailure("missing-field", "deployment_id is required")
 	}
 
-	for attempt := 0; attempt < updateRetryLimit; attempt++ {
+	for attempt := range updateRetryLimit {
 		rec, err := t.store.Get(ctx, deploymentID)
 		if err != nil {
 			return err

--- a/pkg/entity/cmd/schemagen/generator_test.go
+++ b/pkg/entity/cmd/schemagen/generator_test.go
@@ -792,7 +792,7 @@ func TestRegisterEncodedSchemaStableWithDifferentFieldOrder(t *testing.T) {
 	const iterations = 5
 	var outputs []string
 
-	for i := 0; i < iterations; i++ {
+	for i := range iterations {
 		code, err := GenerateSchema(sf, "test")
 		if err != nil {
 			t.Fatalf("Failed to generate schema on iteration %d: %v", i, err)

--- a/pkg/entity/indexwatch/watcher_test.go
+++ b/pkg/entity/indexwatch/watcher_test.go
@@ -139,7 +139,7 @@ func TestWatcher_InitialSyncSnapshot(t *testing.T) {
 	r := require.New(t)
 
 	store := entity.NewMockStore()
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		_, err := store.CreateEntity(context.Background(), makeEntity(fmt.Sprintf("widget-%d", i)))
 		r.NoError(err)
 	}
@@ -399,7 +399,7 @@ func TestWatcher_BlockingBackpressure(t *testing.T) {
 	ch := nextChan(t, chans, 5*time.Second)
 
 	// Pre-create the entities so the server can read them on put events.
-	for i := 0; i < n; i++ {
+	for i := range n {
 		_, err := store.CreateEntity(ctx, makeEntity(fmt.Sprintf("widget-%d", i)))
 		r.NoError(err)
 	}
@@ -407,7 +407,7 @@ func TestWatcher_BlockingBackpressure(t *testing.T) {
 	// Push events faster than they are consumed; the unbuffered channel + buffer
 	// of 1 force backpressure all the way to this goroutine.
 	go func() {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			ch <- putEvent(fmt.Sprintf("widget-%d", i), int64(i+10), true)
 		}
 	}()

--- a/pkg/entity/shortid.go
+++ b/pkg/entity/shortid.go
@@ -105,7 +105,7 @@ func AllocateShortId(entityId string, exists ExistsCheck) (string, error) {
 
 func allocateRandomShortId(exists ExistsCheck) (string, error) {
 	for length := defaultShortIdLen; length <= maxShortIdLen; length++ {
-		for attempt := 0; attempt < 5; attempt++ {
+		for range 5 {
 			candidate, err := randomBase58(length)
 			if err != nil {
 				return "", err

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -500,7 +500,7 @@ func (s *EtcdStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error
 		}
 
 		// Process results for this batch
-		for i := 0; i < len(batchIds); i++ {
+		for i := range batchIds {
 			// Each entity has 2 responses: primary and session
 			primaryIdx := i * 2
 			sessionIdx := i*2 + 1

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -504,7 +504,7 @@ func TestEtcdStore_GetEntities_Batching(t *testing.T) {
 	numEntities := 150 // This will require 3 batches (64 + 64 + 22)
 	var entityIds []Id
 
-	for i := 0; i < numEntities; i++ {
+	for i := range numEntities {
 		entity, err := store.CreateEntity(t.Context(), New(
 			Any(Ident, KeywordValue(fmt.Sprintf("test-entity-%d", i))),
 			Any(Doc, fmt.Sprintf("Test entity %d", i)),
@@ -1273,7 +1273,7 @@ func TestEtcdStore_GetEntities(t *testing.T) {
 		// Create a larger batch of entities
 		var ids []Id
 		numEntities := 50
-		for i := 0; i < numEntities; i++ {
+		for i := range numEntities {
 			entity, err := store.CreateEntity(t.Context(), New(
 				Any(Ident, fmt.Sprintf("batch-entity-%d", i)),
 				Any(Doc, fmt.Sprintf("Batch document %d", i)),
@@ -1300,7 +1300,7 @@ func TestEtcdStore_GetEntities(t *testing.T) {
 		r.Equal(numEntities, validCount)
 
 		// Verify order is preserved
-		for i := 0; i < numEntities; i++ {
+		for i := range numEntities {
 			r.NotNil(entities[i])
 			r.Equal(ids[i], entities[i].Id())
 		}

--- a/pkg/hey/requester/print.go
+++ b/pkg/hey/requester/print.go
@@ -81,7 +81,7 @@ func histogram(buckets []Bucket) string {
 		}
 	}
 	res := new(bytes.Buffer)
-	for i := 0; i < len(buckets); i++ {
+	for i := range buckets {
 		// Normalize bar lengths.
 		var barLen int
 		if max > 0 {

--- a/pkg/hey/requester/report.go
+++ b/pkg/hey/requester/report.go
@@ -226,7 +226,7 @@ func (r *report) latencies() []LatencyDistribution {
 		}
 	}
 	res := make([]LatencyDistribution, len(pctls))
-	for i := 0; i < len(pctls); i++ {
+	for i := range pctls {
 		if data[i] > 0 {
 			res[i] = LatencyDistribution{Percentage: pctls[i], Latency: data[i]}
 		}
@@ -239,7 +239,7 @@ func (r *report) histogram() []Bucket {
 	buckets := make([]float64, bc+1)
 	counts := make([]int, bc+1)
 	bs := (r.slowest - r.fastest) / float64(bc)
-	for i := 0; i < bc; i++ {
+	for i := range bc {
 		buckets[i] = r.fastest + bs*float64(i)
 	}
 	buckets[bc] = r.slowest
@@ -257,7 +257,7 @@ func (r *report) histogram() []Bucket {
 		}
 	}
 	res := make([]Bucket, len(buckets))
-	for i := 0; i < len(buckets); i++ {
+	for i := range buckets {
 		res[i] = Bucket{
 			Mark:      buckets[i],
 			Count:     counts[i],

--- a/pkg/hey/requester/requester.go
+++ b/pkg/hey/requester/requester.go
@@ -216,7 +216,7 @@ func (b *Work) runWorker(client *http.Client, n int) {
 			return http.ErrUseLastResponse
 		}
 	}
-	for i := 0; i < n; i++ {
+	for range n {
 		// Check if application is stopped. Do not send into a closed channel.
 		select {
 		case <-b.stopCh:

--- a/pkg/netdb/netdb_test.go
+++ b/pkg/netdb/netdb_test.go
@@ -89,7 +89,7 @@ func TestNetDB(t *testing.T) {
 
 		// Reserve and release several IPs
 		ips := make([]string, 3)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			ip, err := subnet.Reserve()
 			r.NoError(err)
 			ips[i] = ip.String()
@@ -146,7 +146,7 @@ func TestNetDB(t *testing.T) {
 		r.NoError(err)
 
 		// Normal Reserve should skip the specifically reserved IP
-		for i := 0; i < 48; i++ {
+		for range 48 {
 			ip, err := subnet.Reserve()
 			r.NoError(err)
 			r.NotEqual("172.16.8.50/24", ip.String(), "should not allocate specifically reserved IP")
@@ -321,7 +321,7 @@ func TestNetDB(t *testing.T) {
 		)
 
 		wg.Add(workers)
-		for i := 0; i < workers; i++ {
+		for range workers {
 			go func() {
 				defer wg.Done()
 
@@ -332,7 +332,7 @@ func TestNetDB(t *testing.T) {
 				// Retry past transient SQLite busy errors; the property under
 				// test is uniqueness of successful reservations, not liveness.
 				var ip netip.Prefix
-				for attempt := 0; attempt < 100; attempt++ {
+				for range 100 {
 					ip, err = subnet.Reserve()
 					if err == nil {
 						break

--- a/pkg/outboard/outboard_test.go
+++ b/pkg/outboard/outboard_test.go
@@ -437,7 +437,7 @@ func TestConnectorMultipleDetachCalls(t *testing.T) {
 	})
 
 	// Multiple detach calls should all succeed (idempotent)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		err := c.Detach()
 		assert.NoError(t, err, "detach call %d should succeed", i+1)
 	}

--- a/pkg/perf/count_test.go
+++ b/pkg/perf/count_test.go
@@ -51,7 +51,7 @@ func testIPC(t *testing.T) {
 
 	var sum int64
 	gc, err := hw.MeasureGroup(func() {
-		for i := int64(0); i < 1000000; i++ {
+		for i := range int64(1000000) {
 			sum += i
 		}
 	})
@@ -152,7 +152,7 @@ func testL1DataMissesBadLocality(t *testing.T) {
 	max := 1000
 
 	var bad []interface{}
-	for i := 0; i < 10000; i++ {
+	for range 10000 {
 		bad = append(bad, rng.Intn(max))
 	}
 
@@ -197,7 +197,7 @@ func testL1DataMissesGoodLocality(t *testing.T) {
 	max := 1000
 
 	var contiguous []int
-	for i := 0; i < 10000; i++ {
+	for range 10000 {
 		contiguous = append(contiguous, rng.Intn(max))
 	}
 
@@ -266,13 +266,13 @@ func testL1Group(t *testing.T) {
 	const n = 100000
 
 	valuers := make([]valuer, 0, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		valuers = append(valuers, newValuer(i))
 	}
 
 	sum := 0
 	gc, err := l1.MeasureGroup(func() {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			sum += valuers[i].value()
 		}
 	})

--- a/pkg/perf/group_test.go
+++ b/pkg/perf/group_test.go
@@ -43,7 +43,7 @@ func testGroupCount(t *testing.T) {
 
 	sum := int64(0)
 	gc, err := ev.MeasureGroup(func() {
-		for i := int64(0); i < 50000; i++ {
+		for i := range int64(50000) {
 			sum += i
 		}
 	})

--- a/pkg/perf/perf_example_test.go
+++ b/pkg/perf/perf_example_test.go
@@ -36,7 +36,7 @@ func ExampleHardwareCounter_iPC() {
 
 	sum := 0
 	gc, err := ipc.MeasureGroup(func() {
-		for i := 0; i < 100000; i++ {
+		for i := range 100000 {
 			sum += i
 		}
 	})

--- a/pkg/perf/record_test.go
+++ b/pkg/perf/record_test.go
@@ -74,7 +74,7 @@ func testPollTimeout(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			_, err := getpid.ReadRecord(ctx)
 			errch <- err
 		}
@@ -140,7 +140,7 @@ func testPollCancel(t *testing.T) {
 	errch := make(chan error)
 
 	go func() {
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			_, err := getpid.ReadRecord(ctx)
 			errch <- err
 		}
@@ -379,7 +379,7 @@ func testPollDisabledExplicitly(t *testing.T) {
 	seen := 0
 
 	go func() {
-		for i := 0; i < 2*n; i++ {
+		for range 2 * n {
 			_, err := getpid.ReadRecord(ctx)
 			if err == nil {
 				seen++
@@ -392,7 +392,7 @@ func testPollDisabledExplicitly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < n; i++ {
+	for range n {
 		getpidTrigger()
 	}
 
@@ -400,7 +400,7 @@ func testPollDisabledExplicitly(t *testing.T) {
 		getpidTrigger()
 	}
 
-	for i := 0; i < n; i++ {
+	for range n {
 		getpidTrigger()
 	}
 
@@ -461,7 +461,7 @@ func testPollDisabledByRefresh(t *testing.T) {
 	seen := 0
 
 	go func() {
-		for i := 0; i < 2*n; i++ {
+		for range 2 * n {
 			_, err := getpid.ReadRecord(ctx)
 			if err == nil {
 				seen++
@@ -474,11 +474,11 @@ func testPollDisabledByRefresh(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < n; i++ {
+	for range n {
 		getpidTrigger()
 	}
 
-	for i := 0; i < n; i++ {
+	for range n {
 		getpidTrigger()
 	}
 
@@ -801,7 +801,7 @@ func testCPUWideSwitch(t *testing.T) {
 			sendtid = unix.Gettid()
 			ready <- nil
 			<-start
-			for i := 0; i < numpingpongs; i++ {
+			for range numpingpongs {
 				pingpong <- struct{}{}
 				<-pingpong
 			}
@@ -809,7 +809,7 @@ func testCPUWideSwitch(t *testing.T) {
 			recvtid = unix.Gettid()
 			ready <- nil
 			<-start
-			for i := 0; i < numpingpongs; i++ {
+			for range numpingpongs {
 				<-pingpong
 				pingpong <- struct{}{}
 			}
@@ -994,7 +994,7 @@ func testSampleGetpidConcurrent(t *testing.T) {
 	sawSample := make(chan bool)
 
 	go func() {
-		for i := 0; i < n; i++ {
+		for range n {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 			defer cancel()
 			rec, err := getpid.ReadRecord(ctx)
@@ -1010,7 +1010,7 @@ func testSampleGetpidConcurrent(t *testing.T) {
 	seen := 0
 
 	c, err := getpid.Measure(func() {
-		for i := 0; i < n; i++ {
+		for range n {
 			getpidTrigger()
 			if ok := <-sawSample; ok {
 				seen++
@@ -1191,7 +1191,7 @@ func testRedirectedOutput(t *testing.T) {
 
 	errch := make(chan error)
 	go func() {
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 			defer cancel()
 			_, err := leader.ReadRecord(ctx)
@@ -1214,7 +1214,7 @@ func testRedirectedOutput(t *testing.T) {
 		t.Fatalf("got %d hits for %q, want 1 hit", got.Value, got.Label)
 	}
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case <-time.After(10 * time.Millisecond):
 			t.Errorf("did not get sample record: timeout")

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -104,7 +104,7 @@ func reduceCalc(ctx context.Context, total int) (int, error) {
 		return 0, err
 	}
 	// parallel steps
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		func(i int) {
 			eg.Go(func() error {
 				_, err := calc(ctx, total, fmt.Sprintf("calc-%d", i))

--- a/pkg/progress/progressui/display.go
+++ b/pkg/progress/progressui/display.go
@@ -1135,7 +1135,7 @@ func (disp *ttyDisplay) print(d displayInfo, width, height int, all bool) {
 	}
 	// override previous content
 	if diff := disp.lineCount - lineCount; diff > 0 {
-		for i := 0; i < diff; i++ {
+		for range diff {
 			fmt.Fprintln(disp.c, strings.Repeat(" ", width))
 		}
 		fmt.Fprint(disp.c, aec.EmptyBuilder.Up(uint(diff)).Column(0).ANSI)

--- a/pkg/rpc/audit_test.go
+++ b/pkg/rpc/audit_test.go
@@ -355,7 +355,7 @@ func TestCertAuthDeduper(t *testing.T) {
 		if logged, suppressed := d.record(key); !logged || suppressed != 0 {
 			t.Fatalf("first record: got (%v, %d), want (true, 0)", logged, suppressed)
 		}
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			if logged, _ := d.record(key); logged {
 				t.Fatalf("repeat %d logged, want suppressed", i)
 			}
@@ -366,7 +366,7 @@ func TestCertAuthDeduper(t *testing.T) {
 		d, now := fakeClockDeduper(5 * time.Minute)
 
 		d.record(key)
-		for i := 0; i < 4999; i++ {
+		for range 4999 {
 			d.record(key)
 		}
 
@@ -417,7 +417,7 @@ func TestCertAuthDeduper(t *testing.T) {
 
 	t.Run("a nil deduper logs everything", func(t *testing.T) {
 		var d *certAuthDeduper
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			if logged, suppressed := d.record(key); !logged || suppressed != 0 {
 				t.Fatalf("nil deduper: got (%v, %d), want (true, 0)", logged, suppressed)
 			}
@@ -428,7 +428,7 @@ func TestCertAuthDeduper(t *testing.T) {
 		d, now := fakeClockDeduper(5 * time.Minute)
 		d.max = 16
 
-		for i := 0; i < 500; i++ {
+		for i := range 500 {
 			d.record(certAuthKey{fingerprint: "fp-a", host: fmt.Sprintf("10.0.%d.%d", i/256, i%256)})
 			// Advance a little so entries age out rather than all looking current.
 			*now = now.Add(time.Second)
@@ -467,7 +467,7 @@ func TestLogCertAuthDeduplicates(t *testing.T) {
 
 	// A burst from one peer, including a reconnect on a fresh source port.
 	logCertAuth(context.Background(), log, d, newReq("10.0.0.1:8444"))
-	for i := 0; i < 999; i++ {
+	for range 999 {
 		logCertAuth(context.Background(), log, d, newReq("10.0.0.1:41857"))
 	}
 

--- a/pkg/shellwords/batch_test.go
+++ b/pkg/shellwords/batch_test.go
@@ -55,7 +55,6 @@ func TestSplitBatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			actual, err := shellwords.SplitBatch(tc.String)
 			if err != nil {
@@ -84,7 +83,6 @@ func TestQuoteBatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			actual := shellwords.QuoteBatch(tc.String)
 

--- a/pkg/shellwords/posix_test.go
+++ b/pkg/shellwords/posix_test.go
@@ -61,7 +61,6 @@ func TestSplitPosix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			actual, err := shellwords.SplitPosix(tc.String)
 			if err != nil {
@@ -88,7 +87,6 @@ func TestQuotePosix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			actual := shellwords.QuotePosix(tc.String)
 

--- a/pkg/slogout/slogout_test.go
+++ b/pkg/slogout/slogout_test.go
@@ -148,7 +148,7 @@ func TestLogWriterConcurrentWrites(t *testing.T) {
 	// Write multiple lines concurrently
 	done := make(chan bool, 10)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(id int) {
 			defer func() { done <- true }()
 			message := fmt.Sprintf("concurrent message %d\n", id)
@@ -160,14 +160,14 @@ func TestLogWriterConcurrentWrites(t *testing.T) {
 	}
 
 	// Wait for all goroutines to complete
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 
 	logOutput := buf.String()
 
 	// Should contain messages from all goroutines
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		expected := fmt.Sprintf("concurrent message %d", i)
 		assert.Contains(t, logOutput, expected)
 	}

--- a/pkg/snapshot/restore_test.go
+++ b/pkg/snapshot/restore_test.go
@@ -98,7 +98,7 @@ func TestRestoreImage(t *testing.T) {
 	t.Run("round trip data-zeros-data pattern", func(t *testing.T) {
 		// 3 blocks: data, zeros, data
 		srcData := make([]byte, 12288)
-		for i := 0; i < 4096; i++ {
+		for i := range 4096 {
 			srcData[i] = 0xAA
 		}
 		// middle 4096 stays zero
@@ -225,7 +225,7 @@ func TestSparseWrite(t *testing.T) {
 		require.NoError(t, f.Truncate(8192))
 
 		data := make([]byte, 8192)
-		for i := 0; i < 4096; i++ {
+		for i := range 4096 {
 			data[i] = 0xCD
 		}
 

--- a/pkg/testutils/containerd.go
+++ b/pkg/testutils/containerd.go
@@ -27,7 +27,7 @@ func NukeNamespace(cl *containerd.Client, ns string) {
 
 	// There is a delay as things are cleaned up async that
 	// we can't see easily, so we just retry it if there is a failure.
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		err = cl.NamespaceService().Delete(context.TODO(), ns)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
@@ -141,7 +141,7 @@ func WaitForContainerReady(ctx context.Context, cl *containerd.Client, ns, id st
 
 	var err error
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		cont, err := cl.LoadContainer(ctx, id)
 		if err == nil {
 			task, err := cont.Task(ctx, nil)

--- a/pkg/testutils/port_test.go
+++ b/pkg/testutils/port_test.go
@@ -9,7 +9,7 @@ import "testing"
 func TestGetFreePortReturnsDistinctPorts(t *testing.T) {
 	const n = 200
 	seen := make(map[int]bool, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		port := GetFreePort(t)
 		if port <= 0 {
 			t.Fatalf("call %d: GetFreePort returned non-positive port %d", i, port)

--- a/servers/app/addons_integration_test.go
+++ b/servers/app/addons_integration_test.go
@@ -55,7 +55,7 @@ func TestRotateCredentialConcurrentAdmissionEtcd(t *testing.T) {
 	errs := make([]error, n)
 	start := make(chan struct{})
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -73,7 +73,7 @@ func TestRotateCredentialConcurrentAdmissionEtcd(t *testing.T) {
 
 	var admitted, rejected int
 	var admittedID string
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if errs[i] == nil {
 			admitted++
 			admittedID = ids[i]

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -282,7 +282,7 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 	// enough that genuine contention never spuriously fails, while still
 	// guaranteeing termination rather than looping forever.
 	const maxAttempts = 100
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for range maxAttempts {
 		appEnt, err := r.EC.EAC().Get(ctx, "app/"+name)
 		if err != nil {
 			if errors.Is(err, cond.ErrNotFound{}) {

--- a/servers/build/stream_registry_test.go
+++ b/servers/build/stream_registry_test.go
@@ -226,7 +226,7 @@ func TestStreamRegistry_RegisterAfterStageDoesNotResetState(t *testing.T) {
 func TestStreamRegistry_ConcurrentStreams(t *testing.T) {
 	reg := NewStreamRegistry(t.TempDir(), nil)
 	const n = 8
-	for i := 0; i < n; i++ {
+	for i := range n {
 		id := streamID(i)
 		reg.Register(id, makeTar(t, map[string]string{id: id}))
 	}
@@ -234,7 +234,7 @@ func TestStreamRegistry_ConcurrentStreams(t *testing.T) {
 	var wg sync.WaitGroup
 	paths := make([]string, n)
 	errs := make([]error, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -1420,7 +1420,7 @@ func (s *RegistrationServer) deleteEntitiesByIndex(ctx context.Context, ref enti
 // incrementEnrollmentCount atomically increments the enrollment count on a
 // reusable invite. It retries on CAS contention.
 func (s *RegistrationServer) incrementEnrollmentCount(ctx context.Context, invite *runner_v1alpha.RunnerInvite, revision int64) error {
-	for attempt := 0; attempt < enrollmentCountRetries; attempt++ {
+	for attempt := range enrollmentCountRetries {
 		if attempt > 0 {
 			// Re-read the invite to get the latest revision and count
 			refreshed, rev, err := s.findInviteByHash(ctx, invite.CodeHash)


### PR DESCRIPTION
The full Go fixer sweep wants to touch 147 files at once, mixing syntax cleanup with library rewrites and a few changes that carry real behavior tradeoffs. That is too much unrelated motion for one useful review.

This first slice is deliberately boring. Index and counting loops now use modern range syntax, and four range-variable shadows left over from the pre-1.22 loop semantics are gone. Both transformations came directly from the `rangeint` and `forvar` analyzers, with no generated files or hand-written changes mixed in.

The remaining fixers stay separate so standard-library rewrites, stylistic `any` conversions, and changes involving serialization, context lifetime, or concurrency each get an appropriate review boundary.

Follows #1020, which established the Go 1.26 idiom baseline.