### PR TITLE
Add `miren debug saga` for listing and inspecting executions

### DIFF
--- a/blackbox/debug_saga_test.go
+++ b/blackbox/debug_saga_test.go
@@ -1,0 +1,28 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"testing"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+// TestDebugSagaShowUnknownID checks that `debug saga` is wired up and fails
+// cleanly on a miss. It deliberately does not provision anything: producing a
+// real saga means a full app build plus an addon provision, and what that would
+// verify beyond this is already covered by the decode and index tests in
+// cli/commands. If real-record coverage is wanted later, the cheap place to put
+// it is TestAddonCreateListDestroy, which already runs a provisioning saga.
+func TestDebugSagaShowUnknownID(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	r := m.Run("debug", "saga", "show", "sg-DoesNotExist")
+	if r.Success() {
+		t.Fatalf("expected failure for an unknown saga, got exit 0:\n%s", r.Stdout)
+	}
+	if !r.OutputContains("not found") {
+		t.Errorf("expected a not-found message, got:\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+	}
+}

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -1058,6 +1058,15 @@ Warning: These commands are intended for advanced users and developers. They may
 	d.Dispatch("debug disk lease-status", Infer("debug disk lease-status", "Show detailed status of a disk lease", DebugDiskLeaseStatus))
 	d.Dispatch("debug disk mounts", Infer("debug disk mounts", "List all mounted disks from /proc/mounts", DebugDiskMounts))
 
+	// Debug saga commands
+	d.Dispatch("debug saga", Section("debug saga", "Saga execution debug commands", "", WithSectionDescription(sagaSectionDescription)))
+	d.Dispatch("debug saga list", Infer("debug saga list", "List saga executions", DebugSagaList,
+		WithDescription(sagaListDescription),
+	))
+	d.Dispatch("debug saga show", Infer("debug saga show", "Show a saga execution in detail", DebugSagaShow,
+		WithDescription(sagaShowDescription),
+	))
+
 	// Debug netdb commands
 	d.Dispatch("debug netdb", Section("debug netdb", "Network database debug commands", ""))
 	d.Dispatch("debug netdb list", Infer("debug netdb list", "List all IP leases from netdb", DebugNetDBList))

--- a/cli/commands/debug_saga.go
+++ b/cli/commands/debug_saga.go
@@ -1,0 +1,601 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	saga_v1alpha "miren.dev/runtime/api/saga/saga_v1alpha"
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/saga"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// sagaOutputPreview is how much of an action's output we show before
+// truncating. Wide enough to recognize what came back, short enough that a
+// twenty-action saga still fits on a screen. Use --full to see all of it.
+const sagaOutputPreview = 100
+
+// sagaIDNamespace is the kind prefix execution IDs carry. Listings print IDs
+// without it, the way sandbox and app IDs are shown, and lookups put it back.
+const sagaIDNamespace = "saga/"
+
+// activeSagaStatuses are the non-terminal statuses. These are what `debug saga
+// list` shows by default: a completed saga is history, but a saga sitting in
+// one of these is either working or wedged, which is the thing you opened a
+// debug command to find out.
+var activeSagaStatuses = []saga.Status{
+	saga.StatusPending,
+	saga.StatusRunning,
+	saga.StatusUndoing,
+}
+
+// sagaRecord pairs a decoded execution with the entity store's own timestamps.
+// The saga schema does not persist Execution.CreatedAt/UpdatedAt, but the
+// entity store records when it created and last wrote each entity, and for a
+// saga those are the same events: it is written once per action. A running
+// saga whose entity has not been updated in an hour is the stuck one.
+type sagaRecord struct {
+	exec      *saga.Execution
+	createdAt time.Time
+	updatedAt time.Time
+}
+
+// lastAction returns the most recently executed action name, or "" if the saga
+// has not run anything yet.
+func (r *sagaRecord) lastAction() string {
+	if len(r.exec.ExecutionOrder) == 0 {
+		return ""
+	}
+	return r.exec.ExecutionOrder[len(r.exec.ExecutionOrder)-1]
+}
+
+func DebugSagaList(ctx *Context, opts struct {
+	FormatOptions
+	ConfigCentric
+	Status     string `short:"s" long:"status" description:"Filter by status (pending, running, undoing, completed, failed)"`
+	Definition string `short:"d" long:"definition" description:"Filter by saga definition name"`
+	All        bool   `short:"A" long:"all" description:"Include completed and failed sagas"`
+}) error {
+	var wantStatus saga.Status
+	if opts.Status != "" {
+		var err error
+		wantStatus, err = parseSagaStatus(opts.Status)
+		if err != nil {
+			return err
+		}
+	}
+
+	eac, err := sagaClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Pick the narrowest index the server can answer directly. definition_name
+	// and status are both indexed; when both filters are given we query by
+	// definition and narrow by status below, since a definition name is far
+	// more selective than a status.
+	var indexes []entity.Attr
+	switch {
+	case opts.Definition != "":
+		indexes = append(indexes, entity.String(saga_v1alpha.SagaDefinitionNameId, opts.Definition))
+	case wantStatus != "":
+		attr, err := sagaStatusIndex(wantStatus)
+		if err != nil {
+			return err
+		}
+		indexes = append(indexes, attr)
+	case opts.All:
+		res, err := eac.LookupKind(ctx, "saga")
+		if err != nil {
+			return fmt.Errorf("looking up saga kind: %w", err)
+		}
+		indexes = append(indexes, res.Attr())
+	default:
+		for _, s := range activeSagaStatuses {
+			attr, err := sagaStatusIndex(s)
+			if err != nil {
+				return err
+			}
+			indexes = append(indexes, attr)
+		}
+	}
+
+	records, err := listSagas(ctx, eac, indexes)
+	if err != nil {
+		return err
+	}
+
+	// Filtering to active statuses applies when the user asked for neither a
+	// specific status nor --all. Note that --definition does not opt out: a
+	// definition whose sagas have all completed still lists empty by default.
+	// The empty-state message below keys off this same variable rather than
+	// restating the condition, since the two drifting apart is what silently
+	// suppressed the --all hint in exactly the case that needed it.
+	filterActive := !opts.All && wantStatus == ""
+
+	// Apply whatever the index could not.
+	records = slices.DeleteFunc(records, func(r *sagaRecord) bool {
+		switch {
+		case wantStatus != "":
+			return r.exec.Status != wantStatus
+		case filterActive:
+			return !slices.Contains(activeSagaStatuses, r.exec.Status)
+		default:
+			return false
+		}
+	})
+
+	// Most recent activity first.
+	sort.SliceStable(records, func(i, j int) bool {
+		return records[i].updatedAt.After(records[j].updatedAt)
+	})
+
+	if opts.IsJSON() {
+		items := make([]sagaListJSON, 0, len(records))
+		for _, r := range records {
+			items = append(items, newSagaListJSON(r))
+		}
+		return PrintJSON(items)
+	}
+
+	if len(records) == 0 {
+		if filterActive {
+			ctx.Printf("No active sagas found (use --all to include completed and failed)\n")
+		} else {
+			ctx.Printf("No sagas found\n")
+		}
+		return nil
+	}
+
+	headers := []string{"ID", "DEFINITION", "STATUS", "ACTIONS", "LAST ACTION", "CREATED", "UPDATED"}
+	rows := make([]ui.Row, 0, len(records))
+
+	for _, r := range records {
+		lastAction := r.lastAction()
+		if lastAction == "" {
+			lastAction = "-"
+		}
+
+		rows = append(rows, ui.Row{
+			ui.CleanEntityID(r.exec.ID),
+			r.exec.DefinitionName,
+			string(r.exec.Status),
+			fmt.Sprintf("%d", len(r.exec.ExecutionOrder)),
+			lastAction,
+			humanFriendlyTimestamp(r.createdAt),
+			humanFriendlyTimestamp(r.updatedAt),
+		})
+	}
+
+	columns := ui.AutoSizeColumns(headers, rows, ui.Columns().NoTruncate(0, 2))
+	table := ui.NewTable(
+		ui.WithColumns(columns),
+		ui.WithRows(rows),
+	)
+
+	ctx.Printf("%s\n", table.Render())
+	if len(records) == 1 {
+		ctx.Info("Total: 1 saga")
+	} else {
+		ctx.Info("Total: %d sagas", len(records))
+	}
+
+	return nil
+}
+
+func DebugSagaShow(ctx *Context, opts struct {
+	FormatOptions
+	ConfigCentric
+	Id   string `short:"i" long:"id" description:"Saga execution ID"`
+	Full bool   `long:"full" description:"Print complete action outputs instead of truncating them (JSON always includes them)"`
+
+	Args []string `rest:"true"`
+}) error {
+	id := opts.Id
+	if id == "" {
+		if len(opts.Args) == 0 {
+			return fmt.Errorf("saga execution ID is required (pass as first positional arg or via --id)")
+		}
+		id = opts.Args[0]
+	}
+
+	eac, err := sagaClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	res, err := getSaga(ctx, eac, id)
+	if err != nil {
+		return err
+	}
+
+	record, err := decodeSagaRecord(res)
+	if err != nil {
+		return err
+	}
+
+	// Nested sagas record their parent, and that attribute is indexed, so the
+	// children of this execution are one query away. The ref value is hoisted
+	// into its own variable because the guardrail in guardrails/refenum_test.go
+	// flags entity.Id(…) sitting directly in an entity.Ref, which is how the
+	// short-enum-value bug in MIR-1288 looks. This is a real execution ID, not
+	// an enum value.
+	parentID := entity.Id(record.exec.ID)
+	children, err := listSagas(ctx, eac, []entity.Attr{
+		entity.Ref(saga_v1alpha.SagaParentExecutionIdId, parentID),
+	})
+	if err != nil {
+		return fmt.Errorf("listing child sagas: %w", err)
+	}
+	sort.SliceStable(children, func(i, j int) bool {
+		return children[i].createdAt.Before(children[j].createdAt)
+	})
+
+	if opts.IsJSON() {
+		return PrintJSON(newSagaShowJSON(record, children))
+	}
+
+	printSagaShow(ctx, record, children, opts.Full)
+	return nil
+}
+
+func printSagaShow(ctx *Context, r *sagaRecord, children []*sagaRecord, full bool) {
+	exec := r.exec
+
+	ctx.Printf("ID:         %s\n", ui.CleanEntityID(exec.ID))
+	ctx.Printf("Definition: %s (v%d)\n", exec.DefinitionName, exec.DefinitionVersion)
+	ctx.Printf("Status:     %s\n", exec.Status)
+	if exec.ParentExecutionID != "" {
+		ctx.Printf("Parent:     %s\n", ui.CleanEntityID(exec.ParentExecutionID))
+	}
+	ctx.Printf("Created:    %s\n", sagaTimestamp(r.createdAt))
+	ctx.Printf("Updated:    %s\n", sagaTimestamp(r.updatedAt))
+	if exec.Error != "" {
+		ctx.Printf("Error:      %s\n", exec.Error)
+	}
+
+	if len(exec.InitialInputs) > 0 {
+		ctx.Printf("\nInitial inputs:\n")
+		for _, key := range slices.Sorted(maps.Keys(exec.InitialInputs)) {
+			ctx.Printf("  %s: %s\n", key, formatSagaValue(exec.InitialInputs[key], full, 2))
+		}
+	}
+
+	order := sagaActionOrder(exec)
+	if len(order) == 0 {
+		ctx.Printf("\nActions: none executed yet\n")
+	} else {
+		ctx.Printf("\nActions (%d executed):\n", len(order))
+		for i, name := range order {
+			result := exec.ExecutedActions[name]
+			ctx.Printf("  %d. %-30s %s\n", i+1, name, sagaActionSummary(result))
+			if result == nil {
+				continue
+			}
+			if result.Error != "" {
+				ctx.Printf("     error: %s\n", result.Error)
+			}
+			if len(result.Output) > 0 {
+				ctx.Printf("     output: %s\n", formatSagaJSON(result.Output, full, 5))
+			}
+		}
+	}
+
+	if len(children) > 0 {
+		ctx.Printf("\nChild sagas (%d):\n", len(children))
+		for _, c := range children {
+			ctx.Printf("  %s  %s  %s\n", ui.CleanEntityID(c.exec.ID), c.exec.DefinitionName, c.exec.Status)
+		}
+	}
+}
+
+// sagaActionOrder returns the action names to display, in execution order. The
+// executor appends to ExecutionOrder every time it records a result, so the two
+// should agree, but this is a debug command: if a record somehow holds a result
+// that never made it into the order, show it rather than hide it.
+func sagaActionOrder(exec *saga.Execution) []string {
+	order := slices.Clone(exec.ExecutionOrder)
+	for _, name := range slices.Sorted(maps.Keys(exec.ExecutedActions)) {
+		if !slices.Contains(order, name) {
+			order = append(order, name)
+		}
+	}
+	return order
+}
+
+// sagaActionSummary describes what happened to a single action in one line.
+func sagaActionSummary(result *saga.ActionResult) string {
+	if result == nil {
+		return "no result recorded"
+	}
+
+	var summary string
+	switch {
+	case result.Error != "":
+		summary = fmt.Sprintf("failed %s", humanFriendlyTimestamp(result.ExecutedAt))
+	default:
+		summary = fmt.Sprintf("executed %s", humanFriendlyTimestamp(result.ExecutedAt))
+	}
+
+	if result.UndoneAt != nil {
+		summary += fmt.Sprintf(", undone %s", humanFriendlyTimestamp(*result.UndoneAt))
+	}
+
+	return summary
+}
+
+func sagaTimestamp(t time.Time) string {
+	if t.IsZero() || t.Unix() <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%s (%s)", t.Format(time.RFC3339), humanFriendlyTimestamp(t))
+}
+
+// formatSagaJSON renders raw JSON for display: compacted onto one line and
+// truncated by default, pretty-printed and indented when full is set.
+func formatSagaJSON(raw []byte, full bool, indent int) string {
+	if len(raw) == 0 {
+		return "-"
+	}
+
+	if full {
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, raw, strings.Repeat(" ", indent), "  "); err != nil {
+			return string(raw)
+		}
+		return pretty.String()
+	}
+
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err != nil {
+		return truncateSagaValue(string(raw))
+	}
+	return truncateSagaValue(compact.String())
+}
+
+// formatSagaValue renders an already-decoded value (an initial input) the same
+// way formatSagaJSON renders raw action output.
+func formatSagaValue(v any, full bool, indent int) string {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return formatSagaJSON(raw, full, indent)
+}
+
+func truncateSagaValue(s string) string {
+	if len(s) <= sagaOutputPreview {
+		return s
+	}
+	return s[:sagaOutputPreview] + "… (--full for the rest)"
+}
+
+// parseSagaStatus maps a user-supplied status name onto a saga.Status.
+func parseSagaStatus(s string) (saga.Status, error) {
+	known := []saga.Status{
+		saga.StatusPending,
+		saga.StatusRunning,
+		saga.StatusUndoing,
+		saga.StatusCompleted,
+		saga.StatusFailed,
+	}
+
+	normalized := strings.ToLower(strings.TrimSpace(s))
+	for _, k := range known {
+		if string(k) == normalized {
+			return k, nil
+		}
+	}
+
+	names := make([]string, len(known))
+	for i, k := range known {
+		names[i] = string(k)
+	}
+	return "", fmt.Errorf("unknown saga status %q (expected one of: %s)", s, strings.Join(names, ", "))
+}
+
+// sagaStatusIndex builds the index attribute for querying sagas by status.
+func sagaStatusIndex(s saga.Status) (entity.Attr, error) {
+	attr, ok := saga.StatusIndexAttr(s)
+	if !ok {
+		return attr, fmt.Errorf("no index for saga status %q", s)
+	}
+	return attr, nil
+}
+
+// sagaIDCandidates expands what the user typed into the IDs worth trying, in
+// order. Execution IDs are kind-namespaced (saga/sg-…) but listings print them
+// without the namespace, so the bare name a user copies off the table has to
+// resolve too. The unqualified form is also what sagas minted before IDs grew
+// their namespace look like, so it stays a valid thing to type.
+func sagaIDCandidates(id string) []string {
+	if strings.Contains(id, "/") {
+		return []string{id}
+	}
+	return []string{sagaIDNamespace + id, id}
+}
+
+// getSaga resolves an execution by any of the forms its ID can take.
+func getSaga(ctx *Context, eac *entityserver_v1alpha.EntityAccessClient, id string) (*entityserver_v1alpha.Entity, error) {
+	for _, candidate := range sagaIDCandidates(id) {
+		res, err := eac.Get(ctx, candidate)
+		if err == nil {
+			return res.Entity(), nil
+		}
+		if !errors.Is(err, cond.ErrNotFound{}) {
+			return nil, fmt.Errorf("getting saga %s: %w", candidate, err)
+		}
+	}
+
+	return nil, fmt.Errorf("saga %s not found", id)
+}
+
+func sagaClient(ctx *Context) (*entityserver_v1alpha.EntityAccessClient, error) {
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return nil, err
+	}
+	return entityserver_v1alpha.NewEntityAccessClient(client), nil
+}
+
+// listSagas queries each index and returns the decoded executions, deduplicated
+// by ID. A saga can appear under more than one index at once (a stale pending
+// entry lingering after the transition to running), so the caller would
+// otherwise see the same execution twice.
+func listSagas(ctx *Context, eac *entityserver_v1alpha.EntityAccessClient, indexes []entity.Attr) ([]*sagaRecord, error) {
+	var records []*sagaRecord
+	seen := make(map[string]struct{})
+
+	for _, index := range indexes {
+		res, err := eac.List(ctx, index)
+		if err != nil {
+			return nil, fmt.Errorf("listing sagas: %w", err)
+		}
+
+		for _, e := range res.Values() {
+			if _, dup := seen[e.Id()]; dup {
+				continue
+			}
+			seen[e.Id()] = struct{}{}
+
+			record, err := decodeSagaRecord(e)
+			if err != nil {
+				// One unreadable record should not blank the whole listing.
+				ctx.Warn("skipping saga %s: %s", e.Id(), err)
+				continue
+			}
+			records = append(records, record)
+		}
+	}
+
+	return records, nil
+}
+
+func decodeSagaRecord(e *entityserver_v1alpha.Entity) (*sagaRecord, error) {
+	ent := e.Entity()
+
+	sagaEntity, ok := entity.As[saga_v1alpha.Saga](ent)
+	if !ok {
+		return nil, fmt.Errorf("entity %s is not a saga", e.Id())
+	}
+
+	exec, err := saga.ExecutionFromEntity(sagaEntity)
+	if err != nil {
+		return nil, fmt.Errorf("decoding saga %s: %w", e.Id(), err)
+	}
+
+	return &sagaRecord{
+		exec:      exec,
+		createdAt: time.UnixMilli(e.CreatedAt()),
+		updatedAt: time.UnixMilli(e.UpdatedAt()),
+	}, nil
+}
+
+type sagaListJSON struct {
+	ID                string `json:"id"`
+	DefinitionName    string `json:"definition_name"`
+	DefinitionVersion int    `json:"definition_version"`
+	Status            string `json:"status"`
+	ActionCount       int    `json:"action_count"`
+	LastAction        string `json:"last_action,omitempty"`
+	ParentExecutionID string `json:"parent_execution_id,omitempty"`
+	Error             string `json:"error,omitempty"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+}
+
+// IDs stay fully qualified in JSON. Table output drops the namespace because a
+// human is reading it, but a machine-readable ID should be the one the entity
+// store actually holds.
+func newSagaListJSON(r *sagaRecord) sagaListJSON {
+	return sagaListJSON{
+		ID:                r.exec.ID,
+		DefinitionName:    r.exec.DefinitionName,
+		DefinitionVersion: r.exec.DefinitionVersion,
+		Status:            string(r.exec.Status),
+		ActionCount:       len(r.exec.ExecutionOrder),
+		LastAction:        r.lastAction(),
+		ParentExecutionID: r.exec.ParentExecutionID,
+		Error:             r.exec.Error,
+		CreatedAt:         sagaJSONTime(r.createdAt),
+		UpdatedAt:         sagaJSONTime(r.updatedAt),
+	}
+}
+
+type sagaActionJSON struct {
+	Name       string          `json:"name"`
+	Order      int             `json:"order"`
+	ExecutedAt string          `json:"executed_at,omitempty"`
+	UndoneAt   string          `json:"undone_at,omitempty"`
+	Error      string          `json:"error,omitempty"`
+	Output     json.RawMessage `json:"output,omitempty"`
+}
+
+type sagaChildJSON struct {
+	ID             string `json:"id"`
+	DefinitionName string `json:"definition_name"`
+	Status         string `json:"status"`
+}
+
+type sagaShowJSON struct {
+	sagaListJSON
+	InitialInputs map[string]any   `json:"initial_inputs,omitempty"`
+	Actions       []sagaActionJSON `json:"actions"`
+	Children      []sagaChildJSON  `json:"children,omitempty"`
+}
+
+// JSON carries the whole record. Truncating output would produce invalid JSON,
+// and emitting it only under --full made the default a silently partial record
+// with nothing marking the omission, while initial_inputs went out whole
+// regardless. Size is the human reader's problem, so --full stays a text-mode
+// concern and machine output is always complete.
+func newSagaShowJSON(r *sagaRecord, children []*sagaRecord) sagaShowJSON {
+	out := sagaShowJSON{
+		sagaListJSON:  newSagaListJSON(r),
+		InitialInputs: r.exec.InitialInputs,
+		Actions:       []sagaActionJSON{},
+	}
+
+	for i, name := range sagaActionOrder(r.exec) {
+		action := sagaActionJSON{Name: name, Order: i + 1}
+
+		if result := r.exec.ExecutedActions[name]; result != nil {
+			action.ExecutedAt = sagaJSONTime(result.ExecutedAt)
+			if result.UndoneAt != nil {
+				action.UndoneAt = sagaJSONTime(*result.UndoneAt)
+			}
+			action.Error = result.Error
+			if len(result.Output) > 0 {
+				action.Output = json.RawMessage(result.Output)
+			}
+		}
+
+		out.Actions = append(out.Actions, action)
+	}
+
+	for _, c := range children {
+		out.Children = append(out.Children, sagaChildJSON{
+			ID:             c.exec.ID,
+			DefinitionName: c.exec.DefinitionName,
+			Status:         string(c.exec.Status),
+		})
+	}
+
+	return out
+}
+
+func sagaJSONTime(t time.Time) string {
+	if t.IsZero() || t.Unix() <= 0 {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}

--- a/cli/commands/debug_saga_doc.go
+++ b/cli/commands/debug_saga_doc.go
@@ -1,0 +1,30 @@
+package commands
+
+const sagaSectionDescription = `Sagas are Miren's mechanism for multi-step operations that have to either finish or unwind cleanly, like provisioning an addon or building and deploying an app. Each saga execution records what it ran, in what order, and what each action returned, so a saga that wedges leaves behind a trail you can read.
+
+These commands read that trail. The underlying records are also visible through ` + "`" + `miren debug entity list -k saga` + "`" + `, but the interesting fields are stored as JSON blobs, so that view shows you base64 rather than what happened.`
+
+const sagaListDescription = `By default this lists only active sagas, meaning the ones that are pending, running, or undoing. Completed sagas accumulate and are rarely what you are looking for when something is wedged. Pass ` + "`" + `--all` + "`" + ` to include them, or ` + "`" + `--status` + "`" + ` to ask for one specific status.
+
+The UPDATED column is the useful one for finding a stuck saga: the record is written after every action, so a saga that has been running for an hour without an update has stopped making progress.
+
+` + "```" + `bash
+miren debug saga list
+miren debug saga list --status failed
+miren debug saga list --definition provision_mysql_dedicated --all
+miren debug saga list --format json
+` + "```" + ``
+
+const sagaShowDescription = `Shows one saga execution in full: its status, its initial inputs, and every action it ran with timing, undo state, and output.
+
+:::note[Output details]
+Action outputs are truncated by default so a long saga stays readable. Pass ` + "`" + `--full` + "`" + ` to print them whole. ` + "`" + `--format json` + "`" + ` always carries them in full, since a partial record is worse than a large one for anything parsing it.
+
+Where a saga stopped is the last action listed. This shows the actions that ran, not the complete set the definition declares, since the saga definitions live in the server process and are not exposed over the API.
+:::
+
+` + "```" + `bash
+miren debug saga show saga/sg-4TzP9hQ2mKdX8vNfR3wLbY
+miren debug saga show saga/sg-4TzP9hQ2mKdX8vNfR3wLbY --full
+miren debug saga show saga/sg-4TzP9hQ2mKdX8vNfR3wLbY --format json
+` + "```" + ``

--- a/cli/commands/debug_saga_index_test.go
+++ b/cli/commands/debug_saga_index_test.go
@@ -1,0 +1,118 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	saga_v1alpha "miren.dev/runtime/api/saga/saga_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// TestListSagasAgainstEntityServer runs the queries `debug saga list` builds
+// against a real entity server holding sagas written by the real storage layer.
+// The unit tests above cover decoding and rendering; what they cannot tell us is
+// whether the definition_name and status index lookups actually resolve, which
+// is the part that decides whether the command returns anything at all.
+func TestListSagasAgainstEntityServer(t *testing.T) {
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	ctx := &Context{Context: context.Background(), Stdout: &bytes.Buffer{}}
+	storage := saga.NewEntityStorage(inmem.Store, testutils.TestLogger(t))
+
+	executions := []*saga.Execution{
+		{ID: "saga/sg-A1", DefinitionName: "provision-shared-postgresql", Status: saga.StatusRunning},
+		{ID: "saga/sg-B1", DefinitionName: "provision-shared-postgresql", Status: saga.StatusCompleted},
+		{ID: "saga/sg-C1", DefinitionName: "build-and-deploy", Status: saga.StatusFailed},
+		{ID: "saga/sg-D1", DefinitionName: "build-and-deploy", Status: saga.StatusRunning},
+	}
+	for _, exec := range executions {
+		require.NoError(t, storage.Save(ctx, exec))
+	}
+
+	ids := func(records []*sagaRecord) []string {
+		out := make([]string, 0, len(records))
+		for _, r := range records {
+			out = append(out, r.exec.ID)
+		}
+		return out
+	}
+
+	t.Run("by definition name", func(t *testing.T) {
+		records, err := listSagas(ctx, inmem.EAC, []entity.Attr{
+			entity.String(saga_v1alpha.SagaDefinitionNameId, "build-and-deploy"),
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"saga/sg-C1", "saga/sg-D1"}, ids(records))
+	})
+
+	t.Run("timestamps come from the store, not the saga record", func(t *testing.T) {
+		attr, err := sagaStatusIndex(saga.StatusRunning)
+		require.NoError(t, err)
+
+		records, err := listSagas(ctx, inmem.EAC, []entity.Attr{attr})
+		require.NoError(t, err)
+		require.NotEmpty(t, records)
+
+		// The saga schema has no timestamp fields, so the UPDATED column is
+		// only meaningful if the store stamps the entity itself.
+		//
+		// createdAt is not asserted, and the omission is deliberate: it passes
+		// here and fails against a real server. Saga storage saves by full
+		// replace, MockStore's replace carries db/entity.created forward and
+		// EtcdStore's does not, so asserting it here would claim coverage this
+		// harness cannot give. Verified by hand against a dev server; the
+		// MIR-1526 retention work is fixing the underlying loss.
+		for _, r := range records {
+			assert.False(t, r.updatedAt.IsZero(), "%s has no updated timestamp", r.exec.ID)
+		}
+	})
+
+	t.Run("by status", func(t *testing.T) {
+		attr, err := sagaStatusIndex(saga.StatusFailed)
+		require.NoError(t, err)
+
+		records, err := listSagas(ctx, inmem.EAC, []entity.Attr{attr})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"saga/sg-C1"}, ids(records))
+	})
+
+	t.Run("active statuses, deduplicated across indexes", func(t *testing.T) {
+		var indexes []entity.Attr
+		for _, s := range activeSagaStatuses {
+			attr, err := sagaStatusIndex(s)
+			require.NoError(t, err)
+			indexes = append(indexes, attr)
+		}
+
+		records, err := listSagas(ctx, inmem.EAC, indexes)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"saga/sg-A1", "saga/sg-D1"}, ids(records))
+	})
+
+	t.Run("by parent, for the children of a nested saga", func(t *testing.T) {
+		require.NoError(t, storage.Save(ctx, &saga.Execution{
+			ID:                "saga/sg-Child1",
+			DefinitionName:    "format-disk",
+			Status:            saga.StatusCompleted,
+			ParentExecutionID: "saga/sg-A1",
+		}))
+
+		records, err := listSagas(ctx, inmem.EAC, []entity.Attr{
+			entity.Ref(saga_v1alpha.SagaParentExecutionIdId, entity.Id("saga/sg-A1")),
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"saga/sg-Child1"}, ids(records))
+	})
+
+	// The --all path queries the kind index instead, and that is not covered
+	// here: LookupKind resolves against schema entities the in-memory harness
+	// does not seed, so it fails for every kind, not just saga. It was verified
+	// by hand against a dev server.
+}

