### PR TITLE
Add maintenance mode for HTTP routes

### DIFF
--- a/api/app/app_v1alpha/rpc.gen.go
+++ b/api/app/app_v1alpha/rpc.gen.go
@@ -588,16 +588,17 @@ func (v *VersionInfo) UnmarshalJSON(data []byte) error {
 }
 
 type appInfoData struct {
-	Name             *string             `cbor:"0,keyasint,omitempty" json:"name,omitempty"`
-	CreatedAt        *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"created_at,omitempty"`
-	CurrentVersion   *VersionInfo        `cbor:"2,keyasint,omitempty" json:"current_version,omitempty"`
-	Health           *string             `cbor:"3,keyasint,omitempty" json:"health,omitempty"`
-	ReadyInstances   *int32              `cbor:"4,keyasint,omitempty" json:"ready_instances,omitempty"`
-	DesiredInstances *int32              `cbor:"5,keyasint,omitempty" json:"desired_instances,omitempty"`
-	ScalingMode      *string             `cbor:"6,keyasint,omitempty" json:"scaling_mode,omitempty"`
-	Routes           *[]string           `cbor:"7,keyasint,omitempty" json:"routes,omitempty"`
-	CrashCount       *int64              `cbor:"8,keyasint,omitempty" json:"crash_count,omitempty"`
-	CooldownSeconds  *int32              `cbor:"9,keyasint,omitempty" json:"cooldown_seconds,omitempty"`
+	Name              *string             `cbor:"0,keyasint,omitempty" json:"name,omitempty"`
+	CreatedAt         *standard.Timestamp `cbor:"1,keyasint,omitempty" json:"created_at,omitempty"`
+	CurrentVersion    *VersionInfo        `cbor:"2,keyasint,omitempty" json:"current_version,omitempty"`
+	Health            *string             `cbor:"3,keyasint,omitempty" json:"health,omitempty"`
+	ReadyInstances    *int32              `cbor:"4,keyasint,omitempty" json:"ready_instances,omitempty"`
+	DesiredInstances  *int32              `cbor:"5,keyasint,omitempty" json:"desired_instances,omitempty"`
+	ScalingMode       *string             `cbor:"6,keyasint,omitempty" json:"scaling_mode,omitempty"`
+	Routes            *[]string           `cbor:"7,keyasint,omitempty" json:"routes,omitempty"`
+	CrashCount        *int64              `cbor:"8,keyasint,omitempty" json:"crash_count,omitempty"`
+	CooldownSeconds   *int32              `cbor:"9,keyasint,omitempty" json:"cooldown_seconds,omitempty"`
+	MaintenanceRoutes *[]string           `cbor:"10,keyasint,omitempty" json:"maintenance_routes,omitempty"`
 }
 
 type AppInfo struct {
@@ -747,6 +748,22 @@ func (v *AppInfo) CooldownSeconds() int32 {
 
 func (v *AppInfo) SetCooldownSeconds(cooldown_seconds int32) {
 	v.data.CooldownSeconds = &cooldown_seconds
+}
+
+func (v *AppInfo) HasMaintenanceRoutes() bool {
+	return v.data.MaintenanceRoutes != nil
+}
+
+func (v *AppInfo) MaintenanceRoutes() []string {
+	if v.data.MaintenanceRoutes == nil {
+		return nil
+	}
+	return *v.data.MaintenanceRoutes
+}
+
+func (v *AppInfo) SetMaintenanceRoutes(maintenance_routes []string) {
+	x := slices.Clone(maintenance_routes)
+	v.data.MaintenanceRoutes = &x
 }
 
 func (v *AppInfo) MarshalCBOR() ([]byte, error) {
@@ -1379,6 +1396,7 @@ type applicationStatusData struct {
 	CooldownSeconds   *int32              `cbor:"18,keyasint,omitempty" json:"cooldown_seconds,omitempty"`
 	BoundPorts        *[]*BoundPort       `cbor:"19,keyasint,omitempty" json:"bound_ports,omitempty"`
 	WorkloadRole      *string             `cbor:"20,keyasint,omitempty" json:"workload_role,omitempty"`
+	MaintenanceRoutes *[]string           `cbor:"21,keyasint,omitempty" json:"maintenance_routes,omitempty"`
 }
 
 type ApplicationStatus struct {
@@ -1703,6 +1721,22 @@ func (v *ApplicationStatus) WorkloadRole() string {
 
 func (v *ApplicationStatus) SetWorkloadRole(workloadRole string) {
 	v.data.WorkloadRole = &workloadRole
+}
+
+func (v *ApplicationStatus) HasMaintenanceRoutes() bool {
+	return v.data.MaintenanceRoutes != nil
+}
+
+func (v *ApplicationStatus) MaintenanceRoutes() []string {
+	if v.data.MaintenanceRoutes == nil {
+		return nil
+	}
+	return *v.data.MaintenanceRoutes
+}
+
+func (v *ApplicationStatus) SetMaintenanceRoutes(maintenanceRoutes []string) {
+	x := slices.Clone(maintenanceRoutes)
+	v.data.MaintenanceRoutes = &x
 }
 
 func (v *ApplicationStatus) MarshalCBOR() ([]byte, error) {
@@ -2455,10 +2489,11 @@ func (v *CrudGetConfigurationArgs) UnmarshalJSON(data []byte) error {
 }
 
 type crudGetConfigurationResultsData struct {
-	Configuration  *Configuration `cbor:"0,keyasint,omitempty" json:"configuration,omitempty"`
-	VersionId      *string        `cbor:"1,keyasint,omitempty" json:"versionId,omitempty"`
-	VersionShortId *string        `cbor:"2,keyasint,omitempty" json:"versionShortId,omitempty"`
-	WorkloadRole   *string        `cbor:"3,keyasint,omitempty" json:"workloadRole,omitempty"`
+	Configuration     *Configuration `cbor:"0,keyasint,omitempty" json:"configuration,omitempty"`
+	VersionId         *string        `cbor:"1,keyasint,omitempty" json:"versionId,omitempty"`
+	VersionShortId    *string        `cbor:"2,keyasint,omitempty" json:"versionShortId,omitempty"`
+	WorkloadRole      *string        `cbor:"3,keyasint,omitempty" json:"workloadRole,omitempty"`
+	MaintenanceRoutes *[]string      `cbor:"4,keyasint,omitempty" json:"maintenanceRoutes,omitempty"`
 }
 
 type CrudGetConfigurationResults struct {
@@ -2480,6 +2515,11 @@ func (v *CrudGetConfigurationResults) SetVersionShortId(versionShortId string) {
 
 func (v *CrudGetConfigurationResults) SetWorkloadRole(workloadRole string) {
 	v.data.WorkloadRole = &workloadRole
+}
+
+func (v *CrudGetConfigurationResults) SetMaintenanceRoutes(maintenanceRoutes []string) {
+	x := slices.Clone(maintenanceRoutes)
+	v.data.MaintenanceRoutes = &x
 }
 
 func (v *CrudGetConfigurationResults) MarshalCBOR() ([]byte, error) {
@@ -3941,6 +3981,17 @@ func (v *CrudClientGetConfigurationResults) WorkloadRole() string {
 		return ""
 	}
 	return *v.data.WorkloadRole
+}
+
+func (v *CrudClientGetConfigurationResults) HasMaintenanceRoutes() bool {
+	return v.data.MaintenanceRoutes != nil
+}
+
+func (v *CrudClientGetConfigurationResults) MaintenanceRoutes() []string {
+	if v.data.MaintenanceRoutes == nil {
+		return nil
+	}
+	return *v.data.MaintenanceRoutes
 }
 
 func (v CrudClient) GetConfiguration(ctx context.Context, app string) (*CrudClientGetConfigurationResults, error) {

--- a/api/app/rpc.yml
+++ b/api/app/rpc.yml
@@ -155,6 +155,11 @@ types:
       - name: cooldown_seconds
         type: int32
         index: 9
+      - name: maintenance_routes
+        type: list
+        element: string
+        index: 10
+        doc: "Hostnames of this app's routes currently in maintenance. The default route appears as an empty string."
 
   - type: CpuUsage
     fields:
@@ -357,6 +362,11 @@ types:
         type: string
         index: 20
         doc: "The role the app's sandbox identity tokens authenticate as (empty means the default, app-readonly)"
+      - name: maintenanceRoutes
+        type: list
+        element: string
+        index: 21
+        doc: "Hostnames of this app's routes currently in maintenance, serving a holding page instead of the app. The default route appears as an empty string."
 
   - type: LogEntry
     fields:
@@ -506,6 +516,10 @@ interfaces:
           - name: workloadRole
             type: string
             doc: "The app's workload identity role (empty means the default, app-readonly)"
+          - name: maintenanceRoutes
+            type: list
+            element: string
+            doc: "Hostnames of this app's routes currently in maintenance, serving a holding page instead of the app. The default route appears as an empty string."
       - name: setHost
         http:
           put: /apps/{app}/host

--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -373,8 +373,31 @@ func (c *Client) DetachAuthProviderFromRoute(ctx context.Context, route *ingress
 
 // SetRouteMaintenance puts a route into maintenance. The router serves a
 // holding page for the route until the state is cleared.
-func (c *Client) SetRouteMaintenance(ctx context.Context, route *ingress_v1alpha.HttpRoute, m ingress_v1alpha.Maintenance) (*ingress_v1alpha.HttpRoute, error) {
+//
+// reason and backAt always take effect. startedAt and startedBy are a proposal:
+// they are recorded only if the route is not already in maintenance, so
+// revising the reason mid-window leaves the original opener and start time
+// alone.
+//
+// That decision happens here, inside the read-modify-write, rather than in the
+// caller. A caller deciding it from its own earlier read can be wrong by the
+// time the write lands: two operators opening a window at once would both see
+// "not in maintenance", and the second write would replace the first operator's
+// stamp with its own.
+func (c *Client) SetRouteMaintenance(ctx context.Context, route *ingress_v1alpha.HttpRoute, reason, backAt, startedAt, startedBy string) (*ingress_v1alpha.HttpRoute, error) {
 	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
+		m := ingress_v1alpha.Maintenance{
+			Reason:    reason,
+			BackAt:    backAt,
+			StartedAt: startedAt,
+			StartedBy: startedBy,
+		}
+
+		if !r.Maintenance.Empty() {
+			m.StartedAt = r.Maintenance.StartedAt
+			m.StartedBy = r.Maintenance.StartedBy
+		}
+
 		r.Maintenance = m
 	})
 }

--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -371,6 +371,23 @@ func (c *Client) DetachAuthProviderFromRoute(ctx context.Context, route *ingress
 	})
 }
 
+// SetRouteMaintenance puts a route into maintenance. The router serves a
+// holding page for the route until the state is cleared.
+func (c *Client) SetRouteMaintenance(ctx context.Context, route *ingress_v1alpha.HttpRoute, m ingress_v1alpha.Maintenance) (*ingress_v1alpha.HttpRoute, error) {
+	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
+		r.Maintenance = m
+	})
+}
+
+// ClearRouteMaintenance returns a route to normal serving. The whole component
+// is dropped, so the reason and operator recorded on entry don't linger on a
+// route that's serving again.
+func (c *Client) ClearRouteMaintenance(ctx context.Context, route *ingress_v1alpha.HttpRoute) (*ingress_v1alpha.HttpRoute, error) {
+	return c.mutateAndReplaceRoute(ctx, route.EntityId(), func(r *ingress_v1alpha.HttpRoute) {
+		r.Maintenance = ingress_v1alpha.Maintenance{}
+	})
+}
+
 // mutateAndReplaceRoute performs a read-modify-write on a route entity.
 // It fetches the latest version from the store, applies the mutate function,
 // and replaces the entity at the current revision. This avoids overwriting

--- a/api/ingress/ingress.go
+++ b/api/ingress/ingress.go
@@ -1,3 +1,4 @@
 package ingress
 
 //go:generate go run ../../pkg/entity/cmd/schemagen -input schema.yml -output ingress_v1alpha/schema.gen.go -pkg ingress_v1alpha
+//go:generate go run ../../pkg/rpc/cmd/rpcgen -pkg ingress_v1alpha -input rpc.yml -output ingress_v1alpha/rpc.gen.go

--- a/api/ingress/ingress_v1alpha/rpc.gen.go
+++ b/api/ingress/ingress_v1alpha/rpc.gen.go
@@ -1,0 +1,443 @@
+package ingress_v1alpha
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/fxamacker/cbor/v2"
+	rpc "miren.dev/runtime/pkg/rpc"
+)
+
+type routesSetMaintenanceArgsData struct {
+	Host         *string `cbor:"0,keyasint,omitempty" json:"host,omitempty"`
+	DefaultRoute *bool   `cbor:"1,keyasint,omitempty" json:"default_route,omitempty"`
+	Reason       *string `cbor:"2,keyasint,omitempty" json:"reason,omitempty"`
+	BackAt       *string `cbor:"3,keyasint,omitempty" json:"back_at,omitempty"`
+}
+
+type RoutesSetMaintenanceArgs struct {
+	call rpc.Call
+	data routesSetMaintenanceArgsData
+}
+
+func (v *RoutesSetMaintenanceArgs) HasHost() bool {
+	return v.data.Host != nil
+}
+
+func (v *RoutesSetMaintenanceArgs) Host() string {
+	if v.data.Host == nil {
+		return ""
+	}
+	return *v.data.Host
+}
+
+func (v *RoutesSetMaintenanceArgs) HasDefaultRoute() bool {
+	return v.data.DefaultRoute != nil
+}
+
+func (v *RoutesSetMaintenanceArgs) DefaultRoute() bool {
+	if v.data.DefaultRoute == nil {
+		return false
+	}
+	return *v.data.DefaultRoute
+}
+
+func (v *RoutesSetMaintenanceArgs) HasReason() bool {
+	return v.data.Reason != nil
+}
+
+func (v *RoutesSetMaintenanceArgs) Reason() string {
+	if v.data.Reason == nil {
+		return ""
+	}
+	return *v.data.Reason
+}
+
+func (v *RoutesSetMaintenanceArgs) HasBackAt() bool {
+	return v.data.BackAt != nil
+}
+
+func (v *RoutesSetMaintenanceArgs) BackAt() string {
+	if v.data.BackAt == nil {
+		return ""
+	}
+	return *v.data.BackAt
+}
+
+func (v *RoutesSetMaintenanceArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *RoutesSetMaintenanceArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *RoutesSetMaintenanceArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *RoutesSetMaintenanceArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type routesSetMaintenanceResultsData struct {
+	Route     *string `cbor:"0,keyasint,omitempty" json:"route,omitempty"`
+	Reason    *string `cbor:"1,keyasint,omitempty" json:"reason,omitempty"`
+	BackAt    *string `cbor:"2,keyasint,omitempty" json:"back_at,omitempty"`
+	StartedAt *string `cbor:"3,keyasint,omitempty" json:"started_at,omitempty"`
+	StartedBy *string `cbor:"4,keyasint,omitempty" json:"started_by,omitempty"`
+}
+
+type RoutesSetMaintenanceResults struct {
+	call rpc.Call
+	data routesSetMaintenanceResultsData
+}
+
+func (v *RoutesSetMaintenanceResults) SetRoute(route string) {
+	v.data.Route = &route
+}
+
+func (v *RoutesSetMaintenanceResults) SetReason(reason string) {
+	v.data.Reason = &reason
+}
+
+func (v *RoutesSetMaintenanceResults) SetBackAt(back_at string) {
+	v.data.BackAt = &back_at
+}
+
+func (v *RoutesSetMaintenanceResults) SetStartedAt(started_at string) {
+	v.data.StartedAt = &started_at
+}
+
+func (v *RoutesSetMaintenanceResults) SetStartedBy(started_by string) {
+	v.data.StartedBy = &started_by
+}
+
+func (v *RoutesSetMaintenanceResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *RoutesSetMaintenanceResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *RoutesSetMaintenanceResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *RoutesSetMaintenanceResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type routesClearMaintenanceArgsData struct {
+	Host         *string `cbor:"0,keyasint,omitempty" json:"host,omitempty"`
+	DefaultRoute *bool   `cbor:"1,keyasint,omitempty" json:"default_route,omitempty"`
+}
+
+type RoutesClearMaintenanceArgs struct {
+	call rpc.Call
+	data routesClearMaintenanceArgsData
+}
+
+func (v *RoutesClearMaintenanceArgs) HasHost() bool {
+	return v.data.Host != nil
+}
+
+func (v *RoutesClearMaintenanceArgs) Host() string {
+	if v.data.Host == nil {
+		return ""
+	}
+	return *v.data.Host
+}
+
+func (v *RoutesClearMaintenanceArgs) HasDefaultRoute() bool {
+	return v.data.DefaultRoute != nil
+}
+
+func (v *RoutesClearMaintenanceArgs) DefaultRoute() bool {
+	if v.data.DefaultRoute == nil {
+		return false
+	}
+	return *v.data.DefaultRoute
+}
+
+func (v *RoutesClearMaintenanceArgs) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *RoutesClearMaintenanceArgs) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *RoutesClearMaintenanceArgs) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *RoutesClearMaintenanceArgs) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type routesClearMaintenanceResultsData struct {
+	Route   *string `cbor:"0,keyasint,omitempty" json:"route,omitempty"`
+	Changed *bool   `cbor:"1,keyasint,omitempty" json:"changed,omitempty"`
+}
+
+type RoutesClearMaintenanceResults struct {
+	call rpc.Call
+	data routesClearMaintenanceResultsData
+}
+
+func (v *RoutesClearMaintenanceResults) SetRoute(route string) {
+	v.data.Route = &route
+}
+
+func (v *RoutesClearMaintenanceResults) SetChanged(changed bool) {
+	v.data.Changed = &changed
+}
+
+func (v *RoutesClearMaintenanceResults) MarshalCBOR() ([]byte, error) {
+	return cbor.Marshal(v.data)
+}
+
+func (v *RoutesClearMaintenanceResults) UnmarshalCBOR(data []byte) error {
+	return cbor.Unmarshal(data, &v.data)
+}
+
+func (v *RoutesClearMaintenanceResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.data)
+}
+
+func (v *RoutesClearMaintenanceResults) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &v.data)
+}
+
+type RoutesSetMaintenance struct {
+	rpc.Call
+	args    RoutesSetMaintenanceArgs
+	results RoutesSetMaintenanceResults
+}
+
+func (t *RoutesSetMaintenance) Args() *RoutesSetMaintenanceArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *RoutesSetMaintenance) Results() *RoutesSetMaintenanceResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type RoutesClearMaintenance struct {
+	rpc.Call
+	args    RoutesClearMaintenanceArgs
+	results RoutesClearMaintenanceResults
+}
+
+func (t *RoutesClearMaintenance) Args() *RoutesClearMaintenanceArgs {
+	args := &t.args
+	if args.call != nil {
+		return args
+	}
+	args.call = t.Call
+	t.Call.Args(args)
+	return args
+}
+
+func (t *RoutesClearMaintenance) Results() *RoutesClearMaintenanceResults {
+	results := &t.results
+	if results.call != nil {
+		return results
+	}
+	results.call = t.Call
+	t.Call.Results(results)
+	return results
+}
+
+type Routes interface {
+	SetMaintenance(ctx context.Context, state *RoutesSetMaintenance) error
+	ClearMaintenance(ctx context.Context, state *RoutesClearMaintenance) error
+}
+
+type reexportRoutes struct {
+	client rpc.Client
+}
+
+func (reexportRoutes) SetMaintenance(ctx context.Context, state *RoutesSetMaintenance) error {
+	panic("not implemented")
+}
+
+func (reexportRoutes) ClearMaintenance(ctx context.Context, state *RoutesClearMaintenance) error {
+	panic("not implemented")
+}
+
+func (t reexportRoutes) CapabilityClient() rpc.Client {
+	return t.client
+}
+
+func AdaptRoutes(t Routes) *rpc.Interface {
+	methods := []rpc.Method{
+		{
+			Name:          "setMaintenance",
+			InterfaceName: "Routes",
+			Index:         0,
+			Public:        false,
+			Params:        []string{"host", "default_route", "reason", "back_at"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.SetMaintenance(ctx, &RoutesSetMaintenance{Call: call})
+			},
+		},
+		{
+			Name:          "clearMaintenance",
+			InterfaceName: "Routes",
+			Index:         1,
+			Public:        false,
+			Params:        []string{"host", "default_route"},
+			Handler: func(ctx context.Context, call rpc.Call) error {
+				return t.ClearMaintenance(ctx, &RoutesClearMaintenance{Call: call})
+			},
+		},
+	}
+
+	return rpc.NewInterface(methods, t)
+}
+
+type RoutesClient struct {
+	rpc.Client
+}
+
+func NewRoutesClient(client rpc.Client) *RoutesClient {
+	return &RoutesClient{Client: client}
+}
+
+func (c RoutesClient) Export() Routes {
+	return reexportRoutes{client: c.Client}
+}
+
+type RoutesClientSetMaintenanceResults struct {
+	client rpc.Client
+	data   routesSetMaintenanceResultsData
+}
+
+func (v *RoutesClientSetMaintenanceResults) HasRoute() bool {
+	return v.data.Route != nil
+}
+
+func (v *RoutesClientSetMaintenanceResults) Route() string {
+	if v.data.Route == nil {
+		return ""
+	}
+	return *v.data.Route
+}
+
+func (v *RoutesClientSetMaintenanceResults) HasReason() bool {
+	return v.data.Reason != nil
+}
+
+func (v *RoutesClientSetMaintenanceResults) Reason() string {
+	if v.data.Reason == nil {
+		return ""
+	}
+	return *v.data.Reason
+}
+
+func (v *RoutesClientSetMaintenanceResults) HasBackAt() bool {
+	return v.data.BackAt != nil
+}
+
+func (v *RoutesClientSetMaintenanceResults) BackAt() string {
+	if v.data.BackAt == nil {
+		return ""
+	}
+	return *v.data.BackAt
+}
+
+func (v *RoutesClientSetMaintenanceResults) HasStartedAt() bool {
+	return v.data.StartedAt != nil
+}
+
+func (v *RoutesClientSetMaintenanceResults) StartedAt() string {
+	if v.data.StartedAt == nil {
+		return ""
+	}
+	return *v.data.StartedAt
+}
+
+func (v *RoutesClientSetMaintenanceResults) HasStartedBy() bool {
+	return v.data.StartedBy != nil
+}
+
+func (v *RoutesClientSetMaintenanceResults) StartedBy() string {
+	if v.data.StartedBy == nil {
+		return ""
+	}
+	return *v.data.StartedBy
+}
+
+func (v RoutesClient) SetMaintenance(ctx context.Context, host string, default_route bool, reason string, back_at string) (*RoutesClientSetMaintenanceResults, error) {
+	args := RoutesSetMaintenanceArgs{}
+	args.data.Host = &host
+	args.data.DefaultRoute = &default_route
+	args.data.Reason = &reason
+	args.data.BackAt = &back_at
+
+	var ret routesSetMaintenanceResultsData
+
+	err := v.Call(ctx, "setMaintenance", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RoutesClientSetMaintenanceResults{client: v.Client, data: ret}, nil
+}
+
+type RoutesClientClearMaintenanceResults struct {
+	client rpc.Client
+	data   routesClearMaintenanceResultsData
+}
+
+func (v *RoutesClientClearMaintenanceResults) HasRoute() bool {
+	return v.data.Route != nil
+}
+
+func (v *RoutesClientClearMaintenanceResults) Route() string {
+	if v.data.Route == nil {
+		return ""
+	}
+	return *v.data.Route
+}
+
+func (v *RoutesClientClearMaintenanceResults) HasChanged() bool {
+	return v.data.Changed != nil
+}
+
+func (v *RoutesClientClearMaintenanceResults) Changed() bool {
+	if v.data.Changed == nil {
+		return false
+	}
+	return *v.data.Changed
+}
+
+func (v RoutesClient) ClearMaintenance(ctx context.Context, host string, default_route bool) (*RoutesClientClearMaintenanceResults, error) {
+	args := RoutesClearMaintenanceArgs{}
+	args.data.Host = &host
+	args.data.DefaultRoute = &default_route
+
+	var ret routesClearMaintenanceResultsData
+
+	err := v.Call(ctx, "clearMaintenance", &args, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RoutesClientClearMaintenanceResults{client: v.Client, data: ret}, nil
+}

--- a/api/ingress/ingress_v1alpha/schema.gen.go
+++ b/api/ingress/ingress_v1alpha/schema.gen.go
@@ -11,6 +11,7 @@ const (
 	HttpRouteClaimMappingsId  = entity.Id("dev.miren.ingress/http_route.claim_mappings")
 	HttpRouteDefaultId        = entity.Id("dev.miren.ingress/http_route.default")
 	HttpRouteHostId           = entity.Id("dev.miren.ingress/http_route.host")
+	HttpRouteMaintenanceId    = entity.Id("dev.miren.ingress/http_route.maintenance")
 	HttpRouteRequestTimeoutId = entity.Id("dev.miren.ingress/http_route.request_timeout")
 	HttpRouteWafProfileId     = entity.Id("dev.miren.ingress/http_route.waf_profile")
 )
@@ -22,6 +23,7 @@ type HttpRoute struct {
 	ClaimMappings  []ClaimMappings `cbor:"claim_mappings,omitempty" json:"claim_mappings,omitempty"`
 	Default        bool            `cbor:"default,omitempty" json:"default,omitempty"`
 	Host           string          `cbor:"host,omitempty" json:"host,omitempty"`
+	Maintenance    Maintenance     `cbor:"maintenance,omitempty" json:"maintenance"`
 	RequestTimeout string          `cbor:"request_timeout,omitempty" json:"request_timeout,omitempty"`
 	WafProfile     entity.Id       `cbor:"waf_profile,omitempty" json:"waf_profile,omitempty"`
 }
@@ -46,6 +48,9 @@ func (o *HttpRoute) Decode(e entity.AttrGetter) {
 	}
 	if a, ok := e.Get(HttpRouteHostId); ok && a.Value.Kind() == entity.KindString {
 		o.Host = a.Value.String()
+	}
+	if a, ok := e.Get(HttpRouteMaintenanceId); ok && a.Value.Kind() == entity.KindComponent {
+		o.Maintenance.Decode(a.Value.Component())
 	}
 	if a, ok := e.Get(HttpRouteRequestTimeoutId); ok && a.Value.Kind() == entity.KindString {
 		o.RequestTimeout = a.Value.String()
@@ -85,6 +90,9 @@ func (o *HttpRoute) Encode() (attrs []entity.Attr) {
 	if !entity.Empty(o.Host) {
 		attrs = append(attrs, entity.String(HttpRouteHostId, o.Host))
 	}
+	if !o.Maintenance.Empty() {
+		attrs = append(attrs, entity.Component(HttpRouteMaintenanceId, o.Maintenance.Encode()))
+	}
 	if !entity.Empty(o.RequestTimeout) {
 		attrs = append(attrs, entity.String(HttpRouteRequestTimeoutId, o.RequestTimeout))
 	}
@@ -111,6 +119,9 @@ func (o *HttpRoute) Empty() bool {
 	if !entity.Empty(o.Host) {
 		return false
 	}
+	if !o.Maintenance.Empty() {
+		return false
+	}
 	if !entity.Empty(o.RequestTimeout) {
 		return false
 	}
@@ -127,6 +138,8 @@ func (o *HttpRoute) InitSchema(sb *schema.SchemaBuilder) {
 	(&ClaimMappings{}).InitSchema(sb.Builder("http_route.claim_mappings"))
 	sb.Bool("default", "dev.miren.ingress/http_route.default", schema.Doc("Whether this is the default route for routing"), schema.Indexed)
 	sb.String("host", "dev.miren.ingress/http_route.host", schema.Doc("The hostname to match on for the application"), schema.Indexed)
+	sb.Component("maintenance", "dev.miren.ingress/http_route.maintenance", schema.Doc("Operator-initiated maintenance state. When present, the router serves a holding page instead of proxying to the app. Absent means the route serves normally."))
+	(&Maintenance{}).InitSchema(sb.Builder("http_route.maintenance"))
 	sb.String("request_timeout", "dev.miren.ingress/http_route.request_timeout", schema.Doc("Per-route override for the ingress request timeout (e.g. \"10m\", \"300s\"). Empty falls back to the server's http_request_timeout (default 60s). Must be a positive duration; invalid or non-positive values are ignored at request time."))
 	sb.Ref("waf_profile", "dev.miren.ingress/http_route.waf_profile", schema.Doc("Reference to a WAF profile for request filtering"))
 }
@@ -173,6 +186,74 @@ func (o *ClaimMappings) Empty() bool {
 func (o *ClaimMappings) InitSchema(sb *schema.SchemaBuilder) {
 	sb.String("claim", "dev.miren.ingress/claim_mappings.claim", schema.Doc("The JWT claim name (e.g. email, sub, name)"))
 	sb.String("header", "dev.miren.ingress/claim_mappings.header", schema.Doc("The HTTP header name to inject (e.g. X-User-Email)"))
+}
+
+const (
+	MaintenanceBackAtId    = entity.Id("dev.miren.ingress/maintenance.back_at")
+	MaintenanceReasonId    = entity.Id("dev.miren.ingress/maintenance.reason")
+	MaintenanceStartedAtId = entity.Id("dev.miren.ingress/maintenance.started_at")
+	MaintenanceStartedById = entity.Id("dev.miren.ingress/maintenance.started_by")
+)
+
+type Maintenance struct {
+	BackAt    string `cbor:"back_at,omitempty" json:"back_at,omitempty"`
+	Reason    string `cbor:"reason,omitempty" json:"reason,omitempty"`
+	StartedAt string `cbor:"started_at,omitempty" json:"started_at,omitempty"`
+	StartedBy string `cbor:"started_by,omitempty" json:"started_by,omitempty"`
+}
+
+func (o *Maintenance) Decode(e entity.AttrGetter) {
+	if a, ok := e.Get(MaintenanceBackAtId); ok && a.Value.Kind() == entity.KindString {
+		o.BackAt = a.Value.String()
+	}
+	if a, ok := e.Get(MaintenanceReasonId); ok && a.Value.Kind() == entity.KindString {
+		o.Reason = a.Value.String()
+	}
+	if a, ok := e.Get(MaintenanceStartedAtId); ok && a.Value.Kind() == entity.KindString {
+		o.StartedAt = a.Value.String()
+	}
+	if a, ok := e.Get(MaintenanceStartedById); ok && a.Value.Kind() == entity.KindString {
+		o.StartedBy = a.Value.String()
+	}
+}
+
+func (o *Maintenance) Encode() (attrs []entity.Attr) {
+	if !entity.Empty(o.BackAt) {
+		attrs = append(attrs, entity.String(MaintenanceBackAtId, o.BackAt))
+	}
+	if !entity.Empty(o.Reason) {
+		attrs = append(attrs, entity.String(MaintenanceReasonId, o.Reason))
+	}
+	if !entity.Empty(o.StartedAt) {
+		attrs = append(attrs, entity.String(MaintenanceStartedAtId, o.StartedAt))
+	}
+	if !entity.Empty(o.StartedBy) {
+		attrs = append(attrs, entity.String(MaintenanceStartedById, o.StartedBy))
+	}
+	return
+}
+
+func (o *Maintenance) Empty() bool {
+	if !entity.Empty(o.BackAt) {
+		return false
+	}
+	if !entity.Empty(o.Reason) {
+		return false
+	}
+	if !entity.Empty(o.StartedAt) {
+		return false
+	}
+	if !entity.Empty(o.StartedBy) {
+		return false
+	}
+	return true
+}
+
+func (o *Maintenance) InitSchema(sb *schema.SchemaBuilder) {
+	sb.String("back_at", "dev.miren.ingress/maintenance.back_at", schema.Doc("RFC 3339 timestamp for the expected end of the window. Drives the Retry-After header and the holding page copy. Empty means no estimate was given."))
+	sb.String("reason", "dev.miren.ingress/maintenance.reason", schema.Doc("Operator-supplied explanation shown on the holding page"))
+	sb.String("started_at", "dev.miren.ingress/maintenance.started_at", schema.Doc("RFC 3339 timestamp for when maintenance began"))
+	sb.String("started_by", "dev.miren.ingress/maintenance.started_by", schema.Doc("Identifier of the operator who put the route into maintenance"))
 }
 
 const (
@@ -424,5 +505,5 @@ func init() {
 		(&PasswordProvider{}).InitSchema(sb)
 		(&WafProfile{}).InitSchema(sb)
 	})
-	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x94\x96ے\xdb \f\x86_\xa4\x9d\x1e\xa7纳O\xc4\x10#\xdb\xdap\n`or\xd9\xde\xf4A\xba\xed\x1b\xb6\xd7\x1d\x83\xb36\xe08\xe4&#\v\xf1\t\xc9?\x8a\x1f\x99\xa4\x02\x0e\f\x86J\xa0\x01Y\xa1l\rX\v{\x94\xcc>\x1e_e+\xdfƕ\xaasN\x13\xa3z\a\x7f<\xe1\xf8,\x0f\x9cc\x02\xed_Ô\xa0(\xf3lM\x83\xc0\x99\xfd\xf9k\x87\xec\xf8r\x8bTQ\xad}\xc2z4\xdcI\xc3\x0e\x99\xdf\xf6i{[\xef:\xa2\x8d\x1a\x90\x81\xf1\x00\x11\xbb&\xd4\xef\x11\xf5y\x13Us\x8a\x82\b\xaa5\xca\xd62A\xe5\xe9\xaf'\xcadeDb\xad\x84V\x12\xa4\x9b\xad\xa9cy\x96\xeab\x96\xc2\x06\xfe\xf0\x9dx\x97\x1f?\xa6\x05\xb8?\x05\x04s<jc\x9dA\xd9z\xc4\xfb\xab\x88\x0e蹓\xcdd/ \xed\x00Ƣ\x92\xedpG\xb9\xee(\xd7\x06\x055'2\xd6!<\xeaL\xf2\xf9\xdenv\x9cAC{\xee|\xb2\xf6\xfc0fc;\xa5\xb8\a\xac\xe8t\x01\xe8\x94\r\xbb\x99\xb7\xd2j\xbfln6p\xe8\xc1:\xe2P\x80\xea\x03G\xa5\xce\x14\xf9a\x13\xf9@\x9bQy\rr\xf0\xb8\xfd\xd21)q\xb3\x85\xf73\xec\xf8\xfa\xc2\x15]0'\xc5=\xcf#\x17A\x85\x1a\xfb~\xa9e\vT\xa5\xa9\xa1R!%\x1c\x06\xe0\xe1v$\xbe\xb1\xcc\x1a\xa5۬s٘5\x91\xf8B\x15\xb2\xfa\xe9\"O\xa5\xbe\xc8c\xa3\xb0\x9b&\xd2\xc7+\xb0\xaa\xe6\b\xd2\x11d>9Ώ\xa9,\xbe\x16\x92,\xd4\x06\x82\xd4D\xecJ\x89+\xb3*!*\xd9`K\ueb52AkKGJ\xab\nh\x12j\xa7\f\xf1\xf7/\x8c\xbdؗ2W^[\xcc\xf4\x17s\xfe)\xb8\x9d\xf1\xfe\xb3Az\x13\xa4\xc6#O\xca[\x19\x8f1\xcf\xd6J\x83\r\xa3m\xb2\x8bG[DZ\x9b\x02^\xb1\x9aZ\xfb\xa0\fKU\xfb&\x8f\xcfBo\xfa+X9@\x06\xbc\xd6\xff\xbb\x12Ɠ\xa7\xa3\xb6\v\xba\x8d]\xa5\x1d<d\xec4|o;e\x1c\t\x1f(\xcbAx\xfd[%\x1a'\x05s3y\x9dE\x03(/\xa0\\\x06\xff\x01\x00\x00\xff\xff\x01\x00\x00\xff\xff\x1c\x06\xbc\xb1\x8e\t\x00\x00"))
+	schema.RegisterEncodedSchema("dev.miren.ingress", "v1alpha", []byte("\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\x9c\x96Y\x92\xd3<\x10\x80/\xf2\xffž\x83\xa99\x91J\xb6\xdavO\xace$9\x93<BQ\x05\xf7 pCx\xa6,\xd9\x13-\x8e#x\x99j\xb5[_\xaf\xd3ʉ\t\xca\xe1\x8e\xc1\xbe\xe2\xa8AT(:\r\xc6\xc0\x0e\x053\xa7Ó\xec\xcb\xc7\xe9K\xd5[\xab\x88\x96\xa3\x85\x9f\x8ep\xf8/7<\xdbx\xda\xef\x96INQ\xe4\xde\xda\x16a`\xe6\xdb\xf7\x1a\xd9\xe1\xf1\x16\xa9\xa2J9\x87\xcd$أ\x82\x1a\x99\xbb\xf6v\xfb\xdah{\xa2\xb4\xdc#\x03\xed\x00<Vͨ\x1f\x13\xea\xdd&\xaa\x19(r©R(:\xc38\x15\xc7_\x8e(\x92/\x13\x12\x1bɕ\x14 \xecY\x9a+\x96{\xa9.z),\xe0gW\x89\x97y\xf81\xcd\xc3]\x14\xe0\xc5)\xd4\xd6X\x8d\xa2s\x88WW\x11=Х\x92\xed,\a\x90n\x0fڠ\x14\xdd\xfe\x86\x0e\xaa\xa7\x83\xd2ȩ>\x92)\x0f\xeeP\v\xc9\xf9{\xbeYq\x06-\x1d\a\xeb\x9cu\xcba\xf2\xc6j)\a\aX\x99\xd3\x00\xd0K\xe3o3'\x05\x81\x9e\xa6˯7/O\x15\xb7 \xa8h\xc01v\xa1\xe2J\x8fsr\xb5N.l\xf0\x17\x97\xec\x8b<\xde\x00Uմ\xd9\x11:\x97k9\xa4\x1d^\xa9x\xc8\xd0@\x8d\x14\xbe\xbd\xb3\x9c\x12V\xaa\x16\x12\x8c\xa5\xda\x02[\x02\xb9\r\xce\xffH\xaa\x8f1\xa9>\x16\x8f\\\xd83\xe7\xf2\xfdf\xcb5܍`,\xb1\xc8A\x8e>\x01\x99*\v\xb2\b\x90\xf7\xb4\x9d\x96M\x8b\xc3<E\xa1b^>\x9b)ܞa\x87\xa7\x17\xb6r\xc0\x9c\a\xf0\xff\xdc20*\x9c\xbaO\x97J\x16\xa0*E5\x15\x12)\x19`\x0f\x83_\x88\x89nJ\xb3Aa\xb7[\x15@צ\xd4%*\x915\x0f\xbb{N\xf5Qn\x1b\x99\x15&\xfb\xd5%\xfb\xe6\n\xacj\x06\x04a\t2\xe7\x1c\xcf\xc7t,>\x14\x92\f4\x1a\xfc\xa8\xf1X\x95\x12W\x9e\xa7\x84(E\x8b\x1d\xb9]\xfe\x83w\xa1\"\xa5U\x054\x01\x8d\x95\x9a\xb8\x95\xeb_\xbaXW\xb0\\b\xa6\xdb\xc5\xe7?\xe9\xfd\x95Q\x8b\xef/\x02\x19\xb5\x1f\xb5!Ҥ\xbc\x95\x171\xe6\x99F*0~\xdd\xcdr\xf1k\x16\x91ֶ\x80\x9bXE\x8d\xb9\x97\x9a\xa5S\xfb,\xb7\xcfL\xff\xea\xf5_\t \x03^\xab\xffM\t\xe3A\xd3S\xd3\xfb\xb9\x8dU\xa5\x15\xbc\xcbة\xf9\xce\xf4R[\xe2\x7f\x93\x86\x8b\xf0\xfa\xcf\xd3h\x9d\x14\xecͤ\x9dE\v(O\xa0|\f\xfe\x00\x00\x00\xff\xff\x01\x00\x00\xff\xffo\x96ԕ\x81\v\x00\x00"))
 }

