### PR TITLE
Reference secrets from config and materialize them into sandboxes

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -391,6 +391,7 @@ type namedValueData struct {
 	Source      *string `cbor:"3,keyasint,omitempty" json:"source,omitempty"`
 	Required    *bool   `cbor:"4,keyasint,omitempty" json:"required,omitempty"`
 	Description *string `cbor:"5,keyasint,omitempty" json:"description,omitempty"`
+	Backend     *string `cbor:"6,keyasint,omitempty" json:"backend,omitempty"`
 }
 
 type NamedValue struct {
@@ -485,6 +486,21 @@ func (v *NamedValue) Description() string {
 
 func (v *NamedValue) SetDescription(description string) {
 	v.data.Description = &description
+}
+
+func (v *NamedValue) HasBackend() bool {
+	return v.data.Backend != nil
+}
+
+func (v *NamedValue) Backend() string {
+	if v.data.Backend == nil {
+		return ""
+	}
+	return *v.data.Backend
+}
+
+func (v *NamedValue) SetBackend(backend string) {
+	v.data.Backend = &backend
 }
 
 func (v *NamedValue) MarshalCBOR() ([]byte, error) {

--- a/api/app/envvar.go
+++ b/api/app/envvar.go
@@ -14,6 +14,7 @@ import (
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
 	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/secret"
 )
 
 // EnvVarInput represents an env var to set.
@@ -21,6 +22,11 @@ type EnvVarInput struct {
 	Key       string
 	Value     string
 	Sensitive bool
+
+	// Backend names the secret backend the value comes from. Empty means Value
+	// is an inline literal; otherwise Value holds a backend-relative reference
+	// and the real value is never seen here.
+	Backend string
 }
 
 // MutateResult holds the result of an env var mutation.
@@ -64,7 +70,7 @@ var testHookAfterResolve func()
 // When a baseVersion is pinned, each attempt re-derives from that fixed version by
 // design — the caller asked to base off it — so the retry re-applies the same base
 // rather than composing onto the winner.
-func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
+func SetEnvVars(ctx context.Context, ec *entityserver.Client, resolver secret.Resolver, appName string,
 	baseVersion *core_v1alpha.AppVersion, vars []EnvVarInput, service string) (*MutateResult, error) {
 
 	for _, v := range vars {
@@ -87,7 +93,7 @@ func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 			testHookAfterResolve()
 		}
 
-		result, err := createNewVersion(ctx, ec, appName, appVer, spec, appRec, appRev)
+		result, err := createNewVersion(ctx, ec, resolver, appName, appVer, spec, appRec, appRev)
 		if err == nil {
 			return result, nil
 		}
@@ -109,7 +115,7 @@ func SetEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 // control so a concurrent active-version swing cannot silently clobber the delete.
 // The same baseVersion caveat applies: the retry composes onto a concurrent winner
 // only when baseVersion is nil; a pinned baseVersion is re-applied as-is.
-func DeleteEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
+func DeleteEnvVars(ctx context.Context, ec *entityserver.Client, resolver secret.Resolver, appName string,
 	baseVersion *core_v1alpha.AppVersion, keys []string, service string) (*DeleteResult, error) {
 
 	for range envMutateMaxAttempts {
@@ -168,7 +174,7 @@ func DeleteEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
 			}
 		}
 
-		result, err := createNewVersion(ctx, ec, appName, appVer, spec, appRec, appRev)
+		result, err := createNewVersion(ctx, ec, resolver, appName, appVer, spec, appRec, appRev)
 		if err == nil {
 			return &DeleteResult{
 				MutateResult:   *result,
@@ -239,7 +245,7 @@ func resolveBaseVersion(ctx context.Context, ec *entityserver.Client, appName st
 // The app update uses optimistic concurrency control via Replace+revision so
 // that two parallel SetInitialEnvVars calls (or a deploy slipping in between
 // the read and the write) cannot silently drop staged vars.
-func SetInitialEnvVars(ctx context.Context, ec *entityserver.Client, appName string,
+func SetInitialEnvVars(ctx context.Context, ec *entityserver.Client, resolver secret.Resolver, appName string,
 	vars []EnvVarInput, service string) (entity.Id, error) {
 
 	for _, v := range vars {
@@ -273,6 +279,10 @@ func SetInitialEnvVars(ctx context.Context, ec *entityserver.Client, appName str
 		}
 
 		if err := mergeIntoSpec(&spec, vars, service); err != nil {
+			return "", err
+		}
+
+		if err := pinSecrets(ctx, resolver, &spec); err != nil {
 			return "", err
 		}
 
@@ -324,6 +334,7 @@ func mergeIntoSpec(spec *core_v1alpha.ConfigSpec, vars []EnvVarInput, service st
 					spec.Variables[i].Value = v.Value
 					spec.Variables[i].Sensitive = v.Sensitive
 					spec.Variables[i].Source = "manual"
+					spec.Variables[i].Backend = v.Backend
 					found = true
 					break
 				}
@@ -334,6 +345,7 @@ func mergeIntoSpec(spec *core_v1alpha.ConfigSpec, vars []EnvVarInput, service st
 					Value:     v.Value,
 					Sensitive: v.Sensitive,
 					Source:    "manual",
+					Backend:   v.Backend,
 				})
 			}
 			continue
@@ -349,6 +361,7 @@ func mergeIntoSpec(spec *core_v1alpha.ConfigSpec, vars []EnvVarInput, service st
 						spec.Services[i].Env[j].Value = v.Value
 						spec.Services[i].Env[j].Sensitive = v.Sensitive
 						spec.Services[i].Env[j].Source = "manual"
+						spec.Services[i].Env[j].Backend = v.Backend
 						envFound = true
 						break
 					}
@@ -359,6 +372,7 @@ func mergeIntoSpec(spec *core_v1alpha.ConfigSpec, vars []EnvVarInput, service st
 						Value:     v.Value,
 						Sensitive: v.Sensitive,
 						Source:    "manual",
+						Backend:   v.Backend,
 					})
 				}
 				break
@@ -375,6 +389,7 @@ func mergeIntoSpec(spec *core_v1alpha.ConfigSpec, vars []EnvVarInput, service st
 					Value:     v.Value,
 					Sensitive: v.Sensitive,
 					Source:    "manual",
+					Backend:   v.Backend,
 				}},
 			})
 		}
@@ -389,8 +404,14 @@ func mergeIntoSpec(spec *core_v1alpha.ConfigSpec, vars []EnvVarInput, service st
 // controller injecting addon vars — is detected and the caller retries against
 // the winner's version instead of silently clobbering it. Returns cond.ErrConflict
 // on a lost race.
-func createNewVersion(ctx context.Context, ec *entityserver.Client, appName string,
+func createNewVersion(ctx context.Context, ec *entityserver.Client, resolver secret.Resolver, appName string,
 	appVer *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec, appRec *core_v1alpha.App, appRev int64) (*MutateResult, error) {
+
+	// Freeze every backend-sourced variable to the version it resolves to right
+	// now, so this ConfigVersion records exactly which secret it was built with.
+	if err := pinSecrets(ctx, resolver, spec); err != nil {
+		return nil, err
+	}
 
 	appVer.Version = appName + "-" + idgen.Gen("v")
 
@@ -435,4 +456,25 @@ func createNewVersion(ctx context.Context, ec *entityserver.Client, appName stri
 		AppVersion: appVer,
 		VersionID:  appVer.Version,
 	}, nil
+}
+
+// pinSecrets rewrites every backend-sourced variable in the spec to the exact
+// version it resolves to, so a ConfigVersion minted from it records which secret
+// it was built with rather than a floating reference.
+//
+// A config with no backend-sourced variables never needs a resolver, which keeps
+// a cluster with no secret backends registered working exactly as before. One
+// that does reference a backend fails the write rather than activating a version
+// whose credential silently never arrived.
+func pinSecrets(ctx context.Context, resolver secret.Resolver, spec *core_v1alpha.ConfigSpec) error {
+	refs := coreutil.SecretReferences(spec)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	if resolver == nil {
+		return fmt.Errorf("config references secret %s but this cluster has no secret backends configured", refs[0])
+	}
+
+	return coreutil.PinSecrets(ctx, resolver, spec)
 }

--- a/api/app/envvar_test.go
+++ b/api/app/envvar_test.go
@@ -69,12 +69,12 @@ func TestCreateNewVersionCASGuardsActiveVersion(t *testing.T) {
 
 	// A competing writer swings active_version in the meantime (e.g. a parallel
 	// env set, or the addon controller injecting DATABASE_URL).
-	_, err = SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "COMPETITOR", Value: "c"}}, "")
+	_, err = SetEnvVars(ctx, ec, nil, "myapp", nil, []EnvVarInput{{Key: "COMPETITOR", Value: "c"}}, "")
 	require.NoError(t, err)
 
 	// Our write, built from the now-stale revision, must be rejected.
 	require.NoError(t, mergeIntoSpec(spec, []EnvVarInput{{Key: "MINE", Value: "m"}}, ""))
-	_, err = createNewVersion(ctx, ec, "myapp", appVer, spec, appRec, appRev)
+	_, err = createNewVersion(ctx, ec, nil, "myapp", appVer, spec, appRec, appRev)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, cond.ErrConflict{}), "stale write must conflict, got %v", err)
 
@@ -90,9 +90,9 @@ func TestSetEnvVarsComposesSequentially(t *testing.T) {
 	ctx, ec := newEnvTestClient(t)
 	createEnvTestApp(t, ctx, ec, "myapp", []core_v1alpha.Variable{{Key: "BASE", Value: "1", Source: "config"}})
 
-	_, err := SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "FOO", Value: "a"}}, "")
+	_, err := SetEnvVars(ctx, ec, nil, "myapp", nil, []EnvVarInput{{Key: "FOO", Value: "a"}}, "")
 	require.NoError(t, err)
-	_, err = SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "BAR", Value: "b"}}, "")
+	_, err = SetEnvVars(ctx, ec, nil, "myapp", nil, []EnvVarInput{{Key: "BAR", Value: "b"}}, "")
 	require.NoError(t, err)
 
 	vars := activeEnvVars(t, ctx, ec, "myapp")
@@ -117,12 +117,12 @@ func TestSetEnvVarsRetriesAndRecoversOnConflict(t *testing.T) {
 		testHookAfterResolve = nil
 		// Competing writer wins the active-version swing while we are mid-flight,
 		// bumping the app revision under us so our Patch conflicts.
-		_, err := SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "COMPETITOR", Value: "c"}}, "")
+		_, err := SetEnvVars(ctx, ec, nil, "myapp", nil, []EnvVarInput{{Key: "COMPETITOR", Value: "c"}}, "")
 		require.NoError(t, err)
 	}
 	t.Cleanup(func() { testHookAfterResolve = nil })
 
-	_, err := SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "MINE", Value: "m"}}, "")
+	_, err := SetEnvVars(ctx, ec, nil, "myapp", nil, []EnvVarInput{{Key: "MINE", Value: "m"}}, "")
 	require.NoError(t, err)
 
 	vars := activeEnvVars(t, ctx, ec, "myapp")