--- a/cli/commands/debug_saga_test.go
+++ b/cli/commands/debug_saga_test.go
@@ -1,0 +1,338 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	es "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	saga_v1alpha "miren.dev/runtime/api/saga/saga_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/saga"
+)
+
+// sagaEntityFor encodes an execution into the RPC entity the entity server
+// would hand back, taking the same path EntityStorage.Save does so the test
+// exercises the real round trip rather than a hand-built approximation.
+func sagaEntityFor(t *testing.T, exec *saga.Execution, createdAt, updatedAt time.Time) *es.Entity {
+	t.Helper()
+
+	initialInputs, err := json.Marshal(exec.InitialInputs)
+	require.NoError(t, err)
+	executedActions, err := json.Marshal(exec.ExecutedActions)
+	require.NoError(t, err)
+	executionOrder, err := json.Marshal(exec.ExecutionOrder)
+	require.NoError(t, err)
+
+	status, ok := sagaStatusEnum(exec.Status)
+	require.True(t, ok, "unknown status %q", exec.Status)
+
+	sagaEntity := &saga_v1alpha.Saga{
+		ID:                entity.Id(exec.ID),
+		DefinitionName:    exec.DefinitionName,
+		DefinitionVersion: int64(exec.DefinitionVersion),
+		ParentExecutionId: entity.Id(exec.ParentExecutionID),
+		Status:            status,
+		InitialInputs:     initialInputs,
+		ExecutedActions:   executedActions,
+		ExecutionOrder:    executionOrder,
+		Error:             exec.Error,
+	}
+
+	ent := entity.New(entity.DBId, entity.Id(exec.ID), sagaEntity.Encode())
+
+	e := &es.Entity{}
+	e.SetId(exec.ID)
+	e.SetAttrs(ent.Attrs())
+	e.SetCreatedAt(createdAt.UnixMilli())
+	e.SetUpdatedAt(updatedAt.UnixMilli())
+
+	return e
+}
+
+func sagaStatusEnum(s saga.Status) (saga_v1alpha.SagaStatus, bool) {
+	switch s {
+	case saga.StatusPending:
+		return saga_v1alpha.PENDING, true
+	case saga.StatusRunning:
+		return saga_v1alpha.RUNNING, true
+	case saga.StatusUndoing:
+		return saga_v1alpha.UNDOING, true
+	case saga.StatusCompleted:
+		return saga_v1alpha.COMPLETED, true
+	case saga.StatusFailed:
+		return saga_v1alpha.FAILED, true
+	}
+	return "", false
+}
+
+// wedgedSaga is the case these commands exist for: a saga that ran two actions
+// and then stopped, still claiming to be running hours later.
+func wedgedSaga() *saga.Execution {
+	executedAt := time.Now().Add(-3 * time.Hour)
+	undoneAt := executedAt.Add(time.Minute)
+
+	return &saga.Execution{
+		ID:                "saga/sg-Wedged1",
+		DefinitionName:    "provision_mysql_dedicated",
+		DefinitionVersion: 2,
+		Status:            saga.StatusRunning,
+		InitialInputs: map[string]any{
+			"app_id": "app/checkout",
+			"size":   float64(20),
+		},
+		ExecutionOrder: []string{"create_disk", "attach_disk"},
+		ExecutedActions: map[string]*saga.ActionResult{
+			"create_disk": {
+				Output:     []byte(`{"disk_id":"disk-abc","size_gb":20}`),
+				ExecutedAt: executedAt,
+			},
+			"attach_disk": {
+				ExecutedAt: executedAt.Add(30 * time.Second),
+				UndoneAt:   &undoneAt,
+				Error:      "sandbox not ready",
+			},
+		},
+	}
+}
+
+func TestDecodeSagaRecordRoundTrip(t *testing.T) {
+	exec := wedgedSaga()
+	created := time.Now().Add(-3 * time.Hour).Truncate(time.Millisecond)
+	updated := time.Now().Add(-2 * time.Hour).Truncate(time.Millisecond)
+
+	record, err := decodeSagaRecord(sagaEntityFor(t, exec, created, updated))
+	require.NoError(t, err)
+
+	assert.Equal(t, exec.ID, record.exec.ID)
+	assert.Equal(t, "provision_mysql_dedicated", record.exec.DefinitionName)
+	assert.Equal(t, 2, record.exec.DefinitionVersion)
+	assert.Equal(t, saga.StatusRunning, record.exec.Status)
+	assert.Equal(t, []string{"create_disk", "attach_disk"}, record.exec.ExecutionOrder)
+	assert.Equal(t, "attach_disk", record.lastAction())
+	assert.Equal(t, "app/checkout", record.exec.InitialInputs["app_id"])
+
+	// The saga schema does not persist Execution.CreatedAt/UpdatedAt, so these
+	// have to come from the entity store's own metadata. This is what makes the
+	// UPDATED column meaningful.
+	assert.True(t, created.Equal(record.createdAt), "created %v != %v", created, record.createdAt)
+	assert.True(t, updated.Equal(record.updatedAt), "updated %v != %v", updated, record.updatedAt)
+
+	result := record.exec.ExecutedActions["attach_disk"]
+	require.NotNil(t, result)
+	assert.Equal(t, "sandbox not ready", result.Error)
+	require.NotNil(t, result.UndoneAt)
+}
+
+func TestDecodeSagaRecordRejectsNonSaga(t *testing.T) {
+	ent := entity.New(entity.DBId, entity.Id("app/checkout"))
+
+	e := &es.Entity{}
+	e.SetId("app/checkout")
+	e.SetAttrs(ent.Attrs())
+
+	_, err := decodeSagaRecord(e)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a saga")
+}
+
+func TestPrintSagaShow(t *testing.T) {
+	record, err := decodeSagaRecord(sagaEntityFor(t, wedgedSaga(),
+		time.Now().Add(-3*time.Hour), time.Now().Add(-2*time.Hour)))
+	require.NoError(t, err)
+
+	child, err := decodeSagaRecord(sagaEntityFor(t, &saga.Execution{
+		ID:                "saga/sg-Child1",
+		DefinitionName:    "format_disk",
+		Status:            saga.StatusCompleted,
+		ParentExecutionID: "saga/sg-Wedged1",
+	}, time.Now(), time.Now()))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	ctx := &Context{Stdout: &buf}
+	printSagaShow(ctx, record, []*sagaRecord{child}, false)
+	out := buf.String()
+
+	// The table and header drop the kind namespace; lookups put it back.
+	assert.Contains(t, out, "sg-Wedged1")
+	assert.NotContains(t, out, "saga/sg-Wedged1")
+	assert.Contains(t, out, "provision_mysql_dedicated (v2)")
+	assert.Contains(t, out, "running")
+	assert.Contains(t, out, "app_id")
+
+	// Both actions, in execution order, with their outcomes.
+	assert.Contains(t, out, "1. create_disk")
+	assert.Contains(t, out, "2. attach_disk")
+	assert.Contains(t, out, "disk-abc")
+	assert.Contains(t, out, "error: sandbox not ready")
+	assert.Contains(t, out, "undone")
+
+	assert.Contains(t, out, "sg-Child1")
+	assert.Contains(t, out, "format_disk")
+
+	assert.Less(t, strings.Index(out, "create_disk"), strings.Index(out, "attach_disk"))
+}
+
+func TestPrintSagaShowNoActions(t *testing.T) {
+	record, err := decodeSagaRecord(sagaEntityFor(t, &saga.Execution{
+		ID:             "saga/sg-Fresh1",
+		DefinitionName: "build_and_deploy",
+		Status:         saga.StatusPending,
+	}, time.Now(), time.Now()))
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	ctx := &Context{Stdout: &buf}
+	printSagaShow(ctx, record, nil, false)
+
+	assert.Contains(t, buf.String(), "Actions: none executed yet")
+}
+
+func TestSagaActionOrderIncludesResultsMissingFromOrder(t *testing.T) {
+	exec := &saga.Execution{
+		ExecutionOrder: []string{"first"},
+		ExecutedActions: map[string]*saga.ActionResult{
+			"first":  {},
+			"orphan": {},
+		},
+	}
+
+	// A result the execution order never recorded is a corrupt record, and a
+	// debug command that hid it would hide the evidence.
+	assert.Equal(t, []string{"first", "orphan"}, sagaActionOrder(exec))
+}
+
+func TestFormatSagaJSONTruncates(t *testing.T) {
+	raw := []byte(`{"blob":"` + strings.Repeat("x", 500) + `"}`)
+
+	short := formatSagaJSON(raw, false, 0)
+	assert.Less(t, len(short), 200)
+	assert.Contains(t, short, "--full")
+	assert.NotContains(t, short, "\n")
+
+	full := formatSagaJSON(raw, true, 0)
+	assert.Contains(t, full, strings.Repeat("x", 500))
+
+	assert.Equal(t, "-", formatSagaJSON(nil, false, 0))
+}
+
+func TestFormatSagaJSONPassesThroughInvalidJSON(t *testing.T) {
+	// Outputs are written by json.Marshal so this should not happen, but a
+	// debug command should show whatever is actually stored.
+	assert.Equal(t, "not json", formatSagaJSON([]byte("not json"), false, 0))
+}
+
+func TestParseSagaStatus(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want saga.Status
+	}{
+		{"running", saga.StatusRunning},
+		{"FAILED", saga.StatusFailed},
+		{"  undoing  ", saga.StatusUndoing},
+	} {
+		got, err := parseSagaStatus(tc.in)
+		require.NoError(t, err, tc.in)
+		assert.Equal(t, tc.want, got)
+	}
+
+	_, err := parseSagaStatus("wedged")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown saga status")
+	assert.Contains(t, err.Error(), "undoing")
+}
+
+func TestSagaStatusIndexCoversEveryStatus(t *testing.T) {
+	for _, s := range []saga.Status{
+		saga.StatusPending, saga.StatusRunning, saga.StatusUndoing,
+		saga.StatusCompleted, saga.StatusFailed,
+	} {
+		_, err := sagaStatusIndex(s)
+		require.NoError(t, err, "no index for %s", s)
+	}
+}
+
+func TestSagaShowJSON(t *testing.T) {
+	record, err := decodeSagaRecord(sagaEntityFor(t, wedgedSaga(),
+		time.Now().Add(-3*time.Hour), time.Now().Add(-2*time.Hour)))
+	require.NoError(t, err)
+
+	t.Run("describes every action", func(t *testing.T) {
+		out := newSagaShowJSON(record, nil)
+
+		require.Len(t, out.Actions, 2)
+		assert.Equal(t, "create_disk", out.Actions[0].Name)
+		assert.Equal(t, 1, out.Actions[0].Order)
+		assert.Equal(t, "sandbox not ready", out.Actions[1].Error)
+		assert.NotEmpty(t, out.Actions[1].UndoneAt)
+	})
+
+	t.Run("carries raw output as JSON, not a string", func(t *testing.T) {
+		out := newSagaShowJSON(record, nil)
+
+		encoded, err := json.Marshal(out)
+		require.NoError(t, err)
+		// Embedded as an object rather than an escaped string.
+		assert.Contains(t, string(encoded), `"output":{"disk_id":"disk-abc"`)
+	})
+
+	t.Run("record is whole, with no dependence on --full", func(t *testing.T) {
+		// JSON used to emit initial_inputs unconditionally while withholding
+		// action outputs unless --full, so the default handed a machine a
+		// partial record with nothing marking what was missing. Both halves
+		// go out together now, and nothing about the JSON keys off --full.
+		out := newSagaShowJSON(record, nil)
+
+		assert.NotEmpty(t, out.InitialInputs, "inputs should be present")
+		require.NotEmpty(t, out.Actions)
+		assert.NotEmpty(t, out.Actions[0].Output, "outputs should be present too")
+		assert.True(t, json.Valid(out.Actions[0].Output))
+	})
+
+	t.Run("timestamps are RFC3339", func(t *testing.T) {
+		out := newSagaShowJSON(record, nil)
+
+		_, err := time.Parse(time.RFC3339, out.CreatedAt)
+		assert.NoError(t, err)
+		_, err = time.Parse(time.RFC3339, out.UpdatedAt)
+		assert.NoError(t, err)
+		_, err = time.Parse(time.RFC3339, out.Actions[0].ExecutedAt)
+		assert.NoError(t, err)
+	})
+}
+
+func TestSagaListJSONReportsProgress(t *testing.T) {
+	record, err := decodeSagaRecord(sagaEntityFor(t, wedgedSaga(),
+		time.Now().Add(-3*time.Hour), time.Now().Add(-2*time.Hour)))
+	require.NoError(t, err)
+
+	item := newSagaListJSON(record)
+
+	assert.Equal(t, "saga/sg-Wedged1", item.ID)
+	assert.Equal(t, "running", item.Status)
+	assert.Equal(t, 2, item.ActionCount)
+	assert.Equal(t, "attach_disk", item.LastAction)
+}
+
+func TestSagaIDCandidates(t *testing.T) {
+	// The bare name is what a listing prints, so it has to resolve.
+	assert.Equal(t, []string{"saga/sg-Abc", "sg-Abc"}, sagaIDCandidates("sg-Abc"))
+
+	// A fully qualified ID is taken at face value.
+	assert.Equal(t, []string{"saga/sg-Abc"}, sagaIDCandidates("saga/sg-Abc"))
+
+	// IDs minted before the namespace existed are still typeable, which is why
+	// the unqualified form stays in the candidate list rather than being
+	// rewritten away.
+	assert.Equal(t, []string{"saga/sagaOldStyle", "sagaOldStyle"}, sagaIDCandidates("sagaOldStyle"))
+
+	// Something addressing another kind is passed through, so the error names
+	// what the user actually asked for.
+	assert.Equal(t, []string{"app/checkout"}, sagaIDCandidates("app/checkout"))
+}

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -145,6 +145,9 @@
       "command/debug-rbac",
       "command/debug-rbac-test",
       "command/debug-reindex",