--- a/api/ingress/rpc.yml
+++ b/api/ingress/rpc.yml
@@ -1,0 +1,73 @@
+interfaces:
+  - name: Routes
+    doc: >-
+      Operator controls over an existing HTTP route. Route records themselves
+      are still created and removed through the entity store; this interface
+      exists for the operations that need the server to establish something the
+      caller cannot be trusted to assert about itself.
+    methods:
+      - name: setMaintenance
+        index: 0
+        doc: >-
+          Put a route into maintenance, so the router serves a holding page
+          instead of proxying to the app. The operator identity and the start of
+          the window are stamped server-side from the authenticated caller.
+          Calling this on a route that is already in maintenance updates the
+          reason and expected return without restarting the clock.
+        parameters:
+          - name: host
+            type: string
+            doc: >-
+              Hostname of the route. Ignored when default_route is set, and
+              required otherwise.
+          - name: default_route
+            type: bool
+            doc: >-
+              Act on the default route, which has no hostname of its own,
+              instead of on a named host.
+          - name: reason
+            type: string
+            doc: Operator-supplied explanation shown to visitors.
+          - name: back_at
+            type: string
+            doc: >-
+              RFC 3339 timestamp for the expected end of the window, already
+              normalized by the caller. Empty means no estimate.
+        results:
+          - name: route
+            type: string
+            doc: Label for the route acted on, "default" for the default route.
+          - name: reason
+            type: string
+          - name: back_at
+            type: string
+          - name: started_at
+            type: string
+            doc: When the window opened, preserved across repeated calls.
+          - name: started_by
+            type: string
+            doc: Authenticated identity of the operator who opened the window.
+      - name: clearMaintenance
+        index: 1
+        doc: >-
+          Return a route to normal serving. Clearing a route that is already
+          serving succeeds and reports that nothing changed, so the reversal
+          path never makes an operator stop and work out whether they already
+          ran it.
+        parameters:
+          - name: host
+            type: string
+            doc: >-
+              Hostname of the route. Ignored when default_route is set, and
+              required otherwise.
+          - name: default_route
+            type: bool
+            doc: >-
+              Act on the default route, which has no hostname of its own,
+              instead of on a named host.
+        results:
+          - name: route
+            type: string
+          - name: changed
+            type: bool
+            doc: False when the route was already serving normally.

