### PR TITLE
Use direct standard library helpers

### DIFF
--- a/cli/commands/admin.go
+++ b/cli/commands/admin.go
@@ -290,9 +290,9 @@ func parseUnknownFlags(unknown []string, params map[string]any, paramSources map
 		switch {
 		case strings.HasPrefix(arg, "--"):
 			flagStr := arg[2:]
-			if idx := strings.IndexByte(flagStr, '='); idx >= 0 {
-				key = flagStr[:idx]
-				value = flagStr[idx+1:]
+			if before, after, ok := strings.Cut(flagStr, "="); ok {
+				key = before
+				value = after
 			} else {
 				key = flagStr
 				// Next arg is the value unless it looks like another flag.
@@ -312,9 +312,9 @@ func parseUnknownFlags(unknown []string, params map[string]any, paramSources map
 
 		case strings.HasPrefix(arg, "-"):
 			flagStr := arg[1:]
-			if idx := strings.IndexByte(flagStr, '='); idx >= 0 {
-				key = flagStr[:idx]
-				value = flagStr[idx+1:]
+			if before, after, ok := strings.Cut(flagStr, "="); ok {
+				key = before
+				value = after
 			} else {
 				key = flagStr
 				// Next arg is the value unless it looks like another flag.
@@ -334,9 +334,9 @@ func parseUnknownFlags(unknown []string, params map[string]any, paramSources map
 
 		default:
 			// Bare arg — treat as key=value if it contains '='
-			if idx := strings.IndexByte(arg, '='); idx >= 0 {
-				key = arg[:idx]
-				value = arg[idx+1:]
+			if before, after, ok := strings.Cut(arg, "="); ok {
+				key = before
+				value = after
 			} else {
 				return fmt.Errorf("unexpected argument in flags: %s", arg)
 			}

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -243,10 +243,10 @@ func addCluster(ctx *Context, identityName, clusterName, address string, force b
 func normalizeAddress(address string) (normalizedAddr, sniHost string, err error) {
 	// Strip scheme if present
 	addr := address
-	if strings.HasPrefix(addr, "https://") {
-		addr = strings.TrimPrefix(addr, "https://")
-	} else if strings.HasPrefix(addr, "http://") {
-		addr = strings.TrimPrefix(addr, "http://")
+	if after, ok := strings.CutPrefix(addr, "https://"); ok {
+		addr = after
+	} else if after, ok := strings.CutPrefix(addr, "http://"); ok {
+		addr = after
 	}
 
 	// Handle IPv6 literals and port logic

--- a/cli/commands/debug_bundle.go
+++ b/cli/commands/debug_bundle.go
@@ -85,7 +85,7 @@ func DebugBundle(ctx *Context, opts struct {
 	processData, err := gatherProcesses()
 	if err != nil {
 		ctx.Warn("Failed to gather processes: %v", err)
-		processData = []byte(fmt.Sprintf("Error gathering processes: %v\n", err))
+		processData = fmt.Appendf(nil, "Error gathering processes: %v\n", err)
 	}
 	if err := writeToArchive(tw, "miren-debug/processes.txt", processData); err != nil {
 		return fmt.Errorf("writing processes.txt: %w", err)
@@ -112,7 +112,7 @@ func DebugBundle(ctx *Context, opts struct {
 	containerData, err := gatherContainers(ctx, opts.Socket, opts.Namespace)
 	if err != nil {
 		ctx.Warn("Failed to gather containers: %v", err)
-		containerData = []byte(fmt.Sprintf("Error gathering containers: %v\n", err))
+		containerData = fmt.Appendf(nil, "Error gathering containers: %v\n", err)
 	}
 	if err := writeToArchive(tw, "miren-debug/containers.txt", containerData); err != nil {
 		return fmt.Errorf("writing containers.txt: %w", err)
@@ -123,7 +123,7 @@ func DebugBundle(ctx *Context, opts struct {
 	logData, err := gatherServerLogs(opts.Since, opts.DockerContainer)
 	if err != nil {
 		ctx.Warn("Failed to gather server logs: %v", err)
-		logData = []byte(fmt.Sprintf("Error gathering server logs: %v\n", err))
+		logData = fmt.Appendf(nil, "Error gathering server logs: %v\n", err)
 	}
 	if err := writeToArchive(tw, "miren-debug/server-logs.txt", logData); err != nil {
 		return fmt.Errorf("writing server-logs.txt: %w", err)

--- a/clientconfig/token_refresh_concurrency_test.go
+++ b/clientconfig/token_refresh_concurrency_test.go
@@ -156,8 +156,8 @@ func TestTokenForIdentityConcurrentRefresh(t *testing.T) {
 			}
 			// Child prints the token on a line prefixed with TOKEN=.
 			for _, line := range strings.Split(string(out), "\n") {
-				if strings.HasPrefix(line, "TOKEN=") {
-					tokens <- strings.TrimPrefix(line, "TOKEN=")
+				if after, ok := strings.CutPrefix(line, "TOKEN="); ok {
+					tokens <- after
 				}
 			}
 		}()

--- a/controllers/sandbox/log.go
+++ b/controllers/sandbox/log.go
@@ -107,11 +107,11 @@ func (s *SandboxLogs) processLine(line string) {
 
 	stream := s.stream
 
-	if strings.HasPrefix(line, "!USER ") {
-		line = strings.TrimPrefix(line, "!USER ")
+	if after, ok := strings.CutPrefix(line, "!USER "); ok {
+		line = after
 		stream = observability.UserOOB
-	} else if strings.HasPrefix(line, "!ERROR ") {
-		line = strings.TrimPrefix(line, "!ERROR ")
+	} else if after, ok := strings.CutPrefix(line, "!ERROR "); ok {
+		line = after
 		stream = observability.Error
 	}
 

--- a/controllers/service/service.go
+++ b/controllers/service/service.go
@@ -135,12 +135,12 @@ func nftProto(p network_v1alpha.PortProtocol) string {
 }
 
 func (s *ServiceController) serviceChain(ip netip.Addr, port uint16, proto string) string {
-	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%s:%d", ip.String(), proto, port)))
+	x := blake2b.Sum256(fmt.Appendf(nil, "%s:%s:%d", ip.String(), proto, port))
 	return fmt.Sprintf("service_%s", base58.Encode(x[:]))
 }
 
 func (s *ServiceController) endpointChain(ip netip.Addr, port uint16, proto string) string {
-	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%s:%d", ip.String(), proto, port)))
+	x := blake2b.Sum256(fmt.Appendf(nil, "%s:%s:%d", ip.String(), proto, port))
 	return fmt.Sprintf("endpoint_%s", base58.Encode(x[:]))
 }
 
@@ -148,7 +148,7 @@ func (s *ServiceController) endpointChain(ip netip.Addr, port uint16, proto stri
 // of the cluster-facing port, so the key is (proto, nport) — independent of
 // any service IP, which a service may not yet have when this chain installs.
 func (s *ServiceController) nodeportChain(nport int, proto string) string {
-	x := blake2b.Sum256([]byte(fmt.Sprintf("%s:%d", proto, nport)))
+	x := blake2b.Sum256(fmt.Appendf(nil, "%s:%d", proto, nport))
 	return fmt.Sprintf("nodeport_%s", base58.Encode(x[:]))
 }
 

--- a/metrics/memory_usage.go
+++ b/metrics/memory_usage.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strconv"
 	"time"
 
@@ -53,9 +54,7 @@ func (m *MemoryUsage) RecordUsage(
 	labels := make(map[string]string)
 	labels["entity"] = entity
 	labels["instance"] = m.instance
-	for k, v := range attrs {
-		labels[k] = v
-	}
+	maps.Copy(labels, attrs)
 
 	// Write memory usage in bytes
 	point := MetricPoint{

--- a/pkg/addon/ident.go
+++ b/pkg/addon/ident.go
@@ -36,8 +36,8 @@ func SanitizeIdentifier(name string, maxLen int) string {
 // to an int64 value in gigabytes. Returns 1 if the string cannot be parsed.
 func ParseStorageGb(s string) int64 {
 	s = strings.TrimSpace(s)
-	if strings.HasSuffix(s, "Gi") {
-		n, err := strconv.ParseInt(strings.TrimSuffix(s, "Gi"), 10, 64)
+	if before, ok := strings.CutSuffix(s, "Gi"); ok {
+		n, err := strconv.ParseInt(before, 10, 64)
 		if err == nil && n > 0 {
 			return n
 		}

--- a/pkg/addon/registry.go
+++ b/pkg/addon/registry.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	"miren.dev/runtime/api/addon/addon_v1alpha"
@@ -132,9 +133,7 @@ func (r *Registry) GetVariantConfig(addonName, variantName, version string) (map
 		if v.Name == variantName {
 			// Clone the config so we don't mutate the definition.
 			cfg := make(map[string]string, len(v.Config)+1)
-			for k, val := range v.Config {
-				cfg[k] = val
-			}
+			maps.Copy(cfg, v.Config)
 			cfg[ConfigImage] = ResolveImage(def.BaseImage, def.DefaultVersion, version)
 			return cfg, nil
 		}

--- a/pkg/anywhere/pop.go
+++ b/pkg/anywhere/pop.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"strings"
@@ -567,9 +568,7 @@ func (m *POPManager) RemovePOP(popXID string) {
 func (m *POPManager) Close() {
 	m.mu.Lock()
 	conns := make(map[string]*popConnection, len(m.conns))
-	for k, v := range m.conns {
-		conns[k] = v
-	}
+	maps.Copy(conns, m.conns)
 	m.conns = make(map[string]*popConnection)
 	m.mu.Unlock()
 

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -447,8 +447,8 @@ func (b *Buildkit) BuildImage(
 								continue
 							}
 
-							if strings.HasPrefix(s.Name, "[phase] ") {
-								phase := strings.TrimPrefix(s.Name, "[phase] ")
+							if after, ok0 := strings.CutPrefix(s.Name, "[phase] "); ok0 {
+								phase := after
 								b.Log.Debug("phase update", "phase", phase)
 								opts.phaseUpdates(phase)
 							}

--- a/pkg/cel/types.go
+++ b/pkg/cel/types.go
@@ -18,6 +18,7 @@ package cel
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"time"
 
@@ -325,9 +326,7 @@ func allTypesForDecl(declTypes []*DeclType) map[string]*DeclType {
 	}
 	allTypes := map[string]*DeclType{}
 	for _, declType := range declTypes {
-		for k, t := range FieldTypeMap(declType.TypeName(), declType) {
-			allTypes[k] = t
-		}
+		maps.Copy(allTypes, FieldTypeMap(declType.TypeName(), declType))
 	}
 
 	return allTypes

--- a/pkg/containerdx/opts.go
+++ b/pkg/containerdx/opts.go
@@ -3,8 +3,9 @@ package containerdx
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -45,7 +46,7 @@ func mergeGids(gids1, gids2 []uint32) []uint32 {
 	for gid := range gidsMap {
 		gids = append(gids, gid)
 	}
-	sort.Slice(gids, func(i, j int) bool { return gids[i] < gids[j] })
+	slices.Sort(gids)
 	return gids
 }
 
@@ -490,9 +491,7 @@ func WithSysctls(sysctls map[string]string) oci.SpecOpts {
 		if s.Linux.Sysctl == nil {
 			s.Linux.Sysctl = make(map[string]string)
 		}
-		for k, v := range sysctls {
-			s.Linux.Sysctl[k] = v
-		}
+		maps.Copy(s.Linux.Sysctl, sysctls)
 		return nil
 	}
 }

--- a/pkg/entity/schema/schema.go
+++ b/pkg/entity/schema/schema.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"slices"
-	"sort"
 
 	"github.com/mr-tron/base58"
 	"golang.org/x/crypto/blake2b"
@@ -329,9 +328,7 @@ func IndexedAttributeIDs() []entity.Id {
 		}
 	}
 
-	sort.Slice(ids, func(i, j int) bool {
-		return ids[i] < ids[j]
-	})
+	slices.Sort(ids)
 
 	return ids
 }

--- a/pkg/progress/progressui/display.go
+++ b/pkg/progress/progressui/display.go
@@ -817,7 +817,7 @@ func (t *trace) update(s *client.SolveStatus, termWidth int) {
 				} else if sec < 100 {
 					prec = 2
 				}
-				v.logs = append(v.logs, []byte(fmt.Sprintf("%s %s", fmt.Sprintf("%.[2]*[1]f", sec, prec), dt)))
+				v.logs = append(v.logs, fmt.Appendf(nil, "%s %s", fmt.Sprintf("%.[2]*[1]f", sec, prec), dt))
 			}
 			i++
 		})

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -572,8 +572,8 @@ func (s *State) Connect(remote string, name string) (*NetworkClient, error) {
 		client *NetworkClient
 		err    error
 	)
-	if strings.HasPrefix(remote, "unix:") {
-		client, err = s.connectLocal(strings.TrimPrefix(remote, "unix:"))
+	if after, ok := strings.CutPrefix(remote, "unix:"); ok {
+		client, err = s.connectLocal(after)
 		if err != nil {
 			return nil, err
 		}

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -451,8 +451,8 @@ func (b *Buildkit) BuildImage(
 								continue
 							}
 
-							if strings.HasPrefix(s.Name, "[phase] ") {
-								phase := strings.TrimPrefix(s.Name, "[phase] ")
+							if after, ok0 := strings.CutPrefix(s.Name, "[phase] "); ok0 {
+								phase := after
 								b.Log.Debug("phase update", "phase", phase)
 								opts.phaseUpdates(phase)
 							}

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -294,8 +294,8 @@ func requestScheme(r *http.Request) string {
 	if fwd := r.Header.Get("Forwarded"); fwd != "" {
 		for _, part := range strings.Split(fwd, ";") {
 			part = strings.TrimSpace(part)
-			if strings.HasPrefix(part, "proto=") {
-				return strings.TrimPrefix(part, "proto=")
+			if after, ok := strings.CutPrefix(part, "proto="); ok {
+				return after
 			}
 		}
 	}


### PR DESCRIPTION
`go fix` still had a handful of small, mechanical suggestions after the larger Go 1.26 follow-ups were peeled off. None really warranted its own review cycle, but lumping them into one commit would make the changes harder to inspect.

This keeps three narrow revisions under one PR. The first formats directly into byte slices when the caller immediately needs bytes. The second replaces map-copy loops and natural-order sort callbacks with `maps.Copy` and `slices.Sort`. The third uses `strings.Cut`, `CutPrefix`, and `CutSuffix` where code checked for a delimiter or affix and then repeated the same operation to remove it.

All 27 replacements come directly from the corresponding analyzers and preserve the existing output, ordering, and success conditions. Generated files and the larger or more semantic fixer families stay separate.

Stacked on #1032, which handles the `reflect.TypeFor` cleanup.