### PR TITLE
Fix rollback lookup for canonical app version IDs

### DIFF
--- a/api/app/envvar.go
+++ b/api/app/envvar.go
@@ -454,6 +454,7 @@ func createNewVersion(ctx context.Context, ec *entityserver.Client, resolver sec
 	if err != nil {
 		return nil, err
 	}
+	appVer.ID = avid
 
 	if err := ec.Patch(ctx, appRec.ID, appRev,
 		entity.Ref(core_v1alpha.AppActiveVersionId, avid),

--- a/api/app/envvar_test.go
+++ b/api/app/envvar_test.go
@@ -90,8 +90,10 @@ func TestSetEnvVarsComposesSequentially(t *testing.T) {
 	ctx, ec := newEnvTestClient(t)
 	createEnvTestApp(t, ctx, ec, "myapp", []core_v1alpha.Variable{{Key: "BASE", Value: "1", Source: "config"}})
 
-	_, err := SetEnvVars(ctx, ec, nil, "myapp", nil, []EnvVarInput{{Key: "FOO", Value: "a"}}, "")
+	result, err := SetEnvVars(ctx, ec, nil, "myapp", nil, []EnvVarInput{{Key: "FOO", Value: "a"}}, "")
 	require.NoError(t, err)
+	require.Equal(t, entity.Id("app_version/"+result.VersionID), result.AppVersion.ID,
+		"mutation result must retain the canonical entity ID for deployment tracking")
 	_, err = SetEnvVars(ctx, ec, nil, "myapp", nil, []EnvVarInput{{Key: "BAR", Value: "b"}}, "")
 	require.NoError(t, err)
 

--- a/servers/deployment/guard_test.go
+++ b/servers/deployment/guard_test.go
@@ -87,32 +87,38 @@ func TestDeploy_RejectsCrossAppVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create app-y: %v", err)
 	}
-	if _, err := inmem.Client.Create(ctx, "app-x-v1", &core_v1alpha.AppVersion{Version: "app-x-v1", App: appXID}); err != nil {
+	appXVersionID, err := inmem.Client.Create(ctx, "app-x-v1", &core_v1alpha.AppVersion{Version: "app-x-v1", App: appXID})
+	if err != nil {
 		t.Fatalf("create app-x version: %v", err)
 	}
-	if _, err := inmem.Client.Create(ctx, "app-y-v1", &core_v1alpha.AppVersion{Version: "app-y-v1", App: appYID}); err != nil {
+	appYVersionID, err := inmem.Client.Create(ctx, "app-y-v1", &core_v1alpha.AppVersion{Version: "app-y-v1", App: appYID})
+	if err != nil {
 		t.Fatalf("create app-y version: %v", err)
 	}
 
 	t.Run("DeployVersion rejects another app's version", func(t *testing.T) {
-		res, err := client.DeployVersion(ctx, "app-x", "cluster-1", "app-y-v1", false, nil, "", "")
-		// The mismatch surfaces as a hard error (ValidationFailure), not a
-		// results.Error field.
-		if err == nil {
-			if res != nil && res.HasError() {
-				t.Fatalf("expected a hard error, got results.Error=%q", res.Error())
+		for _, versionRef := range []string{"app-y-v1", string(appYVersionID)} {
+			res, err := client.DeployVersion(ctx, "app-x", "cluster-1", versionRef, false, nil, "", "")
+			// The mismatch surfaces as a hard error (ValidationFailure), not a
+			// results.Error field.
+			if err == nil {
+				if res != nil && res.HasError() {
+					t.Fatalf("ref %q: expected a hard error, got results.Error=%q", versionRef, res.Error())
+				}
+				t.Fatalf("ref %q: expected cross-app version to be rejected", versionRef)
 			}
-			t.Fatal("expected cross-app version to be rejected")
-		}
-		if !strings.Contains(err.Error(), "does not belong to app") {
-			t.Fatalf("expected ownership error, got %v", err)
+			if !strings.Contains(err.Error(), "does not belong to app") {
+				t.Fatalf("ref %q: expected ownership error, got %v", versionRef, err)
+			}
 		}
 	})
 
 	t.Run("CreateDeployment rejects another app's real version", func(t *testing.T) {
-		_, err := client.CreateDeployment(ctx, "app-x", "cluster-1", "app-y-v1", nil)
-		if err == nil || !strings.Contains(err.Error(), "does not belong to app") {
-			t.Fatalf("expected ownership error, got %v", err)
+		for _, versionRef := range []string{"app-y-v1", string(appYVersionID)} {
+			_, err := client.CreateDeployment(ctx, "app-x", "cluster-1", versionRef, nil)
+			if err == nil || !strings.Contains(err.Error(), "does not belong to app") {
+				t.Fatalf("ref %q: expected ownership error, got %v", versionRef, err)
+			}
 		}
 	})
 
@@ -136,16 +142,18 @@ func TestDeploy_RejectsCrossAppVersion(t *testing.T) {
 			t.Fatalf("create deployment: %v", err)
 		}
 
-		_, err = client.UpdateDeploymentAppVersion(ctx, string(depID), "app-y-v1")
-		if err == nil || !strings.Contains(err.Error(), "does not belong to app") {
-			t.Fatalf("expected ownership error, got %v", err)
+		for _, versionRef := range []string{"app-y-v1", string(appYVersionID)} {
+			_, err = client.UpdateDeploymentAppVersion(ctx, string(depID), versionRef)
+			if err == nil || !strings.Contains(err.Error(), "does not belong to app") {
+				t.Fatalf("ref %q: expected ownership error, got %v", versionRef, err)
+			}
 		}
 	})
 
 	t.Run("own version is accepted past the ownership check", func(t *testing.T) {
 		// app-x deploying app-x-v1 must clear the ownership check (it may still
 		// fail later for unrelated reasons, but never with a mismatch error).
-		res, err := client.DeployVersion(ctx, "app-x", "cluster-1", "app-x-v1", false, nil, "", "")
+		res, err := client.DeployVersion(ctx, "app-x", "cluster-1", string(appXVersionID), false, nil, "", "")
 		if err != nil && strings.Contains(err.Error(), "does not belong to app") {
 			t.Fatalf("own version was wrongly rejected: %v", err)
 		}

--- a/servers/deployment/server.go
+++ b/servers/deployment/server.go
@@ -144,14 +144,16 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 	// not-found version is left alone rather than rejected. Any other lookup
 	// error fails closed — skipping the check on a transient store error would
 	// let a cross-app version slip through.
+	appVersionID := args.AppVersionId()
 	var appVersion core_v1alpha.AppVersion
-	switch err := d.EC.Get(ctx, args.AppVersionId(), &appVersion); {
+	switch err := d.getAppVersion(ctx, appVersionID, &appVersion); {
 	case err == nil:
 		if verifyErr := d.verifyVersionOwnedByApp(ctx, &appVersion, appName); verifyErr != nil {
 			return verifyErr
 		}
+		appVersionID = string(appVersion.ID)
 	case !errors.Is(err, cond.ErrNotFound{}):
-		d.Log.Error("Failed to look up app version", "app_version_id", args.AppVersionId(), "error", err)
+		d.Log.Error("Failed to look up app version", "app_version_id", appVersionID, "error", err)
 		return cond.Error("failed to look up app version")
 	}
 
@@ -166,7 +168,7 @@ func (d *DeploymentServer) CreateDeployment(ctx context.Context, req *deployment
 	rec, err := d.tracker.Begin(ctx, deploylifecycle.BeginParams{
 		AppName:    appName,
 		ClusterID:  clusterId,
-		AppVersion: normalizeAppVersion(args.AppVersionId(), ""),
+		AppVersion: normalizeAppVersion(appVersionID, ""),
 		GitInfo:    gitInfo,
 	})
 	if err != nil {
@@ -550,11 +552,12 @@ func (d *DeploymentServer) UpdateDeploymentAppVersion(ctx context.Context, req *
 	// rejected; the cross-app attack always names a real, existing version. Any
 	// other lookup error fails closed.
 	var appVersion core_v1alpha.AppVersion
-	switch err := d.EC.Get(ctx, appVersionId, &appVersion); {
+	switch err := d.getAppVersion(ctx, appVersionId, &appVersion); {
 	case err == nil:
 		if verifyErr := d.verifyVersionOwnedByApp(ctx, &appVersion, deployment.AppName); verifyErr != nil {
 			return verifyErr
 		}
+		appVersionId = string(appVersion.ID)
 	case !errors.Is(err, cond.ErrNotFound{}):
 		d.Log.Error("Failed to look up app version", "app_version_id", appVersionId, "error", err)
 		return cond.Error("failed to look up app version")
@@ -745,8 +748,8 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 
 	appName := args.AppName()
 	clusterId := args.ClusterId()
-	appVersionId := args.AppVersionId()
-	sourceVersionId := appVersionId
+	requestedVersionId := args.AppVersionId()
+	appVersionId := requestedVersionId
 	isRollback := args.HasIsRollback() && args.IsRollback()
 
 	// Enforce app scoping: scoped callers (e.g. OIDC) can only deploy their bound app
@@ -756,7 +759,7 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 
 	// Verify the AppVersion entity exists
 	var appVersion core_v1alpha.AppVersion
-	if err := d.EC.Get(ctx, appVersionId, &appVersion); err != nil {
+	if err := d.getAppVersion(ctx, appVersionId, &appVersion); err != nil {
 		if errors.Is(err, cond.ErrNotFound{}) {
 			results.SetError(fmt.Sprintf("app version %q not found", appVersionId))
 			return nil
@@ -764,6 +767,12 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 		d.Log.Error("Failed to look up app version", "app_version_id", appVersionId, "error", err)
 		results.SetError("failed to look up app version")
 		return nil
+	}
+	appVersionId = string(appVersion.ID)
+	sourceVersionIds := map[string]struct{}{
+		requestedVersionId: {},
+		appVersionId:       {},
+		appVersion.Version: {},
 	}
 
 	// The version must belong to the app being deployed — AllowApp only
@@ -781,7 +790,7 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 			return nil
 		}
 		appVersion = *derivedVersion
-		appVersionId = derivedVersion.Version
+		appVersionId = string(derivedVersion.ID)
 		d.Log.Info("Created derived version with env vars",
 			"original", args.AppVersionId(), "derived", appVersionId,
 			"env_var_count", len(args.EnvVars()))
@@ -874,7 +883,7 @@ func (d *DeploymentServer) DeployVersion(ctx context.Context, req *deployment_v1
 		d.Log.Error("Failed to list deployments for source lookup", "error", listErr)
 	} else {
 		for _, dwe := range allDeployments {
-			if dwe.deployment.AppVersion == sourceVersionId {
+			if _, ok := sourceVersionIds[dwe.deployment.AppVersion]; ok {
 				gitInfo = dwe.deployment.GitInfo
 				sourceDeploymentID = string(dwe.deployment.ID)
 				break // listDeploymentsInternal returns newest first
@@ -1087,6 +1096,9 @@ func (d *DeploymentServer) createEnvVarDeployment(ctx context.Context, appName, 
 	mutResult *appclient.MutateResult, results envVarDeployResults) error {
 
 	appVersionId := mutResult.VersionID
+	if mutResult.AppVersion != nil && mutResult.AppVersion.ID != "" {
+		appVersionId = string(mutResult.AppVersion.ID)
+	}
 
 	// An env-var change has no build, so the record goes straight from Begin to
 	// active. Begin takes the deploy lock, contending with any server-owned
@@ -1360,7 +1372,11 @@ func (d *DeploymentServer) resolveShortIDs(ctx context.Context, ids []string) ma
 		if _, ok := result[id]; ok {
 			continue // already resolved
 		}
-		resp, err := d.EAC.Get(ctx, id)
+		versionID, err := appVersionRefID(id)
+		if err != nil {
+			continue
+		}
+		resp, err := d.EAC.Get(ctx, string(versionID))
 		if err != nil {
 			continue
 		}
@@ -1369,6 +1385,34 @@ func (d *DeploymentServer) resolveShortIDs(ctx context.Context, ids []string) ma
 		}
 	}
 	return result
+}
+
+// appVersionRefID turns every supported app-version reference into the entity
+// ID shape expected by EntityAccess. Deployment records historically contain a
+// mix of canonical IDs and bare version names, while operators may also supply
+// a short ID. EntityAccess resolves the latter once it is scoped to the kind.
+func appVersionRefID(ref string) (entity.Id, error) {
+	const prefix = "app_version/"
+
+	if ref == "" {
+		return "", cond.ValidationFailure("missing-field", "app_version_id is required")
+	}
+	if strings.Contains(ref, "/") {
+		if !strings.HasPrefix(ref, prefix) || len(ref) == len(prefix) {
+			return "", cond.ValidationFailure("invalid-app-version-id",
+				fmt.Sprintf("invalid app version reference %q", ref))
+		}
+		return entity.Id(ref), nil
+	}
+	return entity.Id(prefix + ref), nil
+}
+
+func (d *DeploymentServer) getAppVersion(ctx context.Context, ref string, version *core_v1alpha.AppVersion) error {
+	id, err := appVersionRefID(ref)
+	if err != nil {
+		return err
+	}
+	return d.EC.GetById(ctx, id, version)
 }
 
 type deploymentWithEntity struct {

--- a/servers/deployment/server_test.go
+++ b/servers/deployment/server_test.go
@@ -416,6 +416,119 @@ func TestListDeployments(t *testing.T) {
 	}
 }
 
+func TestListDeploymentsResolvesShortIDsForMixedVersionRefs(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	server, err := newTestDeploymentServer(t, slog.Default(), inmem)
+	if err != nil {
+		t.Fatalf("Failed to create deployment server: %v", err)
+	}
+	client := &deployment_v1alpha.DeploymentClient{
+		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
+	}
+
+	legacyVersionID, err := inmem.Client.Create(ctx, "mixed-app-v1", &core_v1alpha.AppVersion{Version: "mixed-app-v1"})
+	if err != nil {
+		t.Fatalf("Failed to create legacy app version: %v", err)
+	}
+	canonicalVersionID, err := inmem.Client.Create(ctx, "mixed-app-v2", &core_v1alpha.AppVersion{Version: "mixed-app-v2"})
+	if err != nil {
+		t.Fatalf("Failed to create canonical app version: %v", err)
+	}
+
+	legacyShortID := inmem.GetEntity(legacyVersionID).ShortId()
+	canonicalShortID := inmem.GetEntity(canonicalVersionID).ShortId()
+	if legacyShortID == "" || canonicalShortID == "" {
+		t.Fatal("Expected app versions to have short IDs")
+	}
+
+	for name, deployment := range map[string]*core_v1alpha.Deployment{
+		"mixed-dep-v1": {
+			AppName:    "mixed-app",
+			ClusterId:  "cluster1",
+			AppVersion: "mixed-app-v1",
+			Status:     "succeeded",
+			DeployedBy: core_v1alpha.DeployedBy{Timestamp: time.Now().Add(-time.Hour).Format(time.RFC3339)},
+		},
+		"mixed-dep-v2": {
+			AppName:    "mixed-app",
+			ClusterId:  "cluster1",
+			AppVersion: string(canonicalVersionID),
+			Status:     "active",
+			DeployedBy: core_v1alpha.DeployedBy{Timestamp: time.Now().Format(time.RFC3339)},
+		},
+	} {
+		if _, err := inmem.Client.Create(ctx, name, deployment); err != nil {
+			t.Fatalf("Failed to create deployment %s: %v", name, err)
+		}
+	}
+
+	result, err := client.ListDeployments(ctx, "mixed-app", "cluster1", "", 20)
+	if err != nil {
+		t.Fatalf("ListDeployments failed: %v", err)
+	}
+
+	wantShortIDs := map[string]string{
+		"mixed-app-v1":             legacyShortID,
+		string(canonicalVersionID): canonicalShortID,
+	}
+	if len(result.Deployments()) != len(wantShortIDs) {
+		t.Fatalf("Expected %d deployments, got %d", len(wantShortIDs), len(result.Deployments()))
+	}
+	for _, deployment := range result.Deployments() {
+		want, ok := wantShortIDs[deployment.AppVersionId()]
+		if !ok {
+			t.Fatalf("Unexpected app version %q", deployment.AppVersionId())
+		}
+		if !deployment.HasAppVersionShortId() || deployment.AppVersionShortId() != want {
+			t.Errorf("Version %q short ID = %q, want %q", deployment.AppVersionId(), deployment.AppVersionShortId(), want)
+		}
+	}
+}
+
+func TestSetEnvVarsRecordsCanonicalVersionID(t *testing.T) {
+	ctx := context.Background()
+	inmem, cleanup := testutils.NewInMemEntityServer(t)
+	defer cleanup()
+
+	server, err := newTestDeploymentServer(t, slog.Default(), inmem)
+	if err != nil {
+		t.Fatalf("Failed to create deployment server: %v", err)
+	}
+	client := &deployment_v1alpha.DeploymentClient{
+		Client: rpc.LocalClient(deployment_v1alpha.AdaptDeployment(server)),
+	}
+
+	versionID, err := inmem.Client.Create(ctx, "env-app-v1", &core_v1alpha.AppVersion{Version: "env-app-v1"})
+	if err != nil {
+		t.Fatalf("Failed to create app version: %v", err)
+	}
+	if _, err := inmem.Client.Create(ctx, "env-app", &core_v1alpha.App{ActiveVersion: versionID}); err != nil {
+		t.Fatalf("Failed to create app: %v", err)
+	}
+
+	envVar := &deployment_v1alpha.EnvironmentVariable{}
+	envVar.SetKey("GREETING")
+	envVar.SetValue("hello")
+	result, err := client.SetEnvVars(ctx, "env-app", "cluster1", []*deployment_v1alpha.EnvironmentVariable{envVar}, "")
+	if err != nil {
+		t.Fatalf("SetEnvVars failed: %v", err)
+	}
+	if result.HasError() && result.Error() != "" {
+		t.Fatalf("SetEnvVars returned error: %s", result.Error())
+	}
+
+	wantVersionID := "app_version/" + result.VersionId()
+	if got := result.Deployment().AppVersionId(); got != wantVersionID {
+		t.Errorf("Deployment app version = %q, want canonical ID %q", got, wantVersionID)
+	}
+	if !result.Deployment().HasAppVersionShortId() || result.Deployment().AppVersionShortId() == "" {
+		t.Error("Expected env deployment to include an app-version short ID")
+	}
+}
+
 func TestGetDeploymentById(t *testing.T) {
 	ctx := context.Background()
 
@@ -1013,8 +1126,8 @@ func TestDeployVersion(t *testing.T) {
 		if dep.Status() != "active" {
 			t.Errorf("Expected status 'active', got %s", dep.Status())
 		}
-		if dep.AppVersionId() != "testapp-v1abc" {
-			t.Errorf("Expected version 'testapp-v1abc', got %s", dep.AppVersionId())
+		if dep.AppVersionId() != string(versionId) {
+			t.Errorf("Expected canonical version %q, got %q", versionId, dep.AppVersionId())
 		}
 		if dep.SourceDeploymentId() != string(priorId) {
 			t.Errorf("Expected source_deployment_id %s, got %s", priorId, dep.SourceDeploymentId())
@@ -1027,8 +1140,6 @@ func TestDeployVersion(t *testing.T) {
 		if dep.GitInfo().Sha() != "abc123" {
 			t.Errorf("Expected git SHA 'abc123', got %s", dep.GitInfo().Sha())
 		}
-
-		_ = versionId // used indirectly via entity name lookup
 	})
 
 	t.Run("rollback marks previous as rolled_back", func(t *testing.T) {
@@ -1040,13 +1151,13 @@ func TestDeployVersion(t *testing.T) {
 		}
 
 		appVersion := &core_v1alpha.AppVersion{Version: "rollback-app-v1"}
-		_, err = inmem.Client.Create(ctx, "rollback-app-v1", appVersion)
+		version1ID, err := inmem.Client.Create(ctx, "rollback-app-v1", appVersion)
 		if err != nil {
 			t.Fatalf("Failed to create app version: %v", err)
 		}
 
 		appVersion2 := &core_v1alpha.AppVersion{Version: "rollback-app-v2"}
-		_, err = inmem.Client.Create(ctx, "rollback-app-v2", appVersion2)
+		version2ID, err := inmem.Client.Create(ctx, "rollback-app-v2", appVersion2)
 		if err != nil {
 			t.Fatalf("Failed to create app version v2: %v", err)
 		}
@@ -1055,7 +1166,7 @@ func TestDeployVersion(t *testing.T) {
 		activeDep := &core_v1alpha.Deployment{
 			AppName:    "rollback-app",
 			ClusterId:  "cluster1",
-			AppVersion: "rollback-app-v2",
+			AppVersion: string(version2ID),
 			Status:     "active",
 			DeployedBy: core_v1alpha.DeployedBy{
 				Timestamp: time.Now().Format(time.RFC3339),
@@ -1070,7 +1181,7 @@ func TestDeployVersion(t *testing.T) {
 		_, err = inmem.Client.Create(ctx, "succeeded-dep-v1", &core_v1alpha.Deployment{
 			AppName:    "rollback-app",
 			ClusterId:  "cluster1",
-			AppVersion: "rollback-app-v1",
+			AppVersion: string(version1ID),
 			Status:     "succeeded",
 			DeployedBy: core_v1alpha.DeployedBy{
 				Timestamp: time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
@@ -1081,7 +1192,7 @@ func TestDeployVersion(t *testing.T) {
 		}
 
 		// Roll back to v1
-		result, err := client.DeployVersion(ctx, "rollback-app", "cluster1", "rollback-app-v1", true, nil, "", "")
+		result, err := client.DeployVersion(ctx, "rollback-app", "cluster1", string(version1ID), true, nil, "", "")
 		if err != nil {
 			t.Fatalf("DeployVersion (rollback) failed: %v", err)
 		}
@@ -1092,6 +1203,9 @@ func TestDeployVersion(t *testing.T) {
 		newDep := result.Deployment()
 		if newDep.Status() != "active" {
 			t.Errorf("Expected new deployment status 'active', got %s", newDep.Status())
+		}
+		if newDep.AppVersionId() != string(version1ID) {
+			t.Errorf("Expected rollback to retain canonical version %q, got %q", version1ID, newDep.AppVersionId())
 		}
 
 		// Verify the previous active deployment was marked as rolled_back


### PR DESCRIPTION
Rollback selects an app version from deployment history, where normal deploys record the canonical `app_version/...` entity ID. The deployment service treated that value as a bare name and prefixed the kind again, so valid rollback targets came back as missing.

App-version lookup now accepts bare, short, and canonical references, then records canonical IDs going forward. History also resolves short IDs for older bare-name records, which makes mixed deploy and env-mutation rows render consistently. The same normalization keeps source-app ownership checks effective for canonical references.

Closes MIR-1635