--- a/api/ingress/schema.yml
+++ b/api/ingress/schema.yml
@@ -36,6 +36,28 @@ kinds:
         header:
           type: string
           doc: The HTTP header name to inject (e.g. X-User-Email)
+    maintenance:
+      type: component
+      doc: >-
+        Operator-initiated maintenance state. When present, the router serves a
+        holding page instead of proxying to the app. Absent means the route
+        serves normally.
+      attrs:
+        reason:
+          type: string
+          doc: Operator-supplied explanation shown on the holding page
+        back_at:
+          type: string
+          doc: >-
+            RFC 3339 timestamp for the expected end of the window. Drives the
+            Retry-After header and the holding page copy. Empty means no
+            estimate was given.
+        started_at:
+          type: string
+          doc: RFC 3339 timestamp for when maintenance began
+        started_by:
+          type: string
+          doc: Identifier of the operator who put the route into maintenance
   password_provider:
     name:
       type: string

--- a/blackbox/route_maintenance_test.go
+++ b/blackbox/route_maintenance_test.go
@@ -46,6 +46,13 @@ func TestRouteMaintenance(t *testing.T) {
 		if !strings.Contains(body, "Upgrading the database") {
 			return false, "response does not carry the maintenance reason"
 		}
+		// The heading names the site the visitor opened, not the app behind it.
+		if !strings.Contains(body, host+" is down for maintenance") {
+			return false, "holding page does not name the host that was visited"
+		}
+		if strings.Contains(body, name+" is down") {
+			return false, "holding page leaks the internal app name"
+		}
 		return true, ""
 	})
 

--- a/blackbox/route_maintenance_test.go
+++ b/blackbox/route_maintenance_test.go
@@ -1,0 +1,146 @@
+//go:build blackbox
+
+package blackbox
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"miren.dev/runtime/blackbox/harness"
+)
+
+func TestRouteMaintenance(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	name := harness.DeployApp(t, m, harness.AppOptions{
+		Testdata: "go-server",
+	})
+
+	host := name + ".test.local"
+	m.MustRun("route", "set", host, name)
+
+	harness.Poll(t, "app responds via route", 30*time.Second, 2*time.Second, func() (bool, string) {
+		code, _, err := harness.HTTPGet(m, host, "/")
+		if err != nil {
+			return false, err.Error()
+		}
+		if code != 200 {
+			return false, fmt.Sprintf("HTTP %d", code)
+		}
+		return true, ""
+	})
+
+	m.MustRun("route", "down", host, "--reason", "Upgrading the database", "--back-at", "30m")
+
+	harness.Poll(t, "holding page served", 15*time.Second, 1*time.Second, func() (bool, string) {
+		code, body, err := harness.HTTPGet(m, host, "/")
+		if err != nil {
+			return false, err.Error()
+		}
+		if code != 503 {
+			return false, fmt.Sprintf("HTTP %d", code)
+		}
+		if !strings.Contains(body, "Upgrading the database") {
+			return false, "response does not carry the maintenance reason"
+		}
+		return true, ""
+	})
+
+	// The window is only useful if the app itself is still reachable for
+	// migrations, so the headers and the app's own liveness both matter.
+	headers := httpHeadersDuringMaintenance(t, m, host)
+	if !strings.Contains(headers, "retry-after:") {
+		t.Fatalf("expected a Retry-After header during maintenance, got:\n%s", headers)
+	}
+	if !strings.Contains(headers, "cache-control: no-store") {
+		t.Fatalf("expected Cache-Control: no-store during maintenance, got:\n%s", headers)
+	}
+
+	jsonBody := httpJSONDuringMaintenance(t, m, host)
+	if !strings.Contains(jsonBody, `"error":"maintenance"`) && !strings.Contains(jsonBody, `"error": "maintenance"`) {
+		t.Fatalf("expected a JSON maintenance body for an Accept: application/json client, got:\n%s", jsonBody)
+	}
+
+	// The window exists so migrations can run against a quiet app, so the app
+	// staying reachable through `app run` is the behavior, not a side effect.
+	r := m.MustRun("app", "run", "-a", name, "--", "echo", "migration-ran")
+	r.RequireContains(t, "migration-ran")
+
+	r = m.MustRun("route", "list")
+	r.RequireContains(t, "maintenance")
+
+	r = m.MustRun("route", "show", host)
+	r.RequireContains(t, "Upgrading the database")
+
+	r = m.MustRun("app", "status", "-a", name)
+	r.RequireContains(t, "Maintenance")
+
+	m.MustRun("route", "up", host)
+
+	harness.Poll(t, "route serves the app again", 15*time.Second, 1*time.Second, func() (bool, string) {
+		code, body, err := harness.HTTPGet(m, host, "/")
+		if err != nil {
+			return false, err.Error()
+		}
+		if code != 200 {
+			return false, fmt.Sprintf("HTTP %d", code)
+		}
+		if strings.Contains(body, "Upgrading the database") {
+			return false, "still serving the holding page"
+		}
+		return true, ""
+	})
+
+	// Bringing a route up twice is not an error; the reversal path shouldn't
+	// make an operator stop and work out whether they already ran it.
+	m.MustRun("route", "up", host)
+}
+
+// TestRouteDownDefaultNeedsConfirmation covers the guardrail on the widest
+// command available: the default route catches every hostname without a route
+// of its own. JSON output can't carry a prompt, so it must not be a way around
+// one either.
+func TestRouteDownDefaultNeedsConfirmation(t *testing.T) {
+	c := harness.NewCluster(t)
+	m := harness.NewMiren(t, c)
+
+	r := m.Run("route", "down", "--default", "--json", "--reason", "Cluster upgrade")
+	if r.ExitCode == 0 {
+		t.Fatalf("expected --default --json without --yes to be refused, got exit 0: %s", r.Stdout)
+	}
+	r.RequireContains(t, "--yes")
+}
+
+func httpHeadersDuringMaintenance(t *testing.T, m *harness.Miren, host string) string {
+	t.Helper()
+
+	r := m.RunCmd("curl", "-sSkI",
+		"-H", fmt.Sprintf("Host: %s", host),
+		"--max-time", "10",
+		"https://localhost:443/")
+
+	if !r.Success() {
+		t.Fatalf("curl for maintenance headers failed (exit %d): %s", r.ExitCode, r.Stderr)
+	}
+
+	return strings.ToLower(r.Stdout)
+}
+
+func httpJSONDuringMaintenance(t *testing.T, m *harness.Miren, host string) string {
+	t.Helper()
+
+	r := m.RunCmd("curl", "-sSk",
+		"-H", fmt.Sprintf("Host: %s", host),
+		"-H", "Accept: application/json",
+		"--max-time", "10",
+		"https://localhost:443/")
+
+	if !r.Success() {
+		t.Fatalf("curl for maintenance JSON failed (exit %d): %s", r.ExitCode, r.Stderr)
+	}
+
+	return r.Stdout
+}

