### PR TITLE
Inherit base image environment in stack builds

### DIFF
--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -334,6 +334,7 @@ func (b *Buildkit) BuildImage(
 		solveOpt.FrontendAttrs["filename"] = bs.Input
 	} else {
 		buildOpts := stackbuild.BuildOptions{
+			Log:         b.Log,
 			OnBuild:     bs.OnBuild,
 			Version:     bs.Version,
 			AlpineImage: bs.AlpineImage,
@@ -344,7 +345,7 @@ func (b *Buildkit) BuildImage(
 			return nil, err
 		}
 
-		state, err := stack.GenerateLLB(bs.CodeDir, buildOpts)
+		state, err := stack.GenerateLLB(ctx, bs.CodeDir, buildOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/stackbuild/bun.go
+++ b/pkg/stackbuild/bun.go
@@ -1,6 +1,7 @@
 package stackbuild
 
 import (
+	"context"
 	"encoding/json"
 	"regexp"
 	"strings"
@@ -157,7 +158,7 @@ func (s *BunStack) Init(opts BuildOptions) {
 	}
 }
 
-func (s *BunStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error) {
+func (s *BunStack) GenerateLLB(ctx context.Context, dir string, opts BuildOptions) (*llb.State, error) {
 	// Set up local context with the directory
 	localCtx := llb.Local("context",
 		llb.SharedKeyHint(dir),
@@ -170,7 +171,9 @@ func (s *BunStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error
 	if opts.Version != "" {
 		version = opts.Version
 	}
-	base := llb.Image(imagerefs.GetBunImage(version))
+	// Bun's image relocates node onto a PATH its Dockerfile sets, plus other
+	// runtime env; baseImage carries that environment into the final image.
+	base := s.baseImage(ctx, imagerefs.GetBunImage(version), opts)
 
 	base = s.addAppUser(base)
 

--- a/pkg/stackbuild/golang.go
+++ b/pkg/stackbuild/golang.go
@@ -1,6 +1,7 @@
 package stackbuild
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -189,7 +190,7 @@ func (s *GoStack) parseGoModVersion() string {
 	return ""
 }
 
-func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error) {
+func (s *GoStack) GenerateLLB(ctx context.Context, dir string, opts BuildOptions) (*llb.State, error) {
 	// Set up local context with the directory
 	localCtx := llb.Local("context",
 		llb.SharedKeyHint(dir),
@@ -198,7 +199,10 @@ func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
 		llb.WithCustomName("application code"),
 	)
 
-	mr := imagemetaresolver.Default()
+	// New(), not the process-wide Default() singleton, so a long-lived build
+	// server resolves a coherent current config for this build's builder image
+	// rather than a stale cached revision of the mutable tag (see baseImage).
+	mr := imagemetaresolver.New()
 	version := "1.23"
 	if opts.Version != "" {
 		version = opts.Version
@@ -256,7 +260,7 @@ func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
 	builder = builder.AddEnv("APP", "/bin/app")
 	builder = s.applyOnBuild(builder, opts)
 
-	runtime := s.assembleRuntime(h, mr, builder)
+	runtime := s.assembleRuntime(ctx, h, builder, opts)
 
 	return &runtime, nil
 }
@@ -279,9 +283,9 @@ func (s *GoStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
 // Both paths run as uid 2010 (the app user) for consistency with every other
 // stack: debian-slim creates it with adduser, distroless gets a written
 // /etc/passwd since it has no shell to run adduser.
-func (s *GoStack) assembleRuntime(h *highlevelBuilder, mr llb.ImageMetaResolver, builder llb.State) llb.State {
+func (s *GoStack) assembleRuntime(ctx context.Context, h *highlevelBuilder, builder llb.State, opts BuildOptions) llb.State {
 	if s.cgoEnabled || len(s.Augmentations()) > 0 {
-		rt := llb.Image(imagerefs.DebianSlim, llb.WithMetaResolver(mr))
+		rt := s.baseImage(ctx, imagerefs.DebianSlim, opts)
 		rt = h.aptInstall(rt, "ca-certificates")
 		rt = s.addAppUser(rt) // sets result.Config.User = "2010"
 		rt = rt.File(llb.Mkdir("/app", 0o755,
@@ -299,7 +303,7 @@ func (s *GoStack) assembleRuntime(h *highlevelBuilder, mr llb.ImageMetaResolver,
 		return rt
 	}
 
-	rt := llb.Image(imagerefs.GoRuntimeStatic, llb.WithMetaResolver(mr))
+	rt := s.baseImage(ctx, imagerefs.GoRuntimeStatic, opts)
 
 	// distroless ships no shell or coreutils, which breaks two things: the
 	// runner launches the app as `/bin/sh -c <command>` (controllers/sandbox),

--- a/pkg/stackbuild/node.go
+++ b/pkg/stackbuild/node.go
@@ -1,6 +1,7 @@
 package stackbuild
 
 import (
+	"context"
 	"encoding/json"
 	"regexp"
 	"strings"
@@ -155,7 +156,7 @@ func (s *NodeStack) Init(opts BuildOptions) {
 	}
 }
 
-func (s *NodeStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error) {
+func (s *NodeStack) GenerateLLB(ctx context.Context, dir string, opts BuildOptions) (*llb.State, error) {
 	// Set up local context with the directory
 	localCtx := llb.Local("context",
 		llb.SharedKeyHint(dir),
@@ -168,7 +169,9 @@ func (s *NodeStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 	if opts.Version != "" {
 		version = opts.Version
 	}
-	base := llb.Image(imagerefs.GetNodeImage(version))
+	// Carry the upstream node image's environment (PATH, NODE_VERSION, ...)
+	// into the final image.
+	base := s.baseImage(ctx, imagerefs.GetNodeImage(version), opts)
 
 	base = s.addAppUser(base)
 

--- a/pkg/stackbuild/path_test.go
+++ b/pkg/stackbuild/path_test.go
@@ -1,0 +1,135 @@
+package stackbuild
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/moby/buildkit/client/llb/sourceresolver"
+	"github.com/opencontainers/go-digest"
+	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathFromEnv(t *testing.T) {
+	require.Equal(t, "/opt/bin:/usr/bin", pathFromEnv([]string{"NODE_ENV=production", "PATH=/opt/bin:/usr/bin"}))
+	require.Equal(t, "", pathFromEnv([]string{"NODE_ENV=production"}))
+	require.Equal(t, "", pathFromEnv(nil))
+	// First PATH wins.
+	require.Equal(t, "/first", pathFromEnv([]string{"PATH=/first", "PATH=/second"}))
+}
+
+func TestSetResultEnv(t *testing.T) {
+	var s MetaStack
+	s.setupResult() // seeds a default PATH
+
+	// Replacing PATH keeps a single PATH entry.
+	s.setResultEnv("PATH", "/opt/bin:/usr/bin")
+	require.Equal(t, "/opt/bin:/usr/bin", pathFromEnv(s.result.Config.Env))
+	require.Equal(t, 1, countPrefix(s.result.Config.Env, "PATH="))
+
+	// A new key is appended without disturbing PATH.
+	s.setResultEnv("NODE_ENV", "production")
+	require.Contains(t, s.result.Config.Env, "NODE_ENV=production")
+	require.Equal(t, "/opt/bin:/usr/bin", pathFromEnv(s.result.Config.Env))
+}
+
+// fakeMetaResolver returns a fixed image config, or an error, for any ref.
+type fakeMetaResolver struct {
+	cfg []byte
+	err error
+}
+
+func (f fakeMetaResolver) ResolveImageConfig(ctx context.Context, ref string, opt sourceresolver.Opt) (string, digest.Digest, []byte, error) {
+	if f.err != nil {
+		return "", "", nil, f.err
+	}
+	return ref, "", f.cfg, nil
+}
+
+func imageConfigJSON(t *testing.T, env []string) []byte {
+	t.Helper()
+	var img ocispecs.Image
+	img.Config.Env = env
+	data, err := json.Marshal(img)
+	require.NoError(t, err)
+	return data
+}
+
+// envValue returns the value for key in an OCI-style env slice, or "" if absent.
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, e := range env {
+		if len(e) >= len(prefix) && e[:len(prefix)] == prefix {
+			return e[len(prefix):]
+		}
+	}
+	return ""
+}
+
+func TestInheritBaseEnv(t *testing.T) {
+	t.Run("adopts upstream PATH over the default", func(t *testing.T) {
+		var s MetaStack
+		s.setupResult()
+		mr := fakeMetaResolver{cfg: imageConfigJSON(t, []string{"PATH=/usr/local/node/bin:/usr/local/bin:/usr/bin"})}
+		s.inheritBaseEnv(context.Background(), mr, "bun:1", BuildOptions{})
+		require.Equal(t, "/usr/local/node/bin:/usr/local/bin:/usr/bin", pathFromEnv(s.result.Config.Env))
+		require.Equal(t, 1, countPrefix(s.result.Config.Env, "PATH="))
+	})
+
+	t.Run("inherits other env vars, not just PATH", func(t *testing.T) {
+		var s MetaStack
+		s.setupResult()
+		mr := fakeMetaResolver{cfg: imageConfigJSON(t, []string{
+			"LANG=C.UTF-8",
+			"NODE_VERSION=20.11.0",
+			"GEM_HOME=/usr/local/bundle",
+		})}
+		s.inheritBaseEnv(context.Background(), mr, "node:20", BuildOptions{})
+		require.Equal(t, "C.UTF-8", envValue(s.result.Config.Env, "LANG"))
+		require.Equal(t, "20.11.0", envValue(s.result.Config.Env, "NODE_VERSION"))
+		require.Equal(t, "/usr/local/bundle", envValue(s.result.Config.Env, "GEM_HOME"))
+	})
+
+	t.Run("stack's deliberate env wins over the base", func(t *testing.T) {
+		var s MetaStack
+		s.setupResult()
+		// Stack sets a value before inheritance runs.
+		s.AddEnv("BUNDLE_WITHOUT", "development")
+		mr := fakeMetaResolver{cfg: imageConfigJSON(t, []string{"BUNDLE_WITHOUT=test", "GEM_HOME=/usr/local/bundle"})}
+		s.inheritBaseEnv(context.Background(), mr, "ruby:3.4", BuildOptions{})
+		// Base does not clobber the stack's deliberate choice, but still fills in
+		// vars the stack didn't set.
+		require.Equal(t, "development", envValue(s.result.Config.Env, "BUNDLE_WITHOUT"))
+		require.Equal(t, 1, countPrefix(s.result.Config.Env, "BUNDLE_WITHOUT="))
+		require.Equal(t, "/usr/local/bundle", envValue(s.result.Config.Env, "GEM_HOME"))
+	})
+
+	t.Run("keeps default when base declares no PATH", func(t *testing.T) {
+		var s MetaStack
+		s.setupResult()
+		def := pathFromEnv(s.result.Config.Env)
+		mr := fakeMetaResolver{cfg: imageConfigJSON(t, []string{"NODE_ENV=production"})}
+		s.inheritBaseEnv(context.Background(), mr, "bun:1", BuildOptions{})
+		require.Equal(t, def, pathFromEnv(s.result.Config.Env))
+	})
+
+	t.Run("keeps defaults on resolve error", func(t *testing.T) {
+		var s MetaStack
+		s.setupResult()
+		def := pathFromEnv(s.result.Config.Env)
+		mr := fakeMetaResolver{err: context.DeadlineExceeded}
+		s.inheritBaseEnv(context.Background(), mr, "bun:1", BuildOptions{})
+		require.Equal(t, def, pathFromEnv(s.result.Config.Env))
+	})
+}
+
+func countPrefix(env []string, prefix string) int {
+	n := 0
+	for _, e := range env {
+		if len(e) >= len(prefix) && e[:len(prefix)] == prefix {
+			n++
+		}
+	}
+	return n
+}

--- a/pkg/stackbuild/python.go
+++ b/pkg/stackbuild/python.go
@@ -1,6 +1,7 @@
 package stackbuild
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -236,7 +237,7 @@ func (s *PythonStack) detectPackage(pkg string) bool {
 	return false
 }
 
-func (s *PythonStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error) {
+func (s *PythonStack) GenerateLLB(ctx context.Context, dir string, opts BuildOptions) (*llb.State, error) {
 	// Set up local context with the directory
 	localCtx := llb.Local("context",
 		llb.SharedKeyHint(dir),
@@ -250,7 +251,9 @@ func (s *PythonStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, er
 		version = opts.Version
 	}
 
-	base := llb.Image(imagerefs.GetPythonImage(version))
+	// Carry the upstream python image's environment (PATH, LANG,
+	// PYTHON_VERSION, ...) into the final image.
+	base := s.baseImage(ctx, imagerefs.GetPythonImage(version), opts)
 
 	base = s.addAppUser(base)
 

--- a/pkg/stackbuild/ruby.go
+++ b/pkg/stackbuild/ruby.go
@@ -2,13 +2,13 @@ package stackbuild
 
 import (
 	"bufio"
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/moby/buildkit/client/llb"
-	"github.com/moby/buildkit/client/llb/imagemetaresolver"
 	"miren.dev/runtime/pkg/imagerefs"
 )
 
@@ -242,7 +242,7 @@ func (s *RubyStack) detectGem(gem string) bool {
 	return strings.Contains(string(data), gem)
 }
 
-func (s *RubyStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error) {
+func (s *RubyStack) GenerateLLB(ctx context.Context, dir string, opts BuildOptions) (*llb.State, error) {
 	// Set up local context with the directory
 	localCtx := llb.Local("context",
 		llb.SharedKeyHint(dir),
@@ -251,15 +251,15 @@ func (s *RubyStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 		llb.WithCustomName("application code"),
 	)
 
-	mr := imagemetaresolver.Default()
-
 	version := "3.4"
 	if opts.Version != "" {
 		version = opts.Version
 	} else if s.rubyVersion != "" {
 		version = s.rubyVersion
 	}
-	base := llb.Image(imagerefs.GetRubyImage(version), llb.WithMetaResolver(mr))
+	// Carry the upstream ruby image's environment (PATH, GEM_HOME, LANG,
+	// BUNDLE_*, ...) into the final image; our own AddEnv calls below still win.
+	base := s.baseImage(ctx, imagerefs.GetRubyImage(version), opts)
 
 	base = s.addAppUser(base)
 

--- a/pkg/stackbuild/rust.go
+++ b/pkg/stackbuild/rust.go
@@ -1,12 +1,12 @@
 package stackbuild
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/moby/buildkit/client/llb"
-	"github.com/moby/buildkit/client/llb/imagemetaresolver"
 	"github.com/pelletier/go-toml/v2"
 	"miren.dev/runtime/pkg/imagerefs"
 )
@@ -144,7 +144,7 @@ func (s *RustStack) parseCargoToml() *cargoToml {
 	return &cargo
 }
 
-func (s *RustStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, error) {
+func (s *RustStack) GenerateLLB(ctx context.Context, dir string, opts BuildOptions) (*llb.State, error) {
 	// Set up local context with the directory
 	localCtx := llb.Local("context",
 		llb.SharedKeyHint(dir),
@@ -158,12 +158,10 @@ func (s *RustStack) GenerateLLB(dir string, opts BuildOptions) (*llb.State, erro
 		version = opts.Version
 	}
 
-	// NOTE: If we don't pass this in with WithMetaResolver, then
-	// buildkit doesn't add the info from the image, info like
-	// the PATH env var.
-	mr := imagemetaresolver.Default()
-
-	base := llb.Image(imagerefs.GetRustImage(version), llb.WithMetaResolver(mr))
+	// baseImage resolves the image config with a meta resolver, which is what
+	// makes buildkit add the base image's own env (PATH, CARGO_HOME, ...) to the
+	// build steps, and it also folds that env into the final image config.
+	base := s.baseImage(ctx, imagerefs.GetRustImage(version), opts)
 
 	base = s.addAppUser(base)
 

--- a/pkg/stackbuild/stackbuild.go
+++ b/pkg/stackbuild/stackbuild.go
@@ -1,6 +1,8 @@
 package stackbuild
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +12,8 @@ import (
 
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/client/llb/imagemetaresolver"
+	"github.com/moby/buildkit/client/llb/sourceresolver"
 	"github.com/moby/buildkit/util/system"
 	ocispecs "github.com/opencontainers/image-spec/specs-go/v1"
 	"miren.dev/runtime/pkg/imagerefs"
@@ -17,7 +21,10 @@ import (
 
 // BuildOptions contains configuration for stack builds
 type BuildOptions struct {
-	Log interface{ Info(string, ...any) }
+	Log interface {
+		Info(string, ...any)
+		Warn(string, ...any)
+	}
 
 	// Name is the name of the application being built
 	Name string
@@ -55,7 +62,7 @@ type Stack interface {
 	// Init is called after detection to perform common initialization
 	Init(opts BuildOptions)
 	// GenerateLLB creates the BuildKit LLB for building this stack
-	GenerateLLB(dir string, opts BuildOptions) (*llb.State, error)
+	GenerateLLB(ctx context.Context, dir string, opts BuildOptions) (*llb.State, error)
 
 	Image() ocispecs.Image
 
@@ -179,15 +186,115 @@ func (s *MetaStack) setupResult() {
 	s.result.Variant = pl.Variant
 	s.result.RootFS.Type = "layers"
 	s.result.Config.WorkingDir = "/app"
-	s.result.Config.Env = []string{"PATH=" + system.DefaultPathEnv(pl.OS)}
+	s.setResultEnv("PATH", system.DefaultPathEnv(pl.OS))
+}
+
+// setResultEnv sets key=value in the final image config, replacing an existing
+// entry for key if present and appending otherwise.
+func (s *MetaStack) setResultEnv(key, value string) {
+	entry := key + "=" + value
+	prefix := key + "="
+	for i, e := range s.result.Config.Env {
+		if strings.HasPrefix(e, prefix) {
+			s.result.Config.Env[i] = entry
+			return
+		}
+	}
+	s.result.Config.Env = append(s.result.Config.Env, entry)
+}
+
+// hasResultEnv reports whether the final image config already sets key.
+func (s *MetaStack) hasResultEnv(key string) bool {
+	prefix := key + "="
+	for _, e := range s.result.Config.Env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathFromEnv returns the value of the PATH entry in a docker/OCI-style env
+// slice ("KEY=VALUE"), or "" if none is present.
+func pathFromEnv(env []string) string {
+	for _, e := range env {
+		if v, ok := strings.CutPrefix(e, "PATH="); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// baseImage builds the LLB state for a base image ref and inherits the image's
+// environment into the final image config. Every stack should build the base(s)
+// that become its final image through this helper so env inheritance is
+// automatic and uniform — a new stack gets it for free.
+func (s *MetaStack) baseImage(ctx context.Context, ref string, opts BuildOptions) llb.State {
+	// New(), not Default(): Default() is a process-wide singleton whose cache
+	// lives for the process lifetime, keyed by ref+platform. The build server is
+	// long-lived and our refs are mutable tags, so a later build could inherit
+	// Env from a stale cached revision while BuildKit solves against the current
+	// one — the very PATH/config mismatch this helper exists to prevent. A fresh
+	// resolver per build resolves a coherent current config; it is still shared
+	// within the build between inheritBaseEnv and the LLB marshal below.
+	mr := imagemetaresolver.New()
+	s.inheritBaseEnv(ctx, mr, ref, opts)
+	return llb.Image(ref, llb.WithMetaResolver(mr))
+}
+
+// inheritBaseEnv resolves ref's image config and folds the environment the
+// upstream Dockerfile set into the final image config, so the exported image
+// behaves like `docker run <base>` would:
+//
+//   - PATH is always taken from the base. Upstream images (e.g. Bun's, which
+//     relocates node to a non-standard bin dir) prepend their own directories
+//     to the standard set, so the base PATH is a superset and supersedes our
+//     seeded default.
+//   - Every other var (LANG, GEM_HOME, NODE_VERSION, ...) is filled in only
+//     when the stack has not already set it deliberately, so Miren's own
+//     AddEnv choices always win regardless of call order.
+//
+// Best-effort: the base image must be pullable for the build to proceed at all,
+// so a resolve failure here is unlikely; when it happens we keep what we have
+// rather than failing the build.
+func (s *MetaStack) inheritBaseEnv(ctx context.Context, mr llb.ImageMetaResolver, ref string, opts BuildOptions) {
+	pl := platforms.Normalize(platforms.DefaultSpec())
+	_, _, cfg, err := mr.ResolveImageConfig(ctx, ref, sourceresolver.Opt{Platform: &pl})
+	if err != nil {
+		if opts.Log != nil {
+			opts.Log.Warn("could not resolve base image config for env inheritance; keeping defaults", "ref", ref, "error", err.Error())
+		}
+		return
+	}
+
+	var img ocispecs.Image
+	if err := json.Unmarshal(cfg, &img); err != nil {
+		if opts.Log != nil {
+			opts.Log.Warn("could not parse base image config for env inheritance; keeping defaults", "ref", ref, "error", err.Error())
+		}
+		return
+	}
+
+	for _, e := range img.Config.Env {
+		key, value, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		if key == "PATH" || !s.hasResultEnv(key) {
+			s.setResultEnv(key, value)
+		}
+	}
 }
 
 func (s *MetaStack) Image() ocispecs.Image {
 	return s.result
 }
 
+// AddEnv sets a deliberate env var on the final image config. It replaces any
+// existing entry for key — including one inherited from the base image — so the
+// stack's explicit choice wins.
 func (s *MetaStack) AddEnv(key, value string) {
-	s.result.Config.Env = append(s.result.Config.Env, fmt.Sprintf("%s=%s", key, value))
+	s.setResultEnv(key, value)
 }
 
 func (s *MetaStack) SetEntrypoint(ep []string) {

--- a/pkg/stackbuild/stackbuild_test.go
+++ b/pkg/stackbuild/stackbuild_test.go
@@ -216,7 +216,7 @@ func TestRails(t *testing.T) {
 			dir: dir,
 		},
 	}
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "3.2"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "3.2"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state)
@@ -249,7 +249,7 @@ func TestRuby(t *testing.T) {
 			dir: dir,
 		},
 	}
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "3.2"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "3.2"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state)
@@ -277,7 +277,7 @@ func TestPython(t *testing.T) {
 			dir: dir,
 		},
 	}
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "3.11"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "3.11"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state)
@@ -297,7 +297,7 @@ func TestPython(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0644))
 	}
 
-	state, err = stack.GenerateLLB(dir, BuildOptions{Version: "3.11"})
+	state, err = stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "3.11"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state)
@@ -325,7 +325,7 @@ func TestPythonPoetry(t *testing.T) {
 			dir: dir,
 		},
 	}
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "3.11"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "3.11"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state)
@@ -361,7 +361,7 @@ func TestNode(t *testing.T) {
 			dir: dir,
 		},
 	}
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "20"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "20"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state, func(r io.Reader) {
@@ -392,7 +392,7 @@ func TestNode(t *testing.T) {
 			},
 		}
 
-		state, err = stack.GenerateLLB(dir, BuildOptions{Version: "20"})
+		state, err = stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "20"})
 		require.NoError(t, err)
 
 		buildLLB(t, dir, state, func(r io.Reader) {
@@ -503,7 +503,7 @@ func TestNodeNextjs(t *testing.T) {
 			// The build graph must construct and marshal cleanly, including the
 			// Next.js build step (the AddEnv loop + build.Run) for the Next
 			// cases. This covers the GenerateLLB wiring without needing Docker.
-			state, err := stack.GenerateLLB(dir, BuildOptions{EnvVars: map[string]string{"NEXT_PUBLIC_FOO": "bar"}})
+			state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{EnvVars: map[string]string{"NEXT_PUBLIC_FOO": "bar"}})
 			require.NoError(t, err)
 			_, err = state.Marshal(context.Background())
 			require.NoError(t, err)
@@ -539,7 +539,7 @@ func TestBun(t *testing.T) {
 			dir: dir,
 		},
 	}
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "1"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "1"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state)
@@ -689,7 +689,7 @@ func TestGo(t *testing.T) {
 			dir: dir,
 		},
 	}
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "1.23"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "1.23"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state, func(r io.Reader) {
@@ -756,7 +756,7 @@ func TestGoRuntimeIncludesNonGoFiles(t *testing.T) {
 			dir: dir,
 		},
 	}
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "1.23"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "1.23"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state, func(r io.Reader) {
@@ -806,7 +806,7 @@ func TestGoCgo(t *testing.T) {
 	stack.Init(opts)
 	require.True(t, stack.cgoEnabled)
 
-	state, err := stack.GenerateLLB(dir, opts)
+	state, err := stack.GenerateLLB(context.Background(), dir, opts)
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state, func(r io.Reader) {
@@ -872,7 +872,7 @@ func main() {
 			dir: dir,
 		},
 	}
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "1.23"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "1.23"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state, func(r io.Reader) {
@@ -1057,7 +1057,7 @@ func TestRust(t *testing.T) {
 	}
 	require.True(t, stack.Detect())
 	stack.Init(BuildOptions{Version: "1"})
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "1"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "1"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state, func(r io.Reader) {
@@ -1095,7 +1095,7 @@ func TestPythonUv(t *testing.T) {
 	// Verify uv is detected
 	require.True(t, stack.Detect())
 
-	state, err := stack.GenerateLLB(dir, BuildOptions{Version: "3.11"})
+	state, err := stack.GenerateLLB(context.Background(), dir, BuildOptions{Version: "3.11"})
 	require.NoError(t, err)
 
 	buildLLB(t, dir, state)

--- a/servers/build/buildkit.go
+++ b/servers/build/buildkit.go
@@ -370,6 +370,7 @@ func (b *Buildkit) BuildImage(
 		solveOpt.FrontendAttrs["filename"] = bs.Input
 	} else {
 		buildOpts := stackbuild.BuildOptions{
+			Log:         b.Log,
 			Name:        app,
 			OnBuild:     bs.OnBuild,
 			Version:     bs.Version,
@@ -382,7 +383,7 @@ func (b *Buildkit) BuildImage(
 			return nil, err
 		}
 
-		state, err := stack.GenerateLLB(bs.CodeDir, buildOpts)
+		state, err := stack.GenerateLLB(ctx, bs.CodeDir, buildOpts)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When Miren auto-builds an app that has no Dockerfile, `pkg/stackbuild` assembles the final image config from scratch. It seeds the environment with just a default `PATH`, stacks layer on a few of their own vars, and that config gets exported verbatim. The catch: buildkit doesn't merge the base image's own config into a config you hand it explicitly, so every `ENV` the upstream base image's Dockerfile set was silently dropped from the finished image.

This bit us with Bun. Recent Bun images relocate `node` into a non-standard bin dir and prepend that dir to `PATH`. Because we overwrote `PATH` with our default, `node` vanished at runtime and anything that shelled out to it broke. And it wasn't just `PATH`: `LANG`, `GEM_HOME`, the language version vars, everything the official images declare was getting thrown away too.

The fix routes every stack's final base image through a new `baseImage` helper. It resolves the base image config and folds that environment into the final config, so the built image behaves like `docker run <base>` would. `PATH` is always taken from the base, since its directories are a superset of our default. Every other var fills in only where the stack hasn't deliberately set one, so Miren's own choices (Ruby's `BUNDLE_PATH`, and so on) still win regardless of ordering. Putting it in one helper is the point: inheritance is now automatic and uniform, and a stack added later gets it for free rather than having to remember to opt in.

One deliberate exception: the Go builder image doesn't inherit, since we don't want the toolchain's env leaking into the tiny distroless runtime image. Only the runtime base's env comes through there.

Closes MIR-1631

https://claude.ai/code/session_0197pxQ5MX8GgzCQdsgXfLiv