+      "command/debug-saga",
+      "command/debug-saga-list",
+      "command/debug-saga-show",
       "command/debug-test",
       "command/debug-test-load"
     ]

--- a/docs/docs/command/debug-saga-list.md
+++ b/docs/docs/command/debug-saga-list.md
@@ -1,0 +1,46 @@
+---
+title: "miren debug saga list"
+sidebar_label: "debug saga list"
+description: "List saga executions"
+---
+
+# miren debug saga list
+
+List saga executions
+
+By default this lists only active sagas, meaning the ones that are pending, running, or undoing. Completed sagas accumulate and are rarely what you are looking for when something is wedged. Pass `--all` to include them, or `--status` to ask for one specific status.
+
+The UPDATED column is the useful one for finding a stuck saga: the record is written after every action, so a saga that has been running for an hour without an update has stopped making progress.
+
+```bash
+miren debug saga list
+miren debug saga list --status failed
+miren debug saga list --definition provision_mysql_dedicated --all
+miren debug saga list --format json
+```
+
+## Usage
+
+```bash
+miren debug saga list [flags]
+```
+
+## Flags
+
+- `--all, -A` — Include completed and failed sagas
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--definition, -d` — Filter by saga definition name
+- `--format` — Output format (text, json) (default: `text`)
+- `--json` — Shorthand for --format json
+- `--status, -s` — Filter by status (pending, running, undoing, completed, failed)
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## See also
+
+- [`miren debug saga`](/command/debug-saga)

--- a/docs/docs/command/debug-saga-show.md
+++ b/docs/docs/command/debug-saga-show.md
@@ -1,0 +1,48 @@
+---
+title: "miren debug saga show"
+sidebar_label: "debug saga show"
+description: "Show a saga execution in detail"
+---
+
+# miren debug saga show
+
+Show a saga execution in detail
+
+Shows one saga execution in full: its status, its initial inputs, and every action it ran with timing, undo state, and output.
+
+:::note[Output details]
+Action outputs are truncated by default so a long saga stays readable. Pass `--full` to print them whole. `--format json` always carries them in full, since a partial record is worse than a large one for anything parsing it.
+
+Where a saga stopped is the last action listed. This shows the actions that ran, not the complete set the definition declares, since the saga definitions live in the server process and are not exposed over the API.
+:::
+
+```bash
+miren debug saga show saga/sg-4TzP9hQ2mKdX8vNfR3wLbY
+miren debug saga show saga/sg-4TzP9hQ2mKdX8vNfR3wLbY --full
+miren debug saga show saga/sg-4TzP9hQ2mKdX8vNfR3wLbY --format json
+```
+
+## Usage
+
+```bash
+miren debug saga show [args...] [flags]
+```
+
+## Flags
+
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--format` — Output format (text, json) (default: `text`)
+- `--full` — Print complete action outputs instead of truncating them (JSON always includes them)
+- `--id, -i` — Saga execution ID
+- `--json` — Shorthand for --format json
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## See also
+
+- [`miren debug saga`](/command/debug-saga)

