### PR TITLE
Stop `deploy -V` and rollback from dropping addon env vars

### DIFF
--- a/api/core/envcarry.go
+++ b/api/core/envcarry.go
@@ -1,0 +1,160 @@
+package compute
+
+import (
+	"miren.dev/runtime/api/core/core_v1alpha"
+)
+
+// Variable sources. The field is a free-form string in the schema; these are the
+// values the platform actually writes.
+const (
+	// SourceConfig marks a variable declared in .miren/app.toml. It belongs to
+	// the version that was built from that app.toml.
+	SourceConfig = "config"
+
+	// SourceManual marks a variable an operator set (miren env set, deploy -e/-s).
+	SourceManual = "manual"
+
+	// SourceAddon marks a variable an addon injected at provision or rotation
+	// time. Deprovision only strips keys whose source is exactly this, so the
+	// value must never be rewritten to something else.
+	SourceAddon = "addon"
+)
+
+// normalizeSource maps the legacy empty source to manual, matching the merge
+// rules in servers/build/build.go. Versions written before the source field
+// existed carry an empty string and have always been treated as operator-owned.
+func normalizeSource(source string) string {
+	if source == "" {
+		return SourceManual
+	}
+	return source
+}
+
+// carriedForward reports whether a variable with this source belongs to the app
+// rather than to a particular build: addon bindings and operator-set values.
+func carriedForward(source string) bool {
+	switch normalizeSource(source) {
+	case SourceAddon, SourceManual:
+		return true
+	}
+	return false
+}
+
+// CarryForwardVars merges the variables an app owns — addon-injected bindings
+// and operator-set values — from prev into target, and reports whether target
+// changed.
+//
+// It exists for the paths that activate an already-built AppVersion rather than
+// building a new one (deploy -V, app rollback). Those versions are snapshots
+// from an earlier moment, and a snapshot predating an addon has no DATABASE_URL
+// in it. Activating it verbatim used to strand the app without its database
+// credentials permanently, because the addon controller only injects at
+// provision time and never re-injects (MIR-1579).
+//
+// The rule mirrors what the build path already does in mergeVariablesFromAppConfig:
+// addon and manual variables follow the app, while config variables (from
+// .miren/app.toml) stay with the version that was built from that file.
+//
+// The merge is additive. A carried variable overwrites the same key in target,
+// but a key present only in target is left alone — re-activating an old version
+// should never be the thing that deletes a variable. Each carried variable is
+// copied whole, so Source, Backend and the app.toml metadata survive intact.
+func CarryForwardVars(target, prev *core_v1alpha.ConfigSpec) bool {
+	if target == nil || prev == nil {
+		return false
+	}
+
+	changed := false
+
+	vars, varsChanged := carryVars(target.Variables, prev.Variables,
+		func(v core_v1alpha.ConfigSpecVariables) (string, string) { return v.Key, v.Source })
+	if varsChanged {
+		target.Variables = vars
+		changed = true
+	}
+
+	// Addons only inject globals today, but `miren env set --service` writes
+	// per-service manual vars, and those deserve the same treatment. Task env
+	// is left alone: buildTasksConfig rebuilds spec.Tasks wholesale from
+	// app.toml and stamps every entry source="config", and nothing else writes
+	// it, so a task has no app-owned variables to carry.
+	for i := range target.Services {
+		prevSvc := findService(prev.Services, target.Services[i].Name)
+		if prevSvc == nil {
+			continue
+		}
+
+		env, envChanged := carryVars(target.Services[i].Env, prevSvc.Env,
+			func(e core_v1alpha.ConfigSpecServicesEnv) (string, string) { return e.Key, e.Source })
+		if envChanged {
+			target.Services[i].Env = env
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+func findService(services []core_v1alpha.ConfigSpecServices, name string) *core_v1alpha.ConfigSpecServices {
+	for i := range services {
+		if services[i].Name == name {
+			return &services[i]
+		}
+	}
+	return nil
+}
+
+// carryVars merges the app-owned entries of prev into target, preserving
+// target's ordering and appending anything new in prev's order. keySource
+// extracts the key and source from an entry; the two ConfigSpec variable types
+// are field-identical but distinct, so the accessor is what unifies them.
+//
+// T must be a flat value type. The == below is what decides whether anything
+// actually changed, and the caller skips minting a whole version when it says
+// nothing did. The comparable constraint already rules out slice and map fields,
+// but a pointer field would satisfy it while comparing addresses rather than
+// contents, quietly reporting "changed" for equal values. Both instantiations
+// today are plain string/bool structs.
+func carryVars[T comparable](target, prev []T, keySource func(T) (string, string)) ([]T, bool) {
+	positions := make(map[string]int, len(target))
+	for i, v := range target {
+		key, _ := keySource(v)
+		positions[key] = i
+	}
+
+	// Copy lazily: a no-op merge must leave the caller's slice untouched so the
+	// caller can decide not to mint a new version at all.
+	merged := target
+	changed := false
+	copied := false
+	ensureCopy := func() {
+		if !copied {
+			merged = append(make([]T, 0, len(target)+len(prev)), target...)
+			copied = true
+		}
+	}
+
+	for _, pv := range prev {
+		key, source := keySource(pv)
+		if !carriedForward(source) {
+			continue
+		}
+
+		if i, ok := positions[key]; ok {
+			if merged[i] == pv {
+				continue
+			}
+			ensureCopy()
+			merged[i] = pv
+			changed = true
+			continue
+		}
+
+		ensureCopy()
+		positions[key] = len(merged)
+		merged = append(merged, pv)
+		changed = true
+	}
+
+	return merged, changed
+}

--- a/api/core/envcarry_test.go
+++ b/api/core/envcarry_test.go
@@ -1,0 +1,230 @@
+package compute
+
+import (
+	"testing"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+)
+
+func v(key, value, source string) core_v1alpha.ConfigSpecVariables {
+	return core_v1alpha.ConfigSpecVariables{Key: key, Value: value, Source: source}
+}
+
+func varsByKey(vars []core_v1alpha.ConfigSpecVariables) map[string]core_v1alpha.ConfigSpecVariables {
+	out := make(map[string]core_v1alpha.ConfigSpecVariables, len(vars))
+	for _, item := range vars {
+		out[item.Key] = item
+	}
+	return out
+}
+
+func TestCarryForwardVars(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      []core_v1alpha.ConfigSpecVariables
+		prev        []core_v1alpha.ConfigSpecVariables
+		wantChanged bool
+		want        map[string]core_v1alpha.ConfigSpecVariables
+	}{
+		{
+			// MIR-1579: the version being re-activated predates the addon, so it
+			// has no DATABASE_URL at all. Activating it verbatim used to leave
+			// the app permanently without its database credentials.
+			name:        "addon var missing from target is carried forward",
+			target:      []core_v1alpha.ConfigSpecVariables{v("DB_POOL_SIZE", "5", SourceConfig)},
+			prev:        []core_v1alpha.ConfigSpecVariables{v("DB_POOL_SIZE", "5", SourceConfig), v("DATABASE_URL", "postgres://live", SourceAddon)},
+			wantChanged: true,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"DB_POOL_SIZE": v("DB_POOL_SIZE", "5", SourceConfig),
+				"DATABASE_URL": v("DATABASE_URL", "postgres://live", SourceAddon),
+			},
+		},
+		{
+			// Deprovision only strips keys whose source is exactly "addon"
+			// (controllers/addon/controller.go). Relabelling would leak the var.
+			name:        "carried addon var keeps its addon source",
+			target:      nil,
+			prev:        []core_v1alpha.ConfigSpecVariables{v("PGPASSWORD", "hunter2", SourceAddon)},
+			wantChanged: true,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"PGPASSWORD": v("PGPASSWORD", "hunter2", SourceAddon),
+			},
+		},
+		{
+			name:        "rotated addon value overrides the stale one in target",
+			target:      []core_v1alpha.ConfigSpecVariables{v("PGPASSWORD", "old", SourceAddon)},
+			prev:        []core_v1alpha.ConfigSpecVariables{v("PGPASSWORD", "rotated", SourceAddon)},
+			wantChanged: true,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"PGPASSWORD": v("PGPASSWORD", "rotated", SourceAddon),
+			},
+		},
+		{
+			name:        "manual var set after the target version is carried forward",
+			target:      []core_v1alpha.ConfigSpecVariables{v("API_TOKEN", "old", SourceManual)},
+			prev:        []core_v1alpha.ConfigSpecVariables{v("API_TOKEN", "new", SourceManual)},
+			wantChanged: true,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"API_TOKEN": v("API_TOKEN", "new", SourceManual),
+			},
+		},
+		{
+			// app.toml belongs to the build, so the pinned version's value wins.
+			name:        "config var stays with the target version",
+			target:      []core_v1alpha.ConfigSpecVariables{v("LOG_LEVEL", "debug", SourceConfig)},
+			prev:        []core_v1alpha.ConfigSpecVariables{v("LOG_LEVEL", "info", SourceConfig)},
+			wantChanged: false,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"LOG_LEVEL": v("LOG_LEVEL", "debug", SourceConfig),
+			},
+		},
+		{
+			name:        "config var absent from prev is not added",
+			target:      []core_v1alpha.ConfigSpecVariables{v("LOG_LEVEL", "debug", SourceConfig)},
+			prev:        []core_v1alpha.ConfigSpecVariables{v("FEATURE_X", "1", SourceConfig)},
+			wantChanged: false,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"LOG_LEVEL": v("LOG_LEVEL", "debug", SourceConfig),
+			},
+		},
+		{
+			// Additive only: re-activating an old version must not be the thing
+			// that deletes a variable.
+			name:        "target-only manual var is not deleted",
+			target:      []core_v1alpha.ConfigSpecVariables{v("LEGACY_FLAG", "1", SourceManual)},
+			prev:        []core_v1alpha.ConfigSpecVariables{v("DATABASE_URL", "postgres://live", SourceAddon)},
+			wantChanged: true,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"LEGACY_FLAG":  v("LEGACY_FLAG", "1", SourceManual),
+				"DATABASE_URL": v("DATABASE_URL", "postgres://live", SourceAddon),
+			},
+		},
+		{
+			name:        "legacy empty source is treated as manual",
+			target:      nil,
+			prev:        []core_v1alpha.ConfigSpecVariables{v("OLD_VAR", "value", "")},
+			wantChanged: true,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"OLD_VAR": v("OLD_VAR", "value", ""),
+			},
+		},
+		{
+			// The caller skips minting a derived version when nothing changed,
+			// so an identical spec must report false.
+			name:        "identical specs report no change",
+			target:      []core_v1alpha.ConfigSpecVariables{v("DATABASE_URL", "postgres://live", SourceAddon), v("LOG_LEVEL", "info", SourceConfig)},
+			prev:        []core_v1alpha.ConfigSpecVariables{v("DATABASE_URL", "postgres://live", SourceAddon), v("LOG_LEVEL", "info", SourceConfig)},
+			wantChanged: false,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"DATABASE_URL": v("DATABASE_URL", "postgres://live", SourceAddon),
+				"LOG_LEVEL":    v("LOG_LEVEL", "info", SourceConfig),
+			},
+		},
+		{
+			name:        "app with no addons and no manual vars is untouched",
+			target:      []core_v1alpha.ConfigSpecVariables{v("LOG_LEVEL", "info", SourceConfig)},
+			prev:        []core_v1alpha.ConfigSpecVariables{v("LOG_LEVEL", "info", SourceConfig)},
+			wantChanged: false,
+			want: map[string]core_v1alpha.ConfigSpecVariables{
+				"LOG_LEVEL": v("LOG_LEVEL", "info", SourceConfig),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := &core_v1alpha.ConfigSpec{Variables: tt.target}
+			prev := &core_v1alpha.ConfigSpec{Variables: tt.prev}
+
+			changed := CarryForwardVars(target, prev)
+			if changed != tt.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+
+			got := varsByKey(target.Variables)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d variables %v, want %d", len(got), target.Variables, len(tt.want))
+			}
+			for key, want := range tt.want {
+				if got[key] != want {
+					t.Errorf("variable %q = %+v, want %+v", key, got[key], want)
+				}
+			}
+		})
+	}
+}
+
+// A no-op merge must not touch the caller's slice; the deploy path relies on
+// that to decide it can activate the existing version rather than mint a new one.
+func TestCarryForwardVarsLeavesTargetSliceAloneWhenUnchanged(t *testing.T) {
+	original := []core_v1alpha.ConfigSpecVariables{v("LOG_LEVEL", "info", SourceConfig)}
+	target := &core_v1alpha.ConfigSpec{Variables: original}
+	prev := &core_v1alpha.ConfigSpec{Variables: []core_v1alpha.ConfigSpecVariables{v("LOG_LEVEL", "info", SourceConfig)}}
+
+	if CarryForwardVars(target, prev) {
+		t.Fatal("expected no change")
+	}
+	if &target.Variables[0] != &original[0] {
+		t.Error("target slice was reallocated despite no change")
+	}
+}
+
+// Carrying a variable in must not mutate the spec it was read from — the deploy
+// path resolves prev from the app's live ConfigVersion.
+func TestCarryForwardVarsDoesNotMutatePrev(t *testing.T) {
+	target := &core_v1alpha.ConfigSpec{Variables: []core_v1alpha.ConfigSpecVariables{v("A", "1", SourceConfig)}}
+	prevVars := []core_v1alpha.ConfigSpecVariables{v("DATABASE_URL", "postgres://live", SourceAddon)}
+	prev := &core_v1alpha.ConfigSpec{Variables: prevVars}
+
+	if !CarryForwardVars(target, prev) {
+		t.Fatal("expected a change")
+	}
+	if len(prev.Variables) != 1 || prev.Variables[0] != prevVars[0] {
+		t.Errorf("prev was mutated: %+v", prev.Variables)
+	}
+}
+
+func TestCarryForwardVarsServiceEnv(t *testing.T) {
+	env := func(key, value, source string) core_v1alpha.ConfigSpecServicesEnv {
+		return core_v1alpha.ConfigSpecServicesEnv{Key: key, Value: value, Source: source}
+	}
+
+	target := &core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{
+			{Name: "web", Env: []core_v1alpha.ConfigSpecServicesEnv{env("PORT", "8080", SourceConfig)}},
+			{Name: "worker", Env: []core_v1alpha.ConfigSpecServicesEnv{env("QUEUE", "default", SourceConfig)}},
+		},
+	}
+	prev := &core_v1alpha.ConfigSpec{
+		Services: []core_v1alpha.ConfigSpecServices{
+			{Name: "web", Env: []core_v1alpha.ConfigSpecServicesEnv{
+				env("PORT", "9090", SourceConfig),
+				env("WEB_SECRET", "s3cret", SourceManual),
+			}},
+			// A service the target version doesn't have is skipped entirely.
+			{Name: "cron", Env: []core_v1alpha.ConfigSpecServicesEnv{env("SCHEDULE", "* * * * *", SourceManual)}},
+		},
+	}
+
+	if !CarryForwardVars(target, prev) {
+		t.Fatal("expected a change")
+	}
+
+	web := target.Services[0]
+	if len(web.Env) != 2 {
+		t.Fatalf("web env = %+v, want 2 entries", web.Env)
+	}
+	if web.Env[0] != env("PORT", "8080", SourceConfig) {
+		t.Errorf("config-sourced PORT should stay with the target version, got %+v", web.Env[0])
+	}
+	if web.Env[1] != env("WEB_SECRET", "s3cret", SourceManual) {
+		t.Errorf("manual WEB_SECRET not carried, got %+v", web.Env[1])
+	}
+
+	if len(target.Services) != 2 {
+		t.Errorf("services = %d, want 2 (cron exists only in prev and must not be added)", len(target.Services))
+	}
+	if worker := target.Services[1]; len(worker.Env) != 1 || worker.Env[0] != env("QUEUE", "default", SourceConfig) {
+		t.Errorf("worker env changed unexpectedly: %+v", worker.Env)
+	}
+}

