### PR TITLE
Report the deploy log to cloud with a resumable watermark

### DIFF
--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1635,6 +1635,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 			Uplink:     link,
 		})
 		c.startAppReporter(link)
+		c.startDeployReporter(link)
 
 		go func() {
 			// POP connections outlive individual reconnects but not the link

--- a/components/coordinate/deployreport.go
+++ b/components/coordinate/deployreport.go
@@ -1,0 +1,777 @@
+package coordinate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sort"
+	"time"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	esv1 "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/deploylifecycle"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/idgen"
+	"miren.dev/runtime/pkg/rpc/stream"
+	"miren.dev/runtime/pkg/uplink"
+)
+
+// The deploy.* message family carries the cluster's deploy log to cloud, the
+// durable half of the visibility contract in RFD-94.
+//
+// These types are one half of a wire contract. The other half is
+// DeployBatch/DeployState in mirendev/cloud, services/cluster_channel/
+// deploy_handlers.go, and nothing enforces that the two agree: cloud does not
+// import this module, so renaming a json tag here leaves both repos building
+// and every test on both sides passing while the field silently stops
+// arriving. Change a tag, a type or a message name here and you must change it
+// there in the same breath. MIR-1601 is the fix that makes this checkable.
+//
+// It differs from app.* in what a lost message costs. App state is an ephemeral
+// sample and a dropped one self-heals from the next report. A deploy is an event
+// that happened once, and the runtime prunes its own records over time, so once
+// cloud has a deploy it becomes the book of record for it. Nothing here can be
+// left to best effort.
+const (
+	// TypeDeploySyncHello opens deploy sync on a connection, asking cloud where
+	// its copy left off.
+	//
+	// The runtime asks rather than cloud volunteering because three of the four
+	// reasons to distrust a cursor are only visible from this side: whether the
+	// revision has been compacted away, whether it sits above the store's
+	// current head, and whether it is coherent at all. Only "cloud has none"
+	// is visible from over there, and that arrives as a zero. Putting the
+	// question here keeps one decision in one function.
+	TypeDeploySyncHello = "deploy.sync.hello"
+
+	// TypeDeploySyncCursor is cloud's answer: the revision below which it
+	// believes its copy is complete.
+	TypeDeploySyncCursor = "deploy.sync.cursor"
+
+	// TypeDeployBatch carries a contiguous run of deploys and the range it
+	// covers.
+	//
+	// Named for the contiguity claim rather than for the write it performs —
+	// RFD-94 sketches this as deploy.upsert — because the claim is the part
+	// that matters. A message called "upsert" invites a second sender that
+	// upserts without a range, and cloud advancing its watermark on that would
+	// open exactly the permanent gap this design exists to prevent.
+	TypeDeployBatch = "deploy.batch"
+)
+
+const (
+	// deployBatchSize bounds one message so a backfill arrives as a slide
+	// rather than a jump (RFD-94). Reporting must never take meaningful
+	// horsepower from the cluster's real work.
+	deployBatchSize = 100
+
+	// deployBatchPause spaces batches out for the same reason, and leaves the
+	// link available to its other tenants during a long backfill.
+	deployBatchPause = 250 * time.Millisecond
+
+	// deployConnectSpread is how far the opening handshake is scattered across
+	// the fleet, and it deliberately starts after the app reporter's own
+	// spread rather than overlapping it.
+	//
+	// A cluster that just came online should finish painting its app list
+	// before a backfill's long tail starts competing for the same link. That
+	// ordering is a preference rather than a requirement: both tenants send
+	// with backpressure, so an overlap would resolve into them sharing the
+	// pipe rather than one starving the other. Starting later simply makes the
+	// common case the intended one.
+	deployConnectSpread = 90 * time.Second
+
+	// maxErrorReasonBytes bounds the failure reason put on the wire.
+	//
+	// RFD-94 asks for a short reason and never raw build output, and until now
+	// that was a sentence in a comment with nothing enforcing it: the entity's
+	// error message went out whole. A deploy that failed with a stack trace or
+	// a wall of compiler output would ship all of it, which smuggles build logs
+	// past the custody boundary the rest of this file is careful about, and
+	// blows the frame budget on top.
+	//
+	// Truncation is deterministic, so the same record always produces the same
+	// payload. That matters more than it looks: a value that varied per report
+	// would defeat the upsert the way a drifting deployed_at would.
+	maxErrorReasonBytes = 512
+
+	// deployCursorTimeout bounds the wait for cloud's answer.
+	//
+	// A cloud that never answers is treated as a cloud with no cursor, which
+	// costs a re-list and no correctness. Waiting forever instead would mean a
+	// cluster silently stops reporting deploys against a cloud that is up
+	// enough to hold a socket but not to answer.
+	deployCursorTimeout = 30 * time.Second
+)
+
+// DeploySyncHello opens the exchange. It carries no fields today; the runtime
+// is asking a question, not asserting anything.
+type DeploySyncHello struct{}
+
+// DeploySyncCursor is cloud's reply.
+type DeploySyncCursor struct {
+	// Watermark is the revision below which cloud believes its copy is
+	// complete. Zero means it has none.
+	//
+	// A plain value rather than a pointer, unlike the app snapshot's count,
+	// because here absent and zero call for the same thing: a full re-list.
+	// The count guard needed the distinction because a missing field would
+	// otherwise have authorized a destructive sweep. Nothing destructive hangs
+	// off this one, so the two states can safely collapse.
+	Watermark int64 `json:"watermark"`
+}
+
+// DeployBatch is a contiguous run of deploys: every deploy the runtime holds
+// whose revision falls in (FromRevision, ToRevision], with nothing omitted.
+//
+// That claim is what lets cloud move its watermark, and it is why the range
+// travels in the same message as the deploys rather than in a closing message
+// of its own. The app snapshot needs a separate completion message and a count
+// because its epoch spans many envelopes, so a dropped one is invisible. A
+// batch is a single envelope: it arrives whole or not at all, and if it does
+// not arrive the watermark simply does not move. There is nothing for a count
+// to catch.
+type DeployBatch struct {
+	FromRevision int64 `json:"from_revision"`
+	ToRevision   int64 `json:"to_revision"`
+
+	// HeadRevision is the store's head when this connection's sync began.
+	//
+	// Cloud does not need it to decide anything — the runtime already made the
+	// cursor decision, since it is the side that can see compaction. It is
+	// reported so cloud can record what this store's revision sequence looked
+	// like, which is what makes a rebuilt etcd legible after the fact rather
+	// than only at the moment it is detected.
+	HeadRevision int64 `json:"head_revision"`
+
+	// ObservedAt is when the runtime read this state. Cloud keeps it distinct
+	// from its own receipt time so staleness stays visible.
+	ObservedAt time.Time `json:"observed_at"`
+
+	// Deploys may be empty, and an empty batch is meaningful rather than
+	// wasted: it says the range holds no deploys, which is how the watermark
+	// advances across long stretches of unrelated entity writes. Revisions are
+	// store-global, so most of the sequence belongs to other kinds entirely.
+	Deploys []DeployState `json:"deploys"`
+}
+
+// DeployState is one deploy as the runtime holds it.
+//
+// Two things are deliberately absent, for different reasons.
+//
+// Build logs are absent permanently. They stay in the cluster on custody
+// grounds and because they belong to observability (RFD-54), not to this
+// contract. The entity carries them, so this projection is written by hand
+// rather than encoded from the record — an Encode() here would ship them the
+// first time anyone stopped thinking about it.
+//
+// The actor is absent for now. Deployer identity is captured nowhere in the
+// runtime yet (MIR-1271), and the fields that exist hold empty strings on the
+// real deploy path. RFD-94 is explicit that deploys land in cloud unattributed
+// rather than carrying an empty or client-asserted actor, so there is no field
+// here to fill in with a lie.
+type DeployState struct {
+	// ID is the deployment entity id, and cloud's idempotency key. Batches
+	// overlap by design — a re-list re-sends what the previous connection
+	// already delivered — so writes have to collapse on this.
+	ID string `json:"id"`
+
+	// Revision orders writes to this deploy. Store-global and monotonic, so it
+	// settles which of two reports of the same deploy is newer without
+	// consulting any clock.
+	Revision int64 `json:"revision"`
+
+	AppName    string `json:"app_name"`
+	AppVersion string `json:"app_version"`
+	Status     string `json:"status"`
+	Phase      string `json:"phase"`
+
+	// DeployedAt is when the deploy was initiated, and must be identical in
+	// every report of this deploy: cloud partitions on it, so a value that
+	// drifted would write a second row instead of updating the first. It comes
+	// from the record's creation time, which is written once and never
+	// rewritten.
+	DeployedAt  time.Time  `json:"deployed_at"`
+	CompletedAt *time.Time `json:"completed_at"`
+
+	// ErrorReason is a short failure reason, never raw build output.
+	ErrorReason *string `json:"error_reason"`
+
+	Git *DeployGit `json:"git"`
+
+	// SourceDeployID links a rollback or redeploy to what it was based on.
+	SourceDeployID *string `json:"source_deploy_id"`
+}
+
+// DeployGit is the provenance cloud keeps for a deploy.
+//
+// Commit author and author email are on the entity and are left there. They
+// are the PII-carrying half of the git record, RFD-94 asks for the minimum
+// that serves the feature, and the erasure story for git identity is still
+// open. Nothing in visibility needs them today, so taking them would be
+// collecting against a use we have not defined.
+type DeployGit struct {
+	SHA        string `json:"sha"`
+	Branch     string `json:"branch"`
+	Repository string `json:"repository"`
+}
+
+// deployLink is the slice of the uplink the reporter uses.
+//
+// Only the blocking send is here, on purpose. Everything this reporter sends is
+// part of a sequence, and Send's drop-on-overflow is unsafe for sequences: a
+// dropped batch is not a lost sample that the next report repairs, it is a
+// range cloud will never be told about again unless the watermark stays put.
+type deployLink interface {
+	SendMessageBlocking(ctx context.Context, msgType string, data any) error
+}
+
+// deploySource is the runtime state the reporter reads.
+//
+// Narrow and injectable so the sync logic — which is where all the correctness
+// lives — can be tested against a fake store rather than a live etcd.
+type deploySource interface {
+	// HeadRevision reports the store's current revision.
+	HeadRevision(ctx context.Context) (int64, error)
+
+	// List returns every deploy the runtime holds, with the revision the read
+	// was taken at.
+	List(ctx context.Context) ([]*deploylifecycle.Record, int64, error)
+
+	// Watch streams deploy operations in revision order starting just after
+	// fromRevision, blocking until the context ends or the stream fails.
+	Watch(ctx context.Context, fromRevision int64, fn func(*esv1.EntityOp) error) error
+}
+
+// errCompacted ends a stream that cannot continue because the revision it
+// resumed from has been compacted away.
+//
+// A sentinel rather than a log-and-stop because it is the one stream ending
+// that is recoverable and has a specific remedy: the caller re-lists. Every
+// other reason a watch ends means the connection is going away, and the next
+// one starts the exchange over anyway.
+var errCompacted = errors.New("watch start revision has been compacted")
+
+// syncMode is how a connection's deploy sync proceeds.
+type syncMode int
+
+const (
+	// syncDelta streams from cloud's watermark. Catch-up and live tail are the
+	// same ordered stream in this mode, so there is nothing to run alongside
+	// it.
+	syncDelta syncMode = iota
+
+	// syncRelist re-sends everything the runtime holds, oldest first, then
+	// continues from the revision the listing was taken at.
+	syncRelist
+)
+
+// decideSyncMode settles whether a cursor can be used, and says why when it
+// cannot.
+//
+// This is the whole of RFD-94's fallback rule except the compaction case, which
+// cannot be decided here because it is not visible until the watch is opened
+// and reports it. Every case resolves to a re-list, which is the point: a wrong
+// cursor costs a re-list and never data, so this only has to be conservative,
+// not clever.
+func decideSyncMode(watermark, head int64) (syncMode, string) {
+	switch {
+	case watermark == 0:
+		// First contact, or a cursor cloud discarded. Both leave it absent.
+		return syncRelist, "cloud has no watermark"
+
+	case watermark < 0:
+		// Not a revision any store ever issued. Nothing sane produces this, so
+		// the interesting property is that it fails toward the safe path
+		// rather than being used as an offset into a watch.
+		return syncRelist, "watermark is not a valid revision"
+
+	case watermark > head:
+		// A rebuilt etcd starts its revision sequence over, leaving cloud's
+		// watermark stranded above anything this store will issue for a long
+		// time. Reporting head is what turns that into a detectable reset
+		// instead of a watch that silently waits for a revision that already
+		// came and went under different data.
+		return syncRelist, "watermark is ahead of the store's head revision"
+
+	default:
+		return syncDelta, ""
+	}
+}
+
+// startDeployReporter arranges for the cluster's deploy log to be reported to
+// cloud for as long as each connection lasts.
+func (c *Coordinator) startDeployReporter(link *uplink.Client) {
+	reporter := &deployReporter{
+		log:     c.Log.With("module", "coordinate.deployreport"),
+		source:  &entityDeploySource{eac: c.eac},
+		cursors: make(chan int64, 1),
+	}
+
+	link.Handle(TypeDeploySyncCursor, reporter.handleCursor)
+
+	link.OnConnect(func(ctx context.Context) {
+		// Run off the connection goroutine: this reads the entity store, and
+		// the callback returns before the read and write loops start.
+		go reporter.run(ctx, link)
+	})
+}
+
+// deployReporter reports the deploy log over one connection at a time.
+type deployReporter struct {
+	log    *slog.Logger
+	source deploySource
+
+	// cursors carries cloud's replies from the router, which is registered
+	// once for the process, to whichever run is currently waiting. Buffered by
+	// one and drained at the start of each run, so a reply that arrived too
+	// late to be used cannot be mistaken for the answer to the next
+	// connection's question.
+	cursors chan int64
+
+	// Pacing, held as fields rather than read from the constants directly so a
+	// test can drive the protocol without waiting out a spread measured in
+	// minutes. Zero means the constant.
+	spread        time.Duration
+	cursorTimeout time.Duration
+	batchPause    time.Duration
+}
+
+func (r *deployReporter) spreadWindow() time.Duration {
+	if r.spread == 0 {
+		return deployConnectSpread
+	}
+	return r.spread
+}
+
+func (r *deployReporter) timeout() time.Duration {
+	if r.cursorTimeout == 0 {
+		return deployCursorTimeout
+	}
+	return r.cursorTimeout
+}
+
+func (r *deployReporter) pause() time.Duration {
+	if r.batchPause == 0 {
+		return deployBatchPause
+	}
+	return r.batchPause
+}
+
+func (r *deployReporter) handleCursor(_ context.Context, data json.RawMessage) error {
+	var cursor DeploySyncCursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return err
+	}
+
+	select {
+	case r.cursors <- cursor.Watermark:
+	default:
+		// Nobody is waiting, or an answer is already queued. Dropping is right:
+		// an unmatched cursor is stale by definition, and the next connection
+		// asks again.
+		r.log.Debug("discarding unexpected deploy sync cursor", "watermark", cursor.Watermark)
+	}
+
+	return nil
+}
+
+// run reports deploys until the connection drops.
+//
+// Failure here is deliberately non-fatal and unretried within a connection.
+// Reporting is value flowing up to a value-add control plane, never a
+// dependency flowing down: a cluster runs indefinitely with no cloud attached,
+// and the next connection starts the whole exchange over. Nothing the cluster
+// does for its own users may degrade because this failed.
+func (r *deployReporter) run(ctx context.Context, link deployLink) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(uplink.SpreadOnConnect(r.spreadWindow())):
+	}
+
+	watermark, err := r.requestCursor(ctx, link)
+	if err != nil {
+		r.log.Warn("failed to learn cloud's deploy watermark", "error", err)
+		return
+	}
+
+	head, err := r.source.HeadRevision(ctx)
+	if err != nil {
+		r.log.Warn("failed to read store head revision", "error", err)
+		return
+	}
+
+	mode, reason := decideSyncMode(watermark, head)
+	if mode == syncDelta {
+		r.log.Info("resuming deploy sync from cloud's watermark",
+			"watermark", watermark, "head", head)
+
+		err := r.stream(ctx, link, watermark, head)
+		if err == nil || ctx.Err() != nil {
+			return
+		}
+
+		// Compaction is the one stream failure a re-list actually fixes: the
+		// gap between cloud's watermark and what the store still remembers can
+		// no longer be replayed, so the only way to close it is to send
+		// everything again.
+		//
+		// Anything else — a transport error, the entity server going away — is
+		// not evidence the cursor is bad, and re-listing on it would turn a
+		// blip into a full re-send of the cluster's history. The connection is
+		// coming down anyway, and the next one starts the handshake over.
+		if !errors.Is(err, errCompacted) {
+			r.log.Warn("deploy stream ended, waiting for the next connection", "error", err)
+			return
+		}
+
+		r.log.Info("deploy watermark has been compacted away, re-listing")
+	} else {
+		r.log.Info("re-listing deploys for cloud", "reason", reason,
+			"watermark", watermark, "head", head)
+	}
+
+	r.relist(ctx, link, head)
+}
+
+// requestCursor asks cloud where its copy left off and waits for the answer.
+func (r *deployReporter) requestCursor(ctx context.Context, link deployLink) (int64, error) {
+	// Drain first: a reply from the previous connection that lost the race with
+	// its own teardown would otherwise be read as this connection's answer.
+	select {
+	case <-r.cursors:
+	default:
+	}
+
+	if err := link.SendMessageBlocking(ctx, TypeDeploySyncHello, DeploySyncHello{}); err != nil {
+		return 0, err
+	}
+
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case watermark := <-r.cursors:
+		return watermark, nil
+	case <-time.After(r.timeout()):
+		// Treated as "no cursor" rather than as a failure, which costs a
+		// re-list and nothing else.
+		r.log.Warn("cloud did not answer the deploy sync hello, re-listing")
+		return 0, nil
+	}
+}
+
+// stream follows the store from a revision, shipping each deploy as its own
+// contiguous batch.
+//
+// In this mode catch-up and live tail are the same thing: the watch replays
+// what was missed and then continues into new activity without a seam, so every
+// message can carry a range and advance the watermark. The two-stream split
+// RFD-94 describes is only needed when there is no usable cursor, which is what
+// relist handles.
+//
+// Returns nil when the connection ends, and an error when the stream must fall
+// back to a re-list.
+func (r *deployReporter) stream(ctx context.Context, link deployLink, from, head int64) error {
+	sent := from
+
+	return r.source.Watch(ctx, from, func(op *esv1.EntityOp) error {
+		if op.IsCompacted() {
+			return errCompacted
+		}
+
+		revision := op.Revision()
+		if revision <= sent {
+			return nil
+		}
+
+		batch := DeployBatch{
+			FromRevision: sent,
+			ToRevision:   revision,
+			HeadRevision: head,
+			ObservedAt:   time.Now().UTC(),
+		}
+
+		// A batch here can be empty for two different reasons, and both still
+		// advance the range.
+		//
+		// The ordinary one is a progress notification, which carries no entity:
+		// the store saying "nothing you care about happened up to here."
+		// Shipping it as an empty batch is what lets the watermark keep pace
+		// during quiet periods instead of freezing at the last deploy, which on
+		// a cluster that deploys rarely would mean re-walking a widening gap on
+		// every connect.
+		//
+		// The other is a deploy this reporter had to drop, having no stable
+		// creation time to key it by. The empty batch then means "a deploy was
+		// here and is not coming," which is worth reading as different from
+		// silence. Advancing anyway is still right: holding the range back
+		// would wedge the watermark permanently, since the next connection
+		// re-streams the same revision and drops it again, and a record with no
+		// stable timestamp has no home in cloud to hold open for it either.
+		if op.HasEntity() {
+			if state, ok := r.stateFrom(op.Entity()); ok {
+				batch.Deploys = append(batch.Deploys, state)
+			} else {
+				// relist counts these; the tail said nothing, which made the
+				// same event visible on one path and invisible on the other.
+				r.log.Debug("skipping deploy with no usable creation time",
+					"entity_id", op.EntityId(), "revision", revision)
+			}
+		}
+
+		if err := link.SendMessageBlocking(ctx, TypeDeployBatch, batch); err != nil {
+			return err
+		}
+
+		sent = revision
+		return nil
+	})
+}
+
+// relist re-sends every deploy the runtime holds, oldest first, then continues
+// from the revision the listing was taken at.
+//
+// Oldest-first is what makes the watermark truthful. A single number cannot
+// express holes, so the frontier can only advance along a contiguous line from
+// the bottom; walking newest-first would either advance it over deploys not yet
+// sent or not advance it at all. It also makes an interrupted backfill free to
+// resume: whatever ranges committed stay committed, and the next connection
+// picks up from the watermark they left behind.
+func (r *deployReporter) relist(ctx context.Context, link deployLink, head int64) {
+	records, readRevision, err := r.source.List(ctx)
+	if err != nil {
+		r.log.Warn("failed to list deploys for cloud", "error", err)
+		return
+	}
+
+	states := make([]DeployState, 0, len(records))
+	skipped := 0
+	for _, rec := range records {
+		state, ok := r.stateFor(rec)
+		if !ok {
+			skipped++
+			continue
+		}
+		states = append(states, state)
+	}
+
+	if skipped > 0 {
+		r.log.Warn("skipped deploys with no usable creation time", "count", skipped)
+	}
+
+	// By revision, because that is the axis the watermark advances along.
+	// Sorting by deployed_at would order them by a clock cloud does not use
+	// for this, and a batch's range would then no longer bound its contents.
+	sort.Slice(states, func(i, j int) bool {
+		return states[i].Revision < states[j].Revision
+	})
+
+	from := int64(0)
+	for start := 0; start < len(states); start += deployBatchSize {
+		end := min(start+deployBatchSize, len(states))
+		chunk := states[start:end]
+
+		// The last batch closes at the read revision rather than at its
+		// newest deploy, because the listing covered everything up to there.
+		// Stopping at the newest deploy would leave the frontier short of what
+		// was actually proven, and the next connect would re-walk the
+		// difference for nothing.
+		to := chunk[len(chunk)-1].Revision
+		if end == len(states) {
+			to = max(to, readRevision)
+		}
+
+		batch := DeployBatch{
+			FromRevision: from,
+			ToRevision:   to,
+			HeadRevision: head,
+			ObservedAt:   time.Now().UTC(),
+			Deploys:      chunk,
+		}
+
+		if err := link.SendMessageBlocking(ctx, TypeDeployBatch, batch); err != nil {
+			r.log.Warn("failed to send deploy batch", "error", err)
+			return
+		}
+
+		from = to
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(r.pause()):
+		}
+	}
+
+	// A cluster with no deploys still has to move the frontier, or every
+	// connect re-lists nothing and cloud never learns it is caught up.
+	if len(states) == 0 {
+		batch := DeployBatch{
+			FromRevision: 0,
+			ToRevision:   readRevision,
+			HeadRevision: head,
+			ObservedAt:   time.Now().UTC(),
+		}
+		if err := link.SendMessageBlocking(ctx, TypeDeployBatch, batch); err != nil {
+			r.log.Warn("failed to send empty deploy batch", "error", err)
+			return
+		}
+	}
+
+	r.log.Info("re-listed deploys for cloud", "deploys", len(states), "revision", readRevision)
+
+	// Straight into the tail from where the listing left off. New deploys made
+	// during the backfill have revisions above the read revision, so they are
+	// caught here rather than missed.
+	//
+	// This is also why there is no separate live-tail message in v1: the only
+	// window where one would help is a first-contact backfill long enough for a
+	// deploy to happen inside it, and RFD-94 explicitly defers that accelerator.
+	// Adding it later means a message that carries no range and therefore
+	// cannot advance the watermark — the invariant to preserve if it lands.
+	if err := r.stream(ctx, link, readRevision, head); err != nil && ctx.Err() == nil {
+		r.log.Warn("deploy tail ended", "error", err)
+	}
+}
+
+func (r *deployReporter) stateFrom(ent *esv1.Entity) (DeployState, bool) {
+	return r.stateFor(deploylifecycle.RecordFrom(ent))
+}
+
+// stateFor projects a record onto the wire shape, and reports false for a
+// record that cannot be reported at all.
+func (r *deployReporter) stateFor(rec *deploylifecycle.Record) (DeployState, bool) {
+	deployedAt, ok := deployedAtFor(rec)
+	if !ok {
+		// Cloud partitions on this, so a deploy without a stable one has no
+		// safe home. Dropping it is better than inventing a timestamp, which
+		// would differ on every report and write a fresh duplicate row each
+		// time rather than updating one.
+		return DeployState{}, false
+	}
+
+	dep := rec.Deployment
+
+	state := DeployState{
+		ID:         string(dep.ID),
+		Revision:   rec.Revision,
+		AppName:    dep.AppName,
+		AppVersion: rec.AppVersion(),
+		Status:     dep.Status,
+		Phase:      dep.Phase,
+		DeployedAt: deployedAt,
+	}
+
+	if dep.CompletedAt != "" {
+		if t, err := time.Parse(time.RFC3339, dep.CompletedAt); err == nil {
+			completed := t.UTC()
+			state.CompletedAt = &completed
+		}
+	}
+
+	if dep.ErrorMessage != "" {
+		reason := shortReason(dep.ErrorMessage)
+		state.ErrorReason = &reason
+	}
+
+	if dep.SourceDeploymentId != "" {
+		source := dep.SourceDeploymentId
+		state.SourceDeployID = &source
+	}
+
+	if git := dep.GitInfo; git.Sha != "" || git.Branch != "" || git.Repository != "" {
+		state.Git = &DeployGit{
+			SHA:        git.Sha,
+			Branch:     git.Branch,
+			Repository: git.Repository,
+		}
+	}
+
+	return state, true
+}
+
+// shortReason trims a failure message to something that fits the contract.
+//
+// The marker matters: a reader who sees a reason end mid-sentence should be
+// able to tell that cloud has a summary rather than that the deploy failed
+// with a truncated message. Cutting on a byte boundary is deliberate too,
+// since the point is bounding the payload rather than presenting prose.
+func shortReason(msg string) string {
+	if len(msg) <= maxErrorReasonBytes {
+		return msg
+	}
+	return msg[:maxErrorReasonBytes] + "… (truncated)"
+}
+
+// deployedAtFor returns the moment a deploy was initiated, which must be stable
+// across every report of it.
+//
+// The record's own timestamp is written once at creation and never rewritten,
+// so it is the right answer whenever it exists. It does not always exist:
+// records written before the server owned the deploy lifecycle (MIR-681) can
+// carry an empty one, and a backfill reaches back far enough to meet them.
+//
+// The id is the fallback because it is the only other immutable thing on the
+// record that knows when it was made — entity ids are UUIDv7 under their
+// base58, so creation time is recoverable from the identity itself. Deriving it
+// twice always gives the same instant, which is the property that matters here.
+func deployedAtFor(rec *deploylifecycle.Record) (time.Time, bool) {
+	if ts := rec.Deployment.DeployedBy.Timestamp; ts != "" {
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			return t.UTC(), true
+		}
+	}
+
+	return idgen.TimeOf(string(rec.Deployment.ID))
+}
+
+// entityDeploySource reads deploys from the entity store.
+//
+// It carries no logger on purpose: every method returns its error to the
+// reporter, which is the layer that decides how loud a failure to report
+// deploys should be.
+type entityDeploySource struct {
+	eac *esv1.EntityAccessClient
+}
+
+// HeadRevision reads the store's current revision without listing the deploy
+// log.
+//
+// It lists the in-progress index to get there, which sounds indirect but is
+// the cheap way to ask: a list returns the store's global read revision
+// whatever index it was given, and this index holds at most one entry per app
+// rather than one per deploy ever run. Listing the deploy kind instead would
+// mean paying for the full history on every connect to learn one number — the
+// exact cost the watermark exists to avoid.
+func (s *entityDeploySource) HeadRevision(ctx context.Context) (int64, error) {
+	res, err := s.eac.List(ctx, entity.String(
+		core_v1alpha.DeploymentStatusId, string(deploylifecycle.StatusInProgress)))
+	if err != nil {
+		return 0, err
+	}
+	return res.Revision(), nil
+}
+
+func (s *entityDeploySource) List(ctx context.Context) ([]*deploylifecycle.Record, int64, error) {
+	res, err := s.eac.List(ctx, entity.Ref(entity.EntityKind, core_v1alpha.KindDeployment))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	records := make([]*deploylifecycle.Record, 0, len(res.Values()))
+	for _, ent := range res.Values() {
+		records = append(records, deploylifecycle.RecordFrom(ent))
+	}
+
+	return records, res.Revision(), nil
+}
+
+func (s *entityDeploySource) Watch(ctx context.Context, fromRevision int64, fn func(*esv1.EntityOp) error) error {
+	_, err := s.eac.WatchIndex(ctx,
+		entity.Ref(entity.EntityKind, core_v1alpha.KindDeployment),
+		fromRevision,
+		stream.Callback(fn))
+	return err
+}

