### PR TITLE
Carry deploy references as id and short-id pairs

### DIFF
--- a/components/coordinate/deployreport.go
+++ b/components/coordinate/deployreport.go
@@ -182,10 +182,16 @@ type DeployState struct {
 	// consulting any clock.
 	Revision int64 `json:"revision"`
 
-	AppName    string `json:"app_name"`
-	AppVersion string `json:"app_version"`
-	Status     string `json:"status"`
-	Phase      string `json:"phase"`
+	AppName string `json:"app_name"`
+
+	// Version is the app version this deploy shipped, nil when it never got
+	// one — a deploy that failed before a build produced a version has no
+	// version to name, and saying so with an absent object is honest where an
+	// empty string is a value that has to be recognized as meaning nothing.
+	Version *EntityRef `json:"version"`
+
+	Status string `json:"status"`
+	Phase  string `json:"phase"`
 
 	// DeployedAt is when the deploy was initiated, and must be identical in
 	// every report of this deploy: cloud partitions on it, so a value that
@@ -200,8 +206,30 @@ type DeployState struct {
 
 	Git *DeployGit `json:"git"`
 
-	// SourceDeployID links a rollback or redeploy to what it was based on.
-	SourceDeployID *string `json:"source_deploy_id"`
+	// SourceDeploy links a rollback or redeploy to what it was based on, nil
+	// for a fresh build.
+	SourceDeploy *EntityRef `json:"source_deploy"`
+}
+
+// EntityRef names one runtime entity, in both the form that identifies it and
+// the form a person reads.
+//
+// Both are carried because neither does the other's job. The id is the durable
+// handle: UUIDv7 under its base58, never reused, and unique across every
+// cluster. The short id is what the CLI and console actually show, but it is
+// allocated per cluster against the entities alive at that moment
+// (pkg/entity/store.go), so it collides across clusters and is freed for
+// reallocation once its entity is pruned. Cloud becomes the book of record for
+// a deploy after the runtime prunes it, so storing only the short id would
+// leave a history whose identifiers can later name something else.
+//
+// ShortID is empty when the runtime could not resolve one — an entity that was
+// pruned before this deploy was reported, most often. Readers fall back to the
+// id with its kind prefix stripped, which is what pkg/ui.DisplayShortID does
+// for the CLI.
+type EntityRef struct {
+	ID      string `json:"id"`
+	ShortID string `json:"short_id"`
 }
 
 // DeployGit is the provenance cloud keeps for a deploy.
@@ -242,6 +270,24 @@ type deploySource interface {
 	// Watch streams deploy operations in revision order starting just after
 	// fromRevision, blocking until the context ends or the stream fails.
 	Watch(ctx context.Context, fromRevision int64, fn func(*esv1.EntityOp) error) error
+
+	// ShortID resolves one entity's short id, returning "" when the entity is
+	// gone or carries none.
+	//
+	// No error, on purpose. A short id is a display convenience, and there is
+	// nothing a caller here could usefully do with a failure to read one: the
+	// deploy still has to be reported, and the reference still has its durable
+	// id. Returning "" collapses "pruned", "never had one" and "the read
+	// failed" into the one case every reader already handles.
+	ShortID(ctx context.Context, entityID string) string
+
+	// ShortIDsForKind resolves every short id for a kind in a single read.
+	//
+	// This exists for the backfill. Resolving one at a time is fine on the live
+	// path, where deploys arrive one at a time anyway, but a first re-list
+	// walks every deploy a cluster has ever run and would turn into a Get per
+	// deploy against a store that can answer the whole question at once.
+	ShortIDsForKind(ctx context.Context, kind entity.Id) map[string]string
 }
 
 // errCompacted ends a stream that cannot continue because the revision it
@@ -403,12 +449,16 @@ func (r *deployReporter) run(ctx context.Context, link deployLink) {
 		return
 	}
 
+	// One cache for the whole connection, so a delta stream that falls back to
+	// a re-list keeps what it already learned.
+	ids := newShortIDs(r.source)
+
 	mode, reason := decideSyncMode(watermark, head)
 	if mode == syncDelta {
 		r.log.Info("resuming deploy sync from cloud's watermark",
 			"watermark", watermark, "head", head)
 
-		err := r.stream(ctx, link, watermark, head)
+		err := r.stream(ctx, link, watermark, head, ids)
 		if err == nil || ctx.Err() != nil {
 			return
 		}
@@ -433,7 +483,7 @@ func (r *deployReporter) run(ctx context.Context, link deployLink) {
 			"watermark", watermark, "head", head)
 	}
 
-	r.relist(ctx, link, head)
+	r.relist(ctx, link, head, ids)
 }
 
 // requestCursor asks cloud where its copy left off and waits for the answer.
