### PR TITLE
Wait for disk sandbox cleanup before starting replacements

### DIFF
--- a/controllers/deployment/launcher.go
+++ b/controllers/deployment/launcher.go
@@ -1627,8 +1627,9 @@ func (l *Launcher) findStalePoolsForService(
 	return stale, nil
 }
 
-// waitForPoolDrained polls until a pool has no RUNNING or PENDING sandboxes,
-// indicating that its resources (including disk leases) have been released.
+// waitForPoolDrained polls until a pool has no sandboxes that are still being
+// torn down. STOPPED requests teardown; DEAD confirms it finished and resources
+// such as local disk mounts have been released.
 func (l *Launcher) waitForPoolDrained(ctx context.Context, poolID entity.Id, service string, timeout time.Duration) error {
 	pollInterval := 500 * time.Millisecond
 	deadline := time.Now().Add(timeout)
@@ -1660,9 +1661,11 @@ func (l *Launcher) waitForPoolDrained(ctx context.Context, poolID entity.Id, ser
 	}
 }
 
-// hasActiveSandboxForPool returns true if there are any RUNNING, PENDING, or
-// NOT_READY sandboxes for the given pool. NOT_READY sandboxes may still hold
-// disk leases, so we must wait for them to fully stop.
+// hasActiveSandboxForPool returns true if any sandbox for the pool has not
+// reached DEAD. STOPPED is deliberately active here: the pool manager sets it
+// before the sandbox controller finishes graceful process shutdown and resource
+// cleanup, so starting a replacement at STOPPED can overlap access to a local
+// disk with the retiring process.
 func (l *Launcher) hasActiveSandboxForPool(ctx context.Context, poolID entity.Id, service string) (bool, error) {
 	resp, err := l.EAC.List(ctx, entity.Ref(entity.EntityKind, compute_v1alpha.KindSandbox))
 	if err != nil {
@@ -1673,13 +1676,8 @@ func (l *Launcher) hasActiveSandboxForPool(ctx context.Context, poolID entity.Id
 		var sb compute_v1alpha.Sandbox
 		sb.Decode(ent.Entity())
 
-		switch sb.Status {
-		case compute_v1alpha.RUNNING, compute_v1alpha.PENDING, compute_v1alpha.NOT_READY:
-			// Active — may still hold disk resources
-		case compute_v1alpha.STOPPED, compute_v1alpha.DEAD:
-			// Terminal — no longer holds resources.
-			fallthrough
-		default:
+		if sb.Status == compute_v1alpha.DEAD {
+			// DEAD is set after process shutdown and resource cleanup complete.
 			continue
 		}
 

--- a/controllers/deployment/launcher_test.go
+++ b/controllers/deployment/launcher_test.go
@@ -3205,11 +3205,10 @@ func TestDiskPoolDrainedBeforeNewPoolCreated(t *testing.T) {
 	assert.Equal(t, "local", poolV2.SandboxSpec.Volume[0].Provider)
 }
 
-// TestDiskDrainBlockedByActiveSandbox verifies that when a RUNNING sandbox
-// exists for the old pool, the drain times out and the new pool is NOT created.
-// This proves drain-before-create ordering: the launcher won't start the new
-// version while the old one still holds the disk.
-func TestDiskDrainBlockedByActiveSandbox(t *testing.T) {
+// TestDiskDrainWaitsForStoppedSandboxToDie verifies that STOPPED is only a
+// teardown request, not proof that the old process and its disk resources are
+// gone. The replacement pool must wait until the sandbox reaches DEAD.
+func TestDiskDrainWaitsForStoppedSandboxToDie(t *testing.T) {
 	ctx := context.Background()
 	log := testutils.TestLogger(t)
 
@@ -3263,12 +3262,12 @@ func TestDiskDrainBlockedByActiveSandbox(t *testing.T) {
 	require.Len(t, poolsV1, 1)
 	poolV1ID := poolsV1[0].ID
 
-	// Simulate a RUNNING sandbox for the old pool (as the sandbox controller
-	// would create). This holds the disk and blocks draining.
+	// The pool manager marks the sandbox STOPPED before the sandbox controller
+	// finishes graceful shutdown and resource cleanup.
 	sb := &compute_v1alpha.Sandbox{
-		Status: compute_v1alpha.RUNNING,
+		Status: compute_v1alpha.STOPPED,
 	}
-	_, err = server.Client.Create(ctx, "old-sandbox",
+	sbID, err := server.Client.Create(ctx, "old-sandbox",
 		sb,
 		apiserver.WithLabels(types.LabelSet(
 			"pool", poolV1ID.String(),
@@ -3276,6 +3275,7 @@ func TestDiskDrainBlockedByActiveSandbox(t *testing.T) {
 		)),
 	)
 	require.NoError(t, err)
+	sb.ID = sbID
 
 	// Deploy v2
 	v2 := &core_v1alpha.AppVersion{
@@ -3310,14 +3310,14 @@ func TestDiskDrainBlockedByActiveSandbox(t *testing.T) {
 	err = server.Client.Update(ctx, app)
 	require.NoError(t, err)
 
-	// Reconcile should NOT create a new pool because the old sandbox is
-	// still running (drain times out). The service is skipped.
+	// Reconcile should NOT create a new pool while the old sandbox is still
+	// tearing down. The drain times out and the service is skipped.
 	err = launcher.Reconcile(ctx, app, nil)
 	require.NoError(t, err)
 
-	// Only the original pool should exist — no v2 pool was created
+	// Only the original pool should exist; no v2 pool was created.
 	allPools := listAllPools(t, ctx, server)
-	require.Len(t, allPools, 1, "should not create new pool while old sandbox is running")
+	require.Len(t, allPools, 1, "should not create new pool while old sandbox is stopped but not dead")
 
 	// The old pool was marked for drain (desired=0, no refs)
 	getRes, err := server.EAC.Get(ctx, poolV1ID.String())
@@ -3328,6 +3328,18 @@ func TestDiskDrainBlockedByActiveSandbox(t *testing.T) {
 		"old pool should be scaled to 0")
 	assert.Empty(t, poolV1.ReferencedByVersions,
 		"old pool should have no version references")
+
+	// DEAD confirms shutdown and cleanup finished. The next reconcile may now
+	// create the replacement pool.
+	sb.Status = compute_v1alpha.DEAD
+	err = server.Client.Update(ctx, sb)
+	require.NoError(t, err)
+
+	err = launcher.Reconcile(ctx, app, nil)
+	require.NoError(t, err)
+
+	allPools = listAllPools(t, ctx, server)
+	require.Len(t, allPools, 2, "should create replacement pool after old sandbox is dead")
 }
 
 // TestServiceHasDisks verifies the serviceHasDisks helper.

--- a/controllers/integration/redeploy_test.go
+++ b/controllers/integration/redeploy_test.go
@@ -414,21 +414,28 @@ func TestRapidRedeployWithDisk(t *testing.T) {
 		createAppVersion(t, ctx, h, verID, appID, version, image, diskName, diskSizeGB)
 		setActiveVersion(t, ctx, h, appID, verID)
 
-		// Launcher reconcile: creates new pool, scales old pool(s) to 0
+		// The first launcher pass scales old disk pools to 0, then waits for
+		// their sandboxes to finish teardown. The fake lifecycle advances that
+		// teardown explicitly below.
 		reconcileLauncher(t, ctx, launcher, appID)
 
-		// Retire sandboxes in scaled-down pools (release leases + mark DEAD)
+		// Retire sandboxes in scaled-down pools (release leases + mark STOPPED).
 		retireOldSandboxes(t, ctx, h)
 
-		// Manager reconcile: creates sandbox for the new pool
-		reconcileAllPools(t, ctx, h, mgr)
-
 		// Run 0-2 concurrent disk controller reconciliation rounds per iteration
-		// to create varying interleaving patterns
+		// to create varying cleanup interleavings.
 		reconcileRounds := v % 3
 		for range reconcileRounds {
 			concurrentReconcileRound(ctx, h, concWorkers)
 		}
+
+		// DEAD means sandbox shutdown and resource cleanup are complete. Only
+		// now may the launcher create the replacement disk pool.
+		finalizeStoppedSandboxes(t, ctx, h)
+		reconcileLauncher(t, ctx, launcher, appID)
+
+		// Manager reconcile: creates sandbox for the new pool.
+		reconcileAllPools(t, ctx, h, mgr)
 
 		// Boot pending sandboxes (acquire disk leases)
 		bootPendingSandboxes(t, ctx, h, appID)


### PR DESCRIPTION
Disk-backed deployments currently treat STOPPED as if teardown were finished. But STOPPED only requests teardown; the sandbox controller may still be shutting down the process and releasing resources. This lets a replacement start against the same local disk while the retiring process is still using it. We hit this when a retiring process deleted a WAL its replacement had just created.

Keep the old pool draining until all its sandboxes reach DEAD, then create the replacement. The tests cover STOPPED blocking replacement, DEAD unblocking it, and the complete rapid-redeploy lifecycle.

Closes MIR-1641