### PR TITLE
Prefer any for unconstrained values

### DIFF
--- a/cli/commands/admin.go
+++ b/cli/commands/admin.go
@@ -179,7 +179,7 @@ func Admin(ctx *Context, opts struct {
 
 	// Print result
 	if result.Result().HasResult() && result.Result().Result() != "" {
-		var prettyResult interface{}
+		var prettyResult any
 		if err := json.Unmarshal([]byte(result.Result().Result()), &prettyResult); err == nil {
 			if usePretty {
 				ctx.Printf("%s", renderPretty(prettyResult))
@@ -411,7 +411,7 @@ func looksLikeNumber(s string) bool {
 }
 
 // validateAdminCall fetches method introspection and validates the method and parameters
-func validateAdminCall(ctx *Context, client *admin_v1alpha.AdminClient, app, method string, params map[string]interface{}) error {
+func validateAdminCall(ctx *Context, client *admin_v1alpha.AdminClient, app, method string, params map[string]any) error {
 	// Fetch available methods
 	result, err := client.ListMethods(ctx, app)
 	if err != nil {
@@ -633,7 +633,7 @@ var (
 )
 
 // highlightJSON recursively renders a JSON value with syntax highlighting
-func highlightJSON(v interface{}, indent int) string {
+func highlightJSON(v any, indent int) string {
 	indentStr := strings.Repeat("  ", indent)
 	nextIndent := strings.Repeat("  ", indent+1)
 
@@ -658,7 +658,7 @@ func highlightJSON(v interface{}, indent int) string {
 		escaped, _ := json.Marshal(val)
 		return jsonStringStyle.Render(string(escaped))
 
-	case []interface{}:
+	case []any:
 		if len(val) == 0 {
 			return jsonBracket.Render("[]")
 		}
@@ -680,7 +680,7 @@ func highlightJSON(v interface{}, indent int) string {
 		sb.WriteString(jsonBracket.Render("]"))
 		return sb.String()
 
-	case map[string]interface{}:
+	case map[string]any:
 		if len(val) == 0 {
 			return jsonBracket.Render("{}")
 		}
@@ -720,25 +720,25 @@ func highlightJSON(v interface{}, indent int) string {
 }
 
 // renderPretty renders data in a human-friendly format
-func renderPretty(v interface{}) string {
+func renderPretty(v any) string {
 	var sb strings.Builder
 
 	switch val := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		// Separate simple values from tables
 		var simpleKeys []string
 		var tableKeys []string
 		tableData := make(map[string]struct {
-			arr  []interface{}
+			arr  []any
 			keys []string
 		})
 
 		for key, value := range val {
-			if arr, ok := value.([]interface{}); ok {
+			if arr, ok := value.([]any); ok {
 				if keys := getUniformObjectKeys(arr); keys != nil {
 					tableKeys = append(tableKeys, key)
 					tableData[key] = struct {
-						arr  []interface{}
+						arr  []any
 						keys []string
 					}{arr, keys}
 					continue
@@ -778,7 +778,7 @@ func renderPretty(v interface{}) string {
 			}
 		}
 
-	case []interface{}:
+	case []any:
 		// Check if it's an array of uniform objects
 		if keys := getUniformObjectKeys(val); keys != nil {
 			sb.WriteString(renderTable(val, keys))
@@ -801,7 +801,7 @@ func renderPretty(v interface{}) string {
 
 // getUniformObjectKeys checks if all items in an array are objects with the same keys
 // Returns the sorted keys if uniform, nil otherwise
-func getUniformObjectKeys(arr []interface{}) []string {
+func getUniformObjectKeys(arr []any) []string {
 	if len(arr) == 0 {
 		return nil
 	}
@@ -809,7 +809,7 @@ func getUniformObjectKeys(arr []interface{}) []string {
 	var referenceKeys []string
 
 	for i, item := range arr {
-		obj, ok := item.(map[string]interface{})
+		obj, ok := item.(map[string]any)
 		if !ok {
 			return nil // Not an object
 		}
@@ -839,7 +839,7 @@ func getUniformObjectKeys(arr []interface{}) []string {
 }
 
 // renderTable renders an array of uniform objects as a table using ui.Table
-func renderTable(arr []interface{}, keys []string) string {
+func renderTable(arr []any, keys []string) string {
 	if len(arr) == 0 || len(keys) == 0 {
 		return ""
 	}
@@ -853,7 +853,7 @@ func renderTable(arr []interface{}, keys []string) string {
 	// Build rows
 	rows := make([]ui.Row, len(arr))
 	for i, item := range arr {
-		obj := item.(map[string]interface{})
+		obj := item.(map[string]any)
 		row := make(ui.Row, len(keys))
 		for j, key := range keys {
 			row[j] = formatCellValue(obj[key])
@@ -893,7 +893,7 @@ func formatKeyAsTitle(key string) string {
 }
 
 // formatCellValue formats a value for display in a table cell
-func formatCellValue(v interface{}) string {
+func formatCellValue(v any) string {
 	switch val := v.(type) {
 	case nil:
 		return "-"
@@ -916,7 +916,7 @@ func formatCellValue(v interface{}) string {
 }
 
 // renderPrettyValue renders a single value for pretty output with styling
-func renderPrettyValue(v interface{}) string {
+func renderPrettyValue(v any) string {
 	switch val := v.(type) {
 	case nil:
 		return jsonNullStyle.Render("-")
@@ -932,13 +932,13 @@ func renderPrettyValue(v interface{}) string {
 		return jsonNumberStyle.Render(fmt.Sprintf("%g", val))
 	case string:
 		return jsonStringStyle.Render(val)
-	case []interface{}:
+	case []any:
 		if len(val) == 0 {
 			return jsonNullStyle.Render("(empty)")
 		}
 		// For arrays, show count
 		return fmt.Sprintf("(%d items)", len(val))
-	case map[string]interface{}:
+	case map[string]any:
 		// For nested objects, show inline
 		parts := make([]string, 0, len(val))
 		for k, v := range val {

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -21,14 +21,14 @@ import (
 
 // ClusterResponse represents a cluster returned from the API
 type ClusterResponse struct {
-	XID               string                 `json:"xid"`
-	Name              string                 `json:"name"`
-	Description       string                 `json:"description,omitempty"`
-	Tags              map[string]interface{} `json:"tags"`
-	APIAddresses      []string               `json:"api_addresses,omitempty"`
-	CACertFingerprint string                 `json:"ca_cert_fingerprint,omitempty"`
-	OrganizationXID   string                 `json:"organization_xid"`
-	OrganizationName  string                 `json:"organization_name"`
+	XID               string         `json:"xid"`
+	Name              string         `json:"name"`
+	Description       string         `json:"description,omitempty"`
+	Tags              map[string]any `json:"tags"`
+	APIAddresses      []string       `json:"api_addresses,omitempty"`
+	CACertFingerprint string         `json:"ca_cert_fingerprint,omitempty"`
+	OrganizationXID   string         `json:"organization_xid"`
+	OrganizationName  string         `json:"organization_name"`
 }
 
 // hasReachableAddress reports whether the cloud advertised at least one API

--- a/cli/commands/debug_rbac.go
+++ b/cli/commands/debug_rbac.go
@@ -209,7 +209,7 @@ func DebugRBACTest(ctx *Context, opts struct {
 	evaluator := rbac.NewEvaluator(ctx, fetcher, logger)
 
 	// Clean up tags
-	cleanTags := make(map[string]interface{})
+	cleanTags := make(map[string]any)
 	for k, v := range opts.Tags {
 		cleanTags[k] = v
 	}

--- a/cli/commands/global.go
+++ b/cli/commands/global.go
@@ -250,19 +250,19 @@ func (c *Context) SetExitCode(code int) {
 	c.exitCode = code
 }
 
-func (c *Context) Printf(format string, args ...interface{}) {
+func (c *Context) Printf(format string, args ...any) {
 	fmt.Fprintf(c.Stdout, format, args...)
 }
 
-func (c *Context) Completed(format string, args ...interface{}) {
+func (c *Context) Completed(format string, args ...any) {
 	fmt.Fprintf(c.Stdout, ui.Checkmark+" "+format+"\n", args...)
 }
 
-func (c *Context) Info(format string, args ...interface{}) {
+func (c *Context) Info(format string, args ...any) {
 	fmt.Fprintf(c.Stdout, "  "+format+"\n", args...)
 }
 
-func (c *Context) Warn(format string, args ...interface{}) {
+func (c *Context) Warn(format string, args ...any) {
 	fmt.Fprintf(c.Stdout, "W "+format+"\n", args...)
 }
 
@@ -286,7 +286,7 @@ func printConfigWarning(err error) {
 	fmt.Fprintf(os.Stderr, "warning: %v\n", err)
 }
 
-func (c *Context) Begin(format string, args ...interface{}) {
+func (c *Context) Begin(format string, args ...any) {
 	fmt.Fprintf(c.Stderr, ui.Play+" "+format+"\n", args...)
 }
 

--- a/cli/commands/infer.go
+++ b/cli/commands/infer.go
@@ -76,7 +76,7 @@ func WithDaemon() CommandOption {
 
 // Infer creates a command from a function with the signature:
 // func(ctx *Context, opts StructType) error
-func Infer(name, syn string, f interface{}, opts ...CommandOption) *Cmd {
+func Infer(name, syn string, f any, opts ...CommandOption) *Cmd {
 	rv := reflect.ValueOf(f)
 
 	if rv.Kind() != reflect.Func {

--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -111,7 +111,7 @@ type ConfigData struct {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 	var temp ConfigData
 	if err := unmarshal(&temp); err != nil {
 		return err
@@ -127,7 +127,7 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // MarshalYAML implements the yaml.Marshaler interface
-func (c *Config) MarshalYAML() (interface{}, error) {
+func (c *Config) MarshalYAML() (any, error) {
 	return &ConfigData{
 		Active:     c.active,
 		Theme:      c.theme,

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -246,8 +246,8 @@ type CompleteAuthRequest struct {
 
 // CompleteAuthResponse is the response from complete authentication
 type CompleteAuthResponse struct {
-	User  interface{} `json:"user"`
-	Token string      `json:"token"`
+	User  any    `json:"user"`
+	Token string `json:"token"`
 }
 
 // getCacheDir returns the path to the miren cache directory

--- a/components/ocireg/registry_test.go
+++ b/components/ocireg/registry_test.go
@@ -36,9 +36,9 @@ func TestPutManifest_PreventsDuplicateArtifacts(t *testing.T) {
 	handler := NewRegistryHandler(tmpDir, log, entServer.Client)
 
 	// Create a test manifest
-	manifest := map[string]interface{}{
+	manifest := map[string]any{
 		"schemaVersion": 2,
-		"config": map[string]interface{}{
+		"config": map[string]any{
 			"digest": "sha256:abcd1234",
 			"size":   1024,
 		},
@@ -105,9 +105,9 @@ func TestPutManifest_DifferentManifestsCreateSeparateArtifacts(t *testing.T) {
 	handler := NewRegistryHandler(tmpDir, log, entServer.Client)
 
 	// Create two different manifests
-	manifest1 := map[string]interface{}{
+	manifest1 := map[string]any{
 		"schemaVersion": 2,
-		"config": map[string]interface{}{
+		"config": map[string]any{
 			"digest": "sha256:abcd1234",
 			"size":   1024,
 		},
@@ -115,9 +115,9 @@ func TestPutManifest_DifferentManifestsCreateSeparateArtifacts(t *testing.T) {
 	manifestData1, err := json.Marshal(manifest1)
 	require.NoError(t, err)
 
-	manifest2 := map[string]interface{}{
+	manifest2 := map[string]any{
 		"schemaVersion": 2,
-		"config": map[string]interface{}{
+		"config": map[string]any{
 			"digest": "sha256:efgh5678",
 			"size":   2048,
 		},
@@ -162,9 +162,9 @@ func TestGetManifest_ByDigest(t *testing.T) {
 	handler := NewRegistryHandler(tmpDir, log, entServer.Client)
 
 	// Create a test manifest
-	manifest := map[string]interface{}{
+	manifest := map[string]any{
 		"schemaVersion": 2,
-		"config": map[string]interface{}{
+		"config": map[string]any{
 			"digest": "sha256:test1234",
 			"size":   1024,
 		},
@@ -211,9 +211,9 @@ func TestGetManifest_ByReference(t *testing.T) {
 	handler := NewRegistryHandler(tmpDir, log, entServer.Client)
 
 	// Create a test manifest
-	manifest := map[string]interface{}{
+	manifest := map[string]any{
 		"schemaVersion": 2,
-		"config": map[string]interface{}{
+		"config": map[string]any{
 			"digest": "sha256:ref1234",
 			"size":   512,
 		},

--- a/controllers/sandbox/token_server_test.go
+++ b/controllers/sandbox/token_server_test.go
@@ -74,7 +74,7 @@ func TestTokenServer_DefaultToken(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.Value)
 
-	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		assert.Equal(t, "RS256", tok.Method.Alg())
 		return c.WorkloadIssuer.(*workloadidentity.Issuer).PublicKey(), nil
 	})
@@ -99,7 +99,7 @@ func TestTokenServer_CustomAudience(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 
-	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		assert.Equal(t, "RS256", tok.Method.Alg())
 		return c.WorkloadIssuer.(*workloadidentity.Issuer).PublicKey(), nil
 	}, jwt.WithAudience("sts.amazonaws.com"))
@@ -121,7 +121,7 @@ func TestTokenServer_CustomTTL(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 
-	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		assert.Equal(t, "RS256", tok.Method.Alg())
 		return c.WorkloadIssuer.(*workloadidentity.Issuer).PublicKey(), nil
 	})
@@ -239,7 +239,7 @@ func TestTokenServer_RecycledIPResolvesToCurrentSandbox(t *testing.T) {
 	var resp tokenResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
-	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(resp.Value, &workloadidentity.WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		return c.WorkloadIssuer.(*workloadidentity.Issuer).PublicKey(), nil
 	})
 	require.NoError(t, err)

--- a/metrics/integration_test.go
+++ b/metrics/integration_test.go
@@ -49,7 +49,7 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 				result.Data.Result = []Result{
 					{
 						Metric: map[string]string{"app": "testapp"},
-						Value:  []interface{}{float64(time.Now().Unix()), "10.5"},
+						Value:  []any{float64(time.Now().Unix()), "10.5"},
 					},
 				}
 			} else if strings.Contains(query, "topk") {
@@ -57,11 +57,11 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 				result.Data.Result = []Result{
 					{
 						Metric: map[string]string{"path": "/api/users"},
-						Value:  []interface{}{float64(time.Now().Unix()), "150"},
+						Value:  []any{float64(time.Now().Unix()), "150"},
 					},
 					{
 						Metric: map[string]string{"path": "/api/posts"},
-						Value:  []interface{}{float64(time.Now().Unix()), "100"},
+						Value:  []any{float64(time.Now().Unix()), "100"},
 					},
 				}
 			} else if strings.Contains(query, "sum by(status)") {
@@ -69,11 +69,11 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 				result.Data.Result = []Result{
 					{
 						Metric: map[string]string{"status": "404"},
-						Value:  []interface{}{float64(time.Now().Unix()), "25"},
+						Value:  []any{float64(time.Now().Unix()), "25"},
 					},
 					{
 						Metric: map[string]string{"status": "500"},
-						Value:  []interface{}{float64(time.Now().Unix()), "5"},
+						Value:  []any{float64(time.Now().Unix()), "5"},
 					},
 				}
 			} else {
@@ -81,7 +81,7 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 				result.Data.Result = []Result{
 					{
 						Metric: map[string]string{"path": "/api/users"},
-						Value:  []interface{}{float64(time.Now().Unix()), "125.5"},
+						Value:  []any{float64(time.Now().Unix()), "125.5"},
 					},
 				}
 			}
@@ -102,7 +102,7 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 				result.Data.Result = []Result{
 					{
 						Metric: map[string]string{},
-						Values: [][]interface{}{
+						Values: [][]any{
 							{float64(baseTime), "100"},
 							{float64(baseTime + 60), "120"},
 							{float64(baseTime + 120), "110"},
@@ -114,7 +114,7 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 				result.Data.Result = []Result{
 					{
 						Metric: map[string]string{},
-						Values: [][]interface{}{
+						Values: [][]any{
 							{float64(baseTime), "45.5"},
 							{float64(baseTime + 60), "50.2"},
 							{float64(baseTime + 120), "48.3"},
@@ -126,7 +126,7 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 				result.Data.Result = []Result{
 					{
 						Metric: map[string]string{},
-						Values: [][]interface{}{
+						Values: [][]any{
 							{float64(baseTime), "95.5"},
 							{float64(baseTime + 60), "98.2"},
 							{float64(baseTime + 120), "96.7"},
@@ -138,7 +138,7 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 				result.Data.Result = []Result{
 					{
 						Metric: map[string]string{},
-						Values: [][]interface{}{
+						Values: [][]any{
 							{float64(baseTime), "150.3"},
 							{float64(baseTime + 60), "155.8"},
 							{float64(baseTime + 120), "152.1"},
@@ -150,7 +150,7 @@ func TestHTTPMetrics_Integration(t *testing.T) {
 				result.Data.Result = []Result{
 					{
 						Metric: map[string]string{},
-						Values: [][]interface{}{
+						Values: [][]any{
 							{float64(baseTime), "0.05"},
 							{float64(baseTime + 60), "0.03"},
 							{float64(baseTime + 120), "0.04"},
@@ -290,7 +290,7 @@ func TestCPUUsage_Integration(t *testing.T) {
 			result.Data.Result = []Result{
 				{
 					Metric: map[string]string{"entity": "test-app"},
-					Values: [][]interface{}{
+					Values: [][]any{
 						{float64(baseTime), "0.5"},
 						{float64(baseTime + 60), "0.75"},
 						{float64(baseTime + 120), "1.0"},
@@ -462,7 +462,7 @@ func TestMemoryUsage_Integration(t *testing.T) {
 			result.Data.Result = []Result{
 				{
 					Metric: map[string]string{"entity": "test-app"},
-					Values: [][]interface{}{
+					Values: [][]any{
 						{float64(baseTime), "134217728"},       // 128 MB
 						{float64(baseTime + 60), "268435456"},  // 256 MB
 						{float64(baseTime + 120), "536870912"}, // 512 MB

--- a/metrics/victoriametrics_reader.go
+++ b/metrics/victoriametrics_reader.go
@@ -50,8 +50,8 @@ type Data struct {
 
 type Result struct {
 	Metric map[string]string `json:"metric"`
-	Value  []interface{}     `json:"value,omitempty"`  // For instant queries: [timestamp, value_string]
-	Values [][]interface{}   `json:"values,omitempty"` // For range queries: [[timestamp, value_string], ...]
+	Value  []any             `json:"value,omitempty"`  // For instant queries: [timestamp, value_string]
+	Values [][]any           `json:"values,omitempty"` // For range queries: [[timestamp, value_string], ...]
 }
 
 // InstantQuery executes an instant MetricsQL query (point-in-time)

--- a/metrics/victoriametrics_reader_test.go
+++ b/metrics/victoriametrics_reader_test.go
@@ -28,7 +28,7 @@ func TestVictoriaMetricsReader_InstantQuery(t *testing.T) {
 					Result: []Result{
 						{
 							Metric: map[string]string{"job": "prometheus"},
-							Value:  []interface{}{float64(1609459200), "1"},
+							Value:  []any{float64(1609459200), "1"},
 						},
 					},
 				},
@@ -131,7 +131,7 @@ func TestVictoriaMetricsReader_RangeQuery(t *testing.T) {
 					Result: []Result{
 						{
 							Metric: map[string]string{"job": "prometheus"},
-							Values: [][]interface{}{
+							Values: [][]any{
 								{float64(1609459200), "1"},
 								{float64(1609459260), "1"},
 								{float64(1609459320), "1"},
@@ -208,7 +208,7 @@ func TestVictoriaMetricsReader_GetLatestValue(t *testing.T) {
 					Result: []Result{
 						{
 							Metric: map[string]string{"__name__": "test_metric", "app": "test"},
-							Value:  []interface{}{float64(1609459200), "42.5"},
+							Value:  []any{float64(1609459200), "42.5"},
 						},
 					},
 				},
@@ -252,7 +252,7 @@ func TestVictoriaMetricsReader_GetLatestValue(t *testing.T) {
 					Result: []Result{
 						{
 							Metric: map[string]string{"__name__": "test"},
-							Value:  []interface{}{float64(1609459200), 12345}, // int instead of string
+							Value:  []any{float64(1609459200), 12345}, // int instead of string
 						},
 					},
 				},
@@ -280,7 +280,7 @@ func TestVictoriaMetricsReader_GetTimeSeries(t *testing.T) {
 					Result: []Result{
 						{
 							Metric: map[string]string{"__name__": "test_metric"},
-							Values: [][]interface{}{
+							Values: [][]any{
 								{float64(1000), "10.5"},
 								{float64(2000), "20.5"},
 								{float64(3000), "30.5"},
@@ -341,7 +341,7 @@ func TestVictoriaMetricsReader_GetTimeSeries(t *testing.T) {
 					Result: []Result{
 						{
 							Metric: map[string]string{"__name__": "test"},
-							Values: [][]interface{}{
+							Values: [][]any{
 								{float64(1000), "10.5"},
 								{"invalid", "20.5"},        // invalid timestamp
 								{float64(3000), 30.5},      // invalid value (int)
@@ -383,7 +383,7 @@ func TestVictoriaMetricsReader_GetRate(t *testing.T) {
 					Result: []Result{
 						{
 							Metric: map[string]string{},
-							Value:  []interface{}{float64(1609459200), "15.5"},
+							Value:  []any{float64(1609459200), "15.5"},
 						},
 					},
 				},
@@ -415,7 +415,7 @@ func TestVictoriaMetricsReader_GetQuantile(t *testing.T) {
 					Result: []Result{
 						{
 							Metric: map[string]string{},
-							Value:  []interface{}{float64(1609459200), "123.45"},
+							Value:  []any{float64(1609459200), "123.45"},
 						},
 					},
 				},
@@ -447,7 +447,7 @@ func TestVictoriaMetricsReader_GetAverage(t *testing.T) {
 					Result: []Result{
 						{
 							Metric: map[string]string{},
-							Value:  []interface{}{float64(1609459200), "78.9"},
+							Value:  []any{float64(1609459200), "78.9"},
 						},
 					},
 				},

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -491,7 +491,7 @@ func (l *LogReader) parseLogStream(ctx context.Context, body io.Reader, logCh ch
 }
 
 func (l *LogReader) parseLogLine(line []byte) (LogEntry, error) {
-	var logData map[string]interface{}
+	var logData map[string]any
 	if err := json.Unmarshal(line, &logData); err != nil {
 		return LogEntry{}, err
 	}

--- a/pkg/cel/common/equality.go
+++ b/pkg/cel/common/equality.go
@@ -34,10 +34,10 @@ import (
 // to handle concurrency, if any.
 type CorrelatedObject struct {
 	// Currently correlated old value during traversal of the schema/object
-	OldValue interface{}
+	OldValue any
 
 	// Value being validated
-	Value interface{}
+	Value any
 
 	// Schema used for validation of this value. The schema is also used
 	// to determine how to correlate the old object.
@@ -65,10 +65,10 @@ type CorrelatedObject struct {
 	//
 	// It should be expected to have an entry for either all of the children, or
 	// none of them.
-	children map[interface{}]*CorrelatedObject
+	children map[any]*CorrelatedObject
 }
 
-func NewCorrelatedObject(new, old interface{}, schema Schema) *CorrelatedObject {
+func NewCorrelatedObject(new, old any, schema Schema) *CorrelatedObject {
 	d := time.Duration(0)
 	return &CorrelatedObject{
 		OldValue: old,
@@ -88,13 +88,13 @@ func NewCorrelatedObject(new, old interface{}, schema Schema) *CorrelatedObject 
 // the correlated key is not in the old map
 //
 // Otherwise, if the list type is not correlatable this funcion returns nil.
-func (r *CorrelatedObject) correlateOldValueForChildAtNewIndex(index int) interface{} {
-	oldAsList, ok := r.OldValue.([]interface{})
+func (r *CorrelatedObject) correlateOldValueForChildAtNewIndex(index int) any {
+	oldAsList, ok := r.OldValue.([]any)
 	if !ok {
 		return nil
 	}
 
-	asList, ok := r.Value.([]interface{})
+	asList, ok := r.Value.([]any)
 	if !ok {
 		return nil
 	} else if len(asList) <= index {
@@ -167,11 +167,11 @@ func (r *CorrelatedObject) CachedDeepEqual() (res bool) {
 		return false
 	}
 
-	oldAsArray, oldIsArray := r.OldValue.([]interface{})
-	newAsArray, newIsArray := r.Value.([]interface{})
+	oldAsArray, oldIsArray := r.OldValue.([]any)
+	newAsArray, newIsArray := r.Value.([]any)
 
-	oldAsMap, oldIsMap := r.OldValue.(map[string]interface{})
-	newAsMap, newIsMap := r.Value.(map[string]interface{})
+	oldAsMap, oldIsMap := r.OldValue.(map[string]any)
+	newAsMap, newIsMap := r.Value.(map[string]any)
 
 	// If old and new are not the same type, they are not equal
 	if (oldIsArray != newIsArray) || oldIsMap != newIsMap {
@@ -250,8 +250,8 @@ func (r *CorrelatedObject) Key(field string) *CorrelatedObject {
 	}
 
 	// Find correlated old value
-	oldAsMap, okOld := r.OldValue.(map[string]interface{})
-	newAsMap, okNew := r.Value.(map[string]interface{})
+	oldAsMap, okOld := r.OldValue.(map[string]any)
+	newAsMap, okNew := r.Value.(map[string]any)
 	if !okOld || !okNew {
 		return nil
 	}
@@ -272,7 +272,7 @@ func (r *CorrelatedObject) Key(field string) *CorrelatedObject {
 	}
 
 	if r.children == nil {
-		r.children = make(map[interface{}]*CorrelatedObject, len(newAsMap))
+		r.children = make(map[any]*CorrelatedObject, len(newAsMap))
 	}
 
 	res := &CorrelatedObject{
@@ -303,7 +303,7 @@ func (r *CorrelatedObject) Index(i int) *CorrelatedObject {
 		return existing
 	}
 
-	asList, ok := r.Value.([]interface{})
+	asList, ok := r.Value.([]any)
 	if !ok || len(asList) <= i {
 		return nil
 	}
@@ -320,7 +320,7 @@ func (r *CorrelatedObject) Index(i int) *CorrelatedObject {
 	}
 
 	if r.children == nil {
-		r.children = make(map[interface{}]*CorrelatedObject, len(asList))
+		r.children = make(map[any]*CorrelatedObject, len(asList))
 	}
 
 	res := &CorrelatedObject{

--- a/pkg/cel/types.go
+++ b/pkg/cel/types.go
@@ -281,11 +281,11 @@ type DeclField struct {
 	Name         string
 	Type         *DeclType
 	Required     bool
-	enumValues   []interface{}
-	defaultValue interface{}
+	enumValues   []any
+	defaultValue any
 }
 
-func NewDeclField(name string, declType *DeclType, required bool, enumValues []interface{}, defaultValue interface{}) *DeclField {
+func NewDeclField(name string, declType *DeclType, required bool, enumValues []any, defaultValue any) *DeclField {
 	return &DeclField{
 		Name:         name,
 		Type:         declType,
@@ -477,7 +477,7 @@ func (rt *DeclTypeProvider) FindFieldType(typeName, fieldName string) (*ref.Fiel
 
 // NativeToValue is an implementation of the ref.TypeAdapater interface which supports conversion
 // of rule values to CEL ref.Val instances.
-func (rt *DeclTypeProvider) NativeToValue(val interface{}) ref.Val {
+func (rt *DeclTypeProvider) NativeToValue(val any) ref.Val {
 	return rt.typeAdapter.NativeToValue(val)
 }
 

--- a/pkg/cel/types_test.go
+++ b/pkg/cel/types_test.go
@@ -69,7 +69,7 @@ func TestTypes_MapType(t *testing.T) {
 	}
 }
 
-func testValue(t *testing.T, id int64, val interface{}) *DynValue {
+func testValue(t *testing.T, id int64, val any) *DynValue {
 	t.Helper()
 	dv, err := NewDynValue(id, val)
 	if err != nil {

--- a/pkg/cel/url.go
+++ b/pkg/cel/url.go
@@ -39,7 +39,7 @@ var (
 )
 
 // ConvertToNative implements ref.Val.ConvertToNative.
-func (d URL) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+func (d URL) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	if reflect.TypeFor[*url.URL]().AssignableTo(typeDesc) {
 		return d.URL, nil
 	}
@@ -75,6 +75,6 @@ func (d URL) Type() ref.Type {
 }
 
 // Value implements ref.Val.Value.
-func (d URL) Value() interface{} {
+func (d URL) Value() any {
 	return d.URL
 }

--- a/pkg/cel/value.go
+++ b/pkg/cel/value.go
@@ -55,7 +55,7 @@ func NewEmptyDynValue() *DynValue {
 }
 
 // NewDynValue returns a DynValue that corresponds to a parse node id and value.
-func NewDynValue(id int64, val interface{}) (*DynValue, error) {
+func NewDynValue(id int64, val any) (*DynValue, error) {
 	dv := &DynValue{ID: id}
 	err := dv.SetValue(val)
 	return dv, err
@@ -67,7 +67,7 @@ func NewDynValue(id int64, val interface{}) (*DynValue, error) {
 type DynValue struct {
 	ID          int64
 	EncodeStyle EncodeStyle
-	value       interface{}
+	value       any
 	exprValue   ref.Val
 	declType    *DeclType
 }
@@ -82,7 +82,7 @@ func (dv *DynValue) DeclType() *DeclType {
 //
 // The default behavior of this method is to first convert to a CEL type which has a well-defined
 // set of conversion behaviors and proxy to the CEL ConvertToNative method for the type.
-func (dv *DynValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+func (dv *DynValue) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	ev := dv.ExprValue()
 	if types.IsError(ev) {
 		return nil, ev.(*types.Err)
@@ -122,12 +122,12 @@ func (dv *DynValue) ExprValue() ref.Val {
 }
 
 // Value returns the underlying value held by this reference.
-func (dv *DynValue) Value() interface{} {
+func (dv *DynValue) Value() any {
 	return dv.value
 }
 
 // SetValue updates the underlying value held by this reference.
-func (dv *DynValue) SetValue(value interface{}) error {
+func (dv *DynValue) SetValue(value any) error {
 	dv.value = value
 	var err error
 	dv.exprValue, dv.declType, err = exprValue(value)
@@ -139,7 +139,7 @@ func (dv *DynValue) Type() ref.Type {
 	return dv.ExprValue().Type()
 }
 
-func exprValue(value interface{}) (ref.Val, *DeclType, error) {
+func exprValue(value any) (ref.Val, *DeclType, error) {
 	switch v := value.(type) {
 	case bool:
 		return types.Bool(v), BoolType, nil
@@ -199,7 +199,7 @@ func (sv *structValue) AddField(field *Field) {
 }
 
 // ConvertToNative converts the MapValue type to a native go types.
-func (sv *structValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+func (sv *structValue) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	if typeDesc.Kind() != reflect.Map &&
 		typeDesc.Kind() != reflect.Struct &&
 		typeDesc.Kind() != reflect.Pointer &&
@@ -353,7 +353,7 @@ func (o *ObjectValue) Type() ref.Type {
 }
 
 // Value returns the Go-native representation of the object.
-func (o *ObjectValue) Value() interface{} {
+func (o *ObjectValue) Value() any {
 	return o
 }
 
@@ -477,7 +477,7 @@ func (m *MapValue) Type() ref.Type {
 }
 
 // Value returns the Go-native representation of the MapValue.
-func (m *MapValue) Value() interface{} {
+func (m *MapValue) Value() any {
 	return m
 }
 
@@ -602,7 +602,7 @@ func (lv *ListValue) Contains(val ref.Val) ref.Val {
 
 // ConvertToNative is an implementation of the CEL ref.Val method used to adapt between CEL types
 // and Go-native array-like types.
-func (lv *ListValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+func (lv *ListValue) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	// Non-list conversion.
 	if typeDesc.Kind() != reflect.Slice &&
 		typeDesc.Kind() != reflect.Array &&
@@ -697,7 +697,7 @@ func (lv *ListValue) Type() ref.Type {
 }
 
 // Value returns the Go-native value.
-func (lv *ListValue) Value() interface{} {
+func (lv *ListValue) Value() any {
 	return lv
 }
 
@@ -719,7 +719,7 @@ func (lv *ListValue) finalizeValueSet() {
 
 type baseVal struct{}
 
-func (*baseVal) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+func (*baseVal) ConvertToNative(typeDesc reflect.Type) (any, error) {
 	return nil, fmt.Errorf("unsupported native conversion to: %v", typeDesc)
 }
 
@@ -731,7 +731,7 @@ func (*baseVal) Equal(other ref.Val) ref.Val {
 	return types.NewErr("unsupported equality test between instances")
 }
 
-func (v *baseVal) Value() interface{} {
+func (v *baseVal) Value() any {
 	return nil
 }
 

--- a/pkg/cel/value_test.go
+++ b/pkg/cel/value_test.go
@@ -30,7 +30,7 @@ import (
 func TestConvertToType(t *testing.T) {
 	objType := NewObjectType("TestObject", map[string]*DeclField{})
 	tests := []struct {
-		val interface{}
+		val any
 		typ ref.Type
 	}{
 		{true, types.BoolType},
@@ -62,7 +62,7 @@ func TestConvertToType(t *testing.T) {
 }
 
 func TestEqual(t *testing.T) {
-	vals := []interface{}{
+	vals := []any{
 		true, []byte("bytes"), float64(1.2), int64(-42), uint64(63), time.Duration(300),
 		time.Now().UTC(), types.NullValue, NewListValue(), NewMapValue(),
 		NewObjectValue(NewObjectType("TestObject", map[string]*DeclField{})),
@@ -148,11 +148,11 @@ func TestListValueContainsNestedList(t *testing.T) {
 
 func TestListValueConvertToNative(t *testing.T) {
 	lv := NewListValue()
-	none, err := lv.ConvertToNative(reflect.TypeFor[[]interface{}]())
+	none, err := lv.ConvertToNative(reflect.TypeFor[[]any]())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(none, []interface{}{}) {
+	if !reflect.DeepEqual(none, []any{}) {
 		t.Errorf("got %v, wanted empty list", none)
 	}
 	lv.Append(testValue(t, 1, "first"))
@@ -210,18 +210,18 @@ func TestListValueIterator(t *testing.T) {
 
 func TestMapValueConvertToNative(t *testing.T) {
 	mv := NewMapValue()
-	none, err := mv.ConvertToNative(reflect.TypeFor[map[string]interface{}]())
+	none, err := mv.ConvertToNative(reflect.TypeFor[map[string]any]())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(none, map[string]interface{}{}) {
+	if !reflect.DeepEqual(none, map[string]any{}) {
 		t.Errorf("got %v, wanted empty map", none)
 	}
-	none, err = mv.ConvertToNative(reflect.TypeFor[map[interface{}]interface{}]())
+	none, err = mv.ConvertToNative(reflect.TypeFor[map[any]any]())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(none, map[interface{}]interface{}{}) {
+	if !reflect.DeepEqual(none, map[any]any{}) {
 		t.Errorf("got %v, wanted empty map", none)
 	}
 	mv.AddField(NewField(1, "Test"))

--- a/pkg/cloudauth/policy_fetcher_test.go
+++ b/pkg/cloudauth/policy_fetcher_test.go
@@ -185,7 +185,7 @@ func TestPolicyFetcherIntegration(t *testing.T) {
 	config := Config{
 		CloudURL: server.URL,
 		Logger:   slog.Default(),
-		Tags: map[string]interface{}{
+		Tags: map[string]any{
 			"cluster": "test",
 		},
 	}
@@ -205,7 +205,7 @@ func TestPolicyFetcherIntegration(t *testing.T) {
 		Groups:   []string{"test-services"},
 		Resource: "apps/test",
 		Action:   "execute",
-		Tags: map[string]interface{}{
+		Tags: map[string]any{
 			"cluster": "test",
 		},
 	}

--- a/pkg/cloudauth/rpc_adapter_test.go
+++ b/pkg/cloudauth/rpc_adapter_test.go
@@ -17,7 +17,7 @@ func TestConfigValidate(t *testing.T) {
 			config: Config{
 				CloudURL: "https://miren.cloud",
 				Logger:   slog.Default(),
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"environment": "production",
 					"cluster":     "us-west-1",
 				},
@@ -29,7 +29,7 @@ func TestConfigValidate(t *testing.T) {
 			config: Config{
 				CloudURL: "https://miren.cloud",
 				Logger:   slog.Default(),
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"": "value",
 				},
 			},
@@ -41,7 +41,7 @@ func TestConfigValidate(t *testing.T) {
 			config: Config{
 				CloudURL: "https://miren.cloud",
 				Logger:   slog.Default(),
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"invalid": []string{"a", "b"},
 				},
 			},
@@ -53,7 +53,7 @@ func TestConfigValidate(t *testing.T) {
 			config: Config{
 				CloudURL: "https://miren.cloud",
 				Logger:   slog.Default(),
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"invalid": map[string]string{"nested": "value"},
 				},
 			},
@@ -65,7 +65,7 @@ func TestConfigValidate(t *testing.T) {
 			config: Config{
 				CloudURL: "https://miren.cloud",
 				Logger:   slog.Default(),
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"string_tag": "value",
 					"int_tag":    42,
 					"float_tag":  3.14,

--- a/pkg/color/color.go
+++ b/pkg/color/color.go
@@ -250,7 +250,7 @@ func (c *Color) Add(value ...Attribute) *Color {
 // It returns the number of bytes written and any write error encountered.
 // On Windows, users should wrap w with colorable.NewColorable() if w is of
 // type *os.File.
-func (c *Color) Fprint(w io.Writer, a ...interface{}) (n int, err error) {
+func (c *Color) Fprint(w io.Writer, a ...any) (n int, err error) {
 	c.SetWriter(w)
 	defer c.UnsetWriter(w)
 
@@ -262,7 +262,7 @@ func (c *Color) Fprint(w io.Writer, a ...interface{}) (n int, err error) {
 // string. It returns the number of bytes written and any write error
 // encountered. This is the standard fmt.Print() method wrapped with the given
 // color.
-func (c *Color) Print(a ...interface{}) (n int, err error) {
+func (c *Color) Print(a ...any) (n int, err error) {
 	c.Set()
 	defer c.unset()
 
@@ -273,7 +273,7 @@ func (c *Color) Print(a ...interface{}) (n int, err error) {
 // It returns the number of bytes written and any write error encountered.
 // On Windows, users should wrap w with colorable.NewColorable() if w is of
 // type *os.File.
-func (c *Color) Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+func (c *Color) Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
 	c.SetWriter(w)
 	defer c.UnsetWriter(w)
 
@@ -283,7 +283,7 @@ func (c *Color) Fprintf(w io.Writer, format string, a ...interface{}) (n int, er
 // Printf formats according to a format specifier and writes to standard output.
 // It returns the number of bytes written and any write error encountered.
 // This is the standard fmt.Printf() method wrapped with the given color.
-func (c *Color) Printf(format string, a ...interface{}) (n int, err error) {
+func (c *Color) Printf(format string, a ...any) (n int, err error) {
 	c.Set()
 	defer c.unset()
 
@@ -294,7 +294,7 @@ func (c *Color) Printf(format string, a ...interface{}) (n int, err error) {
 // Spaces are always added between operands and a newline is appended.
 // On Windows, users should wrap w with colorable.NewColorable() if w is of
 // type *os.File.
-func (c *Color) Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
+func (c *Color) Fprintln(w io.Writer, a ...any) (n int, err error) {
 	return fmt.Fprintln(w, c.wrap(sprintln(a...)))
 }
 
@@ -303,69 +303,69 @@ func (c *Color) Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
 // appended. It returns the number of bytes written and any write error
 // encountered. This is the standard fmt.Print() method wrapped with the given
 // color.
-func (c *Color) Println(a ...interface{}) (n int, err error) {
+func (c *Color) Println(a ...any) (n int, err error) {
 	return fmt.Fprintln(Output, c.wrap(sprintln(a...)))
 }
 
 // Sprint is just like Print, but returns a string instead of printing it.
-func (c *Color) Sprint(a ...interface{}) string {
+func (c *Color) Sprint(a ...any) string {
 	return c.wrap(fmt.Sprint(a...))
 }
 
 // Sprintln is just like Println, but returns a string instead of printing it.
-func (c *Color) Sprintln(a ...interface{}) string {
+func (c *Color) Sprintln(a ...any) string {
 	return c.wrap(sprintln(a...)) + "\n"
 }
 
 // Sprintf is just like Printf, but returns a string instead of printing it.
-func (c *Color) Sprintf(format string, a ...interface{}) string {
+func (c *Color) Sprintf(format string, a ...any) string {
 	return c.wrap(fmt.Sprintf(format, a...))
 }
 
 // FprintFunc returns a new function that prints the passed arguments as
 // colorized with color.Fprint().
-func (c *Color) FprintFunc() func(w io.Writer, a ...interface{}) {
-	return func(w io.Writer, a ...interface{}) {
+func (c *Color) FprintFunc() func(w io.Writer, a ...any) {
+	return func(w io.Writer, a ...any) {
 		c.Fprint(w, a...)
 	}
 }
 
 // PrintFunc returns a new function that prints the passed arguments as
 // colorized with color.Print().
-func (c *Color) PrintFunc() func(a ...interface{}) {
-	return func(a ...interface{}) {
+func (c *Color) PrintFunc() func(a ...any) {
+	return func(a ...any) {
 		c.Print(a...)
 	}
 }
 
 // FprintfFunc returns a new function that prints the passed arguments as
 // colorized with color.Fprintf().
-func (c *Color) FprintfFunc() func(w io.Writer, format string, a ...interface{}) {
-	return func(w io.Writer, format string, a ...interface{}) {
+func (c *Color) FprintfFunc() func(w io.Writer, format string, a ...any) {
+	return func(w io.Writer, format string, a ...any) {
 		c.Fprintf(w, format, a...)
 	}
 }
 
 // PrintfFunc returns a new function that prints the passed arguments as
 // colorized with color.Printf().
-func (c *Color) PrintfFunc() func(format string, a ...interface{}) {
-	return func(format string, a ...interface{}) {
+func (c *Color) PrintfFunc() func(format string, a ...any) {
+	return func(format string, a ...any) {
 		c.Printf(format, a...)
 	}
 }
 
 // FprintlnFunc returns a new function that prints the passed arguments as
 // colorized with color.Fprintln().
-func (c *Color) FprintlnFunc() func(w io.Writer, a ...interface{}) {
-	return func(w io.Writer, a ...interface{}) {
+func (c *Color) FprintlnFunc() func(w io.Writer, a ...any) {
+	return func(w io.Writer, a ...any) {
 		c.Fprintln(w, a...)
 	}
 }
 
 // PrintlnFunc returns a new function that prints the passed arguments as
 // colorized with color.Println().
-func (c *Color) PrintlnFunc() func(a ...interface{}) {
-	return func(a ...interface{}) {
+func (c *Color) PrintlnFunc() func(a ...any) {
+	return func(a ...any) {
 		c.Println(a...)
 	}
 }
@@ -376,8 +376,8 @@ func (c *Color) PrintlnFunc() func(a ...interface{}) {
 //
 //	put := New(FgYellow).SprintFunc()
 //	fmt.Fprintf(color.Output, "This is a %s", put("warning"))
-func (c *Color) SprintFunc() func(a ...interface{}) string {
-	return func(a ...interface{}) string {
+func (c *Color) SprintFunc() func(a ...any) string {
+	return func(a ...any) string {
 		return c.wrap(fmt.Sprint(a...))
 	}
 }
@@ -385,8 +385,8 @@ func (c *Color) SprintFunc() func(a ...interface{}) string {
 // SprintfFunc returns a new function that returns colorized strings for the
 // given arguments with fmt.Sprintf(). Useful to put into or mix into other
 // string. Windows users should use this in conjunction with color.Output.
-func (c *Color) SprintfFunc() func(format string, a ...interface{}) string {
-	return func(format string, a ...interface{}) string {
+func (c *Color) SprintfFunc() func(format string, a ...any) string {
+	return func(format string, a ...any) string {
 		return c.wrap(fmt.Sprintf(format, a...))
 	}
 }
@@ -394,8 +394,8 @@ func (c *Color) SprintfFunc() func(format string, a ...interface{}) string {
 // SprintlnFunc returns a new function that returns colorized strings for the
 // given arguments with fmt.Sprintln(). Useful to put into or mix into other
 // string. Windows users should use this in conjunction with color.Output.
-func (c *Color) SprintlnFunc() func(a ...interface{}) string {
-	return func(a ...interface{}) string {
+func (c *Color) SprintlnFunc() func(a ...any) string {
+	return func(a ...any) string {
 		return c.wrap(sprintln(a...)) + "\n"
 	}
 }
@@ -505,7 +505,7 @@ func getCachedColor(p Attribute) *Color {
 	return c
 }
 
-func colorPrint(format string, p Attribute, a ...interface{}) {
+func colorPrint(format string, p Attribute, a ...any) {
 	c := getCachedColor(p)
 
 	if !strings.HasSuffix(format, "\n") {
@@ -519,7 +519,7 @@ func colorPrint(format string, p Attribute, a ...interface{}) {
 	}
 }
 
-func colorString(format string, p Attribute, a ...interface{}) string {
+func colorString(format string, p Attribute, a ...any) string {
 	c := getCachedColor(p)
 
 	if len(a) == 0 {
@@ -531,145 +531,145 @@ func colorString(format string, p Attribute, a ...interface{}) string {
 
 // Black is a convenient helper function to print with black foreground. A
 // newline is appended to format by default.
-func Black(format string, a ...interface{}) { colorPrint(format, FgBlack, a...) }
+func Black(format string, a ...any) { colorPrint(format, FgBlack, a...) }
 
 // Red is a convenient helper function to print with red foreground. A
 // newline is appended to format by default.
-func Red(format string, a ...interface{}) { colorPrint(format, FgRed, a...) }
+func Red(format string, a ...any) { colorPrint(format, FgRed, a...) }
 
 // Green is a convenient helper function to print with green foreground. A
 // newline is appended to format by default.
-func Green(format string, a ...interface{}) { colorPrint(format, FgGreen, a...) }
+func Green(format string, a ...any) { colorPrint(format, FgGreen, a...) }
 
 // Yellow is a convenient helper function to print with yellow foreground.
 // A newline is appended to format by default.
-func Yellow(format string, a ...interface{}) { colorPrint(format, FgYellow, a...) }
+func Yellow(format string, a ...any) { colorPrint(format, FgYellow, a...) }
 
 // Blue is a convenient helper function to print with blue foreground. A
 // newline is appended to format by default.
-func Blue(format string, a ...interface{}) { colorPrint(format, FgBlue, a...) }
+func Blue(format string, a ...any) { colorPrint(format, FgBlue, a...) }
 
 // Magenta is a convenient helper function to print with magenta foreground.
 // A newline is appended to format by default.
-func Magenta(format string, a ...interface{}) { colorPrint(format, FgMagenta, a...) }
+func Magenta(format string, a ...any) { colorPrint(format, FgMagenta, a...) }
 
 // Cyan is a convenient helper function to print with cyan foreground. A
 // newline is appended to format by default.
-func Cyan(format string, a ...interface{}) { colorPrint(format, FgCyan, a...) }
+func Cyan(format string, a ...any) { colorPrint(format, FgCyan, a...) }
 
 // White is a convenient helper function to print with white foreground. A
 // newline is appended to format by default.
-func White(format string, a ...interface{}) { colorPrint(format, FgWhite, a...) }
+func White(format string, a ...any) { colorPrint(format, FgWhite, a...) }
 
 // BlackString is a convenient helper function to return a string with black
 // foreground.
-func BlackString(format string, a ...interface{}) string { return colorString(format, FgBlack, a...) }
+func BlackString(format string, a ...any) string { return colorString(format, FgBlack, a...) }
 
 // RedString is a convenient helper function to return a string with red
 // foreground.
-func RedString(format string, a ...interface{}) string { return colorString(format, FgRed, a...) }
+func RedString(format string, a ...any) string { return colorString(format, FgRed, a...) }
 
 // GreenString is a convenient helper function to return a string with green
 // foreground.
-func GreenString(format string, a ...interface{}) string { return colorString(format, FgGreen, a...) }
+func GreenString(format string, a ...any) string { return colorString(format, FgGreen, a...) }
 
 // YellowString is a convenient helper function to return a string with yellow
 // foreground.
-func YellowString(format string, a ...interface{}) string { return colorString(format, FgYellow, a...) }
+func YellowString(format string, a ...any) string { return colorString(format, FgYellow, a...) }
 
 // BlueString is a convenient helper function to return a string with blue
 // foreground.
-func BlueString(format string, a ...interface{}) string { return colorString(format, FgBlue, a...) }
+func BlueString(format string, a ...any) string { return colorString(format, FgBlue, a...) }
 
 // MagentaString is a convenient helper function to return a string with magenta
 // foreground.
-func MagentaString(format string, a ...interface{}) string {
+func MagentaString(format string, a ...any) string {
 	return colorString(format, FgMagenta, a...)
 }
 
 // CyanString is a convenient helper function to return a string with cyan
 // foreground.
-func CyanString(format string, a ...interface{}) string { return colorString(format, FgCyan, a...) }
+func CyanString(format string, a ...any) string { return colorString(format, FgCyan, a...) }
 
 // WhiteString is a convenient helper function to return a string with white
 // foreground.
-func WhiteString(format string, a ...interface{}) string { return colorString(format, FgWhite, a...) }
+func WhiteString(format string, a ...any) string { return colorString(format, FgWhite, a...) }
 
 // HiBlack is a convenient helper function to print with hi-intensity black foreground. A
 // newline is appended to format by default.
-func HiBlack(format string, a ...interface{}) { colorPrint(format, FgHiBlack, a...) }
+func HiBlack(format string, a ...any) { colorPrint(format, FgHiBlack, a...) }
 
 // HiRed is a convenient helper function to print with hi-intensity red foreground. A
 // newline is appended to format by default.
-func HiRed(format string, a ...interface{}) { colorPrint(format, FgHiRed, a...) }
+func HiRed(format string, a ...any) { colorPrint(format, FgHiRed, a...) }
 
 // HiGreen is a convenient helper function to print with hi-intensity green foreground. A
 // newline is appended to format by default.
-func HiGreen(format string, a ...interface{}) { colorPrint(format, FgHiGreen, a...) }
+func HiGreen(format string, a ...any) { colorPrint(format, FgHiGreen, a...) }
 
 // HiYellow is a convenient helper function to print with hi-intensity yellow foreground.
 // A newline is appended to format by default.
-func HiYellow(format string, a ...interface{}) { colorPrint(format, FgHiYellow, a...) }
+func HiYellow(format string, a ...any) { colorPrint(format, FgHiYellow, a...) }
 
 // HiBlue is a convenient helper function to print with hi-intensity blue foreground. A
 // newline is appended to format by default.
-func HiBlue(format string, a ...interface{}) { colorPrint(format, FgHiBlue, a...) }
+func HiBlue(format string, a ...any) { colorPrint(format, FgHiBlue, a...) }
 
 // HiMagenta is a convenient helper function to print with hi-intensity magenta foreground.
 // A newline is appended to format by default.
-func HiMagenta(format string, a ...interface{}) { colorPrint(format, FgHiMagenta, a...) }
+func HiMagenta(format string, a ...any) { colorPrint(format, FgHiMagenta, a...) }
 
 // HiCyan is a convenient helper function to print with hi-intensity cyan foreground. A
 // newline is appended to format by default.
-func HiCyan(format string, a ...interface{}) { colorPrint(format, FgHiCyan, a...) }
+func HiCyan(format string, a ...any) { colorPrint(format, FgHiCyan, a...) }
 
 // HiWhite is a convenient helper function to print with hi-intensity white foreground. A
 // newline is appended to format by default.
-func HiWhite(format string, a ...interface{}) { colorPrint(format, FgHiWhite, a...) }
+func HiWhite(format string, a ...any) { colorPrint(format, FgHiWhite, a...) }
 
 // HiBlackString is a convenient helper function to return a string with hi-intensity black
 // foreground.
-func HiBlackString(format string, a ...interface{}) string {
+func HiBlackString(format string, a ...any) string {
 	return colorString(format, FgHiBlack, a...)
 }
 
 // HiRedString is a convenient helper function to return a string with hi-intensity red
 // foreground.
-func HiRedString(format string, a ...interface{}) string { return colorString(format, FgHiRed, a...) }
+func HiRedString(format string, a ...any) string { return colorString(format, FgHiRed, a...) }
 
 // HiGreenString is a convenient helper function to return a string with hi-intensity green
 // foreground.
-func HiGreenString(format string, a ...interface{}) string {
+func HiGreenString(format string, a ...any) string {
 	return colorString(format, FgHiGreen, a...)
 }
 
 // HiYellowString is a convenient helper function to return a string with hi-intensity yellow
 // foreground.
-func HiYellowString(format string, a ...interface{}) string {
+func HiYellowString(format string, a ...any) string {
 	return colorString(format, FgHiYellow, a...)
 }
 
 // HiBlueString is a convenient helper function to return a string with hi-intensity blue
 // foreground.
-func HiBlueString(format string, a ...interface{}) string { return colorString(format, FgHiBlue, a...) }
+func HiBlueString(format string, a ...any) string { return colorString(format, FgHiBlue, a...) }
 
 // HiMagentaString is a convenient helper function to return a string with hi-intensity magenta
 // foreground.
-func HiMagentaString(format string, a ...interface{}) string {
+func HiMagentaString(format string, a ...any) string {
 	return colorString(format, FgHiMagenta, a...)
 }
 
 // HiCyanString is a convenient helper function to return a string with hi-intensity cyan
 // foreground.
-func HiCyanString(format string, a ...interface{}) string { return colorString(format, FgHiCyan, a...) }
+func HiCyanString(format string, a ...any) string { return colorString(format, FgHiCyan, a...) }
 
 // HiWhiteString is a convenient helper function to return a string with hi-intensity white
 // foreground.
-func HiWhiteString(format string, a ...interface{}) string {
+func HiWhiteString(format string, a ...any) string {
 	return colorString(format, FgHiWhite, a...)
 }
 
 // sprintln is a helper function to format a string with fmt.Sprintln and trim the trailing newline.
-func sprintln(a ...interface{}) string {
+func sprintln(a ...any) string {
 	return strings.TrimSuffix(fmt.Sprintln(a...), "\n")
 }

--- a/pkg/color/color_test.go
+++ b/pkg/color/color_test.go
@@ -388,9 +388,9 @@ func TestNoFormat(t *testing.T) {
 
 func TestNoFormatString(t *testing.T) {
 	tests := []struct {
-		f      func(string, ...interface{}) string
+		f      func(string, ...any) string
 		format string
-		args   []interface{}
+		args   []any
 		want   string
 	}{
 		{BlackString, "%s", nil, "\x1b[30m%s\x1b[0m"},
@@ -507,7 +507,7 @@ func TestIssue206_2(t *testing.T) {
 
 func TestIssue218(t *testing.T) {
 	// Adds a newline to the end of the last string to make sure it isn't trimmed.
-	params := []interface{}{"word1", "word2", "word3", "word4\n"}
+	params := []any{"word1", "word2", "word3", "word4\n"}
 
 	c := New(FgCyan)
 	c.Println(params...)

--- a/pkg/entity/entity_test.go
+++ b/pkg/entity/entity_test.go
@@ -23,7 +23,7 @@ func setupTestStore(t *testing.T) (*FileStore, func()) {
 	return store, cleanup
 }
 
-func assertEntityEqual(t *testing.T, expected, actual *Entity, msgAndArgs ...interface{}) bool {
+func assertEntityEqual(t *testing.T, expected, actual *Entity, msgAndArgs ...any) bool {
 	t.Helper()
 
 	// Make copies to avoid modifying the original entities

--- a/pkg/hey/requester/print.go
+++ b/pkg/hey/requester/print.go
@@ -60,7 +60,7 @@ var tmplFuncMap = template.FuncMap{
 	"jsonify":         jsonify,
 }
 
-func jsonify(v interface{}) string {
+func jsonify(v any) string {
 	d, _ := json.Marshal(v)
 	return string(d)
 }

--- a/pkg/hey/requester/report.go
+++ b/pkg/hey/requester/report.go
@@ -136,7 +136,7 @@ func (r *report) print() {
 	r.printf("\n")
 }
 
-func (r *report) printf(s string, v ...interface{}) {
+func (r *report) printf(s string, v ...any) {
 	fmt.Fprintf(r.w, s, v...)
 }
 

--- a/pkg/oidc/client.go
+++ b/pkg/oidc/client.go
@@ -105,7 +105,7 @@ func (c *Client) ExchangeCode(ctx context.Context, code, pkceVerifier string) (*
 
 // ParseIDToken validates an ID token's signature via the provider's JWKS
 // and checks standard claims (issuer, audience).
-func (c *Client) ParseIDToken(ctx context.Context, idToken string) (map[string]interface{}, error) {
+func (c *Client) ParseIDToken(ctx context.Context, idToken string) (map[string]any, error) {
 	discovery, err := c.getDiscovery(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get discovery data: %w", err)
@@ -154,7 +154,7 @@ func (c *Client) validateAudience(claims jwt.MapClaims) error {
 		if v == c.clientID {
 			return nil
 		}
-	case []interface{}:
+	case []any:
 		for _, a := range v {
 			if s, ok := a.(string); ok && s == c.clientID {
 				return nil
@@ -291,7 +291,7 @@ func (c *Client) getJWKSKeyFunc(ctx context.Context, jwksURI string) (jwt.Keyfun
 		return nil, fmt.Errorf("failed to parse JWKS: %w", err)
 	}
 
-	return func(token *jwt.Token) (interface{}, error) {
+	return func(token *jwt.Token) (any, error) {
 		kid, ok := token.Header["kid"].(string)
 		if !ok {
 			return nil, fmt.Errorf("token missing kid header")
@@ -313,6 +313,6 @@ func generatePKCEChallenge(verifier string) string {
 }
 
 // parseJSON is a helper to parse JSON from an io.Reader
-func parseJSON(r io.Reader, v interface{}) error {
+func parseJSON(r io.Reader, v any) error {
 	return json.NewDecoder(r).Decode(v)
 }

--- a/pkg/oidc/client_test.go
+++ b/pkg/oidc/client_test.go
@@ -55,7 +55,7 @@ func newTestProvider(t *testing.T, key *rsa.PrivateKey) (*httptest.Server, strin
 		// We need the server URL but don't have it yet during setup,
 		// so we read it from the request host.
 		baseURL := fmt.Sprintf("http://%s", r.Host)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"issuer":                 baseURL,
 			"authorization_endpoint": baseURL + "/authorize",
 			"token_endpoint":         baseURL + "/token",

--- a/pkg/oidc/session.go
+++ b/pkg/oidc/session.go
@@ -43,7 +43,7 @@ type SessionData struct {
 	RefreshToken string `json:"refresh_token,omitempty"`
 
 	// Claims are the parsed JWT claims
-	Claims map[string]interface{} `json:"claims"`
+	Claims map[string]any `json:"claims"`
 
 	// ExpiresAt is when this session expires
 	ExpiresAt time.Time `json:"expires_at"`

--- a/pkg/oidc/session_test.go
+++ b/pkg/oidc/session_test.go
@@ -12,7 +12,7 @@ func TestSessionManager_SetAndGetSession(t *testing.T) {
 	// Create test session
 	session := &SessionData{
 		IDToken: "test-id-token",
-		Claims: map[string]interface{}{
+		Claims: map[string]any{
 			"sub":   "test-user",
 			"email": "test@example.com",
 		},

--- a/pkg/oidcauth/validator.go
+++ b/pkg/oidcauth/validator.go
@@ -120,7 +120,7 @@ func audienceContains(claims jwt.MapClaims, expected string) bool {
 	switch v := aud.(type) {
 	case string:
 		return v == expected
-	case []interface{}:
+	case []any:
 		for _, a := range v {
 			if s, ok := a.(string); ok && s == expected {
 				return true
@@ -146,7 +146,7 @@ func mapClaimsToClaims(mc jwt.MapClaims) *Claims {
 	switch v := mc["aud"].(type) {
 	case string:
 		c.Audience = []string{v}
-	case []interface{}:
+	case []any:
 		for _, a := range v {
 			if s, ok := a.(string); ok {
 				c.Audience = append(c.Audience, s)
@@ -304,7 +304,7 @@ func (v *Validator) fetchJWKS(ctx context.Context, jwksURI string) (*jose.JSONWe
 }
 
 func makeKeyFunc(jwks *jose.JSONWebKeySet) jwt.Keyfunc {
-	return func(token *jwt.Token) (interface{}, error) {
+	return func(token *jwt.Token) (any, error) {
 		kid, ok := token.Header["kid"].(string)
 		if ok {
 			keys := jwks.Key(kid)

--- a/pkg/oidcauth/validator_test.go
+++ b/pkg/oidcauth/validator_test.go
@@ -39,7 +39,7 @@ func newTestOIDCServer(t *testing.T) *testOIDCServer {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		// Use the actual server URL once set
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"issuer":   ts.server.URL,
 			"jwks_uri": ts.server.URL + "/jwks",
 		})
@@ -175,7 +175,7 @@ func TestValidateToken_JWKSRefresh(t *testing.T) {
 	var server *httptest.Server
 
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"issuer":   server.URL,
 			"jwks_uri": server.URL + "/jwks",
 		})

--- a/pkg/perf/count_test.go
+++ b/pkg/perf/count_test.go
@@ -151,7 +151,7 @@ func testL1DataMissesBadLocality(t *testing.T) {
 
 	max := 1000
 
-	var bad []interface{}
+	var bad []any
 	for range 10000 {
 		bad = append(bad, rng.Intn(max))
 	}

--- a/pkg/progress/multiwriter.go
+++ b/pkg/progress/multiwriter.go
@@ -16,7 +16,7 @@ type MultiWriter struct {
 	mu      sync.Mutex
 	items   []*Progress
 	writers map[rawProgressWriter]struct{}
-	meta    map[string]interface{}
+	meta    map[string]any
 }
 
 var _ rawProgressWriter = &MultiWriter{}
@@ -24,7 +24,7 @@ var _ rawProgressWriter = &MultiWriter{}
 func NewMultiWriter(opts ...WriterOption) *MultiWriter {
 	mw := &MultiWriter{
 		writers: map[rawProgressWriter]struct{}{},
-		meta:    map[string]interface{}{},
+		meta:    map[string]any{},
 	}
 	for _, o := range opts {
 		o(mw)
@@ -70,7 +70,7 @@ func (ps *MultiWriter) Delete(pw Writer) {
 	ps.mu.Unlock()
 }
 
-func (ps *MultiWriter) Write(id string, v interface{}) error {
+func (ps *MultiWriter) Write(id string, v any) error {
 	p := &Progress{
 		ID:        id,
 		Timestamp: time.Now(),
@@ -83,7 +83,7 @@ func (ps *MultiWriter) Write(id string, v interface{}) error {
 func (ps *MultiWriter) WriteRawProgress(p *Progress) error {
 	meta := p.meta
 	if len(ps.meta) > 0 {
-		meta = map[string]interface{}{}
+		meta = map[string]any{}
 		maps.Copy(meta, p.meta)
 		for k, v := range ps.meta {
 			if _, ok := meta[k]; !ok {

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -67,7 +67,7 @@ func WithProgress(ctx context.Context, pw Writer) context.Context {
 	return context.WithValue(ctx, contextKey, pw)
 }
 
-func WithMetadata(key string, val interface{}) WriterOption {
+func WithMetadata(key string, val any) WriterOption {
 	return func(w Writer) {
 		if pw, ok := w.(*progressWriter); ok {
 			pw.meta[key] = val
@@ -84,7 +84,7 @@ type Controller interface {
 }
 
 type Writer interface {
-	Write(id string, value interface{}) error
+	Write(id string, value any) error
 	Close() error
 }
 
@@ -95,8 +95,8 @@ type Reader interface {
 type Progress struct {
 	ID        string
 	Timestamp time.Time
-	Sys       interface{}
-	meta      map[string]interface{}
+	Sys       any
+	meta      map[string]any
 }
 
 type Status struct {
@@ -207,7 +207,7 @@ func pipe() (*progressReader, *progressWriter, func(error)) {
 }
 
 func newWriter(pw *progressWriter) *progressWriter {
-	meta := make(map[string]interface{})
+	meta := make(map[string]any)
 	maps.Copy(meta, pw.meta)
 	pw = &progressWriter{
 		reader: pw.reader,
@@ -220,10 +220,10 @@ func newWriter(pw *progressWriter) *progressWriter {
 type progressWriter struct {
 	done   bool
 	reader *progressReader
-	meta   map[string]interface{}
+	meta   map[string]any
 }
 
-func (pw *progressWriter) Write(id string, v interface{}) error {
+func (pw *progressWriter) Write(id string, v any) error {
 	if pw.done {
 		return errors.Errorf("writing %s to closed progress writer", id)
 	}
@@ -238,7 +238,7 @@ func (pw *progressWriter) Write(id string, v interface{}) error {
 func (pw *progressWriter) WriteRawProgress(p *Progress) error {
 	meta := p.meta
 	if len(pw.meta) > 0 {
-		meta = map[string]interface{}{}
+		meta = map[string]any{}
 		maps.Copy(meta, p.meta)
 		for k, v := range pw.meta {
 			if _, ok := meta[k]; !ok {
@@ -267,14 +267,14 @@ func (pw *progressWriter) Close() error {
 	return nil
 }
 
-func (p *Progress) Meta(key string) (interface{}, bool) {
+func (p *Progress) Meta(key string) (any, bool) {
 	v, ok := p.meta[key]
 	return v, ok
 }
 
 type noOpWriter struct{}
 
-func (pw *noOpWriter) Write(_ string, _ interface{}) error {
+func (pw *noOpWriter) Write(_ string, _ any) error {
 	return nil
 }
 

--- a/pkg/rbac/evaluator_test.go
+++ b/pkg/rbac/evaluator_test.go
@@ -112,7 +112,7 @@ func TestEvaluatorWithTags(t *testing.T) {
 				Groups:   []string{"admins"},
 				Resource: "secrets/private",
 				Action:   "delete",
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"environment": "production",
 					"cluster":     "prod-1",
 				},
@@ -126,7 +126,7 @@ func TestEvaluatorWithTags(t *testing.T) {
 				Groups:   []string{"admins"},
 				Resource: "secrets/private",
 				Action:   "delete",
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"environment": "development",
 					"cluster":     "dev-1",
 				},
@@ -140,7 +140,7 @@ func TestEvaluatorWithTags(t *testing.T) {
 				Groups:   []string{"developers"},
 				Resource: "apps/myapp",
 				Action:   "write",
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"environment": "development",
 					"cluster":     "dev-1",
 				},
@@ -154,7 +154,7 @@ func TestEvaluatorWithTags(t *testing.T) {
 				Groups:   []string{"developers"},
 				Resource: "apps/myapp",
 				Action:   "write",
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"environment": "production",
 					"cluster":     "prod-1",
 				},
@@ -168,7 +168,7 @@ func TestEvaluatorWithTags(t *testing.T) {
 				Groups:   []string{"viewers"},
 				Resource: "apps/myapp",
 				Action:   "read",
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"environment": "production",
 					"cluster":     "prod-1",
 				},
@@ -182,7 +182,7 @@ func TestEvaluatorWithTags(t *testing.T) {
 				Groups:   []string{"viewers"},
 				Resource: "apps/myapp",
 				Action:   "write",
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"environment": "development",
 					"cluster":     "dev-1",
 				},
@@ -196,7 +196,7 @@ func TestEvaluatorWithTags(t *testing.T) {
 				Groups:   []string{"unknown-group"},
 				Resource: "apps/myapp",
 				Action:   "read",
-				Tags: map[string]interface{}{
+				Tags: map[string]any{
 					"environment": "development",
 					"cluster":     "dev-1",
 				},
@@ -219,7 +219,7 @@ func TestRuleTagMatching(t *testing.T) {
 	tests := []struct {
 		name        string
 		rule        Rule
-		tags        map[string]interface{}
+		tags        map[string]any
 		shouldMatch bool
 	}{
 		{
@@ -232,7 +232,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"env":     "prod",
 				"cluster": "us-west",
 			},
@@ -247,7 +247,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"env": "prod",
 			},
 			shouldMatch: true,
@@ -261,7 +261,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"cluster": "any-value",
 			},
 			shouldMatch: true,
@@ -275,7 +275,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"env": "prod",
 			},
 			shouldMatch: true,
@@ -289,7 +289,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"env": "staging",
 			},
 			shouldMatch: true,
@@ -303,7 +303,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"env": "staging",
 			},
 			shouldMatch: true,
@@ -317,7 +317,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"env": "prod",
 			},
 			shouldMatch: true,
@@ -331,7 +331,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags:        map[string]interface{}{},
+			tags:        map[string]any{},
 			shouldMatch: false,
 		},
 		{
@@ -343,7 +343,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"env":     "prod",
 				"cluster": "us-west",
 				"extra":   "value",
@@ -359,7 +359,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"env": "dev",
 			},
 			shouldMatch: false,
@@ -369,7 +369,7 @@ func TestRuleTagMatching(t *testing.T) {
 			rule: Rule{
 				TagSelector: TagSelector{},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"any": "value",
 			},
 			shouldMatch: true,
@@ -385,7 +385,7 @@ func TestRuleTagMatching(t *testing.T) {
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"env":    "prod",
 				"region": "us-west",
 			},
@@ -396,11 +396,11 @@ func TestRuleTagMatching(t *testing.T) {
 			rule: Rule{
 				TagSelector: TagSelector{
 					Expressions: []TagExpression{
-						{Tag: "port", Value: []interface{}{80, 443, 8080}, Operator: "in"},
+						{Tag: "port", Value: []any{80, 443, 8080}, Operator: "in"},
 					},
 				},
 			},
-			tags: map[string]interface{}{
+			tags: map[string]any{
 				"port": 443,
 			},
 			shouldMatch: true,
@@ -512,7 +512,7 @@ func TestEvaluatorCache(t *testing.T) {
 		Groups:   []string{"test-group"},
 		Resource: "test/resource",
 		Action:   "read",
-		Tags:     map[string]interface{}{},
+		Tags:     map[string]any{},
 	}
 
 	// First evaluation
@@ -546,7 +546,7 @@ func TestEvaluatorWithNoPolicy(t *testing.T) {
 		Groups:   []string{"test-group"},
 		Resource: "test/resource",
 		Action:   "read",
-		Tags:     map[string]interface{}{},
+		Tags:     map[string]any{},
 	}
 
 	decision := eval.Evaluate(req)

--- a/pkg/rpc/error.go
+++ b/pkg/rpc/error.go
@@ -158,7 +158,7 @@ func NewResolveError(kind ResolveErrorKind, err error, msg string) error {
 }
 
 // NewResolveHTTPError creates an HTTP request error
-func NewResolveHTTPError(err error, format string, args ...interface{}) error {
+func NewResolveHTTPError(err error, format string, args ...any) error {
 	return &ResolveError{
 		Kind: ResolveHTTPError,
 		Err:  err,

--- a/pkg/serverconfig/cmd/configgen/main.go
+++ b/pkg/serverconfig/cmd/configgen/main.go
@@ -315,14 +315,14 @@ func goTypeForCLI(fieldType string) string {
 	}
 }
 
-func formatDefault(val interface{}, fieldType string) string {
+func formatDefault(val any, fieldType string) string {
 	// Arrays don't need pointers, they have nil as a zero value
 	if fieldType == "[]string" {
 		if val == nil {
 			return "[]string{}"
 		}
 		switch v := val.(type) {
-		case []interface{}:
+		case []any:
 			if len(v) == 0 {
 				return "[]string{}"
 			}

--- a/pkg/slogout/slogout.go
+++ b/pkg/slogout/slogout.go
@@ -166,7 +166,7 @@ var jsonIgnoreKeys = map[string]struct{}{
 
 // processJSONLine parses a JSON line and extracts key/value pairs
 func (w *logWriter) processJSONLine(line string) {
-	var jsonData map[string]interface{}
+	var jsonData map[string]any
 	if err := json.Unmarshal([]byte(line), &jsonData); err != nil {
 		// If JSON parsing fails, log as plain text
 		w.logger.Log(context.TODO(), w.level, line,

--- a/pkg/workloadidentity/issuer_test.go
+++ b/pkg/workloadidentity/issuer_test.go
@@ -76,7 +76,7 @@ func TestIssueToken(t *testing.T) {
 	require.NotEmpty(t, tokenStr)
 
 	// Parse and verify the token
-	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		assert.Equal(t, jwt.SigningMethodRS256, tok.Method)
 		assert.Equal(t, iss.primary.kid, tok.Header["kid"])
 		return iss.primary.public, nil
@@ -121,7 +121,7 @@ func TestIssueToken_NoOrg(t *testing.T) {
 	tokenStr, err := iss.IssueToken("myapp", "sandbox-789")
 	require.NoError(t, err)
 
-	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestIssueToken_NoApp(t *testing.T) {
 	tokenStr, err := iss.IssueToken("", "sandbox-789")
 	require.NoError(t, err)
 
-	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
@@ -241,7 +241,7 @@ func TestJWKSDocument_WithPreviousKey(t *testing.T) {
 	tokenStr, err := iss2.IssueToken("myapp", "sb-1")
 	require.NoError(t, err)
 
-	_, err = jwt.Parse(tokenStr, func(tok *jwt.Token) (interface{}, error) {
+	_, err = jwt.Parse(tokenStr, func(tok *jwt.Token) (any, error) {
 		kid := tok.Header["kid"].(string)
 		keys := jwks.Key(kid)
 		require.NotEmpty(t, keys)
@@ -253,7 +253,7 @@ func TestJWKSDocument_WithPreviousKey(t *testing.T) {
 	oldTokenStr, err := iss1.IssueToken("myapp", "sb-2")
 	require.NoError(t, err)
 
-	_, err = jwt.Parse(oldTokenStr, func(tok *jwt.Token) (interface{}, error) {
+	_, err = jwt.Parse(oldTokenStr, func(tok *jwt.Token) (any, error) {
 		kid := tok.Header["kid"].(string)
 		keys := jwks.Key(kid)
 		require.NotEmpty(t, keys)
@@ -276,7 +276,7 @@ func TestIssueTokenWithOptions_CustomAudience(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
@@ -299,7 +299,7 @@ func TestIssueTokenWithOptions_CustomTTL(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
@@ -325,7 +325,7 @@ func TestIssueTokenWithOptions_TTLClamping(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
@@ -341,7 +341,7 @@ func TestIssueTokenWithOptions_TTLClamping(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	token2, err := jwt.ParseWithClaims(tokenStr2, &WorkloadClaims{}, func(tok *jwt.Token) (interface{}, error) {
+	token2, err := jwt.ParseWithClaims(tokenStr2, &WorkloadClaims{}, func(tok *jwt.Token) (any, error) {
 		return iss.primary.public, nil
 	})
 	require.NoError(t, err)
@@ -424,7 +424,7 @@ func TestNewIssuer_MigratesLegacyEdDSAKey(t *testing.T) {
 	assert.Equal(t, []any{"RS256", "EdDSA"}, doc["id_token_signing_alg_values_supported"])
 
 	// The freshly minted token verifies under the active RS256 JWK.
-	_, err = jwt.Parse(tokenStr, func(tok *jwt.Token) (interface{}, error) {
+	_, err = jwt.Parse(tokenStr, func(tok *jwt.Token) (any, error) {
 		return jwks.Key(tok.Header["kid"].(string))[0].Key, nil
 	})
 	require.NoError(t, err)
@@ -499,7 +499,7 @@ func TestNewIssuer_LoadsDirectoryKeys(t *testing.T) {
 	assert.Equal(t, iss.primary.kid, parsed.Header["kid"])
 
 	// The token verifies under the primary JWK from JWKS.
-	_, err = jwt.Parse(tokenStr, func(tok *jwt.Token) (interface{}, error) {
+	_, err = jwt.Parse(tokenStr, func(tok *jwt.Token) (any, error) {
 		return jwks.Key(tok.Header["kid"].(string))[0].Key, nil
 	})
 	require.NoError(t, err)

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -868,7 +868,7 @@ func (b *Builder) loadAppConfig(dfs fsutil.FS) (*appconfig.AppConfig, error) {
 }
 
 // sendErrorStatus sends an error status update if status is not nil, logging any send errors
-func (b *Builder) sendErrorStatus(ctx context.Context, status *stream.SendStreamClient[*build_v1alpha.Status], format string, args ...interface{}) {
+func (b *Builder) sendErrorStatus(ctx context.Context, status *stream.SendStreamClient[*build_v1alpha.Status], format string, args ...any) {
 	if status != nil {
 		so := new(build_v1alpha.Status)
 		so.Update().SetError(fmt.Sprintf(format, args...))

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -1367,7 +1367,7 @@ func (d *DeploymentServer) markPreviousActiveAs(ctx context.Context, appName, cu
 }
 
 // decodeEntity is a helper to decode RPC entity to struct
-func decodeEntity(rpcEntity *entityserver_v1alpha.Entity, target interface{}) {
+func decodeEntity(rpcEntity *entityserver_v1alpha.Entity, target any) {
 	type decoder interface {
 		Decode(entity.AttrGetter)
 	}

--- a/servers/httpingress/oidc.go
+++ b/servers/httpingress/oidc.go
@@ -95,7 +95,7 @@ func newOIDCHandler(route *ingress_v1alpha.HttpRoute, provider *ingress_v1alpha.
 
 // checkAuth verifies if the request has a valid OIDC session.
 // Returns true if authenticated, false if redirect to OIDC provider is needed.
-func (h *oidcHandler) checkAuth(w http.ResponseWriter, r *http.Request) (authenticated bool, claims map[string]interface{}) {
+func (h *oidcHandler) checkAuth(w http.ResponseWriter, r *http.Request) (authenticated bool, claims map[string]any) {
 	session, err := h.sessionManager.GetSession(r)
 	if err != nil {
 		h.logger.Error("failed to get session", "error", err)
@@ -237,7 +237,7 @@ func (h *oidcHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 // injectClaims adds JWT claims as HTTP headers based on the route configuration.
 // All configured claim headers are first stripped from the request to prevent
 // clients from spoofing identity headers.
-func (h *oidcHandler) injectClaims(r *http.Request, claims map[string]interface{}) {
+func (h *oidcHandler) injectClaims(r *http.Request, claims map[string]any) {
 	// Strip all configured claim headers to prevent spoofing.
 	// This is important for claims not present in the JWT — without stripping,
 	// a client-provided header would pass through to the app.

--- a/servers/httpingress/oidc_test.go
+++ b/servers/httpingress/oidc_test.go
@@ -14,7 +14,7 @@ func TestInjectClaims(t *testing.T) {
 	tests := []struct {
 		name            string
 		claimMappings   []ingress_v1alpha.ClaimMappings
-		claims          map[string]interface{}
+		claims          map[string]any
 		existingHeaders map[string]string
 		wantHeaders     map[string]string
 		wantAbsent      []string
@@ -25,7 +25,7 @@ func TestInjectClaims(t *testing.T) {
 				{Claim: "email", Header: "X-User-Email"},
 				{Claim: "sub", Header: "X-User-ID"},
 			},
-			claims: map[string]interface{}{
+			claims: map[string]any{
 				"email": "alice@example.com",
 				"sub":   "user-123",
 			},
@@ -40,7 +40,7 @@ func TestInjectClaims(t *testing.T) {
 				{Claim: "email", Header: "X-User-Email"},
 				{Claim: "groups", Header: "X-User-Groups"},
 			},
-			claims: map[string]interface{}{
+			claims: map[string]any{
 				"email": "alice@example.com",
 			},
 			wantHeaders: map[string]string{
@@ -54,7 +54,7 @@ func TestInjectClaims(t *testing.T) {
 				{Claim: "email", Header: "X-User-Email"},
 				{Claim: "groups", Header: "X-User-Groups"},
 			},
-			claims: map[string]interface{}{
+			claims: map[string]any{
 				"email": "alice@example.com",
 				// no "groups" claim
 			},
@@ -71,7 +71,7 @@ func TestInjectClaims(t *testing.T) {
 			claimMappings: []ingress_v1alpha.ClaimMappings{
 				{Claim: "email", Header: "X-User-Email"},
 			},
-			claims: map[string]interface{}{
+			claims: map[string]any{
 				"email": "alice@example.com",
 			},
 			existingHeaders: map[string]string{
@@ -86,7 +86,7 @@ func TestInjectClaims(t *testing.T) {
 			claimMappings: []ingress_v1alpha.ClaimMappings{
 				{Claim: "iat", Header: "X-Token-Issued"},
 			},
-			claims: map[string]interface{}{
+			claims: map[string]any{
 				"iat": float64(1700000000),
 			},
 			wantHeaders: map[string]string{
@@ -98,7 +98,7 @@ func TestInjectClaims(t *testing.T) {
 			claimMappings: []ingress_v1alpha.ClaimMappings{
 				{Claim: "email_verified", Header: "X-Email-Verified"},
 			},
-			claims: map[string]interface{}{
+			claims: map[string]any{
 				"email_verified": true,
 			},
 			wantHeaders: map[string]string{
@@ -110,8 +110,8 @@ func TestInjectClaims(t *testing.T) {
 			claimMappings: []ingress_v1alpha.ClaimMappings{
 				{Claim: "groups", Header: "X-User-Groups"},
 			},
-			claims: map[string]interface{}{
-				"groups": []interface{}{"engineering", "platform"},
+			claims: map[string]any{
+				"groups": []any{"engineering", "platform"},
 			},
 			wantHeaders: map[string]string{
 				"X-User-Groups": `["engineering","platform"]`,
@@ -122,8 +122,8 @@ func TestInjectClaims(t *testing.T) {
 			claimMappings: []ingress_v1alpha.ClaimMappings{
 				{Claim: "address", Header: "X-User-Address"},
 			},
-			claims: map[string]interface{}{
-				"address": map[string]interface{}{"city": "Portland"},
+			claims: map[string]any{
+				"address": map[string]any{"city": "Portland"},
 			},
 			wantHeaders: map[string]string{
 				"X-User-Address": `{"city":"Portland"}`,
@@ -136,7 +136,7 @@ func TestInjectClaims(t *testing.T) {
 				{Claim: "email", Header: ""},
 				{Claim: "sub", Header: "X-User-ID"},
 			},
-			claims: map[string]interface{}{
+			claims: map[string]any{
 				"email": "alice@example.com",
 				"sub":   "user-123",
 			},

--- a/servers/runner/registration.go
+++ b/servers/runner/registration.go
@@ -1496,7 +1496,7 @@ func (s *RegistrationServer) findInviteByHash(ctx context.Context, codeHash stri
 	return nil, 0, nil
 }
 
-func decodeEntity(rpcEntity *entityserver_v1alpha.Entity, target interface{}) {
+func decodeEntity(rpcEntity *entityserver_v1alpha.Entity, target any) {
 	type decoder interface {
 		Decode(entity.AttrGetter)
 	}


### PR DESCRIPTION
The codebase still mixed `interface{}` and `any` for values with no type constraint, mostly according to when each API or test fixture was written. That made older code look more specialized than it actually was.

This pass adopts `any` consistently across those remaining call sites. It is strictly a type-alias spelling change, with no effect on runtime behavior, assignability, or method sets.

All packages compile, generation and module tidiness checks pass, and the affected pure unit packages pass. The broader entity suite still requires the local etcd-backed dev environment, so CI remains authoritative for that path once the current Actions outage clears.

Stacked on #1038.