### PR TITLE
Add contextual agent skill callouts

### DIFF
--- a/docs/docs/app-configuration.md
+++ b/docs/docs/app-configuration.md
@@ -23,6 +23,14 @@ command = "npm start"
 
 Deploy with `miren deploy` and Miren builds the image and runs `web` with that command. Everything else on this page is additive — environment variables, more services, scaling, disks.
 
+:::tip[Have an agent inspect your app]
+Install the [Miren agent skills](/agent-skills) and ask your AI coding agent to
+"set up this app on Miren." The `app-setup` skill can inspect the repository,
+identify the services and environment variables it needs, and prepare a working
+`.miren/app.toml`. Use the rest of this page when you want to review or customize
+the result.
+:::
+
 ## When You Don't Need app.toml
 
 If your app is a single web service with a standard language stack, Miren handles everything:

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -168,6 +168,13 @@ Now that you've got something deployed, here's where to go depending on what you
 
 **Deploy your own app.** Miren auto-detects Python, Node, Bun, Go, Ruby, and Rust projects. Run `miren init` in your project to create a [`.miren/app.toml`](/app-configuration) config, then `miren deploy`. You can always provide a `Dockerfile` if you need full control over the build. For a step-by-step walkthrough for your language, see the [Language Guides](/guides).
 
+:::tip[Set up your own app with an agent]
+Install the [Miren agent skills](/agent-skills) and ask your AI coding agent to
+"set up this app on Miren." The `app-setup` skill inspects your project, works
+out its services and environment variables, creates the configuration, and
+walks through the first deploy.
+:::
+
 **Manage multiple clusters.** If you have more than one server, use [`miren cluster`](/command/cluster) to list your clusters and `miren cluster switch` to change which one you're targeting before deploying.
 
 **Configure your app.** The [App Configuration](/app-configuration) guide covers `.miren/app.toml` in depth: setting commands, ports, environment variables, concurrency, and more.

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -30,6 +30,13 @@ miren doctor auth     # Check authentication
 ```
 </CliCommand>
 
+:::tip[Get a combined diagnosis]
+Install the [Miren agent skills](/agent-skills) and ask your AI coding agent to
+"check the health of this app" or "check the health of this cluster."
+The `app-health` and `cluster-health` skills combine status, deployment history,
+logs, and diagnostics into a prioritized report with suggested next steps.
+:::
+
 ## App not starting
 
 If your app is deployed but not responding:


### PR DESCRIPTION
## Summary

- point users to `app-setup` when they transition to their own app or deeper configuration
- point troubleshooting users to `app-health` and `cluster-health` after the initial diagnostic commands
- keep callouts task-adjacent and out of generated command/reference pages

## Verification

- `bun run build`
- `git diff --check`
- Impeccable UI detector returned no findings for the three changed pages

Closes MIR-1055