--- a/blackbox/addon_test.go
+++ b/blackbox/addon_test.go
@@ -3,6 +3,7 @@
 package blackbox
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
@@ -297,4 +298,73 @@ func TestAddonUnknownAddon(t *testing.T) {
 	if r.Success() {
 		t.Fatal("expected addon create to fail for unknown addon")
 	}
+}
+
+// TestAddonEnvSurvivesDeployVersion reproduces MIR-1579.
+//
+// An addon injects its variables by minting a *successor* AppVersion, so the
+// version produced by the deploy that attached the addon has never contained
+// DATABASE_URL. Re-activating that version with `deploy -V` — the documented way
+// to skip a rebuild, and the natural recovery step after a first deploy whose
+// health check failed — used to leave the app permanently without its database
+// credentials. Nothing restored them: not a rebuild, not `app restart`. The only
+// known recovery was destroying the addon, which drops the database.
+//
+// This is the exact sequence two operators hit independently on two clusters.
+func TestAddonEnvSurvivesDeployVersion(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+
+	// The version built before the addon exists — the one a failed first deploy
+	// names in its error, and the one an operator passes to -V.
+	preAddonVersion := extractVersion(t, m.MustRun("app", "list", "--format", "json").Stdout, name)
+	t.Logf("pre-addon version: %s", preAddonVersion)
+
+	m.MustRun("addon", "create", "miren-postgresql:small", "-a", name)
+	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
+
+	addonVersion := extractVersion(t, m.MustRun("app", "list", "--format", "json").Stdout, name)
+	if addonVersion == preAddonVersion {
+		t.Fatalf("expected the addon to mint a new version, still on %s", preAddonVersion)
+	}
+
+	// The bug trigger.
+	m.MustRun("deploy", "-a", name, "-V", preAddonVersion, "-f")
+	harness.WaitForAppReady(t, m, name, 2*time.Minute)
+
+	// The addon binding must have followed the app onto the re-activated version.
+	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 2*time.Minute)
+
+	// Specifically DATABASE_URL's source, not just the word "addon" somewhere in
+	// the table: deprovision only strips keys whose source is exactly "addon",
+	// so a relabelled var would be leaked when the addon is removed.
+	r := m.MustRun("env", "list", "-a", name, "--format", "json")
+	if got := envVarSource(t, r.Stdout, "DATABASE_URL"); got != "addon" {
+		t.Errorf("DATABASE_URL source = %q, want \"addon\"; a relabelled var leaks on addon destroy:\n%s", got, r.Stdout)
+	}
+}
+
+// envVarSource pulls one variable's source out of `env list --format json`.
+func envVarSource(t *testing.T, jsonOutput, key string) string {
+	t.Helper()
+
+	var vars []struct {
+		Name   string `json:"name"`
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal([]byte(jsonOutput), &vars); err != nil {
+		t.Fatalf("failed to parse env list JSON: %v", err)
+	}
+	for _, v := range vars {
+		if v.Name == key {
+			return v.Source
+		}
+	}
+	t.Fatalf("env var %s not found in env list", key)
+	return ""
 }

--- a/cli/commands/app_rollback.go
+++ b/cli/commands/app_rollback.go
@@ -116,13 +116,15 @@ func Rollback(ctx *Context, opts struct {
 		return fmt.Errorf("rollback failed")
 	}
 
-	versionDisplay := selectedVersion
-	if deployResult.HasDeployment() && deployResult.Deployment().HasAppVersionShortId() {
-		versionDisplay = deployResult.Deployment().AppVersionShortId()
+	var deployed *deployment_v1alpha.DeploymentInfo
+	if deployResult.HasDeployment() {
+		deployed = deployResult.Deployment()
 	}
+	deployedVersion, versionDisplay := rollbackVersionIDs(deployed, selectedVersion)
+
 	ctx.Printf("Rolling back %s to version %s\n", opts.App, versionDisplay)
 
-	if err := awaitHealthy(ctx, opts.App, selectedVersion, versionDisplay); err != nil {
+	if err := awaitHealthy(ctx, opts.App, deployedVersion, versionDisplay); err != nil {
 		return err
 	}
 
@@ -131,4 +133,32 @@ func Rollback(ctx *Context, opts struct {
 	}
 
 	return nil
+}
+
+// rollbackVersionIDs reports which version to wait on and which to show, given
+// the deployment the server opened and the version the operator picked.
+//
+// The two can differ. The server activates a version *derived* from the selected
+// one whenever the app's addon bindings or operator-set env vars have to be
+// carried forward onto it (MIR-1579), and the deployment record then names the
+// derived version. Waiting on the id we asked for would never see it go active,
+// and the wait would fail with "never became active" — the same message that
+// sent operators down the path that caused MIR-1579 in the first place.
+//
+// A nil deployment, or one that names no version, falls back to the selection so
+// an older server that returns neither still behaves as before.
+func rollbackVersionIDs(dep *deployment_v1alpha.DeploymentInfo, selectedVersion string) (deployed, display string) {
+	deployed, display = selectedVersion, selectedVersion
+	if dep == nil {
+		return deployed, display
+	}
+
+	if id := dep.AppVersionId(); id != "" {
+		deployed = id
+		display = id
+	}
+	if dep.HasAppVersionShortId() && dep.AppVersionShortId() != "" {
+		display = dep.AppVersionShortId()
+	}
+	return deployed, display
 }

--- a/cli/commands/app_rollback_test.go
+++ b/cli/commands/app_rollback_test.go
@@ -1,0 +1,81 @@
+package commands
+
+import (
+	"testing"
+
+	"miren.dev/runtime/api/deployment/deployment_v1alpha"
+)
+
+func TestRollbackVersionIDs(t *testing.T) {
+	depInfo := func(versionID, shortID string) *deployment_v1alpha.DeploymentInfo {
+		d := &deployment_v1alpha.DeploymentInfo{}
+		if versionID != "" {
+			d.SetAppVersionId(versionID)
+		}
+		if shortID != "" {
+			d.SetAppVersionShortId(shortID)
+		}
+		return d
+	}
+
+	tests := []struct {
+		name        string
+		dep         *deployment_v1alpha.DeploymentInfo
+		selected    string
+		wantDeploy  string
+		wantDisplay string
+	}{
+		{
+			// MIR-1579: the server carries the app's addon bindings onto the
+			// selected version, which means activating a *derived* version. The
+			// health wait has to follow that one — waiting on the selected id
+			// would hang until it reported "never became active".
+			name:        "derived version is what gets awaited",
+			dep:         depInfo("myapp-vDerived", "d3r1v"),
+			selected:    "myapp-vOld",
+			wantDeploy:  "myapp-vDerived",
+			wantDisplay: "d3r1v",
+		},
+		{
+			name:        "verbatim activation awaits the selected version",
+			dep:         depInfo("myapp-vOld", "0ld"),
+			selected:    "myapp-vOld",
+			wantDeploy:  "myapp-vOld",
+			wantDisplay: "0ld",
+		},
+		{
+			name:        "full id is displayed when no short id is set",
+			dep:         depInfo("myapp-vDerived", ""),
+			selected:    "myapp-vOld",
+			wantDeploy:  "myapp-vDerived",
+			wantDisplay: "myapp-vDerived",
+		},
+		{
+			// An older server may return a deployment naming no version.
+			name:        "empty version falls back to the selection",
+			dep:         depInfo("", ""),
+			selected:    "myapp-vOld",
+			wantDeploy:  "myapp-vOld",
+			wantDisplay: "myapp-vOld",
+		},
+		{
+			name:        "nil deployment falls back to the selection",
+			dep:         nil,
+			selected:    "myapp-vOld",
+			wantDeploy:  "myapp-vOld",
+			wantDisplay: "myapp-vOld",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployed, display := rollbackVersionIDs(tt.dep, tt.selected)
+			if deployed != tt.wantDeploy {
+				t.Errorf("deployed = %q, want %q", deployed, tt.wantDeploy)
+			}
+			if display != tt.wantDisplay {
+				t.Errorf("display = %q, want %q", display, tt.wantDisplay)
+			}
+		})
+	}
+}

--- a/hack/blackbox-groups.json
+++ b/hack/blackbox-groups.json
@@ -52,6 +52,7 @@
         "TestRoutePasswordProviderLifecycle",
         "TestAddonVariants",
         "TestAddonListAvailable",
+        "TestAddonEnvSurvivesDeployVersion",
         "TestDistributedRunnerCordon",
         "TestDistributedRunnerDrain",
         "TestDistributedRunnerList",

--- a/servers/deployment/envcarry_test.go
+++ b/servers/deployment/envcarry_test.go
@@ -1,0 +1,578 @@
+package deployment
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	coreutil "miren.dev/runtime/api/core"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	deployment_v1alpha "miren.dev/runtime/api/deployment/deployment_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/secret"
+)
+
+// envFixture builds an app with two versions in the in-memory store: a target
+// version (the one a -V deploy names) and a live version that is currently
+// active. Both get a real ConfigVersion, the way every version minted since the
+// config-version split does.
+type envFixture struct {
+	ctx     context.Context
+	inmem   *testutils.InMemEntityServer
+	server  *DeploymentServer
+	client  *deployment_v1alpha.DeploymentClient
+	appName string
+	appID   entity.Id
+}
+
+func newEnvFixture(t *testing.T, appName string, targetVars, liveVars []core_v1alpha.ConfigSpecVariables) *envFixture {
+	t.Helper()
+
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	server, err := newTestDeploymentServer(t, slog.Default(), inmem)
+	if err != nil {
+		t.Fatalf("failed to create deployment server: %v", err)
+	}
+
+	appID, err := inmem.Client.Create(ctx, appName, &core_v1alpha.App{})
+	if err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+
+	f := &envFixture{
+		ctx:     ctx,
+		inmem:   inmem,
+		server:  server,
+		client:  &deployment_v1alpha.DeploymentClient{Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server))},
+		appName: appName,
+		appID:   appID,
+	}
+
+	f.createVersion(t, appName+"-target", targetVars)
+	liveID := f.createVersion(t, appName+"-live", liveVars)
+
+	if err := inmem.Client.Update(ctx, &core_v1alpha.App{ID: appID, ActiveVersion: liveID}); err != nil {
+		t.Fatalf("failed to set active version: %v", err)
+	}
+
+	return f
+}
+
+func (f *envFixture) createVersion(t *testing.T, name string, vars []core_v1alpha.ConfigSpecVariables) entity.Id {
+	t.Helper()
+
+	cvID, err := f.inmem.Client.Create(f.ctx, name+"-cfg", &core_v1alpha.ConfigVersion{
+		App:  f.appID,
+		Spec: core_v1alpha.ConfigSpec{Entrypoint: "/app/server", Variables: vars},
+	})
+	if err != nil {
+		t.Fatalf("failed to create config version %s: %v", name, err)
+	}
+
+	id, err := f.inmem.Client.Create(f.ctx, name, &core_v1alpha.AppVersion{
+		App:           f.appID,
+		Version:       name,
+		ImageUrl:      "registry.example/" + name,
+		ConfigVersion: cvID,
+	})
+	if err != nil {
+		t.Fatalf("failed to create app version %s: %v", name, err)
+	}
+	return id
+}
+
+// deploy runs the -V path against the target version and returns the config the
+// app ends up running, plus the version name that actually went active.
+func (f *envFixture) deploy(t *testing.T, envVars []*deployment_v1alpha.EnvironmentVariable) (*core_v1alpha.ConfigSpec, string) {
+	t.Helper()
+
+	result, err := f.client.DeployVersion(f.ctx, f.appName, "cluster1", f.appName+"-target", false, envVars, "", "")
+	if err != nil {
+		t.Fatalf("DeployVersion failed: %v", err)
+	}
+	if result.HasError() && result.Error() != "" {
+		t.Fatalf("DeployVersion returned error: %s", result.Error())
+	}
+
+	var app core_v1alpha.App
+	if err := f.inmem.Client.Get(f.ctx, f.appName, &app); err != nil {
+		t.Fatalf("failed to re-read app: %v", err)
+	}
+	if app.ActiveVersion == "" {
+		t.Fatal("app has no active version after deploy")
+	}
+
+	var active core_v1alpha.AppVersion
+	if err := f.inmem.Client.GetById(f.ctx, app.ActiveVersion, &active); err != nil {
+		t.Fatalf("failed to read active version: %v", err)
+	}
+
+	spec, err := coreutil.ResolveConfig(f.ctx, f.inmem.EAC, &active)
+	if err != nil {
+		t.Fatalf("failed to resolve active config: %v", err)
+	}
+	return spec, active.Version
+}
+
+func cfgVar(key, value, source string) core_v1alpha.ConfigSpecVariables {
+	return core_v1alpha.ConfigSpecVariables{Key: key, Value: value, Source: source}
+}
+
+func lookupVar(t *testing.T, spec *core_v1alpha.ConfigSpec, key string) core_v1alpha.ConfigSpecVariables {
+	t.Helper()
+	for _, v := range spec.Variables {
+		if v.Key == key {
+			return v
+		}
+	}
+	t.Fatalf("variable %q missing from resolved config %+v", key, spec.Variables)
+	return core_v1alpha.ConfigSpecVariables{}
+}
+
+func hasVar(spec *core_v1alpha.ConfigSpec, key string) bool {
+	for _, v := range spec.Variables {
+		if v.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// MIR-1579. An addon injects its variables by minting a successor version, so
+// the version a failed first deploy names has never contained DATABASE_URL.
+// Re-activating it with `miren deploy -V` used to leave the app permanently
+// without its database credentials, recoverable only by destroying the addon.
+func TestDeployVersionPreservesAddonEnvVars(t *testing.T) {
+	f := newEnvFixture(t, "addonapp",
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("DB_POOL_SIZE", "5", coreutil.SourceConfig)},
+		[]core_v1alpha.ConfigSpecVariables{
+			cfgVar("DB_POOL_SIZE", "5", coreutil.SourceConfig),
+			cfgVar("DATABASE_URL", "postgres://live/db", coreutil.SourceAddon),
+			cfgVar("PGPASSWORD", "hunter2", coreutil.SourceAddon),
+		})
+
+	spec, activeVersion := f.deploy(t, nil)
+
+	dbURL := lookupVar(t, spec, "DATABASE_URL")
+	if dbURL.Value != "postgres://live/db" {
+		t.Errorf("DATABASE_URL = %q, want the live value", dbURL.Value)
+	}
+	// Deprovision only strips keys whose source is exactly "addon"; relabelling
+	// would leak the variable when the addon is later removed.
+	if dbURL.Source != coreutil.SourceAddon {
+		t.Errorf("DATABASE_URL source = %q, want %q", dbURL.Source, coreutil.SourceAddon)
+	}
+	if !hasVar(spec, "PGPASSWORD") {
+		t.Error("PGPASSWORD was not carried forward")
+	}
+
+	if activeVersion == "addonapp-target" {
+		t.Error("expected a derived version to be activated, got the target version verbatim")
+	}
+}
+
+func TestDeployVersionPreservesManualEnvVars(t *testing.T) {
+	f := newEnvFixture(t, "manualapp",
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("API_TOKEN", "old", coreutil.SourceManual)},
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("API_TOKEN", "rotated", coreutil.SourceManual)})
+
+	spec, _ := f.deploy(t, nil)
+
+	if got := lookupVar(t, spec, "API_TOKEN"); got.Value != "rotated" {
+		t.Errorf("API_TOKEN = %q, want the current live value %q", got.Value, "rotated")
+	}
+}
+
+// app.toml belongs to the build, so a -V deploy gets the pinned version's value.
+func TestDeployVersionKeepsConfigVarsFromTargetVersion(t *testing.T) {
+	f := newEnvFixture(t, "configapp",
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("LOG_LEVEL", "debug", coreutil.SourceConfig)},
+		[]core_v1alpha.ConfigSpecVariables{
+			cfgVar("LOG_LEVEL", "info", coreutil.SourceConfig),
+			cfgVar("DATABASE_URL", "postgres://live/db", coreutil.SourceAddon),
+		})
+
+	spec, _ := f.deploy(t, nil)
+
+	if got := lookupVar(t, spec, "LOG_LEVEL"); got.Value != "debug" {
+		t.Errorf("LOG_LEVEL = %q, want the target version's value %q", got.Value, "debug")
+	}
+	if !hasVar(spec, "DATABASE_URL") {
+		t.Error("DATABASE_URL was not carried forward alongside the config var")
+	}
+}
+
+// The merge is additive: re-activating an old version must never be the thing
+// that deletes a variable.
+func TestDeployVersionDoesNotDeleteTargetOnlyVars(t *testing.T) {
+	f := newEnvFixture(t, "additiveapp",
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("LEGACY_FLAG", "1", coreutil.SourceManual)},
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("DATABASE_URL", "postgres://live/db", coreutil.SourceAddon)})
+
+	spec, _ := f.deploy(t, nil)
+
+	if !hasVar(spec, "LEGACY_FLAG") {
+		t.Error("LEGACY_FLAG was deleted; the carry-forward merge must be additive")
+	}
+	if !hasVar(spec, "DATABASE_URL") {
+		t.Error("DATABASE_URL was not carried forward")
+	}
+}
+
+// An app whose config has not moved on should keep its exact version identity —
+// blackbox/rollback_test.go asserts the active version id flips back precisely.
+func TestDeployVersionActivatesVerbatimWhenNothingToCarry(t *testing.T) {
+	vars := []core_v1alpha.ConfigSpecVariables{cfgVar("LOG_LEVEL", "info", coreutil.SourceConfig)}
+	f := newEnvFixture(t, "plainapp", vars, vars)
+
+	spec, activeVersion := f.deploy(t, nil)
+
+	if activeVersion != "plainapp-target" {
+		t.Errorf("active version = %q, want the target version activated verbatim", activeVersion)
+	}
+	if len(spec.Variables) != 1 {
+		t.Errorf("variables = %+v, want just the one", spec.Variables)
+	}
+}
+
+// `deploy -V <ver> -e KEY=VAL` used to clone the version without its
+// ConfigVersion and merge the CLI vars into the (empty) legacy inline config,
+// wiping every variable, service, entrypoint, port and disk the app had.
+func TestDeployVersionWithCliEnvVarsKeepsFullConfig(t *testing.T) {
+	f := newEnvFixture(t, "cliapp",
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("LOG_LEVEL", "debug", coreutil.SourceConfig)},
+		[]core_v1alpha.ConfigSpecVariables{
+			cfgVar("LOG_LEVEL", "debug", coreutil.SourceConfig),
+			cfgVar("DATABASE_URL", "postgres://live/db", coreutil.SourceAddon),
+		})
+
+	ev := &deployment_v1alpha.EnvironmentVariable{}
+	ev.SetKey("FEATURE_FLAG")
+	ev.SetValue("on")
+
+	spec, _ := f.deploy(t, []*deployment_v1alpha.EnvironmentVariable{ev})
+
+	if got := lookupVar(t, spec, "FEATURE_FLAG"); got.Value != "on" || got.Source != coreutil.SourceManual {
+		t.Errorf("FEATURE_FLAG = %+v, want value \"on\" with source %q", got, coreutil.SourceManual)
+	}
+	if !hasVar(spec, "LOG_LEVEL") {
+		t.Error("LOG_LEVEL lost — the derived version dropped the target's config")
+	}
+	if !hasVar(spec, "DATABASE_URL") {
+		t.Error("DATABASE_URL lost — the derived version dropped the carried addon vars")
+	}
+	if spec.Entrypoint != "/app/server" {
+		t.Errorf("entrypoint = %q, want the target version's config to survive", spec.Entrypoint)
+	}
+}
+
+// A -e/-s that shadows an app.toml declaration must not blank the metadata that
+// declaration carries: `miren env list` shows the description, and the next
+// build's validateRequiredVars reads Required.
+func TestDeployVersionCliEnvVarsKeepDeclaredMetadata(t *testing.T) {
+	declared := core_v1alpha.ConfigSpecVariables{
+		Key:         "API_TOKEN",
+		Value:       "",
+		Source:      coreutil.SourceConfig,
+		Required:    true,
+		Description: "Shared secret for the write endpoints",
+	}
+	f := newEnvFixture(t, "metaapp",
+		[]core_v1alpha.ConfigSpecVariables{declared},
+		[]core_v1alpha.ConfigSpecVariables{declared})
+
+	ev := &deployment_v1alpha.EnvironmentVariable{}
+	ev.SetKey("API_TOKEN")
+	ev.SetValue("supplied")
+	ev.SetSensitive(true)
+
+	spec, _ := f.deploy(t, []*deployment_v1alpha.EnvironmentVariable{ev})
+
+	got := lookupVar(t, spec, "API_TOKEN")
+	if got.Value != "supplied" || got.Source != coreutil.SourceManual || !got.Sensitive {
+		t.Errorf("API_TOKEN = %+v, want the supplied value as a sensitive manual var", got)
+	}
+	if !got.Required {
+		t.Error("Required was dropped; the next build would treat a declared-required var as optional")
+	}
+	if got.Description != declared.Description {
+		t.Errorf("Description = %q, want it carried from the app.toml declaration", got.Description)
+	}
+}
+
+// A CLI-supplied value is the operator being explicit, so it beats the value
+// currently live on the app.
+func TestDeployVersionCliEnvVarsOverrideCarriedVars(t *testing.T) {
+	f := newEnvFixture(t, "overrideapp",
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("API_TOKEN", "old", coreutil.SourceManual)},
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("API_TOKEN", "live", coreutil.SourceManual)})
+
+	ev := &deployment_v1alpha.EnvironmentVariable{}
+	ev.SetKey("API_TOKEN")
+	ev.SetValue("explicit")
+
+	spec, _ := f.deploy(t, []*deployment_v1alpha.EnvironmentVariable{ev})
+
+	if got := lookupVar(t, spec, "API_TOKEN"); got.Value != "explicit" {
+		t.Errorf("API_TOKEN = %q, want the CLI-supplied value", got.Value)
+	}
+}
+
+// An ephemeral -V deploy must mint exactly one AppVersion: the ephemeral one.
+// Deriving a full version pair first left the intermediate AppVersion orphaned —
+// never activated, never referenced, but still consuming one of the retention
+// GC's RetentionCount slots on every preview deploy.
+func TestDeployVersionEphemeralDoesNotOrphanADerivedVersion(t *testing.T) {
+	f := newEnvFixture(t, "ephapp",
+		[]core_v1alpha.ConfigSpecVariables{cfgVar("LOG_LEVEL", "info", coreutil.SourceConfig)},
+		[]core_v1alpha.ConfigSpecVariables{
+			cfgVar("LOG_LEVEL", "info", coreutil.SourceConfig),
+			cfgVar("DATABASE_URL", "postgres://live/db", coreutil.SourceAddon),
+		})
+
+	before := countAppVersions(t, f)
+
+	result, err := f.client.DeployVersion(f.ctx, f.appName, "cluster1", f.appName+"-target", false, nil, "preview", "1h")
+	if err != nil {
+		t.Fatalf("DeployVersion failed: %v", err)
+	}
+	if result.HasError() && result.Error() != "" {
+		t.Fatalf("DeployVersion returned error: %s", result.Error())
+	}
+
+	if got := countAppVersions(t, f) - before; got != 1 {
+		t.Errorf("created %d AppVersions, want exactly 1 (the ephemeral one)", got)
+	}
+
+	// The ephemeral version still has to carry the app's addon bindings.
+	eph := ephemeralVersion(t, f, "preview")
+	spec, err := coreutil.ResolveConfig(f.ctx, f.inmem.EAC, eph)
+	if err != nil {
+		t.Fatalf("failed to resolve ephemeral config: %v", err)
+	}
+	if !hasVar(spec, "DATABASE_URL") {
+		t.Errorf("ephemeral version missing carried addon var: %+v", spec.Variables)
+	}
+	if !hasVar(spec, "LOG_LEVEL") {
+		t.Errorf("ephemeral version lost the target version's config: %+v", spec.Variables)
+	}
+}
+
+// A legacy version stores its config inline with no ConfigVersion. When there is
+// nothing to carry forward, an ephemeral deploy must leave that inline config
+// alone rather than blanking it alongside a ConfigVersion it never minted.
+func TestDeployVersionEphemeralKeepsLegacyInlineConfig(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	server, err := newTestDeploymentServer(t, slog.Default(), inmem)
+	if err != nil {
+		t.Fatalf("failed to create deployment server: %v", err)
+	}
+
+	appID, err := inmem.Client.Create(ctx, "legacyapp", &core_v1alpha.App{})
+	if err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+
+	// No ConfigVersion — config lives in the inline Config field.
+	versionID, err := inmem.Client.Create(ctx, "legacyapp-target", &core_v1alpha.AppVersion{
+		App:     appID,
+		Version: "legacyapp-target",
+		Config: core_v1alpha.Config{
+			Entrypoint: "/app/legacy",
+			Variable:   []core_v1alpha.Variable{{Key: "LEGACY_VAR", Value: "kept", Source: coreutil.SourceConfig}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create app version: %v", err)
+	}
+	if err := inmem.Client.Update(ctx, &core_v1alpha.App{ID: appID, ActiveVersion: versionID}); err != nil {
+		t.Fatalf("failed to set active version: %v", err)
+	}
+
+	f := &envFixture{
+		ctx:     ctx,
+		inmem:   inmem,
+		server:  server,
+		client:  &deployment_v1alpha.DeploymentClient{Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server))},
+		appName: "legacyapp",
+		appID:   appID,
+	}
+
+	result, err := f.client.DeployVersion(ctx, "legacyapp", "cluster1", "legacyapp-target", false, nil, "preview", "1h")
+	if err != nil {
+		t.Fatalf("DeployVersion failed: %v", err)
+	}
+	if result.HasError() && result.Error() != "" {
+		t.Fatalf("DeployVersion returned error: %s", result.Error())
+	}
+
+	eph := ephemeralVersion(t, f, "preview")
+	spec, err := coreutil.ResolveConfig(ctx, inmem.EAC, eph)
+	if err != nil {
+		t.Fatalf("failed to resolve ephemeral config: %v", err)
+	}
+	if !hasVar(spec, "LEGACY_VAR") {
+		t.Errorf("inline config was blanked: %+v", spec.Variables)
+	}
+	if spec.Entrypoint != "/app/legacy" {
+		t.Errorf("entrypoint = %q, want the legacy inline value", spec.Entrypoint)
+	}
+}
+
+func countAppVersions(t *testing.T, f *envFixture) int {
+	t.Helper()
+	resp, err := f.inmem.EAC.List(f.ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion))
+	if err != nil {
+		t.Fatalf("failed to list app versions: %v", err)
+	}
+	return len(resp.Values())
+}
+
+func ephemeralVersion(t *testing.T, f *envFixture, label string) *core_v1alpha.AppVersion {
+	t.Helper()
+	resp, err := f.inmem.EAC.List(f.ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindAppVersion))
+	if err != nil {
+		t.Fatalf("failed to list app versions: %v", err)
+	}
+	for _, e := range resp.Values() {
+		var av core_v1alpha.AppVersion
+		av.Decode(e.Entity())
+		if av.EphemeralLabel == label {
+			return &av
+		}
+	}
+	t.Fatalf("no ephemeral version with label %q", label)
+	return nil
+}
+
+// ReplaceExisting deletes the preview currently holding the label. Resolving the
+// config after that point would mean a resolution failure leaves the operator
+// with neither the old preview nor a new one, so the resolve has to come first.
+func TestDeployVersionEphemeralKeepsOldPreviewWhenResolveFails(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	server, err := newTestDeploymentServer(t, slog.Default(), inmem)
+	if err != nil {
+		t.Fatalf("failed to create deployment server: %v", err)
+	}
+
+	appID, err := inmem.Client.Create(ctx, "previewapp", &core_v1alpha.App{})
+	if err != nil {
+		t.Fatalf("failed to create app: %v", err)
+	}
+
+	// A target version pointing at a ConfigVersion that does not exist, so
+	// resolving its config fails.
+	if _, err := inmem.Client.Create(ctx, "previewapp-target", &core_v1alpha.AppVersion{
+		App:           appID,
+		Version:       "previewapp-target",
+		ConfigVersion: entity.Id("missing-config-version"),
+	}); err != nil {
+		t.Fatalf("failed to create app version: %v", err)
+	}
+
+	// The preview that must survive the failed deploy.
+	existingID, err := inmem.Client.Create(ctx, "previewapp-eph-old", &core_v1alpha.AppVersion{
+		App:            appID,
+		Version:        "previewapp-eph-old",
+		EphemeralLabel: "preview",
+		EphemeralTtl:   "24h",
+	})
+	if err != nil {
+		t.Fatalf("failed to create existing ephemeral version: %v", err)
+	}
+
+	client := &deployment_v1alpha.DeploymentClient{Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server))}
+	result, err := client.DeployVersion(ctx, "previewapp", "cluster1", "previewapp-target", false, nil, "preview", "1h")
+	if err != nil {
+		t.Fatalf("DeployVersion returned a transport error: %v", err)
+	}
+	if !result.HasError() || result.Error() == "" {
+		t.Fatal("expected the deploy to fail on the unresolvable config")
+	}
+
+	var survivor core_v1alpha.AppVersion
+	if err := inmem.Client.GetById(ctx, existingID, &survivor); err != nil {
+		t.Fatalf("the existing preview was deleted before the config failed to resolve: %v", err)
+	}
+	if survivor.EphemeralLabel != "preview" {
+		t.Errorf("existing preview lost its label: %+v", survivor)
+	}
+}
+
+// A -e/-s literal replaces a secret reference on that key outright: the value is
+// inline now, so the old backend pointer must not survive and turn it back into
+// a reference. A caller that does supply a backend keeps it, so the reference
+// still reaches createConfigVersion to be pinned.
+func TestDeployVersionCliEnvVarBackendHandling(t *testing.T) {
+	referenced := core_v1alpha.ConfigSpecVariables{
+		Key:       "API_TOKEN",
+		Value:     "prod/api-token",
+		Backend:   "vault",
+		Sensitive: true,
+		Source:    coreutil.SourceManual,
+	}
+
+	t.Run("literal clears the backend it replaces", func(t *testing.T) {
+		f := newEnvFixture(t, "litapp",
+			[]core_v1alpha.ConfigSpecVariables{referenced},
+			[]core_v1alpha.ConfigSpecVariables{referenced})
+
+		ev := &deployment_v1alpha.EnvironmentVariable{}
+		ev.SetKey("API_TOKEN")
+		ev.SetValue("inline-literal")
+
+		spec, _ := f.deploy(t, []*deployment_v1alpha.EnvironmentVariable{ev})
+
+		got := lookupVar(t, spec, "API_TOKEN")
+		if got.Value != "inline-literal" {
+			t.Errorf("value = %q, want the literal", got.Value)
+		}
+		if got.Backend != "" {
+			t.Errorf("backend = %q, want it cleared so the literal is not read as a reference", got.Backend)
+		}
+	})
+
+	t.Run("supplied backend reference is preserved and pinned", func(t *testing.T) {
+		f := newEnvFixture(t, "refapp",
+			[]core_v1alpha.ConfigSpecVariables{cfgVar("API_TOKEN", "old", coreutil.SourceManual)},
+			[]core_v1alpha.ConfigSpecVariables{cfgVar("API_TOKEN", "old", coreutil.SourceManual)})
+		f.server.Secrets = pinningResolver{}
+
+		ev := &deployment_v1alpha.EnvironmentVariable{}
+		ev.SetKey("API_TOKEN")
+		ev.SetValue("prod/api-token")
+		ev.SetBackend("vault")
+		ev.SetSensitive(true)
+
+		spec, _ := f.deploy(t, []*deployment_v1alpha.EnvironmentVariable{ev})
+
+		got := lookupVar(t, spec, "API_TOKEN")
+		if got.Backend != "vault" {
+			t.Errorf("backend = %q, want it carried through so the reference can be pinned", got.Backend)
+		}
+		// Reaching the resolver at all is the point: a dropped backend would
+		// have left this an unpinned literal.
+		if got.Value != "prod/api-token@v1" {
+			t.Errorf("value = %q, want the reference pinned to a concrete version", got.Value)
+		}
+	})
+}
+
+// pinningResolver stands in for a cluster secret backend, resolving any ref to a
+// fixed version so a pinned ConfigVersion can be asserted.
+type pinningResolver struct{}
+
+func (pinningResolver) ResolveRef(_ context.Context, _, ref string) (secret.SecretValue, error) {
+	return secret.SecretValue{Ref: ref + "@v1", Bytes: []byte("value")}, nil
+}

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	appclient "miren.dev/runtime/api/app"
+	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	deployment_v1alpha "miren.dev/runtime/api/deployment/deployment_v1alpha"
 	aes "miren.dev/runtime/api/entityserver"
