### PR TITLE
Serve raw Markdown at .md URLs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -93,6 +93,10 @@ const config: Config = {
       {
         generateLLMsTxt: true,
         generateLLMsFullTxt: true,
+        generateMarkdownFiles: true,
+        // Docs are served from the site root, so emit Markdown beside the
+        // corresponding HTML route rather than under build/docs/.
+        preserveDirectoryStructure: false,
         excludeImports: true,
         removeDuplicateHeadings: true,
         logLevel: 'quiet',


### PR DESCRIPTION
## Summary

- generate an individual Markdown file for every documentation page
- place generated Markdown beside the corresponding root-level HTML route
- update llms.txt links to point at the generated .md endpoints

## Verification

- `bun run build`
- `git diff --check`
- confirmed representative root, nested, and generated command routes emit matching `.html` and `.md` files

Closes MIR-1038