### PR TITLE
Let a route carry its own request timeout

### DIFF
--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
@@ -554,5 +555,50 @@ func (c *Client) DetachWAFProfileFromRoute(ctx context.Context, route *ingress_v
 	}
 
 	route.WafProfile = ""
+	return route, nil
+}
+
+// SetRouteRequestTimeout sets the per-route ingress request timeout override.
+// The timeout is stored as a duration string (e.g. "10m") and must parse to a
+// positive duration.
+func (c *Client) SetRouteRequestTimeout(ctx context.Context, route *ingress_v1alpha.HttpRoute, timeout string) (*ingress_v1alpha.HttpRoute, error) {
+	if route == nil {
+		return nil, fmt.Errorf("route is required")
+	}
+
+	d, err := time.ParseDuration(timeout)
+	if err != nil {
+		return nil, fmt.Errorf("invalid request timeout %q: %w", timeout, err)
+	}
+	if d <= 0 {
+		return nil, fmt.Errorf("request timeout must be positive, got %q", timeout)
+	}
+
+	err = c.ec.Patch(ctx, route.ID, 0,
+		entity.String(ingress_v1alpha.HttpRouteRequestTimeoutId, timeout),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set request timeout on route: %w", err)
+	}
+
+	route.RequestTimeout = timeout
+	return route, nil
+}
+
+// ClearRouteRequestTimeout removes the per-route timeout override, so the route
+// falls back to the server-wide http_request_timeout.
+func (c *Client) ClearRouteRequestTimeout(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
+	if route == nil {
+		return nil, fmt.Errorf("route is required")
+	}
+
+	err := c.ec.Patch(ctx, route.ID, 0,
+		entity.String(ingress_v1alpha.HttpRouteRequestTimeoutId, ""),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clear request timeout on route: %w", err)
+	}
+
+	route.RequestTimeout = ""
 	return route, nil
 }

--- a/api/ingress/client_test.go
+++ b/api/ingress/client_test.go
@@ -349,3 +349,83 @@ func TestValidateWildcardHost(t *testing.T) {
 		})
 	}
 }
+
+func TestRouteRequestTimeout(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+	client := &Client{
+		log: slog.Default(),
+		ec:  ec,
+		eac: inmem.EAC,
+	}
+
+	testAppID := entity.Id("test-app-timeout")
+	const host = "timeout.example.com"
+
+	_, err := client.SetRoute(ctx, host, testAppID)
+	require.NoError(t, err)
+
+	// SetRoute returns the struct it wrote, which has no entity ID; the helpers
+	// patch by ID, so work from a looked-up route.
+	route, err := client.Lookup(ctx, host)
+	require.NoError(t, err)
+	require.Empty(t, route.RequestTimeout, "a fresh route carries no override")
+
+	t.Run("SetAndOverwrite", func(t *testing.T) {
+		_, err := client.SetRouteRequestTimeout(ctx, route, "10m")
+		require.NoError(t, err)
+
+		got, err := client.Lookup(ctx, host)
+		require.NoError(t, err)
+		require.Equal(t, "10m", got.RequestTimeout)
+
+		_, err = client.SetRouteRequestTimeout(ctx, got, "300s")
+		require.NoError(t, err)
+
+		got, err = client.Lookup(ctx, host)
+		require.NoError(t, err)
+		require.Equal(t, "300s", got.RequestTimeout)
+	})
+
+	t.Run("RejectsInvalidDurations", func(t *testing.T) {
+		// Establish a known value rather than inheriting whatever an earlier
+		// subtest happened to leave behind.
+		_, err := client.SetRouteRequestTimeout(ctx, route, "45s")
+		require.NoError(t, err)
+
+		for _, bad := range []string{"10", "forever", "0s", "-5m"} {
+			_, err := client.SetRouteRequestTimeout(ctx, route, bad)
+			require.Error(t, err, "expected %q to be rejected", bad)
+		}
+
+		// The rejected writes must not have disturbed the stored value.
+		got, err := client.Lookup(ctx, host)
+		require.NoError(t, err)
+		require.Equal(t, "45s", got.RequestTimeout)
+	})
+
+	t.Run("ClearLeavesOtherFieldsIntact", func(t *testing.T) {
+		// Clearing an already-empty override would pass vacuously, so set one.
+		_, err := client.SetRouteRequestTimeout(ctx, route, "90s")
+		require.NoError(t, err)
+
+		withWAF, err := client.SetRouteWAFLevel(ctx, host, 2)
+		require.NoError(t, err)
+		require.NotEmpty(t, withWAF.WafProfile)
+		require.Equal(t, "90s", withWAF.RequestTimeout, "precondition: an override is in place")
+
+		_, err = client.ClearRouteRequestTimeout(ctx, withWAF)
+		require.NoError(t, err)
+
+		got, err := client.Lookup(ctx, host)
+		require.NoError(t, err)
+		require.Empty(t, got.RequestTimeout, "override should be gone")
+		require.Equal(t, withWAF.WafProfile, got.WafProfile, "clearing must not disturb the WAF profile")
+		require.Equal(t, testAppID, got.App)
+		require.Equal(t, host, got.Host)
+	})
+}

