### PR TITLE
Warn when local disks alias to one shared per-app store

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -1206,6 +1206,52 @@ func (b *Builder) checkLocalStorageMigration(ctx context.Context, appID entity.I
 	)
 }
 
+// aliasedLocalMountPaths returns the sorted, distinct mount paths of the config's
+// provider="local" disks when 2+ of them exist at different paths. Local storage
+// is keyed per app, so every local disk (across all services, whatever its name
+// or mount_path) resolves to the same per-app host directory. Distinct mount
+// paths then misleadingly imply distinct storage when they are really views onto
+// the same files. Returns nil when there's nothing surprising to report: fewer
+// than two local disks, or several local disks that all share one mount path.
+func aliasedLocalMountPaths(configSpec core_v1alpha.ConfigSpec) []string {
+	seen := make(map[string]struct{})
+	for _, svc := range configSpec.Services {
+		for _, disk := range svc.Disks {
+			if disk.Provider == core_v1alpha.ConfigSpecServicesDisksLOCAL {
+				seen[disk.MountPath] = struct{}{}
+			}
+		}
+	}
+	if len(seen) < 2 {
+		return nil
+	}
+	paths := make([]string, 0, len(seen))
+	for p := range seen {
+		paths = append(paths, p)
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+// checkAliasedLocalDisks warns when the config declares local disks at 2+
+// distinct mount paths, which all alias to the same shared per-app store. Unlike
+// the migration warning this needs no on-disk check — the aliasing is visible in
+// the config alone.
+func (b *Builder) checkAliasedLocalDisks(ctx context.Context, configSpec core_v1alpha.ConfigSpec, status *stream.SendStreamClient[*build_v1alpha.Status]) {
+	paths := aliasedLocalMountPaths(configSpec)
+	if len(paths) == 0 {
+		return
+	}
+
+	b.sendLogStatus(ctx, status, "warn", "Multiple local disks share one per-app store",
+		logField("detail", "These local disks all map to the same per-app directory, so they're views onto "+
+			"the same files and a write to one shows up at the others: "+strings.Join(paths, ", ")+". "+
+			"If you want isolated areas, use subdirectories under a single local disk (like /data/cache and "+
+			"/data/uploads) instead of separate disks."),
+		logField("link", "[Configuring Disks](https://miren.md/disks)"),
+	)
+}
+
 // isSystemEnvVar returns true if the given key is a system-managed env var
 // that should not be injected as a build arg. The whole MIREN_ namespace is
 // reserved (the injected MIREN_RUNTIME_* vars are enumerated in
@@ -1808,6 +1854,7 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 		b.Log.Info("app version updated", "app", name, "version", mrv.Version)
 
 		b.checkLocalStorageMigration(ctx, appRec.ID, configSpec, status)
+		b.checkAliasedLocalDisks(ctx, configSpec, status)
 	}
 
 	// Log the deployment to the app's logs

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -694,8 +694,10 @@ func finalize(ctx context.Context, in finalizeIn) (finalizeOut, error) {
 			// route the migration-warning UX through the sender once
 			// the function grows a StatusSender-shaped overload. Saga
 			// deploys skip that warning until then — accepted as a
-			// temporary regression on the flagged path.
+			// temporary regression on the flagged path. The aliased-disk
+			// warning shares the same channel and the same limitation.
 			b.checkLocalStorageMigration(ctx, entity.Id(in.AppID), spec, nil)
+			b.checkAliasedLocalDisks(ctx, spec, nil)
 		}
 	}
 

--- a/servers/build/build_test.go
+++ b/servers/build/build_test.go
@@ -2581,6 +2581,79 @@ func TestShouldWarnLocalStorageMigration(t *testing.T) {
 	})
 }
 
