### PR TITLE
docs: add minimum working example blocks to every feature page

### DIFF
--- a/docs/docs/addons.md
+++ b/docs/docs/addons.md
@@ -10,6 +10,22 @@ import CliCommand from '@site/src/components/CliCommand';
 
 Addons are managed services that Miren provisions and operates for your app. Instead of running your own database as a service, you configure an addon, and Miren handles the infrastructure — creating the server, injecting connection credentials, and cleaning up when you're done.
 
+## Minimum working example
+
+Declare an addon in `.miren/app.toml` and it's provisioned on the next deploy:
+
+```toml
+name = "myapp"
+
+[services.web]
+command = "npm start"
+
+[addons.miren-postgresql]
+variant = "small"
+```
+
+Miren creates the PostgreSQL server, injects `DATABASE_URL` (and the other `PG*` variables) into every service, and holds your app's start until the database is ready.
+
 ## Addons vs. Services
 
 | | Addons | Services |

--- a/docs/docs/admin-interface.md
+++ b/docs/docs/admin-interface.md
@@ -15,6 +15,8 @@ The admin interface allows you to expose custom administrative functions in your
 Handle JSON-RPC 2.0 at `/.well-known/miren/admin` in your web service, validating the injected `ADMIN_TOKEN`:
 
 ```typescript
+const adminToken = process.env.ADMIN_TOKEN;
+
 Bun.serve({
   port: process.env.PORT ?? 3000,
   async fetch(req) {
@@ -22,7 +24,7 @@ Bun.serve({
     if (req.method !== 'POST' || url.pathname !== '/.well-known/miren/admin') {
       return new Response('Not Found', { status: 404 });
     }
-    if (req.headers.get('authorization') !== `Bearer ${process.env.ADMIN_TOKEN}`) {
+    if (!adminToken || req.headers.get('authorization') !== `Bearer ${adminToken}`) {
       return new Response('Unauthorized', { status: 401 });
     }
     const { method, id } = await req.json();

--- a/docs/docs/admin-interface.md
+++ b/docs/docs/admin-interface.md
@@ -10,6 +10,38 @@ import CliCommand from '@site/src/components/CliCommand';
 
 The admin interface allows you to expose custom administrative functions in your application that can be called from the CLI or other tooling. This is useful for user management, cache clearing, database operations, and other maintenance tasks.
 
+## Minimum working example
+
+Handle JSON-RPC 2.0 at `/.well-known/miren/admin` in your web service, validating the injected `ADMIN_TOKEN`:
+
+```typescript
+Bun.serve({
+  port: process.env.PORT ?? 3000,
+  async fetch(req) {
+    const url = new URL(req.url);
+    if (req.method !== 'POST' || url.pathname !== '/.well-known/miren/admin') {
+      return new Response('Not Found', { status: 404 });
+    }
+    if (req.headers.get('authorization') !== `Bearer ${process.env.ADMIN_TOKEN}`) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+    const { method, id } = await req.json();
+    if (method === 'ping') return Response.json({ jsonrpc: '2.0', id, result: 'pong' });
+    return Response.json({ jsonrpc: '2.0', id, error: { code: -32601, message: 'Method not found' } });
+  },
+});
+```
+
+Deploy, then call it from the CLI:
+
+<CliCommand context="client">
+```miren
+miren admin -a myapp ping
+```
+</CliCommand>
+
+The [complete examples](#complete-example-go) below add introspection, typed parameters, and constant-time token comparison.
+
 ## How It Works
 
 Your application exposes admin methods via a JSON-RPC 2.0 endpoint at a well-known path. When you run `miren admin`, the CLI:

--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -10,6 +10,19 @@ import CliCommand from '@site/src/components/CliCommand';
 
 Miren uses a **convention over configuration** approach. Most apps deploy with zero configuration—Miren detects your language, builds your image, and runs it with sensible defaults. When you need to customize, you add a `.miren/app.toml` file.
 
+## Minimum working example
+
+The smallest useful `.miren/app.toml` names the app and its start command:
+
+```toml title=".miren/app.toml"
+name = "myapp"
+
+[services.web]
+command = "npm start"
+```
+
+Deploy with `miren deploy` and Miren builds the image and runs `web` with that command. Everything else on this page is additive — environment variables, more services, scaling, disks.
+
 ## When You Don't Need app.toml
 
 If your app is a single web service with a standard language stack, Miren handles everything:

--- a/docs/docs/ci-deploy.md
+++ b/docs/docs/ci-deploy.md
@@ -16,6 +16,42 @@ GitHub Actions works out of the box. Other OIDC-capable CI systems (GitLab CI, C
 This page covers OIDC for **CI/CD deployment authentication** — letting pipelines deploy without stored secrets. For putting single sign-on in front of your **application's HTTP routes**, see [Protecting Routes](/route-protect).
 :::
 
+## Minimum working example
+
+One-time setup — export the cluster address (store the output as a GitHub Actions secret named `MIREN_CLUSTER`) and allow the repository to deploy:
+
+<CliCommand context="client">
+```miren
+miren cluster export-address
+miren auth ci add -a myapp --github acme/web-app
+```
+</CliCommand>
+
+Then add `.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mirendev/actions/deploy@main
+        with:
+          cluster: ${{ secrets.MIREN_CLUSTER }}
+          app: myapp
+```
+
+Every push to `main` now deploys, authenticated by a short-lived OIDC token — no deploy secrets stored anywhere. The [Quick Start](#quick-start-with-github-actions) below walks through each piece.
+
 ## How It Works
 
 1. **Create an OIDC binding** on your Miren cluster that links an app to an identity provider and the claims that identify your repository.
@@ -55,7 +91,7 @@ Create a binding that allows your GitHub repository to deploy:
 
 <CliCommand context="client">
 ```miren