--- a/cli/commands/app_list.go
+++ b/cli/commands/app_list.go
@@ -66,6 +66,8 @@ func AppList(ctx *Context, opts struct {
 			Routes           []string `json:"routes,omitempty"`
 			CrashCount       int64    `json:"crash_count"`
 			CooldownSeconds  int32    `json:"cooldown_seconds"`
+
+			MaintenanceRoutes []string `json:"maintenance_routes,omitempty"`
 		}
 
 		for _, a := range appList {
@@ -79,6 +81,8 @@ func AppList(ctx *Context, opts struct {
 				Routes           []string `json:"routes,omitempty"`
 				CrashCount       int64    `json:"crash_count"`
 				CooldownSeconds  int32    `json:"cooldown_seconds"`
+
+				MaintenanceRoutes []string `json:"maintenance_routes,omitempty"`
 			}{
 				Name:             a.Name(),
 				Health:           a.Health(),
@@ -87,6 +91,8 @@ func AppList(ctx *Context, opts struct {
 				ScalingMode:      a.ScalingMode(),
 				CrashCount:       a.CrashCount(),
 				CooldownSeconds:  a.CooldownSeconds(),
+
+				MaintenanceRoutes: resolveRoutes(a.MaintenanceRoutes(), defaultHost),
 			}
 
 			if a.HasCurrentVersion() {

--- a/cli/commands/app_status.go
+++ b/cli/commands/app_status.go
@@ -95,6 +95,11 @@ func AppStatus(ctx *Context, opts struct {
 		ctx.Printf("%s %s\n", labelStyle.Render("Workload Role:"), role)
 	}
 
+	if down := appResult.MaintenanceRoutes(); len(down) > 0 {
+		ctx.Printf("%s %s\n", labelStyle.Render("Maintenance:"),
+			yellowStyle.Render(fmt.Sprintf("%s serving a holding page", maintenanceRouteList(down))))
+	}
+
 	// Configuration
 	if appConfig != nil {
 		ctx.Printf("\n%s\n", labelStyle.Render("Configuration:"))
@@ -384,13 +389,15 @@ func printAppStatusJSON(
 		Cluster           string           `json:"cluster"`
 		CurrentVersion    string           `json:"current_version,omitempty"`
 		WorkloadRole      string           `json:"workload_role,omitempty"`
+		MaintenanceRoutes []string         `json:"maintenance_routes,omitempty"`
 		Configuration     *configuration   `json:"configuration,omitempty"`
 		ActiveDeployment  *deploymentJSON  `json:"active_deployment,omitempty"`
 		RecentDeployments []deploymentJSON `json:"recent_deployments,omitempty"`
 	}{
-		App:          app,
-		Cluster:      cluster,
-		WorkloadRole: appResult.WorkloadRole(),
+		App:               app,
+		Cluster:           cluster,
+		WorkloadRole:      appResult.WorkloadRole(),
+		MaintenanceRoutes: appResult.MaintenanceRoutes(),
 	}
 
 	if appResult.HasVersionId() && appResult.VersionId() != "" {
@@ -427,4 +434,19 @@ func printAppStatusJSON(
 	}
 
 	return PrintJSON(output)
+}
+
+// maintenanceRouteList names the routes in maintenance for the status line. The
+// default route has no hostname of its own, so it's named rather than shown as
+// a blank.
+func maintenanceRouteList(hosts []string) string {
+	named := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		if h == "" {
+			h = "the default route"
+		}
+		named = append(named, h)
+	}
+
+	return strings.Join(named, ", ")
 }

--- a/cli/commands/commands.go
+++ b/cli/commands/commands.go
@@ -715,6 +715,33 @@ miren deploy --analyze
 		}),
 	))
 
+	d.Dispatch("route down", Infer("route down", "Put an HTTP route into maintenance", RouteDown,
+		WithDescription(routeDownDescription),
+		WithExample(mflags.Example{
+			Name: "Take a route down with an explanation",
+			Body: `miren route down example.com --reason "Upgrading the database"`,
+		}),
+		WithExample(mflags.Example{
+			Name: "Take a route down with an expected return time",
+			Body: `miren route down example.com --reason "DB migration" --back-at 15:00`,
+		}),
+		WithExample(mflags.Example{
+			Name: "Take the default route down",
+			Body: `miren route down --default --reason "Cluster upgrade"`,
+		}),
+	))
+	d.Dispatch("route up", Infer("route up", "Bring an HTTP route out of maintenance", RouteUp,
+		WithDescription(routeUpDescription),
+		WithExample(mflags.Example{
+			Name: "Bring a route back",
+			Body: "miren route up example.com",
+		}),
+		WithExample(mflags.Example{
+			Name: "Bring the default route back",
+			Body: "miren route up --default",
+		}),
+	))
+
 	// Config commands
 	d.Dispatch("config", Section("config", "Configuration file management", "", WithSectionGroup(GroupClient)))
 	d.Dispatch("config info", Infer("config info", "Show configuration file locations and format", ConfigInfo,
@@ -1331,3 +1358,19 @@ const addonCreateDescription = `Attaching an addon provisions the backing resour
 const addonDestroyDescription = `Removing an addon deprovisions the backing resource and strips its injected environment variables from your app. Miren creates a new app version without those variables and rolls it out automatically — you do not need to run ` + "`" + `miren deploy` + "`" + ` or ` + "`" + `miren app restart` + "`" + `.`
 
 const addonRotateDescription = `Rotating an addon credential generates a new secret, applies it to the running backing engine, and updates the value Miren stores. Consuming apps that embed the credential are redeployed automatically to pick up the new connection details — you do not need to run ` + "`" + `miren deploy` + "`" + ` or ` + "`" + `miren app restart` + "`" + `. Rotation runs asynchronously: the command returns a request id and the rotation controller carries it out.`
+
+const routeDownDescription = `Puts a route into maintenance. Visitors get HTTP 503 and a holding page instead of reaching the app; nothing else changes.
+
+Maintenance is a routing decision and only a routing decision. The app's sandboxes keep running, so ` + "`" + `miren app run` + "`" + ` and one-shot migrations still work during the window — which is the whole point of taking traffic off the route first. Other hostnames pointing at the same app keep serving, and internal service-to-service calls are unaffected.
+
+` + "`" + `--reason` + "`" + ` is shown to visitors, so write it for them rather than for your team. ` + "`" + `--back-at` + "`" + ` accepts a clock time (` + "`" + `15:00` + "`" + `), a duration (` + "`" + `30m` + "`" + `), or an RFC 3339 timestamp; it drives both the holding page copy and the ` + "`" + `Retry-After` + "`" + ` header that crawlers and uptime monitors read.
+
+:::note[Ephemeral preview URLs are covered]
+Preview subdomains resolve through their base route, so taking ` + "`" + `app.example.com` + "`" + ` down also holds ` + "`" + `feat-x.app.example.com` + "`" + `. Previews share the app's database, so a migration window that left them serving would not be a window at all.
+:::`
+
+const routeUpDescription = `Brings a route out of maintenance and back to serving normally.
+
+This clears the whole maintenance record, including the reason and the operator who set it — a stale "Upgrading the database" hanging off a healthy route is a trap for whoever reads it next.
+
+Running this on a route that is already serving succeeds and says so, rather than erroring.`

--- a/cli/commands/route_down.go
+++ b/cli/commands/route_down.go
@@ -1,0 +1,154 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/ui"
+)
+
+func RouteDown(ctx *Context, opts struct {
+	Host    string `position:"0" usage:"Hostname for the route (e.g., example.com); omit and pass --default for the default route"`
+	Default bool   `long:"default" description:"Take the default route down (instead of a hostname)"`
+	Reason  string `long:"reason" description:"Explanation shown to visitors on the holding page"`
+	BackAt  string `long:"back-at" description:"When the route is expected back: a clock time in your own timezone (15:00), a duration (30m), or an RFC 3339 timestamp"`
+	Yes     bool   `long:"yes" short:"y" description:"Skip the confirmation prompt for --default"`
+	FormatOptions
+	ConfigCentric
+}) error {
+	if opts.Host == "" && !opts.Default {
+		return fmt.Errorf("either a hostname or --default must be specified")
+	}
+
+	if opts.Host != "" && opts.Default {
+		return fmt.Errorf("--default cannot be used with a hostname")
+	}
+
+	backAt, err := parseBackAt(opts.BackAt, time.Now())
+	if err != nil {
+		return err
+	}
+
+	// The default route catches every hostname that doesn't match another
+	// route, so this is the widest blast radius available in one command. JSON
+	// output can't carry a prompt, but it mustn't be a way around one either:
+	// there the caller has to say --yes out loud.
+	if opts.Default && !opts.Yes {
+		if opts.IsJSON() {
+			return fmt.Errorf("taking the default route down affects every hostname without its own route; pass --yes to confirm")
+		}
+
+		confirmed, err := ui.Confirm(
+			ui.WithMessage("Take the default route down? Every hostname without its own route gets the holding page."),
+			ui.WithDefault(false),
+		)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			ctx.Printf("Cancelled\n")
+			return nil
+		}
+	}
+
+	client, err := ctx.RPCClient("dev.miren.runtime/routes")
+	if err != nil {
+		return err
+	}
+
+	routes := ingress_v1alpha.NewRoutesClient(client)
+
+	res, err := routes.SetMaintenance(ctx, opts.Host, opts.Default, opts.Reason, backAt)
+	if err != nil {
+		return err
+	}
+
+	if opts.IsJSON() {
+		type RouteDownJSON struct {
+			Route       string `json:"route"`
+			Maintenance bool   `json:"maintenance"`
+			Reason      string `json:"reason,omitempty"`
+			BackAt      string `json:"back_at,omitempty"`
+			StartedAt   string `json:"started_at,omitempty"`
+			StartedBy   string `json:"started_by,omitempty"`
+		}
+
+		return PrintJSON(RouteDownJSON{
+			Route:       res.Route(),
+			Maintenance: true,
+			Reason:      res.Reason(),
+			BackAt:      res.BackAt(),
+			StartedAt:   res.StartedAt(),
+			StartedBy:   res.StartedBy(),
+		})
+	}
+
+	ctx.Printf("Route %s is in maintenance. Visitors get a holding page; the app itself keeps running.\n", res.Route())
+	if res.Reason() != "" {
+		ctx.Printf("Reason: %s\n", res.Reason())
+	}
+	if res.BackAt() != "" {
+		ctx.Printf("Expected back: %s\n", res.BackAt())
+	}
+	ctx.Printf("Bring it back with: miren route up %s\n", upTarget(opts.Host, opts.Default))
+
+	return nil
+}
+
+func upTarget(host string, isDefault bool) string {
+	if isDefault {
+		return "--default"
+	}
+	return host
+}
+
+// parseBackAt normalizes the operator's expected-return time to RFC 3339 UTC.
+// It accepts a duration from now ("30m"), a clock time resolved to its next
+// occurrence ("15:00"), or a full RFC 3339 timestamp.
+//
+// A bare clock time is read in the caller's own timezone, since that is what an
+// operator typing "15:00" means. now carries that location, so the conversion
+// to UTC falls out of it.
+func parseBackAt(in string, now time.Time) (string, error) {
+	in = strings.TrimSpace(in)
+	if in == "" {
+		return "", nil
+	}
+
+	if t, err := time.Parse(time.RFC3339, in); err == nil {
+		return t.UTC().Format(time.RFC3339), nil
+	}
+
+	if d, err := time.ParseDuration(in); err == nil {
+		if d <= 0 {
+			return "", fmt.Errorf("--back-at duration must be in the future: %s", in)
+		}
+		return now.Add(d).UTC().Format(time.RFC3339), nil
+	}
+
+	for _, layout := range []string{"15:04", "15:04:05"} {
+		clock, err := time.Parse(layout, in)
+		if err != nil {
+			continue
+		}
+
+		at := time.Date(now.Year(), now.Month(), now.Day(),
+			clock.Hour(), clock.Minute(), clock.Second(), 0, now.Location())
+		if !at.After(now) {
+			at = at.AddDate(0, 0, 1)
+		}
+
+		// The hour a spring-forward skips does not exist locally, and time.Date
+		// silently slides it to one that does. Rather than quietly meaning an
+		// hour the operator did not type, say so and ask for a timestamp.
+		if at.Hour() != clock.Hour() || at.Minute() != clock.Minute() || at.Second() != clock.Second() {
+			return "", fmt.Errorf("%s does not exist on that date in %s, which is the hour daylight saving time skips: give an RFC 3339 timestamp instead", in, at.Location())
+		}
+
+		return at.UTC().Format(time.RFC3339), nil
+	}
+
+	return "", fmt.Errorf("could not read --back-at %q: use a clock time (15:00), a duration (30m), or an RFC 3339 timestamp", in)
+}

--- a/cli/commands/route_down_test.go
+++ b/cli/commands/route_down_test.go
@@ -1,0 +1,205 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	// Embed the timezone database so the daylight-saving case below runs
+	// everywhere rather than silently skipping where tzdata is absent.
+	_ "time/tzdata"
+)
+
+func TestParseBackAt(t *testing.T) {
+	now := time.Date(2026, 8, 12, 10, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty stays empty", in: "", want: ""},
+		{name: "whitespace stays empty", in: "   ", want: ""},
+		{name: "rfc3339 passes through", in: "2026-08-12T15:00:00Z", want: "2026-08-12T15:00:00Z"},
+		{name: "rfc3339 normalizes to UTC", in: "2026-08-12T08:00:00-07:00", want: "2026-08-12T15:00:00Z"},
+		{name: "duration", in: "30m", want: "2026-08-12T11:00:00Z"},
+		{name: "compound duration", in: "1h30m", want: "2026-08-12T12:00:00Z"},
+		{name: "clock time later today", in: "15:00", want: "2026-08-12T15:00:00Z"},
+		{name: "clock time with seconds", in: "15:00:30", want: "2026-08-12T15:00:30Z"},
+		{name: "clock time already passed rolls to tomorrow", in: "09:00", want: "2026-08-13T09:00:00Z"},
+		{name: "clock time equal to now rolls to tomorrow", in: "10:30", want: "2026-08-13T10:30:00Z"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBackAt(tt.in, now)
+			if err != nil {
+				t.Fatalf("parseBackAt(%q) returned error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseBackAt(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseBackAtRejectsUnreadableInput(t *testing.T) {
+	now := time.Date(2026, 8, 12, 10, 30, 0, 0, time.UTC)
+
+	for _, in := range []string{"soon", "25:00", "-30m", "0s", "tomorrow at 3"} {
+		if _, err := parseBackAt(in, now); err == nil {
+			t.Errorf("parseBackAt(%q) should have returned an error", in)
+		}
+	}
+}
+
+func TestUpTarget(t *testing.T) {
+	if got := upTarget("example.com", false); got != "example.com" {
+		t.Errorf("upTarget for a host = %q, want example.com", got)
+	}
+	if got := upTarget("", true); got != "--default" {
+		t.Errorf("upTarget for the default route = %q, want --default", got)
+	}
+}
+
+// TestParseBackAtUsesTheCallersTimezone pins what a bare clock time means. An
+// operator typing "15:00" means three in the afternoon where they are, not in
+// UTC, and every other case in this file runs with a UTC "now" so the
+// conversion would otherwise never be exercised.
+func TestParseBackAtUsesTheCallersTimezone(t *testing.T) {
+	eastern := time.FixedZone("EST", -5*60*60)
+
+	tests := []struct {
+		name string
+		now  time.Time
+		in   string
+		want string
+	}{
+		{
+			name: "clock time later today",
+			now:  time.Date(2026, 8, 12, 10, 30, 0, 0, eastern),
+			in:   "15:00",
+			want: "2026-08-12T20:00:00Z",
+		},
+		{
+			name: "clock time already passed rolls to tomorrow",
+			now:  time.Date(2026, 8, 12, 16, 0, 0, 0, eastern),
+			in:   "15:00",
+			want: "2026-08-13T20:00:00Z",
+		},
+		{
+			// A clock time late in the local evening lands on the next UTC day.
+			name: "local evening crosses the UTC date line",
+			now:  time.Date(2026, 8, 12, 20, 0, 0, 0, eastern),
+			in:   "22:00",
+			want: "2026-08-13T03:00:00Z",
+		},
+		{
+			// Durations and absolute timestamps are zone-independent.
+			name: "duration is unaffected by the caller's zone",
+			now:  time.Date(2026, 8, 12, 10, 30, 0, 0, eastern),
+			in:   "30m",
+			want: "2026-08-12T16:00:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBackAt(tt.in, tt.now)
+			if err != nil {
+				t.Fatalf("parseBackAt(%q) returned error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseBackAt(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseBackAtRejectsSkippedClockTimes covers the one hour a year that does
+// not exist locally. time.Date slides it to an hour that does, which would mean
+// the holding page quietly announces a time the operator never typed.
+func TestParseBackAtRejectsSkippedClockTimes(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("loading tzdata: %v", err)
+	}
+
+	// 2026-03-08 is a US spring-forward date: 02:00 jumps straight to 03:00.
+	now := time.Date(2026, 3, 8, 0, 30, 0, 0, ny)
+
+	if _, err := parseBackAt("02:30", now); err == nil {
+		t.Error("02:30 does not exist on a spring-forward date and should be refused")
+	}
+
+	// The neighbouring hours are ordinary and must still work.
+	for _, in := range []string{"01:30", "03:30"} {
+		if _, err := parseBackAt(in, now); err != nil {
+			t.Errorf("parseBackAt(%q) should be accepted, got %v", in, err)
+		}
+	}
+}
+
+// TestParseBackAtAlwaysReturnsUTC pins the wire contract: whatever zone the
+// operator's machine is in, and whichever input form they use, what leaves the
+// CLI is UTC. The server stores it verbatim and the router does date arithmetic
+// against it, so a value carrying a local offset would put the whole window an
+// hour or more off for everyone reading it.
+func TestParseBackAtAlwaysReturnsUTC(t *testing.T) {
+	zones := []*time.Location{
+		time.UTC,
+		time.FixedZone("EST", -5*60*60),
+		time.FixedZone("IST", 5*60*60+30*60), // a half-hour offset, which trips naive math
+		time.FixedZone("NPT", 5*60*60+45*60), // and a quarter-hour one
+	}
+
+	for _, zone := range zones {
+		now := time.Date(2026, 8, 12, 10, 30, 0, 0, zone)
+
+		for _, in := range []string{"15:00", "15:00:30", "30m", "1h30m", "2027-03-04T15:00:00Z", "2027-03-04T08:00:00-07:00"} {
+			got, err := parseBackAt(in, now)
+			if err != nil {
+				t.Fatalf("parseBackAt(%q) in %s: %v", in, zone, err)
+			}
+
+			if !strings.HasSuffix(got, "Z") {
+				t.Errorf("parseBackAt(%q) in %s = %q, want a UTC timestamp ending in Z", in, zone, got)
+			}
+
+			parsed, err := time.Parse(time.RFC3339, got)
+			if err != nil {
+				t.Fatalf("parseBackAt(%q) in %s produced unparseable %q", in, zone, got)
+			}
+			if _, offset := parsed.Zone(); offset != 0 {
+				t.Errorf("parseBackAt(%q) in %s carries offset %d, want 0", in, zone, offset)
+			}
+			if !parsed.After(now) {
+				t.Errorf("parseBackAt(%q) in %s = %q, which is not after now", in, zone, got)
+			}
+		}
+	}
+}
+
+// TestParseBackAtPreservesTheInstant checks the conversion is a change of
+// representation and not a change of moment: the same wall-clock request from
+// two zones names two different instants, an hour apart, exactly as it should.
+func TestParseBackAtPreservesTheInstant(t *testing.T) {
+	east := time.FixedZone("UTC-5", -5*60*60)
+	west := time.FixedZone("UTC-6", -6*60*60)
+
+	fromEast, err := parseBackAt("15:00", time.Date(2026, 8, 12, 10, 0, 0, 0, east))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromWest, err := parseBackAt("15:00", time.Date(2026, 8, 12, 10, 0, 0, 0, west))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fromEast != "2026-08-12T20:00:00Z" {
+		t.Errorf("15:00 in UTC-5 = %q, want 2026-08-12T20:00:00Z", fromEast)
+	}
+	if fromWest != "2026-08-12T21:00:00Z" {
+		t.Errorf("15:00 in UTC-6 = %q, want 2026-08-12T21:00:00Z", fromWest)
+	}
+}

--- a/cli/commands/route_list.go
+++ b/cli/commands/route_list.go
@@ -46,6 +46,12 @@ func RouteList(ctx *Context, opts struct {
 			RequestTimeout string `json:"request_timeout,omitempty"`
 			CreatedAt      int64  `json:"created_at"`
 			UpdatedAt      int64  `json:"updated_at"`
+
+			Maintenance          bool   `json:"maintenance"`
+			MaintenanceReason    string `json:"maintenance_reason,omitempty"`
+			MaintenanceBackAt    string `json:"maintenance_back_at,omitempty"`
+			MaintenanceStartedAt string `json:"maintenance_started_at,omitempty"`
+			MaintenanceStartedBy string `json:"maintenance_started_by,omitempty"`
 		}
 
 		var routeInfos []RouteInfo
@@ -62,6 +68,12 @@ func RouteList(ctx *Context, opts struct {
 				RequestTimeout: r.Route.RequestTimeout,
 				CreatedAt:      r.CreatedAt,
 				UpdatedAt:      r.UpdatedAt,
+
+				Maintenance:          !r.Route.Maintenance.Empty(),
+				MaintenanceReason:    r.Route.Maintenance.Reason,
+				MaintenanceBackAt:    r.Route.Maintenance.BackAt,
+				MaintenanceStartedAt: r.Route.Maintenance.StartedAt,
+				MaintenanceStartedBy: r.Route.Maintenance.StartedBy,
 			})
 		}
 
@@ -69,7 +81,7 @@ func RouteList(ctx *Context, opts struct {
 	}
 
 	var rows []ui.Row
-	headers := []string{"HOST", "APP", "DEFAULT", "WAF", "TIMEOUT", "CREATED", "UPDATED"}
+	headers := []string{"HOST", "APP", "DEFAULT", "WAF", "TIMEOUT", "SERVING", "CREATED", "UPDATED"}
 
 	for _, r := range routes {
 		route := r.Route
@@ -99,12 +111,18 @@ func RouteList(ctx *Context, opts struct {
 			timeoutDisplay = route.RequestTimeout
 		}
 
+		servingDisplay := "✓"
+		if !route.Maintenance.Empty() {
+			servingDisplay = "maintenance"
+		}
+
 		rows = append(rows, ui.Row{
 			host,
 			appDisplay,
 			defaultDisplay,
 			wafDisplay,
 			timeoutDisplay,
+			servingDisplay,
 			humanFriendlyTimestamp(time.UnixMilli(r.CreatedAt)),
 			humanFriendlyTimestamp(time.UnixMilli(r.UpdatedAt)),
 		})

--- a/cli/commands/route_show.go
+++ b/cli/commands/route_show.go
@@ -112,6 +112,12 @@ func RouteShow(ctx *Context, opts struct {
 			ClaimMappings   []map[string]string `json:"claim_mappings,omitempty"`
 			WafLevel        int                 `json:"waf_level"`
 			RequestTimeout  string              `json:"request_timeout,omitempty"`
+
+			Maintenance          bool   `json:"maintenance"`
+			MaintenanceReason    string `json:"maintenance_reason,omitempty"`
+			MaintenanceBackAt    string `json:"maintenance_back_at,omitempty"`
+			MaintenanceStartedAt string `json:"maintenance_started_at,omitempty"`
+			MaintenanceStartedBy string `json:"maintenance_started_by,omitempty"`
 		}
 
 		wafLevel := 0
@@ -127,6 +133,12 @@ func RouteShow(ctx *Context, opts struct {
 			ProtectionType: protectionType,
 			WafLevel:       wafLevel,
 			RequestTimeout: route.RequestTimeout,
+
+			Maintenance:          !route.Maintenance.Empty(),
+			MaintenanceReason:    route.Maintenance.Reason,
+			MaintenanceBackAt:    route.Maintenance.BackAt,
+			MaintenanceStartedAt: route.Maintenance.StartedAt,
+			MaintenanceStartedBy: route.Maintenance.StartedBy,
 		}
 
 		if protected {
@@ -221,6 +233,23 @@ func RouteShow(ctx *Context, opts struct {
 
 			ctx.Printf("\n%s\n", table.Render())
 		}
+	}
+
+	if !route.Maintenance.Empty() {
+		ctx.Printf("\nMaintenance: this route is serving a holding page\n")
+		if route.Maintenance.Reason != "" {
+			ctx.Printf("  Reason:    %s\n", route.Maintenance.Reason)
+		}
+		if route.Maintenance.BackAt != "" {
+			ctx.Printf("  Back at:   %s\n", route.Maintenance.BackAt)
+		}
+		if route.Maintenance.StartedAt != "" {
+			ctx.Printf("  Since:     %s\n", route.Maintenance.StartedAt)
+		}
+		if route.Maintenance.StartedBy != "" {
+			ctx.Printf("  Set by:    %s\n", route.Maintenance.StartedBy)
+		}
+		ctx.Printf("  Bring it back with: miren route up %s\n", upTarget(opts.Host, opts.Default))
 	}
 
 	return nil

--- a/cli/commands/route_up.go
+++ b/cli/commands/route_up.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+)
+
+func RouteUp(ctx *Context, opts struct {
+	Host    string `position:"0" usage:"Hostname for the route (e.g., example.com); omit and pass --default for the default route"`
+	Default bool   `long:"default" description:"Bring the default route back (instead of a hostname)"`
+	FormatOptions
+	ConfigCentric
+}) error {
+	if opts.Host == "" && !opts.Default {
+		return fmt.Errorf("either a hostname or --default must be specified")
+	}
+
+	if opts.Host != "" && opts.Default {
+		return fmt.Errorf("--default cannot be used with a hostname")
+	}
+
+	client, err := ctx.RPCClient("dev.miren.runtime/routes")
+	if err != nil {
+		return err
+	}
+
+	routes := ingress_v1alpha.NewRoutesClient(client)
+
+	res, err := routes.ClearMaintenance(ctx, opts.Host, opts.Default)
+	if err != nil {
+		return err
+	}
+
+	if opts.IsJSON() {
+		type RouteUpJSON struct {
+			Route       string `json:"route"`
+			Maintenance bool   `json:"maintenance"`
+			Changed     bool   `json:"changed"`
+		}
+
+		return PrintJSON(RouteUpJSON{
+			Route:       res.Route(),
+			Maintenance: false,
+			Changed:     res.Changed(),
+		})
+	}
+
+	// Bringing a route back that was never down succeeds rather than erroring.
+	// The reversal path is the one an operator runs under pressure, so it
+	// shouldn't make them stop and think.
+	if !res.Changed() {
+		ctx.Printf("Route %s was already serving normally.\n", res.Route())
+		return nil
+	}
+
+	ctx.Printf("Route %s is serving normally.\n", res.Route())
+	return nil
+}

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -31,6 +31,7 @@ import (
 	aes "miren.dev/runtime/api/entityserver"
 	esv1 "miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/exec/exec_v1alpha"
+	"miren.dev/runtime/api/ingress"
 	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/api/oidcbinding/oidcbinding_v1alpha"
 	"miren.dev/runtime/api/run/run_v1alpha"
@@ -93,6 +94,7 @@ import (
 	"miren.dev/runtime/servers/httpingress"
 	"miren.dev/runtime/servers/logs"
 	oidcbindingsrv "miren.dev/runtime/servers/oidcbinding"
+	routessrv "miren.dev/runtime/servers/routes"
 	runnerserver "miren.dev/runtime/servers/runner"
 	"miren.dev/runtime/servers/runnertelemetry"
 	secretsrv "miren.dev/runtime/servers/secret"
@@ -1580,6 +1582,9 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	oidcServer := oidcbindingsrv.NewServer(c.Log, ec, eac)
 	server.ExposeValue("dev.miren.runtime/oidc-bindings", oidcbinding_v1alpha.AdaptOidcBindings(oidcServer))
+
+	routesServer := routessrv.NewServer(c.Log, ingress.NewClient(c.Log, loopback))
+	server.ExposeValue("dev.miren.runtime/routes", ingress_v1alpha.AdaptRoutes(routesServer))
 
 	c.debugServer, err = debugsrv.NewServer(c.Log, filepath.Join(c.DataPath, "net.db"), eac)
 	if err != nil {

--- a/docs/command-sidebar.json
+++ b/docs/command-sidebar.json
@@ -255,6 +255,7 @@
       "id": "command/route"
     },
     "items": [
+      "command/route-down",
       "command/route-list",
       "command/route-protect",
       "command/route-remove",
@@ -264,6 +265,7 @@
       "command/route-timeout",
       "command/route-unprotect",
       "command/route-unset-default",
+      "command/route-up",
       "command/route-waf"
     ]
   },

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -11,6 +11,9 @@ All notable changes to Miren Runtime will be documented in this file.
 ## Unreleased
 *main*
 
+**Features**
+- **Maintenance mode for routes** - `miren route down app.example.com --reason "Upgrading the database"` takes a hostname out of service and shows visitors a holding page; `miren route up` puts it back. Visitors get a 503, which is what crawlers and uptime monitors expect from planned downtime, rather than the 500s or platform error pages the old workarounds produced, plus a `Retry-After` when you give an expected return time with `--back-at`. Your app keeps running throughout, so `miren app run` and one-shot migrations work during the window. See the [maintenance mode guide](/maintenance-mode).
+
 ---
 
 ## v0.13.0

--- a/docs/docs/command/route-down.md
+++ b/docs/docs/command/route-down.md
@@ -1,0 +1,70 @@
+---
+title: "miren route down"
+sidebar_label: "route down"
+description: "Put an HTTP route into maintenance"
+---
+
+# miren route down
+
+Put an HTTP route into maintenance
+
+Puts a route into maintenance. Visitors get HTTP 503 and a holding page instead of reaching the app; nothing else changes.
+
+Maintenance is a routing decision and only a routing decision. The app's sandboxes keep running, so `miren app run` and one-shot migrations still work during the window — which is the whole point of taking traffic off the route first. Other hostnames pointing at the same app keep serving, and internal service-to-service calls are unaffected.
+
+`--reason` is shown to visitors, so write it for them rather than for your team. `--back-at` accepts a clock time (`15:00`), a duration (`30m`), or an RFC 3339 timestamp; it drives both the holding page copy and the `Retry-After` header that crawlers and uptime monitors read.
+
+:::note[Ephemeral preview URLs are covered]
+Preview subdomains resolve through their base route, so taking `app.example.com` down also holds `feat-x.app.example.com`. Previews share the app's database, so a migration window that left them serving would not be a window at all.
+:::
+
+## Usage
+
+```bash
+miren route down <host> [flags]
+```
+
+## Arguments
+
+- `host` — Hostname for the route (e.g., example.com); omit and pass --default for the default route
+
+## Flags
+
+- `--back-at` — When the route is expected back: a clock time in your own timezone (15:00), a duration (30m), or an RFC 3339 timestamp
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--default` — Take the default route down (instead of a hostname)
+- `--format` — Output format (text, json) (default: `text`)
+- `--json` — Shorthand for --format json
+- `--reason` — Explanation shown to visitors on the holding page
+- `--yes, -y` — Skip the confirmation prompt for --default
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Take a route down with an explanation:**
+
+```bash
+miren route down example.com --reason "Upgrading the database"
+```
+
+**Take a route down with an expected return time:**
+
+```bash
+miren route down example.com --reason "DB migration" --back-at 15:00
+```
+
+**Take the default route down:**
+
+```bash
+miren route down --default --reason "Cluster upgrade"
+```
+
+## See also
+
+- [`miren route`](/command/route)

--- a/docs/docs/command/route-up.md
+++ b/docs/docs/command/route-up.md
@@ -1,0 +1,57 @@
+---
+title: "miren route up"
+sidebar_label: "route up"
+description: "Bring an HTTP route out of maintenance"
+---
+
+# miren route up
+
+Bring an HTTP route out of maintenance
+
+Brings a route out of maintenance and back to serving normally.
+
+This clears the whole maintenance record, including the reason and the operator who set it — a stale "Upgrading the database" hanging off a healthy route is a trap for whoever reads it next.
+
+Running this on a route that is already serving succeeds and says so, rather than erroring.
+
+## Usage
+
+```bash
+miren route up <host> [flags]
+```
+
+## Arguments
+
+- `host` — Hostname for the route (e.g., example.com); omit and pass --default for the default route
+
+## Flags
+
+- `--cluster, -C` — Cluster name
+- `--config` — Path to the config file
+- `--default` — Bring the default route back (instead of a hostname)
+- `--format` — Output format (text, json) (default: `text`)
+- `--json` — Shorthand for --format json
+
+## Global Options
+
+- `--options` — Path to file containing options
+- `--server-address` — Server address to connect to (default: `127.0.0.1:8443`)
+- `--verbose, -v` — Enable verbose output
+
+## Examples
+
+**Bring a route back:**
+
+```bash
+miren route up example.com
+```
+
+**Bring the default route back:**
+
+```bash
+miren route up --default
+```
+
+## See also
+
+- [`miren route`](/command/route)

--- a/docs/docs/command/route.md
+++ b/docs/docs/command/route.md
@@ -37,6 +37,7 @@ miren route
 
 ## Subcommands
 
+- [`miren route down`](/command/route-down) — Put an HTTP route into maintenance
 - [`miren route list`](/command/route-list) — List all HTTP routes
 - [`miren route protect`](/command/route-protect) — Protect an HTTP route with an identity provider
 - [`miren route remove`](/command/route-remove) — Remove an HTTP route
@@ -46,4 +47,5 @@ miren route
 - [`miren route timeout`](/command/route-timeout) — Override the ingress request timeout for an HTTP route
 - [`miren route unprotect`](/command/route-unprotect) — Remove identity-provider protection from an HTTP route
 - [`miren route unset-default`](/command/route-unset-default) — Remove the default route
+- [`miren route up`](/command/route-up) — Bring an HTTP route out of maintenance
 - [`miren route waf`](/command/route-waf) — Manage WAF protection on an HTTP route

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -184,6 +184,7 @@ Complete reference for all `miren` CLI commands.
 | Command | Description |
 |---------|-------------|
 | [`miren route`](/command/route) | List all HTTP routes |
+| [`miren route down`](/command/route-down) | Put an HTTP route into maintenance |
 | [`miren route list`](/command/route-list) | List all HTTP routes |
 | [`miren route protect`](/command/route-protect) | Protect an HTTP route with an identity provider |
 | [`miren route remove`](/command/route-remove) | Remove an HTTP route |
@@ -193,6 +194,7 @@ Complete reference for all `miren` CLI commands.
 | [`miren route timeout`](/command/route-timeout) | Override the ingress request timeout for an HTTP route |
 | [`miren route unprotect`](/command/route-unprotect) | Remove identity-provider protection from an HTTP route |
 | [`miren route unset-default`](/command/route-unset-default) | Remove the default route |
+| [`miren route up`](/command/route-up) | Bring an HTTP route out of maintenance |
 | [`miren route waf`](/command/route-waf) | Manage WAF protection on an HTTP route |
 
 ## runner

--- a/docs/docs/maintenance-mode.md
+++ b/docs/docs/maintenance-mode.md
@@ -48,13 +48,19 @@ miren route down app.example.com --reason "DB migration" --back-at 2027-03-04T15
 
 A bare clock time is read in your own timezone, and one that has already passed resolves to tomorrow, so `--back-at 09:00` at 3pm means 9am the next morning. An absolute timestamp has to be in the future; the server refuses one that has already passed rather than putting a stale estimate on the holding page.
 
+:::warning[`--back-at` is a promise to visitors, not a timer]
+It tells people when you expect to be back. It does not bring the route back. The route stays in maintenance until you run `miren route up`, however long that takes.
+
+If the window runs past your estimate, the `Retry-After` header stops being sent, but the page keeps showing the time you gave. That is deliberate: a page still naming a time that has passed reads as overdue, which is the truth, where a page quietly dropping the estimate would read as if nothing were wrong.
+:::
+
 ## What clients see
 
 Visitors get **HTTP 503 Service Unavailable**. This is the right status for deliberate, temporary downtime, and it's the one search crawlers and uptime monitors already know how to read — a maintenance window served as a 500, or as a 200 with an apology, is how sites lose ranking and how on-call gets paged for a planned event.
 
 Alongside it:
 
-- `Retry-After`, when you gave a `--back-at`. Monitors and crawlers use it to decide when to come back.
+- `Retry-After`, when you gave a `--back-at` that is still in the future. Monitors and crawlers use it to decide when to come back.
 - `Cache-Control: no-store`, so no browser or CDN holds the holding page past the end of the window.
 
 Clients that ask for JSON get JSON rather than a web page, which keeps API consumers from having to parse HTML to find out what happened:
@@ -110,6 +116,8 @@ There's no way to browse the real app from behind the holding page yet. Bring th
 
 ## What's not covered
 
-Maintenance mode is HTTP-only. Background workers and scheduled jobs keep running — if you need those paused for a migration, stop them the way you normally would.
+:::warning[Background work keeps running]
+Maintenance mode only affects HTTP traffic. Background workers and scheduled jobs carry on, so a window opened for a migration does not stop them writing to the database you are migrating. Stop them the way you normally would.
+:::
 
 Custom holding-page HTML and scheduled windows (announce a future window, enter and leave automatically) aren't supported yet.

--- a/docs/docs/maintenance-mode.md
+++ b/docs/docs/maintenance-mode.md
@@ -1,0 +1,115 @@
+---
+title: Maintenance Mode
+description: Take a route out of service, show visitors a holding page, and bring it back — one command each way.
+keywords: [maintenance mode, holding page, planned downtime, migration, 503, retry-after, route down, route up]
+---
+
+import CliCommand from '@site/src/components/CliCommand';
+
+# Maintenance Mode
+
+Maintenance mode takes a hostname out of service and shows visitors a holding page instead. It's for the moments you plan for: a database migration that can't run under live traffic, a dependency cutover, an incident where you want the site quiet while you look at it.
+
+It's one command in, and one command out.
+
+## Minimum working example
+
+<CliCommand context="client">
+```miren
+miren route down app.example.com --reason "Upgrading the database"
+miren route up app.example.com
+```
+</CliCommand>
+
+Between those two commands, anyone visiting `app.example.com` gets a holding page that says the app's name and your reason. Your app keeps running the whole time.
+
+## What it does and doesn't touch
+
+Maintenance is a routing decision and only a routing decision. That's what makes it useful:
+
+- **Your app keeps running.** Sandboxes aren't stopped or scaled down, so `miren app run` and one-shot migrations work normally during the window. Taking traffic off the route first is the entire point.
+- **Other hostnames keep serving.** If `app.example.com` and `admin.example.com` both point at the same app, taking one down leaves the other alone.
+- **Internal calls keep working.** Service-to-service requests inside the cluster resolve by app, not by hostname, so they're unaffected.
+- **Preview URLs are covered.** Ephemeral preview subdomains like `feat-x.app.example.com` resolve through their base route, so they go down with it. Previews share the app's database, so a migration window that left them serving wouldn't be much of a window.
+
+## Telling visitors what's happening
+
+`--reason` is shown on the holding page, so write it for your visitors rather than for your team.
+
+`--back-at` sets an expected return time. It takes a clock time, a duration, or a full timestamp:
+
+<CliCommand context="client">
+```miren
+miren route down app.example.com --reason "DB migration" --back-at 15:00
+miren route down app.example.com --reason "DB migration" --back-at 30m
+miren route down app.example.com --reason "DB migration" --back-at 2027-03-04T15:00:00Z
+```
+</CliCommand>
+
+A bare clock time is read in your own timezone, and one that has already passed resolves to tomorrow, so `--back-at 09:00` at 3pm means 9am the next morning. An absolute timestamp has to be in the future; the server refuses one that has already passed rather than putting a stale estimate on the holding page.
+
+## What clients see
+
+Visitors get **HTTP 503 Service Unavailable**. This is the right status for deliberate, temporary downtime, and it's the one search crawlers and uptime monitors already know how to read — a maintenance window served as a 500, or as a 200 with an apology, is how sites lose ranking and how on-call gets paged for a planned event.
+
+Alongside it:
+
+- `Retry-After`, when you gave a `--back-at`. Monitors and crawlers use it to decide when to come back.
+- `Cache-Control: no-store`, so no browser or CDN holds the holding page past the end of the window.
+
+Clients that ask for JSON get JSON rather than a web page, which keeps API consumers from having to parse HTML to find out what happened:
+
+```json
+{
+  "error": "maintenance",
+  "reason": "Upgrading the database",
+  "back_at": "2027-03-04T15:00:00Z"
+}
+```
+
+## The default route
+
+The default route catches every hostname that doesn't match a route of its own, so taking it down is the widest single command available. Because of that it asks for confirmation:
+
+<CliCommand context="client">
+```miren
+miren route down --default --reason "Cluster upgrade"
+miren route up --default
+```
+</CliCommand>
+
+Pass `--yes` to skip the prompt in a script. JSON output can't carry a prompt, so `--json` on the default route requires `--yes` too, and refuses without it rather than quietly becoming the way around the confirmation.
+
+## Seeing what's down
+
+`miren route list` has a SERVING column, and `miren route show` gives the full record — the reason, the expected return, who set it, and when:
+
+<CliCommand context="client">
+```miren
+miren route show app.example.com
+```
+</CliCommand>
+
+`miren app status` also names any of the app's routes that are currently serving a holding page, so you don't have to already suspect maintenance to find it.
+
+## A migration, start to finish
+
+<CliCommand context="client">
+```miren
+miren route down app.example.com --reason "Upgrading the database" --back-at 15:00
+miren app run -a web -- ./bin/migrate
+miren route up app.example.com
+```
+</CliCommand>
+
+The `miren app run` in the middle works because maintenance never touched the app's sandboxes — it only changed what the router does with inbound requests.
+
+:::note[Verifying before you reopen]
+There's no way to browse the real app from behind the holding page yet. Bring the route up and watch, or check the app through `miren app run` and `miren logs` while the window is still open.
+:::
+
+## What's not covered
+
+Maintenance mode is HTTP-only. Background workers and scheduled jobs keep running — if you need those paused for a migration, stop them the way you normally would.
+
+Custom holding-page HTML and scheduled windows (announce a future window, enter and leave automatically) aren't supported yet.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -52,6 +52,7 @@ const sidebars: SidebarsConfig = {
         'tailscale',
         'waf',
         'route-protect',
+        'maintenance-mode',
         'workload-identity',
         'in-cluster-api',
       ],

--- a/hack/blackbox-groups.json
+++ b/hack/blackbox-groups.json
@@ -16,7 +16,8 @@
         "TestSandboxExec",
         "TestDeployGoServer",
         "TestRouteSetListRemove",
-        "TestSandboxList"
+        "TestSandboxList",
+        "TestRouteDownDefaultNeedsConfirmation"
       ]
     },
     {
@@ -58,7 +59,8 @@
         "TestDistributedRunnerLogs",
         "TestDistributedRunnerMetrics",
         "TestDistributedRunnerNodePort",
-        "TestAddonEnvSurvivesDeployVersion"
+        "TestAddonEnvSurvivesDeployVersion",
+        "TestRouteMaintenance"
       ]
     }
   ]

