### PR TITLE
Resolve addon env vars from the association instead of copying them into versions

### DIFF
--- a/api/app/envvar.go
+++ b/api/app/envvar.go
@@ -209,6 +209,10 @@ func resolveBaseVersion(ctx context.Context, ec *entityserver.Client, appName st
 	var appVer core_v1alpha.AppVersion
 	var spec core_v1alpha.ConfigSpec
 
+	// Whichever branch fills spec below, dropAddonVars strips addon variables
+	// before it is returned. This function feeds the paths that mint a new
+	// ConfigVersion, and an addon binding is resolved at runtime rather than
+	// stored.
 	if baseVersion != nil {
 		appVer = *baseVersion
 		resolvedCfg, err := coreutil.ResolveConfig(ctx, ec.EAC(), &appVer)
@@ -230,7 +234,26 @@ func resolveBaseVersion(ctx context.Context, ec *entityserver.Client, appName st
 		appVer.App = appRec.ID
 	}
 
+	dropAddonVars(&spec)
 	return &appVer, &spec, &appRec, appRev, nil
+}
+
+// dropAddonVars removes addon variables from a spec about to become a new
+// ConfigVersion.
+//
+// Addon bindings live on the AddonAssociation and are applied at resolve time by
+// coreutil.ResolveRuntimeConfig. A stored copy is not what the app runs on, so
+// carrying one into a new version would only resurrect a credential the addon
+// may no longer own.
+func dropAddonVars(spec *core_v1alpha.ConfigSpec) {
+	kept := spec.Variables[:0]
+	for _, v := range spec.Variables {
+		if v.Source == coreutil.SourceAddon {
+			continue
+		}
+		kept = append(kept, v)
+	}
+	spec.Variables = kept
 }
 
 // SetInitialEnvVars stages env vars on an app's initial ConfigVersion,

--- a/api/core/addonvars.go
+++ b/api/core/addonvars.go
@@ -1,0 +1,178 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// ResolveRuntimeConfig returns the config an AppVersion runs with: the version's
+// stored config, plus the addon bindings the app's associations currently supply.
+//
+// This reads the app's addon associations, so it costs one indexed List per call
+// and fails if that read fails. Callers that write a ConfigVersion must use
+// ResolveConfig instead. Storing the result of this function would put addon
+// bindings back into a version, which is what this removes.
+//
+// Addon variables stored on the version are dropped, and the live bindings are
+// used instead. This keeps the invariant in one place: an AppVersion records
+// user config, and addon state resolves at runtime. A version that stores a copy
+// never serves it, whether the copy predates this design or a later change
+// writes one.
+//
+// Precedence:
+//
+//   - A binding replaces an app.toml declaration of the same key. Declaring
+//     DATABASE_URL in app.toml and then attaching a database addon means the
+//     addon supplies the value. Required and Description carry from the
+//     declaration onto the binding, because `miren env list` shows them and the
+//     next build validates against them.
+//   - A binding never replaces a variable an operator set. See RFD-59.
+//
+// Before this, an addon contributed its variables by minting a successor
+// version. A version built before the addon existed therefore never contained
+// DATABASE_URL, and activating one left the app without its credentials
+// permanently (MIR-1579).
+func ResolveRuntimeConfig(
+	ctx context.Context,
+	eac *entityserver_v1alpha.EntityAccessClient,
+	ver *core_v1alpha.AppVersion,
+) (*core_v1alpha.ConfigSpec, error) {
+	spec, err := ResolveConfig(ctx, eac, ver)
+	if err != nil {
+		return nil, err
+	}
+
+	if ver.App == "" {
+		return spec, nil
+	}
+
+	bindings, err := addonBindings(ctx, eac, ver.App)
+	if err != nil {
+		return nil, err
+	}
+
+	// The common case: no addons, no stored copies. Return the spec untouched
+	// rather than rebuilding an identical slice.
+	if len(bindings) == 0 && !hasAddonVars(spec.Variables) {
+		return spec, nil
+	}
+
+	// Only operator-set keys block a binding. An app.toml declaration does not,
+	// because blocking it would hand the app a placeholder instead of a credential.
+	kept := make([]core_v1alpha.ConfigSpecVariables, 0, len(spec.Variables)+len(bindings))
+	blocked := make(map[string]struct{}, len(spec.Variables))
+	for _, v := range spec.Variables {
+		if v.Source == SourceAddon {
+			continue
+		}
+		kept = append(kept, v)
+		if operatorOwned(v.Source) {
+			blocked[v.Key] = struct{}{}
+		}
+	}
+
+	for _, b := range bindings {
+		if _, ok := blocked[b.Key]; ok {
+			continue
+		}
+		blocked[b.Key] = struct{}{}
+
+		bound := core_v1alpha.ConfigSpecVariables{
+			Key:       b.Key,
+			Value:     b.Value,
+			Sensitive: b.Sensitive,
+			Source:    SourceAddon,
+		}
+
+		// Replace a shadowed declaration in place. This keeps one entry per key and
+		// preserves its position.
+		if i := indexOfKey(kept, b.Key); i >= 0 {
+			bound.Required = kept[i].Required
+			bound.Description = kept[i].Description
+			kept[i] = bound
+			continue
+		}
+		kept = append(kept, bound)
+	}
+
+	spec.Variables = kept
+	return spec, nil
+}
+
+// operatorOwned reports whether a person set this value, in which case an addon
+// must not replace it. An empty source predates the field and counts as
+// operator-set, matching mergeVariablesFromAppConfig.
+func operatorOwned(source string) bool {
+	return source == SourceManual || source == ""
+}
+
+func indexOfKey(vars []core_v1alpha.ConfigSpecVariables, key string) int {
+	for i := range vars {
+		if vars[i].Key == key {
+			return i
+		}
+	}
+	return -1
+}
+
+func hasAddonVars(vars []core_v1alpha.ConfigSpecVariables) bool {
+	for _, v := range vars {
+		if v.Source == SourceAddon {
+			return true
+		}
+	}
+	return false
+}
+
+// addonBindings returns the variables every active addon association contributes
+// to an app.
+//
+// Only "active" associations count. A pending or provisioning one has no final
+// values yet, and the launcher defers pool creation until they settle (see
+// addonsReady). A deprovisioning one is being torn down, so serving its
+// credentials would point the app at a database that is about to disappear. An
+// "error" one never finished provisioning, so its values were never known good.
+func addonBindings(
+	ctx context.Context,
+	eac *entityserver_v1alpha.EntityAccessClient,
+	appID entity.Id,
+) ([]addon_v1alpha.Variables, error) {
+	results, err := eac.List(ctx, entity.Ref(addon_v1alpha.AddonAssociationAppId, appID))
+	if err != nil {
+		return nil, fmt.Errorf("listing addon associations for %s: %w", appID, err)
+	}
+
+	type contribution struct {
+		assoc entity.Id
+		vars  []addon_v1alpha.Variables
+	}
+
+	var found []contribution
+	for _, ent := range results.Values() {
+		var assoc addon_v1alpha.AddonAssociation
+		assoc.Decode(ent.Entity())
+
+		if assoc.Status != "active" {
+			continue
+		}
+		found = append(found, contribution{assoc: assoc.ID, vars: assoc.Variables})
+	}
+
+	// The first contributor to supply a key wins, so sort by association id to make
+	// that a function of stored state rather than of List order. Two addons
+	// supplying the same key is rare, because AdjustEnvVars asks the second to
+	// rename at provision time, but it is reachable.
+	sort.Slice(found, func(i, j int) bool { return found[i].assoc < found[j].assoc })
+
+	var out []addon_v1alpha.Variables
+	for _, f := range found {
+		out = append(out, f.vars...)
+	}
+	return out, nil
+}

--- a/api/core/addonvars_test.go
+++ b/api/core/addonvars_test.go
@@ -1,0 +1,299 @@
+package compute
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	apiserver "miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+type overlayFixture struct {
+	ctx   context.Context
+	inmem *testutils.InMemEntityServer
+	ec    *apiserver.Client
+	appID entity.Id
+}
+
+func newOverlayFixture(t *testing.T) *overlayFixture {
+	t.Helper()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	ec := inmem.Client
+
+	appID, err := ec.Create(ctx, "myapp", &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	return &overlayFixture{ctx: ctx, inmem: inmem, ec: ec, appID: appID}
+}
+
+func (f *overlayFixture) version(t *testing.T, name string, vars ...core_v1alpha.ConfigSpecVariables) *core_v1alpha.AppVersion {
+	t.Helper()
+
+	cvID, err := f.ec.Create(f.ctx, name+"-cfg", &core_v1alpha.ConfigVersion{
+		App:  f.appID,
+		Spec: core_v1alpha.ConfigSpec{Variables: vars},
+	})
+	require.NoError(t, err)
+
+	ver := &core_v1alpha.AppVersion{App: f.appID, Version: name, ConfigVersion: cvID}
+	id, err := f.ec.Create(f.ctx, name, ver)
+	require.NoError(t, err)
+	ver.ID = id
+	return ver
+}
+
+func (f *overlayFixture) association(t *testing.T, name, status string, vars ...addon_v1alpha.Variables) {
+	t.Helper()
+
+	_, err := f.ec.Create(f.ctx, name, &addon_v1alpha.AddonAssociation{
+		App:       f.appID,
+		Status:    status,
+		Variables: vars,
+	})
+	require.NoError(t, err)
+}
+
+func varsByKey(spec *core_v1alpha.ConfigSpec) map[string]core_v1alpha.ConfigSpecVariables {
+	out := make(map[string]core_v1alpha.ConfigSpecVariables, len(spec.Variables))
+	for _, v := range spec.Variables {
+		out[v.Key] = v
+	}
+	return out
+}
+
+// TestResolveRuntimeConfigSuppliesBindingToVersionThatPredatesAddon is the
+// MIR-1579 case. The version was built before the addon existed, so it has never
+// contained DATABASE_URL; activating it used to strand the app without database
+// credentials permanently.
+func TestResolveRuntimeConfigSuppliesBindingToVersionThatPredatesAddon(t *testing.T) {
+	f := newOverlayFixture(t)
+
+	preAddon := f.version(t, "myapp-v1",
+		core_v1alpha.ConfigSpecVariables{Key: "PORT", Value: "3000", Source: SourceConfig})
+
+	f.association(t, "pg-assoc", "active",
+		addon_v1alpha.Variables{Key: "DATABASE_URL", Value: "postgres://live", Sensitive: true})
+
+	spec, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, preAddon)
+	require.NoError(t, err)
+
+	got := varsByKey(spec)
+	require.Contains(t, got, "DATABASE_URL", "the binding must reach a version that predates the addon")
+	assert.Equal(t, "postgres://live", got["DATABASE_URL"].Value)
+	assert.Equal(t, SourceAddon, got["DATABASE_URL"].Source,
+		"deprovision strips only source==addon, so a relabelled var would leak")
+	assert.True(t, got["DATABASE_URL"].Sensitive)
+	assert.Equal(t, "3000", got["PORT"].Value, "the version's own config must survive")
+
+	// The stored config is untouched: no version has to contain the binding.
+	stored, err := ResolveConfig(f.ctx, f.inmem.EAC, preAddon)
+	require.NoError(t, err)
+	assert.NotContains(t, varsByKey(stored), "DATABASE_URL",
+		"ResolveConfig feeds the write paths and must not carry the overlay")
+}
+
+// TestResolveRuntimeConfigPrefersAssociationOverStoredCopy covers a version that
+// still carries a copy from when provisioning wrote one. The association is the
+// record that gets updated, so it wins.
+func TestResolveRuntimeConfigPrefersAssociationOverStoredCopy(t *testing.T) {
+	f := newOverlayFixture(t)
+
+	ver := f.version(t, "myapp-v2", core_v1alpha.ConfigSpecVariables{
+		Key: "DATABASE_URL", Value: "postgres://stored", Sensitive: true, Source: SourceAddon,
+	})
+
+	f.association(t, "pg-assoc", "active",
+		addon_v1alpha.Variables{Key: "DATABASE_URL", Value: "postgres://rotated", Sensitive: true})
+
+	spec, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+	require.NoError(t, err)
+
+	got := varsByKey(spec)
+	assert.Equal(t, "postgres://rotated", got["DATABASE_URL"].Value)
+	assert.Len(t, spec.Variables, 1, "the binding must replace the copy, not duplicate it")
+}
+
+// TestResolveRuntimeConfigDropsCopyFromDestroyedAddon is what dropping buys.
+// Deprovision no longer rewrites versions, so a version can outlive the addon
+// that contributed to it. Continuing to serve those credentials would point the
+// app at a database that no longer exists.
+func TestResolveRuntimeConfigDropsCopyFromDestroyedAddon(t *testing.T) {
+	f := newOverlayFixture(t)
+
+	ver := f.version(t, "myapp-v1",
+		core_v1alpha.ConfigSpecVariables{Key: "PORT", Value: "3000", Source: SourceConfig},
+		core_v1alpha.ConfigSpecVariables{
+			Key: "DATABASE_URL", Value: "postgres://destroyed", Sensitive: true, Source: SourceAddon,
+		})
+
+	// No association at all: the addon was destroyed.
+	spec, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+	require.NoError(t, err)
+
+	got := varsByKey(spec)
+	assert.NotContains(t, got, "DATABASE_URL",
+		"a stored copy with no live association behind it must not be served")
+	assert.Equal(t, "3000", got["PORT"].Value, "unrelated config must survive")
+}
+
+// TestResolveRuntimeConfigNeverOverridesManual pins RFD-59's rule: an addon
+// variable never displaces one an operator set.
+func TestResolveRuntimeConfigNeverOverridesManual(t *testing.T) {
+	f := newOverlayFixture(t)
+
+	ver := f.version(t, "myapp-v1", core_v1alpha.ConfigSpecVariables{
+		Key: "DATABASE_URL", Value: "postgres://operator-chose-this", Source: SourceManual,
+	})
+
+	f.association(t, "pg-assoc", "active",
+		addon_v1alpha.Variables{Key: "DATABASE_URL", Value: "postgres://addon"})
+
+	spec, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+	require.NoError(t, err)
+
+	got := varsByKey(spec)
+	assert.Equal(t, "postgres://operator-chose-this", got["DATABASE_URL"].Value)
+	assert.Equal(t, SourceManual, got["DATABASE_URL"].Source, "the operator's source must not be relabelled")
+}
+
+// TestResolveRuntimeConfigOverridesAppTomlDeclaration carries over the rule
+// mergeAddonVars used to enforce. Declaring DATABASE_URL in app.toml and then
+// attaching a database addon has always meant the addon supplies the real
+// value; blocking it would hand the app a placeholder instead of a credential.
+func TestResolveRuntimeConfigOverridesAppTomlDeclaration(t *testing.T) {
+	f := newOverlayFixture(t)
+
+	ver := f.version(t, "myapp-v1",
+		core_v1alpha.ConfigSpecVariables{Key: "PORT", Value: "3000", Source: SourceConfig},
+		core_v1alpha.ConfigSpecVariables{
+			Key: "DATABASE_URL", Value: "postgres://placeholder", Source: SourceConfig,
+			Required: true, Description: "where the database lives",
+		})
+
+	f.association(t, "pg-assoc", "active",
+		addon_v1alpha.Variables{Key: "DATABASE_URL", Value: "postgres://real", Sensitive: true})
+
+	spec, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+	require.NoError(t, err)
+
+	got := varsByKey(spec)
+	assert.Equal(t, "postgres://real", got["DATABASE_URL"].Value)
+	assert.Equal(t, SourceAddon, got["DATABASE_URL"].Source)
+	assert.Len(t, spec.Variables, 2, "the binding must replace the declaration, not sit beside it")
+
+	// The declaration's metadata is what `miren env list` renders and what the
+	// next build validates against, so shadowing must not blank it.
+	assert.True(t, got["DATABASE_URL"].Required, "app.toml's required flag must survive being shadowed")
+	assert.Equal(t, "where the database lives", got["DATABASE_URL"].Description)
+}
+
+// TestResolveRuntimeConfigTreatsEmptySourceAsOperatorSet covers versions written
+// before the source field existed. mergeVariablesFromAppConfig has always read
+// an empty source as operator-set, and an addon must not displace those either.
+func TestResolveRuntimeConfigTreatsEmptySourceAsOperatorSet(t *testing.T) {
+	f := newOverlayFixture(t)
+
+	ver := f.version(t, "myapp-v1",
+		core_v1alpha.ConfigSpecVariables{Key: "DATABASE_URL", Value: "postgres://legacy"})
+
+	f.association(t, "pg-assoc", "active",
+		addon_v1alpha.Variables{Key: "DATABASE_URL", Value: "postgres://addon"})
+
+	spec, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+	require.NoError(t, err)
+
+	got := varsByKey(spec)
+	assert.Equal(t, "postgres://legacy", got["DATABASE_URL"].Value,
+		"an unsourced variable predates the field and is treated as operator-set")
+}
+
+// TestResolveRuntimeConfigIgnoresInactiveAssociations covers teardown and
+// mid-provision. Supplying credentials from an association being deprovisioned
+// would keep an app pointed at a database about to disappear.
+func TestResolveRuntimeConfigIgnoresInactiveAssociations(t *testing.T) {
+	for _, status := range []string{"pending", "provisioning", "deprovisioning", "error"} {
+		t.Run(status, func(t *testing.T) {
+			f := newOverlayFixture(t)
+			ver := f.version(t, "myapp-v1")
+			f.association(t, "pg-assoc", status,
+				addon_v1alpha.Variables{Key: "DATABASE_URL", Value: "postgres://x"})
+
+			spec, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+			require.NoError(t, err)
+			assert.NotContains(t, varsByKey(spec), "DATABASE_URL",
+				"only an active association contributes bindings")
+		})
+	}
+}
+
+// TestResolveRuntimeConfigWithoutAddons is the overwhelmingly common path: an app
+// with no addons must resolve exactly as ResolveConfig does, in the same order.
+func TestResolveRuntimeConfigWithoutAddons(t *testing.T) {
+	f := newOverlayFixture(t)
+	ver := f.version(t, "myapp-v1",
+		core_v1alpha.ConfigSpecVariables{Key: "PORT", Value: "3000", Source: SourceConfig},
+		core_v1alpha.ConfigSpecVariables{Key: "LOG_LEVEL", Value: "info", Source: SourceManual})
+
+	spec, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+	require.NoError(t, err)
+
+	stored, err := ResolveConfig(f.ctx, f.inmem.EAC, ver)
+	require.NoError(t, err)
+
+	assert.Equal(t, stored.Variables, spec.Variables)
+}
+
+// TestResolveRuntimeConfigMergesMultipleAddons covers an app holding more than
+// one addon, the composition case MIR-1458 established has to work.
+func TestResolveRuntimeConfigMergesMultipleAddons(t *testing.T) {
+	f := newOverlayFixture(t)
+	ver := f.version(t, "myapp-v1")
+
+	f.association(t, "pg-assoc", "active",
+		addon_v1alpha.Variables{Key: "DATABASE_URL", Value: "postgres://x"})
+	f.association(t, "mc-assoc", "active",
+		addon_v1alpha.Variables{Key: "MEMCACHE_URL", Value: "memcache://y"})
+
+	spec, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+	require.NoError(t, err)
+
+	got := varsByKey(spec)
+	assert.Equal(t, "postgres://x", got["DATABASE_URL"].Value)
+	assert.Equal(t, "memcache://y", got["MEMCACHE_URL"].Value)
+}
+
+// TestResolveRuntimeConfigIsDeterministicAcrossAssociations pins which addon
+// wins when two supply the same key. AdjustEnvVars normally makes the second one
+// rename at provision time, so this is unusual, but the resolved config must be
+// a function of stored state rather than of the order the entity store returned.
+func TestResolveRuntimeConfigIsDeterministicAcrossAssociations(t *testing.T) {
+	f := newOverlayFixture(t)
+	ver := f.version(t, "myapp-v1")
+
+	f.association(t, "assoc-a", "active",
+		addon_v1alpha.Variables{Key: "SHARED_URL", Value: "from-a"})
+	f.association(t, "assoc-b", "active",
+		addon_v1alpha.Variables{Key: "SHARED_URL", Value: "from-b"})
+
+	first, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+	require.NoError(t, err)
+	winner := varsByKey(first)["SHARED_URL"].Value
+	require.NotEmpty(t, winner)
+
+	for i := 0; i < 8; i++ {
+		again, err := ResolveRuntimeConfig(f.ctx, f.inmem.EAC, ver)
+		require.NoError(t, err)
+		assert.Equal(t, winner, varsByKey(again)["SHARED_URL"].Value,
+			"the same stored state must always resolve to the same value")
+	}
+}

