### PR TITLE
Let `miren sandbox exec` pick an app's sandbox for you

### DIFF
--- a/blackbox/sandbox_test.go
+++ b/blackbox/sandbox_test.go
@@ -3,6 +3,7 @@
 package blackbox
 
 import (
+	"strings"
 	"testing"
 
 	"miren.dev/runtime/blackbox/harness"
@@ -20,6 +21,42 @@ func TestSandboxList(t *testing.T) {
 	// Use JSON format since the table view shows short IDs, not app names.
 	r := m.MustRun("sandbox", "list", "--format", "json")
 	r.RequireContains(t, name)
+
+	t.Run("app-filter", func(t *testing.T) {
+		r := m.MustRun("sandbox", "list", "--app", name)
+		r.RequireContains(t, name)
+	})
+
+	// The default blackbox mode shares one dev cluster, so a filter that
+	// matched nothing would still look like a pass above. This is the half
+	// that proves it excludes.
+	t.Run("app-filter-excludes-others", func(t *testing.T) {
+		r := m.MustRun("sandbox", "list", "--app", name+"-nope")
+		if !strings.Contains(r.Stdout, "No sandboxes found") {
+			t.Fatalf("expected an empty listing for an unknown app\nstdout: %s", r.Stdout)
+		}
+		if strings.Contains(r.Stdout, name+" ") {
+			t.Fatalf("filter leaked another app's sandboxes\nstdout: %s", r.Stdout)
+		}
+	})
+
+	t.Run("service-filter", func(t *testing.T) {
+		r := m.MustRun("sandbox", "list", "--app", name, "--service", "web")
+		r.RequireContains(t, name)
+	})
+}
+
+// requireSandboxOf asserts that a `hostname` run landed in a sandbox belonging
+// to app. It checks stdout alone, unlike Result.RequireContains: stderr carries
+// miren's own chatter, and an app name appearing there would pass this without
+// the exec ever having reached the right sandbox.
+func requireSandboxOf(t *testing.T, r *harness.Result, app string) {
+	t.Helper()
+
+	if !strings.Contains(r.Stdout, app) {
+		t.Fatalf("expected a sandbox of app %q, got hostname %q\nstderr: %s",
+			app, strings.TrimSpace(r.Stdout), r.Stderr)
+	}
 }
 
 func TestSandboxExec(t *testing.T) {
@@ -40,5 +77,32 @@ func TestSandboxExec(t *testing.T) {
 	t.Run("id-flag", func(t *testing.T) {
 		r := m.MustRun("sandbox", "exec", "-i", sandboxID, "--", "echo", "hello-from-sandbox")
 		r.RequireContains(t, "hello-from-sandbox")
+	})
+
+	// These ask for the hostname rather than echoing a fixed string, because
+	// the claim under test is *which* sandbox we reached, not that we reached
+	// one. A sandbox's hostname is its entity name, which embeds the app name
+	// (the same property harness.GetSandboxID leans on), so this fails if
+	// selection wanders into another app — and other apps really are present,
+	// since the default blackbox mode shares one dev cluster.
+	//
+	// The "which one did it pick" notice is deliberately not asserted: it only
+	// fires on a terminal, and the harness runs with pipes.
+	t.Run("app-flag", func(t *testing.T) {
+		r := m.MustRun("sandbox", "exec", "-a", name, "--", "hostname")
+		requireSandboxOf(t, r, name)
+	})
+
+	t.Run("app-flag-with-service", func(t *testing.T) {
+		r := m.MustRun("sandbox", "exec", "-a", name, "--service", "web", "--", "hostname")
+		requireSandboxOf(t, r, name)
+	})
+
+	t.Run("app-and-id-conflict", func(t *testing.T) {
+		r := m.Run("sandbox", "exec", "-a", name, "-i", sandboxID, "--", "echo", "nope")
+		if r.Success() {
+			t.Fatalf("expected --app with --id to be rejected\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+		}
+		r.RequireContains(t, "--app and --id")
 	})
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -368,6 +368,14 @@ miren deploy --analyze
 			Body: "miren sandbox list --all",
 		}),
 		WithExample(mflags.Example{
+			Name: "Show only one app's sandboxes",
+			Body: "miren sandbox list --app myapp",
+		}),
+		WithExample(mflags.Example{
+			Name: "Show only one service of an app",
+			Body: "miren sandbox list --app myapp --service worker",
+		}),
+		WithExample(mflags.Example{
 			Name: "List as JSON",
 			Body: "miren sandbox list --format json",
 		}),
@@ -397,6 +405,14 @@ miren deploy --analyze
 		WithExample(mflags.Example{
 			Name: "Run a command in a sandbox",
 			Body: "miren sandbox exec sb_abc123 -- ls -la /app",
+		}),
+		WithExample(mflags.Example{
+			Name: "Let miren pick a running sandbox for an app",
+			Body: "miren sandbox exec --app myapp",
+		}),
+		WithExample(mflags.Example{
+			Name: "Run a command in one of an app's worker sandboxes",
+			Body: "miren sandbox exec --app myapp --service worker -- ps aux",
 		}),
 	))
 

--- a/cli/commands/sandbox_doc.go
+++ b/cli/commands/sandbox_doc.go
@@ -4,9 +4,32 @@ const sandboxSectionDescription = `Sandboxes are the underlying execution enviro
 
 const sandboxExecDescription = `This command connects to an existing sandbox and runs a command inside it. Unlike ` + "`" + `miren app run` + "`" + ` which creates a new ephemeral sandbox, this connects to a sandbox that's already running (typically one serving production traffic).
 
-## Finding Sandbox IDs
+## Letting miren pick the sandbox
 
-Use ` + "`" + `miren sandbox list` + "`" + ` to find the ID of a running sandbox:
+Pass ` + "`" + `--app` + "`" + ` and you don't need a sandbox ID at all — miren picks one of that app's running sandboxes for you:
+
+` + "```" + `bash
+miren sandbox exec --app myapp
+miren sandbox exec --app myapp -- ls -la /app
+` + "```" + `
+
+The choice is random among the sandboxes that qualify, so with more than one running you may land somewhere different each time. When there was more than one to choose from, miren names the one it picked — on a terminal only, so that piping or redirecting output never mixes miren's chatter into the sandbox's own.
+
+An app with several services gets its ` + "`" + `web` + "`" + ` service, and only that one. If no web instance is up, miren says so rather than substituting a worker, since landing in the wrong kind of process is worse than being told to try again. Use ` + "`" + `--service` + "`" + ` to ask for a different one:
+
+` + "```" + `bash
+miren sandbox exec --app myapp --service worker -- ps aux
+` + "```" + `
+
+Within the service you asked for, miren prefers sandboxes running your app's **current** version, so a command run during a deploy won't drop you into the version you just replaced. That one is a preference rather than a rule: a failed deploy leaves the current version pointing at something that never came up while the previous instances keep serving traffic, and refusing those would lock you out of a shell exactly when you need one.
+
+:::warning[Put -- before your command]
+Anything after ` + "`" + `--` + "`" + ` is passed to the sandbox untouched. Without it, a flag meant for your command is read as a flag for miren — ` + "`" + `miren sandbox exec --app myapp ls -la` + "`" + ` fails on ` + "`" + `-l` + "`" + `, and a ` + "`" + `-h` + "`" + ` anywhere before ` + "`" + `--` + "`" + ` prints this help instead of running anything.
+:::
+
+## Finding sandbox IDs
+
+To target a specific sandbox instead, use ` + "`" + `miren sandbox list` + "`" + ` to find its ID:
 
 ` + "```" + `bash
 $ miren sandbox list
@@ -15,10 +38,10 @@ sandbox/myapp-web-abc123    myapp     web       RUNNING   node-1
 sandbox/myapp-web-def456    myapp     web       RUNNING   node-2
 ` + "```" + `
 
-:::warning
+:::warning[This is a live instance]
 When you exec into a production sandbox, you're connecting to a live instance that may be serving traffic. Be careful with commands that could affect the running application.
 :::
 
-:::tip
+:::tip[Use app run to stay out of the way]
 For debugging or one-off tasks without affecting production, use ` + "`" + `miren app run` + "`" + ` to create an isolated ephemeral sandbox instead.
 :::`

--- a/cli/commands/sandbox_exec.go
+++ b/cli/commands/sandbox_exec.go
@@ -6,19 +6,84 @@ import (
 
 	"miren.dev/runtime/api/exec/exec_v1alpha"
 	"miren.dev/runtime/pkg/rpc/stream"
+	"miren.dev/runtime/pkg/ui"
 )
 
-func SandboxExec(ctx *Context, opts struct {
+// sandboxExecOptions is a named type rather than an inline struct so the flag
+// parsing, which now has rules of its own, can be tested directly.
+//
+// App deliberately has no env:"MIREN_APP" tag. Inside a sandbox that variable
+// is injected as the running app's own name, and picking it up here would
+// silently switch the command into --app mode and reinterpret the first
+// positional as part of the command instead of a sandbox id.
+type sandboxExecOptions struct {
 	ConfigCentric
-	Id string `short:"i" long:"id" description:"Sandbox ID"`
+
+	Id      string `short:"i" long:"id" description:"Sandbox ID"`
+	App     string `short:"a" long:"app" description:"Pick a running sandbox belonging to this app"`
+	Service string `long:"service" description:"With --app, restrict the choice to one service (default: web)"`
 
 	Args []string `rest:"true"`
-}) error {
+}
+
+// validate covers the flag combinations mflags can't express. It is called from
+// the command body rather than through OptsValidate, which RunCommand skips.
+func (o sandboxExecOptions) validate() error {
+	if o.App != "" && o.Id != "" {
+		return fmt.Errorf("--app and --id both name a sandbox; pass one or the other")
+	}
+
+	if o.Service != "" && o.App == "" {
+		return fmt.Errorf("--service selects among an app's sandboxes; it needs --app")
+	}
+
+	return nil
+}
+
+// execChoiceNotice describes where --app landed the caller, or returns "" when
+// there was nothing to report. One qualifying sandbox means we didn't choose
+// anything — naming it would be noise in front of every single-instance app.
+func execChoiceNotice(chosen sandboxCandidate, considered int) string {
+	if considered <= 1 {
+		return ""
+	}
+
+	return fmt.Sprintf("%s (%s), picked from %d running", chosen.Brief, chosen.Service, considered)
+}
+
+func SandboxExec(ctx *Context, opts sandboxExecOptions) error {
+	if err := opts.validate(); err != nil {
+		return err
+	}
+
 	id := opts.Id
 	args := opts.Args
-	if id == "" {
+
+	// Non-nil only when we picked the sandbox ourselves, which changes how a
+	// failure downstream has to be explained.
+	var chosen *sandboxCandidate
+
+	switch {
+	case opts.App != "":
+		// Every positional is part of the command here: there is no sandbox id
+		// to consume, because that's the whole point of --app.
+		pick, considered, err := selectAppSandbox(ctx, opts.App, opts.Service)
+		if err != nil {
+			return err
+		}
+		chosen = &pick
+
+		// Only to a terminal: stdout belongs to the sandbox, and plenty of
+		// callers merge stderr into it. This has to happen before setupExecIO
+		// puts the terminal into raw mode.
+		if msg := execChoiceNotice(pick, considered); msg != "" && isInteractiveOutput(ctx.Stderr) {
+			ctx.Begin("%s", msg)
+		}
+
+		id = pick.ID.String()
+	case id == "":
 		if len(args) == 0 {
-			return fmt.Errorf("sandbox ID is required (pass as first positional arg or via --id)")
+			return fmt.Errorf("sandbox ID is required (pass as first positional arg, via --id, or use --app)")
 		}
 		id, args = args[0], args[1:]
 	}
@@ -46,9 +111,34 @@ func SandboxExec(ctx *Context, opts struct {
 		stream.ChanReader(winUpdates),
 	)
 	if err != nil {
+		if chosen != nil {
+			return chosenSandboxExecError(opts.App, *chosen, err)
+		}
 		return err
 	}
 
 	ctx.SetExitCode(int(res.Code()))
 	return nil
+}
+
+// chosenSandboxExecError explains a failed exec against a sandbox the caller
+// never named. Selecting and connecting are separate round trips, so the
+// sandbox we picked can be gone by the time exec looks for it — scaled down,
+// crashed, or reaped along with its pool by a deploy. Left unwrapped, the
+// caller gets an entity id they have no way to connect to the -a they typed.
+//
+// This deliberately doesn't try to tell "it vanished" from any other failure:
+// the cause is shown either way, and retrying is the right first move for both.
+func chosenSandboxExecError(appName string, chosen sandboxCandidate, cause error) error {
+	return &ui.Diagnostic{
+		Summary: fmt.Sprintf("couldn't exec into the sandbox picked for %q", appName),
+		Detail: fmt.Sprintf("We picked %s (%s) from the sandboxes running at the time. "+
+			"If it has gone away since, running the same command again picks from "+
+			"whatever is running now.", chosen.Brief, chosen.Service),
+		Actions: []ui.Action{
+			{Command: "miren sandbox list --app " + appName, Note: "see what's running for it"},
+		},
+		Cause:     cause,
+		ShowCause: true,
+	}
 }

--- a/cli/commands/sandbox_list.go
+++ b/cli/commands/sandbox_list.go
@@ -12,12 +12,50 @@ import (
 	"miren.dev/runtime/pkg/ui"
 )
 
+// sandboxFilter narrows a sandbox listing to one app and/or service. Both
+// match against the values shown in the APP and SERVICE columns, so what you
+// filter on is what you see — including the "-" cases, which simply match
+// nothing rather than matching everything.
+type sandboxFilter struct {
+	app     string
+	service string
+}
+
+func (f sandboxFilter) keep(app, service string) bool {
+	if f.app != "" && app != f.app {
+		return false
+	}
+
+	if f.service != "" && service != f.service {
+		return false
+	}
+
+	return true
+}
+
+func (f sandboxFilter) describe() string {
+	switch {
+	case f.app != "" && f.service != "":
+		return fmt.Sprintf(" for app %q, service %q", f.app, f.service)
+	case f.app != "":
+		return fmt.Sprintf(" for app %q", f.app)
+	case f.service != "":
+		return fmt.Sprintf(" for service %q", f.service)
+	default:
+		return ""
+	}
+}
+
 func SandboxList(ctx *Context, opts struct {
-	All    bool   `short:"a" long:"all" description:"Include dead sandboxes (excluded by default)"`
-	Status string `short:"s" long:"status" description:"Filter by status (pending, not_ready, running, stopped, dead)"`
+	All     bool   `short:"a" long:"all" description:"Include dead sandboxes (excluded by default)"`
+	Status  string `short:"s" long:"status" description:"Filter by status (pending, not_ready, running, stopped, dead)"`
+	App     string `long:"app" description:"Only show sandboxes belonging to this app"`
+	Service string `long:"service" description:"Only show sandboxes of this service (e.g. web, worker)"`
 	FormatOptions
 	ConfigCentric
 }) error {
+	filter := sandboxFilter{app: opts.App, service: opts.Service}
+
 	client, err := ctx.RPCClient("entities")
 	if err != nil {
 		return err
@@ -122,6 +160,18 @@ func SandboxList(ctx *Context, opts struct {
 			var sandbox compute_v1alpha.Sandbox
 			sandbox.Decode(e.Entity())
 
+			// Extract pool label from metadata
+			var md core_v1alpha.Metadata
+			md.Decode(e.Entity())
+			poolLabel, _ := md.Labels.Get("pool")
+
+			// Get service from pool
+			service := poolServiceMap[poolLabel]
+
+			if !filter.keep(ui.CleanEntityID(versionAppMap[sandbox.Spec.Version.String()]), service) {
+				continue
+			}
+
 			if excludeDead && compute.SandboxDead(sandbox.Status) {
 				continue
 			}
@@ -134,14 +184,6 @@ func SandboxList(ctx *Context, opts struct {
 					continue
 				}
 			}
-
-			// Extract pool label from metadata
-			var md core_v1alpha.Metadata
-			md.Decode(e.Entity())
-			poolLabel, _ := md.Labels.Get("pool")
-
-			// Get service from pool
-			service := poolServiceMap[poolLabel]
 
 			// Get network address
 			address := ""
@@ -194,6 +236,21 @@ func SandboxList(ctx *Context, opts struct {
 		var sandbox compute_v1alpha.Sandbox
 		sandbox.Decode(e.Entity())
 
+		// Extract pool label from metadata
+		var md core_v1alpha.Metadata
+		md.Decode(e.Entity())
+		poolLabel, _ := md.Labels.Get("pool")
+
+		// Resolve app name from version
+		appName := ui.CleanEntityID(versionAppMap[sandbox.Spec.Version.String()])
+
+		// Narrowing comes before the dead check so that the "N dead hidden"
+		// tally counts what this listing is actually about. Reporting the
+		// cluster's dead sandboxes under `--app foo` would be a non-sequitur.
+		if !filter.keep(appName, poolServiceMap[poolLabel]) {
+			continue
+		}
+
 		if excludeDead && compute.SandboxDead(sandbox.Status) {
 			deadCount++
 			continue
@@ -213,10 +270,6 @@ func SandboxList(ctx *Context, opts struct {
 			continue
 		}
 
-		// Extract pool label from metadata
-		var md core_v1alpha.Metadata
-		md.Decode(e.Entity())
-		poolLabel, _ := md.Labels.Get("pool")
 		poolLabelDisplay := poolLabel
 		if poolLabelDisplay == "" {
 			poolLabelDisplay = "-"
@@ -263,15 +316,14 @@ func SandboxList(ctx *Context, opts struct {
 			poolLabelDisplay = shortId
 		}
 
-		// Resolve app name from version
-		appName := "-"
-		if name, ok := versionAppMap[sandbox.Spec.Version.String()]; ok {
-			appName = ui.CleanEntityID(name)
+		appDisplay := appName
+		if appDisplay == "" {
+			appDisplay = "-"
 		}
 
 		rows = append(rows, ui.Row{
 			sandboxId,
-			appName,
+			appDisplay,
 			versionDisplay,
 			service,
 			poolLabelDisplay,
@@ -284,7 +336,13 @@ func SandboxList(ctx *Context, opts struct {
 	}
 
 	if len(rows) == 0 {
-		ctx.Printf("No sandboxes found\n")
+		// Naming the filters matters most when they're the reason for the empty
+		// result — a typo'd app name is otherwise indistinguishable from an app
+		// that genuinely has nothing running.
+		ctx.Printf("No sandboxes found%s\n", filter.describe())
+		if deadCount > 0 {
+			ctx.Printf("%d dead sandbox(es) hidden. Use --all to show.\n", deadCount)
+		}
 		return nil
 	}
 

--- a/cli/commands/sandbox_list_test.go
+++ b/cli/commands/sandbox_list_test.go
@@ -1,0 +1,67 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSandboxFilterKeep(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  sandboxFilter
+		app     string
+		service string
+		want    bool
+	}{
+		{name: "no filter keeps everything", app: "myapp", service: "web", want: true},
+		{
+			name:   "app matches",
+			filter: sandboxFilter{app: "myapp"},
+			app:    "myapp", service: "worker", want: true,
+		},
+		{
+			name:   "another app is dropped",
+			filter: sandboxFilter{app: "myapp"},
+			app:    "otherapp", service: "web", want: false,
+		},
+		{
+			name:   "service matches",
+			filter: sandboxFilter{service: "worker"},
+			app:    "myapp", service: "worker", want: true,
+		},
+		{
+			name:   "app and service must both match",
+			filter: sandboxFilter{app: "myapp", service: "worker"},
+			app:    "myapp", service: "web", want: false,
+		},
+		{
+			// A sandbox with no pool has no service to speak of, and the table
+			// renders that as "-". Asking for a service should exclude it
+			// rather than sweep it in.
+			name:   "a sandbox with no service is dropped by a service filter",
+			filter: sandboxFilter{service: "web"},
+			app:    "myapp", service: "", want: false,
+		},
+		{
+			name:   "a sandbox with no app is dropped by an app filter",
+			filter: sandboxFilter{app: "myapp"},
+			app:    "", service: "web", want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.filter.keep(tt.app, tt.service))
+		})
+	}
+}
+
+func TestSandboxFilterDescribe(t *testing.T) {
+	require.Empty(t, sandboxFilter{}.describe())
+	require.Equal(t, ` for app "myapp"`, sandboxFilter{app: "myapp"}.describe())
+	require.Equal(t, ` for service "web"`, sandboxFilter{service: "web"}.describe())
+	require.Equal(t,
+		` for app "myapp", service "web"`,
+		sandboxFilter{app: "myapp", service: "web"}.describe())
+}

--- a/cli/commands/sandbox_select.go
+++ b/cli/commands/sandbox_select.go
@@ -1,0 +1,342 @@
+package commands
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"slices"
+	"strings"
+
+	"miren.dev/runtime/api/app"
+	"miren.dev/runtime/api/compute/compute_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// defaultExecService is the service we exec into when the caller didn't name
+// one. An app's other services exist to do work off the request path, so "the
+// app" almost always means the thing serving traffic.
+const defaultExecService = "web"
+
+// sandboxCandidate is a running sandbox that could serve an exec, reduced to
+// the fields the choice actually turns on. Narrowing works on these rather than
+// on entities so it stays a pure function that can be tested without a server.
+type sandboxCandidate struct {
+	// ID is the full entity id, which is what the exec RPC takes.
+	ID entity.Id
+	// Brief is the short id, for telling the user where they landed.
+	Brief   string
+	Service string
+	Version entity.Id
+}
+
+// selectAppSandbox picks one running sandbox belonging to app to exec into. It
+// also returns how many sandboxes it was choosing between, so the caller can
+// stay quiet when there was never a decision to report.
+//
+// service, when set, is a hard filter; when empty the choice falls back to a
+// preference for the web service.
+func selectAppSandbox(ctx *Context, appName, service string) (sandboxCandidate, int, error) {
+	client, err := ctx.RPCClient("entities")
+	if err != nil {
+		return sandboxCandidate{}, 0, err
+	}
+
+	eac := entityserver_v1alpha.NewEntityAccessClient(client)
+	ec := entityserver.NewClient(ctx.Log, eac)
+
+	appEnt, err := app.NewClient(ctx.Log, client).GetByName(ctx, appName)
+	if err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			return sandboxCandidate{}, 0, unknownAppError(appName, err, ctx.Verbose())
+		}
+		return sandboxCandidate{}, 0, err
+	}
+
+	// A sandbox reaches its app through its pool: the pool carries the indexed
+	// app ref, and every pool-created sandbox is labeled with its pool's id.
+	// Going this way rather than through sandbox.spec.version also excludes the
+	// ephemeral sandboxes `miren app run` creates, which have no pool — those
+	// belong to whoever is sitting in them.
+	pools, err := ec.List(ctx, entity.Ref(compute_v1alpha.SandboxPoolAppId, appEnt.ID))
+	if err != nil {
+		return sandboxCandidate{}, 0, fmt.Errorf("failed to list sandbox pools for %q: %w", appName, err)
+	}
+
+	poolService := make(map[string]string)
+	var known []string
+	for pools.Next() {
+		var pool compute_v1alpha.SandboxPool
+		if err := pools.Read(&pool); err != nil {
+			continue
+		}
+
+		if !slices.Contains(known, pool.Service) {
+			known = append(known, pool.Service)
+		}
+
+		if service != "" && pool.Service != service {
+			continue
+		}
+
+		poolService[pool.ID.String()] = pool.Service
+	}
+
+	if service != "" && len(poolService) == 0 {
+		return sandboxCandidate{}, 0, unknownServiceError(appName, service, known)
+	}
+
+	sandboxes, err := ec.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
+	if err != nil {
+		return sandboxCandidate{}, 0, fmt.Errorf("failed to list sandboxes: %w", err)
+	}
+
+	var candidates []sandboxCandidate
+	for sandboxes.Next() {
+		var sb compute_v1alpha.Sandbox
+		if err := sandboxes.Read(&sb); err != nil {
+			continue
+		}
+
+		md := sandboxes.Metadata()
+		if md == nil {
+			continue
+		}
+
+		pool, _ := md.Labels.Get("pool")
+		svc, ours := poolService[pool]
+		if !ours {
+			continue
+		}
+
+		if sb.Status != compute_v1alpha.RUNNING {
+			continue
+		}
+
+		// Exec is forwarded to whichever node the sandbox landed on, so one
+		// that hasn't been placed yet has nowhere to forward to.
+		var sch compute_v1alpha.Schedule
+		sch.Decode(sandboxes.Entity())
+		if entity.Empty(sch.Key.Node) {
+			continue
+		}
+
+		candidates = append(candidates, sandboxCandidate{
+			ID:      sb.ID,
+			Brief:   ui.BriefId(sandboxes.Entity()),
+			Service: svc,
+			Version: sb.Spec.Version,
+		})
+	}
+
+	choice := narrowSandboxCandidates(
+		candidates, appEnt.ActiveVersion, service, slices.Contains(known, defaultExecService))
+
+	switch {
+	case choice.MissingDefault:
+		return sandboxCandidate{}, 0, noDefaultServiceError(appName, choice.Running)
+	case len(choice.Candidates) == 0:
+		return sandboxCandidate{}, 0, noRunningSandboxError(appName, service)
+	}
+
+	return choice.Candidates[rand.IntN(len(choice.Candidates))], len(choice.Candidates), nil
+}
+
+// sandboxChoice is what narrowing produced: either a set to pick from, or the
+// reason there isn't one.
+type sandboxChoice struct {
+	Candidates []sandboxCandidate
+
+	// MissingDefault reports that the app has a web service but none of its
+	// running sandboxes are web. That is not the same as having nothing to
+	// offer, and it must not be answered by handing over a different service.
+	MissingDefault bool
+	// Running lists the services that do have something running, for telling
+	// the caller what they could ask for instead.
+	Running []string
+}
+
+// narrowSandboxCandidates decides which of the running sandboxes are the ones
+// to land in.
+//
+// Service is a requirement and version is a preference, in that order, and the
+// order is the whole design. Which service you get is the difference between a
+// web process and a background worker, so substituting one for the other is
+// never a kindness. Which version you get is the difference between newer and
+// older code for the same job, where insisting is what hurts: a failed deploy
+// leaves ActiveVersion pointing at a version that never came up while the old
+// instances keep serving traffic, and refusing those would lock you out of a
+// shell exactly when a deploy has just broken.
+//
+// So a rolling deploy that has taken web down to the old version still gives
+// you old web rather than new worker, and an app whose web service has nothing
+// running at all gets told so instead of quietly handed a worker.
+//
+// The result is sorted so that the only nondeterminism left is the caller's
+// random pick.
+func narrowSandboxCandidates(
+	candidates []sandboxCandidate,
+	activeVersion entity.Id,
+	service string,
+	appHasDefaultService bool,
+) sandboxChoice {
+	candidates = slices.Clone(candidates)
+
+	// An explicit --service was already applied as a hard filter against the
+	// pools, so this is only the default for a caller who didn't say. An app
+	// with no web service at all is a different case: there's no substitution
+	// to worry about, so every service stays in play.
+	if service == "" && appHasDefaultService {
+		web := keepSandboxes(candidates, func(c sandboxCandidate) bool {
+			return c.Service == defaultExecService
+		})
+
+		if len(web) == 0 {
+			return sandboxChoice{MissingDefault: true, Running: servicesOf(candidates)}
+		}
+
+		candidates = web
+	}
+
+	if !entity.Empty(activeVersion) {
+		candidates = preferSandboxes(candidates, func(c sandboxCandidate) bool {
+			return c.Version == activeVersion
+		})
+	}
+
+	slices.SortFunc(candidates, func(a, b sandboxCandidate) int {
+		return cmp.Compare(a.ID, b.ID)
+	})
+
+	return sandboxChoice{Candidates: candidates}
+}
+
+// servicesOf lists the distinct services present, sorted.
+func servicesOf(candidates []sandboxCandidate) []string {
+	var services []string
+	for _, c := range candidates {
+		if c.Service != "" && !slices.Contains(services, c.Service) {
+			services = append(services, c.Service)
+		}
+	}
+
+	slices.Sort(services)
+
+	return services
+}
+
+// keepSandboxes is a plain filter: what doesn't match is dropped, even if that
+// leaves nothing.
+func keepSandboxes(candidates []sandboxCandidate, want func(sandboxCandidate) bool) []sandboxCandidate {
+	kept := make([]sandboxCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		if want(c) {
+			kept = append(kept, c)
+		}
+	}
+
+	return kept
+}
+
+// preferSandboxes keeps the candidates matching want, unless that would keep
+// none, in which case the field is left as it was.
+func preferSandboxes(candidates []sandboxCandidate, want func(sandboxCandidate) bool) []sandboxCandidate {
+	preferred := make([]sandboxCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		if want(c) {
+			preferred = append(preferred, c)
+		}
+	}
+
+	if len(preferred) == 0 {
+		return candidates
+	}
+
+	return preferred
+}
+
+func unknownAppError(appName string, cause error, verbose bool) error {
+	return &ui.Diagnostic{
+		Summary: fmt.Sprintf("no app named %q", appName),
+		Actions: []ui.Action{
+			{Command: "miren app list", Note: "see the apps on this cluster"},
+		},
+		Cause:     cause,
+		ShowCause: verbose,
+	}
+}
+
+func unknownServiceError(appName, service string, known []string) error {
+	d := &ui.Diagnostic{
+		Summary: fmt.Sprintf("app %q has no service named %q", appName, service),
+		Actions: []ui.Action{
+			{Command: "miren sandbox list --app " + appName, Note: "see what's running for it"},
+		},
+	}
+
+	slices.Sort(known)
+	if len(known) > 0 {
+		d.Detail = fmt.Sprintf("Its services are: %s.", strings.Join(known, ", "))
+	} else {
+		d.Detail = "It has no sandbox pools at all, so nothing has been deployed for it yet."
+	}
+
+	return d
+}
+
+// noDefaultServiceError reports that exec's default service has nothing
+// running, when the app has other services that do. Handing over one of those
+// instead would be a silent substitution of a background worker for the process
+// serving traffic, so we say what happened and let the caller choose.
+func noDefaultServiceError(appName string, running []string) error {
+	d := &ui.Diagnostic{
+		Summary: fmt.Sprintf("no running %s instance for app %q", defaultExecService, appName),
+		Detail: fmt.Sprintf("Without --service, exec goes to the %s service, and none of "+
+			"its sandboxes are up. This is usually a deploy in progress, in which "+
+			"case trying again shortly will find one.", defaultExecService),
+		Actions: []ui.Action{
+			{Command: "miren sandbox list --all --app " + appName, Note: "see this app's sandboxes and their state"},
+		},
+	}
+
+	if len(running) > 0 {
+		d.Detail += fmt.Sprintf(" Still running: %s.", strings.Join(running, ", "))
+		d.Actions = append([]ui.Action{{
+			Command: fmt.Sprintf("miren sandbox exec -a %s --service %s", appName, running[0]),
+			Note:    "exec into that service instead",
+		}}, d.Actions...)
+	}
+
+	return d
+}
+
+func noRunningSandboxError(appName, service string) error {
+	target := fmt.Sprintf("app %q", appName)
+	if service != "" {
+		target = fmt.Sprintf("service %q of app %q", service, appName)
+	}
+
+	return &ui.Diagnostic{
+		Summary: fmt.Sprintf("no running sandbox for %s", target),
+		// The distinction matters for what to try next: a sandbox that exists
+		// but is still starting will fix itself, and one that never starts is a
+		// different problem than an app that was never deployed.
+		//
+		// The listing caveat earns its place because the action below sends the
+		// reader straight to a command that can contradict this message: `app
+		// run` consoles and task runs get a sandbox without a pool, and the
+		// listing resolves an app for those while exec won't target them.
+		Detail: "Nothing is running and placed on a node right now. A sandbox that is " +
+			"still starting up doesn't count, since exec needs one that's already up. " +
+			"The listing below can still show a sandbox here: consoles from `miren app " +
+			"run` and task runs aren't part of a service, so exec won't pick one.",
+		Actions: []ui.Action{
+			{Command: "miren sandbox list --all --app " + appName, Note: "see this app's sandboxes and their state"},
+			{Command: "miren app run -a " + appName, Note: "run a command in a fresh ephemeral sandbox instead"},
+		},
+	}
+}