--- a/api/ingress/ingress_v1alpha/schema.gen.go
+++ b/api/ingress/ingress_v1alpha/schema.gen.go
@@ -6,22 +6,24 @@ import (
 )
 
 const (
-	HttpRouteAppId           = entity.Id("dev.miren.ingress/http_route.app")
-	HttpRouteAuthProviderId  = entity.Id("dev.miren.ingress/http_route.auth_provider")
-	HttpRouteClaimMappingsId = entity.Id("dev.miren.ingress/http_route.claim_mappings")
-	HttpRouteDefaultId       = entity.Id("dev.miren.ingress/http_route.default")
-	HttpRouteHostId          = entity.Id("dev.miren.ingress/http_route.host")
-	HttpRouteWafProfileId    = entity.Id("dev.miren.ingress/http_route.waf_profile")
+	HttpRouteAppId            = entity.Id("dev.miren.ingress/http_route.app")
+	HttpRouteAuthProviderId   = entity.Id("dev.miren.ingress/http_route.auth_provider")
+	HttpRouteClaimMappingsId  = entity.Id("dev.miren.ingress/http_route.claim_mappings")
+	HttpRouteDefaultId        = entity.Id("dev.miren.ingress/http_route.default")
+	HttpRouteHostId           = entity.Id("dev.miren.ingress/http_route.host")
+	HttpRouteRequestTimeoutId = entity.Id("dev.miren.ingress/http_route.request_timeout")
+	HttpRouteWafProfileId     = entity.Id("dev.miren.ingress/http_route.waf_profile")
 )
 
 type HttpRoute struct {
-	ID            entity.Id       `json:"id"`
-	App           entity.Id       `cbor:"app,omitempty" json:"app,omitempty"`
-	AuthProvider  entity.Id       `cbor:"auth_provider,omitempty" json:"auth_provider,omitempty"`
-	ClaimMappings []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
-	Default       bool            `cbor:"default,omitempty" json:"default,omitempty"`
-	Host          string          `cbor:"host,omitempty" json:"host,omitempty"`
-	WafProfile    entity.Id       `cbor:"waf_profile,omitempty" json:"waf_profile,omitempty"`
+	ID             entity.Id       `json:"id"`
+	App            entity.Id       `cbor:"app,omitempty" json:"app,omitempty"`
+	AuthProvider   entity.Id       `cbor:"auth_provider,omitempty" json:"auth_provider,omitempty"`
+	ClaimMappings  []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
+	Default        bool            `cbor:"default,omitempty" json:"default,omitempty"`
+	Host           string          `cbor:"host,omitempty" json:"host,omitempty"`
+	RequestTimeout string          `cbor:"request_timeout,omitempty" json:"request_timeout,omitempty"`
+	WafProfile     entity.Id       `cbor:"waf_profile,omitempty" json:"waf_profile,omitempty"`
 }
 
 func (o *HttpRoute) Decode(e entity.AttrGetter) {
@@ -44,6 +46,9 @@ func (o *HttpRoute) Decode(e entity.AttrGetter) {
 	}
 	if a, ok := e.Get(HttpRouteHostId); ok && a.Value.Kind() == entity.KindString {
 		o.Host = a.Value.String()
+	}
+	if a, ok := e.Get(HttpRouteRequestTimeoutId); ok && a.Value.Kind() == entity.KindString {
+		o.RequestTimeout = a.Value.String()
 	}
 	if a, ok := e.Get(HttpRouteWafProfileId); ok && a.Value.Kind() == entity.KindId {
 		o.WafProfile = a.Value.Id()
@@ -80,6 +85,9 @@ func (o *HttpRoute) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.Host) {
 		attrs = append(attrs, entity.String(HttpRouteHostId, o.Host))
 	}
+	if !entity.Empty(o.RequestTimeout) {
+		attrs = append(attrs, entity.String(HttpRouteRequestTimeoutId, o.RequestTimeout))
+	}
 	if !entity.Empty(o.WafProfile) {
 		attrs = append(attrs, entity.Ref(HttpRouteWafProfileId, o.WafProfile))
 	}
@@ -103,6 +111,9 @@ func (o *HttpRoute) Empty() bool {
 	if !entity.Empty(o.Host) {
 		return false
 	}
+	if !entity.Empty(o.RequestTimeout) {
+		return false
+	}
 	if !entity.Empty(o.WafProfile) {
 		return false
 	}
@@ -116,6 +127,7 @@ func (o *HttpRoute) InitSchema(sb *schema.SchemaBuilder) {
 	(&ClaimMappings{}).InitSchema(sb.Builder("http_route.claim_mappings"))
 	sb.Bool("default", "dev.miren.ingress/http_route.default", schema.Doc("Whether this is the default route for routing"), schema.Indexed)
 	sb.String("host", "dev.miren.ingress/http_route.host", schema.Doc("The hostname to match on for the application"), schema.Indexed)
+	sb.String("request_timeout", "dev.miren.ingress/http_route.request_timeout", schema.Doc("Per-route override for the ingress request timeout (e.g. \"10m\", \"300s\"). Empty falls back to the server's http_request_timeout (default 60s). Must be a positive duration; invalid or non-positive values are ignored at request time."))
 	sb.Ref("waf_profile", "dev.miren.ingress/http_route.waf_profile", schema.Doc("Reference to a WAF profile for request filtering"))
 }
 
@@ -412,5 +424,5 @@ func init() {
 		(&PasswordProvider{}).InitSchema(sb)
 		(&WafProfile{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x94\x96ے\xd30\f\x86_\x04\x86\xe3p&\xcc>\x91\xc7\x1b+\x89\xb6>\xad\xedv\xdbK\xb8\x80\aa\xe1\rᚉ\x9cnb;\x9b\x9a\x9b\x8e\xaaH\x9f,\xe5\xb7&\xf7Bs\x05\xb7\x02\x0e\x8dB\a\xbaA\xdd;\xf0\x1ev\xa8\x85\xbf?\xbe(\x9e|\x19\x9f4C\b\x969\xb3\x0f\xf0\x9b\b\xc7'e\xe0\x1c\x13i\x7f;a\x14G]V\xeb:\x04)\xfc\xf7\x9f\xd7(\x8eϷH\r\xb7\x96\n\xb6\xa3\x11N\x16\xaeQPڇ\xed\xb4}\x18\x98u\xe6\x80\x02\x1c\x01T\xea\x9aP\xbfF\xd4\xc7MT+9*\xa6\xb8\xb5\xa8{/\x14ק?D\xd4ٓ\x11\x89\xadQ\xd6h\xd0a\xb6\xa6\x89\x95U\x9aG\xabT\x0e\xf0\x1bM\xe2My\xfc\x94\x16\xe1t\n\x88\xe6x\xd4\xce\a\x87\xba'\xc4ۋ\x88\x01\xf8y\x92\xddd/ \xfd\x01\x9cG\xa3\xfb\xc3\x15\x97v\xe0\xd2:Tܝ\xd8؇\"ԙD\xf5^oN\\@\xc7\xf72P\xb1\xfe\xfcg\xac&\xae\x8d\x91\x04X\xd1\xe9\x020\x18\x1f\xb3\x05Yy\xb7\xef6\x93\xefx7ʤC\t\xc4\xd8-\x1d\x93l6\xfb\xbd\x99aǗ\x8fܧ\x05s\x92\xc7\xd32r\x11T)\x88\xaf\xd4ߧMTc\xb9\xe3\xda g\x12\x0e \xa3\x943\xdf\xd8f\x8b:l\xf6\xb9\x1c\xcc\xda\x1b\xa5F\r\x8a\xf6\xe1\xd6M\xad>+c\x93\xb0\xcaf\x7fP\xb3\xef/\xc0\x9aV\"\xe8\xc0PPq\x9c\xff\xe6\xb2\xf8\\I\xf2\xd0:\x88\xfaR\xa9+'\xae,\x96\x8cht\x87=\xbb\xf1FG\xad-\x1d9\xad\xa9\xa0ih\x83q\x8c.K\xdcQ\xa9/g\xae\xbc\xb6\x94I\xb7h\xfe\xc9\xf3W\xa4\x96\xe6\x9f\r\xb6wQj2\xf1伕]\x96\xf2|k,\xf8\xb8\x87&\xbbz\x0f%\xa4\xb5-@\x8a\xb5\xdc\xfb;\xe3D\xae\xdaWe|\x11\xfa_{{\xe5\x00\x05\xf0\xd2\xfc\xafj\x18\x0f\x9e\x81\xfb!\xea6u\xd5N\xf0\xb6`\xe7\xe1;?\x18\x17X\xfc\x9aX.\xc2\xcb\x1f\x16\xc9:\xa9؛\xd9\xeb\xacZ@e\x03\xf52\xf8\a\x00\x00\xff\xff\x01\x00\x00\xff\xff\xfc\xecL2;\t\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x94\x96ے\xdb \f\x86_\xa4\x9d\x1e\xa7纳O\xc4\x10#\xdb\xdap\n`or\xd9\xde\xf4A\xba\xed\x1b\xb6\xd7\x1d\x83\xb36\xe08\xe4&#\v\xf1\t\xc9?\x8a\x1f\x99\xa4\x02\x0e\f\x86J\xa0\x01Y\xa1l\rX\v{\x94\xcc>\x1e_e+\xdfƕ\xaasN\x13\xa3z\a\x7f<\xe1\xf8,\x0f\x9cc\x02\xed_Ô\xa0(\xf3lM\x83\xc0\x99\xfd\xf9k\x87\xec\xf8r\x8bTQ\xad}\xc2z4\xdcI\xc3\x0e\x99\xdf\xf6i{[\xef:\xa2\x8d\x1a\x90\x81\xf1\x00\x11\xbb&\xd4\xef\x11\xf5y\x13Us\x8a\x82\b\xaa5\xca\xd62A\xe5\xe9\xaf'\xcadeDb\xad\x84V\x12\xa4\x9b\xad\xa9cy\x96\xeab\x96\xc2\x06\xfe\xf0\x9dx\x97\x1f?\xa6\x05\xb8?\x05\x04s<jc\x9dA\xd9z\xc4\xfb\xab\x88\x0e蹓\xcdd/ \xed\x00Ƣ\x92\xedpG\xb9\xee(\xd7\x06\x055'2\xd6!<\xeaL\xf2\xf9\xdenv\x9cAC{\xee|\xb2\xf6\xfc0fc;\xa5\xb8\a\xac\xe8t\x01\xe8\x94\r\xbb\x99\xb7\xd2j\xbfln6p\xe8\xc1:\xe2P\x80\xea\x03G\xa5\xce\x14\xf9a\x13\xf9@\x9bQy\rr\xf0\xb8\xfd\xd21)q\xb3\x85\xf73\xec\xf8\xfa\xc2\x15]0'\xc5=\xcf#\x17A\x85\x1a\xfb~\xa9e\vT\xa5\xa9\xa1R!%\x1c\x06\xe0\xe1v$\xbe\xb1\xcc\x1a\xa5۬s٘5\x91\xf8B\x15\xb2\xfa\xe9\"O\xa5\xbe\xc8c\xa3\xb0\x9b&\xd2\xc7+\xb0\xaa\xe6\b\xd2\x11d>9Ώ\xa9,\xbe\x16\x92,\xd4\x06\x82\xd4D\xecJ\x89+\xb3*!*\xd9`K\ueb52AkKGJ\xab\nh\x12j\xa7\f\xf1\xf7/\x8c\xbdؗ2W^[\xcc\xf4\x17s\xfe)\xb8\x9d\xf1\xfe\xb3Az\x13\xa4\xc6#O\xca[\x19\x8f1\xcf\xd6J\x83\r\xa3m\xb2\x8bG[DZ\x9b\x02^\xb1\x9aZ\xfb\xa0\fKU\xfb&\x8f\xcfBo\xfa+X9@\x06\xbc\xd6\xff\xbb\x12Ɠ\xa7\xa3\xb6\v\xba\x8d]\xa5\x1d<d\xec4|o;e\x1c\t\x1f(\xcbAx\xfd[%\x1a'\x05s3y\x9dE\x03(/\xa0\\\x06\xff\x01\x00\x00\xff\xff\x01\x00\x00\xff\xff\x1c\x06\xbc\xb1\x8e\t\x00\x00"))
 }

--- a/api/ingress/schema.yml
+++ b/api/ingress/schema.yml
@@ -15,6 +15,9 @@ kinds:
       type: bool
       indexed: true
       doc: Whether this is the default route for routing
+    request_timeout:
+      type: string
+      doc: Per-route override for the ingress request timeout (e.g. "10m", "300s"). Empty falls back to the server's http_request_timeout (default 60s). Must be a positive duration; invalid or non-positive values are ignored at request time.
     waf_profile:
       type: ref
       doc: Reference to a WAF profile for request filtering

--- a/blackbox/route_timeout_test.go
+++ b/blackbox/route_timeout_test.go
@@ -1,0 +1,95 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"encoding/json"
+	"testing"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+func TestRouteTimeoutSetShowClear(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+
+	host := name + ".timeout.test.local"
+
+	m.MustRun("route", "set", host, name).RequireSuccess(t)
+
+	// No override to begin with
+	r := m.MustRun("route", "timeout", host)
+	r.RequireSuccess(t)
+	r.RequireContains(t, "server default")
+
+	// Set an override
+	r = m.MustRun("route", "timeout", host, "10m")
+	r.RequireSuccess(t)
+	r.RequireContains(t, "10m")
+
+	// It shows up on the route
+	r = m.MustRun("route", "show", host)
+	r.RequireSuccess(t)
+	r.RequireContains(t, "10m")
+
+	r = m.MustRun("route", "show", host, "--format", "json")
+	r.RequireSuccess(t)
+
+	var shown struct {
+		RequestTimeout string `json:"request_timeout"`
+	}
+	if err := json.Unmarshal([]byte(r.Stdout), &shown); err != nil {
+		t.Fatalf("failed to parse route show JSON: %v (stdout: %s)", err, r.Stdout)
+	}
+	if shown.RequestTimeout != "10m" {
+		t.Errorf("expected request_timeout 10m, got %q", shown.RequestTimeout)
+	}
+
+	// And in the list
+	r = m.MustRun("route", "list")
+	r.RequireSuccess(t)
+	r.RequireContains(t, "TIMEOUT")
+
+	// Invalid values are rejected without disturbing the stored one
+	r = m.Run("route", "timeout", host, "10")
+	if r.Success() {
+		t.Errorf("expected a bare number to be rejected\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+	}
+
+	r = m.MustRun("route", "timeout", host, "--format", "json")
+	r.RequireSuccess(t)
+	if err := json.Unmarshal([]byte(r.Stdout), &shown); err != nil {
+		t.Fatalf("failed to parse route timeout JSON: %v (stdout: %s)", err, r.Stdout)
+	}
+	if shown.RequestTimeout != "10m" {
+		t.Errorf("expected request_timeout to stay 10m, got %q", shown.RequestTimeout)
+	}
+
+	// Clearing puts the route back on the server default
+	r = m.MustRun("route", "timeout", host, "--clear")
+	r.RequireSuccess(t)
+	r.RequireContains(t, "server default")
+
+	r = m.MustRun("route", "timeout", host, "--format", "json")
+	r.RequireSuccess(t)
+	// Unmarshal into a fresh value: request_timeout is omitted once cleared, so
+	// reusing `shown` would leave the previous value in place.
+	var cleared struct {
+		RequestTimeout string `json:"request_timeout"`
+	}
+	if err := json.Unmarshal([]byte(r.Stdout), &cleared); err != nil {
+		t.Fatalf("failed to parse route timeout JSON: %v (stdout: %s)", err, r.Stdout)
+	}
+	if cleared.RequestTimeout != "" {
+		t.Errorf("expected request_timeout to be cleared, got %q", cleared.RequestTimeout)
+	}
+
+	// Clearing again is a no-op
+	r = m.MustRun("route", "timeout", host, "--clear")
+	r.RequireSuccess(t)
+	r.RequireContains(t, "No request timeout override")
+}

--- a/blackbox/route_timeout_test.go
+++ b/blackbox/route_timeout_test.go
@@ -93,3 +93,63 @@ func TestRouteTimeoutSetShowClear(t *testing.T) {
 	r.RequireSuccess(t)
 	r.RequireContains(t, "No request timeout override")
 }
+
+// TestRouteTimeoutDefaultRoute covers the --default form, where there is no
+// hostname to give and the sole positional is the duration. That shift is easy
+// to get wrong in argument parsing and cannot be exercised by the named-host
+// path above.
+func TestRouteTimeoutDefaultRoute(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+
+	m.MustRun("route", "set-default", name).RequireSuccess(t)
+
+	r := m.MustRun("route", "timeout", "--default")
+	r.RequireSuccess(t)
+	r.RequireContains(t, "server default")
+
+	// The duration lands in the right slot despite being the only positional.
+	r = m.MustRun("route", "timeout", "--default", "5m")
+	r.RequireSuccess(t)
+	r.RequireContains(t, "5m")
+
+	r = m.MustRun("route", "show", "--default", "--format", "json")
+	r.RequireSuccess(t)
+
+	var shown struct {
+		RequestTimeout string `json:"request_timeout"`
+	}
+	if err := json.Unmarshal([]byte(r.Stdout), &shown); err != nil {
+		t.Fatalf("failed to parse route show JSON: %v (stdout: %s)", err, r.Stdout)
+	}
+	if shown.RequestTimeout != "5m" {
+		t.Errorf("expected request_timeout 5m on the default route, got %q", shown.RequestTimeout)
+	}
+
+	// A hostname alongside --default is a contradiction, not a second reading.
+	r = m.Run("route", "timeout", "--default", "example.com", "5m")
+	if r.Success() {
+		t.Errorf("expected --default with a hostname to be rejected\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+	}
+
+	r = m.MustRun("route", "timeout", "--default", "--clear")
+	r.RequireSuccess(t)
+	r.RequireContains(t, "server default")
+
+	r = m.MustRun("route", "timeout", "--default", "--format", "json")
+	r.RequireSuccess(t)
+
+	var cleared struct {
+		RequestTimeout string `json:"request_timeout"`
+	}
+	if err := json.Unmarshal([]byte(r.Stdout), &cleared); err != nil {
+		t.Fatalf("failed to parse route timeout JSON: %v (stdout: %s)", err, r.Stdout)
+	}
+	if cleared.RequestTimeout != "" {
+		t.Errorf("expected request_timeout to be cleared, got %q", cleared.RequestTimeout)
+	}
+}

--- a/blackbox/route_timeout_test.go
+++ b/blackbox/route_timeout_test.go
@@ -76,16 +76,15 @@ func TestRouteTimeoutSetShowClear(t *testing.T) {
 
 	r = m.MustRun("route", "timeout", host, "--format", "json")
 	r.RequireSuccess(t)
-	// Unmarshal into a fresh value: request_timeout is omitted once cleared, so
-	// reusing `shown` would leave the previous value in place.
-	var cleared struct {
-		RequestTimeout string `json:"request_timeout"`
-	}
+	// Decode into a map rather than a struct: the field carries omitempty, so
+	// "cleared" means absent. An omitted field, "", and null all decode to the
+	// same empty string, which would let a regression through.
+	var cleared map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(r.Stdout), &cleared); err != nil {
 		t.Fatalf("failed to parse route timeout JSON: %v (stdout: %s)", err, r.Stdout)
 	}
-	if cleared.RequestTimeout != "" {
-		t.Errorf("expected request_timeout to be cleared, got %q", cleared.RequestTimeout)
+	if raw, ok := cleared["request_timeout"]; ok {
+		t.Errorf("expected request_timeout to be omitted after clearing, got %s", raw)
 	}
 
 	// Clearing again is a no-op
@@ -143,13 +142,12 @@ func TestRouteTimeoutDefaultRoute(t *testing.T) {
 	r = m.MustRun("route", "timeout", "--default", "--format", "json")
 	r.RequireSuccess(t)
 
-	var cleared struct {
-		RequestTimeout string `json:"request_timeout"`
-	}
+	// Absent, not empty: the field carries omitempty.
+	var cleared map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(r.Stdout), &cleared); err != nil {
 		t.Fatalf("failed to parse route timeout JSON: %v (stdout: %s)", err, r.Stdout)
 	}
-	if cleared.RequestTimeout != "" {
-		t.Errorf("expected request_timeout to be cleared, got %q", cleared.RequestTimeout)
+	if raw, ok := cleared["request_timeout"]; ok {
+		t.Errorf("expected request_timeout to be omitted after clearing, got %s", raw)
 	}
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -682,7 +682,7 @@ miren deploy --analyze
 
 	d.Dispatch("route timeout", Infer("route timeout", "Override the ingress request timeout for an HTTP route", RouteTimeout,
 		WithExample(mflags.Example{
-			Name: "Give a long-poll route a 10 minute timeout",
+			Name: "Give a long-poll route a 10-minute timeout",
 			Body: "miren route timeout example.com 10m",
 		}),
 		WithExample(mflags.Example{

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -680,6 +680,25 @@ miren deploy --analyze
 		}),
 	))
 
+	d.Dispatch("route timeout", Infer("route timeout", "Override the ingress request timeout for an HTTP route", RouteTimeout,
+		WithExample(mflags.Example{
+			Name: "Give a long-poll route a 10 minute timeout",
+			Body: "miren route timeout example.com 10m",
+		}),
+		WithExample(mflags.Example{
+			Name: "Show the current timeout for a route",
+			Body: "miren route timeout example.com",
+		}),
+		WithExample(mflags.Example{
+			Name: "Set a timeout on the default route",
+			Body: "miren route timeout --default 5m",
+		}),
+		WithExample(mflags.Example{
+			Name: "Go back to the server default timeout",
+			Body: "miren route timeout example.com --clear",
+		}),
+	))
+
 	// Config commands
 	d.Dispatch("config", Section("config", "Configuration file management", "", WithSectionGroup(GroupClient)))
 	d.Dispatch("config info", Infer("config info", "Show configuration file locations and format", ConfigInfo,

--- a/cli/commands/route_list.go
+++ b/cli/commands/route_list.go
@@ -39,12 +39,13 @@ func RouteList(ctx *Context, opts struct {
 
 	if opts.IsJSON() {
 		type RouteInfo struct {
-			Host      string `json:"host"`
-			App       string `json:"app"`
-			Default   bool   `json:"default"`
-			WafLevel  int    `json:"waf_level"`
-			CreatedAt int64  `json:"created_at"`
-			UpdatedAt int64  `json:"updated_at"`
+			Host           string `json:"host"`
+			App            string `json:"app"`
+			Default        bool   `json:"default"`
+			WafLevel       int    `json:"waf_level"`
+			RequestTimeout string `json:"request_timeout,omitempty"`
+			CreatedAt      int64  `json:"created_at"`
+			UpdatedAt      int64  `json:"updated_at"`
 		}
 
 		var routeInfos []RouteInfo
@@ -54,12 +55,13 @@ func RouteList(ctx *Context, opts struct {
 				host = "(default)"
 			}
 			routeInfos = append(routeInfos, RouteInfo{
-				Host:      host,
-				App:       string(r.Route.App),
-				Default:   r.Route.Default,
-				WafLevel:  resolveWAFLevel(r.Route),
-				CreatedAt: r.CreatedAt,
-				UpdatedAt: r.UpdatedAt,
+				Host:           host,
+				App:            string(r.Route.App),
+				Default:        r.Route.Default,
+				WafLevel:       resolveWAFLevel(r.Route),
+				RequestTimeout: r.Route.RequestTimeout,
+				CreatedAt:      r.CreatedAt,
+				UpdatedAt:      r.UpdatedAt,
 			})
 		}
 
@@ -67,7 +69,7 @@ func RouteList(ctx *Context, opts struct {
 	}
 
 	var rows []ui.Row
-	headers := []string{"HOST", "APP", "DEFAULT", "WAF", "CREATED", "UPDATED"}
+	headers := []string{"HOST", "APP", "DEFAULT", "WAF", "TIMEOUT", "CREATED", "UPDATED"}
 
 	for _, r := range routes {
 		route := r.Route
@@ -92,11 +94,17 @@ func RouteList(ctx *Context, opts struct {
 			wafDisplay = fmt.Sprintf("%d", wafLevel)
 		}
 
+		timeoutDisplay := "-"
+		if route.RequestTimeout != "" {
+			timeoutDisplay = route.RequestTimeout
+		}
+
 		rows = append(rows, ui.Row{
 			host,
 			appDisplay,
 			defaultDisplay,
 			wafDisplay,
+			timeoutDisplay,
 			humanFriendlyTimestamp(time.UnixMilli(r.CreatedAt)),
 			humanFriendlyTimestamp(time.UnixMilli(r.UpdatedAt)),
 		})

--- a/cli/commands/route_show.go
+++ b/cli/commands/route_show.go
@@ -111,6 +111,7 @@ func RouteShow(ctx *Context, opts struct {
 			ProviderMissing bool                `json:"provider_missing,omitempty"`
 			ClaimMappings   []map[string]string `json:"claim_mappings,omitempty"`
 			WafLevel        int                 `json:"waf_level"`
+			RequestTimeout  string              `json:"request_timeout,omitempty"`
 		}
 
 		wafLevel := 0
@@ -125,6 +126,7 @@ func RouteShow(ctx *Context, opts struct {
 			Protected:      protected,
 			ProtectionType: protectionType,
 			WafLevel:       wafLevel,
+			RequestTimeout: route.RequestTimeout,
 		}
 
 		if protected {
@@ -158,6 +160,9 @@ func RouteShow(ctx *Context, opts struct {
 	ctx.Printf("  Protected: %v\n", protected)
 	if wafProfile != nil {
 		ctx.Printf("  WAF Level: %d\n", wafProfile.ParanoiaLevel)
+	}
+	if route.RequestTimeout != "" {
+		ctx.Printf("  Timeout:   %s\n", route.RequestTimeout)
 	}
 
 	switch protectionType {

--- a/cli/commands/route_timeout.go
+++ b/cli/commands/route_timeout.go
@@ -1,0 +1,146 @@
+package commands
+
+import (
+	"fmt"
+	"time"
+
+	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// resolveRouteTimeoutArgs validates the argument combination before any RPC
+// work and returns the host and timeout to act on.
+//
+// With --default there is no hostname to give, so the sole positional is the
+// duration: `route timeout --default 5m` arrives as host="5m", timeout="", and
+// is shifted into place here.
+func resolveRouteTimeoutArgs(host string, isDefault, clear bool, timeout string) (string, string, error) {
+	if isDefault && host != "" && timeout == "" {
+		host, timeout = "", host
+	}
+
+	if host == "" && !isDefault {
+		return "", "", fmt.Errorf("either a hostname or --default must be specified")
+	}
+
+	if host != "" && isDefault {
+		return "", "", fmt.Errorf("--default cannot be used with a hostname")
+	}
+
+	if clear && timeout != "" {
+		return "", "", fmt.Errorf("--clear cannot be used with a timeout value")
+	}
+
+	if timeout != "" {
+		d, err := time.ParseDuration(timeout)
+		if err != nil {
+			return "", "", fmt.Errorf("invalid timeout %q: expected a duration like 10m or 300s", timeout)
+		}
+		if d <= 0 {
+			return "", "", fmt.Errorf("timeout must be positive, got %q", timeout)
+		}
+	}
+
+	return host, timeout, nil
+}
+
+func RouteTimeout(ctx *Context, opts struct {
+	Host    string `position:"0" usage:"Hostname for the route (e.g., example.com); omit and pass --default for the default route"`
+	Timeout string `position:"1" usage:"Request timeout as a duration (e.g., 10m, 300s); omit to show the current value"`
+	Default bool   `long:"default" description:"Apply to the default route (instead of a hostname)"`
+	Clear   bool   `long:"clear" description:"Remove the override so the route uses the server default"`
+	FormatOptions
+	ConfigCentric
+}) error {
+	host, wantTimeout, err := resolveRouteTimeoutArgs(opts.Host, opts.Default, opts.Clear, opts.Timeout)
+	if err != nil {
+		return err
+	}
+
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return err
+	}
+
+	ic := ingress.NewClient(ctx.Log, client)
+
+	var route *ingress_v1alpha.HttpRoute
+	var routeLabel string
+
+	if opts.Default {
+		route, err = ic.LookupDefault(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to lookup default route: %w", err)
+		}
+		if route == nil {
+			return fmt.Errorf("no default route configured")
+		}
+		routeLabel = "default"
+	} else {
+		route, err = ic.Lookup(ctx, host)
+		if err != nil {
+			return fmt.Errorf("failed to lookup route: %w", err)
+		}
+		if route == nil {
+			return fmt.Errorf("route not found for host: %s", host)
+		}
+		routeLabel = host
+	}
+
+	type RouteTimeoutJSON struct {
+		Route          string `json:"route"`
+		RequestTimeout string `json:"request_timeout,omitempty"`
+	}
+
+	switch {
+	case opts.Clear:
+		if route.RequestTimeout == "" {
+			if opts.IsJSON() {
+				return PrintJSON(RouteTimeoutJSON{Route: routeLabel})
+			}
+			ctx.Printf("No request timeout override on route: %s\n", routeLabel)
+			return nil
+		}
+
+		if _, err := ic.ClearRouteRequestTimeout(ctx, route); err != nil {
+			return fmt.Errorf("failed to clear request timeout on route: %w", err)
+		}
+
+		if opts.IsJSON() {
+			return PrintJSON(RouteTimeoutJSON{Route: routeLabel})
+		}
+		ctx.Printf("Request timeout cleared on route: %s (now using the server default)\n", routeLabel)
+		return nil
+
+	case wantTimeout != "":
+		updated, err := ic.SetRouteRequestTimeout(ctx, route, wantTimeout)
+		if err != nil {
+			return fmt.Errorf("failed to set request timeout on route: %w", err)
+		}
+		route = updated
+
+	default:
+		// No value given — report the current setting.
+		if route.RequestTimeout == "" {
+			if opts.IsJSON() {
+				return PrintJSON(RouteTimeoutJSON{Route: routeLabel})
+			}
+			ctx.Printf("Route %s uses the server default request timeout\n", routeLabel)
+			return nil
+		}
+	}
+
+	if opts.IsJSON() {
+		return PrintJSON(RouteTimeoutJSON{Route: routeLabel, RequestTimeout: route.RequestTimeout})
+	}
+
+	items := []ui.NamedValue{
+		ui.NewNamedValue("Route", routeLabel),
+		ui.NewNamedValue("Timeout", route.RequestTimeout),
+	}
+
+	ctx.Printf("%s\n", ui.NewNamedValueList(items).Render())
+
+	return nil
+}

--- a/cli/commands/route_timeout_test.go
+++ b/cli/commands/route_timeout_test.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveRouteTimeoutArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		host        string
+		isDefault   bool
+		clear       bool
+		timeout     string
+		wantHost    string
+		wantTimeout string
+		wantErr     string
+	}{
+		{name: "host and duration", host: "example.com", timeout: "10m",
+			wantHost: "example.com", wantTimeout: "10m"},
+		{name: "host alone shows current", host: "example.com",
+			wantHost: "example.com"},
+		{name: "seconds", host: "example.com", timeout: "300s",
+			wantHost: "example.com", wantTimeout: "300s"},
+		{name: "clear a host route", host: "example.com", clear: true,
+			wantHost: "example.com"},
+
+		// With --default the sole positional is the duration, not a hostname.
+		{name: "default with duration", isDefault: true, host: "5m",
+			wantTimeout: "5m"},
+		{name: "default alone shows current", isDefault: true},
+		{name: "clear the default route", isDefault: true, clear: true},
+
+		{name: "no target", wantErr: "either a hostname or --default"},
+		{name: "both targets", host: "example.com", isDefault: true, timeout: "10m",
+			wantErr: "--default cannot be used"},
+		{name: "clear with a value", host: "example.com", clear: true, timeout: "10m",
+			wantErr: "--clear cannot be used"},
+		{name: "bare number", host: "example.com", timeout: "10", wantErr: "invalid timeout"},
+		{name: "garbage", host: "example.com", timeout: "forever", wantErr: "invalid timeout"},
+		{name: "garbage on default", isDefault: true, host: "forever", wantErr: "invalid timeout"},
+		{name: "zero", host: "example.com", timeout: "0s", wantErr: "must be positive"},
+		{name: "negative", host: "example.com", timeout: "-5m", wantErr: "must be positive"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, timeout, err := resolveRouteTimeoutArgs(tt.host, tt.isDefault, tt.clear, tt.timeout)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantHost, host)
+			require.Equal(t, tt.wantTimeout, timeout)
+		})
+	}
+}

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -261,6 +261,7 @@
       "command/route-set",
       "command/route-set-default",
       "command/route-show",
+      "command/route-timeout",
       "command/route-unprotect",
       "command/route-unset-default",
       "command/route-waf"

--- a/docs/docs/command/route-timeout.md
+++ b/docs/docs/command/route-timeout.md
@@ -36,7 +36,7 @@ miren route timeout <host> <timeout> [flags]
 
 ## Examples
 
-**Give a long-poll route a 10 minute timeout:**
+**Give a long-poll route a 10-minute timeout:**
 
 ```bash
 miren route timeout example.com 10m

--- a/docs/docs/command/route-timeout.md
+++ b/docs/docs/command/route-timeout.md
@@ -1,0 +1,65 @@
+---
+title: "miren route timeout"
+sidebar_label: "route timeout"
+description: "Override the ingress request timeout for an HTTP route"
+---
+
+# miren route timeout
+
+Override the ingress request timeout for an HTTP route
+
+## Usage
+
+```bash
+miren route timeout <host> <timeout> [flags]
+```
+
+## Arguments
+
+- `host` — Hostname for the route (e.g., example.com); omit and pass --default for the default route
+- `timeout` — Request timeout as a duration (e.g., 10m, 300s); omit to show the current value
+
+## Flags
+
+- `--clear` — Remove the override so the route uses the server default
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--default` — Apply to the default route (instead of a hostname)
+- `--format` — Output format (text, json) (default: `text`)
+- `--json` — Shorthand for --format json
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Give a long-poll route a 10 minute timeout:**
+
+```bash
+miren route timeout example.com 10m
+```
+
+**Show the current timeout for a route:**
+
+```bash
+miren route timeout example.com
+```
+
+**Set a timeout on the default route:**
+
+```bash
+miren route timeout --default 5m
+```
+
+**Go back to the server default timeout:**
+
+```bash
+miren route timeout example.com --clear
+```
+
+## See also
+
+- [`miren route`](/command/route)

--- a/docs/docs/command/route.md
+++ b/docs/docs/command/route.md
@@ -43,6 +43,7 @@ miren route
 - [`miren route set`](/command/route-set) — Create or update an HTTP route
 - [`miren route set-default`](/command/route-set-default) — Set an app as the default route
 - [`miren route show`](/command/route-show) — Show details of an HTTP route
+- [`miren route timeout`](/command/route-timeout) — Override the ingress request timeout for an HTTP route
 - [`miren route unprotect`](/command/route-unprotect) — Remove identity-provider protection from an HTTP route
 - [`miren route unset-default`](/command/route-unset-default) — Remove the default route
 - [`miren route waf`](/command/route-waf) — Manage WAF protection on an HTTP route

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -190,6 +190,7 @@ Complete reference for all `miren` CLI commands.
 | [`miren route set`](/command/route-set) | Create or update an HTTP route |
 | [`miren route set-default`](/command/route-set-default) | Set an app as the default route |
 | [`miren route show`](/command/route-show) | Show details of an HTTP route |
+| [`miren route timeout`](/command/route-timeout) | Override the ingress request timeout for an HTTP route |
 | [`miren route unprotect`](/command/route-unprotect) | Remove identity-provider protection from an HTTP route |
 | [`miren route unset-default`](/command/route-unset-default) | Remove the default route |
 | [`miren route waf`](/command/route-waf) | Manage WAF protection on an HTTP route |

--- a/docs/docs/server-config.md
+++ b/docs/docs/server-config.md
@@ -81,7 +81,7 @@ In standalone mode, embedded services start automatically unless explicitly disa
 | `release_path` | string | — | Path to release directory containing binaries | `MIREN_SERVER_RELEASE_PATH` | `--release-path` |
 | `config_cluster_name` | string | `local` | Cluster name in client config | `MIREN_SERVER_CONFIG_CLUSTER_NAME` | `--config-cluster-name`, `-C` |
 | `skip_client_config` | bool | `false` | Skip writing client config to `clientconfig.d` | `MIREN_SERVER_SKIP_CLIENT_CONFIG` | `--skip-client-config` |
-| `http_request_timeout` | int | `60` | HTTP request timeout in seconds (minimum: 1) | `MIREN_SERVER_HTTP_REQUEST_TIMEOUT` | `--http-request-timeout` |
+| `http_request_timeout` | int | `60` | HTTP request timeout in seconds (minimum: 1). Cluster-wide default; override per route with `miren route timeout` — see [Request Timeouts](/traffic-routing#request-timeouts) | `MIREN_SERVER_HTTP_REQUEST_TIMEOUT` | `--http-request-timeout` |
 | `stop_sandboxes_on_shutdown` | bool | `false` | Stop all sandboxes when server shuts down (useful in development) | `MIREN_SERVER_STOP_SANDBOXES_ON_SHUTDOWN` | `--stop-sandboxes-on-shutdown` |
 ## `[ingress]` — Ingress Settings {#ingress}
 

--- a/docs/docs/traffic-routing.md
+++ b/docs/docs/traffic-routing.md
@@ -103,6 +103,35 @@ miren route set '*.yourdomain.com' myapp
 
 You don't have to do anything else for HTTPS — Miren provisions Let's Encrypt certificates as requests arrive. See [TLS Certificates](/tls) for the details.
 
+### Request Timeouts
+
+Miren gives up on a proxied request once it has gone quiet for 60 seconds — nothing from your app, nothing to send. That covers most apps, but it cuts off patterns that are silent by design: long polling, an endpoint that waits on a slow job before writing its first byte, or a report that takes minutes to assemble.
+
+Raise the limit for just that route:
+
+<CliCommand context="client">
+```miren
+miren route timeout longpoll.yourdomain.com 10m
+```
+</CliCommand>
+
+Check what a route is using, and put it back on the cluster default:
+
+<CliCommand context="client">
+```miren
+miren route timeout longpoll.yourdomain.com
+miren route timeout longpoll.yourdomain.com --clear
+```
+</CliCommand>
+
+The value is a duration string such as `10m`, `300s`, or `2h`, and must be positive. `miren route list` shows a `TIMEOUT` column with each route's override, or `-` when it uses the default.
+
+The 60-second default itself is the `server.http_request_timeout` setting — see [Server Configuration](/server-config). A per-route value overrides it for that route only.
+
+:::note[Streaming responses are already fine]
+The timeout measures silence, not total duration. A server-sent-events stream or a WebSocket that keeps sending data will run indefinitely on the default — you only need an override when the connection genuinely goes quiet for longer than a minute.
+:::
+
 ### Choosing a Port
 
 Miren sets the `PORT` environment variable to tell your app which port to listen on. Your app should bind to `PORT`:

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -69,6 +69,11 @@ const (
 	// apps from having their leases evicted on every 30s tick, which would
 	// force every request through the full entity store + activator pipeline.
 	minLeaseTTL = 5 * time.Minute
+	// maxBadTimeoutsTracked caps the per-route memory of which unusable
+	// request_timeout we have already warned about. Past the cap we stop
+	// warning rather than start flooding — a config error that repeats forever
+	// is worth one line, never a stream of them.
+	maxBadTimeoutsTracked = 1024
 )
 
 type IngressConfig struct {
@@ -88,6 +93,19 @@ type Server struct {
 
 	aa        activator.AppActivator
 	transport http.RoundTripper
+
+	// transports memoizes one proxy transport per distinct per-route timeout
+	// override. Each needs its own connection pool: Go keys pooled connections
+	// by (scheme, host) only, so a connection dialed under a 10m idle deadline
+	// would otherwise be handed to a request that wants the 60s default.
+	transportMu sync.Mutex
+	transports  map[time.Duration]http.RoundTripper
+
+	// badTimeouts records, per route, the last unusable request_timeout we
+	// warned about, so a misconfigured route produces one warning instead of
+	// one per request. See warnBadRouteTimeout.
+	badTimeoutMu sync.Mutex
+	badTimeouts  map[entity.Id]string
 
 	httpMetrics *metrics.HTTPMetrics
 	logWriter   observability.LogWriter
@@ -134,19 +152,6 @@ func NewServer(
 		config.RequestTimeout = 60 * time.Second
 	}
 
-	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
-	baseTransport.ResponseHeaderTimeout = config.RequestTimeout
-	baseTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		conn, err := (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext(ctx, network, addr)
-		if err != nil {
-			return nil, err
-		}
-		return &idleTimeoutConn{Conn: conn, idleTimeout: config.RequestTimeout}, nil
-	}
-
 	var signingKey []byte
 	if config.DataPath != "" {
 		var err error
@@ -164,7 +169,9 @@ func NewServer(
 		ingressClient:      ingress.NewClient(log, rpcClient),
 		appClient:          app.NewClient(log, rpcClient),
 		aa:                 aa,
-		transport:          baseTransport,
+		transport:          newProxyTransport(config.RequestTimeout),
+		transports:         make(map[time.Duration]http.RoundTripper),
+		badTimeouts:        make(map[entity.Id]string),
 		httpMetrics:        httpMetrics,
 		logWriter:          logWriter,
 		apps:               make(map[string]*appUsage),
@@ -187,6 +194,114 @@ func NewServer(
 	go serv.watchInvalidations(ctx)
 
 	return serv
+}
+
+// newProxyTransport builds a transport that gives up on a proxied request once
+// it has been silent for timeout. Two knobs enforce that: ResponseHeaderTimeout
+// bounds the wait for the app's response headers, and idleTimeoutConn bounds
+// the gap between reads once bytes are flowing.
+func newProxyTransport(timeout time.Duration) http.RoundTripper {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.ResponseHeaderTimeout = timeout
+	t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return &idleTimeoutConn{Conn: conn, idleTimeout: timeout}, nil
+	}
+	return t
+}
+
+// transportFor returns the transport enforcing the given request timeout,
+// building and memoizing one the first time a route asks for a value other than
+// the server default. The number of distinct transports is bounded by the
+// number of distinct per-route overrides an operator has configured.
+func (h *Server) transportFor(timeout time.Duration) http.RoundTripper {
+	if timeout <= 0 || timeout == h.config.RequestTimeout {
+		return h.transport
+	}
+
+	h.transportMu.Lock()
+	defer h.transportMu.Unlock()
+
+	if t, ok := h.transports[timeout]; ok {
+		return t
+	}
+
+	// Tests build a Server directly and skip this map; writing to a nil one
+	// would panic rather than fail usefully.
+	if h.transports == nil {
+		h.transports = make(map[time.Duration]http.RoundTripper)
+	}
+
+	h.Log.Info("building proxy transport for per-route request timeout", "timeout", timeout)
+	t := newProxyTransport(timeout)
+	h.transports[timeout] = t
+	return t
+}
+
+// routeRequestTimeout resolves a route's request timeout override. It returns 0
+// when the route carries no override or carries one we cannot honor, which
+// tells transportFor to use the server-wide default.
+func (h *Server) routeRequestTimeout(route *ingress_v1alpha.HttpRoute) time.Duration {
+	if route == nil || route.RequestTimeout == "" {
+		return 0
+	}
+
+	d, err := time.ParseDuration(route.RequestTimeout)
+	if err != nil {
+		h.warnBadRouteTimeout(route, "ignoring unparseable route request timeout", "error", err)
+		return 0
+	}
+
+	if d <= 0 {
+		h.warnBadRouteTimeout(route, "ignoring non-positive route request timeout")
+		return 0
+	}
+
+	return d
+}
+
+// warnBadRouteTimeout warns about an unusable request_timeout once per route,
+// and again only if that route later carries a different unusable value.
+//
+// The warning is worth keeping at Warn — a route that silently ignores its
+// configured timeout is exactly the kind of thing an operator needs to see. But
+// routeRequestTimeout runs on every request through the route, and a bad value
+// never self-heals, so warning unconditionally would emit the same line for as
+// long as the misconfiguration lasts and drown the tier it sits in.
+func (h *Server) warnBadRouteTimeout(route *ingress_v1alpha.HttpRoute, msg string, extra ...any) {
+	h.badTimeoutMu.Lock()
+
+	if h.badTimeouts == nil {
+		h.badTimeouts = make(map[entity.Id]string)
+	}
+
+	warned, tracking := h.badTimeouts[route.ID]
+	switch {
+	case warned == route.RequestTimeout && tracking:
+		h.badTimeoutMu.Unlock()
+		return
+	case !tracking && len(h.badTimeouts) >= maxBadTimeoutsTracked:
+		// Out of room to remember this one. Staying quiet is the safer failure:
+		// the alternative is warning on every request for every route past the
+		// cap.
+		h.badTimeoutMu.Unlock()
+		return
+	}
+
+	h.badTimeouts[route.ID] = route.RequestTimeout
+	h.badTimeoutMu.Unlock()
+
+	args := []any{"route", route.ID, "host", route.Host, "value", route.RequestTimeout}
+	args = append(args, extra...)
+	args = append(args, "note", "further requests on this route will not repeat this warning")
+
+	h.Log.Warn(msg, args...)
 }
 
 // watchInvalidations listens for sandbox invalidation signals from the
@@ -567,9 +682,11 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 		h.Log.Debug("using default route", "host", onlyHost, "app", targetAppId)
 	}
 
+	requestTimeout := h.routeRequestTimeout(route)
+
 	// Compose middleware chain: WAF → auth → serve
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		h.serveAuthenticatedRequest(w, r, targetAppId, routeType, ephemeralLabel, appName)
+		h.serveAuthenticatedRequest(w, r, targetAppId, routeType, ephemeralLabel, appName, requestTimeout)
 	}
 
 	handler = h.authMiddleware(route, handler)
@@ -642,7 +759,7 @@ func (h *Server) authMiddleware(route *ingress_v1alpha.HttpRoute, next http.Hand
 }
 
 // serveAuthenticatedRequest handles the request after authentication (if any)
-func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Request, targetAppId entity.Id, routeType string, ephemeralLabel string, appName *string) {
+func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Request, targetAppId entity.Id, routeType string, ephemeralLabel string, appName *string, requestTimeout time.Duration) {
 	ctx := req.Context()
 
 	// Get app details first to have the name for metrics
@@ -697,7 +814,7 @@ func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Requ
 			req = req.WithContext(ctx)
 			// On non-final attempts, suppress error response so we can retry
 			writeErr := attempt == maxRetries
-			err = h.proxyToLease(w, req, curLease.Lease.URL, targetAppId.String(), *appName, writeErr)
+			err = h.proxyToLease(w, req, curLease.Lease.URL, targetAppId.String(), *appName, writeErr, requestTimeout)
 			if err != nil && isProxyConnectionError(err) {
 				// Cached lease pointed at a dead sandbox — invalidate all app
 				// leases (they likely all point to the same dead sandbox) and retry
@@ -790,7 +907,7 @@ func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Requ
 
 		req = req.WithContext(ctx)
 		// Fresh lease — always write error response (no retry on fresh lease failure)
-		err = h.proxyToLease(w, req, actLease.URL, targetAppId.String(), *appName, true)
+		err = h.proxyToLease(w, req, actLease.URL, targetAppId.String(), *appName, true, requestTimeout)
 		if err != nil {
 			// Connection error on a fresh lease - the sandbox may have died
 			// between lease acquisition and proxy. Invalidate immediately.
@@ -843,7 +960,7 @@ func (h *Server) logRequestFromStats(appEntityID, appName string, stats httputil
 // captures the error but does NOT write to the ResponseWriter, allowing the caller
 // to retry with a fresh lease. This is safe because connection errors happen during
 // TCP dial, before any response bytes are sent.
-func (h *Server) proxyToLease(w http.ResponseWriter, req *http.Request, targetURL, appEntityID, appName string, writeErrorResponse bool) error {
+func (h *Server) proxyToLease(w http.ResponseWriter, req *http.Request, targetURL, appEntityID, appName string, writeErrorResponse bool, requestTimeout time.Duration) error {
 	targetParsed, err := url.Parse(targetURL)
 	if err != nil {
 		h.Log.Error("failed to parse target URL", "error", err, "url", targetURL)
@@ -855,7 +972,7 @@ func (h *Server) proxyToLease(w http.ResponseWriter, req *http.Request, targetUR
 	var proxyErr error
 
 	proxy := &httputil.ReverseProxy{
-		Transport: h.transport,
+		Transport: h.transportFor(requestTimeout),
 		Director: func(outReq *http.Request) {
 			outReq.URL.Scheme = targetParsed.Scheme
 			outReq.URL.Host = targetParsed.Host

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -61,19 +61,17 @@ var httpingressTracer = otel.Tracer("miren.dev/runtime/httpingress")
 
 const (
 	timeoutMessage = "Request timeout"
-	// leaseAcquisitionTimeout is the maximum time to wait for sandbox boot
-	// This is longer than request timeout to prevent dangling resources
+	// leaseAcquisitionTimeout is the maximum time to wait for sandbox boot.
+	// It runs on its own context rather than the request's, so a client that
+	// gives up first still leaves a booting sandbox to finish rather than
+	// stranding it. Unrelated to the request timeout, which a route can now
+	// raise past this.
 	leaseAcquisitionTimeout = 2 * time.Minute
 	// minLeaseTTL is the minimum time a lease is kept in cache after its last
 	// use before it becomes eligible for eviction. This prevents low-traffic
 	// apps from having their leases evicted on every 30s tick, which would
 	// force every request through the full entity store + activator pipeline.
 	minLeaseTTL = 5 * time.Minute
-	// maxBadTimeoutsTracked caps the per-route memory of which unusable
-	// request_timeout we have already warned about. Past the cap we stop
-	// warning rather than start flooding — a config error that repeats forever
-	// is worth one line, never a stream of them.
-	maxBadTimeoutsTracked = 1024
 )
 
 type IngressConfig struct {
@@ -100,12 +98,6 @@ type Server struct {
 	// would otherwise be handed to a request that wants the 60s default.
 	transportMu sync.Mutex
 	transports  map[time.Duration]http.RoundTripper
-
-	// badTimeouts records, per route, the last unusable request_timeout we
-	// warned about, so a misconfigured route produces one warning instead of
-	// one per request. See warnBadRouteTimeout.
-	badTimeoutMu sync.Mutex
-	badTimeouts  map[entity.Id]string
 
 	httpMetrics *metrics.HTTPMetrics
 	logWriter   observability.LogWriter
@@ -171,7 +163,6 @@ func NewServer(
 		aa:                 aa,
 		transport:          newProxyTransport(config.RequestTimeout),
 		transports:         make(map[time.Duration]http.RoundTripper),
-		badTimeouts:        make(map[entity.Id]string),
 		httpMetrics:        httpMetrics,
 		logWriter:          logWriter,
 		apps:               make(map[string]*appUsage),
@@ -232,76 +223,28 @@ func (h *Server) transportFor(timeout time.Duration) http.RoundTripper {
 		return t
 	}
 
-	// Tests build a Server directly and skip this map; writing to a nil one
-	// would panic rather than fail usefully.
-	if h.transports == nil {
-		h.transports = make(map[time.Duration]http.RoundTripper)
-	}
-
 	h.Log.Info("building proxy transport for per-route request timeout", "timeout", timeout)
 	t := newProxyTransport(timeout)
 	h.transports[timeout] = t
 	return t
 }
 
-// routeRequestTimeout resolves a route's request timeout override. It returns 0
-// when the route carries no override or carries one we cannot honor, which
-// tells transportFor to use the server-wide default.
-func (h *Server) routeRequestTimeout(route *ingress_v1alpha.HttpRoute) time.Duration {
+// routeRequestTimeout resolves a route's request timeout override, falling back
+// to the server default (0 here, which transportFor reads as "use the default")
+// on empty, invalid, or non-positive values. SetRouteRequestTimeout rejects
+// those at the write boundary, so a typo can only arrive by editing the entity
+// directly, and quietly ignoring it beats failing the request.
+func routeRequestTimeout(route *ingress_v1alpha.HttpRoute) time.Duration {
 	if route == nil || route.RequestTimeout == "" {
 		return 0
 	}
 
 	d, err := time.ParseDuration(route.RequestTimeout)
-	if err != nil {
-		h.warnBadRouteTimeout(route, "ignoring unparseable route request timeout", "error", err)
-		return 0
-	}
-
-	if d <= 0 {
-		h.warnBadRouteTimeout(route, "ignoring non-positive route request timeout")
+	if err != nil || d <= 0 {
 		return 0
 	}
 
 	return d
-}
-
-// warnBadRouteTimeout warns about an unusable request_timeout once per route,
-// and again only if that route later carries a different unusable value.
-//
-// The warning is worth keeping at Warn — a route that silently ignores its
-// configured timeout is exactly the kind of thing an operator needs to see. But
-// routeRequestTimeout runs on every request through the route, and a bad value
-// never self-heals, so warning unconditionally would emit the same line for as
-// long as the misconfiguration lasts and drown the tier it sits in.
-func (h *Server) warnBadRouteTimeout(route *ingress_v1alpha.HttpRoute, msg string, extra ...any) {
-	h.badTimeoutMu.Lock()
-
-	if h.badTimeouts == nil {
-		h.badTimeouts = make(map[entity.Id]string)
-	}
-
-	warned, tracking := h.badTimeouts[route.ID]
-	switch {
-	case warned == route.RequestTimeout && tracking:
-		h.badTimeoutMu.Unlock()
-		return
-	case !tracking && len(h.badTimeouts) >= maxBadTimeoutsTracked:
-		// Out of room to remember this one. Staying quiet is the safer failure:
-		// the alternative is warning on every request for every route past the
-		// cap.
-		h.badTimeoutMu.Unlock()
-		return
-	}
-
-	h.badTimeouts[route.ID] = route.RequestTimeout
-	h.badTimeoutMu.Unlock()
-
-	args := []any{"route", route.ID, "host", route.Host, "value", route.RequestTimeout}
-	args = append(args, extra...)
-	args = append(args, "note", "further requests on this route will not repeat this warning")
-
-	h.Log.Warn(msg, args...)
 }
 
 // watchInvalidations listens for sandbox invalidation signals from the
@@ -682,7 +625,7 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 		h.Log.Debug("using default route", "host", onlyHost, "app", targetAppId)
 	}
 
-	requestTimeout := h.routeRequestTimeout(route)
+	requestTimeout := routeRequestTimeout(route)
 
 	// Compose middleware chain: WAF → auth → serve
 	handler := func(w http.ResponseWriter, r *http.Request) {

--- a/servers/httpingress/httpingress_test.go
+++ b/servers/httpingress/httpingress_test.go
@@ -429,7 +429,7 @@ func TestProxyToLeaseRetrySuppress(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", nil)
 
 	// Port 1 is not listening — triggers ECONNREFUSED
-	err := h.proxyToLease(rec, req, "http://127.0.0.1:1", "app/test", "test-app", false)
+	err := h.proxyToLease(rec, req, "http://127.0.0.1:1", "app/test", "test-app", false, 0)
 
 	if err == nil {
 		t.Fatal("expected connection error, got nil")
@@ -459,7 +459,7 @@ func TestProxyToLeaseWriteErrorOnFinalAttempt(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/test", nil)
 
-	err := h.proxyToLease(rec, req, "http://127.0.0.1:1", "app/test", "test-app", true)
+	err := h.proxyToLease(rec, req, "http://127.0.0.1:1", "app/test", "test-app", true, 0)
 
 	if err == nil {
 		t.Fatal("expected connection error, got nil")
@@ -486,7 +486,7 @@ func TestProxyToLeaseNoRetryOnTimeout(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/test", nil)
 
-	err := h.proxyToLease(rec, req, backend.URL, "app/test", "test-app", false)
+	err := h.proxyToLease(rec, req, backend.URL, "app/test", "test-app", false, 0)
 
 	// Timeouts are not connection errors — writeErrorResponse only suppresses connection errors
 	if err != nil {

--- a/servers/httpingress/route_timeout_test.go
+++ b/servers/httpingress/route_timeout_test.go
@@ -1,0 +1,193 @@
+package httpingress
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// newTimeoutTestServer builds the minimal Server needed to exercise the
+// transport/timeout resolution helpers, skipping NewServer's RPC dependencies.
+func newTimeoutTestServer(defaultTimeout time.Duration) *Server {
+	return &Server{
+		Log:        slog.New(slog.DiscardHandler),
+		config:     IngressConfig{RequestTimeout: defaultTimeout},
+		transport:  newProxyTransport(defaultTimeout),
+		transports: make(map[time.Duration]http.RoundTripper),
+	}
+}
+
+// countingHandler tallies records per level so tests can assert on log volume.
+type countingHandler struct {
+	slog.Handler
+	warns int
+}
+
+func (h *countingHandler) Handle(ctx context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		h.warns++
+	}
+	return nil
+}
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func TestRouteRequestTimeout(t *testing.T) {
+	h := newTimeoutTestServer(60 * time.Second)
+
+	tests := []struct {
+		name  string
+		route *ingress_v1alpha.HttpRoute
+		want  time.Duration
+	}{
+		{"nil route", nil, 0},
+		{"unset", &ingress_v1alpha.HttpRoute{}, 0},
+		{"minutes", &ingress_v1alpha.HttpRoute{RequestTimeout: "10m"}, 10 * time.Minute},
+		{"seconds", &ingress_v1alpha.HttpRoute{RequestTimeout: "300s"}, 5 * time.Minute},
+		{"unparseable", &ingress_v1alpha.HttpRoute{RequestTimeout: "10"}, 0},
+		{"garbage", &ingress_v1alpha.HttpRoute{RequestTimeout: "forever"}, 0},
+		{"zero", &ingress_v1alpha.HttpRoute{RequestTimeout: "0s"}, 0},
+		{"negative", &ingress_v1alpha.HttpRoute{RequestTimeout: "-5m"}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, h.routeRequestTimeout(tt.route))
+		})
+	}
+}
+
+func TestRouteRequestTimeoutWarnsOncePerRoute(t *testing.T) {
+	counter := &countingHandler{Handler: slog.DiscardHandler}
+
+	h := newTimeoutTestServer(60 * time.Second)
+	h.Log = slog.New(counter)
+	h.badTimeouts = make(map[entity.Id]string)
+
+	bad := &ingress_v1alpha.HttpRoute{ID: "http_route/bad", Host: "bad.example.com", RequestTimeout: "10"}
+
+	for range 100 {
+		require.Zero(t, h.routeRequestTimeout(bad))
+	}
+	require.Equal(t, 1, counter.warns,
+		"a route with a bad value must warn once, not once per request")
+
+	// A different route with its own bad value is its own warning.
+	other := &ingress_v1alpha.HttpRoute{ID: "http_route/other", Host: "other.example.com", RequestTimeout: "0s"}
+	for range 10 {
+		require.Zero(t, h.routeRequestTimeout(other))
+	}
+	require.Equal(t, 2, counter.warns, "each misconfigured route gets its own warning")
+
+	// Changing the same route to a different bad value is news worth repeating.
+	bad.RequestTimeout = "forever"
+	for range 10 {
+		require.Zero(t, h.routeRequestTimeout(bad))
+	}
+	require.Equal(t, 3, counter.warns, "a newly-broken value on the same route should warn again")
+
+	// Fixing the route stops the warnings entirely.
+	bad.RequestTimeout = "10m"
+	for range 10 {
+		require.Equal(t, 10*time.Minute, h.routeRequestTimeout(bad))
+	}
+	require.Equal(t, 3, counter.warns, "a valid value must not warn")
+}
+
+func TestRouteRequestTimeoutWarnCapStaysQuiet(t *testing.T) {
+	counter := &countingHandler{Handler: slog.DiscardHandler}
+
+	h := newTimeoutTestServer(60 * time.Second)
+	h.Log = slog.New(counter)
+	h.badTimeouts = make(map[entity.Id]string)
+
+	// Fill the tracking map to its cap, then confirm routes past it stay silent
+	// rather than falling back to warning on every request.
+	for i := range maxBadTimeoutsTracked {
+		route := &ingress_v1alpha.HttpRoute{
+			ID:             entity.Id(fmt.Sprintf("http_route/bad-%d", i)),
+			RequestTimeout: "nope",
+		}
+		require.Zero(t, h.routeRequestTimeout(route))
+	}
+	require.Equal(t, maxBadTimeoutsTracked, counter.warns)
+
+	overflow := &ingress_v1alpha.HttpRoute{ID: "http_route/overflow", RequestTimeout: "nope"}
+	for range 50 {
+		require.Zero(t, h.routeRequestTimeout(overflow))
+	}
+	require.Equal(t, maxBadTimeoutsTracked, counter.warns,
+		"past the cap we go quiet rather than warn on every request")
+	require.Len(t, h.badTimeouts, maxBadTimeoutsTracked, "the map must not grow past its cap")
+}
+
+func TestTransportForToleratesNilMap(t *testing.T) {
+	// Several existing test helpers build a Server without the transports map;
+	// a write to a nil map would panic instead of failing usefully.
+	h := &Server{
+		Log:       slog.New(slog.DiscardHandler),
+		config:    IngressConfig{RequestTimeout: 60 * time.Second},
+		transport: newProxyTransport(60 * time.Second),
+	}
+
+	require.NotPanics(t, func() {
+		got := h.transportFor(10 * time.Minute)
+		require.NotSame(t, h.transport, got)
+	})
+}
+
+func TestTransportForUsesDefault(t *testing.T) {
+	h := newTimeoutTestServer(60 * time.Second)
+
+	require.Same(t, h.transport, h.transportFor(0),
+		"no override should reuse the shared default transport")
+	require.Same(t, h.transport, h.transportFor(60*time.Second),
+		"an override equal to the default should reuse the shared transport")
+	require.Empty(t, h.transports, "no extra transports should have been built")
+}
+
+func TestTransportForMemoizesOverrides(t *testing.T) {
+	h := newTimeoutTestServer(60 * time.Second)
+
+	tenMin := h.transportFor(10 * time.Minute)
+	require.NotSame(t, h.transport, tenMin, "an override needs its own transport")
+	require.Same(t, tenMin, h.transportFor(10*time.Minute),
+		"repeated lookups of one duration should return the same transport")
+
+	fiveMin := h.transportFor(5 * time.Minute)
+	require.NotSame(t, tenMin, fiveMin, "distinct durations need distinct transports")
+	require.Len(t, h.transports, 2)
+}
+
+func TestTransportForAppliesOverrideTimeout(t *testing.T) {
+	// Backend that never sends response headers.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer backend.Close()
+
+	// A generous server default: without the override, this request would hang
+	// well past the test's patience.
+	h := newTimeoutTestServer(30 * time.Second)
+
+	req, err := http.NewRequest(http.MethodGet, backend.URL+"/slow", nil)
+	require.NoError(t, err)
+
+	start := time.Now()
+	//nolint:bodyclose // the round trip is expected to fail, so there is no body
+	_, err = h.transportFor(100 * time.Millisecond).RoundTrip(req)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "the override timeout should have cut the request short")
+	require.Less(t, elapsed, 5*time.Second,
+		"request should have timed out on the override, not the 30s default")
+}

--- a/servers/httpingress/route_timeout_test.go
+++ b/servers/httpingress/route_timeout_test.go
@@ -1,8 +1,6 @@
 package httpingress
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
-	"miren.dev/runtime/pkg/entity"
 )
 
 // newTimeoutTestServer builds the minimal Server needed to exercise the
@@ -26,24 +23,7 @@ func newTimeoutTestServer(defaultTimeout time.Duration) *Server {
 	}
 }
 
-// countingHandler tallies records per level so tests can assert on log volume.
-type countingHandler struct {
-	slog.Handler
-	warns int
-}
-
-func (h *countingHandler) Handle(ctx context.Context, r slog.Record) error {
-	if r.Level == slog.LevelWarn {
-		h.warns++
-	}
-	return nil
-}
-
-func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
-
 func TestRouteRequestTimeout(t *testing.T) {
-	h := newTimeoutTestServer(60 * time.Second)
-
 	tests := []struct {
 		name  string
 		route *ingress_v1alpha.HttpRoute
@@ -61,88 +41,9 @@ func TestRouteRequestTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, h.routeRequestTimeout(tt.route))
+			require.Equal(t, tt.want, routeRequestTimeout(tt.route))
 		})
 	}
-}
-
-func TestRouteRequestTimeoutWarnsOncePerRoute(t *testing.T) {
-	counter := &countingHandler{Handler: slog.DiscardHandler}
-
-	h := newTimeoutTestServer(60 * time.Second)
-	h.Log = slog.New(counter)
-	h.badTimeouts = make(map[entity.Id]string)
-
-	bad := &ingress_v1alpha.HttpRoute{ID: "http_route/bad", Host: "bad.example.com", RequestTimeout: "10"}
-
-	for range 100 {
-		require.Zero(t, h.routeRequestTimeout(bad))
-	}
-	require.Equal(t, 1, counter.warns,
-		"a route with a bad value must warn once, not once per request")
-
-	// A different route with its own bad value is its own warning.
-	other := &ingress_v1alpha.HttpRoute{ID: "http_route/other", Host: "other.example.com", RequestTimeout: "0s"}
-	for range 10 {
-		require.Zero(t, h.routeRequestTimeout(other))
-	}
-	require.Equal(t, 2, counter.warns, "each misconfigured route gets its own warning")
-
-	// Changing the same route to a different bad value is news worth repeating.
-	bad.RequestTimeout = "forever"
-	for range 10 {
-		require.Zero(t, h.routeRequestTimeout(bad))
-	}
-	require.Equal(t, 3, counter.warns, "a newly-broken value on the same route should warn again")
-
-	// Fixing the route stops the warnings entirely.
-	bad.RequestTimeout = "10m"
-	for range 10 {
-		require.Equal(t, 10*time.Minute, h.routeRequestTimeout(bad))
-	}
-	require.Equal(t, 3, counter.warns, "a valid value must not warn")
-}
-
-func TestRouteRequestTimeoutWarnCapStaysQuiet(t *testing.T) {
-	counter := &countingHandler{Handler: slog.DiscardHandler}
-
-	h := newTimeoutTestServer(60 * time.Second)
-	h.Log = slog.New(counter)
-	h.badTimeouts = make(map[entity.Id]string)
-
-	// Fill the tracking map to its cap, then confirm routes past it stay silent
-	// rather than falling back to warning on every request.
-	for i := range maxBadTimeoutsTracked {
-		route := &ingress_v1alpha.HttpRoute{
-			ID:             entity.Id(fmt.Sprintf("http_route/bad-%d", i)),
-			RequestTimeout: "nope",
-		}
-		require.Zero(t, h.routeRequestTimeout(route))
-	}
-	require.Equal(t, maxBadTimeoutsTracked, counter.warns)
-
-	overflow := &ingress_v1alpha.HttpRoute{ID: "http_route/overflow", RequestTimeout: "nope"}
-	for range 50 {
-		require.Zero(t, h.routeRequestTimeout(overflow))
-	}
-	require.Equal(t, maxBadTimeoutsTracked, counter.warns,
-		"past the cap we go quiet rather than warn on every request")
-	require.Len(t, h.badTimeouts, maxBadTimeoutsTracked, "the map must not grow past its cap")
-}
-
-func TestTransportForToleratesNilMap(t *testing.T) {
-	// Several existing test helpers build a Server without the transports map;
-	// a write to a nil map would panic instead of failing usefully.
-	h := &Server{
-		Log:       slog.New(slog.DiscardHandler),
-		config:    IngressConfig{RequestTimeout: 60 * time.Second},
-		transport: newProxyTransport(60 * time.Second),
-	}
-
-	require.NotPanics(t, func() {
-		got := h.transportFor(10 * time.Minute)
-		require.NotSame(t, h.transport, got)
-	})
 }
 
 func TestTransportForUsesDefault(t *testing.T) {


### PR DESCRIPTION
Ingress gives up on a proxied request once it has gone quiet for `server.http_request_timeout`, 60 seconds by default. That covers most apps, but it cuts off the ones that are silent on purpose: long polling, an endpoint that waits on a slow job before writing its first byte, a report that takes minutes to assemble. Those got killed at 60s and reconnected in a loop. The only lever was raising the setting, which is cluster-wide, so one long-poll app meant weakening the timeout for every other app on the cluster.

A route can now carry a `request_timeout` of its own, set with `miren route timeout longpoll.example.com 10m`. `--clear` puts it back on the cluster default.

The interesting part was where the timeout actually lives. It's two knobs on `http.Transport`: `ResponseHeaderTimeout` bounds the wait for the app's response headers, and the read deadline `idleTimeoutConn` sets bounds the gap between reads once bytes are flowing. Neither is settable per request, and Go's connection pool keys on (scheme, host) alone, so a connection dialed under a 10 minute deadline would happily get handed to the next request that wanted 60 seconds. Threading the value down through the request context runs into the same wall. So rather than mutate one shared transport, ingress keeps one transport per distinct timeout value, built lazily and memoized. Each gets its own connection pool, which is the entire point. The count is bounded by how many distinct overrides an operator has configured, so in practice one or two.

A stored value that will not parse, or that parses non-positive, falls back to the server default and is otherwise ignored. That matches `resolvePortWaitTimeout` and `getShutdownTimeout`, which handle the same shape of user-supplied duration string the same way, and `SetRouteRequestTimeout` validates at the write boundary so a typo can only arrive by editing the entity directly.

Verified end to end with the server default dropped to 5 seconds against an app whose endpoint sleeps for 15. The plain route 503s at 5s, the route carrying a 60s override returns 200 at 15s, and clearing the override puts it back to 503. The transport gets built once no matter how much traffic runs through it.

Two things I left alone on purpose. The JSON output reports `request_timeout` as a Go duration string like `10m`, which a non-Go consumer can't compare or sort without reimplementing `ParseDuration`, and the transport map never evicts, so churning a route's override repeatedly leaves small orphans behind. Both are noted in my local task list rather than pretending they're urgent.

Closes MIR-1576

