### PR TITLE
Drop test.yml's ref input to close the cache-poisoning alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,15 +61,17 @@ jobs:
         env:
           DISPATCH_REF: ${{ inputs.ref }}
           PUSH_REF: ${{ github.ref_name }}
-          PUSH_CHECKOUT: ${{ github.ref }}
+          PUSH_CHECKOUT: ${{ github.sha }}
         run: |
           set -euo pipefail
 
           if [ -z "$DISPATCH_REF" ]; then
             echo "ref=$PUSH_REF" >> "$GITHUB_OUTPUT"
-            # github.ref is already fully qualified, matching the tag path
-            # below, so neither form can be shadowed by a same-named ref of the
-            # other kind.
+            # The triggering commit itself, so no ref name has to be resolved
+            # and none can be shadowed. It also keeps us on the same commit as
+            # the test suite, which checks out the caller's github.sha: taking
+            # the tip of the branch here instead would package something newer
+            # than what was tested whenever main advances mid-run.
             echo "checkout=$PUSH_CHECKOUT" >> "$GITHUB_OUTPUT"
             echo "cache=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -103,19 +105,19 @@ jobs:
   test:
     # A dispatched rebuild repackages a tag whose source already passed this
     # suite when it was pushed, and the packaging code doing the rebuilding was
-    # tested on main. Running it again here would be the one place a dispatch
-    # executes tag code inside the default branch's cache scope — the whole
-    # suite is `make` and `bun run` against a writable shared cache. Skip it
-    # rather than harden nine cache blocks for a path that adds no signal.
+    # tested on main. It is skipped rather than re-run because the suite has no
+    # way to aim at the tag: it inherits our github context, so on a dispatch it
+    # would test main while we package something else. Skipping also keeps tag
+    # code out of the default branch's cache scope, which is the half that
+    # matters for security, since the suite is `make` and `bun run` against a
+    # writable shared cache.
     #
     # Only the explicit-ref form skips. A dispatch with an empty ref builds the
-    # ref it was dispatched on, so its cache scope is that ref's own and there
-    # is nothing to protect.
+    # ref it was dispatched on, so the suite and the packaging agree and the
+    # cache scope is that ref's own.
     if: github.event_name != 'workflow_dispatch' || inputs.ref == ''
     needs: init
     uses: ./.github/workflows/test.yml
-    with:
-      ref: ${{ needs.init.outputs.sha }}
     secrets: inherit
 
   package:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,10 @@ on:
     types: [opened, synchronize, reopened, labeled]
   merge_group:
   workflow_call:
-    # Called by release.yml for main/tag builds
-    inputs:
-      ref:
-        description: 'Git ref to test'
-        required: false
-        type: string
-        default: ''
+    # Called by release.yml for main/tag builds. No inputs: a called workflow
+    # inherits the caller's github context, so a bare checkout already lands on
+    # the commit that triggered the release, and there is no ref for a caller to
+    # aim somewhere else.
 
 # Cancel in-progress runs when a new run is triggered on the same branch/PR.
 concurrency:
@@ -44,7 +41,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ inputs.ref }}
 
     - name: Set up Bun
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -112,7 +108,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ inputs.ref }}
         # Full history only when we actually diff against a base. Quoted so the
         # false branch survives: 0 is falsy in a GitHub expression, so an
         # unquoted `&& 0 ||` would always fall through to the other side.
@@ -154,7 +149,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ inputs.ref }}
 
     - name: Set test matrix
       id: set-matrix
@@ -194,7 +188,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ inputs.ref }}
 
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -257,7 +250,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ inputs.ref }}
 
     - name: Set blackbox shard matrix
       id: set-matrix
@@ -296,7 +288,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ inputs.ref }}
 
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -379,7 +370,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ inputs.ref }}
 
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -491,7 +481,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ inputs.ref }}
 
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -617,7 +606,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-        ref: ${{ inputs.ref }}
 
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0


### PR DESCRIPTION
🤖 Follow-up to #1060. That PR fixed the real problem, and I want to be clear it wasn't wrong: a dispatched rebuild no longer executes a tag's build scripts while holding a write token for the default branch's cache scope, and release.yml's own jobs no longer write to any shared cache on that path. What it didn't do is close the seven alerts. CodeQL re-analyzed the merge commit and still reported seven.

The reason is that the query is structural rather than value-flow. Its message anchors the source at `test.yml`'s `inputs.ref` and the trigger at `release.yml`'s `workflow_dispatch` keyword, so what it's really asking is whether a reusable workflow checks out an inputs-supplied ref while some caller has a write-capable trigger. It never looks at the value passed and it doesn't evaluate `if:`, so resolving to a sha and skipping the job on the dispatch path were both invisible to it.

Nothing needs that input now. It existed for the rebuild case, which #1060 skips, and release.yml is its only caller. A called workflow inherits the caller's `github` context, so a bare checkout already lands on the commit that triggered the release: main's head on a push to main, the tag's commit on a tag push. For PR events those lines already evaluated to empty. So this deletes the input and the nine `ref:` lines without changing what gets built anywhere.