--- a/pkg/workloadroles/roles_test.go
+++ b/pkg/workloadroles/roles_test.go
@@ -92,6 +92,10 @@ func TestCarveOutsAbsentFromAllRoles(t *testing.T) {
 		"netdb":              {"releaseip", "releasesubnet", "releaseall", "gc"},
 		"outboardcontrol":    {"checkversion"},
 		"oidcbindings":       {"add", "remove", "list"},
+		// Maintenance takes a hostname out of service for everyone. It is an
+		// operator action on shared ingress, guarded by rpc.BoundApp rather
+		// than rpc.AllowApp, so no app-scoped or cluster role should reach it.
+		"routes": {"setmaintenance", "clearmaintenance"},
 		// setworkloadrole assigns a role (including cluster-scoped ones) to an
 		// app. It has no rpc.AllowApp guard and is the operator-only path, so it
 		// must never be granted to a token role — otherwise a workload could

--- a/servers/app/app.go
+++ b/servers/app/app.go
@@ -226,6 +226,8 @@ func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) 
 		return nil, err
 	}
 
+	maintenanceMap := make(map[string][]string)
+
 	for routeList.Next() {
 		var route ingress_v1alpha.HttpRoute
 		routeList.Read(&route)
@@ -235,6 +237,10 @@ func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) 
 			routeMap[appName] = append(routeMap[appName], route.Host)
 		} else if route.Default {
 			routeMap[appName] = append(routeMap[appName], "")
+		}
+
+		if !route.Maintenance.Empty() {
+			maintenanceMap[appName] = append(maintenanceMap[appName], route.Host)
 		}
 	}
 
