### PR TITLE
Pick up the flannel fix for the per-node lease watch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -389,8 +389,10 @@ require (
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
-// Temporary fork carrying the etcd subnet-watch compaction-recovery fix:
-// upstream hot-loops forever once a watch's start revision is compacted
-// away. Drop this once the fix is merged upstream into flannel-io/flannel
-// and released. Tracking: MIR-1274.
-replace github.com/flannel-io/flannel => github.com/mirendev/flannel v0.26.8-0.20260630195747-affa754a04b8
+// Temporary fork carrying the etcd subnet-watch compaction-recovery fixes:
+// upstream hot-loops forever once a watch's start revision is compacted away.
+// Both watches are affected, and both run on every node. Both fixes are merged
+// upstream now (flannel-io/flannel#2471, #2524), but only #2471 has shipped, in
+// v0.28.6. Drop this replace once we move to a flannel release carrying both.
+// Tracking: MIR-1274.
+replace github.com/flannel-io/flannel => github.com/mirendev/flannel v0.26.8-0.20260805213236-ce737c30f40c

--- a/go.sum
+++ b/go.sum
@@ -868,8 +868,8 @@ github.com/mimuret/golang-iij-dpf v0.9.1 h1:Gj6EhHJkOhr+q2RnvRPJsPMcjuVnWPSccEHy
 github.com/mimuret/golang-iij-dpf v0.9.1/go.mod h1:sl9KyOkESib9+KRD3HaGpgi1xk7eoN2+d96LCLsME2M=
 github.com/minio/highwayhash v1.0.1/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
-github.com/mirendev/flannel v0.26.8-0.20260630195747-affa754a04b8 h1:FYfTsdVBXM9Qxu2lEYOlU3QZ4V5tY6KS1aJmdCO6oHY=
-github.com/mirendev/flannel v0.26.8-0.20260630195747-affa754a04b8/go.mod h1:/oz+EbTC6NGJTxk2VsqBigFAqaIEYBuS7Bf9/MDJ2DI=
+github.com/mirendev/flannel v0.26.8-0.20260805213236-ce737c30f40c h1:JA+DVw1mVm48VLK/U0zI991j2feFzikW/fU9tO5Eq+s=
+github.com/mirendev/flannel v0.26.8-0.20260805213236-ce737c30f40c/go.mod h1:/oz+EbTC6NGJTxk2VsqBigFAqaIEYBuS7Bf9/MDJ2DI=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
Back in June we pinned a `mirendev/flannel` fork to fix an etcd subnet-watch hot-loop that had filled both toys runners' disks and dropped them out of the cluster (MIR-1274, #874). That fix was real, but it only covered half the problem. I even said so upstream at the time, and then claimed we didn't use the other half. We do, on every node.

flannel has two subnet watches and we run both in the same process. The backend watches every subnet to build WireGuard peers and routes. Separately, `CompleteLease` watches this node's own lease so it can notice a revocation. June's fix covered the first one. The second still takes a start revision it never advances, so once etcd compacts past that revision, every reconnect fails identically at the 5s backoff cap, forever, and only a restart clears it.

This turned up while catching our infra up to the log verbosity change. Both miren-garden runners have been sitting in that loop, and the trigger is an etcd restart rather than anything gradual. On one of them etcd restarted at 18:26:01 and the watch broke nine seconds later, then never recovered.

The log volume is the visible symptom but not the worst part. With the watch wedged, `CompleteLease` can never receive the `EventRemoved` it relies on to notice its lease was revoked, so that safety path stays silently disarmed until the process restarts.

So this bumps the pin to a fork branch carrying the fix. The branch is cut from the commit we already run rather than from flannel master, which is 440 commits ahead, so this stays a one-fix delta instead of a flannel version bump wearing a bugfix's clothes.

The same fix went upstream as flannel-io/flannel#2524 and has now been merged, with tests covering both recovery outcomes plus the full field sequence (healthy watch, drift below the horizon, etcd bounce). Verified fail-before/pass-after there. It is merged but unreleased, though, and we are pinned to a v0.26.7-era fork rather than current master, so we still need the `replace` for now. The `go.mod` comment records that: both fixes are upstream, only #2471 has shipped (v0.28.6), and dropping the `replace` means moving to a release carrying both.

What this PR has not done is run the patched build on real hardware. The first real exercise will be whenever it reaches a runner.

Refs MIR-1274
