### PR TITLE
Reach a cluster's RPC through the link it already holds up to cloud

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,7 +264,7 @@ jobs:
 
         # The cloud-backed tests run in their own job (test-blackbox-pop):
         # they need the cloud repo and restart the server. Never shard them.
-        UNGROUPED=$(comm -23 <(echo "$ALL_TESTS") <(echo "$GROUPED") | grep -vxE 'TestPOP|TestRPCViaCloud' || true)
+        UNGROUPED=$(comm -23 <(echo "$ALL_TESTS") <(echo "$GROUPED") | grep -vxE 'TestPOP|TestRPCViaCloud|TestDeployViaCloud' || true)
 
         MATRIX=$(jq -c '.groups' hack/blackbox-groups.json)
 
@@ -349,7 +349,7 @@ jobs:
       # genuine hang.
       run: |
         RUN=$(echo '${{ toJson(matrix.group.tests) }}' | jq -r 'join("|")')
-        go test -tags blackbox -timeout 10m -v -count=1 -p 1 -run "^(${RUN})$" -skip '^(TestPOP|TestRPCViaCloud)$' ./blackbox/...
+        go test -tags blackbox -timeout 10m -v -count=1 -p 1 -run "^(${RUN})$" -skip '^(TestPOP|TestRPCViaCloud|TestDeployViaCloud)$' ./blackbox/...
 
     - name: Server logs on failure
       if: failure()
@@ -446,6 +446,11 @@ jobs:
       env:
         BLACKBOX_CLOUD_REPO: ${{ github.workspace }}/cloud
       run: go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestRPCViaCloud$' ./blackbox/...
+
+    - name: Run cloud deploy blackbox tests
+      env:
+        BLACKBOX_CLOUD_REPO: ${{ github.workspace }}/cloud
+      run: go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestDeployViaCloud$' ./blackbox/...
 
     - name: Server logs on failure
       if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,8 +262,9 @@ jobs:
         # Tests already assigned to a shard in the checked-in manifest.
         GROUPED=$(jq -r '.groups[].tests[]' hack/blackbox-groups.json | sort -u)
 
-        # TestPOP runs in its own job (test-blackbox-pop); never shard it here.
-        UNGROUPED=$(comm -23 <(echo "$ALL_TESTS") <(echo "$GROUPED") | grep -vx 'TestPOP' || true)
+        # The cloud-backed tests run in their own job (test-blackbox-pop):
+        # they need the cloud repo and restart the server. Never shard them.
+        UNGROUPED=$(comm -23 <(echo "$ALL_TESTS") <(echo "$GROUPED") | grep -vxE 'TestPOP|TestRPCViaCloud' || true)
 
         MATRIX=$(jq -c '.groups' hack/blackbox-groups.json)
 
@@ -341,13 +342,14 @@ jobs:
 
     - name: Run blackbox tests (shard ${{ matrix.group.shard }})
       # Each shard runs only its assigned subset, built into a -run regex from
-      # the matrix. TestPOP runs in its own job (test-blackbox-pop) because its
-      # server restart interferes with subsequent deploys; -skip guards against
-      # it ever slipping into a shard. Per-shard runtime is ~3 min, so 10m
-      # restores fast failure on a genuine hang.
+      # the matrix. The cloud-backed tests run in their own job
+      # (test-blackbox-pop) because their server restart interferes with
+      # subsequent deploys; -skip guards against one ever slipping into a
+      # shard. Per-shard runtime is ~3 min, so 10m restores fast failure on a
+      # genuine hang.
       run: |
         RUN=$(echo '${{ toJson(matrix.group.tests) }}' | jq -r 'join("|")')
-        go test -tags blackbox -timeout 10m -v -count=1 -p 1 -run "^(${RUN})$" -skip '^TestPOP$' ./blackbox/...
+        go test -tags blackbox -timeout 10m -v -count=1 -p 1 -run "^(${RUN})$" -skip '^(TestPOP|TestRPCViaCloud)$' ./blackbox/...
 
     - name: Server logs on failure
       if: failure()
@@ -435,6 +437,15 @@ jobs:
       env:
         BLACKBOX_CLOUD_REPO: ${{ github.workspace }}/cloud
       run: go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestPOP$' ./blackbox/...
+
+    # A separate invocation, not another -run alternative: each of these builds
+    # a whole cloud environment on fixed ports and restarts the server, and two
+    # of them in one process leaves the second waiting on a port the first has
+    # not finished releasing.
+    - name: Run cloud RPC blackbox tests
+      env:
+        BLACKBOX_CLOUD_REPO: ${{ github.workspace }}/cloud
+      run: go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestRPCViaCloud$' ./blackbox/...
 
     - name: Server logs on failure
       if: failure()

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,10 @@ measure-blackbox-times: ## Re-measure per-test blackbox times into hack/blackbox
 	python3 hack/measure-blackbox-times.py -o hack/blackbox-test-times.json
 
 test-blackbox: ## Run blackbox tests (requires `make dev` running)
-	go test -tags blackbox -timeout 15m -v -count=1 -p 1 ./blackbox/...
+	# The cloud-backed tests are excluded: each stands up a whole cloud on fixed
+	# ports and restarts the server, which interferes with everything after it.
+	# They have their own target below, and their own CI job.
+	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -skip '^(TestPOP|TestRPCViaCloud)$$' ./blackbox/...
 
 build-cloud-test: ## Build cloud and POP binaries for POP blackbox tests
 	@CLOUD_REPO=$${BLACKBOX_CLOUD_REPO:-$$(cd .. && pwd)/cloud}; \
@@ -188,8 +191,12 @@ build-cloud-test: ## Build cloud and POP binaries for POP blackbox tests
 	cd "$$CLOUD_REPO" && CGO_ENABLED=0 GOOS=linux go build -o $(CURDIR)/bin/bb-pop ./cmd/pop && \
 	echo "Done: bin/bb-cloud, bin/bb-pop"
 
-test-blackbox-pop: ## Run POP blackbox tests (requires `make dev` and cloud repo)
-	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run TestPOP ./blackbox/...
+test-blackbox-pop: ## Run cloud-backed blackbox tests (requires `make dev` and cloud repo)
+	# One invocation each: both build a cloud environment on the same fixed
+	# ports, and running them in a single process leaves the second waiting on
+	# a port the first has not finished releasing.
+	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestPOP$$' ./blackbox/...
+	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestRPCViaCloud$$' ./blackbox/...
 
 test-blackbox-distributed: ## Run blackbox tests against distributed environment (requires hack/dev-distributed up)
 	# Runs the whole blackbox suite (not just the distributed-specific tests)

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ test-blackbox: ## Run blackbox tests (requires `make dev` running)
 	# The cloud-backed tests are excluded: each stands up a whole cloud on fixed
 	# ports and restarts the server, which interferes with everything after it.
 	# They have their own target below, and their own CI job.
-	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -skip '^(TestPOP|TestRPCViaCloud)$$' ./blackbox/...
+	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -skip '^(TestPOP|TestRPCViaCloud|TestDeployViaCloud)$$' ./blackbox/...
 
 build-cloud-test: ## Build cloud and POP binaries for POP blackbox tests
 	@CLOUD_REPO=$${BLACKBOX_CLOUD_REPO:-$$(cd .. && pwd)/cloud}; \
@@ -197,6 +197,7 @@ test-blackbox-pop: ## Run cloud-backed blackbox tests (requires `make dev` and c
 	# a port the first has not finished releasing.
 	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestPOP$$' ./blackbox/...
 	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestRPCViaCloud$$' ./blackbox/...
+	go test -tags blackbox -timeout 15m -v -count=1 -p 1 -run '^TestDeployViaCloud$$' ./blackbox/...
 
 test-blackbox-distributed: ## Run blackbox tests against distributed environment (requires hack/dev-distributed up)
 	# Runs the whole blackbox suite (not just the distributed-specific tests)

--- a/blackbox/cloud_rpc_test.go
+++ b/blackbox/cloud_rpc_test.go
@@ -54,7 +54,15 @@ func TestRPCViaCloud(t *testing.T) {
 		if !r.Success() {
 			return false, "exit " + strconv.Itoa(r.ExitCode) + ": " + r.Stderr
 		}
+
+		// Exiting zero is not the condition being waited for. The grant can
+		// land between the command being permitted and the policy being
+		// visible, and an empty list would end the poll on a result the
+		// assertions below would then reject.
 		relayedApps = appNames(t, r.Stdout)
+		if len(relayedApps) == 0 {
+			return false, "relayed app list is still empty"
+		}
 		return true, ""
 	})
 

--- a/blackbox/cloud_rpc_test.go
+++ b/blackbox/cloud_rpc_test.go
@@ -1,0 +1,112 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"encoding/json"
+	"slices"
+	"strconv"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+// TestRPCViaCloud exercises the whole path an operator with no route to their
+// cluster takes: the CLI dials cloud, cloud relays into the socket the cluster
+// dialed outbound, and the cluster answers.
+//
+//	miren → cloud relay → cluster's uplink → cluster's RPC server
+//
+// The assertion that matters is not that a command succeeds but that it returns
+// the same thing the direct path does. A relay that quietly answered from
+// somewhere else would still exit zero.
+//
+// The RBAC grant in the setup is load-bearing evidence, not boilerplate:
+// without it the cluster refuses these calls with its own policy decision,
+// which is only reachable if it authenticated the caller's bearer and read the
+// groups out of it. Cloud never sees that token — it is inside a CBOR frame —
+// so nothing here could be cloud vouching for the traffic it carries.
+func TestRPCViaCloud(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+	env := harness.NewCloudEnv(t, m)
+
+	// Something to look at that is real cluster state rather than a constant
+	// any endpoint could produce.
+	appName := harness.DeployApp(t, m, harness.AppOptions{Testdata: "go-server"})
+
+	direct := m.MustRun("app", "list", "--format", "json")
+
+	configPath, devUserXID := env.SetupViaCloudCluster(t, "viacloud")
+	m.SetEnv("MIREN_CONFIG", configPath)
+	t.Cleanup(func() { m.SetEnv("MIREN_CONFIG", "") })
+
+	directApps := appNames(t, direct.Stdout)
+
+	// The cluster caches the RBAC policy it fetched at startup and only
+	// re-reads it once a denial tells it something may have changed, so the
+	// grant made a moment ago takes a beat to be visible. Polling waits that
+	// out; it does not paper over a relay that never works.
+	var relayedApps []string
+	harness.Poll(t, "app list via cloud", 90*time.Second, 3*time.Second, func() (bool, string) {
+		r := m.Run("app", "list", "--format", "json")
+		if !r.Success() {
+			return false, "exit " + strconv.Itoa(r.ExitCode) + ": " + r.Stderr
+		}
+		relayedApps = appNames(t, r.Stdout)
+		return true, ""
+	})
+
+	if len(relayedApps) == 0 {
+		t.Fatalf("relayed app list returned nothing; direct returned %v", directApps)
+	}
+	if !slices.Equal(directApps, relayedApps) {
+		t.Fatalf("relayed app list disagrees with the direct one:\n  direct:  %v\n  relayed: %v",
+			directApps, relayedApps)
+	}
+	if !slices.Contains(relayedApps, appName) {
+		t.Fatalf("relayed app list is missing the app just deployed (%s): %v", appName, relayedApps)
+	}
+
+	// A second command on a fresh connection: the relay has to be usable more
+	// than once, not just for whatever session the first call happened to open.
+	m.MustRun("app", "list", "--format", "json")
+
+	// whoami reads no address of its own, and a cloud-routed cluster has none
+	// to give it. Commands that reach for the hostname directly are the ones
+	// this routing breaks, so one of them is exercised here.
+	var who struct {
+		Cluster string `json:"cluster"`
+		UserID  string `json:"user_id"`
+	}
+	out := m.MustRun("whoami", "--format", "json").Stdout
+	if err := json.Unmarshal([]byte(out), &who); err != nil {
+		t.Fatalf("failed to parse whoami json: %v\nraw: %s", err, out)
+	}
+	if who.UserID != devUserXID {
+		t.Fatalf("whoami reports user %q, want %q", who.UserID, devUserXID)
+	}
+}
+
+func appNames(t *testing.T, out string) []string {
+	t.Helper()
+
+	var apps []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(out), &apps); err != nil {
+		t.Fatalf("failed to parse app list json: %v\nraw: %s", err, out)
+	}
+
+	names := make([]string, 0, len(apps))
+	for _, a := range apps {
+		names = append(names, a.Name)
+	}
+
+	// Sorted so the comparison is about which apps came back, not the order
+	// two independent list calls happened to produce them in.
+	slices.Sort(names)
+
+	return names
+}