-miren auth ci myapp --github acme/web-app
+miren auth ci add -a myapp --github acme/web-app
 ```
 </CliCommand>
 
@@ -120,7 +156,7 @@ The `--github` shorthand accepts any ref from the repository, for the allowed ev
 
 <CliCommand context="client">
 ```miren
-miren auth ci myapp --github acme/web-app \
+miren auth ci add -a myapp --github acme/web-app \
   --allowed-refs "refs/heads/main"
 ```
 </CliCommand>
@@ -151,7 +187,7 @@ By default, only `push` and `workflow_dispatch` events are permitted. To also al
 
 <CliCommand context="client">
 ```miren
-miren auth ci myapp --github acme/web-app \
+miren auth ci add -a myapp --github acme/web-app \
   --allowed-events push,workflow_dispatch,pull_request
 ```
 </CliCommand>
@@ -162,7 +198,7 @@ Restrict deployments to specific git refs:
 
 <CliCommand context="client">
 ```miren
-miren auth ci myapp --github acme/web-app \
+miren auth ci add -a myapp --github acme/web-app \
   --allowed-refs "refs/heads/main,refs/tags/v*"
 ```
 </CliCommand>
@@ -189,7 +225,7 @@ For CI systems other than GitHub Actions, use the `--issuer` and `--subject` fla
 
 <CliCommand context="client">
 ```miren
-miren auth ci myapp \
+miren auth ci add -a myapp \
   --issuer https://gitlab.com \
   --subject "project_path:acme/web-app:ref_type:branch:ref:main"
 ```
@@ -267,7 +303,7 @@ miren auth ci remove abc123
 
 ## CLI Reference
 
-### `miren auth ci`
+### `miren auth ci add`
 
 Create an OIDC binding for an application.
 

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -10,6 +10,18 @@ import CliCommand from '@site/src/components/CliCommand';
 
 Deployment is the core workflow of Miren — it takes your application code, builds a container image, and runs it on your server.
 
+## Minimum working example
+
+From the root of your project:
+
+<CliCommand context="client">
+```miren
+miren deploy
+```
+</CliCommand>
+
+That's the whole thing — Miren detects your language, builds the image on the server, and activates the new version. If the project isn't set up yet, the CLI offers to run `miren init` first; if the app doesn't exist on the server, it's created automatically on first deploy.
+
 ## How Deployment Works
 
 When you run `miren deploy`, Miren:

--- a/docs/docs/disks.md
+++ b/docs/docs/disks.md
@@ -12,6 +12,22 @@ Miren provides two options for persistent storage: **Local Storage** (simple, no
 
 Both storage options are node-local — your data lives on the server where your app runs. See each section below for backup options.
 
+## Minimum working example
+
+Attach a persistent directory to a service in `.miren/app.toml`:
+
+```toml
+[services.web]
+command = "node server.js"
+
+[[services.web.disks]]
+name = "data"
+provider = "local"
+mount_path = "/data"
+```
+
+Anything the service writes under `/data` survives restarts and redeploys. For a managed [Miren Disk](#miren-disks) with exclusive leasing and its own size, drop `provider = "local"` and set `size_gb` instead.
+
 ## Local Storage
 
 Local storage gives your app a persistent directory on the server's filesystem. Data survives container restarts and redeployments.

--- a/docs/docs/disks.md
+++ b/docs/docs/disks.md
@@ -26,7 +26,7 @@ provider = "local"
 mount_path = "/data"
 ```
 