--- a/components/coordinate/deployreport_test.go
+++ b/components/coordinate/deployreport_test.go
@@ -1,0 +1,617 @@
+package coordinate
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	esv1 "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/deploylifecycle"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/idgen"
+)
+
+// The four cases RFD-94 says must discard the cursor. Every one of them costs a
+// re-list and nothing else, which is the property that lets the cursor be a
+// pure optimization.
+func TestDecideSyncModeFallsBackWhenTheCursorIsUnusable(t *testing.T) {
+	cases := []struct {
+		name      string
+		watermark int64
+		head      int64
+		want      syncMode
+	}{
+		{"absent, first contact or discarded", 0, 5000, syncRelist},
+		{"ahead of head, a rebuilt etcd reset the sequence", 9000, 5000, syncRelist},
+		{"not a revision any store issued", -1, 5000, syncRelist},
+		{"usable", 4000, 5000, syncDelta},
+		{"usable at exactly head", 5000, 5000, syncDelta},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := decideSyncMode(tc.watermark, tc.head)
+			assert.Equal(t, tc.want, got)
+			if tc.want == syncRelist {
+				assert.NotEmpty(t, reason, "a re-list should say why, since it is the expensive path")
+			}
+		})
+	}
+}
+
+// The fourth case, compaction, is the one that cannot be decided up front: it
+// only surfaces when the watch is opened and the store reports the resume point
+// is gone. It has to demote a delta stream to a re-list mid-flight.
+func TestCompactedWatchFallsBackToRelist(t *testing.T) {
+	src := &fakeDeploySource{
+		head: 5000,
+		records: []*deploylifecycle.Record{
+			deployRecord(t, "web", 100),
+		},
+		listRevision: 5000,
+		watchErr:     map[int64]error{4000: errCompacted},
+	}
+
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 4000)
+
+	assert.True(t, src.listed, "a compacted watch must fall back to the full re-list")
+	require.NotEmpty(t, link.batches())
+	assert.Equal(t, int64(0), link.batches()[0].FromRevision,
+		"the re-list restarts the frontier from the bottom rather than from the dead cursor")
+}
+
+// A usable cursor means catch-up and live tail are one ordered stream, so the
+// runtime never lists at all. That is the entire point of keeping the cursor.
+func TestUsableCursorStreamsWithoutListing(t *testing.T) {
+	src := &fakeDeploySource{
+		head: 5000,
+		watchOps: []*esv1.EntityOp{
+			deployOp(t, "web", 5100),
+			deployOp(t, "api", 5200),
+		},
+	}
+
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 4000)
+
+	assert.False(t, src.listed, "a usable cursor must not trigger a re-list")
+
+	batches := link.batches()
+	require.Len(t, batches, 2)
+	assert.Equal(t, int64(4000), batches[0].FromRevision)
+	assert.Equal(t, int64(5100), batches[0].ToRevision)
+	assert.Equal(t, int64(5100), batches[1].FromRevision,
+		"each batch must pick up exactly where the last one closed, or the range between them is claimed by nobody")
+	assert.Equal(t, int64(5200), batches[1].ToRevision)
+}
+
+// A watch that reports progress with no entity still advances the range. This
+// is what keeps the frontier moving on a cluster that deploys rarely, instead of
+// freezing at the last deploy and re-walking a widening gap on every connect.
+func TestProgressNotificationAdvancesTheFrontier(t *testing.T) {
+	progress := &esv1.EntityOp{}
+	progress.SetOperation(int64(esv1.EntityOperationProgress))
+	progress.SetRevision(6000)
+
+	src := &fakeDeploySource{head: 5000, watchOps: []*esv1.EntityOp{progress}}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 4000)
+
+	batches := link.batches()
+	require.Len(t, batches, 1)
+	assert.Empty(t, batches[0].Deploys, "a progress notification carries no deploy")
+	assert.Equal(t, int64(4000), batches[0].FromRevision)
+	assert.Equal(t, int64(6000), batches[0].ToRevision,
+		"the empty batch still has to move the frontier, or a quiet cluster never advances")
+}
+
+// A stream failure that is not compaction must not trigger a re-list. The
+// cursor is not implicated by a transport blip, and re-sending a cluster's whole
+// history on one is expensive for nothing.
+func TestNonCompactionStreamErrorDoesNotRelist(t *testing.T) {
+	src := &fakeDeploySource{
+		head:         5000,
+		records:      []*deploylifecycle.Record{deployRecord(t, "web", 100)},
+		listRevision: 5000,
+		watchErr:     map[int64]error{4000: io.ErrUnexpectedEOF},
+	}
+
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 4000)
+
+	assert.False(t, src.listed, "only compaction should fall back to a re-list")
+	assert.Empty(t, link.batches())
+}
+
+// Batches have to tile the revision line with no gaps and no overlaps in the
+// ranges they claim, because cloud advances its frontier to each ToRevision in
+// turn. A gap between two batches is a range cloud believes was covered.
+func TestRelistBatchesTileTheRevisionRange(t *testing.T) {
+	var records []*deploylifecycle.Record
+	for i := range 250 {
+		records = append(records, deployRecord(t, "web", int64(1000+i)))
+	}
+
+	src := &fakeDeploySource{head: 9000, records: records, listRevision: 9000}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	batches := link.batches()
+	require.Len(t, batches, 3, "250 deploys at a batch size of 100")
+
+	from := int64(0)
+	total := 0
+	for _, b := range batches {
+		assert.Equal(t, from, b.FromRevision, "batches must tile without a gap")
+		assert.Greater(t, b.ToRevision, b.FromRevision)
+		for _, d := range b.Deploys {
+			assert.Greater(t, d.Revision, b.FromRevision, "a deploy must fall inside the range that vouches for it")
+			assert.LessOrEqual(t, d.Revision, b.ToRevision)
+		}
+		total += len(b.Deploys)
+		from = b.ToRevision
+	}
+
+	assert.Equal(t, 250, total)
+	assert.Equal(t, int64(9000), from,
+		"the last batch closes at the read revision, since the listing proved everything up to there")
+}
+
+// An interrupted backfill has to resume from the frontier its committed batches
+// left behind, without re-walking what landed and without skipping the rest.
+// This is the resumability the issue asks for, seen from the runtime side.
+func TestInterruptedBackfillResumesFromTheWatermark(t *testing.T) {
+	var records []*deploylifecycle.Record
+	for i := range 250 {
+		records = append(records, deployRecord(t, "web", int64(1000+i)))
+	}
+
+	// First connection: dies after two batches, the way a dropped socket would.
+	first := &fakeDeployLink{failAfter: 2}
+	src := &fakeDeploySource{head: 9000, records: records, listRevision: 9000}
+	runWithCursor(t, src, first, 0)
+
+	delivered := first.batches()
+	require.Len(t, delivered, 2)
+	resumeFrom := delivered[len(delivered)-1].ToRevision
+
+	// Cloud committed those two batches, so its watermark is where they closed.
+	// The next connection asks and gets that back.
+	// The watch replays what the interrupted backfill never sent, then carries
+	// on into new activity. Both have to arrive, or "resumed" would only mean
+	// "started in the right place" while the middle of the log stayed missing.
+	remaining := []*esv1.EntityOp{
+		deployOp(t, "web", resumeFrom+1),
+		deployOp(t, "web", resumeFrom+2),
+		deployOp(t, "api", 9100),
+	}
+
+	second := &fakeDeployLink{}
+	src2 := &fakeDeploySource{
+		head:         9000,
+		records:      records,
+		listRevision: 9000,
+		watchOps:     remaining,
+	}
+	runWithCursor(t, src2, second, resumeFrom)
+
+	assert.False(t, src2.listed,
+		"resuming from a good watermark must stream, not start the backfill over")
+
+	resumed := second.batches()
+	require.Len(t, resumed, len(remaining))
+	assert.Equal(t, resumeFrom, resumed[0].FromRevision,
+		"the resumed stream must open exactly at the frontier the interrupted one left")
+
+	// No gap between where the first connection stopped and where the second
+	// picked up, and none between the batches that followed.
+	from := resumeFrom
+	for i, b := range resumed {
+		assert.Equal(t, from, b.FromRevision, "batch %d must open where the last one closed", i)
+		require.Len(t, b.Deploys, 1)
+		assert.Equal(t, remaining[i].Revision(), b.Deploys[0].Revision)
+		from = b.ToRevision
+	}
+	assert.Equal(t, int64(9100), from)
+}
+
+// Build logs are on the deployment entity and must never reach the wire. This
+// is a custody boundary rather than a preference, so it gets a test that fails
+// loudly if someone later swaps the hand-written projection for an encode.
+func TestBuildLogsAndDeployerNeverReachTheWire(t *testing.T) {
+	// A distinct sentinel per field. Sharing one would let a field leak
+	// undetected whenever another field carrying the same substring is
+	// correctly excluded.
+	rec := deployRecord(t, "web", 100)
+	rec.Deployment.BuildLogs = "SENTINEL-BUILD-LOGS line one\nline two"
+	rec.Deployment.DeployedBy.UserEmail = "SENTINEL-DEPLOYER-EMAIL@example.com"
+	rec.Deployment.DeployedBy.UserName = "SENTINEL-DEPLOYER-NAME"
+	rec.Deployment.DeployedBy.UserId = "SENTINEL-DEPLOYER-ID"
+	rec.Deployment.GitInfo.Author = "SENTINEL-GIT-AUTHOR"
+	rec.Deployment.GitInfo.CommitAuthorEmail = "SENTINEL-GIT-EMAIL@example.com"
+	rec.Deployment.GitInfo.Message = "SENTINEL-GIT-MESSAGE"
+
+	src := &fakeDeploySource{head: 5000, records: []*deploylifecycle.Record{rec}, listRevision: 5000}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	raw := link.raw()
+	for _, sentinel := range []string{
+		"SENTINEL-BUILD-LOGS",
+		"SENTINEL-DEPLOYER-EMAIL",
+		"SENTINEL-DEPLOYER-NAME",
+		"SENTINEL-DEPLOYER-ID",
+		"SENTINEL-GIT-AUTHOR",
+		"SENTINEL-GIT-EMAIL",
+		"SENTINEL-GIT-MESSAGE",
+	} {
+		assert.NotContains(t, raw, sentinel)
+	}
+}
+
+// A deploy whose record carries no creation timestamp still has one in its id.
+// Without this, pre-MIR-681 records would either be dropped or, far worse, get
+// a fresh timestamp on every report and write a new row each time.
+func TestDeployedAtFallsBackToTheIdWhenTheRecordHasNoTimestamp(t *testing.T) {
+	rec := deployRecord(t, "web", 100)
+	rec.Deployment.DeployedBy.Timestamp = ""
+
+	first, ok := deployedAtFor(rec)
+	require.True(t, ok, "an id-derived time should be available")
+
+	fromID, ok := idgen.TimeOf(string(rec.Deployment.ID))
+	require.True(t, ok)
+	assert.Equal(t, fromID, first,
+		"the fallback should be the id's own creation time, not some other clock reading")
+
+	again, ok := deployedAtFor(rec)
+	require.True(t, ok)
+	assert.Equal(t, first, again,
+		"the value is a partition key, so deriving it twice must give the same instant")
+}
+
+// A record with neither a timestamp nor a readable id has no stable partition
+// key, and inventing one would write a duplicate row per report. Dropping it is
+// the honest outcome.
+func TestDeployWithNoStableTimeIsSkipped(t *testing.T) {
+	rec := &deploylifecycle.Record{
+		Deployment: &core_v1alpha.Deployment{ID: entity.Id("not-an-id"), AppName: "web"},
+		Revision:   100,
+	}
+
+	src := &fakeDeploySource{head: 5000, records: []*deploylifecycle.Record{rec}, listRevision: 5000}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	for _, b := range link.batches() {
+		assert.Empty(t, b.Deploys, "a deploy with no stable creation time must not be reported")
+	}
+}
+
+// A cluster that has never deployed still has to move cloud's frontier, or
+// every reconnect re-lists nothing and cloud never learns it is current.
+func TestEmptyClusterStillAdvancesTheFrontier(t *testing.T) {
+	src := &fakeDeploySource{head: 5000, listRevision: 5000}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	batches := link.batches()
+	require.Len(t, batches, 1)
+	assert.Empty(t, batches[0].Deploys)
+	assert.Equal(t, int64(5000), batches[0].ToRevision)
+}
+
+// A cloud that holds the socket but never answers must not wedge reporting. It
+// is treated as a cloud with no cursor, which costs a re-list and no data.
+func TestSilentCloudFallsBackToRelist(t *testing.T) {
+	src := &fakeDeploySource{
+		head:         5000,
+		records:      []*deploylifecycle.Record{deployRecord(t, "web", 100)},
+		listRevision: 5000,
+	}
+	// No onHello, so the hello goes unanswered.
+	link := &fakeDeployLink{}
+	r := newTestReporter(src)
+	r.cursorTimeout = 50 * time.Millisecond
+	r.run(testCtx(t), link)
+
+	assert.True(t, src.listed, "an unanswered hello must fall back to the re-list")
+}
+
+// --- helpers ---
+
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// newTestReporter builds a reporter with the pacing collapsed, so a test
+// exercises the protocol rather than waiting out a fleet spread.
+func newTestReporter(src deploySource) *deployReporter {
+	return &deployReporter{
+		log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		source:        src,
+		cursors:       make(chan int64, 1),
+		spread:        time.Nanosecond,
+		cursorTimeout: 5 * time.Second,
+		batchPause:    time.Nanosecond,
+	}
+}
+
+// runWithCursor runs one connection against a cloud that answers the hello with
+// the given watermark.
+//
+// The answer is delivered in response to the hello rather than queued up front,
+// because the reporter deliberately drains stale replies before asking. Seeding
+// the channel early would test a sequence that never happens on a real link.
+func runWithCursor(t *testing.T, src deploySource, link *fakeDeployLink, watermark int64) *deployReporter {
+	t.Helper()
+
+	r := newTestReporter(src)
+	link.onHello = func() { r.cursors <- watermark }
+	r.run(testCtx(t), link)
+
+	return r
+}
+
+func deployRecord(t *testing.T, app string, revision int64) *deploylifecycle.Record {
+	t.Helper()
+	return &deploylifecycle.Record{
+		Deployment: &core_v1alpha.Deployment{
+			ID:         entity.Id(idgen.GenNS("deployment")),
+			AppName:    app,
+			AppVersion: "v1.0.0",
+			Status:     "active",
+			DeployedBy: core_v1alpha.DeployedBy{
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+		Revision: revision,
+	}
+}
+
+func deployOp(t *testing.T, app string, revision int64) *esv1.EntityOp {
+	t.Helper()
+
+	rec := deployRecord(t, app, revision)
+
+	ent := &esv1.Entity{}
+	ent.SetId(string(rec.Deployment.ID))
+	ent.SetAttrs(rec.Deployment.Encode())
+	ent.SetRevision(revision)
+
+	op := &esv1.EntityOp{}
+	op.SetOperation(int64(esv1.EntityOperationUpdate))
+	op.SetRevision(revision)
+	op.SetEntity(ent)
+
+	return op
+}
+
+type fakeDeploySource struct {
+	head         int64
+	records      []*deploylifecycle.Record
+	listRevision int64
+	watchOps     []*esv1.EntityOp
+	watchErr     map[int64]error
+
+	listed bool
+}
+
+func (f *fakeDeploySource) HeadRevision(context.Context) (int64, error) {
+	return f.head, nil
+}
+
+func (f *fakeDeploySource) List(context.Context) ([]*deploylifecycle.Record, int64, error) {
+	f.listed = true
+	return f.records, f.listRevision, nil
+}
+
+func (f *fakeDeploySource) Watch(_ context.Context, from int64, fn func(*esv1.EntityOp) error) error {
+	if err, ok := f.watchErr[from]; ok {
+		return err
+	}
+
+	for _, op := range f.watchOps {
+		if op.Revision() <= from {
+			continue
+		}
+		if err := fn(op); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// fakeDeployLink records what the reporter put on the wire, and can fail
+// partway to stand in for a connection that dropped mid-backfill.
+type fakeDeployLink struct {
+	mu   sync.Mutex
+	sent []json.RawMessage
+
+	// failAfter makes the nth send onward fail, zero meaning never.
+	failAfter int
+	count     int
+
+	// onHello stands in for cloud answering the sync hello. Nil models a cloud
+	// that holds the socket and never replies.
+	onHello func()
+}
+
+func (f *fakeDeployLink) SendMessageBlocking(_ context.Context, msgType string, data any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if msgType == TypeDeploySyncHello {
+		if f.onHello != nil {
+			f.onHello()
+		}
+		return nil
+	}
+
+	if msgType != TypeDeployBatch {
+		return nil
+	}
+
+	f.count++
+	if f.failAfter > 0 && f.count > f.failAfter {
+		return io.ErrClosedPipe
+	}
+
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	f.sent = append(f.sent, raw)
+
+	return nil
+}
+
+func (f *fakeDeployLink) batches() []DeployBatch {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	out := make([]DeployBatch, 0, len(f.sent))
+	for _, raw := range f.sent {
+		var b DeployBatch
+		if err := json.Unmarshal(raw, &b); err == nil {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+func (f *fakeDeployLink) raw() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var all string
+	for _, raw := range f.sent {
+		all += string(raw)
+	}
+	return all
+}
+
+// cloudReadLimitBytes mirrors the read limit cloud sets on the channel
+// (maxMessageBytes in mirendev/cloud, services/cluster_channel). It is
+// duplicated here because this module cannot import that one, which is the
+// same hand-matched-constant problem MIR-1601 exists to fix. Until it does,
+// this test is what keeps the two honest.
+const cloudReadLimitBytes = 1 << 20
+
+// A full batch has to fit in one websocket frame, and nothing in the type
+// system says so.
+//
+// This is a regression test for a real wedge. coder/websocket defaults to a 32
+// KiB read limit, a hundred deploys carrying git provenance run past 45 KiB, and
+// the failure is not a dropped batch: the read fails, the connection drops, the
+// runtime reconnects and re-sends the same oversized batch forever. A cluster
+// with more than about eighty deploys would never have ingested one.
+func TestFullBatchFitsInOneFrame(t *testing.T) {
+	now := time.Now().UTC()
+
+	// The worst record this reporter can emit: every optional field populated,
+	// a full-length sha, and a failure reason at the cap.
+	worst := func() DeployState {
+		completed := now
+		reason := shortReason(strings.Repeat("x", maxErrorReasonBytes*4))
+		return DeployState{
+			ID:          idgen.GenNS("deployment"),
+			Revision:    5100294,
+			AppName:     "some-reasonably-long-app-name",
+			AppVersion:  "some-reasonably-long-app-name-v8kd0",
+			Status:      "failed",
+			Phase:       "activating",
+			DeployedAt:  now,
+			CompletedAt: &completed,
+			ErrorReason: &reason,
+			Git: &DeployGit{
+				SHA:        strings.Repeat("a1b2c3d4", 5),
+				Branch:     "release/some-fairly-long-branch-name",
+				Repository: "https://github.com/mirendev/some-repository-name",
+			},
+			SourceDeployID: ptr(idgen.GenNS("deployment")),
+		}
+	}
+
+	batch := DeployBatch{
+		FromRevision: 1,
+		ToRevision:   5100294,
+		HeadRevision: 5100300,
+		ObservedAt:   now,
+	}
+	for range deployBatchSize {
+		batch.Deploys = append(batch.Deploys, worst())
+	}
+
+	raw, err := json.Marshal(batch)
+	require.NoError(t, err)
+
+	assert.Less(t, len(raw), cloudReadLimitBytes,
+		"a full batch of worst-case records must fit the frame cloud will read; "+
+			"lower deployBatchSize or maxErrorReasonBytes, or raise cloud's limit")
+}
+
+// The cap is what makes the frame bound reachable, and it has to be stable:
+// a reason that varied per report would write a second row rather than update
+// the first, the same way a drifting deployed_at would.
+func TestShortReasonCapsAndIsStable(t *testing.T) {
+	long := strings.Repeat("boom ", 500)
+
+	first := shortReason(long)
+	assert.LessOrEqual(t, len(first), maxErrorReasonBytes+len("… (truncated)"))
+	assert.Contains(t, first, "truncated", "a trimmed reason should say so")
+	assert.Equal(t, first, shortReason(long), "trimming must be deterministic")
+
+	short := "build failed: exit code 1"
+	assert.Equal(t, short, shortReason(short), "a reason within the cap is untouched")
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// A deploy the reporter cannot key by creation time still has to let the
+// frontier past it.
+//
+// The empty batch this produces means "a deploy was here and is not coming,"
+// not "nothing happened." Holding the range back instead would wedge the
+// watermark permanently: the next connection re-streams the same revision and
+// drops it again, forever.
+func TestUnkeyableDeployInTheTailStillAdvancesTheFrontier(t *testing.T) {
+	// An id base58 cannot decode, and no timestamp on the record, so neither
+	// source of a stable deployed_at is available.
+	rec := &core_v1alpha.Deployment{ID: entity.Id("not-an-id"), AppName: "web"}
+
+	ent := &esv1.Entity{}
+	ent.SetId(string(rec.ID))
+	ent.SetAttrs(rec.Encode())
+	ent.SetRevision(5100)
+
+	op := &esv1.EntityOp{}
+	op.SetOperation(int64(esv1.EntityOperationUpdate))
+	op.SetRevision(5100)
+	op.SetEntity(ent)
+
+	src := &fakeDeploySource{head: 5000, watchOps: []*esv1.EntityOp{op}}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 4000)
+
+	batches := link.batches()
+	require.Len(t, batches, 1)
+	assert.Empty(t, batches[0].Deploys, "the deploy had no stable key, so it is not reported")
+	assert.Equal(t, int64(4000), batches[0].FromRevision)
+	assert.Equal(t, int64(5100), batches[0].ToRevision,
+		"the frontier must still pass it, or this revision wedges the watermark forever")
+}

--- a/pkg/deploylifecycle/store.go
+++ b/pkg/deploylifecycle/store.go
@@ -257,6 +257,15 @@ func (s *Store) MarkPreviousActiveAs(ctx context.Context, appName, exceptID stri
 	return nil
 }
 
+// RecordFrom decodes a stored entity into a Record.
+//
+// Exported for readers that get entities from somewhere other than this store —
+// the changefeed hands out entities directly, and a caller decoding them by
+// hand would be a second copy of the mapping that drifts from this one.
+func RecordFrom(e *entityserver_v1alpha.Entity) *Record {
+	return recordFrom(e)
+}
+
 func recordFrom(e *entityserver_v1alpha.Entity) *Record {
 	var dep core_v1alpha.Deployment
 	dep.Decode(&entityAttrs{entity: e})

--- a/pkg/idgen/idgen.go
+++ b/pkg/idgen/idgen.go
@@ -3,6 +3,7 @@ package idgen
 import (
 	"crypto/rand"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -70,6 +71,53 @@ func Gen(prefix string) string {
 
 func GenNS(ns string) string {
 	return Gen(ns + "-")
+}
+
+// TimeOf recovers the moment an id was generated, and reports whether it could.
+//
+// Gen lays a UUIDv7 down under the base58, so the first six bytes are the
+// millisecond timestamp it was minted at. That makes creation time an immutable
+// property of the id itself rather than a field alongside it, recoverable for
+// records whose own timestamp field was never populated.
+//
+// This lives here rather than at the call site because this package owns the id
+// format. A reader that hand-decoded base58 and reached into byte offsets would
+// be a second, silent copy of Gen's layout, and the two would drift the first
+// time the format changed.
+//
+// It reports false rather than a zero time for anything it cannot read, so a
+// caller has to decide what an unreadable id means instead of receiving the
+// epoch and mistaking it for an answer.
+func TimeOf(id string) (time.Time, bool) {
+	// Ids are prefixed by kind (see GenNS), and the prefix is not part of the
+	// encoding. Everything through the last separator is dropped rather than
+	// the first, since a kind may contain one.
+	if idx := strings.LastIndex(id, "-"); idx >= 0 {
+		id = id[idx+1:]
+	}
+
+	// Exactly the UUID width, not merely enough bytes to read a timestamp from.
+	// base58 drops leading zero bytes, so a truncated or hand-made id can decode
+	// to something shorter whose first six bytes are not the timestamp at all,
+	// and reading them anyway would produce a confident wrong answer rather than
+	// a refusal.
+	raw, err := base58.Decode(id)
+	if err != nil || len(raw) != 16 {
+		return time.Time{}, false
+	}
+
+	milli := int64(raw[0])<<40 |
+		int64(raw[1])<<32 |
+		int64(raw[2])<<24 |
+		int64(raw[3])<<16 |
+		int64(raw[4])<<8 |
+		int64(raw[5])
+
+	if milli <= 0 {
+		return time.Time{}, false
+	}
+
+	return time.UnixMilli(milli).UTC(), true
 }
 
 // GenAdminToken generates a cryptographically secure admin token.

--- a/pkg/idgen/idgen_test.go
+++ b/pkg/idgen/idgen_test.go
@@ -1,0 +1,74 @@
+package idgen
+
+import (
+	"testing"
+	"time"
+)
+
+// The point of TimeOf is that an id carries its own creation time, so a record
+// whose timestamp field was never written still has a stable one available.
+func TestTimeOfRecoversGenerationTime(t *testing.T) {
+	before := time.Now().UTC().Add(-time.Second)
+	id := GenNS("deployment")
+	after := time.Now().UTC().Add(time.Second)
+
+	got, ok := TimeOf(id)
+	if !ok {
+		t.Fatalf("TimeOf(%q) reported no time", id)
+	}
+	if got.Before(before) || got.After(after) {
+		t.Errorf("TimeOf(%q) = %s, want between %s and %s", id, got, before, after)
+	}
+}
+
+// Stability is the property the deploy log actually leans on: the value is used
+// as a partition key, so the same id must always decode to the same instant.
+func TestTimeOfIsStable(t *testing.T) {
+	id := GenNS("deployment")
+
+	first, ok := TimeOf(id)
+	if !ok {
+		t.Fatalf("TimeOf(%q) reported no time", id)
+	}
+
+	for range 5 {
+		again, ok := TimeOf(id)
+		if !ok || !again.Equal(first) {
+			t.Fatalf("TimeOf(%q) = %s, %v on a repeat call; want a stable %s", id, again, ok, first)
+		}
+	}
+}
+
+// Kind prefixes can contain a separator themselves, so the decoder has to cut
+// at the last one rather than the first.
+func TestTimeOfHandlesPrefixesContainingSeparators(t *testing.T) {
+	id := GenNS("disk-lease")
+
+	if _, ok := TimeOf(id); !ok {
+		t.Errorf("TimeOf(%q) reported no time for a multi-part prefix", id)
+	}
+}
+
+func TestTimeOfRejectsUnreadableIds(t *testing.T) {
+	cases := map[string]string{
+		"empty":          "",
+		"prefix only":    "deployment-",
+		"not base58":     "deployment-0OIl+/",
+		"too short":      "deployment-" + "2g",
+		"no time bytes":  "deployment-" + "11111111111111111111111",
+		"bare separator": "-",
+	}
+
+	// A truncated id decodes to fewer than sixteen bytes, and reading a
+	// timestamp out of its leading bytes would give a confident wrong answer.
+	full := GenNS("deployment")
+	cases["truncated id"] = full[:len(full)-3]
+
+	for name, id := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got, ok := TimeOf(id); ok {
+				t.Errorf("TimeOf(%q) = %s, true; want false so the caller has to decide what an unreadable id means", id, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🤖 Deploys are the durable half of RFD-94's contract, and they behave nothing like app state. A dropped health sample self-heals on the next report; a dropped deploy is gone, because the runtime prunes its own records and cloud becomes the book of record once it does. So completeness here has to come from reconciliation rather than from delivery.

The shape that falls out: on each connection the runtime asks cloud where its copy left off, then decides for itself whether that answer is usable. Three of the four reasons to distrust a cursor (compacted away, above the store's head, incoherent) are only visible from the cluster side, and the fourth is just "cloud has none", which arrives as a zero. Putting the decision here keeps all four in one function instead of splitting them across the wire. A usable cursor means the watch from that revision is simultaneously the catch-up and the live tail, so there is no second stream to run. An unusable one costs an oldest-first re-list and nothing else.

What the runtime never gets to do is tell cloud where the frontier is. The link drops on outbox overflow, so a "watermark is now W" message surviving while the batch before it died would move cloud past deploys it never received, and nothing ever looks below the frontier again. Instead a batch carries the range it covers, which is the claim that nothing in that range was omitted. Cloud can't verify that claim, since revisions are store-global and a legitimate gap between two deploys looks exactly like a missing one, but it can refuse to act on half a message. A batch that never arrives leaves the frontier where it was and gets re-sent next connect.

That is also why this is `deploy.batch` rather than RFD-94's sketched `deploy.upsert`. A message named for the write invites a second sender that upserts without a range, and that sender advancing the frontier is precisely the permanent gap the design exists to prevent.

One find worth flagging, since it's load-bearing: `deployed_at` is cloud's partition key and part of the upsert's conflict target, so it has to be identical in every report of a deploy or the same deploy writes two rows. Records written before the server owned the deploy lifecycle can carry an empty timestamp, and the backfill reaches back far enough to meet them. Entity ids turn out to be base58 UUIDv7, so creation time is recoverable from the identity itself, which is the one other immutable thing on the record. That decoding went into `idgen` rather than the reporter, since that package owns the format.

Two things landed after review that are worth pointing at, because they are the sharpest part of the diff and neither is in the story above.

Evan caught that a full batch does not fit a websocket frame. coder/websocket defaults to a 32 KiB read limit and a hundred deploys carrying git provenance measure 105,924 bytes worst case, so a cluster past roughly eighty deploys would not have dropped a batch, it would have wedged: the read fails, the connection drops, the runtime reconnects and re-sends the same oversized batch forever, ingesting nothing. Cloud now sets the limit explicitly, and `TestFullBatchFitsInOneFrame` builds a worst-case batch and asserts it fits, failing at the old default with "105924 is not less than 32768".

Chasing that turned up a worse one. `error_reason` was completely unbounded, while the comment directly above it and RFD-94 both say short reason and never raw build output. A deploy failing with a stack trace shipped all of it, which blows the frame and quietly walks build logs past the custody boundary the rest of the file is careful about. Now capped, deterministically, so the same record always produces the same payload.

The cloud half is mirendev/cloud#203, merged. It uses `SendMessageBlocking` and `SpreadOnConnect` from #1059, which is also merged, so this now sits on main rather than on that branch.

Part of MIR-1560.