@@ -473,7 +523,7 @@ func (r *deployReporter) requestCursor(ctx context.Context, link deployLink) (in
 //
 // Returns nil when the connection ends, and an error when the stream must fall
 // back to a re-list.
-func (r *deployReporter) stream(ctx context.Context, link deployLink, from, head int64) error {
+func (r *deployReporter) stream(ctx context.Context, link deployLink, from, head int64, ids *shortIDs) error {
 	sent := from
 
 	return r.source.Watch(ctx, from, func(op *esv1.EntityOp) error {
@@ -511,7 +561,7 @@ func (r *deployReporter) stream(ctx context.Context, link deployLink, from, head
 		// re-streams the same revision and drops it again, and a record with no
 		// stable timestamp has no home in cloud to hold open for it either.
 		if op.HasEntity() {
-			if state, ok := r.stateFrom(op.Entity()); ok {
+			if state, ok := r.stateFrom(ctx, op.Entity(), ids); ok {
 				batch.Deploys = append(batch.Deploys, state)
 			} else {
 				// relist counts these; the tail said nothing, which made the
@@ -539,17 +589,35 @@ func (r *deployReporter) stream(ctx context.Context, link deployLink, from, head
 // sent or not advance it at all. It also makes an interrupted backfill free to
 // resume: whatever ranges committed stay committed, and the next connection
 // picks up from the watermark they left behind.
-func (r *deployReporter) relist(ctx context.Context, link deployLink, head int64) {
+func (r *deployReporter) relist(ctx context.Context, link deployLink, head int64, ids *shortIDs) {
 	records, readRevision, err := r.source.List(ctx)
 	if err != nil {
 		r.log.Warn("failed to list deploys for cloud", "error", err)
 		return
 	}
 
+	// Resolve short ids before projecting anything, and take the cheapest
+	// source for each kind.
+	//
+	// Versions are not in hand, so they cost one bulk read of the kind rather
+	// than a lookup per deploy. Deploys are: the listing above returned every
+	// record with its entity attached, so the short id of anything a rollback
+	// can name is already in memory. Listing the deployment kind for them would
+	// re-read the largest kind a cluster has, on the one path where that is a
+	// whole history, to learn what the caller is already holding.
+	//
+	// Both are optimizations and neither is authoritative. A version created
+	// after the bulk read, or a source deploy already pruned from the listing,
+	// falls through to a single lookup.
+	ids.preload(ctx, core_v1alpha.KindAppVersion)
+	for _, rec := range records {
+		ids.seed(rec.Entity)
+	}
+
 	states := make([]DeployState, 0, len(records))
 	skipped := 0
 	for _, rec := range records {
-		state, ok := r.stateFor(rec)
+		state, ok := r.stateFor(ctx, rec, ids)
 		if !ok {
 			skipped++
 			continue
@@ -631,18 +699,83 @@ func (r *deployReporter) relist(ctx context.Context, link deployLink, head int64
 	// deploy to happen inside it, and RFD-94 explicitly defers that accelerator.
 	// Adding it later means a message that carries no range and therefore
 	// cannot advance the watermark — the invariant to preserve if it lands.
-	if err := r.stream(ctx, link, readRevision, head); err != nil && ctx.Err() == nil {
+	if err := r.stream(ctx, link, readRevision, head, ids); err != nil && ctx.Err() == nil {
 		r.log.Warn("deploy tail ended", "error", err)
 	}
 }
 
-func (r *deployReporter) stateFrom(ent *esv1.Entity) (DeployState, bool) {
-	return r.stateFor(deploylifecycle.RecordFrom(ent))
+// shortIDs remembers short-id lookups for the life of one connection.
+//
+// Both halves of that matter. Remembering is what keeps a rollback and the
+// deploy it was based on from costing two reads of the same version. Misses are
+// remembered too, which is the less obvious half: a version pruned before its
+// deploy was reported will never resolve, and without a negative entry it would
+// be re-read on every batch for as long as the connection lasts.
+//
+// Scoped to a connection rather than to the process so an answer cannot outlive
+// the store that gave it. A short id freed by a prune and reallocated to
+// another entity would otherwise be served from here indefinitely.
+//
+// Not safe for concurrent use, and does not need to be: it belongs to one run,
+// which is a single goroutine from the handshake through to the tail.
+type shortIDs struct {
+	src   deploySource
+	known map[string]string
+}
+
+func newShortIDs(src deploySource) *shortIDs {
+	return &shortIDs{src: src, known: make(map[string]string)}
+}
+
+// preload fills in every short id for a kind in one read.
+//
+// Existing entries win, so a preload can never overwrite something already
+// observed — the preloaded view is older than any lookup that beat it here.
+func (s *shortIDs) preload(ctx context.Context, kind entity.Id) {
+	for id, short := range s.src.ShortIDsForKind(ctx, kind) {
+		if _, ok := s.known[id]; !ok {
+			s.known[id] = short
+		}
+	}
+}
+
+// seed records an entity the caller already holds, sparing a read for it.
+//
+// Existing entries win, for the same reason they do in preload: whatever is
+// already here was observed no earlier than this.
+func (s *shortIDs) seed(ent *esv1.Entity) {
+	id, short := shortIDEntry(ent)
+	if id == "" {
+		return
+	}
+	if _, ok := s.known[id]; !ok {
+		s.known[id] = short
+	}
+}
+
+// ref builds the reference cloud stores for an entity id, or nil when there is
+// no entity to name.
+func (s *shortIDs) ref(ctx context.Context, id string) *EntityRef {
+	if id == "" {
+		return nil
+	}
+
+	short, ok := s.known[id]
+	if !ok {
+		short = s.src.ShortID(ctx, id)
+		s.known[id] = short
+	}
+
+	return &EntityRef{ID: id, ShortID: short}
+}
+
+func (r *deployReporter) stateFrom(ctx context.Context, ent *esv1.Entity, ids *shortIDs) (DeployState, bool) {
+	return r.stateFor(ctx, deploylifecycle.RecordFrom(ent), ids)
 }
 
 // stateFor projects a record onto the wire shape, and reports false for a
 // record that cannot be reported at all.
-func (r *deployReporter) stateFor(rec *deploylifecycle.Record) (DeployState, bool) {
+func (r *deployReporter) stateFor(ctx context.Context, rec *deploylifecycle.Record, ids *shortIDs) (DeployState, bool) {
 	deployedAt, ok := deployedAtFor(rec)
 	if !ok {
 		// Cloud partitions on this, so a deploy without a stable one has no
@@ -658,7 +791,7 @@ func (r *deployReporter) stateFor(rec *deploylifecycle.Record) (DeployState, boo
 		ID:         string(dep.ID),
 		Revision:   rec.Revision,
 		AppName:    dep.AppName,
-		AppVersion: rec.AppVersion(),
+		Version:    ids.ref(ctx, rec.AppVersion()),
 		Status:     dep.Status,
 		Phase:      dep.Phase,
 		DeployedAt: deployedAt,
@@ -676,10 +809,7 @@ func (r *deployReporter) stateFor(rec *deploylifecycle.Record) (DeployState, boo
 		state.ErrorReason = &reason
 	}
 
-	if dep.SourceDeploymentId != "" {
-		source := dep.SourceDeploymentId
-		state.SourceDeployID = &source
-	}
+	state.SourceDeploy = ids.ref(ctx, dep.SourceDeploymentId)
 
 	if git := dep.GitInfo; git.Sha != "" || git.Branch != "" || git.Repository != "" {
 		state.Git = &DeployGit{
@@ -766,6 +896,64 @@ func (s *entityDeploySource) List(ctx context.Context) ([]*deploylifecycle.Recor
 	}
 
 	return records, res.Revision(), nil
+}
+
+func (s *entityDeploySource) ShortID(ctx context.Context, entityID string) string {
+	resp, err := s.eac.Get(ctx, entityID)
+	if err != nil {
+		// Swallowed rather than reported, per the interface: an entity pruned
+		// between the deploy and this read is the ordinary case, not a fault,
+		// and the caller has nothing better to do with either.
+		return ""
+	}
+	return shortIDOf(resp.Entity())
+}
+
+func (s *entityDeploySource) ShortIDsForKind(ctx context.Context, kind entity.Id) map[string]string {
+	res, err := s.eac.List(ctx, entity.Ref(entity.EntityKind, kind))
+	if err != nil {
+		// An empty map degrades to per-id lookups rather than to missing short
+		// ids, so a failure here costs reads and never correctness.
+		return nil
+	}
+
+	short := make(map[string]string, len(res.Values()))
+	for _, ent := range res.Values() {
+		if id, sid := shortIDEntry(ent); id != "" {
+			short[id] = sid
+		}
+	}
+	return short
+}
+
+// shortIDEntry reads the identity and short id off a listed entity.
+//
+// The id comes from the entity's own field rather than from a db/id attribute,
+// which is not the same string. Attribute values render through Value.String,
+// and that prefixes an id-kinded value with its kind ("id: app_version/…"), so
+// keying the map on one would build a map that ref can never hit — every
+// lookup would miss and fall through to the per-id read the bulk read exists to
+// avoid, silently and with nothing failing.
+func shortIDEntry(ent *esv1.Entity) (id, shortID string) {
+	if ent == nil {
+		return "", ""
+	}
+	return ent.Id(), shortIDOf(ent)
+}
+
+// shortIDOf reads the db/short-id attribute off an RPC entity, or "" when it
+// carries none. That attribute is string-kinded, so String is the right reader
+// for it.
+func shortIDOf(ent *esv1.Entity) string {
+	if ent == nil {
+		return ""
+	}
+	for _, attr := range ent.Attrs() {
+		if entity.Id(attr.ID) == entity.DBShortId {
+			return attr.Value.String()
+		}
+	}
+	return ""
 }
 
 func (s *entityDeploySource) Watch(ctx context.Context, fromRevision int64, fn func(*esv1.EntityOp) error) error {

--- a/components/coordinate/deployreport_test.go
+++ b/components/coordinate/deployreport_test.go
@@ -368,29 +368,37 @@ func runWithCursor(t *testing.T, src deploySource, link *fakeDeployLink, waterma
 
 func deployRecord(t *testing.T, app string, revision int64) *deploylifecycle.Record {
 	t.Helper()
-	return &deploylifecycle.Record{
-		Deployment: &core_v1alpha.Deployment{
-			ID:         entity.Id(idgen.GenNS("deployment")),
-			AppName:    app,
-			AppVersion: "v1.0.0",
-			Status:     "active",
-			DeployedBy: core_v1alpha.DeployedBy{
-				Timestamp: time.Now().UTC().Format(time.RFC3339),
-			},
+
+	dep := &core_v1alpha.Deployment{
+		ID:      entity.Id(idgen.GenNS("deployment")),
+		AppName: app,
+		// A real version reference, so tests that do not care about versions
+		// still model a shape a cluster can actually report. "v1.0.0" was never
+		// one, and a fixture asserting an impossible value is how a rendering
+		// bug looks correct under test.
+		AppVersion: "app_version/" + app + "-vCZ1eUgSgNd28ed6vt2DgY",
+		Status:     "active",
+		DeployedBy: core_v1alpha.DeployedBy{
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		},
-		Revision: revision,
 	}
+
+	// The store hands back records with their entity attached, and the reporter
+	// now leans on that to avoid re-reading the deployment kind. A fixture
+	// without one would leave that path untested and quietly passing.
+	ent := &esv1.Entity{}
+	ent.SetId(string(dep.ID))
+	ent.SetAttrs(dep.Encode())
+	ent.SetRevision(revision)
+
+	return &deploylifecycle.Record{Deployment: dep, Entity: ent, Revision: revision}
 }
 
 func deployOp(t *testing.T, app string, revision int64) *esv1.EntityOp {
 	t.Helper()
 
 	rec := deployRecord(t, app, revision)
-
-	ent := &esv1.Entity{}
-	ent.SetId(string(rec.Deployment.ID))
-	ent.SetAttrs(rec.Deployment.Encode())
-	ent.SetRevision(revision)
+	ent := rec.Entity
 
 	op := &esv1.EntityOp{}
 	op.SetOperation(int64(esv1.EntityOperationUpdate))
@@ -407,7 +415,16 @@ type fakeDeploySource struct {
 	watchOps     []*esv1.EntityOp
 	watchErr     map[int64]error
 
-	listed bool
+	// shortIDs is the store's view of every entity's short id, and byKind says
+	// which of them a bulk read for a kind would return. An id present in the
+	// first but not the second is one only a per-id lookup can find, which is
+	// how a version created after the backfill's bulk read is modelled.
+	shortIDs map[string]string
+	byKind   map[entity.Id][]string
+
+	listed   bool
+	getCalls []string
+	kindList []entity.Id
 }
 
 func (f *fakeDeploySource) HeadRevision(context.Context) (int64, error) {
@@ -417,6 +434,21 @@ func (f *fakeDeploySource) HeadRevision(context.Context) (int64, error) {
 func (f *fakeDeploySource) List(context.Context) ([]*deploylifecycle.Record, int64, error) {
 	f.listed = true
 	return f.records, f.listRevision, nil
+}
+
+func (f *fakeDeploySource) ShortID(_ context.Context, entityID string) string {
+	f.getCalls = append(f.getCalls, entityID)
+	return f.shortIDs[entityID]
+}
+
+func (f *fakeDeploySource) ShortIDsForKind(_ context.Context, kind entity.Id) map[string]string {
+	f.kindList = append(f.kindList, kind)
+
+	out := make(map[string]string)
+	for _, id := range f.byKind[kind] {
+		out[id] = f.shortIDs[id]
+	}
+	return out
 }
 
 func (f *fakeDeploySource) Watch(_ context.Context, from int64, fn func(*esv1.EntityOp) error) error {
@@ -529,10 +561,13 @@ func TestFullBatchFitsInOneFrame(t *testing.T) {
 		completed := now
 		reason := shortReason(strings.Repeat("x", maxErrorReasonBytes*4))
 		return DeployState{
-			ID:          idgen.GenNS("deployment"),
-			Revision:    5100294,
-			AppName:     "some-reasonably-long-app-name",
-			AppVersion:  "some-reasonably-long-app-name-v8kd0",
+			ID:       idgen.GenNS("deployment"),
+			Revision: 5100294,
+			AppName:  "some-reasonably-long-app-name",
+			Version: &EntityRef{
+				ID:      "app_version/some-reasonably-long-app-name-vCZ1eUgSgNd28ed6vt2DgY",
+				ShortID: "8kd0",
+			},
 			Status:      "failed",
 			Phase:       "activating",
 			DeployedAt:  now,
@@ -543,7 +578,10 @@ func TestFullBatchFitsInOneFrame(t *testing.T) {
 				Branch:     "release/some-fairly-long-branch-name",
 				Repository: "https://github.com/mirendev/some-repository-name",
 			},
-			SourceDeployID: ptr(idgen.GenNS("deployment")),
+			SourceDeploy: &EntityRef{
+				ID:      idgen.GenNS("deployment"),
+				ShortID: "2DgY",
+			},
 		}
 	}
 
@@ -580,8 +618,6 @@ func TestShortReasonCapsAndIsStable(t *testing.T) {
 	assert.Equal(t, short, shortReason(short), "a reason within the cap is untouched")
 }
 
-func ptr[T any](v T) *T { return &v }
-
 // A deploy the reporter cannot key by creation time still has to let the
 // frontier past it.
 //
@@ -614,4 +650,293 @@ func TestUnkeyableDeployInTheTailStillAdvancesTheFrontier(t *testing.T) {
 	assert.Equal(t, int64(4000), batches[0].FromRevision)
 	assert.Equal(t, int64(5100), batches[0].ToRevision,
 		"the frontier must still pass it, or this revision wedges the watermark forever")
+}
+
+// The whole point of MIR-1615: a deploy report has to carry the short id the
+// console shows, not just the entity id it was already sending. The short id
+// lives on the app_version entity rather than on the deploy, so nothing reaches
+// the wire unless the reporter goes and joins it.
+func TestVersionShortIdReachesTheWire(t *testing.T) {
+	rec := deployRecord(t, "web", 100)
+	rec.Deployment.AppVersion = "app_version/web-vCZ1eUgSgNd28ed6vt2DgY"
+
+	src := &fakeDeploySource{
+		head:         5000,
+		records:      []*deploylifecycle.Record{rec},
+		listRevision: 5000,
+		shortIDs:     map[string]string{"app_version/web-vCZ1eUgSgNd28ed6vt2DgY": "8kd0"},
+		byKind: map[entity.Id][]string{
+			core_v1alpha.KindAppVersion: {"app_version/web-vCZ1eUgSgNd28ed6vt2DgY"},
+		},
+	}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	state := onlyDeploy(t, link)
+	require.NotNil(t, state.Version)
+	assert.Equal(t, "8kd0", state.Version.ShortID)
+	assert.Equal(t, "app_version/web-vCZ1eUgSgNd28ed6vt2DgY", state.Version.ID,
+		"the durable id travels alongside: short ids are cluster-scoped and are "+
+			"freed for reuse when their entity is pruned, so cloud cannot key on one")
+}
+
+// A version the runtime can no longer resolve still has to be reported. The
+// deploy happened, and the id it names is the honest thing to show — a reader
+// falls back to it with the kind prefix stripped, exactly as the CLI does.
+func TestDeployIsStillReportedWhenTheVersionHasNoShortId(t *testing.T) {
+	rec := deployRecord(t, "web", 100)
+	rec.Deployment.AppVersion = "app_version/web-vGone"
+
+	// Nothing registered: the version entity was pruned before this ran.
+	src := &fakeDeploySource{head: 5000, records: []*deploylifecycle.Record{rec}, listRevision: 5000}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	state := onlyDeploy(t, link)
+	require.NotNil(t, state.Version, "an unresolvable short id must not erase the version")
+	assert.Equal(t, "app_version/web-vGone", state.Version.ID)
+	assert.Empty(t, state.Version.ShortID)
+}
+
+// A deploy that failed before a build produced a version has no version to
+// name. Absent says that; an empty string would be a value a reader has to
+// recognize as meaning nothing.
+func TestDeployWithNoVersionReportsNoVersionAtAll(t *testing.T) {
+	rec := deployRecord(t, "web", 100)
+	rec.Deployment.AppVersion = ""
+
+	src := &fakeDeploySource{head: 5000, records: []*deploylifecycle.Record{rec}, listRevision: 5000}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	state := onlyDeploy(t, link)
+	assert.Nil(t, state.Version)
+	assert.Nil(t, state.SourceDeploy, "a fresh build was based on nothing")
+	assert.Contains(t, link.raw(), `"version":null`,
+		"absent has to survive serialization, since that is what cloud reads")
+}
+
+// A backfill walks every deploy a cluster has ever run. Resolving short ids one
+// at a time there would be a read per deploy against a store that can answer
+// for a whole kind at once, which is the difference between a backfill that is
+// a slide and one that is a load.
+func TestRelistResolvesShortIdsInBulkRatherThanPerDeploy(t *testing.T) {
+	var records []*deploylifecycle.Record
+	byKind := map[entity.Id][]string{}
+	shortIDs := map[string]string{}
+
+	for i := range 50 {
+		rec := deployRecord(t, "web", int64(100+i))
+		// Ten versions across fifty deploys: rollbacks and redeploys ship a
+		// version that already shipped, so ids repeat by design.
+		version := "app_version/web-v" + string(rune('a'+i%10))
+		rec.Deployment.AppVersion = version
+		records = append(records, rec)
+
+		if _, seen := shortIDs[version]; !seen {
+			shortIDs[version] = "s" + string(rune('a'+i%10))
+			byKind[core_v1alpha.KindAppVersion] = append(byKind[core_v1alpha.KindAppVersion], version)
+		}
+	}
+
+	src := &fakeDeploySource{
+		head: 5000, records: records, listRevision: 5000,
+		shortIDs: shortIDs, byKind: byKind,
+	}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	assert.Empty(t, src.getCalls,
+		"a re-list must not fall back to per-id reads for ids the bulk read already covered")
+	assert.Equal(t, []entity.Id{core_v1alpha.KindAppVersion}, src.kindList,
+		"versions cost a bulk read because the listing does not carry them; deploys "+
+			"must not, since it returned every record with its entity attached, and "+
+			"re-reading the largest kind on the backfill path is what this avoids")
+
+	var seen int
+	for _, b := range link.batches() {
+		for _, d := range b.Deploys {
+			require.NotNil(t, d.Version)
+			assert.NotEmpty(t, d.Version.ShortID)
+			seen++
+		}
+	}
+	assert.Equal(t, 50, seen)
+}
+
+// The cache has to remember misses as well as hits. A version pruned before its
+// deploy was reported will never resolve, and re-reading it on every batch for
+// the life of the connection is the failure this guards.
+func TestShortIdCacheRemembersMissesAndHits(t *testing.T) {
+	src := &fakeDeploySource{
+		shortIDs: map[string]string{"app_version/web-vLive": "8kd0"},
+	}
+	ids := newShortIDs(src)
+	ctx := t.Context()
+
+	for range 3 {
+		hit := ids.ref(ctx, "app_version/web-vLive")
+		require.NotNil(t, hit)
+		assert.Equal(t, "8kd0", hit.ShortID)
+
+		miss := ids.ref(ctx, "app_version/web-vGone")
+		require.NotNil(t, miss)
+		assert.Empty(t, miss.ShortID)
+	}
+
+	assert.Equal(t, []string{"app_version/web-vLive", "app_version/web-vGone"}, src.getCalls,
+		"each id is read exactly once, misses included")
+
+	assert.Nil(t, ids.ref(ctx, ""), "nothing to name means no reference at all")
+}
+
+// An entity created after the bulk read still has to resolve. The preloaded map
+// is an optimization, so a miss in it falls through to a lookup rather than
+// standing as an answer.
+func TestPreloadDoesNotMaskEntitiesItDidNotCover(t *testing.T) {
+	src := &fakeDeploySource{
+		shortIDs: map[string]string{
+			"app_version/web-vOld": "old0",
+			"app_version/web-vNew": "new0",
+		},
+		// Only the older version existed when the bulk read ran.
+		byKind: map[entity.Id][]string{
+			core_v1alpha.KindAppVersion: {"app_version/web-vOld"},
+		},
+	}
+
+	ids := newShortIDs(src)
+	ctx := t.Context()
+	ids.preload(ctx, core_v1alpha.KindAppVersion)
+
+	assert.Equal(t, "old0", ids.ref(ctx, "app_version/web-vOld").ShortID)
+	assert.Empty(t, src.getCalls, "the preloaded id needs no read of its own")
+
+	assert.Equal(t, "new0", ids.ref(ctx, "app_version/web-vNew").ShortID)
+	assert.Equal(t, []string{"app_version/web-vNew"}, src.getCalls,
+		"an id the bulk read missed falls through to a lookup")
+}
+
+// A rollback names the deploy it was based on, and the console wants that
+// reference to read the same way the version does.
+func TestSourceDeployCarriesItsShortIdToo(t *testing.T) {
+	rec := deployRecord(t, "web", 100)
+	source := idgen.GenNS("deployment")
+	rec.Deployment.SourceDeploymentId = source
+
+	src := &fakeDeploySource{
+		head: 5000, records: []*deploylifecycle.Record{rec}, listRevision: 5000,
+		shortIDs: map[string]string{source: "r7x2"},
+		byKind:   map[entity.Id][]string{core_v1alpha.KindDeployment: {source}},
+	}
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	state := onlyDeploy(t, link)
+	require.NotNil(t, state.SourceDeploy)
+	assert.Equal(t, source, state.SourceDeploy.ID)
+	assert.Equal(t, "r7x2", state.SourceDeploy.ShortID)
+}
+
+// onlyDeploy returns the single deploy the link received, failing if the run
+// reported any other number.
+func onlyDeploy(t *testing.T, link *fakeDeployLink) DeployState {
+	t.Helper()
+
+	var found []DeployState
+	for _, b := range link.batches() {
+		found = append(found, b.Deploys...)
+	}
+
+	require.Len(t, found, 1)
+	return found[0]
+}
+
+// The bulk read has to key on the same string ref looks up, and the two come
+// from different places: ref uses the plain entity id off a deploy record,
+// while the listing sees whole entities.
+//
+// Reading the id from a db/id attribute instead of the entity's own field is
+// the trap, because attribute values render through Value.String, which
+// prefixes an id-kinded value with its kind. That builds a map whose keys never
+// match, so every reference misses and falls through to the per-id read the
+// bulk read exists to avoid. Nothing errors and nothing fails; a backfill just
+// quietly costs a lookup per deploy again.
+func TestBulkReadKeysOnThePlainEntityId(t *testing.T) {
+	const id = "app_version/web-vCZ1eUgSgNd28ed6vt2DgY"
+
+	ent := &esv1.Entity{}
+	ent.SetId(id)
+	ent.SetAttrs([]entity.Attr{
+		entity.Ref(entity.DBId, entity.Id(id)),
+		entity.String(entity.DBShortId, "8kd0"),
+	})
+
+	gotID, gotShort := shortIDEntry(ent)
+	assert.Equal(t, id, gotID,
+		"the key has to be the plain id a deploy record names, with no kind prefix")
+	assert.Equal(t, "8kd0", gotShort)
+
+	// The specific way it goes wrong, pinned so the trap stays visible.
+	var fromAttr string
+	for _, attr := range ent.Attrs() {
+		if entity.Id(attr.ID) == entity.DBId {
+			fromAttr = attr.Value.String()
+		}
+	}
+	assert.NotEqual(t, id, fromAttr,
+		"if this ever starts matching, the comment on shortIDEntry is stale")
+}
+
+// A listed entity with no short id yields its id and an empty short id, rather
+// than dropping out of the map. The empty value is a real answer — it is what
+// makes the cache remember the miss instead of re-reading it every batch.
+func TestBulkReadKeepsEntitiesWithNoShortId(t *testing.T) {
+	ent := &esv1.Entity{}
+	ent.SetId("app_version/web-vNone")
+
+	id, short := shortIDEntry(ent)
+	assert.Equal(t, "app_version/web-vNone", id)
+	assert.Empty(t, short)
+}
+
+// A rollback names a deploy the listing already returned, so its short id costs
+// nothing to resolve. Re-listing the deployment kind to learn it would re-read
+// a cluster's whole history on the one path where that history is the workload.
+func TestSourceDeployResolvesFromTheListingWithoutAnyRead(t *testing.T) {
+	source := deployRecord(t, "web", 100)
+	rollback := deployRecord(t, "web", 200)
+	rollback.Deployment.SourceDeploymentId = string(source.Deployment.ID)
+
+	src := &fakeDeploySource{
+		head:         5000,
+		records:      []*deploylifecycle.Record{source, rollback},
+		listRevision: 5000,
+		// Registered so a read would succeed, which is what makes the
+		// assertion below mean "never asked" rather than "asked and missed".
+		shortIDs: map[string]string{string(source.Deployment.ID): "r7x2"},
+	}
+
+	// The store's own short id for the source, as the listing carries it.
+	src.records[0].Entity.SetAttrs(append(src.records[0].Entity.Attrs(),
+		entity.String(entity.DBShortId, "r7x2")))
+
+	link := &fakeDeployLink{}
+	runWithCursor(t, src, link, 0)
+
+	var seen *EntityRef
+	for _, b := range link.batches() {
+		for _, d := range b.Deploys {
+			if d.SourceDeploy != nil {
+				seen = d.SourceDeploy
+			}
+		}
+	}
+
+	require.NotNil(t, seen, "the rollback has to report what it was based on")
+	assert.Equal(t, "r7x2", seen.ShortID)
+	assert.NotContains(t, src.getCalls, string(source.Deployment.ID),
+		"the source deploy was in the listing, so resolving it must cost no read")
+	assert.NotContains(t, src.kindList, core_v1alpha.KindDeployment,
+		"and the deployment kind must not be listed to learn it")
 }


### PR DESCRIPTION
The console's app detail view renders versions as `app_version/discoveryagent-vCdjv…` where RFD-96 asks for `8kd0`. Cloud renders what it's sent, and what it's sent is the deployment entity's `app_version` attribute: the full entity id. The short id lives on the `app_version` entity rather than on the deploy, so cloud was never going to recover it. The runtime already does this join for the CLI in the deployment server; the reporter just never did.

Rather than bolting a sibling field onto each reference, `app_version` and `source_deploy_id` become `EntityRef` values carrying the entity id and the short id together. Cloud needs both and neither substitutes for the other: short ids are allocated per cluster against the entities alive at the time, so they collide across clusters and are freed for reuse once their entity is pruned, and cloud becomes the book of record for a deploy after the runtime prunes it. A history keyed on short ids is one whose identifiers can later name something else.

That breaks the wire, which is why `source_deploy_id` came along now rather than waiting for someone to want its short id. Deploy visibility is unreleased, so a reshape costs nothing today and costs compatibility handling forever once clusters we don't control are running the released reporter.

A first backfill walks every deploy a cluster has ever run, so resolution takes the cheapest source per kind: versions cost one bulk read, deploys come free from the listing that already carries them, and the live tail resolves one at a time against a connection-scoped cache that remembers misses as well as hits.

Cloud's half is mirendev/cloud#211. Neither is much use without the other.

MIR-1615