--- a/cli/commands/sandbox_select_test.go
+++ b/cli/commands/sandbox_select_test.go
@@ -1,0 +1,301 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/ui"
+)
+
+func candidateIDs(candidates []sandboxCandidate) []string {
+	ids := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		ids = append(ids, c.ID.String())
+	}
+	return ids
+}
+
+func TestNarrowSandboxCandidates(t *testing.T) {
+	const (
+		active = entity.Id("app_version/v2")
+		old    = entity.Id("app_version/v1")
+	)
+
+	tests := []struct {
+		name          string
+		candidates    []sandboxCandidate
+		activeVersion entity.Id
+		service       string
+		appHasWeb     bool
+		want          []string
+	}{
+		{
+			name: "drops the previous version when the active one is running",
+			candidates: []sandboxCandidate{
+				{ID: "sandbox/a", Service: "web", Version: old},
+				{ID: "sandbox/b", Service: "web", Version: active},
+			},
+			activeVersion: active,
+			appHasWeb:     true,
+			want:          []string{"sandbox/b"},
+		},
+		{
+			// Mid-deploy the new pool may have nothing up yet. Landing in the
+			// old version beats refusing to exec.
+			name: "keeps the previous version when the active one has nothing running",
+			candidates: []sandboxCandidate{
+				{ID: "sandbox/a", Service: "web", Version: old},
+				{ID: "sandbox/b", Service: "web", Version: old},
+			},
+			activeVersion: active,
+			appHasWeb:     true,
+			want:          []string{"sandbox/a", "sandbox/b"},
+		},
+		{
+			name: "an app with no active version keeps everything",
+			candidates: []sandboxCandidate{
+				{ID: "sandbox/a", Service: "web", Version: old},
+				{ID: "sandbox/b", Service: "web", Version: active},
+			},
+			appHasWeb: true,
+			want:      []string{"sandbox/a", "sandbox/b"},
+		},
+		{
+			name: "picks web over the app's other services",
+			candidates: []sandboxCandidate{
+				{ID: "sandbox/a", Service: "worker", Version: active},
+				{ID: "sandbox/b", Service: "web", Version: active},
+				{ID: "sandbox/c", Service: "cron", Version: active},
+			},
+			activeVersion: active,
+			appHasWeb:     true,
+			want:          []string{"sandbox/b"},
+		},
+		{
+			name: "an app without a web service keeps its other services",
+			candidates: []sandboxCandidate{
+				{ID: "sandbox/a", Service: "worker", Version: active},
+				{ID: "sandbox/b", Service: "cron", Version: active},
+			},
+			activeVersion: active,
+			want:          []string{"sandbox/a", "sandbox/b"},
+		},
+		{
+			// --service is a hard filter applied against the pools, so by the
+			// time we get here the web preference must not narrow further.
+			name: "an explicit service disables the web preference",
+			candidates: []sandboxCandidate{
+				{ID: "sandbox/a", Service: "worker", Version: active},
+				{ID: "sandbox/b", Service: "worker", Version: active},
+			},
+			activeVersion: active,
+			service:       "worker",
+			want:          []string{"sandbox/a", "sandbox/b"},
+		},
+		{
+			// The case that matters most. Web binds a port to go ready and
+			// workers don't, so a rolling deploy routinely has worker on the
+			// new version while web is still on the old one. Preferring the
+			// version first would hand over a worker, silently, since only one
+			// candidate survives and the notice stays quiet at one.
+			name: "a rolling deploy gives you old web, never a new worker",
+			candidates: []sandboxCandidate{
+				{ID: "sandbox/a", Service: "web", Version: old},
+				{ID: "sandbox/b", Service: "worker", Version: active},
+			},
+			activeVersion: active,
+			appHasWeb:     true,
+			want:          []string{"sandbox/a"},
+		},
+		{
+			name:          "no candidates stays empty",
+			candidates:    nil,
+			activeVersion: active,
+			want:          []string{},
+		},
+		{
+			name: "result is sorted so only the caller's pick is random",
+			candidates: []sandboxCandidate{
+				{ID: "sandbox/c", Service: "web", Version: active},
+				{ID: "sandbox/a", Service: "web", Version: active},
+				{ID: "sandbox/b", Service: "web", Version: active},
+			},
+			activeVersion: active,
+			appHasWeb:     true,
+			want:          []string{"sandbox/a", "sandbox/b", "sandbox/c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := narrowSandboxCandidates(tt.candidates, tt.activeVersion, tt.service, tt.appHasWeb)
+			require.False(t, got.MissingDefault)
+			require.Equal(t, tt.want, candidateIDs(got.Candidates))
+		})
+	}
+}
+
+// The input is a decoded snapshot the caller may still be holding; narrowing
+// must not reorder it underneath them.
+func TestNarrowSandboxCandidatesLeavesInputAlone(t *testing.T) {
+	candidates := []sandboxCandidate{
+		{ID: "sandbox/c", Service: "web"},
+		{ID: "sandbox/a", Service: "web"},
+	}
+
+	narrowSandboxCandidates(candidates, "", "", true)
+
+	require.Equal(t, []string{"sandbox/c", "sandbox/a"}, candidateIDs(candidates))
+}
+
+// The substitution phinze caught in review: exec must not answer "your web
+// service has nothing up" by handing over a worker.
+func TestNarrowSandboxCandidatesRefusesToSubstituteAService(t *testing.T) {
+	const active = entity.Id("app_version/v2")
+
+	candidates := []sandboxCandidate{
+		{ID: "sandbox/a", Service: "worker", Version: active},
+		{ID: "sandbox/b", Service: "cron", Version: active},
+	}
+
+	got := narrowSandboxCandidates(candidates, active, "", true)
+
+	require.True(t, got.MissingDefault)
+	require.Empty(t, got.Candidates)
+	require.Equal(t, []string{"cron", "worker"}, got.Running)
+}
+
+// A failed deploy leaves ActiveVersion pointing at a version that never came
+// up while the old instances keep serving. Refusing those would lock you out of
+// a shell exactly when a deploy has just broken, so version stays a preference.
+func TestNarrowSandboxCandidatesStillServesAFailedDeploy(t *testing.T) {
+	const (
+		active = entity.Id("app_version/v2")
+		old    = entity.Id("app_version/v1")
+	)
+
+	candidates := []sandboxCandidate{
+		{ID: "sandbox/a", Service: "web", Version: old},
+	}
+
+	got := narrowSandboxCandidates(candidates, active, "", true)
+
+	require.False(t, got.MissingDefault)
+	require.Equal(t, []string{"sandbox/a"}, candidateIDs(got.Candidates))
+}
+
+func TestNoDefaultServiceError(t *testing.T) {
+	var buf bytes.Buffer
+	noDefaultServiceError("myapp", []string{"worker", "cron"}).(*ui.Diagnostic).WriteForTerminal(&buf)
+
+	out := buf.String()
+	require.Contains(t, out, `no running web instance for app "myapp"`)
+	require.Contains(t, out, "worker, cron")
+	require.Contains(t, out, "miren sandbox exec -a myapp --service worker")
+}
+
+// With nothing else running there is no alternative service to offer, and the
+// message must not invent one.
+func TestNoDefaultServiceErrorWithNothingElseRunning(t *testing.T) {
+	var buf bytes.Buffer
+	noDefaultServiceError("myapp", nil).(*ui.Diagnostic).WriteForTerminal(&buf)
+
+	out := buf.String()
+	require.Contains(t, out, `no running web instance for app "myapp"`)
+	require.NotContains(t, out, "Still running")
+	require.NotContains(t, out, "exec -a myapp --service")
+}
+
+func TestSandboxExecOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    sandboxExecOptions
+		wantErr string
+	}{
+		{name: "id alone", opts: sandboxExecOptions{Id: "sandbox/abc"}},
+		{name: "app alone", opts: sandboxExecOptions{App: "myapp"}},
+		{name: "app with service", opts: sandboxExecOptions{App: "myapp", Service: "worker"}},
+		{name: "neither, id comes from a positional", opts: sandboxExecOptions{}},
+		{
+			name:    "app and id both name a sandbox",
+			opts:    sandboxExecOptions{App: "myapp", Id: "sandbox/abc"},
+			wantErr: "--app and --id",
+		},
+		{
+			name:    "service without app has nothing to select among",
+			opts:    sandboxExecOptions{Id: "sandbox/abc", Service: "worker"},
+			wantErr: "it needs --app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestExecChoiceNotice(t *testing.T) {
+	chosen := sandboxCandidate{ID: "sandbox/myapp-web-abc123", Brief: "abc", Service: "web"}
+
+	t.Run("silent when there was no choice", func(t *testing.T) {
+		require.Empty(t, execChoiceNotice(chosen, 1))
+	})
+
+	t.Run("names the sandbox when there was", func(t *testing.T) {
+		require.Equal(t, "abc (web), picked from 3 running", execChoiceNotice(chosen, 3))
+	})
+}
+
+// A failure against a sandbox we picked has to name the app the caller asked
+// for, since the sandbox id is one they never typed.
+func TestChosenSandboxExecError(t *testing.T) {
+	cause := errors.New("failed to get entity sandbox/myapp-web-abc123: not found")
+	err := chosenSandboxExecError("myapp", sandboxCandidate{Brief: "abc", Service: "web"}, cause)
+
+	require.ErrorContains(t, err, `"myapp"`)
+	require.ErrorIs(t, err, cause)
+
+	var buf bytes.Buffer
+	err.(*ui.Diagnostic).WriteForTerminal(&buf)
+	require.Contains(t, buf.String(), "abc (web)")
+	require.Contains(t, buf.String(), cause.Error())
+}
+
+func TestSandboxExecFlagParsing(t *testing.T) {
+	t.Run("app takes every positional as the command", func(t *testing.T) {
+		cmd := Infer("sandbox exec", "test", SandboxExec)
+		require.NoError(t, cmd.fs.Parse([]string{"-a", "myapp", "--", "ls", "-la", "/app"}))
+
+		opts := cmd.opts.Elem().Interface().(sandboxExecOptions)
+		require.Equal(t, "myapp", opts.App)
+		require.Empty(t, opts.Id)
+		require.Equal(t, []string{"ls", "-la", "/app"}, opts.Args)
+	})
+
+	t.Run("without app the first positional is the id", func(t *testing.T) {
+		cmd := Infer("sandbox exec", "test", SandboxExec)
+		require.NoError(t, cmd.fs.Parse([]string{"sb_abc123", "--", "echo", "hi"}))
+
+		opts := cmd.opts.Elem().Interface().(sandboxExecOptions)
+		require.Empty(t, opts.App)
+		require.Equal(t, []string{"sb_abc123", "echo", "hi"}, opts.Args)
+	})
+
+	t.Run("service is long-only", func(t *testing.T) {
+		cmd := Infer("sandbox exec", "test", SandboxExec)
+		require.NoError(t, cmd.fs.Parse([]string{"-a", "myapp", "--service", "worker"}))
+
+		opts := cmd.opts.Elem().Interface().(sandboxExecOptions)
+		require.Equal(t, "worker", opts.Service)
+	})
+}

--- a/docs/docs/command/sandbox-exec.md
+++ b/docs/docs/command/sandbox-exec.md
@@ -10,9 +10,32 @@ Open interactive shell in an existing sandbox
 
 This command connects to an existing sandbox and runs a command inside it. Unlike `miren app run` which creates a new ephemeral sandbox, this connects to a sandbox that's already running (typically one serving production traffic).
 
-## Finding Sandbox IDs
+## Letting miren pick the sandbox
 
-Use `miren sandbox list` to find the ID of a running sandbox:
+Pass `--app` and you don't need a sandbox ID at all — miren picks one of that app's running sandboxes for you:
+
+```bash
+miren sandbox exec --app myapp
+miren sandbox exec --app myapp -- ls -la /app
+```
+
+The choice is random among the sandboxes that qualify, so with more than one running you may land somewhere different each time. When there was more than one to choose from, miren names the one it picked — on a terminal only, so that piping or redirecting output never mixes miren's chatter into the sandbox's own.
+
+An app with several services gets its `web` service, and only that one. If no web instance is up, miren says so rather than substituting a worker, since landing in the wrong kind of process is worse than being told to try again. Use `--service` to ask for a different one:
+
+```bash
+miren sandbox exec --app myapp --service worker -- ps aux
+```
+
+Within the service you asked for, miren prefers sandboxes running your app's **current** version, so a command run during a deploy won't drop you into the version you just replaced. That one is a preference rather than a rule: a failed deploy leaves the current version pointing at something that never came up while the previous instances keep serving traffic, and refusing those would lock you out of a shell exactly when you need one.
+
+:::warning[Put -- before your command]
+Anything after `--` is passed to the sandbox untouched. Without it, a flag meant for your command is read as a flag for miren — `miren sandbox exec --app myapp ls -la` fails on `-l`, and a `-h` anywhere before `--` prints this help instead of running anything.
+:::
+
+## Finding sandbox IDs
+
+To target a specific sandbox instead, use `miren sandbox list` to find its ID:
 
 ```bash
 $ miren sandbox list
@@ -21,11 +44,11 @@ sandbox/myapp-web-abc123    myapp     web       RUNNING   node-1
 sandbox/myapp-web-def456    myapp     web       RUNNING   node-2
 ```
 
-:::warning
+:::warning[This is a live instance]
 When you exec into a production sandbox, you're connecting to a live instance that may be serving traffic. Be careful with commands that could affect the running application.
 :::
 
-:::tip
+:::tip[Use app run to stay out of the way]
 For debugging or one-off tasks without affecting production, use `miren app run` to create an isolated ephemeral sandbox instead.
 :::
 
@@ -37,9 +60,11 @@ miren sandbox exec [args...] [flags]
 
 ## Flags
 
+- `--app, -a` — Pick a running sandbox belonging to this app
 - `--cluster, -C` — Cluster name
 - `--config` — Path to the config file
 - `--id, -i` — Sandbox ID
+- `--service` — With --app, restrict the choice to one service (default: web)
 
 ## Global Options
 
@@ -59,6 +84,18 @@ miren sandbox exec sb_abc123
 
 ```bash
 miren sandbox exec sb_abc123 -- ls -la /app
+```
+
+**Let miren pick a running sandbox for an app:**
+
+```bash
+miren sandbox exec --app myapp
+```
+
+**Run a command in one of an app's worker sandboxes:**
+
+```bash
+miren sandbox exec --app myapp --service worker -- ps aux
 ```
 
 ## See also

--- a/docs/docs/command/sandbox-list.md
+++ b/docs/docs/command/sandbox-list.md
@@ -17,10 +17,12 @@ miren sandbox list [flags]
 ## Flags
 
 - `--all, -a` — Include dead sandboxes (excluded by default)
+- `--app` — Only show sandboxes belonging to this app
 - `--cluster, -C` — Cluster name
 - `--config` — Path to the config file
 - `--format` — Output format (text, json) (default: `text`)
 - `--json` — Shorthand for --format json
+- `--service` — Only show sandboxes of this service (e.g. web, worker)
 - `--status, -s` — Filter by status (pending, not_ready, running, stopped, dead)
 
 ## Global Options
@@ -41,6 +43,18 @@ miren sandbox list
 
 ```bash
 miren sandbox list --all
+```
+
+**Show only one app's sandboxes:**
+
+```bash
+miren sandbox list --app myapp
+```
+
+**Show only one service of an app:**
+
+```bash
+miren sandbox list --app myapp --service worker
 ```
 
 **List as JSON:**


### PR DESCRIPTION
Getting a shell in a running instance had an annoying preamble. You'd run `miren sandbox list`, scan the table for a row belonging to your app that was actually RUNNING, copy the ID, and only then get to the thing you wanted to do. That's a lookup the CLI has everything it needs to do itself, so now it does: `miren sandbox exec --app myapp -- ls -la` picks one for you.

The selection happens entirely in the CLI. It picks an ID and hands it to the exec RPC through the path that already existed, so there's no server or protocol change in here at all. The proxy still resolves the target's app from the sandbox itself and re-checks access, which is the guard that was actually load-bearing.

The interesting decision was how a sandbox gets connected back to its app. The obvious route is `spec.version` to the app version to the app, which is what `sandbox list` uses for its APP column. I went through the pool instead, since the pool carries the indexed app ref and, more importantly, ephemeral sandboxes don't have one. `miren app run` creates those for console sessions, and picking one would drop you into somebody else's shell.

Among what's left, service is a requirement and version is a preference, in that order, and the asymmetry is the interesting part. Which service you get is the difference between a web process and a background worker, so substituting one for the other is never a kindness: without `--service` you get web, and if web has nothing running you get told that rather than quietly handed a worker. Which version you get is the difference between newer and older code for the same job, where insisting is what hurts, since a failed deploy leaves the current version pointing at something that never came up while the previous instances keep serving traffic. Refusing those would lock you out of a shell exactly when a deploy has just broken.

That ordering matters more than it sounds. Web has to bind its declared port to go ready and workers don't, so a rolling deploy routinely has the worker on the new version while web is still on the old one. Taking version first would hand you a worker there, and silently, since only one candidate survives and the "which one did I pick" notice stays quiet at one. Taking service first gives you old web instead. An app with no web service at all is exempt, since there's nothing to substitute. Whatever survives, we pick from at random, and name the choice on stderr when there was more than one to choose from (on a terminal only, since stdout there belongs to the sandbox).

`sandbox list` picked up matching `--app` and `--service` flags along the way. That started as a nicety and turned out to be load-bearing for the error messages: when exec can't find anything running, "go look at `miren sandbox list --app foo`" is a useful thing to say, and "go look at every sandbox on the cluster" isn't. Those filters match the values shown in the APP and SERVICE columns, so what you filter on is what you see.

Closes MIR-1577
