### PR TITLE
Route deploy warnings through the saga status sender

### DIFF
--- a/servers/build/build.go
+++ b/servers/build/build.go
@@ -1137,23 +1137,6 @@ func (b *Builder) sendErrorStatus(ctx context.Context, status *stream.SendStream
 	}
 }
 
-// sendLogStatus sends a structured log status update if status is not nil
-func (b *Builder) sendLogStatus(ctx context.Context, status *stream.SendStreamClient[*build_v1alpha.Status], level, text string, fields ...*build_v1alpha.LogField) {
-	if status != nil {
-		so := new(build_v1alpha.Status)
-		entry := &build_v1alpha.LogEntry{}
-		entry.SetLevel(level)
-		entry.SetText(text)
-		if len(fields) > 0 {
-			entry.SetFields(fields)
-		}
-		so.Update().SetLog(entry)
-		if _, err := status.Send(ctx, so); err != nil {
-			b.Log.Warn("error sending log status", "error", err)
-		}
-	}
-}
-
 func logField(key, value string) *build_v1alpha.LogField {
 	f := &build_v1alpha.LogField{}
 	f.SetKey(key)
@@ -1194,12 +1177,12 @@ func shouldWarnLocalStorageMigration(dataPath string, appID entity.Id, configSpe
 
 // checkLocalStorageMigration checks whether the app has existing data in
 // local storage but no explicit disk config, and sends a deploy warning.
-func (b *Builder) checkLocalStorageMigration(ctx context.Context, appID entity.Id, configSpec core_v1alpha.ConfigSpec, status *stream.SendStreamClient[*build_v1alpha.Status]) {
+func (b *Builder) checkLocalStorageMigration(appID entity.Id, configSpec core_v1alpha.ConfigSpec, status StatusSender) {
 	if !shouldWarnLocalStorageMigration(b.DataPath, appID, configSpec) {
 		return
 	}
 
-	b.sendLogStatus(ctx, status, "warn", "Local storage data was automatically mounted",
+	status.SendLog("warn", "Local storage data was automatically mounted",
 		logField("detail", "This app has data stored on disk, but your app.toml doesn't declare it yet. "+
 			"Add a disk config so the data continues to be available — this safety net will be removed in a future release."),
 		logField("link", "[Configuring Disks](https://miren.md/disks)"),
@@ -1237,13 +1220,13 @@ func aliasedLocalMountPaths(configSpec core_v1alpha.ConfigSpec) []string {
 // distinct mount paths, which all alias to the same shared per-app store. Unlike
 // the migration warning this needs no on-disk check — the aliasing is visible in
 // the config alone.
-func (b *Builder) checkAliasedLocalDisks(ctx context.Context, configSpec core_v1alpha.ConfigSpec, status *stream.SendStreamClient[*build_v1alpha.Status]) {
+func (b *Builder) checkAliasedLocalDisks(configSpec core_v1alpha.ConfigSpec, status StatusSender) {
 	paths := aliasedLocalMountPaths(configSpec)
 	if len(paths) == 0 {
 		return
 	}
 
-	b.sendLogStatus(ctx, status, "warn", "Multiple local disks share one per-app store",
+	status.SendLog("warn", "Multiple local disks share one per-app store",
 		logField("detail", "These local disks all map to the same per-app directory, so they're views onto "+
 			"the same files and a write to one shows up at the others: "+strings.Join(paths, ", ")+". "+
 			"If you want isolated areas, use subdirectories under a single local disk (like /data/cache and "+
@@ -1853,8 +1836,9 @@ func (b *Builder) buildFromDir(ctx context.Context, name string, path string,
 
 		b.Log.Info("app version updated", "app", name, "version", mrv.Version)
 
-		b.checkLocalStorageMigration(ctx, appRec.ID, configSpec, status)
-		b.checkAliasedLocalDisks(ctx, configSpec, status)
+		statusSender := NewRPCStatusSender(status, b.Log)
+		b.checkLocalStorageMigration(appRec.ID, configSpec, statusSender)
+		b.checkAliasedLocalDisks(configSpec, statusSender)
 	}
 
 	// Log the deployment to the app's logs

--- a/servers/build/build_saga.go
+++ b/servers/build/build_saga.go
@@ -689,15 +689,9 @@ func finalize(ctx context.Context, in finalizeIn) (finalizeOut, error) {
 	if in.EphemeralLabel == "" {
 		spec, err := unmarshalConfigSpec(in.ConfigSpec)
 		if err == nil {
-			// checkLocalStorageMigration takes a *SendStreamClient; its
-			// signature predates StatusSender. Pass nil for now and
-			// route the migration-warning UX through the sender once
-			// the function grows a StatusSender-shaped overload. Saga
-			// deploys skip that warning until then — accepted as a
-			// temporary regression on the flagged path. The aliased-disk
-			// warning shares the same channel and the same limitation.
-			b.checkLocalStorageMigration(ctx, entity.Id(in.AppID), spec, nil)
-			b.checkAliasedLocalDisks(ctx, spec, nil)
+			status := deps.statuses.SenderFor(in.StreamID)
+			b.checkLocalStorageMigration(entity.Id(in.AppID), spec, status)
+			b.checkAliasedLocalDisks(spec, status)
 		}
 	}
 

--- a/servers/build/build_saga_test.go
+++ b/servers/build/build_saga_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -207,6 +208,102 @@ func TestBuildSaga_ReceiveTar_EmitsStatusUpdates(t *testing.T) {
 	wantInOrder := []string{"Reading application data", "Launching builder"}
 	if !containsInOrder(rec.Messages, wantInOrder) {
 		t.Errorf("missing expected messages in order: got %v, want subsequence %v", rec.Messages, wantInOrder)
+	}
+}
+
+func TestBuildSaga_Finalize_EmitsDeployWarnings(t *testing.T) {
+	tests := []struct {
+		name        string
+		appConfig   string
+		warningText string
+		prepare     func(*testing.T, *sagaTestHarness)
+	}{
+		{
+			name:        "local storage migration",
+			appConfig:   "name = 'demo'\n",
+			warningText: "Local storage data was automatically mounted",
+			prepare: func(t *testing.T, h *sagaTestHarness) {
+				h.builder.DataPath = t.TempDir()
+				appRec, err := h.builder.appClient.Create(context.Background(), "demo")
+				if err != nil {
+					t.Fatalf("creating app: %v", err)
+				}
+				localDir := filepath.Join(h.builder.DataPath, "data", "local", appRec.ID.String())
+				if err := os.MkdirAll(localDir, 0755); err != nil {
+					t.Fatalf("creating local storage: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(localDir, "data.db"), []byte("existing data"), 0644); err != nil {
+					t.Fatalf("seeding local storage: %v", err)
+				}
+			},
+		},
+		{
+			name: "aliased local disks",
+			appConfig: `name = "demo"
+
+[[services.web.disks]]
+name = "cache"
+provider = "local"
+mount_path = "/cache"
+
+[[services.web.disks]]
+name = "data"
+provider = "local"
+mount_path = "/data"
+`,
+			warningText: "Multiple local disks share one per-app store",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			h := newSagaTestHarness(t)
+			if tt.prepare != nil {
+				tt.prepare(t, h)
+			}
+
+			files := dockerfileTarball(t)
+			files[".miren/app.toml"] = tt.appConfig
+			streamID := "stream-warning-" + strings.ReplaceAll(tt.name, " ", "-")
+			h.streams.Register(streamID, makeTar(t, files))
+
+			rec := &recordingSender{}
+			h.statuses.Register(streamID, rec)
+			t.Cleanup(func() { h.statuses.Unregister(streamID) })
+
+			err := h.executor.Start(sagaBuildFromTar).
+				Input("app_name", "demo").
+				Input("stream_id", streamID).
+				WithID("test-warning-" + strings.ReplaceAll(tt.name, " ", "-")).
+				Execute(ctx)
+			if err != nil {
+				t.Fatalf("saga: %v", err)
+			}
+
+			var warning *recordedLog
+			for i := range rec.Logs {
+				if rec.Logs[i].Text == tt.warningText {
+					warning = &rec.Logs[i]
+					break
+				}
+			}
+			if warning == nil {
+				t.Fatalf("missing warning %q in logs: %v", tt.warningText, rec.Logs)
+			}
+			if warning.Level != "warn" {
+				t.Errorf("warning level = %q, want warn", warning.Level)
+			}
+			fieldKeys := make(map[string]bool)
+			for _, field := range warning.Fields {
+				fieldKeys[field.Key()] = true
+			}
+			for _, key := range []string{"detail", "link"} {
+				if !fieldKeys[key] {
+					t.Errorf("warning fields missing %q: %v", key, warning.Fields)
+				}
+			}
+		})
 	}
 }
 

--- a/servers/build/status_registry.go
+++ b/servers/build/status_registry.go
@@ -38,8 +38,8 @@ type StatusSender interface {
 	// is the channel for the human-readable explanation.
 	SendError(format string, args ...any)
 
-	// SendLog emits a structured log entry. Currently only the
-	// pre-saga "warn" path for local storage migration uses this.
+	// SendLog emits a structured log entry, including deploy warnings that
+	// need to reach the client from either build path.
 	SendLog(level, text string, fields ...*build_v1alpha.LogField)
 
 	// SendDeployment emits the server-owned deployment record's ID and


### PR DESCRIPTION
Saga-backed deploys silently dropped the local-storage migration and aliased-disk warnings because `finalize` called the stream-specific helpers without a live stream. With sagas enabled, users could miss warnings about persistent data or two local disks aliasing the same store.

The warning helpers now emit through `StatusSender`. The legacy path adapts its RPC stream, while saga finalization resolves the sender registered for the deploy. Recovery still gets the noop sender because no client is listening. Full-saga coverage exercises both warning conditions, and the `servers/build` suite passes.

Closes MIR-1640