### PR TITLE
Keep a compatibility window for `app run` across the durable-runs switch

### DIFF
--- a/cli/commands/app_run.go
+++ b/cli/commands/app_run.go
@@ -12,6 +12,7 @@ import (
 	"miren.dev/runtime/api/app/app_v1alpha"
 	"miren.dev/runtime/api/exec/exec_v1alpha"
 	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/stream"
 )
 
@@ -41,6 +42,19 @@ func AppRun(ctx *Context, opts struct {
 }) error {
 	runs, err := runsClient(ctx)
 	if err != nil {
+		// Compatibility window: a server from before durable runs (<= v0.13)
+		// does not offer the app-runs capability. That specific case comes back
+		// as a lookup error -- the server answered, it just does not have the
+		// capability -- and only that case falls back to the legacy
+		// exec-by-app path. A transport or auth failure is a real error and
+		// must surface unchanged rather than be misread as an old server.
+		// Remove this fallback once v0.13 is out of the compatibility window.
+		if serverPredatesRuns(err) {
+			if opts.Task != "" || opts.Detach {
+				return fmt.Errorf("--task and --detach need a newer cluster that supports durable runs; a plain `miren app run` still works against this one")
+			}
+			return appRunLegacy(ctx, opts.App, opts.Args)
+		}
 		return err
 	}
 
@@ -74,6 +88,64 @@ func AppRun(ctx *Context, opts struct {
 	}
 
 	return reportRunExit(ctx, runs, runID)
+}
+
+// serverPredatesRuns reports whether a runsClient error means the cluster is
+// too old to offer durable runs, as opposed to being unreachable, wedged, or
+// refusing the caller.
+//
+// Only a lookup failure qualifies: the server answered and said it does not have
+// the app-runs capability. Transport and auth failures are different
+// ResolveError kinds and must not fall back -- retrying an old protocol against
+// a healthy current server would mask the real problem. RPCClient wraps the
+// error in a *ui.Diagnostic, but that unwraps to its cause, so errors.Is still
+// reaches the ResolveError underneath.
+func serverPredatesRuns(err error) bool {
+	return errors.Is(err, rpc.ErrResolveLookup)
+}
+
+// appRunLegacy runs a command through the pre-durable-runs exec-by-app path.
+//
+// It exists only for the compatibility window. A current CLI talking to a server
+// that predates durable runs (<= v0.13) cannot create a Run, so it falls back to
+// the exec protocol that server still speaks: the server creates an ephemeral
+// sandbox for the app and streams a shell into it. This reproduces the v0.13
+// client exactly, so exit codes still propagate, but none of the durable-run
+// surface (--task, --detach, retrievable outcomes) is available -- the caller
+// has already been steered away from those before reaching here.
+//
+// Remove this once v0.13 is out of the compatibility window.
+func appRunLegacy(ctx *Context, app string, args []string) error {
+	opt := new(exec_v1alpha.ShellOptions)
+	if len(args) > 0 {
+		opt.SetCommand(args)
+	}
+
+	in, out, winUpdates, cleanup := setupExecIO(ctx, opt)
+	defer cleanup()
+
+	cl, err := ctx.RPCClient("dev.miren.runtime/exec")
+	if err != nil {
+		return err
+	}
+
+	sec := exec_v1alpha.NewSandboxExecClient(cl)
+
+	results, err := sec.Exec(
+		ctx,
+		"app", app,
+		strings.Join(args, " "),
+		opt,
+		stream.ServeReader(ctx, in),
+		stream.ServeWriter(ctx, out),
+		stream.ChanReader(winUpdates),
+	)
+	if err != nil {
+		return err
+	}
+
+	ctx.SetExitCode(int(results.Code()))
+	return nil
 }
 
 // stdinIsTerminal reports whether a person is typing at this command.

--- a/cli/commands/app_run_test.go
+++ b/cli/commands/app_run_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"miren.dev/runtime/pkg/rpc"
+	"miren.dev/runtime/pkg/ui"
+)
+
+// The compatibility fallback hinges on one distinction: a server that answered
+// and does not offer app-runs (fall back to legacy exec) versus a server that
+// is unreachable, wedged, or refusing us (surface the real error). Falling back
+// on the wrong one would either retry an old protocol against a healthy current
+// server or hide a transport failure behind a misleading legacy attempt.
+func TestServerPredatesRunsOnlyForLookupFailures(t *testing.T) {
+	const cap = "dev.miren.runtime/app-runs"
+	const remote = "prod:8443"
+
+	t.Run("capability absent falls back", func(t *testing.T) {
+		err := rpc.NewResolveLookupError(cap, remote, "unknown object: "+cap)
+		assert.True(t, serverPredatesRuns(err))
+	})
+
+	t.Run("a diagnostic-wrapped lookup error still falls back", func(t *testing.T) {
+		// runsClient returns the error wrapped by RPCClient in a *ui.Diagnostic;
+		// errors.Is must still reach the ResolveError through the wrap.
+		lookup := rpc.NewResolveLookupError(cap, remote, "unknown object: "+cap)
+		wrapped := &ui.Diagnostic{Summary: "old cluster", Cause: lookup}
+		assert.True(t, serverPredatesRuns(wrapped))
+	})
+
+	notOldServer := []struct {
+		name string
+		err  error
+	}{
+		{"unreachable", rpc.NewResolveUnreachableError(cap, remote, 5*time.Second, errors.New("dial"))},
+		{"went silent", rpc.NewResolveWentSilentError(cap, remote, 30*time.Second, errors.New("reset"))},
+		{"no answer", rpc.NewResolveNoAnswerError(cap, remote, 8*time.Second, errors.New("timeout"))},
+		{"unauthorized", rpc.NewResolveStatusError(cap, remote, 401)},
+		{"unrelated error", errors.New("boom")},
+	}
+	for _, tc := range notOldServer {
+		t.Run(tc.name+" does not fall back", func(t *testing.T) {
+			assert.False(t, serverPredatesRuns(tc.err),
+				"only a lookup failure means an old server; this must surface as-is")
+		})
+	}
+}