@@ -153,10 +153,10 @@ func TestDeleteEnvVarsComposesSequentially(t *testing.T) {
 	ctx, ec := newEnvTestClient(t)
 	createEnvTestApp(t, ctx, ec, "myapp", []core_v1alpha.Variable{{Key: "BASE", Value: "1", Source: "config"}})
 
-	_, err := SetEnvVars(ctx, ec, "myapp", nil, []EnvVarInput{{Key: "FOO", Value: "a"}}, "")
+	_, err := SetEnvVars(ctx, ec, nil, "myapp", nil, []EnvVarInput{{Key: "FOO", Value: "a"}}, "")
 	require.NoError(t, err)
 
-	res, err := DeleteEnvVars(ctx, ec, "myapp", nil, []string{"FOO"}, "")
+	res, err := DeleteEnvVars(ctx, ec, nil, "myapp", nil, []string{"FOO"}, "")
 	require.NoError(t, err)
 	require.NotNil(t, res)
 

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -100,6 +100,14 @@ types:
       - name: description
         type: string
         index: 5
+      - name: backend
+        type: string
+        index: 6
+        optional: true
+        doc: >-
+          Secret backend the value comes from. Empty means value is an inline
+          literal; otherwise value holds a backend-relative reference and the
+          real value never travels here.
 
   - type: VersionInfo
     fields:

--- a/api/core/secretpin.go
+++ b/api/core/secretpin.go
@@ -2,6 +2,8 @@ package compute
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/pkg/secret"
@@ -58,6 +60,10 @@ func SecretReferences(spec *core_v1alpha.ConfigSpec) []secret.Reference {
 // A config with no backend-sourced variables never touches the resolver, so a
 // cluster with no secrets in play pays nothing and cannot fail here.
 func PinSecrets(ctx context.Context, resolver secret.Resolver, spec *core_v1alpha.ConfigSpec) error {
+	if err := rejectLiteralsPosingAsReferences(spec); err != nil {
+		return err
+	}
+
 	refs := SecretReferences(spec)
 	if len(refs) == 0 {
 		return nil
@@ -86,6 +92,36 @@ func PinSecrets(ctx context.Context, resolver secret.Resolver, spec *core_v1alph
 			}
 			spec.Services[s].Env[e].Value = pinned[next]
 			next++
+		}
+	}
+
+	return nil
+}
+
+// rejectLiteralsPosingAsReferences refuses an inline value that looks like the
+// placeholder a backend-sourced variable contributes to a sandbox spec.
+//
+// Backend identity travels in-band, alongside the reference in a single env
+// string, because the spec's env is a flat []string with nowhere structured to
+// put it. That makes the mapping breakable from the other side: a literal whose
+// value happens to start with the scheme would be materialized as though it
+// named a secret. There is no privilege escalation in it — anyone who can set a
+// literal can set a real reference — but it is confusing behavior that is cheap
+// to refuse at the one point every config passes through.
+func rejectLiteralsPosingAsReferences(spec *core_v1alpha.ConfigSpec) error {
+	for _, v := range spec.Variables {
+		if v.Backend == "" && strings.HasPrefix(v.Value, secret.SentinelScheme) {
+			return fmt.Errorf("variable %s has no backend but its value starts with %s, which is reserved for secret references",
+				v.Key, secret.SentinelScheme)
+		}
+	}
+
+	for _, svc := range spec.Services {
+		for _, e := range svc.Env {
+			if e.Backend == "" && strings.HasPrefix(e.Value, secret.SentinelScheme) {
+				return fmt.Errorf("variable %s of service %s has no backend but its value starts with %s, which is reserved for secret references",
+					e.Key, svc.Name, secret.SentinelScheme)
+			}
 		}
 	}
 

--- a/api/core/secretpin.go
+++ b/api/core/secretpin.go
@@ -1,0 +1,93 @@
+package compute
+
+import (
+	"context"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/secret"
+)
+
+// SecretReferences collects every backend-sourced variable in a config, both
+// the shared ones and the per-service ones.
+func SecretReferences(spec *core_v1alpha.ConfigSpec) []secret.Reference {
+	var refs []secret.Reference
+
+	for _, v := range spec.Variables {
+		if v.Backend == "" {
+			continue
+		}
+		refs = append(refs, secret.Reference{
+			Backend: v.Backend,
+			Ref:     v.Value,
+			Key:     v.Key,
+		})
+	}
+
+	for _, svc := range spec.Services {
+		for _, e := range svc.Env {
+			if e.Backend == "" {
+				continue
+			}
+			refs = append(refs, secret.Reference{
+				Backend: e.Backend,
+				Ref:     e.Value,
+				Key:     e.Key,
+				Service: svc.Name,
+			})
+		}
+	}
+
+	return refs
+}
+
+// PinSecrets resolves every backend-sourced variable in a config and rewrites
+// each one's value to the fully-qualified reference it resolved to.
+//
+// Call it immediately before a ConfigVersion is created. An authored reference
+// usually floats ("payments/stripe-key"); what the ConfigVersion records is
+// what it resolved to at that moment ("payments/stripe-key@x1A"). That is what
+// makes "which secret did this version actually ship with?" answerable, and
+// what makes a rollback come back on the value the old version ran with rather
+// than today's.
+//
+// It is idempotent, because resolving an already-pinned reference returns the
+// same reference. A redeploy therefore re-pins a floating app.toml reference to
+// whatever is current — picking up a rotation — while leaving a hand-set
+// reference at the version it was set to.
+//
+// A config with no backend-sourced variables never touches the resolver, so a
+// cluster with no secrets in play pays nothing and cannot fail here.
+func PinSecrets(ctx context.Context, resolver secret.Resolver, spec *core_v1alpha.ConfigSpec) error {
+	refs := SecretReferences(spec)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	pinned, err := secret.Pin(ctx, resolver, refs)
+	if err != nil {
+		return err
+	}
+
+	// Walk in the same order SecretReferences produced, so each resolved
+	// reference lands back on the variable it came from.
+	next := 0
+	for i := range spec.Variables {
+		if spec.Variables[i].Backend == "" {
+			continue
+		}
+		spec.Variables[i].Value = pinned[next]
+		next++
+	}
+
+	for s := range spec.Services {
+		for e := range spec.Services[s].Env {
+			if spec.Services[s].Env[e].Backend == "" {
+				continue
+			}
+			spec.Services[s].Env[e].Value = pinned[next]
+			next++
+		}
+	}
+
+	return nil
+}

--- a/api/core/secretpin_test.go
+++ b/api/core/secretpin_test.go
@@ -1,0 +1,161 @@
+package compute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/secret"
+)
+
+// stubResolver resolves a floating reference to a fixed current version and
+// honours an explicit pin, as every backend guarantees.
+type stubResolver struct {
+	current map[string]string
+	calls   int
+}
+
+func (r *stubResolver) ResolveRef(ctx context.Context, backend, ref string) (secret.SecretValue, error) {
+	r.calls++
+
+	path, version, err := secret.ParseRef(ref)
+	if err != nil {
+		return secret.SecretValue{}, err
+	}
+	if version == "" {
+		var ok bool
+		version, ok = r.current[path]
+		if !ok {
+			return secret.SecretValue{}, secret.ErrNotFound
+		}
+	}
+	return secret.SecretValue{Ref: secret.FormatRef(path, version), Bytes: []byte("value")}, nil
+}
+
+func TestSecretReferencesFindsSharedAndPerServiceVariables(t *testing.T) {
+	spec := &core_v1alpha.ConfigSpec{
+		Variables: []core_v1alpha.ConfigSpecVariables{
+			{Key: "PLAIN", Value: "10"},
+			{Key: "STRIPE_API_KEY", Value: "payments/stripe-key", Backend: "cluster"},
+		},
+		Services: []core_v1alpha.ConfigSpecServices{
+			{
+				Name: "worker",
+				Env: []core_v1alpha.ConfigSpecServicesEnv{
+					{Key: "QUEUE", Value: "default"},
+					{Key: "SIGNING_KEY", Value: "auth/signing", Backend: "prod-vault"},
+				},
+			},
+		},
+	}
+
+	refs := SecretReferences(spec)
+	require.Len(t, refs, 2)
+
+	assert.Equal(t, secret.Reference{Backend: "cluster", Ref: "payments/stripe-key", Key: "STRIPE_API_KEY"}, refs[0])
+	assert.Equal(t, secret.Reference{Backend: "prod-vault", Ref: "auth/signing", Key: "SIGNING_KEY", Service: "worker"}, refs[1])
+}
+
+func TestPinSecretsRewritesReferencesInPlace(t *testing.T) {
+	r := &stubResolver{current: map[string]string{
+		"payments/stripe-key": "x1A",
+		"auth/signing":        "42",
+	}}
+
+	spec := &core_v1alpha.ConfigSpec{
+		Variables: []core_v1alpha.ConfigSpecVariables{
+			{Key: "PLAIN", Value: "10"},
+			{Key: "STRIPE_API_KEY", Value: "payments/stripe-key", Backend: "cluster"},
+		},
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "worker",
+			Env: []core_v1alpha.ConfigSpecServicesEnv{
+				{Key: "QUEUE", Value: "default"},
+				{Key: "SIGNING_KEY", Value: "auth/signing", Backend: "prod-vault"},
+			},
+		}},
+	}
+
+	require.NoError(t, PinSecrets(context.Background(), r, spec))
+
+	assert.Equal(t, "payments/stripe-key@x1A", spec.Variables[1].Value)
+	assert.Equal(t, "auth/signing@42", spec.Services[0].Env[1].Value)
+
+	// Inline literals are left exactly as they were.
+	assert.Equal(t, "10", spec.Variables[0].Value)
+	assert.Equal(t, "default", spec.Services[0].Env[0].Value)
+}
+
+// A redeploy re-pins a floating reference to whatever is current — that is how a
+// rotation reaches an app — while a reference authored with an explicit version
+// stays where it was put.
+func TestPinSecretsRepinsFloatingButHoldsExplicitVersions(t *testing.T) {
+	r := &stubResolver{current: map[string]string{"payments/stripe-key": "m4Q"}}
+
+	spec := &core_v1alpha.ConfigSpec{
+		Variables: []core_v1alpha.ConfigSpecVariables{
+			{Key: "STRIPE_API_KEY", Value: "payments/stripe-key", Backend: "cluster"},
+			{Key: "STRIPE_API_KEY_PREV", Value: "payments/stripe-key@x1A", Backend: "cluster"},
+		},
+	}
+
+	require.NoError(t, PinSecrets(context.Background(), r, spec))
+
+	assert.Equal(t, "payments/stripe-key@m4Q", spec.Variables[0].Value)
+	assert.Equal(t, "payments/stripe-key@x1A", spec.Variables[1].Value)
+}
+
+// Pinning the output of a previous pin must be a no-op, which is what keeps an
+// already-pinned ConfigVersion stable across the mint paths that re-run it.
+func TestPinSecretsIsIdempotent(t *testing.T) {
+	r := &stubResolver{current: map[string]string{"payments/stripe-key": "x1A"}}
+
+	spec := &core_v1alpha.ConfigSpec{
+		Variables: []core_v1alpha.ConfigSpecVariables{
+			{Key: "STRIPE_API_KEY", Value: "payments/stripe-key", Backend: "cluster"},
+		},
+	}
+
+	require.NoError(t, PinSecrets(context.Background(), r, spec))
+	first := spec.Variables[0].Value
+
+	// The secret rotates underneath, but the now-pinned reference does not move.
+	r.current["payments/stripe-key"] = "m4Q"
+	require.NoError(t, PinSecrets(context.Background(), r, spec))
+
+	assert.Equal(t, first, spec.Variables[0].Value)
+}
+
+// A config that references nothing must not depend on a resolver at all, so a
+// cluster with no secret backends keeps working exactly as before.
+func TestPinSecretsSkipsConfigsWithNoReferences(t *testing.T) {
+	r := &stubResolver{current: map[string]string{}}
+
+	spec := &core_v1alpha.ConfigSpec{
+		Variables: []core_v1alpha.ConfigSpecVariables{{Key: "PLAIN", Value: "10"}},
+	}
+
+	require.NoError(t, PinSecrets(context.Background(), r, spec))
+	assert.Zero(t, r.calls)
+}
+
+// A resolution failure must fail the mint rather than leaving the variable at
+// its unresolved reference, which would deploy an app with a literal path where
+// its credential should be.
+func TestPinSecretsFailsClosed(t *testing.T) {
+	r := &stubResolver{current: map[string]string{}}
+
+	spec := &core_v1alpha.ConfigSpec{
+		Variables: []core_v1alpha.ConfigSpecVariables{
+			{Key: "STRIPE_API_KEY", Value: "payments/stripe-key", Backend: "cluster"},
+		},
+	}
+
+	err := PinSecrets(context.Background(), r, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "STRIPE_API_KEY")
+	assert.Equal(t, "payments/stripe-key", spec.Variables[0].Value)
+}

--- a/api/core/secretpin_test.go
+++ b/api/core/secretpin_test.go
@@ -159,3 +159,53 @@ func TestPinSecretsFailsClosed(t *testing.T) {
 	assert.Contains(t, err.Error(), "STRIPE_API_KEY")
 	assert.Equal(t, "payments/stripe-key", spec.Variables[0].Value)
 }
+
+// Backend identity travels in-band, so the mapping is breakable from the other
+// side too: a literal whose value starts with the scheme would be materialized
+// as though it named a secret. Refuse it where every config passes through.
+func TestPinSecretsRejectsALiteralPosingAsAReference(t *testing.T) {
+	r := &stubResolver{current: map[string]string{}}
+
+	spec := &core_v1alpha.ConfigSpec{
+		Variables: []core_v1alpha.ConfigSpecVariables{
+			{Key: "SNEAKY", Value: secret.FormatSentinel("cluster", "payments/stripe-key@x1A")},
+		},
+	}
+
+	err := PinSecrets(context.Background(), r, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SNEAKY")
+	assert.Zero(t, r.calls, "it should be refused before any resolution")
+}
+
+func TestPinSecretsRejectsALiteralPosingAsAReferenceInAService(t *testing.T) {
+	r := &stubResolver{current: map[string]string{}}
+
+	spec := &core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{{
+			Name: "worker",
+			Env: []core_v1alpha.ConfigSpecServicesEnv{
+				{Key: "SNEAKY", Value: secret.FormatSentinel("cluster", "payments/stripe-key@x1A")},
+			},
+		}},
+	}
+
+	err := PinSecrets(context.Background(), r, spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "worker")
+}
+
+// A genuine reference carries the same value shape but names its backend, so it
+// must still pin normally.
+func TestPinSecretsAllowsARealReference(t *testing.T) {
+	r := &stubResolver{current: map[string]string{"payments/stripe-key": "x1A"}}
+
+	spec := &core_v1alpha.ConfigSpec{
+		Variables: []core_v1alpha.ConfigSpecVariables{
+			{Key: "STRIPE_API_KEY", Value: "payments/stripe-key", Backend: "cluster"},
+		},
+	}
+
+	require.NoError(t, PinSecrets(context.Background(), r, spec))
+	assert.Equal(t, "payments/stripe-key@x1A", spec.Variables[0].Value)
+}

