### PR TITLE
Stop `miren logs` printing a stream-reset error after a successful run

### DIFF
--- a/pkg/rpc/inline_router.go
+++ b/pkg/rpc/inline_router.go
@@ -132,7 +132,14 @@ func (s *State) serveInlineCalls(ctx context.Context, dec *cbor.Decoder, enc *cb
 		var rs streamRequest
 
 		if err := dec.Decode(&rs); err != nil {
-			if !errors.Is(err, io.EOF) {
+			// A canceled context means the call these callbacks served has
+			// already finished and the caller is tearing down its session,
+			// which resets any stream still open here. That reset surfaces as
+			// a transport error rather than a clean EOF, and on WebTransport
+			// it does not even carry a matchable type, so the context is what
+			// distinguishes expected teardown from a stream that genuinely
+			// broke mid-call.
+			if !errors.Is(err, io.EOF) && ctx.Err() == nil {
 				s.log.Error("rpc.callstream call: error decoding stream request", "error", err)
 			}
 			return
@@ -161,11 +168,13 @@ func (s *State) serveInlineCalls(ctx context.Context, dec *cbor.Decoder, enc *cb
 				continue
 			}
 
-			ctx, cancel := context.WithCancel(ctx)
-			err := c.callInline(ctx, mm, rs.OID, rs.Method, iface.Interface, enc, dec)
+			callCtx, cancel := context.WithCancel(ctx)
+			err := c.callInline(callCtx, mm, rs.OID, rs.Method, iface.Interface, enc, dec)
 			cancel()
 			if err != nil {
-				if !errors.Is(err, context.Canceled) && !errors.Is(err, cond.ErrClosed{}) {
+				// ctx is deliberately the stream's context, not callCtx, which
+				// cancel has already finished by this point.
+				if !errors.Is(err, context.Canceled) && !errors.Is(err, cond.ErrClosed{}) && ctx.Err() == nil {
 					s.log.Error("rpc.callstream: error calling inline", "error", err)
 				}
 				return

--- a/pkg/rpc/inline_router_test.go
+++ b/pkg/rpc/inline_router_test.go
@@ -1,0 +1,143 @@
+package rpc
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// errReader fails every read with err, standing in for a stream that has been
+// reset underneath a decoder.
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+// errSessionReset reproduces what a WebTransport stream read returns once the
+// session closes underneath it. webtransport-go resets each open stream with
+// its internal sessionCloseErrorCode (0x170d7b68), then fails to map that
+// sentinel back into the WebTransport range, so the caller gets this opaque
+// error instead of a typed one or a clean EOF. See MIR-1570.
+var errSessionReset = fmt.Errorf(
+	"stream reset, but failed to convert stream error %d: %w",
+	0x170d7b68, errors.New("error code outside of expected range"),
+)
+
+// errWriter fails every write, so the encoder callInline replies through cannot
+// flush and callInline reports the stream as unusable.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("stream gone") }
+
+// inlineCallStream builds the bytes a peer's inlineClient writes for one
+// callback: a "call" request followed immediately by its args.
+func inlineCallStream(oid OID, method string) *cbor.Decoder {
+	var buf bytes.Buffer
+
+	enc := cbor.NewEncoder(&buf)
+	if err := enc.Encode(streamRequest{Kind: "call", OID: oid, Method: method}); err != nil {
+		panic(err)
+	}
+	if err := enc.Encode("args"); err != nil {
+		panic(err)
+	}
+
+	return cbor.NewDecoder(&buf)
+}
+
+func serveInlineCallsWithLog(ctx context.Context, readErr error) string {
+	var buf bytes.Buffer
+
+	s := &State{StateCommon: &StateCommon{
+		log: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}}
+
+	s.serveInlineCalls(
+		ctx,
+		cbor.NewDecoder(errReader{err: readErr}),
+		cbor.NewEncoder(io.Discard),
+		func(OID) (*NetworkClient, *InlineCapability, bool) { return nil, nil, false },
+	)
+
+	return buf.String()
+}
+
+func TestServeInlineCalls(t *testing.T) {
+	t.Run("stays quiet when the stream ends cleanly", func(t *testing.T) {
+		require.Empty(t, serveInlineCallsWithLog(t.Context(), io.EOF))
+	})
+
+	t.Run("stays quiet when the call's session is being torn down", func(t *testing.T) {
+		// The caller cancels this context before closing the session that
+		// resets the stream, so a read failure here is expected teardown
+		// rather than something an operator should be told about.
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		require.Empty(t, serveInlineCallsWithLog(ctx, errSessionReset))
+	})
+
+	t.Run("reports a stream that breaks during a live call", func(t *testing.T) {
+		out := serveInlineCallsWithLog(t.Context(), errSessionReset)
+
+		require.Contains(t, out, "error decoding stream request")
+		require.Contains(t, out, "level=ERROR")
+	})
+}
+
+// serveOneInlineCallWithLog drives a single dispatched callback whose reply
+// cannot be written, so serveInlineCalls exercises the callInline arm.
+func serveOneInlineCallWithLog(ctx context.Context) string {
+	var buf bytes.Buffer
+
+	s := &State{StateCommon: &StateCommon{
+		log: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}}
+
+	const oid = OID("inline-cap")
+
+	client := &NetworkClient{State: s, capa: &Capability{OID: oid}}
+	capa := &InlineCapability{
+		Capability: client.capa,
+		Interface: &Interface{
+			name: "Sink",
+			methods: map[string]Method{
+				"Record": {
+					Name:    "Record",
+					Handler: func(context.Context, Call) error { return nil },
+				},
+			},
+		},
+	}
+
+	s.serveInlineCalls(
+		ctx,
+		inlineCallStream(oid, "Record"),
+		cbor.NewEncoder(errWriter{}),
+		func(OID) (*NetworkClient, *InlineCapability, bool) { return client, capa, true },
+	)
+
+	return buf.String()
+}
+
+func TestServeInlineCallsDispatch(t *testing.T) {
+	t.Run("stays quiet when the call's session is being torn down", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		require.Empty(t, serveOneInlineCallWithLog(ctx))
+	})
+
+	t.Run("reports a callback that fails during a live call", func(t *testing.T) {
+		out := serveOneInlineCallWithLog(t.Context())
+
+		require.Contains(t, out, "error calling inline")
+		require.Contains(t, out, "level=ERROR")
+	})
+}


### PR DESCRIPTION
A bounded `miren logs` run would sometimes return every record, exit 0, and still print this to stderr:

```
[ERROR] rpc.callstream call: error decoding stream request │ error: "stream reset, but failed to convert stream error 386759528: error code outside of expected range"
```

That number is the whole story. It's webtransport-go's internal `sessionCloseErrorCode`, the code it uses to reset every open stream when a session closes. The client serves the log sink over an inline callback stream, and when the call finishes it closes its session out from under a decoder still parked on that stream. The reset arrives as an opaque transport error rather than a clean EOF, so the loop called it a failure. Whether the server's own clean close beat our teardown was a race, which is why it only showed up some of the time, and why it was never really about bounded queries.

`serveInlineCalls` now treats a read failure as expected when the stream's context is already canceled, and still reports at Error otherwise, so a callback stream that genuinely breaks mid-call isn't muted. In dev that took a looped query from 11 stderr hits in 40 runs to none in 60, with full records throughout.

The garbled wording is a webtransport-go bug, already fixed upstream in v0.12.0, where `Read` returns a typed `SessionError` instead. We're on v0.9.0, and upgrading is its own piece of work. It would improve the text but wouldn't remove this line, since the loop was treating expected teardown as a failure regardless of how it was worded.

Closes MIR-1570