+// TestAliasedLocalMountPaths covers the detection behind the deploy warning that
+// fires when an app declares local disks at 2+ distinct mount paths, which all
+// alias to the same shared per-app store.
+func TestAliasedLocalMountPaths(t *testing.T) {
+	local := func(name, mountPath string) core_v1alpha.ConfigSpecServicesDisks {
+		return core_v1alpha.ConfigSpecServicesDisks{
+			Name:      name,
+			MountPath: mountPath,
+			Provider:  core_v1alpha.ConfigSpecServicesDisksLOCAL,
+		}
+	}
+	miren := func(name, mountPath string) core_v1alpha.ConfigSpecServicesDisks {
+		return core_v1alpha.ConfigSpecServicesDisks{
+			Name:      name,
+			MountPath: mountPath,
+			Provider:  core_v1alpha.ConfigSpecServicesDisksMIREN,
+		}
+	}
+	svc := func(name string, disks ...core_v1alpha.ConfigSpecServicesDisks) core_v1alpha.ConfigSpecServices {
+		return core_v1alpha.ConfigSpecServices{Name: name, Disks: disks}
+	}
+
+	tests := []struct {
+		name string
+		spec core_v1alpha.ConfigSpec
+		want []string
+	}{
+		{
+			name: "distinct paths in one service",
+			spec: core_v1alpha.ConfigSpec{Services: []core_v1alpha.ConfigSpecServices{
+				svc("web", local("cache", "/cache"), local("data", "/data")),
+			}},
+			want: []string{"/cache", "/data"},
+		},
+		{
+			name: "same path across services is not aliasing",
+			spec: core_v1alpha.ConfigSpec{Services: []core_v1alpha.ConfigSpecServices{
+				svc("web", local("local-data", "/miren/data/local")),
+				svc("worker", local("local-data", "/miren/data/local")),
+			}},
+			want: nil,
+		},
+		{
+			name: "single local disk",
+			spec: core_v1alpha.ConfigSpec{Services: []core_v1alpha.ConfigSpecServices{
+				svc("web", local("data", "/data")),
+			}},
+			want: nil,
+		},
+		{
+			name: "distinct paths spread across services",
+			spec: core_v1alpha.ConfigSpec{Services: []core_v1alpha.ConfigSpecServices{
+				svc("web", local("cache", "/cache")),
+				svc("worker", local("data", "/data")),
+			}},
+			want: []string{"/cache", "/data"},
+		},
+		{
+			name: "miren disks are ignored",
+			spec: core_v1alpha.ConfigSpec{Services: []core_v1alpha.ConfigSpecServices{
+				svc("web", local("data", "/data"), miren("vol", "/vol")),
+			}},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, aliasedLocalMountPaths(tt.spec))
+		})
+	}
+}
+
 func TestValidateDiskConfigsAutoCreate(t *testing.T) {
 	ctx := context.Background()
 	server, cleanup := testutils.NewInMemEntityServer(t)


### PR DESCRIPTION
Local storage keys purely on app ID. Every `provider = "local"` disk an app declares, across all its services and regardless of the disk's `name` or `mount_path`, resolves to the same `data/local/<appID>` directory on the host. So if an app declares two local disks mounted at `/cache` and `/data`, they're two windows onto the same files: a write to one shows up at the other, and nothing in the config hints at it.

That shared store is intentional. Co-located services sharing node-local state through one directory is a coherent model, so this is a legibility gap, not a behavior bug. The [docs already spell it out](https://miren.md/disks), and this closes the other half: a deploy-time note so the aliasing isn't discovered the hard way.

The deployment launcher now checks each app's resolved spec and warns once when it declares local disks at two or more distinct mount paths, naming the paths and pointing at subdirectories under a single disk as the way to get isolation within an app. The trigger is distinct mount paths, not disk count, so the unsurprising cases stay quiet: a single local disk, or several local disks at the same path (which is what the legacy auto-mount injects into sibling services). The note is deduped per app plus mount-path signature, so it fires once per deploy rather than on every reconcile tick, and re-fires if a later deploy introduces a genuinely new collision.

Out of scope, and deliberately so: re-keying named local disks to be independently isolated would strand or break existing apps' data, so that stays a possible future opt-in feature rather than an in-place migration.

Closes MIR-1427