### PR TITLE
Report app state as snapshots that can sweep

### DIFF
--- a/components/coordinate/appreport.go
+++ b/components/coordinate/appreport.go
@@ -2,37 +2,103 @@ package coordinate
 
 import (
 	"context"
+	"crypto/rand"
 	"time"
 
+	"github.com/oklog/ulid/v2"
+
+	app_v1alpha "miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/pkg/uplink"
 )
 
-// TypeAppSnapshot carries the cluster's full current app set to cloud for
-// visibility reporting, one of the app.* family described in RFD-94.
+// The app.* message family carries the cluster's current app state to cloud
+// for visibility reporting, as described in RFD-94.
 //
-// The type and its payload live with the reporter rather than in pkg/uplink
-// because the link is deliberately payload-agnostic: it moves opaque envelopes
-// and understands no apps. A tenant owns its own wire shape.
-const TypeAppSnapshot = "app.snapshot"
+// These types and their payloads live with the reporter rather than in
+// pkg/uplink because the link is deliberately payload-agnostic: it moves
+// opaque envelopes and understands no apps. A tenant owns its own wire shape.
+const (
+	// TypeAppSnapshot carries one batch of the cluster's full app set.
+	TypeAppSnapshot = "app.snapshot"
 
-// AppSnapshot is the cluster's view of every app it currently runs, sent on
-// each (re)connect. Cloud treats it as ground truth for that cluster.
+	// TypeAppSnapshotComplete closes an epoch and is what authorizes cloud to
+	// sweep. It is a separate message rather than a flag on the final batch so
+	// that a cluster running no apps can still close an epoch, which is the
+	// case where sweeping matters most: every app was deleted.
+	TypeAppSnapshotComplete = "app.snapshot.complete"
+
+	// TypeAppStatus carries one app whose sample changed between snapshots.
+	TypeAppStatus = "app.status"
+)
+
+const (
+	// snapshotBatchSize bounds one message so a large cluster's snapshot
+	// arrives as a slide rather than a jump (RFD-94). Reporting must never take
+	// meaningful horsepower from the cluster's real work.
+	snapshotBatchSize = 100
+
+	// batchPause spaces batches out for the same reason, and leaves the link
+	// available to other tenants during the burst that follows a reconnect.
+	batchPause = 100 * time.Millisecond
+
+	// sampleInterval is how often the reporter re-derives app state and emits
+	// deltas for whatever moved. It sets typical freshness.
+	sampleInterval = 15 * time.Second
+
+	// snapshotFloor is the safety net, not the main repair path, which is why
+	// it is this loose.
+	//
+	// It once had three jobs and is down to one. Deltas are sent with the
+	// blocking send, so they are not silently dropped; if a connection dies
+	// mid-send, the reconnect opens a fresh snapshot anyway. Deletes no longer
+	// wait for it either — a removal triggers a snapshot on the next sample.
+	// What remains is a store that lost its samples without the connection
+	// dropping, which on cloud's disk-backed Valkey survives an ordinary
+	// restart and so is genuinely exceptional.
+	//
+	// The cost of a longer floor is how long that exceptional case shows apps
+	// as awaiting a report. The cost of a shorter one is re-sending unchanged
+	// state across the whole fleet forever. For a rare event, the trade favors
+	// the fleet.
+	snapshotFloor = 15 * time.Minute
+
+	// connectSpread is how far the opening snapshot is scattered across the
+	// fleet.
+	//
+	// Clusters reconnect for reasons that are the same for all of them at once
+	// — a cloud deploy, a load balancer rotation — so without this every
+	// cluster's opening snapshot lands on cloud in the same instant. Jittering
+	// the reconnect alone would only move that spike, since the snapshot
+	// follows the connect immediately.
+	//
+	// Chosen generously rather than tightly, because the cost is asymmetric.
+	// This constant ships inside runtimes customers deploy, so widening it later
+	// means getting a release onto every cluster in the fleet, and the fleets
+	// that would most need it are the slowest to upgrade. Overshooting costs a
+	// slightly later first full picture and nothing else, since this is the
+	// ephemeral tier and deltas keep flowing during the wait.
+	connectSpread = 60 * time.Second
+)
+
+// AppSnapshot is one batch of the cluster's view of every app it currently
+// runs. Cloud treats a complete epoch as ground truth for that cluster.
 //
 // This is the ephemeral tier of RFD-94's volatility spectrum: the weakest
 // durability contract in the design. Delivery is best-effort because loss
 // self-heals — a dropped snapshot is repaired by the next one rather than
 // retried, so nothing here is worth an ack.
