### PR TITLE
Use the cloud volume id for accelerator lease calls

### DIFF
--- a/components/diskio/cloud_integration_test.go
+++ b/components/diskio/cloud_integration_test.go
@@ -223,7 +223,18 @@ func (m *mockCloudServer) handleUploadRequest(w http.ResponseWriter, r *http.Req
 
 	volumeID := volumeIDFromUpdatesPath(r.URL.Path)
 
+	// A leased volume rejects writes that don't carry the current nonce, which
+	// is exactly the production failure MIR-1634 reproduces: the uploader knew
+	// the nonce but keyed off the wrong volume id and so omitted it.
 	m.mu.Lock()
+	if lease, held := m.leases[volumeID]; held && req.LeaseNonce != lease.Nonce {
+		m.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"error":"volume has an active lease: nonce required"}`)
+		return
+	}
+
 	segID := m.nextID("seg")
 	m.segments[segID] = &storedSegment{
 		VolumeID: volumeID,
@@ -765,4 +776,75 @@ func TestCloudIntegrationOverwriteSemantics(t *testing.T) {
 	horizon, err := readLogHorizon(volDir)
 	require.NoError(t, err)
 	assert.Equal(t, labels[1], horizon)
+}
+
+// TestCloudIntegrationLeasedWatcherUploadIncludesNonce is the end-to-end
+// regression for MIR-1634. The volume's local entity id and its cloud id are
+// deliberately different, and the cloud holds an active lease, so an upload
+// that omits the nonce is rejected. It exercises the real LogWatcher →
+// CloudSegmentUploader → cloud path and asserts the segment is accepted,
+// proving the nonce was resolved through the cloud id and forwarded.
+func TestCloudIntegrationLeasedWatcherUploadIncludesNonce(t *testing.T) {
+	mock := newMockCloudServer(t)
+	authClient := newTestAuthClient(t, mock.URL())
+
+	// Local entity id and cloud id differ, matching production.
+	entityID := "disk_volume/vol-local"
+	localVolumeID := "vol-local"
+	cloudVolumeID := "vol-cloud-1634"
+	blockSize := uint32(4096)
+	tmpDir := t.TempDir()
+
+	volDir := filepath.Join(tmpDir, "vol-1634")
+	logDir := filepath.Join(volDir, "logs")
+	require.NoError(t, os.MkdirAll(logDir, 0755))
+
+	data := bytes.Repeat([]byte{0xEE}, 4096)
+	label := "400000000000000100000001"
+	buildSegmentFile(t, logDir, label, blockSize, []lbd.Entry{
+		makeWriteEntry(0, data),
+	})
+
+	// Acquire an active lease on the cloud volume via the real client, so the
+	// mock will reject any upload that arrives without the matching nonce.
+	client := NewCloudDiskClient(slog.Default(), mock.URL(), authClient)
+	nonce, err := client.AcquireLease(context.Background(), cloudVolumeID)
+	require.NoError(t, err)
+	require.NotEmpty(t, nonce)
+
+	state := NewState()
+	state.SetVolume(entityID, &VolumeState{
+		EntityId:      entityID,
+		VolumeId:      localVolumeID,
+		CloudVolumeId: cloudVolumeID,
+		DiskPath:      volDir,
+		Mode:          storage_v1alpha.VM_ACCELERATOR,
+	})
+	// The mount records the lease nonce, keyed by the local entity id — the
+	// same shape the mount controller writes in production.
+	state.SetMount("disk_mount/mnt-1634", &MountState{
+		EntityId:   "disk_mount/mnt-1634",
+		VolumeId:   entityID,
+		Mode:       storage_v1alpha.VM_ACCELERATOR,
+		LeaseNonce: nonce,
+	})
+
+	uploader := NewCloudSegmentUploader(slog.Default(), mock.URL(), authClient, state)
+	watcher := NewLogWatcher(slog.Default(), state, uploader, time.Second)
+
+	watcher.scanAndUpload(context.Background())
+
+	// The upload must have been accepted for the cloud volume id, which only
+	// happens if the nonce was forwarded.
+	completed := mock.completedSegments(cloudVolumeID)
+	require.Len(t, completed, 1, "leased upload should succeed with the nonce")
+	assert.Equal(t, label, completed[0].Label)
+
+	// The segment file should have been consumed and the horizon advanced.
+	_, statErr := os.Stat(filepath.Join(logDir, fmt.Sprintf("disk.%s.log", label)))
+	assert.True(t, os.IsNotExist(statErr), "uploaded log file should have been removed")
+
+	horizon, err := readLogHorizon(volDir)
+	require.NoError(t, err)
+	assert.Equal(t, label, horizon)
 }

--- a/components/diskio/cloud_uploader.go
+++ b/components/diskio/cloud_uploader.go
@@ -74,16 +74,13 @@ func (u *CloudSegmentUploader) UploadSegment(ctx context.Context, volumeID, segm
 	}, f, size)
 }
 
-// leaseNonceFor finds the nonce held for a volume in mount state, if any. The
-// cloud requires it on writes to a leased volume.
-func (u *CloudSegmentUploader) leaseNonceFor(volumeID string) string {
+// leaseNonceFor finds the nonce held for a cloud volume in mount state, if any.
+// The cloud requires it on writes to a leased volume. cloudVolumeID is the
+// volume's miren.cloud id; mount state keys off the local entity id, so the
+// lookup is delegated to State, which bridges the two.
+func (u *CloudSegmentUploader) leaseNonceFor(cloudVolumeID string) string {
 	if u.state == nil {
 		return ""
 	}
-	for _, m := range u.state.ListMounts() {
-		if m.VolumeId == volumeID && m.LeaseNonce != "" {
-			return m.LeaseNonce
-		}
-	}
-	return ""
+	return u.state.LeaseNonceForCloudVolume(cloudVolumeID)
 }

--- a/components/diskio/cloud_uploader_test.go
+++ b/components/diskio/cloud_uploader_test.go
@@ -145,14 +145,22 @@ func TestCloudSegmentUploaderRejectsUnlabelledSegment(t *testing.T) {
 func TestCloudSegmentUploaderIncludesLeaseNonce(t *testing.T) {
 	fake := &fakeUpdatesClient{}
 	state := NewState()
+	// The local entity id and the cloud id are deliberately different: the
+	// uploader is handed the cloud id, but mount state keys off the local
+	// entity id, so a direct comparison would omit the nonce (MIR-1634).
+	state.SetVolume("disk_volume/abc", &VolumeState{
+		EntityId:      "disk_volume/abc",
+		VolumeId:      "abc",
+		CloudVolumeId: "vol-cloud-xyz",
+	})
 	state.SetMount("mount-1", &MountState{
 		EntityId:   "mount-1",
-		VolumeId:   "vol-123",
+		VolumeId:   "disk_volume/abc",
 		LeaseNonce: "nonce-abc",
 	})
 
 	uploader := NewCloudSegmentUploaderWithClient(slog.Default(), fake, state)
-	_, err := uploader.UploadSegment(context.Background(), "vol-123",
+	_, err := uploader.UploadSegment(context.Background(), "vol-cloud-xyz",
 		writeTestSegment(t, "400000000000000100000001", []byte("data")))
 	require.NoError(t, err)
 

--- a/components/diskio/disk_mount_controller.go
+++ b/components/diskio/disk_mount_controller.go
@@ -115,14 +115,37 @@ func (c *DiskMountController) Shutdown() {
 	// Release cloud leases for any active mounts
 	if c.cloudClient != nil {
 		for _, ms := range c.state.ListMounts() {
-			if ms.LeaseNonce != "" {
-				c.log.Info("releasing lease on shutdown", "entity_id", ms.EntityId, "volume_id", ms.VolumeId)
-				if err := c.cloudClient.ReleaseLease(context.Background(), ms.VolumeId, ms.LeaseNonce); err != nil {
-					c.log.Warn("failed to release lease on shutdown", "entity_id", ms.EntityId, "error", err)
-				}
+			if ms.LeaseNonce == "" {
+				continue
+			}
+			cloudID := c.cloudVolumeIdFor(ms)
+			if cloudID == "" {
+				continue
+			}
+			c.log.Info("releasing lease on shutdown", "entity_id", ms.EntityId, "cloud_volume_id", cloudID)
+			if err := c.cloudClient.ReleaseLease(context.Background(), cloudID, ms.LeaseNonce); err != nil {
+				c.log.Warn("failed to release lease on shutdown", "entity_id", ms.EntityId, "error", err)
 			}
 		}
 	}
+}
+
+// cloudVolumeIdFor resolves a mount's backing cloud volume id, or "" if the
+// volume is unknown or not yet registered with the cloud. Mount state's
+// VolumeId is the local disk_volume entity id, which the cloud lease api never
+// accepts, so every lease-release path must map through here. The cloud id
+// recorded on the mount wins — it survives the VolumeState being deleted (e.g.
+// orphan cleanup); otherwise fall back to the volume state for mounts persisted
+// before the cloud id was recorded on the mount.
+func (c *DiskMountController) cloudVolumeIdFor(ms *MountState) string {
+	if ms.CloudVolumeId != "" {
+		return ms.CloudVolumeId
+	}
+	v := c.state.GetVolume(ms.VolumeId)
+	if v == nil {
+		return ""
+	}
+	return v.CloudVolumeId
 }
 
 func (c *DiskMountController) reconcileMount(ctx context.Context, mount *storage_v1alpha.DiskMount) error {
@@ -169,17 +192,20 @@ func (c *DiskMountController) reconcileMountMounted(ctx context.Context, mount *
 				)
 				volState := c.state.GetVolume(string(mount.VolumeId))
 				var mode storage_v1alpha.DiskVolumeVolumeMode
+				var cloudVolumeId string
 				if volState != nil {
 					mode = volState.Mode
+					cloudVolumeId = volState.CloudVolumeId
 				}
 				c.state.SetMount(entityId, &MountState{
-					EntityId:   entityId,
-					VolumeId:   string(mount.VolumeId),
-					DevicePath: mount.DevicePath,
-					MountPath:  mount.MountPath,
-					Mounted:    true,
-					ReadOnly:   mount.ReadOnly,
-					Mode:       mode,
+					EntityId:      entityId,
+					VolumeId:      string(mount.VolumeId),
+					CloudVolumeId: cloudVolumeId,
+					DevicePath:    mount.DevicePath,
+					MountPath:     mount.MountPath,
+					Mounted:       true,
+					ReadOnly:      mount.ReadOnly,
+					Mode:          mode,
 				})
 				if err := c.state.Save(); err != nil {
 					c.log.Warn("failed to save reconstructed mount state", "error", err)
@@ -258,11 +284,12 @@ func (c *DiskMountController) attachAndMount(ctx context.Context, mount *storage
 	// Just set up tracking and mark DM_MOUNTED.
 	if alwaysMount(volState.Mode) {
 		devPath, mntPath, err := c.state.SetMountFromVolume(volumeId, &MountState{
-			EntityId: entityId,
-			VolumeId: volumeId,
-			Mounted:  true,
-			ReadOnly: mount.ReadOnly,
-			Mode:     volState.Mode,
+			EntityId:      entityId,
+			VolumeId:      volumeId,
+			CloudVolumeId: volState.CloudVolumeId,
+			Mounted:       true,
+			ReadOnly:      mount.ReadOnly,
+			Mode:          volState.Mode,
 		})
 		if err != nil {
 			c.setMountError(ctx, mount.ID, err.Error())
@@ -365,14 +392,15 @@ func (c *DiskMountController) attachAndMount(ctx context.Context, mount *storage
 	}
 
 	c.state.SetMount(entityId, &MountState{
-		EntityId:   entityId,
-		VolumeId:   volumeId,
-		DevicePath: devicePath,
-		MountPath:  mount.MountPath,
-		Mounted:    false,
-		ReadOnly:   mount.ReadOnly,
-		Mode:       volState.Mode,
-		LeaseNonce: leaseNonce,
+		EntityId:      entityId,
+		VolumeId:      volumeId,
+		CloudVolumeId: volState.CloudVolumeId,
+		DevicePath:    devicePath,
+		MountPath:     mount.MountPath,
+		Mounted:       false,
+		ReadOnly:      mount.ReadOnly,
+		Mode:          volState.Mode,
+		LeaseNonce:    leaseNonce,
 	})
 
 	if err := c.state.Save(); err != nil {
@@ -612,9 +640,11 @@ func (c *DiskMountController) unmountAndDetach(ctx context.Context, mount *stora
 	// Release cloud lease if one was acquired
 	var leaseErr error
 	if mountState.LeaseNonce != "" && c.cloudClient != nil {
-		if err := c.cloudClient.ReleaseLease(ctx, mountState.VolumeId, mountState.LeaseNonce); err != nil {
-			c.log.Warn("failed to release volume lease", "entity_id", entityId, "error", err)
-			leaseErr = fmt.Errorf("failed to release volume lease: %w", err)
+		if cloudID := c.cloudVolumeIdFor(mountState); cloudID != "" {
+			if err := c.cloudClient.ReleaseLease(ctx, cloudID, mountState.LeaseNonce); err != nil {
+				c.log.Warn("failed to release volume lease", "entity_id", entityId, "error", err)
+				leaseErr = fmt.Errorf("failed to release volume lease: %w", err)
+			}
 		}
 	}
 
@@ -812,8 +842,10 @@ func (c *DiskMountController) teardownLocalMount(ctx context.Context, mountState
 	}
 
 	if mountState.LeaseNonce != "" && c.cloudClient != nil {
-		if err := c.cloudClient.ReleaseLease(ctx, mountState.VolumeId, mountState.LeaseNonce); err != nil {
-			c.log.Warn("failed to release lease for orphaned mount", "entity_id", mountState.EntityId, "error", err)
+		if cloudID := c.cloudVolumeIdFor(mountState); cloudID != "" {
+			if err := c.cloudClient.ReleaseLease(ctx, cloudID, mountState.LeaseNonce); err != nil {
+				c.log.Warn("failed to release lease for orphaned mount", "entity_id", mountState.EntityId, "error", err)
+			}
 		}
 	}
 

--- a/components/diskio/disk_mount_controller_test.go
+++ b/components/diskio/disk_mount_controller_test.go
@@ -847,3 +847,71 @@ func TestDiskMountControllerUniversalOrphanSkipsUnmount(t *testing.T) {
 	// Mount state should still be cleaned up from mount controller's perspective
 	assert.Nil(t, state.GetMount("disk_mount/mnt-orphan-uni"))
 }
+
+// TestDiskMountControllerTeardownReleasesWithCloudId asserts the orphan-cleanup
+// lease release uses the volume's cloud id, not the local entity id stored on
+// the mount. The two are deliberately different here (MIR-1634).
+func TestDiskMountControllerTeardownReleasesWithCloudId(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+	state := NewState()
+	ops := newMockDiskMountOps()
+
+	state.SetVolume("disk_volume/vol-acc", &VolumeState{
+		EntityId:      "disk_volume/vol-acc",
+		VolumeId:      "vol-acc",
+		CloudVolumeId: "vol-cloud-acc",
+		Mode:          storage_v1alpha.VM_ACCELERATOR,
+	})
+	mountState := &MountState{
+		EntityId:   "disk_mount/mnt-acc",
+		VolumeId:   "disk_volume/vol-acc",
+		DevicePath: "/dev/loop3",
+		Mode:       storage_v1alpha.VM_ACCELERATOR,
+		LeaseNonce: "nonce-acc",
+	}
+	state.SetMount("disk_mount/mnt-acc", mountState)
+
+	cloud := &mockCloudDiskClient{}
+	mc := newTestDiskMountController(log, t.TempDir(), "test-node", nil, state, ops)
+	mc.SetCloudClient(cloud)
+
+	mc.teardownLocalMount(ctx, mountState)
+
+	require.Len(t, cloud.releaseLeaseCalls, 1)
+	assert.Equal(t, "vol-cloud-acc", cloud.releaseLeaseCalls[0].volumeID)
+	assert.Equal(t, "nonce-acc", cloud.releaseLeaseCalls[0].nonce)
+}
+
+// TestDiskMountControllerTeardownReleasesAfterVolumeGone is the robustness win
+// from persisting the cloud id on the mount: orphan cleanup runs after the
+// backing VolumeState has already been deleted, yet the lease is still released
+// with the correct cloud id because the mount carries it (MIR-1634).
+func TestDiskMountControllerTeardownReleasesAfterVolumeGone(t *testing.T) {
+	ctx := t.Context()
+	log := testutils.TestLogger(t)
+	state := NewState()
+	ops := newMockDiskMountOps()
+
+	// Deliberately no VolumeState: the volume entity/state is gone, which is
+	// exactly the orphan-cleanup situation.
+	mountState := &MountState{
+		EntityId:      "disk_mount/mnt-acc",
+		VolumeId:      "disk_volume/vol-acc",
+		CloudVolumeId: "vol-cloud-acc",
+		DevicePath:    "/dev/loop3",
+		Mode:          storage_v1alpha.VM_ACCELERATOR,
+		LeaseNonce:    "nonce-acc",
+	}
+	state.SetMount("disk_mount/mnt-acc", mountState)
+
+	cloud := &mockCloudDiskClient{}
+	mc := newTestDiskMountController(log, t.TempDir(), "test-node", nil, state, ops)
+	mc.SetCloudClient(cloud)
+
+	mc.teardownLocalMount(ctx, mountState)
+
+	require.Len(t, cloud.releaseLeaseCalls, 1)
+	assert.Equal(t, "vol-cloud-acc", cloud.releaseLeaseCalls[0].volumeID)
+	assert.Equal(t, "nonce-acc", cloud.releaseLeaseCalls[0].nonce)
+}

--- a/components/diskio/segment_replay_test.go
+++ b/components/diskio/segment_replay_test.go
@@ -534,6 +534,15 @@ func TestLeaseReleasedOnUnmount(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	state := NewState()
+	// The local entity id and the cloud id differ; the release must use the
+	// cloud id, resolved through volume state, not the local id on the mount
+	// (MIR-1634).
+	state.SetVolume("disk_volume/vol1", &VolumeState{
+		EntityId:      "disk_volume/vol1",
+		VolumeId:      "vol1",
+		CloudVolumeId: "vol-cloud-1",
+		Mode:          storage_v1alpha.VM_ACCELERATOR,
+	})
 	state.SetMount("disk_mount/mnt-1", &MountState{
 		EntityId:   "disk_mount/mnt-1",
 		VolumeId:   "disk_volume/vol1",
@@ -547,7 +556,7 @@ func TestLeaseReleasedOnUnmount(t *testing.T) {
 	mc.Shutdown()
 
 	require.Len(t, cloud.releaseLeaseCalls, 1)
-	assert.Equal(t, "disk_volume/vol1", cloud.releaseLeaseCalls[0].volumeID)
+	assert.Equal(t, "vol-cloud-1", cloud.releaseLeaseCalls[0].volumeID)
 	assert.Equal(t, "nonce-abc", cloud.releaseLeaseCalls[0].nonce)
 }
 

--- a/components/diskio/state.go
+++ b/components/diskio/state.go
@@ -74,6 +74,13 @@ type MountState struct {
 	// VolumeId is the ID of the disk_volume entity
 	VolumeId string `json:"volume_id"`
 
+	// CloudVolumeId is the backing volume's miren.cloud identifier, captured
+	// when the mount is created. Every cloud lease call keys off it, and
+	// recording it here means lease release still works after the volume's
+	// VolumeState is gone (e.g. orphan cleanup). Empty for mounts persisted
+	// before this field existed, or volumes never registered with the cloud.
+	CloudVolumeId string `json:"cloud_volume_id,omitempty"`
+
 	// DevicePath is the path to the loop device node
 	DevicePath string `json:"device_path"`
 
@@ -317,6 +324,42 @@ func (s *State) SetMountFromVolume(volumeId string, mount *MountState) (devicePa
 	mount.MountPath = v.MountPath
 	s.Mounts[mount.EntityId] = mount
 	return v.DevicePath, v.MountPath, nil
+}
+
+// LeaseNonceForCloudVolume returns the lease nonce held by a mount whose
+// backing volume has the given cloud volume id, or "" if none is held.
+//
+// The uploader is handed a volume's cloud id, but mount state keys off the
+// local disk_volume entity id, so the two cannot be compared directly. This
+// resolves cloud id -> volume entity id -> mount under a single read lock.
+func (s *State) LeaseNonceForCloudVolume(cloudVolumeId string) string {
+	if cloudVolumeId == "" {
+		return ""
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Prefer the cloud id recorded directly on the mount.
+	for _, m := range s.Mounts {
+		if m.CloudVolumeId == cloudVolumeId && m.LeaseNonce != "" {
+			return m.LeaseNonce
+		}
+	}
+
+	// Fall back to resolving through volume state for mounts persisted before
+	// the cloud id was recorded on the mount.
+	for _, v := range s.Volumes {
+		if v.CloudVolumeId != cloudVolumeId {
+			continue
+		}
+		for _, m := range s.Mounts {
+			if m.VolumeId == v.EntityId && m.LeaseNonce != "" {
+				return m.LeaseNonce
+			}
+		}
+	}
+	return ""
 }
 
 // GetVolumeByVolumeId returns a copy of a volume state by volume ID

--- a/components/diskio/state.go
+++ b/components/diskio/state.go
@@ -136,7 +136,44 @@ func LoadState(dataPath string) (*State, error) {
 
 	// Always use the new path going forward
 	state.path = path
+
+	// Backfill the cloud id onto mounts that predate MountState.CloudVolumeId.
+	// Without this, a legacy mount that stays mounted across the upgrade never
+	// records its cloud id, and once its VolumeState is gone (orphan cleanup)
+	// the lease can no longer be released.
+	//
+	// The in-memory backfill is what the running process relies on; persistence
+	// is best-effort. A failed rewrite must not discard the otherwise-valid
+	// state we just loaded (which would drop active lease nonces from memory),
+	// so we swallow the save error rather than fail the load. A later Save
+	// captures the backfill, and because Save serializes volumes and mounts
+	// together, no save can persist a volume deletion without also persisting
+	// the mounts we just backfilled.
+	if state.backfillMountCloudVolumeIds() {
+		_ = state.Save()
+	}
+
 	return &state, nil
+}
+
+// backfillMountCloudVolumeIds copies each volume's cloud id onto any mount that
+// has none, keyed by the mount's local volume entity id. It never overwrites a
+// cloud id already recorded on a mount. Returns true if any mount changed.
+func (s *State) backfillMountCloudVolumeIds() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	changed := false
+	for _, m := range s.Mounts {
+		if m.CloudVolumeId != "" {
+			continue
+		}
+		if v := s.Volumes[m.VolumeId]; v != nil && v.CloudVolumeId != "" {
+			m.CloudVolumeId = v.CloudVolumeId
+			changed = true
+		}
+	}
+	return changed
 }
 
 // Save persists the state to disk atomically.

--- a/components/diskio/state_test.go
+++ b/components/diskio/state_test.go
@@ -1,6 +1,7 @@
 package diskio
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -272,4 +273,47 @@ func TestStateLeaseNonceForCloudVolume(t *testing.T) {
 
 		assert.Equal(t, "nonce-1", state.LeaseNonceForCloudVolume("vol-cloud-1"))
 	})
+}
+
+func TestLoadStateBackfillsMountCloudVolumeId(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a state file shaped like one persisted before MountState.CloudVolumeId
+	// existed: the volume knows its cloud id, the mount does not.
+	seed := NewState()
+	seed.SetPath(dir)
+	seed.SetVolume("disk_volume/vol1", &VolumeState{
+		EntityId:      "disk_volume/vol1",
+		VolumeId:      "vol1",
+		CloudVolumeId: "vol-cloud-1",
+	})
+	seed.SetMount("disk_mount/mnt-1", &MountState{
+		EntityId:   "disk_mount/mnt-1",
+		VolumeId:   "disk_volume/vol1",
+		LeaseNonce: "nonce-1",
+	})
+	require.NoError(t, seed.Save())
+
+	loaded, err := LoadState(dir)
+	require.NoError(t, err)
+
+	// The mount now carries the cloud id, resolved from volume state.
+	m := loaded.GetMount("disk_mount/mnt-1")
+	require.NotNil(t, m)
+	assert.Equal(t, "vol-cloud-1", m.CloudVolumeId)
+
+	// The backfill was persisted, not just applied in memory. Read the file
+	// directly so this is verified independently of a second load (which would
+	// re-backfill from the still-present volume state and mask a missing save).
+	raw, err := os.ReadFile(filepath.Join(dir, stateFileName))
+	require.NoError(t, err)
+	var persisted State
+	require.NoError(t, json.Unmarshal(raw, &persisted))
+	require.NotNil(t, persisted.Mounts["disk_mount/mnt-1"])
+	assert.Equal(t, "vol-cloud-1", persisted.Mounts["disk_mount/mnt-1"].CloudVolumeId)
+
+	// And the lease still resolves after the VolumeState is removed, which is
+	// the orphan-cleanup situation the backfill protects against.
+	loaded.DeleteVolume("disk_volume/vol1")
+	assert.Equal(t, "nonce-1", loaded.LeaseNonceForCloudVolume("vol-cloud-1"))
 }

--- a/components/diskio/state_test.go
+++ b/components/diskio/state_test.go
@@ -239,3 +239,37 @@ func TestStateConcurrentAccess(t *testing.T) {
 	assert.NotNil(t, state.GetVolume("vol-1"))
 	assert.NotNil(t, state.GetMount("mount-1"))
 }
+
+func TestStateLeaseNonceForCloudVolume(t *testing.T) {
+	t.Run("matches on the mount's stored cloud id", func(t *testing.T) {
+		// No VolumeState at all — the mount alone carries the cloud id.
+		state := NewState()
+		state.SetMount("disk_mount/mnt-1", &MountState{
+			EntityId:      "disk_mount/mnt-1",
+			VolumeId:      "disk_volume/vol1",
+			CloudVolumeId: "vol-cloud-1",
+			LeaseNonce:    "nonce-1",
+		})
+
+		assert.Equal(t, "nonce-1", state.LeaseNonceForCloudVolume("vol-cloud-1"))
+		assert.Empty(t, state.LeaseNonceForCloudVolume("vol-other"))
+		assert.Empty(t, state.LeaseNonceForCloudVolume(""))
+	})
+
+	t.Run("falls back to volume state for mounts without a stored cloud id", func(t *testing.T) {
+		// Models a mount persisted before CloudVolumeId was recorded on it.
+		state := NewState()
+		state.SetVolume("disk_volume/vol1", &VolumeState{
+			EntityId:      "disk_volume/vol1",
+			VolumeId:      "vol1",
+			CloudVolumeId: "vol-cloud-1",
+		})
+		state.SetMount("disk_mount/mnt-1", &MountState{
+			EntityId:   "disk_mount/mnt-1",
+			VolumeId:   "disk_volume/vol1",
+			LeaseNonce: "nonce-1",
+		})
+
+		assert.Equal(t, "nonce-1", state.LeaseNonceForCloudVolume("vol-cloud-1"))
+	})
+}


### PR DESCRIPTION
## Summary

Accelerator disk backups stopped as soon as the runtime mounted a volume and acquired its cloud lease. Every upload after that failed with `invalid update request: volume has an active lease: nonce required` and retried every five seconds indefinitely. Seen in production on `disktest2` / volume `vol-ac3q8p1f72o1` (MIR-1634).

The runtime keeps two identifiers for a volume and confused them:

- `MountState.VolumeId` — the local `disk_volume/…` entity id.
- `VolumeState.CloudVolumeId` — the miren.cloud `vol-…` id.

The uploader looked up the lease nonce by comparing the cloud id against the local id, so they never matched and the nonce was omitted — the cloud then rejected the write. The three lease-**release** paths (shutdown, unmount, orphan cleanup) had the mirror of the same bug: they passed the local id to the cloud release call, so they could fail to release indefinite leases.

## What changed

- **`leaseNonceFor`** now resolves the nonce through a new `State.LeaseNonceForCloudVolume` helper that bridges cloud id → volume → mount.
- The **three release paths** resolve the cloud id via a `cloudVolumeIdFor` helper and skip when the volume was never cloud-registered.
- **`MountState.CloudVolumeId`** is now persisted, captured at mount-creation time. This makes orphan cleanup robust: the lease is released with the right id even after the backing `VolumeState` is gone. Mounts persisted before this field fall back to a volume-state lookup, so upgrades don't regress.

## Testing

- The regression tests previously masked the bug by using one string for both ids; they now use deliberately different local and cloud ids.
- The mock cloud server now enforces the nonce on leased volumes, and a new integration test uploads a segment through the real `LogWatcher` → uploader path against an active lease.
- Sanity-checked: reverting only the production `.go` files makes the integration test fail with the exact production error.
- `hack/it components/diskio` — 169 tests pass. `make lint` — 0 issues.

https://claude.ai/code/session_01YNNxdoTF7YUsFaxiJnhsp9