@@ -292,6 +298,10 @@ func (r *AppInfo) ListApps(ctx context.Context) ([]*app_v1alpha.AppInfo, error) 
 		// Routes
 		if routes, ok := routeMap[entry.name]; ok {
 			a.SetRoutes(routes)
+		}
+
+		if down, ok := maintenanceMap[entry.name]; ok {
+			a.SetMaintenanceRoutes(down)
 		}
 
 		results = append(results, &a)
@@ -626,6 +636,12 @@ func (r *AppInfo) GetConfiguration(ctx context.Context, state *app_v1alpha.CrudG
 		role = workloadroles.Default
 	}
 	state.Results().SetWorkloadRole(role)
+
+	if down, err := r.maintenanceRoutes(ctx, appRec.ID); err != nil {
+		r.Log.Warn("could not read maintenance state for app", "error", err, "app", name)
+	} else if len(down) > 0 {
+		state.Results().SetMaintenanceRoutes(down)
+	}
 
 	return nil
 }

--- a/servers/app/runtime.go
+++ b/servers/app/runtime.go
@@ -10,6 +10,7 @@ import (
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	coreutil "miren.dev/runtime/api/core"
 	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
 	"miren.dev/runtime/pkg/addon"
 	"miren.dev/runtime/pkg/apphealth"
 	"miren.dev/runtime/pkg/cond"
@@ -49,6 +50,15 @@ func (a *AppInfo) AppInfo(ctx context.Context, state *app_v1alpha.AppStatusAppIn
 		role = workloadroles.Default
 	}
 	rai.SetWorkloadRole(role)
+
+	// Maintenance state is decoration on this response, so a route store
+	// problem should not take the whole status call down with it. Status is
+	// what an operator reaches for when something is already wrong.
+	if down, err := a.maintenanceRoutes(ctx, appRec.ID); err != nil {
+		a.Log.Warn("could not read maintenance state for app", "error", err, "app", name)
+	} else if len(down) > 0 {
+		rai.SetMaintenanceRoutes(down)
+	}
 
 	var appVer core_v1alpha.AppVersion
 
@@ -267,4 +277,29 @@ func (a *AppInfo) AppInfo(ctx context.Context, state *app_v1alpha.AppStatusAppIn
 	state.Results().SetStatus(&rai)
 
 	return nil
+}
+
+// maintenanceRoutes lists the hostnames of an app's routes that are currently
+// serving a holding page. The default route has no hostname of its own and is
+// reported as an empty string.
+func (a *AppInfo) maintenanceRoutes(ctx context.Context, appID entity.Id) ([]string, error) {
+	routes, err := a.EC.List(ctx, entity.Ref(entity.EntityKind, ingress_v1alpha.KindHttpRoute))
+	if err != nil {
+		return nil, err
+	}
+
+	var down []string
+
+	for routes.Next() {
+		var route ingress_v1alpha.HttpRoute
+		routes.Read(&route)
+
+		if route.App != appID || route.Maintenance.Empty() {
+			continue
+		}
+
+		down = append(down, route.Host)
+	}
+
+	return down, nil
 }

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -631,16 +631,35 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 	// ephemeral lookup should fall back to the active version rather than 404.
 	wildcardRoute := route != nil && ingress.IsWildcardHost(route.Host)
 
-	// Compose middleware chain: WAF → auth → serve
-	handler := func(w http.ResponseWriter, r *http.Request) {
+	handler := h.buildRouteHandler(route, appName, func(w http.ResponseWriter, r *http.Request) {
 		h.serveAuthenticatedRequest(w, r, targetAppId, routeType, ephemeralLabel, wildcardRoute, appName, requestTimeout)
-	}
+	})
+
+	handler(w, req)
+}
+
+// buildRouteHandler composes the per-request middleware chain around serve.
+// Each call wraps the previous handler, so the last one applied runs first and
+// the execution order is WAF → maintenance → auth → serve.
+//
+// Both boundaries are load-bearing. WAF stays outermost so a maintenance window
+// doesn't become an open window for scanners. Maintenance runs ahead of auth
+// because a holding page is public information: otherwise a visitor completes a
+// full round trip to an identity provider only to be told the site is down, and
+// an API client gets a 401 when the honest answer is 503.
+//
+// The order lives here, rather than inline, so it is something a test can hold
+// onto — see TestMiddlewareChainOrder.
+func (h *Server) buildRouteHandler(route *ingress_v1alpha.HttpRoute, appName *string, serve http.HandlerFunc) http.HandlerFunc {
+	handler := serve
 
 	handler = h.authMiddleware(route, handler)
 
+	handler = h.maintenanceMiddleware(route, appName, handler)
+
 	handler = h.wafMiddleware(route, handler)
 
-	handler(w, req)
+	return handler
 }
 
 // lookupEphemeralRoute checks whether the request host is an ephemeral

