### PR TITLE
Let Go manage goroutine and test lifetimes

### DIFF
--- a/cli/commands/deploy.go
+++ b/cli/commands/deploy.go
@@ -865,9 +865,7 @@ func Deploy(ctx *Context, opts struct {
 		buildModel = initialModel(updateCh, buildCh, uploadProgressCh, cachedFiles, totalFiles, cachedBytes)
 		buildProg = tea.NewProgram(buildModel)
 
-		buildWG.Add(1)
-		go func() {
-			defer buildWG.Done()
+		buildWG.Go(func() {
 			fm, runErr := buildProg.Run()
 			buildFinalModel = fm
 			if runErr == nil {
@@ -878,7 +876,7 @@ func Deploy(ctx *Context, opts struct {
 				// UI died; ensure we don't keep uploading/building
 				cancelDeploy()
 			}
-		}()
+		})
 
 		// Progress handler for interactive mode
 		progressHandler := func(status *client.SolveStatus) error {

--- a/cli/commands/deploy_cancel_test.go
+++ b/cli/commands/deploy_cancel_test.go
@@ -48,8 +48,7 @@ func TestCancellationPoller_DetectsCancellation(t *testing.T) {
 
 	poller := newCancellationPoller("test-deployment", mock, 10*time.Millisecond)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var cancelCalled atomic.Bool
 
@@ -135,8 +134,7 @@ func TestCancellationPoller_ContinuesOnError(t *testing.T) {
 
 	poller := newCancellationPoller("test-deployment", mock, 10*time.Millisecond)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var cancelCalled atomic.Bool
 
@@ -176,8 +174,7 @@ func TestCancellationPoller_ImmediateCancellation(t *testing.T) {
 
 	poller := newCancellationPoller("test-deployment", mock, 10*time.Millisecond)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var cancelCalled atomic.Bool
 

--- a/cli/commands/dial_stdio.go
+++ b/cli/commands/dial_stdio.go
@@ -31,21 +31,17 @@ func DialStdio(ctx *Context, opts struct {
 		c.Close()
 	}()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer cancel()
 
 		io.Copy(c, os.Stdin)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer cancel()
 
 		io.Copy(os.Stdout, c)
-	}()
+	})
 
 	wg.Wait()
 

--- a/cli/commands/safe_status_ch_test.go
+++ b/cli/commands/safe_status_ch_test.go
@@ -17,12 +17,10 @@ func TestSafeStatusChNoPanicOnConcurrentClose(t *testing.T) {
 
 	// Drain the channel so senders don't block forever.
 	var drainerWG sync.WaitGroup
-	drainerWG.Add(1)
-	go func() {
-		defer drainerWG.Done()
+	drainerWG.Go(func() {
 		for range s.ch {
 		}
-	}()
+	})
 
 	ctx := context.Background()
 

--- a/clientconfig/leafwrite_test.go
+++ b/clientconfig/leafwrite_test.go
@@ -65,9 +65,7 @@ func TestAtomicWriteFileNoTornRead(t *testing.T) {
 	stop := make(chan struct{})
 
 	// Reader goroutine.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -81,7 +79,7 @@ func TestAtomicWriteFileNoTornRead(t *testing.T) {
 			var cd ConfigData
 			require.NoError(t, yaml.Unmarshal(data, &cd), "reader observed a torn/partial write")
 		}
-	}()
+	})
 
 	// Writer: alternate payloads so length changes each time.
 	for i := range 300 {

--- a/clientconfig/token_refresh_concurrency_test.go
+++ b/clientconfig/token_refresh_concurrency_test.go
@@ -115,9 +115,7 @@ func TestTokenForIdentityConcurrentRefresh(t *testing.T) {
 	// In-process goroutines, each with its own freshly-loaded Config (mirrors
 	// separate `m` invocations that share the on-disk config).
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			cfg, err := LoadConfig()
 			if err != nil {
 				goroutineFailures.Add(1)
@@ -134,14 +132,12 @@ func TestTokenForIdentityConcurrentRefresh(t *testing.T) {
 				return
 			}
 			tokens <- tok
-		}()
+		})
 	}
 
 	// Subprocesses: prove the lock is cross-process, not just cross-goroutine.
 	for range subprocesses {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			cmd := exec.Command(os.Args[0], "-test.run=TestTokenForIdentityChildProcess")
 			cmd.Env = append(os.Environ(),
 				"MIREN_TEST_REFRESH_CHILD=1",
@@ -160,7 +156,7 @@ func TestTokenForIdentityConcurrentRefresh(t *testing.T) {
 					tokens <- after
 				}
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/components/activator/activator_test.go
+++ b/components/activator/activator_test.go
@@ -1736,8 +1736,7 @@ func TestConcurrentPoolIncrement(t *testing.T) {
 // This prevents stale pool references from causing "pool has reached maximum size" errors.
 // Run with: ./hack/dev-exec go test -v -run TestWatchPoolsCleansUpCacheOnDeletion ./components/activator
 func TestWatchPoolsCleansUpCacheOnDeletion(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Use in-memory server with realistic WatchIndex implementation
 	server, cleanup := testutils.NewInMemEntityServer(t)
@@ -2509,8 +2508,7 @@ func TestEvictStaleVersionBindingsOnDereference(t *testing.T) {
 // the Update op this exercises (the same reason TestConcurrentPoolIncrement uses
 // the etcd server for real OCC semantics).
 func TestWatchPoolsEvictsStaleBindingOnDereference(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	server, cleanup := testutils.NewEtcdEntityServer(t)
 	defer cleanup()
@@ -2734,8 +2732,7 @@ func TestActivatorRefreshesStaleMaxPoolSizeCache(t *testing.T) {
 // TestWatchPoolsUpdatesDesiredInstances verifies that the watchPools goroutine
 // updates the in-memory cache when a pool's DesiredInstances changes externally.
 func TestWatchPoolsUpdatesDesiredInstances(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	server, cleanup := testutils.NewInMemEntityServer(t)
 	defer cleanup()

--- a/components/coordinate/coordinator_test.go
+++ b/components/coordinate/coordinator_test.go
@@ -1,7 +1,6 @@
 package coordinate_test
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -44,8 +43,7 @@ func TestCoordinatorParse(t *testing.T) {
 	}
 
 	// Create contexts
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Start coordinator in background
 	coord := coordinate.NewCoordinator(log, coordCfg)

--- a/controllers/integration/redeploy_test.go
+++ b/controllers/integration/redeploy_test.go
@@ -53,15 +53,13 @@ func concurrentReconcileEntities(ctx context.Context, h *TestHarness, index enti
 
 	var wg sync.WaitGroup
 	for range workers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for event := range ch {
 				if err := rc.ProcessEventForTest(ctx, event); err != nil {
 					h.T.Errorf("concurrentReconcileEntities: ProcessEventForTest(%s) failed: %v", event.Id, err)
 				}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/metrics/runtime_memory_test.go
+++ b/metrics/runtime_memory_test.go
@@ -65,8 +65,7 @@ func TestRuntimeMemory_Collect(t *testing.T) {
 func TestRuntimeMemory_MonitorNilWriterIsNoop(t *testing.T) {
 	rm := NewRuntimeMemory(testLogger(), nil)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// With a nil Writer, Monitor must return immediately rather than block on
 	// its ticker, so this completes well within the timeout.

--- a/pkg/deploylifecycle/lock_test.go
+++ b/pkg/deploylifecycle/lock_test.go
@@ -359,9 +359,7 @@ func TestConcurrentAcquireYieldsExactlyOneWinner(t *testing.T) {
 	start := make(chan struct{})
 	for i := range contenders {
 		id := "dep-" + string(rune('a'+i))
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 
 			holder, err := locks.Acquire(ctx, "web", id)
@@ -372,7 +370,7 @@ func TestConcurrentAcquireYieldsExactlyOneWinner(t *testing.T) {
 			mu.Lock()
 			winners = append(winners, holder.DeploymentID)
 			mu.Unlock()
-		}()
+		})
 	}
 
 	close(start)

--- a/pkg/deploylifecycle/tracker_test.go
+++ b/pkg/deploylifecycle/tracker_test.go
@@ -417,22 +417,18 @@ func TestConcurrentUpdatesConverge(t *testing.T) {
 	start := make(chan struct{})
 
 	for _, phase := range []Phase{PhaseBuilding, PhasePushing, PhaseActivating} {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			// Either it applies or it conflicts with the cancel; both are fine,
 			// a lost update is not.
 			_ = tr.SetPhase(ctx, id, phase)
-		}()
+		})
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-start
 		_ = tr.Cancel(ctx, id, "raced")
-	}()
+	})
 
 	close(start)
 	wg.Wait()

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -470,9 +470,7 @@ func (s *Server) Watch(ctx context.Context) error {
 		return s.watchCtx.Err()
 	}
 
-	s.watchWg.Add(1)
-	go func() {
-		defer s.watchWg.Done()
+	s.watchWg.Go(func() {
 		for {
 			select {
 			case <-s.watchCtx.Done():
@@ -484,7 +482,7 @@ func (s *Server) Watch(ctx context.Context) error {
 				s.dispatchSandboxEvent(s.watchCtx, ev)
 			}
 		}
-	}()
+	})
 
 	return nil
 }

--- a/pkg/entity/indexwatch/watcher.go
+++ b/pkg/entity/indexwatch/watcher.go
@@ -209,12 +209,10 @@ func (w *Watcher) Start(ctx context.Context) error {
 		runCtx, cancel := context.WithCancel(ctx)
 		w.cancel = cancel
 
-		w.wg.Add(1)
-		go func() {
-			defer w.wg.Done()
+		w.wg.Go(func() {
 			defer w.closeUpdates()
 			w.run(runCtx)
-		}()
+		})
 	})
 
 	return nil

--- a/pkg/entity/indexwatch/watcher_test.go
+++ b/pkg/entity/indexwatch/watcher_test.go
@@ -145,8 +145,7 @@ func TestWatcher_InitialSyncSnapshot(t *testing.T) {
 	}
 
 	sc := newTestClient(store)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	w := indexwatch.New(sc, testIndex(), fastOpts())
 	r.NoError(w.Start(ctx))
@@ -175,8 +174,7 @@ func TestWatcher_LiveEvents(t *testing.T) {
 	chans := gatedWatch(store)
 	sc := newTestClient(store)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	w := indexwatch.New(sc, testIndex(), fastOpts())
 	r.NoError(w.Start(ctx))
@@ -221,8 +219,7 @@ func TestWatcher_ResumeFromCursorNoResnapshot(t *testing.T) {
 	chans := gatedWatch(store)
 	sc := newTestClient(store)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	w := indexwatch.New(sc, testIndex(), fastOpts())
 	r.NoError(w.Start(ctx))
@@ -265,8 +262,7 @@ func TestWatcher_CompactionResnapshot(t *testing.T) {
 	r.NoError(err)
 
 	sc := newTestClient(store)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	w := indexwatch.New(sc, testIndex(), fastOpts())
 	r.NoError(w.Start(ctx))
@@ -301,8 +297,7 @@ func TestWatcher_ProgressAdvancesCursor(t *testing.T) {
 	chans := gatedWatch(store)
 	sc := newTestClient(store)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	w := indexwatch.New(sc, testIndex(), fastOpts())
 	r.NoError(w.Start(ctx))
@@ -343,8 +338,7 @@ func TestWatcher_CreatedResponseDoesNotAdvanceCursor(t *testing.T) {
 	chans := gatedWatch(store)
 	sc := newTestClient(store)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	w := indexwatch.New(sc, testIndex(), fastOpts())
 	r.NoError(w.Start(ctx))
@@ -384,8 +378,7 @@ func TestWatcher_BlockingBackpressure(t *testing.T) {
 	chans := gatedWatch(store)
 	sc := newTestClient(store)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	opts := fastOpts()
 	opts.BufferSize = 1

--- a/pkg/grunge/grunge.go
+++ b/pkg/grunge/grunge.go
@@ -286,11 +286,9 @@ func (n *Network) Start(ctx context.Context, eg *errgroup.Group) error {
 		defer cancel()
 		// Start "Running" the backend network. This will block until the context is done so run in another goroutine.
 		n.log.Info("Running backend.")
-		wg.Add(1)
-		go func() {
+		wg.Go(func() {
 			bn.Run(ctx)
-			wg.Done()
-		}()
+		})
 
 		err = sm.CompleteLease(ctx, bn.Lease(), &wg)
 		if err != nil {

--- a/pkg/rpc/io/io_test.go
+++ b/pkg/rpc/io/io_test.go
@@ -1,7 +1,6 @@
 package io
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -12,8 +11,7 @@ import (
 func TestReader(t *testing.T) {
 	r := require.New(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	pr, pw := io.Pipe()
 
@@ -51,8 +49,7 @@ func TestReader(t *testing.T) {
 func TestWriter(t *testing.T) {
 	r := require.New(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	pr, pw := io.Pipe()
 

--- a/pkg/rpc/stream/stream_test.go
+++ b/pkg/rpc/stream/stream_test.go
@@ -19,8 +19,7 @@ func TestStream(t *testing.T) {
 	t.Run("can send a stream of values", func(t *testing.T) {
 		r := require.New(t)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify)
 		r.NoError(err)
@@ -64,8 +63,7 @@ func TestStream(t *testing.T) {
 	t.Run("can send a stream of structs", func(t *testing.T) {
 		r := require.New(t)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify)
 		r.NoError(err)
@@ -110,8 +108,7 @@ func TestStream(t *testing.T) {
 	t.Run("ChanWriter closes output channel when stream ends", func(t *testing.T) {
 		r := require.New(t)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Server side: expose a RecvStream backed by a channel
 		sourceCh := make(chan int)

--- a/servers/entityserver/entityserver_test.go
+++ b/servers/entityserver/entityserver_test.go
@@ -816,8 +816,7 @@ func TestEntityServer_WatchIndex_LegacyClientIgnoresProgress(t *testing.T) {
 
 	store, sc, watchCh := watchIndexServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	index := entity.Keyword(entity.Ident, "test/index")
 
@@ -856,8 +855,7 @@ func TestEntityServer_WatchIndex_ProgressForwardedWhenResuming(t *testing.T) {
 
 	_, sc, watchCh := watchIndexServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	index := entity.Keyword(entity.Ident, "test/index")
 
@@ -893,8 +891,7 @@ func TestEntityServer_WatchIndex_CreatedResponseNotProgress(t *testing.T) {
 
 	store, sc, watchCh := watchIndexServer(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	index := entity.Keyword(entity.Ident, "test/index")
 


### PR DESCRIPTION
Two small clusters of concurrency bookkeeping remained after the broader Go cleanup. Production and test code manually paired `WaitGroup.Add` with goroutines that immediately deferred `Done`, while tests created cancelable background contexts only to defer cancellation until exit.

The first revision moves those goroutines onto `WaitGroup.Go`, keeping registration and completion together. The second uses `testing.T.Context` so watcher, stream, and coordinator cancellation belongs to the test lifecycle. The closure bodies and test ownership boundaries stay the same.

All packages compile, both analyzers are clean, module tidiness passes, and the affected in-memory watcher, RPC, metrics, activator, lifecycle, DNS, and CLI tests pass. The coordinator integration test still requires its etcd-backed dev environment, so CI is authoritative for that path once the current Actions outage clears.

Stacked on #1039.