### PR TITLE
Inject secret values at build time

### DIFF
--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -45,7 +45,32 @@ type BuildConfig struct {
 	Version    string   `toml:"version"`
 
 	AlpineImage string `toml:"alpine_image"`
+
+	// Secrets names secret backends to expose to the build. Each entry is mounted
+	// into the build via BuildKit's secret session, so a `RUN --mount=type=secret,id=<id>`
+	// step can read the decrypted value without it ever landing in an image layer
+	// or build log. This is distinct from a runtime [[env]] reference: a build
+	// secret reaches only the build and never becomes an environment variable in
+	// the running container.
+	Secrets []BuildSecret `toml:"secrets,omitempty"`
 }
+
+// BuildSecret exposes a secret to the build. ID is the mount identifier a
+// Dockerfile references with `--mount=type=secret,id=<id>`; Backend and Ref
+// address the secret the same way a runtime [[env]] reference does. Backend is
+// optional and defaults to the built-in "cluster" store when omitted, matching
+// the `--backend` CLI flag.
+type BuildSecret struct {
+	ID      string `json:"id" toml:"id"`
+	Backend string `json:"backend,omitempty" toml:"backend,omitempty"`
+	Ref     string `json:"ref" toml:"ref"`
+}
+
+// buildSecretIDRegexp constrains a build secret's mount id to characters
+// BuildKit accepts in `--mount=type=secret,id=<id>`. An id with a slash or space
+// would pass a bare non-empty check but fail cryptically mid-build, so it is
+// rejected up front with a clear message.
+var buildSecretIDRegexp = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
 // ServiceConcurrencyConfig represents per-service concurrency configuration
 type ServiceConcurrencyConfig struct {
@@ -362,6 +387,23 @@ func (ac *AppConfig) Validate() error {
 		}
 		if err := ev.validateReference(fmt.Sprintf("env[%d]", i)); err != nil {
 			return err
+		}
+	}
+
+	// Validate build secrets
+	if ac.Build != nil {
+		seen := make(map[string]bool, len(ac.Build.Secrets))
+		for i, bs := range ac.Build.Secrets {
+			if err := bs.validate(fmt.Sprintf("build.secrets[%d]", i)); err != nil {
+				return err
+			}
+			if seen[bs.ID] {
+				return &ValidationError{
+					KeyPath: fmt.Sprintf("build.secrets[%d].id", i),
+					Message: fmt.Sprintf("build.secrets[%d]: duplicate id %q — each build secret needs a unique mount id", i, bs.ID),
+				}
+			}
+			seen[bs.ID] = true
 		}
 	}
 