--- a/docs/docs/command/debug-saga.md
+++ b/docs/docs/command/debug-saga.md
@@ -1,0 +1,28 @@
+---
+title: "miren debug saga"
+sidebar_label: "debug saga"
+description: "Saga execution debug commands"
+---
+
+# miren debug saga
+
+Saga execution debug commands
+
+Sagas are Miren's mechanism for multi-step operations that have to either finish or unwind cleanly, like provisioning an addon or building and deploying an app. Each saga execution records what it ran, in what order, and what each action returned, so a saga that wedges leaves behind a trail you can read.
+
+These commands read that trail. The underlying records are also visible through `miren debug entity list -k saga`, but the interesting fields are stored as JSON blobs, so that view shows you base64 rather than what happened.
+
+## Usage
+
+```bash
+miren debug saga [flags]
+```
+
+## Subcommands
+
+- [`miren debug saga list`](/command/debug-saga-list) — List saga executions
+- [`miren debug saga show`](/command/debug-saga-show) — Show a saga execution in detail
+
+## See also
+
+- [`miren debug`](/command/debug)

--- a/docs/docs/command/debug.md
+++ b/docs/docs/command/debug.md
@@ -26,4 +26,5 @@ miren debug [flags]
 - [`miren debug netdb`](/command/debug-netdb) — Network database debug commands
 - [`miren debug rbac`](/command/debug-rbac) — Fetch and display RBAC rules from miren.cloud
 - [`miren debug reindex`](/command/debug-reindex) — Rebuild all entity indexes from scratch