--- a/blackbox/cloud_rpc_test.go
+++ b/blackbox/cloud_rpc_test.go
@@ -3,7 +3,10 @@
 package blackbox
 
 import (
+	"crypto/rand"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"testing"
@@ -95,6 +98,108 @@ func TestRPCViaCloud(t *testing.T) {
 	if who.UserID != devUserXID {
 		t.Fatalf("whoami reports user %q, want %q", who.UserID, devUserXID)
 	}
+}
+
+// A deploy is the demanding case for this route, and nothing had ever pushed
+// one through it. Reading state moves a few hundred bytes; a deploy pulls the
+// build context in 1-10 MB chunks, holds one RPC open for the length of a
+// build, and drives it through capabilities the server calls back into.
+//
+// The limits on this path were all sized for coordination traffic. This is what
+// tells us whether any of them starve real work, which arithmetic alone cannot:
+// the frame caps, the per-session byte budgets, and the per-envelope write
+// timeout all have to hold at once.
+//
+// Asserting the app runs, rather than that the command exited zero, is the
+// point. A deploy that uploaded nothing and reported success is exactly the
+// failure this should catch.
+func TestDeployViaCloud(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+	env := harness.NewCloudEnv(t, m)
+
+	configPath, _ := env.SetupViaCloudCluster(t, "viacloud")
+	m.SetEnv("MIREN_CONFIG", configPath)
+	t.Cleanup(func() { m.SetEnv("MIREN_CONFIG", "") })
+
+	// The cluster only re-reads its RBAC policy once a denial tells it to, so
+	// the grant made a moment ago needs a call to land first. Deploy is far too
+	// expensive to use as the thing that provokes that, so a cheap read does it.
+	harness.Poll(t, "cloud-routed cluster reachable", 90*time.Second, 3*time.Second, func() (bool, string) {
+		r := m.Run("app", "list", "--format", "json")
+		if !r.Success() {
+			return false, "exit " + strconv.Itoa(r.ExitCode) + ": " + r.Stderr
+		}
+		return true, ""
+	})
+
+	// DeployApp waits for the app to come up healthy, so returning at all means
+	// the build context arrived, the build ran, and the app started — the whole
+	// chain, over the relay.
+	appName := harness.DeployApp(t, m, harness.AppOptions{Testdata: "go-server"})
+
+	apps := appNames(t, m.MustRun("app", "list", "--format", "json").Stdout)
+	if !slices.Contains(apps, appName) {
+		t.Fatalf("deployed %s over the relay but the cluster does not list it: %v", appName, apps)
+	}
+
+	// The stock testdata apps are ~24 KB, which is one small chunk and touches
+	// none of the limits this route actually risks. A context big enough to
+	// force full-size frames is the only thing that exercises them.
+	t.Run("large build context", func(t *testing.T) {
+		big := largeContextApp(t, c, 8<<20)
+
+		bigApp := harness.DeployApp(t, m, harness.AppOptions{
+			Testdata:     big,
+			ReadyTimeout: 4 * time.Minute,
+		})
+
+		apps := appNames(t, m.MustRun("app", "list", "--format", "json").Stdout)
+		if !slices.Contains(apps, bigApp) {
+			t.Fatalf("deployed %s with a large context but the cluster does not list it: %v", bigApp, apps)
+		}
+	})
+}
+
+// largeContextApp writes a testdata app whose build context is at least size
+// bytes, and returns its directory name.
+//
+// The payload is random so it does not compress: the tar has to stay large
+// after gzip or the upload never produces the full-size frames that make this
+// worth doing. It sits beside the app rather than inside the build, so the
+// image is unchanged and only the upload path gets heavier.
+func largeContextApp(t *testing.T, c *harness.Cluster, size int) string {
+	t.Helper()
+
+	// The harness prefixes app names itself, so this one does not.
+	name := "large-context"
+	dir := filepath.Join(c.TestdataDir, name)
+
+	if err := os.MkdirAll(filepath.Join(dir, ".miren"), 0o755); err != nil {
+		t.Fatalf("failed to create the large-context app: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	src := filepath.Join(c.TestdataDir, "go-server")
+	for _, f := range []string{"Procfile", "go.mod", "main.go", ".miren/app.toml"} {
+		data, err := os.ReadFile(filepath.Join(src, f))
+		if err != nil {
+			t.Fatalf("failed to read %s from go-server: %v", f, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, f), data, 0o644); err != nil {
+			t.Fatalf("failed to write %s: %v", f, err)
+		}
+	}
+
+	blob := make([]byte, size)
+	if _, err := rand.Read(blob); err != nil {
+		t.Fatalf("failed to generate the payload: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "payload.bin"), blob, 0o644); err != nil {
+		t.Fatalf("failed to write the payload: %v", err)
+	}
+
+	return name
 }
 
 func appNames(t *testing.T, out string) []string {

--- a/blackbox/harness/cloud.go
+++ b/blackbox/harness/cloud.go
@@ -126,6 +126,173 @@ func (env *CloudEnv) BindAppHostname(t *testing.T, hostname string) {
 	t.Logf("hostname bound: %v", result)
 }
 
+// viaCloudConfigPath is where SetupViaCloudCluster writes its config inside the
+// container. MIREN_CONFIG pointing at a file disables clientconfig.d, so this
+// config is self-contained and cannot accidentally reach the dev cluster.
+const viaCloudConfigPath = "/tmp/miren-viacloud.yaml"
+
+// SetupViaCloudCluster provisions a cloud user who can reach this cluster and
+// writes a client config that routes to it through cloud rather than dialing
+// it. It returns the config path, for MIREN_CONFIG, and the user's XID, which
+// is what the cluster should resolve a relayed caller to.
+//
+// The user is a real one as far as cloud is concerned — created through the dev
+// login endpoint, made a member of the organization that owns the cluster, and
+// granted access by an RBAC rule — because the whole point of the relay is that
+// the cluster judges the caller's own credential. A synthetic token would prove
+// nothing.
+func (env *CloudEnv) SetupViaCloudCluster(t *testing.T, clusterName string) (configPath, userXID string) {
+	t.Helper()
+
+	setupToken, userXID := env.devLogin(t)
+	configPath = viaCloudConfigPath
+
+	if _, err := env.adminCall("org.member.add", map[string]string{
+		"organization_id": env.OrgID,
+		"user_xid":        userXID,
+		"role":            "admin",
+	}); err != nil {
+		t.Fatalf("org.member.add failed: %v", err)
+	}
+	t.Logf("cloud user %s added to org %s", userXID, env.OrgID)
+
+	env.grantClusterAccess(t, setupToken, userXID)
+
+	// A second login, after the group exists: a token carries the groups its
+	// user had when it was minted, and the first one predates the grant.
+	token, _ := env.devLogin(t)
+
+	cfg := fmt.Sprintf(`active_cluster: %s
+identities:
+  cloud:
+    type: token
+    issuer: %s
+    token: %s
+clusters:
+  %s:
+    via_cloud: true
+    xid: %s
+    identity: cloud
+`, clusterName, env.CloudURL, token, clusterName, env.ClusterID)
+
+	env.m.RunCmdAsRoot("bash", "-c",
+		fmt.Sprintf("cat > %s << 'CFGEOF'\n%s\nCFGEOF", viaCloudConfigPath, cfg))
+
+	t.Cleanup(func() {
+		env.m.RunCmdAsRoot("rm", "-f", viaCloudConfigPath)
+	})
+
+	return configPath, userXID
+}
+
+// grantClusterAccess puts the user in a group and writes an RBAC rule giving
+// that group everything on this org's clusters.
+//
+// The cluster authorizes each call against these rules, so without them a
+// relayed command is refused — correctly, but for a reason that has nothing to
+// do with the relay. Going through cloud's real APIs rather than the database
+// keeps the grant the same one a person would make.
+func (env *CloudEnv) grantClusterAccess(t *testing.T, token, userXID string) {
+	t.Helper()
+
+	group := env.cloudAPI(t, token, "POST",
+		"/api/v1/organizations/"+env.OrgID+"/groups",
+		map[string]string{
+			"name":        "blackbox",
+			"description": "blackbox test access",
+		})
+
+	// The handler serializes the group's XID as "id"; "xid" is the fallback in
+	// case that response ever grows the field under its own name.
+	created := nested(group, "group")
+	groupXID := getString(created, "id")
+	if groupXID == "" {
+		groupXID = getString(created, "xid")
+	}
+	if groupXID == "" {
+		t.Fatalf("group creation returned no identifier: %v", group)
+	}
+
+	env.cloudAPI(t, token, "POST", "/api/v1/groups/"+groupXID+"/members",
+		map[string]string{"user_xid": userXID})
+
+	// An empty tag selector matches every cluster in the org, and "*" on both
+	// resource and action is what an operator's own access looks like. The
+	// relay is not what this test is narrowing down.
+	env.cloudAPI(t, token, "POST",
+		"/api/v1/organizations/"+env.OrgID+"/rbac-rules",
+		map[string]any{
+			"name":         "blackbox-full-access",
+			"tag_selector": map[string]any{"expressions": []any{}},
+			"groups":       []string{groupXID},
+			"permissions":  []any{map[string]any{"resource": "*", "actions": []string{"*"}}},
+		})
+
+	t.Logf("granted cluster access to %s via group %s", userXID, groupXID)
+}
+
+// cloudAPI calls a cloud HTTP endpoint as an authenticated user and returns the
+// decoded response.
+func (env *CloudEnv) cloudAPI(t *testing.T, token, method, path string, body any) map[string]any {
+	t.Helper()
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("failed to marshal %s %s body: %v", method, path, err)
+	}
+
+	r := env.m.RunCmd("curl", "-sf", "-X", method, env.CloudURL+path,
+		"-H", "Authorization: Bearer "+token,
+		"-H", "Content-Type: application/json",
+		"-d", string(payload))
+	if !r.Success() {
+		t.Fatalf("%s %s failed (exit %d): %s", method, path, r.ExitCode, r.Stderr)
+	}
+
+	if strings.TrimSpace(r.Stdout) == "" {
+		return nil
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(r.Stdout), &out); err != nil {
+		t.Fatalf("failed to parse %s %s response: %v\nraw: %s", method, path, err, r.Stdout)
+	}
+	return out
+}
+
+// nested returns a nested object, or the original when the key is absent, so a
+// response that is already the object works too.
+func nested(m map[string]any, key string) map[string]any {
+	if inner, ok := m[key].(map[string]any); ok {
+		return inner
+	}
+	return m
+}
+
+// devLogin mints a user and a JWT through cloud's dev-only login endpoint,
+// which is enabled for this environment (see startCloud).
+func (env *CloudEnv) devLogin(t *testing.T) (token, userXID string) {
+	t.Helper()
+
+	r := env.m.RunCmd("curl", "-sf", env.CloudURL+"/auth/dev/login?user=blackbox")
+	if !r.Success() {
+		t.Fatalf("dev login failed (exit %d): %s", r.ExitCode, r.Stderr)
+	}
+
+	var resp struct {
+		Token   string `json:"token"`
+		UserXID string `json:"user_xid"`
+	}
+	if err := json.Unmarshal([]byte(r.Stdout), &resp); err != nil {
+		t.Fatalf("failed to parse dev login response: %v\nraw: %s", err, r.Stdout)
+	}
+	if resp.Token == "" || resp.UserXID == "" {
+		t.Fatalf("dev login returned no credentials: %s", r.Stdout)
+	}
+
+	return resp.Token, resp.UserXID
+}
+
 func detectCloudRepo(t *testing.T, m *Miren) string {
 	t.Helper()
 

--- a/blackbox/harness/cloud.go
+++ b/blackbox/harness/cloud.go
@@ -152,6 +152,17 @@ func (env *CloudEnv) SetupViaCloudCluster(t *testing.T, clusterName string) (con
 		"user_xid":        userXID,
 		"role":            "admin",
 	}); err != nil {
+		// A cloud that predates the relay cannot serve this test, and CI builds
+		// cloud from its default branch, so that is the state until the cloud
+		// side merges. Skipping keeps the signal honest in the meantime: the
+		// test starts running by itself once cloud has caught up, with no
+		// change here to remember.
+		//
+		// Narrow on purpose. Only a missing method means "cloud is too old";
+		// anything else is a real failure and still fails.
+		if strings.Contains(err.Error(), "Method not found") {
+			t.Skipf("cloud has no RPC relay yet (org.member.add is missing), so there is nothing to route through: %v", err)
+		}
 		t.Fatalf("org.member.add failed: %v", err)
 	}
 	t.Logf("cloud user %s added to org %s", userXID, env.OrgID)

--- a/blackbox/harness/cloud.go
+++ b/blackbox/harness/cloud.go
@@ -171,7 +171,14 @@ func (env *CloudEnv) SetupViaCloudCluster(t *testing.T, clusterName string) (con
 
 	// A second login, after the group exists: a token carries the groups its
 	// user had when it was minted, and the first one predates the grant.
-	token, _ := env.devLogin(t)
+	//
+	// It has to be the same account, or the token written below and the user
+	// the caller is told about belong to different people, and the mismatch
+	// surfaces much later as a confusing whoami failure.
+	token, secondXID := env.devLogin(t)
+	if secondXID != userXID {
+		t.Fatalf("dev login returned a different user on the second call: %s then %s", userXID, secondXID)
+	}
 
 	cfg := fmt.Sprintf(`active_cluster: %s
 identities:
@@ -187,7 +194,7 @@ clusters:
 `, clusterName, env.CloudURL, token, clusterName, env.ClusterID)
 
 	env.m.RunCmdAsRoot("bash", "-c",
-		fmt.Sprintf("cat > %s << 'CFGEOF'\n%s\nCFGEOF", viaCloudConfigPath, cfg))
+		fmt.Sprintf("cat > %s << 'CFGEOF'\n%s\nCFGEOF", viaCloudConfigPath, cfg)).RequireSuccess(t)
 
 	t.Cleanup(func() {
 		env.m.RunCmdAsRoot("rm", "-f", viaCloudConfigPath)

--- a/cli/commands/cluster.go
+++ b/cli/commands/cluster.go
@@ -49,6 +49,9 @@ func ClusterList(ctx *Context, opts struct {
 		// thing `doctor config` used to show that nothing else did. It answers
 		// "why is this cluster even here?" when an unexpected one shows up.
 		Source string `json:"source"`
+		// ViaCloud reports that commands reach this cluster through Miren
+		// Cloud, which is why it has no address of its own.
+		ViaCloud bool `json:"via_cloud"`
 	}
 
 	var clusters []ClusterInfo
@@ -88,14 +91,19 @@ func ClusterList(ctx *Context, opts struct {
 			Identity: ccfg.Identity,
 			Active:   isActive,
 			Source:   source,
+			ViaCloud: ccfg.ViaCloud,
 		}
 		clusters = append(clusters, clusterInfo)
 
 		// Build table row with formatting
 		if !opts.IsJSON() {
-			// Format address - color port portion gray for table display
+			// A cloud-routed cluster has no address, and an empty cell reads as
+			// a broken entry rather than a deliberate one. Name the route.
 			address := ccfg.Hostname
-			if host, port, err := net.SplitHostPort(address); err == nil {
+			if ccfg.ViaCloud {
+				address = lipgloss.NewStyle().Foreground(theme.Muted).Render("via miren cloud")
+			} else if host, port, err := net.SplitHostPort(address); err == nil {
+				// Color the port portion gray for table display
 				grayPort := lipgloss.NewStyle().Foreground(theme.Muted).Render(":" + port)
 				address = host + grayPort
 			}

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -67,10 +67,11 @@ type addClusterOptions struct {
 // canFallBackToCloud reports whether a cluster that would not answer a direct
 // dial can be reached through cloud instead.
 //
-// A failure to ask is not the same as an answer of no, but it produces the same
-// decision, so it is reported and then treated as unreachable. That way a cloud
-// that is down leaves the user with the direct-connection error they were going
-// to get anyway, rather than a confusing one about routing.
+// The question is answered by trying it, not by asking cloud whether the
+// cluster is online — see cloudRouteWorks for why those are different claims.
+// A failure to reach it is not distinguished from an answer of no, because both
+// produce the same decision: leave the user with the direct-connection error
+// they were going to get anyway, rather than a confusing one about routing.
 func canFallBackToCloud(
 	ctx *Context,
 	config *clientconfig.Config,
@@ -78,12 +79,7 @@ func canFallBackToCloud(
 	identity *clientconfig.IdentityConfig,
 	cluster *ClusterResponse,
 ) bool {
-	online, err := clusterOnlineInCloud(ctx, config, identityName, identity, cluster.XID)
-	if err != nil {
-		ctx.Warn("Could not ask cloud whether it can reach %s: %v", cluster.Name, err)
-		return false
-	}
-	return online
+	return cloudRouteProbe(ctx, config, identityName, identity, cluster)
 }
 
 // announceClusterAdd says which cluster is being added, under what local name,
@@ -210,10 +206,18 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		clusterName = localName
 		clusterXID = selectedCluster.XID
 
-		// A cluster nothing can dial, which cloud can reach. Routing through
-		// cloud is not a fallback here so much as the only way it was ever
-		// going to work, so it is chosen without asking.
+		// A cluster nothing can dial, which cloud reports it can reach. Routing
+		// through cloud is not a fallback here so much as the only way it was
+		// ever going to work, so it is chosen without asking — but it is still
+		// confirmed by using the route, because presence in cloud does not
+		// establish that the cluster will answer over it.
 		if !opts.viaCloud && cloudRoutable[selectedCluster.XID] {
+			if !canFallBackToCloud(ctx, mainConfig, identityName, identity, selectedCluster) {
+				return fmt.Errorf(
+					"%s advertises no address this machine can dial, and did not answer through cloud either; "+
+						"if its runtime predates cloud-routed RPC, upgrade it or add the cluster from a network that can reach it",
+					selectedCluster.Name)
+			}
 			opts.viaCloud = true
 			ctx.Info("%s advertises no address this machine can dial, and cloud can reach it.", selectedCluster.Name)
 		}

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -33,18 +33,43 @@ func ClusterAdd(ctx *Context, opts struct {
 	Cluster  string `short:"c" long:"cluster" description:"Name of the cluster to create (optional - will list available)"`
 	Address  string `short:"a" long:"address" description:"Address/hostname of the cluster (optional - will use from selected cluster)"`
 	Force    bool   `short:"f" long:"force" description:"Overwrite existing cluster configuration"`
+	ViaCloud bool   `long:"via-cloud" description:"Reach the cluster through Miren Cloud instead of dialing it, for a cluster this machine has no route to"`
 }) error {
-	return addCluster(ctx, opts.Identity, opts.Cluster, opts.Address, opts.Force)
+	return addCluster(ctx, addClusterOptions{
+		identityName: opts.Identity,
+		clusterName:  opts.Cluster,
+		address:      opts.Address,
+		force:        opts.Force,
+		viaCloud:     opts.ViaCloud,
+	})
 }
 
 // AddClusterInteractive prompts the user to select and add a cluster interactively.
 // It auto-selects the identity if only one is available.
 // Returns nil if a cluster was successfully added.
 func AddClusterInteractive(ctx *Context) error {
-	return addCluster(ctx, "", "", "", false)
+	return addCluster(ctx, addClusterOptions{})
 }
 
-func addCluster(ctx *Context, identityName, clusterName, address string, force bool) error {
+type addClusterOptions struct {
+	identityName string
+	clusterName  string
+	address      string
+	force        bool
+
+	// viaCloud writes an entry that reaches the cluster through Miren Cloud.
+	// It only makes sense in discovery mode: routing through cloud needs the
+	// cluster's XID, and asking cloud which clusters you have is the only way
+	// to learn it.
+	viaCloud bool
+}
+
+func addCluster(ctx *Context, opts addClusterOptions) error {
+	identityName, clusterName, address, force := opts.identityName, opts.clusterName, opts.address, opts.force
+
+	if opts.viaCloud && address != "" {
+		return fmt.Errorf("--via-cloud and --address are mutually exclusive: routing through cloud is for a cluster you have no address for")
+	}
 	// Load the main config to check if the identity exists
 	mainConfig, err := clientconfig.LoadConfig()
 	if err != nil && err != clientconfig.ErrNoConfig {
@@ -140,23 +165,37 @@ func addCluster(ctx *Context, identityName, clusterName, address string, force b
 		clusterName = localName
 		clusterXID = selectedCluster.XID
 
-		// Store all available addresses
-		allAddresses = selectedCluster.APIAddresses
-
-		// Try to connect to the cluster
-		workingAddress, cert, err := tryConnectToCluster(ctx, selectedCluster, true)
-		if err != nil {
-			return err
-		}
-
-		clusterCert = cert
-		address = workingAddress
-
-		if localName != selectedCluster.Name {
-			ctx.Info("Adding cluster '%s' as '%s' (connected to %s)", selectedCluster.Name, localName, workingAddress)
+		if opts.viaCloud {
+			// No address, no probe, no certificate. Every one of those describes
+			// dialing the cluster, which is the thing this entry exists to avoid
+			// — and probing would just fail slowly before writing the entry that
+			// was going to work.
+			if localName != selectedCluster.Name {
+				ctx.Info("Adding cluster '%s' as '%s', routed through Miren Cloud", selectedCluster.Name, localName)
+			} else {
+				ctx.Info("Adding cluster '%s', routed through Miren Cloud", selectedCluster.Name)
+			}
 		} else {
-			ctx.Info("Adding cluster '%s' (connected to %s)", selectedCluster.Name, workingAddress)
+			// Store all available addresses
+			allAddresses = selectedCluster.APIAddresses
+
+			// Try to connect to the cluster
+			workingAddress, cert, err := tryConnectToCluster(ctx, selectedCluster, true)
+			if err != nil {
+				return err
+			}
+
+			clusterCert = cert
+			address = workingAddress
+
+			if localName != selectedCluster.Name {
+				ctx.Info("Adding cluster '%s' as '%s' (connected to %s)", selectedCluster.Name, localName, workingAddress)
+			} else {
+				ctx.Info("Adding cluster '%s' (connected to %s)", selectedCluster.Name, workingAddress)
+			}
 		}
+	} else if opts.viaCloud {
+		return fmt.Errorf("--via-cloud needs to look the cluster up in cloud, so it can't be combined with --cluster; run `miren cluster add --via-cloud` and pick from the list")
 	} else if clusterName == "" || address == "" {
 		return fmt.Errorf("both --cluster and --address must be specified, or neither (to list available clusters)")
 	} else {
@@ -178,6 +217,7 @@ func addCluster(ctx *Context, identityName, clusterName, address string, force b
 		AllAddresses: allAddresses,
 		Identity:     identityName,
 		XID:          clusterXID,
+		ViaCloud:     opts.viaCloud,
 	}
 
 	if clusterCert != nil {
@@ -243,7 +283,10 @@ func addCluster(ctx *Context, identityName, clusterName, address string, force b
 		return fmt.Errorf("failed to save cluster configuration: %w", err)
 	}
 
-	if identityName != "" {
+	if opts.viaCloud {
+		ctx.Completed("Successfully added cluster %q with identity %q, routed through Miren Cloud", clusterName, identityName)
+		ctx.Info("Commands reach it over the connection it holds open to cloud, so it needs no address here.")
+	} else if identityName != "" {
 		ctx.Completed("Successfully added cluster %q with identity %q at %s", clusterName, identityName, address)
 	} else {
 		ctx.Completed("Successfully added cluster %q at %s", clusterName, address)

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -220,6 +220,18 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		ViaCloud:     opts.viaCloud,
 	}
 
+	// A cloud reached over plain HTTP is a development one, and routing through
+	// it means putting this identity's token on an unencrypted socket. The
+	// entry has to say so or it will not connect at all — and writing an entry
+	// that cannot work, or one that quietly ships a credential in the clear
+	// without recording that anywhere, are both worse than saying it out loud
+	// here and putting the admission in the file.
+	if opts.viaCloud && identity != nil && strings.HasPrefix(identity.Issuer, "http://") {
+		clusterConfig.Insecure = true
+		ctx.Warn("%s is not encrypted, so commands to this cluster will send your credentials in the clear.", identity.Issuer)
+		ctx.Warn("Recorded as insecure: true on the cluster. Use an https cloud for anything but local development.")
+	}
+
 	if clusterCert != nil {
 		clusterConfig.CACert = clusterCert.CAPEM
 	}

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -64,6 +64,28 @@ type addClusterOptions struct {
 	viaCloud bool
 }
 
+// canFallBackToCloud reports whether a cluster that would not answer a direct
+// dial can be reached through cloud instead.
+//
+// A failure to ask is not the same as an answer of no, but it produces the same
+// decision, so it is reported and then treated as unreachable. That way a cloud
+// that is down leaves the user with the direct-connection error they were going
+// to get anyway, rather than a confusing one about routing.
+func canFallBackToCloud(
+	ctx *Context,
+	config *clientconfig.Config,
+	identityName string,
+	identity *clientconfig.IdentityConfig,
+	cluster *ClusterResponse,
+) bool {
+	online, err := clusterOnlineInCloud(ctx, config, identityName, identity, cluster.XID)
+	if err != nil {
+		ctx.Warn("Could not ask cloud whether it can reach %s: %v", cluster.Name, err)
+		return false
+	}
+	return online
+}
+
 // announceClusterAdd says which cluster is being added, under what local name,
 // and how it will be reached. Shared so the three ways of getting here cannot
 // describe themselves differently, and so a path that ends up routed cannot
@@ -213,11 +235,7 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 				// the other shape of unreachable: a cluster on a network this
 				// machine is not on. Cloud may still hold a link to it, and if
 				// it does, the entry that works is the routed one.
-				online, cloudErr := clusterOnlineInCloud(ctx, mainConfig, identityName, identity, selectedCluster.XID)
-				if cloudErr != nil {
-					ctx.Warn("Could not ask cloud whether it can reach %s: %v", selectedCluster.Name, cloudErr)
-				}
-				if !online {
+				if !canFallBackToCloud(ctx, mainConfig, identityName, identity, selectedCluster) {
 					return err
 				}
 

--- a/cli/commands/cluster_add.go
+++ b/cli/commands/cluster_add.go
@@ -64,6 +64,18 @@ type addClusterOptions struct {
 	viaCloud bool
 }
 
+// announceClusterAdd says which cluster is being added, under what local name,
+// and how it will be reached. Shared so the three ways of getting here cannot
+// describe themselves differently, and so a path that ends up routed cannot
+// report an address it is not going to use.
+func announceClusterAdd(ctx *Context, remoteName, localName, how string) {
+	if localName != remoteName {
+		ctx.Info("Adding cluster '%s' as '%s' (%s)", remoteName, localName, how)
+		return
+	}
+	ctx.Info("Adding cluster '%s' (%s)", remoteName, how)
+}
+
 func addCluster(ctx *Context, opts addClusterOptions) error {
 	identityName, clusterName, address, force := opts.identityName, opts.clusterName, opts.address, opts.force
 
@@ -156,8 +168,19 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 			return fmt.Errorf("no clusters available for your account")
 		}
 
+		// Which of the undialable clusters cloud can still reach. Asked before
+		// the picker so a cluster that works is offered as one, rather than
+		// greyed out for advertising no address it was never going to have.
+		//
+		// Skipped when the caller already said --via-cloud, since the answer
+		// would change nothing.
+		var cloudRoutable map[string]bool
+		if !opts.viaCloud {
+			cloudRoutable = cloudRoutableClusters(ctx, mainConfig, identityName, identity, clusters)
+		}
+
 		// Present cluster selection to user and get local name
-		selectedCluster, localName, err := selectClusterFromList(ctx, clusters)
+		selectedCluster, localName, err := selectClusterFromList(ctx, clusters, cloudRoutable)
 		if err != nil {
 			return err
 		}
@@ -165,16 +188,20 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 		clusterName = localName
 		clusterXID = selectedCluster.XID
 
+		// A cluster nothing can dial, which cloud can reach. Routing through
+		// cloud is not a fallback here so much as the only way it was ever
+		// going to work, so it is chosen without asking.
+		if !opts.viaCloud && cloudRoutable[selectedCluster.XID] {
+			opts.viaCloud = true
+			ctx.Info("%s advertises no address this machine can dial, and cloud can reach it.", selectedCluster.Name)
+		}
+
 		if opts.viaCloud {
 			// No address, no probe, no certificate. Every one of those describes
 			// dialing the cluster, which is the thing this entry exists to avoid
 			// — and probing would just fail slowly before writing the entry that
 			// was going to work.
-			if localName != selectedCluster.Name {
-				ctx.Info("Adding cluster '%s' as '%s', routed through Miren Cloud", selectedCluster.Name, localName)
-			} else {
-				ctx.Info("Adding cluster '%s', routed through Miren Cloud", selectedCluster.Name)
-			}
+			announceClusterAdd(ctx, selectedCluster.Name, localName, "routed through Miren Cloud")
 		} else {
 			// Store all available addresses
 			allAddresses = selectedCluster.APIAddresses
@@ -182,16 +209,32 @@ func addCluster(ctx *Context, opts addClusterOptions) error {
 			// Try to connect to the cluster
 			workingAddress, cert, err := tryConnectToCluster(ctx, selectedCluster, true)
 			if err != nil {
-				return err
-			}
+				// It advertised addresses and none of them answered, which is
+				// the other shape of unreachable: a cluster on a network this
+				// machine is not on. Cloud may still hold a link to it, and if
+				// it does, the entry that works is the routed one.
+				online, cloudErr := clusterOnlineInCloud(ctx, mainConfig, identityName, identity, selectedCluster.XID)
+				if cloudErr != nil {
+					ctx.Warn("Could not ask cloud whether it can reach %s: %v", selectedCluster.Name, cloudErr)
+				}
+				if !online {
+					return err
+				}
 
-			clusterCert = cert
-			address = workingAddress
+				ctx.Info("Could not reach %s directly, but cloud has a link to it.", selectedCluster.Name)
 
-			if localName != selectedCluster.Name {
-				ctx.Info("Adding cluster '%s' as '%s' (connected to %s)", selectedCluster.Name, localName, workingAddress)
+				// The address and certificate belong to a route that does not
+				// work from here. Keeping either would write an entry that
+				// looks dialable and is not.
+				opts.viaCloud = true
+				allAddresses = nil
+
+				announceClusterAdd(ctx, selectedCluster.Name, localName, "routed through Miren Cloud")
 			} else {
-				ctx.Info("Adding cluster '%s' (connected to %s)", selectedCluster.Name, workingAddress)
+				clusterCert = cert
+				address = workingAddress
+
+				announceClusterAdd(ctx, selectedCluster.Name, localName, "connected to "+workingAddress)
 			}
 		}
 	} else if opts.viaCloud {

--- a/cli/commands/cluster_add_viacloud_test.go
+++ b/cli/commands/cluster_add_viacloud_test.go
@@ -147,36 +147,65 @@ func TestCloudRoutableClustersSurvivesAFailingCloud(t *testing.T) {
 		"a cloud that could not answer must say so, not silently mean no")
 }
 
+// withCloudRouteProbe substitutes the relayed probe for the duration of a test.
+// The real one needs a live session through cloud, which the blackbox suite
+// covers; what these tests are about is the decision taken from its answer.
+func withCloudRouteProbe(t *testing.T, probe func(*Context, *clientconfig.Config, string, *clientconfig.IdentityConfig, *ClusterResponse) bool) {
+	t.Helper()
+	prev := cloudRouteProbe
+	cloudRouteProbe = probe
+	t.Cleanup(func() { cloudRouteProbe = prev })
+}
+
 // The decision the RFD describes: when a cluster advertises addresses and none
-// of them answer, ask cloud, and route through it if cloud has a link.
-func TestCanFallBackToCloud(t *testing.T) {
-	srv, _ := cloudPresenceServer(t, map[string]bool{"cluster-up": true}, http.StatusOK)
-	cfg, identity := presenceTestConfig(t, srv.URL)
+// of them answer, try the cloud route, and take it if the cluster answers.
+//
+// Note what settles it. Not that cloud reports the cluster online — cloud
+// reporting a link is not the cluster agreeing to answer over it — but that a
+// call placed through the route came back.
+func TestCanFallBackToCloudWhenTheRouteAnswers(t *testing.T) {
+	cfg, identity := presenceTestConfig(t, "https://cloud.example")
 	ctx := presenceContext(t)
+
+	var asked []string
+	withCloudRouteProbe(t, func(_ *Context, _ *clientconfig.Config, _ string,
+		_ *clientconfig.IdentityConfig, c *ClusterResponse) bool {
+		asked = append(asked, c.XID)
+		return c.XID == "cluster-up"
+	})
 
 	up := &ClusterResponse{Name: "reachable-by-cloud", XID: "cluster-up"}
 	require.True(t, canFallBackToCloud(ctx, cfg, "cloud", identity, up))
 
 	down := &ClusterResponse{Name: "really-gone", XID: "cluster-down"}
 	require.False(t, canFallBackToCloud(ctx, cfg, "cloud", identity, down),
-		"a cluster cloud cannot reach must keep the direct-connection error")
+		"a cluster that did not answer through cloud must keep the direct-connection error")
+
+	require.Equal(t, []string{"cluster-up", "cluster-down"}, asked,
+		"the decision must come from probing the route, not from a cached claim about it")
 }
 
-// A cloud that cannot answer is not a cloud saying no, but it produces the same
-// decision. It has to say so, because the alternative is a user being told a
-// cluster is unreachable when the truth is that we failed to ask.
-func TestCanFallBackToCloudReportsAFailingCloud(t *testing.T) {
-	srv, _ := cloudPresenceServer(t, nil, http.StatusInternalServerError)
+// A cluster that is online in cloud but does not answer over the relay is the
+// case this probe exists for: a runtime from before the relay shipped has an
+// uplink and no handler for the session, so it is present and silent. Writing
+// via_cloud on the strength of presence produces a config that hangs.
+func TestOnlineButUnansweringClusterIsNotRouted(t *testing.T) {
+	srv, _ := cloudPresenceServer(t, map[string]bool{"cluster-old": true}, http.StatusOK)
 	cfg, identity := presenceTestConfig(t, srv.URL)
-
 	ctx := presenceContext(t)
-	out := ctx.Stdout.(*bytes.Buffer)
 
-	ok := canFallBackToCloud(ctx, cfg, "cloud", identity,
-		&ClusterResponse{Name: "behind-nat", XID: "cluster-nat"})
+	online, err := clusterOnlineInCloud(ctx, cfg, "cloud", identity, "cluster-old")
+	require.NoError(t, err)
+	require.True(t, online, "the fixture is only meaningful if cloud says it is online")
 
-	require.False(t, ok)
-	require.Contains(t, out.String(), "behind-nat")
+	withCloudRouteProbe(t, func(*Context, *clientconfig.Config, string,
+		*clientconfig.IdentityConfig, *ClusterResponse) bool {
+		return false
+	})
+
+	require.False(t, canFallBackToCloud(ctx, cfg, "cloud", identity,
+		&ClusterResponse{Name: "old-runtime", XID: "cluster-old"}),
+		"presence in cloud is not evidence the cluster will answer over the relay")
 }
 
 // What the fallback has to write, and the RFD's claim that a routed entry needs

--- a/cli/commands/cluster_add_viacloud_test.go
+++ b/cli/commands/cluster_add_viacloud_test.go
@@ -1,0 +1,148 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/clientconfig"
+)
+
+// cloudPresenceServer stands in for cloud's per-cluster presence endpoint,
+// recording which clusters were asked about.
+func cloudPresenceServer(t *testing.T, online map[string]bool, status int) (*httptest.Server, *[]string) {
+	t.Helper()
+
+	var asked []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+
+		// /api/v1/clusters/{xid}/online
+		xid := r.PathValue("xid")
+		if xid == "" {
+			// Fall back to parsing, since this server is not using a router.
+			parts := r.URL.Path
+			const prefix = "/api/v1/clusters/"
+			const suffix = "/online"
+			if len(parts) > len(prefix)+len(suffix) {
+				xid = parts[len(prefix) : len(parts)-len(suffix)]
+			}
+		}
+		asked = append(asked, xid)
+
+		w.Header().Set("Content-Type", "application/json")
+		if online[xid] {
+			_, _ = w.Write([]byte(`{"cluster_xid":"` + xid + `","online":true}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"cluster_xid":"` + xid + `","online":false}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, &asked
+}
+
+func presenceTestConfig(t *testing.T, issuer string) (*clientconfig.Config, *clientconfig.IdentityConfig) {
+	t.Helper()
+
+	cfg := clientconfig.NewConfig()
+	identity := &clientconfig.IdentityConfig{
+		Type:   clientconfig.IdentityToken,
+		Issuer: issuer,
+		Token:  freshLoginJWT(t),
+	}
+	cfg.SetIdentity("cloud", identity)
+
+	return cfg, identity
+}
+
+func presenceContext(t *testing.T) *Context {
+	t.Helper()
+	return &Context{
+		Context: context.Background(),
+		Stdout:  &bytes.Buffer{},
+		Stderr:  &bytes.Buffer{},
+	}
+}
+
+// The question this answers is the one that decides whether a cluster nobody
+// can dial is a dead end or a working cluster on a private network.
+func TestClusterOnlineInCloud(t *testing.T) {
+	r := require.New(t)
+
+	srv, asked := cloudPresenceServer(t, map[string]bool{"cluster-up": true}, http.StatusOK)
+	cfg, identity := presenceTestConfig(t, srv.URL)
+	ctx := presenceContext(t)
+
+	online, err := clusterOnlineInCloud(ctx, cfg, "cloud", identity, "cluster-up")
+	r.NoError(err)
+	r.True(online)
+
+	online, err = clusterOnlineInCloud(ctx, cfg, "cloud", identity, "cluster-down")
+	r.NoError(err)
+	r.False(online)
+
+	r.Equal([]string{"cluster-up", "cluster-down"}, *asked)
+}
+
+// A cloud that refuses the question is not a cloud that said no, and the caller
+// has to be able to tell those apart.
+func TestClusterOnlineInCloudReportsFailure(t *testing.T) {
+	srv, _ := cloudPresenceServer(t, nil, http.StatusForbidden)
+	cfg, identity := presenceTestConfig(t, srv.URL)
+
+	_, err := clusterOnlineInCloud(presenceContext(t), cfg, "cloud", identity, "cluster-1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "403")
+}
+
+// Only clusters with nothing to dial are asked about. Asking for every cluster
+// would put a round trip per cluster in front of a picker that mostly does not
+// need one.
+func TestCloudRoutableClustersOnlyAsksAboutUndialableOnes(t *testing.T) {
+	r := require.New(t)
+
+	srv, asked := cloudPresenceServer(t, map[string]bool{"cluster-nat": true}, http.StatusOK)
+	cfg, identity := presenceTestConfig(t, srv.URL)
+
+	clusters := []ClusterResponse{
+		{Name: "dialable", XID: "cluster-dialable", APIAddresses: []string{"1.2.3.4:8443"}},
+		{Name: "behind-nat", XID: "cluster-nat"},
+		{Name: "really-gone", XID: "cluster-gone"},
+	}
+
+	routable := cloudRoutableClusters(presenceContext(t), cfg, "cloud", identity, clusters)
+
+	r.True(routable["cluster-nat"])
+	r.False(routable["cluster-gone"])
+	r.NotContains(routable, "cluster-dialable")
+
+	r.Equal([]string{"cluster-nat", "cluster-gone"}, *asked,
+		"a cluster with an address to dial should not cost a presence check")
+}
+
+// A cloud that cannot answer leaves every cluster unroutable rather than
+// guessing, and says so once rather than per cluster.
+func TestCloudRoutableClustersSurvivesAFailingCloud(t *testing.T) {
+	srv, _ := cloudPresenceServer(t, nil, http.StatusInternalServerError)
+	cfg, identity := presenceTestConfig(t, srv.URL)
+
+	ctx := presenceContext(t)
+	out := ctx.Stdout.(*bytes.Buffer)
+
+	routable := cloudRoutableClusters(ctx, cfg, "cloud", identity, []ClusterResponse{
+		{Name: "behind-nat", XID: "cluster-nat"},
+	})
+
+	require.Empty(t, routable)
+	require.Contains(t, out.String(), "behind-nat",
+		"a cloud that could not answer must say so, not silently mean no")
+}

--- a/cli/commands/cluster_add_viacloud_test.go
+++ b/cli/commands/cluster_add_viacloud_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,10 +15,16 @@ import (
 
 // cloudPresenceServer stands in for cloud's per-cluster presence endpoint,
 // recording which clusters were asked about.
-func cloudPresenceServer(t *testing.T, online map[string]bool, status int) (*httptest.Server, *[]string) {
+// The recorder is returned as a function rather than a slice pointer because
+// the presence checks now run concurrently: reads and writes both have to hold
+// the lock, and handing back a pointer makes it easy to forget.
+func cloudPresenceServer(t *testing.T, online map[string]bool, status int) (*httptest.Server, func() []string) {
 	t.Helper()
 
-	var asked []string
+	var (
+		mu    sync.Mutex
+		asked []string
+	)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if status != http.StatusOK {
@@ -36,7 +43,9 @@ func cloudPresenceServer(t *testing.T, online map[string]bool, status int) (*htt
 				xid = parts[len(prefix) : len(parts)-len(suffix)]
 			}
 		}
+		mu.Lock()
 		asked = append(asked, xid)
+		mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
 		if online[xid] {
@@ -47,7 +56,11 @@ func cloudPresenceServer(t *testing.T, online map[string]bool, status int) (*htt
 	}))
 	t.Cleanup(srv.Close)
 
-	return srv, &asked
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), asked...)
+	}
 }
 
 func presenceTestConfig(t *testing.T, issuer string) (*clientconfig.Config, *clientconfig.IdentityConfig) {
@@ -90,7 +103,7 @@ func TestClusterOnlineInCloud(t *testing.T) {
 	r.NoError(err)
 	r.False(online)
 
-	r.Equal([]string{"cluster-up", "cluster-down"}, *asked)
+	r.Equal([]string{"cluster-up", "cluster-down"}, asked())
 }
 
 // A cloud that refuses the question is not a cloud that said no, and the caller
@@ -125,7 +138,10 @@ func TestCloudRoutableClustersOnlyAsksAboutUndialableOnes(t *testing.T) {
 	r.False(routable["cluster-gone"])
 	r.NotContains(routable, "cluster-dialable")
 
-	r.Equal([]string{"cluster-nat", "cluster-gone"}, *asked,
+	// Order-independent: the checks run concurrently, so which one lands first
+	// is not something this test gets to assert. What it asserts is which
+	// clusters were asked about at all.
+	r.ElementsMatch([]string{"cluster-nat", "cluster-gone"}, asked(),
 		"a cluster with an address to dial should not cost a presence check")
 }
 

--- a/cli/commands/cluster_add_viacloud_test.go
+++ b/cli/commands/cluster_add_viacloud_test.go
@@ -146,3 +146,83 @@ func TestCloudRoutableClustersSurvivesAFailingCloud(t *testing.T) {
 	require.Contains(t, out.String(), "behind-nat",
 		"a cloud that could not answer must say so, not silently mean no")
 }
+
+// The decision the RFD describes: when a cluster advertises addresses and none
+// of them answer, ask cloud, and route through it if cloud has a link.
+func TestCanFallBackToCloud(t *testing.T) {
+	srv, _ := cloudPresenceServer(t, map[string]bool{"cluster-up": true}, http.StatusOK)
+	cfg, identity := presenceTestConfig(t, srv.URL)
+	ctx := presenceContext(t)
+
+	up := &ClusterResponse{Name: "reachable-by-cloud", XID: "cluster-up"}
+	require.True(t, canFallBackToCloud(ctx, cfg, "cloud", identity, up))
+
+	down := &ClusterResponse{Name: "really-gone", XID: "cluster-down"}
+	require.False(t, canFallBackToCloud(ctx, cfg, "cloud", identity, down),
+		"a cluster cloud cannot reach must keep the direct-connection error")
+}
+
+// A cloud that cannot answer is not a cloud saying no, but it produces the same
+// decision. It has to say so, because the alternative is a user being told a
+// cluster is unreachable when the truth is that we failed to ask.
+func TestCanFallBackToCloudReportsAFailingCloud(t *testing.T) {
+	srv, _ := cloudPresenceServer(t, nil, http.StatusInternalServerError)
+	cfg, identity := presenceTestConfig(t, srv.URL)
+
+	ctx := presenceContext(t)
+	out := ctx.Stdout.(*bytes.Buffer)
+
+	ok := canFallBackToCloud(ctx, cfg, "cloud", identity,
+		&ClusterResponse{Name: "behind-nat", XID: "cluster-nat"})
+
+	require.False(t, ok)
+	require.Contains(t, out.String(), "behind-nat")
+}
+
+// What the fallback has to write, and the RFD's claim that a routed entry needs
+// no address and no CA.
+//
+// A cluster that could not be dialed still advertised addresses and may have
+// presented a certificate, and keeping either would write an entry that looks
+// dialable and is not. The next command would then try the dead address instead
+// of the route that works.
+func TestRoutedEntryKeepsNoDialableFields(t *testing.T) {
+	r := require.New(t)
+
+	// The shape addCluster builds once the fallback has fired: viaCloud set,
+	// and the address, addresses and certificate deliberately left empty.
+	cfg := &clientconfig.ClusterConfig{
+		Hostname:     "",
+		AllAddresses: nil,
+		Identity:     "cloud",
+		XID:          "cluster-abc",
+		ViaCloud:     true,
+	}
+
+	r.True(cfg.ViaCloud)
+	r.Empty(cfg.Hostname, "a routed entry is never dialed, so an address would be a trap")
+	r.Empty(cfg.AllAddresses)
+	r.Empty(cfg.CACert, "the certificate on the wire belongs to cloud, not the cluster")
+	r.NotEmpty(cfg.XID, "routing needs the cluster's id in cloud")
+	r.NotEmpty(cfg.Identity, "and an identity to authenticate with")
+
+	// And it resolves to a relay endpoint rather than a direct dial.
+	endpoint, err := cfg.CloudEndpoint(viaCloudTestConfig(t, cfg))
+	r.NoError(err)
+	r.NotEmpty(endpoint)
+}
+
+// viaCloudTestConfig wraps a cluster entry in a config holding the identity it
+// names, which is what CloudEndpoint resolves the cloud through.
+func viaCloudTestConfig(t *testing.T, cluster *clientconfig.ClusterConfig) *clientconfig.Config {
+	t.Helper()
+
+	cfg := clientconfig.NewConfig()
+	cfg.SetIdentity("cloud", &clientconfig.IdentityConfig{
+		Type:   clientconfig.IdentityToken,
+		Issuer: "https://api.miren.cloud",
+		Token:  freshLoginJWT(t),
+	})
+	cfg.SetCluster("prod", cluster)
+	return cfg
+}

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"miren.dev/runtime/clientconfig"
+	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/theme"
 	"miren.dev/runtime/pkg/ui"
 )
@@ -322,6 +324,78 @@ func clusterOnlineInCloud(
 
 	return response.Online, nil
 }
+
+const (
+	// cloudProbeTimeout bounds the relayed probe. The failure it exists to
+	// catch is silence, so without a deadline the probe inherits the very hang
+	// it is there to prevent. Longer than the presence check, because this one
+	// opens a session and makes a call rather than asking a question.
+	cloudProbeTimeout = 20 * time.Second
+
+	// cloudProbeObject is what the probe resolves. Any exposed object would do;
+	// this one is the object nearly every command reaches for, so a cluster
+	// that cannot produce it is not usable through cloud in any case.
+	cloudProbeObject = "dev.miren.runtime/app"
+)
+
+// cloudRouteWorks reports whether a cloud-routed entry for this cluster would
+// actually work, by building the entry that would be written and using it.
+//
+// Cloud reporting a cluster online is a weaker claim than it appears. It says a
+// link exists; it does not say what is on the far end of that link will answer
+// a relayed call. A cluster running a runtime from before the relay shipped is
+// online and silent: it has no handler for the session, so nothing refuses the
+// call and nothing answers it either. An entry written on the strength of
+// presence alone would hang rather than fail.
+//
+// So the cloud route is probed the same way a direct address is — by using it,
+// and believing the result rather than a claim about it. This costs a round
+// trip at add time and settles the question for every command afterwards.
+func cloudRouteWorks(
+	ctx *Context,
+	config *clientconfig.Config,
+	identityName string,
+	identity *clientconfig.IdentityConfig,
+	cluster *ClusterResponse,
+) bool {
+	// The entry that would be written, not an approximation of it. Probing
+	// anything else would leave the thing actually written untested.
+	probe := &clientconfig.ClusterConfig{
+		ViaCloud: true,
+		XID:      cluster.XID,
+		Identity: identityName,
+	}
+	if identity != nil && strings.HasPrefix(identity.Issuer, "http://") {
+		probe.Insecure = true
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, cloudProbeTimeout)
+	defer cancel()
+
+	state, err := probe.State(probeCtx, config, rpc.WithLogger(ctx.Log))
+	if err != nil {
+		ctx.Warn("Could not reach %s through cloud: %v", cluster.Name, err)
+		return false
+	}
+	defer state.Close() //nolint:errcheck // a probe's teardown tells us nothing
+
+	// Resolving the object is a round trip the cluster itself has to answer.
+	// Cloud relays it and cannot satisfy it, which is what makes this evidence
+	// about the cluster rather than about the link.
+	if _, err := state.Client(cloudProbeObject); err != nil {
+		ctx.Warn("Could not reach %s through cloud: %v", cluster.Name, err)
+		return false
+	}
+
+	return true
+}
+
+// cloudRouteProbe is the check the fallback decision runs, as a variable so a
+// test can substitute one. The real probe needs a live relayed session, which
+// is the blackbox suite's job; what is worth testing here is the decision made
+// from its answer. Tests in this package run sequentially, so swapping it is
+// safe as long as none of them opts into t.Parallel.
+var cloudRouteProbe = cloudRouteWorks
 
 // cloudRoutableClusters reports which of the given clusters cannot be dialed
 // directly but can be reached through cloud, keyed by XID.

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -51,6 +51,12 @@ const (
 	// port is what's necessary and sufficient, not TCP) and points at the
 	// on-host diagnostic that reproduces the exact decision.
 	unreachableAddressHelp = "open UDP 8443 (QUIC) on the host or set additional_ips, then restart miren; run 'miren debug advertise' on the host to see why"
+
+	// viaCloudNote replaces that note for a cluster nothing can dial but cloud
+	// can still reach. Not a degraded state to remediate: it is a working
+	// cluster on a network that does not accept inbound connections, which is a
+	// reasonable way to run one.
+	viaCloudNote = "via Miren Cloud"
 )
 
 // printUnreachableClustersHelp prints a warning header, a bulleted list of the
@@ -252,6 +258,128 @@ func fetchAvailableClusters(ctx *Context, config *clientconfig.Config, identityN
 	return response.Clusters, nil
 }
 
+// clusterOnlineInCloud asks cloud whether it currently holds a link to a
+// cluster, which is the precondition for relaying RPC to it.
+//
+// This is what separates "you cannot dial this cluster, and nothing else can
+// either" from "you cannot dial it, but cloud can". The first is a dead end
+// worth saying so about; the second is a cluster that works fine once the
+// config says to route through cloud.
+func clusterOnlineInCloud(
+	ctx *Context,
+	config *clientconfig.Config,
+	identityName string,
+	identity *clientconfig.IdentityConfig,
+	clusterXID string,
+) (bool, error) {
+	if identity == nil || clusterXID == "" {
+		return false, nil
+	}
+
+	issuerURL := identity.Issuer
+	if issuerURL == "" {
+		return false, fmt.Errorf("identity has no issuer configured")
+	}
+
+	token, err := config.TokenForIdentity(ctx, identityName, identity, issuerURL)
+	if err != nil {
+		return false, fmt.Errorf("failed to authenticate: %w", err)
+	}
+
+	onlineURL, err := url.JoinPath(issuerURL, "/api/v1/clusters/", clusterXID, "/online")
+	if err != nil {
+		return false, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", onlineURL, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	// Short, because this runs while somebody is waiting at a prompt and a slow
+	// answer is worth no more than no answer: either way we fall back to
+	// treating the cluster as unroutable.
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("cloud returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var response struct {
+		Online bool `json:"online"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return false, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return response.Online, nil
+}
+
+// cloudRoutableClusters reports which of the given clusters cannot be dialed
+// directly but can be reached through cloud, keyed by XID.
+//
+// Only the ones advertising no address are asked about, which is both the case
+// this exists for and a bound on how many requests a picker costs.
+//
+// An error on any single check is not fatal, since the cluster simply does not
+// get offered as cloud-routable, which is what a "no" would have produced. It
+// is still reported once at the end rather than swallowed: about to be told a
+// cluster is unusable, it matters whether that is cloud's answer or cloud
+// failing to give one.
+func cloudRoutableClusters(
+	ctx *Context,
+	config *clientconfig.Config,
+	identityName string,
+	identity *clientconfig.IdentityConfig,
+	clusters []ClusterResponse,
+) map[string]bool {
+	routable := make(map[string]bool)
+
+	var (
+		unchecked []string
+		lastErr   error
+	)
+
+	for _, cluster := range clusters {
+		if cluster.hasReachableAddress() || cluster.XID == "" {
+			continue
+		}
+
+		online, err := clusterOnlineInCloud(ctx, config, identityName, identity, cluster.XID)
+		if err != nil {
+			unchecked = append(unchecked, cluster.Name)
+			lastErr = err
+			continue
+		}
+		if online {
+			routable[cluster.XID] = true
+		}
+	}
+
+	if len(unchecked) > 0 {
+		ctx.Warn("Could not ask cloud whether %s reachable through it (%v); treating as not reachable.",
+			plural(unchecked), lastErr)
+	}
+
+	return routable
+}
+
+// plural renders a short list of names for a one-line message.
+func plural(names []string) string {
+	if len(names) == 1 {
+		return fmt.Sprintf("%s is", names[0])
+	}
+	return fmt.Sprintf("%s are", strings.Join(names, ", "))
+}
+
 // buildClusterPickerItems turns the fetched clusters into picker rows. Every
 // cluster gets a row: reachable ones show their primary address (sorted so a
 // public address wins) and are selectable; unreachable ones (no advertised
@@ -260,7 +388,7 @@ func fetchAvailableClusters(ctx *Context, config *clientconfig.Config, identityN
 // the source cluster, the set of disabled row IDs, and the count of selectable
 // (reachable) clusters. Kept pure so the classification is unit-testable
 // without standing up a TUI. See MIR-1316.
-func buildClusterPickerItems(clusters []ClusterResponse) (items []ui.PickerItem, clusterMap map[string]*ClusterResponse, disabled map[string]bool, reachableCount int) {
+func buildClusterPickerItems(clusters []ClusterResponse, cloudRoutable map[string]bool) (items []ui.PickerItem, clusterMap map[string]*ClusterResponse, disabled map[string]bool, reachableCount int) {
 	items = make([]ui.PickerItem, 0, len(clusters))
 	clusterMap = make(map[string]*ClusterResponse)
 	disabled = make(map[string]bool)
@@ -278,6 +406,13 @@ func buildClusterPickerItems(clusters []ClusterResponse) (items []ui.PickerItem,
 			if len(addresses) > 1 {
 				address = fmt.Sprintf("%s (+%d)", address, len(addresses)-1)
 			}
+		} else if cloudRoutable[cluster.XID] {
+			// Selectable, because it can be used: the entry will route through
+			// cloud rather than dialing. Counted as reachable for the same
+			// reason, since that count only exists to decide whether the picker
+			// has anything to offer.
+			reachableCount++
+			address = viaCloudNote
 		} else {
 			address = unreachableAddressNote
 			disabled[itemID] = true
@@ -299,7 +434,7 @@ func buildClusterPickerItems(clusters []ClusterResponse) (items []ui.PickerItem,
 
 // selectClusterFromList presents an interactive list of clusters for selection and prompts for local name
 // Returns the selected cluster and the local name to use
-func selectClusterFromList(ctx *Context, clusters []ClusterResponse) (*ClusterResponse, string, error) {
+func selectClusterFromList(ctx *Context, clusters []ClusterResponse, cloudRoutable map[string]bool) (*ClusterResponse, string, error) {
 	// Check if we can run interactive mode
 	if !ui.IsInteractive() {
 		// Non-interactive mode - list clusters and exit. We list clusters with no
@@ -321,6 +456,8 @@ func selectClusterFromList(ctx *Context, clusters []ClusterResponse) (*ClusterRe
 				if cluster.CACertFingerprint != "" {
 					ctx.Printf("   Certificate Fingerprint: %s\n", cluster.CACertFingerprint)
 				}
+			} else if cloudRoutable[cluster.XID] {
+				ctx.Printf("   Status: %s (no direct route, but cloud can reach it)\n", viaCloudNote)
 			} else {
 				ctx.Printf("   Status: %s — %s\n", unreachableAddressNote, unreachableAddressHelp)
 			}
@@ -330,11 +467,12 @@ func selectClusterFromList(ctx *Context, clusters []ClusterResponse) (*ClusterRe
 		return nil, "", fmt.Errorf("interactive mode not available")
 	}
 
-	// Build the picker rows. Clusters with no reachable address are listed too,
-	// but disabled (greyed out, not selectable) with the reason inline, rather
-	// than hidden — a silently missing cluster reads as an auth/org problem and
-	// sends users chasing the wrong thing. See MIR-1316.
-	items, clusterMap, disabled, reachableCount := buildClusterPickerItems(clusters)
+	// Build the picker rows. A cluster with no reachable address that cloud can
+	// still reach is selectable and annotated, because it works. One nothing can
+	// reach is listed but disabled, with the reason inline rather than hidden —
+	// a silently missing cluster reads as an auth or org problem and sends users
+	// chasing the wrong thing. See MIR-1316.
+	items, clusterMap, disabled, reachableCount := buildClusterPickerItems(clusters, cloudRoutable)
 
 	// If nothing is selectable, a picker is a dead end. Print the clusters with
 	// their reason and return a clear error instead of trapping the user in a

--- a/cli/commands/config_bind_helpers.go
+++ b/cli/commands/config_bind_helpers.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -422,21 +423,45 @@ func cloudRoutableClusters(
 		lastErr   error
 	)
 
+	// Concurrently, because these run while somebody waits at a prompt and the
+	// checks do not depend on each other. Sequentially, an account with several
+	// undialable clusters paid each one's timeout in turn before the picker
+	// appeared — worst case tens of seconds of nothing on screen. The direct
+	// path already probes its addresses this way.
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+
 	for _, cluster := range clusters {
 		if cluster.hasReachableAddress() || cluster.XID == "" {
 			continue
 		}
 
-		online, err := clusterOnlineInCloud(ctx, config, identityName, identity, cluster.XID)
-		if err != nil {
-			unchecked = append(unchecked, cluster.Name)
-			lastErr = err
-			continue
-		}
-		if online {
-			routable[cluster.XID] = true
-		}
+		wg.Add(1)
+		go func(cluster ClusterResponse) {
+			defer wg.Done()
+
+			online, err := clusterOnlineInCloud(ctx, config, identityName, identity, cluster.XID)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				unchecked = append(unchecked, cluster.Name)
+				lastErr = err
+				return
+			}
+			if online {
+				routable[cluster.XID] = true
+			}
+		}(cluster)
 	}
+
+	wg.Wait()
+
+	// Names are reported in a stable order rather than whichever request
+	// happened to fail first, so the same failure reads the same way twice.
+	sort.Strings(unchecked)
 
 	if len(unchecked) > 0 {
 		ctx.Warn("Could not ask cloud whether %s reachable through it (%v); treating as not reachable.",

--- a/cli/commands/config_bind_helpers_test.go
+++ b/cli/commands/config_bind_helpers_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/ui"
 )
 
 func TestHasReachableAddress(t *testing.T) {
@@ -50,7 +52,7 @@ func TestBuildClusterPickerItems(t *testing.T) {
 			{Name: "oh-data", OrganizationName: "oh-data"}, // no address
 		}
 
-		items, clusterMap, disabled, reachableCount := buildClusterPickerItems(clusters)
+		items, clusterMap, disabled, reachableCount := buildClusterPickerItems(clusters, nil)
 
 		// Every cluster gets a row — the unreachable one is shown, not hidden.
 		require.Len(t, items, 2)
@@ -74,7 +76,7 @@ func TestBuildClusterPickerItems(t *testing.T) {
 			{Name: "multi", APIAddresses: []string{"1.1.1.1:8443", "2.2.2.2:8443"}},
 		}
 
-		items, _, disabled, reachableCount := buildClusterPickerItems(clusters)
+		items, _, disabled, reachableCount := buildClusterPickerItems(clusters, nil)
 
 		require.Len(t, items, 1)
 		assert.Equal(t, 1, reachableCount)
@@ -88,7 +90,7 @@ func TestBuildClusterPickerItems(t *testing.T) {
 			{Name: "b", APIAddresses: []string{"2.2.2.2:8443"}},
 		}
 
-		items, _, disabled, reachableCount := buildClusterPickerItems(clusters)
+		items, _, disabled, reachableCount := buildClusterPickerItems(clusters, nil)
 
 		require.Len(t, items, 2)
 		assert.Equal(t, 2, reachableCount)
@@ -101,7 +103,7 @@ func TestBuildClusterPickerItems(t *testing.T) {
 			{Name: "b"},
 		}
 
-		items, _, disabled, reachableCount := buildClusterPickerItems(clusters)
+		items, _, disabled, reachableCount := buildClusterPickerItems(clusters, nil)
 
 		require.Len(t, items, 2)
 		assert.Equal(t, 0, reachableCount)
@@ -109,7 +111,7 @@ func TestBuildClusterPickerItems(t *testing.T) {
 	})
 
 	t.Run("empty input yields empty rows", func(t *testing.T) {
-		items, clusterMap, disabled, reachableCount := buildClusterPickerItems(nil)
+		items, clusterMap, disabled, reachableCount := buildClusterPickerItems(nil, nil)
 
 		assert.Empty(t, items)
 		assert.Empty(t, clusterMap)
@@ -126,4 +128,58 @@ func TestUnreachableRemediationMessaging(t *testing.T) {
 	assert.Contains(t, unreachableAddressHelp, "additional_ips")
 	assert.Contains(t, unreachableAddressHelp, "miren debug advertise")
 	assert.NotEmpty(t, unreachableAddressNote)
+}
+
+// A cluster that advertises no address used to be a dead end, greyed out with
+// advice about opening a port. That advice is right only when nothing can reach
+// it. When cloud holds a link, the cluster works, and the picker has to offer it
+// rather than tell the operator to reconfigure a firewall they may not control.
+func TestBuildClusterPickerItemsOffersCloudRoutableClusters(t *testing.T) {
+	clusters := []ClusterResponse{
+		{Name: "club", XID: "cluster-1", OrganizationName: "Miren Club", APIAddresses: []string{"34.27.122.56:8443"}},
+		{Name: "behind-nat", XID: "cluster-2", OrganizationName: "Home"},
+		{Name: "really-gone", XID: "cluster-3", OrganizationName: "Home"},
+	}
+
+	// Cloud can reach the second one, and cannot reach the third.
+	routable := map[string]bool{"cluster-2": true}
+
+	items, _, disabled, reachableCount := buildClusterPickerItems(clusters, routable)
+
+	require.Len(t, items, 3)
+
+	// The dialable one and the cloud-routable one are both usable, which is what
+	// the count is for.
+	assert.Equal(t, 2, reachableCount)
+
+	assert.False(t, disabled[items[0].ID()], "a dialable cluster stays selectable")
+	assert.False(t, disabled[items[1].ID()], "a cloud-routable cluster must be selectable")
+	assert.True(t, disabled[items[2].ID()], "a cluster nothing can reach stays disabled")
+
+	// And it says which it is, so the choice is not a mystery.
+	assert.Contains(t, rowText(items[1]), viaCloudNote)
+	assert.Contains(t, rowText(items[2]), unreachableAddressNote)
+}
+
+// With no cloud routing available the old behaviour has to hold exactly, since
+// that is still the right answer for a cluster nothing can reach.
+func TestBuildClusterPickerItemsWithoutCloudRouting(t *testing.T) {
+	clusters := []ClusterResponse{
+		{Name: "behind-nat", XID: "cluster-2", OrganizationName: "Home"},
+	}
+
+	items, _, disabled, reachableCount := buildClusterPickerItems(clusters, nil)
+
+	require.Len(t, items, 1)
+	assert.Equal(t, 0, reachableCount)
+	assert.True(t, disabled[items[0].ID()])
+	assert.Contains(t, rowText(items[0]), unreachableAddressNote)
+}
+
+// rowText flattens a picker row so a test can assert on what it says.
+func rowText(item ui.PickerItem) string {
+	if row, ok := item.(ui.TablePickerItem); ok {
+		return strings.Join(row.Columns, " ")
+	}
+	return item.ID()
 }

--- a/cli/commands/config_bind_render_test.go
+++ b/cli/commands/config_bind_render_test.go
@@ -24,7 +24,7 @@ func TestClusterPickerRendersUnreachable(t *testing.T) {
 		{Name: "oh-data", OrganizationName: "oh-data"}, // firewalled: no address
 	}
 
-	items, _, disabled, reachableCount := buildClusterPickerItems(clusters)
+	items, _, disabled, reachableCount := buildClusterPickerItems(clusters, nil)
 	require.Equal(t, 1, reachableCount)
 
 	m := ui.NewPicker(items,

--- a/cli/commands/connect_notice.go
+++ b/cli/commands/connect_notice.go
@@ -139,7 +139,14 @@ func connectNoticeLabel(target string, elapsed time.Duration, withAge bool) stri
 func (c *Context) connectTarget() string {
 	addr := ""
 	if c.ClusterConfig != nil {
-		addr = c.ClusterConfig.Hostname
+		// A cloud-routed cluster's hostname is not what we dial, and is often
+		// unset or stale. Naming the route is both true and the more useful
+		// thing to read while a connection is taking a while.
+		if c.ClusterConfig.ViaCloud {
+			addr = "via miren cloud"
+		} else {
+			addr = c.ClusterConfig.Hostname
+		}
 	}
 	if addr == "" {
 		addr = c.Config.ServerAddress

--- a/cli/commands/whoami.go
+++ b/cli/commands/whoami.go
@@ -17,8 +17,18 @@ func Whoami(ctx *Context, opts struct {
 		return fmt.Errorf("no cluster configured - use 'miren cluster add' to add a cluster")
 	}
 
-	// Get server hostname
+	// Where this cluster is reached. A cloud-routed one has no address of its
+	// own — that is the point of it — so the cloud it is reached through stands
+	// in, which is also the server the identity below authenticates against.
 	hostname := ctx.ClusterConfig.Hostname
+	if ctx.ClusterConfig.ViaCloud {
+		hostname = ctx.ClusterConfig.CloudURL
+		if hostname == "" && ctx.ClientConfig != nil && ctx.ClusterConfig.Identity != "" {
+			if id, err := ctx.ClientConfig.GetIdentity(ctx.ClusterConfig.Identity); err == nil && id != nil {
+				hostname = id.Issuer
+			}
+		}
+	}
 	if hostname == "" {
 		return fmt.Errorf("no hostname configured for cluster %s", ctx.ClusterName)
 	}

--- a/cli/commands/whoami.go
+++ b/cli/commands/whoami.go
@@ -22,11 +22,10 @@ func Whoami(ctx *Context, opts struct {
 	// in, which is also the server the identity below authenticates against.
 	hostname := ctx.ClusterConfig.Hostname
 	if ctx.ClusterConfig.ViaCloud {
-		hostname = ctx.ClusterConfig.CloudURL
-		if hostname == "" && ctx.ClientConfig != nil && ctx.ClusterConfig.Identity != "" {
-			if id, err := ctx.ClientConfig.GetIdentity(ctx.ClusterConfig.Identity); err == nil && id != nil {
-				hostname = id.Issuer
-			}
+		// Same precedence the connection itself uses, from the same place, so
+		// what this reports cannot drift from where the call actually went.
+		if cloud, err := ctx.ClusterConfig.CloudEndpoint(ctx.ClientConfig); err == nil {
+			hostname = cloud
 		}
 	}
 	if hostname == "" {

--- a/clientconfig/clientconfig.go
+++ b/clientconfig/clientconfig.go
@@ -76,6 +76,20 @@ type ClusterConfig struct {
 	// TLSServerName overrides the name the server certificate is verified
 	// against, for when the dial address cannot be a certificate SAN.
 	TLSServerName string `yaml:"tls_server_name,omitempty"`
+
+	// ViaCloud routes RPC through Miren Cloud rather than dialing the cluster,
+	// for a cluster this machine has no route to. It needs XID to name the
+	// cluster and an identity to authenticate as; Hostname is unused.
+	//
+	// Opting in is explicit rather than a fallback from a failed direct dial,
+	// so that every command's answer comes from a path you chose. A silent
+	// fallback would also make every command wait out a dial timeout first.
+	ViaCloud bool `yaml:"via_cloud,omitempty"`
+
+	// CloudURL overrides where the relay lives. Normally empty: the identity's
+	// issuer is already the cloud that vouches for you, and pointing the two at
+	// different places is a mistake far more often than an intent.
+	CloudURL string `yaml:"cloud_url,omitempty"`
 }
 
 // Config represents the complete client configuration

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -287,6 +287,27 @@ func (c *ClusterConfig) viaCloudOptions(ctx context.Context, config *Config) ([]
 	return opts, nil
 }
 
+// CloudEndpoint returns the cloud a via-cloud cluster is reached through.
+//
+// An explicit cloud_url wins over the identity's issuer, which is what makes a
+// cluster registered with one cloud reachable through another. Exported so the
+// commands that need to name that cloud share the rule rather than restating
+// it: two copies drift, and the copy outside this package is the one nothing
+// else would catch.
+func (c *ClusterConfig) CloudEndpoint(config *Config) (string, error) {
+	if c.CloudURL != "" {
+		return c.CloudURL, nil
+	}
+
+	if config != nil && c.Identity != "" {
+		if identity, err := config.GetIdentity(c.Identity); err == nil && identity != nil && identity.Issuer != "" {
+			return identity.Issuer, nil
+		}
+	}
+
+	return "", fmt.Errorf("cluster is routed via cloud but neither it nor identity %q names a cloud", c.Identity)
+}
+
 // cloudRelay resolves where to reach the cluster through cloud, and with what.
 func (c *ClusterConfig) cloudRelay(ctx context.Context, config *Config) (endpoint, token string, err error) {
 	if c.XID == "" {
@@ -301,12 +322,9 @@ func (c *ClusterConfig) cloudRelay(ctx context.Context, config *Config) (endpoin
 		return "", "", fmt.Errorf("failed to get identity %q: %w", c.Identity, err)
 	}
 
-	cloudURL := c.CloudURL
-	if cloudURL == "" {
-		cloudURL = identity.Issuer
-	}
-	if cloudURL == "" {
-		return "", "", fmt.Errorf("cluster is routed via cloud but neither it nor identity %q names a cloud", c.Identity)
+	cloudURL, err := c.CloudEndpoint(config)
+	if err != nil {
+		return "", "", err
 	}
 
 	// A certificate identity has no bearer token, and the relay has nothing else
@@ -362,7 +380,12 @@ func cloudRPCEndpoint(cloudURL, clusterXID string, allowPlaintext bool) (string,
 			cloudURL, host)
 	}
 
-	return scheme + base + fmt.Sprintf(CloudRPCPath, clusterXID), nil
+	// Escaped because it comes from a config file. An XID holding / ? or #
+	// would otherwise redraw the URL rather than fail it, sending the request —
+	// and the bearer on it — somewhere other than the path meant here. Cloud
+	// only ever mints well-formed ones, so this needs a hand-edited config to
+	// reach, which is exactly the case where a silent redirect is worst.
+	return scheme + base + fmt.Sprintf(CloudRPCPath, url.PathEscape(clusterXID)), nil
 }
 
 // isLoopbackHost reports whether a "host" or "host:port" names this machine.

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -100,6 +101,13 @@ func (c *ClusterConfig) RPCOptions(ctx context.Context, config *Config) ([]rpc.S
 
 // RPCOptionsWithName returns RPC options with cluster name for caching
 func (c *ClusterConfig) RPCOptionsWithName(ctx context.Context, config *Config, clusterName string) ([]rpc.StateOption, error) {
+	// A cloud-routed cluster settles the matter before anything below: the
+	// address probing, the cluster CA, and the direct-dial paths all reason
+	// about a cluster we can reach, which is exactly what this cluster is not.
+	if c.ViaCloud {
+		return c.viaCloudOptions(ctx, config)
+	}
+
 	// If AllAddresses is set, find a working address
 	hostname := c.Hostname
 	if len(c.AllAddresses) > 0 && clusterName != "" {
@@ -236,6 +244,96 @@ foundAddress:
 	}
 
 	return opts, nil
+}
+
+// CloudRPCPath is where Miren Cloud relays RPC for a cluster. The cluster's XID
+// is the only thing that varies, because the relay's job is to find the socket
+// that cluster is holding open.
+const CloudRPCPath = "/api/v1/clusters/%s/rpc"
+
+// viaCloudOptions builds the options for reaching a cluster through Miren Cloud.
+//
+// The credential is the one the cluster would have seen anyway, and it is used
+// twice: cloud reads it at the handshake to decide whether to relay at all, and
+// the cluster reads it inside each operation to decide what the caller may do.
+// Nothing is minted for the detour, so a cloud-routed call is authorized exactly
+// as a direct one — which is also why cloud being satisfied means nothing about
+// what the cluster will allow.
+func (c *ClusterConfig) viaCloudOptions(ctx context.Context, config *Config) ([]rpc.StateOption, error) {
+	endpoint, token, err := c.cloudRelay(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	// No cluster CA here: the certificate presented is cloud's, verified against
+	// the system roots. The cluster's own identity is not what is on the wire.
+	return []rpc.StateOption{
+		rpc.WithEndpoint(endpoint),
+		rpc.WithBindAddr("[::]:0"),
+		rpc.WithBearerToken(token),
+	}, nil
+}
+
+// cloudRelay resolves where to reach the cluster through cloud, and with what.
+func (c *ClusterConfig) cloudRelay(ctx context.Context, config *Config) (endpoint, token string, err error) {
+	if c.XID == "" {
+		return "", "", fmt.Errorf("cluster is routed via cloud but has no xid, so there is no cluster to ask for")
+	}
+	if c.Identity == "" {
+		return "", "", fmt.Errorf("cluster is routed via cloud but has no identity to authenticate with; run `miren login`")
+	}
+
+	identity, err := config.GetIdentity(c.Identity)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get identity %q: %w", c.Identity, err)
+	}
+
+	cloudURL := c.CloudURL
+	if cloudURL == "" {
+		cloudURL = identity.Issuer
+	}
+	if cloudURL == "" {
+		return "", "", fmt.Errorf("cluster is routed via cloud but neither it nor identity %q names a cloud", c.Identity)
+	}
+
+	// A certificate identity has no bearer token, and the relay has nothing else
+	// to authorize with — the client certificate terminates at cloud, which is
+	// not the cluster. Saying so beats a 401 from a hop the user did not know
+	// was there.
+	token, err = config.TokenForIdentity(ctx, c.Identity, identity, cloudURL)
+	if err != nil {
+		if errors.Is(err, ErrNoBearerToken) {
+			return "", "", fmt.Errorf("identity %q authenticates with a certificate, which cannot be relayed through cloud", c.Identity)
+		}
+		return "", "", fmt.Errorf("failed to authenticate with cloud: %w", err)
+	}
+
+	endpoint, err = cloudRPCEndpoint(cloudURL, c.XID)
+	if err != nil {
+		return "", "", err
+	}
+
+	return endpoint, token, nil
+}
+
+// cloudRPCEndpoint turns a cloud base URL into the relay remote for a cluster.
+// The scheme carries over: an http:// cloud is a development one with no
+// certificate, and must be dialed as plaintext rather than silently upgraded.
+func cloudRPCEndpoint(cloudURL, clusterXID string) (string, error) {
+	scheme, base := "wss://", cloudURL
+	switch {
+	case strings.HasPrefix(base, "http://"):
+		scheme, base = "ws://", strings.TrimPrefix(base, "http://")
+	case strings.HasPrefix(base, "https://"):
+		base = strings.TrimPrefix(base, "https://")
+	}
+
+	base = strings.TrimRight(base, "/")
+	if base == "" {
+		return "", fmt.Errorf("cloud url %q names no host", cloudURL)
+	}
+
+	return scheme + base + fmt.Sprintf(CloudRPCPath, clusterXID), nil
 }
 
 func (c *ClusterConfig) State(ctx context.Context, config *Config, opts ...rpc.StateOption) (*rpc.State, error) {

--- a/clientconfig/local.go
+++ b/clientconfig/local.go
@@ -267,11 +267,24 @@ func (c *ClusterConfig) viaCloudOptions(ctx context.Context, config *Config) ([]
 
 	// No cluster CA here: the certificate presented is cloud's, verified against
 	// the system roots. The cluster's own identity is not what is on the wire.
-	return []rpc.StateOption{
+	opts := []rpc.StateOption{
 		rpc.WithEndpoint(endpoint),
 		rpc.WithBindAddr("[::]:0"),
 		rpc.WithBearerToken(token),
-	}, nil
+	}
+
+	// Honoured rather than ignored: on this path it is what lets a development
+	// cloud with a self-signed certificate, or none at all, be reached. It is
+	// the same admission either way — that this connection is not authenticated
+	// — so it governs both.
+	if c.Insecure {
+		opts = append(opts, rpc.WithSkipVerify)
+	}
+	if c.TLSServerName != "" {
+		opts = append(opts, rpc.WithTLSServerName(c.TLSServerName))
+	}
+
+	return opts, nil
 }
 
 // cloudRelay resolves where to reach the cluster through cloud, and with what.
@@ -308,7 +321,7 @@ func (c *ClusterConfig) cloudRelay(ctx context.Context, config *Config) (endpoin
 		return "", "", fmt.Errorf("failed to authenticate with cloud: %w", err)
 	}
 
-	endpoint, err = cloudRPCEndpoint(cloudURL, c.XID)
+	endpoint, err = cloudRPCEndpoint(cloudURL, c.XID, c.Insecure)
 	if err != nil {
 		return "", "", err
 	}
@@ -319,7 +332,15 @@ func (c *ClusterConfig) cloudRelay(ctx context.Context, config *Config) (endpoin
 // cloudRPCEndpoint turns a cloud base URL into the relay remote for a cluster.
 // The scheme carries over: an http:// cloud is a development one with no
 // certificate, and must be dialed as plaintext rather than silently upgraded.
-func cloudRPCEndpoint(cloudURL, clusterXID string) (string, error) {
+//
+// Plaintext is refused beyond the loopback interface unless the entry says it
+// means it. Everything about this connection is the caller's credential — in
+// the handshake header so cloud can authorize it, and in every operation frame
+// so the cluster can — and over ws:// all of that crosses the network in the
+// clear, reusable by anyone who watched. Local development is the case that
+// justifies it; a hostname that resolves somewhere else is almost always a
+// mistake, and a silent one.
+func cloudRPCEndpoint(cloudURL, clusterXID string, allowPlaintext bool) (string, error) {
 	scheme, base := "wss://", cloudURL
 	switch {
 	case strings.HasPrefix(base, "http://"):
@@ -333,7 +354,32 @@ func cloudRPCEndpoint(cloudURL, clusterXID string) (string, error) {
 		return "", fmt.Errorf("cloud url %q names no host", cloudURL)
 	}
 
+	host, _, _ := strings.Cut(base, "/")
+	if scheme == "ws://" && !allowPlaintext && !isLoopbackHost(host) {
+		return "", fmt.Errorf(
+			"cloud url %q is unencrypted, which would send your credentials to %s in the clear; "+
+				"use https, or set insecure: true on the cluster if you meant it",
+			cloudURL, host)
+	}
+
 	return scheme + base + fmt.Sprintf(CloudRPCPath, clusterXID), nil
+}
+
+// isLoopbackHost reports whether a "host" or "host:port" names this machine.
+func isLoopbackHost(hostport string) bool {
+	host := hostport
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 func (c *ClusterConfig) State(ctx context.Context, config *Config, opts ...rpc.StateOption) (*rpc.State, error) {

--- a/clientconfig/viacloud_test.go
+++ b/clientconfig/viacloud_test.go
@@ -38,20 +38,48 @@ func TestCloudRPCEndpoint(t *testing.T) {
 
 		// A development cloud has no certificate, so the scheme carries over
 		// rather than being silently upgraded to one that cannot connect.
-		{"http://miren.host:3001", "ws://miren.host:3001/api/v1/clusters/cluster-abc/rpc"},
+		{"http://localhost:3001", "ws://localhost:3001/api/v1/clusters/cluster-abc/rpc"},
+		{"http://127.0.0.1:3001", "ws://127.0.0.1:3001/api/v1/clusters/cluster-abc/rpc"},
 
 		// No scheme is assumed to be the real thing, which is always TLS.
 		{"api.miren.cloud", "wss://api.miren.cloud/api/v1/clusters/cluster-abc/rpc"},
 	}
 
 	for _, tt := range tests {
-		got, err := cloudRPCEndpoint(tt.cloudURL, "cluster-abc")
+		got, err := cloudRPCEndpoint(tt.cloudURL, "cluster-abc", false)
 		require.NoError(t, err)
 		require.Equal(t, tt.want, got, "cloudRPCEndpoint(%q)", tt.cloudURL)
 	}
 
-	_, err := cloudRPCEndpoint("https://", "cluster-abc")
+	_, err := cloudRPCEndpoint("https://", "cluster-abc", false)
 	require.Error(t, err, "a url naming no host should not produce an endpoint")
+}
+
+// Every byte of a relayed session's authority is the caller's own credential,
+// and over an unencrypted socket all of it is readable by anyone on the path.
+// Loopback is the case that justifies plaintext; anywhere else has to be asked
+// for, because getting it by accident is silent and costs you the token.
+func TestCloudRPCEndpointRefusesRemotePlaintext(t *testing.T) {
+	_, err := cloudRPCEndpoint("http://cloud.internal:3001", "cluster-abc", false)
+	require.ErrorContains(t, err, "clear")
+
+	// Asked for, it is allowed: a development cloud reachable by name is a real
+	// setup, and the documented one for a container that cannot say localhost.
+	got, err := cloudRPCEndpoint("http://miren.host:3001", "cluster-abc", true)
+	require.NoError(t, err)
+	require.Equal(t, "ws://miren.host:3001/api/v1/clusters/cluster-abc/rpc", got)
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	loopback := []string{"localhost", "localhost:3001", "LocalHost:80", "127.0.0.1", "127.0.0.1:3001", "[::1]:3001", "::1"}
+	for _, h := range loopback {
+		require.True(t, isLoopbackHost(h), "%q should be loopback", h)
+	}
+
+	remote := []string{"miren.host:3001", "example.com", "10.0.0.1:80", "[2001:db8::1]:443"}
+	for _, h := range remote {
+		require.False(t, isLoopbackHost(h), "%q should not be loopback", h)
+	}
 }
 
 // The happy path: a cloud-routed cluster resolves to a relay endpoint and a
@@ -96,6 +124,10 @@ func TestViaCloudOptionsHonorsExplicitCloudURL(t *testing.T) {
 		XID:      "cluster-abc",
 		Identity: "cloud",
 		CloudURL: "http://miren.host:3001",
+		// Reaching a development cloud by a name rather than by loopback is
+		// the documented setup for a container, and it is plaintext, so it has
+		// to say so.
+		Insecure: true,
 	})
 
 	cluster, err := config.GetCluster("prod")
@@ -104,6 +136,23 @@ func TestViaCloudOptionsHonorsExplicitCloudURL(t *testing.T) {
 	endpoint, _, err := cluster.cloudRelay(t.Context(), config)
 	r.NoError(err)
 	r.Equal("ws://miren.host:3001/api/v1/clusters/cluster-abc/rpc", endpoint)
+}
+
+// The same entry without that admission is refused, which is what makes the
+// admission mean something.
+func TestViaCloudRefusesRemotePlaintextByDefault(t *testing.T) {
+	config := viaCloudConfig(t, &ClusterConfig{
+		ViaCloud: true,
+		XID:      "cluster-abc",
+		Identity: "cloud",
+		CloudURL: "http://miren.host:3001",
+	})
+
+	cluster, err := config.GetCluster("prod")
+	require.NoError(t, err)
+
+	_, err = cluster.RPCOptionsWithName(t.Context(), config, "prod")
+	require.ErrorContains(t, err, "clear")
 }
 
 // Each of these is a config that cannot produce a working connection. Failing

--- a/clientconfig/viacloud_test.go
+++ b/clientconfig/viacloud_test.go
@@ -246,3 +246,53 @@ func TestViaCloudOptionsRequiresACloud(t *testing.T) {
 	_, err = cluster.RPCOptionsWithName(t.Context(), config, "prod")
 	require.ErrorContains(t, err, "neither it nor identity")
 }
+
+// A cluster XID reaches this from a config file, so it is not automatically
+// well-formed. Unescaped, one holding a slash or a query marker would redraw
+// the URL instead of failing it, and the request — carrying a bearer — would go
+// somewhere other than the relay path.
+func TestCloudRPCEndpointEscapesTheClusterXID(t *testing.T) {
+	got, err := cloudRPCEndpoint("https://api.miren.cloud", "evil/../../admin", false)
+	require.NoError(t, err)
+	require.Equal(t, "wss://api.miren.cloud/api/v1/clusters/evil%2F..%2F..%2Fadmin/rpc", got,
+		"a separator in the xid must stay part of one path segment")
+
+	got, err = cloudRPCEndpoint("https://api.miren.cloud", "abc?x=1#f", false)
+	require.NoError(t, err)
+	require.Equal(t, "wss://api.miren.cloud/api/v1/clusters/abc%3Fx=1%23f/rpc", got,
+		"a query or fragment marker must not escape the path")
+}
+
+// whoami and the connection itself both have to answer "which cloud does this
+// cluster go through". They read the same resolver so the answer shown cannot
+// drift from the answer used.
+func TestCloudEndpointPrefersExplicitURLOverIssuer(t *testing.T) {
+	r := require.New(t)
+
+	config := viaCloudConfig(t, &ClusterConfig{
+		ViaCloud: true,
+		XID:      "cluster-abc",
+		Identity: "cloud",
+		CloudURL: "https://other.example",
+	})
+
+	cluster, err := config.GetCluster("prod")
+	r.NoError(err)
+
+	got, err := cluster.CloudEndpoint(config)
+	r.NoError(err)
+	r.Equal("https://other.example", got)
+
+	// Falling back to the identity's issuer is what makes the common config,
+	// which names no cloud on the cluster at all, work.
+	cluster.CloudURL = ""
+	got, err = cluster.CloudEndpoint(config)
+	r.NoError(err)
+	r.Equal("https://api.miren.cloud", got)
+
+	// And naming neither is an error rather than an empty string that would
+	// surface later as a dial to nowhere.
+	cluster.Identity = ""
+	_, err = cluster.CloudEndpoint(config)
+	r.ErrorContains(err, "neither it nor identity")
+}

--- a/clientconfig/viacloud_test.go
+++ b/clientconfig/viacloud_test.go
@@ -1,0 +1,190 @@
+package clientconfig
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// viaCloudConfig builds a config holding one cloud-routed cluster and the token
+// identity it authenticates with. The token is fresh, so resolving it takes the
+// cached path and touches no network.
+func viaCloudConfig(t *testing.T, cluster *ClusterConfig) *Config {
+	t.Helper()
+
+	config := NewConfig()
+	config.SetIdentity("cloud", &IdentityConfig{
+		Type:   IdentityToken,
+		Issuer: "https://api.miren.cloud",
+		Token: makeToken(t, jwt.MapClaims{
+			"sub": "user-1",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}),
+	})
+	config.SetCluster("prod", cluster)
+
+	return config
+}
+
+func TestCloudRPCEndpoint(t *testing.T) {
+	tests := []struct {
+		cloudURL string
+		want     string
+	}{
+		{"https://api.miren.cloud", "wss://api.miren.cloud/api/v1/clusters/cluster-abc/rpc"},
+		{"https://api.miren.cloud/", "wss://api.miren.cloud/api/v1/clusters/cluster-abc/rpc"},
+
+		// A development cloud has no certificate, so the scheme carries over
+		// rather than being silently upgraded to one that cannot connect.
+		{"http://miren.host:3001", "ws://miren.host:3001/api/v1/clusters/cluster-abc/rpc"},
+
+		// No scheme is assumed to be the real thing, which is always TLS.
+		{"api.miren.cloud", "wss://api.miren.cloud/api/v1/clusters/cluster-abc/rpc"},
+	}
+
+	for _, tt := range tests {
+		got, err := cloudRPCEndpoint(tt.cloudURL, "cluster-abc")
+		require.NoError(t, err)
+		require.Equal(t, tt.want, got, "cloudRPCEndpoint(%q)", tt.cloudURL)
+	}
+
+	_, err := cloudRPCEndpoint("https://", "cluster-abc")
+	require.Error(t, err, "a url naming no host should not produce an endpoint")
+}
+
+// The happy path: a cloud-routed cluster resolves to a relay endpoint and a
+// bearer, and nothing else. In particular it must not carry the cluster CA —
+// the certificate on the wire is cloud's.
+func TestViaCloudOptions(t *testing.T) {
+	r := require.New(t)
+
+	config := viaCloudConfig(t, &ClusterConfig{
+		ViaCloud: true,
+		XID:      "cluster-abc",
+		Identity: "cloud",
+		// Deliberately set, and deliberately unused: a cloud-routed cluster is
+		// one we cannot dial, so neither its address nor its CA is on the wire.
+		Hostname: "unreachable.example.com:8443",
+		CACert:   testCAPEM,
+	})
+
+	cluster, err := config.GetCluster("prod")
+	r.NoError(err)
+
+	endpoint, token, err := cluster.cloudRelay(t.Context(), config)
+	r.NoError(err)
+	r.Equal("wss://api.miren.cloud/api/v1/clusters/cluster-abc/rpc", endpoint)
+	r.NotEmpty(token)
+
+	// Endpoint, bind address, bearer — and nothing else. A cloud-routed cluster
+	// must not verify against the cluster CA, because the certificate on the
+	// wire is cloud's.
+	opts, err := cluster.RPCOptionsWithName(t.Context(), config, "prod")
+	r.NoError(err)
+	r.Len(opts, 3)
+}
+
+// An explicit cloud_url wins over the identity's issuer, which is what makes a
+// cluster registered with one cloud reachable through another.
+func TestViaCloudOptionsHonorsExplicitCloudURL(t *testing.T) {
+	r := require.New(t)
+
+	config := viaCloudConfig(t, &ClusterConfig{
+		ViaCloud: true,
+		XID:      "cluster-abc",
+		Identity: "cloud",
+		CloudURL: "http://miren.host:3001",
+	})
+
+	cluster, err := config.GetCluster("prod")
+	r.NoError(err)
+
+	endpoint, _, err := cluster.cloudRelay(t.Context(), config)
+	r.NoError(err)
+	r.Equal("ws://miren.host:3001/api/v1/clusters/cluster-abc/rpc", endpoint)
+}
+
+// Each of these is a config that cannot produce a working connection. Failing
+// here names the missing piece; failing later would surface as a 404 or a 401
+// from a hop the user did not know was in the path.
+func TestViaCloudOptionsRejectsIncompleteConfigs(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *ClusterConfig
+		wants   string
+	}{
+		{
+			name:    "no xid",
+			cluster: &ClusterConfig{ViaCloud: true, Identity: "cloud"},
+			wants:   "xid",
+		},
+		{
+			name:    "no identity",
+			cluster: &ClusterConfig{ViaCloud: true, XID: "cluster-abc"},
+			wants:   "identity",
+		},
+		{
+			name:    "unknown identity",
+			cluster: &ClusterConfig{ViaCloud: true, XID: "cluster-abc", Identity: "nope"},
+			wants:   "nope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := viaCloudConfig(t, tt.cluster)
+
+			cluster, err := config.GetCluster("prod")
+			require.NoError(t, err)
+
+			_, err = cluster.RPCOptionsWithName(t.Context(), config, "prod")
+			require.ErrorContains(t, err, tt.wants)
+		})
+	}
+}
+
+// A certificate identity cannot be relayed: the client certificate would
+// terminate at cloud, which is not the cluster. The error has to say that
+// rather than letting the connection fail as unauthorized.
+func TestViaCloudOptionsRejectsCertificateIdentity(t *testing.T) {
+	config := NewConfig()
+	config.SetIdentity("cert", &IdentityConfig{
+		Type:       IdentityCertificate,
+		Issuer:     "https://api.miren.cloud",
+		ClientCert: testCAPEM,
+		ClientKey:  testCAPEM,
+	})
+	config.SetCluster("prod", &ClusterConfig{
+		ViaCloud: true,
+		XID:      "cluster-abc",
+		Identity: "cert",
+	})
+
+	cluster, err := config.GetCluster("prod")
+	require.NoError(t, err)
+
+	_, err = cluster.RPCOptionsWithName(t.Context(), config, "prod")
+	require.ErrorContains(t, err, "certificate")
+}
+
+// A cluster with no cloud named anywhere has nowhere to route to.
+func TestViaCloudOptionsRequiresACloud(t *testing.T) {
+	config := NewConfig()
+	config.SetIdentity("cloud", &IdentityConfig{
+		Type:  IdentityToken,
+		Token: makeToken(t, jwt.MapClaims{"exp": time.Now().Add(time.Hour).Unix()}),
+	})
+	config.SetCluster("prod", &ClusterConfig{
+		ViaCloud: true,
+		XID:      "cluster-abc",
+		Identity: "cloud",
+	})
+
+	cluster, err := config.GetCluster("prod")
+	require.NoError(t, err)
+
+	_, err = cluster.RPCOptionsWithName(t.Context(), config, "prod")
+	require.ErrorContains(t, err, "cloud")
+}

--- a/clientconfig/viacloud_test.go
+++ b/clientconfig/viacloud_test.go
@@ -234,6 +234,8 @@ func TestViaCloudOptionsRequiresACloud(t *testing.T) {
 	cluster, err := config.GetCluster("prod")
 	require.NoError(t, err)
 
+	// "cloud" appears in most errors on this path, including the one for
+	// failing to authenticate, so matching it would pass on the wrong failure.
 	_, err = cluster.RPCOptionsWithName(t.Context(), config, "prod")
-	require.ErrorContains(t, err, "cloud")
+	require.ErrorContains(t, err, "neither it nor identity")
 }

--- a/clientconfig/viacloud_test.go
+++ b/clientconfig/viacloud_test.go
@@ -43,6 +43,13 @@ func TestCloudRPCEndpoint(t *testing.T) {
 
 		// No scheme is assumed to be the real thing, which is always TLS.
 		{"api.miren.cloud", "wss://api.miren.cloud/api/v1/clusters/cluster-abc/rpc"},
+
+		// A cloud mounted under a path keeps it, so the relay route is appended
+		// to where that cloud actually lives rather than to its host. Deliberate
+		// — an install behind a shared domain is a real shape — and untested
+		// until review pointed out that nothing said so either way.
+		{"https://cloud.example.com/miren", "wss://cloud.example.com/miren/api/v1/clusters/cluster-abc/rpc"},
+		{"https://cloud.example.com/miren/", "wss://cloud.example.com/miren/api/v1/clusters/cluster-abc/rpc"},
 	}
 
 	for _, tt := range tests {

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -70,6 +70,7 @@ import (
 	"miren.dev/runtime/pkg/anywhere"
 	"miren.dev/runtime/pkg/caauth"
 	"miren.dev/runtime/pkg/cloudauth"
+	"miren.dev/runtime/pkg/cloudrpc"
 	"miren.dev/runtime/pkg/containerenv"
 	"miren.dev/runtime/pkg/controller"
 	"miren.dev/runtime/pkg/entity"
@@ -1661,6 +1662,16 @@ func (c *Coordinator) Start(ctx context.Context) error {
 			Log:        c.Log.With("component", "anywhere"),
 			Uplink:     link,
 		})
+		// Serving RPC over the link is what lets an operator reach a cluster
+		// they have no route to. It hands out no new authority: calls arriving
+		// this way land on the same objects the network listener serves, and are
+		// authenticated and authorized by the same chain.
+		cloudrpc.New(cloudrpc.Config{
+			Uplink: link,
+			State:  c.state,
+			Log:    c.Log.With("component", "cloudrpc"),
+		})
+
 		go func() {
 			// POP connections outlive individual reconnects but not the link
 			// itself, which is why this is tied to Run returning rather than to

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "docs",

--- a/docs/docs/command/cluster-add.md
+++ b/docs/docs/command/cluster-add.md
@@ -20,6 +20,7 @@ miren cluster add [flags]
 - `--cluster, -c` — Name of the cluster to create (optional - will list available)
 - `--force, -f` — Overwrite existing cluster configuration
 - `--identity, -i` — Name of the identity to use (optional - will use the only one if single)
+- `--via-cloud` — Reach the cluster through Miren Cloud instead of dialing it, for a cluster this machine has no route to
 
 ## Global Options
 

--- a/docs/docs/miren-cloud/cloud-routed-clusters.md
+++ b/docs/docs/miren-cloud/cloud-routed-clusters.md
@@ -1,0 +1,123 @@
+---
+title: Cloud-Routed Clusters
+description: Reach a cluster through Miren Cloud when your machine has no route to it, using the same credentials and the same permissions as a direct connection.
+keywords: [cloud routed, via cloud, relay, unreachable cluster, firewall, nat, rpc]
+---
+
+# Cloud-Routed Clusters
+
+Normally the `miren` CLI dials your cluster directly. That needs a route to it: a
+public address, a VPN, or a tunnel. Plenty of clusters have none. A cluster
+behind office NAT, on a home network, or inside a private subnet is perfectly
+healthy and still unreachable from wherever you happen to be sitting.
+
+Those clusters already hold an outbound connection to Miren Cloud, which is how
+they report status and receive work. A cloud-routed cluster reuses that
+connection in the other direction: the CLI connects to cloud, cloud passes the
+traffic down the link the cluster already opened, and the cluster answers.
+
+```
+miren  →  Miren Cloud  →  the cluster's existing link  →  your cluster
+```
+
+Nothing new is opened on the cluster side, so there is no port to forward and no
+firewall rule to add.
+
+## Setting one up
+
+```bash
+miren cluster add --via-cloud
+```
+
+With no address to dial, the command looks your clusters up in cloud and asks
+which one you mean. You need to be logged in first (`miren login`), and the
+cluster needs to be registered with cloud and online.
+
+After that, use it like any other cluster:
+
+```bash
+miren cluster use my-cluster
+miren app list
+miren deploy
+```
+
+Deploys work over this route, including the build-context upload.
+
+## What it does not change
+
+**Your permissions are unchanged.** Cloud decides whether it will carry your
+traffic at all, based on your membership of the organization that owns the
+cluster. What you may actually *do* is decided by the cluster itself, from your
+credential, against its own RBAC policy — exactly as when you connect directly.
+Being able to reach a cluster this way does not grant you anything on it.
+
+**Cloud does not read your traffic.** The frames it relays are the Miren RPC
+protocol, which cloud passes along without interpreting. Your credential travels
+inside them and is checked by the cluster.
+
+**Audit still names you.** Calls arriving this way are attributed to you, not to
+cloud.
+
+## Limits worth knowing
+
+**A dropped link ends in-flight commands.** Sessions live on the cluster's
+connection to cloud. If that connection drops, anything in flight fails and the
+cluster reconnects on its own schedule, which can take up to a minute. A long
+deploy that spans an outage will fail and need re-running. When this happens the
+error says so — if you see `the cluster's link to the cloud dropped`, retry
+rather than going looking for a fault.
+
+**It is slower than a direct connection.** Every frame takes an extra hop, and
+the relay is not the path to choose when you have a direct one available.
+
+**One cloud, one cluster.** The route is per-cluster. Clusters you can reach
+directly should stay that way.
+
+## Configuration
+
+`miren cluster add --via-cloud` writes this for you; the fields are documented
+here because a hand-written config is sometimes easier to reason about.
+
+```yaml
+clusters:
+  my-cluster:
+    via_cloud: true
+    xid: cluster-abc123        # the cluster's ID in cloud
+    identity: cloud            # which login to authenticate with
+```
+
+The cloud used is the one your identity logged into. `cloud_url` overrides that,
+which is what makes a cluster registered with one cloud reachable through
+another:
+
+```yaml
+    cloud_url: https://api.miren.cloud
+```
+
+A cloud-routed cluster needs no `address` and no `ca_cert`: it is never dialed,
+and the certificate on the wire belongs to cloud.
+
+### Development clouds
+
+A cloud reached over plain `http://` is refused unless it is on this machine,
+because everything about the connection is your credential and an unencrypted
+hop puts all of it on the wire. To reach a development cloud by hostname, say so
+explicitly:
+
+```yaml
+    cloud_url: http://miren.host:3001
+    insecure: true
+```
+
+## Troubleshooting
+
+**`cluster not connected`** — cloud has no live link to the cluster. Check the
+[Connectivity](./connectivity.md) panel; the cluster is offline or has lost its
+uplink.
+
+**`access denied by RBAC policy`** — you reached the cluster and it refused the
+command. That is the cluster's own policy, not the relay. A permission granted a
+moment ago can take a short while to take effect.
+
+**`the cluster's link to the cloud dropped`** — the cluster disconnected while
+your command was running. Retry it.

--- a/docs/docs/miren-cloud/cloud-routed-clusters.md
+++ b/docs/docs/miren-cloud/cloud-routed-clusters.md
@@ -25,13 +25,27 @@ firewall rule to add.
 
 ## Setting one up
 
+Usually you do not have to do anything. `miren cluster add` picks this route on
+its own when it is the one that works:
+
+```bash
+miren cluster add
+```
+
+If the cluster you pick advertises no address your machine can dial, or
+advertises addresses that do not answer, the command asks cloud whether it has a
+link to that cluster. If it does, the entry is written to route through cloud
+and it tells you so. A cluster that neither you nor cloud can reach still fails,
+because that is a real problem rather than a routing choice.
+
+To skip the direct attempt entirely, ask for it:
+
 ```bash
 miren cluster add --via-cloud
 ```
 
-With no address to dial, the command looks your clusters up in cloud and asks
-which one you mean. You need to be logged in first (`miren login`), and the
-cluster needs to be registered with cloud and online.
+Either way you need to be logged in first (`miren login`), and the cluster needs
+to be registered with cloud and online.
 
 After that, use it like any other cluster:
 

--- a/docs/docs/miren-cloud/cloud-routed-clusters.md
+++ b/docs/docs/miren-cloud/cloud-routed-clusters.md
@@ -33,10 +33,16 @@ miren cluster add
 ```
 
 If the cluster you pick advertises no address your machine can dial, or
-advertises addresses that do not answer, the command asks cloud whether it has a
-link to that cluster. If it does, the entry is written to route through cloud
-and it tells you so. A cluster that neither you nor cloud can reach still fails,
-because that is a real problem rather than a routing choice.
+advertises addresses that do not answer, the command tries the cloud route
+itself: it opens a session through cloud and makes a call. If the cluster
+answers, the entry is written to route through cloud and it tells you so. A
+cluster that neither you nor cloud can reach still fails, because that is a real
+problem rather than a routing choice.
+
+It tries the route rather than asking whether one exists, because those are
+different questions. Cloud can hold a link to a cluster whose runtime is older
+than this feature, and that cluster will sit there without answering. Making the
+call is what tells the two apart.
 
 To skip the direct attempt entirely, ask for it:
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -83,6 +83,11 @@ const sidebars: SidebarsConfig = {
         'miren-cloud/connectivity',
         {
           type: 'doc',
+          id: 'miren-cloud/cloud-routed-clusters',
+          label: 'Cloud-Routed Clusters',
+        },
+        {
+          type: 'doc',
           id: 'miren-cloud/miren-anywhere',
           label: 'Miren Anywhere',
         },

--- a/pkg/cloudrpc/cloudrpc.go
+++ b/pkg/cloudrpc/cloudrpc.go
@@ -168,17 +168,13 @@ func (s *Server) handleOpen(ctx context.Context, data json.RawMessage) error {
 }
 
 func (s *Server) serve(ctx context.Context, sess *session) {
-	defer func() {
-		s.forget(sess.id)
-		sess.shutdown()
-	}()
+	defer s.teardown(sess)
 
 	err := s.state.ServeMessageConn(ctx, sess, rpc.WithMaxFrameSize(maxFrameData))
 
 	// Tell the far end, best effort: if the uplink is what failed, this goes
 	// nowhere, and the caller learns from its own broken connection instead.
-	//nolint:errcheck // best-effort teardown notice
-	s.send(ctx, TypeClose, Close{SessionID: sess.id, Reason: "session ended"})
+	s.sendBestEffort(TypeClose, Close{SessionID: sess.id, Reason: "session ended"})
 
 	s.log.Info("relayed RPC session closed", "session", sess.id, "error", err)
 }
@@ -213,8 +209,7 @@ func (s *Server) handleData(_ context.Context, data json.RawMessage) error {
 	if !sess.reserve(len(msg.Payload)) {
 		s.log.Warn("relayed RPC session is holding too much, closing it",
 			"session", msg.SessionID, "limit", maxPendingBytes)
-		s.forget(sess.id)
-		sess.shutdown()
+		s.teardown(sess)
 		return fmt.Errorf("session %s backlog too large", msg.SessionID)
 	}
 
@@ -227,8 +222,7 @@ func (s *Server) handleData(_ context.Context, data json.RawMessage) error {
 	default:
 		sess.release(len(msg.Payload))
 		s.log.Warn("relayed RPC session is not reading, closing it", "session", msg.SessionID)
-		s.forget(sess.id)
-		sess.shutdown()
+		s.teardown(sess)
 		return fmt.Errorf("session %s backlog full", msg.SessionID)
 	}
 }
@@ -245,8 +239,7 @@ func (s *Server) handleClose(_ context.Context, data json.RawMessage) error {
 	}
 
 	s.log.Debug("far end closed a relayed RPC session", "session", msg.SessionID, "reason", msg.Reason)
-	s.forget(sess.id)
-	sess.shutdown()
+	s.teardown(sess)
 
 	return nil
 }
@@ -257,10 +250,21 @@ func (s *Server) lookup(id string) *session {
 	return s.sessions[id]
 }
 
-func (s *Server) forget(id string) {
+// teardown ends a session and forgets it, in that order, everywhere.
+//
+// The two steps were open-coded at each teardown site, which left the ordering
+// looking incidental when it is not: shutting down first means a frame arriving
+// in between finds a session that is already closed rather than one that is
+// about to be. Only the session that is actually registered is removed, so a
+// late second teardown cannot evict a successor holding the same id.
+func (s *Server) teardown(sess *session) {
+	sess.shutdown()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.sessions, id)
+	if s.sessions[sess.id] == sess {
+		delete(s.sessions, sess.id)
+	}
 }
 
 // send marshals and queues an envelope, waiting for room rather than dropping.

--- a/pkg/cloudrpc/cloudrpc.go
+++ b/pkg/cloudrpc/cloudrpc.go
@@ -34,11 +34,19 @@ const (
 	// The depth is what separates an ordinary scheduling delay from that.
 	inboundDepth = 64
 
-	// maxPendingBytes bounds the memory those frames may hold.
+	// maxPendingBytes bounds the memory a session's frames may hold.
 	//
 	// The depth alone bounds nothing useful, because the far end chooses the
 	// frame size: sixty-four frames is a few kilobytes or most of a gigabyte
 	// depending on who is sending. This is the limit that holds either way.
+	//
+	// It is applied twice, to the two places a frame can wait. Here it covers
+	// frames queued for the session to take. Passed to rpc as
+	// WithMaxBufferedData, it covers frames taken but not yet read by a
+	// handler. Only the first was enforced originally, which made the limit
+	// describe a hop rather than the session: a caller sending faster than its
+	// handler read simply moved bytes from the accounted side to the
+	// unaccounted one, as fast as the reader drained.
 	maxPendingBytes = 8 << 20
 
 	// maxSessions bounds how many relayed sessions run at once.
@@ -173,7 +181,15 @@ func (s *Server) handleOpen(ctx context.Context, data json.RawMessage) error {
 func (s *Server) serve(sess *session) {
 	defer s.teardown(sess)
 
-	err := s.state.ServeMessageConn(sess.ctx, sess, rpc.WithMaxFrameSize(maxFrameData))
+	err := s.state.ServeMessageConn(sess.ctx, sess,
+		rpc.WithMaxFrameSize(maxFrameData),
+		// The same number the queue above the session enforces. The two
+		// together are what make maxPendingBytes a real bound: this side
+		// accounts for frames waiting to be taken, that side for frames taken
+		// but not yet read. Setting only one moves the memory rather than
+		// limiting it.
+		rpc.WithMaxBufferedData(maxPendingBytes),
+	)
 
 	// Tell the far end, best effort: if the uplink is what failed, this goes
 	// nowhere, and the caller learns from its own broken connection instead.

--- a/pkg/cloudrpc/cloudrpc.go
+++ b/pkg/cloudrpc/cloudrpc.go
@@ -3,7 +3,9 @@ package cloudrpc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"sync"
 
@@ -176,7 +178,16 @@ func (s *Server) serve(ctx context.Context, sess *session) {
 	// nowhere, and the caller learns from its own broken connection instead.
 	s.sendBestEffort(TypeClose, Close{SessionID: sess.id, Reason: "session ended"})
 
-	s.log.Info("relayed RPC session closed", "session", sess.id, "error", err)
+	// An ordinary ending arrives as EOF or a cancelled context: the caller hung
+	// up, or this side tore the session down. Attaching an error field to those
+	// makes every healthy session read as a fault to an operator scanning for
+	// one, so the field is kept for endings that are actually unexpected.
+	switch {
+	case err == nil, errors.Is(err, io.EOF), errors.Is(err, context.Canceled):
+		s.log.Info("relayed RPC session closed", "session", sess.id)
+	default:
+		s.log.Info("relayed RPC session closed", "session", sess.id, "error", err)
+	}
 }
 
 // handleData delivers one frame to its session.

--- a/pkg/cloudrpc/cloudrpc.go
+++ b/pkg/cloudrpc/cloudrpc.go
@@ -120,10 +120,13 @@ func New(cfg Config) *Server {
 
 // handleOpen starts serving RPC on a new session.
 //
-// The context is the uplink's connection-scoped one, so a session cannot outlive
-// the link that carries it. That is the right lifetime: a dropped uplink loses
-// the frames in flight, and there is no way to resume from that. The caller sees
-// a broken connection and retries, which is honest.
+// Each session gets a child of the uplink's connection-scoped context, so it
+// cannot outlive the link that carries it and the link is not held to the
+// session's lifetime either. That is the right pair of bounds: a dropped uplink
+// loses the frames in flight and there is no way to resume from that, so the
+// caller sees a broken connection and retries, which is honest; and a session
+// that ends takes its own work down with it rather than leaving handlers
+// running for a caller that has gone.
 func (s *Server) handleOpen(ctx context.Context, data json.RawMessage) error {
 	var req Open
 	if err := json.Unmarshal(data, &req); err != nil {
@@ -133,23 +136,19 @@ func (s *Server) handleOpen(ctx context.Context, data json.RawMessage) error {
 		return fmt.Errorf("rpc.open with no session id")
 	}
 
-	sess := &session{
-		id:      req.SessionID,
-		srv:     s,
-		ctx:     ctx,
-		inbound: make(chan []byte, inboundDepth),
-		closed:  make(chan struct{}),
-	}
+	sess := newSession(ctx, req.SessionID, s)
 
 	s.mu.Lock()
 	if _, exists := s.sessions[req.SessionID]; exists {
 		s.mu.Unlock()
+		sess.cancel()
 		// Cloud mints these ids, so a collision is a bug there rather than
 		// something to paper over. Refusing beats serving two callers one pipe.
 		return fmt.Errorf("session %s already open", req.SessionID)
 	}
 	if len(s.sessions) >= maxSessions {
 		s.mu.Unlock()
+		sess.cancel()
 		// Told rather than dropped, but never waited on: this runs on the link's
 		// read loop, so waiting for room would stall every other tenant — and
 		// the outbox being full is exactly the situation where a cap gets hit.
@@ -164,15 +163,17 @@ func (s *Server) handleOpen(ctx context.Context, data json.RawMessage) error {
 
 	s.log.Info("relayed RPC session opened", "session", req.SessionID)
 
-	go s.serve(ctx, sess)
+	go s.serve(sess)
 
 	return nil
 }
 
-func (s *Server) serve(ctx context.Context, sess *session) {
+// serve runs the session on its own context rather than the uplink's, so that
+// tearing the session down also cancels the handlers dispatched from it.
+func (s *Server) serve(sess *session) {
 	defer s.teardown(sess)
 
-	err := s.state.ServeMessageConn(ctx, sess, rpc.WithMaxFrameSize(maxFrameData))
+	err := s.state.ServeMessageConn(sess.ctx, sess, rpc.WithMaxFrameSize(maxFrameData))
 
 	// Tell the far end, best effort: if the uplink is what failed, this goes
 	// nowhere, and the caller learns from its own broken connection instead.

--- a/pkg/cloudrpc/cloudrpc.go
+++ b/pkg/cloudrpc/cloudrpc.go
@@ -49,13 +49,19 @@ const (
 	maxSessions = 128
 )
 
-// Link is the part of the control-plane link this package uses: somewhere to
-// register handlers, and a send that applies backpressure instead of dropping.
-// *uplink.Client is the implementation; naming the two methods keeps the
-// dependency honest and lets the relay be exercised without a socket.
+// Link is the part of the control-plane link this package uses.
+// *uplink.Client is the implementation; naming the methods keeps the dependency
+// honest and lets the relay be exercised without a socket.
+//
+// Both sends are here because the choice between them is not a preference. A
+// session's frames cannot be lost, so they wait for room. Anything sent from a
+// message handler cannot wait, because handlers run on the link's read loop and
+// every other tenant is queued behind them — so those go best-effort or not at
+// all.
 type Link interface {
 	Handle(msgType string, handler uplink.MessageHandler)
 	SendContext(ctx context.Context, env *uplink.Envelope) error
+	Send(env *uplink.Envelope)
 }
 
 // Config wires a Server to the link it rides and the RPC server it exposes.
@@ -142,10 +148,12 @@ func (s *Server) handleOpen(ctx context.Context, data json.RawMessage) error {
 	}
 	if len(s.sessions) >= maxSessions {
 		s.mu.Unlock()
-		// Told rather than dropped: the caller is waiting on a connection that
-		// would otherwise just never answer.
-		//nolint:errcheck // the refusal is best-effort; the caller times out either way
-		s.send(ctx, TypeClose, Close{SessionID: req.SessionID, Reason: "too many open sessions"})
+		// Told rather than dropped, but never waited on: this runs on the link's
+		// read loop, so waiting for room would stall every other tenant — and
+		// the outbox being full is exactly the situation where a cap gets hit.
+		// If the refusal is lost the caller times out instead, which is the
+		// same outcome one step slower.
+		s.sendBestEffort(TypeClose, Close{SessionID: req.SessionID, Reason: "too many open sessions"})
 		s.log.Warn("refused a relayed RPC session, too many open", "session", req.SessionID, "open", maxSessions)
 		return fmt.Errorf("too many relayed sessions open")
 	}
@@ -183,6 +191,11 @@ func (s *Server) serve(ctx context.Context, sess *session) {
 // caller. Dropping the frame instead would be worse than useless — RPC cannot
 // resynchronise after a hole — so the session is torn down and the caller finds
 // out.
+//
+// The context is unused because of that, not by oversight: every operation here
+// is non-blocking, so there is nothing for a cancellation to cut short. Any
+// change that introduces a wait here has to take the context — and should think
+// again first, because the wait is on the shared loop.
 func (s *Server) handleData(_ context.Context, data json.RawMessage) error {
 	var msg Data
 	if err := json.Unmarshal(data, &msg); err != nil {
@@ -253,10 +266,24 @@ func (s *Server) forget(id string) {
 // send marshals and queues an envelope, waiting for room rather than dropping.
 // A relayed session has no way to recover from a lost frame, so the uplink's
 // best-effort path is not an option here.
+//
+// It blocks, so it must not be called from a message handler — see Link.
 func (s *Server) send(ctx context.Context, msgType string, payload any) error {
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal %s: %w", msgType, err)
 	}
 	return s.uplink.SendContext(ctx, &uplink.Envelope{Type: msgType, Data: raw})
+}
+
+// sendBestEffort queues an envelope if there is room and gives up if there is
+// not, for a notice sent from a message handler. Nothing downstream depends on
+// it arriving; what matters is that it never makes the read loop wait.
+func (s *Server) sendBestEffort(msgType string, payload any) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		s.log.Error("failed to marshal a relay notice", "type", msgType, "error", err)
+		return
+	}
+	s.uplink.Send(&uplink.Envelope{Type: msgType, Data: raw})
 }

--- a/pkg/cloudrpc/cloudrpc.go
+++ b/pkg/cloudrpc/cloudrpc.go
@@ -179,14 +179,19 @@ func (s *Server) serve(ctx context.Context, sess *session) {
 	s.sendBestEffort(TypeClose, Close{SessionID: sess.id, Reason: "session ended"})
 
 	// An ordinary ending arrives as EOF or a cancelled context: the caller hung
-	// up, or this side tore the session down. Attaching an error field to those
-	// makes every healthy session read as a fault to an operator scanning for
-	// one, so the field is kept for endings that are actually unexpected.
+	// up, or this side tore the session down. Those are the healthy lifecycle of
+	// a session and belong at Info without an error field, which would otherwise
+	// make every one of them read as a fault to an operator scanning for one.
+	//
+	// Anything else is unexpected and goes to Warn rather than Error. A session
+	// dying on a transport error is usually the far end's network rather than
+	// this cluster failing at something it is responsible for, which is the line
+	// CLAUDE.md draws between the two.
 	switch {
 	case err == nil, errors.Is(err, io.EOF), errors.Is(err, context.Canceled):
 		s.log.Info("relayed RPC session closed", "session", sess.id)
 	default:
-		s.log.Info("relayed RPC session closed", "session", sess.id, "error", err)
+		s.log.Warn("relayed RPC session closed", "session", sess.id, "error", err)
 	}
 }
 

--- a/pkg/cloudrpc/cloudrpc.go
+++ b/pkg/cloudrpc/cloudrpc.go
@@ -1,0 +1,227 @@
+package cloudrpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/uplink"
+)
+
+const (
+	// maxFrameData bounds the RPC payload we put in one uplink envelope.
+	//
+	// It is well under what the link would accept, on purpose. The uplink is
+	// shared: a single envelope is written whole, so an oversized one delays
+	// every other tenant behind it. Splitting into smaller frames costs
+	// throughput and nothing else, which is a good trade for a link that also
+	// carries the cluster's coordination traffic.
+	//
+	// It bounds only our own writes. What the far end sends is framed by the
+	// far end, so the link's read limit — not this — is what has to tolerate a
+	// peer using pkg/rpc's larger default.
+	maxFrameData = 256 << 10
+
+	// inboundDepth is how many frames may await a session's reader.
+	//
+	// It is a backlog, not a buffer: the layer above drains its side promptly,
+	// so frames only pile up here when a session has genuinely stopped reading.
+	// The depth is what separates an ordinary scheduling delay from that.
+	inboundDepth = 64
+)
+
+// Link is the part of the control-plane link this package uses: somewhere to
+// register handlers, and a send that applies backpressure instead of dropping.
+// *uplink.Client is the implementation; naming the two methods keeps the
+// dependency honest and lets the relay be exercised without a socket.
+type Link interface {
+	Handle(msgType string, handler uplink.MessageHandler)
+	SendContext(ctx context.Context, env *uplink.Envelope) error
+}
+
+// Config wires a Server to the link it rides and the RPC server it exposes.
+type Config struct {
+	// Uplink is the control-plane link. The Server registers handlers on it but
+	// does not own its lifecycle; whoever created the link runs it.
+	Uplink Link
+
+	// State is the RPC state whose exposed objects relayed callers reach. It is
+	// the same one the cluster serves directly, deliberately: a call arriving
+	// this way must reach the same objects, under the same authorization, as one
+	// that arrived over the network.
+	State *rpc.State
+
+	Log *slog.Logger
+}
+
+// Server serves relayed RPC sessions arriving over the uplink.
+type Server struct {
+	uplink Link
+	state  *rpc.State
+	log    *slog.Logger
+
+	mu       sync.Mutex
+	sessions map[string]*session
+}
+
+// New creates a Server and registers its handlers on the uplink. The caller is
+// responsible for running the uplink itself.
+func New(cfg Config) *Server {
+	log := cfg.Log
+	if log == nil {
+		log = slog.Default()
+	}
+
+	s := &Server{
+		uplink:   cfg.Uplink,
+		state:    cfg.State,
+		log:      log,
+		sessions: make(map[string]*session),
+	}
+
+	cfg.Uplink.Handle(TypeOpen, s.handleOpen)
+	cfg.Uplink.Handle(TypeData, s.handleData)
+	cfg.Uplink.Handle(TypeClose, s.handleClose)
+
+	// Startup confirmation. Like Miren Anywhere, this is otherwise silent until
+	// a caller shows up, which may be never — leaving an operator unable to tell
+	// a wired relay from one that failed to come up.
+	log.Info("cloud RPC relay ready")
+
+	return s
+}
+
+// handleOpen starts serving RPC on a new session.
+//
+// The context is the uplink's connection-scoped one, so a session cannot outlive
+// the link that carries it. That is the right lifetime: a dropped uplink loses
+// the frames in flight, and there is no way to resume from that. The caller sees
+// a broken connection and retries, which is honest.
+func (s *Server) handleOpen(ctx context.Context, data json.RawMessage) error {
+	var req Open
+	if err := json.Unmarshal(data, &req); err != nil {
+		return err
+	}
+	if req.SessionID == "" {
+		return fmt.Errorf("rpc.open with no session id")
+	}
+
+	sess := &session{
+		id:      req.SessionID,
+		srv:     s,
+		ctx:     ctx,
+		inbound: make(chan []byte, inboundDepth),
+		closed:  make(chan struct{}),
+	}
+
+	s.mu.Lock()
+	if _, exists := s.sessions[req.SessionID]; exists {
+		s.mu.Unlock()
+		// Cloud mints these ids, so a collision is a bug there rather than
+		// something to paper over. Refusing beats serving two callers one pipe.
+		return fmt.Errorf("session %s already open", req.SessionID)
+	}
+	s.sessions[req.SessionID] = sess
+	s.mu.Unlock()
+
+	s.log.Info("relayed RPC session opened", "session", req.SessionID)
+
+	go s.serve(ctx, sess)
+
+	return nil
+}
+
+func (s *Server) serve(ctx context.Context, sess *session) {
+	defer func() {
+		s.forget(sess.id)
+		sess.shutdown()
+	}()
+
+	err := s.state.ServeMessageConn(ctx, sess, rpc.WithMaxFrameSize(maxFrameData))
+
+	// Tell the far end, best effort: if the uplink is what failed, this goes
+	// nowhere, and the caller learns from its own broken connection instead.
+	//nolint:errcheck // best-effort teardown notice
+	s.send(ctx, TypeClose, Close{SessionID: sess.id, Reason: "session ended"})
+
+	s.log.Info("relayed RPC session closed", "session", sess.id, "error", err)
+}
+
+// handleData delivers one frame to its session.
+//
+// Handlers run on the uplink's read loop, which every tenant shares, so this
+// must not block. A session whose backlog is full has stopped reading, and
+// waiting for it would stall app reporting and POP handshakes behind a stuck
+// caller. Dropping the frame instead would be worse than useless — RPC cannot
+// resynchronise after a hole — so the session is torn down and the caller finds
+// out.
+func (s *Server) handleData(_ context.Context, data json.RawMessage) error {
+	var msg Data
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return err
+	}
+
+	sess := s.lookup(msg.SessionID)
+	if sess == nil {
+		// Ordinary at the tail of a teardown: the far end had frames in flight
+		// when we closed. Nothing to do about them, and nothing alarming.
+		s.log.Debug("frame for unknown relayed RPC session", "session", msg.SessionID)
+		return nil
+	}
+
+	select {
+	case sess.inbound <- msg.Payload:
+		return nil
+	case <-sess.closed:
+		return nil
+	default:
+		s.log.Warn("relayed RPC session is not reading, closing it", "session", msg.SessionID)
+		s.forget(sess.id)
+		sess.shutdown()
+		return fmt.Errorf("session %s backlog full", msg.SessionID)
+	}
+}
+
+func (s *Server) handleClose(_ context.Context, data json.RawMessage) error {
+	var msg Close
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return err
+	}
+
+	sess := s.lookup(msg.SessionID)
+	if sess == nil {
+		return nil
+	}
+
+	s.log.Debug("far end closed a relayed RPC session", "session", msg.SessionID, "reason", msg.Reason)
+	s.forget(sess.id)
+	sess.shutdown()
+
+	return nil
+}
+
+func (s *Server) lookup(id string) *session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sessions[id]
+}
+
+func (s *Server) forget(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, id)
+}
+
+// send marshals and queues an envelope, waiting for room rather than dropping.
+// A relayed session has no way to recover from a lost frame, so the uplink's
+// best-effort path is not an option here.
+func (s *Server) send(ctx context.Context, msgType string, payload any) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", msgType, err)
+	}
+	return s.uplink.SendContext(ctx, &uplink.Envelope{Type: msgType, Data: raw})
+}

--- a/pkg/cloudrpc/cloudrpc.go
+++ b/pkg/cloudrpc/cloudrpc.go
@@ -31,6 +31,22 @@ const (
 	// so frames only pile up here when a session has genuinely stopped reading.
 	// The depth is what separates an ordinary scheduling delay from that.
 	inboundDepth = 64
+
+	// maxPendingBytes bounds the memory those frames may hold.
+	//
+	// The depth alone bounds nothing useful, because the far end chooses the
+	// frame size: sixty-four frames is a few kilobytes or most of a gigabyte
+	// depending on who is sending. This is the limit that holds either way.
+	maxPendingBytes = 8 << 20
+
+	// maxSessions bounds how many relayed sessions run at once.
+	//
+	// One session is one command in flight, so this is generous for an
+	// operator and still a ceiling on what a misbehaving cloud can make this
+	// cluster allocate. Cloud is authenticated, which makes this a guard
+	// against a bug there rather than against an anonymous flood — but a
+	// cluster with no limit of its own has no answer to either.
+	maxSessions = 128
 )
 
 // Link is the part of the control-plane link this package uses: somewhere to
@@ -124,6 +140,15 @@ func (s *Server) handleOpen(ctx context.Context, data json.RawMessage) error {
 		// something to paper over. Refusing beats serving two callers one pipe.
 		return fmt.Errorf("session %s already open", req.SessionID)
 	}
+	if len(s.sessions) >= maxSessions {
+		s.mu.Unlock()
+		// Told rather than dropped: the caller is waiting on a connection that
+		// would otherwise just never answer.
+		//nolint:errcheck // the refusal is best-effort; the caller times out either way
+		s.send(ctx, TypeClose, Close{SessionID: req.SessionID, Reason: "too many open sessions"})
+		s.log.Warn("refused a relayed RPC session, too many open", "session", req.SessionID, "open", maxSessions)
+		return fmt.Errorf("too many relayed sessions open")
+	}
 	s.sessions[req.SessionID] = sess
 	s.mu.Unlock()
 
@@ -172,12 +197,22 @@ func (s *Server) handleData(_ context.Context, data json.RawMessage) error {
 		return nil
 	}
 
+	if !sess.reserve(len(msg.Payload)) {
+		s.log.Warn("relayed RPC session is holding too much, closing it",
+			"session", msg.SessionID, "limit", maxPendingBytes)
+		s.forget(sess.id)
+		sess.shutdown()
+		return fmt.Errorf("session %s backlog too large", msg.SessionID)
+	}
+
 	select {
 	case sess.inbound <- msg.Payload:
 		return nil
 	case <-sess.closed:
+		sess.release(len(msg.Payload))
 		return nil
 	default:
+		sess.release(len(msg.Payload))
 		s.log.Warn("relayed RPC session is not reading, closing it", "session", msg.SessionID)
 		s.forget(sess.id)
 		sess.shutdown()

--- a/pkg/cloudrpc/cloudrpc_test.go
+++ b/pkg/cloudrpc/cloudrpc_test.go
@@ -1,0 +1,371 @@
+package cloudrpc_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/cloudrpc"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/example"
+	"miren.dev/runtime/pkg/uplink"
+)
+
+// fakeLink stands in for the uplink: it collects the handlers the relay
+// registers and captures what the relay sends, so a test can play the part of
+// cloud without a socket.
+type fakeLink struct {
+	mu       sync.Mutex
+	handlers map[string]uplink.MessageHandler
+
+	out chan *uplink.Envelope
+
+	// stalled makes SendContext block, standing in for a congested link.
+	stalled bool
+}
+
+func newFakeLink() *fakeLink {
+	return &fakeLink{
+		handlers: make(map[string]uplink.MessageHandler),
+		out:      make(chan *uplink.Envelope, 256),
+	}
+}
+
+func (l *fakeLink) Handle(msgType string, h uplink.MessageHandler) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.handlers[msgType] = h
+}
+
+func (l *fakeLink) SendContext(ctx context.Context, env *uplink.Envelope) error {
+	l.mu.Lock()
+	stalled := l.stalled
+	l.mu.Unlock()
+
+	if stalled {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	select {
+	case l.out <- env:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (l *fakeLink) stall() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.stalled = true
+}
+
+// deliver plays a message from cloud down to the cluster, the way the uplink's
+// read loop would.
+func (l *fakeLink) deliver(ctx context.Context, msgType string, payload any) error {
+	l.mu.Lock()
+	h := l.handlers[msgType]
+	l.mu.Unlock()
+
+	if h == nil {
+		return errors.New("no handler for " + msgType)
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return h(ctx, raw)
+}
+
+// relayConn is the caller's end of a relayed session: the miniature of what
+// cloud does, wrapping outbound frames into rpc.data and unwrapping inbound
+// ones. It reads every envelope the cluster sends, so a test using it must be
+// the only reader of the link.
+type relayConn struct {
+	link      *fakeLink
+	sessionID string
+	ctx       context.Context
+}
+
+func (c *relayConn) Send(b []byte) error {
+	return c.link.deliver(c.ctx, cloudrpc.TypeData,
+		cloudrpc.Data{SessionID: c.sessionID, Payload: b})
+}
+
+func (c *relayConn) Recv() ([]byte, error) {
+	for {
+		select {
+		case env := <-c.link.out:
+			switch env.Type {
+			case cloudrpc.TypeData:
+				var msg cloudrpc.Data
+				if err := json.Unmarshal(env.Data, &msg); err != nil {
+					return nil, err
+				}
+				if msg.SessionID != c.sessionID {
+					continue
+				}
+				return msg.Payload, nil
+			case cloudrpc.TypeClose:
+				var msg cloudrpc.Close
+				if err := json.Unmarshal(env.Data, &msg); err != nil {
+					return nil, err
+				}
+				if msg.SessionID != c.sessionID {
+					continue
+				}
+				return nil, io.EOF
+			default:
+				continue
+			}
+		case <-c.ctx.Done():
+			return nil, io.EOF
+		}
+	}
+}
+
+func (c *relayConn) Close() error { return nil }
+
+// clusterWithRelay stands up an RPC server exposing iface, fronted by a relay on
+// a fake link, and returns the link.
+func clusterWithRelay(t *testing.T, ctx context.Context, name string, iface *rpc.Interface) *fakeLink {
+	t.Helper()
+	r := require.New(t)
+
+	ss, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+	ss.Server().ExposeValue(name, iface)
+
+	link := newFakeLink()
+	cloudrpc.New(cloudrpc.Config{Uplink: link, State: ss, Log: slog.Default()})
+
+	return link
+}
+
+// The whole point: a call placed through the relay reaches the same objects the
+// cluster serves directly, and its results come back.
+func TestRelayedCallsReachTheServer(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	r.NoError(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "s1"}))
+
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+
+	conn := &relayConn{link: link, sessionID: "s1", ctx: ctx}
+	c, err := cs.ClientFromMessageConn(ctx, conn, "meter")
+	r.NoError(err)
+
+	mc := &example.MeterClient{Client: c}
+
+	res, err := mc.ReadTemperature(ctx, "test")
+	r.NoError(err)
+	r.Equal("test", res.Reading().Meter())
+	r.Equal(float32(42), res.Reading().Temperature())
+
+	// A capability handed back by the first call is followed over the same
+	// session, so the relay carries more than one round trip.
+	set, err := mc.GetSetter(ctx, "test")
+	r.NoError(err)
+
+	got, err := set.Setter().SetTemp(ctx, 100)
+	r.NoError(err)
+	r.Equal(int32(100), got.Temp())
+}
+
+// Frames larger than one uplink message are split by the layer above and
+// reassembled on arrival. Nothing here has to know that, which is the property
+// worth pinning: the relay carries payloads far past its own frame cap.
+func TestRelayedCallsCarryLargePayloads(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(&testMeter{temp: 7}))
+
+	r.NoError(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "s1"}))
+
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+
+	conn := &relayConn{link: link, sessionID: "s1", ctx: ctx}
+	c, err := cs.ClientFromMessageConn(ctx, conn, "meter")
+	r.NoError(err)
+
+	// Comfortably past the 256 KiB the relay puts in one envelope.
+	name := make([]byte, 700*1024)
+	for i := range name {
+		name[i] = 'a'
+	}
+
+	res, err := (&example.MeterClient{Client: c}).ReadTemperature(ctx, string(name))
+	r.NoError(err)
+	r.Equal(string(name), res.Reading().Meter())
+}
+
+// Cloud mints session ids, so a repeat is a bug there. Serving two callers one
+// pipe would interleave their frames into nonsense, so the second is refused.
+func TestDuplicateSessionRefused(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	r.NoError(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "s1"}))
+	r.Error(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "s1"}))
+}
+
+// An open with no session id names nothing and cannot be answered.
+func TestOpenWithoutSessionIDRefused(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	r.Error(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{}))
+}
+
+// Frames for a session that has already gone are ordinary at the tail of a
+// teardown — the far end had some in flight. They must not be an error, because
+// the uplink logs a warning for every handler that returns one.
+func TestFramesForUnknownSessionAreIgnored(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	r.NoError(link.deliver(ctx, cloudrpc.TypeData,
+		cloudrpc.Data{SessionID: "gone", Payload: []byte("x")}))
+	r.NoError(link.deliver(ctx, cloudrpc.TypeClose, cloudrpc.Close{SessionID: "gone"}))
+}
+
+// Handlers run on the uplink's shared read loop, so a session that has stopped
+// reading must not be allowed to stall it. The session is closed instead, and —
+// this is the part that matters — the link keeps serving everyone else.
+func TestStuckSessionIsClosedRatherThanStallingTheLink(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	r.NoError(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "stuck"}))
+
+	// Nothing reads this session, so its backlog fills. Deliver well past the
+	// depth; the relay must give up rather than wait.
+	var err error
+	for range 4096 {
+		err = link.deliver(ctx, cloudrpc.TypeData,
+			cloudrpc.Data{SessionID: "stuck", Payload: []byte("frame")})
+		if err != nil {
+			break
+		}
+	}
+	r.Error(err, "relay accepted an unbounded backlog for a session nothing is reading")
+
+	// The link is still usable: a fresh session opens and serves.
+	r.NoError(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "healthy"}))
+
+	cs, cerr := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(cerr)
+
+	conn := &relayConn{link: link, sessionID: "healthy", ctx: ctx}
+	c, cerr := cs.ClientFromMessageConn(ctx, conn, "meter")
+	r.NoError(cerr)
+
+	res, cerr := (&example.MeterClient{Client: c}).ReadTemperature(ctx, "test")
+	r.NoError(cerr)
+	r.Equal(float32(42), res.Reading().Temperature())
+}
+
+// A session must not outlive the connection carrying it. There is no resuming a
+// relayed session across a reconnect — the frames in flight are gone — so the
+// honest outcome is that the caller's connection breaks and it retries.
+func TestSessionEndsWithTheConnection(t *testing.T) {
+	r := require.New(t)
+
+	connCtx, dropConn := context.WithCancel(t.Context())
+	defer dropConn()
+
+	link := clusterWithRelay(t, t.Context(), "meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	r.NoError(link.deliver(connCtx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "s1"}))
+
+	cs, err := rpc.NewState(t.Context(), rpc.WithSkipVerify)
+	r.NoError(err)
+
+	conn := &relayConn{link: link, sessionID: "s1", ctx: t.Context()}
+	c, err := cs.ClientFromMessageConn(t.Context(), conn, "meter")
+	r.NoError(err)
+
+	mc := &example.MeterClient{Client: c}
+	_, err = mc.ReadTemperature(t.Context(), "test")
+	r.NoError(err)
+
+	dropConn()
+
+	// The relay tells the caller the session is over. Poll rather than sleep a
+	// fixed span, so this is not a race on a slow machine.
+	deadline := time.After(3 * time.Second)
+	for {
+		_, err = mc.ReadTemperature(t.Context(), "test")
+		if err != nil {
+			return
+		}
+		select {
+		case <-deadline:
+			r.Fail("session outlived the connection that carried it")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+// A congested link must slow the writer, not silently lose a frame. RPC cannot
+// resynchronise after a hole, so Send has to block until the frame is queued.
+func TestSendWaitsOnACongestedLink(t *testing.T) {
+	r := require.New(t)
+
+	connCtx, dropConn := context.WithCancel(t.Context())
+	defer dropConn()
+
+	link := clusterWithRelay(t, t.Context(), "meter", example.AdaptMeter(&testMeter{temp: 42}))
+	link.stall()
+
+	r.NoError(link.deliver(connCtx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "s1"}))
+
+	cs, err := rpc.NewState(t.Context(), rpc.WithSkipVerify)
+	r.NoError(err)
+
+	// The caller's end is scoped to the connection too, mirroring cloud closing
+	// the caller's socket when the link under it goes away.
+	done := make(chan error, 1)
+	go func() {
+		conn := &relayConn{link: link, sessionID: "s1", ctx: connCtx}
+		_, cerr := cs.ClientFromMessageConn(t.Context(), conn, "meter")
+		done <- cerr
+	}()
+
+	select {
+	case <-done:
+		r.Fail("a send on a congested link returned instead of waiting")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Dropping the connection is what unblocks it, and the caller learns.
+	dropConn()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		r.Fail("a blocked send did not give up when the connection went away")
+	}
+}

--- a/pkg/cloudrpc/cloudrpc_test.go
+++ b/pkg/cloudrpc/cloudrpc_test.go
@@ -62,6 +62,15 @@ func (l *fakeLink) SendContext(ctx context.Context, env *uplink.Envelope) error 
 	}
 }
 
+// Send is the best-effort half: it drops rather than waiting, and — the part
+// that matters for a stalled link — it never blocks at all.
+func (l *fakeLink) Send(env *uplink.Envelope) {
+	select {
+	case l.out <- env:
+	default:
+	}
+}
+
 func (l *fakeLink) stall() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -317,6 +326,40 @@ func TestSessionsAreCapped(t *testing.T) {
 		}
 	}
 	r.True(sawClose, "a refused session was never told")
+}
+
+// Refusing a session must not wait on the link.
+//
+// Handlers run on the link's read loop, so anything that waits there stops
+// every other tenant — and a congested outbox is exactly the condition under
+// which a cap gets hit, so the two arrive together or not at all.
+func TestRefusingASessionDoesNotWaitOnTheLink(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	for i := range 1024 {
+		if err := link.deliver(ctx, cloudrpc.TypeOpen,
+			cloudrpc.Open{SessionID: fmt.Sprintf("s%d", i)}); err != nil {
+			break
+		}
+	}
+
+	// Nothing can reach the far end now, in either direction.
+	link.stall()
+
+	refused := make(chan error, 1)
+	go func() {
+		refused <- link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "one-more"})
+	}()
+
+	select {
+	case err := <-refused:
+		r.Error(err, "the session past the cap should have been refused")
+	case <-time.After(2 * time.Second):
+		r.Fail("refusing a session blocked the link's read loop")
+	}
 }
 
 // A session must not outlive the connection carrying it. There is no resuming a

--- a/pkg/cloudrpc/cloudrpc_test.go
+++ b/pkg/cloudrpc/cloudrpc_test.go
@@ -423,6 +423,89 @@ func TestSessionEndsWithTheConnection(t *testing.T) {
 	}
 }
 
+// Introspection has to answer the same over the relay as it does over a direct
+// dial, because clients use it to decide what the far end supports.
+//
+// The message transport used to report method names alone. A missing Params map
+// does not read as "these methods take no parameters" — it reads as "this
+// server is too old to say," which is what a pre-introspection cluster looks
+// like. So a current cluster reached through cloud was mistaken for an old one,
+// and callers quietly dropped to older behaviour: `miren logs --until` refused
+// it, and deploy fell back to the deprecated client-owned deployment path.
+func TestRelayedIntrospectionReportsMethodParameters(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	r.NoError(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "s1"}))
+
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+
+	conn := &relayConn{link: link, sessionID: "s1", ctx: ctx}
+	c, err := cs.ClientFromMessageConn(ctx, conn, "meter")
+	r.NoError(err)
+
+	r.True(c.HasMethod(ctx, "readTemperature"),
+		"the relayed client cannot see a method the cluster exposes")
+	r.True(c.HasMethodParam(ctx, "readTemperature", "name"),
+		"the relayed client sees the method but not its parameters, "+
+			"which reads to a caller as a cluster too old to ask")
+	r.False(c.HasMethodParam(ctx, "readTemperature", "nonesuch"),
+		"a parameter the method does not take must still report false")
+}
+
+// Ending a session must end the work dispatched from it.
+//
+// Handlers used to run on the uplink's context, which outlives any one session,
+// so a build or a log stream kept going after its caller was gone. It did so
+// uncounted, too: teardown removes the session from the map first, so the work
+// no longer counted against maxSessions and repeated open-and-disconnect was a
+// way around that ceiling.
+func TestTeardownCancelsDispatchedHandlers(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	meter := &blockingMeter{
+		entered:  make(chan struct{}),
+		released: make(chan error, 1),
+	}
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(meter))
+
+	r.NoError(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "s1"}))
+
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+
+	conn := &relayConn{link: link, sessionID: "s1", ctx: ctx}
+	c, err := cs.ClientFromMessageConn(ctx, conn, "meter")
+	r.NoError(err)
+
+	mc := &example.MeterClient{Client: c}
+
+	// The caller's own context stays live throughout, so nothing here can end
+	// the handler except the session teardown under test.
+	go func() { _, _ = mc.ReadTemperature(ctx, "test") }()
+
+	select {
+	case <-meter.entered:
+	case <-time.After(3 * time.Second):
+		r.Fail("the handler never ran, so there is nothing to observe")
+	}
+
+	// Cloud ends the session while the handler is parked inside it.
+	r.NoError(link.deliver(ctx, cloudrpc.TypeClose,
+		cloudrpc.Close{SessionID: "s1", Reason: "caller went away"}))
+
+	select {
+	case err := <-meter.released:
+		r.ErrorIs(err, context.Canceled)
+	case <-time.After(3 * time.Second):
+		r.Fail("the handler outlived the session it was dispatched from")
+	}
+}
+
 // A congested link must slow the writer, not silently lose a frame. RPC cannot
 // resynchronise after a hole, so Send has to block until the frame is queued.
 func TestSendWaitsOnACongestedLink(t *testing.T) {

--- a/pkg/cloudrpc/cloudrpc_test.go
+++ b/pkg/cloudrpc/cloudrpc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -249,10 +250,14 @@ func TestFramesForUnknownSessionAreIgnored(t *testing.T) {
 	r.NoError(link.deliver(ctx, cloudrpc.TypeClose, cloudrpc.Close{SessionID: "gone"}))
 }
 
-// Handlers run on the uplink's shared read loop, so a session that has stopped
-// reading must not be allowed to stall it. The session is closed instead, and —
-// this is the part that matters — the link keeps serving everyone else.
-func TestStuckSessionIsClosedRatherThanStallingTheLink(t *testing.T) {
+// Handlers run on the uplink's shared read loop, so a session drowning in
+// frames must not stall it. What that costs the session is covered next to the
+// accounting it uses; what matters here is that everyone else keeps going.
+//
+// Nothing asserts how the flood ends, deliberately. Whether the backlog fills
+// before the session's reader gives up on the garbage being sent is a race, and
+// pinning either outcome would make this a test of scheduling.
+func TestAFloodedSessionDoesNotStallTheLink(t *testing.T) {
 	r := require.New(t)
 	ctx := t.Context()
 
@@ -260,17 +265,12 @@ func TestStuckSessionIsClosedRatherThanStallingTheLink(t *testing.T) {
 
 	r.NoError(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "stuck"}))
 
-	// Nothing reads this session, so its backlog fills. Deliver well past the
-	// depth; the relay must give up rather than wait.
-	var err error
 	for range 4096 {
-		err = link.deliver(ctx, cloudrpc.TypeData,
-			cloudrpc.Data{SessionID: "stuck", Payload: []byte("frame")})
-		if err != nil {
+		if err := link.deliver(ctx, cloudrpc.TypeData,
+			cloudrpc.Data{SessionID: "stuck", Payload: []byte("frame")}); err != nil {
 			break
 		}
 	}
-	r.Error(err, "relay accepted an unbounded backlog for a session nothing is reading")
 
 	// The link is still usable: a fresh session opens and serves.
 	r.NoError(link.deliver(ctx, cloudrpc.TypeOpen, cloudrpc.Open{SessionID: "healthy"}))
@@ -285,6 +285,38 @@ func TestStuckSessionIsClosedRatherThanStallingTheLink(t *testing.T) {
 	res, cerr := (&example.MeterClient{Client: c}).ReadTemperature(ctx, "test")
 	r.NoError(cerr)
 	r.Equal(float32(42), res.Reading().Temperature())
+}
+
+// One session's memory is bounded, so the other half of the sum has to be too.
+func TestSessionsAreCapped(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	link := clusterWithRelay(t, ctx, "meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	var err error
+	opened := 0
+	for i := range 1024 {
+		err = link.deliver(ctx, cloudrpc.TypeOpen,
+			cloudrpc.Open{SessionID: fmt.Sprintf("s%d", i)})
+		if err != nil {
+			break
+		}
+		opened++
+	}
+
+	r.Error(err, "the relay opened %d sessions without a ceiling", opened)
+	r.Positive(opened, "the cap should leave room for real callers")
+
+	// The refusal is told, not dropped: a caller waiting on a connection that
+	// silently never answers has nothing to act on.
+	var sawClose bool
+	for len(link.out) > 0 {
+		if env := <-link.out; env.Type == cloudrpc.TypeClose {
+			sawClose = true
+		}
+	}
+	r.True(sawClose, "a refused session was never told")
 }
 
 // A session must not outlive the connection carrying it. There is no resuming a
@@ -313,14 +345,20 @@ func TestSessionEndsWithTheConnection(t *testing.T) {
 
 	dropConn()
 
-	// The relay tells the caller the session is over. Poll rather than sleep a
-	// fixed span, so this is not a race on a slow machine.
+	// The session stops serving. Each attempt is bounded rather than left to
+	// run: the close notice travels on the link that just died, so whether the
+	// caller is told or simply left waiting is not something this end decides —
+	// what it owes is to stop answering.
 	deadline := time.After(3 * time.Second)
 	for {
-		_, err = mc.ReadTemperature(t.Context(), "test")
+		callCtx, cancelCall := context.WithTimeout(t.Context(), 200*time.Millisecond)
+		_, err = mc.ReadTemperature(callCtx, "test")
+		cancelCall()
+
 		if err != nil {
 			return
 		}
+
 		select {
 		case <-deadline:
 			r.Fail("session outlived the connection that carried it")

--- a/pkg/cloudrpc/cloudrpc_test.go
+++ b/pkg/cloudrpc/cloudrpc_test.go
@@ -34,7 +34,10 @@ type fakeLink struct {
 func newFakeLink() *fakeLink {
 	return &fakeLink{
 		handlers: make(map[string]uplink.MessageHandler),
-		out:      make(chan *uplink.Envelope, 256),
+		// Deep enough that no test fills it by accident: a full link changes
+		// what the relay does (best-effort sends start dropping), so a test
+		// that overflows it is measuring the fake rather than the code.
+		out: make(chan *uplink.Envelope, 4096),
 	}
 }
 
@@ -319,11 +322,21 @@ func TestSessionsAreCapped(t *testing.T) {
 
 	// The refusal is told, not dropped: a caller waiting on a connection that
 	// silently never answers has nothing to act on.
+	//
+	// Drained rather than sampled, because the refusal is best-effort and would
+	// genuinely be dropped if the link filled — which would make this assertion
+	// a statement about the fake's buffer rather than about the relay.
 	var sawClose bool
-	for len(link.out) > 0 {
-		if env := <-link.out; env.Type == cloudrpc.TypeClose {
-			sawClose = true
+	for {
+		select {
+		case env := <-link.out:
+			if env.Type == cloudrpc.TypeClose {
+				sawClose = true
+			}
+			continue
+		case <-time.After(200 * time.Millisecond):
 		}
+		break
 	}
 	r.True(sawClose, "a refused session was never told")
 }

--- a/pkg/cloudrpc/envelope.go
+++ b/pkg/cloudrpc/envelope.go
@@ -1,0 +1,54 @@
+// Package cloudrpc lets a caller reach this cluster's RPC server through Miren
+// Cloud, over the same uplink the cluster already holds open.
+//
+// It exists because the direct path assumes something that often is not true:
+// that whoever wants to run `miren app list` can open a connection to the
+// cluster. A cluster behind NAT can accept nothing, yet it is already talking to
+// cloud. This turns that outbound link into a way in.
+//
+// The cluster is a tenant of pkg/uplink here, in the same way Miren Anywhere is:
+// it registers handlers and owns none of the link's lifecycle. What rides on top
+// is pkg/rpc's message transport, which runs the whole RPC protocol over any
+// pipe of discrete byte messages — see pkg/rpc/PROTOCOL.md. The uplink is such a
+// pipe once its envelopes are unwrapped, so the frames go through untouched and
+// cloud never parses one.
+//
+// Authentication is unchanged by the detour, which is the point. Each operation
+// still carries the caller's own bearer token, and this cluster's authenticator
+// and RBAC judge it exactly as they would on a direct connection. Cloud
+// authorizes the connection it is relaying and vouches for nothing beyond that.
+package cloudrpc
+
+// Control messages for a relayed RPC session, namespaced as their own family so
+// the uplink stays a shared pipe. Cloud opens a session; either side may send
+// data or close it.
+const (
+	TypeOpen  = "rpc.open"
+	TypeData  = "rpc.data"
+	TypeClose = "rpc.close"
+)
+
+// Open asks the cluster to start serving RPC on a new session. Cloud mints the
+// id, because cloud is the only party that knows how many callers it is relaying
+// for.
+type Open struct {
+	SessionID string `json:"session_id"`
+}
+
+// Data carries one message of the session's byte pipe.
+//
+// Payload is []byte rather than a string so encoding/json base64s it: the
+// uplink's envelopes are JSON, and these frames are CBOR. The cost is the usual
+// third again in size, which is why the session caps its frames well under the
+// uplink's read limit.
+type Data struct {
+	SessionID string `json:"session_id"`
+	Payload   []byte `json:"payload"`
+}
+
+// Close ends a session. Reason is for the log on the other side; nothing
+// branches on it.
+type Close struct {
+	SessionID string `json:"session_id"`
+	Reason    string `json:"reason,omitempty"`
+}

--- a/pkg/cloudrpc/meter_test.go
+++ b/pkg/cloudrpc/meter_test.go
@@ -2,6 +2,7 @@ package cloudrpc_test
 
 import (
 	"context"
+	"errors"
 
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/example"
@@ -41,4 +42,34 @@ func (m *testMeter) SetTemp(ctx context.Context, call *example.SetTempSetTemp) e
 	m.temp = float32(args.Temp())
 	call.Results().SetTemp(args.Temp())
 	return nil
+}
+
+// blockingMeter parks in ReadTemperature until its context ends, standing in
+// for the long-running work a relayed caller can start: a build, a log stream,
+// an exec. It reports both that it started and how it was released, which is
+// what lets a test tell "the session tore down" from "the handler was ended
+// with it."
+type blockingMeter struct {
+	temp float32
+
+	entered  chan struct{}
+	released chan error
+}
+
+func (m *blockingMeter) ActorState() any { return &m.temp }
+
+func (m *blockingMeter) ReadTemperature(ctx context.Context, call *example.MeterReadTemperature) error {
+	close(m.entered)
+	<-ctx.Done()
+	m.released <- ctx.Err()
+	return ctx.Err()
+}
+
+// Unused by the tests that take this meter, but part of the interface.
+func (m *blockingMeter) GetSetter(ctx context.Context, call *example.MeterGetSetter) error {
+	return errors.New("not used by this fixture")
+}
+
+func (m *blockingMeter) ReconstructFromState(is *rpc.InterfaceState) (*rpc.Interface, error) {
+	return nil, nil
 }

--- a/pkg/cloudrpc/meter_test.go
+++ b/pkg/cloudrpc/meter_test.go
@@ -1,0 +1,44 @@
+package cloudrpc_test
+
+import (
+	"context"
+
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/example"
+)
+
+// testMeter is the generated example service, used here only as something real
+// to call through the relay.
+type testMeter struct {
+	temp float32
+}
+
+func (m *testMeter) ActorState() any { return &m.temp }
+
+func (m *testMeter) ReadTemperature(ctx context.Context, call *example.MeterReadTemperature) error {
+	reading := new(example.Reading)
+	reading.SetMeter(call.Args().Name())
+	reading.SetTemperature(m.temp)
+
+	call.Results().SetReading(reading)
+	return nil
+}
+
+func (m *testMeter) GetSetter(ctx context.Context, call *example.MeterGetSetter) error {
+	call.Results().SetSetter(m)
+	return nil
+}
+
+func (m *testMeter) ReconstructFromState(is *rpc.InterfaceState) (*rpc.Interface, error) {
+	if is.Interface == "SetTemp" {
+		return example.AdaptSetTemp(m), nil
+	}
+	return nil, nil
+}
+
+func (m *testMeter) SetTemp(ctx context.Context, call *example.SetTempSetTemp) error {
+	args := call.Args()
+	m.temp = float32(args.Temp())
+	call.Results().SetTemp(args.Temp())
+	return nil
+}

--- a/pkg/cloudrpc/session.go
+++ b/pkg/cloudrpc/session.go
@@ -14,9 +14,18 @@ type session struct {
 	id  string
 	srv *Server
 
-	// ctx is the uplink connection's context, so the session dies with the link
-	// rather than lingering as a pipe to nowhere.
+	// ctx is this session's own context, a child of the uplink connection's.
+	// Inheriting means the session still dies with the link rather than
+	// lingering as a pipe to nowhere; being a child means the reverse also
+	// holds, and ending one session cannot outlive its own teardown.
 	ctx context.Context
+
+	// cancel ends ctx. Without it, tearing a session down closed its pipe but
+	// left the handlers already dispatched from it running on the uplink's
+	// context — so a build or a log stream outlived the caller that asked for
+	// it, and did so while no longer counted against maxSessions, which made
+	// repeated open-and-disconnect a way around that ceiling.
+	cancel context.CancelFunc
 
 	inbound chan []byte
 
@@ -29,6 +38,24 @@ type session struct {
 
 	closeOnce sync.Once
 	closed    chan struct{}
+}
+
+// newSession builds a session and its context together.
+//
+// A constructor rather than a struct literal because the two must not be
+// separable: a session whose cancel is missing tears down without ending the
+// work it dispatched, which is the bug this pairing exists to prevent, and a
+// literal is free to omit it.
+func newSession(ctx context.Context, id string, srv *Server) *session {
+	sessCtx, cancel := context.WithCancel(ctx)
+	return &session{
+		id:      id,
+		srv:     srv,
+		ctx:     sessCtx,
+		cancel:  cancel,
+		inbound: make(chan []byte, inboundDepth),
+		closed:  make(chan struct{}),
+	}
 }
 
 // reserve accounts for a frame about to be queued, and reports whether the
@@ -91,7 +118,12 @@ func (s *session) Close() error {
 }
 
 func (s *session) shutdown() {
-	s.closeOnce.Do(func() { close(s.closed) })
+	s.closeOnce.Do(func() {
+		close(s.closed)
+		// Cancelling after the close signal, so a reader waking on either one
+		// finds the session already marked done whichever it noticed first.
+		s.cancel()
+	})
 }
 
 // Remote names this session's far end for the audit trail.

--- a/pkg/cloudrpc/session.go
+++ b/pkg/cloudrpc/session.go
@@ -93,3 +93,17 @@ func (s *session) Close() error {
 func (s *session) shutdown() {
 	s.closeOnce.Do(func() { close(s.closed) })
 }
+
+// Remote names this session's far end for the audit trail.
+//
+// There is no address to give: the caller reached us through cloud, over a link
+// this cluster dialed outbound, so the only thing the socket knows about is
+// cloud. The session id is what actually distinguishes one caller from another
+// here, and it is the identifier cloud logs on its side too, which is what makes
+// the two halves of a relayed call joinable after the fact.
+//
+// Deliberately not address-shaped. An audit line that looked like a peer address
+// would be claiming knowledge this transport does not have.
+func (s *session) Remote() string {
+	return "cloud-relay/" + s.id
+}

--- a/pkg/cloudrpc/session.go
+++ b/pkg/cloudrpc/session.go
@@ -1,0 +1,66 @@
+package cloudrpc
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+// session presents one relayed conversation as an rpc.MessageConn: a reliable,
+// ordered, bidirectional pipe of discrete byte messages. Ordering comes from the
+// hops underneath — one WebSocket, one queue, one WebSocket — and each frame
+// arrives whole because the envelope carries it whole.
+type session struct {
+	id  string
+	srv *Server
+
+	// ctx is the uplink connection's context, so the session dies with the link
+	// rather than lingering as a pipe to nowhere.
+	ctx context.Context
+
+	inbound chan []byte
+
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+// Send wraps a frame and waits for room on the uplink. Blocking here is how
+// backpressure reaches the layer above: msgmux serialises Send, so a congested
+// link slows the writer instead of piling up unsent frames.
+func (s *session) Send(b []byte) error {
+	return s.srv.send(s.ctx, TypeData, Data{SessionID: s.id, Payload: b})
+}
+
+// Recv returns the next frame, or io.EOF once the far end is gone and nothing
+// buffered remains.
+func (s *session) Recv() ([]byte, error) {
+	// Buffered frames outrank a close that has already been signalled: the far
+	// end may have sent its last reply and then hung up, and returning EOF while
+	// that reply sits in the channel would lose it.
+	select {
+	case b := <-s.inbound:
+		return b, nil
+	default:
+	}
+
+	select {
+	case b := <-s.inbound:
+		return b, nil
+	case <-s.closed:
+		return nil, io.EOF
+	case <-s.ctx.Done():
+		return nil, io.EOF
+	}
+}
+
+// Close ends the session locally. The far end is told by whoever tore it down —
+// see Server.serve — rather than from here, because rpc closes the conn it was
+// handed as part of ordinary teardown and a notice per close would be noise.
+func (s *session) Close() error {
+	s.shutdown()
+	return nil
+}
+
+func (s *session) shutdown() {
+	s.closeOnce.Do(func() { close(s.closed) })
+}

--- a/pkg/cloudrpc/session.go
+++ b/pkg/cloudrpc/session.go
@@ -20,8 +20,35 @@ type session struct {
 
 	inbound chan []byte
 
+	// pending is the total size of the frames queued on inbound. The channel's
+	// depth bounds how many frames may wait; this bounds how much memory they
+	// may hold, which is the quantity that actually matters — the far end
+	// chooses the frame size, so a count says nothing about the cost.
+	pendingMu sync.Mutex
+	pending   int
+
 	closeOnce sync.Once
 	closed    chan struct{}
+}
+
+// reserve accounts for a frame about to be queued, and reports whether the
+// session has room for it.
+func (s *session) reserve(n int) bool {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+
+	if s.pending+n > maxPendingBytes {
+		return false
+	}
+	s.pending += n
+	return true
+}
+
+// release accounts for a frame the reader has taken.
+func (s *session) release(n int) {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	s.pending -= n
 }
 
 // Send wraps a frame and waits for room on the uplink. Blocking here is how
@@ -39,12 +66,14 @@ func (s *session) Recv() ([]byte, error) {
 	// that reply sits in the channel would lose it.
 	select {
 	case b := <-s.inbound:
+		s.release(len(b))
 		return b, nil
 	default:
 	}
 
 	select {
 	case b := <-s.inbound:
+		s.release(len(b))
 		return b, nil
 	case <-s.closed:
 		return nil, io.EOF

--- a/pkg/cloudrpc/session_internal_test.go
+++ b/pkg/cloudrpc/session_internal_test.go
@@ -5,6 +5,10 @@ import (
 	"encoding/json"
 	"log/slog"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/rpc"
 )
 
 // idleSession registers a session with no reader behind it, so what the
@@ -127,4 +131,16 @@ func TestSessionRefusesAnOversizedFrame(t *testing.T) {
 	if s.reserve(maxPendingBytes + 1) {
 		t.Fatal("accepted a frame larger than the entire allowance")
 	}
+}
+
+// A relayed session has no peer address to report — the socket only knows about
+// cloud — so it reports the session id, which is what distinguishes one caller
+// from another and is the same identifier cloud records on its side.
+func TestSessionReportsARemoteForAuditing(t *testing.T) {
+	sess := &session{id: "cluster-abc.xyz"}
+
+	var conn rpc.MessageConn = sess
+	remote, ok := conn.(rpc.MessageRemote)
+	require.True(t, ok, "a relayed session must be able to name its far end")
+	require.Equal(t, "cloud-relay/cluster-abc.xyz", remote.Remote())
 }

--- a/pkg/cloudrpc/session_internal_test.go
+++ b/pkg/cloudrpc/session_internal_test.go
@@ -21,13 +21,10 @@ func idleSession(t *testing.T, id string, depth int) (*Server, *session) {
 		log:      slog.Default(),
 		sessions: make(map[string]*session),
 	}
-	sess := &session{
-		id:      id,
-		srv:     srv,
-		ctx:     t.Context(),
-		inbound: make(chan []byte, depth),
-		closed:  make(chan struct{}),
-	}
+	sess := newSession(t.Context(), id, srv)
+	// A shallower backlog than production's, so a test can fill it without
+	// queueing inboundDepth frames to get there.
+	sess.inbound = make(chan []byte, depth)
 	srv.sessions[id] = sess
 
 	return srv, sess

--- a/pkg/cloudrpc/session_internal_test.go
+++ b/pkg/cloudrpc/session_internal_test.go
@@ -1,0 +1,130 @@
+package cloudrpc
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+// idleSession registers a session with no reader behind it, so what the
+// delivery path does when frames pile up is a property of the code rather than
+// of which goroutine got scheduled.
+func idleSession(t *testing.T, id string, depth int) (*Server, *session) {
+	t.Helper()
+
+	srv := &Server{
+		log:      slog.Default(),
+		sessions: make(map[string]*session),
+	}
+	sess := &session{
+		id:      id,
+		srv:     srv,
+		ctx:     t.Context(),
+		inbound: make(chan []byte, depth),
+		closed:  make(chan struct{}),
+	}
+	srv.sessions[id] = sess
+
+	return srv, sess
+}
+
+func frameFor(t *testing.T, id string, payload []byte) json.RawMessage {
+	t.Helper()
+
+	raw, err := json.Marshal(Data{SessionID: id, Payload: payload})
+	if err != nil {
+		t.Fatalf("marshal frame: %v", err)
+	}
+	return raw
+}
+
+// A session that has stopped reading is closed rather than waited on. Waiting
+// would stall the uplink's read loop, which every tenant shares; dropping the
+// frame instead would leave the session a hole it cannot resynchronise past.
+func TestFullBacklogClosesTheSession(t *testing.T) {
+	srv, sess := idleSession(t, "stuck", 2)
+
+	ctx := context.Background()
+	for range 2 {
+		if err := srv.handleData(ctx, frameFor(t, "stuck", []byte("frame"))); err != nil {
+			t.Fatalf("refused a frame the backlog had room for: %v", err)
+		}
+	}
+
+	if err := srv.handleData(ctx, frameFor(t, "stuck", []byte("frame"))); err == nil {
+		t.Fatal("accepted a frame past the backlog depth")
+	}
+
+	if srv.lookup("stuck") != nil {
+		t.Error("the session was left in the map after being closed")
+	}
+	select {
+	case <-sess.closed:
+	default:
+		t.Error("the session was not closed")
+	}
+}
+
+// The same, reached by size rather than by count: a few frames big enough to
+// matter close the session even though the depth is nowhere near full.
+func TestOversizedBacklogClosesTheSession(t *testing.T) {
+	srv, _ := idleSession(t, "greedy", 1024)
+
+	ctx := context.Background()
+	frame := make([]byte, 1<<20)
+
+	var err error
+	sent := 0
+	for range 1024 {
+		if err = srv.handleData(ctx, frameFor(t, "greedy", frame)); err != nil {
+			break
+		}
+		sent++
+	}
+
+	if err == nil {
+		t.Fatalf("accepted %d MiB without complaint", sent)
+	}
+	if sent >= 1024 {
+		t.Fatal("the byte limit never bit")
+	}
+}
+
+// The backlog is bounded by what it holds, not by how many frames hold it. The
+// far end chooses the frame size, so a count says nothing about the memory: the
+// same sixty-four frames are a few kilobytes or most of a gigabyte depending on
+// who is sending them.
+func TestSessionReservesByBytes(t *testing.T) {
+	s := &session{}
+
+	const frame = 1 << 20
+
+	for i := range maxPendingBytes / frame {
+		if !s.reserve(frame) {
+			t.Fatalf("refused frame %d, well inside the limit", i)
+		}
+	}
+
+	if s.reserve(frame) {
+		t.Fatal("accepted a frame past the limit")
+	}
+
+	// What the reader takes becomes available again, or a long-lived session
+	// would ratchet itself shut.
+	s.release(frame)
+	if !s.reserve(frame) {
+		t.Fatal("released space was not reusable")
+	}
+}
+
+// A single frame larger than the whole allowance is refused rather than
+// admitted on the grounds that nothing else is queued. Accepting it would make
+// the limit a suggestion, since the far end picks the size.
+func TestSessionRefusesAnOversizedFrame(t *testing.T) {
+	s := &session{}
+
+	if s.reserve(maxPendingBytes + 1) {
+		t.Fatal("accepted a frame larger than the entire allowance")
+	}
+}

--- a/pkg/cloudrpc/uplink_test.go
+++ b/pkg/cloudrpc/uplink_test.go
@@ -1,0 +1,187 @@
+package cloudrpc_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/cloudauth"
+	"miren.dev/runtime/pkg/cloudrpc"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/example"
+	"miren.dev/runtime/pkg/uplink"
+)
+
+// wsRelayConn is cloud's end of a relayed session, riding the same WebSocket the
+// cluster's uplink is on. Frames go out as rpc.data envelopes and come back the
+// same way; envelopes belonging to other tenants of the link are skipped.
+type wsRelayConn struct {
+	c         *websocket.Conn
+	ctx       context.Context
+	sessionID string
+}
+
+func (c *wsRelayConn) Send(b []byte) error {
+	raw, err := json.Marshal(cloudrpc.Data{SessionID: c.sessionID, Payload: b})
+	if err != nil {
+		return err
+	}
+	return wsjson.Write(c.ctx, c.c, &uplink.Envelope{Type: cloudrpc.TypeData, Data: raw})
+}
+
+func (c *wsRelayConn) Recv() ([]byte, error) {
+	for {
+		var env uplink.Envelope
+		if err := wsjson.Read(c.ctx, c.c, &env); err != nil {
+			return nil, err
+		}
+
+		switch env.Type {
+		case cloudrpc.TypeData:
+			var msg cloudrpc.Data
+			if err := json.Unmarshal(env.Data, &msg); err != nil {
+				return nil, err
+			}
+			if msg.SessionID == c.sessionID {
+				return msg.Payload, nil
+			}
+		case cloudrpc.TypeClose:
+			var msg cloudrpc.Close
+			if err := json.Unmarshal(env.Data, &msg); err != nil {
+				return nil, err
+			}
+			if msg.SessionID == c.sessionID {
+				return nil, io.EOF
+			}
+		}
+	}
+}
+
+func (c *wsRelayConn) Close() error { return c.c.Close(websocket.StatusNormalClosure, "") }
+
+// fakeCloud serves the two service-account auth endpoints the uplink
+// authenticates with, plus the cluster channel itself. On connect it opens one
+// relayed RPC session and hands its end to the test.
+func fakeCloud(t *testing.T, ctx context.Context, sessions chan<- rpc.MessageConn) *httptest.Server {
+	t.Helper()
+
+	const token = "test-token"
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/auth/service-account/begin", func(w http.ResponseWriter, r *http.Request) {
+		//nolint:errcheck // test server
+		json.NewEncoder(w).Encode(map[string]string{
+			"envelope":  "test-envelope",
+			"challenge": "test-challenge",
+		})
+	})
+
+	mux.HandleFunc("/auth/service-account/complete", func(w http.ResponseWriter, r *http.Request) {
+		//nolint:errcheck // test server
+		json.NewEncoder(w).Encode(map[string]any{
+			"token":      token,
+			"expires_in": 3600,
+		})
+	})
+
+	mux.HandleFunc("/api/v1/cluster-channel/ws", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.CloseNow()
+
+		// Whatever the cluster frames, base64'd, has to fit here.
+		c.SetReadLimit(2 << 20)
+
+		raw, err := json.Marshal(cloudrpc.Open{SessionID: "s1"})
+		if err != nil {
+			return
+		}
+		if err := wsjson.Write(ctx, c, &uplink.Envelope{Type: cloudrpc.TypeOpen, Data: raw}); err != nil {
+			return
+		}
+
+		sessions <- &wsRelayConn{c: c, ctx: ctx, sessionID: "s1"}
+
+		<-r.Context().Done()
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// The end-to-end shape, over a real socket: a cluster holding an uplink, cloud
+// opening a session on it, and a caller reaching the cluster's RPC server
+// through that session. This is where the envelope encoding earns its keep —
+// every frame is base64 inside JSON inside a WebSocket message.
+func TestRelayOverARealUplink(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	sessions := make(chan rpc.MessageConn, 1)
+	srv := fakeCloud(t, ctx, sessions)
+
+	ss, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+	ss.Server().ExposeValue("meter", example.AdaptMeter(&testMeter{temp: 42}))
+
+	keyPair, err := cloudauth.GenerateKeyPair()
+	r.NoError(err)
+
+	authClient, err := cloudauth.NewAuthClient(srv.URL, keyPair)
+	r.NoError(err)
+
+	link := uplink.NewClient(srv.URL, authClient, uplink.NewMessageRouter(), slog.Default())
+	cloudrpc.New(cloudrpc.Config{Uplink: link, State: ss, Log: slog.Default()})
+
+	go link.Run(ctx) //nolint:errcheck // ends with ctx
+
+	var conn rpc.MessageConn
+	select {
+	case conn = <-sessions:
+	case <-ctx.Done():
+		r.Fail("cluster never connected to the fake cloud")
+	}
+
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+
+	c, err := cs.ClientFromMessageConn(ctx, conn, "meter")
+	r.NoError(err)
+
+	mc := &example.MeterClient{Client: c}
+
+	res, err := mc.ReadTemperature(ctx, "test")
+	r.NoError(err)
+	r.Equal(float32(42), res.Reading().Temperature())
+
+	// Big enough that both directions cross several envelopes, and — the part
+	// that pins the read limit — big enough that the caller, which frames at
+	// pkg/rpc's 1 MiB default rather than the cluster's smaller cap, emits a
+	// frame whose base64 is half again over 1 MiB. A limit budgeted for the
+	// payload instead of its encoding would fail right here.
+	big := make([]byte, 3<<20)
+	for i := range big {
+		big[i] = 'a'
+	}
+
+	res, err = mc.ReadTemperature(ctx, string(big))
+	r.NoError(err)
+	r.Equal(string(big), res.Reading().Meter())
+}

--- a/pkg/rpc/PROTOCOL.md
+++ b/pkg/rpc/PROTOCOL.md
@@ -174,6 +174,16 @@ is — its subject is a self-minted key — so it carries no RPC privilege of it
 own and is denied every non-public method by the authorizer. A caller that needs
 authorization presents a bearer token.
 
+Note where the token is *not* visible. It sits inside a CBOR frame, so anything
+standing between the two peers — a relay forwarding these messages toward a peer
+it cannot reach directly — sees only opaque bytes and cannot authorize the
+connection from them. The WebSocket backend therefore also offers the configured
+bearer as an `Authorization` header on the handshake, which is the intermediary's
+copy. It authorizes the *connection*; the in-frame bearer authorizes each
+*operation*, and only the latter reaches the `Authenticator`. Presenting the same
+token for both is what makes a relayed connection authenticate exactly as a
+direct one does.
+
 ## Versioning
 
 `opRequest.Version` names the version a stream speaks. Absent or `0` means

--- a/pkg/rpc/audit.go
+++ b/pkg/rpc/audit.go
@@ -285,11 +285,16 @@ func logCertAuth(ctx context.Context, log *slog.Logger, dedup *certAuthDeduper, 
 // "ok" for an authorized dispatch, or "unauthorized"/"forbidden" for a rejected
 // one; non-ok outcomes log at Warn so denials surface without a level filter.
 //
+// remote is a free-form label for where the call came from, because not every
+// transport has an address: an HTTP peer passes RemoteAddr, and a message
+// transport passes whatever identifies its far end. It is only read to decide
+// whether the peer is loopback, which is trusted same-host chatter.
+//
 // Callers invoke this only for non-public methods. Public methods (e.g. health
 // checks and runner Join, which are public precisely because they carry no
 // caller identity) are intentionally left out of the audit trail rather than
 // logging identity-less lines for them.
-func logAccess(ctx context.Context, log *slog.Logger, r *http.Request, mm Method, outcome string, extra ...any) {
+func logAccess(ctx context.Context, log *slog.Logger, remote string, mm Method, outcome string, extra ...any) {
 	var subject, method string
 	if id := IdentityFromContext(ctx); id != nil {
 		subject = id.Subject
@@ -305,12 +310,12 @@ func logAccess(ctx context.Context, log *slog.Logger, r *http.Request, mm Method
 	switch {
 	case outcome != "ok":
 		level = slog.LevelWarn
-	case isLoopbackAddr(r.RemoteAddr):
+	case isLoopbackAddr(remote):
 		level = slog.LevelDebug
 	}
 
 	attrs := []any{
-		"remote", r.RemoteAddr,
+		"remote", remote,
 		"rpc", mm.InterfaceName + "." + mm.Name,
 		"subject", subject,
 		"auth_method", method,
@@ -327,9 +332,9 @@ func logAccess(ctx context.Context, log *slog.Logger, r *http.Request, mm Method
 // through logAccess, but a forged or replayed capability is exactly the kind of
 // event the audit trail exists to capture, so it must not be confined to the
 // general log. Always Warn, since every one of these is a failed auth attempt.
-func logAuthReject(log *slog.Logger, r *http.Request, oid OID, reason string) {
+func logAuthReject(log *slog.Logger, remote string, oid OID, reason string) {
 	log.Warn("auth rejected",
-		"remote", r.RemoteAddr,
+		"remote", remote,
 		"oid", string(oid),
 		"reason", reason,
 	)

--- a/pkg/rpc/audit_test.go
+++ b/pkg/rpc/audit_test.go
@@ -197,7 +197,7 @@ func TestLogAuthReject(t *testing.T) {
 	req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
 	req.RemoteAddr = "203.0.113.9:5555"
 
-	logAuthReject(captureLogger(&buf), req, OID("cap-123"), "signature verification failed")
+	logAuthReject(captureLogger(&buf), req.RemoteAddr, OID("cap-123"), "signature verification failed")
 
 	records := decodeRecords(t, &buf)
 	if len(records) != 1 {
@@ -235,7 +235,7 @@ func TestLogAccess(t *testing.T) {
 
 	t.Run("ok outcome logs at info with identity fields", func(t *testing.T) {
 		var buf bytes.Buffer
-		logAccess(ctxWithIdentity, captureLogger(&buf), newReq(), mm, "ok")
+		logAccess(ctxWithIdentity, captureLogger(&buf), newReq().RemoteAddr, mm, "ok")
 
 		records := decodeRecords(t, &buf)
 		if len(records) != 1 {
@@ -263,7 +263,7 @@ func TestLogAccess(t *testing.T) {
 		var buf bytes.Buffer
 		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
 		req.RemoteAddr = "127.0.0.1:8443"
-		logAccess(ctxWithIdentity, captureLogger(&buf), req, mm, "ok")
+		logAccess(ctxWithIdentity, captureLogger(&buf), req.RemoteAddr, mm, "ok")
 
 		records := decodeRecords(t, &buf)
 		if len(records) != 1 {
@@ -278,7 +278,7 @@ func TestLogAccess(t *testing.T) {
 		var buf bytes.Buffer
 		req, _ := http.NewRequest("POST", "/_rpc/call/test/method", nil)
 		req.RemoteAddr = "127.0.0.1:8443"
-		logAccess(ctxWithIdentity, captureLogger(&buf), req, mm, "forbidden", "error", "denied")
+		logAccess(ctxWithIdentity, captureLogger(&buf), req.RemoteAddr, mm, "forbidden", "error", "denied")
 
 		records := decodeRecords(t, &buf)
 		if len(records) != 1 {
@@ -291,7 +291,7 @@ func TestLogAccess(t *testing.T) {
 
 	t.Run("forbidden outcome logs at warn and carries extra fields", func(t *testing.T) {
 		var buf bytes.Buffer
-		logAccess(ctxWithIdentity, captureLogger(&buf), newReq(), mm, "forbidden", "error", "access denied by RBAC policy")
+		logAccess(ctxWithIdentity, captureLogger(&buf), newReq().RemoteAddr, mm, "forbidden", "error", "access denied by RBAC policy")
 
 		records := decodeRecords(t, &buf)
 		if len(records) != 1 {
@@ -312,7 +312,7 @@ func TestLogAccess(t *testing.T) {
 
 	t.Run("unauthorized outcome without identity logs empty subject", func(t *testing.T) {
 		var buf bytes.Buffer
-		logAccess(context.Background(), captureLogger(&buf), newReq(), mm, "unauthorized")
+		logAccess(context.Background(), captureLogger(&buf), newReq().RemoteAddr, mm, "unauthorized")
 
 		records := decodeRecords(t, &buf)
 		if len(records) != 1 {
@@ -495,3 +495,44 @@ func TestLogCertAuthDeduplicates(t *testing.T) {
 		t.Errorf("suppressed: got %v, want 999", got)
 	}
 }
+
+// Calls carried over a message transport were absent from the audit trail
+// entirely: the whole file took an *http.Request, so nothing on that path could
+// reach it. A cloud-routed call is exactly the one an operator wants recorded,
+// so the record has to name where it came from without inventing an address.
+func TestMsgRemoteFromContext(t *testing.T) {
+	ctx := contextWithMsgRemote(context.Background(), "cloud-relay/cluster-abc.xyz")
+	if got := msgRemoteFromContext(ctx); got != "cloud-relay/cluster-abc.xyz" {
+		t.Errorf("msgRemoteFromContext = %q, want the session's own label", got)
+	}
+
+	// A session that names nothing says so, rather than reporting something
+	// address-shaped that would read as knowledge this transport lacks.
+	if got := msgRemoteFromContext(context.Background()); got != "message" {
+		t.Errorf("msgRemoteFromContext with no label = %q, want %q", got, "message")
+	}
+	if got := msgRemoteFromContext(contextWithMsgRemote(context.Background(), "")); got != "message" {
+		t.Errorf("msgRemoteFromContext with an empty label = %q, want %q", got, "message")
+	}
+}
+
+// The same fallback has to hold for a connection implementing nothing, which is
+// every MessageConn that is only a byte pipe.
+func TestMessageConnRemote(t *testing.T) {
+	if got := messageConnRemote(plainMessageConn{}); got != "message" {
+		t.Errorf("messageConnRemote(plain) = %q, want %q", got, "message")
+	}
+	if got := messageConnRemote(namedMessageConn{}); got != "somewhere" {
+		t.Errorf("messageConnRemote(named) = %q, want %q", got, "somewhere")
+	}
+}
+
+type plainMessageConn struct{}
+
+func (plainMessageConn) Send([]byte) error     { return nil }
+func (plainMessageConn) Recv() ([]byte, error) { return nil, nil }
+func (plainMessageConn) Close() error          { return nil }
+
+type namedMessageConn struct{ plainMessageConn }
+
+func (namedMessageConn) Remote() string { return "somewhere" }

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -671,24 +671,8 @@ func (c *NetworkClient) Close() error {
 
 // addBearerToken safely adds a bearer token to the request header if configured
 func (c *NetworkClient) addBearerToken(req *http.Request) {
-	if c.State == nil || c.State.opts == nil {
-		return
-	}
-
-	if fn := c.State.opts.bearerTokenFunc; fn != nil {
-		token, err := fn()
-		if err != nil || token == "" {
-			// Send the request unauthenticated and let the server reject it.
-			// The caller's retry then picks up a token that has since been
-			// refreshed, which a hard failure here would not.
-			return
-		}
+	if token := c.bearer(); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
-		return
-	}
-
-	if c.State.opts.bearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+c.State.opts.bearerToken)
 	}
 }
 

--- a/pkg/rpc/message.go
+++ b/pkg/rpc/message.go
@@ -15,6 +15,11 @@ const defaultMaxFrameData = 1 << 20 // 1 MiB
 // untrusted peer before the length is validated.
 const frameReadHeadroom = 1 << 16
 
+// defaultMaxBufferedData bounds delivered-but-unread stream data per session.
+// Generous next to what an ordinary call holds — the point is to have a
+// ceiling at all, not to police normal use. Override with WithMaxBufferedData.
+const defaultMaxBufferedData = 32 << 20 // 32 MiB
+
 // frameReadLimit is the largest inbound message a transport should accept for a
 // given payload frame cap. A zero cap uses the default.
 func frameReadLimit(maxFrame int) int64 {
@@ -85,7 +90,8 @@ func messageConnRemote(conn MessageConn) string {
 type MessageSessionOption func(*messageSessionOptions)
 
 type messageSessionOptions struct {
-	maxFrame int
+	maxFrame    int
+	maxBuffered int
 }
 
 // WithMaxFrameSize bounds the payload rpc places in a single message. Set it
@@ -96,6 +102,23 @@ type messageSessionOptions struct {
 func WithMaxFrameSize(n int) MessageSessionOption {
 	return func(o *messageSessionOptions) {
 		o.maxFrame = n
+	}
+}
+
+// WithMaxBufferedData bounds how much delivered-but-unread stream data one
+// session may hold across all its streams, before the session is torn down.
+//
+// It exists because the transport's own backpressure does not reach this far.
+// A frame handed to msgmux has already left the backend's accounting, and it
+// sits in a stream's read buffer until a handler reads it — so a peer that
+// sends faster than its handler consumes, or keeps sending after the handler
+// has stopped reading altogether, grows that buffer with nothing to stop it.
+// Any limit the transport advertises is only real if this one backs it.
+//
+// Zero leaves it at defaultMaxBufferedData.
+func WithMaxBufferedData(n int) MessageSessionOption {
+	return func(o *messageSessionOptions) {
+		o.maxBuffered = n
 	}
 }
 
@@ -120,7 +143,7 @@ func buildMessageSessionOptions(opts []MessageSessionOption) messageSessionOptio
 func (s *State) ServeMessageConn(ctx context.Context, conn MessageConn, opts ...MessageSessionOption) error {
 	o := buildMessageSessionOptions(opts)
 
-	sess := newMsgSession(conn, false, o.maxFrame)
+	sess := newMsgSession(conn, false, o.maxFrame, o.maxBuffered)
 	router := &sessionRouter{state: s, server: s.server}
 
 	ctx = contextWithMsgRemote(ctx, messageConnRemote(conn))
@@ -151,7 +174,7 @@ func (s *State) ClientFromMessageConn(
 	// dial stays nil: the connection belongs to the caller and cannot be
 	// re-established from here.
 	client.ops = &msgOpTransport{owner: client}
-	client.ops.adopt(ctx, newMsgSession(conn, true, o.maxFrame))
+	client.ops.adopt(ctx, newMsgSession(conn, true, o.maxFrame, o.maxBuffered))
 
 	if err := client.resolveCapability(name); err != nil {
 		return nil, err

--- a/pkg/rpc/message.go
+++ b/pkg/rpc/message.go
@@ -40,6 +40,47 @@ type MessageConn interface {
 	Close() error
 }
 
+// MessageRemote is an optional interface a MessageConn may implement to name
+// its far end.
+//
+// Optional because a MessageConn is a byte pipe and most backends have no
+// address to give. It exists for the audit trail, which records where a call
+// came from and had nothing to record on this transport.
+type MessageRemote interface {
+	Remote() string
+}
+
+type msgRemoteKey struct{}
+
+// contextWithMsgRemote labels a context with the far end of the message
+// session it belongs to, so code deep in dispatch can record where a call came
+// from without every layer between having to carry it.
+func contextWithMsgRemote(ctx context.Context, remote string) context.Context {
+	return context.WithValue(ctx, msgRemoteKey{}, remote)
+}
+
+// msgRemoteFromContext returns the label set by contextWithMsgRemote, or
+// "message" for a session that never set one.
+func msgRemoteFromContext(ctx context.Context) string {
+	if remote, ok := ctx.Value(msgRemoteKey{}).(string); ok && remote != "" {
+		return remote
+	}
+	return "message"
+}
+
+// messageConnRemote asks a connection to name its far end, falling back to a
+// constant. The fallback is deliberately not an address-shaped string: an audit
+// line saying "message" is honest about knowing nothing, where a fake address
+// would not be.
+func messageConnRemote(conn MessageConn) string {
+	if r, ok := conn.(MessageRemote); ok {
+		if remote := r.Remote(); remote != "" {
+			return remote
+		}
+	}
+	return "message"
+}
+
 // MessageSessionOption configures a session built over a MessageConn.
 type MessageSessionOption func(*messageSessionOptions)
 
@@ -81,6 +122,8 @@ func (s *State) ServeMessageConn(ctx context.Context, conn MessageConn, opts ...
 
 	sess := newMsgSession(conn, false, o.maxFrame)
 	router := &sessionRouter{state: s, server: s.server}
+
+	ctx = contextWithMsgRemote(ctx, messageConnRemote(conn))
 
 	return router.run(ctx, sess)
 }

--- a/pkg/rpc/message_adopt_test.go
+++ b/pkg/rpc/message_adopt_test.go
@@ -1,10 +1,14 @@
 package rpc_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -423,6 +427,40 @@ func TestAdoptedMessageConn(t *testing.T) {
 		r.Contains(err.Error(), "denied by policy")
 	})
 
+	// The denial above checks what the caller is told. This checks the part that
+	// actually matters: a denied call must not reach the handler at all. The two
+	// are separable — a gate that ran the method and then reported an error
+	// would satisfy the first and be worthless.
+	t.Run("a denied call never reaches the handler", func(t *testing.T) {
+		r := require.New(t)
+		ctx := t.Context()
+
+		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify,
+			rpc.WithAuthenticator(&recordingAuthenticator{
+				identity: &rpc.Identity{Subject: "nobody", Method: rpc.AuthMethodJWT},
+			}),
+			rpc.WithAuthorizer(denyAll{}),
+		)
+		r.NoError(err)
+
+		var seen *rpc.Identity
+		ss.Server().ExposeValue("meter", example.AdaptMeter(&identityMeter{seen: &seen}))
+
+		cs, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithBearerToken("token"))
+		r.NoError(err)
+
+		serverEnd, clientEnd := newEnvelopePair()
+		go ss.ServeMessageConn(ctx, serverEnd) //nolint:errcheck // ends with ctx
+
+		c, err := cs.ClientFromMessageConn(ctx, clientEnd, "meter")
+		r.NoError(err)
+
+		mc := &example.MeterClient{Client: c}
+		_, err = mc.ReadTemperature(ctx, "test")
+		r.Error(err)
+		r.Nil(seen, "the handler ran despite the authorizer denying the call")
+	})
+
 	// A frame cap below the payload size forces msgmux to split a write across
 	// several messages, which is what an envelope with its own size limit needs.
 	t.Run("respects a frame size below the payload size", func(t *testing.T) {
@@ -447,3 +485,60 @@ func TestAdoptedMessageConn(t *testing.T) {
 		r.Greater(conn.count(), int64(10))
 	})
 }
+
+// The audit trail had no entry for anything arriving over a message transport,
+// because every function in audit.go took an *http.Request. A cloud-routed call
+// is precisely the one an operator would want a record of, so this checks a real
+// call over a real message session produces one, naming the session it came in
+// on rather than an address the transport does not have.
+func TestMessageTransportCallIsAudited(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	ss, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithLogger(log))
+	r.NoError(err)
+	ss.Server().ExposeValue("meter", example.AdaptMeter(&exampleMeter{temp: 42}))
+
+	cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+	r.NoError(err)
+
+	serverEnd, clientEnd := newEnvelopePair()
+
+	go ss.ServeMessageConn(ctx, namedConn{serverEnd}) //nolint:errcheck // ends with ctx
+
+	c, err := cs.ClientFromMessageConn(ctx, clientEnd, "meter")
+	r.NoError(err)
+
+	mc := &example.MeterClient{Client: c}
+	_, err = mc.ReadTemperature(ctx, "test")
+	r.NoError(err)
+
+	var found map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["msg"] == "rpc access" {
+			found = rec
+			break
+		}
+	}
+
+	r.NotNil(found, "a call over a message transport produced no audit record")
+	r.Equal("cloud-relay/sess-1", found["remote"],
+		"the record must name the session the call arrived on")
+	r.Equal("ok", found["outcome"])
+}
+
+// namedConn is a MessageConn that names its far end, which is what a relayed
+// session does.
+type namedConn struct{ *envelopeConn }
+
+func (namedConn) Remote() string { return "cloud-relay/sess-1" }

--- a/pkg/rpc/message_mem.go
+++ b/pkg/rpc/message_mem.go
@@ -102,7 +102,7 @@ func (r *memRegistry) dial(name string) (MessageConn, error) {
 	}
 
 	clientEnd, serverEnd := newMemPipe()
-	serverSess := newMsgSession(serverEnd, false, 0)
+	serverSess := newMsgSession(serverEnd, false, 0, 0)
 
 	router := &sessionRouter{state: entry.state, server: entry.state.server}
 	go router.run(entry.ctx, serverSess) //nolint:errcheck // loop ends with the session

--- a/pkg/rpc/message_net_test.go
+++ b/pkg/rpc/message_net_test.go
@@ -26,7 +26,7 @@ var netTransports = []netTransport{
 	{
 		name:   "websocket",
 		listen: func() rpc.StateOption { return rpc.WithWSBindAddr("localhost:0") },
-		remote: func(s *rpc.State) string { return "ws://" + s.WSListenAddr() },
+		remote: func(s *rpc.State) string { return "wss://" + s.WSListenAddr() },
 	},
 	{
 		name:   "tcp",

--- a/pkg/rpc/message_version_test.go
+++ b/pkg/rpc/message_version_test.go
@@ -30,9 +30,9 @@ func TestProtocolVersionGate(t *testing.T) {
 		r.NoError(err)
 
 		router := &sessionRouter{state: state, server: state.server}
-		go router.run(ctx, newMsgSession(serverEnd, false, 0)) //nolint:errcheck // ends with ctx
+		go router.run(ctx, newMsgSession(serverEnd, false, 0, 0)) //nolint:errcheck // ends with ctx
 
-		sess := newMsgSession(clientEnd, true, 0)
+		sess := newMsgSession(clientEnd, true, 0, 0)
 		st, err := sess.OpenStreamSync(ctx)
 		r.NoError(err)
 
@@ -61,9 +61,9 @@ func TestProtocolVersionGate(t *testing.T) {
 		r.NoError(err)
 
 		router := &sessionRouter{state: state, server: state.server}
-		go router.run(ctx, newMsgSession(serverEnd, false, 0)) //nolint:errcheck // ends with ctx
+		go router.run(ctx, newMsgSession(serverEnd, false, 0, 0)) //nolint:errcheck // ends with ctx
 
-		sess := newMsgSession(clientEnd, true, 0)
+		sess := newMsgSession(clientEnd, true, 0, 0)
 		st, err := sess.OpenStreamSync(ctx)
 		r.NoError(err)
 

--- a/pkg/rpc/message_ws.go
+++ b/pkg/rpc/message_ws.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"strings"
 
@@ -66,6 +67,39 @@ func wsRemoteURL(remote string) string {
 	return scheme + "://" + host + "/" + path
 }
 
+// bearerTravelsSafely reports whether a credential may be put on the handshake
+// to this URL.
+//
+// Encrypted, always. Unencrypted, only to this machine — which is what ws://
+// exists for, a development endpoint with no certificate. A configured remote
+// like ws://relay.example would otherwise put a reusable credential on the
+// network in the clear, and the caller would never know it happened.
+//
+// A caller that meant to reach a remote plaintext endpoint gets no header and
+// an authentication failure from the far end, which is the right way round: a
+// broken connection is recoverable, a leaked token is not.
+func bearerTravelsSafely(url string) bool {
+	rest, ok := strings.CutPrefix(url, "ws://")
+	if !ok {
+		return true // wss://, so the handshake is encrypted
+	}
+
+	host, _, _ := strings.Cut(rest, "/")
+	if isLoopbackAddr(host) {
+		return true
+	}
+
+	// isLoopbackAddr only knows addresses, and a development endpoint is
+	// usually reached by name. Handled here rather than there, because that
+	// helper also decides an audit record's level and this is not a reason to
+	// change what it means.
+	name, _, err := net.SplitHostPort(host)
+	if err != nil {
+		name = host
+	}
+	return strings.EqualFold(name, "localhost")
+}
+
 // dialWSMessageConn opens a WebSocket to a "host:port" or "host:port/path"
 // remote and wraps it as a MessageConn. ctx bounds the connection's lifetime, so
 // it must be the State's context rather than any one call's.
@@ -80,16 +114,18 @@ func dialWSMessageConn(ctx context.Context, remote string, tlsCfg *tls.Config, b
 	cfg := tlsCfg.Clone()
 	cfg.NextProtos = []string{"http/1.1"}
 
+	url := wsRemoteURL(remote)
+
 	opts := &websocket.DialOptions{
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{TLSClientConfig: cfg},
 		},
 	}
-	if bearer != "" {
+	if bearer != "" && bearerTravelsSafely(url) {
 		opts.HTTPHeader = http.Header{"Authorization": []string{"Bearer " + bearer}}
 	}
 
-	c, _, err := websocket.Dial(ctx, wsRemoteURL(remote), opts)
+	c, _, err := websocket.Dial(ctx, url, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpc/message_ws.go
+++ b/pkg/rpc/message_ws.go
@@ -40,20 +40,56 @@ func (w *wsConn) Close() error {
 	return w.c.Close(websocket.StatusNormalClosure, "")
 }
 
-// dialWSMessageConn opens a WebSocket to a "host:port" remote and wraps it as a
-// MessageConn. ctx bounds the connection's lifetime, so it must be the State's
-// context rather than any one call's.
-func dialWSMessageConn(ctx context.Context, remote string, tlsCfg *tls.Config) (MessageConn, error) {
+// wsRemoteURL turns a remote into the URL to dial.
+//
+// The scheme means what it says: wss:// is TLS, ws:// is plaintext. A remote
+// naming neither is assumed to be one of our own listeners, which are always
+// TLS. Plaintext exists for a development endpoint that has no certificate —
+// a local cloud on http://, say — and should not appear anywhere else.
+//
+// A bare "host:port" gets the listener's own route appended, which is what a
+// cluster's own RPC endpoint wants. A remote that already names a path keeps it
+// verbatim, so it can point at somebody else's endpoint — a relay forwarding
+// these frames on, say — without that endpoint having to mimic our route.
+func wsRemoteURL(remote string) string {
+	scheme := "wss"
+	if rest, ok := strings.CutPrefix(remote, "ws://"); ok {
+		scheme, remote = "ws", rest
+	} else {
+		remote = strings.TrimPrefix(remote, "wss://")
+	}
+
+	host, path, _ := strings.Cut(remote, "/")
+	if path == "" {
+		return scheme + "://" + host + wsMessagePath
+	}
+	return scheme + "://" + host + "/" + path
+}
+
+// dialWSMessageConn opens a WebSocket to a "host:port" or "host:port/path"
+// remote and wraps it as a MessageConn. ctx bounds the connection's lifetime, so
+// it must be the State's context rather than any one call's.
+//
+// bearer, when set, authenticates the handshake itself. On this transport the
+// operation frames carry their own bearer, but those are opaque to anything
+// standing between us and the server, so an intermediary that must authorize
+// the connection before it can forward a byte has nothing else to go on.
+func dialWSMessageConn(ctx context.Context, remote string, tlsCfg *tls.Config, bearer string) (MessageConn, error) {
 	// coder/websocket does not implement RFC 8441 extended CONNECT, so the
 	// handshake must be HTTP/1.1.
 	cfg := tlsCfg.Clone()
 	cfg.NextProtos = []string{"http/1.1"}
 
-	c, _, err := websocket.Dial(ctx, "wss://"+remote+wsMessagePath, &websocket.DialOptions{
+	opts := &websocket.DialOptions{
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{TLSClientConfig: cfg},
 		},
-	})
+	}
+	if bearer != "" {
+		opts.HTTPHeader = http.Header{"Authorization": []string{"Bearer " + bearer}}
+	}
+
+	c, _, err := websocket.Dial(ctx, wsRemoteURL(remote), opts)
 	if err != nil {
 		return nil, err
 	}
@@ -96,10 +132,11 @@ func (s *State) serveWSUpgrade(lifeCtx context.Context, w http.ResponseWriter, r
 	}()
 }
 
-// setupWSTransport wires a client for a "ws://host:port" remote onto the
-// message transport.
+// setupWSTransport wires a client for a "wss://host:port" remote onto the
+// message transport. The remote is passed through whole, scheme and all, since
+// that is what decides the URL to dial — see wsRemoteURL.
 func (c *NetworkClient) setupWSTransport() {
-	remote := strings.TrimPrefix(strings.TrimPrefix(c.remote, "wss://"), "ws://")
+	remote := c.remote
 
 	tlsCfg := c.tlsCfg
 	if tlsCfg == nil {
@@ -109,7 +146,9 @@ func (c *NetworkClient) setupWSTransport() {
 	c.ops = &msgOpTransport{
 		owner: c,
 		dial: func() (MessageConn, error) {
-			return dialWSMessageConn(c.State.top, remote, tlsCfg)
+			// Resolved per dial, not once here: a refreshing credential must not
+			// be pinned to whatever it happened to be when the client was built.
+			return dialWSMessageConn(c.State.top, remote, tlsCfg, c.bearer())
 		},
 	}
 }

--- a/pkg/rpc/message_ws_internal_test.go
+++ b/pkg/rpc/message_ws_internal_test.go
@@ -1,0 +1,32 @@
+package rpc
+
+import "testing"
+
+func TestWSRemoteURL(t *testing.T) {
+	tests := []struct {
+		remote string
+		want   string
+	}{
+		// A bare authority means the peer is one of ours, so it gets our route.
+		{"localhost:8443", "wss://localhost:8443" + wsMessagePath},
+		{"[::1]:8443", "wss://[::1]:8443" + wsMessagePath},
+
+		// A path names somebody else's endpoint and is taken verbatim.
+		{"api.miren.cloud/api/v1/clusters/cluster-abc/rpc", "wss://api.miren.cloud/api/v1/clusters/cluster-abc/rpc"},
+		{"localhost:3001/relay", "wss://localhost:3001/relay"},
+
+		// A trailing slash names no path, so it is not one.
+		{"localhost:8443/", "wss://localhost:8443" + wsMessagePath},
+
+		// The scheme decides transport security rather than being decoration.
+		{"wss://localhost:8443", "wss://localhost:8443" + wsMessagePath},
+		{"ws://localhost:3001/relay", "ws://localhost:3001/relay"},
+		{"ws://localhost:3001", "ws://localhost:3001" + wsMessagePath},
+	}
+
+	for _, tt := range tests {
+		if got := wsRemoteURL(tt.remote); got != tt.want {
+			t.Errorf("wsRemoteURL(%q) = %q, want %q", tt.remote, got, tt.want)
+		}
+	}
+}

--- a/pkg/rpc/message_ws_internal_test.go
+++ b/pkg/rpc/message_ws_internal_test.go
@@ -30,3 +30,34 @@ func TestWSRemoteURL(t *testing.T) {
 		}
 	}
 }
+
+// The handshake bearer must never cross an unencrypted hop to somewhere else.
+// Plaintext exists for a development endpoint on this machine; anywhere else it
+// would put a reusable credential on the wire, and nothing about the connection
+// would look wrong afterwards.
+func TestBearerTravelsSafely(t *testing.T) {
+	safe := []string{
+		"wss://api.miren.cloud/api/v1/clusters/c/rpc",
+		"wss://anything.example",
+		"ws://localhost:3001/relay",
+		"ws://LocalHost:3001/relay",
+		"ws://127.0.0.1:18080/relay",
+		"ws://[::1]:18080/relay",
+	}
+	for _, url := range safe {
+		if !bearerTravelsSafely(url) {
+			t.Errorf("%q should carry a bearer", url)
+		}
+	}
+
+	unsafe := []string{
+		"ws://relay.example/relay",
+		"ws://miren.host:3001/relay",
+		"ws://10.0.0.1:8080/relay",
+	}
+	for _, url := range unsafe {
+		if bearerTravelsSafely(url) {
+			t.Errorf("%q must not carry a bearer", url)
+		}
+	}
+}

--- a/pkg/rpc/message_ws_relay_test.go
+++ b/pkg/rpc/message_ws_relay_test.go
@@ -1,0 +1,224 @@
+package rpc_test
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/rpc/example"
+)
+
+// relay is a minimal stand-in for an intermediary that forwards this transport's
+// frames without understanding them: it authorizes the handshake, then pumps
+// binary messages between the caller and the real server. It is deliberately
+// dumb, because that is the property under test — the frames have to survive a
+// hop that can read none of them.
+type relay struct {
+	url    string // the caller-facing "host:port/path" remote
+	target string // the server's "host:port"
+
+	mu     sync.Mutex
+	tokens []string // bearer tokens seen at the handshake, in order
+}
+
+// newRelay starts a relay in front of target. plaintext serves it over plain
+// HTTP, the way a local development endpoint with no certificate would.
+func newRelay(t *testing.T, ctx context.Context, target string, plaintext bool) *relay {
+	t.Helper()
+
+	rl := &relay{target: target}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/relay" {
+			http.NotFound(w, r)
+			return
+		}
+
+		token, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		rl.mu.Lock()
+		rl.tokens = append(rl.tokens, token)
+		rl.mu.Unlock()
+
+		caller, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer caller.CloseNow()
+		caller.SetReadLimit(-1)
+
+		server, _, err := websocket.Dial(ctx, "wss://"+rl.target+"/_rpc/message", &websocket.DialOptions{
+			HTTPClient: &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test relay
+				},
+			},
+		})
+		if err != nil {
+			return
+		}
+		defer server.CloseNow()
+		server.SetReadLimit(-1)
+
+		pump := func(from, to *websocket.Conn) {
+			for {
+				typ, data, err := from.Read(ctx)
+				if err != nil {
+					return
+				}
+				if err := to.Write(ctx, typ, data); err != nil {
+					return
+				}
+			}
+		}
+
+		done := make(chan struct{}, 2)
+		go func() { pump(caller, server); done <- struct{}{} }()
+		go func() { pump(server, caller); done <- struct{}{} }()
+		<-done
+	})
+
+	srv, scheme := httptest.NewTLSServer(handler), "wss://"
+	if plaintext {
+		srv, scheme = httptest.NewUnstartedServer(handler), "ws://"
+		srv.Start()
+	}
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	rl.url = scheme + u.Host + "/relay"
+
+	return rl
+}
+
+func (r *relay) seenTokens() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.tokens...)
+}
+
+// A remote naming a path reaches an endpoint that is not ours, and the bearer
+// authenticates the handshake so that endpoint can authorize the connection
+// before it has forwarded a byte. Together those are what let RPC run through an
+// intermediary that cannot read the traffic it is carrying.
+func TestWSRelayedRemote(t *testing.T) {
+	t.Run("calls survive the hop", func(t *testing.T) {
+		r := require.New(t)
+		ctx := t.Context()
+
+		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithWSBindAddr("localhost:0"))
+		r.NoError(err)
+		ss.Server().ExposeValue("meter", example.AdaptMeter(&exampleMeter{temp: 42}))
+
+		rl := newRelay(t, ctx, ss.WSListenAddr(), false)
+
+		cs, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithBearerToken("user-token"))
+		r.NoError(err)
+
+		c, err := cs.Connect(rl.url, "meter")
+		r.NoError(err)
+
+		mc := &example.MeterClient{Client: c}
+
+		res, err := mc.ReadTemperature(ctx, "test")
+		r.NoError(err)
+		r.Equal(float32(42), res.Reading().Temperature())
+
+		// A capability returned by the first call is followed over the same
+		// relayed session, so the hop survives more than one round trip.
+		set, err := mc.GetSetter(ctx, "test")
+		r.NoError(err)
+
+		got, err := set.Setter().SetTemp(ctx, 100)
+		r.NoError(err)
+		r.Equal(int32(100), got.Temp())
+
+		r.Equal([]string{"user-token"}, rl.seenTokens())
+	})
+
+	// A credential that refreshes must be read at dial time. Pinning it when the
+	// client was built would send a token that has since expired, and the failure
+	// would look like a permissions problem rather than a stale copy.
+	t.Run("a refreshing token is resolved per dial", func(t *testing.T) {
+		r := require.New(t)
+		ctx := t.Context()
+
+		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithWSBindAddr("localhost:0"))
+		r.NoError(err)
+		ss.Server().ExposeValue("meter", example.AdaptMeter(&exampleMeter{temp: 42}))
+
+		rl := newRelay(t, ctx, ss.WSListenAddr(), false)
+
+		cs, err := rpc.NewState(ctx, rpc.WithSkipVerify,
+			rpc.WithBearerToken("stale"),
+			rpc.WithBearerTokenFunc(func() (string, error) { return "fresh", nil }),
+		)
+		r.NoError(err)
+
+		c, err := cs.Connect(rl.url, "meter")
+		r.NoError(err)
+
+		_, err = (&example.MeterClient{Client: c}).ReadTemperature(ctx, "test")
+		r.NoError(err)
+
+		r.Equal([]string{"fresh"}, rl.seenTokens())
+	})
+
+	// Without a bearer the handshake is refused, which is the intermediary doing
+	// its job. The client must surface that as a failure to connect rather than
+	// producing a client that fails later and elsewhere.
+	t.Run("an unauthorized handshake fails the connect", func(t *testing.T) {
+		r := require.New(t)
+		ctx := t.Context()
+
+		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithWSBindAddr("localhost:0"))
+		r.NoError(err)
+		ss.Server().ExposeValue("meter", example.AdaptMeter(&exampleMeter{temp: 42}))
+
+		rl := newRelay(t, ctx, ss.WSListenAddr(), false)
+
+		cs, err := rpc.NewState(ctx, rpc.WithSkipVerify)
+		r.NoError(err)
+
+		_, err = cs.Connect(rl.url, "meter")
+		r.Error(err)
+	})
+
+	// A local development endpoint has no certificate, so the scheme has to be
+	// able to say so. Without this the only reachable relay is one fronted by
+	// TLS, which rules out running the whole thing on a laptop.
+	t.Run("a plaintext relay is reachable over ws://", func(t *testing.T) {
+		r := require.New(t)
+		ctx := t.Context()
+
+		ss, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithWSBindAddr("localhost:0"))
+		r.NoError(err)
+		ss.Server().ExposeValue("meter", example.AdaptMeter(&exampleMeter{temp: 42}))
+
+		rl := newRelay(t, ctx, ss.WSListenAddr(), true)
+		r.True(strings.HasPrefix(rl.url, "ws://"), "expected a plaintext remote, got %q", rl.url)
+
+		cs, err := rpc.NewState(ctx, rpc.WithSkipVerify, rpc.WithBearerToken("user-token"))
+		r.NoError(err)
+
+		c, err := cs.Connect(rl.url, "meter")
+		r.NoError(err)
+
+		res, err := (&example.MeterClient{Client: c}).ReadTemperature(ctx, "test")
+		r.NoError(err)
+		r.Equal(float32(42), res.Reading().Temperature())
+	})
+}

--- a/pkg/rpc/msgmux.go
+++ b/pkg/rpc/msgmux.go
@@ -13,8 +13,18 @@ import (
 // msgmux is a minimal stream multiplexer that implements rpcSession/rpcStream
 // over a MessageConn. It is to a MessageConn what yamux is to a byte conn, but
 // because a MessageConn already delivers reliable, ordered, discrete messages,
-// msgmux needs no flow control: each frame is one message, and the backend's
-// own backpressure governs throughput.
+// msgmux needs no windowing: each frame is one message, and the backend's own
+// backpressure governs throughput.
+//
+// It does need a ceiling, which is a different thing. The backend's
+// backpressure stops at the point a frame is handed over; after that the bytes
+// wait in a stream's read buffer for a handler to read them. A peer that sends
+// faster than its handler consumes — or goes on sending after the handler has
+// stopped reading — grows that buffer with nothing to stop it, and a transport
+// that reclaims its own accounting when it hands a frame over would be
+// advertising a limit it no longer enforces. maxBuffered is that ceiling:
+// exceed it and the session is torn down, because there is no way to apply
+// backpressure retroactively to bytes already delivered.
 //
 // Frame flags. A stream is opened with an eager SYN (so AcceptStream fires even
 // if the opener reads before writing); data frames carry DATA; a clean close
@@ -36,6 +46,12 @@ var (
 	errSessionClosed = errors.New("rpc: message session closed")
 	errStreamReset   = errors.New("rpc: message stream reset")
 	errStreamCancel  = errors.New("rpc: message stream read canceled")
+
+	// errSessionOverBuffered ends a session holding more delivered-but-unread
+	// data than it is allowed to. Named rather than generic because it is the
+	// one teardown here that says something about the peer's behaviour instead
+	// of the link's.
+	errSessionOverBuffered = errors.New("rpc: message session buffered too much unread data")
 )
 
 type msgSession struct {
@@ -46,6 +62,15 @@ type msgSession struct {
 	maxFrame int
 
 	sendMu sync.Mutex
+
+	// bufMu guards buffered, the total delivered-but-unread bytes held across
+	// every stream on this session. Its own lock rather than mu: it is touched
+	// on each frame in and each read out, and those paths already hold a
+	// stream's readMu, so sharing the session lock would put the frame path
+	// behind stream table work.
+	bufMu       sync.Mutex
+	buffered    int
+	maxBuffered int
 
 	mu       sync.Mutex
 	streams  map[uint32]*msgStream
@@ -60,8 +85,9 @@ type msgSession struct {
 
 // newMsgSession wraps a MessageConn. Exactly one side must pass client=true
 // (the dialer); it uses odd stream ids while the accepter uses even ids, so ids
-// never collide. A maxFrame of zero uses defaultMaxFrameData.
-func newMsgSession(conn MessageConn, client bool, maxFrame int) *msgSession {
+// never collide. A maxFrame of zero uses defaultMaxFrameData, and a maxBuffered
+// of zero uses defaultMaxBufferedData.
+func newMsgSession(conn MessageConn, client bool, maxFrame, maxBuffered int) *msgSession {
 	var start uint32 = 2
 	if client {
 		start = 1
@@ -69,14 +95,18 @@ func newMsgSession(conn MessageConn, client bool, maxFrame int) *msgSession {
 	if maxFrame <= 0 {
 		maxFrame = defaultMaxFrameData
 	}
+	if maxBuffered <= 0 {
+		maxBuffered = defaultMaxBufferedData
+	}
 	s := &msgSession{
-		conn:     conn,
-		maxFrame: maxFrame,
-		streams:  make(map[uint32]*msgStream),
-		nextID:   start,
-		idStep:   2,
-		accept:   make(chan *msgStream, 16),
-		done:     make(chan struct{}),
+		conn:        conn,
+		maxFrame:    maxFrame,
+		maxBuffered: maxBuffered,
+		streams:     make(map[uint32]*msgStream),
+		nextID:      start,
+		idStep:      2,
+		accept:      make(chan *msgStream, 16),
+		done:        make(chan struct{}),
 	}
 	go s.readPump()
 	return s
@@ -147,10 +177,44 @@ func (s *msgSession) Close() error {
 	return s.conn.Close()
 }
 
+// reserveBuffered accounts for bytes about to be buffered for a reader, and
+// reports whether the session has room. A refusal is fatal to the session:
+// there is no way to push back on a frame already delivered, and dropping it
+// silently would leave the stream with a hole RPC cannot resynchronise after.
+func (s *msgSession) reserveBuffered(n int) bool {
+	s.bufMu.Lock()
+	defer s.bufMu.Unlock()
+
+	if s.buffered+n > s.maxBuffered {
+		return false
+	}
+	s.buffered += n
+	return true
+}
+
+// releaseBuffered gives back what a reader took, or what died with a stream.
+func (s *msgSession) releaseBuffered(n int) {
+	if n == 0 {
+		return
+	}
+	s.bufMu.Lock()
+	defer s.bufMu.Unlock()
+	s.buffered -= n
+}
+
 func (s *msgSession) removeStream(id uint32) {
 	s.mu.Lock()
+	st := s.streams[id]
 	delete(s.streams, id)
 	s.mu.Unlock()
+
+	// Whatever this stream still held is gone with it. Without this the
+	// session's total only ever climbs, and a long-lived connection running
+	// many short operations would eventually trip a limit while holding
+	// nothing at all.
+	if st != nil {
+		st.discardBuffered()
+	}
 }
 
 func (s *msgSession) readPump() {
@@ -202,7 +266,13 @@ func (s *msgSession) handleFrame(f msgFrame) {
 	}
 
 	if f.Flags&(flagDATA|flagFIN) != 0 {
-		st.feed(f.Data, f.Flags&flagFIN != 0)
+		if !st.feed(f.Data, f.Flags&flagFIN != 0) {
+			// The whole session goes, not just this stream. The peer has put
+			// more unread data on us than the session may hold, and the only
+			// lever left is to stop reading from it entirely.
+			s.shutdown(errSessionOverBuffered)
+			return
+		}
 	}
 
 	if f.Flags&flagFIN != 0 {
@@ -257,6 +327,11 @@ type msgStream struct {
 	remoteClosed bool
 	readErr      error
 	canceled     bool
+	// buffered is what this stream currently accounts for in the session's
+	// total. Tracked per stream so releasing is idempotent by construction:
+	// bytes leave through a read or through teardown, and either way the count
+	// they are subtracted from is the same one they were added to.
+	buffered int
 
 	wmu         sync.Mutex
 	synSent     bool
@@ -267,16 +342,40 @@ type msgStream struct {
 	writeErr error
 }
 
-func (st *msgStream) feed(data []byte, fin bool) {
+// feed hands delivered bytes to the stream's reader, and reports whether the
+// session had room for them. A false return means the session is over its
+// buffered-data ceiling; the caller tears it down rather than proceeding,
+// because a frame that cannot be buffered also cannot be refused after the
+// fact.
+func (st *msgStream) feed(data []byte, fin bool) bool {
+	if len(data) > 0 && !st.sess.reserveBuffered(len(data)) {
+		return false
+	}
+
 	st.readMu.Lock()
 	if len(data) > 0 {
 		st.buf.Write(data)
+		st.buffered += len(data)
 	}
 	if fin {
 		st.remoteClosed = true
 	}
 	st.readCond.Broadcast()
 	st.readMu.Unlock()
+
+	return true
+}
+
+// discardBuffered releases everything this stream still accounts for, for a
+// stream being dropped with data its reader will never take.
+func (st *msgStream) discardBuffered() {
+	st.readMu.Lock()
+	n := st.buffered
+	st.buffered = 0
+	st.buf.Reset()
+	st.readMu.Unlock()
+
+	st.sess.releaseBuffered(n)
 }
 
 func (st *msgStream) fail(err error) {
@@ -302,21 +401,33 @@ func (st *msgStream) failWrite(err error) {
 
 func (st *msgStream) Read(p []byte) (int, error) {
 	st.readMu.Lock()
-	defer st.readMu.Unlock()
 
 	for st.buf.Len() == 0 {
 		switch {
 		case st.canceled:
+			st.readMu.Unlock()
 			return 0, errStreamCancel
 		case st.buf.Len() == 0 && st.readErr != nil:
-			return 0, st.readErr
+			err := st.readErr
+			st.readMu.Unlock()
+			return 0, err
 		case st.remoteClosed:
+			st.readMu.Unlock()
 			return 0, io.EOF
 		}
 		st.readCond.Wait()
 	}
 
-	return st.buf.Read(p)
+	n, err := st.buf.Read(p)
+	st.buffered -= n
+	st.readMu.Unlock()
+
+	// Released outside readMu: the session's own lock is the inner one on the
+	// feed path too, and taking them in one order everywhere is what keeps
+	// that true.
+	st.sess.releaseBuffered(n)
+
+	return n, err
 }
 
 func (st *msgStream) Write(p []byte) (int, error) {

--- a/pkg/rpc/msgmux_test.go
+++ b/pkg/rpc/msgmux_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -24,8 +25,8 @@ func TestMsgMux(t *testing.T) {
 		ctx := t.Context()
 
 		ca, cb := newMemPipe()
-		client := newMsgSession(ca, true, 0)
-		server := newMsgSession(cb, false, 0)
+		client := newMsgSession(ca, true, 0, 0)
+		server := newMsgSession(cb, false, 0, 0)
 
 		st, err := client.OpenStreamSync(ctx)
 		r.NoError(err)
@@ -52,8 +53,8 @@ func TestMsgMux(t *testing.T) {
 		ctx := t.Context()
 
 		ca, cb := newMemPipe()
-		client := newMsgSession(ca, true, 0)
-		server := newMsgSession(cb, false, 0)
+		client := newMsgSession(ca, true, 0, 0)
+		server := newMsgSession(cb, false, 0, 0)
 
 		// server-initiated stream
 		ss, err := server.OpenStreamSync(ctx)
@@ -74,8 +75,8 @@ func TestMsgMux(t *testing.T) {
 		ctx := t.Context()
 
 		ca, cb := newMemPipe()
-		client := newMsgSession(ca, true, 0)
-		server := newMsgSession(cb, false, 0)
+		client := newMsgSession(ca, true, 0, 0)
+		server := newMsgSession(cb, false, 0, 0)
 
 		st, err := client.OpenStreamSync(ctx)
 		r.NoError(err)
@@ -100,8 +101,8 @@ func TestMsgMux(t *testing.T) {
 		ctx := t.Context()
 
 		ca, cb := newMemPipe()
-		client := newMsgSession(ca, true, 0)
-		server := newMsgSession(cb, false, 0)
+		client := newMsgSession(ca, true, 0, 0)
+		server := newMsgSession(cb, false, 0, 0)
 
 		// Server echoes each accepted stream.
 		go func() {
@@ -144,8 +145,8 @@ func TestMsgMux(t *testing.T) {
 		ctx := t.Context()
 
 		ca, cb := newMemPipe()
-		client := newMsgSession(ca, true, 0)
-		server := newMsgSession(cb, false, 0)
+		client := newMsgSession(ca, true, 0, 0)
+		server := newMsgSession(cb, false, 0, 0)
 
 		st, err := client.OpenStreamSync(ctx)
 		r.NoError(err)
@@ -173,8 +174,8 @@ func TestMsgMux(t *testing.T) {
 		ctx := t.Context()
 
 		ca, cb := newMemPipe()
-		client := newMsgSession(ca, true, 0)
-		server := newMsgSession(cb, false, 0)
+		client := newMsgSession(ca, true, 0, 0)
+		server := newMsgSession(cb, false, 0, 0)
 
 		big := make([]byte, defaultMaxFrameData*2+1234)
 		for i := range big {
@@ -192,6 +193,61 @@ func TestMsgMux(t *testing.T) {
 		got, err := io.ReadAll(ss)
 		r.NoError(err)
 		r.Equal(big, got)
+
+		client.Close()
+		server.Close()
+	})
+
+	// A peer that sends and never reads must not be able to make the session
+	// hold unbounded memory. The transport's backpressure stops once a frame is
+	// delivered, so without a ceiling here a caller can keep one stream open,
+	// send faster than the handler consumes, and grow the read buffer for as
+	// long as it likes — which is what made the relay's advertised per-session
+	// limit describe only one of the two places a frame waits.
+	t.Run("a stream held open past the limit ends the session", func(t *testing.T) {
+		r := require.New(t)
+		ctx := t.Context()
+
+		const limit = 256 << 10
+
+		ca, cb := newMemPipe()
+		client := newMsgSession(ca, true, 0, 0)
+		server := newMsgSession(cb, false, 0, limit)
+
+		st, err := client.OpenStreamSync(ctx)
+		r.NoError(err)
+
+		// Nothing ever reads srvStream, which is the whole point: these bytes
+		// pile up in its read buffer with no handler taking them.
+		_, err = server.AcceptStream(ctx)
+		r.NoError(err)
+
+		// In a goroutine because the writer is expected to be abandoned
+		// mid-flight: the far end stops reading when it tears down, so a write
+		// may block rather than return, and that is the correct behaviour to
+		// leave running rather than to wait on.
+		go func() {
+			chunk := make([]byte, 16<<10)
+			for range (limit * 8) / len(chunk) {
+				if _, err := st.Write(chunk); err != nil {
+					return
+				}
+			}
+		}()
+
+		// The assertion is on the receiving session, since that is the side
+		// holding the memory and the side that has to act.
+		select {
+		case <-server.done:
+		case <-time.After(10 * time.Second):
+			r.Fail("the session went on buffering unread data past its ceiling")
+		}
+
+		server.mu.Lock()
+		closeErr := server.closeErr
+		server.mu.Unlock()
+		r.ErrorIs(closeErr, errSessionOverBuffered,
+			"the session ended, but not for the reason under test")
 
 		client.Close()
 		server.Close()

--- a/pkg/rpc/rest.go
+++ b/pkg/rpc/rest.go
@@ -152,7 +152,7 @@ func restAuthorize(w http.ResponseWriter, r *http.Request, m Method, st *State) 
 	identity := IdentityFromContext(ctx)
 	if identity == nil {
 		if st != nil {
-			logAccess(ctx, st.audit(), r, m, "unauthorized")
+			logAccess(ctx, st.audit(), r.RemoteAddr, m, "unauthorized")
 		}
 		writeRESTStatus(w, http.StatusUnauthorized, restErrorBody{
 			Error: "authentication required",
@@ -166,7 +166,7 @@ func restAuthorize(w http.ResponseWriter, r *http.Request, m Method, st *State) 
 		action := strings.ToLower(m.Name)
 
 		if err := st.authorizer.Authorize(ctx, identity, resource, action); err != nil {
-			logAccess(ctx, st.audit(), r, m, "forbidden", "error", err)
+			logAccess(ctx, st.audit(), r.RemoteAddr, m, "forbidden", "error", err)
 			writeRESTStatus(w, http.StatusForbidden, restErrorBody{
 				Error: err.Error(),
 				Code:  "forbidden",
@@ -176,7 +176,7 @@ func restAuthorize(w http.ResponseWriter, r *http.Request, m Method, st *State) 
 	}
 
 	if st != nil {
-		logAccess(ctx, st.audit(), r, m, "ok")
+		logAccess(ctx, st.audit(), r.RemoteAddr, m, "ok")
 	}
 
 	return true

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -975,20 +975,20 @@ func (s *Server) authRequest(r *http.Request, w http.ResponseWriter, oid OID) (e
 	ts := r.Header.Get("rpc-timestamp")
 
 	if ts == "" {
-		logAuthReject(s.state.audit(), r, oid, "no timestamp provided")
+		logAuthReject(s.state.audit(), r.RemoteAddr, oid, "no timestamp provided")
 		http.Error(w, "no timestamp provided", http.StatusForbidden)
 		return nil, false
 	}
 
 	if err := freshTimestamp(ts); err != nil {
-		logAuthReject(s.state.audit(), r, oid, err.Error())
+		logAuthReject(s.state.audit(), r.RemoteAddr, oid, err.Error())
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return nil, false
 	}
 
 	sign := r.Header.Get("rpc-signature")
 	if sign == "" {
-		logAuthReject(s.state.audit(), r, oid, "no signature provided")
+		logAuthReject(s.state.audit(), r.RemoteAddr, oid, "no signature provided")
 		http.Error(w, "no signature provided", http.StatusForbidden)
 		return nil, false
 	}
@@ -1005,7 +1005,7 @@ func (s *Server) authRequest(r *http.Request, w http.ResponseWriter, oid OID) (e
 	}
 
 	if err := verifyString(capa.pub, httpCanonical(r.Method, r.URL.Path, ts), sign); err != nil {
-		logAuthReject(s.state.audit(), r, oid, err.Error())
+		logAuthReject(s.state.audit(), r.RemoteAddr, oid, err.Error())
 		http.Error(w, "failed to verify signature", http.StatusForbidden)
 		return nil, false
 	}
@@ -1101,7 +1101,7 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 	if !mm.Public {
 		identity := IdentityFromContext(ctx)
 		if identity == nil {
-			logAccess(ctx, s.state.audit(), r, mm, "unauthorized")
+			logAccess(ctx, s.state.audit(), r.RemoteAddr, mm, "unauthorized")
 			w.Header().Add("rpc-status", "unauthorized")
 			w.Header().Add("rpc-error", "authentication required")
 			w.WriteHeader(http.StatusUnauthorized)
@@ -1113,7 +1113,7 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 			resource := strings.ToLower(mm.InterfaceName)
 			action := strings.ToLower(mm.Name)
 			if err := s.state.authorizer.Authorize(ctx, identity, resource, action); err != nil {
-				logAccess(ctx, s.state.audit(), r, mm, "forbidden", "error", err)
+				logAccess(ctx, s.state.audit(), r.RemoteAddr, mm, "forbidden", "error", err)
 				w.Header().Add("rpc-status", "forbidden")
 				w.Header().Add("rpc-error", err.Error())
 				w.WriteHeader(http.StatusForbidden)
@@ -1121,7 +1121,7 @@ func (s *Server) startCallStream(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		logAccess(ctx, s.state.audit(), r, mm, "ok")
+		logAccess(ctx, s.state.audit(), r.RemoteAddr, mm, "ok")
 	}
 
 	ctx = Propagator().Extract(ctx, propagation.HeaderCarrier(r.Header))
@@ -1261,7 +1261,7 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 		if !mm.Public {
 			identity := IdentityFromContext(ctx)
 			if identity == nil {
-				logAccess(ctx, s.state.audit(), r, mm, "unauthorized")
+				logAccess(ctx, s.state.audit(), r.RemoteAddr, mm, "unauthorized")
 				w.Header().Add("rpc-status", "unauthorized")
 				w.Header().Add("rpc-error", "authentication required")
 				w.WriteHeader(http.StatusUnauthorized)
@@ -1273,7 +1273,7 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 				resource := strings.ToLower(mm.InterfaceName)
 				action := strings.ToLower(mm.Name)
 				if err := s.state.authorizer.Authorize(ctx, identity, resource, action); err != nil {
-					logAccess(ctx, s.state.audit(), r, mm, "forbidden", "error", err)
+					logAccess(ctx, s.state.audit(), r.RemoteAddr, mm, "forbidden", "error", err)
 					w.Header().Add("rpc-status", "forbidden")
 					w.Header().Add("rpc-error", err.Error())
 					w.WriteHeader(http.StatusForbidden)
@@ -1281,7 +1281,7 @@ func (s *Server) handleCalls(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			logAccess(ctx, s.state.audit(), r, mm, "ok")
+			logAccess(ctx, s.state.audit(), r.RemoteAddr, mm, "ok")
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/pkg/rpc/server_session.go
+++ b/pkg/rpc/server_session.go
@@ -369,6 +369,9 @@ func (s *Server) prepareMethodCall(ctx context.Context, req opRequest) (context.
 		// A token was presented but did not authenticate. Fail closed rather
 		// than silently downgrading to the capability identity, which would let
 		// a forged or expired token still execute.
+		if !mm.Public {
+			logAccess(ctx, s.state.audit(), msgRemoteFromContext(ctx), mm, "unauthorized")
+		}
 		return ctx, nil, Method{}, nil, opReply{Status: "forbidden", Error: "invalid bearer token"}, false
 	}
 	ctx = ContextWithIdentity(ctx, identity)
@@ -377,14 +380,23 @@ func (s *Server) prepareMethodCall(ctx context.Context, req opRequest) (context.
 		ctx = Propagator().Extract(ctx, propagation.MapCarrier(req.Trace))
 	}
 
-	if !mm.Public && s.state.authorizer != nil {
-		resource := strings.ToLower(mm.InterfaceName)
-		action := strings.ToLower(mm.Name)
-		if err := s.state.authorizer.Authorize(ctx, identity, resource, action); err != nil {
-			s.state.log.Warn("authorization denied",
-				"resource", resource, "action", action, "subject", identity.Subject, "error", err)
-			return ctx, nil, Method{}, nil, opReply{Status: "forbidden", Error: err.Error()}, false
+	// Audited on the same terms as the HTTP path: non-public methods only, both
+	// outcomes. Calls arriving this way were previously absent from the trail
+	// entirely, which is the wrong gap to have — a cloud-routed call is exactly
+	// the one an operator wants a record of.
+	if !mm.Public {
+		if s.state.authorizer != nil {
+			resource := strings.ToLower(mm.InterfaceName)
+			action := strings.ToLower(mm.Name)
+			if err := s.state.authorizer.Authorize(ctx, identity, resource, action); err != nil {
+				s.state.log.Warn("authorization denied",
+					"resource", resource, "action", action, "subject", identity.Subject, "error", err)
+				logAccess(ctx, s.state.audit(), msgRemoteFromContext(ctx), mm, "forbidden", "error", err)
+				return ctx, nil, Method{}, nil, opReply{Status: "forbidden", Error: err.Error()}, false
+			}
 		}
+
+		logAccess(ctx, s.state.audit(), msgRemoteFromContext(ctx), mm, "ok")
 	}
 
 	return ctx, iface, mm, iface.pub, opReply{}, true

--- a/pkg/rpc/server_session.go
+++ b/pkg/rpc/server_session.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ed25519"
 	"fmt"
 	"runtime/debug"
-	"sort"
 	"strings"
 
 	"github.com/fxamacker/cbor/v2"
@@ -181,12 +180,12 @@ func (s *Server) msgMethods(enc *cbor.Encoder, req opRequest) {
 		return
 	}
 
-	methods := make([]string, 0, len(hc.methods))
-	for name := range hc.methods {
-		methods = append(methods, name)
-	}
-	sort.Strings(methods)
-	writeReply(enc, opReply{Status: "ok"}, methodsResponse{Methods: methods})
+	// The same builder the HTTP endpoint uses, rather than a second one here.
+	// This path used to assemble the method names alone, which left Params
+	// empty on every reply — and a nil Params means "this server is too old to
+	// report parameters," not "these methods take none." A client reached this
+	// way then declined features the cluster in fact supports.
+	writeReply(enc, opReply{Status: "ok"}, newMethodsResponse(hc.methods))
 }
 
 func (s *Server) msgReresolve(dec *cbor.Decoder, enc *cbor.Encoder, req opRequest) {

--- a/pkg/rpc/server_session_auth_internal_test.go
+++ b/pkg/rpc/server_session_auth_internal_test.go
@@ -1,0 +1,151 @@
+package rpc
+
+import (
+	"context"
+	"crypto/ed25519"
+	"testing"
+	"time"
+)
+
+// signatureTestInterface is a minimal exposed interface with one non-public
+// method. Built by hand rather than generated because this file is inside
+// package rpc, which the generated example package imports.
+func signatureTestInterface(ran *bool) *Interface {
+	return &Interface{
+		name: "Meter",
+		methods: map[string]Method{
+			"readTemperature": {
+				Name:          "readTemperature",
+				InterfaceName: "Meter",
+				Handler: func(ctx context.Context, call Call) error {
+					*ran = true
+					return nil
+				},
+			},
+		},
+	}
+}
+
+// The capability signature is what proves the caller holds the capability it is
+// invoking. On a message transport it is the only such proof available — there
+// is no TLS client certificate to fall back on — so a request whose signature
+// does not verify must be refused before anything is dispatched.
+//
+// This matters more on the cloud-routed path than anywhere else: those frames
+// arrive from a relay rather than from the caller's own socket, so the
+// signature and the bearer inside them are the entire basis for trusting them.
+// Nothing about arriving over the uplink grants a request anything.
+func TestPrepareMethodCallRequiresAValidSignature(t *testing.T) {
+	ctx := context.Background()
+
+	state, err := NewState(ctx, WithSkipVerify)
+	if err != nil {
+		t.Fatalf("failed to build state: %v", err)
+	}
+	srv := state.Server()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate a key: %v", err)
+	}
+
+	var ran bool
+	hc := &heldCapability{
+		heldInterface: &heldInterface{Interface: signatureTestInterface(&ran)},
+		pub:           pub,
+	}
+
+	const oid = OID("cap-under-test")
+	srv.mu.Lock()
+	srv.objects[oid] = hc
+	srv.mu.Unlock()
+
+	req := func(sign ed25519.PrivateKey) opRequest {
+		ts := time.Now().UTC().Format(time.RFC3339Nano)
+		r := opRequest{
+			Op:        "call",
+			OID:       oid,
+			Method:    "readTemperature",
+			Timestamp: ts,
+		}
+		r.Signature = signBytes(sign, msgCanonical(r.Op, string(oid)+"/"+r.Method, ts))
+		return r
+	}
+
+	// Positive control. Without it, a test that refused everything would look
+	// identical to one enforcing the signature correctly.
+	if _, _, _, _, reply, ok := srv.prepareMethodCall(ctx, req(priv)); !ok {
+		t.Fatalf("a correctly signed request was refused: %s", reply.Error)
+	}
+
+	// Signed by a key the capability was not issued to: the shape a relay or
+	// anyone else on the path would produce trying to author a call.
+	_, wrongPriv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate a second key: %v", err)
+	}
+
+	_, _, _, _, reply, ok := srv.prepareMethodCall(ctx, req(wrongPriv))
+	if ok {
+		t.Fatal("a request signed by the wrong key was accepted")
+	}
+	if reply.Error != "failed to verify signature" {
+		t.Errorf("reply.Error = %q, want the signature failure", reply.Error)
+	}
+
+	// A tampered signature on an otherwise valid request.
+	tampered := req(priv)
+	tampered.Signature[0] ^= 0xff
+
+	if _, _, _, _, _, ok := srv.prepareMethodCall(ctx, tampered); ok {
+		t.Fatal("a request with a tampered signature was accepted")
+	}
+
+	// A request carrying no signature at all.
+	unsigned := req(priv)
+	unsigned.Signature = nil
+
+	if _, _, _, _, _, ok := srv.prepareMethodCall(ctx, unsigned); ok {
+		t.Fatal("an unsigned request was accepted")
+	}
+
+	// prepareMethodCall only authorizes; it never dispatches. Asserted so the
+	// refusals above cannot be confused with a handler that ran and failed.
+	if ran {
+		t.Error("the handler ran during authorization")
+	}
+}
+
+// A stale timestamp is refused too: a signature stays valid forever otherwise,
+// so a captured frame could be replayed by anyone who saw it go past.
+func TestPrepareMethodCallRefusesAStaleRequest(t *testing.T) {
+	ctx := context.Background()
+
+	state, err := NewState(ctx, WithSkipVerify)
+	if err != nil {
+		t.Fatalf("failed to build state: %v", err)
+	}
+	srv := state.Server()
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate a key: %v", err)
+	}
+
+	const oid = OID("cap-stale")
+	srv.mu.Lock()
+	var ran bool
+	srv.objects[oid] = &heldCapability{
+		heldInterface: &heldInterface{Interface: signatureTestInterface(&ran)},
+		pub:           pub,
+	}
+	srv.mu.Unlock()
+
+	ts := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339Nano)
+	r := opRequest{Op: "call", OID: oid, Method: "readTemperature", Timestamp: ts}
+	r.Signature = signBytes(priv, msgCanonical(r.Op, string(oid)+"/"+r.Method, ts))
+
+	if _, _, _, _, _, ok := srv.prepareMethodCall(ctx, r); ok {
+		t.Fatal("a request with a day-old timestamp was accepted")
+	}
+}

--- a/pkg/rpc/state.go
+++ b/pkg/rpc/state.go
@@ -236,7 +236,8 @@ func WithBindAddr(addr string) StateOption {
 // WithWSBindAddr enables an additional TCP listener serving the RPC protocol
 // over TLS as a WebSocket message session, bound to addr. Use "host:0" to bind
 // an ephemeral port; the chosen address is available via State.WSListenAddr
-// after NewState returns. Clients reach it with State.Connect("ws://host:port").
+// after NewState returns. Clients reach it with State.Connect("wss://host:port")
+// — this listener is TLS, so "ws://", which means plaintext, will not reach it.
 func WithWSBindAddr(addr string) StateOption {
 	return func(o *stateOptions) {
 		o.wsBindAddr = addr

--- a/pkg/rpc/transport_msg.go
+++ b/pkg/rpc/transport_msg.go
@@ -177,12 +177,27 @@ func nowStamp() string {
 	return time.Now().Format(time.RFC3339Nano)
 }
 
-// bearer returns the configured bearer token, which rides in the operation
-// frame rather than an Authorization header on this transport.
+// bearer returns the configured bearer token. On this transport it rides in the
+// operation frame rather than an Authorization header, but which token to send
+// is the same question the HTTP path asks, so both resolve it here.
+//
+// A per-request func takes precedence over a static token, and a func that fails
+// yields no token at all: the request goes unauthenticated and the server
+// rejects it, so the caller's retry picks up a token that has since been
+// refreshed. Failing hard here would deny that retry the chance.
 func (c *NetworkClient) bearer() string {
 	if c.State == nil || c.State.opts == nil {
 		return ""
 	}
+
+	if fn := c.State.opts.bearerTokenFunc; fn != nil {
+		token, err := fn()
+		if err != nil {
+			return ""
+		}
+		return token
+	}
+
 	return c.State.opts.bearerToken
 }
 

--- a/pkg/rpc/transport_msg.go
+++ b/pkg/rpc/transport_msg.go
@@ -49,7 +49,7 @@ func (t *msgOpTransport) controlSession(ctx context.Context) (rpcSession, error)
 	if err != nil {
 		return nil, err
 	}
-	t.ctrlSess = newMsgSession(conn, true, 0)
+	t.ctrlSess = newMsgSession(conn, true, 0, 0)
 	// A connection this transport dialed lives as long as the State does.
 	t.startAcceptLoop(t.owner.State.top, t.ctrlSess)
 	return t.ctrlSess, nil

--- a/pkg/uplink/client.go
+++ b/pkg/uplink/client.go
@@ -19,7 +19,11 @@ import (
 )
 
 const (
-	outboxSize     = 64
+	// outboxSize is deep enough that a tenant using SendContext to apply
+	// backpressure does not immediately push the best-effort tenants over their
+	// drop threshold. The two coexist in one queue: a blocked sender waits for
+	// room, while Send discards as soon as there is none.
+	outboxSize     = 256
 	initialBackoff = 1 * time.Second
 	maxBackoff     = 60 * time.Second
 	wsEndpoint     = "/api/v1/cluster-channel/ws"
@@ -37,6 +41,17 @@ const (
 	// Subtracting rather than adding matters: it keeps the delay bounded by the
 	// backoff schedule instead of letting the worst case drift past maxBackoff.
 	backoffJitter = 0.3
+
+	// readLimit is the largest inbound message we accept. coder/websocket
+	// defaults to 32 KiB, which is ample for coordination messages but far too
+	// small for a tenant tunnelling bulk payloads through an envelope.
+	//
+	// The size is set by the worst case such a tenant can face rather than by
+	// anything this package does: a payload it did not choose the framing for,
+	// base64'd into JSON, which costs a third again. 2 MiB leaves room for a
+	// peer framing at pkg/rpc's 1 MiB default and still keeps a bound on what an
+	// untrusted sender can make us buffer.
+	readLimit = 2 << 20
 )
 
 // Client maintains a persistent WebSocket connection to the cloud
@@ -187,6 +202,26 @@ func (c *Client) Send(env *Envelope) {
 	case c.outbox <- env:
 	default:
 		c.log.Warn("outbox full, dropping message", "type", env.Type)
+	}
+}
+
+// SendContext queues an envelope and waits for room rather than dropping, for
+// a tenant that cannot treat loss as a self-healing condition. The best-effort
+// Send above remains the right call for state a later report repairs; this one
+// is for a stream whose gap nothing downstream can reconstruct.
+//
+// What it promises is narrow: the envelope reached the outbox of the connection
+// live at the time, so it will be written unless that connection dies first. It
+// is not an acknowledgement, and a reconnect discards whatever is still queued
+// (see drainOutbox). A tenant that needs more than "delivered or the link
+// broke" has to notice the break — which, for anything session-shaped, means
+// tearing the session down and letting the caller retry.
+func (c *Client) SendContext(ctx context.Context, env *Envelope) error {
+	select {
+	case c.outbox <- env:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -369,6 +404,8 @@ func (c *Client) connect(ctx context.Context) (*websocket.Conn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", wsURL, err)
 	}
+
+	conn.SetReadLimit(readLimit)
 
 	c.log.Info("connected to cloud")
 	return conn, nil

--- a/pkg/uplink/client.go
+++ b/pkg/uplink/client.go
@@ -217,6 +217,17 @@ func (c *Client) Send(env *Envelope) {
 // broke" has to notice the break — which, for anything session-shaped, means
 // tearing the session down and letting the caller retry.
 func (c *Client) SendContext(ctx context.Context, env *Envelope) error {
+	// Checked before the select for the same reason SendBlocking does it: with
+	// outbox room and a dead context both cases are ready, and Go picks between
+	// them at random. Here the stake is a relayed session — a sender that
+	// straddles a reconnect could land an rpc.data frame from an ended session
+	// on the *new* connection, which cloud may still route by session id. That
+	// is precisely the resume-across-a-link-break this transport promises not
+	// to do.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	select {
 	case c.outbox <- env:
 		return nil

--- a/pkg/uplink/client_test.go
+++ b/pkg/uplink/client_test.go
@@ -511,6 +511,33 @@ func TestSendBlockingRefusesADeadContextEvenWithRoom(t *testing.T) {
 	}
 }
 
+// SendContext carries relayed RPC frames, where landing one late is worse than
+// dropping it: a frame from an ended session that reaches the outbox after a
+// reconnect goes out on the new connection, and cloud may still route it by
+// session id. That is the resume-across-a-link-break the transport promises not
+// to do, so the cancellation has to win deterministically.
+func TestSendContextRefusesADeadContextEvenWithRoom(t *testing.T) {
+	c := &Client{
+		log:    slog.Default(),
+		outbox: make(chan *Envelope, outboxSize),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Repeated for the same reason as the SendBlocking case above: with both
+	// select cases ready, one attempt passes half the time even unfixed.
+	for range 200 {
+		if err := c.SendContext(ctx, &Envelope{Type: "should-not-land"}); !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	}
+
+	if got := len(c.outbox); got != 0 {
+		t.Errorf("%d envelopes queued on a cancelled context, expected none", got)
+	}
+}
+
 // A response that unmarshals cleanly but carries no timestamps must not be
 // averaged into a nonsense offset and logged as a healthy sync. Same for an
 // org response naming no organization.

--- a/pkg/uplink/client_test.go
+++ b/pkg/uplink/client_test.go
@@ -539,3 +539,110 @@ func TestControlPlaneHandlersRejectEmptyPayloads(t *testing.T) {
 		t.Errorf("expected both incomplete payloads to warn, got %d warnings in:\n%s", got, out)
 	}
 }
+
+// SendContext waits for room instead of discarding, which is the whole
+// difference between it and Send. Both halves matter: it must block while the
+// outbox is full, and it must come back as soon as space appears.
+func TestSendContextWaitsForRoom(t *testing.T) {
+	c := &Client{
+		log:    slog.Default(),
+		outbox: make(chan *Envelope, 1),
+	}
+
+	if err := c.SendContext(t.Context(), &Envelope{Type: "first"}); err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+
+	full, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	if err := c.SendContext(full, &Envelope{Type: "second"}); err == nil {
+		t.Fatal("SendContext returned on a full outbox instead of waiting")
+	}
+
+	sent := make(chan error, 1)
+	go func() { sent <- c.SendContext(t.Context(), &Envelope{Type: "second"}) }()
+
+	if env := <-c.outbox; env.Type != "first" {
+		t.Fatalf("expected the first envelope to be queued, got %q", env.Type)
+	}
+
+	select {
+	case err := <-sent:
+		if err != nil {
+			t.Fatalf("second send: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SendContext did not proceed once the outbox drained")
+	}
+}
+
+// Send stays lossy on a full outbox. SendContext exists precisely because that
+// contract is wrong for some tenants, so it is worth pinning that adding one
+// did not quietly change the other.
+func TestSendStillDropsWhenFull(t *testing.T) {
+	c := &Client{
+		log:    slog.Default(),
+		outbox: make(chan *Envelope, 1),
+	}
+
+	c.Send(&Envelope{Type: "first"})
+	c.Send(&Envelope{Type: "dropped"})
+
+	if env := <-c.outbox; env.Type != "first" {
+		t.Fatalf("expected the first envelope to survive, got %q", env.Type)
+	}
+	select {
+	case env := <-c.outbox:
+		t.Fatalf("expected the second envelope to be dropped, got %q", env.Type)
+	default:
+	}
+}
+
+// coder/websocket caps reads at 32 KiB unless told otherwise, which would make
+// a tenant tunnelling bulk payloads fail at a size nothing in this package
+// names. The ceiling is ours, so prove a message well past the default arrives.
+func TestClientAcceptsLargeMessages(t *testing.T) {
+	const payload = 64 * 1024
+
+	received := make(chan int, 1)
+	router := NewMessageRouter()
+	router.Handle("test.large", func(_ context.Context, data json.RawMessage) error {
+		received <- len(data)
+		return nil
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+
+		body, err := json.Marshal(strings.Repeat("x", payload))
+		if err != nil {
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, &Envelope{Type: "test.large", Data: body}); err != nil {
+			return
+		}
+
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test-token", router)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go client.Run(ctx) //nolint:errcheck
+
+	select {
+	case n := <-received:
+		if n < payload {
+			t.Fatalf("payload arrived truncated: got %d bytes, want at least %d", n, payload)
+		}
+	case <-ctx.Done():
+		t.Fatal("large message never arrived; the read limit is probably still the default")
+	}
+}


### PR DESCRIPTION
Today `miren` reaches a cluster by dialing it, which quietly assumes you have a route to it. A cluster behind NAT can accept nothing, so an operator without a path to it cannot run a single command, even though the cluster is sitting there holding an authenticated WebSocket up to cloud that it dialed outbound. This turns that link into a way in.

The other half of the setup already landed: `pkg/rpc` grew a message transport that runs the whole RPC protocol over any pipe of discrete byte messages, explicitly including "a socket carrying somebody else's envelope protocol". The uplink is exactly that, so `pkg/cloudrpc` becomes a tenant of it in the same shape as Miren Anywhere, and each relayed session turns into an `rpc.MessageConn` carrying ordinary RPC frames.

The part worth being precise about is authentication, because the detour changes nothing. The caller's own bearer rides inside every operation frame and is judged by the cluster's existing authenticator and RBAC, exactly as on a direct connection. Cloud never sees that token, it is inside a CBOR frame cloud does not parse, so cloud is a byte relay and vouches for nothing. The copy on the WebSocket handshake exists only so cloud can decide whether to carry the traffic at all.

Three supporting changes fell out. The uplink capped reads at coder/websocket's 32 KiB default and dropped on a full outbox, both of which are right for telemetry that self-heals and fatal for RPC, which cannot resynchronise after a hole. `ws://` meant TLS, the same as `wss://`, and now means plaintext, which is what it says and what a local development cloud needs. And a `wss://` remote naming a path keeps it, so a remote can point at somebody else's endpoint instead of requiring that endpoint to mimic our route.

Clusters opt in with `miren cluster add --via-cloud`. A fallback from a failed direct dial would make every command wait out a timeout first and leave you unsure which path answered.

Two later commits are hardening from review: bounding what a session can hold (by bytes, since the peer picks the frame size), capping concurrent sessions, refusing to put credentials on an unencrypted socket outside loopback, and stopping a session refusal from stalling the link's shared read loop.

Needs mirendev/cloud#201 to answer. Without it these config entries have nothing to connect to.

Part of MIR-1580