--- a/components/coordinate/coordinate.go
+++ b/components/coordinate/coordinate.go
@@ -1412,7 +1412,13 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	)
 	c.cm.AddController(runSandboxReconciler)
 
-	eps := execproxy.NewServer(c.Log, eac, rs)
+	// AppInfo is built here (ahead of its own ExposeValue calls below) because
+	// the exec proxy needs it: its legacy exec-by-app compatibility path creates
+	// a run in-process through AppInfo rather than over a loopback RPC.
+	ai := app.NewAppInfo(c.Log, ec, c.Cpu, c.Mem, c.HTTP, secretRegistry)
+	c.appInfo = ai
+
+	eps := execproxy.NewServer(c.Log, eac, rs, ai)
 	server.ExposeValue("dev.miren.runtime/exec", exec_v1alpha.AdaptSandboxExec(eps))
 
 	// Give the addon framework an exec client so providers whose credential lives
@@ -1527,8 +1533,6 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	}
 	c.schemaReindex.Start(ctx)
 
-	ai := app.NewAppInfo(c.Log, ec, c.Cpu, c.Mem, c.HTTP, secretRegistry)
-	c.appInfo = ai
 	server.ExposeValue("dev.miren.runtime/app", app_v1alpha.AdaptCrud(ai))
 	server.ExposeValue("dev.miren.runtime/app-status", app_v1alpha.AdaptAppStatus(ai))
 	server.ExposeValue("dev.miren.runtime/app-runs", app_v1alpha.AdaptRuns(ai))

--- a/servers/app/runs.go
+++ b/servers/app/runs.go
@@ -255,28 +255,40 @@ func (r *AppInfo) GetRun(ctx context.Context, state *app_v1alpha.RunsGetRun) err
 // transition, so this deliberately does not write CANCELED itself -- a second
 // writer would race the reconcile that is also deciding this run's fate.
 func (r *AppInfo) CancelRun(ctx context.Context, state *app_v1alpha.RunsCancelRun) error {
-	run, _, err := r.lookupRun(ctx, state.Args().Id())
+	canceled, err := r.CancelRunEntity(ctx, state.Args().Id())
 	if err != nil {
 		return err
 	}
+	state.Results().SetCanceled(canceled)
+	return nil
+}
+
+// CancelRunEntity requests cancellation of a run and reports whether the request
+// was recorded (false if the run had already reached a terminal state). It is
+// the in-process core of CancelRun, shared so the exec proxy's legacy
+// compatibility path can cancel a run it created without re-authenticating over
+// a loopback RPC.
+func (r *AppInfo) CancelRunEntity(ctx context.Context, runID string) (bool, error) {
+	run, _, err := r.lookupRun(ctx, runID)
+	if err != nil {
+		return false, err
+	}
 	if err := r.authorizeRun(ctx, run); err != nil {
-		return err
+		return false, err
 	}
 
 	if isRunTerminal(run.Status) {
-		state.Results().SetCanceled(false)
-		return nil
+		return false, nil
 	}
 
 	if err := r.EC.Patch(ctx, run.ID, 0,
 		entity.Time(run_v1alpha.RunCancelRequestedAtId, time.Now()),
 	); err != nil {
-		return fmt.Errorf("requesting cancellation: %w", err)
+		return false, fmt.Errorf("requesting cancellation: %w", err)
 	}
 
 	r.Log.Info("cancellation requested for run", "run", run.ID, "task", run.Task)
-	state.Results().SetCanceled(true)
-	return nil
+	return true, nil
 }
 
 // authorizeRun resolves the app a run belongs to and applies the same guard the

