### PR TITLE
Re-list deploys when cloud says the cursor is no good

### DIFF
--- a/components/coordinate/deployreport.go
+++ b/components/coordinate/deployreport.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"sort"
+	"sync"
 	"time"
 
 	"miren.dev/runtime/api/core/core_v1alpha"
@@ -58,6 +59,21 @@ const (
 	// upserts without a range, and cloud advancing its watermark on that would
 	// open exactly the permanent gap this design exists to prevent.
 	TypeDeployBatch = "deploy.batch"
+
+	// TypeDeploySyncReset is cloud telling this cluster that the cursor it is
+	// reporting against is no longer usable and the sync has to start over.
+	//
+	// Cloud sends it two ways, and they mean the same thing here. An operator
+	// repairing history discards the cursor and cloud says so directly; or a
+	// batch arrives claiming to start above where cloud has reached, which
+	// would leave a hole in the frontier, and cloud refuses it and says so in
+	// reply. Either way the cursor this reporter is working from describes a
+	// position cloud does not share, and the only way back into agreement is a
+	// full re-list.
+	//
+	// It carries no payload on purpose. A reason would invite the reporter to
+	// treat some reasons differently, and there is only one correct response.
+	TypeDeploySyncReset = "deploy.sync.reset"
 )
 
 const (
@@ -299,6 +315,15 @@ type deploySource interface {
 // one starts the exchange over anyway.
 var errCompacted = errors.New("watch start revision has been compacted")
 
+// errResetRequested ends a stream because cloud asked for a full re-list.
+//
+// Deliberately the same shape as errCompacted, and handled beside it, because
+// the two are the same situation reached from opposite directions: the cursor
+// this stream resumed from is not one cloud can accept, and re-listing is the
+// remedy. Compaction is the cluster discovering that; a reset is cloud saying
+// it.
+var errResetRequested = errors.New("cloud asked for a full re-list")
+
 // syncMode is how a connection's deploy sync proceeds.
 type syncMode int
 
@@ -356,6 +381,7 @@ func (c *Coordinator) startDeployReporter(link *uplink.Client) {
 	}
 
 	link.Handle(TypeDeploySyncCursor, reporter.handleCursor)
+	link.Handle(TypeDeploySyncReset, reporter.handleReset)
 
 	link.OnConnect(func(ctx context.Context) {
 		// Run off the connection goroutine: this reads the entity store, and
@@ -375,6 +401,25 @@ type deployReporter struct {
 	// late to be used cannot be mistaken for the answer to the next
 	// connection's question.
 	cursors chan int64
+
+	// mu guards resetWanted and cancelStream.
+	//
+	// A flag rather than a queue, and the distinction is load-bearing. A
+	// channel makes "is a reset pending" and "take the reset" the same
+	// operation, so every place that wants to *ask* also has to consume, and
+	// any of them that then fails to re-list drops the request on the floor.
+	// Separating the two means only the code that actually starts a re-list
+	// clears it, and a connection dying anywhere else leaves it standing for
+	// the next one.
+	//
+	// It collapses for free: two resets and one reset ask for the same thing.
+	//
+	// cancelStream is the running stream's cancel, or nil when none is
+	// running. The lock is held only long enough to read or replace these; the
+	// cancel is called outside it, since it runs arbitrary work.
+	mu           sync.Mutex
+	resetWanted  bool
+	cancelStream context.CancelFunc
 
 	// Pacing, held as fields rather than read from the constants directly so a
 	// test can drive the protocol without waiting out a spread measured in
@@ -423,6 +468,65 @@ func (r *deployReporter) handleCursor(_ context.Context, data json.RawMessage) e
 	return nil
 }
 
+// handleReset records that cloud wants a full re-list.
+//
+// Nothing is read out of the message, and a reset that arrives when no stream
+// is running is deliberately left in the buffer rather than dropped. The two
+// senders differ in timing: a rejected batch arrives mid-stream and wants to
+// interrupt it, while an operator's reset can land between connections, and
+// keeping it means the next run honours it instead of needing cloud to say it
+// again.
+func (r *deployReporter) handleReset(_ context.Context, _ json.RawMessage) error {
+	r.log.Info("cloud asked for a full deploy re-list")
+
+	r.mu.Lock()
+	r.resetWanted = true
+	cancel := r.cancelStream
+	r.mu.Unlock()
+
+	// Wake a stream that is parked waiting for the next deploy.
+	//
+	// Queuing alone is not enough, because the only thing that reads the queue
+	// mid-stream is the watch callback, and the callback does not run until the
+	// cluster produces a deploy. On a quiet cluster that could be hours, which
+	// is exactly the cluster where an operator most needs the reset to land
+	// now: they were told the nudge was delivered.
+	//
+	// Done even when a reset was already pending. A second one against a
+	// parked stream still has to wake it.
+	if cancel != nil {
+		cancel()
+	}
+
+	return nil
+}
+
+// setStreamCancel records the running stream's cancel, or clears it with nil.
+func (r *deployReporter) setStreamCancel(cancel context.CancelFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cancelStream = cancel
+}
+
+// resetPending reports whether cloud has asked for a re-list, without taking
+// the request. Everything that decides uses this; only takeReset clears it.
+func (r *deployReporter) resetPending() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.resetWanted
+}
+
+// takeReset clears a pending request.
+//
+// Called from exactly one place, where a re-list actually begins. Anything
+// else that cleared it could fail to re-list afterwards, and the request would
+// be gone with the cursor it was meant to invalidate still in use.
+func (r *deployReporter) takeReset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.resetWanted = false
+}
+
 // run reports deploys until the connection drops.
 //
 // Failure here is deliberately non-fatal and unretried within a connection.
@@ -454,6 +558,15 @@ func (r *deployReporter) run(ctx context.Context, link deployLink) {
 	ids := newShortIDs(r.source)
 
 	mode, reason := decideSyncMode(watermark, head)
+
+	// A reset that arrived while nothing was streaming outranks the cursor.
+	// Cloud may well have answered the hello with a watermark it is about to
+	// disown, since clearing the cursor and saying so are two writes and the
+	// handshake can land between them.
+	if r.resetPending() {
+		mode, reason = syncRelist, "cloud asked for a full re-list"
+	}
+
 	if mode == syncDelta {
 		r.log.Info("resuming deploy sync from cloud's watermark",
 			"watermark", watermark, "head", head)
@@ -472,12 +585,15 @@ func (r *deployReporter) run(ctx context.Context, link deployLink) {
 		// not evidence the cursor is bad, and re-listing on it would turn a
 		// blip into a full re-send of the cluster's history. The connection is
 		// coming down anyway, and the next one starts the handshake over.
-		if !errors.Is(err, errCompacted) {
+		switch {
+		case errors.Is(err, errCompacted):
+			r.log.Info("deploy watermark has been compacted away, re-listing")
+		case errors.Is(err, errResetRequested):
+			r.log.Info("cloud disowned the deploy watermark mid-stream, re-listing")
+		default:
 			r.log.Warn("deploy stream ended, waiting for the next connection", "error", err)
 			return
 		}
-
-		r.log.Info("deploy watermark has been compacted away, re-listing")
 	} else {
 		r.log.Info("re-listing deploys for cloud", "reason", reason,
 			"watermark", watermark, "head", head)
@@ -524,11 +640,35 @@ func (r *deployReporter) requestCursor(ctx context.Context, link deployLink) (in
 // Returns nil when the connection ends, and an error when the stream must fall
 // back to a re-list.
 func (r *deployReporter) stream(ctx context.Context, link deployLink, from, head int64, ids *shortIDs) error {
+	// The watch runs under a context this reporter can cancel, so a reset can
+	// end a stream that is parked between deploys rather than waiting for one.
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	r.setStreamCancel(cancel)
+	defer r.setStreamCancel(nil)
+
+	// A reset that landed between the caller's check and the registration
+	// above found no stream to cancel, and a parked watch would never notice
+	// it. Checked here, after the cancel is visible, so that window is closed.
+	if r.resetPending() {
+		return errResetRequested
+	}
+
 	sent := from
 
-	return r.source.Watch(ctx, from, func(op *esv1.EntityOp) error {
+	err := r.source.Watch(watchCtx, from, func(op *esv1.EntityOp) error {
 		if op.IsCompacted() {
 			return errCompacted
+		}
+
+		// The callback fires as the cluster produces deploys, which is exactly
+		// when a stream is advancing cloud's watermark past the position a
+		// reset was trying to clear, so a busy cluster stops here on its next
+		// event. A parked one never reaches this at all, and is woken by the
+		// cancellation above instead.
+		if r.resetPending() {
+			return errResetRequested
 		}
 
 		revision := op.Revision()
@@ -578,6 +718,17 @@ func (r *deployReporter) stream(ctx context.Context, link deployLink, from, head
 		sent = revision
 		return nil
 	})
+
+	// A watch cancelled by a reset is indistinguishable from any other
+	// cancellation at this point, and the pending flag is what tells them
+	// apart. No parent-context guard is needed: nothing is consumed here, so a
+	// connection going away mid-answer leaves the request standing for the
+	// next one rather than losing it.
+	if err != nil && !errors.Is(err, errResetRequested) && r.resetPending() {
+		return errResetRequested
+	}
+
+	return err
 }
 
 // relist re-sends every deploy the runtime holds, oldest first, then continues
@@ -590,6 +741,10 @@ func (r *deployReporter) stream(ctx context.Context, link deployLink, from, head
 // resume: whatever ranges committed stay committed, and the next connection
 // picks up from the watermark they left behind.
 func (r *deployReporter) relist(ctx context.Context, link deployLink, head int64, ids *shortIDs) {
+	// The single place a pending reset is cleared, because this is the single
+	// place its request is carried out.
+	r.takeReset()
+
 	records, readRevision, err := r.source.List(ctx)
 	if err != nil {
 		r.log.Warn("failed to list deploys for cloud", "error", err)

--- a/components/coordinate/deployreport_test.go
+++ b/components/coordinate/deployreport_test.go
@@ -422,6 +422,16 @@ type fakeDeploySource struct {
 	shortIDs map[string]string
 	byKind   map[entity.Id][]string
 
+	// parkWatch makes the first watch block after delivering its ops, the way a
+	// real one does between deploys, and closes parked when it gets there.
+	// Only the first, so the re-list that follows an interrupt can finish.
+	parkWatch bool
+	parked    chan struct{}
+
+	// onOp runs before each streamed op is handed to the reporter, so a test
+	// can act from inside an active watch rather than only around one.
+	onOp func(int)
+
 	listed   bool
 	getCalls []string
 	kindList []entity.Id
@@ -451,18 +461,28 @@ func (f *fakeDeploySource) ShortIDsForKind(_ context.Context, kind entity.Id) ma
 	return out
 }
 
-func (f *fakeDeploySource) Watch(_ context.Context, from int64, fn func(*esv1.EntityOp) error) error {
+func (f *fakeDeploySource) Watch(ctx context.Context, from int64, fn func(*esv1.EntityOp) error) error {
 	if err, ok := f.watchErr[from]; ok {
 		return err
 	}
 
-	for _, op := range f.watchOps {
+	for i, op := range f.watchOps {
 		if op.Revision() <= from {
 			continue
+		}
+		if f.onOp != nil {
+			f.onOp(i)
 		}
 		if err := fn(op); err != nil {
 			return err
 		}
+	}
+
+	if f.parkWatch {
+		f.parkWatch = false
+		close(f.parked)
+		<-ctx.Done()
+		return ctx.Err()
 	}
 
 	return nil
@@ -939,4 +959,226 @@ func TestSourceDeployResolvesFromTheListingWithoutAnyRead(t *testing.T) {
 		"the source deploy was in the listing, so resolving it must cost no read")
 	assert.NotContains(t, src.kindList, core_v1alpha.KindDeployment,
 		"and the deployment kind must not be listed to learn it")
+}
+
+// A reset that lands mid-stream has to abandon the stream, not finish it.
+//
+// This is the case the whole mechanism exists for. A busy cluster streaming
+// deploys is exactly the one whose batches keep re-creating the cursor an
+// operator just cleared, so noticing the reset only at the next connect would
+// mean noticing it after the damage.
+func TestResetMidStreamFallsBackToRelist(t *testing.T) {
+	src := &fakeDeploySource{
+		head: 5000,
+		records: []*deploylifecycle.Record{
+			deployRecord(t, "web", 100),
+		},
+		listRevision: 5000,
+		watchOps: []*esv1.EntityOp{
+			deployOp(t, "web", 5100),
+			deployOp(t, "api", 5200),
+		},
+	}
+
+	r := newTestReporter(src)
+	link := &fakeDeployLink{}
+	link.onHello = func() { r.cursors <- 4000 }
+
+	// Delivered from inside the watch, after one op has streamed. Sending it
+	// during the hello would be intercepted by run's pre-stream check and the
+	// callback path — the one this test exists for — would never run.
+	src.onOp = func(i int) {
+		if i == 1 {
+			require.NoError(t, r.handleReset(context.Background(), nil))
+		}
+	}
+
+	r.run(testCtx(t), link)
+
+	assert.True(t, src.listed, "a reset must fall back to the full re-list")
+
+	batches := link.batches()
+	require.NotEmpty(t, batches)
+
+	// The first batch predates the reset: it is the delta stream doing its job
+	// against a cursor cloud had not yet disowned. What matters is that the
+	// stream stopped there and the re-list picked up from the bottom.
+	assert.Equal(t, int64(4000), batches[0].FromRevision)
+
+	require.Greater(t, len(batches), 1, "the stream must be followed by a re-list")
+	assert.Equal(t, int64(0), batches[1].FromRevision,
+		"the re-list restarts the frontier from the bottom, not from the disowned cursor")
+
+	for _, b := range batches[1:] {
+		assert.NotEqual(t, int64(4000), b.FromRevision,
+			"nothing after the reset may still report against the disowned cursor")
+	}
+}
+
+// A reset that arrives between connections outranks whatever the hello was
+// answered with.
+//
+// Clearing the cursor and saying so are two separate writes, so a handshake can
+// land in between and be told a watermark cloud is about to disown. The reset
+// has to win that race or the repair silently does not happen.
+func TestResetBetweenConnectionsOverridesAUsableCursor(t *testing.T) {
+	src := &fakeDeploySource{
+		head: 5000,
+		records: []*deploylifecycle.Record{
+			deployRecord(t, "web", 100),
+		},
+		listRevision: 5000,
+		watchOps: []*esv1.EntityOp{
+			deployOp(t, "web", 5100),
+		},
+	}
+
+	r := newTestReporter(src)
+	require.NoError(t, r.handleReset(context.Background(), nil))
+
+	link := &fakeDeployLink{}
+	link.onHello = func() { r.cursors <- 4000 }
+	r.run(testCtx(t), link)
+
+	assert.True(t, src.listed,
+		"a pending reset must re-list even though the cursor it was answered with looks usable")
+}
+
+// Two resets and one reset ask for the same thing, so the second must not buy a
+// second re-list on the following connection.
+func TestRepeatedResetsCollapse(t *testing.T) {
+	r := newTestReporter(&fakeDeploySource{head: 5000})
+
+	require.NoError(t, r.handleReset(context.Background(), nil))
+	require.NoError(t, r.handleReset(context.Background(), nil))
+
+	assert.True(t, r.resetPending())
+
+	r.takeReset()
+	assert.False(t, r.resetPending(),
+		"two asks are one request; the second must not buy a second re-list")
+}
+
+// Asking must not consume, or any caller that asks and then fails to re-list
+// drops the request on the floor along with the cursor it was invalidating.
+func TestAskingForAResetDoesNotConsumeIt(t *testing.T) {
+	r := newTestReporter(&fakeDeploySource{head: 5000})
+
+	assert.False(t, r.resetPending(), "nothing pending to begin with")
+	require.NoError(t, r.handleReset(context.Background(), nil))
+
+	assert.True(t, r.resetPending())
+	assert.True(t, r.resetPending(), "asking twice must still say yes")
+
+	r.takeReset()
+	assert.False(t, r.resetPending())
+}
+
+// A reset has to interrupt a watch that is parked between deploys, not wait for
+// the cluster to produce one.
+//
+// The queue alone cannot do this: the only thing that reads it mid-stream is
+// the watch callback, and on a quiet cluster the callback does not run. That is
+// the cluster where an operator most needs the reset to land promptly, because
+// cloud has already told them the nudge was delivered.
+func TestResetInterruptsAParkedWatch(t *testing.T) {
+	src := &fakeDeploySource{
+		head: 5000,
+		records: []*deploylifecycle.Record{
+			deployRecord(t, "web", 100),
+		},
+		listRevision: 5000,
+		parkWatch:    true,
+		parked:       make(chan struct{}),
+	}
+
+	r := newTestReporter(src)
+	link := &fakeDeployLink{}
+	link.onHello = func() { r.cursors <- 4000 }
+
+	// Delivered only once the watch is genuinely parked, so this cannot pass by
+	// racing ahead of the stream the way the mid-stream test does.
+	go func() {
+		<-src.parked
+		_ = r.handleReset(context.Background(), nil)
+	}()
+
+	r.run(testCtx(t), link)
+
+	assert.True(t, src.listed,
+		"a reset must wake a parked watch rather than waiting for the next deploy")
+
+	batches := link.batches()
+	require.NotEmpty(t, batches)
+	assert.Equal(t, int64(0), batches[0].FromRevision,
+		"and the re-list restarts from the bottom, not from the disowned cursor")
+}
+
+// A connection going away while a reset happens to be pending must not be
+// turned into a re-list against a link that is closing. The reset stays queued
+// and the next connection honours it.
+func TestParentCancellationIsNotAReset(t *testing.T) {
+	src := &fakeDeploySource{
+		head:         5000,
+		records:      []*deploylifecycle.Record{deployRecord(t, "web", 100)},
+		listRevision: 5000,
+		parkWatch:    true,
+		parked:       make(chan struct{}),
+	}
+
+	r := newTestReporter(src)
+	link := &fakeDeployLink{}
+	link.onHello = func() { r.cursors <- 4000 }
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		<-src.parked
+		cancel()
+	}()
+
+	r.run(ctx, link)
+
+	assert.False(t, src.listed, "a closing connection must not start a backfill")
+}
+
+// A stream that ends without re-listing must leave the request standing.
+//
+// This is the failure the flag exists to make impossible. When asking and
+// taking were one operation, a stream could consume the request, return
+// "re-list", and then have run decline to act because the connection had gone
+// away in the meantime. The request was then gone while the cursor it was
+// meant to invalidate stayed in use, and the next connection resumed happily
+// from it.
+func TestAStreamThatDoesNotRelistLeavesTheResetStanding(t *testing.T) {
+	src := &fakeDeploySource{head: 5000}
+	r := newTestReporter(src)
+
+	require.NoError(t, r.handleReset(context.Background(), nil))
+
+	// A connection that is already gone, so nothing downstream will re-list.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_ = r.stream(ctx, &fakeDeployLink{}, 4000, 5000, newShortIDs(src))
+
+	assert.True(t, r.resetPending(),
+		"stream must not consume a request it did not carry out")
+}
+
+// And the re-list is what clears it, so the repair is not asked for twice.
+func TestRelistTakesTheReset(t *testing.T) {
+	src := &fakeDeploySource{
+		head:         5000,
+		records:      []*deploylifecycle.Record{deployRecord(t, "web", 100)},
+		listRevision: 5000,
+	}
+
+	r := newTestReporter(src)
+	require.NoError(t, r.handleReset(context.Background(), nil))
+
+	r.relist(testCtx(t), &fakeDeployLink{}, 5000, newShortIDs(src))
+
+	assert.True(t, src.listed)
+	assert.False(t, r.resetPending(), "the re-list satisfied the request")
 }


### PR DESCRIPTION
Cloud holds the deploy sync cursor and this reporter reads it exactly once per connection, at the sync hello. That left cloud with no way to say "your cursor is wrong" at any other moment, which matters more than it sounds: an operator clearing a cursor to repair stored deploy history had to wait for a reconnect that nothing forces, and until then the cluster kept streaming against a position cloud had already disowned.

So cloud can now send `deploy.sync.reset`. It means what compaction already meant here, that the cursor this stream resumed from isn't one cloud can accept and the remedy is to send everything again, so it's handled right beside `errCompacted`. The two are the same situation from opposite directions: compaction is the cluster discovering it, a reset is cloud saying it.

A reset also cancels a watch that's parked between deploys, rather than waiting for an event that may never come. Without that the nudge does nothing on a quiet cluster, which is exactly the cluster where an operator most needs it to land, having just been told it was delivered.

The pending request is a flag under the mutex that guards the stream's cancel, rather than a queue, so that asking and taking are separate operations. Only `relist` clears it, at the point it starts doing the work. A channel would force every site that wants to ask to consume, and any of them that then failed to re-list would drop the request while the cursor it was invalidating stayed in use.

Pairs with mirendev/cloud#213, which is the other half.

MIR-1616