+- [`miren debug saga`](/command/debug-saga) — Saga execution debug commands
 - [`miren debug test`](/command/debug-test) — Debug test commands

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -314,6 +314,9 @@ These commands are intended for advanced debugging and troubleshooting. They may
 | [`miren debug rbac`](/command/debug-rbac) | Fetch and display RBAC rules from miren.cloud |
 | [`miren debug rbac test`](/command/debug-rbac-test) | Test RBAC evaluation with fetched rules |
 | [`miren debug reindex`](/command/debug-reindex) | Rebuild all entity indexes from scratch |
+| [`miren debug saga`](/command/debug-saga) | Saga execution debug commands |
+| [`miren debug saga list`](/command/debug-saga-list) | List saga executions |
+| [`miren debug saga show`](/command/debug-saga-show) | Show a saga execution in detail |
 | [`miren debug test`](/command/debug-test) | Debug test commands |
 | [`miren debug test load`](/command/debug-test-load) | Loadtest a URL |
 

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -590,7 +590,17 @@ func collectOutputs(def *Definition, exec *Execution) *NestedResult {
 	}
 }
 
+// Execution IDs follow the same shape as every other entity ID in the system:
+// a kind namespace, then a name carrying a short mnemonic prefix and a
+// separator before the base58 body, as in sandbox/sb-… and pool/…. Sagas used
+// to mint a bare idgen.Gen("saga"), which produced sagaCdjkwhnn… with the word
+// running straight into lowercase base58 and no kind namespace at all.
+const (
+	sagaIDKind = "saga"
+	sagaIDName = "sg"
+)
+
 // generateID creates a unique execution ID.
 func generateID() string {
-	return idgen.Gen("saga")
+	return sagaIDKind + "/" + idgen.GenNS(sagaIDName)
 }

