### PR TITLE
run: deploy and schedule triggers, with retention (RFD-97, 3/3)

### DIFF
--- a/blackbox/tasks_test.go
+++ b/blackbox/tasks_test.go
@@ -303,3 +303,42 @@ func TestAttachedRunWaitsForTheCommand(t *testing.T) {
 		t.Fatalf("attached run missed output written before the command exited; got:\n%s", r.Stdout)
 	}
 }
+
+// A failing deploy task must fail the deploy. The gate sits before any rollout
+// begins, so the app should end up with no active version at all rather than a
+// half-promoted one.
+func TestDeployTaskGatesTheDeploy(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.UniqueAppName(t, "deploy-gate")
+	t.Cleanup(func() {
+		m.Run("app", "delete", name, "-f")
+	})
+
+	dir := m.ContainerPath(fmt.Sprintf("%s/task-deploy-gate", c.TestdataDir))
+	r := m.Run("deploy", "-a", name, "-d", dir, "-f")
+
+	if r.Success() {
+		t.Fatal("deploy succeeded despite its deploy task failing; the gate did not hold")
+	}
+	if !strings.Contains(r.Stdout+r.Stderr, "migrate") {
+		t.Fatalf("deploy failure should name the task that failed:\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+	}
+
+	// The run is recorded even though the deploy failed -- that is where its
+	// logs live and how you find out why.
+	runs := listRuns(t, m, name)
+	var found bool
+	for _, run := range runs {
+		if run.Task == "migrate" && run.Trigger == "deploy" {
+			found = true
+			if run.Status != "failed" {
+				t.Errorf("deploy-triggered run status %q, want failed", run.Status)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected a deploy-triggered run for migrate, got %+v", runs)
+	}
+}

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -382,6 +382,7 @@ type Coordinator struct {
 	certProvider  autotls.CertificateProvider
 	autocertReady func() // nil when DNS-01 path is used
 	artifactGC    *artifactctrl.GCController
+	runScheduler  *runctrl.Scheduler
 	ephemeralGC   *ephemeralctrl.GCController
 	versionGC     *versionctrl.GCController
 	indexGC       *indexgcctrl.GCController
@@ -460,6 +461,9 @@ func (c *Coordinator) Stop() {
 	}
 	if c.ephemeralGC != nil {
 		c.ephemeralGC.Stop()
+	}
+	if c.runScheduler != nil {
+		c.runScheduler.Stop()
 	}
 	if c.versionGC != nil {
 		c.versionGC.Stop()
@@ -1356,6 +1360,12 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	runController.RC = runReconciler
 	runReconciler.SetPeriodic(runctrl.SweepInterval, runController.SweepDeadlines)
 	c.cm.AddController(runReconciler)
+
+	// Scheduled tasks. Deliberately not a reconcile controller: ticks are
+	// derived from config on a timer, not from an entity changing, and dedup is
+	// the create-if-absent on the tick-derived name rather than any lock.
+	c.runScheduler = runctrl.NewScheduler(c.Log, ec, eac)
+	c.runScheduler.Start(ctx)
 
 	// A sandbox reaching STOPPED produces no event on the run index, so without
 	// this bridge a finished run would wait for the sweep to notice it.

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1365,17 +1365,6 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	runReconciler.SetPeriodic(runctrl.SweepInterval, runController.SweepDeadlines)
 	c.cm.AddController(runReconciler)
 
-	// Scheduled tasks. Deliberately not a reconcile controller: ticks are
-	// derived from config on a timer, not from an entity changing, and dedup is
-	// the create-if-absent on the tick-derived name rather than any lock.
-	c.runScheduler = runctrl.NewScheduler(c.Log, ec, eac)
-	c.runScheduler.Start(ctx)
-
-	// Run retention. Not a reconcile controller: it deletes rather than
-	// transitions, on a cadence of minutes.
-	c.runGC = runctrl.NewGCController(c.Log, ec, eac)
-	c.runGC.Start(ctx)
-
 	// A sandbox reaching STOPPED produces no event on the run index, so without
 	// this bridge a finished run would wait for the sweep to notice it.
 	runSandboxWatch := runctrl.NewSandboxWatchController(c.Log, eac, runReconciler)
@@ -1418,6 +1407,21 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		c.Log.Error("failed to start controller manager", "error", err)
 		return err
 	}
+
+	// Scheduled tasks. Deliberately not a reconcile controller: ticks come from
+	// config on a timer, not from an entity changing, and dedup is the
+	// create-if-absent on the tick-derived name rather than any lock.
+	//
+	// Started here with the other background controllers rather than at
+	// construction, so it does not begin firing runs before the reconcile
+	// manager -- including the run controller that would execute them -- is up.
+	c.runScheduler = runctrl.NewScheduler(c.Log, ec, eac)
+	c.runScheduler.Start(ctx)
+
+	// Run retention. Not a reconcile controller either: it deletes rather than
+	// transitions, on a cadence of minutes.
+	c.runGC = runctrl.NewGCController(c.Log, ec, eac)
+	c.runGC.Start(ctx)
 
 	// Start the artifact GC controller
 	c.artifactGC = &artifactctrl.GCController{

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -383,6 +383,7 @@ type Coordinator struct {
 	autocertReady func() // nil when DNS-01 path is used
 	artifactGC    *artifactctrl.GCController
 	runScheduler  *runctrl.Scheduler
+	runGC         *runctrl.GCController
 	ephemeralGC   *ephemeralctrl.GCController
 	versionGC     *versionctrl.GCController
 	indexGC       *indexgcctrl.GCController
@@ -464,6 +465,9 @@ func (c *Coordinator) Stop() {
 	}
 	if c.runScheduler != nil {
 		c.runScheduler.Stop()
+	}
+	if c.runGC != nil {
+		c.runGC.Stop()
 	}
 	if c.versionGC != nil {
 		c.versionGC.Stop()
@@ -1366,6 +1370,11 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	// the create-if-absent on the tick-derived name rather than any lock.
 	c.runScheduler = runctrl.NewScheduler(c.Log, ec, eac)
 	c.runScheduler.Start(ctx)
+
+	// Run retention. Not a reconcile controller: it deletes rather than
+	// transitions, on a cadence of minutes.
+	c.runGC = runctrl.NewGCController(c.Log, ec, eac)
+	c.runGC.Start(ctx)
 
 	// A sandbox reaching STOPPED produces no event on the run index, so without
 	// this bridge a finished run would wait for the sweep to notice it.

--- a/controllers/run/gc.go
+++ b/controllers/run/gc.go
@@ -1,0 +1,366 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"slices"
+	"time"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// GCConfig bounds how long runs are kept.
+type GCConfig struct {
+	// CheckInterval is how often a sweep happens.
+	CheckInterval time.Duration
+
+	// RetentionCount is how many terminal runs to keep per app regardless of
+	// age. It is per app rather than per task on purpose: an app with two
+	// hundred tasks would otherwise accumulate two hundred times this many.
+	RetentionCount int
+
+	// RetentionPeriod keeps runs newer than this regardless of count.
+	RetentionPeriod time.Duration
+
+	// ConsoleRetention is the shorter window for console runs. Their value is
+	// an audit record and a recent scrollback, not a permanent log, and on an
+	// app people debug regularly they would otherwise crowd out everything
+	// worth reading.
+	ConsoleRetention time.Duration
+
+	// ScheduledFloor is the age below which a schedule-triggered run is never
+	// deleted.
+	//
+	// This is a correctness constraint, not a tuning knob. The dedup guard for
+	// a scheduled tick *is* the run entity's existence, so removing one while
+	// any replica could still evaluate that tick -- one that was partitioned,
+	// or restarted behind the others -- lets create-if-absent succeed a second
+	// time and the job double-fires. The floor has to sit well beyond any
+	// plausible partition, and scheduled runs are exempt from the count cap
+	// entirely: a count applied naively to a busy app would evict same-day
+	// ticks and silently reintroduce double-firing.
+	ScheduledFloor time.Duration
+
+	// OrphanSandbox is how long a terminal run's sandbox may linger before it
+	// is torn down.
+	OrphanSandbox time.Duration
+}
+
+func DefaultGCConfig() GCConfig {
+	return GCConfig{
+		CheckInterval:    15 * time.Minute,
+		RetentionCount:   50,
+		RetentionPeriod:  7 * 24 * time.Hour,
+		ConsoleRetention: 24 * time.Hour,
+		ScheduledFloor:   30 * 24 * time.Hour,
+		OrphanSandbox:    5 * time.Minute,
+	}
+}
+
+// GCResult reports what one sweep did.
+type GCResult struct {
+	DeletedRuns    int
+	FailedRuns     int
+	RetainedRuns   int
+	StoppedSandbox int
+	ReapedOrphans  int
+	TotalScanned   int
+}
+
+func (r GCResult) didSomething() bool {
+	return r.DeletedRuns > 0 || r.FailedRuns > 0 || r.StoppedSandbox > 0 || r.ReapedOrphans > 0
+}
+
+// GCController retires finished runs and the sandboxes they leave behind.
+type GCController struct {
+	Log    *slog.Logger
+	EC     *entityserver.Client
+	EAC    *entityserver_v1alpha.EntityAccessClient
+	Config GCConfig
+
+	cancel context.CancelFunc
+}
+
+func NewGCController(log *slog.Logger, ec *entityserver.Client, eac *entityserver_v1alpha.EntityAccessClient) *GCController {
+	return &GCController{
+		Log:    log.With("module", "run-gc"),
+		EC:     ec,
+		EAC:    eac,
+		Config: DefaultGCConfig(),
+	}
+}
+
+func (c *GCController) Start(ctx context.Context) {
+	c.Log.Info("starting run GC controller",
+		"check_interval", c.Config.CheckInterval,
+		"retention_count", c.Config.RetentionCount,
+		"scheduled_floor", c.Config.ScheduledFloor)
+
+	ctx, c.cancel = context.WithCancel(ctx)
+	go c.run(ctx)
+}
+
+func (c *GCController) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+func (c *GCController) run(ctx context.Context) {
+	ticker := time.NewTicker(c.Config.CheckInterval)
+	defer ticker.Stop()
+
+	// Let the cluster settle before the first sweep.
+	select {
+	case <-time.After(30 * time.Second):
+		c.sweepAndLog(ctx)
+	case <-ctx.Done():
+		c.Log.Info("run GC controller stopped")
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.Log.Info("run GC controller stopped")
+			return
+		case <-ticker.C:
+			c.sweepAndLog(ctx)
+		}
+	}
+}
+
+func (c *GCController) sweepAndLog(ctx context.Context) {
+	sweepCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	result, err := c.RunGC(sweepCtx, time.Now())
+	if err != nil {
+		c.Log.Error("run GC sweep failed", "error", err)
+		return
+	}
+
+	// Info only when something happened; a healthy quiet sweep is Debug.
+	if result.didSomething() {
+		c.Log.Info("run GC sweep complete",
+			"deleted", result.DeletedRuns,
+			"failed", result.FailedRuns,
+			"retained", result.RetainedRuns,
+			"sandboxes_stopped", result.StoppedSandbox,
+			"orphans_reaped", result.ReapedOrphans)
+		return
+	}
+
+	c.Log.Debug("run GC sweep complete, nothing to do", "scanned", result.TotalScanned)
+}
+
+// RunGC performs one sweep. now is a parameter so tests can drive it.
+func (c *GCController) RunGC(ctx context.Context, now time.Time) (GCResult, error) {
+	var result GCResult
+
+	apps, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindApp))
+	if err != nil {
+		return result, err
+	}
+
+	for _, e := range apps.Values() {
+		appID := entity.Id(e.Id())
+		if err := c.sweepApp(ctx, appID, now, &result); err != nil {
+			c.Log.Warn("failed to sweep app runs", "app", appID, "error", err)
+		}
+	}
+
+	if err := c.reapOrphanSandboxes(ctx, &result); err != nil {
+		c.Log.Warn("failed to reap orphaned run sandboxes", "error", err)
+	}
+
+	return result, nil
+}
+
+func (c *GCController) sweepApp(ctx context.Context, appID entity.Id, now time.Time, result *GCResult) error {
+	results, err := c.EAC.List(ctx, entity.Ref(run_v1alpha.RunAppId, appID))
+	if err != nil {
+		return err
+	}
+
+	type candidate struct {
+		run     run_v1alpha.Run
+		endedAt time.Time
+	}
+
+	var capped []candidate
+	for _, e := range results.Values() {
+		var r run_v1alpha.Run
+		r.Decode(e.Entity())
+		r.ID = entity.Id(e.Id())
+
+		result.TotalScanned++
+
+		// Never touch a run that hasn't finished.
+		if !isTerminal(r.Status) {
+			result.RetainedRuns++
+			continue
+		}
+
+		if err := c.stopFinishedSandbox(ctx, &r, now, result); err != nil {
+			c.Log.Debug("failed to stop sandbox for terminal run", "run", r.ID, "error", err)
+		}
+
+		endedAt := r.EndedAt
+		if endedAt.IsZero() {
+			endedAt = r.StartedAt
+		}
+		age := now.Sub(endedAt)
+
+		switch {
+		case r.Trigger == run_v1alpha.SCHEDULE:
+			// Exempt from the count cap; only age retires a tick, and only well
+			// past any plausible partition. See ScheduledFloor.
+			if endedAt.IsZero() || age < c.Config.ScheduledFloor {
+				result.RetainedRuns++
+				continue
+			}
+			c.deleteRun(ctx, r.ID, result)
+
+		case r.Task == consoleTaskName:
+			if endedAt.IsZero() || age < c.Config.ConsoleRetention {
+				result.RetainedRuns++
+				continue
+			}
+			c.deleteRun(ctx, r.ID, result)
+
+		default:
+			capped = append(capped, candidate{run: r, endedAt: endedAt})
+		}
+	}
+
+	// Newest first, keep RetentionCount, then retire what is also past the age
+	// floor. Both have to be satisfied: the count alone would evict a burst of
+	// recent runs, and the age alone would let a busy app grow without bound.
+	slices.SortFunc(capped, func(a, b candidate) int {
+		return b.endedAt.Compare(a.endedAt)
+	})
+
+	for i, cand := range capped {
+		if i < c.Config.RetentionCount {
+			result.RetainedRuns++
+			continue
+		}
+		if cand.endedAt.IsZero() || now.Sub(cand.endedAt) < c.Config.RetentionPeriod {
+			result.RetainedRuns++
+			continue
+		}
+		c.deleteRun(ctx, cand.run.ID, result)
+	}
+
+	return nil
+}
+
+// consoleTaskName mirrors the server's console convention. Duplicated rather
+// than imported to keep the controller from depending on the app server.
+const consoleTaskName = "console"
+
+func (c *GCController) deleteRun(ctx context.Context, id entity.Id, result *GCResult) {
+	if _, err := c.EAC.Delete(ctx, id.String()); err != nil {
+		if !errors.Is(err, cond.ErrNotFound{}) {
+			c.Log.Warn("failed to delete run", "run", id, "error", err)
+			result.FailedRuns++
+			return
+		}
+	}
+	result.DeletedRuns++
+}
+
+// stopFinishedSandbox tears down a sandbox left running by a finished run.
+//
+// The run controller does this on the transition; this is the backstop for when
+// that write was lost, which the framework makes possible by dropping handler
+// errors without requeueing.
+func (c *GCController) stopFinishedSandbox(ctx context.Context, r *run_v1alpha.Run, now time.Time, result *GCResult) error {
+	if r.Sandbox == "" {
+		return nil
+	}
+	if !r.EndedAt.IsZero() && now.Sub(r.EndedAt) < c.Config.OrphanSandbox {
+		return nil
+	}
+
+	resp, err := c.EAC.Get(ctx, r.Sandbox.String())
+	if err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			return nil
+		}
+		return err
+	}
+
+	var sb compute.Sandbox
+	sb.Decode(resp.Entity().Entity())
+	if sb.Status == compute.STOPPED || sb.Status == compute.DEAD {
+		return nil
+	}
+
+	c.Log.Info("stopping sandbox left behind by a finished run", "run", r.ID, "sandbox", r.Sandbox)
+	_, err = c.EAC.Patch(ctx, entity.New(
+		entity.Ref(entity.DBId, r.Sandbox),
+		(&compute.Sandbox{Status: compute.STOPPED}).Encode,
+	).Attrs(), 0)
+	if err != nil {
+		return err
+	}
+
+	result.StoppedSandbox++
+	return nil
+}
+
+// reapOrphanSandboxes stops any run sandbox whose run no longer exists.
+//
+// This is what makes the old exec-sandbox leak un-leakable rather than merely
+// less likely. Previously teardown was a deferred call in a request handler, so
+// a crash stranded a running sandbox with nothing that would ever collect it.
+// Now the run owns the lifecycle -- and this catches the case where the run
+// itself is gone, whether garbage collected or deleted with its app.
+func (c *GCController) reapOrphanSandboxes(ctx context.Context, result *GCResult) error {
+	sandboxes, err := c.EAC.List(ctx, entity.Ref(entity.EntityKind, compute.KindSandbox))
+	if err != nil {
+		return err
+	}
+
+	for _, e := range sandboxes.Values() {
+		var sb compute.Sandbox
+		sb.Decode(e.Entity())
+		sb.ID = entity.Id(e.Id())
+
+		runID := runIDFor(&sb)
+		if runID == "" {
+			continue
+		}
+		if sb.Status == compute.DEAD || sb.Status == compute.STOPPED {
+			continue
+		}
+
+		if _, err := c.EAC.Get(ctx, runID.String()); err == nil {
+			continue
+		} else if !errors.Is(err, cond.ErrNotFound{}) {
+			continue
+		}
+
+		c.Log.Info("reaping sandbox whose run no longer exists", "sandbox", sb.ID, "run", runID)
+		if _, err := c.EAC.Patch(ctx, entity.New(
+			entity.Ref(entity.DBId, sb.ID),
+			(&compute.Sandbox{Status: compute.STOPPED}).Encode,
+		).Attrs(), 0); err != nil {
+			c.Log.Warn("failed to reap orphaned sandbox", "sandbox", sb.ID, "error", err)
+			continue
+		}
+
+		result.ReapedOrphans++
+	}
+
+	return nil
+}

--- a/controllers/run/gc.go
+++ b/controllers/run/gc.go
@@ -287,7 +287,17 @@ func (c *GCController) stopFinishedSandbox(ctx context.Context, r *run_v1alpha.R
 	if r.Sandbox == "" {
 		return nil
 	}
-	if !r.EndedAt.IsZero() && now.Sub(r.EndedAt) < c.Config.OrphanSandbox {
+	// Only look at runs that finished recently enough for a lingering sandbox
+	// to be plausible. Without an upper bound this re-reads the sandbox of
+	// every retained run on every sweep, which for an app at the retention cap
+	// is a fixed cost per sweep that buys nothing: the run controller tears
+	// down on the transition, and anything it missed is caught within one
+	// window rather than needing to be rechecked forever.
+	if r.EndedAt.IsZero() {
+		return nil
+	}
+	age := now.Sub(r.EndedAt)
+	if age < c.Config.OrphanSandbox || age > c.Config.OrphanSandbox+c.Config.CheckInterval*4 {
 		return nil
 	}
 

--- a/controllers/run/gc_test.go
+++ b/controllers/run/gc_test.go
@@ -1,0 +1,234 @@
+package run
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	compute "miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/entity/types"
+)
+
+type gcHarness struct {
+	t   *testing.T
+	gc  *GCController
+	inm *testutils.InMemEntityServer
+	app entity.Id
+}
+
+func newGCHarness(t *testing.T) *gcHarness {
+	t.Helper()
+
+	inm, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	appID := entity.Id("app/demo")
+	_, err := inm.EAC.Put(context.Background(), wrap(entity.New(
+		(&core_v1alpha.Metadata{Name: "demo"}).Encode,
+		entity.DBId, appID,
+		(&core_v1alpha.App{}).Encode,
+	), appID))
+	require.NoError(t, err)
+
+	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &gcHarness{t: t, gc: NewGCController(log, inm.Client, inm.EAC), inm: inm, app: appID}
+}
+
+func (h *gcHarness) put(id string, r *run_v1alpha.Run) entity.Id {
+	h.t.Helper()
+
+	r.App = h.app
+	eid := entity.Id(id)
+	_, err := h.inm.EAC.Put(context.Background(), wrap(entity.New(entity.DBId, eid, r.Encode), eid))
+	require.NoError(h.t, err)
+	return eid
+}
+
+func (h *gcHarness) exists(id entity.Id) bool {
+	h.t.Helper()
+	_, err := h.inm.EAC.Get(context.Background(), id.String())
+	return err == nil
+}
+
+// A run still going is never touched, whatever the retention says.
+func TestGCNeverDeletesANonTerminalRun(t *testing.T) {
+	ctx := context.Background()
+	h := newGCHarness(t)
+
+	long := h.put("run/still-going", &run_v1alpha.Run{
+		Task: "reindex", Trigger: run_v1alpha.MANUAL,
+		Status: run_v1alpha.RUNNING, StartedAt: time.Now().Add(-365 * 24 * time.Hour),
+	})
+
+	_, err := h.gc.RunGC(ctx, time.Now())
+	require.NoError(t, err)
+	assert.True(t, h.exists(long))
+}
+
+// The dedup guard for a scheduled tick is the run entity's existence, so a
+// scheduled run must survive the count cap entirely -- otherwise a busy app
+// evicts same-day ticks and the job silently double-fires.
+func TestGCExemptsScheduledRunsFromTheCountCap(t *testing.T) {
+	ctx := context.Background()
+	h := newGCHarness(t)
+	h.gc.Config.RetentionCount = 2
+	h.gc.Config.RetentionPeriod = 0
+
+	now := time.Now()
+	var ids []entity.Id
+	for i := range 10 {
+		ids = append(ids, h.put("run/tick-"+string(rune('a'+i)), &run_v1alpha.Run{
+			Task: "cleanup", Trigger: run_v1alpha.SCHEDULE, Status: run_v1alpha.SUCCEEDED,
+			EndedAt: now.Add(-time.Duration(i) * time.Hour),
+			Tick:    now.Add(-time.Duration(i) * time.Hour).Format(time.RFC3339),
+		}))
+	}
+
+	_, err := h.gc.RunGC(ctx, now)
+	require.NoError(t, err)
+
+	for _, id := range ids {
+		assert.True(t, h.exists(id), "%s: a scheduled run inside the floor must survive the count cap", id)
+	}
+}
+
+// Past the floor they do go, or scheduled runs would accumulate forever.
+func TestGCRetiresScheduledRunsPastTheFloor(t *testing.T) {
+	ctx := context.Background()
+	h := newGCHarness(t)
+	h.gc.Config.ScheduledFloor = 24 * time.Hour
+
+	now := time.Now()
+	recent := h.put("run/tick-recent", &run_v1alpha.Run{
+		Task: "cleanup", Trigger: run_v1alpha.SCHEDULE, Status: run_v1alpha.SUCCEEDED,
+		EndedAt: now.Add(-1 * time.Hour),
+	})
+	ancient := h.put("run/tick-ancient", &run_v1alpha.Run{
+		Task: "cleanup", Trigger: run_v1alpha.SCHEDULE, Status: run_v1alpha.SUCCEEDED,
+		EndedAt: now.Add(-72 * time.Hour),
+	})
+
+	_, err := h.gc.RunGC(ctx, now)
+	require.NoError(t, err)
+
+	assert.True(t, h.exists(recent), "inside the floor")
+	assert.False(t, h.exists(ancient), "past the floor")
+}
+
+// Console runs are an audit record and a scrollback, not a permanent log, so
+// they get a shorter window than everything else.
+func TestGCRetiresConsoleRunsSooner(t *testing.T) {
+	ctx := context.Background()
+	h := newGCHarness(t)
+	h.gc.Config.ConsoleRetention = time.Hour
+	h.gc.Config.RetentionPeriod = 30 * 24 * time.Hour
+
+	now := time.Now()
+	console := h.put("run/console-old", &run_v1alpha.Run{
+		Task: "console", Trigger: run_v1alpha.MANUAL, Status: run_v1alpha.SUCCEEDED,
+		EndedAt: now.Add(-2 * time.Hour),
+	})
+	other := h.put("run/reindex-old", &run_v1alpha.Run{
+		Task: "reindex", Trigger: run_v1alpha.MANUAL, Status: run_v1alpha.SUCCEEDED,
+		EndedAt: now.Add(-2 * time.Hour),
+	})
+
+	_, err := h.gc.RunGC(ctx, now)
+	require.NoError(t, err)
+
+	assert.False(t, h.exists(console), "console runs age out quickly")
+	assert.True(t, h.exists(other), "an ordinary run of the same age is kept")
+}
+
+// Count and age both have to be satisfied: the count alone would evict a burst
+// of recent runs, the age alone would let a busy app grow without bound.
+func TestGCAppliesCountAndAgeTogether(t *testing.T) {
+	ctx := context.Background()
+	h := newGCHarness(t)
+	h.gc.Config.RetentionCount = 2
+	h.gc.Config.RetentionPeriod = time.Hour
+
+	now := time.Now()
+	// Three recent runs: over the count, but inside the age floor.
+	var recent []entity.Id
+	for i := range 3 {
+		recent = append(recent, h.put("run/recent-"+string(rune('a'+i)), &run_v1alpha.Run{
+			Task: "reindex", Trigger: run_v1alpha.MANUAL, Status: run_v1alpha.SUCCEEDED,
+			EndedAt: now.Add(-time.Duration(i) * time.Minute),
+		}))
+	}
+	old := h.put("run/old", &run_v1alpha.Run{
+		Task: "reindex", Trigger: run_v1alpha.MANUAL, Status: run_v1alpha.SUCCEEDED,
+		EndedAt: now.Add(-48 * time.Hour),
+	})
+
+	_, err := h.gc.RunGC(ctx, now)
+	require.NoError(t, err)
+
+	for _, id := range recent {
+		assert.True(t, h.exists(id), "%s is over the count but inside the age floor", id)
+	}
+	assert.False(t, h.exists(old), "over the count and past the age floor")
+}
+
+// A sandbox whose run is gone has nothing that will ever collect it. Catching
+// that is what makes the old exec-sandbox leak un-leakable rather than merely
+// less likely.
+func TestGCReapsSandboxesWhoseRunIsGone(t *testing.T) {
+	ctx := context.Background()
+	h := newGCHarness(t)
+
+	sbID := entity.Id("sandbox/run-orphan-a1")
+	var sb compute.Sandbox
+	sb.Status = compute.RUNNING
+	sb.Spec.LogAttribute = labelSet("miren.stage", "run", "miren.run", "run/vanished")
+
+	_, err := h.inm.EAC.Put(ctx, wrap(entity.New(entity.DBId, sbID, sb.Encode), sbID))
+	require.NoError(t, err)
+
+	result, err := h.gc.RunGC(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ReapedOrphans)
+
+	resp, err := h.inm.EAC.Get(ctx, sbID.String())
+	require.NoError(t, err)
+	var got compute.Sandbox
+	got.Decode(resp.Entity().Entity())
+	assert.Equal(t, compute.STOPPED, got.Status)
+}
+
+// A sandbox that isn't a run's is none of this controller's business.
+func TestGCLeavesNonRunSandboxesAlone(t *testing.T) {
+	ctx := context.Background()
+	h := newGCHarness(t)
+
+	sbID := entity.Id("sandbox/service-web")
+	var sb compute.Sandbox
+	sb.Status = compute.RUNNING
+	sb.Spec.LogAttribute = labelSet("miren.stage", "app-run", "miren.service", "web")
+
+	_, err := h.inm.EAC.Put(ctx, wrap(entity.New(entity.DBId, sbID, sb.Encode), sbID))
+	require.NoError(t, err)
+
+	result, err := h.gc.RunGC(ctx, time.Now())
+	require.NoError(t, err)
+	assert.Zero(t, result.ReapedOrphans)
+
+	resp, err := h.inm.EAC.Get(ctx, sbID.String())
+	require.NoError(t, err)
+	var got compute.Sandbox
+	got.Decode(resp.Entity().Entity())
+	assert.Equal(t, compute.RUNNING, got.Status)
+}
+
+// labelSet is a thin alias so the tests read the way the spec does.
+func labelSet(kv ...string) types.Labels { return types.LabelSet(kv...) }

--- a/controllers/run/scheduler.go
+++ b/controllers/run/scheduler.go
@@ -259,6 +259,16 @@ func (s *Scheduler) fireTick(
 		Tick:        tick.UTC().Format(time.RFC3339),
 	}
 
+	// A skipped tick is born terminal, so it never passes through the
+	// controller that would otherwise stamp its timestamps. Retention is
+	// measured from EndedAt, and a scheduled run with none is retained
+	// unconditionally -- so without this, skipped ticks accumulate forever on
+	// exactly the busy task that produces the most of them.
+	if status == run_v1alpha.SKIPPED {
+		run.StartedAt = tick
+		run.EndedAt = tick
+	}
+
 	// Create is put-if-absent on a name derived from the tick, which is the
 	// entire single-execution guarantee: every replica derives the same name,
 	// etcd admits one, and the rest learn the tick is taken.

--- a/controllers/run/scheduler.go
+++ b/controllers/run/scheduler.go
@@ -160,8 +160,10 @@ func (s *Scheduler) sweepTask(
 	expr, err := oncalendar.Parse(task.Schedule)
 	if err != nil {
 		// Config validation rejects unparseable schedules, so reaching here
-		// means a version predating that check. Skip rather than retrying every
-		// interval forever.
+		// means a version that predates that check. The error is returned and
+		// logged by the caller on every sweep, which is noisy but honest: a
+		// task the platform cannot schedule should keep saying so rather than
+		// going quiet and looking healthy.
 		return fmt.Errorf("parsing schedule %q: %w", task.Schedule, err)
 	}
 
@@ -200,16 +202,17 @@ func (s *Scheduler) sweepTask(
 		}
 	}
 
-	if len(fired) > 0 {
-		s.mu.Lock()
-		s.frontier[key] = fired[len(fired)-1]
-		s.mu.Unlock()
-	}
-
+	// Advance the frontier only past ticks that were actually handled. Moving
+	// it first would drop any tick whose fire failed -- permanently, since the
+	// frontier is what decides a tick is behind us.
 	for _, tick := range fired {
 		if err := s.fireTick(ctx, app, ver, appName, task, tick); err != nil {
 			return err
 		}
+
+		s.mu.Lock()
+		s.frontier[key] = tick
+		s.mu.Unlock()
 	}
 
 	return nil

--- a/controllers/run/scheduler.go
+++ b/controllers/run/scheduler.go
@@ -1,0 +1,312 @@
+package run
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	coreutil "miren.dev/runtime/api/core"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/oncalendar"
+)
+
+// SchedulerInterval is how often the scheduler looks for ticks that have come
+// due. It bounds how late a run can start, not how precisely ticks are
+// computed: tick times come from the calendar expression, so a slow poll delays
+// a run without shifting the schedule.
+const SchedulerInterval = 15 * time.Second
+
+// Scheduler creates runs for tasks whose calendar expression has come due.
+//
+// It holds no leader election and no external coordination. A tick is a pure
+// function of the stored calendar expression, so every replica derives exactly
+// the same firing times; the run's entity id is derived from the tick, which
+// makes creating it a put-if-absent that etcd resolves to a single winner. The
+// losers see the run already exists and move on.
+//
+// The consequence worth stating: the dedup guard is the run entity's existence.
+// Deleting a tick's run resurrects that tick, which is why retention treats
+// scheduled runs as a correctness constraint rather than a preference.
+type Scheduler struct {
+	Log *slog.Logger
+	EC  *entityserver.Client
+	EAC *entityserver_v1alpha.EntityAccessClient
+
+	Interval time.Duration
+
+	cancel func()
+
+	// mu guards frontier, which records the newest tick already considered for
+	// each (app, task). It is in-memory on purpose: on startup the frontier
+	// begins at now, which is what makes missed ticks skipped rather than
+	// backfilled.
+	mu       sync.Mutex
+	frontier map[string]time.Time
+}
+
+func NewScheduler(log *slog.Logger, ec *entityserver.Client, eac *entityserver_v1alpha.EntityAccessClient) *Scheduler {
+	return &Scheduler{
+		Log:      log.With("module", "run-scheduler"),
+		EC:       ec,
+		EAC:      eac,
+		Interval: SchedulerInterval,
+		frontier: make(map[string]time.Time),
+	}
+}
+
+func (s *Scheduler) Start(ctx context.Context) {
+	s.Log.Info("starting run scheduler", "interval", s.Interval)
+
+	ctx, s.cancel = context.WithCancel(ctx)
+	go s.run(ctx)
+}
+
+func (s *Scheduler) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+func (s *Scheduler) run(ctx context.Context) {
+	ticker := time.NewTicker(s.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.Log.Info("run scheduler stopped")
+			return
+		case <-ticker.C:
+			if err := s.Sweep(ctx, time.Now()); err != nil {
+				s.Log.Warn("scheduler sweep failed", "error", err)
+			}
+		}
+	}
+}
+
+// Sweep fires every tick that has come due since the last sweep.
+//
+// now is a parameter so tests can drive it; in production it is time.Now.
+func (s *Scheduler) Sweep(ctx context.Context, now time.Time) error {
+	apps, err := s.EAC.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindApp))
+	if err != nil {
+		return fmt.Errorf("listing apps: %w", err)
+	}
+
+	for _, e := range apps.Values() {
+		var app core_v1alpha.App
+		app.Decode(e.Entity())
+		app.ID = entity.Id(e.Id())
+
+		if app.ActiveVersion == "" {
+			continue
+		}
+
+		if err := s.sweepApp(ctx, &app, now); err != nil {
+			s.Log.Warn("failed to sweep app for scheduled tasks", "app", app.ID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Scheduler) sweepApp(ctx context.Context, app *core_v1alpha.App, now time.Time) error {
+	var ver core_v1alpha.AppVersion
+	if err := s.EC.GetById(ctx, app.ActiveVersion, &ver); err != nil {
+		return fmt.Errorf("reading active version: %w", err)
+	}
+
+	cfgSpec, err := coreutil.ResolveConfig(ctx, s.EAC, &ver)
+	if err != nil {
+		return fmt.Errorf("resolving config: %w", err)
+	}
+
+	var md core_v1alpha.Metadata
+	if err := s.EC.GetById(ctx, app.ID, &md); err != nil {
+		return fmt.Errorf("reading app metadata: %w", err)
+	}
+
+	for _, task := range cfgSpec.Tasks {
+		if task.Schedule == "" {
+			continue
+		}
+		if err := s.sweepTask(ctx, app, &ver, md.Name, task, now); err != nil {
+			s.Log.Warn("failed to sweep task", "app", app.ID, "task", task.Name, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Scheduler) sweepTask(
+	ctx context.Context,
+	app *core_v1alpha.App,
+	ver *core_v1alpha.AppVersion,
+	appName string,
+	task core_v1alpha.ConfigSpecTasks,
+	now time.Time,
+) error {
+	expr, err := oncalendar.Parse(task.Schedule)
+	if err != nil {
+		// Config validation rejects unparseable schedules, so reaching here
+		// means a version predating that check. Skip rather than retrying every
+		// interval forever.
+		return fmt.Errorf("parsing schedule %q: %w", task.Schedule, err)
+	}
+
+	key := app.ID.String() + "/" + task.Name
+
+	s.mu.Lock()
+	from, seen := s.frontier[key]
+	if !seen {
+		// First sight of this task: start the frontier at now, so ticks that
+		// came due while the cluster was down are skipped rather than
+		// backfilled. Replaying an outage's worth of cleanups on recovery is a
+		// good way to turn an outage into an incident, and a job that needs
+		// catch-up can be made idempotent over a window instead.
+		from = now
+		s.frontier[key] = now
+	}
+	s.mu.Unlock()
+
+	// Only fire ticks this replica's own clock has passed. Skew therefore makes
+	// a fast replica fire early rather than twice, which matters for a
+	// nine-o'clock report and not for a six-hourly cleanup.
+	var fired []time.Time
+	cursor := from
+	for {
+		next, ok := expr.Next(cursor)
+		if !ok || next.After(now) {
+			break
+		}
+		fired = append(fired, next)
+		cursor = next
+
+		// A pathological expression plus a long outage could otherwise produce
+		// an unbounded list; the frontier advance below still moves past them.
+		if len(fired) >= 64 {
+			break
+		}
+	}
+
+	if len(fired) > 0 {
+		s.mu.Lock()
+		s.frontier[key] = fired[len(fired)-1]
+		s.mu.Unlock()
+	}
+
+	for _, tick := range fired {
+		if err := s.fireTick(ctx, app, ver, appName, task, tick); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// fireTick creates the run for one tick, or records that it was skipped.
+func (s *Scheduler) fireTick(
+	ctx context.Context,
+	app *core_v1alpha.App,
+	ver *core_v1alpha.AppVersion,
+	appName string,
+	task core_v1alpha.ConfigSpecTasks,
+	tick time.Time,
+) error {
+	name := tickRunName(appName, task.Name, tick)
+
+	// Ticks do not queue and do not overlap. A tick whose predecessor is still
+	// going is skipped -- and recorded as skipped, because "my job stopped
+	// running" and "my job got slower than its interval" are indistinguishable
+	// from the outside otherwise.
+	status := run_v1alpha.PENDING
+	busy, err := s.taskIsBusy(ctx, app.ID, task.Name)
+	if err != nil {
+		return err
+	}
+	if busy {
+		status = run_v1alpha.SKIPPED
+	}
+
+	maxAttempts := int64(1)
+	if task.Retries > 0 {
+		maxAttempts = task.Retries + 1
+	}
+
+	run := &run_v1alpha.Run{
+		App:         app.ID,
+		Version:     ver.ID,
+		Task:        task.Name,
+		Trigger:     run_v1alpha.SCHEDULE,
+		Command:     task.Command,
+		Status:      status,
+		Timeout:     task.Timeout,
+		MaxAttempts: maxAttempts,
+		Tick:        tick.UTC().Format(time.RFC3339),
+	}
+
+	// Create is put-if-absent on a name derived from the tick, which is the
+	// entire single-execution guarantee: every replica derives the same name,
+	// etcd admits one, and the rest learn the tick is taken.
+	id, err := s.EC.Create(ctx, name, run)
+	if err != nil {
+		if errors.Is(err, cond.ErrConflict{}) {
+			s.Log.Debug("tick already claimed by another replica",
+				"app", app.ID, "task", task.Name, "tick", run.Tick)
+			return nil
+		}
+		return fmt.Errorf("creating run for tick %s: %w", run.Tick, err)
+	}
+
+	if status == run_v1alpha.SKIPPED {
+		s.Log.Info("skipped scheduled tick, previous run still going",
+			"run", id, "app", app.ID, "task", task.Name, "tick", run.Tick)
+		return nil
+	}
+
+	s.Log.Info("scheduled tick fired",
+		"run", id, "app", app.ID, "task", task.Name, "tick", run.Tick)
+	return nil
+}
+
+// taskIsBusy reports whether a run of this task is still going.
+func (s *Scheduler) taskIsBusy(ctx context.Context, appID entity.Id, task string) (bool, error) {
+	results, err := s.EAC.List(ctx, entity.Ref(run_v1alpha.RunAppId, appID))
+	if err != nil {
+		return false, fmt.Errorf("listing runs: %w", err)
+	}
+
+	for _, e := range results.Values() {
+		var other run_v1alpha.Run
+		other.Decode(e.Entity())
+		if other.Task == task && !isTerminal(other.Status) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// tickRunName derives the run's name from the tick, which is what makes
+// creating it a deduplicating operation.
+//
+// The timestamp is hashed rather than embedded: entity names are a single clean
+// segment, and an RFC 3339 string carries colons and a plus. The hash is
+// truncated because it only has to separate ticks of one task on one app, not
+// resist collision by an adversary.
+func tickRunName(appName, task string, tick time.Time) string {
+	sum := sha256.Sum256([]byte(tick.UTC().Format(time.RFC3339)))
+	digest := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(sum[:6]))
+	return fmt.Sprintf("%s-%s-%s", appName, task, digest)
+}

--- a/controllers/run/scheduler.go
+++ b/controllers/run/scheduler.go
@@ -46,6 +46,11 @@ type Scheduler struct {
 	Interval time.Duration
 
 	cancel func()
+	// done closes once the sweep loop has exited, so Stop can wait for it.
+	// Without that, Stop returns while a sweep is mid-flight and the scheduler
+	// can still create runs afterwards -- which for a caller shutting down in
+	// order is the opposite of what Stop appears to promise.
+	done chan struct{}
 
 	// mu guards frontier, which records the newest tick already considered for
 	// each (app, task). It is in-memory on purpose: on startup the frontier
@@ -78,16 +83,26 @@ func (s *Scheduler) Start(ctx context.Context) {
 	s.Log.Info("starting run scheduler", "interval", s.Interval)
 
 	ctx, s.cancel = context.WithCancel(ctx)
+	s.done = make(chan struct{})
 	go s.run(ctx)
 }
 
+// Stop cancels the scheduler and waits for an in-flight sweep to finish, so a
+// caller shutting down in order can rely on no further runs being created.
 func (s *Scheduler) Stop() {
-	if s.cancel != nil {
-		s.cancel()
+	if s.cancel == nil {
+		return
+	}
+	s.cancel()
+
+	if s.done != nil {
+		<-s.done
 	}
 }
 
 func (s *Scheduler) run(ctx context.Context) {
+	defer close(s.done)
+
 	ticker := time.NewTicker(s.Interval)
 	defer ticker.Stop()
 
@@ -205,7 +220,9 @@ func (s *Scheduler) sweepTask(
 		cursor = next
 
 		// A pathological expression plus a long outage could otherwise produce
-		// an unbounded list; the frontier advance below still moves past them.
+		// an unbounded list. The remainder is not dropped: the frontier only
+		// advances past ticks that were fired, so the next sweep picks up where
+		// this one stopped.
 		if len(fired) >= 64 {
 			break
 		}

--- a/controllers/run/scheduler.go
+++ b/controllers/run/scheduler.go
@@ -292,7 +292,10 @@ func (s *Scheduler) fireTick(
 	}
 
 	if status == run_v1alpha.SKIPPED {
-		s.Log.Info("skipped scheduled tick, previous run still going",
+		// Warn, not Info: the task did not run. That is a degraded handled
+		// event, and an operator watching a schedule wants it to stand out
+		// from the ticks that fired normally.
+		s.Log.Warn("skipped scheduled tick, previous run still going",
 			"run", id, "app", app.ID, "task", task.Name, "tick", run.Tick)
 		return nil
 	}

--- a/controllers/run/scheduler.go
+++ b/controllers/run/scheduler.go
@@ -53,16 +53,25 @@ type Scheduler struct {
 	// backfilled.
 	mu       sync.Mutex
 	frontier map[string]time.Time
+
+	// fire is the tick-firing step, indirected so a test can make it fail.
+	// The frontier only advances past ticks that were actually handled, and
+	// that rule is invisible unless a failure can be injected -- a sweep where
+	// everything succeeds behaves identically whether the frontier moves before
+	// or after firing.
+	fire func(context.Context, *core_v1alpha.App, *core_v1alpha.AppVersion, string, core_v1alpha.ConfigSpecTasks, time.Time) error
 }
 
 func NewScheduler(log *slog.Logger, ec *entityserver.Client, eac *entityserver_v1alpha.EntityAccessClient) *Scheduler {
-	return &Scheduler{
+	s := &Scheduler{
 		Log:      log.With("module", "run-scheduler"),
 		EC:       ec,
 		EAC:      eac,
 		Interval: SchedulerInterval,
 		frontier: make(map[string]time.Time),
 	}
+	s.fire = s.fireTick
+	return s
 }
 
 func (s *Scheduler) Start(ctx context.Context) {
@@ -206,7 +215,7 @@ func (s *Scheduler) sweepTask(
 	// it first would drop any tick whose fire failed -- permanently, since the
 	// frontier is what decides a tick is behind us.
 	for _, tick := range fired {
-		if err := s.fireTick(ctx, app, ver, appName, task, tick); err != nil {
+		if err := s.fire(ctx, app, ver, appName, task, tick); err != nil {
 			return err
 		}
 

--- a/controllers/run/scheduler.go
+++ b/controllers/run/scheduler.go
@@ -348,7 +348,29 @@ func (s *Scheduler) taskIsBusy(ctx context.Context, appID entity.Id, task string
 // truncated because it only has to separate ticks of one task on one app, not
 // resist collision by an adversary.
 func tickRunName(appName, task string, tick time.Time) string {
-	sum := sha256.Sum256([]byte(tick.UTC().Format(time.RFC3339)))
+	// App and task go into the digest, not just the readable prefix.
+	//
+	// The prefix joins them with hyphens, and neither is restricted to exclude
+	// one: task names are TOML table keys, so [tasks.db-migrate] is ordinary.
+	// That makes app "api" + task "db-migrate" and app "api-db" + task
+	// "migrate" render the same prefix, and a run's identity is cluster-wide
+	// within its kind rather than scoped per app. Hashing the tick alone then
+	// collides them outright whenever the instants agree -- which for two daily
+	// or six-hourly schedules is every time, not a rare race.
+	//
+	// The loser of that Create sees ErrConflict, which this scheduler reads as
+	// "another replica claimed this tick", so it advances the frontier and
+	// never retries: one app's job silently stops running, and the only trace
+	// says something untrue about why. The NUL separators cannot appear in
+	// either input, so the digest distinguishes what the prefix cannot.
+	h := sha256.New()
+	h.Write([]byte(appName))
+	h.Write([]byte{0})
+	h.Write([]byte(task))
+	h.Write([]byte{0})
+	h.Write([]byte(tick.UTC().Format(time.RFC3339)))
+	sum := h.Sum(nil)
+
 	digest := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(sum[:6]))
 	return fmt.Sprintf("%s-%s-%s", appName, task, digest)
 }

--- a/controllers/run/scheduler_test.go
+++ b/controllers/run/scheduler_test.go
@@ -265,3 +265,28 @@ func TestSchedulerFrontierDoesNotSkipUnfiredTicks(t *testing.T) {
 	assert.True(t, ticks["2026-08-04T12:30:00Z"], "the earlier tick must not be skipped over")
 	assert.True(t, ticks["2026-08-04T13:00:00Z"])
 }
+
+// A skipped tick is terminal the moment it is created, so it never passes
+// through the controller that stamps timestamps. Retention measures from
+// EndedAt and retains a scheduled run that has none, so without them the
+// busiest task accumulates skipped ticks forever.
+func TestSchedulerStampsSkippedTicks(t *testing.T) {
+	ctx := context.Background()
+	h := newSchedHarness(t, "*-*-* *:00/30:00")
+
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:30:01Z")))
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T13:00:01Z")))
+
+	var skipped *run_v1alpha.Run
+	for _, r := range h.runs(ctx) {
+		if r.Status == run_v1alpha.SKIPPED {
+			skipped = &r
+		}
+	}
+	require.NotNil(t, skipped, "expected a skipped tick")
+
+	assert.False(t, skipped.EndedAt.IsZero(), "GC retains a scheduled run with no EndedAt forever")
+	assert.Equal(t, atUTC("2026-08-04T13:00:00Z"), skipped.EndedAt.UTC(),
+		"the tick it claimed is the honest timestamp for a run that never executed")
+}

--- a/controllers/run/scheduler_test.go
+++ b/controllers/run/scheduler_test.go
@@ -325,3 +325,52 @@ func TestSchedulerStampsSkippedTicks(t *testing.T) {
 	assert.Equal(t, atUTC("2026-08-04T13:00:00Z"), skipped.EndedAt.UTC(),
 		"the tick it claimed is the honest timestamp for a run that never executed")
 }
+
+// Stop has to wait for an in-flight sweep, or a caller shutting down in order
+// can still see runs created after it returns -- the opposite of what Stop
+// appears to promise.
+func TestSchedulerStopWaitsForTheSweep(t *testing.T) {
+	h := newSchedHarness(t, "*-*-* *:00/30:00")
+	h.s.Interval = time.Millisecond
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+
+	real := h.s.fire
+	h.s.fire = func(ctx context.Context, app *core_v1alpha.App, ver *core_v1alpha.AppVersion, appName string, task core_v1alpha.ConfigSpecTasks, tick time.Time) error {
+		once.Do(func() { close(entered) })
+		<-release
+		return real(ctx, app, ver, appName, task, tick)
+	}
+
+	// Seed the frontier in the past so the very next sweep has a tick to fire.
+	h.s.frontier[entity.Id("app/demo").String()+"/cleanup"] = time.Now().Add(-time.Hour)
+	h.s.Start(context.Background())
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sweep never started")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		h.s.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned while a sweep was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return after the sweep finished")
+	}
+}

--- a/controllers/run/scheduler_test.go
+++ b/controllers/run/scheduler_test.go
@@ -1,0 +1,242 @@
+package run
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+type schedHarness struct {
+	t   *testing.T
+	s   *Scheduler
+	inm *testutils.InMemEntityServer
+}
+
+// newSchedHarness seeds an app whose active version declares one scheduled task.
+func newSchedHarness(t *testing.T, schedule string) *schedHarness {
+	t.Helper()
+
+	inm, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	appID := entity.Id("app/demo")
+	cfgID := entity.Id("config_version/v1-cfg")
+	verID := entity.Id("app_version/v1")
+
+	_, err := inm.EAC.Put(ctx, wrap(entity.New(
+		(&core_v1alpha.Metadata{Name: "demo"}).Encode,
+		entity.DBId, appID,
+		(&core_v1alpha.App{ActiveVersion: verID}).Encode,
+	), appID))
+	require.NoError(t, err)
+
+	_, err = inm.EAC.Put(ctx, wrap(entity.New(
+		entity.DBId, cfgID,
+		(&core_v1alpha.ConfigVersion{
+			App: appID,
+			Spec: core_v1alpha.ConfigSpec{
+				Tasks: []core_v1alpha.ConfigSpecTasks{
+					{Name: "cleanup", Command: "bin/cleanup", Trigger: "schedule", Schedule: schedule, MaxConcurrent: 1},
+				},
+			},
+		}).Encode,
+	), cfgID))
+	require.NoError(t, err)
+
+	_, err = inm.EAC.Put(ctx, wrap(entity.New(
+		entity.DBId, verID,
+		(&core_v1alpha.AppVersion{Version: "v1", ImageUrl: "img:v1", ConfigVersion: cfgID}).Encode,
+	), verID))
+	require.NoError(t, err)
+
+	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &schedHarness{t: t, s: NewScheduler(log, inm.Client, inm.EAC), inm: inm}
+}
+
+func (h *schedHarness) runs(ctx context.Context) []run_v1alpha.Run {
+	h.t.Helper()
+
+	results, err := h.inm.EAC.List(ctx, entity.Ref(run_v1alpha.RunAppId, entity.Id("app/demo")))
+	require.NoError(h.t, err)
+
+	var out []run_v1alpha.Run
+	for _, e := range results.Values() {
+		var r run_v1alpha.Run
+		r.Decode(e.Entity())
+		r.ID = entity.Id(e.Id())
+		out = append(out, r)
+	}
+	return out
+}
+
+func atUTC(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t.UTC()
+}
+
+// A tick that came due while the cluster was down is skipped, not replayed.
+// Running an outage's worth of missed cleanups on recovery is a good way to
+// turn an outage into an incident.
+func TestSchedulerDoesNotBackfillMissedTicks(t *testing.T) {
+	ctx := context.Background()
+	h := newSchedHarness(t, "*-*-* *:00/30:00")
+
+	// First sight is well after many ticks have already passed.
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+	assert.Empty(t, h.runs(ctx), "the frontier starts at now; history is not replayed")
+}
+
+func TestSchedulerFiresATickThatComesDue(t *testing.T) {
+	ctx := context.Background()
+	h := newSchedHarness(t, "*-*-* *:00/30:00")
+
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+	require.Empty(t, h.runs(ctx))
+
+	// 12:30 comes due.
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:30:01Z")))
+
+	runs := h.runs(ctx)
+	require.Len(t, runs, 1)
+	assert.Equal(t, "cleanup", runs[0].Task)
+	assert.Equal(t, run_v1alpha.SCHEDULE, runs[0].Trigger)
+	assert.Equal(t, run_v1alpha.PENDING, runs[0].Status)
+	assert.Equal(t, "2026-08-04T12:30:00Z", runs[0].Tick, "the run records the tick it claims")
+}
+
+// The dedup guarantee: every replica derives the same tick and therefore the
+// same entity name, so repeated sweeps -- or a second replica -- produce one
+// run, not several.
+func TestSchedulerFiresEachTickExactlyOnce(t *testing.T) {
+	ctx := context.Background()
+	h := newSchedHarness(t, "*-*-* *:00/30:00")
+
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+
+	// A second scheduler sharing the store, as another replica would be.
+	log := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	other := NewScheduler(log, h.inm.Client, h.inm.EAC)
+	require.NoError(t, other.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+
+	at := atUTC("2026-08-04T12:30:01Z")
+	require.NoError(t, h.s.Sweep(ctx, at))
+	require.NoError(t, other.Sweep(ctx, at))
+	require.NoError(t, h.s.Sweep(ctx, at))
+
+	assert.Len(t, h.runs(ctx), 1, "one tick must produce one run however many replicas evaluate it")
+}
+
+// Ticks do not queue. A tick whose predecessor is still going is skipped -- and
+// recorded as skipped, because a silent gap is indistinguishable from a job
+// that stopped running.
+func TestSchedulerRecordsASkippedTick(t *testing.T) {
+	ctx := context.Background()
+	h := newSchedHarness(t, "*-*-* *:00/30:00")
+
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:30:01Z")))
+	require.Len(t, h.runs(ctx), 1)
+
+	// The first run is still going when the next tick comes due.
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T13:00:01Z")))
+
+	runs := h.runs(ctx)
+	require.Len(t, runs, 2)
+
+	var skipped int
+	for _, r := range runs {
+		if r.Status == run_v1alpha.SKIPPED {
+			skipped++
+			assert.Equal(t, "2026-08-04T13:00:00Z", r.Tick)
+		}
+	}
+	assert.Equal(t, 1, skipped, "the skip has to be visible, not a silent gap")
+}
+
+// Once the predecessor finishes, the next tick runs normally.
+func TestSchedulerResumesAfterThePredecessorFinishes(t *testing.T) {
+	ctx := context.Background()
+	h := newSchedHarness(t, "*-*-* *:00/30:00")
+
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:30:01Z")))
+
+	first := h.runs(ctx)[0]
+	_, err := h.inm.EAC.Patch(ctx, entity.New(
+		entity.Ref(entity.DBId, first.ID),
+		(&run_v1alpha.Run{Status: run_v1alpha.SUCCEEDED}).Encode,
+	).Attrs(), 0)
+	require.NoError(t, err)
+
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T13:00:01Z")))
+
+	var pending int
+	for _, r := range h.runs(ctx) {
+		if r.Status == run_v1alpha.PENDING {
+			pending++
+		}
+	}
+	assert.Equal(t, 1, pending, "a finished predecessor must not hold the schedule back")
+}
+
+// An app with no active version has nothing to schedule against.
+func TestSchedulerIgnoresAppsWithoutAnActiveVersion(t *testing.T) {
+	ctx := context.Background()
+	h := newSchedHarness(t, "*-*-* *:00/30:00")
+
+	_, err := h.inm.EAC.Patch(ctx, entity.New(
+		entity.Ref(entity.DBId, entity.Id("app/demo")),
+		entity.Ref(core_v1alpha.AppActiveVersionId, entity.Id("")),
+	).Attrs(), 0)
+	require.NoError(t, err)
+
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T13:00:01Z")))
+	assert.Empty(t, h.runs(ctx))
+}
+
+// Manual and deploy tasks are not on a schedule and must never be fired by it.
+func TestSchedulerIgnoresUnscheduledTasks(t *testing.T) {
+	ctx := context.Background()
+	h := newSchedHarness(t, "")
+
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-05T12:00:00Z")))
+	assert.Empty(t, h.runs(ctx))
+}
+
+// The name is what dedups, so it must be a pure function of the tick and stable
+// across processes.
+func TestTickRunName(t *testing.T) {
+	tick := atUTC("2026-08-04T12:30:00Z")
+
+	a := tickRunName("demo", "cleanup", tick)
+	assert.Equal(t, a, tickRunName("demo", "cleanup", tick), "same tick, same name")
+
+	assert.NotEqual(t, a, tickRunName("demo", "cleanup", atUTC("2026-08-04T13:00:00Z")))
+	assert.NotEqual(t, a, tickRunName("demo", "other", tick))
+	assert.NotEqual(t, a, tickRunName("other", "cleanup", tick))
+
+	// Entity names are one segment; an RFC 3339 timestamp is not.
+	assert.NotContains(t, a, ":")
+	assert.NotContains(t, a, "+")
+
+	// A tick expressed in another zone is the same instant and must not produce
+	// a second run.
+	tokyo := tick.In(time.FixedZone("JST", 9*60*60))
+	assert.Equal(t, a, tickRunName("demo", "cleanup", tokyo))
+}

--- a/controllers/run/scheduler_test.go
+++ b/controllers/run/scheduler_test.go
@@ -374,3 +374,37 @@ func TestSchedulerStopWaitsForTheSweep(t *testing.T) {
 		t.Fatal("Stop did not return after the sweep finished")
 	}
 }
+
+// The readable prefix joins app and task with a hyphen, and neither excludes
+// one -- task names are TOML table keys, so [tasks.db-migrate] is ordinary. A
+// run's identity is cluster-wide within its kind, so if the digest covers only
+// the tick, these two collide outright whenever their instants agree. Two daily
+// schedules agree every day.
+//
+// The consequence is not a duplicated run but a missing one: the loser of the
+// create reads ErrConflict as "another replica claimed this tick", advances its
+// frontier, and never retries.
+func TestTickRunNameDistinguishesAmbiguousAppAndTaskPairs(t *testing.T) {
+	tick := time.Date(2026, 8, 12, 0, 0, 0, 0, time.UTC)
+
+	a := tickRunName("api", "db-migrate", tick)
+	b := tickRunName("api-db", "migrate", tick)
+
+	assert.NotEqual(t, a, b, "two different jobs sharing an instant must not share a name")
+}
+
+// The dedup property the whole schedule trigger rests on: same app, same task,
+// same instant is the same name on every replica.
+func TestTickRunNameIsStableForTheSameJobAndTick(t *testing.T) {
+	tick := time.Date(2026, 8, 12, 6, 0, 0, 0, time.UTC)
+
+	assert.Equal(t,
+		tickRunName("api", "cleanup", tick),
+		tickRunName("api", "cleanup", tick.In(time.FixedZone("elsewhere", 3600))),
+		"the same instant in another zone is the same tick")
+
+	assert.NotEqual(t,
+		tickRunName("api", "cleanup", tick),
+		tickRunName("api", "cleanup", tick.Add(time.Hour)),
+		"a different instant is a different tick")
+}

--- a/controllers/run/scheduler_test.go
+++ b/controllers/run/scheduler_test.go
@@ -2,8 +2,10 @@ package run
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -132,12 +134,25 @@ func TestSchedulerFiresEachTickExactlyOnce(t *testing.T) {
 	other := NewScheduler(log, h.inm.Client, h.inm.EAC)
 	require.NoError(t, other.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
 
+	// Evaluate the same tick from both replicas at once. Sequential sweeps
+	// would let the later one observe the earlier one's run and skip on that
+	// basis, which proves nothing about the create-if-absent guarantee.
 	at := atUTC("2026-08-04T12:30:01Z")
-	require.NoError(t, h.s.Sweep(ctx, at))
-	require.NoError(t, other.Sweep(ctx, at))
-	require.NoError(t, h.s.Sweep(ctx, at))
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i, s := range []*Scheduler{h.s, other} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = s.Sweep(ctx, at)
+		}()
+	}
+	wg.Wait()
 
-	assert.Len(t, h.runs(ctx), 1, "one tick must produce one run however many replicas evaluate it")
+	for _, err := range errs {
+		require.NoError(t, err, "losing the race is not an error")
+	}
+	assert.Len(t, h.runs(ctx), 1, "one tick must produce one run however many replicas evaluate it at once")
 }
 
 // Ticks do not queue. A tick whose predecessor is still going is skipped -- and
@@ -244,25 +259,45 @@ func TestTickRunName(t *testing.T) {
 }
 
 // The frontier is what decides a tick is behind us, so it must only advance
-// past ticks that were actually handled. Advancing first would drop any tick
-// whose fire failed, permanently.
+// past ticks that were actually handled. Advancing first would drop the
+// remainder permanently when one fails -- and that difference is invisible
+// unless a failure is injected, since a sweep where everything succeeds
+// behaves identically either way.
 func TestSchedulerFrontierDoesNotSkipUnfiredTicks(t *testing.T) {
 	ctx := context.Background()
 	h := newSchedHarness(t, "*-*-* *:00/30:00")
 
 	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
 
-	// Two ticks come due at once.
-	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T13:00:01Z")))
+	// Two ticks come due at once, and the first one fails to fire.
+	real := h.s.fire
+	var attempted []time.Time
+	h.s.fire = func(ctx context.Context, app *core_v1alpha.App, ver *core_v1alpha.AppVersion, appName string, task core_v1alpha.ConfigSpecTasks, tick time.Time) error {
+		attempted = append(attempted, tick)
+		if tick.Equal(atUTC("2026-08-04T12:30:00Z")) {
+			return errors.New("injected fire failure")
+		}
+		return real(ctx, app, ver, appName, task, tick)
+	}
 
-	runs := h.runs(ctx)
-	require.Len(t, runs, 2, "both due ticks are accounted for")
+	// A failing task is logged rather than aborting the sweep -- one bad task
+	// must not stop the others -- so the observable contract is what the next
+	// sweep does, not what this one returns.
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T13:00:01Z")))
+	require.Equal(t, []time.Time{atUTC("2026-08-04T12:30:00Z")}, attempted,
+		"the sweep stops at the failed tick rather than racing past it")
+
+	// The failure is over; the next sweep must retry the tick it could not
+	// fire, not skip to the newer one.
+	h.s.fire = real
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T13:00:02Z")))
 
 	ticks := map[string]bool{}
-	for _, r := range runs {
+	for _, r := range h.runs(ctx) {
 		ticks[r.Tick] = true
 	}
-	assert.True(t, ticks["2026-08-04T12:30:00Z"], "the earlier tick must not be skipped over")
+	assert.True(t, ticks["2026-08-04T12:30:00Z"],
+		"a tick that failed to fire must be retried, not left behind the frontier")
 	assert.True(t, ticks["2026-08-04T13:00:00Z"])
 }
 

--- a/controllers/run/scheduler_test.go
+++ b/controllers/run/scheduler_test.go
@@ -175,7 +175,9 @@ func TestSchedulerResumesAfterThePredecessorFinishes(t *testing.T) {
 	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
 	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:30:01Z")))
 
-	first := h.runs(ctx)[0]
+	runs := h.runs(ctx)
+	require.Len(t, runs, 1, "the tick should have produced exactly one run")
+	first := runs[0]
 	_, err := h.inm.EAC.Patch(ctx, entity.New(
 		entity.Ref(entity.DBId, first.ID),
 		(&run_v1alpha.Run{Status: run_v1alpha.SUCCEEDED}).Encode,
@@ -239,4 +241,27 @@ func TestTickRunName(t *testing.T) {
 	// a second run.
 	tokyo := tick.In(time.FixedZone("JST", 9*60*60))
 	assert.Equal(t, a, tickRunName("demo", "cleanup", tokyo))
+}
+
+// The frontier is what decides a tick is behind us, so it must only advance
+// past ticks that were actually handled. Advancing first would drop any tick
+// whose fire failed, permanently.
+func TestSchedulerFrontierDoesNotSkipUnfiredTicks(t *testing.T) {
+	ctx := context.Background()
+	h := newSchedHarness(t, "*-*-* *:00/30:00")
+
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T12:00:00Z")))
+
+	// Two ticks come due at once.
+	require.NoError(t, h.s.Sweep(ctx, atUTC("2026-08-04T13:00:01Z")))
+
+	runs := h.runs(ctx)
+	require.Len(t, runs, 2, "both due ticks are accounted for")
+
+	ticks := map[string]bool{}
+	for _, r := range runs {
+		ticks[r.Tick] = true
+	}
+	assert.True(t, ticks["2026-08-04T12:30:00Z"], "the earlier tick must not be skipped over")
+	assert.True(t, ticks["2026-08-04T13:00:00Z"])
 }

--- a/docs/docs/tasks.md
+++ b/docs/docs/tasks.md
@@ -74,11 +74,17 @@ schedule = "Mon *-*-* 09:00:00"
 
 Scheduling has three behaviors worth knowing before you rely on it:
 
-**Ticks don't queue.** If a run is still going when the next firing comes due, that firing is **skipped** — and recorded as skipped, so `miren app runs` shows it. A job that has grown slower than its interval looks the same as a job that stopped running, unless the platform says which.
+:::note[Ticks don't queue]
+If a run is still going when the next firing comes due, that firing is **skipped** — and recorded as skipped, so `miren app runs` shows it. A job that has grown slower than its interval looks the same as a job that stopped running, unless the platform says which.
+:::
 
-**Missed firings aren't replayed.** If the cluster was down when a firing came due, it's skipped rather than run on recovery. Replaying an outage's worth of jobs is a good way to turn an outage into an incident. If you need catch-up, make the job idempotent over a window.
+:::note[Missed firings aren't replayed]
+If the cluster was down when a firing came due, it's skipped rather than run on recovery. Replaying an outage's worth of jobs is a good way to turn an outage into an incident. If you need catch-up, make the job idempotent over a window.
+:::
 
-**Each firing runs once**, across the whole cluster, without you configuring anything.
+:::note[Each firing runs once]
+Once across the whole cluster, without you configuring anything.
+:::
 
 ### `manual` — run when you ask
 

--- a/docs/docs/tasks.md
+++ b/docs/docs/tasks.md
@@ -50,8 +50,14 @@ The deploy waits. If the task fails, **the deploy fails** and your previous vers
 
 Deploy tasks run after your addons are ready, so a migration has its database. Several of them run at the same time; ordering between tasks isn't expressible yet.
 
+:::warning[Your previous version is running while the task is]
+The gate sits before the new version takes traffic, but the task itself runs on the **new** image. So a migration executes against your database while the **old** code is still serving every request.
+
+Your schema changes have to be compatible with both versions at once — expand-contract, or an equivalent. This is the normal path, not an edge case.
+:::
+
 :::note[Rollbacks]
-Rollbacks don't run deploy tasks. Activating a version that already exists would re-run a migration against a database that's already migrated forward, and Miren doesn't run down-migrations. Reversibility is your app's to design — expand-contract is the usual answer.
+Rollbacks don't run deploy tasks. Activating a version that already exists would re-run a migration against a database that's already migrated forward, and Miren doesn't run down-migrations. Reversibility is your app's to design.
 :::
 
 ### `schedule` — run on a timer
@@ -146,6 +152,10 @@ Until you do, Miren treats a `[services.console]` block as a task and warns at b
 
 ## Current limitations
 
-- **No per-task image or disks.** A task runs in the app's image and touches no disks directly. It can still reach anything your addons expose, since those arrive as environment variables.
-- **No ordering between deploy tasks.** They run concurrently.
-- **No per-stage deploy hooks.** A deploy task gates the whole deploy, before any rollout begins; "run this after the canary validates" isn't expressible yet.
+- **A task cannot reach a Miren disk.** If your app keeps data on a [disk](./disks.md), a task can't see it — not even the disk belonging to a service in the same app. Miren disks are single-writer, and a task running beside the service that holds the lease would either block or race it, so runs skip disks entirely.
+
+  This one is quiet: nothing warns you, and your program reports its own "no such file or directory". A backfill over disk-backed data isn't expressible yet — reach that data through an addon, or do the work inside the service that owns the disk.
+
+- **No ordering between deploy tasks.** Every deploy task starts at once, and the deploy waits for all of them. If one migration has to land before another, put both in a single task and order them yourself.
+
+- **A task runs in the app's image.** No per-task image. Anything your addons expose is available, since those arrive as environment variables.

--- a/docs/docs/tasks.md
+++ b/docs/docs/tasks.md
@@ -1,0 +1,145 @@
+---
+title: Tasks
+sidebar_label: Tasks
+description: Run commands on Miren — once per deploy, on a schedule, or on demand — with recorded exit codes and logs.
+keywords: [tasks, migrations, cron, scheduled jobs, one-off commands, miren app run]
+---
+
+# Tasks
+
+A **service** is a process Miren keeps up. A **task** is a command Miren knows how to run.
+
+Migrations, backfills, cleanup jobs, reindexes, and one-off scripts are tasks. Before tasks existed, these had to be smuggled in somewhere — a goroutine inside the app, a "worker" service that was really a sleep loop, or an external cron hitting an endpoint you built for the purpose. Those work until they don't, and when they stop you usually find out from the data rather than from the platform.
+
+Each run of a task gets a fresh sandbox built from your app's deployed image and config, runs one command, records an exit code, and is torn down.
+
+## Declaring a task
+
+```toml
+[tasks.migrate]
+command = "bin/rails db:migrate"
+trigger = "deploy"
+timeout = "10m"
+```
+
+See the [`app.toml` reference](/app-toml#tasks) for every field.
+
+A task always runs in your app's image and sees the same environment your services do, including credentials injected by [addons](/addons) — which is what makes the migration case work without extra configuration.
+
+## Triggers
+
+A task's `trigger` says what starts it.
+
+| `trigger` | Starts when |
+|-----------|-------------|
+| `deploy` | A new version is deployed, before it takes traffic |
+| `schedule` | A calendar expression comes due |
+| `manual` | Only when you ask (the default) |
+
+Any task can be invoked by hand whatever its trigger — that's how you re-run a migration without redeploying.
+
+### `deploy` — run before the new version goes live
+
+```toml
+[tasks.migrate]
+command = "bin/rails db:migrate"
+trigger = "deploy"
+```
+
+The deploy waits. If the task fails, **the deploy fails** and your previous version keeps serving — nothing was brought up, so there is nothing to roll back. If it succeeds, the new version takes traffic.
+
+Deploy tasks run after your addons are ready, so a migration has its database. Several of them run at the same time; ordering between tasks isn't expressible yet.
+
+:::note[Rollbacks]
+Rollbacks don't run deploy tasks. Activating a version that already exists would re-run a migration against a database that's already migrated forward, and Miren doesn't run down-migrations. Reversibility is your app's to design — expand-contract is the usual answer.
+:::
+
+### `schedule` — run on a timer
+
+```toml
+# Every six hours, at 00:00, 06:00, 12:00 and 18:00 UTC
+[tasks.cleanup]
+command = "bin/cleanup-sessions"
+trigger = "schedule"
+every = "6h"
+
+# Mondays at 9am
+[tasks.report]
+command = "bin/weekly-report"
+trigger = "schedule"
+schedule = "Mon *-*-* 09:00:00"
+```
+
+`every` and `schedule` are two spellings of the same thing and are mutually exclusive. `every` is sugar: it's converted to a calendar expression when your config is read, so that's what `miren app runs` shows you.
+
+Scheduling has three behaviors worth knowing before you rely on it:
+
+**Ticks don't queue.** If a run is still going when the next firing comes due, that firing is **skipped** — and recorded as skipped, so `miren app runs` shows it. A job that has grown slower than its interval looks the same as a job that stopped running, unless the platform says which.
+
+**Missed firings aren't replayed.** If the cluster was down when a firing came due, it's skipped rather than run on recovery. Replaying an outage's worth of jobs is a good way to turn an outage into an incident. If you need catch-up, make the job idempotent over a window.
+
+**Each firing runs once**, across the whole cluster, without you configuring anything.
+
+### `manual` — run when you ask
+
+```toml
+[tasks.reindex]
+command = "bin/reindex"
+timeout = "4h"
+```
+
+```bash
+miren app run --task reindex
+```
+
+## Running and watching tasks
+
+```bash
+miren app run --task reindex            # run it, attached to your terminal
+miren app run --task reindex --detach   # start it, get an id back
+miren app runs                          # what has run, and how it ended
+miren app attach run/myapp-reindex-4kq  # join a run already going
+miren logs run run/myapp-reindex-4kq    # read a run's output
+miren app runs cancel run/myapp-...     # stop a run early
+```
+
+### Disconnecting is not cancelling
+
+A run belongs to the platform, not to your terminal. If your connection drops, the command keeps going — reattach with `miren app attach`, read its output with `miren logs run`, or leave it and let its `timeout` reap it.
+
+That gives `--detach` exactly one meaning: *don't attach my terminal right now*. To actually stop a run, use `miren app runs cancel`.
+
+## Apps that are only tasks
+
+An app doesn't need a long-running process at all:
+
+```toml
+name = "batch-jobs"
+web = false
+
+[tasks.reindex]
+command = "bin/reindex"
+```
+
+`web = false` says so out loud. Without it, Miren would synthesize a web service from your image's entrypoint and keep it running forever — so declaring tasks with no services and no `web` setting is a build error rather than a guess.
+
+Deploying such an app builds the image and provisions addons; that's all. Nothing runs, and nothing is billed for compute, between invocations. `miren app list` reports it as `ready` — deployed and available to invoke, as opposed to `idle`, which means an app that scaled itself to zero.
+
+## Migrating from `[services.console]`
+
+Declaring `[services.console]` used to get you two things: a long-running service Miren kept up, and the command `miren app run` executed. Only the second was ever useful.
+
+Rename it:
+
+```toml
+[tasks.console]
+command = "bin/rails console"
+```
+
+Until you do, Miren treats a `[services.console]` block as a task and warns at build time. That's the behavior you wanted anyway — the service was costing you a sandbox nobody used.
+
+## Current limitations
+
+- **No per-task image or disks.** A task runs in the app's image and touches no disks directly. It can still reach anything your addons expose, since those arrive as environment variables.
+- **No ordering between deploy tasks.** They run concurrently.
+- **No per-stage deploy hooks.** A deploy task gates the whole deploy, before any rollout begins; "run this after the canary validates" isn't expressible yet.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -25,6 +25,7 @@ const sidebars: SidebarsConfig = {
         'deployment',
         'app-configuration',
         'services',
+        'tasks',
         'ci-deploy',
         'pr-environments',
       ],

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -1696,6 +1696,31 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 			}
 		}
 
+		// Gate the flip on deploy-triggered tasks. This mirrors the saga's
+		// runDeployTasks action and has to exist here too: the saga builder is
+		// behind a labs flag, so this is the path that actually runs today.
+		if len(deployTriggeredTasks(&configSpec)) > 0 {
+			appRec, appErr := b.appClient.GetByName(ctx, name)
+			if appErr != nil {
+				return nil, fmt.Errorf("reading app for deploy tasks: %w", appErr)
+			}
+
+			if taskErr := b.runDeployTasks(ctx, name, appRec.ID, id, &configSpec,
+				func(format string, args ...any) {
+					if status == nil {
+						return
+					}
+					so := new(build_v1alpha.Status)
+					so.Update().SetMessage(fmt.Sprintf(format, args...))
+					if _, sendErr := status.Send(ctx, so); sendErr != nil {
+						b.Log.Warn("error sending deploy task status", "error", sendErr)
+					}
+				}); taskErr != nil {
+				b.sendErrorStatus(ctx, status, "%s", taskErr)
+				return nil, taskErr
+			}
+		}
+
 		b.Log.Info("updating app entity with new version", "app", name, "version", mrv.Version)
 		err = b.appClient.SetActiveVersion(activateCtx, name, string(id))
 		if err != nil {

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -1706,16 +1706,7 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 			}
 
 			if taskErr := b.runDeployTasks(ctx, name, appRec.ID, id, &configSpec,
-				func(format string, args ...any) {
-					if status == nil {
-						return
-					}
-					so := new(build_v1alpha.Status)
-					so.Update().SetMessage(fmt.Sprintf(format, args...))
-					if _, sendErr := status.Send(ctx, so); sendErr != nil {
-						b.Log.Warn("error sending deploy task status", "error", sendErr)
-					}
-				}); taskErr != nil {
+				NewRPCStatusSender(status, b.Log)); taskErr != nil {
 				b.sendErrorStatus(ctx, status, "%s", taskErr)
 				return nil, taskErr
 			}

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -584,10 +584,7 @@ func runDeployTasks(ctx context.Context, in runDeployTasksIn) (runDeployTasksOut
 		return runDeployTasksOut{}, fmt.Errorf("reading app: %w", err)
 	}
 
-	err = b.runDeployTasks(ctx, in.AppName, appRec.ID, entity.Id(in.AppVersionID), &spec,
-		func(format string, args ...any) {
-			status.SendMessage(fmt.Sprintf(format, args...))
-		})
+	err = b.runDeployTasks(ctx, in.AppName, appRec.ID, entity.Id(in.AppVersionID), &spec, status)
 	if err != nil {
 		status.SendError("%s", err)
 		return runDeployTasksOut{}, err

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -36,6 +36,7 @@ const (
 	actionCreateConfigVer = "create-config-version"
 	actionCreateVersion   = "create-version"
 	actionProvisionAddons = "provision-addons"
+	actionRunDeployTasks  = "run-deploy-tasks"
 	actionSetActiveVer    = "set-active-version"
 	actionFinalize        = "finalize"
 	actionBeginDeploy     = "begin-deployment"
@@ -538,6 +539,71 @@ func undoProvisionAddons(_ context.Context, _ provisionAddonsIn, _ provisionAddo
 // with the active version, not replace it). Records the previous
 // active version so undo can restore it on failure.
 
+// runDeployTasksIn gates the version flip on every deploy-triggered task.
+//
+// It consumes addons_provisioned so it runs only once the app's backing
+// services exist -- a migration needs its database -- and produces an edge
+// setActiveVersion consumes, which is what puts it strictly before any traffic
+// moves.
+type runDeployTasksIn struct {
+	AppName        string    `json:"app_name" saga:"app_name"`
+	StreamID       string    `json:"stream_id" saga:"stream_id"`
+	AppVersionID   string    `json:"app_version_id" saga:"app_version_id"`
+	ConfigSpec     string    `json:"config_spec_json" saga:"config_spec_json"`
+	EphemeralLabel string    `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
+	AddonsReady    saga.Edge `saga:"addons_provisioned"`
+}
+
+type runDeployTasksOut struct {
+	Done saga.Edge `saga:"deploy_tasks_ran"`
+}
+
+func runDeployTasks(ctx context.Context, in runDeployTasksIn) (runDeployTasksOut, error) {
+	// An ephemeral preview shares the app's addons and is torn down on its own
+	// schedule; running its migrations again would be at best redundant and at
+	// worst a second writer against the same database.
+	if in.EphemeralLabel != "" {
+		return runDeployTasksOut{}, nil
+	}
+
+	deps := saga.Get[*buildSagaDeps](ctx)
+	b := deps.builder
+	status := deps.statuses.SenderFor(in.StreamID)
+
+	spec, err := unmarshalConfigSpec(in.ConfigSpec)
+	if err != nil {
+		return runDeployTasksOut{}, fmt.Errorf("deserializing config: %w", err)
+	}
+
+	if len(deployTriggeredTasks(&spec)) == 0 {
+		return runDeployTasksOut{}, nil
+	}
+
+	appRec, err := b.appClient.GetByName(ctx, in.AppName)
+	if err != nil {
+		return runDeployTasksOut{}, fmt.Errorf("reading app: %w", err)
+	}
+
+	err = b.runDeployTasks(ctx, in.AppName, appRec.ID, entity.Id(in.AppVersionID), &spec,
+		func(format string, args ...any) {
+			status.SendMessage(fmt.Sprintf(format, args...))
+		})
+	if err != nil {
+		status.SendError("%s", err)
+		return runDeployTasksOut{}, err
+	}
+
+	return runDeployTasksOut{}, nil
+}
+
+// undoRunDeployTasks deliberately does nothing. The runs happened; a deploy
+// task's effects are the app's to reverse, and the platform does not run
+// down-migrations. Nothing was brought up to tear down either, since this gate
+// sits ahead of the rollout.
+func undoRunDeployTasks(_ context.Context, _ runDeployTasksIn, _ runDeployTasksOut) error {
+	return nil
+}
+
 type setActiveVersionIn struct {
 	AppName        string               `json:"app_name" saga:"app_name"`
 	StreamID       string               `json:"stream_id" saga:"stream_id"`
@@ -545,6 +611,10 @@ type setActiveVersionIn struct {
 	EphemeralLabel string               `json:"ephemeral_label,omitempty" saga:"ephemeral_label,optional"`
 	AppConfig      *appconfig.AppConfig `json:"app_config,omitempty" saga:"app_config,optional"`
 	AddonsReady    saga.Edge            `saga:"addons_provisioned"`
+	// DeployTasksRan puts the version flip strictly after every
+	// deploy-triggered task has succeeded, so a failed task means a failed
+	// deploy rather than a half-promoted one.
+	DeployTasksRan saga.Edge `saga:"deploy_tasks_ran"`
 	// DeploymentID is empty for an untracked build. Consuming it also anchors
 	// this action after begin-deployment, which is where the record is created.
 	DeploymentID string `json:"deployment_id,omitempty" saga:"deployment_id,optional"`
@@ -873,6 +943,7 @@ func registerBuildSaga(
 		Action(actionCreateConfigVer, createConfigVersion).Undo(undoCreateConfigVersion).
 		Action(actionCreateVersion, createVersion).Undo(undoCreateVersion).
 		Action(actionProvisionAddons, provisionAddons).Undo(undoProvisionAddons).
+		Action(actionRunDeployTasks, runDeployTasks).Undo(undoRunDeployTasks).
 		Action(actionSetActiveVer, setActiveVersion).Undo(undoSetActiveVersion).
 		Action(actionFinalize, finalize).Undo(undoFinalize).
 		Action(actionBeginDeploy, beginDeployment).Undo(undoBeginDeployment).

--- a/servers/build/build_saga_test.go
+++ b/servers/build/build_saga_test.go
@@ -365,3 +365,45 @@ func TestBuildSaga_FailsWhenStreamUnavailable(t *testing.T) {
 	}
 
 }
+
+// The saga orders actions by data dependency, not by registration order, so the
+// gate's position has to be asserted rather than assumed. Everything about
+// deploy tasks depends on landing in exactly one place: after addons exist,
+// because a migration needs its database, and before ActiveVersion flips,
+// because that placement is what makes a failed task a failed deploy rather
+// than a half-promoted one.
+func TestBuildSaga_DeployTasksGateSitsBetweenAddonsAndActivation(t *testing.T) {
+	registry := saga.NewRegistry()
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	if err := registerBuildSaga(registry, nil, nil, nil, log); err != nil {
+		t.Fatalf("registering build saga: %v", err)
+	}
+
+	def, ok := registry.Get(sagaBuildFromTar)
+	if !ok {
+		t.Fatal("build saga not registered")
+	}
+
+	order := def.ExecutionOrder()
+
+	pos := func(action string) int {
+		for i, name := range order {
+			if name == action {
+				return i
+			}
+		}
+		t.Fatalf("action %q not in execution order: %v", action, order)
+		return -1
+	}
+
+	addons := pos(actionProvisionAddons)
+	tasks := pos(actionRunDeployTasks)
+	activate := pos(actionSetActiveVer)
+
+	if addons >= tasks {
+		t.Errorf("deploy tasks must run after addons are provisioned (a migration needs its database); order: %v", order)
+	}
+	if tasks >= activate {
+		t.Errorf("deploy tasks must gate the version flip, or a failed task leaves a half-promoted deploy; order: %v", order)
+	}
+}

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -2923,7 +2923,7 @@ func TestDeployGateRejectsASkippedRun(t *testing.T) {
 	_, err := inmem.EAC.Put(ctx, runEntity(t, runID, run_v1alpha.SKIPPED))
 	require.NoError(t, err)
 
-	err = b.awaitDeployRuns(ctx, map[entity.Id]string{runID: "migrate"}, func(string, ...any) {})
+	err = b.awaitDeployRuns(ctx, map[entity.Id]string{runID: "migrate"}, noopStatusSender{})
 	require.Error(t, err, "a skipped run never executed, so it cannot satisfy the gate")
 	assert.Contains(t, err.Error(), "migrate")
 	assert.Contains(t, err.Error(), "skipped")
@@ -2943,7 +2943,7 @@ func TestDeployGateAcceptsASucceededRun(t *testing.T) {
 	_, err := inmem.EAC.Put(ctx, runEntity(t, runID, run_v1alpha.SUCCEEDED))
 	require.NoError(t, err)
 
-	assert.NoError(t, b.awaitDeployRuns(ctx, map[entity.Id]string{runID: "migrate"}, func(string, ...any) {}))
+	assert.NoError(t, b.awaitDeployRuns(ctx, map[entity.Id]string{runID: "migrate"}, noopStatusSender{}))
 }
 
 func TestDeployGateRejectsAFailedRun(t *testing.T) {
@@ -2958,7 +2958,7 @@ func TestDeployGateRejectsAFailedRun(t *testing.T) {
 	_, err := inmem.EAC.Put(ctx, runEntity(t, runID, run_v1alpha.FAILED))
 	require.NoError(t, err)
 
-	err = b.awaitDeployRuns(ctx, map[entity.Id]string{runID: "migrate"}, func(string, ...any) {})
+	err = b.awaitDeployRuns(ctx, map[entity.Id]string{runID: "migrate"}, noopStatusSender{})
 	require.Error(t, err)
 	// The message has to point at the logs, since a failing migration is a
 	// deploy failure and the user is already reading this output.

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -14,6 +14,7 @@ import (
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
 	storage "miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/appconfig"
 	"miren.dev/runtime/pkg/entity"
@@ -2903,4 +2904,16 @@ func TestMigrateConsoleService(t *testing.T) {
 		// and leave the console running with the wrong environment.
 		assert.Equal(t, "production", ac.Tasks["console"].EnvVars[0].Value)
 	})
+}
+
+// The deploy gate exists to prove every task ran. A skipped run did not, so it
+// must not let the version flip.
+func TestDeployGateRejectsASkippedRun(t *testing.T) {
+	// terminalWord is the message helper; the behavior under test is that
+	// SKIPPED is not in the success branch of awaitDeployRuns. Asserting the
+	// classification keeps that explicit.
+	assert.False(t, isDeployTaskSuccess(run_v1alpha.SKIPPED),
+		"a skipped run never executed, so it cannot satisfy the gate")
+	assert.True(t, isDeployTaskSuccess(run_v1alpha.SUCCEEDED))
+	assert.False(t, isDeployTaskSuccess(run_v1alpha.FAILED))
 }

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -14,6 +14,7 @@ import (
 	"miren.dev/runtime/api/build/build_v1alpha"
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
 	storage "miren.dev/runtime/api/storage/storage_v1alpha"
 	"miren.dev/runtime/appconfig"
@@ -2907,13 +2908,73 @@ func TestMigrateConsoleService(t *testing.T) {
 }
 
 // The deploy gate exists to prove every task ran. A skipped run did not, so it
-// must not let the version flip.
+// must not let the version flip -- and that has to be exercised through
+// awaitDeployRuns, since asserting the predicate alone would still pass if the
+// wait loop treated SKIPPED as done.
 func TestDeployGateRejectsASkippedRun(t *testing.T) {
-	// terminalWord is the message helper; the behavior under test is that
-	// SKIPPED is not in the success branch of awaitDeployRuns. Asserting the
-	// classification keeps that explicit.
-	assert.False(t, isDeployTaskSuccess(run_v1alpha.SKIPPED),
-		"a skipped run never executed, so it cannot satisfy the gate")
-	assert.True(t, isDeployTaskSuccess(run_v1alpha.SUCCEEDED))
-	assert.False(t, isDeployTaskSuccess(run_v1alpha.FAILED))
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	b := &Builder{Log: testutils.TestLogger(t), ec: inmem.Client}
+
+	runID := entity.Id("run/demo-migrate-1")
+	_, err := inmem.EAC.Put(ctx, runEntity(t, runID, run_v1alpha.SKIPPED))
+	require.NoError(t, err)
+
+	err = b.awaitDeployRuns(ctx, map[entity.Id]string{runID: "migrate"}, func(string, ...any) {})
+	require.Error(t, err, "a skipped run never executed, so it cannot satisfy the gate")
+	assert.Contains(t, err.Error(), "migrate")
+	assert.Contains(t, err.Error(), "skipped")
+}
+
+// And the succeeding case has to actually pass, or the gate would block every
+// deploy rather than only the broken ones.
+func TestDeployGateAcceptsASucceededRun(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	b := &Builder{Log: testutils.TestLogger(t), ec: inmem.Client}
+
+	runID := entity.Id("run/demo-migrate-2")
+	_, err := inmem.EAC.Put(ctx, runEntity(t, runID, run_v1alpha.SUCCEEDED))
+	require.NoError(t, err)
+
+	assert.NoError(t, b.awaitDeployRuns(ctx, map[entity.Id]string{runID: "migrate"}, func(string, ...any) {}))
+}
+
+func TestDeployGateRejectsAFailedRun(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	b := &Builder{Log: testutils.TestLogger(t), ec: inmem.Client}
+
+	runID := entity.Id("run/demo-migrate-3")
+	_, err := inmem.EAC.Put(ctx, runEntity(t, runID, run_v1alpha.FAILED))
+	require.NoError(t, err)
+
+	err = b.awaitDeployRuns(ctx, map[entity.Id]string{runID: "migrate"}, func(string, ...any) {})
+	require.Error(t, err)
+	// The message has to point at the logs, since a failing migration is a
+	// deploy failure and the user is already reading this output.
+	assert.Contains(t, err.Error(), "miren logs run")
+}
+
+// runEntity builds a terminal run for the gate tests.
+func runEntity(t *testing.T, id entity.Id, status run_v1alpha.RunStatus) *entityserver_v1alpha.Entity {
+	t.Helper()
+
+	var e entityserver_v1alpha.Entity
+	e.SetId(id.String())
+	e.SetAttrs(entity.New(entity.DBId, id, (&run_v1alpha.Run{
+		Task:    "migrate",
+		Trigger: run_v1alpha.DEPLOY,
+		Status:  status,
+	}).Encode).Attrs())
+	return &e
 }

--- a/servers/build/deploy_tasks.go
+++ b/servers/build/deploy_tasks.go
@@ -52,7 +52,7 @@ func (b *Builder) runDeployTasks(
 	appID entity.Id,
 	versionID entity.Id,
 	cfgSpec *core_v1alpha.ConfigSpec,
-	report func(format string, args ...any),
+	status StatusSender,
 ) error {
 	tasks := deployTriggeredTasks(cfgSpec)
 	if len(tasks) == 0 {
@@ -67,10 +67,10 @@ func (b *Builder) runDeployTasks(
 		}
 		runIDs[id] = task.Name
 
-		report("Running deploy task %s", task.Name)
+		status.SendMessage(fmt.Sprintf("Running deploy task %s", task.Name))
 	}
 
-	return b.awaitDeployRuns(ctx, runIDs, report)
+	return b.awaitDeployRuns(ctx, runIDs, status)
 }
 
 // deployTriggeredTasks returns the tasks a deploy must run, in a stable order.
@@ -126,7 +126,7 @@ func (b *Builder) createDeployRun(
 func (b *Builder) awaitDeployRuns(
 	ctx context.Context,
 	runIDs map[entity.Id]string,
-	report func(format string, args ...any),
+	status StatusSender,
 ) error {
 	deadline := time.Now().Add(deployTaskCeiling)
 	pending := make(map[entity.Id]string, len(runIDs))
@@ -167,7 +167,7 @@ func (b *Builder) awaitDeployRuns(
 			switch run.Status {
 			case run_v1alpha.SUCCEEDED:
 				delete(pending, id)
-				report("Deploy task %s succeeded", task)
+				status.SendMessage(fmt.Sprintf("Deploy task %s succeeded", task))
 
 			case run_v1alpha.FAILED, run_v1alpha.TIMED_OUT, run_v1alpha.CANCELED:
 				// Surface where to look. A failing migration is a deploy

--- a/servers/build/deploy_tasks.go
+++ b/servers/build/deploy_tasks.go
@@ -2,12 +2,14 @@ package build
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"miren.dev/runtime/api/core/core_v1alpha"
 	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
+	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/idgen"
 )
@@ -151,9 +153,15 @@ func (b *Builder) awaitDeployRuns(
 		for id, task := range pending {
 			var run run_v1alpha.Run
 			if err := b.ec.GetById(ctx, id, &run); err != nil {
-				// A run that can't be read yet is not a failure; the next poll
-				// tries again and the ceiling bounds it.
-				continue
+				// A run that isn't visible yet is a race with its own creation,
+				// and the next poll picks it up. Anything else -- a permission
+				// or transport failure -- will not fix itself, and waiting out
+				// the ceiling would turn it into a two-hour hang with a
+				// misleading message.
+				if errors.Is(err, cond.ErrNotFound{}) {
+					continue
+				}
+				return fmt.Errorf("reading deploy task run %s: %w", task, err)
 			}
 
 			switch run.Status {
@@ -173,10 +181,12 @@ func (b *Builder) awaitDeployRuns(
 				// Still going.
 
 			case run_v1alpha.SKIPPED:
-				// Only a scheduled tick is ever skipped, so this cannot happen
-				// for a deploy-triggered run. Treat it as done rather than
-				// waiting out the ceiling if it somehow does.
-				delete(pending, id)
+				// Only a scheduled tick is ever skipped, so a deploy-triggered
+				// run reaching here means something is wrong. Fail the deploy:
+				// the gate exists to prove every task ran, and a task that was
+				// skipped did not.
+				return fmt.Errorf("deploy task %s was skipped without running; see: miren logs run %s",
+					task, run.ID)
 
 			default:
 			}
@@ -184,6 +194,12 @@ func (b *Builder) awaitDeployRuns(
 	}
 
 	return nil
+}
+
+// isDeployTaskSuccess reports whether a run satisfies the deploy gate. Only a
+// command that ran and exited zero does; a skipped run never executed.
+func isDeployTaskSuccess(s run_v1alpha.RunStatus) bool {
+	return s == run_v1alpha.SUCCEEDED
 }
 
 func terminalWord(s run_v1alpha.RunStatus) string {

--- a/servers/build/deploy_tasks.go
+++ b/servers/build/deploy_tasks.go
@@ -1,0 +1,210 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/idgen"
+)
+
+const (
+	// deployTaskPoll is how often the gate re-reads its runs. The run controller
+	// does the work; this only decides how promptly the deploy notices.
+	deployTaskPoll = 2 * time.Second
+
+	// deployTaskCeiling bounds the gate as a whole, independently of any task's
+	// own timeout. A task with no timeout would otherwise be able to hold a
+	// deploy open forever.
+	deployTaskCeiling = 2 * time.Hour
+)
+
+// runDeployTasks creates a Run for every task triggered by deploy and waits for
+// all of them.
+//
+// It sits between addons being ready and ActiveVersion flipping, which is the
+// only hook point in the deploy and deliberately so. Gating here means the runs
+// complete or fail while the previous version is still the only thing serving:
+// there is no partial rollout to unwind, no traffic to shift back, and no
+// compensation step. A failed deploy task is a failed deploy, not a
+// half-promoted one, and that holds for every rollout strategy because the gate
+// sits ahead of all of them rather than inside any.
+//
+// The cost is that a strategy cannot gate per stage -- "run the backfill after
+// the canary validates" is not expressible. That is worth having eventually,
+// but the right shape for it is a step in the strategy's sequence that
+// references a task by name, not another field on the task: the task says what
+// to run, the strategy says when. Keeping that split means adding per-stage
+// hooks later doesn't invalidate this.
+//
+// What it deliberately does not do is undo anything. If a task succeeded and a
+// later step failed, its effects stay; the platform does not run
+// down-migrations, and reversibility is the app's problem.
+func (b *Builder) runDeployTasks(
+	ctx context.Context,
+	appName string,
+	appID entity.Id,
+	versionID entity.Id,
+	cfgSpec *core_v1alpha.ConfigSpec,
+	report func(format string, args ...any),
+) error {
+	tasks := deployTriggeredTasks(cfgSpec)
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	runIDs := make(map[entity.Id]string, len(tasks))
+	for _, task := range tasks {
+		id, err := b.createDeployRun(ctx, appName, appID, versionID, task)
+		if err != nil {
+			return fmt.Errorf("creating run for task %q: %w", task.Name, err)
+		}
+		runIDs[id] = task.Name
+
+		report("Running deploy task %s", task.Name)
+	}
+
+	return b.awaitDeployRuns(ctx, runIDs, report)
+}
+
+// deployTriggeredTasks returns the tasks a deploy must run, in a stable order.
+//
+// Ordering between them is not expressed: RFD-79 put task dependencies out of
+// scope, and RFD-88's readiness graph is the right home if we ever want them.
+// They run concurrently; sorting only keeps the reported order stable.
+func deployTriggeredTasks(cfgSpec *core_v1alpha.ConfigSpec) []core_v1alpha.ConfigSpecTasks {
+	if cfgSpec == nil {
+		return nil
+	}
+
+	var tasks []core_v1alpha.ConfigSpecTasks
+	for _, t := range cfgSpec.Tasks {
+		if t.Trigger == string(deployTrigger) {
+			tasks = append(tasks, t)
+		}
+	}
+	return tasks
+}
+
+// deployTrigger is the app.toml value, not the entity enum: config stores the
+// bare word while the entity stores a namespaced id.
+const deployTrigger = "deploy"
+
+func (b *Builder) createDeployRun(
+	ctx context.Context,
+	appName string,
+	appID entity.Id,
+	versionID entity.Id,
+	task core_v1alpha.ConfigSpecTasks,
+) (entity.Id, error) {
+	maxAttempts := int64(1)
+	if task.Retries > 0 {
+		maxAttempts = task.Retries + 1
+	}
+
+	name := fmt.Sprintf("%s-%s-%s", appName, task.Name, idgen.Gen(""))
+	return b.ec.Create(ctx, name, &run_v1alpha.Run{
+		App:         appID,
+		Version:     versionID,
+		Task:        task.Name,
+		Trigger:     run_v1alpha.DEPLOY,
+		Command:     task.Command,
+		Status:      run_v1alpha.PENDING,
+		Timeout:     task.Timeout,
+		MaxAttempts: maxAttempts,
+	})
+}
+
+// awaitDeployRuns blocks until every run finishes, and fails the deploy if any
+// of them did.
+func (b *Builder) awaitDeployRuns(
+	ctx context.Context,
+	runIDs map[entity.Id]string,
+	report func(format string, args ...any),
+) error {
+	deadline := time.Now().Add(deployTaskCeiling)
+	pending := make(map[entity.Id]string, len(runIDs))
+	for id, task := range runIDs {
+		pending[id] = task
+	}
+
+	for len(pending) > 0 {
+		if time.Now().After(deadline) {
+			var names []string
+			for _, task := range pending {
+				names = append(names, task)
+			}
+			return fmt.Errorf("deploy tasks did not finish within %s: %s",
+				deployTaskCeiling, strings.Join(names, ", "))
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(deployTaskPoll):
+		}
+
+		for id, task := range pending {
+			var run run_v1alpha.Run
+			if err := b.ec.GetById(ctx, id, &run); err != nil {
+				// A run that can't be read yet is not a failure; the next poll
+				// tries again and the ceiling bounds it.
+				continue
+			}
+
+			switch run.Status {
+			case run_v1alpha.SUCCEEDED:
+				delete(pending, id)
+				report("Deploy task %s succeeded", task)
+
+			case run_v1alpha.FAILED, run_v1alpha.TIMED_OUT, run_v1alpha.CANCELED:
+				// Surface where to look. A failing migration is a deploy
+				// failure and the user is already reading this output, so the
+				// message has to carry the run id rather than making them go
+				// find it.
+				return fmt.Errorf("deploy task %s %s (exit code %s); see: miren logs run %s",
+					task, terminalWord(run.Status), exitCodeWord(&run), run.ID)
+
+			case run_v1alpha.PENDING, run_v1alpha.RUNNING:
+				// Still going.
+
+			case run_v1alpha.SKIPPED:
+				// Only a scheduled tick is ever skipped, so this cannot happen
+				// for a deploy-triggered run. Treat it as done rather than
+				// waiting out the ceiling if it somehow does.
+				delete(pending, id)
+
+			default:
+			}
+		}
+	}
+
+	return nil
+}
+
+func terminalWord(s run_v1alpha.RunStatus) string {
+	switch s {
+	case run_v1alpha.TIMED_OUT:
+		return "timed out"
+	case run_v1alpha.CANCELED:
+		return "was canceled"
+	case run_v1alpha.PENDING, run_v1alpha.RUNNING, run_v1alpha.SUCCEEDED,
+		run_v1alpha.FAILED, run_v1alpha.SKIPPED:
+		return "failed"
+	default:
+		return "failed"
+	}
+}
+
+// exitCodeWord renders the exit code, or says none was observed rather than
+// printing a 0 that would read as a clean exit.
+func exitCodeWord(run *run_v1alpha.Run) string {
+	if run.Result.At.IsZero() {
+		return "none reported"
+	}
+	return fmt.Sprintf("%d", run.Result.Code)
+}

--- a/servers/build/deploy_tasks.go
+++ b/servers/build/deploy_tasks.go
@@ -196,12 +196,6 @@ func (b *Builder) awaitDeployRuns(
 	return nil
 }
 
-// isDeployTaskSuccess reports whether a run satisfies the deploy gate. Only a
-// command that ran and exited zero does; a skipped run never executed.
-func isDeployTaskSuccess(s run_v1alpha.RunStatus) bool {
-	return s == run_v1alpha.SUCCEEDED
-}
-
 func terminalWord(s run_v1alpha.RunStatus) string {
 	switch s {
 	case run_v1alpha.TIMED_OUT:

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -912,6 +912,17 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	defer cancelSettle()
 
 	// This path has no build; it goes straight to activation.
+	//
+	// Deploy-triggered tasks (RFD-97) deliberately do not run here. They gate
+	// the build saga, which activates a *new* version; this path activates one
+	// that already exists, which is a rollback or a redeploy of a known-good
+	// version. Re-running a migration against a database that has already been
+	// migrated forward is more likely to be wrong than right, and the platform
+	// has no down-migrations to make it reversible.
+	//
+	// That is a decision rather than an oversight, but it is not one RFD-97
+	// makes -- it is tracked as an open question there. If rollbacks should run
+	// tasks, this is the hook point.
 	if phaseErr := d.tracker.SetPhase(ctx, newDeploymentId, deploylifecycle.PhaseActivating); phaseErr != nil {
 		d.Log.Error("Failed to set activating phase", "error", phaseErr)
 	}

--- a/testdata/task-deploy-gate/.miren/app.toml
+++ b/testdata/task-deploy-gate/.miren/app.toml
@@ -1,0 +1,10 @@
+name = "task-deploy-gate"
+
+# A deploy task that always fails, so a test can assert the deploy is gated on
+# it rather than proceeding to flip the active version.
+web = false
+
+[tasks.migrate]
+command = "/bin/app fail"
+trigger = "deploy"
+timeout = "2m"

--- a/testdata/task-deploy-gate/go.mod
+++ b/testdata/task-deploy-gate/go.mod
@@ -1,0 +1,3 @@
+module task-deploy-gate
+
+go 1.26

--- a/testdata/task-deploy-gate/main.go
+++ b/testdata/task-deploy-gate/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// A tiny program with one job per task, so blackbox tests can assert on exit
+// codes and output without needing a real workload.
+func main() {
+	mode := "hello"
+	if len(os.Args) > 1 {
+		mode = os.Args[1]
+	}
+
+	switch mode {
+	case "hello":
+		fmt.Println("hello from a task")
+	case "fail":
+		fmt.Fprintln(os.Stderr, "task failed on purpose")
+		os.Exit(3)
+	case "slow":
+		fmt.Println("starting slow task")
+		time.Sleep(10 * time.Minute)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown mode %q\n", mode)
+		os.Exit(64)
+	}
+}


### PR DESCRIPTION
Third and final PR implementing [RFD-97 "App Tasks"](https://github.com/mirendev/rfd/blob/main/rfds/0075/0097-app-tasks.md) (MIR-853). Stacked on #1043.

Everything that creates a `Run` without a person asking, plus the retention policy the schedule trigger's correctness depends on.

## `deploy` — gating the version flip

Creates a Run for every task with `trigger = "deploy"` and waits, between addons being ready and `ActiveVersion` flipping.

That placement is the design. Gating there means the runs complete or fail while the previous version is still the only thing serving: no partial rollout to unwind, no traffic to shift back, no compensation step. A failed deploy task is a failed deploy rather than a half-promoted one, and that holds for every rollout strategy because the gate sits ahead of all of them rather than inside any.

It also has a consequence the docs now state outright, because a user meets it on the first migration they write: the task runs on the **new** image while the **old** code is still serving every request. Schema changes have to be compatible with both at once. That was previously framed as a rollback concern, which was wrong — expand-contract is mandatory on the normal path.

The cost of gating whole-deploy is that a strategy can't gate per stage — "run the backfill after the canary validates" isn't expressible. When that's wanted, the right shape is a step in the strategy's sequence referencing a task by name, not another field on the task: the task says *what*, the strategy says *when*. Keeping that split means adding per-stage hooks later doesn't invalidate this.

The saga orders actions by data dependency rather than registration order, so the gate's position is asserted rather than assumed — a test reads `ExecutionOrder()` and pins that it lands after `provision-addons` and before `set-active-version`.

**Two paths, not one.** The saga builder is behind the `sagas` labs flag, so wiring only the saga meant the gate did nothing on the path that actually runs. The blackbox test caught exactly that — the deploy succeeded despite its task failing. Both paths gate now.

**Rollbacks deliberately don't run tasks.** That path activates a version that already exists, and re-running a migration against a database already migrated forward is more likely to be wrong than right, with no down-migrations to make it reversible. RFD-97 doesn't decide this either way, so the reasoning and the hook point are written down at the call site rather than left as a silent omission.

## `schedule` — one firing, one run

A tick is one scheduled firing, identified by app, task, and the instant it comes due. Because both scheduling forms are calendar expressions — `every` having been desugared at parse time — a tick is a pure function of the stored config, so every replica derives exactly the same ones without coordinating. The run's entity name is derived from the tick, which makes creating it a put-if-absent that etcd resolves to a single winner.

No leader election and no Valkey. RFD-79 left open whether to reuse cloud's `internal/bgtask/cron.go`; this says no for the runtime layer specifically — that code is good where Valkey is already a dependency, and the runtime's scheduler doesn't have one.

Deriving that name is load-bearing in a way worth stating, because the first version got it wrong. A run's identity is cluster-wide within its kind, and the readable prefix joins app and task with a hyphen that neither excludes — task names are TOML table keys, so `[tasks.db-migrate]` is ordinary. Hashing only the instant made app `api` + task `db-migrate` and app `api-db` + task `migrate` the same run whenever their schedules agreed, which for two daily jobs is daily. The failure is not a duplicate but a silent absence: the loser reads the conflict as "another replica claimed this tick", advances its frontier, and never retries. App and task are inside the digest now.

Three behaviors that needed deciding rather than defaulting:

- **Missed ticks are skipped, not backfilled.** The frontier starts at now, so an outage's worth of missed cleanups doesn't replay on recovery and turn an outage into an incident.
- **Overlapping ticks are skipped *and recorded*.** That falls out of the concurrency cap, but it earns its own status and a Warn: "my job stopped running" and "my job got slower than its interval" are indistinguishable from outside if the skip leaves a silent gap.
- **A replica only fires a tick its own clock has passed**, so skew makes a fast replica fire early rather than twice.

The frontier advances per fired tick rather than in one jump, so a tick whose fire fails is retried instead of being stepped over permanently. `Stop` waits for an in-flight sweep rather than only cancelling its context, since otherwise a sweep could still create runs after shutdown returned.

## Retention, which is a correctness constraint

The dedup guard for a scheduled tick *is* the run entity's existence. Deleting one while any replica could still evaluate that tick — partitioned, or restarted behind the others — lets create-if-absent succeed a second time and the job double-fires.

So schedule-triggered runs are **exempt from the count cap entirely** and retired only by age, well past any plausible partition. A count applied naively to a busy app would evict same-day ticks and silently reintroduce double-firing. That's why it's a constraint and not a tuning knob.

Everything else is count-and-age together, per **app** rather than per task (an app with 200 tasks would otherwise keep 200× the cap). Both conditions must hold: count alone evicts a burst of recent runs, age alone lets a busy app grow without bound. Console runs get a shorter window — their value is an audit record and a scrollback, not a permanent log.

**Sandbox reaping closes the leak for good.** Any sandbox tagged with a run id whose run no longer exists is stopped. That's what makes the old exec-sandbox leak un-leakable rather than merely less likely, since teardown used to be a deferred call in a request handler that a crash simply skipped.

This is another GC alongside the existing ones; @phinze filed MIR-1573 for a consolidation pass rather than blocking on it here.

## Docs

`docs/docs/tasks.md`: the three triggers, the scheduling behaviors above, disconnect-is-not-cancellation, task-only apps, and the `[services.console]` migration.

The limitations section describes behavior rather than absences, after review pointed out it was listing negative space. The two a user actually walks into:

- **A task cannot reach a Miren disk**, including one belonging to a service in the same app. Disks are single-writer and a run beside the lease-holder would block or race it, so runs skip them. It's silent — nothing warns, and the program reports its own "no such file or directory" — which makes a backfill over disk-backed data inexpressible today.
- **No ordering between deploy tasks.** They all start at once and the deploy waits for all of them; ordering means putting both steps in one task.

## Testing

`make lint` clean, docs lint clean. `make test` clean apart from `pkg/addon/postgresql` and `pkg/addon/rabbitmq`, which fail identically on `main`.

Thirteen scheduler tests cover dedup across two schedulers sharing a store, no-backfill, the skip being recorded and stamped, resumption once the predecessor finishes, the frontier not stepping over an unfired tick, `Stop` waiting for a sweep in flight, and the tick name distinguishing two jobs that share an instant while staying stable for one job across timezones. Seven GC tests cover the scheduled exemption, the age floor, console's shorter window, count-and-age together, and orphan reaping.

Eleven blackbox tests pass against a dev cluster, covering this PR and #1043 together: task-only deploy reporting `ready`, detached runs, exit-code recording, `logs run`, cancellation, attached exit-code propagation, an attached run waiting for its command rather than for its own stdin, bare `miren app run` opening a console, quoted arguments surviving as argv, declared task env reaching the container, and the deploy gate failing a deploy whose task fails.
