### PR TITLE
Fall back to active version for wildcard-route subdomains

### DIFF
--- a/api/ingress/client.go
+++ b/api/ingress/client.go
@@ -87,6 +87,11 @@ func (c *Client) LookupWithWildcard(ctx context.Context, host string) (*ingress_
 	return nil, nil
 }
 
+// IsWildcardHost reports whether host is a wildcard route pattern (e.g. *.example.com).
+func IsWildcardHost(host string) bool {
+	return strings.HasPrefix(strings.ToLower(host), "*.")
+}
+
 // ValidateWildcardHost validates a wildcard host pattern.
 // Valid patterns: *.example.com, *.sub.example.com
 // Invalid: *.com, foo.*.com, **, *

--- a/api/ingress/client_test.go
+++ b/api/ingress/client_test.go
@@ -211,6 +211,26 @@ func TestClientLookupWithWildcard(t *testing.T) {
 	})
 }
 
+func TestIsWildcardHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"*.example.com", true},
+		{"*.APP.EXAMPLE.COM", true},
+		{"app.example.com", false},
+		{"example.com", false},
+		{"*", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			require.Equal(t, tt.want, IsWildcardHost(tt.host))
+		})
+	}
+}
+
 func TestExtractSubdomainLabel(t *testing.T) {
 	tests := []struct {
 		requestHost string

--- a/servers/httpingress/httpingress.go
+++ b/servers/httpingress/httpingress.go
@@ -627,9 +627,13 @@ func (h *Server) serveHTTPWithMetrics(w http.ResponseWriter, req *http.Request, 
 
 	requestTimeout := routeRequestTimeout(route)
 
+	// A wildcard route also serves as a multi-tenant subdomain, so a failed
+	// ephemeral lookup should fall back to the active version rather than 404.
+	wildcardRoute := route != nil && ingress.IsWildcardHost(route.Host)
+
 	// Compose middleware chain: WAF → auth → serve
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		h.serveAuthenticatedRequest(w, r, targetAppId, routeType, ephemeralLabel, appName, requestTimeout)
+		h.serveAuthenticatedRequest(w, r, targetAppId, routeType, ephemeralLabel, wildcardRoute, appName, requestTimeout)
 	}
 
 	handler = h.authMiddleware(route, handler)
@@ -701,8 +705,45 @@ func (h *Server) authMiddleware(route *ingress_v1alpha.HttpRoute, next http.Hand
 	}
 }
 
+// versionResolution describes how a request resolves to an app version.
+type versionResolution int
+
+const (
+	resolveActive            versionResolution = iota // serve app.ActiveVersion
+	resolveEphemeralStrict                            // resolve ephemeral by label; 404 if missing
+	resolveEphemeralOrActive                          // resolve ephemeral by label; fall back to active if missing
+)
+
+// resolveVersionStrategy decides how to resolve the app version for a request.
+// A request with no ephemeral label always serves the active version. When an
+// ephemeral label is present, a wildcard route (which doubles as a multi-tenant
+// subdomain) falls back to the active version if the label does not resolve,
+// while a non-wildcard route stays strict and 404s on a miss.
+func resolveVersionStrategy(ephemeralLabel string, wildcardRoute bool) versionResolution {
+	if ephemeralLabel == "" {
+		return resolveActive
+	}
+	if wildcardRoute {
+		return resolveEphemeralOrActive
+	}
+	return resolveEphemeralStrict
+}
+
+// leaseCacheKey returns the lease cache key for a request. A request that
+// resolved an ephemeral version is scoped per label so it never shares a lease
+// with the active version or another label. Everything else, including a
+// wildcard subdomain that fell back to the active version, shares the app base
+// key so those requests reuse one active-version lease pool instead of
+// fragmenting into a per-tenant entry.
+func leaseCacheKey(appID entity.Id, ephemeralLabel string, ephemeralResolved bool) string {
+	if ephemeralResolved {
+		return appID.String() + ":eph:" + ephemeralLabel
+	}
+	return appID.String()
+}
+
 // serveAuthenticatedRequest handles the request after authentication (if any)
-func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Request, targetAppId entity.Id, routeType string, ephemeralLabel string, appName *string, requestTimeout time.Duration) {
+func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Request, targetAppId entity.Id, routeType string, ephemeralLabel string, wildcardRoute bool, appName *string, requestTimeout time.Duration) {
 	ctx := req.Context()
 
 	// Get app details first to have the name for metrics
@@ -730,12 +771,33 @@ func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Requ
 		))
 	defer leaseSpan.End()
 
