### PR TITLE
Secrets on distributed runners, version reaping, and docs

### DIFF
--- a/api/secret/rpc.yml
+++ b/api/secret/rpc.yml
@@ -137,6 +137,24 @@ interfaces:
           - name: to_key
             type: string
 
+      # Resolve a reference to its value. This is how a node holding no key
+      # material materializes a secret: the bytes are decrypted where the
+      # keyring lives and travel to the caller, which holds them in memory only
+      # for as long as it takes to hand them to a container.
+      - name: resolve
+        parameters:
+          - name: backend
+            type: string
+            optional: true
+          - name: ref
+            type: string
+        results:
+          - name: ref
+            type: string
+            doc: The fully-qualified reference the input resolved to
+          - name: value
+            type: bytes
+
       # Transition one version between enabled, disabled and destroyed.
       # Anything still pinned to a version that leaves enabled fails closed on
       # its next resolve.

--- a/api/secret/secret_v1alpha/rpc.gen.go
+++ b/api/secret/secret_v1alpha/rpc.gen.go
@@ -633,6 +633,89 @@ func (v *SecretsRotateKeyResults) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &v.data)
 }
 
+type secretsResolveArgsData struct {
+	Backend *string `cbor:"0,keyasint,omitempty" json:"backend,omitempty"`
+	Ref     *string `cbor:"1,keyasint,omitempty" json:"ref,omitempty"`
+}
+
+type SecretsResolveArgs struct {
+	call rpc.Call
+	data secretsResolveArgsData
+}
+
+func (v *SecretsResolveArgs) HasBackend() bool {
+	return v.data.Backend != nil
+}
+
+func (v *SecretsResolveArgs) Backend() string {
+	if v.data.Backend == nil {
+		return ""
+	}
+	return *v.data.Backend
+}
+
+func (v *SecretsResolveArgs) HasRef() bool {
+	return v.data.Ref != nil
+}
+
+func (v *SecretsResolveArgs) Ref() string {
+	if v.data.Ref == nil {
+		return ""
+	}
+	return *v.data.Ref
+}
+
+func (v *SecretsResolveArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *SecretsResolveArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *SecretsResolveArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *SecretsResolveArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type secretsResolveResultsData struct {
+	Ref   *string `cbor:"0,keyasint,omitempty" json:"ref,omitempty"`
+	Value *[]byte `cbor:"1,keyasint,omitempty" json:"value,omitempty"`
+}
+
+type SecretsResolveResults struct {
+	call rpc.Call
+	data secretsResolveResultsData
+}
+
+func (v *SecretsResolveResults) SetRef(ref string) {
+	v.data.Ref = &ref
+}
+
+func (v *SecretsResolveResults) SetValue(value []byte) {
+	x := slices.Clone(value)
+	v.data.Value = &x
+}
+
+func (v *SecretsResolveResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *SecretsResolveResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *SecretsResolveResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *SecretsResolveResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
 type secretsSetStateArgsData struct {
 	Backend *string `cbor:"0,keyasint,omitempty" json:"backend,omitempty"`
 	Ref     *string `cbor:"1,keyasint,omitempty" json:"ref,omitempty"`
@@ -846,6 +929,32 @@ func (t *SecretsRotateKey) Results() *SecretsRotateKeyResults {
 	return results
 }
 
+type SecretsResolve struct {
+	rpc.Call
+	args    SecretsResolveArgs
+	results SecretsResolveResults
+}
+
+func (t *SecretsResolve) Args() *SecretsResolveArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *SecretsResolve) Results() *SecretsResolveResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
 type SecretsSetState struct {
 	rpc.Call
 	args    SecretsSetStateArgs
@@ -878,6 +987,7 @@ type Secrets interface {
 	ListVersions(ctx context.Context, state *SecretsListVersions) error
 	Keyring(ctx context.Context, state *SecretsKeyring) error
 	RotateKey(ctx context.Context, state *SecretsRotateKey) error
+	Resolve(ctx context.Context, state *SecretsResolve) error
 	SetState(ctx context.Context, state *SecretsSetState) error
 }
 
@@ -902,6 +1012,10 @@ func (reexportSecrets) Keyring(ctx context.Context, state *SecretsKeyring) error
 }
 
 func (reexportSecrets) RotateKey(ctx context.Context, state *SecretsRotateKey) error {
+	panic("not implemented")
+}
+
+func (reexportSecrets) Resolve(ctx context.Context, state *SecretsResolve) error {
 	panic("not implemented")
 }
 
@@ -963,6 +1077,16 @@ func AdaptSecrets(t Secrets) *rpc.Interface {
 			Params:        []string{},
 			Handler: func(ctx context.Context, call rpc.Call) error {
 				return t.RotateKey(ctx, &SecretsRotateKey{Call: call})
+			},
+		},
+		{
+			Name:          "resolve",
+			InterfaceName: "Secrets",
+			Index:         0,
+			Public:        false,
+			Params:        []string{"backend", "ref"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.Resolve(ctx, &SecretsResolve{Call: call})
 			},
 		},
 		{
@@ -1193,6 +1317,48 @@ func (v SecretsClient) RotateKey(ctx context.Context) (*SecretsClientRotateKeyRe
 	}
 
 	return &SecretsClientRotateKeyResults{client: v.Client, data: ret}, nil
+}
+
+type SecretsClientResolveResults struct {
+	client rpc.Client
+	data   secretsResolveResultsData
+}
+
+func (v *SecretsClientResolveResults) HasRef() bool {
+	return v.data.Ref != nil
+}
+
+func (v *SecretsClientResolveResults) Ref() string {
+	if v.data.Ref == nil {
+		return ""
+	}
+	return *v.data.Ref
+}
+
+func (v *SecretsClientResolveResults) HasValue() bool {
+	return v.data.Value != nil
+}
+
+func (v *SecretsClientResolveResults) Value() []byte {
+	if v.data.Value == nil {
+		return nil
+	}
+	return *v.data.Value
+}
+
+func (v SecretsClient) Resolve(ctx context.Context, backend string, ref string) (*SecretsClientResolveResults, error) {
+	args := SecretsResolveArgs{}
+	args.data.Backend = &backend
+	args.data.Ref = &ref
+
+	var ret secretsResolveResultsData
+
+	err := v.Call(ctx, "resolve", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SecretsClientResolveResults{client: v.Client, data: ret}, nil
 }
 
 type SecretsClientSetStateResults struct {

--- a/blackbox/secret_test.go
+++ b/blackbox/secret_test.go
@@ -1,0 +1,140 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"encoding/json"
+	"testing"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+// TestSecretStoreAndRotate covers the store side on its own: writing, seeing
+// what is there, recognizing an unchanged write, and revoking.
+func TestSecretStoreAndRotate(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	const path = "blackbox/api-key"
+
+	r := m.MustRun("secret", "set", path, "--value", "first-value")
+	r.RequireContains(t, "Stored "+path+"@")
+
+	// The same value again must not mint a duplicate version, or every pin
+	// would be invalidated by a no-op command.
+	r = m.MustRun("secret", "set", path, "--value", "first-value")
+	r.RequireContains(t, "already stored at that value")
+
+	r = m.MustRun("secret", "set", path, "--value", "second-value")
+	r.RequireContains(t, "Stored "+path+"@")
+
+	r = m.MustRun("secret", "list")
+	r.RequireContains(t, path)
+	r.RequireContains(t, "cluster")
+
+	// Two versions now exist, and the listing distinguishes them.
+	r = m.MustRun("secret", "versions", path, "--format", "json")
+	r.RequireContains(t, `"current": true`)
+
+	// The value itself must never appear in any listing.
+	if r.OutputContains("first-value") || r.OutputContains("second-value") {
+		t.Fatalf("secret listing leaked a value:\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+	}
+}
+
+// TestSecretReferencedByApp is the loop the whole feature exists for: store a
+// secret, point a variable at it, and have the app receive the real value while
+// nothing but a reference is ever written down.
+func TestSecretReferencedByApp(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	const (
+		path     = "blackbox/app-secret"
+		original = "value-before-rotation"
+		rotated  = "value-after-rotation"
+	)
+
+	m.MustRun("secret", "set", path, "--value", original)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+
+	m.MustRun("env", "set", "-a", name, "-e", "APP_SECRET", "--backend", "cluster", "--ref", path)
+
+	// What is recorded is the reference and its pin, not the value.
+	r := m.MustRun("env", "list", "-a", name)
+	r.RequireContains(t, "cluster:"+path+"@")
+	if r.OutputContains(original) {
+		t.Fatalf("env list leaked the secret value:\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+	}
+
+	// But the running container sees the real thing.
+	sandboxID := harness.GetSandboxID(t, m, name)
+	r = m.MustRun("sandbox", "exec", sandboxID, "--", "printenv", "APP_SECRET")
+	r.RequireContains(t, original)
+
+	// Rotating does not disturb what is already running.
+	m.MustRun("secret", "set", path, "--value", rotated)
+	r = m.MustRun("sandbox", "exec", sandboxID, "--", "printenv", "APP_SECRET")
+	r.RequireContains(t, original)
+
+	// Re-setting the reference re-pins it and rolls the change out.
+	m.MustRun("env", "set", "-a", name, "-e", "APP_SECRET", "--backend", "cluster", "--ref", path)
+
+	sandboxID = harness.GetSandboxID(t, m, name)
+	r = m.MustRun("sandbox", "exec", sandboxID, "--", "printenv", "APP_SECRET")
+	r.RequireContains(t, rotated)
+}
+
+// TestSecretRevocationFailsClosed checks the property that matters most after a
+// leak: once a version is revoked, a deploy that needs it fails rather than
+// starting the app without its credential.
+func TestSecretRevocationFailsClosed(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	const path = "blackbox/revoked-secret"
+
+	m.MustRun("secret", "set", path, "--value", "doomed-value")
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+	m.MustRun("env", "set", "-a", name, "-e", "APP_SECRET", "--backend", "cluster", "--ref", path)
+
+	// Find the version the app is pinned to and revoke exactly it.
+	versions := m.MustRun("secret", "versions", path, "--format", "json")
+	version := currentVersionFrom(t, versions.Stdout)
+
+	m.MustRun("secret", "disable", path+"@"+version)
+
+	// Re-pointing at the revoked version must fail rather than deploy without it.
+	r := m.Run("env", "set", "-a", name, "-e", "APP_SECRET", "--backend", "cluster", "--ref", path+"@"+version)
+	if r.ExitCode == 0 {
+		t.Fatalf("expected setting a revoked secret to fail\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+	}
+	r.RequireContains(t, "APP_SECRET")
+
+	// Re-enabling restores it, since disabling never touched the value.
+	m.MustRun("secret", "enable", path+"@"+version)
+	m.MustRun("env", "set", "-a", name, "-e", "APP_SECRET", "--backend", "cluster", "--ref", path+"@"+version)
+}
+
+// currentVersionFrom pulls the current version handle out of `secret versions
+// --format json` output.
+func currentVersionFrom(t *testing.T, out string) string {
+	t.Helper()
+
+	var parsed struct {
+		CurrentVersion string `json:"current_version"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("parsing secret versions output: %v\noutput: %s", err, out)
+	}
+	if parsed.CurrentVersion == "" {
+		t.Fatalf("no current version in output: %s", out)
+	}
+	return parsed.CurrentVersion
+}

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -24,6 +24,7 @@ import (
 	"miren.dev/runtime/api/metric/metric_v1alpha"
 	"miren.dev/runtime/api/network/network_v1alpha"
 	"miren.dev/runtime/api/runner/runner_v1alpha"
+	"miren.dev/runtime/api/secret/secret_v1alpha"
 	"miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/clientconfig"
 	"miren.dev/runtime/components/coordinate"
@@ -46,6 +47,7 @@ import (
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/saga"
 	"miren.dev/runtime/pkg/secret"
+	remotesecret "miren.dev/runtime/pkg/secret/remote"
 	"miren.dev/runtime/pkg/workloadidentity"
 	"miren.dev/runtime/servers/exec"
 	"miren.dev/runtime/version"
@@ -375,6 +377,14 @@ func (r *Runner) Start(ctx context.Context, eg ...*errgroup.Group) error {
 		r.Log.Warn("failed to set up workload identity issuer", "error", err)
 	}
 
+	// Likewise for secrets: a distributed runner can reach the entity store but
+	// not the cluster keyring, so it resolves through the coordinator. This one
+	// must not degrade quietly — a runner without it starts sandboxes whose
+	// referenced secrets can never materialize.
+	if err := r.setupRemoteSecrets(rs); err != nil {
+		return fmt.Errorf("setting up secret resolution: %w", err)
+	}
+
 	cm, err := r.SetupControllers(ctx, eas, rs.Server())
 	if err != nil {
 		return err
@@ -471,6 +481,27 @@ func queryWorkloadIssuerInfo(ctx context.Context, regClient *runner_v1alpha.Runn
 	ctx, cancel := context.WithTimeout(ctx, remoteTokenTimeout)
 	defer cancel()
 	return regClient.WorkloadIssuerInfo(ctx)
+}
+
+// setupRemoteSecrets points a distributed runner's secret resolution at the
+// coordinator. Runners do not hold the cluster keyring, so they cannot decrypt
+// a stored secret themselves.
+//
+// The coordinator's embedded runner (r.Config == nil) already holds the local
+// backend registry it was constructed with, and keeps it.
+func (r *Runner) setupRemoteSecrets(rs *rpc.State) error {
+	if r.Config == nil || r.deps.Secrets != nil {
+		return nil
+	}
+
+	client, err := rs.Client("dev.miren.runtime/secrets")
+	if err != nil {
+		return fmt.Errorf("connecting to coordinator secrets service: %w", err)
+	}
+
+	r.deps.Secrets = remotesecret.NewResolver(secret_v1alpha.NewSecretsClient(client))
+	r.Log.Info("secret resolution enabled via coordinator")
+	return nil
 }
 
 // initializeNetwork sets up the Flannel network for distributed runners.

--- a/controllers/version/gc.go
+++ b/controllers/version/gc.go
@@ -149,6 +149,36 @@ func (c *GCController) runGCWithLogging(ctx context.Context) {
 			"retained", result.RetainedVersions,
 			"total", result.TotalScanned)
 	}
+
+	// Secret versions are reaped on the same tick, after app versions: deleting
+	// an app version drops the ConfigVersion pinning its secrets, so running in
+	// this order lets a secret version become reapable in the same sweep that
+	// released it rather than waiting for the next one.
+	c.runSecretGCWithLogging(ctx)
+}
+
+func (c *GCController) runSecretGCWithLogging(ctx context.Context) {
+	result, err := c.RunSecretGC(ctx)
+	if err != nil {
+		c.Log.Error("secret version GC failed", "error", err)
+		return
+	}
+
+	if result.DeletedVersions > 0 || result.FailedVersions > 0 {
+		c.Log.Info("secret version GC complete",
+			"deleted", result.DeletedVersions,
+			"failed", result.FailedVersions,
+			"retained_pinned", result.RetainedPinned,
+			"retained_current", result.RetainedCurrent,
+			"retained_recent", result.RetainedRecent,
+			"total", result.TotalScanned)
+	} else {
+		c.Log.Debug("secret version GC complete, nothing reaped",
+			"retained_pinned", result.RetainedPinned,
+			"retained_current", result.RetainedCurrent,
+			"retained_recent", result.RetainedRecent,
+			"total", result.TotalScanned)
+	}
 }
 
 type versionInfo struct {

--- a/controllers/version/gc.go
+++ b/controllers/version/gc.go
@@ -112,7 +112,7 @@ func (c *GCController) run(ctx context.Context) {
 	// Run an initial GC on startup after a short delay.
 	select {
 	case <-time.After(30 * time.Second):
-		c.runGCWithLogging(ctx)
+		c.sweep(ctx)
 	case <-ctx.Done():
 		c.Log.Info("version retention GC controller stopped")
 		return
@@ -121,12 +121,26 @@ func (c *GCController) run(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			c.runGCWithLogging(ctx)
+			c.sweep(ctx)
 		case <-ctx.Done():
 			c.Log.Info("version retention GC controller stopped")
 			return
 		}
 	}
+}
+
+// sweep runs both retention passes for one tick.
+//
+// App versions go first: deleting one drops the ConfigVersion pinning its
+// secrets, so a secret version can become reapable in the same tick that
+// released it rather than waiting for the next. The order is the only thing
+// they share — the secret sweep reads its own pin picture and never looks at
+// the app sweep's result, so a failing app sweep must not take it down too.
+// Coupling them would hide the secret sweep behind an unrelated failure, and
+// the symptom (versions quietly accumulating) has no signal of its own.
+func (c *GCController) sweep(ctx context.Context) {
+	c.runGCWithLogging(ctx)
+	c.runSecretGCWithLogging(ctx)
 }
 
 func (c *GCController) runGCWithLogging(ctx context.Context) {
@@ -150,11 +164,6 @@ func (c *GCController) runGCWithLogging(ctx context.Context) {
 			"total", result.TotalScanned)
 	}
 
-	// Secret versions are reaped on the same tick, after app versions: deleting
-	// an app version drops the ConfigVersion pinning its secrets, so running in
-	// this order lets a secret version become reapable in the same sweep that
-	// released it rather than waiting for the next one.
-	c.runSecretGCWithLogging(ctx)
 }
 
 func (c *GCController) runSecretGCWithLogging(ctx context.Context) {

--- a/controllers/version/secret_gc.go
+++ b/controllers/version/secret_gc.go
@@ -3,6 +3,7 @@ package version
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	coreutil "miren.dev/runtime/api/core"
@@ -75,6 +76,17 @@ func (c *GCController) RunSecretGC(ctx context.Context) (*SecretGCResult, error)
 
 	cutoff := time.Now().Add(-secretVersionRetention)
 
+	// Candidates cleared every retention rule on the snapshot. They are
+	// collected rather than deleted inline so the pre-delete re-check below can
+	// be one fresh read for the whole sweep instead of one per candidate.
+	type candidate struct {
+		id      entity.Id
+		path    string
+		version string
+		ref     string
+	}
+	var candidates []candidate
+
 	for _, e := range secretsResp.Values() {
 		var sec core_v1alpha.Secret
 		sec.Decode(e.Entity())
@@ -85,11 +97,21 @@ func (c *GCController) RunSecretGC(ctx context.Context) (*SecretGCResult, error)
 			return result, fmt.Errorf("failed to list versions of secret %s: %w", sec.ID, err)
 		}
 
+		versions := make([]*entity.Entity, 0, len(versionsResp.Values()))
 		for _, ve := range versionsResp.Values() {
-			result.TotalScanned++
+			versions = append(versions, ve.Entity())
+		}
+		result.TotalScanned += len(versions)
 
-			ent := ve.Entity()
-			versionID := ent.Id()
+		// Newest first, so each version's successor is the one before it. A
+		// version stopped being usable when its successor was created, which is
+		// what the retention window is actually measured from.
+		sort.Slice(versions, func(i, j int) bool {
+			return versions[i].GetCreatedAt().After(versions[j].GetCreatedAt())
+		})
+
+		for i, ve := range versions {
+			versionID := ve.Id()
 
 			// The version a floating reference resolves to is never reapable,
 			// whatever else is true of it.
@@ -98,48 +120,75 @@ func (c *GCController) RunSecretGC(ctx context.Context) (*SecretGCResult, error)
 				continue
 			}
 
-			ref := secret.FormatRef(sec.Path, ent.ShortId())
+			ref := secret.FormatRef(sec.Path, ve.ShortId())
 			if pinned[ref] {
 				result.RetainedPinned++
 				continue
 			}
 
-			if ent.GetCreatedAt().After(cutoff) {
+			// Measuring from creation would give the case this window exists
+			// for no window at all: a credential that sat current for a year
+			// and rotated this morning is already long past the cutoff on the
+			// day it is superseded. What matters is how long ago it stopped
+			// being current, which is when the next version appeared.
+			supersededAt := ve.GetCreatedAt()
+			if i > 0 {
+				supersededAt = versions[i-1].GetCreatedAt()
+			}
+			if supersededAt.After(cutoff) {
 				result.RetainedRecent++
 				continue
 			}
 
-			// The pin snapshot was taken at the top of the sweep and can be a
-			// full pass stale, so re-check immediately before deleting. A
-			// ConfigVersion minted in that window pins a version this pass
-			// already decided was unreferenced, and unlike an app version there
-			// is no rebuilding a secret that gets deleted underneath it. Same
-			// pattern as pinnedNow on the app-version sweep.
-			nowPinned, err := c.secretVersionPinnedNow(gcCtx, ref)
-			if err != nil {
-				c.Log.Warn("failed to re-check secret version before delete; retaining",
-					"secret", sec.Path, "version", ent.ShortId(), "error", err)
-				result.FailedVersions++
-				continue
-			}
-			if nowPinned {
-				c.Log.Debug("retaining secret version pinned during sweep",
-					"secret", sec.Path, "version", ent.ShortId())
-				result.RetainedPinned++
-				continue
-			}
-
-			if _, err := c.EAC.Delete(gcCtx, versionID.String()); err != nil {
-				c.Log.Warn("failed to delete secret version",
-					"secret", sec.Path, "version", ent.ShortId(), "error", err)
-				result.FailedVersions++
-				continue
-			}
-
-			c.Log.Info("reaped unreferenced secret version",
-				"secret", sec.Path, "version", ent.ShortId())
-			result.DeletedVersions++
+			candidates = append(candidates, candidate{
+				id:      versionID,
+				path:    sec.Path,
+				version: ve.ShortId(),
+				ref:     ref,
+			})
 		}
+	}
+
+	if len(candidates) == 0 {
+		return result, nil
+	}
+
+	// The snapshot above can be a full pass stale by now, and a ConfigVersion
+	// minted in that window pins a version this sweep already judged
+	// unreferenced. Unlike an app version there is no rebuilding a secret that
+	// gets deleted underneath it, so re-read the pins once here and drop
+	// anything that has since been claimed.
+	//
+	// Once for the sweep, not once per candidate: this walks every
+	// ConfigVersion in the cluster, so per-candidate it would be K x N and a
+	// first sweep on a cluster with history could exhaust the time budget and
+	// abort partway.
+	fresh, err := c.pinnedSecretVersions(gcCtx)
+	if err != nil {
+		c.Log.Warn("failed to re-check secret pins before deleting; retaining this sweep",
+			"candidates", len(candidates), "error", err)
+		result.FailedVersions += len(candidates)
+		return result, nil
+	}
+
+	for _, cand := range candidates {
+		if fresh[cand.ref] {
+			c.Log.Debug("retaining secret version pinned during sweep",
+				"secret", cand.path, "version", cand.version)
+			result.RetainedPinned++
+			continue
+		}
+
+		if _, err := c.EAC.Delete(gcCtx, cand.id.String()); err != nil {
+			c.Log.Warn("failed to delete secret version",
+				"secret", cand.path, "version", cand.version, "error", err)
+			result.FailedVersions++
+			continue
+		}
+
+		c.Log.Info("reaped unreferenced secret version",
+			"secret", cand.path, "version", cand.version)
+		result.DeletedVersions++
 	}
 
 	return result, nil
@@ -168,19 +217,4 @@ func (c *GCController) pinnedSecretVersions(ctx context.Context) (map[string]boo
 	}
 
 	return pinned, nil
-}
-
-// secretVersionPinnedNow re-reads the live ConfigVersions and reports whether
-// any of them pins this reference.
-//
-// It runs only for versions that already cleared every other retention rule,
-// so the extra pass costs nothing on a healthy sweep and buys the guarantee
-// that matters: a version is never deleted on the strength of a snapshot that
-// a newly minted config has since invalidated.
-func (c *GCController) secretVersionPinnedNow(ctx context.Context, ref string) (bool, error) {
-	pinned, err := c.pinnedSecretVersions(ctx)
-	if err != nil {
-		return false, err
-	}
-	return pinned[ref], nil
 }

--- a/controllers/version/secret_gc.go
+++ b/controllers/version/secret_gc.go
@@ -1,0 +1,150 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	coreutil "miren.dev/runtime/api/core"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/secret"
+)
+
+// SecretGCResult reports what a secret-version sweep did.
+type SecretGCResult struct {
+	// DeletedVersions is the number of secret versions hard-deleted.
+	DeletedVersions int
+	// FailedVersions is the number that failed to delete.
+	FailedVersions int
+	// RetainedCurrent is the number kept because they are their secret's
+	// current version.
+	RetainedCurrent int
+	// RetainedPinned is the number kept because a live ConfigVersion still
+	// pins them.
+	RetainedPinned int
+	// RetainedRecent is the number kept because they are younger than the
+	// retention window.
+	RetainedRecent int
+	// TotalScanned is the number of secret versions evaluated.
+	TotalScanned int
+}
+
+// secretVersionRetention is how long a superseded secret version is kept even
+// when nothing references it.
+//
+// A rotation is exactly when someone might need the old value back — a service
+// that has not finished picking up the new one, a deploy that has to be rolled
+// back by hand. Reaping the instant the last reference drops would make that
+// window zero. This is deliberately generous: a superseded version is a few
+// hundred bytes of ciphertext, and the cost of keeping one too long is far
+// below the cost of destroying one still needed.
+const secretVersionRetention = 30 * 24 * time.Hour
+
+// RunSecretGC reaps secret versions that nothing can reach any more.
+//
+// A version is reapable only when it is neither its secret's current version
+// nor pinned by any live ConfigVersion. That second condition is what makes the
+// cluster backend's retention promise real: a reference pinned in a
+// ConfigVersion stays resolvable, so a rollback comes up on the bytes that
+// version originally shipped with rather than failing or, worse, silently
+// resolving something else.
+//
+// Unlike an app version, a secret version cannot be rebuilt. So this is
+// conservative in every direction: any error listing the pins abandons the
+// sweep rather than proceeding on a partial picture, which would look exactly
+// like "nothing references this."
+func (c *GCController) RunSecretGC(ctx context.Context) (*SecretGCResult, error) {
+	result := &SecretGCResult{}
+
+	gcCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	// Collect every pin first. A partial read here is indistinguishable from
+	// "unreferenced", so a failure has to abandon the sweep rather than delete
+	// on incomplete information.
+	pinned, err := c.pinnedSecretVersions(gcCtx)
+	if err != nil {
+		return result, err
+	}
+
+	secretsResp, err := c.EAC.List(gcCtx, entity.Ref(entity.EntityKind, core_v1alpha.KindSecret))
+	if err != nil {
+		return result, fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	cutoff := time.Now().Add(-secretVersionRetention)
+
+	for _, e := range secretsResp.Values() {
+		var sec core_v1alpha.Secret
+		sec.Decode(e.Entity())
+		sec.ID = e.Entity().Id()
+
+		versionsResp, err := c.EAC.List(gcCtx, entity.Ref(core_v1alpha.SecretVersionSecretId, sec.ID))
+		if err != nil {
+			return result, fmt.Errorf("failed to list versions of secret %s: %w", sec.ID, err)
+		}
+
+		for _, ve := range versionsResp.Values() {
+			result.TotalScanned++
+
+			ent := ve.Entity()
+			versionID := ent.Id()
+
+			// The version a floating reference resolves to is never reapable,
+			// whatever else is true of it.
+			if versionID == sec.CurrentVersion {
+				result.RetainedCurrent++
+				continue
+			}
+
+			if pinned[secret.FormatRef(sec.Path, ent.ShortId())] {
+				result.RetainedPinned++
+				continue
+			}
+
+			if ent.GetCreatedAt().After(cutoff) {
+				result.RetainedRecent++
+				continue
+			}
+
+			if _, err := c.EAC.Delete(gcCtx, versionID.String()); err != nil {
+				c.Log.Warn("failed to delete secret version",
+					"secret", sec.Path, "version", ent.ShortId(), "error", err)
+				result.FailedVersions++
+				continue
+			}
+
+			c.Log.Info("reaped unreferenced secret version",
+				"secret", sec.Path, "version", ent.ShortId())
+			result.DeletedVersions++
+		}
+	}
+
+	return result, nil
+}
+
+// pinnedSecretVersions collects every secret reference pinned by a live
+// ConfigVersion, as a set of fully-qualified references.
+//
+// Every ConfigVersion counts, not only those belonging to active app versions:
+// a rollback target is by definition not active, and it is precisely the case
+// this protection exists for.
+func (c *GCController) pinnedSecretVersions(ctx context.Context) (map[string]bool, error) {
+	resp, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindConfigVersion))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list config versions: %w", err)
+	}
+
+	pinned := make(map[string]bool)
+	for _, e := range resp.Values() {
+		var cv core_v1alpha.ConfigVersion
+		cv.Decode(e.Entity())
+
+		for _, ref := range coreutil.SecretReferences(&cv.Spec) {
+			pinned[ref.Ref] = true
+		}
+	}
+
+	return pinned, nil
+}

--- a/controllers/version/secret_gc.go
+++ b/controllers/version/secret_gc.go
@@ -98,13 +98,34 @@ func (c *GCController) RunSecretGC(ctx context.Context) (*SecretGCResult, error)
 				continue
 			}
 
-			if pinned[secret.FormatRef(sec.Path, ent.ShortId())] {
+			ref := secret.FormatRef(sec.Path, ent.ShortId())
+			if pinned[ref] {
 				result.RetainedPinned++
 				continue
 			}
 
 			if ent.GetCreatedAt().After(cutoff) {
 				result.RetainedRecent++
+				continue
+			}
+
+			// The pin snapshot was taken at the top of the sweep and can be a
+			// full pass stale, so re-check immediately before deleting. A
+			// ConfigVersion minted in that window pins a version this pass
+			// already decided was unreferenced, and unlike an app version there
+			// is no rebuilding a secret that gets deleted underneath it. Same
+			// pattern as pinnedNow on the app-version sweep.
+			nowPinned, err := c.secretVersionPinnedNow(gcCtx, ref)
+			if err != nil {
+				c.Log.Warn("failed to re-check secret version before delete; retaining",
+					"secret", sec.Path, "version", ent.ShortId(), "error", err)
+				result.FailedVersions++
+				continue
+			}
+			if nowPinned {
+				c.Log.Debug("retaining secret version pinned during sweep",
+					"secret", sec.Path, "version", ent.ShortId())
+				result.RetainedPinned++
 				continue
 			}
 
@@ -147,4 +168,19 @@ func (c *GCController) pinnedSecretVersions(ctx context.Context) (map[string]boo
 	}
 
 	return pinned, nil
+}
+
+// secretVersionPinnedNow re-reads the live ConfigVersions and reports whether
+// any of them pins this reference.
+//
+// It runs only for versions that already cleared every other retention rule,
+// so the extra pass costs nothing on a healthy sweep and buys the guarantee
+// that matters: a version is never deleted on the strength of a snapshot that
+// a newly minted config has since invalidated.
+func (c *GCController) secretVersionPinnedNow(ctx context.Context, ref string) (bool, error) {
+	pinned, err := c.pinnedSecretVersions(ctx)
+	if err != nil {
+		return false, err
+	}
+	return pinned[ref], nil
 }

--- a/controllers/version/secret_gc_test.go
+++ b/controllers/version/secret_gc_test.go
@@ -271,12 +271,7 @@ func TestSecretGCRecheckesPinsImmediatelyBeforeDeleting(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// The re-check sees what the snapshot could not.
-	nowPinned, err := gc.secretVersionPinnedNow(ctx, ref)
-	require.NoError(t, err)
-	assert.True(t, nowPinned, "the pre-delete re-check must see the newly minted pin")
-
-	// And a full sweep now retains it rather than reaping it.
+	// The sweep's pre-delete re-check sees what its own snapshot could not.
 	result, err := gc.RunSecretGC(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.DeletedVersions)
@@ -284,4 +279,70 @@ func TestSecretGCRecheckesPinsImmediatelyBeforeDeleting(t *testing.T) {
 
 	_, err = inmem.EAC.Get(ctx, orphan.String())
 	assert.NoError(t, err, "the newly pinned version must still exist")
+}
+
+// The window has to run from when a version stopped being current, not from
+// when it was created. Measuring from creation gives the case it exists for no
+// protection at all: a credential that sat current for a year and rotated this
+// morning is already long past the cutoff on the day it is superseded.
+func TestSecretGCMeasuresRetentionFromSupersessionNotCreation(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	secretID := entity.Id("secret/payments.stripe-key")
+
+	// Created long ago, and current right up until moments ago.
+	longLived := createSecretVersion(t, inmem.EAC, "sv-long-lived",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, aged())
+
+	// The rotation that superseded it just happened.
+	current := createSecretVersion(t, inmem.EAC, "sv-current",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, time.Now())
+
+	_, err := inmem.Client.Create(ctx, "payments.stripe-key", &core_v1alpha.Secret{
+		Path:           "payments/stripe-key",
+		CurrentVersion: current,
+	})
+	require.NoError(t, err)
+
+	result, err := newSecretGC(t, inmem.EAC).RunSecretGC(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.DeletedVersions,
+		"a just-superseded version must be retained however old it is")
+	assert.Equal(t, 1, result.RetainedRecent)
+
+	_, err = inmem.EAC.Get(ctx, longLived.String())
+	assert.NoError(t, err, "the old value must still be recoverable right after a rotation")
+}
+
+// The flip side: once the window has actually elapsed since supersession, an
+// unreferenced version does go.
+func TestSecretGCReapsOnceTheWindowHasElapsedSinceSupersession(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	secretID := entity.Id("secret/payments.stripe-key")
+
+	// Superseded long ago: both it and its successor predate the window.
+	old := createSecretVersion(t, inmem.EAC, "sv-old",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED},
+		aged().Add(-time.Hour))
+	current := createSecretVersion(t, inmem.EAC, "sv-current",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, aged())
+
+	_, err := inmem.Client.Create(ctx, "payments.stripe-key", &core_v1alpha.Secret{
+		Path:           "payments/stripe-key",
+		CurrentVersion: current,
+	})
+	require.NoError(t, err)
+
+	result, err := newSecretGC(t, inmem.EAC).RunSecretGC(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.DeletedVersions)
+	_, err = inmem.EAC.Get(ctx, old.String())
+	assert.Error(t, err)
 }

--- a/controllers/version/secret_gc_test.go
+++ b/controllers/version/secret_gc_test.go
@@ -225,3 +225,63 @@ func TestSecretGCWithNoSecrets(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.TotalScanned)
 }
+
+// The pin snapshot is taken once at the top of the sweep, so a ConfigVersion
+// minted afterwards would otherwise lose its secret to a decision made before
+// it existed. Unlike an app version, a reaped secret version cannot be rebuilt.
+func TestSecretGCRecheckesPinsImmediatelyBeforeDeleting(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	secretID := entity.Id("secret/payments.stripe-key")
+
+	orphan := createSecretVersion(t, inmem.EAC, "sv-orphan",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, aged())
+	current := createSecretVersion(t, inmem.EAC, "sv-current",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, aged())
+
+	_, err := inmem.Client.Create(ctx, "payments.stripe-key", &core_v1alpha.Secret{
+		Path:           "payments/stripe-key",
+		CurrentVersion: current,
+	})
+	require.NoError(t, err)
+
+	gc := newSecretGC(t, inmem.EAC)
+
+	// Nothing references it yet, so this version is squarely a delete candidate.
+	ref := secret.FormatRef("payments/stripe-key", shortIDOf(t, inmem.EAC, orphan))
+	stale, err := gc.pinnedSecretVersions(ctx)
+	require.NoError(t, err)
+	require.False(t, stale[ref], "precondition: the snapshot sees it as unreferenced")
+
+	// A config lands pinning it, exactly as one could between snapshot and
+	// delete.
+	appID, err := inmem.Client.Create(ctx, "gcapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+	_, err = inmem.Client.Create(ctx, "late-cfg", &core_v1alpha.ConfigVersion{
+		App: appID,
+		Spec: core_v1alpha.ConfigSpec{
+			Variables: []core_v1alpha.ConfigSpecVariables{{
+				Key:     "STRIPE_API_KEY",
+				Backend: secret.ClusterBackendName,
+				Value:   ref,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	// The re-check sees what the snapshot could not.
+	nowPinned, err := gc.secretVersionPinnedNow(ctx, ref)
+	require.NoError(t, err)
+	assert.True(t, nowPinned, "the pre-delete re-check must see the newly minted pin")
+
+	// And a full sweep now retains it rather than reaping it.
+	result, err := gc.RunSecretGC(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.DeletedVersions)
+	assert.Equal(t, 1, result.RetainedPinned)
+
+	_, err = inmem.EAC.Get(ctx, orphan.String())
+	assert.NoError(t, err, "the newly pinned version must still exist")
+}

--- a/controllers/version/secret_gc_test.go
+++ b/controllers/version/secret_gc_test.go
@@ -1,0 +1,227 @@
+package version
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
+	"miren.dev/runtime/pkg/secret"
+)
+
+// aged is safely outside the retention window, so a version created at this
+// time is judged on references alone.
+func aged() time.Time {
+	return time.Now().Add(-2 * secretVersionRetention)
+}
+
+func createSecretVersion(t *testing.T, eac *entityserver_v1alpha.EntityAccessClient,
+	name string, sv *core_v1alpha.SecretVersion, createdAt time.Time) entity.Id {
+	t.Helper()
+
+	ent := entity.New(
+		(&core_v1alpha.Metadata{Name: name}).Encode,
+		sv.Encode,
+		entity.Ident, types.Keyword(sv.ShortKind()+"/"+name),
+	)
+	ent.SetCreatedAt(createdAt)
+
+	var rpcE entityserver_v1alpha.Entity
+	rpcE.SetAttrs(ent.Attrs())
+	pr, err := eac.Put(context.Background(), &rpcE)
+	require.NoError(t, err)
+	return entity.Id(pr.Id())
+}
+
+// shortIDOf reads the handle a reference names a version by.
+func shortIDOf(t *testing.T, eac *entityserver_v1alpha.EntityAccessClient, id entity.Id) string {
+	t.Helper()
+
+	res, err := eac.Get(context.Background(), id.String())
+	require.NoError(t, err)
+
+	for _, attr := range res.Entity().Attrs() {
+		if attr.ID == entity.DBShortId {
+			return attr.Value.String()
+		}
+	}
+	t.Fatalf("secret version %s has no short id", id)
+	return ""
+}
+
+func newSecretGC(t *testing.T, eac *entityserver_v1alpha.EntityAccessClient) *GCController {
+	return &GCController{Log: testutils.TestLogger(t), EAC: eac}
+}
+
+// The version a floating reference resolves to is never reapable, however old
+// it is and whether or not anything pins it.
+func TestSecretGCKeepsTheCurrentVersion(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	current := createSecretVersion(t, inmem.EAC, "sv-current",
+		&core_v1alpha.SecretVersion{State: core_v1alpha.ENABLED}, aged())
+
+	_, err := inmem.Client.Create(ctx, "payments.stripe-key", &core_v1alpha.Secret{
+		Path:           "payments/stripe-key",
+		CurrentVersion: current,
+	})
+	require.NoError(t, err)
+
+	// Point the version back at its secret now that the secret exists.
+	require.NoError(t, inmem.Client.UpdateAttrs(ctx, current,
+		entity.Ref(core_v1alpha.SecretVersionSecretId, entity.Id("secret/payments.stripe-key"))))
+
+	result, err := newSecretGC(t, inmem.EAC).RunSecretGC(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.DeletedVersions)
+	assert.Equal(t, 1, result.RetainedCurrent)
+}
+
+// The load-bearing case: a superseded version that a live ConfigVersion still
+// pins must survive, or a rollback would come up on the wrong secret.
+func TestSecretGCKeepsAVersionPinnedByAConfigVersion(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	secretID := entity.Id("secret/payments.stripe-key")
+
+	old := createSecretVersion(t, inmem.EAC, "sv-old",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, aged())
+	current := createSecretVersion(t, inmem.EAC, "sv-current",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, aged())
+
+	_, err := inmem.Client.Create(ctx, "payments.stripe-key", &core_v1alpha.Secret{
+		Path:           "payments/stripe-key",
+		CurrentVersion: current,
+	})
+	require.NoError(t, err)
+
+	// A past app version's config still names the old secret version.
+	appID, err := inmem.Client.Create(ctx, "gcapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+	_, err = inmem.Client.Create(ctx, "rolled-back-cfg", &core_v1alpha.ConfigVersion{
+		App: appID,
+		Spec: core_v1alpha.ConfigSpec{
+			Variables: []core_v1alpha.ConfigSpecVariables{{
+				Key:     "STRIPE_API_KEY",
+				Backend: secret.ClusterBackendName,
+				Value:   secret.FormatRef("payments/stripe-key", shortIDOf(t, inmem.EAC, old)),
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := newSecretGC(t, inmem.EAC).RunSecretGC(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.DeletedVersions)
+	assert.Equal(t, 1, result.RetainedPinned)
+	assert.Equal(t, 1, result.RetainedCurrent)
+
+	// It is still readable, which is the point.
+	_, err = inmem.EAC.Get(ctx, old.String())
+	assert.NoError(t, err)
+}
+
+func TestSecretGCReapsAnUnreferencedVersion(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	secretID := entity.Id("secret/payments.stripe-key")
+
+	orphan := createSecretVersion(t, inmem.EAC, "sv-orphan",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, aged())
+	current := createSecretVersion(t, inmem.EAC, "sv-current",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, aged())
+
+	_, err := inmem.Client.Create(ctx, "payments.stripe-key", &core_v1alpha.Secret{
+		Path:           "payments/stripe-key",
+		CurrentVersion: current,
+	})
+	require.NoError(t, err)
+
+	result, err := newSecretGC(t, inmem.EAC).RunSecretGC(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.DeletedVersions)
+	assert.Equal(t, 1, result.RetainedCurrent)
+	assert.Equal(t, 2, result.TotalScanned)
+
+	_, err = inmem.EAC.Get(ctx, orphan.String())
+	assert.Error(t, err, "the unreferenced version should be gone")
+}
+
+// A rotation is exactly when someone might need the old value back, so a
+// recently superseded version is kept even with nothing referencing it.
+func TestSecretGCKeepsARecentlySupersededVersion(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	secretID := entity.Id("secret/payments.stripe-key")
+
+	createSecretVersion(t, inmem.EAC, "sv-recent",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, time.Now())
+	current := createSecretVersion(t, inmem.EAC, "sv-current",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, time.Now())
+
+	_, err := inmem.Client.Create(ctx, "payments.stripe-key", &core_v1alpha.Secret{
+		Path:           "payments/stripe-key",
+		CurrentVersion: current,
+	})
+	require.NoError(t, err)
+
+	result, err := newSecretGC(t, inmem.EAC).RunSecretGC(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.DeletedVersions)
+	assert.Equal(t, 1, result.RetainedRecent)
+}
+
+// A disabled version is still reapable once nothing references it — revoking is
+// about resolution, not retention.
+func TestSecretGCReapsADisabledUnreferencedVersion(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	secretID := entity.Id("secret/payments.stripe-key")
+
+	createSecretVersion(t, inmem.EAC, "sv-revoked",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.DISABLED}, aged())
+	current := createSecretVersion(t, inmem.EAC, "sv-current",
+		&core_v1alpha.SecretVersion{Secret: secretID, State: core_v1alpha.ENABLED}, aged())
+
+	_, err := inmem.Client.Create(ctx, "payments.stripe-key", &core_v1alpha.Secret{
+		Path:           "payments/stripe-key",
+		CurrentVersion: current,
+	})
+	require.NoError(t, err)
+
+	result, err := newSecretGC(t, inmem.EAC).RunSecretGC(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.DeletedVersions)
+}
+
+// A cluster holding no secrets must sweep cleanly rather than erroring.
+func TestSecretGCWithNoSecrets(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	result, err := newSecretGC(t, inmem.EAC).RunSecretGC(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.TotalScanned)
+}

--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -164,11 +164,26 @@ description = "Third-party API key for payment processing"
 |-------|------|-------------|
 | `key` | string | Variable name (required) |
 | `value` | string | Variable value |
+| `backend` | string | Secret backend to source the value from, instead of `value` — see [Secrets](/secrets) |
+| `ref` | string | Reference to the secret within that backend |
 | `required` | bool | If `true`, deploy will fail when this variable has no value |
 | `sensitive` | bool | If `true`, the value is masked in CLI output and logs |
 | `description` | string | Human-readable explanation of what this variable is for |
 
 The `required` flag is useful for variables whose values differ per environment—declare them in `app.toml` with an empty value and `required = true`, then set the actual value with `miren env set` before deploying. The `sensitive` flag ensures secrets aren't accidentally exposed in terminal output.
+
+#### Referencing a Secret
+
+For a real credential, `sensitive` is not enough: it masks display but the value still sits in your config. Use `backend` and `ref` to point at a [secret](/secrets) instead, so `app.toml` holds only a pointer and stays safe to commit:
+
+```toml
+[[env]]
+key = "STRIPE_API_KEY"
+backend = "cluster"
+ref = "payments/stripe-key"
+```
+
+Set `value` or `ref`, never both. A referenced variable is sensitive automatically.
 
 #### Variables Miren Injects
 

--- a/docs/docs/app-toml.md
+++ b/docs/docs/app-toml.md
@@ -88,18 +88,25 @@ key = "SECRET_KEY"
 required = true
 sensitive = true
 description = "Used for session signing"
+
+[[env]]
+key = "STRIPE_API_KEY"
+backend = "cluster"
+ref = "payments/stripe-key"
 ```
 
 | Field | Type | Description | Default |
 |-------|------|-------------|---------|
 | `key` | string | Variable name. **Required.** | — |
 | `value` | string | Variable value | `""` |
+| `backend` | string | [Secret](/secrets) backend to source the value from | `""` |
+| `ref` | string | Reference to the secret within that backend | `""` |
 | `required` | bool | Fail deploy if value is empty | `false` |
 | `sensitive` | bool | Mask value in CLI output and logs | `false` |
 | `description` | string | Human-readable explanation of this variable | — |
 
 :::note[Validation]
-Every env entry must have a non-empty `key`. If `required` is `true` and `value` is empty at deploy time, the deploy fails.
+Every env entry must have a non-empty `key`. If `required` is `true` and `value` is empty at deploy time, the deploy fails. `ref` requires `backend`, and cannot be combined with `value`.
 :::
 
 ## `[build]` — Build Configuration {#build}

--- a/docs/docs/secrets.md
+++ b/docs/docs/secrets.md
@@ -1,0 +1,175 @@
+---
+title: Secrets
+description: Store credentials encrypted in your cluster and reference them from app config, so the value never sits in plaintext and every deploy records exactly which version it used.
+keywords: [secrets, credentials, encryption, rotation, env vars, secret backend]
+---
+
+import CliCommand from '@site/src/components/CliCommand';
+
+# Secrets
+
+A secret is a credential Miren holds **encrypted**, that your app config **points at** rather than contains. The value is decrypted only in memory, at the moment a container starts.
+
+This is different from marking an env var sensitive:
+
+| | `miren env set -s KEY` | `miren secret set` |
+|---|---|---|
+| Stored | plaintext in the cluster store | encrypted at rest |
+| In CLI output | masked | never present — only the reference is |
+| Rotation | edit the variable on each app | rotate once, apps re-pin |
+| History | none | immutable versions you can roll back to |
+
+Use `-s` for values that are merely noisy in a terminal. Use a secret for anything that would matter if it leaked.
+
+## Storing a secret
+
+<CliCommand context="client">
+
+```miren
+miren secret set payments/stripe-key
+```
+
+</CliCommand>
+
+You are prompted with masking; the value is never echoed, logged, or written to disk by the CLI. Each write mints an immutable version and prints its handle:
+
+```
+Stored payments/stripe-key@x1A  (cluster, enabled)
+```
+
+That `@x1A` is the version. It is an opaque id, not a counter.
+
+To read a value from a file instead of being prompted — useful for certificates and JSON keys — use `--value @filename`. A trailing newline is trimmed, since a credential with one appended is the most common way a copied token stops working.
+
+<CliCommand context="client">
+
+```miren
+miren secret set tls/cert --value @server.pem
+```
+
+</CliCommand>
+
+Storing a value identical to the current version is reported as unchanged rather than minting a duplicate, so re-running the command is safe.
+
+## Using a secret in an app
+
+Point an environment variable at it. The value does not travel through your shell, your config file, or your terminal — only the reference does.
+
+<CliCommand context="app">
+
+```miren
+miren env set -e STRIPE_API_KEY --backend cluster --ref payments/stripe-key
+```
+
+</CliCommand>
+
+Or declare it in `app.toml`, which is safe to commit:
+
+```toml
+[[env]]
+key = "STRIPE_API_KEY"
+backend = "cluster"
+ref = "payments/stripe-key"
+```
+
+Your app reads `STRIPE_API_KEY` as an ordinary environment variable. Nothing in the app needs to know it came from a secret.
+
+`miren env list` shows the reference rather than a mask, because there is no local value to hide:
+
+```
+NAME             VALUE                              SOURCE
+STRIPE_API_KEY   → cluster:payments/stripe-key@x1A  manual
+DATABASE_POOL    10                                 manual
+```
+
+A reference cannot be combined with a value — set one or the other.
+
+## Pinning: which version a deploy used
+
+Every deploy records the exact secret version it resolved. That pin — the `@x1A` above — is stored in the immutable config for that app version.
+
+This is what makes two things work:
+
+- **"What did we ship?"** is answerable for the most sensitive input a deploy has.
+- **Rollback restores the right secret.** Rolling back to an older version brings back the value *that version ran with*, not today's. Miren never deletes a version an old config still points at.
+
+## Rotating
+
+Rotating mints a new version. **Running apps are not disturbed** — there is no surprise mid-run swap.
+
+<CliCommand context="client">
+
+```miren
+miren secret set payments/stripe-key
+```
+
+</CliCommand>
+
+How the rotation reaches your apps depends on how the reference was authored:
+
+- **Declared in `app.toml`** — the reference floats, so the next `miren deploy` picks up the new version automatically.
+- **Set with `miren env set`** — the reference is pinned when you set it, so re-run the same `env set` command to move it. This rolls out immediately.
+
+To hold a variable at a specific version regardless, write the version into the reference: `--ref payments/stripe-key@x1A`. This is how you run a rotation overlap, with one variable tracking the new value and another holding the outgoing one while the change propagates.
+
+## Revoking
+
+Disabling a version stops it resolving. Anything still pointing at it **fails closed** on its next deploy rather than falling back to a different value — a revoked credential must never silently become a working one.
+
+<CliCommand context="client">
+
+```miren
+miren secret disable payments/stripe-key@x1A
+```
+
+</CliCommand>
+
+Disabling is reversible with `miren secret enable`; the value itself is untouched. Note that already-running sandboxes keep the value they started with — revoking prevents new resolutions, it does not reach into running processes.
+
+`miren secret destroy` goes further and deletes the value for good. Prefer `disable` when responding to a leak: it fails closed just as hard and leaves you able to recover if something still needed the value.
+
+## Seeing what you have
+
+<CliCommand context="client">
+
+```miren
+miren secret list
+miren secret versions payments/stripe-key
+```
+
+</CliCommand>
+
+```
+PATH                 BACKEND  CURRENT  VERSIONS
+payments/stripe-key  cluster  @m4Q     @m4Q @x1A(disabled)
+registry/npm-token   cluster  @p7R     @p7R
+```
+
+Both support `--format json`.
+
+## How it is stored
+
+Each version is sealed with its own random data key, and only that key is encrypted by a cluster key. So:
+
+- Rotating the cluster key re-encrypts a few bytes per version, never the values themselves.
+- A leaked data key exposes exactly one version rather than every secret.
+- The cluster key only ever performs small fixed-size operations, so it can move behind a KMS later without your stored data changing shape.
+
+The plaintext exists only transiently, in memory, while a deploy resolves it and while the container that needs it is being created. It is never written to the cluster store, a sandbox spec, an image layer, or a log.
+
+:::warning[Back up the keyring]
+The cluster key lives at `<data-path>/server/secrets.keyring`, alongside the cluster's CA key. **If that file is lost, every stored secret is permanently unrecoverable.** Include it in whatever backs up your data path.
+:::
+
+## Backends
+
+`cluster` is Miren's own store, and is always available. It is one *backend instance* among what a cluster may register — the model is designed so that external managers (Vault, AWS Secrets Manager, GCP Secret Manager) can be registered alongside it under their own names, with references written the same way:
+
+```toml
+[[env]]
+key = "SIGNING_KEY"
+backend = "prod-vault"
+ref = "secret/data/storefront#signing"
+```
+
+Miren only ever *reads* an external manager — it never writes into one, so that manager stays the source of truth for its own secrets. Only the `cluster` backend ships today.

--- a/docs/docs/secrets.md
+++ b/docs/docs/secrets.md
@@ -55,7 +55,7 @@ Storing a value identical to the current version is reported as unchanged rather
 
 Point an environment variable at it. The value does not travel through your shell, your config file, or your terminal — only the reference does.
 
-<CliCommand context="app">
+<CliCommand context="client">
 
 ```miren
 miren env set -e STRIPE_API_KEY --backend cluster --ref payments/stripe-key

--- a/docs/docs/secrets.md
+++ b/docs/docs/secrets.md
@@ -33,7 +33,7 @@ miren secret set payments/stripe-key
 
 You are prompted with masking; the value is never echoed, logged, or written to disk by the CLI. Each write mints an immutable version and prints its handle:
 
-```
+```text
 Stored payments/stripe-key@x1A  (cluster, enabled)
 ```
 
@@ -76,7 +76,7 @@ Your app reads `STRIPE_API_KEY` as an ordinary environment variable. Nothing in 
 
 `miren env list` shows the reference rather than a mask, because there is no local value to hide:
 
-```
+```text
 NAME             VALUE                              SOURCE
 STRIPE_API_KEY   → cluster:payments/stripe-key@x1A  manual
 DATABASE_POOL    10                                 manual
@@ -124,9 +124,15 @@ miren secret disable payments/stripe-key@x1A
 
 </CliCommand>
 
-Disabling is reversible with `miren secret enable`; the value itself is untouched. Note that already-running sandboxes keep the value they started with — revoking prevents new resolutions, it does not reach into running processes.
+Disabling is reversible with `miren secret enable`; the value itself is untouched.
 
-`miren secret destroy` goes further and deletes the value for good. Prefer `disable` when responding to a leak: it fails closed just as hard and leaves you able to recover if something still needed the value.
+:::warning[Revoking does not reach running processes]
+Already-running sandboxes keep the value they started with. Disabling a version prevents new resolutions — it does not reach into processes that already hold the secret. Restart or redeploy the affected apps if you need them off the old value.
+:::
+
+:::danger[Destroy cannot be undone]
+`miren secret destroy` deletes the value for good, and anything still referencing that version can never resolve again. Prefer `miren secret disable` when responding to a leak: it fails closed just as hard and leaves you able to recover if something still needed the value.
+:::
 
 ## Seeing what you have
 
@@ -139,7 +145,7 @@ miren secret versions payments/stripe-key
 
 </CliCommand>
 
-```
+```text
 PATH                 BACKEND  CURRENT  VERSIONS
 payments/stripe-key  cluster  @m4Q     @m4Q @x1A(disabled)
 registry/npm-token   cluster  @p7R     @p7R
@@ -155,7 +161,9 @@ Each version is sealed with its own random data key, and only that key is encryp
 - A leaked data key exposes exactly one version rather than every secret.
 - The cluster key only ever performs small fixed-size operations, so it can move behind a KMS later without your stored data changing shape.
 
-The plaintext exists only transiently, in memory, while a deploy resolves it and while the container that needs it is being created. It is never written to the cluster store, a sandbox spec, an image layer, or a log.
+Within Miren, the plaintext exists only transiently and only in memory: while a deploy resolves it, and while the container that needs it is being created. It is never written to the cluster store, a sandbox spec, an image layer, or a log.
+
+Once the container starts, your application holds its own copy for as long as it runs — an environment variable is readable by the process and anything that can inspect it. Miren stops handing the value around; it cannot un-give it to the app you handed it to.
 
 :::warning[Back up the keyring]
 The cluster key lives at `<data-path>/server/secrets.keyring`, alongside the cluster's CA key. **If that file is lost, every stored secret is permanently unrecoverable.** Include it in whatever backs up your data path.

--- a/docs/docs/secrets.md
+++ b/docs/docs/secrets.md
@@ -173,6 +173,37 @@ Once the container starts, your application holds its own copy for as long as it
 The cluster key lives at `<data-path>/server/secrets.keyring`, alongside the cluster's CA key. **If that file is lost, every stored secret is permanently unrecoverable.** Include it in whatever backs up your data path.
 :::
 
+## The cluster key
+
+Everything above rotates *secrets*. The key that encrypts them rotates too, and Miren handles it.
+
+Each stored version is sealed with its own data key, and only that data key is encrypted by the cluster key. Rotating the cluster key therefore rewrites a few dozen bytes per version and never touches the values themselves, so the work does not grow with how large your secrets are.
+
+A cluster rotates its key automatically once it passes 90 days old (`secrets.key_rotation_period`; set it to `0` to rotate only on request). To rotate now, which is what an incident calls for:
+
+<CliCommand context="client">
+
+```miren
+miren secret rotate-key
+miren secret keyring
+```
+
+</CliCommand>
+
+```text
+KEY          CURRENT  AGE       VERSIONS
+Qa1gSJKRrOU  -        3 months  12
+p9XmK2vNbQs  ✓        just now  4
+
+Rotating off Qa1gSJKRrOU — 4 versions rewrapped so far.
+```
+
+A key other than the current one with versions still on it is a rotation part-way through. Nothing is unreadable while that runs — every key in the ring can still decrypt what it wrapped — and the old key is retired only once its count reaches zero. An interrupted rotation resumes on its own, because the work left is "versions still on the old key", which the cluster can always re-ask.
+
+:::note[Rotating the key does not touch your secrets]
+This changes how values are encrypted at rest. It does not change any secret's value or mint new versions, so nothing referencing a secret needs redeploying.
+:::
+
 ## Backends
 
 `cluster` is Miren's own store, and is always available. It is one *backend instance* among what a cluster may register — the model is designed so that external managers (Vault, AWS Secrets Manager, GCP Secret Manager) can be registered alongside it under their own names, with references written the same way:

--- a/docs/docs/secrets.md
+++ b/docs/docs/secrets.md
@@ -1,6 +1,6 @@
 ---
 title: Secrets
-description: Store credentials encrypted in your cluster and reference them from app config, so the value never sits in plaintext and every deploy records exactly which version it used.
+description: Store credentials encrypted in your cluster and reference them from app config, so the value is never stored in the clear and every deploy records exactly which version it used.
 keywords: [secrets, credentials, encryption, rotation, env vars, secret backend]
 ---
 
@@ -8,9 +8,7 @@ import CliCommand from '@site/src/components/CliCommand';
 
 # Secrets
 
-A secret is a credential Miren holds **encrypted**, that your app config **points at** rather than contains. The value is decrypted only in memory, at the moment a container starts.
-
-This is different from marking an env var sensitive:
+For a real credential, `miren env set -s` is not enough: it masks the value in output, but the value itself still sits in your config. A secret is the alternative — a credential Miren holds **encrypted**, that your app config **points at** rather than contains.
 
 | | `miren env set -s KEY` | `miren secret set` |
 |---|---|---|
@@ -20,6 +18,8 @@ This is different from marking an env var sensitive:
 | History | none | immutable versions you can roll back to |
 
 Use `-s` for values that are merely noisy in a terminal. Use a secret for anything that would matter if it leaked.
+
+Miren decrypts a secret at two points and holds the result only in memory: when a deploy resolves your reference to a concrete version, and when the container that needs the value is created. It is never written back to the cluster store in the clear.
 
 ## Storing a secret
 
@@ -58,10 +58,12 @@ Point an environment variable at it. The value does not travel through your shel
 <CliCommand context="client">
 
 ```miren
-miren env set -e STRIPE_API_KEY --backend cluster --ref payments/stripe-key
+miren env set -e STRIPE_API_KEY --ref payments/stripe-key
 ```
 
 </CliCommand>
+
+`--backend` defaults to `cluster`, so it is only needed when you have another backend registered.
 
 Or declare it in `app.toml`, which is safe to commit:
 
@@ -82,7 +84,7 @@ STRIPE_API_KEY   → cluster:payments/stripe-key@x1A  manual
 DATABASE_POOL    10                                 manual
 ```
 
-A reference cannot be combined with a value — set one or the other.
+Note the asymmetry: `backend` is optional on the command line but **required** in `app.toml`, where a `ref` without one is rejected rather than assumed. A reference cannot be combined with a value — set one or the other.
 
 ## Pinning: which version a deploy used
 
@@ -162,6 +164,8 @@ Each version is sealed with its own random data key, and only that key is encryp
 - The cluster key only ever performs small fixed-size operations, so it can move behind a KMS later without your stored data changing shape.
 
 Within Miren, the plaintext exists only transiently and only in memory: while a deploy resolves it, and while the container that needs it is being created. It is never written to the cluster store, a sandbox spec, an image layer, or a log.
+
+On a multi-node cluster the value does cross the network once. A runner holds no key material, so the coordinator decrypts and returns the value over the cluster's authenticated connection, where it lives only long enough to be handed to the container.
 
 Once the container starts, your application holds its own copy for as long as it runs — an environment variable is readable by the process and anything that can inspect it. Miren stops handing the value around; it cannot un-give it to the app you handed it to.
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -44,6 +44,7 @@ const sidebars: SidebarsConfig = {
       label: 'Networking & Security',
       collapsed: false,
       items: [
+        'secrets',
         'traffic-routing',
         'tls',
         'firewall',

--- a/pkg/secret/remote/remote.go
+++ b/pkg/secret/remote/remote.go
@@ -1,0 +1,55 @@
+// Package remote resolves secret references over RPC, for nodes that hold no
+// key material.
+//
+// A distributed runner can reach the entity store but not the cluster keyring,
+// so it cannot decrypt a stored secret itself. It asks the coordinator instead:
+// the bytes are decrypted where the keyring lives and travel back over the
+// authenticated RPC connection the runner already holds, to be held in memory
+// only for as long as it takes to hand them to a container.
+package remote
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"miren.dev/runtime/api/secret/secret_v1alpha"
+	"miren.dev/runtime/pkg/secret"
+)
+
+// resolveTimeout bounds a single resolve so a hung coordinator cannot stall
+// sandbox creation indefinitely. Failing is better than hanging: the sandbox
+// reports a clear error and the scheduler can retry.
+const resolveTimeout = 15 * time.Second
+
+// Resolver resolves references through the coordinator's secrets service.
+type Resolver struct {
+	client *secret_v1alpha.SecretsClient
+}
+
+var _ secret.Resolver = (*Resolver)(nil)
+
+// NewResolver wraps a secrets client as a Resolver.
+func NewResolver(client *secret_v1alpha.SecretsClient) *Resolver {
+	return &Resolver{client: client}
+}
+
+// ResolveRef fetches a reference's value from the coordinator.
+//
+// The error deliberately names the backend and reference but not the upstream
+// error's full text, which could quote surrounding context back into a log on a
+// node that has no business holding it.
+func (r *Resolver) ResolveRef(ctx context.Context, backend, ref string) (secret.SecretValue, error) {
+	ctx, cancel := context.WithTimeout(ctx, resolveTimeout)
+	defer cancel()
+
+	res, err := r.client.Resolve(ctx, backend, ref)
+	if err != nil {
+		return secret.SecretValue{}, fmt.Errorf("resolving %s:%s via coordinator: %w", backend, ref, err)
+	}
+
+	return secret.SecretValue{
+		Ref:   res.Ref(),
+		Bytes: res.Value(),
+	}, nil
+}

--- a/servers/secret/server.go
+++ b/servers/secret/server.go
@@ -309,3 +309,35 @@ func (s *Server) RotateKey(ctx context.Context, state *secret_v1alpha.SecretsRot
 	state.Results().SetToKey(to)
 	return nil
 }
+
+// Resolve returns a reference's value, for a caller that cannot decrypt it
+// itself.
+//
+// A distributed runner holds no key material, so this is how a sandbox on one
+// materializes its secrets: the bytes are decrypted here, where the keyring
+// lives, and travel to the runner, which holds them only long enough to hand
+// them to a container.
+//
+// It is deliberately not logged at Info. Unlike a write or a revocation, a
+// resolve happens on every sandbox start, so recording each one would drown the
+// audit tier it sits in without telling an operator anything they did not
+// already know from the deploy.
+func (s *Server) Resolve(ctx context.Context, state *secret_v1alpha.SecretsResolve) error {
+	args := state.Args()
+
+	ref := args.Ref()
+	if ref == "" {
+		return fmt.Errorf("secret reference is required")
+	}
+
+	backendName := backendOrDefault(args.Backend())
+
+	val, err := s.registry.ResolveRef(ctx, backendName, ref)
+	if err != nil {
+		return err
+	}
+
+	state.Results().SetRef(val.Ref)
+	state.Results().SetValue(val.Bytes)
+	return nil
+}

--- a/servers/secret/server.go
+++ b/servers/secret/server.go
@@ -318,6 +318,18 @@ func (s *Server) RotateKey(ctx context.Context, state *secret_v1alpha.SecretsRot
 // lives, and travel to the runner, which holds them only long enough to hand
 // them to a container.
 //
+// Access control comes from the RPC layer, not from here: the method is not
+// marked Public, so the server rejects it before dispatch unless the caller
+// presented an identity it authenticated (mTLS or OIDC — see the non-public
+// branch in pkg/rpc.Server). Naming that explicitly because this is the one
+// place plaintext leaves the coordinator, and the guarantee is otherwise
+// invisible at the call site.
+//
+// What that does *not* yet give us is per-secret scoping — any authenticated
+// caller can resolve any reference. RFD-90 leaves that open ("Per-secret access
+// scoping"), and it wants deciding before secrets carry anything an operator
+// would not hand every workload in the cluster.
+//
 // It is deliberately not logged at Info. Unlike a write or a revocation, a
 // resolve happens on every sandbox start, so recording each one would drown the
 // audit tier it sits in without telling an operator anything they did not

--- a/servers/secret/server_test.go
+++ b/servers/secret/server_test.go
@@ -283,3 +283,58 @@ func TestRotateKeyWithoutRotationWired(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not enabled")
 }
+
+// Resolve is how a node holding no key material gets a value: the bytes are
+// decrypted where the keyring lives and travel back over RPC.
+func TestResolveReturnsTheValueAndAConcreteRef(t *testing.T) {
+	c := newTestClient(t)
+	ctx := t.Context()
+
+	set, err := c.Set(ctx, "", "payments/stripe-key", []byte("sk_live_abc123"))
+	require.NoError(t, err)
+
+	// A floating reference comes back fully qualified, so the caller learns
+	// which version it actually got.
+	res, err := c.Resolve(ctx, "", "payments/stripe-key")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("sk_live_abc123"), res.Value())
+	assert.Equal(t, secret.FormatRef("payments/stripe-key", set.Version()), res.Ref())
+}
+
+func TestResolveHonoursAPin(t *testing.T) {
+	c := newTestClient(t)
+	ctx := t.Context()
+
+	first, err := c.Set(ctx, "", "payments/stripe-key", []byte("old"))
+	require.NoError(t, err)
+	_, err = c.Set(ctx, "", "payments/stripe-key", []byte("new"))
+	require.NoError(t, err)
+
+	res, err := c.Resolve(ctx, "", secret.FormatRef("payments/stripe-key", first.Version()))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("old"), res.Value())
+}
+
+// A revoked version must not resolve for a remote caller either, or disabling a
+// leaked credential would only take effect on the coordinator.
+func TestResolveFailsClosedOnARevokedVersion(t *testing.T) {
+	c := newTestClient(t)
+	ctx := t.Context()
+
+	set, err := c.Set(ctx, "", "payments/stripe-key", []byte("sk_live"))
+	require.NoError(t, err)
+
+	ref := secret.FormatRef("payments/stripe-key", set.Version())
+	_, err = c.SetState(ctx, "", ref, string(secret.StateDisabled))
+	require.NoError(t, err)
+
+	_, err = c.Resolve(ctx, "", ref)
+	assert.Error(t, err)
+}
+
+func TestResolveRejectsAnEmptyRef(t *testing.T) {
+	c := newTestClient(t)
+
+	_, err := c.Resolve(t.Context(), "", "")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Third of three stacked PRs implementing [RFD-90: Secret Backends and Materialization](https://github.com/mirendev/rfd/blob/main/rfds/0075/0090-secret-backends-and-materialization.md) ([MIR-1343](https://linear.app/miren/issue/MIR-1343)). Stacked on #1028.

The pieces that make the feature correct everywhere rather than just on a single-node cluster, plus the docs.

## Distributed runners

A distributed runner can reach the entity store but not the cluster keyring, so it cannot decrypt a stored secret itself. It now resolves through the coordinator: the bytes are decrypted where the keyring lives and travel back over the authenticated connection the runner already holds, to sit in memory only long enough to be handed to a container.

This mirrors the remote workload identity issuer, with one deliberate difference: **a failure to wire it up is fatal rather than degrading.** A runner without token issuance still runs apps; a runner without secret resolution starts sandboxes whose referenced secrets can never materialize, which is worse than refusing to start. `distributedrunners` is on by default, so without this, secrets would break on any multi-node cluster.

`Resolve` is not audited at Info. A write or a revocation is what an operator goes looking for after an incident, but a resolve happens on every sandbox start — logging each one would drown the tier it sits in while adding nothing the deploy record does not already say.

## Version reaping

A secret version is reapable only when it is neither its secret's current version nor pinned by any live ConfigVersion. That second condition is what makes the cluster backend's retention promise real: a pinned reference stays resolvable, so a rollback comes up on the bytes that version originally shipped with rather than failing or, worse, silently resolving something else.

Every ConfigVersion counts toward that, not only those belonging to active app versions — a rollback target is by definition not active, and it is exactly the case this protects.

Unlike an app version, a secret version cannot be rebuilt, so the sweep is conservative in every direction:

- A failure to list the pins **abandons the sweep** rather than proceeding on a partial picture, which would look exactly like "nothing references this."
- A superseded version is kept for a window even with nothing referencing it, because a rotation is exactly when someone might need the old value back.
- Secret versions sweep after app versions on the same tick, so deleting an app version releases its pins in the sweep that can act on them rather than the next one.

## Docs

A new [Secrets](docs/docs/secrets.md) page, plus `backend`/`ref` in the `app.toml` reference. The page leads with the distinction that actually matters: `-s` masks display while the value still sits in the store, whereas a secret is encrypted and referenced. Someone reaching for `-s` on a real credential should find that out here rather than after an audit.

Two things are called out prominently because getting them wrong is expensive: **how a rotation propagates** depends on where the reference was authored (an `app.toml` reference floats and moves on the next deploy; one set with `env set` is pinned and moves when you re-run it), and **losing the keyring file makes every stored secret permanently unrecoverable**, so it needs to be in whatever backs up the data path.

## Deliberately not included: tmpfs file secrets

RFD-90 also describes materializing a secret as an in-memory *file* for cases like a certificate or a JSON key. **I have left that out**, and I would rather flag why than ship it half-safe.

Writing a decrypted secret to a host tmpfs and bind-mounting it needs a guaranteed unmount at teardown *and* recovery for mounts orphaned by a controller crash. The sandbox controller has no per-sandbox directory cleanup today — only the Tempdir path is removed in the destroy path — so there is nowhere to hang the unmount, and no reconciliation to catch what a crash leaves behind. A tmpfs holding a decrypted secret that survives a controller restart with nothing to clean it up is a security regression relative to not having the feature.

Doing it properly needs a `mount_path` on the variable schema, the mount and unmount, and startup reconciliation for orphans following the `tokenRefresher` re-registration pattern. That is its own piece of work rather than a tail-end addition here.

Environment-variable materialization — which RFD-90 calls the common case — ships in #1028 and is unaffected.

## Testing

Unit tests for the reaping rules: current version retained, pinned version retained (with an explicit assertion that it is still readable afterward), unreferenced version reaped, recently superseded version kept, disabled-but-unreferenced version reaped, and an empty cluster sweeping cleanly. Service tests for `Resolve`, including that a revoked version fails closed for a remote caller too — otherwise disabling a leaked credential would only take effect on the coordinator.

New blackbox coverage running the full loop against a real cluster: store, reference, read the materialized value out of the running container with `sandbox exec`, rotate without disturbing it, re-pin, and confirm a revoked version fails closed. It also asserts the value never appears in any listing.

Full unit suite green.