### PR TITLE
Remove ineffective JSON omitempty options

### DIFF
--- a/api/compute/compute_v1alpha/schema.gen.go
+++ b/api/compute/compute_v1alpha/schema.gen.go
@@ -771,7 +771,7 @@ const (
 
 type Lease struct {
 	ID            entity.Id `json:"id"`
-	LastHeartbeat time.Time `cbor:"last_heartbeat,omitempty" json:"last_heartbeat,omitempty"`
+	LastHeartbeat time.Time `cbor:"last_heartbeat,omitempty" json:"last_heartbeat"`
 	Project       entity.Id `cbor:"project,omitempty" json:"project,omitempty"`
 	Sandbox       entity.Id `cbor:"sandbox,omitempty" json:"sandbox,omitempty"`
 }
@@ -860,7 +860,7 @@ type Node struct {
 	ApiAddress   string         `cbor:"api_address,omitempty" json:"api_address,omitempty"`
 	Constraints  types.Labels   `cbor:"constraints,omitempty" json:"constraints,omitempty"`
 	Name         string         `cbor:"name,omitempty" json:"name,omitempty"`
-	RegisteredAt time.Time      `cbor:"registered_at,omitempty" json:"registered_at,omitempty"`
+	RegisteredAt time.Time      `cbor:"registered_at,omitempty" json:"registered_at"`
 	RunnerId     string         `cbor:"runner_id,omitempty" json:"runner_id,omitempty"`
 	Scheduling   NodeScheduling `cbor:"scheduling,omitempty" json:"scheduling,omitempty"`
 	Status       NodeStatus     `cbor:"status,omitempty" json:"status,omitempty"`
@@ -1036,12 +1036,12 @@ type Sandbox struct {
 	Container    []Container   `cbor:"container" json:"container"`
 	HostNetwork  bool          `cbor:"hostNetwork,omitempty" json:"hostNetwork,omitempty"`
 	Labels       []string      `cbor:"labels,omitempty" json:"labels,omitempty"`
-	LastActivity time.Time     `cbor:"last_activity,omitempty" json:"last_activity,omitempty"`
+	LastActivity time.Time     `cbor:"last_activity,omitempty" json:"last_activity"`
 	LogAttribute types.Labels  `cbor:"logAttribute,omitempty" json:"logAttribute,omitempty"`
 	LogEntity    string        `cbor:"logEntity,omitempty" json:"logEntity,omitempty"`
 	Network      []Network     `cbor:"network,omitempty" json:"network,omitempty"`
 	Route        []Route       `cbor:"route,omitempty" json:"route,omitempty"`
-	Spec         SandboxSpec   `cbor:"spec,omitempty" json:"spec,omitempty"`
+	Spec         SandboxSpec   `cbor:"spec,omitempty" json:"spec"`
 	StaticHost   []StaticHost  `cbor:"static_host,omitempty" json:"static_host,omitempty"`
 	Status       SandboxStatus `cbor:"status,omitempty" json:"status,omitempty"`
 	Volume       []Volume      `cbor:"volume,omitempty" json:"volume,omitempty"`
@@ -1892,16 +1892,16 @@ type SandboxPool struct {
 	ID                    entity.Id    `json:"id"`
 	App                   entity.Id    `cbor:"app,omitempty" json:"app,omitempty"`
 	ConsecutiveCrashCount int64        `cbor:"consecutive_crash_count,omitempty" json:"consecutive_crash_count,omitempty"`
-	CooldownUntil         time.Time    `cbor:"cooldown_until,omitempty" json:"cooldown_until,omitempty"`
+	CooldownUntil         time.Time    `cbor:"cooldown_until,omitempty" json:"cooldown_until"`
 	CurrentInstances      int64        `cbor:"current_instances,omitempty" json:"current_instances,omitempty"`
 	DesiredInstances      int64        `cbor:"desired_instances,omitempty" json:"desired_instances,omitempty"`
 	Ephemeral             bool         `cbor:"ephemeral,omitempty" json:"ephemeral,omitempty"`
-	LastCrashTime         time.Time    `cbor:"last_crash_time,omitempty" json:"last_crash_time,omitempty"`
+	LastCrashTime         time.Time    `cbor:"last_crash_time,omitempty" json:"last_crash_time"`
 	ReadyInstances        int64        `cbor:"ready_instances,omitempty" json:"ready_instances,omitempty"`
 	ReferencedByVersions  []entity.Id  `cbor:"referenced_by_versions,omitempty" json:"referenced_by_versions,omitempty"`
 	SandboxLabels         types.Labels `cbor:"sandbox_labels,omitempty" json:"sandbox_labels,omitempty"`
 	SandboxPrefix         string       `cbor:"sandbox_prefix,omitempty" json:"sandbox_prefix,omitempty"`
-	SandboxSpec           SandboxSpec  `cbor:"sandbox_spec,omitempty" json:"sandbox_spec,omitempty"`
+	SandboxSpec           SandboxSpec  `cbor:"sandbox_spec,omitempty" json:"sandbox_spec"`
 	Service               string       `cbor:"service,omitempty" json:"service,omitempty"`
 }
 
@@ -2075,7 +2075,7 @@ const (
 
 type Schedule struct {
 	ID  entity.Id `json:"id"`
-	Key Key       `cbor:"key,omitempty" json:"key,omitempty"`
+	Key Key       `cbor:"key,omitempty" json:"key"`
 }
 
 func (o *Schedule) Decode(e entity.AttrGetter) {

--- a/api/core/core_v1alpha/schema.gen.go
+++ b/api/core/core_v1alpha/schema.gen.go
@@ -102,7 +102,7 @@ const (
 
 type ConfigSpecServices struct {
 	Command     string                        `cbor:"command,omitempty" json:"command,omitempty"`
-	Concurrency ConfigSpecServicesConcurrency `cbor:"concurrency,omitempty" json:"concurrency,omitempty"`
+	Concurrency ConfigSpecServicesConcurrency `cbor:"concurrency,omitempty" json:"concurrency"`
 	Disks       []ConfigSpecServicesDisks     `cbor:"disks,omitempty" json:"disks,omitempty"`
 	Env         []ConfigSpecServicesEnv       `cbor:"env,omitempty" json:"env,omitempty"`
 	Image       string                        `cbor:"image,omitempty" json:"image,omitempty"`
@@ -861,9 +861,9 @@ type AppVersion struct {
 	AdminToken         string    `cbor:"admin_token,omitempty" json:"admin_token,omitempty"`
 	App                entity.Id `cbor:"app,omitempty" json:"app,omitempty"`
 	Artifact           entity.Id `cbor:"artifact,omitempty" json:"artifact,omitempty"`
-	Config             Config    `cbor:"config,omitempty" json:"config,omitempty"`
+	Config             Config    `cbor:"config,omitempty" json:"config"`
 	ConfigVersion      entity.Id `cbor:"config_version,omitempty" json:"config_version,omitempty"`
-	EphemeralExpiresAt time.Time `cbor:"ephemeral_expires_at,omitempty" json:"ephemeral_expires_at,omitempty"`
+	EphemeralExpiresAt time.Time `cbor:"ephemeral_expires_at,omitempty" json:"ephemeral_expires_at"`
 	EphemeralLabel     string    `cbor:"ephemeral_label,omitempty" json:"ephemeral_label,omitempty"`
 	EphemeralTtl       string    `cbor:"ephemeral_ttl,omitempty" json:"ephemeral_ttl,omitempty"`
 	ImageUrl           string    `cbor:"image_url,omitempty" json:"image_url,omitempty"`
@@ -1197,7 +1197,7 @@ type Services struct {
 	PortName           string             `cbor:"port_name,omitempty" json:"port_name,omitempty"`
 	PortType           string             `cbor:"port_type,omitempty" json:"port_type,omitempty"`
 	Ports              []Ports            `cbor:"ports,omitempty" json:"ports,omitempty"`
-	ServiceConcurrency ServiceConcurrency `cbor:"service_concurrency,omitempty" json:"service_concurrency,omitempty"`
+	ServiceConcurrency ServiceConcurrency `cbor:"service_concurrency,omitempty" json:"service_concurrency"`
 }
 
 func (o *Services) Decode(e entity.AttrGetter) {
@@ -1929,7 +1929,7 @@ const (
 type ConfigVersion struct {
 	ID   entity.Id  `json:"id"`
 	App  entity.Id  `cbor:"app,omitempty" json:"app,omitempty"`
-	Spec ConfigSpec `cbor:"spec,omitempty" json:"spec,omitempty"`
+	Spec ConfigSpec `cbor:"spec,omitempty" json:"spec"`
 }
 
 func (o *ConfigVersion) Decode(e entity.AttrGetter) {
@@ -2005,9 +2005,9 @@ type Deployment struct {
 	BuildLogs          string     `cbor:"build_logs,omitempty" json:"build_logs,omitempty"`
 	ClusterId          string     `cbor:"cluster_id,omitempty" json:"cluster_id,omitempty"`
 	CompletedAt        string     `cbor:"completed_at,omitempty" json:"completed_at,omitempty"`
-	DeployedBy         DeployedBy `cbor:"deployed_by,omitempty" json:"deployed_by,omitempty"`
+	DeployedBy         DeployedBy `cbor:"deployed_by,omitempty" json:"deployed_by"`
 	ErrorMessage       string     `cbor:"error_message,omitempty" json:"error_message,omitempty"`
-	GitInfo            GitInfo    `cbor:"git_info,omitempty" json:"git_info,omitempty"`
+	GitInfo            GitInfo    `cbor:"git_info,omitempty" json:"git_info"`
 	Phase              string     `cbor:"phase,omitempty" json:"phase,omitempty"`
 	SourceDeploymentId string     `cbor:"source_deployment_id,omitempty" json:"source_deployment_id,omitempty"`
 	Status             string     `cbor:"status,omitempty" json:"status,omitempty"`
@@ -2360,10 +2360,10 @@ const (
 
 type DeploymentLock struct {
 	ID           entity.Id `json:"id"`
-	AcquiredAt   time.Time `cbor:"acquired_at,omitempty" json:"acquired_at,omitempty"`
+	AcquiredAt   time.Time `cbor:"acquired_at,omitempty" json:"acquired_at"`
 	AppName      string    `cbor:"app_name,omitempty" json:"app_name,omitempty"`
 	DeploymentId string    `cbor:"deployment_id,omitempty" json:"deployment_id,omitempty"`
-	ExpiresAt    time.Time `cbor:"expires_at,omitempty" json:"expires_at,omitempty"`
+	ExpiresAt    time.Time `cbor:"expires_at,omitempty" json:"expires_at"`
 }
 
 func (o *DeploymentLock) Decode(e entity.AttrGetter) {

--- a/api/runner/runner_v1alpha/schema.gen.go
+++ b/api/runner/runner_v1alpha/schema.gen.go
@@ -27,12 +27,12 @@ const (
 
 type RunnerInvite struct {
 	ID              entity.Id          `json:"id"`
-	ClaimedAt       time.Time          `cbor:"claimed_at,omitempty" json:"claimed_at,omitempty"`
+	ClaimedAt       time.Time          `cbor:"claimed_at,omitempty" json:"claimed_at"`
 	ClaimedBy       string             `cbor:"claimed_by,omitempty" json:"claimed_by,omitempty"`
 	CodeHash        string             `cbor:"code_hash,omitempty" json:"code_hash,omitempty"`
-	CreatedAt       time.Time          `cbor:"created_at,omitempty" json:"created_at,omitempty"`
+	CreatedAt       time.Time          `cbor:"created_at,omitempty" json:"created_at"`
 	EnrollmentCount int64              `cbor:"enrollment_count,omitempty" json:"enrollment_count,omitempty"`
-	ExpiresAt       time.Time          `cbor:"expires_at,omitempty" json:"expires_at,omitempty"`
+	ExpiresAt       time.Time          `cbor:"expires_at,omitempty" json:"expires_at"`
 	Labels          types.Labels       `cbor:"labels,omitempty" json:"labels,omitempty"`
 	Name            string             `cbor:"name,omitempty" json:"name,omitempty"`
 	Reusable        bool               `cbor:"reusable,omitempty" json:"reusable,omitempty"`

--- a/api/saga/saga_v1alpha/schema.gen.go
+++ b/api/saga/saga_v1alpha/schema.gen.go
@@ -27,7 +27,7 @@ const (
 
 type Saga struct {
 	ID                entity.Id  `json:"id"`
-	CreatedAt         time.Time  `cbor:"created_at,omitempty" json:"created_at,omitempty"`
+	CreatedAt         time.Time  `cbor:"created_at,omitempty" json:"created_at"`
 	DefinitionName    string     `cbor:"definition_name,omitempty" json:"definition_name,omitempty"`
 	DefinitionVersion int64      `cbor:"definition_version,omitempty" json:"definition_version,omitempty"`
 	Error             string     `cbor:"error,omitempty" json:"error,omitempty"`
@@ -36,7 +36,7 @@ type Saga struct {
 	InitialInputs     []byte     `cbor:"initial_inputs,omitempty" json:"initial_inputs,omitempty"`
 	ParentExecutionId entity.Id  `cbor:"parent_execution_id,omitempty" json:"parent_execution_id,omitempty"`
 	Status            SagaStatus `cbor:"status,omitempty" json:"status,omitempty"`
-	UpdatedAt         time.Time  `cbor:"updated_at,omitempty" json:"updated_at,omitempty"`
+	UpdatedAt         time.Time  `cbor:"updated_at,omitempty" json:"updated_at"`
 }
 
 type SagaStatus string

--- a/api/storage/storage_v1alpha/schema.go
+++ b/api/storage/storage_v1alpha/schema.go
@@ -215,11 +215,11 @@ const (
 
 type DiskLease struct {
 	ID           entity.Id       `json:"id"`
-	AcquiredAt   time.Time       `cbor:"acquired_at,omitempty" json:"acquired_at,omitempty"`
+	AcquiredAt   time.Time       `cbor:"acquired_at,omitempty" json:"acquired_at"`
 	AppId        entity.Id       `cbor:"app_id,omitempty" json:"app_id,omitempty"`
 	DiskId       entity.Id       `cbor:"disk_id" json:"disk_id"`
 	ErrorMessage string          `cbor:"error_message,omitempty" json:"error_message,omitempty"`
-	Mount        Mount           `cbor:"mount,omitempty" json:"mount,omitempty"`
+	Mount        Mount           `cbor:"mount,omitempty" json:"mount"`
 	NodeId       entity.Id       `cbor:"node_id" json:"node_id"`
 	SandboxId    entity.Id       `cbor:"sandbox_id,omitempty" json:"sandbox_id,omitempty"`
 	Status       DiskLeaseStatus `cbor:"status,omitempty" json:"status,omitempty"`

--- a/pkg/cloudauth/status.go
+++ b/pkg/cloudauth/status.go
@@ -26,7 +26,7 @@ type StatusReport struct {
 	State             string            `json:"state"` // required: active, degraded, inactive, unknown
 	NodeCount         int               `json:"node_count,omitempty"`
 	WorkloadCount     int               `json:"workload_count,omitempty"`
-	ResourceUsage     ResourceUsage     `json:"resource_usage,omitempty"`
+	ResourceUsage     ResourceUsage     `json:"resource_usage"`
 	HealthChecks      map[string]string `json:"health_checks,omitempty"`
 	RBACRulesVersion  string            `json:"rbac_rules_version,omitempty"`
 	LastRBACSync      *time.Time        `json:"last_rbac_sync,omitempty"`

--- a/pkg/entity/cmd/schemagen/generator.go
+++ b/pkg/entity/cmd/schemagen/generator.go
@@ -315,8 +315,17 @@ func (g *gen) attr(name string, attr *schemaAttr) {
 		g.ensureAttrs = append(g.ensureAttrs, j.Id(g.local+fname+"Id"))
 	}
 
+	jsonTag := tn
+	if !attr.Required && !attr.Many &&
+		(attr.Type == "time" || attr.Type == "component" || attr.Type == "label" ||
+			(attr.Type != "" && g.sf.Components[attr.Type] != nil)) {
+		// encoding/json's omitempty option never omits value structs. Keep
+		// the generated tag honest without changing the existing output.
+		jsonTag = name
+	}
+
 	tag := map[string]string{
-		"json": tn,
+		"json": jsonTag,
 		"cbor": tn,
 	}
 

--- a/pkg/entity/cmd/schemagen/generator_test.go
+++ b/pkg/entity/cmd/schemagen/generator_test.go
@@ -196,6 +196,40 @@ func TestBoolFieldOptional(t *testing.T) {
 	}
 }
 
+func TestOptionalValueStructJSONTags(t *testing.T) {
+	sf := &schemaFile{
+		Domain:  "test",
+		Version: "v1",
+		Kinds: map[string]schemaAttrs{
+			"lease": {
+				"expires_at": {
+					Type: "time",
+				},
+				"mount": {
+					Type: "component",
+					Attrs: map[string]*schemaAttr{
+						"path": {Type: "string"},
+					},
+				},
+			},
+		},
+	}
+
+	code, err := GenerateSchema(sf, "test")
+	if err != nil {
+		t.Fatalf("Failed to generate schema: %v", err)
+	}
+
+	for _, tag := range []string{
+		`cbor:"expires_at,omitempty" json:"expires_at"`,
+		`cbor:"mount,omitempty" json:"mount"`,
+	} {
+		if !strings.Contains(code, tag) {
+			t.Errorf("Expected generated field tag %q", tag)
+		}
+	}
+}
+
 func TestEntityEmptyConsidersAllFields(t *testing.T) {
 	// Test that Entity.Empty() method considers bool fields along with other fields
 	sf := &schemaFile{

--- a/pkg/registration/registration.go
+++ b/pkg/registration/registration.go
@@ -92,7 +92,7 @@ type StoredRegistration struct {
 	Status         string    `json:"status,omitempty"` // "pending" or "approved"
 	RegistrationID string    `json:"registration_id,omitempty"`
 	PollURL        string    `json:"poll_url,omitempty"`
-	ExpiresAt      time.Time `json:"expires_at,omitempty"`
+	ExpiresAt      time.Time `json:"expires_at"`
 }
 
 // Client handles the cluster registration flow


### PR DESCRIPTION
The final Go fixer family came with a small trap: replacing these tags with `omitzero` would change the JSON wire output. Value structs were never considered empty by `omitempty`, so the behavior-preserving fix is to remove an option that never did anything.

This updates the affected hand-written types and teaches the entity schema generator to omit `omitempty` from JSON tags for value structs while leaving its CBOR tags alone. A generator regression test covers optional time and nested component fields, and the generated schemas are refreshed from that source change.

Zero-valued structs continue to be serialized exactly as before. The analyzer is clean, all packages compile, generation and module tidiness checks pass, and the affected generator, schema, cloud-auth, and registration tests pass.

Stacked on #1040.