### PR TITLE
Recover addon associations stranded by a coordinator crash

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1302,7 +1302,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	}
 
 	// Add addon controller (reconciles addon associations for provisioning/deprovisioning)
-	addonController := addonctrl.NewController(c.Log, ec, eac, addonRegistry)
+	addonController := addonctrl.NewController(c.Log, ec, eac, addonRegistry, addonFw.Storage)
 	if err := addonController.Init(ctx); err != nil {
 		c.Log.Error("failed to initialize addon controller", "error", err)
 		return err

--- a/controllers/addon/controller.go
+++ b/controllers/addon/controller.go
@@ -50,7 +50,19 @@ func (c *Controller) Init(ctx context.Context) error {
 
 func (c *Controller) Reconcile(ctx context.Context, assoc *addon_v1alpha.AddonAssociation, meta *entity.Meta) error {
 	switch assoc.Status {
-	case "pending":
+	case "pending", "provisioning":
+		// "provisioning" belongs here because provision() writes it before the
+		// work starts, so a coordinator that dies mid-provision leaves the
+		// association on it. The switch used to have no case for that: every
+		// later pass fell through and returned in silence, nothing picked the
+		// work back up, and because the deployment launcher holds an app back
+		// while an association is still provisioning, the app stopped
+		// deploying too. That is MIR-1524.
+		//
+		// Re-entering is safe because of the revs below this one: the
+		// execution is named after the association, so a second pass continues
+		// the interrupted attempt rather than starting a fresh one beside
+		// whatever the first already built.
 		return c.provision(ctx, assoc, meta)
 	case "deprovisioning":
 		return c.deprovision(ctx, assoc, meta)
@@ -68,12 +80,15 @@ func (c *Controller) provision(ctx context.Context, assoc *addon_v1alpha.AddonAs
 	// resync, the reconcile event may carry an older revision than what's
 	// now in the store). If the user has already marked this association for
 	// deprovisioning, skip; the subsequent deprovisioning event will handle it.
+	//
+	// "provisioning" passes as well as "pending", because an attempt a crash
+	// interrupted is still an attempt that should finish.
 	var current addon_v1alpha.AddonAssociation
 	if err := c.ec.GetById(ctx, assoc.ID, &current); err != nil {
 		return fmt.Errorf("re-reading association: %w", err)
 	}
-	if current.Status != "pending" {
-		c.log.Info("association no longer pending, skipping provision",
+	if current.Status != "pending" && current.Status != "provisioning" {
+		c.log.Info("association no longer wants provisioning, skipping",
 			"association", assoc.ID, "status", current.Status)
 		return nil
 	}

--- a/controllers/addon/controller.go
+++ b/controllers/addon/controller.go
@@ -15,6 +15,7 @@ import (
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/saga"
 )
 
 // Controller reconciles AddonAssociation entities, driving provisioning
@@ -26,6 +27,11 @@ type Controller struct {
 	ec       *entityserver.Client
 	eac      *entityserver_v1alpha.EntityAccessClient
 	registry *addon.Registry
+
+	// Providers build their own executors, so this is not for running sagas.
+	// It is here so the controller can retire a teardown record it owns; see
+	// deprovision.
+	sagaStorage saga.Storage
 }
 
 // NewController creates a new addon controller.
@@ -34,12 +40,14 @@ func NewController(
 	ec *entityserver.Client,
 	eac *entityserver_v1alpha.EntityAccessClient,
 	registry *addon.Registry,
+	sagaStorage saga.Storage,
 ) *Controller {
 	return &Controller{
-		log:      log.With("module", "addon"),
-		ec:       ec,
-		eac:      eac,
-		registry: registry,
+		log:         log.With("module", "addon"),
+		ec:          ec,
+		eac:         eac,
+		registry:    registry,
+		sagaStorage: sagaStorage,
 	}
 }
 
@@ -135,6 +143,14 @@ func (c *Controller) provision(ctx context.Context, assoc *addon_v1alpha.AddonAs
 	// just created. If compensation also fails, return the error without
 	// setting terminal "error" status so the controller retries.
 	if err := c.completeProvision(ctx, assoc, meta, provider, result); err != nil {
+		// Same reasoning as deprovision(): this compensation runs the teardown
+		// saga under the association's name, so a failed one would answer every
+		// later attempt from its own record and the retry promised above would
+		// never actually run.
+		if dropErr := saga.DropIfFailed(ctx, c.sagaStorage,
+			addon.DeprovisionExecutionID(assoc.ID)); dropErr != nil {
+			return fmt.Errorf("clearing failed teardown record: %w", dropErr)
+		}
 		depErr := provider.Deprovision(ctx, addon.AssociationFrom(assoc, meta.Entity))
 		if depErr != nil {
 			c.log.Error("compensation deprovision failed, will retry",
@@ -221,6 +237,19 @@ func (c *Controller) deprovision(ctx context.Context, assoc *addon_v1alpha.Addon
 	provider, _, ok := c.registry.Get(addonName)
 	if !ok {
 		return c.setError(meta, fmt.Errorf("unknown addon %q", addonName))
+	}
+
+	// Naming the execution after the association makes a teardown resumable,
+	// but it also makes a failed one permanent: Execute would hand back the
+	// recorded error on every later pass, so `addon destroy` would be one-shot
+	// until saga retention freed the name. Retrying a compensated saga is the
+	// owner's decision, and for teardown the controller is that owner. Every
+	// undo in these sagas is a no-op, so a failed run tore nothing down and put
+	// nothing back; a fresh attempt has strictly more to do, never something to
+	// redo.
+	if err := saga.DropIfFailed(ctx, c.sagaStorage,
+		addon.DeprovisionExecutionID(assoc.ID)); err != nil {
+		return fmt.Errorf("clearing failed teardown record: %w", err)
 	}
 
 	// Step 1: Call provider.Deprovision

--- a/controllers/addon/controller.go
+++ b/controllers/addon/controller.go
@@ -107,7 +107,7 @@ func (c *Controller) provision(ctx context.Context, assoc *addon_v1alpha.AddonAs
 		ID:   assoc.App,
 		Name: appName,
 	}
-	result, err := provider.Provision(ctx, app, addon.Variant{
+	result, err := provider.Provision(ctx, addon.AssociationFrom(assoc, meta.Entity), app, addon.Variant{
 		Name:   assoc.Variant,
 		Config: variantConfig,
 	})
@@ -120,13 +120,7 @@ func (c *Controller) provision(ctx context.Context, assoc *addon_v1alpha.AddonAs
 	// just created. If compensation also fails, return the error without
 	// setting terminal "error" status so the controller retries.
 	if err := c.completeProvision(ctx, assoc, meta, provider, result); err != nil {
-		depErr := provider.Deprovision(ctx, addon.AddonAssociation{
-			ID:      assoc.ID,
-			App:     assoc.App,
-			Addon:   assoc.Addon,
-			Variant: assoc.Variant,
-			Entity:  meta.Entity,
-		})
+		depErr := provider.Deprovision(ctx, addon.AssociationFrom(assoc, meta.Entity))
 		if depErr != nil {
 			c.log.Error("compensation deprovision failed, will retry",
 				"provision_error", err, "deprovision_error", depErr)
@@ -165,13 +159,7 @@ func (c *Controller) completeProvision(
 	envVars := result.EnvVars
 	collisions := findCollisions(existingVars, envVars)
 	if len(collisions) > 0 {
-		adjusted, err := provider.AdjustEnvVars(ctx, result, addon.AddonAssociation{
-			ID:      assoc.ID,
-			App:     assoc.App,
-			Addon:   assoc.Addon,
-			Variant: assoc.Variant,
-			Entity:  meta.Entity,
-		}, collisions)
+		adjusted, err := provider.AdjustEnvVars(ctx, result, addon.AssociationFrom(assoc, meta.Entity), collisions)
 		if err != nil {
 			return fmt.Errorf("adjusting env vars: %w", err)
 		}
@@ -221,13 +209,7 @@ func (c *Controller) deprovision(ctx context.Context, assoc *addon_v1alpha.Addon
 	}
 
 	// Step 1: Call provider.Deprovision
-	err := provider.Deprovision(ctx, addon.AddonAssociation{
-		ID:      assoc.ID,
-		App:     assoc.App,
-		Addon:   assoc.Addon,
-		Variant: assoc.Variant,
-		Entity:  meta.Entity,
-	})
+	err := provider.Deprovision(ctx, addon.AssociationFrom(assoc, meta.Entity))
 	if err != nil {
 		// Try to set error status, but don't fail if the update is rejected
 		// (e.g., the app was deleted and the entity server rejects the patch

--- a/controllers/addon/controller_test.go
+++ b/controllers/addon/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"miren.dev/runtime/pkg/addon"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/saga"
 )
 
 func TestAddonNameFromRef(t *testing.T) {
@@ -196,9 +197,56 @@ func setupControllerTest(t *testing.T) (context.Context, *Controller, *entityser
 		},
 	})
 
-	ctrl := NewController(slog.Default(), ec, inmem.EAC, registry)
+	// Tests that care reach this back through ctrl.sagaStorage.
+	ctrl := NewController(slog.Default(), ec, inmem.EAC, registry, saga.NewMemoryStorage())
 
 	return ctx, ctrl, ec, provider
+}
+
+// Naming a teardown after its association makes a failed one permanent unless
+// something retires the record: Execute would replay the recorded error on
+// every later pass and never call the provider again, so `addon destroy` would
+// be one-shot. Every undo in these sagas is a no-op, so a failed run left its
+// resources in place and a retry has only more to do.
+func TestDeprovisionRetriesAfterAFailedTeardownSaga(t *testing.T) {
+	ctx, ctrl, ec, provider := setupControllerTest(t)
+
+	appID := createAppWithVars(t, ctx, ec, "myapp", nil)
+	addonID, err := ec.Create(ctx, "miren-postgresql", &addon_v1alpha.Addon{
+		Name: "miren-postgresql",
+	})
+	require.NoError(t, err)
+
+	assocID, err := ec.Create(ctx, "test-assoc", &addon_v1alpha.AddonAssociation{
+		App:     appID,
+		Addon:   addonID,
+		Variant: "small",
+		Status:  "deprovisioning",
+	})
+	require.NoError(t, err)
+
+	// What an earlier teardown that gave up leaves behind.
+	require.NoError(t, ctrl.sagaStorage.Save(ctx, &saga.Execution{
+		ID:             addon.DeprovisionExecutionID(assocID),
+		DefinitionName: "deprovision-dedicated-postgresql",
+		Status:         saga.StatusFailed,
+		Error:          "engine unreachable",
+	}))
+
+	var assoc addon_v1alpha.AddonAssociation
+	meta, err := getMeta(ctx, ec, assocID, &assoc)
+	require.NoError(t, err)
+
+	require.NoError(t, ctrl.Reconcile(ctx, &assoc, meta))
+
+	// The load-bearing assertion. The provider here is a mock that never runs a
+	// saga, so it would be called either way; what decides whether a real one
+	// re-runs is whether the failed record is still sitting under that name.
+	_, err = ctrl.sagaStorage.Get(ctx, addon.DeprovisionExecutionID(assocID))
+	assert.ErrorIs(t, err, saga.ErrExecutionNotFound,
+		"a failed teardown record must be retired so the next Execute runs the saga")
+
+	assert.True(t, provider.deprovisionCalled, "and the teardown still reaches the provider")
 }
 
 // getMeta fetches an entity by ID and returns both the decoded struct and a Meta
@@ -247,11 +295,6 @@ func TestProvisionCompensatesOnPostProvisionFailure(t *testing.T) {
 	assert.True(t, provider.deprovisionCalled, "Deprovision should have been called as compensation after post-provision failure")
 }
 
-// TestProvisionSkipsWhenAssociationNoLongerPending verifies the pre-flight
-// re-read: if a stale Reconcile event routes through provision() but the
-// association has since moved to "deprovisioning" (e.g. on startup resync
-// after the user ran `addon destroy`), provision() must be a no-op so the
-// subsequent deprovisioning event can run.
 // MIR-1524 itself. provision() writes "provisioning" before the work starts, so
 // a coordinator that dies partway leaves the association sitting on it. The
 // switch had no case for that value, so every later pass fell through and
@@ -292,6 +335,11 @@ func TestReconcileResumesAnInterruptedProvision(t *testing.T) {
 	assert.Equal(t, "active", staged.Status, "and run through to a settled status")
 }
 
+// TestProvisionSkipsWhenAssociationNoLongerPending verifies the pre-flight
+// re-read: if a stale Reconcile event routes through provision() but the
+// association has since moved to "deprovisioning" (e.g. on startup resync
+// after the user ran `addon destroy`), provision() must be a no-op so the
+// subsequent deprovisioning event can run.
 func TestProvisionSkipsWhenAssociationNoLongerPending(t *testing.T) {
 	ctx, ctrl, ec, provider := setupControllerTest(t)
 

--- a/controllers/addon/controller_test.go
+++ b/controllers/addon/controller_test.go
@@ -252,6 +252,46 @@ func TestProvisionCompensatesOnPostProvisionFailure(t *testing.T) {
 // association has since moved to "deprovisioning" (e.g. on startup resync
 // after the user ran `addon destroy`), provision() must be a no-op so the
 // subsequent deprovisioning event can run.
+// MIR-1524 itself. provision() writes "provisioning" before the work starts, so
+// a coordinator that dies partway leaves the association sitting on it. The
+// switch had no case for that value, so every later pass fell through and
+// returned in silence, and the association was never picked back up.
+func TestReconcileResumesAnInterruptedProvision(t *testing.T) {
+	ctx, ctrl, ec, provider := setupControllerTest(t)
+
+	appID := createAppWithVars(t, ctx, ec, "myapp", nil)
+
+	addonID, err := ec.Create(ctx, "miren-postgresql", &addon_v1alpha.Addon{
+		Name: "miren-postgresql",
+	})
+	require.NoError(t, err)
+
+	// Exactly what a crash mid-provision leaves behind.
+	assocID, err := ec.Create(ctx, "test-assoc", &addon_v1alpha.AddonAssociation{
+		App:     appID,
+		Addon:   addonID,
+		Variant: "small",
+		Status:  "provisioning",
+	})
+	require.NoError(t, err)
+
+	var assoc addon_v1alpha.AddonAssociation
+	meta, err := getMeta(ctx, ec, assocID, &assoc)
+	require.NoError(t, err)
+
+	require.NoError(t, ctrl.Reconcile(ctx, &assoc, meta))
+
+	assert.True(t, provider.provisionCalled,
+		"an interrupted provision must be picked back up, not skipped in silence")
+
+	// Read the status off meta rather than the store: the controller framework
+	// flushes a handler's writes once it returns, so calling Reconcile directly
+	// leaves them staged here.
+	var staged addon_v1alpha.AddonAssociation
+	staged.Decode(meta.Entity)
+	assert.Equal(t, "active", staged.Status, "and run through to a settled status")
+}
+
 func TestProvisionSkipsWhenAssociationNoLongerPending(t *testing.T) {
 	ctx, ctrl, ec, provider := setupControllerTest(t)
 

--- a/controllers/addon/controller_test.go
+++ b/controllers/addon/controller_test.go
@@ -149,7 +149,7 @@ func (p *testProvider) LocalityMode() addon.LocalityMode {
 	return p.localityMode
 }
 
-func (p *testProvider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *testProvider) Provision(ctx context.Context, _ addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	p.provisionCalled = true
 	if p.provisionFn != nil {
 		return p.provisionFn(ctx, app, variant)

--- a/controllers/addon/rotation_controller.go
+++ b/controllers/addon/rotation_controller.go
@@ -101,13 +101,7 @@ func (c *RotationController) rotate(ctx context.Context, req *addon_v1alpha.Rota
 		return c.setError(ctx, req, fmt.Errorf("rotation not supported for addon %q", addonName))
 	}
 
-	assoc := addon.AddonAssociation{
-		ID:      assocData.ID,
-		App:     assocData.App,
-		Addon:   assocData.Addon,
-		Variant: assocData.Variant,
-		Entity:  assocEntity,
-	}
+	assoc := addon.AssociationFrom(&assocData, assocEntity)
 
 	// Claim the target secret durably *before* any engine change, so a crash is
 	// recoverable: a retry reuses this exact secret instead of minting a fresh one

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -22,6 +22,7 @@ type SagaSandboxController struct {
 	inner    *SandboxController
 	ops      *sandboxOps
 	executor *saga.Executor
+	storage  saga.Storage
 	registry *saga.Registry
 	log      *slog.Logger
 }
@@ -47,6 +48,7 @@ func NewSagaSandboxController(
 		inner:    inner,
 		ops:      &sandboxOps{ctrl: inner},
 		executor: executor,
+		storage:  storage,
 		registry: registry,
 		log:      log.With("module", "saga-sandbox-controller"),
 	}, nil
@@ -167,9 +169,19 @@ func (s *SagaSandboxController) Create(ctx context.Context, co *compute.Sandbox,
 func (s *SagaSandboxController) createSandboxViaSaga(ctx context.Context, co *compute.Sandbox) error {
 	s.log.Info("creating sandbox via saga", "id", co.ID)
 
+	execID := fmt.Sprintf("create-sandbox-%s", co.ID)
+
+	// We only get here once CheckSandbox has found the containers missing, so a
+	// record of a previous successful creation describes resources that are no
+	// longer there. Left in place it would resume straight to success and the
+	// sandbox would never be rebuilt, which the old overwrite-on-start hid.
+	if err := saga.DropIfCompleted(ctx, s.storage, execID); err != nil {
+		return fmt.Errorf("clearing stale creation record: %w", err)
+	}
+
 	err := s.executor.Start(sagaCreateSandbox).
 		Input("sandbox_id", co.ID.String()).
-		WithID(fmt.Sprintf("create-sandbox-%s", co.ID)).
+		WithID(execID).
 		Execute(ctx)
 
 	if errors.Is(err, saga.ErrExecutionInProgress) {

--- a/controllers/sandbox/saga_controller.go
+++ b/controllers/sandbox/saga_controller.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -170,6 +171,15 @@ func (s *SagaSandboxController) createSandboxViaSaga(ctx context.Context, co *co
 		Input("sandbox_id", co.ID.String()).
 		WithID(fmt.Sprintf("create-sandbox-%s", co.ID)).
 		Execute(ctx)
+
+	if errors.Is(err, saga.ErrExecutionInProgress) {
+		// This controller keeps one executor for its lifetime, so the claim is
+		// real here: an earlier pass is still driving this creation. Nothing
+		// has failed, so leave the sandbox PENDING for the reconciler rather
+		// than killing it over work that is still going.
+		s.log.Debug("sandbox creation already in flight", "id", co.ID)
+		return nil
+	}
 
 	if err != nil {
 		s.log.Error("saga sandbox creation failed, marking DEAD", "id", co.ID, "error", err)

--- a/pkg/addon/memcache/dedicated.go
+++ b/pkg/addon/memcache/dedicated.go
@@ -30,10 +30,6 @@ func memcacheContainerPorts() []compute_v1alpha.SandboxSpecContainerPort {
 	}
 }
 
-type resultCapture struct {
-	Result *addon.ProvisionResult
-}
-
 // --- Dedicated Provisioning Saga Actions ---
 
 type GenerateNamesIn struct {
@@ -174,41 +170,10 @@ func UndoUpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn, 
 	return nil
 }
 
-type BuildDedicatedResultIn struct {
-	ServiceHost string    `saga:"servicehost"`
-	ServerID    entity.Id `saga:"serverid"`
-}
-
-type BuildDedicatedResultOut struct {
-	Done bool
-}
-
-func BuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn) (BuildDedicatedResultOut, error) {
-	rc := saga.Get[*resultCapture](ctx)
-
-	envVars := buildEnvVars(in.ServiceHost, memcachePort)
-
-	dedicatedData := &addon_v1alpha.MemcacheDedicatedData{
-		MemcacheServer: in.ServerID,
-	}
-
-	rc.Result = &addon.ProvisionResult{
-		EnvVars: envVars,
-		Attrs:   dedicatedData.Encode(),
-	}
-
-	return BuildDedicatedResultOut{Done: true}, nil
-}
-
-func UndoBuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn, out BuildDedicatedResultOut) error {
-	return nil
-}
-
-func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
 	cfg := &dbsaga.AddonConfig{AddonName: AddonName, Port: memcachePort, ReadyTimeout: poolReadyTimeout}
 	return saga.Define("provision-dedicated-memcache").
 		Using(fw).
-		Using(rc).
 		Using(cfg).
 		Action(GenerateNames).Undo(UndoGenerateNames).
 		Action(CreateMemcacheServer).Undo(UndoCreateMemcacheServer).
@@ -217,7 +182,6 @@ func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework,
 		Action(dbsaga.CreateDedicatedService).Undo(dbsaga.UndoCreateDedicatedService).
 		Action(dbsaga.WaitForDedicatedService).Undo(dbsaga.UndoWaitForDedicatedService).
 		Action(UpdateDedicatedServer).Undo(UndoUpdateDedicatedServer).
-		Action(BuildDedicatedResult).Undo(UndoBuildDedicatedResult).
 		RegisterTo(registry)
 }
 
@@ -316,18 +280,18 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		"app", app.Name,
 		"variant", variant.Name)
 
-	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterDedicatedSaga(registry, p.Fw, rc); err != nil {
+	if err := RegisterDedicatedSaga(registry, p.Fw); err != nil {
 		return nil, fmt.Errorf("registering dedicated saga: %w", err)
 	}
 
 	storage := p.Fw.Storage
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
+	execID := addon.ProvisionExecutionID(assoc.ID)
 	err := executor.Start("provision-dedicated-memcache").
-		WithID(addon.ProvisionExecutionID(assoc.ID)).
+		WithID(execID).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -336,12 +300,32 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		return nil, err
 	}
 
-	if rc.Result == nil {
-		return nil, fmt.Errorf("saga completed but no result was captured")
+	// Read the answer back out of the execution rather than out of a struct the
+	// run filled in, so a saga that finished on an earlier pass still yields one.
+	out, err := executor.ExecutionOutputs(ctx, execID)
+	if err != nil {
+		return nil, fmt.Errorf("reading provisioning outputs: %w", err)
 	}
 
-	p.Log.Info("dedicated Memcached provisioned", "app", app.Name)
-	return rc.Result, nil
+	var host string
+	var serverID entity.Id
+
+	for key, target := range map[string]any{
+		"servicehost": &host,
+		"serverid":    &serverID,
+	} {
+		if err := out.Get(key, target); err != nil {
+			return nil, fmt.Errorf("reading %s from provisioning outputs: %w", key, err)
+		}
+	}
+
+	p.Log.Info("dedicated Memcache provisioned", "app", app.Name)
+	return &addon.ProvisionResult{
+		EnvVars: buildEnvVars(host, memcachePort),
+		Attrs: (&addon_v1alpha.MemcacheDedicatedData{
+			MemcacheServer: serverID,
+		}).Encode(),
+	}, nil
 }
 
 func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/memcache/dedicated.go
+++ b/pkg/addon/memcache/dedicated.go
@@ -311,7 +311,7 @@ func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.Provide
 		RegisterTo(registry)
 }
 
-func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	p.Log.Info("provisioning dedicated Memcached",
 		"app", app.Name,
 		"variant", variant.Name)
@@ -327,6 +327,7 @@ func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, varian
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-dedicated-memcache").
+		WithID(addon.ProvisionExecutionID(assoc.ID)).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -356,6 +357,7 @@ func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAs
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-dedicated-memcache").
+		WithID(addon.DeprovisionExecutionID(assoc.ID)).
 		Input("assocentity", assoc.Entity).
 		Execute(ctx)
 	if err != nil {

--- a/pkg/addon/memcache/dedicated_test.go
+++ b/pkg/addon/memcache/dedicated_test.go
@@ -13,15 +13,14 @@ import (
 func TestRegisterDedicatedSaga(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-memcache")
 	require.True(t, ok)
 	assert.Equal(t, "provision-dedicated-memcache", def.Name)
-	assert.Len(t, def.Actions, 8)
+	assert.Len(t, def.Actions, 7)
 }
 
 func TestRegisterDeprovisionDedicatedSaga(t *testing.T) {
@@ -72,27 +71,26 @@ func TestDeprovisionDedicatedSagaOrder(t *testing.T) {
 func TestDedicatedSagaActionOrder(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-memcache")
 	require.True(t, ok)
 
-	expectedActions := []string{
+	// Order comes from the data dependencies between actions, not from the order
+	// they were registered in. Worth pinning rather than just asserting
+	// membership: deleting an action, as dropping the result-building step did,
+	// changes the graph the topological sort reads.
+	expectedOrder := []string{
 		"generate-names",
-		"create-memcache-server",
 		"create-dedicated-pool",
-		"wait-for-dedicated-pool",
 		"create-dedicated-service",
+		"create-memcache-server",
+		"wait-for-dedicated-pool",
 		"wait-for-dedicated-service",
 		"update-dedicated-server",
-		"build-dedicated-result",
 	}
 
-	for _, name := range expectedActions {
-		_, exists := def.Actions[name]
-		assert.True(t, exists, "expected action %q to exist", name)
-	}
+	assert.Equal(t, expectedOrder, def.ExecutionOrder())
 }

--- a/pkg/addon/memcache/provider.go
+++ b/pkg/addon/memcache/provider.go
@@ -22,8 +22,8 @@ func NewProvider(fw *addon.ProviderFramework) *Provider {
 	}
 }
 
-func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
-	return p.provisionDedicated(ctx, app, variant)
+func (p *Provider) Provision(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+	return p.provisionDedicated(ctx, assoc, app, variant)
 }
 
 func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/mysql/dedicated.go
+++ b/pkg/addon/mysql/dedicated.go
@@ -27,10 +27,6 @@ func mysqlContainerPorts() []compute_v1alpha.SandboxSpecContainerPort {
 	}
 }
 
-type resultCapture struct {
-	Result *addon.ProvisionResult
-}
-
 // --- Dedicated Provisioning Saga Actions ---
 
 type GenerateCredentialsIn struct {
@@ -215,46 +211,10 @@ func UndoUpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn, 
 	return nil
 }
 
-type BuildDedicatedResultIn struct {
-	ServiceHost  string    `saga:"servicehost"`
-	Username     string    `saga:"username"`
-	Password     string    `saga:"password"`
-	DatabaseName string    `saga:"databasename"`
-	ServerID     entity.Id `saga:"serverid"`
-}
-
-type BuildDedicatedResultOut struct {
-	Done bool
-}
-
-func BuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn) (BuildDedicatedResultOut, error) {
-	rc := saga.Get[*resultCapture](ctx)
-
-	envVars := buildEnvVars(in.ServiceHost, mysqlPort, in.Username, in.Password, in.DatabaseName)
-
-	dedicatedData := &addon_v1alpha.MysqlDedicatedData{
-		MysqlServer:  in.ServerID,
-		DatabaseName: in.DatabaseName,
-		Username:     in.Username,
-	}
-
-	rc.Result = &addon.ProvisionResult{
-		EnvVars: envVars,
-		Attrs:   dedicatedData.Encode(),
-	}
-
-	return BuildDedicatedResultOut{Done: true}, nil
-}
-
-func UndoBuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn, out BuildDedicatedResultOut) error {
-	return nil
-}
-
-func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
 	cfg := &dbsaga.AddonConfig{AddonName: AddonName, Port: mysqlPort, ReadyTimeout: poolReadyTimeout}
 	return saga.Define("provision-dedicated-mysql").
 		Using(fw).
-		Using(rc).
 		Using(cfg).
 		Action(GenerateCredentials).Undo(UndoGenerateCredentials).
 		Action(CreateMysqlServer).Undo(UndoCreateMysqlServer).
@@ -263,7 +223,6 @@ func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework,
 		Action(dbsaga.CreateDedicatedService).Undo(dbsaga.UndoCreateDedicatedService).
 		Action(dbsaga.WaitForDedicatedService).Undo(dbsaga.UndoWaitForDedicatedService).
 		Action(UpdateDedicatedServer).Undo(UndoUpdateDedicatedServer).
-		Action(BuildDedicatedResult).Undo(UndoBuildDedicatedResult).
 		RegisterTo(registry)
 }
 
@@ -376,18 +335,18 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		"app", app.Name,
 		"variant", variant.Name)
 
-	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterDedicatedSaga(registry, p.Fw, rc); err != nil {
+	if err := RegisterDedicatedSaga(registry, p.Fw); err != nil {
 		return nil, fmt.Errorf("registering dedicated saga: %w", err)
 	}
 
 	storage := p.Fw.Storage
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
+	execID := addon.ProvisionExecutionID(assoc.ID)
 	err := executor.Start("provision-dedicated-mysql").
-		WithID(addon.ProvisionExecutionID(assoc.ID)).
+		WithID(execID).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -396,12 +355,37 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		return nil, err
 	}
 
-	if rc.Result == nil {
-		return nil, fmt.Errorf("saga completed but no result was captured")
+	// Read the answer back out of the execution rather than out of a struct the
+	// run filled in, so a saga that finished on an earlier pass still yields one.
+	out, err := executor.ExecutionOutputs(ctx, execID)
+	if err != nil {
+		return nil, fmt.Errorf("reading provisioning outputs: %w", err)
+	}
+
+	var host, username, password, dbName string
+	var serverID entity.Id
+
+	for key, target := range map[string]any{
+		"servicehost":  &host,
+		"username":     &username,
+		"password":     &password,
+		"databasename": &dbName,
+		"serverid":     &serverID,
+	} {
+		if err := out.Get(key, target); err != nil {
+			return nil, fmt.Errorf("reading %s from provisioning outputs: %w", key, err)
+		}
 	}
 
 	p.Log.Info("dedicated MySQL provisioned", "app", app.Name)
-	return rc.Result, nil
+	return &addon.ProvisionResult{
+		EnvVars: buildEnvVars(host, mysqlPort, username, password, dbName),
+		Attrs: (&addon_v1alpha.MysqlDedicatedData{
+			MysqlServer:  serverID,
+			DatabaseName: dbName,
+			Username:     username,
+		}).Encode(),
+	}, nil
 }
 
 func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/mysql/dedicated.go
+++ b/pkg/addon/mysql/dedicated.go
@@ -371,7 +371,7 @@ func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.Provide
 		RegisterTo(registry)
 }
 
-func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	p.Log.Info("provisioning dedicated MySQL",
 		"app", app.Name,
 		"variant", variant.Name)
@@ -387,6 +387,7 @@ func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, varian
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-dedicated-mysql").
+		WithID(addon.ProvisionExecutionID(assoc.ID)).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -416,6 +417,7 @@ func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAs
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-dedicated-mysql").
+		WithID(addon.DeprovisionExecutionID(assoc.ID)).
 		Input("assocentity", assoc.Entity).
 		Execute(ctx)
 	if err != nil {

--- a/pkg/addon/mysql/dedicated_test.go
+++ b/pkg/addon/mysql/dedicated_test.go
@@ -13,15 +13,14 @@ import (
 func TestRegisterDedicatedSaga(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-mysql")
 	require.True(t, ok)
 	assert.Equal(t, "provision-dedicated-mysql", def.Name)
-	assert.Len(t, def.Actions, 8)
+	assert.Len(t, def.Actions, 7)
 }
 
 func TestRegisterDeprovisionDedicatedSaga(t *testing.T) {
@@ -72,27 +71,26 @@ func TestDeprovisionDedicatedSagaOrder(t *testing.T) {
 func TestDedicatedSagaActionOrder(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-mysql")
 	require.True(t, ok)
 
-	expectedActions := []string{
+	// Order comes from the data dependencies between actions, not from the order
+	// they were registered in. Worth pinning rather than just asserting
+	// membership: deleting an action, as dropping the result-building step did,
+	// changes the graph the topological sort reads.
+	expectedOrder := []string{
 		"generate-credentials",
-		"create-mysql-server",
 		"create-dedicated-pool",
-		"wait-for-dedicated-pool",
 		"create-dedicated-service",
+		"create-mysql-server",
+		"wait-for-dedicated-pool",
 		"wait-for-dedicated-service",
 		"update-dedicated-server",
-		"build-dedicated-result",
 	}
 
-	for _, name := range expectedActions {
-		_, exists := def.Actions[name]
-		assert.True(t, exists, "expected action %q to exist", name)
-	}
+	assert.Equal(t, expectedOrder, def.ExecutionOrder())
 }

--- a/pkg/addon/mysql/provider.go
+++ b/pkg/addon/mysql/provider.go
@@ -22,11 +22,11 @@ func NewProvider(fw *addon.ProviderFramework) *Provider {
 	}
 }
 
-func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *Provider) Provision(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	if IsSharedVariant(variant.Name) {
-		return p.provisionShared(ctx, app, variant)
+		return p.provisionShared(ctx, assoc, app, variant)
 	}
-	return p.provisionDedicated(ctx, app, variant)
+	return p.provisionDedicated(ctx, assoc, app, variant)
 }
 
 func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/mysql/rotate_integration_test.go
+++ b/pkg/addon/mysql/rotate_integration_test.go
@@ -110,7 +110,7 @@ func TestMySQL_Integration(t *testing.T) {
 
 	// --- Shared ---
 
-	sharedProv, err := provider.Provision(ctx, addon.App{Name: "myshared-app"}, addon.Variant{Name: "shared"})
+	sharedProv, err := provider.Provision(ctx, addon.AddonAssociation{ID: "assoc-myshared"}, addon.App{Name: "myshared-app"}, addon.Variant{Name: "shared"})
 	require.NoError(t, err)
 	require.NotNil(t, sharedProv)
 	sharedEnv := envMap(sharedProv.EnvVars)
@@ -168,7 +168,7 @@ func TestMySQL_Integration(t *testing.T) {
 
 	// --- Dedicated ---
 
-	dedProv, err := provider.Provision(ctx, addon.App{Name: "myded-app"}, addon.Variant{Name: "small"})
+	dedProv, err := provider.Provision(ctx, addon.AddonAssociation{ID: "assoc-myded"}, addon.App{Name: "myded-app"}, addon.Variant{Name: "small"})
 	require.NoError(t, err)
 	require.NotNil(t, dedProv)
 	dedEnv := envMap(dedProv.EnvVars)
@@ -241,7 +241,7 @@ func TestMySQL_Integration(t *testing.T) {
 	// consumes the old password only fires on saga failure, which this happy-path
 	// wire test does not force; the read that feeds it is exercised here.)
 
-	legacyProv, err := provider.Provision(ctx, addon.App{Name: "mylegacy-app"}, addon.Variant{Name: "small"})
+	legacyProv, err := provider.Provision(ctx, addon.AddonAssociation{ID: "assoc-mylegacy"}, addon.App{Name: "mylegacy-app"}, addon.Variant{Name: "small"})
 	require.NoError(t, err)
 	require.NotNil(t, legacyProv)
 	legacyEnv := envMap(legacyProv.EnvVars)

--- a/pkg/addon/mysql/shared.go
+++ b/pkg/addon/mysql/shared.go
@@ -454,42 +454,7 @@ func UndoCreateSharedDatabase(ctx context.Context, in CreateSharedDatabaseIn, ou
 	return dropMysqlDatabase(ctx, db, in.SharedDatabaseName)
 }
 
-type BuildSharedResultIn struct {
-	ServerID           entity.Id
-	ServiceHost        string
-	SharedDatabaseName string
-	SharedUsername     string
-	SharedPassword     string
-}
-
-type BuildSharedResultOut struct {
-	Done bool
-}
-
-func BuildSharedResult(ctx context.Context, in BuildSharedResultIn) (BuildSharedResultOut, error) {
-	rc := saga.Get[*resultCapture](ctx)
-
-	envVars := buildEnvVars(in.ServiceHost, mysqlPort, in.SharedUsername, in.SharedPassword, in.SharedDatabaseName)
-
-	sharedData := &addon_v1alpha.MysqlSharedData{
-		MysqlServer:  in.ServerID,
-		DatabaseName: in.SharedDatabaseName,
-		Username:     in.SharedUsername,
-	}
-
-	rc.Result = &addon.ProvisionResult{
-		EnvVars: envVars,
-		Attrs:   sharedData.Encode(),
-	}
-
-	return BuildSharedResultOut{Done: true}, nil
-}
-
-func UndoBuildSharedResult(ctx context.Context, in BuildSharedResultIn, out BuildSharedResultOut) error {
-	return nil
-}
-
-func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
 	if err := RegisterEnsureSharedServerSaga(registry, fw); err != nil {
 		return err
 	}
@@ -497,7 +462,6 @@ func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc
 	cfg := &dbsaga.AddonConfig{AddonName: AddonName, SharedServerName: sharedServerName, Port: mysqlPort, ReadyTimeout: poolReadyTimeout}
 	b := saga.Define("provision-shared-mysql").
 		Using(fw).
-		Using(rc).
 		Using(cfg)
 	saga.UsingAs[dbsaga.ServerCounter](b, mysqlServerCounter{})
 	return b.
@@ -506,7 +470,6 @@ func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc
 		Action(CreateSharedUser).Undo(UndoCreateSharedUser).
 		Action(CreateSharedDatabase).Undo(UndoCreateSharedDatabase).
 		Action(dbsaga.IncrementAssociationCount).Undo(dbsaga.UndoIncrementAssociationCount).
-		Action(BuildSharedResult).Undo(UndoBuildSharedResult).
 		RegisterTo(registry)
 }
 
@@ -737,18 +700,18 @@ func (p *Provider) provisionShared(ctx context.Context, assoc addon.AddonAssocia
 		"app", app.Name,
 		"variant", variant.Name)
 
-	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterSharedSaga(registry, p.Fw, rc); err != nil {
+	if err := RegisterSharedSaga(registry, p.Fw); err != nil {
 		return nil, fmt.Errorf("registering shared saga: %w", err)
 	}
 
 	storage := p.Fw.Storage
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
+	execID := addon.ProvisionExecutionID(assoc.ID)
 	err := executor.Start("provision-shared-mysql").
-		WithID(addon.ProvisionExecutionID(assoc.ID)).
+		WithID(execID).
 		Input("appname", app.Name).
 		Input("variantconfig", variant.Config).
 		Execute(ctx)
@@ -756,12 +719,37 @@ func (p *Provider) provisionShared(ctx context.Context, assoc addon.AddonAssocia
 		return nil, err
 	}
 
-	if rc.Result == nil {
-		return nil, fmt.Errorf("saga completed but no result was captured")
+	// Read the answer back out of the execution rather than out of a struct the
+	// run filled in, so a saga that finished on an earlier pass still yields one.
+	out, err := executor.ExecutionOutputs(ctx, execID)
+	if err != nil {
+		return nil, fmt.Errorf("reading provisioning outputs: %w", err)
+	}
+
+	var host, username, password, dbName string
+	var serverID entity.Id
+
+	for key, target := range map[string]any{
+		"servicehost":        &host,
+		"sharedusername":     &username,
+		"sharedpassword":     &password,
+		"shareddatabasename": &dbName,
+		"serverid":           &serverID,
+	} {
+		if err := out.Get(key, target); err != nil {
+			return nil, fmt.Errorf("reading %s from provisioning outputs: %w", key, err)
+		}
 	}
 
 	p.Log.Info("shared MySQL provisioned", "app", app.Name)
-	return rc.Result, nil
+	return &addon.ProvisionResult{
+		EnvVars: buildEnvVars(host, mysqlPort, username, password, dbName),
+		Attrs: (&addon_v1alpha.MysqlSharedData{
+			MysqlServer:  serverID,
+			DatabaseName: dbName,
+			Username:     username,
+		}).Encode(),
+	}, nil
 }
 
 func (p *Provider) deprovisionShared(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/mysql/shared.go
+++ b/pkg/addon/mysql/shared.go
@@ -732,7 +732,7 @@ func RegisterDeprovisionSharedSaga(registry *saga.Registry, fw *addon.ProviderFr
 		RegisterTo(registry)
 }
 
-func (p *Provider) provisionShared(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *Provider) provisionShared(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	p.Log.Info("provisioning shared MySQL",
 		"app", app.Name,
 		"variant", variant.Name)
@@ -748,6 +748,7 @@ func (p *Provider) provisionShared(ctx context.Context, app addon.App, variant a
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-shared-mysql").
+		WithID(addon.ProvisionExecutionID(assoc.ID)).
 		Input("appname", app.Name).
 		Input("variantconfig", variant.Config).
 		Execute(ctx)
@@ -776,6 +777,7 @@ func (p *Provider) deprovisionShared(ctx context.Context, assoc addon.AddonAssoc
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-shared-mysql").
+		WithID(addon.DeprovisionExecutionID(assoc.ID)).
 		Input("assocentity", assoc.Entity).
 		Execute(ctx)
 	if err != nil {

--- a/pkg/addon/mysql/shared_test.go
+++ b/pkg/addon/mysql/shared_test.go
@@ -13,15 +13,14 @@ import (
 func TestRegisterSharedSaga(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterSharedSaga(registry, fw, rc)
+	err := RegisterSharedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-shared-mysql")
 	require.True(t, ok)
 	assert.Equal(t, "provision-shared-mysql", def.Name)
-	assert.Len(t, def.Actions, 6)
+	assert.Len(t, def.Actions, 5)
 }
 
 func TestRegisterEnsureSharedServerSaga(t *testing.T) {

--- a/pkg/addon/postgresql/dedicated.go
+++ b/pkg/addon/postgresql/dedicated.go
@@ -385,7 +385,7 @@ func sanitizeIdentifier(name string) string {
 	return addon.SanitizeIdentifier(name, maxPgIdentLen)
 }
 
-func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	p.Log.Info("provisioning dedicated PostgreSQL",
 		"app", app.Name,
 		"variant", variant.Name)
@@ -401,6 +401,7 @@ func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, varian
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-dedicated-postgresql").
+		WithID(addon.ProvisionExecutionID(assoc.ID)).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -430,6 +431,7 @@ func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAs
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-dedicated-postgresql").
+		WithID(addon.DeprovisionExecutionID(assoc.ID)).
 		Input("assocentity", assoc.Entity).
 		Execute(ctx)
 	if err != nil {

--- a/pkg/addon/postgresql/dedicated.go
+++ b/pkg/addon/postgresql/dedicated.go
@@ -27,12 +27,6 @@ func postgresContainerPorts() []compute_v1alpha.SandboxSpecContainerPort {
 	}
 }
 
-// resultCapture is injected as a saga dependency so the final action
-// can pass the ProvisionResult back to the caller.
-type resultCapture struct {
-	Result *addon.ProvisionResult
-}
-
 // --- Dedicated Provisioning Saga Actions ---
 
 type GenerateCredentialsIn struct {
@@ -213,48 +207,11 @@ func UndoUpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn, 
 	return nil
 }
 
-type BuildDedicatedResultIn struct {
-	ServiceHost  string
-	Username     string
-	Password     string
-	DatabaseName string
-	ServerID     entity.Id
-}
-
-type BuildDedicatedResultOut struct {
-	Done bool
-}
-
-func BuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn) (BuildDedicatedResultOut, error) {
-	rc := saga.Get[*resultCapture](ctx)
-
-	host := in.ServiceHost
-	envVars := buildEnvVars(host, postgresPort, in.Username, in.Password, in.DatabaseName)
-
-	dedicatedData := &addon_v1alpha.PostgresqlDedicatedData{
-		PostgresServer: in.ServerID,
-		DatabaseName:   in.DatabaseName,
-		Username:       in.Username,
-	}
-
-	rc.Result = &addon.ProvisionResult{
-		EnvVars: envVars,
-		Attrs:   dedicatedData.Encode(),
-	}
-
-	return BuildDedicatedResultOut{Done: true}, nil
-}
-
-func UndoBuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn, out BuildDedicatedResultOut) error {
-	return nil
-}
-
 // RegisterDedicatedSaga registers the dedicated PostgreSQL provisioning saga.
-func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
 	cfg := &dbsaga.AddonConfig{AddonName: AddonName, Port: postgresPort, ReadyTimeout: poolReadyTimeout}
 	return saga.Define("provision-dedicated-postgresql").
 		Using(fw).
-		Using(rc).
 		Using(cfg).
 		Action(GenerateCredentials).Undo(UndoGenerateCredentials).
 		Action(CreatePostgresServer).Undo(UndoCreatePostgresServer).
@@ -263,7 +220,6 @@ func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework,
 		Action(dbsaga.CreateDedicatedService).Undo(dbsaga.UndoCreateDedicatedService).
 		Action(dbsaga.WaitForDedicatedService).Undo(dbsaga.UndoWaitForDedicatedService).
 		Action(UpdateDedicatedServer).Undo(UndoUpdateDedicatedServer).
-		Action(BuildDedicatedResult).Undo(UndoBuildDedicatedResult).
 		RegisterTo(registry)
 }
 
@@ -390,18 +346,18 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		"app", app.Name,
 		"variant", variant.Name)
 
-	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterDedicatedSaga(registry, p.Fw, rc); err != nil {
+	if err := RegisterDedicatedSaga(registry, p.Fw); err != nil {
 		return nil, fmt.Errorf("registering dedicated saga: %w", err)
 	}
 
 	storage := p.Fw.Storage
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
+	execID := addon.ProvisionExecutionID(assoc.ID)
 	err := executor.Start("provision-dedicated-postgresql").
-		WithID(addon.ProvisionExecutionID(assoc.ID)).
+		WithID(execID).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -410,12 +366,38 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		return nil, err
 	}
 
-	if rc.Result == nil {
-		return nil, fmt.Errorf("saga completed but no result was captured")
+	// Read the answer back out of the execution rather than out of a struct the
+	// run filled in. A saga that finished on an earlier pass leaves nothing in
+	// memory here, so anything held only in memory would be missing exactly
+	// when a crash made us re-enter.
+	out, err := executor.ExecutionOutputs(ctx, execID)
+	if err != nil {
+		return nil, fmt.Errorf("reading provisioning outputs: %w", err)
+	}
+
+	var host, username, password, dbName string
+	var serverID entity.Id
+	for key, target := range map[string]any{
+		"servicehost":  &host,
+		"username":     &username,
+		"password":     &password,
+		"databasename": &dbName,
+		"serverid":     &serverID,
+	} {
+		if err := out.Get(key, target); err != nil {
+			return nil, fmt.Errorf("reading %s from provisioning outputs: %w", key, err)
+		}
 	}
 
 	p.Log.Info("dedicated PostgreSQL provisioned", "app", app.Name)
-	return rc.Result, nil
+	return &addon.ProvisionResult{
+		EnvVars: buildEnvVars(host, postgresPort, username, password, dbName),
+		Attrs: (&addon_v1alpha.PostgresqlDedicatedData{
+			PostgresServer: serverID,
+			DatabaseName:   dbName,
+			Username:       username,
+		}).Encode(),
+	}, nil
 }
 
 func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/postgresql/dedicated_test.go
+++ b/pkg/addon/postgresql/dedicated_test.go
@@ -13,15 +13,14 @@ import (
 func TestRegisterDedicatedSaga(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-postgresql")
 	require.True(t, ok)
 	assert.Equal(t, "provision-dedicated-postgresql", def.Name)
-	assert.Len(t, def.Actions, 8)
+	assert.Len(t, def.Actions, 7)
 }
 
 func TestRegisterDeprovisionDedicatedSaga(t *testing.T) {
@@ -73,28 +72,26 @@ func TestDeprovisionDedicatedSagaOrder(t *testing.T) {
 func TestDedicatedSagaActionOrder(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-postgresql")
 	require.True(t, ok)
 
-	// Verify that all expected actions are present
-	expectedActions := []string{
+	// Order comes from the data dependencies between actions, not from the order
+	// they were registered in. Worth pinning rather than just asserting
+	// membership: deleting an action, as dropping the result-building step did,
+	// changes the graph the topological sort reads.
+	expectedOrder := []string{
 		"generate-credentials",
-		"create-postgres-server",
 		"create-dedicated-pool",
-		"wait-for-dedicated-pool",
 		"create-dedicated-service",
+		"create-postgres-server",
+		"wait-for-dedicated-pool",
 		"wait-for-dedicated-service",
 		"update-dedicated-server",
-		"build-dedicated-result",
 	}
 
-	for _, name := range expectedActions {
-		_, exists := def.Actions[name]
-		assert.True(t, exists, "expected action %q to exist", name)
-	}
+	assert.Equal(t, expectedOrder, def.ExecutionOrder())
 }

--- a/pkg/addon/postgresql/provider.go
+++ b/pkg/addon/postgresql/provider.go
@@ -24,11 +24,11 @@ func NewProvider(fw *addon.ProviderFramework) *Provider {
 	}
 }
 
-func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *Provider) Provision(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	if IsSharedVariant(variant.Name) {
-		return p.provisionShared(ctx, app, variant)
+		return p.provisionShared(ctx, assoc, app, variant)
 	}
-	return p.provisionDedicated(ctx, app, variant)
+	return p.provisionDedicated(ctx, assoc, app, variant)
 }
 
 func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/postgresql/shared.go
+++ b/pkg/addon/postgresql/shared.go
@@ -499,44 +499,9 @@ func UndoCreateSharedDatabase(ctx context.Context, in CreateSharedDatabaseIn, ou
 
 // Step 6: Build the ProvisionResult.
 
-type BuildSharedResultIn struct {
-	ServerID           entity.Id
-	ServiceHost        string
-	SharedDatabaseName string
-	SharedUsername     string
-	SharedPassword     string
-}
-
-type BuildSharedResultOut struct {
-	Done bool
-}
-
-func BuildSharedResult(ctx context.Context, in BuildSharedResultIn) (BuildSharedResultOut, error) {
-	rc := saga.Get[*resultCapture](ctx)
-
-	envVars := buildEnvVars(in.ServiceHost, postgresPort, in.SharedUsername, in.SharedPassword, in.SharedDatabaseName)
-
-	sharedData := &addon_v1alpha.PostgresqlSharedData{
-		PostgresServer: in.ServerID,
-		DatabaseName:   in.SharedDatabaseName,
-		Username:       in.SharedUsername,
-	}
-
-	rc.Result = &addon.ProvisionResult{
-		EnvVars: envVars,
-		Attrs:   sharedData.Encode(),
-	}
-
-	return BuildSharedResultOut{Done: true}, nil
-}
-
-func UndoBuildSharedResult(ctx context.Context, in BuildSharedResultIn, out BuildSharedResultOut) error {
-	return nil
-}
-
 // RegisterSharedSaga registers the shared PostgreSQL provisioning saga.
 // This also registers the nested ensure-shared-server saga in the same registry.
-func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
 	if err := RegisterEnsureSharedServerSaga(registry, fw); err != nil {
 		return err
 	}
@@ -544,7 +509,6 @@ func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc
 	cfg := &dbsaga.AddonConfig{AddonName: AddonName, SharedServerName: sharedServerName, Port: postgresPort, ReadyTimeout: poolReadyTimeout}
 	b := saga.Define("provision-shared-postgresql").
 		Using(fw).
-		Using(rc).
 		Using(cfg)
 	saga.UsingAs[dbsaga.ServerCounter](b, pgServerCounter{})
 	return b.
@@ -553,7 +517,6 @@ func RegisterSharedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc
 		Action(CreateSharedUser).Undo(UndoCreateSharedUser).
 		Action(CreateSharedDatabase).Undo(UndoCreateSharedDatabase).
 		Action(dbsaga.IncrementAssociationCount).Undo(dbsaga.UndoIncrementAssociationCount).
-		Action(BuildSharedResult).Undo(UndoBuildSharedResult).
 		RegisterTo(registry)
 }
 
@@ -788,18 +751,18 @@ func (p *Provider) provisionShared(ctx context.Context, assoc addon.AddonAssocia
 		"app", app.Name,
 		"variant", variant.Name)
 
-	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterSharedSaga(registry, p.Fw, rc); err != nil {
+	if err := RegisterSharedSaga(registry, p.Fw); err != nil {
 		return nil, fmt.Errorf("registering shared saga: %w", err)
 	}
 
 	storage := p.Fw.Storage
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
+	execID := addon.ProvisionExecutionID(assoc.ID)
 	err := executor.Start("provision-shared-postgresql").
-		WithID(addon.ProvisionExecutionID(assoc.ID)).
+		WithID(execID).
 		Input("appname", app.Name).
 		Input("variantconfig", variant.Config).
 		Execute(ctx)
@@ -807,12 +770,37 @@ func (p *Provider) provisionShared(ctx context.Context, assoc addon.AddonAssocia
 		return nil, err
 	}
 
-	if rc.Result == nil {
-		return nil, fmt.Errorf("saga completed but no result was captured")
+	// Read the answer back out of the execution rather than out of a struct the
+	// run filled in, so a saga that finished on an earlier pass still yields
+	// one.
+	out, err := executor.ExecutionOutputs(ctx, execID)
+	if err != nil {
+		return nil, fmt.Errorf("reading provisioning outputs: %w", err)
+	}
+
+	var host, username, password, dbName string
+	var serverID entity.Id
+	for key, target := range map[string]any{
+		"servicehost":        &host,
+		"sharedusername":     &username,
+		"sharedpassword":     &password,
+		"shareddatabasename": &dbName,
+		"serverid":           &serverID,
+	} {
+		if err := out.Get(key, target); err != nil {
+			return nil, fmt.Errorf("reading %s from provisioning outputs: %w", key, err)
+		}
 	}
 
 	p.Log.Info("shared PostgreSQL provisioned", "app", app.Name)
-	return rc.Result, nil
+	return &addon.ProvisionResult{
+		EnvVars: buildEnvVars(host, postgresPort, username, password, dbName),
+		Attrs: (&addon_v1alpha.PostgresqlSharedData{
+			PostgresServer: serverID,
+			DatabaseName:   dbName,
+			Username:       username,
+		}).Encode(),
+	}, nil
 }
 
 func (p *Provider) deprovisionShared(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/postgresql/shared.go
+++ b/pkg/addon/postgresql/shared.go
@@ -783,7 +783,7 @@ func RegisterDeprovisionSharedSaga(registry *saga.Registry, fw *addon.ProviderFr
 		RegisterTo(registry)
 }
 
-func (p *Provider) provisionShared(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *Provider) provisionShared(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	p.Log.Info("provisioning shared PostgreSQL",
 		"app", app.Name,
 		"variant", variant.Name)
@@ -799,6 +799,7 @@ func (p *Provider) provisionShared(ctx context.Context, app addon.App, variant a
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-shared-postgresql").
+		WithID(addon.ProvisionExecutionID(assoc.ID)).
 		Input("appname", app.Name).
 		Input("variantconfig", variant.Config).
 		Execute(ctx)
@@ -827,6 +828,7 @@ func (p *Provider) deprovisionShared(ctx context.Context, assoc addon.AddonAssoc
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-shared-postgresql").
+		WithID(addon.DeprovisionExecutionID(assoc.ID)).
 		Input("assocentity", assoc.Entity).
 		Execute(ctx)
 	if err != nil {

--- a/pkg/addon/postgresql/shared_integration_test.go
+++ b/pkg/addon/postgresql/shared_integration_test.go
@@ -142,7 +142,7 @@ func TestPostgreSQL_Integration(t *testing.T) {
 		app := addon.App{Name: "mytest-app"}
 		variant := addon.Variant{Name: "shared"}
 
-		provResult, err := provider.Provision(ctx, app, variant)
+		provResult, err := provider.Provision(ctx, addon.AddonAssociation{ID: entity.Id("assoc-" + app.Name)}, app, variant)
 		require.NoError(t, err)
 		require.NotNil(t, provResult, "provision result should be returned")
 		assert.NotEmpty(t, provResult.EnvVars, "env vars should be set")
@@ -190,7 +190,7 @@ func TestPostgreSQL_Integration(t *testing.T) {
 		require.NoError(t, err)
 		countBefore := serverBefore.AssociationCount
 
-		firstResult, err := provider.Provision(ctx, addon.App{Name: "first-app"}, variant)
+		firstResult, err := provider.Provision(ctx, addon.AddonAssociation{ID: "assoc-first"}, addon.App{Name: "first-app"}, variant)
 		require.NoError(t, err)
 		require.NotNil(t, firstResult)
 
@@ -201,7 +201,7 @@ func TestPostgreSQL_Integration(t *testing.T) {
 		firstServiceRef := serverAfterFirst.Service
 		assert.Equal(t, countBefore+1, serverAfterFirst.AssociationCount)
 
-		secondResult, err := provider.Provision(ctx, addon.App{Name: "second-app"}, variant)
+		secondResult, err := provider.Provision(ctx, addon.AddonAssociation{ID: "assoc-second"}, addon.App{Name: "second-app"}, variant)
 		require.NoError(t, err)
 		require.NotNil(t, secondResult)
 
@@ -229,7 +229,7 @@ func TestPostgreSQL_Integration(t *testing.T) {
 	t.Run("RotateDedicatedCredential", func(t *testing.T) {
 		provider := postgresql.NewProvider(fw)
 
-		provResult, err := provider.Provision(ctx, addon.App{Name: "dedrot-app"}, addon.Variant{Name: "small"})
+		provResult, err := provider.Provision(ctx, addon.AddonAssociation{ID: "assoc-dedrot"}, addon.App{Name: "dedrot-app"}, addon.Variant{Name: "small"})
 		require.NoError(t, err)
 		require.NotNil(t, provResult)
 
@@ -329,7 +329,7 @@ func TestPostgreSQL_Integration(t *testing.T) {
 	t.Run("RotateDedicatedCredential_LegacyFallback", func(t *testing.T) {
 		provider := postgresql.NewProvider(fw)
 
-		provResult, err := provider.Provision(ctx, addon.App{Name: "dedlegacy-app"}, addon.Variant{Name: "small"})
+		provResult, err := provider.Provision(ctx, addon.AddonAssociation{ID: "assoc-dedlegacy"}, addon.App{Name: "dedlegacy-app"}, addon.Variant{Name: "small"})
 		require.NoError(t, err)
 		require.NotNil(t, provResult)
 

--- a/pkg/addon/postgresql/shared_test.go
+++ b/pkg/addon/postgresql/shared_test.go
@@ -40,15 +40,14 @@ func TestRegisterEnsureSharedServerSaga(t *testing.T) {
 func TestRegisterSharedSaga(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterSharedSaga(registry, fw, rc)
+	err := RegisterSharedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-shared-postgresql")
 	require.True(t, ok)
 	assert.Equal(t, "provision-shared-postgresql", def.Name)
-	assert.Len(t, def.Actions, 6)
+	assert.Len(t, def.Actions, 5)
 }
 
 func TestRegisterDeprovisionSharedSaga(t *testing.T) {
@@ -67,9 +66,8 @@ func TestRegisterDeprovisionSharedSaga(t *testing.T) {
 func TestRegisterSharedSaga_IncludesNestedSaga(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterSharedSaga(registry, fw, rc)
+	err := RegisterSharedSaga(registry, fw)
 	require.NoError(t, err)
 
 	// The nested ensure-shared-server saga should also be registered
@@ -82,9 +80,8 @@ func TestRegisterSharedSaga_IncludesNestedSaga(t *testing.T) {
 func TestSharedSagaActionOrder(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterSharedSaga(registry, fw, rc)
+	err := RegisterSharedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-shared-postgresql")

--- a/pkg/addon/provider.go
+++ b/pkg/addon/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"miren.dev/runtime/api/addon/addon_v1alpha"
 	"miren.dev/runtime/pkg/entity"
 )
 
@@ -27,8 +28,11 @@ type AddonProvider interface {
 	LocalityMode() LocalityMode
 
 	// Provision creates the backing resources for an addon and returns the
-	// environment variables and entity attributes to store.
-	Provision(ctx context.Context, app App, variant Variant) (*ProvisionResult, error)
+	// environment variables and entity attributes to store. It takes the
+	// association so the work can be named after it, which is what lets a
+	// later pass continue an attempt a crash interrupted rather than start
+	// over on top of what it already built.
+	Provision(ctx context.Context, assoc AddonAssociation, app App, variant Variant) (*ProvisionResult, error)
 
 	// AdjustEnvVars is called when provisioned env vars collide with existing
 	// app env vars. The provider can rename or adjust variables.
@@ -92,13 +96,36 @@ type ProvisionResult struct {
 	Attrs   []entity.Attr
 }
 
-// AddonAssociation holds the state needed for deprovisioning.
+// AddonAssociation is the provider's view of an association: enough to name the
+// work after it, plus the entity so a teardown or rotation can read what an
+// earlier run recorded.
 type AddonAssociation struct {
 	ID      entity.Id
 	App     entity.Id
 	Addon   entity.Id
 	Variant string
-	Entity  *entity.Entity
+
+	// Read-only in practice, despite the type. Providers report writes by
+	// returning Attrs on a ProvisionResult, and a resumed saga could not write
+	// through this anyway: it arrives as a detached copy via JSON.
+	Entity *entity.Entity
+}
+
+// AssociationFrom builds the provider view from a decoded association and the
+// entity it came out of.
+//
+// NOTE for future cleanup: this type is a subset of
+// addon_v1alpha.AddonAssociation plus that entity. Passing the decoded
+// association through instead would delete the type, this function, and every
+// conversion at once.
+func AssociationFrom(assoc *addon_v1alpha.AddonAssociation, ent *entity.Entity) AddonAssociation {
+	return AddonAssociation{
+		ID:      assoc.ID,
+		App:     assoc.App,
+		Addon:   assoc.Addon,
+		Variant: assoc.Variant,
+		Entity:  ent,
+	}
 }
 
 // AddonDefinition describes an addon's metadata and available variants.
@@ -148,4 +175,23 @@ func NameFromRef(ref entity.Id) string {
 		}
 	}
 	return s
+}
+
+// ProvisionExecutionID and DeprovisionExecutionID name an association's saga
+// after the association itself. That is what lets a later reconcile pass
+// continue an attempt a crash interrupted, instead of starting a second one
+// alongside whatever the first already built.
+//
+// Two passes must not drive the same execution at once. The executor guards
+// against that within a single instance, but each operation here builds its
+// own, so what actually serializes association work is the reconcile
+// controller: it processes one event per entity at a time and queues the rest.
+// Anything that drives a provision from outside that loop would need its own
+// answer.
+func ProvisionExecutionID(assocID entity.Id) string {
+	return "provision-" + assocID.String()
+}
+
+func DeprovisionExecutionID(assocID entity.Id) string {
+	return "deprovision-" + assocID.String()
 }

--- a/pkg/addon/rabbitmq/dedicated.go
+++ b/pkg/addon/rabbitmq/dedicated.go
@@ -370,7 +370,7 @@ func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.Provide
 		RegisterTo(registry)
 }
 
-func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	p.Log.Info("provisioning dedicated RabbitMQ",
 		"app", app.Name,
 		"variant", variant.Name)
@@ -386,6 +386,7 @@ func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, varian
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-dedicated-rabbitmq").
+		WithID(addon.ProvisionExecutionID(assoc.ID)).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -415,6 +416,7 @@ func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAs
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-dedicated-rabbitmq").
+		WithID(addon.DeprovisionExecutionID(assoc.ID)).
 		Input("assocentity", assoc.Entity).
 		Execute(ctx)
 	if err != nil {

--- a/pkg/addon/rabbitmq/dedicated.go
+++ b/pkg/addon/rabbitmq/dedicated.go
@@ -33,10 +33,6 @@ func rabbitmqContainerPorts() []compute_v1alpha.SandboxSpecContainerPort {
 	}
 }
 
-type resultCapture struct {
-	Result *addon.ProvisionResult
-}
-
 // --- Dedicated Provisioning Saga Actions ---
 
 type GenerateCredentialsIn struct {
@@ -215,44 +211,10 @@ func UndoUpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn, 
 	return nil
 }
 
-type BuildDedicatedResultIn struct {
-	ServiceHost string    `saga:"servicehost"`
-	ServerID    entity.Id `saga:"serverid"`
-	Username    string    `saga:"username"`
-	Password    string    `saga:"password"`
-	Vhost       string    `saga:"vhost"`
-}
-
-type BuildDedicatedResultOut struct {
-	Done bool
-}
-
-func BuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn) (BuildDedicatedResultOut, error) {
-	rc := saga.Get[*resultCapture](ctx)
-
-	envVars := buildEnvVars(in.Username, in.Password, in.ServiceHost, rabbitmqPort, in.Vhost)
-
-	dedicatedData := &addon_v1alpha.RabbitmqDedicatedData{
-		RabbitmqServer: in.ServerID,
-	}
-
-	rc.Result = &addon.ProvisionResult{
-		EnvVars: envVars,
-		Attrs:   dedicatedData.Encode(),
-	}
-
-	return BuildDedicatedResultOut{Done: true}, nil
-}
-
-func UndoBuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn, out BuildDedicatedResultOut) error {
-	return nil
-}
-
-func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
 	cfg := &dbsaga.AddonConfig{AddonName: AddonName, Port: rabbitmqPort, ReadyTimeout: poolReadyTimeout}
 	return saga.Define("provision-dedicated-rabbitmq").
 		Using(fw).
-		Using(rc).
 		Using(cfg).
 		Action(GenerateCredentials).Undo(UndoGenerateCredentials).
 		Action(CreateRabbitmqServer).Undo(UndoCreateRabbitmqServer).
@@ -261,7 +223,6 @@ func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework,
 		Action(dbsaga.CreateDedicatedService).Undo(dbsaga.UndoCreateDedicatedService).
 		Action(dbsaga.WaitForDedicatedService).Undo(dbsaga.UndoWaitForDedicatedService).
 		Action(UpdateDedicatedServer).Undo(UndoUpdateDedicatedServer).
-		Action(BuildDedicatedResult).Undo(UndoBuildDedicatedResult).
 		RegisterTo(registry)
 }
 
@@ -375,18 +336,18 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		"app", app.Name,
 		"variant", variant.Name)
 
-	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterDedicatedSaga(registry, p.Fw, rc); err != nil {
+	if err := RegisterDedicatedSaga(registry, p.Fw); err != nil {
 		return nil, fmt.Errorf("registering dedicated saga: %w", err)
 	}
 
 	storage := p.Fw.Storage
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
+	execID := addon.ProvisionExecutionID(assoc.ID)
 	err := executor.Start("provision-dedicated-rabbitmq").
-		WithID(addon.ProvisionExecutionID(assoc.ID)).
+		WithID(execID).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -395,12 +356,35 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		return nil, err
 	}
 
-	if rc.Result == nil {
-		return nil, fmt.Errorf("saga completed but no result was captured")
+	// Read the answer back out of the execution rather than out of a struct the
+	// run filled in, so a saga that finished on an earlier pass still yields one.
+	out, err := executor.ExecutionOutputs(ctx, execID)
+	if err != nil {
+		return nil, fmt.Errorf("reading provisioning outputs: %w", err)
+	}
+
+	var host, username, password, vhost string
+	var serverID entity.Id
+
+	for key, target := range map[string]any{
+		"servicehost": &host,
+		"username":    &username,
+		"password":    &password,
+		"vhost":       &vhost,
+		"serverid":    &serverID,
+	} {
+		if err := out.Get(key, target); err != nil {
+			return nil, fmt.Errorf("reading %s from provisioning outputs: %w", key, err)
+		}
 	}
 
 	p.Log.Info("dedicated RabbitMQ provisioned", "app", app.Name)
-	return rc.Result, nil
+	return &addon.ProvisionResult{
+		EnvVars: buildEnvVars(username, password, host, rabbitmqPort, vhost),
+		Attrs: (&addon_v1alpha.RabbitmqDedicatedData{
+			RabbitmqServer: serverID,
+		}).Encode(),
+	}, nil
 }
 
 func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/rabbitmq/dedicated_test.go
+++ b/pkg/addon/rabbitmq/dedicated_test.go
@@ -13,15 +13,14 @@ import (
 func TestRegisterDedicatedSaga(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-rabbitmq")
 	require.True(t, ok)
 	assert.Equal(t, "provision-dedicated-rabbitmq", def.Name)
-	assert.Len(t, def.Actions, 8)
+	assert.Len(t, def.Actions, 7)
 }
 
 func TestRegisterDeprovisionDedicatedSaga(t *testing.T) {
@@ -74,27 +73,26 @@ func TestDeprovisionDedicatedSagaOrder(t *testing.T) {
 func TestDedicatedSagaActionOrder(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-rabbitmq")
 	require.True(t, ok)
 
-	expectedActions := []string{
+	// Order comes from the data dependencies between actions, not from the order
+	// they were registered in. Worth pinning rather than just asserting
+	// membership: deleting an action, as dropping the result-building step did,
+	// changes the graph the topological sort reads.
+	expectedOrder := []string{
 		"generate-credentials",
-		"create-rabbitmq-server",
 		"create-dedicated-pool",
-		"wait-for-dedicated-pool",
 		"create-dedicated-service",
+		"create-rabbitmq-server",
+		"wait-for-dedicated-pool",
 		"wait-for-dedicated-service",
 		"update-dedicated-server",
-		"build-dedicated-result",
 	}
 
-	for _, name := range expectedActions {
-		_, exists := def.Actions[name]
-		assert.True(t, exists, "expected action %q to exist", name)
-	}
+	assert.Equal(t, expectedOrder, def.ExecutionOrder())
 }

--- a/pkg/addon/rabbitmq/provider.go
+++ b/pkg/addon/rabbitmq/provider.go
@@ -23,8 +23,8 @@ func NewProvider(fw *addon.ProviderFramework) *Provider {
 	}
 }
 
-func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
-	return p.provisionDedicated(ctx, app, variant)
+func (p *Provider) Provision(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+	return p.provisionDedicated(ctx, assoc, app, variant)
 }
 
 func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/rabbitmq/rotate_integration_test.go
+++ b/pkg/addon/rabbitmq/rotate_integration_test.go
@@ -61,7 +61,7 @@ func TestRabbitMQ_Rotation_Integration(t *testing.T) {
 
 	provider := rabbitmq.NewProvider(fw)
 
-	prov, err := provider.Provision(ctx, addon.App{Name: "rmqrot-app"}, addon.Variant{Name: "small"})
+	prov, err := provider.Provision(ctx, addon.AddonAssociation{ID: "assoc-rmqrot"}, addon.App{Name: "rmqrot-app"}, addon.Variant{Name: "small"})
 	require.NoError(t, err)
 	require.NotNil(t, prov)
 

--- a/pkg/addon/registry_test.go
+++ b/pkg/addon/registry_test.go
@@ -38,7 +38,7 @@ type mockProvider struct{}
 func (m *mockProvider) LocalityMode() LocalityMode {
 	return OnCluster
 }
-func (m *mockProvider) Provision(ctx context.Context, app App, variant Variant) (*ProvisionResult, error) {
+func (m *mockProvider) Provision(ctx context.Context, _ AddonAssociation, app App, variant Variant) (*ProvisionResult, error) {
 	return &ProvisionResult{}, nil
 }
 func (m *mockProvider) AdjustEnvVars(ctx context.Context, result *ProvisionResult, assoc AddonAssociation, collisions []string) ([]Variable, error) {

--- a/pkg/addon/valkey/dedicated.go
+++ b/pkg/addon/valkey/dedicated.go
@@ -352,7 +352,7 @@ func RegisterDeprovisionDedicatedSaga(registry *saga.Registry, fw *addon.Provide
 		RegisterTo(registry)
 }
 
-func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	p.Log.Info("provisioning dedicated Valkey",
 		"app", app.Name,
 		"variant", variant.Name)
@@ -368,6 +368,7 @@ func (p *Provider) provisionDedicated(ctx context.Context, app addon.App, varian
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("provision-dedicated-valkey").
+		WithID(addon.ProvisionExecutionID(assoc.ID)).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -397,6 +398,7 @@ func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAs
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
 	err := executor.Start("deprovision-dedicated-valkey").
+		WithID(addon.DeprovisionExecutionID(assoc.ID)).
 		Input("assocentity", assoc.Entity).
 		Execute(ctx)
 	if err != nil {

--- a/pkg/addon/valkey/dedicated.go
+++ b/pkg/addon/valkey/dedicated.go
@@ -31,10 +31,6 @@ func valkeyContainerPorts() []compute_v1alpha.SandboxSpecContainerPort {
 	}
 }
 
-type resultCapture struct {
-	Result *addon.ProvisionResult
-}
-
 // --- Dedicated Provisioning Saga Actions ---
 
 type GenerateCredentialsIn struct {
@@ -199,42 +195,10 @@ func UndoUpdateDedicatedServer(ctx context.Context, in UpdateDedicatedServerIn, 
 	return nil
 }
 
-type BuildDedicatedResultIn struct {
-	ServiceHost string    `saga:"servicehost"`
-	Password    string    `saga:"password"`
-	ServerID    entity.Id `saga:"serverid"`
-}
-
-type BuildDedicatedResultOut struct {
-	Done bool
-}
-
-func BuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn) (BuildDedicatedResultOut, error) {
-	rc := saga.Get[*resultCapture](ctx)
-
-	envVars := buildEnvVars(in.ServiceHost, valkeyPort, in.Password)
-
-	dedicatedData := &addon_v1alpha.ValkeyDedicatedData{
-		ValkeyServer: in.ServerID,
-	}
-
-	rc.Result = &addon.ProvisionResult{
-		EnvVars: envVars,
-		Attrs:   dedicatedData.Encode(),
-	}
-
-	return BuildDedicatedResultOut{Done: true}, nil
-}
-
-func UndoBuildDedicatedResult(ctx context.Context, in BuildDedicatedResultIn, out BuildDedicatedResultOut) error {
-	return nil
-}
-
-func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework, rc *resultCapture) error {
+func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework) error {
 	cfg := &dbsaga.AddonConfig{AddonName: AddonName, Port: valkeyPort, ReadyTimeout: poolReadyTimeout}
 	return saga.Define("provision-dedicated-valkey").
 		Using(fw).
-		Using(rc).
 		Using(cfg).
 		Action(GenerateCredentials).Undo(UndoGenerateCredentials).
 		Action(CreateValkeyServer).Undo(UndoCreateValkeyServer).
@@ -243,7 +207,6 @@ func RegisterDedicatedSaga(registry *saga.Registry, fw *addon.ProviderFramework,
 		Action(dbsaga.CreateDedicatedService).Undo(dbsaga.UndoCreateDedicatedService).
 		Action(dbsaga.WaitForDedicatedService).Undo(dbsaga.UndoWaitForDedicatedService).
 		Action(UpdateDedicatedServer).Undo(UndoUpdateDedicatedServer).
-		Action(BuildDedicatedResult).Undo(UndoBuildDedicatedResult).
 		RegisterTo(registry)
 }
 
@@ -357,18 +320,18 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		"app", app.Name,
 		"variant", variant.Name)
 
-	rc := &resultCapture{}
 	registry := saga.NewRegistry()
 
-	if err := RegisterDedicatedSaga(registry, p.Fw, rc); err != nil {
+	if err := RegisterDedicatedSaga(registry, p.Fw); err != nil {
 		return nil, fmt.Errorf("registering dedicated saga: %w", err)
 	}
 
 	storage := p.Fw.Storage
 	executor := saga.NewExecutor(storage, saga.WithRegistry(registry), saga.WithLogger(p.Log))
 
+	execID := addon.ProvisionExecutionID(assoc.ID)
 	err := executor.Start("provision-dedicated-valkey").
-		WithID(addon.ProvisionExecutionID(assoc.ID)).
+		WithID(execID).
 		Input("appname", app.Name).
 		Input("variantname", variant.Name).
 		Input("variantconfig", variant.Config).
@@ -377,12 +340,33 @@ func (p *Provider) provisionDedicated(ctx context.Context, assoc addon.AddonAsso
 		return nil, err
 	}
 
-	if rc.Result == nil {
-		return nil, fmt.Errorf("saga completed but no result was captured")
+	// Read the answer back out of the execution rather than out of a struct the
+	// run filled in, so a saga that finished on an earlier pass still yields one.
+	out, err := executor.ExecutionOutputs(ctx, execID)
+	if err != nil {
+		return nil, fmt.Errorf("reading provisioning outputs: %w", err)
+	}
+
+	var host, password string
+	var serverID entity.Id
+
+	for key, target := range map[string]any{
+		"servicehost": &host,
+		"password":    &password,
+		"serverid":    &serverID,
+	} {
+		if err := out.Get(key, target); err != nil {
+			return nil, fmt.Errorf("reading %s from provisioning outputs: %w", key, err)
+		}
 	}
 
 	p.Log.Info("dedicated Valkey provisioned", "app", app.Name)
-	return rc.Result, nil
+	return &addon.ProvisionResult{
+		EnvVars: buildEnvVars(host, valkeyPort, password),
+		Attrs: (&addon_v1alpha.ValkeyDedicatedData{
+			ValkeyServer: serverID,
+		}).Encode(),
+	}, nil
 }
 
 func (p *Provider) deprovisionDedicated(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/addon/valkey/dedicated_test.go
+++ b/pkg/addon/valkey/dedicated_test.go
@@ -13,15 +13,14 @@ import (
 func TestRegisterDedicatedSaga(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-valkey")
 	require.True(t, ok)
 	assert.Equal(t, "provision-dedicated-valkey", def.Name)
-	assert.Len(t, def.Actions, 8)
+	assert.Len(t, def.Actions, 7)
 }
 
 func TestRegisterDeprovisionDedicatedSaga(t *testing.T) {
@@ -72,27 +71,26 @@ func TestDeprovisionDedicatedSagaOrder(t *testing.T) {
 func TestDedicatedSagaActionOrder(t *testing.T) {
 	registry := saga.NewRegistry()
 	fw := &addon.ProviderFramework{}
-	rc := &resultCapture{}
 
-	err := RegisterDedicatedSaga(registry, fw, rc)
+	err := RegisterDedicatedSaga(registry, fw)
 	require.NoError(t, err)
 
 	def, ok := registry.Get("provision-dedicated-valkey")
 	require.True(t, ok)
 
-	expectedActions := []string{
+	// Order comes from the data dependencies between actions, not from the order
+	// they were registered in. Worth pinning rather than just asserting
+	// membership: deleting an action, as dropping the result-building step did,
+	// changes the graph the topological sort reads.
+	expectedOrder := []string{
 		"generate-credentials",
-		"create-valkey-server",
 		"create-dedicated-pool",
-		"wait-for-dedicated-pool",
 		"create-dedicated-service",
+		"create-valkey-server",
+		"wait-for-dedicated-pool",
 		"wait-for-dedicated-service",
 		"update-dedicated-server",
-		"build-dedicated-result",
 	}
 
-	for _, name := range expectedActions {
-		_, exists := def.Actions[name]
-		assert.True(t, exists, "expected action %q to exist", name)
-	}
+	assert.Equal(t, expectedOrder, def.ExecutionOrder())
 }

--- a/pkg/addon/valkey/provider.go
+++ b/pkg/addon/valkey/provider.go
@@ -23,8 +23,8 @@ func NewProvider(fw *addon.ProviderFramework) *Provider {
 	}
 }
 
-func (p *Provider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
-	return p.provisionDedicated(ctx, app, variant)
+func (p *Provider) Provision(ctx context.Context, assoc addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+	return p.provisionDedicated(ctx, assoc, app, variant)
 }
 
 func (p *Provider) Deprovision(ctx context.Context, assoc addon.AddonAssociation) error {

--- a/pkg/saga/drop.go
+++ b/pkg/saga/drop.go
@@ -1,0 +1,54 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Naming an execution after the entity it belongs to makes the record durable
+// across passes, which is the point. It also means the record can outlive the
+// truth: a teardown that failed without compensating anything, or a successful
+// build whose resources have since disappeared. Execute will not second-guess
+// either, because deciding that a recorded outcome no longer describes reality
+// needs knowledge the saga framework does not have.
+//
+// These hand that decision to the caller that does have it. Dropping an
+// execution that is absent, or that is in any other state, is not an error, so
+// a caller can say what it means without first reading the record.
+
+// DropIfFailed removes an execution that failed, so a later Execute under the
+// same name runs again instead of handing back the recorded error.
+//
+// For a caller that owns the operation and has decided a retry is right.
+// Addon teardown is the motivating case: its undos are all no-ops, so a failed
+// run compensated nothing and left its resources exactly where they were, and
+// a second attempt has strictly more to do rather than something to redo.
+func DropIfFailed(ctx context.Context, s Storage, id string) error {
+	return dropIf(ctx, s, id, StatusFailed)
+}
+
+// DropIfCompleted removes an execution that succeeded, so a later Execute under
+// the same name builds again instead of reporting the old success.
+//
+// For a caller that knows the resources the run created are gone. Sandbox
+// creation is the motivating case: containers can vanish under a live runner
+// with nothing written to the entity, and the controller that notices arrives
+// here wanting a build, not a receipt for one.
+func DropIfCompleted(ctx context.Context, s Storage, id string) error {
+	return dropIf(ctx, s, id, StatusCompleted)
+}
+
+func dropIf(ctx context.Context, s Storage, id string, want Status) error {
+	exec, err := s.Get(ctx, id)
+	if errors.Is(err, ErrExecutionNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("loading execution %q: %w", id, err)
+	}
+	if exec.Status != want {
+		return nil
+	}
+	return s.Delete(ctx, id)
+}

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"miren.dev/runtime/pkg/idgen"
@@ -13,6 +14,12 @@ import (
 
 // ErrExecutionNotFound is returned by Storage.Get when no execution exists for the given ID.
 var ErrExecutionNotFound = errors.New("execution not found")
+
+// ErrExecutionInProgress reports that this Executor is already driving the
+// named execution, so this call did nothing. It is not a failure and it is not
+// success: the work is still going, and the caller should come back for the
+// answer rather than read outputs that have not been written yet.
+var ErrExecutionInProgress = errors.New("execution already in progress")
 
 type executorCtxKey struct{}
 type executionIDCtxKey struct{}
@@ -61,6 +68,22 @@ type Executor struct {
 	storage  Storage
 	registry *Registry
 	log      *slog.Logger
+
+	// inFlight names the executions this Executor is currently driving. A
+	// caller that names its execution after the entity it belongs to will
+	// re-enter Execute on every reconcile pass, and without this the second
+	// caller would drive the same execution concurrently with the first.
+	//
+	// The scope really is this value, not the process: callers that build an
+	// Executor per operation get an empty map each time and so get nothing from
+	// this. Serializing across them is the caller's problem, and for addon and
+	// sandbox work it is already solved a level up, by a reconcile controller
+	// that handles one event per entity at a time. Anything driving an
+	// execution from outside such a loop needs its own answer, and a durable
+	// one (a lease or a compare-and-swap on the record) if it wants to hold
+	// across processes rather than within one.
+	inFlightMu sync.Mutex
+	inFlight   map[string]struct{}
 }
 
 // ExecutorOption configures an Executor.
@@ -87,11 +110,31 @@ func NewExecutor(storage Storage, opts ...ExecutorOption) *Executor {
 		storage:  storage,
 		registry: globalRegistry,
 		log:      slog.Default(),
+		inFlight: make(map[string]struct{}),
 	}
 	for _, opt := range opts {
 		opt(e)
 	}
 	return e
+}
+
+// claim marks an execution as being driven by this Executor, reporting false if
+// this Executor is already driving it.
+func (e *Executor) claim(id string) bool {
+	e.inFlightMu.Lock()
+	defer e.inFlightMu.Unlock()
+
+	if _, busy := e.inFlight[id]; busy {
+		return false
+	}
+	e.inFlight[id] = struct{}{}
+	return true
+}
+
+func (e *Executor) release(id string) {
+	e.inFlightMu.Lock()
+	defer e.inFlightMu.Unlock()
+	delete(e.inFlight, id)
 }
 
 // StartBuilder provides a fluent API for starting saga executions.
@@ -118,6 +161,14 @@ func (sb *StartBuilder) Input(key string, value any) *StartBuilder {
 }
 
 // WithID sets a specific execution ID (otherwise one is generated).
+//
+// Naming an execution makes Execute idempotent under that name: a second call
+// continues the existing run rather than starting a new one. The inputs given
+// here are the bootstrap data for the first call only. A later call that
+// supplies different ones resumes from what the first recorded and ignores
+// them, because the actions that already ran did so against the originals and
+// re-deriving half a saga from new inputs would produce a run that never
+// happened.
 func (sb *StartBuilder) WithID(id string) *StartBuilder {
 	sb.id = id
 	return sb
@@ -139,6 +190,27 @@ func (e *Executor) execute(ctx context.Context, defName string, inputs map[strin
 	// Generate ID if not provided
 	if id == "" {
 		id = generateID()
+	}
+
+	// A caller that names its execution after the entity it belongs to calls
+	// this on every reconcile pass. Only one of those may drive at a time.
+	if !e.claim(id) {
+		e.log.Debug("execution already being driven here, skipping",
+			"saga", defName, "execution", id)
+		return ErrExecutionInProgress
+	}
+	defer e.release(id)
+
+	// Naming an execution that already exists means continue it, not replace
+	// it. Overwriting would discard the record of what a previous attempt
+	// built, leaving those resources with nothing that knows to undo them.
+	switch existing, err := e.storage.Get(ctx, id); {
+	case err == nil:
+		e.log.Info("continuing existing execution",
+			"saga", defName, "execution", id, "status", existing.Status)
+		return e.resume(ctx, def, existing)
+	case !errors.Is(err, ErrExecutionNotFound):
+		return fmt.Errorf("loading execution %q: %w", id, err)
 	}
 
 	// Create execution
@@ -490,34 +562,21 @@ func (e *Executor) Recover(ctx context.Context) error {
 
 		e.log.Info("recovering saga", "saga", exec.DefinitionName, "execution", exec.ID, "status", exec.Status)
 
-		// Check version compatibility
-		if def.Version != exec.DefinitionVersion {
-			e.log.Warn("saga definition version mismatch",
-				"saga", exec.DefinitionName,
-				"execution_version", exec.DefinitionVersion,
-				"current_version", def.Version)
+		if !e.claim(exec.ID) {
+			e.log.Debug("execution already being driven here, leaving it alone",
+				"saga", exec.DefinitionName, "execution", exec.ID)
+			continue
 		}
+		// Released through defer so an action that panics cannot strand the
+		// claim. A stranded one is permanent: every later Execute under that
+		// name would report the work as still in flight and never run it.
+		err := func() error {
+			defer e.release(exec.ID)
+			return e.resume(ctx, def, exec)
+		}()
 
-		switch exec.Status {
-		case StatusPending, StatusRunning:
-			// Check if there's a failed action that needs compensation.
-			// This handles the edge case where we crashed after recording failure
-			// but before persisting StatusUndoing.
-			if exec.Error != "" {
-				e.log.Info("found failed action during recovery, starting undo",
-					"saga", exec.DefinitionName, "error", exec.Error)
-				recoverErrors = append(recoverErrors, e.runUndo(ctx, def, exec))
-			} else {
-				// Resume execution (pending means crashed before first action started)
-				if err := e.runExecution(ctx, def, exec); err != nil {
-					recoverErrors = append(recoverErrors, err)
-				}
-			}
-		case StatusUndoing:
-			// Resume undo
-			recoverErrors = append(recoverErrors, e.runUndo(ctx, def, exec))
-		case StatusCompleted, StatusFailed:
-			// Terminal states; nothing to recover.
+		if err != nil {
+			recoverErrors = append(recoverErrors, err)
 		}
 	}
 
@@ -525,6 +584,47 @@ func (e *Executor) Recover(ctx context.Context) error {
 		return fmt.Errorf("recovery completed with %d errors", len(recoverErrors))
 	}
 	return nil
+}
+
+// resume continues an execution from wherever it stopped. Both Recover and a
+// re-entered Execute go through here, so the two cannot drift apart on what
+// "continue this" means for a given status.
+//
+// A caller that reaches a Failed execution gets the recorded failure back
+// rather than a silent success: the saga tried, compensated, and gave up, and
+// retrying that is a decision for whoever owns the operation, not something to
+// do implicitly under the same name.
+func (e *Executor) resume(ctx context.Context, def *Definition, exec *Execution) error {
+	if def.Version != exec.DefinitionVersion {
+		e.log.Warn("saga definition version mismatch",
+			"saga", exec.DefinitionName,
+			"execution_version", exec.DefinitionVersion,
+			"current_version", def.Version)
+	}
+
+	switch exec.Status {
+	case StatusPending, StatusRunning:
+		// A recorded error with a non-terminal status means we crashed after
+		// noting the failure but before persisting StatusUndoing.
+		if exec.Error != "" {
+			e.log.Info("found failed action, starting undo",
+				"saga", exec.DefinitionName, "error", exec.Error)
+			return e.runUndo(ctx, def, exec)
+		}
+		return e.runExecution(ctx, def, exec)
+	case StatusUndoing:
+		return e.runUndo(ctx, def, exec)
+	case StatusCompleted:
+		return nil
+	case StatusFailed:
+		return fmt.Errorf("saga failed: %s", exec.Error)
+	}
+
+	// This whole change exists because a value nobody listed fell through a
+	// switch in silence, so not here. An unrecognized status is a corrupt
+	// record or one written by a version that knows a state this one does not,
+	// and resuming is not something we can claim to have done either way.
+	return fmt.Errorf("execution %q has unrecognized status %q", exec.ID, exec.Status)
 }
 
 // extractOutputs extracts output key-value pairs from an action's output.

--- a/pkg/saga/executor.go
+++ b/pkg/saga/executor.go
@@ -595,6 +595,16 @@ func (e *Executor) Recover(ctx context.Context) error {
 // retrying that is a decision for whoever owns the operation, not something to
 // do implicitly under the same name.
 func (e *Executor) resume(ctx context.Context, def *Definition, exec *Execution) error {
+	// A name that means one saga to the caller and another to the record is an
+	// id collision, and resuming across it would run this definition's actions
+	// against the other's recorded outputs. Naming executions after entities
+	// makes collisions the thing worth guarding, so this is an error rather
+	// than the warning a version skew gets.
+	if def.Name != exec.DefinitionName {
+		return fmt.Errorf("execution %q belongs to saga %q, not %q",
+			exec.ID, exec.DefinitionName, def.Name)
+	}
+
 	if def.Version != exec.DefinitionVersion {
 		e.log.Warn("saga definition version mismatch",
 			"saga", exec.DefinitionName,

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -1058,3 +1058,73 @@ func TestExecutor_ConcurrentExecuteDoesNotDriveTheSameRunTwice(t *testing.T) {
 	assert.Equal(t, StatusCompleted, exec.Status)
 	assert.Len(t, exec.ExecutionOrder, 1, "the action must have run exactly once")
 }
+
+// A caller that knows the recorded outcome no longer describes reality can
+// retire it. Anything else is left alone, so a caller can say what it means
+// without first reading the record.
+func TestDropIf(t *testing.T) {
+	ctx := context.Background()
+
+	save := func(t *testing.T, s Storage, id string, status Status) {
+		t.Helper()
+		require.NoError(t, s.Save(ctx, &Execution{ID: id, DefinitionName: "d", Status: status}))
+	}
+	exists := func(t *testing.T, s Storage, id string) bool {
+		t.Helper()
+		_, err := s.Get(ctx, id)
+		return err == nil
+	}
+
+	t.Run("failed is dropped, completed is not", func(t *testing.T) {
+		s := NewMemoryStorage()
+		save(t, s, "a", StatusFailed)
+		save(t, s, "b", StatusCompleted)
+		require.NoError(t, DropIfFailed(ctx, s, "a"))
+		require.NoError(t, DropIfFailed(ctx, s, "b"))
+		assert.False(t, exists(t, s, "a"))
+		assert.True(t, exists(t, s, "b"))
+	})
+
+	t.Run("completed is dropped, running is not", func(t *testing.T) {
+		s := NewMemoryStorage()
+		save(t, s, "a", StatusCompleted)
+		save(t, s, "b", StatusRunning)
+		require.NoError(t, DropIfCompleted(ctx, s, "a"))
+		require.NoError(t, DropIfCompleted(ctx, s, "b"))
+		assert.False(t, exists(t, s, "a"))
+		assert.True(t, exists(t, s, "b"), "an in-flight run must never be pulled out from under its driver")
+	})
+
+	t.Run("absent is not an error", func(t *testing.T) {
+		s := NewMemoryStorage()
+		assert.NoError(t, DropIfFailed(ctx, s, "nope"))
+		assert.NoError(t, DropIfCompleted(ctx, s, "nope"))
+	})
+}
+
+// An id collision must not run one saga's actions against another's record.
+func TestExecutor_ReExecuteRejectsADifferentDefinitionUnderTheSameName(t *testing.T) {
+	registry := NewRegistry()
+	ctrl := &testController{}
+	require.NoError(t, Define("calc-a").Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).RegisterTo(registry))
+
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+	require.NoError(t, storage.Save(ctx, &Execution{
+		ID:                "shared-name",
+		DefinitionName:    "calc-b", // a different saga recorded under this name
+		DefinitionVersion: 1,
+		Status:            StatusRunning,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}))
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err := executor.Start("calc-a").Input("a", 2).Input("b", 3).
+		WithID("shared-name").Execute(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "calc-b")
+	assert.Empty(t, ctrl.addCalls, "and no action runs against the other saga's record")
+}

--- a/pkg/saga/saga_test.go
+++ b/pkg/saga/saga_test.go
@@ -835,3 +835,226 @@ func TestExecutor_EdgeDependency(t *testing.T) {
 	assert.Equal(t, StatusCompleted, exec.Status)
 	assert.Equal(t, []string{"step-a", "step-b"}, exec.ExecutionOrder)
 }
+
+// A caller that names its execution after the entity it belongs to re-enters
+// Execute on every reconcile pass. That must continue the existing execution
+// rather than start a fresh one over the top of it.
+func TestExecutor_ReExecuteResumesInsteadOfRestarting(t *testing.T) {
+	registry := NewRegistry()
+
+	ctrl := &testController{}
+	err := Define("resume-calc").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	executor := NewExecutor(storage, WithRegistry(registry))
+	ctx := context.Background()
+
+	start := func() error {
+		return executor.Start("resume-calc").
+			Input("a", 2).
+			Input("b", 3).
+			Input("factor", 4).
+			WithID("assoc-42").
+			Execute(ctx)
+	}
+
+	require.NoError(t, start())
+	require.Len(t, ctrl.addCalls, 1)
+	require.Len(t, ctrl.multiplyCalls, 1)
+
+	// Same name again: the work is already done, so nothing should re-run and
+	// the record must survive intact.
+	require.NoError(t, start())
+	assert.Len(t, ctrl.addCalls, 1, "completed action must not run twice")
+	assert.Len(t, ctrl.multiplyCalls, 1, "completed action must not run twice")
+
+	exec, err := storage.Get(ctx, "assoc-42")
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, exec.Status)
+	assert.Len(t, exec.ExecutionOrder, 2, "re-entry must not clobber the record")
+}
+
+// The case MIR-1524 is about: a process dies with an execution half finished,
+// and the next pass picks it up where it stopped instead of starting over on
+// top of what the first attempt already built.
+func TestExecutor_ReExecuteContinuesInterruptedRun(t *testing.T) {
+	registry := NewRegistry()
+
+	ctrl := &testController{}
+	err := Define("interrupted-calc").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	// Stand in for a crash after the first action: the record says running,
+	// with only "add" recorded.
+	require.NoError(t, storage.Save(ctx, &Execution{
+		ID:                "assoc-99",
+		DefinitionName:    "interrupted-calc",
+		DefinitionVersion: 1,
+		InitialInputs:     map[string]any{"a": float64(2), "b": float64(3), "factor": float64(4)},
+		Status:            StatusRunning,
+		ExecutedActions: map[string]*ActionResult{
+			// Output keys are Go field names, as json.Marshal writes them.
+			"add": {Output: []byte(`{"Sum":5}`), ExecutedAt: time.Now()},
+		},
+		ExecutionOrder: []string{"add"},
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}))
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	require.NoError(t, executor.Start("interrupted-calc").
+		Input("a", 2).
+		Input("b", 3).
+		Input("factor", 4).
+		WithID("assoc-99").
+		Execute(ctx))
+
+	assert.Empty(t, ctrl.addCalls, "already-recorded action must not re-run")
+	require.Len(t, ctrl.multiplyCalls, 1, "remaining action must run")
+	assert.Equal(t, MultiplyIn{Sum: 5, Factor: 4}, ctrl.multiplyCalls[0],
+		"resumed action must see the first attempt's output")
+
+	exec, err := storage.Get(ctx, "assoc-99")
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, exec.Status)
+}
+
+// A saga that already failed and compensated hands its error back rather than
+// reporting a quiet success. Retrying under the same name would run against
+// resources the rollback has already torn down, so the decision belongs to
+// whoever owns the operation.
+func TestExecutor_ReExecuteReportsAnAlreadyFailedRun(t *testing.T) {
+	registry := NewRegistry()
+
+	ctrl := &testController{}
+	err := Define("failed-calc").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		Action("multiply", Multiply).Undo(UndoMultiply).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	require.NoError(t, storage.Save(ctx, &Execution{
+		ID:                "assoc-failed",
+		DefinitionName:    "failed-calc",
+		DefinitionVersion: 1,
+		InitialInputs:     map[string]any{"a": float64(2), "b": float64(3), "factor": float64(4)},
+		Status:            StatusFailed,
+		Error:             "out of turkey",
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}))
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err = executor.Start("failed-calc").
+		Input("a", 2).
+		Input("b", 3).
+		Input("factor", 4).
+		WithID("assoc-failed").
+		Execute(ctx)
+
+	require.Error(t, err, "a failed execution must not read as success")
+	assert.Contains(t, err.Error(), "out of turkey", "and must carry what actually went wrong")
+	assert.Empty(t, ctrl.addCalls, "a compensated saga must not quietly run again")
+	assert.Empty(t, ctrl.multiplyCalls)
+}
+
+// A status resume does not recognise must not read as a finished saga. This is
+// the same shape as the bug the rest of this change is about: a value nobody
+// listed falling through a switch and being reported as success.
+func TestExecutor_ReExecuteRejectsAnUnrecognizedStatus(t *testing.T) {
+	registry := NewRegistry()
+
+	ctrl := &testController{}
+	err := Define("odd-calc").
+		Using(ctrl).
+		Action("add", AddNumbers).Undo(UndoAddNumbers).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+
+	require.NoError(t, storage.Save(ctx, &Execution{
+		ID:                "assoc-odd",
+		DefinitionName:    "odd-calc",
+		DefinitionVersion: 1,
+		InitialInputs:     map[string]any{"a": float64(2), "b": float64(3)},
+		Status:            Status("marinating"), // a state this version has never heard of
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}))
+
+	executor := NewExecutor(storage, WithRegistry(registry))
+	err = executor.Start("odd-calc").
+		Input("a", 2).
+		Input("b", 3).
+		WithID("assoc-odd").
+		Execute(ctx)
+
+	require.Error(t, err, "an unknown status must not be reported as a completed saga")
+	assert.Contains(t, err.Error(), "marinating", "and must say what it could not make sense of")
+	assert.Empty(t, ctrl.addCalls, "nor should it run actions over a record it cannot read")
+}
+
+// Two passes arriving at once must not both drive the same execution. The
+// second is told the work is in progress, which is neither a failure nor a
+// success, so a caller can tell it apart from a finished run.
+func TestExecutor_ConcurrentExecuteDoesNotDriveTheSameRunTwice(t *testing.T) {
+	registry := NewRegistry()
+
+	ctrl := &testController{}
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	err := Define("slow-calc").
+		Using(ctrl).
+		Action("add", func(ctx context.Context, in AddNumbersIn) (AddNumbersOut, error) {
+			close(entered)
+			<-release
+			return AddNumbers(ctx, in)
+		}).Undo(UndoAddNumbers).
+		RegisterTo(registry)
+	require.NoError(t, err)
+
+	storage := NewMemoryStorage()
+	ctx := context.Background()
+	executor := NewExecutor(storage, WithRegistry(registry))
+
+	start := func() error {
+		return executor.Start("slow-calc").
+			Input("a", 2).
+			Input("b", 3).
+			WithID("assoc-concurrent").
+			Execute(ctx)
+	}
+
+	first := make(chan error, 1)
+	go func() { first <- start() }()
+
+	<-entered // the first pass is inside the action and holds the claim
+	assert.ErrorIs(t, start(), ErrExecutionInProgress,
+		"the second pass must be told the work is already being driven")
+
+	close(release)
+	require.NoError(t, <-first)
+
+	exec, err := storage.Get(ctx, "assoc-concurrent")
+	require.NoError(t, err)
+	assert.Equal(t, StatusCompleted, exec.Status)
+	assert.Len(t, exec.ExecutionOrder, 1, "the action must have run exactly once")
+}

--- a/servers/app/addons_test.go
+++ b/servers/app/addons_test.go
@@ -24,7 +24,7 @@ func (m *mockProvider) LocalityMode() addon.LocalityMode {
 	return addon.OnCluster
 }
 
-func (m *mockProvider) Provision(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
+func (m *mockProvider) Provision(ctx context.Context, _ addon.AddonAssociation, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error) {
 	return &addon.ProvisionResult{}, nil
 }
 


### PR DESCRIPTION
This has gone through a whole loop-de-loo. ➿ Analyzing the bug here caused me to realize that Addons diverged in how they were treating Sagas from other usages, which made me want to write up guidelines for us to use going forward, which became RFD-99.

RFD-99 evolved all the way to sketching a full FSM library for us, which I do think will help us make our entity -> controller -> saga relationships more stable in the long run, but is also a fairly large swing that touches our low level subsystems while the sagas we do have are still in a split flag situation.

So this PR went from being "the first demo of new-world FSM library" back to a ~minimal fix for the bug, which is still a nontrivial diff!

The rest of RFD-99 becomes guidelines for greenfield and someday backlog stuff.

---

🤖 Kill a coordinator halfway through provisioning an addon and the association never comes back. `provision()` writes `provisioning` before the work starts, so a crash leaves the association on that value, and reconcile's switch had no case for it. Every later pass fell through and returned in silence. The app doesn't recover either: the deployment launcher defers pool creation while an association is still provisioning, so it activates but never gets running workloads.

The missing case is one line, but on its own it would have traded a wedged association for a duplicated one. Starting a saga has always meant writing a fresh execution over anything sharing its name, so a second pass would have discarded the record of what the first attempt built and created a second set of backing resources beside it. So the first two revs are groundwork: `Execute` now treats an existing name as "continue this one" (resume an unfinished run, finish an interrupted rollback, return straight away if it already succeeded), sharing the code path `Recover` already used, and addon provisioning names its execution after the association so a later pass can find the first attempt. Sandbox creation picks this up for free, since it already named executions after the sandbox and had been racing recovery to clobber its log.

That resumability then forces the third rev. Every provisioning saga used to end with a `Build*Result` action that stashed the answer in a struct the provider read back out of memory, which stops working the moment a resumed execution completes without running anything. The provider now reads the recorded outputs back off the execution and assembles the result itself, deleting the action, its undo, and the capture struct from all seven provider paths.

Fixes MIR-1524