-//
-// Two things are deliberately absent and belong to the follow-up that adds
-// sync correctness:
-//
-//   - No epoch. Cloud upserts what it receives and never sweeps, so an app
-//     deleted in the cluster lingers in cloud until epochs arrive and make
-//     mark-and-sweep safe. Sweeping without an epoch would soft-delete apps
-//     that simply haven't landed yet, since a real snapshot arrives in
-//     batches rather than atomically.
-//   - No instance counts or resource usage. Health alone proves the seam.
 type AppSnapshot struct {
+	// Epoch identifies the snapshot this batch belongs to. Cloud accumulates
+	// the apps it sees under an epoch and sweeps whatever is missing only once
+	// the matching complete message arrives, so a snapshot interrupted midway
+	// sweeps nothing at all rather than soft-deleting apps that simply had not
+	// landed yet.
+	//
+	// A ULID rather than a counter because a counter restarts at zero when the
+	// runtime does, and cloud would then see a fresh epoch collide with the
+	// abandoned remains of the previous process's epoch of the same name.
+	Epoch string `json:"epoch"`
+
 	// ObservedAt is the runtime's own clock reading for when this state was
 	// true. Cloud reconciles it against its own clock using the offset from
 	// the link's time sync, and applies last-writer-wins with it, so a delayed
@@ -42,7 +108,46 @@ type AppSnapshot struct {
 	Apps []AppState `json:"apps"`
 }
 
-// AppState is one app's current sample within a snapshot.
+// AppSnapshotComplete closes an epoch and tells cloud how many apps that epoch
+// should have contained.
+//
+// There is deliberately no timestamp here. Every batch already carries the
+// epoch's observed_at, which is the moment the state was derived; a second
+// timestamp taken when transmission happened to finish would describe the
+// sender's pacing rather than the data, and sooner or later someone would
+// reasonably mistake it for the latter.
+type AppSnapshotComplete struct {
+	Epoch string `json:"epoch"`
+
+	// AppCount is how many apps the runtime sent under this epoch, and exists
+	// so a snapshot missing a batch fails safe.
+	//
+	// The link drops on outbox overflow and is drained on reconnect, so batches
+	// can go missing with no error anywhere. Cloud cannot tell a batch that was
+	// dropped from apps that were deleted, and guessing wrong soft-deletes live
+	// apps. Comparing the count it accumulated against the count claimed here
+	// lets it decline to sweep instead, leaving the repair to the next epoch.
+	AppCount int `json:"app_count"`
+}
+
+// AppStatus carries the apps whose samples changed since the last report. A
+// lost delta is not a correctness problem: the next snapshot repairs it.
+//
+// A list rather than one app per message, because changes cluster in time. A
+// rolling deploy, a node draining, an autoscale event: each moves many apps
+// within a single sampling tick, and one message per app would turn that into a
+// burst of envelopes that cloud pays for individually. The ordinary case of a
+// single app degenerates to a one-element list at no cost.
+//
+// All apps in one message share ObservedAt because they come from one
+// derivation of the cluster's state, which is the same reason a snapshot batch
+// carries one timestamp for its whole list.
+type AppStatus struct {
+	ObservedAt time.Time  `json:"observed_at"`
+	Apps       []AppState `json:"apps"`
+}
+
+// AppState is one app's current sample.
 //
 // Note there is no cluster or organization field. Cloud derives both from the
 // authenticated cluster identity on the socket and its own clusters record — a
@@ -56,63 +161,333 @@ type AppState struct {
 	// the same way `miren app list` computes it, deliberately, so the CLI and
 	// the dashboard cannot disagree about whether an app is fine.
 	Health string `json:"health"`
+
+	ReadyInstances   int32 `json:"ready_instances"`
+	DesiredInstances int32 `json:"desired_instances"`
+}
+
+// reportLink is the slice of the uplink the reporter uses. Depending on the
+// narrow interface keeps the reporter testable without standing up a socket,
+// and keeps unrelated link changes from rippling into it.
+//
+// Only the blocking send is here on purpose: everything this reporter sends is
+// part of a sequence, and the dropping form is unsafe for sequences.
+type reportLink interface {
+	SendMessageBlocking(ctx context.Context, msgType string, data any) error
 }
 
 // startAppReporter arranges for the cluster's app state to be reported to
-// cloud on every (re)connection of the uplink.
+// cloud for as long as each connection lasts.
 //
-// Reconnect is the trigger rather than a timer because the uplink discards
-// anything queued while it was down. Whatever cloud missed during an outage
-// never reached the wire at all, so it can only be recovered by re-deriving
-// the current state from the entity store once the link is back. That makes
-// the source, not the pipe, responsible for completeness — see RFD-94.
+// Reporting is scoped to a connection rather than run on a standalone timer
+// because the uplink discards anything queued while it was down. Whatever
+// cloud missed during an outage never reached the wire at all, so it can only
+// be recovered by re-deriving current state from the entity store once the
+// link is back. That makes the source, not the pipe, responsible for
+// completeness — see RFD-94.
 func (c *Coordinator) startAppReporter(link *uplink.Client) {
 	link.OnConnect(func(ctx context.Context) {
 		// Run off the connection goroutine: this reads the entity store, and
 		// the callback returns before the read and write loops start.
-		go c.reportAppSnapshot(ctx)
+		go c.runAppReporter(ctx, link)
 	})
 }
 
-// reportAppSnapshot sends the cluster's current app set to cloud.
+// runAppReporter reports app state until the connection drops.
+//
+// It opens with a full snapshot, then samples on a timer, sending deltas for
+// what changed and a fresh snapshot whenever the floor expires. The two share
+// one derivation of app state so a delta and a snapshot can never disagree
+// about an app's health.
 //
 // Failure here is deliberately non-fatal and unretried. Reporting is value
-// flowing up to a value-add control plane, never a dependency flowing down:
-// a cluster runs indefinitely with no cloud attached, and visibility simply
+// flowing up to a value-add control plane, never a dependency flowing down: a
+// cluster runs indefinitely with no cloud attached, and visibility simply
 // stops updating until the link returns. Nothing the cluster does for its own
 // users may degrade because this failed, so the loudest response available is
 // a warning.
-func (c *Coordinator) reportAppSnapshot(ctx context.Context) {
-	if c.appInfo == nil || c.uplink == nil {
+func (c *Coordinator) runAppReporter(ctx context.Context, link reportLink) {
+	if c.appInfo == nil {
 		return
 	}
 
+	c.reportLoop(ctx, link, c.deriveAppState, reportTiming{
+		spread: connectSpread,
+		sample: sampleInterval,
+		floor:  snapshotFloor,
+	})
+}
+
+// reportTiming is the loop's cadence, injectable so a test can drive the
+// snapshot-or-delta decision without waiting out a real fifteen-minute floor.
+type reportTiming struct {
+	spread time.Duration
+	sample time.Duration
+	floor  time.Duration
+}
+
+// reportLoop is runAppReporter with its two dependencies handed in: where state
+// comes from, and how fast the clock runs. The decision it makes each tick is
+// the part worth testing and the part nothing else covers, since everything it
+// calls is exercised directly elsewhere.
+func (c *Coordinator) reportLoop(
+	ctx context.Context,
+	link reportLink,
+	deriveState func(context.Context) (map[string]AppState, error),
+	timing reportTiming,
+) {
+	// Wait out this cluster's share of the spread before the opening snapshot,
+	// so a fleet that reconnected together does not report together.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(uplink.SpreadOnConnect(timing.spread)):
+	}
+
+	// Held per connection, not on the Coordinator. After a reconnect cloud's
+	// state is unknown and the opening snapshot re-establishes all of it, so
+	// carrying deltas across the gap would be reasoning from a baseline that
+	// no longer describes anything.
+	var lastSent map[string]AppState
+
+	// A store that stays unhappy would otherwise warn on every sample tick for
+	// as long as it lasts, which is the retry-loop-that-cannot-converge case
+	// CLAUDE.md calls out: it drowns the tier it is in. Say it once, stay quiet
+	// while it persists, and say how many times it happened once it clears, so
+	// an operator gets the beginning and the end rather than the middle.
+	failures := 0
+	derive := func() (map[string]AppState, bool) {
+		state, err := deriveState(ctx)
+		if err != nil {
+			failures++
+			if failures == 1 {
+				c.Log.Warn("failed to list apps for cloud report", "error", err)
+			} else {
+				c.Log.Debug("still failing to list apps for cloud report",
+					"error", err, "failures", failures)
+			}
+			return nil, false
+		}
+
+		if failures > 0 {
+			c.Log.Info("listing apps for cloud report recovered", "failures", failures)
+			failures = 0
+		}
+		return state, true
+	}
+
+	if state, ok := derive(); ok {
+		if c.sendAppSnapshot(ctx, link, state) == nil {
+			lastSent = state
+		}
+	}
+
+	ticker := time.NewTicker(timing.sample)
+	defer ticker.Stop()
+
+	lastSnapshot := time.Now()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		state, ok := derive()
+		if !ok {
+			continue
+		}
+
+		if lastSent == nil || removedAny(lastSent, state) || time.Since(lastSnapshot) >= timing.floor {
+			if c.sendAppSnapshot(ctx, link, state) != nil {
+				continue
+			}
+			lastSnapshot = time.Now()
+			lastSent = state
+			continue
+		}
+
+		if c.sendAppDeltas(ctx, link, lastSent, state) != nil {
+			continue
+		}
+		lastSent = state
+	}
+}
+
+// removedAny reports whether any app in the last report is gone now.
+//
+// A removal is the one change deltas cannot carry, so it is what promotes an
+// ordinary sample tick into a full snapshot. Cloud learns about deletes only
+// by comparing a completed epoch against what it holds, which means without
+// this the floor would set how long a deleted app keeps appearing in the
+// console — and the floor is tuned for a rare failure, not for something a
+// user does on purpose and then goes looking for.
+//
+// Firing a whole snapshot to communicate a delete looks heavy-handed next to
+// sending a "deleted" message, and that is the point: a message can be lost,
+// and its loss leaves a phantom app in the console with nothing to correct it.
+// Deriving deletes from a complete epoch has no such failure mode. This only
+// changes when that epoch happens, never how deletes are decided.
+//
+// No debounce is needed. One tick sees every removal since the last report at
+// once, so a mass deletion produces a single snapshot, and the sample interval
+// already bounds how often this can fire.
+func removedAny(previous, current map[string]AppState) bool {
+	for name := range previous {
+		if _, ok := current[name]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+// deriveAppState lists the cluster's apps and reduces them to the sample
+// fields cloud stores, keyed by name.
+// The caller owns the logging, because how loudly a failure should be reported
+// depends on how many came before it, and only the loop knows that.
+func (c *Coordinator) deriveAppState(ctx context.Context) (map[string]AppState, error) {
 	apps, err := c.appInfo.ListApps(ctx)
 	if err != nil {
-		c.Log.Warn("failed to list apps for cloud snapshot", "error", err)
-		return
+		return nil, err
 	}
 
-	snapshot := AppSnapshot{
-		ObservedAt: time.Now().UTC(),
-		Apps:       make([]AppState, 0, len(apps)),
-	}
-
+	state := make(map[string]AppState, len(apps))
 	for _, a := range apps {
-		snapshot.Apps = append(snapshot.Apps, AppState{
-			Name:   a.Name(),
-			Health: a.Health(),
+		state[a.Name()] = appStateFrom(a)
+	}
+	return state, nil
+}
+
+func appStateFrom(a *app_v1alpha.AppInfo) AppState {
+	return AppState{
+		Name:             a.Name(),
+		Health:           a.Health(),
+		ReadyInstances:   a.ReadyInstances(),
+		DesiredInstances: a.DesiredInstances(),
+	}
+}
+
+// sendAppSnapshot streams a full epoch: every app in bounded batches, then the
+// complete message that authorizes cloud to sweep.
+//
+// Batches use the blocking send. A snapshot is a sequence, and a silently
+// dropped batch in a sequence does not look like a lost sample that the next
+// report repairs — it looks exactly like those apps having been deleted.
+func (c *Coordinator) sendAppSnapshot(ctx context.Context, link reportLink, state map[string]AppState) error {
+	// Not MustNew. This runs on a goroutine of its own, so a panic here would
+	// take the process down over a failure to report, and reporting is the one
+	// thing in this file that must never cost the cluster anything. An entropy
+	// failure is close to impossible on a real host, which is exactly why it
+	// would be an absurd way to lose a runtime.
+	id, err := ulid.New(ulid.Now(), rand.Reader)
+	if err != nil {
+		c.Log.Warn("failed to mint app snapshot epoch", "error", err)
+		return err
+	}
+
+	epoch := id.String()
+	observedAt := time.Now().UTC()
+
+	batch := make([]AppState, 0, snapshotBatchSize)
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		// Hand off the slice and start a fresh one rather than truncating and
+		// refilling. Reusing the backing array would leave every batch already
+		// queued pointing at storage the next batch overwrites, which is only
+		// invisible today because the sender marshals before it returns.
+		apps := batch
+		batch = make([]AppState, 0, snapshotBatchSize)
+
+		return link.SendMessageBlocking(ctx, TypeAppSnapshot, AppSnapshot{
+			Epoch:      epoch,
+			ObservedAt: observedAt,
+			Apps:       apps,
 		})
 	}
 
-	if err := c.uplink.SendMessage(TypeAppSnapshot, snapshot); err != nil {
-		c.Log.Warn("failed to queue app snapshot for cloud", "error", err)
-		return
+	for _, app := range state {
+		batch = append(batch, app)
+		if len(batch) < snapshotBatchSize {
+			continue
+		}
+		if err := flush(); err != nil {
+			c.Log.Warn("failed to queue app snapshot batch", "epoch", epoch, "error", err)
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(batchPause):
+		}
 	}
 
-	// Queued, not reported: SendMessage returns nil whether or not the envelope
-	// made it into the outbox, which drops on overflow and is discarded on
-	// reconnect. Claiming we reported would assert something we cannot observe
-	// from here.
-	c.Log.Info("queued app snapshot for cloud", "apps", len(snapshot.Apps))
+	if err := flush(); err != nil {
+		c.Log.Warn("failed to queue app snapshot batch", "epoch", epoch, "error", err)
+		return err
+	}
+
+	err = link.SendMessageBlocking(ctx, TypeAppSnapshotComplete, AppSnapshotComplete{
+		Epoch:    epoch,
+		AppCount: len(state),
+	})
+	if err != nil {
+		// Without the complete message cloud sweeps nothing, which is the safe
+		// outcome: the apps it received still upsert, and the next epoch closes
+		// properly. Worth a warning because deletes stop propagating until then.
+		c.Log.Warn("failed to close app snapshot epoch", "epoch", epoch, "error", err)
+		return err
+	}
+
+	// Queued, not sent. The blocking send tightened the claim but did not close
+	// it: the envelope sits in the outbox until the write loop drains it, and a
+	// reconnect discards whatever is still there. Saying "sent" would mislead
+	// whoever reads this line against an empty console.
+	c.Log.Info("queued app snapshot for cloud", "epoch", epoch, "apps", len(state))
+	return nil
+}
+
+// sendAppDeltas reports the apps whose samples moved since the last report.
+//
+// Only changes go on the wire, which is what keeps a 15-second sampling
+// interval from becoming a 15-second write cycle on an idle cluster. Apps that
+// appeared are deltas too; apps that disappeared are not, because a delta
+// cannot express a delete. Removal rides on a snapshot's sweep instead — see
+// removedAny, which is what makes sure that snapshot comes promptly rather
+// than whenever the floor next expires.
+func (c *Coordinator) sendAppDeltas(ctx context.Context, link reportLink, previous, current map[string]AppState) error {
+	observedAt := time.Now().UTC()
+
+	changed := make([]AppState, 0, len(current))
+	for name, app := range current {
+		if before, ok := previous[name]; ok && before == app {
+			continue
+		}
+		changed = append(changed, app)
+	}
+
+	if len(changed) == 0 {
+		return nil
+	}
+
+	// Deltas go out in one message however many apps moved. They are bounded by
+	// what changed in a single sampling interval rather than by the size of the
+	// cluster, so unlike a snapshot there is nothing here to batch.
+	err := link.SendMessageBlocking(ctx, TypeAppStatus, AppStatus{
+		ObservedAt: observedAt,
+		Apps:       changed,
+	})
+	if err != nil {
+		c.Log.Warn("failed to queue app status deltas", "apps", len(changed), "error", err)
+		return err
+	}
+
+	// Debug rather than Info: this fires on the sample tick whenever anything
+	// moved, and an operator cannot act on the fact that three apps changed.
+	// The snapshot log above marks the state transitions worth reading.
+	c.Log.Debug("queued app status deltas for cloud", "apps", len(changed))
+	return nil
 }

--- a/components/coordinate/appreport_test.go
+++ b/components/coordinate/appreport_test.go
@@ -1,0 +1,520 @@
+package coordinate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingSender captures what the reporter puts on the wire, standing in for
+// the uplink so these tests exercise the message sequence rather than a socket.
+type recordingSender struct {
+	sent []sentMessage
+}
+
+type sentMessage struct {
+	Type string
+	Data any
+}
+
+func (r *recordingSender) SendMessageBlocking(_ context.Context, msgType string, data any) error {
+	r.sent = append(r.sent, sentMessage{Type: msgType, Data: data})
+	return nil
+}
+
+func (r *recordingSender) ofType(msgType string) []sentMessage {
+	var out []sentMessage
+	for _, m := range r.sent {
+		if m.Type == msgType {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func testCoordinator() *Coordinator {
+	return &Coordinator{Log: slog.Default()}
+}
+
+func appStates(names ...string) map[string]AppState {
+	state := make(map[string]AppState, len(names))
+	for _, n := range names {
+		state[n] = AppState{Name: n, Health: "healthy", ReadyInstances: 1, DesiredInstances: 1}
+	}
+	return state
+}
+
+// A snapshot larger than one batch has to arrive as several messages that
+// cloud can recognize as one epoch, and the closing count has to describe the
+// whole snapshot rather than the last batch. Cloud's sweep is gated on exactly
+// that comparison, so getting the count wrong here disables deletes entirely.
+func TestSnapshotBatchesUnderOneEpoch(t *testing.T) {
+	const total = snapshotBatchSize*2 + 5
+
+	names := make([]string, 0, total)
+	for i := range total {
+		names = append(names, string(rune('a'+i%26))+string(rune('a'+i/26)))
+	}
+	state := appStates(names...)
+
+	c := testCoordinator()
+	sender := &recordingSender{}
+
+	if err := c.sendAppSnapshot(t.Context(), sender, state); err != nil {
+		t.Fatalf("sendAppSnapshot: %v", err)
+	}
+
+	batches := sender.ofType(TypeAppSnapshot)
+	if len(batches) != 3 {
+		t.Fatalf("expected 3 batches for %d apps, got %d", total, len(batches))
+	}
+
+	epoch := ""
+	seen := map[string]bool{}
+	for i, m := range batches {
+		batch, ok := m.Data.(AppSnapshot)
+		if !ok {
+			t.Fatalf("batch %d carried %T, not AppSnapshot", i, m.Data)
+		}
+		if len(batch.Apps) > snapshotBatchSize {
+			t.Errorf("batch %d carried %d apps, over the %d bound", i, len(batch.Apps), snapshotBatchSize)
+		}
+		if epoch == "" {
+			epoch = batch.Epoch
+		} else if batch.Epoch != epoch {
+			t.Errorf("batch %d used epoch %q, expected %q", i, batch.Epoch, epoch)
+		}
+		for _, a := range batch.Apps {
+			if seen[a.Name] {
+				t.Errorf("app %q appeared in more than one batch", a.Name)
+			}
+			seen[a.Name] = true
+		}
+	}
+
+	if len(seen) != total {
+		t.Errorf("epoch carried %d distinct apps, expected %d", len(seen), total)
+	}
+
+	complete := sender.ofType(TypeAppSnapshotComplete)
+	if len(complete) != 1 {
+		t.Fatalf("expected exactly one complete message, got %d", len(complete))
+	}
+	done, ok := complete[0].Data.(AppSnapshotComplete)
+	if !ok {
+		t.Fatalf("complete carried %T, not AppSnapshotComplete", complete[0].Data)
+	}
+	if done.Epoch != epoch {
+		t.Errorf("complete closed epoch %q, batches used %q", done.Epoch, epoch)
+	}
+	if done.AppCount != total {
+		t.Errorf("complete claimed %d apps, sent %d", done.AppCount, total)
+	}
+
+	// The closing message must come last, or cloud would sweep against a
+	// partially accumulated epoch and delete apps still in flight behind it.
+	if last := sender.sent[len(sender.sent)-1]; last.Type != TypeAppSnapshotComplete {
+		t.Errorf("epoch closed with a %s, expected the complete message last", last.Type)
+	}
+}
+
+// The case where sweeping matters most is the one with nothing to send: every
+// app was deleted. An epoch has to close even with no batches, which is why
+// completion is its own message rather than a flag on the last batch.
+func TestSnapshotClosesEpochWithNoApps(t *testing.T) {
+	c := testCoordinator()
+	sender := &recordingSender{}
+
+	if err := c.sendAppSnapshot(t.Context(), sender, map[string]AppState{}); err != nil {
+		t.Fatalf("sendAppSnapshot: %v", err)
+	}
+
+	if batches := sender.ofType(TypeAppSnapshot); len(batches) != 0 {
+		t.Errorf("expected no batches for an empty cluster, got %d", len(batches))
+	}
+
+	complete := sender.ofType(TypeAppSnapshotComplete)
+	if len(complete) != 1 {
+		t.Fatalf("an empty cluster must still close its epoch, got %d complete messages", len(complete))
+	}
+	if done := complete[0].Data.(AppSnapshotComplete); done.AppCount != 0 {
+		t.Errorf("expected a count of 0, got %d", done.AppCount)
+	}
+}
+
+// Deltas exist to keep an idle cluster quiet between snapshots. If unchanged
+// apps went on the wire, a 15-second sample interval would become a
+// 15-second write cycle against every app in cloud.
+func TestDeltasReportOnlyWhatMoved(t *testing.T) {
+	previous := appStates("web", "worker", "cron")
+
+	current := appStates("web", "worker", "cron")
+	current["web"] = AppState{Name: "web", Health: "degraded", ReadyInstances: 1, DesiredInstances: 1}
+	current["worker"] = AppState{Name: "worker", Health: "healthy", ReadyInstances: 3, DesiredInstances: 3}
+	current["api"] = AppState{Name: "api", Health: "starting", ReadyInstances: 0, DesiredInstances: 1}
+
+	c := testCoordinator()
+	sender := &recordingSender{}
+
+	if err := c.sendAppDeltas(t.Context(), sender, previous, current); err != nil {
+		t.Fatalf("sendAppDeltas: %v", err)
+	}
+
+	// Everything that moved rides in one message. Changes cluster in time, so a
+	// message per app would turn a rolling deploy into a burst of envelopes that
+	// cloud pays for individually.
+	messages := sender.ofType(TypeAppStatus)
+	if len(messages) != 1 {
+		t.Fatalf("expected one delta message for three changed apps, got %d", len(messages))
+	}
+
+	delta, ok := messages[0].Data.(AppStatus)
+	if !ok {
+		t.Fatalf("delta carried %T, not AppStatus", messages[0].Data)
+	}
+
+	reported := map[string]AppState{}
+	for _, app := range delta.Apps {
+		reported[app.Name] = app
+	}
+
+	if len(reported) != 3 {
+		t.Fatalf("expected deltas for web, worker and api, got %v", reported)
+	}
+	if _, ok := reported["cron"]; ok {
+		t.Error("reported a delta for an app that did not change")
+	}
+	if got := reported["web"].Health; got != "degraded" {
+		t.Errorf("web reported health %q, expected degraded", got)
+	}
+	if got := reported["worker"].ReadyInstances; got != 3 {
+		t.Errorf("worker reported %d ready instances, expected 3", got)
+	}
+}
+
+// A delta cannot express a delete, and inventing one would reintroduce exactly
+// the lose-a-message failure that mark-and-sweep exists to avoid. A vanished
+// app must stay silent and wait for the next epoch to sweep it.
+func TestDeltasStaySilentAboutRemovedApps(t *testing.T) {
+	previous := appStates("web", "worker")
+	current := appStates("web")
+
+	c := testCoordinator()
+	sender := &recordingSender{}
+
+	if err := c.sendAppDeltas(t.Context(), sender, previous, current); err != nil {
+		t.Fatalf("sendAppDeltas: %v", err)
+	}
+
+	if got := len(sender.sent); got != 0 {
+		t.Fatalf("expected silence when an app disappears, got %d messages: %+v", got, sender.sent)
+	}
+}
+
+// A removal is the one change a delta cannot carry, so it has to promote the
+// tick into a full snapshot. Without this, how long a deleted app keeps
+// showing up in the console would be set by the snapshot floor, which is tuned
+// for a rare failure rather than for something a user did on purpose and is
+// actively looking for.
+func TestRemovalPromotesTheTickToASnapshot(t *testing.T) {
+	previous := appStates("web", "worker")
+
+	if !removedAny(previous, appStates("web")) {
+		t.Error("an app disappearing should force a snapshot")
+	}
+	if !removedAny(previous, appStates()) {
+		t.Error("every app disappearing should force a snapshot")
+	}
+}
+
+// The cases that must stay on the cheap path. Snapshots are the expensive
+// message, and promoting a tick that only changed a health value or gained an
+// app would put the whole fleet back to re-sending everything on every change.
+func TestOrdinaryChangesStayOnTheDeltaPath(t *testing.T) {
+	previous := appStates("web", "worker")
+
+	if removedAny(previous, appStates("web", "worker")) {
+		t.Error("an unchanged app set should not force a snapshot")
+	}
+	if removedAny(previous, appStates("web", "worker", "api")) {
+		t.Error("a new app arrives as a delta and should not force a snapshot")
+	}
+
+	flipped := appStates("web", "worker")
+	flipped["web"] = AppState{Name: "web", Health: "crashed"}
+	if removedAny(previous, flipped) {
+		t.Error("a health change should not force a snapshot")
+	}
+
+	// A rename is a delete plus an add, and the delete half is what matters:
+	// without a snapshot the old name would linger in the console forever.
+	if !removedAny(previous, appStates("web", "worker-renamed")) {
+		t.Error("a rename should force a snapshot so the old name is swept")
+	}
+}
+
+// The wire shape is the contract every downstream consumer builds on, and
+// cloud unmarshals these by field name. Renaming one is a silent break, so the
+// JSON is pinned here rather than left to whatever the struct happens to emit.
+func TestSnapshotWireShape(t *testing.T) {
+	raw, err := json.Marshal(AppSnapshot{
+		Epoch: "01J000000000000000000000AB",
+		Apps: []AppState{{
+			Name:             "web",
+			Health:           "healthy",
+			ReadyInstances:   2,
+			DesiredInstances: 3,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var shape struct {
+		Epoch      string `json:"epoch"`
+		ObservedAt string `json:"observed_at"`
+		Apps       []struct {
+			Name             string `json:"name"`
+			Health           string `json:"health"`
+			ReadyInstances   int32  `json:"ready_instances"`
+			DesiredInstances int32  `json:"desired_instances"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal(raw, &shape); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if shape.Epoch == "" || len(shape.Apps) != 1 {
+		t.Fatalf("snapshot did not round-trip: %s", raw)
+	}
+
+	// The delta shares the snapshot's shape for its app list, so a consumer can
+	// decode either with one type. Divergence here is the kind that only shows
+	// up as a field silently reading zero on the far side.
+	rawDelta, err := json.Marshal(AppStatus{
+		Apps: []AppState{{Name: "web", Health: "healthy", ReadyInstances: 2}},
+	})
+	if err != nil {
+		t.Fatalf("marshal delta: %v", err)
+	}
+
+	var deltaShape struct {
+		ObservedAt string `json:"observed_at"`
+		Apps       []struct {
+			Name           string `json:"name"`
+			Health         string `json:"health"`
+			ReadyInstances int32  `json:"ready_instances"`
+		} `json:"apps"`
+	}
+	if err := json.Unmarshal(rawDelta, &deltaShape); err != nil {
+		t.Fatalf("unmarshal delta: %v", err)
+	}
+	if len(deltaShape.Apps) != 1 || deltaShape.Apps[0].Name != "web" || deltaShape.Apps[0].ReadyInstances != 2 {
+		t.Errorf("delta did not round-trip under the snapshot's app shape: %s", rawDelta)
+	}
+
+	// The completion message carries no timestamp on purpose.
+	rawComplete, err := json.Marshal(AppSnapshotComplete{Epoch: "e", AppCount: 3})
+	if err != nil {
+		t.Fatalf("marshal complete: %v", err)
+	}
+	if bytes.Contains(rawComplete, []byte("observed_at")) {
+		t.Errorf("complete grew a timestamp nothing reads: %s", rawComplete)
+	}
+	app := shape.Apps[0]
+	if app.Name != "web" || app.Health != "healthy" {
+		t.Errorf("app identity did not round-trip: %s", raw)
+	}
+	if app.ReadyInstances != 2 || app.DesiredInstances != 3 {
+		t.Errorf("instance counts did not round-trip: %s", raw)
+	}
+}
+
+// The three-way decision each tick makes — snapshot, deltas, or skip — is the
+// one part of the reporter nothing else covers, because the real intervals are
+// minutes long. These drive reportLoop directly with a stubbed state source and
+// a millisecond clock.
+
+// collectSent drains a recorder until it has seen wantTypes worth of messages
+// or the deadline passes, so a test asserts on what the loop chose rather than
+// on how fast the machine ran it.
+func waitForMessages(t *testing.T, sender *lockedSender, n int) []sentMessage {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := sender.snapshot(); len(got) >= n {
+			return got
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return sender.snapshot()
+}
+
+// lockedSender is recordingSender with a mutex, since the loop runs on its own
+// goroutine here.
+type lockedSender struct {
+	mu   sync.Mutex
+	sent []sentMessage
+}
+
+func (l *lockedSender) SendMessageBlocking(_ context.Context, msgType string, data any) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.sent = append(l.sent, sentMessage{Type: msgType, Data: data})
+	return nil
+}
+
+func (l *lockedSender) snapshot() []sentMessage {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return slices.Clone(l.sent)
+}
+
+func fastTiming() reportTiming {
+	return reportTiming{spread: 0, sample: 5 * time.Millisecond, floor: time.Hour}
+}
+
+func countOfType(msgs []sentMessage, msgType string) int {
+	n := 0
+	for _, m := range msgs {
+		if m.Type == msgType {
+			n++
+		}
+	}
+	return n
+}
+
+// An opening snapshot that fails must leave lastSent nil, so the next tick
+// tries a snapshot again rather than sending deltas against a baseline that was
+// never established. Getting this wrong would have cloud's first picture of a
+// cluster be a delta describing changes from nothing.
+func TestFailedOpeningSnapshotRetriesAsSnapshot(t *testing.T) {
+	c := testCoordinator()
+	sender := &failThenRecord{failures: 2}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	state := appStates("web")
+	go c.reportLoop(ctx, sender, func(context.Context) (map[string]AppState, error) {
+		return state, nil
+	}, fastTiming())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && countOfType(sender.snapshot(), TypeAppSnapshotComplete) == 0 {
+		time.Sleep(2 * time.Millisecond)
+	}
+	cancel()
+
+	got := sender.snapshot()
+	if countOfType(got, TypeAppStatus) != 0 {
+		t.Errorf("sent deltas before any snapshot succeeded: %+v", got)
+	}
+	if countOfType(got, TypeAppSnapshotComplete) == 0 {
+		t.Error("never retried the snapshot after the opening one failed")
+	}
+}
+
+// Once a snapshot lands, ordinary changes ride deltas. If this regressed to
+// sending snapshots the fleet would re-send everything on every tick.
+func TestSteadyStateSendsDeltasNotSnapshots(t *testing.T) {
+	c := testCoordinator()
+	sender := &lockedSender{}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var mu sync.Mutex
+	health := "healthy"
+	go c.reportLoop(ctx, sender, func(context.Context) (map[string]AppState, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return map[string]AppState{"web": {Name: "web", Health: health}}, nil
+	}, fastTiming())
+
+	waitForMessages(t, sender, 2) // the opening snapshot plus its completion
+
+	mu.Lock()
+	health = "degraded"
+	mu.Unlock()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && countOfType(sender.snapshot(), TypeAppStatus) == 0 {
+		time.Sleep(2 * time.Millisecond)
+	}
+	cancel()
+
+	got := sender.snapshot()
+	if countOfType(got, TypeAppStatus) == 0 {
+		t.Error("a health change should have gone out as a delta")
+	}
+	if n := countOfType(got, TypeAppSnapshotComplete); n != 1 {
+		t.Errorf("expected exactly the opening snapshot, got %d completions", n)
+	}
+}
+
+// A removal promotes the tick to a full snapshot, end to end through the loop.
+// Deltas cannot carry a delete, so without this the app lingers in the console
+// until the floor expires.
+func TestRemovalPromotesTheTickEndToEnd(t *testing.T) {
+	c := testCoordinator()
+	sender := &lockedSender{}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var mu sync.Mutex
+	apps := appStates("web", "worker")
+	go c.reportLoop(ctx, sender, func(context.Context) (map[string]AppState, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return apps, nil
+	}, fastTiming())
+
+	waitForMessages(t, sender, 2)
+
+	mu.Lock()
+	apps = appStates("web")
+	mu.Unlock()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && countOfType(sender.snapshot(), TypeAppSnapshotComplete) < 2 {
+		time.Sleep(2 * time.Millisecond)
+	}
+	cancel()
+
+	if n := countOfType(sender.snapshot(), TypeAppSnapshotComplete); n < 2 {
+		t.Errorf("a removal should have forced a second snapshot, saw %d completions", n)
+	}
+}
+
+// failThenRecord fails its first few sends, standing in for a link that cannot
+// carry the opening snapshot yet.
+type failThenRecord struct {
+	mu       sync.Mutex
+	failures int
+	sent     []sentMessage
+}
+
+func (f *failThenRecord) SendMessageBlocking(_ context.Context, msgType string, data any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failures > 0 {
+		f.failures--
+		return context.DeadlineExceeded
+	}
+	f.sent = append(f.sent, sentMessage{Type: msgType, Data: data})
+	return nil
+}
+
+func (f *failThenRecord) snapshot() []sentMessage {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.sent)
+}

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -426,14 +426,12 @@ type Coordinator struct {
 	// ready. nil when sagas are disabled. See MIR-1285.
 	sagaBuilder *build.SagaBuilder
 
-	// appInfo and uplink are retained so app state can be reported up to
-	// cloud for visibility (MIR-1558). appInfo is the same instance backing
-	// the app RPC surface, so cloud sees the health `miren app list` sees;
-	// uplink is the control-plane link to send it on. Both are nil when cloud
+	// appInfo is retained so app state can be reported up to cloud for
+	// visibility (MIR-1558). It is the same instance backing the app RPC
+	// surface, so cloud sees the health `miren app list` sees. nil when cloud
 	// auth is not configured, which is the disconnected case reporting must
 	// tolerate.
 	appInfo *app.AppInfo
-	uplink  *uplink.Client
 }
 
 func (c *Coordinator) Activator() activator.AppActivator {
@@ -1630,8 +1628,6 @@ func (c *Coordinator) Start(ctx context.Context) error {
 			uplink.NewMessageRouter(),
 			c.Log.With("component", "uplink"),
 		)
-		c.uplink = link
-
 		anywhereConn := anywhere.New(anywhere.Config{
 			ClusterXID: c.CloudAuth.ClusterID,
 			Ingress:    c.hs,

--- a/pkg/uplink/client.go
+++ b/pkg/uplink/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"net/http"
 	"slices"
 	"strings"
@@ -23,6 +24,19 @@ const (
 	maxBackoff     = 60 * time.Second
 	wsEndpoint     = "/api/v1/cluster-channel/ws"
 	writeTimeout   = 10 * time.Second
+
+	// backoffJitter is the fraction of a delay that is randomized away.
+	//
+	// Clusters do not disconnect independently. The common cause is something
+	// on the other end — a cloud deploy, a load balancer rotation — which drops
+	// every cluster at the same instant. An undithered backoff then marches the
+	// entire fleet back in lockstep, and since each one opens a snapshot on
+	// connect, cloud takes the whole fleet's reconnect work as a single spike
+	// rather than as a rate.
+	//
+	// Subtracting rather than adding matters: it keeps the delay bounded by the
+	// backoff schedule instead of letting the worst case drift past maxBackoff.
+	backoffJitter = 0.3
 )
 
 // Client maintains a persistent WebSocket connection to the cloud
@@ -186,6 +200,56 @@ func (c *Client) SendMessage(msgType string, data any) error {
 	return nil
 }
 
+// SendBlocking queues an envelope, waiting for room instead of dropping when
+// the outbox is full. It returns when the envelope is queued, or with the
+// context's error if the connection goes away first.
+//
+// Send's drop-on-overflow is the right behavior for a single small message
+// whose loss self-heals, but wrong for a stream. A tenant sending a bounded
+// sequence — a snapshot in batches, a backfill walking a watermark — is
+// pushing faster than one message per connect, and silent drops there don't
+// read as "we lost a sample," they read as "that batch never existed." For a
+// snapshot that is indistinguishable from apps having been deleted.
+//
+// Blocking makes the write loop's drain rate the natural throttle, which is
+// also what lets two streaming tenants share the link without coordinating:
+// neither can starve the other by filling the outbox, because filling it just
+// slows the filler down. Callers must pass the connection-scoped context so a
+// sender parked here is released when the connection drops rather than waking
+// up to write into a socket that is gone.
+func (c *Client) SendBlocking(ctx context.Context, env *Envelope) error {
+	// Checked before the select rather than left to it. When the outbox has
+	// room and the context is already dead, both cases below are ready and Go
+	// picks between them at random, so a sender whose connection just went away
+	// would queue an envelope about half the time. That envelope usually dies
+	// in the next connect's drainOutbox, but a sender that was slow enough to
+	// straddle the reconnect can land it on the *new* connection instead, which
+	// for a snapshot means an abandoned epoch arriving intact and authorizing a
+	// sweep against a stale picture. Making the contract deterministic is worth
+	// more than the nanosecond, particularly for something other tenants build
+	// on.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	select {
+	case c.outbox <- env:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// SendMessageBlocking marshals data and queues it, waiting for outbox room.
+// See SendBlocking for when to prefer this over SendMessage.
+func (c *Client) SendMessageBlocking(ctx context.Context, msgType string, data any) error {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", msgType, err)
+	}
+	return c.SendBlocking(ctx, &Envelope{Type: msgType, Data: raw})
+}
+
 // Run maintains the WebSocket connection with reconnection. It blocks
 // until the context is cancelled.
 func (c *Client) Run(ctx context.Context) error {
@@ -204,17 +268,49 @@ func (c *Client) Run(ctx context.Context) error {
 			backoff = initialBackoff
 		}
 
+		delay := jittered(backoff)
+
 		c.log.Warn("websocket disconnected, reconnecting",
-			"error", err, "backoff", backoff)
+			"error", err, "backoff", delay)
 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(backoff):
+		case <-time.After(delay):
 		}
 
 		backoff = min(backoff*2, maxBackoff)
 	}
+}
+
+// jittered spreads a delay over [(1-backoffJitter)·d, d] so a fleet knocked
+// offline together does not come back together.
+func jittered(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	return d - time.Duration(rand.Float64()*backoffJitter*float64(d))
+}
+
+// SpreadOnConnect returns a delay a tenant should wait before starting the
+// work it does on each connect, so that work is spread across the fleet rather
+// than landing as one spike.
+//
+// Exported rather than kept inside Run because jittering the reconnect alone
+// only moves the spike: a fleet that comes back staggered but then has every
+// cluster immediately stream a snapshot has changed when the pile-up happens,
+// not whether it does. Tenants need the same treatment for their own connect
+// work.
+//
+// The window is the caller's choice because it depends on what the work is
+// worth delaying. Anything on the ephemeral tier can afford a generous one:
+// nothing downstream distinguishes a snapshot that starts now from one that
+// starts a minute from now.
+func SpreadOnConnect(window time.Duration) time.Duration {
+	if window <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Float64() * float64(window))
 }
 
 // runOnce connects and processes messages until an error occurs.

--- a/pkg/uplink/client_test.go
+++ b/pkg/uplink/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -342,6 +343,171 @@ func TestOnConnectContextCancelledOnDisconnect(t *testing.T) {
 	case <-cancelled:
 	case <-time.After(3 * time.Second):
 		t.Fatal("callback context outlived the connection")
+	}
+}
+
+// A streaming tenant needs backpressure, not the drop Send does. Losing one
+// batch of a snapshot is not a lost sample the next one repairs — it looks
+// exactly like the apps in that batch no longer existing, which is what makes
+// silent drops dangerous for anything sent as a sequence.
+func TestSendBlockingWaitsForRoomInsteadOfDropping(t *testing.T) {
+	c := &Client{
+		log:    slog.Default(),
+		outbox: make(chan *Envelope, 1),
+	}
+
+	c.Send(&Envelope{Type: "first"})
+
+	// Send would drop this one on the floor and report nothing.
+	queued := make(chan error, 1)
+	go func() {
+		queued <- c.SendBlocking(t.Context(), &Envelope{Type: "second"})
+	}()
+
+	select {
+	case <-queued:
+		t.Fatal("SendBlocking returned while the outbox was full")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if got := <-c.outbox; got.Type != "first" {
+		t.Fatalf("expected first out of the outbox, got %s", got.Type)
+	}
+
+	select {
+	case err := <-queued:
+		if err != nil {
+			t.Fatalf("SendBlocking: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SendBlocking stayed parked after the outbox drained")
+	}
+
+	if got := <-c.outbox; got.Type != "second" {
+		t.Fatalf("expected second out of the outbox, got %s", got.Type)
+	}
+}
+
+// The counterpart risk to blocking: a sender parked on a full outbox when the
+// connection dies must be released rather than held until the next drain. The
+// connection-scoped context is what does that, so a caller passing the wrong
+// one leaks a goroutine per reconnect.
+func TestSendBlockingReleasesOnContextCancel(t *testing.T) {
+	c := &Client{
+		log:    slog.Default(),
+		outbox: make(chan *Envelope, 1),
+	}
+
+	c.Send(&Envelope{Type: "filler"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	released := make(chan error, 1)
+	go func() {
+		released <- c.SendBlocking(ctx, &Envelope{Type: "parked"})
+	}()
+
+	// Give the sender a moment to actually park before pulling it back out.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-released:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SendBlocking outlived its connection context")
+	}
+}
+
+// Clusters do not disconnect independently — a cloud deploy drops all of them
+// at once — so an undithered backoff marches the whole fleet back in lockstep
+// and hands cloud the fleet's reconnect work as one spike. What matters is
+// that the delays actually spread, not that any single one is a given value.
+func TestBackoffJitterSpreadsReconnects(t *testing.T) {
+	const base = 10 * time.Second
+
+	buckets := map[int]bool{}
+	for range 500 {
+		got := jittered(base)
+
+		if got > base {
+			t.Fatalf("jittered(%v) = %v, must not exceed the backoff schedule", base, got)
+		}
+		if min := time.Duration(float64(base) * (1 - backoffJitter)); got < min {
+			t.Fatalf("jittered(%v) = %v, below the %v floor", base, got, min)
+		}
+
+		buckets[int(got/(base/20))] = true
+	}
+
+	// A constant would land in one bucket; a healthy spread covers most of them.
+	if len(buckets) < 5 {
+		t.Errorf("reconnect delays clustered into %d buckets, expected them spread", len(buckets))
+	}
+}
+
+// Jittering the reconnect alone only moves the spike, because each tenant
+// starts streaming the moment it connects. The spread has to reach that work
+// too, which is what SpreadOnConnect is for.
+func TestSpreadOnConnectScattersAcrossTheWindow(t *testing.T) {
+	const window = time.Minute
+
+	buckets := map[int]bool{}
+	for range 500 {
+		got := SpreadOnConnect(window)
+
+		if got < 0 || got >= window {
+			t.Fatalf("SpreadOnConnect(%v) = %v, outside the window", window, got)
+		}
+		buckets[int(got/(window/20))] = true
+	}
+
+	if len(buckets) < 15 {
+		t.Errorf("connect delays covered %d of 20 buckets, expected a wide scatter", len(buckets))
+	}
+}
+
+// A zero or negative window means the caller wants no spreading, which has to
+// mean "go now" rather than panicking or blocking forever.
+func TestSpreadOnConnectHandlesNoWindow(t *testing.T) {
+	if got := SpreadOnConnect(0); got != 0 {
+		t.Errorf("SpreadOnConnect(0) = %v, want 0", got)
+	}
+	if got := SpreadOnConnect(-time.Second); got != 0 {
+		t.Errorf("SpreadOnConnect(-1s) = %v, want 0", got)
+	}
+	if got := jittered(0); got != 0 {
+		t.Errorf("jittered(0) = %v, want 0", got)
+	}
+}
+
+// With outbox room available and a dead context, both select cases are ready
+// and Go chooses at random, so this has to be decided before the select or it
+// is right about half the time. A sender that slips an envelope through after
+// its connection died can have it land on the next connection instead, which
+// for a snapshot means an abandoned epoch arriving whole and authorizing a
+// sweep against stale state.
+func TestSendBlockingRefusesADeadContextEvenWithRoom(t *testing.T) {
+	c := &Client{
+		log:    slog.Default(),
+		outbox: make(chan *Envelope, outboxSize),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Repeated because the bug is probabilistic: one attempt passes half the
+	// time even with the check missing.
+	for range 200 {
+		if err := c.SendBlocking(ctx, &Envelope{Type: "should-not-land"}); !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	}
+
+	if got := len(c.outbox); got != 0 {
+		t.Errorf("%d envelopes queued on a cancelled context, expected none", got)
 	}
 }
 


### PR DESCRIPTION
Another step in getting a real sync protocol running over our uplink! We spent a lot of time looking at the scaling properties of the protocol here: one cluster many apps, many clusters checking into cloud, that kind of thing. That's what landed the snapshot batching and startup jitter into the mix, as well as the follow up issues to think through other aspects of this uplink protocol scaling up.

If "epoch" and "mark-and-sweep" read as jargon: an epoch is which snapshot a message belongs to, and mark-and-sweep is the GC trick, mark what the snapshot mentions and delete what it doesn't.

There's deliberately no delete message anywhere, because that's the one message whose loss you can never recover from. (Another way to design around this would be to change `app delete` to record tombstones but that would be its own can-o-worms.)

---

🤖 The reporter sent one snapshot when the uplink connected and then went quiet, so cloud's picture aged until the next reconnect and it never learned that an app had been deleted. Deletes are the hard half. A delete message can be dropped, and unlike a stale health value its loss is permanent, so nothing later repairs it. An app's absence from a completed snapshot proves the deletion instead.

Here's the conversation that produces, with the two pre-existing exchanges at the top for context:

```mermaid
sequenceDiagram
    autonumber
    participant R as runtime
    participant C as cloud

    R->>C: WebSocket upgrade (bearer token)
    C-->>R: 101 Switching Protocols
    Note over C: token resolves to clusterXID,<br/>the only identity that counts

    R->>C: time.request (t1)
    C-->>R: time.response (t1, t2, t3)
    R->>C: org.info.request
    C-->>R: org.info.response (organization_id)

    Note over R: wait a random slice of 60s,<br/>so the fleet does not report in unison

    R->>C: app.snapshot (epoch, observed_at, up to 100 apps)
    R->>C: app.snapshot (epoch, observed_at, remaining apps)
    R->>C: app.snapshot.complete (epoch, app_count)
    Note over C: marks == app_count ? sweep absent apps<br/>: create only, sweep nothing

    loop every 15s, only when something moved
        R->>C: app.status (observed_at, changed apps)
    end

    Note over R: an app disappeared,<br/>or the 15 minute floor expired
    R->>C: app.snapshot ... complete (fresh epoch)
```

The epoch is what lets cloud recognize a snapshot as a whole. Batches carry it, the closing message carries the count of what was sent, and cloud sweeps only when the two agree. A snapshot interrupted by a disconnect never sends its closing message and so sweeps nothing, which is what lets the design skip timeouts and partial-apply logic entirely: the missing message is already the safe state. The count covers the case the epoch can't, where a batch dropped on outbox overflow looks exactly like the apps in it having been deleted.

Between snapshots the reporter samples every fifteen seconds and sends only what moved, so an idle cluster stays quiet. A removal can't ride a delta, so it promotes that tick to a full snapshot rather than waiting out the floor. That's what lets the floor sit at fifteen minutes: it's a backstop for a lost sample store rather than the main repair path. Instance counts come along because they were already on `AppInfo` and cost nothing.

The first rev is the uplink rather than the reporter, because two other things had to be true first. `Send` drops on outbox overflow, which is right for a lone message whose loss self-heals and wrong for a sequence, so streaming tenants get a blocking send. And reconnect backoff had no jitter, which matters much more now that every cluster opens a snapshot the moment it connects: clusters don't disconnect independently, so the fleet was marching back in lockstep. MIR-1560 wants both, which is why they're separated out.

One thing worth flagging for review: the sixty-second connect spread is chosen generously rather than measured. Widening it later means shipping a release to every cluster in the fleet, so the cost of overshooting is a slightly later first snapshot and the cost of undershooting is a stampede we can't easily fix. MIR-1587 covers handing that number to cloud instead.

Part of MIR-1559.
