### PR TITLE
Use direct bounds and string helpers

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -413,7 +413,8 @@ func (m Model) View() string {
 			))
 	}
 
-	hdr := fmt.Sprintf("       name: %s\nlast update: %s %s\n",
+	var hdr strings.Builder
+	fmt.Fprintf(&hdr, "       name: %s\nlast update: %s %s\n",
 		bold.Render(m.status.Name()),
 		bold.Render(lastUpdate),
 		laExtra,
@@ -441,7 +442,7 @@ func (m Model) View() string {
 			instanceInfo = fmt.Sprintf("instances=%d (auto)", instanceCount)
 		}
 
-		hdr += fmt.Sprintf("       pool: %s %s\n", bold.Render(ps.Name()), instanceInfo)
+		fmt.Fprintf(&hdr, "       pool: %s %s\n", bold.Render(ps.Name()), instanceInfo)
 	}
 
 	var (
@@ -637,7 +638,7 @@ func (m Model) View() string {
 			)
 	}
 
-	frame := lipgloss.JoinVertical(lipgloss.Top, hdr, body, footer)
+	frame := lipgloss.JoinVertical(lipgloss.Top, hdr.String(), body, footer)
 	if m.quitting {
 		frame += "\n"
 	}

--- a/cli/commands/auth_provider_github.go
+++ b/cli/commands/auth_provider_github.go
@@ -102,7 +102,7 @@ func buildGitHubConfigJSON(orgs []string) (string, error) {
 		}
 		org := connectors.GitHubOrg{Name: name}
 		if hasTeams {
-			for _, t := range strings.Split(teamsPart, ",") {
+			for t := range strings.SplitSeq(teamsPart, ",") {
 				t = strings.TrimSpace(t)
 				if t != "" {
 					org.Teams = append(org.Teams, t)

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -399,32 +399,32 @@ func (c *Context) DisplayTable(headers []string, rows [][]string) {
 	}
 
 	// Render headers
-	headerRow := ""
+	var headerRow strings.Builder
 	for i, header := range headers {
-		headerRow += headerStyle.
+		headerRow.WriteString(headerStyle.
 			Width(colWidths[i] + 2).
-			Render(header)
+			Render(header))
 	}
-	fmt.Fprintln(c.Stdout, headerRow)
+	fmt.Fprintln(c.Stdout, headerRow.String())
 
 	// Render separator
-	sep := ""
+	var sep strings.Builder
 	for _, width := range colWidths {
-		sep += strings.Repeat("─", width+2)
+		sep.WriteString(strings.Repeat("─", width+2))
 	}
 	fmt.Fprintln(c.Stdout, lipgloss.NewStyle().
 		Foreground(theme.Muted). // Gray
-		Render(sep))
+		Render(sep.String()))
 
 	// Render data rows
 	for _, row := range rows {
-		renderedRow := ""
+		var renderedRow strings.Builder
 		for i, cell := range row {
-			renderedRow += cellStyle.
+			renderedRow.WriteString(cellStyle.
 				Width(colWidths[i] + 2).
-				Render(cell)
+				Render(cell))
 		}
-		fmt.Fprintln(c.Stdout, renderedRow)
+		fmt.Fprintln(c.Stdout, renderedRow.String())
 	}
 }
 

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -110,10 +110,7 @@ func setup(ctx context.Context, flags *GlobalFlags, opts any, commandName string
 	// Initialize config from flags
 	s.Config.ServerAddress = flags.ServerAddress
 
-	level := baseLogLevel(daemon) - slog.Level(4*s.verbose)
-	if level < slog.LevelDebug {
-		level = slog.LevelDebug
-	}
+	level := max(baseLogLevel(daemon)-slog.Level(4*s.verbose), slog.LevelDebug)
 
 	s.levelVar.Set(level)
 

--- a/cli/commands/section_help_test.go
+++ b/cli/commands/section_help_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"miren.dev/mflags"
@@ -42,14 +43,14 @@ func TestSectionHelpWithGlobalFlag(t *testing.T) {
 }
 
 func argsName(args []string) string {
-	name := ""
+	var name strings.Builder
 	for i, a := range args {
 		if i > 0 {
-			name += "_"
+			name.WriteString("_")
 		}
-		name += a
+		name.WriteString(a)
 	}
-	return name
+	return name.String()
 }
 
 // captureDispatch builds the full dispatcher and runs Execute with the given

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -57,7 +57,7 @@ func checkSystemRequirements() systemRequirements {
 	if err != nil {
 		reqs.memoryCheckFailed = true
 	} else {
-		for _, line := range strings.Split(string(meminfoBytes), "\n") {
+		for line := range strings.SplitSeq(string(meminfoBytes), "\n") {
 			if strings.HasPrefix(line, "MemTotal:") {
 				fields := strings.Fields(line)
 				if len(fields) >= 2 {

--- a/cli/commands/upgrade_permissions.go
+++ b/cli/commands/upgrade_permissions.go
@@ -122,8 +122,8 @@ func ensureUserInstallDir(installPath string) (needsPathUpdate bool, err error) 
 
 	// Check if the directory is in PATH
 	pathEnv := os.Getenv("PATH")
-	paths := strings.Split(pathEnv, ":")
-	for _, p := range paths {
+	paths := strings.SplitSeq(pathEnv, ":")
+	for p := range paths {
 		if p == dir {
 			return false, nil
 		}

--- a/clientconfig/token_refresh_concurrency_test.go
+++ b/clientconfig/token_refresh_concurrency_test.go
@@ -155,7 +155,7 @@ func TestTokenForIdentityConcurrentRefresh(t *testing.T) {
 				return
 			}
 			// Child prints the token on a line prefixed with TOKEN=.
-			for _, line := range strings.Split(string(out), "\n") {
+			for line := range strings.SplitSeq(string(out), "\n") {
 				if after, ok := strings.CutPrefix(line, "TOKEN="); ok {
 					tokens <- after
 				}

--- a/components/base/base.go
+++ b/components/base/base.go
@@ -525,10 +525,7 @@ func (b *BaseComponent) handleRestart(ctx context.Context, stopMonitor <-chan st
 	}
 
 	// Calculate backoff
-	backoff := policy.BackoffBase * time.Duration(1<<(restartCount-1))
-	if backoff > policy.BackoffMax {
-		backoff = policy.BackoffMax
-	}
+	backoff := min(policy.BackoffBase*time.Duration(1<<(restartCount-1)), policy.BackoffMax)
 
 	b.Log.Info("restarting "+b.ComponentName+" after backoff",
 		"restart_count", restartCount,

--- a/components/etcd/tuning.go
+++ b/components/etcd/tuning.go
@@ -76,7 +76,7 @@ func detectSystemRAMBytes() int64 {
 	if err != nil {
 		return 0
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		if !strings.HasPrefix(line, "MemTotal:") {
 			continue
 		}

--- a/components/etcd/tuning.go
+++ b/components/etcd/tuning.go
@@ -98,20 +98,11 @@ func detectSystemRAMBytes() int64 {
 // --quota-backend-bytes explicitly (operator-configured); otherwise the quota is the
 // RAM-scaled value clamped to [quotaFloorBytes, quotaCapBytes].
 func computeTuning(systemRAMBytes int64, quotaOverride int64) etcdTuning {
-	budget := systemRAMBytes / 10
-	if budget < memoryFloorBytes {
-		budget = memoryFloorBytes
-	}
+	budget := max(systemRAMBytes/10, memoryFloorBytes)
 
 	quota := quotaOverride
 	if quota <= 0 {
-		quota = budget * 30 / 100
-		if quota < quotaFloorBytes {
-			quota = quotaFloorBytes
-		}
-		if quota > quotaCapBytes {
-			quota = quotaCapBytes
-		}
+		quota = min(max(budget*30/100, quotaFloorBytes), quotaCapBytes)
 	}
 
 	streams := budget / (2 * mib)

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -659,10 +659,7 @@ func (m *Manager) checkPoolForScaleDown(ctx context.Context, pool *compute_v1alp
 	// If we have idle sandboxes and we're above minimum instances, decrement desired
 	if idleCount > 0 && pool.DesiredInstances > minInstances {
 		// Only decrement by the number of idle sandboxes, but respect minimum
-		newDesired := pool.DesiredInstances - idleCount
-		if newDesired < minInstances {
-			newDesired = minInstances
-		}
+		newDesired := max(pool.DesiredInstances-idleCount, minInstances)
 
 		if newDesired < pool.DesiredInstances {
 			m.log.Info("proactively scaling down pool",
@@ -872,12 +869,8 @@ func (m *Manager) calculateBackoff(crashCount int64) time.Time {
 // to prove stability. The required uptime scales with the crash count.
 func (m *Manager) hasHealthySandbox(sandboxes []*sandboxWithMeta, crashCount int64) bool {
 	// Calculate required uptime based on current backoff
-	requiredUptime := backoffDuration(crashCount)
-
 	// Minimum 2 minutes required uptime
-	if requiredUptime < 2*time.Minute {
-		requiredUptime = 2 * time.Minute
-	}
+	requiredUptime := max(backoffDuration(crashCount), 2*time.Minute)
 
 	now := time.Now()
 	for _, sbm := range sandboxes {

--- a/hack/coverage-changed-lines/main.go
+++ b/hack/coverage-changed-lines/main.go
@@ -187,8 +187,8 @@ func getChangedLineRanges(baseBranch string) ([]ChangedLineRange, error) {
 	diffFilePattern := regexp.MustCompile(`^diff --git a/(.*) b/(.*)$`)
 	chunkPattern := regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
 
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(output), "\n")
+	for line := range lines {
 		// Track current file (use the "b/" path - new version)
 		if matches := diffFilePattern.FindStringSubmatch(line); matches != nil {
 			currentFile = matches[2]

--- a/metrics/runtime_memory_test.go
+++ b/metrics/runtime_memory_test.go
@@ -54,7 +54,7 @@ func TestRuntimeMemory_Collect(t *testing.T) {
 	}
 
 	// Every series carries the control-process entity label.
-	for _, line := range strings.Split(strings.TrimSpace(receivedData), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(receivedData), "\n") {
 		if line == "" {
 			continue
 		}

--- a/metrics/victoriametrics_reader.go
+++ b/metrics/victoriametrics_reader.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -231,16 +232,17 @@ func buildMetricSelector(metricName string, labels map[string]string) string {
 		return metricName
 	}
 
-	selector := metricName + "{"
+	var selector strings.Builder
+	selector.WriteString(metricName + "{")
 	first := true
 	for k, v := range labels {
 		if !first {
-			selector += ","
+			selector.WriteString(",")
 		}
 		first = false
-		selector += fmt.Sprintf(`%s="%s"`, k, v)
+		fmt.Fprintf(&selector, `%s="%s"`, k, v)
 	}
-	selector += "}"
+	selector.WriteString("}")
 
-	return selector
+	return selector.String()
 }

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -576,8 +576,8 @@ func (l *LogReader) executeQuery(ctx context.Context, query string, limit int, s
 	}
 
 	// Split by newlines and parse each line
-	lines := bytes.Split(body, []byte("\n"))
-	for _, line := range lines {
+	lines := bytes.SplitSeq(body, []byte("\n"))
+	for line := range lines {
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue

--- a/observability/profile/profile.go
+++ b/observability/profile/profile.go
@@ -179,7 +179,7 @@ func getCPUs() ([]uint, error) {
 func ReadCPURange(cpuRangeStr string) ([]uint, error) {
 	var cpus []uint
 	cpuRangeStr = strings.Trim(cpuRangeStr, "\n ")
-	for _, cpuRange := range strings.Split(cpuRangeStr, ",") {
+	for cpuRange := range strings.SplitSeq(cpuRangeStr, ",") {
 		rangeOp := strings.SplitN(cpuRange, "-", 2)
 		first, err := strconv.ParseUint(rangeOp[0], 10, 32)
 		if err != nil {

--- a/pkg/addon/dbsaga/shared.go
+++ b/pkg/addon/dbsaga/shared.go
@@ -143,10 +143,7 @@ func UndoIncrementAssociationCount(ctx context.Context, in IncrementAssociationC
 		return err
 	}
 
-	newCount := count - 1
-	if newCount < 0 {
-		newCount = 0
-	}
+	newCount := max(count-1, 0)
 	return sc.PatchAssociationCount(ctx, in.ServerID, rev, newCount)
 }
 

--- a/pkg/containerdx/opts.go
+++ b/pkg/containerdx/opts.go
@@ -209,8 +209,8 @@ func ensureShared(path string, lookupMount func(string) (mount.Info, error)) err
 	}
 
 	// Make sure source mount point is shared.
-	optsSplit := strings.Split(mountInfo.Optional, " ")
-	for _, opt := range optsSplit {
+	optsSplit := strings.SplitSeq(mountInfo.Optional, " ")
+	for opt := range optsSplit {
 		if strings.HasPrefix(opt, "shared:") {
 			return nil
 		}
@@ -226,8 +226,8 @@ func ensureSharedOrSlave(path string, lookupMount func(string) (mount.Info, erro
 		return err
 	}
 	// Make sure source mount point is shared.
-	optsSplit := strings.Split(mountInfo.Optional, " ")
-	for _, opt := range optsSplit {
+	optsSplit := strings.SplitSeq(mountInfo.Optional, " ")
+	for opt := range optsSplit {
 		if strings.HasPrefix(opt, "shared:") {
 			return nil
 		} else if strings.HasPrefix(opt, "master:") {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -237,10 +237,7 @@ func (c *ReconcileController) Start(top context.Context) error {
 					return
 				case <-time.After(retryDelay):
 					// Exponential backoff with max delay
-					retryDelay = retryDelay * 2
-					if retryDelay > maxRetryDelay {
-						retryDelay = maxRetryDelay
-					}
+					retryDelay = min(retryDelay*2, maxRetryDelay)
 				}
 			} else {
 				// Watch completed normally (shouldn't happen unless context cancelled)

--- a/pkg/deploylifecycle/lock.go
+++ b/pkg/deploylifecycle/lock.go
@@ -122,10 +122,7 @@ const lockRetryBackoffMax = 100 * time.Millisecond
 // waits one base interval. The initial acquire (attempt 0 in Acquire's loop is
 // the first try, which never calls this) pays no delay.
 func (l *Locks) backoff(attempt int) {
-	d := time.Duration(attempt) * lockRetryBackoff
-	if d > lockRetryBackoffMax {
-		d = lockRetryBackoffMax
-	}
+	d := min(time.Duration(attempt)*lockRetryBackoff, lockRetryBackoffMax)
 	if d <= 0 {
 		return
 	}

--- a/pkg/entity/indexwatch/watcher.go
+++ b/pkg/entity/indexwatch/watcher.go
@@ -455,10 +455,7 @@ func (w *Watcher) sleep(ctx context.Context, backoff *time.Duration) bool {
 	case <-ctx.Done():
 		return false
 	case <-time.After(*backoff):
-		next := *backoff * 2
-		if next > w.opts.MaxBackoff {
-			next = w.opts.MaxBackoff
-		}
+		next := min(*backoff*2, w.opts.MaxBackoff)
 		*backoff = next
 		return true
 	}

--- a/pkg/entity/store.go
+++ b/pkg/entity/store.go
@@ -474,10 +474,7 @@ func (s *EtcdStore) GetEntities(ctx context.Context, ids []Id) ([]*Entity, error
 	entities := make([]*Entity, len(ids))
 
 	for start := 0; start < len(ids); start += maxEntitiesPerBatch {
-		end := start + maxEntitiesPerBatch
-		if end > len(ids) {
-			end = len(ids)
-		}
+		end := min(start+maxEntitiesPerBatch, len(ids))
 
 		batchIds := ids[start:end]
 

--- a/pkg/hey/requester/requester.go
+++ b/pkg/hey/requester/requester.go
@@ -277,10 +277,3 @@ func cloneRequest(r *http.Request, body []byte) *http.Request {
 	}
 	return r2
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/pkg/multierror/multierror.go
+++ b/pkg/multierror/multierror.go
@@ -3,6 +3,7 @@ package multierror
 import (
 	"errors"
 	"slices"
+	"strings"
 )
 
 type MultiError struct {
@@ -10,11 +11,11 @@ type MultiError struct {
 }
 
 func (m *MultiError) Error() string {
-	var s string
+	var s strings.Builder
 	for _, err := range m.errors {
-		s += err.Error() + "\n"
+		s.WriteString(err.Error() + "\n")
 	}
-	return s
+	return s.String()
 }
 
 func (m *MultiError) Unwrap() []error {

--- a/pkg/netdb/netdb.go
+++ b/pkg/netdb/netdb.go
@@ -749,9 +749,6 @@ func calculateCapacity(prefix netip.Prefix) int {
 		total := 1 << hostBits
 		return total - 3 // subtract network, broadcast, gateway
 	}
-	hostBits := 128 - bits
-	if hostBits > 16 {
-		hostBits = 16
-	}
+	hostBits := min(128-bits, 16)
 	return (1 << hostBits) - 1
 }

--- a/pkg/rbac/evaluator.go
+++ b/pkg/rbac/evaluator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -229,26 +230,27 @@ func (dc *decisionCache) clear() {
 
 func (dc *decisionCache) requestKey(req *Request) string {
 	// Include all relevant fields in cache key
-	key := fmt.Sprintf("%s:%s:%s", req.Subject, req.Resource, req.Action)
+	var key strings.Builder
+	fmt.Fprintf(&key, "%s:%s:%s", req.Subject, req.Resource, req.Action)
 
 	sort.Strings(req.Groups)
 
 	// Add groups to key
 	for _, g := range req.Groups {
-		key += ":" + g
+		key.WriteString(":" + g)
 	}
 
 	// Add tags to key
 	for k, v := range mapx.StableOrder(req.Tags) {
-		key += fmt.Sprintf(":%s=%v", k, v)
+		fmt.Fprintf(&key, ":%s=%v", k, v)
 	}
 
 	// Add context to key
 	for k, v := range mapx.StableOrder(req.Context) {
-		key += fmt.Sprintf(":%s=%v", k, v)
+		fmt.Fprintf(&key, ":%s=%v", k, v)
 	}
 
-	return key
+	return key.String()
 }
 
 func (dc *decisionCache) cleanup(ctx context.Context) {

--- a/pkg/rpc/stream/stream.go
+++ b/pkg/rpc/stream/stream.go
@@ -128,10 +128,7 @@ func (s *serveReader) Recv(ctx context.Context, state *RecvStreamRecv[[]byte]) e
 	args := state.Args()
 
 	// Limit the maximum read size to prevent excessive memory allocation
-	readSize := int(args.Count())
-	if readSize > streamChunkSize*2 {
-		readSize = streamChunkSize * 2
-	}
+	readSize := min(int(args.Count()), streamChunkSize*2)
 
 	buf := make([]byte, readSize)
 
@@ -140,10 +137,7 @@ func (s *serveReader) Recv(ctx context.Context, state *RecvStreamRecv[[]byte]) e
 		err error
 	)
 	if s.minBatch > 0 {
-		minBatch := s.minBatch
-		if minBatch > readSize {
-			minBatch = readSize
-		}
+		minBatch := min(s.minBatch, readSize)
 		n, err = io.ReadAtLeast(s.r, buf, minBatch)
 	} else {
 		// Streaming mode: ship whatever the underlying reader yields right

--- a/pkg/slogfmt/logger.go
+++ b/pkg/slogfmt/logger.go
@@ -990,9 +990,9 @@ func (b *testHandler) Handle(ctx context.Context, rec slog.Record) error {
 	output = bytes.TrimSuffix(output, []byte("\n"))
 
 	if bytes.ContainsRune(output, '\n') {
-		parts := bytes.Split(output, []byte{'\n'})
+		parts := bytes.SplitSeq(output, []byte{'\n'})
 
-		for _, x := range parts {
+		for x := range parts {
 			b.t.Log(string(x))
 		}
 	} else {

--- a/pkg/sysstats/sysstats.go
+++ b/pkg/sysstats/sysstats.go
@@ -36,8 +36,8 @@ func CollectSystemStats(dataPath string) ResourceUsage {
 	meminfoBytes, err := os.ReadFile("/proc/meminfo")
 	if err == nil {
 		var memTotal, memAvailable int64
-		lines := strings.Split(string(meminfoBytes), "\n")
-		for _, line := range lines {
+		lines := strings.SplitSeq(string(meminfoBytes), "\n")
+		for line := range lines {
 			fields := strings.Fields(line)
 			if len(fields) < 2 {
 				continue
@@ -89,8 +89,8 @@ func getCPUCount() int {
 	}
 
 	count := 0
-	lines := strings.Split(string(cpuinfoBytes), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(cpuinfoBytes), "\n")
+	for line := range lines {
 		if strings.HasPrefix(line, "processor") {
 			count++
 		}

--- a/pkg/tarx/tarx.go
+++ b/pkg/tarx/tarx.go
@@ -425,7 +425,7 @@ func SafeWritePath(root, name string) (string, error) {
 	}
 
 	current := root
-	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+	for part := range strings.SplitSeq(rel, string(filepath.Separator)) {
 		if part == "." || part == "" {
 			continue
 		}

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -261,10 +261,7 @@ func AutoSizeColumns(headers []string, rows []Row, builder *ColumnBuilder) []Col
 						minWidth = 10 // Default minimum
 					}
 
-					newWidth := int(float64(widths[i]) * scaleFactor)
-					if newWidth < minWidth {
-						newWidth = minWidth
-					}
+					newWidth := max(int(float64(widths[i])*scaleFactor), minWidth)
 					widths[i] = newWidth
 				}
 			}

--- a/servers/build/build_saga_buildkit.go
+++ b/servers/build/build_saga_buildkit.go
@@ -211,8 +211,8 @@ func (b *Builder) runBuildkitBuild(
 		}
 		for _, log := range ss.Logs {
 			if log.Data != nil {
-				lines := strings.Split(string(log.Data), "\n")
-				for _, line := range lines {
+				lines := strings.SplitSeq(string(log.Data), "\n")
+				for line := range lines {
 					line = strings.TrimRight(line, " \t\r\n")
 					if strings.TrimSpace(line) != "" {
 						buildLog.write(line)

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -292,7 +292,7 @@ func requestScheme(r *http.Request) string {
 	}
 
 	if fwd := r.Header.Get("Forwarded"); fwd != "" {
-		for _, part := range strings.Split(fwd, ";") {
+		for part := range strings.SplitSeq(fwd, ";") {
 			part = strings.TrimSpace(part)
 			if after, ok := strings.CutPrefix(part, "proto="); ok {
 				return after

--- a/servers/telemetry/server.go
+++ b/servers/telemetry/server.go
@@ -85,7 +85,7 @@ func (s *Server) ReportSpans(ctx context.Context, state *telemetry_v1alpha.Telem
 // key1=value1,key2=value2
 func parseOTLPHeaders(raw string) map[string]string {
 	headers := make(map[string]string)
-	for _, pair := range strings.Split(raw, ",") {
+	for pair := range strings.SplitSeq(raw, ",") {
 		k, v, ok := strings.Cut(strings.TrimSpace(pair), "=")
 		if ok {
 			headers[strings.TrimSpace(k)] = strings.TrimSpace(v)


### PR DESCRIPTION
The smaller Go fixer pass in #1034 left a medium-sized group of helpers that are still mechanical, but broad enough to benefit from their own review boundary.

This keeps three analyzer families in separate revisions. The first replaces follow-up clamp branches with the built-in `min` and `max` helpers across backoff, batching, quota, and sizing paths. The second moves repeated string construction onto `strings.Builder`. The third ranges over `strings.SplitSeq` and `bytes.SplitSeq` where callers consume a split result once, avoiding the intermediate slice.

The resulting values, output ordering, empty fields, and trailing-delimiter behavior are unchanged. The larger collection-membership sweep and the concurrency, test-lifecycle, and serialization fixers stay separate.

All packages compile, generation and module tidiness checks pass, and the affected unit tests pass. Service-backed tests that require bridge creation, containerd, etcd, or VictoriaLogs remain unavailable locally, so CI is authoritative for those paths.

Stacked on #1034, which handles the smaller direct standard-library helpers.