--- a/servers/app/runs.go
+++ b/servers/app/runs.go
@@ -83,31 +83,51 @@ var _ app_v1alpha.Runs = &AppInfo{}
 func (r *AppInfo) CreateRun(ctx context.Context, state *app_v1alpha.RunsCreateRun) error {
 	args := state.Args()
 
-	// CreateRun executes a command inside the app's image with its credentials,
+	id, sandboxName, err := r.CreateRunEntity(ctx, args.App(), args.Task(), args.Command(), args.Tty())
+	if err != nil {
+		return err
+	}
+
+	state.Results().SetId(id.String())
+	// Derived from the run and the attempt by the same helper the controller
+	// uses, so a client can attach without waiting to observe the sandbox being
+	// created -- and the two cannot drift apart.
+	state.Results().SetSandboxName(sandboxName)
+	return nil
+}
+
+// CreateRunEntity records a run and returns its id and the name its first
+// attempt's sandbox will have. It is the in-process core of CreateRun so that
+// other coordinator services -- notably the exec proxy's legacy exec-by-app
+// compatibility path -- can create a run with the caller's own identity rather
+// than re-authenticating over a loopback RPC as the coordinator.
+//
+// app is the app entity ref; taskName may be empty for the console task.
+func (r *AppInfo) CreateRunEntity(ctx context.Context, app, taskName string, command []string, tty bool) (entity.Id, string, error) {
+	// createRun executes a command inside the app's image with its credentials,
 	// so this is the gate that matters most of the four.
-	if !rpc.AllowApp(ctx, args.App()) {
-		return rpc.AppAccessError(ctx, args.App())
+	if !rpc.AllowApp(ctx, app) {
+		return "", "", rpc.AppAccessError(ctx, app)
 	}
 
 	var appRec core_v1alpha.App
-	if err := r.EC.Get(ctx, args.App(), &appRec); err != nil {
-		return fmt.Errorf("app %s not found: %w", args.App(), err)
+	if err := r.EC.Get(ctx, app, &appRec); err != nil {
+		return "", "", fmt.Errorf("app %s not found: %w", app, err)
 	}
 	if appRec.ActiveVersion == "" {
-		return fmt.Errorf("app %s has no active version to run against", args.App())
+		return "", "", fmt.Errorf("app %s has no active version to run against", app)
 	}
 
-	appName, err := r.appName(ctx, appRec.ID, args.App())
+	appName, err := r.appName(ctx, appRec.ID, app)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	cfgSpec, err := r.resolveActiveConfig(ctx, appRec.ActiveVersion)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
-	taskName := args.Task()
 	if taskName == "" {
 		taskName = ConsoleTask
 	}
@@ -118,7 +138,7 @@ func (r *AppInfo) CreateRun(ctx context.Context, state *app_v1alpha.RunsCreateRu
 	// never mentions it still gets one, resolved from the image the same way it
 	// always was. Any other name has to exist.
 	if task == nil && taskName != ConsoleTask {
-		return fmt.Errorf("app %s declares no task named %q", args.App(), taskName)
+		return "", "", fmt.Errorf("app %s declares no task named %q", app, taskName)
 	}
 
 	// Refuse rather than queue. A run held back at the limit is invisible to the
@@ -127,10 +147,10 @@ func (r *AppInfo) CreateRun(ctx context.Context, state *app_v1alpha.RunsCreateRu
 	// after that message gets the command executed twice -- which for a
 	// hand-invoked migration is the failure this whole design exists to prevent.
 	if err := r.refuseIfAtLimit(ctx, appRec.ID, taskName, task); err != nil {
-		return err
+		return "", "", err
 	}
 
-	command := resolveCommand(task, args.Command())
+	resolvedCommand := resolveCommand(task, command)
 
 	timeout := ""
 	if task != nil {
@@ -149,8 +169,8 @@ func (r *AppInfo) CreateRun(ctx context.Context, state *app_v1alpha.RunsCreateRu
 		Version:     appRec.ActiveVersion,
 		Task:        taskName,
 		Trigger:     run_v1alpha.MANUAL,
-		Command:     command,
-		Tty:         args.Tty(),
+		Command:     resolvedCommand,
+		Tty:         tty,
 		Status:      run_v1alpha.PENDING,
 		Timeout:     timeout,
 		MaxAttempts: manualMaxAttempts,
@@ -158,18 +178,13 @@ func (r *AppInfo) CreateRun(ctx context.Context, state *app_v1alpha.RunsCreateRu
 
 	id, err := r.EC.Create(ctx, name, run)
 	if err != nil {
-		return fmt.Errorf("creating run: %w", err)
+		return "", "", fmt.Errorf("creating run: %w", err)
 	}
 
 	r.Log.Info("created run",
 		"run", id, "app", appName, "task", taskName, "trigger", "manual")
 
-	state.Results().SetId(id.String())
-	// Derived from the run and the attempt by the same helper the controller
-	// uses, so a client can attach without waiting to observe the sandbox being
-	// created -- and the two cannot drift apart.
-	state.Results().SetSandboxName(runapi.SandboxName(id, 1).String())
-	return nil
+	return id, runapi.SandboxName(id, 1).String(), nil
 }
 
 func (r *AppInfo) ListRuns(ctx context.Context, state *app_v1alpha.RunsListRuns) error {

--- a/servers/exec_proxy/exec_by_app_test.go
+++ b/servers/exec_proxy/exec_by_app_test.go
@@ -1,17 +1,60 @@
 package execproxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"miren.dev/runtime/api/exec/exec_v1alpha"
 	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
 	"miren.dev/runtime/pkg/cond"
+	"miren.dev/runtime/pkg/entity"
+	"miren.dev/runtime/pkg/entity/testutils"
 )
+
+type fakeRunManager struct {
+	canceledID     string
+	cancelCtxErr   error
+	cancelCtxHasIt bool
+}
+
+func (f *fakeRunManager) CreateRunEntity(context.Context, string, string, []string, bool) (entity.Id, string, error) {
+	return "", "", nil
+}
+
+func (f *fakeRunManager) CancelRunEntity(ctx context.Context, runID string) (bool, error) {
+	f.canceledID = runID
+	// Capture liveness at call time: the cleanup helper cancels its context on
+	// return, so it can only be inspected from inside the call.
+	f.cancelCtxErr = ctx.Err()
+	f.cancelCtxHasIt = true
+	return true, nil
+}
+
+// A run abandoned by the legacy exec-by-app path has to be canceled even when
+// the request context is already canceled -- a disconnected client is one of the
+// reasons we abandon it. Cancelling on the request context would fail before it
+// recorded anything, so cleanup must run on a detached context that still keeps
+// the caller identity CancelRunEntity authorizes against.
+func TestCancelAbandonedRunUsesLiveContext(t *testing.T) {
+	fake := &fakeRunManager{}
+	s := &Server{Log: testutils.TestLogger(t), runs: fake}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the request context is already dead
+
+	s.cancelAbandonedRun(ctx, entity.Id("run/demo-x"))
+
+	assert.Equal(t, "run/demo-x", fake.canceledID, "the abandoned run must be canceled")
+	require.True(t, fake.cancelCtxHasIt, "CancelRunEntity must have been called")
+	assert.NoError(t, fake.cancelCtxErr,
+		"cancellation must run on a live context, not the canceled request context")
+}
 
 // A v0.13 client asks for a terminal by carrying an initial WinSize, never by
 // setting Terminal (its setupExecIO leaves Terminal unset and the old exec

--- a/servers/exec_proxy/exec_by_app_test.go
+++ b/servers/exec_proxy/exec_by_app_test.go
@@ -8,9 +8,32 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"miren.dev/runtime/api/exec/exec_v1alpha"
 	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
 	"miren.dev/runtime/pkg/cond"
 )
+
+// A v0.13 client asks for a terminal by carrying an initial WinSize, never by
+// setting Terminal (its setupExecIO leaves Terminal unset and the old exec
+// server keyed the pty off WinSize). Reading only Terminal, as the first cut
+// did, gives every interactive v0.13 run a non-tty: `test -t 0` reports false
+// and `stty size` fails. execTTY has to honor the WinSize signal.
+func TestExecTTY(t *testing.T) {
+	assert.False(t, execTTY(nil), "no options means no terminal")
+	assert.False(t, execTTY(&exec_v1alpha.ShellOptions{}), "neither signal set")
+
+	term := &exec_v1alpha.ShellOptions{}
+	term.SetTerminal(true)
+	assert.True(t, execTTY(term), "an explicit Terminal flag still allocates a pty")
+
+	withSize := &exec_v1alpha.ShellOptions{}
+	ws := &exec_v1alpha.WindowSize{}
+	ws.SetWidth(80)
+	ws.SetHeight(24)
+	withSize.SetWinSize(ws)
+	assert.False(t, withSize.Terminal(), "the v0.13 client leaves Terminal unset")
+	assert.True(t, execTTY(withSize), "a WinSize is how a v0.13 client asks for a pty")
+}
 
 // The legacy exec-by-app path retries an attach while the run's sandbox is
 // coming up. attachNotReady decides what is worth waiting on: the node's three

--- a/servers/exec_proxy/exec_by_app_test.go
+++ b/servers/exec_proxy/exec_by_app_test.go
@@ -1,0 +1,70 @@
+package execproxy
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
+	"miren.dev/runtime/pkg/cond"
+)
+
+// The legacy exec-by-app path retries an attach while the run's sandbox is
+// coming up. attachNotReady decides what is worth waiting on: the node's three
+// "not yet" phrasings and a missing entity, but nothing else -- a denial or a
+// transport failure must surface at once, not be retried into the 2m deadline.
+// The typed error does not survive the RPC hop to the node, so the match is by
+// text, mirroring the client's attachTargetMissing.
+func TestAttachNotReady(t *testing.T) {
+	assert.True(t, attachNotReady(cond.ErrNotFound{}), "a missing sandbox is worth waiting on")
+	assert.True(t, attachNotReady(errors.New(`attach: container "app" of sandbox/run-x-a1 is not running yet`)),
+		"the node's NotReadyError text must be recognized across the RPC boundary")
+	assert.True(t, attachNotReady(errors.New("failed to find sandbox foo")))
+	assert.True(t, attachNotReady(errors.New("sandbox is not scheduled to a node yet")))
+	// Wrapped forms still match by substring and by errors.Is.
+	assert.True(t, attachNotReady(fmt.Errorf("attaching: %w", cond.ErrNotFound{})))
+
+	assert.False(t, attachNotReady(errors.New("access denied for app foo")),
+		"a denial must not be retried into the deadline")
+	assert.False(t, attachNotReady(errors.New("connection reset by peer")),
+		"a transport failure is not a not-ready condition")
+}
+
+// The exit code a v0.13 client reads back must describe the command, not its
+// teardown: a killed (canceled/timed-out) run's kernel-reported code is noise,
+// and reporting it as the command's result would tell a script a failing run
+// succeeded, or vice versa.
+func TestExitCodeReportingRules(t *testing.T) {
+	assert.True(t, reportsExitCode(run_v1alpha.SUCCEEDED))
+	assert.True(t, reportsExitCode(run_v1alpha.FAILED))
+	for _, s := range []run_v1alpha.RunStatus{
+		run_v1alpha.PENDING, run_v1alpha.RUNNING, run_v1alpha.CANCELED,
+		run_v1alpha.TIMED_OUT, run_v1alpha.SKIPPED,
+	} {
+		assert.False(t, reportsExitCode(s), "%s carries meaning in its status, not an exit code", s)
+	}
+}
+
+func TestIsTerminalRunStatus(t *testing.T) {
+	for _, s := range []run_v1alpha.RunStatus{
+		run_v1alpha.SUCCEEDED, run_v1alpha.FAILED, run_v1alpha.TIMED_OUT,
+		run_v1alpha.CANCELED, run_v1alpha.SKIPPED,
+	} {
+		assert.True(t, isTerminalRunStatus(s), "%s is terminal", s)
+	}
+	assert.False(t, isTerminalRunStatus(run_v1alpha.PENDING))
+	assert.False(t, isTerminalRunStatus(run_v1alpha.RUNNING))
+}
+
+// Real exit codes are a byte, so clamping only matters for a corrupt value --
+// but wrapping one into a small plausible-looking number is the worst outcome,
+// since nothing downstream can tell it from a genuine result.
+func TestClampInt32Saturates(t *testing.T) {
+	assert.Equal(t, int32(0), clampInt32(0))
+	assert.Equal(t, int32(42), clampInt32(42))
+	assert.Equal(t, int32(math.MaxInt32), clampInt32(math.MaxInt32+1))
+	assert.Equal(t, int32(math.MinInt32), clampInt32(math.MinInt32-1))
+}

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -20,26 +20,31 @@ import (
 	"miren.dev/runtime/pkg/rpc/stream"
 )
 
-// RunCreator records a durable run in-process and returns its id and the name
-// its first attempt's sandbox will have. The exec proxy uses it on the legacy
-// exec-by-app compatibility path so the run is created with the caller's own
-// identity rather than the coordinator's. *app.AppInfo satisfies it.
-type RunCreator interface {
+// RunManager creates and cancels durable runs in-process. The exec proxy uses
+// it on the legacy exec-by-app compatibility path so a run is created (and, when
+// abandoned, canceled) with the caller's own identity rather than the
+// coordinator's. *app.AppInfo satisfies it.
+type RunManager interface {
+	// CreateRunEntity records a run and returns its id and the name its first
+	// attempt's sandbox will have.
 	CreateRunEntity(ctx context.Context, app, task string, command []string, tty bool) (entity.Id, string, error)
+	// CancelRunEntity requests cancellation of a run, reporting whether the
+	// request was recorded (false if it was already terminal).
+	CancelRunEntity(ctx context.Context, runID string) (bool, error)
 }
 
 type Server struct {
 	Log  *slog.Logger
 	EAC  *entityserver_v1alpha.EntityAccessClient
 	rs   *rpc.State
-	runs RunCreator
+	runs RunManager
 }
 
 func NewServer(
 	log *slog.Logger,
 	eac *entityserver_v1alpha.EntityAccessClient,
 	rs *rpc.State,
-	runs RunCreator,
+	runs RunManager,
 ) *Server {
 	return &Server{
 		Log:  log,
@@ -182,13 +187,12 @@ func (s *Server) execByApp(ctx context.Context, req *exec_v1alpha.SandboxExecExe
 	args := req.Args()
 
 	var command []string
-	tty := false
-	if opts := args.Options(); opts != nil {
+	opts := args.Options()
+	if opts != nil {
 		command = opts.Command()
-		tty = opts.Terminal()
 	}
 
-	runID, sandboxName, err := s.runs.CreateRunEntity(ctx, args.Value(), "", command, tty)
+	runID, sandboxName, err := s.runs.CreateRunEntity(ctx, args.Value(), "", command, execTTY(opts))
 	if err != nil {
 		return err
 	}
@@ -201,12 +205,20 @@ func (s *Server) execByApp(ctx context.Context, req *exec_v1alpha.SandboxExecExe
 	outW := stream.ToWriter(ctx, args.Output())
 	defer outW.Close()
 
-	// winCh is fed once and read by a fresh ChanReader per attach attempt. While
-	// an attempt is returning early (not ready), nothing drains it, so a resize
-	// that arrives in that gap can be dropped. That is harmless here: the next
-	// successful attach reads the current terminal size anyway, and this is a
-	// compatibility shim rather than a long-lived interactive session.
+	// winCh is read by a fresh ChanReader per attach attempt. ChanReader is lazy,
+	// so a not-ready attempt does not drain it and a queued resize survives to the
+	// next attempt.
+	//
+	// A v0.13 client reports its initial terminal size through the shell options,
+	// not the update stream (its stream only carries later SIGWINCH events), so
+	// seed that size as the first resize -- the old exec server read the same
+	// field to size the pty. Seed before wiring the update stream so it is first
+	// in line; the buffer of one holds it until the first successful attach reads
+	// it.
 	winCh := make(chan *exec_v1alpha.WindowSize, 1)
+	if opts != nil && opts.HasWinSize() {
+		winCh <- opts.WinSize()
+	}
 	if args.HasWindowUpdates() {
 		stream.ChanWriter(ctx, args.WindowUpdates(), winCh)
 	}
@@ -253,7 +265,17 @@ func (s *Server) execByApp(ctx context.Context, req *exec_v1alpha.SandboxExecExe
 		}
 
 		if time.Now().After(deadline) {
-			return fmt.Errorf("run %s for app %s did not start within %s", runID, args.Value(), execByAppTimeout)
+			// Cancel before returning, or the run stays pending and the
+			// controller executes it later -- after this call already told the
+			// legacy client it failed. The legacy protocol hands back no run id,
+			// so the caller cannot cancel it and a natural retry would run the
+			// command twice. This mirrors the client's own attachToRun, which
+			// cancels a run that never started for the same reason.
+			if _, cerr := s.runs.CancelRunEntity(ctx, runID.String()); cerr != nil {
+				s.Log.Warn("could not cancel a run that never started",
+					"run", runID, "error", cerr)
+			}
+			return fmt.Errorf("run %s for app %s did not start within %s and was canceled", runID, args.Value(), execByAppTimeout)
 		}
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -267,6 +289,17 @@ func (s *Server) execByApp(ctx context.Context, req *exec_v1alpha.SandboxExecExe
 	}
 	req.Results().SetCode(code)
 	return nil
+}
+
+// execTTY reports whether a legacy exec-by-app request wants a terminal. A
+// v0.13 client never sets Terminal: it signals a pty by carrying an initial
+// WinSize, which is the field the old exec server keyed on. Accept either, so
+// both the real v0.13 signal and a well-formed Terminal flag allocate a pty.
+func execTTY(opts *exec_v1alpha.ShellOptions) bool {
+	if opts == nil {
+		return false
+	}
+	return opts.HasWinSize() || opts.Terminal()
 }
 
 // runSandboxNode reports the node a run's sandbox is scheduled to. ready is

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -197,6 +197,20 @@ func (s *Server) execByApp(ctx context.Context, req *exec_v1alpha.SandboxExecExe
 		return err
 	}
 
+	// Until this call hands back the run's own exit code, it owns the run's fate.
+	// A v0.13 client gets no run id, so any run abandoned here -- because the
+	// startup deadline passed, the client disconnected, or a transport error cut
+	// the attach -- is one it can neither observe nor cancel, and a run still
+	// pending would execute after we reported failure, so a natural retry runs the
+	// command twice. Cancel on every early exit; the happy path clears this flag
+	// first, and CancelRunEntity is a no-op on an already-terminal run.
+	done := false
+	defer func() {
+		if !done {
+			s.cancelAbandonedRun(ctx, runID)
+		}
+	}()
+
 	// Bridge the incoming exec streams once and re-wrap them per attach attempt,
 	// exactly as the client's attachToRun does. A not-ready attach returns before
 	// any stdin is pumped, so re-serving the same reader across attempts is safe.
@@ -265,16 +279,7 @@ func (s *Server) execByApp(ctx context.Context, req *exec_v1alpha.SandboxExecExe
 		}
 
 		if time.Now().After(deadline) {
-			// Cancel before returning, or the run stays pending and the
-			// controller executes it later -- after this call already told the
-			// legacy client it failed. The legacy protocol hands back no run id,
-			// so the caller cannot cancel it and a natural retry would run the
-			// command twice. This mirrors the client's own attachToRun, which
-			// cancels a run that never started for the same reason.
-			if _, cerr := s.runs.CancelRunEntity(ctx, runID.String()); cerr != nil {
-				s.Log.Warn("could not cancel a run that never started",
-					"run", runID, "error", cerr)
-			}
+			// The deferred cleanup cancels the still-pending run.
 			return fmt.Errorf("run %s for app %s did not start within %s and was canceled", runID, args.Value(), execByAppTimeout)
 		}
 		if ctx.Err() != nil {
@@ -288,7 +293,29 @@ func (s *Server) execByApp(ctx context.Context, req *exec_v1alpha.SandboxExecExe
 		return err
 	}
 	req.Results().SetCode(code)
+	done = true
 	return nil
+}
+
+// runCleanupTimeout bounds the cancellation issued when a legacy exec-by-app
+// request abandons its run. It runs on a detached context, so without a bound a
+// wedged entity store could hold the handler open past the request itself.
+const runCleanupTimeout = 10 * time.Second
+
+// cancelAbandonedRun cancels a run this call created but is giving up on.
+//
+// It deliberately does not use the request context: that context is often
+// already canceled (the client disconnected, which is one of the reasons we are
+// abandoning the run), and cancellation issued on a canceled context would fail
+// before it recorded anything. context.WithoutCancel keeps the caller identity
+// CancelRunEntity authorizes against while dropping the cancellation.
+func (s *Server) cancelAbandonedRun(ctx context.Context, runID entity.Id) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), runCleanupTimeout)
+	defer cancel()
+
+	if _, err := s.runs.CancelRunEntity(cleanupCtx, runID.String()); err != nil {
+		s.Log.Warn("could not cancel an abandoned run", "run", runID, "error", err)
+	}
 }
 
 // execTTY reports whether a legacy exec-by-app request wants a terminal. A

--- a/servers/exec_proxy/exec_proxy.go
+++ b/servers/exec_proxy/exec_proxy.go
@@ -5,33 +5,47 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"strings"
+	"time"
 
 	"miren.dev/runtime/api/compute/compute_v1alpha"
 	"miren.dev/runtime/api/core/core_v1alpha"
 	"miren.dev/runtime/api/entityserver/entityserver_v1alpha"
 	"miren.dev/runtime/api/exec/exec_v1alpha"
+	run_v1alpha "miren.dev/runtime/api/run/run_v1alpha"
 	"miren.dev/runtime/pkg/cond"
 	"miren.dev/runtime/pkg/entity"
 	"miren.dev/runtime/pkg/rpc"
 	"miren.dev/runtime/pkg/rpc/stream"
 )
 
+// RunCreator records a durable run in-process and returns its id and the name
+// its first attempt's sandbox will have. The exec proxy uses it on the legacy
+// exec-by-app compatibility path so the run is created with the caller's own
+// identity rather than the coordinator's. *app.AppInfo satisfies it.
+type RunCreator interface {
+	CreateRunEntity(ctx context.Context, app, task string, command []string, tty bool) (entity.Id, string, error)
+}
+
 type Server struct {
-	Log *slog.Logger
-	EAC *entityserver_v1alpha.EntityAccessClient
-	rs  *rpc.State
+	Log  *slog.Logger
+	EAC  *entityserver_v1alpha.EntityAccessClient
+	rs   *rpc.State
+	runs RunCreator
 }
 
 func NewServer(
 	log *slog.Logger,
 	eac *entityserver_v1alpha.EntityAccessClient,
 	rs *rpc.State,
+	runs RunCreator,
 ) *Server {
 	return &Server{
-		Log: log,
-		EAC: eac,
-		rs:  rs,
+		Log:  log,
+		EAC:  eac,
+		rs:   rs,
+		runs: runs,
 	}
 }
 
@@ -82,7 +96,12 @@ func (s *Server) Exec(ctx context.Context, req *exec_v1alpha.SandboxExecExec) er
 		}
 
 	case "app":
-		return fmt.Errorf("exec by app name is no longer supported; use `miren app run` (which creates a run) or `miren sandbox exec` for an existing sandbox")
+		// Compatibility window: a pre-durable-runs client (<= v0.13) reaches an
+		// app by name here, expecting the old ephemeral-sandbox exec. Rather
+		// than restore that leak-prone path, translate the request onto a
+		// durable run and attach to it, so the run controller owns the sandbox's
+		// lifecycle. Remove this once v0.13 is out of the compatibility window.
+		return s.execByApp(ctx, req)
 	}
 
 	if found == nil {
@@ -137,6 +156,266 @@ func (s *Server) Exec(ctx context.Context, req *exec_v1alpha.SandboxExecExec) er
 	req.Results().SetCode(eret.Code())
 
 	return nil
+}
+
+// execByAppTimeout bounds how long the legacy exec-by-app path waits for its
+// run's sandbox to come up before giving up. It matches the client's own attach
+// deadline (cli attachToRun waits 2m), so a slow image pull is tolerated while a
+// run that never starts does not pin the request handler open forever.
+const execByAppTimeout = 2 * time.Minute
+
+// execByAppPoll is how often the wait loop re-checks the entity store.
+const execByAppPoll = 250 * time.Millisecond
+
+// execByApp serves a legacy exec-by-app request by creating a durable run and
+// attaching to it. It exists only for the compatibility window (see the "app"
+// case in Exec) and reproduces the old synchronous behavior a v0.13 client
+// expects: run the app's console command, stream its terminal, return its exit
+// code.
+//
+// The run is created with the caller's identity -- CreateRunEntity gates on
+// rpc.AllowApp with this ctx -- which is stricter than the v0.13 exec-by-app
+// path that had no app guard at all, and is the safe direction. Unlike the old
+// ephemeral sandbox this replaces, an abandoned run stays owned by the run
+// controller, so a handler that dies mid-request leaks nothing.
+func (s *Server) execByApp(ctx context.Context, req *exec_v1alpha.SandboxExecExec) error {
+	args := req.Args()
+
+	var command []string
+	tty := false
+	if opts := args.Options(); opts != nil {
+		command = opts.Command()
+		tty = opts.Terminal()
+	}
+
+	runID, sandboxName, err := s.runs.CreateRunEntity(ctx, args.Value(), "", command, tty)
+	if err != nil {
+		return err
+	}
+
+	// Bridge the incoming exec streams once and re-wrap them per attach attempt,
+	// exactly as the client's attachToRun does. A not-ready attach returns before
+	// any stdin is pumped, so re-serving the same reader across attempts is safe.
+	inR := stream.ToReader(ctx, args.Input())
+	defer inR.Close()
+	outW := stream.ToWriter(ctx, args.Output())
+	defer outW.Close()
+
+	// winCh is fed once and read by a fresh ChanReader per attach attempt. While
+	// an attempt is returning early (not ready), nothing drains it, so a resize
+	// that arrives in that gap can be dropped. That is harmless here: the next
+	// successful attach reads the current terminal size anyway, and this is a
+	// compatibility shim rather than a long-lived interactive session.
+	winCh := make(chan *exec_v1alpha.WindowSize, 1)
+	if args.HasWindowUpdates() {
+		stream.ChanWriter(ctx, args.WindowUpdates(), winCh)
+	}
+
+	// Mirror the client's attach loop: the sandbox exists only once the run
+	// controller has admitted the run, and the node reports "not running yet"
+	// until the container boots, so retry while it is simply not ready. A real
+	// error -- a denial, a transport failure -- is returned at once rather than
+	// waited out.
+	deadline := time.Now().Add(execByAppTimeout)
+	for {
+		node, ready, err := s.runSandboxNode(ctx, sandboxName)
+		if err != nil {
+			return err
+		}
+
+		if ready {
+			rcl, err := s.rs.Connect(node.ApiAddress, "dev.miren.runtime/exec")
+			if err != nil {
+				return fmt.Errorf("failed to connect to node %s: %w", node.ApiAddress, err)
+			}
+
+			sec := &exec_v1alpha.SandboxExecClient{Client: rcl}
+			_, aerr := sec.Attach(
+				ctx,
+				sandboxName, "",
+				stream.ServeReader(ctx, inR),
+				stream.ServeWriter(ctx, outW),
+				stream.ChanReader(winCh),
+			)
+			if aerr == nil {
+				break // the container ended; its exit code is on the run.
+			}
+			if !attachNotReady(aerr) {
+				return fmt.Errorf("attaching to run %s: %w", runID, aerr)
+			}
+		}
+
+		// A short command can finish before the terminal ever attaches, taking
+		// its container with it. That is not a failure -- the run did what it was
+		// asked and recorded an outcome -- so stop waiting and report it.
+		if s.runIsTerminal(ctx, runID) {
+			break
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("run %s for app %s did not start within %s", runID, args.Value(), execByAppTimeout)
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		time.Sleep(execByAppPoll)
+	}
+
+	code, err := s.runExitCode(ctx, runID)
+	if err != nil {
+		return err
+	}
+	req.Results().SetCode(code)
+	return nil
+}
+
+// runSandboxNode reports the node a run's sandbox is scheduled to. ready is
+// false -- with no error -- while the sandbox has not been created or scheduled
+// yet, which is the caller's cue to wait rather than fail.
+func (s *Server) runSandboxNode(ctx context.Context, sandboxName string) (compute_v1alpha.Node, bool, error) {
+	var node compute_v1alpha.Node
+
+	ret, err := s.EAC.Get(ctx, sandboxName)
+	if err != nil {
+		if errors.Is(err, cond.ErrNotFound{}) {
+			return node, false, nil
+		}
+		return node, false, fmt.Errorf("looking up run sandbox %s: %w", sandboxName, err)
+	}
+
+	var sch compute_v1alpha.Schedule
+	sch.Decode(ret.Entity().Entity())
+	if sch.Key.Node == "" {
+		return node, false, nil
+	}
+
+	nret, err := s.EAC.Get(ctx, string(sch.Key.Node))
+	if err != nil {
+		return node, false, fmt.Errorf("looking up node %s: %w", sch.Key.Node, err)
+	}
+	node.Decode(nret.Entity().Entity())
+	return node, true, nil
+}
+
+// runExitCode reads a finished run's exit code, waiting briefly for the runner
+// to record it. The container's stdio closes just before the runner writes the
+// outcome, so reading once would be a coin flip on a fast command -- and losing
+// it would report a failing command as success to whatever invoked the old CLI.
+// A run that ended without a task exit code (canceled, timed out) reports 0
+// here; its status, not this number, carries that meaning, and the old protocol
+// has nowhere to put it.
+func (s *Server) runExitCode(ctx context.Context, runID entity.Id) (int32, error) {
+	deadline := time.Now().Add(runSettleTimeout)
+	var lastErr error
+	for {
+		run, err := s.getRun(ctx, runID)
+		if err != nil {
+			lastErr = err
+		} else {
+			if reportsExitCode(run.Status) && !run.Result.At.IsZero() {
+				return clampInt32(run.Result.Code), nil
+			}
+			if isTerminalRunStatus(run.Status) {
+				return 0, nil
+			}
+		}
+
+		if time.Now().After(deadline) {
+			// A run that could never be read has just been reported as a clean
+			// zero-exit, which on the wire is indistinguishable from a real one.
+			// Leave a trace so a corrupt or missing run entity is not silently a
+			// success in the server log.
+			if lastErr != nil {
+				s.Log.Warn("could not read a run's outcome before reporting its exit; assuming 0",
+					"run", runID, "error", lastErr)
+			}
+			return 0, nil
+		}
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
+		time.Sleep(execByAppPoll)
+	}
+}
+
+// runIsTerminal reports whether a run has reached a terminal state. A read
+// failure answers no, so the caller keeps waiting under its own deadline rather
+// than abandoning over a transient blip.
+func (s *Server) runIsTerminal(ctx context.Context, runID entity.Id) bool {
+	run, err := s.getRun(ctx, runID)
+	if err != nil {
+		return false
+	}
+	return isTerminalRunStatus(run.Status)
+}
+
+func (s *Server) getRun(ctx context.Context, runID entity.Id) (*run_v1alpha.Run, error) {
+	ret, err := s.EAC.Get(ctx, runID.String())
+	if err != nil {
+		return nil, err
+	}
+	var run run_v1alpha.Run
+	run.Decode(ret.Entity().Entity())
+	return &run, nil
+}
+
+// runSettleTimeout bounds how long runExitCode waits for the outcome to be
+// recorded after the container is gone. The two are written by different actors,
+// so a small gap is expected and is not the run still working.
+const runSettleTimeout = 15 * time.Second
+
+// attachNotReady reports whether an attach failed only because the run's
+// sandbox is not up yet, as opposed to a reason waiting will not fix. The typed
+// error does not survive the RPC hop to the node, so this matches the node's
+// three ways of saying "not yet" by text, the same way the client's
+// attachTargetMissing does.
+func attachNotReady(err error) bool {
+	if errors.Is(err, cond.ErrNotFound{}) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "failed to find sandbox") ||
+		strings.Contains(msg, "not scheduled to a node yet") ||
+		strings.Contains(msg, "is not running yet")
+}
+
+// reportsExitCode says whether a run ended by its command exiting, the only case
+// where the recorded code describes the task rather than its teardown. It
+// mirrors the app server's own rule for the same entity.
+func reportsExitCode(s run_v1alpha.RunStatus) bool {
+	switch s {
+	case run_v1alpha.SUCCEEDED, run_v1alpha.FAILED:
+		return true
+	case run_v1alpha.PENDING, run_v1alpha.RUNNING, run_v1alpha.TIMED_OUT,
+		run_v1alpha.CANCELED, run_v1alpha.SKIPPED:
+		return false
+	}
+	return false
+}
+
+func isTerminalRunStatus(s run_v1alpha.RunStatus) bool {
+	switch s {
+	case run_v1alpha.SUCCEEDED, run_v1alpha.FAILED, run_v1alpha.TIMED_OUT,
+		run_v1alpha.CANCELED, run_v1alpha.SKIPPED:
+		return true
+	case run_v1alpha.PENDING, run_v1alpha.RUNNING:
+		return false
+	}
+	return false
+}
+
+// clampInt32 saturates rather than wrapping at the entity(int64)->wire(int32)
+// boundary. Real exit codes are a byte, so this only matters for a corrupt or
+// hostile value, where wrapping into a small plausible number is the worst
+// outcome.
+func clampInt32(v int64) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
 }
 
 // resolveSandboxApp returns the app a sandbox entity belongs to, or "" if it


### PR DESCRIPTION
When we absorbed `miren app run` into durable runs, we swapped its wire protocol in both directions at the same time. That left no working upgrade order across the boundary. A current CLI can't resolve the `app-runs` capability against a released v0.13 server, and a v0.13 CLI's old exec-by-app request gets rejected outright by a current server. Production runs v0.13, so this actually blocked `app run` against prod, and the only workaround was to keep an old CLI lying around.

This restores a compatibility window in both directions.

On the client side, when `app-runs` resolution comes back saying the capability is specifically absent (the server answered, it just doesn't have it), the CLI falls back to the legacy exec-by-app path. That's the exact request a released v0.13 server already knows how to serve, so an older cluster handles it with its own code. The distinction matters: a transport failure or an auth rejection is a real error and surfaces unchanged, rather than being misread as an old server and quietly retried against a healthy one.

On the server side, the current server accepts the old exec-by-app request again. Rather than restoring the leak-prone ephemeral sandbox that the durable-runs work deliberately removed, it translates the request onto a durable run, created with the caller's own identity so the app-scoping guard still means something. The run controller owns the sandbox's lifecycle, so a request handler that dies mid-stream leaks nothing. The features the old protocol can't express, `--task` and `--detach`, are refused with a clear message instead of silently dropped.

Both shims are temporary and commented as such, to be removed once v0.13 is out of the support window.

Closes MIR-1633

https://claude.ai/code/session_01SnGq1uY7vDZSkxhnw2r4rc