--- a/api/core/varsource.go
+++ b/api/core/varsource.go
@@ -1,0 +1,21 @@
+package compute
+
+// Variable sources: who owns a variable. The schema documents this field as
+// "config or manual", but the addon controller writes a third value and the
+// deprovision path matches on it exactly, so name them here.
+//
+// This is the ownership axis, not RFD-55's storage-backend axis. Storage lives
+// on the `backend` field. See RFD-90, which settled that split.
+const (
+	// SourceConfig marks a variable declared in .miren/app.toml. It belongs to
+	// the version built from that app.toml.
+	SourceConfig = "config"
+
+	// SourceManual marks a variable an operator set.
+	SourceManual = "manual"
+
+	// SourceAddon marks a variable an addon contributed. Deprovision strips only
+	// keys whose source is exactly this, so the value must never be rewritten to
+	// anything else.
+	SourceAddon = "addon"
+)

--- a/blackbox/addon_test.go
+++ b/blackbox/addon_test.go
@@ -3,6 +3,7 @@
 package blackbox
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
@@ -297,4 +298,109 @@ func TestAddonUnknownAddon(t *testing.T) {
 	if r.Success() {
 		t.Fatal("expected addon create to fail for unknown addon")
 	}
+}
+
+// TestAddonEnvSurvivesDeployVersion covers MIR-1579.
+//
+// An addon's variables belong to the app, not to any one build, so no version
+// has to have been built with them. Re-activating a version that does not carry
+// DATABASE_URL — which `deploy -V` does, and which is the natural recovery step
+// after a first deploy whose health check failed — used to leave the app without
+// its database credentials permanently. Nothing restored them: not a rebuild,
+// not `app restart`. The only known recovery was destroying the addon, which
+// drops the database.
+//
+// This is the sequence two operators hit independently on two clusters.
+func TestAddonEnvSurvivesDeployVersion(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+	appDir := m.ContainerPath(filepath.Join(c.TestdataDir, "go-server"))
+
+	// The version built before the addon exists — the one a failed first deploy
+	// names in its error, and the one an operator passes to -V.
+	preAddonVersion := extractVersion(t, m.MustRun("app", "list", "--format", "json").Stdout, name)
+	t.Logf("pre-addon version: %s", preAddonVersion)
+
+	m.MustRun("addon", "create", "miren-postgresql:small", "-a", name)
+	harness.WaitForAddonReady(t, m, name, "miren-postgresql", 30*time.Second)
+	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 5*time.Minute)
+
+	// Captured now, asserted at the end: attaching an addon contributes a binding
+	// without minting a version. Checking it here would mask the defect this test
+	// is really about, because a build that predates the addon fails the
+	// DATABASE_URL assertions below whether or not a version was minted.
+	versionAfterAttach := extractVersion(t, m.MustRun("app", "list", "--format", "json").Stdout, name)
+
+	// Rebuild so there is a genuinely different version to come back from.
+	m.MustRun("deploy", "-a", name, "-d", appDir, "-f")
+	harness.WaitForAppReady(t, m, name, 2*time.Minute)
+
+	rebuilt := extractVersion(t, m.MustRun("app", "list", "--format", "json").Stdout, name)
+	if rebuilt == preAddonVersion {
+		t.Fatalf("expected the rebuild to produce a new version, still on %s", preAddonVersion)
+	}
+
+	// The bug trigger.
+	m.MustRun("deploy", "-a", name, "-V", preAddonVersion, "-f")
+	harness.WaitForAppReady(t, m, name, 2*time.Minute)
+	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 2*time.Minute)
+
+	// Specifically DATABASE_URL's source, not just the word "addon" somewhere in
+	// the table: deprovision only strips keys whose source is exactly "addon",
+	// so a relabelled var would be leaked when the addon is removed.
+	r := m.MustRun("env", "list", "-a", name, "--format", "json")
+	if got := envVarSource(t, r.Stdout, "DATABASE_URL"); got != "addon" {
+		t.Errorf("DATABASE_URL source = %q, want \"addon\"; a relabelled var leaks on addon destroy:\n%s", got, r.Stdout)
+	}
+
+	// And the operator got the version they asked for, not one derived from it.
+	if got := extractVersion(t, m.MustRun("app", "list", "--format", "json").Stdout, name); got != preAddonVersion {
+		t.Errorf("active version = %q, want %q; `deploy -V` must activate the named version, not a derivative",
+			got, preAddonVersion)
+	}
+
+	// The other half of the same defect: once the app was on a version without
+	// the binding, nothing put it back. `app restart` re-launched the same
+	// configuration and a rebuild copied config forward from whatever was
+	// active. Restarting while on the re-activated version is the case that used
+	// to stay broken.
+	m.MustRun("app", "restart", "-a", name)
+	harness.WaitForAppReady(t, m, name, 2*time.Minute)
+	harness.WaitForEnvVar(t, m, name, "DATABASE_URL", 2*time.Minute)
+
+	r = m.MustRun("env", "list", "-a", name, "--format", "json")
+	if got := envVarSource(t, r.Stdout, "DATABASE_URL"); got != "addon" {
+		t.Errorf("DATABASE_URL source = %q, want \"addon\" after restart:\n%s", got, r.Stdout)
+	}
+
+	// The binding is resolved rather than stored, so attaching the addon never
+	// had to mint a version to carry it.
+	if versionAfterAttach != preAddonVersion {
+		t.Errorf("version after attaching addon = %q, want %q; a binding must not require a new version",
+			versionAfterAttach, preAddonVersion)
+	}
+}
+
+// envVarSource pulls one variable's source out of `env list --format json`.
+func envVarSource(t *testing.T, jsonOutput, key string) string {
+	t.Helper()
+
+	var vars []struct {
+		Name   string `json:"name"`
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal([]byte(jsonOutput), &vars); err != nil {
+		t.Fatalf("failed to parse env list JSON: %v", err)
+	}
+	for _, v := range vars {
+		if v.Name == key {
+			return v.Source
+		}
+	}
+	t.Fatalf("env var %s not found in env list", key)
+	return ""
 }

--- a/cli/commands/sandbox_pool_list.go
+++ b/cli/commands/sandbox_pool_list.go
@@ -52,7 +52,7 @@ func SandboxPoolList(ctx *Context, opts struct {
 		if sid := e.Entity().ShortId(); sid != "" {
 			versionShortIdMap[v.ID.String()] = sid
 		}
-		if resolvedCfg, err := coreutil.ResolveConfig(ctx, eac, v); err == nil {
+		if resolvedCfg, err := coreutil.ResolveRuntimeConfig(ctx, eac, v); err == nil {
 			specMap[v.ID.String()] = resolvedCfg
 		}
 	}

--- a/components/activator/activator.go
+++ b/components/activator/activator.go
@@ -606,7 +606,7 @@ func (a *localActivator) requestPoolCapacity(ctx context.Context, ver *core_v1al
 	// register a freshly-discovered pool on the cache-miss path. This is the
 	// scale-up path (only reached when no sandbox has capacity), so the extra
 	// entity store reads are acceptable.
-	spec, err := coreutil.ResolveConfig(ctx, a.eac, ver)
+	spec, err := coreutil.ResolveRuntimeConfig(ctx, a.eac, ver)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve config: %w", err)
 	}
@@ -1416,7 +1416,7 @@ func (a *localActivator) watchSandboxes(ctx context.Context) {
 			appVer.Decode(verResp.Entity().Entity())
 
 			// Resolve config from ConfigVersion if available
-			spec, err := coreutil.ResolveConfig(ctx, a.eac, &appVer)
+			spec, err := coreutil.ResolveRuntimeConfig(ctx, a.eac, &appVer)
 			if err != nil {
 				a.log.Error("failed to resolve config for sandbox", "error", err, "sandbox", sb.ID)
 				return nil
@@ -1610,7 +1610,7 @@ func (a *localActivator) recoverSandboxes(ctx context.Context) error {
 		appVer.Decode(verResp.Entity().Entity())
 
 		// Resolve config from ConfigVersion if available
-		spec, err := coreutil.ResolveConfig(ctx, a.eac, &appVer)
+		spec, err := coreutil.ResolveRuntimeConfig(ctx, a.eac, &appVer)
 		if err != nil {
 			a.log.Error("failed to resolve config for sandbox", "error", err, "sandbox", sb.ID)
 			continue
@@ -1724,7 +1724,7 @@ func (a *localActivator) recoverPools(ctx context.Context) error {
 		appVer.Decode(verResp.Entity().Entity())
 
 		// Resolve config from ConfigVersion if available
-		spec, err := coreutil.ResolveConfig(ctx, a.eac, &appVer)
+		spec, err := coreutil.ResolveRuntimeConfig(ctx, a.eac, &appVer)
 		if err != nil {
 			a.log.Error("failed to resolve config for pool", "error", err, "pool", pool.ID)
 			continue

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1099,6 +1099,23 @@ func (c *Coordinator) Start(ctx context.Context) error {
 		return err
 	}
 
+	// Report associations left stale by a rotation that predates resolving
+	// bindings from them. This only reports; see ReportStaleAssociationVariables
+	// for why repairing it here would be worse.
+	//
+	// Bounded by the same startup-maintenance deadline as the migrations above, so
+	// a large or slow store delays boot by at most that budget. A sweep cut short
+	// reports what it reached and boot continues: an unread association means a
+	// missing warning, never a missing binding.
+	assocStale, assocChecked, assocErr := addonctrl.ReportStaleAssociationVariables(maintCtx, c.Log, ec, eac)
+	if assocErr != nil {
+		c.Log.Warn("addon association variable check did not complete",
+			"stale", assocStale, "checked", assocChecked, "error", assocErr)
+	} else if assocStale > 0 {
+		c.Log.Warn("addon associations disagree with their apps' stored config",
+			"stale", assocStale, "checked", assocChecked)
+	}
+
 	// Set up addon registry and register providers.
 	addonRegistry := addon.NewRegistry()
 	addonFw := addon.NewProviderFramework(c.Log, ec, eac, saga.NewEntityStorage(etcdStore, c.Log))

--- a/controllers/addon/assocvars.go
+++ b/controllers/addon/assocvars.go
@@ -1,0 +1,110 @@
+package addon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// setAssociationVars replaces the association's record of what the addon
+// supplies. Every other attribute on the entity is left as it was.
+//
+// This rewrites the whole entity instead of patching it. Patch and Update both
+// merge multi-valued attributes, so patching `variables` would append the new
+// credential next to the superseded one. Replace is the only write that can
+// overwrite a many-valued attribute (see CreateOrReplace in
+// api/entityserver/client.go). Replace does not retry, so the CAS loop is here.
+func setAssociationVars(
+	ctx context.Context,
+	eac *entityserver_v1alpha.EntityAccessClient,
+	assocID entity.Id,
+	envVars []addon.Variable,
+) error {
+	// A live-lock backstop, not an expected limit. Only one rotation runs per
+	// addon at a time, so contention on a single association is rare.
+	const maxAttempts = 100
+
+	// Collapse repeated keys, last one wins. A container environment is a map, so
+	// a repeated key has no meaning to store. It also has to go before the
+	// comparison below, which assumes one entry per key: with duplicates, two
+	// different sets can have the same length and the same key-to-value map, and
+	// the write would be skipped as a no-op.
+	desired := make([]addon_v1alpha.Variables, 0, len(envVars))
+	at := make(map[string]int, len(envVars))
+	for _, v := range envVars {
+		next := addon_v1alpha.Variables{Key: v.Key, Value: v.Value, Sensitive: v.Sensitive}
+		if i, ok := at[v.Key]; ok {
+			desired[i] = next
+			continue
+		}
+		at[v.Key] = len(desired)
+		desired = append(desired, next)
+	}
+
+	for attempt := 1; ; attempt++ {
+		resp, err := eac.Get(ctx, assocID.String())
+		if err != nil {
+			return fmt.Errorf("reading association %s: %w", assocID, err)
+		}
+		ent := resp.Entity().Entity()
+		rev := resp.Entity().Revision()
+
+		var current addon_v1alpha.AddonAssociation
+		current.Decode(ent)
+		if assocVarsEqual(current.Variables, desired) {
+			return nil
+		}
+
+		// Remove drops every value of the attribute, which is what makes this a
+		// replacement instead of an append.
+		ent.Remove(addon_v1alpha.AddonAssociationVariablesId)
+		attrs := ent.Attrs()
+		for i := range desired {
+			attrs = append(attrs, entity.Component(
+				addon_v1alpha.AddonAssociationVariablesId, desired[i].Encode()))
+		}
+
+		if _, err := eac.Replace(ctx, attrs, rev); err == nil {
+			return nil
+		} else if !errors.Is(err, cond.ErrConflict{}) {
+			return fmt.Errorf("recording association variables: %w", err)
+		}
+
+		if attempt >= maxAttempts {
+			return fmt.Errorf("recording association variables on %s: too many conflicts after %d attempts",
+				assocID, maxAttempts)
+		}
+	}
+}
+
+// assocVarsEqual reports whether two variable sets match, ignoring order.
+// Providers build their result sets independently per call, so order carries no
+// meaning. A positional comparison would rewrite the entity on every retry.
+//
+// b must have no repeated keys; setAssociationVars collapses them first. Given
+// that, a stored set with a repeat can never compare equal, because it holds
+// fewer distinct keys than b in the same length, so it is rewritten and cleaned
+// up rather than mistaken for a match.
+func assocVarsEqual(a, b []addon_v1alpha.Variables) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	byKey := make(map[string]addon_v1alpha.Variables, len(a))
+	for _, v := range a {
+		byKey[v.Key] = v
+	}
+	for _, v := range b {
+		prev, ok := byKey[v.Key]
+		if !ok || prev != v {
+			return false
+		}
+	}
+	return true
+}

--- a/controllers/addon/assocvars_test.go
+++ b/controllers/addon/assocvars_test.go
@@ -1,0 +1,280 @@
+package addon
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/pkg/addon"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+func setupAssocTest(t *testing.T) (context.Context, *entityserver.Client, *testutils.InMemEntityServer) {
+	t.Helper()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+	return context.Background(), entityserver.NewClient(slog.Default(), inmem.EAC), inmem
+}
+
+// appOnVersion creates an app whose active version carries vars.
+func appOnVersion(t *testing.T, ctx context.Context, ec *entityserver.Client, name string,
+	vars ...core_v1alpha.ConfigSpecVariables) entity.Id {
+	t.Helper()
+
+	appID, err := ec.Create(ctx, name, &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	cvID, err := ec.Create(ctx, name+"-cfg", &core_v1alpha.ConfigVersion{
+		App:  appID,
+		Spec: core_v1alpha.ConfigSpec{Variables: vars},
+	})
+	require.NoError(t, err)
+
+	verID, err := ec.Create(ctx, name+"-v1", &core_v1alpha.AppVersion{
+		App: appID, Version: name + "-v1", ConfigVersion: cvID,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, ec.Patch(ctx, appID, 0, entity.Ref(core_v1alpha.AppActiveVersionId, verID)))
+	return appID
+}
+
+func assocVars(t *testing.T, ctx context.Context, ec *entityserver.Client, id entity.Id) map[string]addon_v1alpha.Variables {
+	t.Helper()
+	var got addon_v1alpha.AddonAssociation
+	require.NoError(t, ec.GetById(ctx, id, &got))
+	out := make(map[string]addon_v1alpha.Variables, len(got.Variables))
+	for _, v := range got.Variables {
+		out[v.Key] = v
+	}
+	return out
+}
+
+// TestSetAssociationVarsReplacesRatherThanAppends is the regression test for the
+// trap that kept association.variables frozen in the first place. Patch and
+// Update both MERGE multi-valued attributes, so the obvious implementation
+// leaves the superseded credential sitting alongside the new one and a reader
+// cannot tell which is live. Only Replace can overwrite a many-valued attribute.
+//
+// It also pins the other half of using Replace: because it rewrites the whole
+// entity, every attribute this function does not manage has to survive.
+func TestSetAssociationVarsReplacesRatherThanAppends(t *testing.T) {
+	ctx, ec, inmem := setupAssocTest(t)
+
+	appID := appOnVersion(t, ctx, ec, "myapp")
+	addonID, err := ec.Create(ctx, "some-addon", &addon_v1alpha.Addon{Name: "miren-postgresql"})
+	require.NoError(t, err)
+
+	assocID, err := ec.Create(ctx, "rotate-assoc", &addon_v1alpha.AddonAssociation{
+		App:     appID,
+		Addon:   addonID,
+		Variant: "small",
+		Status:  "active",
+		Variables: []addon_v1alpha.Variables{
+			{Key: "PGPASSWORD", Value: "old", Sensitive: true},
+			{Key: "DATABASE_URL", Value: "postgres://old", Sensitive: true},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, setAssociationVars(ctx, inmem.EAC, assocID, []addon.Variable{
+		{Key: "PGPASSWORD", Value: "new", Sensitive: true},
+		{Key: "DATABASE_URL", Value: "postgres://new", Sensitive: true},
+	}))
+
+	got := assocVars(t, ctx, ec, assocID)
+	require.Len(t, got, 2, "a merging write would have left the old pair alongside the new one")
+	assert.Equal(t, "new", got["PGPASSWORD"].Value)
+	assert.Equal(t, "postgres://new", got["DATABASE_URL"].Value)
+	assert.True(t, got["PGPASSWORD"].Sensitive, "sensitivity must carry over")
+
+	var full addon_v1alpha.AddonAssociation
+	require.NoError(t, ec.GetById(ctx, assocID, &full))
+	assert.Equal(t, appID, full.App, "the app ref must survive a full-entity replace")
+	assert.Equal(t, addonID, full.Addon, "the addon ref must survive a full-entity replace")
+	assert.Equal(t, "small", full.Variant, "unmanaged attrs must survive a full-entity replace")
+	assert.Equal(t, "active", full.Status, "status must survive a full-entity replace")
+}
+
+// TestSetAssociationVarsIsIdempotent keeps a retry from rewriting the entity on
+// every pass. Providers are idempotent for a fixed secret, so a retry arrives
+// with the values already recorded.
+func TestSetAssociationVarsIsIdempotent(t *testing.T) {
+	ctx, ec, inmem := setupAssocTest(t)
+
+	assocID, err := ec.Create(ctx, "rotate-assoc", &addon_v1alpha.AddonAssociation{
+		Status:    "active",
+		Variables: []addon_v1alpha.Variables{{Key: "PGPASSWORD", Value: "same", Sensitive: true}},
+	})
+	require.NoError(t, err)
+
+	vars := []addon.Variable{{Key: "PGPASSWORD", Value: "same", Sensitive: true}}
+	require.NoError(t, setAssociationVars(ctx, inmem.EAC, assocID, vars))
+
+	resp, err := inmem.EAC.Get(ctx, assocID.String())
+	require.NoError(t, err)
+	revAfter := resp.Entity().Revision()
+
+	require.NoError(t, setAssociationVars(ctx, inmem.EAC, assocID, vars))
+
+	resp, err = inmem.EAC.Get(ctx, assocID.String())
+	require.NoError(t, err)
+	assert.Equal(t, revAfter, resp.Entity().Revision(),
+		"re-recording identical variables must not write the entity")
+}
+
+// TestSetAssociationVarsCollapsesDuplicateKeys covers a set arriving with the
+// same key twice. A container environment is a map, so only one value can win,
+// and storing both would leave a reader unable to tell which. It also protects
+// the equality check: with duplicates, two different sets can share a length and
+// a key-to-value map, and the write would be skipped as a no-op.
+func TestSetAssociationVarsCollapsesDuplicateKeys(t *testing.T) {
+	ctx, ec, inmem := setupAssocTest(t)
+
+	assocID, err := ec.Create(ctx, "pg-assoc", &addon_v1alpha.AddonAssociation{Status: "active"})
+	require.NoError(t, err)
+
+	require.NoError(t, setAssociationVars(ctx, inmem.EAC, assocID, []addon.Variable{
+		{Key: "PGPASSWORD", Value: "first"},
+		{Key: "PGPASSWORD", Value: "second"},
+	}))
+
+	got := assocVars(t, ctx, ec, assocID)
+	require.Len(t, got, 1, "a repeated key must be stored once")
+	assert.Equal(t, "second", got["PGPASSWORD"].Value, "the last value wins")
+}
+
+// TestSetAssociationVarsDoesNotSkipWhenIncomingHasDuplicates is the regression
+// test for the skipped write.
+//
+// The equality check builds its map from the stored set and looks up the
+// incoming one, so a repeated incoming key collapses. {A=1, B=2} stored against
+// {A=1, A=1} incoming then matches on length and on every lookup, and the write
+// is skipped as a no-op. The association keeps B, which the addon no longer
+// supplies, and the app keeps resolving it.
+func TestSetAssociationVarsDoesNotSkipWhenIncomingHasDuplicates(t *testing.T) {
+	ctx, ec, inmem := setupAssocTest(t)
+
+	assocID, err := ec.Create(ctx, "pg-assoc", &addon_v1alpha.AddonAssociation{
+		Status: "active",
+		Variables: []addon_v1alpha.Variables{
+			{Key: "PGPASSWORD", Value: "one"},
+			{Key: "PGHOST", Value: "two"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, setAssociationVars(ctx, inmem.EAC, assocID, []addon.Variable{
+		{Key: "PGPASSWORD", Value: "one"},
+		{Key: "PGPASSWORD", Value: "one"},
+	}))
+
+	got := assocVars(t, ctx, ec, assocID)
+	assert.NotContains(t, got, "PGHOST",
+		"a variable the addon no longer supplies must not survive because the comparison collapsed a duplicate")
+	require.Len(t, got, 1)
+	assert.Equal(t, "one", got["PGPASSWORD"].Value)
+}
+
+// TestReportStaleAssociationVariablesFlagsDisagreement covers the state a
+// rotation on v0.12.x leaves behind: the version stores the rotated value and
+// the association still holds the provision-time one. It is reported, never
+// repaired, because repairing it from a boot path means writing to a live
+// credential with no reliable way to tell which record is fresher.
+func TestReportStaleAssociationVariablesFlagsDisagreement(t *testing.T) {
+	ctx, ec, inmem := setupAssocTest(t)
+
+	appID := appOnVersion(t, ctx, ec, "myapp",
+		core_v1alpha.ConfigSpecVariables{
+			Key: "DATABASE_URL", Value: "postgres://rotated", Sensitive: true, Source: coreutil.SourceAddon,
+		})
+
+	assocID, err := ec.Create(ctx, "pg-assoc", &addon_v1alpha.AddonAssociation{
+		App:       appID,
+		Status:    "active",
+		Variables: []addon_v1alpha.Variables{{Key: "DATABASE_URL", Value: "postgres://provisioned", Sensitive: true}},
+	})
+	require.NoError(t, err)
+
+	stale, checked, err := ReportStaleAssociationVariables(ctx, slog.Default(), ec, inmem.EAC)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stale)
+	assert.Equal(t, 1, checked)
+
+	// Nothing was written. The association keeps what it had, and the app keeps
+	// running on it, which is the whole point of reporting rather than repairing.
+	got := assocVars(t, ctx, ec, assocID)
+	assert.Equal(t, "postgres://provisioned", got["DATABASE_URL"].Value,
+		"the check must not write to a credential")
+}
+
+// TestReportStaleAssociationVariablesQuietWhenAgreed is the overwhelmingly
+// common case: an app that never rotated, where both records match.
+func TestReportStaleAssociationVariablesQuietWhenAgreed(t *testing.T) {
+	ctx, ec, inmem := setupAssocTest(t)
+
+	appID := appOnVersion(t, ctx, ec, "myapp",
+		core_v1alpha.ConfigSpecVariables{
+			Key: "DATABASE_URL", Value: "postgres://same", Source: coreutil.SourceAddon,
+		})
+	_, err := ec.Create(ctx, "pg-assoc", &addon_v1alpha.AddonAssociation{
+		App:       appID,
+		Status:    "active",
+		Variables: []addon_v1alpha.Variables{{Key: "DATABASE_URL", Value: "postgres://same"}},
+	})
+	require.NoError(t, err)
+
+	stale, checked, err := ReportStaleAssociationVariables(ctx, slog.Default(), ec, inmem.EAC)
+	require.NoError(t, err)
+	assert.Equal(t, 0, stale)
+	assert.Equal(t, 1, checked)
+}
+
+// TestReportStaleAssociationVariablesIgnoresMissingKey covers the MIR-1579 state
+// itself: the app is on a version that never carried the binding, so there is
+// nothing to disagree with and nothing to report.
+func TestReportStaleAssociationVariablesIgnoresMissingKey(t *testing.T) {
+	ctx, ec, inmem := setupAssocTest(t)
+
+	appID := appOnVersion(t, ctx, ec, "myapp",
+		core_v1alpha.ConfigSpecVariables{Key: "PORT", Value: "3000", Source: coreutil.SourceConfig})
+	_, err := ec.Create(ctx, "pg-assoc", &addon_v1alpha.AddonAssociation{
+		App:       appID,
+		Status:    "active",
+		Variables: []addon_v1alpha.Variables{{Key: "DATABASE_URL", Value: "postgres://only-copy"}},
+	})
+	require.NoError(t, err)
+
+	stale, _, err := ReportStaleAssociationVariables(ctx, slog.Default(), ec, inmem.EAC)
+	require.NoError(t, err)
+	assert.Equal(t, 0, stale, "a version that simply lacks the key is not a disagreement")
+}
+
+// TestReportStaleAssociationVariablesSkipsInactive leaves associations that are
+// mid-provision or being torn down out of the count.
+func TestReportStaleAssociationVariablesSkipsInactive(t *testing.T) {
+	ctx, ec, inmem := setupAssocTest(t)
+
+	appID := appOnVersion(t, ctx, ec, "myapp", core_v1alpha.ConfigSpecVariables{
+		Key: "DATABASE_URL", Value: "postgres://rotated", Source: coreutil.SourceAddon,
+	})
+	_, err := ec.Create(ctx, "pg-assoc", &addon_v1alpha.AddonAssociation{
+		App:       appID,
+		Status:    "deprovisioning",
+		Variables: []addon_v1alpha.Variables{{Key: "DATABASE_URL", Value: "postgres://provisioned"}},
+	})
+	require.NoError(t, err)
+
+	stale, checked, err := ReportStaleAssociationVariables(ctx, slog.Default(), ec, inmem.EAC)
+	require.NoError(t, err)
+	assert.Equal(t, 0, stale)
+	assert.Equal(t, 0, checked)
+}

--- a/controllers/addon/controller.go
+++ b/controllers/addon/controller.go
@@ -2,7 +2,6 @@ package addon
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
@@ -12,9 +11,7 @@ import (
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/pkg/addon"
-	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
-	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/saga"
 )
 
@@ -197,14 +194,11 @@ func (c *Controller) completeProvision(
 		envVars = adjusted
 	}
 
-	// Step 5: Create a new AppVersion with addon env vars merged in and activate it.
-	if err := c.createVersionWithAddonVars(ctx, assoc.App, envVars); err != nil {
-		return fmt.Errorf("creating version with addon vars: %w", err)
-	}
-
-	// Step 5b: Persist variables on the association immediately so that
-	// compensation (deprovision → removeEnvVars) can find the keys to
-	// remove even if step 6 fails.
+	// Step 5: Record what this addon supplies. This is the only write. The app's
+	// versions are untouched; the binding reaches the app because
+	// ResolveRuntimeConfig reads it from here. Step 6 sets status to active, which
+	// makes it visible, and the launcher's AddonAssociation watch turns that into
+	// a reconcile.
 	variables := make([]addon_v1alpha.Variables, len(envVars))
 	for i, v := range envVars {
 		variables[i] = addon_v1alpha.Variables{
@@ -265,12 +259,14 @@ func (c *Controller) deprovision(ctx context.Context, assoc *addon_v1alpha.Addon
 		return fmt.Errorf("deprovisioning: %w", err)
 	}
 
-	// Step 2: Remove addon env vars from app ConfigVersion
-	if err := c.removeEnvVars(ctx, assoc.App, assoc.Variables); err != nil {
-		return fmt.Errorf("removing addon env vars: %w", err)
-	}
-
-	// Step 3: Delete the association entity
+	// Step 2: Delete the association entity.
+	//
+	// Nothing strips the variables from the app's config, because they were never
+	// written there. The app stopped receiving them when its status became
+	// "deprovisioning": ResolveRuntimeConfig reads only active associations, and
+	// the launcher's AddonAssociation watch reconciled the app on that change.
+	// The watch ignores deletes, so this is not itself a trigger. That is fine,
+	// because the app was already reconciled without the binding.
 	if err := c.ec.Delete(ctx, assoc.ID); err != nil {
 		return fmt.Errorf("deleting association: %w", err)
 	}
@@ -324,7 +320,9 @@ func (c *Controller) getAppVariables(ctx context.Context, appID entity.Id) ([]co
 		return nil, fmt.Errorf("getting app version: %w", err)
 	}
 
-	spec, err := coreutil.ResolveConfig(ctx, c.eac, &version)
+	// The runtime view, so a collision with another addon's binding is visible
+	// even though no version stores those bindings.
+	spec, err := coreutil.ResolveRuntimeConfig(ctx, c.eac, &version)
 	if err != nil {
 		return nil, fmt.Errorf("resolving config: %w", err)
 	}
@@ -335,243 +333,6 @@ func (c *Controller) getAppVariables(ctx context.Context, appID entity.Id) ([]co
 		vars[i] = core_v1alpha.Variable(v)
 	}
 	return vars, nil
-}
-
-// createVersionWithAddonVars creates a new AppVersion with addon env vars merged
-// into the ConfigVersion and sets it as the active version. This ensures the
-// launcher always reads a version that has all vars baked in.
-func (c *Controller) createVersionWithAddonVars(ctx context.Context, appID entity.Id, envVars []addon.Variable) error {
-	return createVersionWithVars(ctx, c.log, c.ec, c.eac, appID, envVars)
-}
-
-// errNoActiveVersion signals that an app has no active version to update. It is
-// treated as a hard error on the provision path (triggering compensation) and as
-// a no-op on the deprovision path (nothing to remove).
-var errNoActiveVersion = errors.New("app has no active version")
-
-// updateAppActiveVersion atomically applies transform to the app's active config
-// spec: it resolves the current active config, lets transform mutate it in place,
-// mints a new ConfigVersion/AppVersion, and points ActiveVersion at it under
-// optimistic concurrency control — which triggers a redeploy via the launcher's
-// App watch.
-//
-// Multiple addon associations for the same app reconcile concurrently — they are
-// distinct entities handled by separate controller workers, and the in-flight
-// guard only serializes events for the same entity ID. Without OCC, two writers
-// both read the same active version and the second Patch clobbers the first,
-// dropping one addon's variables (MIR-1458). The Patch is therefore guarded by a
-// CAS on the app's revision and the whole read-modify-write is retried on
-// conflict, so the retry observes the winner's version and the transforms
-// compose. Shared by the provisioning, deprovisioning, and rotation paths.
-func updateAppActiveVersion(
-	ctx context.Context,
-	log *slog.Logger,
-	ec *entityserver.Client,
-	eac *entityserver_v1alpha.EntityAccessClient,
-	appID entity.Id,
-	transform func(spec *core_v1alpha.ConfigSpec) error,
-) error {
-	// maxAttempts is only a live-lock backstop to guarantee termination — it is
-	// not expected to be reached. Each conflict means some other writer swung the
-	// active version first; there are only ever a handful of concurrent addon
-	// operations per app, so a few retries suffice. It is set high so genuine
-	// contention never spuriously fails a caller, and on exhaustion the error is
-	// returned to the reconcile framework, which retries the whole reconcile.
-	const maxAttempts = 100
-
-	for attempt := 1; ; attempt++ {
-		var app core_v1alpha.App
-		appEnt, err := ec.GetByIdWithEntity(ctx, appID, &app)
-		if err != nil {
-			return fmt.Errorf("getting app: %w", err)
-		}
-		if app.ActiveVersion == "" {
-			return errNoActiveVersion
-		}
-		appRev := appEnt.Revision()
-
-		var version core_v1alpha.AppVersion
-		if err := ec.GetById(ctx, app.ActiveVersion, &version); err != nil {
-			return fmt.Errorf("getting app version: %w", err)
-		}
-
-		// Resolve the current config (reads ConfigVersion if present, else inline)
-		spec, err := coreutil.ResolveConfig(ctx, eac, &version)
-		if err != nil {
-			return fmt.Errorf("resolving config: %w", err)
-		}
-
-		if err := transform(spec); err != nil {
-			return err
-		}
-
-		appName, err := resolveAppName(ctx, ec, appID)
-		if err != nil {
-			return fmt.Errorf("resolving app name: %w", err)
-		}
-
-		newVersionName := appName + "-" + idgen.Gen("v")
-
-		configVer := &core_v1alpha.ConfigVersion{
-			App:  appID,
-			Spec: *spec,
-		}
-		cvid, err := ec.Create(ctx, newVersionName+"-cfg", configVer)
-		if err != nil {
-			return fmt.Errorf("creating config version: %w", err)
-		}
-
-		version.Version = newVersionName
-		version.ConfigVersion = cvid
-		version.Config = core_v1alpha.Config{}
-
-		newID, err := ec.Create(ctx, newVersionName, &version)
-		if err != nil {
-			return fmt.Errorf("creating new app version: %w", err)
-		}
-
-		// Swing the active version under OCC. A conflict means another writer
-		// updated the active version between our read and this write, so retry
-		// against the new active version.
-		err = ec.Patch(ctx, appID, appRev,
-			entity.Ref(core_v1alpha.AppActiveVersionId, newID),
-		)
-		if err == nil {
-			log.Info("updated app active version",
-				"app", appID, "old_version", app.ActiveVersion, "new_version", newID)
-			return nil
-		}
-
-		if errors.Is(err, cond.ErrConflict{}) {
-			// This attempt lost the race, so the version pair we just minted was
-			// never activated. Best-effort delete it, AppVersion first: only drop
-			// the ConfigVersion once its AppVersion is gone, so a failed delete
-			// leaves a coherent pair for the version GC to reap rather than an
-			// AppVersion dangling at a missing ConfigVersion.
-			if delErr := ec.Delete(ctx, newID); delErr != nil {
-				log.Warn("failed to delete superseded app version after conflict",
-					"app", appID, "version", newID, "error", delErr)
-			} else if delErr := ec.Delete(ctx, cvid); delErr != nil {
-				log.Warn("failed to delete superseded config version after conflict",
-					"app", appID, "config_version", cvid, "error", delErr)
-			}
-
-			if attempt < maxAttempts {
-				log.Info("app active version changed concurrently, retrying",
-					"app", appID, "attempt", attempt)
-				continue
-			}
-		}
-
-		return fmt.Errorf("setting active version: %w", err)
-	}
-}
-
-// createVersionWithVars merges envVars into the app's active config, mints a new
-// ConfigVersion + AppVersion, and points ActiveVersion at it — which triggers a
-// redeploy via the launcher's App watch. It is shared by the provisioning path
-// (adding addon vars) and the rotation path (replacing a rotated credential).
-func createVersionWithVars(
-	ctx context.Context,
-	log *slog.Logger,
-	ec *entityserver.Client,
-	eac *entityserver_v1alpha.EntityAccessClient,
-	appID entity.Id,
-	envVars []addon.Variable,
-) error {
-	if len(envVars) == 0 {
-		return nil
-	}
-
-	return updateAppActiveVersion(ctx, log, ec, eac, appID, func(spec *core_v1alpha.ConfigSpec) error {
-		// Convert ConfigSpecVariables to Variable for merging
-		existingVars := make([]core_v1alpha.Variable, len(spec.Variables))
-		for i, v := range spec.Variables {
-			existingVars[i] = core_v1alpha.Variable(v)
-		}
-
-		merged := mergeAddonVars(existingVars, envVars)
-
-		// Write back as ConfigSpecVariables
-		spec.Variables = make([]core_v1alpha.ConfigSpecVariables, len(merged))
-		for i, v := range merged {
-			spec.Variables[i] = core_v1alpha.ConfigSpecVariables(v)
-		}
-		return nil
-	})
-}
-
-// removeEnvVars removes addon-sourced variables from the app's active version
-// by creating a new ConfigVersion without those vars and a new AppVersion
-// pointing to it.
-func (c *Controller) removeEnvVars(ctx context.Context, appID entity.Id, variables []addon_v1alpha.Variables) error {
-	if len(variables) == 0 {
-		return nil
-	}
-
-	// Build set of keys to remove
-	removeKeys := make(map[string]bool, len(variables))
-	for _, v := range variables {
-		removeKeys[v.Key] = true
-	}
-
-	err := updateAppActiveVersion(ctx, c.log, c.ec, c.eac, appID, func(spec *core_v1alpha.ConfigSpec) error {
-		var filtered []core_v1alpha.ConfigSpecVariables
-		for _, v := range spec.Variables {
-			if removeKeys[v.Key] && v.Source == "addon" {
-				continue
-			}
-			filtered = append(filtered, v)
-		}
-		spec.Variables = filtered
-		return nil
-	})
-
-	// The app or its active version being gone (or having no active version)
-	// means there is nothing left to clean up — treat as a successful no-op.
-	if errors.Is(err, cond.ErrNotFound{}) || errors.Is(err, errNoActiveVersion) {
-		c.log.Info("app or active version unavailable, skipping env var removal", "app", appID)
-		return nil
-	}
-	return err
-}
-
-// mergeAddonVars merges addon-contributed variables into the existing variable set.
-// Addon vars (source="addon") never override manual vars.
-func mergeAddonVars(existing []core_v1alpha.Variable, addonVars []addon.Variable) []core_v1alpha.Variable {
-	varMap := make(map[string]core_v1alpha.Variable, len(existing))
-
-	for _, v := range existing {
-		varMap[v.Key] = v
-	}
-
-	for _, v := range addonVars {
-		source := ""
-		if ev, ok := varMap[v.Key]; ok {
-			source = ev.Source
-			if source == "" {
-				source = "manual"
-			}
-		}
-
-		// Never override manual vars
-		if source == "manual" {
-			continue
-		}
-
-		varMap[v.Key] = core_v1alpha.Variable{
-			Key:       v.Key,
-			Value:     v.Value,
-			Sensitive: v.Sensitive,
-			Source:    "addon",
-		}
-	}
-
-	result := make([]core_v1alpha.Variable, 0, len(varMap))
-	for _, v := range varMap {
-		result = append(result, v)
-	}
-	return result
 }
 
 // findCollisions returns keys that exist in both existing vars and addon vars.

--- a/controllers/addon/controller_test.go
+++ b/controllers/addon/controller_test.go
@@ -2,6 +2,7 @@ package addon
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"miren.dev/runtime/api/addon/addon_v1alpha"
-	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver"
 	"miren.dev/runtime/pkg/addon"
@@ -69,75 +69,13 @@ func TestFindCollisionsNoOverlap(t *testing.T) {
 	assert.Empty(t, collisions)
 }
 
-func TestMergeAddonVars(t *testing.T) {
-	existing := []core_v1alpha.Variable{
-		{Key: "MANUAL_VAR", Value: "manual_val", Source: "manual"},
-		{Key: "CONFIG_VAR", Value: "config_val", Source: "config"},
-	}
-
-	addonVars := []addon.Variable{
-		{Key: "DATABASE_URL", Value: "postgres://...", Sensitive: true},
-		{Key: "PGHOST", Value: "host.addon.app.miren"},
-		{Key: "MANUAL_VAR", Value: "should_not_override"},
-		{Key: "CONFIG_VAR", Value: "should_override"},
-	}
-
-	result := mergeAddonVars(existing, addonVars)
-
-	varMap := make(map[string]core_v1alpha.Variable, len(result))
-	for _, v := range result {
-		varMap[v.Key] = v
-	}
-
-	// Manual var should NOT be overridden
-	assert.Equal(t, "manual_val", varMap["MANUAL_VAR"].Value)
-	assert.Equal(t, "manual", varMap["MANUAL_VAR"].Source)
-
-	// Config var should be overridden by addon
-	assert.Equal(t, "should_override", varMap["CONFIG_VAR"].Value)
-	assert.Equal(t, "addon", varMap["CONFIG_VAR"].Source)
-
-	// New addon vars should be added
-	assert.Equal(t, "postgres://...", varMap["DATABASE_URL"].Value)
-	assert.True(t, varMap["DATABASE_URL"].Sensitive)
-	assert.Equal(t, "addon", varMap["DATABASE_URL"].Source)
-
-	assert.Equal(t, "host.addon.app.miren", varMap["PGHOST"].Value)
-	assert.Equal(t, "addon", varMap["PGHOST"].Source)
-}
-
-func TestMergeAddonVarsEmptySource(t *testing.T) {
-	// Vars with empty source should be treated as manual (backward compat)
-	existing := []core_v1alpha.Variable{
-		{Key: "DATABASE_URL", Value: "old", Source: ""},
-	}
-
-	addonVars := []addon.Variable{
-		{Key: "DATABASE_URL", Value: "new"},
-	}
-
-	result := mergeAddonVars(existing, addonVars)
-
-	varMap := make(map[string]core_v1alpha.Variable, len(result))
-	for _, v := range result {
-		varMap[v.Key] = v
-	}
-
-	// Empty source treated as manual — should NOT be overridden
-	assert.Equal(t, "old", varMap["DATABASE_URL"].Value)
-}
-
-func TestMergeAddonVarsEmpty(t *testing.T) {
-	result := mergeAddonVars(nil, nil)
-	assert.Empty(t, result)
-}
-
 // testProvider is a configurable mock for testing controller behavior.
 type testProvider struct {
 	localityMode   addon.LocalityMode
 	provisionFn    func(ctx context.Context, app addon.App, variant addon.Variant) (*addon.ProvisionResult, error)
 	deprovisionFn  func(ctx context.Context, assoc addon.AddonAssociation) error
 	deprovisionErr error
+	adjustErr      error
 
 	provisionCalled   bool
 	deprovisionCalled bool
@@ -163,6 +101,9 @@ func (p *testProvider) Provision(ctx context.Context, _ addon.AddonAssociation, 
 }
 
 func (p *testProvider) AdjustEnvVars(ctx context.Context, result *addon.ProvisionResult, assoc addon.AddonAssociation, collisions []string) ([]addon.Variable, error) {
+	if p.adjustErr != nil {
+		return nil, p.adjustErr
+	}
 	return result.EnvVars, nil
 }
 
@@ -266,11 +207,14 @@ func getMeta(ctx context.Context, ec *entityserver.Client, id entity.Id, sc enti
 func TestProvisionCompensatesOnPostProvisionFailure(t *testing.T) {
 	ctx, ctrl, ec, provider := setupControllerTest(t)
 
-	// Create an app entity without an active version — this will cause
-	// createVersionWithAddonVars to fail with "app has no active version",
-	// triggering the compensation path.
-	appID, err := ec.Create(ctx, "myapp", &core_v1alpha.App{})
-	require.NoError(t, err)
+	// The app already sets DATABASE_URL, which is what testProvider contributes,
+	// so completeProvision reaches AdjustEnvVars — a step that runs after
+	// Provision has already created resources, which is what makes compensation
+	// necessary.
+	appID := createAppWithVars(t, ctx, ec, "myapp", []core_v1alpha.Variable{
+		{Key: "DATABASE_URL", Value: "postgres://existing", Source: "manual"},
+	})
+	provider.adjustErr = errors.New("cannot adjust")
 
 	addonID, err := ec.Create(ctx, "miren-postgresql", &addon_v1alpha.Addon{
 		Name: "miren-postgresql",
@@ -402,107 +346,6 @@ func createAppWithVars(t *testing.T, ctx context.Context, ec *entityserver.Clien
 	return appID
 }
 
-// activeVars resolves the variables on an app's current active version, keyed by name.
-func activeVars(t *testing.T, ctx context.Context, ctrl *Controller, appID entity.Id) map[string]core_v1alpha.ConfigSpecVariables {
-	t.Helper()
-
-	var app core_v1alpha.App
-	require.NoError(t, ctrl.ec.GetById(ctx, appID, &app))
-
-	var ver core_v1alpha.AppVersion
-	require.NoError(t, ctrl.ec.GetById(ctx, app.ActiveVersion, &ver))
-
-	spec, err := coreutil.ResolveConfig(ctx, ctrl.eac, &ver)
-	require.NoError(t, err)
-
-	out := make(map[string]core_v1alpha.ConfigSpecVariables, len(spec.Variables))
-	for _, v := range spec.Variables {
-		out[v.Key] = v
-	}
-	return out
-}
-
-// TestUpdateAppActiveVersionRetriesOnConcurrentSwing is the MIR-1458 regression
-// test. Two addon associations for the same app reconcile concurrently and each
-// swings the app's active version. Without optimistic concurrency control the
-// second write clobbers the first, silently dropping one addon's variables.
-//
-// The race is reproduced deterministically without goroutines: a competing addon
-// (memcache) swings the active version exactly once, during our transform's first
-// invocation — i.e. after we captured the app revision but before our own Patch.
-// Our Patch must then conflict, the read-modify-write must retry against the
-// competitor's version, and the final active config must carry BOTH addons' vars.
-func TestUpdateAppActiveVersionRetriesOnConcurrentSwing(t *testing.T) {
-	ctx, ctrl, ec, _ := setupControllerTest(t)
-
-	appID := createAppWithVars(t, ctx, ec, "myapp", []core_v1alpha.Variable{
-		{Key: "BASE", Value: "1", Source: "config"},
-	})
-
-	competed := false
-	err := updateAppActiveVersion(ctx, ctrl.log, ctrl.ec, ctrl.eac, appID, func(spec *core_v1alpha.ConfigSpec) error {
-		if !competed {
-			competed = true
-			// A competing addon (memcache) wins the active-version swing while
-			// we are mid-flight, bumping the app revision under us.
-			require.NoError(t, ctrl.createVersionWithAddonVars(ctx, appID, []addon.Variable{
-				{Key: "MEMCACHE_URL", Value: "memcache://x"},
-			}))
-		}
-		spec.Variables = append(spec.Variables, core_v1alpha.ConfigSpecVariables{
-			Key: "DATABASE_URL", Value: "postgres://y", Sensitive: true, Source: "addon",
-		})
-		return nil
-	})
-	require.NoError(t, err)
-	require.True(t, competed, "the competing swing must have run")
-
-	vars := activeVars(t, ctx, ctrl, appID)
-	assert.Equal(t, "1", vars["BASE"].Value, "base config var must be preserved")
-	assert.Equal(t, "memcache://x", vars["MEMCACHE_URL"].Value,
-		"competing addon's var must survive the retry (would be clobbered without OCC)")
-	assert.Equal(t, "postgres://y", vars["DATABASE_URL"].Value, "our addon's var must be present")
-
-	// The version pair minted on the losing first attempt must have been deleted,
-	// not left to accumulate: base + competitor + final activated = 3 AppVersions.
-	assert.Equal(t, 3, countKind(t, ctx, ec, core_v1alpha.KindAppVersion),
-		"the superseded version from the lost CAS race must be cleaned up")
-}
-
-// countKind returns the number of entities of the given kind in the store.
-func countKind(t *testing.T, ctx context.Context, ec *entityserver.Client, kind entity.Id) int {
-	t.Helper()
-	res, err := ec.List(ctx, entity.Ref(entity.EntityKind, kind))
-	require.NoError(t, err)
-	n := 0
-	for res.Next() {
-		n++
-	}
-	return n
-}
-
-// TestCreateVersionWithAddonVarsComposesSequentially verifies that attaching two
-// addons one after another accumulates both var sets (the non-racing baseline).
-func TestCreateVersionWithAddonVarsComposesSequentially(t *testing.T) {
-	ctx, ctrl, ec, _ := setupControllerTest(t)
-
-	appID := createAppWithVars(t, ctx, ec, "myapp", []core_v1alpha.Variable{
-		{Key: "BASE", Value: "1", Source: "config"},
-	})
-
-	require.NoError(t, ctrl.createVersionWithAddonVars(ctx, appID, []addon.Variable{
-		{Key: "DATABASE_URL", Value: "postgres://y", Sensitive: true},
-	}))
-	require.NoError(t, ctrl.createVersionWithAddonVars(ctx, appID, []addon.Variable{
-		{Key: "MEMCACHE_URL", Value: "memcache://x"},
-	}))
-
-	vars := activeVars(t, ctx, ctrl, appID)
-	assert.Equal(t, "1", vars["BASE"].Value)
-	assert.Equal(t, "postgres://y", vars["DATABASE_URL"].Value)
-	assert.Equal(t, "memcache://x", vars["MEMCACHE_URL"].Value)
-}
-
 func TestDeprovisionCompletesWhenAppDeleted(t *testing.T) {
 	ctx, ctrl, ec, provider := setupControllerTest(t)
 
@@ -525,8 +368,8 @@ func TestDeprovisionCompletesWhenAppDeleted(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Delete the app — removeEnvVars should treat this as a no-op
-	// so that deprovision can complete and the association is cleaned up.
+	// Delete the app. Deprovision no longer touches the app's config at all,
+	// so a missing app is simply not its problem and teardown still completes.
 	require.NoError(t, ec.Delete(ctx, appID))
 
 	var assoc addon_v1alpha.AddonAssociation

--- a/controllers/addon/migrate.go
+++ b/controllers/addon/migrate.go
@@ -1,0 +1,119 @@
+package addon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"miren.dev/runtime/api/addon/addon_v1alpha"
+	coreutil "miren.dev/runtime/api/core"
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/entityserver"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// ReportStaleAssociationVariables warns about associations whose recorded
+// variables disagree with the copy in the app's active version.
+//
+// Rotation used to write the new credential into a new app version and leave the
+// association holding the provision-time value. The runtime now resolves through
+// the association, so one left stale by a rotation on v0.12.x names a password
+// that no longer works.
+//
+// This only reports; it never writes. There is no reliable way to tell which
+// record is fresher: before this design the version was, after it the
+// association is. A sweep that guessed wrong would take a working app offline,
+// and it would guess wrong on every coordinator restart that followed a
+// rotation. Running `miren addon rotate` again reconciles both records.
+//
+// Delete this once v0.12.x and v0.13.x are out of upgrade range. It writes
+// nothing, so there is no data to unwind.
+func ReportStaleAssociationVariables(
+	ctx context.Context,
+	log *slog.Logger,
+	ec *entityserver.Client,
+	eac *entityserver_v1alpha.EntityAccessClient,
+) (stale int, checked int, err error) {
+	results, err := ec.List(ctx, entity.Ref(entity.EntityKind, addon_v1alpha.KindAddonAssociation))
+	if err != nil {
+		return 0, 0, fmt.Errorf("listing addon associations: %w", err)
+	}
+
+	for results.Next() {
+		var assoc addon_v1alpha.AddonAssociation
+		if err := results.Read(&assoc); err != nil {
+			return stale, checked, fmt.Errorf("reading addon association: %w", err)
+		}
+
+		if assoc.Status != "active" || len(assoc.Variables) == 0 {
+			continue
+		}
+		checked++
+
+		live, err := activeVariables(ctx, ec, eac, assoc.App)
+		if err != nil {
+			// One unreadable app must not stop the sweep.
+			log.Warn("could not read active config while checking association variables",
+				"association", assoc.ID, "app", assoc.App, "error", err)
+			continue
+		}
+
+		var disagreeing []string
+		for _, v := range assoc.Variables {
+			if cur, ok := live[v.Key]; ok && cur.Value != v.Value {
+				disagreeing = append(disagreeing, v.Key)
+			}
+		}
+		if len(disagreeing) == 0 {
+			continue
+		}
+
+		stale++
+		// Warn, not Error: nothing has failed, and one command fixes it. Name the
+		// keys but never the values, which are credentials.
+		log.Warn("addon association variables disagree with the app's active config; "+
+			"the app will run with the association's values. If this addon's credentials were "+
+			"rotated before upgrading, re-run `miren addon rotate` to reconcile both records",
+			"association", assoc.ID, "app", assoc.App, "keys", disagreeing)
+	}
+
+	return stale, checked, nil
+}
+
+// activeVariables returns the addon-sourced variables an app's active version
+// currently carries, keyed by name.
+func activeVariables(
+	ctx context.Context,
+	ec *entityserver.Client,
+	eac *entityserver_v1alpha.EntityAccessClient,
+	appID entity.Id,
+) (map[string]core_v1alpha.ConfigSpecVariables, error) {
+	var app core_v1alpha.App
+	if err := ec.GetById(ctx, appID, &app); err != nil {
+		return nil, fmt.Errorf("getting app %s: %w", appID, err)
+	}
+	if app.ActiveVersion == "" {
+		return nil, nil
+	}
+
+	var version core_v1alpha.AppVersion
+	if err := ec.GetById(ctx, app.ActiveVersion, &version); err != nil {
+		return nil, fmt.Errorf("getting app version %s: %w", app.ActiveVersion, err)
+	}
+
+	// The stored config, not the resolved one. The point is to compare against
+	// what the version carries, not against what the association would supply.
+	spec, err := coreutil.ResolveConfig(ctx, eac, &version)
+	if err != nil {
+		return nil, fmt.Errorf("resolving config for %s: %w", app.ActiveVersion, err)
+	}
+
+	out := make(map[string]core_v1alpha.ConfigSpecVariables, len(spec.Variables))
+	for _, v := range spec.Variables {
+		if v.Source == coreutil.SourceAddon {
+			out[v.Key] = v
+		}
+	}
+	return out, nil
+}

--- a/controllers/addon/rotation_controller.go
+++ b/controllers/addon/rotation_controller.go
@@ -128,19 +128,21 @@ func (c *RotationController) rotate(ctx context.Context, req *addon_v1alpha.Rota
 		return c.setError(ctx, req, fmt.Errorf("rotating credential: %w", err))
 	}
 
-	// Propagate to the consuming app by minting a new version so the injected
-	// connection string picks up the new secret. This runs *after* the credential
-	// already changed, so a failure here must stay retryable rather than terminal:
-	// returning an error re-reconciles, and re-running the idempotent rotation
-	// above converges. (The authoritative running value lives in the ConfigVersion
-	// this creates; association.variables are intentionally left as-is.)
+	// Record the new values on the association. That is the whole propagation:
+	// the app resolves its bindings from here, and the launcher's
+	// AddonAssociation watch turns the change into a reconcile that relaunches
+	// the consumer with the new secret. No version is minted.
+	//
+	// This runs after the credential already changed on the engine, so a failure
+	// must stay retryable rather than terminal. Returning an error re-reconciles,
+	// and re-running the idempotent rotation above converges.
 	if len(result.EnvVars) > 0 {
-		if err := createVersionWithVars(ctx, c.log, c.ec, c.eac, assoc.App, result.EnvVars); err != nil {
-			return fmt.Errorf("redeploying consumer (will retry): %w", err)
+		if err := setAssociationVars(ctx, c.eac, req.Association, result.EnvVars); err != nil {
+			return fmt.Errorf("recording rotated variables (will retry): %w", err)
 		}
 	}
 
-	// Done — clear the recorded secret now that it lives in the app config.
+	// Done — clear the recorded secret now that it lives on the association.
 	if err := c.ec.Patch(ctx, req.ID, 0,
 		entity.String(addon_v1alpha.RotationRequestStatusId, "done"),
 		entity.String(addon_v1alpha.RotationRequestNewSecretId, ""),

--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -95,7 +95,7 @@ func (l *Launcher) CreatePoolForVersion(ctx context.Context, ver *core_v1alpha.A
 	app.ID = ver.App
 
 	// Resolve config
-	spec, err := coreutil.ResolveConfig(ctx, l.EAC, ver)
+	spec, err := coreutil.ResolveRuntimeConfig(ctx, l.EAC, ver)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve config for version %s: %w", ver.Version, err)
 	}
@@ -248,7 +248,7 @@ func (l *Launcher) reconcileAppVersion(ctx context.Context, app *core_v1alpha.Ap
 	ver.Decode(verResp.Entity().Entity())
 
 	// Resolve config from ConfigVersion if available, otherwise use inline
-	spec, err := coreutil.ResolveConfig(ctx, l.EAC, &ver)
+	spec, err := coreutil.ResolveRuntimeConfig(ctx, l.EAC, &ver)
 	if err != nil {
 		return fmt.Errorf("failed to resolve config: %w", err)
 	}

--- a/controllers/run/admission.go
+++ b/controllers/run/admission.go
@@ -236,7 +236,7 @@ func (c *Controller) maxConcurrent(ctx context.Context, r *run_v1alpha.Run) (int
 	var ver core_v1alpha.AppVersion
 	ver.Decode(resp.Entity().Entity())
 
-	cfgSpec, err := coreutil.ResolveConfig(ctx, c.EAC, &ver)
+	cfgSpec, err := coreutil.ResolveRuntimeConfig(ctx, c.EAC, &ver)
 	if err != nil {
 		return runapi.MaxConcurrent(nil, r.Task), nil
 	}

--- a/controllers/run/controller.go
+++ b/controllers/run/controller.go
@@ -446,7 +446,7 @@ func (c *Controller) buildSpec(ctx context.Context, r *run_v1alpha.Run) (*comput
 	var ver core_v1alpha.AppVersion
 	ver.Decode(verResp.Entity().Entity())
 
-	cfgSpec, err := coreutil.ResolveConfig(ctx, c.EAC, &ver)
+	cfgSpec, err := coreutil.ResolveRuntimeConfig(ctx, c.EAC, &ver)
 	if err != nil {
 		return nil, "", fmt.Errorf("resolving config: %w", err)
 	}

--- a/controllers/run/scheduler.go
+++ b/controllers/run/scheduler.go
@@ -151,7 +151,7 @@ func (s *Scheduler) sweepApp(ctx context.Context, app *core_v1alpha.App, now tim
 		return fmt.Errorf("reading active version: %w", err)
 	}
 
-	cfgSpec, err := coreutil.ResolveConfig(ctx, s.EAC, &ver)
+	cfgSpec, err := coreutil.ResolveRuntimeConfig(ctx, s.EAC, &ver)
 	if err != nil {
 		return fmt.Errorf("resolving config: %w", err)
 	}

--- a/controllers/sandboxpool/manager.go
+++ b/controllers/sandboxpool/manager.go
@@ -589,7 +589,7 @@ func (m *Manager) checkAllPoolsForScaleDown(ctx context.Context) error {
 		ver.Decode(verResp.Entity().Entity())
 
 		// Resolve config from ConfigVersion if available
-		spec, err := coreutil.ResolveConfig(ctx, m.eac, &ver)
+		spec, err := coreutil.ResolveRuntimeConfig(ctx, m.eac, &ver)
 		if err != nil {
 			m.log.Error("failed to resolve config for pool", "pool", pool.ID, "error", err)
 			continue

--- a/hack/blackbox-groups.json
+++ b/hack/blackbox-groups.json
@@ -57,7 +57,8 @@
         "TestDistributedRunnerList",
         "TestDistributedRunnerLogs",
         "TestDistributedRunnerMetrics",
-        "TestDistributedRunnerNodePort"
+        "TestDistributedRunnerNodePort",
+        "TestAddonEnvSurvivesDeployVersion"
       ]
     }
   ]

--- a/pkg/addon/mysql/rotate.go
+++ b/pkg/addon/mysql/rotate.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"miren.dev/runtime/api/addon/addon_v1alpha"
-	coreutil "miren.dev/runtime/api/core"
-	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/pkg/addon"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/saga"
@@ -54,31 +52,24 @@ func (p *Provider) RotateCredential(ctx context.Context, assoc addon.AddonAssoci
 	}
 }
 
-// activeConfigVar reads a variable's value from an app's active ConfigVersion.
-// This is the authoritative current value; association.variables is deliberately
-// not rewritten on rotation and can hold a stale password.
-func activeConfigVar(ctx context.Context, fw *addon.ProviderFramework, appID entity.Id, key string) (string, error) {
-	var app core_v1alpha.App
-	if err := fw.EC.GetById(ctx, appID, &app); err != nil {
-		return "", fmt.Errorf("getting app %s: %w", appID, err)
-	}
-	if app.ActiveVersion == "" {
-		return "", nil
-	}
-	var version core_v1alpha.AppVersion
-	if err := fw.EC.GetById(ctx, app.ActiveVersion, &version); err != nil {
-		return "", fmt.Errorf("getting app version: %w", err)
-	}
-	spec, err := coreutil.ResolveConfig(ctx, fw.EAC, &version)
-	if err != nil {
-		return "", fmt.Errorf("resolving config: %w", err)
-	}
-	for _, v := range spec.Variables {
+// associationVar reads a variable's value from the addon association's own
+// record of what it supplies.
+//
+// The association is the current record. The rotation controller rewrites it on
+// every rotation, and coreutil.ResolveRuntimeConfig resolves the app's bindings
+// from it. Reading the app's stored ConfigVersion instead finds nothing, because
+// no version records addon variables any more.
+//
+// An association that last rotated before that change can still hold a stale
+// password. ReportStaleAssociationVariables names those at boot; the repair is
+// to rotate again.
+func associationVar(assoc *addon_v1alpha.AddonAssociation, key string) string {
+	for _, v := range assoc.Variables {
 		if v.Key == key {
-			return v.Value, nil
+			return v.Value
 		}
 	}
-	return "", nil
+	return ""
 }
 
 // bestEffortOldUserPassword reads the app's current MYSQL_PASSWORD for use as a
@@ -86,16 +77,10 @@ func activeConfigVar(ctx context.Context, fw *addon.ProviderFramework, appID ent
 // on rollback is a safety net, and the forward rotation (which durably redeploys
 // the app onto the new secret) is authoritative. An empty result just means the
 // rollback ALTER is skipped.
-func bestEffortOldUserPassword(ctx context.Context, fw *addon.ProviderFramework, appID entity.Id) string {
-	if appID == "" {
-		return ""
-	}
-	old, err := activeConfigVar(ctx, fw, appID, "MYSQL_PASSWORD")
-	if err != nil {
-		fw.Log.Warn("could not read current user password for rollback; rollback will skip restore", "app", appID, "error", err)
-		return ""
-	}
-	return old
+func bestEffortOldUserPassword(assoc *addon_v1alpha.AddonAssociation) string {
+	// Read before the rotation controller records the new values, so this is the
+	// password the app is running with.
+	return associationVar(assoc, "MYSQL_PASSWORD")
 }
 
 // --- Shared per-app user rotation (Class A) ---
@@ -109,13 +94,11 @@ type CaptureOldUserPasswordOut struct {
 }
 
 func CaptureOldUserPassword(ctx context.Context, in CaptureOldUserPasswordIn) (CaptureOldUserPasswordOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
 	var assoc addon_v1alpha.AddonAssociation
 	if in.AssocEntity != nil {
 		assoc.Decode(in.AssocEntity)
 	}
-	return CaptureOldUserPasswordOut{UserOldPassword: bestEffortOldUserPassword(ctx, fw, assoc.App)}, nil
+	return CaptureOldUserPasswordOut{UserOldPassword: bestEffortOldUserPassword(&assoc)}, nil
 }
 
 func UndoCaptureOldUserPassword(ctx context.Context, in CaptureOldUserPasswordIn, out CaptureOldUserPasswordOut) error {
@@ -439,8 +422,6 @@ type CaptureDedicatedConnInfoOut struct {
 // existed fall back to the app's active config. The old user password is a
 // best-effort read used only for rollback.
 func CaptureDedicatedConnInfo(ctx context.Context, in CaptureDedicatedConnInfoIn) (CaptureDedicatedConnInfoOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
 	var data addon_v1alpha.MysqlDedicatedData
 	if in.AssocEntity != nil {
 		data.Decode(in.AssocEntity)
@@ -452,39 +433,27 @@ func CaptureDedicatedConnInfo(ctx context.Context, in CaptureDedicatedConnInfoIn
 		assoc.Decode(in.AssocEntity)
 	}
 
-	// Legacy associations predate these attrs; recover conn info from the app's
-	// active config so they stay rotatable.
-	if user == "" || database == "" {
-		if assoc.App == "" {
-			return CaptureDedicatedConnInfoOut{}, fmt.Errorf("association has no stored connection info and no app ref to fall back to")
-		}
-		if user == "" {
-			u, err := activeConfigVar(ctx, fw, assoc.App, "MYSQL_USER")
-			if err != nil {
-				return CaptureDedicatedConnInfoOut{}, fmt.Errorf("reading MYSQL_USER from active config: %w", err)
-			}
-			user = u
-		}
-		if database == "" {
-			d, err := activeConfigVar(ctx, fw, assoc.App, "MYSQL_DATABASE")
-			if err != nil {
-				return CaptureDedicatedConnInfoOut{}, fmt.Errorf("reading MYSQL_DATABASE from active config: %w", err)
-			}
-			database = d
-		}
+	// Legacy associations predate these attrs. Recover conn info from the
+	// variables the association records, which provisioning has written since
+	// before the attrs existed, so they stay rotatable.
+	if user == "" {
+		user = associationVar(&assoc, "MYSQL_USER")
+	}
+	if database == "" {
+		database = associationVar(&assoc, "MYSQL_DATABASE")
 	}
 
 	if user == "" {
-		return CaptureDedicatedConnInfoOut{}, fmt.Errorf("could not determine dedicated mysql user (no stored attr, no MYSQL_USER in active config)")
+		return CaptureDedicatedConnInfoOut{}, fmt.Errorf("could not determine dedicated mysql user (no stored attr, no MYSQL_USER on the association)")
 	}
 	if database == "" {
-		return CaptureDedicatedConnInfoOut{}, fmt.Errorf("could not determine dedicated mysql database (no stored attr, no MYSQL_DATABASE in active config)")
+		return CaptureDedicatedConnInfoOut{}, fmt.Errorf("could not determine dedicated mysql database (no stored attr, no MYSQL_DATABASE on the association)")
 	}
 
 	return CaptureDedicatedConnInfoOut{
 		DedicatedUser:        user,
 		DedicatedDatabase:    database,
-		DedicatedUserOldPass: bestEffortOldUserPassword(ctx, fw, assoc.App),
+		DedicatedUserOldPass: bestEffortOldUserPassword(&assoc),
 	}, nil
 }
 

--- a/pkg/addon/mysql/rotate_integration_test.go
+++ b/pkg/addon/mysql/rotate_integration_test.go
@@ -264,9 +264,9 @@ func TestMySQL_Integration(t *testing.T) {
 	}
 	require.Len(t, legacyServerAttrs, 1, "provision should record the server ref attr")
 
-	// Stand up the app whose active config carries the connection vars. The
-	// fallback reads user/database from here; MYSQL_PASSWORD rides along as the
-	// value a rollback would restore.
+	// Stand up an app so the association has a realistic app ref. The fallback no
+	// longer reads config from here: addon variables are not stored on a version
+	// any more, so it reads the association's own record instead.
 	legacyCvID, err := ec.Create(ctx, idgen.GenNS("config-version"), &core_v1alpha.ConfigVersion{
 		Spec: core_v1alpha.ConfigSpec{
 			Variables: []core_v1alpha.ConfigSpecVariables{
@@ -287,11 +287,19 @@ func TestMySQL_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Build the legacy-shaped association: app ref set, server ref patched on,
-	// username/database attrs absent.
+	// username/database attrs absent, but the contributed variables present.
+	// Provisioning has written association.variables since before those attrs
+	// existed, so an association old enough to be missing them still carries the
+	// variables. That is the shape this fallback exists for.
 	legacyAssocID, err := ec.Create(ctx, idgen.GenNS("addon-assoc"), &addon_v1alpha.AddonAssociation{
 		Variant: "small",
 		Status:  "active",
 		App:     legacyAppID,
+		Variables: []addon_v1alpha.Variables{
+			{Key: "MYSQL_USER", Value: legacyUser},
+			{Key: "MYSQL_DATABASE", Value: legacyDB},
+			{Key: "MYSQL_PASSWORD", Value: legacyOldPass, Sensitive: true},
+		},
 	})
 	require.NoError(t, err)
 	require.NoError(t, ec.Patch(ctx, legacyAssocID, 0, legacyServerAttrs...))
@@ -319,10 +327,10 @@ func TestMySQL_Integration(t *testing.T) {
 		require.NotNil(t, res)
 
 		rotEnv := envMap(res.EnvVars)
-		// (a) The fallback resolved user/database from active config: with the attrs
-		// absent, a correct result env can only have come from the ConfigVersion.
-		assert.Equal(t, legacyUser, rotEnv["MYSQL_USER"], "user should resolve from active config")
-		assert.Equal(t, legacyDB, rotEnv["MYSQL_DATABASE"], "database should resolve from active config")
+		// (a) The fallback resolved user/database from the association: with the
+		// attrs absent, a correct result env can only have come from its variables.
+		assert.Equal(t, legacyUser, rotEnv["MYSQL_USER"], "user should resolve from the association")
+		assert.Equal(t, legacyDB, rotEnv["MYSQL_DATABASE"], "database should resolve from the association")
 		assert.Equal(t, newSecret, rotEnv["MYSQL_PASSWORD"], "result should carry the new password")
 
 		// (b) Wire-level proof: new password authenticates, old is rejected.

--- a/pkg/addon/postgresql/rotate.go
+++ b/pkg/addon/postgresql/rotate.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"miren.dev/runtime/api/addon/addon_v1alpha"
-	coreutil "miren.dev/runtime/api/core"
-	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/pkg/addon"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/saga"
@@ -55,33 +53,24 @@ func (p *Provider) RotateCredential(ctx context.Context, assoc addon.AddonAssoci
 	}
 }
 
-// activeConfigVar reads a variable's value from an app's active ConfigVersion.
-// This is the authoritative current value — unlike association.variables, which
-// is deliberately not rewritten on rotation and can hold a stale password. The
-// per-app compensation uses it so a rollback restores the password the app is
-// actually running with, not an older one.
-func activeConfigVar(ctx context.Context, fw *addon.ProviderFramework, appID entity.Id, key string) (string, error) {
-	var app core_v1alpha.App
-	if err := fw.EC.GetById(ctx, appID, &app); err != nil {
-		return "", fmt.Errorf("getting app %s: %w", appID, err)
-	}
-	if app.ActiveVersion == "" {
-		return "", nil
-	}
-	var version core_v1alpha.AppVersion
-	if err := fw.EC.GetById(ctx, app.ActiveVersion, &version); err != nil {
-		return "", fmt.Errorf("getting app version: %w", err)
-	}
-	spec, err := coreutil.ResolveConfig(ctx, fw.EAC, &version)
-	if err != nil {
-		return "", fmt.Errorf("resolving config: %w", err)
-	}
-	for _, v := range spec.Variables {
+// associationVar reads a variable's value from the addon association's own
+// record of what it supplies.
+//
+// The association is the current record. The rotation controller rewrites it on
+// every rotation, and coreutil.ResolveRuntimeConfig resolves the app's bindings
+// from it. Reading the app's stored ConfigVersion instead finds nothing, because
+// no version records addon variables any more.
+//
+// An association that last rotated before that change can still hold a stale
+// password. ReportStaleAssociationVariables names those at boot; the repair is
+// to rotate again.
+func associationVar(assoc *addon_v1alpha.AddonAssociation, key string) string {
+	for _, v := range assoc.Variables {
 		if v.Key == key {
-			return v.Value, nil
+			return v.Value
 		}
 	}
-	return "", nil
+	return ""
 }
 
 // --- Per-app user rotation (Class A) ---
@@ -95,8 +84,6 @@ type CaptureOldUserPasswordOut struct {
 }
 
 func CaptureOldUserPassword(ctx context.Context, in CaptureOldUserPasswordIn) (CaptureOldUserPasswordOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
 	var assoc addon_v1alpha.AddonAssociation
 	if in.AssocEntity != nil {
 		assoc.Decode(in.AssocEntity)
@@ -105,11 +92,9 @@ func CaptureOldUserPassword(ctx context.Context, in CaptureOldUserPasswordIn) (C
 		return CaptureOldUserPasswordOut{}, fmt.Errorf("association has no app ref")
 	}
 
-	old, err := activeConfigVar(ctx, fw, assoc.App, "PGPASSWORD")
-	if err != nil {
-		return CaptureOldUserPasswordOut{}, fmt.Errorf("reading current user password from active config: %w", err)
-	}
-	return CaptureOldUserPasswordOut{UserOldPassword: old}, nil
+	// Read before the rotation controller records the new values, so this is the
+	// password the app is running with.
+	return CaptureOldUserPasswordOut{UserOldPassword: associationVar(&assoc, "PGPASSWORD")}, nil
 }
 
 func UndoCaptureOldUserPassword(ctx context.Context, in CaptureOldUserPasswordIn, out CaptureOldUserPasswordOut) error {
@@ -432,51 +417,39 @@ type CaptureDedicatedConnInfoOut struct {
 // CaptureDedicatedConnInfo resolves the role name and database to connect to.
 // Provisioning records both on the association attrs (see BuildDedicatedResult),
 // so they read straight off the entity — no dependency on a deployed app.
-// Associations created before those attrs existed fall back to the app's active
-// ConfigVersion, the authoritative record of what the app connects as. The
+// Associations created before those attrs existed fall back to the variables the
+// association itself records, which is where an addon's contribution lives. The
 // password is never read here: the durable current password lives on the server
 // entity (see LoadDedicatedRotationState), which survives even a retry that
 // already redeployed the app onto the new secret.
 func CaptureDedicatedConnInfo(ctx context.Context, in CaptureDedicatedConnInfoIn) (CaptureDedicatedConnInfoOut, error) {
-	fw := saga.Get[*addon.ProviderFramework](ctx)
-
 	var data addon_v1alpha.PostgresqlDedicatedData
 	if in.AssocEntity != nil {
 		data.Decode(in.AssocEntity)
 	}
 	user, database := data.Username, data.DatabaseName
 
-	// Legacy associations predate these attrs; recover conn info from the app's
-	// active config so they stay rotatable.
+	// Legacy associations predate these attrs. Recover conn info from the
+	// variables the association records, which provisioning has written since
+	// before the attrs existed, so they stay rotatable.
 	if user == "" || database == "" {
 		var assoc addon_v1alpha.AddonAssociation
 		if in.AssocEntity != nil {
 			assoc.Decode(in.AssocEntity)
 		}
-		if assoc.App == "" {
-			return CaptureDedicatedConnInfoOut{}, fmt.Errorf("association has no stored connection info and no app ref to fall back to")
-		}
 		if user == "" {
-			u, err := activeConfigVar(ctx, fw, assoc.App, "PGUSER")
-			if err != nil {
-				return CaptureDedicatedConnInfoOut{}, fmt.Errorf("reading PGUSER from active config: %w", err)
-			}
-			user = u
+			user = associationVar(&assoc, "PGUSER")
 		}
 		if database == "" {
-			d, err := activeConfigVar(ctx, fw, assoc.App, "PGDATABASE")
-			if err != nil {
-				return CaptureDedicatedConnInfoOut{}, fmt.Errorf("reading PGDATABASE from active config: %w", err)
-			}
-			database = d
+			database = associationVar(&assoc, "PGDATABASE")
 		}
 	}
 
 	if user == "" {
-		return CaptureDedicatedConnInfoOut{}, fmt.Errorf("could not determine dedicated postgres user (no stored attr, no PGUSER in active config)")
+		return CaptureDedicatedConnInfoOut{}, fmt.Errorf("could not determine dedicated postgres user (no stored attr, no PGUSER on the association)")
 	}
 	if database == "" {
-		return CaptureDedicatedConnInfoOut{}, fmt.Errorf("could not determine dedicated postgres database (no stored attr, no PGDATABASE in active config)")
+		return CaptureDedicatedConnInfoOut{}, fmt.Errorf("could not determine dedicated postgres database (no stored attr, no PGDATABASE on the association)")
 	}
 
 	return CaptureDedicatedConnInfoOut{DedicatedUser: user, DedicatedDatabase: database}, nil

--- a/pkg/addon/postgresql/shared_integration_test.go
+++ b/pkg/addon/postgresql/shared_integration_test.go
@@ -356,9 +356,9 @@ func TestPostgreSQL_Integration(t *testing.T) {
 		}
 		require.Len(t, serverAttrs, 1, "provision should record the server ref attr")
 
-		// Stand up the app whose active config carries the connection vars. The
-		// fallback reads user/database from here; PGPASSWORD rides along as the
-		// value a per-app rollback would restore.
+		// Stand up an app so the association has a realistic app ref. The fallback
+		// no longer reads config from here: addon variables are not stored on a
+		// version any more, so it reads the association's own record instead.
 		cvID, err := ec.Create(ctx, idgen.GenNS("config-version"), &core_v1alpha.ConfigVersion{
 			Spec: core_v1alpha.ConfigSpec{
 				Variables: []core_v1alpha.ConfigSpecVariables{
@@ -379,11 +379,19 @@ func TestPostgreSQL_Integration(t *testing.T) {
 		require.NoError(t, err)
 
 		// Build the legacy-shaped association: app ref set, server ref patched on,
-		// username/database attrs absent.
+		// username/database attrs absent, but the contributed variables present.
+		// Provisioning has written association.variables since before those attrs
+		// existed, so an association old enough to be missing them still carries
+		// the variables. That is the shape this fallback exists for.
 		assocID, err := ec.Create(ctx, idgen.GenNS("addon-assoc"), &addon_v1alpha.AddonAssociation{
 			Variant: "small",
 			Status:  "active",
 			App:     appID,
+			Variables: []addon_v1alpha.Variables{
+				{Key: "PGUSER", Value: user},
+				{Key: "PGDATABASE", Value: database},
+				{Key: "PGPASSWORD", Value: oldPassword, Sensitive: true},
+			},
 		})
 		require.NoError(t, err)
 		require.NoError(t, ec.Patch(ctx, assocID, 0, serverAttrs...))
@@ -422,10 +430,10 @@ func TestPostgreSQL_Integration(t *testing.T) {
 		for _, v := range rotResult.EnvVars {
 			rotEnv[v.Key] = v.Value
 		}
-		// (a) The fallback resolved user/database from active config: with the attrs
-		// absent, a correct result env can only have come from the ConfigVersion.
-		assert.Equal(t, user, rotEnv["PGUSER"], "user should resolve from active config")
-		assert.Equal(t, database, rotEnv["PGDATABASE"], "database should resolve from active config")
+		// (a) The fallback resolved user/database from the association: with the
+		// attrs absent, a correct result env can only have come from its variables.
+		assert.Equal(t, user, rotEnv["PGUSER"], "user should resolve from the association")
+		assert.Equal(t, database, rotEnv["PGDATABASE"], "database should resolve from the association")
 		assert.Equal(t, newSecret, rotEnv["PGPASSWORD"], "result should carry the new password")
 
 		// (b) Wire-level proof: the new password authenticates.

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -180,7 +180,7 @@ func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) 
 			if verEnt, err := r.EC.GetByIdWithEntity(ctx, entity.Id(app.ActiveVersion), &appVer); err == nil {
 				entry.activeVersion = &appVer
 				entry.activeVersionEntity = verEnt
-				if resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer); err == nil {
+				if resolvedCfg, err := coreutil.ResolveRuntimeConfig(ctx, r.EC.EAC(), &appVer); err == nil {
 					specMap[appVer.ID.String()] = resolvedCfg
 				}
 			}
@@ -532,7 +532,7 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 		return fmt.Errorf("app has no active version")
 	}
 
-	spec, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
+	spec, err := coreutil.ResolveRuntimeConfig(ctx, r.EC.EAC(), &appVer)
 	if err != nil {
 		return fmt.Errorf("failed to resolve config: %w", err)
 	}
@@ -817,7 +817,7 @@ func (r *AppInfo) Restart(ctx context.Context, state *app_v1alpha.CrudRestart) e
 			r.Log.Warn("failed to get active version, skipping desired instance restore",
 				"version", appRec.ActiveVersion, "error", err)
 		} else {
-			spec, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &ver)
+			spec, err := coreutil.ResolveRuntimeConfig(ctx, r.EC.EAC(), &ver)
 			if err != nil {
 				r.Log.Warn("failed to resolve config, skipping desired instance restore", "error", err)
 			} else {

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -340,6 +340,9 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 			if err := r.EC.GetById(ctx, appRec.ActiveVersion, &appVer); err != nil {
 				return err
 			}
+			// The stored config, not ResolveRuntimeConfig. This is a write path, and
+			// resolving through the overlay would store live addon bindings in the
+			// ConfigVersion minted below.
 			resolvedCfg, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &appVer)
 			if err != nil {
 				return fmt.Errorf("failed to resolve config: %w", err)
@@ -379,10 +382,20 @@ func (r *AppInfo) SetConfiguration(ctx context.Context, state *app_v1alpha.CrudS
 
 		// Replace the entire env var list with the new one from the client
 		// The client is responsible for sending the complete desired state
+		//
+		// Addon bindings are dropped, not stored. GetConfiguration returns the
+		// runtime view, so a client that round-trips it sends them back here.
+		// Storing them would copy an addon's credentials into a version again, and
+		// they would outlive the addon, because deprovisioning no longer rewrites
+		// stored config. The app still gets its bindings: they are supplied at
+		// resolve time, not read from here.
 		if cfg.HasEnvVars() {
 			spec.Variables = nil
 			for _, ev := range cfg.EnvVars() {
 				source := ev.Source()
+				if source == coreutil.SourceAddon {
+					continue
+				}
 				nv := core_v1alpha.ConfigSpecVariables{
 					Key:         ev.Key(),
 					Value:       ev.Value(),

--- a/servers/app/app_test.go
+++ b/servers/app/app_test.go
@@ -1457,3 +1457,66 @@ func TestSetInitialEnvVarsPreservesTheSecretBackend(t *testing.T) {
 	assert.Equal(t, "cluster", cv.Spec.Variables[0].Backend)
 	assert.Equal(t, "payments/stripe-key@x1A", cv.Spec.Variables[0].Value)
 }
+
+// TestSetConfiguration_DropsAddonBindings covers the GetConfiguration round
+// trip. GetConfiguration returns the runtime view, so a client that reads it,
+// edits one variable and writes the whole set back sends the addon's binding
+// along with everything else. Storing it would copy an addon credential into a
+// version again, and because deprovisioning no longer rewrites stored config,
+// that copy would outlive the addon.
+func TestSetConfiguration_DropsAddonBindings(t *testing.T) {
+	ctx := context.Background()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	ec := entityserver.NewClient(slog.Default(), inmem.EAC)
+	appInfo := &AppInfo{
+		Log:  slog.Default(),
+		EC:   ec,
+		CPU:  &metrics.CPUUsage{},
+		Mem:  &metrics.MemoryUsage{},
+		HTTP: &metrics.HTTPMetrics{},
+	}
+	client := &app_v1alpha.CrudClient{Client: rpc.LocalClient(app_v1alpha.AdaptCrud(appInfo))}
+
+	appName := "addon-roundtrip"
+	appID, err := inmem.Client.Create(ctx, appName, &core_v1alpha.App{})
+	require.NoError(t, err)
+
+	// What a client sends back after reading the runtime view: its own variable
+	// plus the addon's binding, which it never set and does not own.
+	own := &app_v1alpha.NamedValue{}
+	own.SetKey("LOG_LEVEL")
+	own.SetValue("debug")
+	own.SetSource(coreutil.SourceManual)
+
+	binding := &app_v1alpha.NamedValue{}
+	binding.SetKey("DATABASE_URL")
+	binding.SetValue("postgres://from-the-addon")
+	binding.SetSensitive(true)
+	binding.SetSource(coreutil.SourceAddon)
+
+	cfg := &app_v1alpha.Configuration{}
+	cfg.SetEnvVars([]*app_v1alpha.NamedValue{own, binding})
+
+	_, err = client.SetConfiguration(ctx, appName, cfg)
+	require.NoError(t, err)
+
+	var appCheck core_v1alpha.App
+	require.NoError(t, ec.GetById(ctx, appID, &appCheck))
+
+	var ver core_v1alpha.AppVersion
+	require.NoError(t, ec.GetById(ctx, appCheck.ActiveVersion, &ver))
+
+	stored, err := coreutil.ResolveConfig(ctx, ec.EAC(), &ver)
+	require.NoError(t, err)
+
+	keys := make(map[string]string, len(stored.Variables))
+	for _, v := range stored.Variables {
+		keys[v.Key] = v.Value
+	}
+	assert.Equal(t, "debug", keys["LOG_LEVEL"], "the client's own variable must be stored")
+	assert.NotContains(t, keys, "DATABASE_URL",
+		"an addon binding handed back by the client must not be written into a version")
+}

--- a/servers/app/runs.go
+++ b/servers/app/runs.go
@@ -321,7 +321,7 @@ func (r *AppInfo) resolveActiveConfig(ctx context.Context, versionID entity.Id) 
 		return nil, fmt.Errorf("reading active version: %w", err)
 	}
 
-	cfgSpec, err := coreutil.ResolveConfig(ctx, r.EC.EAC(), &ver)
+	cfgSpec, err := coreutil.ResolveRuntimeConfig(ctx, r.EC.EAC(), &ver)
 	if err != nil {
 		return nil, fmt.Errorf("resolving config: %w", err)
 	}

--- a/servers/app/runtime.go
+++ b/servers/app/runtime.go
@@ -182,7 +182,7 @@ func (a *AppInfo) AppInfo(ctx context.Context, state *app_v1alpha.AppStatusAppIn
 			// before the loop so an active version with no pools yet is still
 			// classified correctly (a fixed service reads as starting, not idle).
 			var spec *core_v1alpha.ConfigSpec
-			if resolved, rerr := coreutil.ResolveConfig(ctx, a.EC.EAC(), &appVer); rerr == nil {
+			if resolved, rerr := coreutil.ResolveRuntimeConfig(ctx, a.EC.EAC(), &appVer); rerr == nil {
 				spec = resolved
 			}
 			health := poolHealth{

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -820,6 +820,16 @@ func buildVariablesFromAppConfig(appConfig *appconfig.AppConfig) []core_v1alpha.
 	return variables
 }
 
+// hasAddonSourced reports whether any variable came from an addon.
+func hasAddonSourced(vars []core_v1alpha.ConfigSpecVariables) bool {
+	for _, v := range vars {
+		if v.Source == coreutil.SourceAddon {
+			return true
+		}
+	}
+	return false
+}
+
 // mergeVariablesFromAppConfig merges environment variables from app.toml into existing variables.
 // The merge strategy respects variable sources:
 // - Manual vars (source="manual") always persist and shadow config vars with the same key
@@ -829,9 +839,21 @@ func buildVariablesFromAppConfig(appConfig *appconfig.AppConfig) []core_v1alpha.
 func mergeVariablesFromAppConfig(existingVars []core_v1alpha.ConfigSpecVariables, appConfig *appconfig.AppConfig) []core_v1alpha.ConfigSpecVariables {
 	appConfigVars := buildVariablesFromAppConfig(appConfig)
 
-	// If no app.toml vars, preserve all existing vars
+	// No app.toml vars: keep the existing ones, minus addon bindings, which every
+	// path out of here drops for the reason below. Returned as-is when there is
+	// nothing to drop, so a nil stays nil.
 	if appConfigVars == nil {
-		return existingVars
+		if !hasAddonSourced(existingVars) {
+			return existingVars
+		}
+		kept := make([]core_v1alpha.ConfigSpecVariables, 0, len(existingVars))
+		for _, v := range existingVars {
+			if v.Source == coreutil.SourceAddon {
+				continue
+			}
+			kept = append(kept, v)
+		}
+		return kept
 	}
 
 	// Build a map of app.toml variables for quick lookup
@@ -843,7 +865,13 @@ func mergeVariablesFromAppConfig(existingVars []core_v1alpha.ConfigSpecVariables
 	// Build result by merging
 	varMap := make(map[string]core_v1alpha.ConfigSpecVariables)
 
-	// First, add all existing manual and addon variables - these always persist
+	// Carry operator-set variables forward. They belong to the app, not to any one
+	// build.
+	//
+	// Addon variables are not carried. They live on the AddonAssociation and are
+	// applied when a version is resolved to run. A build that copied one would
+	// store a credential the addon may later rotate or take back, and that copy
+	// would outlive the addon. Versions built from here on contain none.
 	for _, v := range existingVars {
 		// Backward compatibility: preserve unknown-source vars as manual
 		source := v.Source
@@ -851,8 +879,7 @@ func mergeVariablesFromAppConfig(existingVars []core_v1alpha.ConfigSpecVariables
 			source = "manual"
 		}
 
-		// Keep manual and addon vars - they shadow config vars with the same key
-		if source == "manual" || source == "addon" {
+		if source == "manual" {
 			varMap[v.Key] = v
 		}
 		// config vars are only kept if still in app.toml (checked below)

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -1023,7 +1023,10 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "addon vars persist across deploys",
+			// Addon bindings are resolved from the association when a version
+			// runs, so a build must not copy them into the version it stores.
+			// The app still receives them; see ResolveRuntimeConfig.
+			name: "addon vars are not carried into a build",
 			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "DATABASE_URL", Value: "postgres://addon/db", Source: "addon", Sensitive: true},
 				{Key: "PGHOST", Value: "host.addon.app.miren", Source: "addon"},
@@ -1035,13 +1038,14 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 				},
 			},
 			wantVars: []core_v1alpha.ConfigSpecVariables{
-				{Key: "DATABASE_URL", Value: "postgres://addon/db", Source: "addon", Sensitive: true},
-				{Key: "PGHOST", Value: "host.addon.app.miren", Source: "addon"},
 				{Key: "CONFIG_VAR", Value: "new", Source: "config"},
 			},
 		},
 		{
-			name: "addon vars not overridden by config vars",
+			// The stored version keeps the app.toml declaration. The addon's
+			// value still wins at runtime, because ResolveRuntimeConfig lets a
+			// binding displace a config-sourced variable.
+			name: "app.toml declaration is stored where an addon var was dropped",
 			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "DATABASE_URL", Value: "postgres://addon/db", Source: "addon"},
 			},
@@ -1051,18 +1055,17 @@ func TestMergeVariablesFromAppConfig(t *testing.T) {
 				},
 			},
 			wantVars: []core_v1alpha.ConfigSpecVariables{
-				{Key: "DATABASE_URL", Value: "postgres://addon/db", Source: "addon"},
+				{Key: "DATABASE_URL", Value: "postgres://manual/db", Source: "config"},
 			},
 		},
 		{
-			name: "addon vars preserved when app.toml has no env section",
+			name: "operator vars preserved when app.toml has no env section",
 			existingVars: []core_v1alpha.ConfigSpecVariables{
 				{Key: "DATABASE_URL", Value: "postgres://addon/db", Source: "addon"},
 				{Key: "MANUAL_VAR", Value: "val", Source: "manual"},
 			},
 			appConfig: nil,
 			wantVars: []core_v1alpha.ConfigSpecVariables{
-				{Key: "DATABASE_URL", Value: "postgres://addon/db", Source: "addon"},
 				{Key: "MANUAL_VAR", Value: "val", Source: "manual"},
 			},
 		},
@@ -1968,7 +1971,11 @@ func TestMergeVariablesFromAppConfig_MetadataCarried(t *testing.T) {
 		assert.Equal(t, "PostgreSQL connection string", result[0].Description, "should carry Description from config var")
 	})
 
-	t.Run("addon var inherits metadata from config var", func(t *testing.T) {
+	// An addon var is no longer stored at all, so what a build keeps for this key
+	// is the app.toml declaration itself, metadata included. The binding still
+	// shadows it when the version runs, and still inherits that metadata there;
+	// see TestResolveRuntimeConfigOverridesAppTomlDeclaration.
+	t.Run("config metadata survives dropping an addon var", func(t *testing.T) {
 		existingVars := []core_v1alpha.ConfigSpecVariables{
 			{Key: "DATABASE_URL", Value: "postgres://addon/db", Source: "addon"},
 		}
@@ -1980,7 +1987,7 @@ func TestMergeVariablesFromAppConfig_MetadataCarried(t *testing.T) {
 
 		result := mergeVariablesFromAppConfig(existingVars, appConfig)
 		require.Len(t, result, 1)
-		assert.Equal(t, "addon", result[0].Source)
+		assert.Equal(t, "config", result[0].Source)
 		assert.True(t, result[0].Required)
 		assert.Equal(t, "Database URL", result[0].Description)
 	})

--- a/servers/exec/exec.go
+++ b/servers/exec/exec.go
@@ -148,7 +148,7 @@ func (s *Server) Exec(ctx context.Context, req *exec_v1alpha.SandboxExecExec) er
 		v.Decode(res.Entity().Entity())
 
 		// Resolve config from ConfigVersion if available
-		resolvedCfg, err := coreutil.ResolveConfig(ctx, s.EAC, &v)
+		resolvedCfg, err := coreutil.ResolveRuntimeConfig(ctx, s.EAC, &v)
 		if err == nil {
 			s.Log.Debug("found version", "id", verId)
 


### PR DESCRIPTION
This is an alternative to #1055. Same bug, same Linear issue, different layer, and Evan's PR is a correct fix for the model we have today. This one argues the model is the thing to change.

## The diagnosis

An addon's variables are recorded in two places. The `AddonAssociation` holds them, which is where RFD-59 says they live. Provisioning then also copies them into the app's config, by minting a new version.

That copy is the bug. It gets made once and never maintained, so a version built before the addon was attached simply doesn't have it. Activating such a version — which is exactly what `deploy -V` and `app rollback` do — hands the app a config with no `DATABASE_URL`, and nothing puts it back. Rebuilds copy config forward from whatever is active, so they inherit the gap. The addon controller only injects at provision time, so it never re-injects. The only recovery anyone found was destroying the addon, which drops the database.

Every other symptom is the same copy showing up somewhere else: deprovision has to hunt down copies by exact string match to delete them, rotation has to mint a version to update them, and two addons updating copies at once needed a CAS retry loop to keep from clobbering each other.

So instead of teaching one more write path to maintain the copy, this deletes the copy. Bindings are read from the association at resolve time. They follow the app rather than the version, and no version has to have been built with them.

## What that buys

`deploy -V g8W` activates `g8W` — not a version derived from it, `g8W` itself. Rollback stops minting anything. `app restart` on a version without the binding works, which a fix in `DeployVersion` can't reach.

And about 250 lines go away. With nothing maintaining copies, `updateAppActiveVersion`, `createVersionWithVars`, `removeEnvVars` and `mergeAddonVars` have no callers. The MIR-1458 race goes with them: two associations used to concurrently swing `active_version` and clobber each other, and now each writes only its own entity, so there's nothing to race over. That retry loop is gone rather than merely unused.

## The commits

**Sync addon association variables at boot.** Rotation used to write the new credential into a version and leave the association holding the old one. Harmless while nothing read the values, but the next commit makes them load-bearing, so the record has to be made true first. One pass over active associations, bounded by how many addons exist, idempotent. No version history is walked and no ConfigVersion is rewritten. Worth knowing: replacing the variables needs a full-entity `Replace`, because `Patch` and `Update` both *merge* multi-valued attributes and would leave the superseded credential beside the new one. That's most likely why the field was left frozen in the first place.

**Resolve addon bindings from the association at runtime.** The resolver, plus switching the runtime consumers to it. Write paths deliberately stay on `ResolveConfig`, since resolving through the overlay and storing the result would bake the copy straight back in.

**Stop the addon controller from writing app versions.** The deletions. Provisioning, rotation and deprovision each write only the association now. They still propagate: the launcher already watches `AddonAssociation`, and pool identity is keyed on the resolved sandbox spec rather than the version, so a changed environment produces a new pool. Minting a version was only ever the trigger; the config diff always did the work.

**Cover the MIR-1579 recovery path end to end.** Blackbox, run against a real cluster in both directions: it passes here and fails deterministically on trunk.

## Sequencing

The boot sync ships in the same release as the resolver that depends on it, and runs before any controller starts. That ordering is the whole safety argument, so it's worth a look in review.

Rotation has only been out since v0.12.1 with near-zero usage, which is what makes the sync's blast radius small: for any app that never rotated, it's a no-op.

## Left alone

Addon credentials still travel as plaintext values, so they land in the sandbox pool spec and therefore in etcd. RFD-90 already flagged this: it asks whether addons should `Put` into the cluster backend and contribute a reference, so their secrets get the same at-rest protection and versioning as any other secret, and calls the convergence attractive but contract-changing. This PR changes the addon contract anyway, which makes that a shorter step from here than from trunk, but it doesn't attempt it.

Nothing here touches `source`. RFD-90 settled that it is the ownership axis (`config | manual | addon`) rather than RFD-55's storage-backend axis, and this PR uses it exactly that way.

Closes MIR-1579 if we take this route instead of #1055.