--- a/servers/httpingress/maintenance.go
+++ b/servers/httpingress/maintenance.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"html/template"
 	"math"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -36,9 +37,11 @@ func (s *Server) maintenanceMiddleware(route *ingress_v1alpha.HttpRoute, appName
 }
 
 func (s *Server) serveMaintenance(w http.ResponseWriter, r *http.Request, appID entity.Id, appName *string, maint ingress_v1alpha.Maintenance) {
-	display := s.maintenanceAppName(r, appID)
+	// Metrics want the app; the visitor wants the site they opened. The app's
+	// name is an operator's identifier, so "payments-api is down" means nothing
+	// to someone who typed shop.example.com.
 	if appName != nil && *appName == "" {
-		*appName = display
+		*appName = s.maintenanceAppName(r, appID)
 	}
 
 	w.Header().Set("Cache-Control", "no-store")
@@ -71,13 +74,13 @@ func (s *Server) serveMaintenance(w http.ResponseWriter, r *http.Request, appID 
 	w.WriteHeader(http.StatusServiceUnavailable)
 
 	data := struct {
-		AppName string
-		Reason  string
-		BackAt  string
+		Site   string
+		Reason string
+		BackAt string
 	}{
-		AppName: display,
-		Reason:  maint.Reason,
-		BackAt:  formatBackAt(maint.BackAt),
+		Site:   visitorHost(r),
+		Reason: maint.Reason,
+		BackAt: formatBackAt(maint.BackAt),
 	}
 
 	if err := maintenancePage.Execute(w, data); err != nil {
@@ -85,9 +88,26 @@ func (s *Server) serveMaintenance(w http.ResponseWriter, r *http.Request, appID 
 	}
 }
 
-// maintenanceAppName resolves the app's display name for the holding page. It
-// returns an empty string on any failure — the page renders without a name
-// rather than turning a planned outage into a 500.
+// visitorHost is the hostname the visitor actually opened, without its port.
+//
+// It reads the request rather than the route because the route's host can be a
+// pattern or nothing at all: a wildcard route stores "*.example.com" and the
+// default route stores no host, while the request always carries the concrete
+// name. That also makes preview subdomains name themselves correctly.
+func visitorHost(r *http.Request) string {
+	host := r.Host
+
+	if stripped, _, err := net.SplitHostPort(host); err == nil {
+		host = stripped
+	}
+
+	return host
+}
+
+// maintenanceAppName resolves the app's name for request metrics, so a window's
+// traffic stays attributed to the app instead of landing in "unknown". It
+// returns an empty string on any failure — a lookup problem must not turn a
+// planned outage into a 500.
 func (s *Server) maintenanceAppName(r *http.Request, appID entity.Id) string {
 	if entity.Empty(appID) {
 		return ""
@@ -218,7 +238,7 @@ var maintenancePage = template.Must(template.New("maintenance").Parse(`<!DOCTYPE
 </head>
 <body>
 <main>
-<h1>{{if .AppName}}{{.AppName}} is down for maintenance{{else}}Down for maintenance{{end}}</h1>
+<h1>{{if .Site}}{{.Site}} is down for maintenance{{else}}Down for maintenance{{end}}</h1>
 {{if .Reason}}<p>{{.Reason}}</p>{{end}}
 {{if .BackAt}}<p class="muted">Expected back at {{.BackAt}}.</p>{{else}}<p class="muted">Please check back shortly.</p>{{end}}
 </main>

--- a/servers/httpingress/maintenance.go
+++ b/servers/httpingress/maintenance.go
@@ -1,0 +1,227 @@
+package httpingress
+
+import (
+	"encoding/json"
+	"html/template"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"miren.dev/runtime/api/core/core_v1alpha"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+)
+
+// maintenanceMiddleware short-circuits requests for a route an operator has
+// taken out of service, serving a holding page instead of proxying to the app.
+//
+// It sits between the WAF filter and the auth wrapper. WAF stays outermost so a
+// maintenance window doesn't become an open window for scanners. Maintenance
+// runs ahead of auth because a holding page is public information: otherwise a
+// visitor completes a full round trip to an identity provider only to be told
+// the site is down, and an API client gets a 401 when the honest answer is 503.
+func (s *Server) maintenanceMiddleware(route *ingress_v1alpha.HttpRoute, appName *string, next http.HandlerFunc) http.HandlerFunc {
+	if route == nil || route.Maintenance.Empty() {
+		return next
+	}
+
+	maint := route.Maintenance
+	appID := route.App
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.serveMaintenance(w, r, appID, appName, maint)
+	}
+}
+
+func (s *Server) serveMaintenance(w http.ResponseWriter, r *http.Request, appID entity.Id, appName *string, maint ingress_v1alpha.Maintenance) {
+	display := s.maintenanceAppName(r, appID)
+	if appName != nil && *appName == "" {
+		*appName = display
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+
+	if secs, ok := retryAfterSeconds(maint.BackAt, time.Now()); ok {
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
+	}
+
+	if prefersJSON(r.Header.Get("Accept")) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+
+		body := struct {
+			Error  string `json:"error"`
+			Reason string `json:"reason,omitempty"`
+			BackAt string `json:"back_at,omitempty"`
+		}{
+			Error:  "maintenance",
+			Reason: maint.Reason,
+			BackAt: maint.BackAt,
+		}
+
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			s.Log.Debug("failed to write maintenance JSON response", "error", err)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusServiceUnavailable)
+
+	data := struct {
+		AppName string
+		Reason  string
+		BackAt  string
+	}{
+		AppName: display,
+		Reason:  maint.Reason,
+		BackAt:  formatBackAt(maint.BackAt),
+	}
+
+	if err := maintenancePage.Execute(w, data); err != nil {
+		s.Log.Debug("failed to render maintenance page", "error", err)
+	}
+}
+
+// maintenanceAppName resolves the app's display name for the holding page. It
+// returns an empty string on any failure — the page renders without a name
+// rather than turning a planned outage into a 500.
+func (s *Server) maintenanceAppName(r *http.Request, appID entity.Id) string {
+	if entity.Empty(appID) {
+		return ""
+	}
+
+	gr, err := s.eac.Get(r.Context(), appID.String())
+	if err != nil {
+		s.Log.Debug("failed to look up app for maintenance page", "error", err, "app", appID)
+		return ""
+	}
+
+	var md core_v1alpha.Metadata
+	md.Decode(gr.Entity().Entity())
+
+	return md.Name
+}
+
+// retryAfterSeconds converts a stored RFC 3339 return time into the
+// delta-seconds form of Retry-After. A time that doesn't parse, or that has
+// already passed, yields no header at all rather than a misleading one.
+func retryAfterSeconds(backAt string, now time.Time) (int, bool) {
+	if backAt == "" {
+		return 0, false
+	}
+
+	t, err := time.Parse(time.RFC3339, backAt)
+	if err != nil {
+		return 0, false
+	}
+
+	d := t.Sub(now)
+	if d <= 0 {
+		return 0, false
+	}
+
+	return int(math.Ceil(d.Seconds())), true
+}
+
+// formatBackAt renders the return time for the holding page. Visitors can be
+// anywhere, so it's shown in UTC and labeled as such rather than silently
+// rendered in the server's zone.
+func formatBackAt(backAt string) string {
+	if backAt == "" {
+		return ""
+	}
+
+	t, err := time.Parse(time.RFC3339, backAt)
+	if err != nil {
+		return ""
+	}
+
+	return t.UTC().Format("15:04 UTC on 2 January 2006")
+}
+
+// prefersJSON reports whether the client's Accept header ranks JSON above HTML.
+// An absent or unparseable header means HTML, which is what a browser gets.
+func prefersJSON(accept string) bool {
+	var jsonQ, htmlQ float64
+
+	for _, part := range strings.Split(accept, ",") {
+		media, q := parseMediaRange(part)
+		if media == "" {
+			continue
+		}
+
+		switch {
+		case media == "application/json" || strings.HasSuffix(media, "+json"):
+			jsonQ = math.Max(jsonQ, q)
+		case media == "text/html" || media == "application/xhtml+xml":
+			htmlQ = math.Max(htmlQ, q)
+		}
+	}
+
+	return jsonQ > htmlQ
+}
+
+func parseMediaRange(part string) (string, float64) {
+	fields := strings.Split(strings.TrimSpace(part), ";")
+
+	media := strings.ToLower(strings.TrimSpace(fields[0]))
+	if media == "" {
+		return "", 0
+	}
+
+	q := 1.0
+	for _, param := range fields[1:] {
+		name, value, ok := strings.Cut(param, "=")
+		if !ok || strings.ToLower(strings.TrimSpace(name)) != "q" {
+			continue
+		}
+		if parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64); err == nil {
+			q = parsed
+		}
+	}
+
+	return media, q
+}
+
+// The page is entirely self-contained — inline styles, no external requests —
+// because it has to render on a network where the app itself doesn't.
+var maintenancePage = template.Must(template.New("maintenance").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Down for maintenance</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    background: #f6f7f9;
+    color: #1f2430;
+  }
+  main { max-width: 34rem; padding: 2rem; text-align: center; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 1rem; }
+  p { font-size: 1.05rem; line-height: 1.6; margin: 0 0 0.75rem; }
+  .muted { color: #5b6472; font-size: 0.95rem; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #14171c; color: #e7eaef; }
+    .muted { color: #9aa3b2; }
+  }
+</style>
+</head>
+<body>
+<main>
+<h1>{{if .AppName}}{{.AppName}} is down for maintenance{{else}}Down for maintenance{{end}}</h1>
+{{if .Reason}}<p>{{.Reason}}</p>{{end}}
+{{if .BackAt}}<p class="muted">Expected back at {{.BackAt}}.</p>{{else}}<p class="muted">Please check back shortly.</p>{{end}}
+</main>
+</body>
+</html>
+`))

--- a/servers/httpingress/maintenance_test.go
+++ b/servers/httpingress/maintenance_test.go
@@ -1,0 +1,223 @@
+package httpingress
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+)
+
+func newTestMaintenanceServer() *Server {
+	return &Server{Log: slog.Default()}
+}
+
+// runMaintenance drives the middleware for a route with no app reference, so
+// the app-name lookup short circuits and no entity client is needed.
+func runMaintenance(t *testing.T, maint ingress_v1alpha.Maintenance, accept string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	s := newTestMaintenanceServer()
+	route := &ingress_v1alpha.HttpRoute{Maintenance: maint}
+
+	next := func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("request reached the app while the route was in maintenance")
+	}
+
+	req := httptest.NewRequest("GET", "http://app.example.com/", nil)
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+
+	rec := httptest.NewRecorder()
+	s.maintenanceMiddleware(route, nil, next)(rec, req)
+
+	return rec
+}
+
+func TestMaintenanceMiddlewarePassesThroughWhenNotSet(t *testing.T) {
+	s := newTestMaintenanceServer()
+
+	route := &ingress_v1alpha.HttpRoute{Host: "app.example.com"}
+	called := false
+	next := func(w http.ResponseWriter, r *http.Request) { called = true }
+
+	handler := s.maintenanceMiddleware(route, nil, next)
+
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequest("GET", "http://app.example.com/", nil))
+
+	assert.True(t, called, "next handler should run for a route that isn't in maintenance")
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMaintenanceMiddlewareServesHoldingPage(t *testing.T) {
+	rec := runMaintenance(t, ingress_v1alpha.Maintenance{
+		Reason:    "Upgrading the database",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}, "text/html")
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+
+	body := rec.Body.String()
+	assert.Contains(t, body, "Down for maintenance")
+	assert.Contains(t, body, "Upgrading the database")
+}
+
+func TestMaintenanceMiddlewareEscapesOperatorReason(t *testing.T) {
+	rec := runMaintenance(t, ingress_v1alpha.Maintenance{
+		Reason: `<script>alert("xss")</script>`,
+	}, "text/html")
+
+	body := rec.Body.String()
+	assert.NotContains(t, body, "<script>alert")
+	assert.Contains(t, body, "&lt;script&gt;")
+}
+
+func TestMaintenanceMiddlewareRetryAfter(t *testing.T) {
+	t.Run("future back_at sets the header", func(t *testing.T) {
+		backAt := time.Now().Add(30 * time.Minute).UTC().Format(time.RFC3339)
+
+		rec := runMaintenance(t, ingress_v1alpha.Maintenance{BackAt: backAt}, "text/html")
+
+		secs, err := strconv.Atoi(rec.Header().Get("Retry-After"))
+		require.NoError(t, err)
+		assert.Greater(t, secs, 1700)
+		assert.LessOrEqual(t, secs, 1800)
+		assert.Contains(t, rec.Body.String(), "Expected back at")
+	})
+
+	t.Run("past back_at omits the header", func(t *testing.T) {
+		backAt := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+
+		rec := runMaintenance(t, ingress_v1alpha.Maintenance{BackAt: backAt}, "text/html")
+
+		assert.Empty(t, rec.Header().Get("Retry-After"))
+	})
+
+	t.Run("unparseable back_at omits the header", func(t *testing.T) {
+		rec := runMaintenance(t, ingress_v1alpha.Maintenance{BackAt: "soon"}, "text/html")
+
+		assert.Empty(t, rec.Header().Get("Retry-After"))
+		assert.Contains(t, rec.Body.String(), "Please check back shortly")
+	})
+
+	t.Run("no back_at omits the header", func(t *testing.T) {
+		rec := runMaintenance(t, ingress_v1alpha.Maintenance{Reason: "migrating"}, "text/html")
+
+		assert.Empty(t, rec.Header().Get("Retry-After"))
+	})
+}
+
+func TestMaintenanceMiddlewareServesJSON(t *testing.T) {
+	backAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+	rec := runMaintenance(t, ingress_v1alpha.Maintenance{
+		Reason: "Upgrading the database",
+		BackAt: backAt,
+	}, "application/json")
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+
+	var body struct {
+		Error  string `json:"error"`
+		Reason string `json:"reason"`
+		BackAt string `json:"back_at"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	assert.Equal(t, "maintenance", body.Error)
+	assert.Equal(t, "Upgrading the database", body.Reason)
+	assert.Equal(t, backAt, body.BackAt)
+}
+
+func TestPrefersJSON(t *testing.T) {
+	tests := []struct {
+		accept string
+		want   bool
+	}{
+		{"", false},
+		{"*/*", false},
+		{"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", false},
+		{"application/json", true},
+		{"application/json, text/plain, */*", true},
+		{"application/vnd.api+json", true},
+		{"text/html,application/json;q=0.9", false},
+		{"application/json;q=0.9,text/html;q=0.8", true},
+		{"application/json;q=bogus", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.accept, func(t *testing.T) {
+			assert.Equal(t, tt.want, prefersJSON(tt.accept))
+		})
+	}
+}
+
+// TestMiddlewareChainOrder pins the two ordering decisions in
+// buildRouteHandler. The chain is three adjacent statements, so reordering it
+// is a one-line accident that compiles and passes everything else.
+func TestMiddlewareChainOrder(t *testing.T) {
+	maint := ingress_v1alpha.Maintenance{
+		Reason:    "Upgrading the database",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	t.Run("maintenance answers before auth", func(t *testing.T) {
+		// A real (empty) entity client, so that if auth did run first this
+		// fails on the assertion below rather than panicking on a nil client.
+		inmem, cleanup := testutils.NewInMemEntityServer(t)
+		defer cleanup()
+
+		s := newTestMaintenanceServer()
+		s.eac = inmem.EAC
+
+		// A protected route in maintenance. If auth ran first it would try to
+		// resolve this provider and send the visitor to a login, when the
+		// honest answer is that the site is deliberately down.
+		route := &ingress_v1alpha.HttpRoute{
+			AuthProvider: entity.Id("oidc_provider/corp-sso"),
+			Maintenance:  maint,
+		}
+
+		serve := func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("request reached the app while the route was in maintenance")
+		}
+
+		rec := httptest.NewRecorder()
+		s.buildRouteHandler(route, nil, serve)(rec, httptest.NewRequest("GET", "http://app.example.com/", nil))
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		assert.Contains(t, rec.Body.String(), "Upgrading the database",
+			"an unauthenticated visitor should get the holding page, not a login")
+	})
+
+	t.Run("WAF still filters a route in maintenance", func(t *testing.T) {
+		s := newTestWAFServer()
+
+		route := newTestRoute("waf-l1", 1, s)
+		route.Maintenance = maint
+
+		serve := func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("request reached the app while the route was in maintenance")
+		}
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "http://app.example.com/?id=1%20OR%201=1--", nil)
+		s.buildRouteHandler(route, nil, serve)(rec, req)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code,
+			"a maintenance window must not become an open window for scanners")
+	})
+}

--- a/servers/httpingress/maintenance_test.go
+++ b/servers/httpingress/maintenance_test.go
@@ -43,6 +43,72 @@ func runMaintenance(t *testing.T, maint ingress_v1alpha.Maintenance, accept stri
 	return rec
 }
 
+// TestMaintenancePageNamesTheHostVisited pins the heading to the name the
+// visitor typed. The route's own host is the wrong source: a wildcard route
+// stores a pattern and the default route stores nothing, so both would put
+// something meaningless in front of a person.
+func TestMaintenancePageNamesTheHostVisited(t *testing.T) {
+	tests := []struct {
+		name      string
+		routeHost string
+		requested string
+		want      string
+	}{
+		{
+			name:      "plain route",
+			routeHost: "app.example.com",
+			requested: "http://app.example.com/",
+			want:      "app.example.com",
+		},
+		{
+			name:      "wildcard route names the concrete subdomain",
+			routeHost: "*.example.com",
+			requested: "http://shop.example.com/",
+			want:      "shop.example.com",
+		},
+		{
+			name:      "preview subdomain names itself",
+			routeHost: "app.example.com",
+			requested: "http://feat-x.app.example.com/",
+			want:      "feat-x.app.example.com",
+		},
+		{
+			name:      "default route has no host of its own",
+			routeHost: "",
+			requested: "http://anything.example.com/",
+			want:      "anything.example.com",
+		},
+		{
+			name:      "port is stripped",
+			routeHost: "app.example.com",
+			requested: "http://app.example.com:8443/",
+			want:      "app.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestMaintenanceServer()
+
+			route := &ingress_v1alpha.HttpRoute{
+				Host:        tt.routeHost,
+				Maintenance: ingress_v1alpha.Maintenance{Reason: "Upgrading the database"},
+			}
+
+			next := func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("request reached the app while the route was in maintenance")
+			}
+
+			rec := httptest.NewRecorder()
+			s.maintenanceMiddleware(route, nil, next)(rec, httptest.NewRequest("GET", tt.requested, nil))
+
+			body := rec.Body.String()
+			assert.Contains(t, body, tt.want+" is down for maintenance")
+			assert.NotContains(t, body, ":8443", "the port has no business on the page")
+		})
+	}
+}
+
 func TestMaintenanceMiddlewarePassesThroughWhenNotSet(t *testing.T) {
 	s := newTestMaintenanceServer()
 

--- a/servers/routes/server.go
+++ b/servers/routes/server.go
@@ -51,25 +51,19 @@ func (s *Server) SetMaintenance(ctx context.Context, state *ingress_v1alpha.Rout
 		return err
 	}
 
-	maint := ingress_v1alpha.Maintenance{
-		Reason:    args.Reason(),
-		BackAt:    backAt,
-		StartedAt: route.Maintenance.StartedAt,
-		StartedBy: route.Maintenance.StartedBy,
-	}
-
-	// A repeat call is how an operator revises the reason or pushes out the
-	// estimate mid-window. Restamping the start would then misreport how long
-	// traffic has actually been held, which is the one number worth having
-	// afterwards, so only a route that was serving gets a fresh stamp.
-	if route.Maintenance.Empty() {
-		maint.StartedAt = time.Now().UTC().Format(time.RFC3339)
-		maint.StartedBy = operatorIdentity(ctx)
-	}
-
-	if _, err := s.IC.SetRouteMaintenance(ctx, route, maint); err != nil {
+	// These two are a proposal, not a decision. Whether they get recorded
+	// depends on the route's state at the moment of the write, which only the
+	// mutation can see: a repeat call mid-window has to leave the original
+	// opener and start time alone, or the record stops answering the one
+	// question worth asking afterwards, which is how long traffic was held.
+	updated, err := s.IC.SetRouteMaintenance(ctx, route,
+		args.Reason(), backAt,
+		time.Now().UTC().Format(time.RFC3339), operatorIdentity(ctx))
+	if err != nil {
 		return fmt.Errorf("failed to put route into maintenance: %w", err)
 	}
+
+	maint := updated.Maintenance
 
 	s.Log.Info("route entered maintenance",
 		"route", label, "reason", maint.Reason, "back_at", maint.BackAt, "by", maint.StartedBy)

--- a/servers/routes/server.go
+++ b/servers/routes/server.go
@@ -1,0 +1,177 @@
+// Package routes serves operator controls over existing HTTP routes.
+//
+// Routes are otherwise managed straight through the entity store, so this
+// package is deliberately narrow: it exists for the operations where the server
+// has to establish something the caller cannot be trusted to assert about
+// itself. Maintenance windows record who opened them and when, and both of
+// those are only worth reading if the server stamped them.
+package routes
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+type Server struct {
+	Log *slog.Logger
+	IC  *ingress.Client
+}
+
+var _ ingress_v1alpha.Routes = (*Server)(nil)
+
+func NewServer(log *slog.Logger, ic *ingress.Client) *Server {
+	return &Server{
+		Log: log.With("module", "routes"),
+		IC:  ic,
+	}
+}
+
+func (s *Server) SetMaintenance(ctx context.Context, state *ingress_v1alpha.RoutesSetMaintenance) error {
+	args := state.Args()
+
+	// Taking a hostname out of service is an operator action on shared
+	// infrastructure, not something an app does to itself.
+	if app := rpc.BoundApp(ctx); app != "" {
+		return rpc.AppAccessError(ctx, app)
+	}
+
+	backAt, err := validateBackAt(args.BackAt(), time.Now())
+	if err != nil {
+		return err
+	}
+
+	route, label, err := s.resolve(ctx, args.Host(), args.DefaultRoute())
+	if err != nil {
+		return err
+	}
+
+	maint := ingress_v1alpha.Maintenance{
+		Reason:    args.Reason(),
+		BackAt:    backAt,
+		StartedAt: route.Maintenance.StartedAt,
+		StartedBy: route.Maintenance.StartedBy,
+	}
+
+	// A repeat call is how an operator revises the reason or pushes out the
+	// estimate mid-window. Restamping the start would then misreport how long
+	// traffic has actually been held, which is the one number worth having
+	// afterwards, so only a route that was serving gets a fresh stamp.
+	if route.Maintenance.Empty() {
+		maint.StartedAt = time.Now().UTC().Format(time.RFC3339)
+		maint.StartedBy = operatorIdentity(ctx)
+	}
+
+	if _, err := s.IC.SetRouteMaintenance(ctx, route, maint); err != nil {
+		return fmt.Errorf("failed to put route into maintenance: %w", err)
+	}
+
+	s.Log.Info("route entered maintenance",
+		"route", label, "reason", maint.Reason, "back_at", maint.BackAt, "by", maint.StartedBy)
+
+	results := state.Results()
+	results.SetRoute(label)
+	results.SetReason(maint.Reason)
+	results.SetBackAt(maint.BackAt)
+	results.SetStartedAt(maint.StartedAt)
+	results.SetStartedBy(maint.StartedBy)
+
+	return nil
+}
+
+func (s *Server) ClearMaintenance(ctx context.Context, state *ingress_v1alpha.RoutesClearMaintenance) error {
+	args := state.Args()
+
+	if app := rpc.BoundApp(ctx); app != "" {
+		return rpc.AppAccessError(ctx, app)
+	}
+
+	route, label, err := s.resolve(ctx, args.Host(), args.DefaultRoute())
+	if err != nil {
+		return err
+	}
+
+	changed := !route.Maintenance.Empty()
+
+	if changed {
+		if _, err := s.IC.ClearRouteMaintenance(ctx, route); err != nil {
+			return fmt.Errorf("failed to bring route out of maintenance: %w", err)
+		}
+
+		s.Log.Info("route left maintenance", "route", label)
+	}
+
+	results := state.Results()
+	results.SetRoute(label)
+	results.SetChanged(changed)
+
+	return nil
+}
+
+// resolve turns a hostname, or the default-route flag, into the route entity to
+// act on plus a label to show the operator.
+func (s *Server) resolve(ctx context.Context, host string, isDefault bool) (*ingress_v1alpha.HttpRoute, string, error) {
+	if isDefault {
+		route, err := s.IC.LookupDefault(ctx)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to lookup default route: %w", err)
+		}
+		if route == nil {
+			return nil, "", fmt.Errorf("no default route configured")
+		}
+		return route, "default", nil
+	}
+
+	if host == "" {
+		return nil, "", fmt.Errorf("either a hostname or the default route must be specified")
+	}
+
+	route, err := s.IC.Lookup(ctx, host)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to lookup route: %w", err)
+	}
+	if route == nil {
+		return nil, "", fmt.Errorf("route not found for host: %s", host)
+	}
+
+	return route, host, nil
+}
+
+// validateBackAt checks the expected-return time the caller sent and normalizes
+// it to UTC. It has to parse, and it has to be in the future: a time that has
+// already passed puts a stale estimate on the holding page and produces no
+// Retry-After at all, and there is no way to arrive at one on purpose.
+func validateBackAt(backAt string, now time.Time) (string, error) {
+	if backAt == "" {
+		return "", nil
+	}
+
+	t, err := time.Parse(time.RFC3339, backAt)
+	if err != nil {
+		return "", fmt.Errorf("back_at must be an RFC 3339 timestamp, got %q", backAt)
+	}
+
+	if !t.After(now) {
+		return "", fmt.Errorf("back_at must be in the future, got %s", t.UTC().Format(time.RFC3339))
+	}
+
+	return t.UTC().Format(time.RFC3339), nil
+}
+
+// operatorIdentity names the authenticated caller for the maintenance record.
+// It reads the identity the server established rather than anything the client
+// sent, which is the whole reason this call is an RPC instead of a direct
+// entity write.
+func operatorIdentity(ctx context.Context) string {
+	identity := rpc.IdentityFromContext(ctx)
+	if identity == nil {
+		return ""
+	}
+
+	return identity.Subject
+}

--- a/servers/routes/server_test.go
+++ b/servers/routes/server_test.go
@@ -86,6 +86,48 @@ func TestSetMaintenanceKeepsTheOriginalStartOnRepeat(t *testing.T) {
 	assert.Equal(t, backAt, second.BackAt())
 }
 
+// TestSetMaintenanceKeepsTheFirstOpenerUnderInterleaving covers two operators
+// opening a window at the same moment.
+//
+// Both read the route while it is still serving, so both believe they are the
+// first and both carry a fresh stamp. One write lands; the other must notice
+// the route is now in maintenance and keep the first operator's stamp rather
+// than its own. The stale route value below is exactly what the losing caller
+// holds: a snapshot taken before the other write landed.
+func TestSetMaintenanceKeepsTheFirstOpenerUnderInterleaving(t *testing.T) {
+	_, ic := newTestServer(t)
+
+	ctx := context.Background()
+
+	stale, err := ic.Lookup(ctx, testHost)
+	require.NoError(t, err)
+	require.True(t, stale.Maintenance.Empty(), "both callers start from a serving route")
+
+	_, err = ic.SetRouteMaintenance(ctx, stale,
+		"first operator's window", "", "2026-08-12T10:00:00Z", "evan@miren.dev")
+	require.NoError(t, err)
+
+	// The second caller writes from its pre-existing snapshot, still showing an
+	// empty component, and proposes its own stamp.
+	second, err := ic.SetRouteMaintenance(ctx, stale,
+		"second operator's window", "", "2026-08-12T10:00:05Z", "someone-else@miren.dev")
+	require.NoError(t, err)
+
+	assert.Equal(t, "evan@miren.dev", second.Maintenance.StartedBy,
+		"the window belongs to whoever opened it, not to whoever wrote last")
+	assert.Equal(t, "2026-08-12T10:00:00Z", second.Maintenance.StartedAt,
+		"the clock started when the first write landed")
+
+	// The reason is not part of the preservation: a later call is how an
+	// operator revises it, so the newest one wins.
+	assert.Equal(t, "second operator's window", second.Maintenance.Reason)
+
+	stored, err := ic.Lookup(ctx, testHost)
+	require.NoError(t, err)
+	assert.Equal(t, "evan@miren.dev", stored.Maintenance.StartedBy)
+	assert.Equal(t, "2026-08-12T10:00:00Z", stored.Maintenance.StartedAt)
+}
+
 func TestSetMaintenanceStampsAfreshAfterClearing(t *testing.T) {
 	client, _ := newTestServer(t)
 

--- a/servers/routes/server_test.go
+++ b/servers/routes/server_test.go
@@ -1,0 +1,205 @@
+package routes
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
+	"miren.dev/runtime/api/ingress"
+	"miren.dev/runtime/api/ingress/ingress_v1alpha"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
+	"miren.dev/runtime/pkg/rpc"
+)
+
+const testHost = "app.example.com"
+
+func newTestServer(t *testing.T) (*ingress_v1alpha.RoutesClient, *ingress.Client) {
+	t.Helper()
+
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	t.Cleanup(cleanup)
+
+	entities := rpc.LocalClient(entityserver_v1alpha.AdaptEntityAccess(inmem.Server))
+	ic := ingress.NewClient(slog.Default(), entities)
+
+	_, err := ic.SetRoute(context.Background(), testHost, entity.Id("app/web"))
+	require.NoError(t, err)
+
+	srv := NewServer(slog.Default(), ic)
+
+	return ingress_v1alpha.NewRoutesClient(rpc.LocalClient(ingress_v1alpha.AdaptRoutes(srv))), ic
+}
+
+// operatorContext stands in for a human operator on the cert plane, which is
+// the only caller shape allowed to reach these methods.
+func operatorContext(subject string) context.Context {
+	return rpc.ContextWithIdentity(context.Background(), &rpc.Identity{
+		Subject: subject,
+		Method:  rpc.AuthMethodCert,
+	})
+}
+
+func TestSetMaintenanceStampsTheAuthenticatedOperator(t *testing.T) {
+	client, ic := newTestServer(t)
+
+	ctx := operatorContext("evan@miren.dev")
+
+	res, err := client.SetMaintenance(ctx, testHost, false, "Upgrading the database", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, testHost, res.Route())
+	assert.Equal(t, "Upgrading the database", res.Reason())
+	assert.Equal(t, "evan@miren.dev", res.StartedBy(),
+		"started_by must come from the authenticated identity, not from anything the caller sent")
+	assert.NotEmpty(t, res.StartedAt())
+
+	route, err := ic.Lookup(ctx, testHost)
+	require.NoError(t, err)
+	assert.Equal(t, "evan@miren.dev", route.Maintenance.StartedBy)
+	assert.Equal(t, "Upgrading the database", route.Maintenance.Reason)
+}
+
+func TestSetMaintenanceKeepsTheOriginalStartOnRepeat(t *testing.T) {
+	client, _ := newTestServer(t)
+
+	first, err := client.SetMaintenance(operatorContext("evan@miren.dev"), testHost, false, "Migrating", "")
+	require.NoError(t, err)
+
+	// Revising the reason mid-window must not restart the clock, and must not
+	// reassign the window to whoever happened to run the second command.
+	// Derived rather than hardcoded: back_at has to be in the future, so a
+	// fixed date would turn this into a test that starts failing on its own.
+	backAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second).Format(time.RFC3339)
+
+	second, err := client.SetMaintenance(operatorContext("someone-else@miren.dev"),
+		testHost, false, "Migrating, taking longer than expected", backAt)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.StartedAt(), second.StartedAt())
+	assert.Equal(t, "evan@miren.dev", second.StartedBy())
+	assert.Equal(t, "Migrating, taking longer than expected", second.Reason())
+	assert.Equal(t, backAt, second.BackAt())
+}
+
+func TestSetMaintenanceStampsAfreshAfterClearing(t *testing.T) {
+	client, _ := newTestServer(t)
+
+	_, err := client.SetMaintenance(operatorContext("evan@miren.dev"), testHost, false, "First window", "")
+	require.NoError(t, err)
+
+	_, err = client.ClearMaintenance(operatorContext("evan@miren.dev"), testHost, false)
+	require.NoError(t, err)
+
+	second, err := client.SetMaintenance(operatorContext("someone-else@miren.dev"), testHost, false, "Second window", "")
+	require.NoError(t, err)
+
+	// Deliberately not asserting the timestamp moved: RFC 3339 is second
+	// resolution and both windows open in the same second here, so that
+	// comparison would be a coin flip. The identity is the part that carries
+	// the meaning, and it only changes on a genuinely new window.
+	assert.Equal(t, "someone-else@miren.dev", second.StartedBy(),
+		"a new window belongs to whoever opened it")
+}
+
+func TestClearMaintenanceIsIdempotent(t *testing.T) {
+	client, ic := newTestServer(t)
+
+	ctx := operatorContext("evan@miren.dev")
+
+	_, err := client.SetMaintenance(ctx, testHost, false, "Migrating", "")
+	require.NoError(t, err)
+
+	first, err := client.ClearMaintenance(ctx, testHost, false)
+	require.NoError(t, err)
+	assert.True(t, first.Changed())
+
+	second, err := client.ClearMaintenance(ctx, testHost, false)
+	require.NoError(t, err)
+	assert.False(t, second.Changed(), "clearing an already-serving route reports no change rather than failing")
+
+	route, err := ic.Lookup(ctx, testHost)
+	require.NoError(t, err)
+	assert.True(t, route.Maintenance.Empty(),
+		"clearing drops the whole record, so a stale reason can't linger on a serving route")
+}
+
+func TestMaintenanceRejectsAppScopedCallers(t *testing.T) {
+	client, _ := newTestServer(t)
+
+	// A workload token is bound to one app. Maintenance takes a hostname out of
+	// service for everyone, so an app must not be able to reach it.
+	ctx := rpc.ContextWithIdentity(context.Background(), &rpc.Identity{
+		Subject:  "org:o:app:web:sandbox:sb-1",
+		Method:   rpc.AuthMethodWorkload,
+		Metadata: map[string]any{"app": "web"},
+	})
+
+	_, err := client.SetMaintenance(ctx, testHost, false, "Migrating", "")
+	assert.Error(t, err)
+
+	_, err = client.ClearMaintenance(ctx, testHost, false)
+	assert.Error(t, err)
+}
+
+func TestMaintenanceReportsUnknownRoutes(t *testing.T) {
+	client, _ := newTestServer(t)
+
+	ctx := operatorContext("evan@miren.dev")
+
+	_, err := client.SetMaintenance(ctx, "nope.example.com", false, "Migrating", "")
+	assert.ErrorContains(t, err, "nope.example.com")
+
+	_, err = client.SetMaintenance(ctx, "", true, "Cluster upgrade", "")
+	assert.ErrorContains(t, err, "no default route configured")
+}
+
+func TestSetMaintenanceRejectsUnusableReturnTimes(t *testing.T) {
+	client, ic := newTestServer(t)
+
+	ctx := operatorContext("evan@miren.dev")
+
+	_, err := client.SetMaintenance(ctx, testHost, false, "Migrating", "2020-01-01T00:00:00Z")
+	assert.ErrorContains(t, err, "must be in the future")
+
+	_, err = client.SetMaintenance(ctx, testHost, false, "Migrating", "half past three")
+	assert.ErrorContains(t, err, "RFC 3339")
+
+	// A rejected call must not have opened a window on its way to failing.
+	route, err := ic.Lookup(ctx, testHost)
+	require.NoError(t, err)
+	assert.True(t, route.Maintenance.Empty())
+}
+
+func TestSetMaintenanceNormalizesTheReturnTime(t *testing.T) {
+	client, _ := newTestServer(t)
+
+	// An offset the caller happened to send, rather than UTC. Storing it as
+	// given would leave route show and the holding page rendering the same
+	// instant differently depending on who set it. Both sides are derived from
+	// the same future instant so this cannot expire.
+	future := time.Now().Add(24 * time.Hour).Truncate(time.Second)
+	sent := future.In(time.FixedZone("PDT", -7*60*60)).Format(time.RFC3339)
+
+	res, err := client.SetMaintenance(operatorContext("evan@miren.dev"),
+		testHost, false, "Migrating", sent)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, sent, res.BackAt(), "the offset form should not be what gets stored")
+	assert.Equal(t, future.UTC().Format(time.RFC3339), res.BackAt())
+}
+
+func TestValidateBackAt(t *testing.T) {
+	now := time.Date(2026, 8, 12, 10, 30, 0, 0, time.UTC)
+
+	got, err := validateBackAt("", now)
+	require.NoError(t, err, "no estimate is a legitimate window")
+	assert.Empty(t, got)
+
+	_, err = validateBackAt(now.Format(time.RFC3339), now)
+	assert.Error(t, err, "a return time of exactly now is not in the future")
+}


### PR DESCRIPTION
Taking an app offline for a migration has always meant improvising. Edit DNS and point the hostname at a static page somewhere else. Hand-edit an nginx config in front of the app. Push a deploy that flips a `MAINTENANCE=true` env var the app checks on every request. Or scale to zero and let visitors see a platform error page. All of them are ad-hoc, they touch production at exactly the moment you least want to be improvising, and each one has an "off" path that's a separate sequence of steps you have to remember under pressure.

So now there's `miren route down app.example.com --reason "Upgrading the database"`, and `miren route up` when you're finished.

Maintenance state lives as a small component on the `http_route` entity, and the router short-circuits with a 503 and a holding page instead of proxying. The check sits between the WAF filter and the auth wrapper. Both boundaries are deliberate: a maintenance window shouldn't become an open window for scanners, and a holding page is public information, so a visitor shouldn't have to complete a login round-trip just to be told the site is down (and an API client shouldn't get a 401 when the honest answer is 503). That ordering is three adjacent lines, which is an easy thing to break by accident, so it lives in `buildRouteHandler` with a test that fails if either boundary moves.

Everything else about routes is managed straight through the entity store, and maintenance started out that way too. But the record names who opened the window and when, and neither of those is worth reading if the client is the one who supplied it. So maintenance goes through a narrow `routes` service instead, which stamps the operator from the authenticated identity rather than anything the caller sent. Putting it behind an RPC also gave it somewhere to hold two behaviors that belong on the server: revising the reason mid-window keeps the original start time instead of restarting the clock, and taking a hostname out of service is guarded as an operator action on shared ingress rather than something an app can do to itself.

The thing that makes the window actually useful is what maintenance *doesn't* touch. It's a routing decision and nothing else, so sandboxes keep running and `miren app run -a web -- ./bin/migrate` works fine while the holding page is up. Other hostnames pointing at the same app keep serving. Internal service-to-service calls resolve by app rather than by route, so they're unaffected without any special-casing. Preview subdomains resolve through their base route, so they go down with it, which is what you want given they share the app's database.

Visitors get a 503 with `Cache-Control: no-store` and, if you passed `--back-at`, a `Retry-After`. Getting the status right matters more than it looks: a maintenance window served as a 500, or as a 200 with an apology, is how sites lose search ranking and how on-call gets paged for a planned event. Clients that ask for JSON get JSON rather than having to parse HTML.

The one guardrail worth calling out is on `--default`. That route catches every hostname without one of its own, so it's the widest blast radius available in a single command, and it prompts before it goes. JSON output can't carry a prompt, so there it refuses and tells you to pass `--yes`, rather than quietly becoming the way around the confirmation.

This follows RFD-100, and resolves the open questions it left: a verb pair rather than `--on`/`--off` flags, matching `route protect`/`unprotect` and `runner cordon`/`uncordon`; no `--app` fan-out in v1; a confirmation prompt on `--default`; and a JSON body for clients that ask for one. The bypass credential and operator-supplied HTML stay deferred, as the RFD proposed.

Related: MIR-1111