@@ -772,21 +773,6 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 		return err
 	}
 
-	// If env vars are provided, create a derived version with merged variables
-	if args.HasEnvVars() && len(args.EnvVars()) > 0 {
-		derivedVersion, err := d.createDerivedVersion(ctx, &appVersion, args.EnvVars())
-		if err != nil {
-			d.Log.Error("Failed to create derived version with env vars", "error", err)
-			results.SetError(fmt.Sprintf("failed to apply env vars: %v", err))
-			return nil
-		}
-		appVersion = *derivedVersion
-		appVersionId = derivedVersion.Version
-		d.Log.Info("Created derived version with env vars",
-			"original", args.AppVersionId(), "derived", appVersionId,
-			"env_var_count", len(args.EnvVars()))
-	}
-
 	isEphemeral := args.HasEphemeralLabel() && args.EphemeralLabel() != ""
 
 	if isEphemeral {
@@ -819,6 +805,18 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 			return nil
 		}
 
+		// An ephemeral deploy off an old version needs the app's addon bindings
+		// just as much as a normal one. Resolve before ReplaceExisting, which
+		// deletes the preview currently holding this label: a resolution failure
+		// after that point would leave the operator with neither the old preview
+		// nor a new one.
+		spec, needsDerived, err := d.resolveDeployConfig(ctx, appName, &appVersion, args.EnvVars())
+		if err != nil {
+			d.Log.Error("Failed to resolve config for ephemeral version", "app", appName, "version", appVersionId, "error", err)
+			results.SetError(fmt.Sprintf("failed to resolve config: %v", err))
+			return nil
+		}
+
 		if err := ephemeralx.ReplaceExisting(ctx, d.EAC, appEntity.ID, ephLabel, d.Log); err != nil {
 			results.SetError(fmt.Sprintf("failed to replace existing ephemeral version %q: %v", ephLabel, err))
 			return nil
@@ -838,6 +836,22 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 
 		ephName := appName + "-eph-" + idgen.Gen("v")
 		ephVersion.Version = ephName
+
+		// Only the ConfigVersion is minted here — ephVersion is the AppVersion
+		// that gets created, so deriving a full version pair first would leave
+		// the intermediate one orphaned. Config is blanked only alongside a new
+		// ConfigVersion, so a legacy inline-config version with nothing to carry
+		// keeps its inline config.
+		if needsDerived {
+			cvid, cvErr := d.createConfigVersion(ctx, &appVersion, spec)
+			if cvErr != nil {
+				d.Log.Error("Failed to create config version for ephemeral deploy", "app", appName, "error", cvErr)
+				results.SetError(fmt.Sprintf("failed to apply config: %v", cvErr))
+				return nil
+			}
+			ephVersion.ConfigVersion = cvid
+			ephVersion.Config = core_v1alpha.Config{}
+		}
 
 		ephID, createErr := d.EC.Create(ctx, ephName, &ephVersion)
 		if createErr != nil {
@@ -910,6 +924,57 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 	// that cancellation is right here, in the failure path.
 	settleCtx, cancelSettle := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer cancelSettle()
+
+	// Work out what this version should actually run with: its own config, plus
+	// the addon bindings and operator-set variables that belong to the app, plus
+	// any CLI-supplied vars. When that differs from what the version already
+	// stores, activate a derived version carrying the merged config instead.
+	//
+	// This sits after Begin so the read-merge-activate runs under the deploy
+	// lock and a concurrent deploy for the same app cannot land between the read
+	// and the activation. It does not close the window against the addon
+	// controller, which swings active_version under its own CAS without taking
+	// this lock — that needs SetActiveVersion to become a CAS too (MIR-1579
+	// follow-up).
+	spec, needsDerived, err := d.resolveDeployConfig(ctx, appName, &appVersion, args.EnvVars())
+	if err != nil {
+		d.Log.Error("Failed to resolve config for version", "app", appName, "version", appVersionId, "error", err)
+		failMsg := fmt.Sprintf("failed to resolve config: %v", err)
+		if failErr := d.tracker.Fail(settleCtx, newDeploymentId, failMsg, ""); failErr != nil {
+			d.Log.Error("Failed to mark deployment as failed; releasing lock", "error", failErr)
+			d.releaseDeployLock(settleCtx, appName, newDeploymentId)
+		}
+		results.SetError(failMsg)
+		return nil
+	}
+	if needsDerived {
+		derivedVersion, deriveErr := d.deriveVersion(ctx, &appVersion, spec)
+		if deriveErr != nil {
+			d.Log.Error("Failed to create derived version", "app", appName, "error", deriveErr)
+			failMsg := fmt.Sprintf("failed to apply config: %v", deriveErr)
+			if failErr := d.tracker.Fail(settleCtx, newDeploymentId, failMsg, ""); failErr != nil {
+				d.Log.Error("Failed to mark deployment as failed; releasing lock", "error", failErr)
+				d.releaseDeployLock(settleCtx, appName, newDeploymentId)
+			}
+			results.SetError(failMsg)
+			return nil
+		}
+		appVersion = *derivedVersion
+		appVersionId = derivedVersion.Version
+
+		// The record was opened against the source version; point it at what is
+		// actually going live so the deployment history and the CLI's health
+		// wait both name the right version. This carries the version *name*, not
+		// the entity id — that is what the record holds on every other path, and
+		// what awaitHealthy on the client matches against.
+		if setErr := d.tracker.SetAppVersion(ctx, newDeploymentId, derivedVersion.Version); setErr != nil {
+			d.Log.Error("Failed to record derived version on deployment", "error", setErr)
+		}
+
+		d.Log.Info("Created derived version to preserve app config",
+			"app", appName, "source_version", sourceVersionId, "derived_version", appVersionId,
+			"variable_count", len(spec.Variables), "cli_env_var_count", len(args.EnvVars()))
+	}
 
 	// This path has no build; it goes straight to activation.
 	//
@@ -1429,8 +1494,6 @@ func (w *rpcEntityWrapper) Attrs() []entity.Attr {
 	return w.entity.Attrs()
 }
 
-// createDerivedVersion clones an existing AppVersion with CLI env vars merged
-// into its config, creates the new entity, and returns it.
 // verifyVersionOwnedByApp rejects deploying an AppVersion that belongs to a
 // different app than appName.
 //
@@ -1460,42 +1523,32 @@ func (d *DeploymentServer) verifyVersionOwnedByApp(ctx context.Context, version 
 	return nil
 }
 
-func (d *DeploymentServer) createDerivedVersion(ctx context.Context, base *core_v1alpha.AppVersion, envVars []*deployment_v1alpha.EnvironmentVariable) (*core_v1alpha.AppVersion, error) {
-	// Extract app name from the base version's App field (e.g. "app/go-server" -> "go-server")
-	appName := string(base.App)
-	if idx := len("app/"); len(appName) > idx && appName[:idx] == "app/" {
-		appName = appName[idx:]
-	}
-
+// deriveVersion clones an existing AppVersion onto a new ConfigSpec, minting the
+// ConfigVersion + AppVersion pair the rest of the system reads through. The
+// artifact fields are carried over verbatim: the point of this path is to run
+// exactly the image the base version built, under a different configuration.
+//
+// The pair is written the same way as the build path (servers/build/build_saga.go)
+// and the env-mutation path (api/app/envvar.go): config lives in the
+// ConfigVersion entity and the inline Config field is left blank.
+func (d *DeploymentServer) deriveVersion(ctx context.Context, base *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec) (*core_v1alpha.AppVersion, error) {
+	appName := strings.TrimPrefix(string(base.App), "app/")
 	newVersionName := appName + "-" + idgen.Gen("v")
+
+	cvid, err := d.createConfigVersion(ctx, base, spec)
+	if err != nil {
+		return nil, err
+	}
 
 	derived := &core_v1alpha.AppVersion{
 		App:            base.App,
 		Version:        newVersionName,
 		Artifact:       base.Artifact,
 		ImageUrl:       base.ImageUrl,
-		Config:         base.Config,
+		ConfigVersion:  cvid,
 		AdminToken:     base.AdminToken,
 		Manifest:       base.Manifest,
 		ManifestDigest: base.ManifestDigest,
-	}
-
-	// Merge env vars into config
-	varMap := make(map[string]core_v1alpha.Variable)
-	for _, v := range derived.Config.Variable {
-		varMap[v.Key] = v
-	}
-	for _, ev := range envVars {
-		varMap[ev.Key()] = core_v1alpha.Variable{
-			Key:       ev.Key(),
-			Value:     ev.Value(),
-			Sensitive: ev.Sensitive(),
-			Source:    "manual",
-		}
-	}
-	derived.Config.Variable = make([]core_v1alpha.Variable, 0, len(varMap))
-	for _, v := range varMap {
-		derived.Config.Variable = append(derived.Config.Variable, v)
 	}
 
 	id, err := d.EC.Create(ctx, newVersionName, derived)
@@ -1505,4 +1558,141 @@ func (d *DeploymentServer) createDerivedVersion(ctx context.Context, base *core_
 	derived.ID = id
 
 	return derived, nil
+}
+
+// createConfigVersion writes a ConfigVersion entity holding spec, pinning any
+// backend-sourced variables first so the record names the exact secret version
+// it was built with. A spec with no references never needs a resolver, which
+// keeps clusters with no secret backends working exactly as before.
+func (d *DeploymentServer) createConfigVersion(ctx context.Context, base *core_v1alpha.AppVersion, spec *core_v1alpha.ConfigSpec) (entity.Id, error) {
+	if refs := coreutil.SecretReferences(spec); len(refs) > 0 {
+		if d.Secrets == nil {
+			return "", fmt.Errorf("config references secret %s but this cluster has no secret backends configured", refs[0])
+		}
+		if err := coreutil.PinSecrets(ctx, d.Secrets, spec); err != nil {
+			return "", fmt.Errorf("failed to pin secrets: %w", err)
+		}
+	}
+
+	appName := strings.TrimPrefix(string(base.App), "app/")
+	cvid, err := d.EC.Create(ctx, appName+"-"+idgen.Gen("c")+"-cfg", &core_v1alpha.ConfigVersion{
+		App:  base.App,
+		Spec: *spec,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create derived config version: %w", err)
+	}
+	return cvid, nil
+}
+
+// resolveDeployConfig works out the config the named version should actually run
+// with, and reports whether that differs from the version's own stored config.
+//
+// A version is a snapshot of one build. Re-activating an old one (deploy -V, app
+// rollback) must not roll back the things that belong to the app rather than to
+// that build: addon-injected bindings and operator-set variables. An addon
+// injects its variables once, at provision time, by minting a *successor*
+// version — so the version a failed first deploy names has never contained
+// DATABASE_URL, and activating it verbatim stranded the app without a database
+// permanently (MIR-1579).
+//
+// CLI-supplied vars are applied last, so an explicit -e/-s always wins.
+func (d *DeploymentServer) resolveDeployConfig(ctx context.Context, appName string,
+	target *core_v1alpha.AppVersion, envVars []*deployment_v1alpha.EnvironmentVariable) (*core_v1alpha.ConfigSpec, bool, error) {
+
+	spec, err := coreutil.ResolveConfig(ctx, d.EAC, target)
+	if err != nil {
+		return nil, false, fmt.Errorf("resolving config for version %s: %w", target.Version, err)
+	}
+
+	changed := false
+
+	if live, err := d.liveConfig(ctx, appName); err != nil {
+		return nil, false, err
+	} else if live != nil {
+		changed = coreutil.CarryForwardVars(spec, live)
+	}
+
+	for _, ev := range envVars {
+		if mergeManualVar(spec, ev) {
+			changed = true
+		}
+	}
+
+	return spec, changed, nil
+}
+
+// liveConfig resolves the config the app is running right now, or nil when it
+// has never been deployed.
+func (d *DeploymentServer) liveConfig(ctx context.Context, appName string) (*core_v1alpha.ConfigSpec, error) {
+	var appRec core_v1alpha.App
+	if err := d.EC.Get(ctx, appName, &appRec); err != nil {
+		return nil, fmt.Errorf("getting app %s: %w", appName, err)
+	}
+	if appRec.ActiveVersion == "" {
+		return nil, nil
+	}
+
+	var active core_v1alpha.AppVersion
+	if err := d.EC.GetById(ctx, appRec.ActiveVersion, &active); err != nil {
+		// A dangling active_version is not a reason to refuse the deploy; the
+		// version being activated is still perfectly valid on its own.
+		d.Log.Warn("could not read active version for env carry-forward",
+			"app", appName, "active_version", appRec.ActiveVersion, "error", err)
+		return nil, nil
+	}
+
+	spec, err := coreutil.ResolveConfig(ctx, d.EAC, &active)
+	if err != nil {
+		d.Log.Warn("could not resolve active config for env carry-forward",
+			"app", appName, "active_version", appRec.ActiveVersion, "error", err)
+		return nil, nil
+	}
+	return spec, nil
+}
+
+// mergeManualVar applies one CLI-supplied variable to the spec as an operator
+// value, reporting whether it changed anything.
+//
+// An existing entry is updated field by field rather than replaced, so the
+// app.toml metadata on it — Required and Description — survives a -e/-s that
+// shadows a declared variable. This matches mergeIntoSpec (api/app/envvar.go)
+// and the metadata carry in mergeVariablesFromAppConfig (servers/build/build.go);
+// replacing the struct would blank the description in `miren env list` and make
+// a declared-required variable look optional to the next build's validation.
+//
+// Backend comes from the incoming variable rather than the one being replaced.
+// The `-e KEY=VALUE` callers never set it, so this clears a secret reference the
+// key used to hold, which is what mergeCliEnvVars does and what you want: a
+// literal replaces the reference outright rather than being read as a new
+// reference into the backend the old value named. Carrying the incoming value
+// instead of hardcoding empty means a caller that does supply a reference keeps
+// it, and createConfigVersion pins it like any other.
+func mergeManualVar(spec *core_v1alpha.ConfigSpec, ev *deployment_v1alpha.EnvironmentVariable) bool {
+	for i, existing := range spec.Variables {
+		if existing.Key != ev.Key() {
+			continue
+		}
+
+		updated := existing
+		updated.Value = ev.Value()
+		updated.Sensitive = ev.Sensitive()
+		updated.Source = coreutil.SourceManual
+		updated.Backend = ev.Backend()
+
+		if updated == existing {
+			return false
+		}
+		spec.Variables[i] = updated
+		return true
+	}
+
+	spec.Variables = append(spec.Variables, core_v1alpha.ConfigSpecVariables{
+		Key:       ev.Key(),
+		Value:     ev.Value(),
+		Sensitive: ev.Sensitive(),
+		Source:    coreutil.SourceManual,
+		Backend:   ev.Backend(),
+	})
+	return true
 }


### PR DESCRIPTION
Two operators, independently, on two different clusters, bricked a real app by following the recovery path our own error message points at. Deploy an app with a Postgres addon, the health check fails because there's no migration hook so the schema doesn't exist yet, the error names the version. Apply the schema by hand with `miren app run`, then re-activate the already-built version with `miren deploy -V g8W`, which is documented as "Deploy an existing version (skip build)" and is the obvious way to skip an identical rebuild. At that point `DATABASE_URL` is gone, permanently. Rebuilds don't bring it back, `app restart` doesn't, and `addon list` still cheerfully reports the addon as attached. The only recovery anyone found was destroying the addon, which drops the database.

The reason is that an addon doesn't add its variables to the version you built. It mints a *successor* version and swings `active_version` to that. So `g8W`, the version the failed deploy names in its error, has never contained `DATABASE_URL` at any point. `DeployVersion` activated it verbatim, with no merge base at all, and once it was active a rebuild had nothing to carry forward, because rebuilds copy config from whatever is currently active.

Every other write path already got this right. The build path explicitly preserves `source == "manual" || source == "addon"` across deploys, and the env mutation path merges rather than replaces. `DeployVersion` was the one outlier.

So it now merges the variables that belong to the app rather than to a particular build (`addon` and `manual`) from the live config onto the version being activated, and activates a derived version when that differs. Variables from `app.toml` still come from the pinned version, since those genuinely belong to the build. The merge is additive, so re-activating an old version never deletes anything, and a derived version is only minted when something actually changed, so an ordinary rollback with nothing to carry keeps its exact version identity.

Chasing this turned up a second, worse bug sitting on the same path. `deploy -V <ver> -e KEY=VAL` cloned the version without its `ConfigVersion` and merged the CLI vars into the legacy inline config that every modern version leaves empty. That wiped the entire config: every variable, service, entrypoint, port and disk. Nothing anywhere covered it. Rewriting the derived-version path to mint a real ConfigVersion/AppVersion pair fixes it as a side effect.

The merge runs under the deploy lock so a concurrent deploy can't land between the read and the activation. The addon controller swings `active_version` under its own CAS without taking that lock, so that race stays open until `SetActiveVersion` becomes a CAS too. That's a separate pre-existing defect and I've left a comment at the spot rather than let the code imply more safety than it has.

The second commit is the client half. Now that the server can activate a version derived from the one you picked, `app rollback` waiting on the id it selected would never see it go active, and would fail with "never became active", which is the same message that sent operators down this path in the first place.

Verified end to end on a real cluster: deploy with a Postgres addon, capture the pre-addon version, `deploy -V` back to it, and all six Postgres variables survive with `SOURCE=addon` intact.

### Worth knowing

Carrying manual vars forward means `app rollback` no longer undoes a bad `miren env set`. That was a deliberate scope choice, but it's a behavior change and deserves a doc note (tracked separately, not in this PR). Relatedly, because the merge is additive, `env delete FOO` followed by a rollback to a version that had `FOO` will bring it back, which matters if someone deletes a leaked credential.

`hack/blackbox-groups.json` gets the new test added by hand. That file is normally regenerated from measured CI times, so the shard's `estimated_s` is slightly stale until someone re-runs `make measure-blackbox-times`. I didn't invent a timing entry for it.

Closes MIR-1579
