### PR TITLE
Stop hardcoding DNS for the builder

### DIFF
--- a/components/buildkit/buildkit.go
+++ b/components/buildkit/buildkit.go
@@ -321,10 +321,6 @@ insecure-entitlements = [ "network.host", "security.insecure" ]
 [log]
   format = "text"
 
-[dns]
-  nameservers=["1.1.1.1","8.8.8.8"]
-  options=["edns0"]
-
 [grpc]
   address = [ "unix:///run/buildkit/buildkitd.sock" ]
   uid = 0

--- a/components/buildkit/config_test.go
+++ b/components/buildkit/config_test.go
@@ -86,4 +86,14 @@ func TestGenerateConfig(t *testing.T) {
 		defaultConfig := c.generateConfig(10*1024*1024*1024, 86400, "")
 		r.Contains(defaultConfig, `[registry."cluster.local:5000"]`)
 	})
+
+	t.Run("does not hardcode DNS nameservers", func(t *testing.T) {
+		r := require.New(t)
+		// MIR-1643: DNS is delegated to buildkitd, which derives each build's
+		// resolv.conf from the host. A hardcoded nameserver directive would
+		// override that and break builds on hosts with an internal resolver.
+		r.NotContains(config, "nameservers=")
+		r.NotContains(config, "1.1.1.1")
+		r.NotContains(config, "8.8.8.8")
+	})
 }


### PR DESCRIPTION
The embedded BuildKit daemon pinned every build's DNS to `1.1.1.1` and `8.8.8.8`. It did this through a `[dns]` block in the generated `buildkitd.toml`, which BuildKit writes into the resolv.conf of each build sandbox it spawns for `RUN` steps. That's fine on a plain internet connection, but on a network that needs a specific internal resolver (split-horizon DNS, a private package mirror, a corporate network) it meant builds couldn't resolve internal names and quietly sent every lookup off to public resolvers.

Reading the vendored BuildKit source showed that when no nameservers are configured, buildkitd already does the right thing: it derives each build sandbox's resolv.conf from the host, systemd-resolved aware, strips loopback entries that wouldn't be reachable from the sandbox's network namespace, and falls back to public DNS only if nothing usable remains. So the hardcoded block wasn't adding anything, it was the one thing overriding that behavior. The fix is to delete it and let BuildKit pick up the host's DNS.

There was no blackbox test exercising the builder's DNS, so this adds one. The `build-dns` fixture's Dockerfile runs `apk add`, which only succeeds if the builder handed the sandbox a working, reachable resolver. Deploy it and the build is the assertion. There's also a small unit test guarding that the generated config no longer carries hardcoded nameservers, so nobody reintroduces the block.

One behavior note: with the block gone, the empty-list fallback becomes libnetwork's default (`8.8.8.8`/`8.8.4.4`) instead of the old `1.1.1.1`/`8.8.8.8`, which only matters on a host whose only resolver is loopback.

Closes MIR-1643