### PR TITLE
Keep the connect notice off a non-terminal stderr

### DIFF
--- a/cli/commands/connect_notice.go
+++ b/cli/commands/connect_notice.go
@@ -31,9 +31,14 @@ const (
 //
 // It writes to stderr, never stdout: this runs before every RPC command, and a
 // progress line in stdout would corrupt `--format json` output the moment
-// anyone pipes it. It also deliberately avoids a full terminal UI. Raw mode on
-// a code path this hot means a Ctrl-C during a slow connect can leave the
-// user's terminal broken, and rewriting one line with \r cannot do that.
+// anyone pipes it. Stderr alone isn't enough, though — plenty of callers merge
+// the two streams — so a stderr that isn't a terminal produces no notice at
+// all. The only thing this line does is reassure someone watching a terminal
+// that we haven't hung, and nobody is watching a pipe.
+//
+// It also deliberately avoids a full terminal UI. Raw mode on a code path this
+// hot means a Ctrl-C during a slow connect can leave the user's terminal
+// broken, and rewriting one line with \r cannot do that.
 type connectNotice struct {
 	out         io.Writer
 	interactive bool
@@ -73,6 +78,12 @@ func (n *connectNotice) Stop() {
 func (n *connectNotice) run(start time.Time) {
 	defer close(n.done)
 
+	// Without a terminal there's no one to reassure, and the line would just be
+	// debris in whatever captured the stream.
+	if !n.interactive {
+		return
+	}
+
 	// Stay quiet unless the connection is actually slow.
 	select {
 	case <-n.stop:
@@ -86,8 +97,6 @@ func (n *connectNotice) run(start time.Time) {
 	defer ticker.Stop()
 
 	for {
-		// The static (non-terminal) line is printed once and never rewritten,
-		// so a running clock on it would be a lie the moment it's drawn.
 		w.label = connectNoticeLabel(n.target, time.Since(start), n.interactive)
 		w.tick()
 

--- a/cli/commands/connect_notice_test.go
+++ b/cli/commands/connect_notice_test.go
@@ -112,24 +112,21 @@ func TestConnectNoticeErasesItself(t *testing.T) {
 	}
 }
 
-// Without a terminal there's nothing to animate, so it should say its piece
-// once rather than emitting a frame every tick into a log file.
-func TestConnectNoticePrintsOnceWhenNotInteractive(t *testing.T) {
+// Without a terminal nobody is watching for a hang, and anything written here
+// is debris in whatever captured the stream — `--format json` output with
+// stderr merged in, most painfully.
+func TestConnectNoticeSilentWhenNotInteractive(t *testing.T) {
 	var out syncBuffer
 	n := newTestNotice(&out, false, time.Millisecond)
 	go n.run(time.Now())
 
-	// Give the ticker several chances to print again before stopping, so a
-	// missing guard would actually show up as a repeat.
-	waitForOutput(t, &out)
+	// Long enough that an interactive notice would be several frames in, so
+	// silence here means suppressed rather than merely not started yet.
 	time.Sleep(50 * time.Millisecond)
 	n.Stop()
 
-	if got := strings.Count(out.String(), "connecting to"); got != 1 {
-		t.Errorf("non-interactive notice printed %d times, want 1:\n%s", got, out.String())
-	}
-	if strings.Contains(out.String(), "\033[K") {
-		t.Errorf("non-interactive notice emitted terminal escapes: %q", out.String())
+	if out.String() != "" {
+		t.Errorf("non-interactive notice wrote output: %q", out.String())
 	}
 }
 


### PR DESCRIPTION
The "connecting to ..." line we added recently was leaking into machine-readable output. It goes to stderr specifically so it can't corrupt `--format json` on stdout, which was the right instinct, but stderr alone turns out not to be enough. Plenty of callers merge the two streams, and `miren app list --format json 2>&1 | jq` would find `  connecting to cluster "local" (localhost:8443)` sitting in the middle of what should have been JSON.

The interesting part is that the terminal check was already there, it just wasn't doing the job you'd assume from its name. It picked *how* to render (spinner on a terminal it could rewrite, one static line otherwise) rather than *whether* to render at all, so a piped stderr still got a line. Now it gates the notice entirely. The only thing this line does is reassure someone watching a terminal that we haven't hung, and nobody is watching a pipe.

I left the shared `waitingLine` helper alone. Its other caller is the deploy health wait, which writes to stdout and genuinely should leave a static line behind in CI logs, so the fix belongs in the notice rather than the helper.

Verified by pointing a throwaway config at an unroutable address to force a five second connect: piped with stderr merged in, you now get nothing but the eventual error. One caveat worth flagging, I couldn't spot-check the real-terminal path by hand, since driving the CLI under a fake pty hangs on an unrelated startup step (miren queries the terminal for its background color and nothing in a scripted pty answers). The interactive path is covered by the existing unit tests and is untouched by construction, since the only new code is an early return on the non-interactive branch.

Closes MIR-1574