--- a/pkg/saga/executor_id_test.go
+++ b/pkg/saga/executor_id_test.go
@@ -1,0 +1,38 @@
+package saga
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Execution IDs are the handle an operator types into `miren debug saga show`,
+// and they should look like every other entity ID in the system rather than the
+// bare "sagaCdjk…" blob they used to be. Pin the shape so it does not drift.
+func TestGeneratedExecutionIDShape(t *testing.T) {
+	id := generateID()
+
+	kind, name, ok := strings.Cut(id, "/")
+	require.True(t, ok, "id %q has no kind namespace", id)
+	assert.Equal(t, "saga", kind)
+
+	prefix, body, ok := strings.Cut(name, "-")
+	require.True(t, ok, "id %q has no separator before the base58 body", id)
+	assert.Equal(t, "sg", prefix)
+	assert.NotEmpty(t, body)
+
+	assert.NotEqual(t, generateID(), id, "generated IDs must be unique")
+}
+
+func TestDerivedChildIDShape(t *testing.T) {
+	id := deriveChildID("saga/sg-Parent1", "child-saga", "parent-step")
+
+	assert.True(t, strings.HasPrefix(id, "saga/sg-"), "derived id %q", id)
+
+	// Determinism is what makes nested-saga recovery idempotent, so the shape
+	// change must not have made it depend on anything but its inputs.
+	assert.Equal(t, id, deriveChildID("saga/sg-Parent1", "child-saga", "parent-step"))
+	assert.NotEqual(t, id, deriveChildID("saga/sg-Parent2", "child-saga", "parent-step"))
+}

