### PR TITLE
Mount accelerator disks without udev; shore up disk restore testing

### DIFF
--- a/components/diskio/disk_ops_linux.go
+++ b/components/diskio/disk_ops_linux.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -258,7 +259,11 @@ func (r *realDiskMountOps) LbdAttach(ctx context.Context, imagePath, logDir stri
 		// lbdctl add already attached the device, but the caller receives
 		// only an error (no path), so it cannot detach. Clean up here, or a
 		// repeated failure leaks a kernel device with no state to reclaim it.
-		if derr := r.LbdDetach(ctx, result.Device); derr != nil {
+		// Give the detach an independent context so it can still complete even
+		// if the caller's ctx has already been canceled.
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if derr := r.LbdDetach(cleanupCtx, result.Device); derr != nil {
 			return "", fmt.Errorf("lbdctl add: %w (detach after failure also failed: %v)", err, derr)
 		}
 		return "", fmt.Errorf("lbdctl add: %w", err)
@@ -364,6 +369,11 @@ func (r *realDiskMountOps) LbdDetach(ctx context.Context, devicePath string) err
 // a malformed path can't be turned into the wrong index.
 func lbdDeviceIndex(devicePath string) (string, error) {
 	name := filepath.Base(devicePath)
+	// Only ever remove a device that lives at /dev/lbdN; a stray path like
+	// /tmp/lbd7 must not be turned into an index that detaches a real volume.
+	if devicePath != filepath.Join("/dev", name) {
+		return "", fmt.Errorf("not an lbd device path: %q", devicePath)
+	}
 	index := strings.TrimPrefix(name, "lbd")
 	if index == name || index == "" {
 		return "", fmt.Errorf("not an lbd device path: %q", devicePath)

--- a/components/diskio/disk_ops_linux.go
+++ b/components/diskio/disk_ops_linux.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -249,7 +250,58 @@ func (r *realDiskMountOps) LbdAttach(ctx context.Context, imagePath, logDir stri
 		return "", fmt.Errorf("lbdctl add returned empty device path")
 	}
 
+	// The kernel registers the block device in sysfs, but the /dev node is
+	// normally created by udev. Containers whose /dev is a private tmpfs have
+	// no udev, so the node never appears and the mount that follows fails with
+	// ENOENT. Create it ourselves from the major:minor sysfs reports.
+	if err := ensureDeviceNode(result.Device); err != nil {
+		return "", fmt.Errorf("lbdctl add: %w", err)
+	}
+
 	return result.Device, nil
+}
+
+// ensureDeviceNode makes sure the block device node at devicePath (e.g.
+// /dev/lbd0) exists, creating it from /sys/block/<name>/dev when it is missing.
+// This lets accelerator disks mount in environments without udev.
+func ensureDeviceNode(devicePath string) error {
+	if _, err := os.Stat(devicePath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", devicePath, err)
+	}
+
+	name := filepath.Base(devicePath)
+	sysDev := filepath.Join("/sys/block", name, "dev")
+	data, err := os.ReadFile(sysDev)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", sysDev, err)
+	}
+
+	majStr, minStr, ok := strings.Cut(strings.TrimSpace(string(data)), ":")
+	if !ok {
+		return fmt.Errorf("unexpected %s contents %q", sysDev, string(data))
+	}
+	// ParseUint with bitSize 32 bounds the values to what unix.Mkdev accepts,
+	// so the uint32 conversions below cannot overflow.
+	major, err := strconv.ParseUint(majStr, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse major from %q: %w", string(data), err)
+	}
+	minor, err := strconv.ParseUint(minStr, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse minor from %q: %w", string(data), err)
+	}
+
+	dev := int(unix.Mkdev(uint32(major), uint32(minor)))
+	if err := unix.Mknod(devicePath, unix.S_IFBLK|0o600, dev); err != nil {
+		// A concurrent udev (or a retry) may have created it already.
+		if errors.Is(err, os.ErrExist) {
+			return nil
+		}
+		return fmt.Errorf("mknod %s (%d:%d): %w", devicePath, major, minor, err)
+	}
+	return nil
 }
 
 func (r *realDiskMountOps) LbdDetach(ctx context.Context, devicePath string) error {

--- a/components/diskio/disk_ops_linux.go
+++ b/components/diskio/disk_ops_linux.go
@@ -255,6 +255,12 @@ func (r *realDiskMountOps) LbdAttach(ctx context.Context, imagePath, logDir stri
 	// no udev, so the node never appears and the mount that follows fails with
 	// ENOENT. Create it ourselves from the major:minor sysfs reports.
 	if err := ensureDeviceNode(result.Device); err != nil {
+		// lbdctl add already attached the device, but the caller receives
+		// only an error (no path), so it cannot detach. Clean up here, or a
+		// repeated failure leaks a kernel device with no state to reclaim it.
+		if derr := r.LbdDetach(ctx, result.Device); derr != nil {
+			return "", fmt.Errorf("lbdctl add: %w (detach after failure also failed: %v)", err, derr)
+		}
 		return "", fmt.Errorf("lbdctl add: %w", err)
 	}
 
@@ -263,15 +269,16 @@ func (r *realDiskMountOps) LbdAttach(ctx context.Context, imagePath, logDir stri
 
 // ensureDeviceNode makes sure the block device node at devicePath (e.g.
 // /dev/lbd0) exists, creating it from /sys/block/<name>/dev when it is missing.
-// This lets accelerator disks mount in environments without udev.
+// This lets accelerator disks mount in environments without udev. A node that
+// already exists must be the block device sysfs describes; anything else (a
+// stale file, a character device, a different device number) is rejected so the
+// caller never mounts the wrong thing.
 func ensureDeviceNode(devicePath string) error {
-	if _, err := os.Stat(devicePath); err == nil {
-		return nil
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("stat %s: %w", devicePath, err)
+	name := filepath.Base(devicePath)
+	if name == "" || name == "." || name == ".." || strings.ContainsRune(name, '/') {
+		return fmt.Errorf("unexpected device path %q", devicePath)
 	}
 
-	name := filepath.Base(devicePath)
 	sysDev := filepath.Join("/sys/block", name, "dev")
 	data, err := os.ReadFile(sysDev)
 	if err != nil {
@@ -292,26 +299,79 @@ func ensureDeviceNode(devicePath string) error {
 	if err != nil {
 		return fmt.Errorf("parse minor from %q: %w", string(data), err)
 	}
+	want := unix.Mkdev(uint32(major), uint32(minor))
 
-	dev := int(unix.Mkdev(uint32(major), uint32(minor)))
-	if err := unix.Mknod(devicePath, unix.S_IFBLK|0o600, dev); err != nil {
-		// A concurrent udev (or a retry) may have created it already.
+	// If a node is already present, make sure it is the device we expect
+	// rather than a leftover file or a different device.
+	if fi, err := os.Stat(devicePath); err == nil {
+		return verifyBlockDevice(devicePath, fi, want)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", devicePath, err)
+	}
+
+	if err := unix.Mknod(devicePath, unix.S_IFBLK|0o660, int(want)); err != nil {
+		// A concurrent udev (or a retry) may have created it already; make
+		// sure what landed there is the right device.
 		if errors.Is(err, os.ErrExist) {
-			return nil
+			fi, serr := os.Stat(devicePath)
+			if serr != nil {
+				return fmt.Errorf("stat %s after mknod reported it exists: %w", devicePath, serr)
+			}
+			return verifyBlockDevice(devicePath, fi, want)
 		}
 		return fmt.Errorf("mknod %s (%d:%d): %w", devicePath, major, minor, err)
 	}
 	return nil
 }
 
+// verifyBlockDevice returns an error unless path is a block device whose device
+// number matches want.
+func verifyBlockDevice(path string, fi os.FileInfo, want uint64) error {
+	if fi.Mode()&os.ModeDevice == 0 || fi.Mode()&os.ModeCharDevice != 0 {
+		return fmt.Errorf("%s exists but is not a block device", path)
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("%s: unexpected stat type %T", path, fi.Sys())
+	}
+	if uint64(st.Rdev) != want {
+		return fmt.Errorf("%s is device %d:%d, expected %d:%d", path,
+			unix.Major(uint64(st.Rdev)), unix.Minor(uint64(st.Rdev)),
+			unix.Major(want), unix.Minor(want))
+	}
+	return nil
+}
+
 func (r *realDiskMountOps) LbdDetach(ctx context.Context, devicePath string) error {
-	cmd := exec.CommandContext(ctx, "lbdctl", "remove", "--json", devicePath)
+	// lbdctl remove takes the numeric device index, not a path -- it parses its
+	// argument with atoi, so passing "/dev/lbd1" would remove index 0 and detach
+	// the wrong volume.
+	index, err := lbdDeviceIndex(devicePath)
+	if err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "lbdctl", "remove", "--json", index)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("lbdctl remove failed: %w\noutput: %s", err, string(output))
 	}
 	_ = output // JSON output available but not needed for remove
 	return nil
+}
+
+// lbdDeviceIndex extracts the numeric index from an lbd device path, e.g.
+// "/dev/lbd7" -> "7". It errors on anything that isn't a numbered lbd device so
+// a malformed path can't be turned into the wrong index.
+func lbdDeviceIndex(devicePath string) (string, error) {
+	name := filepath.Base(devicePath)
+	index := strings.TrimPrefix(name, "lbd")
+	if index == name || index == "" {
+		return "", fmt.Errorf("not an lbd device path: %q", devicePath)
+	}
+	if _, err := strconv.ParseUint(index, 10, 32); err != nil {
+		return "", fmt.Errorf("lbd device path %q has a non-numeric index: %w", devicePath, err)
+	}
+	return index, nil
 }
 
 func (r *realDiskMountOps) LbdAvailable() bool {

--- a/hack/e2e_disk/main.go
+++ b/hack/e2e_disk/main.go
@@ -108,10 +108,11 @@ func main() {
 	mc := diskio.NewDiskMountController(log, *workDir, compute_v1alpha.NewNodeId("e2e-node"), diskio.NewState(), nil)
 	mc.SetUpdatesClient(updates)
 	check(mc.RestoreImageIfMissing(ctx, &diskio.VolumeState{
-		VolumeId:   volumeID,
-		Name:       "e2e-disk",
-		DiskPath:   diskPath,
-		Filesystem: "ext4",
+		VolumeId:      volumeID,
+		CloudVolumeId: volumeID,
+		Name:          "e2e-disk",
+		DiskPath:      diskPath,
+		Filesystem:    "ext4",
 	}, imagePath), "restore image")
 
 	restored, err := os.ReadFile(imagePath)

--- a/testdata/miren-disk-app/.miren/app.toml
+++ b/testdata/miren-disk-app/.miren/app.toml
@@ -1,0 +1,11 @@
+name = "miren-disk-app"
+
+[services.web.concurrency]
+mode = "fixed"
+num_instances = 1
+
+[[services.web.disks]]
+name = "data"
+provider = "miren"
+mount_path = "/data"
+size_gb = 1

--- a/testdata/miren-disk-app/Procfile
+++ b/testdata/miren-disk-app/Procfile
@@ -1,0 +1,1 @@
+web: /bin/app

--- a/testdata/miren-disk-app/go.mod
+++ b/testdata/miren-disk-app/go.mod
@@ -1,0 +1,3 @@
+module miren-disk-app
+
+go 1.26

--- a/testdata/miren-disk-app/main.go
+++ b/testdata/miren-disk-app/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+const dataPath = "/data/value"
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
+
+	// POST /data writes the (possibly large) request body to the disk.
+	// GET  /data returns its sha256 so we can verify a restore without
+	// streaming the whole payload back.
+	http.HandleFunc("/data", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			f, err := os.Open(dataPath)
+			if err != nil {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			defer f.Close()
+			h := sha256.New()
+			n, err := io.Copy(h, f)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprintf(w, "%x %d\n", h.Sum(nil), n)
+		case http.MethodPost:
+			f, err := os.Create(dataPath)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			defer f.Close()
+			if _, err := io.Copy(f, r.Body); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if err := f.Sync(); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK\n")
+	})
+
+	fmt.Printf("Server starting on port %s\n", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		fmt.Printf("Error starting server: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## What

Three related changes that let accelerator-mode disks mount and restore reliably, and make the disk restore path actually exercisable in tests.

- **`diskio`: create the lbd device node when udev is absent.** `LbdAttach` relied on udev to materialize `/dev/lbdN` after `lbdctl add`. In a container whose `/dev` is a private tmpfs there is no udev, so the node never appeared and the follow-up format/mount failed with `ENOENT`. We now read the `major:minor` the kernel reports in `/sys/block/<name>/dev` and `mknod` the node ourselves when it's missing.
- **`e2e_disk`: set `CloudVolumeId` so the restore step runs.** `restoreImageIfMissing` early-returns when `CloudVolumeId` is empty, which it always was in the driver, so the restore step silently did nothing (and the later `ReadFile` failed). Passing the volume id through makes the round trip actually exercise restore.
- **`testdata/miren-disk-app`: a managed-disk fixture.** A minimal app that declares a `provider = "miren"` disk and stores a payload at `/data`, exposing its sha256 on `GET` so a restore can be verified.

## Why

Without the `mknod`, accelerator disks can't mount in the iso dev container (no udev), so the whole managed-disk path was untestable there.

## Validation

Exercised end to end against a real local cloud, driven entirely through the normal deploy path (`provider = "miren"` disk, no debug commands):

1. **Create** — deploy auto-creates the disk in accelerator mode, provisions it, registers the volume with the cloud.
2. **Mount** — auto-leased and mounted via `/dev/lbd1` (node created by this change), formatted, mounted at `/data`.
3. **Backup** — app writes 80 MiB over HTTP → real lbd log segments → LogWatcher uploads them to the cloud.
4. **Restore** — simulate node loss (zero the local image + reset the horizon) → remount replays the segments from the cloud → `GET /data` returns the original sha256, byte-identical.

## Companion fix

The real lbd segment path also needed a kernel fix in the `lbd` repo (`vfs_rename` faulted on NULL parent dentries during segment rotation on newer kernels); that's merged separately. Both are required for accelerator rotation + restore to work on kernels that carry `old_parent`/`new_parent` in `struct renamedata`.

## Not included

The dev container needs `lbdctl` on its `PATH` for accelerator mode; I left that out of this PR (it was a local `.iso/config.yml` bind) since it wants a proper answer — baking `lbdctl` into the `.iso` image — rather than a bind-mount.