-	// Scope the lease cache key by ephemeral label so different versions
-	// (active vs ephemeral, or different ephemeral labels) never share leases.
-	leaseKey := targetAppId.String()
-	if ephemeralLabel != "" {
-		leaseKey = targetAppId.String() + ":eph:" + ephemeralLabel
+	// Resolve the version identity up front so the lease cache key reflects
+	// the version actually served. A resolved ephemeral version scopes the key
+	// per-label; an unresolved label on a wildcard route falls back to the
+	// active version and shares its lease pool rather than fragmenting into a
+	// per-tenant entry. Label-free requests skip the lookup and stay on the
+	// fast active path.
+	strategy := resolveVersionStrategy(ephemeralLabel, wildcardRoute)
+	var ephVer *core_v1alpha.AppVersion
+
+	if strategy != resolveActive {
+		ev, err := ephemeralx.LookupByLabel(ctx, h.eac, targetAppId, ephemeralLabel)
+		if err != nil {
+			h.Log.Error("error looking up ephemeral version", "error", err, "label", ephemeralLabel)
+			http.Error(w, fmt.Sprintf("error looking up ephemeral version: %s", ephemeralLabel), http.StatusInternalServerError)
+			return
+		}
+		if ev == nil && strategy == resolveEphemeralStrict {
+			h.Log.Debug("no ephemeral version found", "label", ephemeralLabel, "app", targetAppId)
+			http.Error(w, fmt.Sprintf("ephemeral version %q not found or has expired", ephemeralLabel), http.StatusNotFound)
+			return
+		}
+		// ev may be nil here for a resolveEphemeralOrActive miss, which leaves
+		// the request on the active version and its shared lease pool.
+		ephVer = ev
 	}
+
+	leaseKey := leaseCacheKey(targetAppId, ephemeralLabel, ephVer != nil)
 
 	// Retry loop: if a cached lease fails with a connection error (stale sandbox),
 	// invalidate all cached leases and retry once to acquire a fresh lease.
@@ -781,26 +843,15 @@ func (h *Server) serveAuthenticatedRequest(w http.ResponseWriter, req *http.Requ
 
 		var av core_v1alpha.AppVersion
 
-		if ephemeralLabel != "" {
-			// Resolve ephemeral version by label
-			ephVer, ephErr := ephemeralx.LookupByLabel(ctx, h.eac, targetAppId, ephemeralLabel)
-			if ephErr != nil {
-				h.Log.Error("error looking up ephemeral version", "error", ephErr, "label", ephemeralLabel)
-				http.Error(w, fmt.Sprintf("error looking up ephemeral version: %s", ephemeralLabel), http.StatusInternalServerError)
-				return
-			}
-			if ephVer == nil {
-				h.Log.Debug("no ephemeral version found", "label", ephemeralLabel, "app", targetAppId)
-				http.Error(w, fmt.Sprintf("ephemeral version %q not found or has expired", ephemeralLabel), http.StatusNotFound)
-				return
-			}
+		if ephVer != nil {
 			av = *ephVer
 			leaseSpan.SetAttributes(
 				attribute.String("miren.app.version", string(av.ID)),
 				attribute.String("miren.ephemeral.label", ephemeralLabel),
 			)
 		} else {
-			// Resolve active version
+			// Active version: either a label-free request or a wildcard
+			// subdomain whose ephemeral label did not resolve.
 			if app.ActiveVersion == "" {
 				h.Log.Debug("no active version for app", "app", targetAppId)
 				http.Error(w, fmt.Sprintf("no active version for app: %s", targetAppId), http.StatusNotFound)

--- a/servers/httpingress/httpingress_test.go
+++ b/servers/httpingress/httpingress_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/httputil"
 )
 
@@ -494,5 +495,54 @@ func TestProxyToLeaseNoRetryOnTimeout(t *testing.T) {
 	}
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Errorf("expected 503 for timeout, got %d", rec.Code)
+	}
+}
+
+func TestResolveVersionStrategy(t *testing.T) {
+	tests := []struct {
+		name           string
+		ephemeralLabel string
+		wildcardRoute  bool
+		want           versionResolution
+	}{
+		// A wildcard tenant subdomain that names no live ephemeral version must
+		// fall back to the active version, not hard-404 (MIR-1613).
+		{"wildcard label falls back to active", "tenant1", true, resolveEphemeralOrActive},
+		{"non-wildcard label stays strict", "feat-x", false, resolveEphemeralStrict},
+		{"no label serves active on wildcard", "", true, resolveActive},
+		{"no label serves active on exact", "", false, resolveActive},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveVersionStrategy(tt.ephemeralLabel, tt.wildcardRoute)
+			if got != tt.want {
+				t.Errorf("resolveVersionStrategy(%q, %v) = %d, want %d", tt.ephemeralLabel, tt.wildcardRoute, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLeaseCacheKey(t *testing.T) {
+	app := entity.Id("app-1")
+
+	// Two distinct wildcard subdomains that did not resolve to an ephemeral
+	// version must land on the same base key so they share one active-version
+	// lease pool instead of fragmenting per tenant.
+	tenant1 := leaseCacheKey(app, "tenant1", false)
+	tenant2 := leaseCacheKey(app, "tenant2", false)
+	labelFree := leaseCacheKey(app, "", false)
+	if tenant1 != labelFree || tenant2 != labelFree {
+		t.Errorf("unresolved labels should share the base key %q, got tenant1=%q tenant2=%q", labelFree, tenant1, tenant2)
+	}
+
+	// A resolved ephemeral version stays scoped per label and never collides
+	// with the base key or another label.
+	resolved := leaseCacheKey(app, "feat-x", true)
+	if resolved == labelFree {
+		t.Errorf("resolved ephemeral key %q must differ from the base key %q", resolved, labelFree)
+	}
+	if other := leaseCacheKey(app, "feat-y", true); other == resolved {
+		t.Errorf("distinct ephemeral labels must not share a key, both were %q", resolved)
 	}
 }


### PR DESCRIPTION
The first DNS label under a route did double duty: an ephemeral version label (`feat-x.app.example.com`) or a wildcard subdomain (`tenant1.app.example.com`). When a wildcard route matched, we always read the prefix as an ephemeral label and 404'd if no such version existed, so `*.app.example.com` couldn't serve tenants off the active version.

Now only wildcard routes (host starts with `*.`) fall back to the active version on an ephemeral miss. Exact routes reached via label-stripping stay strict and still 404.

Closes MIR-1613