--- a/api/deployment/deployment_v1alpha/rpc.gen.go
+++ b/api/deployment/deployment_v1alpha/rpc.gen.go
@@ -625,6 +625,7 @@ type environmentVariableData struct {
 	Key       *string `cbor:"0,keyasint,omitempty" json:"key,omitempty"`
 	Value     *string `cbor:"1,keyasint,omitempty" json:"value,omitempty"`
 	Sensitive *bool   `cbor:"2,keyasint,omitempty" json:"sensitive,omitempty"`
+	Backend   *string `cbor:"3,keyasint,omitempty" json:"backend,omitempty"`
 }
 
 type EnvironmentVariable struct {
@@ -674,6 +675,21 @@ func (v *EnvironmentVariable) Sensitive() bool {
 
 func (v *EnvironmentVariable) SetSensitive(sensitive bool) {
 	v.data.Sensitive = &sensitive
+}
+
+func (v *EnvironmentVariable) HasBackend() bool {
+	return v.data.Backend != nil
+}
+
+func (v *EnvironmentVariable) Backend() string {
+	if v.data.Backend == nil {
+		return ""
+	}
+	return *v.data.Backend
+}
+
+func (v *EnvironmentVariable) SetBackend(backend string) {
+	v.data.Backend = &backend
 }
 
 func (v *EnvironmentVariable) MarshalCBOR() ([]byte, error) {

--- a/api/deployment/rpc.yml
+++ b/api/deployment/rpc.yml
@@ -481,6 +481,14 @@ types:
         type: bool
         index: 2
         doc: Whether this is a sensitive value that should be masked
+      - name: backend
+        type: string
+        index: 3
+        optional: true
+        doc: >-
+          Secret backend the value comes from. Empty means value is an inline
+          literal; otherwise value holds a backend-relative reference and the
+          real value never travels here.
 
   - type: AccessInfo
     doc: Information about how to access the deployed application

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -27,9 +27,12 @@ type AppEnvVar struct {
 	// never appears in app.toml, only a pointer to it, so the file stays safe to
 	// commit.
 	//
-	// A reference authored here floats — it re-pins to whatever is current on
-	// every deploy, which is how a rotation reaches the app. Appending @version
-	// to Ref holds it at that exact version instead.
+	// A reference authored here floats: each new ConfigVersion resolves it to
+	// whatever is current, which is how a rotation reaches the app. Note that
+	// this is about minting a config, not running one — deploying or rolling
+	// back to an existing version keeps the reference that version recorded, so
+	// a rotation reaches an app only once a new config is created for it.
+	// Appending @version to Ref holds it at that exact version regardless.
 	Backend string `json:"backend,omitempty" toml:"backend,omitempty"`
 	Ref     string `json:"ref,omitempty" toml:"ref,omitempty"`
 }

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -21,6 +21,17 @@ type AppEnvVar struct {
 	Required    bool   `json:"required,omitempty" toml:"required,omitempty"`
 	Sensitive   bool   `json:"sensitive,omitempty" toml:"sensitive,omitempty"`
 	Description string `json:"description,omitempty" toml:"description,omitempty"`
+
+	// Backend names the secret backend the value comes from, and Ref addresses
+	// the secret within it. Together they replace Value: the credential itself
+	// never appears in app.toml, only a pointer to it, so the file stays safe to
+	// commit.
+	//
+	// A reference authored here floats — it re-pins to whatever is current on
+	// every deploy, which is how a rotation reaches the app. Appending @version
+	// to Ref holds it at that exact version instead.
+	Backend string `json:"backend,omitempty" toml:"backend,omitempty"`
+	Ref     string `json:"ref,omitempty" toml:"ref,omitempty"`
 }
 
 type BuildConfig struct {
@@ -174,6 +185,9 @@ func (ac *AppConfig) Validate() error {
 		if ev.Key == "" {
 			return &ValidationError{KeyPath: "env", Message: fmt.Sprintf("env[%d]: key is required", i)}
 		}
+		if err := ev.validateReference(fmt.Sprintf("env[%d]", i)); err != nil {
+			return err
+		}
 	}
 
 	// Validate service configurations
@@ -269,6 +283,9 @@ func (ac *AppConfig) Validate() error {
 		// Validate service environment variables
 		// Note: empty values are allowed - secrets may be stored server-side
 		for i, ev := range svcConfig.EnvVars {
+			if err := ev.validateReference(fmt.Sprintf("%s.env[%d]", svcPrefix, i)); err != nil {
+				return err
+			}
 			if ev.Key == "" {
 				return &ValidationError{
 					KeyPath: svcPrefix + ".env",
@@ -551,4 +568,31 @@ func AliasLineNumbers(configPath string) map[string]int {
 	}
 
 	return result
+}
+
+// validateReference checks the secret-reference form of an env var. A reference
+// replaces the value rather than accompanying it, so accepting both would leave
+// it ambiguous which one is meant to reach the app — and the wrong guess ships a
+// literal path where a credential belongs.
+func (ev AppEnvVar) validateReference(keyPath string) error {
+	switch {
+	case ev.Ref == "" && ev.Backend == "":
+		return nil
+	case ev.Ref == "":
+		return &ValidationError{
+			KeyPath: keyPath + ".ref",
+			Message: fmt.Sprintf("%s: backend %q needs a ref naming the secret", keyPath, ev.Backend),
+		}
+	case ev.Backend == "":
+		return &ValidationError{
+			KeyPath: keyPath + ".backend",
+			Message: fmt.Sprintf("%s: ref %q needs a backend to resolve it against", keyPath, ev.Ref),
+		}
+	case ev.Value != "":
+		return &ValidationError{
+			KeyPath: keyPath + ".value",
+			Message: fmt.Sprintf("%s: set either value or ref, not both — a referenced secret gets its value from the backend", keyPath),
+		}
+	}
+	return nil
 }

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -31,6 +31,19 @@ func maskURLUserinfo(value string) string {
 	return urlUserinfoRe.ReplaceAllString(value, "${1}"+envRedacted+"@")
 }
 
+// displayEnvValue renders what `env list`/`env get` shows for one variable.
+//
+// A backend-sourced variable has no local value to mask: the bytes never
+// travelled here, only the reference did. Showing the reference — backend,
+// path, and the version this config pinned — is both safe and the only useful
+// thing to show, so --unmask has nothing extra to reveal for one.
+func displayEnvValue(value, backend string, sensitive, unmask bool) string {
+	if backend != "" {
+		return "\u2192 " + backend + ":" + value
+	}
+	return maskEnvValue(value, sensitive, unmask)
+}
+
 // maskEnvValue is the single source of truth for how an env-var value is
 // displayed anywhere in the CLI (env list/get, deploy analysis, and any future
 // surface). Sensitivity is decided by EVIDENCE, in tiers, and this function
@@ -56,19 +69,6 @@ func maskURLUserinfo(value string) string {
 // literal bytes" — no masking, no escaping — for copying or scripting.
 // Without it, the value is rendered display-safe: control/ANSI sequences are
 // escaped so a malicious value can't corrupt terminal or CI output.
-// displayEnvValue renders what `env list`/`env get` shows for one variable.
-//
-// A backend-sourced variable has no local value to mask: the bytes never
-// travelled here, only the reference did. Showing the reference — backend,
-// path, and the version this config pinned — is both safe and the only useful
-// thing to show, so --unmask has nothing extra to reveal for one.
-func displayEnvValue(value, backend string, sensitive, unmask bool) string {
-	if backend != "" {
-		return "\u2192 " + backend + ":" + value
-	}
-	return maskEnvValue(value, sensitive, unmask)
-}
-
 func maskEnvValue(value string, sensitive, unmask bool) string {
 	if unmask {
 		return value

--- a/cli/commands/env.go
+++ b/cli/commands/env.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/api/deployment/deployment_v1alpha"
+	"miren.dev/runtime/pkg/secret"
 	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
@@ -55,6 +56,19 @@ func maskURLUserinfo(value string) string {
 // literal bytes" — no masking, no escaping — for copying or scripting.
 // Without it, the value is rendered display-safe: control/ANSI sequences are
 // escaped so a malicious value can't corrupt terminal or CI output.
+// displayEnvValue renders what `env list`/`env get` shows for one variable.
+//
+// A backend-sourced variable has no local value to mask: the bytes never
+// travelled here, only the reference did. Showing the reference — backend,
+// path, and the version this config pinned — is both safe and the only useful
+// thing to show, so --unmask has nothing extra to reveal for one.
+func displayEnvValue(value, backend string, sensitive, unmask bool) string {
+	if backend != "" {
+		return "\u2192 " + backend + ":" + value
+	}
+	return maskEnvValue(value, sensitive, unmask)
+}
+
 func maskEnvValue(value string, sensitive, unmask bool) string {
 	if unmask {
 		return value
@@ -185,7 +199,13 @@ func EnvSet(ctx *Context, opts struct {
 	Service   string   `short:"S" long:"service" description:"Set env var for specific service only (if not specified, sets for all services)"`
 	Env       []string `short:"e" long:"env" description:"Set environment variables (use KEY to prompt, KEY=VALUE to set directly, KEY=@file to read from file)"`
 	Sensitive []string `short:"s" long:"sensitive" description:"Set sensitive environment variables (use KEY to prompt with masking, KEY=VALUE to set directly, KEY=@file to read from file)"`
+	Backend   string   `short:"b" long:"backend" description:"Source the value from a secret backend instead of setting it literally (default: cluster, with --ref)"`
+	Ref       string   `long:"ref" description:"Backend-relative reference to the secret, e.g. payments/stripe-key"`
 }) error {
+	if opts.Ref != "" || opts.Backend != "" {
+		return envSetReference(ctx, opts.App, opts.Service, opts.Env, opts.Sensitive, opts.Backend, opts.Ref)
+	}
+
 	if len(opts.Env) == 0 && len(opts.Sensitive) == 0 {
 		return fmt.Errorf("no environment variables specified")
 	}
@@ -220,7 +240,54 @@ func EnvSet(ctx *Context, opts struct {
 		vars = append(vars, ev)
 	}
 
-	res, err := depClient.SetEnvVars(ctx, opts.App, ctx.ClusterName, vars, opts.Service)
+	return applyEnvVars(ctx, depClient, opts.App, opts.Service, vars)
+}
+
+// envSetReference points a variable at a secret backend rather than giving it a
+// literal value. The value itself never travels here: only the reference does,
+// and the server pins it to a concrete version as it mints the new config.
+func envSetReference(ctx *Context, app, service string, env, sensitive []string, backend, ref string) error {
+	keys := append(append([]string{}, env...), sensitive...)
+
+	switch {
+	case ref == "":
+		return fmt.Errorf("--backend needs --ref naming the secret, e.g. --ref payments/stripe-key")
+	case len(keys) != 1:
+		return fmt.Errorf("--ref sets exactly one variable; pass a single -e KEY")
+	case strings.Contains(keys[0], "="):
+		// A literal alongside a reference is a contradiction, and guessing which
+		// one the user meant is how the wrong thing ends up deployed.
+		return fmt.Errorf("use -e KEY with --ref, not KEY=VALUE: the value comes from the backend")
+	}
+
+	if backend == "" {
+		backend = secret.ClusterBackendName
+	}
+
+	depCl, err := ctx.RPCClient("dev.miren.runtime/deployment")
+	if err != nil {
+		return fmt.Errorf("failed to connect to deployment service: %w", err)
+	}
+	depClient := deployment_v1alpha.NewDeploymentClient(depCl)
+
+	ctx.Printf("pointing %s at %s:%s...\n", keys[0], backend, ref)
+
+	ev := &deployment_v1alpha.EnvironmentVariable{}
+	ev.SetKey(keys[0])
+	ev.SetValue(ref)
+	ev.SetBackend(backend)
+	ev.SetSensitive(true)
+
+	return applyEnvVars(ctx, depClient, app, service, []*deployment_v1alpha.EnvironmentVariable{ev})
+}
+
+// applyEnvVars pushes a set of variables and waits for the version they mint to
+// come up healthy, shared by the literal and reference paths so both report the
+// same way.
+func applyEnvVars(ctx *Context, depClient *deployment_v1alpha.DeploymentClient,
+	app, service string, vars []*deployment_v1alpha.EnvironmentVariable) error {
+
+	res, err := depClient.SetEnvVars(ctx, app, ctx.ClusterName, vars, service)
 	if err != nil {
 		return err
 	}
@@ -235,14 +302,14 @@ func EnvSet(ctx *Context, opts struct {
 	}
 
 	versionDisplay := ui.DisplayShortID(res.Deployment().AppVersionShortId(), res.VersionId())
-	ctx.Printf("Setting env vars on %s — new version: %s\n", opts.App, versionDisplay)
+	ctx.Printf("Setting env vars on %s — new version: %s\n", app, versionDisplay)
 
-	if err := awaitHealthy(ctx, opts.App, res.VersionId(), versionDisplay); err != nil {
+	if err := awaitHealthy(ctx, app, res.VersionId(), versionDisplay); err != nil {
 		return err
 	}
 
 	if res.HasAccessInfo() && res.AccessInfo() != nil {
-		displayDeployVersionAccessInfo(ctx, opts.App, res.AccessInfo())
+		displayDeployVersionAccessInfo(ctx, app, res.AccessInfo())
 	}
 
 	return nil
@@ -303,7 +370,7 @@ func EnvGet(ctx *Context, opts struct {
 		}
 	}
 
-	ctx.Printf("%s\n", maskEnvValue(found.Value(), found.Sensitive(), opts.Unmask))
+	ctx.Printf("%s\n", displayEnvValue(found.Value(), found.Backend(), found.Sensitive(), opts.Unmask))
 	return nil
 }
 
@@ -391,7 +458,7 @@ func EnvList(ctx *Context, opts struct {
 		for _, entry := range entries {
 			vars = append(vars, EnvVar{
 				Name:        entry.nv.Key(),
-				Value:       maskEnvValue(entry.nv.Value(), entry.nv.Sensitive(), false),
+				Value:       displayEnvValue(entry.nv.Value(), entry.nv.Backend(), entry.nv.Sensitive(), false),
 				Sensitive:   entry.nv.Sensitive(),
 				Service:     entry.service,
 				Source:      entry.nv.Source(),
@@ -510,7 +577,7 @@ func printEnvTable(ctx *Context, entries []envVarEntry) {
 	// Build rows
 	var rows []ui.Row
 	for _, entry := range entries {
-		value := maskEnvValue(entry.nv.Value(), entry.nv.Sensitive(), false)
+		value := displayEnvValue(entry.nv.Value(), entry.nv.Backend(), entry.nv.Sensitive(), false)
 		// Gray out values we masked so it's clear the redaction is intentional.
 		if value != entry.nv.Value() {
 			value = grayStyle.Render(value)

--- a/cli/commands/server.go
+++ b/cli/commands/server.go
@@ -49,6 +49,7 @@ import (
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/registration"
 	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/secret"
 	"miren.dev/runtime/pkg/serverconfig"
 	"miren.dev/runtime/pkg/units"
 	"miren.dev/runtime/pkg/workloadidentity"
@@ -668,6 +669,12 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 	// publicly trusted certificate. Only federating to an outside party needs
 	// those, and a cluster with no hostname simply has an anchor nobody outside
 	// can resolve.
+	// One registry shared by the coordinator and the runner in this process. The
+	// coordinator registers the in-cluster backend into it once it has an entity
+	// store; the runner then materializes through the same instance rather than
+	// needing its own access to the keyring.
+	secretRegistry := secret.NewRegistry()
+
 	var workloadIssuer *workloadidentity.Issuer
 	{
 		issuerURL := workloadidentity.LocalIssuerURL
@@ -799,6 +806,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 		VictoriametricsAddress:    ctx.ServerState.VictoriametricsAddress,
 		VictorialogsAddress:       ctx.ServerState.VictorialogsAddress,
 		WorkloadIssuer:            workloadIssuer,
+		Secrets:                   secretRegistry,
 		AppVersionRetentionCount:  cfg.AppVersion.GetRetentionCount(),
 		AppVersionRetentionPeriod: appVersionRetentionPeriod,
 		SagaRetentionPeriod:       sagaRetentionPeriod,
@@ -955,6 +963,7 @@ func Server(ctx *Context, opts serverconfig.CLIFlags) error {
 
 	// Build RunnerDeps from ServerState (all dependencies already initialized)
 	deps := runner.RunnerDeps{
+		Secrets:         secretRegistry,
 		CC:              ctx.ServerState.CC,
 		Namespace:       ctx.ServerState.Namespace,
 		Bridge:          ctx.ServerState.Bridge,

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1408,7 +1408,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	}
 	c.schemaReindex.Start(ctx)
 
-	ai := app.NewAppInfo(c.Log, ec, c.Cpu, c.Mem, c.HTTP)
+	ai := app.NewAppInfo(c.Log, ec, c.Cpu, c.Mem, c.HTTP, secretRegistry)
 	server.ExposeValue("dev.miren.runtime/app", app_v1alpha.AdaptCrud(ai))
 	server.ExposeValue("dev.miren.runtime/app-status", app_v1alpha.AdaptAppStatus(ai))
 
@@ -1430,6 +1430,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	bs := build.NewBuilder(c.Log, eac, appClient, addonsClient, c.Resolver, c.TempDir, c.LogWriter, c.CloudAuth.DNSHostname, c.BuildKit, c.DataPath)
 	bs.WorkloadIssuer = c.WorkloadIssuer
+	bs.Secrets = secretRegistry
 
 	var buildHandler build_v1alpha.Builder = bs
 	if labs.Sagas() {
@@ -1451,7 +1452,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	ls := logs.NewServer(c.Log, ec, c.Logs)
 	server.ExposeValue("dev.miren.runtime/logs", app_v1alpha.AdaptLogs(ls))
 
-	ds, err := deployment.NewDeploymentServer(c.Log, eac, ec, appClient, c.CloudAuth.DNSHostname)
+	ds, err := deployment.NewDeploymentServer(c.Log, eac, ec, appClient, c.CloudAuth.DNSHostname, secretRegistry)
 	if err != nil {
 		c.Log.Error("failed to create deployment server", "error", err)
 		return err

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -162,6 +162,13 @@ type CoordinatorConfig struct {
 
 	// WorkloadIssuer signs workload identity tokens for sandbox containers
 	WorkloadIssuer *workloadidentity.Issuer
+
+	// Secrets holds the registered secret backends. The caller builds it so the
+	// runner sharing this process materializes through the same registry the
+	// coordinator pins and serves with. Nil leaves the cluster without a secret
+	// store, in which case a config referencing one fails rather than deploying
+	// without it.
+	Secrets *secret.Registry
 }
 
 // CloudAuthConfig contains cloud authentication settings
@@ -1074,15 +1081,18 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		return err
 	}
 
-	// Set up the secret backend registry. The built-in in-cluster backend is
-	// always present so a team can hold secrets without standing up an external
-	// manager first; externally configured instances register alongside it.
+	// The in-cluster backend needs the entity store, which only exists here, so
+	// the caller supplies an empty registry and this fills it in. Externally
+	// configured instances would register alongside it.
+	secretRegistry := c.Secrets
+	if secretRegistry == nil {
+		secretRegistry = secret.NewRegistry()
+	}
 	secretKeyring, err := keyring.Ensure(c.Log, c.DataPath)
 	if err != nil {
 		c.Log.Error("failed to open secret keyring", "error", err)
 		return err
 	}
-	secretRegistry := secret.NewRegistry()
 	secretBackend := secretcluster.NewBackend(c.Log, ec, secretKeyring)
 	secretRegistry.Register(secretBackend)
 

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1094,7 +1094,10 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		return err
 	}
 	secretBackend := secretcluster.NewBackend(c.Log, ec, secretKeyring)
-	secretRegistry.Register(secretBackend)
+	if err := secretRegistry.Register(secretBackend); err != nil {
+		c.Log.Error("failed to register the in-cluster secret backend", "error", err)
+		return err
+	}
 
 	// Rotation owns the keyring from here: it is the only thing that swaps the
 	// backend's ring, and it persists each new ring before the backend seals

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -45,6 +45,7 @@ import (
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/saga"
+	"miren.dev/runtime/pkg/secret"
 	"miren.dev/runtime/pkg/workloadidentity"
 	"miren.dev/runtime/servers/exec"
 	"miren.dev/runtime/version"
@@ -125,6 +126,13 @@ type RunnerDeps struct {
 	// CACert is the cluster CA in PEM form, mounted into sandboxes so they can
 	// verify the API certificate.
 	CACert []byte
+
+	// Secrets materializes the secret references a sandbox spec carries, at
+	// container creation. On the coordinator this is the local backend
+	// registry, where the keyring lives. A distributed runner holds no key
+	// material, so it must resolve over RPC instead; until that exists, a
+	// sandbox on such a runner fails rather than starting without its secret.
+	Secrets secret.Resolver
 }
 
 const (
@@ -710,6 +718,7 @@ func (r *Runner) SetupControllers(
 		WorkloadIssuer: r.deps.WorkloadIssuer,
 		ApiAddress:     r.deps.ApiAddress,
 		CACert:         r.deps.CACert,
+		Secrets:        r.deps.Secrets,
 	}
 
 	var sbc sandbox.SandboxLifecycle

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -731,7 +731,7 @@ func (l *Launcher) buildSandboxSpec(
 	envMap := make(map[string]string)
 	for _, x := range cfgSpec.Variables {
 		if !isSystemEnvVar(x.Key) {
-			envMap[x.Key] = envValueFor(x.Backend, x.Value)
+			envMap[x.Key] = secret.EnvValue(x.Backend, x.Value)
 		}
 	}
 
@@ -740,7 +740,7 @@ func (l *Launcher) buildSandboxSpec(
 		if svc.Name == serviceName {
 			for _, x := range svc.Env {
 				if !isSystemEnvVar(x.Key) {
-					envMap[x.Key] = envValueFor(x.Backend, x.Value)
+					envMap[x.Key] = secret.EnvValue(x.Backend, x.Value)
 				}
 			}
 			break
@@ -1119,20 +1119,6 @@ func envVarsEqual(env1, env2 []string) bool {
 	}
 
 	return true
-}
-
-// envValueFor renders what a variable contributes to a sandbox spec: its
-// literal value, or — when it is sourced from a secret backend — a reference
-// standing in for the value.
-//
-// The reference carries the concrete version its ConfigVersion pinned, so it
-// changes exactly when the bytes behind it would. That keeps pool reuse honest
-// without the pool comparison ever seeing a secret.
-func envValueFor(backend, value string) string {
-	if backend == "" {
-		return value
-	}
-	return secret.FormatSentinel(backend, value)
 }
 
 // isSystemEnvVar returns true if the given key is a system-managed env var

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -31,6 +31,7 @@ import (
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/types"
 	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/secret"
 )
 
 var launcherTracer = otel.Tracer("miren.dev/runtime/deployment/launcher")
@@ -720,11 +721,17 @@ func (l *Launcher) buildSandboxSpec(
 		appCont.Port = containerPorts
 	}
 
-	// Add user-supplied config env vars, stripping any system-managed keys
+	// Add user-supplied config env vars, stripping any system-managed keys.
+	//
+	// A backend-sourced variable contributes a reference, never a value. This
+	// spec is persisted as part of the sandbox pool entity, so materializing
+	// here would put the plaintext in etcd — the exact thing referencing a
+	// secret instead of inlining it is meant to avoid. The value is substituted
+	// in memory when the container is created.
 	envMap := make(map[string]string)
 	for _, x := range cfgSpec.Variables {
 		if !isSystemEnvVar(x.Key) {
-			envMap[x.Key] = x.Value
+			envMap[x.Key] = envValueFor(x.Backend, x.Value)
 		}
 	}
 
@@ -733,7 +740,7 @@ func (l *Launcher) buildSandboxSpec(
 		if svc.Name == serviceName {
 			for _, x := range svc.Env {
 				if !isSystemEnvVar(x.Key) {
-					envMap[x.Key] = x.Value
+					envMap[x.Key] = envValueFor(x.Backend, x.Value)
 				}
 			}
 			break
@@ -1112,6 +1119,20 @@ func envVarsEqual(env1, env2 []string) bool {
 	}
 
 	return true
+}
+
+// envValueFor renders what a variable contributes to a sandbox spec: its
+// literal value, or — when it is sourced from a secret backend — a reference
+// standing in for the value.
+//
+// The reference carries the concrete version its ConfigVersion pinned, so it
+// changes exactly when the bytes behind it would. That keeps pool reuse honest
+// without the pool comparison ever seeing a secret.
+func envValueFor(backend, value string) string {
+	if backend == "" {
+		return value
+	}
+	return secret.FormatSentinel(backend, value)
 }
 
 // isSystemEnvVar returns true if the given key is a system-managed env var

--- a/controllers/deployment/launcher_secret_test.go
+++ b/controllers/deployment/launcher_secret_test.go
@@ -1,0 +1,124 @@
+package deployment
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/secret"
+)
+
+// deployWithSecretRef stands up an app whose config sources a variable from a
+// secret backend, reconciles it, and returns the pool that resulted.
+func deployWithSecretRef(t *testing.T, pinnedRef string) compute_v1alpha.SandboxPool {
+	t.Helper()
+
+	ctx := context.Background()
+	log := testutils.TestLogger(t)
+
+	server, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	app := &core_v1alpha.App{Project: entity.Id("project-1")}
+	appID, err := server.Client.Create(ctx, "test-app", app)
+	require.NoError(t, err)
+	app.ID = appID
+
+	configVer := &core_v1alpha.ConfigVersion{
+		App: app.ID,
+		Spec: core_v1alpha.ConfigSpec{
+			Variables: []core_v1alpha.ConfigSpecVariables{
+				{Key: "DATABASE_POOL", Value: "10", Source: "manual"},
+				{
+					Key:       "STRIPE_API_KEY",
+					Value:     pinnedRef,
+					Backend:   secret.ClusterBackendName,
+					Source:    "manual",
+					Sensitive: true,
+				},
+			},
+			Services: []core_v1alpha.ConfigSpecServices{{
+				Name:        "web",
+				Concurrency: core_v1alpha.ConfigSpecServicesConcurrency{Mode: "fixed", NumInstances: 1},
+			}},
+		},
+	}
+	cvID, err := server.Client.Create(ctx, "test-cfg", configVer)
+	require.NoError(t, err)
+
+	version := &core_v1alpha.AppVersion{
+		App:           app.ID,
+		Version:       "v1",
+		ImageUrl:      "test:latest",
+		ConfigVersion: cvID,
+	}
+	verID, err := server.Client.Create(ctx, "test-ver", version)
+	require.NoError(t, err)
+	version.ID = verID
+
+	app.ActiveVersion = version.ID
+	require.NoError(t, server.Client.Update(ctx, app))
+
+	launcher := newTestLauncher(log, server.EAC)
+	require.NoError(t, launcher.Reconcile(ctx, app, nil))
+
+	pools := listAllPools(t, ctx, server)
+	require.Len(t, pools, 1)
+	return pools[0]
+}
+
+// The sandbox spec is persisted, so a resolved value written into it would sit
+// in the entity store in plaintext — the exact thing referencing a secret
+// instead of inlining it is meant to prevent. The spec must carry only the
+// reference.
+func TestLauncherWritesSecretReferencesNotValues(t *testing.T) {
+	pool := deployWithSecretRef(t, "payments/stripe-key@x1A")
+
+	var stripeEntry string
+	for _, entry := range pool.SandboxSpec.Container[0].Env {
+		if strings.HasPrefix(entry, "STRIPE_API_KEY=") {
+			stripeEntry = entry
+		}
+	}
+	require.NotEmpty(t, stripeEntry, "the referenced variable should still reach the spec")
+
+	value := strings.TrimPrefix(stripeEntry, "STRIPE_API_KEY=")
+	assert.True(t, secret.IsSentinel(value), "expected a reference, got %q", value)
+
+	backend, ref, ok := secret.ParseSentinel(value)
+	require.True(t, ok)
+	assert.Equal(t, secret.ClusterBackendName, backend)
+
+	// The pinned version rides along, so what the sandbox resolves is exactly
+	// what this ConfigVersion froze.
+	assert.Equal(t, "payments/stripe-key@x1A", ref)
+}
+
+// Belt and braces: nothing anywhere in the persisted pool may contain the
+// secret's value, however the spec is serialized.
+func TestPersistedPoolContainsNoSecretValue(t *testing.T) {
+	pool := deployWithSecretRef(t, "payments/stripe-key@x1A")
+
+	encoded, err := json.Marshal(pool)
+	require.NoError(t, err)
+
+	// The value that would have been resolved had materialization happened here.
+	assert.NotContains(t, string(encoded), "sk_live")
+	assert.Contains(t, string(encoded), secret.SentinelScheme)
+}
+
+// An ordinary inline variable must be entirely unaffected, so a cluster using
+// no secrets sees no change.
+func TestLauncherLeavesInlineVariablesAlone(t *testing.T) {
+	pool := deployWithSecretRef(t, "payments/stripe-key@x1A")
+
+	assert.Contains(t, pool.SandboxSpec.Container[0].Env, "DATABASE_POOL=10")
+}

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -39,6 +39,7 @@ import (
 	"miren.dev/runtime/pkg/imagerefs"
 	"miren.dev/runtime/pkg/netdb"
 	"miren.dev/runtime/pkg/netutil"
+	"miren.dev/runtime/pkg/secret"
 	"miren.dev/runtime/pkg/workloadidentity"
 
 	compute "miren.dev/runtime/api/compute/compute_v1alpha"
@@ -101,6 +102,12 @@ type SandboxControllerDeps struct {
 	// CACert is the cluster CA in PEM form, mounted into sandboxes so they can
 	// verify the API certificate rather than skipping verification.
 	CACert []byte
+
+	// Secrets materializes the secret references a sandbox spec carries, at the
+	// moment a container is created. Nil where no backend is reachable, in which
+	// case a spec that references one fails rather than starting the container
+	// with the reference in place of the value.
+	Secrets secret.Resolver
 }
 
 type SandboxController struct {
@@ -130,6 +137,12 @@ type SandboxController struct {
 	WorkloadIssuer workloadidentity.TokenIssuer
 	ApiAddress     string
 	CACert         []byte
+
+	// Secrets materializes the secret references a sandbox spec carries, at the
+	// moment a container is created. Nil where no backend is reachable, in which
+	// case a spec that references one fails rather than starting the container
+	// with the reference in place of the value.
+	Secrets secret.Resolver
 
 	tokenRefresher *tokenRefresher
 	tokenSecrets   *tokenSecretRegistry
@@ -212,6 +225,7 @@ func NewSandboxController(cfg SandboxControllerDeps) (*SandboxController, error)
 		WorkloadIssuer: cfg.WorkloadIssuer,
 		ApiAddress:     cfg.ApiAddress,
 		CACert:         cfg.CACert,
+		Secrets:        cfg.Secrets,
 	}, nil
 }
 
@@ -2500,8 +2514,20 @@ func (c *SandboxController) buildSubContainerSpec(
 		}
 	}
 
+	// Materialize any secret the spec references. The spec carries references
+	// rather than values precisely so nothing sensitive is at rest in the
+	// entity store; the value comes into being here, in memory, and goes
+	// straight into the container's environment below.
+	//
+	// A failure stops the container from starting. An app handed a reference
+	// where its credential belongs does not fail in a way anyone can read — it
+	// fails much later, inside whatever the credential was for.
+	envVars, err := secret.MaterializeEnv(ctx, c.Secrets, co.Env)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox %s container %s: %w", sb.ID, co.Name, err)
+	}
+
 	// Extract instance number from metadata labels and inject the instance env var
-	envVars := co.Env
 	var md core_v1alpha.Metadata
 	md.Decode(meta)
 

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -27,10 +27,12 @@ func TestSandboxControllerFrozen(t *testing.T) {
 		// Workload identity: BuildSpec mounts the cluster CA and injects
 		// MIREN_IN_CLUSTER/MIREN_API_ADDRESS/MIREN_CA_CERT_PATH, Init opens the
 		// API port on the bridge, and mint now resolves the app's workload role
-		// (resolveAppAndRole) so the token carries it. The saga path needs no
-		// matching edit: it reaches the same code through sandboxOps.BuildSpec,
+		// (resolveAppAndRole) so the token carries it. Secret materialization
+		// also lives under BuildSpec, substituting referenced values in memory
+		// just before the container is created. The saga path needs no matching
+		// edit for either: it reaches the same code through sandboxOps.BuildSpec,
 		// which delegates to SandboxController.BuildSpec.
-		"sandbox.go":  "34fc580340814ca612fadb3e14466f1ea2df5ec9b800dffdf30de285c06f4399",
+		"sandbox.go":  "f7191f5775c675318f63c7fae229578cdc59238949a0487193b8545de59aec7e",
 		"volume.go":   "580062fb8a34f3f7f965689467a4b0f2ed403bc63c1ecdeb44949a7ba7e08dff",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/docs/docs/command/env-set.md
+++ b/docs/docs/command/env-set.md
@@ -24,7 +24,9 @@ miren env set [flags]
 
 ## Flags
 
+- `--backend, -b` — Source the value from a secret backend instead of setting it literally (default: cluster, with --ref)
 - `--env, -e` — Set environment variables (use KEY to prompt, KEY=VALUE to set directly, KEY=@file to read from file)
+- `--ref` — Backend-relative reference to the secret, e.g. payments/stripe-key
 - `--sensitive, -s` — Set sensitive environment variables (use KEY to prompt with masking, KEY=VALUE to set directly, KEY=@file to read from file)
 - `--service, -S` — Set env var for specific service only (if not specified, sets for all services)
 

--- a/pkg/secret/materialize.go
+++ b/pkg/secret/materialize.go
@@ -1,0 +1,66 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// MaterializeEnv replaces every secret placeholder in a KEY=VALUE environment
+// slice with the resolved value, returning a new slice and leaving the input
+// untouched.
+//
+// This is the point of use: the value exists in the returned slice, in memory,
+// and goes straight into the container's process environment. Nothing here
+// writes to disk, and the spec these values came from keeps carrying only
+// references.
+//
+// It fails rather than degrading. An app started with a placeholder where its
+// credential should be does not fail at boot in a way anyone can read — it
+// fails later, deep in whatever the credential was for. A missing resolver, an
+// unknown backend, a revoked version, and an unreadable reference are all
+// errors here, so the failure lands where it can name the variable.
+func MaterializeEnv(ctx context.Context, resolver Resolver, env []string) ([]string, error) {
+	// Most sandboxes reference no secrets at all. Detect that first so the
+	// common path allocates nothing and never needs a resolver.
+	if !containsSentinel(env) {
+		return env, nil
+	}
+
+	out := make([]string, len(env))
+	copy(out, env)
+
+	for i, entry := range env {
+		key, value, found := strings.Cut(entry, "=")
+		if !found || !strings.HasPrefix(value, SentinelScheme) {
+			continue
+		}
+
+		backend, ref, ok := ParseSentinel(value)
+		if !ok {
+			return nil, MalformedSentinelError{Key: key}
+		}
+
+		if resolver == nil {
+			return nil, fmt.Errorf("environment variable %s references secret %s:%s but no secret backends are available here", key, backend, ref)
+		}
+
+		val, err := resolver.ResolveRef(ctx, backend, ref)
+		if err != nil {
+			return nil, fmt.Errorf("cannot materialize environment variable %s: %w", key, err)
+		}
+
+		out[i] = key + "=" + string(val.Bytes)
+	}
+
+	return out, nil
+}
+
+func containsSentinel(env []string) bool {
+	for _, entry := range env {
+		if _, value, found := strings.Cut(entry, "="); found && strings.HasPrefix(value, SentinelScheme) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/secret/materialize_test.go
+++ b/pkg/secret/materialize_test.go
@@ -1,0 +1,166 @@
+package secret
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type envResolver struct {
+	values map[string][]byte
+	err    error
+	calls  int
+}
+
+func (r *envResolver) ResolveRef(ctx context.Context, backend, ref string) (SecretValue, error) {
+	r.calls++
+	if r.err != nil {
+		return SecretValue{}, r.err
+	}
+	val, ok := r.values[backend+"/"+ref]
+	if !ok {
+		return SecretValue{}, ErrNotFound
+	}
+	return SecretValue{Ref: ref, Bytes: val}, nil
+}
+
+func TestFormatAndParseSentinelRoundTrip(t *testing.T) {
+	s := FormatSentinel(ClusterBackendName, "payments/stripe-key@x1A")
+	assert.Equal(t, "miren+secret://cluster/payments/stripe-key@x1A", s)
+
+	backend, ref, ok := ParseSentinel(s)
+	require.True(t, ok)
+	assert.Equal(t, ClusterBackendName, backend)
+	assert.Equal(t, "payments/stripe-key@x1A", ref)
+}
+
+func TestParseSentinelIgnoresOrdinaryValues(t *testing.T) {
+	for _, value := range []string{
+		"",
+		"postgres://localhost/db",
+		"just a value",
+		"miren+secret://",
+		"miren+secret://cluster",
+		"miren+secret:///ref",
+	} {
+		t.Run(value, func(t *testing.T) {
+			_, _, ok := ParseSentinel(value)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestMaterializeEnvSubstitutesReferences(t *testing.T) {
+	r := &envResolver{values: map[string][]byte{
+		"cluster/payments/stripe-key@x1A": []byte("sk_live_abc123"),
+	}}
+
+	env := []string{
+		"PORT=3000",
+		"STRIPE_API_KEY=" + FormatSentinel(ClusterBackendName, "payments/stripe-key@x1A"),
+	}
+
+	out, err := MaterializeEnv(context.Background(), r, env)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"PORT=3000", "STRIPE_API_KEY=sk_live_abc123"}, out)
+}
+
+// The input is what came off a persisted spec, so materializing must not write
+// a value back into it.
+func TestMaterializeEnvLeavesTheInputUntouched(t *testing.T) {
+	r := &envResolver{values: map[string][]byte{
+		"cluster/payments/stripe-key@x1A": []byte("sk_live_abc123"),
+	}}
+
+	sentinel := FormatSentinel(ClusterBackendName, "payments/stripe-key@x1A")
+	env := []string{"STRIPE_API_KEY=" + sentinel}
+
+	_, err := MaterializeEnv(context.Background(), r, env)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"STRIPE_API_KEY=" + sentinel}, env)
+}
+
+// The overwhelmingly common case is a sandbox with no secrets at all, which
+// must neither allocate nor require a resolver.
+func TestMaterializeEnvWithNoReferencesIsAPassThrough(t *testing.T) {
+	env := []string{"PORT=3000", "DATABASE_POOL=10"}
+
+	out, err := MaterializeEnv(context.Background(), nil, env)
+	require.NoError(t, err)
+	assert.Equal(t, env, out)
+}
+
+// A value that happens to contain "=" must survive intact — a URL with a query
+// string is an ordinary env var, not something to re-split.
+func TestMaterializeEnvPreservesValuesContainingEquals(t *testing.T) {
+	r := &envResolver{values: map[string][]byte{
+		"cluster/db/url": []byte("postgres://u:p@h/db?sslmode=require"),
+	}}
+
+	env := []string{
+		"OTHER=a=b=c",
+		"DATABASE_URL=" + FormatSentinel(ClusterBackendName, "db/url"),
+	}
+
+	out, err := MaterializeEnv(context.Background(), r, env)
+	require.NoError(t, err)
+	assert.Equal(t, "OTHER=a=b=c", out[0])
+	assert.Equal(t, "DATABASE_URL=postgres://u:p@h/db?sslmode=require", out[1])
+}
+
+// Starting a container with the reference still in place would hand the app a
+// URL where its credential belongs, and it would fail much later somewhere
+// harder to read. Every way this can go wrong must fail here instead.
+func TestMaterializeEnvFailsClosed(t *testing.T) {
+	sentinel := FormatSentinel(ClusterBackendName, "payments/stripe-key@x1A")
+
+	t.Run("no resolver available", func(t *testing.T) {
+		_, err := MaterializeEnv(context.Background(), nil, []string{"STRIPE_API_KEY=" + sentinel})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "STRIPE_API_KEY")
+	})
+
+	t.Run("secret not found", func(t *testing.T) {
+		r := &envResolver{values: map[string][]byte{}}
+		_, err := MaterializeEnv(context.Background(), r, []string{"STRIPE_API_KEY=" + sentinel})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNotFound)
+		assert.Contains(t, err.Error(), "STRIPE_API_KEY")
+	})
+
+	t.Run("version revoked", func(t *testing.T) {
+		r := &envResolver{err: ErrVersionNotEnabled}
+		_, err := MaterializeEnv(context.Background(), r, []string{"STRIPE_API_KEY=" + sentinel})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrVersionNotEnabled)
+	})
+
+	t.Run("malformed reference", func(t *testing.T) {
+		r := &envResolver{values: map[string][]byte{}}
+		_, err := MaterializeEnv(context.Background(), r, []string{"STRIPE_API_KEY=" + SentinelScheme + "cluster"})
+		require.Error(t, err)
+
+		var malformed MalformedSentinelError
+		require.True(t, errors.As(err, &malformed))
+		assert.Equal(t, "STRIPE_API_KEY", malformed.Key)
+	})
+}
+
+// An error may name the variable an operator has to fix, but never the value it
+// was trying to fetch.
+func TestMaterializeEnvErrorNeverCarriesTheValue(t *testing.T) {
+	const value = "sk_live_abc123"
+	r := &envResolver{
+		values: map[string][]byte{"cluster/payments/stripe-key@x1A": []byte(value)},
+		err:    ErrVersionNotEnabled,
+	}
+
+	_, err := MaterializeEnv(context.Background(), r,
+		[]string{"STRIPE_API_KEY=" + FormatSentinel(ClusterBackendName, "payments/stripe-key@x1A")})
+	require.Error(t, err)
+	assert.False(t, strings.Contains(err.Error(), value))
+}

--- a/pkg/secret/pin.go
+++ b/pkg/secret/pin.go
@@ -1,0 +1,75 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+)
+
+// Reference is one backend-sourced value inside a config, identified well
+// enough to name it in an error without quoting the value.
+type Reference struct {
+	// Backend is the registered instance name the value comes from.
+	Backend string
+
+	// Ref is the backend-relative reference, floating or already pinned.
+	Ref string
+
+	// Key is the variable this reference feeds, for error messages.
+	Key string
+
+	// Service scopes the variable to one service, or is empty for a variable
+	// shared by all of them.
+	Service string
+}
+
+// String renders a reference the way it is written and displayed.
+func (r Reference) String() string {
+	return r.Backend + ":" + r.Ref
+}
+
+// describe names where a reference lives, so a failure says which variable
+// could not be resolved rather than only which secret.
+func (r Reference) describe() string {
+	if r.Service == "" {
+		return fmt.Sprintf("variable %s (%s)", r.Key, r)
+	}
+	return fmt.Sprintf("variable %s of service %s (%s)", r.Key, r.Service, r)
+}
+
+// Pin resolves a set of references and returns the fully-qualified reference
+// each one resolves to, keyed by the same index as the input.
+//
+// It is what freezes a config: an authored reference usually floats, and
+// recording what it resolved to at mint time is how a ConfigVersion becomes
+// answerable for the most sensitive input it carries. Because Resolve returns a
+// concrete version even for an already-pinned input, pinning is idempotent —
+// which is what lets a hand-set reference stay at the version it was set to
+// while an app.toml reference re-pins on every deploy, with no second piece of
+// state to keep in sync.
+//
+// The resolved bytes are deliberately discarded. Pinning happens in the control
+// plane at config-mint time; materializing the value belongs at the point of
+// use, so nothing here can leak into a persisted config.
+//
+// A failure names the variable and the backend, and never the value or the
+// backend's own error text, which can quote surrounding context.
+func Pin(ctx context.Context, resolver Resolver, refs []Reference) ([]string, error) {
+	pinned := make([]string, len(refs))
+
+	for i, ref := range refs {
+		if ref.Backend == "" {
+			return nil, fmt.Errorf("%s has no backend to resolve against", ref.describe())
+		}
+		if ref.Ref == "" {
+			return nil, fmt.Errorf("%s names backend %q but no secret", ref.describe(), ref.Backend)
+		}
+
+		val, err := resolver.ResolveRef(ctx, ref.Backend, ref.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("cannot resolve %s: %w", ref.describe(), err)
+		}
+		pinned[i] = val.Ref
+	}
+
+	return pinned, nil
+}

--- a/pkg/secret/pin_test.go
+++ b/pkg/secret/pin_test.go
@@ -1,0 +1,126 @@
+package secret
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedResolver resolves a floating reference to a named current version and
+// honours an explicit pin, which is the behaviour every backend guarantees.
+type fixedResolver struct {
+	current map[string]string // path -> current version
+	err     error
+	calls   int
+}
+
+func (r *fixedResolver) ResolveRef(ctx context.Context, backend, ref string) (SecretValue, error) {
+	r.calls++
+	if r.err != nil {
+		return SecretValue{}, r.err
+	}
+
+	path, version, err := ParseRef(ref)
+	if err != nil {
+		return SecretValue{}, err
+	}
+	if version == "" {
+		var ok bool
+		version, ok = r.current[path]
+		if !ok {
+			return SecretValue{}, ErrNotFound
+		}
+	}
+
+	return SecretValue{Ref: FormatRef(path, version), Bytes: []byte("value-of-" + path)}, nil
+}
+
+func TestPinResolvesFloatingReferences(t *testing.T) {
+	r := &fixedResolver{current: map[string]string{"payments/stripe-key": "x1A"}}
+
+	pinned, err := Pin(context.Background(), r, []Reference{
+		{Backend: ClusterBackendName, Ref: "payments/stripe-key", Key: "STRIPE_API_KEY"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"payments/stripe-key@x1A"}, pinned)
+}
+
+// Pinning an already-pinned reference must return it unchanged. That identity is
+// what lets a hand-set reference stay put while an app.toml reference re-pins on
+// every deploy, with no second piece of state to keep in sync.
+func TestPinIsIdempotent(t *testing.T) {
+	r := &fixedResolver{current: map[string]string{"payments/stripe-key": "m4Q"}}
+
+	refs := []Reference{{Backend: ClusterBackendName, Ref: "payments/stripe-key@x1A", Key: "STRIPE_API_KEY"}}
+
+	first, err := Pin(context.Background(), r, refs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"payments/stripe-key@x1A"}, first)
+
+	second, err := Pin(context.Background(), r, []Reference{{Backend: ClusterBackendName, Ref: first[0], Key: "STRIPE_API_KEY"}})
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+func TestPinPreservesOrder(t *testing.T) {
+	r := &fixedResolver{current: map[string]string{
+		"a": "1", "b": "2", "c": "3",
+	}}
+
+	pinned, err := Pin(context.Background(), r, []Reference{
+		{Backend: ClusterBackendName, Ref: "a", Key: "A"},
+		{Backend: ClusterBackendName, Ref: "b", Key: "B"},
+		{Backend: ClusterBackendName, Ref: "c", Key: "C"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a@1", "b@2", "c@3"}, pinned)
+}
+
+// A failure has to say which variable could not be resolved, since that is the
+// only thing the operator can act on — and must not quote the value.
+func TestPinErrorNamesTheVariable(t *testing.T) {
+	r := &fixedResolver{current: map[string]string{}}
+
+	_, err := Pin(context.Background(), r, []Reference{
+		{Backend: ClusterBackendName, Ref: "payments/stripe-key", Key: "STRIPE_API_KEY"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "STRIPE_API_KEY")
+	assert.Contains(t, err.Error(), ClusterBackendName)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestPinErrorNamesTheService(t *testing.T) {
+	r := &fixedResolver{current: map[string]string{}}
+
+	_, err := Pin(context.Background(), r, []Reference{
+		{Backend: ClusterBackendName, Ref: "payments/stripe-key", Key: "STRIPE_API_KEY", Service: "worker"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "worker")
+}
+
+func TestPinRejectsIncompleteReferences(t *testing.T) {
+	r := &fixedResolver{current: map[string]string{"a": "1"}}
+
+	t.Run("no backend", func(t *testing.T) {
+		_, err := Pin(context.Background(), r, []Reference{{Ref: "a", Key: "A"}})
+		assert.Error(t, err)
+	})
+
+	t.Run("no secret", func(t *testing.T) {
+		_, err := Pin(context.Background(), r, []Reference{{Backend: ClusterBackendName, Key: "A"}})
+		assert.Error(t, err)
+	})
+}
+
+func TestPinWithNoReferencesNeverCallsTheResolver(t *testing.T) {
+	r := &fixedResolver{current: map[string]string{}}
+
+	pinned, err := Pin(context.Background(), r, nil)
+	require.NoError(t, err)
+	assert.Empty(t, pinned)
+	assert.Zero(t, r.calls)
+}

--- a/pkg/secret/registry.go
+++ b/pkg/secret/registry.go
@@ -32,10 +32,19 @@ func NewRegistry() *Registry {
 
 // Register adds a backend under its own name, replacing any previous
 // registration for that instance.
-func (r *Registry) Register(b SecretBackend) {
+//
+// A name that cannot round-trip through a reference is refused here rather than
+// at resolve time, so a misconfigured instance fails at startup instead of
+// silently resolving the wrong secret later.
+func (r *Registry) Register(b SecretBackend) error {
+	if err := ValidateBackendName(b.Name()); err != nil {
+		return err
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.backends[b.Name()] = b
+	return nil
 }
 
 // Get returns the backend registered under name.

--- a/pkg/secret/registry_test.go
+++ b/pkg/secret/registry_test.go
@@ -136,3 +136,30 @@ func TestRegistryResolveRefErrorNamesRefNotValue(t *testing.T) {
 func TestRegistrySatisfiesResolver(t *testing.T) {
 	var _ Resolver = NewRegistry()
 }
+
+// A backend name has to survive a round trip through a sentinel. The backend
+// and the reference share one string separated by the first "/", so a name
+// containing one would parse back as a different backend and reference — and if
+// both were registered, resolve a different secret.
+func TestRegisterRejectsNamesThatCannotRoundTrip(t *testing.T) {
+	r := NewRegistry()
+
+	for _, name := range []string{"", "team/a", " padded", "padded "} {
+		t.Run(name, func(t *testing.T) {
+			err := r.Register(&readOnlyBackend{name: name})
+			assert.Error(t, err)
+
+			_, ok := r.Get(name)
+			assert.False(t, ok, "a refused backend must not be registered")
+		})
+	}
+}
+
+func TestRegisterAcceptsOrdinaryNames(t *testing.T) {
+	r := NewRegistry()
+
+	for _, name := range []string{ClusterBackendName, "prod-vault", "aws_sm", "vault.eu"} {
+		require.NoError(t, r.Register(&readOnlyBackend{name: name}), name)
+	}
+	assert.Len(t, r.Names(), 4)
+}

--- a/pkg/secret/sentinel.go
+++ b/pkg/secret/sentinel.go
@@ -24,6 +24,19 @@ func FormatSentinel(backend, ref string) string {
 	return SentinelScheme + backend + "/" + ref
 }
 
+// EnvValue renders what a config variable contributes to a sandbox spec: its
+// literal value, or a reference standing in for one when it is backend-sourced.
+//
+// Every path that builds a sandbox spec from a config goes through this, so
+// there is one answer to "does a secret ever get written into a spec?" rather
+// than one per call site.
+func EnvValue(backend, value string) string {
+	if backend == "" {
+		return value
+	}
+	return FormatSentinel(backend, value)
+}
+
 // ParseSentinel splits a placeholder back into its backend and reference.
 // The second return is false for an ordinary value, which is the common case.
 func ParseSentinel(value string) (backend, ref string, ok bool) {

--- a/pkg/secret/sentinel.go
+++ b/pkg/secret/sentinel.go
@@ -5,6 +5,27 @@ import (
 	"strings"
 )
 
+// ValidateBackendName rejects names that cannot survive a round trip through a
+// sentinel.
+//
+// The backend and the reference share one string, separated by the first "/",
+// so a name containing a slash would parse back as a different backend and a
+// different reference — and if both names happened to be registered, resolve a
+// different secret entirely. Rejecting the character is cheaper than encoding
+// around it, and costs nothing real: a backend name is an operator-chosen
+// instance label, not a path.
+func ValidateBackendName(name string) error {
+	switch {
+	case name == "":
+		return fmt.Errorf("secret backend name is empty")
+	case strings.Contains(name, "/"):
+		return fmt.Errorf("secret backend name %q cannot contain %q", name, "/")
+	case strings.TrimSpace(name) != name:
+		return fmt.Errorf("secret backend name %q cannot have leading or trailing whitespace", name)
+	}
+	return nil
+}
+
 // SentinelScheme prefixes an environment value that names a secret rather than
 // holding one.
 const SentinelScheme = "miren+secret://"

--- a/pkg/secret/sentinel.go
+++ b/pkg/secret/sentinel.go
@@ -1,0 +1,59 @@
+package secret
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SentinelScheme prefixes an environment value that names a secret rather than
+// holding one.
+const SentinelScheme = "miren+secret://"
+
+// FormatSentinel renders a reference as the placeholder that stands in for a
+// value inside a sandbox spec.
+//
+// A sandbox spec is a persisted entity, so a resolved value written into it
+// would sit in etcd in plaintext — exactly what referencing a secret is meant
+// to avoid. The spec therefore carries this placeholder, and the value is
+// substituted in memory at the moment the container is created.
+//
+// It doubles as the unit of change detection for pool reuse: the reference
+// carries a concrete version, so it differs precisely when the bytes behind it
+// would differ.
+func FormatSentinel(backend, ref string) string {
+	return SentinelScheme + backend + "/" + ref
+}
+
+// ParseSentinel splits a placeholder back into its backend and reference.
+// The second return is false for an ordinary value, which is the common case.
+func ParseSentinel(value string) (backend, ref string, ok bool) {
+	rest, found := strings.CutPrefix(value, SentinelScheme)
+	if !found {
+		return "", "", false
+	}
+
+	backend, ref, found = strings.Cut(rest, "/")
+	if !found || backend == "" || ref == "" {
+		return "", "", false
+	}
+	return backend, ref, true
+}
+
+// IsSentinel reports whether a value names a secret rather than holding one.
+func IsSentinel(value string) bool {
+	_, _, ok := ParseSentinel(value)
+	return ok
+}
+
+// MalformedSentinelError reports a placeholder that carries the scheme but does
+// not parse. It is deliberately distinct from "not a placeholder": a value that
+// looks like a reference and cannot be read is a bug or a tampered spec, and
+// starting the container with it verbatim would hand the app a URL where its
+// credential should be.
+type MalformedSentinelError struct {
+	Key string
+}
+
+func (e MalformedSentinelError) Error() string {
+	return fmt.Sprintf("environment variable %s names a secret but the reference could not be read", e.Key)
+}

--- a/pkg/secret/sentinel_test.go
+++ b/pkg/secret/sentinel_test.go
@@ -1,0 +1,43 @@
+package secret
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateBackendName(t *testing.T) {
+	for _, name := range []string{ClusterBackendName, "prod-vault", "aws_sm", "vault.eu", "A1"} {
+		assert.NoError(t, ValidateBackendName(name), name)
+	}
+
+	for _, name := range []string{"", "team/a", "/leading", "trailing/", " padded", "padded "} {
+		assert.Error(t, ValidateBackendName(name), name)
+	}
+}
+
+// The ambiguity this guards against: with a slash in the name, format and parse
+// disagree about where the backend ends.
+func TestSentinelRoundTripIsUnambiguousForValidNames(t *testing.T) {
+	const ref = "payments/stripe-key@x1A"
+
+	for _, name := range []string{ClusterBackendName, "prod-vault", "vault.eu"} {
+		require.NoError(t, ValidateBackendName(name))
+
+		backend, got, ok := ParseSentinel(FormatSentinel(name, ref))
+		require.True(t, ok, name)
+		assert.Equal(t, name, backend)
+		assert.Equal(t, ref, got)
+	}
+
+	// Demonstrates why the name is validated rather than encoded around: this
+	// one does not round-trip, which is exactly what ValidateBackendName stops
+	// from ever reaching a sentinel.
+	backend, got, ok := ParseSentinel(FormatSentinel("team/a", ref))
+	require.True(t, ok)
+	assert.NotEqual(t, "team/a", backend)
+	assert.Equal(t, "team", backend)
+	assert.Equal(t, "a/"+ref, got)
+	assert.Error(t, ValidateBackendName("team/a"))
+}

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -23,6 +23,7 @@ import (
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/secret"
 	"miren.dev/runtime/pkg/ui"
 	"miren.dev/runtime/pkg/workloadroles"
 )
@@ -42,9 +43,13 @@ type AppInfo struct {
 	CPU  *metrics.CPUUsage
 	Mem  *metrics.MemoryUsage
 	HTTP *metrics.HTTPMetrics
+
+	// Secrets resolves backend-sourced variables so a ConfigVersion minted by an
+	// env change records the exact secret version it saw.
+	Secrets secret.Resolver
 }
 
-func NewAppInfo(log *slog.Logger, ec *entityserver.Client, cpu *metrics.CPUUsage, mem *metrics.MemoryUsage, http *metrics.HTTPMetrics) *AppInfo {
+func NewAppInfo(log *slog.Logger, ec *entityserver.Client, cpu *metrics.CPUUsage, mem *metrics.MemoryUsage, http *metrics.HTTPMetrics, secrets secret.Resolver) *AppInfo {
 	return &AppInfo{
 		Log:  log,
 		CV:   nil,
@@ -52,6 +57,8 @@ func NewAppInfo(log *slog.Logger, ec *entityserver.Client, cpu *metrics.CPUUsage
 		CPU:  cpu,
 		Mem:  mem,
 		HTTP: http,
+
+		Secrets: secrets,
 	}
 }
 
@@ -650,7 +657,7 @@ func (r *AppInfo) SetWorkloadRole(ctx context.Context, state *app_v1alpha.CrudSe
 }
 
 func (r *AppInfo) setEnvVars(ctx context.Context, name string, vars []appclient.EnvVarInput, service string) (string, error) {
-	result, err := appclient.SetEnvVars(ctx, r.EC, name, nil, vars, service)
+	result, err := appclient.SetEnvVars(ctx, r.EC, r.Secrets, name, nil, vars, service)
 	if err != nil {
 		return "", err
 	}
@@ -726,7 +733,7 @@ func (r *AppInfo) SetInitialEnvVars(ctx context.Context, state *app_v1alpha.Crud
 		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive()}
 	}
 
-	cvid, err := appclient.SetInitialEnvVars(ctx, r.EC, args.App(), vars, args.Service())
+	cvid, err := appclient.SetInitialEnvVars(ctx, r.EC, r.Secrets, args.App(), vars, args.Service())
 	if err != nil {
 		return err
 	}
@@ -742,7 +749,7 @@ func (r *AppInfo) DeleteEnvVar(ctx context.Context, state *app_v1alpha.CrudDelet
 		return rpc.AppAccessError(ctx, args.App())
 	}
 
-	result, err := appclient.DeleteEnvVars(ctx, r.EC, args.App(), nil, []string{args.Key()}, args.Service())
+	result, err := appclient.DeleteEnvVars(ctx, r.EC, r.Secrets, args.App(), nil, []string{args.Key()}, args.Service())
 	if err != nil {
 		return err
 	}

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -535,6 +535,7 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 		env.SetSource(ev.Source)
 		env.SetRequired(ev.Required)
 		env.SetDescription(ev.Description)
+		env.SetBackend(ev.Backend)
 		envVars = append(envVars, &env)
 	}
 
@@ -563,6 +564,7 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 				env.SetSource(ev.Source)
 				env.SetRequired(ev.Required)
 				env.SetDescription(ev.Description)
+				env.SetBackend(ev.Backend)
 				svcEnvVars = append(svcEnvVars, &env)
 			}
 			sc.SetServiceEnv(svcEnvVars)

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -367,6 +367,7 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 					Source:      source,
 					Required:    ev.Required(),
 					Description: ev.Description(),
+					Backend:     ev.Backend(),
 				}
 				spec.Variables = append(spec.Variables, nv)
 			}
@@ -399,6 +400,7 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 									Source:      source,
 									Required:    ev.Required(),
 									Description: ev.Description(),
+									Backend:     ev.Backend(),
 								}
 								spec.Services[i].Env = append(spec.Services[i].Env, nv)
 							}
@@ -421,6 +423,7 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 							Source:      source,
 							Required:    ev.Required(),
 							Description: ev.Description(),
+							Backend:     ev.Backend(),
 						}
 						svc.Env = append(svc.Env, nv)
 					}
@@ -702,7 +705,7 @@ func (r *AppInfo) SetEnvVars(ctx context.Context, state *app_v1alpha.CrudSetEnvV
 
 	vars := make([]appclient.EnvVarInput, len(rpcVars))
 	for i, v := range rpcVars {
-		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive()}
+		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive(), Backend: v.Backend()}
 	}
 
 	versionId, err := r.setEnvVars(ctx, args.App(), vars, args.Service())
@@ -732,7 +735,7 @@ func (r *AppInfo) SetInitialEnvVars(ctx context.Context, state *app_v1alpha.Crud
 
 	vars := make([]appclient.EnvVarInput, len(rpcVars))
 	for i, v := range rpcVars {
-		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive()}
+		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive(), Backend: v.Backend()}
 	}
 
 	cvid, err := appclient.SetInitialEnvVars(ctx, r.EC, r.Secrets, args.App(), vars, args.Service())

--- a/servers/app/app_test.go
+++ b/servers/app/app_test.go
@@ -5,13 +5,17 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"miren.dev/runtime/api/app/app_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/metrics"
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
 	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/secret"
 )
 
 func TestSetConfiguration_DuplicateEnvVars(t *testing.T) {
@@ -1315,4 +1319,141 @@ func TestSetInitialEnvVars(t *testing.T) {
 			t.Fatalf("expected WORKER_TOKEN in worker service, got %+v", cv.Spec.Services[0].Env)
 		}
 	})
+}
+
+// pinningResolver resolves any reference to itself, which is all this test
+// needs: it is about the backend field surviving, not about what it resolves to.
+type pinningResolver struct{}
+
+func (pinningResolver) ResolveRef(ctx context.Context, backend, ref string) (secret.SecretValue, error) {
+	return secret.SecretValue{Ref: ref, Bytes: []byte("value")}, nil
+}
+
+// A variable that loses its backend on the way in becomes an ordinary literal
+// holding a reference path, and every guard downstream then reads it as fine:
+// nothing pins it, nothing materializes it, and the app receives the path text
+// where its credential belongs. Silent by construction, so it is worth pinning
+// down at each write path rather than trusting the next caller to notice.
+func TestConfigWritePathsPreserveTheSecretBackend(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+
+	appInfo := &AppInfo{
+		Log:     slog.Default(),
+		EC:      ec,
+		CPU:     &metrics.CPUUsage{},
+		Mem:     &metrics.MemoryUsage{},
+		HTTP:    &metrics.HTTPMetrics{},
+		Secrets: pinningResolver{},
+	}
+
+	client := &app_v1alpha.CrudClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptCrud(appInfo)),
+	}
+
+	appName := "test-backend-passthrough"
+	_, err := inmem.Client.Create(ctx, appName, &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	reference := func(key string) *app_v1alpha.NamedValue {
+		nv := &app_v1alpha.NamedValue{}
+		nv.SetKey(key)
+		nv.SetValue("payments/stripe-key@x1A")
+		nv.SetSensitive(true)
+		nv.SetBackend("cluster")
+		return nv
+	}
+
+	// SetConfiguration rebuilds the variable list wholesale from what the
+	// client sent, for both shared and per-service variables.
+	svc := &app_v1alpha.ServiceConfig{}
+	svc.SetService("worker")
+	svc.SetServiceEnv([]*app_v1alpha.NamedValue{reference("WORKER_SECRET")})
+
+	cfg := &app_v1alpha.Configuration{}
+	cfg.SetEnvVars([]*app_v1alpha.NamedValue{reference("STRIPE_API_KEY")})
+	cfg.SetServices([]*app_v1alpha.ServiceConfig{svc})
+
+	_, err = client.SetConfiguration(ctx, appName, cfg)
+	require.NoError(t, err)
+
+	var appRec core_v1alpha.App
+	require.NoError(t, ec.Get(ctx, appName, &appRec))
+
+	var appVer core_v1alpha.AppVersion
+	require.NoError(t, ec.GetById(ctx, appRec.ActiveVersion, &appVer))
+
+	stored, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVer)
+	require.NoError(t, err)
+
+	require.Len(t, stored.Variables, 1)
+	assert.Equal(t, "cluster", stored.Variables[0].Backend,
+		"the backend must survive SetConfiguration, or the reference becomes a literal")
+
+	require.Len(t, stored.Services, 1)
+	require.Len(t, stored.Services[0].Env, 1)
+	assert.Equal(t, "cluster", stored.Services[0].Env[0].Backend,
+		"the backend must survive the per-service write path too")
+
+	// And it must come back out again, so a round trip through the API does not
+	// quietly drop it either.
+	read, err := client.GetConfiguration(ctx, appName)
+	require.NoError(t, err)
+
+	var found bool
+	for _, ev := range read.Configuration().EnvVars() {
+		if ev.Key() == "STRIPE_API_KEY" {
+			found = true
+			assert.Equal(t, "cluster", ev.Backend())
+		}
+	}
+	assert.True(t, found, "the referenced variable should be readable back")
+}
+
+// The EnvVarInput adapters are the other way a reference reaches config, and
+// they drop the backend just as silently if it is not carried across.
+func TestSetInitialEnvVarsPreservesTheSecretBackend(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+
+	appInfo := &AppInfo{
+		Log:     slog.Default(),
+		EC:      ec,
+		CPU:     &metrics.CPUUsage{},
+		Mem:     &metrics.MemoryUsage{},
+		HTTP:    &metrics.HTTPMetrics{},
+		Secrets: pinningResolver{},
+	}
+
+	client := &app_v1alpha.CrudClient{
+		Client: rpc.LocalClient(app_v1alpha.AdaptCrud(appInfo)),
+	}
+
+	appName := "test-backend-initial"
+	_, err := inmem.Client.Create(ctx, appName, &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	nv := &app_v1alpha.NamedValue{}
+	nv.SetKey("STRIPE_API_KEY")
+	nv.SetValue("payments/stripe-key@x1A")
+	nv.SetSensitive(true)
+	nv.SetBackend("cluster")
+
+	res, err := client.SetInitialEnvVars(ctx, appName, []*app_v1alpha.NamedValue{nv}, "")
+	require.NoError(t, err)
+
+	var cv core_v1alpha.ConfigVersion
+	require.NoError(t, ec.GetById(ctx, entity.Id(res.ConfigVersionId()), &cv))
+
+	require.Len(t, cv.Spec.Variables, 1)
+	assert.Equal(t, "cluster", cv.Spec.Variables[0].Backend)
+	assert.Equal(t, "payments/stripe-key@x1A", cv.Spec.Variables[0].Value)
 }

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -42,6 +42,7 @@ import (
 	"miren.dev/runtime/pkg/procfile"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/stream"
+	"miren.dev/runtime/pkg/secret"
 	"miren.dev/runtime/pkg/stackbuild"
 	"miren.dev/runtime/pkg/tarx"
 	"miren.dev/runtime/pkg/workloadidentity"
@@ -111,6 +112,12 @@ type Builder struct {
 	BuildKit BuildKitProvider
 
 	WorkloadIssuer *workloadidentity.Issuer
+
+	// Secrets resolves backend-sourced variables so a minted ConfigVersion
+	// records the exact secret version it saw. Nil on a cluster with no secret
+	// backends registered, in which case a config that references one fails
+	// rather than silently deploying without it.
+	Secrets secret.Resolver
 
 	// deploy owns the server-side deployment record lifecycle for builds whose
 	// client asked the server to manage it. It is an in-process wrapper over the
@@ -1434,6 +1441,15 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 	createVerCtx, createVerSpan := buildTracer.Start(ctx, "build.create_version",
 		trace.WithAttributes(attribute.String("miren.app.version", mrv.Version)))
 
+	// Freeze every backend-sourced variable to the version it resolves to right
+	// now, so this ConfigVersion records exactly which secret it shipped with.
+	if err := b.pinSecrets(createVerCtx, &configSpec); err != nil {
+		createVerSpan.RecordError(err)
+		createVerSpan.SetStatus(codes.Error, err.Error())
+		createVerSpan.End()
+		return nil, err
+	}
+
 	// Create ConfigVersion as the sole config store (inline Config is no longer written)
 	configVer := &core_v1alpha.ConfigVersion{
 		App:  mrv.App,
@@ -1533,6 +1549,27 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 		versionShortId: versionShortId,
 		accessInfo:     accessInfo,
 	}, nil
+}
+
+// pinSecrets rewrites every backend-sourced variable in the spec to the exact
+// version it resolves to, so the ConfigVersion about to be minted records what
+// the deploy actually shipped with rather than a floating reference.
+//
+// A config with no such variables never needs a resolver, which keeps a cluster
+// that has no secret backends registered working exactly as before. One that
+// does reference a backend fails the deploy rather than starting an app whose
+// credential silently never arrived.
+func (b *Builder) pinSecrets(ctx context.Context, spec *core_v1alpha.ConfigSpec) error {
+	refs := coreutil.SecretReferences(spec)
+	if len(refs) == 0 {
+		return nil
+	}
+
+	if b.Secrets == nil {
+		return fmt.Errorf("config references secret %s but this cluster has no secret backends configured", refs[0])
+	}
+
+	return coreutil.PinSecrets(ctx, b.Secrets, spec)
 }
 
 // getAccessInfo queries routes to determine how the app can be accessed.

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -518,13 +518,19 @@ func buildServicesConfig(appConfig *appconfig.AppConfig, procfileServices map[st
 			if len(serviceConfig.EnvVars) > 0 {
 				svc.Env = make([]core_v1alpha.ConfigSpecServicesEnv, 0, len(serviceConfig.EnvVars))
 				for _, envVar := range serviceConfig.EnvVars {
+					value, backend, sensitive := envVar.Value, envVar.Backend, envVar.Sensitive
+					if backend != "" {
+						value, sensitive = envVar.Ref, true
+					}
+
 					svc.Env = append(svc.Env, core_v1alpha.ConfigSpecServicesEnv{
 						Key:         envVar.Key,
-						Value:       envVar.Value,
-						Sensitive:   envVar.Sensitive,
+						Value:       value,
+						Sensitive:   sensitive,
 						Required:    envVar.Required,
 						Description: envVar.Description,
 						Source:      "config",
+						Backend:     backend,
 					})
 				}
 			}
@@ -625,13 +631,22 @@ func buildVariablesFromAppConfig(appConfig *appconfig.AppConfig) []core_v1alpha.
 
 	variables := make([]core_v1alpha.ConfigSpecVariables, 0, len(appConfig.EnvVars))
 	for _, envVar := range appConfig.EnvVars {
+		value, backend, sensitive := envVar.Value, envVar.Backend, envVar.Sensitive
+		if backend != "" {
+			// A referenced secret carries its reference where an inline value
+			// would go, and is sensitive by construction: it exists precisely
+			// because the real value is not fit to sit in config.
+			value, sensitive = envVar.Ref, true
+		}
+
 		variables = append(variables, core_v1alpha.ConfigSpecVariables{
 			Key:         envVar.Key,
-			Value:       envVar.Value,
-			Sensitive:   envVar.Sensitive,
+			Value:       value,
+			Sensitive:   sensitive,
 			Required:    envVar.Required,
 			Description: envVar.Description,
 			Source:      "config",
+			Backend:     backend,
 		})
 	}
 	return variables
@@ -712,6 +727,10 @@ func mergeCliEnvVars(existingVars []core_v1alpha.ConfigSpecVariables, cliVars []
 
 	// CLI vars always override (marked as user-provided).
 	// Preserve Required/Description metadata from existing vars (e.g. from app.toml).
+	//
+	// Backend is deliberately not preserved: `-e KEY=VALUE` supplies a literal,
+	// so it replaces a secret reference on that key outright rather than being
+	// read as a new reference into whatever backend the old value named.
 	for _, cv := range cliVars {
 		newVar := core_v1alpha.ConfigSpecVariables{
 			Key:       cv.Key(),

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -385,6 +385,15 @@ func createConfigVersion(ctx context.Context, in createConfigVersionIn) (createC
 		return createConfigVersionOut{}, fmt.Errorf("deserializing config spec: %w", err)
 	}
 
+	// Freeze every backend-sourced variable to the version it resolves to right
+	// now, so this ConfigVersion records exactly which secret it shipped with.
+	// Pinning happens here rather than upstream in the saga because the action
+	// that stores the spec must be the one that records the pin: whichever
+	// version this attempt resolves is the version the config it writes claims.
+	if err := b.pinSecrets(ctx, &spec); err != nil {
+		return createConfigVersionOut{}, err
+	}
+
 	cv := &core_v1alpha.ConfigVersion{
 		App:  entity.Id(in.AppID),
 		Spec: spec,

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -21,6 +21,7 @@ import (
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/standard"
+	"miren.dev/runtime/pkg/secret"
 )
 
 type DeploymentServer struct {
@@ -31,6 +32,10 @@ type DeploymentServer struct {
 	IngressClient *ingress.Client
 	DNSHostname   string
 
+	// Secrets resolves backend-sourced variables so a ConfigVersion minted by an
+	// env change records the exact secret version it saw.
+	Secrets secret.Resolver
+
 	// tracker owns the deployment record state machine and the deploy lock. The
 	// build server holds its own Tracker over the same entity store, and both
 	// acquire the same app-scoped lock, so a client that drives a record through
@@ -40,7 +45,7 @@ type DeploymentServer struct {
 
 var _ deployment_v1alpha.Deployment = (*DeploymentServer)(nil)
 
-func NewDeploymentServer(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, ec *aes.Client, appClient *appclient.Client, dnsHostname string) (*DeploymentServer, error) {
+func NewDeploymentServer(log *slog.Logger, eac *entityserver_v1alpha.EntityAccessClient, ec *aes.Client, appClient *appclient.Client, dnsHostname string, secrets secret.Resolver) (*DeploymentServer, error) {
 	return &DeploymentServer{
 		Log:           log.With("module", "deployment"),
 		EAC:           eac,
@@ -48,6 +53,7 @@ func NewDeploymentServer(log *slog.Logger, eac *entityserver_v1alpha.EntityAcces
 		AppClient:     appClient,
 		IngressClient: ingress.NewClient(log, eac),
 		DNSHostname:   dnsHostname,
+		Secrets:       secrets,
 		tracker:       deploylifecycle.NewTracker(log, eac),
 	}, nil
 }
@@ -991,7 +997,7 @@ func (d *DeploymentServer) SetEnvVars(ctx context.Context, req *deployment_v1alp
 	}
 
 	// Call shared helper to create new version
-	mutResult, err := appclient.SetEnvVars(ctx, d.EC, appName, nil, vars, service)
+	mutResult, err := appclient.SetEnvVars(ctx, d.EC, d.Secrets, appName, nil, vars, service)
 	if err != nil {
 		d.Log.Error("Failed to set env vars", "error", err, "app", appName)
 		results.SetError(fmt.Sprintf("failed to set env vars: %v", err))
@@ -1036,7 +1042,7 @@ func (d *DeploymentServer) DeleteEnvVars(ctx context.Context, req *deployment_v1
 	}
 
 	// Call shared helper to create new version
-	delResult, err := appclient.DeleteEnvVars(ctx, d.EC, appName, nil, args.Keys(), service)
+	delResult, err := appclient.DeleteEnvVars(ctx, d.EC, d.Secrets, appName, nil, args.Keys(), service)
 	if err != nil {
 		d.Log.Error("Failed to delete env vars", "error", err, "app", appName)
 		results.SetError(fmt.Sprintf("failed to delete env vars: %v", err))

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -993,7 +993,7 @@ func (d *DeploymentServer) SetEnvVars(ctx context.Context, req *deployment_v1alp
 	// Convert RPC vars to shared helper input
 	vars := make([]appclient.EnvVarInput, len(args.Vars()))
 	for i, v := range args.Vars() {
-		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive()}
+		vars[i] = appclient.EnvVarInput{Key: v.Key(), Value: v.Value(), Sensitive: v.Sensitive(), Backend: v.Backend()}
 	}
 
 	// Call shared helper to create new version

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -25,7 +25,7 @@ func newTestDeploymentServer(t *testing.T, logger *slog.Logger, inmem *testutils
 	localClient := rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(inmem.Server))
 	ec := aes.NewClient(logger, inmem.EAC)
 	ac := appclient.NewClient(logger, localClient)
-	return NewDeploymentServer(logger, inmem.EAC, ec, ac, "")
+	return NewDeploymentServer(logger, inmem.EAC, ec, ac, "", nil)
 }
 
 func TestCreateDeploymentWithGitInfo(t *testing.T) {

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -19,6 +19,7 @@ import (
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/stream"
+	"miren.dev/runtime/pkg/secret"
 )
 
 type Server struct {
@@ -406,12 +407,16 @@ func (s *Server) buildSandboxSpec(
 	// Add global config env vars, stripping any reserved MIREN_ keys so user
 	// config can't shadow the injected sandbox metadata above (mirrors the
 	// filter in controllers/deployment/launcher.go).
+	//
+	// A backend-sourced variable contributes a reference here too, for the same
+	// reason it does on the deploy path: this spec is persisted, and the sandbox
+	// controller materializes the value in memory at container creation.
 	envMap := make(map[string]string)
 	for _, x := range cfgSpec.Variables {
 		if appclient.IsReservedEnvVar(x.Key) {
 			continue
 		}
-		envMap[x.Key] = x.Value
+		envMap[x.Key] = secret.EnvValue(x.Backend, x.Value)
 	}
 
 	// Convert map to env var slice


### PR DESCRIPTION
Second of three stacked PRs implementing [RFD-90: Secret Backends and Materialization](https://github.com/mirendev/rfd/blob/main/rfds/0075/0090-secret-backends-and-materialization.md) ([MIR-1343](https://linear.app/miren/issue/MIR-1343)). Stacked on #1027, which built the storage half.

This PR makes a stored secret consumable by an app: a variable can point at a backend instead of holding a value, and the value arrives in the container's environment without ever being written down.

## Pinning

An authored reference usually floats — `payments/stripe-key`, meaning whatever is current. What a ConfigVersion records is what that resolved to at mint time: `payments/stripe-key@x1A`. This makes "which secret did this version actually ship with?" answerable for the most sensitive input a deploy has, and it makes a rollback come back on the value the old version ran with rather than today's.

Pinning is idempotent, because resolving an already-pinned reference returns the same reference. That single property is what lets a hand-set reference stay at the version it was set to while an `app.toml` reference re-pins on every deploy, with **no second piece of state to keep in sync**.

Per the RFD's open question, `miren env set` **pins at set-time**. A rotation therefore reaches a hand-set variable when you re-run `env set`, and reaches an `app.toml` reference on the next `miren deploy`.

## Not writing secrets down

A sandbox spec is a persisted entity. Resolving a secret while building it would put the plaintext in etcd — the exact thing referencing a secret rather than inlining it is meant to prevent. So the spec carries a reference, and the value comes into being in the sandbox controller at container creation, on its way into the process environment.

The reference doubles as the unit of change detection for pool reuse: it carries a concrete version, so it differs precisely when the bytes behind it would differ, without the pool comparison ever seeing a secret.

Two paths build sandbox specs — the deploy launcher and exec sandboxes — and initially I only fixed the first, which showed up as `miren app run -- printenv` printing a path where a credential belonged. Both now go through one function, so "does a secret ever get written into a spec?" has a single answer rather than one per call site.

## Failing closed

Materialization fails rather than degrading. An app handed a reference where its credential belongs does not fail at boot in a way anyone can read — it fails much later, inside whatever the credential was for. A missing resolver, an unknown backend, a revoked version, and an unreadable reference all stop the container, where the error can name the variable. Errors name the variable and the backend, never the value.

A config that references no backend never touches a resolver at all, so a cluster with no secrets in play pays nothing and cannot fail here.

## Authoring

```bash
miren env set -e STRIPE_API_KEY --backend cluster --ref payments/stripe-key
```

```toml
[[env]]
key = "STRIPE_API_KEY"
backend = "cluster"
ref = "payments/stripe-key"
```

**Deviation from the RFD, flagged deliberately**: RFD-90's examples use an `[env]` map form (`KEY = { backend = …, ref = … }`). The shipped format is `[[env]]` array-of-tables, so this follows the shipped format rather than introducing a second one.

A reference replaces the value rather than accompanying it, so supplying both is rejected: guessing which was meant is how a literal path ends up deployed where a credential belongs. `env list` shows the reference and its pin rather than a mask, since there is nothing local to hide.

## Note for reviewers

The frozen-`sandbox.go` guard asks for an audit of the saga path before rehashing. Both the direct and saga paths reach container creation through `SandboxController.BuildSpec`, and the materialization sits inside `buildSubContainerSpec` beneath it, so the saga controller picks up the same behavior with no parallel change. The last commit is just that rehash.

## Testing

Unit coverage for pinning (including idempotence and fail-closed), sentinel parsing, and env materialization. A launcher test asserts that a persisted sandbox pool contains only references and no resolved value, however the spec is serialized.

Verified end to end in the dev environment against a real app:

- `secret set` → `env set --backend --ref` → deploy → the app serves the real value
- rotating the secret leaves the running app untouched; re-running `env set` re-pins and rolls it out
- an `app.toml` reference floats and re-pins on a plain `miren deploy`
- `miren app run -- printenv` materializes (this is what caught the second spec path)
- disabling the pinned version makes the next deploy fail closed: `cannot resolve variable STRIPE_API_KEY (cluster:payments/stripe-key): secret version is not enabled` — while the already-running app keeps serving
- entity inspection shows each ConfigVersion permanently recording its own pin (`@QEa`, `@Bvm`, `@oSX`), which is what makes rollback restore the right secret

Full suite green (5667 tests).

## What's next

**PR 3** — runner-node resolution over RPC (required: a distributed runner holds no key material today), tmpfs file secrets, version reaping that respects pins, and docs.