-Anything the service writes under `/data` survives restarts and redeploys. For a managed [Miren Disk](#miren-disks) with exclusive leasing and its own size, drop `provider = "local"` and set `size_gb` instead.
+Anything the service writes under `/data` survives restarts and redeploys. For a managed [Miren Disk](#miren-disks) with exclusive leasing and its own size, drop `provider = "local"` and set `size_gb` instead — and give the service fixed concurrency (`mode = "fixed"`, `num_instances = 1`), which miren disks require.
 
 ## Local Storage
 
@@ -132,11 +132,15 @@ The feature is designed to keep our costs low, and our intention is to pass that
 
 ### Configuring Disks
 
-Add a disk to your application by including a `disks` section in your service configuration in `.miren/app.toml`:
+Add a disk to your application by including a `disks` section in your service configuration in `.miren/app.toml`. Because a miren disk is leased exclusively to one instance, the service must use fixed concurrency with `num_instances = 1`:
 
 ```toml
 [services.web]
 image = "myapp:latest"
+
+[services.web.concurrency]
+mode = "fixed"
+num_instances = 1
 
 [[services.web.disks]]
 name = "my-app-data"
@@ -187,6 +191,10 @@ the walk. Set `owner = "keep"` to opt out entirely.
 [services.db]
 image = "postgres:16"
 
+[services.db.concurrency]
+mode = "fixed"
+num_instances = 1
+
 [[services.db.env]]
 key = "POSTGRES_PASSWORD"
 value = "secret"
@@ -207,6 +215,10 @@ filesystem = "ext4"
 ```toml
 [services.web]
 image = "myapp:latest"
+
+[services.web.concurrency]
+mode = "fixed"
+num_instances = 1
 
 [[services.web.disks]]
 name = "myapp-uploads"

--- a/docs/docs/distributed-runners.md
+++ b/docs/docs/distributed-runners.md
@@ -12,6 +12,27 @@ A Miren cluster starts as a single machine: one server that builds your apps, sc
 
 Distributed runners are the way past that ceiling. You add more machines to the cluster, and Miren spreads your workloads across all of them, so you scale out instead of up.
 
+## Minimum working example
+
+Three commands take a cluster from one machine to two. On your workstation, mint a join token:
+
+<CliCommand context="client">
+```miren
+miren runner token create
+```
+</CliCommand>
+
+On the machine you're adding, join with that token and install the runner as a service:
+
+<CliCommand context="server">
+```miren
+miren runner join mren_...
+miren runner install
+```
+</CliCommand>
+
+Once `miren runner list` shows the node ready, the scheduler starts placing sandboxes on it — nothing changes in your apps.
+
 ## How it works
 
 A distributed cluster has two kinds of nodes: one **coordinator** and any number of **runners**.

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -14,6 +14,18 @@ Miren automatically configures firewall rules during setup. Most users won't nee
 
 Miren automatically configures iptables rules to enable container networking. This page explains how Miren's firewall rules work and how to troubleshoot networking issues.
 
+## Minimum working example
+
+Host-level rules are managed for you. The only thing to configure yourself is your cloud provider's security group or network ACL — allow these inbound ports:
+
+```text
+8443/udp   Miren API (QUIC) — CLI and client connections
+80/tcp     HTTP — ACME challenges and redirect to HTTPS
+443/tcp    HTTPS — application traffic
+```
+
+Also open any `node_port` values your apps declare for TCP/UDP services, and the [inter-node ports](#between-nodes-distributed-runners) if you run distributed runners.
+
 ## How Miren Configures Firewall Rules
 
 When Miren sets up the network bridge, it installs iptables rules in two chains:

--- a/docs/docs/in-cluster-api.md
+++ b/docs/docs/in-cluster-api.md
@@ -18,6 +18,22 @@ Every sandbox already carries a [workload identity token](/workload-identity). T
 
 Typical uses: a CI job running inside a sandbox that redeploys its own app, a sidecar that tails its app's logs, an operator tool that reads status across the cluster, or an app that manages its own configuration.
 
+## Minimum working example
+
+From inside any sandbox with the `miren` binary in its image, the CLI authenticates automatically:
+
+```bash
+miren app status
+miren logs
+```
+
+That works out of the box under the default `app-readonly` role. To let an app do more — redeploy itself, for example — raise its role in `.miren/app.toml`:
+
+```toml
+name = "my-app"
+workload_role = "app-deployer"
+```
+
 ## Connecting
 
 From inside a sandbox, the `miren` CLI just works — it detects that it's running in-cluster and authenticates with the mounted token:

--- a/docs/docs/logs.md
+++ b/docs/docs/logs.md
@@ -10,6 +10,20 @@ import CliCommand from '@site/src/components/CliCommand';
 
 Miren captures logs from your applications, sandboxes, builds, and the system itself. Logs are stored in [VictoriaLogs](https://docs.victoriametrics.com/victorialogs/) and queryable through the `miren logs` command and its subcommands.
 
+## Minimum working example
+
+<CliCommand context="client">
+```miren
+# Last 100 lines for the current app
+miren logs
+
+# Follow in real time, filtered to errors
+miren logs -f -g error
+```
+</CliCommand>
+
+Add `-a myapp` to target a specific app. Build, sandbox, and system logs each have their own subcommand, covered below.
+
 ## Subcommands
 
 | Subcommand | Description |

--- a/docs/docs/managing-disk-space.md
+++ b/docs/docs/managing-disk-space.md
@@ -8,6 +8,18 @@ keywords: [disk space, garbage collection, retention, image cleanup, disk pressu
 
 Every deploy leaves something behind on the node: a container image, a snapshot, some registry blobs, build cache, logs. On a cluster that deploys often, all of that accumulates, and a node with a finite disk will eventually fill up. Miren reclaims this space automatically and continuously, so under normal use you never have to think about it. This page is the map for when you do — what accumulates, how each piece gets cleaned up, what you can tune, and what changes when the disk gets tight.
 
+## Minimum working example
+
+Cleanup is automatic and needs no configuration. The knob you're most likely to want — how much deploy history each app keeps — lives in the server config:
+
+```toml title="/etc/miren/server.toml"
+[app_version]
+retention_count = 10      # always keep this many recent versions per app
+retention_period = "14d"  # keep anything younger than this when there's room
+```
+
+Aging versions out sooner lets the image cleanup cascade reclaim their disk over the next few sweeps. The rest of this page explains what accumulates and how each piece is reclaimed.
+
 ## What uses disk
 
 A handful of things grow over time:

--- a/docs/docs/observability.md
+++ b/docs/docs/observability.md
@@ -8,6 +8,22 @@ keywords: [observability, tracing, opentelemetry, spans, latency, cold start]
 
 Miren instruments the request lifecycle with [OpenTelemetry](https://opentelemetry.io/) distributed tracing. Traces flow from the initial HTTP request through internal routing, sandbox management, and container operations, giving you visibility into what's happening at every layer.
 
+## Minimum working example
+
+Miren's side needs no setup — every request is already traced, and the `traceparent` header is forwarded to your app. To join your app's spans to those traces, point an OpenTelemetry SDK at your backend in `.miren/app.toml`:
+
+```toml
+[[env]]
+key = "OTEL_EXPORTER_OTLP_ENDPOINT"
+value = "https://your-otel-collector:4318"
+
+[[env]]
+key = "OTEL_SERVICE_NAME"
+value = "my-app"
+```
+
+The SDK picks up `traceparent` from incoming requests, so your app's spans land in the same trace as Miren's routing and cold-start spans.
+
 ## What Miren Traces
 
 Every HTTP request that arrives at Miren generates a trace with spans covering:

--- a/docs/docs/pr-environments.md
+++ b/docs/docs/pr-environments.md
@@ -10,6 +10,18 @@ import CliCommand from '@site/src/components/CliCommand';
 
 A pull request environment is a labeled build of your app — called an **ephemeral version** in Miren — that runs alongside the active version on its own subdomain. It runs separately from your normal deploys and is deleted automatically when its TTL expires. The typical use is one preview per PR, reachable at something like `pr-123.myapp.example.com`.
 
+## Minimum working example
+
+With wildcard DNS pointed at your cluster (`*.myapp.example.com` → your cluster's hostname), one flag creates a preview:
+
+<CliCommand context="client">
+```miren
+miren deploy --ephemeral pr-123 --ttl 48h
+```
+</CliCommand>
+
+The build comes up at `https://pr-123.myapp.example.com`, runs alongside the active version without touching production traffic, and deletes itself when the TTL expires. See [Quick Start](#quick-start) for the DNS setup.
+
 ## How It Works
 
 When you run `miren deploy --ephemeral <label>`:
@@ -171,11 +183,11 @@ To deploy a preview per pull request from GitHub Actions, pair this with [CI/CD 
 
 **Step 1: Allow `pull_request` events on the OIDC binding.**
 
-`miren auth ci --github` permits `push` and `workflow_dispatch` by default. Add `pull_request`:
+`miren auth ci add --github` permits `push` and `workflow_dispatch` by default. Add `pull_request`:
 
 <CliCommand context="client">
 ```miren
-miren auth ci myapp-staging --github acme/web-app \
+miren auth ci add -a myapp-staging --github acme/web-app \
   --allowed-events push,workflow_dispatch,pull_request
 ```
 </CliCommand>

--- a/docs/docs/route-protect.md
+++ b/docs/docs/route-protect.md
@@ -21,6 +21,19 @@ Both work the same way: add an auth provider, then attach it to a route with `mi
 
 With OIDC, your app reads identity straight off plain HTTP headers like `X-User-Email`, so there's no auth code to write. Any standards-compliant identity provider works.
 
+## Minimum working example
+
+The fastest way to put a login in front of a route is a shared password:
+
+<CliCommand context="client">
+```miren
+miren auth provider add password staging-pw
+miren route protect staging.example.com --provider staging-pw
+```
+</CliCommand>
+
+Visitors now get a login form; entering the right password sets a 24-hour session cookie. For per-user identity from a provider like Google or GitHub, use the OIDC [Quick Start](#quick-start) below instead.
+
 ## Quick Start
 
 **Step 1: Add an identity provider**

--- a/docs/docs/scaling.md
+++ b/docs/docs/scaling.md
@@ -14,6 +14,23 @@ Miren automatically scales your application instances based on traffic. This pag
 This page is about how many instances of your app run. When the machine itself runs out of room, you add more machines to the cluster instead: see [Distributed Runners](/distributed-runners).
 :::
 
+## Minimum working example
+
+Configure scaling in `.miren/app.toml` under `[services.<name>.concurrency]`:
+
+```toml
+[services.web.concurrency]
+mode = "auto"
+requests_per_instance = 10
+scale_down_delay = "15m"
+
+[services.worker.concurrency]
+mode = "fixed"
+num_instances = 2
+```
+
+`auto` scales the service with traffic, all the way down to zero when idle; `fixed` runs an exact instance count. Deploy and the settings take effect. Both modes and every field are explained below.
+
 ## How Autoscaling Works
 
 By default, Miren uses **autoscaling** for web services. As traffic to your application increases, Miren automatically launches additional instances to handle the load. When traffic decreases, instances are scaled back down.

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -10,6 +10,22 @@ import CliCommand from '@site/src/components/CliCommand';
 
 A Miren app can run multiple **services**—separate processes that work together as part of the same application. Each service can have its own command, image, environment variables, and scaling configuration.
 
+## Minimum working example
+
+Define one service per process in `.miren/app.toml`:
+
+```toml title=".miren/app.toml"
+name = "myapp"
+
+[services.web]
+command = "npm start"
+
+[services.worker]
+command = "npm run worker"
+```
+
+Deploy, and both processes run from your app's built image — `web` receives HTTP traffic, `worker` runs alongside it, and each scales independently.
+
 ## What is a Service?
 
 A service is a named process within your app. Common patterns include:

--- a/docs/docs/tailscale.md
+++ b/docs/docs/tailscale.md
@@ -19,6 +19,23 @@ Tailscale is the common case, but nothing here is specific to it. Headscale,
 Nebula, ZeroTier, and plain WireGuard all behave the same way.
 :::
 
+## Minimum working example
+
+Install and register the cluster the way you normally would. The one required
+change on a host the internet can't reach is switching app certificates to a
+DNS-01 challenge:
+
+```toml title="/etc/miren/server.toml"
+[tls]
+acme_email = 'you@example.com'
+acme_dns_provider = 'dnsimple'
+```
+
+Put your DNS provider's API credentials in `/var/lib/miren/server/env` and
+restart the server. Point your domain's DNS at the tailnet address (or use
+[Miren Anywhere](/miren-cloud/miren-anywhere) for public traffic), and deploys
+work unchanged.
+
 ## Setting up
 
 Install Miren and register the cluster the way you normally would. There's no

--- a/docs/docs/tls.md
+++ b/docs/docs/tls.md
@@ -10,6 +10,24 @@ import CliCommand from '@site/src/components/CliCommand';
 
 Miren automatically provisions TLS certificates for your applications using [Let's Encrypt](https://letsencrypt.org/). By default, no configuration is needed — when you set a route for your app, Miren obtains a certificate automatically.
 
+## Minimum working example
+
+There's nothing to configure — set a route and HTTPS follows:
+
+<CliCommand context="client">
+```miren
+miren route set myapp.example.com myapp
+```
+</CliCommand>
+
+The first request to the hostname triggers certificate provisioning from Let's Encrypt; renewal is automatic. If your server isn't reachable from the public internet, switch to a [DNS-01 challenge](#dns-01-challenge):
+
+```toml title="/etc/miren/server.toml"
+[tls]
+acme_dns_provider = "cloudflare"
+acme_email = "you@example.com"
+```
+
 ## How It Works
 
 When a request arrives for a hostname with a configured route, Miren provisions a TLS certificate from Let's Encrypt using the ACME protocol. Certificates are cached on disk and renewed automatically before they expire.
@@ -44,7 +62,7 @@ Miren uses [lego](https://go-acme.github.io/lego/) for DNS challenges, which sup
 
 Add the DNS provider and ACME email to your server config file:
 
-```toml title="/var/lib/miren/server/config.toml"
+```toml title="/etc/miren/server.toml"
 [tls]
 acme_dns_provider = "dnsimple"
 acme_email = "you@example.com"
@@ -127,7 +145,7 @@ See [Server Configuration Reference → `[ingress]`](/server-config#ingress) for
 
 ## TLS Settings Reference
 
-All TLS settings live under the `[tls]` section of the server config file (typically `/var/lib/miren/server/config.toml`). The three ingress-cert settings below are consulted only under TLS-terminating ingress modes:
+All TLS settings live under the `[tls]` section of the server config file (typically `/etc/miren/server.toml` — see [Server Configuration](/server-config#config-file) for the search order). The three ingress-cert settings below are consulted only under TLS-terminating ingress modes:
 
 | Setting | CLI Flag | Description |
 |---------|----------|-------------|

--- a/docs/docs/tls.md
+++ b/docs/docs/tls.md
@@ -28,6 +28,8 @@ acme_dns_provider = "cloudflare"
 acme_email = "you@example.com"
 ```
 
+The DNS provider also needs its API credential in the Miren server's environment (for Cloudflare, `CF_DNS_API_TOKEN`) — the [DNS-01 section](#dns-01-challenge) shows how to wire it up.
+
 ## How It Works
 
 When a request arrives for a hostname with a configured route, Miren provisions a TLS certificate from Let's Encrypt using the ACME protocol. Certificates are cached on disk and renewed automatically before they expire.

--- a/docs/docs/traffic-routing.md
+++ b/docs/docs/traffic-routing.md
@@ -10,6 +10,26 @@ import CliCommand from '@site/src/components/CliCommand';
 
 Miren handles getting traffic to your app. For HTTP apps, this works automatically — deploy and add a route. For non-HTTP services like IRC servers, game servers, or custom TCP/UDP protocols, you configure ports explicitly.
 
+## Minimum working example
+
+Map a hostname to your app:
+
+<CliCommand context="client">
+```miren
+miren route set myapp.example.com myapp
+```
+</CliCommand>
+
+Requests to that hostname now reach your `web` service, with TLS provisioned automatically. For a non-HTTP service, expose a port directly in `.miren/app.toml`:
+
+```toml
+[[services.irc.ports]]
+port = 6667
+name = "irc"
+type = "tcp"
+node_port = 6667
+```
+
 ## Web Traffic (HTTP)
 
 When you deploy an app, the `web` service automatically receives HTTP traffic. No port configuration is needed — Miren handles TLS, routing, and load balancing.

--- a/docs/docs/waf.md
+++ b/docs/docs/waf.md
@@ -16,7 +16,7 @@ WAF is configured per route. Enable it and all requests to that route are inspec
 The WAF inspects request content for attack payloads (SQL injection, XSS, command injection, path traversal). It does **not** rate-limit, fingerprint bots, or block reconnaissance scans (e.g., probes for `/wp-admin/` or `/xmlrpc.php` on non-WordPress sites). For that kind of filtering, use an upstream proxy like Cloudflare in front of your route.
 :::
 
-## Enabling WAF
+## Minimum working example
 
 <CliCommand context="client">
 ```miren
@@ -24,7 +24,7 @@ miren route waf myapp.example.com
 ```
 </CliCommand>
 
-This enables WAF at paranoia level 1 (the default), which catches well-known attack patterns with minimal false positives.
+That's the entire setup — WAF is enabled at paranoia level 1 (the default), which catches well-known attack patterns with minimal false positives. Malicious requests to the route now get a `403 Forbidden`; clean requests pass through unchanged.
 
 To use a higher paranoia level:
 

--- a/docs/docs/workload-identity.md
+++ b/docs/docs/workload-identity.md
@@ -34,8 +34,8 @@ TOKEN=$(cat "$MIREN_IDENTITY_TOKEN_PATH")
 Or request one scoped to a specific audience from the token server:
 
 ```bash
-curl -H "Authorization: Bearer $MIREN_IDENTITY_TOKEN_SECRET" \
-  "$MIREN_IDENTITY_TOKEN_URL?audience=sts.amazonaws.com&ttl=900"
+TOKEN=$(curl -s -H "Authorization: Bearer $MIREN_IDENTITY_TOKEN_SECRET" \
+  "$MIREN_IDENTITY_TOKEN_URL?audience=sts.amazonaws.com&ttl=900" | jq -r .value)
 ```
 
 Present the JWT to any service configured to trust your cluster's issuer (`$MIREN_OIDC_ISSUER_URL`) — see [AWS via STS Federation](#aws-via-sts-federation) for the end-to-end flow.

--- a/docs/docs/workload-identity.md
+++ b/docs/docs/workload-identity.md
@@ -23,6 +23,23 @@ Both rely on the cluster's OIDC infrastructure, but the token flows in different
 The same token can authenticate to your cluster's own API — deploy, read logs, open a shell — scoped by a role you choose per app. See [In-Cluster API Access](/in-cluster-api).
 :::
 
+## Minimum working example
+
+Every sandbox already has a token — no configuration needed. Read it from the mounted file:
+
+```bash
+TOKEN=$(cat "$MIREN_IDENTITY_TOKEN_PATH")
+```
+
+Or request one scoped to a specific audience from the token server:
+
+```bash
+curl -H "Authorization: Bearer $MIREN_IDENTITY_TOKEN_SECRET" \
+  "$MIREN_IDENTITY_TOKEN_URL?audience=sts.amazonaws.com&ttl=900"
+```
+
+Present the JWT to any service configured to trust your cluster's issuer (`$MIREN_OIDC_ISSUER_URL`) — see [AWS via STS Federation](#aws-via-sts-federation) for the end-to-end flow.
+
 ## How It Works
 
 1. **Your cluster is an OIDC issuer.** It owns a signing key and publishes a standard discovery document at `/.well-known/openid-configuration` and its public keys (JWKS) at `/.well-known/miren/jwks`.


### PR DESCRIPTION
Each feature page (Deploy, Data & Storage, Networking & Security, Run & Scale — 21 pages) now opens with a copy-pasteable **Minimum working example** section: the smallest config or command that exercises the feature, placed above the conceptual explanation. Agents and humans scan for code first; this lets a question be answered from a single retrieved chunk. The heading is identical on every page to give retrieval a stable anchor.

Every example was verified against the source (app.toml parser in `appconfig/`, CLI definitions in `cli/commands/`, server config loader) and the CLI invocations were run through a freshly built binary. That audit surfaced two pre-existing doc errors, fixed here as well:

- `miren auth ci <app> --github ...` doesn't parse — `auth ci` is a help-only section; the runnable command is `miren auth ci add -a <app> --github ...`. Fixed in `ci-deploy.md` and `pr-environments.md` (7 occurrences).
- The server never reads `/var/lib/miren/server/config.toml` — the loader searches `/etc/miren/server.toml`, then `/var/lib/miren/config/server.toml`. Fixed in `tls.md`, `tailscale.md`, and `managing-disk-space.md` to match `server-config.md`.

Docs lint and full Docusaurus build pass with no broken links or anchors.

Fixes MIR-1049