### PR TITLE
Verify networking commands before install; document host command needs

### DIFF
--- a/cli/commands/install_requirements.go
+++ b/cli/commands/install_requirements.go
@@ -25,3 +25,27 @@ const systemResourceTolerance = 0.90 // accept down to 90% of the threshold
 func meetsThreshold(observed, threshold int64) bool {
 	return float64(observed) >= float64(threshold)*systemResourceTolerance
 }
+
+// requiredNetCommands lists the external commands the server and runner always
+// shell out to for container networking: iptables for the bridge and sandbox
+// NAT rules, and nft (nftables) for services and NodePorts. Neither ships in the
+// release bundle, so a host missing them fails only later, when networking
+// silently breaks — the install-time check catches it up front instead. Disk and
+// SELinux tooling is deliberately excluded here: it's needed only for optional
+// features and those paths already degrade gracefully.
+func requiredNetCommands() []string {
+	return []string{"iptables", "nft"}
+}
+
+// findMissingCommands returns the subset of names that lookup can't resolve on
+// PATH, preserving input order. lookup is normally exec.LookPath; taking it as a
+// parameter keeps this pure and testable.
+func findMissingCommands(names []string, lookup func(string) (string, error)) []string {
+	var missing []string
+	for _, name := range names {
+		if _, err := lookup(name); err != nil {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}

--- a/cli/commands/install_requirements_test.go
+++ b/cli/commands/install_requirements_test.go
@@ -1,10 +1,39 @@
 package commands
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestFindMissingCommands(t *testing.T) {
+	names := []string{"iptables", "nft"}
+
+	// lookupWith returns a fake exec.LookPath that resolves only the given
+	// commands and reports the rest as missing.
+	lookupWith := func(present ...string) func(string) (string, error) {
+		set := make(map[string]bool, len(present))
+		for _, p := range present {
+			set[p] = true
+		}
+		return func(name string) (string, error) {
+			if set[name] {
+				return "/usr/sbin/" + name, nil
+			}
+			return "", fmt.Errorf("not found")
+		}
+	}
+
+	assert.Empty(t, findMissingCommands(names, lookupWith("iptables", "nft")),
+		"all present should report nothing missing")
+
+	assert.Equal(t, []string{"nft"}, findMissingCommands(names, lookupWith("iptables")),
+		"only the unresolved command should be reported")
+
+	assert.Equal(t, []string{"iptables", "nft"}, findMissingCommands(names, lookupWith()),
+		"none present should report all, in input order")
+}
 
 func TestMeetsThreshold(t *testing.T) {
 	const gib = int64(1024 * 1024 * 1024)

--- a/cli/commands/runner_install.go
+++ b/cli/commands/runner_install.go
@@ -46,16 +46,19 @@ func RunnerInstall(ctx *Context, opts struct {
 		}
 	}
 
-	// Check prerequisites (root + systemd)
+	// Check prerequisites (root + systemd + networking commands)
 	prereqs := checkInstallPrerequisites()
-	if !prereqs.hasRoot || !prereqs.hasSystemd {
+	if !prereqs.hasRoot || !prereqs.hasSystemd || len(prereqs.missingNetCommands) > 0 {
 		printRunnerPrerequisiteGuidance(ctx, prereqs)
 		if !prereqs.hasRoot {
 			return fmt.Errorf("root privileges required")
 		}
-		return fmt.Errorf("systemd not available")
+		if !prereqs.hasSystemd {
+			return fmt.Errorf("systemd not available")
+		}
+		return fmt.Errorf("missing required commands: %s", strings.Join(prereqs.missingNetCommands, ", "))
 	}
-	ctx.Completed("Prerequisites verified (root, systemd)")
+	ctx.Completed("Prerequisites verified (root, systemd, networking tools)")
 
 	// Check system requirements (memory, disk space)
 	if !opts.SkipSystemCheck {
@@ -281,6 +284,10 @@ func printRunnerPrerequisiteGuidance(ctx *Context, prereqs installPrerequisites)
 		ctx.Info("Root privileges are required.")
 		fmt.Println("  Run with sudo: sudo miren runner install")
 		fmt.Println()
+	}
+
+	if len(prereqs.missingNetCommands) > 0 {
+		printMissingNetCommandGuidance(ctx, prereqs.missingNetCommands)
 	}
 
 	if !prereqs.hasSystemd {

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -184,7 +184,7 @@ func printInstallPrerequisiteGuidance(ctx *Context, prereqs installPrerequisites
 	fmt.Println()
 
 	if !prereqs.hasRoot {
-		ctx.Info("Root privileges are required for systemd installation.")
+		ctx.Info("Root privileges are required for installation.")
 		fmt.Println("  Run with sudo: sudo miren server install")
 		fmt.Println()
 	}

--- a/cli/commands/server_install.go
+++ b/cli/commands/server_install.go
@@ -147,6 +147,7 @@ type installPrerequisites struct {
 	hasRoot             bool
 	hasSystemd          bool
 	hasContainerRuntime bool
+	missingNetCommands  []string
 }
 
 // checkInstallPrerequisites checks all prerequisites and returns their status
@@ -156,6 +157,7 @@ func checkInstallPrerequisites() installPrerequisites {
 		hasRoot:             os.Geteuid() == 0,
 		hasSystemd:          checkSystemdAvailable(),
 		hasContainerRuntime: runtimeErr == nil,
+		missingNetCommands:  findMissingCommands(requiredNetCommands(), exec.LookPath),
 	}
 }
 
@@ -178,13 +180,17 @@ func checkSystemdAvailable() bool {
 // printInstallPrerequisiteGuidance prints helpful guidance based on what's available
 func printInstallPrerequisiteGuidance(ctx *Context, prereqs installPrerequisites) {
 	fmt.Println()
-	ctx.Warn("Cannot proceed with systemd installation.")
+	ctx.Warn("Cannot proceed with installation.")
 	fmt.Println()
 
 	if !prereqs.hasRoot {
 		ctx.Info("Root privileges are required for systemd installation.")
 		fmt.Println("  Run with sudo: sudo miren server install")
 		fmt.Println()
+	}
+
+	if len(prereqs.missingNetCommands) > 0 {
+		printMissingNetCommandGuidance(ctx, prereqs.missingNetCommands)
 	}
 
 	if !prereqs.hasSystemd {
@@ -210,6 +216,23 @@ func printInstallPrerequisiteGuidance(ctx *Context, prereqs installPrerequisites
 			fmt.Println("  3. Use your system's init system to manage the miren server process")
 		}
 	}
+}
+
+// printMissingNetCommandGuidance explains which networking commands are missing
+// and how to install them. Miren shells out to these at runtime to configure
+// container networking, so they have to be on the host before the server or
+// runner starts.
+func printMissingNetCommandGuidance(ctx *Context, missing []string) {
+	ctx.Info("Missing required networking commands: %s", strings.Join(missing, ", "))
+	fmt.Println()
+	fmt.Println("  Miren uses iptables and nftables (nft) to configure container networking,")
+	fmt.Println("  services, and NodePorts. Install them with your package manager:")
+	fmt.Println()
+	fmt.Println("    Debian/Ubuntu:  sudo apt install iptables nftables")
+	fmt.Println("    RHEL/Fedora:    sudo dnf install iptables nftables")
+	fmt.Println()
+	fmt.Println("  More details: https://miren.md/system-requirements")
+	fmt.Println()
 }
 
 // ensureReleaseBundlePresent checks whether the full release bundle has been
@@ -326,15 +349,18 @@ func ServerInstall(ctx *Context, opts struct {
 	// Check all prerequisites upfront
 	prereqs := checkInstallPrerequisites()
 
-	if !prereqs.hasRoot || !prereqs.hasSystemd {
+	if !prereqs.hasRoot || !prereqs.hasSystemd || len(prereqs.missingNetCommands) > 0 {
 		printInstallPrerequisiteGuidance(ctx, prereqs)
 		if !prereqs.hasRoot {
 			return fmt.Errorf("root privileges required")
 		}
-		return fmt.Errorf("systemd not available")
+		if !prereqs.hasSystemd {
+			return fmt.Errorf("systemd not available")
+		}
+		return fmt.Errorf("missing required commands: %s", strings.Join(prereqs.missingNetCommands, ", "))
 	}
 
-	ctx.Completed("Prerequisites verified (root, systemd)")
+	ctx.Completed("Prerequisites verified (root, systemd, networking tools)")
 
 	// Check system requirements (memory, disk space)
 	if !opts.SkipSystemCheck {

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -28,6 +28,10 @@ Also open any `node_port` values your apps declare for TCP/UDP services, and the
 
 ## How Miren Configures Firewall Rules
 
+:::info[Both iptables and nftables are required]
+Miren uses `iptables` for the network bridge and per-sandbox NAT, and `nftables` (the `nft` command) for services and NodePorts. Both must be installed on the host — see [System Requirements](/system-requirements#required-host-commands).
+:::
+
 When Miren sets up the network bridge, it installs iptables rules in two chains:
 
 ### FORWARD Chain

--- a/docs/docs/system-requirements.md
+++ b/docs/docs/system-requirements.md
@@ -24,6 +24,7 @@ Beyond hardware, Miren shells out to a couple of Linux networking tools that don
 | Command | Package | Used for |
 |---------|---------|----------|
 | `iptables` | `iptables` | The network bridge and per-sandbox NAT rules |
+| `ip6tables` | `iptables` | The IPv6 bridge rules (ships with the `iptables` package) |
 | `nft` | `nftables` | Services and NodePorts |
 
 Install both with your package manager:

--- a/docs/docs/system-requirements.md
+++ b/docs/docs/system-requirements.md
@@ -17,6 +17,31 @@ Miren needs a Linux server with enough memory and disk space to run its componen
 | **Memory** | 4 GB | 8 GB |
 | **Storage** | 50 GB | 100 GB |
 
+## Required host commands
+
+Beyond hardware, Miren shells out to a couple of Linux networking tools that don't ship in the release bundle. They must be installed on any machine running a Miren server or runner:
+
+| Command | Package | Used for |
+|---------|---------|----------|
+| `iptables` | `iptables` | The network bridge and per-sandbox NAT rules |
+| `nft` | `nftables` | Services and NodePorts |
+
+Install both with your package manager:
+
+```bash
+# Debian/Ubuntu
+sudo apt install iptables nftables
+
+# RHEL/Fedora
+sudo dnf install iptables nftables
+```
+
+`miren server install` and `miren runner install` verify these are present before installing, so a missing tool stops the install with instructions rather than surfacing later as a broken network.
+
+:::note[Extra tooling for optional features]
+Some features reach for more commands, installed automatically or only when you opt in. [Block-device volumes](/managing-disk-space) use disk tooling (`lbdctl`, `mkfs.*`, `blkid`) when a disk is provisioned, and on SELinux-enforcing hosts the installer uses `semanage` and `restorecon` to label the binary. Both paths degrade gracefully if the tools are absent, so you only need them if you use the corresponding feature.
+:::
+
 ## Why these numbers?
 
 ### Memory


### PR DESCRIPTION
## Summary

Closes MIR-1612.

Miren's server and runner shell out to external system commands that aren't in the release bundle and weren't checked or documented. If a host is missing them, networking silently breaks at runtime — hard to diagnose. This adds an install-time preflight check for the always-required networking tools and documents the full host command inventory.

## Changes

**Preflight check** — `miren server install` and `miren runner install` now verify `iptables` and `nft` (nftables) are on `PATH` before installing, and fail early with per-distro (apt/dnf) install guidance if either is missing.

- `cli/commands/install_requirements.go` — pure, testable `requiredNetCommands()` and `findMissingCommands(names, lookup)` helpers.
- `cli/commands/server_install.go` — `missingNetCommands` on `installPrerequisites`, the gate, and a shared `printMissingNetCommandGuidance`.
- `cli/commands/runner_install.go` — same gate + guidance for the runner path.
- `cli/commands/install_requirements_test.go` — `TestFindMissingCommands`.

**Docs**

- `docs/docs/system-requirements.md` — new "Required host commands" section (iptables + nftables), plus a `:::note` on feature-conditional tooling (disk tools for block-device volumes; SELinux tools at install time — both fail-soft).
- `docs/docs/firewall.md` — `:::info` clarifying both iptables and nftables are required.

## Scope

Only `iptables` and `nft` are always exercised and fail hard, so those are what the check gates on. Conditional commands (disk tooling, SELinux tools) and bundled ones (`containerd`, `ctr`) are documented rather than gated. The `shasum`/perl item from the issue lives in the bash installer in the separate `mirendev/cloud` repo and is out of scope here.

## Testing

- `go vet ./cli/commands/` — clean
- `go test ./cli/commands/ -run TestFindMissingCommands` — PASS
- `make lint` — 0 issues (Go) and docs lint passed