### PR TITLE
appconfig: publish addon services field in app.toml schema

### DIFF
--- a/docs/static/app-toml.schema.json
+++ b/docs/static/app-toml.schema.json
@@ -132,7 +132,8 @@
       "additionalProperties": false,
       "properties": {
         "variant": {"type": "string"},
-        "version": {"type": "string"}
+        "version": {"type": "string"},
+        "services": {"type": "array", "description": "Services this addon's storage attaches to. Empty or omitted means every service.", "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
       }
     }
   }


### PR DESCRIPTION
## What

Adds the `services` property to the `addon` definition in the published `app.toml` JSON Schema (`docs/static/app-toml.schema.json`).

## Why

`AddonConfig` gained a `Services []string` field (toml tag `services`) that scopes an addon's storage to named services, but the published schema — the one that powers editor tooling for `app.toml` — still advertised only `variant` and `version`. `TestPublishedSchemaFieldsMatchConfig` exists to catch exactly this drift between the TOML structs and the schema, and it was failing:

```
addon: schema fields = [variant version], config fields = [services variant version]
```

## Change

The new property is an array of non-empty strings with `uniqueItems`, matching the field's real behavior: empty or omitted means the addon's storage attaches to every service.

## Testing

`TestPublishedSchemaFieldsMatchConfig` (and its `addon` subtest) now pass.

Fixes MIR-1637.

https://claude.ai/code/session_019ktunDHFHhPEN9GuzSAF4y