--- a/pkg/saga/nested.go
+++ b/pkg/saga/nested.go
@@ -168,5 +168,5 @@ func UndoNested(ctx context.Context, executionID string) error {
 // createChildExecution's idempotency check to find the prior child execution.
 func deriveChildID(parentExecID, sagaName, actionName string) string {
 	h := sha256.Sum256([]byte(parentExecID + "\x00" + sagaName + "\x00" + actionName))
-	return "saga" + base58.Encode(h[:16])
+	return sagaIDKind + "/" + sagaIDName + "-" + base58.Encode(h[:16])
 }

--- a/pkg/saga/storage.go
+++ b/pkg/saga/storage.go
@@ -214,6 +214,44 @@ func statusFromEntity(s saga_v1alpha.SagaStatus) Status {
 	}
 }
 
+// StatusIndexAttr returns the entity index attribute that selects executions in
+// the given status, for callers querying the entity store directly rather than
+// through a Storage (the CLI's `debug saga` commands). It reports false for an
+// unrecognized status rather than guessing, since a wrong index silently
+// returns the wrong sagas.
+func StatusIndexAttr(s Status) (entity.Attr, bool) {
+	var id entity.Id
+
+	switch s {
+	case StatusPending:
+		id = saga_v1alpha.SagaStatusPendingId
+	case StatusRunning:
+		id = saga_v1alpha.SagaStatusRunningId
+	case StatusUndoing:
+		id = saga_v1alpha.SagaStatusUndoingId
+	case StatusCompleted:
+		id = saga_v1alpha.SagaStatusCompletedId
+	case StatusFailed:
+		id = saga_v1alpha.SagaStatusFailedId
+	default:
+		return entity.Attr{}, false
+	}
+
+	return entity.Ref(saga_v1alpha.SagaStatusId, id), true
+}
+
+// ExecutionFromEntity converts a decoded saga entity into an Execution,
+// deserializing the JSON-encoded inputs, action results, and execution order.
+// Exposed so tools that read saga entities directly (the CLI's `debug saga`
+// commands) decode them the same way the executor does.
+//
+// Note that CreatedAt and UpdatedAt are not persisted on the entity and so are
+// left zero here; callers that need them should read the entity store's own
+// creation and update metadata.
+func ExecutionFromEntity(sagaEntity *saga_v1alpha.Saga) (*Execution, error) {
+	return entityToExecution(sagaEntity)
+}
+
 // entityToExecution converts a saga entity to an Execution.
 func entityToExecution(sagaEntity *saga_v1alpha.Saga) (*Execution, error) {
 	exec := &Execution{

--- a/pkg/ui/entity.go
+++ b/pkg/ui/entity.go
@@ -16,6 +16,7 @@ func CleanEntityID(id string) string {
 		"app_version/",
 		"app/",
 		"pool/",
+		"saga/",
 	}
 
 	cleaned := id


### PR DESCRIPTION
Inspecting a stuck saga meant running `debug entity list -k saga` and reading base64 out of the output by hand. The fields you actually want (initial inputs, per-action results, execution order) are stored as JSON blobs, so the raw entity view shows you bytes rather than what happened. RFD-35 left saga observability as an open question and it stayed open.

`debug saga list` defaults to active executions only, meaning pending, running, and undoing. Completed sagas dominate the store and are never what you're looking for when something is wedged, so `--all` widens and `--status` narrows. Both filters the issue asked for, definition name and status, were already indexed on the schema, so there's no migration and no reindex. `debug saga show` walks the execution order with per-action timing, undo state, errors, and decoded output, truncated by default and whole with `--full`. It also lists child sagas, since `parent_execution_id` is indexed too. Everything supports `--format json`.

Then building it made the ID format impossible to ignore, and prerelease is the window for that. Sagas were minting `idgen.Gen("saga")`, the generator meant for short opaque tokens that get embedded in longer names, rather than the `GenNS` every other entity uses. The result was `sagaCdjkwhnngwnS8AZYPSTcK`: the word running straight into lowercase base58 with no separator your eye can find, and no kind namespace at all, sitting next to things like `sandbox/sb-…` and `pool/…`. They're `saga/sg-…` now, with `deriveChildID` moved in lockstep so nested-saga recovery stays deterministic, plus a test pinning both shapes. Listings strip the namespace the way sandbox and app listings already do, and lookups accept the bare name, the qualified ID, or the legacy unnamespaced form, so the ID you copy off the table pastes straight back and existing sagas keep resolving without a migration.

Two things worth flagging. `show` renders the actions that ran, not the full set the definition declares, because the saga registry is built at server startup and isn't exposed over the API. So "where it stopped" is the last executed action plus the error, and a registry-listing RPC would unlock real DAG visualization if we want it.

And the CREATED column is blank on real sagas today. Saga storage saves by full replace, and `ReplaceEntity` carries the revision forward but not `db/entity.created`, so an execution loses its creation timestamp on the first save after the initial one. The MIR-1526 retention work is fixing that, so the column stays and starts working when it lands. Worth knowing how it surfaced: an in-memory integration test that saves through the real `EntityStorage` asserted the timestamp was present and passed, because MockStore's replace preserves the attr where EtcdStore's doesn't. Anything using `NewInMemEntityServer` to reason about persistence has that blind spot.

One known risk, taken deliberately. `deriveChildID` produces the idempotency key that `createChildExecution` uses to find an already-created nested child during recovery, so changing the ID format means a child created before this lands won't be found after it, and a parent re-running that action would spawn a second child and re-execute its actions. Top-level sagas are unaffected, since they recover by reading their stored ID rather than deriving it. We're prerelease and that's precisely why the format is moving now, so we're taking the narrow upgrade window rather than carrying the old derivation in the saga hot path indefinitely.

Closes MIR-1523
