### PR TITLE
Use slices helpers for membership checks

### DIFF
--- a/cli/commands/auth_provider_oidc.go
+++ b/cli/commands/auth_provider_oidc.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"miren.dev/runtime/api/ingress"
@@ -33,13 +34,7 @@ func AuthProviderAddOIDC(ctx *Context, opts struct {
 
 	// "openid" must be in the scope list for the OIDC handshake to succeed.
 	// Users frequently forget it, so prepend it if it's missing.
-	hasOpenID := false
-	for _, s := range opts.Scopes {
-		if s == "openid" {
-			hasOpenID = true
-			break
-		}
-	}
+	hasOpenID := slices.Contains(opts.Scopes, "openid")
 	scopeList := opts.Scopes
 	if !hasOpenID {
 		scopeList = append([]string{"openid"}, scopeList...)

--- a/cli/commands/envdetect.go
+++ b/cli/commands/envdetect.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -283,13 +284,7 @@ func looksLikeAppEnvVar(key string) bool {
 		"APPLICATION_SECRET",
 		"APP_SECRET",
 	}
-	for _, name := range standaloneNames {
-		if upperKey == name {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(standaloneNames, upperKey)
 }
 
 // looksLikeSensitive guesses, from a key NAME alone, whether a var is likely a

--- a/cli/commands/runner_start.go
+++ b/cli/commands/runner_start.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"syscall"
 	"time"
 
@@ -590,10 +591,8 @@ func certCoversListenAddr(certPEM, listenAddr string) (bool, error) {
 		return false, nil
 	}
 
-	for _, name := range cert.DNSNames {
-		if name == host {
-			return true, nil
-		}
+	if slices.Contains(cert.DNSNames, host) {
+		return true, nil
 	}
 	return false, nil
 }

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -1110,18 +1110,16 @@ func (a *localActivator) findPoolInStore(ctx context.Context, versionID entity.I
 		}
 
 		// Check if this pool references our version (pool reuse mechanism)
-		for _, refVersion := range pool.ReferencedByVersions {
-			if refVersion == versionID {
-				a.log.Debug("found pool in store via referenced_by_versions",
-					"pool", pool.ID,
-					"service", service,
-					"version", versionID,
-					"num_refs", len(pool.ReferencedByVersions))
-				return &poolWithRevision{
-					pool:     &pool,
-					revision: ent.Revision(),
-				}, nil
-			}
+		if slices.Contains(pool.ReferencedByVersions, versionID) {
+			a.log.Debug("found pool in store via referenced_by_versions",
+				"pool", pool.ID,
+				"service", service,
+				"version", versionID,
+				"num_refs", len(pool.ReferencedByVersions))
+			return &poolWithRevision{
+				pool:     &pool,
+				revision: ent.Revision(),
+			}, nil
 		}
 	}
 

--- a/controllers/certificate/autocert_controller.go
+++ b/controllers/certificate/autocert_controller.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -413,10 +414,8 @@ func (c *AutocertController) dnsPointsToUs(domain string) bool {
 		if resolved == nil {
 			continue
 		}
-		for _, pub := range ips {
-			if resolved.Equal(pub) {
-				return true
-			}
+		if slices.ContainsFunc(ips, resolved.Equal) {
+			return true
 		}
 	}
 	return false

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -1173,12 +1173,7 @@ func portsEqual(ports1, ports2 []compute_v1alpha.SandboxSpecContainerPort) bool 
 
 // containsRef checks if a slice of refs contains a specific ref
 func containsRef(refs []entity.Id, ref entity.Id) bool {
-	for _, r := range refs {
-		if r == ref {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(refs, ref)
 }
 
 // updatePool updates a pool entity in the store

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -974,24 +975,12 @@ func TestPerServiceEnvVarsDoNotRestartOtherServices(t *testing.T) {
 
 	// Verify env vars are in the web pool spec
 	require.Len(t, webV2Pool.SandboxSpec.Container, 1, "web pool should have one container")
-	foundAPIKey := false
-	for _, envVar := range webV2Pool.SandboxSpec.Container[0].Env {
-		if envVar == "API_KEY=secret123" {
-			foundAPIKey = true
-			break
-		}
-	}
+	foundAPIKey := slices.Contains(webV2Pool.SandboxSpec.Container[0].Env, "API_KEY=secret123")
 	assert.True(t, foundAPIKey, "web pool should have API_KEY env var")
 
 	// Verify postgres pool spec does NOT have the API_KEY env var
 	require.Len(t, postgresPoolAfter.SandboxSpec.Container, 1, "postgres pool should have one container")
-	foundAPIKeyInPostgres := false
-	for _, envVar := range postgresPoolAfter.SandboxSpec.Container[0].Env {
-		if envVar == "API_KEY=secret123" {
-			foundAPIKeyInPostgres = true
-			break
-		}
-	}
+	foundAPIKeyInPostgres := slices.Contains(postgresPoolAfter.SandboxSpec.Container[0].Env, "API_KEY=secret123")
 	assert.False(t, foundAPIKeyInPostgres, "postgres pool should NOT have API_KEY env var")
 }
 

--- a/controllers/sandbox/sandbox.go
+++ b/controllers/sandbox/sandbox.go
@@ -893,11 +893,8 @@ func (c *SandboxController) checkNetworkHealth(ctx context.Context, sb *compute.
 
 	hasTCPPorts := false
 	for _, container := range sb.Spec.Container {
-		for _, p := range container.Port {
-			if portIsTCP(p) {
-				hasTCPPorts = true
-				break
-			}
+		if slices.ContainsFunc(container.Port, portIsTCP) {
+			hasTCPPorts = true
 		}
 		if hasTCPPorts {
 			break

--- a/controllers/sandbox/sandbox_frozen_test.go
+++ b/controllers/sandbox/sandbox_frozen_test.go
@@ -30,7 +30,7 @@ func TestSandboxControllerFrozen(t *testing.T) {
 		// (resolveAppAndRole) so the token carries it. The saga path needs no
 		// matching edit: it reaches the same code through sandboxOps.BuildSpec,
 		// which delegates to SandboxController.BuildSpec.
-		"sandbox.go":  "1dab698635c481da6c45e1f4d11a6543b13f5cfd33c69bba509ecc729a398a78",
+		"sandbox.go":  "34fc580340814ca612fadb3e14466f1ea2df5ec9b800dffdf30de285c06f4399",
 		"volume.go":   "580062fb8a34f3f7f965689467a4b0f2ed403bc63c1ecdeb44949a7ba7e08dff",
 		"firewall.go": "648cb5d91091d5eb7400152b19695a8045585feae59c5dd36c12d663a27bb91f",
 	}

--- a/discovery/network.go
+++ b/discovery/network.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httputil"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -105,12 +106,7 @@ func containsDotDot(v string) bool {
 	if !strings.Contains(v, "..") {
 		return false
 	}
-	for _, ent := range strings.FieldsFunc(v, isSlashRune) {
-		if ent == ".." {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.FieldsFunc(v, isSlashRune), "..")
 }
 
 func (h *LocalContainerEndpoint) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/pkg/color/color.go
+++ b/pkg/color/color.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -488,13 +489,7 @@ func (c *Color) Equals(c2 *Color) bool {
 }
 
 func (c *Color) attrExists(a Attribute) bool {
-	for _, attr := range c.params {
-		if attr == a {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(c.params, a)
 }
 
 func getCachedColor(p Attribute) *Color {

--- a/pkg/containerenv/containerenv.go
+++ b/pkg/containerenv/containerenv.go
@@ -7,6 +7,7 @@ package containerenv
 
 import (
 	"os"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -47,12 +48,7 @@ func detect() bool {
 	if fileExists(dockerEnvPath) || fileExists(podmanEnvPath) {
 		return true
 	}
-	for _, p := range cgroupPaths {
-		if cgroupIndicatesContainer(p) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(cgroupPaths, cgroupIndicatesContainer)
 }
 
 func fileExists(path string) bool {

--- a/pkg/deploylifecycle/lifecycle.go
+++ b/pkg/deploylifecycle/lifecycle.go
@@ -7,6 +7,7 @@ package deploylifecycle
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"miren.dev/runtime/pkg/cond"
@@ -157,10 +158,8 @@ func Transition(from, to Status) error {
 			"status must be one of: "+joinStatuses(allStatuses))
 	}
 
-	for _, allowed := range validTransitions[from] {
-		if allowed == to {
-			return nil
-		}
+	if slices.Contains(validTransitions[from], to) {
+		return nil
 	}
 
 	return cond.Conflict("deployment-status",

--- a/pkg/entity/diff.go
+++ b/pkg/entity/diff.go
@@ -1,5 +1,7 @@
 package entity
 
+import "slices"
+
 func (e *Entity) Clone() *Entity {
 	clonedAttrs := make([]Attr, len(e.attrs))
 	for i, attr := range e.attrs {
@@ -17,13 +19,7 @@ func Diff(a, b *Entity) []Attr {
 	var diff []Attr
 
 	for _, aAttr := range a.attrs {
-		found := false
-		for _, bAttr := range b.attrs {
-			if aAttr.Equal(bAttr) {
-				found = true
-				break
-			}
-		}
+		found := slices.ContainsFunc(b.attrs, aAttr.Equal)
 		if !found {
 			diff = append(diff, aAttr)
 		}

--- a/pkg/entity/store_test.go
+++ b/pkg/entity/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -127,13 +128,7 @@ func TestEtcdStore_CreateEntity(t *testing.T) {
 				expected = tt.attrs
 			}
 			for _, expectedAttr := range expected {
-				found := false
-				for _, actualAttr := range entity.Attrs() {
-					if expectedAttr.Equal(actualAttr) {
-						found = true
-						break
-					}
-				}
+				found := slices.ContainsFunc(entity.Attrs(), expectedAttr.Equal)
 				assert.True(t, found, "expected attribute %s not found in entity %s", expectedAttr.ID, entity.Id())
 			}
 			assert.Greater(t, entity.GetRevision(), int64(0))
@@ -236,13 +231,7 @@ func TestEtcdStore_AttrPred(t *testing.T) {
 			tt.attrs = append(tt.attrs, Ref(DBId, entity.Id()))
 			// Check that each expected attribute is present (entity will have additional system attributes)
 			for _, expectedAttr := range tt.attrs {
-				found := false
-				for _, actualAttr := range entity.Attrs() {
-					if expectedAttr.Equal(actualAttr) {
-						found = true
-						break
-					}
-				}
+				found := slices.ContainsFunc(entity.Attrs(), expectedAttr.Equal)
 				assert.True(t, found, "expected attribute %s not found in entity", expectedAttr.ID)
 			}
 			assert.Greater(t, entity.GetRevision(), int64(0))

--- a/pkg/multierror/multierror.go
+++ b/pkg/multierror/multierror.go
@@ -27,12 +27,7 @@ func (m *MultiError) Errors() []error {
 }
 
 func (m *MultiError) Is(err error) bool {
-	for _, e := range m.errors {
-		if e == err {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(m.errors, err)
 }
 
 func (m *MultiError) As(target any) bool {

--- a/pkg/rbac/policy.go
+++ b/pkg/rbac/policy.go
@@ -2,6 +2,7 @@ package rbac
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -173,10 +174,8 @@ func (r *Rule) HasPermission(resource, action string) bool {
 func (r *Rule) AppliesTo(groups []string) bool {
 	// Check if any of the user's groups match the rule's groups
 	for _, ruleGroup := range r.Groups {
-		for _, userGroup := range groups {
-			if ruleGroup == userGroup {
-				return true
-			}
+		if slices.Contains(groups, ruleGroup) {
+			return true
 		}
 	}
 	return false

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -553,12 +553,7 @@ func (c *NetworkClient) HasMethod(ctx context.Context, method string) bool {
 	if err != nil {
 		return false
 	}
-	for _, m := range methods {
-		if m == method {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(methods, method)
 }
 
 // HasMethodParam reports whether the remote interface's method accepts a given
@@ -571,12 +566,7 @@ func (c *NetworkClient) HasMethodParam(ctx context.Context, method, param string
 	if err != nil {
 		return false
 	}
-	for _, p := range result.Params[method] {
-		if p == param {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(result.Params[method], param)
 }
 
 func (c *NetworkClient) requestReexportCapability(ctx context.Context, capa *Capability, target ed25519.PublicKey) (*Capability, error) {

--- a/pkg/rpc/generator.go
+++ b/pkg/rpc/generator.go
@@ -113,10 +113,8 @@ func (g *Generator) ti(name string) typeInfo {
 		if !ok {
 			x, ok := g.importedPackages[name[:dot]]
 			if ok {
-				for _, t := range x {
-					if t == name[dot+1:] {
-						return typeInfo{}
-					}
+				if slices.Contains(x, name[dot+1:]) {
+					return typeInfo{}
 				}
 			}
 

--- a/pkg/shellwords/parser.go
+++ b/pkg/shellwords/parser.go
@@ -2,6 +2,7 @@ package shellwords
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"unicode/utf8"
 )
@@ -120,12 +121,7 @@ func (p *parser) scanQuote(delim rune) (string, error) {
 }
 
 func (p *parser) isQuote(r rune) bool {
-	for _, qr := range p.QuoteChars {
-		if qr == r {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(p.QuoteChars, r)
 }
 
 func (p *parser) isQuoteEscape(r rune) (rune, bool) {
@@ -138,12 +134,7 @@ func (p *parser) isQuoteEscape(r rune) (rune, bool) {
 }
 
 func (p *parser) isFieldSeperator(r rune) bool {
-	for _, qr := range p.FieldSeperators {
-		if qr == r {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(p.FieldSeperators, r)
 }
 
 func (p *parser) scanUntil(f func(rune) bool) string {

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -860,13 +861,7 @@ func (r *AppInfo) Restart(ctx context.Context, state *app_v1alpha.CrudRestart) e
 		// during crash cooldown. Only do this for pools that reference the
 		// active version — stale pools from old deployments were intentionally
 		// scaled to 0 and should not be resurrected.
-		isActivePool := false
-		for _, ref := range pool.ReferencedByVersions {
-			if ref == appRec.ActiveVersion {
-				isActivePool = true
-				break
-			}
-		}
+		isActivePool := slices.Contains(pool.ReferencedByVersions, appRec.ActiveVersion)
 		if isActivePool && configSpec != nil {
 			svcConc, err := coreutil.GetServiceConcurrency(configSpec, pool.Service)
 			if err == nil && svcConc.Mode == "fixed" && svcConc.NumInstances > 0 {

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
@@ -66,13 +67,7 @@ func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.
 
 	// Parse scopes, ensuring "openid" is always included
 	scopes := strings.Fields(provider.Scopes)
-	hasOpenID := false
-	for _, s := range scopes {
-		if s == "openid" {
-			hasOpenID = true
-			break
-		}
-	}
+	hasOpenID := slices.Contains(scopes, "openid")
 	if !hasOpenID {
 		scopes = append([]string{"openid"}, scopes...)
 	}

--- a/servers/runner/registration_test.go
+++ b/servers/runner/registration_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"net"
+	"slices"
 	"testing"
 	"time"
 
@@ -237,13 +238,7 @@ func TestJoinCreatesNodeEntity(t *testing.T) {
 		}
 	}
 
-	foundLocalhost := false
-	for _, name := range cert.DNSNames {
-		if name == "localhost" {
-			foundLocalhost = true
-			break
-		}
-	}
+	foundLocalhost := slices.Contains(cert.DNSNames, "localhost")
 	if !foundLocalhost {
 		t.Errorf("certificate missing DNS SAN 'localhost', got %v", cert.DNSNames)
 	}
@@ -989,12 +984,7 @@ func containsIP(ips []net.IP, want string) bool {
 }
 
 func containsStr(ss []string, want string) bool {
-	for _, s := range ss {
-		if s == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(ss, want)
 }
 
 // TestAuthorizeSystemWorkloadRequest covers the authorization guarding system


### PR DESCRIPTION
The remaining Go cleanup still had a collection of loops whose only job was answering whether a slice contained a value. Those loops made simple membership questions look like custom traversal logic.

This pass replaces them with `slices.Contains` and `slices.ContainsFunc`, preserving the existing comparisons, predicates, and early-exit behavior. It also refreshes the frozen sandbox controller hash after auditing the TCP-port predicate change; the saga path has no parallel implementation to update.

All packages compile, the analyzer has no remaining `slicescontains` changes, module tidiness is clean, and the affected pure unit tests pass. Service-backed controller paths remain unavailable locally, so CI is authoritative for those tests once the current Actions outage clears.

Stacked on #1036.