@@ -940,6 +982,30 @@ func (ev AppEnvVar) validateReference(keyPath string) error {
 		return &ValidationError{
 			KeyPath: keyPath + ".value",
 			Message: fmt.Sprintf("%s: set either value or ref, not both — a referenced secret gets its value from the backend", keyPath),
+		}
+	}
+	return nil
+}
+
+// validate checks a build secret. A build secret has no inline form, so id and
+// ref are always required. Backend is optional and defaults to the "cluster"
+// store at resolve time, so it is not checked here.
+func (bs BuildSecret) validate(keyPath string) error {
+	switch {
+	case bs.ID == "":
+		return &ValidationError{
+			KeyPath: keyPath + ".id",
+			Message: fmt.Sprintf("%s: id is required — it is the mount identifier a Dockerfile references with --mount=type=secret,id=<id>", keyPath),
+		}
+	case !buildSecretIDRegexp.MatchString(bs.ID):
+		return &ValidationError{
+			KeyPath: keyPath + ".id",
+			Message: fmt.Sprintf("%s: id %q must contain only letters, digits, and _.- — BuildKit rejects other characters in a secret mount id", keyPath, bs.ID),
+		}
+	case bs.Ref == "":
+		return &ValidationError{
+			KeyPath: keyPath + ".ref",
+			Message: fmt.Sprintf("%s: ref is required to name the secret within the backend", keyPath),
 		}
 	}
 	return nil

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -220,6 +220,83 @@ console = "   "
 `,
 			wantErr: `alias "console": command must not be empty`,
 		},
+		{
+			name: "valid build secret",
+			config: `
+name = "test-app"
+
+[build]
+dockerfile = "Dockerfile"
+
+[[build.secrets]]
+id = "npm_token"
+backend = "cluster"
+ref = "registry/npm-token"
+`,
+			wantErr: "",
+		},
+		{
+			name: "build secret missing id",
+			config: `
+name = "test-app"
+
+[[build.secrets]]
+backend = "cluster"
+ref = "registry/npm-token"
+`,
+			wantErr: "build.secrets[0]: id is required",
+		},
+		{
+			name: "build secret without backend defaults to cluster",
+			config: `
+name = "test-app"
+
+[[build.secrets]]
+id = "npm_token"
+ref = "registry/npm-token"
+`,
+			wantErr: "",
+		},
+		{
+			name: "build secret invalid id",
+			config: `
+name = "test-app"
+
+[[build.secrets]]
+id = "npm/token"
+backend = "cluster"
+ref = "registry/npm-token"
+`,
+			wantErr: `build.secrets[0]: id "npm/token" must contain only letters, digits, and _.-`,
+		},
+		{
+			name: "build secret missing ref",
+			config: `
+name = "test-app"
+
+[[build.secrets]]
+id = "npm_token"
+backend = "cluster"
+`,
+			wantErr: "build.secrets[0]: ref is required",
+		},
+		{
+			name: "build secret duplicate id",
+			config: `
+name = "test-app"
+
+[[build.secrets]]
+id = "npm_token"
+backend = "cluster"
+ref = "registry/npm-token"
+
+[[build.secrets]]
+id = "npm_token"
+backend = "cluster"
+ref = "registry/other-token"
+`,
+			wantErr: `build.secrets[1]: duplicate id "npm_token"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/docs/docs/app-toml.md
+++ b/docs/docs/app-toml.md
@@ -169,6 +169,22 @@ alpine_image = "alpine:3.19"
 | `onbuild` | string[] | Commands to run in `/app` after the main build steps | — |
 | `alpine_image` | string | Custom Alpine base image for the runtime stage | Built-in default |
 
+### `[[build.secrets]]` — Build-time secrets {#build-secrets}
+
+Exposes an encrypted [secret](/secrets) to a Dockerfile build. BuildKit keeps the value out of image layers and its own logs; your `RUN` command must not print it. Each entry is mounted by its `id`, which your Dockerfile reads with `RUN --mount=type=secret,id=<id>`. Supported for Dockerfile builds only — declaring one on an auto-detected language stack is an error. See [Using a secret at build time](/secrets#using-a-secret-at-build-time) for the full contract.
+
+```toml
+[[build.secrets]]
+id = "npm_token"
+ref = "registry/npm-token"
+```
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| `id` | string | Mount identifier used in `--mount=type=secret,id=<id>`. Letters, digits, and `_.-` only; unique within the list | Required |
+| `backend` | string | [Secret](/secrets) backend to resolve against | `cluster` (built-in store) |
+| `ref` | string | Reference naming the secret within the backend | Required |
+
 ## `[services.<name>]` — Service Configuration {#services}
 
 Each named section under `services` defines a process in your app. See [Services](/services) for usage patterns.

--- a/docs/docs/secrets.md
+++ b/docs/docs/secrets.md
@@ -19,7 +19,7 @@ For a real credential, `miren env set -s` is not enough: it masks the value in o
 
 Use `-s` for values that are merely noisy in a terminal. Use a secret for anything that would matter if it leaked.
 
-Miren decrypts a secret at two points and holds the result only in memory: when a deploy resolves your reference to a concrete version, and when the container that needs the value is created. It is never written back to the cluster store in the clear.
+Miren decrypts a secret only into memory, never back to the cluster store in the clear. This happens at two points by default: when a deploy resolves your reference to a concrete version, and when the container that needs the value is created. A Dockerfile build can add a third — the value is decrypted into the builder's memory for a single build step (see [Using a secret at build time](#using-a-secret-at-build-time)), which BuildKit keeps out of the image unless your own build command copies or prints it.
 
 ## Storing a secret
 
@@ -85,6 +85,41 @@ DATABASE_POOL    10                                 manual
 ```
 
 Note the asymmetry: `backend` is optional on the command line but **required** in `app.toml`, where a `ref` without one is rejected rather than assumed. A reference cannot be combined with a value — set one or the other.
+
+## Using a secret at build time
+
+An `[[env]]` reference reaches your app at runtime, not during the build. A build sometimes needs a credential of its own — a private package-registry token for `npm ci` or `bundle install`, a license key needed to compile, a key to pull a private dependency. For those, declare a build secret.
+
+:::info[Dockerfile builds only]
+Build secrets reach Dockerfile builds only. You wire each one into a `RUN --mount=type=secret` step yourself, and Miren's automatic language builds have no such step — so declaring a build secret on an app that builds from an auto-detected stack is a build error, not a silent no-op.
+:::
+
+Declare the secrets under `[build]` in `app.toml`. Each entry has an `id` — the name your Dockerfile mounts it by — plus a `ref` naming the secret. `backend` names which store to resolve against and defaults to `cluster`, Miren's own built-in store (see [Backends](#backends) for registering others), so you set it only when the secret lives in a different backend. The `id` may contain letters, digits, and `_.-`:
+
+```toml
+[build]
+dockerfile = "Dockerfile"
+
+[[build.secrets]]
+id = "npm_token"
+backend = "cluster"
+ref = "registry/npm-token"
+```
+
+Then consume it in the Dockerfile with a secret mount. The value appears as a file under `/run/secrets/<id>` for the duration of that one `RUN`, and BuildKit places it nowhere else on its own — what your command does with it from there is the subject of the warning below:
+
+```dockerfile
+RUN --mount=type=secret,id=npm_token \
+    NPM_TOKEN="$(cat /run/secrets/npm_token)" npm ci
+```
+
+The credential is resolved to plaintext only in the builder's memory, handed to BuildKit over the build session, and mounted into the single `RUN` that asks for it. It never becomes a build argument, and BuildKit never writes it to the build log or an image layer on its own — so it is not visible in `docker history` or to anyone who later pulls the image. This is the difference from an inline value passed with `-e` or `--sensitive`, which is masked in CLI output but does end up baked into the image.
+
+:::warning[Read the mount, don't print it]
+BuildKit keeps the value out of layers and out of its own logs, but it cannot stop your own commands from leaking it. If you copy it into an `ENV`, write it to a file a later layer keeps, or print it to stdout or stderr — an `echo`, a `set -x`, a verbose tool — the value ends up in the image or the build log. Read it inside the `--mount=type=secret` `RUN`, use it there, and don't print it.
+:::
+
+A build secret must resolve at build time: if the `ref` cannot be found, or the cluster has no secret backend registered, the build fails rather than proceeding without the credential. Each `id` must be unique within the list and contain only letters, digits, and `_.-`, and the value is capped at 500 KB.
 
 ## Pinning: which version a deploy used
 

--- a/docs/static/app-toml.schema.json
+++ b/docs/static/app-toml.schema.json
@@ -44,7 +44,18 @@
         "version": {"type": "string", "description": "Language or runtime version."},
         "dockerfile": {"type": "string", "description": "Path to a custom Dockerfile."},
         "onbuild": {"type": "array", "description": "Commands run in /app after the main build steps.", "items": {"type": "string"}},
-        "alpine_image": {"type": "string", "description": "Custom Alpine base image for the runtime stage."}
+        "alpine_image": {"type": "string", "description": "Custom Alpine base image for the runtime stage."},
+        "secrets": {"type": "array", "description": "Secrets exposed to a Dockerfile build via --mount=type=secret. Never enters an image layer, and BuildKit does not write it to the build log on its own.", "items": {"$ref": "#/$defs/build_secret"}}
+      }
+    },
+    "build_secret": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "ref"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-zA-Z0-9_.-]+$", "description": "Mount identifier referenced by --mount=type=secret,id=<id>. Letters, digits, and _.- only."},
+        "backend": {"type": "string", "description": "Secret backend from which to resolve the value. Defaults to the built-in cluster store when omitted."},
+        "ref": {"type": "string", "minLength": 1, "description": "Reference naming the secret within the backend."}
       }
     },
     "port": {

--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -1905,6 +1905,48 @@ func (b *Builder) pinSecrets(ctx context.Context, spec *core_v1alpha.ConfigSpec)
 	return coreutil.PinSecrets(ctx, b.Secrets, spec)
 }
 
+// resolveBuildSecrets resolves the [[build.secrets]] declared in app.toml to
+// their plaintext, keyed by mount id, for a BuildKit secrets session. The bytes
+// are held only for the duration of the build: they are never written to disk,
+// logged, added as a build-arg, or recorded in the saga log (only the reference
+// travels in the AppConfig).
+//
+// Returns nil when nothing is declared, so a build with no build secrets never
+// touches the resolver. A cluster with no secret backends fails the build rather
+// than silently building without the credential — matching pinSecrets.
+//
+// stack is the resolved build stack ("dockerfile" or "auto"). Only a Dockerfile
+// build has a place to consume a secret (its own --mount=type=secret step), so a
+// build secret declared for an auto-detected language stack is rejected rather
+// than resolved and silently ignored.
+func (b *Builder) resolveBuildSecrets(ctx context.Context, ac *appconfig.AppConfig, stack string) (map[string][]byte, error) {
+	if ac == nil || ac.Build == nil || len(ac.Build.Secrets) == 0 {
+		return nil, nil
+	}
+
+	if stack != "dockerfile" {
+		return nil, fmt.Errorf("build secret %q is set, but build secrets are only supported for Dockerfile builds; this app builds with an auto-detected language stack, so add a Dockerfile with a matching --mount=type=secret step or remove [[build.secrets]]", ac.Build.Secrets[0].ID)
+	}
+
+	if b.Secrets == nil {
+		return nil, fmt.Errorf("build references secret %q but this cluster has no secret backends configured", ac.Build.Secrets[0].ID)
+	}
+
+	resolved := make(map[string][]byte, len(ac.Build.Secrets))
+	for _, bs := range ac.Build.Secrets {
+		backend := bs.Backend
+		if backend == "" {
+			backend = secret.ClusterBackendName
+		}
+		sv, err := b.Secrets.ResolveRef(ctx, backend, bs.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("resolving build secret %q (%s/%s): %w", bs.ID, backend, bs.Ref, err)
+		}
+		resolved[bs.ID] = sv.Bytes
+	}
+	return resolved, nil
+}
+
 // getAccessInfo queries routes to determine how the app can be accessed.
 // When ephemeralLabel is non-empty, wildcard routes are resolved to concrete
 // hostnames using the label (e.g., *.app.example.com → feat-x.app.example.com).

--- a/servers/build/build_saga_buildkit.go
+++ b/servers/build/build_saga_buildkit.go
@@ -177,11 +177,24 @@ func (b *Builder) runBuildkitBuild(
 		b.Log.Info("injecting env vars into build", "count", len(buildEnvVars))
 	}
 
+	buildSecrets, err := b.resolveBuildSecrets(ctx, in.AppConfig, in.BuildStack.Stack)
+	if err != nil {
+		b.Log.Error("failed to resolve build secrets", "error", err)
+		status.SendError("Failed to resolve build secrets: %v", err)
+		return nil, "", "", err
+	}
+	if len(buildSecrets) > 0 {
+		b.Log.Info("injecting secrets into build", "count", len(buildSecrets))
+	}
+
 	tos := []TransformOptions{
 		WithBuildArg("MIREN_VERSION", in.VersionName),
 	}
 	if len(buildEnvVars) > 0 {
 		tos = append(tos, WithBuildArgs(buildEnvVars))
+	}
+	if len(buildSecrets) > 0 {
+		tos = append(tos, WithBuildSecrets(buildSecrets))
 	}
 
 	// Pass env vars for auto-stack builds. We have to copy the stack so

--- a/servers/build/build_secrets_test.go
+++ b/servers/build/build_secrets_test.go
@@ -1,0 +1,246 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+
+	bkclient "github.com/moby/buildkit/client"
+	bksecrets "github.com/moby/buildkit/session/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"miren.dev/runtime/appconfig"
+	"miren.dev/runtime/pkg/secret"
+)
+
+// stubSecretResolver returns a fixed value per ref, or an error when the ref is
+// unknown. It records how many times it was called (so a test can assert the
+// resolver is left untouched when nothing is declared) and which backend each
+// ref was resolved against (so a test can assert the backend is forwarded, and
+// that an omitted backend defaults to "cluster").
+type stubSecretResolver struct {
+	values   map[string]string // ref -> plaintext
+	backends map[string]string // ref -> backend seen on the resolve call
+	calls    int
+}
+
+func (r *stubSecretResolver) ResolveRef(_ context.Context, backend, ref string) (secret.SecretValue, error) {
+	r.calls++
+	if r.backends == nil {
+		r.backends = map[string]string{}
+	}
+	r.backends[ref] = backend
+	v, ok := r.values[ref]
+	if !ok {
+		return secret.SecretValue{}, errors.New("no such secret")
+	}
+	return secret.SecretValue{Ref: ref, Bytes: []byte(v)}, nil
+}
+
+func newTestBuilder(secrets secret.Resolver) *Builder {
+	return &Builder{
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Secrets: secrets,
+	}
+}
+
+func buildSecretConfig(secrets ...appconfig.BuildSecret) *appconfig.AppConfig {
+	return &appconfig.AppConfig{
+		Name:  "test-app",
+		Build: &appconfig.BuildConfig{Secrets: secrets},
+	}
+}
+
+func TestResolveBuildSecretsResolvesEachEntry(t *testing.T) {
+	r := require.New(t)
+	resolver := &stubSecretResolver{values: map[string]string{
+		"registry/npm-token": "npm-secret",
+		"licenses/compiler":  "license-key",
+	}}
+	b := newTestBuilder(resolver)
+
+	ac := buildSecretConfig(
+		appconfig.BuildSecret{ID: "npm_token", Backend: "cluster", Ref: "registry/npm-token"},
+		appconfig.BuildSecret{ID: "license", Backend: "cluster", Ref: "licenses/compiler"},
+	)
+
+	got, err := b.resolveBuildSecrets(context.Background(), ac, "dockerfile")
+	r.NoError(err)
+	r.Equal(map[string][]byte{
+		"npm_token": []byte("npm-secret"),
+		"license":   []byte("license-key"),
+	}, got)
+	// The declared backend must reach the resolver, not be dropped or defaulted
+	// over.
+	r.Equal("cluster", resolver.backends["registry/npm-token"])
+}
+
+func TestResolveBuildSecretsDefaultsBackendToCluster(t *testing.T) {
+	r := require.New(t)
+	resolver := &stubSecretResolver{values: map[string]string{
+		"registry/npm-token": "npm-secret",
+	}}
+	b := newTestBuilder(resolver)
+
+	// Backend omitted: it should resolve against the built-in cluster store.
+	ac := buildSecretConfig(
+		appconfig.BuildSecret{ID: "npm_token", Ref: "registry/npm-token"},
+	)
+
+	got, err := b.resolveBuildSecrets(context.Background(), ac, "dockerfile")
+	r.NoError(err)
+	r.Equal(map[string][]byte{"npm_token": []byte("npm-secret")}, got)
+	r.Equal(secret.ClusterBackendName, resolver.backends["registry/npm-token"])
+}
+
+func TestResolveBuildSecretsRejectedForAutoStack(t *testing.T) {
+	r := require.New(t)
+	resolver := &stubSecretResolver{values: map[string]string{
+		"registry/npm-token": "npm-secret",
+	}}
+	b := newTestBuilder(resolver)
+
+	ac := buildSecretConfig(
+		appconfig.BuildSecret{ID: "npm_token", Backend: "cluster", Ref: "registry/npm-token"},
+	)
+
+	// An auto-detected language stack has no place to consume the secret, so it
+	// is rejected before the resolver is ever touched.
+	_, err := b.resolveBuildSecrets(context.Background(), ac, "auto")
+	r.Error(err)
+	r.Contains(err.Error(), "only supported for Dockerfile builds")
+	r.Contains(err.Error(), "npm_token")
+	r.Zero(resolver.calls, "an auto-stack build must fail before resolving any secret")
+}
+
+func TestResolveBuildSecretsNilWhenNoneDeclared(t *testing.T) {
+	r := require.New(t)
+	resolver := &stubSecretResolver{}
+	b := newTestBuilder(resolver)
+
+	// nil config, nil build block, and an empty secrets list all short-circuit
+	// before the resolver is touched.
+	for _, ac := range []*appconfig.AppConfig{
+		nil,
+		{Name: "test-app"},
+		buildSecretConfig(),
+	} {
+		// "auto" stack too: with nothing declared, the short-circuit wins and the
+		// auto-stack guard never fires.
+		got, err := b.resolveBuildSecrets(context.Background(), ac, "auto")
+		r.NoError(err)
+		r.Nil(got)
+	}
+	r.Zero(resolver.calls, "resolver must not be called when no build secrets are declared")
+}
+
+func TestResolveBuildSecretsErrorsWhenNoBackendsConfigured(t *testing.T) {
+	r := require.New(t)
+	b := newTestBuilder(nil) // cluster has no secret backends
+
+	ac := buildSecretConfig(
+		appconfig.BuildSecret{ID: "npm_token", Backend: "cluster", Ref: "registry/npm-token"},
+	)
+
+	_, err := b.resolveBuildSecrets(context.Background(), ac, "dockerfile")
+	r.Error(err)
+	r.Contains(err.Error(), "no secret backends configured")
+	r.Contains(err.Error(), "npm_token")
+}
+
+func TestResolveBuildSecretsPropagatesResolverError(t *testing.T) {
+	r := require.New(t)
+	resolver := &stubSecretResolver{values: map[string]string{}} // knows nothing
+	b := newTestBuilder(resolver)
+
+	ac := buildSecretConfig(
+		appconfig.BuildSecret{ID: "npm_token", Backend: "cluster", Ref: "registry/missing"},
+	)
+
+	_, err := b.resolveBuildSecrets(context.Background(), ac, "dockerfile")
+	r.Error(err)
+	r.Contains(err.Error(), "npm_token")
+}
+
+// The resolution logic above is only half the feature; these cover the wiring
+// that actually carries the value to BuildKit — WithBuildSecrets stashing the
+// map and attachBuildSecrets turning it into a session provider. The wiring is
+// the security-critical half: it is what keeps the value on the session channel
+// and out of the frontend attributes and image layers.
+
+func TestWithBuildSecretsSetsField(t *testing.T) {
+	r := require.New(t)
+	m := map[string][]byte{"npm_token": []byte("npm-secret")}
+
+	var opts transformOpt
+	WithBuildSecrets(m)(&opts)
+
+	r.Equal(m, opts.buildSecrets)
+}
+
+func TestAttachBuildSecretsNoopWhenEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		secrets map[string][]byte
+	}{
+		{"nil", nil},
+		{"empty", map[string][]byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var solveOpt bkclient.SolveOpt
+			attachBuildSecrets(&solveOpt, tc.secrets)
+			assert.Empty(t, solveOpt.Session, "no session provider should be attached when there are no secrets")
+		})
+	}
+}
+
+// TestAttachBuildSecretsDeliversByID proves the attached provider hands the
+// resolved value back keyed by its mount id, and answers NotFound for an id the
+// build never declared. It stands the provider up over an in-memory gRPC
+// connection, the same shape a real BuildKit session uses, so the test exercises
+// the actual delivery path rather than reaching into the map.
+func TestAttachBuildSecretsDeliversByID(t *testing.T) {
+	r := require.New(t)
+
+	var solveOpt bkclient.SolveOpt
+	attachBuildSecrets(&solveOpt, map[string][]byte{"npm_token": []byte("npm-secret")})
+	r.Len(solveOpt.Session, 1)
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	solveOpt.Session[0].Register(server)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		listener.Close()
+	})
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	r.NoError(err)
+	t.Cleanup(func() { conn.Close() })
+
+	client := bksecrets.NewSecretsClient(conn)
+
+	resp, err := client.GetSecret(context.Background(), &bksecrets.GetSecretRequest{ID: "npm_token"})
+	r.NoError(err)
+	r.Equal([]byte("npm-secret"), resp.Data)
+
+	_, err = client.GetSecret(context.Background(), &bksecrets.GetSecretRequest{ID: "unknown"})
+	r.Error(err)
+	assert.Equal(t, codes.NotFound, status.Code(err), "an undeclared id must not resolve to some other secret")
+}

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -18,6 +18,7 @@ import (
 	"github.com/moby/buildkit/frontend"
 	gateway "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"miren.dev/runtime/components/ocireg"
 	"miren.dev/runtime/pkg/idgen"
 	"miren.dev/runtime/pkg/stackbuild"
@@ -79,6 +80,12 @@ type transformOpt struct {
 	phaseUpdates  func(phase string)
 	cacheDir      string
 	frontendAttrs map[string]string
+	// buildSecrets maps a BuildKit secret id to its resolved plaintext. When
+	// non-empty, a secrets session provider is attached to the solve so a
+	// `RUN --mount=type=secret,id=<id>` step can read the value without it
+	// landing in an image layer. The bytes live only for the duration of the
+	// build and are never logged or exported.
+	buildSecrets map[string][]byte
 }
 
 type TransformOptions func(*transformOpt)
@@ -113,6 +120,25 @@ func WithBuildArgs(args map[string]string) TransformOptions {
 			o.frontendAttrs["build-arg:"+k] = v
 		}
 	}
+}
+
+// WithBuildSecrets attaches resolved secrets to the build, keyed by the mount id
+// a Dockerfile references with `--mount=type=secret,id=<id>`. Unlike build args,
+// these never enter the image or the frontend attributes.
+func WithBuildSecrets(secrets map[string][]byte) TransformOptions {
+	return func(o *transformOpt) {
+		o.buildSecrets = secrets
+	}
+}
+
+// attachBuildSecrets adds a secrets session provider to solveOpt when any build
+// secret was supplied. Mirrors addRegistryAuth: the value reaches BuildKit over
+// the session, never through frontend attributes or a layer.
+func attachBuildSecrets(solveOpt *client.SolveOpt, secrets map[string][]byte) {
+	if len(secrets) == 0 {
+		return
+	}
+	solveOpt.Session = append(solveOpt.Session, secretsprovider.FromMap(secrets))
 }
 
 func (b *Buildkit) Transform(ctx context.Context, dfs fsutil.FS, tos ...TransformOptions) (io.ReadCloser, chan struct{}, error) {
@@ -153,6 +179,7 @@ func (b *Buildkit) Transform(ctx context.Context, dfs fsutil.FS, tos ...Transfor
 	if err := b.addRegistryAuth(&solveOpt, ocireg.Host); err != nil {
 		return nil, nil, err
 	}
+	attachBuildSecrets(&solveOpt, opts.buildSecrets)
 
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -394,6 +421,7 @@ func (b *Buildkit) BuildImage(
 	if err := b.addRegistryAuth(&solveOpt, registryHost); err != nil {
 		return nil, err
 	}
+	attachBuildSecrets(&solveOpt, opts.buildSecrets)
 
 	if opts.cacheDir != "" {
 		solveOpt.CacheImports = []client.CacheOptionsEntry{


### PR DESCRIPTION
Build steps sometimes need a credential of their own: a private package-registry token for `npm ci` or `bundle install`, a license key to compile, a key to pull a private dependency. There was no good way to get one there. The only value that reached a build was an env var injected as a build-arg, and when that variable referenced a secret, the build-arg carried the reference string rather than the decrypted value, so it was useless to the build. The one working alternative was an inline value, which is masked in CLI output but still ends up baked into image history and build logs. Not something you want a real credential in.

This wires BuildKit's `RUN --mount=type=secret` into the build. You declare the secrets in a new `[[build.secrets]]` list in app.toml, naming each one by a mount id plus the same backend/ref a runtime secret reference already uses:

```toml
[[build.secrets]]
id = "npm_token"
backend = "cluster"
ref = "registry/npm-token"
```

Your Dockerfile then reads it inside a `--mount=type=secret,id=npm_token` step. At build time the value is resolved to plaintext through the existing secret resolver, held only in memory, and handed to BuildKit over the same session channel that already carries the registry token. It never becomes a build-arg, never shows up in the build log, and never lands in an image layer, so it isn't visible in `docker history` or to anyone who later pulls the image. If the cluster has no secret backend, or a ref can't be found, the build fails rather than quietly building without the credential.

This first cut covers Dockerfile builds, where you write the `--mount` step yourself. Auto-stack builds (the automatic language builders) don't consume the secret yet; that's a tracked follow-up, along with a warning for when build secrets are declared on a build that can't use them.

Closes MIR-1642

https://claude.ai/code/session_013PjMokK2y4cGnPsHNmGFsY